### PR TITLE
Add support for boltdb and badger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,14 @@ internal/arenaskl.bench: GOFLAGS += -cpu 1,8
 %.bench:
 	${GO} test -run - -bench . -count 10 ${GOFLAGS} ./$* 2>&1 | tee $*/bench.txt.new
 
-# The cmd/pebble/rocksdb.go file causes various cockroach dependencies
-# to be pulled in which is undesirable. Hack around this by
-# temporarily moving hiding that file.
+# The cmd/pebble/{badger,boltdb,rocksdb}.go files causes various
+# cockroach dependencies to be pulled in which is undesirable. Hack
+# around this by temporarily moving hiding that file.
 mod-update:
-	mv cmd/pebble/rocksdb.go cmd/pebble/_rocksdb.go
+	mkdir -p cmd/pebble/_bak
+	mv cmd/pebble/{badger,boltdb,rocksdb}.go cmd/pebble/_bak
 	GO111MODULE=on go mod vendor
-	mv cmd/pebble/_rocksdb.go cmd/pebble/rocksdb.go
+	mv cmd/pebble/_bak/* cmd/pebble && rmdir cmd/pebble/_bak
 
 .PHONY: clean
 clean:

--- a/cmd/pebble/badger.go
+++ b/cmd/pebble/badger.go
@@ -1,0 +1,143 @@
+// Copyright 2018 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build badger
+
+package main
+
+import (
+	"bytes"
+	"log"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/dgraph-io/badger"
+)
+
+// Adapters for Badger.
+type badgerDB struct {
+	db *badger.DB
+}
+
+func newBadgerDB(dir string) DB {
+	db, err := badger.Open(badger.DefaultOptions(dir))
+	if err != nil {
+		log.Fatal(err)
+	}
+	return &badgerDB{db}
+}
+
+func (b badgerDB) NewIter(opts *pebble.IterOptions) iterator {
+	txn := b.db.NewTransaction(false)
+	iopts := badger.DefaultIteratorOptions
+	iopts.PrefetchValues = false
+	iter := txn.NewIterator(iopts)
+	return &badgerIterator{
+		txn:   txn,
+		iter:  iter,
+		lower: opts.GetLowerBound(),
+		upper: opts.GetUpperBound(),
+	}
+}
+
+func (b badgerDB) NewBatch() batch {
+	txn := b.db.NewTransaction(true)
+	return &badgerBatch{txn}
+}
+
+func (b badgerDB) Scan(key []byte, count int64, reverse bool) error {
+	panic("badgerDB.Scan: unimplemented")
+}
+
+func (b badgerDB) Metrics() *pebble.VersionMetrics {
+	return &pebble.VersionMetrics{}
+}
+
+func (b badgerDB) Flush() error {
+	return nil
+}
+
+type badgerIterator struct {
+	txn   *badger.Txn
+	iter  *badger.Iterator
+	buf   []byte
+	lower []byte
+	upper []byte
+}
+
+func (i *badgerIterator) SeekGE(key []byte) bool {
+	i.iter.Seek(key)
+	if !i.iter.Valid() {
+		return false
+	}
+	if i.upper != nil && bytes.Compare(i.Key(), i.upper) >= 0 {
+		return false
+	}
+	return true
+}
+
+func (i *badgerIterator) Valid() bool {
+	return i.iter.Valid()
+}
+
+func (i *badgerIterator) Key() []byte {
+	return i.iter.Item().Key()
+}
+
+func (i *badgerIterator) Value() []byte {
+	var err error
+	i.buf, err = i.iter.Item().ValueCopy(i.buf[:0])
+	if err != nil {
+		log.Fatal(err)
+	}
+	return i.buf
+}
+
+func (i *badgerIterator) First() bool {
+	return i.SeekGE(i.lower)
+}
+
+func (i *badgerIterator) Next() bool {
+	i.iter.Next()
+	if !i.iter.Valid() {
+		return false
+	}
+	if i.upper != nil && bytes.Compare(i.Key(), i.upper) >= 0 {
+		return false
+	}
+	return true
+}
+
+func (i *badgerIterator) Last() bool {
+	return false
+}
+
+func (i *badgerIterator) Prev() bool {
+	return false
+}
+
+func (i *badgerIterator) Close() error {
+	i.iter.Close()
+	i.txn.Discard()
+	return nil
+}
+
+type badgerBatch struct {
+	txn *badger.Txn
+}
+
+func (b badgerBatch) Commit(opts *pebble.WriteOptions) error {
+	return b.txn.Commit()
+}
+
+func (b badgerBatch) Set(key, value []byte, _ *pebble.WriteOptions) error {
+	return b.txn.Set(key, value)
+}
+
+func (b badgerBatch) LogData(data []byte, _ *pebble.WriteOptions) error {
+	panic("badgerBatch.logData: unimplemented")
+}
+
+func (b badgerBatch) Repr() []byte {
+	return nil
+}

--- a/cmd/pebble/badger_disabled.go
+++ b/cmd/pebble/badger_disabled.go
@@ -1,0 +1,14 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build !badger
+
+package main
+
+import "log"
+
+func newBadgerDB(dir string) DB {
+	log.Fatalf("pebble not compiled with Badger support: recompile with \"-tags badger\"\n")
+	return nil
+}

--- a/cmd/pebble/boltdb.go
+++ b/cmd/pebble/boltdb.go
@@ -1,0 +1,166 @@
+// Copyright 2018 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build boltdb
+
+package main
+
+import (
+	"bytes"
+	"log"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/ngaut/bolt"
+)
+
+// Adapters for BoltDB
+type boltDB struct {
+	db     *bolt.DB
+	bucket []byte
+}
+
+func newBoltDB(dir string) DB {
+	db, err := bolt.Open(dir, 0755, &bolt.Options{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	bucket := []byte("test")
+	db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucketIfNotExists(bucket); err != nil {
+			log.Fatalf("create bucket: %s", err)
+		}
+		return nil
+	})
+	return &boltDB{db: db, bucket: bucket}
+}
+
+func (b boltDB) NewIter(opts *pebble.IterOptions) iterator {
+	tx, err := b.db.Begin(false)
+	if err != nil {
+		log.Fatal(err)
+	}
+	cursor := tx.Bucket(b.bucket).Cursor()
+	return &boltDBIterator{
+		tx:     tx,
+		cursor: cursor,
+		lower:  opts.GetLowerBound(),
+		upper:  opts.GetUpperBound(),
+	}
+}
+
+func (b boltDB) NewBatch() batch {
+	tx, err := b.db.Begin(true)
+	if err != nil {
+		log.Fatal(err)
+	}
+	bucket := tx.Bucket(b.bucket)
+	return boltDBBatch{tx: tx, bucket: bucket}
+}
+
+func (b boltDB) Scan(key []byte, count int64, reverse bool) error {
+	panic("boltDB.Scan: unimplemented")
+}
+
+func (b boltDB) Metrics() *pebble.VersionMetrics {
+	return &pebble.VersionMetrics{}
+}
+
+func (b boltDB) Flush() error {
+	// NB: Flushing is a no-op with BoltDB.
+	return nil
+}
+
+type boltDBIterator struct {
+	tx     *bolt.Tx
+	cursor *bolt.Cursor
+	key    []byte
+	value  []byte
+	lower  []byte
+	upper  []byte
+}
+
+func (i *boltDBIterator) SeekGE(key []byte) bool {
+	i.key, i.value = i.cursor.Seek(key)
+	if i.key != nil && i.upper != nil && bytes.Compare(i.key, i.upper) >= 0 {
+		i.key = nil
+	}
+	return i.key != nil
+}
+
+func (i *boltDBIterator) Valid() bool {
+	return i.key != nil
+}
+
+func (i *boltDBIterator) Key() []byte {
+	return i.key
+}
+
+func (i *boltDBIterator) Value() []byte {
+	return i.value
+}
+
+func (i *boltDBIterator) First() bool {
+	if i.lower != nil {
+		return i.SeekGE(i.lower)
+	}
+	i.key, i.value = i.cursor.First()
+	if i.key != nil && i.upper != nil && bytes.Compare(i.key, i.upper) >= 0 {
+		i.key = nil
+	}
+	return i.key != nil
+}
+
+func (i *boltDBIterator) Next() bool {
+	i.key, i.value = i.cursor.Next()
+	if i.key != nil && i.upper != nil && bytes.Compare(i.key, i.upper) >= 0 {
+		i.key = nil
+	}
+	return i.key != nil
+}
+
+func (i *boltDBIterator) Last() bool {
+	if i.upper != nil {
+		return i.SeekGE(i.upper)
+	}
+	i.key, i.value = i.cursor.Last()
+	if i.key != nil && i.lower != nil && bytes.Compare(i.key, i.lower) < 0 {
+		i.key = nil
+	}
+	return i.key != nil
+}
+
+func (i *boltDBIterator) Prev() bool {
+	i.key, i.value = i.cursor.Prev()
+	if i.key != nil && i.lower != nil && bytes.Compare(i.key, i.lower) < 0 {
+		i.key = nil
+	}
+	return i.key != nil
+}
+
+func (i *boltDBIterator) Close() error {
+	i.tx.Rollback()
+	return nil
+}
+
+type boltDBBatch struct {
+	tx     *bolt.Tx
+	bucket *bolt.Bucket
+}
+
+func (b boltDBBatch) Commit(opts *pebble.WriteOptions) error {
+	return b.tx.Commit()
+}
+
+func (b boltDBBatch) Set(key, value []byte, _ *pebble.WriteOptions) error {
+	return b.bucket.Put(key, value)
+}
+
+func (b boltDBBatch) LogData(data []byte, _ *pebble.WriteOptions) error {
+	panic("boltDBBatch.logData: unimplemented")
+}
+
+func (b boltDBBatch) Repr() []byte {
+	return nil
+}

--- a/cmd/pebble/boltdb_disabled.go
+++ b/cmd/pebble/boltdb_disabled.go
@@ -1,0 +1,14 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build !boltdb
+
+package main
+
+import "log"
+
+func newBoltDB(dir string) DB {
+	log.Fatalf("pebble not compiled with BoltDB support: recompile with \"-tags boltdb\"\n")
+	return nil
+}

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -19,8 +19,8 @@ var (
 	concurrency     int
 	disableWAL      bool
 	duration        time.Duration
+	engineType      string
 	maxOpsPerSec    string
-	rocksdb         bool
 	verbose         bool
 	waitCompactions bool
 	wipe            bool
@@ -69,10 +69,9 @@ func main() {
 		cmd.Flags().DurationVarP(
 			&duration, "duration", "d", 10*time.Second, "the duration to run (0, run forever)")
 		cmd.Flags().StringVarP(
+			&engineType, "engine", "e", "pebble", "engine type (pebble [default], badger, boltdb, rocksdb)")
+		cmd.Flags().StringVarP(
 			&maxOpsPerSec, "rate", "m", "1000000", "max ops per second [{zipf,uniform}:]min[-max][/period (sec)]")
-		cmd.Flags().BoolVar(
-			&rocksdb, "rocksdb", false,
-			"use rocksdb storage engine instead of pebble")
 		cmd.Flags().BoolVarP(
 			&verbose, "verbose", "v", false, "enable verbose event logging")
 		cmd.Flags().BoolVar(

--- a/cmd/pebble/test.go
+++ b/cmd/pebble/test.go
@@ -15,8 +15,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/codahale/hdrhistogram"
 	"github.com/cockroachdb/pebble"
+	"github.com/codahale/hdrhistogram"
 )
 
 const (
@@ -225,10 +225,15 @@ func runTest(dir string, t test) {
 	fmt.Printf("dir %s\nconcurrency %d\n", dir, concurrency)
 
 	var db DB
-	if rocksdb {
-		db = newRocksDB(dir)
-	} else {
+	switch engineType {
+	case "badger":
+		db = newBadgerDB(dir)
+	case "boltdb":
+		db = newBoltDB(dir)
+	case "pebble":
 		db = newPebbleDB(dir)
+	case "rocksdb":
+		db = newRocksDB(dir)
 	}
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
Replace the `--rocksdb` flag with an `--engine` flag that can specify
"pebble", "badger", "boltdb", or "rocksdb". Note that not all of the
engine types implement all of the engine functionality. This is intended
for comparative performance tests.