### PR TITLE
internal/cache: explicitly manage Cache lifetime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,11 @@ matrix:
       go: 1.13.x
       os: windows
       script: go test ./...
+    - name: "go1.13.x-freebsd"
+      go: 1.13.x
+      os: linux
+      # NB: "env: GOOS=freebsd" does not have the desired effect.
+      script: GOOS=freebsd go build -v ./...
 
 notifications:
   email:

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -12,10 +12,17 @@ import (
 
 	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCheckpoint(t *testing.T) {
 	dbs := make(map[string]*DB)
+	defer func() {
+		for _, db := range dbs {
+			require.NoError(t, db.Close())
+		}
+	}()
+
 	var buf syncedBuffer
 	mem := vfs.NewMem()
 	opts := &Options{

--- a/cleaner_test.go
+++ b/cleaner_test.go
@@ -12,10 +12,17 @@ import (
 
 	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
 )
 
 func TestArchiveCleaner(t *testing.T) {
 	dbs := make(map[string]*DB)
+	defer func() {
+		for _, db := range dbs {
+			require.NoError(t, db.Close())
+		}
+	}()
+
 	var buf syncedBuffer
 	mem := vfs.NewMem()
 	opts := &Options{

--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -47,8 +47,10 @@ type pebbleDB struct {
 }
 
 func newPebbleDB(dir string) DB {
+	cache := pebble.NewCache(cacheSize)
+	defer cache.Unref()
 	opts := &pebble.Options{
-		Cache:                       pebble.NewCache(cacheSize),
+		Cache:                       cache,
 		Comparer:                    mvccComparer,
 		DisableWAL:                  disableWAL,
 		MemTableSize:                64 << 20,

--- a/db.go
+++ b/db.go
@@ -808,6 +808,9 @@ func (d *DB) Close() error {
 		panic(ErrClosed)
 	}
 	atomic.StoreInt32(&d.closed, 1)
+
+	defer d.opts.Cache.Unref()
+
 	for d.mu.compact.compactingCount > 0 || d.mu.compact.flushing {
 		d.mu.compact.cond.Wait()
 	}

--- a/flush_test.go
+++ b/flush_test.go
@@ -12,15 +12,17 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
 )
 
 func TestManualFlush(t *testing.T) {
 	d, err := Open("", &Options{
 		FS: vfs.NewMem(),
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, d.Close())
+	}()
 
 	datadriven.RunTest(t, "testdata/manual_flush", func(td *datadriven.TestData) string {
 		switch td.Cmd {
@@ -69,6 +71,9 @@ func TestManualFlush(t *testing.T) {
 			return s
 
 		case "reset":
+			if err := d.Close(); err != nil {
+				return err.Error()
+			}
 			d, err = Open("", &Options{
 				FS: vfs.NewMem(),
 			})

--- a/internal/cache/clockpro_test.go
+++ b/internal/cache/clockpro_test.go
@@ -22,6 +22,8 @@ func TestCache(t *testing.T) {
 	}
 
 	cache := newShards(200, 1)
+	defer cache.Unref()
+
 	scanner := bufio.NewScanner(f)
 	line := 1
 
@@ -67,6 +69,8 @@ func testAutoValue(cache *Cache, s string, repeat int) *Value {
 
 func TestWeakHandle(t *testing.T) {
 	cache := newShards(5, 1)
+	defer cache.Unref()
+
 	cache.Set(1, 1, 0, testAutoValue(cache, "a", 5)).Release()
 	h := cache.Set(1, 0, 0, testAutoValue(cache, "b", 5))
 	if v := h.Get(); string(v) != "bbbbb" {
@@ -85,6 +89,8 @@ func TestWeakHandle(t *testing.T) {
 
 func TestCacheDelete(t *testing.T) {
 	cache := newShards(100, 1)
+	defer cache.Unref()
+
 	cache.Set(1, 0, 0, testManualValue(cache, "a", 5)).Release()
 	cache.Set(1, 1, 0, testManualValue(cache, "a", 5)).Release()
 	cache.Set(1, 2, 0, testManualValue(cache, "a", 5)).Release()
@@ -114,6 +120,8 @@ func TestCacheDelete(t *testing.T) {
 
 func TestEvictFile(t *testing.T) {
 	cache := newShards(100, 1)
+	defer cache.Unref()
+
 	cache.Set(1, 0, 0, testManualValue(cache, "a", 5)).Release()
 	cache.Set(1, 1, 0, testManualValue(cache, "a", 5)).Release()
 	cache.Set(1, 2, 0, testManualValue(cache, "a", 5)).Release()
@@ -140,12 +148,16 @@ func TestEvictAll(t *testing.T) {
 	// Verify that it is okay to evict all of the data from a cache. Previously
 	// this would trigger a nil-pointer dereference.
 	cache := newShards(100, 1)
+	defer cache.Unref()
+
 	cache.Set(1, 0, 0, testManualValue(cache, "a", 101)).Release()
 	cache.Set(1, 1, 0, testManualValue(cache, "a", 101)).Release()
 }
 
 func TestMultipleDBs(t *testing.T) {
 	cache := newShards(100, 1)
+	defer cache.Unref()
+
 	cache.Set(1, 0, 0, testManualValue(cache, "a", 5)).Release()
 	cache.Set(2, 0, 0, testManualValue(cache, "b", 5)).Release()
 	if expected, size := int64(10), cache.Size(); expected != size {
@@ -162,16 +174,22 @@ func TestMultipleDBs(t *testing.T) {
 	h = cache.Get(2, 0, 0)
 	if v := h.Get(); string(v) != "bbbbb" {
 		t.Fatalf("expected bbbbb, but found %s", v)
+	} else {
+		h.Release()
 	}
 }
 
 func TestZeroSize(t *testing.T) {
 	cache := newShards(0, 1)
+	defer cache.Unref()
+
 	cache.Set(1, 0, 0, testManualValue(cache, "a", 5)).Release()
 }
 
 func TestReserve(t *testing.T) {
 	cache := newShards(4, 2)
+	defer cache.Unref()
+
 	cache.Set(1, 0, 0, testManualValue(cache, "a", 1)).Release()
 	cache.Set(2, 0, 0, testManualValue(cache, "a", 1)).Release()
 	require.EqualValues(t, 2, cache.Size())
@@ -191,6 +209,8 @@ func TestReserve(t *testing.T) {
 
 func TestReserveDoubleRelease(t *testing.T) {
 	cache := newShards(100, 1)
+	defer cache.Unref()
+
 	r := cache.Reserve(10)
 	r()
 

--- a/internal/cache/robin_hood.go
+++ b/internal/cache/robin_hood.go
@@ -134,13 +134,14 @@ func maxDistForSize(size uint32) uint32 {
 func newRobinHoodMap(initialCapacity int) *robinHoodMap {
 	m := &robinHoodMap{}
 	m.init(initialCapacity)
-	runtime.SetFinalizer(m, clearRobinHoodMap)
+	runtime.SetFinalizer(m, func(obj interface{}) {
+		m := obj.(*robinHoodMap)
+		if m.entries.ptr != nil {
+			fmt.Fprintf(os.Stderr, "%p: robin-hood map not freed\n", m)
+			os.Exit(1)
+		}
+	})
 	return m
-}
-
-func clearRobinHoodMap(obj interface{}) {
-	m := obj.(*robinHoodMap)
-	m.free()
 }
 
 func (m *robinHoodMap) init(initialCapacity int) {

--- a/internal/cache/robin_hood_test.go
+++ b/internal/cache/robin_hood_test.go
@@ -17,6 +17,8 @@ import (
 func TestRobinHoodMap(t *testing.T) {
 	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 	rhMap := newRobinHoodMap(0)
+	defer rhMap.free()
+
 	goMap := make(map[key]*entry)
 
 	randomKey := func() key {

--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -187,6 +187,10 @@ func TestMeta(t *testing.T) {
 	// written to <run-dir>/OPTIONS and a child process is created to actually
 	// execute the test.
 	runOptions := func(t *testing.T, opts *testOptions) {
+		if opts.opts.Cache != nil {
+			defer opts.opts.Cache.Unref()
+		}
+
 		runDir := filepath.Join(metaDir, path.Base(t.Name()))
 		if err := os.MkdirAll(runDir, 0755); err != nil {
 			t.Fatal(err)

--- a/internal/metamorphic/test.go
+++ b/internal/metamorphic/test.go
@@ -51,6 +51,8 @@ func (t *test) init(h *history, dir string, testOpts *testOptions) error {
 	t.opts.EventListener = pebble.MakeLoggingEventListener(t.opts.Logger)
 	t.opts.DebugCheck = true
 
+	defer t.opts.Cache.Unref()
+
 	// If an error occurs and we were using an in-memory FS, attempt to clone to
 	// on-disk in order to allow post-mortem debugging. Note that always using
 	// the on-disk FS isn't desirable because there is a large performance
@@ -150,6 +152,7 @@ func (t *test) restartDB() error {
 	if !t.testOpts.strictFS {
 		return nil
 	}
+	t.opts.Cache.Ref()
 	fs := t.opts.FS.(*vfs.MemFS)
 	fs.SetIgnoreSyncs(true)
 	if err := t.db.Close(); err != nil {
@@ -159,6 +162,7 @@ func (t *test) restartDB() error {
 	fs.SetIgnoreSyncs(false)
 	var err error
 	t.db, err = pebble.Open(t.dir, t.opts)
+	t.opts.Cache.Unref()
 	return err
 }
 

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -45,8 +45,15 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 	memFS := vfs.NewMem()
 	cmp := DefaultComparer.Compare
 	var levels [][]fileMetadata
+
 	// Indexed by fileNum
 	var readers []*sstable.Reader
+	defer func() {
+		for _, r := range readers {
+			r.Close()
+		}
+	}()
+
 	var fileNum uint64
 	newIters :=
 		func(meta *fileMetadata, opts *IterOptions, bytesIterated *uint64) (internalIterator, internalIterator, error) {

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -154,6 +154,9 @@ func (lt *levelIterTest) newIters(
 
 func (lt *levelIterTest) runClear(d *datadriven.TestData) string {
 	lt.mem = vfs.NewMem()
+	for _, r := range lt.readers {
+		r.Close()
+	}
 	lt.readers = nil
 	lt.files = nil
 	return ""
@@ -234,6 +237,8 @@ func (lt *levelIterTest) runBuild(d *datadriven.TestData) string {
 
 func TestLevelIterBoundaries(t *testing.T) {
 	lt := newLevelIterTest()
+	defer lt.runClear(nil)
+
 	datadriven.RunTest(t, "testdata/level_iter_boundaries", func(d *datadriven.TestData) string {
 		switch d.Cmd {
 		case "clear":
@@ -301,6 +306,8 @@ func (i *levelIterTestIter) SeekLT(key []byte) (*InternalKey, []byte) {
 
 func TestLevelIterSeek(t *testing.T) {
 	lt := newLevelIterTest()
+	defer lt.runClear(nil)
+
 	datadriven.RunTest(t, "testdata/level_iter_seek", func(d *datadriven.TestData) string {
 		switch d.Cmd {
 		case "clear":
@@ -362,6 +369,8 @@ func buildLevelIterTables(
 	}
 
 	opts := sstable.ReaderOptions{Cache: NewCache(128 << 20)}
+	defer opts.Cache.Unref()
+
 	readers := make([]*sstable.Reader, len(files))
 	for i := range files {
 		f, err := mem.Open(fmt.Sprintf("bench%d", i))

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMetricsFormat(t *testing.T) {
@@ -88,10 +89,17 @@ func TestMetrics(t *testing.T) {
 	d, err := Open("", &Options{
 		FS: vfs.NewMem(),
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, d.Close())
+	}()
+
 	iters := make(map[string]*Iterator)
+	defer func() {
+		for _, i := range iters {
+			require.NoError(t, i.Close())
+		}
+	}()
 
 	datadriven.RunTest(t, "testdata/metrics", func(td *datadriven.TestData) string {
 		switch td.Cmd {

--- a/open_test.go
+++ b/open_test.go
@@ -173,6 +173,7 @@ func testOpenCloseOpenClose(t *testing.T, fs vfs.FS, root string) {
 							startFromEmpty, length, err)
 						continue
 					}
+					got = append([]byte(nil), got...)
 				}
 				err = d1.Close()
 				if err != nil {

--- a/options_test.go
+++ b/options_test.go
@@ -190,6 +190,9 @@ func TestOptionsParse(t *testing.T) {
 			if str != parsedStr {
 				t.Fatalf("expected\n%s\nbut found\n%s", str, parsedStr)
 			}
+			if parsedOptions.Cache != nil {
+				parsedOptions.Cache.Unref()
+			}
 		})
 	}
 }

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -107,9 +107,6 @@ type ReaderOptions struct {
 }
 
 func (o ReaderOptions) ensureDefaults() ReaderOptions {
-	if o.Cache == nil {
-		o.Cache = cache.New(0)
-	}
 	if o.Comparer == nil {
 		o.Comparer = base.DefaultComparer
 	}

--- a/sstable/properties_test.go
+++ b/sstable/properties_test.go
@@ -79,11 +79,11 @@ func TestPropertiesLoad(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer f.Close()
 		r, err := NewReader(f, ReaderOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer r.Close()
 
 		if diff := pretty.Diff(expected, r.Properties); diff != nil {
 			t.Fatalf("%s", strings.Join(diff, "\n"))

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -1028,6 +1028,8 @@ type Reader struct {
 
 // Close implements DB.Close, as documented in the pebble package.
 func (r *Reader) Close() error {
+	r.opts.Cache.Unref()
+
 	if r.err != nil {
 		if r.file != nil {
 			r.file.Close()
@@ -1569,6 +1571,12 @@ func NewReader(f vfs.File, o ReaderOptions, extraOpts ...ReaderOption) (*Reader,
 		file: f,
 		opts: o,
 	}
+	if r.opts.Cache == nil {
+		r.opts.Cache = cache.New(0)
+	} else {
+		r.opts.Cache.Ref()
+	}
+
 	if f == nil {
 		r.err = errors.New("pebble/table: nil file")
 		return nil, r.Close()

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -228,6 +228,11 @@ func runTestReader(t *testing.T, o WriterOptions, dir string, r *Reader) {
 				return fmt.Sprintf("unknown command: %s", d.Cmd)
 			}
 		})
+
+		if r != nil {
+			r.Close()
+			r = nil
+		}
 	})
 }
 
@@ -435,8 +440,10 @@ func buildTestTable(
 	if err != nil {
 		t.Fatal(err)
 	}
+	c := cache.New(128 << 20)
+	defer c.Unref()
 	r, err := NewReader(f1, ReaderOptions{
-		Cache: cache.New(128 << 20),
+		Cache: c,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -476,8 +483,10 @@ func buildBenchmarkTable(b *testing.B, blockSize, restartInterval int) (*Reader,
 	if err != nil {
 		b.Fatal(err)
 	}
+	c := cache.New(128 << 20)
+	defer c.Unref()
 	r, err := NewReader(f1, ReaderOptions{
-		Cache: cache.New(128 << 20),
+		Cache: c,
 	})
 	if err != nil {
 		b.Fatal(err)

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -492,9 +492,7 @@ func TestBloomFilterFalsePositiveRate(t *testing.T) {
 			c.Name(): c,
 		},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	const n = 10000
 	// key is a buffer that will be re-used for n Get calls, each with a
@@ -528,6 +526,8 @@ func TestBloomFilterFalsePositiveRate(t *testing.T) {
 	if got := float64(100*c.falsePositives) / n; got < 0.2 || 5 < got {
 		t.Errorf("false positive rate: got %v%%, want approximately 1%%", got)
 	}
+
+	require.NoError(t, r.Close())
 }
 
 type countingFilterPolicy struct {
@@ -659,10 +659,7 @@ func TestReaderGlobalSeqNum(t *testing.T) {
 		t.Fatal(err)
 	}
 	r, err := NewReader(f, ReaderOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer r.Close()
+	require.NoError(t, err)
 
 	const globalSeqNum = 42
 	r.Properties.GlobalSeqNum = globalSeqNum
@@ -673,9 +670,8 @@ func TestReaderGlobalSeqNum(t *testing.T) {
 			t.Fatalf("expected %d, but found %d", globalSeqNum, i.Key().SeqNum())
 		}
 	}
-	if err := i.Close(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, i.Close())
+	require.NoError(t, r.Close())
 }
 
 func TestMetaIndexEntriesSorted(t *testing.T) {
@@ -686,9 +682,7 @@ func TestMetaIndexEntriesSorted(t *testing.T) {
 	}
 
 	r, err := NewReader(f, ReaderOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	b, err := r.readBlock(r.metaIndexBH, nil /* transform */, false /* weak */)
 	if err != nil {
@@ -708,9 +702,8 @@ func TestMetaIndexEntriesSorted(t *testing.T) {
 		t.Fatalf("metaindex block out of order: %v", keys)
 	}
 
-	if err := i.Close(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, i.Close())
+	require.NoError(t, r.Close())
 }
 
 func TestFooterRoundTrip(t *testing.T) {

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -162,8 +162,12 @@ func newTableCache() (*tableCache, *tableCacheTestFS, error) {
 	fs.closeCounts = map[string]int{}
 	fs.mu.Unlock()
 
-	opts := &Options{}
+	opts := &Options{
+		Cache: NewCache(8 << 20), // 8 MB
+	}
 	opts.EnsureDefaults()
+	defer opts.Cache.Unref()
+
 	c := &tableCache{}
 	c.init(opts.Cache.NewID(), "", fs, opts, tableCacheTestCacheSize, tableCacheTestHitBufferSize)
 	return c, fs, nil

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -48,4 +48,5 @@ func TestVersionSetCheckpoint(t *testing.T) {
 	}
 	checkValue("a", "b")
 	checkValue("c", "d")
+	require.NoError(t, d.Close())
 }


### PR DESCRIPTION
Add `Cache.{Ref,Unref}()` to explicitly manage the lifetime of a
`Cache`.