### PR TITLE
Comments on why certain loops in mergingIter will make forward progress.

### DIFF
--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -134,7 +134,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 	var levels []levelInfo
 	// Indexed by fileNum
 	var readers []*sstable.Reader
-	var fileNum uint64 = 0
+	var fileNum uint64
 	newIters :=
 		func(meta *fileMetadata, opts *IterOptions, bytesIterated *uint64) (internalIterator, internalIterator, error) {
 			r := readers[meta.FileNum]


### PR DESCRIPTION
Motivated by Peter's finding of an infinite loop which turned out to
have a different root cause.