### PR TITLE
db: prevent concurrent compactions to same output level

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -439,7 +439,10 @@ func conflictsWithInProgress(
 	level int, outputLevel int, inProgressCompactions []compactionInfo,
 ) bool {
 	for _, c := range inProgressCompactions {
-		if level == c.startLevelNum() || outputLevel == c.startLevelNum() || level == c.outputLevelNum() {
+		if level == c.startLevelNum() ||
+			level == c.outputLevelNum() ||
+			outputLevel == c.startLevelNum() ||
+			outputLevel == c.outputLevelNum() {
 			return true
 		}
 	}

--- a/testdata/compaction_picker_target_level
+++ b/testdata/compaction_picker_target_level
@@ -196,3 +196,14 @@ startLevel: 0, outputLevel: 4
 pick
 ----
 startLevel: 5, outputLevel: 6
+
+init_cp
+----
+
+queue
+----
+4: 2.0,0: 1.2,5: 1.0,
+
+pick ongoing=(0,5)
+----
+no compaction


### PR DESCRIPTION
Enhance `conflictsWithInProgress` to prevent concurrent compactions to
the same output level even if the compactions have different input
levels. The scenario seen in the wild was a compaction from L0->L5 and
then a concurrent compaction from L4->L5. Both compactions targeted the
same sstables: boom! There are several possibilities for how both
compactions could target the same sstables. The L0 sstable may not have
overlapped with any of the L4 sstables. When the L4 sstable was
compacted we expanded the inputs to include the same L5 sstable. This
could also occur due to the new ingestion target-level heuristic which
allows ingestion below L0 even if there is sstable overlap if there is
no key overlap.

We'll be able to allow concurrent compactions to the same output level
in the future once support for intra-L0 compactions is merged which
brings with it precise tracking of which sstables are being compacted.

Fixes #541