### PR TITLE
various batch and batchskl optimizations

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -36,27 +36,6 @@ var ErrNotIndexed = errors.New("pebble: batch not indexed")
 // ErrInvalidBatch indicates that a batch is invalid or otherwise corrupted.
 var ErrInvalidBatch = errors.New("pebble: invalid batch")
 
-type batchStorage struct {
-	// Data is the wire format of a batch's log entry:
-	//   - 8 bytes for a sequence number of the first batch element,
-	//     or zeroes if the batch has not yet been applied,
-	//   - 4 bytes for the count: the number of elements in the batch,
-	//     or "\xff\xff\xff\xff" if the batch is invalid,
-	//   - count elements, being:
-	//     - one byte for the kind
-	//     - the varint-string user key,
-	//     - the varint-string value (if kind != delete).
-	// The sequence number and count are stored in little-endian order.
-	//
-	// The data field can be (but is not guaranteed to be) nil for new
-	// batches. Large batches will set the data field to nil when committed as
-	// the data has been moved to a flushableBatch and inserted into the queue of
-	// memtables.
-	data           []byte
-	cmp            Compare
-	abbreviatedKey AbbreviatedKey
-}
-
 // DeferredBatchOp represents a batch operation (eg. set, merge, delete) that is
 // being inserted into the batch. Indexing is not performed on the specified key
 // until Finish is called, hence the name deferred. This struct lets the caller
