### PR TITLE
tool: `sstable {scan,layout}` improvements

### DIFF
--- a/internal/private/sstable.go
+++ b/internal/private/sstable.go
@@ -8,6 +8,12 @@ package private
 // sstable.NewReader.
 var SSTableCacheOpts func(cacheID, fileNum uint64) interface{}
 
+// SSTableRawTombstonesOpt is a sstable.Reader option for disabling
+// fragmentation of the range tombstones returned by
+// sstable.Reader.NewRangeDelIter(). Used by debug tools to get a raw view of
+// the tombstones contained in an sstable.
+var SSTableRawTombstonesOpt interface{}
+
 // SSTableWriterDisableKeyOrderChecks is a hook for disabling the key ordering
 // invariant check performed by sstable.Writer. It is intended for internal use
 // only in the construction of invalid sstables for testing. See

--- a/tool/testdata/sstable_layout
+++ b/tool/testdata/sstable_layout
@@ -3696,39 +3696,39 @@ h.no-compression.two_level_index.sst
      27209    [restart 27185]
      27222  range-del (421)
      27222    record (13 = 3 [0] + 9 + 1) [restart]
-              a-a#0,15
+              a-a#0,RANGEDEL
      27235    record (23 = 3 [0] + 13 + 7) [restart]
-              beard-bearers#0,15
+              beard-bearers#0,RANGEDEL
      27258    record (24 = 3 [0] + 16 + 5) [restart]
-              carriage-carve#0,15
+              carriage-carve#0,RANGEDEL
      27282    record (21 = 3 [0] + 13 + 5) [restart]
-              cross-crows#0,15
+              cross-crows#0,RANGEDEL
      27303    record (23 = 3 [0] + 14 + 6) [restart]
-              duller-duties#0,15
+              duller-duties#0,RANGEDEL
      27326    record (21 = 3 [0] + 14 + 4) [restart]
-              fierce-fire#0,15
+              fierce-fire#0,RANGEDEL
      27347    record (21 = 3 [0] + 13 + 5) [restart]
-              grace-great#0,15
+              grace-great#0,RANGEDEL
      27368    record (17 = 3 [0] + 11 + 3) [restart]
-              how-ice#0,15
+              how-ice#0,RANGEDEL
      27385    record (20 = 3 [0] + 12 + 5) [restart]
-              lead-lends#0,15
+              lead-lends#0,RANGEDEL
      27405    record (18 = 3 [0] + 12 + 3) [restart]
-              meet-met#0,15
+              meet-met#0,RANGEDEL
      27423    record (17 = 3 [0] + 10 + 4) [restart]
-              of-once#0,15
+              of-once#0,RANGEDEL
      27440    record (25 = 3 [0] + 16 + 6) [restart]
-              precurse-prison#0,15
+              precurse-prison#0,RANGEDEL
      27465    record (15 = 3 [0] + 9 + 3) [restart]
-              s-saw#0,15
+              s-saw#0,RANGEDEL
      27480    record (19 = 3 [0] + 12 + 4) [restart]
-              slay-soil#0,15
+              slay-soil#0,RANGEDEL
      27499    record (24 = 3 [0] + 16 + 5) [restart]
-              suppress-sword#0,15
+              suppress-sword#0,RANGEDEL
      27523    record (23 = 3 [0] + 16 + 4) [restart]
-              traduced-true#0,15
+              traduced-true#0,RANGEDEL
      27546    record (25 = 3 [0] + 15 + 7) [restart]
-              warning-wedding#0,15
+              warning-wedding#0,RANGEDEL
      27571    [restart 27222]
      27575    [restart 27235]
      27579    [restart 27258]

--- a/tool/testdata/sstable_scan
+++ b/tool/testdata/sstable_scan
@@ -20,6 +20,7 @@ sstable scan
 ../sstable/testdata/h.sst
 ----
 h.sst
+a-a#0,15
 a#0,1 [3937]
 aboard#0,1 [32]
 about#0,1 [32]
@@ -122,6 +123,134 @@ h.sst
 test formatter: you#0,1 [313130]
 test formatter: young#0,1 [36]
 test formatter: your#0,1 [3439]
