### PR TITLE
db: extend the metrics returned by DB.Metrics

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1195,8 +1195,12 @@ func (b *flushableBatch) newRangeDelIter(o *IterOptions) internalIterator {
 	return rangedel.NewIter(b.cmp, b.tombstones)
 }
 
-func (b *flushableBatch) totalBytes() uint64 {
+func (b *flushableBatch) inuseBytes() uint64 {
 	return uint64(len(b.data) - batchHeaderLen)
+}
+
+func (b *flushableBatch) totalBytes() uint64 {
+	return uint64(cap(b.data))
 }
 
 func (b *flushableBatch) flushed() chan struct{} {

--- a/batch_test.go
+++ b/batch_test.go
@@ -615,7 +615,7 @@ func TestFlushableBatchBytesIterated(t *testing.T) {
 			prevIterated = bytesIterated
 		}
 
-		expected := fb.totalBytes()
+		expected := fb.inuseBytes()
 		if bytesIterated != expected {
 			t.Fatalf("bytesIterated: got %d, want %d", bytesIterated, expected)
 		}

--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -17,7 +17,7 @@ type DB interface {
 	NewIter(*pebble.IterOptions) iterator
 	NewBatch() batch
 	Scan(key []byte, count int64, reverse bool) error
-	Metrics() *pebble.VersionMetrics
+	Metrics() *pebble.Metrics
 	Flush() error
 }
 
@@ -119,6 +119,6 @@ func (p pebbleDB) Scan(key []byte, count int64, reverse bool) error {
 	return iter.Close()
 }
 
-func (p pebbleDB) Metrics() *pebble.VersionMetrics {
+func (p pebbleDB) Metrics() *pebble.Metrics {
 	return p.d.Metrics()
 }

--- a/cmd/pebble/test.go
+++ b/cmd/pebble/test.go
@@ -261,7 +261,7 @@ func runTest(dir string, t test) {
 	stopProf := startCPUProfile()
 	defer stopProf()
 
-	backgroundCompactions := func(p *pebble.VersionMetrics) bool {
+	backgroundCompactions := func(p *pebble.Metrics) bool {
 		// The last level never gets selected as an input level for compaction,
 		// only as an output level, so ignore it for the purposes of determining if
 		// background compactions are still needed.

--- a/compaction.go
+++ b/compaction.go
@@ -635,7 +635,7 @@ func (d *DB) getCompactionPacerInfo() compactionPacerInfo {
 		totalCompactionDebt: d.mu.versions.picker.estimatedCompactionDebt(bytesFlushed),
 	}
 	for _, m := range d.mu.mem.queue {
-		pacerInfo.totalDirtyBytes += m.totalBytes()
+		pacerInfo.totalDirtyBytes += m.inuseBytes()
 	}
 	d.mu.Unlock()
 
@@ -646,7 +646,7 @@ func (d *DB) getFlushPacerInfo() flushPacerInfo {
 	var pacerInfo flushPacerInfo
 	d.mu.Lock()
 	for _, m := range d.mu.mem.queue {
-		pacerInfo.totalBytes += m.totalBytes()
+		pacerInfo.inuseBytes += m.inuseBytes()
 	}
 	d.mu.Unlock()
 	return pacerInfo
@@ -769,6 +769,7 @@ func (d *DB) flush1() error {
 		}
 	}
 
+	d.mu.versions.incrementFlushes()
 	d.opts.EventListener.FlushEnd(info)
 
 	// Refresh bytes flushed count.
@@ -897,6 +898,7 @@ func (d *DB) compact1() (err error) {
 			info.Output.Tables = append(info.Output.Tables, e.Meta.TableInfo())
 		}
 	}
+	d.mu.versions.incrementCompactions()
 	d.opts.EventListener.CompactionEnd(info)
 
 	// Update the read state before deleting obsolete files because the
@@ -927,7 +929,8 @@ func (d *DB) runCompaction(jobID int, c *compaction, pacer pacer) (
 		meta := &c.inputs[0][0]
 		c.metrics = map[int]*LevelMetrics{
 			c.outputLevel: &LevelMetrics{
-				BytesMoved: meta.Size,
+				BytesMoved:  meta.Size,
+				TablesMoved: 1,
 			},
 		}
 		ve := &versionEdit{
@@ -1070,6 +1073,11 @@ func (d *DB) runCompaction(jobID int, c *compaction, pacer pacer) (
 		meta.LargestSeqNum = writerMeta.LargestSeqNum
 
 		metrics.BytesWritten += meta.Size
+		if c.flushing == nil {
+			metrics.TablesCompacted++
+		} else {
+			metrics.TablesFlushed++
+		}
 
 		// The handling of range boundaries is a bit complicated.
 		if n := len(ve.NewFiles); n > 1 {

--- a/ingest.go
+++ b/ingest.go
@@ -486,6 +486,7 @@ func (d *DB) ingestApply(jobID int, meta []*fileMetadata) (*versionEdit, error) 
 			metrics[f.Level] = levelMetrics
 		}
 		levelMetrics.BytesIngested += m.Size
+		levelMetrics.TablesIngested++
 	}
 	if err := d.mu.versions.logAndApply(jobID, ve, metrics, d.dataDir); err != nil {
 		return nil, err

--- a/internal/humanize/humanize.go
+++ b/internal/humanize/humanize.go
@@ -9,26 +9,57 @@ import (
 	"math"
 )
 
-var sizes = []string{"B", "K", "M", "G", "T", "P", "E"}
-
 func logn(n, b float64) float64 {
 	return math.Log(n) / math.Log(b)
 }
 
-// Uint64 produces a human readable representation of the value.
-func Uint64(s uint64) string {
-	const base = 1024
-
+func humanate(s uint64, base float64, suffixes []string) string {
 	if s < 10 {
-		return fmt.Sprintf("%d B", s)
+		return fmt.Sprintf("%d%s", s, suffixes[0])
 	}
 	e := math.Floor(logn(float64(s), base))
-	suffix := sizes[int(e)]
+	suffix := suffixes[int(e)]
 	val := math.Floor(float64(s)/math.Pow(base, e)*10+0.5) / 10
-	f := "%.0f %s"
+	f := "%.0f%s"
 	if val < 10 {
-		f = "%.1f %s"
+		f = "%.1f%s"
 	}
 
 	return fmt.Sprintf(f, val, suffix)
+}
+
+type config struct {
+	base   float64
+	suffix []string
+}
+
+// IEC produces human readable representations of integer values in IEC units.
+var IEC = config{1024, []string{" B", " K", " M", " G", " T", " P", " E"}}
+
+// SI produces human readable representations of integer values in SI units.
+var SI = config{1000, []string{"", " K", " M", " G", " T", " P", " E"}}
+
+// Int64 produces a human readable representation of the value.
+func (c *config) Int64(s int64) string {
+	if s < 0 {
+		return "-" + humanate(uint64(-s), c.base, c.suffix)
+	}
+	return humanate(uint64(s), c.base, c.suffix)
+}
+
+// Uint64 produces a human readable representation of the value.
+func (c *config) Uint64(s uint64) string {
+	return humanate(s, c.base, c.suffix)
+}
+
+// Int64 produces a human readable representation of the value in IEC units
+// (base 1024).
+func Int64(s int64) string {
+	return IEC.Int64(s)
+}
+
+// Uint64 produces a human readable representation of the value in IEC units
+// (base 1024).
+func Uint64(s uint64) string {
+	return IEC.Uint64(s)
 }

--- a/mem_table.go
+++ b/mem_table.go
@@ -198,8 +198,12 @@ func (m *memTable) newRangeDelIter(*IterOptions) internalIterator {
 	return rangedel.NewIter(m.cmp, tombstones)
 }
 
-func (m *memTable) totalBytes() uint64 {
+func (m *memTable) inuseBytes() uint64 {
 	return uint64(m.skl.Size() - m.emptySize)
+}
+
+func (m *memTable) totalBytes() uint64 {
+	return uint64(m.skl.Arena().Capacity())
 }
 
 func (m *memTable) close() error {

--- a/mem_table_test.go
+++ b/mem_table_test.go
@@ -135,7 +135,7 @@ func TestMemTableBytesIterated(t *testing.T) {
 	m := newMemTable(nil)
 	for i := 0; i < 200; i++ {
 		bytesIterated := m.bytesIterated(t)
-		expected := m.totalBytes()
+		expected := m.inuseBytes()
 		if bytesIterated != expected {
 			t.Fatalf("bytesIterated: got %d, want %d", bytesIterated, expected)
 		}

--- a/metrics.go
+++ b/metrics.go
@@ -8,8 +8,24 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/humanize"
+	"github.com/cockroachdb/pebble/sstable"
 )
+
+// CacheMetrics holds metrics for the block and table cache.
+type CacheMetrics = cache.Metrics
+
+// FilterMetrics holds metrics for the filter policy
+type FilterMetrics = sstable.FilterMetrics
+
+func formatCacheMetrics(buf *bytes.Buffer, m *CacheMetrics, name string) {
+	fmt.Fprintf(buf, "%7s %9s %7s %6.1f%%  (score == hit-rate)\n",
+		name,
+		humanize.SI.Int64(m.Count),
+		humanize.IEC.Int64(m.Size),
+		hitRate(m.Hits, m.Misses))
+}
 
 // LevelMetrics holds per-level metrics such as the number of files and total
 // size of the files, and compaction related metrics.
@@ -24,15 +40,26 @@ type LevelMetrics struct {
 	// compactions. This excludes bytes moved and bytes ingested. For L0 this is
 	// the bytes written to the WAL.
 	BytesIn uint64
-	// The number of bytes ingested.
+	// The number of bytes ingested. The sibling metric for tables is
+	// TablesIngested.
 	BytesIngested uint64
-	// The number of bytes moved into the level by a "move" compaction.
+	// The number of bytes moved into the level by a "move" compaction. The
+	// sibling metric for tables is TablesMoved.
 	BytesMoved uint64
 	// The number of bytes read for compactions at the level. This includes bytes
 	// read from other levels (BytesIn), as well as bytes read for the level.
 	BytesRead uint64
-	// The number of bytes written during compactions.
+	// The number of bytes written during flushes and compactions. The sibling
+	// metrics for tables are TablesCompacted and TablesFlushed.
 	BytesWritten uint64
+	// The number of sstables compacted to this level.
+	TablesCompacted uint64
+	// The number of sstables flushed to this level.
+	TablesFlushed uint64
+	// The number of sstables ingested into the level.
+	TablesIngested uint64
+	// The number of sstables moved to this level by a "move" compaction.
+	TablesMoved uint64
 }
 
 // Add updates the counter metrics for the level.
@@ -42,6 +69,10 @@ func (m *LevelMetrics) Add(u *LevelMetrics) {
 	m.BytesMoved += u.BytesMoved
 	m.BytesRead += u.BytesRead
 	m.BytesWritten += u.BytesWritten
+	m.TablesCompacted += u.TablesCompacted
+	m.TablesFlushed += u.TablesFlushed
+	m.TablesIngested += u.TablesIngested
+	m.TablesMoved += u.TablesMoved
 }
 
 // WriteAmp computes the write amplification for compactions at this
@@ -55,22 +86,61 @@ func (m *LevelMetrics) WriteAmp() float64 {
 
 // format generates a string of the receiver's metrics, formatting it into the
 // supplied buffer.
-func (m *LevelMetrics) format(buf *bytes.Buffer) {
-	fmt.Fprintf(buf, "%6d %7s %7.2f %7s %7s %7s %7s %7s %7.1f\n",
+func (m *LevelMetrics) format(buf *bytes.Buffer, score string) {
+	fmt.Fprintf(buf, "%9d %7s %7s %7s %7s %7s %7s %7s %7s %7s %7s %7.1f\n",
 		m.NumFiles,
-		humanize.Uint64(m.Size),
-		m.Score,
-		humanize.Uint64(m.BytesIn),
-		humanize.Uint64(m.BytesIngested),
-		humanize.Uint64(m.BytesMoved),
-		humanize.Uint64(m.BytesRead),
-		humanize.Uint64(m.BytesWritten),
-		m.WriteAmp(),
-	)
+		humanize.IEC.Uint64(m.Size),
+		score,
+		humanize.IEC.Uint64(m.BytesIn),
+		humanize.IEC.Uint64(m.BytesIngested),
+		humanize.SI.Uint64(m.TablesIngested),
+		humanize.IEC.Uint64(m.BytesMoved),
+		humanize.SI.Uint64(m.TablesMoved),
+		humanize.IEC.Uint64(m.BytesWritten),
+		humanize.SI.Uint64(m.TablesFlushed+m.TablesCompacted),
+		humanize.IEC.Uint64(m.BytesRead),
+		m.WriteAmp())
 }
 
-// VersionMetrics holds metrics for each level.
-type VersionMetrics struct {
+// Metrics holds metrics for various subsystems of the DB such as the Cache,
+// Compactions, WAL, and per-Level metrics.
+//
+// TODO(peter): The testing of these metrics is relatively weak. There should
+// be testing that performs various operations on a DB and verifies that the
+// metrics reflect those operations.
+type Metrics struct {
+	BlockCache CacheMetrics
+
+	Compact struct {
+		// The total number of compactions.
+		Count int64
+		// An estimate of the number of bytes that need to be compacted for the LSM
+		// to reach a stable state.
+		EstimatedDebt uint64
+	}
+
+	Flush struct {
+		// The total number of flushes.
+		Count int64
+	}
+
+	Filter FilterMetrics
+
+	Levels [numLevels]LevelMetrics
+
+	MemTable struct {
+		// The number of bytes allocated by memtables and large (flushable)
+		// batches.
+		Size uint64
+		// The count of memtables.
+		Count int64
+	}
+
+	TableCache CacheMetrics
+
+	// Count of the number of open sstable iterators.
+	TableIters int64
+
 	WAL struct {
 		// Number of live WAL files.
 		Files int64
@@ -84,50 +154,66 @@ type VersionMetrics struct {
 		// Number of bytes written to the WAL.
 		BytesWritten uint64
 	}
-	Levels [numLevels]LevelMetrics
 }
 
-func (m *VersionMetrics) formatWAL(buf *bytes.Buffer) {
+const notApplicable = "-"
+
+func (m *Metrics) formatWAL(buf *bytes.Buffer) {
 	var writeAmp float64
 	if m.WAL.BytesIn > 0 {
 		writeAmp = float64(m.WAL.BytesWritten) / float64(m.WAL.BytesIn)
 	}
-	fmt.Fprintf(buf, "  WAL %6d %7s       - %7s       -       -       - %7s %7.1f\n",
+	fmt.Fprintf(buf, "    WAL %9d %7s %7s %7s %7s %7s %7s %7s %7s %7s %7s %7.1f\n",
 		m.WAL.Files,
 		humanize.Uint64(m.WAL.Size),
+		notApplicable,
 		humanize.Uint64(m.WAL.BytesIn),
+		notApplicable,
+		notApplicable,
+		notApplicable,
+		notApplicable,
 		humanize.Uint64(m.WAL.BytesWritten),
+		notApplicable,
+		notApplicable,
 		writeAmp)
 }
 
 // Pretty-print the metrics, showing a line for the WAL, a line per-level, and
 // a total:
 //
-//   level__files____size___score______in__ingest____move____read___write___w-amp
-//     WAL      1    53 M       -   744 M       -       -       -   765 M     1.0
-//       0      6   285 M    3.00   712 M     0 B     0 B     0 B   707 M     1.0
-//       1      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
-//       2      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
-//       3      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
-//       4      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
-//       5     80   312 M    1.09   328 M     0 B     0 B   580 M   580 M     1.8
-//       6     23   110 M    0.35   110 M     0 B     0 B   146 M   146 M     1.3
-//   total    109   706 M    0.00   765 M     0 B     0 B   726 M   2.1 G     2.9
+//   __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___w-amp
+//       WAL         1    27 B       -    48 B       -       -       -       -   108 B       -       -     2.2
+//         0         2   1.6 K    0.50    81 B   825 B       1     0 B       0   2.4 K       3     0 B    30.6
+//         1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+//         2         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+//         3         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+//         4         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+//         5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+//         6         1   825 B    0.00   1.6 K     0 B       0     0 B       0   825 B       1   1.6 K     0.5
+//     total         3   2.4 K       -   933 B   825 B       1     0 B       0   4.1 K       4   1.6 K     4.5
+//     flush         3
+//   compact         1   1.6 K          (size == estimated-debt)
+//    memtbl         1   4.0 M
+//    bcache         4   752 B    7.7%  (score == hit-rate)
+//    tcache         0     0 B    0.0%  (score == hit-rate)
+//    titers         0
+//    filter         -       -    0.0%  (score == utility)
 //
 // The WAL "in" metric is the size of the batches written to the WAL. The WAL
 // "write" metric is the size of the physical data written to the WAL which
 // includes record fragment overhead. Write amplification is computed as
 // bytes-written / bytes-in, except for the total row where bytes-in is
 // replaced with WAL-bytes-written + bytes-ingested.
-func (m *VersionMetrics) String() string {
+func (m *Metrics) String() string {
 	var buf bytes.Buffer
 	var total LevelMetrics
-	fmt.Fprintf(&buf, "level__files____size___score______in__ingest____move____read___write___w-amp\n")
+	fmt.Fprintf(&buf, "__level_____count____size___score______in__ingest(sz_cnt)"+
+		"____move(sz_cnt)___write(sz_cnt)____read___w-amp\n")
 	m.formatWAL(&buf)
 	for level := 0; level < numLevels; level++ {
 		l := &m.Levels[level]
-		fmt.Fprintf(&buf, "%5d ", level)
-		l.format(&buf)
+		fmt.Fprintf(&buf, "%7d ", level)
+		l.format(&buf, fmt.Sprintf("%0.2f", l.Score))
 		total.Add(l)
 		total.NumFiles += l.NumFiles
 		total.Size += l.Size
@@ -138,7 +224,31 @@ func (m *VersionMetrics) String() string {
 	// the bytes written to the log and bytes written externally and then
 	// ingested.
 	total.BytesWritten += total.BytesIn
-	fmt.Fprintf(&buf, "total ")
-	total.format(&buf)
+	fmt.Fprintf(&buf, "  total ")
+	total.format(&buf, "-")
+
+	fmt.Fprintf(&buf, "  flush %9d\n", m.Flush.Count)
+	fmt.Fprintf(&buf, "compact %9d %7s %7s  (size == estimated-debt)\n",
+		m.Compact.Count,
+		humanize.IEC.Uint64(m.Compact.EstimatedDebt),
+		"")
+	fmt.Fprintf(&buf, " memtbl %9d %7s\n",
+		m.MemTable.Count,
+		humanize.IEC.Uint64(m.MemTable.Size))
+	formatCacheMetrics(&buf, &m.BlockCache, "bcache")
+	formatCacheMetrics(&buf, &m.TableCache, "tcache")
+	fmt.Fprintf(&buf, " titers %9d\n", m.TableIters)
+	fmt.Fprintf(&buf, " filter %9s %7s %6.1f%%  (score == utility)\n",
+		notApplicable,
+		notApplicable,
+		hitRate(m.Filter.Hits, m.Filter.Misses))
 	return buf.String()
+}
+
+func hitRate(hits, misses int64) float64 {
+	sum := hits + misses
+	if sum == 0 {
+		return 0
+	}
+	return 100 * float64(hits) / float64(sum)
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,0 +1,72 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import "testing"
+
+func TestMetricsFormat(t *testing.T) {
+	var m Metrics
+	m.BlockCache.Size = 1
+	m.BlockCache.Count = 2
+	m.BlockCache.Hits = 3
+	m.BlockCache.Misses = 4
+	m.Compact.Count = 5
+	m.Compact.EstimatedDebt = 6
+	m.Flush.Count = 7
+	m.Filter.Hits = 8
+	m.Filter.Misses = 9
+	m.MemTable.Size = 10
+	m.MemTable.Count = 11
+	m.TableCache.Size = 12
+	m.TableCache.Count = 13
+	m.TableCache.Hits = 14
+	m.TableCache.Misses = 15
+	m.TableIters = 16
+	m.WAL.Files = 17
+	m.WAL.ObsoleteFiles = 18
+	m.WAL.Size = 19
+	m.WAL.BytesIn = 20
+	m.WAL.BytesWritten = 21
+
+	for i := range m.Levels {
+		l := &m.Levels[i]
+		base := uint64((i + 1) * 100)
+		l.NumFiles = int64(base) + 1
+		l.Size = base + 2
+		l.Score = float64(base) + 3
+		l.BytesIn = base + 4
+		l.BytesIngested = base + 4
+		l.BytesMoved = base + 6
+		l.BytesRead = base + 7
+		l.BytesWritten = base + 8
+		l.TablesCompacted = base + 9
+		l.TablesFlushed = base + 10
+		l.TablesIngested = base + 11
+		l.TablesMoved = base + 12
+	}
+
+	const expected = `
+__level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___w-amp
+    WAL        17    19 B       -    20 B       -       -       -       -    21 B       -       -     1.1
+      0       101   102 B  103.00   104 B   104 B     111   106 B     112   108 B     219   107 B     1.0
+      1       201   202 B  203.00   204 B   204 B     211   206 B     212   208 B     419   207 B     1.0
+      2       301   302 B  303.00   304 B   304 B     311   306 B     312   308 B     619   307 B     1.0
+      3       401   402 B  403.00   404 B   404 B     411   406 B     412   408 B     819   407 B     1.0
+      4       501   502 B  503.00   504 B   504 B     511   506 B     512   508 B   1.0 K   507 B     1.0
+      5       601   602 B  603.00   604 B   604 B     611   606 B     612   608 B   1.2 K   607 B     1.0
+      6       701   702 B  703.00   704 B   704 B     711   706 B     712   708 B   1.4 K   707 B     1.0
+  total      2807   2.7 K       -   2.8 K   2.8 K   2.9 K   2.8 K   2.9 K   5.6 K   5.7 K   2.8 K     2.0
+  flush         7
+compact         5     6 B          (size == estimated-debt)
+ memtbl        11    10 B
+ bcache         2     1 B   42.9%  (score == hit-rate)
+ tcache        13    12 B   48.3%  (score == hit-rate)
+ titers        16
+ filter         -       -   47.1%  (score == utility)
+`
+	if s := "\n" + m.String(); expected != s {
+		t.Fatalf("expected%s\nbut found%s", expected, s)
+	}
+}

--- a/pacer_test.go
+++ b/pacer_test.go
@@ -123,7 +123,7 @@ func TestCompactionPacerMaybeThrottle(t *testing.T) {
 				case "flush":
 					getInfo := func() flushPacerInfo {
 						return flushPacerInfo{
-							totalBytes: currentTotal,
+							inuseBytes: currentTotal,
 						}
 					}
 					flushPacer := newFlushPacer(flushPacerEnv{

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -23,11 +23,6 @@ import (
 	"github.com/golang/snappy"
 )
 
-// BlockHandle is the file offset and length of a block.
-type BlockHandle struct {
-	Offset, Length uint64
-}
-
 // decodeBlockHandle returns the block handle encoded at the start of src, as
 // well as the number of bytes it occupies. It returns zero if given invalid
 // input.

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -148,16 +148,23 @@ sync: db
 
 metrics
 ----
-level__files____size___score______in__ingest____move____read___write___w-amp
-  WAL      1    27 B       -    48 B       -       -       -   108 B     2.2
-    0      2   1.6 K    0.50    81 B   825 B     0 B     0 B   2.4 K    30.6
-    1      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
-    2      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
-    3      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
-    4      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
-    5      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
-    6      1   825 B    0.00   1.6 K     0 B     0 B   1.6 K   825 B     0.5
-total      3   2.4 K    0.00   933 B   825 B     0 B   1.6 K   4.1 K     4.5
+__level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___w-amp
+    WAL         1    27 B       -    48 B       -       -       -       -   108 B       -       -     2.2
+      0         2   1.6 K    0.50    81 B   825 B       1     0 B       0   2.4 K       3     0 B    30.6
+      1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      2         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      3         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      4         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      6         1   825 B    0.00   1.6 K     0 B       0     0 B       0   825 B       1   1.6 K     0.5
+  total         3   2.4 K       -   933 B   825 B       1     0 B       0   4.1 K       4   1.6 K     4.5
+  flush         3
+compact         1   1.6 K          (size == estimated-debt)
+ memtbl         1   4.0 M
+ bcache         4   752 B    7.7%  (score == hit-rate)
+ tcache         0     0 B    0.0%  (score == hit-rate)
+ titers         0
+ filter         -       -    0.0%  (score == utility)
 
 sstables
 ----

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -10,13 +10,20 @@ open non-existent: file does not exist
 db lsm
 ../testdata/db-stage-4
 ----
-level__files____size___score______in__ingest____move____read___write___w-amp
-  WAL      1    82 B       -     0 B       -       -       -    82 B     0.0
-    0      1   986 B    0.25     0 B     0 B     0 B     0 B     0 B     0.0
-    1      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
-    2      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
-    3      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
-    4      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
-    5      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
-    6      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
-total      1   986 B    0.00    82 B     0 B     0 B     0 B    82 B     1.0
+__level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___w-amp
+    WAL         1    82 B       -     0 B       -       -       -       -    82 B       -       -     0.0
+      0         1   986 B    0.25     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      2         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      3         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      4         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      6         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+  total         1   986 B       -    82 B     0 B       0     0 B       0    82 B       0     0 B     1.0
+  flush         0
+compact         0   986 B          (size == estimated-debt)
+ memtbl         2   8.0 M
+ bcache         0     0 B    0.0%  (score == hit-rate)
+ tcache         0     0 B    0.0%  (score == hit-rate)
+ titers         0
+ filter         -       -    0.0%  (score == utility)

--- a/version_set.go
+++ b/version_set.go
@@ -49,7 +49,7 @@ type versionSet struct {
 	versions versionList
 	picker   *compactionPicker
 
-	metrics VersionMetrics
+	metrics Metrics
 
 	// A pointer to versionSet.addObsoleteLocked. Avoids allocating a new closure
 	// on the creation of every version.
@@ -389,6 +389,14 @@ func (vs *versionSet) logAndApply(
 		l.Size = uint64(totalSize(newVersion.Files[i]))
 	}
 	return nil
+}
+
+func (vs *versionSet) incrementCompactions() {
+	vs.metrics.Compact.Count++
+}
+
+func (vs *versionSet) incrementFlushes() {
+	vs.metrics.Flush.Count++
 }
 
 // createManifest creates a manifest file that contains a snapshot of vs.


### PR DESCRIPTION
Add metrics for the cache, compactions, flushes, filters, and
memory. Extend the per-level metrics with counts of flushed, compacted,
ingested, and moved sstables.

Fixes #322