@@ -183,7 +162,24 @@ func (d DeferredBatchOp) Finish() {
 // WAL, and thus stable. New record kinds may be added, but the existing ones
 // will not be modified.
 type Batch struct {
-	storage batchStorage
+	// Data is the wire format of a batch's log entry:
+	//   - 8 bytes for a sequence number of the first batch element,
+	//     or zeroes if the batch has not yet been applied,
+	//   - 4 bytes for the count: the number of elements in the batch,
+	//     or "\xff\xff\xff\xff" if the batch is invalid,
+	//   - count elements, being:
+	//     - one byte for the kind
+	//     - the varint-string user key,
+	//     - the varint-string value (if kind != delete).
+	// The sequence number and count are stored in little-endian order.
+	//
+	// The data field can be (but is not guaranteed to be) nil for new
+	// batches. Large batches will set the data field to nil when committed as
+	// the data has been moved to a flushableBatch and inserted into the queue of
+	// memtables.
+	data           []byte
+	cmp            Compare
+	abbreviatedKey AbbreviatedKey
 
 	memTableSize uint32
 
@@ -245,11 +241,11 @@ func newBatch(db *DB) *Batch {
 
 func newIndexedBatch(db *DB, comparer *Comparer) *Batch {
 	i := indexedBatchPool.Get().(*indexedBatch)
-	i.batch.storage.cmp = comparer.Compare
-	i.batch.storage.abbreviatedKey = comparer.AbbreviatedKey
+	i.batch.cmp = comparer.Compare
+	i.batch.abbreviatedKey = comparer.AbbreviatedKey
 	i.batch.db = db
 	i.batch.index = &i.index
-	i.batch.index.Init(&i.batch.storage.data, i.batch.storage.cmp, i.batch.storage.abbreviatedKey)
+	i.batch.index.Init(&i.batch.data, i.batch.cmp, i.batch.abbreviatedKey)
 	return &i.batch
 }
 
@@ -269,8 +265,8 @@ func (b *Batch) release() {
 	// field. Without using an atomic to clear that field the Go race detector
 	// complains.
 	b.Reset()
-	b.storage.cmp = nil
-	b.storage.abbreviatedKey = nil
+	b.cmp = nil
+	b.abbreviatedKey = nil
 	b.memTableSize = 0
 
 	b.flushable = nil
@@ -289,7 +285,7 @@ func (b *Batch) release() {
 
 func (b *Batch) refreshMemTableSize() {
 	b.memTableSize = 0
-	if len(b.storage.data) < batchHeaderLen {
+	if len(b.data) < batchHeaderLen {
 		return
 	}
 
@@ -306,27 +302,27 @@ func (b *Batch) refreshMemTableSize() {
 //
 // It is safe to modify the contents of the arguments after Apply returns.
 func (b *Batch) Apply(batch *Batch, _ *WriteOptions) error {
-	if len(batch.storage.data) == 0 {
+	if len(batch.data) == 0 {
 		return nil
 	}
-	if len(batch.storage.data) < batchHeaderLen {
+	if len(batch.data) < batchHeaderLen {
 		return errors.New("pebble: invalid batch")
 	}
 
-	offset := len(b.storage.data)
+	offset := len(b.data)
 	if offset == 0 {
 		b.init(offset)
 		offset = batchHeaderLen
 	}
-	b.storage.data = append(b.storage.data, batch.storage.data[batchHeaderLen:]...)
+	b.data = append(b.data, batch.data[batchHeaderLen:]...)
 
 	b.setCount(b.Count() + batch.Count())
 
 	if b.db != nil || b.index != nil {
 		// Only iterate over the new entries if we need to track memTableSize or in
 		// order to update the index.
-		for iter := BatchReader(b.storage.data[offset:]); len(iter) > 0; {
-			offset := uintptr(unsafe.Pointer(&iter[0])) - uintptr(unsafe.Pointer(&b.storage.data[0]))
+		for iter := BatchReader(b.data[offset:]); len(iter) > 0; {
+			offset := uintptr(unsafe.Pointer(&iter[0])) - uintptr(unsafe.Pointer(&b.data[0]))
 			kind, key, value, ok := iter.Next()
 			if !ok {
 				break
@@ -335,8 +331,7 @@ func (b *Batch) Apply(batch *Batch, _ *WriteOptions) error {
 				var err error
 				if kind == InternalKeyKindRangeDelete {
 					if b.rangeDelIndex == nil {
-						b.rangeDelIndex = batchskl.NewSkiplist(
-							&b.storage.data, b.storage.cmp, b.storage.abbreviatedKey)
+						b.rangeDelIndex = batchskl.NewSkiplist(&b.data, b.cmp, b.abbreviatedKey)
 					}
 					err = b.rangeDelIndex.Add(uint32(offset))
 				} else {
@@ -366,16 +361,16 @@ func (b *Batch) Get(key []byte) (value []byte, err error) {
 }
 
 func (b *Batch) prepareDeferredKeyValueRecord(keyLen, valueLen int, kind InternalKeyKind) {
-	if len(b.storage.data) == 0 {
+	if len(b.data) == 0 {
 		b.init(keyLen + valueLen + 2*binary.MaxVarintLen64 + batchHeaderLen)
 	}
 	b.count++
 	b.memTableSize += memTableEntrySize(keyLen, valueLen)
 
-	pos := len(b.storage.data)
+	pos := len(b.data)
 	b.deferredOp.offset = uint32(pos)
 	b.grow(1 + 2*maxVarintLen32 + keyLen + valueLen)
-	b.storage.data[pos] = byte(kind)
+	b.data[pos] = byte(kind)
 	pos++
 
 	{
@@ -384,15 +379,15 @@ func (b *Batch) prepareDeferredKeyValueRecord(keyLen, valueLen int, kind Interna
 		// versions show this to not be a performance win.
 		x := uint32(keyLen)
 		for x >= 0x80 {
-			b.storage.data[pos] = byte(x) | 0x80
+			b.data[pos] = byte(x) | 0x80
 			x >>= 7
 			pos++
 		}
-		b.storage.data[pos] = byte(x)
+		b.data[pos] = byte(x)
 		pos++
 	}
 
-	b.deferredOp.Key = b.storage.data[pos : pos+keyLen]
+	b.deferredOp.Key = b.data[pos : pos+keyLen]
 	pos += keyLen
 
 	{
@@ -401,30 +396,30 @@ func (b *Batch) prepareDeferredKeyValueRecord(keyLen, valueLen int, kind Interna
 		// versions show this to not be a performance win.
 		x := uint32(valueLen)
 		for x >= 0x80 {
-			b.storage.data[pos] = byte(x) | 0x80
+			b.data[pos] = byte(x) | 0x80
 			x >>= 7
 			pos++
 		}
-		b.storage.data[pos] = byte(x)
+		b.data[pos] = byte(x)
 		pos++
 	}
 
-	b.deferredOp.Value = b.storage.data[pos : pos+valueLen]
+	b.deferredOp.Value = b.data[pos : pos+valueLen]
 	// Shrink data since varints may be shorter than the upper bound.
-	b.storage.data = b.storage.data[:pos+valueLen]
+	b.data = b.data[:pos+valueLen]
 }
 
 func (b *Batch) prepareDeferredKeyRecord(keyLen int, kind InternalKeyKind) {
-	if len(b.storage.data) == 0 {
+	if len(b.data) == 0 {
 		b.init(keyLen + binary.MaxVarintLen64 + batchHeaderLen)
 	}
 	b.count++
 	b.memTableSize += memTableEntrySize(keyLen, 0)
 
-	pos := len(b.storage.data)
+	pos := len(b.data)
 	b.deferredOp.offset = uint32(pos)
 	b.grow(1 + maxVarintLen32 + keyLen)
-	b.storage.data[pos] = byte(kind)
+	b.data[pos] = byte(kind)
 	pos++
 
 	{
@@ -433,19 +428,19 @@ func (b *Batch) prepareDeferredKeyRecord(keyLen int, kind InternalKeyKind) {
 		// BenchmarkBatchSet.
 		x := uint32(keyLen)
 		for x >= 0x80 {
-			b.storage.data[pos] = byte(x) | 0x80
+			b.data[pos] = byte(x) | 0x80
 			x >>= 7
 			pos++
 		}
-		b.storage.data[pos] = byte(x)
+		b.data[pos] = byte(x)
 		pos++
 	}
 
-	b.deferredOp.Key = b.storage.data[pos : pos+keyLen]
+	b.deferredOp.Key = b.data[pos : pos+keyLen]
 	b.deferredOp.Value = nil
 
 	// Shrink data since varint may be shorter than the upper bound.
-	b.storage.data = b.storage.data[:pos+keyLen]
+	b.data = b.data[:pos+keyLen]
 }
 
 // Set adds an action to the batch that sets the key to map to the value.
@@ -593,8 +588,7 @@ func (b *Batch) DeleteRangeDeferred(startLen, endLen int) *DeferredBatchOp {
 		b.tombstones = nil
 		// Range deletions are rare, so we lazily allocate the index for them.
 		if b.rangeDelIndex == nil {
-			b.rangeDelIndex = batchskl.NewSkiplist(
-				&b.storage.data, b.storage.cmp, b.storage.abbreviatedKey)
+			b.rangeDelIndex = batchskl.NewSkiplist(&b.data, b.cmp, b.abbreviatedKey)
 		}
 		b.deferredOp.index = b.rangeDelIndex
 	}
@@ -619,18 +613,18 @@ func (b *Batch) LogData(data []byte, _ *WriteOptions) error {
 
 // Empty returns true if the batch is empty, and false otherwise.
 func (b *Batch) Empty() bool {
-	return len(b.storage.data) <= batchHeaderLen
+	return len(b.data) <= batchHeaderLen
 }
 
 // Repr returns the underlying batch representation. It is not safe to modify
 // the contents. Reset() will not change the contents of the returned value,
 // though any other mutation operation may do so.
 func (b *Batch) Repr() []byte {
-	if len(b.storage.data) == 0 {
+	if len(b.data) == 0 {
 		b.init(batchHeaderLen)
 	}
 	binary.LittleEndian.PutUint32(b.countData(), b.Count())
-	return b.storage.data
+	return b.data
 }
 
 // SetRepr sets the underlying batch representation. The batch takes ownership
@@ -640,7 +634,7 @@ func (b *Batch) SetRepr(data []byte) error {
 	if len(data) < batchHeaderLen {
 		return fmt.Errorf("invalid batch")
 	}
-	b.storage.data = data
+	b.data = data
 	b.count = uint64(binary.LittleEndian.Uint32(b.countData()))
 	if b.db != nil {
 		// Only track memTableSize for batches that will be committed to the DB.
@@ -667,7 +661,7 @@ func (b *Batch) newInternalIter(o *IterOptions) internalIterator {
 		return newErrorIter(ErrNotIndexed)
 	}
 	return &batchIter{
-		cmp:   b.storage.cmp,
+		cmp:   b.cmp,
 		batch: b,
 		iter:  b.index.NewIter(o.GetLowerBound(), o.GetUpperBound()),
 	}
@@ -686,13 +680,13 @@ func (b *Batch) newRangeDelIter(o *IterOptions) internalIterator {
 	// tombstone is added to the batch.
 	if b.tombstones == nil {
 		frag := &rangedel.Fragmenter{
-			Cmp: b.storage.cmp,
+			Cmp: b.cmp,
 			Emit: func(fragmented []rangedel.Tombstone) {
 				b.tombstones = append(b.tombstones, fragmented...)
 			},
 		}
 		it := &batchIter{
-			cmp:   b.storage.cmp,
+			cmp:   b.cmp,
 			batch: b,
 			iter:  b.rangeDelIndex.NewIter(nil, nil),
 		}
@@ -706,7 +700,7 @@ func (b *Batch) newRangeDelIter(o *IterOptions) internalIterator {
 		frag.Finish()
 	}
 
-	return rangedel.NewIter(b.storage.cmp, b.tombstones)
+	return rangedel.NewIter(b.cmp, b.tombstones)
 }
 
 // Commit applies the batch to its parent writer.
@@ -731,10 +725,10 @@ func (b *Batch) init(cap int) {
 	for n < cap {
 		n *= 2
 	}
-	b.storage.data = rawalloc.New(batchHeaderLen, n)
+	b.data = rawalloc.New(batchHeaderLen, n)
 	b.setCount(0)
 	b.setSeqNum(0)
-	b.storage.data = b.storage.data[:batchHeaderLen]
+	b.data = b.data[:batchHeaderLen]
 }
 
 // Reset clears the underlying byte slice and effectively empties the batch for
@@ -743,16 +737,16 @@ func (b *Batch) init(cap int) {
 // Commits and Closes take care of releasing resources when appropriate.
 func (b *Batch) Reset() {
 	b.count = 0
-	if b.storage.data != nil {
-		if cap(b.storage.data) > batchMaxRetainedSize {
+	if b.data != nil {
+		if cap(b.data) > batchMaxRetainedSize {
 			// If the capacity of the buffer is larger than our maximum
 			// retention size, don't re-use it. Let it be GC-ed instead.
 			// This prevents the memory from an unusually large batch from
 			// being held on to indefinitely.
-			b.storage.data = nil
+			b.data = nil
 		} else {
 			// Otherwise, reset the buffer for re-use.
-			b.storage.data = b.storage.data[:batchHeaderLen]
+			b.data = b.data[:batchHeaderLen]
 			b.setSeqNum(0)
 		}
 	}
@@ -761,27 +755,27 @@ func (b *Batch) Reset() {
 // seqNumData returns the 8 byte little-endian sequence number. Zero means that
 // the batch has not yet been applied.
 func (b *Batch) seqNumData() []byte {
-	return b.storage.data[:8]
+	return b.data[:8]
 }
 
 // countData returns the 4 byte little-endian count data. "\xff\xff\xff\xff"
 // means that the batch is invalid.
 func (b *Batch) countData() []byte {
-	return b.storage.data[8:12]
+	return b.data[8:12]
 }
 
 func (b *Batch) grow(n int) {
-	newSize := len(b.storage.data) + n
-	if newSize > cap(b.storage.data) {
-		newCap := 2 * cap(b.storage.data)
+	newSize := len(b.data) + n
+	if newSize > cap(b.data) {
+		newCap := 2 * cap(b.data)
 		for newCap < newSize {
 			newCap *= 2
 		}
-		newData := rawalloc.New(len(b.storage.data), newCap)
-		copy(newData, b.storage.data)
-		b.storage.data = newData
+		newData := rawalloc.New(len(b.data), newCap)
+		copy(newData, b.data)
+		b.data = newData
 	}
-	b.storage.data = b.storage.data[:newSize]
+	b.data = b.data[:newSize]
 }
 
 func (b *Batch) setSeqNum(seqNum uint64) {
@@ -811,7 +805,7 @@ func (b *Batch) Count() uint32 {
 // Reader returns a BatchReader for the current batch contents. If the batch is
 // mutated, the new entries will not be visible to the reader.
 func (b *Batch) Reader() BatchReader {
-	return b.storage.data[batchHeaderLen:]
+	return b.data[batchHeaderLen:]
 }
 
 func batchDecode(data []byte, offset uint32) (kind InternalKeyKind, ukey []byte, value []byte, ok bool) {
@@ -966,7 +960,7 @@ func (i *batchIter) Key() *InternalKey {
 }
 
 func (i *batchIter) Value() []byte {
-	_, _, value, ok := batchDecode(i.batch.storage.data, i.iter.KeyOffset())
+	_, _, value, ok := batchDecode(i.batch.data, i.iter.KeyOffset())
 	if !ok {
 		i.err = fmt.Errorf("corrupted batch")
 	}
@@ -1040,7 +1034,7 @@ var _ flushable = (*flushableBatch)(nil)
 // of the batch data.
 func newFlushableBatch(batch *Batch, comparer *Comparer) *flushableBatch {
 	b := &flushableBatch{
-		data:      batch.storage.data,
+		data:      batch.data,
 		cmp:       comparer.Compare,
 		offsets:   make([]flushableBatchEntry, 0, batch.Count()),
 		flushedCh: make(chan struct{}),

--- a/commit.go
+++ b/commit.go
@@ -283,7 +283,7 @@ func (p *commitPipeline) AllocateSeqNum(count int, prepare func(), apply func(se
 
 	// Give the batch a count of 1 so that the log and visible sequence number
 	// are incremented correctly.
-	b.storage.data = make([]byte, batchHeaderLen)
+	b.data = make([]byte, batchHeaderLen)
 	b.setCount(uint32(count))
 	b.commit.Add(1)
 

--- a/commit_test.go
+++ b/commit_test.go
@@ -47,7 +47,7 @@ func (e *testCommitEnv) apply(b *Batch, mem *memTable) error {
 }
 
 func (e *testCommitEnv) write(b *Batch, _ *sync.WaitGroup, _ *error) (*memTable, error) {
-	n := int64(len(b.storage.data))
+	n := int64(len(b.data))
 	atomic.AddInt64(&e.writePos, n)
 	atomic.AddUint64(&e.writeCount, 1)
 	return nil, nil
@@ -194,7 +194,7 @@ func TestCommitPipelineWALClose(t *testing.T) {
 			return nil
 		},
 		write: func(b *Batch, syncWG *sync.WaitGroup, syncErr *error) (*memTable, error) {
-			_, err := wal.SyncRecord(b.storage.data, syncWG, syncErr)
+			_, err := wal.SyncRecord(b.data, syncWG, syncErr)
 			return nil, err
 		},
 	}
@@ -265,7 +265,7 @@ func BenchmarkCommitPipeline(b *testing.B) {
 						break
 					}
 
-					_, err := wal.SyncRecord(b.storage.data, syncWG, syncErr)
+					_, err := wal.SyncRecord(b.data, syncWG, syncErr)
 					return mem, err
 				},
 			}

--- a/db.go
+++ b/db.go
@@ -466,7 +466,7 @@ func (d *DB) Apply(batch *Batch, opts *WriteOptions) error {
 	// an sstable. For a 100 MB batch, this might actually be faster. For a 1
 	// GB batch this is almost certainly faster.
 	if batch.flushable != nil {
-		batch.storage.data = nil
+		batch.data = nil
 	}
 	return nil
 }

--- a/internal/batchskl/iterator.go
+++ b/internal/batchskl/iterator.go
@@ -53,16 +53,16 @@ func (it *Iterator) Close() error {
 // is up to the caller to ensure that key is greater than or equal to the lower
 // bound.
 func (it *Iterator) SeekGE(key []byte) *base.InternalKey {
-	_, it.nd, _ = it.seekForBaseSplice(key, it.list.storage.AbbreviatedKey(key))
+	_, it.nd = it.seekForBaseSplice(key, it.list.abbreviatedKey(key))
 	if it.nd == it.list.tail {
 		return nil
 	}
-	keyOffset := it.list.getKey(it.nd)
-	if it.upper != nil && it.list.storage.Compare(it.upper, keyOffset) <= 0 {
+	nodeKey := it.list.getKey(it.nd)
+	if it.upper != nil && it.list.cmp(it.upper, nodeKey.UserKey) <= 0 {
 		it.nd = it.list.tail
 		return nil
 	}
-	it.key = it.list.storage.Get(keyOffset)
+	it.key = nodeKey
 	return &it.key
 }
 
@@ -71,16 +71,16 @@ func (it *Iterator) SeekGE(key []byte) *base.InternalKey {
 // otherwise. Note that SeekLT only checks the lower bound. It is up to the
 // caller to ensure that key is less than the upper bound.
 func (it *Iterator) SeekLT(key []byte) *base.InternalKey {
-	it.nd, _, _ = it.seekForBaseSplice(key, it.list.storage.AbbreviatedKey(key))
+	it.nd, _ = it.seekForBaseSplice(key, it.list.abbreviatedKey(key))
 	if it.nd == it.list.head {
 		return nil
 	}
-	keyOffset := it.list.getKey(it.nd)
-	if it.lower != nil && it.list.storage.Compare(it.lower, it.list.getKey(it.nd)) > 0 {
+	nodeKey := it.list.getKey(it.nd)
+	if it.lower != nil && it.list.cmp(it.lower, nodeKey.UserKey) > 0 {
 		it.nd = it.list.head
 		return nil
 	}
-	it.key = it.list.storage.Get(keyOffset)
+	it.key = nodeKey
 	return &it.key
 }
 
@@ -93,12 +93,12 @@ func (it *Iterator) First() *base.InternalKey {
 	if it.nd == it.list.tail {
 		return nil
 	}
-	keyOffset := it.list.getKey(it.nd)
-	if it.upper != nil && it.list.storage.Compare(it.upper, keyOffset) <= 0 {
+	nodeKey := it.list.getKey(it.nd)
+	if it.upper != nil && it.list.cmp(it.upper, nodeKey.UserKey) <= 0 {
 		it.nd = it.list.tail
 		return nil
 	}
-	it.key = it.list.storage.Get(keyOffset)
+	it.key = nodeKey
 	return &it.key
 }
 
@@ -111,12 +111,12 @@ func (it *Iterator) Last() *base.InternalKey {
 	if it.nd == it.list.head {
 		return nil
 	}
-	keyOffset := it.list.getKey(it.nd)
-	if it.lower != nil && it.list.storage.Compare(it.lower, keyOffset) > 0 {
+	nodeKey := it.list.getKey(it.nd)
+	if it.lower != nil && it.list.cmp(it.lower, nodeKey.UserKey) > 0 {
 		it.nd = it.list.head
 		return nil
 	}
-	it.key = it.list.storage.Get(keyOffset)
+	it.key = nodeKey
 	return &it.key
 }
 
@@ -127,12 +127,12 @@ func (it *Iterator) Next() *base.InternalKey {
 	if it.nd == it.list.tail {
 		return nil
 	}
-	keyOffset := it.list.getKey(it.nd)
-	if it.upper != nil && it.list.storage.Compare(it.upper, keyOffset) <= 0 {
+	nodeKey := it.list.getKey(it.nd)
+	if it.upper != nil && it.list.cmp(it.upper, nodeKey.UserKey) <= 0 {
 		it.nd = it.list.tail
 		return nil
 	}
-	it.key = it.list.storage.Get(keyOffset)
+	it.key = nodeKey
 	return &it.key
 }
 
@@ -143,12 +143,12 @@ func (it *Iterator) Prev() *base.InternalKey {
 	if it.nd == it.list.head {
 		return nil
 	}
-	keyOffset := it.list.getKey(it.nd)
-	if it.lower != nil && it.list.storage.Compare(it.lower, keyOffset) > 0 {
+	nodeKey := it.list.getKey(it.nd)
+	if it.lower != nil && it.list.cmp(it.lower, nodeKey.UserKey) > 0 {
 		it.nd = it.list.head
 		return nil
 	}
-	it.key = it.list.storage.Get(keyOffset)
+	it.key = nodeKey
 	return &it.key
 }
 
@@ -159,7 +159,7 @@ func (it *Iterator) Key() *base.InternalKey {
 
 // KeyOffset returns the key offset at the current position.
 func (it *Iterator) KeyOffset() uint32 {
-	return it.list.getKey(it.nd)
+	return it.list.node(it.nd).offset
 }
 
 // Head true iff the iterator is positioned at the sentinel head node.
@@ -187,18 +187,10 @@ func (it *Iterator) SetBounds(lower, upper []byte) {
 
 func (it *Iterator) seekForBaseSplice(
 	key []byte, abbreviatedKey uint64,
-) (prev, next uint32, found bool) {
+) (prev, next uint32) {
 	prev = it.list.head
 	for level := it.list.height - 1; ; level-- {
-		prev, next, found = it.list.findSpliceForLevel(key, abbreviatedKey, level, prev)
-		if found {
-			if level != 0 {
-				// next is pointing at the target node, but we need to find previous on
-				// the bottom level.
-				prev = it.list.getPrev(next, 0)
-			}
-			break
-		}
+		prev, next = it.list.findSpliceForLevel(key, abbreviatedKey, level, prev)
 		if level == 0 {
 			break
 		}

--- a/internal/batchskl/iterator.go
+++ b/internal/batchskl/iterator.go
@@ -157,9 +157,11 @@ func (it *Iterator) Key() *base.InternalKey {
 	return &it.key
 }
 
-// KeyOffset returns the key offset at the current position.
-func (it *Iterator) KeyOffset() uint32 {
-	return it.list.node(it.nd).offset
+// KeyInfo returns the offset of the start of the record, the start of the key,
+// and the end of the key.
+func (it *Iterator) KeyInfo() (offset, keyStart, keyEnd uint32) {
+	n := it.list.node(it.nd)
+	return n.offset, n.keyStart, n.keyEnd
 }
 
 // Head true iff the iterator is positioned at the sentinel head node.

--- a/internal/batchskl/iterator.go
+++ b/internal/batchskl/iterator.go
@@ -24,11 +24,6 @@ type splice struct {
 	next uint32
 }
 
-func (s *splice) init(prev, next uint32) {
-	s.prev = prev
-	s.next = next
-}
-
 // Iterator is an iterator over the skiplist object. Use Skiplist.NewIterator
 // to construct an iterator. The current state of the iterator can be cloned
 // by simply value copying the struct.

--- a/internal/batchskl/skl_test.go
+++ b/internal/batchskl/skl_test.go
@@ -457,6 +457,21 @@ func BenchmarkReadWrite(b *testing.B) {
 	}
 }
 
+func BenchmarkOrderedWrite(b *testing.B) {
+	var buf [8]byte
+	d := &testStorage{
+		data: make([]byte, 0, b.N*10),
+	}
+	l := newTestSkiplist(d)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		binary.BigEndian.PutUint64(buf[:], uint64(i))
+		offset := d.addBytes(buf[:])
+		_ = l.Add(offset)
+	}
+}
+
 func BenchmarkIterNext(b *testing.B) {
 	var buf [8]byte
 	d := &testStorage{

--- a/open.go
+++ b/open.go
@@ -347,7 +347,7 @@ func (d *DB) replayWAL(
 			flushMem()
 			// Make a copy of the data slice since it is currently owned by buf and will
 			// be reused in the next iteration.
-			b.storage.data = append([]byte(nil), b.storage.data...)
+			b.data = append([]byte(nil), b.data...)
 			b.flushable = newFlushableBatch(&b, d.opts.Comparer)
 			if d.opts.ReadOnly {
 				d.mu.mem.queue = append(d.mu.mem.queue, b.flushable)


### PR DESCRIPTION
* internal/batchskl: add in-order insertion fast-path
* internal/batchskl: remove splice.init and Skiplist.set{Next,Prev}
* internal/batchskl: manually inline findSpliceForLevel in findSplice
* batchDecodeStr
* remove batchStorage
* internal/batchskl: rework Skiplist key storage

These were motivated by investigation of the CRDB
`BatchApplyBatchRepr_Pebble` benchmark:

```
name                                                                                 old time/op    new time/op    delta
BatchApplyBatchRepr_Pebble/indexed=false/seq=false/valueSize=10/batchSize=10000-16      188µs ± 4%     148µs ± 2%   -21.22%  (p=0.000 n=10+9)
BatchApplyBatchRepr_Pebble/indexed=false/seq=true/valueSize=10/batchSize=10000-16       185µs ± 4%     148µs ± 1%   -19.80%  (p=0.000 n=10+9)
BatchApplyBatchRepr_Pebble/indexed=true/seq=false/valueSize=10/batchSize=10000-16      2.07ms ± 1%    1.76ms ± 3%   -14.82%  (p=0.000 n=8+10)
BatchApplyBatchRepr_Pebble/indexed=true/seq=true/valueSize=10/batchSize=10000-16       1.44ms ± 3%    0.55ms ± 6%   -61.82%  (p=0.000 n=10+10)
BatchApplyBatchRepr_RocksDB/indexed=false/seq=false/valueSize=10/batchSize=10000-16     566µs ± 1%     543µs ± 1%    -4.02%  (p=0.030 n=2+10)
```