### PR TITLE
Add arenaskl optimization for boundary checks

### DIFF
--- a/internal/arenaskl/iterator.go
+++ b/internal/arenaskl/iterator.go
@@ -24,6 +24,12 @@ import (
 	"github.com/petermattis/pebble/internal/base"
 )
 
+const (
+	// crossoverThreshold is the threshold at which we start comparing the lower
+	// and upper bound node pointers rather than the user keys on each iteration.
+	crossoverThreshold = 15
+)
+
 type splice struct {
 	prev *node
 	next *node
@@ -43,6 +49,11 @@ type Iterator struct {
 	key   base.InternalKey
 	lower []byte
 	upper []byte
+
+	prevCount uint32
+	nextCount uint32
+	lowerNode *node
+	upperNode *node
 }
 
 var iterPool = sync.Pool{
@@ -149,9 +160,30 @@ func (it *Iterator) Next() (*base.InternalKey, []byte) {
 		return nil, nil
 	}
 	it.decodeKey()
-	if it.upper != nil && it.list.cmp(it.upper, it.key.UserKey) <= 0 {
-		it.nd = it.list.tail
-		return nil, nil
+	if it.upper != nil {
+		if it.nextCount >= crossoverThreshold {
+			if it.upperNode == nil {
+				// Cache upper bound node.
+				_, it.upperNode, _ = it.seekForBaseSplice(it.upper)
+				if it.upperNode == it.list.tail {
+					// Upper bound node does not exist. Do not check upper bound again.
+					it.upper = nil
+				}
+			}
+			if it.nd == it.upperNode {
+				it.nd = it.list.tail
+				return nil, nil
+			}
+		} else {
+			it.nextCount++
+			if it.list.cmp(it.upper, it.key.UserKey) <= 0 {
+				// Cache upper bound node.
+				it.upperNode = it.nd
+				it.nextCount = crossoverThreshold
+				it.nd = it.list.tail
+				return nil, nil
+			}
+		}
 	}
 	return &it.key, it.Value()
 }
@@ -164,9 +196,30 @@ func (it *Iterator) Prev() (*base.InternalKey, []byte) {
 		return nil, nil
 	}
 	it.decodeKey()
-	if it.lower != nil && it.list.cmp(it.lower, it.key.UserKey) > 0 {
-		it.nd = it.list.head
-		return nil, nil
+	if it.lower != nil {
+		if it.prevCount >= crossoverThreshold {
+			if it.lowerNode == nil {
+				// Cache lower bound node.
+				it.lowerNode, _, _ = it.seekForBaseSplice(it.lower)
+				if it.lowerNode == it.list.head {
+					// Lower bound node does not exist. Do not check lower bound again.
+					it.lower = nil
+				}
+			}
+			if it.nd == it.lowerNode {
+				it.nd = it.list.head
+				return nil, nil
+			}
+		} else {
+			it.prevCount++
+			if it.list.cmp(it.lower, it.key.UserKey) > 0 {
+				// Cache lower bound node.
+				it.lowerNode = it.nd
+				it.prevCount = crossoverThreshold
+				it.nd = it.list.head
+				return nil, nil
+			}
+		}
 	}
 	return &it.key, it.Value()
 }
@@ -200,6 +253,10 @@ func (it *Iterator) Valid() bool {
 // result of Next and Prev will be undefined until the iterator has been
 // repositioned with SeekGE, SeekPrefixGE, SeekLT, First, or Last.
 func (it *Iterator) SetBounds(lower, upper []byte) {
+	it.prevCount = 0
+	it.nextCount = 0
+	it.lowerNode = nil
+	it.upperNode = nil
 	it.lower = lower
 	it.upper = upper
 }


### PR DESCRIPTION
Update arenaskl to not check `{lower,upper}bound` in `Prev` and `Next`. Instead, we compare pointers to the nodes which bound the lower and upper bounds. This is described in #98.

The benchmarks show a very significant increase in performance:
```
name             old time/op  new time/op  delta
IterBoundNext    18.9ns ± 0%  12.5ns ± 1%  -33.63%  (p=0.000 n=8+10)
IterBoundNext-8  19.0ns ± 1%  12.5ns ± 2%  -34.08%  (p=0.000 n=9+10)
IterBoundPrev    19.0ns ± 1%  12.6ns ± 2%  -33.37%  (p=0.000 n=9+10)
IterBoundPrev-8  18.8ns ± 0%  12.6ns ± 1%  -33.24%  (p=0.000 n=7+10)
```

However, this performance gain does not reflect real life performance gains. In the benchmark, we use the maximum possible key as the upper bound, and the minimum possible key as the lower bound. 

To see what real life performance gains would look like, we would need to know what the average number of iterations is before hitting the `{lower,upper}bound`. I suspect that if the `{lower,upper}bound` is reached after only a few iterations, the cost of the `SeekGE(upper)` and `SeekLT(lower)` may overcome the cost of doing a direct boundary comparison a few times. It also depends on other factors such as the length of the keys.

Can you think of anything else I should be benchmarking here?