### PR TITLE
fix concurrent use of LogWriter in TestCommitPipelineWALClose

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -349,6 +349,8 @@ func (d *DB) Ingest(paths []string) error {
 
 	var mem flushable
 	prepare := func() {
+		// Note that d.commit.mu is held by commitPipeline when calling prepare.
+
 		d.mu.Lock()
 		defer d.mu.Unlock()
 


### PR DESCRIPTION
`TestCommitPipelineWALClose` was calling `LogWriter.Close` concurrently
with `LogWriter.SyncRecord`. This is a no-no according to the
`LogWriter` comments, and also not something done by Pebble itself. Fix
this concurrency violation by adding a `WaitGroup` that allows the test
to determine when all of the workers have queued their WAL writes and
are waiting for them to sync. This both the concurrency problem, and
also removes a timing wart in the test implementation.