### PR TITLE
tool: add db properties subcommand

### DIFF
--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/humanize"
 	"github.com/cockroachdb/pebble/internal/private"
 	"github.com/cockroachdb/pebble/internal/rangedel"
 	"github.com/cockroachdb/pebble/sstable"
@@ -266,15 +267,15 @@ func (s *sstableT) runProperties(cmd *cobra.Command, args []string) {
 		tw := tabwriter.NewWriter(stdout, 2, 1, 2, ' ', 0)
 		fmt.Fprintf(tw, "version\t%d\n", r.Properties.FormatVersion)
 		fmt.Fprintf(tw, "size\t\n")
-		fmt.Fprintf(tw, "  file\t%d\n", stat.Size())
-		fmt.Fprintf(tw, "  data\t%d\n", r.Properties.DataSize)
+		fmt.Fprintf(tw, "  file\t%s\n", humanize.Int64(stat.Size()))
+		fmt.Fprintf(tw, "  data\t%s\n", humanize.Uint64(r.Properties.DataSize))
 		fmt.Fprintf(tw, "    blocks\t%d\n", r.Properties.NumDataBlocks)
-		fmt.Fprintf(tw, "  index\t%d\n", r.Properties.IndexSize)
+		fmt.Fprintf(tw, "  index\t%s\n", humanize.Uint64(r.Properties.IndexSize))
 		fmt.Fprintf(tw, "    blocks\t%d\n", 1+r.Properties.IndexPartitions)
-		fmt.Fprintf(tw, "    top-level\t%d\n", r.Properties.TopLevelIndexSize)
-		fmt.Fprintf(tw, "  filter\t%d\n", r.Properties.FilterSize)
-		fmt.Fprintf(tw, "  raw-key\t%d\n", r.Properties.RawKeySize)
-		fmt.Fprintf(tw, "  raw-value\t%d\n", r.Properties.RawValueSize)
+		fmt.Fprintf(tw, "    top-level\t%s\n", humanize.Uint64(r.Properties.TopLevelIndexSize))
+		fmt.Fprintf(tw, "  filter\t%s\n", humanize.Uint64(r.Properties.FilterSize))
+		fmt.Fprintf(tw, "  raw-key\t%s\n", humanize.Uint64(r.Properties.RawKeySize))
+		fmt.Fprintf(tw, "  raw-value\t%s\n", humanize.Uint64(r.Properties.RawValueSize))
 		fmt.Fprintf(tw, "records\t%d\n", r.Properties.NumEntries)
 		fmt.Fprintf(tw, "  set\t%d\n", r.Properties.NumEntries-
 			(r.Properties.NumDeletions+r.Properties.NumMergeOperands))

--- a/tool/testdata/db_properties
+++ b/tool/testdata/db_properties
@@ -1,0 +1,31 @@
+db properties
+----
+accepts 1 arg(s), received 0
+
+db properties
+non-existent
+----
+open non-existent/CURRENT: file does not exist
+
+db properties
+../testdata/db-stage-4
+----
+                  L0      L1     L2     L3     L4     L5     L6     TOTAL
+count             1       0      0      0      0      0      0      1
+seq num                                                             
+  smallest        3       0      0      0      0      0      0      3
+  largest         5       0      0      0      0      0      0      5
+size                                                                
+  data            62 B    0 B    0 B    0 B    0 B    0 B    0 B    62 B
+    blocks        1       0      0      0      0      0      0      1
+  index           27 B    0 B    0 B    0 B    0 B    0 B    0 B    27 B
+    blocks        1       0      0      0      0      0      0      1
+    top-level     0 B     0 B    0 B    0 B    0 B    0 B    0 B    0 B
+  filter          0 B     0 B    0 B    0 B    0 B    0 B    0 B    0 B
+  raw-key         33 B    0 B    0 B    0 B    0 B    0 B    0 B    33 B
+  raw-value       9 B     0 B    0 B    0 B    0 B    0 B    0 B    9 B
+records                                                             
+  set             2       0      0      0      0      0      0      2
+  delete          1       0      0      0      0      0      0      1
+  range-delete    0       0      0      0      0      0      0      0
+  merge           0       0      0      0      0      0      0      0

--- a/tool/testdata/sstable_properties
+++ b/tool/testdata/sstable_properties
@@ -8,15 +8,15 @@ sstable properties
 h.sst
 version           0
 size              
-  file            15432
-  data            13913
+  file            15 K
+  data            14 K
     blocks        14
-  index           325
+  index           325 B
     blocks        1
-    top-level     0
-  filter          0
-  raw-key         23938
-  raw-value       1912
+    top-level     0 B
+  filter          0 B
+  raw-key         23 K
+  raw-value       1.9 K
 records           1727
   set             1710
   delete          0
@@ -43,15 +43,15 @@ sstable properties
 h.ldb
 version           0
 size              
-  file            15381
-  data            13913
+  file            15 K
+  data            14 K
     blocks        14
-  index           325
+  index           325 B
     blocks        1
-    top-level     0
-  filter          0
-  raw-key         23938
-  raw-value       1912
+    top-level     0 B
+  filter          0 B
+  raw-key         23 K
+  raw-value       1.9 K
 records           1727
   set             1710
   delete          0
@@ -77,15 +77,15 @@ sstable properties
 h.no-compression.two_level_index.sst
 version           0
 size              
-  file            28539
-  data            26799
+  file            28 K
+  data            26 K
     blocks        14
-  index           408
+  index           408 B
     blocks        4
-    top-level     70
-  filter          0
-  raw-key         23938
-  raw-value       1912
+    top-level     70 B
+  filter          0 B
+  raw-key         23 K
+  raw-value       1.9 K
 records           1727
   set             1710
   delete          0


### PR DESCRIPTION
Add an 'aggprops' db subcommand that reads properties from all SSTables
across all levels and prints aggregates of them per-level and overall.
I needed this for getting a sense of the RANGEDEL distribution across
levels but thought it might be useful more generally as well.