### PR TITLE
*: use Go 1.13 error wrapping

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -725,7 +725,7 @@ func (c *compaction) newInputIter(newIters tableNewIters) (_ internalIterator, r
 			f := c.inputs[0][i]
 			iter, rangeDelIter, err := newIters(f, nil /* iter options */, &c.bytesIterated)
 			if err != nil {
-				return nil, fmt.Errorf("pebble: could not open table %d: %v", f.FileNum, err)
+				return nil, fmt.Errorf("pebble: could not open table %d: %w", f.FileNum, err)
 			}
 			iters = append(iters, iter)
 			if rangeDelIter != nil {

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -370,7 +370,7 @@ func (v *Version) Overlaps(level int, cmp Compare, start, end []byte) (ret []*Fi
 func (v *Version) CheckOrdering(cmp Compare, format base.Formatter) error {
 	for level, files := range v.Files {
 		if err := CheckOrdering(cmp, format, level, files); err != nil {
-			return fmt.Errorf("%s\n%s", err, v.DebugString(format))
+			return fmt.Errorf("%w\n%s", err, v.DebugString(format))
 		}
 	}
 	return nil

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -539,7 +539,7 @@ func (b *BulkVersionEdit) Apply(
 			}
 			SortBySeqNum(v.Files[level])
 			if err := CheckOrdering(cmp, format, 0, v.Files[level]); err != nil {
-				return nil, nil, fmt.Errorf("pebble: internal error: %v", err)
+				return nil, nil, fmt.Errorf("pebble: internal error: %w", err)
 			}
 			continue
 		}

--- a/internal/record/log_writer.go
+++ b/internal/record/log_writer.go
@@ -446,7 +446,7 @@ func (w *LogWriter) flushPending(
 		// the stack that created the panic if panic'ing itself hits a panic
 		// (e.g. unlock of unlocked mutex).
 		if r := recover(); r != nil {
-			err = fmt.Errorf("%v\n%s", err, debug.Stack())
+			err = fmt.Errorf("%w\n%s", err, debug.Stack())
 		}
 	}()
 

--- a/level_checker.go
+++ b/level_checker.go
@@ -175,7 +175,7 @@ func (m *simpleMergingIter) step() bool {
 			m.valueMerger, m.err = m.merge(item.key.UserKey, item.value)
 		}
 		if m.err != nil {
-			m.err = fmt.Errorf("merge processing error on key %s in %s: %v",
+			m.err = fmt.Errorf("merge processing error on key %s in %s: %w",
 				item.key.Pretty(m.format), l.iter, m.err)
 			return false
 		}
@@ -238,7 +238,7 @@ func (m *simpleMergingIter) step() bool {
 		if m.valueMerger != nil {
 			_, m.err = m.valueMerger.Finish()
 			if m.err != nil {
-				m.err = fmt.Errorf("merge processing error on key %s in %s: %v",
+				m.err = fmt.Errorf("merge processing error on key %s in %s: %w",
 					item.key.Pretty(m.format), lastRecordMsg, m.err)
 			}
 			m.valueMerger = nil

--- a/open.go
+++ b/open.go
@@ -172,7 +172,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 			return nil, err
 		}
 	} else if err != nil {
-		return nil, fmt.Errorf("pebble: database %q: %v", dirname, err)
+		return nil, fmt.Errorf("pebble: database %q: %w", dirname, err)
 	} else if opts.ErrorIfExists {
 		return nil, fmt.Errorf("pebble: database %q already exists", dirname)
 	} else {

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -199,7 +199,7 @@ func readFooter(f vfs.File) (footer, error) {
 	var footer footer
 	stat, err := f.Stat()
 	if err != nil {
-		return footer, fmt.Errorf("pebble/table: invalid table (could not stat file): %v", err)
+		return footer, fmt.Errorf("pebble/table: invalid table (could not stat file): %w", err)
 	}
 	if stat.Size() < minFooterLen {
 		return footer, errors.New("pebble/table: invalid table (file size is too small)")
@@ -212,7 +212,7 @@ func readFooter(f vfs.File) (footer, error) {
 	}
 	n, err := f.ReadAt(buf, off)
 	if err != nil && err != io.EOF {
-		return footer, fmt.Errorf("pebble/table: invalid table (could not read footer): %v", err)
+		return footer, fmt.Errorf("pebble/table: invalid table (could not read footer): %w", err)
 	}
 	buf = buf[:n]
 

--- a/version_set.go
+++ b/version_set.go
@@ -155,7 +155,7 @@ func (vs *versionSet) load(dirname string, opts *Options, mu *sync.Mutex) error 
 	// Read the CURRENT file to find the current manifest file.
 	current, err := vs.fs.Open(base.MakeFilename(vs.fs, dirname, fileTypeCurrent, 0))
 	if err != nil {
-		return fmt.Errorf("pebble: could not open CURRENT file for DB %q: %v", dirname, err)
+		return fmt.Errorf("pebble: could not open CURRENT file for DB %q: %w", dirname, err)
 	}
 	defer current.Close()
 	stat, err := current.Stat()
@@ -188,7 +188,7 @@ func (vs *versionSet) load(dirname string, opts *Options, mu *sync.Mutex) error 
 	var bve bulkVersionEdit
 	manifest, err := vs.fs.Open(vs.fs.PathJoin(dirname, string(b)))
 	if err != nil {
-		return fmt.Errorf("pebble: could not open manifest file %q for DB %q: %v", b, dirname, err)
+		return fmt.Errorf("pebble: could not open manifest file %q for DB %q: %w", b, dirname, err)
 	}
 	defer manifest.Close()
 	rr := record.NewReader(manifest, 0 /* logNum */)


### PR DESCRIPTION
Go 1.13 introduced a new format string verb `%w`. This verb is used
with fmt.Errorf to wrap the old error, avoiding erasing the original
error when adding context.

This will be useful for #438, allowing us to retry only injected
errors by checking the root error through `errors.Is`.

https://blog.golang.org/go1.13-errors