### PR TITLE
internal/arenaskl: ensure entire node points to allocated memory

### DIFF
--- a/internal/arenaskl/arena.go
+++ b/internal/arenaskl/arena.go
@@ -67,7 +67,7 @@ func (a *Arena) Capacity() uint32 {
 	return uint32(len(a.buf))
 }
 
-func (a *Arena) alloc(size, align uint32) (uint32, uint32, error) {
+func (a *Arena) alloc(size, align, overflow uint32) (uint32, uint32, error) {
 	// Verify that the arena isn't already full.
 	origSize := atomic.LoadUint64(&a.n)
 	if int(origSize) > len(a.buf) {
@@ -78,7 +78,7 @@ func (a *Arena) alloc(size, align uint32) (uint32, uint32, error) {
 	padded := uint32(size) + align
 
 	newSize := atomic.AddUint64(&a.n, uint64(padded))
-	if int(newSize) > len(a.buf) {
+	if int(newSize)+int(overflow) > len(a.buf) {
 		return 0, 0, ErrArenaFull
 	}
 

--- a/internal/arenaskl/arena_test.go
+++ b/internal/arenaskl/arena_test.go
@@ -34,19 +34,19 @@ func TestArenaSizeOverflow(t *testing.T) {
 	a := newArena(math.MaxUint32)
 
 	// Allocating under the limit throws no error.
-	offset, _, err := a.alloc(math.MaxUint16, 0)
+	offset, _, err := a.alloc(math.MaxUint16, 0, 0)
 	require.Nil(t, err)
 	require.Equal(t, uint32(1), offset)
 	require.Equal(t, uint32(math.MaxUint16)+1, a.Size())
 
 	// Allocating over the limit could cause an accounting
 	// overflow if 32-bit arithmetic was used. It shouldn't.
-	_, _, err = a.alloc(math.MaxUint32, 0)
+	_, _, err = a.alloc(math.MaxUint32, 0, 0)
 	require.Equal(t, ErrArenaFull, err)
 	require.Equal(t, uint32(math.MaxUint32), a.Size())
 
 	// Continuing to allocate continues to throw an error.
-	_, _, err = a.alloc(math.MaxUint16, 0)
+	_, _, err = a.alloc(math.MaxUint16, 0, 0)
 	require.Equal(t, ErrArenaFull, err)
 	require.Equal(t, uint32(math.MaxUint32), a.Size())
 }

--- a/internal/arenaskl/node.go
+++ b/internal/arenaskl/node.go
@@ -87,11 +87,11 @@ func newNode(
 func newRawNode(arena *Arena, height uint32, keySize, valueSize uint32) (nd *node, err error) {
 	// Compute the amount of the tower that will never be used, since the height
 	// is less than maxHeight.
-	unusedSize := (maxHeight - int(height)) * linksSize
-	nodeSize := uint32(maxNodeSize - unusedSize)
+	unusedSize := uint32((maxHeight - int(height)) * linksSize)
+	nodeSize := uint32(maxNodeSize) - unusedSize
 	valueIndex := int32(valueSize)
 
-	nodeOffset, allocSize, err := arena.alloc(nodeSize+keySize+valueSize, align4)
+	nodeOffset, allocSize, err := arena.alloc(nodeSize+keySize+valueSize, align4, unusedSize)
 	if err != nil {
 		return
 	}

--- a/internal/arenaskl/race_test.go
+++ b/internal/arenaskl/race_test.go
@@ -1,0 +1,41 @@
+// +build race
+
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package arenaskl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNodeArenaEnd tests allocating a node at the boundary of an arena. In Go
+// 1.14 when the race detector is running, Go will also perform some pointer
+// alignment checks. It will detect alignment issues, for example #667 where a
+// node's memory would straddle the arena boundary, with unused regions of the
+// node struct dipping into unallocated memory. This test is only run when the
+// race build tag is provided.
+func TestNodeArenaEnd(t *testing.T) {
+	ikey := makeIkey("a")
+	val := []byte("b")
+
+	// Rather than hardcode an arena size at just the right size, try
+	// allocating using successively larger arena sizes until we allocate
+	// successfully. The prior attempt will have exercised the right code
+	// path.
+	for i := uint32(1); i < 256; i++ {
+		a := newArena(i)
+		_, err := newNode(a, 1, ikey, val)
+		if err == nil {
+			// We reached an arena size big enough to allocate a node.
+			// If there's an issue at the boundary, the race detector would
+			// have found it by now.
+			t.Log(i)
+			break
+		}
+		require.Equal(t, ErrArenaFull, err)
+	}
+}


### PR DESCRIPTION
This commit solves the same problem as #667 but for the arenaskl. A
node allocated at the end of the arena might straddle the edge of the
arena's allocated memory. The Go 1.14 checkptr compile flag (which is
enabled on -race builds) would complain when these boundary nodes were
converted to a `*node`.