### PR TITLE
sstable: sstable.Writer optimizations

### DIFF
--- a/sstable/block.go
+++ b/sstable/block.go
@@ -126,14 +126,14 @@ func (w *blockWriter) finish() []byte {
 	}
 	binary.LittleEndian.PutUint32(tmp4, uint32(len(w.restarts)))
 	w.buf = append(w.buf, tmp4...)
-	return w.buf
-}
+	result := w.buf
 
-func (w *blockWriter) reset() {
+	// Reset the block state.
 	w.nEntries = 0
 	w.nextRestart = 0
 	w.buf = w.buf[:0]
 	w.restarts = w.restarts[:0]
+	return result
 }
 
 func (w *blockWriter) estimatedSize() int {

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -434,7 +434,6 @@ func buildBenchmarkTable(b *testing.B, blockSize, restartInterval int) (*Reader,
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer f0.Close()
 
 	w := NewWriter(f0, WriterOptions{
 		BlockRestartInterval: restartInterval,


### PR DESCRIPTION
* sstable: encode varints directly into buf in blockWriter.store
* sstable: micro-optimize Writer.addPoint()
* sstable: minor cleanup of Writer/blockWriter
* sstable: micro-optimize blockWriter.store

Combined, the optimizations result in a decent improvement on the new
`sstable.Writer` benchmark.

```
name       old time/op  new time/op  delta
Writer-16  94.9ms ± 1%  74.6ms ± 4%  -21.40%  (p=0.000 n=10+20)
```