### PR TITLE
sstable: fix a bug with iterator "wrap around" on next/prev

### DIFF
--- a/sstable/block.go
+++ b/sstable/block.go
@@ -212,6 +212,8 @@ func (i *blockIter) invalidate() {
 	i.offset = 0
 	i.nextOffset = 0
 	i.restarts = 0
+	i.numRestarts = 0
+	i.data = nil
 }
 
 func (i *blockIter) resetForReuse() blockIter {

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -377,7 +377,8 @@ func TestBytesIteratedUncompressed(t *testing.T) {
 
 				expected := r.Properties.DataSize
 				if bytesIterated != expected {
-					t.Fatalf("bytesIterated: got %d, want %d", bytesIterated, expected)
+					t.Fatalf("bytesIterated: got %d, want %d (blockSize=%d indexBlockSize=%d numEntries=%d)",
+						bytesIterated, expected, blockSize, indexBlockSize, numEntries)
 				}
 			}
 		}

--- a/sstable/testdata/reader/iter
+++ b/sstable/testdata/reader/iter
@@ -239,3 +239,38 @@ next
 <b:2>
 .
 <a:1>
+
+# Verify that iteration from before the beginning or after the end of
+# the sstable does not "wrap around". A bug previously allowed this to
+# happen by letting the data block iterator and index iterator get out
+# of sync.
+
+build
+a.SET.1:a
+----
+
+iter
+first
+prev
+next
+next
+next
+----
+<a:1>
+.
+<a:1>
+.
+.
+
+iter
+last
+next
+prev
+prev
+prev
+----
+<a:1>
+.
+<a:1>
+.
+.


### PR DESCRIPTION
Fix a bug introduced by the change to skip over empty data blocks. We
were failing to invalidate the data block appropriately when we iterated
off the end of the sstable.

Found via the metamorphic test.