### PR TITLE
add support for Metrics.{,Mem}Table.Zombie{Count,Size}

### DIFF
--- a/internal/manifest/testdata/version_edit_apply
+++ b/internal/manifest/testdata/version_edit_apply
@@ -16,6 +16,7 @@ edit
 2:
   1:[a#1,SET-b#2,SET]
   4:[c#3,SET-d#4,SET]
+zombies []
 
 apply
  L0
@@ -67,6 +68,7 @@ edit
   4:[b#0,SET-d#0,SET]
   1:[a#1,SET-c#2,SET]
   2:[c#3,SET-d#4,SET]
+zombies []
 
 
 apply
@@ -79,6 +81,7 @@ edit
 0:
   1:[a#1,SET-c#2,SET]
   4:[b#3,SET-d#5,SET]
+zombies []
 
 apply
  L0
@@ -86,6 +89,7 @@ apply
 ----
 0:
   1:[a#1,SET-c#2,SET]
+zombies []
 
 apply
  L2
@@ -112,6 +116,7 @@ edit
   5:[h#3,SET-j#4,SET]
   10:[j#3,SET-m#2,SET]
   2:[n#5,SET-q#3,SET]
+zombies [1 4]
 
 apply
 edit
@@ -123,3 +128,35 @@ edit
 2:
   6:[a#10,SET-a#7,SET]
   10:[j#3,SET-m#2,SET]
+zombies []
+
+# Verify that the zombies map is populated correctly.
+
+apply
+ L0
+  1:a.SET.1-b.SET.2
+ L1
+  2:c.SET.3-d.SET.4
+edit
+ delete
+  L0
+   1
+  L1
+   2
+----
+zombies [1 2]
+
+# Deletion of a non-existent table does not result in an entry in the
+# zombies map.
+
+apply
+ L0
+  1:a.SET.1-b.SET.2
+edit
+ delete
+  L0
+   2
+----
+0:
+  1:[a#1,SET-b#2,SET]
+zombies []

--- a/level_checker.go
+++ b/level_checker.go
@@ -422,9 +422,7 @@ type CheckLevelsStats struct {
 func (d *DB) CheckLevels(stats *CheckLevelsStats) error {
 	// Grab and reference the current readState.
 	readState := d.loadReadState()
-	defer func() {
-		readState.unref()
-	}()
+	defer readState.unref()
 
 	// Determine the seqnum to read at after grabbing the read state (current and
 	// memtables) above.

--- a/metrics.go
+++ b/metrics.go
@@ -134,6 +134,19 @@ type Metrics struct {
 		Size uint64
 		// The count of memtables.
 		Count int64
+		// The number of bytes present in zombie memtables which are no longer
+		// referenced by the current DB state but are still in use by an iterator.
+		ZombieSize uint64
+		// The count of zombie memtables.
+		ZombieCount int64
+	}
+
+	Table struct {
+		// The number of bytes present in zombie tables which are no longer
+		// referenced by the current DB state but are still in use by an iterator.
+		ZombieSize uint64
+		// The count of zombie tables.
+		ZombieCount int64
 	}
 
 	TableCache CacheMetrics
@@ -194,6 +207,8 @@ func (m *Metrics) formatWAL(buf *bytes.Buffer) {
 //     flush         3
 //   compact         1   1.6 K          (size == estimated-debt)
 //    memtbl         1   4.0 M
+//   zmemtbl         0     0 B
+//      ztbl         0     0 B
 //    bcache         4   752 B    7.7%  (score == hit-rate)
 //    tcache         0     0 B    0.0%  (score == hit-rate)
 //    titers         0
@@ -235,6 +250,12 @@ func (m *Metrics) String() string {
 	fmt.Fprintf(&buf, " memtbl %9d %7s\n",
 		m.MemTable.Count,
 		humanize.IEC.Uint64(m.MemTable.Size))
+	fmt.Fprintf(&buf, "zmemtbl %9d %7s\n",
+		m.MemTable.ZombieCount,
+		humanize.IEC.Uint64(m.MemTable.ZombieSize))
+	fmt.Fprintf(&buf, "   ztbl %9d %7s\n",
+		m.Table.ZombieCount,
+		humanize.IEC.Uint64(m.Table.ZombieSize))
 	formatCacheMetrics(&buf, &m.BlockCache, "bcache")
 	formatCacheMetrics(&buf, &m.TableCache, "tcache")
 	fmt.Fprintf(&buf, " titers %9d\n", m.TableIters)

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -4,7 +4,14 @@
 
 package pebble
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/cockroachdb/pebble/vfs"
+)
 
 func TestMetricsFormat(t *testing.T) {
 	var m Metrics
@@ -19,16 +26,20 @@ func TestMetricsFormat(t *testing.T) {
 	m.Filter.Misses = 9
 	m.MemTable.Size = 10
 	m.MemTable.Count = 11
-	m.TableCache.Size = 12
-	m.TableCache.Count = 13
-	m.TableCache.Hits = 14
-	m.TableCache.Misses = 15
-	m.TableIters = 16
-	m.WAL.Files = 17
-	m.WAL.ObsoleteFiles = 18
-	m.WAL.Size = 19
-	m.WAL.BytesIn = 20
-	m.WAL.BytesWritten = 21
+	m.MemTable.ZombieSize = 12
+	m.MemTable.ZombieCount = 13
+	m.Table.ZombieSize = 14
+	m.Table.ZombieCount = 15
+	m.TableCache.Size = 16
+	m.TableCache.Count = 17
+	m.TableCache.Hits = 18
+	m.TableCache.Misses = 19
+	m.TableIters = 20
+	m.WAL.Files = 21
+	m.WAL.ObsoleteFiles = 22
+	m.WAL.Size = 23
+	m.WAL.BytesIn = 24
+	m.WAL.BytesWritten = 25
 
 	for i := range m.Levels {
 		l := &m.Levels[i]
@@ -49,7 +60,7 @@ func TestMetricsFormat(t *testing.T) {
 
 	const expected = `
 __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___w-amp
-    WAL        17    19 B       -    20 B       -       -       -       -    21 B       -       -     1.1
+    WAL        21    23 B       -    24 B       -       -       -       -    25 B       -       -     1.0
       0       101   102 B  103.00   104 B   104 B     111   106 B     112   108 B     219   107 B     1.0
       1       201   202 B  203.00   204 B   204 B     211   206 B     212   208 B     419   207 B     1.0
       2       301   302 B  303.00   304 B   304 B     311   306 B     312   308 B     619   307 B     1.0
@@ -61,12 +72,99 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   flush         7
 compact         5     6 B          (size == estimated-debt)
  memtbl        11    10 B
+zmemtbl        13    12 B
+   ztbl        15    14 B
  bcache         2     1 B   42.9%  (score == hit-rate)
- tcache        13    12 B   48.3%  (score == hit-rate)
- titers        16
+ tcache        17    16 B   48.6%  (score == hit-rate)
+ titers        20
  filter         -       -   47.1%  (score == utility)
 `
 	if s := "\n" + m.String(); expected != s {
 		t.Fatalf("expected%s\nbut found%s", expected, s)
 	}
+}
+
+func TestMetrics(t *testing.T) {
+	d, err := Open("", &Options{
+		FS: vfs.NewMem(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	iters := make(map[string]*Iterator)
+
+	datadriven.RunTest(t, "testdata/metrics", func(td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "batch":
+			b := d.NewBatch()
+			if err := runBatchDefineCmd(td, b); err != nil {
+				return err.Error()
+			}
+			b.Commit(nil)
+			return ""
+
+		case "compact":
+			if err := runCompactCommand(td, d); err != nil {
+				return err.Error()
+			}
+
+			d.mu.Lock()
+			s := d.mu.versions.currentVersion().DebugString(base.DefaultFormatter)
+			d.mu.Unlock()
+			return s
+
+		case "flush":
+			if err := d.Flush(); err != nil {
+				return err.Error()
+			}
+
+			d.mu.Lock()
+			s := d.mu.versions.currentVersion().DebugString(base.DefaultFormatter)
+			d.mu.Unlock()
+			return s
+
+		case "iter-close":
+			if len(td.CmdArgs) != 1 {
+				return "iter-close <name>"
+			}
+			name := td.CmdArgs[0].String()
+			if iter := iters[name]; iter != nil {
+				if err := iter.Close(); err != nil {
+					return err.Error()
+				}
+				delete(iters, name)
+			} else {
+				return fmt.Sprintf("%s: not found", name)
+			}
+
+			// The deletion of obsolete files happens asynchronously when an iterator
+			// is closed. Wait for the obsolete tables to be deleted. Note that
+			// waiting on cleaner.cond isn't precisely correct.
+			d.mu.Lock()
+			for d.mu.cleaner.cleaning || len(d.mu.versions.obsoleteTables) > 0 {
+				d.mu.cleaner.cond.Wait()
+			}
+			d.mu.Unlock()
+			return ""
+
+		case "iter-new":
+			if len(td.CmdArgs) != 1 {
+				return "iter-new <name>"
+			}
+			name := td.CmdArgs[0].String()
+			if iter := iters[name]; iter != nil {
+				if err := iter.Close(); err != nil {
+					return err.Error()
+				}
+			}
+			iters[name] = d.NewIter(nil)
+			return ""
+
+		case "metrics":
+			return d.Metrics().String()
+
+		default:
+			return fmt.Sprintf("unknown command: %s", td.Cmd)
+		}
+	})
 }

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -159,6 +159,8 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   flush         3
 compact         1   1.6 K          (size == estimated-debt)
  memtbl         1   256 K
+zmemtbl         0     0 B
+   ztbl         0     0 B
  bcache         4   752 B    7.7%  (score == hit-rate)
  tcache         0     0 B    0.0%  (score == hit-rate)
  titers         0

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -1,0 +1,162 @@
+batch
+set a 1
+----
+
+iter-new a
+----
+
+flush
+----
+0:
+  5:[a#0,SET-a#0,SET]
+
+# iter b references both a memtable and sstable 5.
+
+iter-new b
+----
+
+metrics
+----
+__level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___w-amp
+    WAL         1    28 B       -    17 B       -       -       -       -    56 B       -       -     3.3
+      0         1   826 B    0.25    28 B     0 B       0     0 B       0   826 B       1     0 B    29.5
+      1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      2         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      3         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      4         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      6         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+  total         1   826 B       -    56 B     0 B       0     0 B       0   882 B       1     0 B    15.8
+  flush         1
+compact         0   826 B          (size == estimated-debt)
+ memtbl         1   256 K
+zmemtbl         1   256 K
+   ztbl         0     0 B
+ bcache         3   732 B    0.0%  (score == hit-rate)
+ tcache         1   688 B    0.0%  (score == hit-rate)
+ titers         1
+ filter         -       -    0.0%  (score == utility)
+
+batch
+set b 2
+----
+
+flush
+----
+0:
+  5:[a#0,SET-a#0,SET]
+  7:[b#1,SET-b#1,SET]
+
+# iter c references both a memtable and sstables 5 and 7.
+
+iter-new c
+----
+
+compact a-z
+----
+6:
+  8:[a#0,SET-b#0,SET]
+
+metrics
+----
+__level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___w-amp
+    WAL         1    28 B       -    34 B       -       -       -       -    84 B       -       -     2.5
+      0         0     0 B    0.00    56 B     0 B       0     0 B       0   1.6 K       2     0 B    29.5
+      1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      2         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      3         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      4         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      6         1   833 B    0.00   1.6 K     0 B       0     0 B       0   833 B       1   1.6 K     0.5
+  total         1   833 B       -    84 B     0 B       0     0 B       0   2.5 K       3   1.6 K    30.6
+  flush         2
+compact         1     0 B          (size == estimated-debt)
+ memtbl         1   256 K
+zmemtbl         2   512 K
+   ztbl         2   1.6 K
+ bcache         8   1.5 K   27.3%  (score == hit-rate)
+ tcache         2   1.3 K   60.0%  (score == hit-rate)
+ titers         3
+ filter         -       -    0.0%  (score == utility)
+
+# Closing iter a will release one of the zombie memtables.
+
+iter-close a
+----
+
+metrics
+----
+__level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___w-amp
+    WAL         1    28 B       -    34 B       -       -       -       -    84 B       -       -     2.5
+      0         0     0 B    0.00    56 B     0 B       0     0 B       0   1.6 K       2     0 B    29.5
+      1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      2         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      3         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      4         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      6         1   833 B    0.00   1.6 K     0 B       0     0 B       0   833 B       1   1.6 K     0.5
+  total         1   833 B       -    84 B     0 B       0     0 B       0   2.5 K       3   1.6 K    30.6
+  flush         2
+compact         1     0 B          (size == estimated-debt)
+ memtbl         1   256 K
+zmemtbl         1   256 K
+   ztbl         2   1.6 K
+ bcache         8   1.5 K   27.3%  (score == hit-rate)
+ tcache         2   1.3 K   60.0%  (score == hit-rate)
+ titers         3
+ filter         -       -    0.0%  (score == utility)
+
+# Closing iter c will release one of the zombie sstables. The other
+# zombie sstable is still referenced by iter b.
+
+iter-close c
+----
+
+metrics
+----
+__level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___w-amp
+    WAL         1    28 B       -    34 B       -       -       -       -    84 B       -       -     2.5
+      0         0     0 B    0.00    56 B     0 B       0     0 B       0   1.6 K       2     0 B    29.5
+      1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      2         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      3         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      4         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      6         1   833 B    0.00   1.6 K     0 B       0     0 B       0   833 B       1   1.6 K     0.5
+  total         1   833 B       -    84 B     0 B       0     0 B       0   2.5 K       3   1.6 K    30.6
+  flush         2
+compact         1     0 B          (size == estimated-debt)
+ memtbl         1   256 K
+zmemtbl         1   256 K
+   ztbl         1   826 B
+ bcache         4   753 B   27.3%  (score == hit-rate)
+ tcache         1   688 B   60.0%  (score == hit-rate)
+ titers         1
+ filter         -       -    0.0%  (score == utility)
+
+# Closing iter b will release the last zombie sstable and the last zombie memtable.
+
+iter-close b
+----
+
+metrics
+----
+__level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___w-amp
+    WAL         1    28 B       -    34 B       -       -       -       -    84 B       -       -     2.5
+      0         0     0 B    0.00    56 B     0 B       0     0 B       0   1.6 K       2     0 B    29.5
+      1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      2         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      3         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      4         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+      6         1   833 B    0.00   1.6 K     0 B       0     0 B       0   833 B       1   1.6 K     0.5
+  total         1   833 B       -    84 B     0 B       0     0 B       0   2.5 K       3   1.6 K    30.6
+  flush         2
+compact         1     0 B          (size == estimated-debt)
+ memtbl         1   256 K
+zmemtbl         0     0 B
+   ztbl         0     0 B
+ bcache         0     0 B   27.3%  (score == hit-rate)
+ tcache         0     0 B   60.0%  (score == hit-rate)
+ titers         0
+ filter         -       -    0.0%  (score == utility)

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -150,7 +150,7 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 			}
 
 			if cmp != nil {
-				v, err := bve.Apply(nil, cmp.Compare, m.fmtKey.fn)
+				v, _, err := bve.Apply(nil /* version */, cmp.Compare, m.fmtKey.fn)
 				if err != nil {
 					fmt.Fprintf(stdout, "%s\n", err)
 					return
@@ -226,7 +226,7 @@ func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
 				}
 				// TODO(sbhola): add option to Apply that reports all errors instead of
 				// one error.
-				newv, err := bve.Apply(v, cmp.Compare, m.fmtKey.fn)
+				newv, _, err := bve.Apply(v, cmp.Compare, m.fmtKey.fn)
 				if err != nil {
 					fmt.Fprintf(stdout, "%s: offset: %d err: %s\n",
 						arg, offset, err)

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -23,6 +23,8 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   flush         0
 compact         0   986 B          (size == estimated-debt)
  memtbl         2   768 K
+zmemtbl         0     0 B
+   ztbl         0     0 B
  bcache         0     0 B    0.0%  (score == hit-rate)
  tcache         0     0 B    0.0%  (score == hit-rate)
  titers         0


### PR DESCRIPTION
Add support for tracking zombie memtable and sstable counts and
sizes. Zombie {mem,ss}tables are those which are no longer referenced by
the current `readState`, but are still in use by an earlier
`readState` (i.e. inuse by an iterator).

Fix a bug where we weren't deleting obsolete sstables when an iterator
was closed until the next flush or compaction occurred.

Fixes #49