### PR TITLE
fix concurrent ingestion and compaction

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -367,10 +367,6 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 			return nil, err
 		}
 		d.updateReadStateLocked(nil)
-		for i := range ve.NewFiles {
-			meta := &ve.NewFiles[i].Meta
-			delete(d.mu.compact.pendingOutputs, meta.FileNum)
-		}
 	}
 
 	return d, nil

--- a/db.go
+++ b/db.go
@@ -258,12 +258,6 @@ type DB struct {
 			cond       sync.Cond
 			flushing   bool
 			compacting bool
-			// pendingOutputs is the set of sstables created by in-progress
-			// flushes/compactions.
-			//
-			// TODO(peter): This is likely unnecessary now that we're only scanning
-			// for obsolete files at open.
-			pendingOutputs map[uint64]struct{}
 			// The list of manual compactions. The next manual compaction to perform
 			// is at the start of the list. New entries are added to the end.
 			manual []*manualCompaction

--- a/event.go
+++ b/event.go
@@ -155,7 +155,8 @@ func (i ManifestDeleteInfo) String() string {
 // TableCreateInfo contains the info for a table creation event.
 type TableCreateInfo struct {
 	JobID int
-	// Reason is the reason for the table creation (flushing or compacting).
+	// Reason is the reason for the table creation: "compacting", "flushing", or
+	// "ingesting".
 	Reason  string
 	Path    string
 	FileNum uint64

--- a/ingest.go
+++ b/ingest.go
@@ -294,7 +294,9 @@ func ingestUpdateSeqNum(opts *Options, dirname string, seqNum uint64, meta []*fi
 	return nil
 }
 
-func ingestTargetLevel(cmp Compare, v *version, meta *fileMetadata) int {
+func ingestTargetLevel(
+	cmp Compare, v *version, compactions map[*compaction]struct{}, meta *fileMetadata,
+) int {
 	// Find the lowest level which does not have any files which overlap meta. We
 	// search from L0 to L6 looking for whether there are any files in the level
 	// which overlap meta. We want the "lowest" level (where lower means
@@ -309,6 +311,20 @@ func ingestTargetLevel(cmp Compare, v *version, meta *fileMetadata) int {
 	level := 1
 	for ; level < numLevels; level++ {
 		if len(v.Overlaps(level, cmp, meta.Smallest.UserKey, meta.Largest.UserKey)) != 0 {
+			break
+		}
+		overlaps := false
+		for c := range compactions {
+			if level != c.outputLevel {
+				continue
+			}
+			if cmp(meta.Smallest.UserKey, c.largest.UserKey) <= 0 &&
+				cmp(meta.Largest.UserKey, c.smallest.UserKey) >= 0 {
+				overlaps = true
+				break
+			}
+		}
+		if overlaps {
 			break
 		}
 	}
@@ -515,7 +531,7 @@ func (d *DB) ingestApply(jobID int, meta []*fileMetadata) (*versionEdit, error) 
 		// overlap any existing files in the level.
 		m := meta[i]
 		f := &ve.NewFiles[i]
-		f.Level = ingestTargetLevel(d.cmp, current, m)
+		f.Level = ingestTargetLevel(d.cmp, current, d.mu.compact.inProgress, m)
 		f.Meta = *m
 		levelMetrics := metrics[f.Level]
 		if levelMetrics == nil {

--- a/ingest.go
+++ b/ingest.go
@@ -383,20 +383,9 @@ func (d *DB) Ingest(paths []string) error {
 	for i := range paths {
 		pendingOutputs[i] = d.mu.versions.getNextFileNum()
 	}
-	for _, fileNum := range pendingOutputs {
-		d.mu.compact.pendingOutputs[fileNum] = struct{}{}
-	}
 	jobID := d.mu.nextJobID
 	d.mu.nextJobID++
 	d.mu.Unlock()
-
-	defer func() {
-		d.mu.Lock()
-		for _, fileNum := range pendingOutputs {
-			delete(d.mu.compact.pendingOutputs, fileNum)
-		}
-		d.mu.Unlock()
-	}()
 
 	// Load the metadata for all of the files being ingested. This step detects
 	// and elides empty sstables.

--- a/open.go
+++ b/open.go
@@ -70,6 +70,7 @@ func Open(dirname string, opts *Options) (*DB, error) {
 	d.mu.cleaner.cond.L = &d.mu.Mutex
 	d.mu.compact.cond.L = &d.mu.Mutex
 	d.mu.compact.pendingOutputs = make(map[uint64]struct{})
+	d.mu.compact.inProgress = make(map[*compaction]struct{})
 	d.mu.snapshots.init()
 	d.largeBatchThreshold = (d.opts.MemTableSize - int(d.mu.mem.mutable.emptySize)) / 2
 

--- a/open.go
+++ b/open.go
@@ -69,7 +69,6 @@ func Open(dirname string, opts *Options) (*DB, error) {
 	d.mu.mem.queue = append(d.mu.mem.queue, d.mu.mem.mutable)
 	d.mu.cleaner.cond.L = &d.mu.Mutex
 	d.mu.compact.cond.L = &d.mu.Mutex
-	d.mu.compact.pendingOutputs = make(map[uint64]struct{})
 	d.mu.compact.inProgress = make(map[*compaction]struct{})
 	d.mu.snapshots.init()
 	d.largeBatchThreshold = (d.opts.MemTableSize - int(d.mu.mem.mutable.emptySize)) / 2
@@ -395,18 +394,11 @@ func (d *DB) replayWAL(
 	} else {
 		c := newFlush(d.opts, d.mu.versions.currentVersion(),
 			1 /* base level */, toFlush, &d.bytesFlushed)
-		newVE, pendingOutputs, err := d.runCompaction(jobID, c, nilPacer)
+		newVE, _, err := d.runCompaction(jobID, c, nilPacer)
 		if err != nil {
 			return 0, err
 		}
 		ve.NewFiles = append(ve.NewFiles, newVE.NewFiles...)
-		// Strictly speaking, it's too early to delete from d.pendingOutputs, but
-		// we are replaying the log file, which happens before Open returns, so
-		// there is no possibility of deleteObsoleteFiles being called concurrently
-		// here.
-		for _, fileNum := range pendingOutputs {
-			delete(d.mu.compact.pendingOutputs, fileNum)
-		}
 		for i := range toFlush {
 			toFlush[i].readerUnref()
 		}

--- a/testdata/ingest_target_level
+++ b/testdata/ingest_target_level
@@ -39,3 +39,23 @@ i-m
 0
 2
 6
+
+define
+5: a-a c-c
+6: a-a c-c
+----
+
+target
+b-b
+----
+6
+
+define
+5: a-a c-c
+6: a-a c-c compact:a-c
+----
+
+target
+b-b
+----
+5


### PR DESCRIPTION
Previously, a concurrent ingestion and compaction could lead to
violation of the no-overlap invariant. This was due to ingestion not
accounting for in-progress compactions when determining the target level
for an ingestion. We now keep track of in-progress flushes and
compactions and prohibit ingestion into a compaction's output level if
the ingested sstables overlaps the key-range of the compaction.