### PR TITLE
mem_table: Don't increment seqNum for logData requests

### DIFF
--- a/db.go
+++ b/db.go
@@ -388,8 +388,6 @@ func (d *DB) Merge(key, value []byte, opts *WriteOptions) error {
 // which makes it useful for testing WAL performance.
 //
 // It is safe to modify the contents of the argument after LogData returns.
-//
-// TODO(peter): untested.
 func (d *DB) LogData(data []byte, opts *WriteOptions) error {
 	b := newBatch(d)
 	defer b.release()

--- a/db_test.go
+++ b/db_test.go
@@ -468,6 +468,29 @@ func TestGetMerge(t *testing.T) {
 	}
 }
 
+func TestLogData(t *testing.T) {
+	d, err := Open("", &Options{
+		FS: vfs.NewMem(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := d.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	if err := d.LogData([]byte("foo"), Sync); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.LogData([]byte("bar"), Sync); err != nil {
+		t.Fatal(err)
+	}
+	// TODO(itsbilal): Confirm that we wrote some bytes to the WAL.
+	// For now, LogData proceeding ahead without a panic is good enough.
+}
+
 func TestSingleDeleteGet(t *testing.T) {
 	d, err := Open("", &Options{
 		FS: vfs.NewMem(),

--- a/mem_table.go
+++ b/mem_table.go
@@ -159,6 +159,9 @@ func (m *memTable) apply(batch *Batch, seqNum uint64) error {
 			err = m.rangeDelSkl.Add(ikey, value)
 			tombstoneCount++
 		case InternalKeyKindLogData:
+			// Don't increment seqNum for LogData, since these are not applied
+			// to the memtable.
+			seqNum--
 		default:
 			err = ins.Add(&m.skl, ikey, value)
 		}

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -167,7 +167,7 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 }
 
 func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
-	var ok bool = true
+	ok := true
 	for _, arg := range args {
 		func() {
 			f, err := m.opts.FS.Open(arg)


### PR DESCRIPTION
Currently, any batches with LogDatas would panic on commit due to
mismatching batch counts. This is because we were not accounting for
the fact that LogData's don't add to the batch count when incrementing
seqNum.