### PR TITLE
db: sync the OPTIONS file

### DIFF
--- a/open.go
+++ b/open.go
@@ -252,7 +252,8 @@ func Open(dirname string, opts *Options) (*DB, error) {
 		if _, err := optionsFile.Write([]byte(opts.String())); err != nil {
 			return nil, err
 		}
-		optionsFile.Close()
+		_ = optionsFile.Sync()
+		_ = optionsFile.Close()
 		if err := d.dataDir.Sync(); err != nil {
 			return nil, err
 		}

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -14,6 +14,7 @@ create: db/000002.log
 sync: db
 sync: db/MANIFEST-000001
 create: db/OPTIONS-000003
+sync: db/OPTIONS-000003
 close: db/OPTIONS-000003
 sync: db
 

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -16,6 +16,7 @@ create: wal/000002.log
 sync: wal
 sync: db/MANIFEST-000001
 create: db/OPTIONS-000003
+sync: db/OPTIONS-000003
 close: db/OPTIONS-000003
 sync: db
 

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -26,6 +26,7 @@ rename: db/CURRENT.000003.dbtmp -> db/CURRENT
 sync: db
 [JOB 1] MANIFEST created 000003
 create: db/OPTIONS-000004
+sync: db/OPTIONS-000004
 close: db/OPTIONS-000004
 sync: db
 [JOB 1] MANIFEST deleted 000001


### PR DESCRIPTION
Found with a verbose version of mem_fs.go and the db-restarting
metamorphic test. This did not cause the test to fail.