### PR TITLE
internal/manifest: change type of Version.Files

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -45,7 +45,7 @@ func maxGrandparentOverlapBytes(opts *Options, level int) uint64 {
 }
 
 // totalSize returns the total size of all the files in f.
-func totalSize(f []fileMetadata) (size uint64) {
+func totalSize(f []*fileMetadata) (size uint64) {
 	for _, x := range f {
 		size += x.Size
 	}
@@ -98,7 +98,7 @@ type compaction struct {
 	// is applied.
 	atomicBytesIterated *uint64
 	// inputs are the tables to be compacted.
-	inputs [2][]fileMetadata
+	inputs [2][]*fileMetadata
 	// The boundaries of the input data.
 	smallest InternalKey
 	largest  InternalKey
@@ -111,7 +111,7 @@ type compaction struct {
 	// grandparents are the tables in level+2 that overlap with the files being
 	// compacted. Used to determine output table boundaries. Do not assume that the actual files
 	// in the grandparent when this compaction finishes will be the same.
-	grandparents []fileMetadata
+	grandparents []*fileMetadata
 
 	// List of disjoint inuse key ranges the compaction overlaps with in
 	// grandparent and lower levels. See setupInuseKeyRanges() for the
@@ -304,7 +304,7 @@ func (c *compaction) setupInputs() {
 // tombstones will be truncated at "b" (the largest key in its atomic
 // compaction unit). In the scenario here, that could result in b#1 becoming
 // visible when it should be deleted.
-func (c *compaction) expandInputs(level int, inputs []fileMetadata) []fileMetadata {
+func (c *compaction) expandInputs(level int, inputs []*fileMetadata) []*fileMetadata {
 	if level == 0 {
 		// We already called version.Overlaps for L0 and that call guarantees that
 		// we get a "clean cut".
@@ -329,8 +329,8 @@ func (c *compaction) expandInputs(level int, inputs []fileMetadata) []fileMetada
 	end := start + len(inputs)
 
 	for ; start > 0; start-- {
-		cur := &files[start]
-		prev := &files[start-1]
+		cur := files[start]
+		prev := files[start-1]
 		if c.cmp(prev.Largest.UserKey, cur.Smallest.UserKey) < 0 {
 			break
 		}
@@ -347,8 +347,8 @@ func (c *compaction) expandInputs(level int, inputs []fileMetadata) []fileMetada
 	}
 
 	for ; end < len(files); end++ {
-		cur := &files[end-1]
-		next := &files[end]
+		cur := files[end-1]
+		next := files[end]
 		if c.cmp(cur.Largest.UserKey, next.Smallest.UserKey) < 0 {
 			break
 		}
@@ -405,7 +405,7 @@ func (c *compaction) setupInuseKeyRanges() {
 	for ; level < numLevels; level++ {
 		overlaps := c.version.Overlaps(level, c.cmp, c.smallest.UserKey, c.largest.UserKey)
 		for i := range overlaps {
-			m := &overlaps[i]
+			m := overlaps[i]
 			input = append(input, userKeyRange{m.Smallest.UserKey, m.Largest.UserKey})
 		}
 	}
@@ -551,7 +551,7 @@ func (c *compaction) atomicUnitBounds(f *fileMetadata) (lower, upper []byte) {
 	for i := range c.inputs {
 		files := c.inputs[i]
 		for j := range files {
-			if f == &files[j] {
+			if f == files[j] {
 				// Note that if this file is in a multi-file atomic compaction unit, this file
 				// may not be the first file in that unit. An example in Pebble would be a
 				// preceding file with Largest c#12,1 and this file with Smallest c#9,1 and
@@ -564,8 +564,8 @@ func (c *compaction) atomicUnitBounds(f *fileMetadata) (lower, upper []byte) {
 				// compatibility.
 				lowerBound := f.Smallest.UserKey
 				for k := j; k > 0; k-- {
-					cur := &files[k]
-					prev := &files[k-1]
+					cur := files[k]
+					prev := files[k-1]
 					if c.cmp(prev.Largest.UserKey, cur.Smallest.UserKey) < 0 {
 						break
 					}
@@ -582,8 +582,8 @@ func (c *compaction) atomicUnitBounds(f *fileMetadata) (lower, upper []byte) {
 
 				upperBound := f.Largest.UserKey
 				for k := j + 1; k < len(files); k++ {
-					cur := &files[k-1]
-					next := &files[k]
+					cur := files[k-1]
+					next := files[k]
 					if c.cmp(cur.Largest.UserKey, next.Smallest.UserKey) < 0 {
 						break
 					}
@@ -696,7 +696,7 @@ func (c *compaction) newInputIter(newIters tableNewIters) (_ internalIterator, r
 		iters = append(iters, newLevelIter(iterOpts, c.cmp, newRangeDelIter, c.inputs[0], &c.bytesIterated))
 	} else {
 		for i := range c.inputs[0] {
-			f := &c.inputs[0][i]
+			f := c.inputs[0][i]
 			iter, rangeDelIter, err := newIters(f, nil /* iter options */, &c.bytesIterated)
 			if err != nil {
 				return nil, fmt.Errorf("pebble: could not open table %d: %v", f.FileNum, err)
@@ -1042,7 +1042,7 @@ func (d *DB) compact1(c *compaction, errChannel chan error) (err error) {
 	info.Output.Level = c.outputLevel
 	for i := range c.inputs {
 		for j := range c.inputs[i] {
-			m := &c.inputs[i][j]
+			m := c.inputs[i][j]
 			info.Input.Tables[i] = append(info.Input.Tables[i], m.TableInfo())
 		}
 	}
@@ -1115,7 +1115,7 @@ func (d *DB) runCompaction(
 	// the move could create a parent file that will require a very expensive
 	// merge later on.
 	if c.trivialMove() {
-		meta := &c.inputs[0][0]
+		meta := c.inputs[0][0]
 		c.metrics = map[int]*LevelMetrics{
 			c.outputLevel: &LevelMetrics{
 				BytesMoved:  meta.Size,
@@ -1127,7 +1127,7 @@ func (d *DB) runCompaction(
 				deletedFileEntry{Level: c.startLevel, FileNum: meta.FileNum}: true,
 			},
 			NewFiles: []newFileEntry{
-				{Level: c.outputLevel, Meta: *meta},
+				{Level: c.outputLevel, Meta: meta},
 			},
 		}
 		return ve, nil, nil
@@ -1218,7 +1218,7 @@ func (d *DB) runCompaction(
 
 		ve.NewFiles = append(ve.NewFiles, newFileEntry{
 			Level: c.outputLevel,
-			Meta: fileMetadata{
+			Meta: &fileMetadata{
 				FileNum: fileNum,
 			},
 		})
@@ -1256,7 +1256,7 @@ func (d *DB) runCompaction(
 			return err
 		}
 		tw = nil
-		meta := &ve.NewFiles[len(ve.NewFiles)-1].Meta
+		meta := ve.NewFiles[len(ve.NewFiles)-1].Meta
 		meta.Size = writerMeta.Size
 		meta.SmallestSeqNum = writerMeta.SmallestSeqNum
 		meta.LargestSeqNum = writerMeta.LargestSeqNum
@@ -1272,7 +1272,7 @@ func (d *DB) runCompaction(
 		if n := len(ve.NewFiles); n > 1 {
 			// This is not the first output file. Bound the smallest range key by the
 			// previous tables largest key.
-			prevMeta := &ve.NewFiles[n-2].Meta
+			prevMeta := ve.NewFiles[n-2].Meta
 			if writerMeta.SmallestRange.UserKey != nil {
 				c := d.cmp(writerMeta.SmallestRange.UserKey, prevMeta.Largest.UserKey)
 				if c < 0 {

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -312,7 +312,7 @@ func (p *compactionPickerByScore) initCompactionQueue(v *version, opts *Options)
 		smallestSeqNum := uint64(math.MaxUint64)
 		files := v.Files[p.compactionQueue[i].level]
 		for j := range files {
-			f := &files[j]
+			f := files[j]
 			if smallestSeqNum > f.SmallestSeqNum {
 				smallestSeqNum = f.SmallestSeqNum
 				p.compactionQueue[i].file = j
@@ -328,7 +328,7 @@ func (p *compactionPickerByScore) initCompactionQueue(v *version, opts *Options)
 		}
 		files := v.Files[level]
 		for i := range files {
-			f := &files[i]
+			f := files[i]
 			if f.MarkedForCompaction {
 				p.compactionQueue = append(p.compactionQueue, pickedCompactionInfo{
 					score:       p.scores[level],

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -48,12 +48,12 @@ func loadVersion(d *datadriven.TestData) (*version, *Options, string) {
 			}
 			if level == 0 {
 				for i := uint64(0); i < size; i++ {
-					vers.Files[level] = append(vers.Files[level], fileMetadata{
+					vers.Files[level] = append(vers.Files[level], &fileMetadata{
 						Size: 1,
 					})
 				}
 			} else {
-				vers.Files[level] = append(vers.Files[level], fileMetadata{
+				vers.Files[level] = append(vers.Files[level], &fileMetadata{
 					Size: size,
 				})
 			}

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -74,7 +74,7 @@ func (p *compactionPickerForTesting) pickManual(
 }
 
 func TestPickCompaction(t *testing.T) {
-	fileNums := func(f []fileMetadata) string {
+	fileNums := func(f []*fileMetadata) string {
 		ss := make([]string, 0, len(f))
 		for _, meta := range f {
 			ss = append(ss, strconv.Itoa(int(meta.FileNum)))
@@ -93,8 +93,8 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "no compaction",
 			version: version{
-				Files: [numLevels][]fileMetadata{
-					0: []fileMetadata{
+				Files: [numLevels][]*fileMetadata{
+					0: []*fileMetadata{
 						{
 							FileNum:  100,
 							Size:     1,
@@ -110,8 +110,8 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "1 L0 file",
 			version: version{
-				Files: [numLevels][]fileMetadata{
-					0: []fileMetadata{
+				Files: [numLevels][]*fileMetadata{
+					0: []*fileMetadata{
 						{
 							FileNum:  100,
 							Size:     1,
@@ -132,8 +132,8 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "2 L0 files (0 overlaps)",
 			version: version{
-				Files: [numLevels][]fileMetadata{
-					0: []fileMetadata{
+				Files: [numLevels][]*fileMetadata{
+					0: []*fileMetadata{
 						{
 							FileNum:  100,
 							Size:     1,
@@ -160,8 +160,8 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "2 L0 files, with ikey overlap",
 			version: version{
-				Files: [numLevels][]fileMetadata{
-					0: []fileMetadata{
+				Files: [numLevels][]*fileMetadata{
+					0: []*fileMetadata{
 						{
 							FileNum:  100,
 							Size:     1,
@@ -188,8 +188,8 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "2 L0 files, with ukey overlap",
 			version: version{
-				Files: [numLevels][]fileMetadata{
-					0: []fileMetadata{
+				Files: [numLevels][]*fileMetadata{
+					0: []*fileMetadata{
 						{
 							FileNum:  100,
 							Size:     1,
@@ -216,8 +216,8 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "1 L0 file, 2 L1 files (0 overlaps)",
 			version: version{
-				Files: [numLevels][]fileMetadata{
-					0: []fileMetadata{
+				Files: [numLevels][]*fileMetadata{
+					0: []*fileMetadata{
 						{
 							FileNum:  100,
 							Size:     1,
@@ -225,7 +225,7 @@ func TestPickCompaction(t *testing.T) {
 							Largest:  base.ParseInternalKey("i.SET.102"),
 						},
 					},
-					1: []fileMetadata{
+					1: []*fileMetadata{
 						{
 							FileNum:  200,
 							Size:     1,
@@ -252,8 +252,8 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "1 L0 file, 2 L1 files (1 overlap), 4 L2 files (3 overlaps)",
 			version: version{
-				Files: [numLevels][]fileMetadata{
-					0: []fileMetadata{
+				Files: [numLevels][]*fileMetadata{
+					0: []*fileMetadata{
 						{
 							FileNum:  100,
 							Size:     1,
@@ -261,7 +261,7 @@ func TestPickCompaction(t *testing.T) {
 							Largest:  base.ParseInternalKey("t.SET.102"),
 						},
 					},
-					1: []fileMetadata{
+					1: []*fileMetadata{
 						{
 							FileNum:  200,
 							Size:     1,
@@ -275,7 +275,7 @@ func TestPickCompaction(t *testing.T) {
 							Largest:  base.ParseInternalKey("j.SET.212"),
 						},
 					},
-					2: []fileMetadata{
+					2: []*fileMetadata{
 						{
 							FileNum:  300,
 							Size:     1,
@@ -314,8 +314,8 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "4 L1 files, 2 L2 files, can grow",
 			version: version{
-				Files: [numLevels][]fileMetadata{
-					1: []fileMetadata{
+				Files: [numLevels][]*fileMetadata{
+					1: []*fileMetadata{
 						{
 							FileNum:  200,
 							Size:     1,
@@ -341,7 +341,7 @@ func TestPickCompaction(t *testing.T) {
 							Largest:  base.ParseInternalKey("l2.SET.232"),
 						},
 					},
-					2: []fileMetadata{
+					2: []*fileMetadata{
 						{
 							FileNum:  300,
 							Size:     1,
@@ -368,8 +368,8 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "4 L1 files, 2 L2 files, can't grow (range)",
 			version: version{
-				Files: [numLevels][]fileMetadata{
-					1: []fileMetadata{
+				Files: [numLevels][]*fileMetadata{
+					1: []*fileMetadata{
 						{
 							FileNum:  200,
 							Size:     1,
@@ -395,7 +395,7 @@ func TestPickCompaction(t *testing.T) {
 							Largest:  base.ParseInternalKey("l2.SET.232"),
 						},
 					},
-					2: []fileMetadata{
+					2: []*fileMetadata{
 						{
 							FileNum:  300,
 							Size:     1,
@@ -422,8 +422,8 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "4 L1 files, 2 L2 files, can't grow (size)",
 			version: version{
-				Files: [numLevels][]fileMetadata{
-					1: []fileMetadata{
+				Files: [numLevels][]*fileMetadata{
+					1: []*fileMetadata{
 						{
 							FileNum:  200,
 							Size:     expandedCompactionByteSizeLimit(opts, 1) - 1,
@@ -449,7 +449,7 @@ func TestPickCompaction(t *testing.T) {
 							Largest:  base.ParseInternalKey("l2.SET.232"),
 						},
 					},
-					2: []fileMetadata{
+					2: []*fileMetadata{
 						{
 							FileNum:  300,
 							Size:     expandedCompactionByteSizeLimit(opts, 2) - 1,
@@ -522,8 +522,8 @@ func TestElideTombstone(t *testing.T) {
 			desc:  "non-empty",
 			level: 1,
 			version: version{
-				Files: [numLevels][]fileMetadata{
-					1: []fileMetadata{
+				Files: [numLevels][]*fileMetadata{
+					1: []*fileMetadata{
 						{
 							Smallest: base.ParseInternalKey("c.SET.801"),
 							Largest:  base.ParseInternalKey("g.SET.800"),
@@ -533,7 +533,7 @@ func TestElideTombstone(t *testing.T) {
 							Largest:  base.ParseInternalKey("y.SET.700"),
 						},
 					},
-					2: []fileMetadata{
+					2: []*fileMetadata{
 						{
 							Smallest: base.ParseInternalKey("d.SET.601"),
 							Largest:  base.ParseInternalKey("h.SET.600"),
@@ -543,7 +543,7 @@ func TestElideTombstone(t *testing.T) {
 							Largest:  base.ParseInternalKey("t.SET.500"),
 						},
 					},
-					3: []fileMetadata{
+					3: []*fileMetadata{
 						{
 							Smallest: base.ParseInternalKey("f.SET.401"),
 							Largest:  base.ParseInternalKey("g.SET.400"),
@@ -553,7 +553,7 @@ func TestElideTombstone(t *testing.T) {
 							Largest:  base.ParseInternalKey("x.SET.300"),
 						},
 					},
-					4: []fileMetadata{
+					4: []*fileMetadata{
 						{
 							Smallest: base.ParseInternalKey("f.SET.201"),
 							Largest:  base.ParseInternalKey("m.SET.200"),
@@ -592,8 +592,8 @@ func TestElideTombstone(t *testing.T) {
 			desc:  "repeated ukey",
 			level: 1,
 			version: version{
-				Files: [numLevels][]fileMetadata{
-					6: []fileMetadata{
+				Files: [numLevels][]*fileMetadata{
+					6: []*fileMetadata{
 						{
 							Smallest: base.ParseInternalKey("i.SET.401"),
 							Largest:  base.ParseInternalKey("i.SET.400"),
@@ -952,14 +952,14 @@ func TestManualCompaction(t *testing.T) {
 
 func TestCompactionFindGrandparentLimit(t *testing.T) {
 	cmp := DefaultComparer.Compare
-	var grandparents []fileMetadata
+	var grandparents []*fileMetadata
 
-	parseMeta := func(s string) fileMetadata {
+	parseMeta := func(s string) *fileMetadata {
 		parts := strings.Split(s, "-")
 		if len(parts) != 2 {
 			t.Fatalf("malformed table spec: %s", s)
 		}
-		return fileMetadata{
+		return &fileMetadata{
 			Smallest: InternalKey{UserKey: []byte(parts[0])},
 			Largest:  InternalKey{UserKey: []byte(parts[1])},
 		}
@@ -1059,12 +1059,12 @@ func TestCompactionOutputLevel(t *testing.T) {
 }
 
 func TestCompactionSetupInputs(t *testing.T) {
-	parseMeta := func(s string) fileMetadata {
+	parseMeta := func(s string) *fileMetadata {
 		parts := strings.Split(s, "-")
 		if len(parts) != 2 {
 			t.Fatalf("malformed table spec: %s", s)
 		}
-		m := fileMetadata{
+		m := &fileMetadata{
 			Smallest: base.ParseInternalKey(strings.TrimSpace(parts[0])),
 			Largest:  base.ParseInternalKey(strings.TrimSpace(parts[1])),
 		}
@@ -1089,7 +1089,7 @@ func TestCompactionSetupInputs(t *testing.T) {
 					outputLevel:      -1,
 					maxExpandedBytes: 1 << 30,
 				}
-				var files *[]fileMetadata
+				var files *[]*fileMetadata
 				fileNum := uint64(1)
 
 				for _, data := range strings.Split(d.Input, "\n") {
@@ -1156,14 +1156,14 @@ func TestCompactionSetupInputs(t *testing.T) {
 
 func TestCompactionExpandInputs(t *testing.T) {
 	cmp := DefaultComparer.Compare
-	var files []fileMetadata
+	var files []*fileMetadata
 
-	parseMeta := func(s string) fileMetadata {
+	parseMeta := func(s string) *fileMetadata {
 		parts := strings.Split(s, "-")
 		if len(parts) != 2 {
 			t.Fatalf("malformed table spec: %s", s)
 		}
-		return fileMetadata{
+		return &fileMetadata{
 			Smallest: base.ParseInternalKey(parts[0]),
 			Largest:  base.ParseInternalKey(parts[1]),
 		}
@@ -1204,7 +1204,7 @@ func TestCompactionExpandInputs(t *testing.T) {
 
 				var buf bytes.Buffer
 				for i := range inputs {
-					f := &inputs[i]
+					f := inputs[i]
 					fmt.Fprintf(&buf, "%d: %s-%s\n", f.FileNum, f.Smallest, f.Largest)
 				}
 				return buf.String()
@@ -1217,14 +1217,14 @@ func TestCompactionExpandInputs(t *testing.T) {
 
 func TestCompactionAtomicUnitBounds(t *testing.T) {
 	cmp := DefaultComparer.Compare
-	var files []fileMetadata
+	var files []*fileMetadata
 
-	parseMeta := func(s string) fileMetadata {
+	parseMeta := func(s string) *fileMetadata {
 		parts := strings.Split(s, "-")
 		if len(parts) != 2 {
 			t.Fatalf("malformed table spec: %s", s)
 		}
-		return fileMetadata{
+		return &fileMetadata{
 			Smallest: base.ParseInternalKey(parts[0]),
 			Largest:  base.ParseInternalKey(parts[1]),
 		}
@@ -1259,7 +1259,7 @@ func TestCompactionAtomicUnitBounds(t *testing.T) {
 					return err.Error()
 				}
 
-				lower, upper := c.atomicUnitBounds(&files[index])
+				lower, upper := c.atomicUnitBounds(files[index])
 				return fmt.Sprintf("%s-%s\n", lower, upper)
 
 			default:
@@ -1269,12 +1269,12 @@ func TestCompactionAtomicUnitBounds(t *testing.T) {
 }
 
 func TestCompactionInuseKeyRanges(t *testing.T) {
-	parseMeta := func(s string) fileMetadata {
+	parseMeta := func(s string) *fileMetadata {
 		parts := strings.Split(s, "-")
 		if len(parts) != 2 {
 			t.Fatalf("malformed table spec: %s", s)
 		}
-		m := fileMetadata{
+		m := &fileMetadata{
 			Smallest: base.ParseInternalKey(strings.TrimSpace(parts[0])),
 			Largest:  base.ParseInternalKey(strings.TrimSpace(parts[1])),
 		}
@@ -1292,7 +1292,7 @@ func TestCompactionInuseKeyRanges(t *testing.T) {
 				format:  DefaultComparer.Format,
 				version: &version{},
 			}
-			var files *[]fileMetadata
+			var files *[]*fileMetadata
 			fileNum := uint64(1)
 
 			for _, data := range strings.Split(td.Input, "\n") {
@@ -1361,7 +1361,7 @@ func TestCompactionAllowZeroSeqNum(t *testing.T) {
 	}()
 
 	metaRE := regexp.MustCompile(`^L([0-9]+):([^-]+)-(.+)$`)
-	parseMeta := func(s string) (level int, meta fileMetadata) {
+	parseMeta := func(s string) (level int, meta *fileMetadata) {
 		match := metaRE.FindStringSubmatch(s)
 		if match == nil {
 			t.Fatalf("malformed table spec: %s", s)
@@ -1370,7 +1370,7 @@ func TestCompactionAllowZeroSeqNum(t *testing.T) {
 		if err != nil {
 			t.Fatalf("malformed table spec: %s: %s", s, err)
 		}
-		meta = fileMetadata{
+		meta = &fileMetadata{
 			Smallest: InternalKey{UserKey: []byte(match[2])},
 			Largest:  InternalKey{UserKey: []byte(match[3])},
 		}
@@ -1462,12 +1462,12 @@ func TestCompactionAllowZeroSeqNum(t *testing.T) {
 }
 
 func TestCompactionCheckOrdering(t *testing.T) {
-	parseMeta := func(s string) fileMetadata {
+	parseMeta := func(s string) *fileMetadata {
 		parts := strings.Split(s, "-")
 		if len(parts) != 2 {
 			t.Fatalf("malformed table spec: %s", s)
 		}
-		m := fileMetadata{
+		m := &fileMetadata{
 			Smallest: base.ParseInternalKey(strings.TrimSpace(parts[0])),
 			Largest:  base.ParseInternalKey(strings.TrimSpace(parts[1])),
 		}
@@ -1487,7 +1487,7 @@ func TestCompactionCheckOrdering(t *testing.T) {
 					startLevel:  -1,
 					outputLevel: -1,
 				}
-				var files *[]fileMetadata
+				var files *[]*fileMetadata
 				fileNum := uint64(1)
 
 				for _, data := range strings.Split(d.Input, "\n") {

--- a/db.go
+++ b/db.go
@@ -691,7 +691,7 @@ func (d *DB) newIterInternal(
 	// need to wrap level 0 files individually in level iterators.
 	current := readState.current
 	for i := len(current.Files[0]) - 1; i >= 0; i-- {
-		f := &current.Files[0][i]
+		f := current.Files[0][i]
 		iter, rangeDelIter, err := d.newIters(f, &dbi.opts, nil)
 		if err != nil {
 			// Ensure the mergingIter is initialized so Iterator.Close will properly
@@ -1114,7 +1114,7 @@ func (d *DB) EstimateDiskUsage(start, end []byte) (uint64, error) {
 				totalSize += file.Size
 			} else if d.opts.Comparer.Compare(file.Smallest.UserKey, end) <= 0 &&
 				d.opts.Comparer.Compare(start, file.Largest.UserKey) <= 0 {
-				size, err := d.tableCache.estimateDiskUsage(&file, start, end)
+				size, err := d.tableCache.estimateDiskUsage(file, start, end)
 				if err != nil {
 					return 0, err
 				}

--- a/get_iter.go
+++ b/get_iter.go
@@ -27,7 +27,7 @@ type getIter struct {
 	level        int
 	batch        *Batch
 	mem          flushableList
-	l0           []fileMetadata
+	l0           []*fileMetadata
 	version      *version
 	iterKey      *InternalKey
 	iterValue    []byte
@@ -133,7 +133,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 		if g.level == 0 {
 			// Create iterators from L0 from newest to oldest.
 			if n := len(g.l0); n > 0 {
-				l := &g.l0[n-1]
+				l := g.l0[n-1]
 				g.iter, g.rangeDelIter, g.err = g.newIters(
 					l,
 					nil, /* iter options */

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -484,7 +484,7 @@ func TestGetIter(t *testing.T) {
 			defer d.close()
 			m[tt.fileNum] = d
 
-			meta := fileMetadata{
+			meta := &fileMetadata{
 				FileNum: tt.fileNum,
 			}
 			for i, datum := range tt.data {

--- a/ingest.go
+++ b/ingest.go
@@ -290,7 +290,9 @@ func ingestUpdateSeqNum(opts *Options, dirname string, seqNum uint64, meta []*fi
 	return nil
 }
 
-func overlapWithIterator(iter internalIterator, rangeDelIter *internalIterator, meta *fileMetadata, cmp Compare) bool {
+func overlapWithIterator(
+	iter internalIterator, rangeDelIter *internalIterator, meta *fileMetadata, cmp Compare,
+) bool {
 	// Check overlap with point operations.
 	//
 	// When using levelIter, it seeks to the SST whose boundaries
@@ -345,7 +347,13 @@ func overlapWithIterator(iter internalIterator, rangeDelIter *internalIterator, 
 }
 
 func ingestTargetLevel(
-	newIters tableNewIters, iterOps IterOptions, cmp Compare, v *version, baseLevel int, compactions map[*compaction]struct{}, meta *fileMetadata,
+	newIters tableNewIters,
+	iterOps IterOptions,
+	cmp Compare,
+	v *version,
+	baseLevel int,
+	compactions map[*compaction]struct{},
+	meta *fileMetadata,
 ) (int, error) {
 	// Find the lowest level which does not have any files which overlap meta.
 	// We search from L0 to L6 looking for whether there are any files in the level
@@ -371,7 +379,7 @@ func ingestTargetLevel(
 			continue
 		}
 
-		iter, rangeDelIter, err := newIters(&meta0, nil, nil)
+		iter, rangeDelIter, err := newIters(meta0, nil, nil)
 		if err != nil {
 			return 0, err
 		}
@@ -626,7 +634,7 @@ func (d *DB) ingestApply(jobID int, meta []*fileMetadata) (*versionEdit, error) 
 		if err != nil {
 			return nil, err
 		}
-		f.Meta = *m
+		f.Meta = m
 		levelMetrics := metrics[f.Level]
 		if levelMetrics == nil {
 			levelMetrics = &LevelMetrics{}

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -61,7 +61,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 			NewFiles: []NewFileEntry{
 				{
 					Level: 5,
-					Meta: FileMetadata{
+					Meta: &FileMetadata{
 						FileNum:  805,
 						Size:     8050,
 						Smallest: base.DecodeInternalKey([]byte("abc\x00\x01\x02\x03\x04\x05\x06\x07")),
@@ -70,7 +70,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 				},
 				{
 					Level: 6,
-					Meta: FileMetadata{
+					Meta: &FileMetadata{
 						FileNum:             806,
 						Size:                8060,
 						Smallest:            base.DecodeInternalKey([]byte("A\x00\x01\x02\x03\x04\x05\x06\x07")),
@@ -131,7 +131,7 @@ func TestVersionEditDecode(t *testing.T) {
 					NewFiles: []NewFileEntry{
 						{
 							Level: 0,
-							Meta: FileMetadata{
+							Meta: &FileMetadata{
 								FileNum:        4,
 								Size:           986,
 								Smallest:       base.MakeInternalKey([]byte("bar"), 5, base.InternalKeyKindDelete),
@@ -317,14 +317,13 @@ func TestVersionEditApply(t *testing.T) {
 								return err.Error()
 							}
 							if isVersion {
-								meta.refs = new(int32)
 								if v == nil {
 									v = new(Version)
 								}
-								v.Files[level] = append(v.Files[level], *meta)
+								v.Files[level] = append(v.Files[level], meta)
 							} else {
 								ve.NewFiles =
-									append(ve.NewFiles, NewFileEntry{Level: level, Meta: *meta})
+									append(ve.NewFiles, NewFileEntry{Level: level, Meta: meta})
 							}
 						} else {
 							fileNum, err := strconv.Atoi(data)

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -61,10 +61,10 @@ func TestIkeyRange(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		var f []FileMetadata
+		var f []*FileMetadata
 		if tc.input != "" {
 			for _, s := range strings.Split(tc.input, " ") {
-				f = append(f, FileMetadata{
+				f = append(f, &FileMetadata{
 					Smallest: ikey(s[0:1]),
 					Largest:  ikey(s[2:3]),
 				})
@@ -86,80 +86,80 @@ func TestIkeyRange(t *testing.T) {
 }
 
 func TestOverlaps(t *testing.T) {
-	m00 := FileMetadata{
+	m00 := &FileMetadata{
 		FileNum:  700,
 		Size:     1,
 		Smallest: base.ParseInternalKey("b.SET.7008"),
 		Largest:  base.ParseInternalKey("e.SET.7009"),
 	}
-	m01 := FileMetadata{
+	m01 := &FileMetadata{
 		FileNum:  701,
 		Size:     1,
 		Smallest: base.ParseInternalKey("c.SET.7018"),
 		Largest:  base.ParseInternalKey("f.SET.7019"),
 	}
-	m02 := FileMetadata{
+	m02 := &FileMetadata{
 		FileNum:  702,
 		Size:     1,
 		Smallest: base.ParseInternalKey("f.SET.7028"),
 		Largest:  base.ParseInternalKey("g.SET.7029"),
 	}
-	m03 := FileMetadata{
+	m03 := &FileMetadata{
 		FileNum:  703,
 		Size:     1,
 		Smallest: base.ParseInternalKey("x.SET.7038"),
 		Largest:  base.ParseInternalKey("y.SET.7039"),
 	}
-	m04 := FileMetadata{
+	m04 := &FileMetadata{
 		FileNum:  704,
 		Size:     1,
 		Smallest: base.ParseInternalKey("n.SET.7048"),
 		Largest:  base.ParseInternalKey("p.SET.7049"),
 	}
-	m05 := FileMetadata{
+	m05 := &FileMetadata{
 		FileNum:  705,
 		Size:     1,
 		Smallest: base.ParseInternalKey("p.SET.7058"),
 		Largest:  base.ParseInternalKey("p.SET.7059"),
 	}
-	m06 := FileMetadata{
+	m06 := &FileMetadata{
 		FileNum:  706,
 		Size:     1,
 		Smallest: base.ParseInternalKey("p.SET.7068"),
 		Largest:  base.ParseInternalKey("u.SET.7069"),
 	}
-	m07 := FileMetadata{
+	m07 := &FileMetadata{
 		FileNum:  707,
 		Size:     1,
 		Smallest: base.ParseInternalKey("r.SET.7078"),
 		Largest:  base.ParseInternalKey("s.SET.7079"),
 	}
 
-	m10 := FileMetadata{
+	m10 := &FileMetadata{
 		FileNum:  710,
 		Size:     1,
 		Smallest: base.ParseInternalKey("d.SET.7108"),
 		Largest:  base.ParseInternalKey("g.SET.7109"),
 	}
-	m11 := FileMetadata{
+	m11 := &FileMetadata{
 		FileNum:  711,
 		Size:     1,
 		Smallest: base.ParseInternalKey("g.SET.7118"),
 		Largest:  base.ParseInternalKey("j.SET.7119"),
 	}
-	m12 := FileMetadata{
+	m12 := &FileMetadata{
 		FileNum:  712,
 		Size:     1,
 		Smallest: base.ParseInternalKey("n.SET.7128"),
 		Largest:  base.ParseInternalKey("p.SET.7129"),
 	}
-	m13 := FileMetadata{
+	m13 := &FileMetadata{
 		FileNum:  713,
 		Size:     1,
 		Smallest: base.ParseInternalKey("p.SET.7138"),
 		Largest:  base.ParseInternalKey("p.SET.7139"),
 	}
-	m14 := FileMetadata{
+	m14 := &FileMetadata{
 		FileNum:  714,
 		Size:     1,
 		Smallest: base.ParseInternalKey("p.SET.7148"),
@@ -167,7 +167,7 @@ func TestOverlaps(t *testing.T) {
 	}
 
 	v := Version{
-		Files: [NumLevels][]FileMetadata{
+		Files: [NumLevels][]*FileMetadata{
 			0: {m00, m01, m02, m03, m04, m05, m06, m07},
 			1: {m10, m11, m12, m13, m14},
 		},
@@ -293,7 +293,7 @@ func TestCheckOrdering(t *testing.T) {
 				// avoid repeating it, and make it the inverse of
 				// Version.DebugString().
 				v := Version{}
-				var files *[]FileMetadata
+				var files *[]*FileMetadata
 				fileNum := uint64(1)
 
 				for _, data := range strings.Split(d.Input, "\n") {
@@ -309,7 +309,7 @@ func TestCheckOrdering(t *testing.T) {
 						meta := parseMeta(data)
 						meta.FileNum = fileNum
 						fileNum++
-						*files = append(*files, meta)
+						*files = append(*files, &meta)
 					}
 				}
 

--- a/level_checker.go
+++ b/level_checker.go
@@ -258,7 +258,7 @@ func checkRangeTombstones(c *checkConfig) error {
 
 	current := c.readState.current
 	for i := len(current.Files[0]) - 1; i >= 0; i-- {
-		f := &current.Files[0][i]
+		f := current.Files[0][i]
 		iterToClose, iter, err := c.newIters(f, nil, nil)
 		if err != nil {
 			return err
@@ -280,7 +280,7 @@ func checkRangeTombstones(c *checkConfig) error {
 		files := &current.Files[i]
 		for j := 0; j < len(*files); j++ {
 			lower, upper := getAtomicUnitBounds(c.cmp, *files, j)
-			iterToClose, iter, err := c.newIters(&(*files)[j], nil, nil)
+			iterToClose, iter, err := c.newIters((*files)[j], nil, nil)
 			if err != nil {
 				return err
 			}
@@ -307,12 +307,12 @@ func checkRangeTombstones(c *checkConfig) error {
 }
 
 // TODO(sbhola): mostly copied from compaction.go: refactor and reuse?
-func getAtomicUnitBounds(cmp Compare, files []fileMetadata, index int) (lower, upper []byte) {
+func getAtomicUnitBounds(cmp Compare, files []*fileMetadata, index int) (lower, upper []byte) {
 	lower = files[index].Smallest.UserKey
 	upper = files[index].Largest.UserKey
 	for i := index; i > 0; i-- {
-		cur := &files[i]
-		prev := &files[i-1]
+		cur := files[i]
+		prev := files[i-1]
 		if cmp(prev.Largest.UserKey, cur.Smallest.UserKey) < 0 {
 			break
 		}
@@ -322,8 +322,8 @@ func getAtomicUnitBounds(cmp Compare, files []fileMetadata, index int) (lower, u
 		lower = prev.Smallest.UserKey
 	}
 	for i := index + 1; i < len(files); i++ {
-		cur := &files[i-1]
-		next := &files[i]
+		cur := files[i-1]
+		next := files[i]
 		if cmp(cur.Largest.UserKey, next.Smallest.UserKey) < 0 {
 			break
 		}
@@ -475,7 +475,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 	// Add L0 files from newest to oldest.
 	current := c.readState.current
 	for i := len(current.Files[0]) - 1; i >= 0; i-- {
-		f := &current.Files[0][i]
+		f := current.Files[0][i]
 		iter, rangeDelIter, err := c.newIters(f, nil, nil)
 		if err != nil {
 			return err

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -44,7 +44,7 @@ func TestCheckLevelsBasics(t *testing.T) {
 func TestCheckLevelsCornerCases(t *testing.T) {
 	memFS := vfs.NewMem()
 	cmp := DefaultComparer.Compare
-	var levels [][]fileMetadata
+	var levels [][]*fileMetadata
 
 	// Indexed by fileNum
 	var readers []*sstable.Reader
@@ -82,7 +82,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 				keys := strings.Fields(line)
 				smallestKey := base.ParseInternalKey(keys[0])
 				largestKey := base.ParseInternalKey(keys[1])
-				*li = append(*li, fileMetadata{
+				*li = append(*li, &fileMetadata{
 					FileNum:  fileNum,
 					Smallest: smallestKey,
 					Largest:  largestKey,

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestLevelIter(t *testing.T) {
 	var iters []*fakeIter
-	var files []fileMetadata
+	var files []*fileMetadata
 
 	newIters := func(
 		meta *fileMetadata, opts *IterOptions, bytesIterated *uint64,
@@ -48,7 +48,7 @@ func TestLevelIter(t *testing.T) {
 				}
 				iters = append(iters, f)
 
-				meta := fileMetadata{
+				meta := &fileMetadata{
 					FileNum: uint64(len(files)),
 				}
 				meta.Smallest = f.keys[0]
@@ -129,7 +129,7 @@ type levelIterTest struct {
 	cmp     base.Comparer
 	mem     vfs.FS
 	readers []*sstable.Reader
-	files   []fileMetadata
+	files   []*fileMetadata
 }
 
 func newLevelIterTest() *levelIterTest {
@@ -222,7 +222,7 @@ func (lt *levelIterTest) runBuild(d *datadriven.TestData) string {
 		return err.Error()
 	}
 	lt.readers = append(lt.readers, r)
-	lt.files = append(lt.files, fileMetadata{
+	lt.files = append(lt.files, &fileMetadata{
 		FileNum:  fileNum,
 		Smallest: meta.Smallest(lt.cmp.Compare),
 		Largest:  meta.Largest(lt.cmp.Compare),
@@ -332,7 +332,7 @@ func TestLevelIterSeek(t *testing.T) {
 
 func buildLevelIterTables(
 	b *testing.B, blockSize, restartInterval, count int,
-) ([]*sstable.Reader, []fileMetadata, [][]byte) {
+) ([]*sstable.Reader, []*fileMetadata, [][]byte) {
 	mem := vfs.NewMem()
 	files := make([]vfs.File, count)
 	for i := range files {
@@ -383,10 +383,11 @@ func buildLevelIterTables(
 		}
 	}
 
-	meta := make([]fileMetadata, len(readers))
+	meta := make([]*fileMetadata, len(readers))
 	for i := range readers {
 		iter := readers[i].NewIter(nil /* lower */, nil /* upper */)
 		key, _ := iter.First()
+		meta[i] = &fileMetadata{}
 		meta[i].FileNum = uint64(i)
 		meta[i].Smallest = *key
 		key, _ = iter.Last()

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -166,7 +166,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 				keys := strings.Fields(line)
 				smallestKey := base.ParseInternalKey(keys[0])
 				largestKey := base.ParseInternalKey(keys[1])
-				*files = append(*files, fileMetadata{
+				*files = append(*files, &fileMetadata{
 					FileNum:  fileNum,
 					Smallest: smallestKey,
 					Largest:  largestKey,

--- a/tool/find.go
+++ b/tool/find.go
@@ -233,7 +233,7 @@ func (f *findT) readManifests() {
 						f.editRefs[nf.Meta.FileNum] = append(refs, i)
 					}
 					if _, ok := f.tableMeta[nf.Meta.FileNum]; !ok {
-						f.tableMeta[nf.Meta.FileNum] = &nf.Meta
+						f.tableMeta[nf.Meta.FileNum] = nf.Meta
 					}
 				}
 			}

--- a/tool/make_incorrect_manifests.go
+++ b/tool/make_incorrect_manifests.go
@@ -39,13 +39,13 @@ func makeManifest1() {
 	ve.NextFileNum = 5
 	ve.LastSeqNum = 20
 	ve.NewFiles = []manifest.NewFileEntry{
-		{0, manifest.FileMetadata{
+		{0, &manifest.FileMetadata{
 			FileNum: 1, SmallestSeqNum: 2, LargestSeqNum: 5}}}
 	writeVE(writer, &ve)
 
 	ve.MinUnflushedLogNum = 3
 	ve.NewFiles = []manifest.NewFileEntry{
-		{0, manifest.FileMetadata{
+		{0, &manifest.FileMetadata{
 			FileNum: 2, SmallestSeqNum: 1, LargestSeqNum: 4}}}
 	writeVE(writer, &ve)
 

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -162,7 +162,7 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 				for level := range v.Files {
 					fmt.Fprintf(stdout, "--- L%d ---\n", level)
 					for j := range v.Files[level] {
-						f := &v.Files[level][j]
+						f := v.Files[level][j]
 						fmt.Fprintf(stdout, "  %06d:%d", f.FileNum, f.Size)
 						formatKeyRange(stdout, m.fmtKey, &f.Smallest, &f.Largest)
 						fmt.Fprintf(stdout, "\n")
@@ -238,7 +238,7 @@ func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
 					for level := range v.Files {
 						fmt.Fprintf(stdout, "--- L%d ---\n", level)
 						for j := range v.Files[level] {
-							f := &v.Files[level][j]
+							f := v.Files[level][j]
 							fmt.Fprintf(stdout, "  %06d:%d", f.FileNum, f.Size)
 							formatKeyRange(stdout, m.fmtKey, &f.Smallest, &f.Largest)
 							fmt.Fprintf(stdout, "\n")


### PR DESCRIPTION
Change type of `Version.Files` to be slices of `*FileMetadata` rather than
`FileMetadata`. This fixes a few places where we were escaping local
variables to the heap, and will bring consistency for the level 
representation when L0 sublevels are introduced.

The number of allocations should be unchanged. While every
`*FileMetadata` is now allocated individually, we were previously 
allocating `FileMetadata.refs` individually. This may be a win on 
performance for very large numbers of files because
`BulkVersionEdit.Apply` now only moves pointers (8 bytes) instead of
`FileMetadata` (112 bytes).