### PR TITLE
sstable: NewReader cleanup on error

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -55,10 +55,10 @@ func ingestLoad1(opts *Options, path string, cacheID, fileNum uint64) (*fileMeta
 
 	cacheOpts := private.SSTableCacheOpts(cacheID, fileNum).(sstable.OpenOption)
 	r, err := sstable.NewReader(f, opts, cacheOpts)
-	defer r.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer r.Close()
 
 	meta := &fileMetadata{}
 	meta.FileNum = fileNum

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -1382,7 +1382,7 @@ func NewReader(
 	}
 	if f == nil {
 		r.err = errors.New("pebble/table: nil file")
-		return r, r.err
+		return nil, r.Close()
 	}
 
 	// Note that the extra options are applied twice. First here for pre-apply
@@ -1401,12 +1401,12 @@ func NewReader(
 	footer, err := readFooter(f)
 	if err != nil {
 		r.err = err
-		return r, r.err
+		return nil, r.Close()
 	}
 	// Read the metaindex.
 	if err := r.readMetaindex(footer.metaindexBH, o); err != nil {
 		r.err = err
-		return r, r.err
+		return nil, r.Close()
 	}
 	r.index.bh = footer.indexBH
 	r.metaIndexBH = footer.metaindexBH
@@ -1439,7 +1439,10 @@ func NewReader(
 				r.fileNum, r.Properties.MergerName)
 		}
 	}
-	return r, r.err
+	if r.err != nil {
+		return nil, r.Close()
+	}
+	return r, nil
 }
 
 // Layout describes the block organization of an sstable.

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -131,12 +131,12 @@ func (s *sstableT) runCheck(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(stdout, "%s\n", arg)
 
 			r, err := s.newReader(f)
-			defer r.Close()
 
 			if err != nil {
 				fmt.Fprintf(stdout, "%s\n", err)
 				return
 			}
+			defer r.Close()
 
 			// Update the internal formatter if this comparator has one specified.
 			s.fmtKey.setForComparer(r.Properties.ComparerName, s.comparers)

--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -29,6 +29,17 @@ func NewMem() FS {
 	}
 }
 
+// NewMemFile returns a memory-backed File implementation. The memory-backed
+// file takes ownership of data.
+func NewMemFile(data []byte) File {
+	return &memFile{
+		n: &memNode{
+			data:    data,
+			modTime: time.Now(),
+		},
+	}
+}
+
 // memFS implements FS.
 type memFS struct {
 	mu   sync.Mutex


### PR DESCRIPTION
Changed `NewReader()` to return either a Reader on success, or an
error on failure, but never both. This should be more conventional.

Also introduced `vfs.NewMemFile()` on the pretense of it being useful
for this PR's unit test. Though really it is needed to simplify a PR in
Cockroach repo.