### PR TITLE
db: rework how cache IDs are allocated

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -629,7 +629,7 @@ func TestCompaction(t *testing.T) {
 					return "", "", fmt.Errorf("Open: %v", err)
 				}
 				defer f.Close()
-				r, err := sstable.NewReader(f, 0, meta.FileNum, nil)
+				r, err := sstable.NewReader(f, nil)
 				if err != nil {
 					return "", "", fmt.Errorf("NewReader: %v", err)
 				}

--- a/db.go
+++ b/db.go
@@ -162,7 +162,7 @@ type Writer interface {
 //		Comparer: myComparer,
 //	})
 type DB struct {
-	dbNum          uint64
+	cacheID        uint64
 	dirname        string
 	walDirname     string
 	opts           *Options

--- a/ingest.go
+++ b/ingest.go
@@ -41,7 +41,7 @@ func ingestValidateKey(opts *Options, key *InternalKey) error {
 	return nil
 }
 
-func ingestLoad1(opts *Options, path string, dbNum, fileNum uint64) (*fileMetadata, error) {
+func ingestLoad1(opts *Options, path string, cacheID, fileNum uint64) (*fileMetadata, error) {
 	stat, err := opts.FS.Stat(path)
 	if err != nil {
 		return nil, err
@@ -52,7 +52,7 @@ func ingestLoad1(opts *Options, path string, dbNum, fileNum uint64) (*fileMetada
 		return nil, err
 	}
 
-	r, err := sstable.NewReader(f, dbNum, fileNum, opts)
+	r, err := sstable.NewReader(f, cacheID, fileNum, opts)
 	defer r.Close()
 	if err != nil {
 		return nil, err
@@ -122,12 +122,12 @@ func ingestLoad1(opts *Options, path string, dbNum, fileNum uint64) (*fileMetada
 }
 
 func ingestLoad(
-	opts *Options, paths []string, dbNum uint64, pending []uint64,
+	opts *Options, paths []string, cacheID uint64, pending []uint64,
 ) ([]*fileMetadata, []string, error) {
 	meta := make([]*fileMetadata, 0, len(paths))
 	newPaths := make([]string, 0, len(paths))
 	for i := range paths {
-		m, err := ingestLoad1(opts, paths[i], dbNum, pending[i])
+		m, err := ingestLoad1(opts, paths[i], cacheID, pending[i])
 		if err != nil {
 			return nil, nil, err
 		}
@@ -351,7 +351,7 @@ func (d *DB) Ingest(paths []string) error {
 
 	// Load the metadata for all of the files being ingested. This step detects
 	// and elides empty sstables.
-	meta, paths, err := ingestLoad(d.opts, paths, d.dbNum, pendingOutputs)
+	meta, paths, err := ingestLoad(d.opts, paths, d.cacheID, pendingOutputs)
 	if err != nil {
 		return err
 	}

--- a/ingest.go
+++ b/ingest.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/private"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -52,7 +53,8 @@ func ingestLoad1(opts *Options, path string, cacheID, fileNum uint64) (*fileMeta
 		return nil, err
 	}
 
-	r, err := sstable.NewReader(f, cacheID, fileNum, opts)
+	cacheOpts := private.SSTableCacheOpts(cacheID, fileNum).(sstable.OpenOption)
+	r, err := sstable.NewReader(f, opts, cacheOpts)
 	defer r.Close()
 	if err != nil {
 		return nil, err

--- a/internal/cache/clockpro.go
+++ b/internal/cache/clockpro.go
@@ -45,6 +45,7 @@ func (p entryType) String() string {
 }
 
 type fileKey struct {
+	// id is the namespace for fileNums.
 	id      uint64
 	fileNum uint64
 }

--- a/internal/cache/clockpro_test.go
+++ b/internal/cache/clockpro_test.go
@@ -32,9 +32,9 @@ func TestCache(t *testing.T) {
 		wantHit := fields[1][0] == 'h'
 
 		var hit bool
-		h := cache.Get(0, uint64(key), 0)
+		h := cache.Get(1, uint64(key), 0)
 		if v := h.Get(); v == nil {
-			cache.Set(0, uint64(key), 0, append([]byte(nil), fields[0][0]))
+			cache.Set(1, uint64(key), 0, append([]byte(nil), fields[0][0]))
 		} else {
 			hit = true
 			if !bytes.Equal(v, fields[0][:1]) {
@@ -51,8 +51,8 @@ func TestCache(t *testing.T) {
 
 func TestWeakHandle(t *testing.T) {
 	cache := newShards(5, 1)
-	cache.Set(0, 1, 0, bytes.Repeat([]byte("a"), 5))
-	h := cache.Set(0, 0, 0, bytes.Repeat([]byte("b"), 5))
+	cache.Set(1, 1, 0, bytes.Repeat([]byte("a"), 5))
+	h := cache.Set(1, 0, 0, bytes.Repeat([]byte("b"), 5))
 	if v := h.Get(); string(v) != "bbbbb" {
 		t.Fatalf("expected bbbbb, but found %v", v)
 	}
@@ -61,7 +61,7 @@ func TestWeakHandle(t *testing.T) {
 	if v := w.Get(); string(v) != "bbbbb" {
 		t.Fatalf("expected bbbbb, but found %v", v)
 	}
-	cache.Set(0, 2, 0, bytes.Repeat([]byte("a"), 5))
+	cache.Set(1, 2, 0, bytes.Repeat([]byte("a"), 5))
 	if v := w.Get(); v != nil {
 		t.Fatalf("expected nil, but found %s", v)
 	}
@@ -69,23 +69,23 @@ func TestWeakHandle(t *testing.T) {
 
 func TestEvictFile(t *testing.T) {
 	cache := newShards(100, 1)
-	cache.Set(0, 0, 0, bytes.Repeat([]byte("a"), 5))
-	cache.Set(0, 1, 0, bytes.Repeat([]byte("a"), 5))
-	cache.Set(0, 2, 0, bytes.Repeat([]byte("a"), 5))
-	cache.Set(0, 2, 1, bytes.Repeat([]byte("a"), 5))
-	cache.Set(0, 2, 2, bytes.Repeat([]byte("a"), 5))
+	cache.Set(1, 0, 0, bytes.Repeat([]byte("a"), 5))
+	cache.Set(1, 1, 0, bytes.Repeat([]byte("a"), 5))
+	cache.Set(1, 2, 0, bytes.Repeat([]byte("a"), 5))
+	cache.Set(1, 2, 1, bytes.Repeat([]byte("a"), 5))
+	cache.Set(1, 2, 2, bytes.Repeat([]byte("a"), 5))
 	if expected, size := int64(25), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	cache.EvictFile(0, 0)
+	cache.EvictFile(1, 0)
 	if expected, size := int64(20), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	cache.EvictFile(0, 1)
+	cache.EvictFile(1, 1)
 	if expected, size := int64(15), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	cache.EvictFile(0, 2)
+	cache.EvictFile(1, 2)
 	if expected, size := int64(0), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
@@ -95,26 +95,26 @@ func TestEvictAll(t *testing.T) {
 	// Verify that it is okay to evict all of the data from a cache. Previously
 	// this would trigger a nil-pointer dereference.
 	cache := newShards(100, 1)
-	cache.Set(0, 0, 0, bytes.Repeat([]byte("a"), 101))
-	cache.Set(0, 1, 0, bytes.Repeat([]byte("a"), 101))
+	cache.Set(1, 0, 0, bytes.Repeat([]byte("a"), 101))
+	cache.Set(1, 1, 0, bytes.Repeat([]byte("a"), 101))
 }
 
 func TestMultipleDBs(t *testing.T) {
 	cache := newShards(100, 1)
-	cache.Set(0, 0, 0, bytes.Repeat([]byte("a"), 5))
-	cache.Set(1, 0, 0, bytes.Repeat([]byte("b"), 5))
+	cache.Set(1, 0, 0, bytes.Repeat([]byte("a"), 5))
+	cache.Set(2, 0, 0, bytes.Repeat([]byte("b"), 5))
 	if expected, size := int64(10), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	cache.EvictFile(0, 0)
+	cache.EvictFile(1, 0)
 	if expected, size := int64(5), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	h := cache.Get(0, 0, 0)
+	h := cache.Get(1, 0, 0)
 	if v := h.Get(); v != nil {
 		t.Fatalf("expected not present, but found %s", v)
 	}
-	h = cache.Get(1, 0, 0)
+	h = cache.Get(2, 0, 0)
 	if v := h.Get(); string(v) != "bbbbb" {
 		t.Fatalf("expected bbbbb, but found %v", v)
 	}
@@ -122,5 +122,5 @@ func TestMultipleDBs(t *testing.T) {
 
 func TestZeroSize(t *testing.T) {
 	cache := newShards(0, 1)
-	cache.Set(0, 0, 0, bytes.Repeat([]byte("a"), 5))
+	cache.Set(1, 0, 0, bytes.Repeat([]byte("a"), 5))
 }

--- a/internal/private/sstable.go
+++ b/internal/private/sstable.go
@@ -4,6 +4,10 @@
 
 package private
 
+// SSTableCacheOpts is a hook for specifying cache options to
+// sstable.NewReader.
+var SSTableCacheOpts func(cacheID, fileNum uint64) interface{}
+
 // SSTableWriterDisableKeyOrderChecks is a hook for disabling the key ordering
 // invariant check performed by sstable.Writer. It is intended for internal use
 // only in the construction of invalid sstables for testing. See

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -186,7 +186,7 @@ func TestLevelIterBoundaries(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			r, err := sstable.NewReader(f1, 0, 0, nil)
+			r, err := sstable.NewReader(f1, nil)
 			if err != nil {
 				return err.Error()
 			}
@@ -254,17 +254,14 @@ func buildLevelIterTables(
 		}
 	}
 
-	cache := NewCache(128 << 20)
-	cacheID := cache.NewID()
+	opts := &Options{Cache: NewCache(128 << 20)}
 	readers := make([]*sstable.Reader, len(files))
 	for i := range files {
 		f, err := mem.Open(fmt.Sprintf("bench%d", i))
 		if err != nil {
 			b.Fatal(err)
 		}
-		readers[i], err = sstable.NewReader(f, cacheID, uint64(i), &Options{
-			Cache: cache,
-		})
+		readers[i], err = sstable.NewReader(f, opts)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -255,13 +255,14 @@ func buildLevelIterTables(
 	}
 
 	cache := NewCache(128 << 20)
+	cacheID := cache.NewID()
 	readers := make([]*sstable.Reader, len(files))
 	for i := range files {
 		f, err := mem.Open(fmt.Sprintf("bench%d", i))
 		if err != nil {
 			b.Fatal(err)
 		}
-		readers[i], err = sstable.NewReader(f, 0, uint64(i), &Options{
+		readers[i], err = sstable.NewReader(f, cacheID, uint64(i), &Options{
 			Cache: cache,
 		})
 		if err != nil {

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -172,17 +172,14 @@ func buildMergingIterTables(
 		}
 	}
 
-	cache := NewCache(128 << 20)
-	cacheID := cache.NewID()
+	opts := &Options{Cache: NewCache(128 << 20)}
 	readers := make([]*sstable.Reader, len(files))
 	for i := range files {
 		f, err := mem.Open(fmt.Sprintf("bench%d", i))
 		if err != nil {
 			b.Fatal(err)
 		}
-		readers[i], err = sstable.NewReader(f, cacheID, uint64(i), &Options{
-			Cache: cache,
-		})
+		readers[i], err = sstable.NewReader(f, opts)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -173,13 +173,14 @@ func buildMergingIterTables(
 	}
 
 	cache := NewCache(128 << 20)
+	cacheID := cache.NewID()
 	readers := make([]*sstable.Reader, len(files))
 	for i := range files {
 		f, err := mem.Open(fmt.Sprintf("bench%d", i))
 		if err != nil {
 			b.Fatal(err)
 		}
-		readers[i], err = sstable.NewReader(f, 0, uint64(i), &Options{
+		readers[i], err = sstable.NewReader(f, cacheID, uint64(i), &Options{
 			Cache: cache,
 		})
 		if err != nil {

--- a/sstable/properties_test.go
+++ b/sstable/properties_test.go
@@ -80,7 +80,7 @@ func TestPropertiesLoad(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer f.Close()
-		r, err := NewReader(f, 0, 0, nil)
+		r, err := NewReader(f, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -164,7 +164,7 @@ func TestHamletReader(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r, err := NewReader(f, 0 /* dbNum */, 0 /* fileNum */, nil)
+		r, err := NewReader(f, 0 /* cacheID */, 0 /* fileNum */, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -188,7 +188,6 @@ func runTestReader(t *testing.T, o Options, dir string, r *Reader) {
 	}
 
 	mem := vfs.NewMem()
-	var dbNum uint64
 
 	datadriven.Walk(t, dir, func(t *testing.T, path string) {
 		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
@@ -214,11 +213,10 @@ func runTestReader(t *testing.T, o Options, dir string, r *Reader) {
 				if err != nil {
 					return err.Error()
 				}
-				r, err = NewReader(f, dbNum, 0, &o)
+				r, err = NewReader(f, 0, 0, &o)
 				if err != nil {
 					return err.Error()
 				}
-				dbNum++
 				return ""
 
 			case "iter":

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -164,7 +164,7 @@ func TestHamletReader(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r, err := NewReader(f, 0 /* cacheID */, 0 /* fileNum */, nil)
+		r, err := NewReader(f, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -213,7 +213,7 @@ func runTestReader(t *testing.T, o Options, dir string, r *Reader) {
 				if err != nil {
 					return err.Error()
 				}
-				r, err = NewReader(f, 0, 0, &o)
+				r, err = NewReader(f, &o)
 				if err != nil {
 					return err.Error()
 				}
@@ -390,7 +390,7 @@ func TestReaderCheckComparerMerger(t *testing.T) {
 			for _, merger := range c.mergers {
 				mergers[merger.Name] = merger
 			}
-			r, err := NewReader(f1, 0, 0, nil, comparers, mergers)
+			r, err := NewReader(f1, nil, comparers, mergers)
 			if err != nil {
 				if !strings.HasSuffix(err.Error(), c.expected) {
 					t.Fatalf("expected %q, but found %q", c.expected, err.Error())
@@ -493,7 +493,7 @@ func buildTestTable(
 	if err != nil {
 		t.Fatal(err)
 	}
-	r, err := NewReader(f1, 0, 0, &Options{
+	r, err := NewReader(f1, &Options{
 		Cache: cache.New(128 << 20),
 	})
 	if err != nil {
@@ -535,7 +535,7 @@ func buildBenchmarkTable(b *testing.B, blockSize, restartInterval int) (*Reader,
 	if err != nil {
 		b.Fatal(err)
 	}
-	r, err := NewReader(f1, 0, 0, &Options{
+	r, err := NewReader(f1, &Options{
 		Cache: cache.New(128 << 20),
 	})
 	if err != nil {

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -115,7 +115,7 @@ func init() {
 }
 
 func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
-	r, err := NewReader(f, 0, 0, &Options{
+	r, err := NewReader(f, &Options{
 		Comparer: comparer,
 		Levels: []TableOptions{{
 			FilterPolicy: fp,
@@ -489,7 +489,7 @@ func TestBloomFilterFalsePositiveRate(t *testing.T) {
 	c := &countingFilterPolicy{
 		FilterPolicy: bloom.FilterPolicy(1),
 	}
-	r, err := NewReader(f, 0, 0, &Options{
+	r, err := NewReader(f, &Options{
 		Levels: []TableOptions{{
 			FilterPolicy: c,
 		}},
@@ -628,7 +628,7 @@ func TestFinalBlockIsWritten(t *testing.T) {
 						t.Errorf("nk=%d, vLen=%d: memFS open: %v", nk, vLen, err)
 						continue
 					}
-					r, err := NewReader(rf, 0, 0, nil)
+					r, err := NewReader(rf, nil)
 					if err != nil {
 						t.Errorf("nk=%d, vLen=%d: reader open: %v", nk, vLen, err)
 					}
@@ -660,7 +660,7 @@ func TestReaderGlobalSeqNum(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r, err := NewReader(f, 0, 0, nil)
+	r, err := NewReader(f, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -684,7 +684,7 @@ func TestMetaIndexEntriesSorted(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := NewReader(f, 0 /* cacheID */, 0 /* fileNum */, nil /* extra opts */)
+	r, err := NewReader(f, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -684,7 +684,7 @@ func TestMetaIndexEntriesSorted(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := NewReader(f, 0 /* dbNum */, 0 /* fileNum */, nil /* extra opts */)
+	r, err := NewReader(f, 0 /* cacheID */, 0 /* fileNum */, nil /* extra opts */)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -108,7 +108,7 @@ func TestWriter(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			r, err = NewReader(f1, 0, 0, nil)
+			r, err = NewReader(f1, nil)
 			if err != nil {
 				return err.Error()
 			}
@@ -158,7 +158,7 @@ func TestWriter(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			r, err = NewReader(f1, 0, 0, nil)
+			r, err = NewReader(f1, nil)
 			if err != nil {
 				return err.Error()
 			}

--- a/table_cache.go
+++ b/table_cache.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/private"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -335,7 +336,8 @@ func (n *tableCacheNode) load(c *tableCacheShard) {
 		close(n.loaded)
 		return
 	}
-	n.reader, n.err = sstable.NewReader(f, c.cacheID, n.meta.FileNum, c.opts)
+	cacheOpts := private.SSTableCacheOpts(c.cacheID, n.meta.FileNum).(sstable.OpenOption)
+	n.reader, n.err = sstable.NewReader(f, c.opts, cacheOpts)
 	if n.meta.SmallestSeqNum == n.meta.LargestSeqNum {
 		n.reader.Properties.GlobalSeqNum = n.meta.LargestSeqNum
 	}

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -153,7 +153,7 @@ func newTableCache() (*tableCache, *tableCacheTestFS, error) {
 	opts := &Options{}
 	opts.EnsureDefaults()
 	c := &tableCache{}
-	c.init(0, "", fs, opts, tableCacheTestCacheSize, tableCacheTestHitBufferSize)
+	c.init(opts.Cache.NewID(), "", fs, opts, tableCacheTestCacheSize, tableCacheTestHitBufferSize)
 	return c, fs, nil
 }
 

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -116,7 +116,7 @@ order which means the records will be printed in that order.
 }
 
 func (s *sstableT) newReader(f vfs.File) (*sstable.Reader, error) {
-	return sstable.NewReader(f, 0, 0, s.opts, s.comparers, s.mergers)
+	return sstable.NewReader(f, s.opts, s.comparers, s.mergers)
 }
 
 func (s *sstableT) runCheck(cmd *cobra.Command, args []string) {

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -28,7 +28,6 @@ type sstableT struct {
 	opts      *sstable.Options
 	comparers sstable.Comparers
 	mergers   sstable.Mergers
-	dbNum     uint64
 
 	// Flags.
 	fmtKey   formatter
@@ -117,8 +116,7 @@ order which means the records will be printed in that order.
 }
 
 func (s *sstableT) newReader(f vfs.File) (*sstable.Reader, error) {
-	s.dbNum++
-	return sstable.NewReader(f, s.dbNum, 0, s.opts, s.comparers, s.mergers)
+	return sstable.NewReader(f, 0, 0, s.opts, s.comparers, s.mergers)
 }
 
 func (s *sstableT) runCheck(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Avoid a common source of errors which made it easy to accidentally get
cache collisions by preventing the use of the zero cache ID. Renamed
`dbNum` to `cacheID` to make it clear that the cache can be used without
a DB.

Added `Cache.NewID()` for allocating cache IDs. Changed
`sstable.NewReader` to allocate a new `cacheID` via `Cache.NewID()` if 0
is passed as an argument.