### PR TITLE
sstable: reset singleLevelIterator.block{Lower,Upper} on bounds change

### DIFF
--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -1,0 +1,219 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/cockroachdb/pebble/internal/rangedel"
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+func runBuildCmd(td *datadriven.TestData) (*WriterMetadata, *Reader, error) {
+	mem := vfs.NewMem()
+	f0, err := mem.Create("test")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var writerOpts WriterOptions
+	for _, arg := range td.CmdArgs {
+		switch arg.Key {
+		case "leveldb":
+			if len(arg.Vals) != 0 {
+				return nil, nil, fmt.Errorf("%s: arg %s expects 0 values", td.Cmd, arg.Key)
+			}
+			writerOpts.TableFormat = TableFormatLevelDB
+		case "index-block-size":
+			if len(arg.Vals) != 1 {
+				return nil, nil, fmt.Errorf("%s: arg %s expects 1 value", td.Cmd, arg.Key)
+			}
+			var err error
+			writerOpts.IndexBlockSize, err = strconv.Atoi(arg.Vals[0])
+			if err != nil {
+				return nil, nil, err
+			}
+		default:
+			return nil, nil, fmt.Errorf("%s: unknown arg %s", td.Cmd, arg.Key)
+		}
+	}
+
+	w := NewWriter(f0, writerOpts)
+	var tombstones []rangedel.Tombstone
+	f := rangedel.Fragmenter{
+		Cmp: DefaultComparer.Compare,
+		Emit: func(fragmented []rangedel.Tombstone) {
+			tombstones = append(tombstones, fragmented...)
+		},
+	}
+	for _, data := range strings.Split(td.Input, "\n") {
+		j := strings.Index(data, ":")
+		key := base.ParseInternalKey(data[:j])
+		value := []byte(data[j+1:])
+		switch key.Kind() {
+		case InternalKeyKindRangeDelete:
+			var err error
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						err = errors.New(fmt.Sprint(r))
+					}
+				}()
+				f.Add(key, value)
+			}()
+			if err != nil {
+				return nil, nil, err
+			}
+		default:
+			if err := w.Add(key, value); err != nil {
+				return nil, nil, err
+			}
+
+		}
+	}
+	f.Finish()
+	for _, v := range tombstones {
+		if err := w.Add(v.Start, v.End); err != nil {
+			return nil, nil, err
+		}
+	}
+	if err := w.Close(); err != nil {
+		return nil, nil, err
+	}
+	meta, err := w.Metadata()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	f1, err := mem.Open("test")
+	if err != nil {
+		return nil, nil, err
+	}
+	r, err := NewReader(f1, ReaderOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+	return meta, r, nil
+}
+
+func runBuildRawCmd(td *datadriven.TestData) (*WriterMetadata, *Reader, error) {
+	mem := vfs.NewMem()
+	f0, err := mem.Create("test")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	w := NewWriter(f0, WriterOptions{})
+	for i := range td.CmdArgs {
+		arg := &td.CmdArgs[i]
+		if arg.Key == "range-del-v1" {
+			w.rangeDelV1Format = true
+			break
+		}
+	}
+
+	for _, data := range strings.Split(td.Input, "\n") {
+		j := strings.Index(data, ":")
+		key := base.ParseInternalKey(data[:j])
+		value := []byte(data[j+1:])
+		if err := w.Add(key, value); err != nil {
+			return nil, nil, err
+		}
+	}
+	if err := w.Close(); err != nil {
+		return nil, nil, err
+	}
+	meta, err := w.Metadata()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	f1, err := mem.Open("test")
+	if err != nil {
+		return nil, nil, err
+	}
+	r, err := NewReader(f1, ReaderOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+	return meta, r, nil
+}
+
+func runIterCmd(td *datadriven.TestData, r *Reader) string {
+	for _, arg := range td.CmdArgs {
+		switch arg.Key {
+		case "globalSeqNum":
+			if len(arg.Vals) != 1 {
+				return fmt.Sprintf("%s: arg %s expects 1 value", td.Cmd, arg.Key)
+			}
+			v, err := strconv.Atoi(arg.Vals[0])
+			if err != nil {
+				return err.Error()
+			}
+			r.Properties.GlobalSeqNum = uint64(v)
+		default:
+			return fmt.Sprintf("%s: unknown arg: %s", td.Cmd, arg.Key)
+		}
+	}
+
+	iter := newIterAdapter(r.NewIter(nil /* lower */, nil /* upper */))
+	if err := iter.Error(); err != nil {
+		return err.Error()
+	}
+
+	var b bytes.Buffer
+	var prefix []byte
+	for _, line := range strings.Split(td.Input, "\n") {
+		parts := strings.Fields(line)
+		if len(parts) == 0 {
+			continue
+		}
+		switch parts[0] {
+		case "seek-ge":
+			if len(parts) != 2 {
+				return fmt.Sprintf("seek-ge <key>\n")
+			}
+			prefix = nil
+			iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
+		case "seek-prefix-ge":
+			if len(parts) != 2 {
+				return fmt.Sprintf("seek-prefix-ge <key>\n")
+			}
+			prefix = []byte(strings.TrimSpace(parts[1]))
+			iter.SeekPrefixGE(prefix, prefix /* key */)
+		case "seek-lt":
+			if len(parts) != 2 {
+				return fmt.Sprintf("seek-lt <key>\n")
+			}
+			prefix = nil
+			iter.SeekLT([]byte(strings.TrimSpace(parts[1])))
+		case "first":
+			prefix = nil
+			iter.First()
+		case "last":
+			prefix = nil
+			iter.Last()
+		case "next":
+			iter.Next()
+		case "prev":
+			iter.Prev()
+		}
+		if iter.Valid() && checkValidPrefix(prefix, iter.Key().UserKey) {
+			fmt.Fprintf(&b, "<%s:%d>", iter.Key().UserKey, iter.Key().SeqNum())
+		} else if err := iter.Error(); err != nil {
+			fmt.Fprintf(&b, "<err=%v>", err)
+		} else {
+			fmt.Fprintf(&b, ".")
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -205,6 +205,30 @@ func runIterCmd(td *datadriven.TestData, r *Reader) string {
 			iter.Next()
 		case "prev":
 			iter.Prev()
+		case "set-bounds":
+			if len(parts) <= 1 || len(parts) > 3 {
+				return fmt.Sprintf("set-bounds lower=<lower> upper=<upper>\n")
+			}
+			var lower []byte
+			var upper []byte
+			for _, part := range parts[1:] {
+				arg := strings.Split(strings.TrimSpace(part), "=")
+				switch arg[0] {
+				case "lower":
+					lower = []byte(arg[1])
+					if len(lower) == 0 {
+						lower = nil
+					}
+				case "upper":
+					upper = []byte(arg[1])
+					if len(upper) == 0 {
+						upper = nil
+					}
+				default:
+					return fmt.Sprintf("set-bounds: unknown arg: %s", arg)
+				}
+			}
+			iter.SetBounds(lower, upper)
 		}
 		if iter.Valid() && checkValidPrefix(prefix, iter.Key().UserKey) {
 			fmt.Fprintf(&b, "<%s:%d>", iter.Key().UserKey, iter.Key().SeqNum())

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -116,10 +116,6 @@ func (i *singleLevelIterator) resetForReuse() singleLevelIterator {
 }
 
 func (i *singleLevelIterator) initBounds() {
-	if i.lower == nil && i.upper == nil {
-		return
-	}
-
 	// Trim the iteration bounds for the current block. We don't have to check
 	// the bounds on each iteration if the block is entirely contained within the
 	// iteration bounds.
@@ -433,6 +429,8 @@ func (i *singleLevelIterator) Close() error {
 func (i *singleLevelIterator) SetBounds(lower, upper []byte) {
 	i.lower = lower
 	i.upper = upper
+	i.blockLower = nil
+	i.blockUpper = nil
 }
 
 // compactionIterator is similar to Iterator but it increments the number of

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -85,6 +85,11 @@ func (i *iterAdapter) Valid() bool {
 	return i.key != nil
 }
 
+func (i *iterAdapter) SetBounds(lower, upper []byte) {
+	i.Iterator.SetBounds(lower, upper)
+	i.key = nil
+}
+
 func TestReader(t *testing.T) {
 	writerOpts := map[string]WriterOptions{
 		// No bloom filters.

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -12,7 +12,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -191,117 +190,23 @@ func TestInvalidReader(t *testing.T) {
 }
 
 func runTestReader(t *testing.T, o WriterOptions, dir string, r *Reader) {
-	makeIkeyValue := func(s string) (InternalKey, []byte) {
-		j := strings.Index(s, ":")
-		k := strings.Index(s, "=")
-		seqNum, err := strconv.Atoi(s[j+1 : k])
-		if err != nil {
-			panic(err)
-		}
-		return base.MakeInternalKey([]byte(s[:j]), uint64(seqNum), InternalKeyKindSet), []byte(s[k+1:])
-	}
-
-	mem := vfs.NewMem()
-
 	datadriven.Walk(t, dir, func(t *testing.T, path string) {
 		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "build":
 				if r != nil {
 					r.Close()
-					mem.Remove("sstable")
+					r = nil
 				}
-
-				f, err := mem.Create("sstable")
-				if err != nil {
-					return err.Error()
-				}
-				w := NewWriter(f, o)
-				for _, e := range strings.Split(strings.TrimSpace(d.Input), ",") {
-					k, v := makeIkeyValue(e)
-					w.Add(k, v)
-				}
-				w.Close()
-
-				f, err = mem.Open("sstable")
-				if err != nil {
-					return err.Error()
-				}
-				r, err = NewReader(f, ReaderOptions{})
+				var err error
+				_, r, err = runBuildCmd(d)
 				if err != nil {
 					return err.Error()
 				}
 				return ""
 
 			case "iter":
-				for _, arg := range d.CmdArgs {
-					switch arg.Key {
-					case "globalSeqNum":
-						if len(arg.Vals) != 1 {
-							return fmt.Sprintf("%s: arg %s expects 1 value", d.Cmd, arg.Key)
-						}
-						v, err := strconv.Atoi(arg.Vals[0])
-						if err != nil {
-							return err.Error()
-						}
-						r.Properties.GlobalSeqNum = uint64(v)
-					default:
-						return fmt.Sprintf("%s: unknown arg: %s", d.Cmd, arg.Key)
-					}
-				}
-
-				iter := newIterAdapter(r.NewIter(nil /* lower */, nil /* upper */))
-				if err := iter.Error(); err != nil {
-					t.Fatal(err)
-				}
-
-				var b bytes.Buffer
-				var prefix []byte
-				for _, line := range strings.Split(d.Input, "\n") {
-					parts := strings.Fields(line)
-					if len(parts) == 0 {
-						continue
-					}
-					switch parts[0] {
-					case "seek-ge":
-						if len(parts) != 2 {
-							return fmt.Sprintf("seek-ge <key>\n")
-						}
-						prefix = nil
-						iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
-					case "seek-prefix-ge":
-						if len(parts) != 2 {
-							return fmt.Sprintf("seek-prefix-ge <key>\n")
-						}
-						prefix = []byte(strings.TrimSpace(parts[1]))
-						iter.SeekPrefixGE(prefix, prefix /* key */)
-					case "seek-lt":
-						if len(parts) != 2 {
-							return fmt.Sprintf("seek-lt <key>\n")
-						}
-						prefix = nil
-						iter.SeekLT([]byte(strings.TrimSpace(parts[1])))
-					case "first":
-						prefix = nil
-						iter.First()
-					case "last":
-						prefix = nil
-						iter.Last()
-					case "next":
-						iter.Next()
-					case "prev":
-						iter.Prev()
-					}
-					if iter.Valid() && checkValidPrefix(prefix, iter.Key().UserKey) {
-						fmt.Fprintf(&b, "<%s:%d>", iter.Key().UserKey, iter.Key().SeqNum())
-					} else if err := iter.Error(); err != nil {
-						fmt.Fprintf(&b, "<err=%v>", err)
-					} else {
-						fmt.Fprintf(&b, ".")
-					}
-					b.WriteString("\n")
-				}
-				return b.String()
+				return runIterCmd(d, r)
 
 			case "get":
 				var b bytes.Buffer
@@ -475,10 +380,7 @@ func TestBytesIteratedUncompressed(t *testing.T) {
 }
 
 func buildTestTable(
-	t *testing.T,
-	numEntries uint64,
-	blockSize, indexBlockSize int,
-	compression Compression,
+	t *testing.T, numEntries uint64, blockSize, indexBlockSize int, compression Compression,
 ) *Reader {
 	mem := vfs.NewMem()
 	f0, err := mem.Create("test")

--- a/sstable/testdata/prefixreader/bloom
+++ b/sstable/testdata/prefixreader/bloom
@@ -1,5 +1,9 @@
 build
-a:1=A,aa:2=AA,aaa:3=AAA,aaaa:4=AAAA,b:5=B
+a.SET.1:A
+aa.SET.2:AA
+aaa.SET.3:AAA
+aaaa.SET.4:AAAA
+b.SET.5:B
 ----
 
 get

--- a/sstable/testdata/prefixreader/iter
+++ b/sstable/testdata/prefixreader/iter
@@ -1,5 +1,8 @@
 build
-a:1=A,aa:2=AA,c:3=C,d:4=D
+a.SET.1:A
+aa.SET.2:AA
+c.SET.3:C
+d.SET.4:D
 ----
 
 iter

--- a/sstable/testdata/reader/bloom
+++ b/sstable/testdata/reader/bloom
@@ -1,5 +1,9 @@
 build
-a:1=A,aa:2=AA,aaa:3=AAA,aaaa:4=AAAA,b:5=B
+a.SET.1:A
+aa.SET.2:AA
+aaa.SET.3:AAA
+aaaa.SET.4:AAAA
+b.SET.5:B
 ----
 
 get

--- a/sstable/testdata/reader/iter
+++ b/sstable/testdata/reader/iter
@@ -1,5 +1,8 @@
 build
-a:1=A,b:2=B,c:3=C,d:4=D
+a.SET.1:A
+b.SET.2:B
+c.SET.3:C
+d.SET.4:D
 ----
 
 iter

--- a/sstable/testdata/reader/iter
+++ b/sstable/testdata/reader/iter
@@ -193,3 +193,25 @@ A
 <err: pebble: not found>
 D
 C
+
+# Verify that clearing the bounds on an iterator also clears
+# previously set block{Lower,Upper}.
+
+iter
+seek-ge c
+seek-lt b
+set-bounds lower=b upper=c
+seek-ge c
+seek-lt b
+set-bounds lower= upper=
+seek-ge c
+seek-lt b
+----
+<c:3>
+<a:1>
+.
+.
+.
+.
+<c:3>
+<a:1>


### PR DESCRIPTION
Clear `singleLevelIterator.block{Lower,Upper}` in `SetBounds`. Failing to
do this was causing the values to be reused inappropriately if previous
bounds on the iterator were replaced with no bounds. Also remove the
unnecessary optimizing to elide setting `block{Lower,Upper}` in
`singleLevelIterator.initBounds`.

Found via the metamorphic test.