### PR TITLE
db: fix WAL replay in read-only mode

### DIFF
--- a/db.go
+++ b/db.go
@@ -1352,6 +1352,9 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 		var logSeqNum uint64
 		if b != nil {
 			logSeqNum = b.SeqNum()
+			if b.flushable != nil {
+				logSeqNum += uint64(b.Count())
+			}
 		} else {
 			logSeqNum = atomic.LoadUint64(&d.mu.versions.logSeqNum)
 		}


### PR DESCRIPTION
The addition of `memTable.logSeqNum` broke WAL replay in read-only mode
because we were initializing `memTable.logSeqNum` too early and setting
it to the visible sequence number rather than the first sequence number
in the WAL being replayed. This would result in an error during `Open`
that looked like:

```
   pebble: batch seqnum 2 is less than memtable creation seqnum 3
```