### PR TITLE
db: add support for concurrent compactions.

### DIFF
--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/stretchr/testify/require"
 )
 
 func loadVersion(d *datadriven.TestData) (*version, *Options, string) {
@@ -72,10 +73,11 @@ func TestCompactionPickerLevelMaxBytes(t *testing.T) {
 					return errMsg
 				}
 
-				p := newCompactionPicker(vers, opts)
+				p := newCompactionPicker(vers, opts, nil)
 				var buf bytes.Buffer
-				for level := p.baseLevel; level < numLevels; level++ {
-					fmt.Fprintf(&buf, "%d: %d\n", level, p.levelMaxBytes[level])
+				levelMaxBytes := p.getLevelMaxBytes()
+				for level := p.getBaseLevel(); level < numLevels; level++ {
+					fmt.Fprintf(&buf, "%d: %d\n", level, levelMaxBytes[level])
 				}
 				return buf.String()
 
@@ -85,19 +87,70 @@ func TestCompactionPickerLevelMaxBytes(t *testing.T) {
 		})
 }
 
+type compactionInfoTesting struct {
+	startLevel  int
+	outputLevel int
+}
+
+func (c compactionInfoTesting) startLevelNum() int       { return c.startLevel }
+func (c compactionInfoTesting) outputLevelNum() int      { return c.outputLevel }
+func (c compactionInfoTesting) smallestKey() InternalKey { return InternalKey{} }
+func (c compactionInfoTesting) largestKey() InternalKey  { return InternalKey{} }
+
 func TestCompactionPickerTargetLevel(t *testing.T) {
+	var vers *version
+	var opts *Options
+	var pickerByScore *compactionPickerByScore
 	datadriven.RunTest(t, "testdata/compaction_picker_target_level",
 		func(d *datadriven.TestData) string {
 			switch d.Cmd {
-			case "pick":
-				vers, opts, errMsg := loadVersion(d)
+			case "init":
+				var errMsg string
+				vers, opts, errMsg = loadVersion(d)
 				if errMsg != "" {
 					return errMsg
 				}
-
-				p := newCompactionPicker(vers, opts)
-				return fmt.Sprintf("%d: %.1f\n", p.level, p.score)
-
+				return ""
+			case "init_cp":
+				p := newCompactionPicker(vers, opts, nil)
+				var ok bool
+				pickerByScore, ok = p.(*compactionPickerByScore)
+				require.True(t, ok)
+				return ""
+			case "queue":
+				var b strings.Builder
+				for _, c := range pickerByScore.compactionQueue {
+					fmt.Fprintf(&b, "%d: %.1f,", c.level, c.score)
+				}
+				return b.String()
+			case "pick":
+				var levels []int
+				if len(d.CmdArgs) == 1 {
+					arg := d.CmdArgs[0]
+					if arg.Key != "ongoing" {
+						return "unknown arg: " + arg.Key
+					}
+					for _, s := range arg.Vals {
+						l, err := strconv.ParseInt(s, 10, 8)
+						if err != nil {
+							return err.Error()
+						}
+						levels = append(levels, int(l))
+					}
+				}
+				if len(levels)%2 != 0 {
+					return "odd number of levels with ongoing compactions"
+				}
+				var inProgress []compactionInfo
+				for i := 0; i < len(levels); i += 2 {
+					inProgress = append(inProgress,
+						compactionInfoTesting{startLevel: levels[i], outputLevel: levels[i+1]})
+				}
+				c := pickerByScore.pickAuto(opts, new(uint64), inProgress)
+				if c == nil {
+					return "no compaction"
+				}
+				return fmt.Sprintf("startLevel: %d, outputLevel: %d", c.startLevel, c.outputLevel)
 			default:
 				return fmt.Sprintf("unknown command: %s", d.Cmd)
 			}
@@ -115,7 +168,7 @@ func TestCompactionPickerEstimatedCompactionDebt(t *testing.T) {
 				}
 				opts.MemTableSize = 1000
 
-				p := newCompactionPicker(vers, opts)
+				p := newCompactionPicker(vers, opts, nil)
 				return fmt.Sprintf("%d\n", p.estimatedCompactionDebt(0))
 
 			default:

--- a/data_test.go
+++ b/data_test.go
@@ -373,7 +373,7 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 		}
 
 		c := newFlush(d.opts, d.mu.versions.currentVersion(),
-			d.mu.versions.picker.baseLevel, []flushable{mem}, &d.bytesFlushed)
+			d.mu.versions.picker.getBaseLevel(), []flushable{mem}, &d.bytesFlushed)
 		c.disableRangeTombstoneElision = true
 		newVE, _, err := d.runCompaction(0, c, nilPacer)
 		if err != nil {
@@ -436,7 +436,9 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 		jobID := d.mu.nextJobID
 		d.mu.nextJobID++
 		d.mu.versions.logLock()
-		if err := d.mu.versions.logAndApply(jobID, ve, nil, d.dataDir); err != nil {
+		if err := d.mu.versions.logAndApply(jobID, ve, nil, d.dataDir, func() []compactionInfo {
+			return nil
+		}); err != nil {
 			return nil, err
 		}
 		d.updateReadStateLocked(nil)

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -427,7 +427,7 @@ func TestIteratorTableFilter(t *testing.T) {
 
 			d.mu.Lock()
 			// Disable the "dynamic base level" code for this test.
-			d.mu.versions.picker.baseLevel = 1
+			d.mu.versions.picker.forceBaseLevel1()
 			s := d.mu.versions.currentVersion().DebugString(base.DefaultFormatter)
 			d.mu.Unlock()
 			return s

--- a/open.go
+++ b/open.go
@@ -229,7 +229,9 @@ func Open(dirname string, opts *Options) (*DB, error) {
 		// newLogNum. There should be no difference in using either value.
 		ve.MinUnflushedLogNum = newLogNum
 		d.mu.versions.logLock()
-		if err := d.mu.versions.logAndApply(jobID, &ve, nil, d.dataDir); err != nil {
+		if err := d.mu.versions.logAndApply(jobID, &ve, nil, d.dataDir, func() []compactionInfo {
+			return nil
+		}); err != nil {
 			return nil, err
 		}
 	}

--- a/options.go
+++ b/options.go
@@ -351,6 +351,10 @@ type Options struct {
 	// default is 1 MB/s.
 	MinFlushRate int
 
+	// MaxConcurrentCompactions specifies the maximum number of concurrent compactions. The
+	// default is 1.
+	MaxConcurrentCompactions int
+
 	// ReadOnly indicates that the DB should be opened in read-only mode. Writes
 	// to the DB will return an error, background compactions are disabled, and
 	// the flush that normally occurs after replaying the WAL at startup is
@@ -462,6 +466,9 @@ func (o *Options) EnsureDefaults() *Options {
 	if o.MinFlushRate == 0 {
 		o.MinFlushRate = 1 << 20 // 1 MB/s
 	}
+	if o.MaxConcurrentCompactions <= 0 {
+		o.MaxConcurrentCompactions = 1
+	}
 
 	o.initMaps()
 	return o
@@ -533,6 +540,7 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  mem_table_stop_writes_threshold=%d\n", o.MemTableStopWritesThreshold)
 	fmt.Fprintf(&buf, "  min_compaction_rate=%d\n", o.MinCompactionRate)
 	fmt.Fprintf(&buf, "  min_flush_rate=%d\n", o.MinFlushRate)
+	fmt.Fprintf(&buf, "  num_concurrent_compactions=%d\n", o.MaxConcurrentCompactions)
 	fmt.Fprintf(&buf, "  merger=%s\n", o.Merger.Name)
 	fmt.Fprintf(&buf, "  table_property_collectors=[")
 	for i := range o.TablePropertyCollectors {
@@ -687,6 +695,8 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				o.MinCompactionRate, err = strconv.Atoi(value)
 			case "min_flush_rate":
 				o.MinFlushRate, err = strconv.Atoi(value)
+			case "num_concurrent_compactions":
+				o.MaxConcurrentCompactions, err = strconv.Atoi(value)
 			case "merger":
 				switch value {
 				case "nullptr":

--- a/options_test.go
+++ b/options_test.go
@@ -58,6 +58,7 @@ func TestOptionsString(t *testing.T) {
   mem_table_stop_writes_threshold=2
   min_compaction_rate=4194304
   min_flush_rate=1048576
+  num_concurrent_compactions=1
   merger=pebble.concatenate
   table_property_collectors=[]
   wal_dir=

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -30,7 +30,7 @@ func TestRangeDel(t *testing.T) {
 
 			d.mu.Lock()
 			// Disable the "dynamic base level" code for this test.
-			d.mu.versions.picker.baseLevel = 1
+			d.mu.versions.picker.forceBaseLevel1()
 			s := fmt.Sprintf("mem: %d\n%s", len(d.mu.mem.queue), d.mu.versions.currentVersion())
 			d.mu.Unlock()
 			return s
@@ -41,7 +41,7 @@ func TestRangeDel(t *testing.T) {
 			}
 			d.mu.Lock()
 			// Disable the "dynamic base level" code for this test.
-			d.mu.versions.picker.baseLevel = 1
+			d.mu.versions.picker.forceBaseLevel1()
 			s := d.mu.versions.currentVersion().String()
 			d.mu.Unlock()
 			return s

--- a/testdata/compaction_picker_target_level
+++ b/testdata/compaction_picker_target_level
@@ -1,28 +1,55 @@
-pick 1
+init 1
 ----
-0: 0.0
 
-pick 1
+init_cp
+----
+
+queue
+----
+
+init 1
 6: 1
 ----
-0: 0.0
 
-pick 1
+init_cp
+----
+
+queue
+----
+
+init 1
 6: 1000000
 ----
-0: 0.0
 
-pick 1
+init_cp
+----
+
+queue
+----
+
+init 1
 5: 1
 6: 10
 ----
-5: 1.0
 
-pick 1
+init_cp
+----
+
+queue
+----
+5: 1.0,
+
+init 1
 5: 2
 6: 10
 ----
-5: 2.0
+
+init_cp
+----
+
+queue
+----
+5: 2.0,
 
 # Smoothing multiplier is
 # `(size(Lbottom)/size(Lbase))^(Lbottom-Lbase) = (30/1)^(1/(6-4)) = 30^(1/2)`
@@ -31,53 +58,142 @@ pick 1
 # size(L5) = size(L4) * 30^(1/2) ~= 5
 # size(L6) = size(L5) * 30^(1/2) = 30
 
-pick 1
+init 1
 5: 2
 6: 30
 ----
-5: 0.4
 
-pick 1
+init_cp
+----
+
+queue
+----
+
+init 1
 4: 2
 5: 2
 6: 100
 ----
-4: 2.0
 
-pick 1
+init_cp
+----
+
+queue
+----
+4: 2.0,
+
+init 1
 4: 1
 5: 2
 6: 100
 ----
-4: 1.0
 
-pick 1
+init_cp
+----
+
+queue
+----
+4: 1.0,
+
+init 1
 4: 1
 5: 11
 6: 100
 ----
-5: 1.1
 
-pick 1
+init_cp
+----
+
+queue
+----
+5: 1.1,4: 1.0,
+
+init 1
 4: 2
 5: 11
 6: 100
 ----
-4: 2.0
 
-pick 1
+init_cp
+----
+
+queue
+----
+4: 2.0,5: 1.1,
+
+init 1
 0: 4
 ----
-0: 1.0
 
-pick 1
+init_cp
+----
+
+queue
+----
+0: 1.0,
+
+init 1
 0: 5
 ----
-0: 1.2
 
-pick 1
+init_cp
+----
+
+queue
+----
+0: 1.2,
+
+init 1
 0: 5
 5: 2
 6: 10
 ----
-5: 2.0
+
+init_cp
+----
+
+queue
+----
+5: 2.0,0: 1.2,
+
+pick
+----
+startLevel: 5, outputLevel: 6
+
+pick
+----
+startLevel: 0, outputLevel: 5
+
+init_cp
+----
+
+pick
+----
+startLevel: 5, outputLevel: 6
+
+pick ongoing=(5,6)
+----
+no compaction
+
+init 1
+0: 5
+4: 2
+5: 3
+6: 10
+----
+
+init_cp
+----
+
+queue
+----
+4: 2.0,0: 1.2,5: 1.0,
+
+pick ongoing=(5,6)
+----
+startLevel: 0, outputLevel: 4
+
+pick
+----
+startLevel: 5, outputLevel: 6
+

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -366,3 +366,65 @@ prev
 c:4
 a:3
 .
+
+define target-file-sizes=(1, 1, 1, 1)
+L0
+  b.SET.1:v
+L0
+  a.SET.2:v
+----
+0:
+  000004:[b-b]
+  000005:[a-a]
+
+add-ongoing-compaction startLevel=0 outputLevel=1
+----
+
+async-compact a-b L0
+----
+manual compaction blocked until ongoing finished
+1:
+  000006:[a#0,SET-a#0,SET]
+  000007:[b#0,SET-b#0,SET]
+
+compact a-b L1
+----
+2:
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
+
+add-ongoing-compaction startLevel=0 outputLevel=1
+----
+
+async-compact a-b L2
+----
+manual compaction blocked until ongoing finished
+3:
+  000010:[a#0,SET-a#0,SET]
+  000011:[b#0,SET-b#0,SET]
+
+add-ongoing-compaction startLevel=0 outputLevel=1
+----
+
+set-concurrent-compactions num=2
+----
+
+async-compact a-b L3
+----
+manual compaction did not block for ongoing
+4:
+  000012:[a#0,SET-a#0,SET]
+  000013:[b#0,SET-b#0,SET]
+
+remove-ongoing-compaction
+----
+
+add-ongoing-compaction startLevel=5 outputLevel=6
+----
+
+async-compact a-b L4
+----
+manual compaction blocked until ongoing finished
+5:
+  000014:[a#0,SET-a#0,SET]
+  000015:[b#0,SET-b#0,SET]

--- a/version_set.go
+++ b/version_set.go
@@ -47,7 +47,7 @@ type versionSet struct {
 
 	// Mutable fields.
 	versions versionList
-	picker   *compactionPicker
+	picker   compactionPicker
 
 	metrics Metrics
 
@@ -109,7 +109,7 @@ func (vs *versionSet) create(
 	vs.init(dirname, opts, mu)
 	newVersion := &version{}
 	vs.append(newVersion)
-	vs.picker = newCompactionPicker(newVersion, vs.opts)
+	vs.picker = newCompactionPicker(newVersion, vs.opts, nil)
 
 	// Note that a "snapshot" version edit is written to the manifest when it is
 	// created.
@@ -241,7 +241,7 @@ func (vs *versionSet) load(dirname string, opts *Options, mu *sync.Mutex) error 
 	}
 	vs.append(newVersion)
 
-	vs.picker = newCompactionPicker(newVersion, vs.opts)
+	vs.picker = newCompactionPicker(newVersion, vs.opts, nil)
 
 	for i := range vs.metrics.Levels {
 		l := &vs.metrics.Levels[i]
@@ -291,8 +291,14 @@ func (vs *versionSet) logUnlock() {
 // while performing file I/O. Requires that the manifest is locked for writing
 // (see logLock). Will unconditionally release the manifest lock (via
 // logUnlock) even if an error occurs.
+//
+// inProgressCompactions is called while DB.mu is held, to get the list of in-progress compactions.
 func (vs *versionSet) logAndApply(
-	jobID int, ve *versionEdit, metrics map[int]*LevelMetrics, dir vfs.File,
+	jobID int,
+	ve *versionEdit,
+	metrics map[int]*LevelMetrics,
+	dir vfs.File,
+	inProgressCompactions func() []compactionInfo,
 ) error {
 	if !vs.writing {
 		vs.opts.Logger.Fatalf("MANIFEST not locked for writing")
@@ -326,7 +332,6 @@ func (vs *versionSet) logAndApply(
 		newManifestFileNum = vs.getNextFileNum()
 	}
 
-	var picker *compactionPicker
 	var zombies map[uint64]uint64
 	if err := func() error {
 		vs.mu.Unlock()
@@ -389,10 +394,6 @@ func (vs *versionSet) logAndApply(
 				FileNum: newManifestFileNum,
 			})
 		}
-		picker = newCompactionPicker(newVersion, vs.opts)
-		if !vs.dynamicBaseLevel {
-			picker.baseLevel = 1
-		}
 		return nil
 	}(); err != nil {
 		return err
@@ -416,7 +417,10 @@ func (vs *versionSet) logAndApply(
 		}
 		vs.manifestFileNum = newManifestFileNum
 	}
-	vs.picker = picker
+	vs.picker = newCompactionPicker(newVersion, vs.opts, inProgressCompactions())
+	if !vs.dynamicBaseLevel {
+		vs.picker.forceBaseLevel1()
+	}
 
 	for level, update := range metrics {
 		vs.metrics.Levels[level].Add(update)


### PR DESCRIPTION
compactionPicker is now an interface since it makes it cleaner to
try different implementation heuristics. The implementation of
this interface, compactionPickerByScore, is a trivial extension
of the current implementation.