### PR TITLE
sstable: add error return value to NewIter, NewCompactionIter

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -835,7 +835,11 @@ func TestCompaction(t *testing.T) {
 					return "", "", errors.WithStack(err)
 				}
 				defer r.Close()
-				ss = append(ss, get1(r.NewIter(nil /* lower */, nil /* upper */))+".")
+				iter, err := r.NewIter(nil /* lower */, nil /* upper */)
+				if err != nil {
+					return "", "", errors.WithStack(err)
+				}
+				ss = append(ss, get1(iter)+".")
 			}
 		}
 		sort.Strings(ss)

--- a/ingest.go
+++ b/ingest.go
@@ -73,7 +73,10 @@ func ingestLoad1(
 	empty := true
 
 	{
-		iter := r.NewIter(nil /* lower */, nil /* upper */)
+		iter, err := r.NewIter(nil /* lower */, nil /* upper */)
+		if err != nil {
+			return nil, err
+		}
 		defer iter.Close()
 		if key, _ := iter.First(); key != nil {
 			if err := ingestValidateKey(opts, key); err != nil {

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -87,7 +87,11 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 			if err != nil {
 				return nil, nil, err
 			}
-			return r.NewIter(nil /* lower */, nil /* upper */), rangeDelIter, nil
+			iter, err := r.NewIter(nil /* lower */, nil /* upper */)
+			if err != nil {
+				return nil, nil, err
+			}
+			return iter, rangeDelIter, nil
 		}
 
 	failMerger := &Merger{

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/rangedel"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
 )
 
@@ -145,7 +146,11 @@ func TestMergingIterCornerCases(t *testing.T) {
 			if err != nil {
 				return nil, nil, err
 			}
-			return r.NewIter(opts.GetLowerBound(), opts.GetUpperBound()), rangeDelIter, nil
+			iter, err := r.NewIter(opts.GetLowerBound(), opts.GetUpperBound())
+			if err != nil {
+				return nil, nil, err
+			}
+			return iter, rangeDelIter, nil
 		}
 
 	datadriven.RunTest(t, "testdata/merging_iter", func(d *datadriven.TestData) string {
@@ -326,7 +331,9 @@ func BenchmarkMergingIterSeekGE(b *testing.B) {
 							readers, keys := buildMergingIterTables(b, blockSize, restartInterval, count)
 							iters := make([]internalIterator, len(readers))
 							for i := range readers {
-								iters[i] = readers[i].NewIter(nil /* lower */, nil /* upper */)
+								var err error
+								iters[i], err = readers[i].NewIter(nil /* lower */, nil /* upper */)
+								require.NoError(b, err)
 							}
 							m := newMergingIter(nil /* logger */, DefaultComparer.Compare, iters...)
 							rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
@@ -353,7 +360,9 @@ func BenchmarkMergingIterNext(b *testing.B) {
 							readers, _ := buildMergingIterTables(b, blockSize, restartInterval, count)
 							iters := make([]internalIterator, len(readers))
 							for i := range readers {
-								iters[i] = readers[i].NewIter(nil /* lower */, nil /* upper */)
+								var err error
+								iters[i], err = readers[i].NewIter(nil /* lower */, nil /* upper */)
+								require.NoError(b, err)
 							}
 							m := newMergingIter(nil /* logger */, DefaultComparer.Compare, iters...)
 
@@ -383,7 +392,9 @@ func BenchmarkMergingIterPrev(b *testing.B) {
 							readers, _ := buildMergingIterTables(b, blockSize, restartInterval, count)
 							iters := make([]internalIterator, len(readers))
 							for i := range readers {
-								iters[i] = readers[i].NewIter(nil /* lower */, nil /* upper */)
+								var err error
+								iters[i], err = readers[i].NewIter(nil /* lower */, nil /* upper */)
+								require.NoError(b, err)
 							}
 							m := newMergingIter(nil /* logger */, DefaultComparer.Compare, iters...)
 

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -172,11 +172,11 @@ func runIterCmd(td *datadriven.TestData, r *Reader) string {
 			return fmt.Sprintf("%s: unknown arg: %s", td.Cmd, arg.Key)
 		}
 	}
-
-	iter := newIterAdapter(r.NewIter(nil /* lower */, nil /* upper */))
-	if err := iter.Error(); err != nil {
+	origIter, err := r.NewIter(nil /* lower */, nil /* upper */)
+	if err != nil {
 		return err.Error()
 	}
+	iter := newIterAdapter(origIter)
 	defer iter.Close()
 
 	var b bytes.Buffer

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -142,7 +142,11 @@ func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
 		}
 
 		// Check using SeekGE.
-		i := newIterAdapter(r.NewIter(nil /* lower */, nil /* upper */))
+		iter, err := r.NewIter(nil /* lower */, nil /* upper */)
+		if err != nil {
+			return err
+		}
+		i := newIterAdapter(iter)
 		if !i.SeekGE([]byte(k)) || string(i.Key().UserKey) != k {
 			return errors.Errorf("Find %q: key was not in the table", k)
 		}
@@ -188,7 +192,11 @@ func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
 		}
 
 		// Check using Find.
-		i := newIterAdapter(r.NewIter(nil /* lower */, nil /* upper */))
+		iter, err := r.NewIter(nil /* lower */, nil /* upper */)
+		if err != nil {
+			return err
+		}
+		i := newIterAdapter(iter)
 		if i.SeekGE([]byte(s)) && s == string(i.Key().UserKey) {
 			return errors.Errorf("Find %q: unexpectedly found key in the table", s)
 		}
@@ -214,7 +222,11 @@ func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
 		{0, "~"},
 	}
 	for _, ct := range countTests {
-		n, i := 0, newIterAdapter(r.NewIter(nil /* lower */, nil /* upper */))
+		iter, err := r.NewIter(nil /* lower */, nil /* upper */)
+		if err != nil {
+			return err
+		}
+		n, i := 0, newIterAdapter(iter)
 		for valid := i.SeekGE([]byte(ct.start)); valid; valid = i.Next() {
 			n++
 		}
@@ -263,7 +275,11 @@ func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
 			upper = []byte(words[upperIdx])
 		}
 
-		i := newIterAdapter(r.NewIter(lower, upper))
+		iter, err := r.NewIter(lower, upper)
+		if err != nil {
+			return err
+		}
+		i := newIterAdapter(iter)
 
 		{
 			// NB: the semantics of First are that it starts iteration from the
@@ -625,7 +641,9 @@ func TestFinalBlockIsWritten(t *testing.T) {
 					if err != nil {
 						t.Errorf("nk=%d, vLen=%d: reader open: %v", nk, vLen, err)
 					}
-					i := newIterAdapter(r.NewIter(nil /* lower */, nil /* upper */))
+					iter, err := r.NewIter(nil /* lower */, nil /* upper */)
+					require.NoError(t, err)
+					i := newIterAdapter(iter)
 					for valid := i.First(); valid; valid = i.Next() {
 						got++
 					}
@@ -658,7 +676,9 @@ func TestReaderGlobalSeqNum(t *testing.T) {
 	const globalSeqNum = 42
 	r.Properties.GlobalSeqNum = globalSeqNum
 
-	i := newIterAdapter(r.NewIter(nil /* lower */, nil /* upper */))
+	iter, err := r.NewIter(nil /* lower */, nil /* upper */)
+	require.NoError(t, err)
+	i := newIterAdapter(iter)
 	for valid := i.First(); valid; valid = i.Next() {
 		if globalSeqNum != i.Key().SeqNum() {
 			t.Fatalf("expected %d, but found %d", globalSeqNum, i.Key().SeqNum())

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -60,7 +60,11 @@ func TestWriter(t *testing.T) {
 				meta.SmallestSeqNum, meta.LargestSeqNum)
 
 		case "scan":
-			iter := newIterAdapter(r.NewIter(nil /* lower */, nil /* upper */))
+			origIter, err := r.NewIter(nil /* lower */, nil /* upper */)
+			if err != nil {
+				return err.Error()
+			}
+			iter := newIterAdapter(origIter)
 			defer iter.Close()
 
 			var buf bytes.Buffer

--- a/tool/find.go
+++ b/tool/find.go
@@ -407,7 +407,10 @@ func (f *findT) searchTables(searchKey []byte, refs []findRef) []findRef {
 				r.Properties.GlobalSeqNum = m.LargestSeqNum
 			}
 
-			iter := r.NewIter(nil, nil)
+			iter, err := r.NewIter(nil, nil)
+			if err != nil {
+				return err
+			}
 			defer iter.Close()
 			key, value := iter.SeekGE(searchKey)
 

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -167,7 +167,11 @@ func (s *sstableT) runCheck(cmd *cobra.Command, args []string) {
 		// Update the internal formatter if this comparator has one specified.
 		s.fmtKey.setForComparer(r.Properties.ComparerName, s.comparers)
 
-		iter := r.NewIter(nil, nil)
+		iter, err := r.NewIter(nil, nil)
+		if err != nil {
+			fmt.Fprintf(stderr, "%s\n", err)
+			return
+		}
 		var lastKey base.InternalKey
 		for key, _ := iter.First(); key != nil; key, _ = iter.Next() {
 			if base.InternalCompare(r.Compare, lastKey, *key) >= 0 {
@@ -340,7 +344,11 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 		// Update the internal formatter if this comparator has one specified.
 		s.fmtKey.setForComparer(r.Properties.ComparerName, s.comparers)
 
-		iter := r.NewIter(nil, s.end)
+		iter, err := r.NewIter(nil, s.end)
+		if err != nil {
+			fmt.Fprintf(stderr, "%s%s\n", prefix, err)
+			return
+		}
 		defer iter.Close()
 		key, value := iter.SeekGE(s.start)
 


### PR DESCRIPTION
Add an error return value to `NewIter` and `NewCompactionIter`. If either of
these functions error, they guarantee they clean up after themselves
and return `nil, err`.

Also, remove `Init` from the `sstable.Iterator` interface because it's unused
outside of the sstable package.