### PR TITLE
db: better ingestion heuristic

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -315,12 +315,17 @@ func runCompactCmd(td *datadriven.TestData, d *DB) error {
 }
 
 func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
-	if td.Input == "" {
-		return nil, fmt.Errorf("empty test input")
-	}
-
 	opts = opts.EnsureDefaults()
 	opts.FS = vfs.NewMem()
+
+	if td.Input == "" {
+		// Empty LSM.
+		d, err := Open("", opts)
+		if err != nil {
+			return nil, err
+		}
+		return d, nil
+	}
 
 	var snapshots []uint64
 	for _, arg := range td.CmdArgs {
@@ -377,7 +382,7 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 		c.disableRangeTombstoneElision = true
 		newVE, _, err := d.runCompaction(0, c, nilPacer)
 		if err != nil {
-			return nil
+			return err
 		}
 		for _, f := range newVE.NewFiles {
 			ve.NewFiles = append(ve.NewFiles, newFileEntry{
@@ -387,6 +392,31 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 		}
 		level = -1
 		return nil
+	}
+
+	// Example, a-c.
+	parseMeta := func(s string) (*fileMetadata, error) {
+		parts := strings.Split(s, "-")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("malformed table spec: %s", s)
+		}
+		return &fileMetadata{
+			Smallest: InternalKey{UserKey: []byte(parts[0])},
+			Largest:  InternalKey{UserKey: []byte(parts[1])},
+		}, nil
+	}
+
+	// Example, compact: a-c.
+	parseCompaction := func(outputLevel int, s string) (*compaction, error) {
+		m, err := parseMeta(s[len("compact:"):])
+		if err != nil {
+			return nil, err
+		}
+		return &compaction{
+			outputLevel: outputLevel,
+			smallest:    m.Smallest,
+			largest:     m.Largest,
+		}, nil
 	}
 
 	for _, line := range strings.Split(td.Input, "\n") {
@@ -420,6 +450,15 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 
 		for _, data := range fields {
 			i := strings.Index(data, ":")
+			// Define in-progress compactions.
+			if data[:i] == "compact" {
+				c, err := parseCompaction(level, data)
+				if err != nil {
+					return nil, err
+				}
+				d.mu.compact.inProgress[c] = struct{}{}
+				continue
+			}
 			key := base.ParseInternalKey(data[:i])
 			value := []byte(data[i+1:])
 			if err := mem.set(key, value); err != nil {

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -168,8 +168,8 @@ compact         1   1.6 K          (size == estimated-debt)
  memtbl         1   256 K
 zmemtbl         0     0 B
    ztbl         0     0 B
- bcache         4   752 B    7.7%  (score == hit-rate)
- tcache         0     0 B    0.0%  (score == hit-rate)
+ bcache         8   1.5 K    5.9%  (score == hit-rate)
+ tcache         1   688 B    0.0%  (score == hit-rate)
  titers         0
  filter         -       -    0.0%  (score == utility)
 

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -183,6 +183,8 @@ set j 9
 set k 10
 ----
 
+# Overlap with point keys in memtable, hence memtable will be flushed.
+
 build ext5
 set k 11
 ----
@@ -215,6 +217,8 @@ k
 ----
 j:9
 k:11
+
+# No data overlap in memtable, hence it will not be flushed.
 
 batch
 set m 12
@@ -313,28 +317,13 @@ k:11
 m:30
 
 build ext9
-del-range a x
+set a 40
+set f 40
+set g 40
 ----
 
-build ext10
-set y 40
+ingest ext9
 ----
-
-# Ingesting two files into L0 is allowed.
-
-ingest ext9 ext10
-----
-
-get
-j
-k
-m
-y
-----
-j: pebble: not found
-k: pebble: not found
-m: pebble: not found
-y:40
 
 lsm
 ----
@@ -347,9 +336,287 @@ lsm
   000017:[m#9,SET-m#9,SET]
   000015:[a#11,RANGEDEL-z#72057594037927935,RANGEDEL]
   000018:[j#12,RANGEDEL-m#12,SET]
-  000019:[a#13,RANGEDEL-x#72057594037927935,RANGEDEL]
-  000020:[y#14,SET-y#14,SET]
+  000019:[a#13,SET-g#13,SET]
 6:
   000006:[a#1,SET-b#1,SET]
   000014:[n#10,SET-n#10,SET]
   000010:[x#5,SET-y#5,SET]
+
+# Overlap with sst boundary containing range del sentinel (fileNum 000015) is not considered an overlap since
+# range del's end key is exclusive. Hence ext9 gets ingested into L6.
+
+build ext10
+set z 40
+----
+
+# Although ext11 falls into sst boundaries of fileNum 000019, 000015, they don't actually contain any key within ext11's boundary.
+# Hence ext11 is allowed to go further down and get ingested into L6.
+
+build ext11
+set d 40
+----
+
+# Overlap with fileNum 000018 is not considered an overlap since ext12's end key is range del sentinel which is exclusive.
+
+build ext12
+del-range i j
+----
+
+# Ingesting multiple files into L0 is allowed.
+
+ingest ext10 ext11 ext12
+----
+
+get
+z
+d
+----
+z:40
+d:40
+
+lsm
+----
+0:
+  000007:[a#2,SET-b#2,DEL]
+  000008:[a#3,SET-c#3,SET]
+  000009:[b#4,MERGE-c#4,DEL]
+  000013:[j#6,SET-k#7,SET]
+  000011:[k#8,SET-k#8,SET]
+  000017:[m#9,SET-m#9,SET]
+  000015:[a#11,RANGEDEL-z#72057594037927935,RANGEDEL]
+  000018:[j#12,RANGEDEL-m#12,SET]
+  000019:[a#13,SET-g#13,SET]
+6:
+  000006:[a#1,SET-b#1,SET]
+  000021:[d#14,SET-d#14,SET]
+  000022:[i#15,RANGEDEL-j#72057594037927935,RANGEDEL]
+  000014:[n#10,SET-n#10,SET]
+  000010:[x#5,SET-y#5,SET]
+  000020:[z#16,SET-z#16,SET]
+
+# No overlap between fileNum 000019 that contains point key f, since f is ingested file's range del sentinel.
+
+build ext13
+del-range e f
+----
+
+ingest ext13
+----
+
+lsm
+----
+0:
+  000007:[a#2,SET-b#2,DEL]
+  000008:[a#3,SET-c#3,SET]
+  000009:[b#4,MERGE-c#4,DEL]
+  000013:[j#6,SET-k#7,SET]
+  000011:[k#8,SET-k#8,SET]
+  000017:[m#9,SET-m#9,SET]
+  000015:[a#11,RANGEDEL-z#72057594037927935,RANGEDEL]
+  000018:[j#12,RANGEDEL-m#12,SET]
+  000019:[a#13,SET-g#13,SET]
+6:
+  000006:[a#1,SET-b#1,SET]
+  000021:[d#14,SET-d#14,SET]
+  000023:[e#17,RANGEDEL-f#72057594037927935,RANGEDEL]
+  000022:[i#15,RANGEDEL-j#72057594037927935,RANGEDEL]
+  000014:[n#10,SET-n#10,SET]
+  000010:[x#5,SET-y#5,SET]
+  000020:[z#16,SET-z#16,SET]
+
+# Overlap with range delete keys in memtable, hence memtable will be flushed.
+
+batch
+del-range a d
+----
+
+build ext14
+set b 1
+----
+
+ingest ext14
+----
+
+lsm
+----
+0:
+  000007:[a#2,SET-b#2,DEL]
+  000008:[a#3,SET-c#3,SET]
+  000009:[b#4,MERGE-c#4,DEL]
+  000013:[j#6,SET-k#7,SET]
+  000011:[k#8,SET-k#8,SET]
+  000017:[m#9,SET-m#9,SET]
+  000015:[a#11,RANGEDEL-z#72057594037927935,RANGEDEL]
+  000018:[j#12,RANGEDEL-m#12,SET]
+  000019:[a#13,SET-g#13,SET]
+  000026:[a#18,RANGEDEL-d#72057594037927935,RANGEDEL]
+  000024:[b#19,SET-b#19,SET]
+6:
+  000006:[a#1,SET-b#1,SET]
+  000021:[d#14,SET-d#14,SET]
+  000023:[e#17,RANGEDEL-f#72057594037927935,RANGEDEL]
+  000022:[i#15,RANGEDEL-j#72057594037927935,RANGEDEL]
+  000014:[n#10,SET-n#10,SET]
+  000010:[x#5,SET-y#5,SET]
+  000020:[z#16,SET-z#16,SET]
+
+reset
+----
+
+# Tests to show that keys don't overlap with range delete sentinels.
+
+batch
+set b 1
+----
+
+build ext15
+del-range a b
+----
+
+ingest ext15
+----
+
+lsm
+----
+6:
+  000004:[a#1,RANGEDEL-b#72057594037927935,RANGEDEL]
+
+reset
+----
+
+batch
+del-range b c
+----
+
+build ext16
+del-range a b
+----
+
+ingest ext16
+----
+
+lsm
+----
+6:
+  000004:[a#1,RANGEDEL-b#72057594037927935,RANGEDEL]
+
+reset
+----
+
+# Tests for branch coverage of method overlapWithIterator,
+# when levelIter is used and it produces a range del sentinel boundary
+# because it finds no overlapping point key.
+
+# Case 1) levelIter produced boundary is less than ingested file's largest key.
+
+build ext17
+del-range a b
+----
+
+ingest ext17
+----
+
+build ext18
+set a 10
+set c 10
+----
+
+ingest ext18
+----
+
+lsm
+----
+0:
+  000005:[a#2,SET-c#2,SET]
+6:
+  000004:[a#1,RANGEDEL-b#72057594037927935,RANGEDEL]
+
+reset
+----
+
+# Case 2) levelIter produced boundary is more than ingested file's largest key.
+
+build ext19
+del-range c d
+----
+
+ingest ext19
+----
+
+build ext20
+set a 10
+set b 10
+----
+
+ingest ext20
+----
+
+build ext21
+set c 10
+----
+
+ingest ext21
+----
+
+lsm
+----
+0:
+  000006:[c#3,SET-c#3,SET]
+6:
+  000005:[a#2,SET-b#2,SET]
+  000004:[c#1,RANGEDEL-d#72057594037927935,RANGEDEL]
+
+reset
+----
+
+# Case 3) levelIter produced boundary is equal to ingested file's largest key,
+# where the latter is not a range del sentinel.
+
+build ext22
+del-range a b
+----
+
+ingest ext22
+----
+
+build ext23
+set a 10
+set b 10
+----
+
+ingest ext23
+----
+
+lsm
+----
+0:
+  000005:[a#2,SET-b#2,SET]
+6:
+  000004:[a#1,RANGEDEL-b#72057594037927935,RANGEDEL]
+
+reset
+----
+
+# Case 4) levelIter produced boundary is equal to ingested file's largest key,
+# where the latter is a range del sentinel.
+
+build ext24
+del-range a b
+----
+
+ingest ext24
+----
+
+build ext25
+del-range a b
+----
+
+ingest ext25
+----
+
+lsm
+----
+0:
+  000005:[a#2,RANGEDEL-b#72057594037927935,RANGEDEL]
+6:
+  000004:[a#1,RANGEDEL-b#72057594037927935,RANGEDEL]

--- a/testdata/ingest_memtable_overlaps
+++ b/testdata/ingest_memtable_overlaps
@@ -5,8 +5,10 @@ set a 1
 overlaps
 a-b
 b-c
+aa-ab
 ----
 true
+false
 false
 
 define
@@ -118,3 +120,21 @@ e-d
 true
 false
 true
+
+define default
+set b 1
+----
+
+overlaps
+a.RANGEDEL.2-b.RANGEDEL.72057594037927935
+----
+false
+
+define default
+del-range b c
+----
+
+overlaps
+a.RANGEDEL.2-b.RANGEDEL.72057594037927935
+----
+false

--- a/testdata/ingest_target_level
+++ b/testdata/ingest_target_level
@@ -8,8 +8,12 @@ a-b
 6
 
 define
-5: b-c
+L5
+  b.SET.1:1
+  c.SET.2:2
 ----
+5:
+  000004:[b#1,SET-c#2,SET]
 
 target
 a-b
@@ -17,33 +21,65 @@ b-c
 c-d
 a-aa
 d-e
+bb-bb
 ----
 4
 4
 4
+6
 6
 6
 
 define
-0: b-e d-f x-y
-3: g-h
+L0
+  b.SET.3:3
+  e.SET.4:4
+L0
+  d.SET.5:5
+  f.SET.6:6
+L0
+  x.SET.7:7
+  y.SET.8:8
+L3
+  g.SET.1:1
+  h.SET.2:2
 ----
+0:
+  000004:[b#3,SET-e#4,SET]
+  000005:[d#5,SET-f#6,SET]
+  000006:[x#7,SET-y#8,SET]
+3:
+  000007:[g#1,SET-h#2,SET]
 
 target
 b-c
 d-e
 g-m
 i-m
+c-c
 ----
 0
 0
 2
 6
+6
 
 define
-5: a-a c-c
-6: a-a c-c
+L5
+  a.SET.4:4
+L5
+  c.SET.3:3
+L6
+  a.SET.2:2
+L6
+  c.SET.1:1
 ----
+5:
+  000004:[a#4,SET-a#4,SET]
+  000005:[c#3,SET-c#3,SET]
+6:
+  000006:[a#2,SET-a#2,SET]
+  000007:[c#1,SET-c#1,SET]
 
 target
 b-b
@@ -51,11 +87,52 @@ b-b
 6
 
 define
-5: a-a c-c
-6: a-a c-c compact:a-c
+L5
+  a.SET.4:4
+L5
+  c.SET.3:3
+L6
+  a.SET.2:2
+L6
+  c.SET.1:1
+  compact:a-c
 ----
+5:
+  000004:[a#4,SET-a#4,SET]
+  000005:[c#3,SET-c#3,SET]
+6:
+  000006:[a#2,SET-a#2,SET]
+  000007:[c#1,SET-c#1,SET]
 
 target
 b-b
 ----
 5
+
+define
+L0
+  c.SET.4:4
+  d.SET.3:3
+  d.RANGEDEL.2:g
+L2
+  a.RANGEDEL.1:g
+----
+0:
+  000004:[c#4,SET-g#72057594037927935,RANGEDEL]
+2:
+  000005:[a#1,RANGEDEL-g#72057594037927935,RANGEDEL]
+
+target
+cc-cc
+c-c
+g-g
+d-d
+e-e
+a-a
+----
+1
+0
+6
+0
+0
+1


### PR DESCRIPTION
Ingesting into the lowest possible level while obeying Pebble's
constraints is desirable to reduce write amplification.

Currently to find the target level we stop our search on the level
whose ssts overlap with the ingested file based on the key range covered
by their sst boundaries.

However, we can go further down if there's no actual overlap with the
point and range delete keys of the ssts in a level. This is also what RocksDB
does in it's ingestion logic (see Version::OverlapWithLevelIterator).

Resolves: #221