### PR TITLE
rename make{Reader,Writer}Options to Options.Make{Reader,Writer}Options

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -998,7 +998,7 @@ func (d *DB) runCompaction(jobID int, c *compaction, pacer pacer) (
 		c.outputLevel: metrics,
 	}
 
-	writerOpts := makeWriterOptions(d.opts, d.opts.Level(c.outputLevel))
+	writerOpts := d.opts.MakeWriterOptions(c.outputLevel)
 
 	newOutput := func() error {
 		d.mu.Lock()

--- a/ingest.go
+++ b/ingest.go
@@ -54,7 +54,7 @@ func ingestLoad1(opts *Options, path string, cacheID, fileNum uint64) (*fileMeta
 	}
 
 	cacheOpts := private.SSTableCacheOpts(cacheID, fileNum).(sstable.ReaderOption)
-	r, err := sstable.NewReader(f, makeReaderOptions(opts), cacheOpts)
+	r, err := sstable.NewReader(f, opts.MakeReaderOptions(), cacheOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/options.go
+++ b/options.go
@@ -759,36 +759,41 @@ func (o *Options) Validate() error {
 	return errors.New(buf.String())
 }
 
-func makeReaderOptions(opts *Options) sstable.ReaderOptions {
-	var o sstable.ReaderOptions
-	if opts != nil {
-		o.Cache = opts.Cache
-		o.Comparer = opts.Comparer
-		o.Filters = opts.Filters
-		if opts.Merger != nil {
-			o.MergerName = opts.Merger.Name
+// MakeReaderOptions constructs sstable.ReaderOptions from the corresponding
+// options in the receiver.
+func (o *Options) MakeReaderOptions() sstable.ReaderOptions {
+	var readerOpts sstable.ReaderOptions
+	if o != nil {
+		readerOpts.Cache = o.Cache
+		readerOpts.Comparer = o.Comparer
+		readerOpts.Filters = o.Filters
+		if o.Merger != nil {
+			readerOpts.MergerName = o.Merger.Name
 		}
 	}
-	return o
+	return readerOpts
 }
 
-func makeWriterOptions(opts *Options, levelOpts LevelOptions) sstable.WriterOptions {
-	var o sstable.WriterOptions
-	if opts != nil {
-		o.Cache = opts.Cache
-		o.Comparer = opts.Comparer
-		if opts.Merger != nil {
-			o.MergerName = opts.Merger.Name
+// MakeWriterOptions constructs sstable.WriterOptions for the specified level
+// from the corresponding options in the receiver.
+func (o *Options) MakeWriterOptions(level int) sstable.WriterOptions {
+	var writerOpts sstable.WriterOptions
+	if o != nil {
+		writerOpts.Cache = o.Cache
+		writerOpts.Comparer = o.Comparer
+		if o.Merger != nil {
+			writerOpts.MergerName = o.Merger.Name
 		}
-		o.TableFormat = opts.TableFormat
-		o.TablePropertyCollectors = opts.TablePropertyCollectors
+		writerOpts.TableFormat = o.TableFormat
+		writerOpts.TablePropertyCollectors = o.TablePropertyCollectors
 	}
-	o.BlockRestartInterval = levelOpts.BlockRestartInterval
-	o.BlockSize = levelOpts.BlockSize
-	o.BlockSizeThreshold = levelOpts.BlockSizeThreshold
-	o.Compression = levelOpts.Compression
-	o.FilterPolicy = levelOpts.FilterPolicy
-	o.FilterType = levelOpts.FilterType
-	o.IndexBlockSize = levelOpts.IndexBlockSize
-	return o
+	levelOpts := o.Level(level)
+	writerOpts.BlockRestartInterval = levelOpts.BlockRestartInterval
+	writerOpts.BlockSize = levelOpts.BlockSize
+	writerOpts.BlockSizeThreshold = levelOpts.BlockSizeThreshold
+	writerOpts.Compression = levelOpts.Compression
+	writerOpts.FilterPolicy = levelOpts.FilterPolicy
+	writerOpts.FilterType = levelOpts.FilterType
+	writerOpts.IndexBlockSize = levelOpts.IndexBlockSize
+	return writerOpts
 }

--- a/table_cache.go
+++ b/table_cache.go
@@ -118,7 +118,7 @@ func (c *tableCacheShard) init(
 	c.cacheID = cacheID
 	c.dirname = dirname
 	c.fs = fs
-	c.opts = makeReaderOptions(opts)
+	c.opts = opts.MakeReaderOptions()
 	c.size = size
 	c.mu.nodes = make(map[uint64]*tableCacheNode)
 	c.mu.lru.next = &c.mu.lru


### PR DESCRIPTION
This exposes `Make{Reader,Writer}Options` for use by the metamorphic
test.