### PR TITLE
internal/private: ratchet visible sequence number too

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -418,17 +418,17 @@ func (p *commitPipeline) publish(b *Batch) {
 	}
 }
 
-// ratchetSeqNum allocates all sequence numbers less than but excluding
-// `nextSeqNum`, returning the lowest sequence number it allocates and the
-// number of sequence numbers allocated. If the next sequence number is
-// already greater than or equal to nextSeqNum, ratchetSeqNum returns 0 for
-// both values.
-func (p *commitPipeline) ratchetSeqNum(nextSeqNum uint64) (seqNum uint64, count uint64) {
+// ratchetSeqNum allocates and marks visible all sequence numbers less than
+// but excluding `nextSeqNum`.
+func (p *commitPipeline) ratchetSeqNum(nextSeqNum uint64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	logSeqNum := atomic.LoadUint64(p.env.logSeqNum)
 	if logSeqNum >= nextSeqNum {
-		return 0, 0
+		return
 	}
-	count = nextSeqNum - logSeqNum
-	seqNum = atomic.AddUint64(p.env.logSeqNum, uint64(count)) - uint64(count)
-	return seqNum, count
+	count := nextSeqNum - logSeqNum
+	_ = atomic.AddUint64(p.env.logSeqNum, uint64(count)) - uint64(count)
+	atomic.StoreUint64(p.env.visibleSeqNum, nextSeqNum)
 }

--- a/internal/private/flush_external.go
+++ b/internal/private/flush_external.go
@@ -23,10 +23,10 @@ import (
 // calling this private hook directly.
 var FlushExternalTable func(interface{}, string, *manifest.FileMetadata) error
 
-// RatchetSeqNum is a hook for allocating sequence numbers up to a specific
-// absolute value. Its first parameter is a *pebble.DB and its second is the
-// new next sequence number. RatchetSeqNum does nothing if the next sequence
-// is already greater than or equal to nextSeqNum.
+// RatchetSeqNum is a hook for allocating and publishing sequence numbers up
+// to a specific absolute value. Its first parameter is a *pebble.DB and its
+// second is the new next sequence number. RatchetSeqNum does nothing if the
+// next sequence is already greater than or equal to nextSeqNum.
 //
 // This function is used by the internal/replay package to ensure replayed
 // operations receive the same absolute sequence number.


### PR DESCRIPTION
Update private.RatchetSeqNum to ratchet the visible sequence number too.
Previously, we would use RatchetSeqNum to ratchet the sequence number
before an Ingest, but with 9ff7ba9 the Ingest would spin waiting for a
sequence number to be published that would never be published.