### PR TITLE
add Options.ErrorIfNotExists

### DIFF
--- a/open.go
+++ b/open.go
@@ -121,14 +121,15 @@ func Open(dirname string, opts *Options) (*DB, error) {
 	d.mu.nextJobID++
 
 	currentName := base.MakeFilename(opts.FS, dirname, fileTypeCurrent, 0)
-	if _, err := opts.FS.Stat(currentName); os.IsNotExist(err) && !d.opts.ReadOnly {
+	if _, err := opts.FS.Stat(currentName); os.IsNotExist(err) &&
+		!d.opts.ReadOnly && !d.opts.ErrorIfNotExists {
 		// Create the DB if it did not already exist.
 		if err := d.mu.versions.create(jobID, dirname, d.dataDir, opts, &d.mu.Mutex); err != nil {
 			return nil, err
 		}
 	} else if err != nil {
 		return nil, fmt.Errorf("pebble: database %q: %v", dirname, err)
-	} else if opts.ErrorIfDBExists {
+	} else if opts.ErrorIfExists {
 		return nil, fmt.Errorf("pebble: database %q already exists", dirname)
 	} else {
 		// Load the version set.

--- a/options.go
+++ b/options.go
@@ -244,10 +244,17 @@ type Options struct {
 	// TODO(peter): untested
 	DisableWAL bool
 
-	// ErrorIfDBExists is whether it is an error if the database already exists.
+	// ErrorIfExists is whether it is an error if the database already exists.
 	//
 	// The default value is false.
-	ErrorIfDBExists bool
+	ErrorIfExists bool
+
+	// ErrorIfNotExists is whether it is an error if the database does not
+	// already exist.
+	//
+	// The default value is false which will cause a database to be created if it
+	// does not already exist.
+	ErrorIfNotExists bool
 
 	// EventListener provides hooks to listening to significant DB events such as
 	// flushes, compactions, and table deletion.


### PR DESCRIPTION
Needed to implement `MustExist` when opening a CRDB storage engine.

Rename `Options.ErrorIfDBExists` to `Options.ErrorIfExists` for
consistency.