### PR TITLE
db: fix skipping of range tombstones in Iterator 

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -787,7 +787,7 @@ func TestManualCompaction(t *testing.T) {
 			return b.String()
 
 		case "compact":
-			if err := runCompactCommand(td, d); err != nil {
+			if err := runCompactCmd(td, d); err != nil {
 				return err.Error()
 			}
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -104,7 +104,7 @@ func TestMetrics(t *testing.T) {
 			return ""
 
 		case "compact":
-			if err := runCompactCommand(td, d); err != nil {
+			if err := runCompactCmd(td, d); err != nil {
 				return err.Error()
 			}
 

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -36,7 +36,7 @@ func TestRangeDel(t *testing.T) {
 			return s
 
 		case "compact":
-			if err := runCompactCommand(td, d); err != nil {
+			if err := runCompactCmd(td, d); err != nil {
 				return err.Error()
 			}
 			d.mu.Lock()
@@ -47,37 +47,7 @@ func TestRangeDel(t *testing.T) {
 			return s
 
 		case "get":
-			snap := Snapshot{
-				db:     d,
-				seqNum: InternalKeySeqNumMax,
-			}
-
-			for _, arg := range td.CmdArgs {
-				if len(arg.Vals) != 1 {
-					return fmt.Sprintf("%s: %s=<value>", td.Cmd, arg.Key)
-				}
-				switch arg.Key {
-				case "seq":
-					var err error
-					snap.seqNum, err = strconv.ParseUint(arg.Vals[0], 10, 64)
-					if err != nil {
-						return err.Error()
-					}
-				default:
-					return fmt.Sprintf("%s: unknown arg: %s", td.Cmd, arg.Key)
-				}
-			}
-
-			var buf bytes.Buffer
-			for _, data := range strings.Split(td.Input, "\n") {
-				v, err := snap.Get([]byte(data))
-				if err != nil {
-					fmt.Fprintf(&buf, "%s\n", err)
-				} else {
-					fmt.Fprintf(&buf, "%s\n", v)
-				}
-			}
-			return buf.String()
+			return runGetCmd(td, d)
 
 		case "iter":
 			snap := Snapshot{

--- a/testdata/iterator_next_prev
+++ b/testdata/iterator_next_prev
@@ -1,0 +1,98 @@
+build ext1
+merge a 1
+set c 2
+----
+
+ingest ext1
+----
+6:
+  4:[a#1,MERGE-c#1,SET]
+
+build ext2
+del-range b c
+----
+
+ingest ext2
+----
+5:
+  5:[b#2,RANGEDEL-c#72057594037927935,RANGEDEL]
+6:
+  4:[a#1,MERGE-c#1,SET]
+
+# Regression test for a bug where range tombstones were not properly
+# ignored by Iterator.prevUserKey when switching from forward to
+# reverse iteration. In the forward direction, the Iterator sees the
+# keys:
+#
+#   a#1,MERGE
+#   c#1,SET
+#
+# Due to the synthetic boundary key generated for sstable 5, in the
+# reverse direction Iterator sees the keys:
+#
+#   c#1,SET
+#   b#2,RANGEDEL
+#   a#1,MERGE
+#
+# Normally the record b#2,RANGEDEL is skipped by Iterator during
+# iteration, but logic to do so was missing from Iterator.prevUserKey.
+# The result was that prev could return the same key that iterator was
+# currently pointed at.
+
+iter
+first
+prev
+----
+a:1
+.
+
+reset
+----
+
+build ext1
+set t 1
+merge z 2
+----
+
+ingest ext1
+----
+6:
+  4:[t#1,SET-z#1,MERGE]
+
+build ext2
+del-range x y
+----
+
+ingest ext2
+----
+5:
+  5:[x#2,RANGEDEL-y#72057594037927935,RANGEDEL]
+6:
+  4:[t#1,SET-z#1,MERGE]
+
+# Regression test for a bug where range tombstones were not properly
+# ignored by Iterator.nextUserKey when switching from reverse to
+# forward iteration. In the reverse direction, the Iterator sees the
+# keys:
+#
+#   z#1,MERGE
+#   t#1,SET
+#
+# Due to the synthetic boundary key generated for sstable 5, in the
+# forward direction Iterator sees the keys:
+#
+#   t#1,SET
+#   y#72057594037927935,RANGEDEL
+#   z#1,MERGE
+#
+# Normally the record y#72057594037927935,RANGEDEL is skipped by
+# Iterator during iteration, but logic to do so was missing from
+# Iterator.nextUserKey. The result was that next could return the same
+# key that iterator was currently pointed at.
+
+iter
+last
+next
+----
+z:2
+.

--- a/testdata/range_del
+++ b/testdata/range_del
@@ -21,54 +21,54 @@ a
 b
 c
 ----
-b
-b
-b
+a:b
+b:b
+c:b
 
 get seq=4
 a
 b
 c
 ----
-c
-bc
-c
+a:c
+b:bc
+c:c
 
 get seq=6
 a
 b
 c
 ----
-d
-bcd
-d
+a:d
+b:bcd
+c:d
 
 get seq=7
 a
 b
 c
 ----
-d
-pebble: not found
-d
+a:d
+b: pebble: not found
+c:d
 
 get seq=8
 a
 b
 c
 ----
-d
-e
-d
+a:d
+b:e
+c:d
 
 get seq=6
 a
 b
 c
 ----
-d
-bcd
-d
+a:d
+b:bcd
+c:d
 
 iter seq=6
 first
@@ -163,54 +163,54 @@ a
 b
 c
 ----
-b
-b
-b
+a:b
+b:b
+c:b
 
 get seq=4
 a
 b
 c
 ----
-c
-bc
-c
+a:c
+b:bc
+c:c
 
 get seq=6
 a
 b
 c
 ----
-d
-bcd
-d
+a:d
+b:bcd
+c:d
 
 get seq=7
 a
 b
 c
 ----
-d
-pebble: not found
-d
+a:d
+b: pebble: not found
+c:d
 
 get seq=8
 a
 b
 c
 ----
-d
-e
-d
+a:d
+b:e
+c:d
 
 get seq=6
 a
 b
 c
 ----
-d
-bcd
-d
+a:d
+b:bcd
+c:d
 
 iter seq=6
 first
@@ -313,10 +313,10 @@ b
 c
 d
 ----
-1
-1
-1
-1
+a:1
+b:1
+c:1
+d:1
 
 get seq=3
 a
@@ -324,10 +324,10 @@ b
 c
 d
 ----
-pebble: not found
-pebble: not found
-pebble: not found
-1
+a: pebble: not found
+b: pebble: not found
+c: pebble: not found
+d:1
 
 get seq=5
 a
@@ -335,10 +335,10 @@ b
 c
 d
 ----
-2
-pebble: not found
-pebble: not found
-2
+a:2
+b: pebble: not found
+c: pebble: not found
+d:2
 
 get seq=7
 a
@@ -346,10 +346,10 @@ b
 c
 d
 ----
-3
-3
-pebble: not found
-3
+a:3
+b:3
+c: pebble: not found
+d:3
 
 get seq=9
 a
@@ -357,10 +357,10 @@ b
 c
 d
 ----
-4
-4
-4
-4
+a:4
+b:4
+c:4
+d:4
 
 iter seq=2
 first
@@ -489,10 +489,10 @@ b
 c
 d
 ----
-1
-1
-1
-1
+a:1
+b:1
+c:1
+d:1
 
 get seq=3
 a
@@ -500,10 +500,10 @@ b
 c
 d
 ----
-pebble: not found
-pebble: not found
-pebble: not found
-1
+a: pebble: not found
+b: pebble: not found
+c: pebble: not found
+d:1
 
 get seq=5
 a
@@ -511,10 +511,10 @@ b
 c
 d
 ----
-2
-pebble: not found
-pebble: not found
-2
+a:2
+b: pebble: not found
+c: pebble: not found
+d:2
 
 get seq=7
 a
@@ -522,10 +522,10 @@ b
 c
 d
 ----
-3
-3
-pebble: not found
-3
+a:3
+b:3
+c: pebble: not found
+d:3
 
 get seq=9
 a
@@ -533,10 +533,10 @@ b
 c
 d
 ----
-4
-4
-4
-4
+a:4
+b:4
+c:4
+d:4
 
 iter seq=2
 first
@@ -648,22 +648,22 @@ mem: 1
 get seq=1
 a
 ----
-pebble: not found
+a: pebble: not found
 
 get seq=2
 a
 ----
-1
+a:1
 
 get seq=3
 a
 ----
-2
+a:2
 
 get seq=4
 a
 ----
-3
+a:3
 
 iter seq=2
 first
@@ -727,22 +727,22 @@ mem: 1
 get seq=1
 a
 ----
-pebble: not found
+a: pebble: not found
 
 get seq=2
 a
 ----
-1
+a:1
 
 get seq=3
 a
 ----
-12
+a:12
 
 get seq=4
 a
 ----
-123
+a:123
 
 iter seq=2
 first
@@ -812,27 +812,27 @@ mem: 1
 get seq=1
 a
 ----
-pebble: not found
+a: pebble: not found
 
 get seq=2
 a
 ----
-1
+a:1
 
 get seq=3
 a
 ----
-12
+a:12
 
 get seq=4
 a
 ----
-123
+a:123
 
 get seq=5
 a
 ----
-1234
+a:1234
 
 iter seq=2
 first
@@ -930,10 +930,10 @@ b
 c
 d
 ----
-1
-1
-1
-1
+a:1
+b:1
+c:1
+d:1
 
 get seq=3
 a
@@ -941,10 +941,10 @@ b
 c
 d
 ----
-pebble: not found
-pebble: not found
-pebble: not found
-2
+a: pebble: not found
+b: pebble: not found
+c: pebble: not found
+d:2
 
 get seq=4
 a
@@ -952,10 +952,10 @@ b
 c
 d
 ----
-3
-pebble: not found
-pebble: not found
-3
+a:3
+b: pebble: not found
+c: pebble: not found
+d:3
 
 get seq=5
 a
@@ -963,10 +963,10 @@ b
 c
 d
 ----
-4
-4
-pebble: not found
-4
+a:4
+b:4
+c: pebble: not found
+d:4
 
 iter seq=2
 first
@@ -1054,10 +1054,10 @@ b
 c
 d
 ----
-1
-1
-1
-1
+a:1
+b:1
+c:1
+d:1
 
 get seq=3
 a
@@ -1065,10 +1065,10 @@ b
 c
 d
 ----
-pebble: not found
-pebble: not found
-pebble: not found
-1
+a: pebble: not found
+b: pebble: not found
+c: pebble: not found
+d:1
 
 get seq=4
 a
@@ -1076,10 +1076,10 @@ b
 c
 d
 ----
-3
-3
-3
-3
+a:3
+b:3
+c:3
+d:3
 
 iter seq=2
 first
@@ -1145,7 +1145,7 @@ mem: 1
 get seq=3
 a
 ----
-pebble: not found
+a: pebble: not found
 
 # A range tombstone straddles two SSTs. One is compacted to a lower level. Its
 # keys that are newer than the range tombstone should not disappear.
@@ -1271,7 +1271,7 @@ compact d-e
 get seq=4
 c
 ----
-v
+c:v
 
 compact a-b L1
 ----
@@ -1284,7 +1284,7 @@ compact a-b L1
 get seq=4
 c
 ----
-v
+c:v
 
 # A slight variation on the scenario above where a range tombstone is
 # expanded past the boundaries of its "atomic compaction unit".
@@ -1334,7 +1334,7 @@ compact d-e
 get seq=4
 c
 ----
-v
+c:v
 
 compact f-f L0
 ----
@@ -1357,4 +1357,4 @@ compact a-f L1
 get seq=4
 c
 ----
-v
+c:v


### PR DESCRIPTION
`Iterator` is required to skip over any range tombstones it sees as
there is nothing for it to do with them. These range tombstones are
present because `levelIter` uses them as markers to prevent iterating to
the next (or prev) sstable too soon. Somewhat confusingly, these marker
records may exists while iterating in one direction, but not the
other. This caused a subtle bug in `Iterator` when switching
directions. The code in `Iterator.{Next,Prev}` to handle switching from
forward to backward iteration (and vice versa) relies on knowing how the
child iterator is positioned in the absence of range
tombstones. Unfortunately, the logic was incomplete and was not ignoring
range tombstones in some circumstances (specifically,
`Iterator.{next,prev}UserKey`).

Found via the metamorphic test.