### PR TITLE
[wip] error injection in metamorphic test

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -7,8 +7,6 @@ package pebble
 import (
 	"bytes"
 	"fmt"
-	"io"
-	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -24,168 +22,6 @@ func (l panicLogger) Infof(format string, args ...interface{}) {
 
 func (l panicLogger) Fatalf(format string, args ...interface{}) {
 	panic(fmt.Errorf("fatal: "+format, args...))
-}
-
-type errorFS struct {
-	vfs.FS
-	index int32
-}
-
-func newErrorFS(index int32) *errorFS {
-	return &errorFS{
-		FS:    vfs.NewMem(),
-		index: index,
-	}
-}
-
-func (fs *errorFS) maybeError() error {
-	if atomic.AddInt32(&fs.index, -1) == -1 {
-		return fmt.Errorf("injected error")
-	}
-	return nil
-}
-
-func (fs *errorFS) Create(name string) (vfs.File, error) {
-	if err := fs.maybeError(); err != nil {
-		return nil, err
-	}
-	f, err := fs.FS.Create(name)
-	if err != nil {
-		return nil, err
-	}
-	return errorFile{f, fs}, nil
-}
-
-func (fs *errorFS) Link(oldname, newname string) error {
-	if err := fs.maybeError(); err != nil {
-		return err
-	}
-	return fs.FS.Link(oldname, newname)
-}
-
-func (fs *errorFS) Open(name string, opts ...vfs.OpenOption) (vfs.File, error) {
-	if err := fs.maybeError(); err != nil {
-		return nil, err
-	}
-	f, err := fs.FS.Open(name)
-	if err != nil {
-		return nil, err
-	}
-	ef := errorFile{f, fs}
-	for _, opt := range opts {
-		opt.Apply(ef)
-	}
-	return ef, nil
-}
-
-func (fs *errorFS) OpenDir(name string) (vfs.File, error) {
-	if err := fs.maybeError(); err != nil {
-		return nil, err
-	}
-	f, err := fs.FS.OpenDir(name)
-	if err != nil {
-		return nil, err
-	}
-	return errorFile{f, fs}, nil
-}
-
-func (fs *errorFS) Remove(name string) error {
-	if _, err := fs.FS.Stat(name); os.IsNotExist(err) {
-		return nil
-	}
-
-	if err := fs.maybeError(); err != nil {
-		return err
-	}
-	return fs.FS.Remove(name)
-}
-
-func (fs *errorFS) Rename(oldname, newname string) error {
-	if err := fs.maybeError(); err != nil {
-		return err
-	}
-	return fs.FS.Rename(oldname, newname)
-}
-
-func (fs *errorFS) ReuseForWrite(oldname, newname string) (vfs.File, error) {
-	if err := fs.maybeError(); err != nil {
-		return nil, err
-	}
-	return fs.FS.ReuseForWrite(oldname, newname)
-}
-
-func (fs *errorFS) MkdirAll(dir string, perm os.FileMode) error {
-	if err := fs.maybeError(); err != nil {
-		return err
-	}
-	return fs.FS.MkdirAll(dir, perm)
-}
-
-func (fs *errorFS) Lock(name string) (io.Closer, error) {
-	if err := fs.maybeError(); err != nil {
-		return nil, err
-	}
-	return fs.FS.Lock(name)
-}
-
-func (fs *errorFS) List(dir string) ([]string, error) {
-	if err := fs.maybeError(); err != nil {
-		return nil, err
-	}
-	return fs.FS.List(dir)
-}
-
-func (fs *errorFS) Stat(name string) (os.FileInfo, error) {
-	if err := fs.maybeError(); err != nil {
-		return nil, err
-	}
-	return fs.FS.Stat(name)
-}
-
-type errorFile struct {
-	file vfs.File
-	fs   *errorFS
-}
-
-func (f errorFile) Close() error {
-	// We don't inject errors during close as those calls should never fail in
-	// practice.
-	return f.file.Close()
-}
-
-func (f errorFile) Read(p []byte) (int, error) {
-	if err := f.fs.maybeError(); err != nil {
-		return 0, err
-	}
-	return f.file.Read(p)
-}
-
-func (f errorFile) ReadAt(p []byte, off int64) (int, error) {
-	if err := f.fs.maybeError(); err != nil {
-		return 0, err
-	}
-	return f.file.ReadAt(p, off)
-}
-
-func (f errorFile) Write(p []byte) (int, error) {
-	if err := f.fs.maybeError(); err != nil {
-		return 0, err
-	}
-	return f.file.Write(p)
-}
-
-func (f errorFile) Stat() (os.FileInfo, error) {
-	if err := f.fs.maybeError(); err != nil {
-		return nil, err
-	}
-	return f.file.Stat()
-}
-
-func (f errorFile) Sync() error {
-	if err := f.fs.maybeError(); err != nil {
-		return err
-	}
-	return f.file.Sync()
 }
 
 // corruptFS injects a corruption in the `index`th byte read.
@@ -255,7 +91,7 @@ func expectLSM(expected string, d *DB, t *testing.T) {
 // TestErrors repeatedly runs a short sequence of operations, injecting FS
 // errors at different points, until success is achieved.
 func TestErrors(t *testing.T) {
-	run := func(fs *errorFS) (err error) {
+	run := func(fs vfs.FS) (err error) {
 		defer func() {
 			if r := recover(); r != nil {
 				if e, ok := r.(error); ok {
@@ -297,7 +133,8 @@ func TestErrors(t *testing.T) {
 
 	errorCounts := make(map[string]int)
 	for i := int32(0); ; i++ {
-		fs := newErrorFS(i)
+		index := i
+		fs := vfs.NewErrorFS(&index, 0.0 /* prob */, vfs.ErrorFSRead|vfs.ErrorFSWrite, vfs.NewMem())
 		err := run(fs)
 		if err == nil {
 			t.Logf("success %d\n", i)
@@ -327,10 +164,9 @@ func TestErrors(t *testing.T) {
 func TestRequireReadError(t *testing.T) {
 	run := func(index int32) (err error) {
 		// Perform setup with error injection disabled as it involves writes/background ops.
-		fs := &errorFS{
-			FS:    vfs.NewMem(),
-			index: -1,
-		}
+		savedIndex := index
+		index = -1
+		fs := vfs.NewErrorFS(&index, 0.0 /* prob */, vfs.ErrorFSRead|vfs.ErrorFSWrite, vfs.NewMem())
 		d, err := Open("", &Options{
 			FS:     fs,
 			Logger: panicLogger{},
@@ -371,7 +207,7 @@ func TestRequireReadError(t *testing.T) {
 `, d, t)
 
 		// Now perform foreground ops with error injection enabled.
-		atomic.StoreInt32(&fs.index, index)
+		atomic.StoreInt32(&index, savedIndex)
 		iter := d.NewIter(nil)
 		numFound := 0
 		expectedKeys := [][]byte{key1, key2}
@@ -393,8 +229,8 @@ func TestRequireReadError(t *testing.T) {
 		// Reaching here implies all read operations succeeded. This
 		// should only happen when we reached a large enough index at
 		// which `errorFS` did not return any error.
-		if fs.index < 0 {
-			t.Errorf("FS error injected %d ops ago went unreported", -fs.index)
+		if index < 0 {
+			t.Errorf("FS error injected %d ops ago went unreported", -index)
 		}
 		if numFound != 2 {
 			t.Fatalf("expected 2 values; found %d", numFound)

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -313,7 +313,7 @@ func TestIngestLinkFallback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	opts := &Options{FS: &errorFS{mem, 0}}
+	opts := &Options{FS: vfs.NewErrorFS(new(int32) /* index */, 0.0 /* prob */, vfs.ErrorFSWrite, mem)}
 	opts.EnsureDefaults()
 
 	meta := []*fileMetadata{{FileNum: 1}}

--- a/vfs/error_fs.go
+++ b/vfs/error_fs.go
@@ -1,0 +1,197 @@
+package vfs
+
+import (
+	"errors"
+	"io"
+	"math/rand"
+	"os"
+	"sync/atomic"
+)
+
+// ErrorFSMode is a bit field specifying the operation types for which error injection
+// is enabled.
+type ErrorFSMode int
+
+// ErrorFSMsg is the error message for injected errors.
+const ErrorFSMsg = "injected error"
+
+const (
+	// ErrorFSRead enables errors for filesystem read operations.
+	ErrorFSRead ErrorFSMode = 0x1
+	// ErrorFSWrite enables errors for filesystem write operations.
+	ErrorFSWrite = 0x2
+)
+
+// NewErrorFS returns a new FS implementation that wraps another FS
+// and injects an error for the operation at the specified index, or
+// for operations with the specified probability.
+func NewErrorFS(index *int32, prob float64, mode ErrorFSMode, fs FS) FS {
+	return &errorFS{
+		FS:    fs,
+		index: index,
+		prob:  prob,
+		mode:  mode,
+	}
+}
+
+type errorFS struct {
+	FS
+	index *int32
+	prob  float64
+	mode  ErrorFSMode
+}
+
+func (fs *errorFS) maybeError(mode ErrorFSMode) error {
+	if fs.mode&mode == 0 {
+		return nil
+	}
+	if fs.index != nil && atomic.AddInt32(fs.index, -1) == -1 {
+		return errors.New(ErrorFSMsg)
+	}
+	if fs.prob > 0.0 && rand.Float64() < fs.prob {
+		return errors.New(ErrorFSMsg)
+	}
+	return nil
+}
+
+func (fs *errorFS) Create(name string) (File, error) {
+	if err := fs.maybeError(ErrorFSWrite); err != nil {
+		return nil, err
+	}
+	f, err := fs.FS.Create(name)
+	if err != nil {
+		return nil, err
+	}
+	return errorFile{f, fs}, nil
+}
+
+func (fs *errorFS) Link(oldname, newname string) error {
+	if err := fs.maybeError(ErrorFSWrite); err != nil {
+		return err
+	}
+	return fs.FS.Link(oldname, newname)
+}
+
+func (fs *errorFS) Open(name string, opts ...OpenOption) (File, error) {
+	if err := fs.maybeError(ErrorFSRead); err != nil {
+		return nil, err
+	}
+	f, err := fs.FS.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	ef := errorFile{f, fs}
+	for _, opt := range opts {
+		opt.Apply(ef)
+	}
+	return ef, nil
+}
+
+func (fs *errorFS) OpenDir(name string) (File, error) {
+	if err := fs.maybeError(ErrorFSRead); err != nil {
+		return nil, err
+	}
+	f, err := fs.FS.OpenDir(name)
+	if err != nil {
+		return nil, err
+	}
+	return errorFile{f, fs}, nil
+}
+
+func (fs *errorFS) Remove(name string) error {
+	if _, err := fs.FS.Stat(name); os.IsNotExist(err) {
+		return nil
+	}
+	if err := fs.maybeError(ErrorFSWrite); err != nil {
+		return err
+	}
+	return fs.FS.Remove(name)
+}
+
+func (fs *errorFS) Rename(oldname, newname string) error {
+	if err := fs.maybeError(ErrorFSWrite); err != nil {
+		return err
+	}
+	return fs.FS.Rename(oldname, newname)
+}
+
+func (fs *errorFS) ReuseForWrite(oldname, newname string) (File, error) {
+	if err := fs.maybeError(ErrorFSWrite); err != nil {
+		return nil, err
+	}
+	return fs.FS.ReuseForWrite(oldname, newname)
+}
+
+func (fs *errorFS) MkdirAll(dir string, perm os.FileMode) error {
+	if err := fs.maybeError(ErrorFSWrite); err != nil {
+		return err
+	}
+	return fs.FS.MkdirAll(dir, perm)
+}
+
+func (fs *errorFS) Lock(name string) (io.Closer, error) {
+	if err := fs.maybeError(ErrorFSWrite); err != nil {
+		return nil, err
+	}
+	return fs.FS.Lock(name)
+}
+
+func (fs *errorFS) List(dir string) ([]string, error) {
+	if err := fs.maybeError(ErrorFSRead); err != nil {
+		return nil, err
+	}
+	return fs.FS.List(dir)
+}
+
+func (fs *errorFS) Stat(name string) (os.FileInfo, error) {
+	if err := fs.maybeError(ErrorFSRead); err != nil {
+		return nil, err
+	}
+	return fs.FS.Stat(name)
+}
+
+type errorFile struct {
+	file File
+	fs   *errorFS
+}
+
+func (f errorFile) Close() error {
+	// We don't inject errors during close as those calls should never fail in
+	// practice.
+	return f.file.Close()
+}
+
+func (f errorFile) Read(p []byte) (int, error) {
+	if err := f.fs.maybeError(ErrorFSRead); err != nil {
+		return 0, err
+	}
+	return f.file.Read(p)
+}
+
+func (f errorFile) ReadAt(p []byte, off int64) (int, error) {
+	if err := f.fs.maybeError(ErrorFSRead); err != nil {
+		return 0, err
+	}
+	return f.file.ReadAt(p, off)
+}
+
+func (f errorFile) Write(p []byte) (int, error) {
+	if err := f.fs.maybeError(ErrorFSWrite); err != nil {
+		return 0, err
+	}
+	return f.file.Write(p)
+}
+
+func (f errorFile) Stat() (os.FileInfo, error) {
+	if err := f.fs.maybeError(ErrorFSRead); err != nil {
+		return nil, err
+	}
+	return f.file.Stat()
+}
+
+func (f errorFile) Sync() error {
+	if err := f.fs.maybeError(ErrorFSWrite); err != nil {
+		return err
+	}
+	return f.file.Sync()
+}


### PR DESCRIPTION
Added an `-error-rate` flag to metamorphic test which injects errors, currently for reads only. Introduced a `retryableIter` that holds the last key successfully returned. It is used to recover from error state by seeking back to that key after encountering an error. Then, failed operations can be retried.