### PR TITLE
vfs: NewMemFile should be readable

### DIFF
--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -37,6 +37,7 @@ func NewMemFile(data []byte) File {
 			data:    data,
 			modTime: time.Now(),
 		},
+		read: true,
 	}
 }
 

--- a/vfs/mem_fs_test.go
+++ b/vfs/mem_fs_test.go
@@ -6,6 +6,7 @@ package vfs
 
 import (
 	"io"
+	"io/ioutil"
 	"os"
 	"sort"
 	"strconv"
@@ -229,5 +230,17 @@ func TestList(t *testing.T) {
 		if got != want {
 			t.Errorf("List %q: got %q, want %q", s[0], got, want)
 		}
+	}
+}
+
+func TestMemFile(t *testing.T) {
+	want := "foo"
+	f := NewMemFile([]byte(want))
+	buf, err := ioutil.ReadAll(f)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if got := string(buf); got != want {
+		t.Fatalf("got %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
Follow-up to #341. Since `NewMemFile()` was only used in tests expected
to encounter errors that hid the bug that such files were not readable.
Added a test for `NewMemFile()` where its contents must be readable.