### PR TITLE
internal/metamorphic: add -fail flag

### DIFF
--- a/internal/metamorphic/history_test.go
+++ b/internal/metamorphic/history_test.go
@@ -7,11 +7,13 @@ package metamorphic
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestHistoryLogger(t *testing.T) {
 	var buf bytes.Buffer
-	h := newHistory(&buf)
+	h := newHistory("", &buf)
 	l := h.Logger()
 	l.Infof("hello\nworld\n")
 	l.Fatalf("hello\n\nworld")
@@ -25,4 +27,13 @@ func TestHistoryLogger(t *testing.T) {
 	if actual := buf.String(); expected != actual {
 		t.Fatalf("expected\n%s\nbut found\n%s", expected, actual)
 	}
+}
+
+func TestHistoryFail(t *testing.T) {
+	var buf bytes.Buffer
+	h := newHistory("foo", &buf)
+	h.Recordf("bar")
+	require.False(t, h.Failed())
+	h.Recordf("foo bar")
+	require.True(t, h.Failed())
 }


### PR DESCRIPTION
Add a `-fail` flag which specifies a regular expression to match against
the the results of operations. When the regular expression matches, the
test is failed, saving the in-memory FS state to allow for post-mortem
debugging. This is useful for debugging problems that
non-deterministically fail in ways that are not detectable from an
individual test run. For example, we might uncover a failure in the
output between two tests, determine which of the two outputs is in
error, then add additional instrumentation to debug the erroneous
output. But if that erroneous output only occurs once out of every 100
runs reproduction becomes onerous. With the `-fail` flag you can specify
a regular expression to detect the erroneous output and run with:

  `-count 100 -fail <re>`