### PR TITLE
db: fix an incomplete manifest file error when reopening a db

### DIFF
--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -120,23 +120,27 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 				m.fmtKey.setForComparer(ve.ComparerName, m.comparers)
 				if ve.MinUnflushedLogNum != 0 {
 					empty = false
-					fmt.Fprintf(stdout, "  log-num:      %d\n", ve.MinUnflushedLogNum)
+					fmt.Fprintf(stdout, "  log-num:       %d\n", ve.MinUnflushedLogNum)
 				}
 				if ve.ObsoletePrevLogNum != 0 {
 					empty = false
-					fmt.Fprintf(stdout, "  prev-log-num: %d\n", ve.ObsoletePrevLogNum)
+					fmt.Fprintf(stdout, "  prev-log-num:  %d\n", ve.ObsoletePrevLogNum)
+				}
+				if ve.NextFileNum != 0 {
+					empty = false
+					fmt.Fprintf(stdout, "  next-file-num: %d\n", ve.NextFileNum)
 				}
 				if ve.LastSeqNum != 0 {
 					empty = false
-					fmt.Fprintf(stdout, "  last-seq-num: %d\n", ve.LastSeqNum)
+					fmt.Fprintf(stdout, "  last-seq-num:  %d\n", ve.LastSeqNum)
 				}
 				for df := range ve.DeletedFiles {
 					empty = false
-					fmt.Fprintf(stdout, "  deleted:      L%d %06d\n", df.Level, df.FileNum)
+					fmt.Fprintf(stdout, "  deleted:       L%d %06d\n", df.Level, df.FileNum)
 				}
 				for _, nf := range ve.NewFiles {
 					empty = false
-					fmt.Fprintf(stdout, "  added:        L%d %06d:%d",
+					fmt.Fprintf(stdout, "  added:         L%d %06d:%d",
 						nf.Level, nf.Meta.FileNum, nf.Meta.Size)
 					formatKeyRange(stdout, m.fmtKey, &nf.Meta.Smallest, &nf.Meta.Largest)
 					fmt.Fprintf(stdout, "\n")

--- a/tool/testdata/manifest_dump
+++ b/tool/testdata/manifest_dump
@@ -7,7 +7,7 @@ manifest dump
 ----
 MANIFEST-000001
 0
-  <empty>
+  next-file-num: 2
 EOF
 
 manifest dump
@@ -19,9 +19,10 @@ MANIFEST-000005
 35
   <empty>
 44
-  log-num:      4
-  last-seq-num: 5
-  added:        L0 000004:986[bar#5,DEL-foo#4,SET]
+  log-num:       4
+  next-file-num: 6
+  last-seq-num:  5
+  added:         L0 000004:986[bar#5,DEL-foo#4,SET]
 EOF
 --- L0 ---
   000004:986[bar#5,DEL-foo#4,SET]
@@ -42,9 +43,10 @@ MANIFEST-000005
 35
   <empty>
 44
-  log-num:      4
-  last-seq-num: 5
-  added:        L0 000004:986[626172#5,DEL-666f6f#4,SET]
+  log-num:       4
+  next-file-num: 6
+  last-seq-num:  5
+  added:         L0 000004:986[626172#5,DEL-666f6f#4,SET]
 EOF
 --- L0 ---
   000004:986[626172#5,DEL-666f6f#4,SET]
@@ -65,9 +67,10 @@ MANIFEST-000005
 35
   <empty>
 44
-  log-num:      4
-  last-seq-num: 5
-  added:        L0 000004:986
+  log-num:       4
+  next-file-num: 6
+  last-seq-num:  5
+  added:         L0 000004:986
 EOF
 --- L0 ---
   000004:986
@@ -88,9 +91,10 @@ MANIFEST-000005
 35
   <empty>
 44
-  log-num:      4
-  last-seq-num: 5
-  added:        L0 000004:986[bar#5,DEL-foo#4,SET]
+  log-num:       4
+  next-file-num: 6
+  last-seq-num:  5
+  added:         L0 000004:986[bar#5,DEL-foo#4,SET]
 EOF
 --- L0 ---
   000004:986[bar#5,DEL-foo#4,SET]
@@ -111,9 +115,10 @@ MANIFEST-000005
 35
   <empty>
 44
-  log-num:      4
-  last-seq-num: 5
-  added:        L0 000004:986[test formatter: bar#5,DEL-test formatter: foo#4,SET]
+  log-num:       4
+  next-file-num: 6
+  last-seq-num:  5
+  added:         L0 000004:986[test formatter: bar#5,DEL-test formatter: foo#4,SET]
 EOF
 --- L0 ---
   000004:986[test formatter: bar#5,DEL-test formatter: foo#4,SET]
@@ -154,14 +159,16 @@ manifest dump
 MANIFEST-invalid
 0
   comparer:     leveldb.BytewiseComparator
-  log-num:      2
-  last-seq-num: 20
-  added:        L0 000001:0[#0,DEL-#0,DEL]
+  log-num:       2
+  next-file-num: 5
+  last-seq-num:  20
+  added:         L0 000001:0[#0,DEL-#0,DEL]
 65
   comparer:     leveldb.BytewiseComparator
-  log-num:      3
-  last-seq-num: 20
-  added:        L0 000002:0[#0,DEL-#0,DEL]
+  log-num:       3
+  next-file-num: 5
+  last-seq-num:  20
+  added:         L0 000002:0[#0,DEL-#0,DEL]
 EOF
 pebble: internal error: L0 flushed file 000001 overlaps with the largest seqnum of a preceding flushed file: 2-5 vs 4
 

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -1,0 +1,51 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionSetCheckpoint(t *testing.T) {
+	mem := vfs.NewMem()
+	require.NoError(t, mem.MkdirAll("ext", 0755))
+
+	opts := &Options{
+		FS:                  mem,
+		MaxManifestFileSize: 1,
+	}
+	d, err := Open("", opts)
+	require.NoError(t, err)
+
+	writeAndIngest := func(k InternalKey, v []byte, filename string) {
+		path := mem.PathJoin("ext", filename)
+		f, err := mem.Create(path)
+		require.NoError(t, err)
+		w := sstable.NewWriter(f, sstable.WriterOptions{})
+		require.NoError(t, w.Add(k, v))
+		require.NoError(t, w.Close())
+		require.NoError(t, d.Ingest([]string{path}))
+	}
+
+	// Multiple manifest files are created such that the latest one must have a correct snapshot
+	// of the preceding state for the DB to be opened correctly and see the written data.
+	writeAndIngest(base.MakeInternalKey([]byte("a"), 0, InternalKeyKindSet), []byte("b"), "a")
+	writeAndIngest(base.MakeInternalKey([]byte("c"), 0, InternalKeyKindSet), []byte("d"), "c")
+	require.NoError(t, d.Close())
+	d, err = Open("", opts)
+	require.NoError(t, err)
+	checkValue := func(k string, expected string) {
+		v, err := d.Get([]byte(k))
+		require.NoError(t, err)
+		require.Equal(t, expected, string(v))
+	}
+	checkValue("a", "b")
+	checkValue("c", "d")
+}


### PR DESCRIPTION
This was caused by the snapshot VersionEdit not containing minUnflushedLogNum and the nextFileNum.
Also print the nextFileNum in the "manifest dump".

Found using the extension to the metamorphic test that closes and reopens the DB.