### PR TITLE
Add vfs.FS.ReuseWAL method for reusing WAL files.

### DIFF
--- a/db.go
+++ b/db.go
@@ -1072,10 +1072,8 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 			recycleLogNum := d.logRecycler.peek()
 			if recycleLogNum > 0 {
 				recycleLogName := base.MakeFilename(d.opts.FS, d.walDirname, fileTypeLog, recycleLogNum)
-				err = d.opts.FS.Rename(recycleLogName, newLogName)
-			}
-
-			if err == nil {
+				newLogFile, err = d.opts.FS.ReuseForWrite(recycleLogName, newLogName)
+			} else {
 				newLogFile, err = d.opts.FS.Create(newLogName)
 			}
 
@@ -1099,7 +1097,7 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 			}
 
 			if recycleLogNum > 0 {
-				err = d.logRecycler.pop(recycleLogNum)
+				err = firstError(err, d.logRecycler.pop(recycleLogNum))
 			}
 
 			d.opts.EventListener.WALCreated(WALCreateInfo{

--- a/error_test.go
+++ b/error_test.go
@@ -104,6 +104,13 @@ func (fs *errorFS) Rename(oldname, newname string) error {
 	return fs.FS.Rename(oldname, newname)
 }
 
+func (fs *errorFS) ReuseForWrite(oldname, newname string) (vfs.File, error) {
+	if err := fs.maybeError(); err != nil {
+		return nil, err
+	}
+	return fs.FS.ReuseForWrite(oldname, newname)
+}
+
 func (fs *errorFS) MkdirAll(dir string, perm os.FileMode) error {
 	if err := fs.maybeError(); err != nil {
 		return err

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -92,6 +92,15 @@ func (fs loggingFS) Rename(oldname, newname string) error {
 	return fs.FS.Rename(oldname, newname)
 }
 
+func (fs loggingFS) ReuseForWrite(oldname, newname string) (vfs.File, error) {
+	fmt.Fprintf(fs.w, "reuseForWrite: %s -> %s\n", oldname, newname)
+	f, err := fs.FS.ReuseForWrite(oldname, newname)
+	if err == nil {
+		f = loggingFile{f, newname, fs.w}
+	}
+	return f, err
+}
+
 func (fs loggingFS) MkdirAll(dir string, perm os.FileMode) error {
 	fmt.Fprintf(fs.w, "mkdir-all: %s %#o\n", dir, perm)
 	return fs.FS.MkdirAll(dir, perm)

--- a/internal/record/record.go
+++ b/internal/record/record.go
@@ -259,7 +259,10 @@ func (r *Reader) nextChunk(wantFirst bool) error {
 		}
 		if r.n < blockSize && r.started {
 			if r.end != r.n {
-				return io.ErrUnexpectedEOF
+				// This can happen if the previous instance of the log ended with a partial block
+				// at the same blockNum as the new log but extended beyond the partial block of the
+				// new log.
+				return ErrInvalidChunk
 			}
 			return io.EOF
 		}

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -45,8 +45,7 @@ sync: db/000004.log
 
 flush db
 ----
-rename: db/000002.log -> db/000006.log
-create: db/000006.log
+reuseForWrite: db/000002.log -> db/000006.log
 sync: db
 sync: db/000004.log
 close: db/000004.log
@@ -88,8 +87,7 @@ checkpoint checkpoint1: file already exists
 
 compact db
 ----
-rename: db/000004.log -> db/000008.log
-create: db/000008.log
+reuseForWrite: db/000004.log -> db/000008.log
 sync: db
 sync: db/000006.log
 close: db/000006.log

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -43,8 +43,7 @@ sync: db/000004.log
 
 compact db
 ----
-rename: db/000002.log -> db/000006.log
-create: db/000006.log
+reuseForWrite: db/000002.log -> db/000006.log
 sync: db
 sync: db/000004.log
 close: db/000004.log

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -57,8 +57,7 @@ sync: db
 compact
 ----
 sync: wal/000005.log
-rename: wal/000002.log -> wal/000008.log
-create: wal/000008.log
+reuseForWrite: wal/000002.log -> wal/000008.log
 sync: wal
 sync: wal/000005.log
 close: wal/000005.log
@@ -104,8 +103,7 @@ disable-file-deletions
 flush
 ----
 sync: wal/000008.log
-rename: wal/000005.log -> wal/000013.log
-create: wal/000013.log
+reuseForWrite: wal/000005.log -> wal/000013.log
 sync: wal
 sync: wal/000008.log
 close: wal/000008.log

--- a/vfs/mem_fs_test.go
+++ b/vfs/mem_fs_test.go
@@ -64,6 +64,10 @@ func TestBasics(t *testing.T) {
 		"9d: rename /bar/baz /bar/caz",
 		"9e: open /bar/baz/z fails",
 		"9f: open /bar/caz/z",
+		// ReuseForWrite
+		"10a: reuseForWrite /bar/caz/z /bar/z",
+		"10b: open /bar/caz/z fails",
+		"10c: open /bar/z",
 	}
 	var f File
 	for _, tc := range testCases {
@@ -97,6 +101,8 @@ func TestBasics(t *testing.T) {
 			err = fs.Remove(s[1])
 		case "rename":
 			err = fs.Rename(s[1], s[2])
+		case "reuseForWrite":
+			_, err = fs.ReuseForWrite(s[1], s[2])
 		case "f.write":
 			_, err = f.Write([]byte(s[1]))
 		case "f.read":

--- a/vfs/testdata/vfs
+++ b/vfs/testdata/vfs
@@ -113,3 +113,10 @@ remove-all: e [<nil>]
 a
 b
 d
+
+define
+reuseForWrite a b
+reuseForWrite x y
+----
+reuseForWrite: a -> b [<nil>]
+reuseForWrite: x -> y [file does not exist]


### PR DESCRIPTION
The existing rename+create flow prevents the FS from distinguishing
this case from normal renames, which is a problem for an encrypted
FS where we are currently unable to reuse WAL files.