### PR TITLE
internal/metamorphic: address a TODO in history logging

### DIFF
--- a/internal/metamorphic/history.go
+++ b/internal/metamorphic/history.go
@@ -5,8 +5,10 @@
 package metamorphic
 
 import (
+	"fmt"
 	"io"
 	"log"
+	"strings"
 
 	"github.com/cockroachdb/pebble"
 )
@@ -39,16 +41,25 @@ type historyLogger struct {
 	log *log.Logger
 }
 
+func (h *historyLogger) format(prefix, format string, args ...interface{}) string {
+	var buf strings.Builder
+	orig := fmt.Sprintf(format, args...)
+	for _, line := range strings.Split(strings.TrimSpace(orig), "\n") {
+		buf.WriteString(prefix)
+		buf.WriteString(line)
+		buf.WriteString("\n")
+	}
+	return buf.String()
+}
+
 // Infof implements the pebble.Logger interface. Note that the output is
 // commented.
 func (h *historyLogger) Infof(format string, args ...interface{}) {
-	// TODO(peter): Prefix every line with "// INFO:".
-	h.log.Printf("// INFO: "+format, args...)
+	_ = h.log.Output(2, h.format("// INFO: ", format, args...))
 }
 
 // Fatalf implements the pebble.Logger interface. Note that the output is
 // commented.
 func (h *historyLogger) Fatalf(format string, args ...interface{}) {
-	// TODO(peter): Prefix every line with "// FATAL:".
-	h.log.Printf("// FATAL: "+format, args...)
+	_ = h.log.Output(2, h.format("// FATAL: ", format, args...))
 }

--- a/internal/metamorphic/history_test.go
+++ b/internal/metamorphic/history_test.go
@@ -1,0 +1,28 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package metamorphic
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestHistoryLogger(t *testing.T) {
+	var buf bytes.Buffer
+	h := newHistory(&buf)
+	l := h.Logger()
+	l.Infof("hello\nworld\n")
+	l.Fatalf("hello\n\nworld")
+
+	expected := `// INFO: hello
+// INFO: world
+// FATAL: hello
+// FATAL: 
+// FATAL: world
+`
+	if actual := buf.String(); expected != actual {
+		t.Fatalf("expected\n%s\nbut found\n%s", expected, actual)
+	}
+}


### PR DESCRIPTION
Prefix all lines of `Infof` and `Fatalf` output with `// {INFO,FATAL}`.