### PR TITLE
tool: Show sublevels at the end of manifest dump

### DIFF
--- a/tool/testdata/manifest_dump
+++ b/tool/testdata/manifest_dump
@@ -24,7 +24,7 @@ MANIFEST-000005
   last-seq-num:  5
   added:         L0 000004:986<#3-#5>[bar#5,DEL-foo#4,SET]
 EOF
---- L0 ---
+--- L0.0 ---
   000004:986<#3-#5>[bar#5,DEL-foo#4,SET]
 --- L1 ---
 --- L2 ---
@@ -48,7 +48,7 @@ MANIFEST-000005
   last-seq-num:  5
   added:         L0 000004:986<#3-#5>[626172#5,DEL-666f6f#4,SET]
 EOF
---- L0 ---
+--- L0.0 ---
   000004:986<#3-#5>[626172#5,DEL-666f6f#4,SET]
 --- L1 ---
 --- L2 ---
@@ -72,7 +72,7 @@ MANIFEST-000005
   last-seq-num:  5
   added:         L0 000004:986<#3-#5>
 EOF
---- L0 ---
+--- L0.0 ---
   000004:986<#3-#5>
 --- L1 ---
 --- L2 ---
@@ -96,7 +96,7 @@ MANIFEST-000005
   last-seq-num:  5
   added:         L0 000004:986<#3-#5>[bar#5,DEL-foo#4,SET]
 EOF
---- L0 ---
+--- L0.0 ---
   000004:986<#3-#5>[bar#5,DEL-foo#4,SET]
 --- L1 ---
 --- L2 ---
@@ -120,7 +120,7 @@ MANIFEST-000005
   last-seq-num:  5
   added:         L0 000004:986<#3-#5>[test formatter: bar#5,DEL-test formatter: foo#4,SET]
 EOF
---- L0 ---
+--- L0.0 ---
   000004:986<#3-#5>[test formatter: bar#5,DEL-test formatter: foo#4,SET]
 --- L1 ---
 --- L2 ---


### PR DESCRIPTION
This change updates the manifest commands that output an LSM
structure to also show L0 sublevels if they exist.