### PR TITLE
fix L0StopWritesThreshold write stalls

### DIFF
--- a/db.go
+++ b/db.go
@@ -944,7 +944,7 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 			d.mu.compact.cond.Wait()
 			continue
 		}
-		if len(d.mu.versions.currentVersion().Files[0]) > d.opts.L0StopWritesThreshold {
+		if len(d.mu.versions.currentVersion().Files[0]) >= d.opts.L0StopWritesThreshold {
 			// There are too many level-0 files, so we wait.
 			if !stalled {
 				stalled = true


### PR DESCRIPTION
Previously, L0StopWritesThreshold was stalling writes until the number
of L0 files fell to `<= L0StopWritesThreshold`. This is now changed to
`< L0StopWritesThreshold` to match the semantics in RocksDB.