### PR TITLE
internal/replay: assign ingested tables correct sequence number

### DIFF
--- a/cmd/pebble/compact.go
+++ b/cmd/pebble/compact.go
@@ -263,21 +263,24 @@ func runReplay(cmd *cobra.Command, args []string) error {
 				replayedCount++
 				verbosef("Flushing table %d/%d %s (%s, seqnums %d-%d)\n", replayedCount, workloadTableCount,
 					name, humanize.Int64(int64(f.meta.Size)), f.meta.SmallestSeqNum, f.meta.LargestSeqNum)
-				if err := rd.FlushExternal(tablePath, f.meta); err != nil {
+				if err := rd.FlushExternal(replay.Table{Path: tablePath, FileMetadata: f.meta}); err != nil {
 					return err
 				}
 			}
 		} else {
-			var paths []string
+			var tables []replay.Table
 			for _, f := range li.added {
 				name := fmt.Sprintf("%s.sst", f.meta.FileNum)
 				tablePath := filepath.Join(workloadDir, name)
 				replayedCount++
 				verbosef("Ingesting %d tables: table %d/%d %s (%s)\n", len(li.added), replayedCount,
 					workloadTableCount, name, humanize.Int64(int64(f.meta.Size)))
-				paths = append(paths, tablePath)
+				tables = append(tables, replay.Table{
+					Path:         tablePath,
+					FileMetadata: f.meta,
+				})
 			}
-			if err := rd.Ingest(paths); err != nil {
+			if err := rd.Ingest(tables); err != nil {
 				return err
 			}
 		}

--- a/commit.go
+++ b/commit.go
@@ -405,3 +405,18 @@ func (p *commitPipeline) publish(b *Batch) {
 		t.commit.Done()
 	}
 }
+
+// ratchetSeqNum allocates all sequence numbers less than but excluding
+// `nextSeqNum`, returning the lowest sequence number it allocates and the
+// number of sequence numbers allocated. If the next sequence number is
+// already greater than or equal to nextSeqNum, ratchetSeqNum returns 0 for
+// both values.
+func (p *commitPipeline) ratchetSeqNum(nextSeqNum uint64) (seqNum uint64, count uint64) {
+	logSeqNum := atomic.LoadUint64(p.env.logSeqNum)
+	if logSeqNum >= nextSeqNum {
+		return 0, 0
+	}
+	count = nextSeqNum - logSeqNum
+	seqNum = atomic.AddUint64(p.env.logSeqNum, uint64(count)) - uint64(count)
+	return seqNum, count
+}

--- a/internal/private/flush_external.go
+++ b/internal/private/flush_external.go
@@ -22,3 +22,12 @@ import (
 // internal/replay package. Clients should use the replay package rather than
 // calling this private hook directly.
 var FlushExternalTable func(interface{}, string, *manifest.FileMetadata) error
+
+// RatchetSeqNum is a hook for allocating sequence numbers up to a specific
+// absolute value. Its first parameter is a *pebble.DB and its second is the
+// new next sequence number. RatchetSeqNum does nothing if the next sequence
+// is already greater than or equal to nextSeqNum.
+//
+// This function is used by the internal/replay package to ensure replayed
+// operations receive the same absolute sequence number.
+var RatchetSeqNum func(interface{}, uint64)


### PR DESCRIPTION
Previously, the internal/replay package and `pebble bench compact` did
not account for flushes with lower sequence numbers than preceding
ingestions. These flushes are possible when keys accumulate in a
memtable and do not overlap with the ingestion that succeeds them.

This change updates internal/replay to ratchet nextSeqNum up to the
ingested file's original sequence number from when it was ingested in
the reference database. It also updates the external flush logic to only
ratchet and publish sequence numbers when required.

These changes mean that during the course of a replay, keys may appear
at historical sequence numbers. This is okay because the database does
not escape from the replay.DB wrapper which never performs reads. It's
also okay because the replay will converge on a consistent state as long
as the reference database's operations were consistent.

I discovered this while replaying tables from a `clearrange` roachtest.