### PR TITLE
internal/rate: skip a few tests that are flaky on Windows CI

### DIFF
--- a/internal/rate/rate_test.go
+++ b/internal/rate/rate_test.go
@@ -171,7 +171,6 @@ func TestLongRunningQPS(t *testing.T) {
 	switch runtime.GOOS {
 	case "openbsd", "windows":
 		t.Skip("low resolution time.Sleep invalidates test (golang.org/issue/14183)")
-		return
 	}
 
 	// The test runs for a few seconds executing many requests and then checks
@@ -395,6 +394,10 @@ func runWait(t *testing.T, lim *Limiter, w wait) {
 }
 
 func TestWaitSimple(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("flaky on Windows")
+	}
+
 	lim := NewLimiter(10, 3)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -408,6 +411,10 @@ func TestWaitSimple(t *testing.T) {
 }
 
 func TestWaitCancel(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("flaky on Windows")
+	}
+
 	lim := NewLimiter(10, 3)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -423,6 +430,10 @@ func TestWaitCancel(t *testing.T) {
 }
 
 func TestWaitTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("flaky on Windows")
+	}
+
 	lim := NewLimiter(10, 3)
 
 	ctx, cancel := context.WithTimeout(context.Background(), d)


### PR DESCRIPTION
The flakiness seems related to the lower time resolution on Windows, but
could also be related to the VMs. Regardless, getting notified about
these failures isn't helpful.