### PR TITLE
Fix incorrect manifest.CheckOrdering checks

### DIFF
--- a/testdata/compaction_check_ordering
+++ b/testdata/compaction_check_ordering
@@ -16,14 +16,35 @@ L0
   c.SET.3-d.SET.4
   a.SET.1-b.SET.2
 ----
-fatal: L0 files 000001 and 000002 are not in increasing largest seqnum order: 4 vs 2
+fatal: L0 files 000001 and 000002 are not properly ordered: 3-4 vs 1-2
 
 check-ordering
 L0
   c.SET.3-d.SET.4
   a.SET.1-b.SET.5
 ----
-fatal: L0 files 000001 and 000002 are not in increasing smallest seqnum order: 3 vs 1
+fatal: L0 files 000001 and 000002 have overlapping seqnums: 3-4 vs 1-5
+
+check-ordering
+L0
+  a.SET.3-d.SET.3
+  a.SET.1-b.SET.2
+----
+fatal: L0 files 000001 and 000002 are not properly ordered: 3-3 vs 1-2
+
+check-ordering
+L0
+  a.SET.2-d.SET.4
+  a.SET.3-b.SET.3
+----
+fatal: L0 files 000001 and 000002 are not properly ordered: 2-4 vs 3-3
+
+check-ordering
+L0
+  a.SET.3-d.SET.3
+  a.SET.3-b.SET.3
+----
+fatal: L0 files 000001 and 000002 have overlapping seqnums: 3-3 vs 3-3
 
 check-ordering
 L1
@@ -63,14 +84,14 @@ L1
   a.SET.1-b.SET.2
   b.SET.2-d.SET.4
 ----
-fatal: L1 files 000001 and 000002 are not in increasing key order: b#2,1 vs b#2,1
+fatal: L1 files 000001 and 000002 have overlapping ranges: a#1,1-b#2,1 vs b#2,1-d#4,1
 
 check-ordering
 L1
   a.SET.1-c.SET.2
   b.SET.3-d.SET.4
 ----
-fatal: L1 files 000001 and 000002 are not in increasing key order: c#2,1 vs b#3,1
+fatal: L1 files 000001 and 000002 have overlapping ranges: a#1,1-c#2,1 vs b#3,1-d#4,1
 
 check-ordering
 L1
@@ -87,4 +108,4 @@ L2
   b.SET.3-d.SET.4
   c.SET.5-e.SET.6
 ----
-fatal: L2 files 000002 and 000003 are not in increasing key order: d#4,1 vs c#5,1
+fatal: L2 files 000002 and 000003 have overlapping ranges: b#3,1-d#4,1 vs c#5,1-e#6,1


### PR DESCRIPTION
The `manifest.CheckOrdering` checks were overly strict, rejecting valid
L0 orderings. In particular, the checks were rejecting orderings that
can occur after ingestion. An sstable ingested into L0 can be given a
global seqnum which lies in the middle of another L0 sstable. This is ok
because during ingestion we checked that the ingested sstable does not
overlap in the key range of the other sstable.