### PR TITLE
db: fix Iterator.SeekPrefixGE+tombstone perf problem

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -58,17 +58,19 @@ func (i *Iterator) findNextEntry() bool {
 
 	for i.iterKey != nil {
 		key := *i.iterKey
+
+		if i.prefix != nil {
+			if n := i.split(key.UserKey); !bytes.Equal(i.prefix, key.UserKey[:n]) {
+				return false
+			}
+		}
+
 		switch key.Kind() {
 		case InternalKeyKindDelete, InternalKeyKindSingleDelete:
 			i.nextUserKey()
 			continue
 
 		case InternalKeyKindSet:
-			if i.prefix != nil {
-				if n := i.split(key.UserKey); !bytes.Equal(i.prefix, key.UserKey[:n]) {
-					return false
-				}
-			}
 			i.keyBuf = append(i.keyBuf[:0], key.UserKey...)
 			i.key = i.keyBuf
 			i.value = i.iterValue
@@ -76,11 +78,6 @@ func (i *Iterator) findNextEntry() bool {
 			return true
 
 		case InternalKeyKindMerge:
-			if i.prefix != nil {
-				if n := i.split(key.UserKey); !bytes.Equal(i.prefix, key.UserKey[:n]) {
-					return false
-				}
-			}
 			var valueMerger ValueMerger
 			valueMerger, i.err = i.merge(i.key, i.iterValue)
 			if i.err == nil {


### PR DESCRIPTION
`Iterator.SeekPrefixGE` was failing to notice that it the prefix no longer
matched when it was stuck in a swath of tombstones. This significantly
affected performance of some workloads, such as `ycsb/F`, causing
performance of various `MVCCGet` calls (in particular from
`EndTxn`) to take longer and longer over time.

```
name            old ops/sec  new ops/sec  delta 
ycsb/F/nodes=3   6.30k ±16%  9.46k ±14%  +50.16%  (p=0.000 n=18+19)

name            old p95      new p95      delta 
ycsb/F/nodes=3    33.7 ±28%    18.6 ± 7%  -44.66%  (p=0.000 n=18+18)

name            old p99      new p99      delta
ycsb/F/nodes=3    78.1 ±40%    49.5 ±44%  -36.55%  (p=0.000 n=18+19)
```
