### PR TITLE
[release-20.1] backports

### DIFF
--- a/bloom/bloom.go
+++ b/bloom/bloom.go
@@ -117,15 +117,28 @@ func hash(b []byte) uint32 {
 		h *= m
 		h ^= h >> 16
 	}
+
+	// The code below first casts each byte to a signed 8-bit integer. This is
+	// necessary to match RocksDB's behavior. Note that the `byte` type in Go is
+	// unsigned. What is the difference between casting a signed 8-bit value vs
+	// unsigned 8-bit value into an unsigned 32-bit value?
+	// Sign-extension. Consider the value 250 which has the bit pattern 11111010:
+	//
+	//   uint32(250)        = 00000000000000000000000011111010
+	//   uint32(int8(250))  = 11111111111111111111111111111010
+	//
+	// Note that the original LevelDB code did not explicitly cast to a signed
+	// 8-bit value which left the behavior dependent on whether C characters were
+	// signed or unsigned which is a compiler flag for gcc (-funsigned-char).
 	switch len(b) {
 	case 3:
-		h += uint32(b[2]) << 16
+		h += uint32(int8(b[2])) << 16
 		fallthrough
 	case 2:
-		h += uint32(b[1]) << 8
+		h += uint32(int8(b[1])) << 8
 		fallthrough
 	case 1:
-		h += uint32(b[0])
+		h += uint32(int8(b[0]))
 		h *= m
 		h ^= h >> 24
 	}

--- a/bloom/bloom_test.go
+++ b/bloom/bloom_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/stretchr/testify/require"
 )
 
 func (f tableFilter) String() string {
@@ -130,23 +131,56 @@ loop:
 }
 
 func TestHash(t *testing.T) {
-	// The magic want numbers come from running the C++ leveldb code in hash.cc.
 	testCases := []struct {
-		s    string
-		want uint32
+		s        string
+		expected uint32
 	}{
-		{"", 0xbc9f1d34},
-		{"g", 0xd04a8bda},
-		{"go", 0x3e0b0745},
-		{"gop", 0x0c326610},
-		{"goph", 0x8c9d6390},
-		{"gophe", 0x9bfd4b0a},
-		{"gopher", 0xa78edc7c},
-		{"I had a dream it would end this way.", 0xe14a9db9},
+		// The magic expected numbers come from RocksDB's util/hash_test.cc:TestHash.
+		{"", 3164544308},
+		{"\x08", 422599524},
+		{"\x17", 3168152998},
+		{"\x9a", 3195034349},
+		{"\x1c", 2651681383},
+		{"\x4d\x76", 2447836956},
+		{"\x52\xd5", 3854228105},
+		{"\x91\xf7", 31066776},
+		{"\xd6\x27", 1806091603},
+		{"\x30\x46\x0b", 3808221797},
+		{"\x56\xdc\xd6", 2157698265},
+		{"\xd4\x52\x33", 1721992661},
+		{"\x6a\xb5\xf4", 2469105222},
+		{"\x67\x53\x81\x1c", 118283265},
+		{"\x69\xb8\xc0\x88", 3416318611},
+		{"\x1e\x84\xaf\x2d", 3315003572},
+		{"\x46\xdc\x54\xbe", 447346355},
+		{"\xd0\x7a\x6e\xea\x56", 4255445370},
+		{"\x86\x83\xd5\xa4\xd8", 2390603402},
+		{"\xb7\x46\xbb\x77\xce", 2048907743},
+		{"\x6c\xa8\xbc\xe5\x99", 2177978500},
+		{"\x5c\x5e\xe1\xa0\x73\x81", 1036846008},
+		{"\x08\x5d\x73\x1c\xe5\x2e", 229980482},
+		{"\x42\xfb\xf2\x52\xb4\x10", 3655585422},
+		{"\x73\xe1\xff\x56\x9c\xce", 3502708029},
+		{"\x5c\xbe\x97\x75\x54\x9a\x52", 815120748},
+		{"\x16\x82\x39\x49\x88\x2b\x36", 3056033698},
+		{"\x59\x77\xf0\xa7\x24\xf4\x78", 587205227},
+		{"\xd3\xa5\x7c\x0e\xc0\x02\x07", 2030937252},
+		{"\x31\x1b\x98\x75\x96\x22\xd3\x9a", 469635402},
+		{"\x38\xd6\xf7\x28\x20\xb4\x8a\xe9", 3530274698},
+		{"\xbb\x18\x5d\xf4\x12\x03\xf7\x99", 1974545809},
+		{"\x80\xd4\x3b\x3b\xae\x22\xa2\x78", 3563570120},
+		{"\x1a\xb5\xd0\xfe\xab\xc3\x61\xb2\x99", 2706087434},
+		{"\x8e\x4a\xc3\x18\x20\x2f\x06\xe6\x3c", 1534654151},
+		{"\xb6\xc0\xdd\x05\x3f\xc4\x86\x4c\xef", 2355554696},
+		{"\x9a\x5f\x78\x0d\xaf\x50\xe1\x1f\x55", 1400800912},
+		{"\x22\x6f\x39\x1f\xf8\xdd\x4f\x52\x17\x94", 3420325137},
+		{"\x32\x89\x2a\x75\x48\x3a\x4a\x02\x69\xdd", 3427803584},
+		{"\x06\x92\x5c\xf4\x88\x0e\x7e\x68\x38\x3e", 1152407945},
+		{"\xbd\x2c\x63\x38\xbf\xe9\x78\xb7\xbf\x15", 3382479516},
 	}
 	for _, tc := range testCases {
-		if got := hash([]byte(tc.s)); got != tc.want {
-			t.Errorf("s=%q: got 0x%08x, want 0x%08x", tc.s, got, tc.want)
-		}
+		t.Run("", func(t *testing.T) {
+			require.EqualValues(t, tc.expected, hash([]byte(tc.s)))
+		})
 	}
 }

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -22,6 +22,7 @@ var comparer = func() pebble.Comparer {
 
 func parseOptions(opts *testOptions, data string) error {
 	hooks := &pebble.ParseHooks{
+		NewCache: pebble.NewCache,
 		NewFilterPolicy: func(name string) (pebble.FilterPolicy, error) {
 			if name == "none" {
 				return nil, nil

--- a/options_test.go
+++ b/options_test.go
@@ -137,8 +137,13 @@ func TestOptionsParse(t *testing.T) {
 	testComparer.Name = "test-comparer"
 	testMerger := *DefaultMerger
 	testMerger.Name = "test-merger"
+	var newCacheSize int64
 
 	hooks := &ParseHooks{
+		NewCache: func(size int64) *Cache {
+			newCacheSize = size
+			return nil
+		},
 		NewCleaner: func(name string) (Cleaner, error) {
 			if name == (testCleaner{}).String() {
 				return testCleaner{}, nil
@@ -181,15 +186,15 @@ func TestOptionsParse(t *testing.T) {
 			opts.EnsureDefaults()
 			str := opts.String()
 
+			newCacheSize = 0
 			var parsedOptions Options
 			require.NoError(t, parsedOptions.Parse(str, hooks))
 			parsedStr := parsedOptions.String()
 			if str != parsedStr {
 				t.Fatalf("expected\n%s\nbut found\n%s", str, parsedStr)
 			}
-			if parsedOptions.Cache != nil {
-				parsedOptions.Cache.Unref()
-			}
+			require.Nil(t, parsedOptions.Cache)
+			require.NotEqual(t, newCacheSize, 0)
 		})
 	}
 }


### PR DESCRIPTION
* bloom: fix hash() to be compatible with RocksDB
* db: add ParseHooks.NewCache