### PR TITLE
internal/record: fix blockage when using min-sync-interval

### DIFF
--- a/internal/record/log_writer.go
+++ b/internal/record/log_writer.go
@@ -375,6 +375,12 @@ func (w *LogWriter) flushLoop(context.Context) {
 				break
 			}
 			if f.close {
+				// If the writer is closed, pretend the sync timer fired immediately so
+				// that we can process any queued sync requests.
+				f.syncQ.clearBlocked()
+				if !f.syncQ.empty() {
+					break
+				}
 				return
 			}
 			f.ready.Wait()


### PR DESCRIPTION
If a `LogWriter` is closed while we were waiting for the
min-sync-interval timer to expire, the queued sync requests would never
be processed leading to a blockage of the commit pipeline.