### PR TITLE
fix resetting of Batch.count for large batches

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -240,18 +240,19 @@ func (p *commitPipeline) Commit(b *Batch, syncWAL bool) error {
 	// Prepare the batch for committing: enqueuing the batch in the pending
 	// queue, determining the batch sequence number and writing the data to the
 	// WAL.
+	//
+	// NB: We set Batch.commitErr on error so that the batch won't be a candidate
+	// for reuse. See Batch.release().
 	mem, err := p.prepare(b, syncWAL)
 	if err != nil {
-		// TODO(peter): what to do on error? the pipeline will be horked at this
-		// point.
-		panic(err)
+		b.db = nil // prevent batch reuse on error
+		return err
 	}
 
 	// Apply the batch to the memtable.
 	if err := p.env.apply(b, mem); err != nil {
-		// TODO(peter): what to do on error? the pipeline will be horked at this
-		// point.
-		panic(err)
+		b.db = nil // prevent batch reuse on error
+		return err
 	}
 
 	// Publish the batch sequence number.
@@ -260,11 +261,9 @@ func (p *commitPipeline) Commit(b *Batch, syncWAL bool) error {
 	<-p.sem
 
 	if b.commitErr != nil {
-		// TODO(peter): what to do on a log sync error? the pipeline will be horked
-		// at this point.
-		panic(b.commitErr)
+		b.db = nil // prevent batch reuse on error
 	}
-	return nil
+	return b.commitErr
 }
 
 // AllocateSeqNum allocates count sequence numbers, invokes the prepare

--- a/commit.go
+++ b/commit.go
@@ -227,9 +227,6 @@ func newCommitPipeline(env commitEnv) *commitPipeline {
 	return p
 }
 
-func (p *commitPipeline) Close() {
-}
-
 // Commit the specified batch, writing it to the WAL, optionally syncing the
 // WAL, and applying the batch to the memtable. Upon successful return the
 // batch's mutations will be visible for reading.

--- a/db.go
+++ b/db.go
@@ -338,9 +338,13 @@ func (d *DB) getInternal(key []byte, b *Batch, s *Snapshot) ([]byte, error) {
 // It is safe to modify the contents of the arguments after Set returns.
 func (d *DB) Set(key, value []byte, opts *WriteOptions) error {
 	b := newBatch(d)
-	defer b.release()
 	_ = b.Set(key, value, opts)
-	return d.Apply(b, opts)
+	if err := d.Apply(b, opts); err != nil {
+		return err
+	}
+	// Only release the batch on success.
+	b.release()
+	return nil
 }
 
 // Delete deletes the value for the given key. Deletes are blind all will
@@ -349,9 +353,13 @@ func (d *DB) Set(key, value []byte, opts *WriteOptions) error {
 // It is safe to modify the contents of the arguments after Delete returns.
 func (d *DB) Delete(key []byte, opts *WriteOptions) error {
 	b := newBatch(d)
-	defer b.release()
 	_ = b.Delete(key, opts)
-	return d.Apply(b, opts)
+	if err := d.Apply(b, opts); err != nil {
+		return err
+	}
+	// Only release the batch on success.
+	b.release()
+	return nil
 }
 
 // SingleDelete adds an action to the batch that single deletes the entry for key.
@@ -360,9 +368,13 @@ func (d *DB) Delete(key []byte, opts *WriteOptions) error {
 // It is safe to modify the contents of the arguments after SingleDelete returns.
 func (d *DB) SingleDelete(key []byte, opts *WriteOptions) error {
 	b := newBatch(d)
-	defer b.release()
 	_ = b.SingleDelete(key, opts)
-	return d.Apply(b, opts)
+	if err := d.Apply(b, opts); err != nil {
+		return err
+	}
+	// Only release the batch on success.
+	b.release()
+	return nil
 }
 
 // DeleteRange deletes all of the keys (and values) in the range [start,end)
@@ -372,9 +384,13 @@ func (d *DB) SingleDelete(key []byte, opts *WriteOptions) error {
 // returns.
 func (d *DB) DeleteRange(start, end []byte, opts *WriteOptions) error {
 	b := newBatch(d)
-	defer b.release()
 	_ = b.DeleteRange(start, end, opts)
-	return d.Apply(b, opts)
+	if err := d.Apply(b, opts); err != nil {
+		return err
+	}
+	// Only release the batch on success.
+	b.release()
+	return nil
 }
 
 // Merge adds an action to the DB that merges the value at key with the new
@@ -384,9 +400,13 @@ func (d *DB) DeleteRange(start, end []byte, opts *WriteOptions) error {
 // It is safe to modify the contents of the arguments after Merge returns.
 func (d *DB) Merge(key, value []byte, opts *WriteOptions) error {
 	b := newBatch(d)
-	defer b.release()
 	_ = b.Merge(key, value, opts)
-	return d.Apply(b, opts)
+	if err := d.Apply(b, opts); err != nil {
+		return err
+	}
+	// Only release the batch on success.
+	b.release()
+	return nil
 }
 
 // LogData adds the specified to the batch. The data will be written to the
@@ -396,9 +416,13 @@ func (d *DB) Merge(key, value []byte, opts *WriteOptions) error {
 // It is safe to modify the contents of the argument after LogData returns.
 func (d *DB) LogData(data []byte, opts *WriteOptions) error {
 	b := newBatch(d)
-	defer b.release()
 	_ = b.LogData(data, opts)
-	return d.Apply(b, opts)
+	if err := d.Apply(b, opts); err != nil {
+		return err
+	}
+	// Only release the batch on success.
+	b.release()
+	return nil
 }
 
 // Apply the operations contained in the batch to the DB. If the batch is large
@@ -429,20 +453,22 @@ func (d *DB) Apply(batch *Batch, opts *WriteOptions) error {
 	if int(batch.memTableSize) >= d.largeBatchThreshold {
 		batch.flushable = newFlushableBatch(batch, d.opts.Comparer)
 	}
-	err := d.commit.Commit(batch, sync)
-	if err == nil {
-		// If this is a large batch, we need to clear the batch contents as the
-		// flushable batch may still be present in the flushables queue.
-		//
-		// TODO(peter): Currently large batches are written to the WAL. We could
-		// skip the WAL write and instead wait for the large batch to be flushed to
-		// an sstable. For a 100 MB batch, this might actually be faster. For a 1
-		// GB batch this is almost certainly faster.
-		if batch.flushable != nil {
-			batch.storage.data = nil
-		}
+	if err := d.commit.Commit(batch, sync); err != nil {
+		// There isn't much we can do on an error here. The commit pipeline will be
+		// horked at this point.
+		d.opts.Logger.Fatalf("%v", err)
 	}
-	return err
+	// If this is a large batch, we need to clear the batch contents as the
+	// flushable batch may still be present in the flushables queue.
+	//
+	// TODO(peter): Currently large batches are written to the WAL. We could
+	// skip the WAL write and instead wait for the large batch to be flushed to
+	// an sstable. For a 100 MB batch, this might actually be faster. For a 1
+	// GB batch this is almost certainly faster.
+	if batch.flushable != nil {
+		batch.storage.data = nil
+	}
+	return nil
 }
 
 func (d *DB) commitApply(b *Batch, mem *memTable) error {

--- a/db.go
+++ b/db.go
@@ -723,7 +723,6 @@ func (d *DB) Close() error {
 		panic("pebble: log-writer should be nil in read-only mode")
 	}
 	err = firstError(err, d.fileLock.Close())
-	d.commit.Close()
 
 	err = firstError(err, d.dataDir.Close())
 	if d.dataDir != d.walDir {

--- a/db_test.go
+++ b/db_test.go
@@ -426,6 +426,13 @@ func TestLargeBatch(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Allocate a bunch of batches to exhaust the batchPool. None of these
+	// batches should have a non-zero count.
+	for i := 0; i < 10; i++ {
+		b := d.NewBatch()
+		require.EqualValues(t, 0, b.Count())
+	}
+
 	if err := d.Close(); err != nil {
 		t.Fatal(err)
 	}

--- a/mem_table.go
+++ b/mem_table.go
@@ -225,7 +225,7 @@ func (m *memTable) apply(batch *Batch, seqNum uint64) error {
 		}
 	}
 	if seqNum != startSeqNum+uint64(batch.Count()) {
-		panic(fmt.Sprintf("pebble: inconsistent batch count: %d vs %d",
+		panic(fmt.Errorf("pebble: inconsistent batch count: %d vs %d",
 			seqNum, startSeqNum+uint64(batch.Count())))
 	}
 	if tombstoneCount != 0 {


### PR DESCRIPTION
We were failing to clear `Batch.count` for large batches which was leading
to some super strange `make stress` errors. This turned out to be extremely
onerous to debug which resulted in most of the code changes here (the fix
is the small change to `Batch.Reset`).

The `make stress` failure was a panic comming out of `syncQueue.pop()`
because the `WaitGroup` had a negative counter. How did an incorrect
`Batch.count` result in a negative `WaitGroup` counter? The incorrect
`Batch.count` was causing `memTable.apply` to panic. The panic there was
propagating up through `DB.LogData` which had a `defer Batch.release()`.
Defers get run on the panic return, so we were calling
`Batch.release()` on a batch still sitting on the
`syncQueue`. Internally, `Batch.release()` resets `Batch.commit` (the
`WaitGroup` passed to `LogWriter.SyncRecord`). When the `LogWriter`
eventually performed the sync, it called `WaitGroup.Done()` on what was
essentially a zero-initialized object. Boom!

To mitigate such debugging odysseys in the future, most (but not all)
panics in and near `commitPipeline.Commit` have been replaced with error
returns. `DB.Apply`, the singular caller of `commitPipeline.Commit`, now
calls `Logger.Fatalf` on error. This is preferrable to the panic because we
will get a clean termination and not an obscure one.

Lastly, the `defer Batch.release()` pattern has been removed and now we
only release batches when they successfully apply. Unsuccessful application
will result in the batch being left for GC.

Fixes #346