### PR TITLE
*: use require.NoError everywhere

### DIFF
--- a/commit_test.go
+++ b/commit_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/record"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
 )
 
@@ -173,9 +174,8 @@ func TestCommitPipelineWALClose(t *testing.T) {
 
 	mem := vfs.NewMem()
 	f, err := mem.Create("test-wal")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	// syncDelayFile will block on the done channel befor returning from Sync
 	// call.
 	sf := &syncDelayFile{
@@ -224,14 +224,9 @@ func TestCommitPipelineWALClose(t *testing.T) {
 	close(sf.done)
 
 	// Close the WAL. A "queue is full" panic means that something is broken.
-	if err := wal.Close(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, wal.Close())
 	for i := 0; i < cap(errCh); i++ {
-		err := <-errCh
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, <-errCh)
 	}
 }
 

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -278,10 +278,10 @@ func TestCompactionPickerTargetLevel(t *testing.T) {
 				iStart := base.MakeInternalKey([]byte(start), InternalKeySeqNumMax, InternalKeyKindMax)
 				iEnd := base.MakeInternalKey([]byte(end), 0, 0)
 				manual := &manualCompaction{
-					done:        make(chan error, 1),
-					level:       startLevel,
-					start:       iStart,
-					end:         iEnd,
+					done:  make(chan error, 1),
+					level: startLevel,
+					start: iStart,
+					end:   iEnd,
 				}
 
 				c, retryLater := pickerByScore.pickManual(compactionEnv{
@@ -331,9 +331,7 @@ func TestCompactionPickerIntraL0(t *testing.T) {
 		m := &fileMetadata{}
 		var err error
 		m.FileNum, err = strconv.ParseUint(s[:index], 10, 64)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		fields := strings.Fields(s[index+1:])
 		if len(fields) != 2 && len(fields) != 3 {
@@ -353,9 +351,7 @@ func TestCompactionPickerIntraL0(t *testing.T) {
 		}
 
 		m.Size, err = strconv.ParseUint(fields[1], 10, 64)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		if len(fields) == 3 {
 			if fields[2] != "compacting" {

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -133,10 +133,7 @@ func TestEventListener(t *testing.T) {
 	var d *DB
 	var buf syncedBuffer
 	mem := vfs.NewMem()
-	err := mem.MkdirAll("ext", 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, mem.MkdirAll("ext", 0755))
 
 	datadriven.RunTest(t, "testdata/event_listener", func(td *datadriven.TestData) string {
 		switch td.Cmd {
@@ -301,19 +298,15 @@ func TestWriteStallEvents(t *testing.T) {
 				L0CompactionThreshold:       2,
 				L0StopWritesThreshold:       2,
 			})
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			defer d.Close()
 
 			for i := 0; i < flushCount; i++ {
-				if err := d.Set([]byte("a"), nil, NoSync); err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, d.Set([]byte("a"), nil, NoSync))
+
 				ch, err := d.AsyncFlush()
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
+
 				// If we're delaying the flush (because we're testing for memtable
 				// write stalls), we can't wait for the flush to finish as doing so
 				// would deadlock. If we're not delaying the flush (because we're

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -94,9 +94,7 @@ func TestIngestLoadRand(t *testing.T) {
 
 		func() {
 			f, err := mem.Create(paths[i])
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			keys := make([]InternalKey, 1+rng.Intn(100))
 			for i := range keys {
@@ -120,14 +118,11 @@ func TestIngestLoadRand(t *testing.T) {
 				}
 				w.Add(keys[i], nil)
 			}
-			if err := w.Close(); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, w.Close())
 
 			meta, err := w.Metadata()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+
 			expected[i].Size = meta.Size
 		}()
 	}
@@ -137,9 +132,8 @@ func TestIngestLoadRand(t *testing.T) {
 		FS:       mem,
 	}
 	meta, _, err := ingestLoad(opts, paths, 0, pending)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	for _, m := range meta {
 		m.CreationTime = 0
 	}
@@ -151,10 +145,8 @@ func TestIngestLoadRand(t *testing.T) {
 func TestIngestLoadInvalid(t *testing.T) {
 	mem := vfs.NewMem()
 	f, err := mem.Create("invalid")
-	if err != nil {
-		t.Fatal(err)
-	}
-	f.Close()
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
 
 	opts := &Options{
 		Comparer: DefaultComparer,
@@ -229,9 +221,7 @@ func TestIngestLink(t *testing.T) {
 			mem := vfs.NewMem()
 			opts := &Options{FS: mem}
 			opts.EnsureDefaults()
-			if err := mem.MkdirAll(dir, 0755); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, mem.MkdirAll(dir, 0755))
 
 			paths := make([]string, 10)
 			meta := make([]*fileMetadata, len(paths))
@@ -241,14 +231,12 @@ func TestIngestLink(t *testing.T) {
 				meta[j] = &fileMetadata{}
 				meta[j].FileNum = uint64(j)
 				f, err := mem.Create(paths[j])
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
+
 				contents[j] = []byte(fmt.Sprintf("data%d", j))
-				if _, err := f.Write(contents[j]); err != nil {
-					t.Fatal(err)
-				}
-				f.Close()
+				_, err = f.Write(contents[j])
+				require.NoError(t, err)
+				require.NoError(t, f.Close())
 			}
 
 			if i < count {
@@ -260,14 +248,13 @@ func TestIngestLink(t *testing.T) {
 				if err == nil {
 					t.Fatalf("expected error, but found success")
 				}
-			} else if err != nil {
-				t.Fatal(err)
+			} else {
+				require.NoError(t, err)
 			}
 
 			files, err := mem.List(dir)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+
 			sort.Strings(files)
 
 			if i < count {
@@ -291,14 +278,11 @@ func TestIngestLink(t *testing.T) {
 						t.Fatalf("expected table %d, but found %d", j, fileNum)
 					}
 					f, err := mem.Open(mem.PathJoin(dir, files[j]))
-					if err != nil {
-						t.Fatal(err)
-					}
+					require.NoError(t, err)
+
 					data, err := ioutil.ReadAll(f)
-					if err != nil {
-						t.Fatal(err)
-					}
-					f.Close()
+					require.NoError(t, err)
+					require.NoError(t, f.Close())
 					if !bytes.Equal(contents[j], data) {
 						t.Fatalf("expected %s, but found %s", contents[j], data)
 					}
@@ -313,30 +297,22 @@ func TestIngestLinkFallback(t *testing.T) {
 	// copying.
 	mem := vfs.NewMem()
 	src, err := mem.Create("source")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	opts := &Options{FS: &errorFS{mem, 0}}
 	opts.EnsureDefaults()
 
 	meta := []*fileMetadata{{FileNum: 1}}
-	if err := ingestLink(0, opts, "", []string{"source"}, meta); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, ingestLink(0, opts, "", []string{"source"}, meta))
 
 	dest, err := mem.Open("000001.sst")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// We should be able to write bytes to src, and not have them show up in
 	// dest.
 	_, _ = src.Write([]byte("test"))
 	data, err := ioutil.ReadAll(dest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(data) != 0 {
 		t.Fatalf("expected copy, but files appear to be hard linked: [%s] unexpectedly found", data)
 	}
@@ -516,19 +492,16 @@ func TestIngest(t *testing.T) {
 		}
 
 		mem = vfs.NewMem()
-		err := mem.MkdirAll("ext", 0755)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, mem.MkdirAll("ext", 0755))
+
+		var err error
 		d, err = Open("", &Options{
 			FS:                    mem,
 			L0CompactionThreshold: 100,
 			L0StopWritesThreshold: 100,
 			DebugCheck:            true,
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	}
 	reset()
 
@@ -585,32 +558,23 @@ func TestIngestCompact(t *testing.T) {
 		L0CompactionThreshold: 1,
 		L0StopWritesThreshold: 1,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	src := func(i int) string {
 		return fmt.Sprintf("ext%d", i)
 	}
 	f, err := mem.Create(src(0))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	w := sstable.NewWriter(f, sstable.WriterOptions{})
 	key := []byte("a")
-	if err := w.Add(base.MakeInternalKey(key, 0, InternalKeyKindSet), nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, w.Add(base.MakeInternalKey(key, 0, InternalKeyKindSet), nil))
+	require.NoError(t, w.Close())
 
 	// Make N copies of the sstable.
 	const count = 20
 	for i := 1; i < count; i++ {
-		if err := vfs.Copy(d.opts.FS, src(0), src(i)); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, vfs.Copy(d.opts.FS, src(0), src(i)))
 	}
 
 	// Ingest the same sstable multiple times. Compaction should take place as
@@ -620,13 +584,9 @@ func TestIngestCompact(t *testing.T) {
 			// Half-way through the ingestions, set a key in the memtable to force
 			// overlap with the memtable which will require the memtable to be
 			// flushed.
-			if err := d.Set(key, nil, nil); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, d.Set(key, nil, nil))
 		}
-		if err := d.Ingest([]string{src(i)}); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, d.Ingest([]string{src(i)}))
 	}
 
 	require.NoError(t, d.Close())
@@ -637,9 +597,7 @@ func TestConcurrentIngest(t *testing.T) {
 	d, err := Open("", &Options{
 		FS: mem,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Create an sstable with 2 keys. This is necessary to trigger the overlap
 	// bug because an sstable with a single key will not have overlap in internal
@@ -649,26 +607,17 @@ func TestConcurrentIngest(t *testing.T) {
 		return fmt.Sprintf("ext%d", i)
 	}
 	f, err := mem.Create(src(0))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	w := sstable.NewWriter(f, sstable.WriterOptions{})
-	if err := w.Set([]byte("a"), nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := w.Set([]byte("b"), nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, w.Set([]byte("a"), nil))
+	require.NoError(t, w.Set([]byte("b"), nil))
+	require.NoError(t, w.Close())
 
 	// Make N copies of the sstable.
 	errCh := make(chan error, 5)
 	for i := 1; i < cap(errCh); i++ {
-		if err := vfs.Copy(d.opts.FS, src(0), src(i)); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, vfs.Copy(d.opts.FS, src(0), src(i)))
 	}
 
 	// Perform N ingestions concurrently.
@@ -684,10 +633,7 @@ func TestConcurrentIngest(t *testing.T) {
 		}(i)
 	}
 	for i := 0; i < cap(errCh); i++ {
-		err := <-errCh
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, <-errCh)
 	}
 
 	require.NoError(t, d.Close())
@@ -710,35 +656,24 @@ func TestConcurrentIngestCompact(t *testing.T) {
 					},
 				},
 			})
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			ingest := func(keys ...string) {
 				t.Helper()
 				f, err := mem.Create("ext")
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
+
 				w := sstable.NewWriter(f, sstable.WriterOptions{})
 				for _, k := range keys {
-					if err := w.Set([]byte(k), nil); err != nil {
-						t.Fatal(err)
-					}
+					require.NoError(t, w.Set([]byte(k), nil))
 				}
-				if err := w.Close(); err != nil {
-					t.Fatal(err)
-				}
-				if err := d.Ingest([]string{"ext"}); err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, w.Close())
+				require.NoError(t, d.Ingest([]string{"ext"}))
 			}
 
 			compact := func(start, end string) {
 				t.Helper()
-				if err := d.Compact([]byte(start), []byte(end)); err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, d.Compact([]byte(start), []byte(end)))
 			}
 
 			lsm := func() string {
@@ -828,19 +763,13 @@ func TestIngestFlushQueuedMemTable(t *testing.T) {
 	d, err := Open("", &Options{
 		FS: mem,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Add the key "a" to the memtable, then fill up the memtable with the key
 	// "b". The ingested sstable will only overlap with the queued memtable.
-	if err := d.Set([]byte("a"), nil, nil); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, d.Set([]byte("a"), nil, nil))
 	for {
-		if err := d.Set([]byte("b"), nil, nil); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, d.Set([]byte("b"), nil, nil))
 		d.mu.Lock()
 		done := len(d.mu.mem.queue) == 2
 		d.mu.Unlock()
@@ -852,21 +781,14 @@ func TestIngestFlushQueuedMemTable(t *testing.T) {
 	ingest := func(keys ...string) {
 		t.Helper()
 		f, err := mem.Create("ext")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		w := sstable.NewWriter(f, sstable.WriterOptions{})
 		for _, k := range keys {
-			if err := w.Set([]byte(k), nil); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, w.Set([]byte(k), nil))
 		}
-		if err := w.Close(); err != nil {
-			t.Fatal(err)
-		}
-		if err := d.Ingest([]string{"ext"}); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, w.Close())
+		require.NoError(t, d.Ingest([]string{"ext"}))
 	}
 
 	ingest("a")
@@ -881,9 +803,7 @@ func TestIngestFlushQueuedLargeBatch(t *testing.T) {
 	d, err := Open("", &Options{
 		FS: mem,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// The default large batch threshold is slightly less than 1/2 of the
 	// memtable size which makes triggering a problem with flushing queued large
@@ -896,28 +816,19 @@ func TestIngestFlushQueuedLargeBatch(t *testing.T) {
 
 	// Set a record with a large value. This will be transformed into a large
 	// batch and placed in the flushable queue.
-	if err := d.Set([]byte("a"), bytes.Repeat([]byte("v"), d.largeBatchThreshold), nil); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, d.Set([]byte("a"), bytes.Repeat([]byte("v"), d.largeBatchThreshold), nil))
 
 	ingest := func(keys ...string) {
 		t.Helper()
 		f, err := mem.Create("ext")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		w := sstable.NewWriter(f, sstable.WriterOptions{})
 		for _, k := range keys {
-			if err := w.Set([]byte(k), nil); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, w.Set([]byte(k), nil))
 		}
-		if err := w.Close(); err != nil {
-			t.Fatal(err)
-		}
-		if err := d.Ingest([]string{"ext"}); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, w.Close())
+		require.NoError(t, d.Ingest([]string{"ext"}))
 	}
 
 	ingest("a")

--- a/internal/arenaskl/skl_test.go
+++ b/internal/arenaskl/skl_test.go
@@ -633,10 +633,7 @@ func TestIteratorSeekLT(t *testing.T) {
 func TestIteratorBounds(t *testing.T) {
 	l := NewSkiplist(newArena(arenaSize), bytes.Compare)
 	for i := 1; i < 10; i++ {
-		err := l.Add(makeIntKey(i), makeValue(i))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, l.Add(makeIntKey(i), makeValue(i)))
 	}
 
 	key := func(i int) []byte {

--- a/internal/batchskl/skl_test.go
+++ b/internal/batchskl/skl_test.go
@@ -357,10 +357,7 @@ func TestIteratorBounds(t *testing.T) {
 	d := &testStorage{}
 	l := newTestSkiplist(d)
 	for i := 1; i < 10; i++ {
-		err := l.Add(d.add(fmt.Sprintf("%05d", i)))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, l.Add(d.add(fmt.Sprintf("%05d", i))))
 	}
 
 	it := iterAdapter{l.NewIter(makeKey("00003"), makeKey("00007"))}

--- a/internal/cache/clockpro_test.go
+++ b/internal/cache/clockpro_test.go
@@ -19,9 +19,7 @@ import (
 func TestCache(t *testing.T) {
 	// Test data was generated from the python code
 	f, err := os.Open("testdata/cache")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	cache := newShards(200, 1)
 	defer cache.Unref()
@@ -33,9 +31,8 @@ func TestCache(t *testing.T) {
 		fields := bytes.Fields(scanner.Bytes())
 
 		key, err := strconv.Atoi(string(fields[0]))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		wantHit := fields[1][0] == 'h'
 
 		var hit bool

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -12,11 +12,10 @@ import (
 	"testing"
 
 	"github.com/ghemawat/stream"
+	"github.com/stretchr/testify/require"
 )
 
-func dirCmd(
-	t *testing.T, dir string, name string, args ...string,
-) stream.Filter {
+func dirCmd(t *testing.T, dir string, name string, args ...string) stream.Filter {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
@@ -25,7 +24,7 @@ func dirCmd(
 	case *exec.ExitError:
 		// Non-zero exit is expected.
 	default:
-		t.Fatal(err)
+		require.NoError(t, err)
 	}
 	return stream.ReadLines(bytes.NewReader(out))
 }
@@ -42,9 +41,7 @@ func TestLint(t *testing.T) {
 	const root = "github.com/cockroachdb/pebble"
 
 	pkg, err := build.Import(root, "../..", 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var pkgs []string
 	if err := stream.ForEach(
@@ -54,7 +51,7 @@ func TestLint(t *testing.T) {
 		), func(s string) {
 			pkgs = append(pkgs, s)
 		}); err != nil {
-		t.Fatal(err)
+		require.NoError(t, err)
 	}
 
 	t.Run("TestGolint", func(t *testing.T) {

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/cockroachdb/pebble/internal/record"
 	"github.com/kr/pretty"
+	"github.com/stretchr/testify/require"
 )
 
 func checkRoundTrip(e0 VersionEdit) error {
@@ -214,9 +215,7 @@ func TestVersionEditEncodeLastSeqNum(t *testing.T) {
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
 			var buf bytes.Buffer
-			if err := c.edit.Encode(&buf); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, c.edit.Encode(&buf))
 			if result := buf.String(); c.encoded != result {
 				t.Fatalf("expected %x, but found %x", c.encoded, result)
 			}
@@ -228,32 +227,24 @@ func TestVersionEditEncodeLastSeqNum(t *testing.T) {
 
 				// Decode ComparerName.
 				tag, err := d.readUvarint()
-				if err != nil {
-					t.Fatal()
-				}
+				require.NoError(t, err)
 				if tag != tagComparator {
 					t.Fatalf("expected %d, but found %d", tagComparator, tag)
 				}
 				s, err := d.readBytes()
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				if c.edit.ComparerName != string(s) {
 					t.Fatalf("expected %q, but found %q", c.edit.ComparerName, s)
 				}
 
 				// Decode LastSeqNum.
 				tag, err = d.readUvarint()
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				if tag != tagLastSequence {
 					t.Fatalf("expected %d, but found %d", tagLastSequence, tag)
 				}
 				val, err := d.readUvarint()
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				if c.edit.LastSeqNum != val {
 					t.Fatalf("expected %d, but found %d", c.edit.LastSeqNum, val)
 				}

--- a/internal/randvar/skewed_latest_test.go
+++ b/internal/randvar/skewed_latest_test.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func dumpSamples(x []int) {
@@ -52,9 +54,7 @@ func dumpSamples(x []int) {
 
 func TestSkewedLatest(t *testing.T) {
 	z, err := NewSkewedLatest(nil, 0, 99, 0.99)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	x := make([]int, 10000)
 	for i := range x {

--- a/internal/randvar/zipf_test.go
+++ b/internal/randvar/zipf_test.go
@@ -18,6 +18,8 @@ package randvar
 import (
 	"math"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestZeta(t *testing.T) {
@@ -74,18 +76,15 @@ func TestZeta(t *testing.T) {
 func TestZetaIncMax(t *testing.T) {
 	// Construct a zipf generator covering the range [0,10] incrementally.
 	z0, err := NewZipf(nil, 0, 0, 0.99)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	for i := 0; i < 10; i++ {
 		z0.IncMax(1)
 	}
 
 	// Contruct a zipf generator covering the range [0,10] via the constructor.
 	z10, err := NewZipf(nil, 0, 10, 0.99)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	z0.mu.Lock()
 	defer z0.mu.Unlock()
@@ -110,17 +109,13 @@ func TestNewZipf(t *testing.T) {
 
 	for _, gen := range gens {
 		_, err := NewZipf(nil, gen.min, gen.max, gen.theta)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	}
 }
 
 func TestZipf(t *testing.T) {
 	z, err := NewZipf(nil, 0, 99, 0.99)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	x := make([]int, 10000)
 	for i := range x {

--- a/internal/rangedel/fragmenter_test.go
+++ b/internal/rangedel/fragmenter_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/stretchr/testify/require"
 )
 
 var tombstoneRe = regexp.MustCompile(`(\d+):\s*(\w+)-*(\w+)`)
@@ -24,9 +25,7 @@ func parseTombstone(t *testing.T, s string) Tombstone {
 		t.Fatalf("expected 4 components, but found %d: %s", len(m), s)
 	}
 	seqNum, err := strconv.Atoi(m[1])
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return Tombstone{
 		Start: base.MakeInternalKey([]byte(m[2]), uint64(seqNum), base.InternalKeyKindRangeDelete),
 		End:   []byte(m[3]),
@@ -97,9 +96,7 @@ func TestFragmenter(t *testing.T) {
 			t.Fatalf("expected 3 components, but found %d", len(m))
 		}
 		seq, err := strconv.Atoi(m[2])
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		return m[1], seq
 	}
 
@@ -137,9 +134,7 @@ func TestFragmenter(t *testing.T) {
 				return fmt.Sprintf("expected timestamp argument, but found %s", d.CmdArgs[0])
 			}
 			readSeq, err := strconv.Atoi(d.CmdArgs[0].Vals[0])
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			var results []string
 			for _, p := range strings.Split(d.Input, " ") {

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -210,8 +210,8 @@ func (f *fakeIter) SetBounds(lower, upper []byte) {
 // invalidatingIter tests unsafe key/value slice reuse by modifying the last
 // returned key/value to all 1s.
 type invalidatingIter struct {
-	iter internalIterator
-	lastKey *InternalKey
+	iter      internalIterator
+	lastKey   *InternalKey
 	lastValue []byte
 }
 
@@ -286,7 +286,6 @@ func (i *invalidatingIter) SetBounds(lower, upper []byte) {
 func (i *invalidatingIter) String() string {
 	return i.iter.String()
 }
-
 
 // testIterator tests creating a combined iterator from a number of sub-
 // iterators. newFunc is a constructor function. splitFunc returns a random
@@ -585,16 +584,12 @@ func TestIteratorNextPrev(t *testing.T) {
 		}
 
 		mem = vfs.NewMem()
-		err := mem.MkdirAll("ext", 0755)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, mem.MkdirAll("ext", 0755))
+		var err error
 		d, err = Open("", &Options{
 			FS: mem,
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	}
 	reset()
 

--- a/log_recycler_test.go
+++ b/log_recycler_test.go
@@ -83,9 +83,7 @@ func TestRecycleLogs(t *testing.T) {
 	d, err := Open("", &Options{
 		FS: mem,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	logNum := func() uint64 {
 		d.mu.Lock()
@@ -103,29 +101,21 @@ func TestRecycleLogs(t *testing.T) {
 	require.EqualValues(t, []uint64(nil), d.logRecycler.logNums())
 	curLog := logNum()
 
-	if err := d.Flush(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, d.Flush())
 
 	require.EqualValues(t, []uint64{curLog}, d.logRecycler.logNums())
 	curLog = logNum()
 
-	if err := d.Flush(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, d.Flush())
 
 	require.EqualValues(t, []uint64{curLog}, d.logRecycler.logNums())
 
-	if err := d.Close(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, d.Close())
 
 	d, err = Open("", &Options{
 		FS: mem,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	metrics := d.Metrics()
 	if n := logCount(); n != int(metrics.WAL.Files) {
 		t.Fatalf("expected %d WAL files, but found %d", n, metrics.WAL.Files)
@@ -136,7 +126,5 @@ func TestRecycleLogs(t *testing.T) {
 	if recycled := d.logRecycler.logNums(); len(recycled) != 0 {
 		t.Fatalf("expected no recycled WAL files after recovery, but found %d", recycled)
 	}
-	if err := d.Close(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, d.Close())
 }

--- a/mem_table_test.go
+++ b/mem_table_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/arenaskl"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
 )
 
@@ -126,9 +127,7 @@ func TestMemTableCount(t *testing.T) {
 		}
 		m.set(InternalKey{UserKey: []byte{byte(i)}}, nil)
 	}
-	if err := m.close(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, m.close())
 }
 
 func TestMemTableBytesIterated(t *testing.T) {
@@ -141,9 +140,7 @@ func TestMemTableBytesIterated(t *testing.T) {
 		}
 		m.set(InternalKey{UserKey: []byte{byte(i)}}, nil)
 	}
-	if err := m.close(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, m.close())
 }
 
 func TestMemTableEmpty(t *testing.T) {
@@ -177,9 +174,7 @@ func TestMemTable1000Entries(t *testing.T) {
 		j := r.Intn(N)
 		k := []byte(strconv.Itoa(j))
 		v, err := m0.get(k)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		if len(v) != cap(v) {
 			t.Fatalf("get: j=%d, got len(v)=%d, cap(v)=%d", j, len(v), cap(v))
 		}
@@ -354,9 +349,7 @@ func TestMemTableConcurrentDeleteRange(t *testing.T) {
 				b := newBatch(nil)
 				b.DeleteRange(start, end, nil)
 				n := atomic.AddUint64(&seqNum, 1) - 1
-				if err := m.apply(b, n); err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, m.apply(b, n))
 				b.release()
 
 				var count int

--- a/open_test.go
+++ b/open_test.go
@@ -67,24 +67,16 @@ func TestErrorIfNotExists(t *testing.T) {
 		FS:               mem,
 		ErrorIfNotExists: false,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := d.Close(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	require.NoError(t, d.Close())
 
 	// The DB exists, so the setting of ErrorIfNotExists is a no-op.
 	d, err = Open("", &Options{
 		FS:               mem,
 		ErrorIfNotExists: true,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := d.Close(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	require.NoError(t, d.Close())
 }
 
 func TestNewDBFilenames(t *testing.T) {
@@ -220,9 +212,7 @@ func TestOpenCloseOpenClose(t *testing.T) {
 			case "disk":
 				var err error
 				dir, err = ioutil.TempDir("", "open-close")
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				defer func() {
 					_ = os.RemoveAll(dir)
 				}()
@@ -241,12 +231,8 @@ func TestOpenOptionsCheck(t *testing.T) {
 	opts := &Options{FS: mem}
 
 	d, err := Open("", opts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := d.Close(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	require.NoError(t, d.Close())
 
 	opts = &Options{
 		Comparer: &Comparer{Name: "foo"},
@@ -322,9 +308,7 @@ func TestOpenReadOnly(t *testing.T) {
 			FS:       mem,
 			ReadOnly: true,
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// Verify various write operations fail in read-only mode.
 		require.EqualValues(t, ErrReadOnly, d.Compact(nil, nil))
@@ -446,9 +430,8 @@ func TestOpenWALReplay(t *testing.T) {
 				MemTableSize: 300 << 10,
 				ReadOnly:     readOnly,
 			})
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+
 			if readOnly {
 				d.mu.Lock()
 				require.Equal(t, 10, len(d.mu.mem.queue))
@@ -514,9 +497,7 @@ func TestOpenWALReplay2(t *testing.T) {
 						MemTableSize: 300 << 10,
 						ReadOnly:     readOnly,
 					})
-					if err != nil {
-						t.Fatal(err)
-					}
+					require.NoError(t, err)
 					require.NoError(t, d.Close())
 				})
 			}
@@ -550,7 +531,7 @@ func TestOpenWALReplayMemtableGrowth(t *testing.T) {
 func TestGetVersion(t *testing.T) {
 	mem := vfs.NewMem()
 	opts := &Options{
-		FS:           mem,
+		FS: mem,
 	}
 
 	// Case 1: No options file.

--- a/options_test.go
+++ b/options_test.go
@@ -183,9 +183,7 @@ func TestOptionsParse(t *testing.T) {
 			str := opts.String()
 
 			var parsedOptions Options
-			if err := parsedOptions.Parse(str, hooks); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, parsedOptions.Parse(str, hooks))
 			parsedStr := parsedOptions.String()
 			if str != parsedStr {
 				t.Fatalf("expected\n%s\nbut found\n%s", str, parsedStr)
@@ -228,9 +226,7 @@ func TestOptionsValidate(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			var opts Options
 			opts.EnsureDefaults()
-			if err := opts.Parse(c.options, nil); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, opts.Parse(c.options, nil))
 			err := opts.Validate()
 			if c.expected == "" {
 				if err != nil {

--- a/options_test.go
+++ b/options_test.go
@@ -6,7 +6,6 @@ package pebble
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/cockroachdb/pebble/internal/base"
@@ -229,18 +228,10 @@ func TestOptionsValidate(t *testing.T) {
 			require.NoError(t, opts.Parse(c.options, nil))
 			err := opts.Validate()
 			if c.expected == "" {
-				if err != nil {
-					t.Fatalf("expected success, but found %v", err)
-				}
+				require.NoError(t, err)
 			} else {
-				if err == nil {
-					t.Fatalf("expected %q, but found success\n%s", c.expected, opts.String())
-				}
-				if ok, merr := regexp.MatchString(c.expected, err.Error()); merr != nil {
-					t.Fatal(merr)
-				} else if !ok {
-					t.Fatalf("expected %q, but found %v", c.expected, err)
-				}
+				require.Error(t, err)
+				require.Regexp(t, c.expected, err.Error())
 			}
 		})
 	}

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -183,9 +183,7 @@ func TestSnapshotClosed(t *testing.T) {
 	d, err := Open("", &Options{
 		FS: vfs.NewMem(),
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	catch := func(f func()) (err error) {
 		defer func() {
@@ -198,9 +196,7 @@ func TestSnapshotClosed(t *testing.T) {
 	}
 
 	snap := d.NewSnapshot()
-	if err := snap.Close(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, snap.Close())
 	require.EqualValues(t, ErrClosed, catch(func() { _ = snap.Close() }))
 	require.EqualValues(t, ErrClosed, catch(func() { _, _, _ = snap.Get(nil) }))
 	require.EqualValues(t, ErrClosed, catch(func() { snap.NewIter(nil) }))

--- a/sstable/block_test.go
+++ b/sstable/block_test.go
@@ -85,9 +85,7 @@ func TestBlockIter(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		i, err := newRawBlockIter(bytes.Compare, k)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		i.SeekGE([]byte(tc.key))
 		for j, keyWant := range []string{"apple", "apricot", "banana"}[tc.index:] {
 			if !i.Valid() {
@@ -108,9 +106,7 @@ func TestBlockIter(t *testing.T) {
 
 	{
 		i, err := newRawBlockIter(bytes.Compare, k)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		i.Last()
 		for j, keyWant := range []string{"banana", "apricot", "apple"} {
 			if !i.Valid() {
@@ -234,9 +230,7 @@ func TestBlockIterKeyStability(t *testing.T) {
 	block := w.finish()
 
 	i, err := newBlockIter(bytes.Compare, block)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Check that the supplied slice resides within the bounds of the block.
 	check := func(v []byte) {
@@ -296,9 +290,7 @@ func TestBlockIterReverseDirections(t *testing.T) {
 	for targetPos := 0; targetPos < w.restartInterval; targetPos++ {
 		t.Run("", func(t *testing.T) {
 			i, err := newBlockIter(bytes.Compare, block)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			pos := 3
 			if key, _ := i.SeekLT([]byte("carrot")); !bytes.Equal(keys[pos], key.UserKey) {

--- a/sstable/properties_test.go
+++ b/sstable/properties_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/kr/pretty"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPropertiesLoad(t *testing.T) {
@@ -45,13 +46,10 @@ func TestPropertiesLoad(t *testing.T) {
 	{
 		// Check that we can read properties from a table.
 		f, err := os.Open(filepath.FromSlash("testdata/h.sst"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		r, err := NewReader(f, ReaderOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer r.Close()
 
 		r.Properties.Loaded = nil
@@ -107,9 +105,7 @@ func TestPropertiesSave(t *testing.T) {
 		w.restartInterval = propertiesBlockRestartInterval
 		expected.save(&w)
 		var props Properties
-		if err := props.load(w.finish(), 0); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, props.load(w.finish(), 0))
 		props.Loaded = nil
 		if diff := pretty.Diff(*expected, props); diff != nil {
 			t.Fatalf("%s", strings.Join(diff, "\n"))

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
 )
 
@@ -163,14 +164,10 @@ func TestHamletReader(t *testing.T) {
 
 	for _, prebuiltSST := range prebuiltSSTs {
 		f, err := os.Open(filepath.FromSlash(prebuiltSST))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		r, err := NewReader(f, ReaderOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		t.Run(
 			fmt.Sprintf("sst=%s", prebuiltSST),
@@ -261,16 +258,11 @@ func TestReaderCheckComparerMerger(t *testing.T) {
 
 	mem := vfs.NewMem()
 	f0, err := mem.Create(testTable)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	w := NewWriter(f0, writerOpts)
-	if err := w.Set([]byte("test"), nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, w.Set([]byte("test"), nil))
+	require.NoError(t, w.Close())
 
 	testCases := []struct {
 		comparers []*base.Comparer
@@ -312,9 +304,8 @@ func TestReaderCheckComparerMerger(t *testing.T) {
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
 			f1, err := mem.Open(testTable)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+
 			comparers := make(Comparers)
 			for _, comparer := range c.comparers {
 				comparers[comparer.Name] = comparer
@@ -366,12 +357,8 @@ func TestBytesIteratedCompressed(t *testing.T) {
 					t.Fatalf("bytesIterated: got %d, want %d", bytesIterated, expected)
 				}
 
-				if err := citer.Close(); err != nil {
-					t.Fatal(err)
-				}
-				if err := r.Close(); err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, citer.Close())
+				require.NoError(t, r.Close())
 			}
 		}
 	}
@@ -399,12 +386,8 @@ func TestBytesIteratedUncompressed(t *testing.T) {
 						bytesIterated, expected, blockSize, indexBlockSize, numEntries)
 				}
 
-				if err := citer.Close(); err != nil {
-					t.Fatal(err)
-				}
-				if err := r.Close(); err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, citer.Close())
+				require.NoError(t, r.Close())
 			}
 		}
 	}
@@ -415,9 +398,7 @@ func buildTestTable(
 ) *Reader {
 	mem := vfs.NewMem()
 	f0, err := mem.Create("test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	w := NewWriter(f0, WriterOptions{
 		BlockSize:      blockSize,
@@ -435,23 +416,18 @@ func buildTestTable(
 		w.Add(ikey, value)
 	}
 
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, w.Close())
 
 	// Re-open that filename for reading.
 	f1, err := mem.Open("test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	c := cache.New(128 << 20)
 	defer c.Unref()
 	r, err := NewReader(f1, ReaderOptions{
 		Cache: c,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return r
 }
 

--- a/sstable/writer_fixture_test.go
+++ b/sstable/writer_fixture_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -174,9 +175,7 @@ func runTestFixtureOutput(opts fixtureOpts) error {
 func TestFixtureOutput(t *testing.T) {
 	for opt := range fixtures {
 		t.Run(opt.String(), func(t *testing.T) {
-			if err := runTestFixtureOutput(opt); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, runTestFixtureOutput(opt))
 		})
 	}
 }

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -117,17 +117,11 @@ func TestWriterClearCache(t *testing.T) {
 
 	build := func(name string) {
 		f, err := mem.Create(name)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		w := NewWriter(f, writerOpts, cacheOpts)
-		if err := w.Set([]byte("hello"), []byte("world")); err != nil {
-			t.Fatal(err)
-		}
-		if err := w.Close(); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, w.Set([]byte("hello"), []byte("world")))
+		require.NoError(t, w.Close())
 	}
 
 	// Build the sstable a first time so that we can determine the locations of
@@ -135,17 +129,13 @@ func TestWriterClearCache(t *testing.T) {
 	build("test")
 
 	f, err := mem.Open("test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	r, err := NewReader(f, opts)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	layout, err := r.Layout()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	foreachBH := func(layout *Layout, f func(bh BlockHandle)) {
 		for _, bh := range layout.Data {

--- a/tool/data_test.go
+++ b/tool/data_test.go
@@ -17,13 +17,13 @@ import (
 	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
 )
 
 func runTests(t *testing.T, path string) {
 	paths, err := filepath.Glob(path)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	root := filepath.Dir(path)
 	for {
 		next := filepath.Dir(root)
@@ -42,9 +42,8 @@ func runTests(t *testing.T, path string) {
 
 	for _, path := range paths {
 		name, err := filepath.Rel(root, path)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		t.Run(name, func(t *testing.T) {
 			datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
 				args := []string{d.Cmd}

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -54,8 +54,7 @@ func TestVersionSetCheckpoint(t *testing.T) {
 	require.NoError(t, d.Close())
 }
 
-
-func TestVersionSetSeqNums(t *testing.T)  {
+func TestVersionSetSeqNums(t *testing.T) {
 	mem := vfs.NewMem()
 	require.NoError(t, mem.MkdirAll("ext", 0755))
 
@@ -70,6 +69,7 @@ func TestVersionSetSeqNums(t *testing.T)  {
 	writeAndIngest(t, mem, d, base.MakeInternalKey([]byte("c"), 0, InternalKeyKindSet), []byte("d"), "c")
 	require.NoError(t, d.Close())
 	d, err = Open("", opts)
+	require.NoError(t, err)
 	defer d.Close()
 
 	// Check that the manifest has the correct LastSeqNum, equalling the highest
@@ -103,5 +103,5 @@ func TestVersionSetSeqNums(t *testing.T)  {
 	// 2 ingestions happened, so LastSeqNum should equal 2.
 	require.Equal(t, uint64(2), lastSeqNum)
 	// logSeqNum is always one greater than the last assigned sequence number.
-	require.Equal(t, d.mu.versions.logSeqNum, lastSeqNum + 1)
+	require.Equal(t, d.mu.versions.logSeqNum, lastSeqNum+1)
 }

--- a/vfs/file_lock_test.go
+++ b/vfs/file_lock_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
 )
 
 var lockFilename = flag.String("lockfile", "", "File to lock. A non-empty value implies a child process.")
@@ -33,15 +34,12 @@ func TestLock(t *testing.T) {
 		filename = *lockFilename
 	} else {
 		f, err := ioutil.TempFile("", "golang-pebble-db-testlock-")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		filename = f.Name()
 		// NB: On Windows, locking will fail if the file is already open by the
 		// current process, so we close the lockfile here.
-		if err := f.Close(); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, f.Close())
 		defer os.Remove(filename)
 	}
 

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/stretchr/testify/require"
 )
 
 func normalizeError(err error) error {
@@ -229,9 +230,7 @@ func TestVFS(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Run("disk", func(t *testing.T) {
 			dir, err := ioutil.TempDir("", "test-vfs")
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			defer func() {
 				_ = os.RemoveAll(dir)
 			}()


### PR DESCRIPTION
Replace the `if err != nil { t.Fatal(err) }` boilerplate with
`require.NoError(t, err)`. This makes for somewhat better readability in 
tests.