### PR TITLE
Make `compactionIter.key` always point to an immutable buffer

### DIFF
--- a/compaction_iter.go
+++ b/compaction_iter.go
@@ -490,6 +490,7 @@ func (i *compactionIter) mergeNext(valueMerger ValueMerger) stripeChangeType {
 func (i *compactionIter) singleDeleteNext() bool {
 	// Save the current key.
 	i.saveKey()
+	i.value = i.iterValue
 	i.valid = true
 
 	// Loop until finds a key to be passed to the next level.

--- a/testdata/compaction_iter
+++ b/testdata/compaction_iter
@@ -708,6 +708,21 @@ first
 .
 
 define
+a.SET.3:a
+b.SINGLEDEL.2:
+b.DEL.1:
+----
+
+iter
+first
+next
+next
+----
+a#3,1:a
+b#2,0:
+.
+
+define
 a.SINGLEDEL.2:
 a.DEL.1:
 ----


### PR DESCRIPTION
Fixes #402.
This is done for better usage semantics of `compactionIter.key`.

The other change going in is to not include previous emitted entry's value when emitting a single delete entry from `compactionIter`.  A data driven test case is included to assert this no longer happens.

