### PR TITLE
Avoid invalid calls to Iterator.Key

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -470,7 +470,7 @@ func TestFlushableBatch(t *testing.T) {
 			}
 			b.seqNum = uint64(seqNum)
 
-			iter := internalIterAdapter{b.newIter(nil)}
+			iter := newInternalIterAdapter(b.newIter(nil))
 			var buf bytes.Buffer
 			for valid := iter.First(); valid; valid = iter.Next() {
 				fmt.Fprintf(&buf, "%s:%s\n", iter.Key(), iter.Value())
@@ -548,7 +548,7 @@ func TestFlushableBatchBytesIterated(t *testing.T) {
 		it := fb.newFlushIter(nil, &bytesIterated)
 
 		var prevIterated uint64
-		for it.First(); it.Valid(); it.Next() {
+		for key, _ := it.First(); key != nil; key, _ = it.Next() {
 			if bytesIterated < prevIterated {
 				t.Fatalf("bytesIterated moved backward: %d < %d", bytesIterated, prevIterated)
 			}

--- a/data_test.go
+++ b/data_test.go
@@ -107,35 +107,37 @@ func runInternalIterCmd(d *datadriven.TestData, iter internalIterator, opts ...i
 		if len(parts) == 0 {
 			continue
 		}
+		var key *InternalKey
+		var value []byte
 		switch parts[0] {
 		case "seek-ge":
 			if len(parts) != 2 {
 				return fmt.Sprintf("seek-ge <key>\n")
 			}
 			prefix = nil
-			iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
+			key, value = iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
 		case "seek-prefix-ge":
 			if len(parts) != 2 {
 				return fmt.Sprintf("seek-prefix-ge <key>\n")
 			}
 			prefix = []byte(strings.TrimSpace(parts[1]))
-			iter.SeekPrefixGE(prefix, prefix /* key */)
+			key, value = iter.SeekPrefixGE(prefix, prefix /* key */)
 		case "seek-lt":
 			if len(parts) != 2 {
 				return fmt.Sprintf("seek-lt <key>\n")
 			}
 			prefix = nil
-			iter.SeekLT([]byte(strings.TrimSpace(parts[1])))
+			key, value = iter.SeekLT([]byte(strings.TrimSpace(parts[1])))
 		case "first":
 			prefix = nil
-			iter.First()
+			key, value = iter.First()
 		case "last":
 			prefix = nil
-			iter.Last()
+			key, value = iter.Last()
 		case "next":
-			iter.Next()
+			key, value = iter.Next()
 		case "prev":
-			iter.Prev()
+			key, value = iter.Prev()
 		case "set-bounds":
 			if len(parts) <= 1 || len(parts) > 3 {
 				return fmt.Sprintf("set-bounds lower=<lower> upper=<upper>\n")
@@ -158,11 +160,11 @@ func runInternalIterCmd(d *datadriven.TestData, iter internalIterator, opts ...i
 		default:
 			return fmt.Sprintf("unknown op: %s", parts[0])
 		}
-		if iter.Valid() && checkValidPrefix(prefix, iter.Key().UserKey) {
+		if key != nil && checkValidPrefix(prefix, key.UserKey) {
 			if verboseKey {
-				fmt.Fprintf(&b, "%s:%s\n", iter.Key(), iter.Value())
+				fmt.Fprintf(&b, "%s:%s\n", key, value)
 			} else {
-				fmt.Fprintf(&b, "%s:%s\n", iter.Key().UserKey, iter.Value())
+				fmt.Fprintf(&b, "%s:%s\n", key.UserKey, value)
 			}
 		} else if err := iter.Error(); err != nil {
 			fmt.Fprintf(&b, "err=%v\n", err)

--- a/internal/arenaskl/flush_iterator.go
+++ b/internal/arenaskl/flush_iterator.go
@@ -65,7 +65,7 @@ func (it *flushIterator) Next() (*base.InternalKey, []byte) {
 	}
 	it.decodeKey()
 	*it.bytesIterated += uint64(it.nd.allocSize)
-	return &it.key, it.Value()
+	return &it.key, it.value()
 }
 
 func (it *flushIterator) Prev() (*base.InternalKey, []byte) {

--- a/internal/arenaskl/iterator.go
+++ b/internal/arenaskl/iterator.go
@@ -81,7 +81,7 @@ func (it *Iterator) SeekGE(key []byte) (*base.InternalKey, []byte) {
 		it.nd = it.list.tail
 		return nil, nil
 	}
-	return &it.key, it.Value()
+	return &it.key, it.value()
 }
 
 func (it *Iterator) SeekPrefixGE(prefix, key []byte) (*base.InternalKey, []byte) {
@@ -104,7 +104,7 @@ func (it *Iterator) SeekLT(key []byte) (*base.InternalKey, []byte) {
 		it.nd = it.list.head
 		return nil, nil
 	}
-	return &it.key, it.Value()
+	return &it.key, it.value()
 }
 
 // First seeks position at the first entry in list. Returns the key and value
@@ -121,7 +121,7 @@ func (it *Iterator) First() (*base.InternalKey, []byte) {
 		it.nd = it.list.tail
 		return nil, nil
 	}
-	return &it.key, it.Value()
+	return &it.key, it.value()
 }
 
 // Last seeks position at the last entry in list. Returns the key and value if
@@ -138,7 +138,7 @@ func (it *Iterator) Last() (*base.InternalKey, []byte) {
 		it.nd = it.list.head
 		return nil, nil
 	}
-	return &it.key, it.Value()
+	return &it.key, it.value()
 }
 
 // Next advances to the next position. Returns the key and value if the
@@ -155,7 +155,7 @@ func (it *Iterator) Next() (*base.InternalKey, []byte) {
 		it.nd = it.list.tail
 		return nil, nil
 	}
-	return &it.key, it.Value()
+	return &it.key, it.value()
 }
 
 // Prev moves to the previous position. Returns the key and value if the
@@ -170,16 +170,11 @@ func (it *Iterator) Prev() (*base.InternalKey, []byte) {
 		it.nd = it.list.head
 		return nil, nil
 	}
-	return &it.key, it.Value()
+	return &it.key, it.value()
 }
 
-// Key returns the key at the current position.
-func (it *Iterator) Key() *base.InternalKey {
-	return &it.key
-}
-
-// Value returns the value at the current position.
-func (it *Iterator) Value() []byte {
+// value returns the value at the current position.
+func (it *Iterator) value() []byte {
 	return it.nd.getValue(it.list.arena)
 }
 
@@ -191,11 +186,6 @@ func (it *Iterator) Head() bool {
 // Tail true iff the iterator is positioned at the sentinel tail node.
 func (it *Iterator) Tail() bool {
 	return it.nd == it.list.tail
-}
-
-// Valid returns true iff the iterator is positioned at a valid node.
-func (it *Iterator) Valid() bool {
-	return it.nd != it.list.head && it.nd != it.list.tail
 }
 
 // SetBounds sets the lower and upper bounds for the iterator. Note that the

--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -60,20 +60,6 @@ type InternalIterator interface {
 	// otherwise.
 	Prev() (*InternalKey, []byte)
 
-	// Key returns the encoded internal key of the current key/value pair, or nil
-	// if done. The caller should not modify the contents of the returned key,
-	// and its contents may change on the next call to Next.
-	Key() *InternalKey
-
-	// Value returns the value of the current key/value pair, or nil if done.
-	// The caller should not modify the contents of the returned slice, and
-	// its contents may change on the next call to Next.
-	Value() []byte
-
-	// Valid returns true if the iterator is positioned at a valid key/value pair
-	// and false otherwise.
-	Valid() bool
-
 	// Error returns any accumulated error.
 	Error() error
 

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -66,8 +66,8 @@ func newFakeIterator(closeErr error, keys ...string) *fakeIter {
 func (f *fakeIter) SeekGE(key []byte) (*InternalKey, []byte) {
 	f.valid = false
 	for f.index = 0; f.index < len(f.keys); f.index++ {
-		if DefaultComparer.Compare(key, f.Key().UserKey) <= 0 {
-			if f.upper != nil && DefaultComparer.Compare(f.upper, f.Key().UserKey) <= 0 {
+		if DefaultComparer.Compare(key, f.key().UserKey) <= 0 {
+			if f.upper != nil && DefaultComparer.Compare(f.upper, f.key().UserKey) <= 0 {
 				return nil, nil
 			}
 			f.valid = true
@@ -84,8 +84,8 @@ func (f *fakeIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
 func (f *fakeIter) SeekLT(key []byte) (*InternalKey, []byte) {
 	f.valid = false
 	for f.index = len(f.keys) - 1; f.index >= 0; f.index-- {
-		if DefaultComparer.Compare(key, f.Key().UserKey) > 0 {
-			if f.lower != nil && DefaultComparer.Compare(f.lower, f.Key().UserKey) > 0 {
+		if DefaultComparer.Compare(key, f.key().UserKey) > 0 {
+			if f.lower != nil && DefaultComparer.Compare(f.lower, f.key().UserKey) > 0 {
 				return nil, nil
 			}
 			f.valid = true
@@ -101,7 +101,7 @@ func (f *fakeIter) First() (*InternalKey, []byte) {
 	if key, _ := f.Next(); key == nil {
 		return nil, nil
 	}
-	if f.upper != nil && DefaultComparer.Compare(f.upper, f.Key().UserKey) <= 0 {
+	if f.upper != nil && DefaultComparer.Compare(f.upper, f.key().UserKey) <= 0 {
 		return nil, nil
 	}
 	f.valid = true
@@ -114,7 +114,7 @@ func (f *fakeIter) Last() (*InternalKey, []byte) {
 	if key, _ := f.Prev(); key == nil {
 		return nil, nil
 	}
-	if f.lower != nil && DefaultComparer.Compare(f.lower, f.Key().UserKey) > 0 {
+	if f.lower != nil && DefaultComparer.Compare(f.lower, f.key().UserKey) > 0 {
 		return nil, nil
 	}
 	f.valid = true
@@ -130,7 +130,7 @@ func (f *fakeIter) Next() (*InternalKey, []byte) {
 	if f.index == len(f.keys) {
 		return nil, nil
 	}
-	if f.upper != nil && DefaultComparer.Compare(f.upper, f.Key().UserKey) <= 0 {
+	if f.upper != nil && DefaultComparer.Compare(f.upper, f.key().UserKey) <= 0 {
 		return nil, nil
 	}
 	f.valid = true
@@ -146,18 +146,32 @@ func (f *fakeIter) Prev() (*InternalKey, []byte) {
 	if f.index < 0 {
 		return nil, nil
 	}
-	if f.lower != nil && DefaultComparer.Compare(f.lower, f.Key().UserKey) > 0 {
+	if f.lower != nil && DefaultComparer.Compare(f.lower, f.key().UserKey) > 0 {
 		return nil, nil
 	}
 	f.valid = true
 	return f.Key(), f.Value()
 }
 
+// key returns the current Key the iterator is positioned at regardless of the
+// value of f.valid.
+func (f *fakeIter) key() *InternalKey {
+	return &f.keys[f.index]
+}
+
 func (f *fakeIter) Key() *InternalKey {
-	if f.index >= 0 && f.index < len(f.keys) {
+	if f.valid {
 		return &f.keys[f.index]
 	}
-	return nil
+	// It is invalid to call Key() when Valid() returns false. Rather than
+	// returning nil here which would technically be more correct, return a
+	// non-nil key which is the behavior of some InternalIterator
+	// implementations. This provides better testing of users of
+	// InternalIterators.
+	if f.index < 0 {
+		return &f.keys[0]
+	}
+	return &f.keys[len(f.keys)-1]
 }
 
 func (f *fakeIter) Value() []byte {

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -276,6 +276,7 @@ func testIterator(
 			iters[i] = newFakeIterator(nil, split...)
 		}
 		iter := newFunc(iters...)
+		iter.First()
 
 		j := 0
 		for ; iter.Valid() && j < len(testKeyValuePairs); j++ {

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -275,7 +275,7 @@ func testIterator(
 		for i, split := range splits {
 			iters[i] = newFakeIterator(nil, split...)
 		}
-		iter := newFunc(iters...)
+		iter := newInternalIterAdapter(newFunc(iters...))
 		iter.First()
 
 		j := 0

--- a/level_iter.go
+++ b/level_iter.go
@@ -377,30 +377,6 @@ func (l *levelIter) skipEmptyFileBackward() (*InternalKey, []byte) {
 	return key, val
 }
 
-func (l *levelIter) Key() *InternalKey {
-	if l.iter == nil {
-		if l.boundary != nil {
-			return l.boundary
-		}
-		return nil
-	}
-	return l.iter.Key()
-}
-
-func (l *levelIter) Value() []byte {
-	if l.iter == nil {
-		return nil
-	}
-	return l.iter.Value()
-}
-
-func (l *levelIter) Valid() bool {
-	if l.iter == nil {
-		return l.boundary != nil
-	}
-	return l.iter.Valid()
-}
-
 func (l *levelIter) Error() error {
 	if l.err != nil || l.iter == nil {
 		return l.err

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -329,10 +329,11 @@ func BenchmarkLevelIterNext(b *testing.B) {
 
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {
-								if !l.Valid() {
-									l.First()
+								key, _ := l.Next()
+								if key == nil {
+									key, _ = l.First()
 								}
-								l.Next()
+								_ = key
 							}
 						})
 				}
@@ -359,10 +360,11 @@ func BenchmarkLevelIterPrev(b *testing.B) {
 
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {
-								if !l.Valid() {
-									l.Last()
+								key, _ := l.Prev()
+								if key == nil {
+									key, _ = l.Last()
 								}
-								l.Prev()
+								_ = key
 							}
 						})
 				}

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -644,18 +644,6 @@ func (m *mergingIter) Prev() (*InternalKey, []byte) {
 	return m.findPrevEntry()
 }
 
-func (m *mergingIter) Key() *InternalKey {
-	return &m.heap.items[0].key
-}
-
-func (m *mergingIter) Value() []byte {
-	return m.heap.items[0].value
-}
-
-func (m *mergingIter) Valid() bool {
-	return m.heap.len() > 0 && m.err == nil
-}
-
 func (m *mergingIter) Error() error {
 	if m.heap.len() == 0 || m.err != nil {
 		return m.err

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -293,9 +293,11 @@ func (m *mergingIter) switchToMinHeap() {
 		if i == cur {
 			continue
 		}
-		iterKey := i.Key()
-		if iterKey == nil {
-			iterKey, _ = i.Next()
+		var iterKey *InternalKey
+		if i.Valid() {
+			iterKey = i.Key()
+		} else {
+			iterKey, _ = i.First()
 		}
 		for ; iterKey != nil; iterKey, _ = i.Next() {
 			if base.InternalCompare(m.heap.cmp, key, *iterKey) < 0 {
@@ -334,9 +336,11 @@ func (m *mergingIter) switchToMaxHeap() {
 		if i == cur {
 			continue
 		}
-		iterKey := i.Key()
-		if iterKey == nil {
-			iterKey, _ = i.Prev()
+		var iterKey *InternalKey
+		if i.Valid() {
+			iterKey = i.Key()
+		} else {
+			iterKey, _ = i.Last()
 		}
 		for ; iterKey != nil; iterKey, _ = i.Prev() {
 			if base.InternalCompare(m.heap.cmp, key, *iterKey) > 0 {

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -678,13 +678,3 @@ func (i *blockIter) SetBounds(lower, upper []byte) {
 	// This should never be called as bounds are handled by sstable.Iterator.
 	panic("pebble: SetBounds unimplemented")
 }
-
-// invalidate the iterator, positioning it below the first entry.
-func (i *blockIter) invalidateLower() {
-	i.offset = -1
-}
-
-// invalidate the iterator, positioning it after the last entry.
-func (i *blockIter) invalidateUpper() {
-	i.offset = i.restarts
-}

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -14,12 +14,12 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/golang/snappy"
 	"github.com/cockroachdb/pebble/cache"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/crc"
 	"github.com/cockroachdb/pebble/internal/rangedel"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/golang/snappy"
 )
 
 // BlockHandle is the file offset and length of a block.
@@ -222,7 +222,6 @@ func (i *singleLevelIterator) SeekGE(key []byte) (*InternalKey, []byte) {
 		return nil, nil
 	}
 	if i.blockUpper != nil && i.cmp(ikey.UserKey, i.blockUpper) >= 0 {
-		i.data.invalidateUpper() // force i.data.Valid() to return false
 		return nil, nil
 	}
 	return ikey, val
@@ -243,7 +242,6 @@ func (i *singleLevelIterator) SeekPrefixGE(prefix, key []byte) (*InternalKey, []
 			return nil, nil
 		}
 		if !i.reader.tableFilter.mayContain(data, prefix) {
-			i.data.invalidateUpper() // force i.data.Valid() to return false
 			return nil, nil
 		}
 	}
@@ -259,7 +257,6 @@ func (i *singleLevelIterator) SeekPrefixGE(prefix, key []byte) (*InternalKey, []
 		return nil, nil
 	}
 	if i.blockUpper != nil && i.cmp(ikey.UserKey, i.blockUpper) >= 0 {
-		i.data.invalidateUpper() // force i.data.Valid() to return false
 		return nil, nil
 	}
 	return ikey, val
@@ -303,7 +300,6 @@ func (i *singleLevelIterator) SeekLT(key []byte) (*InternalKey, []byte) {
 		}
 	}
 	if i.blockLower != nil && i.cmp(ikey.UserKey, i.blockLower) < 0 {
-		i.data.invalidateLower() // force i.data.Valid() to return false
 		return nil, nil
 	}
 	return ikey, val
@@ -329,7 +325,6 @@ func (i *singleLevelIterator) First() (*InternalKey, []byte) {
 		return nil, nil
 	}
 	if i.blockUpper != nil && i.cmp(ikey.UserKey, i.blockUpper) >= 0 {
-		i.data.invalidateUpper() // force i.data.Valid() to return false
 		return nil, nil
 	}
 	return ikey, val
@@ -354,7 +349,6 @@ func (i *singleLevelIterator) Last() (*InternalKey, []byte) {
 		return nil, nil
 	}
 	if i.blockLower != nil && i.cmp(i.data.ikey.UserKey, i.blockLower) < 0 {
-		i.data.invalidateLower()
 		return nil, nil
 	}
 	return &i.data.ikey, i.data.val
@@ -370,7 +364,6 @@ func (i *singleLevelIterator) Next() (*InternalKey, []byte) {
 	}
 	if key, val := i.data.Next(); key != nil {
 		if i.blockUpper != nil && i.cmp(key.UserKey, i.blockUpper) >= 0 {
-			i.data.invalidateUpper()
 			return nil, nil
 		}
 		return key, val
@@ -389,7 +382,6 @@ func (i *singleLevelIterator) Next() (*InternalKey, []byte) {
 				return nil, nil
 			}
 			if i.blockUpper != nil && i.cmp(key.UserKey, i.blockUpper) >= 0 {
-				i.data.invalidateUpper()
 				return nil, nil
 			}
 			return key, val
@@ -406,7 +398,6 @@ func (i *singleLevelIterator) Prev() (*InternalKey, []byte) {
 	}
 	if key, val := i.data.Prev(); key != nil {
 		if i.blockLower != nil && i.cmp(key.UserKey, i.blockLower) < 0 {
-			i.data.invalidateLower()
 			return nil, nil
 		}
 		return key, val
@@ -425,30 +416,12 @@ func (i *singleLevelIterator) Prev() (*InternalKey, []byte) {
 				return nil, nil
 			}
 			if i.blockLower != nil && i.cmp(key.UserKey, i.blockLower) < 0 {
-				i.data.invalidateLower()
 				return nil, nil
 			}
 			return key, val
 		}
 	}
 	return nil, nil
-}
-
-// Key implements internalIterator.Key, as documented in the pebble package.
-func (i *singleLevelIterator) Key() *InternalKey {
-	return i.data.Key()
-}
-
-// Value implements internalIterator.Value, as documented in the pebble
-// package.
-func (i *singleLevelIterator) Value() []byte {
-	return i.data.Value()
-}
-
-// Valid implements internalIterator.Valid, as documented in the pebble
-// package.
-func (i *singleLevelIterator) Valid() bool {
-	return i.data.Valid()
 }
 
 // Error implements internalIterator.Error, as documented in the pebble
@@ -1033,16 +1006,16 @@ func (r *Reader) get(key []byte) (value []byte, err error) {
 	}
 
 	i := r.NewIter(nil /* lower */, nil /* upper */)
-	i.SeekGE(key)
+	ikey, value := i.SeekGE(key)
 
-	if !i.Valid() || r.Compare(key, i.Key().UserKey) != 0 {
+	if ikey == nil || r.Compare(key, ikey.UserKey) != 0 {
 		err := i.Close()
 		if err == nil {
 			err = base.ErrNotFound
 		}
 		return nil, err
 	}
-	return i.Value(), i.Close()
+	return value, i.Close()
 }
 
 // NewIter returns an iterator for the contents of the table.

--- a/sstable/testdata/reader/iter
+++ b/sstable/testdata/reader/iter
@@ -61,6 +61,13 @@ seek-ge e
 .
 
 iter
+seek-ge d
+seek-ge z
+----
+<d:4>
+.
+
+iter
 seek-ge b
 seek-ge c
 seek-ge d

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -143,7 +143,7 @@ func TestWriter(t *testing.T) {
 				meta.SmallestSeqNum, meta.LargestSeqNum)
 
 		case "scan":
-			iter := iterAdapter{r.NewIter(nil /* lower */, nil /* upper */)}
+			iter := newIterAdapter(r.NewIter(nil /* lower */, nil /* upper */))
 			defer iter.Close()
 
 			var buf bytes.Buffer

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -181,15 +181,15 @@ func testTableCacheRandomAccess(t *testing.T, concurrent bool) {
 				errc <- fmt.Errorf("i=%d, fileNum=%d: find: %v", i, fileNum, err)
 				return
 			}
-			iter.SeekGE([]byte("k"))
+			key, value := iter.SeekGE([]byte("k"))
 			if concurrent {
 				time.Sleep(time.Duration(sleepTime) * time.Microsecond)
 			}
-			if !iter.Valid() {
+			if key == nil {
 				errc <- fmt.Errorf("i=%d, fileNum=%d: valid.0: got false, want true", i, fileNum)
 				return
 			}
-			if got := len(iter.Value()); got != fileNum {
+			if got := len(value); got != fileNum {
 				errc <- fmt.Errorf("i=%d, fileNum=%d: value: got %d bytes, want %d", i, fileNum, got, fileNum)
 				return
 			}


### PR DESCRIPTION
It is only valid to call `Iterator.Key()` if `Iterator.Valid()` returns
true.