+
+# Start and end scan keys lie within range tombstones.
+sstable scan
+--start=beards
+--end=carrying
+../sstable/testdata/h.sst
+----
+h.sst
+beard-bearers#0,15
+bearers#0,1 [31]
+bears#0,1 [31]
+beast#0,1 [32]
+beating#0,1 [31]
+beauty#0,1 [31]
+beaver#0,1 [31]
+beckons#0,1 [32]
+bed#0,1 [34]
+been#0,1 [34]
+beetles#0,1 [31]
+befitted#0,1 [31]
+before#0,1 [36]
+beg#0,1 [31]
+beguile#0,1 [31]
+behold#0,1 [31]
+behoves#0,1 [31]
+being#0,1 [34]
+belief#0,1 [31]
+believe#0,1 [36]
+bell#0,1 [31]
+bend#0,1 [32]
+beneath#0,1 [35]
+benefit#0,1 [31]
+bernardo#0,1 [3330]
+beseech#0,1 [32]
+besmirch#0,1 [31]
+best#0,1 [35]
+beteem#0,1 [31]
+bethought#0,1 [31]
+better#0,1 [32]
+between#0,1 [32]
+beware#0,1 [32]
+beyond#0,1 [31]
+bid#0,1 [32]
+bird#0,1 [32]
+birth#0,1 [33]
+bites#0,1 [31]
+bitter#0,1 [31]
+black#0,1 [31]
+blast#0,1 [31]
+blastments#0,1 [31]
+blasts#0,1 [31]
+blazes#0,1 [31]
+blazon#0,1 [31]
+blessing#0,1 [33]
+blood#0,1 [37]
+blossoms#0,1 [31]
+blows#0,1 [31]
+bodes#0,1 [31]
+body#0,1 [35]
+bonds#0,1 [31]
+bones#0,1 [31]
+book#0,1 [31]
+books#0,1 [31]
+born#0,1 [32]
+borrower#0,1 [31]
+borrowing#0,1 [31]
+bosom#0,1 [31]
+both#0,1 [33]
+bound#0,1 [32]
+bounteous#0,1 [31]
+bow#0,1 [31]
+boy#0,1 [32]
+brain#0,1 [32]
+bray#0,1 [31]
+brazen#0,1 [31]
+breach#0,1 [31]
+break#0,1 [33]
+breaking#0,1 [31]
+breath#0,1 [31]
+breathing#0,1 [31]
+brief#0,1 [31]
+bring#0,1 [31]
+brokers#0,1 [31]
+brother#0,1 [36]
+brow#0,1 [31]
+bruit#0,1 [31]
+bulk#0,1 [31]
+buried#0,1 [31]
+burns#0,1 [32]
+burnt#0,1 [31]
+burst#0,1 [32]
+business#0,1 [34]
+but#0,1 [3538]
+buttons#0,1 [31]
+buy#0,1 [31]
+by#0,1 [3331]
+call#0,1 [34]
+calumnious#0,1 [31]
+came#0,1 [32]
+can#0,1 [35]
+canker#0,1 [31]
+cannon#0,1 [32]
+cannot#0,1 [33]
+canon#0,1 [31]
+canonized#0,1 [31]
+canst#0,1 [32]
+cap#0,1 [31]
+carefully#0,1 [31]
+carriage-carve#0,15
+carriage#0,1 [31]
+
+# Start scan key lies on range tombstone end key.
+sstable scan
+--start=bearers
+--end=bears
+../sstable/testdata/h.sst
+----
+h.sst
+bearers#0,1 [31]
+
+# End scan key lies on range tombstone start key.
+sstable scan
+--start=bear
+--end=beard
+../sstable/testdata/h.sst
+----
+h.sst
+bear#0,1 [35]
 
 sstable scan
 testdata/out-of-order.sst

--- a/tool/testdata/sstable_scan
+++ b/tool/testdata/sstable_scan
@@ -20,7 +20,7 @@ sstable scan
 ../sstable/testdata/h.sst
 ----
 h.sst
-a-a#0,15
+a-a#0,RANGEDEL
 a#0,1 [3937]
 aboard#0,1 [32]
 about#0,1 [32]
@@ -131,7 +131,7 @@ sstable scan
 ../sstable/testdata/h.sst
 ----
 h.sst
-beard-bearers#0,15
+beard-bearers#0,RANGEDEL
 bearers#0,1 [31]
 bears#0,1 [31]
 beast#0,1 [32]
@@ -231,7 +231,7 @@ canonized#0,1 [31]
 canst#0,1 [32]
 cap#0,1 [31]
 carefully#0,1 [31]
-carriage-carve#0,15
+carriage-carve#0,RANGEDEL
 carriage#0,1 [31]
 
 # Start scan key lies on range tombstone end key.

--- a/tool/util.go
+++ b/tool/util.go
@@ -51,10 +51,10 @@ func (k *key) Set(v string) error {
 }
 
 type formatter struct {
-	spec        string
-	fn          base.Formatter
-	setByUser   bool
-	comparer    string
+	spec      string
+	fn        base.Formatter
+	setByUser bool
+	comparer  string
 }
 
 func (f *formatter) String() string {
@@ -178,7 +178,7 @@ func formatKeyValue(
 ) {
 	if key.Kind() == base.InternalKeyKindRangeDelete {
 		if fmtKey.spec != "null" {
-			fmt.Fprintf(w, "%s-%s#%d,%d",
+			fmt.Fprintf(w, "%s-%s#%d,%s",
 				fmtKey.fn(key.UserKey), fmtKey.fn(value),
 				key.SeqNum(), key.Kind())
 		}


### PR DESCRIPTION
* tool: display symbolic key kind, instead of numeric
* tool: make `sstable scan` display range tombstones