### PR TITLE
internal/cache: move the bulk of allocations off the Go heap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,11 @@ matrix:
     - name: "go1.13.x-linux-race"
       go: 1.13.x
       os: linux
-      script: make testrace
+      script: make testrace TAGS=
+    - name: "go1.13.x-linux-no-invariants"
+      go: 1.13.x
+      os: linux
+      script: make test TAGS=
     - name: "go1.13.x-darwin"
       go: 1.13.x
       os: osx
@@ -26,11 +30,6 @@ matrix:
       go: 1.13.x
       os: windows
       script: go test ./...
-    - name: "go1.13.x-freebsd"
-      go: 1.13.x
-      os: linux
-      # NB: "env: GOOS=freebsd" does not have the desired effect.
-      script: GOOS=freebsd go build -v ./...
 
 notifications:
   email:

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,0 +1,86 @@
+# Memory Management
+
+## Background
+
+Pebble has two significant sources of memory usage: MemTables and the
+Block Cache. MemTables buffer data that has been written to the WAL
+but not yet flushed to an SSTable. The Block Cache provides a cache of
+uncompressed SSTable data blocks.
+
+Originally, Pebble used regular Go memory allocation for the memory
+backing both MemTables and the Block Cache. This was problematic as it
+put significant pressure on the Go GC. The higher the bandwidth of
+memory allocations, the more work GC has to do to reclaim the
+memory. In order to lessen the pressure on the Go GC, an "allocation
+cache" was introduced to the Block Cache which allowed reusing the
+memory backing cached blocks in most circumstances. This produced a
+dramatic reduction in GC pressure and a measurable performance
+improvement in CockroachDB workloads.
+
+Unfortunately, the use of Go allocated memory still caused a
+problem. CockroachDB running on top of Pebble often resulted in an RSS
+(resident set size) 2x what it was when using RocksDB. The cause of
+this effect is due to the Go runtime's heuristic for triggering GC:
+
+> A collection is triggered when the ratio of freshly allocated data
+> to live data remaining after the previous collection reaches this
+> percentage.
+
+This percentage can be configured by the
+[`GOGC`](https://golang.org/pkg/runtime/) environment variable or by
+calling
+[`debug.SetGCPercent`](https://golang.org/pkg/runtime/debug/#SetGCPercent). The
+default value is `100`, which means that GC is triggered when the
+freshly allocated data is equal to the amount of live data at the end
+of the last collection period. This generally works well in practice,
+but the Pebble Block Cache is often configured to be 10s of gigabytes
+in size. Waiting for 10s of gigabytes of data to be allocated before
+triggering a GC results in very large Go heap sizes.
+
+## Manual Memory Management
+
+Attempting to adjust `GOGC` to account for the significant amount of
+memory used by the Block Cache is fraught. What value should be used?
+`10%`? `20%`? Should the setting be tuned dynamically? Rather than
+introducing a heuristic which may have cascading effects on the
+application using Pebble, we decided to move the Block Cache and
+MemTable memory out of the Go heap. This is done by using the C memory
+allocator, though it could also be done by providing a simple memory
+allocator in Go which uses `mmap` to allocate memory.
+
+In order to support manual memory management for the Block Cache and
+MemTables, Pebble needs to precisely track their lifetime. This was
+already being done for the MemTable in order to account for its memory
+usage in metrics. It was mostly being done for the Block Cache. Values
+stores in the Block Cache are reference counted and are returned to
+the "alloc cache" when their reference count falls
+to 0. Unfortunately, this tracking wasn't precise and there were
+numerous cases where the cache values were being leaked. This was
+acceptable in a world where the Go GC would clean up after us. It is
+unacceptable if the leak becomes permanent.
+
+## Leak Detection
+
+In order to find all of the cache value leaks, Pebble has a leak
+detection facility built on top of
+[`runtime.SetFinalizer`](https://golang.org/pkg/runtime/#SetFinalizer). A
+finalizer is a function associated with an object which is run when
+the object is no longer reachable. On the surface, this sounds perfect
+as a facility for performing all memory reclamation. Unfortunately,
+finalizers are generally frowned upon by the Go implementors, and come
+with very loose guarantees:
+
+> The finalizer is scheduled to run at some arbitrary time after the
+> program can no longer reach the object to which obj points. There is
+> no guarantee that finalizers will run before a program exits, so
+> typically they are useful only for releasing non-memory resources
+> associated with an object during a long-running program
+
+This language is somewhat frightening, but in practice finalizers are
+run at the end of every GC period. Pebble does not use finalizers for
+correctness, but instead uses them for its leak detection facility. In
+the block cache, a finalizer is associated with the Go allocated
+`cache.Value` object. When the finalizer is run, it checks that the
+buffer backing the `cache.Value` has been freed. This leak detection
+facility is enabled by the `"invariants"` build tag which is enabled
+by the Pebble unit tests.

--- a/internal/cache/alloc_test.go
+++ b/internal/cache/alloc_test.go
@@ -7,12 +7,14 @@ package cache
 import (
 	"testing"
 	"unsafe"
+
+	"github.com/cockroachdb/pebble/internal/manual"
 )
 
 func TestAllocCache(t *testing.T) {
 	c := newAllocCache()
 	for i := 0; i < 64; i++ {
-		c.free(make([]byte, 1025))
+		c.free(manual.New(1025))
 		if c.size == 0 {
 			t.Fatalf("expected cache size to be non-zero")
 		}
@@ -34,7 +36,7 @@ func TestAllocCache(t *testing.T) {
 func TestAllocCacheEvict(t *testing.T) {
 	c := newAllocCache()
 	for i := 0; i < allocCacheCountLimit; i++ {
-		c.free(make([]byte, 1024))
+		c.free(manual.New(1024))
 	}
 
 	bufs := make([][]byte, allocCacheCountLimit)
@@ -61,7 +63,7 @@ func BenchmarkAllocCache(b *testing.B) {
 	// Populate the cache with buffers if one size class.
 	c := newAllocCache()
 	for i := 0; i < allocCacheCountLimit; i++ {
-		c.free(make([]byte, 1024))
+		c.free(manual.New(1024))
 	}
 
 	// Benchmark allocating buffers of a different size class.

--- a/internal/cache/entry.go
+++ b/internal/cache/entry.go
@@ -1,0 +1,157 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package cache
+
+import (
+	"sync/atomic"
+	"unsafe"
+)
+
+type entryType int8
+
+const (
+	etTest entryType = iota
+	etCold
+	etHot
+)
+
+func (p entryType) String() string {
+	switch p {
+	case etTest:
+		return "test"
+	case etCold:
+		return "cold"
+	case etHot:
+		return "hot"
+	}
+	return "unknown"
+}
+
+// entry holds the metadata for a cache entry. If the value stored in an entry
+// is manually managed, the entry will also use manual memory management.
+//
+// Using manual memory management for entries is technically a volation of the
+// Cgo pointer rules:
+//
+//   https://golang.org/cmd/cgo/#hdr-Passing_pointers
+//
+// Specifically, Go pointers should not be stored in C allocated memory. The
+// reason for this rule is that the Go GC will not look at C allocated memory
+// to find pointers to Go objects. If the only reference to a Go object is
+// stored in C allocated memory, the object will be reclaimed. The blockLink,
+// fileLink, and shard fields of the entry struct may all point to Go objects,
+// thus the violation. What makes this "safe" is that the Cache guarantees that
+// there are other pointers to the entry and shard which will keep them
+// alive. In particular, every Go allocated entry in the cache is referenced by
+// the shard.entries map. And every shard is referenced by the Cache.shards
+// map.
+type entry struct {
+	key       key
+	val       unsafe.Pointer
+	blockLink struct {
+		next *entry
+		prev *entry
+	}
+	fileLink struct {
+		next *entry
+		prev *entry
+	}
+	size  int64
+	ptype entryType
+	// Is the memory for the entry manually managed? A manually managed entry can
+	// only store manually managed values (Value.manual() is true).
+	manual bool
+	// referenced is atomically set to indicate that this entry has been accessed
+	// since the last time one of the clock hands swept it.
+	referenced int32
+	shard      *shard
+}
+
+const entrySize = int(unsafe.Sizeof(entry{}))
+
+func newEntry(s *shard, key key, size int64, manual bool) *entry {
+	var e *entry
+	if manual {
+		e = entryAllocNew()
+	} else {
+		e = &entry{}
+	}
+	*e = entry{
+		key:    key,
+		size:   size,
+		ptype:  etCold,
+		manual: manual,
+		shard:  s,
+	}
+	e.blockLink.next = e
+	e.blockLink.prev = e
+	e.fileLink.next = e
+	e.fileLink.prev = e
+	return e
+}
+
+func (e *entry) free() {
+	if e.manual {
+		*e = entry{}
+		entryAllocFree(e)
+	}
+}
+
+func (e *entry) next() *entry {
+	if e == nil {
+		return nil
+	}
+	return e.blockLink.next
+}
+
+func (e *entry) prev() *entry {
+	if e == nil {
+		return nil
+	}
+	return e.blockLink.prev
+}
+
+func (e *entry) link(s *entry) {
+	s.blockLink.prev = e.blockLink.prev
+	s.blockLink.prev.blockLink.next = s
+	s.blockLink.next = e
+	s.blockLink.next.blockLink.prev = s
+}
+
+func (e *entry) unlink() *entry {
+	next := e.blockLink.next
+	e.blockLink.prev.blockLink.next = e.blockLink.next
+	e.blockLink.next.blockLink.prev = e.blockLink.prev
+	e.blockLink.prev = e
+	e.blockLink.next = e
+	return next
+}
+
+func (e *entry) linkFile(s *entry) {
+	s.fileLink.prev = e.fileLink.prev
+	s.fileLink.prev.fileLink.next = s
+	s.fileLink.next = e
+	s.fileLink.next.fileLink.prev = s
+}
+
+func (e *entry) unlinkFile() *entry {
+	next := e.fileLink.next
+	e.fileLink.prev.fileLink.next = e.fileLink.next
+	e.fileLink.next.fileLink.prev = e.fileLink.prev
+	e.fileLink.prev = e
+	e.fileLink.next = e
+	return next
+}
+
+func (e *entry) setValue(v *Value) {
+	if old := e.getValue(); old != nil {
+		old.release()
+	}
+	atomic.StorePointer(&e.val, unsafe.Pointer(v))
+}
+
+func (e *entry) getValue() *Value {
+	return (*Value)(atomic.LoadPointer(&e.val))
+}

--- a/internal/cache/entry.go
+++ b/internal/cache/entry.go
@@ -60,9 +60,13 @@ type entry struct {
 	}
 	size  int64
 	ptype entryType
-	// Is the memory for the entry manually managed? A manually managed entry can
-	// only store manually managed values (Value.manual() is true).
+	// Can the entry hold a manual Value? Only a manually managed entry can store
+	// manually managed values (Value.manual() is true).
 	manual bool
+	// Was the entry allocated using the Go allocator or the manual
+	// allocator. This can differ from the setting of the manual field due when
+	// the "invariants" build tag is set.
+	managed bool
 	// referenced is atomically set to indicate that this entry has been accessed
 	// since the last time one of the clock hands swept it.
 	referenced int32
@@ -79,11 +83,12 @@ func newEntry(s *shard, key key, size int64, manual bool) *entry {
 		e = &entry{}
 	}
 	*e = entry{
-		key:    key,
-		size:   size,
-		ptype:  etCold,
-		manual: manual,
-		shard:  s,
+		key:     key,
+		size:    size,
+		ptype:   etCold,
+		manual:  manual,
+		managed: e.managed,
+		shard:   s,
 	}
 	e.blockLink.next = e
 	e.blockLink.prev = e

--- a/internal/cache/entry_invariants.go
+++ b/internal/cache/entry_invariants.go
@@ -1,0 +1,18 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+//
+// +build invariants tracing
+
+package cache
+
+// When the "invariants" or "tracing" build tags are enabled, we need to
+// allocate entries using the Go allocator so entry.val properly maintains a
+// reference to the Value.
+
+func entryAllocNew() *entry {
+	return &entry{}
+}
+
+func entryAllocFree(e *entry) {
+}

--- a/internal/cache/entry_normal.go
+++ b/internal/cache/entry_normal.go
@@ -28,6 +28,7 @@ func entryAllocNew() *entry {
 	a := entryAllocPool.Get().(*entryAllocCache)
 	e := a.alloc()
 	entryAllocPool.Put(a)
+	e.managed = true
 	return e
 }
 

--- a/internal/cache/entry_normal.go
+++ b/internal/cache/entry_normal.go
@@ -1,0 +1,80 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+//
+// +build !invariants,!tracing
+
+package cache
+
+import (
+	"runtime"
+	"sync"
+	"unsafe"
+
+	"github.com/cockroachdb/pebble/internal/manual"
+)
+
+const (
+	entryAllocCacheLimit = 128
+)
+
+var entryAllocPool = sync.Pool{
+	New: func() interface{} {
+		return newEntryAllocCache()
+	},
+}
+
+func entryAllocNew() *entry {
+	a := entryAllocPool.Get().(*entryAllocCache)
+	e := a.alloc()
+	entryAllocPool.Put(a)
+	return e
+}
+
+func entryAllocFree(e *entry) {
+	a := entryAllocPool.Get().(*entryAllocCache)
+	a.free(e)
+	entryAllocPool.Put(a)
+}
+
+type entryAllocCache struct {
+	entries []*entry
+}
+
+func newEntryAllocCache() *entryAllocCache {
+	c := &entryAllocCache{}
+	runtime.SetFinalizer(c, freeEntryAllocCache)
+	return c
+}
+
+func freeEntryAllocCache(obj interface{}) {
+	c := obj.(*entryAllocCache)
+	for i, e := range c.entries {
+		c.dealloc(e)
+		c.entries[i] = nil
+	}
+}
+
+func (c *entryAllocCache) alloc() *entry {
+	n := len(c.entries)
+	if n == 0 {
+		b := manual.New(entrySize)
+		return (*entry)(unsafe.Pointer(&b[0]))
+	}
+	e := c.entries[n-1]
+	c.entries = c.entries[:n-1]
+	return e
+}
+
+func (c *entryAllocCache) dealloc(e *entry) {
+	buf := (*[manual.MaxArrayLen]byte)(unsafe.Pointer(e))[:entrySize:entrySize]
+	manual.Free(buf)
+}
+
+func (c *entryAllocCache) free(e *entry) {
+	if len(c.entries) == entryAllocCacheLimit {
+		c.dealloc(e)
+		return
+	}
+	c.entries = append(c.entries, e)
+}

--- a/internal/cache/robin_hood.go
+++ b/internal/cache/robin_hood.go
@@ -1,0 +1,318 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package cache
+
+import (
+	"fmt"
+	"math/bits"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"time"
+	"unsafe"
+
+	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/internal/manual"
+)
+
+var hashSeed = uint64(time.Now().UnixNano())
+
+// Fibonacci hash: https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/
+func robinHoodHash(k key, shift uint32) uint32 {
+	const m = 11400714819323198485
+	h := hashSeed
+	h ^= k.id * m
+	h ^= k.fileNum * m
+	h ^= k.offset * m
+	return uint32(h >> shift)
+}
+
+type robinHoodEntry struct {
+	key key
+	// Note that value may point to a Go allocated object, even though the memory
+	// for the entry itself is manually managed. This is technically a volation
+	// of the Cgo pointer rules:
+	//
+	//   https://golang.org/cmd/cgo/#hdr-Passing_pointers
+	//
+	// Specifically, Go pointers should not be stored in C allocated memory. The
+	// reason for this rule is that the Go GC will not look at C allocated memory
+	// to find pointers to Go objects. If the only reference to a Go object is
+	// stored in C allocated memory, the object will be reclaimed. What makes
+	// this "safe" is that the Cache guarantees that there are other pointers to
+	// the entry and shard which will keep them alive. In particular, every Go
+	// allocated entry in the cache is referenced by the shard.entries map. And
+	// every shard is referenced by the Cache.shards map.
+	value *entry
+	// The distance the entry is from its desired position.
+	dist uint32
+}
+
+type robinHoodEntries struct {
+	ptr unsafe.Pointer
+	len uint32
+}
+
+func newRobinHoodEntries(n uint32) robinHoodEntries {
+	size := uintptr(n) * unsafe.Sizeof(robinHoodEntry{})
+	return robinHoodEntries{
+		ptr: unsafe.Pointer(&(manual.New(int(size)))[0]),
+		len: n,
+	}
+}
+
+func (e robinHoodEntries) at(i uint32) *robinHoodEntry {
+	return (*robinHoodEntry)(unsafe.Pointer(uintptr(e.ptr) +
+		uintptr(i)*unsafe.Sizeof(robinHoodEntry{})))
+}
+
+func (e robinHoodEntries) free() {
+	size := uintptr(e.len) * unsafe.Sizeof(robinHoodEntry{})
+	buf := (*[manual.MaxArrayLen]byte)(e.ptr)[:size:size]
+	manual.Free(buf)
+}
+
+// robinHoodMap is an implementation of Robin Hood hashing. Robin Hood hashing
+// is an open-address hash table using linear probing. The twist is that the
+// linear probe distance is reduced by moving existing entries when inserting
+// and deleting. This is accomplished by keeping track of how far an entry is
+// from its "desired" slot (hash of key modulo number of slots). During
+// insertion, if the new entry being inserted is farther from its desired slot
+// than the target entry, we swap the target and new entry. This effectively
+// steals from the "rich" target entry and gives to the "poor" new entry (thus
+// the origin of the name).
+//
+// An extension over the base Robin Hood hashing idea comes from
+// https://probablydance.com/2017/02/26/i-wrote-the-fastest-hashtable/. A cap
+// is placed on the max distance an entry can be from its desired slot. When
+// this threshold is reached during insertion, the size of the table is doubled
+// and insertion is restarted. Additionally, the entries slice is given "max
+// dist" extra entries on the end. The very last entry in the entries slice is
+// never used and acts as a sentinel which terminates loops. The previous
+// maxDist-1 entries act as the extra entries. For example, if the size of the
+// table is 2, maxDist is computed as 4 and the actual size of the entry slice
+// is 6.
+//
+//   +---+---+---+---+---+---+
+//   | 0 | 1 | 2 | 3 | 4 | 5 |
+//   +---+---+---+---+---+---+
+//           ^
+//          size
+//
+// In this scenario, the target entry for a key will always be in the range
+// [0,1]. Valid entries may reside in the range [0,4] due to the linear probing
+// of up to maxDist entries. The entry at index 5 will never contain a value,
+// and instead acts as a sentinel (its distance is always 0). The max distance
+// threshold is set to log2(num-entries). This ensures that retrieval is O(log
+// N), though note that N is the number of total entries, not the count of
+// valid entries.
+//
+// Deletion is implemented via the backward shift delete mechanism instead of
+// tombstones. This preserves the performance of the table in the presence of
+// deletions. See
+// http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion
+// for details.
+type robinHoodMap struct {
+	entries robinHoodEntries
+	size    uint32
+	shift   uint32
+	count   uint32
+	maxDist uint32
+}
+
+func maxDistForSize(size uint32) uint32 {
+	desired := uint32(bits.Len32(size))
+	if desired < 4 {
+		desired = 4
+	}
+	return desired
+}
+
+func newRobinHoodMap(initialCapacity int) *robinHoodMap {
+	m := &robinHoodMap{}
+	m.init(initialCapacity)
+	runtime.SetFinalizer(m, clearRobinHoodMap)
+	return m
+}
+
+func clearRobinHoodMap(obj interface{}) {
+	m := obj.(*robinHoodMap)
+	m.free()
+}
+
+func (m *robinHoodMap) init(initialCapacity int) {
+	if initialCapacity < 1 {
+		initialCapacity = 1
+	}
+	targetSize := 1 << (uint(bits.Len(uint(2*initialCapacity-1))) - 1)
+	m.rehash(uint32(targetSize))
+}
+
+func (m *robinHoodMap) free() {
+	if m.entries.ptr != nil {
+		m.entries.free()
+		m.entries.ptr = nil
+	}
+}
+
+func (m *robinHoodMap) rehash(size uint32) {
+	oldEntries := m.entries
+
+	m.size = size
+	m.shift = uint32(64 - bits.Len32(m.size-1))
+	m.maxDist = maxDistForSize(size)
+	m.entries = newRobinHoodEntries(size + m.maxDist)
+	m.count = 0
+
+	for i := uint32(0); i < oldEntries.len; i++ {
+		e := oldEntries.at(i)
+		if e.value != nil {
+			m.Put(e.key, e.value)
+		}
+	}
+
+	if oldEntries.ptr != nil {
+		oldEntries.free()
+	}
+}
+
+// Find an entry containing the specified value. This is intended to be used
+// from debug and test code.
+func (m *robinHoodMap) findByValue(v *entry) *robinHoodEntry {
+	for i := uint32(0); i < m.entries.len; i++ {
+		e := m.entries.at(i)
+		if e.value == v {
+			return e
+		}
+	}
+	return nil
+}
+
+func (m *robinHoodMap) Count() int {
+	return int(m.count)
+}
+
+func (m *robinHoodMap) Put(k key, v *entry) {
+	maybeExists := true
+	n := robinHoodEntry{key: k, value: v, dist: 0}
+	for i := robinHoodHash(k, m.shift); ; i++ {
+		e := m.entries.at(i)
+		if maybeExists && k == e.key {
+			// Entry already exists: overwrite.
+			e.value = n.value
+			m.checkEntry(i)
+			return
+		}
+
+		if e.value == nil {
+			// Found an empty entry: insert here.
+			*e = n
+			m.count++
+			m.checkEntry(i)
+			return
+		}
+
+		if e.dist < n.dist {
+			// Swap the new entry with the current entry because the current is
+			// rich. We then continue to loop, looking for a new location for the
+			// current entry. Note that this is also the not-found condition for
+			// retrieval, which means that "k" is not present in the map. See Get().
+			n, *e = *e, n
+			m.checkEntry(i)
+			maybeExists = false
+		}
+
+		// The new entry gradually moves away from its ideal position.
+		n.dist++
+
+		// If we've reached the max distance threshold, grow the table and restart
+		// the insertion.
+		if n.dist == m.maxDist {
+			m.rehash(2 * m.size)
+			i = robinHoodHash(n.key, m.shift) - 1
+			n.dist = 0
+			maybeExists = false
+		}
+	}
+}
+
+func (m *robinHoodMap) Get(k key) *entry {
+	var dist uint32
+	for i := robinHoodHash(k, m.shift); ; i++ {
+		e := m.entries.at(i)
+		if k == e.key {
+			// Found.
+			return e.value
+		}
+		if e.dist < dist {
+			// Not found.
+			return nil
+		}
+		dist++
+	}
+}
+
+func (m *robinHoodMap) Delete(k key) {
+	var dist uint32
+	for i := robinHoodHash(k, m.shift); ; i++ {
+		e := m.entries.at(i)
+		if k == e.key {
+			m.checkEntry(i)
+			// We found the entry to delete. Shift the following entries backwards
+			// until the next empty value or entry with a zero distance. Note that
+			// empty values are guaranteed to have "dist == 0".
+			m.count--
+			for j := i + 1; ; j++ {
+				t := m.entries.at(j)
+				if t.dist == 0 {
+					*e = robinHoodEntry{}
+					return
+				}
+				e.key = t.key
+				e.value = t.value
+				e.dist = t.dist - 1
+				e = t
+				m.checkEntry(j)
+			}
+		}
+		if dist > e.dist {
+			// Not found.
+			return
+		}
+		dist++
+	}
+}
+
+func (m *robinHoodMap) checkEntry(i uint32) {
+	if invariants.Enabled {
+		e := m.entries.at(i)
+		if e.value != nil {
+			pos := robinHoodHash(e.key, m.shift)
+			if (uint32(i) - pos) != e.dist {
+				fmt.Fprintf(os.Stderr, "%d: invalid dist=%d, expected %d: %s\n%s",
+					i, e.dist, uint32(i)-pos, e.key, debug.Stack())
+				os.Exit(1)
+			}
+			if e.dist > m.maxDist {
+				fmt.Fprintf(os.Stderr, "%d: invalid dist=%d > maxDist=%d: %s\n%s",
+					i, e.dist, m.maxDist, e.key, debug.Stack())
+				os.Exit(1)
+			}
+		}
+	}
+}
+
+func (m *robinHoodMap) String() string {
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "count: %d\n", m.count)
+	for i := uint32(0); i < m.entries.len; i++ {
+		e := m.entries.at(i)
+		if e.value != nil {
+			fmt.Fprintf(&buf, "%d: [%s,%p,%d]\n", i, e.key, e.value, e.dist)
+		}
+	}
+	return buf.String()
+}

--- a/internal/cache/robin_hood_test.go
+++ b/internal/cache/robin_hood_test.go
@@ -1,0 +1,238 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package cache
+
+import (
+	"fmt"
+	"io/ioutil"
+	"runtime"
+	"testing"
+	"time"
+
+	"golang.org/x/exp/rand"
+)
+
+func TestRobinHoodMap(t *testing.T) {
+	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
+	rhMap := newRobinHoodMap(0)
+	goMap := make(map[key]*entry)
+
+	randomKey := func() key {
+		n := rng.Intn(len(goMap))
+		for k := range goMap {
+			if n == 0 {
+				return k
+			}
+			n--
+		}
+		return key{}
+	}
+
+	ops := 10000 + rng.Intn(10000)
+	for i := 0; i < ops; i++ {
+		var which float64
+		if len(goMap) > 0 {
+			which = rng.Float64()
+		}
+
+		switch {
+		case which < 0.4:
+			// 40% insert.
+			var k key
+			k.id = rng.Uint64()
+			k.fileNum = rng.Uint64()
+			k.offset = rng.Uint64()
+			e := &entry{}
+			goMap[k] = e
+			rhMap.Put(k, e)
+			if len(goMap) != int(rhMap.Count()) {
+				t.Fatalf("map sizes differ: %d != %d", len(goMap), rhMap.Count())
+			}
+
+		case which < 0.1:
+			// 10% overwrite.
+			k := randomKey()
+			e := &entry{}
+			goMap[k] = e
+			rhMap.Put(k, e)
+			if len(goMap) != int(rhMap.Count()) {
+				t.Fatalf("map sizes differ: %d != %d", len(goMap), rhMap.Count())
+			}
+
+		case which < 0.75:
+			// 25% delete.
+			k := randomKey()
+			delete(goMap, k)
+			rhMap.Delete(k)
+			if len(goMap) != int(rhMap.Count()) {
+				t.Fatalf("map sizes differ: %d != %d", len(goMap), rhMap.Count())
+			}
+
+		default:
+			// 25% lookup.
+			k := randomKey()
+			v := goMap[k]
+			u := rhMap.Get(k)
+			if v != u {
+				t.Fatalf("%s: expected %p, but found %p", k, v, u)
+			}
+		}
+	}
+
+	t.Logf("map size: %d", len(goMap))
+}
+
+const benchSize = 1 << 20
+
+func BenchmarkGoMapInsert(b *testing.B) {
+	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
+	keys := make([]key, benchSize)
+	for i := range keys {
+		keys[i].fileNum = uint64(rng.Intn(1 << 20))
+		keys[i].offset = uint64(rng.Intn(1 << 20))
+	}
+	b.ResetTimer()
+
+	var m map[key]*entry
+	for i, j := 0, 0; i < b.N; i, j = i+1, j+1 {
+		if m == nil || j == len(keys) {
+			b.StopTimer()
+			m = make(map[key]*entry, len(keys))
+			j = 0
+			b.StartTimer()
+		}
+		m[keys[j]] = nil
+	}
+}
+
+func BenchmarkRobinHoodInsert(b *testing.B) {
+	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
+	keys := make([]key, benchSize)
+	for i := range keys {
+		keys[i].fileNum = uint64(rng.Intn(1 << 20))
+		keys[i].offset = uint64(rng.Intn(1 << 20))
+	}
+	e := &entry{}
+	b.ResetTimer()
+
+	var m *robinHoodMap
+	for i, j := 0, 0; i < b.N; i, j = i+1, j+1 {
+		if m == nil || j == len(keys) {
+			b.StopTimer()
+			m = newRobinHoodMap(len(keys))
+			j = 0
+			b.StartTimer()
+		}
+		m.Put(keys[j], e)
+	}
+
+	runtime.KeepAlive(e)
+}
+
+func BenchmarkGoMapLookupHit(b *testing.B) {
+	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
+	keys := make([]key, benchSize)
+	m := make(map[key]*entry, len(keys))
+	e := &entry{}
+	for i := range keys {
+		keys[i].fileNum = uint64(rng.Intn(1 << 20))
+		keys[i].offset = uint64(rng.Intn(1 << 20))
+		m[keys[i]] = e
+	}
+	b.ResetTimer()
+
+	var p *entry
+	for i, j := 0, 0; i < b.N; i, j = i+1, j+1 {
+		if j == len(keys) {
+			j = 0
+		}
+		p = m[keys[j]]
+	}
+
+	if testing.Verbose() {
+		fmt.Fprintln(ioutil.Discard, p)
+	}
+}
+
+func BenchmarkRobinHoodLookupHit(b *testing.B) {
+	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
+	keys := make([]key, benchSize)
+	m := newRobinHoodMap(len(keys))
+	e := &entry{}
+	for i := range keys {
+		keys[i].fileNum = uint64(rng.Intn(1 << 20))
+		keys[i].offset = uint64(rng.Intn(1 << 20))
+		m.Put(keys[i], e)
+	}
+	b.ResetTimer()
+
+	var p *entry
+	for i, j := 0, 0; i < b.N; i, j = i+1, j+1 {
+		if j == len(keys) {
+			j = 0
+		}
+		p = m.Get(keys[j])
+	}
+
+	if testing.Verbose() {
+		fmt.Fprintln(ioutil.Discard, p)
+	}
+	runtime.KeepAlive(e)
+}
+
+func BenchmarkGoMapLookupMiss(b *testing.B) {
+	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
+	keys := make([]key, benchSize)
+	m := make(map[key]*entry, len(keys))
+	e := &entry{}
+	for i := range keys {
+		keys[i].id = 1
+		keys[i].fileNum = uint64(rng.Intn(1 << 20))
+		keys[i].offset = uint64(rng.Intn(1 << 20))
+		m[keys[i]] = e
+		keys[i].id = 2
+	}
+	b.ResetTimer()
+
+	var p *entry
+	for i, j := 0, 0; i < b.N; i, j = i+1, j+1 {
+		if j == len(keys) {
+			j = 0
+		}
+		p = m[keys[j]]
+	}
+
+	if testing.Verbose() {
+		fmt.Fprintln(ioutil.Discard, p)
+	}
+}
+
+func BenchmarkRobinHoodLookupMiss(b *testing.B) {
+	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
+	keys := make([]key, benchSize)
+	m := newRobinHoodMap(len(keys))
+	e := &entry{}
+	for i := range keys {
+		keys[i].id = 1
+		keys[i].fileNum = uint64(rng.Intn(1 << 20))
+		keys[i].offset = uint64(rng.Intn(1 << 20))
+		m.Put(keys[i], e)
+		keys[i].id = 2
+	}
+	b.ResetTimer()
+
+	var p *entry
+	for i, j := 0, 0; i < b.N; i, j = i+1, j+1 {
+		if j == len(keys) {
+			j = 0
+		}
+		p = m.Get(keys[j])
+	}
+
+	if testing.Verbose() {
+		fmt.Fprintln(ioutil.Discard, p)
+	}
+	runtime.KeepAlive(e)
+}

--- a/internal/cache/value.go
+++ b/internal/cache/value.go
@@ -1,0 +1,60 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package cache
+
+import "sync/atomic"
+
+func newAutoValue(b []byte) *Value {
+	if b == nil {
+		return nil
+	}
+	// A value starts with an invalid reference count. When the value is added to
+	// the cache, the reference count will be set to 2: one reference for the
+	// cache, and another for the returned Handle.
+	return &Value{buf: b, refs: -(1 << 30)}
+}
+
+// Buf returns the buffer associated with the value. The contents of the buffer
+// should not be changed once the value has been added to the cache. Instead, a
+// new Value should be created and added to the cache to replace the existing
+// value.
+func (v *Value) Buf() []byte {
+	if v == nil {
+		return nil
+	}
+	return v.buf
+}
+
+// Truncate the buffer to the specified length. The buffer length should not be
+// changed once the value has been added to the cache as there may be
+// concurrent readers of the Value. Instead, a new Value should be created and
+// added to the cache to replace the existing value.
+func (v *Value) Truncate(n int) {
+	v.buf = v.buf[:n]
+}
+
+func (v *Value) auto() bool {
+	return atomic.LoadInt32(&v.refs) < 0
+}
+
+func (v *Value) manual() bool {
+	return !v.auto()
+}
+
+func (v *Value) acquire() {
+	atomic.AddInt32(&v.refs, 1)
+	v.trace("acquire")
+}
+
+func (v *Value) release() {
+	n := atomic.AddInt32(&v.refs, -1)
+	v.trace("release")
+	if n == 0 {
+		allocFree(v.buf)
+		// Setting Value.buf to nil is needed for correctness of the leak checking
+		// that is performed when the "invariants" build tag is enabled.
+		v.buf = nil
+	}
+}

--- a/internal/cache/value.go
+++ b/internal/cache/value.go
@@ -52,9 +52,6 @@ func (v *Value) release() {
 	n := atomic.AddInt32(&v.refs, -1)
 	v.trace("release")
 	if n == 0 {
-		allocFree(v.buf)
-		// Setting Value.buf to nil is needed for correctness of the leak checking
-		// that is performed when the "invariants" build tag is enabled.
-		v.buf = nil
+		v.free()
 	}
 }

--- a/internal/cache/value_invariants.go
+++ b/internal/cache/value_invariants.go
@@ -1,0 +1,40 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build invariants tracing
+
+package cache
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"sync/atomic"
+)
+
+func checkValue(obj interface{}) {
+	v := obj.(*Value)
+	if v.buf != nil {
+		fmt.Fprintf(os.Stderr, "%p: cache value was not freed: refs=%d\n%s",
+			v.buf, atomic.LoadInt32(&v.refs), v.traces())
+		os.Exit(1)
+	}
+}
+
+// newManualValue creates a Value with a manually managed buffer of size n.
+//
+// This definition of newManualValue is used when either the "invariants" or
+// "tracing" build tags are specified. It hooks up a finalizer to the returned
+// Value that checks for memory leaks when the GC determines the Value is no
+// longer reachable.
+func newManualValue(n int) *Value {
+	if n == 0 {
+		return nil
+	}
+	b := allocNew(n)
+	v := &Value{buf: b, refs: 1}
+	v.trace("alloc")
+	runtime.SetFinalizer(v, checkValue)
+	return v
+}

--- a/internal/cache/value_invariants.go
+++ b/internal/cache/value_invariants.go
@@ -38,3 +38,11 @@ func newManualValue(n int) *Value {
 	runtime.SetFinalizer(v, checkValue)
 	return v
 }
+
+func (v *Value) free() {
+	allocFree(v.buf)
+	// Setting Value.buf to nil is needed for correctness of the leak checking
+	// that is performed when the "invariants" or "tracing" build tags are
+	// enabled.
+	v.buf = nil
+}

--- a/internal/cache/value_normal.go
+++ b/internal/cache/value_normal.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-// +build !tracing,!invariants
+// +build !invariants,!tracing
 
 package cache
 

--- a/internal/cache/value_normal.go
+++ b/internal/cache/value_normal.go
@@ -1,0 +1,32 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build !tracing,!invariants
+
+package cache
+
+// Value holds a reference counted immutable value.
+//
+// This is the definition of Value that is used in normal builds.
+type Value struct {
+	buf []byte
+	// The number of references on the value. When refs drops to 0, the buf
+	// associated with the value may be reused. This is a form of manual memory
+	// management. See Cache.Free.
+	//
+	// Auto values are distinguished by setting their reference count to
+	// -(1<<30).
+	refs int32
+}
+
+func newManualValue(n int) *Value {
+	if n == 0 {
+		return nil
+	}
+	b := allocNew(n)
+	return &Value{buf: b, refs: 1}
+}
+
+func (v *Value) trace(msg string) {
+}

--- a/internal/cache/value_normal.go
+++ b/internal/cache/value_normal.go
@@ -6,27 +6,33 @@
 
 package cache
 
-// Value holds a reference counted immutable value.
-//
-// This is the definition of Value that is used in normal builds.
-type Value struct {
-	buf []byte
-	// The number of references on the value. When refs drops to 0, the buf
-	// associated with the value may be reused. This is a form of manual memory
-	// management. See Cache.Free.
-	//
-	// Auto values are distinguished by setting their reference count to
-	// -(1<<30).
-	refs int32
-}
+import (
+	"unsafe"
+
+	"github.com/cockroachdb/pebble/internal/manual"
+)
+
+const valueSize = int(unsafe.Sizeof(Value{}))
 
 func newManualValue(n int) *Value {
 	if n == 0 {
 		return nil
 	}
-	b := allocNew(n)
-	return &Value{buf: b, refs: 1}
+	// When we're not performing leak detection, the lifetime of the returned
+	// Value is exactly the lifetime of the backing buffer and we can manually
+	// allocate both.
+	b := allocNew(valueSize + n)
+	v := (*Value)(unsafe.Pointer(&b[0]))
+	v.buf = b[valueSize:]
+	v.refs = 1
+	return v
 }
 
-func (v *Value) trace(msg string) {
+func (v *Value) free() {
+	// When we're not performing leak detection, the Value and buffer were
+	// allocated contiguously.
+	n := valueSize + cap(v.buf)
+	buf := (*[manual.MaxArrayLen]byte)(unsafe.Pointer(v))[:n:n]
+	v.buf = nil
+	allocFree(buf)
 }

--- a/internal/cache/value_notracing.go
+++ b/internal/cache/value_notracing.go
@@ -1,0 +1,30 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build invariants,!tracing
+
+package cache
+
+// Value holds a reference counted immutable value.
+//
+// This is the definition of Value that is used when the "invariants" build tag
+// is specified and the "tracing" build tag is not specified. If the "tracing"
+// build tag is specified, the Value definition comes from value_tracing.go.
+type Value struct {
+	buf []byte
+	// The number of references on the value. When refs drops to 0, the buf
+	// associated with the value may be reused. This is a form of manual memory
+	// management. See Cache.Free.
+	//
+	// Auto values are distinguished by setting their reference count to
+	// -(1<<30).
+	refs int32
+}
+
+func (v *Value) trace(msg string) {
+}
+
+func (v *Value) traces() string {
+	return ""
+}

--- a/internal/cache/value_notracing.go
+++ b/internal/cache/value_notracing.go
@@ -2,15 +2,16 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-// +build invariants,!tracing
+// +build !tracing
 
 package cache
 
 // Value holds a reference counted immutable value.
 //
-// This is the definition of Value that is used when the "invariants" build tag
-// is specified and the "tracing" build tag is not specified. If the "tracing"
-// build tag is specified, the Value definition comes from value_tracing.go.
+// This is the definition of Value that is used in normal builds and when the
+// "invariants" build tag is specified and the "tracing" build tag is not
+// specified. If the "tracing" build tag is specified, the Value definition
+// comes from value_tracing.go.
 type Value struct {
 	buf []byte
 	// The number of references on the value. When refs drops to 0, the buf
@@ -28,3 +29,6 @@ func (v *Value) trace(msg string) {
 func (v *Value) traces() string {
 	return ""
 }
+
+// Silence unused warning.
+var _ = (*Value).traces

--- a/internal/cache/value_tracing.go
+++ b/internal/cache/value_tracing.go
@@ -1,0 +1,49 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build tracing
+
+package cache
+
+import (
+	"fmt"
+	"runtime/debug"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// Value holds a reference counted immutable value.
+//
+// This is the definition of Value that is used when the "tracing" build tag is
+// specified.
+type Value struct {
+	buf []byte
+	// The number of references on the value. When refs drops to 0, the buf
+	// associated with the value may be reused. This is a form of manual memory
+	// management. See Cache.Free.
+	//
+	// Auto values are distinguished by setting their reference count to
+	// -(1<<30).
+	refs int32
+	// Traces recorded by Value.trace. Used for debugging.
+	tr struct {
+		sync.Mutex
+		msgs []string
+	}
+}
+
+func (v *Value) trace(msg string) {
+	s := fmt.Sprintf("%s: refs=%d\n%s", msg, atomic.LoadInt32(&v.refs), debug.Stack())
+	v.tr.Lock()
+	v.tr.msgs = append(v.tr.msgs, s)
+	v.tr.Unlock()
+}
+
+func (v *Value) traces() string {
+	v.tr.Lock()
+	s := strings.Join(v.tr.msgs, "\n")
+	v.tr.Unlock()
+	return s
+}

--- a/internal/manual/manual.go
+++ b/internal/manual/manual.go
@@ -33,7 +33,7 @@ func New(n int) []byte {
 	//   to Go.
 	ptr := C.calloc(C.size_t(n), 1)
 	// Interpret the C pointer as a pointer to a Go array, then slice.
-	return (*[maxArrayLen]byte)(unsafe.Pointer(ptr))[:n:n]
+	return (*[MaxArrayLen]byte)(unsafe.Pointer(ptr))[:n:n]
 }
 
 // Free frees the specified slice.

--- a/internal/manual/manual.go
+++ b/internal/manual/manual.go
@@ -1,0 +1,48 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package manual
+
+// #include <stdlib.h>
+import "C"
+import "unsafe"
+
+// TODO(peter): Rather than relying an C malloc/free, we could fork the Go
+// runtime page allocator and allocate large chunks of memory using mmap or
+// similar.
+
+// New allocates a slice of size n. The returned slice is from manually managed
+// memory and MUST be released by calling Free. Failure to do so will result in
+// a memory leak.
+func New(n int) []byte {
+	if n == 0 {
+		return make([]byte, 0)
+	}
+	// We need to be conscious of the Cgo pointer passing rules:
+	//
+	//   https://golang.org/cmd/cgo/#hdr-Passing_pointers
+	//
+	//   ...
+	//   Note: the current implementation has a bug. While Go code is permitted
+	//   to write nil or a C pointer (but not a Go pointer) to C memory, the
+	//   current implementation may sometimes cause a runtime error if the
+	//   contents of the C memory appear to be a Go pointer. Therefore, avoid
+	//   passing uninitialized C memory to Go code if the Go code is going to
+	//   store pointer values in it. Zero out the memory in C before passing it
+	//   to Go.
+	ptr := C.calloc(C.size_t(n), 1)
+	// Interpret the C pointer as a pointer to a Go array, then slice.
+	return (*[maxArrayLen]byte)(unsafe.Pointer(ptr))[:n:n]
+}
+
+// Free frees the specified slice.
+func Free(b []byte) {
+	if cap(b) != 0 {
+		if len(b) == 0 {
+			b = b[:cap(b)]
+		}
+		ptr := unsafe.Pointer(&b[0])
+		C.free(ptr)
+	}
+}

--- a/internal/manual/manual_32bit.go
+++ b/internal/manual/manual_32bit.go
@@ -7,6 +7,6 @@
 package manual
 
 const (
-	// maxArrayLen is a safe maximum length for slices on this architecture.
-	maxArrayLen = 1<<31 - 1
+	// MaxArrayLen is a safe maximum length for slices on this architecture.
+	MaxArrayLen = 1<<31 - 1
 )

--- a/internal/manual/manual_32bit.go
+++ b/internal/manual/manual_32bit.go
@@ -1,0 +1,12 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build 386 amd64p32 arm armbe  mips mipsle mips64p32 mips64p32le ppc sparc
+
+package manual
+
+const (
+	// maxArrayLen is a safe maximum length for slices on this architecture.
+	maxArrayLen = 1<<31 - 1
+)

--- a/internal/manual/manual_64bit.go
+++ b/internal/manual/manual_64bit.go
@@ -1,0 +1,12 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build amd64 arm64 arm64be ppc64 ppc64le mips64 mips64le s390x sparc64
+
+package manual
+
+const (
+	// maxArrayLen is a safe maximum length for slices on this architecture.
+	maxArrayLen = 1<<50 - 1
+)

--- a/internal/manual/manual_64bit.go
+++ b/internal/manual/manual_64bit.go
@@ -7,6 +7,6 @@
 package manual
 
 const (
-	// maxArrayLen is a safe maximum length for slices on this architecture.
-	maxArrayLen = 1<<50 - 1
+	// MaxArrayLen is a safe maximum length for slices on this architecture.
+	MaxArrayLen = 1<<50 - 1
 )

--- a/internal/manual/manual_nocgo.go
+++ b/internal/manual/manual_nocgo.go
@@ -1,0 +1,19 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build !cgo
+
+package manual
+
+// Provides versions of New and Free when cgo is not available (e.g. cross
+// compilation).
+
+// New allocates a slice of size n.
+func New(n int) []byte {
+	return make([]byte, n)
+}
+
+// Free frees the specified slice.
+func Free(b []byte) {
+}

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -267,6 +267,12 @@ func (i *blockIter) init(cmp Compare, block block, globalSeqNum uint64) error {
 	return nil
 }
 
+func (i *blockIter) initHandle(cmp Compare, block cache.Handle, globalSeqNum uint64) error {
+	i.cacheHandle.Release()
+	i.cacheHandle = block
+	return i.init(cmp, block.Get(), globalSeqNum)
+}
+
 func (i *blockIter) invalidate() {
 	i.clearCache()
 	i.offset = 0
@@ -282,11 +288,6 @@ func (i *blockIter) resetForReuse() blockIter {
 		cached:    i.cached[:0],
 		cachedBuf: i.cachedBuf[:0],
 	}
-}
-
-func (i *blockIter) setCacheHandle(h cache.Handle) {
-	i.cacheHandle.Release()
-	i.cacheHandle = h
 }
 
 func (i *blockIter) readEntry() {
@@ -832,6 +833,7 @@ func (i *blockIter) Error() error {
 // package.
 func (i *blockIter) Close() error {
 	i.cacheHandle.Release()
+	i.cacheHandle = cache.Handle{}
 	i.val = nil
 	return i.err
 }

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -177,6 +177,7 @@ func runIterCmd(td *datadriven.TestData, r *Reader) string {
 	if err := iter.Error(); err != nil {
 		return err.Error()
 	}
+	defer iter.Close()
 
 	var b bytes.Buffer
 	var prefix []byte

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -343,6 +343,7 @@ func TestBytesIteratedCompressed(t *testing.T) {
 				r := buildTestTable(t, numEntries, blockSize, indexBlockSize, SnappyCompression)
 				var bytesIterated, prevIterated uint64
 				citer := r.NewCompactionIter(&bytesIterated)
+
 				for key, _ := citer.First(); key != nil; key, _ = citer.Next() {
 					if bytesIterated < prevIterated {
 						t.Fatalf("bytesIterated moved backward: %d < %d", bytesIterated, prevIterated)
@@ -354,6 +355,13 @@ func TestBytesIteratedCompressed(t *testing.T) {
 				// There is some inaccuracy due to compression estimation.
 				if bytesIterated < expected*99/100 || bytesIterated > expected*101/100 {
 					t.Fatalf("bytesIterated: got %d, want %d", bytesIterated, expected)
+				}
+
+				if err := citer.Close(); err != nil {
+					t.Fatal(err)
+				}
+				if err := r.Close(); err != nil {
+					t.Fatal(err)
 				}
 			}
 		}
@@ -368,6 +376,7 @@ func TestBytesIteratedUncompressed(t *testing.T) {
 				r := buildTestTable(t, numEntries, blockSize, indexBlockSize, NoCompression)
 				var bytesIterated, prevIterated uint64
 				citer := r.NewCompactionIter(&bytesIterated)
+
 				for key, _ := citer.First(); key != nil; key, _ = citer.Next() {
 					if bytesIterated < prevIterated {
 						t.Fatalf("bytesIterated moved backward: %d < %d", bytesIterated, prevIterated)
@@ -379,6 +388,13 @@ func TestBytesIteratedUncompressed(t *testing.T) {
 				if bytesIterated != expected {
 					t.Fatalf("bytesIterated: got %d, want %d (blockSize=%d indexBlockSize=%d numEntries=%d)",
 						bytesIterated, expected, blockSize, indexBlockSize, numEntries)
+				}
+
+				if err := citer.Close(); err != nil {
+					t.Fatal(err)
+				}
+				if err := r.Close(); err != nil {
+					t.Fatal(err)
 				}
 			}
 		}
@@ -483,6 +499,8 @@ func BenchmarkTableIterSeekGE(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					it.SeekGE(keys[rng.Intn(len(keys))])
 				}
+
+				it.Close()
 			})
 	}
 }
@@ -501,6 +519,8 @@ func BenchmarkTableIterSeekLT(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					it.SeekLT(keys[rng.Intn(len(keys))])
 				}
+
+				it.Close()
 			})
 	}
 }
@@ -527,6 +547,8 @@ func BenchmarkTableIterNext(b *testing.B) {
 				if testing.Verbose() {
 					fmt.Fprint(ioutil.Discard, sum)
 				}
+
+				it.Close()
 			})
 	}
 }
@@ -553,6 +575,8 @@ func BenchmarkTableIterPrev(b *testing.B) {
 				if testing.Verbose() {
 					fmt.Fprint(ioutil.Discard, sum)
 				}
+
+				it.Close()
 			})
 	}
 }

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -673,6 +673,9 @@ func TestReaderGlobalSeqNum(t *testing.T) {
 			t.Fatalf("expected %d, but found %d", globalSeqNum, i.Key().SeqNum())
 		}
 	}
+	if err := i.Close(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestMetaIndexEntriesSorted(t *testing.T) {
@@ -687,12 +690,12 @@ func TestMetaIndexEntriesSorted(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b, err := r.readBlock(r.metaIndexBH, nil /* transform */)
+	b, err := r.readBlock(r.metaIndexBH, nil /* transform */, false /* weak */)
 	if err != nil {
 		t.Fatal(err)
 	}
 	i, err := newRawBlockIter(bytes.Compare, b.Get())
-	b.Release()
+	defer b.Release()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -99,7 +99,12 @@ func TestWriterClearCache(t *testing.T) {
 	opts := ReaderOptions{Cache: cache.New(64 << 20)}
 	writerOpts := WriterOptions{Cache: opts.Cache}
 	cacheOpts := &cacheOpts{cacheID: 1, fileNum: 1}
-	invalidData := []byte("invalid data")
+	invalidData := func() *cache.Value {
+		invalid := []byte("invalid data")
+		v := opts.Cache.AllocManual(len(invalid))
+		copy(v.Buf(), invalid)
+		return v
+	}
 
 	build := func(name string) {
 		f, err := mem.Create(name)
@@ -149,7 +154,7 @@ func TestWriterClearCache(t *testing.T) {
 
 	// Poison the cache for each of the blocks.
 	poison := func(bh BlockHandle) {
-		opts.Cache.Set(cacheOpts.cacheID, cacheOpts.fileNum, bh.Offset, invalidData)
+		opts.Cache.Set(cacheOpts.cacheID, cacheOpts.fileNum, bh.Offset, invalidData()).Release()
 	}
 	foreachBH(layout, poison)
 
@@ -161,7 +166,7 @@ func TestWriterClearCache(t *testing.T) {
 	check := func(bh BlockHandle) {
 		h := opts.Cache.Get(cacheOpts.cacheID, cacheOpts.fileNum, bh.Offset)
 		if h.Get() != nil {
-			t.Fatalf("%d: expected cache to be cleared, but found %q", bh.Offset, invalidData)
+			t.Fatalf("%d: expected cache to be cleared, but found %q", bh.Offset, h.Get())
 		}
 	}
 	foreachBH(layout, check)

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -169,7 +169,7 @@ compact         1   1.6 K          (size == estimated-debt)
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.5 K    5.9%  (score == hit-rate)
- tcache         1   688 B    0.0%  (score == hit-rate)
+ tcache         1   664 B    0.0%  (score == hit-rate)
  titers         0
  filter         -       -    0.0%  (score == utility)
 

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -33,7 +33,7 @@ compact         0   826 B          (size == estimated-debt)
 zmemtbl         1   256 K
    ztbl         0     0 B
  bcache         3   732 B    0.0%  (score == hit-rate)
- tcache         1   688 B    0.0%  (score == hit-rate)
+ tcache         1   664 B    0.0%  (score == hit-rate)
  titers         1
  filter         -       -    0.0%  (score == utility)
 
@@ -130,7 +130,7 @@ compact         1     0 B          (size == estimated-debt)
 zmemtbl         1   256 K
    ztbl         1   826 B
  bcache         4   753 B   27.3%  (score == hit-rate)
- tcache         1   688 B   60.0%  (score == hit-rate)
+ tcache         1   664 B   60.0%  (score == hit-rate)
  titers         1
  filter         -       -    0.0%  (score == utility)
 


### PR DESCRIPTION
Use C malloc/free for the bulk of cache allocations. This required
elevating `cache.Value` to a public citizen of the cache package. A
distinction is made between manually managed memory and automatically
managed memory. Weak handles can only be made from values stored in
automatically managed memory. Note that weak handles are only used for
the index, filter, and range-del blocks, so the number of weak handles
is O(num-tables).

A finalizer is set on `*allocCache` and `*Cache` in order to ensure that
any outstanding manually allocated memory is released when these objects
are collected.

When `invariants` are enabled, finalizers are also set on `*Value` and
sstable iterators to ensure that we're not leaking manually managed
memory.

Fixes #11 