### PR TITLE
Introduce Formatter function for formatting user keys

### DIFF
--- a/flush_test.go
+++ b/flush_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -37,7 +38,7 @@ func TestManualFlush(t *testing.T) {
 			}
 
 			d.mu.Lock()
-			s := d.mu.versions.currentVersion().DebugString()
+			s := d.mu.versions.currentVersion().DebugString(base.DefaultFormatter)
 			d.mu.Unlock()
 			return s
 
@@ -63,7 +64,7 @@ func TestManualFlush(t *testing.T) {
 			}
 
 			d.mu.Lock()
-			s := d.mu.versions.currentVersion().DebugString()
+			s := d.mu.versions.currentVersion().DebugString(base.DefaultFormatter)
 			d.mu.Unlock()
 			return s
 

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -519,7 +519,7 @@ func TestGetIter(t *testing.T) {
 			v.Files[tt.level] = append(v.Files[tt.level], meta)
 		}
 
-		err := v.CheckOrdering(cmp)
+		err := v.CheckOrdering(cmp, base.DefaultFormatter)
 		if tc.badOrdering && err == nil {
 			t.Errorf("desc=%q: want bad ordering, got nil error", desc)
 			continue

--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -302,10 +302,19 @@ func (k InternalKey) Clone() InternalKey {
 
 // String returns a string representation of the key.
 func (k InternalKey) String() string {
-	return fmt.Sprintf("%s#%d,%d", k.UserKey, k.SeqNum(), k.Kind())
+	return fmt.Sprintf("%s#%d,%d", FormatBytes(k.UserKey), k.SeqNum(), k.Kind())
 }
 
-// Pretty returns a pretty-printed string representation of the key.
-func (k InternalKey) Pretty(f func([]byte) string) string {
-	return fmt.Sprintf("%s#%d,%d", f(k.UserKey), k.SeqNum(), k.Kind())
+// Pretty returns a formatter for the key.
+func (k InternalKey) Pretty(f Formatter) fmt.Formatter {
+	return prettyInternalKey{k, f}
+}
+
+type prettyInternalKey struct {
+	InternalKey
+	formatter Formatter
+}
+
+func (k prettyInternalKey) Format(s fmt.State, c rune) {
+	fmt.Fprintf(s, "%s#%d,%d", k.formatter(k.UserKey), k.SeqNum(), k.Kind())
 }

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -405,7 +405,7 @@ func (b *BulkVersionEdit) Accumulate(ve *VersionEdit) {
 //
 // base may be nil, which is equivalent to a pointer to a zero version.
 func (b *BulkVersionEdit) Apply(
-	opts *Options, base *Version, cmp Compare,
+	base *Version, cmp Compare, format base.Formatter,
 ) (*Version, error) {
 	v := new(Version)
 	for level := range v.Files {
@@ -460,7 +460,7 @@ func (b *BulkVersionEdit) Apply(
 			SortBySmallest(v.Files[level], cmp)
 		}
 	}
-	if err := v.CheckOrdering(cmp); err != nil {
+	if err := v.CheckOrdering(cmp, format); err != nil {
 		return nil, fmt.Errorf("pebble: internal error: %v", err)
 	}
 	return v, nil

--- a/internal/rangedel/tombstone.go
+++ b/internal/rangedel/tombstone.go
@@ -40,3 +40,20 @@ func (t Tombstone) String() string {
 	}
 	return fmt.Sprintf("%s-%s#%d", t.Start.UserKey, t.End, t.Start.SeqNum())
 }
+
+// Pretty returns a formatter for the tombstone.
+func (t Tombstone) Pretty(f base.Formatter) fmt.Formatter {
+	return prettyTombstone{t, f}
+}
+
+type prettyTombstone struct {
+	Tombstone
+	formatter base.Formatter
+}
+
+func (t prettyTombstone) Format(s fmt.State, c rune) {
+	if t.Empty() {
+		fmt.Fprintf(s, "<empty>")
+	}
+	fmt.Fprintf(s, "%s-%s#%d", t.formatter(t.Start.UserKey), t.formatter(t.End), t.Start.SeqNum())
+}

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -409,7 +409,7 @@ func TestIteratorTableFilter(t *testing.T) {
 			d.mu.Lock()
 			// Disable the "dynamic base level" code for this test.
 			d.mu.versions.picker.baseLevel = 1
-			s := d.mu.versions.currentVersion().DebugString()
+			s := d.mu.versions.currentVersion().DebugString(base.DefaultFormatter)
 			d.mu.Unlock()
 			return s
 

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -137,7 +137,7 @@ func TestRangeDelCompactionTruncation(t *testing.T) {
 
 	lsm := func() string {
 		d.mu.Lock()
-		s := d.mu.versions.currentVersion().DebugString()
+		s := d.mu.versions.currentVersion().DebugString(base.DefaultFormatter)
 		d.mu.Unlock()
 		return s
 	}

--- a/testdata/compaction_check_ordering
+++ b/testdata/compaction_check_ordering
@@ -1,0 +1,90 @@
+check-ordering
+L0
+  a.SET.1-b.SET.2
+----
+OK
+
+check-ordering
+L0
+  a.SET.1-b.SET.2
+  c.SET.3-d.SET.4
+----
+OK
+
+check-ordering
+L0
+  c.SET.3-d.SET.4
+  a.SET.1-b.SET.2
+----
+fatal: L0 files 000001 and 000002 are not in increasing largest seqnum order: 4 vs 2
+
+check-ordering
+L0
+  c.SET.3-d.SET.4
+  a.SET.1-b.SET.5
+----
+fatal: L0 files 000001 and 000002 are not in increasing smallest seqnum order: 3 vs 1
+
+check-ordering
+L1
+  a.SET.1-b.SET.2
+----
+OK
+
+check-ordering
+L1
+  b.SET.1-a.SET.2
+----
+fatal: L1 file 000001 has inconsistent bounds: b#1,1 vs a#2,1
+
+check-ordering
+L1
+  a.SET.1-b.SET.2
+  c.SET.3-d.SET.4
+----
+OK
+
+check-ordering
+L1
+  a.SET.1-b.SET.2
+  d.SET.3-c.SET.4
+----
+fatal: L1 file 000002 has inconsistent bounds: d#3,1 vs c#4,1
+
+check-ordering
+L1
+  a.SET.1-b.SET.2
+  b.SET.1-d.SET.4
+----
+OK
+
+check-ordering
+L1
+  a.SET.1-b.SET.2
+  b.SET.2-d.SET.4
+----
+fatal: L1 files 000001 and 000002 are not in increasing key order: b#2,1 vs b#2,1
+
+check-ordering
+L1
+  a.SET.1-c.SET.2
+  b.SET.3-d.SET.4
+----
+fatal: L1 files 000001 and 000002 are not in increasing key order: c#2,1 vs b#3,1
+
+check-ordering
+L1
+  a.SET.1-c.SET.2
+L2
+  b.SET.3-d.SET.4
+----
+OK
+
+check-ordering
+L1
+  a.SET.1-c.SET.2
+L2
+  b.SET.3-d.SET.4
+  c.SET.5-e.SET.6
+----
+fatal: L2 files 000002 and 000003 are not in increasing key order: d#4,1 vs c#5,1

--- a/tool/db.go
+++ b/tool/db.go
@@ -159,14 +159,14 @@ func (d *dbT) runScan(cmd *cobra.Command, args []string) {
 		if fmtKeys || fmtValues {
 			needDelimiter := false
 			if fmtKeys {
-				d.fmtKey.fn(stdout, iter.Key())
+				fmt.Fprintf(stdout, "%s", d.fmtKey.fn(iter.Key()))
 				needDelimiter = true
 			}
 			if fmtValues {
 				if needDelimiter {
 					stdout.Write([]byte{' '})
 				}
-				d.fmtValue.fn(stdout, iter.Value())
+				fmt.Fprintf(stdout, "%s", d.fmtValue.fn(iter.Value()))
 			}
 			stdout.Write([]byte{'\n'})
 		}

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -128,7 +128,7 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 			}
 
 			if cmp != nil {
-				v, err := bve.Apply(m.opts, nil, cmp.Compare)
+				v, err := bve.Apply(nil, cmp.Compare, m.fmtKey.fn)
 				if err != nil {
 					fmt.Fprintf(stdout, "%s\n", err)
 					return

--- a/tool/wal.go
+++ b/tool/wal.go
@@ -116,23 +116,17 @@ func (w *walT) runDump(cmd *cobra.Command, args []string) {
 					fmt.Fprintf(stdout, "    %s(", kind)
 					switch kind {
 					case base.InternalKeyKindDelete:
-						w.fmtKey.fn(stdout, ukey)
+						fmt.Fprintf(stdout, "%s", w.fmtKey.fn(ukey))
 					case base.InternalKeyKindSet:
-						w.fmtKey.fn(stdout, ukey)
-						stdout.Write([]byte{','})
-						w.fmtValue.fn(stdout, value)
+						fmt.Fprintf(stdout, "%s,%s", w.fmtKey.fn(ukey), w.fmtValue.fn(value))
 					case base.InternalKeyKindMerge:
-						w.fmtKey.fn(stdout, ukey)
-						stdout.Write([]byte{','})
-						w.fmtValue.fn(stdout, value)
+						fmt.Fprintf(stdout, "%s,%s", w.fmtKey.fn(ukey), w.fmtValue.fn(value))
 					case base.InternalKeyKindLogData:
-						w.fmtValue.fn(stdout, ukey)
+						fmt.Fprintf(stdout, "%s", w.fmtValue.fn(value))
 					case base.InternalKeyKindSingleDelete:
-						w.fmtKey.fn(stdout, ukey)
+						fmt.Fprintf(stdout, "%s", w.fmtKey.fn(ukey))
 					case base.InternalKeyKindRangeDelete:
-						w.fmtKey.fn(stdout, ukey)
-						stdout.Write([]byte{','})
-						w.fmtKey.fn(stdout, value)
+						fmt.Fprintf(stdout, "%s,%s", w.fmtKey.fn(ukey), w.fmtKey.fn(value))
 					}
 					fmt.Fprintf(stdout, ")\n")
 				}

--- a/version_set.go
+++ b/version_set.go
@@ -166,7 +166,7 @@ func (vs *versionSet) load(dirname string, opts *Options, mu *sync.Mutex) error 
 	vs.markFileNumUsed(vs.logNum)
 	vs.markFileNumUsed(vs.prevLogNum)
 
-	newVersion, err := bve.Apply(opts, nil, vs.cmp)
+	newVersion, err := bve.Apply(nil, vs.cmp, opts.Comparer.Format)
 	if err != nil {
 		return err
 	}
@@ -227,7 +227,7 @@ func (vs *versionSet) logAndApply(
 		bve.Accumulate(ve)
 
 		var err error
-		newVersion, err = bve.Apply(vs.opts, currentVersion, vs.cmp)
+		newVersion, err = bve.Apply(currentVersion, vs.cmp, vs.opts.Comparer.Format)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Use the configured format when formatting keys for error messages.

Clarify some comments about the keys passed to Comparer functions.