### PR TITLE
[WIP] Consider range deletion in shouldStopBefore

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -860,7 +860,7 @@ func TestCompactionShouldStopBefore(t *testing.T) {
 					if i == 0 {
 						smallest = key
 					}
-					if c.shouldStopBefore(base.MakeInternalKey([]byte(key), 0, 0)) {
+					if c.shouldStopBefore(base.MakeInternalKey([]byte(key), 0, 0), nil /* val */) {
 						fmt.Fprintf(&buf, "%s-%s\n", smallest, largest)
 						smallest = key
 					}


### PR DESCRIPTION
Added a bit of code to consider range deletion tombstones in the `shouldStopBefore` decision. The full implementation may need to truncate/split the range deletion tombstone since the current simple solution doesn't work for very large spanning range deletions.

Tests will need to be added to make sure this is working as intended. I wanted to clarify the approach before doing that. 