### PR TITLE
make randomHeight faster by using runtime.fastrand

### DIFF
--- a/internal/batchskl/skl.go
+++ b/internal/batchskl/skl.go
@@ -59,11 +59,10 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"time"
 	"unsafe"
 
 	"github.com/cockroachdb/pebble/internal/base"
-	"golang.org/x/exp/rand"
+	"github.com/zhiqiangxu/util"
 )
 
 const (
@@ -116,7 +115,6 @@ type Skiplist struct {
 	head           uint32
 	tail           uint32
 	height         uint32 // Current height: 1 <= height <= maxHeight
-	rand           rand.PCGSource
 }
 
 var (
@@ -168,7 +166,6 @@ func (s *Skiplist) Init(
 		nodes:          s.nodes[:0],
 		height:         1,
 	}
-	s.rand.Seed(uint64(time.Now().UnixNano()))
 
 	const initBufSize = 256
 	if cap(s.nodes) < initBufSize {
@@ -300,7 +297,7 @@ func (s *Skiplist) node(offset uint32) *node {
 }
 
 func (s *Skiplist) randomHeight() uint32 {
-	rnd := uint32(s.rand.Uint64())
+	rnd := util.FastRand()
 	h := uint32(1)
 	for h < maxHeight && rnd <= probabilities[h] {
 		h++


### PR DESCRIPTION
FYI:

https://github.com/golang/go/blob/b5c66de0892d0e9f3f59126eeebc31070e79143b/src/runtime/stubs.go#L115

