### PR TITLE
sstable: retain blockIter buffers across sync.Pool reuse

### DIFF
--- a/sstable/block.go
+++ b/sstable/block.go
@@ -116,7 +116,6 @@ type blockIter struct {
 	data         []byte
 	key, val     []byte
 	fullKey      []byte
-	keyBuf       [256]byte
 	ikey         InternalKey
 	cached       []blockEntry
 	cachedBuf    []byte
@@ -140,14 +139,18 @@ func (i *blockIter) init(cmp Compare, block block, globalSeqNum uint64) error {
 	i.globalSeqNum = globalSeqNum
 	i.ptr = unsafe.Pointer(&block[0])
 	i.data = block
-	if i.fullKey == nil {
-		i.fullKey = i.keyBuf[:0]
-	} else {
-		i.fullKey = i.fullKey[:0]
-	}
+	i.fullKey = i.fullKey[:0]
 	i.val = nil
 	i.clearCache()
 	return nil
+}
+
+func (i *blockIter) resetForReuse() blockIter {
+	return blockIter{
+		fullKey:   i.fullKey[:0],
+		cached:    i.cached[:0],
+		cachedBuf: i.cachedBuf[:0],
+	}
 }
 
 func (i *blockIter) setCacheHandle(h cache.Handle) {


### PR DESCRIPTION
Retain the `blockIter.{fullKey,cached,cachedBuf}` (the dynamically
allocated buffers) across `sync.Pool` reuse of `singleLevelIterator` and
`twoLevelIterator`. This significantly reduces allocations which is the
point of pool allocation in the first place. This also obviates the need
for `blockIter.keyBuf` which has now been removed.

This provides a nice speedup on CRDB's short range (1-10 row)
`MVCCReverseScan` benchmarks:

```
name                                                         old time/op    new time/op    delta
MVCCReverseScan_Pebble/rows=1/versions=1/valueSize=8-16        3.17µs ± 3%    2.69µs ± 2%  -15.39%  (p=0.000 n=10+10)
MVCCReverseScan_Pebble/rows=1/versions=1/valueSize=64-16       5.07µs ± 4%    4.00µs ± 3%  -21.08%  (p=0.000 n=10+10)
MVCCReverseScan_Pebble/rows=1/versions=1/valueSize=512-16      4.58µs ± 2%    3.94µs ± 1%  -14.02%  (p=0.000 n=10+8)
MVCCReverseScan_Pebble/rows=10/versions=1/valueSize=8-16       5.56µs ± 5%    4.95µs ± 4%  -11.08%  (p=0.000 n=10+10)
MVCCReverseScan_Pebble/rows=10/versions=1/valueSize=64-16      7.84µs ± 4%    6.76µs ± 1%  -13.83%  (p=0.000 n=10+8)
MVCCReverseScan_Pebble/rows=10/versions=1/valueSize=512-16     9.31µs ± 2%    8.57µs ± 1%   -7.92%  (p=0.000 n=10+9)
MVCCReverseScan_Pebble/rows=100/versions=1/valueSize=8-16      22.9µs ± 3%    22.7µs ± 3%     ~     (p=0.075 n=10+10)
MVCCReverseScan_Pebble/rows=100/versions=1/valueSize=64-16     30.3µs ± 3%    29.6µs ± 4%   -2.13%  (p=0.035 n=9+10)
MVCCReverseScan_Pebble/rows=100/versions=1/valueSize=512-16    46.6µs ± 2%    46.0µs ± 2%     ~     (p=0.095 n=9+10)
```

Also verified that there was no impact on the forward scan benchmarks.