### PR TITLE
levelIter bug fix: Handle the case where index is valid, err is nil

### DIFF
--- a/testdata/level_iter
+++ b/testdata/level_iter
@@ -174,6 +174,38 @@ first
 a:1
 a:1
 
+iter
+set-bounds lower=dd upper=f
+seek-lt dc
+set-bounds lower=a upper=f
+seek-lt dc
+prev
+prev
+prev
+prev
+----
+.
+d:4
+c:3
+b:2
+a:1
+.
+
+iter
+set-bounds lower=a upper=b
+seek-ge c
+set-bounds lower=a upper=f
+seek-ge c
+next
+next
+next
+----
+.
+c:3
+d:4
+dd:5
+.
+
 # levelIter trims lower/upper bound in the options passed to sstables.
 load a
 ----


### PR DESCRIPTION
and iter is nil because the file pointed to by index is beyond the
iteration bounds. This is not an error, and if the bounds change
and the index does not, we should create an iterator.

Fixes cockroach #42353