### PR TITLE
db: add ParseHooks.NewCache

### DIFF
--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -22,6 +22,7 @@ var comparer = func() pebble.Comparer {
 
 func parseOptions(opts *testOptions, data string) error {
 	hooks := &pebble.ParseHooks{
+		NewCache: pebble.NewCache,
 		NewFilterPolicy: func(name string) (pebble.FilterPolicy, error) {
 			if name == "none" {
 				return nil, nil

--- a/options_test.go
+++ b/options_test.go
@@ -137,8 +137,13 @@ func TestOptionsParse(t *testing.T) {
 	testComparer.Name = "test-comparer"
 	testMerger := *DefaultMerger
 	testMerger.Name = "test-merger"
+	var newCacheSize int64
 
 	hooks := &ParseHooks{
+		NewCache: func(size int64) *Cache {
+			newCacheSize = size
+			return nil
+		},
 		NewCleaner: func(name string) (Cleaner, error) {
 			if name == (testCleaner{}).String() {
 				return testCleaner{}, nil
@@ -181,15 +186,15 @@ func TestOptionsParse(t *testing.T) {
 			opts.EnsureDefaults()
 			str := opts.String()
 
+			newCacheSize = 0
 			var parsedOptions Options
 			require.NoError(t, parsedOptions.Parse(str, hooks))
 			parsedStr := parsedOptions.String()
 			if str != parsedStr {
 				t.Fatalf("expected\n%s\nbut found\n%s", str, parsedStr)
 			}
-			if parsedOptions.Cache != nil {
-				parsedOptions.Cache.Unref()
-			}
+			require.Nil(t, parsedOptions.Cache)
+			require.NotEqual(t, newCacheSize, 0)
 		})
 	}
 }


### PR DESCRIPTION
Add `ParseHooks.NewCache` to allow configuration of whether
`Options.Parse` creates a cache or not. This fixes a bug in the `db
{scan,lsm,check}` tools which were leaving a dangling cache reference
because `Options.Parse` was creating a cache they weren't expecting.