### PR TITLE
disable compaction/flush pacing

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -597,6 +597,7 @@ func TestCompaction(t *testing.T) {
 		FS:           mem,
 		MemTableSize: memTableSize,
 		DebugCheck:   true,
+		enablePacing: true,
 	})
 	if err != nil {
 		t.Fatalf("Open: %v", err)

--- a/options.go
+++ b/options.go
@@ -374,6 +374,11 @@ type Options struct {
 	// TODO(peter): rather than a closure, should there be another mechanism for
 	// changing options dynamically?
 	WALMinSyncInterval func() time.Duration
+
+	// TODO(peter): A private option to enable flush/compaction pacing. Only used
+	// by tests. Compaction/flush pacing is disabled until we fix the impact on
+	// throughput.
+	enablePacing bool
 }
 
 // EnsureDefaults ensures that the default values for all options are set if a


### PR DESCRIPTION
Disable compaction/flush pacing until we understand why it so
significantly impacts throughput.

```
name                    old ops/sec  new ops/sec  delta
kv0/enc=false/nodes=1    15.2k ± 6%   16.5k ± 6%   +9.09%  (p=0.000 n=20+19)
```