### PR TITLE
avoid (re-)computing Batch.memTableSize when it won't be used

### DIFF
--- a/open.go
+++ b/open.go
@@ -334,7 +334,9 @@ func (d *DB) replayWAL(
 			return 0, fmt.Errorf("pebble: corrupt log file %q", filename)
 		}
 
-		b = Batch{}
+		// Specify Batch.db so that Batch.SetRepr will compute Batch.memTableSize
+		// which is used below.
+		b = Batch{db: d}
 		b.SetRepr(buf.Bytes())
 		seqNum := b.SeqNum()
 		maxSeqNum = seqNum + uint64(b.Count())


### PR DESCRIPTION
CockroachDB uses pebble.Batch for building batches. This avoids a
performance a regression due to the recomputation of
`Batch.memTableSize` whenever `Batch.Apply` and `Batch.SetRepr` are
called. `Batch.memTableSize` is only used by Pebble when committing a
batch. Rather than computing it up front, we can delay computation if
the `Batch` is not associated with a `DB`.