### PR TITLE
internal/manifest: add Version.CheckConsistency

### DIFF
--- a/internal/manifest/testdata/version_check_consistency
+++ b/internal/manifest/testdata/version_check_consistency
@@ -1,0 +1,92 @@
+build
+000001:10
+000002:20
+000003:30
+----
+open test/000001.sst: file does not exist
+
+check-consistency
+----
+OK
+
+check-consistency
+L0
+  000005:10
+----
+L0: 000005: stat test/000005.sst: file does not exist
+
+check-consistency
+L0
+  000001:10
+----
+L0: 000001: stat test/000001.sst: file does not exist
+
+check-consistency
+L0
+  000001:11
+----
+L0: 000001: stat test/000001.sst: file does not exist
+
+check-consistency redact
+L0
+  000001:11
+----
+<*errors.errorString>
+wrapper: <*safedetails.withSafeDetails>
+(more details:)
+L%d: %s: %v
+-- arg 1: 0
+-- arg 2: 000001
+-- arg 3: *errors.errorString: file does not exist
+wrapper: *os.PathError: stat
+
+check-consistency
+L0
+  000001:10
+L1
+  000002:20
+L2
+  000003:30
+----
+L0: 000001: stat test/000001.sst: file does not exist
+L1: 000002: stat test/000002.sst: file does not exist
+L2: 000003: stat test/000003.sst: file does not exist
+
+check-consistency
+L0
+  000001:11
+L1
+  000002:22
+L2
+  000003:33
+----
+L0: 000001: stat test/000001.sst: file does not exist
+L1: 000002: stat test/000002.sst: file does not exist
+L2: 000003: stat test/000003.sst: file does not exist
+
+check-consistency redact
+L0
+  000001:11
+L1
+  000002:22
+L2
+  000004:30
+----
+<*errors.errorString>
+wrapper: <*safedetails.withSafeDetails>
+(more details:)
+L%d: %s: %v
+L%d: %s: %v
+L%d: %s: %v
+-- arg 1: 0
+-- arg 2: 000001
+-- arg 3: *errors.errorString: file does not exist
+wrapper: *os.PathError: stat
+-- arg 4: 1
+-- arg 5: 000002
+-- arg 6: *errors.errorString: file does not exist
+wrapper: *os.PathError: stat
+-- arg 7: 2
+-- arg 8: 000004
+-- arg 9: *errors.errorString: file does not exist
+wrapper: *os.PathError: stat

--- a/open.go
+++ b/open.go
@@ -181,6 +181,9 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		if err := d.mu.versions.load(dirname, opts, &d.mu.Mutex); err != nil {
 			return nil, err
 		}
+		if err := d.mu.versions.currentVersion().CheckConsistency(dirname, opts.FS); err != nil {
+			return nil, err
+		}
 	}
 
 	// In read-only mode, we replay directly into the mutable memtable but never


### PR DESCRIPTION
Add `Version.CheckConsistency` which checks that the files listed in the
version exist and their on-disk sizes match the sizes listed in the
version.

Call `Version.CheckConsistency` during `DB.Open` after loading the
MANIFEST.

Fixes #651