### PR TITLE
add randvar.Flag and randvar.BytesFlag

### DIFF
--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -20,7 +20,7 @@ var (
 	disableWAL      bool
 	duration        time.Duration
 	engineType      string
-	maxOpsPerSec    string
+	maxOpsPerSec    *rateFlag
 	verbose         bool
 	waitCompactions bool
 	wipe            bool
@@ -69,9 +69,10 @@ func main() {
 		cmd.Flags().DurationVarP(
 			&duration, "duration", "d", 10*time.Second, "the duration to run (0, run forever)")
 		cmd.Flags().StringVarP(
-			&engineType, "engine", "e", "pebble", "engine type (pebble [default], badger, boltdb, rocksdb)")
-		cmd.Flags().StringVarP(
-			&maxOpsPerSec, "rate", "m", "1000000", "max ops per second [{zipf,uniform}:]min[-max][/period (sec)]")
+			&engineType, "engine", "e", "pebble", "engine type (pebble, badger, boltdb, rocksdb)")
+		maxOpsPerSec = newRateFlag("1000000")
+		cmd.Flags().VarP(
+			maxOpsPerSec, "rate", "m", "max ops per second [{zipf,uniform}:]min[-max][/period (sec)]")
 		cmd.Flags().BoolVarP(
 			&verbose, "verbose", "v", false, "enable verbose event logging")
 		cmd.Flags().BoolVar(

--- a/cmd/pebble/random.go
+++ b/cmd/pebble/random.go
@@ -9,7 +9,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -20,120 +19,62 @@ import (
 	"golang.org/x/exp/rand"
 )
 
-var randVarRE = regexp.MustCompile(`^(?:(uniform|zipf):)?(\d+)(?:-(\d+))?$`)
-
-func newFluctuatingRateLimiter(maxOpsPerSec string) (*rate.Limiter, error) {
-	rateDist, fluctuateDuration, err := parseRateSpec(maxOpsPerSec)
-	if err != nil {
-		return nil, err
-	}
-	limiter := rate.NewLimiter(rate.Limit(rateDist.Uint64()), 1)
-	if fluctuateDuration != 0 {
-		go func(limiter *rate.Limiter) {
-			ticker := time.NewTicker(fluctuateDuration)
-			for i := 0; ; i++ {
-				select {
-				case <-ticker.C:
-					limiter.SetLimit(rate.Limit(rateDist.Uint64()))
-				}
-			}
-		}(limiter)
-	}
-	return limiter, nil
+type rateFlag struct {
+	randvar.Flag
+	fluctuateDuration time.Duration
+	spec              string
 }
 
-func parseRandVarSpec(d string) (randvar.Static, error) {
-	m := randVarRE.FindStringSubmatch(d)
-	if m == nil {
-		return nil, fmt.Errorf("invalid random var spec: %s", d)
+func newRateFlag(spec string) *rateFlag {
+	f := &rateFlag{}
+	if err := f.Set(spec); err != nil {
+		panic(err)
 	}
-
-	min, err := strconv.Atoi(m[2])
-	if err != nil {
-		return nil, err
-	}
-	max := min
-	if m[3] != "" {
-		max, err = strconv.Atoi(m[3])
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	switch strings.ToLower(m[1]) {
-	case "", "uniform":
-		return randvar.NewUniform(nil, uint64(min), uint64(max)), nil
-	case "zipf":
-		return randvar.NewZipf(nil, uint64(min), uint64(max), 0.99)
-	default:
-		return nil, fmt.Errorf("unknown distribution: %s", m[1])
-	}
+	return f
 }
 
-func parseRateSpec(v string) (randvar.Static, time.Duration, error) {
-	parts := strings.Split(v, "/")
+func (f *rateFlag) String() string {
+	return f.spec
+}
+
+// Type implements the Flag.Value interface.
+func (f *rateFlag) Type() string {
+	return "ratevar"
+}
+
+// Set implements the Flag.Value interface.
+func (f *rateFlag) Set(spec string) error {
+	parts := strings.Split(spec, "/")
 	if len(parts) == 0 || len(parts) > 2 {
-		return nil, 0, fmt.Errorf("invalid max-ops-per-sec spec: %s", v)
+		return fmt.Errorf("invalid ratevar spec: %s", spec)
 	}
-	r, err := parseRandVarSpec(parts[0])
-	if err != nil {
-		return nil, 0, err
+	if err := f.Flag.Set(parts[0]); err != nil {
+		return err
 	}
 	// Don't fluctuate by default.
-	fluctuateDuration := time.Duration(0)
+	f.fluctuateDuration = time.Duration(0)
 	if len(parts) == 2 {
 		fluctuateDurationFloat, err := strconv.ParseFloat(parts[1], 64)
 		if err != nil {
-			return nil, 0, err
+			return err
 		}
-		fluctuateDuration = time.Duration(fluctuateDurationFloat) * time.Second
+		f.fluctuateDuration = time.Duration(fluctuateDurationFloat) * time.Second
 	}
-	return r, fluctuateDuration, nil
+	f.spec = spec
+	return nil
 }
 
-func parseValuesSpec(v string) (randvar.Static, float64, error) {
-	parts := strings.Split(v, "/")
-	if len(parts) == 0 || len(parts) > 2 {
-		return nil, 0, fmt.Errorf("invalid values spec: %s", v)
+func (f *rateFlag) newRateLimiter() *rate.Limiter {
+	limiter := rate.NewLimiter(rate.Limit(f.Uint64()), 1)
+	if f.fluctuateDuration != 0 {
+		go func(limiter *rate.Limiter) {
+			ticker := time.NewTicker(f.fluctuateDuration)
+			for range ticker.C {
+				limiter.SetLimit(rate.Limit(f.Uint64()))
+			}
+		}(limiter)
 	}
-	r, err := parseRandVarSpec(parts[0])
-	if err != nil {
-		return nil, 0, err
-	}
-	targetCompression := 1.0
-	if len(parts) == 2 {
-		targetCompression, err = strconv.ParseFloat(parts[1], 64)
-		if err != nil {
-			return nil, 0, err
-		}
-	}
-	return r, targetCompression, nil
-}
-
-func randomBlock(
-	r *rand.Rand, size int, targetCompressionRatio float64,
-) []byte {
-	uniqueSize := int(float64(size) / targetCompressionRatio)
-	if uniqueSize < 1 {
-		uniqueSize = 1
-	}
-	data := make([]byte, size)
-	offset := 0
-	for offset+8 <= uniqueSize {
-		binary.LittleEndian.PutUint64(data[offset:], r.Uint64())
-		offset += 8
-	}
-	word := r.Uint64()
-	for offset < uniqueSize {
-		data[offset] = byte(word)
-		word >>= 8
-		offset++
-	}
-	for offset < size {
-		data[offset] = data[offset-uniqueSize]
-		offset++
-	}
-	return data
+	return limiter
 }
 
 type sequence struct {

--- a/internal/randvar/flag.go
+++ b/internal/randvar/flag.go
@@ -1,0 +1,157 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package randvar
+
+import (
+	"encoding/binary"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"golang.org/x/exp/rand"
+)
+
+var randVarRE = regexp.MustCompile(`^(?:(latest|uniform|zipf):)?(\d+)(?:-(\d+))?$`)
+
+// Flag provides a command line flag interface for specifying static random
+// variables.
+type Flag struct {
+	Static
+	spec string
+}
+
+// NewFlag creates a new Flag initialized with the specified spec.
+func NewFlag(spec string) *Flag {
+	f := &Flag{}
+	if err := f.Set(spec); err != nil {
+		panic(err)
+	}
+	return f
+}
+
+func (f *Flag) String() string {
+	return f.spec
+}
+
+// Type implements the Flag.Value interface.
+func (f *Flag) Type() string {
+	return "randvar"
+}
+
+// Set implements the Flag.Value interface.
+func (f *Flag) Set(spec string) error {
+	m := randVarRE.FindStringSubmatch(spec)
+	if m == nil {
+		return fmt.Errorf("invalid random var spec: %s", spec)
+	}
+
+	min, err := strconv.Atoi(m[2])
+	if err != nil {
+		return err
+	}
+	max := min
+	if m[3] != "" {
+		max, err = strconv.Atoi(m[3])
+		if err != nil {
+			return err
+		}
+	}
+
+	switch strings.ToLower(m[1]) {
+	case "", "uniform":
+		f.Static = NewUniform(nil, uint64(min), uint64(max))
+	case "latest":
+		f.Static, err = NewSkewedLatest(nil, uint64(min), uint64(max), 0.99)
+		if err != nil {
+			return err
+		}
+	case "zipf":
+		var err error
+		f.Static, err = NewZipf(nil, uint64(min), uint64(max), 0.99)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown random var distribution: %s", m[1])
+	}
+	f.spec = spec
+	return nil
+}
+
+// BytesFlag provides a command line flag interface for specifying random
+// bytes. The specification provides for both the length of the random bytes
+// and a target compression ratio.
+type BytesFlag struct {
+	sizeFlag          Flag
+	targetCompression float64
+	spec              string
+}
+
+// NewBytesFlag creates a new BytesFlag initialized with the specified spec.
+func NewBytesFlag(spec string) *BytesFlag {
+	f := &BytesFlag{}
+	if err := f.Set(spec); err != nil {
+		panic(err)
+	}
+	return f
+}
+
+func (f *BytesFlag) String() string {
+	return f.spec
+}
+
+// Type implements the Flag.Value interface.
+func (f *BytesFlag) Type() string {
+	return "randbytes"
+}
+
+// Set implements the Flag.Value interface.
+func (f *BytesFlag) Set(spec string) error {
+	parts := strings.Split(spec, "/")
+	if len(parts) == 0 || len(parts) > 2 {
+		return fmt.Errorf("invalid randbytes spec: %s", spec)
+	}
+	if err := f.sizeFlag.Set(parts[0]); err != nil {
+		return err
+	}
+	f.targetCompression = 1.0
+	if len(parts) == 2 {
+		var err error
+		f.targetCompression, err = strconv.ParseFloat(parts[1], 64)
+		if err != nil {
+			return err
+		}
+	}
+	f.spec = spec
+	return nil
+}
+
+// Bytes returns random bytes. The length of the random bytes comes from the
+// internal sizeFlag.
+func (f *BytesFlag) Bytes(r *rand.Rand) []byte {
+	size := int(f.sizeFlag.Uint64())
+	uniqueSize := int(float64(size) / f.targetCompression)
+	if uniqueSize < 1 {
+		uniqueSize = 1
+	}
+	data := make([]byte, size)
+	offset := 0
+	for offset+8 <= uniqueSize {
+		binary.LittleEndian.PutUint64(data[offset:], r.Uint64())
+		offset += 8
+	}
+	word := r.Uint64()
+	for offset < uniqueSize {
+		data[offset] = byte(word)
+		word >>= 8
+		offset++
+	}
+	for offset < size {
+		data[offset] = data[offset-uniqueSize]
+		offset++
+	}
+	return data
+}


### PR DESCRIPTION
Add `randvar.Flag` and `randvar.BytesFlag` for specifying random
variables via command line flags. Extracted from
`cmd/pebble.parse{RandVar,Values}Spec`. Also added `rateFlag` which is
used by `cmd/pebble`. This is both general cleanup and preparation for
being able to use `randvar.{,Bytes}Flag` outside of `cmd/pebble`.