### PR TITLE
Allow creating a flushable batch on an empty batch

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -562,6 +562,13 @@ func TestFlushableBatchBytesIterated(t *testing.T) {
 	}
 }
 
+func TestEmptyFlushableBatch(t *testing.T) {
+	// Verify that we can create a flushable batch on an empty batch.
+	fb := newFlushableBatch(newBatch(nil), DefaultComparer)
+	it := &internalIterAdapter{fb.newIter(nil)}
+	require.False(t, it.First())
+}
+
 func BenchmarkBatchSet(b *testing.B) {
 	value := make([]byte, 10)
 	for i := range value {

--- a/internal/batch/batch.go
+++ b/internal/batch/batch.go
@@ -1,0 +1,11 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package batch
+
+import "github.com/cockroachdb/pebble/internal/base"
+
+// Sort is a hook for constructing iterators over the point and range mutations
+// contained in a batch in sorted order. It is intended for testing use only.
+var Sort func(interface{}) (base.InternalIterator, base.InternalIterator)


### PR DESCRIPTION
Previously, creating a flushable batch on an empty batch would panic.

Add a `Batch.sort` facility which is exposed for testing via
`internal/Batch.Sort`. Not currently used, but will be in the
metamorphic tests.