### PR TITLE
internal/{manual,rawalloc}: remove empty assembly files

### DIFF
--- a/internal/manual/manual.s
+++ b/internal/manual/manual.s
@@ -1,1 +1,0 @@
-// Empty assembly file to allow go:linkname to work.

--- a/internal/rawalloc/rawalloc.s
+++ b/internal/rawalloc/rawalloc.s
@@ -1,1 +1,0 @@
-// Empty assembly file to allow go:linkname to work.


### PR DESCRIPTION
They are no longer needed for `go:linkname` to function, but cause
problems as without additional work they can cause the binary to have
executable stacks.

Fixes #680