### PR TITLE
only grow the memtable size if we filled it over 50%

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -697,7 +697,7 @@ func TestIterLeak(t *testing.T) {
 func TestMemTableReservation(t *testing.T) {
 	opts := &Options{
 		Cache:        cache.New(128 << 10 /* 128 KB */),
-		MemTableSize: 256 << 10, /* 256 KB */
+		MemTableSize: initialMemTableSize,
 		FS:           vfs.NewMem(),
 	}
 	opts.EnsureDefaults()

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -293,6 +293,7 @@ func TestWriteStallEvents(t *testing.T) {
 			d, err := Open("db", &Options{
 				EventListener:               listener,
 				FS:                          vfs.NewMem(),
+				MemTableSize:                initialMemTableSize,
 				MemTableStopWritesThreshold: 2,
 				L0CompactionThreshold:       2,
 				L0StopWritesThreshold:       2,

--- a/open.go
+++ b/open.go
@@ -19,6 +19,8 @@ import (
 	"github.com/cockroachdb/pebble/vfs"
 )
 
+const initialMemTableSize = 256 << 10 // 256 KB
+
 // Open opens a LevelDB whose files live in the given directory.
 func Open(dirname string, opts *Options) (*DB, error) {
 	// Make a copy of the options so that we don't mutate the passed in options.
@@ -59,7 +61,6 @@ func Open(dirname string, opts *Options) (*DB, error) {
 	d.flushLimiter = rate.NewLimiter(rate.Limit(d.opts.MinFlushRate), d.opts.MinFlushRate)
 	d.mu.nextJobID = 1
 	d.mu.mem.nextSize = opts.MemTableSize
-	const initialMemTableSize = 256 << 10 // 256 KB
 	if d.mu.mem.nextSize > initialMemTableSize {
 		d.mu.mem.nextSize = initialMemTableSize
 	}

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -158,7 +158,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   total         3   2.4 K       -   933 B   825 B       1     0 B       0   4.1 K       4   1.6 K     4.5
   flush         3
 compact         1   1.6 K          (size == estimated-debt)
- memtbl         1   2.0 M
+ memtbl         1   256 K
  bcache         4   752 B    7.7%  (score == hit-rate)
  tcache         0     0 B    0.0%  (score == hit-rate)
  titers         0


### PR DESCRIPTION
Tweak the dynamic memtable sizing logic so that we only grow the
memtable size if we filled it over 50% when a manual flush was
performed. This reduces memtable memory pressure in workloads which
frequently manually flush.