### PR TITLE
vfs: add LinkOrCopy utility

### DIFF
--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -147,16 +147,25 @@ func (y *memFS) Link(oldname, newname string) error {
 		return err
 	}
 	if n == nil {
-		return &os.PathError{
-			Op:   "open",
-			Path: oldname,
-			Err:  os.ErrNotExist,
+		return &os.LinkError{
+			Op:  "link",
+			Old: oldname,
+			New: newname,
+			Err: os.ErrNotExist,
 		}
 	}
 	return y.walk(newname, func(dir *memNode, frag string, final bool) error {
 		if final {
 			if frag == "" {
 				return errors.New("pebble/vfs: empty file name")
+			}
+			if _, ok := dir.children[frag]; ok {
+				return &os.LinkError{
+					Op:  "link",
+					Old: oldname,
+					New: newname,
+					Err: os.ErrExist,
+				}
 			}
 			dir.children[frag] = n
 		}

--- a/vfs/testdata/vfs
+++ b/vfs/testdata/vfs
@@ -1,0 +1,58 @@
+define
+link a b
+create a
+link a b
+link a b
+link c d
+remove b
+link-or-copy a b
+remove b
+----
+link: a -> b [file does not exist]
+create: a [<nil>]
+link: a -> b [<nil>]
+link: a -> b [file already exists]
+link: c -> d [file does not exist]
+remove: b [<nil>]
+link: a -> b [<nil>]
+remove: b [<nil>]
+
+define linkErr=ErrExist
+create a
+link a b
+link-or-copy a b
+----
+create: a [<nil>]
+link: a -> b [file already exists]
+link: a -> b [file already exists]
+
+define linkErr=ErrNotExist
+create a
+link a b
+link-or-copy a b
+----
+create: a [<nil>]
+link: a -> b [file does not exist]
+link: a -> b [file does not exist]
+
+define linkErr=ErrPermission
+create a
+link a b
+link-or-copy a b
+----
+create: a [<nil>]
+link: a -> b [permission denied]
+link: a -> b [permission denied]
+
+define linkErr=random
+create a
+link a b
+link-or-copy a b
+----
+create: a [<nil>]
+link: a -> b [random]
+link: a -> b [random]
+open: a [<nil>]
+create: b [<nil>]
+close: b [<nil>]
+close: a [<nil>]

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -170,3 +170,40 @@ func (randomReadsOption) Apply(f File) {
 		_ = fadviseRandom(osFile.Fd())
 	}
 }
+
+// LinkOrCopy creates newname as a hard link to the oldname file. If creating
+// the hard link fails, LinkOrCopy falls back to copying the file (which may
+// also fail if newname doesn't exist or oldname already exists).
+func LinkOrCopy(fs FS, oldname, newname string) error {
+	err := fs.Link(oldname, newname)
+	if err == nil {
+		return nil
+	}
+	// Whitelist a handful of errors which we know won't be fixed by copying the
+	// file.
+	if os.IsExist(err) || os.IsNotExist(err) || os.IsPermission(err) {
+		return err
+	}
+
+	// Note that we don't check for the specifics of the error code as it isn't
+	// easy to do so in a portable manner. On Unix we'd have to check for
+	// LinkError.Err == syscall.EXDEV. On Windows we'd have to check for
+	// ERROR_NOT_SAME_DEVICE, ERROR_INVALID_FUNCTION, and
+	// ERROR_INVALID_PARAMETER. Rather that such OS specific checks, we fall back
+	// to always trying to copy if hard-linking failed.
+
+	src, err := fs.Open(oldname)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	dst, err := fs.Create(newname)
+	if err != nil {
+		return err
+	}
+	defer dst.Close()
+
+	_, err = io.Copy(dst, src)
+	return err
+}

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -1,0 +1,169 @@
+// Copyright 2012 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package vfs
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/datadriven"
+)
+
+func normalizeError(err error) error {
+	// It is OS-specific which errors match IsExist, IsNotExist, and
+	// IsPermission, with OS-specific error messages. We normalize to the os.Err*
+	// errors which have standard error messages across platforms.
+	switch {
+	case os.IsExist(err):
+		return os.ErrExist
+	case os.IsNotExist(err):
+		return os.ErrNotExist
+	case os.IsPermission(err):
+		return os.ErrPermission
+	}
+	return err
+}
+
+type loggingFS struct {
+	FS
+	w       io.Writer
+	linkErr error
+}
+
+func (fs loggingFS) Create(name string) (File, error) {
+	f, err := fs.FS.Create(name)
+	fmt.Fprintf(fs.w, "create: %s [%v]\n", fs.PathBase(name), normalizeError(err))
+	return loggingFile{f, fs.PathBase(name), fs.w}, err
+}
+
+func (fs loggingFS) Link(oldname, newname string) error {
+	err := fs.linkErr
+	if err == nil {
+		err = fs.FS.Link(oldname, newname)
+	}
+	fmt.Fprintf(fs.w, "link: %s -> %s [%v]\n",
+		fs.PathBase(oldname), fs.PathBase(newname), normalizeError(err))
+	return err
+}
+
+func (fs loggingFS) Open(name string, opts ...OpenOption) (File, error) {
+	f, err := fs.FS.Open(name, opts...)
+	fmt.Fprintf(fs.w, "open: %s [%v]\n", fs.PathBase(name), normalizeError(err))
+	return loggingFile{f, fs.PathBase(name), fs.w}, err
+}
+
+func (fs loggingFS) Remove(name string) error {
+	err := fs.FS.Remove(name)
+	fmt.Fprintf(fs.w, "remove: %s [%v]\n", fs.PathBase(name), normalizeError(err))
+	return err
+}
+
+type loggingFile struct {
+	File
+	name string
+	w    io.Writer
+}
+
+func (f loggingFile) Close() error {
+	err := f.File.Close()
+	fmt.Fprintf(f.w, "close: %s [%v]\n", f.name, err)
+	return err
+}
+
+func runTestVFS(t *testing.T, baseFS FS, dir string) {
+	var buf bytes.Buffer
+	fs := loggingFS{FS: baseFS, w: &buf}
+
+	datadriven.RunTest(t, "testdata/vfs", func(td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "define":
+			buf.Reset()
+
+			for _, arg := range td.CmdArgs {
+				switch arg.Key {
+				case "linkErr":
+					if len(arg.Vals) != 1 {
+						return fmt.Sprintf("%s: %s expected 1 value", td.Cmd, arg.Key)
+					}
+					switch arg.Vals[0] {
+					case "ErrExist":
+						fs.linkErr = os.ErrExist
+					case "ErrNotExist":
+						fs.linkErr = os.ErrNotExist
+					case "ErrPermission":
+						fs.linkErr = os.ErrPermission
+					default:
+						fs.linkErr = errors.New(arg.Vals[0])
+					}
+				default:
+					return fmt.Sprintf("%s: unknown arg: %s", td.Cmd, arg.Key)
+				}
+			}
+
+			for _, line := range strings.Split(td.Input, "\n") {
+				parts := strings.Fields(line)
+				if len(parts) == 0 {
+					return fmt.Sprintf("<op> [<args>]")
+				}
+
+				switch parts[0] {
+				case "create":
+					if len(parts) != 2 {
+						return fmt.Sprintf("create <name>")
+					}
+					_, _ = fs.Create(fs.PathJoin(dir, parts[1]))
+
+				case "link":
+					if len(parts) != 3 {
+						return fmt.Sprintf("link <oldname> <newname>")
+					}
+					_ = fs.Link(fs.PathJoin(dir, parts[1]), fs.PathJoin(dir, parts[2]))
+
+				case "link-or-copy":
+					if len(parts) != 3 {
+						return fmt.Sprintf("link-or-copy <oldname> <newname>")
+					}
+					_ = LinkOrCopy(fs, fs.PathJoin(dir, parts[1]), fs.PathJoin(dir, parts[2]))
+
+				case "remove":
+					if len(parts) != 2 {
+						return fmt.Sprintf("remove <name>")
+					}
+					_ = fs.Remove(fs.PathJoin(dir, parts[1]))
+				}
+			}
+
+			return buf.String()
+
+		default:
+			return fmt.Sprintf("unknown command: %s", td.Cmd)
+		}
+	})
+}
+
+func TestVFS(t *testing.T) {
+	t.Run("mem", func(t *testing.T) {
+		runTestVFS(t, NewMem(), "")
+	})
+	if runtime.GOOS != "windows" {
+		t.Run("disk", func(t *testing.T) {
+			dir, err := ioutil.TempDir("", "test-vfs")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				_ = os.RemoveAll(dir)
+			}()
+			runTestVFS(t, Default, dir)
+		})
+	}
+}


### PR DESCRIPTION
Add `LinkOrCopy` utility which attempts to create a hard link, and falls
back to copying if hard linking fails.

Fixes #305