### PR TITLE
db: change DB.Ingest to delete source files on success

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -456,11 +456,6 @@ func runIngestCmd(td *datadriven.TestData, d *DB, fs vfs.FS) error {
 	if err := d.Ingest(paths); err != nil {
 		return err
 	}
-	for _, path := range paths {
-		if err := fs.Remove(path); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -230,9 +230,6 @@ func TestEventListener(t *testing.T) {
 			if err := d.Ingest([]string{"ext/0"}); err != nil {
 				return err.Error()
 			}
-			if err := mem.Remove("ext/0"); err != nil {
-				return err.Error()
-			}
 			return buf.String()
 
 		case "metrics":

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -210,9 +210,6 @@ func (o *ingestOp) run(t *test, h *history) {
 	}
 
 	err = firstError(err, t.db.Ingest(paths))
-	for _, path := range paths {
-		err = firstError(err, t.opts.FS.Remove(path))
-	}
 
 	h.Recordf("%s // %v", o, err)
 }

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -472,9 +472,6 @@ func BenchmarkRangeDelIterate(b *testing.B) {
 					if err := d.Ingest([]string{"ext"}); err != nil {
 						b.Fatal(err)
 					}
-					if err := mem.Remove("ext"); err != nil {
-						b.Fatal(err)
-					}
 
 					// Create a range tombstone that deletes most (or all) of those entries.
 					from := makeKey(0)


### PR DESCRIPTION
Change `DB.Ingest` to match the RocksDB semantics when `move_files` is
specified: the source files are deleted on success.

Fixes #492