### PR TITLE
db: disable problematic use of hard links in Ingest

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"math"
-	"os"
 	"regexp"
 	"runtime"
 	"sort"
@@ -763,14 +762,6 @@ func TestCompaction(t *testing.T) {
 	}
 }
 
-type noLinkFS struct {
-	vfs.FS
-}
-
-func (fs noLinkFS) Link(oldname, newname string) error {
-	return os.ErrInvalid
-}
-
 func TestManualCompaction(t *testing.T) {
 	var mem vfs.FS
 	var d *DB
@@ -782,11 +773,7 @@ func TestManualCompaction(t *testing.T) {
 			t.Fatal(err)
 		}
 		d, err = Open("", &Options{
-			// NB: We need to disable hard links for this test as the combination of
-			// CheckLevels and the deletion of the files after ingestion is
-			// incompatible because CheckLevels causes the files to get loaded into
-			// the table cache and memFS prohibits removing open files.
-			FS:         noLinkFS{mem},
+			FS:         mem,
 			DebugCheck: true,
 		})
 		if err != nil {


### PR DESCRIPTION
The combination of `MemFS+Ingest+DebugCheck` causes awkwardness for the
caller. Disable hard links when this explicit combination occurs, and
copy ingested sstables instead.

Fixes #495