### PR TITLE
allow accumulation of merge operands before merge

### DIFF
--- a/internal/base/merger.go
+++ b/internal/base/merger.go
@@ -4,21 +4,41 @@
 
 package base
 
-// Merge merges oldValue and newValue, and returns the merged value. The buf
-// parameter can be used to store the newly merged value in order to avoid
-// memory allocations. The merge operation must be associative. That is, for
-// the values A, B, C:
+// Merge creates a ValueMerger for the specified key initialized with the value
+// of one merge operand.
+type Merge func(key, value []byte) (ValueMerger, error)
+
+// ValueMerger receives merge operands one by one. The operand received is either
+// newer or older than all operands received so far as indicated by the function
+// names, `MergeNewer()` and `MergeOlder()`. Once all operands have been received,
+// the client will invoke `Finish()` to obtain the final result.
 //
-//   Merge(A, Merge(B, C)) == Merge(Merge(A, B), C)
+// The implementation may choose to merge values into the result immediately upon
+// receiving each operand, or buffer operands until Finish() is called. For example,
+// buffering may be useful to avoid (de)serializing partial merge results.
+//
+// The merge operation must be associative. That is, for the values A, B, C:
+//
+//   Merge(A).MergeOlder(B).MergeOlder(C) == Merge(C).MergeNewer(B).MergeNewer(A)
 //
 // Examples of merge operators are integer addition, list append, and string
 // concatenation.
-//
-// Note that during forward scans merges are processed from newest to oldest
-// value, and in reverse scans merges are processed from oldest to newest
-// value. DO NOT rely on this ordering: compactions will create partial merge
-// results that may not show up in simple tests.
-type Merge func(key, oldValue, newValue, buf []byte) []byte
+type ValueMerger interface {
+	// MergeNewer adds an operand that is newer than all existing operands.
+	// The caller retains ownership of value.
+	MergeNewer(value []byte) error
+
+	// MergeOlder adds an operand that is older than all existing operands.
+	// The caller retains ownership of value.
+	MergeOlder(value []byte) error
+
+	// Finish does any final processing of the added operands and returns a
+	// result. The caller can assume the returned byte slice will not be mutated.
+	//
+	// Finish must be the last function called on the ValueMerger. The caller
+	// must not call any other ValueMerger functions after calling Finish.
+	Finish() ([]byte, error)
+}
 
 // Merger defines an associative merge operation. The merge operation merges
 // two or more values for a single key. A merge operation is requested by
@@ -39,11 +59,38 @@ type Merger struct {
 	Name string
 }
 
+// AppendValueMerger concatenates merge operands in order from oldest to newest.
+type AppendValueMerger struct {
+	buf []byte
+}
+
+// MergeNewer appends value to the result.
+func (a *AppendValueMerger) MergeNewer(value []byte) error {
+	a.buf = append(a.buf, value...)
+	return nil
+}
+
+// MergeOlder prepends value to the result, which involves allocating a new buffer.
+func (a *AppendValueMerger) MergeOlder(value []byte) error {
+	buf := make([]byte, len(a.buf)+len(value))
+	copy(buf, value)
+	copy(buf[len(value):], a.buf)
+	a.buf = buf
+	return nil
+}
+
+// Finish returns the buffer that was constructed on-demand in `Merge{OlderNewer}()` calls.
+func (a *AppendValueMerger) Finish() ([]byte, error) {
+	return a.buf, nil
+}
+
 // DefaultMerger is the default implementation of the Merger interface. It
 // concatenates the two values to merge.
 var DefaultMerger = &Merger{
-	Merge: func(key, oldValue, newValue, buf []byte) []byte {
-		return append(append(buf, oldValue...), newValue...)
+	Merge: func(key, value []byte) (ValueMerger, error) {
+		res := &AppendValueMerger{}
+		res.buf = append(res.buf, value...)
+		return res, nil
 	},
 
 	Name: "pebble.concatenate",

--- a/merger.go
+++ b/merger.go
@@ -12,5 +12,8 @@ type Merge = base.Merge
 // Merger exports the base.Merger type.
 type Merger = base.Merger
 
+// ValueMerger exports the base.ValueMerger type.
+type ValueMerger = base.ValueMerger
+
 // DefaultMerger exports the base.DefaultMerger variable.
 var DefaultMerger = base.DefaultMerger


### PR DESCRIPTION
Changed the merge operator API to support adding operands one by one via
`Merge{Newer,Older}()` followed by a call to `Finish()`. This gives
implementations the option to accumulate merge operands, only doing the
final merge work when `Finish()` is called. For example, it can be used
to reduce (de)serialization of partial merge results compared to the
previous binary operation API.