### PR TITLE
iterator: Copy iterValue before Prev() on internal iterator

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -44,6 +44,7 @@ type Iterator struct {
 	key       []byte
 	keyBuf    []byte
 	value     []byte
+	valueBuf  []byte
 	valid     bool
 	iterKey   *InternalKey
 	iterValue []byte
@@ -148,7 +149,12 @@ func (i *Iterator) findPrevEntry() bool {
 		case InternalKeyKindSet:
 			i.keyBuf = append(i.keyBuf[:0], key.UserKey...)
 			i.key = i.keyBuf
-			i.value = i.iterValue
+			// iterValue is owned by i.iter and could change after the Prev()
+			// call, so use valueBuf instead. Note that valueBuf is only used
+			// in this one instance; everywhere else (eg. in findNextEntry),
+			// we just point i.value to the unsafe i.iter-owned value buffer.
+			i.valueBuf = append(i.valueBuf[:0], i.iterValue...)
+			i.value = i.valueBuf
 			i.valid = true
 			i.iterKey, i.iterValue = i.iter.Prev()
 			valueMerger = nil


### PR DESCRIPTION
We were reusing the underlying iterator's value buffer as the
outer iterator's value buffer without copying it, even though
in some cases the underlying buffer would change. In particular,
this was observed to return wrong values when reverse iterating
around the start key of an L6 SSTable.

Found by the MVCC metamorphic tests.