### PR TITLE
db: provide facility for retaining obsolete WALs, MANIFESTs, and sstables

### DIFF
--- a/cleaner.go
+++ b/cleaner.go
@@ -1,0 +1,16 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import "github.com/cockroachdb/pebble/internal/base"
+
+// Cleaner exports the base.Cleaner type.
+type Cleaner = base.Cleaner
+
+// DeleteCleaner exports the base.DeleteCleaner type.
+type DeleteCleaner = base.DeleteCleaner
+
+// ArchiveCleaner exports the base.ArchiveCleaner type.
+type ArchiveCleaner = base.ArchiveCleaner

--- a/cleaner_test.go
+++ b/cleaner_test.go
@@ -1,0 +1,103 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+func TestArchiveCleaner(t *testing.T) {
+	dbs := make(map[string]*DB)
+	var buf syncedBuffer
+	mem := vfs.NewMem()
+	opts := &Options{
+		FS:      loggingFS{mem, &buf},
+		Cleaner: ArchiveCleaner{},
+	}
+
+	datadriven.RunTest(t, "testdata/cleaner", func(td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "batch":
+			if len(td.CmdArgs) != 1 {
+				return "batch <db>"
+			}
+			buf.Reset()
+			d := dbs[td.CmdArgs[0].String()]
+			b := d.NewBatch()
+			if err := runBatchDefineCmd(td, b); err != nil {
+				return err.Error()
+			}
+			if err := b.Commit(Sync); err != nil {
+				return err.Error()
+			}
+			return buf.String()
+
+		case "compact":
+			if len(td.CmdArgs) != 1 {
+				return "compact <db>"
+			}
+			buf.Reset()
+			d := dbs[td.CmdArgs[0].String()]
+			if err := d.Compact(nil, []byte("\xff")); err != nil {
+				return err.Error()
+			}
+			return buf.String()
+
+		case "flush":
+			if len(td.CmdArgs) != 1 {
+				return "flush <db>"
+			}
+			buf.Reset()
+			d := dbs[td.CmdArgs[0].String()]
+			if err := d.Flush(); err != nil {
+				return err.Error()
+			}
+			return buf.String()
+
+		case "list":
+			if len(td.CmdArgs) != 1 {
+				return "list <dir>"
+			}
+			paths, err := mem.List(td.CmdArgs[0].String())
+			if err != nil {
+				return err.Error()
+			}
+			sort.Strings(paths)
+			buf.Reset()
+			fmt.Fprintf(&buf, "%s\n", strings.Join(paths, "\n"))
+			return buf.String()
+
+		case "open":
+			if len(td.CmdArgs) != 1 && len(td.CmdArgs) != 2 {
+				return "open <dir> [readonly]"
+			}
+			opts.ReadOnly = false
+			if len(td.CmdArgs) == 2 {
+				if td.CmdArgs[1].String() != "readonly" {
+					return "open <dir> [readonly]"
+				}
+				opts.ReadOnly = true
+			}
+
+			buf.Reset()
+			dir := td.CmdArgs[0].String()
+			d, err := Open(dir, opts)
+			if err != nil {
+				return err.Error()
+			}
+			dbs[dir] = d
+			return buf.String()
+
+		default:
+			return fmt.Sprintf("unknown command: %s", td.Cmd)
+		}
+	})
+}

