### PR TITLE
docs: minor fix to range deletion docs

### DIFF
--- a/docs/range_deletions.md
+++ b/docs/range_deletions.md
@@ -59,7 +59,7 @@ the same key have the same sequence number).
   |   .       > .        > .        > yy
   |   .      >  .       >  .       >  .
   |   .     >   .      >   .      >   .
-n |   V    >    xx    >    x.    >    V
+n |   V    >    xx    >    .     >    V
   |   .   >     x.   >     x.   >     . 
   |   .  >      x.  >      x.  >      .
   |   . >       x. >       x. >       .

--- a/docs/rocksdb.md
+++ b/docs/rocksdb.md
@@ -456,13 +456,12 @@ of read operations in the presence of range tombstones.
 
 A range tombstone is composed of a start key, end key, and sequence
 number. Any key that falls within the range is considered deleted if
-the key's sequence number is less than or equal to the range
-tombstone's sequence number. RocksDB stores range tombstones
-segregated from point operations in a special range deletion block
-within each sstable. Conceptually, the range tombstones stored within
-an sstable are truncated to the boundaries of the sstable, though
-there are complexities that cause this to not actually be physically
-true.
+the key's sequence number is less than to the range tombstone's
+sequence number. RocksDB stores range tombstones segregated from
+point operations in a special range deletion block within each
+sstable. Conceptually, the range tombstones stored within an sstable
+are truncated to the boundaries of the sstable, though there are
+complexities that cause this to not actually be physically true.
 
 In RocksDB, the main structure implementing range tombstone processing
 is the `RangeDelAggregator`. Each read operation and iterator has its


### PR DESCRIPTION
The docs around range deletion were inconsistent around whether the
points within the range with the same sequence number as the range
deletion would be deleted. This PR updates the docs to consistently say
that this point would not be included in the range deletion.