### PR TITLE
tool: use Option pattern, add DefaultComparer option

### DIFF
--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/tool"
 	"github.com/spf13/cobra"
 )
@@ -52,16 +51,7 @@ func main() {
 	}
 	rootCmd.AddCommand(benchCmd)
 
-	t := tool.New()
-	t.RegisterComparer(mvccComparer)
-	t.RegisterMerger(func() *base.Merger {
-		// TODO(peter): This isn't the actual cockroach_merge_operator, but a
-		// placeholder so we can examine cockroach generated sstables.
-		var m base.Merger
-		m = *base.DefaultMerger
-		m.Name = "cockroach_merge_operator"
-		return &m
-	}())
+	t := tool.New(tool.Comparers(mvccComparer), tool.Mergers(fauxMVCCMerger))
 	rootCmd.AddCommand(t.Commands...)
 
 	for _, cmd := range []*cobra.Command{compactNewCmd, compactRunCmd, scanCmd, syncCmd, ycsbCmd} {

--- a/tool/data_test.go
+++ b/tool/data_test.go
@@ -82,11 +82,9 @@ func runTests(t *testing.T, path string) {
 					timeNow = time.Now
 				}()
 
-				tool := New()
-				tool.setFS(fs)
 				// Register a test comparer and merger so that we can check the
 				// behavior of tools when the comparer and merger do not match.
-				tool.RegisterComparer(func() *Comparer {
+				comparer := func() *Comparer {
 					c := *base.DefaultComparer
 					c.Name = "test-comparer"
 					c.FormatKey = func(key []byte) fmt.Formatter {
@@ -102,12 +100,15 @@ func runTests(t *testing.T, path string) {
 						}
 					}
 					return &c
-				}())
-				tool.RegisterMerger(func() *Merger {
+				}()
+				merger := func() *Merger {
 					m := *base.DefaultMerger
 					m.Name = "test-merger"
 					return &m
-				}())
+				}()
+
+				tool := New(DefaultComparer(comparer), Mergers(merger))
+				tool.setFS(fs)
 
 				c := &cobra.Command{}
 				c.AddCommand(tool.Commands...)

--- a/tool/find.go
+++ b/tool/find.go
@@ -58,7 +58,7 @@ type findT struct {
 	tableMeta map[base.FileNum]*manifest.FileMetadata
 }
 
-func newFind(opts *pebble.Options, comparers sstable.Comparers) *findT {
+func newFind(opts *pebble.Options, comparers sstable.Comparers, defaultComparer string) *findT {
 	f := &findT{
 		opts:      opts,
 		comparers: comparers,
@@ -81,7 +81,7 @@ provenance of the sstables (flushed, ingested, compacted).
 	f.Root.Flags().BoolVarP(
 		&f.verbose, "verbose", "v", false, "verbose output")
 	f.Root.Flags().StringVar(
-		&f.comparerName, "comparer", "", "comparer name (use default if empty)")
+		&f.comparerName, "comparer", defaultComparer, "comparer name")
 	f.Root.Flags().Var(
 		&f.fmtKey, "key", "key formatter")
 	f.Root.Flags().Var(

--- a/tool/testdata/wal_dump
+++ b/tool/testdata/wal_dump
@@ -7,6 +7,24 @@ wal dump
 ----
 000003.log
 0(21) seq=1 count=1
+    SET(test formatter: foo,test value formatter: one)
+28(21) seq=2 count=1
+    SET(test formatter: bar,test value formatter: two)
+56(23) seq=3 count=1
+    SET(test formatter: baz,test value formatter: three)
+86(22) seq=4 count=1
+    SET(test formatter: foo,test value formatter: four)
+115(17) seq=5 count=1
+    DEL(test formatter: bar)
+EOF
+
+wal dump
+../testdata/db-stage-2/000003.log
+--key=pretty:leveldb.BytewiseComparator
+--value=size
+----
+000003.log
+0(21) seq=1 count=1
     SET(foo,<3>)
 28(21) seq=2 count=1
     SET(bar,<3>)
@@ -19,6 +37,8 @@ wal dump
 EOF
 
 wal dump
+--key=pretty:leveldb.BytewiseComparator
+--value=size
 ../testdata/db-stage-4/000006.log
 ----
 000006.log
@@ -46,7 +66,7 @@ EOF
 
 wal dump
 ../testdata/db-stage-4/000006.log
---key=pretty
+--key=pretty:leveldb.BytewiseComparator
 --value=pretty:test-comparer
 ----
 000006.log
@@ -74,6 +94,7 @@ EOF
 
 wal dump
 ../testdata/db-stage-4/000006.log
+--key=pretty:leveldb.BytewiseComparator
 --value=quoted
 ----
 000006.log

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -30,20 +30,63 @@ type Merger = base.Merger
 
 // T is the container for all of the introspection tools.
 type T struct {
-	Commands  []*cobra.Command
-	db        *dbT
-	find      *findT
-	lsm       *lsmT
-	manifest  *manifestT
-	sstable   *sstableT
-	wal       *walT
-	opts      pebble.Options
-	comparers sstable.Comparers
-	mergers   sstable.Mergers
+	Commands        []*cobra.Command
+	db              *dbT
+	find            *findT
+	lsm             *lsmT
+	manifest        *manifestT
+	sstable         *sstableT
+	wal             *walT
+	opts            pebble.Options
+	comparers       sstable.Comparers
+	mergers         sstable.Mergers
+	defaultComparer string
+}
+
+// A Option configures the Pebble introspection tool.
+type Option func(*T)
+
+// Comparers may be passed to New to register comparers for use by
+// the introspesction tools.
+func Comparers(cmps ...*Comparer) Option {
+	return func(t *T) {
+		for _, c := range cmps {
+			t.comparers[c.Name] = c
+		}
+	}
+}
+
+// DefaultComparer registers a comparer for use by the introspection tools and
+// sets it as the default.
+func DefaultComparer(c *Comparer) Option {
+	return func(t *T) {
+		t.comparers[c.Name] = c
+		t.defaultComparer = c.Name
+	}
+}
+
+// Mergers may be passed to New to register mergers for use by the
+// introspection tools.
+func Mergers(mergers ...*Merger) Option {
+	return func(t *T) {
+		for _, m := range mergers {
+			t.mergers[m.Name] = m
+		}
+	}
+}
+
+// Filters may be passed to New to register filter policies for use by the
+// introspection tools.
+func Filters(filters ...FilterPolicy) Option {
+	return func(t *T) {
+		for _, f := range filters {
+			t.opts.Filters[f.Name()] = f
+		}
+	}
 }
 
 // New creates a new introspection tool.
-func New() *T {
+func New(opts ...Option) *T {
 	cache := pebble.NewCache(128 << 20 /* 128 MB */)
 
 	t := &T{
@@ -53,20 +96,26 @@ func New() *T {
 			FS:       vfs.Default,
 			ReadOnly: true,
 		},
-		comparers: make(sstable.Comparers),
-		mergers:   make(sstable.Mergers),
+		comparers:       make(sstable.Comparers),
+		mergers:         make(sstable.Mergers),
+		defaultComparer: base.DefaultComparer.Name,
 	}
 
-	t.RegisterComparer(base.DefaultComparer)
-	t.RegisterFilter(bloom.FilterPolicy(10))
-	t.RegisterMerger(base.DefaultMerger)
+	opts = append(opts,
+		Comparers(base.DefaultComparer),
+		Filters(bloom.FilterPolicy(10)),
+		Mergers(base.DefaultMerger))
+
+	for _, opt := range opts {
+		opt(t)
+	}
 
 	t.db = newDB(&t.opts, t.comparers, t.mergers)
-	t.find = newFind(&t.opts, t.comparers)
+	t.find = newFind(&t.opts, t.comparers, t.defaultComparer)
 	t.lsm = newLSM(&t.opts, t.comparers)
 	t.manifest = newManifest(&t.opts, t.comparers)
 	t.sstable = newSSTable(&t.opts, t.comparers, t.mergers)
-	t.wal = newWAL(&t.opts, t.comparers)
+	t.wal = newWAL(&t.opts, t.comparers, t.defaultComparer)
 	t.Commands = []*cobra.Command{
 		t.db.Root,
 		t.find.Root,
@@ -80,21 +129,6 @@ func New() *T {
 		cache.Unref()
 	})
 	return t
-}
-
-// RegisterComparer registers a comparer for use by the introspection tools.
-func (t *T) RegisterComparer(c *Comparer) {
-	t.comparers[c.Name] = c
-}
-
-// RegisterFilter registers a filter policy for use by the introspection tools.
-func (t *T) RegisterFilter(f FilterPolicy) {
-	t.opts.Filters[f.Name()] = f
-}
-
-// RegisterMerger registers a merger for use by the introspection tools.
-func (t *T) RegisterMerger(m *Merger) {
-	t.mergers[m.Name] = m
 }
 
 // setFS sets the filesystem implementation to use by the introspection tools.

--- a/tool/wal.go
+++ b/tool/wal.go
@@ -26,17 +26,19 @@ type walT struct {
 	fmtKey   keyFormatter
 	fmtValue valueFormatter
 
-	comparers sstable.Comparers
-	verbose   bool
+	defaultComparer string
+	comparers       sstable.Comparers
+	verbose         bool
 }
 
-func newWAL(opts *pebble.Options, comparers sstable.Comparers) *walT {
+func newWAL(opts *pebble.Options, comparers sstable.Comparers, defaultComparer string) *walT {
 	w := &walT{
 		opts: opts,
 	}
 	w.fmtKey.mustSet("quoted")
 	w.fmtValue.mustSet("size")
 	w.comparers = comparers
+	w.defaultComparer = defaultComparer
 
 	w.Root = &cobra.Command{
 		Use:   "wal",
@@ -63,8 +65,8 @@ Print the contents of the WAL files.
 }
 
 func (w *walT) runDump(cmd *cobra.Command, args []string) {
-	w.fmtKey.setForComparer("", w.comparers)
-	w.fmtValue.setForComparer("", w.comparers)
+	w.fmtKey.setForComparer(w.defaultComparer, w.comparers)
+	w.fmtValue.setForComparer(w.defaultComparer, w.comparers)
 
 	for _, arg := range args {
 		func() {


### PR DESCRIPTION
Some tools such as the WAL inspection tool are unable to infer
the appropriate comparer. For these tools, allow configuring a default
comparer.

Additionally, convert the Register{Comparer|Filter|Merger} methods into
options passed into New. These are always configured at tool
instantiation and providing them upfront ensures that the `find` tool can
print the true default comparer for its `--comparer` flag in its help
output.

I assumed it's okay to break the interface for the tool package?

Fix #638.