### PR TITLE
compaction: Don't elide range tombstones when flushing memtables

### DIFF
--- a/testdata/manual_flush
+++ b/testdata/manual_flush
@@ -58,6 +58,8 @@ del-range a c
 
 flush
 ----
+0:
+  000005:[a#2,RANGEDEL-c#72057594037927935,RANGEDEL]
 
 reset
 ----


### PR DESCRIPTION
This change short-circuits the method to figure out if a range
tombstone should be elided during compaction, if the compaction
is a flush. This is because when the output is to L0, it's possible
for a range tombstone in one memtable to overlap keys in another
memtable in the same level that was flushed earlier (but within
the same compaction).

Will fix https://github.com/cockroachdb/cockroach/issues/45581
when this lands in the cockroach repo.