### PR TITLE
fix two ingestion bugs

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -871,6 +871,7 @@ func (d *DB) flush1() error {
 			metrics.BytesIn += size
 		}
 
+		d.mu.versions.logLock()
 		err = d.mu.versions.logAndApply(jobID, ve, c.metrics, d.dataDir)
 		for _, fileNum := range pendingOutputs {
 			if _, ok := d.mu.compact.pendingOutputs[fileNum]; !ok {
@@ -997,6 +998,7 @@ func (d *DB) compact1() (err error) {
 	ve, pendingOutputs, err := d.runCompaction(jobID, c, compactionPacer)
 
 	if err == nil {
+		d.mu.versions.logLock()
 		err = d.mu.versions.logAndApply(jobID, ve, c.metrics, d.dataDir)
 		for _, fileNum := range pendingOutputs {
 			if _, ok := d.mu.compact.pendingOutputs[fileNum]; !ok {

--- a/data_test.go
+++ b/data_test.go
@@ -362,6 +362,7 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 	if len(ve.NewFiles) > 0 {
 		jobID := d.mu.nextJobID
 		d.mu.nextJobID++
+		d.mu.versions.logLock()
 		if err := d.mu.versions.logAndApply(jobID, ve, nil, d.dataDir); err != nil {
 			return nil, err
 		}

--- a/open.go
+++ b/open.go
@@ -225,6 +225,7 @@ func Open(dirname string, opts *Options) (*DB, error) {
 		// sets MinUnflushedLogNum to max-recovered-log-num + 1. We set it to the
 		// newLogNum. There should be no difference in using either value.
 		ve.MinUnflushedLogNum = newLogNum
+		d.mu.versions.logLock()
 		if err := d.mu.versions.logAndApply(jobID, &ve, nil, d.dataDir); err != nil {
 			return nil, err
 		}

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -27,7 +27,7 @@ ingest ext0
 lsm
 ----
 6:
-  6:[a-b]
+  6:[a#1,SET-b#1,SET]
 
 iter
 seek-ge a
@@ -56,9 +56,9 @@ ingest ext1
 lsm
 ----
 5:
-  7:[a-b]
+  7:[a#2,SET-b#2,DEL]
 6:
-  6:[a-b]
+  6:[a#1,SET-b#1,SET]
 
 iter
 seek-ge a
@@ -86,11 +86,11 @@ ingest ext2
 lsm
 ----
 4:
-  8:[a-c]
+  8:[a#3,SET-c#3,SET]
 5:
-  7:[a-b]
+  7:[a#2,SET-b#2,DEL]
 6:
-  6:[a-b]
+  6:[a#1,SET-b#1,SET]
 
 iter
 seek-ge a
@@ -121,13 +121,13 @@ ingest ext3
 lsm
 ----
 3:
-  9:[b-c]
+  9:[b#4,MERGE-c#4,DEL]
 4:
-  8:[a-c]
+  8:[a#3,SET-c#3,SET]
 5:
-  7:[a-b]
+  7:[a#2,SET-b#2,DEL]
 6:
-  6:[a-b]
+  6:[a#1,SET-b#1,SET]
 
 iter
 seek-ge a
@@ -158,14 +158,14 @@ ingest ext4
 lsm
 ----
 3:
-  9:[b-c]
+  9:[b#4,MERGE-c#4,DEL]
 4:
-  8:[a-c]
+  8:[a#3,SET-c#3,SET]
 5:
-  7:[a-b]
+  7:[a#2,SET-b#2,DEL]
 6:
-  6:[a-b]
-  10:[x-y]
+  6:[a#1,SET-b#1,SET]
+  10:[x#5,SET-y#5,SET]
 
 iter
 seek-lt y
@@ -198,17 +198,17 @@ ingest ext5
 lsm
 ----
 0:
-  13:[j-k]
-  11:[k-k]
+  13:[j#6,SET-k#7,SET]
+  11:[k#8,SET-k#8,SET]
 3:
-  9:[b-c]
+  9:[b#4,MERGE-c#4,DEL]
 4:
-  8:[a-c]
+  8:[a#3,SET-c#3,SET]
 5:
-  7:[a-b]
+  7:[a#2,SET-b#2,DEL]
 6:
-  6:[a-b]
-  10:[x-y]
+  6:[a#1,SET-b#1,SET]
+  10:[x#5,SET-y#5,SET]
 
 iter
 seek-ge j
@@ -238,18 +238,18 @@ ingest ext6
 lsm
 ----
 0:
-  13:[j-k]
-  11:[k-k]
+  13:[j#6,SET-k#7,SET]
+  11:[k#8,SET-k#8,SET]
 3:
-  9:[b-c]
+  9:[b#4,MERGE-c#4,DEL]
 4:
-  8:[a-c]
+  8:[a#3,SET-c#3,SET]
 5:
-  7:[a-b]
+  7:[a#2,SET-b#2,DEL]
 6:
-  6:[a-b]
-  14:[n-n]
-  10:[x-y]
+  6:[a#1,SET-b#1,SET]
+  14:[n#10,SET-n#10,SET]
+  10:[x#5,SET-y#5,SET]
 
 get
 m
@@ -269,20 +269,20 @@ ingest ext7
 lsm
 ----
 0:
-  13:[j-k]
-  11:[k-k]
-  17:[m-m]
-  15:[a-z]
+  13:[j#6,SET-k#7,SET]
+  11:[k#8,SET-k#8,SET]
+  17:[m#9,SET-m#9,SET]
+  15:[a#11,RANGEDEL-z#72057594037927935,RANGEDEL]
 3:
-  9:[b-c]
+  9:[b#4,MERGE-c#4,DEL]
 4:
-  8:[a-c]
+  8:[a#3,SET-c#3,SET]
 5:
-  7:[a-b]
+  7:[a#2,SET-b#2,DEL]
 6:
-  6:[a-b]
-  14:[n-n]
-  10:[x-y]
+  6:[a#1,SET-b#1,SET]
+  14:[n#10,SET-n#10,SET]
+  10:[x#5,SET-y#5,SET]
 
 get
 a
@@ -353,20 +353,20 @@ y:40
 lsm
 ----
 0:
-  13:[j-k]
-  11:[k-k]
-  17:[m-m]
-  15:[a-z]
-  18:[j-m]
-  19:[a-x]
-  20:[y-y]
+  13:[j#6,SET-k#7,SET]
+  11:[k#8,SET-k#8,SET]
+  17:[m#9,SET-m#9,SET]
+  15:[a#11,RANGEDEL-z#72057594037927935,RANGEDEL]
+  18:[j#12,RANGEDEL-m#12,SET]
+  19:[a#13,RANGEDEL-x#72057594037927935,RANGEDEL]
+  20:[y#14,SET-y#14,SET]
 3:
-  9:[b-c]
+  9:[b#4,MERGE-c#4,DEL]
 4:
-  8:[a-c]
+  8:[a#3,SET-c#3,SET]
 5:
-  7:[a-b]
+  7:[a#2,SET-b#2,DEL]
 6:
-  6:[a-b]
-  14:[n-n]
-  10:[x-y]
+  6:[a#1,SET-b#1,SET]
+  14:[n#10,SET-n#10,SET]
+  10:[x#5,SET-y#5,SET]


### PR DESCRIPTION
Fix a bug where ingestion was blindly updating the seqnum for the
largest key in an sstable. This unintentionally extended the bounds for
an sstable when the largest key was a range tombstone sentinel key. This
is a minor cosmetic issue as the range tombstone's effect was not
changed by the extension of the sstable bounds.

Fix a bug where concurrent ingestions could collide in choosing their
target level. This collision occurred in `DB.ingestApply` which appears
to have mutual exclusion via `DB.mu`, but that exclusion was being
thwarted by `versionSet.logAndApply` which releases `DB.mu` during the
write to the MANIFEST. Internally, `logAndApply` achieves mutual
exclusion of MANIFEST operations by a separate mechanism. That mechanism
is now made visible via `versionSet.log{Lock,Unlock}` calls.