### PR TITLE
db: deflake TestTableCacheRetryAfterFailure

### DIFF
--- a/table_cache.go
+++ b/table_cache.go
@@ -426,7 +426,6 @@ func (n *tableCacheNode) load(c *tableCacheShard) {
 			n.reader.Properties.GlobalSeqNum = n.meta.LargestSeqNum
 		}
 	}
-	close(n.loaded)
 	if n.err != nil {
 		c.mu.Lock()
 		defer c.mu.Unlock()
@@ -436,6 +435,7 @@ func (n *tableCacheNode) load(c *tableCacheShard) {
 			c.releaseNode(n)
 		}
 	}
+	close(n.loaded)
 }
 
 func (n *tableCacheNode) release(c *tableCacheShard) {


### PR DESCRIPTION
We were closing the `tableCacheNode.loaded` channel on error before
removing the `tableCacheNode` from the map, causing a race which allowed
the error to be reported and a subsequent operation to find the error
before the node was actually removed.

Fixes #469