### PR TITLE
internal/manifest: Introduce L0SubLevels data structure

### DIFF
--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -1,0 +1,446 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package manifest
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+)
+
+// TODO(bilal): work items:
+// - Integration with Pebble
+
+// Intervals are of the form [start, end) with no gap between intervals. Each
+// file overlaps perfectly with a sequence of intervals. This perfect overlap
+// occurs because the union of file boundary keys is used to pick intervals.
+// However the largest key in a file is inclusive, so when it is used as
+// an interval, the actual key is ImmediateSuccessor(key). We don't have the
+// ImmediateSuccessor function to do this computation, so we instead keep an
+// isLargest bool to remind the code about this fact. This is used for
+// comparisons in the following manner:
+// - intervalKey{k, false} < intervalKey{k, true}
+// - k1 < k2 => intervalKey{k1, _} < intervalKey{k2, _}.
+//
+// For example, consider three files with bounds [a,e], [b,g], and [e,j]. The
+// interval keys produced would be intervalKey{a, false}, intervalKey{b, false},
+// intervalKey{e, false}, intervalKey{e, true}, intervalKey{g, true} and
+// intervalKey{j, true}, resulting in intervals
+// [a, b), [b, (e, false)), [(e,false), (e, true)), [(e, true), (g, true)) and
+// [(g, true), (j, true)). The first file overlaps with the first three
+// perfectly, the second file overlaps with the second through to fourth
+// intervals, and the third file overlaps with the last three.
+//
+// The intervals are indexed starting from 0, with the index of the interval
+// being the index of the start key of the interval.
+//
+// In addition to helping with compaction picking, we use interval indices
+// to assign each file an interval range once. Subsequent operations, say
+// picking overlapping files for a compaction, only need to use the index
+// numbers and so avoid expensive byte slice comparisons.
+type intervalKey struct {
+	key       []byte
+	isLargest bool
+}
+
+func intervalKeyCompare(cmp Compare, a, b intervalKey) int {
+	rv := cmp(a.key, b.key)
+	if rv == 0 {
+		if a.isLargest && !b.isLargest {
+			return +1
+		}
+		if !a.isLargest && b.isLargest {
+			return -1
+		}
+	}
+	return rv
+}
+
+type intervalKeySorter struct {
+	keys []intervalKey
+	cmp  Compare
+}
+
+func (s intervalKeySorter) Len() int { return len(s.keys) }
+func (s intervalKeySorter) Less(i, j int) bool {
+	return intervalKeyCompare(s.cmp, s.keys[i], s.keys[j]) < 0
+}
+func (s intervalKeySorter) Swap(i, j int) {
+	s.keys[i], s.keys[j] = s.keys[j], s.keys[i]
+}
+
+func sortAndDedup(keys []intervalKey, cmp Compare) []intervalKey {
+	if len(keys) == 0 {
+		return nil
+	}
+	sorter := intervalKeySorter{keys: keys, cmp: cmp}
+	sort.Sort(sorter)
+	j := 0
+	for i := 1; i < len(keys); i++ {
+		cmp := intervalKeyCompare(cmp, keys[i], keys[j])
+		if cmp != 0 {
+			j++
+			keys[j] = keys[i]
+		}
+	}
+	return keys[:j+1]
+}
+
+type subLevelAndFile struct {
+	subLevel  int
+	fileIndex int
+}
+
+// A key interval of the form [start, end). The end is not represented here
+// since it is implicit in the start of the next interval. The last interval is
+// an exception but we don't need to ever lookup the end of that interval; the
+// last fileInterval will only act as an end key marker. The set of intervals
+// is const after initialization.
+type fileInterval struct {
+	index    int
+	startKey intervalKey
+
+	// True iff some file in this interval is compacting to base. Such intervals
+	// cannot have any files participate in L0 => Lbase compactions.
+	isBaseCompacting bool
+
+	// The min and max intervals index across all the files that overlap with this
+	// interval. Inclusive on both sides.
+	filesMinIntervalIndex int
+	filesMaxIntervalIndex int
+
+	// True if another interval that has a file extending into this interval is
+	// undergoing a compaction into Lbase. In other words, this bool is true
+	// if any interval in [filesMinIntervalIndex,
+	// filesMaxIntervalIndex] has isBaseCompacting set to true. This
+	// lets the compaction picker de-prioritize this interval for picking
+	// compactions, since there's a high chance that a base compaction with a
+	// sufficient height of sublevels rooted at this interval could not be
+	// chosen due to the ongoing base compaction in the
+	// other interval. If the file straddling the two intervals is at a
+	// sufficiently high sublevel (with enough compactible files below it to
+	// satisfy minCompactionDepth), this is not an issue, but to optimize for
+	// quickly picking base compactions far away from other base compactions,
+	// this bool is used as a heuristic (but not as a complete disqualifier).
+	intervalRangeIsBaseCompacting bool
+
+	// fileCount - compactingFileCount is the stack depth that requires
+	// starting new compactions. This metric is not precise since the
+	// compactingFileCount can include files that are part of N (where N > 1)
+	// intra-L0 compactions, so the stack depth after those complete will be
+	// fileCount - compactingFileCount + N. We ignore this imprecision since
+	// we don't want to track which files are part of which intra-L0
+	// compaction.
+	fileCount           int
+	compactingFileCount int
+
+	// The number of consecutive files starting from the the top of the stack
+	// in this range that are not compacting. Note that any intra-L0
+	// compaction can only choose from these files. Additionally after some
+	// subset of files starting from the top are disqualified because of being
+	// too young (earliestUnflushedSeqNum), any files picked are the next
+	// ones.
+	topOfStackNonCompactingFileCount int
+	// In increasing sublevel order.
+	subLevelAndFileList []subLevelAndFile
+
+	// Interpolated from files in this interval. For files spanning multiple
+	// intervals, we assume an equal distribution of bytes across all those
+	// intervals.
+	estimatedBytes uint64
+}
+
+// L0SubLevels represents a sublevel view of SSTables in L0. Tables in one
+// sublevel are non-overlapping in key ranges, and keys in higher-indexed
+// sublevels shadow older versions in lower-indexed sublevels. These invariants
+// are similar to the regular level invariants, except with higher indexed
+// sublevels having newer keys as opposed to lower indexed levels.
+//
+// There is no limit to the number of sublevels that can exist in L0 at any
+// time, however read and compaction performance is best when there are as few
+// sublevels as possible.
+type L0SubLevels struct {
+	// Files are ordered from oldest sublevel to youngest sublevel in the
+	// outer slice, and the inner slice contains non-overlapping files for
+	// that sublevel in increasing key order.
+	Files [][]*FileMetadata
+
+	cmp    Compare
+	format base.Formatter
+
+	fileBytes uint64
+	// Contains all files in one slice, ordered from oldest to youngest.
+	filesByAge []*FileMetadata
+
+	// The file intervals in increasing key order.
+	orderedIntervals []fileInterval
+
+	// Keys to break flushes at.
+	flushSplitUserKeys [][]byte
+}
+
+func insertIntoSubLevel(files []*FileMetadata, f *FileMetadata) []*FileMetadata {
+	index := sort.Search(len(files), func(i int) bool {
+		return f.minIntervalIndex < files[i].minIntervalIndex
+	})
+	if index == len(files) {
+		files = append(files, f)
+		return files
+	}
+	files = append(files, nil)
+	copy(files[index+1:], files[index:])
+	files[index] = f
+	return files
+}
+
+// NewL0SubLevels creates an L0SubLevels instance for a given set of L0 files.
+// These files must all be in L0 and must be sorted by seqnum (see
+// SortBySeqNum). During interval iteration, when flushSplitMaxBytes bytes are
+// exceeded in the range of intervals since the last flush split key, a flush
+// split key is added.
+func NewL0SubLevels(
+	files []*FileMetadata,
+	cmp Compare,
+	formatter base.Formatter,
+	flushSplitMaxBytes uint64,
+) (*L0SubLevels, error) {
+	s := &L0SubLevels{cmp: cmp, format: formatter}
+	s.filesByAge = files
+	keys := make([]intervalKey, 0, 2*len(files))
+	for i := range s.filesByAge {
+		files[i].l0Index = i
+		keys = append(keys, intervalKey{key: files[i].Smallest.UserKey})
+		keys = append(keys, intervalKey{key: files[i].Largest.UserKey, isLargest: true})
+	}
+	keys = sortAndDedup(keys, cmp)
+	// All interval indices reference s.orderedIntervals.
+	s.orderedIntervals = make([]fileInterval, len(keys))
+	for i := range keys {
+		s.orderedIntervals[i] = fileInterval{
+			index:                 i,
+			startKey:              keys[i],
+			filesMinIntervalIndex: i,
+			filesMaxIntervalIndex: i,
+		}
+	}
+	// Initialize minIntervalIndex and maxIntervalIndex for each file, and use that
+	// to update intervals.
+	intervalRangeIsBaseCompacting := make([]bool, len(keys))
+	for fileIndex, f := range s.filesByAge {
+		// Set f.minIntervalIndex and f.maxIntervalIndex.
+		f.minIntervalIndex = sort.Search(len(keys), func(index int) bool {
+			return intervalKeyCompare(cmp, intervalKey{key: f.Smallest.UserKey}, keys[index]) <= 0
+		})
+		if f.minIntervalIndex == len(keys) {
+			return nil, errors.Errorf("expected sstable bound to be in interval keys: %s", f.Smallest.UserKey)
+		}
+		f.maxIntervalIndex = sort.Search(len(keys), func(index int) bool {
+			return intervalKeyCompare(
+				cmp, intervalKey{key: f.Largest.UserKey, isLargest: true}, keys[index]) <= 0
+		})
+		if f.maxIntervalIndex == len(keys) {
+			return nil, errors.Errorf("expected sstable bound to be in interval keys: %s", f.Largest.UserKey)
+		}
+		f.maxIntervalIndex--
+		// This is a simple and not very accurate estimate of the number of
+		// bytes this SSTable contributes to the intervals it is a part of.
+		//
+		// TODO(bilal): Call EstimateDiskUsage in sstable.Reader with interval
+		// bounds to get a better estimate for each interval.
+		interpolatedBytes := f.Size / uint64(f.maxIntervalIndex-f.minIntervalIndex+1)
+		s.fileBytes += f.Size
+		subLevel := 0
+		// Update state in every fileInterval for this file.
+		for i := f.minIntervalIndex; i <= f.maxIntervalIndex; i++ {
+			interval := &s.orderedIntervals[i]
+			if len(interval.subLevelAndFileList) > 0 &&
+				subLevel <= interval.subLevelAndFileList[len(interval.subLevelAndFileList)-1].subLevel {
+				subLevel = interval.subLevelAndFileList[len(interval.subLevelAndFileList)-1].subLevel + 1
+			}
+			s.orderedIntervals[i].fileCount++
+			if f.Compacting {
+				interval.compactingFileCount++
+				interval.topOfStackNonCompactingFileCount = 0
+				if !f.IsIntraL0Compacting {
+					// If f.Compacting && !f.IsIntraL0Compacting, this file is
+					// being compacted to Lbase.
+					interval.isBaseCompacting = true
+					intervalRangeIsBaseCompacting[i] = true
+				}
+			} else if f.IsIntraL0Compacting {
+				return nil, errors.Errorf("file %s not marked as compacting but marked as intra-L0 compacting", f.FileNum)
+			} else {
+				interval.topOfStackNonCompactingFileCount++
+			}
+			interval.estimatedBytes += interpolatedBytes
+			if f.minIntervalIndex < interval.filesMinIntervalIndex {
+				interval.filesMinIntervalIndex = f.minIntervalIndex
+			}
+			if f.maxIntervalIndex > interval.filesMaxIntervalIndex {
+				interval.filesMaxIntervalIndex = f.maxIntervalIndex
+			}
+		}
+		for i := f.minIntervalIndex; i <= f.maxIntervalIndex; i++ {
+			interval := &s.orderedIntervals[i]
+			interval.subLevelAndFileList = append(interval.subLevelAndFileList,
+				subLevelAndFile{subLevel: subLevel, fileIndex: fileIndex})
+		}
+		f.subLevel = subLevel
+		if subLevel > len(s.Files) {
+			return nil, errors.Errorf("chose a sublevel beyond allowed range of sublevels: %d vs 0-%d", subLevel, len(s.Files))
+		}
+		if subLevel == len(s.Files) {
+			s.Files = append(s.Files, []*FileMetadata{f})
+		} else {
+			s.Files[subLevel] = insertIntoSubLevel(s.Files[subLevel], f)
+		}
+	}
+	min := 0
+	var cumulativeBytes uint64
+	for i := 0; i < len(s.orderedIntervals); i++ {
+		interval := &s.orderedIntervals[i]
+		if interval.isBaseCompacting {
+			minIndex := interval.filesMinIntervalIndex
+			if minIndex < min {
+				minIndex = min
+			}
+			for j := minIndex; j <= interval.filesMaxIntervalIndex; j++ {
+				min = j
+				s.orderedIntervals[j].intervalRangeIsBaseCompacting = true
+			}
+		}
+		if cumulativeBytes > flushSplitMaxBytes && (len(s.flushSplitUserKeys) == 0 ||
+			!bytes.Equal(interval.startKey.key, s.flushSplitUserKeys[len(s.flushSplitUserKeys)-1])) {
+			s.flushSplitUserKeys = append(s.flushSplitUserKeys, interval.startKey.key)
+			cumulativeBytes = 0
+		}
+		cumulativeBytes += s.orderedIntervals[i].estimatedBytes
+	}
+	return s, nil
+}
+
+// String produces a string containing useful debug information. Useful in test
+// code and debugging.
+func (s *L0SubLevels) String() string {
+	return s.describe(false)
+}
+
+func (s *L0SubLevels) describe(verbose bool) string {
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "file count: %d, sublevels: %d, intervals: %d\nflush split keys(%d): [",
+		len(s.filesByAge), len(s.Files), len(s.orderedIntervals), len(s.flushSplitUserKeys))
+	for i := range s.flushSplitUserKeys {
+		fmt.Fprintf(&buf, "%s", s.format(s.flushSplitUserKeys[i]))
+		if i < len(s.flushSplitUserKeys) - 1 {
+			fmt.Fprintf(&buf, ", ")
+		}
+	}
+	fmt.Fprintln(&buf, "]")
+	numCompactingFiles := 0
+	for i := len(s.Files) - 1; i >= 0; i-- {
+		maxIntervals := 0
+		sumIntervals := 0
+		var totalBytes uint64
+		for _, f := range s.Files[i] {
+			intervals := f.maxIntervalIndex - f.minIntervalIndex + 1
+			if intervals > maxIntervals {
+				maxIntervals = intervals
+			}
+			sumIntervals += intervals
+			totalBytes += f.Size
+			if f.Compacting {
+				numCompactingFiles++
+			}
+		}
+		fmt.Fprintf(&buf, "0.%d: file count: %d, bytes: %d, width (mean, max): %0.1f, %d, interval range: [%d, %d]\n",
+			i, len(s.Files[i]), totalBytes, float64(sumIntervals)/float64(len(s.Files[i])), maxIntervals, s.Files[i][0].minIntervalIndex,
+			s.Files[i][len(s.Files[i])-1].maxIntervalIndex)
+		if verbose {
+			for _, f := range s.Files[i] {
+				intervals := f.maxIntervalIndex - f.minIntervalIndex + 1
+				fmt.Fprintf(&buf, "\t%s\n", f)
+				if len(s.filesByAge) > 50 && intervals*3 > len(s.orderedIntervals) {
+					var intervalsBytes uint64
+					for k := f.minIntervalIndex; k <= f.maxIntervalIndex; k++ {
+						intervalsBytes += s.orderedIntervals[k].estimatedBytes
+					}
+					fmt.Fprintf(&buf, "wide file: %d, [%d, %d], byte fraction: %f\n",
+						f.FileNum, f.minIntervalIndex, f.maxIntervalIndex,
+						float64(intervalsBytes)/float64(s.fileBytes))
+				}
+			}
+		}
+	}
+	lastCompactingIntervalStart := -1
+	fmt.Fprintf(&buf, "compacting file count: %d, base compacting intervals: ", numCompactingFiles)
+	i := 0
+	for ; i < len(s.orderedIntervals); i++ {
+		interval := &s.orderedIntervals[i]
+		if interval.fileCount == 0 {
+			continue
+		}
+		if !interval.isBaseCompacting {
+			if lastCompactingIntervalStart != -1 {
+				fmt.Fprintf(&buf, "[%d, %d], ", lastCompactingIntervalStart, i-1)
+			}
+			lastCompactingIntervalStart = -1
+		} else {
+			if lastCompactingIntervalStart == -1 {
+				lastCompactingIntervalStart = i
+			}
+		}
+	}
+	if lastCompactingIntervalStart != -1 {
+		fmt.Fprintf(&buf, "[%d, %d], ", lastCompactingIntervalStart, i-1)
+	}
+	fmt.Fprintln(&buf, "")
+	return buf.String()
+}
+
+// ReadAmplification returns the contribution of L0Sublevels to the read
+// amplification for any particular point key. It is the maximum height of any
+// tracked fileInterval. This is always less than or equal to the number of
+// sublevels.
+func (s *L0SubLevels) ReadAmplification() int {
+	amp := 0
+	for i := range s.orderedIntervals {
+		interval := &s.orderedIntervals[i]
+		if amp < interval.fileCount {
+			amp = interval.fileCount
+		}
+	}
+	return amp
+}
+
+// FlushSplitKeys returns a slice of user keys to split flushes at.
+// Used by flushes to avoid writing sstables that straddle these split keys.
+// These should be interpreted as the keys to start the next sstable (not the
+// last key to include in the prev sstable). These are user keys so that
+// range tombstones can be properly truncated (untruncated range tombstones
+// are not permitted for L0 files).
+func (s *L0SubLevels) FlushSplitKeys() [][]byte {
+	return s.flushSplitUserKeys
+}
+
+// MaxDepthAfterOngoingCompactions returns an estimate of maximum depth of
+// sublevels after all ongoing compactions run to completion. Used by compaction
+// picker to decide compaction score for L0. There is no scoring for intra-L0
+// compactions -- they only run if L0 score is high but we're unable to pick an
+// L0 => Lbase compaction.
+func (s *L0SubLevels) MaxDepthAfterOngoingCompactions() int {
+	depth := 0
+	for i := range s.orderedIntervals {
+		interval := &s.orderedIntervals[i]
+		intervalDepth := interval.fileCount - interval.compactingFileCount
+		if depth < intervalDepth {
+			depth = intervalDepth
+		}
+	}
+	return depth
+}

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -1,0 +1,188 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package manifest
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/cockroachdb/pebble/internal/record"
+)
+
+func readManifest(filename string) (*Version, error) {
+	f, err := os.Open("testdata/MANIFEST_import")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	rr := record.NewReader(f, 0 /* logNum */)
+	var v *Version
+	for {
+		r, err := rr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		var ve VersionEdit
+		if err = ve.Decode(r); err != nil {
+			return nil, err
+		}
+		var bve BulkVersionEdit
+		bve.Accumulate(&ve)
+		if v, _, err = bve.Apply(v, base.DefaultComparer.Compare, base.DefaultFormatter); err != nil {
+			return nil, err
+		}
+	}
+	fmt.Printf("L0 filecount: %d\n", len(v.Files[0]))
+	return v, nil
+}
+
+func TestL0SubLevels(t *testing.T) {
+	parseMeta := func(s string) (*FileMetadata, error) {
+		parts := strings.Split(s, ":")
+		if len(parts) != 2 {
+			t.Fatalf("malformed table spec: %s", s)
+		}
+		fileNum, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+		if err != nil {
+			return nil, err
+		}
+		fields := strings.Fields(parts[1])
+		keyRange := strings.Split(strings.TrimSpace(fields[0]), "-")
+		m := FileMetadata{
+			Smallest: base.ParseInternalKey(strings.TrimSpace(keyRange[0])),
+			Largest:  base.ParseInternalKey(strings.TrimSpace(keyRange[1])),
+		}
+		m.SmallestSeqNum = m.Smallest.SeqNum()
+		m.LargestSeqNum = m.Largest.SeqNum()
+		m.FileNum = base.FileNum(fileNum)
+		m.Size = uint64(256)
+
+		if len(fields) > 1 {
+			for _, field := range fields[1:] {
+				parts := strings.Split(field, "=")
+				switch parts[0] {
+				case "base_compacting":
+					m.IsIntraL0Compacting = false
+					m.Compacting = true
+				case "intra_l0_compacting":
+					m.IsIntraL0Compacting = true
+					m.Compacting = true
+				case "compacting":
+					m.Compacting = true
+				case "size":
+					sizeInt, err := strconv.Atoi(parts[1])
+					if err != nil {
+						return nil, err
+					}
+					m.Size = uint64(sizeInt)
+				}
+			}
+		}
+
+		return &m, nil
+	}
+
+	var level int
+	var err error
+	var fileMetas [NumLevels][]*FileMetadata
+	var sublevels *L0SubLevels
+	baseLevel := NumLevels - 1
+
+	datadriven.RunTest(t, "testdata/l0_sublevels", func(td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "define":
+			fileMetas = [NumLevels][]*FileMetadata{}
+			baseLevel = NumLevels - 1
+			for _, data := range strings.Split(td.Input, "\n") {
+				data = strings.TrimSpace(data)
+				switch data {
+				case "L0", "L1", "L2", "L3", "L4", "L5", "L6":
+					level, err = strconv.Atoi(data[1:])
+					if err != nil {
+						return err.Error()
+					}
+				default:
+					meta, err := parseMeta(data)
+					if err != nil {
+						return err.Error()
+					}
+					if level != 0 && level < baseLevel {
+						baseLevel = level
+					}
+					fileMetas[level] = append(fileMetas[level], meta)
+				}
+			}
+
+			flushSplitMaxBytes := 64
+			for _, arg := range td.CmdArgs {
+				switch arg.Key {
+				case "flush_split_max_bytes":
+					flushSplitMaxBytes, err = strconv.Atoi(arg.Vals[0])
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			for i := 0; i < NumLevels; i++ {
+				SortBySeqNum(fileMetas[i])
+			}
+
+			sublevels, err = NewL0SubLevels(
+				fileMetas[0],
+				base.DefaultComparer.Compare,
+				base.DefaultFormatter,
+				uint64(flushSplitMaxBytes))
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var builder strings.Builder
+			builder.WriteString(sublevels.describe(true))
+			return builder.String()
+		case "read-amp":
+			return strconv.Itoa(sublevels.ReadAmplification())
+		case "flush-split-keys":
+			var builder strings.Builder
+			builder.WriteString("flush user split keys: ")
+			flushSplitKeys := sublevels.FlushSplitKeys()
+			for i, key := range flushSplitKeys {
+				builder.Write(key)
+				if i < len(flushSplitKeys) - 1 {
+					builder.WriteString(", ")
+				}
+			}
+			return builder.String()
+		case "max-depth-after-ongoing-compactions":
+			return strconv.Itoa(sublevels.MaxDepthAfterOngoingCompactions())
+		}
+		return fmt.Sprintf("unrecognized command: %s", td.Cmd)
+	})
+}
+
+func BenchmarkL0SubLevelsInit(b *testing.B) {
+	v, err := readManifest("testdata/MANIFEST_import")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		sl, err := NewL0SubLevels(v.Files[0], base.DefaultComparer.Compare, base.DefaultFormatter, 5<<20)
+		if err != nil {
+			b.Fatal(err)
+		} else if sl == nil {
+			b.Fatal("expected non-nil L0SubLevels to be generated")
+		}
+	}
+}

