### PR TITLE
dynamically grow the memtable size

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1182,6 +1182,10 @@ func (b *flushableBatch) flushed() chan struct{} {
 	return b.flushedCh
 }
 
+func (b *flushableBatch) manualFlush() bool {
+	return false
+}
+
 func (b *flushableBatch) readyForFlush() bool {
 	return true
 }

--- a/commit_test.go
+++ b/commit_test.go
@@ -238,7 +238,7 @@ func BenchmarkCommitPipeline(b *testing.B) {
 	for _, parallelism := range []int{1, 2, 4, 8, 16, 32, 64, 128} {
 		b.Run(fmt.Sprintf("parallel=%d", parallelism), func(b *testing.B) {
 			b.SetParallelism(parallelism)
-			mem := newMemTable(nil /* opts */, nil /* reservation */)
+			mem := newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
 			wal := record.NewLogWriter(ioutil.Discard, 0 /* logNum */)
 
 			nullCommitEnv := commitEnv{
@@ -256,7 +256,7 @@ func BenchmarkCommitPipeline(b *testing.B) {
 					for {
 						err := mem.prepare(b)
 						if err == arenaskl.ErrArenaFull {
-							mem = newMemTable(nil /* opts */, nil /* reservation */)
+							mem = newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
 							continue
 						}
 						if err != nil {

--- a/data_test.go
+++ b/data_test.go
@@ -330,7 +330,7 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 				}
 				// Add a memtable layer.
 				if !d.mu.mem.mutable.empty() {
-					d.mu.mem.mutable = newMemTable(d.opts, nil /* reservation */)
+					d.mu.mem.mutable = newMemTable(d.opts, 0 /* size */, nil /* reservation */)
 					d.mu.mem.queue = append(d.mu.mem.queue, d.mu.mem.mutable)
 					d.updateReadStateLocked()
 				}
@@ -345,7 +345,7 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 					return nil, err
 				}
 				fields = fields[1:]
-				mem = newMemTable(d.opts, nil /* reservation */)
+				mem = newMemTable(d.opts, 0 /* size */, nil /* reservation */)
 			}
 		}
 

--- a/db_test.go
+++ b/db_test.go
@@ -696,8 +696,8 @@ func TestIterLeak(t *testing.T) {
 
 func TestMemTableReservation(t *testing.T) {
 	opts := &Options{
-		Cache:        cache.New(1 << 20 /* 1 MB */),
-		MemTableSize: 2 << 20, /* 2 MB */
+		Cache:        cache.New(128 << 10 /* 128 KB */),
+		MemTableSize: 256 << 10, /* 256 KB */
 		FS:           vfs.NewMem(),
 	}
 	opts.EnsureDefaults()

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -480,7 +480,7 @@ func TestGetIter(t *testing.T) {
 
 		v := version{}
 		for _, tt := range tc.tables {
-			d := newMemTable(nil /* opts */, nil /* reservation */)
+			d := newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
 			defer d.close()
 			m[tt.fileNum] = d
 

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -391,7 +391,7 @@ func TestIngestMemtableOverlaps(t *testing.T) {
 						}
 					}
 
-					mem = newMemTable(opts, nil /* reservation */)
+					mem = newMemTable(opts, 0 /* size */, nil /* reservation */)
 					if err := mem.apply(b, 0); err != nil {
 						return err.Error()
 					}

--- a/mem_table_test.go
+++ b/mem_table_test.go
@@ -68,7 +68,7 @@ func ikey(s string) InternalKey {
 
 func TestMemTableBasic(t *testing.T) {
 	// Check the empty DB.
-	m := newMemTable(nil /* opts */, nil /* reservation */)
+	m := newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
 	if got, want := m.count(), 0; got != want {
 		t.Fatalf("0.count: got %v, want %v", got, want)
 	}
@@ -119,7 +119,7 @@ func TestMemTableBasic(t *testing.T) {
 }
 
 func TestMemTableCount(t *testing.T) {
-	m := newMemTable(nil /* opts */, nil /* reservation */)
+	m := newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
 	for i := 0; i < 200; i++ {
 		if j := m.count(); j != i {
 			t.Fatalf("count: got %d, want %d", j, i)
@@ -132,7 +132,7 @@ func TestMemTableCount(t *testing.T) {
 }
 
 func TestMemTableBytesIterated(t *testing.T) {
-	m := newMemTable(nil /* opts */, nil /* reservation */)
+	m := newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
 	for i := 0; i < 200; i++ {
 		bytesIterated := m.bytesIterated(t)
 		expected := m.inuseBytes()
@@ -147,7 +147,7 @@ func TestMemTableBytesIterated(t *testing.T) {
 }
 
 func TestMemTableEmpty(t *testing.T) {
-	m := newMemTable(nil /* opts */, nil /* reservation */)
+	m := newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
 	if !m.empty() {
 		t.Errorf("got !empty, want empty")
 	}
@@ -161,7 +161,7 @@ func TestMemTableEmpty(t *testing.T) {
 func TestMemTable1000Entries(t *testing.T) {
 	// Initialize the DB.
 	const N = 1000
-	m0 := newMemTable(nil /* opts */, nil /* reservation */)
+	m0 := newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
 	for i := 0; i < N; i++ {
 		k := ikey(strconv.Itoa(i))
 		v := []byte(strings.Repeat("x", i))
@@ -242,7 +242,7 @@ func TestMemTableIter(t *testing.T) {
 		datadriven.RunTest(t, testdata, func(d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "define":
-				mem = newMemTable(nil /* opts */, nil /* reservation */)
+				mem = newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
 				for _, key := range strings.Split(d.Input, "\n") {
 					j := strings.Index(key, ":")
 					if err := mem.set(base.ParseInternalKey(key[:j]), []byte(key[j+1:])); err != nil {
@@ -299,7 +299,7 @@ func TestMemTableDeleteRange(t *testing.T) {
 				return err.Error()
 			}
 			if mem == nil {
-				mem = newMemTable(nil /* opts */, nil /* reservation */)
+				mem = newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
 			}
 			if err := mem.apply(b, seqNum); err != nil {
 				return err.Error()
@@ -339,7 +339,7 @@ func TestMemTableConcurrentDeleteRange(t *testing.T) {
 	// tombstones, and then immediately retrieve them verifying that the
 	// tombstones they've added are all present.
 
-	m := newMemTable(&Options{MemTableSize: 64 << 20}, nil /* reservation */)
+	m := newMemTable(&Options{MemTableSize: 64 << 20}, 0 /* size */, nil /* reservation */)
 
 	const workers = 10
 	var wg sync.WaitGroup
@@ -377,7 +377,7 @@ func TestMemTableConcurrentDeleteRange(t *testing.T) {
 }
 
 func buildMemTable(b *testing.B) (*memTable, [][]byte) {
-	m := newMemTable(nil /* opts */, nil /* reservation */)
+	m := newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
 	var keys [][]byte
 	var ikey InternalKey
 	for i := 0; ; i++ {

--- a/open_test.go
+++ b/open_test.go
@@ -424,7 +424,9 @@ func TestOpenWALReplay(t *testing.T) {
 			}
 		}
 		require.Equal(t, 0, sstCount)
-		require.Equal(t, 1, logCount)
+		// The memtable size starts at 256KB and doubles up to 32MB so we expect 5
+		// logs (one for each doubling).
+		require.Equal(t, 7, logCount)
 
 		// Re-open the DB with a smaller memtable. Values for 1, 2 will fit in the first memtable;
 		// value for 3 will go in the next memtable; value for 4 will be in a flushable batch
@@ -440,7 +442,7 @@ func TestOpenWALReplay(t *testing.T) {
 		}
 		if readOnly {
 			d.mu.Lock()
-			require.Len(t, d.mu.mem.queue, 5)
+			require.Equal(t, 10, len(d.mu.mem.queue))
 			require.NotNil(t, d.mu.mem.mutable)
 			d.mu.Unlock()
 		}

--- a/options.go
+++ b/options.go
@@ -306,16 +306,20 @@ type Options struct {
 	// The default value is 1000.
 	MaxOpenFiles int
 
-	// The size of a MemTable. Note that more than one MemTable can be in
-	// existence since flushing a MemTable involves creating a new one and
+	// The size of a MemTable in steady state. The actual MemTable size starts at
+	// min(256KB, MemTableSize) and doubles for each subsequent MemTable up to
+	// MemTableSize. This reduces the memory pressure caused by MemTables for
+	// short lived (test) DB instances. Note that more than one MemTable can be
+	// in existence since flushing a MemTable involves creating a new one and
 	// writing the contents of the old one in the
-	// background. MemTableStopWritesThreshold places a hard limit on the number
-	// of MemTables allowed at once.
+	// background. MemTableStopWritesThreshold places a hard limit on the size of
+	// the queued MemTables.
 	MemTableSize int
 
-	// Hard limit on the number of MemTables. Writes are stopped when this number
-	// is reached. This value should be at least 2 or writes will stop whenever
-	// the MemTable is being flushed.
+	// Hard limit on the size of queued of MemTables. Writes are stopped when the
+	// sum of the queued memtable sizes exceeds
+	// MemTableStopWritesThreshold*MemTableSize. This value should be at least 2
+	// or writes will stop whenever a MemTable is being flushed.
 	MemTableStopWritesThreshold int
 
 	// Merger defines the associative merge operation to use for merging values

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -158,7 +158,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   total         3   2.4 K       -   933 B   825 B       1     0 B       0   4.1 K       4   1.6 K     4.5
   flush         3
 compact         1   1.6 K          (size == estimated-debt)
- memtbl         1   4.0 M
+ memtbl         1   2.0 M
  bcache         4   752 B    7.7%  (score == hit-rate)
  tcache         0     0 B    0.0%  (score == hit-rate)
  titers         0

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -22,7 +22,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   total         1   986 B       -    82 B     0 B       0     0 B       0    82 B       0     0 B     1.0
   flush         0
 compact         0   986 B          (size == estimated-debt)
- memtbl         2   8.0 M
+ memtbl         2   768 K
  bcache         0     0 B    0.0%  (score == hit-rate)
  tcache         0     0 B    0.0%  (score == hit-rate)
  titers         0


### PR DESCRIPTION
Always allocating memtables with a backing arena of
`Options.MemTableSize` causes severe memory pressure in tests which use
a lot of concurrent DB instances such as the CRDB logic tests. Unlike
RocksDB, the Pebble memtable fully allocates the memory for a memtable
up front. So a 64MB memtable consumes 64MB immediately. Changing the
`arenaskl` to allow the arena to grow dynamically is tricky to do in a
performant manner in Go. Rather, we take the approach of starting a DB
with a small memtable size (256KB) and then doubling the size of each
subsequent memtable up to `Options.MemTableSize`.

In order to avoid any significant change in flushing behavior, the flush
heuristic has been changed so that we only flush when the sum of the
flushable queued memtables reaches `Options.MemTableSize/2`. With a 64MB
memtable size, this means we won't perform the first flush until 63MB of
memtables are queued.

Fixes #387