### PR TITLE
db: properly reset Batch.tombstones

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -403,6 +403,19 @@ func TestBatchDeleteRange(t *testing.T) {
 			b = nil
 			return ""
 
+		case "apply":
+			if b == nil {
+				b = newIndexedBatch(nil, DefaultComparer)
+			}
+			t := newBatch(nil)
+			if err := runBatchDefineCmd(td, t); err != nil {
+				return err.Error()
+			}
+			if err := b.Apply(t, nil); err != nil {
+				return err.Error()
+			}
+			return ""
+
 		case "define":
 			if b == nil {
 				b = newIndexedBatch(nil, DefaultComparer)

--- a/testdata/batch_delete_range
+++ b/testdata/batch_delete_range
@@ -79,3 +79,26 @@ b#27,15:c
 b#22,15:c
 b#17,15:c
 c#27,15:d
+
+# Verify that adding a range tombstone via Batch.Apply invalidates the
+# cached fragmented tombstones.
+
+clear
+----
+
+define
+del-range a b
+----
+
+scan range-del
+----
+a#12,15:b
+
+apply
+del-range c d
+----
+
+scan range-del
+----
+a#12,15:b
+c#17,15:d


### PR DESCRIPTION
Clear `Batch.tombstones` in `Batch.release` and in `Batch.Apply` if
tombstones were added to the batch. This fixes a bug where tombstones
added to a batch were not seen during subsequent iteration.

Found via the metamorphic test.