### PR TITLE
*: introduce Comparer.FormatValue

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1226,7 +1226,7 @@ func TestCompactionSetupInputs(t *testing.T) {
 
 				c := &compaction{
 					cmp:              DefaultComparer.Compare,
-					format:           DefaultComparer.Format,
+					formatKey:        DefaultComparer.FormatKey,
 					version:          &version{},
 					startLevel:       -1,
 					outputLevel:      -1,
@@ -1431,9 +1431,9 @@ func TestCompactionInuseKeyRanges(t *testing.T) {
 		switch td.Cmd {
 		case "define":
 			c = &compaction{
-				cmp:     DefaultComparer.Compare,
-				format:  DefaultComparer.Format,
-				version: &version{},
+				cmp:       DefaultComparer.Compare,
+				formatKey: DefaultComparer.FormatKey,
+				version:   &version{},
 			}
 			var files *[]*fileMetadata
 			fileNum := FileNum(1)
@@ -1454,7 +1454,7 @@ func TestCompactionInuseKeyRanges(t *testing.T) {
 					*files = append(*files, meta)
 				}
 			}
-			return c.version.DebugString(c.format)
+			return c.version.DebugString(c.formatKey)
 
 		case "inuse-key-ranges":
 			var buf bytes.Buffer
@@ -1625,7 +1625,7 @@ func TestCompactionCheckOrdering(t *testing.T) {
 			case "check-ordering":
 				c := &compaction{
 					cmp:         DefaultComparer.Compare,
-					format:      DefaultComparer.Format,
+					formatKey:   DefaultComparer.FormatKey,
 					logger:      panicLogger{},
 					startLevel:  -1,
 					outputLevel: -1,

--- a/ingest.go
+++ b/ingest.go
@@ -34,11 +34,11 @@ func sstableKeyCompare(userCmp Compare, a, b InternalKey) int {
 func ingestValidateKey(opts *Options, key *InternalKey) error {
 	if key.Kind() == InternalKeyKindInvalid {
 		return errors.Errorf("pebble: external sstable has corrupted key: %s",
-			key.Pretty(opts.Comparer.Format))
+			key.Pretty(opts.Comparer.FormatKey))
 	}
 	if key.SeqNum() != 0 {
 		return errors.Errorf("pebble: external sstable has non-zero seqnum: %s",
-			key.Pretty(opts.Comparer.Format))
+			key.Pretty(opts.Comparer.FormatKey))
 	}
 	return nil
 }

--- a/internal/base/comparer.go
+++ b/internal/base/comparer.go
@@ -35,8 +35,8 @@ type Equal func(a, b []byte) bool
 // of the user key prefix in the order that gives the correct ordering.
 type AbbreviatedKey func(key []byte) uint64
 
-// Formatter returns a formatter for the user key.
-type Formatter func(key []byte) fmt.Formatter
+// FormatKey returns a formatter for the user key.
+type FormatKey func(key []byte) fmt.Formatter
 
 // Separator is used to construct SSTable index blocks. A trivial implementation
 // is `return a`, but appending fewer bytes leads to smaller SSTables.
@@ -88,7 +88,7 @@ type Comparer struct {
 	Compare        Compare
 	Equal          Equal
 	AbbreviatedKey AbbreviatedKey
-	Format         Formatter
+	FormatKey      FormatKey
 	Separator      Separator
 	Split          Split
 	Successor      Successor
@@ -125,7 +125,7 @@ var DefaultComparer = &Comparer{
 		return v << uint(8*(8-len(key)))
 	},
 
-	Format: DefaultFormatter,
+	FormatKey: DefaultFormatter,
 
 	Separator: func(dst, a, b []byte) []byte {
 		i, n := SharedPrefixLen(a, b), len(dst)

--- a/internal/base/comparer.go
+++ b/internal/base/comparer.go
@@ -38,6 +38,11 @@ type AbbreviatedKey func(key []byte) uint64
 // FormatKey returns a formatter for the user key.
 type FormatKey func(key []byte) fmt.Formatter
 
+// FormatValue returns a formatter for the user value. The key is also
+// specified for the value formatter in order to support value formatting that
+// is dependent on the key.
+type FormatValue func(key, value []byte) fmt.Formatter
+
 // Separator is used to construct SSTable index blocks. A trivial implementation
 // is `return a`, but appending fewer bytes leads to smaller SSTables.
 //
@@ -89,6 +94,7 @@ type Comparer struct {
 	Equal          Equal
 	AbbreviatedKey AbbreviatedKey
 	FormatKey      FormatKey
+	FormatValue    FormatValue
 	Separator      Separator
 	Split          Split
 	Successor      Successor

--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -300,15 +300,15 @@ func (k InternalKey) String() string {
 }
 
 // Pretty returns a formatter for the key.
-func (k InternalKey) Pretty(f Formatter) fmt.Formatter {
+func (k InternalKey) Pretty(f FormatKey) fmt.Formatter {
 	return prettyInternalKey{k, f}
 }
 
 type prettyInternalKey struct {
 	InternalKey
-	formatter Formatter
+	formatKey FormatKey
 }
 
 func (k prettyInternalKey) Format(s fmt.State, c rune) {
-	fmt.Fprintf(s, "%s#%d,%s", k.formatter(k.UserKey), k.SeqNum(), k.Kind())
+	fmt.Fprintf(s, "%s#%d,%s", k.formatKey(k.UserKey), k.SeqNum(), k.Kind())
 }

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -200,7 +200,7 @@ func (v *Version) String() string {
 }
 
 // Pretty returns a string representation of the version.
-func (v *Version) Pretty(format base.Formatter) string {
+func (v *Version) Pretty(format base.FormatKey) string {
 	var buf bytes.Buffer
 	for level := 0; level < NumLevels; level++ {
 		if len(v.Files[level]) == 0 {
@@ -218,7 +218,7 @@ func (v *Version) Pretty(format base.Formatter) string {
 
 // DebugString returns an alternative format to String() which includes
 // sequence number and kind information for the sstable boundaries.
-func (v *Version) DebugString(format base.Formatter) string {
+func (v *Version) DebugString(format base.FormatKey) string {
 	var buf bytes.Buffer
 	for level := 0; level < NumLevels; level++ {
 		if len(v.Files[level]) == 0 {
@@ -368,7 +368,7 @@ func (v *Version) Overlaps(level int, cmp Compare, start, end []byte) (ret []*Fi
 // CheckOrdering checks that the files are consistent with respect to
 // increasing file numbers (for level 0 files) and increasing and non-
 // overlapping internal key ranges (for level non-0 files).
-func (v *Version) CheckOrdering(cmp Compare, format base.Formatter) error {
+func (v *Version) CheckOrdering(cmp Compare, format base.FormatKey) error {
 	for level, files := range v.Files {
 		if err := CheckOrdering(cmp, format, level, files); err != nil {
 			return errors.Errorf("%s\n%s", err, v.DebugString(format))
@@ -439,7 +439,7 @@ func (l *VersionList) Remove(v *Version) {
 // CheckOrdering checks that the files are consistent with respect to
 // seqnums (for level 0 files -- see detailed comment below) and increasing and non-
 // overlapping internal key ranges (for non-level 0 files).
-func CheckOrdering(cmp Compare, format base.Formatter, level int, files []*FileMetadata) error {
+func CheckOrdering(cmp Compare, format base.FormatKey, level int, files []*FileMetadata) error {
 	if level == 0 {
 		// We have 2 kinds of files:
 		// - Files with exactly one sequence number: these could be either ingested files

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -468,7 +468,7 @@ func (b *BulkVersionEdit) Accumulate(ve *VersionEdit) {
 // referenced by the returned Version, but cannot be deleted from disk as they
 // are still in use by the incoming Version.
 func (b *BulkVersionEdit) Apply(
-	curr *Version, cmp Compare, format base.Formatter,
+	curr *Version, cmp Compare, formatKey base.FormatKey,
 ) (_ *Version, zombies map[base.FileNum]uint64, _ error) {
 	addZombie := func(fileNum base.FileNum, size uint64) {
 		if zombies == nil {
@@ -547,7 +547,7 @@ func (b *BulkVersionEdit) Apply(
 				}
 			}
 			SortBySeqNum(v.Files[level])
-			if err := CheckOrdering(cmp, format, 0, v.Files[level]); err != nil {
+			if err := CheckOrdering(cmp, formatKey, 0, v.Files[level]); err != nil {
 				return nil, nil, errors.Wrap(err, "pebble: internal error")
 			}
 			continue
@@ -604,8 +604,8 @@ func (b *BulkVersionEdit) Apply(
 					return nil, nil, errors.Errorf(
 						"pebble: internal error: L%d files %s and %s have overlapping ranges: [%s-%s] vs [%s-%s]",
 						errors.Safe(level), errors.Safe(cf.FileNum), errors.Safe(f.FileNum),
-						cf.Smallest.Pretty(format), cf.Largest.Pretty(format),
-						f.Smallest.Pretty(format), f.Largest.Pretty(format))
+						cf.Smallest.Pretty(formatKey), cf.Largest.Pretty(formatKey),
+						f.Smallest.Pretty(formatKey), f.Largest.Pretty(formatKey))
 				}
 			}
 			v.Files[level] = append(v.Files[level], f)

--- a/internal/rangedel/tombstone.go
+++ b/internal/rangedel/tombstone.go
@@ -62,18 +62,18 @@ func (t Tombstone) String() string {
 }
 
 // Pretty returns a formatter for the tombstone.
-func (t Tombstone) Pretty(f base.Formatter) fmt.Formatter {
+func (t Tombstone) Pretty(f base.FormatKey) fmt.Formatter {
 	return prettyTombstone{t, f}
 }
 
 type prettyTombstone struct {
 	Tombstone
-	formatter base.Formatter
+	formatKey base.FormatKey
 }
 
 func (t prettyTombstone) Format(s fmt.State, c rune) {
 	if t.Empty() {
 		fmt.Fprintf(s, "<empty>")
 	}
-	fmt.Fprintf(s, "%s-%s#%d", t.formatter(t.Start.UserKey), t.formatter(t.End), t.Start.SeqNum())
+	fmt.Fprintf(s, "%s-%s#%d", t.formatKey(t.Start.UserKey), t.formatKey(t.End), t.Start.SeqNum())
 }

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -81,7 +81,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 	memFS := vfs.NewMem()
 	cmp := DefaultComparer.Compare
 	var levels [][]*fileMetadata
-	format := DefaultComparer.Format
+	formatKey := DefaultComparer.FormatKey
 	// Indexed by fileNum
 	var readers []*sstable.Reader
 	defer func() {
@@ -246,7 +246,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 				newIters:  newIters,
 				seqNum:    InternalKeySeqNumMax,
 				merge:     merge,
-				format:    format,
+				formatKey: formatKey,
 			}
 			if err := checkLevelsInternal(c); err != nil {
 				return err.Error()

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -228,7 +228,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 				readers = append(readers, r)
 			}
 
-			return v.DebugString(DefaultComparer.Format)
+			return v.DebugString(DefaultComparer.FormatKey)
 		case "iter":
 			levelIters := make([]mergingIterLevel, 0, len(v.Files))
 			for i, l := range v.Files {

--- a/tool/data_test.go
+++ b/tool/data_test.go
@@ -87,8 +87,7 @@ func runTests(t *testing.T, path string) {
 				// Register a test comparer and merger so that we can check the
 				// behavior of tools when the comparer and merger do not match.
 				tool.RegisterComparer(func() *Comparer {
-					var c Comparer
-					c = *base.DefaultComparer
+					c := *base.DefaultComparer
 					c.Name = "test-comparer"
 					c.FormatKey = func(key []byte) fmt.Formatter {
 						return fmtFormatter{
@@ -96,11 +95,16 @@ func runTests(t *testing.T, path string) {
 							v:   key,
 						}
 					}
+					c.FormatValue = func(_, value []byte) fmt.Formatter {
+						return fmtFormatter{
+							fmt: "test value formatter: %s",
+							v:   value,
+						}
+					}
 					return &c
 				}())
 				tool.RegisterMerger(func() *Merger {
-					var m Merger
-					m = *base.DefaultMerger
+					m := *base.DefaultMerger
 					m.Name = "test-merger"
 					return &m
 				}())

--- a/tool/data_test.go
+++ b/tool/data_test.go
@@ -90,7 +90,7 @@ func runTests(t *testing.T, path string) {
 					var c Comparer
 					c = *base.DefaultComparer
 					c.Name = "test-comparer"
-					c.Format = func(key []byte) fmt.Formatter {
+					c.FormatKey = func(key []byte) fmt.Formatter {
 						return fmtFormatter{
 							fmt: "test formatter: %s",
 							v:   key,

--- a/tool/db.go
+++ b/tool/db.go
@@ -41,8 +41,8 @@ type dbT struct {
 	// Flags.
 	comparerName string
 	mergerName   string
-	fmtKey       formatter
-	fmtValue     formatter
+	fmtKey       keyFormatter
+	fmtValue     valueFormatter
 	start        key
 	end          key
 	count        int64
@@ -267,6 +267,7 @@ func (d *dbT) runScan(cmd *cobra.Command, args []string) {
 	// Update the internal formatter if this comparator has one specified.
 	if d.opts.Comparer != nil {
 		d.fmtKey.setForComparer(d.opts.Comparer.Name, d.comparers)
+		d.fmtValue.setForComparer(d.opts.Comparer.Name, d.comparers)
 	}
 
 	start := timeNow()
@@ -288,7 +289,7 @@ func (d *dbT) runScan(cmd *cobra.Command, args []string) {
 				if needDelimiter {
 					stdout.Write([]byte{' '})
 				}
-				fmt.Fprintf(stdout, "%s", d.fmtValue.fn(iter.Value()))
+				fmt.Fprintf(stdout, "%s", d.fmtValue.fn(iter.Key(), iter.Value()))
 			}
 			stdout.Write([]byte{'\n'})
 		}
@@ -374,6 +375,7 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 			if ve.ComparerName != "" {
 				cmp = d.comparers[ve.ComparerName]
 				d.fmtKey.setForComparer(ve.ComparerName, d.comparers)
+				d.fmtValue.setForComparer(ve.ComparerName, d.comparers)
 			}
 		}
 		v, _, err := bve.Apply(nil /* version */, cmp.Compare, d.fmtKey.fn)

--- a/tool/find.go
+++ b/tool/find.go
@@ -36,8 +36,8 @@ type findT struct {
 
 	// Flags.
 	comparerName string
-	fmtKey       formatter
-	fmtValue     formatter
+	fmtKey       keyFormatter
+	fmtValue     valueFormatter
 	verbose      bool
 
 	// Map from file num to path on disk.
@@ -108,6 +108,7 @@ func (f *findT) run(cmd *cobra.Command, args []string) {
 		return
 	}
 	f.fmtKey.setForComparer(f.opts.Comparer.Name, f.comparers)
+	f.fmtValue.setForComparer(f.opts.Comparer.Name, f.comparers)
 
 	refs := f.search(key)
 	var lastFileNum base.FileNum

--- a/tool/lsm.go
+++ b/tool/lsm.go
@@ -58,7 +58,7 @@ type lsmT struct {
 	opts      *pebble.Options
 	comparers sstable.Comparers
 
-	fmtKey formatter
+	fmtKey keyFormatter
 	embed  bool
 	pretty bool
 

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -27,7 +27,7 @@ type manifestT struct {
 
 	opts      *pebble.Options
 	comparers sstable.Comparers
-	fmtKey    formatter
+	fmtKey    keyFormatter
 	verbose   bool
 }
 

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -37,8 +37,8 @@ type sstableT struct {
 	mergers   sstable.Mergers
 
 	// Flags.
-	fmtKey   formatter
-	fmtValue formatter
+	fmtKey   keyFormatter
+	fmtValue valueFormatter
 	start    key
 	end      key
 	filter   key
@@ -167,6 +167,7 @@ func (s *sstableT) runCheck(cmd *cobra.Command, args []string) {
 
 		// Update the internal formatter if this comparator has one specified.
 		s.fmtKey.setForComparer(r.Properties.ComparerName, s.comparers)
+		s.fmtValue.setForComparer(r.Properties.ComparerName, s.comparers)
 
 		iter, err := r.NewIter(nil, nil)
 		if err != nil {
@@ -241,6 +242,7 @@ func (s *sstableT) runLayout(cmd *cobra.Command, args []string) {
 
 		// Update the internal formatter if this comparator has one specified.
 		s.fmtKey.setForComparer(r.Properties.ComparerName, s.comparers)
+		s.fmtValue.setForComparer(r.Properties.ComparerName, s.comparers)
 
 		l, err := r.Layout()
 		if err != nil {
@@ -372,6 +374,7 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 
 		// Update the internal formatter if this comparator has one specified.
 		s.fmtKey.setForComparer(r.Properties.ComparerName, s.comparers)
+		s.fmtValue.setForComparer(r.Properties.ComparerName, s.comparers)
 
 		iter, err := r.NewIter(nil, s.end)
 		if err != nil {

--- a/tool/testdata/find
+++ b/tool/testdata/find
@@ -34,30 +34,30 @@ find
 testdata/find-db
 bbb
 --key=%x
---value=[%s]
+--value=pretty:test-comparer
 ----
 000002.log
-    626262#1,SET [2]
+    626262#1,SET test value formatter: 2
 000004.log
     626262-656565#9,RANGEDEL
 000005.sst [616161#0,SET-636363#4,MERGE]
     (flushed to L0, moved to L6)
-    626262#1,SET [2]
+    626262#1,SET test value formatter: 2
 000006.sst [626262#5,SET-636363#5,SET]
     (ingested to L0)
-    626262#5,SET [22]
+    626262#5,SET test value formatter: 22
 000008.sst [616161#0,SET-636363#0,MERGE]
     (compacted L0 [000006] + L6 [000005])
-    626262#5,SET [22]
-    626262#0,SET [2]
+    626262#5,SET test value formatter: 22
+    626262#0,SET test value formatter: 2
 000010.sst [616161#7,DEL-656565#72057594037927935,RANGEDEL]
     (flushed to L0)
     626262-656565#9,RANGEDEL
 000011.sst [616161#7,DEL-656565#72057594037927935,RANGEDEL]
     (compacted L0 [000010] + L6 [000008 ...])
     626262-656565#9,RANGEDEL
-    626262#5,SET [22]
-    626262#0,SET [2]
+    626262#5,SET test value formatter: 22
+    626262#0,SET test value formatter: 2
 
 find
 testdata/find-db

--- a/tool/testdata/sstable_layout
+++ b/tool/testdata/sstable_layout
@@ -104,269 +104,269 @@ h.no-compression.two_level_index.sst
 
 sstable layout
 -v
---value=null
+--value=pretty:test-comparer
 ../sstable/testdata/h.no-compression.two_level_index.sst
 ----
 h.no-compression.two_level_index.sst
          0  data (2041)
          0    record (14 = 3 [0] + 9 + 2) [restart]
-              a#0,SET
+              a#0,SET test value formatter: 97
         14    record (17 = 3 [1] + 13 + 1)
-              aboard#0,SET
+              aboard#0,SET test value formatter: 2
         31    record (14 = 3 [3] + 10 + 1)
-              about#0,SET
+              about#0,SET test value formatter: 2
         45    record (14 = 3 [3] + 10 + 1)
-              above#0,SET
+              above#0,SET test value formatter: 1
         59    record (16 = 3 [2] + 12 + 1)
-              abroad#0,SET
+              abroad#0,SET test value formatter: 1
         75    record (16 = 3 [2] + 12 + 1)
-              absurd#0,SET
+              absurd#0,SET test value formatter: 1
         91    record (16 = 3 [2] + 12 + 1)
-              abused#0,SET
+              abused#0,SET test value formatter: 1
        107    record (17 = 3 [1] + 13 + 1)
-              accord#0,SET
+              accord#0,SET test value formatter: 1
        124    record (15 = 3 [4] + 11 + 1)
-              account#0,SET
+              account#0,SET test value formatter: 1
        139    record (22 = 3 [2] + 18 + 1)
-              achievements#0,SET
+              achievements#0,SET test value formatter: 1
        161    record (18 = 3 [2] + 14 + 1)
-              acquaint#0,SET
+              acquaint#0,SET test value formatter: 1
        179    record (13 = 3 [2] + 9 + 1)
-              act#0,SET
+              act#0,SET test value formatter: 5
        192    record (15 = 3 [3] + 11 + 1)
-              action#0,SET
+              action#0,SET test value formatter: 1
        207    record (13 = 3 [6] + 9 + 1)
-              actions#0,SET
+              actions#0,SET test value formatter: 1
        220    record (19 = 3 [1] + 15 + 1)
-              addition#0,SET
+              addition#0,SET test value formatter: 1
        239    record (16 = 3 [3] + 12 + 1)
-              address#0,SET
+              address#0,SET test value formatter: 1
        255    record (17 = 3 [0] + 13 + 1) [restart]
-              adieu#0,SET
+              adieu#0,SET test value formatter: 4
        272    record (20 = 3 [2] + 16 + 1)
-              admiration#0,SET
+              admiration#0,SET test value formatter: 1
        292    record (18 = 3 [2] + 14 + 1)
-              adoption#0,SET
+              adoption#0,SET test value formatter: 1
        310    record (20 = 3 [2] + 16 + 1)
-              adulterate#0,SET
+              adulterate#0,SET test value formatter: 1
        330    record (19 = 3 [2] + 15 + 1)
-              advantage#0,SET
+              advantage#0,SET test value formatter: 1
        349    record (15 = 3 [3] + 11 + 1)
-              advice#0,SET
+              advice#0,SET test value formatter: 1
        364    record (17 = 3 [1] + 13 + 1)
-              affair#0,SET
+              affair#0,SET test value formatter: 2
        381    record (18 = 3 [3] + 14 + 1)
-              affection#0,SET
+              affection#0,SET test value formatter: 3
        399    record (15 = 3 [2] + 11 + 1)
-              after#0,SET
+              after#0,SET test value formatter: 1
        414    record (16 = 3 [5] + 12 + 1)
-              afternoon#0,SET
+              afternoon#0,SET test value formatter: 1
        430    record (17 = 3 [1] + 12 + 2)
-              again#0,SET
+              again#0,SET test value formatter: 13
        447    record (14 = 3 [5] + 10 + 1)
-              against#0,SET
+              against#0,SET test value formatter: 5
        461    record (13 = 3 [1] + 9 + 1)
-              ah#0,SET
+              ah#0,SET test value formatter: 2
        474    record (14 = 3 [1] + 10 + 1)
-              air#0,SET
+              air#0,SET test value formatter: 5
        488    record (13 = 3 [3] + 9 + 1)
-              airs#0,SET
+              airs#0,SET test value formatter: 1
        501    record (15 = 3 [1] + 11 + 1)
-              alas#0,SET
+              alas#0,SET test value formatter: 1
        516    record (16 = 3 [0] + 11 + 2) [restart]
-              all#0,SET
+              all#0,SET test value formatter: 36
        532    record (15 = 3 [3] + 11 + 1)
-              alleys#0,SET
+              alleys#0,SET test value formatter: 1
        547    record (14 = 3 [3] + 10 + 1)
-              allow#0,SET
+              allow#0,SET test value formatter: 1
        561    record (16 = 3 [2] + 12 + 1)
-              almost#0,SET
+              almost#0,SET test value formatter: 4
        577    record (15 = 3 [2] + 11 + 1)
-              alone#0,SET
+              alone#0,SET test value formatter: 4
        592    record (13 = 3 [4] + 9 + 1)
-              along#0,SET
+              along#0,SET test value formatter: 2
        605    record (17 = 3 [2] + 13 + 1)
-              already#0,SET
+              already#0,SET test value formatter: 1
        622    record (16 = 3 [2] + 12 + 1)
-              always#0,SET
+              always#0,SET test value formatter: 1
        638    record (13 = 3 [1] + 9 + 1)
-              am#0,SET
+              am#0,SET test value formatter: 9
        651    record (16 = 3 [2] + 12 + 1)
-              amazed#0,SET
+              amazed#0,SET test value formatter: 1
        667    record (19 = 3 [2] + 15 + 1)
-              ambiguous#0,SET
+              ambiguous#0,SET test value formatter: 1
        686    record (17 = 3 [4] + 13 + 1)
-              ambitious#0,SET
+              ambitious#0,SET test value formatter: 1
        703    record (14 = 3 [1] + 9 + 2)
-              an#0,SET
+              an#0,SET test value formatter: 13
        717    record (15 = 3 [2] + 9 + 3)
-              and#0,SET
+              and#0,SET test value formatter: 227
        732    record (15 = 3 [2] + 11 + 1)
-              angel#0,SET
+              angel#0,SET test value formatter: 1
        747    record (13 = 3 [5] + 9 + 1)
-              angels#0,SET
+              angels#0,SET test value formatter: 1
        760    record (17 = 3 [0] + 13 + 1) [restart]
-              anger#0,SET
+              anger#0,SET test value formatter: 1
        777    record (14 = 3 [3] + 10 + 1)
-              angry#0,SET
+              angry#0,SET test value formatter: 1
        791    record (17 = 3 [2] + 13 + 1)
-              another#0,SET
+              another#0,SET test value formatter: 1
        808    record (16 = 3 [2] + 12 + 1)
-              answer#0,SET
+              answer#0,SET test value formatter: 4
        824    record (15 = 3 [2] + 11 + 1)
-              antic#0,SET
+              antic#0,SET test value formatter: 1
        839    record (13 = 3 [2] + 9 + 1)
-              any#0,SET
+              any#0,SET test value formatter: 6
        852    record (18 = 3 [1] + 14 + 1)
-              apparel#0,SET
+              apparel#0,SET test value formatter: 1
        870    record (17 = 3 [5] + 13 + 1)
-              apparition#0,SET
+              apparition#0,SET test value formatter: 2
        887    record (15 = 3 [3] + 11 + 1)
-              appear#0,SET
+              appear#0,SET test value formatter: 4
        902    record (13 = 3 [6] + 9 + 1)
-              appears#0,SET
+              appears#0,SET test value formatter: 1
        915    record (16 = 3 [4] + 12 + 1)
-              appetite#0,SET
+              appetite#0,SET test value formatter: 1
        931    record (16 = 3 [3] + 12 + 1)
-              approve#0,SET
+              approve#0,SET test value formatter: 1
        947    record (13 = 3 [2] + 9 + 1)
-              apt#0,SET
+              apt#0,SET test value formatter: 1
        960    record (15 = 3 [1] + 10 + 2)
-              are#0,SET
+              are#0,SET test value formatter: 21
        975    record (13 = 3 [2] + 9 + 1)
-              arm#0,SET
+              arm#0,SET test value formatter: 2
        988    record (14 = 3 [3] + 10 + 1)
-              armed#0,SET
+              armed#0,SET test value formatter: 2
       1002    record (18 = 3 [0] + 14 + 1) [restart]
-              armour#0,SET
+              armour#0,SET test value formatter: 1
       1020    record (13 = 3 [3] + 9 + 1)
-              arms#0,SET
+              arms#0,SET test value formatter: 2
       1033    record (16 = 3 [2] + 12 + 1)
-              arrant#0,SET
+              arrant#0,SET test value formatter: 1
       1049    record (13 = 3 [2] + 9 + 1)
-              art#0,SET
+              art#0,SET test value formatter: 6
       1062    record (15 = 3 [3] + 11 + 1)
-              artery#0,SET
+              artery#0,SET test value formatter: 1
       1077    record (16 = 3 [3] + 12 + 1)
-              article#0,SET
+              article#0,SET test value formatter: 1
       1093    record (13 = 3 [7] + 9 + 1)
-              articles#0,SET
+              articles#0,SET test value formatter: 1
       1106    record (14 = 3 [1] + 9 + 2)
-              as#0,SET
+              as#0,SET test value formatter: 56
       1120    record (15 = 3 [2] + 11 + 1)
-              aside#0,SET
+              aside#0,SET test value formatter: 1
       1135    record (16 = 3 [2] + 12 + 1)
-              asking#0,SET
+              asking#0,SET test value formatter: 1
       1151    record (16 = 3 [2] + 12 + 1)
-              assail#0,SET
+              assail#0,SET test value formatter: 1
       1167    record (18 = 3 [3] + 14 + 1)
-              assistant#0,SET
+              assistant#0,SET test value formatter: 1
       1185    record (15 = 3 [3] + 11 + 1)
-              assume#0,SET
+              assume#0,SET test value formatter: 2
       1200    record (14 = 3 [1] + 9 + 2)
-              at#0,SET
+              at#0,SET test value formatter: 18
       1214    record (20 = 3 [2] + 16 + 1)
-              attendants#0,SET
+              attendants#0,SET test value formatter: 1
       1234    record (13 = 3 [5] + 9 + 1)
-              attent#0,SET
+              attent#0,SET test value formatter: 1
       1247    record (21 = 3 [0] + 17 + 1) [restart]
-              attribute#0,SET
+              attribute#0,SET test value formatter: 1
       1268    record (19 = 3 [1] + 15 + 1)
-              audience#0,SET
+              audience#0,SET test value formatter: 1
       1287    record (15 = 3 [2] + 11 + 1)
-              aught#0,SET
+              aught#0,SET test value formatter: 2
       1302    record (20 = 3 [2] + 16 + 1)
-              auspicious#0,SET
+              auspicious#0,SET test value formatter: 1
       1322    record (16 = 3 [1] + 12 + 1)
-              avoid#0,SET
+              avoid#0,SET test value formatter: 1
       1338    record (15 = 3 [3] + 11 + 1)
-              avouch#0,SET
+              avouch#0,SET test value formatter: 1
       1353    record (16 = 3 [1] + 12 + 1)
-              awake#0,SET
+              awake#0,SET test value formatter: 1
       1369    record (13 = 3 [3] + 9 + 1)
-              away#0,SET
+              away#0,SET test value formatter: 7
       1382    record (16 = 3 [2] + 12 + 1)
-              awhile#0,SET
+              awhile#0,SET test value formatter: 2
       1398    record (13 = 3 [1] + 9 + 1)
-              ay#0,SET
+              ay#0,SET test value formatter: 7
       1411    record (16 = 3 [0] + 12 + 1)
-              baby#0,SET
+              baby#0,SET test value formatter: 1
       1427    record (14 = 3 [2] + 10 + 1)
-              back#0,SET
+              back#0,SET test value formatter: 1
       1441    record (15 = 3 [2] + 11 + 1)
-              baked#0,SET
+              baked#0,SET test value formatter: 1
       1456    record (14 = 3 [2] + 10 + 1)
-              bark#0,SET
+              bark#0,SET test value formatter: 1
       1470    record (13 = 3 [3] + 9 + 1)
-              barr#0,SET
+              barr#0,SET test value formatter: 1
       1483    record (14 = 3 [2] + 10 + 1)
-              base#0,SET
+              base#0,SET test value formatter: 1
       1497    record (17 = 3 [0] + 13 + 1) [restart]
-              baser#0,SET
+              baser#0,SET test value formatter: 1
       1514    record (15 = 3 [2] + 11 + 1)
-              bawds#0,SET
+              bawds#0,SET test value formatter: 1
       1529    record (14 = 3 [1] + 9 + 2)
-              be#0,SET
+              be#0,SET test value formatter: 42
       1543    record (14 = 3 [2] + 10 + 1)
-              bear#0,SET
+              bear#0,SET test value formatter: 5
       1557    record (13 = 3 [4] + 9 + 1)
-              beard#0,SET
+              beard#0,SET test value formatter: 1
       1570    record (15 = 3 [4] + 11 + 1)
-              bearers#0,SET
+              bearers#0,SET test value formatter: 1
       1585    record (13 = 3 [4] + 9 + 1)
-              bears#0,SET
+              bears#0,SET test value formatter: 1
       1598    record (14 = 3 [3] + 10 + 1)
-              beast#0,SET
+              beast#0,SET test value formatter: 2
       1612    record (16 = 3 [3] + 12 + 1)
-              beating#0,SET
+              beating#0,SET test value formatter: 1
       1628    record (15 = 3 [3] + 11 + 1)
-              beauty#0,SET
+              beauty#0,SET test value formatter: 1
       1643    record (15 = 3 [3] + 11 + 1)
-              beaver#0,SET
+              beaver#0,SET test value formatter: 1
       1658    record (17 = 3 [2] + 13 + 1)
-              beckons#0,SET
+              beckons#0,SET test value formatter: 2
       1675    record (13 = 3 [2] + 9 + 1)
-              bed#0,SET
+              bed#0,SET test value formatter: 4
       1688    record (14 = 3 [2] + 10 + 1)
-              been#0,SET
+              been#0,SET test value formatter: 4
       1702    record (16 = 3 [3] + 12 + 1)
-              beetles#0,SET
+              beetles#0,SET test value formatter: 1
       1718    record (18 = 3 [2] + 14 + 1)
-              befitted#0,SET
+              befitted#0,SET test value formatter: 1
       1736    record (18 = 3 [0] + 14 + 1) [restart]
-              before#0,SET
+              before#0,SET test value formatter: 6
       1754    record (13 = 3 [2] + 9 + 1)
-              beg#0,SET
+              beg#0,SET test value formatter: 1
       1767    record (16 = 3 [3] + 12 + 1)
-              beguile#0,SET
+              beguile#0,SET test value formatter: 1
       1783    record (16 = 3 [2] + 12 + 1)
-              behold#0,SET
+              behold#0,SET test value formatter: 1
       1799    record (15 = 3 [4] + 11 + 1)
-              behoves#0,SET
+              behoves#0,SET test value formatter: 1
       1814    record (15 = 3 [2] + 11 + 1)
-              being#0,SET
+              being#0,SET test value formatter: 4
       1829    record (16 = 3 [2] + 12 + 1)
-              belief#0,SET
+              belief#0,SET test value formatter: 1
       1845    record (14 = 3 [5] + 10 + 1)
-              believe#0,SET
+              believe#0,SET test value formatter: 6
       1859    record (13 = 3 [3] + 9 + 1)
-              bell#0,SET
+              bell#0,SET test value formatter: 1
       1872    record (14 = 3 [2] + 10 + 1)
-              bend#0,SET
+              bend#0,SET test value formatter: 2
       1886    record (16 = 3 [3] + 12 + 1)
-              beneath#0,SET
+              beneath#0,SET test value formatter: 5
       1902    record (15 = 3 [4] + 11 + 1)
-              benefit#0,SET
+              benefit#0,SET test value formatter: 1
       1917    record (19 = 3 [2] + 14 + 2)
-              bernardo#0,SET
+              bernardo#0,SET test value formatter: 30
       1936    record (17 = 3 [2] + 13 + 1)
-              beseech#0,SET
+              beseech#0,SET test value formatter: 2
       1953    record (17 = 3 [3] + 13 + 1)
-              besmirch#0,SET
+              besmirch#0,SET test value formatter: 1
       1970    record (13 = 3 [3] + 9 + 1)
-              best#0,SET
+              best#0,SET test value formatter: 5
       1983    record (18 = 3 [0] + 14 + 1) [restart]
-              beteem#0,SET
+              beteem#0,SET test value formatter: 1
       2001    [restart 0]
       2005    [restart 255]
       2009    [restart 516]
@@ -378,263 +378,263 @@ h.no-compression.two_level_index.sst
       2033    [restart 1983]
       2046  data (2044)
       2046    record (21 = 3 [0] + 17 + 1) [restart]
-              bethought#0,SET
+              bethought#0,SET test value formatter: 1
       2067    record (15 = 3 [3] + 11 + 1)
-              better#0,SET
+              better#0,SET test value formatter: 2
       2082    record (16 = 3 [3] + 12 + 1)
-              between#0,SET
+              between#0,SET test value formatter: 2
       2098    record (16 = 3 [2] + 12 + 1)
-              beware#0,SET
+              beware#0,SET test value formatter: 2
       2114    record (16 = 3 [2] + 12 + 1)
-              beyond#0,SET
+              beyond#0,SET test value formatter: 1
       2130    record (14 = 3 [1] + 10 + 1)
-              bid#0,SET
+              bid#0,SET test value formatter: 2
       2144    record (14 = 3 [2] + 10 + 1)
-              bird#0,SET
+              bird#0,SET test value formatter: 2
       2158    record (14 = 3 [3] + 10 + 1)
-              birth#0,SET
+              birth#0,SET test value formatter: 3
       2172    record (15 = 3 [2] + 11 + 1)
-              bites#0,SET
+              bites#0,SET test value formatter: 1
       2187    record (15 = 3 [3] + 11 + 1)
-              bitter#0,SET
+              bitter#0,SET test value formatter: 1
       2202    record (16 = 3 [1] + 12 + 1)
-              black#0,SET
+              black#0,SET test value formatter: 1
       2218    record (14 = 3 [3] + 10 + 1)
-              blast#0,SET
+              blast#0,SET test value formatter: 1
       2232    record (17 = 3 [5] + 13 + 1)
-              blastments#0,SET
+              blastments#0,SET test value formatter: 1
       2249    record (13 = 3 [5] + 9 + 1)
-              blasts#0,SET
+              blasts#0,SET test value formatter: 1
       2262    record (15 = 3 [3] + 11 + 1)
-              blazes#0,SET
+              blazes#0,SET test value formatter: 1
       2277    record (14 = 3 [4] + 10 + 1)
-              blazon#0,SET
+              blazon#0,SET test value formatter: 1
       2291    record (20 = 3 [0] + 16 + 1) [restart]
-              blessing#0,SET
+              blessing#0,SET test value formatter: 3
       2311    record (15 = 3 [2] + 11 + 1)
-              blood#0,SET
+              blood#0,SET test value formatter: 7
       2326    record (17 = 3 [3] + 13 + 1)
-              blossoms#0,SET
+              blossoms#0,SET test value formatter: 1
       2343    record (14 = 3 [3] + 10 + 1)
-              blows#0,SET
+              blows#0,SET test value formatter: 1
       2357    record (16 = 3 [1] + 12 + 1)
-              bodes#0,SET
+              bodes#0,SET test value formatter: 1
       2373    record (13 = 3 [3] + 9 + 1)
-              body#0,SET
+              body#0,SET test value formatter: 5
       2386    record (15 = 3 [2] + 11 + 1)
-              bonds#0,SET
+              bonds#0,SET test value formatter: 1
       2401    record (14 = 3 [3] + 10 + 1)
-              bones#0,SET
+              bones#0,SET test value formatter: 1
       2415    record (14 = 3 [2] + 10 + 1)
-              book#0,SET
+              book#0,SET test value formatter: 1
       2429    record (13 = 3 [4] + 9 + 1)
-              books#0,SET
+              books#0,SET test value formatter: 1
       2442    record (14 = 3 [2] + 10 + 1)
-              born#0,SET
+              born#0,SET test value formatter: 2
       2456    record (17 = 3 [3] + 13 + 1)
-              borrower#0,SET
+              borrower#0,SET test value formatter: 1
       2473    record (15 = 3 [6] + 11 + 1)
-              borrowing#0,SET
+              borrowing#0,SET test value formatter: 1
       2488    record (15 = 3 [2] + 11 + 1)
-              bosom#0,SET
+              bosom#0,SET test value formatter: 1
       2503    record (14 = 3 [2] + 10 + 1)
-              both#0,SET
+              both#0,SET test value formatter: 3
       2517    record (15 = 3 [2] + 11 + 1)
-              bound#0,SET
+              bound#0,SET test value formatter: 2
       2532    record (21 = 3 [0] + 17 + 1) [restart]
-              bounteous#0,SET
+              bounteous#0,SET test value formatter: 1
       2553    record (13 = 3 [2] + 9 + 1)
-              bow#0,SET
+              bow#0,SET test value formatter: 1
       2566    record (13 = 3 [2] + 9 + 1)
-              boy#0,SET
+              boy#0,SET test value formatter: 2
       2579    record (16 = 3 [1] + 12 + 1)
-              brain#0,SET
+              brain#0,SET test value formatter: 2
       2595    record (13 = 3 [3] + 9 + 1)
-              bray#0,SET
+              bray#0,SET test value formatter: 1
       2608    record (15 = 3 [3] + 11 + 1)
-              brazen#0,SET
+              brazen#0,SET test value formatter: 1
       2623    record (16 = 3 [2] + 12 + 1)
-              breach#0,SET
+              breach#0,SET test value formatter: 1
       2639    record (13 = 3 [4] + 9 + 1)
-              break#0,SET
+              break#0,SET test value formatter: 3
       2652    record (15 = 3 [5] + 11 + 1)
-              breaking#0,SET
+              breaking#0,SET test value formatter: 1
       2667    record (14 = 3 [4] + 10 + 1)
-              breath#0,SET
+              breath#0,SET test value formatter: 1
       2681    record (15 = 3 [6] + 11 + 1)
-              breathing#0,SET
+              breathing#0,SET test value formatter: 1
       2696    record (15 = 3 [2] + 11 + 1)
-              brief#0,SET
+              brief#0,SET test value formatter: 1
       2711    record (14 = 3 [3] + 10 + 1)
-              bring#0,SET
+              bring#0,SET test value formatter: 1
       2725    record (17 = 3 [2] + 13 + 1)
-              brokers#0,SET
+              brokers#0,SET test value formatter: 1
       2742    record (16 = 3 [3] + 12 + 1)
-              brother#0,SET
+              brother#0,SET test value formatter: 6
       2758    record (13 = 3 [3] + 9 + 1)
-              brow#0,SET
+              brow#0,SET test value formatter: 1
       2771    record (17 = 3 [0] + 13 + 1) [restart]
-              bruit#0,SET
+              bruit#0,SET test value formatter: 1
       2788    record (15 = 3 [1] + 11 + 1)
-              bulk#0,SET
+              bulk#0,SET test value formatter: 1
       2803    record (16 = 3 [2] + 12 + 1)
-              buried#0,SET
+              buried#0,SET test value formatter: 1
       2819    record (14 = 3 [3] + 10 + 1)
-              burns#0,SET
+              burns#0,SET test value formatter: 2
       2833    record (13 = 3 [4] + 9 + 1)
-              burnt#0,SET
+              burnt#0,SET test value formatter: 1
       2846    record (14 = 3 [3] + 10 + 1)
-              burst#0,SET
+              burst#0,SET test value formatter: 2
       2860    record (18 = 3 [2] + 14 + 1)
-              business#0,SET
+              business#0,SET test value formatter: 4
       2878    record (14 = 3 [2] + 9 + 2)
-              but#0,SET
+              but#0,SET test value formatter: 58
       2892    record (16 = 3 [3] + 12 + 1)
-              buttons#0,SET
+              buttons#0,SET test value formatter: 1
       2908    record (13 = 3 [2] + 9 + 1)
-              buy#0,SET
+              buy#0,SET test value formatter: 1
       2921    record (14 = 3 [1] + 9 + 2)
-              by#0,SET
+              by#0,SET test value formatter: 31
       2935    record (16 = 3 [0] + 12 + 1)
-              call#0,SET
+              call#0,SET test value formatter: 4
       2951    record (19 = 3 [3] + 15 + 1)
-              calumnious#0,SET
+              calumnious#0,SET test value formatter: 1
       2970    record (14 = 3 [2] + 10 + 1)
-              came#0,SET
+              came#0,SET test value formatter: 2
       2984    record (13 = 3 [2] + 9 + 1)
-              can#0,SET
+              can#0,SET test value formatter: 5
       2997    record (15 = 3 [3] + 11 + 1)
-              canker#0,SET
+              canker#0,SET test value formatter: 1
       3012    record (18 = 3 [0] + 14 + 1) [restart]
-              cannon#0,SET
+              cannon#0,SET test value formatter: 2
       3030    record (13 = 3 [5] + 9 + 1)
-              cannot#0,SET
+              cannot#0,SET test value formatter: 3
       3043    record (14 = 3 [3] + 10 + 1)
-              canon#0,SET
+              canon#0,SET test value formatter: 1
       3057    record (16 = 3 [5] + 12 + 1)
-              canonized#0,SET
+              canonized#0,SET test value formatter: 1
       3073    record (14 = 3 [3] + 10 + 1)
-              canst#0,SET
+              canst#0,SET test value formatter: 2
       3087    record (13 = 3 [2] + 9 + 1)
-              cap#0,SET
+              cap#0,SET test value formatter: 1
       3100    record (19 = 3 [2] + 15 + 1)
-              carefully#0,SET
+              carefully#0,SET test value formatter: 1
       3119    record (17 = 3 [3] + 13 + 1)
-              carriage#0,SET
+              carriage#0,SET test value formatter: 1
       3136    record (16 = 3 [4] + 12 + 1)
-              carrying#0,SET
+              carrying#0,SET test value formatter: 1
       3152    record (14 = 3 [3] + 10 + 1)
-              carve#0,SET
+              carve#0,SET test value formatter: 1
       3166    record (14 = 3 [2] + 10 + 1)
-              cast#0,SET
+              cast#0,SET test value formatter: 3
       3180    record (14 = 3 [4] + 10 + 1)
-              castle#0,SET
+              castle#0,SET test value formatter: 2
       3194    record (15 = 3 [2] + 11 + 1)
-              catch#0,SET
+              catch#0,SET test value formatter: 1
       3209    record (16 = 3 [2] + 12 + 1)
-              cautel#0,SET
+              cautel#0,SET test value formatter: 1
       3225    record (15 = 3 [4] + 11 + 1)
-              caution#0,SET
+              caution#0,SET test value formatter: 1
       3240    record (21 = 3 [1] + 17 + 1)
-              celebrated#0,SET
+              celebrated#0,SET test value formatter: 1
       3261    record (21 = 3 [0] + 17 + 1) [restart]
-              celestial#0,SET
+              celestial#0,SET test value formatter: 1
       3282    record (18 = 3 [3] + 14 + 1)
-              cellarage#0,SET
+              cellarage#0,SET test value formatter: 1
       3300    record (17 = 3 [2] + 13 + 1)
-              censure#0,SET
+              censure#0,SET test value formatter: 2
       3317    record (19 = 3 [2] + 15 + 1)
-              cerements#0,SET
+              cerements#0,SET test value formatter: 1
       3336    record (16 = 3 [3] + 12 + 1)
-              certain#0,SET
+              certain#0,SET test value formatter: 1
       3352    record (18 = 3 [1] + 14 + 1)
-              chances#0,SET
+              chances#0,SET test value formatter: 1
       3370    record (14 = 3 [4] + 10 + 1)
-              change#0,SET
+              change#0,SET test value formatter: 1
       3384    record (18 = 3 [3] + 14 + 1)
-              character#0,SET
+              character#0,SET test value formatter: 1
       3402    record (14 = 3 [4] + 10 + 1)
-              charge#0,SET
+              charge#0,SET test value formatter: 3
       3416    record (16 = 3 [4] + 12 + 1)
-              chariest#0,SET
+              chariest#0,SET test value formatter: 1
       3432    record (17 = 3 [5] + 13 + 1)
-              charitable#0,SET
+              charitable#0,SET test value formatter: 1
       3449    record (13 = 3 [4] + 9 + 1)
-              charm#0,SET
+              charm#0,SET test value formatter: 1
       3462    record (15 = 3 [3] + 11 + 1)
-              chaste#0,SET
+              chaste#0,SET test value formatter: 1
       3477    record (15 = 3 [2] + 11 + 1)
-              cheer#0,SET
+              cheer#0,SET test value formatter: 1
       3492    record (15 = 3 [2] + 11 + 1)
-              chief#0,SET
+              chief#0,SET test value formatter: 2
       3507    record (15 = 3 [5] + 11 + 1)
-              chiefest#0,SET
+              chiefest#0,SET test value formatter: 1
       3522    record (18 = 3 [0] + 14 + 1) [restart]
-              choice#0,SET
+              choice#0,SET test value formatter: 2
       3540    record (15 = 3 [3] + 11 + 1)
-              choose#0,SET
+              choose#0,SET test value formatter: 1
       3555    record (24 = 3 [1] + 20 + 1)
-              circumscribed#0,SET
+              circumscribed#0,SET test value formatter: 1
       3579    record (17 = 3 [7] + 13 + 1)
-              circumstance#0,SET
+              circumstance#0,SET test value formatter: 2
       3596    record (15 = 3 [1] + 11 + 1)
-              clad#0,SET
+              clad#0,SET test value formatter: 1
       3611    record (17 = 3 [3] + 13 + 1)
-              claudius#0,SET
+              claudius#0,SET test value formatter: 8
       3628    record (17 = 3 [2] + 13 + 1)
-              clearly#0,SET
+              clearly#0,SET test value formatter: 1
       3645    record (14 = 3 [3] + 10 + 1)
-              clepe#0,SET
+              clepe#0,SET test value formatter: 1
       3659    record (15 = 3 [2] + 11 + 1)
-              cliff#0,SET
+              cliff#0,SET test value formatter: 1
       3674    record (19 = 3 [3] + 15 + 1)
-              climatures#0,SET
+              climatures#0,SET test value formatter: 1
       3693    record (15 = 3 [2] + 11 + 1)
-              cloak#0,SET
+              cloak#0,SET test value formatter: 1
       3708    record (15 = 3 [3] + 11 + 1)
-              clouds#0,SET
+              clouds#0,SET test value formatter: 2
       3723    record (15 = 3 [1] + 11 + 1)
-              cock#0,SET
+              cock#0,SET test value formatter: 5
       3738    record (14 = 3 [2] + 10 + 1)
-              cold#0,SET
+              cold#0,SET test value formatter: 2
       3752    record (14 = 3 [4] + 10 + 1)
-              coldly#0,SET
+              coldly#0,SET test value formatter: 1
       3766    record (19 = 3 [3] + 15 + 1)
-              colleagued#0,SET
+              colleagued#0,SET test value formatter: 1
       3785    record (18 = 3 [0] + 14 + 1) [restart]
-              colour#0,SET
+              colour#0,SET test value formatter: 1
       3803    record (16 = 3 [2] + 12 + 1)
-              combat#0,SET
+              combat#0,SET test value formatter: 1
       3819    record (14 = 3 [6] + 10 + 1)
-              combated#0,SET
+              combated#0,SET test value formatter: 1
       3833    record (16 = 3 [4] + 12 + 1)
-              combined#0,SET
+              combined#0,SET test value formatter: 1
       3849    record (14 = 3 [3] + 9 + 2)
-              come#0,SET
+              come#0,SET test value formatter: 17
       3863    record (13 = 3 [4] + 9 + 1)
-              comes#0,SET
+              comes#0,SET test value formatter: 7
       3876    record (13 = 3 [5] + 9 + 1)
-              comest#0,SET
+              comest#0,SET test value formatter: 1
       3889    record (16 = 3 [3] + 12 + 1)
-              comfort#0,SET
+              comfort#0,SET test value formatter: 1
       3905    record (15 = 3 [3] + 11 + 1)
-              coming#0,SET
+              coming#0,SET test value formatter: 1
       3920    record (16 = 3 [3] + 12 + 1)
-              command#0,SET
+              command#0,SET test value formatter: 1
       3936    record (16 = 3 [7] + 12 + 1)
-              commandment#0,SET
+              commandment#0,SET test value formatter: 1
       3952    record (15 = 3 [4] + 11 + 1)
-              commend#0,SET
+              commend#0,SET test value formatter: 2
       3967    record (16 = 3 [7] + 12 + 1)
-              commendable#0,SET
+              commendable#0,SET test value formatter: 1
       3983    record (14 = 3 [4] + 10 + 1)
-              common#0,SET
+              common#0,SET test value formatter: 4
       3997    record (16 = 3 [3] + 12 + 1)
-              compact#0,SET
+              compact#0,SET test value formatter: 1
       4013    record (17 = 3 [4] + 13 + 1)
-              competent#0,SET
+              competent#0,SET test value formatter: 1
       4030    record (20 = 3 [0] + 16 + 1) [restart]
-              complete#0,SET
+              complete#0,SET test value formatter: 1
       4050    [restart 2046]
       4054    [restart 2291]
       4058    [restart 2532]
@@ -646,257 +646,257 @@ h.no-compression.two_level_index.sst
       4082    [restart 4030]
       4095  data (2039)
       4095    record (22 = 3 [0] + 18 + 1) [restart]
-              complexion#0,SET
+              complexion#0,SET test value formatter: 1
       4117    record (20 = 3 [4] + 16 + 1)
-              compulsatory#0,SET
+              compulsatory#0,SET test value formatter: 1
       4137    record (16 = 3 [3] + 12 + 1)
-              comrade#0,SET
+              comrade#0,SET test value formatter: 1
       4153    record (17 = 3 [2] + 13 + 1)
-              conceal#0,SET
+              conceal#0,SET test value formatter: 1
       4170    record (20 = 3 [3] + 16 + 1)
-              condolement#0,SET
+              condolement#0,SET test value formatter: 1
       4190    record (16 = 3 [3] + 12 + 1)
-              confess#0,SET
+              confess#0,SET test value formatter: 1
       4206    record (15 = 3 [4] + 11 + 1)
-              confine#0,SET
+              confine#0,SET test value formatter: 1
       4221    record (13 = 3 [7] + 9 + 1)
-              confined#0,SET
+              confined#0,SET test value formatter: 1
       4234    record (18 = 3 [3] + 14 + 1)
-              conqueror#0,SET
+              conqueror#0,SET test value formatter: 1
       4252    record (16 = 3 [3] + 12 + 1)
-              consent#0,SET
+              consent#0,SET test value formatter: 3
       4268    record (18 = 3 [4] + 14 + 1)
-              constantly#0,SET
+              constantly#0,SET test value formatter: 1
       4286    record (19 = 3 [3] + 15 + 1)
-              contagious#0,SET
+              contagious#0,SET test value formatter: 1
       4305    record (18 = 3 [4] + 14 + 1)
-              contracted#0,SET
+              contracted#0,SET test value formatter: 1
       4323    record (15 = 3 [5] + 11 + 1)
-              contrive#0,SET
+              contrive#0,SET test value formatter: 1
       4338    record (21 = 3 [3] + 17 + 1)
-              conveniently#0,SET
+              conveniently#0,SET test value formatter: 1
       4359    record (14 = 3 [4] + 10 + 1)
-              convoy#0,SET
+              convoy#0,SET test value formatter: 1
       4373    record (18 = 3 [0] + 14 + 1) [restart]
-              copied#0,SET
+              copied#0,SET test value formatter: 1
       4391    record (19 = 3 [2] + 15 + 1)
-              cornelius#0,SET
+              cornelius#0,SET test value formatter: 4
       4410    record (19 = 3 [3] + 15 + 1)
-              coronation#0,SET
+              coronation#0,SET test value formatter: 1
       4429    record (19 = 3 [3] + 15 + 1)
-              corruption#0,SET
+              corruption#0,SET test value formatter: 1
       4448    record (14 = 3 [3] + 10 + 1)
-              corse#0,SET
+              corse#0,SET test value formatter: 2
       4462    record (16 = 3 [2] + 12 + 1)
-              costly#0,SET
+              costly#0,SET test value formatter: 1
       4478    record (15 = 3 [2] + 11 + 1)
-              couch#0,SET
+              couch#0,SET test value formatter: 1
       4493    record (14 = 3 [3] + 10 + 1)
-              could#0,SET
+              could#0,SET test value formatter: 2
       4507    record (20 = 3 [3] + 16 + 1)
-              countenance#0,SET
+              countenance#0,SET test value formatter: 2
       4527    record (14 = 3 [5] + 10 + 1)
-              country#0,SET
+              country#0,SET test value formatter: 1
       4541    record (15 = 3 [7] + 11 + 1)
-              countrymen#0,SET
+              countrymen#0,SET test value formatter: 1
       4556    record (15 = 3 [3] + 11 + 1)
-              couple#0,SET
+              couple#0,SET test value formatter: 1
       4571    record (15 = 3 [3] + 11 + 1)
-              course#0,SET
+              course#0,SET test value formatter: 2
       4586    record (13 = 3 [6] + 9 + 1)
-              courses#0,SET
+              courses#0,SET test value formatter: 1
       4599    record (13 = 3 [4] + 9 + 1)
-              court#0,SET
+              court#0,SET test value formatter: 1
       4612    record (16 = 3 [5] + 12 + 1)
-              courteous#0,SET
+              courteous#0,SET test value formatter: 1
       4628    record (20 = 3 [0] + 16 + 1) [restart]
-              courtier#0,SET
+              courtier#0,SET test value formatter: 1
       4648    record (15 = 3 [3] + 11 + 1)
-              cousin#0,SET
+              cousin#0,SET test value formatter: 2
       4663    record (18 = 3 [2] + 14 + 1)
-              covenant#0,SET
+              covenant#0,SET test value formatter: 1
       4681    record (16 = 3 [1] + 12 + 1)
-              crack#0,SET
+              crack#0,SET test value formatter: 1
       4697    record (17 = 3 [2] + 13 + 1)
-              credent#0,SET
+              credent#0,SET test value formatter: 1
       4714    record (17 = 3 [3] + 13 + 1)
-              crescent#0,SET
+              crescent#0,SET test value formatter: 1
       4731    record (13 = 3 [3] + 9 + 1)
-              crew#0,SET
+              crew#0,SET test value formatter: 2
       4744    record (15 = 3 [2] + 11 + 1)
-              cried#0,SET
+              cried#0,SET test value formatter: 1
       4759    record (13 = 3 [4] + 9 + 1)
-              cries#0,SET
+              cries#0,SET test value formatter: 1
       4772    record (15 = 3 [3] + 11 + 1)
-              crimes#0,SET
+              crimes#0,SET test value formatter: 1
       4787    record (15 = 3 [2] + 11 + 1)
-              cross#0,SET
+              cross#0,SET test value formatter: 1
       4802    record (16 = 3 [3] + 12 + 1)
-              crowing#0,SET
+              crowing#0,SET test value formatter: 1
       4818    record (13 = 3 [4] + 9 + 1)
-              crown#0,SET
+              crown#0,SET test value formatter: 2
       4831    record (13 = 3 [4] + 9 + 1)
-              crows#0,SET
+              crows#0,SET test value formatter: 1
       4844    record (15 = 3 [2] + 11 + 1)
-              crust#0,SET
+              crust#0,SET test value formatter: 1
       4859    record (15 = 3 [1] + 11 + 1)
-              curd#0,SET
+              curd#0,SET test value formatter: 1
       4874    record (18 = 3 [0] + 14 + 1) [restart]
-              cursed#0,SET
+              cursed#0,SET test value formatter: 2
       4892    record (16 = 3 [2] + 12 + 1)
-              custom#0,SET
+              custom#0,SET test value formatter: 3
       4908    record (15 = 3 [6] + 11 + 1)
-              customary#0,SET
+              customary#0,SET test value formatter: 1
       4923    record (13 = 3 [2] + 9 + 1)
-              cut#0,SET
+              cut#0,SET test value formatter: 1
       4936    record (14 = 3 [0] + 9 + 2)
-              d#0,SET
+              d#0,SET test value formatter: 54
       4950    record (16 = 3 [1] + 12 + 1)
-              daily#0,SET
+              daily#0,SET test value formatter: 1
       4966    record (19 = 3 [2] + 15 + 1)
-              dalliance#0,SET
+              dalliance#0,SET test value formatter: 1
       4985    record (14 = 3 [2] + 10 + 1)
-              damn#0,SET
+              damn#0,SET test value formatter: 1
       4999    record (14 = 3 [4] + 10 + 1)
-              damned#0,SET
+              damned#0,SET test value formatter: 2
       5013    record (14 = 3 [2] + 10 + 1)
-              dane#0,SET
+              dane#0,SET test value formatter: 3
       5027    record (15 = 3 [3] + 11 + 1)
-              danger#0,SET
+              danger#0,SET test value formatter: 1
       5042    record (15 = 3 [2] + 11 + 1)
-              dared#0,SET
+              dared#0,SET test value formatter: 1
       5057    record (13 = 3 [4] + 9 + 1)
-              dares#0,SET
+              dares#0,SET test value formatter: 1
       5070    record (18 = 3 [2] + 14 + 1)
-              daughter#0,SET
+              daughter#0,SET test value formatter: 2
       5088    record (17 = 3 [2] + 13 + 1)
-              dawning#0,SET
+              dawning#0,SET test value formatter: 1
       5105    record (13 = 3 [2] + 9 + 1)
-              day#0,SET
+              day#0,SET test value formatter: 8
       5118    record (16 = 3 [0] + 12 + 1) [restart]
-              days#0,SET
+              days#0,SET test value formatter: 1
       5134    record (15 = 3 [1] + 11 + 1)
-              dead#0,SET
+              dead#0,SET test value formatter: 7
       5149    record (13 = 3 [3] + 9 + 1)
-              dear#0,SET
+              dear#0,SET test value formatter: 4
       5162    record (15 = 3 [4] + 11 + 1)
-              dearest#0,SET
+              dearest#0,SET test value formatter: 2
       5177    record (14 = 3 [4] + 10 + 1)
-              dearly#0,SET
+              dearly#0,SET test value formatter: 1
       5191    record (14 = 3 [3] + 10 + 1)
-              death#0,SET
+              death#0,SET test value formatter: 6
       5205    record (17 = 3 [2] + 13 + 1)
-              decline#0,SET
+              decline#0,SET test value formatter: 1
       5222    record (14 = 3 [2] + 10 + 1)
-              deed#0,SET
+              deed#0,SET test value formatter: 1
       5236    record (13 = 3 [4] + 9 + 1)
-              deeds#0,SET
+              deeds#0,SET test value formatter: 1
       5249    record (13 = 3 [3] + 9 + 1)
-              deep#0,SET
+              deep#0,SET test value formatter: 1
       5262    record (18 = 3 [2] + 14 + 1)
-              defeated#0,SET
+              defeated#0,SET test value formatter: 1
       5280    record (14 = 3 [4] + 10 + 1)
-              defect#0,SET
+              defect#0,SET test value formatter: 1
       5294    record (14 = 3 [4] + 10 + 1)
-              defend#0,SET
+              defend#0,SET test value formatter: 1
       5308    record (18 = 3 [2] + 14 + 1)
-              dejected#0,SET
+              dejected#0,SET test value formatter: 1
       5326    record (17 = 3 [2] + 13 + 1)
-              delated#0,SET
+              delated#0,SET test value formatter: 1
       5343    record (16 = 3 [3] + 12 + 1)
-              delight#0,SET
+              delight#0,SET test value formatter: 1
       5359    record (19 = 3 [0] + 15 + 1) [restart]
-              deliver#0,SET
+              deliver#0,SET test value formatter: 2
       5378    record (22 = 3 [2] + 18 + 1)
-              demonstrated#0,SET
+              demonstrated#0,SET test value formatter: 1
       5400    record (18 = 3 [2] + 13 + 2)
-              denmark#0,SET
+              denmark#0,SET test value formatter: 13
       5418    record (15 = 3 [3] + 11 + 1)
-              denote#0,SET
+              denote#0,SET test value formatter: 1
       5433    record (16 = 3 [2] + 12 + 1)
-              depart#0,SET
+              depart#0,SET test value formatter: 1
       5449    record (16 = 3 [3] + 12 + 1)
-              depends#0,SET
+              depends#0,SET test value formatter: 1
       5465    record (16 = 3 [3] + 12 + 1)
-              deprive#0,SET
+              deprive#0,SET test value formatter: 1
       5481    record (16 = 3 [2] + 12 + 1)
-              design#0,SET
+              design#0,SET test value formatter: 1
       5497    record (14 = 3 [4] + 10 + 1)
-              desire#0,SET
+              desire#0,SET test value formatter: 6
       5511    record (18 = 3 [3] + 14 + 1)
-              desperate#0,SET
+              desperate#0,SET test value formatter: 1
       5529    record (15 = 3 [8] + 11 + 1)
-              desperation#0,SET
+              desperation#0,SET test value formatter: 1
       5544    record (13 = 3 [2] + 9 + 1)
-              dew#0,SET
+              dew#0,SET test value formatter: 3
       5557    record (13 = 3 [3] + 9 + 1)
-              dews#0,SET
+              dews#0,SET test value formatter: 1
       5570    record (19 = 3 [2] + 15 + 1)
-              dexterity#0,SET
+              dexterity#0,SET test value formatter: 1
       5589    record (15 = 3 [1] + 10 + 2)
-              did#0,SET
+              did#0,SET test value formatter: 14
       5604    record (14 = 3 [3] + 10 + 1)
-              didst#0,SET
+              didst#0,SET test value formatter: 1
       5618    record (15 = 3 [0] + 11 + 1) [restart]
-              die#0,SET
+              die#0,SET test value formatter: 1
       5633    record (13 = 3 [3] + 9 + 1)
-              died#0,SET
+              died#0,SET test value formatter: 1
       5646    record (13 = 3 [3] + 9 + 1)
-              diet#0,SET
+              diet#0,SET test value formatter: 1
       5659    record (17 = 3 [2] + 13 + 1)
-              dignity#0,SET
+              dignity#0,SET test value formatter: 1
       5676    record (16 = 3 [2] + 12 + 1)
-              direct#0,SET
+              direct#0,SET test value formatter: 1
       5692    record (14 = 3 [3] + 10 + 1)
-              dirge#0,SET
+              dirge#0,SET test value formatter: 1
       5706    record (22 = 3 [2] + 18 + 1)
-              disappointed#0,SET
+              disappointed#0,SET test value formatter: 1
       5728    record (17 = 3 [4] + 13 + 1)
-              disasters#0,SET
+              disasters#0,SET test value formatter: 1
       5745    record (18 = 3 [3] + 14 + 1)
-              disclosed#0,SET
+              disclosed#0,SET test value formatter: 1
       5763    record (17 = 3 [4] + 13 + 1)
-              discourse#0,SET
+              discourse#0,SET test value formatter: 1
       5780    record (18 = 3 [4] + 14 + 1)
-              discretion#0,SET
+              discretion#0,SET test value formatter: 1
       5798    record (17 = 3 [3] + 13 + 1)
-              disjoint#0,SET
+              disjoint#0,SET test value formatter: 1
       5815    record (17 = 3 [3] + 13 + 1)
-              dispatch#0,SET
+              dispatch#0,SET test value formatter: 2
       5832    record (19 = 3 [4] + 15 + 1)
-              disposition#0,SET
+              disposition#0,SET test value formatter: 3
       5851    record (18 = 3 [3] + 14 + 1)
-              distilled#0,SET
+              distilled#0,SET test value formatter: 1
       5869    record (16 = 3 [6] + 12 + 1)
-              distilment#0,SET
+              distilment#0,SET test value formatter: 1
       5885    record (22 = 3 [0] + 18 + 1) [restart]
-              distracted#0,SET
+              distracted#0,SET test value formatter: 1
       5907    record (16 = 3 [2] + 12 + 1)
-              divide#0,SET
+              divide#0,SET test value formatter: 1
       5923    record (14 = 3 [1] + 9 + 2)
-              do#0,SET
+              do#0,SET test value formatter: 36
       5937    record (14 = 3 [2] + 10 + 1)
-              does#0,SET
+              does#0,SET test value formatter: 3
       5951    record (14 = 3 [2] + 10 + 1)
-              dole#0,SET
+              dole#0,SET test value formatter: 1
       5965    record (14 = 3 [2] + 10 + 1)
-              done#0,SET
+              done#0,SET test value formatter: 3
       5979    record (14 = 3 [2] + 10 + 1)
-              doom#0,SET
+              doom#0,SET test value formatter: 1
       5993    record (16 = 3 [4] + 12 + 1)
-              doomsday#0,SET
+              doomsday#0,SET test value formatter: 1
       6009    record (14 = 3 [2] + 10 + 1)
-              doth#0,SET
+              doth#0,SET test value formatter: 7
       6023    record (16 = 3 [2] + 12 + 1)
-              double#0,SET
+              double#0,SET test value formatter: 2
       6039    record (13 = 3 [4] + 9 + 1)
-              doubt#0,SET
+              doubt#0,SET test value formatter: 4
       6052    record (15 = 3 [5] + 11 + 1)
-              doubtful#0,SET
+              doubtful#0,SET test value formatter: 1
       6067    record (14 = 3 [2] + 10 + 1)
-              down#0,SET
+              down#0,SET test value formatter: 7
       6081    record (17 = 3 [1] + 13 + 1)
-              drains#0,SET
+              drains#0,SET test value formatter: 1
       6098    [restart 4095]
       6102    [restart 4373]
       6106    [restart 4628]
@@ -907,267 +907,267 @@ h.no-compression.two_level_index.sst
       6126    [restart 5885]
       6139  data (2036)
       6139    record (16 = 3 [0] + 12 + 1) [restart]
-              dram#0,SET
+              dram#0,SET test value formatter: 1
       6155    record (17 = 3 [3] + 13 + 1)
-              draughts#0,SET
+              draughts#0,SET test value formatter: 1
       6172    record (13 = 3 [3] + 9 + 1)
-              draw#0,SET
+              draw#0,SET test value formatter: 1
       6185    record (13 = 3 [4] + 9 + 1)
-              draws#0,SET
+              draws#0,SET test value formatter: 1
       6198    record (15 = 3 [2] + 11 + 1)
-              dread#0,SET
+              dread#0,SET test value formatter: 1
       6213    record (14 = 3 [5] + 10 + 1)
-              dreaded#0,SET
+              dreaded#0,SET test value formatter: 1
       6227    record (15 = 3 [5] + 11 + 1)
-              dreadful#0,SET
+              dreadful#0,SET test value formatter: 2
       6242    record (13 = 3 [4] + 9 + 1)
-              dream#0,SET
+              dream#0,SET test value formatter: 1
       6255    record (13 = 3 [5] + 9 + 1)
-              dreamt#0,SET
+              dreamt#0,SET test value formatter: 1
       6268    record (15 = 3 [2] + 11 + 1)
-              drink#0,SET
+              drink#0,SET test value formatter: 1
       6283    record (13 = 3 [5] + 9 + 1)
-              drinks#0,SET
+              drinks#0,SET test value formatter: 1
       6296    record (18 = 3 [2] + 14 + 1)
-              dropping#0,SET
+              dropping#0,SET test value formatter: 1
       6314    record (13 = 3 [8] + 9 + 1)
-              droppings#0,SET
+              droppings#0,SET test value formatter: 1
       6327    record (14 = 3 [2] + 10 + 1)
-              drum#0,SET
+              drum#0,SET test value formatter: 1
       6341    record (18 = 3 [3] + 14 + 1)
-              drunkards#0,SET
+              drunkards#0,SET test value formatter: 1
       6359    record (15 = 3 [1] + 11 + 1)
-              dull#0,SET
+              dull#0,SET test value formatter: 1
       6374    record (18 = 3 [0] + 14 + 1) [restart]
-              duller#0,SET
+              duller#0,SET test value formatter: 1
       6392    record (13 = 3 [4] + 9 + 1)
-              dulls#0,SET
+              dulls#0,SET test value formatter: 1
       6405    record (14 = 3 [2] + 10 + 1)
-              dumb#0,SET
+              dumb#0,SET test value formatter: 2
       6419    record (14 = 3 [2] + 10 + 1)
-              dust#0,SET
+              dust#0,SET test value formatter: 1
       6433    record (16 = 3 [2] + 12 + 1)
-              duties#0,SET
+              duties#0,SET test value formatter: 1
       6449    record (13 = 3 [3] + 9 + 1)
-              duty#0,SET
+              duty#0,SET test value formatter: 7
       6462    record (19 = 3 [1] + 15 + 1)
-              dwelling#0,SET
+              dwelling#0,SET test value formatter: 1
       6481    record (14 = 3 [1] + 10 + 1)
-              dye#0,SET
+              dye#0,SET test value formatter: 1
       6495    record (13 = 3 [0] + 9 + 1)
-              e#0,SET
+              e#0,SET test value formatter: 1
       6508    record (15 = 3 [1] + 11 + 1)
-              each#0,SET
+              each#0,SET test value formatter: 5
       6523    record (15 = 3 [2] + 11 + 1)
-              eager#0,SET
+              eager#0,SET test value formatter: 2
       6538    record (14 = 3 [2] + 10 + 1)
-              eale#0,SET
+              eale#0,SET test value formatter: 1
       6552    record (13 = 3 [2] + 9 + 1)
-              ear#0,SET
+              ear#0,SET test value formatter: 5
       6565    record (13 = 3 [3] + 9 + 1)
-              ears#0,SET
+              ears#0,SET test value formatter: 3
       6578    record (14 = 3 [3] + 10 + 1)
-              earth#0,SET
+              earth#0,SET test value formatter: 9
       6592    record (14 = 3 [5] + 10 + 1)
-              earthly#0,SET
+              earthly#0,SET test value formatter: 1
       6606    record (16 = 3 [0] + 12 + 1) [restart]
-              ease#0,SET
+              ease#0,SET test value formatter: 2
       6622    record (13 = 3 [3] + 9 + 1)
-              east#0,SET
+              east#0,SET test value formatter: 1
       6635    record (16 = 3 [4] + 12 + 1)
-              eastward#0,SET
+              eastward#0,SET test value formatter: 1
       6651    record (18 = 3 [1] + 14 + 1)
-              eclipse#0,SET
+              eclipse#0,SET test value formatter: 1
       6669    record (15 = 3 [1] + 11 + 1)
-              edge#0,SET
+              edge#0,SET test value formatter: 1
       6684    record (17 = 3 [1] + 13 + 1)
-              effect#0,SET
+              effect#0,SET test value formatter: 2
       6701    record (17 = 3 [1] + 13 + 1)
-              eleven#0,SET
+              eleven#0,SET test value formatter: 1
       6718    record (14 = 3 [2] + 10 + 1)
-              else#0,SET
+              else#0,SET test value formatter: 4
       6732    record (17 = 3 [3] + 13 + 1)
-              elsinore#0,SET
+              elsinore#0,SET test value formatter: 2
       6749    record (17 = 3 [1] + 13 + 1)
-              embark#0,SET
+              embark#0,SET test value formatter: 1
       6766    record (16 = 3 [2] + 12 + 1)
-              empire#0,SET
+              empire#0,SET test value formatter: 1
       6782    record (17 = 3 [2] + 13 + 1)
-              emulate#0,SET
+              emulate#0,SET test value formatter: 1
       6799    record (13 = 3 [1] + 9 + 1)
-              en#0,SET
+              en#0,SET test value formatter: 2
       6812    record (19 = 3 [2] + 15 + 1)
-              encounter#0,SET
+              encounter#0,SET test value formatter: 1
       6831    record (17 = 3 [3] + 13 + 1)
-              encumber#0,SET
+              encumber#0,SET test value formatter: 1
       6848    record (13 = 3 [2] + 9 + 1)
-              end#0,SET
+              end#0,SET test value formatter: 1
       6861    record (17 = 3 [0] + 13 + 1) [restart]
-              enemy#0,SET
+              enemy#0,SET test value formatter: 1
       6878    record (16 = 3 [2] + 12 + 1)
-              enmity#0,SET
+              enmity#0,SET test value formatter: 1
       6894    record (16 = 3 [2] + 12 + 1)
-              enough#0,SET
+              enough#0,SET test value formatter: 1
       6910    record (16 = 3 [2] + 11 + 2)
-              enter#0,SET
+              enter#0,SET test value formatter: 12
       6926    record (17 = 3 [5] + 13 + 1)
-              enterprise#0,SET
+              enterprise#0,SET test value formatter: 1
       6943    record (20 = 3 [5] + 16 + 1)
-              entertainment#0,SET
+              entertainment#0,SET test value formatter: 1
       6963    record (17 = 3 [3] + 13 + 1)
-              entrance#0,SET
+              entrance#0,SET test value formatter: 1
       6980    record (17 = 3 [4] + 13 + 1)
-              entreated#0,SET
+              entreated#0,SET test value formatter: 1
       6997    record (17 = 3 [7] + 13 + 1)
-              entreatments#0,SET
+              entreatments#0,SET test value formatter: 1
       7014    record (16 = 3 [1] + 12 + 1)
-              equal#0,SET
+              equal#0,SET test value formatter: 1
       7030    record (13 = 3 [1] + 9 + 1)
-              er#0,SET
+              er#0,SET test value formatter: 5
       7043    record (13 = 3 [2] + 9 + 1)
-              ere#0,SET
+              ere#0,SET test value formatter: 4
       7056    record (18 = 3 [2] + 14 + 1)
-              ergrowth#0,SET
+              ergrowth#0,SET test value formatter: 1
       7074    record (18 = 3 [2] + 14 + 1)
-              ermaster#0,SET
+              ermaster#0,SET test value formatter: 1
       7092    record (16 = 3 [2] + 12 + 1)
-              erring#0,SET
+              erring#0,SET test value formatter: 1
       7108    record (18 = 3 [2] + 14 + 1)
-              eruption#0,SET
+              eruption#0,SET test value formatter: 1
       7126    record (19 = 3 [0] + 15 + 1) [restart]
-              erwhelm#0,SET
+              erwhelm#0,SET test value formatter: 1
       7145    record (17 = 3 [1] + 13 + 1)
-              esteem#0,SET
+              esteem#0,SET test value formatter: 1
       7162    record (13 = 3 [1] + 9 + 1)
-              et#0,SET
+              et#0,SET test value formatter: 1
       7175    record (17 = 3 [2] + 13 + 1)
-              eternal#0,SET
+              eternal#0,SET test value formatter: 1
       7192    record (15 = 3 [5] + 11 + 1)
-              eternity#0,SET
+              eternity#0,SET test value formatter: 1
       7207    record (15 = 3 [1] + 11 + 1)
-              even#0,SET
+              even#0,SET test value formatter: 8
       7222    record (14 = 3 [4] + 10 + 1)
-              events#0,SET
+              events#0,SET test value formatter: 1
       7236    record (13 = 3 [3] + 9 + 1)
-              ever#0,SET
+              ever#0,SET test value formatter: 6
       7249    record (19 = 3 [4] + 15 + 1)
-              everlasting#0,SET
+              everlasting#0,SET test value formatter: 1
       7268    record (13 = 3 [4] + 9 + 1)
-              every#0,SET
+              every#0,SET test value formatter: 3
       7281    record (18 = 3 [1] + 14 + 1)
-              exactly#0,SET
+              exactly#0,SET test value formatter: 1
       7299    record (19 = 3 [2] + 15 + 1)
-              excellent#0,SET
+              excellent#0,SET test value formatter: 1
       7318    record (16 = 3 [2] + 12 + 1)
-              exeunt#0,SET
+              exeunt#0,SET test value formatter: 8
       7334    record (14 = 3 [2] + 10 + 1)
-              exit#0,SET
+              exit#0,SET test value formatter: 6
       7348    record (17 = 3 [2] + 13 + 1)
-              express#0,SET
+              express#0,SET test value formatter: 2
       7365    record (17 = 3 [2] + 13 + 1)
-              extinct#0,SET
+              extinct#0,SET test value formatter: 1
       7382    record (20 = 3 [0] + 16 + 1) [restart]
-              extorted#0,SET
+              extorted#0,SET test value formatter: 1
       7402    record (20 = 3 [3] + 16 + 1)
-              extravagant#0,SET
+              extravagant#0,SET test value formatter: 1
       7422    record (14 = 3 [1] + 10 + 1)
-              eye#0,SET
+              eye#0,SET test value formatter: 6
       7436    record (13 = 3 [3] + 9 + 1)
-              eyes#0,SET
+              eyes#0,SET test value formatter: 7
       7449    record (16 = 3 [0] + 12 + 1)
-              face#0,SET
+              face#0,SET test value formatter: 2
       7465    record (15 = 3 [2] + 11 + 1)
-              faded#0,SET
+              faded#0,SET test value formatter: 1
       7480    record (14 = 3 [2] + 10 + 1)
-              fail#0,SET
+              fail#0,SET test value formatter: 1
       7494    record (13 = 3 [3] + 9 + 1)
-              fair#0,SET
+              fair#0,SET test value formatter: 3
       7507    record (13 = 3 [4] + 9 + 1)
-              fairy#0,SET
+              fairy#0,SET test value formatter: 1
       7520    record (14 = 3 [3] + 10 + 1)
-              faith#0,SET
+              faith#0,SET test value formatter: 4
       7534    record (17 = 3 [2] + 13 + 1)
-              falling#0,SET
+              falling#0,SET test value formatter: 1
       7551    record (14 = 3 [3] + 10 + 1)
-              false#0,SET
+              false#0,SET test value formatter: 1
       7565    record (18 = 3 [2] + 14 + 1)
-              familiar#0,SET
+              familiar#0,SET test value formatter: 1
       7583    record (15 = 3 [2] + 11 + 1)
-              fancy#0,SET
+              fancy#0,SET test value formatter: 1
       7598    record (16 = 3 [3] + 12 + 1)
-              fantasy#0,SET
+              fantasy#0,SET test value formatter: 2
       7614    record (13 = 3 [2] + 9 + 1)
-              far#0,SET
+              far#0,SET test value formatter: 2
       7627    record (16 = 3 [0] + 12 + 1) [restart]
-              fare#0,SET
+              fare#0,SET test value formatter: 2
       7643    record (16 = 3 [4] + 12 + 1)
-              farewell#0,SET
+              farewell#0,SET test value formatter: 8
       7659    record (17 = 3 [2] + 13 + 1)
-              fashion#0,SET
+              fashion#0,SET test value formatter: 3
       7676    record (13 = 3 [3] + 9 + 1)
-              fast#0,SET
+              fast#0,SET test value formatter: 2
       7689    record (13 = 3 [2] + 9 + 1)
-              fat#0,SET
+              fat#0,SET test value formatter: 1
       7702    record (13 = 3 [3] + 9 + 1)
-              fate#0,SET
+              fate#0,SET test value formatter: 2
       7715    record (13 = 3 [4] + 9 + 1)
-              fates#0,SET
+              fates#0,SET test value formatter: 1
       7728    record (16 = 3 [3] + 11 + 2)
-              father#0,SET
+              father#0,SET test value formatter: 28
       7744    record (13 = 3 [6] + 9 + 1)
-              fathers#0,SET
+              fathers#0,SET test value formatter: 1
       7757    record (15 = 3 [4] + 11 + 1)
-              fathoms#0,SET
+              fathoms#0,SET test value formatter: 1
       7772    record (15 = 3 [2] + 11 + 1)
-              fault#0,SET
+              fault#0,SET test value formatter: 4
       7787    record (16 = 3 [2] + 12 + 1)
-              favour#0,SET
+              favour#0,SET test value formatter: 2
       7803    record (15 = 3 [1] + 11 + 1)
-              fear#0,SET
+              fear#0,SET test value formatter: 9
       7818    record (15 = 3 [4] + 11 + 1)
-              fearful#0,SET
+              fearful#0,SET test value formatter: 1
       7833    record (13 = 3 [2] + 9 + 1)
-              fed#0,SET
+              fed#0,SET test value formatter: 1
       7846    record (13 = 3 [2] + 9 + 1)
-              fee#0,SET
+              fee#0,SET test value formatter: 1
       7859    record (16 = 3 [0] + 12 + 1) [restart]
-              fell#0,SET
+              fell#0,SET test value formatter: 2
       7875    record (14 = 3 [4] + 10 + 1)
-              fellow#0,SET
+              fellow#0,SET test value formatter: 2
       7889    record (13 = 3 [2] + 9 + 1)
-              few#0,SET
+              few#0,SET test value formatter: 3
       7902    record (14 = 3 [1] + 10 + 1)
-              fie#0,SET
+              fie#0,SET test value formatter: 4
       7916    record (15 = 3 [3] + 11 + 1)
-              fierce#0,SET
+              fierce#0,SET test value formatter: 1
       7931    record (16 = 3 [2] + 12 + 1)
-              figure#0,SET
+              figure#0,SET test value formatter: 3
       7947    record (16 = 3 [2] + 12 + 1)
-              filial#0,SET
+              filial#0,SET test value formatter: 1
       7963    record (14 = 3 [2] + 10 + 1)
-              find#0,SET
+              find#0,SET test value formatter: 2
       7977    record (16 = 3 [3] + 12 + 1)
-              fingers#0,SET
+              fingers#0,SET test value formatter: 1
       7993    record (14 = 3 [2] + 10 + 1)
-              fire#0,SET
+              fire#0,SET test value formatter: 4
       8007    record (13 = 3 [4] + 9 + 1)
-              fires#0,SET
+              fires#0,SET test value formatter: 1
       8020    record (14 = 3 [3] + 10 + 1)
-              first#0,SET
+              first#0,SET test value formatter: 1
       8034    record (13 = 3 [2] + 9 + 1)
-              fit#0,SET
+              fit#0,SET test value formatter: 2
       8047    record (13 = 3 [3] + 9 + 1)
-              fits#0,SET
+              fits#0,SET test value formatter: 1
       8060    record (16 = 3 [3] + 12 + 1)
-              fitting#0,SET
+              fitting#0,SET test value formatter: 1
       8076    record (13 = 3 [2] + 9 + 1)
-              fix#0,SET
+              fix#0,SET test value formatter: 2
       8089    record (18 = 3 [0] + 14 + 1) [restart]
-              flames#0,SET
+              flames#0,SET test value formatter: 1
       8107    record (13 = 3 [3] + 9 + 1)
-              flat#0,SET
+              flat#0,SET test value formatter: 1
       8120    record (15 = 3 [2] + 11 + 1)
-              flesh#0,SET
+              flesh#0,SET test value formatter: 2
       8135    [restart 6139]
       8139    [restart 6374]
       8143    [restart 6606]
@@ -1179,269 +1179,269 @@ h.no-compression.two_level_index.sst
       8167    [restart 8089]
       8180  data (2032)
       8180    record (17 = 3 [0] + 13 + 1) [restart]
-              flood#0,SET
+              flood#0,SET test value formatter: 1
       8197    record (17 = 3 [3] + 13 + 1)
-              flourish#0,SET
+              flourish#0,SET test value formatter: 1
       8214    record (18 = 3 [2] + 14 + 1)
-              flushing#0,SET
+              flushing#0,SET test value formatter: 1
       8232    record (14 = 3 [1] + 10 + 1)
-              foe#0,SET
+              foe#0,SET test value formatter: 1
       8246    record (16 = 3 [2] + 12 + 1)
-              follow#0,SET
+              follow#0,SET test value formatter: 9
       8262    record (13 = 3 [6] + 9 + 1)
-              follows#0,SET
+              follows#0,SET test value formatter: 1
       8275    record (14 = 3 [2] + 10 + 1)
-              fond#0,SET
+              fond#0,SET test value formatter: 1
       8289    record (14 = 3 [2] + 10 + 1)
-              food#0,SET
+              food#0,SET test value formatter: 1
       8303    record (13 = 3 [3] + 9 + 1)
-              fool#0,SET
+              fool#0,SET test value formatter: 1
       8316    record (13 = 3 [4] + 9 + 1)
-              fools#0,SET
+              fools#0,SET test value formatter: 1
       8329    record (13 = 3 [3] + 9 + 1)
-              foot#0,SET
+              foot#0,SET test value formatter: 1
       8342    record (14 = 3 [2] + 9 + 2)
-              for#0,SET
+              for#0,SET test value formatter: 45
       8356    record (15 = 3 [3] + 11 + 1)
-              forbid#0,SET
+              forbid#0,SET test value formatter: 1
       8371    record (15 = 3 [3] + 11 + 1)
-              forced#0,SET
+              forced#0,SET test value formatter: 1
       8386    record (16 = 3 [3] + 12 + 1)
-              foreign#0,SET
+              foreign#0,SET test value formatter: 1
       8402    record (19 = 3 [4] + 15 + 1)
-              foreknowing#0,SET
+              foreknowing#0,SET test value formatter: 1
       8421    record (20 = 3 [0] + 16 + 1) [restart]
-              foresaid#0,SET
+              foresaid#0,SET test value formatter: 1
       8441    record (16 = 3 [3] + 12 + 1)
-              forfeit#0,SET
+              forfeit#0,SET test value formatter: 1
       8457    record (15 = 3 [3] + 11 + 1)
-              forged#0,SET
+              forged#0,SET test value formatter: 1
       8472    record (13 = 3 [5] + 9 + 1)
-              forget#0,SET
+              forget#0,SET test value formatter: 1
       8485    record (13 = 3 [3] + 9 + 1)
-              form#0,SET
+              form#0,SET test value formatter: 4
       8498    record (13 = 3 [4] + 9 + 1)
-              forms#0,SET
+              forms#0,SET test value formatter: 2
       8511    record (14 = 3 [3] + 10 + 1)
-              forth#0,SET
+              forth#0,SET test value formatter: 3
       8525    record (17 = 3 [4] + 13 + 1)
-              fortified#0,SET
+              fortified#0,SET test value formatter: 1
       8542    record (17 = 3 [5] + 13 + 1)
-              fortinbras#0,SET
+              fortinbras#0,SET test value formatter: 6
       8559    record (13 = 3 [4] + 9 + 1)
-              forts#0,SET
+              forts#0,SET test value formatter: 1
       8572    record (15 = 3 [4] + 11 + 1)
-              fortune#0,SET
+              fortune#0,SET test value formatter: 1
       8587    record (16 = 3 [3] + 12 + 1)
-              forward#0,SET
+              forward#0,SET test value formatter: 1
       8603    record (16 = 3 [2] + 12 + 1)
-              fought#0,SET
+              fought#0,SET test value formatter: 1
       8619    record (13 = 3 [3] + 9 + 1)
-              foul#0,SET
+              foul#0,SET test value formatter: 6
       8632    record (18 = 3 [1] + 14 + 1)
-              frailty#0,SET
+              frailty#0,SET test value formatter: 1
       8650    record (14 = 3 [3] + 10 + 1)
-              frame#0,SET
+              frame#0,SET test value formatter: 1
       8664    record (18 = 3 [0] + 14 + 1) [restart]
-              france#0,SET
+              france#0,SET test value formatter: 3
       8682    record (17 = 3 [5] + 12 + 2)
-              francisco#0,SET
+              francisco#0,SET test value formatter: 10
       8699    record (14 = 3 [2] + 10 + 1)
-              free#0,SET
+              free#0,SET test value formatter: 1
       8713    record (14 = 3 [4] + 10 + 1)
-              freely#0,SET
+              freely#0,SET test value formatter: 1
       8727    record (14 = 3 [4] + 10 + 1)
-              freeze#0,SET
+              freeze#0,SET test value formatter: 1
       8741    record (16 = 3 [3] + 12 + 1)
-              fretful#0,SET
+              fretful#0,SET test value formatter: 1
       8757    record (16 = 3 [2] + 12 + 1)
-              friend#0,SET
+              friend#0,SET test value formatter: 3
       8773    record (15 = 3 [6] + 11 + 1)
-              friending#0,SET
+              friending#0,SET test value formatter: 1
       8788    record (13 = 3 [6] + 9 + 1)
-              friends#0,SET
+              friends#0,SET test value formatter: 5
       8801    record (15 = 3 [2] + 10 + 2)
-              from#0,SET
+              from#0,SET test value formatter: 21
       8816    record (14 = 3 [3] + 10 + 1)
-              frown#0,SET
+              frown#0,SET test value formatter: 1
       8830    record (17 = 3 [5] + 13 + 1)
-              frowningly#0,SET
+              frowningly#0,SET test value formatter: 1
       8847    record (18 = 3 [2] + 14 + 1)
-              fruitful#0,SET
+              fruitful#0,SET test value formatter: 1
       8865    record (15 = 3 [1] + 11 + 1)
-              full#0,SET
+              full#0,SET test value formatter: 2
       8880    record (17 = 3 [2] + 13 + 1)
-              funeral#0,SET
+              funeral#0,SET test value formatter: 3
       8897    record (17 = 3 [2] + 13 + 1)
-              furnish#0,SET
+              furnish#0,SET test value formatter: 1
       8914    record (19 = 3 [0] + 15 + 1) [restart]
-              further#0,SET
+              further#0,SET test value formatter: 4
       8933    record (17 = 3 [0] + 13 + 1)
-              gaged#0,SET
+              gaged#0,SET test value formatter: 1
       8950    record (16 = 3 [2] + 12 + 1)
-              gainst#0,SET
+              gainst#0,SET test value formatter: 2
       8966    record (13 = 3 [3] + 9 + 1)
-              gait#0,SET
+              gait#0,SET test value formatter: 1
       8979    record (16 = 3 [2] + 12 + 1)
-              galled#0,SET
+              galled#0,SET test value formatter: 1
       8995    record (13 = 3 [4] + 9 + 1)
-              galls#0,SET
+              galls#0,SET test value formatter: 1
       9008    record (14 = 3 [2] + 10 + 1)
-              gape#0,SET
+              gape#0,SET test value formatter: 1
       9022    record (17 = 3 [2] + 13 + 1)
-              garbage#0,SET
+              garbage#0,SET test value formatter: 1
       9039    record (15 = 3 [3] + 11 + 1)
-              garden#0,SET
+              garden#0,SET test value formatter: 1
       9054    record (15 = 3 [2] + 11 + 1)
-              gates#0,SET
+              gates#0,SET test value formatter: 1
       9069    record (15 = 3 [2] + 11 + 1)
-              gaudy#0,SET
+              gaudy#0,SET test value formatter: 1
       9084    record (18 = 3 [1] + 14 + 1)
-              general#0,SET
+              general#0,SET test value formatter: 1
       9102    record (15 = 3 [5] + 11 + 1)
-              generous#0,SET
+              generous#0,SET test value formatter: 1
       9117    record (15 = 3 [3] + 11 + 1)
-              gentle#0,SET
+              gentle#0,SET test value formatter: 1
       9132    record (15 = 3 [6] + 11 + 1)
-              gentlemen#0,SET
+              gentlemen#0,SET test value formatter: 5
       9147    record (18 = 3 [2] + 14 + 1)
-              gertrude#0,SET
+              gertrude#0,SET test value formatter: 4
       9165    record (15 = 3 [0] + 11 + 1) [restart]
-              get#0,SET
+              get#0,SET test value formatter: 1
       9180    record (17 = 3 [1] + 12 + 2)
-              ghost#0,SET
+              ghost#0,SET test value formatter: 26
       9197    record (17 = 3 [1] + 13 + 1)
-              gibber#0,SET
+              gibber#0,SET test value formatter: 1
       9214    record (15 = 3 [2] + 11 + 1)
-              gifts#0,SET
+              gifts#0,SET test value formatter: 3
       9229    record (14 = 3 [2] + 10 + 1)
-              gins#0,SET
+              gins#0,SET test value formatter: 1
       9243    record (14 = 3 [2] + 10 + 1)
-              girl#0,SET
+              girl#0,SET test value formatter: 1
       9257    record (15 = 3 [2] + 10 + 2)
-              give#0,SET
+              give#0,SET test value formatter: 13
       9272    record (13 = 3 [4] + 9 + 1)
-              given#0,SET
+              given#0,SET test value formatter: 4
       9285    record (15 = 3 [3] + 11 + 1)
-              giving#0,SET
+              giving#0,SET test value formatter: 3
       9300    record (15 = 3 [1] + 11 + 1)
-              glad#0,SET
+              glad#0,SET test value formatter: 2
       9315    record (18 = 3 [2] + 14 + 1)
-              glimpses#0,SET
+              glimpses#0,SET test value formatter: 1
       9333    record (15 = 3 [2] + 11 + 1)
-              globe#0,SET
+              globe#0,SET test value formatter: 1
       9348    record (13 = 3 [3] + 9 + 1)
-              glow#0,SET
+              glow#0,SET test value formatter: 1
       9361    record (14 = 3 [1] + 9 + 2)
-              go#0,SET
+              go#0,SET test value formatter: 15
       9375    record (16 = 3 [2] + 12 + 1)
-              goblin#0,SET
+              goblin#0,SET test value formatter: 1
       9391    record (13 = 3 [2] + 9 + 1)
-              god#0,SET
+              god#0,SET test value formatter: 8
       9404    record (16 = 3 [0] + 12 + 1) [restart]
-              goes#0,SET
+              goes#0,SET test value formatter: 3
       9420    record (15 = 3 [2] + 11 + 1)
-              going#0,SET
+              going#0,SET test value formatter: 1
       9435    record (14 = 3 [2] + 10 + 1)
-              gone#0,SET
+              gone#0,SET test value formatter: 4
       9449    record (15 = 3 [2] + 10 + 2)
-              good#0,SET
+              good#0,SET test value formatter: 20
       9464    record (14 = 3 [4] + 10 + 1)
-              goodly#0,SET
+              goodly#0,SET test value formatter: 1
       9478    record (16 = 3 [1] + 12 + 1)
-              grace#0,SET
+              grace#0,SET test value formatter: 6
       9494    record (13 = 3 [5] + 9 + 1)
-              graces#0,SET
+              graces#0,SET test value formatter: 1
       9507    record (16 = 3 [4] + 12 + 1)
-              gracious#0,SET
+              gracious#0,SET test value formatter: 2
       9523    record (16 = 3 [3] + 12 + 1)
-              grapple#0,SET
+              grapple#0,SET test value formatter: 1
       9539    record (14 = 3 [3] + 10 + 1)
-              grave#0,SET
+              grave#0,SET test value formatter: 1
       9553    record (13 = 3 [5] + 9 + 1)
-              graves#0,SET
+              graves#0,SET test value formatter: 1
       9566    record (15 = 3 [2] + 11 + 1)
-              great#0,SET
+              great#0,SET test value formatter: 1
       9581    record (16 = 3 [5] + 12 + 1)
-              greatness#0,SET
+              greatness#0,SET test value formatter: 1
       9597    record (14 = 3 [3] + 10 + 1)
-              green#0,SET
+              green#0,SET test value formatter: 2
       9611    record (16 = 3 [4] + 12 + 1)
-              greeting#0,SET
+              greeting#0,SET test value formatter: 1
       9627    record (15 = 3 [2] + 11 + 1)
-              grief#0,SET
+              grief#0,SET test value formatter: 3
       9642    record (20 = 3 [0] + 16 + 1) [restart]
-              grizzled#0,SET
+              grizzled#0,SET test value formatter: 1
       9662    record (15 = 3 [2] + 11 + 1)
-              gross#0,SET
+              gross#0,SET test value formatter: 2
       9677    record (15 = 3 [3] + 11 + 1)
-              ground#0,SET
+              ground#0,SET test value formatter: 3
       9692    record (13 = 3 [3] + 9 + 1)
-              grow#0,SET
+              grow#0,SET test value formatter: 2
       9705    record (13 = 3 [4] + 9 + 1)
-              grown#0,SET
+              grown#0,SET test value formatter: 1
       9718    record (13 = 3 [4] + 9 + 1)
-              grows#0,SET
+              grows#0,SET test value formatter: 2
       9731    record (16 = 3 [1] + 12 + 1)
-              guard#0,SET
+              guard#0,SET test value formatter: 1
       9747    record (16 = 3 [2] + 12 + 1)
-              guilty#0,SET
+              guilty#0,SET test value formatter: 2
       9763    record (14 = 3 [0] + 10 + 1)
-              ha#0,SET
+              ha#0,SET test value formatter: 1
       9777    record (15 = 3 [2] + 11 + 1)
-              habit#0,SET
+              habit#0,SET test value formatter: 2
       9792    record (14 = 3 [2] + 9 + 2)
-              had#0,SET
+              had#0,SET test value formatter: 13
       9806    record (14 = 3 [2] + 10 + 1)
-              hail#0,SET
+              hail#0,SET test value formatter: 1
       9820    record (13 = 3 [3] + 9 + 1)
-              hair#0,SET
+              hair#0,SET test value formatter: 1
       9833    record (16 = 3 [2] + 12 + 1)
-              hallow#0,SET
+              hallow#0,SET test value formatter: 1
       9849    record (18 = 3 [2] + 12 + 3)
-              hamlet#0,SET
+              hamlet#0,SET test value formatter: 100
       9867    record (14 = 3 [2] + 10 + 1)
-              hand#0,SET
+              hand#0,SET test value formatter: 5
       9881    record (17 = 3 [0] + 13 + 1) [restart]
-              hands#0,SET
+              hands#0,SET test value formatter: 4
       9898    record (13 = 3 [3] + 9 + 1)
-              hang#0,SET
+              hang#0,SET test value formatter: 2
       9911    record (13 = 3 [2] + 9 + 1)
-              hap#0,SET
+              hap#0,SET test value formatter: 1
       9924    record (16 = 3 [3] + 12 + 1)
-              happily#0,SET
+              happily#0,SET test value formatter: 1
       9940    record (20 = 3 [2] + 16 + 1)
-              harbingers#0,SET
+              harbingers#0,SET test value formatter: 1
       9960    record (13 = 3 [3] + 9 + 1)
-              hard#0,SET
+              hard#0,SET test value formatter: 2
       9973    record (13 = 3 [4] + 9 + 1)
-              hardy#0,SET
+              hardy#0,SET test value formatter: 1
       9986    record (15 = 3 [3] + 11 + 1)
-              harrow#0,SET
+              harrow#0,SET test value formatter: 1
      10001    record (13 = 3 [6] + 9 + 1)
-              harrows#0,SET
+              harrows#0,SET test value formatter: 1
      10014    record (13 = 3 [2] + 9 + 1)
-              has#0,SET
+              has#0,SET test value formatter: 3
      10027    record (13 = 3 [3] + 9 + 1)
-              hast#0,SET
+              hast#0,SET test value formatter: 4
      10040    record (13 = 3 [4] + 9 + 1)
-              haste#0,SET
+              haste#0,SET test value formatter: 7
      10053    record (15 = 3 [2] + 11 + 1)
-              hatch#0,SET
+              hatch#0,SET test value formatter: 1
      10068    record (14 = 3 [3] + 9 + 2)
-              hath#0,SET
+              hath#0,SET test value formatter: 15
      10082    record (15 = 3 [2] + 10 + 2)
-              have#0,SET
+              have#0,SET test value formatter: 31
      10097    record (15 = 3 [3] + 11 + 1)
-              havior#0,SET
+              havior#0,SET test value formatter: 1
      10112    record (15 = 3 [0] + 10 + 2) [restart]
-              he#0,SET
+              he#0,SET test value formatter: 34
      10127    record (14 = 3 [2] + 10 + 1)
-              head#0,SET
+              head#0,SET test value formatter: 6
      10141    record (14 = 3 [4] + 10 + 1)
-              headed#0,SET
+              headed#0,SET test value formatter: 1
      10155    record (17 = 3 [4] + 13 + 1)
-              headshake#0,SET
+              headshake#0,SET test value formatter: 1
      10172    [restart 8180]
      10176    [restart 8421]
      10180    [restart 8664]
@@ -1453,261 +1453,261 @@ h.no-compression.two_level_index.sst
      10204    [restart 10112]
      10217  data (2042)
      10217    record (18 = 3 [0] + 14 + 1) [restart]
-              health#0,SET
+              health#0,SET test value formatter: 3
      10235    record (13 = 3 [3] + 9 + 1)
-              hear#0,SET
+              hear#0,SET test value formatter: 9
      10248    record (13 = 3 [4] + 9 + 1)
-              heard#0,SET
+              heard#0,SET test value formatter: 4
      10261    record (15 = 3 [4] + 11 + 1)
-              hearing#0,SET
+              hearing#0,SET test value formatter: 1
      10276    record (13 = 3 [4] + 9 + 1)
-              hears#0,SET
+              hears#0,SET test value formatter: 2
      10289    record (14 = 3 [5] + 10 + 1)
-              hearsed#0,SET
+              hearsed#0,SET test value formatter: 1
      10303    record (14 = 3 [4] + 9 + 2)
-              heart#0,SET
+              heart#0,SET test value formatter: 10
      10317    record (15 = 3 [5] + 11 + 1)
-              heartily#0,SET
+              heartily#0,SET test value formatter: 3
      10332    record (13 = 3 [5] + 9 + 1)
-              hearts#0,SET
+              hearts#0,SET test value formatter: 1
      10345    record (13 = 3 [3] + 9 + 1)
-              heat#0,SET
+              heat#0,SET test value formatter: 1
      10358    record (16 = 3 [3] + 11 + 2)
-              heaven#0,SET
+              heaven#0,SET test value formatter: 21
      10374    record (13 = 3 [6] + 9 + 1)
-              heavens#0,SET
+              heavens#0,SET test value formatter: 1
      10387    record (13 = 3 [4] + 9 + 1)
-              heavy#0,SET
+              heavy#0,SET test value formatter: 1
      10400    record (17 = 3 [2] + 13 + 1)
-              hebenon#0,SET
+              hebenon#0,SET test value formatter: 1
      10417    record (16 = 3 [2] + 12 + 1)
-              height#0,SET
+              height#0,SET test value formatter: 1
      10433    record (14 = 3 [2] + 10 + 1)
-              held#0,SET
+              held#0,SET test value formatter: 1
      10447    record (16 = 3 [0] + 12 + 1) [restart]
-              hell#0,SET
+              hell#0,SET test value formatter: 3
      10463    record (13 = 3 [3] + 9 + 1)
-              help#0,SET
+              help#0,SET test value formatter: 2
      10476    record (13 = 3 [2] + 9 + 1)
-              her#0,SET
+              her#0,SET test value formatter: 8
      10489    record (17 = 3 [3] + 13 + 1)
-              heraldry#0,SET
+              heraldry#0,SET test value formatter: 1
      10506    record (17 = 3 [3] + 13 + 1)
-              hercules#0,SET
+              hercules#0,SET test value formatter: 1
      10523    record (14 = 3 [3] + 9 + 2)
-              here#0,SET
+              here#0,SET test value formatter: 11
      10537    record (17 = 3 [4] + 13 + 1)
-              hereafter#0,SET
+              hereafter#0,SET test value formatter: 1
      10554    record (14 = 3 [4] + 10 + 1)
-              herein#0,SET
+              herein#0,SET test value formatter: 3
      10568    record (14 = 3 [1] + 10 + 1)
-              hic#0,SET
+              hic#0,SET test value formatter: 1
      10582    record (17 = 3 [2] + 13 + 1)
-              hideous#0,SET
+              hideous#0,SET test value formatter: 1
      10599    record (14 = 3 [2] + 10 + 1)
-              hies#0,SET
+              hies#0,SET test value formatter: 1
      10613    record (14 = 3 [2] + 10 + 1)
-              high#0,SET
+              high#0,SET test value formatter: 2
      10627    record (14 = 3 [4] + 10 + 1)
-              higher#0,SET
+              higher#0,SET test value formatter: 1
      10641    record (14 = 3 [2] + 10 + 1)
-              hill#0,SET
+              hill#0,SET test value formatter: 1
      10655    record (13 = 3 [4] + 9 + 1)
-              hillo#0,SET
+              hillo#0,SET test value formatter: 2
      10668    record (14 = 3 [2] + 9 + 2)
-              him#0,SET
+              him#0,SET test value formatter: 21
      10682    record (19 = 3 [0] + 15 + 1) [restart]
-              himself#0,SET
+              himself#0,SET test value formatter: 3
      10701    record (14 = 3 [2] + 9 + 2)
-              his#0,SET
+              his#0,SET test value formatter: 57
      10715    record (16 = 3 [2] + 12 + 1)
-              hither#0,SET
+              hither#0,SET test value formatter: 1
      10731    record (14 = 3 [6] + 10 + 1)
-              hitherto#0,SET
+              hitherto#0,SET test value formatter: 1
      10745    record (13 = 3 [1] + 9 + 1)
-              ho#0,SET
+              ho#0,SET test value formatter: 5
      10758    record (14 = 3 [2] + 10 + 1)
-              hold#0,SET
+              hold#0,SET test value formatter: 9
      10772    record (15 = 3 [4] + 11 + 1)
-              holding#0,SET
+              holding#0,SET test value formatter: 1
      10787    record (13 = 3 [4] + 9 + 1)
-              holds#0,SET
+              holds#0,SET test value formatter: 2
      10800    record (14 = 3 [3] + 10 + 1)
-              holla#0,SET
+              holla#0,SET test value formatter: 1
      10814    record (13 = 3 [3] + 9 + 1)
-              holy#0,SET
+              holy#0,SET test value formatter: 1
      10827    record (16 = 3 [2] + 12 + 1)
-              honest#0,SET
+              honest#0,SET test value formatter: 2
      10843    record (15 = 3 [3] + 11 + 1)
-              honour#0,SET
+              honour#0,SET test value formatter: 5
      10858    record (16 = 3 [6] + 12 + 1)
-              honourable#0,SET
+              honourable#0,SET test value formatter: 1
      10874    record (15 = 3 [2] + 11 + 1)
-              hoops#0,SET
+              hoops#0,SET test value formatter: 1
      10889    record (18 = 3 [2] + 13 + 2)
-              horatio#0,SET
+              horatio#0,SET test value formatter: 85
      10907    record (17 = 3 [3] + 13 + 1)
-              horrible#0,SET
+              horrible#0,SET test value formatter: 4
      10924    record (20 = 3 [0] + 16 + 1) [restart]
-              horridly#0,SET
+              horridly#0,SET test value formatter: 1
      10944    record (14 = 3 [2] + 10 + 1)
-              host#0,SET
+              host#0,SET test value formatter: 1
      10958    record (13 = 3 [2] + 9 + 1)
-              hot#0,SET
+              hot#0,SET test value formatter: 1
      10971    record (14 = 3 [2] + 10 + 1)
-              hour#0,SET
+              hour#0,SET test value formatter: 6
      10985    record (14 = 3 [3] + 10 + 1)
-              house#0,SET
+              house#0,SET test value formatter: 2
      10999    record (13 = 3 [2] + 9 + 1)
-              how#0,SET
+              how#0,SET test value formatter: 7
      11012    record (18 = 3 [3] + 14 + 1)
-              howsoever#0,SET
+              howsoever#0,SET test value formatter: 1
      11030    record (17 = 3 [1] + 13 + 1)
-              humbly#0,SET
+              humbly#0,SET test value formatter: 1
      11047    record (17 = 3 [2] + 13 + 1)
-              hundred#0,SET
+              hundred#0,SET test value formatter: 1
      11064    record (19 = 3 [2] + 15 + 1)
-              husbandry#0,SET
+              husbandry#0,SET test value formatter: 1
      11083    record (19 = 3 [1] + 15 + 1)
-              hyperion#0,SET
+              hyperion#0,SET test value formatter: 1
      11102    record (15 = 3 [0] + 9 + 3)
-              i#0,SET
+              i#0,SET test value formatter: 124
      11117    record (14 = 3 [1] + 10 + 1)
-              ice#0,SET
+              ice#0,SET test value formatter: 1
      11131    record (14 = 3 [1] + 9 + 2)
-              if#0,SET
+              if#0,SET test value formatter: 22
      11145    record (20 = 3 [1] + 16 + 1)
-              ignorance#0,SET
+              ignorance#0,SET test value formatter: 1
      11165    record (13 = 3 [1] + 9 + 1)
-              ii#0,SET
+              ii#0,SET test value formatter: 1
      11178    record (15 = 3 [0] + 11 + 1) [restart]
-              iii#0,SET
+              iii#0,SET test value formatter: 1
      11193    record (17 = 3 [1] + 13 + 1)
-              illume#0,SET
+              illume#0,SET test value formatter: 1
      11210    record (16 = 3 [4] + 12 + 1)
-              illusion#0,SET
+              illusion#0,SET test value formatter: 1
      11226    record (16 = 3 [1] + 12 + 1)
-              image#0,SET
+              image#0,SET test value formatter: 1
      11242    record (19 = 3 [4] + 15 + 1)
-              imagination#0,SET
+              imagination#0,SET test value formatter: 1
      11261    record (19 = 3 [2] + 15 + 1)
-              immediate#0,SET
+              immediate#0,SET test value formatter: 1
      11280    record (17 = 3 [3] + 13 + 1)
-              imminent#0,SET
+              imminent#0,SET test value formatter: 1
      11297    record (17 = 3 [3] + 13 + 1)
-              immortal#0,SET
+              immortal#0,SET test value formatter: 1
      11314    record (16 = 3 [2] + 12 + 1)
-              impart#0,SET
+              impart#0,SET test value formatter: 3
      11330    record (16 = 3 [6] + 12 + 1)
-              impartment#0,SET
+              impartment#0,SET test value formatter: 1
      11346    record (17 = 3 [4] + 13 + 1)
-              impatient#0,SET
+              impatient#0,SET test value formatter: 1
      11363    record (22 = 3 [3] + 18 + 1)
-              imperfections#0,SET
+              imperfections#0,SET test value formatter: 1
      11385    record (15 = 3 [5] + 11 + 1)
-              imperial#0,SET
+              imperial#0,SET test value formatter: 1
      11400    record (16 = 3 [3] + 12 + 1)
-              impious#0,SET
+              impious#0,SET test value formatter: 1
      11416    record (19 = 3 [3] + 15 + 1)
-              implements#0,SET
+              implements#0,SET test value formatter: 1
      11435    record (19 = 3 [4] + 15 + 1)
-              implorators#0,SET
+              implorators#0,SET test value formatter: 1
      11454    record (21 = 3 [0] + 17 + 1) [restart]
-              importing#0,SET
+              importing#0,SET test value formatter: 1
      11475    record (16 = 3 [6] + 12 + 1)
-              importuned#0,SET
+              importuned#0,SET test value formatter: 1
      11491    record (15 = 3 [8] + 11 + 1)
-              importunity#0,SET
+              importunity#0,SET test value formatter: 1
      11506    record (16 = 3 [4] + 12 + 1)
-              impotent#0,SET
+              impotent#0,SET test value formatter: 1
      11522    record (16 = 3 [3] + 12 + 1)
-              impress#0,SET
+              impress#0,SET test value formatter: 1
      11538    record (15 = 3 [1] + 9 + 3)
-              in#0,SET
+              in#0,SET test value formatter: 118
      11553    record (16 = 3 [2] + 12 + 1)
-              incest#0,SET
+              incest#0,SET test value formatter: 1
      11569    record (16 = 3 [6] + 12 + 1)
-              incestuous#0,SET
+              incestuous#0,SET test value formatter: 2
      11585    record (18 = 3 [3] + 14 + 1)
-              incorrect#0,SET
+              incorrect#0,SET test value formatter: 1
      11603    record (17 = 3 [3] + 13 + 1)
-              increase#0,SET
+              increase#0,SET test value formatter: 1
      11620    record (16 = 3 [2] + 12 + 1)
-              indeed#0,SET
+              indeed#0,SET test value formatter: 8
      11636    record (17 = 3 [2] + 13 + 1)
-              infants#0,SET
+              infants#0,SET test value formatter: 1
      11653    record (17 = 3 [3] + 13 + 1)
-              infinite#0,SET
+              infinite#0,SET test value formatter: 1
      11670    record (18 = 3 [3] + 14 + 1)
-              influence#0,SET
+              influence#0,SET test value formatter: 1
      11688    record (15 = 3 [3] + 11 + 1)
-              inform#0,SET
+              inform#0,SET test value formatter: 1
      11703    record (21 = 3 [2] + 17 + 1)
-              inheritance#0,SET
+              inheritance#0,SET test value formatter: 1
      11724    record (16 = 3 [0] + 12 + 1) [restart]
-              inky#0,SET
+              inky#0,SET test value formatter: 1
      11740    record (17 = 3 [2] + 13 + 1)
-              instant#0,SET
+              instant#0,SET test value formatter: 2
      11757    record (20 = 3 [4] + 16 + 1)
-              instrumental#0,SET
+              instrumental#0,SET test value formatter: 1
      11777    record (16 = 3 [2] + 12 + 1)
-              intent#0,SET
+              intent#0,SET test value formatter: 1
      11793    record (13 = 3 [6] + 9 + 1)
-              intents#0,SET
+              intents#0,SET test value formatter: 1
      11806    record (13 = 3 [3] + 9 + 1)
-              into#0,SET
+              into#0,SET test value formatter: 5
      11819    record (15 = 3 [2] + 11 + 1)
-              inurn#0,SET
+              inurn#0,SET test value formatter: 1
      11834    record (21 = 3 [2] + 17 + 1)
-              investments#0,SET
+              investments#0,SET test value formatter: 1
      11855    record (16 = 3 [3] + 12 + 1)
-              invites#0,SET
+              invites#0,SET test value formatter: 1
      11871    record (21 = 3 [3] + 17 + 1)
-              invulnerable#0,SET
+              invulnerable#0,SET test value formatter: 1
      11892    record (16 = 3 [2] + 12 + 1)
-              inward#0,SET
+              inward#0,SET test value formatter: 1
      11908    record (14 = 3 [1] + 9 + 2)
-              is#0,SET
+              is#0,SET test value formatter: 62
      11922    record (15 = 3 [2] + 11 + 1)
-              issue#0,SET
+              issue#0,SET test value formatter: 1
      11937    record (15 = 3 [1] + 9 + 3)
-              it#0,SET
+              it#0,SET test value formatter: 126
      11952    record (13 = 3 [2] + 9 + 1)
-              its#0,SET
+              its#0,SET test value formatter: 1
      11965    record (15 = 3 [3] + 11 + 1)
-              itself#0,SET
+              itself#0,SET test value formatter: 9
      11980    record (14 = 3 [0] + 10 + 1) [restart]
-              iv#0,SET
+              iv#0,SET test value formatter: 1
      11994    record (16 = 3 [0] + 12 + 1)
-              jaws#0,SET
+              jaws#0,SET test value formatter: 1
      12010    record (16 = 3 [1] + 12 + 1)
-              jelly#0,SET
+              jelly#0,SET test value formatter: 1
      12026    record (17 = 3 [1] + 13 + 1)
-              jocund#0,SET
+              jocund#0,SET test value formatter: 1
      12043    record (15 = 3 [2] + 11 + 1)
-              joint#0,SET
+              joint#0,SET test value formatter: 2
      12058    record (16 = 3 [5] + 12 + 1)
-              jointress#0,SET
+              jointress#0,SET test value formatter: 1
      12074    record (13 = 3 [2] + 9 + 1)
-              joy#0,SET
+              joy#0,SET test value formatter: 1
      12087    record (19 = 3 [1] + 15 + 1)
-              judgment#0,SET
+              judgment#0,SET test value formatter: 1
      12106    record (15 = 3 [2] + 11 + 1)
-              juice#0,SET
+              juice#0,SET test value formatter: 1
      12121    record (16 = 3 [2] + 12 + 1)
-              julius#0,SET
+              julius#0,SET test value formatter: 1
      12137    record (14 = 3 [2] + 10 + 1)
-              jump#0,SET
+              jump#0,SET test value formatter: 1
      12151    record (16 = 3 [0] + 12 + 1)
-              keep#0,SET
+              keep#0,SET test value formatter: 3
      12167    record (13 = 3 [4] + 9 + 1)
-              keeps#0,SET
+              keeps#0,SET test value formatter: 1
      12180    record (14 = 3 [2] + 10 + 1)
-              kept#0,SET
+              kept#0,SET test value formatter: 1
      12194    record (16 = 3 [2] + 12 + 1)
-              kettle#0,SET
+              kettle#0,SET test value formatter: 1
      12210    record (13 = 3 [2] + 9 + 1)
-              key#0,SET
+              key#0,SET test value formatter: 1
      12223    [restart 10217]
      12227    [restart 10447]
      12231    [restart 10682]
@@ -1718,275 +1718,275 @@ h.no-compression.two_level_index.sst
      12251    [restart 11980]
      12264  data (2039)
      12264    record (15 = 3 [0] + 11 + 1) [restart]
-              kin#0,SET
+              kin#0,SET test value formatter: 1
      12279    record (13 = 3 [3] + 9 + 1)
-              kind#0,SET
+              kind#0,SET test value formatter: 1
      12292    record (14 = 3 [3] + 9 + 2)
-              king#0,SET
+              king#0,SET test value formatter: 23
      12306    record (15 = 3 [4] + 11 + 1)
-              kingdom#0,SET
+              kingdom#0,SET test value formatter: 1
      12321    record (16 = 3 [1] + 12 + 1)
-              knave#0,SET
+              knave#0,SET test value formatter: 1
      12337    record (14 = 3 [2] + 10 + 1)
-              knew#0,SET
+              knew#0,SET test value formatter: 1
      12351    record (17 = 3 [2] + 13 + 1)
-              knotted#0,SET
+              knotted#0,SET test value formatter: 1
      12368    record (14 = 3 [3] + 9 + 2)
-              know#0,SET
+              know#0,SET test value formatter: 17
      12382    record (13 = 3 [4] + 9 + 1)
-              known#0,SET
+              known#0,SET test value formatter: 2
      12395    record (13 = 3 [4] + 9 + 1)
-              knows#0,SET
+              knows#0,SET test value formatter: 1
      12408    record (20 = 3 [0] + 16 + 1)
-              labourer#0,SET
+              labourer#0,SET test value formatter: 1
      12428    record (16 = 3 [6] + 12 + 1)
-              laboursome#0,SET
+              laboursome#0,SET test value formatter: 1
      12444    record (14 = 3 [2] + 10 + 1)
-              lack#0,SET
+              lack#0,SET test value formatter: 1
      12458    record (13 = 3 [4] + 9 + 1)
-              lacks#0,SET
+              lacks#0,SET test value formatter: 1
      12471    record (18 = 3 [2] + 13 + 2)
-              laertes#0,SET
+              laertes#0,SET test value formatter: 16
      12489    record (14 = 3 [2] + 10 + 1)
-              land#0,SET
+              land#0,SET test value formatter: 2
      12503    record (17 = 3 [0] + 13 + 1) [restart]
-              lands#0,SET
+              lands#0,SET test value formatter: 3
      12520    record (16 = 3 [2] + 12 + 1)
-              larger#0,SET
+              larger#0,SET test value formatter: 1
      12536    record (14 = 3 [2] + 10 + 1)
-              last#0,SET
+              last#0,SET test value formatter: 3
      12550    record (15 = 3 [4] + 11 + 1)
-              lasting#0,SET
+              lasting#0,SET test value formatter: 1
      12565    record (14 = 3 [2] + 10 + 1)
-              late#0,SET
+              late#0,SET test value formatter: 3
      12579    record (13 = 3 [2] + 9 + 1)
-              law#0,SET
+              law#0,SET test value formatter: 2
      12592    record (16 = 3 [3] + 12 + 1)
-              lawless#0,SET
+              lawless#0,SET test value formatter: 1
      12608    record (13 = 3 [2] + 9 + 1)
-              lay#0,SET
+              lay#0,SET test value formatter: 1
      12621    record (15 = 3 [2] + 11 + 1)
-              lazar#0,SET
+              lazar#0,SET test value formatter: 1
      12636    record (15 = 3 [1] + 11 + 1)
-              lead#0,SET
+              lead#0,SET test value formatter: 1
      12651    record (14 = 3 [3] + 10 + 1)
-              least#0,SET
+              least#0,SET test value formatter: 2
      12665    record (14 = 3 [3] + 10 + 1)
-              leave#0,SET
+              leave#0,SET test value formatter: 8
      12679    record (14 = 3 [5] + 10 + 1)
-              leavens#0,SET
+              leavens#0,SET test value formatter: 1
      12693    record (14 = 3 [2] + 10 + 1)
-              left#0,SET
+              left#0,SET test value formatter: 1
      12707    record (17 = 3 [2] + 13 + 1)
-              leisure#0,SET
+              leisure#0,SET test value formatter: 1
      12724    record (14 = 3 [2] + 10 + 1)
-              lend#0,SET
+              lend#0,SET test value formatter: 1
      12738    record (18 = 3 [0] + 14 + 1) [restart]
-              lender#0,SET
+              lender#0,SET test value formatter: 1
      12756    record (13 = 3 [4] + 9 + 1)
-              lends#0,SET
+              lends#0,SET test value formatter: 1
      12769    record (15 = 3 [3] + 11 + 1)
-              length#0,SET
+              length#0,SET test value formatter: 1
      12784    record (18 = 3 [2] + 14 + 1)
-              leperous#0,SET
+              leperous#0,SET test value formatter: 1
      12802    record (14 = 3 [2] + 10 + 1)
-              less#0,SET
+              less#0,SET test value formatter: 2
      12816    record (14 = 3 [4] + 10 + 1)
-              lesson#0,SET
+              lesson#0,SET test value formatter: 1
      12830    record (14 = 3 [2] + 9 + 2)
-              let#0,SET
+              let#0,SET test value formatter: 23
      12844    record (14 = 3 [3] + 10 + 1)
-              lethe#0,SET
+              lethe#0,SET test value formatter: 1
      12858    record (13 = 3 [3] + 9 + 1)
-              lets#0,SET
+              lets#0,SET test value formatter: 1
      12871    record (16 = 3 [2] + 12 + 1)
-              levies#0,SET
+              levies#0,SET test value formatter: 1
      12887    record (18 = 3 [2] + 14 + 1)
-              lewdness#0,SET
+              lewdness#0,SET test value formatter: 1
      12905    record (20 = 3 [1] + 16 + 1)
-              libertine#0,SET
+              libertine#0,SET test value formatter: 1
      12925    record (14 = 3 [2] + 10 + 1)
-              lids#0,SET
+              lids#0,SET test value formatter: 1
      12939    record (18 = 3 [2] + 14 + 1)
-              liegemen#0,SET
+              liegemen#0,SET test value formatter: 1
      12957    record (13 = 3 [3] + 9 + 1)
-              lies#0,SET
+              lies#0,SET test value formatter: 1
      12970    record (14 = 3 [2] + 10 + 1)
-              life#0,SET
+              life#0,SET test value formatter: 7
      12984    record (18 = 3 [0] + 14 + 1) [restart]
-              lifted#0,SET
+              lifted#0,SET test value formatter: 1
      13002    record (15 = 3 [2] + 11 + 1)
-              light#0,SET
+              light#0,SET test value formatter: 1
      13017    record (15 = 3 [5] + 11 + 1)
-              lightest#0,SET
+              lightest#0,SET test value formatter: 1
      13032    record (15 = 3 [2] + 10 + 2)
-              like#0,SET
+              like#0,SET test value formatter: 23
      13047    record (14 = 3 [2] + 10 + 1)
-              link#0,SET
+              link#0,SET test value formatter: 1
      13061    record (14 = 3 [2] + 10 + 1)
-              lion#0,SET
+              lion#0,SET test value formatter: 1
      13075    record (14 = 3 [2] + 10 + 1)
-              lips#0,SET
+              lips#0,SET test value formatter: 1
      13089    record (16 = 3 [2] + 12 + 1)
-              liquid#0,SET
+              liquid#0,SET test value formatter: 1
      13105    record (14 = 3 [2] + 10 + 1)
-              list#0,SET
+              list#0,SET test value formatter: 6
      13119    record (13 = 3 [4] + 9 + 1)
-              lists#0,SET
+              lists#0,SET test value formatter: 1
      13132    record (16 = 3 [2] + 12 + 1)
-              little#0,SET
+              little#0,SET test value formatter: 3
      13148    record (14 = 3 [2] + 10 + 1)
-              live#0,SET
+              live#0,SET test value formatter: 3
      13162    record (14 = 3 [4] + 10 + 1)
-              livery#0,SET
+              livery#0,SET test value formatter: 1
      13176    record (13 = 3 [4] + 9 + 1)
-              lives#0,SET
+              lives#0,SET test value formatter: 1
      13189    record (14 = 3 [1] + 9 + 2)
-              ll#0,SET
+              ll#0,SET test value formatter: 18
      13203    record (13 = 3 [1] + 9 + 1)
-              lo#0,SET
+              lo#0,SET test value formatter: 1
      13216    record (16 = 3 [0] + 12 + 1) [restart]
-              loan#0,SET
+              loan#0,SET test value formatter: 1
      13232    record (18 = 3 [3] + 14 + 1)
-              loathsome#0,SET
+              loathsome#0,SET test value formatter: 1
      13250    record (14 = 3 [2] + 10 + 1)
-              lock#0,SET
+              lock#0,SET test value formatter: 1
      13264    record (13 = 3 [4] + 9 + 1)
-              locks#0,SET
+              locks#0,SET test value formatter: 1
      13277    record (15 = 3 [2] + 11 + 1)
-              lodge#0,SET
+              lodge#0,SET test value formatter: 1
      13292    record (15 = 3 [2] + 11 + 1)
-              lofty#0,SET
+              lofty#0,SET test value formatter: 1
      13307    record (14 = 3 [2] + 10 + 1)
-              long#0,SET
+              long#0,SET test value formatter: 4
      13321    record (14 = 3 [4] + 10 + 1)
-              longer#0,SET
+              longer#0,SET test value formatter: 3
      13335    record (15 = 3 [2] + 10 + 2)
-              look#0,SET
+              look#0,SET test value formatter: 10
      13350    record (13 = 3 [4] + 9 + 1)
-              looks#0,SET
+              looks#0,SET test value formatter: 2
      13363    record (14 = 3 [3] + 10 + 1)
-              loose#0,SET
+              loose#0,SET test value formatter: 1
      13377    record (15 = 3 [2] + 10 + 2)
-              lord#0,SET
+              lord#0,SET test value formatter: 60
      13392    record (13 = 3 [4] + 9 + 1)
-              lords#0,SET
+              lords#0,SET test value formatter: 1
      13405    record (15 = 3 [5] + 11 + 1)
-              lordship#0,SET
+              lordship#0,SET test value formatter: 1
      13420    record (14 = 3 [2] + 10 + 1)
-              lose#0,SET
+              lose#0,SET test value formatter: 2
      13434    record (13 = 3 [4] + 9 + 1)
-              loses#0,SET
+              loses#0,SET test value formatter: 1
      13447    record (16 = 3 [0] + 12 + 1) [restart]
-              loss#0,SET
+              loss#0,SET test value formatter: 1
      13463    record (13 = 3 [3] + 9 + 1)
-              lost#0,SET
+              lost#0,SET test value formatter: 5
      13476    record (14 = 3 [2] + 10 + 1)
-              loud#0,SET
+              loud#0,SET test value formatter: 1
      13490    record (14 = 3 [2] + 10 + 1)
-              love#0,SET
+              love#0,SET test value formatter: 8
      13504    record (13 = 3 [4] + 9 + 1)
-              loves#0,SET
+              loves#0,SET test value formatter: 5
      13517    record (15 = 3 [3] + 11 + 1)
-              loving#0,SET
+              loving#0,SET test value formatter: 2
      13532    record (15 = 3 [1] + 11 + 1)
-              lust#0,SET
+              lust#0,SET test value formatter: 2
      13547    record (16 = 3 [2] + 12 + 1)
-              luxury#0,SET
+              luxury#0,SET test value formatter: 1
      13563    record (13 = 3 [0] + 9 + 1)
-              m#0,SET
+              m#0,SET test value formatter: 2
      13576    record (16 = 3 [1] + 12 + 1)
-              madam#0,SET
+              madam#0,SET test value formatter: 4
      13592    record (13 = 3 [3] + 9 + 1)
-              made#0,SET
+              made#0,SET test value formatter: 8
      13605    record (16 = 3 [3] + 12 + 1)
-              madness#0,SET
+              madness#0,SET test value formatter: 1
      13621    record (14 = 3 [2] + 10 + 1)
-              maid#0,SET
+              maid#0,SET test value formatter: 1
      13635    record (14 = 3 [4] + 10 + 1)
-              maiden#0,SET
+              maiden#0,SET test value formatter: 1
      13649    record (13 = 3 [3] + 9 + 1)
-              main#0,SET
+              main#0,SET test value formatter: 2
      13662    record (20 = 3 [2] + 16 + 1)
-              majestical#0,SET
+              majestical#0,SET test value formatter: 1
      13682    record (19 = 3 [0] + 15 + 1) [restart]
-              majesty#0,SET
+              majesty#0,SET test value formatter: 1
      13701    record (14 = 3 [2] + 10 + 1)
-              make#0,SET
+              make#0,SET test value formatter: 8
      13715    record (13 = 3 [4] + 9 + 1)
-              makes#0,SET
+              makes#0,SET test value formatter: 2
      13728    record (15 = 3 [3] + 11 + 1)
-              making#0,SET
+              making#0,SET test value formatter: 2
      13743    record (19 = 3 [2] + 15 + 1)
-              malicious#0,SET
+              malicious#0,SET test value formatter: 1
      13762    record (14 = 3 [2] + 9 + 2)
-              man#0,SET
+              man#0,SET test value formatter: 11
      13776    record (15 = 3 [3] + 11 + 1)
-              manner#0,SET
+              manner#0,SET test value formatter: 1
      13791    record (13 = 3 [6] + 9 + 1)
-              manners#0,SET
+              manners#0,SET test value formatter: 1
      13804    record (15 = 3 [3] + 11 + 1)
-              mantle#0,SET
+              mantle#0,SET test value formatter: 1
      13819    record (13 = 3 [3] + 9 + 1)
-              many#0,SET
+              many#0,SET test value formatter: 2
      13832    record (16 = 3 [2] + 12 + 1)
-              marble#0,SET
+              marble#0,SET test value formatter: 1
      13848    record (19 = 3 [3] + 14 + 2)
-              marcellus#0,SET
+              marcellus#0,SET test value formatter: 46
      13867    record (13 = 3 [4] + 9 + 1)
-              march#0,SET
+              march#0,SET test value formatter: 2
      13880    record (13 = 3 [3] + 9 + 1)
-              mark#0,SET
+              mark#0,SET test value formatter: 2
      13893    record (17 = 3 [3] + 13 + 1)
-              marriage#0,SET
+              marriage#0,SET test value formatter: 3
      13910    record (14 = 3 [5] + 10 + 1)
-              married#0,SET
+              married#0,SET test value formatter: 2
      13924    record (18 = 3 [0] + 14 + 1) [restart]
-              marrow#0,SET
+              marrow#0,SET test value formatter: 1
      13942    record (13 = 3 [4] + 9 + 1)
-              marry#0,SET
+              marry#0,SET test value formatter: 3
      13955    record (13 = 3 [3] + 9 + 1)
-              mart#0,SET
+              mart#0,SET test value formatter: 1
      13968    record (15 = 3 [4] + 11 + 1)
-              martial#0,SET
+              martial#0,SET test value formatter: 1
      13983    record (15 = 3 [3] + 11 + 1)
-              marvel#0,SET
+              marvel#0,SET test value formatter: 1
      13998    record (15 = 3 [2] + 11 + 1)
-              matin#0,SET
+              matin#0,SET test value formatter: 1
      14013    record (15 = 3 [3] + 11 + 1)
-              matter#0,SET
+              matter#0,SET test value formatter: 1
      14028    record (14 = 3 [2] + 9 + 2)
-              may#0,SET
+              may#0,SET test value formatter: 19
      14042    record (14 = 3 [1] + 9 + 2)
-              me#0,SET
+              me#0,SET test value formatter: 47
      14056    record (14 = 3 [2] + 10 + 1)
-              mean#0,SET
+              mean#0,SET test value formatter: 2
      14070    record (13 = 3 [4] + 9 + 1)
-              means#0,SET
+              means#0,SET test value formatter: 2
      14083    record (14 = 3 [3] + 10 + 1)
-              meats#0,SET
+              meats#0,SET test value formatter: 1
      14097    record (20 = 3 [2] + 16 + 1)
-              meditation#0,SET
+              meditation#0,SET test value formatter: 1
      14117    record (14 = 3 [2] + 10 + 1)
-              meet#0,SET
+              meet#0,SET test value formatter: 3
      14131    record (15 = 3 [4] + 11 + 1)
-              meeting#0,SET
+              meeting#0,SET test value formatter: 1
      14146    record (14 = 3 [2] + 10 + 1)
-              melt#0,SET
+              melt#0,SET test value formatter: 1
      14160    record (18 = 3 [0] + 14 + 1) [restart]
-              memory#0,SET
+              memory#0,SET test value formatter: 5
      14178    record (13 = 3 [2] + 9 + 1)
-              men#0,SET
+              men#0,SET test value formatter: 3
      14191    record (15 = 3 [2] + 11 + 1)
-              mercy#0,SET
+              mercy#0,SET test value formatter: 2
      14206    record (13 = 3 [3] + 9 + 1)
-              mere#0,SET
+              mere#0,SET test value formatter: 1
      14219    record (14 = 3 [4] + 10 + 1)
-              merely#0,SET
+              merely#0,SET test value formatter: 1
      14233    record (17 = 3 [2] + 13 + 1)
-              message#0,SET
+              message#0,SET test value formatter: 1
      14250    record (13 = 3 [2] + 9 + 1)
-              met#0,SET
+              met#0,SET test value formatter: 1
      14263    [restart 12264]
      14267    [restart 12503]
      14271    [restart 12738]
@@ -1998,267 +1998,267 @@ h.no-compression.two_level_index.sst
      14295    [restart 14160]
      14308  data (2037)
      14308    record (20 = 3 [0] + 16 + 1) [restart]
-              methinks#0,SET
+              methinks#0,SET test value formatter: 2
      14328    record (17 = 3 [4] + 13 + 1)
-              methought#0,SET
+              methought#0,SET test value formatter: 1
      14345    record (15 = 3 [3] + 11 + 1)
-              mettle#0,SET
+              mettle#0,SET test value formatter: 1
      14360    record (17 = 3 [1] + 13 + 1)
-              middle#0,SET
+              middle#0,SET test value formatter: 1
      14377    record (15 = 3 [2] + 11 + 1)
-              might#0,SET
+              might#0,SET test value formatter: 7
      14392    record (16 = 3 [5] + 12 + 1)
-              mightiest#0,SET
+              mightiest#0,SET test value formatter: 1
      14408    record (14 = 3 [2] + 10 + 1)
-              milk#0,SET
+              milk#0,SET test value formatter: 1
      14422    record (14 = 3 [2] + 10 + 1)
-              mind#0,SET
+              mind#0,SET test value formatter: 6
      14436    record (13 = 3 [3] + 9 + 1)
-              mine#0,SET
+              mine#0,SET test value formatter: 6
      14449    record (18 = 3 [3] + 14 + 1)
-              ministers#0,SET
+              ministers#0,SET test value formatter: 1
      14467    record (15 = 3 [3] + 11 + 1)
-              minute#0,SET
+              minute#0,SET test value formatter: 1
      14482    record (13 = 3 [6] + 9 + 1)
-              minutes#0,SET
+              minutes#0,SET test value formatter: 1
      14495    record (15 = 3 [2] + 11 + 1)
-              mirth#0,SET
+              mirth#0,SET test value formatter: 1
      14510    record (15 = 3 [1] + 11 + 1)
-              mock#0,SET
+              mock#0,SET test value formatter: 1
      14525    record (15 = 3 [4] + 11 + 1)
-              mockery#0,SET
+              mockery#0,SET test value formatter: 1
      14540    record (18 = 3 [2] + 14 + 1)
-              moderate#0,SET
+              moderate#0,SET test value formatter: 1
      14558    record (18 = 3 [0] + 14 + 1) [restart]
-              moiety#0,SET
+              moiety#0,SET test value formatter: 1
      14576    record (14 = 3 [3] + 10 + 1)
-              moist#0,SET
+              moist#0,SET test value formatter: 1
      14590    record (14 = 3 [2] + 10 + 1)
-              mole#0,SET
+              mole#0,SET test value formatter: 2
      14604    record (16 = 3 [2] + 12 + 1)
-              moment#0,SET
+              moment#0,SET test value formatter: 1
      14620    record (15 = 3 [2] + 11 + 1)
-              month#0,SET
+              month#0,SET test value formatter: 3
      14635    record (13 = 3 [5] + 9 + 1)
-              months#0,SET
+              months#0,SET test value formatter: 1
      14648    record (15 = 3 [2] + 11 + 1)
-              moods#0,SET
+              moods#0,SET test value formatter: 1
      14663    record (13 = 3 [3] + 9 + 1)
-              moon#0,SET
+              moon#0,SET test value formatter: 2
      14676    record (15 = 3 [2] + 10 + 2)
-              more#0,SET
+              more#0,SET test value formatter: 19
      14691    record (13 = 3 [3] + 9 + 1)
-              morn#0,SET
+              morn#0,SET test value formatter: 3
      14704    record (15 = 3 [4] + 11 + 1)
-              morning#0,SET
+              morning#0,SET test value formatter: 3
      14719    record (15 = 3 [2] + 10 + 2)
-              most#0,SET
+              most#0,SET test value formatter: 28
      14734    record (14 = 3 [2] + 10 + 1)
-              mote#0,SET
+              mote#0,SET test value formatter: 1
      14748    record (15 = 3 [3] + 11 + 1)
-              mother#0,SET
+              mother#0,SET test value formatter: 5
      14763    record (15 = 3 [3] + 11 + 1)
-              motion#0,SET
+              motion#0,SET test value formatter: 1
      14778    record (14 = 3 [4] + 10 + 1)
-              motive#0,SET
+              motive#0,SET test value formatter: 2
      14792    record (17 = 3 [0] + 13 + 1) [restart]
-              mourn#0,SET
+              mourn#0,SET test value formatter: 1
      14809    record (15 = 3 [5] + 11 + 1)
-              mourning#0,SET
+              mourning#0,SET test value formatter: 1
      14824    record (14 = 3 [3] + 10 + 1)
-              mouse#0,SET
+              mouse#0,SET test value formatter: 1
      14838    record (14 = 3 [3] + 10 + 1)
-              mouth#0,SET
+              mouth#0,SET test value formatter: 1
      14852    record (15 = 3 [2] + 11 + 1)
-              moved#0,SET
+              moved#0,SET test value formatter: 1
      14867    record (15 = 3 [1] + 11 + 1)
-              much#0,SET
+              much#0,SET test value formatter: 9
      14882    record (16 = 3 [2] + 12 + 1)
-              murder#0,SET
+              murder#0,SET test value formatter: 3
      14898    record (15 = 3 [2] + 10 + 2)
-              must#0,SET
+              must#0,SET test value formatter: 14
      14913    record (15 = 3 [1] + 9 + 3)
-              my#0,SET
+              my#0,SET test value formatter: 126
      14928    record (16 = 3 [2] + 12 + 1)
-              myself#0,SET
+              myself#0,SET test value formatter: 4
      14944    record (16 = 3 [0] + 12 + 1)
-              name#0,SET
+              name#0,SET test value formatter: 2
      14960    record (17 = 3 [2] + 13 + 1)
-              nations#0,SET
+              nations#0,SET test value formatter: 1
      14977    record (14 = 3 [4] + 10 + 1)
-              native#0,SET
+              native#0,SET test value formatter: 2
      14991    record (16 = 3 [3] + 12 + 1)
-              natural#0,SET
+              natural#0,SET test value formatter: 2
      15007    record (14 = 3 [5] + 9 + 2)
-              nature#0,SET
+              nature#0,SET test value formatter: 13
      15021    record (13 = 3 [2] + 9 + 1)
-              nay#0,SET
+              nay#0,SET test value formatter: 7
      15034    record (14 = 3 [0] + 10 + 1) [restart]
-              ne#0,SET
+              ne#0,SET test value formatter: 1
      15048    record (14 = 3 [2] + 10 + 1)
-              near#0,SET
+              near#0,SET test value formatter: 3
      15062    record (21 = 3 [2] + 17 + 1)
-              necessaries#0,SET
+              necessaries#0,SET test value formatter: 1
      15083    record (14 = 3 [2] + 10 + 1)
-              need#0,SET
+              need#0,SET test value formatter: 1
      15097    record (15 = 3 [4] + 11 + 1)
-              needful#0,SET
+              needful#0,SET test value formatter: 1
      15112    record (13 = 3 [4] + 9 + 1)
-              needs#0,SET
+              needs#0,SET test value formatter: 1
      15125    record (17 = 3 [2] + 13 + 1)
-              neither#0,SET
+              neither#0,SET test value formatter: 1
      15142    record (16 = 3 [2] + 12 + 1)
-              nemean#0,SET
+              nemean#0,SET test value formatter: 1
      15158    record (16 = 3 [2] + 12 + 1)
-              nephew#0,SET
+              nephew#0,SET test value formatter: 1
      15174    record (16 = 3 [3] + 12 + 1)
-              neptune#0,SET
+              neptune#0,SET test value formatter: 1
      15190    record (15 = 3 [2] + 11 + 1)
-              nerve#0,SET
+              nerve#0,SET test value formatter: 1
      15205    record (15 = 3 [2] + 11 + 1)
-              never#0,SET
+              never#0,SET test value formatter: 6
      15220    record (13 = 3 [2] + 9 + 1)
-              new#0,SET
+              new#0,SET test value formatter: 1
      15233    record (13 = 3 [3] + 9 + 1)
-              news#0,SET
+              news#0,SET test value formatter: 2
      15246    record (17 = 3 [1] + 12 + 2)
-              night#0,SET
+              night#0,SET test value formatter: 22
      15263    record (14 = 3 [5] + 10 + 1)
-              nighted#0,SET
+              nighted#0,SET test value formatter: 1
      15277    record (19 = 3 [0] + 15 + 1) [restart]
-              nightly#0,SET
+              nightly#0,SET test value formatter: 1
      15296    record (13 = 3 [5] + 9 + 1)
-              nights#0,SET
+              nights#0,SET test value formatter: 3
      15309    record (15 = 3 [2] + 11 + 1)
-              niobe#0,SET
+              niobe#0,SET test value formatter: 1
      15324    record (17 = 3 [2] + 13 + 1)
-              nipping#0,SET
+              nipping#0,SET test value formatter: 1
      15341    record (14 = 3 [1] + 9 + 2)
-              no#0,SET
+              no#0,SET test value formatter: 28
      15355    record (18 = 3 [2] + 14 + 1)
-              nobility#0,SET
+              nobility#0,SET test value formatter: 1
      15373    record (14 = 3 [3] + 10 + 1)
-              noble#0,SET
+              noble#0,SET test value formatter: 5
      15387    record (14 = 3 [2] + 10 + 1)
-              none#0,SET
+              none#0,SET test value formatter: 2
      15401    record (14 = 3 [2] + 9 + 2)
-              nor#0,SET
+              nor#0,SET test value formatter: 14
      15415    record (15 = 3 [3] + 11 + 1)
-              norway#0,SET
+              norway#0,SET test value formatter: 5
      15430    record (14 = 3 [2] + 9 + 2)
-              not#0,SET
+              not#0,SET test value formatter: 80
      15444    record (13 = 3 [3] + 9 + 1)
-              note#0,SET
+              note#0,SET test value formatter: 2
      15457    record (16 = 3 [3] + 12 + 1)
-              nothing#0,SET
+              nothing#0,SET test value formatter: 2
      15473    record (14 = 3 [2] + 9 + 2)
-              now#0,SET
+              now#0,SET test value formatter: 19
      15487    record (14 = 3 [0] + 9 + 2)
-              o#0,SET
+              o#0,SET test value formatter: 30
      15501    record (15 = 3 [1] + 11 + 1)
-              oath#0,SET
+              oath#0,SET test value formatter: 1
      15516    record (16 = 3 [0] + 12 + 1) [restart]
-              obey#0,SET
+              obey#0,SET test value formatter: 3
      15532    record (16 = 3 [2] + 12 + 1)
-              object#0,SET
+              object#0,SET test value formatter: 1
      15548    record (20 = 3 [2] + 16 + 1)
-              obligation#0,SET
+              obligation#0,SET test value formatter: 1
      15568    record (20 = 3 [2] + 16 + 1)
-              obsequious#0,SET
+              obsequious#0,SET test value formatter: 1
      15588    record (18 = 3 [4] + 14 + 1)
-              observance#0,SET
+              observance#0,SET test value formatter: 1
      15606    record (13 = 3 [8] + 9 + 1)
-              observant#0,SET
+              observant#0,SET test value formatter: 1
      15619    record (16 = 3 [7] + 12 + 1)
-              observation#0,SET
+              observation#0,SET test value formatter: 1
      15635    record (18 = 3 [3] + 14 + 1)
-              obstinate#0,SET
+              obstinate#0,SET test value formatter: 1
      15653    record (19 = 3 [1] + 15 + 1)
-              occasion#0,SET
+              occasion#0,SET test value formatter: 1
      15672    record (14 = 3 [1] + 10 + 1)
-              odd#0,SET
+              odd#0,SET test value formatter: 1
      15686    record (15 = 3 [1] + 9 + 3)
-              of#0,SET
+              of#0,SET test value formatter: 176
      15701    record (13 = 3 [2] + 9 + 1)
-              off#0,SET
+              off#0,SET test value formatter: 6
      15714    record (16 = 3 [3] + 12 + 1)
-              offence#0,SET
+              offence#0,SET test value formatter: 2
      15730    record (13 = 3 [5] + 9 + 1)
-              offend#0,SET
+              offend#0,SET test value formatter: 1
      15743    record (14 = 3 [6] + 10 + 1)
-              offended#0,SET
+              offended#0,SET test value formatter: 1
      15757    record (13 = 3 [4] + 9 + 1)
-              offer#0,SET
+              offer#0,SET test value formatter: 2
      15770    record (15 = 3 [0] + 11 + 1) [restart]
-              oft#0,SET
+              oft#0,SET test value formatter: 7
      15785    record (14 = 3 [1] + 10 + 1)
-              old#0,SET
+              old#0,SET test value formatter: 4
      15799    record (15 = 3 [1] + 11 + 1)
-              omen#0,SET
+              omen#0,SET test value formatter: 1
      15814    record (14 = 3 [1] + 9 + 2)
-              on#0,SET
+              on#0,SET test value formatter: 25
      15828    record (14 = 3 [2] + 10 + 1)
-              once#0,SET
+              once#0,SET test value formatter: 8
      15842    record (13 = 3 [2] + 9 + 1)
-              one#0,SET
+              one#0,SET test value formatter: 6
      15855    record (15 = 3 [1] + 11 + 1)
-              oped#0,SET
+              oped#0,SET test value formatter: 1
      15870    record (13 = 3 [3] + 9 + 1)
-              open#0,SET
+              open#0,SET test value formatter: 1
      15883    record (18 = 3 [2] + 13 + 2)
-              ophelia#0,SET
+              ophelia#0,SET test value formatter: 15
      15901    record (17 = 3 [2] + 13 + 1)
-              opinion#0,SET
+              opinion#0,SET test value formatter: 1
      15918    record (17 = 3 [2] + 13 + 1)
-              opposed#0,SET
+              opposed#0,SET test value formatter: 1
      15935    record (17 = 3 [5] + 13 + 1)
-              opposition#0,SET
+              opposition#0,SET test value formatter: 1
      15952    record (16 = 3 [3] + 12 + 1)
-              oppress#0,SET
+              oppress#0,SET test value formatter: 1
      15968    record (14 = 3 [1] + 9 + 2)
-              or#0,SET
+              or#0,SET test value formatter: 28
      15982    record (17 = 3 [2] + 13 + 1)
-              orchard#0,SET
+              orchard#0,SET test value formatter: 2
      15999    record (18 = 3 [2] + 14 + 1)
-              ordnance#0,SET
+              ordnance#0,SET test value formatter: 1
      16017    record (18 = 3 [0] + 14 + 1) [restart]
-              origin#0,SET
+              origin#0,SET test value formatter: 1
      16035    record (16 = 3 [1] + 12 + 1)
-              other#0,SET
+              other#0,SET test value formatter: 4
      16051    record (15 = 3 [1] + 10 + 2)
-              our#0,SET
+              our#0,SET test value formatter: 45
      16066    record (16 = 3 [3] + 12 + 1)
-              ourself#0,SET
+              ourself#0,SET test value formatter: 2
      16082    record (15 = 3 [6] + 11 + 1)
-              ourselves#0,SET
+              ourselves#0,SET test value formatter: 1
      16097    record (13 = 3 [2] + 9 + 1)
-              out#0,SET
+              out#0,SET test value formatter: 8
      16110    record (14 = 3 [1] + 10 + 1)
-              own#0,SET
+              own#0,SET test value formatter: 6
      16124    record (16 = 3 [3] + 12 + 1)
-              ownself#0,SET
+              ownself#0,SET test value formatter: 1
      16140    record (16 = 3 [0] + 12 + 1)
-              pale#0,SET
+              pale#0,SET test value formatter: 4
      16156    record (13 = 3 [4] + 9 + 1)
-              pales#0,SET
+              pales#0,SET test value formatter: 1
      16169    record (13 = 3 [3] + 9 + 1)
-              palm#0,SET
+              palm#0,SET test value formatter: 1
      16182    record (13 = 3 [4] + 9 + 1)
-              palmy#0,SET
+              palmy#0,SET test value formatter: 1
      16195    record (16 = 3 [2] + 12 + 1)
-              pardon#0,SET
+              pardon#0,SET test value formatter: 1
      16211    record (14 = 3 [3] + 10 + 1)
-              parle#0,SET
+              parle#0,SET test value formatter: 1
      16225    record (13 = 3 [5] + 9 + 1)
-              parley#0,SET
+              parley#0,SET test value formatter: 1
      16238    record (13 = 3 [3] + 9 + 1)
-              part#0,SET
+              part#0,SET test value formatter: 6
      16251    record (22 = 3 [0] + 18 + 1) [restart]
-              particular#0,SET
+              particular#0,SET test value formatter: 6
      16273    record (15 = 3 [5] + 11 + 1)
-              partisan#0,SET
+              partisan#0,SET test value formatter: 1
      16288    record (17 = 3 [2] + 13 + 1)
-              passeth#0,SET
+              passeth#0,SET test value formatter: 1
      16305    [restart 14308]
      16309    [restart 14558]
      16313    [restart 14792]
@@ -2270,257 +2270,257 @@ h.no-compression.two_level_index.sst
      16337    [restart 16251]
      16350  data (2029)
      16350    record (19 = 3 [0] + 15 + 1) [restart]
-              passing#0,SET
+              passing#0,SET test value formatter: 1
      16369    record (13 = 3 [3] + 9 + 1)
-              past#0,SET
+              past#0,SET test value formatter: 1
      16382    record (15 = 3 [4] + 11 + 1)
-              pastors#0,SET
+              pastors#0,SET test value formatter: 1
      16397    record (14 = 3 [2] + 10 + 1)
-              path#0,SET
+              path#0,SET test value formatter: 1
      16411    record (16 = 3 [3] + 12 + 1)
-              patrick#0,SET
+              patrick#0,SET test value formatter: 1
      16427    record (13 = 3 [2] + 9 + 1)
-              pay#0,SET
+              pay#0,SET test value formatter: 1
      16440    record (13 = 3 [1] + 9 + 1)
-              pe#0,SET
+              pe#0,SET test value formatter: 1
      16453    record (15 = 3 [2] + 11 + 1)
-              peace#0,SET
+              peace#0,SET test value formatter: 2
      16468    record (17 = 3 [2] + 13 + 1)
-              peevish#0,SET
+              peevish#0,SET test value formatter: 1
      16485    record (19 = 3 [2] + 15 + 1)
-              perchance#0,SET
+              perchance#0,SET test value formatter: 2
      16504    record (16 = 3 [3] + 12 + 1)
-              perform#0,SET
+              perform#0,SET test value formatter: 1
      16520    record (15 = 3 [4] + 11 + 1)
-              perfume#0,SET
+              perfume#0,SET test value formatter: 1
      16535    record (16 = 3 [3] + 12 + 1)
-              perhaps#0,SET
+              perhaps#0,SET test value formatter: 1
      16551    record (17 = 3 [3] + 13 + 1)
-              perilous#0,SET
+              perilous#0,SET test value formatter: 1
      16568    record (18 = 3 [3] + 14 + 1)
-              permanent#0,SET
+              permanent#0,SET test value formatter: 1
      16586    record (19 = 3 [3] + 15 + 1)
-              pernicious#0,SET
+              pernicious#0,SET test value formatter: 1
      16605    record (20 = 3 [0] + 16 + 1) [restart]
-              persever#0,SET
+              persever#0,SET test value formatter: 1
      16625    record (14 = 3 [4] + 10 + 1)
-              person#0,SET
+              person#0,SET test value formatter: 1
      16639    record (14 = 3 [6] + 10 + 1)
-              personal#0,SET
+              personal#0,SET test value formatter: 1
      16653    record (13 = 3 [6] + 9 + 1)
-              persons#0,SET
+              persons#0,SET test value formatter: 1
      16666    record (18 = 3 [3] + 14 + 1)
-              perturbed#0,SET
+              perturbed#0,SET test value formatter: 1
      16684    record (16 = 3 [2] + 12 + 1)
-              pester#0,SET
+              pester#0,SET test value formatter: 1
      16700    record (18 = 3 [2] + 14 + 1)
-              petition#0,SET
+              petition#0,SET test value formatter: 1
      16718    record (14 = 3 [3] + 10 + 1)
-              petty#0,SET
+              petty#0,SET test value formatter: 1
      16732    record (21 = 3 [1] + 17 + 1)
-              philosophy#0,SET
+              philosophy#0,SET test value formatter: 1
      16753    record (16 = 3 [2] + 12 + 1)
-              phrase#0,SET
+              phrase#0,SET test value formatter: 3
      16769    record (16 = 3 [1] + 12 + 1)
-              piece#0,SET
+              piece#0,SET test value formatter: 1
      16785    record (13 = 3 [2] + 9 + 1)
-              pin#0,SET
+              pin#0,SET test value formatter: 1
      16798    record (16 = 3 [2] + 12 + 1)
-              pioner#0,SET
+              pioner#0,SET test value formatter: 1
      16814    record (14 = 3 [3] + 10 + 1)
-              pious#0,SET
+              pious#0,SET test value formatter: 1
      16828    record (14 = 3 [2] + 10 + 1)
-              pith#0,SET
+              pith#0,SET test value formatter: 1
      16842    record (13 = 3 [3] + 9 + 1)
-              pity#0,SET
+              pity#0,SET test value formatter: 1
      16855    record (17 = 3 [0] + 13 + 1) [restart]
-              place#0,SET
+              place#0,SET test value formatter: 3
      16872    record (14 = 3 [3] + 10 + 1)
-              plain#0,SET
+              plain#0,SET test value formatter: 1
      16886    record (16 = 3 [3] + 12 + 1)
-              planets#0,SET
+              planets#0,SET test value formatter: 1
      16902    record (17 = 3 [3] + 13 + 1)
-              platform#0,SET
+              platform#0,SET test value formatter: 5
      16919    record (17 = 3 [3] + 13 + 1)
-              plausive#0,SET
+              plausive#0,SET test value formatter: 1
      16936    record (13 = 3 [3] + 9 + 1)
-              play#0,SET
+              play#0,SET test value formatter: 2
      16949    record (16 = 3 [2] + 12 + 1)
-              please#0,SET
+              please#0,SET test value formatter: 1
      16965    record (15 = 3 [3] + 11 + 1)
-              pledge#0,SET
+              pledge#0,SET test value formatter: 1
      16980    record (16 = 3 [1] + 12 + 1)
-              point#0,SET
+              point#0,SET test value formatter: 2
      16996    record (17 = 3 [2] + 13 + 1)
-              polacks#0,SET
+              polacks#0,SET test value formatter: 1
      17013    record (13 = 3 [3] + 9 + 1)
-              pole#0,SET
+              pole#0,SET test value formatter: 1
      17026    record (18 = 3 [3] + 13 + 2)
-              polonius#0,SET
+              polonius#0,SET test value formatter: 13
      17044    record (19 = 3 [2] + 15 + 1)
-              ponderous#0,SET
+              ponderous#0,SET test value formatter: 1
      17063    record (14 = 3 [2] + 10 + 1)
-              pooh#0,SET
+              pooh#0,SET test value formatter: 1
      17077    record (13 = 3 [3] + 9 + 1)
-              poor#0,SET
+              poor#0,SET test value formatter: 9
      17090    record (17 = 3 [2] + 13 + 1)
-              porches#0,SET
+              porches#0,SET test value formatter: 1
      17107    record (22 = 3 [0] + 18 + 1) [restart]
-              porpentine#0,SET
+              porpentine#0,SET test value formatter: 1
      17129    record (19 = 3 [3] + 15 + 1)
-              portentous#0,SET
+              portentous#0,SET test value formatter: 1
      17148    record (17 = 3 [2] + 13 + 1)
-              possess#0,SET
+              possess#0,SET test value formatter: 1
      17165    record (13 = 3 [5] + 9 + 1)
-              posset#0,SET
+              posset#0,SET test value formatter: 1
      17178    record (13 = 3 [3] + 9 + 1)
-              post#0,SET
+              post#0,SET test value formatter: 3
      17191    record (14 = 3 [2] + 10 + 1)
-              pour#0,SET
+              pour#0,SET test value formatter: 1
      17205    record (15 = 3 [2] + 11 + 1)
-              power#0,SET
+              power#0,SET test value formatter: 3
      17220    record (15 = 3 [1] + 11 + 1)
-              pray#0,SET
+              pray#0,SET test value formatter: 7
      17235    record (15 = 3 [4] + 11 + 1)
-              prayers#0,SET
+              prayers#0,SET test value formatter: 1
      17250    record (19 = 3 [2] + 15 + 1)
-              preceding#0,SET
+              preceding#0,SET test value formatter: 1
      17269    record (15 = 3 [5] + 11 + 1)
-              precepts#0,SET
+              precepts#0,SET test value formatter: 1
      17284    record (16 = 3 [4] + 12 + 1)
-              precurse#0,SET
+              precurse#0,SET test value formatter: 1
      17300    record (21 = 3 [3] + 17 + 1)
-              preparations#0,SET
+              preparations#0,SET test value formatter: 1
      17321    record (17 = 3 [3] + 13 + 1)
-              presence#0,SET
+              presence#0,SET test value formatter: 1
      17338    record (13 = 3 [6] + 9 + 1)
-              present#0,SET
+              present#0,SET test value formatter: 1
      17351    record (17 = 3 [4] + 13 + 1)
-              pressures#0,SET
+              pressures#0,SET test value formatter: 1
      17368    record (16 = 3 [0] + 12 + 1) [restart]
-              prey#0,SET
+              prey#0,SET test value formatter: 1
      17384    record (15 = 3 [2] + 11 + 1)
-              prick#0,SET
+              prick#0,SET test value formatter: 2
      17399    record (14 = 3 [3] + 10 + 1)
-              pride#0,SET
+              pride#0,SET test value formatter: 1
      17413    record (17 = 3 [3] + 13 + 1)
-              primrose#0,SET
+              primrose#0,SET test value formatter: 1
      17430    record (13 = 3 [4] + 9 + 1)
-              primy#0,SET
+              primy#0,SET test value formatter: 1
      17443    record (15 = 3 [3] + 11 + 1)
-              prince#0,SET
+              prince#0,SET test value formatter: 1
      17458    record (15 = 3 [3] + 11 + 1)
-              prison#0,SET
+              prison#0,SET test value formatter: 1
      17473    record (16 = 3 [3] + 12 + 1)
-              private#0,SET
+              private#0,SET test value formatter: 1
      17489    record (13 = 3 [4] + 9 + 1)
-              privy#0,SET
+              privy#0,SET test value formatter: 1
      17502    record (19 = 3 [2] + 15 + 1)
-              probation#0,SET
+              probation#0,SET test value formatter: 1
      17521    record (16 = 3 [3] + 12 + 1)
-              process#0,SET
+              process#0,SET test value formatter: 1
      17537    record (17 = 3 [4] + 13 + 1)
-              proclaims#0,SET
+              proclaims#0,SET test value formatter: 1
      17554    record (17 = 3 [3] + 13 + 1)
-              prodigal#0,SET
+              prodigal#0,SET test value formatter: 2
      17571    record (17 = 3 [3] + 13 + 1)
-              prologue#0,SET
+              prologue#0,SET test value formatter: 1
      17588    record (16 = 3 [3] + 12 + 1)
-              promise#0,SET
+              promise#0,SET test value formatter: 1
      17604    record (20 = 3 [3] + 16 + 1)
-              pronouncing#0,SET
+              pronouncing#0,SET test value formatter: 1
      17624    record (21 = 3 [0] + 17 + 1) [restart]
-              prophetic#0,SET
+              prophetic#0,SET test value formatter: 1
      17645    record (19 = 3 [4] + 15 + 1)
-              proportions#0,SET
+              proportions#0,SET test value formatter: 1
      17664    record (14 = 3 [5] + 10 + 1)
-              propose#0,SET
+              propose#0,SET test value formatter: 1
      17678    record (15 = 3 [1] + 11 + 1)
-              puff#0,SET
+              puff#0,SET test value formatter: 1
      17693    record (14 = 3 [2] + 10 + 1)
-              pure#0,SET
+              pure#0,SET test value formatter: 1
      17707    record (15 = 3 [3] + 11 + 1)
-              purged#0,SET
+              purged#0,SET test value formatter: 1
      17722    record (16 = 3 [3] + 12 + 1)
-              purpose#0,SET
+              purpose#0,SET test value formatter: 1
      17738    record (14 = 3 [3] + 10 + 1)
-              purse#0,SET
+              purse#0,SET test value formatter: 1
      17752    record (16 = 3 [4] + 12 + 1)
-              pursuest#0,SET
+              pursuest#0,SET test value formatter: 1
      17768    record (13 = 3 [2] + 9 + 1)
-              put#0,SET
+              put#0,SET test value formatter: 2
      17781    record (13 = 3 [3] + 9 + 1)
-              puts#0,SET
+              puts#0,SET test value formatter: 1
      17794    record (19 = 3 [0] + 15 + 1)
-              quarrel#0,SET
+              quarrel#0,SET test value formatter: 1
      17813    record (15 = 3 [2] + 11 + 1)
-              queen#0,SET
+              queen#0,SET test value formatter: 7
      17828    record (17 = 3 [3] + 13 + 1)
-              question#0,SET
+              question#0,SET test value formatter: 2
      17845    record (16 = 3 [8] + 12 + 1)
-              questionable#0,SET
+              questionable#0,SET test value formatter: 1
      17861    record (21 = 3 [2] + 17 + 1)
-              quicksilver#0,SET
+              quicksilver#0,SET test value formatter: 1
      17882    record (17 = 3 [0] + 13 + 1) [restart]
-              quiet#0,SET
+              quiet#0,SET test value formatter: 1
      17899    record (14 = 3 [5] + 10 + 1)
-              quietly#0,SET
+              quietly#0,SET test value formatter: 1
      17913    record (15 = 3 [3] + 11 + 1)
-              quills#0,SET
+              quills#0,SET test value formatter: 1
      17928    record (19 = 3 [0] + 15 + 1)
-              radiant#0,SET
+              radiant#0,SET test value formatter: 1
      17947    record (14 = 3 [2] + 10 + 1)
-              rank#0,SET
+              rank#0,SET test value formatter: 2
      17961    record (14 = 3 [4] + 10 + 1)
-              rankly#0,SET
+              rankly#0,SET test value formatter: 1
      17975    record (14 = 3 [2] + 10 + 1)
-              rate#0,SET
+              rate#0,SET test value formatter: 1
      17989    record (17 = 3 [3] + 13 + 1)
-              ratified#0,SET
+              ratified#0,SET test value formatter: 1
      18006    record (13 = 3 [1] + 9 + 1)
-              re#0,SET
+              re#0,SET test value formatter: 2
      18019    record (17 = 3 [2] + 13 + 1)
-              reaches#0,SET
+              reaches#0,SET test value formatter: 1
      18036    record (13 = 3 [3] + 9 + 1)
-              rear#0,SET
+              rear#0,SET test value formatter: 1
      18049    record (15 = 3 [3] + 11 + 1)
-              reason#0,SET
+              reason#0,SET test value formatter: 5
      18064    record (16 = 3 [2] + 12 + 1)
-              rebels#0,SET
+              rebels#0,SET test value formatter: 1
      18080    record (18 = 3 [2] + 14 + 1)
-              reckless#0,SET
+              reckless#0,SET test value formatter: 1
      18098    record (17 = 3 [4] + 13 + 1)
-              reckoning#0,SET
+              reckoning#0,SET test value formatter: 1
      18115    record (13 = 3 [4] + 9 + 1)
-              recks#0,SET
+              recks#0,SET test value formatter: 1
      18128    record (19 = 3 [0] + 15 + 1) [restart]
-              records#0,SET
+              records#0,SET test value formatter: 1
      18147    record (15 = 3 [4] + 11 + 1)
-              recover#0,SET
+              recover#0,SET test value formatter: 1
      18162    record (13 = 3 [2] + 9 + 1)
-              red#0,SET
+              red#0,SET test value formatter: 1
      18175    record (13 = 3 [3] + 9 + 1)
-              rede#0,SET
+              rede#0,SET test value formatter: 1
      18188    record (15 = 3 [2] + 11 + 1)
-              reels#0,SET
+              reels#0,SET test value formatter: 1
      18203    record (16 = 3 [2] + 12 + 1)
-              relief#0,SET
+              relief#0,SET test value formatter: 1
      18219    record (15 = 3 [5] + 11 + 1)
-              relieved#0,SET
+              relieved#0,SET test value formatter: 1
      18234    record (16 = 3 [2] + 12 + 1)
-              remain#0,SET
+              remain#0,SET test value formatter: 1
      18250    record (17 = 3 [3] + 13 + 1)
-              remember#0,SET
+              remember#0,SET test value formatter: 6
      18267    record (17 = 3 [6] + 13 + 1)
-              remembrance#0,SET
+              remembrance#0,SET test value formatter: 1
      18284    record (15 = 3 [3] + 11 + 1)
-              remove#0,SET
+              remove#0,SET test value formatter: 1
      18299    record (13 = 3 [6] + 9 + 1)
-              removed#0,SET
+              removed#0,SET test value formatter: 1
      18312    record (16 = 3 [2] + 12 + 1)
-              render#0,SET
+              render#0,SET test value formatter: 1
      18328    record (15 = 3 [2] + 11 + 1)
-              reply#0,SET
+              reply#0,SET test value formatter: 1
      18343    [restart 16350]
      18347    [restart 16605]
      18351    [restart 16855]
@@ -2531,271 +2531,271 @@ h.no-compression.two_level_index.sst
      18371    [restart 18128]
      18384  data (2040)
      18384    record (18 = 3 [0] + 14 + 1) [restart]
-              report#0,SET
+              report#0,SET test value formatter: 1
      18402    record (17 = 3 [2] + 13 + 1)
-              request#0,SET
+              request#0,SET test value formatter: 1
      18419    record (15 = 3 [4] + 11 + 1)
-              requite#0,SET
+              requite#0,SET test value formatter: 1
      18434    record (17 = 3 [2] + 13 + 1)
-              reserve#0,SET
+              reserve#0,SET test value formatter: 1
      18451    record (18 = 3 [3] + 14 + 1)
-              resolutes#0,SET
+              resolutes#0,SET test value formatter: 1
      18469    record (14 = 3 [5] + 10 + 1)
-              resolve#0,SET
+              resolve#0,SET test value formatter: 1
      18483    record (13 = 3 [3] + 9 + 1)
-              rest#0,SET
+              rest#0,SET test value formatter: 2
      18496    record (20 = 3 [2] + 16 + 1)
-              retrograde#0,SET
+              retrograde#0,SET test value formatter: 1
      18516    record (15 = 3 [3] + 11 + 1)
-              return#0,SET
+              return#0,SET test value formatter: 2
      18531    record (16 = 3 [2] + 12 + 1)
-              reveal#0,SET
+              reveal#0,SET test value formatter: 1
      18547    record (13 = 3 [4] + 9 + 1)
-              revel#0,SET
+              revel#0,SET test value formatter: 1
      18560    record (15 = 3 [4] + 11 + 1)
-              revenge#0,SET
+              revenge#0,SET test value formatter: 3
      18575    record (16 = 3 [3] + 12 + 1)
-              revisit#0,SET
+              revisit#0,SET test value formatter: 1
      18591    record (18 = 3 [1] + 14 + 1)
-              rhenish#0,SET
+              rhenish#0,SET test value formatter: 1
      18609    record (15 = 3 [1] + 11 + 1)
-              rich#0,SET
+              rich#0,SET test value formatter: 1
      18624    record (13 = 3 [2] + 9 + 1)
-              rid#0,SET
+              rid#0,SET test value formatter: 1
      18637    record (17 = 3 [0] + 13 + 1) [restart]
-              right#0,SET
+              right#0,SET test value formatter: 3
      18654    record (14 = 3 [2] + 10 + 1)
-              rise#0,SET
+              rise#0,SET test value formatter: 1
      18668    record (16 = 3 [2] + 12 + 1)
-              rivals#0,SET
+              rivals#0,SET test value formatter: 1
      18684    record (14 = 3 [3] + 10 + 1)
-              river#0,SET
+              river#0,SET test value formatter: 1
      18698    record (15 = 3 [1] + 11 + 1)
-              roar#0,SET
+              roar#0,SET test value formatter: 1
      18713    record (16 = 3 [2] + 12 + 1)
-              romage#0,SET
+              romage#0,SET test value formatter: 1
      18729    record (13 = 3 [4] + 9 + 1)
-              roman#0,SET
+              roman#0,SET test value formatter: 1
      18742    record (13 = 3 [3] + 9 + 1)
-              rome#0,SET
+              rome#0,SET test value formatter: 1
      18755    record (14 = 3 [2] + 10 + 1)
-              room#0,SET
+              room#0,SET test value formatter: 2
      18769    record (14 = 3 [3] + 10 + 1)
-              roots#0,SET
+              roots#0,SET test value formatter: 1
      18783    record (16 = 3 [2] + 12 + 1)
-              rotten#0,SET
+              rotten#0,SET test value formatter: 1
      18799    record (17 = 3 [2] + 13 + 1)
-              roughly#0,SET
+              roughly#0,SET test value formatter: 1
      18816    record (14 = 3 [3] + 10 + 1)
-              rouse#0,SET
+              rouse#0,SET test value formatter: 2
      18830    record (15 = 3 [2] + 11 + 1)
-              royal#0,SET
+              royal#0,SET test value formatter: 2
      18845    record (16 = 3 [1] + 12 + 1)
-              ruled#0,SET
+              ruled#0,SET test value formatter: 1
      18861    record (17 = 3 [2] + 13 + 1)
-              running#0,SET
+              running#0,SET test value formatter: 1
      18878    record (18 = 3 [0] + 14 + 1) [restart]
-              russet#0,SET
+              russet#0,SET test value formatter: 1
      18896    record (14 = 3 [0] + 9 + 2)
-              s#0,SET
+              s#0,SET test value formatter: 39
      18910    record (16 = 3 [1] + 12 + 1)
-              sable#0,SET
+              sable#0,SET test value formatter: 1
      18926    record (16 = 3 [2] + 12 + 1)
-              safety#0,SET
+              safety#0,SET test value formatter: 2
      18942    record (14 = 3 [2] + 10 + 1)
-              said#0,SET
+              said#0,SET test value formatter: 3
      18956    record (13 = 3 [3] + 9 + 1)
-              sail#0,SET
+              sail#0,SET test value formatter: 1
      18969    record (14 = 3 [3] + 10 + 1)
-              saint#0,SET
+              saint#0,SET test value formatter: 1
      18983    record (14 = 3 [2] + 10 + 1)
-              salt#0,SET
+              salt#0,SET test value formatter: 1
      18997    record (14 = 3 [2] + 10 + 1)
-              same#0,SET
+              same#0,SET test value formatter: 5
      19011    record (20 = 3 [2] + 16 + 1)
-              sanctified#0,SET
+              sanctified#0,SET test value formatter: 1
      19031    record (14 = 3 [2] + 10 + 1)
-              sate#0,SET
+              sate#0,SET test value formatter: 1
      19045    record (14 = 3 [3] + 10 + 1)
-              satyr#0,SET
+              satyr#0,SET test value formatter: 1
      19059    record (17 = 3 [2] + 13 + 1)
-              saviour#0,SET
+              saviour#0,SET test value formatter: 1
      19076    record (13 = 3 [2] + 9 + 1)
-              saw#0,SET
+              saw#0,SET test value formatter: 6
      19089    record (13 = 3 [3] + 9 + 1)
-              saws#0,SET
+              saws#0,SET test value formatter: 1
      19102    record (14 = 3 [2] + 9 + 2)
-              say#0,SET
+              say#0,SET test value formatter: 11
      19116    record (18 = 3 [0] + 14 + 1) [restart]
-              saying#0,SET
+              saying#0,SET test value formatter: 1
      19134    record (13 = 3 [3] + 9 + 1)
-              says#0,SET
+              says#0,SET test value formatter: 3
      19147    record (16 = 3 [1] + 12 + 1)
-              scale#0,SET
+              scale#0,SET test value formatter: 1
      19163    record (16 = 3 [3] + 12 + 1)
-              scandal#0,SET
+              scandal#0,SET test value formatter: 1
      19179    record (15 = 3 [4] + 11 + 1)
-              scanter#0,SET
+              scanter#0,SET test value formatter: 1
      19194    record (15 = 3 [3] + 11 + 1)
-              scapes#0,SET
+              scapes#0,SET test value formatter: 1
      19209    record (17 = 3 [3] + 13 + 1)
-              scarcely#0,SET
+              scarcely#0,SET test value formatter: 1
      19226    record (15 = 3 [2] + 11 + 1)
-              scene#0,SET
+              scene#0,SET test value formatter: 5
      19241    record (13 = 3 [4] + 9 + 1)
-              scent#0,SET
+              scent#0,SET test value formatter: 1
      19254    record (17 = 3 [2] + 13 + 1)
-              scholar#0,SET
+              scholar#0,SET test value formatter: 1
      19271    record (13 = 3 [7] + 9 + 1)
-              scholars#0,SET
+              scholars#0,SET test value formatter: 1
      19284    record (14 = 3 [4] + 10 + 1)
-              school#0,SET
+              school#0,SET test value formatter: 1
      19298    record (15 = 3 [2] + 11 + 1)
-              scope#0,SET
+              scope#0,SET test value formatter: 2
      19313    record (14 = 3 [1] + 10 + 1)
-              sea#0,SET
+              sea#0,SET test value formatter: 3
      19327    record (13 = 3 [3] + 9 + 1)
-              seal#0,SET
+              seal#0,SET test value formatter: 2
      19340    record (15 = 3 [3] + 11 + 1)
-              season#0,SET
+              season#0,SET test value formatter: 4
      19355    record (16 = 3 [0] + 12 + 1) [restart]
-              seat#0,SET
+              seat#0,SET test value formatter: 1
      19371    record (16 = 3 [2] + 12 + 1)
-              second#0,SET
+              second#0,SET test value formatter: 1
      19387    record (16 = 3 [3] + 12 + 1)
-              secrecy#0,SET
+              secrecy#0,SET test value formatter: 1
      19403    record (13 = 3 [5] + 9 + 1)
-              secret#0,SET
+              secret#0,SET test value formatter: 1
      19416    record (13 = 3 [6] + 9 + 1)
-              secrets#0,SET
+              secrets#0,SET test value formatter: 1
      19429    record (15 = 3 [3] + 11 + 1)
-              secure#0,SET
+              secure#0,SET test value formatter: 2
      19444    record (16 = 3 [2] + 12 + 1)
-              seduce#0,SET
+              seduce#0,SET test value formatter: 1
      19460    record (13 = 3 [2] + 9 + 1)
-              see#0,SET
+              see#0,SET test value formatter: 7
      19473    record (13 = 3 [3] + 9 + 1)
-              seed#0,SET
+              seed#0,SET test value formatter: 1
      19486    record (15 = 3 [3] + 11 + 1)
-              seeing#0,SET
+              seeing#0,SET test value formatter: 1
      19501    record (13 = 3 [3] + 9 + 1)
-              seek#0,SET
+              seek#0,SET test value formatter: 1
      19514    record (13 = 3 [3] + 9 + 1)
-              seem#0,SET
+              seem#0,SET test value formatter: 2
      19527    record (15 = 3 [4] + 11 + 1)
-              seeming#0,SET
+              seeming#0,SET test value formatter: 1
      19542    record (13 = 3 [4] + 9 + 1)
-              seems#0,SET
+              seems#0,SET test value formatter: 3
      19555    record (13 = 3 [3] + 9 + 1)
-              seen#0,SET
+              seen#0,SET test value formatter: 8
      19568    record (16 = 3 [2] + 12 + 1)
-              seized#0,SET
+              seized#0,SET test value formatter: 1
      19584    record (18 = 3 [0] + 14 + 1) [restart]
-              select#0,SET
+              select#0,SET test value formatter: 1
      19602    record (13 = 3 [3] + 9 + 1)
-              self#0,SET
+              self#0,SET test value formatter: 1
      19615    record (15 = 3 [2] + 11 + 1)
-              sense#0,SET
+              sense#0,SET test value formatter: 1
      19630    record (16 = 3 [4] + 12 + 1)
-              sensible#0,SET
+              sensible#0,SET test value formatter: 1
      19646    record (13 = 3 [3] + 9 + 1)
-              sent#0,SET
+              sent#0,SET test value formatter: 1
      19659    record (19 = 3 [2] + 15 + 1)
-              sepulchre#0,SET
+              sepulchre#0,SET test value formatter: 1
      19678    record (17 = 3 [2] + 13 + 1)
-              serious#0,SET
+              serious#0,SET test value formatter: 1
      19695    record (16 = 3 [3] + 12 + 1)
-              serpent#0,SET
+              serpent#0,SET test value formatter: 2
      19711    record (16 = 3 [3] + 12 + 1)
-              servant#0,SET
+              servant#0,SET test value formatter: 1
      19727    record (13 = 3 [7] + 9 + 1)
-              servants#0,SET
+              servants#0,SET test value formatter: 1
      19740    record (15 = 3 [4] + 11 + 1)
-              service#0,SET
+              service#0,SET test value formatter: 1
      19755    record (13 = 3 [2] + 9 + 1)
-              set#0,SET
+              set#0,SET test value formatter: 4
      19768    record (16 = 3 [1] + 12 + 1)
-              shake#0,SET
+              shake#0,SET test value formatter: 2
      19784    record (15 = 3 [3] + 10 + 2)
-              shall#0,SET
+              shall#0,SET test value formatter: 22
      19799    record (13 = 3 [4] + 9 + 1)
-              shalt#0,SET
+              shalt#0,SET test value formatter: 1
      19812    record (14 = 3 [3] + 10 + 1)
-              shame#0,SET
+              shame#0,SET test value formatter: 1
      19826    record (20 = 3 [0] + 16 + 1) [restart]
-              shameful#0,SET
+              shameful#0,SET test value formatter: 1
      19846    record (14 = 3 [3] + 10 + 1)
-              shape#0,SET
+              shape#0,SET test value formatter: 2
      19860    record (13 = 3 [5] + 9 + 1)
-              shapes#0,SET
+              shapes#0,SET test value formatter: 1
      19873    record (14 = 3 [3] + 10 + 1)
-              shark#0,SET
+              shark#0,SET test value formatter: 1
      19887    record (13 = 3 [2] + 9 + 1)
-              she#0,SET
+              she#0,SET test value formatter: 6
      19900    record (16 = 3 [3] + 12 + 1)
-              sheeted#0,SET
+              sheeted#0,SET test value formatter: 1
      19916    record (13 = 3 [5] + 9 + 1)
-              sheets#0,SET
+              sheets#0,SET test value formatter: 1
      19929    record (15 = 3 [2] + 11 + 1)
-              shift#0,SET
+              shift#0,SET test value formatter: 1
      19944    record (20 = 3 [3] + 16 + 1)
-              shipwrights#0,SET
+              shipwrights#0,SET test value formatter: 1
      19964    record (15 = 3 [2] + 11 + 1)
-              shoes#0,SET
+              shoes#0,SET test value formatter: 1
      19979    record (13 = 3 [3] + 9 + 1)
-              shot#0,SET
+              shot#0,SET test value formatter: 2
      19992    record (15 = 3 [3] + 11 + 1)
-              should#0,SET
+              should#0,SET test value formatter: 6
      20007    record (14 = 3 [6] + 10 + 1)
-              shoulder#0,SET
+              shoulder#0,SET test value formatter: 1
      20021    record (14 = 3 [6] + 10 + 1)
-              shouldst#0,SET
+              shouldst#0,SET test value formatter: 1
      20035    record (13 = 3 [3] + 9 + 1)
-              show#0,SET
+              show#0,SET test value formatter: 6
      20048    record (13 = 3 [4] + 9 + 1)
-              shows#0,SET
+              shows#0,SET test value formatter: 2
      20061    record (20 = 3 [0] + 16 + 1) [restart]
-              shrewdly#0,SET
+              shrewdly#0,SET test value formatter: 1
      20081    record (15 = 3 [3] + 11 + 1)
-              shrill#0,SET
+              shrill#0,SET test value formatter: 1
      20096    record (15 = 3 [3] + 11 + 1)
-              shrunk#0,SET
+              shrunk#0,SET test value formatter: 1
      20111    record (15 = 3 [1] + 11 + 1)
-              sick#0,SET
+              sick#0,SET test value formatter: 2
      20126    record (14 = 3 [2] + 10 + 1)
-              side#0,SET
+              side#0,SET test value formatter: 1
      20140    record (15 = 3 [2] + 11 + 1)
-              sight#0,SET
+              sight#0,SET test value formatter: 3
      20155    record (17 = 3 [2] + 13 + 1)
-              silence#0,SET
+              silence#0,SET test value formatter: 1
      20172    record (15 = 3 [3] + 11 + 1)
-              silver#0,SET
+              silver#0,SET test value formatter: 1
      20187    record (16 = 3 [2] + 12 + 1)
-              simple#0,SET
+              simple#0,SET test value formatter: 1
      20203    record (13 = 3 [2] + 9 + 1)
-              sin#0,SET
+              sin#0,SET test value formatter: 1
      20216    record (14 = 3 [3] + 10 + 1)
-              since#0,SET
+              since#0,SET test value formatter: 1
      20230    record (15 = 3 [3] + 11 + 1)
-              sinews#0,SET
+              sinews#0,SET test value formatter: 1
      20245    record (16 = 3 [3] + 12 + 1)
-              singeth#0,SET
+              singeth#0,SET test value formatter: 1
      20261    record (13 = 3 [2] + 9 + 1)
-              sir#0,SET
+              sir#0,SET test value formatter: 3
      20274    record (13 = 3 [3] + 9 + 1)
-              sirs#0,SET
+              sirs#0,SET test value formatter: 1
      20287    record (16 = 3 [2] + 12 + 1)
-              sister#0,SET
+              sister#0,SET test value formatter: 3
      20303    record (15 = 3 [0] + 11 + 1) [restart]
-              sit#0,SET
+              sit#0,SET test value formatter: 4
      20318    record (13 = 3 [3] + 9 + 1)
-              sits#0,SET
+              sits#0,SET test value formatter: 2
      20331    record (17 = 3 [1] + 13 + 1)
-              skirts#0,SET
+              skirts#0,SET test value formatter: 1
      20348    record (18 = 3 [1] + 14 + 1)
-              slander#0,SET
+              slander#0,SET test value formatter: 1
      20366    record (18 = 3 [3] + 14 + 1)
-              slaughter#0,SET
+              slaughter#0,SET test value formatter: 1
      20384    [restart 18384]
      20388    [restart 18637]
      20392    [restart 18878]
@@ -2807,269 +2807,269 @@ h.no-compression.two_level_index.sst
      20416    [restart 20303]
      20429  data (2030)
      20429    record (16 = 3 [0] + 12 + 1) [restart]
-              slay#0,SET
+              slay#0,SET test value formatter: 1
      20445    record (17 = 3 [2] + 13 + 1)
-              sledded#0,SET
+              sledded#0,SET test value formatter: 1
      20462    record (14 = 3 [3] + 10 + 1)
-              sleep#0,SET
+              sleep#0,SET test value formatter: 1
      20476    record (15 = 3 [5] + 11 + 1)
-              sleeping#0,SET
+              sleeping#0,SET test value formatter: 3
      20491    record (14 = 3 [2] + 10 + 1)
-              slow#0,SET
+              slow#0,SET test value formatter: 2
      20505    record (16 = 3 [1] + 12 + 1)
-              smile#0,SET
+              smile#0,SET test value formatter: 2
      20521    record (13 = 3 [5] + 9 + 1)
-              smiles#0,SET
+              smiles#0,SET test value formatter: 1
      20534    record (15 = 3 [4] + 11 + 1)
-              smiling#0,SET
+              smiling#0,SET test value formatter: 2
      20549    record (16 = 3 [2] + 12 + 1)
-              smooth#0,SET
+              smooth#0,SET test value formatter: 1
      20565    record (14 = 3 [3] + 10 + 1)
-              smote#0,SET
+              smote#0,SET test value formatter: 1
      20579    record (14 = 3 [1] + 9 + 2)
-              so#0,SET
+              so#0,SET test value formatter: 48
      20593    record (13 = 3 [2] + 9 + 1)
-              soe#0,SET
+              soe#0,SET test value formatter: 1
      20606    record (14 = 3 [2] + 10 + 1)
-              soft#0,SET
+              soft#0,SET test value formatter: 2
      20620    record (14 = 3 [2] + 10 + 1)
-              soil#0,SET
+              soil#0,SET test value formatter: 2
      20634    record (17 = 3 [2] + 13 + 1)
-              soldier#0,SET
+              soldier#0,SET test value formatter: 1
      20651    record (13 = 3 [7] + 9 + 1)
-              soldiers#0,SET
+              soldiers#0,SET test value formatter: 1
      20664    record (18 = 3 [0] + 14 + 1) [restart]
-              solemn#0,SET
+              solemn#0,SET test value formatter: 2
      20682    record (14 = 3 [3] + 10 + 1)
-              solid#0,SET
+              solid#0,SET test value formatter: 1
      20696    record (15 = 3 [2] + 10 + 2)
-              some#0,SET
+              some#0,SET test value formatter: 13
      20711    record (17 = 3 [4] + 13 + 1)
-              something#0,SET
+              something#0,SET test value formatter: 3
      20728    record (15 = 3 [5] + 11 + 1)
-              sometime#0,SET
+              sometime#0,SET test value formatter: 1
      20743    record (13 = 3 [8] + 9 + 1)
-              sometimes#0,SET
+              sometimes#0,SET test value formatter: 1
      20756    record (16 = 3 [4] + 12 + 1)
-              somewhat#0,SET
+              somewhat#0,SET test value formatter: 1
      20772    record (13 = 3 [2] + 9 + 1)
-              son#0,SET
+              son#0,SET test value formatter: 3
      20785    record (14 = 3 [3] + 10 + 1)
-              songs#0,SET
+              songs#0,SET test value formatter: 1
      20799    record (14 = 3 [2] + 10 + 1)
-              sore#0,SET
+              sore#0,SET test value formatter: 1
      20813    record (15 = 3 [3] + 11 + 1)
-              sorrow#0,SET
+              sorrow#0,SET test value formatter: 3
      20828    record (13 = 3 [4] + 9 + 1)
-              sorry#0,SET
+              sorry#0,SET test value formatter: 1
      20841    record (13 = 3 [3] + 9 + 1)
-              sort#0,SET
+              sort#0,SET test value formatter: 1
      20854    record (14 = 3 [2] + 10 + 1)
-              soul#0,SET
+              soul#0,SET test value formatter: 8
      20868    record (13 = 3 [4] + 9 + 1)
-              souls#0,SET
+              souls#0,SET test value formatter: 1
      20881    record (14 = 3 [3] + 10 + 1)
-              sound#0,SET
+              sound#0,SET test value formatter: 2
      20895    record (20 = 3 [0] + 16 + 1) [restart]
-              sounding#0,SET
+              sounding#0,SET test value formatter: 1
      20915    record (15 = 3 [3] + 11 + 1)
-              source#0,SET
+              source#0,SET test value formatter: 1
      20930    record (21 = 3 [2] + 17 + 1)
-              sovereignty#0,SET
+              sovereignty#0,SET test value formatter: 1
      20951    record (17 = 3 [1] + 12 + 2)
-              speak#0,SET
+              speak#0,SET test value formatter: 27
      20968    record (15 = 3 [5] + 11 + 1)
-              speaking#0,SET
+              speaking#0,SET test value formatter: 1
      20983    record (15 = 3 [3] + 11 + 1)
-              speech#0,SET
+              speech#0,SET test value formatter: 1
      20998    record (13 = 3 [4] + 9 + 1)
-              speed#0,SET
+              speed#0,SET test value formatter: 1
      21011    record (14 = 3 [3] + 10 + 1)
-              spend#0,SET
+              spend#0,SET test value formatter: 1
      21025    record (17 = 3 [2] + 13 + 1)
-              spheres#0,SET
+              spheres#0,SET test value formatter: 1
      21042    record (16 = 3 [2] + 12 + 1)
-              spirit#0,SET
+              spirit#0,SET test value formatter: 8
      21058    record (13 = 3 [6] + 9 + 1)
-              spirits#0,SET
+              spirits#0,SET test value formatter: 1
      21071    record (14 = 3 [3] + 10 + 1)
-              spite#0,SET
+              spite#0,SET test value formatter: 1
      21085    record (15 = 3 [2] + 11 + 1)
-              spoke#0,SET
+              spoke#0,SET test value formatter: 1
      21100    record (16 = 3 [2] + 12 + 1)
-              spring#0,SET
+              spring#0,SET test value formatter: 2
      21116    record (14 = 3 [6] + 10 + 1)
-              springes#0,SET
+              springes#0,SET test value formatter: 1
      21130    record (17 = 3 [1] + 13 + 1)
-              squeak#0,SET
+              squeak#0,SET test value formatter: 1
      21147    record (14 = 3 [0] + 10 + 1) [restart]
-              st#0,SET
+              st#0,SET test value formatter: 4
      21161    record (15 = 3 [2] + 11 + 1)
-              stale#0,SET
+              stale#0,SET test value formatter: 1
      21176    record (13 = 3 [4] + 9 + 1)
-              stalk#0,SET
+              stalk#0,SET test value formatter: 1
      21189    record (13 = 3 [5] + 9 + 1)
-              stalks#0,SET
+              stalks#0,SET test value formatter: 1
      21202    record (14 = 3 [3] + 10 + 1)
-              stamp#0,SET
+              stamp#0,SET test value formatter: 1
      21216    record (14 = 3 [3] + 10 + 1)
-              stand#0,SET
+              stand#0,SET test value formatter: 5
      21230    record (13 = 3 [5] + 9 + 1)
-              stands#0,SET
+              stands#0,SET test value formatter: 1
      21243    record (13 = 3 [3] + 9 + 1)
-              star#0,SET
+              star#0,SET test value formatter: 3
      21256    record (13 = 3 [4] + 9 + 1)
-              stars#0,SET
+              stars#0,SET test value formatter: 2
      21269    record (13 = 3 [4] + 9 + 1)
-              start#0,SET
+              start#0,SET test value formatter: 1
      21282    record (14 = 3 [5] + 10 + 1)
-              started#0,SET
+              started#0,SET test value formatter: 1
      21296    record (14 = 3 [3] + 10 + 1)
-              state#0,SET
+              state#0,SET test value formatter: 8
      21310    record (14 = 3 [5] + 10 + 1)
-              stately#0,SET
+              stately#0,SET test value formatter: 1
      21324    record (15 = 3 [4] + 11 + 1)
-              station#0,SET
+              station#0,SET test value formatter: 1
      21339    record (13 = 3 [3] + 9 + 1)
-              stay#0,SET
+              stay#0,SET test value formatter: 7
      21352    record (15 = 3 [2] + 11 + 1)
-              steel#0,SET
+              steel#0,SET test value formatter: 2
      21367    record (17 = 3 [0] + 13 + 1) [restart]
-              steep#0,SET
+              steep#0,SET test value formatter: 1
      21384    record (17 = 3 [3] + 13 + 1)
-              sterling#0,SET
+              sterling#0,SET test value formatter: 1
      21401    record (17 = 3 [2] + 13 + 1)
-              stiffly#0,SET
+              stiffly#0,SET test value formatter: 1
      21418    record (14 = 3 [3] + 10 + 1)
-              still#0,SET
+              still#0,SET test value formatter: 8
      21432    record (14 = 3 [3] + 10 + 1)
-              sting#0,SET
+              sting#0,SET test value formatter: 2
      21446    record (13 = 3 [3] + 9 + 1)
-              stir#0,SET
+              stir#0,SET test value formatter: 2
      21459    record (16 = 3 [4] + 12 + 1)
-              stirring#0,SET
+              stirring#0,SET test value formatter: 1
      21475    record (15 = 3 [2] + 11 + 1)
-              stole#0,SET
+              stole#0,SET test value formatter: 1
      21490    record (16 = 3 [3] + 12 + 1)
-              stomach#0,SET
+              stomach#0,SET test value formatter: 1
      21506    record (14 = 3 [3] + 10 + 1)
-              stood#0,SET
+              stood#0,SET test value formatter: 2
      21520    record (13 = 3 [3] + 9 + 1)
-              stop#0,SET
+              stop#0,SET test value formatter: 1
      21533    record (14 = 3 [3] + 10 + 1)
-              story#0,SET
+              story#0,SET test value formatter: 1
      21547    record (17 = 3 [2] + 13 + 1)
-              strange#0,SET
+              strange#0,SET test value formatter: 6
      21564    record (13 = 3 [7] + 9 + 1)
-              stranger#0,SET
+              stranger#0,SET test value formatter: 1
      21577    record (16 = 3 [3] + 12 + 1)
-              streets#0,SET
+              streets#0,SET test value formatter: 1
      21593    record (15 = 3 [3] + 11 + 1)
-              strict#0,SET
+              strict#0,SET test value formatter: 1
      21608    record (18 = 3 [0] + 14 + 1) [restart]
-              strike#0,SET
+              strike#0,SET test value formatter: 2
      21626    record (16 = 3 [3] + 12 + 1)
-              strokes#0,SET
+              strokes#0,SET test value formatter: 1
      21642    record (14 = 3 [4] + 10 + 1)
-              strong#0,SET
+              strong#0,SET test value formatter: 1
      21656    record (15 = 3 [3] + 11 + 1)
-              struck#0,SET
+              struck#0,SET test value formatter: 2
      21671    record (22 = 3 [2] + 18 + 1)
-              stubbornness#0,SET
+              stubbornness#0,SET test value formatter: 1
      21693    record (16 = 3 [3] + 12 + 1)
-              student#0,SET
+              student#0,SET test value formatter: 1
      21709    record (14 = 3 [3] + 10 + 1)
-              stung#0,SET
+              stung#0,SET test value formatter: 1
      21723    record (18 = 3 [1] + 14 + 1)
-              subject#0,SET
+              subject#0,SET test value formatter: 3
      21741    record (18 = 3 [3] + 14 + 1)
-              substance#0,SET
+              substance#0,SET test value formatter: 1
      21759    record (15 = 3 [2] + 10 + 2)
-              such#0,SET
+              such#0,SET test value formatter: 10
      21774    record (16 = 3 [2] + 12 + 1)
-              sudden#0,SET
+              sudden#0,SET test value formatter: 1
      21790    record (14 = 3 [2] + 10 + 1)
-              suit#0,SET
+              suit#0,SET test value formatter: 1
      21804    record (13 = 3 [4] + 9 + 1)
-              suits#0,SET
+              suits#0,SET test value formatter: 3
      21817    record (20 = 3 [2] + 16 + 1)
-              sulphurous#0,SET
+              sulphurous#0,SET test value formatter: 1
      21837    record (16 = 3 [2] + 12 + 1)
-              summit#0,SET
+              summit#0,SET test value formatter: 1
      21853    record (15 = 3 [4] + 11 + 1)
-              summons#0,SET
+              summons#0,SET test value formatter: 1
      21868    record (15 = 3 [0] + 11 + 1) [restart]
-              sun#0,SET
+              sun#0,SET test value formatter: 2
      21883    record (15 = 3 [3] + 11 + 1)
-              sunday#0,SET
+              sunday#0,SET test value formatter: 1
      21898    record (20 = 3 [2] + 16 + 1)
-              suppliance#0,SET
+              suppliance#0,SET test value formatter: 1
      21918    record (16 = 3 [4] + 12 + 1)
-              supposal#0,SET
+              supposal#0,SET test value formatter: 1
      21934    record (16 = 3 [4] + 12 + 1)
-              suppress#0,SET
+              suppress#0,SET test value formatter: 1
      21950    record (14 = 3 [2] + 10 + 1)
-              sure#0,SET
+              sure#0,SET test value formatter: 1
      21964    record (18 = 3 [3] + 14 + 1)
-              surprised#0,SET
+              surprised#0,SET test value formatter: 1
      21982    record (18 = 3 [3] + 14 + 1)
-              surrender#0,SET
+              surrender#0,SET test value formatter: 1
      22000    record (17 = 3 [3] + 13 + 1)
-              survivor#0,SET
+              survivor#0,SET test value formatter: 1
      22017    record (21 = 3 [2] + 17 + 1)
-              suspiration#0,SET
+              suspiration#0,SET test value formatter: 1
      22038    record (16 = 3 [3] + 12 + 1)
-              sustain#0,SET
+              sustain#0,SET test value formatter: 1
      22054    record (21 = 3 [1] + 17 + 1)
-              swaggering#0,SET
+              swaggering#0,SET test value formatter: 1
      22075    record (16 = 3 [2] + 11 + 2)
-              swear#0,SET
+              swear#0,SET test value formatter: 10
      22091    record (14 = 3 [4] + 10 + 1)
-              sweaty#0,SET
+              sweaty#0,SET test value formatter: 1
      22105    record (14 = 3 [3] + 10 + 1)
-              sweep#0,SET
+              sweep#0,SET test value formatter: 1
      22119    record (13 = 3 [4] + 9 + 1)
-              sweet#0,SET
+              sweet#0,SET test value formatter: 2
      22132    record (17 = 3 [0] + 13 + 1) [restart]
-              swift#0,SET
+              swift#0,SET test value formatter: 2
      22149    record (16 = 3 [3] + 12 + 1)
-              swinish#0,SET
+              swinish#0,SET test value formatter: 1
      22165    record (15 = 3 [2] + 11 + 1)
-              sword#0,SET
+              sword#0,SET test value formatter: 5
      22180    record (13 = 3 [4] + 9 + 1)
-              sworn#0,SET
+              sworn#0,SET test value formatter: 2
      22193    record (14 = 3 [0] + 9 + 2)
-              t#0,SET
+              t#0,SET test value formatter: 18
      22207    record (13 = 3 [1] + 9 + 1)
-              ta#0,SET
+              ta#0,SET test value formatter: 1
      22220    record (15 = 3 [2] + 11 + 1)
-              table#0,SET
+              table#0,SET test value formatter: 1
      22235    record (13 = 3 [5] + 9 + 1)
-              tables#0,SET
+              tables#0,SET test value formatter: 2
      22248    record (15 = 3 [2] + 11 + 1)
-              taint#0,SET
+              taint#0,SET test value formatter: 1
      22263    record (15 = 3 [2] + 10 + 2)
-              take#0,SET
+              take#0,SET test value formatter: 10
      22278    record (13 = 3 [4] + 9 + 1)
-              taken#0,SET
+              taken#0,SET test value formatter: 1
      22291    record (13 = 3 [4] + 9 + 1)
-              takes#0,SET
+              takes#0,SET test value formatter: 3
      22304    record (14 = 3 [2] + 10 + 1)
-              tale#0,SET
+              tale#0,SET test value formatter: 1
      22318    record (13 = 3 [3] + 9 + 1)
-              talk#0,SET
+              talk#0,SET test value formatter: 1
      22331    record (14 = 3 [2] + 10 + 1)
-              task#0,SET
+              task#0,SET test value formatter: 1
      22345    record (13 = 3 [2] + 9 + 1)
-              tax#0,SET
+              tax#0,SET test value formatter: 1
      22358    record (17 = 3 [0] + 13 + 1) [restart]
-              teach#0,SET
+              teach#0,SET test value formatter: 2
      22375    record (14 = 3 [3] + 10 + 1)
-              tears#0,SET
+              tears#0,SET test value formatter: 2
      22389    record (14 = 3 [2] + 10 + 1)
-              tell#0,SET
+              tell#0,SET test value formatter: 9
      22403    record (16 = 3 [2] + 12 + 1)
-              temple#0,SET
+              temple#0,SET test value formatter: 1
      22419    [restart 20429]
      22423    [restart 20664]
      22427    [restart 20895]
@@ -3081,261 +3081,261 @@ h.no-compression.two_level_index.sst
      22451    [restart 22358]
      22464  data (2035)
      22464    record (17 = 3 [0] + 13 + 1) [restart]
-              tempt#0,SET
+              tempt#0,SET test value formatter: 1
      22481    record (17 = 3 [2] + 13 + 1)
-              tenable#0,SET
+              tenable#0,SET test value formatter: 1
      22498    record (18 = 3 [4] + 14 + 1)
-              tenantless#0,SET
+              tenantless#0,SET test value formatter: 1
      22516    record (13 = 3 [3] + 9 + 1)
-              tend#0,SET
+              tend#0,SET test value formatter: 1
      22529    record (14 = 3 [4] + 10 + 1)
-              tender#0,SET
+              tender#0,SET test value formatter: 2
      22543    record (13 = 3 [6] + 9 + 1)
-              tenders#0,SET
+              tenders#0,SET test value formatter: 3
      22556    record (14 = 3 [2] + 10 + 1)
-              term#0,SET
+              term#0,SET test value formatter: 2
      22570    record (13 = 3 [4] + 9 + 1)
-              terms#0,SET
+              terms#0,SET test value formatter: 2
      22583    record (16 = 3 [2] + 12 + 1)
-              tether#0,SET
+              tether#0,SET test value formatter: 1
      22599    record (15 = 3 [3] + 11 + 1)
-              tetter#0,SET
+              tetter#0,SET test value formatter: 1
      22614    record (16 = 3 [1] + 11 + 2)
-              than#0,SET
+              than#0,SET test value formatter: 15
      22630    record (14 = 3 [4] + 10 + 1)
-              thanks#0,SET
+              thanks#0,SET test value formatter: 2
      22644    record (14 = 3 [3] + 9 + 2)
-              that#0,SET
+              that#0,SET test value formatter: 83
      22658    record (13 = 3 [3] + 9 + 1)
-              thaw#0,SET
+              thaw#0,SET test value formatter: 1
      22671    record (15 = 3 [2] + 9 + 3)
-              the#0,SET
+              the#0,SET test value formatter: 237
      22686    record (14 = 3 [3] + 9 + 2)
-              thee#0,SET
+              thee#0,SET test value formatter: 23
      22700    record (18 = 3 [0] + 13 + 2) [restart]
-              their#0,SET
+              their#0,SET test value formatter: 10
      22718    record (14 = 3 [3] + 9 + 2)
-              them#0,SET
+              them#0,SET test value formatter: 10
      22732    record (13 = 3 [4] + 9 + 1)
-              theme#0,SET
+              theme#0,SET test value formatter: 1
      22745    record (14 = 3 [3] + 9 + 2)
-              then#0,SET
+              then#0,SET test value formatter: 15
      22759    record (15 = 3 [3] + 10 + 2)
-              there#0,SET
+              there#0,SET test value formatter: 18
      22774    record (16 = 3 [5] + 12 + 1)
-              therefore#0,SET
+              therefore#0,SET test value formatter: 4
      22790    record (14 = 3 [5] + 10 + 1)
-              thereto#0,SET
+              thereto#0,SET test value formatter: 1
      22804    record (15 = 3 [3] + 10 + 2)
-              these#0,SET
+              these#0,SET test value formatter: 13
      22819    record (14 = 3 [3] + 10 + 1)
-              thews#0,SET
+              thews#0,SET test value formatter: 1
      22833    record (14 = 3 [3] + 9 + 2)
-              they#0,SET
+              they#0,SET test value formatter: 14
      22847    record (14 = 3 [2] + 10 + 1)
-              thin#0,SET
+              thin#0,SET test value formatter: 1
      22861    record (13 = 3 [4] + 9 + 1)
-              thine#0,SET
+              thine#0,SET test value formatter: 3
      22874    record (13 = 3 [4] + 9 + 1)
-              thing#0,SET
+              thing#0,SET test value formatter: 6
      22887    record (13 = 3 [5] + 9 + 1)
-              things#0,SET
+              things#0,SET test value formatter: 3
      22900    record (14 = 3 [4] + 9 + 2)
-              think#0,SET
+              think#0,SET test value formatter: 16
      22914    record (15 = 3 [5] + 11 + 1)
-              thinking#0,SET
+              thinking#0,SET test value formatter: 1
      22929    record (17 = 3 [0] + 13 + 1) [restart]
-              third#0,SET
+              third#0,SET test value formatter: 1
      22946    record (14 = 3 [3] + 9 + 2)
-              this#0,SET
+              this#0,SET test value formatter: 67
      22960    record (16 = 3 [2] + 12 + 1)
-              thorns#0,SET
+              thorns#0,SET test value formatter: 1
      22976    record (13 = 3 [5] + 9 + 1)
-              thorny#0,SET
+              thorny#0,SET test value formatter: 1
      22989    record (14 = 3 [3] + 10 + 1)
-              those#0,SET
+              those#0,SET test value formatter: 7
      23003    record (14 = 3 [3] + 9 + 2)
-              thou#0,SET
+              thou#0,SET test value formatter: 28
      23017    record (15 = 3 [4] + 10 + 2)
-              though#0,SET
+              though#0,SET test value formatter: 10
      23032    record (13 = 3 [6] + 9 + 1)
-              thought#0,SET
+              thought#0,SET test value formatter: 2
      23045    record (13 = 3 [7] + 9 + 1)
-              thoughts#0,SET
+              thoughts#0,SET test value formatter: 4
      23058    record (16 = 3 [2] + 12 + 1)
-              thrice#0,SET
+              thrice#0,SET test value formatter: 1
      23074    record (14 = 3 [4] + 10 + 1)
-              thrift#0,SET
+              thrift#0,SET test value formatter: 2
      23088    record (15 = 3 [3] + 11 + 1)
-              throat#0,SET
+              throat#0,SET test value formatter: 1
      23103    record (14 = 3 [4] + 10 + 1)
-              throne#0,SET
+              throne#0,SET test value formatter: 2
      23117    record (15 = 3 [4] + 11 + 1)
-              through#0,SET
+              through#0,SET test value formatter: 3
      23132    record (13 = 3 [4] + 9 + 1)
-              throw#0,SET
+              throw#0,SET test value formatter: 1
      23145    record (17 = 3 [2] + 13 + 1)
-              thunder#0,SET
+              thunder#0,SET test value formatter: 1
      23162    record (16 = 3 [0] + 12 + 1) [restart]
-              thus#0,SET
+              thus#0,SET test value formatter: 9
      23178    record (14 = 3 [2] + 9 + 2)
-              thy#0,SET
+              thy#0,SET test value formatter: 36
      23192    record (16 = 3 [3] + 12 + 1)
-              thyself#0,SET
+              thyself#0,SET test value formatter: 1
      23208    record (15 = 3 [1] + 11 + 1)
-              till#0,SET
+              till#0,SET test value formatter: 4
      23223    record (15 = 3 [2] + 10 + 2)
-              time#0,SET
+              time#0,SET test value formatter: 10
      23238    record (13 = 3 [4] + 9 + 1)
-              times#0,SET
+              times#0,SET test value formatter: 1
      23251    record (14 = 3 [2] + 9 + 2)
-              tis#0,SET
+              tis#0,SET test value formatter: 22
      23265    record (15 = 3 [1] + 9 + 3)
-              to#0,SET
+              to#0,SET test value formatter: 192
      23280    record (13 = 3 [2] + 9 + 1)
-              toe#0,SET
+              toe#0,SET test value formatter: 1
      23293    record (18 = 3 [2] + 14 + 1)
-              together#0,SET
+              together#0,SET test value formatter: 7
      23311    record (15 = 3 [2] + 11 + 1)
-              toils#0,SET
+              toils#0,SET test value formatter: 1
      23326    record (14 = 3 [2] + 10 + 1)
-              told#0,SET
+              told#0,SET test value formatter: 2
      23340    record (16 = 3 [2] + 12 + 1)
-              tongue#0,SET
+              tongue#0,SET test value formatter: 4
      23356    record (13 = 3 [2] + 9 + 1)
-              too#0,SET
+              too#0,SET test value formatter: 9
      23369    record (13 = 3 [2] + 9 + 1)
-              top#0,SET
+              top#0,SET test value formatter: 1
      23382    record (20 = 3 [2] + 16 + 1)
-              tormenting#0,SET
+              tormenting#0,SET test value formatter: 1
      23402    record (20 = 3 [0] + 16 + 1) [restart]
-              touching#0,SET
+              touching#0,SET test value formatter: 3
      23422    record (16 = 3 [2] + 12 + 1)
-              toward#0,SET
+              toward#0,SET test value formatter: 4
      23438    record (13 = 3 [2] + 9 + 1)
-              toy#0,SET
+              toy#0,SET test value formatter: 1
      23451    record (13 = 3 [3] + 9 + 1)
-              toys#0,SET
+              toys#0,SET test value formatter: 1
      23464    record (19 = 3 [1] + 15 + 1)
-              traduced#0,SET
+              traduced#0,SET test value formatter: 1
      23483    record (16 = 3 [3] + 12 + 1)
-              tragedy#0,SET
+              tragedy#0,SET test value formatter: 1
      23499    record (15 = 3 [3] + 11 + 1)
-              trains#0,SET
+              trains#0,SET test value formatter: 1
      23514    record (18 = 3 [4] + 14 + 1)
-              traitorous#0,SET
+              traitorous#0,SET test value formatter: 1
      23532    record (18 = 3 [3] + 14 + 1)
-              trappings#0,SET
+              trappings#0,SET test value formatter: 1
      23550    record (16 = 3 [2] + 12 + 1)
-              treads#0,SET
+              treads#0,SET test value formatter: 1
      23566    record (16 = 3 [4] + 12 + 1)
-              treasure#0,SET
+              treasure#0,SET test value formatter: 2
      23582    record (16 = 3 [3] + 12 + 1)
-              tremble#0,SET
+              tremble#0,SET test value formatter: 1
      23598    record (15 = 3 [2] + 11 + 1)
-              tried#0,SET
+              tried#0,SET test value formatter: 1
      23613    record (17 = 3 [3] + 13 + 1)
-              trifling#0,SET
+              trifling#0,SET test value formatter: 1
      23630    record (16 = 3 [3] + 12 + 1)
-              triumph#0,SET
+              triumph#0,SET test value formatter: 1
      23646    record (16 = 3 [3] + 12 + 1)
-              trivial#0,SET
+              trivial#0,SET test value formatter: 1
      23662    record (19 = 3 [0] + 15 + 1) [restart]
-              trouble#0,SET
+              trouble#0,SET test value formatter: 1
      23681    record (13 = 3 [7] + 9 + 1)
-              troubles#0,SET
+              troubles#0,SET test value formatter: 1
      23694    record (16 = 3 [2] + 12 + 1)
-              truant#0,SET
+              truant#0,SET test value formatter: 2
      23710    record (13 = 3 [3] + 9 + 1)
-              true#0,SET
+              true#0,SET test value formatter: 5
      23723    record (17 = 3 [4] + 13 + 1)
-              truepenny#0,SET
+              truepenny#0,SET test value formatter: 1
      23740    record (14 = 3 [3] + 10 + 1)
-              truly#0,SET
+              truly#0,SET test value formatter: 1
      23754    record (16 = 3 [3] + 12 + 1)
-              trumpet#0,SET
+              trumpet#0,SET test value formatter: 2
      23770    record (13 = 3 [7] + 9 + 1)
-              trumpets#0,SET
+              trumpets#0,SET test value formatter: 1
      23783    record (18 = 3 [3] + 14 + 1)
-              truncheon#0,SET
+              truncheon#0,SET test value formatter: 1
      23801    record (16 = 3 [3] + 12 + 1)
-              truster#0,SET
+              truster#0,SET test value formatter: 1
      23817    record (14 = 3 [3] + 10 + 1)
-              truth#0,SET
+              truth#0,SET test value formatter: 2
      23831    record (15 = 3 [1] + 11 + 1)
-              tush#0,SET
+              tush#0,SET test value formatter: 2
      23846    record (17 = 3 [1] + 13 + 1)
-              twelve#0,SET
+              twelve#0,SET test value formatter: 3
      23863    record (14 = 3 [3] + 10 + 1)
-              twere#0,SET
+              twere#0,SET test value formatter: 1
      23877    record (15 = 3 [2] + 11 + 1)
-              twice#0,SET
+              twice#0,SET test value formatter: 2
      23892    record (14 = 3 [3] + 10 + 1)
-              twill#0,SET
+              twill#0,SET test value formatter: 2
      23906    record (17 = 3 [0] + 13 + 1) [restart]
-              twixt#0,SET
+              twixt#0,SET test value formatter: 1
      23923    record (13 = 3 [2] + 9 + 1)
-              two#0,SET
+              two#0,SET test value formatter: 5
      23936    record (18 = 3 [0] + 14 + 1)
-              ubique#0,SET
+              ubique#0,SET test value formatter: 1
      23954    record (17 = 3 [1] + 13 + 1)
-              unanel#0,SET
+              unanel#0,SET test value formatter: 1
      23971    record (15 = 3 [2] + 11 + 1)
-              uncle#0,SET
+              uncle#0,SET test value formatter: 5
      23986    record (17 = 3 [2] + 13 + 1)
-              undergo#0,SET
+              undergo#0,SET test value formatter: 1
      24003    record (17 = 3 [5] + 13 + 1)
-              understand#0,SET
+              understand#0,SET test value formatter: 1
      24020    record (15 = 3 [10] + 11 + 1)
-              understanding#0,SET
+              understanding#0,SET test value formatter: 2
      24035    record (21 = 3 [2] + 17 + 1)
-              uneffectual#0,SET
+              uneffectual#0,SET test value formatter: 1
      24056    record (19 = 3 [2] + 15 + 1)
-              unfledged#0,SET
+              unfledged#0,SET test value formatter: 1
      24075    record (15 = 3 [3] + 11 + 1)
-              unfold#0,SET
+              unfold#0,SET test value formatter: 3
      24090    record (16 = 3 [4] + 12 + 1)
-              unforced#0,SET
+              unforced#0,SET test value formatter: 1
      24106    record (18 = 3 [5] + 14 + 1)
-              unfortified#0,SET
+              unfortified#0,SET test value formatter: 1
      24124    record (20 = 3 [2] + 16 + 1)
-              ungracious#0,SET
+              ungracious#0,SET test value formatter: 1
      24144    record (16 = 3 [2] + 12 + 1)
-              unhand#0,SET
+              unhand#0,SET test value formatter: 1
      24160    record (15 = 3 [3] + 11 + 1)
-              unholy#0,SET
+              unholy#0,SET test value formatter: 1
      24175    record (20 = 3 [0] + 16 + 1) [restart]
-              unhousel#0,SET
+              unhousel#0,SET test value formatter: 1
      24195    record (20 = 3 [2] + 16 + 1)
-              unimproved#0,SET
+              unimproved#0,SET test value formatter: 1
      24215    record (17 = 3 [2] + 13 + 1)
-              unmanly#0,SET
+              unmanly#0,SET test value formatter: 1
      24232    record (14 = 3 [4] + 10 + 1)
-              unmask#0,SET
+              unmask#0,SET test value formatter: 1
      24246    record (15 = 3 [5] + 11 + 1)
-              unmaster#0,SET
+              unmaster#0,SET test value formatter: 1
      24261    record (14 = 3 [3] + 10 + 1)
-              unmix#0,SET
+              unmix#0,SET test value formatter: 1
      24275    record (19 = 3 [2] + 15 + 1)
-              unnatural#0,SET
+              unnatural#0,SET test value formatter: 2
      24294    record (22 = 3 [2] + 18 + 1)
-              unprevailing#0,SET
+              unprevailing#0,SET test value formatter: 1
      24316    record (20 = 3 [4] + 16 + 1)
-              unprofitable#0,SET
+              unprofitable#0,SET test value formatter: 1
      24336    record (21 = 3 [5] + 17 + 1)
-              unproportioned#0,SET
+              unproportioned#0,SET test value formatter: 1
      24357    record (21 = 3 [2] + 17 + 1)
-              unrighteous#0,SET
+              unrighteous#0,SET test value formatter: 1
      24378    record (18 = 3 [2] + 14 + 1)
-              unschool#0,SET
+              unschool#0,SET test value formatter: 1
      24396    record (17 = 3 [3] + 13 + 1)
-              unsifted#0,SET
+              unsifted#0,SET test value formatter: 1
      24413    record (14 = 3 [2] + 10 + 1)
-              unto#0,SET
+              unto#0,SET test value formatter: 4
      24427    record (18 = 3 [2] + 14 + 1)
-              unvalued#0,SET
+              unvalued#0,SET test value formatter: 1
      24445    record (18 = 3 [2] + 14 + 1)
-              unweeded#0,SET
+              unweeded#0,SET test value formatter: 1
      24463    [restart 22464]
      24467    [restart 22700]
      24471    [restart 22929]
@@ -3346,273 +3346,273 @@ h.no-compression.two_level_index.sst
      24491    [restart 24175]
      24504  data (2036)
      24504    record (15 = 3 [0] + 10 + 2) [restart]
-              up#0,SET
+              up#0,SET test value formatter: 10
      24519    record (19 = 3 [2] + 15 + 1)
-              uphoarded#0,SET
+              uphoarded#0,SET test value formatter: 1
      24538    record (15 = 3 [2] + 10 + 2)
-              upon#0,SET
+              upon#0,SET test value formatter: 18
      24553    record (14 = 3 [1] + 9 + 2)
-              us#0,SET
+              us#0,SET test value formatter: 19
      24567    record (13 = 3 [2] + 9 + 1)
-              use#0,SET
+              use#0,SET test value formatter: 1
      24580    record (13 = 3 [3] + 9 + 1)
-              uses#0,SET
+              uses#0,SET test value formatter: 1
      24593    record (15 = 3 [2] + 11 + 1)
-              usurp#0,SET
+              usurp#0,SET test value formatter: 1
      24608    record (13 = 3 [0] + 9 + 1)
-              v#0,SET
+              v#0,SET test value formatter: 1
      24621    record (17 = 3 [1] + 13 + 1)
-              vailed#0,SET
+              vailed#0,SET test value formatter: 1
      24638    record (13 = 3 [3] + 9 + 1)
-              vain#0,SET
+              vain#0,SET test value formatter: 1
      24651    record (17 = 3 [2] + 13 + 1)
-              valiant#0,SET
+              valiant#0,SET test value formatter: 2
      24668    record (16 = 3 [2] + 12 + 1)
-              vanish#0,SET
+              vanish#0,SET test value formatter: 1
      24684    record (19 = 3 [3] + 15 + 1)
-              vanquisher#0,SET
+              vanquisher#0,SET test value formatter: 1
      24703    record (14 = 3 [2] + 10 + 1)
-              vast#0,SET
+              vast#0,SET test value formatter: 1
      24717    record (15 = 3 [1] + 11 + 1)
-              very#0,SET
+              very#0,SET test value formatter: 9
      24732    record (15 = 3 [1] + 11 + 1)
-              vial#0,SET
+              vial#0,SET test value formatter: 1
      24747    record (19 = 3 [0] + 15 + 1) [restart]
-              vicious#0,SET
+              vicious#0,SET test value formatter: 1
      24766    record (16 = 3 [2] + 12 + 1)
-              vigour#0,SET
+              vigour#0,SET test value formatter: 1
      24782    record (14 = 3 [2] + 10 + 1)
-              vile#0,SET
+              vile#0,SET test value formatter: 1
      24796    record (16 = 3 [3] + 12 + 1)
-              villain#0,SET
+              villain#0,SET test value formatter: 5
      24812    record (18 = 3 [2] + 14 + 1)
-              violence#0,SET
+              violence#0,SET test value formatter: 2
      24830    record (13 = 3 [5] + 9 + 1)
-              violet#0,SET
+              violet#0,SET test value formatter: 1
      24843    record (16 = 3 [2] + 12 + 1)
-              virtue#0,SET
+              virtue#0,SET test value formatter: 3
      24859    record (13 = 3 [6] + 9 + 1)
-              virtues#0,SET
+              virtues#0,SET test value formatter: 1
      24872    record (15 = 3 [5] + 11 + 1)
-              virtuous#0,SET
+              virtuous#0,SET test value formatter: 1
      24887    record (16 = 3 [2] + 12 + 1)
-              visage#0,SET
+              visage#0,SET test value formatter: 1
      24903    record (15 = 3 [3] + 11 + 1)
-              vision#0,SET
+              vision#0,SET test value formatter: 1
      24918    record (13 = 3 [4] + 9 + 1)
-              visit#0,SET
+              visit#0,SET test value formatter: 2
      24931    record (16 = 3 [1] + 12 + 1)
-              voice#0,SET
+              voice#0,SET test value formatter: 5
      24947    record (19 = 3 [2] + 15 + 1)
-              voltimand#0,SET
+              voltimand#0,SET test value formatter: 4
      24966    record (15 = 3 [3] + 11 + 1)
-              volume#0,SET
+              volume#0,SET test value formatter: 1
      24981    record (13 = 3 [2] + 9 + 1)
-              vow#0,SET
+              vow#0,SET test value formatter: 1
      24994    record (16 = 3 [0] + 12 + 1) [restart]
-              vows#0,SET
+              vows#0,SET test value formatter: 3
      25010    record (17 = 3 [1] + 13 + 1)
-              vulgar#0,SET
+              vulgar#0,SET test value formatter: 2
      25027    record (16 = 3 [0] + 12 + 1)
-              wake#0,SET
+              wake#0,SET test value formatter: 1
      25043    record (14 = 3 [2] + 10 + 1)
-              walk#0,SET
+              walk#0,SET test value formatter: 6
      25057    record (13 = 3 [4] + 9 + 1)
-              walks#0,SET
+              walks#0,SET test value formatter: 1
      25070    record (15 = 3 [2] + 11 + 1)
-              wants#0,SET
+              wants#0,SET test value formatter: 1
      25085    record (13 = 3 [2] + 9 + 1)
-              war#0,SET
+              war#0,SET test value formatter: 1
      25098    record (16 = 3 [3] + 12 + 1)
-              warlike#0,SET
+              warlike#0,SET test value formatter: 2
      25114    record (16 = 3 [3] + 12 + 1)
-              warning#0,SET
+              warning#0,SET test value formatter: 1
      25130    record (16 = 3 [3] + 12 + 1)
-              warrant#0,SET
+              warrant#0,SET test value formatter: 1
      25146    record (13 = 3 [3] + 9 + 1)
-              wars#0,SET
+              wars#0,SET test value formatter: 1
      25159    record (13 = 3 [3] + 9 + 1)
-              wary#0,SET
+              wary#0,SET test value formatter: 1
      25172    record (14 = 3 [2] + 9 + 2)
-              was#0,SET
+              was#0,SET test value formatter: 17
      25186    record (16 = 3 [3] + 12 + 1)
-              wassail#0,SET
+              wassail#0,SET test value formatter: 1
      25202    record (16 = 3 [2] + 11 + 2)
-              watch#0,SET
+              watch#0,SET test value formatter: 12
      25218    record (15 = 3 [5] + 11 + 1)
-              watchman#0,SET
+              watchman#0,SET test value formatter: 1
      25233    record (17 = 3 [0] + 13 + 1) [restart]
-              waves#0,SET
+              waves#0,SET test value formatter: 3
      25250    record (15 = 3 [2] + 11 + 1)
-              waxes#0,SET
+              waxes#0,SET test value formatter: 2
      25265    record (13 = 3 [2] + 9 + 1)
-              way#0,SET
+              way#0,SET test value formatter: 2
      25278    record (13 = 3 [3] + 9 + 1)
-              ways#0,SET
+              ways#0,SET test value formatter: 1
      25291    record (14 = 3 [1] + 9 + 2)
-              we#0,SET
+              we#0,SET test value formatter: 34
      25305    record (14 = 3 [2] + 10 + 1)
-              weak#0,SET
+              weak#0,SET test value formatter: 1
      25319    record (14 = 3 [3] + 10 + 1)
-              wears#0,SET
+              wears#0,SET test value formatter: 1
      25333    record (13 = 3 [4] + 9 + 1)
-              weary#0,SET
+              weary#0,SET test value formatter: 1
      25346    record (17 = 3 [2] + 13 + 1)
-              wedding#0,SET
+              wedding#0,SET test value formatter: 1
      25363    record (14 = 3 [2] + 10 + 1)
-              weed#0,SET
+              weed#0,SET test value formatter: 1
      25377    record (13 = 3 [3] + 9 + 1)
-              week#0,SET
+              week#0,SET test value formatter: 1
      25390    record (15 = 3 [2] + 11 + 1)
-              weigh#0,SET
+              weigh#0,SET test value formatter: 2
      25405    record (15 = 3 [5] + 11 + 1)
-              weighing#0,SET
+              weighing#0,SET test value formatter: 1
      25420    record (17 = 3 [2] + 13 + 1)
-              welcome#0,SET
+              welcome#0,SET test value formatter: 3
      25437    record (14 = 3 [3] + 9 + 2)
-              well#0,SET
+              well#0,SET test value formatter: 14
      25451    record (14 = 3 [2] + 10 + 1)
-              went#0,SET
+              went#0,SET test value formatter: 1
      25465    record (16 = 3 [0] + 12 + 1) [restart]
-              were#0,SET
+              were#0,SET test value formatter: 3
      25481    record (14 = 3 [2] + 10 + 1)
-              west#0,SET
+              west#0,SET test value formatter: 1
      25495    record (16 = 3 [4] + 12 + 1)
-              westward#0,SET
+              westward#0,SET test value formatter: 1
      25511    record (16 = 3 [1] + 12 + 1)
-              wharf#0,SET
+              wharf#0,SET test value formatter: 1
      25527    record (14 = 3 [3] + 9 + 2)
-              what#0,SET
+              what#0,SET test value formatter: 42
      25541    record (18 = 3 [4] + 14 + 1)
-              whatsoever#0,SET
+              whatsoever#0,SET test value formatter: 1
      25559    record (14 = 3 [2] + 10 + 1)
-              when#0,SET
+              when#0,SET test value formatter: 8
      25573    record (14 = 3 [4] + 10 + 1)
-              whence#0,SET
+              whence#0,SET test value formatter: 1
      25587    record (14 = 3 [3] + 10 + 1)
-              where#0,SET
+              where#0,SET test value formatter: 9
      25601    record (16 = 3 [5] + 12 + 1)
-              wherefore#0,SET
+              wherefore#0,SET test value formatter: 1
      25617    record (14 = 3 [5] + 10 + 1)
-              wherein#0,SET
+              wherein#0,SET test value formatter: 4
      25631    record (14 = 3 [5] + 10 + 1)
-              whereof#0,SET
+              whereof#0,SET test value formatter: 2
      25645    record (16 = 3 [3] + 12 + 1)
-              whether#0,SET
+              whether#0,SET test value formatter: 1
      25661    record (16 = 3 [2] + 11 + 2)
-              which#0,SET
+              which#0,SET test value formatter: 16
      25677    record (14 = 3 [3] + 10 + 1)
-              while#0,SET
+              while#0,SET test value formatter: 2
      25691    record (13 = 3 [5] + 9 + 1)
-              whiles#0,SET
+              whiles#0,SET test value formatter: 1
      25704    record (18 = 3 [0] + 14 + 1) [restart]
-              whilst#0,SET
+              whilst#0,SET test value formatter: 1
      25722    record (17 = 3 [3] + 13 + 1)
-              whirling#0,SET
+              whirling#0,SET test value formatter: 1
      25739    record (16 = 3 [3] + 12 + 1)
-              whisper#0,SET
+              whisper#0,SET test value formatter: 1
      25755    record (13 = 3 [2] + 9 + 1)
-              who#0,SET
+              who#0,SET test value formatter: 8
      25768    record (14 = 3 [3] + 10 + 1)
-              whole#0,SET
+              whole#0,SET test value formatter: 3
      25782    record (16 = 3 [5] + 12 + 1)
-              wholesome#0,SET
+              wholesome#0,SET test value formatter: 2
      25798    record (14 = 3 [3] + 10 + 1)
-              whose#0,SET
+              whose#0,SET test value formatter: 8
      25812    record (14 = 3 [2] + 9 + 2)
-              why#0,SET
+              why#0,SET test value formatter: 13
      25826    record (17 = 3 [1] + 13 + 1)
-              wicked#0,SET
+              wicked#0,SET test value formatter: 3
      25843    record (14 = 3 [2] + 10 + 1)
-              wide#0,SET
+              wide#0,SET test value formatter: 1
      25857    record (14 = 3 [2] + 10 + 1)
-              wife#0,SET
+              wife#0,SET test value formatter: 1
      25871    record (14 = 3 [2] + 10 + 1)
-              wild#0,SET
+              wild#0,SET test value formatter: 1
      25885    record (14 = 3 [3] + 9 + 2)
-              will#0,SET
+              will#0,SET test value formatter: 25
      25899    record (15 = 3 [4] + 11 + 1)
-              willing#0,SET
+              willing#0,SET test value formatter: 1
      25914    record (14 = 3 [7] + 10 + 1)
-              willingly#0,SET
+              willingly#0,SET test value formatter: 1
      25928    record (13 = 3 [3] + 9 + 1)
-              wilt#0,SET
+              wilt#0,SET test value formatter: 1
      25941    record (16 = 3 [0] + 12 + 1) [restart]
-              wind#0,SET
+              wind#0,SET test value formatter: 2
      25957    record (13 = 3 [4] + 9 + 1)
-              winds#0,SET
+              winds#0,SET test value formatter: 2
      25970    record (13 = 3 [4] + 9 + 1)
-              windy#0,SET
+              windy#0,SET test value formatter: 1
      25983    record (14 = 3 [3] + 10 + 1)
-              wings#0,SET
+              wings#0,SET test value formatter: 1
      25997    record (14 = 3 [2] + 10 + 1)
-              wipe#0,SET
+              wipe#0,SET test value formatter: 1
      26011    record (16 = 3 [2] + 12 + 1)
-              wisdom#0,SET
+              wisdom#0,SET test value formatter: 1
      26027    record (13 = 3 [6] + 9 + 1)
-              wisdoms#0,SET
+              wisdoms#0,SET test value formatter: 1
      26040    record (15 = 3 [3] + 11 + 1)
-              wisest#0,SET
+              wisest#0,SET test value formatter: 1
      26055    record (15 = 3 [3] + 11 + 1)
-              wishes#0,SET
+              wishes#0,SET test value formatter: 1
      26070    record (13 = 3 [2] + 9 + 1)
-              wit#0,SET
+              wit#0,SET test value formatter: 2
      26083    record (14 = 3 [3] + 10 + 1)
-              witch#0,SET
+              witch#0,SET test value formatter: 1
      26097    record (17 = 3 [5] + 13 + 1)
-              witchcraft#0,SET
+              witchcraft#0,SET test value formatter: 1
      26114    record (14 = 3 [3] + 9 + 2)
-              with#0,SET
+              with#0,SET test value formatter: 65
      26128    record (14 = 3 [4] + 10 + 1)
-              withal#0,SET
+              withal#0,SET test value formatter: 2
      26142    record (15 = 3 [4] + 10 + 2)
-              within#0,SET
+              within#0,SET test value formatter: 11
      26157    record (15 = 3 [4] + 11 + 1)
-              without#0,SET
+              without#0,SET test value formatter: 3
      26172    record (19 = 3 [0] + 15 + 1) [restart]
-              witness#0,SET
+              witness#0,SET test value formatter: 1
      26191    record (19 = 3 [3] + 15 + 1)
-              wittenberg#0,SET
+              wittenberg#0,SET test value formatter: 4
      26210    record (14 = 3 [1] + 10 + 1)
-              woe#0,SET
+              woe#0,SET test value formatter: 3
      26224    record (15 = 3 [2] + 11 + 1)
-              woman#0,SET
+              woman#0,SET test value formatter: 2
      26239    record (13 = 3 [3] + 9 + 1)
-              womb#0,SET
+              womb#0,SET test value formatter: 1
      26252    record (13 = 3 [2] + 9 + 1)
-              won#0,SET
+              won#0,SET test value formatter: 1
      26265    record (15 = 3 [3] + 11 + 1)
-              wonder#0,SET
+              wonder#0,SET test value formatter: 1
      26280    record (15 = 3 [6] + 11 + 1)
-              wonderful#0,SET
+              wonderful#0,SET test value formatter: 1
      26295    record (16 = 3 [4] + 12 + 1)
-              wondrous#0,SET
+              wondrous#0,SET test value formatter: 1
      26311    record (13 = 3 [3] + 9 + 1)
-              wont#0,SET
+              wont#0,SET test value formatter: 1
      26324    record (19 = 3 [2] + 15 + 1)
-              woodcocks#0,SET
+              woodcocks#0,SET test value formatter: 1
      26343    record (14 = 3 [2] + 10 + 1)
-              word#0,SET
+              word#0,SET test value formatter: 3
      26357    record (13 = 3 [4] + 9 + 1)
-              words#0,SET
+              words#0,SET test value formatter: 2
      26370    record (13 = 3 [3] + 9 + 1)
-              wore#0,SET
+              wore#0,SET test value formatter: 1
      26383    record (13 = 3 [3] + 9 + 1)
-              work#0,SET
+              work#0,SET test value formatter: 2
      26396    record (14 = 3 [3] + 10 + 1)
-              world#0,SET
+              world#0,SET test value formatter: 3
      26410    record (16 = 3 [0] + 12 + 1) [restart]
-              worm#0,SET
+              worm#0,SET test value formatter: 1
      26426    record (14 = 3 [3] + 10 + 1)
-              worth#0,SET
+              worth#0,SET test value formatter: 1
      26440    record (13 = 3 [5] + 9 + 1)
-              worthy#0,SET
+              worthy#0,SET test value formatter: 1
      26453    record (16 = 3 [2] + 11 + 2)
-              would#0,SET
+              would#0,SET test value formatter: 14
      26469    record (14 = 3 [5] + 10 + 1)
-              wouldst#0,SET
+              wouldst#0,SET test value formatter: 3
      26483    record (17 = 3 [1] + 13 + 1)
-              wretch#0,SET
+              wretch#0,SET test value formatter: 1
      26500    [restart 24504]
      26504    [restart 24747]
      26508    [restart 24994]
@@ -3624,37 +3624,37 @@ h.no-compression.two_level_index.sst
      26532    [restart 26410]
      26545  data (249)
      26545    record (16 = 3 [0] + 12 + 1) [restart]
-              writ#0,SET
+              writ#0,SET test value formatter: 2
      26561    record (15 = 3 [4] + 11 + 1)
-              writing#0,SET
+              writing#0,SET test value formatter: 1
      26576    record (15 = 3 [2] + 11 + 1)
-              wrong#0,SET
+              wrong#0,SET test value formatter: 1
      26591    record (15 = 3 [2] + 11 + 1)
-              wrung#0,SET
+              wrung#0,SET test value formatter: 1
      26606    record (15 = 3 [0] + 11 + 1)
-              yea#0,SET
+              yea#0,SET test value formatter: 1
      26621    record (13 = 3 [2] + 9 + 1)
-              yes#0,SET
+              yes#0,SET test value formatter: 4
      26634    record (20 = 3 [3] + 16 + 1)
-              yesternight#0,SET
+              yesternight#0,SET test value formatter: 1
      26654    record (13 = 3 [2] + 9 + 1)
-              yet#0,SET
+              yet#0,SET test value formatter: 7
      26667    record (19 = 3 [1] + 15 + 1)
-              yielding#0,SET
+              yielding#0,SET test value formatter: 1
      26686    record (14 = 3 [1] + 10 + 1)
-              yon#0,SET
+              yon#0,SET test value formatter: 1
      26700    record (13 = 3 [3] + 9 + 1)
-              yond#0,SET
+              yond#0,SET test value formatter: 1
      26713    record (15 = 3 [2] + 9 + 3)
-              you#0,SET
+              you#0,SET test value formatter: 110
      26728    record (14 = 3 [3] + 10 + 1)
-              young#0,SET
+              young#0,SET test value formatter: 6
      26742    record (14 = 3 [3] + 9 + 2)
-              your#0,SET
+              your#0,SET test value formatter: 49
      26756    record (16 = 3 [4] + 12 + 1)
-              yourself#0,SET
+              yourself#0,SET test value formatter: 7
      26772    record (14 = 3 [3] + 10 + 1)
-              youth#0,SET
+              youth#0,SET test value formatter: 5
      26786    [restart 26545]
      26799  index (120)
      26799    block:0/2041 [restart]

--- a/tool/testdata/sstable_scan
+++ b/tool/testdata/sstable_scan
@@ -102,27 +102,27 @@ your#0,SET [3439]
 
 sstable scan
 --key=pretty
---value=[%x]
+--value=pretty
 --start=hex:796f75
 --end=raw:yourself
 ../sstable/testdata/h.sst
 ----
 h.sst
-you#0,SET [313130]
-young#0,SET [36]
-your#0,SET [3439]
+you#0,SET 110
+young#0,SET 6
+your#0,SET 49
 
 sstable scan
 --key=pretty:test-comparer
---value=[%x]
+--value=pretty:test-comparer
 --start=hex:796f75
 --end=raw:yourself
 ../sstable/testdata/h.sst
 ----
 h.sst
-test formatter: you#0,SET [313130]
-test formatter: young#0,SET [36]
-test formatter: your#0,SET [3439]
+test formatter: you#0,SET test value formatter: 110
+test formatter: young#0,SET test value formatter: 6
+test formatter: your#0,SET test value formatter: 49
 
 # Start and end scan keys lie within range tombstones.
 sstable scan

--- a/tool/testdata/wal_dump
+++ b/tool/testdata/wal_dump
@@ -47,13 +47,13 @@ EOF
 wal dump
 ../testdata/db-stage-4/000006.log
 --key=pretty
---value=%x
+--value=pretty:test-comparer
 ----
 000006.log
 0(22) seq=6 count=1
-    SET(foo,66697665)
+    SET(foo,test value formatter: five)
 29(22) seq=7 count=1
-    SET(quux,736978)
+    SET(quux,test value formatter: six)
 58(17) seq=8 count=1
     DEL(baz)
 EOF

--- a/tool/util.go
+++ b/tool/util.go
@@ -55,7 +55,7 @@ func (k *key) Set(v string) error {
 
 type formatter struct {
 	spec      string
-	fn        base.Formatter
+	fn        base.FormatKey
 	setByUser bool
 	comparer  string
 }
@@ -124,8 +124,8 @@ func (f *formatter) setForComparer(comparerName string, comparers sstable.Compar
 		return
 	}
 
-	if cmp := comparers[comparerName]; cmp != nil && cmp.Format != nil {
-		f.fn = cmp.Format
+	if cmp := comparers[comparerName]; cmp != nil && cmp.FormatKey != nil {
+		f.fn = cmp.FormatKey
 	}
 }
 

--- a/tool/util.go
+++ b/tool/util.go
@@ -53,43 +53,43 @@ func (k *key) Set(v string) error {
 	return nil
 }
 
-type formatter struct {
+type keyFormatter struct {
 	spec      string
 	fn        base.FormatKey
 	setByUser bool
 	comparer  string
 }
 
-func (f *formatter) String() string {
+func (f *keyFormatter) String() string {
 	return f.spec
 }
 
-func (f *formatter) Type() string {
-	return "formatter"
+func (f *keyFormatter) Type() string {
+	return "keyFormatter"
 }
 
-func (f *formatter) Set(spec string) error {
+func (f *keyFormatter) Set(spec string) error {
 	f.spec = spec
 	f.setByUser = true
 	switch spec {
 	case "null":
-		f.fn = formatNull
+		f.fn = formatKeyNull
 	case "quoted":
-		f.fn = formatQuoted
+		f.fn = formatKeyQuoted
 	case "pretty":
-		// Using "pretty" defaults to base.FormatBytes (just like formatQuoted),
+		// Using "pretty" defaults to base.FormatBytes (just like formatKeyQuoted),
 		// except with the ability of having the comparer-provided formatter
-		// overwrite f.fn if there is one specified. We determine whether to
-		// do that overwrite through setByUser.
-		f.fn = formatQuoted
+		// overwrite f.fn if there is one specified. We determine whether to do
+		// that overwrite through setByUser.
+		f.fn = formatKeyQuoted
 		f.setByUser = false
 	case "size":
-		f.fn = formatSize
+		f.fn = formatKeySize
 	default:
 		if strings.HasPrefix(spec, "pretty:") {
 			// Usage: pretty:<comparer-name>
 			f.comparer = spec[7:]
-			f.fn = formatQuoted
+			f.fn = formatKeyQuoted
 			return nil
 		}
 		if strings.Count(spec, "%") != 1 {
@@ -102,7 +102,7 @@ func (f *formatter) Set(spec string) error {
 	return nil
 }
 
-func (f *formatter) mustSet(spec string) {
+func (f *keyFormatter) mustSet(spec string) {
 	if err := f.Set(spec); err != nil {
 		panic(err)
 	}
@@ -110,7 +110,7 @@ func (f *formatter) mustSet(spec string) {
 }
 
 // Sets the appropriate formatter function for this comparer.
-func (f *formatter) setForComparer(comparerName string, comparers sstable.Comparers) {
+func (f *keyFormatter) setForComparer(comparerName string, comparers sstable.Comparers) {
 	if f.setByUser && len(f.comparer) == 0 {
 		// User specified a different formatter, no-op.
 		return
@@ -129,6 +129,82 @@ func (f *formatter) setForComparer(comparerName string, comparers sstable.Compar
 	}
 }
 
+type valueFormatter struct {
+	spec      string
+	fn        base.FormatValue
+	setByUser bool
+	comparer  string
+}
+
+func (f *valueFormatter) String() string {
+	return f.spec
+}
+
+func (f *valueFormatter) Type() string {
+	return "valueFormatter"
+}
+
+func (f *valueFormatter) Set(spec string) error {
+	f.spec = spec
+	f.setByUser = true
+	switch spec {
+	case "null":
+		f.fn = formatValueNull
+	case "quoted":
+		f.fn = formatValueQuoted
+	case "pretty":
+		// Using "pretty" defaults to base.FormatBytes (just like
+		// formatValueQuoted), except with the ability of having the
+		// comparer-provided formatter overwrite f.fn if there is one specified. We
+		// determine whether to do that overwrite through setByUser.
+		f.fn = formatValueQuoted
+		f.setByUser = false
+	case "size":
+		f.fn = formatValueSize
+	default:
+		if strings.HasPrefix(spec, "pretty:") {
+			// Usage: pretty:<comparer-name>
+			f.comparer = spec[7:]
+			f.fn = formatValueQuoted
+			return nil
+		}
+		if strings.Count(spec, "%") != 1 {
+			return errors.Errorf("unknown formatter: %q", errors.Safe(spec))
+		}
+		f.fn = func(k, v []byte) fmt.Formatter {
+			return fmtFormatter{f.spec, v}
+		}
+	}
+	return nil
+}
+
+func (f *valueFormatter) mustSet(spec string) {
+	if err := f.Set(spec); err != nil {
+		panic(err)
+	}
+	f.setByUser = false
+}
+
+// Sets the appropriate formatter function for this comparer.
+func (f *valueFormatter) setForComparer(comparerName string, comparers sstable.Comparers) {
+	if f.setByUser && len(f.comparer) == 0 {
+		// User specified a different formatter, no-op.
+		return
+	}
+
+	if len(f.comparer) > 0 {
+		// User specified a comparer to reference for formatting, which takes
+		// precedence.
+		comparerName = f.comparer
+	} else if len(comparerName) == 0 {
+		return
+	}
+
+	if cmp := comparers[comparerName]; cmp != nil && cmp.FormatValue != nil {
+		f.fn = cmp.FormatValue
+	}
+}
+
 type fmtFormatter struct {
 	fmt string
 	v   []byte
@@ -143,11 +219,19 @@ type nullFormatter struct{}
 func (nullFormatter) Format(s fmt.State, c rune) {
 }
 
-func formatNull(v []byte) fmt.Formatter {
+func formatKeyNull(v []byte) fmt.Formatter {
 	return nullFormatter{}
 }
 
-func formatQuoted(v []byte) fmt.Formatter {
+func formatValueNull(k, v []byte) fmt.Formatter {
+	return nullFormatter{}
+}
+
+func formatKeyQuoted(v []byte) fmt.Formatter {
+	return base.FormatBytes(v)
+}
+
+func formatValueQuoted(k, v []byte) fmt.Formatter {
 	return base.FormatBytes(v)
 }
 
@@ -157,11 +241,15 @@ func (v sizeFormatter) Format(s fmt.State, c rune) {
 	fmt.Fprintf(s, "<%d>", len(v))
 }
 
-func formatSize(v []byte) fmt.Formatter {
+func formatKeySize(v []byte) fmt.Formatter {
 	return sizeFormatter(v)
 }
 
-func formatKey(w io.Writer, fmtKey formatter, key *base.InternalKey) bool {
+func formatValueSize(k, v []byte) fmt.Formatter {
+	return sizeFormatter(v)
+}
+
+func formatKey(w io.Writer, fmtKey keyFormatter, key *base.InternalKey) bool {
 	if fmtKey.spec == "null" {
 		return false
 	}
@@ -173,7 +261,7 @@ func formatSeqNumRange(w io.Writer, start, end uint64) {
 	fmt.Fprintf(w, "<#%d-#%d>", start, end)
 }
 
-func formatKeyRange(w io.Writer, fmtKey formatter, start, end *base.InternalKey) {
+func formatKeyRange(w io.Writer, fmtKey keyFormatter, start, end *base.InternalKey) {
 	if fmtKey.spec == "null" {
 		return
 	}
@@ -181,7 +269,7 @@ func formatKeyRange(w io.Writer, fmtKey formatter, start, end *base.InternalKey)
 }
 
 func formatKeyValue(
-	w io.Writer, fmtKey formatter, fmtValue formatter, key *base.InternalKey, value []byte,
+	w io.Writer, fmtKey keyFormatter, fmtValue valueFormatter, key *base.InternalKey, value []byte,
 ) {
 	if key.Kind() == base.InternalKeyKindRangeDelete {
 		if fmtKey.spec != "null" {
@@ -195,7 +283,7 @@ func formatKeyValue(
 			if needDelimiter {
 				w.Write([]byte{' '})
 			}
-			fmt.Fprintf(w, "%s", fmtValue.fn(value))
+			fmt.Fprintf(w, "%s", fmtValue.fn(key.UserKey, value))
 		}
 	}
 	w.Write([]byte{'\n'})

--- a/tool/wal.go
+++ b/tool/wal.go
@@ -23,8 +23,8 @@ type walT struct {
 	Dump *cobra.Command
 
 	opts     *pebble.Options
-	fmtKey   formatter
-	fmtValue formatter
+	fmtKey   keyFormatter
+	fmtValue valueFormatter
 
 	comparers sstable.Comparers
 	verbose   bool
@@ -64,6 +64,8 @@ Print the contents of the WAL files.
 
 func (w *walT) runDump(cmd *cobra.Command, args []string) {
 	w.fmtKey.setForComparer("", w.comparers)
+	w.fmtValue.setForComparer("", w.comparers)
+
 	for _, arg := range args {
 		func() {
 			// Parse the filename in order to extract the file number. This is
@@ -127,11 +129,11 @@ func (w *walT) runDump(cmd *cobra.Command, args []string) {
 					case base.InternalKeyKindDelete:
 						fmt.Fprintf(stdout, "%s", w.fmtKey.fn(ukey))
 					case base.InternalKeyKindSet:
-						fmt.Fprintf(stdout, "%s,%s", w.fmtKey.fn(ukey), w.fmtValue.fn(value))
+						fmt.Fprintf(stdout, "%s,%s", w.fmtKey.fn(ukey), w.fmtValue.fn(ukey, value))
 					case base.InternalKeyKindMerge:
-						fmt.Fprintf(stdout, "%s,%s", w.fmtKey.fn(ukey), w.fmtValue.fn(value))
+						fmt.Fprintf(stdout, "%s,%s", w.fmtKey.fn(ukey), w.fmtValue.fn(ukey, value))
 					case base.InternalKeyKindLogData:
-						fmt.Fprintf(stdout, "%s", w.fmtValue.fn(value))
+						fmt.Fprintf(stdout, "<%d>", len(value))
 					case base.InternalKeyKindSingleDelete:
 						fmt.Fprintf(stdout, "%s", w.fmtKey.fn(ukey))
 					case base.InternalKeyKindRangeDelete:

--- a/version_set.go
+++ b/version_set.go
@@ -249,7 +249,7 @@ func (vs *versionSet) load(dirname string, opts *Options, mu *sync.Mutex) error 
 	}
 	vs.markFileNumUsed(vs.minUnflushedLogNum)
 
-	newVersion, _, err := bve.Apply(nil, vs.cmp, opts.Comparer.Format)
+	newVersion, _, err := bve.Apply(nil, vs.cmp, opts.Comparer.FormatKey)
 	if err != nil {
 		return err
 	}
@@ -379,7 +379,7 @@ func (vs *versionSet) logAndApply(
 		bve.Accumulate(ve)
 
 		var err error
-		newVersion, zombies, err = bve.Apply(currentVersion, vs.cmp, vs.opts.Comparer.Format)
+		newVersion, zombies, err = bve.Apply(currentVersion, vs.cmp, vs.opts.Comparer.FormatKey)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Rename `tool.formatter` to `tool.keyFormatter` and add
`tool.valueFormatter`. This allowed plumbing through the use of
`Comparer.FormatValue` throughout the tool commands.

Fixes #630