### PR TITLE
db: consistently handle key decoding failure

### DIFF
--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -20,7 +20,7 @@ var (
 	disableWAL      bool
 	duration        time.Duration
 	engineType      string
-	maxOpsPerSec    *rateFlag = newRateFlag("1000000")
+	maxOpsPerSec    = newRateFlag("1000000")
 	verbose         bool
 	waitCompactions bool
 	wipe            bool

--- a/internal/arenaskl/skl_test.go
+++ b/internal/arenaskl/skl_test.go
@@ -850,3 +850,21 @@ func BenchmarkIterPrev(b *testing.B) {
 // 		})
 // 	}
 // }
+
+func TestInvalidInternalKeyDecoding(t *testing.T) {
+	a := NewArena(arenaSize, 0)
+
+	// We synthetically fill the arena with an invalid key
+	// that doesn't have an 8 byte trailer.
+	nd, err := newRawNode(a, 1, 1, 1)
+	require.Nil(t, err)
+
+	l := NewSkiplist(a, bytes.Compare)
+	it := Iterator{
+		list: l,
+		nd:   nd,
+	}
+	it.decodeKey()
+	require.Nil(t, it.key.UserKey)
+	require.Equal(t, uint64(base.InternalKeyKindInvalid), it.key.Trailer)
+}

--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -169,6 +169,7 @@ func DecodeInternalKey(encodedKey []byte) InternalKey {
 		encodedKey = encodedKey[:n:n]
 	} else {
 		trailer = uint64(InternalKeyKindInvalid)
+		encodedKey = nil
 	}
 	return InternalKey{
 		UserKey: encodedKey,

--- a/internal/base/internal_test.go
+++ b/internal/base/internal_test.go
@@ -46,6 +46,11 @@ func TestInvalidInternalKey(t *testing.T) {
 		if k.Valid() {
 			t.Errorf("%q is a valid key, want invalid", tc)
 		}
+
+		// Invalid key kind because the key doesn't have an 8 byte trailer.
+		if k.Kind() == InternalKeyKindInvalid && k.UserKey != nil {
+			t.Errorf("expected nil UserKey after decoding encodedKey=%q", tc)
+		}
 	}
 }
 
@@ -57,6 +62,9 @@ func TestInternalKeyComparer(t *testing.T) {
 		"" + "\x00\xff\xff\xff\xff\xff\xff\xff",
 		"" + "\x01\x01\x00\x00\x00\x00\x00\x00",
 		"" + "\x00\x01\x00\x00\x00\x00\x00\x00",
+		// Invalid internal keys have no user key, but have trailer "\xff \x00 \x00 \x00 \x00 \x00 \x00 \x00"
+		// i.e. seqNum 0 and kind 255 (InternalKeyKindInvalid).
+		"",
 		"" + "\x01\x00\x00\x00\x00\x00\x00\x00",
 		"" + "\x00\x00\x00\x00\x00\x00\x00\x00",
 		"\x00" + "\x00\x00\x00\x00\x00\x00\x00\x00",
@@ -66,9 +74,6 @@ func TestInternalKeyComparer(t *testing.T) {
 		"blue\x00" + "\x01\x11\x00\x00\x00\x00\x00\x00",
 		"green" + "\xff\x11\x00\x00\x00\x00\x00\x00",
 		"green" + "\x01\x11\x00\x00\x00\x00\x00\x00",
-		// Invalid internal keys sort after valid ones for the same user key
-		// because the seqnum is zero.
-		"green",
 		"green" + "\x01\x00\x00\x00\x00\x00\x00\x00",
 		"red" + "\x01\xff\xff\xff\xff\xff\xff\xff",
 		"red" + "\x01\x72\x73\x74\x75\x76\x77\x78",

--- a/sstable/block_test.go
+++ b/sstable/block_test.go
@@ -42,6 +42,21 @@ func TestBlockWriter(t *testing.T) {
 	}
 }
 
+func TestInvalidInternalKeyDecoding(t *testing.T) {
+	// Invalid keys since they don't have an 8 byte trailer.
+	testCases := []string{
+		"",
+		"\x01\x02\x03\x04\x05\x06\x07",
+		"foo",
+	}
+	for _, tc := range testCases {
+		i := blockIter{}
+		i.decodeInternalKey([]byte(tc))
+		require.Nil(t, i.ikey.UserKey)
+		require.Equal(t, uint64(InternalKeyKindInvalid), i.ikey.Trailer)
+	}
+}
+
 func TestBlockIter(t *testing.T) {
 	// k is a block that maps three keys "apple", "apricot", "banana" to empty strings.
 	k := block([]byte(


### PR DESCRIPTION
Inside skiplist and block iterator we've self-inlined
`base.DecodeInternalKey` for performance and because
Go runtime doesn't inline itself.

However, the inlined versions differ from the actual
method in their handling of insufficient trailer bytes.
This change makes them consistent.

Resolves: #401