### PR TITLE
disable zeroing of seqnums when flushing

### DIFF
--- a/testdata/compaction_allow_zero_seqnum
+++ b/testdata/compaction_allow_zero_seqnum
@@ -53,3 +53,20 @@ allow-zero-seqnum
 flush
 ----
 false
+
+# We never allow zeroing of seqnums during flushing as doing so runs
+# afoul of the WAL replay logic which flushes after each WAL is
+# replayed, but doesn't construct a version edit in between each
+# flush. Both disallowing of seqnum zeroing during flushing, and the
+# WAL replay behavior match RocksDB's behavior.
+
+define
+mem
+  a.SET.2:2
+  b.SET.3:3
+----
+
+allow-zero-seqnum
+flush
+----
+false

--- a/testdata/manual_flush
+++ b/testdata/manual_flush
@@ -7,7 +7,7 @@ set b 2
 flush
 ----
 0:
-  5:[a#0,SET-b#0,SET]
+  5:[a#0,SET-b#1,SET]
 
 reset
 ----
@@ -70,4 +70,4 @@ set b 2
 async-flush
 ----
 0:
-  5:[a#0,SET-b#0,SET]
+  5:[a#0,SET-b#1,SET]


### PR DESCRIPTION
RocksDB never zeroes seqnums when flushing. Doing so mostly works except
for a bad interaction with WAL replaying at startup. While that
interaction could be fixed, for now it seems safest to match the RocksDB
behavior.