### PR TITLE
multiple fixes for filesystem read error propagation

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -5,12 +5,15 @@
 package pebble
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/vfs"
 )
 
@@ -185,6 +188,70 @@ func (f errorFile) Sync() error {
 	return f.file.Sync()
 }
 
+// corruptFS injects a corruption in the `index`th byte read.
+type corruptFS struct {
+	vfs.FS
+	index     int32
+	bytesRead int32
+}
+
+func newCorruptFS(index int32) *corruptFS {
+	return &corruptFS{
+		FS:        vfs.NewMem(),
+		index:     index,
+		bytesRead: 0,
+	}
+}
+
+func (fs corruptFS) maybeCorrupt(n int32, p []byte) {
+	newBytesRead := atomic.AddInt32(&fs.bytesRead, n)
+	pIdx := newBytesRead - 1 - fs.index
+	if pIdx >= 0 && pIdx < n {
+		p[pIdx]++
+	}
+}
+
+func (fs *corruptFS) Open(name string, opts ...vfs.OpenOption) (vfs.File, error) {
+	f, err := fs.FS.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	cf := corruptFile{f, fs}
+	for _, opt := range opts {
+		opt.Apply(cf)
+	}
+	return cf, nil
+}
+
+type corruptFile struct {
+	vfs.File
+	fs *corruptFS
+}
+
+func (f corruptFile) Read(p []byte) (int, error) {
+	n, err := f.File.Read(p)
+	f.fs.maybeCorrupt(int32(n), p)
+	return n, err
+}
+
+func (f corruptFile) ReadAt(p []byte, off int64) (int, error) {
+	n, err := f.File.ReadAt(p, off)
+	f.fs.maybeCorrupt(int32(n), p)
+	return n, err
+}
+
+func expectLSM(expected string, d *DB, t *testing.T) {
+	t.Helper()
+	expected = strings.TrimSpace(expected)
+	d.mu.Lock()
+	actual := d.mu.versions.currentVersion().DebugString(base.DefaultFormatter)
+	d.mu.Unlock()
+	actual = strings.TrimSpace(actual)
+	if expected != actual {
+		t.Fatalf("expected\n%s\nbut found\n%s", expected, actual)
+	}
+}
+
 // TestErrors repeatedly runs a short sequence of operations, injecting FS
 // errors at different points, until success is achieved.
 func TestErrors(t *testing.T) {
@@ -248,6 +315,187 @@ func TestErrors(t *testing.T) {
 	for _, expected := range expectedErrors {
 		if errorCounts[expected] == 0 {
 			t.Errorf("expected error %q did not occur", expected)
+		}
+	}
+}
+
+// TestRequireReadError injects FS errors into read operations at successively later
+// points until all operations can complete. It requires an operation fails any time
+// an error was injected. This differs from the TestErrors case above as that one
+// cannot require operations fail since it involves flush/compaction, which retry
+// internally and succeed following an injected error.
+func TestRequireReadError(t *testing.T) {
+	run := func(index int32) (err error) {
+		// Perform setup with error injection disabled as it involves writes/background ops.
+		fs := &errorFS{
+			FS:    vfs.NewMem(),
+			index: -1,
+		}
+		d, err := Open("", &Options{
+			FS:     fs,
+			Logger: panicLogger{},
+		})
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		key1 := []byte("a1")
+		key2 := []byte("a2")
+		value := []byte("b")
+		if err := d.Set(key1, value, nil); err != nil {
+			t.Fatalf("%v", err)
+		}
+		if err := d.Set(key2, value, nil); err != nil {
+			t.Fatalf("%v", err)
+		}
+		if err := d.Flush(); err != nil {
+			t.Fatalf("%v", err)
+		}
+		if err := d.Compact(key1, key2); err != nil {
+			t.Fatalf("%v", err)
+		}
+		if err := d.DeleteRange(key1, key2, nil); err != nil {
+			t.Fatalf("%v", err)
+		}
+		if err := d.Set(key1, value, nil); err != nil {
+			t.Fatalf("%v", err)
+		}
+		if err := d.Flush(); err != nil {
+			t.Fatalf("%v", err)
+		}
+		expectLSM(`
+0:
+  7:[a1#3,SET-a2#72057594037927935,RANGEDEL]
+6:
+  5:[a1#0,SET-a2#1,SET]
+`, d, t)
+
+		// Now perform foreground ops with error injection enabled.
+		atomic.StoreInt32(&fs.index, index)
+		iter := d.NewIter(nil)
+		numFound := 0
+		expectedKeys := [][]byte{key1, key2}
+		for valid := iter.First(); valid; valid = iter.Next() {
+			if !bytes.Equal(iter.Key(), expectedKeys[numFound]) {
+				t.Fatalf("expected key %v; found %v", expectedKeys[numFound], iter.Key())
+			}
+			if !bytes.Equal(iter.Value(), value) {
+				t.Fatalf("expected value %v; found %v", value, iter.Value())
+			}
+			numFound++
+		}
+		if err := iter.Close(); err != nil {
+			return err
+		}
+		if err := d.Close(); err != nil {
+			return err
+		}
+		// Reaching here implies all read operations succeeded. This
+		// should only happen when we reached a large enough index at
+		// which `errorFS` did not return any error.
+		if fs.index < 0 {
+			t.Errorf("FS error injected %d ops ago went unreported", -fs.index)
+		}
+		if numFound != 2 {
+			t.Fatalf("expected 2 values; found %d", numFound)
+		}
+		return nil
+	}
+
+	for i := int32(0); ; i++ {
+		err := run(i)
+		if err == nil {
+			t.Logf("no failures reported at index %d", i)
+			break
+		}
+	}
+}
+
+// TestCorruptReadError verifies that reads to a corrupted file detect the
+// corruption and return an error. In this case the filesystem reads return
+// successful status but the data they return is corrupt.
+func TestCorruptReadError(t *testing.T) {
+	run := func(index int32) (err error) {
+		// Perform setup with corruption injection disabled as it involves writes/background ops.
+		fs := &corruptFS{
+			FS:    vfs.NewMem(),
+			index: -1,
+		}
+		d, err := Open("", &Options{
+			FS:     fs,
+			Logger: panicLogger{},
+		})
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		key1 := []byte("a1")
+		key2 := []byte("a2")
+		value := []byte("b")
+		if err := d.Set(key1, value, nil); err != nil {
+			t.Fatalf("%v", err)
+		}
+		if err := d.Set(key2, value, nil); err != nil {
+			t.Fatalf("%v", err)
+		}
+		if err := d.Flush(); err != nil {
+			t.Fatalf("%v", err)
+		}
+		if err := d.Compact(key1, key2); err != nil {
+			t.Fatalf("%v", err)
+		}
+		if err := d.DeleteRange(key1, key2, nil); err != nil {
+			t.Fatalf("%v", err)
+		}
+		if err := d.Set(key1, value, nil); err != nil {
+			t.Fatalf("%v", err)
+		}
+		if err := d.Flush(); err != nil {
+			t.Fatalf("%v", err)
+		}
+		expectLSM(`
+0:
+  7:[a1#3,SET-a2#72057594037927935,RANGEDEL]
+6:
+  5:[a1#0,SET-a2#1,SET]
+`, d, t)
+
+		// Now perform foreground ops with corruption injection enabled.
+		atomic.StoreInt32(&fs.index, index)
+		iter := d.NewIter(nil)
+		numFound := 0
+		expectedKeys := [][]byte{key1, key2}
+		for valid := iter.First(); valid; valid = iter.Next() {
+			if !bytes.Equal(iter.Key(), expectedKeys[numFound]) {
+				t.Fatalf("expected key %v; found %v", expectedKeys[numFound], iter.Key())
+			}
+			if !bytes.Equal(iter.Value(), value) {
+				t.Fatalf("expected value %v; found %v", value, iter.Value())
+			}
+			numFound++
+		}
+		if err := iter.Close(); err != nil {
+			return err
+		}
+		if err := d.Close(); err != nil {
+			return err
+		}
+		// Reaching here implies all read operations succeeded. This
+		// should only happen when we reached a large enough index at
+		// which `corruptFS` did not inject any corruption.
+		if atomic.LoadInt32(&fs.bytesRead) > fs.index {
+			t.Errorf("corruption error injected at index %d went unreported", fs.index)
+		}
+		if numFound != 2 {
+			t.Fatalf("expected 2 values; found %d", numFound)
+		}
+		return nil
+	}
+	for i := int32(0); ; i++ {
+		err := run(i)
+		if err == nil {
+			t.Logf("no failures reported at index %d", i)
+			break
 		}
 	}
 }

--- a/ingest.go
+++ b/ingest.go
@@ -92,7 +92,11 @@ func ingestLoad1(opts *Options, path string, cacheID, fileNum uint64) (*fileMeta
 		}
 	}
 
