### PR TITLE
fix rangedel.Fragmenter panic

### DIFF
--- a/testdata/compaction_iter
+++ b/testdata/compaction_iter
@@ -905,3 +905,20 @@ next
 ----
 d#2,0:a
 .
+
+define
+a.MERGE.2:a
+b.RANGEDEL.1:c
+----
+
+iter
+first
+tombstones a
+next
+tombstones
+----
+a#2,2:a
+.
+.
+b-c#1
+.


### PR DESCRIPTION
Fix a panic in rangedel.Fragmenter: `flush-to key < flushed key`. The
problem was that `compactionIter` was adding tombstones to the
fragmenter too early. In particular, we hit this panic by adding
tombstones that had a larger start key than the current key. If the
compaction logic decided to switch to the next sstable, we'd flush up to
the current key which is less than the start key of the most recently
added tombstone.

Fixes #317