### PR TITLE
internal/base: tweak format of {Compaction,Flush}Info.String()

### DIFF
--- a/internal/base/event.go
+++ b/internal/base/event.go
@@ -7,6 +7,7 @@ package base
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/pebble/internal/humanize"
 )
@@ -35,6 +36,17 @@ func totalSize(tables []TableInfo) uint64 {
 		size += tables[i].Size
 	}
 	return size
+}
+
+func formatFileNums(tables []TableInfo) string {
+	var buf strings.Builder
+	for i := range tables {
+		if i > 0 {
+			buf.WriteString(" ")
+		}
+		fmt.Fprintf(&buf, "%06d", tables[i].FileNum)
+	}
+	return buf.String()
 }
 
 // CompactionInfo contains the info for a compaction event.
@@ -68,19 +80,26 @@ func (i CompactionInfo) String() string {
 	}
 
 	if !i.Done {
-		return fmt.Sprintf("[JOB %d] compacting L%d -> L%d: %d+%d (%s + %s)",
-			i.JobID, i.Input.Level, i.Output.Level,
-			len(i.Input.Tables[0]), len(i.Input.Tables[1]),
+		return fmt.Sprintf("[JOB %d] compacting L%d [%s] (%s) + L%d [%s] (%s)",
+			i.JobID,
+			i.Input.Level,
+			formatFileNums(i.Input.Tables[0]),
 			humanize.Uint64(totalSize(i.Input.Tables[0])),
+			i.Output.Level,
+			formatFileNums(i.Input.Tables[1]),
 			humanize.Uint64(totalSize(i.Input.Tables[1])))
 	}
 
-	return fmt.Sprintf("[JOB %d] compacted L%d -> L%d: %d+%d (%s + %s) -> %d (%s)",
-		i.JobID, i.Input.Level, i.Output.Level,
-		len(i.Input.Tables[0]), len(i.Input.Tables[1]),
+	return fmt.Sprintf("[JOB %d] compacted L%d [%s] (%s) + L%d [%s] (%s) -> L%d [%s] (%s)",
+		i.JobID,
+		i.Input.Level,
+		formatFileNums(i.Input.Tables[0]),
 		humanize.Uint64(totalSize(i.Input.Tables[0])),
+		i.Output.Level,
+		formatFileNums(i.Input.Tables[1]),
 		humanize.Uint64(totalSize(i.Input.Tables[1])),
-		len(i.Output.Tables),
+		i.Output.Level,
+		formatFileNums(i.Output.Tables),
 		humanize.Uint64(totalSize(i.Output.Tables)))
 }
 
@@ -106,8 +125,10 @@ func (i FlushInfo) String() string {
 		return fmt.Sprintf("[JOB %d] flushing to L0", i.JobID)
 	}
 
-	return fmt.Sprintf("[JOB %d] flushed to L0: %d (%s)", i.JobID,
-		len(i.Output), humanize.Uint64(totalSize(i.Output)))
+	return fmt.Sprintf("[JOB %d] flushed to L0 [%s] (%s)",
+		i.JobID,
+		formatFileNums(i.Output),
+		humanize.Uint64(totalSize(i.Output)))
 }
 
 // ManifestCreateInfo contains info about a manifest creation event.

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -51,7 +51,7 @@ close: db/CURRENT.000007.dbtmp
 rename: db/CURRENT.000007.dbtmp -> db/CURRENT
 sync: db
 [JOB 3] MANIFEST created 000007
-[JOB 3] flushed to L0: 1 (825 B)
+[JOB 3] flushed to L0 [000006] (825 B)
 [JOB 3] MANIFEST deleted 000003
 
 compact
@@ -77,9 +77,9 @@ close: db/CURRENT.000010.dbtmp
 rename: db/CURRENT.000010.dbtmp -> db/CURRENT
 sync: db
 [JOB 5] MANIFEST created 000010
-[JOB 5] flushed to L0: 1 (825 B)
+[JOB 5] flushed to L0 [000009] (825 B)
 [JOB 5] MANIFEST deleted 000007
-[JOB 6] compacting L0 -> L6: 2+0 (1.6 K + 0 B)
+[JOB 6] compacting L0 [000006 000009] (1.6 K) + L6 [] (0 B)
 create: db/000011.sst
 [JOB 6] compacting: sstable created 000011
 sync: db/000011.sst
@@ -93,7 +93,7 @@ close: db/CURRENT.000012.dbtmp
 rename: db/CURRENT.000012.dbtmp -> db/CURRENT
 sync: db
 [JOB 6] MANIFEST created 000012
-[JOB 6] compacted L0 -> L6: 2+0 (1.6 K + 0 B) -> 1 (825 B)
+[JOB 6] compacted L0 [000006 000009] (1.6 K) + L6 [] (0 B) -> L6 [000011] (825 B)
 [JOB 6] sstable deleted 000006
 [JOB 6] sstable deleted 000009
 [JOB 6] MANIFEST deleted 000010
@@ -124,7 +124,7 @@ close: db/CURRENT.000015.dbtmp
 rename: db/CURRENT.000015.dbtmp -> db/CURRENT
 sync: db
 [JOB 8] MANIFEST created 000015
-[JOB 8] flushed to L0: 1 (825 B)
+[JOB 8] flushed to L0 [000014] (825 B)
 
 enable-file-deletions
 ----


### PR DESCRIPTION
Include the file numbers of compaction and flush output, and the file
numbers of compaction inputs. This will make logging flush/compaction
events more useful for post-mortem debugging.