--- a/internal/base/cleaner.go
+++ b/internal/base/cleaner.go
@@ -1,0 +1,51 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package base
+
+import (
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+// Cleaner cleans obsolete files.
+type Cleaner interface {
+	Clean(fs vfs.FS, fileType FileType, path string) error
+}
+
+// DeleteCleaner deletes file.
+type DeleteCleaner struct{}
+
+// Clean removes file.
+func (DeleteCleaner) Clean(fs vfs.FS, fileType FileType, path string) error {
+	return fs.Remove(path)
+}
+
+func (DeleteCleaner) String() string {
+	return "delete"
+}
+
+// ArchiveCleaner archives file instead delete.
+type ArchiveCleaner struct{}
+
+// Clean archives file.
+func (ArchiveCleaner) Clean(fs vfs.FS, fileType FileType, path string) error {
+	switch fileType {
+	case FileTypeLog, FileTypeManifest, FileTypeTable:
+		destDir := fs.PathJoin(fs.PathDir(path), "archive")
+
+		if err := fs.MkdirAll(destDir, 0755); err != nil {
+			return err
+		}
+
+		destPath := fs.PathJoin(destDir, fs.PathBase(path))
+		return fs.Rename(path, destPath)
+
+	default:
+		return fs.Remove(path)
+	}
+}
+
+func (ArchiveCleaner) String() string {
+	return "archive"
+}

--- a/internal/base/options.go
+++ b/internal/base/options.go
@@ -231,6 +231,11 @@ type Options struct {
 	// The default cache size is 8 MB.
 	Cache *cache.Cache
 
+	// Cleaner cleans obsolete files.
+	//
+	// The default cleaner uses the DeleteCleaner.
+	Cleaner Cleaner
+
 	// Comparer defines a total ordering over the space of []byte keys: a 'less
 	// than' relationship. The same comparison algorithm must be used for reads
 	// and writes over the lifetime of the DB.
@@ -360,6 +365,9 @@ func (o *Options) EnsureDefaults() *Options {
 	if o.Cache == nil {
 		o.Cache = cache.New(8 << 20) // 8 MB
 	}
+	if o.Cleaner == nil {
+		o.Cleaner = DeleteCleaner{}
+	}
 	if o.Comparer == nil {
 		o.Comparer = DefaultComparer
 	}
@@ -468,6 +476,7 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "[Options]\n")
 	fmt.Fprintf(&buf, "  bytes_per_sync=%d\n", o.BytesPerSync)
 	fmt.Fprintf(&buf, "  cache_size=%d\n", o.Cache.MaxSize())
+	fmt.Fprintf(&buf, "  cleaner=%s\n", o.Cleaner)
 	fmt.Fprintf(&buf, "  comparer=%s\n", o.Comparer.Name)
 	fmt.Fprintf(&buf, "  disable_wal=%t\n", o.DisableWAL)
 	fmt.Fprintf(&buf, "  l0_compaction_threshold=%d\n", o.L0CompactionThreshold)

--- a/internal/base/options_test.go
+++ b/internal/base/options_test.go
@@ -42,6 +42,7 @@ func TestOptionsString(t *testing.T) {
 [Options]
   bytes_per_sync=524288
   cache_size=8388608
+  cleaner=delete
   comparer=leveldb.BytewiseComparator
   disable_wal=false
   l0_compaction_threshold=4

--- a/internal/datadriven/test_data_reader.go
+++ b/internal/datadriven/test_data_reader.go
@@ -179,7 +179,7 @@ func (r *testDataReader) emit(s string) {
 	}
 }
 
-var splitDirectivesRE = regexp.MustCompile(`^ *[a-zA-Z0-9_,-\.]+(|=[-a-zA-Z0-9_@]+|=\([^)]*\))( |$)`)
+var splitDirectivesRE = regexp.MustCompile(`^ *[a-zA-Z0-9_\/,-\.]+(|=[-a-zA-Z0-9_@]+|=\([^)]*\))( |$)`)
 
 // splits a directive line into tokens, where each token is
 // either:

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -1,0 +1,80 @@
+open db
+----
+mkdir-all: db 0755
+open-dir: db
+lock: db/LOCK
+create: db/MANIFEST-000001
+sync: db/MANIFEST-000001
+create: db/CURRENT.000001.dbtmp
+sync: db/CURRENT.000001.dbtmp
+close: db/CURRENT.000001.dbtmp
+rename: db/CURRENT.000001.dbtmp -> db/CURRENT
+sync: db
+create: db/000002.log
+sync: db
+sync: db/MANIFEST-000001
+create: db/OPTIONS-000003
+close: db/OPTIONS-000003
+sync: db
+
+batch db
+set a 1
+set b 2
+set c 3
+----
+sync: db/000002.log
+
+flush db
+----
+create: db/000004.log
+sync: db
+sync: db/000002.log
+close: db/000002.log
+create: db/000005.sst
+sync: db/000005.sst
+close: db/000005.sst
+sync: db
+sync: db/MANIFEST-000001
+
+batch db
+set d 4
+----
+sync: db/000004.log
+
+compact db
+----
+rename: db/000002.log -> db/000006.log
+create: db/000006.log
+sync: db
+sync: db/000004.log
+close: db/000004.log
+create: db/000007.sst
+sync: db/000007.sst
+close: db/000007.sst
+sync: db
+sync: db/MANIFEST-000001
+create: db/000008.sst
+sync: db/000008.sst
+close: db/000008.sst
+sync: db
+sync: db/MANIFEST-000001
+mkdir-all: db/archive 0755
+rename: db/000005.sst -> db/archive/000005.sst
+mkdir-all: db/archive 0755
+rename: db/000007.sst -> db/archive/000007.sst
+
+list db
+----
+000004.log
+000006.log
+000008.sst
+CURRENT
+LOCK
+MANIFEST-000001
+OPTIONS-000003
+archive
+
+list db/archive
+----
+000005.sst
+000007.sst

--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -344,6 +344,12 @@ func (*memFS) PathJoin(elem ...string) string {
 	return path.Join(elem...)
 }
 
+func (*memFS) PathDir(p string) string {
+	// Note that memFS uses forward slashes for its separator, hence the use of
+	// path.Dir, not filepath.Dir.
+	return path.Dir(p)
+}
+
 // memNode holds a file's data or a directory's children, and implements os.FileInfo.
 type memNode struct {
 	name     string

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -97,6 +97,9 @@ type FS interface {
 	// PathJoin joins any number of path elements into a single path, adding a
 	// separator if necessary.
 	PathJoin(elem ...string) string
+
+	// PathDir returns all but the last element of path, typically the path's directory.
+	PathDir(path string) string
 }
 
 // Default is a FS implementation backed by the underlying operating system's
@@ -155,6 +158,10 @@ func (defaultFS) PathBase(path string) string {
 
 func (defaultFS) PathJoin(elem ...string) string {
 	return filepath.Join(elem...)
+}
+
+func (defaultFS) PathDir(path string) string {
+	return filepath.Dir(path)
 }
 
 type randomReadsOption struct{}


### PR DESCRIPTION
For debugging purposes, db cleaner option can set as archive cleaner. If this option is set, the files are renamed to the archive directory instead of deleting.

Fixes #284