### PR TITLE
Fix sstable/Iterator.Valid

### DIFF
--- a/sstable/block.go
+++ b/sstable/block.go
@@ -678,13 +678,3 @@ func (i *blockIter) SetBounds(lower, upper []byte) {
 	// This should never be called as bounds are handled by sstable.Iterator.
 	panic("pebble: SetBounds unimplemented")
 }
-
-// invalidate the iterator, positioning it below the first entry.
-func (i *blockIter) invalidateLower() {
-	i.offset = -1
-}
-
-// invalidate the iterator, positioning it after the last entry.
-func (i *blockIter) invalidateUpper() {
-	i.offset = i.restarts
-}

--- a/sstable/testdata/reader/iter
+++ b/sstable/testdata/reader/iter
@@ -61,6 +61,13 @@ seek-ge e
 .
 
 iter
+seek-ge d
+seek-ge z
+----
+<d:4>
+.
+
+iter
 seek-ge b
 seek-ge c
 seek-ge d


### PR DESCRIPTION
The previous implementation was somewhat error prone. Now
`singleLevelIterator` maintains `key` and `value` fields. Before
positioning calls the `key` field is set to nil. This prevents getting
into a state where a positioning call such as `SeekGE` returns a nil
key, but `SeekGE.Valid()` returns true.