### PR TITLE
db: don't create mutable memtable in read-only mode

### DIFF
--- a/open.go
+++ b/open.go
@@ -321,6 +321,9 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	if !d.opts.ReadOnly {
 		d.scanObsoleteFiles(ls)
 		d.deleteObsoleteFiles(jobID)
+	} else {
+		// All the log files are obsolete.
+		d.mu.versions.metrics.WAL.Files = int64(len(logFiles))
 	}
 	d.maybeScheduleFlush()
 	d.maybeScheduleCompaction()
@@ -528,14 +531,7 @@ func (d *DB) replayWAL(
 	}
 	flushMem()
 	// mem is nil here.
-	if d.opts.ReadOnly {
-		// We need to restore the invariant that the last memtable in d.mu.mem.queue is the
-		// mutable one for the next WAL file, since in read-only mode, each WAL file is replayed
-		// into its own set of memtables. This is done so that the WAL metrics can be accurately
-		// provided.
-		ensureMem(atomic.LoadUint64(&d.mu.versions.logSeqNum))
-		d.mu.versions.metrics.WAL.Files++
-	} else {
+	if !d.opts.ReadOnly {
 		c := newFlush(d.opts, d.mu.versions.currentVersion(),
 			1 /* base level */, toFlush, &d.bytesFlushed)
 		newVE, _, err := d.runCompaction(jobID, c, nilPacer)

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -11,7 +11,7 @@ db lsm
 ../testdata/db-stage-4
 ----
 __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___r-amp___w-amp
-    WAL         1    82 B       -     0 B       -       -       -       -    82 B       -       -       -     0.0
+    WAL         1     0 B       -     0 B       -       -       -       -     0 B       -       -       -     0.0
       0         1   986 B    0.25     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       2         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
@@ -19,10 +19,10 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       4         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       6         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
-  total         1   986 B       -    82 B     0 B       0     0 B       0    82 B       0     0 B       0     1.0
+  total         1   986 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
   flush         0
 compact         0   986 B          (size == estimated-debt)
- memtbl         2   768 K
+ memtbl         1   256 K
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         0     0 B    0.0%  (score == hit-rate)


### PR DESCRIPTION
Don't create a mutable memtable while replaying read-only mode.
Previously we used d.mu.versions.logSeqNum as the seqnum for the mutable
memtable, but that isn't guaranteed to be less than the sequence number
of any additional logs that we've yet to replay.

See cockroachdb/cockroach#48660.