### PR TITLE
db: transform merge+del -> set during compaction

### DIFF
--- a/testdata/compaction_iter
+++ b/testdata/compaction_iter
@@ -444,7 +444,7 @@ next
 tombstones
 ----
 a#3,15:c
-b#5,2:de
+b#5,1:de
 d#5,2:bc
 d#3,15:f
 .
@@ -1011,3 +1011,96 @@ a#0,2:v1
 .
 a-b#1
 .
+
+# Verify that we transform merge+del -> set.
+
+define
+a.MERGE.5:5
+a.DEL.3:3
+a.MERGE.1:1
+----
+
+iter
+first
+next
+----
+a#0,1:5
+.
+
+iter elide-tombstones=true
+first
+next
+----
+a#0,1:5
+.
+
+iter snapshots=2
+first
+next
+next
+----
+a#5,1:5
+a#0,2:1
+.
+
+iter snapshots=2 elide-tombstones=true
+first
+next
+next
+----
+a#5,1:5
+a#0,2:1
+.
+
+# Verify that we transform merge+rangedel -> set. This isn't strictly
+# necessary, but provides consistency with the behavior for merge+del.
+
+define
+a.RANGEDEL.3:c
+b.MERGE.5:5
+b.SET.2:2
+b.MERGE.1:1
+----
+
+iter
+first
+next
+next
+----
+a#3,15:c
+b#0,1:5
+.
+
+iter snapshots=2
+first
+next
+next
+----
+a#3,15:c
+b#5,1:5
+b#0,2:1
+
+define
+a.RANGEDEL.3:c
+b.MERGE.5:5
+b.MERGE.2:2
+b.MERGE.1:1
+----
+
+iter
+first
+next
+next
+----
+a#3,15:c
+b#0,1:5
+.
+
+iter snapshots=2
+first
+next
+next
+----
+a#3,15:c
+b#5,1:5
+b#0,2:1


### PR DESCRIPTION
Consider the sequence of records: `a.MERGE.5`, `a.DEL.3`,
`a.MERGE.1`. During a compaction, if there is a snapshot at seqnum 2 we
were previously dropping the record `a.DEL.3`, emitting only `a.MERGE.5`
and `a.MERGE.1`. Now we transform `a.MERGE.5`+`a.DEL.3` into
`a.SET.5`. This causes that record to shadow the older `a.SET.1` record,
instead of erroneously merging with it.

Found via the metamorphic test.