### PR TITLE
db: calculate compensated file sizes

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -479,6 +479,9 @@ func TestPickCompaction(t *testing.T) {
 			opts:    opts,
 			cmp:     DefaultComparer.Compare,
 			cmpName: DefaultComparer.Name,
+			fileStats: fileStatsSampler{
+				loadStats: func(*fileMetadata, *fileStats) error { return nil },
+			},
 		}
 		vs.versions.Init(nil)
 		vs.append(&tc.version)

--- a/file_stats.go
+++ b/file_stats.go
@@ -1,0 +1,88 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"sync"
+)
+
+const maxStatsSamples = 20
+
+type fileStatsSampler struct {
+	loadStats     func(*fileMetadata, *fileStats) error
+	eventListener EventListener
+
+	mu            sync.Mutex
+	accum         fileStats
+	accumFileSize uint64
+}
+
+func (s *fileStatsSampler) init(loadFunc func(*fileMetadata, *fileStats) error, el EventListener) {
+	s.loadStats = loadFunc
+	s.eventListener = el
+}
+
+// sample loads file stats from the properties of added and updates its
+// accumulated totals. It updates sampled files to have non-zero compensated
+// sizes. This method will perform IO, so call it without holding d.mu.
+func (s *fileStatsSampler) sample(added [numLevels][]*fileMetadata) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	samples := s.collectLocked(added)
+
+	// Compute average value size with the updated accumulated stats.
+	var averageValueSize uint64
+	nonDeletions := s.accum.Entries - s.accum.Deletions
+	if nonDeletions != 0 {
+		averageValueSize = s.accum.RawValueBytes / nonDeletions *
+			s.accumFileSize /
+			(s.accum.RawKeyBytes + s.accum.RawValueBytes)
+	}
+
+	// Calculate compensated sizes for sampled files.
+	for _, f := range samples {
+		// NB: This is a different compensated size calculation than
+		// RocksDB's. RocksDB's only adjusts the size if deletion entries
+		// exceed non-deletion entries in a file. RocksDB also adds additional
+		// weight to each deletion.
+		// TODO(jackson): compensate for range deletion tombstones
+		stats := f.MaybeStats()
+		if stats == nil {
+			panic("programming error")
+		}
+		v := f.Size + stats.Deletions*averageValueSize
+		f.SetCompensatedSize(v)
+	}
+}
+
+func (s *fileStatsSampler) collectLocked(added [numLevels][]*fileMetadata) []*fileMetadata {
+	samples := make([]*fileMetadata, 0, maxStatsSamples)
+	for _, ff := range added {
+		for _, f := range ff {
+			if stats := f.MaybeStats(); stats != nil {
+				// Skip files that already have collected stats.
+				continue
+			}
+
+			stats, err := f.Stats(s.loadStats)
+			if err != nil {
+				s.eventListener.BackgroundError(err)
+				continue
+			}
+			s.accum.Entries += stats.Entries
+			s.accum.Deletions += stats.Deletions
+			s.accum.RawKeyBytes += stats.RawKeyBytes
+			s.accum.RawValueBytes += stats.RawValueBytes
+			s.accumFileSize += f.Size
+			samples = append(samples, f)
+
+			if len(samples) == maxStatsSamples {
+				return samples
+			}
+		}
+	}
+	return samples
+}

