### PR TITLE
Recyclable Merger Result

### DIFF
--- a/compaction_iter.go
+++ b/compaction_iter.go
@@ -5,6 +5,7 @@
 package pebble
 
 import (
+	"io"
 	"sort"
 
 	"github.com/cockroachdb/errors"
@@ -131,8 +132,9 @@ type compactionIter struct {
 	// Additionally, it is the internal state when the code is moving to the
 	// next key so it can determine whether the user key has changed from
 	// the previous key.
-	key   InternalKey
-	value []byte
+	key         InternalKey
+	value       []byte
+	valueCloser io.Closer
 	// Temporary buffer used for storing the previous user key in order to
 	// determine when iteration has advanced to a new user key and thus a new
 	// snapshot stripe.
@@ -217,6 +219,15 @@ func (i *compactionIter) First() (*InternalKey, []byte) {
 func (i *compactionIter) Next() (*InternalKey, []byte) {
 	if i.err != nil {
 		return nil, nil
+	}
+
+	// close closer for current value if available
+	if i.valueCloser != nil {
+		i.err = i.valueCloser.Close()
+		i.valueCloser = nil
+		if i.err != nil {
+			return nil, nil
+		}
 	}
 
 	// Prior to this call to `Next()` we are in one of three situations with
@@ -307,7 +318,7 @@ func (i *compactionIter) Next() (*InternalKey, []byte) {
 				change = i.mergeNext(valueMerger)
 			}
 			if i.err == nil {
-				i.value, i.err = valueMerger.Finish()
+				i.value, i.valueCloser, i.err = valueMerger.Finish()
 			}
 			if i.err == nil {
 				// A non-skippable entry does not necessarily cover later merge
@@ -555,6 +566,16 @@ func (i *compactionIter) Close() error {
 	if i.err == nil {
 		i.err = err
 	}
+
+	// close leftover closer
+	if i.valueCloser != nil {
+		closerErr := i.valueCloser.Close()
+		if i.err == nil {
+			i.err = closerErr
+		}
+		i.valueCloser = nil
+	}
+
 	return i.err
 }
 

--- a/compaction_iter.go
+++ b/compaction_iter.go
@@ -221,7 +221,7 @@ func (i *compactionIter) Next() (*InternalKey, []byte) {
 		return nil, nil
 	}
 
-	// close closer for current value if available
+	// Close the closer for the current value if one was open.
 	if i.valueCloser != nil {
 		i.err = i.valueCloser.Close()
 		i.valueCloser = nil
@@ -567,7 +567,7 @@ func (i *compactionIter) Close() error {
 		i.err = err
 	}
 
-	// close leftover closer
+	// Close the closer for the current value if one was open.
 	if i.valueCloser != nil {
 		closerErr := i.valueCloser.Close()
 		if i.err == nil {

--- a/compaction_iter.go
+++ b/compaction_iter.go
@@ -569,10 +569,7 @@ func (i *compactionIter) Close() error {
 
 	// Close the closer for the current value if one was open.
 	if i.valueCloser != nil {
-		closerErr := i.valueCloser.Close()
-		if i.err == nil {
-			i.err = closerErr
-		}
+		i.err = firstError(i.err, i.valueCloser.Close())
 		i.valueCloser = nil
 	}
 

--- a/internal/base/merger.go
+++ b/internal/base/merger.go
@@ -47,7 +47,7 @@ type ValueMerger interface {
 	// must not call any other ValueMerger functions after calling Finish.
 	//
 	// If a Closer is returned, the returned slice will remain valid until it is
-	// closed and the caller MUST call closer.Close() or a memory leak will occur.
+	// closed. The caller must arrange for the closer to be eventually closed.
 	Finish() ([]byte, io.Closer, error)
 }
 

--- a/internal/base/merger.go
+++ b/internal/base/merger.go
@@ -14,7 +14,7 @@ type Merge func(key, value []byte) (ValueMerger, error)
 // newer or older than all operands received so far as indicated by the function
 // names, `MergeNewer()` and `MergeOlder()`. Once all operands have been received,
 // the client will invoke `Finish()` to obtain the final result. The order of
-// a merge is usually not changed after the first call to `MergeNewer()` or
+// a merge is not changed after the first call to `MergeNewer()` or
 // `MergeOlder()`, i.e. the same method is used to submit all operands.
 //
 // The implementation may choose to merge values into the result immediately upon

--- a/internal/base/merger.go
+++ b/internal/base/merger.go
@@ -28,10 +28,16 @@ type Merge func(key, value []byte) (ValueMerger, error)
 type ValueMerger interface {
 	// MergeNewer adds an operand that is newer than all existing operands.
 	// The caller retains ownership of value.
+	//
+	// If an error is returned the merge is aborted and no other methods will
+	// be called.
 	MergeNewer(value []byte) error
 
 	// MergeOlder adds an operand that is older than all existing operands.
 	// The caller retains ownership of value.
+	//
+	// If an error is returned the merge is aborted and no other methods will
+	// be called.
 	MergeOlder(value []byte) error
 
 	// Finish does any final processing of the added operands and returns a

--- a/internal/base/merger.go
+++ b/internal/base/merger.go
@@ -29,14 +29,14 @@ type ValueMerger interface {
 	// MergeNewer adds an operand that is newer than all existing operands.
 	// The caller retains ownership of value.
 	//
-	// If an error is returned the merge is aborted and no other methods will
+	// If an error is returned the merge is aborted and no other methods must
 	// be called.
 	MergeNewer(value []byte) error
 
 	// MergeOlder adds an operand that is older than all existing operands.
 	// The caller retains ownership of value.
 	//
-	// If an error is returned the merge is aborted and no other methods will
+	// If an error is returned the merge is aborted and no other methods must
 	// be called.
 	MergeOlder(value []byte) error
 
@@ -46,7 +46,8 @@ type ValueMerger interface {
 	// Finish must be the last function called on the ValueMerger. The caller
 	// must not call any other ValueMerger functions after calling Finish.
 	//
-	// The returned closer is called once the returned slice is not used further.
+	// If a Closer is returned, the returned slice will remain valid until it is
+	// closed and the caller MUST call closer.Close() or a memory leak will occur.
 	Finish() ([]byte, io.Closer, error)
 }
 

--- a/internal/base/merger.go
+++ b/internal/base/merger.go
@@ -4,6 +4,8 @@
 
 package base
 
+import "io"
+
 // Merge creates a ValueMerger for the specified key initialized with the value
 // of one merge operand.
 type Merge func(key, value []byte) (ValueMerger, error)
@@ -37,7 +39,9 @@ type ValueMerger interface {
 	//
 	// Finish must be the last function called on the ValueMerger. The caller
 	// must not call any other ValueMerger functions after calling Finish.
-	Finish() ([]byte, error)
+	//
+	// The returned closer is called once the returned slice is not used further.
+	Finish() ([]byte, io.Closer, error)
 }
 
 // Merger defines an associative merge operation. The merge operation merges
@@ -80,8 +84,8 @@ func (a *AppendValueMerger) MergeOlder(value []byte) error {
 }
 
 // Finish returns the buffer that was constructed on-demand in `Merge{OlderNewer}()` calls.
-func (a *AppendValueMerger) Finish() ([]byte, error) {
-	return a.buf, nil
+func (a *AppendValueMerger) Finish() ([]byte, io.Closer, error) {
+	return a.buf, nil, nil
 }
 
 // DefaultMerger is the default implementation of the Merger interface. It

--- a/internal/base/merger.go
+++ b/internal/base/merger.go
@@ -13,7 +13,9 @@ type Merge func(key, value []byte) (ValueMerger, error)
 // ValueMerger receives merge operands one by one. The operand received is either
 // newer or older than all operands received so far as indicated by the function
 // names, `MergeNewer()` and `MergeOlder()`. Once all operands have been received,
-// the client will invoke `Finish()` to obtain the final result.
+// the client will invoke `Finish()` to obtain the final result. The order of
+// a merge is usually not changed after the first call to `MergeNewer()` or
+// `MergeOlder()`, i.e. the same method is used to submit all operands.
 //
 // The implementation may choose to merge values into the result immediately upon
 // receiving each operand, or buffer operands until Finish() is called. For example,

--- a/iterator.go
+++ b/iterator.go
@@ -66,10 +66,13 @@ func (i *Iterator) findNextEntry() bool {
 	i.valid = false
 	i.pos = iterPosCur
 
-	// close closer for current value if available
+	// Close the closer for the current value if one was open.
 	if i.valueCloser != nil {
-		_ = i.valueCloser.Close()
+		i.err = i.valueCloser.Close()
 		i.valueCloser = nil
+		if i.err != nil {
+			return false
+		}
 	}
 
 	for i.iterKey != nil {
@@ -138,10 +141,13 @@ func (i *Iterator) findPrevEntry() bool {
 	i.valid = false
 	i.pos = iterPosCur
 
-	// close closer for current value if available
+	// Close the closer for the current value if one was open.
 	if i.valueCloser != nil {
-		_ = i.valueCloser.Close()
+		i.err = i.valueCloser.Close()
 		i.valueCloser = nil
+		if i.err != nil {
+			return false
+		}
 	}
 
 	var valueMerger ValueMerger
@@ -516,10 +522,13 @@ func (i *Iterator) Close() error {
 		i.readState = nil
 	}
 
-	// close leftover closer if available
+	// Close the closer for the current value if one was open.
 	if i.valueCloser != nil {
-		_ = i.valueCloser.Close()
+		closerErr := i.valueCloser.Close()
 		i.valueCloser = nil
+		if err == nil {
+			err = closerErr
+		}
 	}
 
 	if alloc := i.alloc; alloc != nil {

--- a/iterator.go
+++ b/iterator.go
@@ -524,11 +524,8 @@ func (i *Iterator) Close() error {
 
 	// Close the closer for the current value if one was open.
 	if i.valueCloser != nil {
-		closerErr := i.valueCloser.Close()
+		err = firstError(err, i.valueCloser.Close())
 		i.valueCloser = nil
-		if err == nil {
-			err = closerErr
-		}
 	}
 
 	if alloc := i.alloc; alloc != nil {


### PR DESCRIPTION
This PR adds the `io.Closer` return value to the `ValueMerger.Finish` method to allow returned merge results to be recycled once its not used anymore by the iterators. See #617.

@petermattis I'm not sure how I can test this during a compaction, is there a way to facilitate the conditions needed?