### PR TITLE
truncate sstable boundaries to the compaction input boundaries

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -283,7 +283,7 @@ func (p *compactionPicker) pickAuto(
 		}
 	}
 
-	c.setupOtherInputs()
+	c.setupInputs()
 	return c
 }
 
@@ -296,7 +296,6 @@ func (p *compactionPicker) pickManual(
 		return nil
 	}
 
-	// TODO(peter): The logic here is untested and possibly incomplete.
 	cur := p.vers
 	c = newCompaction(opts, cur, manual.level, p.baseLevel, bytesCompacted)
 	manual.outputLevel = c.outputLevel
@@ -305,6 +304,6 @@ func (p *compactionPicker) pickManual(
 	if len(c.inputs[0]) == 0 {
 		return nil
 	}
-	c.setupOtherInputs()
+	c.setupInputs()
 	return c
 }

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -59,7 +59,7 @@ type FileMetadata struct {
 	MarkedForCompaction bool
 }
 
-func (m *FileMetadata) String() string {
+func (m FileMetadata) String() string {
 	return fmt.Sprintf("%d:%s-%s", m.FileNum, m.Smallest, m.Largest)
 }
 

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -241,11 +241,10 @@ func TestRangeDelCompactionTruncation(t *testing.T) {
 	expectLSM(`
 1:
   12:[a#2,15-b#72057594037927935,15]
-2:
-  14:[b#3,1-b#3,1]
 3:
-  17:[b#1,1-c#72057594037927935,15]
-  18:[c#4,1-d#72057594037927935,15]
+  17:[b#3,1-b#3,1]
+  18:[b#1,1-c#72057594037927935,15]
+  19:[c#4,1-d#72057594037927935,15]
 `)
 
 	// The L1 table still contains a tombstone from [a,d) which will improperly
@@ -332,15 +331,15 @@ func TestRangeDelCompactionTruncation2(t *testing.T) {
 	}
 	expectLSM(`
 6:
-  8:[a#2,15-b#1,1]
-  12:[b#0,15-c#72057594037927935,15]
-  13:[c#3,1-d#72057594037927935,15]
+  12:[a#2,15-b#1,1]
+  13:[b#0,15-c#72057594037927935,15]
+  14:[c#3,1-d#72057594037927935,15]
 `)
 }
 
+// TODO(peter): rewrite this test, TestRangeDelCompactionTruncation, and
+// TestRangeDelCompactionTruncation2 as data-driven tests.
 func TestRangeDelCompactionTruncation3(t *testing.T) {
-	t.Skip("demonstrates need for expanding clean cuts to the left during compaction")
-
 	// Use a small target file size so that there is a single key per sstable.
 	d, err := Open("tmp", &Options{
 		Cleaner: ArchiveCleaner{},
@@ -423,22 +422,20 @@ func TestRangeDelCompactionTruncation3(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectLSM(`
-3:
-  12:[a#2,15-b#1,1]
 4:
-  19:[b#0,15-c#72057594037927935,15]
-  20:[c#3,1-d#72057594037927935,15]
+  20:[a#2,15-b#1,1]
+  21:[b#0,15-c#72057594037927935,15]
+  22:[c#3,1-d#72057594037927935,15]
 `)
 
 	if err := d.Compact([]byte("c"), []byte("c")); err != nil {
 		t.Fatal(err)
 	}
 	expectLSM(`
-3:
-  12:[a#2,15-b#1,1]
 5:
-  21:[b#0,15-c#72057594037927935,15]
-  22:[c#3,1-d#72057594037927935,15]
+  23:[a#2,15-b#1,1]
+  24:[b#0,15-c#72057594037927935,15]
+  25:[c#3,1-d#72057594037927935,15]
 `)
 
 	if _, err := d.Get([]byte("b")); err != ErrNotFound {
@@ -449,11 +446,11 @@ func TestRangeDelCompactionTruncation3(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectLSM(`
-4:
-  23:[a#2,15-b#1,1]
 5:
-  21:[b#0,15-c#72057594037927935,15]
-  22:[c#3,1-d#72057594037927935,15]
+  25:[c#3,1-d#72057594037927935,15]
+6:
+  26:[a#2,15-b#1,1]
+  27:[b#0,15-c#72057594037927935,15]
 `)
 
 	if v, err := d.Get([]byte("b")); err != ErrNotFound {

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -145,7 +145,7 @@ func TestRangeDelCompactionTruncation(t *testing.T) {
 		expected = strings.TrimSpace(expected)
 		actual := strings.TrimSpace(lsm())
 		if expected != actual {
-			t.Fatalf("expected\n%sbut found\n%s", expected, actual)
+			t.Fatalf("expected\n%s\nbut found\n%s", expected, actual)
 		}
 	}
 
@@ -244,7 +244,7 @@ func TestRangeDelCompactionTruncation(t *testing.T) {
 2:
   14:[b#3,1-b#3,1]
 3:
-  17:[b#2,15-c#72057594037927935,15]
+  17:[b#1,1-c#72057594037927935,15]
   18:[c#4,1-d#72057594037927935,15]
 `)
 

--- a/testdata/compaction_expand_inputs
+++ b/testdata/compaction_expand_inputs
@@ -37,6 +37,7 @@ expand-inputs 0
 
 expand-inputs 1
 ----
+0: a#1,1-b#2,1
 1: b#1,1-d#4,1
 
 expand-inputs 2
@@ -57,6 +58,7 @@ expand-inputs 0
 
 expand-inputs 1
 ----
+0: a#1,1-b#2,1
 1: b#1,1-d#4,1
 2: d#2,1-f#6,1
 

--- a/testdata/compaction_setup_inputs
+++ b/testdata/compaction_setup_inputs
@@ -1,0 +1,87 @@
+setup-inputs a a
+L0
+  a.SET.1-b.SET.2
+----
+L0
+  1:a#1,1-b#2,1
+
+setup-inputs c c
+L0
+  a.SET.1-b.SET.2
+----
+
+# Verify we expand the start level inputs to a clean cut.
+setup-inputs a a
+L1
+  a.SET.1-b.SET.2
+  b.SET.1-c.SET.2
+----
+L1
+  1:a#1,1-b#2,1
+  2:b#1,1-c#2,1
+
+# The range deletion sentinel acts as a clean cut boundary.
+setup-inputs a a
+L1
+  a.SET.1-b.RANGEDEL.72057594037927935
+  b.SET.1-c.SET.2
+----
+L1
+  1:a#1,1-b#72057594037927935,15
+
+# Verify we expand the output level inputs to a clean cut.
+setup-inputs a a
+L1
+  a.SET.5-b.SET.6
+L2
+  a.SET.3-c.SET.4
+  c.SET.3-d.SET.2
+----
+L1
+  1:a#5,1-b#6,1
+L2
+  2:a#3,1-c#4,1
+  3:c#3,1-d#2,1
+
+# Verify we expand the output level inputs to a clean cut.
+setup-inputs a a
+L1
+  a.SET.5-b.SET.6
+L2
+  a.SET.3-c.RANGEDEL.72057594037927935
+  c.SET.3-d.SET.2
+----
+L1
+  1:a#5,1-b#6,1
+L2
+  2:a#3,1-c#72057594037927935,15
+
+# Verify we grow the start level inputs to include all sstables which
+# lie within the output level bounds.
+setup-inputs a a
+L1
+  a.SET.5-b.SET.6
+  c.SET.4-e.SET.3
+L2
+  a.SET.3-d.SET.4
+----
+L1
+  1:a#5,1-b#6,1
+  2:c#4,1-e#3,1
+L2
+  3:a#3,1-d#4,1
+
+# We won't grow the start level inputs if doing so would grow the
+# output level inputs.
+setup-inputs a a
+L1
+  a.SET.5-b.SET.6
+  c.SET.4-e.SET.3
+L2
+  a.SET.3-d.SET.4
+  e.SET.2-f.SET.1
+----
+L1
+  1:a#5,1-b#6,1
+L2
+  3:a#3,1-d#4,1


### PR DESCRIPTION
When determining the boundaries for an sstable, we need to truncate the
boundaries to the boundaries of the input. Failing to do this was
allowing the lower bound of the first sstable in a compaction to expand
beyond the lower bound of the input when the sstable contain a range
tombstone.

Fixes #337