### PR TITLE
tool: Use the comparator-specified Formatter if there is one

### DIFF
--- a/tool/data_test.go
+++ b/tool/data_test.go
@@ -6,6 +6,7 @@ package tool
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -66,6 +67,12 @@ func runTests(t *testing.T, path string) {
 					var c Comparer
 					c = *base.DefaultComparer
 					c.Name = "test-comparer"
+					c.Format = func(key []byte) fmt.Formatter {
+						return fmtFormatter{
+							fmt: "test formatter: %s",
+							v:   key,
+						}
+					}
 					return &c
 				}())
 				tool.RegisterMerger(func() *Merger {

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -96,6 +96,7 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 					}
 					fmt.Fprintf(stdout, "\n")
 				}
+				m.fmtKey.setForComparer(ve.ComparerName, m.comparers)
 				if ve.LogNum != 0 {
 					empty = false
 					fmt.Fprintf(stdout, "  log-num:      %d\n", ve.LogNum)

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -167,6 +167,9 @@ func (s *sstableT) runLayout(cmd *cobra.Command, args []string) {
 				return
 			}
 
+			// Update the internal formatter if this comparator has one specified.
+			s.fmtKey.setForComparer(r.Properties.ComparerName, s.comparers)
+
 			l, err := r.Layout()
 			if err != nil {
 				fmt.Fprintf(stderr, "%s\n", err)
@@ -293,6 +296,9 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 				fmt.Fprintf(stdout, "%s\n", err)
 				return
 			}
+
+			// Update the internal formatter if this comparator has one specified.
+			s.fmtKey.setForComparer(r.Properties.ComparerName, s.comparers)
 
 			iter := r.NewIter(nil, s.end)
 			var lastKey base.InternalKey

--- a/tool/testdata/manifest_dump
+++ b/tool/testdata/manifest_dump
@@ -77,3 +77,49 @@ EOF
 --- L4 ---
 --- L5 ---
 --- L6 ---
+
+manifest dump
+../testdata/db-stage-4/MANIFEST-000005
+--key=pretty
+----
+../testdata/db-stage-4/MANIFEST-000005
+0
+  comparer:     leveldb.BytewiseComparator
+35
+  <empty>
+44
+  log-num:      4
+  last-seq-num: 5
+  added:        L0 4:986[bar#5,0-foo#4,1]
+EOF
+--- L0 ---
+  4:986[bar#5,0-foo#4,1]
+--- L1 ---
+--- L2 ---
+--- L3 ---
+--- L4 ---
+--- L5 ---
+--- L6 ---
+
+manifest dump
+../testdata/db-stage-4/MANIFEST-000005
+--key=pretty:test-comparer
+----
+../testdata/db-stage-4/MANIFEST-000005
+0
+  comparer:     leveldb.BytewiseComparator
+35
+  <empty>
+44
+  log-num:      4
+  last-seq-num: 5
+  added:        L0 4:986[test formatter: bar#5,0-test formatter: foo#4,1]
+EOF
+--- L0 ---
+  4:986[test formatter: bar#5,0-test formatter: foo#4,1]
+--- L1 ---
+--- L2 ---
+--- L3 ---
+--- L4 ---
+--- L5 ---
+--- L6 ---

--- a/tool/testdata/sstable_scan
+++ b/tool/testdata/sstable_scan
@@ -76,6 +76,54 @@ sstable scan
 [3439]
 
 sstable scan
+--key=pretty
+--value=[%x]
+--start=hex:796f75
+--end=raw:yourself
+../sstable/testdata/h.sst
+----
+../sstable/testdata/h.sst
+you#0,1 [313130]
+young#0,1 [36]
+your#0,1 [3439]
+
+sstable scan
+--key=pretty
+--value=[%x]
+--start=hex:796f75
+--end=raw:yourself
+../sstable/testdata/h.sst
+----
+../sstable/testdata/h.sst
+you#0,1 [313130]
+young#0,1 [36]
+your#0,1 [3439]
+
+sstable scan
+--key=pretty
+--value=[%x]
+--start=hex:796f75
+--end=raw:yourself
+../sstable/testdata/h.sst
+----
+../sstable/testdata/h.sst
+you#0,1 [313130]
+young#0,1 [36]
+your#0,1 [3439]
+
+sstable scan
+--key=pretty:test-comparer
+--value=[%x]
+--start=hex:796f75
+--end=raw:yourself
+../sstable/testdata/h.sst
+----
+../sstable/testdata/h.sst
+test formatter: you#0,1 [313130]
+test formatter: young#0,1 [36]
+test formatter: your#0,1 [3439]
+
+sstable scan
 testdata/out-of-order.sst
 ----
 testdata/out-of-order.sst

--- a/tool/testdata/wal_dump
+++ b/tool/testdata/wal_dump
@@ -46,6 +46,34 @@ EOF
 
 wal dump
 ../testdata/db-stage-4/000006.log
+--key=pretty
+--value=%x
+----
+../testdata/db-stage-4/000006.log
+0(22) seq=6 count=1
+    SET(foo,66697665)
+29(22) seq=7 count=1
+    SET(quux,736978)
+58(17) seq=8 count=1
+    DEL(baz)
+EOF
+
+wal dump
+../testdata/db-stage-4/000006.log
+--key=pretty:test-comparer
+--value=%x
+----
+../testdata/db-stage-4/000006.log
+0(22) seq=6 count=1
+    SET(test formatter: foo,66697665)
+29(22) seq=7 count=1
+    SET(test formatter: quux,736978)
+58(17) seq=8 count=1
+    DEL(test formatter: baz)
+EOF
+
+wal dump
+../testdata/db-stage-4/000006.log
 --value=quoted
 ----
 ../testdata/db-stage-4/000006.log

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -52,7 +52,7 @@ func New() *T {
 	t.db = newDB(&t.opts, t.comparers, t.mergers)
 	t.manifest = newManifest(&t.opts, t.comparers)
 	t.sstable = newSSTable(&t.opts, t.comparers, t.mergers)
-	t.wal = newWAL(&t.opts)
+	t.wal = newWAL(&t.opts, t.comparers)
 	t.Commands = []*cobra.Command{
 		t.db.Root,
 		t.manifest.Root,

--- a/tool/wal.go
+++ b/tool/wal.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/record"
+	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/spf13/cobra"
 )
@@ -24,12 +25,15 @@ type walT struct {
 
 	fmtKey   formatter
 	fmtValue formatter
+
+	comparers sstable.Comparers
 }
 
-func newWAL(opts *base.Options) *walT {
+func newWAL(opts *base.Options, comparers sstable.Comparers) *walT {
 	w := &walT{}
 	w.fmtKey.mustSet("quoted")
 	w.fmtValue.mustSet("size")
+	w.comparers = comparers
 
 	w.Root = &cobra.Command{
 		Use:   "wal",
@@ -55,6 +59,7 @@ Print the contents of the WAL files.
 }
 
 func (w *walT) runDump(cmd *cobra.Command, args []string) {
+	w.fmtKey.setForComparer("", w.comparers)
 	for _, arg := range args {
 		func() {
 			// Parse the filename in order to extract the file number. This is


### PR DESCRIPTION
If the key formatter falls back to calling printf on the key,
and there's an in-use pebble.Comparator with a specified Format
function, then use that format function instead.