### PR TITLE
internal/rangedel: replace iterator with base.InternalIterator

### DIFF
--- a/internal/rangedel/fragmenter_test.go
+++ b/internal/rangedel/fragmenter_test.go
@@ -103,7 +103,7 @@ func TestFragmenter(t *testing.T) {
 		return m[1], seq
 	}
 
-	var iter iterator
+	var iter base.InternalIterator
 
 	// Returns true if the specified <key,seq> pair is deleted at the specified
 	// read sequence number. Get ignores tombstones newer than the read sequence

--- a/internal/rangedel/get.go
+++ b/internal/rangedel/get.go
@@ -6,35 +6,13 @@ package rangedel
 
 import "github.com/cockroachdb/pebble/internal/base"
 
-// iterator is a subset of the pebble.internalIterator interface needed for
-// range deletion iteration.
-type iterator interface {
-	// SeekLT moves the iterator to the last key/value pair whose key is less
-	// than the given key.
-	SeekLT(key []byte) (*base.InternalKey, []byte)
-
-	// First moves the iterator the the first key/value pair.
-	First() (*base.InternalKey, []byte)
-
-	// Last moves the iterator the the last key/value pair.
-	Last() (*base.InternalKey, []byte)
-
-	// Next moves the iterator to the next key/value pair.
-	// It returns whether the iterator is exhausted.
-	Next() (*base.InternalKey, []byte)
-
-	// Prev moves the iterator to the previous key/value pair.
-	// It returns whether the iterator is exhausted.
-	Prev() (*base.InternalKey, []byte)
-}
-
 // Get returns the newest tombstone that contains the target key. If no
 // tombstone contains the target key, an empty tombstone is returned. The
 // snapshot parameter controls the visibility of tombstones (only tombstones
 // older than the snapshot sequence number are visible). The iterator must
 // contain fragmented tombstones: any overlapping tombstones must have the same
 // start and end key.
-func Get(cmp base.Compare, iter iterator, key []byte, snapshot uint64) Tombstone {
+func Get(cmp base.Compare, iter base.InternalIterator, key []byte, snapshot uint64) Tombstone {
 	// NB: We use SeekLT in order to land on the proper tombstone for a search
 	// key that resides in the middle of a tombstone. Consider the scenario:
 	//

--- a/internal/rangedel/seek.go
+++ b/internal/rangedel/seek.go
@@ -12,7 +12,7 @@ import "github.com/cockroachdb/pebble/internal/base"
 // iterator must contain fragmented tombstones: any overlapping tombstones must
 // have the same start and end key. The position of the iterator is undefined
 // after calling SeekGE and may not be pointing at the returned tombstone.
-func SeekGE(cmp base.Compare, iter iterator, key []byte, snapshot uint64) Tombstone {
+func SeekGE(cmp base.Compare, iter base.InternalIterator, key []byte, snapshot uint64) Tombstone {
 	// NB: We use SeekLT in order to land on the proper tombstone for a search
 	// key that resides in the middle of a tombstone. Consider the scenario:
 	//
@@ -80,7 +80,7 @@ func SeekGE(cmp base.Compare, iter iterator, key []byte, snapshot uint64) Tombst
 // iterator must contain fragmented tombstones: any overlapping tombstones must
 // have the same start and end key. The position of the iterator is undefined
 // after calling SeekLE and may not be pointing at the returned tombstone.
-func SeekLE(cmp base.Compare, iter iterator, key []byte, snapshot uint64) Tombstone {
+func SeekLE(cmp base.Compare, iter base.InternalIterator, key []byte, snapshot uint64) Tombstone {
 	// NB: We use SeekLT in order to land on the proper tombstone for a search
 	// key that resides in the middle of a tombstone. Consider the scenario:
 	//

--- a/internal/rangedel/truncate.go
+++ b/internal/rangedel/truncate.go
@@ -8,7 +8,7 @@ import "github.com/cockroachdb/pebble/internal/base"
 
 // Truncate creates a new iterator where every tombstone in the supplied
 // iterator is truncated to be contained within the range [lower, upper).
-func Truncate(cmp base.Compare, iter iterator, lower, upper []byte) *Iter {
+func Truncate(cmp base.Compare, iter base.InternalIterator, lower, upper []byte) *Iter {
 	var tombstones []Tombstone
 	for key, value := iter.First(); key != nil; key, value = iter.Next() {
 		t := Tombstone{

--- a/internal/rangedel/truncate_test.go
+++ b/internal/rangedel/truncate_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestTruncate(t *testing.T) {
 	cmp := base.DefaultComparer.Compare
-	var iter iterator
+	var iter base.InternalIterator
 
 	datadriven.RunTest(t, "testdata/truncate", func(d *datadriven.TestData) string {
 		switch d.Cmd {


### PR DESCRIPTION
The `rangedel.iterator` interface was added before
`base.InternalIterator` came into existence. Now that we have
`base.InternalIterator`, it makes sense to use it.