### PR TITLE
db: fix DB.Get to return non-cache memory

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -315,10 +315,11 @@ func TestBatchGet(t *testing.T) {
 					if len(td.CmdArgs) != 1 {
 						return fmt.Sprintf("%s expects 1 argument", td.Cmd)
 					}
-					v, err := b.Get([]byte(td.CmdArgs[0].String()))
+					v, closer, err := b.Get([]byte(td.CmdArgs[0].String()))
 					if err != nil {
 						return err.Error()
 					}
+					defer closer.Close()
 					return string(v)
 
 				default:

--- a/cache.go
+++ b/cache.go
@@ -10,7 +10,14 @@ import "github.com/cockroachdb/pebble/internal/cache"
 type Cache = cache.Cache
 
 // NewCache creates a new cache of the specified size. Memory for the cache is
-// allocated on demand, not during initialization.
+// allocated on demand, not during initialization. The cache is created with a
+// reference count of 1. Each DB it is associated with adds a reference, so the
+// creator of the cache should usually release their reference after the DB is
+// created.
+//
+//   c := pebble.NewCache(...)
+//   defer c.Unref()
+//   d, err := pebble.Open(pebble.Options{Cache: c})
 func NewCache(size int64) *cache.Cache {
 	return cache.New(size)
 }

--- a/data_test.go
+++ b/data_test.go
@@ -46,11 +46,12 @@ func runGetCmd(td *datadriven.TestData, d *DB) string {
 
 	var buf bytes.Buffer
 	for _, data := range strings.Split(td.Input, "\n") {
-		v, err := snap.Get([]byte(data))
+		v, closer, err := snap.Get([]byte(data))
 		if err != nil {
 			fmt.Fprintf(&buf, "%s: %s\n", data, err)
 		} else {
 			fmt.Fprintf(&buf, "%s:%s\n", data, v)
+			closer.Close()
 		}
 	}
 	return buf.String()

--- a/internal/cache/clockpro.go
+++ b/internal/cache/clockpro.go
@@ -611,8 +611,8 @@ type Cache struct {
 // created.
 //
 //   c := cache.New(...)
+//   defer c.Unref()
 //   d, err := pebble.Open(pebble.Options{Cache: c})
-//   c.Unref()
 func New(size int64) *Cache {
 	return newShards(size, 2*runtime.NumCPU())
 }

--- a/internal/cache/value_invariants.go
+++ b/internal/cache/value_invariants.go
@@ -38,6 +38,11 @@ func newManualValue(n int) *Value {
 }
 
 func (v *Value) free() {
+	// When "invariants" are enabled set the value contents to 0xff in order to
+	// cache use-after-free bugs.
+	// for i := range v.buf {
+	// 	v.buf[i] = 0xff
+	// }
 	allocFree(v.buf)
 	// Setting Value.buf to nil is needed for correctness of the leak checking
 	// that is performed when the "invariants" or "tracing" build tags are

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -306,8 +306,11 @@ type getOp struct {
 
 func (o *getOp) run(t *test, h *history) {
 	r := t.getReader(o.readerID)
-	val, err := r.Get(o.key)
+	val, closer, err := r.Get(o.key)
 	h.Recordf("%s // [%q] %v", o, val, err)
+	if closer != nil {
+		closer.Close()
+	}
 }
 
 func (o *getOp) String() string {

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -193,8 +193,10 @@ func TestRangeDelCompactionTruncation(t *testing.T) {
 `)
 
 	// "b" is still visible at this point as it should be.
-	if _, err := d.Get([]byte("b")); err != nil {
+	if _, closer, err := d.Get([]byte("b")); err != nil {
 		t.Fatalf("expected success, but found %v", err)
+	} else {
+		closer.Close()
 	}
 
 	keys := func() string {
@@ -232,8 +234,10 @@ func TestRangeDelCompactionTruncation(t *testing.T) {
 
 	// The L1 table still contains a tombstone from [a,d) which will improperly
 	// delete the newer version of "b" in L2.
-	if _, err := d.Get([]byte("b")); err != nil {
+	if _, closer, err := d.Get([]byte("b")); err != nil {
 		t.Errorf("expected success, but found %v", err)
+	} else {
+		closer.Close()
 	}
 
 	if expected, actual := `b c`, keys(); expected != actual {
@@ -383,7 +387,7 @@ func TestRangeDelCompactionTruncation3(t *testing.T) {
 	snap3 := d.NewSnapshot()
 	defer snap3.Close()
 
-	if _, err := d.Get([]byte("b")); err != ErrNotFound {
+	if _, _, err := d.Get([]byte("b")); err != ErrNotFound {
 		t.Fatalf("expected not found, but found %v", err)
 	}
 
@@ -423,7 +427,7 @@ func TestRangeDelCompactionTruncation3(t *testing.T) {
   000025:[c#3,SET-d#72057594037927935,RANGEDEL]
 `)
 
-	if _, err := d.Get([]byte("b")); err != ErrNotFound {
+	if _, _, err := d.Get([]byte("b")); err != ErrNotFound {
 		t.Fatalf("expected not found, but found %v", err)
 	}
 
@@ -438,7 +442,7 @@ func TestRangeDelCompactionTruncation3(t *testing.T) {
   000027:[b#0,RANGEDEL-c#72057594037927935,RANGEDEL]
 `)
 
-	if v, err := d.Get([]byte("b")); err != ErrNotFound {
+	if v, _, err := d.Get([]byte("b")); err != ErrNotFound {
 		t.Fatalf("expected not found, but found %v [%s]", err, v)
 	}
 }

--- a/snapshot.go
+++ b/snapshot.go
@@ -4,6 +4,8 @@
 
 package pebble
 
+import "io"
+
 // Snapshot provides a read-only point-in-time view of the DB state.
 type Snapshot struct {
 	// The db the snapshot was created from.
@@ -19,12 +21,14 @@ type Snapshot struct {
 
 var _ Reader = (*Snapshot)(nil)
 
-// Get gets the value for the given key. It returns ErrNotFound if the DB does
-// not contain the key.
+// Get gets the value for the given key. It returns ErrNotFound if the Snapshot
+// does not contain the key.
 //
 // The caller should not modify the contents of the returned slice, but it is
-// safe to modify the contents of the argument after Get returns.
-func (s *Snapshot) Get(key []byte) ([]byte, error) {
+// safe to modify the contents of the argument after Get returns. The returned
+// slice will remain valid until the returned Closer is closed. On success, the
+// caller MUST call closer.Close() or a memory leak will occur.
+func (s *Snapshot) Get(key []byte) ([]byte, io.Closer, error) {
 	if s.db == nil {
 		panic(ErrClosed)
 	}

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -202,7 +202,7 @@ func TestSnapshotClosed(t *testing.T) {
 		t.Fatal(err)
 	}
 	require.EqualValues(t, ErrClosed, catch(func() { _ = snap.Close() }))
-	require.EqualValues(t, ErrClosed, catch(func() { _, _ = snap.Get(nil) }))
+	require.EqualValues(t, ErrClosed, catch(func() { _, _, _ = snap.Get(nil) }))
 	require.EqualValues(t, ErrClosed, catch(func() { snap.NewIter(nil) }))
 
 	require.NoError(t, d.Close())

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -42,9 +42,10 @@ func TestVersionSetCheckpoint(t *testing.T) {
 	d, err = Open("", opts)
 	require.NoError(t, err)
 	checkValue := func(k string, expected string) {
-		v, err := d.Get([]byte(k))
+		v, closer, err := d.Get([]byte(k))
 		require.NoError(t, err)
 		require.Equal(t, expected, string(v))
+		closer.Close()
 	}
 	checkValue("a", "b")
 	checkValue("c", "d")


### PR DESCRIPTION
Fix `DB.Get` to make a copy of the value rather than returning a pointer
that potentially points into cache memory. The cached memory can get
reclaimed/reused as soon as the `getIter` is closed.

Fixes #537