### PR TITLE
db: do not recycle WAL files used for recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ document all the incompatibilities. The list below contains known
 incompatibilities.
 
 * Pebble's use of WAL recycling is only compatible with RocksDB's
-  `kPointInTimeRecovery` WAL recovery mode. The
-  `kTolerateCorruptedTailRecords` and `kAbsoluteConsistency` modes
-  will result in RocksDB being unable to open a Pebble generated
-  WAL. See [#566](https://github.com/cockroachdb/pebble/issues/566).
+  `kTolerateCorruptedTailRecords` WAL recovery mode. Older versions of
+  RocksDB would automatically map incompatible WAL recovery modes to
+  `kTolerateCorruptedTailRecords`. New versions of RocksDB will
+  disable WAL recycling.
 * Column families. Pebble does not support column families, nor does
   it attempt to detect their usage when opening a DB that may contain
   them.

--- a/open.go
+++ b/open.go
@@ -219,6 +219,9 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 			if fn >= d.mu.versions.minUnflushedLogNum {
 				logFiles = append(logFiles, fileNumAndName{fn, filename})
 			}
+			if d.logRecycler.minRecycleLogNum <= fn {
+				d.logRecycler.minRecycleLogNum = fn + 1
+			}
 		case fileTypeOptions:
 			if err := checkOptions(opts, opts.FS.PathJoin(dirname, filename)); err != nil {
 				return nil, err


### PR DESCRIPTION
WAL recycling depends on the recycled WAL only containing log records
written with the recyclable record format. Pebble always writes WAL
files with the recyclable record format, but RocksDB only uses that
format if WAL recycling is enabled. If Pebble recycles a RocksDB-written
WAL that doesn't use the recyclable record format, it can leave valid
looking log entries in the tail of the log. A subsequent replay of the
WAL by either Pebble or RocksDB could then replay those already
committed log entries. The most common way this badness would be
detected is by Pebble's L0 consistency checks, though the varieties of
badness here are almost unlimited (deleted records reappearing, written
records being deleted, etc). In order to protect against this, Pebble
now only recycles WAL files that it has written in the current
incarnation and thus knows for certain have been written with the
recyclable record format. RocksDB has similar behavior, though the code
which achieves this is somewhat convoluted so the behavior may have been
accidental.

Fixes #567