### PR TITLE
db: never return a nil iterator on success from newRangeDelIter

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -672,6 +672,9 @@ func (c *compaction) newInputIter(newIters tableNewIters) (_ internalIterator, r
 				rangeDelIter = rangedel.Truncate(c.cmp, rangeDelIter, lowerBound, upperBound)
 			}
 		}
+		if rangeDelIter == nil {
+			rangeDelIter = emptyIter
+		}
 		return rangeDelIter, nil, err
 	}
 

--- a/level_iter.go
+++ b/level_iter.go
@@ -287,7 +287,7 @@ func (l *levelIter) loadFile(index, dir int) bool {
 
 		var rangeDelIter internalIterator
 		l.iter, rangeDelIter, l.err = l.newIters(f, &l.tableOpts, l.bytesIterated)
-		if l.err != nil || l.iter == nil {
+		if l.err != nil {
 			return false
 		}
 		if l.rangeDelIter != nil {

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -31,7 +31,12 @@ type mergingIterLevel struct {
 	smallestUserKey, largestUserKey  []byte
 	isLargestUserKeyRangeDelSentinel bool
 
-	// tombstone caches the tombstone rangeDelIter is currently pointed at.
+	// tombstone caches the tombstone rangeDelIter is currently pointed at. If
+	// tombstone.Empty() is true, there are no further tombstones within the
+	// current sstable in the current iterator direction. The cached tombstone is
+	// only valid for the levels in the range [0,heap[0].index]. This avoids
+	// positioning tombstones at lower levels which cannot possibly shadow the
+	// current key.
 	tombstone rangedel.Tombstone
 }
 
@@ -423,12 +428,18 @@ func (m *mergingIter) switchToMaxHeap() {
 
 // Steps to the next entry. item is the current top item in the heap.
 func (m *mergingIter) nextEntry(item *mergingIterItem) {
-	oldTopLevel := item.index
 	l := &m.levels[item.index]
+	oldTopLevel := item.index
+	oldRangeDelIter := l.rangeDelIter
 	if l.iterKey, l.iterValue = l.iter.Next(); l.iterKey != nil {
 		item.key, item.value = *l.iterKey, l.iterValue
 		if m.heap.len() > 1 {
 			m.heap.fix(0)
+		}
+		if l.rangeDelIter != oldRangeDelIter {
+			// The rangeDelIter changed which indicates that the l.iter moved to the
+			// next sstable. We have to update the tombstone for oldTopLevel as well.
+			oldTopLevel--
 		}
 	} else {
 		m.err = l.iter.Error()
@@ -436,10 +447,10 @@ func (m *mergingIter) nextEntry(item *mergingIterItem) {
 			m.heap.pop()
 		}
 	}
-	// TODO(sbhola): this is unnecessary -- we are inconsistent wrt maintaining the position
-	// invariant of the range deletion iterators. We are maintaining it for nextEntry()
-	// but not in seek. And isNextEntryDeleted() ensures that if the tombstone is too small
-	// that we do rangedel.SeekGE().
+
+	// The cached tombstones are only valid for the levels
+	// [0,oldTopLevel]. Updated the cached tombstones for any levels in the range
+	// [oldTopLevel+1,heap[0].index].
 	m.initMinRangeDelIters(oldTopLevel)
 }
 
@@ -456,6 +467,8 @@ func (m *mergingIter) isNextEntryDeleted(item *mergingIterItem) bool {
 	for level := 0; level <= item.index; level++ {
 		l := &m.levels[level]
 		if l.rangeDelIter == nil || l.tombstone.Empty() {
+			// If l.tombstone.Empty() is true, there are no further tombstones in the
+			// current sstable in the current (forward) iteration direction.
 			continue
 		}
 		if m.heap.cmp(l.tombstone.End, item.key.UserKey) <= 0 {
@@ -550,12 +563,19 @@ func (m *mergingIter) findNextEntry() (*InternalKey, []byte) {
 
 // Steps to the prev entry. item is the current top item in the heap.
 func (m *mergingIter) prevEntry(item *mergingIterItem) {
-	oldTopLevel := item.index
 	l := &m.levels[item.index]
+	oldTopLevel := item.index
+	oldRangeDelIter := l.rangeDelIter
 	if l.iterKey, l.iterValue = l.iter.Prev(); l.iterKey != nil {
 		item.key, item.value = *l.iterKey, l.iterValue
 		if m.heap.len() > 1 {
 			m.heap.fix(0)
+		}
+		if l.rangeDelIter != oldRangeDelIter && l.rangeDelIter != nil {
+			// The rangeDelIter changed which indicates that the l.iter moved to the
+			// previous sstable. We have to update the tombstone for oldTopLevel as
+			// well.
+			oldTopLevel--
 		}
 	} else {
 		m.err = l.iter.Error()
@@ -563,10 +583,10 @@ func (m *mergingIter) prevEntry(item *mergingIterItem) {
 			m.heap.pop()
 		}
 	}
-	// TODO(sbhola): this is unnecessary -- we are inconsistent wrt maintaining the position
-	// invariant of the range deletion iterators. We are maintaining it for prevEntry()
-	// but not in seek. And isPrevEntryDeleted() ensures that if the tombstone is too large
-	// that we do rangedel.SeekLE().
+
+	// The cached tombstones are only valid for the levels
+	// [0,oldTopLevel]. Updated the cached tombstones for any levels in the range
+	// [oldTopLevel+1,heap[0].index].
 	m.initMaxRangeDelIters(oldTopLevel)
 }
 
@@ -583,6 +603,8 @@ func (m *mergingIter) isPrevEntryDeleted(item *mergingIterItem) bool {
 	for level := 0; level <= item.index; level++ {
 		l := &m.levels[level]
 		if l.rangeDelIter == nil || l.tombstone.Empty() {
+			// If l.tombstone.Empty() is true, there are no further tombstones in the
+			// current sstable in the current (reverse) iteration direction.
 			continue
 		}
 		if m.heap.cmp(item.key.UserKey, l.tombstone.Start.UserKey) < 0 {
@@ -951,7 +973,7 @@ func (m *mergingIter) DebugString() string {
 	sep := ""
 	for m.heap.len() > 0 {
 		item := m.heap.pop()
-		fmt.Fprintf(&buf, "%s%s:%d", sep, item.key.UserKey, item.key.SeqNum())
+		fmt.Fprintf(&buf, "%s%s", sep, item.key)
 		sep = " "
 	}
 	if m.dir == 1 {

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -290,8 +290,8 @@ next
 ----
 a:2
 b:2
-c:1
-d:1
+z:1
+.
 
 compact a-z
 ----

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -242,3 +242,69 @@ compact a-c L1
   6:[b#2,SET-b#2,SET]
   7:[b#1,SET-b#1,SET]
   8:[b#0,SET-b#0,SET]
+
+# Regression test for a bug where compaction would stop process range
+# tombstones for an input level upon finding an sstable in the input
+# level with no range tombstones. In the scenario below, sstable 6
+# does not contain any range tombstones while sstable 7 does. Both are
+# compacted together with sstable 5.
+
+reset
+----
+
+batch
+set a 1
+set b 1
+set c 1
+set d 1
+set z 1
+----
+
+compact a-z
+----
+6:
+  5:[a#0,SET-z#4,SET]
+
+build ext1
+set a 2
+----
+
+build ext2
+set b 2
+del-range c z
+----
+
+ingest ext1 ext2
+----
+5:
+  6:[a#5,SET-a#5,SET]
+  7:[b#6,SET-z#72057594037927935,RANGEDEL]
+6:
+  5:[a#0,SET-z#4,SET]
+
+iter
+first
+next
+next
+next
+----
+a:2
+b:2
+c:1
+d:1
+
+compact a-z
+----
+6:
+  8:[a#0,SET-z#0,SET]
+
+iter
+first
+next
+next
+next
+----
+a:2
+b:2
+z:1
+.

--- a/testdata/merging_iter
+++ b/testdata/merging_iter
@@ -382,3 +382,65 @@ d#2,15:
 f#6,15:
 c#3,1:3
 c#9,1:9
+
+# Verify that the tombstone for the current level is updated correctly
+# when we advance the iterator on the level and step into a new
+# sstable. In the scenario below, the keys "c" and "d" should not show
+# up in the iteration output.
+
+define
+L
+a.SET.2 a.SET.2
+a.SET.2:2
+c.RANGEDEL.4 e.RANGEDEL.72057594037927935
+c.RANGEDEL.4:e
+f.SET.3 f.SET.3
+f.SET.3:3
+L
+a.SET.0 f.SET.0
+a.SET.0:1 b.SET.0:1 c.SET.0:1 d.SET.0:1 e.SET.0:1 f.SET.0:1
+----
+1:
+  15:[a#2,SET-a#2,SET]
+  16:[c#4,RANGEDEL-e#72057594037927935,RANGEDEL]
+  17:[f#3,SET-f#3,SET]
+2:
+  18:[a#0,SET-f#0,SET]
+
+iter
+first
+next
+next
+next
+next
+next
+next
+next
+----
+a#2,1:2
+a#0,1:1
+b#0,1:1
+e#72057594037927935,15:
+e#0,1:1
+f#3,1:3
+f#0,1:1
+.
+
+iter
+last
+prev
+prev
+prev
+prev
+prev
+prev
+prev
+----
+f#0,1:1
+f#3,1:3
+e#0,1:1
+c#4,15:
+b#0,1:1
+a#0,1:1
+a#2,1:2
+.


### PR DESCRIPTION
`compaction.newInputIter` iterates over the inputs to a compaction by
constructing a merging iter composed of 4 level iterators: 1 point and 1
range-del `levelIter` for the two input levels. The range-del
`levelIter` is constructed using a `newRangeDelIter` closure. This
closure was returning `nil` if an sstable did not contain a range
tombstones. Unfortunately, this interacted badly with
`levelIter.loadFile` which had an odd contional to assume that return a
`nil` iterator and a `nil` error indicated some sort of "end of
iteration" indication. This was completely bogus. The interaction of
these two problems was droppage of range tombstones during a compaction
whenever an sstable contained a range tombstone and an earlier sstable
in the same level that was part of the compaction did not contain any
range tombstones. I suspect this is the cause of some of the roachtest
consistency failures we've seen.

Found via the metamorphic test.