### PR TITLE
internal/arenaskl: remove extValueThreshold detritus

### DIFF
--- a/internal/arenaskl/arena.go
+++ b/internal/arenaskl/arena.go
@@ -43,7 +43,7 @@ var (
 )
 
 // NewArena allocates a new arena of the specified size and returns it.
-func NewArena(size, extValueThreshold uint32) *Arena {
+func NewArena(size uint32) *Arena {
 	// Don't store data at position 0 in order to reserve offset=0 as a kind
 	// of nil pointer.
 	return &Arena{

--- a/internal/arenaskl/arena_test.go
+++ b/internal/arenaskl/arena_test.go
@@ -27,7 +27,7 @@ import (
 // TestArenaSizeOverflow tests that large allocations do not cause Arena's
 // internal size accounting to overflow and produce incorrect results.
 func TestArenaSizeOverflow(t *testing.T) {
-	a := NewArena(math.MaxUint32, 0)
+	a := NewArena(math.MaxUint32)
 
 	// Allocating under the limit throws no error.
 	offset, _, err := a.alloc(math.MaxUint16, 0)

--- a/internal/arenaskl/skl_test.go
+++ b/internal/arenaskl/skl_test.go
@@ -144,7 +144,7 @@ func lengthRev(s *Skiplist) int {
 
 func TestEmpty(t *testing.T) {
 	key := makeKey("aaa")
-	l := NewSkiplist(NewArena(arenaSize, 0), bytes.Compare)
+	l := NewSkiplist(NewArena(arenaSize), bytes.Compare)
 	it := newIterAdapter(l.NewIter(nil, nil))
 
 	require.False(t, it.Valid())
@@ -160,7 +160,7 @@ func TestEmpty(t *testing.T) {
 }
 
 func TestFull(t *testing.T) {
-	l := NewSkiplist(NewArena(1000, 0), bytes.Compare)
+	l := NewSkiplist(NewArena(1000), bytes.Compare)
 
 	foundArenaFull := false
 	for i := 0; i < 100; i++ {
@@ -181,7 +181,7 @@ func TestFull(t *testing.T) {
 func TestBasic(t *testing.T) {
 	for _, inserter := range []bool{false, true} {
 		t.Run(fmt.Sprintf("inserter=%t", inserter), func(t *testing.T) {
-			l := NewSkiplist(NewArena(arenaSize, 0), bytes.Compare)
+			l := NewSkiplist(NewArena(arenaSize), bytes.Compare)
 			it := newIterAdapter(l.NewIter(nil, nil))
 
 			add := l.Add
@@ -252,7 +252,7 @@ func TestConcurrentBasic(t *testing.T) {
 	for _, inserter := range []bool{false, true} {
 		t.Run(fmt.Sprintf("inserter=%t", inserter), func(t *testing.T) {
 			// Set testing flag to make it easier to trigger unusual race conditions.
-			l := NewSkiplist(NewArena(arenaSize, 0), bytes.Compare)
+			l := NewSkiplist(NewArena(arenaSize), bytes.Compare)
 			l.testing = true
 
 			var wg sync.WaitGroup
@@ -298,7 +298,7 @@ func TestConcurrentOneKey(t *testing.T) {
 	for _, inserter := range []bool{false, true} {
 		t.Run(fmt.Sprintf("inserter=%t", inserter), func(t *testing.T) {
 			// Set testing flag to make it easier to trigger unusual race conditions.
-			l := NewSkiplist(NewArena(arenaSize, 0), bytes.Compare)
+			l := NewSkiplist(NewArena(arenaSize), bytes.Compare)
 			l.testing = true
 
 			var wg sync.WaitGroup
@@ -352,7 +352,7 @@ func TestConcurrentOneKey(t *testing.T) {
 func TestSkiplistAdd(t *testing.T) {
 	for _, inserter := range []bool{false, true} {
 		t.Run(fmt.Sprintf("inserter=%t", inserter), func(t *testing.T) {
-			l := NewSkiplist(NewArena(arenaSize, 0), bytes.Compare)
+			l := NewSkiplist(NewArena(arenaSize), bytes.Compare)
 			it := newIterAdapter(l.NewIter(nil, nil))
 
 			add := l.Add
@@ -367,7 +367,7 @@ func TestSkiplistAdd(t *testing.T) {
 			require.EqualValues(t, []byte{}, it.Key().UserKey)
 			require.EqualValues(t, []byte{}, it.Value())
 
-			l = NewSkiplist(NewArena(arenaSize, 0), bytes.Compare)
+			l = NewSkiplist(NewArena(arenaSize), bytes.Compare)
 			it = newIterAdapter(l.NewIter(nil, nil))
 
 			add = l.Add
@@ -429,7 +429,7 @@ func TestConcurrentAdd(t *testing.T) {
 			const n = 100
 
 			// Set testing flag to make it easier to trigger unusual race conditions.
-			l := NewSkiplist(NewArena(arenaSize, 0), bytes.Compare)
+			l := NewSkiplist(NewArena(arenaSize), bytes.Compare)
 			l.testing = true
 
 			start := make([]sync.WaitGroup, n)
@@ -476,7 +476,7 @@ func TestConcurrentAdd(t *testing.T) {
 // TestIteratorNext tests a basic iteration over all nodes from the beginning.
 func TestIteratorNext(t *testing.T) {
 	const n = 100
-	l := NewSkiplist(NewArena(arenaSize, 0), bytes.Compare)
+	l := NewSkiplist(NewArena(arenaSize), bytes.Compare)
 	it := newIterAdapter(l.NewIter(nil, nil))
 
 	require.False(t, it.Valid())
@@ -501,7 +501,7 @@ func TestIteratorNext(t *testing.T) {
 // TestIteratorPrev tests a basic iteration over all nodes from the end.
 func TestIteratorPrev(t *testing.T) {
 	const n = 100
-	l := NewSkiplist(NewArena(arenaSize, 0), bytes.Compare)
+	l := NewSkiplist(NewArena(arenaSize), bytes.Compare)
 	it := newIterAdapter(l.NewIter(nil, nil))
 
 	require.False(t, it.Valid())
@@ -526,7 +526,7 @@ func TestIteratorPrev(t *testing.T) {
 
 func TestIteratorSeekGE(t *testing.T) {
 	const n = 100
-	l := NewSkiplist(NewArena(arenaSize, 0), bytes.Compare)
+	l := NewSkiplist(NewArena(arenaSize), bytes.Compare)
 	it := newIterAdapter(l.NewIter(nil, nil))
 
 	require.False(t, it.Valid())
@@ -576,7 +576,7 @@ func TestIteratorSeekGE(t *testing.T) {
 
 func TestIteratorSeekLT(t *testing.T) {
 	const n = 100
-	l := NewSkiplist(NewArena(arenaSize, 0), bytes.Compare)
+	l := NewSkiplist(NewArena(arenaSize), bytes.Compare)
 	it := newIterAdapter(l.NewIter(nil, nil))
 
 	require.False(t, it.Valid())
@@ -627,7 +627,7 @@ func TestIteratorSeekLT(t *testing.T) {
 
 // TODO(peter): test First and Last.
 func TestIteratorBounds(t *testing.T) {
-	l := NewSkiplist(NewArena(arenaSize, 0), bytes.Compare)
+	l := NewSkiplist(NewArena(arenaSize), bytes.Compare)
 	for i := 1; i < 10; i++ {
 		err := l.Add(makeIntKey(i), makeValue(i))
 		if err != nil {
@@ -695,7 +695,7 @@ func TestIteratorBounds(t *testing.T) {
 }
 
 func TestBytesIterated(t *testing.T) {
-	l := NewSkiplist(NewArena(arenaSize, 0), bytes.Compare)
+	l := NewSkiplist(NewArena(arenaSize), bytes.Compare)
 	emptySize := l.arena.Size()
 	for i := 0; i < 200; i++ {
 		bytesIterated := l.bytesIterated(t)
@@ -737,7 +737,7 @@ func BenchmarkReadWrite(b *testing.B) {
 	for i := 0; i <= 10; i++ {
 		readFrac := float32(i) / 10.0
 		b.Run(fmt.Sprintf("frac_%d", i*10), func(b *testing.B) {
-			l := NewSkiplist(NewArena(uint32((b.N+2)*maxNodeSize), 0), bytes.Compare)
+			l := NewSkiplist(NewArena(uint32((b.N+2)*maxNodeSize)), bytes.Compare)
 			b.ResetTimer()
 			var count int
 			b.RunParallel(func(pb *testing.PB) {
@@ -762,7 +762,7 @@ func BenchmarkReadWrite(b *testing.B) {
 }
 
 func BenchmarkOrderedWrite(b *testing.B) {
-	l := NewSkiplist(NewArena(8<<20, 0), bytes.Compare)
+	l := NewSkiplist(NewArena(8<<20), bytes.Compare)
 	var ins Inserter
 	buf := make([]byte, 8)
 
@@ -771,7 +771,7 @@ func BenchmarkOrderedWrite(b *testing.B) {
 		binary.BigEndian.PutUint64(buf, uint64(i))
 		if err := ins.Add(l, base.InternalKey{UserKey: buf}, nil); err == ErrArenaFull {
 			b.StopTimer()
-			l = NewSkiplist(NewArena(uint32((b.N+2)*maxNodeSize), 0), bytes.Compare)
+			l = NewSkiplist(NewArena(uint32((b.N+2)*maxNodeSize)), bytes.Compare)
 			ins = Inserter{}
 			b.StartTimer()
 		}
@@ -779,7 +779,7 @@ func BenchmarkOrderedWrite(b *testing.B) {
 }
 
 func BenchmarkIterNext(b *testing.B) {
-	l := NewSkiplist(NewArena(64<<10, 0), bytes.Compare)
+	l := NewSkiplist(NewArena(64<<10), bytes.Compare)
 	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 	buf := make([]byte, 8)
 	for {
@@ -800,7 +800,7 @@ func BenchmarkIterNext(b *testing.B) {
 }
 
 func BenchmarkIterPrev(b *testing.B) {
-	l := NewSkiplist(NewArena(64<<10, 0), bytes.Compare)
+	l := NewSkiplist(NewArena(64<<10), bytes.Compare)
 	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 	buf := make([]byte, 8)
 	for {
@@ -852,7 +852,7 @@ func BenchmarkIterPrev(b *testing.B) {
 // }
 
 func TestInvalidInternalKeyDecoding(t *testing.T) {
-	a := NewArena(arenaSize, 0)
+	a := NewArena(arenaSize)
 
 	// We synthetically fill the arena with an invalid key
 	// that doesn't have an 8 byte trailer.

--- a/mem_table.go
+++ b/mem_table.go
@@ -116,7 +116,7 @@ func newMemTable(opts memTableOptions) *memTable {
 		m.releaseMemAccounting = opts.memAccounting(opts.size)
 	}
 
-	arena := arenaskl.NewArena(uint32(opts.size), 0)
+	arena := arenaskl.NewArena(uint32(opts.size))
 	m.skl.Reset(arena, m.cmp)
 	m.rangeDelSkl.Reset(arena, m.cmp)
 	m.emptySize = arena.Size()


### PR DESCRIPTION
Remove the unused `extValueThreshold` parameter to `NewArena`. This was
leftover detritus from a time when large values were stored outside of
the `Arena`. This proved to be too slow, and the facility was
removed. Large values (e.g. batches) are now handled by placing them
directly in the list of immutable memtables.