### PR TITLE
db: verify returned levelIter keys lie within iterator bounds

### DIFF
--- a/db.go
+++ b/db.go
@@ -652,6 +652,7 @@ func (d *DB) newIterInternal(
 	if o != nil {
 		dbi.opts = *o
 	}
+	dbi.opts.logger = d.opts.Logger
 
 	mlevels := buf.mlevels[:0]
 	if batchIter != nil {

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -295,7 +295,6 @@ func testIterator(
 		if j != len(testKeyValuePairs) {
 			bad = true
 			t.Errorf("random splits: i=%d, j=%d: want j=%d", i, j, len(testKeyValuePairs))
-			fmt.Printf("splits: %v\n", splits)
 			return
 		}
 		if err := iter.Close(); err != nil {

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -28,6 +28,8 @@ func TestLevelIter(t *testing.T) {
 		meta *fileMetadata, opts *IterOptions, bytesIterated *uint64,
 	) (internalIterator, internalIterator, error) {
 		f := *iters[meta.FileNum]
+		f.lower = opts.GetLowerBound()
+		f.upper = opts.GetUpperBound()
 		return &f, nil, nil
 	}
 
@@ -74,7 +76,9 @@ func TestLevelIter(t *testing.T) {
 
 			iter := newLevelIter(&opts, DefaultComparer.Compare, newIters, files, nil)
 			defer iter.Close()
-			return runInternalIterCmd(d, iter)
+			// Fake up the range deletion initialization.
+			iter.initRangeDel(new(internalIterator))
+			return runInternalIterCmd(d, iter, iterCmdVerboseKey)
 
 		case "load":
 			// The "load" command allows testing the iterator options passed to load

--- a/options.go
+++ b/options.go
@@ -73,6 +73,9 @@ type IterOptions struct {
 	// iteration based on the user properties. Return true to scan the table and
 	// false to skip scanning.
 	TableFilter func(userProps map[string]string) bool
+
+	// Internal options.
+	logger Logger
 }
 
 // GetLowerBound returns the LowerBound or nil if the receiver is nil.
@@ -89,6 +92,13 @@ func (o *IterOptions) GetUpperBound() []byte {
 		return nil
 	}
 	return o.UpperBound
+}
+
+func (o *IterOptions) getLogger() Logger {
+	if o == nil || o.logger == nil {
+		return DefaultLogger
+	}
+	return o.logger
 }
 
 // WriteOptions hold the optional per-query parameters for Set and Delete

--- a/testdata/level_iter
+++ b/testdata/level_iter
@@ -448,7 +448,7 @@ set-bounds lower=e
 next
 ----
 c#3,1:3
-d#4,1:4
+.
 
 # The lower bound lies within the current table's bounds.
 
@@ -468,7 +468,7 @@ set-bounds upper=c
 prev
 ----
 d#4,1:4
-c#3,1:3
+.
 
 # The upper bound lies within the current table's bounds.
 

--- a/testdata/level_iter
+++ b/testdata/level_iter
@@ -12,11 +12,11 @@ next
 next
 next
 ----
-a:1
-b:2
-c:3
-d:4
-dd:5
+a#1,1:1
+b#2,1:2
+c#3,1:3
+d#4,1:4
+dd#5,1:5
 .
 
 iter
@@ -26,10 +26,10 @@ next
 next
 next
 ----
-b:2
-c:3
-d:4
-dd:5
+b#2,1:2
+c#3,1:3
+d#4,1:4
+dd#5,1:5
 .
 
 iter
@@ -38,9 +38,9 @@ next
 next
 next
 ----
-c:3
-d:4
-dd:5
+c#3,1:3
+d#4,1:4
+dd#5,1:5
 .
 
 iter
@@ -48,15 +48,15 @@ seek-ge d
 next
 next
 ----
-d:4
-dd:5
+d#4,1:4
+dd#5,1:5
 .
 
 iter
 seek-ge dd
 next
 ----
-dd:5
+dd#5,1:5
 .
 
 iter
@@ -73,7 +73,7 @@ iter
 seek-lt b
 prev
 ----
-a:1
+a#1,1:1
 .
 
 iter
@@ -81,8 +81,8 @@ seek-lt c
 prev
 prev
 ----
-b:2
-a:1
+b#2,1:2
+a#1,1:1
 .
 
 iter
@@ -91,9 +91,9 @@ prev
 prev
 prev
 ----
-c:3
-b:2
-a:1
+c#3,1:3
+b#2,1:2
+a#1,1:1
 .
 
 iter
@@ -104,34 +104,34 @@ prev
 prev
 prev
 ----
-dd:5
-d:4
-c:3
-b:2
-a:1
+dd#5,1:5
+d#4,1:4
+c#3,1:3
+b#2,1:2
+a#1,1:1
 .
 
 iter
 seek-prefix-ge a
 next
 ----
-a:1
-b:2
+a#1,1:1
+b#2,1:2
 
 iter
 seek-prefix-ge d
 next
 next
 ----
-d:4
-dd:5
+d#4,1:4
+dd#5,1:5
 .
 
 iter
 seek-prefix-ge dd
 next
 ----
-dd:5
+dd#5,1:5
 .
 
 iter
@@ -140,39 +140,39 @@ next
 prev
 prev
 ----
-d:4
-dd:5
-d:4
-c:3
+d#4,1:4
+dd#5,1:5
+d#4,1:4
+c#3,1:3
 
 iter
 seek-prefix-ge d
 prev
 ----
-d:4
-c:3
+d#4,1:4
+c#3,1:3
 
 iter
 seek-prefix-ge dd
 prev
 ----
-dd:5
-d:4
+dd#5,1:5
+d#4,1:4
 
 iter lower=a
 seek-ge a
 first
 ----
-a:1
-a:1
+a#1,1:1
+a#1,1:1
 
 iter
 set-bounds lower=a
 seek-ge a
 first
 ----
-a:1
-a:1
+a#1,1:1
+a#1,1:1
 
 iter
 set-bounds lower=dd upper=f
@@ -185,10 +185,10 @@ prev
 prev
 ----
 .
-d:4
-c:3
-b:2
-a:1
+d#4,1:4
+c#3,1:3
+b#2,1:2
+a#1,1:1
 .
 
 iter
@@ -201,9 +201,9 @@ next
 next
 ----
 .
-c:3
-d:4
-dd:5
+c#3,1:3
+d#4,1:4
+dd#5,1:5
 .
 
 # levelIter trims lower/upper bound in the options passed to sstables.
@@ -211,9 +211,9 @@ load a
 ----
 [,]
 
-load b lower=aa upper=b
+load b lower=aa upper=bb
 ----
-[aa,b]
+[aa,]
 
 load b lower=aa upper=c
 ----
@@ -232,39 +232,39 @@ iter lower=b
 seek-ge a
 first
 ----
-a:1
-a:1
+a#1,1:1
+a#1,1:1
 
 iter lower=c
 seek-ge a
 first
 ----
-c:3
-c:3
+c#3,1:3
+c#3,1:3
 
 iter
 set-bounds lower=b
 seek-ge a
 first
 ----
-a:1
-a:1
+a#1,1:1
+a#1,1:1
 
 iter
 set-bounds lower=c
 seek-ge a
 first
 ----
-c:3
-c:3
+c#3,1:3
+c#3,1:3
 
 # levelIter only checks lower bound when loading sstables.
 iter lower=d
 seek-ge a
 first
 ----
-c:3
-c:3
+c#3,1:3
+c#3,1:3
 
 iter lower=e
 seek-ge a
@@ -277,16 +277,16 @@ iter upper=e
 seek-lt e
 last
 ----
-dd:5
-dd:5
+dd#5,1:5
+dd#5,1:5
 
 iter
 set-bounds lower=d
 seek-ge a
 first
 ----
-c:3
-c:3
+c#3,1:3
+c#3,1:3
 
 iter
 set-bounds lower=e
@@ -301,47 +301,47 @@ set-bounds upper=e
 seek-lt e
 last
 ----
-dd:5
-dd:5
+dd#5,1:5
+dd#5,1:5
 
 # levelIter only checks upper bound when loading sstables.
 iter upper=d
 seek-lt e
 last
 ----
-d:4
-d:4
+d#4,1:4
+d#4,1:4
 
 iter upper=c
 seek-lt e
 last
 ----
-b:2
-b:2
+b#2,1:2
+b#2,1:2
 
 iter
 set-bounds upper=d
 seek-lt e
 last
 ----
-d:4
-d:4
+d#4,1:4
+d#4,1:4
 
 iter
 set-bounds upper=c
 seek-lt e
 last
 ----
-b:2
-b:2
+b#2,1:2
+b#2,1:2
 
-# levelIter only checks lower bound when loading sstables.
+# levelIter only checks upper bound when loading sstables.
 iter upper=b
 seek-lt e
 last
 ----
-b:2
-b:2
+b#2,1:2
+b#2,1:2
 
 iter upper=a
 seek-lt e
@@ -354,7 +354,7 @@ iter upper=dd
 seek-prefix-ge d
 next
 ----
-d:4
+d#4,1:4
 .
 
 iter
@@ -362,8 +362,8 @@ set-bounds upper=b
 seek-lt e
 last
 ----
-b:2
-b:2
+b#2,1:2
+b#2,1:2
 
 iter
 set-bounds upper=a
@@ -378,7 +378,7 @@ set-bounds upper=dd
 seek-prefix-ge d
 next
 ----
-d:4
+d#4,1:4
 .
 
 iter upper=e
@@ -386,30 +386,30 @@ seek-prefix-ge d
 next
 next
 ----
-d:4
-dd:5
+d#4,1:4
+dd#5,1:5
 .
 
 iter lower=dd
 seek-prefix-ge d
 next
 ----
-dd:5
+dd#5,1:5
 .
 
 iter lower=d
 seek-prefix-ge dd
 prev
 ----
-dd:5
-d:4
+dd#5,1:5
+d#4,1:4
 
 iter lower=c
 seek-prefix-ge dd
 prev
 ----
-dd:5
-d:4
+dd#5,1:5
+d#4,1:4
 
 iter lower=c
 seek-lt c
@@ -421,7 +421,7 @@ seek-lt c
 set-bounds lower=c
 seek-lt c
 ----
-b:2
+b#2,1:2
 .
 
 iter upper=c
@@ -434,5 +434,67 @@ seek-ge c
 set-bounds upper=c
 seek-ge c
 ----
-c:3
+c#3,1:3
 .
+
+# The behavior of next/prev after set-bounds is undefined. We're just
+# asserting the current behavior.
+
+# The lower bound is beyond the current table's bounds.
+
+iter
+seek-ge c
+set-bounds lower=e
+next
+----
+c#3,1:3
+d#4,1:4
+
+# The lower bound lies within the current table's bounds.
+
+iter
+seek-ge c
+set-bounds lower=d
+next
+----
+c#3,1:3
+d#4,1:4
+
+# The upper bound is before the current table's bounds.
+
+iter
+seek-ge d
+set-bounds upper=c
+prev
+----
+d#4,1:4
+c#3,1:3
+
+# The upper bound lies within the current table's bounds.
+
+iter
+seek-ge d
+set-bounds upper=cc
+prev
+----
+d#4,1:4
+c#3,1:3
+
+# Setting bounds should update the table bounds, allowing a subsequent
+# seek-ge/seek-lt to see the boundary keys.
+
+iter
+seek-ge d
+set-bounds lower=cc
+seek-lt d
+----
+d#4,1:4
+c#3,15:
+
+iter
+seek-ge c
+set-bounds upper=cc
+seek-ge d
+----
+c#3,1:3
+d#4,15:

--- a/testdata/level_iter_boundaries
+++ b/testdata/level_iter_boundaries
@@ -176,3 +176,54 @@ c#2,15:
 d#3,1:d
 c#2,15:
 d#3,1:d
+
+# Regression test to check that Seek{GE,LT}, First, and Last properly
+# reset the iteration upper bound when levelIter had previously set it
+# to a sentinel value during SeekPrefixGE.
+
+clear
+----
+
+build
+b.SET.4:b
+d.SET.3:d
+----
+0: b#4,1-d#3,1
+
+iter
+seek-prefix-ge c
+seek-ge d
+next
+----
+d#3,15:
+d#3,1:d
+.
+
+iter
+seek-prefix-ge c
+seek-lt e
+next
+----
+d#3,15:
+d#3,1:d
+.
+
+iter
+seek-prefix-ge c
+first
+next
+next
+----
+d#3,15:
+b#4,1:b
+d#3,1:d
+.
+
+iter
+seek-prefix-ge c
+last
+next
+----
+d#3,15:
+d#3,1:d
+.

--- a/testdata/level_iter_boundaries
+++ b/testdata/level_iter_boundaries
@@ -177,9 +177,12 @@ d#3,1:d
 c#2,15:
 d#3,1:d
 
-# Regression test to check that Seek{GE,LT}, First, and Last properly
-# reset the iteration upper bound when levelIter had previously set it
-# to a sentinel value during SeekPrefixGE.
+# Regression test to check that Seek{GE,LT}, First, and Last do not
+# have iteration bounds affected by SeekPrefixGE. Previously,
+# SeekPrefixGE adjusted the iteration upper bound which would leak
+# over to other positioning operations. While SeekPrefixGE no longer
+# has this behavior, it is good to check the iteration bounds handling
+# regardless.
 
 clear
 ----


### PR DESCRIPTION
Added `levelIter.verify` which is a race-build-only verification that
the returned key lies within the iterator bounds. Verified that this
structure of `if raceEnabled` gets compiled out of existence for
non-race builds and doesn't impact performance. `levelIter.verify` is
currently disabled as it exposes bugs in `mergingIter` bounds
handling. Those will be fixed in a subsequent change.

Fixed resetting of the table iter boundaries in
`levelIter.SetBounds()`. This was preventing a subsequent positioning
call from correctly encountering the boundary key.

Fixes #395