### PR TITLE
cmd/pebble: fix --rate flag

### DIFF
--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -20,7 +20,7 @@ var (
 	disableWAL      bool
 	duration        time.Duration
 	engineType      string
-	maxOpsPerSec    *rateFlag
+	maxOpsPerSec    *rateFlag = newRateFlag("1000000")
 	verbose         bool
 	waitCompactions bool
 	wipe            bool
@@ -70,7 +70,6 @@ func main() {
 			&duration, "duration", "d", 10*time.Second, "the duration to run (0, run forever)")
 		cmd.Flags().StringVarP(
 			&engineType, "engine", "e", "pebble", "engine type (pebble, badger, boltdb, rocksdb)")
-		maxOpsPerSec = newRateFlag("1000000")
 		cmd.Flags().VarP(
 			maxOpsPerSec, "rate", "m", "max ops per second [{zipf,uniform}:]min[-max][/period (sec)]")
 		cmd.Flags().BoolVarP(


### PR DESCRIPTION
The `maxOpsPerSec` was being initialized in a loop, making only the last
declaration (for the `ycsb` command) effective.

Fixes #509