### PR TITLE
db: add memTable.logSeqNum

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1203,8 +1203,8 @@ func (b *flushableBatch) readyForFlush() bool {
 	return true
 }
 
-func (b *flushableBatch) logInfo() (uint64, uint64) {
-	return b.logNum, 0 /* logSize */
+func (b *flushableBatch) logInfo() (logNum, size, seqNum uint64) {
+	return b.logNum, 0 /* logSize */, b.seqNum
 }
 
 // Note: flushableBatchIter mirrors the implementation of batchIter. Keep the

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -126,7 +126,7 @@ func (d *DB) Checkpoint(destDir string) (err error) {
 	// will cause the WAL files to be reused which would invalidate the
 	// checkpoint.
 	for i := range memQueue {
-		logNum, _ := memQueue[i].logInfo()
+		logNum, _, _ := memQueue[i].logInfo()
 		if logNum == 0 {
 			continue
 		}

--- a/commit_test.go
+++ b/commit_test.go
@@ -239,7 +239,7 @@ func BenchmarkCommitPipeline(b *testing.B) {
 	for _, parallelism := range []int{1, 2, 4, 8, 16, 32, 64, 128} {
 		b.Run(fmt.Sprintf("parallel=%d", parallelism), func(b *testing.B) {
 			b.SetParallelism(parallelism)
-			mem := newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
+			mem := newMemTable(memTableOptions{})
 			wal := record.NewLogWriter(ioutil.Discard, 0 /* logNum */)
 
 			nullCommitEnv := commitEnv{
@@ -257,7 +257,7 @@ func BenchmarkCommitPipeline(b *testing.B) {
 					for {
 						err := mem.prepare(b)
 						if err == arenaskl.ErrArenaFull {
-							mem = newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
+							mem = newMemTable(memTableOptions{})
 							continue
 						}
 						if err != nil {

--- a/compaction.go
+++ b/compaction.go
@@ -852,10 +852,10 @@ func (d *DB) flush1() error {
 
 	// Require that every memtable being flushed has a log number less than the
 	// new minimum unflushed log number.
-	minUnflushedLogNum, _ := d.mu.mem.queue[n].logInfo()
+	minUnflushedLogNum, _, _ := d.mu.mem.queue[n].logInfo()
 	if !d.opts.DisableWAL {
 		for i := 0; i < n; i++ {
-			logNum, _ := d.mu.mem.queue[i].logInfo()
+			logNum, _, _ := d.mu.mem.queue[i].logInfo()
 			if logNum >= minUnflushedLogNum {
 				return errFlushInvariant
 			}
@@ -904,7 +904,7 @@ func (d *DB) flush1() error {
 		ve.MinUnflushedLogNum = minUnflushedLogNum
 		metrics := c.metrics[0]
 		for i := 0; i < n; i++ {
-			_, size := d.mu.mem.queue[i].logInfo()
+			_, size, _ := d.mu.mem.queue[i].logInfo()
 			metrics.BytesIn += size
 		}
 

--- a/data_test.go
+++ b/data_test.go
@@ -399,7 +399,7 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 				}
 				// Add a memtable layer.
 				if !d.mu.mem.mutable.empty() {
-					d.mu.mem.mutable = newMemTable(d.opts, 0 /* size */, nil /* reservation */)
+					d.mu.mem.mutable = newMemTable(memTableOptions{Options: d.opts})
 					d.mu.mem.queue = append(d.mu.mem.queue, d.mu.mem.mutable)
 					d.updateReadStateLocked(nil)
 				}
@@ -414,7 +414,7 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 					return nil, err
 				}
 				fields = fields[1:]
-				mem = newMemTable(d.opts, 0 /* size */, nil /* reservation */)
+				mem = newMemTable(memTableOptions{Options: d.opts})
 			}
 		}
 

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -480,7 +480,7 @@ func TestGetIter(t *testing.T) {
 
 		v := version{}
 		for _, tt := range tc.tables {
-			d := newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
+			d := newMemTable(memTableOptions{})
 			defer d.close()
 			m[tt.fileNum] = d
 

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -391,7 +391,7 @@ func TestIngestMemtableOverlaps(t *testing.T) {
 						}
 					}
 
-					mem = newMemTable(opts, 0 /* size */, nil /* reservation */)
+					mem = newMemTable(memTableOptions{Options: opts})
 					if err := mem.apply(b, 0); err != nil {
 						return err.Error()
 					}

--- a/mem_table_test.go
+++ b/mem_table_test.go
@@ -68,7 +68,7 @@ func ikey(s string) InternalKey {
 
 func TestMemTableBasic(t *testing.T) {
 	// Check the empty DB.
-	m := newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
+	m := newMemTable(memTableOptions{})
 	if got, want := m.count(), 0; got != want {
 		t.Fatalf("0.count: got %v, want %v", got, want)
 	}
@@ -119,7 +119,7 @@ func TestMemTableBasic(t *testing.T) {
 }
 
 func TestMemTableCount(t *testing.T) {
-	m := newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
+	m := newMemTable(memTableOptions{})
 	for i := 0; i < 200; i++ {
 		if j := m.count(); j != i {
 			t.Fatalf("count: got %d, want %d", j, i)
@@ -132,7 +132,7 @@ func TestMemTableCount(t *testing.T) {
 }
 
 func TestMemTableBytesIterated(t *testing.T) {
-	m := newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
+	m := newMemTable(memTableOptions{})
 	for i := 0; i < 200; i++ {
 		bytesIterated := m.bytesIterated(t)
 		expected := m.inuseBytes()
@@ -147,7 +147,7 @@ func TestMemTableBytesIterated(t *testing.T) {
 }
 
 func TestMemTableEmpty(t *testing.T) {
-	m := newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
+	m := newMemTable(memTableOptions{})
 	if !m.empty() {
 		t.Errorf("got !empty, want empty")
 	}
@@ -161,7 +161,7 @@ func TestMemTableEmpty(t *testing.T) {
 func TestMemTable1000Entries(t *testing.T) {
 	// Initialize the DB.
 	const N = 1000
-	m0 := newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
+	m0 := newMemTable(memTableOptions{})
 	for i := 0; i < N; i++ {
 		k := ikey(strconv.Itoa(i))
 		v := []byte(strings.Repeat("x", i))
@@ -242,7 +242,7 @@ func TestMemTableIter(t *testing.T) {
 		datadriven.RunTest(t, testdata, func(d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "define":
-				mem = newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
+				mem = newMemTable(memTableOptions{})
 				for _, key := range strings.Split(d.Input, "\n") {
 					j := strings.Index(key, ":")
 					if err := mem.set(base.ParseInternalKey(key[:j]), []byte(key[j+1:])); err != nil {
@@ -299,7 +299,7 @@ func TestMemTableDeleteRange(t *testing.T) {
 				return err.Error()
 			}
 			if mem == nil {
-				mem = newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
+				mem = newMemTable(memTableOptions{})
 			}
 			if err := mem.apply(b, seqNum); err != nil {
 				return err.Error()
@@ -339,7 +339,7 @@ func TestMemTableConcurrentDeleteRange(t *testing.T) {
 	// tombstones, and then immediately retrieve them verifying that the
 	// tombstones they've added are all present.
 
-	m := newMemTable(&Options{MemTableSize: 64 << 20}, 0 /* size */, nil /* reservation */)
+	m := newMemTable(memTableOptions{Options: &Options{MemTableSize: 64 << 20}})
 
 	const workers = 10
 	var wg sync.WaitGroup
@@ -377,7 +377,7 @@ func TestMemTableConcurrentDeleteRange(t *testing.T) {
 }
 
 func buildMemTable(b *testing.B) (*memTable, [][]byte) {
-	m := newMemTable(nil /* opts */, 0 /* size */, nil /* reservation */)
+	m := newMemTable(memTableOptions{})
 	var keys [][]byte
 	var ikey InternalKey
 	for i := 0; ; i++ {


### PR DESCRIPTION
Track the seqnum at which a memtable was created. This is necessary for
correctness when picking sstables for intra-L0
compactions. Additionally, this allowed addressing a long standing TODO
to avoid reading from memtables that are newer than the snapshot being
read at.