### PR TITLE
fix compaction.allowZeroSeqNum when flushing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 install:
-  - go get -t -v ./...
+  - go get -d -t -v ./...
   - go get -v golang.org/x/lint/golint
 
 matrix:

--- a/testdata/compaction_allow_zero_seqnum
+++ b/testdata/compaction_allow_zero_seqnum
@@ -33,3 +33,23 @@ allow-zero-seqnum
 L1:c-c
 ----
 true
+
+# Regression test for a bug where the allow-zero-seqnum check was not
+# actually working for flushes due to a failure to clone the
+# lower-bound key used for checking for overlap. This caused the
+# overlap check to use [b,b] in the test below, rather than [a,b].
+
+define
+mem
+  a.SET.2:2
+  b.SET.3:3
+L1
+  a.SET.0:0
+----
+1:
+  4:[a-a]
+
+allow-zero-seqnum
+flush
+----
+false


### PR DESCRIPTION
When flushing, the `allowZeroSeqNum` check finds the smallest and
largest key being flushed and checks to see if there is any overlap with
sstables in lower levels. This logic is sound, but we need to make a
copy of the keys because any iterator positioning call such as `Last`
will invalidate the key returned from a previous call. So instead of
checking `[smallest,largest]` for overlap, we were checking
`[largest,largest]`.