### PR TITLE
db: (re-)enable levelIter invariants

### DIFF
--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -78,6 +78,7 @@ func TestLevelIter(t *testing.T) {
 			defer iter.Close()
 			// Fake up the range deletion initialization.
 			iter.initRangeDel(new(internalIterator))
+			iter.disableInvariants = true
 			return runInternalIterCmd(d, iter, iterCmdVerboseKey)
 
 		case "load":


### PR DESCRIPTION
The `levelIter` invariants were disabled due to a `mergingIter` bug that
had been fixed. We still need a mechanism to disable the invariants for
certain `levelIter` tests which intentionally violate them.