### PR TITLE
db: document that Close may not be called twice

### DIFF
--- a/db.go
+++ b/db.go
@@ -804,9 +804,9 @@ func (d *DB) NewSnapshot() *Snapshot {
 
 // Close closes the DB.
 //
-// It is not safe to close a DB until all outstanding iterators are closed.
-// It is valid to call Close multiple times. Other methods should not be
-// called after the DB has been closed.
+// It is not safe to close a DB until all outstanding iterators are closed
+// or to call Close concurrently with any other DB method. It is not valid
+// to call any of a DB's methods after the DB has been closed.
 func (d *DB) Close() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()


### PR DESCRIPTION
The Close documentation states that Close may be called multiple times,
but Close deliberately panics if the DB has already been marked as
closed.