### PR TITLE
internal/record: don't return partial records (again)

### DIFF
--- a/internal/record/record.go
+++ b/internal/record/record.go
@@ -273,6 +273,9 @@ func (r *Reader) nextChunk(wantFirst bool) error {
 		}
 		n, err := io.ReadFull(r.r, r.buf[:])
 		if err != nil && err != io.ErrUnexpectedEOF {
+			if err == io.EOF && !wantFirst {
+				return io.ErrUnexpectedEOF
+			}
 			return err
 		}
 		r.begin, r.end, r.n = 0, 0, n


### PR DESCRIPTION
When a record spans blocks in the WAL it is broken into chunks. We were
erroneously returning a truncated record if a non-first chunk for a
record was at the tail end of the WAL.

Fixes #620