### PR TITLE
db: force flushing of overlapping queued memtables during ingestion

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1019,6 +1019,10 @@ type flushableBatch struct {
 
 	flushedCh chan struct{}
 
+	// flushForced indicates whether a flush was forced on this batch (either
+	// manual, or due to ingestion).
+	flushForced bool
+
 	logNum uint64
 }
 
@@ -1187,8 +1191,12 @@ func (b *flushableBatch) flushed() chan struct{} {
 	return b.flushedCh
 }
 
-func (b *flushableBatch) manualFlush() bool {
-	return false
+func (b *flushableBatch) forcedFlush() bool {
+	return b.flushForced
+}
+
+func (b *flushableBatch) setForceFlush() {
+	b.flushForced = true
 }
 
 func (b *flushableBatch) readyForFlush() bool {

--- a/compaction.go
+++ b/compaction.go
@@ -788,9 +788,9 @@ func (d *DB) maybeScheduleFlush() {
 		if !d.mu.mem.queue[n].readyForFlush() {
 			break
 		}
-		if d.mu.mem.queue[n].manualFlush() {
-			// A manual flush was requested. Pretend the memtable size is the
-			// configured size. See minFlushSize below.
+		if d.mu.mem.queue[n].forcedFlush() {
+			// A flush was forced. Pretend the memtable size is the configured
+			// size. See minFlushSize below.
 			size += uint64(d.opts.MemTableSize)
 		} else {
 			size += d.mu.mem.queue[n].totalBytes()

--- a/mem_table.go
+++ b/mem_table.go
@@ -71,8 +71,9 @@ type memTable struct {
 	// drops to zero.
 	writerRefs int32
 	flushedCh  chan struct{}
-	// flushManual indicates whether a manual flush was forced on this memtable.
-	flushManual bool
+	// flushForced indicates whether a flush was forced on this memtable (either
+	// manual, or due to ingestion).
+	flushForced bool
 	tombstones  rangeTombstoneCache
 	logNum      uint64
 	logSize     uint64
@@ -148,8 +149,12 @@ func (m *memTable) flushed() chan struct{} {
 	return m.flushedCh
 }
 
-func (m *memTable) manualFlush() bool {
-	return m.flushManual
+func (m *memTable) forcedFlush() bool {
+	return m.flushForced
+}
+
+func (m *memTable) setForceFlush() {
+	m.flushForced = true
 }
 
 func (m *memTable) readyForFlush() bool {


### PR DESCRIPTION
When a memtable (or large batch) is queued for flushing, it is not
necessarily automatically flushed due to the heuristic in
`DB.maybeScheduleFlush` which avoids flushing a small memtable. If
ingestion encounters such a queued memtable, it needs to force the
flushing to occur. Most of the mechanism for doing so already existed
via the `flushable.manualFlush()` method. That has now been renamed to
`flushable.forcedFlush()`.

See cockroachdb/cockroach#44631