### PR TITLE
stop zeroing merge seqnum above range tombstones

### DIFF
--- a/compaction_iter_test.go
+++ b/compaction_iter_test.go
@@ -52,6 +52,7 @@ func TestCompactionIter(t *testing.T) {
 	var vals [][]byte
 	var snapshots []uint64
 	var elideTombstones bool
+	var allowZeroSeqnum bool
 
 	newIter := func() *compactionIter {
 		return newCompactionIter(
@@ -60,7 +61,7 @@ func TestCompactionIter(t *testing.T) {
 			&fakeIter{keys: keys, vals: vals},
 			snapshots,
 			&rangedel.Fragmenter{},
-			false, /* allowZeroSeqNum */
+			allowZeroSeqnum,
 			func([]byte) bool {
 				return elideTombstones
 			},
@@ -98,6 +99,12 @@ func TestCompactionIter(t *testing.T) {
 				case "elide-tombstones":
 					var err error
 					elideTombstones, err = strconv.ParseBool(arg.Vals[0])
+					if err != nil {
+						return err.Error()
+					}
+				case "allow-zero-seqnum":
+					var err error
+					allowZeroSeqnum, err = strconv.ParseBool(arg.Vals[0])
 					if err != nil {
 						return err.Error()
 					}

--- a/testdata/compaction_iter
+++ b/testdata/compaction_iter
@@ -991,3 +991,23 @@ b#1,15:c
 .
 b-c#1
 .
+
+define
+a.MERGE.2:v2
+a.RANGEDEL.1:b
+a.MERGE.1:v1
+----
+
+iter allow-zero-seqnum=true
+first
+next
+next
+next
+tombstones
+----
+a#2,2:v2
+a#1,15:b
+a#0,2:v1
+.
+a-b#1
+.


### PR DESCRIPTION
If a merge ends by hitting a range tombstone, there may still be unmerged
operands for that key. Those yet-to-be-merged operands will have their
seqnum zeroed, so we cannot zero the seqnum of the present merge result.
