### PR TITLE
db: fix Iterator.{Next,Prev} direction switching at boundaries

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -675,9 +675,10 @@ func (c *compaction) newInputIter(newIters tableNewIters) (_ internalIterator, r
 		return rangeDelIter, nil, err
 	}
 
+	iterOpts := IterOptions{logger: c.logger}
 	if c.startLevel != 0 {
-		iters = append(iters, newLevelIter(nil, c.cmp, newIters, c.inputs[0], &c.bytesIterated))
-		iters = append(iters, newLevelIter(nil, c.cmp, newRangeDelIter, c.inputs[0], &c.bytesIterated))
+		iters = append(iters, newLevelIter(iterOpts, c.cmp, newIters, c.inputs[0], &c.bytesIterated))
+		iters = append(iters, newLevelIter(iterOpts, c.cmp, newRangeDelIter, c.inputs[0], &c.bytesIterated))
 	} else {
 		for i := range c.inputs[0] {
 			f := &c.inputs[0][i]
@@ -692,8 +693,8 @@ func (c *compaction) newInputIter(newIters tableNewIters) (_ internalIterator, r
 		}
 	}
 
-	iters = append(iters, newLevelIter(nil, c.cmp, newIters, c.inputs[1], &c.bytesIterated))
-	iters = append(iters, newLevelIter(nil, c.cmp, newRangeDelIter, c.inputs[1], &c.bytesIterated))
+	iters = append(iters, newLevelIter(iterOpts, c.cmp, newIters, c.inputs[1], &c.bytesIterated))
+	iters = append(iters, newLevelIter(iterOpts, c.cmp, newRangeDelIter, c.inputs[1], &c.bytesIterated))
 	return newMergingIter(c.logger, c.cmp, iters...), nil
 }
 

--- a/db.go
+++ b/db.go
@@ -362,6 +362,7 @@ func (d *DB) getInternal(key []byte, b *Batch, s *Snapshot) ([]byte, error) {
 	}
 
 	get := &buf.get
+	get.logger = d.opts.Logger
 	get.cmp = d.cmp
 	get.equal = d.equal
 	get.newIters = d.newIters
@@ -728,7 +729,7 @@ func (d *DB) newIterInternal(
 			li = &levelIter{}
 		}
 
-		li.init(&dbi.opts, d.cmp, d.newIters, current.Files[level], nil)
+		li.init(dbi.opts, d.cmp, d.newIters, current.Files[level], nil)
 		li.initRangeDel(&mlevels[0].rangeDelIter)
 		li.initSmallestLargestUserKey(&mlevels[0].smallestUserKey, &mlevels[0].largestUserKey,
 			&mlevels[0].isLargestUserKeyRangeDelSentinel)
@@ -738,6 +739,7 @@ func (d *DB) newIterInternal(
 
 	buf.merging.init(&dbi.opts, d.cmp, finalMLevels...)
 	buf.merging.snapshot = seqNum
+	buf.merging.elideRangeTombstones = true
 	return dbi
 }
 

--- a/get_iter.go
+++ b/get_iter.go
@@ -4,15 +4,14 @@
 
 package pebble
 
-import (
-	"github.com/cockroachdb/pebble/internal/rangedel"
-)
+import "github.com/cockroachdb/pebble/internal/rangedel"
 
 // getIter is an internal iterator used to perform gets. It iterates through
 // the values for a particular key, level by level. It is not a general purpose
 // internalIterator, but specialized for Get operations so that it loads data
 // lazily.
 type getIter struct {
+	logger       Logger
 	cmp          Compare
 	equal        Equal
 	newIters     tableNewIters
@@ -154,7 +153,8 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 			continue
 		}
 
-		g.levelIter.init(nil, g.cmp, g.newIters, g.version.Files[g.level], nil)
+		iterOpts := IterOptions{logger: g.logger}
+		g.levelIter.init(iterOpts, g.cmp, g.newIters, g.version.Files[g.level], nil)
 		g.levelIter.initRangeDel(&g.rangeDelIter)
 		g.level++
 		g.iter = &g.levelIter

--- a/iterator.go
+++ b/iterator.go
@@ -417,6 +417,9 @@ func (i *Iterator) Next() bool {
 			} else {
 				i.iterKey, i.iterValue = i.iter.First()
 			}
+			for i.iterKey != nil && i.iterKey.Kind() == InternalKeyKindRangeDelete {
+				i.iterKey, i.iterValue = i.iter.Next()
+			}
 		} else {
 			i.nextUserKey()
 		}
