### PR TITLE
db: fix cases where we were removing still open files

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"os"
 	"regexp"
 	"runtime"
 	"sort"
@@ -630,7 +631,6 @@ func TestCompaction(t *testing.T) {
 				if err != nil {
 					return "", "", fmt.Errorf("Open: %v", err)
 				}
-				defer f.Close()
 				r, err := sstable.NewReader(f, sstable.ReaderOptions{})
 				if err != nil {
 					return "", "", fmt.Errorf("NewReader: %v", err)
@@ -713,6 +713,14 @@ func TestCompaction(t *testing.T) {
 	}
 }
 
+type noLinkFS struct {
+	vfs.FS
+}
+
+func (fs noLinkFS) Link(oldname, newname string) error {
+	return os.ErrInvalid
+}
+
 func TestManualCompaction(t *testing.T) {
 	var mem vfs.FS
 	var d *DB
@@ -724,7 +732,11 @@ func TestManualCompaction(t *testing.T) {
 			t.Fatal(err)
 		}
 		d, err = Open("", &Options{
-			FS:         mem,
+			// NB: We need to disable hard links for this test as the combination of
+			// CheckLevels and the deletion of the files after ingestion is
+			// incompatible because CheckLevels causes the files to get loaded into
+			// the table cache and memFS prohibits removing open files.
+			FS:         noLinkFS{mem},
 			DebugCheck: true,
 		})
 		if err != nil {

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -95,7 +95,6 @@ func TestIngestLoadRand(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer f.Close()
 
 			keys := make([]InternalKey, 1+rng.Intn(100))
 			for i := range keys {

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -392,7 +392,6 @@ func buildTestTable(
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f0.Close()
 
 	w := NewWriter(f0, WriterOptions{
 		BlockSize:      blockSize,

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -345,7 +345,6 @@ func build(
 	if err != nil {
 		return nil, err
 	}
-	defer f0.Close()
 	tmpFileCount++
 
 	writerOpts := WriterOptions{

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -17,6 +17,7 @@ create: wal/000002.log
 sync: wal
 [JOB 1] WAL created 000002
 create: db/MANIFEST-000003
+close: db/MANIFEST-000001
 sync: db/MANIFEST-000003
 create: db/CURRENT.000003.dbtmp
 sync: db/CURRENT.000003.dbtmp
@@ -44,6 +45,7 @@ sync: db/000006.sst
 close: db/000006.sst
 sync: db
 create: db/MANIFEST-000007
+close: db/MANIFEST-000003
 sync: db/MANIFEST-000007
 create: db/CURRENT.000007.dbtmp
 sync: db/CURRENT.000007.dbtmp
@@ -69,6 +71,7 @@ sync: db/000009.sst
 close: db/000009.sst
 sync: db
 create: db/MANIFEST-000010
+close: db/MANIFEST-000007
 sync: db/MANIFEST-000010
 create: db/CURRENT.000010.dbtmp
 sync: db/CURRENT.000010.dbtmp
@@ -85,6 +88,7 @@ sync: db/000011.sst
 close: db/000011.sst
 sync: db
 create: db/MANIFEST-000012
+close: db/MANIFEST-000010
 sync: db/MANIFEST-000012
 create: db/CURRENT.000012.dbtmp
 sync: db/CURRENT.000012.dbtmp
@@ -115,6 +119,7 @@ sync: db/000014.sst
 close: db/000014.sst
 sync: db
 create: db/MANIFEST-000015
+close: db/MANIFEST-000012
 sync: db/MANIFEST-000015
 create: db/CURRENT.000015.dbtmp
 sync: db/CURRENT.000015.dbtmp
@@ -134,6 +139,7 @@ link: ext/0 -> db/000016.sst
 [JOB 10] ingesting: sstable created 000016
 sync: db
 create: db/MANIFEST-000017
+close: db/MANIFEST-000015
 sync: db/MANIFEST-000017
 create: db/CURRENT.000017.dbtmp
 sync: db/CURRENT.000017.dbtmp

--- a/version_set.go
+++ b/version_set.go
@@ -481,6 +481,17 @@ func (vs *versionSet) createManifest(dirname string, fileNum uint64) (err error)
 		return err
 	}
 
+	if vs.manifest != nil {
+		vs.manifest.Close()
+		vs.manifest = nil
+	}
+	if vs.manifestFile != nil {
+		if err := vs.manifestFile.Close(); err != nil {
+			return err
+		}
+		vs.manifestFile = nil
+	}
+
 	vs.manifest, manifest = manifest, nil
 	vs.manifestFile, manifestFile = manifestFile, nil
 	return nil

--- a/vfs/testdata/vfs
+++ b/vfs/testdata/vfs
@@ -10,6 +10,7 @@ remove b
 ----
 link: a -> b [file does not exist]
 create: a [<nil>]
+close: a [<nil>]
 link: a -> b [<nil>]
 link: a -> b [file already exists]
 link: c -> d [file does not exist]
@@ -23,6 +24,7 @@ link a b
 link-or-copy a b
 ----
 create: a [<nil>]
+close: a [<nil>]
 link: a -> b [file already exists]
 link: a -> b [file already exists]
 
@@ -32,6 +34,7 @@ link a b
 link-or-copy a b
 ----
 create: a [<nil>]
+close: a [<nil>]
 link: a -> b [file does not exist]
 link: a -> b [file does not exist]
 
@@ -41,6 +44,7 @@ link a b
 link-or-copy a b
 ----
 create: a [<nil>]
+close: a [<nil>]
 link: a -> b [permission denied]
 link: a -> b [permission denied]
 
@@ -50,6 +54,7 @@ link a b
 link-or-copy a b
 ----
 create: a [<nil>]
+close: a [<nil>]
 link: a -> b [random]
 link: a -> b [random]
 open: a [<nil>]
@@ -66,8 +71,10 @@ create d/b/c
 ----
 mkdir: d [<nil>]
 create: d/a [<nil>]
+close: a [<nil>]
 mkdir: d/b [<nil>]
 create: d/b/c [<nil>]
+close: c [<nil>]
 
 define
 clone d e

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -163,7 +163,8 @@ func runTestVFS(t *testing.T, baseFS FS, dir string) {
 					if len(parts) != 2 {
 						return fmt.Sprintf("create <name>")
 					}
-					_, _ = fs.Create(fs.PathJoin(dir, parts[1]))
+					f, _ := fs.Create(fs.PathJoin(dir, parts[1]))
+					f.Close()
 
 				case "link":
 					if len(parts) != 3 {


### PR DESCRIPTION
Windows disallows removing open files. In order to catch these case,
`memFS` has been changed to have those same semantics. The two
problematic places in non-test were a failure to close the previous
manifest on rollover, and the asynchronous closing of sstables when they
are evicted from the table cache due to being obsolete.

Fixes #477