### PR TITLE
sstable: support NeedCompact method for property collectors

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1343,6 +1343,7 @@ func (d *DB) runCompaction(
 		meta.Size = writerMeta.Size
 		meta.SmallestSeqNum = writerMeta.SmallestSeqNum
 		meta.LargestSeqNum = writerMeta.LargestSeqNum
+		meta.MarkedForCompaction = writerMeta.MarkedForCompaction
 
 		if c.flushing == nil {
 			metrics.TablesCompacted++

--- a/options.go
+++ b/options.go
@@ -55,8 +55,11 @@ const (
 	TableFormatLevelDB   = sstable.TableFormatLevelDB
 )
 
-// TablePropertyCollector exports the base.TablePropertyCollector type.
+// TablePropertyCollector exports the sstable.TablePropertyCollector type.
 type TablePropertyCollector = sstable.TablePropertyCollector
+
+// NeedCompacter exports the sstable.NeedCompacter type.
+type NeedCompacter = sstable.NeedCompacter
 
 // IterOptions hold the optional per-query parameters for NewIter.
 //

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -80,6 +80,15 @@ type TablePropertyCollector interface {
 	Name() string
 }
 
+// NeedCompacter is an optional interface that may be implemented by a
+// TablePropertyCollector to force an sstable compaction.
+type NeedCompacter interface {
+	// NeedCompact is called when all the entries have been added to the
+	// sstable but before Finish. If NeedCompact returns true, the resulting
+	// table will be marked for compaction.
+	NeedCompact() bool
+}
+
 // ReaderOptions holds the parameters needed for reading an sstable.
 type ReaderOptions struct {
 	// Cache is used to cache uncompressed blocks from sstables.

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -841,3 +841,41 @@ func TestTablePropertyCollectorErrors(t *testing.T) {
 	require.Regexp(t, `add f#0,2 failed`, w.Merge([]byte("f"), []byte("g")))
 	require.Regexp(t, `finish failed`, w.Close())
 }
+
+type needCompactCollector struct{}
+
+func (needCompactCollector) Add(key InternalKey, _ []byte) error {
+	return nil
+}
+
+func (needCompactCollector) Finish(_ map[string]string) error {
+	return nil
+}
+
+func (needCompactCollector) NeedCompact() bool {
+	return true
+}
+
+func (needCompactCollector) Name() string {
+	return "needCompactCollector"
+}
+
+func TestTablePropertyCollectorNeedCompact(t *testing.T) {
+	mem := vfs.NewMem()
+	f, err := mem.Create("foo")
+	require.NoError(t, err)
+
+	var opts WriterOptions
+	opts.TablePropertyCollectors = append(opts.TablePropertyCollectors,
+		func() TablePropertyCollector {
+			return needCompactCollector{}
+		})
+
+	w := NewWriter(f, opts)
+	require.NoError(t, w.Set([]byte("a"), []byte("b")))
+	require.NoError(t, w.Set([]byte("c"), []byte("d")))
+	require.NoError(t, w.Close())
+	m, err := w.Metadata()
+	require.NoError(t, err)
+	require.True(t, m.MarkedForCompaction)
+}


### PR DESCRIPTION
This change updates sstable.Writer to check if a TablePropertyCollector
exposes a NeedCompact method. If it does and it returns true, mark the
resulting file as requiring compaction. This mirrors RocksDB and
prepares for cockroachdb/cockroach#47763.

I avoided adding the NeedCompact method to the TablePropertyCollector
interface so that clients with existing TablePropertyCollectors don't
need to be updated for a change that should be temporary. A compaction
heuristic that appropriately values compacting range deletions should
obviate the need for this explicit compaction trigger.