### PR TITLE
vfs: add FS.RemoveAll

### DIFF
--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -234,6 +234,25 @@ func (y *memFS) Remove(fullname string) error {
 			if frag == "" {
 				return errors.New("pebble/vfs: empty file name")
 			}
+			child, ok := dir.children[frag]
+			if !ok {
+				return os.ErrNotExist
+			}
+			if len(child.children) > 0 {
+				return os.ErrExist
+			}
+			delete(dir.children, frag)
+		}
+		return nil
+	})
+}
+
+func (y *memFS) RemoveAll(fullname string) error {
+	return y.walk(fullname, func(dir *memNode, frag string, final bool) error {
+		if final {
+			if frag == "" {
+				return errors.New("pebble/vfs: empty file name")
+			}
 			_, ok := dir.children[frag]
 			if !ok {
 				return os.ErrNotExist

--- a/vfs/testdata/vfs
+++ b/vfs/testdata/vfs
@@ -97,3 +97,19 @@ define
 list e/b
 ----
 c
+
+define
+list /
+remove e
+remove-all e
+list /
+----
+a
+b
+d
+e
+remove: e [file already exists]
+remove-all: e [<nil>]
+a
+b
+d

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -52,6 +52,11 @@ type FS interface {
 	// Remove removes the named file or directory.
 	Remove(name string) error
 
+	// Remove removes the named file or directory and any children it
+	// contains. It removes everything it can but returns the first error it
+	// encounters.
+	RemoveAll(name string) error
+
 	// Rename renames a file. It overwrites the file at newname if one exists,
 	// the same as os.Rename.
 	Rename(oldname, newname string) error
@@ -129,6 +134,10 @@ func (defaultFS) Open(name string, opts ...OpenOption) (File, error) {
 
 func (defaultFS) Remove(name string) error {
 	return os.Remove(name)
+}
+
+func (defaultFS) RemoveAll(name string) error {
+	return os.RemoveAll(name)
 }
 
 func (defaultFS) Rename(oldname, newname string) error {

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -82,6 +82,12 @@ func (fs loggingFS) Remove(name string) error {
 	return err
 }
 
+func (fs loggingFS) RemoveAll(name string) error {
+	err := fs.FS.RemoveAll(name)
+	fmt.Fprintf(fs.w, "remove-all: %s [%v]\n", fs.stripBase(name), normalizeError(err))
+	return err
+}
+
 type loggingFile struct {
 	File
 	name string
@@ -182,6 +188,12 @@ func runTestVFS(t *testing.T, baseFS FS, dir string) {
 						return fmt.Sprintf("remove <name>")
 					}
 					_ = fs.Remove(fs.PathJoin(dir, parts[1]))
+
+				case "remove-all":
+					if len(parts) != 2 {
+						return fmt.Sprintf("remove-all <name>")
+					}
+					_ = fs.RemoveAll(fs.PathJoin(dir, parts[1]))
 				}
 			}
 


### PR DESCRIPTION
Fix a buglet in `memFS.Remove` where it was acting like `RemoveAll` and
removing non-empty directories.

Fixes #353