### PR TITLE
fix levelIter.Seek{GE,LT} bug

### DIFF
--- a/testdata/level_iter_boundaries
+++ b/testdata/level_iter_boundaries
@@ -143,3 +143,36 @@ prev
 c#2,1:c
 a#1,15:
 .
+
+# Regression test to check that Seek{GE,LT} work properly in certain
+# cases when then levelIter is positioned at a boundary key.
+
+clear
+----
+
+build
+d.SET.3:d
+c.RANGEDEL.2:e
+----
+0: c#2,15-e#72057594037927935,15
+
+iter
+seek-ge d
+next
+seek-ge d
+next
+seek-lt e
+prev
+seek-ge d
+prev
+seek-lt e
+----
+d#3,1:d
+e#72057594037927935,15:
+d#3,1:d
+e#72057594037927935,15:
+d#3,1:d
+c#2,15:
+d#3,1:d
+c#2,15:
+d#3,1:d


### PR DESCRIPTION
Fix a bug which caused `levelIter.Seek{GE,LT}` to return `nil,nil` when
it was positioned at a boundary key and the seek operation was to the
same sstable that it was already pointing at. The root cause of the bug
was overloading the meaning of the `levelIter.iter` field.

Took the opportunity to remove some detritus that had been necessary
before previous simplifications to the `internalIterator`
API. Specifically, now that there is no longer `Key()` method we don't
need to setting `levelIter.iter` to `nil` when we're at a boundary
key. Additionally, there is no need for `Next()` and `Prev()` to do
anything sane when positioned off the end of the level as all callers
properly use `First()` and `Last()` now.