### PR TITLE
internal/metamorphic: compare output from runs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/kr/pretty v0.1.0
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/stretchr/testify v1.2.2

--- a/internal/metamorphic/config.go
+++ b/internal/metamorphic/config.go
@@ -57,7 +57,7 @@ var defaultConfig = config{
 		iterPrev:          100,
 		iterSeekGE:        100,
 		iterSeekLT:        100,
-		iterSeekPrefixGE:  0,
+		iterSeekPrefixGE:  100,
 		iterSetBounds:     10,
 		newBatch:          5,
 		newIndexedBatch:   5,

--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/randvar"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/pmezard/go-difflib/difflib"
 	"golang.org/x/exp/rand"
 )
 
@@ -40,11 +42,15 @@ import (
 // - Add support for Writer.LogData
 
 var (
-	dir    = flag.String("dir", "_meta", "")
-	disk   = flag.Bool("disk", false, "")
-	keep   = flag.Bool("keep", false, "")
-	ops    = randvar.NewFlag("uniform:5000-10000")
-	runDir = flag.String("run-dir", "", "")
+	// TODO(peter): Enable comparing of output by default. Currently disabled as
+	// comparing output shows differences between runs that appear to be due to
+	// bugs in Pebble.
+	compare = flag.Bool("compare", false, "")
+	dir     = flag.String("dir", "_meta", "")
+	disk    = flag.Bool("disk", false, "")
+	keep    = flag.Bool("keep", false, "")
+	ops     = randvar.NewFlag("uniform:5000-10000")
+	runDir  = flag.String("run-dir", "", "")
 )
 
 func init() {
@@ -167,12 +173,6 @@ func TestMeta(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		defer func() {
-			if !t.Failed() && !*keep {
-				_ = os.RemoveAll(runDir)
-			}
-		}()
-
 		optionsPath := filepath.Join(runDir, "OPTIONS")
 		if err := ioutil.WriteFile(optionsPath, []byte(opts.String()), 0644); err != nil {
 			t.Fatal(err)
@@ -186,8 +186,10 @@ func TestMeta(t *testing.T) {
 	}
 
 	// Perform runs with the standard options.
+	var names []string
 	for i, opts := range standardOptions() {
 		name := fmt.Sprintf("standard-%03d", i)
+		names = append(names, name)
 		t.Run(name, func(t *testing.T) {
 			runOptions(t, opts)
 		})
@@ -197,10 +199,51 @@ func TestMeta(t *testing.T) {
 	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 	for i := 0; i < 20; i++ {
 		name := fmt.Sprintf("random-%03d", i)
+		names = append(names, name)
 		t.Run(name, func(t *testing.T) {
 			runOptions(t, randomOptions(rng))
 		})
 	}
 
-	// TODO(peter): Compare the output from the runs.
+	// Don't bother comparing output if we've already failed.
+	if t.Failed() {
+		return
+	}
+
+	if *compare {
+		// Read a history file, stripping out lines that begin with a comment.
+		readHistory := func(name string) []string {
+			historyPath := filepath.Join(metaDir, name, "history")
+			data, err := ioutil.ReadFile(historyPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			lines := difflib.SplitLines(string(data))
+			newLines := make([]string, 0, len(lines))
+			for _, line := range lines {
+				if strings.HasPrefix(line, "// ") {
+					continue
+				}
+				newLines = append(newLines, line)
+			}
+			return newLines
+		}
+
+		base := readHistory(names[0])
+		for i := 1; i < len(names); i++ {
+			lines := readHistory(names[i])
+			diff := difflib.UnifiedDiff{
+				A:       base,
+				B:       lines,
+				Context: 5,
+			}
+			text, err := difflib.GetUnifiedDiffString(diff)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if text != "" {
+				t.Fatalf("diff %s/{%s,%s}\n%s\n", metaDir, names[0], names[1], text)
+			}
+		}
+	}
 }

--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -75,10 +75,12 @@ func testMetaRun(t *testing.T, runDir string) {
 		t.Fatal(err)
 	}
 	opts := &pebble.Options{}
-	if err := opts.Parse(string(optionsData), nil); err != nil {
+	if err := parseOptions(opts, string(optionsData)); err != nil {
 		t.Fatal(err)
 	}
 
+	// Always use our custom comparer which provides a Split method.
+	opts.Comparer = &comparer
 	// Use an archive cleaner to ease post-mortem debugging.
 	opts.Cleaner = base.ArchiveCleaner{}
 

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -48,7 +48,7 @@ type applyOp struct {
 func (o *applyOp) run(t *test, h *history) {
 	b := t.getBatch(o.batchID)
 	w := t.getWriter(o.writerID)
-	err := w.Apply(b, nil)
+	err := w.Apply(b, pebble.NoSync)
 	h.Recordf("%s // %v", o, err)
 	_ = b.Close()
 	t.clearObj(o.batchID)
@@ -82,7 +82,7 @@ type deleteOp struct {
 
 func (o *deleteOp) run(t *test, h *history) {
 	w := t.getWriter(o.writerID)
-	err := w.Delete(o.key, nil)
+	err := w.Delete(o.key, pebble.NoSync)
 	h.Recordf("%s // %v", o, err)
 }
 
@@ -99,7 +99,7 @@ type deleteRangeOp struct {
 
 func (o *deleteRangeOp) run(t *test, h *history) {
 	w := t.getWriter(o.writerID)
-	err := w.DeleteRange(o.start, o.end, nil)
+	err := w.DeleteRange(o.start, o.end, pebble.NoSync)
 	h.Recordf("%s // %v", o, err)
 }
 
@@ -116,7 +116,7 @@ type mergeOp struct {
 
 func (o *mergeOp) run(t *test, h *history) {
 	w := t.getWriter(o.writerID)
-	err := w.Merge(o.key, o.value, nil)
+	err := w.Merge(o.key, o.value, pebble.NoSync)
 	h.Recordf("%s // %v", o, err)
 }
 
@@ -133,7 +133,7 @@ type setOp struct {
 
 func (o *setOp) run(t *test, h *history) {
 	w := t.getWriter(o.writerID)
-	err := w.Set(o.key, o.value, nil)
+	err := w.Set(o.key, o.value, pebble.NoSync)
 	h.Recordf("%s // %v", o, err)
 }
 
@@ -179,7 +179,7 @@ type batchCommitOp struct {
 func (o *batchCommitOp) run(t *test, h *history) {
 	b := t.getBatch(o.batchID)
 	t.clearObj(o.batchID)
-	err := b.Commit(nil)
+	err := b.Commit(pebble.NoSync)
 	h.Recordf("%s // %v", o, err)
 }
 

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -393,7 +393,7 @@ func (o *iterSeekPrefixGEOp) run(t *test, h *history) {
 }
 
 func (o *iterSeekPrefixGEOp) String() string {
-	return fmt.Sprintf("%s.SetPrefixGE(%q)", o.iterID, o.key)
+	return fmt.Sprintf("%s.SeekPrefixGE(%q)", o.iterID, o.key)
 }
 
 // iterSeekLTOp models an Iterator.SeekLT operation.


### PR DESCRIPTION
Output comparison is currently disabled by default as it is finding
differences that appear to be due to bugs in Pebble.

Pass `pebble.NoSync` to the various write methods as we're not relying
on syncing and Pebble returns an error if you try to sync and the WAL is
disabled.

Fixes #408