@@ -452,6 +455,9 @@ func (i *Iterator) Prev() bool {
 				i.iterKey, i.iterValue = i.iter.SeekLT(upperBound)
 			} else {
 				i.iterKey, i.iterValue = i.iter.Last()
+			}
+			for i.iterKey != nil && i.iterKey.Kind() == InternalKeyKindRangeDelete {
+				i.iterKey, i.iterValue = i.iter.Prev()
 			}
 		} else {
 			i.prevUserKey()

--- a/iterator.go
+++ b/iterator.go
@@ -63,12 +63,6 @@ func (i *Iterator) findNextEntry() bool {
 			i.nextUserKey()
 			continue
 
-		case InternalKeyKindRangeDelete:
-			// Range deletions are treated as no-ops. See the comments in levelIter
-			// regarding table boundaries for more details.
-			i.iterKey, i.iterValue = i.iter.Next()
-			continue
-
 		case InternalKeyKindSet:
 			if i.prefix != nil {
 				if n := i.split(key.UserKey); !bytes.Equal(i.prefix, key.UserKey[:n]) {
@@ -120,11 +114,6 @@ func (i *Iterator) nextUserKey() {
 		if done || i.iterKey == nil {
 			break
 		}
-		if i.iterKey.Kind() == InternalKeyKindRangeDelete {
-			// Range deletions are treated as no-ops. See the comments in levelIter
-			// regarding table boundaries for more details.
-			continue
-		}
 		if !i.equal(i.key, i.iterKey.UserKey) {
 			break
 		}
@@ -156,12 +145,6 @@ func (i *Iterator) findPrevEntry() bool {
 			i.value = nil
 			i.valid = false
 			valueMerger = nil
-			i.iterKey, i.iterValue = i.iter.Prev()
-			continue
-
-		case InternalKeyKindRangeDelete:
-			// Range deletions are treated as no-ops. See the comments in levelIter
-			// regarding table boundaries for more details.
 			i.iterKey, i.iterValue = i.iter.Prev()
 			continue
 
@@ -232,11 +215,6 @@ func (i *Iterator) prevUserKey() {
 		if i.iterKey == nil {
 			break
 		}
-		if i.iterKey.Kind() == InternalKeyKindRangeDelete {
-			// Range deletions are treated as no-ops. See the comments in levelIter
-			// regarding table boundaries for more details.
-			continue
-		}
 		if !i.equal(i.key, i.iterKey.UserKey) {
 			break
 		}
@@ -267,11 +245,6 @@ func (i *Iterator) mergeNext(key InternalKey, valueMerger ValueMerger) {
 			// We've hit a deletion tombstone. Return everything up to this
 			// point.
 			return
-
-		case InternalKeyKindRangeDelete:
-			// Range deletions are treated as no-ops. See the comments in levelIter
-			// regarding table boundaries for more details.
-			continue
 
 		case InternalKeyKindSet:
 			// We've hit a Set value. Merge with the existing value and return.
@@ -417,9 +390,6 @@ func (i *Iterator) Next() bool {
 			} else {
 				i.iterKey, i.iterValue = i.iter.First()
 			}
-			for i.iterKey != nil && i.iterKey.Kind() == InternalKeyKindRangeDelete {
-				i.iterKey, i.iterValue = i.iter.Next()
-			}
 		} else {
 			i.nextUserKey()
 		}
@@ -446,7 +416,7 @@ func (i *Iterator) Prev() bool {
 		// The underlying iterator is pointed to the next key (this can only happen
 		// when switching iteration directions). We set i.valid to false here to
 		// force the calls to prevUserKey to save the current key i.iter is
-		// pointing at in order to determine when the next user-key is reached.
+		// pointing at in order to determine when the prev user-key is reached.
 		i.valid = false
 		if i.iterKey == nil {
 			// We're positioned after the last key. Need to reposition to point to
@@ -455,9 +425,6 @@ func (i *Iterator) Prev() bool {
 				i.iterKey, i.iterValue = i.iter.SeekLT(upperBound)
 			} else {
 				i.iterKey, i.iterValue = i.iter.Last()
-			}
-			for i.iterKey != nil && i.iterKey.Kind() == InternalKeyKindRangeDelete {
-				i.iterKey, i.iterValue = i.iter.Prev()
 			}
 		} else {
 			i.prevUserKey()

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -328,6 +328,7 @@ func TestIterator(t *testing.T) {
 			vals:  vals,
 		})
 		iter.snapshot = seqNum
+		iter.elideRangeTombstones = true
 		return &Iterator{
 			opts:  opts,
 			cmp:   cmp,

--- a/level_checker.go
+++ b/level_checker.go
@@ -231,6 +231,7 @@ func iterateAndCheckTombstones(cmp Compare, tombstones []tombstoneWithLevel) err
 }
 
 type checkConfig struct {
+	logger    Logger
 	cmp       Compare
 	readState *readState
 	newIters  tableNewIters
@@ -430,7 +431,8 @@ func (d *DB) CheckLevels(stats *CheckLevelsStats) error {
 	seqNum := atomic.LoadUint64(&d.mu.versions.visibleSeqNum)
 
 	checkConfig := &checkConfig{
-		cmp:       DefaultComparer.Compare,
+		logger:    d.opts.Logger,
+		cmp:       d.cmp,
 		readState: readState,
 		newIters:  d.newIters,
 		seqNum:    seqNum,
@@ -498,8 +500,9 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 		if len(current.Files[level]) == 0 {
 			continue
 		}
+		iterOpts := IterOptions{logger: c.logger}
 		li := &levelIter{}
-		li.init(nil, c.cmp, c.newIters, current.Files[level], nil)
+		li.init(iterOpts, c.cmp, c.newIters, current.Files[level], nil)
 		li.initRangeDel(&mlevelAlloc[0].rangeDelIter)
 		li.initSmallestLargestUserKey(&mlevelAlloc[0].smallestUserKey, nil, nil)
 		mlevelAlloc[0].iter = li

--- a/level_iter.go
+++ b/level_iter.go
@@ -27,8 +27,8 @@ type tableNewIters func(
 // tombstone, we materialize a fake entry to return from levelIter. This
 // prevents mergingIter from advancing past the sstable until the sstable
 // contains the smallest (or largest for reverse iteration) key in the merged
-// heap. Note that Iterator treat a range deletion tombstone as a no-op and
-// processes range deletions via mergingIter.
+// heap. Note that mergingIter treats a range deletion tombstone returned by
+// the point iterator as a no-op.
 //
 // SeekPrefixGE presents the need for a second type of pausing. If an sstable
 // iterator returns "not found" for a SeekPrefixGE operation, we don't want to
@@ -128,7 +128,7 @@ type levelIter struct {
 var _ internalIterator = (*levelIter)(nil)
 
 func newLevelIter(
-	opts *IterOptions,
+	opts IterOptions,
 	cmp Compare,
 	newIters tableNewIters,
 	files []fileMetadata,
@@ -140,18 +140,16 @@ func newLevelIter(
 }
 
 func (l *levelIter) init(
-	opts *IterOptions,
+	opts IterOptions,
 	cmp Compare,
 	newIters tableNewIters,
 	files []fileMetadata,
 	bytesIterated *uint64,
 ) {
 	l.logger = opts.getLogger()
-	if opts != nil {
-		l.lower = opts.LowerBound
-		l.upper = opts.UpperBound
-		l.tableOpts.TableFilter = opts.TableFilter
-	}
+	l.lower = opts.LowerBound
+	l.upper = opts.UpperBound
+	l.tableOpts.TableFilter = opts.TableFilter
 	l.cmp = cmp
 	l.index = -1
 	l.newIters = newIters

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -74,7 +74,7 @@ func TestLevelIter(t *testing.T) {
 				}
 			}
 
-			iter := newLevelIter(&opts, DefaultComparer.Compare, newIters, files, nil)
+			iter := newLevelIter(opts, DefaultComparer.Compare, newIters, files, nil)
 			defer iter.Close()
 			// Fake up the range deletion initialization.
 			iter.initRangeDel(new(internalIterator))
@@ -113,7 +113,7 @@ func TestLevelIter(t *testing.T) {
 				return newIters(meta, opts, nil)
 			}
 
-			iter := newLevelIter(&opts, DefaultComparer.Compare, newIters2, files, nil)
+			iter := newLevelIter(opts, DefaultComparer.Compare, newIters2, files, nil)
 			iter.SeekGE([]byte(key))
 			lower, upper := tableOpts.GetLowerBound(), tableOpts.GetUpperBound()
 			return fmt.Sprintf("[%s,%s]\n", lower, upper)
@@ -239,7 +239,7 @@ func TestLevelIterBoundaries(t *testing.T) {
 			return lt.runBuild(d)
 
 		case "iter":
-			iter := newLevelIter(nil, DefaultComparer.Compare, lt.newIters, lt.files, nil)
+			iter := newLevelIter(IterOptions{}, DefaultComparer.Compare, lt.newIters, lt.files, nil)
 			defer iter.Close()
 			// Fake up the range deletion initialization.
 			iter.initRangeDel(new(internalIterator))
@@ -307,7 +307,7 @@ func TestLevelIterSeek(t *testing.T) {
 
 		case "iter":
 			iter := &levelIterTestIter{
-				levelIter: newLevelIter(&IterOptions{}, DefaultComparer.Compare, lt.newIters, lt.files, nil),
+				levelIter: newLevelIter(IterOptions{}, DefaultComparer.Compare, lt.newIters, lt.files, nil),
 			}
 			defer iter.Close()
 			iter.initRangeDel(&iter.rangeDelIter)
@@ -397,7 +397,7 @@ func BenchmarkLevelIterSeekGE(b *testing.B) {
 							) (internalIterator, internalIterator, error) {
 								return readers[meta.FileNum].NewIter(nil /* lower */, nil /* upper */), nil, nil
 							}
-							l := newLevelIter(nil, DefaultComparer.Compare, newIters, files, nil)
+							l := newLevelIter(IterOptions{}, DefaultComparer.Compare, newIters, files, nil)
 							rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 
 							b.ResetTimer()
@@ -425,7 +425,7 @@ func BenchmarkLevelIterNext(b *testing.B) {
 							) (internalIterator, internalIterator, error) {
 								return readers[meta.FileNum].NewIter(nil /* lower */, nil /* upper */), nil, nil
 							}
-							l := newLevelIter(nil, DefaultComparer.Compare, newIters, files, nil)
+							l := newLevelIter(IterOptions{}, DefaultComparer.Compare, newIters, files, nil)
 
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {
@@ -456,7 +456,7 @@ func BenchmarkLevelIterPrev(b *testing.B) {
 							) (internalIterator, internalIterator, error) {
 								return readers[meta.FileNum].NewIter(nil /* lower */, nil /* upper */), nil, nil
 							}
-							l := newLevelIter(nil, DefaultComparer.Compare, newIters, files, nil)
+							l := newLevelIter(IterOptions{}, DefaultComparer.Compare, newIters, files, nil)
 
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -219,7 +219,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 					continue
 				}
 				li := &levelIter{}
-				li.init(nil, cmp, newIters, l, nil)
+				li.init(IterOptions{}, cmp, newIters, l, nil)
 				i := len(levelIters)
 				levelIters = append(levelIters, mergingIterLevel{iter: li})
 				li.initRangeDel(&levelIters[i].rangeDelIter)

--- a/testdata/iterator_next_prev
+++ b/testdata/iterator_next_prev
@@ -96,3 +96,81 @@ next
 ----
 z:2
 .
+
+# Verify that switching from reverse iteration to forward iteration
+# properly skips over range tombstones at the start of forward
+# iteration.
+
+reset
+----
+
+build ext1
+set e e
+----
+
+ingest ext1
+----
+6:
+  4:[e#1,SET-e#1,SET]
+
+build ext2
+set b b
+del-range c d
+----
+
+ingest ext2
+----
+6:
+  5:[b#2,SET-d#72057594037927935,RANGEDEL]
+  4:[e#1,SET-e#1,SET]
+
+# The scenario requires iteration at a snapshot. The "last" operation
+# will exhaust the mergingIter looking backwards for visible
+# records. The subsequent "next" will seek-ge(lower) which will skip
+# over the "b" record and find the boundary key due to the range
+# deletion sentinel.
+
+iter seq=2
+set-bounds lower=c upper=f
+last
+next
+----
+.
+e:e
+.
+
+# Verify that switching from forward iteration to reverse iteration
+# properly skips over range tombstones at the end of reverse
+# iteration.
+
+reset
+----
+
+build ext1
+merge a a
+----
+
+ingest ext1
+----
+6:
+  4:[a#1,MERGE-a#1,MERGE]
+
+build ext2
+set e e
+del-range c d
+----
+
+ingest ext2
+----
+6:
+  4:[a#1,MERGE-a#1,MERGE]
+  5:[c#2,RANGEDEL-e#2,SET]
+
+iter seq=2
+set-bounds lower=a upper=e
+first
+prev
+----
+.
+a:a
+.


### PR DESCRIPTION
Fix a bug in `Iterator.{Next,Prev}` when switching iteration directions
at the boundaries of iteration. We need to skip over range tombstones if
they are the first/last key returned by the child iterator.

Found via the metamorphic test.