### PR TITLE
internal/cache: improve allocCache eviction heuristics

### DIFF
--- a/internal/cache/alloc.go
+++ b/internal/cache/alloc.go
@@ -4,7 +4,12 @@
 
 package cache
 
-import "sync"
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/exp/rand"
+)
 
 const (
 	// The min size of a byte slice held in an allocCache instance. Byte slices
@@ -21,7 +26,7 @@ const (
 
 var allocPool = sync.Pool{
 	New: func() interface{} {
-		return &allocCache{}
+		return newAllocCache()
 	},
 }
 
@@ -51,6 +56,7 @@ func allocFree(b []byte) {
 // size class as the allocation. Size classes are multiples of 1024.
 type allocCache struct {
 	size int
+	rnd  rand.PCGSource
 	bufs [][]byte
 }
 
@@ -62,6 +68,14 @@ func classToSize(class int) int {
 	return (class + 1) * 1024
 }
 
+func newAllocCache() *allocCache {
+	c := &allocCache{
+		bufs: make([][]byte, 0, allocCacheCountLimit),
+	}
+	c.rnd.Seed(uint64(time.Now().UnixNano()))
+	return c
+}
+
 func (c *allocCache) alloc(n int) []byte {
 	if n < allocCacheMinSize || n >= allocCacheMaxSize {
 		return make([]byte, n)
@@ -69,12 +83,11 @@ func (c *allocCache) alloc(n int) []byte {
 
 	class := sizeToClass(n)
 	for i := range c.bufs {
-		if t := c.bufs[i]; sizeToClass(len(t)) == class {
+		if t := c.bufs[i]; sizeToClass(cap(t)) == class {
 			j := len(c.bufs) - 1
-			c.bufs[i], c.bufs[j] = c.bufs[j], c.bufs[i]
-			c.bufs[j] = nil
+			c.bufs[i], c.bufs[j] = c.bufs[j], nil
 			c.bufs = c.bufs[:j]
-			c.size -= len(t)
+			c.size -= cap(t)
 			return t[:n]
 		}
 	}
@@ -89,13 +102,25 @@ func (c *allocCache) free(b []byte) {
 	}
 	b = b[:n:n]
 
+	// Rather than always evicting a specific slot, we randomly choose a slot to
+	// evict. This ensures we will eventually evict buffers which are not being
+	// used. Always evicting the first element and preserving exactly the N most
+	// recently freed buffers would be expensive as we'd have to shift the
+	// elements in the slice on every free.
 	for c.size+n >= allocCacheSizeLimit || len(c.bufs) >= allocCacheCountLimit {
+		// Randomly choose a victim buffer to evict. We swap the victim to the last
+		// element in the slice and then trim the length of the slice.
 		i := len(c.bufs) - 1
-		t := c.bufs[i]
-		c.size -= len(t)
-		c.bufs[i] = nil
+		// This is the integer multiplication version of bounding a random integer
+		// to a range: (range * rand[0-65535]) / 65536. See
+		// http://www.pcg-random.org/posts/bounded-rands.html. The random integers
+		// are biased, but that is fine for the usage here.
+		j := (uint32(len(c.bufs)) * (uint32(c.rnd.Uint64()) & ((1 << 16) - 1))) >> 16
+		c.size -= cap(c.bufs[j])
+		c.bufs[i], c.bufs[j] = nil, c.bufs[i]
 		c.bufs = c.bufs[:i]
 	}
+
 	c.bufs = append(c.bufs, b)
 	c.size += n
 }


### PR DESCRIPTION
Rather than always evicting the last slot in `allocCache.free`, we now
evict a random slot. Additionally, the newly freed buffer is inserted
into a random slot. This prevents pathological behavior where the cache
is filled with buffers of a size class that is no longer useful for
allocation.

```
name           old time/op    new time/op    delta
AllocCache-16     271ns ± 2%      40ns ± 1%   -85.15%  (p=0.000 n=9+10)

name           old alloc/op   new alloc/op   delta
AllocCache-16    2.05kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)

name           old allocs/op  new allocs/op  delta
AllocCache-16      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
```

Fixes #358