### PR TITLE
crl-release-20.1: db: don't create mutable memtable in read-only mode

### DIFF
--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -11,7 +11,7 @@ db lsm
 ../testdata/db-stage-4
 ----
 __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___w-amp
-    WAL         1    82 B       -     0 B       -       -       -       -    82 B       -       -     0.0
+    WAL         1     0 B       -     0 B       -       -       -       -     0 B       -       -     0.0
       0         1   986 B    0.25     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
       1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
       2         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
@@ -19,10 +19,10 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       4         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
       6         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
-  total         1   986 B       -    82 B     0 B       0     0 B       0    82 B       0     0 B     1.0
+  total         1   986 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
   flush         0
 compact         0   986 B          (size == estimated-debt)
- memtbl         2   768 K
+ memtbl         1   256 K
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         0     0 B    0.0%  (score == hit-rate)


### PR DESCRIPTION
20.1 backport of #671.

---

Don't create a mutable memtable while replaying read-only mode.
Previously we used d.mu.versions.logSeqNum as the seqnum for the mutable
memtable, but that isn't guaranteed to be less than the sequence number
of any additional logs that we've yet to replay.