### PR TITLE
tool: Show smallest/largest sequence numbers for SSTs in manifest

### DIFF
--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -154,6 +154,7 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 					empty = false
 					fmt.Fprintf(stdout, "  added:         L%d %06d:%d",
 						nf.Level, nf.Meta.FileNum, nf.Meta.Size)
+					formatSeqNumRange(stdout, nf.Meta.SmallestSeqNum, nf.Meta.LargestSeqNum)
 					formatKeyRange(stdout, m.fmtKey, &nf.Meta.Smallest, &nf.Meta.Largest)
 					if nf.Meta.CreationTime != 0 {
 						fmt.Fprintf(stdout, " (%s)",
@@ -180,6 +181,7 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 					for j := range v.Files[level] {
 						f := v.Files[level][j]
 						fmt.Fprintf(stdout, "  %06d:%d", f.FileNum, f.Size)
+						formatSeqNumRange(stdout, f.SmallestSeqNum, f.LargestSeqNum)
 						formatKeyRange(stdout, m.fmtKey, &f.Smallest, &f.Largest)
 						fmt.Fprintf(stdout, "\n")
 					}
@@ -256,6 +258,7 @@ func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
 						for j := range v.Files[level] {
 							f := v.Files[level][j]
 							fmt.Fprintf(stdout, "  %06d:%d", f.FileNum, f.Size)
+							formatSeqNumRange(stdout, f.SmallestSeqNum, f.LargestSeqNum)
 							formatKeyRange(stdout, m.fmtKey, &f.Smallest, &f.Largest)
 							fmt.Fprintf(stdout, "\n")
 						}
@@ -267,6 +270,7 @@ func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
 					for _, nf := range ve.NewFiles {
 						fmt.Fprintf(stdout, "  added: L%d %06d:%d",
 							nf.Level, nf.Meta.FileNum, nf.Meta.Size)
+						formatSeqNumRange(stdout, nf.Meta.SmallestSeqNum, nf.Meta.LargestSeqNum)
 						formatKeyRange(stdout, m.fmtKey, &nf.Meta.Smallest, &nf.Meta.Largest)
 						fmt.Fprintf(stdout, "\n")
 					}

--- a/tool/testdata/manifest_dump
+++ b/tool/testdata/manifest_dump
@@ -22,10 +22,10 @@ MANIFEST-000005
   log-num:       4
   next-file-num: 6
   last-seq-num:  5
-  added:         L0 000004:986[bar#5,DEL-foo#4,SET]
+  added:         L0 000004:986<#3-#5>[bar#5,DEL-foo#4,SET]
 EOF
 --- L0 ---
-  000004:986[bar#5,DEL-foo#4,SET]
+  000004:986<#3-#5>[bar#5,DEL-foo#4,SET]
 --- L1 ---
 --- L2 ---
 --- L3 ---
@@ -46,10 +46,10 @@ MANIFEST-000005
   log-num:       4
   next-file-num: 6
   last-seq-num:  5
-  added:         L0 000004:986[626172#5,DEL-666f6f#4,SET]
+  added:         L0 000004:986<#3-#5>[626172#5,DEL-666f6f#4,SET]
 EOF
 --- L0 ---
-  000004:986[626172#5,DEL-666f6f#4,SET]
+  000004:986<#3-#5>[626172#5,DEL-666f6f#4,SET]
 --- L1 ---
 --- L2 ---
 --- L3 ---
@@ -70,10 +70,10 @@ MANIFEST-000005
   log-num:       4
   next-file-num: 6
   last-seq-num:  5
-  added:         L0 000004:986
+  added:         L0 000004:986<#3-#5>
 EOF
 --- L0 ---
-  000004:986
+  000004:986<#3-#5>
 --- L1 ---
 --- L2 ---
 --- L3 ---
@@ -94,10 +94,10 @@ MANIFEST-000005
   log-num:       4
   next-file-num: 6
   last-seq-num:  5
-  added:         L0 000004:986[bar#5,DEL-foo#4,SET]
+  added:         L0 000004:986<#3-#5>[bar#5,DEL-foo#4,SET]
 EOF
 --- L0 ---
-  000004:986[bar#5,DEL-foo#4,SET]
+  000004:986<#3-#5>[bar#5,DEL-foo#4,SET]
 --- L1 ---
 --- L2 ---
 --- L3 ---
@@ -118,10 +118,10 @@ MANIFEST-000005
   log-num:       4
   next-file-num: 6
   last-seq-num:  5
-  added:         L0 000004:986[test formatter: bar#5,DEL-test formatter: foo#4,SET]
+  added:         L0 000004:986<#3-#5>[test formatter: bar#5,DEL-test formatter: foo#4,SET]
 EOF
 --- L0 ---
-  000004:986[test formatter: bar#5,DEL-test formatter: foo#4,SET]
+  000004:986<#3-#5>[test formatter: bar#5,DEL-test formatter: foo#4,SET]
 --- L1 ---
 --- L2 ---
 --- L3 ---
@@ -162,13 +162,13 @@ MANIFEST-invalid
   log-num:       2
   next-file-num: 5
   last-seq-num:  20
-  added:         L0 000001:0[#0,DEL-#0,DEL]
+  added:         L0 000001:0<#2-#5>[#0,DEL-#0,DEL]
 65
   comparer:     leveldb.BytewiseComparator
   log-num:       3
   next-file-num: 5
   last-seq-num:  20
-  added:         L0 000002:0[#0,DEL-#0,DEL]
+  added:         L0 000002:0<#1-#4>[#0,DEL-#0,DEL]
 EOF
 pebble: internal error: L0 flushed file 000001 overlaps with the largest seqnum of a preceding flushed file: 2-5 vs 4
 
@@ -178,7 +178,7 @@ manifest check
 MANIFEST-invalid: offset: 65 err: pebble: internal error: L0 flushed file 000001 overlaps with the largest seqnum of a preceding flushed file: 2-5 vs 4
 Version state before failed Apply
 --- L0 ---
-  000001:0[#0,DEL-#0,DEL]
+  000001:0<#2-#5>[#0,DEL-#0,DEL]
 --- L1 ---
 --- L2 ---
 --- L3 ---
@@ -186,7 +186,7 @@ Version state before failed Apply
 --- L5 ---
 --- L6 ---
 Version edit that failed
-  added: L0 000002:0[#0,DEL-#0,DEL]
+  added: L0 000002:0<#1-#4>[#0,DEL-#0,DEL]
 
 manifest dump
 ./testdata/find-db/MANIFEST-000001
@@ -202,38 +202,38 @@ MANIFEST-000001
   log-num:       4
   next-file-num: 6
   last-seq-num:  5
-  added:         L0 000005:797[aaa#0,SET-ccc#4,MERGE] (2020-02-26T00:47:32Z)
+  added:         L0 000005:797<#0-#4>[aaa#0,SET-ccc#4,MERGE] (2020-02-26T00:47:32Z)
 102
   next-file-num: 6
   last-seq-num:  5
   deleted:       L0 000005
-  added:         L6 000005:797[aaa#0,SET-ccc#4,MERGE] (2020-02-26T00:47:32Z)
+  added:         L6 000005:797<#0-#4>[aaa#0,SET-ccc#4,MERGE] (2020-02-26T00:47:32Z)
 155
   next-file-num: 7
   last-seq-num:  6
-  added:         L0 000006:838[bbb#5,SET-ccc#5,SET] (2020-02-26T00:47:32Z)
+  added:         L0 000006:838<#5-#5>[bbb#5,SET-ccc#5,SET] (2020-02-26T00:47:32Z)
 205
   next-file-num: 8
   last-seq-num:  7
-  added:         L6 000007:829[ddd#6,SET-ddd#6,SET] (2020-02-26T00:47:32Z)
+  added:         L6 000007:829<#6-#6>[ddd#6,SET-ddd#6,SET] (2020-02-26T00:47:32Z)
 255
   next-file-num: 9
   last-seq-num:  7
   deleted:       L0 000006
   deleted:       L6 000005
-  added:         L6 000008:812[aaa#0,SET-ccc#0,MERGE] (2020-02-26T00:47:32Z)
+  added:         L6 000008:812<#0-#5>[aaa#0,SET-ccc#0,MERGE] (2020-02-26T00:47:32Z)
 311
   log-num:       9
   next-file-num: 11
   last-seq-num:  10
-  added:         L0 000010:855[aaa#7,DEL-eee#72057594037927935,RANGEDEL] (2020-02-26T00:47:32Z)
+  added:         L0 000010:855<#7-#9>[aaa#7,DEL-eee#72057594037927935,RANGEDEL] (2020-02-26T00:47:32Z)
 363
   next-file-num: 12
   last-seq-num:  10
   deleted:       L0 000010
   deleted:       L6 000007
   deleted:       L6 000008
-  added:         L6 000011:919[aaa#7,DEL-eee#72057594037927935,RANGEDEL] (2020-02-26T00:47:32Z)
+  added:         L6 000011:919<#0-#9>[aaa#7,DEL-eee#72057594037927935,RANGEDEL] (2020-02-26T00:47:32Z)
 EOF
 --- L0 ---
 --- L1 ---
@@ -242,4 +242,4 @@ EOF
 --- L4 ---
 --- L5 ---
 --- L6 ---
-  000011:919[aaa#7,DEL-eee#72057594037927935,RANGEDEL]
+  000011:919<#0-#9>[aaa#7,DEL-eee#72057594037927935,RANGEDEL]

--- a/tool/util.go
+++ b/tool/util.go
@@ -168,6 +168,10 @@ func formatKey(w io.Writer, fmtKey formatter, key *base.InternalKey) bool {
 	return true
 }
 
+func formatSeqNumRange(w io.Writer, start, end uint64) {
+	fmt.Fprintf(w, "<#%d-#%d>", start, end)
+}
+
 func formatKeyRange(w io.Writer, fmtKey formatter, start, end *base.InternalKey) {
 	if fmtKey.spec == "null" {
 		return


### PR DESCRIPTION
As in title. Comes in handy when investigating ingestions, etc,
where the actual sequence number is in the manifest and not
in the SST's properties.