### PR TITLE
db: add flushableEntry which wraps a flushable

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -126,7 +126,7 @@ func (d *DB) Checkpoint(destDir string) (err error) {
 	// will cause the WAL files to be reused which would invalidate the
 	// checkpoint.
 	for i := range memQueue {
-		logNum, _, _ := memQueue[i].logInfo()
+		logNum := memQueue[i].logNum
 		if logNum == 0 {
 			continue
 		}

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1554,7 +1554,7 @@ func TestFlushInvariant(t *testing.T) {
 					case 1:
 						// Force the flushing memtable to have a log number equal to the new
 						// log's number.
-						d.mu.mem.mutable.logNum = d.mu.versions.nextFileNum
+						d.mu.mem.queue[len(d.mu.mem.queue)-1].logNum = d.mu.versions.nextFileNum
 					}
 					d.mu.Unlock()
 

--- a/db.go
+++ b/db.go
@@ -40,63 +40,6 @@ var (
 	ErrReadOnly = errors.New("pebble: read-only")
 )
 
-type flushable interface {
-	newIter(o *IterOptions) internalIterator
-	newFlushIter(o *IterOptions, bytesFlushed *uint64) internalIterator
-	newRangeDelIter(o *IterOptions) internalIterator
-	inuseBytes() uint64
-	totalBytes() uint64
-	readyForFlush() bool
-}
-
-type flushableEntry struct {
-	flushable
-	// Channel which is closed when the flushable has been flushed.
-	flushed chan struct{}
-	// flushForced indicates whether a flush was forced on this memtable (either
-	// manual, or due to ingestion). Protected by DB.mu.
-	flushForced bool
-	// logNum corresponds to the WAL that contains the records present in the
-	// receiver.
-	logNum uint64
-	// logSize is the size in bytes of the associated WAL. Protected by DB.mu.
-	logSize uint64
-	// The current logSeqNum at the time the memtable was created. This is
-	// guaranteed to be less than or equal to any seqnum stored in the memtable.
-	logSeqNum uint64
-	// readerRefs tracks the read references on the flushable. The two sources of
-	// reader references are DB.mu.mem.queue and readState.memtables. The memory
-	// reserved by the flushable in the cache is released when the reader refs
-	// drop to zero. If the flushable is a memTable, when the reader refs drops
-	// to zero, the writer refs will already be zero because the memtable will
-	// have been flushed and that only occurs once the writer refs drops to zero.
-	readerRefs int32
-	// Closure to invoke to release memory accounting.
-	releaseMemAccounting func()
-}
-
-func (e *flushableEntry) readerRef() {
-	switch v := atomic.AddInt32(&e.readerRefs, 1); {
-	case v <= 1:
-		panic(fmt.Sprintf("pebble: inconsistent reference count: %d", v))
-	}
-}
-
-func (e *flushableEntry) readerUnref() {
-	switch v := atomic.AddInt32(&e.readerRefs, -1); {
-	case v < 0:
-		panic(fmt.Sprintf("pebble: inconsistent reference count: %d", v))
-	case v == 0:
-		if e.releaseMemAccounting == nil {
-			panic(fmt.Sprintf("pebble: memtable reservation already released"))
-		}
-		e.releaseMemAccounting()
-		e.releaseMemAccounting = nil
-	}
-}
-
-type flushableList []*flushableEntry
-
 // Reader is a readable key/value store.
 //
 // It is safe to call Get and NewIter from concurrent goroutines.

--- a/db.go
+++ b/db.go
@@ -46,20 +46,56 @@ type flushable interface {
 	newRangeDelIter(o *IterOptions) internalIterator
 	inuseBytes() uint64
 	totalBytes() uint64
-	readerRef()
-	readerUnref()
-	flushed() chan struct{}
-	forcedFlush() bool
-	setForceFlush()
 	readyForFlush() bool
-	// Returns info about how the receiver relates to the log:
-	// - logNum corresponds to the WAL that contains the records present in the
-	//   receiver
-	// - logSize is the size in bytes of the associated WAL
-	// - seqNum is a sequence number that is less than or equal to the first
-	//   seqnum in the receiver
-	logInfo() (logNum, logSize, seqNum uint64)
 }
+
+type flushableEntry struct {
+	flushable
+	// Channel which is closed when the flushable has been flushed.
+	flushed chan struct{}
+	// flushForced indicates whether a flush was forced on this memtable (either
+	// manual, or due to ingestion). Protected by DB.mu.
+	flushForced bool
+	// logNum corresponds to the WAL that contains the records present in the
+	// receiver.
+	logNum uint64
+	// logSize is the size in bytes of the associated WAL. Protected by DB.mu.
+	logSize uint64
+	// The current logSeqNum at the time the memtable was created. This is
+	// guaranteed to be less than or equal to any seqnum stored in the memtable.
+	logSeqNum uint64
+	// readerRefs tracks the read references on the flushable. The two sources of
+	// reader references are DB.mu.mem.queue and readState.memtables. The memory
+	// reserved by the flushable in the cache is released when the reader refs
+	// drop to zero. If the flushable is a memTable, when the reader refs drops
+	// to zero, the writer refs will already be zero because the memtable will
+	// have been flushed and that only occurs once the writer refs drops to zero.
+	readerRefs int32
+	// Closure to invoke to release memory accounting.
+	releaseMemAccounting func()
+}
+
+func (e *flushableEntry) readerRef() {
+	switch v := atomic.AddInt32(&e.readerRefs, 1); {
+	case v <= 1:
+		panic(fmt.Sprintf("pebble: inconsistent reference count: %d", v))
+	}
+}
+
+func (e *flushableEntry) readerUnref() {
+	switch v := atomic.AddInt32(&e.readerRefs, -1); {
+	case v < 0:
+		panic(fmt.Sprintf("pebble: inconsistent reference count: %d", v))
+	case v == 0:
+		if e.releaseMemAccounting == nil {
+			panic(fmt.Sprintf("pebble: memtable reservation already released"))
+		}
+		e.releaseMemAccounting()
+		e.releaseMemAccounting = nil
+	}
+}
+
+type flushableList []*flushableEntry
 
 // Reader is a readable key/value store.
 //
@@ -284,7 +320,7 @@ type DB struct {
 			// added to the end of the slice and removed from the beginning. Once an
 			// index is set it is never modified making a fixed slice immutable and
 			// safe for concurrent reads.
-			queue []flushable
+			queue flushableList
 			// True when the memtable is actively been switched. Both mem.mutable and
 			// log.LogWriter are invalid while switching is true.
 			switching bool
@@ -386,7 +422,7 @@ func (d *DB) getInternal(key []byte, b *Batch, s *Snapshot) ([]byte, error) {
 	// at.
 	for len(get.mem) > 0 {
 		n := len(get.mem)
-		if _, _, logSeqNum := get.mem[n-1].logInfo(); logSeqNum < seqNum {
+		if logSeqNum := get.mem[n-1].logSeqNum; logSeqNum < seqNum {
 			break
 		}
 		get.mem = get.mem[:n-1]
@@ -693,7 +729,7 @@ func (d *DB) newIterInternal(
 		mem := memtables[i]
 		// We only need to read from memtables which contain sequence numbers older
 		// than seqNum.
-		if _, _, logSeqNum := mem.logInfo(); logSeqNum >= seqNum {
+		if logSeqNum := mem.logSeqNum; logSeqNum >= seqNum {
 			continue
 		}
 		mlevels = append(mlevels, mergingIterLevel{
@@ -912,29 +948,27 @@ func (d *DB) Compact(
 
 	// Determine if any memtable overlaps with the compaction range. We wait for
 	// any such overlap to flush (initiating a flush if necessary).
-	mem, err := func() (flushable, error) {
-		if ingestMemtableOverlaps(d.cmp, d.mu.mem.mutable, meta) {
-			mem := d.mu.mem.mutable
-
-			// We have to hold both commitPipeline.mu and DB.mu when calling
-			// makeRoomForWrite(). Lock order requirements elsewhere force us to
-			// unlock DB.mu in order to grab commitPipeline.mu first.
-			d.mu.Unlock()
-			d.commit.mu.Lock()
-			d.mu.Lock()
-			defer d.commit.mu.Unlock()
-			if mem == d.mu.mem.mutable {
-				// Only flush if the active memtable is unchanged.
-				return mem, d.makeRoomForWrite(nil)
-			}
-			return mem, nil
-		}
-		// Check to see if any files overlap with any of the immutable
-		// memtables. The queue is ordered from oldest to newest. We want to wait
-		// for the newest table that overlaps.
+	mem, err := func() (*flushableEntry, error) {
+		// Check to see if any files overlap with any of the memtables. The queue
+		// is ordered from oldest to newest with the mutable memtable being the
+		// last element in the slice. We want to wait for the newest table that
+		// overlaps.
 		for i := len(d.mu.mem.queue) - 1; i >= 0; i-- {
 			mem := d.mu.mem.queue[i]
 			if ingestMemtableOverlaps(d.cmp, mem, meta) {
+				if mem.flushable == d.mu.mem.mutable {
+					// We have to hold both commitPipeline.mu and DB.mu when calling
+					// makeRoomForWrite(). Lock order requirements elsewhere force us to
+					// unlock DB.mu in order to grab commitPipeline.mu first.
+					d.mu.Unlock()
+					d.commit.mu.Lock()
+					d.mu.Lock()
+					defer d.commit.mu.Unlock()
+					if mem.flushable == d.mu.mem.mutable {
+						// Only flush if the active memtable is unchanged.
+						return mem, d.makeRoomForWrite(nil)
+					}
+				}
 				return mem, nil
 			}
 		}
@@ -947,7 +981,7 @@ func (d *DB) Compact(
 		return err
 	}
 	if mem != nil {
-		<-mem.flushed()
+		<-mem.flushed
 	}
 
 	for level := 0; level < maxLevelWithFiles; {
@@ -1002,14 +1036,14 @@ func (d *DB) AsyncFlush() (<-chan struct{}, error) {
 
 	d.commit.mu.Lock()
 	d.mu.Lock()
-	mem := d.mu.mem.mutable
+	flushed := d.mu.mem.queue[len(d.mu.mem.queue)-1].flushed
 	err := d.makeRoomForWrite(nil)
 	d.mu.Unlock()
 	d.commit.mu.Unlock()
 	if err != nil {
 		return nil, err
 	}
-	return mem.flushed(), nil
+	return flushed, nil
 }
 
 // Metrics returns metrics about the database.
@@ -1030,8 +1064,7 @@ func (d *DB) Metrics() *Metrics {
 	metrics.WAL.Size = atomic.LoadUint64(&d.mu.log.size)
 	metrics.WAL.BytesIn = d.mu.log.bytesIn // protected by d.mu
 	for i, n := 0, len(d.mu.mem.queue)-1; i < n; i++ {
-		_, size, _ := d.mu.mem.queue[i].logInfo()
-		metrics.WAL.Size += size
+		metrics.WAL.Size += d.mu.mem.queue[i].logSize
 	}
 	metrics.WAL.BytesWritten = metrics.Levels[0].BytesIn + metrics.WAL.Size
 	metrics.Levels[0].Score = float64(metrics.Levels[0].NumFiles) / float64(d.opts.L0CompactionThreshold)
@@ -1157,7 +1190,7 @@ func (d *DB) walPreallocateSize() int {
 	return size
 }
 
-func (d *DB) newMemTable(logSeqNum uint64) *memTable {
+func (d *DB) newMemTable(logNum, logSeqNum uint64) (*memTable, *flushableEntry) {
 	size := d.mu.mem.nextSize
 	if d.mu.mem.nextSize < d.opts.MemTableSize {
 		d.mu.mem.nextSize *= 2
@@ -1165,21 +1198,34 @@ func (d *DB) newMemTable(logSeqNum uint64) *memTable {
 			d.mu.mem.nextSize = d.opts.MemTableSize
 		}
 	}
-	return newMemTable(memTableOptions{
+
+	atomic.AddInt64(&d.memTableCount, 1)
+	atomic.AddInt64(&d.memTableReserved, int64(size))
+	releaseAccountingReservation := d.opts.Cache.Reserve(size)
+	releaseMemAccounting := func() {
+		atomic.AddInt64(&d.memTableCount, -1)
+		atomic.AddInt64(&d.memTableReserved, -int64(size))
+		releaseAccountingReservation()
+	}
+
+	mem := newMemTable(memTableOptions{
 		Options:   d.opts,
 		size:      size,
 		logSeqNum: logSeqNum,
-		memAccounting: func(size int) func() {
-			atomic.AddInt64(&d.memTableCount, 1)
-			atomic.AddInt64(&d.memTableReserved, int64(size))
-			releaseAccountingReservation := d.opts.Cache.Reserve(size)
-			return func() {
-				atomic.AddInt64(&d.memTableCount, -1)
-				atomic.AddInt64(&d.memTableReserved, -int64(size))
-				releaseAccountingReservation()
-			}
-		},
 	})
+	entry := d.newFlushableEntry(mem, logNum, logSeqNum)
+	entry.releaseMemAccounting = releaseMemAccounting
+	return mem, entry
+}
+
+func (d *DB) newFlushableEntry(f flushable, logNum, logSeqNum uint64) *flushableEntry {
+	return &flushableEntry{
+		flushable:  f,
+		flushed:    make(chan struct{}),
+		logNum:     logNum,
+		logSeqNum:  logSeqNum,
+		readerRefs: 1,
+	}
 }
 
 // makeRoomForWrite ensures that the memtable has room to hold the contents of
@@ -1327,21 +1373,17 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 			d.mu.log.LogWriter.SetMinSyncInterval(d.opts.WALMinSyncInterval)
 		}
 
-		imm := d.mu.mem.mutable
-		// We atomically update logSize because it is read concurrently (yet not
-		// used) on the read path in DB.{get,newIter}Internal via a call to
-		// flushable.logInfo().
-		atomic.StoreUint64(&imm.logSize, prevLogSize)
-		if b == nil {
-			imm.setForceFlush()
-		}
+		immMem := d.mu.mem.mutable
+		imm := d.mu.mem.queue[len(d.mu.mem.queue)-1]
+		imm.logSize = prevLogSize
+		imm.flushForced = imm.flushForced || (b == nil)
 
 		// If we are manually flushing and we used less than half of the bytes in
 		// the memtable, don't increase the size for the next memtable. This
 		// reduces memtable memory pressure when an application is frequently
 		// manually flushing.
-		if (b == nil) && uint64(imm.availBytes()) > imm.totalBytes()/2 {
-			d.mu.mem.nextSize = int(imm.totalBytes())
+		if (b == nil) && uint64(immMem.availBytes()) > immMem.totalBytes()/2 {
+			d.mu.mem.nextSize = int(immMem.totalBytes())
 		}
 
 		if b != nil && b.flushable != nil {
@@ -1356,8 +1398,12 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 			// See DB.commitWrite for the special handling of log writes for large
 			// batches. In particular, the large batch has already written to
 			// imm.logNum.
-			b.flushable.logNum, imm.logNum = imm.logNum, 0
-			d.mu.mem.queue = append(d.mu.mem.queue, b.flushable)
+			entry := d.newFlushableEntry(b.flushable, imm.logNum, b.SeqNum())
+			// The large batch is by definition large. Reserve space from the cache
+			// for it until it is flushed.
+			entry.releaseMemAccounting = d.opts.Cache.Reserve(int(b.flushable.totalBytes()))
+			d.mu.mem.queue = append(d.mu.mem.queue, entry)
+			imm.logNum = 0
 		}
 
 		var logSeqNum uint64
@@ -1374,16 +1420,17 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 		// also have to wait for all previous immutable tables to
 		// flush. Additionally, the memtable is tied to particular WAL file and we
 		// want to go through the flush path in order to recycle that WAL file.
-		d.mu.mem.mutable = d.newMemTable(logSeqNum)
+		//
 		// NB: newLogNum corresponds to the WAL that contains mutations that are
 		// present in the new memtable. When immutable memtables are flushed to
 		// disk, a VersionEdit will be created telling the manifest the minimum
 		// unflushed log number (which will be the next one in d.mu.mem.mutable
 		// that was not flushed).
-		d.mu.mem.mutable.logNum = newLogNum
-		d.mu.mem.queue = append(d.mu.mem.queue, d.mu.mem.mutable)
+		var entry *flushableEntry
+		d.mu.mem.mutable, entry = d.newMemTable(newLogNum, logSeqNum)
+		d.mu.mem.queue = append(d.mu.mem.queue, entry)
 		d.updateReadStateLocked(nil)
-		if imm.writerUnref() {
+		if immMem.writerUnref() {
 			d.maybeScheduleFlush()
 		}
 		force = false
@@ -1391,9 +1438,9 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 }
 
 func (d *DB) getEarliestUnflushedSeqNumLocked() uint64 {
-	_, _, seqNum := d.mu.mem.mutable.logInfo()
+	seqNum := InternalKeySeqNumMax
 	for i := range d.mu.mem.queue {
-		_, _, logSeqNum := d.mu.mem.queue[i].logInfo()
+		logSeqNum := d.mu.mem.queue[i].logSeqNum
 		if seqNum > logSeqNum {
 			seqNum = logSeqNum
 		}

--- a/db_test.go
+++ b/db_test.go
@@ -720,7 +720,7 @@ func TestMemTableReservation(t *testing.T) {
 	}
 
 	checkReserved(int64(opts.MemTableSize))
-	if refs := atomic.LoadInt32(&d.mu.mem.mutable.readerRefs); refs != 2 {
+	if refs := atomic.LoadInt32(&d.mu.mem.queue[len(d.mu.mem.queue)-1].readerRefs); refs != 2 {
 		t.Fatalf("expected 2 refs, but found %d", refs)
 	}
 	// Verify the memtable reservation has caused our test block to be evicted.
@@ -760,7 +760,7 @@ func TestMemTableReservationLeak(t *testing.T) {
 		t.Fatal(err)
 	}
 	d.mu.Lock()
-	d.mu.mem.mutable.readerRef()
+	d.mu.mem.queue[len(d.mu.mem.queue)-1].readerRef()
 	d.mu.Unlock()
 	if err := d.Close(); err == nil {
 		t.Fatalf("expected failure, but found success")

--- a/flushable.go
+++ b/flushable.go
@@ -1,0 +1,75 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+// flushable defines the interface for immutable memtables.
+type flushable interface {
+	newIter(o *IterOptions) internalIterator
+	newFlushIter(o *IterOptions, bytesFlushed *uint64) internalIterator
+	newRangeDelIter(o *IterOptions) internalIterator
+	// inuseBytes returns the number of inuse bytes by the flushable.
+	inuseBytes() uint64
+	// totalBytes returns the total number of bytes allocated by the flushable.
+	totalBytes() uint64
+	// readyForFlush returns true when the flushable is ready for flushing. See
+	// memTable.readyForFlush for one implementation which needs to check whether
+	// there are any outstanding write references.
+	readyForFlush() bool
+}
+
+// flushableEntry wraps a flushable and adds additional metadata and
+// functionality that is common to all flushables.
+type flushableEntry struct {
+	flushable
+	// Channel which is closed when the flushable has been flushed.
+	flushed chan struct{}
+	// flushForced indicates whether a flush was forced on this memtable (either
+	// manual, or due to ingestion). Protected by DB.mu.
+	flushForced bool
+	// logNum corresponds to the WAL that contains the records present in the
+	// receiver.
+	logNum uint64
+	// logSize is the size in bytes of the associated WAL. Protected by DB.mu.
+	logSize uint64
+	// The current logSeqNum at the time the memtable was created. This is
+	// guaranteed to be less than or equal to any seqnum stored in the memtable.
+	logSeqNum uint64
+	// readerRefs tracks the read references on the flushable. The two sources of
+	// reader references are DB.mu.mem.queue and readState.memtables. The memory
+	// reserved by the flushable in the cache is released when the reader refs
+	// drop to zero. If the flushable is a memTable, when the reader refs drops
+	// to zero, the writer refs will already be zero because the memtable will
+	// have been flushed and that only occurs once the writer refs drops to zero.
+	readerRefs int32
+	// Closure to invoke to release memory accounting.
+	releaseMemAccounting func()
+}
+
+func (e *flushableEntry) readerRef() {
+	switch v := atomic.AddInt32(&e.readerRefs, 1); {
+	case v <= 1:
+		panic(fmt.Sprintf("pebble: inconsistent reference count: %d", v))
+	}
+}
+
+func (e *flushableEntry) readerUnref() {
+	switch v := atomic.AddInt32(&e.readerRefs, -1); {
+	case v < 0:
+		panic(fmt.Sprintf("pebble: inconsistent reference count: %d", v))
+	case v == 0:
+		if e.releaseMemAccounting == nil {
+			panic(fmt.Sprintf("pebble: memtable reservation already released"))
+		}
+		e.releaseMemAccounting()
+		e.releaseMemAccounting = nil
+	}
+}
+
+type flushableList []*flushableEntry

--- a/get_iter.go
+++ b/get_iter.go
@@ -26,7 +26,7 @@ type getIter struct {
 	levelIter    levelIter
 	level        int
 	batch        *Batch
-	mem          []flushable
+	mem          flushableList
 	l0           []fileMetadata
 	version      *version
 	iterKey      *InternalKey

--- a/ingest.go
+++ b/ingest.go
@@ -443,32 +443,26 @@ func (d *DB) Ingest(paths []string) error {
 		return err
 	}
 
-	var mem flushable
+	var mem *flushableEntry
 	prepare := func() {
 		// Note that d.commit.mu is held by commitPipeline when calling prepare.
 
 		d.mu.Lock()
 		defer d.mu.Unlock()
 
-		// If the mutable memtable contains keys which overlap any of the sstables
-		// then flush the memtable. Note that apply will wait for the flushing to
-		// finish.
-		if ingestMemtableOverlaps(d.cmp, d.mu.mem.mutable, meta) {
-			mem = d.mu.mem.mutable
-			err = d.makeRoomForWrite(nil)
-			mem.setForceFlush()
-			d.maybeScheduleFlush()
-			return
-		}
-
-		// Check to see if any files overlap with any of the immutable
-		// memtables. The queue is ordered from oldest to newest. We want to wait
-		// for the newest table that overlaps.
-		for i := len(d.mu.mem.queue) - 1; i >= 0; i-- {
+		// Check to see if any files overlap with any of the memtables. The queue
+		// is ordered from oldest to newest with the mutable memtable being the
+		// last element in the slice. We want to wait for the newest table that
+		// overlaps.
+		mutableIndex := len(d.mu.mem.queue) - 1
+		for i := mutableIndex; i >= 0; i-- {
 			m := d.mu.mem.queue[i]
 			if ingestMemtableOverlaps(d.cmp, m, meta) {
 				mem = m
-				mem.setForceFlush()
+				if i == mutableIndex {
+					err = d.makeRoomForWrite(nil)
+				}
+				mem.flushForced = true
 				d.maybeScheduleFlush()
 				return
 			}
@@ -491,7 +485,7 @@ func (d *DB) Ingest(paths []string) error {
 		// If we overlapped with a memtable in prepare wait for the flush to
 		// finish.
 		if mem != nil {
-			<-mem.flushed()
+			<-mem.flushed
 		}
 
 		// Assign the sstables to the correct level in the LSM and apply the

--- a/ingest.go
+++ b/ingest.go
@@ -454,12 +454,11 @@ func (d *DB) Ingest(paths []string) error {
 		// is ordered from oldest to newest with the mutable memtable being the
 		// last element in the slice. We want to wait for the newest table that
 		// overlaps.
-		mutableIndex := len(d.mu.mem.queue) - 1
-		for i := mutableIndex; i >= 0; i-- {
+		for i := len(d.mu.mem.queue) - 1; i >= 0; i-- {
 			m := d.mu.mem.queue[i]
 			if ingestMemtableOverlaps(d.cmp, m, meta) {
 				mem = m
-				if i == mutableIndex {
+				if mem.flushable == d.mu.mem.mutable {
 					err = d.makeRoomForWrite(nil)
 				}
 				mem.flushForced = true

--- a/read_state.go
+++ b/read_state.go
@@ -22,7 +22,7 @@ type readState struct {
 	db        *DB
 	refcnt    int32
 	current   *version
-	memtables []flushable
+	memtables flushableList
 }
 
 // ref adds a reference to the readState.


### PR DESCRIPTION
Extract some common fields from the `flushable` interface into a
`flushableEntry` struct. This struct wraps around a `flushable` and
provides additional metadata that is common to all flushable
implementations, such as `log{Num,Size,SeqNum}`, the `flushed` channel,
and the `flushForced` bit. In addition to removing duplicate code, this
also made it more natural to access individual fields.