### PR TITLE
db: fix an innocuous race in reading/updating memTable.logSize

### DIFF
--- a/db.go
+++ b/db.go
@@ -1328,7 +1328,10 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 		}
 
 		imm := d.mu.mem.mutable
-		imm.logSize = prevLogSize
+		// We atomically update logSize because it is read concurrently (yet not
+		// used) on the read path in DB.{get,newIter}Internal via a call to
+		// flushable.logInfo().
+		atomic.StoreUint64(&imm.logSize, prevLogSize)
 		if b == nil {
 			imm.setForceFlush()
 		}

--- a/mem_table.go
+++ b/mem_table.go
@@ -178,7 +178,7 @@ func (m *memTable) readyForFlush() bool {
 }
 
 func (m *memTable) logInfo() (logNum, size, seqNum uint64) {
-	return m.logNum, m.logSize, m.logSeqNum
+	return m.logNum, atomic.LoadUint64(&m.logSize), m.logSeqNum
 }
 
 // Get gets the value for the given key. It returns ErrNotFound if the DB does


### PR DESCRIPTION
Fix an innocuous race. `memTable.logSize` is updated when we're
switching a memtable from being mutable to immutable, yet that field is
read but not used on the read path (in
`DB.{get,newIter}Internal`). Switch to updating and reading the field
atomically. I have an idea for a better long term solution, but this
will suffice in the very short term.