### PR TITLE
cmd/pebble: replay ingests, flushes faithfully

### DIFF
--- a/cmd/pebble/compact_new.go
+++ b/cmd/pebble/compact_new.go
@@ -5,18 +5,15 @@
 package main
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/record"
-	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/spf13/cobra"
 )
@@ -45,110 +42,119 @@ func runCompactNew(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	hist, err := replayManifests(src)
+	manifests, hist, err := replayManifests(src)
 	if err != nil {
 		return err
 	}
+	for _, manifest := range manifests {
+		err := vfs.Copy(vfs.Default, manifest, filepath.Join(workloadDst, filepath.Base(manifest)))
+		if err != nil {
+			return err
+		}
+	}
 
-	// Rewrite all the flushed and ingested sstables to remove duplicate keys.
-	writtenSizes := map[pebble.FileNum]uint64{}
 	for _, logItem := range hist {
-		if !logItem.newData {
+		if logItem.compaction {
 			continue
 		}
 
-		// First look in the archive, because that's likely where it is.
-		srcPath := base.MakeFilename(vfs.Default, archiveDir, base.FileTypeTable, logItem.num)
-		dstPath := base.MakeFilename(vfs.Default, workloadDst, base.FileTypeTable, logItem.num)
-		sz, err := flattenSSTable(srcPath, dstPath)
-		if os.IsNotExist(err) {
-			// Maybe it's still in the data directory.
-			srcPath = base.MakeFilename(vfs.Default, src, base.FileTypeTable, logItem.num)
-			sz, err = flattenSSTable(srcPath, dstPath)
-		}
-		if err != nil {
-			return errors.Wrap(err, filepath.Base(srcPath))
-		}
-		verbosef("Rewrote %s to %s.\n", srcPath, dstPath)
-		writtenSizes[logItem.num] = sz
-		if compactNewConfig.deleteSourceFiles {
-			err := os.Remove(srcPath)
+		for _, f := range logItem.added {
+			// First look in the archive, because that's likely where it is.
+			srcPath := base.MakeFilename(vfs.Default, archiveDir, base.FileTypeTable, f.meta.FileNum)
+			dstPath := base.MakeFilename(vfs.Default, workloadDst, base.FileTypeTable, f.meta.FileNum)
+			err := vfs.LinkOrCopy(vfs.Default, srcPath, dstPath)
+			if os.IsNotExist(err) {
+				// Maybe it's still in the data directory.
+				srcPath = base.MakeFilename(vfs.Default, src, base.FileTypeTable, f.meta.FileNum)
+				err = vfs.LinkOrCopy(vfs.Default, srcPath, dstPath)
+			}
 			if err != nil {
-				return err
+				return errors.Wrap(err, filepath.Base(srcPath))
+			}
+			verbosef("Linked or copied %s to %s.\n", srcPath, dstPath)
+			if compactNewConfig.deleteSourceFiles {
+				err := os.Remove(srcPath)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}
-
-	// Write the history as a csv, using our updated table sizes for rewritten tables.
-	f, err := os.Create(filepath.Join(workloadDst, "history"))
-	if err != nil {
-		return err
-	}
-	for _, li := range hist {
-		sz, ok := writtenSizes[li.num]
-		if !ok {
-			sz = li.size
-		}
-		addRm := "rm"
-		if li.add {
-			addRm = "add"
-		}
-		fmt.Fprintf(f, "%d,%s,%s,%d,%t\n", li.level, li.num, addRm, sz, li.newData)
-	}
-	return f.Close()
+	return nil
 }
 
 type logItem struct {
-	level   int
-	num     pebble.FileNum
-	add     bool
-	size    uint64
-	newData bool
+	compaction bool
+	flush      bool
+	added      []fileEntry
+	removed    []fileEntry
+}
+
+func (li logItem) levelSizesDelta() levelSizes {
+	var sizes levelSizes
+	for _, f := range li.added {
+		sizes[f.level] += int64(f.meta.Size)
+	}
+	for _, f := range li.removed {
+		sizes[f.level] -= int64(f.meta.Size)
+	}
+	return sizes
+}
+
+type fileEntry struct {
+	level int
+	meta  *manifest.FileMetadata
 }
 
 // replayManifests replays all manifests from the archive and the data
 // directory in order, returning an in-order history of sstable additions,
 // deletions and moves.
-func replayManifests(srcPath string) ([]logItem, error) {
+func replayManifests(srcPath string) ([]string, []logItem, error) {
 	var history []logItem
+	var manifests []string
 	metas := make(map[base.FileNum]*manifest.FileMetadata)
 
-	// First look in the archive for deleted manifests.
+	// If there's an archive directory in srcPath, look in the archive for
+	// deleted manifests.
 	archivePath := filepath.Join(srcPath, "archive")
 	infos, err := ioutil.ReadDir(archivePath)
-	if err != nil {
-		return nil, err
+	if err != nil && !os.IsNotExist(err) {
+		return nil, nil, err
 	}
 	for _, info := range infos {
 		typ, _, ok := base.ParseFilename(vfs.Default, info.Name())
 		if !ok || typ != base.FileTypeManifest {
 			continue
 		}
-		manifestLog, err := loadManifest(filepath.Join(archivePath, info.Name()), metas)
+		path := filepath.Join(archivePath, info.Name())
+		manifestLog, err := loadManifest(path, metas)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
+		manifests = append(manifests, path)
 		history = append(history, manifestLog...)
 	}
 
-	// Next look in the data directory for active manifests.
+	// Next look directly in srcPath.
 	infos, err = ioutil.ReadDir(srcPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	for _, info := range infos {
 		typ, _, ok := base.ParseFilename(vfs.Default, info.Name())
 		if !ok || typ != base.FileTypeManifest {
 			continue
 		}
-		manifestLog, err := loadManifest(filepath.Join(srcPath, info.Name()), metas)
+		path := filepath.Join(srcPath, info.Name())
+		manifestLog, err := loadManifest(path, metas)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
+		manifests = append(manifests, path)
 		history = append(history, manifestLog...)
 	}
 
-	return history, nil
+	return manifests, history, nil
 }
 
 func loadManifest(path string, metas map[base.FileNum]*manifest.FileMetadata) ([]logItem, error) {
@@ -180,129 +186,25 @@ func loadManifest(path string, metas map[base.FileNum]*manifest.FileMetadata) ([
 		if err != nil {
 			return nil, err
 		}
+		if len(ve.NewFiles) == 0 && len(ve.DeletedFiles) == 0 {
+			continue
+		}
+
+		li := logItem{
+			// If a version edit deletes files, we assume it's a compaction.
+			// Only non-compaction added files will be replayed.
+			compaction: len(ve.DeletedFiles) != 0,
+			flush:      false,
+		}
 		for _, nf := range ve.NewFiles {
 			metas[nf.Meta.FileNum] = nf.Meta
-			log = append(log, logItem{
-				level: nf.Level,
-				num:   nf.Meta.FileNum,
-				add:   true,
-				size:  nf.Meta.Size,
-				// If a version edit doesn't delete files, we assume all its
-				// new files must be new data from a flush or an ingest.
-				// Only these files will actually be ingested when running the
-				// workload.
-				newData: len(ve.DeletedFiles) == 0,
-			})
+			li.added = append(li.added, fileEntry{level: nf.Level, meta: nf.Meta})
+			li.flush = !li.compaction && (li.flush || nf.Meta.SmallestSeqNum != nf.Meta.LargestSeqNum)
 		}
 		for df := range ve.DeletedFiles {
-			log = append(log, logItem{
-				level:   df.Level,
-				num:     df.FileNum,
-				add:     false,
-				size:    metas[df.FileNum].Size,
-				newData: false,
-			})
+			li.removed = append(li.removed, fileEntry{df.Level, metas[df.FileNum]})
 		}
+		log = append(log, li)
 	}
 	return log, nil
-}
-
-// flattenSSTable copies an sstable from srcPath to dstPath, zeros its
-// keys' sequence numbers and drops duplicate keys in preparation
-// for ingestion.
-func flattenSSTable(srcPath, dstPath string) (writtenSize uint64, err error) {
-	srcFile, err := os.Open(srcPath)
-	if err != nil {
-		return 0, err
-	}
-	r, err := sstable.NewReader(srcFile, sstable.ReaderOptions{
-		// TODO(jackson): This hardcodes `pebble bench compact` for cockroach workloads.
-		// It'd be nice to support archives created with the pebble default
-		// comparer and merger too.
-		Comparer:   mvccComparer,
-		MergerName: "cockroach_merge_operator",
-	})
-	if err != nil {
-		_ = srcFile.Close()
-		return 0, err
-	}
-	defer r.Close()
-
-	dstFile, err := os.Create(dstPath)
-	if err != nil {
-		return 0, err
-	}
-	w := sstable.NewWriter(dstFile, sstable.WriterOptions{
-		MergerName: r.Properties.MergerName,
-		Comparer:   mvccComparer,
-	})
-	if err != nil {
-		_ = dstFile.Close()
-		return 0, err
-	}
-
-	var dropped uint64
-	// Copy points.
-	{
-		iter, err := r.NewIter(nil, nil)
-		if err != nil {
-			return 0, err
-		}
-		var lastUserKey []byte
-		for key, value := iter.First(); key != nil; key, value = iter.Next() {
-			// Ignore duplicate keys.
-			if mvccComparer.Equal(lastUserKey, key.UserKey) {
-				dropped++
-				continue
-			}
-			lastUserKey = append(lastUserKey[:0], key.UserKey...)
-
-			key.SetSeqNum(0)
-			if err := w.Add(*key, value); err != nil {
-				return 0, err
-			}
-		}
-		if err := iter.Close(); err != nil {
-			return 0, err
-		}
-	}
-
-	// Copy range deletions.
-	{
-		iter, err := r.NewRangeDelIter()
-		if err != nil {
-			return 0, err
-		}
-		var lastUserKey []byte
-		if iter != nil {
-			for key, value := iter.First(); key != nil; key, value = iter.Next() {
-				// Ignore duplicate keys.
-				if mvccComparer.Equal(lastUserKey, key.UserKey) {
-					dropped++
-					continue
-				}
-				lastUserKey = append(lastUserKey[:0], key.UserKey...)
-
-				key.SetSeqNum(0)
-				if err := w.Add(*key, value); err != nil {
-					return 0, err
-				}
-			}
-			if err := iter.Close(); err != nil {
-				return 0, err
-			}
-		}
-	}
-
-	if dropped > 0 {
-		verbosef("Dropped %d keys from %s.\n", dropped, srcPath)
-	}
-	if err = w.Close(); err != nil {
-		return 0, err
-	}
-	meta, err := w.Metadata()
-	if err != nil {
-		return 0, err
-	}
-	return meta.Size, nil
 }

--- a/flush_external.go
+++ b/flush_external.go
@@ -1,0 +1,112 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/private"
+)
+
+// flushExternalTable is installed as the private.FlushExternalTable hook.
+// It's used by the internal/replay package to flush external tables into L0
+// for supporting the pebble bench compact commands. Clients should use the
+// replay package rather than calling this private hook directly.
+func flushExternalTable(untypedDB interface{}, path string, originalMeta *fileMetadata) error {
+	d := untypedDB.(*DB)
+	if atomic.LoadInt32(&d.closed) != 0 {
+		panic(ErrClosed)
+	}
+	if d.opts.ReadOnly {
+		return ErrReadOnly
+	}
+
+	d.mu.Lock()
+	fileNum := d.mu.versions.getNextFileNum()
+	jobID := d.mu.nextJobID
+	d.mu.nextJobID++
+	d.mu.Unlock()
+
+	m := &fileMetadata{
+		FileNum:        fileNum,
+		Size:           originalMeta.Size,
+		CreationTime:   time.Now().Unix(),
+		Smallest:       originalMeta.Smallest,
+		Largest:        originalMeta.Largest,
+		SmallestSeqNum: originalMeta.SmallestSeqNum,
+		LargestSeqNum:  originalMeta.LargestSeqNum,
+	}
+
+	// Hard link the sstable into the DB directory.
+	if err := ingestLink(jobID, d.opts, d.dirname, []string{path}, []*fileMetadata{m}); err != nil {
+		return err
+	}
+	if err := d.dataDir.Sync(); err != nil {
+		return err
+	}
+
+	d.commit.mu.Lock()
+	defer d.commit.mu.Unlock()
+
+	// Verify that the log sequence number hasn't exceeded the minimum
+	// sequence number of the file.
+	nextSeqNum := atomic.LoadUint64(d.commit.env.logSeqNum)
+	if nextSeqNum > m.SmallestSeqNum {
+		if err := ingestCleanup(d.opts.FS, d.dirname, []*fileMetadata{m}); err != nil {
+			d.opts.Logger.Infof("flush external cleanup failed: %v", err)
+		}
+		return errors.Errorf("flush external %s: commit seqnum %d > file's smallest seqnum %d",
+			m.FileNum, nextSeqNum, m.SmallestSeqNum)
+	}
+
+	// Assign sequence numbers from its current value through to the
+	// external file's largest sequence number.
+	count := m.LargestSeqNum - nextSeqNum + 1
+
+	b := newBatch(nil)
+	defer b.release()
+	b.data = make([]byte, batchHeaderLen)
+	b.setCount(uint32(count))
+	b.commit.Add(1)
+	d.commit.pending.enqueue(b)
+	seqNum := atomic.AddUint64(d.commit.env.logSeqNum, uint64(count)) - uint64(count)
+	b.setSeqNum(seqNum)
+
+	// Apply the version edit.
+	d.mu.Lock()
+	d.mu.versions.logLock()
+	ve := &versionEdit{
+		NewFiles: []newFileEntry{newFileEntry{Level: 0, Meta: m}},
+	}
+	metrics := map[int]*LevelMetrics{
+		0: &LevelMetrics{BytesIngested: m.Size, TablesIngested: 1},
+	}
+	err := d.mu.versions.logAndApply(jobID, ve, metrics, d.dataDir, func() []compactionInfo {
+		return d.getInProgressCompactionInfoLocked(nil)
+	})
+	if err != nil {
+		// NB: logAndApply will release d.mu.versions.logLock  unconditionally.
+		d.mu.Unlock()
+		if err2 := ingestCleanup(d.opts.FS, d.dirname, []*fileMetadata{m}); err2 != nil {
+			d.opts.Logger.Infof("flush external cleanup failed: %v", err2)
+		}
+		return err
+	}
+	d.updateReadStateLocked(d.opts.DebugCheck)
+	d.deleteObsoleteFiles(jobID)
+	d.maybeScheduleCompaction()
+	d.mu.Unlock()
+
+	// Publish the sequence number.
+	d.commit.publish(b)
+
+	return nil
+}
+
+func init() {
+	private.FlushExternalTable = flushExternalTable
+}

--- a/internal/private/flush_external.go
+++ b/internal/private/flush_external.go
@@ -1,0 +1,24 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package private
+
+import (
+	"github.com/cockroachdb/pebble/internal/manifest"
+)
+
+// FlushExternalTable is a hook for linking files into L0 without assigning a
+// global sequence number, mimicking a flush. FlushExternalTable takes a
+// *pebble.DB, the path and the metadata of a sstable to flush directly into
+// L0.
+//
+// Calls to flush a sstable may fail if the file's sequence numbers are not
+// greater than the current commit pipeline's sequence number. On success the
+// commit pipeline's published sequence number will be moved to the file's
+// highest sequence number.
+//
+// This function is wrapped in a safer, more ergonomic API in the
+// internal/replay package. Clients should use the replay package rather than
+// calling this private hook directly.
+var FlushExternalTable func(interface{}, string, *manifest.FileMetadata) error

--- a/internal/replay/replay.go
+++ b/internal/replay/replay.go
@@ -1,0 +1,75 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// Package replay implements facilities for replaying writes to a database.
+package replay
+
+import (
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/internal/private"
+)
+
+// Open opens a database for replaying flushed and ingested tables. It's
+// intended for use by the `pebble bench compact` command.
+func Open(dirname string, opts *pebble.Options) (*DB, error) {
+	d, err := pebble.Open(dirname, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &DB{d: d}, nil
+}
+
+// A DB is a wrapper around a Pebble database for replaying table-level
+// writes to a database. It is not safe for concurrent access.
+type DB struct {
+	done bool
+	d    *pebble.DB
+}
+
+// Ingest ingests a set of sstables into the DB.
+func (d *DB) Ingest(paths []string) error {
+	if d.done {
+		panic("replay already finished")
+	}
+	return d.d.Ingest(paths)
+}
+
+// FlushExternal simulates a flush of the sstable at path, linking it directly
+// into level zero.
+func (d *DB) FlushExternal(path string, meta *manifest.FileMetadata) error {
+	if d.done {
+		panic("replay already finished")
+	}
+	return private.FlushExternalTable(d.d, path, meta)
+}
+
+// Metrics returns the underlying DB's Metrics.
+func (d *DB) Metrics() *pebble.Metrics {
+	if d.done {
+		panic("replay already finished")
+	}
+	return d.d.Metrics()
+}
+
+// Done finishes a replay, returning the underlying database.  All of the
+// *replay.DB's methods except Close will error if called after Done.
+func (d *DB) Done() *pebble.DB {
+	if d.done {
+		panic("replay already finished")
+	}
+	d.done = true
+	return d.d
+}
+
+// Close closes a replay and the underlying database.
+// If Close is called after Done, Close does nothing.
+func (d *DB) Close() error {
+	if d.done {
+		// Allow clients to defer Close()
+		return nil
+	}
+	d.done = true
+	return d.d.Close()
+}


### PR DESCRIPTION
This PR has two commits. One introduces a private hook for ingesting sstables with nonzero sequence numbers directly into L0. The other adapts cmd/pebble's bench compact commands to use the new hook.