### PR TITLE
fix indefinite write stall after ingestion

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -468,5 +468,8 @@ func (d *DB) ingestApply(jobID int, meta []*fileMetadata) (*versionEdit, error) 
 	}
 	d.updateReadStateLocked()
 	d.deleteObsoleteFiles(jobID)
+	// The ingestion may have pushed a level over the threshold for compaction,
+	// so check to see if one is necessary and schedule it.
+	d.maybeScheduleCompaction()
 	return ve, nil
 }


### PR DESCRIPTION
Ingestion needs to schedule a compaction as a final step, otherwise we
can hit a write stall due to too many L0 files, but nothing has kicked
off a compaction. Found by the metamorphic test.