### PR TITLE
fix levelIter.SeekPrefiGE positioning

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -21,10 +21,6 @@ const (
 	iterCmdVerboseKey iterCmdOpt = iota
 )
 
-func checkValidPrefix(prefix, key []byte) bool {
-	return prefix == nil || bytes.HasPrefix(key, prefix)
-}
-
 func runIterCmd(d *datadriven.TestData, iter *Iterator) string {
 	var b bytes.Buffer
 	for _, line := range strings.Split(d.Input, "\n") {
@@ -160,7 +156,7 @@ func runInternalIterCmd(d *datadriven.TestData, iter internalIterator, opts ...i
 		default:
 			return fmt.Sprintf("unknown op: %s", parts[0])
 		}
-		if key != nil && checkValidPrefix(prefix, key.UserKey) {
+		if key != nil {
 			if verboseKey {
 				fmt.Fprintf(&b, "%s:%s\n", key, value)
 			} else {

--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -31,14 +31,22 @@ type InternalIterator interface {
 	// is greater than or equal to the lower bound.
 	SeekGE(key []byte) (*InternalKey, []byte)
 
-	// SeekPrefixGE moves the iterator to the first key/value pair whose key
-	// starts with the given prefix and is greater than or equal to the given
-	// key. Returns the key and value if the iterator is pointing at a valid
-	// entry, and (nil, nil) otherwise. Note that the iterator will still observe
-	// keys not matching the prefix. It is up to the user to check if the prefix
-	// matches, and iteration beyond the prefix is undefined. Note that
-	// SeekPrefixGE only checks the upper bound. It is up to the caller to
-	// ensure that key is greater than or equal to the lower bound.
+	// SeekPrefixGE moves the iterator to the first key/value pair whose key is
+	// greater than or equal to the given key. Returns the key and value if the
+	// iterator is pointing at a valid entry, and (nil, nil) otherwise. Note that
+	// SeekPrefixGE only checks the upper bound. It is up to the caller to ensure
+	// that key is greater than or equal to the lower bound.
+	//
+	// The prefix argument is used by some InternalIterator implementations (e.g.
+	// sstable.Reader) to avoid expensive operations. A user-defined Split
+	// function must be supplied to the Comparer for the DB. The supplied prefix
+	// will be the prefix of the given key returned by that Split function. If
+	// the iterator is able to determine that no key with the prefix exists, it
+	// can return (nil,nil). Unlike SeekGE, this is not an indication that
+	// iteration is exhausted.
+	//
+	// Note that the iterator may return keys not matching the prefix. It is up
+	// to the user to check if the prefix matches.
 	SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte)
 
 	// SeekLT moves the iterator to the last key/value pair whose key is less

--- a/testdata/level_iter
+++ b/testdata/level_iter
@@ -116,7 +116,7 @@ seek-prefix-ge a
 next
 ----
 a:1
-.
+b:2
 
 iter
 seek-prefix-ge d
@@ -143,21 +143,21 @@ prev
 d:4
 dd:5
 d:4
-.
+c:3
 
 iter
 seek-prefix-ge d
 prev
 ----
 d:4
-.
+c:3
 
 iter
 seek-prefix-ge dd
 prev
 ----
 dd:5
-.
+d:4
 
 iter lower=a
 seek-ge a
@@ -402,14 +402,14 @@ seek-prefix-ge dd
 prev
 ----
 dd:5
-.
+d:4
 
 iter lower=c
 seek-prefix-ge dd
 prev
 ----
 dd:5
-.
+d:4
 
 iter lower=c
 seek-lt c

--- a/testdata/level_iter_boundaries
+++ b/testdata/level_iter_boundaries
@@ -32,7 +32,7 @@ seek-prefix-ge d
 seek-lt b
 prev
 ----
-.
+d#72057594037927935,15:
 .
 a#1,15:
 .

--- a/testdata/level_iter_seek_prefix_ge
+++ b/testdata/level_iter_seek_prefix_ge
@@ -1,0 +1,28 @@
+# Note that this test file uses a levelIterTestIter which combines a
+# point iterator and a range-del iterator, returning both results in a
+# single key:
+#
+#   <point-key>/<tombstone>#<point-seqnum,point-kind>
+
+build
+a.RANGEDEL.10:c
+d.SET.9:e
+----
+0: a#10,15-d#9,1
+
+build
+f.SET.8:g
+h.SET.7:i
+----
+0: a#10,15-d#9,1
+1: f#8,1-h#7,1
+
+iter
+seek-ge a
+----
+d/a-c#10#9,1:e
+
+iter
+seek-prefix-ge a
+----
+d/a-c#10#9,15:

--- a/testdata/merging_iter_seek
+++ b/testdata/merging_iter_seek
@@ -73,7 +73,7 @@ seek-prefix-ge a0
 next
 ----
 a0:0
-.
+a1:1
 
 iter
 seek-prefix-ge a0
@@ -189,14 +189,14 @@ next
 a:0
 aa:1
 aaa:2
-.
+b:3
 
 iter
 seek-prefix-ge aa
 prev
 ----
 aa:1
-.
+a:0
 
 iter
 seek-prefix-ge aa
@@ -207,7 +207,7 @@ prev
 aa:1
 aaa:2
 aa:1
-.
+a:0
 
 iter
 seek-prefix-ge aa
@@ -220,28 +220,28 @@ aa:1
 aaa:2
 aa:1
 aaa:2
-.
+b:3
 
 iter
 seek-prefix-ge aaa
 next
 ----
 aaa:2
-.
+b:3
 
 iter
 seek-prefix-ge aaa
 prev
 ----
 aaa:2
-.
+aa:1
 
 iter
 seek-prefix-ge b
 prev
 ----
 b:3
-.
+aaa:2
 
 iter
 seek-prefix-ge b


### PR DESCRIPTION
Fix `levelIter.SeekPrefixGE` to not seek past an sstable which doesn't
contain the target key if that table does contain range tombstones. The
prior behavior allowed range tombstones to be unintentionally skipped.