### PR TITLE
Disable RocksDB sstable extensions with TableFormatLevelDB

### DIFF
--- a/internal/base/options.go
+++ b/internal/base/options.go
@@ -331,14 +331,10 @@ type Options struct {
 	// disabled.
 	ReadOnly bool
 
-	// TableFormat specifies the format version for sstables. The default is
-	// TableFormatRocksDBv2 which creates RocksDB compatible sstables. Use
+	// TableFormat specifies the format version for writing sstables. The default
+	// is TableFormatRocksDBv2 which creates RocksDB compatible sstables. Use
 	// TableFormatLevelDB to create LevelDB compatible sstable which can be used
 	// by a wider range of tools and libraries.
-	//
-	// TODO(peter): TableFormatLevelDB does not support all of the functionality
-	// of TableFormatRocksDBv2. We should ensure it is only used when writing an
-	// sstable directly, and not used when opening a database.
 	TableFormat TableFormat
 
 	// TablePropertyCollectors is a list of TablePropertyCollector creation

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -290,3 +290,13 @@ func (f footer) encode(buf []byte) []byte {
 
 	return buf
 }
+
+func supportsTwoLevelIndex(format TableFormat) bool {
+	switch format {
+	case TableFormatLevelDB:
+		return false
+	case TableFormatRocksDBv2:
+		return true
+	}
+	return true
+}

--- a/sstable/testdata/writer
+++ b/sstable/testdata/writer
@@ -217,3 +217,44 @@ j#1,15:m
 m#2,15:s
 m#1,15:s
 s#1,15:z
+
+# Setting a very small index-block-size results in a two-level index.
+
+build index-block-size=1
+a.SET.1:a
+b.SET.1:b
+c.SET.1:c
+----
+point:   [a#1,1,c#1,1]
+range:   [#0,0,#0,0]
+seqnums: [1,1]
+
+layout
+----
+         0  data (37)
+        42  index (8)
+        55  index (22)
+        82  top-index (39)
+       126  properties (716)
+       847  meta-index (32)
+       884  footer (53)
+
+# Enabling leveldb format disables the creation of a two-level index
+# (the input data here mirrors the test case above).
+
+build leveldb index-block-size=1
+a.SET.1:a
+b.SET.1:b
+c.SET.1:c
+----
+point:   [a#1,1,c#1,1]
+range:   [#0,0,#0,0]
+seqnums: [1,1]
+
+layout
+----
+         0  data (37)
+        42  index (22)
+        69  properties (678)
+       752  meta-index (32)
+       789  leveldb-footer (48)

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -359,7 +359,8 @@ func (w *Writer) flushPendingBH(key InternalKey) {
 	}
 	n := encodeBlockHandle(w.tmp[:], w.pendingBH)
 
-	if shouldFlush(sep, w.tmp[:n], w.indexBlock, w.indexBlockSize, w.indexBlockSizeThreshold) {
+	if supportsTwoLevelIndex(w.tableFormat) &&
+		shouldFlush(sep, w.tmp[:n], w.indexBlock, w.indexBlockSize, w.indexBlockSizeThreshold) {
 		// Enable two level indexes if there is more than one index block.
 		w.twoLevelIndex = true
 		w.finishIndexBlock()


### PR DESCRIPTION
Currently this disables usage of the RocksDB sstable footer and
two-level indexes.

Fixes #285