--- a/internal/manifest/testdata/l0_sublevels
+++ b/internal/manifest/testdata/l0_sublevels
@@ -1,0 +1,198 @@
+define
+L0
+  0009:a.SET.10-b.SET.10
+  0007:b.SET.6-j.SET.8
+  0003:e.SET.5-j.SET.7
+----
+file count: 3, sublevels: 3, intervals: 5
+flush split keys(3): [b, e, j]
+0.2: file count: 1, bytes: 256, width (mean, max): 2.0, 2, interval range: [0, 1]
+	000009:a#10,1-b#10,1
+0.1: file count: 1, bytes: 256, width (mean, max): 3.0, 3, interval range: [1, 3]
+	000007:b#6,1-j#8,1
+0.0: file count: 1, bytes: 256, width (mean, max): 1.0, 1, interval range: [3, 3]
+	000003:e#5,1-j#7,1
+compacting file count: 0, base compacting intervals: 
+
+define
+L0
+  0001:a.SET.2-b.SET.3
+  0002:c.SET.3-d.SET.5
+  0003:e.SET.5-f.SET.7
+  0005:f.SET.6-h.SET.9
+  0006:f.SET.4-g.SET.5
+  0009:f.SET.10-i.SET.10
+  0010:f.SET.11-g.SET.11
+L6
+  0007:a.SET.0-f.SET.0
+  0008:g.SET.0-z.SET.0
+----
+file count: 7, sublevels: 5, intervals: 10
+flush split keys(5): [b, d, f, g, h]
+0.4: file count: 1, bytes: 256, width (mean, max): 2.0, 2, interval range: [5, 6]
+	000010:f#11,1-g#11,1
+0.3: file count: 1, bytes: 256, width (mean, max): 4.0, 4, interval range: [5, 8]
+	000009:f#10,1-i#10,1
+0.2: file count: 1, bytes: 256, width (mean, max): 3.0, 3, interval range: [5, 7]
+	000005:f#6,1-h#9,1
+0.1: file count: 1, bytes: 256, width (mean, max): 2.0, 2, interval range: [4, 5]
+	000003:e#5,1-f#7,1
+0.0: file count: 3, bytes: 768, width (mean, max): 1.3, 2, interval range: [0, 6]
+	000001:a#2,1-b#3,1
+	000002:c#3,1-d#5,1
+	000006:f#4,1-g#5,1
+compacting file count: 0, base compacting intervals: 
+
+max-depth-after-ongoing-compactions
+----
+5
+
+# Extend one of the SSTables (0009) to the right, and place an SSTable "under"
+# the extension (0011).
+
+define
+L0
+  0005:f.SET.6-h.SET.9
+  0006:f.SET.4-g.SET.5
+  0009:f.SET.10-p.SET.10
+  0010:f.SET.11-g.SET.11
+  0011:n.SET.8-p.SET.10
+L6
+  0007:a.SET.0-f.SET.0
+  0008:g.SET.0-z.SET.0
+----
+file count: 5, sublevels: 4, intervals: 5
+flush split keys(3): [g, h, p]
+0.3: file count: 1, bytes: 256, width (mean, max): 1.0, 1, interval range: [0, 0]
+	000010:f#11,1-g#11,1
+0.2: file count: 1, bytes: 256, width (mean, max): 4.0, 4, interval range: [0, 3]
+	000009:f#10,1-p#10,1
+0.1: file count: 1, bytes: 256, width (mean, max): 2.0, 2, interval range: [0, 1]
+	000005:f#6,1-h#9,1
+0.0: file count: 2, bytes: 512, width (mean, max): 1.0, 1, interval range: [0, 3]
+	000006:f#4,1-g#5,1
+	000011:n#8,1-p#10,1
+compacting file count: 0, base compacting intervals: 
+
+# Assume a base compaction from the above files is chosen. This should reduce
+# max-depth-after-ongoing-compactions.
+
+define
+L0
+  0005:f.SET.6-h.SET.9 base_compacting
+  0006:f.SET.4-g.SET.5 base_compacting
+  0009:f.SET.12-p.SET.12
+  0010:f.SET.11-g.SET.11 base_compacting
+  0011:n.SET.8-p.SET.10 base_compacting
+L6
+  0007:a.SET.0-f.SET.0
+  0008:g.SET.0-z.SET.0
+----
+file count: 5, sublevels: 4, intervals: 5
+flush split keys(3): [g, h, p]
+0.3: file count: 1, bytes: 256, width (mean, max): 4.0, 4, interval range: [0, 3]
+	000009:f#12,1-p#12,1
+0.2: file count: 1, bytes: 256, width (mean, max): 1.0, 1, interval range: [0, 0]
+	000010:f#11,1-g#11,1
+0.1: file count: 1, bytes: 256, width (mean, max): 2.0, 2, interval range: [0, 1]
+	000005:f#6,1-h#9,1
+0.0: file count: 2, bytes: 512, width (mean, max): 1.0, 1, interval range: [0, 3]
+	000006:f#4,1-g#5,1
+	000011:n#8,1-p#10,1
+compacting file count: 4, base compacting intervals: [0, 1], [3, 4], 
+
+max-depth-after-ongoing-compactions
+----
+1
+
+read-amp
+----
+4
+
+define flush_split_max_bytes=32
+L0
+  0001:a.SET.2-e.SET.5 size=64
+  0002:c.SET.6-g.SET.8 size=16
+  0003:f.SET.9-j.SET.11 size=16
+L6
+  0007:a.SET.0-f.SET.0
+  0008:g.SET.0-z.SET.0
+----
+file count: 3, sublevels: 3, intervals: 6
+flush split keys(1): [e]
+0.2: file count: 1, bytes: 16, width (mean, max): 2.0, 2, interval range: [3, 4]
+	000003:f#9,1-j#11,1
+0.1: file count: 1, bytes: 16, width (mean, max): 3.0, 3, interval range: [1, 3]
+	000002:c#6,1-g#8,1
+0.0: file count: 1, bytes: 64, width (mean, max): 2.0, 2, interval range: [0, 1]
+	000001:a#2,1-e#5,1
+compacting file count: 0, base compacting intervals: 
+
+# Check that read amplification is the sublevel height of the tallest key
+# interval, not the overall count of sublevels.
+
+read-amp
+----
+2
+
+# The comparison of a cumulative count of interpolated bytes and
+# flushSplitMaxBytes is a <, so even though the cumulative count equals 32 after
+# a-c, we do not emit a flush split key until the end of the next interval, c-e.
+
+flush-split-keys
+----
+flush user split keys: e
+
+# Reduce flush_split_max_bytes by 1, and there should also be a split key at c.
+
+define flush_split_max_bytes=31
+L0
+  0001:a.SET.2-e.SET.5 size=64
+  0002:c.SET.6-g.SET.8 size=16
+  0003:f.SET.9-j.SET.11 size=16
+L6
+  0007:a.SET.0-f.SET.0
+  0008:g.SET.0-z.SET.0
+----
+file count: 3, sublevels: 3, intervals: 6
+flush split keys(2): [c, e]
+0.2: file count: 1, bytes: 16, width (mean, max): 2.0, 2, interval range: [3, 4]
+	000003:f#9,1-j#11,1
+0.1: file count: 1, bytes: 16, width (mean, max): 3.0, 3, interval range: [1, 3]
+	000002:c#6,1-g#8,1
+0.0: file count: 1, bytes: 64, width (mean, max): 2.0, 2, interval range: [0, 1]
+	000001:a#2,1-e#5,1
+compacting file count: 0, base compacting intervals: 
+
+flush-split-keys
+----
+flush user split keys: c, e
+
+# Reduce flush_split_max_bytes by 1, and there should also be a split key at c.
+
+define flush_split_max_bytes=31
+L0
+  0001:a.SET.2-e.SET.5 size=64
+  0002:c.SET.6-g.SET.8 size=16
+  0003:f.SET.9-j.SET.11 size=16
+L6
+  0007:a.SET.0-f.SET.0
+  0008:g.SET.0-z.SET.0
+----
+file count: 3, sublevels: 3, intervals: 6
+flush split keys(2): [c, e]
+0.2: file count: 1, bytes: 16, width (mean, max): 2.0, 2, interval range: [3, 4]
+	000003:f#9,1-j#11,1
+0.1: file count: 1, bytes: 16, width (mean, max): 3.0, 3, interval range: [1, 3]
+	000002:c#6,1-g#8,1
+0.0: file count: 1, bytes: 64, width (mean, max): 2.0, 2, interval range: [0, 1]
+	000001:a#2,1-e#5,1
+compacting file count: 0, base compacting intervals: 
+
+flush-split-keys
+----
+flush user split keys: c, e
+
+max-depth-after-ongoing-compactions
+----
+2

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -62,6 +62,18 @@ type FileMetadata struct {
 	MarkedForCompaction bool
 	// True if the file is actively being compacted. Protected by DB.mu.
 	Compacting bool
+	// For L0 files only. Protected by DB.mu. Used to generate L0 sublevels and
+	// pick L0 compactions.
+	//
+	// IsIntraL0Compacting is set to True if this file is part of an intra-L0
+	// compaction. When it's true, Compacting must also be true. If Compacting
+	// is true and IsIntraL0Compacting is false for an L0 file, the file must
+	// be part of a compaction to Lbase.
+	IsIntraL0Compacting bool
+	subLevel            int
+	l0Index             int
+	minIntervalIndex    int
+	maxIntervalIndex    int
 }
 
 func (m FileMetadata) String() string {


### PR DESCRIPTION
This change introduces L0SubLevels, a data structure to encaptulate
all information to compute L0 Sublevels, flush split keys, and
base / intra-L0 compactions. This data structure will be generated
every time there's a file addition/deletion in L0, the integration
bits will come in future PRs.

The methods to pick base / intra-L0 compactions will come in a
separate PR.

Captures some of the largest code pieces of #563, and effectively
replaces a part of that PR. Sumeer wrote the bulk of this code as
part of his prototype, so thanks Sumeer for his work.

Most of these functions are dead code at the moment, only invoked
by the provided datadriven and non-datadriven tests.