### PR TITLE
cmd/pebble: skip first manifest record in `bench compact new`

### DIFF
--- a/cmd/pebble/compact_new.go
+++ b/cmd/pebble/compact_new.go
@@ -160,6 +160,13 @@ func loadManifest(path string, metas map[base.FileNum]*manifest.FileMetadata) ([
 
 	var log []logItem
 	rr := record.NewReader(f, 0 /* logNum */)
+
+	// A manifest's first record contains all the active files when the
+	// manifest was created. We only care about edits to the version.
+	if _, err = rr.Next(); err != nil {
+		return nil, err
+	}
+
 	for {
 		r, err := rr.Next()
 		if err == io.EOF {


### PR DESCRIPTION
The first record of a manifest establishes the current version's file
set. Previously, the `bench compact new` subcommand would interpret the
first record of a manifest as an addition of new files from a flush or
ingest because the version edit contained exclusively additions.

This meant that `pebble bench compact new` would add files twice if a
store had created multiple MANIFESTs, and running the benchmark
would fail when attempting to ingest an already-ingested sstable.