### PR TITLE
change TableIngestInfo.String to a single-line format

### DIFF
--- a/event.go
+++ b/event.go
@@ -201,10 +201,13 @@ func (i TableIngestInfo) String() string {
 	}
 
 	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "[JOB %d] ingested", i.JobID)
 	for j := range i.Tables {
 		t := &i.Tables[j]
-		fmt.Fprintf(&buf, "[JOB %d] ingested to L%d (%s)\n", i.JobID,
-			t.Level, humanize.Uint64(t.Size))
+		if j > 0 {
+			fmt.Fprintf(&buf, ",")
+		}
+		fmt.Fprintf(&buf, " L%d:%06d (%s)", t.Level, t.FileNum, humanize.Uint64(t.Size))
 	}
 	return buf.String()
 }

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -142,7 +142,7 @@ rename: db/CURRENT.000017.dbtmp -> db/CURRENT
 sync: db
 [JOB 10] MANIFEST created 000017
 [JOB 10] MANIFEST deleted 000015
-[JOB 10] ingested to L0 (825 B)
+[JOB 10] ingested L0:000016 (825 B)
 
 metrics
 ----


### PR DESCRIPTION
`TableIngestInfo.String` was the only event info struct that used a
multi-line format. A single-line format looks nicer in output to CRDB
log files. Tweaked the format to include the file numbers of the
ingested sstables.