### PR TITLE
Add pebble bench flag to find peak sustainable throughput

### DIFF
--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -15,15 +15,16 @@ import (
 )
 
 var (
-	cacheSize       int64
-	concurrency     int
-	disableWAL      bool
-	duration        time.Duration
-	maxOpsPerSec    int
-	rocksdb         bool
-	verbose         bool
-	waitCompactions bool
-	wipe            bool
+	cacheSize         int64
+	concurrency       int
+	disableWAL        bool
+	duration          time.Duration
+	findPeakOpsPerSec bool
+	maxOpsPerSec      int
+	rocksdb           bool
+	verbose           bool
+	waitCompactions   bool
+	wipe              bool
 )
 
 func main() {
@@ -57,6 +58,9 @@ func main() {
 			&disableWAL, "disable-wal", false, "disable the WAL (voiding persistence guarantees)")
 		cmd.Flags().DurationVarP(
 			&duration, "duration", "d", 10*time.Second, "the duration to run (0, run forever)")
+		cmd.Flags().BoolVar(
+			&findPeakOpsPerSec, "find-peak-ops-per-sec", false,
+			"search for the peak sustainable (i.e., no write stalls) throughput")
 		cmd.Flags().IntVarP(
 			&maxOpsPerSec, "max-ops-per-sec", "m", math.MaxInt32, "max ops per second")
 		cmd.Flags().BoolVar(

--- a/cmd/pebble/peak_rate.go
+++ b/cmd/pebble/peak_rate.go
@@ -1,0 +1,151 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package main
+
+import (
+	"math"
+	"time"
+
+	"github.com/petermattis/pebble/internal/rate"
+)
+
+type findPeakBounds struct {
+	lower, upper float64
+}
+
+// findPeakLoop finds the peak sustainable throughput by trialing rate limits. If a
+// rate trial causes decreasing compaction debt the next trial will be for a higher
+// rate. If a rate trial causes a write stall or increasing compaction debt, the
+// next trial will be for a lower rate.
+//
+// TODO(ajkr): the implementation has several problems:
+// (1) decreasing compaction debt over a few intervals may mislead us into
+//     thinking we should raise the rate, while actually if we had kept the same
+//     rate for longer we'd have hit memtable or L0 file count stalls. Instead
+//     of a fixed number of intervals, we could require a trend lasts for one (or
+//     more) full L0->Lbase compaction cycles.
+// (2) at low compaction debt levels (below compactionSlowdownThreshold), the
+//     rate limiter prevents compaction from happening at full speed. This makes
+//     it more likely we observe increasing debt and thus lower the rate, perhaps
+//     unnecessarily. We currently have a workaround to treat debt below 1GB as
+//     non-increasing regardless of the actual trend; however, this does not solve
+//     the problem in all cases.
+// (3) also at low compaction debt levels, the write-amp is higher due to the
+//     higher fanout. Again, this makes us more likely to see increasing debt
+//     and lower the rate. Ideally we would run the benchmark as close to the
+//     disk space limit as possible in order to minimize write-amp.
+func findPeakLoop(db DB, limiter *rate.Limiter, update chan<- findPeakBounds) {
+	const (
+		// If compaction debt trends in the same direction for trendLen consecutive
+		// intervals, the current rate trial ends. The direction of the trend
+		// determines whether the rate increases or decreases.
+		trendLen = 6
+		// If trialLen intervals pass without identifying a trend of length trendLen,
+		// the current rate trial ends. In this case the compaction debt at the
+		// beginning and end of the rate trial are compared to decide whether the rate
+		// should increase or decrease.
+		trialLen = 18
+		// Interval between measurements of compaction debt
+		interval = 5 * time.Second
+	)
+
+	// The compaction debts seen in the current rate trial
+	var compactionDebtHistory []uint64
+	// Reserved ops at the start of the current rate trial
+	trialStartOps := int64(0)
+	// Time the current rate trial started
+	trialStartTime := time.Now()
+	bounds := findPeakBounds{
+		lower: float64(0),
+		upper: float64(limiter.Limit()),
+	}
+
+	// finishTrial updates the accounting info and reports updates to the test loop
+	finishTrial := func() {
+		metrics := db.Metrics()
+		compactionDebtHistory = compactionDebtHistory[:0]
+		compactionDebtHistory = append(compactionDebtHistory, metrics.EstimatedCompactionDebt)
+		trialStartOps = limiter.TotalReserved()
+		trialStartTime = time.Now()
+		limiter.SetLimit(rate.Limit((bounds.lower + bounds.upper) / 2))
+		update <- bounds
+	}
+
+	isIncreasing := func(i, j int) bool {
+		// If compaction rate is close to zero (here defined as less than 1GB),
+		// count it as non-increasing. That allows us to increase the rate if a
+		// trivial compaction debt is seen for trendLen consecutive intervals, even
+		// if debt is not strictly decreasing over those intervals. It also mitigates
+		// the risk that we lower the rate due to seeing slowly increasing compaction
+		// debt while compaction is still being throttled. Although ideally we'd use
+		// compactionSlowdownThreshold instead of 1GB.
+		return compactionDebtHistory[j] >= (1<<30) &&
+			compactionDebtHistory[j] > compactionDebtHistory[i]
+	}
+
+	// hasTrend checks `compactionDebtHistory` to see if there's a trend in the direction
+	// indicated by `increasing`. Or, if the current trial is over, just use the first and
+	// last debt to determine trend.
+	hasTrend := func(increasing bool) bool {
+		n := len(compactionDebtHistory)
+		if n < trendLen+1 {
+			return false
+		}
+		var i int
+		for i = n - 1; i >= n-trendLen; i-- {
+			if isIncreasing(i-1, i) != increasing {
+				break
+			}
+		}
+		if i == n-trendLen-1 {
+			return true
+		}
+		if n < trialLen {
+			return false
+		}
+		return increasing == isIncreasing(0, n-1)
+	}
+
+	stallBegan, stallEnded := db.(pebbleDB).stallBegan, db.(pebbleDB).stallEnded
+	stalled := false
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stallBegan:
+			// The current rate is too fast as it caused a stall. Set it as the
+			// upper-bound of the search.
+			stalled = true
+			bounds.upper = math.Min(
+				bounds.upper,
+				float64(limiter.TotalReserved()-trialStartOps)/
+					time.Since(trialStartTime).Seconds())
+			// Temporarily disable writes until stall ends
+			limiter.SetLimit(0)
+
+		case <-stallEnded:
+			// Now that the stall ended, try a new (reduced) rate
+			finishTrial()
+			stalled = false
+
+		case <-ticker.C:
+			if stalled {
+				break
+			}
+
+			metrics := db.Metrics()
+			compactionDebtHistory = append(compactionDebtHistory, metrics.EstimatedCompactionDebt)
+			intervalRate := float64(limiter.TotalReserved()-trialStartOps) /
+				time.Since(trialStartTime).Seconds()
+			if hasTrend(true /*increasing*/) {
+				bounds.upper = math.Min(bounds.upper, intervalRate)
+				finishTrial()
+			} else if hasTrend(false /*increasing*/) {
+				bounds.lower = math.Max(bounds.lower, intervalRate)
+				finishTrial()
+			}
+		}
+	}
+}

