### PR TITLE
tool: properly calculate "set" and "delete" records

### DIFF
--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -273,8 +273,8 @@ func (s *sstableT) runProperties(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(tw, "  raw-value\t%d\n", r.Properties.RawValueSize)
 			fmt.Fprintf(tw, "records\t%d\n", r.Properties.NumEntries)
 			fmt.Fprintf(tw, "  set\t%d\n", r.Properties.NumEntries-
-				(r.Properties.NumDeletions+r.Properties.NumRangeDeletions+r.Properties.NumMergeOperands))
-			fmt.Fprintf(tw, "  delete\t%d\n", r.Properties.NumDeletions)
+				(r.Properties.NumDeletions+r.Properties.NumMergeOperands))
+			fmt.Fprintf(tw, "  delete\t%d\n", r.Properties.NumDeletions-r.Properties.NumRangeDeletions)
 			fmt.Fprintf(tw, "  range-delete\t%d\n", r.Properties.NumRangeDeletions)
 			fmt.Fprintf(tw, "  merge\t%d\n", r.Properties.NumMergeOperands)
 			fmt.Fprintf(tw, "  global-seq-num\t%d\n", r.Properties.GlobalSeqNum)

--- a/tool/testdata/sstable_properties
+++ b/tool/testdata/sstable_properties
@@ -18,8 +18,8 @@ size
   raw-key         23938
   raw-value       1912
 records           1727
-  set             1693
-  delete          17
+  set             1710
+  delete          0
   range-delete    17
   merge           0
   global-seq-num  0
@@ -53,8 +53,8 @@ size
   raw-key         23938
   raw-value       1912
 records           1727
-  set             1693
-  delete          17
+  set             1710
+  delete          0
   range-delete    17
   merge           0
   global-seq-num  0
@@ -87,8 +87,8 @@ size
   raw-key         23938
   raw-value       1912
 records           1727
-  set             1693
-  delete          17
+  set             1710
+  delete          0
   range-delete    17
   merge           0
   global-seq-num  0


### PR DESCRIPTION
In `sstable properties`, account for `NumDeletions` also include
`NumRangeDeletions`. We were previously double counting range-deletions
in both the "set" and "delete" record counts.

Fixes #459