### PR TITLE
add the "go 1.13" declaration to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,3 +14,5 @@ require (
 	golang.org/x/exp v0.0.0-20190426190305-956cc1757749
 	golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa
 )
+
+go 1.13


### PR DESCRIPTION
Apparently this declaration is harmless. Older versions of Go will
ignore it and there is still active discussion over what the semantics
would be.