### PR TITLE
db: add support for intra-L0 compactions

### DIFF
--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -55,6 +55,7 @@ func newPebbleDB(dir string) DB {
 		DisableWAL:                  disableWAL,
 		MemTableSize:                64 << 20,
 		MemTableStopWritesThreshold: 4,
+		MaxConcurrentCompactions:    2,
 		MinCompactionRate:           4 << 20, // 4 MB/s
 		MinFlushRate:                1 << 20, // 1 MB/s
 		L0CompactionThreshold:       2,

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -11,7 +11,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -87,20 +89,33 @@ func TestCompactionPickerLevelMaxBytes(t *testing.T) {
 		})
 }
 
-type compactionInfoTesting struct {
-	startLevel  int
-	outputLevel int
-}
-
-func (c compactionInfoTesting) startLevelNum() int       { return c.startLevel }
-func (c compactionInfoTesting) outputLevelNum() int      { return c.outputLevel }
-func (c compactionInfoTesting) smallestKey() InternalKey { return InternalKey{} }
-func (c compactionInfoTesting) largestKey() InternalKey  { return InternalKey{} }
-
 func TestCompactionPickerTargetLevel(t *testing.T) {
 	var vers *version
 	var opts *Options
 	var pickerByScore *compactionPickerByScore
+
+	parseInProgress := func(vals []string) ([]compactionInfo, error) {
+		var levels []int
+		for _, s := range vals {
+			l, err := strconv.ParseInt(s, 10, 8)
+			if err != nil {
+				return nil, err
+			}
+			levels = append(levels, int(l))
+		}
+		if len(levels)%2 != 0 {
+			return nil, fmt.Errorf("odd number of levels with ongoing compactions")
+		}
+		var inProgress []compactionInfo
+		for i := 0; i < len(levels); i += 2 {
+			inProgress = append(inProgress, compactionInfo{
+				startLevel:  levels[i],
+				outputLevel: levels[i+1],
+			})
+		}
+		return inProgress, nil
+	}
+
 	datadriven.RunTest(t, "testdata/compaction_picker_target_level",
 		func(d *datadriven.TestData) string {
 			switch d.Cmd {
@@ -112,7 +127,20 @@ func TestCompactionPickerTargetLevel(t *testing.T) {
 				}
 				return ""
 			case "init_cp":
-				p := newCompactionPicker(vers, opts, nil)
+				var inProgress []compactionInfo
+				if len(d.CmdArgs) == 1 {
+					arg := d.CmdArgs[0]
+					if arg.Key != "ongoing" {
+						return "unknown arg: " + arg.Key
+					}
+					var err error
+					inProgress, err = parseInProgress(arg.Vals)
+					if err != nil {
+						return err.Error()
+					}
+				}
+
+				p := newCompactionPicker(vers, opts, inProgress)
 				var ok bool
 				pickerByScore, ok = p.(*compactionPickerByScore)
 				require.True(t, ok)
@@ -120,33 +148,28 @@ func TestCompactionPickerTargetLevel(t *testing.T) {
 			case "queue":
 				var b strings.Builder
 				for _, c := range pickerByScore.compactionQueue {
-					fmt.Fprintf(&b, "%d: %.1f,", c.level, c.score)
+					fmt.Fprintf(&b, "L%d->L%d: %.1f\n", c.level, c.outputLevel, c.score)
 				}
 				return b.String()
 			case "pick":
-				var levels []int
+				var inProgress []compactionInfo
 				if len(d.CmdArgs) == 1 {
 					arg := d.CmdArgs[0]
 					if arg.Key != "ongoing" {
 						return "unknown arg: " + arg.Key
 					}
-					for _, s := range arg.Vals {
-						l, err := strconv.ParseInt(s, 10, 8)
-						if err != nil {
-							return err.Error()
-						}
-						levels = append(levels, int(l))
+					var err error
+					inProgress, err = parseInProgress(arg.Vals)
+					if err != nil {
+						return err.Error()
 					}
 				}
-				if len(levels)%2 != 0 {
-					return "odd number of levels with ongoing compactions"
-				}
-				var inProgress []compactionInfo
-				for i := 0; i < len(levels); i += 2 {
-					inProgress = append(inProgress,
-						compactionInfoTesting{startLevel: levels[i], outputLevel: levels[i+1]})
-				}
-				c := pickerByScore.pickAuto(opts, new(uint64), inProgress)
+
+				c := pickerByScore.pickAuto(compactionEnv{
+					bytesCompacted:          new(uint64),
+					inProgressCompactions:   inProgress,
+					earliestUnflushedSeqNum: InternalKeySeqNumMax,
+				})
 				if c == nil {
 					return "no compaction"
 				}
@@ -170,6 +193,108 @@ func TestCompactionPickerEstimatedCompactionDebt(t *testing.T) {
 
 				p := newCompactionPicker(vers, opts, nil)
 				return fmt.Sprintf("%d\n", p.estimatedCompactionDebt(0))
+
+			default:
+				return fmt.Sprintf("unknown command: %s", d.Cmd)
+			}
+		})
+}
+
+func TestCompactionPickerIntraL0(t *testing.T) {
+	opts := &Options{}
+	opts = opts.EnsureDefaults()
+	var files []*fileMetadata
+
+	parseMeta := func(s string) *fileMetadata {
+		index := strings.Index(s, ":")
+		if index == -1 {
+			t.Fatalf("malformed table spec: %s", s)
+		}
+		m := &fileMetadata{}
+		var err error
+		m.FileNum, err = strconv.ParseUint(s[:index], 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		fields := strings.Fields(s[index+1:])
+		if len(fields) != 2 && len(fields) != 3 {
+			t.Fatalf("malformed table spec: %s", s)
+		}
+
+		parts := strings.Split(fields[0], "-")
+		if len(parts) != 2 {
+			t.Fatalf("malformed table spec: %s", s)
+		}
+		m.Smallest = base.ParseInternalKey(strings.TrimSpace(parts[0]))
+		m.Largest = base.ParseInternalKey(strings.TrimSpace(parts[1]))
+		m.SmallestSeqNum = m.Smallest.SeqNum()
+		m.LargestSeqNum = m.Largest.SeqNum()
+		if m.SmallestSeqNum > m.LargestSeqNum {
+			m.SmallestSeqNum, m.LargestSeqNum = m.LargestSeqNum, m.SmallestSeqNum
+		}
+
+		m.Size, err = strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(fields) == 3 {
+			if fields[2] != "compacting" {
+				t.Fatalf("malformed table spec: %s", s)
+			}
+			m.Compacting = true
+		}
+
+		return m
+	}
+
+	datadriven.RunTest(t, "testdata/compaction_picker_intra_L0",
+		func(d *datadriven.TestData) string {
+			switch d.Cmd {
+			case "define":
+				files = nil
+				if len(d.Input) == 0 {
+					return ""
+				}
+				for _, data := range strings.Split(d.Input, "\n") {
+					files = append(files, parseMeta(data))
+				}
+				manifest.SortBySeqNum(files)
+				return ""
+
+			case "pick-intra-L0":
+				env := compactionEnv{}
+				env.earliestUnflushedSeqNum = InternalKeySeqNumMax
+
+				if len(d.CmdArgs) == 1 {
+					if d.CmdArgs[0].Key != "earliest-unflushed" {
+						return fmt.Sprintf("unknown argument: %s", d.CmdArgs[0])
+					}
+					if len(d.CmdArgs[0].Vals) != 1 {
+						return fmt.Sprintf("%s expects 1 value: %s", d.CmdArgs[0].Key, d.CmdArgs[0])
+					}
+					var err error
+					env.earliestUnflushedSeqNum, err = strconv.ParseUint(d.CmdArgs[0].Vals[0], 10, 64)
+					if err != nil {
+						return err.Error()
+					}
+				}
+
+				c := pickIntraL0(env, opts, &version{
+					Files: [7][]*fileMetadata{
+						0: files,
+					},
+				})
+				if c == nil {
+					return "<nil>\n"
+				}
+
+				var buf bytes.Buffer
+				for _, f := range c.inputs[0] {
+					fmt.Fprintf(&buf, "%s\n", f)
+				}
+				return buf.String()
 
 			default:
 				return fmt.Sprintf("unknown command: %s", d.Cmd)

--- a/db.go
+++ b/db.go
@@ -1407,8 +1407,12 @@ func (d *DB) getEarliestUnflushedSeqNumLocked() uint64 {
 
 func (d *DB) getInProgressCompactionInfoLocked(finishing *compaction) (rv []compactionInfo) {
 	for c := range d.mu.compact.inProgress {
-		if c.outputLevel > 0 && (finishing == nil || c != finishing) {
-			rv = append(rv, c)
+		if len(c.flushing) == 0 && (finishing == nil || c != finishing) {
+			rv = append(rv, compactionInfo{
+				startLevel:  c.startLevel,
+				outputLevel: c.outputLevel,
+				inputs:      c.inputs,
+			})
 		}
 	}
 	return

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -55,6 +55,8 @@ type FileMetadata struct {
 	LargestSeqNum  uint64
 	// True if user asked us to compact this file.
 	MarkedForCompaction bool
+	// True if the file is actively being compacted. Protected by DB.mu.
+	Compacting bool
 }
 
 func (m FileMetadata) String() string {

--- a/table_cache.go
+++ b/table_cache.go
@@ -346,7 +346,7 @@ func (c *tableCacheShard) evict(fileNum uint64) {
 		// tableCacheShard.mu in order to avoid a race with Close()
 		c.unlinkNode(n)
 		if v := atomic.AddInt32(&n.refCount, -1); v != 0 {
-			c.logger.Fatalf("table refcount is not zero: %d", v)
+			c.logger.Fatalf("sstable %06d: refcount is not zero: %d", fileNum, v)
 		}
 		c.releasing.Add(1)
 	}

--- a/testdata/compaction_picker_intra_L0
+++ b/testdata/compaction_picker_intra_L0
@@ -1,0 +1,144 @@
+# Not enough L0 files to perform an intra-L0 compaction (the minimum
+# is 4).
+
+define
+000001:a.SET.1-b.SET.1 1
+000002:a.SET.2-b.SET.2 1
+000003:a.SET.3-b.SET.3 1
+----
+
+pick-intra-L0
+----
+<nil>
+
+# The basic intra-L0 scenario.
+
+define
+000001:a.SET.1-b.SET.1 1
+000002:a.SET.2-b.SET.2 1
+000003:a.SET.3-b.SET.3 1
+000004:a.SET.4-b.SET.4 1
+----
+
+pick-intra-L0 earliest-unflushed=5
+----
+000001:a#1,1-b#1,1
+000002:a#2,1-b#2,1
+000003:a#3,1-b#3,1
+000004:a#4,1-b#4,1
+
+# We exclude files from the compaction which overlap in seqnum space
+# with the earliest unflushed seqnum.
+
+pick-intra-L0 earliest-unflushed=4
+----
+<nil>
+
+pick-intra-L0 earliest-unflushed=3
+----
+<nil>
+
+# We exclude files from the compaction which are already being
+# compacted.
+
+define
+000001:a.SET.1-b.SET.1 1 compacting
+000002:a.SET.2-b.SET.2 1
+000003:a.SET.3-b.SET.3 1
+000004:a.SET.4-b.SET.4 1
+----
+
+pick-intra-L0
+----
+<nil>
+
+define
+000001:a.SET.1-b.SET.1 1
+000002:a.SET.2-b.SET.2 1
+000003:a.SET.3-b.SET.3 1
+000004:a.SET.4-b.SET.4 1 compacting
+----
+
+pick-intra-L0
+----
+<nil>
+
+define
+000001:a.SET.1-b.SET.1 1 compacting
+000002:a.SET.2-b.SET.2 1
+000003:a.SET.3-b.SET.3 1
+000004:a.SET.4-b.SET.4 1
+000005:a.SET.5-b.SET.5 1
+----
+
+pick-intra-L0
+----
+000002:a#2,1-b#2,1
+000003:a#3,1-b#3,1
+000004:a#4,1-b#4,1
+000005:a#5,1-b#5,1
+
+pick-intra-L0 earliest-unflushed=5
+----
+<nil>
+
+# Files are added to the intra-L0 compaction until the amount of
+# compaction work per file begins increasing. This setup is right on
+# the boundary of that condition.
+
+define
+000001:a.SET.1-b.SET.1 5
+000002:a.SET.2-b.SET.2 1
+000003:a.SET.3-b.SET.3 1
+000004:a.SET.4-b.SET.4 1
+000005:a.SET.5-b.SET.5 1
+----
+
+pick-intra-L0
+----
+000001:a#1,1-b#1,1
+000002:a#2,1-b#2,1
+000003:a#3,1-b#3,1
+000004:a#4,1-b#4,1
+000005:a#5,1-b#5,1
+
+# Files are added to the intra-L0 compaction until the amount of
+# compaction work per file begins increasing. Similar to the setup
+# above, but we're on the other side of the boundary which will
+# exclude 000001 from the compaction.
+
+define
+000001:a.SET.1-b.SET.1 6
+000002:a.SET.2-b.SET.2 1
+000003:a.SET.3-b.SET.3 1
+000004:a.SET.4-b.SET.4 1
+000005:a.SET.5-b.SET.5 1
+----
+
+pick-intra-L0
+----
+000002:a#2,1-b#2,1
+000003:a#3,1-b#3,1
+000004:a#4,1-b#4,1
+000005:a#5,1-b#5,1
+
+# The reverse of the above setup, where the large file is the newest
+# L0 table. The tables are considered from newest to oldest. Since the
+# amount of work per compaction is not increasing, all of the files
+# are included in the compaction.
+
+define
+000001:a.SET.1-b.SET.1 1
+000002:a.SET.2-b.SET.2 1
+000003:a.SET.3-b.SET.3 1
+000004:a.SET.4-b.SET.4 1
+000005:a.SET.5-b.SET.5 6
+----
+
+pick-intra-L0
+----
+000001:a#1,1-b#1,1
+000002:a#2,1-b#2,1
+000003:a#3,1-b#3,1
+000004:a#4,1-b#4,1
+000005:a#5,1-b#5,1

--- a/testdata/compaction_picker_target_level
+++ b/testdata/compaction_picker_target_level
@@ -37,7 +37,7 @@ init_cp
 
 queue
 ----
-5: 1.0,
+L5->L6: 1.0
 
 init 1
 5: 2
@@ -49,7 +49,7 @@ init_cp
 
 queue
 ----
-5: 2.0,
+L5->L6: 2.0
 
 # Smoothing multiplier is
 # `(size(Lbottom)/size(Lbase))^(Lbottom-Lbase) = (30/1)^(1/(6-4)) = 30^(1/2)`
@@ -80,7 +80,7 @@ init_cp
 
 queue
 ----
-4: 2.0,
+L4->L5: 2.0
 
 init 1
 4: 1
@@ -93,7 +93,7 @@ init_cp
 
 queue
 ----
-4: 1.0,
+L4->L5: 1.0
 
 init 1
 4: 1
@@ -106,7 +106,8 @@ init_cp
 
 queue
 ----
-5: 1.1,4: 1.0,
+L5->L6: 1.1
+L4->L5: 1.0
 
 init 1
 4: 2
@@ -119,7 +120,8 @@ init_cp
 
 queue
 ----
-4: 2.0,5: 1.1,
+L4->L5: 2.0
+L5->L6: 1.1
 
 init 1
 0: 4
@@ -130,7 +132,7 @@ init_cp
 
 queue
 ----
-0: 1.0,
+L0->L6: 1.0
 
 init 1
 0: 5
@@ -141,7 +143,7 @@ init_cp
 
 queue
 ----
-0: 1.2,
+L0->L6: 1.2
 
 init 1
 0: 5
@@ -154,7 +156,8 @@ init_cp
 
 queue
 ----
-5: 2.0,0: 1.2,
+L5->L6: 2.0
+L0->L5: 1.2
 
 pick
 ----
@@ -187,7 +190,9 @@ init_cp
 
 queue
 ----
-4: 2.0,0: 1.2,5: 1.0,
+L4->L5: 2.0
+L0->L4: 1.2
+L5->L6: 1.0
 
 pick ongoing=(5,6)
 ----
@@ -202,8 +207,37 @@ init_cp
 
 queue
 ----
-4: 2.0,0: 1.2,5: 1.0,
+L4->L5: 2.0
+L0->L4: 1.2
+L5->L6: 1.0
 
 pick ongoing=(0,5)
 ----
 no compaction
+
+init 1
+0: 6
+6: 10
+----
+
+init_cp ongoing=(0,5)
+----
+
+queue
+----
+L0->L0: 1.5
+
+pick
+----
+startLevel: 0, outputLevel: 0
+
+init_cp ongoing=(0,5)
+----
+
+queue
+----
+L0->L0: 1.5
+
+pick ongoing=(0,5)
+----
+startLevel: 0, outputLevel: 0


### PR DESCRIPTION
Intra-L0 compactions are compactions from L0 to L0. They reduce read
amplification in scenarios where L0->Lbase compactions cannot keep
up. One such scenario is the `sysbench/otlp_update_index` benchmark
which is an update heavy workload.

Intra-L0 compactions are only scheduled when an existing L0->Lbase
compaction is already running. We copy the RocksDB heuristics which
require the compaction to involve a minimum of 4 L0 files, and to only
perform an intra-L0 compaction if the number of L0 files exceeds
`L0CompationThreshold+2`. Additionally, we copy the RocksDB heuristic
for determination of which files to include. Specifically, we keep on
adding files to the compaction as long as the average file size keeps
increasing. There isn't much commentary in RocksDB on what this
heuristic is doing, but it seems safer to replicate it rather than come
up with a different heuristic.
