### PR TITLE
db: fix sstable smallest boundary generation

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -778,7 +778,14 @@ func TestManualCompaction(t *testing.T) {
 			return runLSMCmd(td, d)
 
 		case "iter":
-			iter := d.NewIter(nil)
+			// TODO(peter): runDBDefineCmd doesn't properly update the visible
+			// sequence number. So we have to use a snapshot with a very large
+			// sequence number, otherwise the DB appears empty.
+			snap := Snapshot{
+				db:     d,
+				seqNum: InternalKeySeqNumMax,
+			}
+			iter := snap.NewIter(nil)
 			defer iter.Close()
 			return runIterCmd(td, iter)
 

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -147,7 +147,7 @@ func TestRangeDelCompactionTruncation(t *testing.T) {
 	expectLSM(`
 1:
   8:[a#2,RANGEDEL-b#72057594037927935,RANGEDEL]
-  9:[b#1,SET-d#72057594037927935,RANGEDEL]
+  9:[b#2,RANGEDEL-d#72057594037927935,RANGEDEL]
 `)
 
 	// Compact again to move one of the tables to L2.
@@ -158,7 +158,7 @@ func TestRangeDelCompactionTruncation(t *testing.T) {
 1:
   8:[a#2,RANGEDEL-b#72057594037927935,RANGEDEL]
 2:
-  9:[b#1,SET-d#72057594037927935,RANGEDEL]
+  9:[b#2,RANGEDEL-d#72057594037927935,RANGEDEL]
 `)
 
 	// Write "b" and "c" to a new table.
@@ -177,7 +177,7 @@ func TestRangeDelCompactionTruncation(t *testing.T) {
 1:
   8:[a#2,RANGEDEL-b#72057594037927935,RANGEDEL]
 2:
-  9:[b#1,SET-d#72057594037927935,RANGEDEL]
+  9:[b#2,RANGEDEL-d#72057594037927935,RANGEDEL]
 `)
 
 	// "b" is still visible at this point as it should be.

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -85,8 +85,8 @@ compact a-e L1
 ----
 2:
   8:[a#3,SET-b#72057594037927935,RANGEDEL]
-  9:[b#0,RANGEDEL-d#72057594037927935,RANGEDEL]
-  10:[d#0,RANGEDEL-e#72057594037927935,RANGEDEL]
+  9:[b#2,RANGEDEL-d#72057594037927935,RANGEDEL]
+  10:[d#2,RANGEDEL-e#72057594037927935,RANGEDEL]
 3:
   6:[a#0,SET-b#0,SET]
   7:[c#0,SET-d#0,SET]
@@ -125,9 +125,9 @@ compact a-e L1
 ----
 2:
   10:[a#3,SET-b#72057594037927935,RANGEDEL]
-  11:[b#0,RANGEDEL-d#72057594037927935,RANGEDEL]
-  12:[d#0,RANGEDEL-f#72057594037927935,RANGEDEL]
-  13:[f#0,RANGEDEL-g#72057594037927935,RANGEDEL]
+  11:[b#2,RANGEDEL-d#72057594037927935,RANGEDEL]
+  12:[d#2,RANGEDEL-f#72057594037927935,RANGEDEL]
+  13:[f#2,RANGEDEL-g#72057594037927935,RANGEDEL]
 3:
   6:[a#0,SET-b#0,SET]
   7:[c#0,SET-d#0,SET]
@@ -166,9 +166,9 @@ compact a-e L1
 ----
 2:
   9:[a#3,SET-b#72057594037927935,RANGEDEL]
-  10:[b#0,RANGEDEL-d#72057594037927935,RANGEDEL]
-  11:[d#0,RANGEDEL-f#72057594037927935,RANGEDEL]
-  12:[f#0,RANGEDEL-h#3,SET]
+  10:[b#2,RANGEDEL-d#72057594037927935,RANGEDEL]
+  11:[d#2,RANGEDEL-f#72057594037927935,RANGEDEL]
+  12:[f#2,RANGEDEL-h#3,SET]
 3:
   6:[a#0,SET-b#0,SET]
   7:[c#0,SET-d#0,SET]
@@ -202,8 +202,8 @@ compact a-e L1
 ----
 2:
   8:[a#3,RANGEDEL-b#72057594037927935,RANGEDEL]
-  9:[b#0,RANGEDEL-d#72057594037927935,RANGEDEL]
-  10:[d#0,RANGEDEL-e#72057594037927935,RANGEDEL]
+  9:[b#3,RANGEDEL-d#72057594037927935,RANGEDEL]
+  10:[d#3,RANGEDEL-e#72057594037927935,RANGEDEL]
 3:
   6:[a#0,SET-b#0,SET]
   7:[c#0,SET-d#0,SET]
@@ -237,7 +237,7 @@ compact a-c L1
 ----
 2:
   9:[a#3,RANGEDEL-b#72057594037927935,RANGEDEL]
-  10:[b#0,RANGEDEL-c#2,SET]
+  10:[b#3,RANGEDEL-c#2,SET]
 3:
   6:[b#2,SET-b#2,SET]
   7:[b#1,SET-b#1,SET]
@@ -307,4 +307,62 @@ next
 a:2
 b:2
 z:1
+.
+
+# Regresion test for a bug in sstable smallest boundary generation
+# where the smallest key for an sstable was set to a key "larger" than
+# the start key of the first range tombstone. This in turn fouled up
+# the processing logic of range tombstones used by mergingIter which
+# allowed stepping out of an sstable even though it contained a range
+# tombstone that covered keys in lower levels.
+
+define target-file-sizes=(1, 1, 1, 1)
+L0
+  c.SET.4:4
+L1
+  a.SET.3:3
+L2
+  a.RANGEDEL.2:e
+L3
+  b.SET.1:1
+----
+0:
+  4:[c-c]
+1:
+  5:[a-a]
+2:
+  6:[a-e]
+3:
+  7:[b-b]
+
+compact a-e L1
+----
+0:
+  4:[c#4,SET-c#4,SET]
+2:
+  8:[a#3,SET-b#72057594037927935,RANGEDEL]
+  9:[b#2,RANGEDEL-e#72057594037927935,RANGEDEL]
+3:
+  7:[b#1,SET-b#1,SET]
+
+# We should only see a:3 and c:4 at this point.
+
+iter
+first
+next
+next
+----
+a:3
+c:4
+.
+
+# The bug allowed seeing b:1 during reverse iteration.
+
+iter
+last
+prev
+prev
+----
+c:4
+a:3
 .


### PR DESCRIPTION
Fix the generation of the sstable's smallest boundary key when that key
comes from a range tombstone. This is necessary, otherwise the smallest
key metadata for an sstable can be "larger" than the first range
tombstone stored in a file which mucks up handling of range tombstones
during iteration.

Found via the metamorphic test.