--- a/open.go
+++ b/open.go
@@ -169,7 +169,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	if _, err := opts.FS.Stat(currentName); os.IsNotExist(err) &&
 		!d.opts.ReadOnly && !d.opts.ErrorIfNotExists {
 		// Create the DB if it did not already exist.
-		if err := d.mu.versions.create(jobID, dirname, d.dataDir, opts, &d.mu.Mutex); err != nil {
+		if err := d.mu.versions.create(jobID, dirname, d.dataDir, opts, &d.mu.Mutex, d.tableCache.loadMetadataStats); err != nil {
 			return nil, err
 		}
 	} else if err != nil {
@@ -178,7 +178,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		return nil, errors.Errorf("pebble: database %q already exists", dirname)
 	} else {
 		// Load the version set.
-		if err := d.mu.versions.load(dirname, opts, &d.mu.Mutex); err != nil {
+		if err := d.mu.versions.load(dirname, opts, &d.mu.Mutex, d.tableCache.loadMetadataStats); err != nil {
 			return nil, err
 		}
 	}

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -387,3 +387,23 @@ func TestTableCacheEvictClose(t *testing.T) {
 		require.NoError(t, err)
 	}
 }
+
+func TestTableCacheLoadMetadataStats(t *testing.T) {
+	c, _, err := newTableCache()
+	require.NoError(t, err)
+	for i := 0; i < tableCacheTestNumTables; i++ {
+		f := &fileMetadata{FileNum: FileNum(i)}
+		var stats fileStats
+		err := c.loadMetadataStats(f, &stats)
+		require.NoError(t, err)
+		if stats.entries != 1 {
+			t.Errorf("stats.entries = %d, want 1", stats.entries)
+		}
+		if stats.rawKeyBytes == 0 {
+			t.Errorf("stats.rawKeyBytes is zero, want nonzero: %+v", stats)
+		}
+		if stats.rawValueBytes != uint64(i) {
+			t.Errorf("stats.rawKeyBytes = %d, want %d", stats.rawValueBytes, i)
+		}
+	}
+}

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -168,8 +168,8 @@ compact         1   1.6 K          (size == estimated-debt)
  memtbl         1   256 K
 zmemtbl         0     0 B
    ztbl         0     0 B
- bcache         8   1.4 K    5.9%  (score == hit-rate)
- tcache         1   672 B    0.0%  (score == hit-rate)
+ bcache        10   2.1 K   14.3%  (score == hit-rate)
+ tcache         3   2.0 K   37.5%  (score == hit-rate)
  titers         0
  filter         -       -    0.0%  (score == utility)
 

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -74,9 +74,9 @@ compact         1     0 B          (size == estimated-debt)
  memtbl         1   256 K
 zmemtbl         2   512 K
    ztbl         2   1.5 K
- bcache         8   1.4 K   33.3%  (score == hit-rate)
- tcache         2   1.3 K   50.0%  (score == hit-rate)
- titers         2
+ bcache        10   2.0 K   23.1%  (score == hit-rate)
+ tcache         3   2.0 K   62.5%  (score == hit-rate)
+ titers         3
  filter         -       -    0.0%  (score == utility)
 
 # Closing iter a will release one of the zombie memtables.
@@ -101,9 +101,9 @@ compact         1     0 B          (size == estimated-debt)
  memtbl         1   256 K
 zmemtbl         1   256 K
    ztbl         2   1.5 K
- bcache         8   1.4 K   33.3%  (score == hit-rate)
- tcache         2   1.3 K   50.0%  (score == hit-rate)
- titers         2
+ bcache        10   2.0 K   23.1%  (score == hit-rate)
+ tcache         3   2.0 K   62.5%  (score == hit-rate)
+ titers         3
  filter         -       -    0.0%  (score == utility)
 
 # Closing iter c will release one of the zombie sstables. The other
@@ -129,8 +129,8 @@ compact         1     0 B          (size == estimated-debt)
  memtbl         1   256 K
 zmemtbl         1   256 K
    ztbl         1   771 B
- bcache         4   698 B   33.3%  (score == hit-rate)
- tcache         1   672 B   50.0%  (score == hit-rate)
+ bcache         6   1.3 K   23.1%  (score == hit-rate)
+ tcache         2   1.3 K   62.5%  (score == hit-rate)
  titers         1
  filter         -       -    0.0%  (score == utility)
 
@@ -156,7 +156,7 @@ compact         1     0 B          (size == estimated-debt)
  memtbl         1   256 K
 zmemtbl         0     0 B
    ztbl         0     0 B
- bcache         0     0 B   33.3%  (score == hit-rate)
- tcache         0     0 B   50.0%  (score == hit-rate)
+ bcache         2   655 B   23.1%  (score == hit-rate)
+ tcache         1   672 B   62.5%  (score == hit-rate)
  titers         0
  filter         -       -    0.0%  (score == utility)

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -25,7 +25,7 @@ compact         0   986 B          (size == estimated-debt)
  memtbl         2   768 K
 zmemtbl         0     0 B
    ztbl         0     0 B
- bcache         0     0 B    0.0%  (score == hit-rate)
- tcache         0     0 B    0.0%  (score == hit-rate)
+ bcache         2   834 B    0.0%  (score == hit-rate)
+ tcache         1   672 B    0.0%  (score == hit-rate)
  titers         0
  filter         -       -    0.0%  (score == utility)


### PR DESCRIPTION
This commit adds calculation of 'compensated file sizes' analagous to
RocksDB's compensated file size. The compensated file size of a file
is inflated by the approximate space that may be reclaimed by compacting
its deletions. Currently, all deletions (point and range) are treated
identically. In future work, we can adjust the compensated size to
further inflate the compensated size for range tombstones.

To estimate the cost of uncompacted deletions, like RocksDB, this change
incremently updates accumulated stats that approximate the average value
size in the database.

Calculating compensated file sizes and updating accumulated stats
requires reading the properties of a sstable. Like RocksDB, in order to
limit IO, this change limits the number of sstables it reads to 20 at
a time. Unlike RocksDB, it will read properties and update compensated
sizes for files that previously were skipped because this cap was
reached, ensuring that eventually every file has a compensated file
size.

Currently, this sampling of sstable properties is performed
synchronously on version load and logAndApply. I'm unsure if this will
prove to be a problem, by blocking additional version edits. We might
want to sample asynchronously, so as to not block installation of
additional versions. I'm anticipating benchmarking of the new hueristic
will help clarify this.