### PR TITLE
internal/rangedel: fix SeekLE returning incorrect tombstone

### DIFF
--- a/internal/rangedel/seek_test.go
+++ b/internal/rangedel/seek_test.go
@@ -7,7 +7,6 @@ package rangedel
 import (
 	"bytes"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -88,21 +87,7 @@ func TestSeek(t *testing.T) {
 					return err.Error()
 				}
 				tombstone := seek(cmp, iter, []byte(parts[0]), seq)
-				fmt.Fprintf(&buf, "%s",
-					strings.TrimSpace(formatTombstones([]Tombstone{tombstone})))
-				// Check that the returned tombstone and the tombstone the iterator is
-				// pointed at are identical.
-				var iTombstone Tombstone
-				if iter.Valid() {
-					iTombstone = Tombstone{
-						Start: *iter.Key(),
-						End:   iter.Value(),
-					}
-				}
-				if !reflect.DeepEqual(tombstone, iTombstone) {
-					fmt.Fprintf(&buf, " [%s]",
-						strings.TrimSpace(formatTombstones([]Tombstone{tombstone})))
-				}
+				fmt.Fprintf(&buf, "%s", strings.TrimSpace(formatTombstones([]Tombstone{tombstone})))
 				fmt.Fprintf(&buf, "\n")
 			}
 			return buf.String()

--- a/internal/rangedel/testdata/seek
+++ b/internal/rangedel/testdata/seek
@@ -286,3 +286,35 @@ z 2
 3:                   s------z
 2:             m-----s
 1:          j--m
+
+build
+1: a-c
+3: a-c
+5: a-c
+5: c-e
+----
+5: a-c
+3: a-c
+1: a-c
+5:   c-e
+
+# Regression test for a bug where seek-le was failing to find the most
+# recent version of a tombstone. The problematic case was "seek-le c
+# 4". The seeking code was finding the tombstone c-e#5, determining it
+# wasn't visible and then return the immediately preceding tombstone
+# a-c#1, instead of the correct tombstone a-c#3.
+
+seek-le
+c 1
+c 2
+c 3
+c 4
+c 5
+c 6
+----
+<empty>
+1: a-c
+1: a-c
+3: a-c
+3: a-c
+5:   c-e


### PR DESCRIPTION
Fix a bug in `SeekLE` where it was returning the oldest tombstone rather
than the newest visible tombstone. The problem scenario involved 4
tombstones:

```
  5: a-c
  3: a-c
  1: a-c
  5:   c-e
```

A call to `SeekLE("c", 4)` was returning the tombstone `a-c#1` rather
than the correct tombstone `a-c#3`. The problem was that the tombstone
`c-e#5` contains the search key, but none of the versions of that
fragment are visible and the code was naively returning the immediately
preceding tombstone.

Removed an invariant that `Seek{GE,LE}` leave the iterator positioned at
the returned tombstone. This wasn't being used anywhere, and resulted in
some confusing code in `SeekLE`. While this invariant falls out
naturally in `SeekGE`, it seems useful for consistency for neither
`SeekGE` or `SeekLE` to provide it.

Found via the metamorphic test.