### PR TITLE
[WIP] internal/cache: move the bulk of allocations of the Go heap

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -705,7 +705,10 @@ func TestMemTableReservation(t *testing.T) {
 	// Add a block to the cache. Note that the memtable size is larger than the
 	// cache size, so opening the DB should cause this block to be evicted.
 	tmpID := opts.Cache.NewID()
-	opts.Cache.Set(tmpID, 0, 0, []byte("hello world"))
+	helloWorld := []byte("hello world")
+	value := opts.Cache.Alloc(len(helloWorld))
+	copy(value.Buf(), helloWorld)
+	opts.Cache.Set(tmpID, 0, 0, value)
 
 	d, err := Open("", opts)
 	if err != nil {
@@ -725,7 +728,7 @@ func TestMemTableReservation(t *testing.T) {
 	}
 	// Verify the memtable reservation has caused our test block to be evicted.
 	if h := opts.Cache.Get(tmpID, 0, 0); h.Get() != nil {
-		t.Fatalf("expected failure, but found success: %s", h.Get())
+		t.Fatalf("expected failure, but found success: %s", h.Get().Buf())
 	}
 
 	// Flush the memtable. The memtable reservation should be unchanged because a

--- a/internal/cache/alloc.go
+++ b/internal/cache/alloc.go
@@ -5,6 +5,7 @@
 package cache
 
 import (
+	"runtime"
 	"sync"
 	"time"
 
@@ -73,12 +74,20 @@ func newAllocCache() *allocCache {
 		bufs: make([][]byte, 0, allocCacheCountLimit),
 	}
 	c.rnd.Seed(uint64(time.Now().UnixNano()))
+	runtime.SetFinalizer(c, freeAllocCache)
 	return c
+}
+
+func freeAllocCache(obj interface{}) {
+	c := obj.(*allocCache)
+	for i := range c.bufs {
+		manualFree(c.bufs[i])
+	}
 }
 
 func (c *allocCache) alloc(n int) []byte {
 	if n < allocCacheMinSize || n >= allocCacheMaxSize {
-		return make([]byte, n)
+		return manualNew(n)
 	}
 
 	class := sizeToClass(n)
@@ -92,12 +101,13 @@ func (c *allocCache) alloc(n int) []byte {
 		}
 	}
 
-	return make([]byte, n, classToSize(class))
+	return manualNew(classToSize(class))[:n]
 }
 
 func (c *allocCache) free(b []byte) {
 	n := cap(b)
 	if n < allocCacheMinSize || n >= allocCacheMaxSize {
+		manualFree(b)
 		return
 	}
 	b = b[:n:n]
@@ -117,6 +127,7 @@ func (c *allocCache) free(b []byte) {
 		// are biased, but that is fine for the usage here.
 		j := (uint32(len(c.bufs)) * (uint32(c.rnd.Uint64()) & ((1 << 16) - 1))) >> 16
 		c.size -= cap(c.bufs[j])
+		manualFree(c.bufs[j])
 		c.bufs[i], c.bufs[j] = nil, c.bufs[i]
 		c.bufs = c.bufs[:i]
 	}

--- a/internal/cache/alloc_test.go
+++ b/internal/cache/alloc_test.go
@@ -12,7 +12,7 @@ import (
 func TestAllocCache(t *testing.T) {
 	c := newAllocCache()
 	for i := 0; i < 64; i++ {
-		c.free(make([]byte, 1025))
+		c.free(manualNew(1025))
 		if c.size == 0 {
 			t.Fatalf("expected cache size to be non-zero")
 		}
@@ -34,7 +34,7 @@ func TestAllocCache(t *testing.T) {
 func TestAllocCacheEvict(t *testing.T) {
 	c := newAllocCache()
 	for i := 0; i < allocCacheCountLimit; i++ {
-		c.free(make([]byte, 1024))
+		c.free(manualNew(1024))
 	}
 
 	bufs := make([][]byte, allocCacheCountLimit)
@@ -61,7 +61,7 @@ func BenchmarkAllocCache(b *testing.B) {
 	// Populate the cache with buffers if one size class.
 	c := newAllocCache()
 	for i := 0; i < allocCacheCountLimit; i++ {
-		c.free(make([]byte, 1024))
+		c.free(manualNew(1024))
 	}
 
 	// Benchmark allocating buffers of a different size class.

--- a/internal/cache/manual.go
+++ b/internal/cache/manual.go
@@ -1,0 +1,33 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package cache
+
+// #include <stdlib.h>
+import "C"
+import "unsafe"
+
+// TODO(peter): Rather than relying an C malloc/free, we could fork the Go
+// runtime page allocator and allocate large chunks of memory using mmap or
+// similar.
+
+// manualNew allocates a slice of size n.
+func manualNew(n int) []byte {
+	if n == 0 {
+		return make([]byte, 0)
+	}
+	ptr := C.malloc(C.size_t(n))
+	// Interpret the C pointer as a pointer to a Go array, then slice.
+	return (*[maxArrayLen]byte)(unsafe.Pointer(ptr))[:n:n]
+}
+
+// manualFree frees the specified slice.
+func manualFree(b []byte) {
+	if cap(b) != 0 {
+		if len(b) == 0 {
+			b = b[:cap(b)]
+		}
+		C.free(unsafe.Pointer(&b[0]))
+	}
+}

--- a/internal/cache/manual_32bit.go
+++ b/internal/cache/manual_32bit.go
@@ -1,0 +1,12 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build 386 amd64p32 arm armbe  mips mipsle mips64p32 mips64p32le ppc sparc
+
+package cache
+
+const (
+	// maxArrayLen is a safe maximum length for slices on this architecture.
+	maxArrayLen = 1<<31 - 1
+)

--- a/internal/cache/manual_64bit.go
+++ b/internal/cache/manual_64bit.go
@@ -1,0 +1,12 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build amd64 arm64 arm64be ppc64 ppc64le mips64 mips64le s390x sparc64
+
+package cache
+
+const (
+	// maxArrayLen is a safe maximum length for slices on this architecture.
+	maxArrayLen = 1<<50 - 1
+)

--- a/internal/cache/manual_nocgo.go
+++ b/internal/cache/manual_nocgo.go
@@ -1,0 +1,19 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build !cgo
+
+package cache
+
+// Provides versions of manualNew and manualFree when cgo is not available
+// (e.g. cross compilation).
+
+// manualNew allocates a slice of size n.
+func manualNew(n int) []byte {
+	return make([]byte, n)
+}
+
+// manualFree frees the specified slice.
+func manualFree(b []byte) {
+}

--- a/sstable/block_test.go
+++ b/sstable/block_test.go
@@ -155,7 +155,7 @@ func TestBlockIter2(t *testing.T) {
 					return ""
 
 				case "iter":
-					iter, err := newBlockIter(bytes.Compare, block)
+					iter, err := newBlockIterWithBuf(bytes.Compare, block)
 					if err != nil {
 						return err.Error()
 					}
@@ -233,7 +233,7 @@ func TestBlockIterKeyStability(t *testing.T) {
 	}
 	block := w.finish()
 
-	i, err := newBlockIter(bytes.Compare, block)
+	i, err := newBlockIterWithBuf(bytes.Compare, block)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -295,7 +295,7 @@ func TestBlockIterReverseDirections(t *testing.T) {
 
 	for targetPos := 0; targetPos < w.restartInterval; targetPos++ {
 		t.Run("", func(t *testing.T) {
-			i, err := newBlockIter(bytes.Compare, block)
+			i, err := newBlockIterWithBuf(bytes.Compare, block)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -337,7 +337,7 @@ func BenchmarkBlockIterSeekGE(b *testing.B) {
 					w.add(ikey, nil)
 				}
 
-				it, err := newBlockIter(bytes.Compare, w.finish())
+				it, err := newBlockIterWithBuf(bytes.Compare, w.finish())
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -379,7 +379,7 @@ func BenchmarkBlockIterSeekLT(b *testing.B) {
 					w.add(ikey, nil)
 				}
 
-				it, err := newBlockIter(bytes.Compare, w.finish())
+				it, err := newBlockIterWithBuf(bytes.Compare, w.finish())
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -425,7 +425,7 @@ func BenchmarkBlockIterNext(b *testing.B) {
 					w.add(ikey, nil)
 				}
 
-				it, err := newBlockIter(bytes.Compare, w.finish())
+				it, err := newBlockIterWithBuf(bytes.Compare, w.finish())
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -457,7 +457,7 @@ func BenchmarkBlockIterPrev(b *testing.B) {
 					w.add(ikey, nil)
 				}
 
-				it, err := newBlockIter(bytes.Compare, w.finish())
+				it, err := newBlockIterWithBuf(bytes.Compare, w.finish())
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -691,7 +691,7 @@ func TestMetaIndexEntriesSorted(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	i, err := newRawBlockIter(bytes.Compare, b.Get())
+	i, err := newRawBlockIter(bytes.Compare, b.Get().Buf())
 	b.Release()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Use C malloc/free for the bulk of cache allocations. This required
elevating `cache.Value` to a public class citizen of the cache package
as `cache.Value` is used to hold a reference for weak references. When a
weak reference is presence, a finalizer is set on the `cache.Value`
which manually frees the memory when run. Weak references are only used
for the index, filter, and range-del blocks, so the number of weak
references is O(num-tables). A finalizer is also set on `allocCache`
which is stored in a `sync.Pool` in order to provide precise management
of the cached buffers.