### PR TITLE
vfs: implicitly sync wrapped file in syncingFile.Close

### DIFF
--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -29,8 +29,10 @@ flush db
 create: db/000004.log
 sync: db
 sync: db/000002.log
+sync: db/000002.log
 close: db/000002.log
 create: db/000005.sst
+sync: db/000005.sst
 sync: db/000005.sst
 close: db/000005.sst
 sync: db
@@ -48,8 +50,10 @@ flush db
 reuseForWrite: db/000002.log -> db/000006.log
 sync: db
 sync: db/000004.log
+sync: db/000004.log
 close: db/000004.log
 create: db/000007.sst
+sync: db/000007.sst
 sync: db/000007.sst
 close: db/000007.sst
 sync: db
@@ -68,14 +72,17 @@ open-dir: checkpoint1
 link: db/OPTIONS-000003 -> checkpoint1/OPTIONS-000003
 create: checkpoint1/MANIFEST-000001
 sync: checkpoint1/MANIFEST-000001
+sync: checkpoint1/MANIFEST-000001
 close: checkpoint1/MANIFEST-000001
 create: checkpoint1/CURRENT.000001.dbtmp
+sync: checkpoint1/CURRENT.000001.dbtmp
 sync: checkpoint1/CURRENT.000001.dbtmp
 close: checkpoint1/CURRENT.000001.dbtmp
 rename: checkpoint1/CURRENT.000001.dbtmp -> checkpoint1/CURRENT
 link: db/000005.sst -> checkpoint1/000005.sst
 link: db/000007.sst -> checkpoint1/000007.sst
 create: checkpoint1/000006.log
+sync: checkpoint1/000006.log
 sync: checkpoint1/000006.log
 close: checkpoint1/000006.log
 sync: checkpoint1
@@ -90,13 +97,16 @@ compact db
 reuseForWrite: db/000004.log -> db/000008.log
 sync: db
 sync: db/000006.log
+sync: db/000006.log
 close: db/000006.log
 create: db/000009.sst
+sync: db/000009.sst
 sync: db/000009.sst
 close: db/000009.sst
 sync: db
 sync: db/MANIFEST-000001
 create: db/000010.sst
+sync: db/000010.sst
 sync: db/000010.sst
 close: db/000010.sst
 sync: db

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -31,8 +31,10 @@ flush db
 create: wal/000004.log
 sync: wal
 sync: wal/000002.log
+sync: wal/000002.log
 close: wal/000002.log
 create: db/000005.sst
+sync: db/000005.sst
 sync: db/000005.sst
 close: db/000005.sst
 sync: db
@@ -50,8 +52,10 @@ compact db
 create: wal/000006.log
 sync: wal
 sync: wal/000004.log
+sync: wal/000004.log
 close: wal/000004.log
 create: db/000007.sst
+sync: db/000007.sst
 sync: db/000007.sst
 close: db/000007.sst
 sync: db
@@ -59,6 +63,7 @@ sync: db/MANIFEST-000001
 mkdir-all: wal/archive 0755
 rename: wal/000004.log -> wal/archive/000004.log
 create: db/000008.sst
+sync: db/000008.sst
 sync: db/000008.sst
 close: db/000008.sst
 sync: db

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -35,11 +35,13 @@ sync: wal/000002.log
 create: wal/000005.log
 sync: wal
 sync: wal/000002.log
+sync: wal/000002.log
 close: wal/000002.log
 [JOB 2] WAL created 000005
 [JOB 3] flushing to L0
 create: db/000006.sst
 [JOB 3] flushing: sstable created 000006
+sync: db/000006.sst
 sync: db/000006.sst
 close: db/000006.sst
 sync: db
@@ -60,11 +62,13 @@ sync: wal/000005.log
 reuseForWrite: wal/000002.log -> wal/000008.log
 sync: wal
 sync: wal/000005.log
+sync: wal/000005.log
 close: wal/000005.log
 [JOB 4] WAL created 000008 (recycled 000002)
 [JOB 5] flushing to L0
 create: db/000009.sst
 [JOB 5] flushing: sstable created 000009
+sync: db/000009.sst
 sync: db/000009.sst
 close: db/000009.sst
 sync: db
@@ -81,6 +85,7 @@ sync: db
 [JOB 6] compacting L0 [000006 000009] (1.6 K) + L6 [] (0 B)
 create: db/000011.sst
 [JOB 6] compacting: sstable created 000011
+sync: db/000011.sst
 sync: db/000011.sst
 close: db/000011.sst
 sync: db
@@ -106,11 +111,13 @@ sync: wal/000008.log
 reuseForWrite: wal/000005.log -> wal/000013.log
 sync: wal
 sync: wal/000008.log
+sync: wal/000008.log
 close: wal/000008.log
 [JOB 7] WAL created 000013 (recycled 000005)
 [JOB 8] flushing to L0
 create: db/000014.sst
 [JOB 8] flushing: sstable created 000014
+sync: db/000014.sst
 sync: db/000014.sst
 close: db/000014.sst
 sync: db
@@ -179,8 +186,10 @@ open-dir: checkpoint
 link: db/OPTIONS-000004 -> checkpoint/OPTIONS-000004
 create: checkpoint/MANIFEST-000017
 sync: checkpoint/MANIFEST-000017
+sync: checkpoint/MANIFEST-000017
 close: checkpoint/MANIFEST-000017
 create: checkpoint/CURRENT.000017.dbtmp
+sync: checkpoint/CURRENT.000017.dbtmp
 sync: checkpoint/CURRENT.000017.dbtmp
 close: checkpoint/CURRENT.000017.dbtmp
 rename: checkpoint/CURRENT.000017.dbtmp -> checkpoint/CURRENT
@@ -188,6 +197,7 @@ link: db/000014.sst -> checkpoint/000014.sst
 link: db/000016.sst -> checkpoint/000016.sst
 link: db/000011.sst -> checkpoint/000011.sst
 create: checkpoint/000013.log
+sync: checkpoint/000013.log
 sync: checkpoint/000013.log
 close: checkpoint/000013.log
 sync: checkpoint
@@ -199,6 +209,7 @@ pebble: file deletion disablement invariant violated
 
 close
 ----
+sync: wal/000013.log
 sync: wal/000013.log
 close: wal/000013.log
 close: db/MANIFEST-000017

--- a/vfs/syncing_file.go
+++ b/vfs/syncing_file.go
@@ -52,6 +52,14 @@ func NewSyncingFile(f File, opts SyncingFileOptions) File {
 	return s
 }
 
+// Close Syncs and Closes the wrapped file.
+func (f *syncingFile) Close() error {
+	if err := f.Sync(); err != nil {
+		return err
+	}
+	return f.File.Close()
+}
+
 // NB: syncingFile.Write is unsafe for concurrent use!
 func (f *syncingFile) Write(p []byte) (n int, err error) {
 	_ = f.preallocate(atomic.LoadInt64(&f.atomic.offset) + int64(n))


### PR DESCRIPTION
This commit changes a syncingFile's Close behavior to sync any unsynced bytes.
This reduces the amount of dirty data in the OS buffer cache.