-	if iter := r.NewRangeDelIter(); iter != nil {
+	iter, err := r.NewRangeDelIter()
+	if err != nil {
+		return nil, err
+	}
+	if iter != nil {
 		defer iter.Close()
 		if key, _ := iter.First(); key != nil {
 			if err := ingestValidateKey(opts, key); err != nil {

--- a/iterator.go
+++ b/iterator.go
@@ -457,7 +457,7 @@ func (i *Iterator) Valid() bool {
 
 // Error returns any accumulated error.
 func (i *Iterator) Error() error {
-	return i.err
+	return firstError(i.err, i.iter.Error())
 }
 
 // Close closes the iterator and returns any accumulated error. Exhausting
@@ -469,9 +469,7 @@ func (i *Iterator) Close() error {
 		i.readState.unref()
 		i.readState = nil
 	}
-	if err := i.iter.Close(); err != nil && i.err != nil {
-		i.err = err
-	}
+	i.err = firstError(i.err, i.iter.Close())
 	err := i.err
 	if alloc := i.alloc; alloc != nil {
 		*i = Iterator{}

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -52,7 +52,11 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 	newIters :=
 		func(meta *fileMetadata, opts *IterOptions, bytesIterated *uint64) (internalIterator, internalIterator, error) {
 			r := readers[meta.FileNum]
-			return r.NewIter(nil, nil), r.NewRangeDelIter(), nil
+			rangeDelIter, err := r.NewRangeDelIter()
+			if err != nil {
+				return nil, nil, err
+			}
+			return r.NewIter(nil /* lower */, nil /* upper */), rangeDelIter, nil
 		}
 
 	datadriven.RunTest(t, "testdata/level_checker", func(d *datadriven.TestData) string {

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -144,7 +144,10 @@ func (lt *levelIterTest) newIters(
 	meta *fileMetadata, opts *IterOptions, _ *uint64,
 ) (internalIterator, internalIterator, error) {
 	iter := lt.readers[meta.FileNum].NewIter(opts.LowerBound, opts.UpperBound)
-	rangeDelIter := lt.readers[meta.FileNum].NewRangeDelIter()
+	rangeDelIter, err := lt.readers[meta.FileNum].NewRangeDelIter()
+	if err != nil {
+		return nil, nil, err
+	}
 	return iter, rangeDelIter, nil
 }
 

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -262,6 +262,11 @@ func (m *mergingIter) initHeap() {
 				key:   *l.iterKey,
 				value: l.iterValue,
 			})
+		} else {
+			m.err = firstError(m.err, l.iter.Error())
+			if m.err != nil {
+				return
+			}
 		}
 	}
 	m.heap.init()

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -134,7 +134,11 @@ func TestMergingIterCornerCases(t *testing.T) {
 	newIters :=
 		func(meta *fileMetadata, opts *IterOptions, bytesIterated *uint64) (internalIterator, internalIterator, error) {
 			r := readers[meta.FileNum]
-			return r.NewIter(opts.GetLowerBound(), opts.GetUpperBound()), r.NewRangeDelIter(), nil
+			rangeDelIter, err := r.NewRangeDelIter()
+			if err != nil {
+				return nil, nil, err
+			}
+			return r.NewIter(opts.GetLowerBound(), opts.GetUpperBound()), rangeDelIter, nil
 		}
 	datadriven.RunTest(t, "testdata/merging_iter", func(d *datadriven.TestData) string {
 		switch d.Cmd {

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -1042,21 +1042,19 @@ func (r *Reader) NewCompactionIter(bytesIterated *uint64) Iterator {
 // NewRangeDelIter returns an internal iterator for the contents of the
 // range-del block for the table. Returns nil if the table does not contain any
 // range deletions.
-func (r *Reader) NewRangeDelIter() base.InternalIterator {
+func (r *Reader) NewRangeDelIter() (base.InternalIterator, error) {
 	if r.rangeDel.bh.Length == 0 {
-		return nil
+		return nil, nil
 	}
 	b, err := r.readRangeDel()
 	if err != nil {
-		// TODO(peter): propagate the error
-		panic(err)
+		return nil, err
 	}
 	i := &blockIter{}
 	if err := i.init(r.Compare, b, r.Properties.GlobalSeqNum); err != nil {
-		// TODO(peter): propagate the error
-		panic(err)
+		return nil, err
 	}
-	return i
+	return i, nil
 }
 
 func (r *Reader) readIndex() (block, error) {

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -61,7 +61,10 @@ func TestWriter(t *testing.T) {
 			return buf.String()
 
 		case "scan-range-del":
-			iter := r.NewRangeDelIter()
+			iter, err := r.NewRangeDelIter()
+			if err != nil {
+				return err.Error()
+			}
 			if iter == nil {
 				return ""
 			}


### PR DESCRIPTION
* Changed `NewRangeDelIter()` to return its error instead of panicking with it.
* Fixed a bug in `Iterator.Close()` where we weren't returning the error from the underlying `mergingIter.Close()`.
* Fixed a bug in `mergingIter` where we weren't returning errors from children iterators until they reached the top of the heap, which could be after we already returned wrong results.

Fixes #466.