### PR TITLE
sstable: evict newly written blocks from the block cache

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/internal/private"
 	"github.com/cockroachdb/pebble/internal/rangedel"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -1020,7 +1021,8 @@ func (d *DB) runCompaction(jobID int, c *compaction, pacer pacer) (
 			BytesPerSync: d.opts.BytesPerSync,
 		})
 		filenames = append(filenames, filename)
-		tw = sstable.NewWriter(file, d.opts, d.opts.Level(c.outputLevel))
+		cacheOpts := private.SSTableCacheOpts(d.cacheID, fileNum).(sstable.WriterOption)
+		tw = sstable.NewWriter(file, d.opts, d.opts.Level(c.outputLevel), cacheOpts)
 
 		ve.NewFiles = append(ve.NewFiles, newFileEntry{
 			Level: c.outputLevel,

--- a/ingest.go
+++ b/ingest.go
@@ -53,7 +53,7 @@ func ingestLoad1(opts *Options, path string, cacheID, fileNum uint64) (*fileMeta
 		return nil, err
 	}
 
-	cacheOpts := private.SSTableCacheOpts(cacheID, fileNum).(sstable.OpenOption)
+	cacheOpts := private.SSTableCacheOpts(cacheID, fileNum).(sstable.ReaderOption)
 	r, err := sstable.NewReader(f, opts, cacheOpts)
 	defer r.Close()
 	if err != nil {

--- a/internal/cache/clockpro_test.go
+++ b/internal/cache/clockpro_test.go
@@ -67,6 +67,31 @@ func TestWeakHandle(t *testing.T) {
 	}
 }
 
+func TestCacheDelete(t *testing.T) {
+	cache := newShards(100, 1)
+	cache.Set(1, 0, 0, bytes.Repeat([]byte("a"), 5))
+	cache.Set(1, 1, 0, bytes.Repeat([]byte("a"), 5))
+	cache.Set(1, 2, 0, bytes.Repeat([]byte("a"), 5))
+	if expected, size := int64(15), cache.Size(); expected != size {
+		t.Fatalf("expected cache size %d, but found %d", expected, size)
+	}
+	cache.Delete(1, 1, 0)
+	if expected, size := int64(10), cache.Size(); expected != size {
+		t.Fatalf("expected cache size %d, but found %d", expected, size)
+	}
+	if h := cache.Get(1, 0, 0); h.Get() == nil {
+		t.Fatalf("expected to find block 0/0")
+	}
+	if h := cache.Get(1, 1, 0); h.Get() != nil {
+		t.Fatalf("expected to not find block 1/0")
+	}
+	// Deleting a non-existing block does nothing.
+	cache.Delete(1, 1, 0)
+	if expected, size := int64(10), cache.Size(); expected != size {
+		t.Fatalf("expected cache size %d, but found %d", expected, size)
+	}
+}
+
 func TestEvictFile(t *testing.T) {
 	cache := newShards(100, 1)
 	cache.Set(1, 0, 0, bytes.Repeat([]byte("a"), 5))

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/cockroachdb/pebble/internal/rangedel"
 	"github.com/cockroachdb/pebble/vfs"
@@ -203,4 +204,77 @@ func TestWriter(t *testing.T) {
 			return fmt.Sprintf("unknown command: %s", td.Cmd)
 		}
 	})
+}
+
+func TestWriterClearCache(t *testing.T) {
+	// Verify that Writer clears the cache of blocks that it writes.
+	mem := vfs.NewMem()
+	opts := &Options{Cache: cache.New(64 << 20)}
+	cacheOpts := &cacheOpts{cacheID: 1, fileNum: 1}
+	invalidData := []byte("invalid data")
+
+	build := func(name string) {
+		f, err := mem.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		w := NewWriter(f, opts, TableOptions{}, cacheOpts)
+		if err := w.Set([]byte("hello"), []byte("world")); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Build the sstable a first time so that we can determine the locations of
+	// all of the blocks.
+	build("test")
+
+	f, err := mem.Open("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := NewReader(f, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	layout, err := r.Layout()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	foreachBH := func(layout *Layout, f func(bh BlockHandle)) {
+		for _, bh := range layout.Data {
+			f(bh)
+		}
+		for _, bh := range layout.Index {
+			f(bh)
+		}
+		f(layout.TopIndex)
+		f(layout.Filter)
+		f(layout.RangeDel)
+		f(layout.Properties)
+		f(layout.MetaIndex)
+	}
+
+	// Poison the cache for each of the blocks.
+	poison := func(bh BlockHandle) {
+		opts.Cache.Set(cacheOpts.cacheID, cacheOpts.fileNum, bh.Offset, invalidData)
+	}
+	foreachBH(layout, poison)
+
+	// Build the table a second time. This should clear the cache for the blocks
+	// that are written.
+	build("test")
+
+	// Verify that the written blocks have been cleared from the cache.
+	check := func(bh BlockHandle) {
+		h := opts.Cache.Get(cacheOpts.cacheID, cacheOpts.fileNum, bh.Offset)
+		if h.Get() != nil {
+			t.Fatalf("%d: expected cache to be cleared, but found %q", bh.Offset, invalidData)
+		}
+	}
+	foreachBH(layout, check)
 }

--- a/table_cache.go
+++ b/table_cache.go
@@ -336,7 +336,7 @@ func (n *tableCacheNode) load(c *tableCacheShard) {
 		close(n.loaded)
 		return
 	}
-	cacheOpts := private.SSTableCacheOpts(c.cacheID, n.meta.FileNum).(sstable.OpenOption)
+	cacheOpts := private.SSTableCacheOpts(c.cacheID, n.meta.FileNum).(sstable.ReaderOption)
 	n.reader, n.err = sstable.NewReader(f, c.opts, cacheOpts)
 	if n.meta.SmallestSeqNum == n.meta.LargestSeqNum {
 		n.reader.Properties.GlobalSeqNum = n.meta.LargestSeqNum


### PR DESCRIPTION
When an sstable is being written, evict newly written blocks from the
block cache. This provides a further defensive mechanism against
accidentally using a block in the cache that was written by a previous
sstable.

Fixes #336