### PR TITLE
db: ensure upper-bound is reset in levelIter.loadFile

### DIFF
--- a/db.go
+++ b/db.go
@@ -611,6 +611,7 @@ func (d *DB) newIterInternal(
 	if o != nil {
 		dbi.opts = *o
 	}
+	dbi.opts.logger = d.opts.Logger
 
 	mlevels := buf.mlevels[:0]
 	if batchIter != nil {

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -295,7 +295,6 @@ func testIterator(
 		if j != len(testKeyValuePairs) {
 			bad = true
 			t.Errorf("random splits: i=%d, j=%d: want j=%d", i, j, len(testKeyValuePairs))
-			fmt.Printf("splits: %v\n", splits)
 			return
 		}
 		if err := iter.Close(); err != nil {

--- a/level_iter.go
+++ b/level_iter.go
@@ -212,6 +212,17 @@ func (l *levelIter) loadFile(index, dir int) bool {
 			// We don't bother comparing the file bounds with the iteration bounds when we have
 			// an already open iterator. It is possible that the iter may not be relevant given the
 			// current iteration bounds, but it knows those bounds, so it will enforce them.
+			//
+			// We have to reset l.tableOpts.UpperBound here in case it was set to
+			// sentinelUpperBound by a previous call to SeekPrefixGE().
+			f := &l.files[l.index]
+			l.tableOpts.UpperBound = l.upper
+			if l.cmp(l.tableOpts.UpperBound, f.Largest.UserKey) > 0 {
+				// The upper bound is greater than the largest key in the
+				// table. Iteration within the table does not need to check the upper
+				// bound. NB: tableOpts.UpperBound is exclusive and f.Largest is inclusive.
+				l.tableOpts.UpperBound = nil
+			}
 			return true
 		}
 		// We were already at index, but don't have an iterator, probably because the file was

--- a/level_iter.go
+++ b/level_iter.go
@@ -4,7 +4,10 @@
 
 package pebble
 
-import "sort"
+import (
+	"runtime/debug"
+	"sort"
+)
 
 // tableNewIters creates a new point and range-del iterator for the given file
 // number. If bytesIterated is specified, it is incremented as the given file is
@@ -38,7 +41,9 @@ var sentinelUpperBound = make([]byte, 0)
 // kind InternalKeyKindRangeDeletion which will be used to pause the levelIter
 // at the sstable until the mergingIter is ready to advance past it.
 type levelIter struct {
-	opts      *IterOptions
+	logger    Logger
+	lower     []byte
+	upper     []byte
 	tableOpts IterOptions
 	cmp       Compare
 	// The current file wrt the iterator position.
@@ -138,9 +143,11 @@ func (l *levelIter) init(
 	files []fileMetadata,
 	bytesIterated *uint64,
 ) {
-	l.opts = opts
-	if l.opts != nil {
-		l.tableOpts.TableFilter = l.opts.TableFilter
+	l.logger = opts.getLogger()
+	if opts != nil {
+		l.lower = opts.LowerBound
+		l.upper = opts.UpperBound
+		l.tableOpts.TableFilter = opts.TableFilter
 	}
 	l.cmp = cmp
 	l.index = -1
@@ -211,18 +218,12 @@ func (l *levelIter) loadFile(index, dir int) bool {
 		// beyond the iteration bounds. It may still be, but it is also possible that the bounds
 		// have changed. We handle that below.
 	}
+
 	// Close both iter and rangeDelIter. While mergingIter knows about
 	// rangeDelIter, it can't call Close() on it because it does not know when
-	// the levelIter will switch it.
-	if l.iter != nil {
-		l.err = l.iter.Close()
-		l.iter = nil
-	}
-	if l.rangeDelIter != nil && *l.rangeDelIter != nil {
-		l.err = firstError(l.err, (*l.rangeDelIter).Close())
-		*l.rangeDelIter = nil
-	}
-	if l.err != nil {
+	// the levelIter will switch it. Note that levelIter.Close() can be called
+	// multiple times.
+	if err := l.Close(); err != nil {
 		return false
 	}
 
@@ -233,7 +234,7 @@ func (l *levelIter) loadFile(index, dir int) bool {
 		}
 
 		f := &l.files[l.index]
-		l.tableOpts.LowerBound = l.opts.GetLowerBound()
+		l.tableOpts.LowerBound = l.lower
 		if l.tableOpts.LowerBound != nil {
 			if l.cmp(f.Largest.UserKey, l.tableOpts.LowerBound) < 0 {
 				// The largest key in the sstable is smaller than the lower bound.
@@ -249,7 +250,7 @@ func (l *levelIter) loadFile(index, dir int) bool {
 				l.tableOpts.LowerBound = nil
 			}
 		}
-		l.tableOpts.UpperBound = l.opts.GetUpperBound()
+		l.tableOpts.UpperBound = l.upper
 		if l.tableOpts.UpperBound != nil {
 			if l.cmp(f.Smallest.UserKey, l.tableOpts.UpperBound) >= 0 {
 				// The smallest key in the sstable is greater than or equal to the
@@ -288,16 +289,43 @@ func (l *levelIter) loadFile(index, dir int) bool {
 	}
 }
 
+// In race builds we verify that the keys returned by levelIter lie within
+// [lower,upper).
+func (l *levelIter) verify(key *InternalKey, val []byte) (*InternalKey, []byte) {
+	// TODO(peter): Currently disabled as this fails due t>o mergingIter violating
+	// the invariant of calling levelIter.Seek* with target keys that fall
+	// outside of the bounds.
+	//
+	// Note that raceEnabled is a compile time constant, which means the block of
+	// code will be compiled out of non-race builds making this method eligible
+	// for inlining. Do not change this to use a variable.
+	if false && raceEnabled {
+		if key == nil {
+			return key, val
+		}
+		// We allow returning a boundary key that is outside of the lower/upper
+		// bounds as such keys are always range tombstones which will be skipped by
+		// the Iterator.
+		if l.lower != nil && key != l.smallestBoundary && l.cmp(key.UserKey, l.lower) < 0 {
+			l.logger.Fatalf("levelIter: lower bound violation: %s < %s\n%s", key, l.lower, debug.Stack())
+		}
+		if l.upper != nil && key != l.largestBoundary && l.cmp(key.UserKey, l.upper) > 0 {
+			l.logger.Fatalf("levelIter: upper bound violation: %s > %s\n%s", key, l.upper, debug.Stack())
+		}
+	}
+	return key, val
+}
+
 func (l *levelIter) SeekGE(key []byte) (*InternalKey, []byte) {
 	// NB: the top-level Iterator has already adjusted key based on
 	// IterOptions.LowerBound.
 	if !l.loadFile(l.findFileGE(key), 1) {
 		return nil, nil
 	}
-	if key, val := l.iter.SeekGE(key); key != nil {
-		return key, val
+	if ikey, val := l.iter.SeekGE(key); ikey != nil {
+		return l.verify(ikey, val)
 	}
-	return l.skipEmptyFileForward()
+	return l.verify(l.skipEmptyFileForward())
 }
 
 func (l *levelIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
@@ -307,7 +335,7 @@ func (l *levelIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
 		return nil, nil
 	}
 	if key, val := l.iter.SeekPrefixGE(prefix, key); key != nil {
-		return key, val
+		return l.verify(key, val)
 	}
 	// When SeekPrefixGE returns nil, we have not necessarily reached the end of
 	// the sstable. All we know is that a key with prefix does not exist in the
@@ -319,7 +347,7 @@ func (l *levelIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
 	if l.tableOpts.UpperBound == nil {
 		l.tableOpts.UpperBound = sentinelUpperBound
 	}
-	return l.skipEmptyFileForward()
+	return l.verify(l.skipEmptyFileForward())
 }
 
 func (l *levelIter) SeekLT(key []byte) (*InternalKey, []byte) {
@@ -329,9 +357,9 @@ func (l *levelIter) SeekLT(key []byte) (*InternalKey, []byte) {
 		return nil, nil
 	}
 	if key, val := l.iter.SeekLT(key); key != nil {
-		return key, val
+		return l.verify(key, val)
 	}
-	return l.skipEmptyFileBackward()
+	return l.verify(l.skipEmptyFileBackward())
 }
 
 func (l *levelIter) First() (*InternalKey, []byte) {
@@ -341,9 +369,9 @@ func (l *levelIter) First() (*InternalKey, []byte) {
 		return nil, nil
 	}
 	if key, val := l.iter.First(); key != nil {
-		return key, val
+		return l.verify(key, val)
 	}
-	return l.skipEmptyFileForward()
+	return l.verify(l.skipEmptyFileForward())
 }
 
 func (l *levelIter) Last() (*InternalKey, []byte) {
@@ -353,9 +381,9 @@ func (l *levelIter) Last() (*InternalKey, []byte) {
 		return nil, nil
 	}
 	if key, val := l.iter.Last(); key != nil {
-		return key, val
+		return l.verify(key, val)
 	}
-	return l.skipEmptyFileBackward()
+	return l.verify(l.skipEmptyFileBackward())
 }
 
 func (l *levelIter) Next() (*InternalKey, []byte) {
@@ -367,9 +395,9 @@ func (l *levelIter) Next() (*InternalKey, []byte) {
 		// We're stepping past the boundary key, so now we can load the next file.
 		if l.loadFile(l.index+1, 1) {
 			if key, val := l.iter.First(); key != nil {
-				return key, val
+				return l.verify(key, val)
 			}
-			return l.skipEmptyFileForward()
+			return l.verify(l.skipEmptyFileForward())
 		}
 		return nil, nil
 	}
@@ -380,9 +408,9 @@ func (l *levelIter) Next() (*InternalKey, []byte) {
 		return nil, nil
 	}
 	if key, val := l.iter.Next(); key != nil {
-		return key, val
+		return l.verify(key, val)
 	}
-	return l.skipEmptyFileForward()
+	return l.verify(l.skipEmptyFileForward())
 }
 
 func (l *levelIter) Prev() (*InternalKey, []byte) {
@@ -394,9 +422,9 @@ func (l *levelIter) Prev() (*InternalKey, []byte) {
 		// We're stepping past the boundary key, so now we can load the prev file.
 		if l.loadFile(l.index-1, -1) {
 			if key, val := l.iter.Last(); key != nil {
-				return key, val
+				return l.verify(key, val)
 			}
-			return l.skipEmptyFileBackward()
+			return l.verify(l.skipEmptyFileBackward())
 		}
 		return nil, nil
 	}
@@ -407,9 +435,9 @@ func (l *levelIter) Prev() (*InternalKey, []byte) {
 		return nil, nil
 	}
 	if key, val := l.iter.Prev(); key != nil {
-		return key, val
+		return l.verify(key, val)
 	}
-	return l.skipEmptyFileBackward()
+	return l.verify(l.skipEmptyFileBackward())
 }
 
 func (l *levelIter) skipEmptyFileForward() (*InternalKey, []byte) {
@@ -493,7 +521,7 @@ func (l *levelIter) skipEmptyFileBackward() (*InternalKey, []byte) {
 			// never going to look at earlier sstables (we've reached the lower
 			// bound).
 			f := &l.files[l.index]
-			if l.tableOpts.LowerBound != nil && l.rangeDelIter != nil {
+			if l.tableOpts.LowerBound != nil {
 				l.syntheticBoundary = f.Smallest
 				l.syntheticBoundary.SetKind(InternalKeyKindRangeDelete)
 				l.smallestBoundary = &l.syntheticBoundary
@@ -528,9 +556,7 @@ func (l *levelIter) Close() error {
 	}
 	if l.rangeDelIter != nil {
 		if t := *l.rangeDelIter; t != nil {
-			if err := t.Close(); err != nil && l.err == nil {
-				l.err = err
-			}
+			l.err = firstError(l.err, t.Close())
 		}
 		*l.rangeDelIter = nil
 	}
@@ -538,9 +564,44 @@ func (l *levelIter) Close() error {
 }
 
 func (l *levelIter) SetBounds(lower, upper []byte) {
-	l.opts.LowerBound = lower
-	l.opts.UpperBound = upper
-	if l.iter != nil {
-		l.iter.SetBounds(lower, upper)
+	l.lower = lower
+	l.upper = upper
+
+	if l.iter == nil {
+		return
 	}
+
+	f := &l.files[l.index]
+	l.tableOpts.LowerBound = l.lower
+	if l.tableOpts.LowerBound != nil {
+		if l.cmp(f.Largest.UserKey, l.tableOpts.LowerBound) < 0 {
+			// The largest key in the sstable is smaller than the lower bound. Note
+			// that levelIter.Close() can be called multiple times.
+			_ = l.Close()
+			return
+		}
+		if l.cmp(l.tableOpts.LowerBound, f.Smallest.UserKey) <= 0 {
+			// The lower bound is smaller or equal to the smallest key in the
+			// table. Iteration within the table does not need to check the lower
+			// bound.
+			l.tableOpts.LowerBound = nil
+		}
+	}
+	l.tableOpts.UpperBound = l.upper
+	if l.tableOpts.UpperBound != nil {
+		if l.cmp(f.Smallest.UserKey, l.tableOpts.UpperBound) >= 0 {
+			// The smallest key in the sstable is greater than or equal to the lower
+			// bound. Note that levelIter.Close() can be called multiple times.
+			_ = l.Close()
+			return
+		}
+		if l.cmp(l.tableOpts.UpperBound, f.Largest.UserKey) > 0 {
+			// The upper bound is greater than the largest key in the
+			// table. Iteration within the table does not need to check the upper
+			// bound. NB: tableOpts.UpperBound is exclusive and f.Largest is inclusive.
+			l.tableOpts.UpperBound = nil
+		}
+	}
+
+	l.iter.SetBounds(lower, upper)
 }

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -28,6 +28,8 @@ func TestLevelIter(t *testing.T) {
 		meta *fileMetadata, opts *IterOptions, bytesIterated *uint64,
 	) (internalIterator, internalIterator, error) {
 		f := *iters[meta.FileNum]
+		f.lower = opts.GetLowerBound()
+		f.upper = opts.GetUpperBound()
 		return &f, nil, nil
 	}
 
@@ -74,7 +76,9 @@ func TestLevelIter(t *testing.T) {
 
 			iter := newLevelIter(&opts, DefaultComparer.Compare, newIters, files, nil)
 			defer iter.Close()
-			return runInternalIterCmd(d, iter)
+			// Fake up the range deletion initialization.
+			iter.initRangeDel(new(internalIterator))
+			return runInternalIterCmd(d, iter, iterCmdVerboseKey)
 
 		case "load":
 			// The "load" command allows testing the iterator options passed to load

--- a/options.go
+++ b/options.go
@@ -73,6 +73,9 @@ type IterOptions struct {
 	// iteration based on the user properties. Return true to scan the table and
 	// false to skip scanning.
 	TableFilter func(userProps map[string]string) bool
+
+	// Internal options.
+	logger Logger
 }
 
 // GetLowerBound returns the LowerBound or nil if the receiver is nil.
@@ -89,6 +92,13 @@ func (o *IterOptions) GetUpperBound() []byte {
 		return nil
 	}
 	return o.UpperBound
+}
+
+func (o *IterOptions) getLogger() Logger {
+	if o == nil || o.logger == nil {
+		return DefaultLogger
+	}
+	return o.logger
 }
 
 // WriteOptions hold the optional per-query parameters for Set and Delete

--- a/testdata/level_iter
+++ b/testdata/level_iter
@@ -12,11 +12,11 @@ next
 next
 next
 ----
-a:1
-b:2
-c:3
-d:4
-dd:5
+a#1,1:1
+b#2,1:2
+c#3,1:3
+d#4,1:4
+dd#5,1:5
 .
 
 iter
@@ -26,10 +26,10 @@ next
 next
 next
 ----
-b:2
-c:3
-d:4
-dd:5
+b#2,1:2
+c#3,1:3
+d#4,1:4
+dd#5,1:5
 .
 
 iter
@@ -38,9 +38,9 @@ next
 next
 next
 ----
-c:3
-d:4
-dd:5
+c#3,1:3
+d#4,1:4
+dd#5,1:5
 .
 
 iter
@@ -48,15 +48,15 @@ seek-ge d
 next
 next
 ----
-d:4
-dd:5
+d#4,1:4
+dd#5,1:5
 .
 
 iter
 seek-ge dd
 next
 ----
-dd:5
+dd#5,1:5
 .
 
 iter
@@ -73,7 +73,7 @@ iter
 seek-lt b
 prev
 ----
-a:1
+a#1,1:1
 .
 
 iter
@@ -81,8 +81,8 @@ seek-lt c
 prev
 prev
 ----
-b:2
-a:1
+b#2,1:2
+a#1,1:1
 .
 
 iter
@@ -91,9 +91,9 @@ prev
 prev
 prev
 ----
-c:3
-b:2
-a:1
+c#3,1:3
+b#2,1:2
+a#1,1:1
 .
 
 iter
@@ -104,34 +104,34 @@ prev
 prev
 prev
 ----
-dd:5
-d:4
-c:3
-b:2
-a:1
+dd#5,1:5
+d#4,1:4
+c#3,1:3
+b#2,1:2
+a#1,1:1
 .
 
 iter
 seek-prefix-ge a
 next
 ----
-a:1
-b:2
+a#1,1:1
+b#2,1:2
 
 iter
 seek-prefix-ge d
 next
 next
 ----
-d:4
-dd:5
+d#4,1:4
+dd#5,1:5
 .
 
 iter
 seek-prefix-ge dd
 next
 ----
-dd:5
+dd#5,1:5
 .
 
 iter
@@ -140,39 +140,39 @@ next
 prev
 prev
 ----
-d:4
-dd:5
-d:4
-c:3
+d#4,1:4
+dd#5,1:5
+d#4,1:4
+c#3,1:3
 
 iter
 seek-prefix-ge d
 prev
 ----
-d:4
-c:3
+d#4,1:4
+c#3,1:3
 
 iter
 seek-prefix-ge dd
 prev
 ----
-dd:5
-d:4
+dd#5,1:5
+d#4,1:4
 
 iter lower=a
 seek-ge a
 first
 ----
-a:1
-a:1
+a#1,1:1
+a#1,1:1
 
 iter
 set-bounds lower=a
 seek-ge a
 first
 ----
-a:1
-a:1
+a#1,1:1
+a#1,1:1
 
 iter
 set-bounds lower=dd upper=f
@@ -185,10 +185,10 @@ prev
 prev
 ----
 .
-d:4
-c:3
-b:2
-a:1
+d#4,1:4
+c#3,1:3
+b#2,1:2
+a#1,1:1
 .
 
 iter
@@ -201,9 +201,9 @@ next
 next
 ----
 .
-c:3
-d:4
-dd:5
+c#3,1:3
+d#4,1:4
+dd#5,1:5
 .
 
 # levelIter trims lower/upper bound in the options passed to sstables.
@@ -211,9 +211,9 @@ load a
 ----
 [,]
 
-load b lower=aa upper=b
+load b lower=aa upper=bb
 ----
-[aa,b]
+[aa,]
 
 load b lower=aa upper=c
 ----
@@ -232,39 +232,39 @@ iter lower=b
 seek-ge a
 first
 ----
-a:1
-a:1
+a#1,1:1
+a#1,1:1
 
 iter lower=c
 seek-ge a
 first
 ----
-c:3
-c:3
+c#3,1:3
+c#3,1:3
 
 iter
 set-bounds lower=b
 seek-ge a
 first
 ----
-a:1
-a:1
+a#1,1:1
+a#1,1:1
 
 iter
 set-bounds lower=c
 seek-ge a
 first
 ----
-c:3
-c:3
+c#3,1:3
+c#3,1:3
 
 # levelIter only checks lower bound when loading sstables.
 iter lower=d
 seek-ge a
 first
 ----
-c:3
-c:3
+c#3,1:3
+c#3,1:3
 
 iter lower=e
 seek-ge a
@@ -277,16 +277,16 @@ iter upper=e
 seek-lt e
 last
 ----
-dd:5
-dd:5
+dd#5,1:5
+dd#5,1:5
 
 iter
 set-bounds lower=d
 seek-ge a
 first
 ----
-c:3
-c:3
+c#3,1:3
+c#3,1:3
 
 iter
 set-bounds lower=e
@@ -301,47 +301,47 @@ set-bounds upper=e
 seek-lt e
 last
 ----
-dd:5
-dd:5
+dd#5,1:5
+dd#5,1:5
 
 # levelIter only checks upper bound when loading sstables.
 iter upper=d
 seek-lt e
 last
 ----
-d:4
-d:4
+d#4,1:4
+d#4,1:4
 
 iter upper=c
 seek-lt e
 last
 ----
-b:2
-b:2
+b#2,1:2
+b#2,1:2
 
 iter
 set-bounds upper=d
 seek-lt e
 last
 ----
-d:4
-d:4
+d#4,1:4
+d#4,1:4
 
 iter
 set-bounds upper=c
 seek-lt e
 last
 ----
-b:2
-b:2
+b#2,1:2
+b#2,1:2
 
-# levelIter only checks lower bound when loading sstables.
+# levelIter only checks upper bound when loading sstables.
 iter upper=b
 seek-lt e
 last
 ----
-b:2
-b:2
+b#2,1:2
+b#2,1:2
 
 iter upper=a
 seek-lt e
@@ -354,7 +354,7 @@ iter upper=dd
 seek-prefix-ge d
 next
 ----
-d:4
+d#4,1:4
 .
 
 iter
@@ -362,8 +362,8 @@ set-bounds upper=b
 seek-lt e
 last
 ----
-b:2
-b:2
+b#2,1:2
+b#2,1:2
 
 iter
 set-bounds upper=a
@@ -378,7 +378,7 @@ set-bounds upper=dd
 seek-prefix-ge d
 next
 ----
-d:4
+d#4,1:4
 .
 
 iter upper=e
@@ -386,30 +386,30 @@ seek-prefix-ge d
 next
 next
 ----
-d:4
-dd:5
+d#4,1:4
+dd#5,1:5
 .
 
 iter lower=dd
 seek-prefix-ge d
 next
 ----
-dd:5
+dd#5,1:5
 .
 
 iter lower=d
 seek-prefix-ge dd
 prev
 ----
-dd:5
-d:4
+dd#5,1:5
+d#4,1:4
 
 iter lower=c
 seek-prefix-ge dd
 prev
 ----
-dd:5
-d:4
+dd#5,1:5
+d#4,1:4
 
 iter lower=c
 seek-lt c
@@ -421,7 +421,7 @@ seek-lt c
 set-bounds lower=c
 seek-lt c
 ----
-b:2
+b#2,1:2
 .
 
 iter upper=c
@@ -434,5 +434,67 @@ seek-ge c
 set-bounds upper=c
 seek-ge c
 ----
-c:3
+c#3,1:3
 .
+
+# The behavior of next/prev after set-bounds is undefined. We're just
+# asserting the current behavior.
+
+# The lower bound is beyond the current table's bounds.
+
+iter
+seek-ge c
+set-bounds lower=e
+next
+----
+c#3,1:3
+.
+
+# The lower bound lies within the current table's bounds.
+
+iter
+seek-ge c
+set-bounds lower=d
+next
+----
+c#3,1:3
+d#4,1:4
+
+# The upper bound is before the current table's bounds.
+
+iter
+seek-ge d
+set-bounds upper=c
+prev
+----
+d#4,1:4
+.
+
+# The upper bound lies within the current table's bounds.
+
+iter
+seek-ge d
+set-bounds upper=cc
+prev
+----
+d#4,1:4
+c#3,1:3
+
+# Setting bounds should update the table bounds, allowing a subsequent
+# seek-ge/seek-lt to see the boundary keys.
+
+iter
+seek-ge d
+set-bounds lower=cc
+seek-lt d
+----
+d#4,1:4
+c#3,15:
+
+iter
+seek-ge c
+set-bounds upper=cc
+seek-ge d
+----
+c#3,1:3
+d#4,15:

--- a/testdata/level_iter_boundaries
+++ b/testdata/level_iter_boundaries
@@ -176,3 +176,54 @@ c#2,15:
 d#3,1:d
 c#2,15:
 d#3,1:d
+
+# Regression test to check that Seek{GE,LT}, First, and Last properly
+# reset the iteration upper bound when levelIter had previously set it
+# to a sentinel value during SeekPrefixGE.
+
+clear
+----
+
+build
+b.SET.4:b
+d.SET.3:d
+----
+0: b#4,1-d#3,1
+
+iter
+seek-prefix-ge c
+seek-ge d
+next
+----
+d#3,15:
+d#3,1:d
+.
+
+iter
+seek-prefix-ge c
+seek-lt e
+next
+----
+d#3,15:
+d#3,1:d
+.
+
+iter
+seek-prefix-ge c
+first
+next
+next
+----
+d#3,15:
+b#4,1:b
+d#3,1:d
+.
+
+iter
+seek-prefix-ge c
+last
+next
+----
+d#3,15:
+d#3,1:d
+.


### PR DESCRIPTION
`levelIter.SeekPrefixGE` sets the upper bound to a sentinel value to ensure
we don't iterate past an sstable too soon during prefix iteration. We need
to reset the upper bound on a subsequent positioning call (`SeekGE`,
`SeekLT`, `First`, or `Last`) which does not actually switch to a new
sstable.