### PR TITLE
db: various fixes to mergingIter iter bounds handling

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -601,7 +601,7 @@ func (c *compaction) newInputIter(newIters tableNewIters) (_ internalIterator, r
 			f := c.flushing[0]
 			iter := f.newFlushIter(nil, &c.bytesIterated)
 			if rangeDelIter := f.newRangeDelIter(nil); rangeDelIter != nil {
-				return newMergingIter(c.cmp, iter, rangeDelIter), nil
+				return newMergingIter(c.logger, c.cmp, iter, rangeDelIter), nil
 			}
 			return iter, nil
 		}
@@ -614,7 +614,7 @@ func (c *compaction) newInputIter(newIters tableNewIters) (_ internalIterator, r
 				iters = append(iters, rangeDelIter)
 			}
 		}
-		return newMergingIter(c.cmp, iters...), nil
+		return newMergingIter(c.logger, c.cmp, iters...), nil
 	}
 
 	// Check that the LSM ordering invariants are ok in order to prevent
@@ -694,7 +694,7 @@ func (c *compaction) newInputIter(newIters tableNewIters) (_ internalIterator, r
 
 	iters = append(iters, newLevelIter(nil, c.cmp, newIters, c.inputs[1], &c.bytesIterated))
 	iters = append(iters, newLevelIter(nil, c.cmp, newRangeDelIter, c.inputs[1], &c.bytesIterated))
-	return newMergingIter(c.cmp, iters...), nil
+	return newMergingIter(c.logger, c.cmp, iters...), nil
 }
 
 func (c *compaction) String() string {

--- a/db.go
+++ b/db.go
@@ -686,7 +686,7 @@ func (d *DB) newIterInternal(
 		if err != nil {
 			// Ensure the mergingIter is initialized so Iterator.Close will properly
 			// close any sstable iterators that have been opened.
-			buf.merging.init(d.cmp, mlevels...)
+			buf.merging.init(&dbi.opts, d.cmp, mlevels...)
 			dbi.err = err
 			return dbi
 		}
@@ -732,7 +732,7 @@ func (d *DB) newIterInternal(
 		mlevels = mlevels[1:]
 	}
 
-	buf.merging.init(d.cmp, finalMLevels...)
+	buf.merging.init(&dbi.opts, d.cmp, finalMLevels...)
 	buf.merging.snapshot = seqNum
 	return dbi
 }

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -320,7 +320,7 @@ func TestIterator(t *testing.T) {
 		equal := DefaultComparer.Equal
 		split := func(a []byte) int { return len(a) }
 		// NB: Use a mergingIter to filter entries newer than seqNum.
-		iter := newMergingIter(cmp, &fakeIter{
+		iter := newMergingIter(nil /* logger */, cmp, &fakeIter{
 			lower: opts.GetLowerBound(),
 			upper: opts.GetUpperBound(),
 			keys:  keys,

--- a/level_iter.go
+++ b/level_iter.go
@@ -493,6 +493,12 @@ func (l *levelIter) skipEmptyFileForward() (*InternalKey, []byte) {
 			// bound).
 			f := &l.files[l.index]
 			if l.tableOpts.UpperBound != nil {
+				// TODO(peter): Rather than using f.Largest, can we use
+				// l.tableOpts.UpperBound and set the seqnum to 0? We know the upper
+				// bound resides within the table boundaries. Not clear if this is
+				// kosher with respect to the invariant that only one record for a
+				// given user key will have seqnum 0. See Iterator.nextUserKey for an
+				// optimization that requires this.
 				l.syntheticBoundary = f.Largest
 				l.syntheticBoundary.SetKind(InternalKeyKindRangeDelete)
 				l.largestBoundary = &l.syntheticBoundary
@@ -544,6 +550,9 @@ func (l *levelIter) skipEmptyFileBackward() (*InternalKey, []byte) {
 			// bound).
 			f := &l.files[l.index]
 			if l.tableOpts.LowerBound != nil {
+				// TODO(peter): Rather than using f.Smallest, can we use
+				// l.tableOpts.LowerBound and set the seqnum to InternalKeySeqNumMax?
+				// We know the lower bound resides within the table boundaries.
 				l.syntheticBoundary = f.Smallest
 				l.syntheticBoundary.SetKind(InternalKeyKindRangeDelete)
 				l.smallestBoundary = &l.syntheticBoundary

--- a/merging_iter_heap.go
+++ b/merging_iter_heap.go
@@ -20,6 +20,10 @@ func (h *mergingIterHeap) len() int {
 	return len(h.items)
 }
 
+func (h *mergingIterHeap) clear() {
+	h.items = h.items[:0]
+}
+
 func (h *mergingIterHeap) less(i, j int) bool {
 	ikey, jkey := h.items[i].key, h.items[j].key
 	if c := h.cmp(ikey.UserKey, jkey.UserKey); c != 0 {

--- a/testdata/merging_iter
+++ b/testdata/merging_iter
@@ -18,10 +18,10 @@ L
 e.SET.10 g.SET.20
 e.SET.10:10 g.SET.20:20 e.RANGEDEL.8:f
 ----
-Level 1
-  file 0: [a#30,1-e#72057594037927935,15]
-Level 2
-  file 0: [e#10,1-g#20,1]
+1:
+  0:[a#30,SET-e#72057594037927935,RANGEDEL]
+2:
+  1:[e#10,SET-g#20,SET]
 
 # isNextEntryDeleted() should not allow the rangedel to act on the points in the lower sstable
 # that are after it.
@@ -84,10 +84,10 @@ L
 e.SET.10 g.SET.15
 e.SET.10:10 g.SET.15:15
 ----
-Level 1
-  file 0: [a#15,1-f#16,1]
-Level 2
-  file 0: [e#10,1-g#15,1]
+1:
+  2:[a#15,SET-f#16,SET]
+2:
+  3:[e#10,SET-g#15,SET]
 
 iter
 first
@@ -128,10 +128,10 @@ L
 a.SET.10 c.RANGEDEL.72057594037927935
 a.SET.10:10 b.SET.12:12 a.RANGEDEL.8:f
 ----
-Level 1
-  file 0: [c#30,1-f#0,15]
-Level 2
-  file 0: [a#10,1-c#72057594037927935,15]
+1:
+  4:[c#30,SET-f#0,RANGEDEL]
+2:
+  5:[a#10,SET-c#72057594037927935,RANGEDEL]
 
 # isNextEntryDeleted() should not allow the rangedel to act on the points in the lower sstable
 # that are before it.
@@ -194,10 +194,10 @@ L
 b.SET.14 d.SET.10
 b.SET.14:14 d.SET.10:10
 ----
-Level 1
-  file 0: [c#15,1-g#16,1]
-Level 2
-  file 0: [b#14,1-d#10,1]
+1:
+  6:[c#15,SET-g#16,SET]
+2:
+  7:[b#14,SET-d#10,SET]
 
 iter
 last
@@ -226,10 +226,10 @@ L
 e.SET.10 g.SET.20
 e.SET.10:10 g.SET.20:20 e.RANGEDEL.8:g
 ----
-Level 1
-  file 0: [a#30,1-e#72057594037927935,15]
-Level 2
-  file 0: [e#10,1-g#20,1]
+1:
+  8:[a#30,SET-e#72057594037927935,RANGEDEL]
+2:
+  9:[e#10,SET-g#20,SET]
 
 # When doing seek-lt f, the rangedel should not apply to e in the lower sstable. This is the
 # reason we cannot just use largest user key to constrain the rangedel and we need to
@@ -271,3 +271,114 @@ c#27,1:27
 e#72057594037927935,15:
 e#10,1:10
 g#20,1:20
+
+# Verify that switching directions respects lower/upper bound.
+
+define
+L
+a.SET.9 d.SET.6
+a.SET.9:9 b.SET.8:8 c.SET.7:7 d.SET.6:6
+----
+1:
+  10:[a#9,SET-d#6,SET]
+
+# Verify the lower bound is respected in switchToMinHeap() when the
+# heap is empty.
+
+iter
+set-bounds lower=c
+seek-ge c
+prev
+prev
+next
+----
+c#7,1:7
+a#9,15:
+.
+c#7,1:7
+
+# Verify the upper bound is respected in switchToMaxHeap() when the
+# heap is empty.
+
+iter
+set-bounds upper=c
+seek-lt c
+next
+next
+prev
+----
+b#8,1:8
+d#6,15:
+.
+b#8,1:8
+
+# Verify the lower bound is respected in switchToMinHeap() when the
+# heap is not empty.
+
+define
+L
+a.SET.9 d.SET.6
+a.SET.9:9 b.SET.8:8 c.SET.7:7 d.SET.6:6
+L
+c.SET.5 f.SET.2
+c.SET.5:5 d.SET.4:4 e.SET.3:3 f.SET.2:2
+----
+1:
+  11:[a#9,SET-d#6,SET]
+2:
+  12:[c#5,SET-f#2,SET]
+
+iter
+set-bounds lower=d
+seek-ge d
+prev
+prev
+next
+next
+----
+d#6,1:6
+c#5,15:
+a#9,15:
+d#6,1:6
+d#4,1:4
+
+# Check the behavior of reverse prefix iteration.
+
+iter
+seek-prefix-ge d
+prev
+next
+----
+d#6,1:6
+err=pebble: unsupported reverse prefix iteration
+err=pebble: unsupported reverse prefix iteration
+
+# Verify the upper bound is respected in switchToMaxHeap() when the
+# heap is not empty.
+
+define
+L
+c.SET.9 f.SET.6
+c.SET.9:9 d.SET.8:8 e.SET.7:7 f.SET.6:6
+L
+a.SET.5 d.SET.2
+a.SET.5:5 b.SET.4:4 c.SET.3:3 d.SET.2:2
+----
+1:
+  13:[c#9,SET-f#6,SET]
+2:
+  14:[a#5,SET-d#2,SET]
+
+iter
+set-bounds upper=d
+seek-lt d
+next
+next
+prev
+prev
+----
+c#3,1:3
+d#2,15:
+f#6,15:
+c#3,1:3
+c#9,1:9

--- a/testdata/merging_iter_seek
+++ b/testdata/merging_iter_seek
@@ -80,7 +80,7 @@ seek-prefix-ge a0
 prev
 ----
 a0:0
-.
+err=pebble: unsupported reverse prefix iteration
 
 iter
 seek-prefix-ge a0
@@ -196,31 +196,25 @@ seek-prefix-ge aa
 prev
 ----
 aa:1
-a:0
+err=pebble: unsupported reverse prefix iteration
 
 iter
 seek-prefix-ge aa
 next
 prev
-prev
 ----
 aa:1
 aaa:2
-aa:1
-a:0
+err=pebble: unsupported reverse prefix iteration
 
 iter
 seek-prefix-ge aa
 next
 prev
-next
-next
 ----
 aa:1
 aaa:2
-aa:1
-aaa:2
-b:3
+err=pebble: unsupported reverse prefix iteration
 
 iter
 seek-prefix-ge aaa
@@ -234,14 +228,14 @@ seek-prefix-ge aaa
 prev
 ----
 aaa:2
-aa:1
+err=pebble: unsupported reverse prefix iteration
 
 iter
 seek-prefix-ge b
 prev
 ----
 b:3
-aaa:2
+err=pebble: unsupported reverse prefix iteration
 
 iter
 seek-prefix-ge b


### PR DESCRIPTION
`mergingIter` was previously blindly calling `Seek{GE,LT},First,Last` and
disregarding supplied iterator bounds. This violated the
`InternalIterator` contract for these methods leading to various badness 
such as returning out of bounds keys which could in turn lead to iteration
stopping prematurely, making it seem like keys were missing.