### PR TITLE
internal/metamorphic: exit on the first failure

### DIFF
--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -251,7 +251,11 @@ func TestMeta(t *testing.T) {
 				t.Fatal(err)
 			}
 			if text != "" {
-				t.Fatalf("diff %s/{%s,%s}\n%s\n", metaDir, names[0], names[1], text)
+				// NB: We force an exit rather than using t.Fatal because the later
+				// will run another instance of the test if -count is specified, while
+				// we're happy to exit on the first failure.
+				fmt.Printf("diff %s/{%s,%s}\n%s\n", metaDir, names[0], names[i], text)
+				os.Exit(1)
 			}
 		}
 	}

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -104,21 +104,13 @@ func standardOptions() []*pebble.Options {
 `,
 		14: `
 [Level "0"]
-  compression=Snappy
+  index_block_size=1
 `,
 		15: `
 [Level "0"]
-  index_block_size=1
-`,
-		16: `
-[Level "0"]
-  index_block_size=1
-`,
-		17: `
-[Level "0"]
   target_file_size=1
 `,
-		18: `
+		16: `
 [Level "0"]
   filter_policy=none
 `,


### PR DESCRIPTION
When running the `TestMeta` with `-count > 1`, it is nice to exit on the
first failure rather than continuing.

Remove some redundant options from `standardOptions()`.