### PR TITLE
internal/metamorphic: properly pass --{keep,disk} to subtest

### DIFF
--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -126,6 +126,10 @@ func testMetaRun(t *testing.T, runDir string) {
 		}
 	}
 	m.finish(h)
+
+	if *keep && !*disk {
+		m.maybeSaveData()
+	}
 }
 
 // TestMeta generates a random set of operations to run, then runs the test
@@ -187,7 +191,11 @@ func TestMeta(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cmd := exec.Command(os.Args[0], "-run-dir", runDir, "-test.run="+rootName+"$")
+		cmd := exec.Command(os.Args[0],
+			"-disk="+fmt.Sprint(*disk),
+			"-keep="+fmt.Sprint(*keep),
+			"-run-dir="+runDir,
+			"-test.run="+rootName+"$")
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			t.Fatalf("%v\n%s\n\n%s", err, filepath.Join(runDir, "history"), out)


### PR DESCRIPTION
Previously, `--{keep,disk}` were only having an effect when `--run-dir`
was specified. Now they are always properly passed through to the
sub-test.

Also made `--keep` have an effect when `--disk` is not specified and the
test passes.