### PR TITLE
sstable: unref cache handle on error in EstimateDiskUsage

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -1515,6 +1515,7 @@ func (r *Reader) EstimateDiskUsage(start, end []byte) (uint64, error) {
 		if err != nil {
 			return 0, err
 		}
+		defer startIdxBlock.Release()
 		startIdxIter, err = newBlockIter(r.Compare, startIdxBlock.Get())
 		if err != nil {
 			return 0, err
@@ -1534,6 +1535,7 @@ func (r *Reader) EstimateDiskUsage(start, end []byte) (uint64, error) {
 			if err != nil {
 				return 0, err
 			}
+			defer endIdxBlock.Release()
 			endIdxIter, err = newBlockIter(r.Compare, endIdxBlock.Get())
 			if err != nil {
 				return 0, err

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -198,6 +198,12 @@ func TestInjectedErrors(t *testing.T) {
 				return firstError(err, f.Close())
 			}
 			defer func() { reterr = firstError(reterr, r.Close()) }()
+
+			_, err = r.EstimateDiskUsage([]byte("borrower"), []byte("lender"))
+			if err != nil {
+				return err
+			}
+
 			iter, err := r.NewIter(nil, nil)
 			if err != nil {
 				return err


### PR DESCRIPTION
If an error occurred while estimating disk usage on a sstable with a
partitioned index, the two cache handles of the bottom-tier index blocks
were leaked.