### PR TITLE
db: tweak ingestTargetLevel heuristics

### DIFF
--- a/ingest_test.go
+++ b/ingest_test.go
@@ -481,7 +481,7 @@ func TestIngestTargetLevel(t *testing.T) {
 			var buf bytes.Buffer
 			for _, target := range strings.Split(d.Input, "\n") {
 				meta := parseMeta(target)
-				level := ingestTargetLevel(cmp, vers, compactions, &meta)
+				level := ingestTargetLevel(cmp, vers, 1, compactions, &meta)
 				fmt.Fprintf(&buf, "%d\n", level)
 			}
 			return buf.String()
@@ -730,7 +730,7 @@ func TestConcurrentIngestCompact(t *testing.T) {
 	ingest("c")
 
 	expectLSM(`
-5:
+0:
   000005:[a#2,SET-a#2,SET]
   000007:[c#4,SET-c#4,SET]
 6:
@@ -754,7 +754,7 @@ func TestConcurrentIngestCompact(t *testing.T) {
 	compact("a", "z")
 
 	expectLSM(`
-5:
+0:
   000009:[b#5,SET-b#5,SET]
 6:
   000008:[a#0,SET-c#0,SET]

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -55,7 +55,7 @@ ingest ext1
 
 lsm
 ----
-5:
+0:
   000007:[a#2,SET-b#2,DEL]
 6:
   000006:[a#1,SET-b#1,SET]
@@ -85,10 +85,9 @@ ingest ext2
 
 lsm
 ----
-4:
-  000008:[a#3,SET-c#3,SET]
-5:
+0:
   000007:[a#2,SET-b#2,DEL]
+  000008:[a#3,SET-c#3,SET]
 6:
   000006:[a#1,SET-b#1,SET]
 
@@ -120,12 +119,10 @@ ingest ext3
 
 lsm
 ----
-3:
-  000009:[b#4,MERGE-c#4,DEL]
-4:
-  000008:[a#3,SET-c#3,SET]
-5:
+0:
   000007:[a#2,SET-b#2,DEL]
+  000008:[a#3,SET-c#3,SET]
+  000009:[b#4,MERGE-c#4,DEL]
 6:
   000006:[a#1,SET-b#1,SET]
 
@@ -157,12 +154,10 @@ ingest ext4
 
 lsm
 ----
-3:
-  000009:[b#4,MERGE-c#4,DEL]
-4:
-  000008:[a#3,SET-c#3,SET]
-5:
+0:
   000007:[a#2,SET-b#2,DEL]
+  000008:[a#3,SET-c#3,SET]
+  000009:[b#4,MERGE-c#4,DEL]
 6:
   000006:[a#1,SET-b#1,SET]
   000010:[x#5,SET-y#5,SET]
@@ -198,14 +193,11 @@ ingest ext5
 lsm
 ----
 0:
+  000007:[a#2,SET-b#2,DEL]
+  000008:[a#3,SET-c#3,SET]
+  000009:[b#4,MERGE-c#4,DEL]
   000013:[j#6,SET-k#7,SET]
   000011:[k#8,SET-k#8,SET]
-3:
-  000009:[b#4,MERGE-c#4,DEL]
-4:
-  000008:[a#3,SET-c#3,SET]
-5:
-  000007:[a#2,SET-b#2,DEL]
 6:
   000006:[a#1,SET-b#1,SET]
   000010:[x#5,SET-y#5,SET]
@@ -238,14 +230,11 @@ ingest ext6
 lsm
 ----
 0:
+  000007:[a#2,SET-b#2,DEL]
+  000008:[a#3,SET-c#3,SET]
+  000009:[b#4,MERGE-c#4,DEL]
   000013:[j#6,SET-k#7,SET]
   000011:[k#8,SET-k#8,SET]
-3:
-  000009:[b#4,MERGE-c#4,DEL]
-4:
-  000008:[a#3,SET-c#3,SET]
-5:
-  000007:[a#2,SET-b#2,DEL]
 6:
   000006:[a#1,SET-b#1,SET]
   000014:[n#10,SET-n#10,SET]
@@ -269,16 +258,13 @@ ingest ext7
 lsm
 ----
 0:
+  000007:[a#2,SET-b#2,DEL]
+  000008:[a#3,SET-c#3,SET]
+  000009:[b#4,MERGE-c#4,DEL]
   000013:[j#6,SET-k#7,SET]
   000011:[k#8,SET-k#8,SET]
   000017:[m#9,SET-m#9,SET]
   000015:[a#11,RANGEDEL-z#72057594037927935,RANGEDEL]
-3:
-  000009:[b#4,MERGE-c#4,DEL]
-4:
-  000008:[a#3,SET-c#3,SET]
-5:
-  000007:[a#2,SET-b#2,DEL]
 6:
   000006:[a#1,SET-b#1,SET]
   000014:[n#10,SET-n#10,SET]
@@ -353,6 +339,9 @@ y:40
 lsm
 ----
 0:
+  000007:[a#2,SET-b#2,DEL]
+  000008:[a#3,SET-c#3,SET]
+  000009:[b#4,MERGE-c#4,DEL]
   000013:[j#6,SET-k#7,SET]
   000011:[k#8,SET-k#8,SET]
   000017:[m#9,SET-m#9,SET]
@@ -360,12 +349,6 @@ lsm
   000018:[j#12,RANGEDEL-m#12,SET]
   000019:[a#13,RANGEDEL-x#72057594037927935,RANGEDEL]
   000020:[y#14,SET-y#14,SET]
-3:
-  000009:[b#4,MERGE-c#4,DEL]
-4:
-  000008:[a#3,SET-c#3,SET]
-5:
-  000007:[a#2,SET-b#2,DEL]
 6:
   000006:[a#1,SET-b#1,SET]
   000014:[n#10,SET-n#10,SET]

--- a/testdata/iterator_next_prev
+++ b/testdata/iterator_next_prev
@@ -14,7 +14,7 @@ del-range b c
 
 ingest ext2
 ----
-5:
+0:
   000005:[b#2,RANGEDEL-c#72057594037927935,RANGEDEL]
 6:
   000004:[a#1,MERGE-c#1,SET]
@@ -65,7 +65,7 @@ del-range x y
 
 ingest ext2
 ----
-5:
+0:
   000005:[x#2,RANGEDEL-y#72057594037927935,RANGEDEL]
 6:
   000004:[t#1,SET-z#1,MERGE]

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -276,7 +276,7 @@ del-range c z
 
 ingest ext1 ext2
 ----
-5:
+0:
   000006:[a#5,SET-a#5,SET]
   000007:[b#6,SET-z#72057594037927935,RANGEDEL]
 6:


### PR DESCRIPTION
Change the `ingestTargetLevel()` heuristics to be closer to RocksDB. If
we can't find a level below L0 to ingest into, ingest into L0 rather
than opening a new level. The primary behavior tended to quickly explode
the number of levels in the LSM which the system was then very slow to
recover from.