### PR TITLE
compaction_picker: Skip manual compaction if start level is empty

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -618,6 +618,14 @@ func (p *compactionPickerByScore) pickManual(
 	outputLevel := manual.level + 1
 	if manual.level == 0 {
 		outputLevel = p.baseLevel
+	} else if manual.level < p.baseLevel {
+		// The start level for a compaction must be >= Lbase. A manual
+		// compaction could have been created adhering to that condition, and
+		// then an automatic compaction came in and compacted all of the
+		// sstables in Lbase to Lbase+1 which caused Lbase to change. Simply
+		// ignore this manual compaction as there is nothing to do (manual.level
+		// points to an empty level).
+		return nil, false
 	}
 	// TODO(peter): The conflictsWithInProgress call should no longer be
 	// necessary, but TestManualCompaction currently expects it.

--- a/testdata/compaction_picker_target_level
+++ b/testdata/compaction_picker_target_level
@@ -315,3 +315,48 @@ L5->L6: 2.0
 pick ongoing=(5,6,5,6,5,6)
 ----
 no compaction
+
+# Verify that successive manual compactions interleaved with an automatic
+# compaction does not trigger an error.
+
+init 5
+0: 7
+5: 10
+6: 5
+----
+
+init_cp
+----
+base: 5
+
+queue
+----
+L5->L6: 2.0
+L5->L6: 1.8
+L5->L6: 1.6
+
+pick_manual level=0 start=0 end=12
+----
+L0->L5, retryLater = false
+
+pick
+----
+L5->L6: 2.0
+
+# Assume the above two compactions (one manual L0 -> L5 and one automatic
+# L5 -> L6) have run, and Lbase = L6 now, but the manual compaction code is
+# still going to try running a manual compaction from L5 -> L6 since L5 was the
+# output of the last manual compaction. No compaction should be picked.
+
+init 5
+0: 7
+6: 5
+----
+
+init_cp
+----
+base: 6
+
+pick_manual level=5 start=0 end=12
+----
+nil, retryLater = false


### PR DESCRIPTION
This addresses one case seen in MVCC metamorphic tests where the
manual compactor enqueues a compaction, but before that compaction
is run, a concurrent automatic compaction clears up the start level
and increments the base level, causing a panic in newCompaction.