### PR TITLE
*: add FileNum type

### DIFF
--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -329,9 +329,9 @@ func TestCompactionPickerIntraL0(t *testing.T) {
 			t.Fatalf("malformed table spec: %s", s)
 		}
 		m := &fileMetadata{}
-		var err error
-		m.FileNum, err = strconv.ParseUint(s[:index], 10, 64)
+		fn, err := strconv.ParseUint(s[:index], 10, 64)
 		require.NoError(t, err)
+		m.FileNum = FileNum(fn)
 
 		fields := strings.Fields(s[index+1:])
 		if len(fields) != 2 && len(fields) != 3 {

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1228,7 +1228,7 @@ func TestCompactionSetupInputs(t *testing.T) {
 					maxExpandedBytes: 1 << 30,
 				}
 				var files *[]*fileMetadata
-				fileNum := uint64(1)
+				fileNum := FileNum(1)
 
 				for _, data := range strings.Split(d.Input, "\n") {
 					switch data {
@@ -1317,7 +1317,7 @@ func TestCompactionExpandInputs(t *testing.T) {
 				}
 				for _, data := range strings.Split(d.Input, "\n") {
 					meta := parseMeta(data)
-					meta.FileNum = uint64(len(files))
+					meta.FileNum = FileNum(len(files))
 					files = append(files, meta)
 				}
 				manifest.SortBySmallest(files, cmp)
@@ -1378,7 +1378,7 @@ func TestCompactionAtomicUnitBounds(t *testing.T) {
 				}
 				for _, data := range strings.Split(d.Input, "\n") {
 					meta := parseMeta(data)
-					meta.FileNum = uint64(len(files))
+					meta.FileNum = FileNum(len(files))
 					files = append(files, meta)
 				}
 				manifest.SortBySmallest(files, cmp)
@@ -1431,7 +1431,7 @@ func TestCompactionInuseKeyRanges(t *testing.T) {
 				version: &version{},
 			}
 			var files *[]*fileMetadata
-			fileNum := uint64(1)
+			fileNum := FileNum(1)
 
 			for _, data := range strings.Split(td.Input, "\n") {
 				switch data {
@@ -1626,7 +1626,7 @@ func TestCompactionCheckOrdering(t *testing.T) {
 					outputLevel: -1,
 				}
 				var files *[]*fileMetadata
-				fileNum := uint64(1)
+				fileNum := FileNum(1)
 
 				for _, data := range strings.Split(d.Input, "\n") {
 					switch data {

--- a/db.go
+++ b/db.go
@@ -171,7 +171,7 @@ type DB struct {
 	// inserted into a memtable.
 	largeBatchThreshold int
 	// The current OPTIONS file number.
-	optionsFileNum uint64
+	optionsFileNum FileNum
 
 	fileLock io.Closer
 	dataDir  vfs.File
@@ -244,7 +244,7 @@ type DB struct {
 			// flushed logs will be a prefix, the unflushed logs a suffix. The
 			// delimeter between flushed and unflushed logs is
 			// versionSet.minUnflushedLogNum.
-			queue []uint64
+			queue []FileNum
 			// The size of the current log file (i.e. queue[len(queue)-1].
 			size uint64
 			// The number of input bytes to the log. This is the raw size of the
@@ -1145,7 +1145,7 @@ func (d *DB) walPreallocateSize() int {
 	return size
 }
 
-func (d *DB) newMemTable(logNum, logSeqNum uint64) (*memTable, *flushableEntry) {
+func (d *DB) newMemTable(logNum FileNum, logSeqNum uint64) (*memTable, *flushableEntry) {
 	size := d.mu.mem.nextSize
 	if d.mu.mem.nextSize < d.opts.MemTableSize {
 		d.mu.mem.nextSize *= 2
@@ -1178,7 +1178,7 @@ func (d *DB) newMemTable(logNum, logSeqNum uint64) (*memTable, *flushableEntry) 
 	return mem, entry
 }
 
-func (d *DB) newFlushableEntry(f flushable, logNum, logSeqNum uint64) *flushableEntry {
+func (d *DB) newFlushableEntry(f flushable, logNum FileNum, logSeqNum uint64) *flushableEntry {
 	return &flushableEntry{
 		flushable:  f,
 		flushed:    make(chan struct{}),
@@ -1252,7 +1252,7 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 			continue
 		}
 
-		var newLogNum uint64
+		var newLogNum FileNum
 		var newLogFile vfs.File
 		var prevLogSize uint64
 		var err error

--- a/db_test.go
+++ b/db_test.go
@@ -367,12 +367,12 @@ func TestLargeBatch(t *testing.T) {
 		}
 	}
 
-	logNum := func() uint64 {
+	logNum := func() FileNum {
 		d.mu.Lock()
 		defer d.mu.Unlock()
 		return d.mu.log.queue[len(d.mu.log.queue)-1]
 	}
-	fileSize := func(fileNum uint64) int64 {
+	fileSize := func(fileNum FileNum) int64 {
 		info, err := d.opts.FS.Stat(base.MakeFilename(d.opts.FS, "", fileTypeLog, fileNum))
 		require.NoError(t, err)
 		return info.Size()
@@ -399,12 +399,12 @@ func TestLargeBatch(t *testing.T) {
 	}
 	startLogEndSize := fileSize(startLogNum)
 	if startLogEndSize == startLogStartSize {
-		t.Fatalf("expected large batch to be written to %06d.log, but file size unchanged at %d",
+		t.Fatalf("expected large batch to be written to %s.log, but file size unchanged at %d",
 			startLogNum, startLogEndSize)
 	}
 	endLogSize := fileSize(endLogNum)
 	if endLogSize != 0 {
-		t.Fatalf("expected %06d.log to be empty, but found %d", endLogNum, endLogSize)
+		t.Fatalf("expected %s.log to be empty, but found %d", endLogNum, endLogSize)
 	}
 	if creationSeqNum := memTableCreationSeqNum(); creationSeqNum <= startSeqNum {
 		t.Fatalf("expected memTable.logSeqNum=%d > largeBatch.seqNum=%d", creationSeqNum, startSeqNum)
@@ -786,7 +786,7 @@ func TestRollManifest(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	manifestFileNumber := func() uint64 {
+	manifestFileNumber := func() FileNum {
 		d.mu.Lock()
 		defer d.mu.Unlock()
 		return d.mu.versions.manifestFileNum
@@ -817,7 +817,7 @@ func TestRollManifest(t *testing.T) {
 		}
 		lastManifestNum = num
 
-		expectedCurrent := fmt.Sprintf("MANIFEST-%06d\n", lastManifestNum)
+		expectedCurrent := fmt.Sprintf("MANIFEST-%s\n", lastManifestNum)
 		if v := current(); expectedCurrent != v {
 			t.Fatalf("expected %s, but found %s", expectedCurrent, v)
 		}
@@ -836,7 +836,7 @@ func TestRollManifest(t *testing.T) {
 			manifests = append(manifests, filename)
 		}
 	}
-	expected := []string{fmt.Sprintf("MANIFEST-%06d", lastManifestNum)}
+	expected := []string{fmt.Sprintf("MANIFEST-%s", lastManifestNum)}
 	require.EqualValues(t, expected, manifests)
 
 	require.NoError(t, d.Close())

--- a/event.go
+++ b/event.go
@@ -31,7 +31,7 @@ func formatFileNums(tables []TableInfo) string {
 		if i > 0 {
 			buf.WriteString(" ")
 		}
-		fmt.Fprintf(&buf, "%06d", tables[i].FileNum)
+		buf.WriteString(tables[i].FileNum.String())
 	}
 	return buf.String()
 }
@@ -128,7 +128,7 @@ type ManifestCreateInfo struct {
 	JobID int
 	Path  string
 	// The file number of the new Manifest.
-	FileNum uint64
+	FileNum FileNum
 	Err     error
 }
 
@@ -136,8 +136,7 @@ func (i ManifestCreateInfo) String() string {
 	if i.Err != nil {
 		return fmt.Sprintf("[JOB %d] MANIFEST create error: %s", i.JobID, i.Err)
 	}
-
-	return fmt.Sprintf("[JOB %d] MANIFEST created %06d", i.JobID, i.FileNum)
+	return fmt.Sprintf("[JOB %d] MANIFEST created %s", i.JobID, i.FileNum)
 }
 
 // ManifestDeleteInfo contains the info for a Manifest deletion event.
@@ -145,7 +144,7 @@ type ManifestDeleteInfo struct {
 	// JobID is the ID of the job the caused the Manifest to be deleted.
 	JobID   int
 	Path    string
-	FileNum uint64
+	FileNum FileNum
 	Err     error
 }
 
@@ -153,8 +152,7 @@ func (i ManifestDeleteInfo) String() string {
 	if i.Err != nil {
 		return fmt.Sprintf("[JOB %d] MANIFEST delete error: %s", i.JobID, i.Err)
 	}
-
-	return fmt.Sprintf("[JOB %d] MANIFEST deleted %06d", i.JobID, i.FileNum)
+	return fmt.Sprintf("[JOB %d] MANIFEST deleted %s", i.JobID, i.FileNum)
 }
 
 // TableCreateInfo contains the info for a table creation event.
@@ -164,27 +162,27 @@ type TableCreateInfo struct {
 	// "ingesting".
 	Reason  string
 	Path    string
-	FileNum uint64
+	FileNum FileNum
 }
 
 func (i TableCreateInfo) String() string {
-	return fmt.Sprintf("[JOB %d] %s: sstable created %06d", i.JobID, i.Reason, i.FileNum)
+	return fmt.Sprintf("[JOB %d] %s: sstable created %s", i.JobID, i.Reason, i.FileNum)
 }
 
 // TableDeleteInfo contains the info for a table deletion event.
 type TableDeleteInfo struct {
 	JobID   int
 	Path    string
-	FileNum uint64
+	FileNum FileNum
 	Err     error
 }
 
 func (i TableDeleteInfo) String() string {
 	if i.Err != nil {
-		return fmt.Sprintf("[JOB %d] sstable delete error %06d: %s",
+		return fmt.Sprintf("[JOB %d] sstable delete error %s: %s",
 			i.JobID, i.FileNum, i.Err)
 	}
-	return fmt.Sprintf("[JOB %d] sstable deleted %06d", i.JobID, i.FileNum)
+	return fmt.Sprintf("[JOB %d] sstable deleted %s", i.JobID, i.FileNum)
 }
 
 // TableIngestInfo contains the info for a table ingestion event.
@@ -213,7 +211,7 @@ func (i TableIngestInfo) String() string {
 		if j > 0 {
 			fmt.Fprintf(&buf, ",")
 		}
-		fmt.Fprintf(&buf, " L%d:%06d (%s)", t.Level, t.FileNum, humanize.Uint64(t.Size))
+		fmt.Fprintf(&buf, " L%d:%s (%s)", t.Level, t.FileNum, humanize.Uint64(t.Size))
 	}
 	return buf.String()
 }
@@ -224,10 +222,10 @@ type WALCreateInfo struct {
 	JobID int
 	Path  string
 	// The file number of the new WAL.
-	FileNum uint64
+	FileNum FileNum
 	// The file number of a previous WAL which was recycled to create this
 	// one. Zero if recycling did not take place.
-	RecycledFileNum uint64
+	RecycledFileNum FileNum
 	Err             error
 }
 
@@ -237,10 +235,10 @@ func (i WALCreateInfo) String() string {
 	}
 
 	if i.RecycledFileNum == 0 {
-		return fmt.Sprintf("[JOB %d] WAL created %06d", i.JobID, i.FileNum)
+		return fmt.Sprintf("[JOB %d] WAL created %s", i.JobID, i.FileNum)
 	}
 
-	return fmt.Sprintf("[JOB %d] WAL created %06d (recycled %06d)",
+	return fmt.Sprintf("[JOB %d] WAL created %s (recycled %s)",
 		i.JobID, i.FileNum, i.RecycledFileNum)
 }
 
@@ -249,7 +247,7 @@ type WALDeleteInfo struct {
 	// JobID is the ID of the job the caused the WAL to be deleted.
 	JobID   int
 	Path    string
-	FileNum uint64
+	FileNum FileNum
 	Err     error
 }
 
@@ -257,8 +255,7 @@ func (i WALDeleteInfo) String() string {
 	if i.Err != nil {
 		return fmt.Sprintf("[JOB %d] WAL delete error: %s", i.JobID, i.Err)
 	}
-
-	return fmt.Sprintf("[JOB %d] WAL deleted %06d", i.JobID, i.FileNum)
+	return fmt.Sprintf("[JOB %d] WAL deleted %s", i.JobID, i.FileNum)
 }
 
 // WriteStallBeginInfo contains the info for a write stall begin event.

--- a/filenames.go
+++ b/filenames.go
@@ -13,6 +13,9 @@ import (
 
 type fileType = base.FileType
 
+// FileNum is an identifier for a file within a database.
+type FileNum = base.FileNum
+
 const (
 	fileTypeLog      = base.FileTypeLog
 	fileTypeLock     = base.FileTypeLock
@@ -23,7 +26,7 @@ const (
 	fileTypeTemp     = base.FileTypeTemp
 )
 
-func setCurrentFile(dirname string, fs vfs.FS, fileNum uint64) error {
+func setCurrentFile(dirname string, fs vfs.FS, fileNum FileNum) error {
 	newFilename := base.MakeFilename(fs, dirname, fileTypeCurrent, fileNum)
 	oldFilename := base.MakeFilename(fs, dirname, fileTypeTemp, fileNum)
 	fs.Remove(oldFilename)
@@ -31,7 +34,7 @@ func setCurrentFile(dirname string, fs vfs.FS, fileNum uint64) error {
 	if err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintf(f, "MANIFEST-%06d\n", fileNum); err != nil {
+	if _, err := fmt.Fprintf(f, "MANIFEST-%s\n", fileNum); err != nil {
 		return err
 	}
 	if err := f.Sync(); err != nil {

--- a/flushable.go
+++ b/flushable.go
@@ -35,7 +35,7 @@ type flushableEntry struct {
 	flushForced bool
 	// logNum corresponds to the WAL that contains the records present in the
 	// receiver.
-	logNum uint64
+	logNum FileNum
 	// logSize is the size in bytes of the associated WAL. Protected by DB.mu.
 	logSize uint64
 	// The current logSeqNum at the time the memtable was created. This is

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -17,7 +17,7 @@ func TestGetIter(t *testing.T) {
 	// Each element of data is a string of the form "internalKey value".
 	type testTable struct {
 		level   int
-		fileNum uint64
+		fileNum FileNum
 		data    []string
 	}
 
@@ -467,7 +467,7 @@ func TestGetIter(t *testing.T) {
 		desc := tc.description[:strings.Index(tc.description, ":")]
 
 		// m is a map from file numbers to DBs.
-		m := map[uint64]*memTable{}
+		m := map[FileNum]*memTable{}
 		newIter := func(
 			meta *fileMetadata, _ *IterOptions, _ *uint64,
 		) (internalIterator, internalIterator, error) {

--- a/ingest.go
+++ b/ingest.go
@@ -43,7 +43,9 @@ func ingestValidateKey(opts *Options, key *InternalKey) error {
 	return nil
 }
 
-func ingestLoad1(opts *Options, path string, cacheID, fileNum uint64) (*fileMetadata, error) {
+func ingestLoad1(
+	opts *Options, path string, cacheID uint64, fileNum FileNum,
+) (*fileMetadata, error) {
 	stat, err := opts.FS.Stat(path)
 	if err != nil {
 		return nil, err
@@ -130,7 +132,7 @@ func ingestLoad1(opts *Options, path string, cacheID, fileNum uint64) (*fileMeta
 }
 
 func ingestLoad(
-	opts *Options, paths []string, cacheID uint64, pending []uint64,
+	opts *Options, paths []string, cacheID uint64, pending []FileNum,
 ) ([]*fileMetadata, []string, error) {
 	meta := make([]*fileMetadata, 0, len(paths))
 	newPaths := make([]string, 0, len(paths))
@@ -482,7 +484,7 @@ func (d *DB) Ingest(paths []string) error {
 	// ordering. The sorting of L0 tables by sequence number avoids relying on
 	// that (busted) invariant.
 	d.mu.Lock()
-	pendingOutputs := make([]uint64, len(paths))
+	pendingOutputs := make([]FileNum, len(paths))
 	for i := range paths {
 		pendingOutputs[i] = d.mu.versions.getNextFileNum()
 	}

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -54,7 +54,7 @@ func TestIngestLoad(t *testing.T) {
 				Comparer: DefaultComparer,
 				FS:       mem,
 			}
-			meta, _, err := ingestLoad(opts, []string{"ext"}, 0, []uint64{1})
+			meta, _, err := ingestLoad(opts, []string{"ext"}, 0, []FileNum{1})
 			if err != nil {
 				return err.Error()
 			}
@@ -84,11 +84,11 @@ func TestIngestLoadRand(t *testing.T) {
 	}
 
 	paths := make([]string, 1+rng.Intn(10))
-	pending := make([]uint64, len(paths))
+	pending := make([]FileNum, len(paths))
 	expected := make([]*fileMetadata, len(paths))
 	for i := range paths {
 		paths[i] = fmt.Sprint(i)
-		pending[i] = uint64(rng.Int63())
+		pending[i] = FileNum(rng.Int63())
 		expected[i] = &fileMetadata{
 			FileNum: pending[i],
 		}
@@ -153,7 +153,7 @@ func TestIngestLoadInvalid(t *testing.T) {
 		Comparer: DefaultComparer,
 		FS:       mem,
 	}
-	if _, _, err := ingestLoad(opts, []string{"invalid"}, 0, []uint64{1}); err == nil {
+	if _, _, err := ingestLoad(opts, []string{"invalid"}, 0, []FileNum{1}); err == nil {
 		t.Fatalf("expected error, but found success")
 	}
 }
@@ -230,7 +230,7 @@ func TestIngestLink(t *testing.T) {
 			for j := range paths {
 				paths[j] = fmt.Sprintf("external%d", j)
 				meta[j] = &fileMetadata{}
-				meta[j].FileNum = uint64(j)
+				meta[j].FileNum = FileNum(j)
 				f, err := mem.Create(paths[j])
 				require.NoError(t, err)
 
@@ -275,7 +275,7 @@ func TestIngestLink(t *testing.T) {
 					if fileTypeTable != ftype {
 						t.Fatalf("expected table, but found %d", ftype)
 					}
-					if uint64(j) != fileNum {
+					if FileNum(j) != fileNum {
 						t.Fatalf("expected table %d, but found %d", j, fileNum)
 					}
 					f, err := mem.Open(mem.PathJoin(dir, files[j]))

--- a/internal/base/filenames_test.go
+++ b/internal/base/filenames_test.go
@@ -61,9 +61,9 @@ func TestFilenameRoundTrip(t *testing.T) {
 	}
 	fs := vfs.NewMem()
 	for fileType, numbered := range testCases {
-		fileNums := []uint64{0}
+		fileNums := []FileNum{0}
 		if numbered {
-			fileNums = []uint64{0, 1, 2, 3, 10, 42, 99, 1001}
+			fileNums = []FileNum{0, 1, 2, 3, 10, 42, 99, 1001}
 		}
 		for _, fileNum := range fileNums {
 			filename := MakeFilename(fs, "foo", fileType, fileNum)

--- a/internal/cache/clockpro_test.go
+++ b/internal/cache/clockpro_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
 )
@@ -36,11 +37,11 @@ func TestCache(t *testing.T) {
 		wantHit := fields[1][0] == 'h'
 
 		var hit bool
-		h := cache.Get(1, uint64(key), 0)
+		h := cache.Get(1, base.FileNum(key), 0)
 		if v := h.Get(); v == nil {
 			value := cache.Alloc(1)
 			value.Buf()[0] = fields[0][0]
-			cache.Set(1, uint64(key), 0, value).Release()
+			cache.Set(1, base.FileNum(key), 0, value).Release()
 		} else {
 			hit = true
 			if !bytes.Equal(v, fields[0][:1]) {

--- a/internal/cache/robin_hood.go
+++ b/internal/cache/robin_hood.go
@@ -25,7 +25,7 @@ func robinHoodHash(k key, shift uint32) uint32 {
 	const m = 11400714819323198485
 	h := hashSeed
 	h ^= k.id * m
-	h ^= k.fileNum * m
+	h ^= uint64(k.fileNum) * m
 	h ^= k.offset * m
 	return uint32(h >> shift)
 }

--- a/internal/cache/robin_hood_test.go
+++ b/internal/cache/robin_hood_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/pebble/internal/base"
 	"golang.org/x/exp/rand"
 )
 
@@ -44,7 +45,7 @@ func TestRobinHoodMap(t *testing.T) {
 			// 40% insert.
 			var k key
 			k.id = rng.Uint64()
-			k.fileNum = rng.Uint64()
+			k.fileNum = base.FileNum(rng.Uint64())
 			k.offset = rng.Uint64()
 			e := &entry{}
 			goMap[k] = e
@@ -92,7 +93,7 @@ func BenchmarkGoMapInsert(b *testing.B) {
 	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 	keys := make([]key, benchSize)
 	for i := range keys {
-		keys[i].fileNum = uint64(rng.Intn(1 << 20))
+		keys[i].fileNum = base.FileNum(rng.Intn(1 << 20))
 		keys[i].offset = uint64(rng.Intn(1 << 20))
 	}
 	b.ResetTimer()
@@ -113,7 +114,7 @@ func BenchmarkRobinHoodInsert(b *testing.B) {
 	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 	keys := make([]key, benchSize)
 	for i := range keys {
-		keys[i].fileNum = uint64(rng.Intn(1 << 20))
+		keys[i].fileNum = base.FileNum(rng.Intn(1 << 20))
 		keys[i].offset = uint64(rng.Intn(1 << 20))
 	}
 	e := &entry{}
@@ -139,7 +140,7 @@ func BenchmarkGoMapLookupHit(b *testing.B) {
 	m := make(map[key]*entry, len(keys))
 	e := &entry{}
 	for i := range keys {
-		keys[i].fileNum = uint64(rng.Intn(1 << 20))
+		keys[i].fileNum = base.FileNum(rng.Intn(1 << 20))
 		keys[i].offset = uint64(rng.Intn(1 << 20))
 		m[keys[i]] = e
 	}
@@ -164,7 +165,7 @@ func BenchmarkRobinHoodLookupHit(b *testing.B) {
 	m := newRobinHoodMap(len(keys))
 	e := &entry{}
 	for i := range keys {
-		keys[i].fileNum = uint64(rng.Intn(1 << 20))
+		keys[i].fileNum = base.FileNum(rng.Intn(1 << 20))
 		keys[i].offset = uint64(rng.Intn(1 << 20))
 		m.Put(keys[i], e)
 	}
@@ -191,7 +192,7 @@ func BenchmarkGoMapLookupMiss(b *testing.B) {
 	e := &entry{}
 	for i := range keys {
 		keys[i].id = 1
-		keys[i].fileNum = uint64(rng.Intn(1 << 20))
+		keys[i].fileNum = base.FileNum(rng.Intn(1 << 20))
 		keys[i].offset = uint64(rng.Intn(1 << 20))
 		m[keys[i]] = e
 		keys[i].id = 2
@@ -218,7 +219,7 @@ func BenchmarkRobinHoodLookupMiss(b *testing.B) {
 	e := &entry{}
 	for i := range keys {
 		keys[i].id = 1
-		keys[i].fileNum = uint64(rng.Intn(1 << 20))
+		keys[i].fileNum = base.FileNum(rng.Intn(1 << 20))
 		keys[i].offset = uint64(rng.Intn(1 << 20))
 		m.Put(keys[i], e)
 		keys[i].id = 2

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -270,7 +270,7 @@ func TestVersionEditApply(t *testing.T) {
 		}
 		m.SmallestSeqNum = m.Smallest.SeqNum()
 		m.LargestSeqNum = m.Largest.SeqNum()
-		m.FileNum = uint64(fileNum)
+		m.FileNum = base.FileNum(fileNum)
 		return &m, nil
 	}
 
@@ -323,7 +323,7 @@ func TestVersionEditApply(t *testing.T) {
 							if err != nil {
 								return err.Error()
 							}
-							dfe := DeletedFileEntry{Level: level, FileNum: uint64(fileNum)}
+							dfe := DeletedFileEntry{Level: level, FileNum: base.FileNum(fileNum)}
 							if ve.DeletedFiles == nil {
 								ve.DeletedFiles = make(map[DeletedFileEntry]bool)
 							}
@@ -338,7 +338,7 @@ func TestVersionEditApply(t *testing.T) {
 					return err.Error()
 				}
 
-				zombieFileNums := make([]uint64, 0, len(zombies))
+				zombieFileNums := make([]base.FileNum, 0, len(zombies))
 				for fileNum := range zombies {
 					zombieFileNums = append(zombieFileNums, fileNum)
 				}

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -261,7 +261,7 @@ func TestOverlaps(t *testing.T) {
 func TestVersionUnref(t *testing.T) {
 	list := &VersionList{}
 	list.Init(&sync.Mutex{})
-	v := &Version{Deleted: func([]uint64) {}}
+	v := &Version{Deleted: func([]base.FileNum) {}}
 	v.Ref()
 	list.PushBack(v)
 	v.Unref()
@@ -294,7 +294,7 @@ func TestCheckOrdering(t *testing.T) {
 				// Version.DebugString().
 				v := Version{}
 				var files *[]*FileMetadata
-				fileNum := uint64(1)
+				fileNum := base.FileNum(1)
 
 				for _, data := range strings.Split(d.Input, "\n") {
 					switch data {

--- a/internal/private/sstable.go
+++ b/internal/private/sstable.go
@@ -4,9 +4,11 @@
 
 package private
 
+import "github.com/cockroachdb/pebble/internal/base"
+
 // SSTableCacheOpts is a hook for specifying cache options to
 // sstable.NewReader.
-var SSTableCacheOpts func(cacheID, fileNum uint64) interface{}
+var SSTableCacheOpts func(cacheID uint64, fileNum base.FileNum) interface{}
 
 // SSTableRawTombstonesOpt is a sstable.Reader option for disabling
 // fragmentation of the range tombstones returned by

--- a/internal/record/log_writer.go
+++ b/internal/record/log_writer.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/crc"
 )
 
@@ -282,7 +283,7 @@ type LogWriter struct {
 }
 
 // NewLogWriter returns a new LogWriter.
-func NewLogWriter(w io.Writer, logNum uint64) *LogWriter {
+func NewLogWriter(w io.Writer, logNum base.FileNum) *LogWriter {
 	c, _ := w.(io.Closer)
 	s, _ := w.(syncer)
 	r := &LogWriter{

--- a/internal/record/record.go
+++ b/internal/record/record.go
@@ -108,6 +108,7 @@ import (
 	"errors"
 	"io"
 
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/crc"
 )
 
@@ -178,7 +179,7 @@ type Reader struct {
 // NewReader returns a new reader. If the file contains records encoded using
 // the recyclable record format, then the log number in those records must
 // match the specifed logNum.
-func NewReader(r io.Reader, logNum uint64) *Reader {
+func NewReader(r io.Reader, logNum base.FileNum) *Reader {
 	return &Reader{
 		r:        r,
 		logNum:   uint32(logNum),

--- a/level_checker.go
+++ b/level_checker.go
@@ -272,7 +272,7 @@ type tombstoneWithLevel struct {
 	level int
 	// The level in LSM. A -1 means it's a memtable.
 	lsmLevel int
-	fileNum  uint64
+	fileNum  FileNum
 }
 
 // For sorting tombstoneWithLevels in increasing order of start UserKey and
@@ -442,18 +442,18 @@ func getAtomicUnitBounds(cmp Compare, files []*fileMetadata, index int) (lower, 
 	return
 }
 
-func levelOrMemtable(lsmLevel int, fileNum uint64) string {
+func levelOrMemtable(lsmLevel int, fileNum FileNum) string {
 	if lsmLevel == -1 {
 		return "memtable"
 	}
-	return fmt.Sprintf("L%d: fileNum=%06d", lsmLevel, fileNum)
+	return fmt.Sprintf("L%d: fileNum=%s", lsmLevel, fileNum)
 }
 
 func addTombstonesFromIter(
 	iter base.InternalIterator,
 	level int,
 	lsmLevel int,
-	fileNum uint64,
+	fileNum FileNum,
 	tombstones []tombstoneWithLevel,
 	seqNum uint64,
 	cmp Compare,

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -8,13 +8,13 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/cockroachdb/pebble/internal/private"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/cockroachdb/pebble/internal/private"
 	"github.com/cockroachdb/pebble/internal/rangedel"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -79,7 +79,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 		}
 	}()
 
-	var fileNum uint64
+	var fileNum FileNum
 	newIters :=
 		func(meta *fileMetadata, opts *IterOptions, bytesIterated *uint64) (internalIterator, internalIterator, error) {
 			r := readers[meta.FileNum]

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -53,7 +53,7 @@ func TestLevelIter(t *testing.T) {
 				iters = append(iters, f)
 
 				meta := &fileMetadata{
-					FileNum: uint64(len(files)),
+					FileNum: FileNum(len(files)),
 				}
 				meta.Smallest = f.keys[0]
 				meta.Largest = f.keys[len(f.keys)-1]
@@ -167,7 +167,7 @@ func (lt *levelIterTest) runClear(d *datadriven.TestData) string {
 }
 
 func (lt *levelIterTest) runBuild(d *datadriven.TestData) string {
-	fileNum := uint64(len(lt.readers))
+	fileNum := FileNum(len(lt.readers))
 	name := fmt.Sprint(fileNum)
 	f0, err := lt.mem.Create(name)
 	if err != nil {
@@ -396,7 +396,7 @@ func buildLevelIterTables(
 		iter := readers[i].NewIter(nil /* lower */, nil /* upper */)
 		key, _ := iter.First()
 		meta[i] = &fileMetadata{}
-		meta[i].FileNum = uint64(i)
+		meta[i].FileNum = FileNum(i)
 		meta[i].Smallest = *key
 		key, _ = iter.Last()
 		meta[i].Largest = *key

--- a/log_recycler.go
+++ b/log_recycler.go
@@ -18,19 +18,19 @@ type logRecycler struct {
 	// recycling a log written by a previous instance of the DB which may not
 	// have had log recycling enabled. If that previous instance of the DB was
 	// RocksDB, the old non-recyclable log record headers will be present.
-	minRecycleLogNum uint64
+	minRecycleLogNum FileNum
 
 	mu struct {
 		sync.Mutex
-		logNums   []uint64
-		maxLogNum uint64
+		logNums   []FileNum
+		maxLogNum FileNum
 	}
 }
 
 // add attempts to recycle the log file specified by logNum. Returns true if
 // the log file should not be deleted (i.e. the log is being recycled), and
 // false otherwise.
-func (r *logRecycler) add(logNum uint64) bool {
+func (r *logRecycler) add(logNum FileNum) bool {
 	if logNum < r.minRecycleLogNum {
 		return false
 	}
@@ -58,7 +58,7 @@ func (r *logRecycler) add(logNum uint64) bool {
 
 // peek returns the log number at the head of the recycling queue, or zero if
 // the queue is empty.
-func (r *logRecycler) peek() uint64 {
+func (r *logRecycler) peek() FileNum {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -77,7 +77,7 @@ func (r *logRecycler) count() int {
 // pop removes the log number at the head of the recycling queue, enforcing
 // that it matches the specifed logNum. An error is returned of the recycling
 // queue is empty or the head log number does not match the specified one.
-func (r *logRecycler) pop(logNum uint64) error {
+func (r *logRecycler) pop(logNum FileNum) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -137,7 +137,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 		}
 	}()
 
-	var fileNum uint64
+	var fileNum base.FileNum
 	newIters :=
 		func(meta *fileMetadata, opts *IterOptions, bytesIterated *uint64) (internalIterator, internalIterator, error) {
 			r := readers[meta.FileNum]

--- a/open.go
+++ b/open.go
@@ -205,7 +205,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 
 	// Replay any newer log files than the ones named in the manifest.
 	type fileNumAndName struct {
-		num  uint64
+		num  FileNum
 		name string
 	}
 	var logFiles []fileNumAndName
@@ -345,7 +345,7 @@ func GetVersion(dir string, fs vfs.FS) (string, error) {
 		return "", err
 	}
 	var version string
-	lastOptionsSeen := uint64(0)
+	lastOptionsSeen := FileNum(0)
 	for _, filename := range ls {
 		ft, fn, ok := base.ParseFilename(fs, filename)
 		if !ok {
@@ -398,7 +398,7 @@ func GetVersion(dir string, fs vfs.FS) (string, error) {
 // d.mu must be held when calling this, but the mutex may be dropped and
 // re-acquired during the course of this method.
 func (d *DB) replayWAL(
-	jobID int, ve *versionEdit, fs vfs.FS, filename string, logNum uint64,
+	jobID int, ve *versionEdit, fs vfs.FS, filename string, logNum FileNum,
 ) (maxSeqNum uint64, err error) {
 	file, err := fs.Open(filename)
 	if err != nil {

--- a/open_test.go
+++ b/open_test.go
@@ -548,7 +548,7 @@ func TestGetVersion(t *testing.T) {
 	require.Equal(t, "0.1", version)
 
 	// Case 3: Manually created OPTIONS file with a higher number.
-	highestOptionsNum := uint64(0)
+	highestOptionsNum := FileNum(0)
 	ls, err := mem.List("")
 	require.NoError(t, err)
 	for _, filename := range ls {

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -500,7 +500,7 @@ func (i *singleLevelIterator) Close() error {
 }
 
 func (i *singleLevelIterator) String() string {
-	return fmt.Sprintf("%06d", i.reader.fileNum)
+	return i.reader.fileNum.String()
 }
 
 // SetBounds implements internalIterator.SetBounds, as documented in the pebble
@@ -524,7 +524,7 @@ type compactionIterator struct {
 var _ base.InternalIterator = (*compactionIterator)(nil)
 
 func (i *compactionIterator) String() string {
-	return fmt.Sprintf("%06d", i.reader.fileNum)
+	return i.reader.fileNum.String()
 }
 
 func (i *compactionIterator) SeekGE(key []byte) (*InternalKey, []byte) {
@@ -636,7 +636,7 @@ func (i *twoLevelIterator) Init(r *Reader, lower, upper []byte) error {
 }
 
 func (i *twoLevelIterator) String() string {
-	return fmt.Sprintf("%06d", i.reader.fileNum)
+	return i.reader.fileNum.String()
 }
 
 // SeekGE implements internalIterator.SeekGE, as documented in the pebble
@@ -901,7 +901,7 @@ func (i *twoLevelCompactionIterator) Prev() (*InternalKey, []byte) {
 }
 
 func (i *twoLevelCompactionIterator) String() string {
-	return fmt.Sprintf("%06d", i.reader.fileNum)
+	return i.reader.fileNum.String()
 }
 
 func (i *twoLevelCompactionIterator) skipForward(
@@ -1005,7 +1005,7 @@ func (m Mergers) readerApply(r *Reader) {
 // number. If not specified, a unique cache ID will be used.
 type cacheOpts struct {
 	cacheID uint64
-	fileNum uint64
+	fileNum base.FileNum
 }
 
 // Marker function to indicate the option should be applied before reading the
@@ -1044,7 +1044,7 @@ func (rawTombstonesOpt) readerApply(r *Reader) {
 }
 
 func init() {
-	private.SSTableCacheOpts = func(cacheID, fileNum uint64) interface{} {
+	private.SSTableCacheOpts = func(cacheID uint64, fileNum base.FileNum) interface{} {
 		return &cacheOpts{cacheID, fileNum}
 	}
 	private.SSTableRawTombstonesOpt = rawTombstonesOpt{}
@@ -1054,7 +1054,7 @@ func init() {
 type Reader struct {
 	file              vfs.File
 	cacheID           uint64
-	fileNum           uint64
+	fileNum           base.FileNum
 	rawTombstones     bool
 	err               error
 	index             weakCachedBlock

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -89,7 +89,7 @@ type Writer struct {
 	// the cache, providing a defense in depth against bugs which cause cache
 	// collisions.
 	cacheID uint64
-	fileNum uint64
+	fileNum base.FileNum
 	// The following fields are copied from Options.
 	blockSize               int
 	blockSizeThreshold      int

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -91,7 +91,7 @@ func (fs *tableCacheTestFS) validateOpenTables(f func(i, gotO, gotC int) error) 
 
 		numStillOpen := 0
 		for i := 0; i < tableCacheTestNumTables; i++ {
-			filename := base.MakeFilename(fs, "", fileTypeTable, uint64(i))
+			filename := base.MakeFilename(fs, "", fileTypeTable, FileNum(i))
 			gotO, gotC := fs.openCounts[filename], fs.closeCounts[filename]
 			if gotO > gotC {
 				numStillOpen++
@@ -121,7 +121,7 @@ func (fs *tableCacheTestFS) validateNoneStillOpen() error {
 		defer fs.mu.Unlock()
 
 		for i := 0; i < tableCacheTestNumTables; i++ {
-			filename := base.MakeFilename(fs, "", fileTypeTable, uint64(i))
+			filename := base.MakeFilename(fs, "", fileTypeTable, FileNum(i))
 			gotO, gotC := fs.openCounts[filename], fs.closeCounts[filename]
 			if gotO != gotC {
 				return fmt.Errorf("i=%d: opened %d times, closed %d times", i, gotO, gotC)
@@ -143,7 +143,7 @@ func newTableCache() (*tableCache, *tableCacheTestFS, error) {
 		FS: vfs.NewMem(),
 	}
 	for i := 0; i < tableCacheTestNumTables; i++ {
-		f, err := fs.Create(base.MakeFilename(fs, "", fileTypeTable, uint64(i)))
+		f, err := fs.Create(base.MakeFilename(fs, "", fileTypeTable, FileNum(i)))
 		if err != nil {
 			return nil, nil, fmt.Errorf("fs.Create: %v", err)
 		}
@@ -188,7 +188,7 @@ func testTableCacheRandomAccess(t *testing.T, concurrent bool) {
 			fileNum, sleepTime := rng.Intn(tableCacheTestNumTables), rng.Intn(1000)
 			rngMu.Unlock()
 			iter, _, err := c.newIters(
-				&fileMetadata{FileNum: uint64(fileNum)},
+				&fileMetadata{FileNum: FileNum(fileNum)},
 				nil, /* iter options */
 				nil /* bytes iterated */)
 			if err != nil {
@@ -244,7 +244,7 @@ func TestTableCacheFrequentlyUsed(t *testing.T) {
 	for i := 0; i < N; i++ {
 		for _, j := range [...]int{pinned0, i % tableCacheTestNumTables, pinned1} {
 			iter, _, err := c.newIters(
-				&fileMetadata{FileNum: uint64(j)},
+				&fileMetadata{FileNum: FileNum(j)},
 				nil, /* iter options */
 				nil /* bytes iterated */)
 			if err != nil {
@@ -280,7 +280,7 @@ func TestTableCacheEvictions(t *testing.T) {
 	for i := 0; i < N; i++ {
 		j := rng.Intn(tableCacheTestNumTables)
 		iter, _, err := c.newIters(
-			&fileMetadata{FileNum: uint64(j)},
+			&fileMetadata{FileNum: FileNum(j)},
 			nil, /* iter options */
 			nil /* bytes iterated */)
 		if err != nil {
@@ -290,7 +290,7 @@ func TestTableCacheEvictions(t *testing.T) {
 			t.Fatalf("i=%d, j=%d: close: %v", i, j, err)
 		}
 
-		c.evict(uint64(lo + rng.Intn(hi-lo)))
+		c.evict(FileNum(lo + rng.Intn(hi-lo)))
 	}
 
 	sumEvicted, nEvicted := 0, 0

--- a/tool/lsm.go
+++ b/tool/lsm.go
@@ -33,9 +33,9 @@ type lsmVersionEdit struct {
 	// Reason for the edit: flushed, ingested, compacted, added.
 	Reason string
 	// Map from level to files added to the level.
-	Added map[int][]uint64 `json:",omitempty"`
+	Added map[int][]base.FileNum `json:",omitempty"`
 	// Map from level to files deleted from the level.
-	Deleted map[int][]uint64 `json:",omitempty"`
+	Deleted map[int][]base.FileNum `json:",omitempty"`
 }
 
 type lsmKey struct {
@@ -46,9 +46,9 @@ type lsmKey struct {
 
 type lsmState struct {
 	Manifest string
-	Edits    []lsmVersionEdit           `json:",omitempty"`
-	Files    map[uint64]lsmFileMetadata `json:",omitempty"`
-	Keys     []lsmKey                   `json:",omitempty"`
+	Edits    []lsmVersionEdit                 `json:",omitempty"`
+	Files    map[base.FileNum]lsmFileMetadata `json:",omitempty"`
+	Keys     []lsmKey                         `json:",omitempty"`
 }
 
 type lsmT struct {
@@ -200,15 +200,15 @@ func (l *lsmT) buildKeys(edits []*manifest.VersionEdit) {
 
 func (l *lsmT) buildEdits(edits []*manifest.VersionEdit) {
 	l.state.Edits = nil
-	l.state.Files = make(map[uint64]lsmFileMetadata)
+	l.state.Files = make(map[base.FileNum]lsmFileMetadata)
 	for _, ve := range edits {
 		if len(ve.DeletedFiles) == 0 && len(ve.NewFiles) == 0 {
 			continue
 		}
 		edit := lsmVersionEdit{
 			Reason:  l.reason(ve),
-			Added:   make(map[int][]uint64),
-			Deleted: make(map[int][]uint64),
+			Added:   make(map[int][]base.FileNum),
+			Deleted: make(map[int][]base.FileNum),
 		}
 		for df := range ve.DeletedFiles {
 			edit.Deleted[df.Level] = append(edit.Deleted[df.Level], df.FileNum)

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -148,11 +148,11 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 					return entries[i].FileNum < entries[j].FileNum
 				})
 				for _, df := range entries {
-					fmt.Fprintf(stdout, "  deleted:       L%d %06d\n", df.Level, df.FileNum)
+					fmt.Fprintf(stdout, "  deleted:       L%d %s\n", df.Level, df.FileNum)
 				}
 				for _, nf := range ve.NewFiles {
 					empty = false
-					fmt.Fprintf(stdout, "  added:         L%d %06d:%d",
+					fmt.Fprintf(stdout, "  added:         L%d %s:%d",
 						nf.Level, nf.Meta.FileNum, nf.Meta.Size)
 					formatSeqNumRange(stdout, nf.Meta.SmallestSeqNum, nf.Meta.LargestSeqNum)
 					formatKeyRange(stdout, m.fmtKey, &nf.Meta.Smallest, &nf.Meta.Largest)
@@ -180,7 +180,7 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 					fmt.Fprintf(stdout, "--- L%d ---\n", level)
 					for j := range v.Files[level] {
 						f := v.Files[level][j]
-						fmt.Fprintf(stdout, "  %06d:%d", f.FileNum, f.Size)
+						fmt.Fprintf(stdout, "  %s:%d", f.FileNum, f.Size)
 						formatSeqNumRange(stdout, f.SmallestSeqNum, f.LargestSeqNum)
 						formatKeyRange(stdout, m.fmtKey, &f.Smallest, &f.Largest)
 						fmt.Fprintf(stdout, "\n")
@@ -257,7 +257,7 @@ func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
 						fmt.Fprintf(stdout, "--- L%d ---\n", level)
 						for j := range v.Files[level] {
 							f := v.Files[level][j]
-							fmt.Fprintf(stdout, "  %06d:%d", f.FileNum, f.Size)
+							fmt.Fprintf(stdout, "  %s:%d", f.FileNum, f.Size)
 							formatSeqNumRange(stdout, f.SmallestSeqNum, f.LargestSeqNum)
 							formatKeyRange(stdout, m.fmtKey, &f.Smallest, &f.Largest)
 							fmt.Fprintf(stdout, "\n")
@@ -265,10 +265,10 @@ func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
 					}
 					fmt.Fprintf(stdout, "Version edit that failed\n")
 					for df := range ve.DeletedFiles {
-						fmt.Fprintf(stdout, "  deleted: L%d %06d\n", df.Level, df.FileNum)
+						fmt.Fprintf(stdout, "  deleted: L%d %s\n", df.Level, df.FileNum)
 					}
 					for _, nf := range ve.NewFiles {
-						fmt.Fprintf(stdout, "  added: L%d %06d:%d",
+						fmt.Fprintf(stdout, "  added: L%d %s:%d",
 							nf.Level, nf.Meta.FileNum, nf.Meta.Size)
 						formatSeqNumRange(stdout, nf.Meta.SmallestSeqNum, nf.Meta.LargestSeqNum)
 						formatKeyRange(stdout, m.fmtKey, &nf.Meta.Smallest, &nf.Meta.Largest)


### PR DESCRIPTION
Add a `type FileNum uint64` type for file numbers. It implements
Stringer by formatting itself as a six-digit number w/ leading zeros.
This will ensure that file numbers are always formatted like this, even
when wrapped by `errors.Safe`.

As a follow-up or in this PR, we could also create separate file number
types for some or all of LogNum, TableNum, OptionsNum, etc. I didn't
have high confidence in how that would shake out cleanly in some
code paths, which is why I opted for a general `FileNum` initially. 