### PR TITLE
fix buglet in vfs.Clone

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -123,7 +123,7 @@ func TestBasicReads(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.dirname, func(t *testing.T) {
 			fs := vfs.NewMem()
-			_, err := vfs.Clone(vfs.Default, fs, filepath.Join("testdata", tc.dirname), "")
+			_, err := vfs.Clone(vfs.Default, fs, filepath.Join("testdata", tc.dirname), tc.dirname)
 			if err != nil {
 				t.Fatalf("%s: cloneFileSystem failed: %v", tc.dirname, err)
 			}

--- a/tool/data_test.go
+++ b/tool/data_test.go
@@ -59,7 +59,9 @@ func runTests(t *testing.T, path string) {
 				// always uses "/" for the path separator.
 				fs := vfs.NewMem()
 				for i := range args {
-					if ok, err := vfs.Clone(vfs.Default, fs, normalize(args[i]), ""); err != nil {
+					src := normalize(args[i])
+					dest := vfs.Default.PathBase(src)
+					if ok, err := vfs.Clone(vfs.Default, fs, src, dest); err != nil {
 						return err.Error()
 					} else if ok {
 						args[i] = fs.PathBase(args[i])

--- a/vfs/clone.go
+++ b/vfs/clone.go
@@ -7,6 +7,7 @@ package vfs
 import (
 	"io/ioutil"
 	"os"
+	"sort"
 )
 
 // Clone recursively copies a directory structure from srcFS to dstFS. srcPath
@@ -15,9 +16,8 @@ import (
 // compatible with the dstFS path format. Returns (true,nil) on a successful
 // copy, (false,nil) if srcPath does not exist, and (false,err) if an error
 // occurred.
-func Clone(srcFS, dstFS FS, srcPath, dstDir string) (bool, error) {
-	dstPath := dstFS.PathJoin(dstDir, srcFS.PathBase(srcPath))
-	srcFile, err := Default.Open(srcPath)
+func Clone(srcFS, dstFS FS, srcPath, dstPath string) (bool, error) {
+	srcFile, err := srcFS.Open(srcPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// Ignore non-existent errors. Those will translate into non-existent
@@ -43,8 +43,10 @@ func Clone(srcFS, dstFS FS, srcPath, dstDir string) (bool, error) {
 		if err != nil {
 			return false, err
 		}
+		// Sort the paths so we get deterministic test output.
+		sort.Strings(list)
 		for _, name := range list {
-			_, err := Clone(srcFS, dstFS, srcFS.PathJoin(srcPath, name), dstPath)
+			_, err := Clone(srcFS, dstFS, srcFS.PathJoin(srcPath, name), dstFS.PathJoin(dstPath, name))
 			if err != nil {
 				return false, err
 			}

--- a/vfs/testdata/vfs
+++ b/vfs/testdata/vfs
@@ -57,3 +57,43 @@ create: b [<nil>]
 sync: b [<nil>]
 close: b [<nil>]
 close: a [<nil>]
+
+define
+mkdir d
+create d/a
+mkdir  d/b
+create d/b/c
+----
+mkdir: d [<nil>]
+create: d/a [<nil>]
+mkdir: d/b [<nil>]
+create: d/b/c [<nil>]
+
+define
+clone d e
+----
+open: d [<nil>]
+close: d [<nil>]
+mkdir: e [<nil>]
+open: d/a [<nil>]
+close: d/a [<nil>]
+create: e/a [<nil>]
+close: a [<nil>]
+open: d/b [<nil>]
+close: d/b [<nil>]
+mkdir: e/b [<nil>]
+open: d/b/c [<nil>]
+close: d/b/c [<nil>]
+create: e/b/c [<nil>]
+close: c [<nil>]
+
+define
+list e
+----
+a
+b
+
+define
+list e/b
+----
+c


### PR DESCRIPTION
`vfs.Clone` was accidentally using `vfs.Default` instead of `srcFS` in
one place.

Tweaked the semantics of clone so that the `dstDir` now becomes
`dstPath`. This makes `vfs.Clone(..., "a/b", "c")` copy the contents of
directory "a/b" into "c", rather than copying the contents into "c/b".

Extended `TestVFS` to test the behavior of clone.