--- a/cmd/pebble/scan.go
+++ b/cmd/pebble/scan.go
@@ -70,7 +70,7 @@ func runScan(cmd *cobra.Command, args []string) {
 	}
 
 	runTest(args[0], test{
-		init: func(d DB, wg *sync.WaitGroup) {
+		init: func(d DB, limiter *rate.Limiter, wg *sync.WaitGroup) {
 			const count = 100000
 			const batch = 1000
 
@@ -96,7 +96,6 @@ func runScan(cmd *cobra.Command, args []string) {
 				log.Fatal(err)
 			}
 
-			limiter := rate.NewLimiter(rate.Limit(maxOpsPerSec), 1)
 			wg.Add(concurrency)
 			for i := 0; i < concurrency; i++ {
 				go func(i int) {

--- a/cmd/pebble/sync.go
+++ b/cmd/pebble/sync.go
@@ -65,8 +65,7 @@ func runSync(cmd *cobra.Command, args []string) {
 	}
 
 	runTest(args[0], test{
-		init: func(d DB, wg *sync.WaitGroup) {
-			limiter := rate.NewLimiter(rate.Limit(maxOpsPerSec), 1)
+		init: func(d DB, limiter *rate.Limiter, wg *sync.WaitGroup) {
 			wg.Add(concurrency)
 			for i := 0; i < concurrency; i++ {
 				latency := reg.Register("ops")

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -58,7 +58,10 @@ func (p *compactionPicker) compactionNeeded() bool {
 }
 
 // estimatedCompactionDebt estimates the number of bytes which need to be
-// compacted before the LSM tree becomes stable.
+// compacted before the LSM tree becomes stable. To get the smoothed debt,
+// the caller can pass in the bytes processed by a pending flush as `l0ExtraSize`,
+// and subtract the bytes processed by a pending compaction from the result.
+// Note in `DB` these values are available in `bytesFlushed` and `bytesCompacted`.
 func (p *compactionPicker) estimatedCompactionDebt(l0ExtraSize uint64) uint64 {
 	if p == nil {
 		return 0

--- a/metrics.go
+++ b/metrics.go
@@ -84,7 +84,8 @@ type VersionMetrics struct {
 		// Number of bytes written to the WAL.
 		BytesWritten uint64
 	}
-	Levels [numLevels]LevelMetrics
+	Levels                  [numLevels]LevelMetrics
+	EstimatedCompactionDebt uint64
 }
 
 func (m *VersionMetrics) formatWAL(buf *bytes.Buffer) {


### PR DESCRIPTION
Peak sustainable throughput is the max possible throughput not leading
to stalls. We estimate it by using binary search to find the highest
throughput where stalls are not seen and background work backlog is
non-increasing over a period of time.

benchmark setup (on c5d.xlarge):
```
$ ./pebble bench ycsb /mnt/data1/bench_16G/ --workload insert=100 --values 64 --initial-keys 0 --keys uniform --concurrency 64 --batch 64 --num-ops $[(4 << 30) / 64 / 64] --duration 0s --wait-compactions
```

optionally add initial compaction debt:
```
$ ./pebble bench ycsb /mnt/data1/bench_16G/ --workload update=100 --concurrency 64 --batch 64 --values 64 --prepopulated-keys $[(4 << 30) / 64] --initial-keys 0 --keys uniform --duration 0s --verbose
```

benchmark command:
```
$ ./pebble bench ycsb /mnt/data1/bench_16G/ --workload update=100 --concurrency 64 --batch 64 --values 64 --prepopulated-keys $[(4 << 30) / 64] --initial-keys 0 --keys uniform --duration 0s --find-peak-ops-per-sec --verbose
```

results:

initial debt (GB) | trial | peak keys/sec | final debt (GB)
-- | -- | -- | --
0 | 1 | 68992 | 7
0 | 2 | 70272 | 7
16 | 1 | 101824 | 21
16 | 2 | 85312 | 13