### PR TITLE
internal/lint: prohibit usage of "errors" and fmt.Errorf

### DIFF
--- a/filenames_test.go
+++ b/filenames_test.go
@@ -5,9 +5,9 @@
 package pebble
 
 import (
-	"errors"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/internal/private"
 	"github.com/cockroachdb/pebble/sstable"
@@ -370,7 +371,7 @@ func (o *ingestOp) collapseBatch(t *test, b *pebble.Batch) (*pebble.Batch, error
 			case pebble.InternalKeyKindLogData:
 				err = collapsed.LogData(key.UserKey, nil)
 			default:
-				err = fmt.Errorf("unknown batch record kind: %d", key.Kind())
+				err = errors.Errorf("unknown batch record kind: %d", key.Kind())
 			}
 			if err != nil {
 				return nil, err

--- a/internal/record/record_test.go
+++ b/internal/record/record_test.go
@@ -39,10 +39,7 @@ type recordWriter interface {
 }
 
 func testGeneratorWriter(
-	t *testing.T,
-	reset func(),
-	gen func() (string, bool),
-	newWriter func(io.Writer) recordWriter,
+	t *testing.T, reset func(), gen func() (string, bool), newWriter func(io.Writer) recordWriter,
 ) {
 	buf := new(bytes.Buffer)
 
@@ -572,11 +569,11 @@ func verifyLastBlockRecover(recs *testRecords) error {
 			r.recover()
 		case len(recs.records):
 			if err != io.EOF {
-				return fmt.Errorf("Expected io.EOF, got %v", err)
+				return errors.Errorf("Expected io.EOF, got %v", err)
 			}
 		default:
 			if err != nil {
-				return fmt.Errorf("Next: %v", err)
+				return errors.Errorf("Next: %v", err)
 			}
 		}
 	}

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -29,12 +29,12 @@ func runBuildCmd(td *datadriven.TestData) (*WriterMetadata, *Reader, error) {
 		switch arg.Key {
 		case "leveldb":
 			if len(arg.Vals) != 0 {
-				return nil, nil, fmt.Errorf("%s: arg %s expects 0 values", td.Cmd, arg.Key)
+				return nil, nil, errors.Errorf("%s: arg %s expects 0 values", td.Cmd, arg.Key)
 			}
 			writerOpts.TableFormat = TableFormatLevelDB
 		case "block-size":
 			if len(arg.Vals) != 1 {
-				return nil, nil, fmt.Errorf("%s: arg %s expects 1 value", td.Cmd, arg.Key)
+				return nil, nil, errors.Errorf("%s: arg %s expects 1 value", td.Cmd, arg.Key)
 			}
 			var err error
 			writerOpts.BlockSize, err = strconv.Atoi(arg.Vals[0])
@@ -43,7 +43,7 @@ func runBuildCmd(td *datadriven.TestData) (*WriterMetadata, *Reader, error) {
 			}
 		case "index-block-size":
 			if len(arg.Vals) != 1 {
-				return nil, nil, fmt.Errorf("%s: arg %s expects 1 value", td.Cmd, arg.Key)
+				return nil, nil, errors.Errorf("%s: arg %s expects 1 value", td.Cmd, arg.Key)
 			}
 			var err error
 			writerOpts.IndexBlockSize, err = strconv.Atoi(arg.Vals[0])
@@ -51,7 +51,7 @@ func runBuildCmd(td *datadriven.TestData) (*WriterMetadata, *Reader, error) {
 				return nil, nil, err
 			}
 		default:
-			return nil, nil, fmt.Errorf("%s: unknown arg %s", td.Cmd, arg.Key)
+			return nil, nil, errors.Errorf("%s: unknown arg %s", td.Cmd, arg.Key)
 		}
 	}
 

--- a/sstable/writer_fixture_test.go
+++ b/sstable/writer_fixture_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/stretchr/testify/require"
@@ -126,7 +127,7 @@ var fixtures = map[fixtureOpts]struct {
 func runTestFixtureOutput(opts fixtureOpts) error {
 	fixture, ok := fixtures[opts]
 	if !ok {
-		return fmt.Errorf("fixture missing: %+v", opts)
+		return errors.Errorf("fixture missing: %+v", opts)
 	}
 
 	compression := NoCompression
@@ -166,7 +167,7 @@ func runTestFixtureOutput(opts fixtureOpts) error {
 		for ; i < len(got) && i < len(want) && got[i] == want[i]; i++ {
 		}
 		ioutil.WriteFile("fail.txt", got, 0644)
-		return fmt.Errorf("built table %s does not match pre-made table. From byte %d onwards,\ngot:\n% x\nwant:\n% x",
+		return errors.Errorf("built table %s does not match pre-made table. From byte %d onwards,\ngot:\n% x\nwant:\n% x",
 			fixture.filename, i, got[i:], want[i:])
 	}
 	return nil


### PR DESCRIPTION
Prevent usage of the stdlib "errors" package and of `fmt.Errorf`. We now 
require the usage of the functions in `github.com/cockroachdb/errors`.