### PR TITLE
compaction: Check closed flag after logLock returns

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1050,6 +1050,12 @@ func (d *DB) maybeScheduleCompaction() {
 	d.mu.versions.logLock()
 	defer d.mu.versions.logUnlock()
 
+	// Check for the closed flag again, in case the DB was closed while we were
+	// waiting for logLock().
+	if atomic.LoadInt32(&d.closed) != 0 {
+		return
+	}
+
 	env := compactionEnv{
 		bytesCompacted:          &d.bytesCompacted,
 		earliestUnflushedSeqNum: d.getEarliestUnflushedSeqNumLocked(),

--- a/version_set.go
+++ b/version_set.go
@@ -270,7 +270,8 @@ func (vs *versionSet) close() error {
 // logLock locks the manifest for writing. The lock must be released by either
 // a call to logUnlock or logAndApply.
 //
-// DB.mu must be held when calling this method.
+// DB.mu must be held when calling this method, but the mutex may be dropped and
+// re-acquired during the course of this method.
 func (vs *versionSet) logLock() {
 	// Wait for any existing writing to the manifest to complete, then mark the
 	// manifest as busy.


### PR DESCRIPTION
This fixes one concurrency error in maybeScheduleCompaction(),
that happened if logLock() resulted in the mutex being released and a
concurrent db.Close() was allowed to run successfully. The closing
routine would not wait for any compactions since there are none
scheduled yet, but maybeScheduleCompaction would step in and schedule
one _after_ the close, resulting in a panic.

Discovered by MVCC metamorphic tests in CI:
https://github.com/cockroachdb/cockroach/issues/46366

Fixes #560 