### PR TITLE
db: fix levelIter.{Next,Prev} when stepping away from opposite boundary

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -884,8 +884,8 @@ type batchIter struct {
 	err   error
 }
 
-// batchIter implements the internalIterator interface.
-var _ internalIterator = (*batchIter)(nil)
+// batchIter implements the base.InternalIterator interface.
+var _ base.InternalIterator = (*batchIter)(nil)
 
 func (i *batchIter) SeekGE(key []byte) (*InternalKey, []byte) {
 	ikey := i.iter.SeekGE(key)
@@ -1222,8 +1222,8 @@ type flushableBatchIter struct {
 	upper []byte
 }
 
-// flushableBatchIter implements the internalIterator interface.
-var _ internalIterator = (*flushableBatchIter)(nil)
+// flushableBatchIter implements the base.InternalIterator interface.
+var _ base.InternalIterator = (*flushableBatchIter)(nil)
 
 // SeekGE implements internalIterator.SeekGE, as documented in the pebble
 // package.
@@ -1392,8 +1392,8 @@ type flushFlushableBatchIter struct {
 	bytesIterated *uint64
 }
 
-// flushFlushableBatchIter implements the internalIterator interface.
-var _ internalIterator = (*flushFlushableBatchIter)(nil)
+// flushFlushableBatchIter implements the base.InternalIterator interface.
+var _ base.InternalIterator = (*flushFlushableBatchIter)(nil)
 
 func (i *flushFlushableBatchIter) SeekGE(key []byte) (*InternalKey, []byte) {
 	panic("pebble: SeekGE unimplemented")

--- a/error_iter.go
+++ b/error_iter.go
@@ -4,11 +4,14 @@
 
 package pebble
 
+import "github.com/cockroachdb/pebble/internal/base"
+
 type errorIter struct {
 	err error
 }
 
-var _ internalIterator = (*errorIter)(nil)
+// errorIter implements the base.InternalIterator interface.
+var _ base.InternalIterator = (*errorIter)(nil)
 
 func newErrorIter(err error) *errorIter {
 	return &errorIter{err: err}

--- a/get_iter.go
+++ b/get_iter.go
@@ -4,7 +4,10 @@
 
 package pebble
 
-import "github.com/cockroachdb/pebble/internal/rangedel"
+import (
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/rangedel"
+)
 
 // getIter is an internal iterator used to perform gets. It iterates through
 // the values for a particular key, level by level. It is not a general purpose
@@ -31,8 +34,8 @@ type getIter struct {
 	err          error
 }
 
-// getIter implements the internalIterator interface.
-var _ internalIterator = (*getIter)(nil)
+// getIter implements the base.InternalIterator interface.
+var _ base.InternalIterator = (*getIter)(nil)
 
 func (g *getIter) SeekGE(key []byte) (*InternalKey, []byte) {
 	panic("pebble: SeekGE unimplemented")

--- a/internal/arenaskl/flush_iterator.go
+++ b/internal/arenaskl/flush_iterator.go
@@ -17,9 +17,7 @@
 
 package arenaskl
 
-import (
-	"github.com/cockroachdb/pebble/internal/base"
-)
+import "github.com/cockroachdb/pebble/internal/base"
 
 // flushIterator is an iterator over the skiplist object. Use Skiplist.NewFlushIter
 // to construct an iterator. The current state of the iterator can be cloned by
@@ -28,6 +26,9 @@ type flushIterator struct {
 	Iterator
 	bytesIterated *uint64
 }
+
+// flushIterator implements the base.InternalIterator interface.
+var _ base.InternalIterator = (*flushIterator)(nil)
 
 func (it *flushIterator) SeekGE(key []byte) (*base.InternalKey, []byte) {
 	panic("pebble: SeekGE unimplemented")

--- a/internal/arenaskl/iterator.go
+++ b/internal/arenaskl/iterator.go
@@ -45,6 +45,9 @@ type Iterator struct {
 	upper []byte
 }
 
+// Iterator implements the base.InternalIterator interface.
+var _ base.InternalIterator = (*Iterator)(nil)
+
 var iterPool = sync.Pool{
 	New: func() interface{} {
 		return &Iterator{}

--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -125,12 +125,22 @@ type InternalIterator interface {
 	// value if the iterator is pointing at a valid entry, and (nil, nil)
 	// otherwise. Note that Next only checks the upper bound. It is up to the
 	// caller to ensure that key is greater than or equal to the lower bound.
+	//
+	// It is valid to call Next when the iterator is positioned before the first
+	// key/value pair due to either a prior call to SeekLT or Prev which returned
+	// (nil, nil). It is undefined to call Next when the previous call to SeekGE
+	// or Next returned (nil, nil).
 	Next() (*InternalKey, []byte)
 
 	// Prev moves the iterator to the previous key/value pair. Returns the key
 	// and value if the iterator is pointing at a valid entry, and (nil, nil)
 	// otherwise. Note that Prev only checks the lower bound. It is up to the
 	// caller to ensure that key is less than the upper bound.
+	//
+	// It is valid to call Prev when the iterator is positioned after the last
+	// key/value pair due to either a prior call to SeekGE or Next which returned
+	// (nil, nil). It is undefined to call Next when the previous call to SeekLT
+	// or Prev returned (nil, nil).
 	Prev() (*InternalKey, []byte)
 
 	// Error returns any accumulated error.

--- a/internal/rangedel/iter.go
+++ b/internal/rangedel/iter.go
@@ -13,6 +13,9 @@ type Iter struct {
 	index      int
 }
 
+// Iter implements the base.InternalIterator interface.
+var _ base.InternalIterator = (*Iter)(nil)
+
 // NewIter returns a new iterator over a set of fragmented tombstones.
 func NewIter(cmp base.Compare, tombstones []Tombstone) *Iter {
 	return &Iter{

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -42,6 +42,9 @@ type fakeIter struct {
 	closeErr error
 }
 
+// fakeIter implements the base.InternalIterator interface.
+var _ base.InternalIterator = (*fakeIter)(nil)
+
 func fakeIkey(s string) InternalKey {
 	j := strings.Index(s, ":")
 	seqNum, err := strconv.Atoi(s[j+1:])

--- a/level_iter.go
+++ b/level_iter.go
@@ -424,21 +424,9 @@ func (l *levelIter) Next() (*InternalKey, []byte) {
 		}
 		return nil, nil
 
-	case l.smallestBoundary != nil:
-		// We're at the smallest boundary, so we need to seek the child iterator to
-		// the first key.
-		l.smallestBoundary = nil
-		if l.tableOpts.LowerBound != nil {
-			if key, val := l.iter.SeekGE(l.tableOpts.LowerBound); key != nil {
-				return l.verify(key, val)
-			}
-		} else {
-			if key, val := l.iter.First(); key != nil {
-				return l.verify(key, val)
-			}
-		}
-
 	default:
+		// Reset the smallest boundary since we're moving away from it.
+		l.smallestBoundary = nil
 		if key, val := l.iter.Next(); key != nil {
 			return l.verify(key, val)
 		}
@@ -462,21 +450,9 @@ func (l *levelIter) Prev() (*InternalKey, []byte) {
 		}
 		return nil, nil
 
-	case l.largestBoundary != nil:
-		// We're at the largest boundary, so we need to seek the child iterator to
-		// the last key.
-		l.largestBoundary = nil
-		if l.tableOpts.UpperBound != nil {
-			if key, val := l.iter.SeekLT(l.tableOpts.UpperBound); key != nil {
-				return l.verify(key, val)
-			}
-		} else {
-			if key, val := l.iter.Last(); key != nil {
-				return l.verify(key, val)
-			}
-		}
-
 	default:
+		// Reset the largest boundary since we're moving away from it.
+		l.largestBoundary = nil
 		if key, val := l.iter.Prev(); key != nil {
 			return l.verify(key, val)
 		}

--- a/level_iter.go
+++ b/level_iter.go
@@ -7,6 +7,8 @@ package pebble
 import (
 	"runtime/debug"
 	"sort"
+
+	"github.com/cockroachdb/pebble/internal/base"
 )
 
 // tableNewIters creates a new point and range-del iterator for the given file
@@ -124,8 +126,8 @@ type levelIter struct {
 	bytesIterated *uint64
 }
 
-// levelIter implements the internalIterator interface.
-var _ internalIterator = (*levelIter)(nil)
+// levelIter implements the base.InternalIterator interface.
+var _ base.InternalIterator = (*levelIter)(nil)
 
 func newLevelIter(
 	opts IterOptions,

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -220,8 +220,8 @@ type mergingIter struct {
 	elideRangeTombstones bool
 }
 
-// mergingIter implements the internalIterator interface.
-var _ internalIterator = (*mergingIter)(nil)
+// mergingIter implements the base.InternalIterator interface.
+var _ base.InternalIterator = (*mergingIter)(nil)
 
 // newMergingIter returns an iterator that merges its input. Walking the
 // resultant iterator will return all key/value pairs of all input iterators

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -207,6 +207,13 @@ func (i *blockIter) init(cmp Compare, block block, globalSeqNum uint64) error {
 	return nil
 }
 
+func (i *blockIter) invalidate() {
+	i.clearCache()
+	i.offset = 0
+	i.nextOffset = 0
+	i.restarts = 0
+}
+
 func (i *blockIter) resetForReuse() blockIter {
 	return blockIter{
 		fullKey:   i.fullKey[:0],

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -182,6 +182,9 @@ type blockIter struct {
 	err         error
 }
 
+// blockIter implements the base.InternalIterator interface.
+var _ base.InternalIterator = (*blockIter)(nil)
+
 func newBlockIter(cmp Compare, block block) (*blockIter, error) {
 	i := &blockIter{}
 	return i, i.init(cmp, block, 0)

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -183,6 +183,10 @@ func (i *singleLevelIterator) SeekGE(key []byte) (*InternalKey, []byte) {
 	}
 
 	if ikey, _ := i.index.SeekGE(key); ikey == nil {
+		// The target key is greater than any key in the sstable. Invalidate the
+		// block iterator so that a subsequent call to Prev() will return the last
+		// key in the table.
+		i.data.invalidate()
 		return nil, nil
 	}
 	if !i.loadBlock() {

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -75,6 +75,9 @@ type singleLevelIterator struct {
 	closeHook  func(i Iterator) error
 }
 
+// singleLevelIterator implements the base.InternalIterator interface.
+var _ base.InternalIterator = (*singleLevelIterator)(nil)
+
 var singleLevelIterPool = sync.Pool{
 	New: func() interface{} {
 		return &singleLevelIterator{}
@@ -435,6 +438,9 @@ type compactionIterator struct {
 	prevOffset    uint64
 }
 
+// compactionIterator implements the base.InternalIterator interface.
+var _ base.InternalIterator = (*compactionIterator)(nil)
+
 func (i *compactionIterator) SeekGE(key []byte) (*InternalKey, []byte) {
 	panic("pebble: SeekGE unimplemented")
 }
@@ -505,6 +511,9 @@ type twoLevelIterator struct {
 	singleLevelIterator
 	topLevelIndex blockIter
 }
+
+// twoLevelIterator implements the base.InternalIterator interface.
+var _ base.InternalIterator = (*twoLevelIterator)(nil)
 
 // loadIndex loads the index block at the current top level index position and
 // leaves i.index unpositioned. If unsuccessful, it gets i.err to any error
@@ -764,6 +773,9 @@ type twoLevelCompactionIterator struct {
 	bytesIterated *uint64
 	prevOffset    uint64
 }
+
+// twoLevelCompactionIterator implements the base.InternalIterator interface.
+var _ base.InternalIterator = (*twoLevelCompactionIterator)(nil)
 
 func (i *twoLevelCompactionIterator) SeekGE(key []byte) (*InternalKey, []byte) {
 	panic("pebble: SeekGE unimplemented")

--- a/sstable/testdata/reader/iter
+++ b/sstable/testdata/reader/iter
@@ -215,3 +215,27 @@ seek-lt b
 .
 <c:3>
 <a:1>
+
+# Verify that seeking past the end of the sstable leaves the iterator
+# in a state where prev returns the last key in the table.
+
+iter
+seek-lt d
+seek-ge f
+prev
+----
+<c:3>
+.
+<d:4>
+
+# Verify that seeking before the beginning of the sstable leaves the
+# iterator in a state where next returns the first key in the table.
+
+iter
+seek-ge b
+seek-lt a
+next
+----
+<b:2>
+.
+<a:1>

--- a/testdata/level_iter_seek
+++ b/testdata/level_iter_seek
@@ -158,3 +158,47 @@ a/a-b#5#5,15:
 c#7,1:c
 a#5,15:
 .
+
+# Verify that prev when positioned at the largest boundary returns the
+# last key.
+
+clear
+----
+
+build
+a.SET.1:a
+b.SET.1:b
+d.RANGEDEL.2:e
+----
+0: a#1,1-e#72057594037927935,15
+
+iter
+seek-lt c
+seek-ge d
+prev
+----
+b/<empty>#1,1:b
+e/d-e#2#72057594037927935,15:
+b#1,1:b
+
+# Verify that next when positioned at the smallest boundary returns
+# the first key.
+
+clear
+----
+
+build
+a.RANGEDEL.1:b
+d.SET.2:d
+e.SET.2:e
+----
+0: a#1,15-e#2,1
+
+iter
+seek-ge d
+seek-lt d
+next
+----
+d/<empty>#2,1:d
+a/a-b#1#1,15:
+d#2,1:d


### PR DESCRIPTION
Fix a bug in `levelIter.Next` when stepping away from the smallest
boundary only calls `Next` on the child iterator, rather than `First`. A
similar bug existed in `levelIter.Prev` when stepping away from the
largest boundary.

Found via the metamorphic test.