### PR TITLE
db: clear iter err before absolute positioning

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -895,6 +895,7 @@ func (i *batchIter) String() string {
 }
 
 func (i *batchIter) SeekGE(key []byte) (*InternalKey, []byte) {
+	i.err = nil // clear cached iteration error
 	ikey := i.iter.SeekGE(key)
 	if ikey == nil {
 		return nil, nil
@@ -903,10 +904,12 @@ func (i *batchIter) SeekGE(key []byte) (*InternalKey, []byte) {
 }
 
 func (i *batchIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
+	i.err = nil // clear cached iteration error
 	return i.SeekGE(key)
 }
 
 func (i *batchIter) SeekLT(key []byte) (*InternalKey, []byte) {
+	i.err = nil // clear cached iteration error
 	ikey := i.iter.SeekLT(key)
 	if ikey == nil {
 		return nil, nil
@@ -915,6 +918,7 @@ func (i *batchIter) SeekLT(key []byte) (*InternalKey, []byte) {
 }
 
 func (i *batchIter) First() (*InternalKey, []byte) {
+	i.err = nil // clear cached iteration error
 	ikey := i.iter.First()
 	if ikey == nil {
 		return nil, nil
@@ -923,6 +927,7 @@ func (i *batchIter) First() (*InternalKey, []byte) {
 }
 
 func (i *batchIter) Last() (*InternalKey, []byte) {
+	i.err = nil // clear cached iteration error
 	ikey := i.iter.Last()
 	if ikey == nil {
 		return nil, nil
@@ -1215,6 +1220,7 @@ func (i *flushableBatchIter) String() string {
 // SeekGE implements internalIterator.SeekGE, as documented in the pebble
 // package.
 func (i *flushableBatchIter) SeekGE(key []byte) (*InternalKey, []byte) {
+	i.err = nil // clear cached iteration error
 	ikey := base.MakeSearchKey(key)
 	i.index = sort.Search(len(i.offsets), func(j int) bool {
 		return base.InternalCompare(i.cmp, ikey, i.getKey(j)) <= 0
@@ -1239,6 +1245,7 @@ func (i *flushableBatchIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []b
 // SeekLT implements internalIterator.SeekLT, as documented in the pebble
 // package.
 func (i *flushableBatchIter) SeekLT(key []byte) (*InternalKey, []byte) {
+	i.err = nil // clear cached iteration error
 	ikey := base.MakeSearchKey(key)
 	i.index = sort.Search(len(i.offsets), func(j int) bool {
 		return base.InternalCompare(i.cmp, ikey, i.getKey(j)) <= 0
@@ -1258,6 +1265,7 @@ func (i *flushableBatchIter) SeekLT(key []byte) (*InternalKey, []byte) {
 // First implements internalIterator.First, as documented in the pebble
 // package.
 func (i *flushableBatchIter) First() (*InternalKey, []byte) {
+	i.err = nil // clear cached iteration error
 	if len(i.offsets) == 0 {
 		return nil, nil
 	}
@@ -1273,6 +1281,7 @@ func (i *flushableBatchIter) First() (*InternalKey, []byte) {
 // Last implements internalIterator.Last, as documented in the pebble
 // package.
 func (i *flushableBatchIter) Last() (*InternalKey, []byte) {
+	i.err = nil // clear cached iteration error
 	if len(i.offsets) == 0 {
 		return nil, nil
 	}
@@ -1399,6 +1408,7 @@ func (i *flushFlushableBatchIter) SeekLT(key []byte) (*InternalKey, []byte) {
 }
 
 func (i *flushFlushableBatchIter) First() (*InternalKey, []byte) {
+	i.err = nil // clear cached iteration error
 	key, val := i.flushableBatchIter.First()
 	if key == nil {
 		return nil, nil

--- a/db.go
+++ b/db.go
@@ -700,8 +700,10 @@ func (d *DB) newIterInternal(
 			// Ensure the mergingIter is initialized so Iterator.Close will properly
 			// close any sstable iterators that have been opened.
 			buf.merging.init(&dbi.opts, d.cmp, mlevels...)
-			dbi.err = err
-			return dbi
+			_ = dbi.Close()
+			// Return a new alloced Iterator structure, because dbi.Close will
+			// return dbi to a sync.Pool.
+			return &Iterator{err: err}
 		}
 		mlevels = append(mlevels, mergingIterLevel{
 			iter:         iter,

--- a/error_test.go
+++ b/error_test.go
@@ -198,6 +198,9 @@ func TestRequireReadError(t *testing.T) {
 		// Now perform foreground ops with error injection enabled.
 		inj.SetIndex(index)
 		iter := d.NewIter(nil)
+		if err := iter.Error(); err != nil {
+			return err
+		}
 		numFound := 0
 		expectedKeys := [][]byte{key1, key2}
 		for valid := iter.First(); valid; valid = iter.Next() {
@@ -280,6 +283,10 @@ func TestCorruptReadError(t *testing.T) {
 		// Now perform foreground ops with corruption injection enabled.
 		atomic.StoreInt32(&fs.index, index)
 		iter := d.NewIter(nil)
+		if err := iter.Error(); err != nil {
+			return err
+		}
+
 		numFound := 0
 		expectedKeys := [][]byte{key1, key2}
 		for valid := iter.First(); valid; valid = iter.Next() {

--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -69,6 +69,11 @@ import "fmt"
 // underlying DB, if that DB permits modification. However, the resultant
 // key/value pairs are not guaranteed to be a consistent snapshot of that DB
 // at a particular point in time.
+//
+// InternalIterators accumulate errors encountered during operation, exposing
+// them through the Error method. All of the absolute positioning methods
+// reset any accumulated error before positioning. Relative positioning
+// methods return without advancing if the iterator has accumulated an error.
 type InternalIterator interface {
 	// SeekGE moves the iterator to the first key/value pair whose key is greater
 	// than or equal to the given key. Returns the key and value if the iterator

--- a/level_iter.go
+++ b/level_iter.go
@@ -344,6 +344,8 @@ func (l *levelIter) verify(key *InternalKey, val []byte) (*InternalKey, []byte) 
 }
 
 func (l *levelIter) SeekGE(key []byte) (*InternalKey, []byte) {
+	l.err = nil // clear cached iteration error
+
 	// NB: the top-level Iterator has already adjusted key based on
 	// IterOptions.LowerBound.
 	if !l.loadFile(l.findFileGE(key), 1) {
@@ -356,6 +358,8 @@ func (l *levelIter) SeekGE(key []byte) (*InternalKey, []byte) {
 }
 
 func (l *levelIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
+	l.err = nil // clear cached iteration error
+
 	// NB: the top-level Iterator has already adjusted key based on
 	// IterOptions.LowerBound.
 	if !l.loadFile(l.findFileGE(key), 1) {
@@ -381,6 +385,8 @@ func (l *levelIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
 }
 
 func (l *levelIter) SeekLT(key []byte) (*InternalKey, []byte) {
+	l.err = nil // clear cached iteration error
+
 	// NB: the top-level Iterator has already adjusted key based on
 	// IterOptions.UpperBound.
 	if !l.loadFile(l.findFileLT(key), -1) {
@@ -393,6 +399,8 @@ func (l *levelIter) SeekLT(key []byte) (*InternalKey, []byte) {
 }
 
 func (l *levelIter) First() (*InternalKey, []byte) {
+	l.err = nil // clear cached iteration error
+
 	// NB: the top-level Iterator will call SeekGE if IterOptions.LowerBound is
 	// set.
 	if !l.loadFile(0, 1) {
@@ -405,6 +413,8 @@ func (l *levelIter) First() (*InternalKey, []byte) {
 }
 
 func (l *levelIter) Last() (*InternalKey, []byte) {
+	l.err = nil // clear cached iteration error
+
 	// NB: the top-level Iterator will call SeekLT if IterOptions.UpperBound is
 	// set.
 	if !l.loadFile(len(l.files)-1, -1) {

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -248,7 +248,7 @@ func newMergingIter(logger Logger, cmp Compare, iters ...internalIterator) *merg
 }
 
 func (m *mergingIter) init(opts *IterOptions, cmp Compare, levels ...mergingIterLevel) {
-	m.err = nil
+	m.err = nil // clear cached iteration error
 	m.logger = opts.getLogger()
 	if opts != nil {
 		m.lower = opts.LowerBound
@@ -795,6 +795,7 @@ func (m *mergingIter) String() string {
 // the upper bound. It is up to the caller to ensure that key is greater than
 // or equal to the lower bound.
 func (m *mergingIter) SeekGE(key []byte) (*InternalKey, []byte) {
+	m.err = nil // clear cached iteration error
 	m.prefix = nil
 	m.seekGE(key, 0 /* start level */)
 	return m.findNextEntry()
@@ -804,6 +805,7 @@ func (m *mergingIter) SeekGE(key []byte) (*InternalKey, []byte) {
 // SeekPrefixGE only checks the upper bound. It is up to the caller to ensure
 // that key is greater than or equal to the lower bound.
 func (m *mergingIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
+	m.err = nil // clear cached iteration error
 	m.prefix = prefix
 	m.seekGE(key, 0 /* start level */)
 	return m.findNextEntry()
@@ -873,6 +875,7 @@ func (m *mergingIter) seekLT(key []byte, level int) {
 // the lower bound. It is up to the caller to ensure that key is less than the
 // upper bound.
 func (m *mergingIter) SeekLT(key []byte) (*InternalKey, []byte) {
+	m.err = nil // clear cached iteration error
 	m.prefix = nil
 	m.seekLT(key, 0 /* start level */)
 	return m.findPrevEntry()
@@ -882,6 +885,7 @@ func (m *mergingIter) SeekLT(key []byte) (*InternalKey, []byte) {
 // the upper bound. It is up to the caller to ensure that key is greater than
 // or equal to the lower bound (e.g. via a call to SeekGE(lower)).
 func (m *mergingIter) First() (*InternalKey, []byte) {
+	m.err = nil // clear cached iteration error
 	m.prefix = nil
 	m.heap.items = m.heap.items[:0]
 	for i := range m.levels {
@@ -896,6 +900,7 @@ func (m *mergingIter) First() (*InternalKey, []byte) {
 // lower bound. It is up to the caller to ensure that key is less than the
 // upper bound (e.g. via a call to SeekLT(upper))
 func (m *mergingIter) Last() (*InternalKey, []byte) {
+	m.err = nil // clear cached iteration error
 	m.prefix = nil
 	for i := range m.levels {
 		l := &m.levels[i]

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -231,9 +231,7 @@ func (i *singleLevelIterator) recordOffset() uint64 {
 // package. Note that SeekGE only checks the upper bound. It is up to the
 // caller to ensure that key is greater than or equal to the lower bound.
 func (i *singleLevelIterator) SeekGE(key []byte) (*InternalKey, []byte) {
-	if i.err != nil {
-		return nil, nil
-	}
+	i.err = nil // clear cached iteration error
 
 	if ikey, _ := i.index.SeekGE(key); ikey == nil {
 		// The target key is greater than any key in the sstable. Invalidate the
@@ -258,9 +256,7 @@ func (i *singleLevelIterator) SeekGE(key []byte) (*InternalKey, []byte) {
 // pebble package. Note that SeekPrefixGE only checks the upper bound. It is up
 // to the caller to ensure that key is greater than or equal to the lower bound.
 func (i *singleLevelIterator) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
-	if i.err != nil {
-		return nil, nil
-	}
+	i.err = nil // clear cached iteration error
 
 	// Check prefix bloom filter.
 	if i.reader.tableFilter != nil {
@@ -298,9 +294,7 @@ func (i *singleLevelIterator) SeekPrefixGE(prefix, key []byte) (*InternalKey, []
 // package. Note that SeekLT only checks the lower bound. It is up to the
 // caller to ensure that key is less than the upper bound.
 func (i *singleLevelIterator) SeekLT(key []byte) (*InternalKey, []byte) {
-	if i.err != nil {
-		return nil, nil
-	}
+	i.err = nil // clear cached iteration error
 
 	if ikey, _ := i.index.SeekGE(key); ikey == nil {
 		i.index.Last()
@@ -333,9 +327,7 @@ func (i *singleLevelIterator) SeekLT(key []byte) (*InternalKey, []byte) {
 // to ensure that key is greater than or equal to the lower bound (e.g. via a
 // call to SeekGE(lower)).
 func (i *singleLevelIterator) First() (*InternalKey, []byte) {
-	if i.err != nil {
-		return nil, nil
-	}
+	i.err = nil // clear cached iteration error
 
 	if ikey, _ := i.index.First(); ikey == nil {
 		i.data.invalidate()
@@ -358,9 +350,7 @@ func (i *singleLevelIterator) First() (*InternalKey, []byte) {
 // to ensure that key is less than the upper bound (e.g. via a call to
 // SeekLT(upper))
 func (i *singleLevelIterator) Last() (*InternalKey, []byte) {
-	if i.err != nil {
-		return nil, nil
-	}
+	i.err = nil // clear cached iteration error
 
 	if ikey, _ := i.index.Last(); ikey == nil {
 		i.data.invalidate()
@@ -534,6 +524,7 @@ func (i *compactionIterator) SeekLT(key []byte) (*InternalKey, []byte) {
 }
 
 func (i *compactionIterator) First() (*InternalKey, []byte) {
+	i.err = nil // clear cached iteration error
 	return i.skipForward(i.singleLevelIterator.First())
 }
 
@@ -636,9 +627,7 @@ func (i *twoLevelIterator) String() string {
 // package. Note that SeekGE only checks the upper bound. It is up to the
 // caller to ensure that key is greater than or equal to the lower bound.
 func (i *twoLevelIterator) SeekGE(key []byte) (*InternalKey, []byte) {
-	if i.err != nil {
-		return nil, nil
-	}
+	i.err = nil // clear cached iteration error
 
 	if ikey, _ := i.topLevelIndex.SeekGE(key); ikey == nil {
 		return nil, nil
@@ -658,9 +647,7 @@ func (i *twoLevelIterator) SeekGE(key []byte) (*InternalKey, []byte) {
 // pebble package. Note that SeekPrefixGE only checks the upper bound. It is up
 // to the caller to ensure that key is greater than or equal to the lower bound.
 func (i *twoLevelIterator) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
-	if i.err != nil {
-		return nil, nil
-	}
+	i.err = nil // clear cached iteration error
 
 	if ikey, _ := i.topLevelIndex.SeekGE(key); ikey == nil {
 		return nil, nil
@@ -680,9 +667,7 @@ func (i *twoLevelIterator) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byt
 // package. Note that SeekLT only checks the lower bound. It is up to the
 // caller to ensure that key is less than the upper bound.
 func (i *twoLevelIterator) SeekLT(key []byte) (*InternalKey, []byte) {
-	if i.err != nil {
-		return nil, nil
-	}
+	i.err = nil // clear cached iteration error
 
 	if ikey, _ := i.topLevelIndex.SeekGE(key); ikey == nil {
 		if ikey, _ := i.topLevelIndex.Last(); ikey == nil {
@@ -711,9 +696,7 @@ func (i *twoLevelIterator) SeekLT(key []byte) (*InternalKey, []byte) {
 // to ensure that key is greater than or equal to the lower bound (e.g. via a
 // call to SeekGE(lower)).
 func (i *twoLevelIterator) First() (*InternalKey, []byte) {
-	if i.err != nil {
-		return nil, nil
-	}
+	i.err = nil // clear cached iteration error
 
 	if ikey, _ := i.topLevelIndex.First(); ikey == nil {
 		return nil, nil
@@ -734,9 +717,7 @@ func (i *twoLevelIterator) First() (*InternalKey, []byte) {
 // to ensure that key is less than the upper bound (e.g. via a call to
 // SeekLT(upper))
 func (i *twoLevelIterator) Last() (*InternalKey, []byte) {
-	if i.err != nil {
-		return nil, nil
-	}
+	i.err = nil // clear cached iteration error
 
 	if ikey, _ := i.topLevelIndex.Last(); ikey == nil {
 		return nil, nil
@@ -863,6 +844,7 @@ func (i *twoLevelCompactionIterator) SeekLT(key []byte) (*InternalKey, []byte) {
 }
 
 func (i *twoLevelCompactionIterator) First() (*InternalKey, []byte) {
+	i.err = nil // clear cached iteration error
 	return i.skipForward(i.twoLevelIterator.First())
 }
 


### PR DESCRIPTION
This change updates iterator (internal and external) error handling such
that errors are cleared before performing absolute positioning
operations (SeekGE, SeekLT, First, Last, etc). Relative positioning
operations (Next, Prev) are unchanged and return immediately if the
iterator has accumulated an error.

Additionally, if an error occurs while creating a new *pebble.Iterator,
the iterator's resources are immediately cleaned up and a
*pebble.Iterator that will always error is returned.