### PR TITLE
sstable: avoid use of reflect.Value.IsZero

### DIFF
--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -145,7 +145,8 @@ func (p *Properties) String() string {
 		}
 
 		f := v.Field(i)
-		if f.IsZero() {
+		// TODO(peter): Use f.IsZero() when we can rely on go1.13.
+		if zero := reflect.Zero(f.Type()); zero.Interface() == f.Interface() {
 			// Skip printing of zero values which were not loaded from disk.
 			if _, ok := p.ValueOffsets[tag]; !ok {
 				continue


### PR DESCRIPTION
`reflect.Value.IsZero` arrived with go1.13, but CockroachDB still
verifies that the source is buildable using go1.12 (even though it
creates binaries using go1.13). Remove this go1.13-ism temporarily.