### PR TITLE
db: replace tableCacheShard LRU with Clock-PRO

### DIFF
--- a/open.go
+++ b/open.go
@@ -86,7 +86,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	if tableCacheSize < minTableCacheSize {
 		tableCacheSize = minTableCacheSize
 	}
-	d.tableCache.init(d.cacheID, dirname, opts.FS, d.opts, tableCacheSize, defaultTableCacheHitBuffer)
+	d.tableCache.init(d.cacheID, dirname, opts.FS, d.opts, tableCacheSize)
 	d.newIters = d.tableCache.newIters
 	d.commit = newCommitPipeline(commitEnv{
 		logSeqNum:     &d.mu.versions.logSeqNum,


### PR DESCRIPTION
The Clock-PRO cache replacement algorithm avoids ever using an exclusive
lock on access (even a batched/deferred exclusive lock). The common case
for the tableCache is that it is sized so that size-based evictions are
never performed. Avoiding exclusive locks on access performs
significantly better in that common case, removing `tableCacheShard.mu`
as a contention bottleneck.

The impact on `pebble bench ycsb --workload=C` (100% reads) is dramatic:

```
name     old ops/sec  new ops/sec  delta
ycsb/C   617k ± 1%   1346k ± 1%  +118.15%  (p=0.000 n=10+10)
```

The mutex contention profile showed the old table cache spending
significant time with the shard lock exclusively held while "recording
hits":

```
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context
----------------------------------------------------------+-------------
                                            63.38s 99.71% |   github.com/cockroachdb/pebble.(*tableCacheShard).recordHits
                                             0.18s  0.29% |   github.com/cockroachdb/pebble/internal/cache.(*shard).Set
     1.98s  3.11%  3.11%     63.57s 99.66%                | sync.(*RWMutex).Unlock
                                            61.58s 96.88% |   sync.(*Mutex).Unlock
```

A 100% read workload is the best case for this change, but it also
affects other workloads. Here are workload A (50% reads, 50% updates)
and B (95% reads, 5% updates):

```
name     old ops/sec  new ops/sec  delta
ycsb/A   755k ± 1%    769k ± 1%    +1.76%  (p=0.000 n=10+10)
ycsb/B   643k ± 1%    804k ± 1%   +25.07%  (p=0.000 n=10+9)
```