### PR TITLE
db: unlock manifest on ingest error

### DIFF
--- a/db.go
+++ b/db.go
@@ -992,11 +992,11 @@ func (d *DB) AsyncFlush() (<-chan struct{}, error) {
 	}
 
 	d.commit.mu.Lock()
+	defer d.commit.mu.Unlock()
 	d.mu.Lock()
+	defer d.mu.Unlock()
 	flushed := d.mu.mem.queue[len(d.mu.mem.queue)-1].flushed
 	err := d.makeRoomForWrite(nil)
-	d.mu.Unlock()
-	d.commit.mu.Unlock()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/errorfs/errorfs.go
+++ b/internal/errorfs/errorfs.go
@@ -37,7 +37,7 @@ func (ii *InjectIndex) SetIndex(v int32) { atomic.StoreInt32(&ii.index, v) }
 // MaybeError implements the Injector interface.
 func (ii *InjectIndex) MaybeError() error {
 	if atomic.AddInt32(&ii.index, -1) == -1 {
-		return ErrInjected
+		return errors.WithStack(ErrInjected)
 	}
 	return nil
 }

--- a/internal/record/log_writer.go
+++ b/internal/record/log_writer.go
@@ -523,8 +523,10 @@ func (w *LogWriter) Close() error {
 	}
 
 	if w.c != nil {
-		if err := w.c.Close(); err != nil {
-			return err
+		cerr := w.c.Close()
+		w.c = nil
+		if cerr != nil {
+			return cerr
 		}
 	}
 	w.err = errors.New("pebble/record: closed LogWriter")


### PR DESCRIPTION
Previously, if `ingestTargetLevel` returned an error, Ingest would
return without unlocking the manifest. Any future updates to the
manifest would block indefinitely.

This commit also includes a few additional small fixes that fell out of
the TestIngestError unit test.

* check unchecked iterator Errors in a couple locations within ingestLoad1
* nil out a record.LogWriter's Closer once it's Close method has been
called. This prevents a panic from a double Close of the underlying
file.