### PR TITLE
internal/cache: remove weak cache handles and optimize cache.Delete()

### DIFF
--- a/docs/rocksdb.md
+++ b/docs/rocksdb.md
@@ -751,8 +751,6 @@ and writes are served as quickly as possible.
   calls
 * Previous pointers in the memtable and indexed batch skiplists
 * Elision of per-key lower/upper bound checks in long range scans
-* Weak cache references remove the need to pin index and filter blocks
-  in memory
 * Improved `Iterator` API
   + `SeekPrefixGE` for prefix iteration
   + `SetBounds` for adjusting the bounds on an existing `Iterator`

--- a/internal/cache/clockpro.go
+++ b/internal/cache/clockpro.go
@@ -52,13 +52,10 @@ func (k key) String() string {
 	return fmt.Sprintf("%d/%d/%d", k.id, k.fileNum, k.offset)
 }
 
-// Handle provides a strong reference to an entry in the cache. The reference
-// does not pin the entry in the cache, but it does prevent the underlying byte
-// slice from being reused. When entry is non-nil, value is initialized to
-// entry.val. Over the lifetime of the handle (until Release is called),
-// entry.val may change, but value will remain unchanged.
+// Handle provides a strong reference to a value in the cache. The reference
+// does not pin the value in the cache, but it does prevent the underlying byte
+// slice from being reused.
 type Handle struct {
-	entry *entry
 	value *Value
 }
 
@@ -77,51 +74,6 @@ func (h Handle) Release() {
 	if h.value != nil {
 		h.value.release()
 	}
-	if h.entry != nil {
-		h.entry.release()
-	}
-}
-
-// Weak converts the (strong) handle into a WeakHandle. A WeakHandle allows the
-// underlying data to be evicted and GC'd, while allowing WeakHandle.Strong()
-// to quickly convert the handle back to a strong handle in order to retrieve
-// the cached data (if it has not been evicted). It is still necessary to call
-// Handle.Release() after calling Weak() (i.e. the receiver - a strong handle -
-// still maintains a reference to the value).
-func (h Handle) Weak() *WeakHandle {
-	if h.entry == nil {
-		return nil
-	}
-	h.entry.acquire()
-	return (*WeakHandle)(h.entry)
-}
-
-// WeakHandle provides a "weak" reference to an entry in the cache. A weak
-// reference allows the entry to be evicted, but also provides fast access
-type WeakHandle entry
-
-// Strong converts the weak handle into a strong handle, allowing the value to
-// be retrieved. The returned Handle must be released.
-func (h *WeakHandle) Strong() Handle {
-	e := (*entry)(h)
-	v := e.acquireValue()
-	if v == nil {
-		return Handle{}
-	}
-	atomic.StoreInt32(&e.referenced, 1)
-	// Record a cache hit because the entry is being used as a WeakHandle and
-	// successfully avoided a more expensive shard.Get() operation.
-	atomic.AddInt64(&e.shard.hits, 1)
-	// NB: The returned strong handle cannot be converted back to a weak handle
-	// again. We could allow this, but it adds an entry.acquire() call to this
-	// path.
-	return Handle{value: v}
-}
-
-// Release releases the reference to the cache entry.
-func (h *WeakHandle) Release() {
-	e := (*entry)(h)
-	e.release()
 }
 
 type shard struct {
@@ -154,15 +106,11 @@ type shard struct {
 
 func (c *shard) Get(id uint64, fileNum base.FileNum, offset uint64) Handle {
 	c.mu.RLock()
-	e := c.blocks.Get(key{fileKey{id, fileNum}, offset})
 	var value *Value
-	if e != nil {
+	if e := c.blocks.Get(key{fileKey{id, fileNum}, offset}); e != nil {
 		value = e.acquireValue()
 		if value != nil {
 			atomic.StoreInt32(&e.referenced, 1)
-			e.acquire()
-		} else {
-			e = nil
 		}
 	}
 	c.mu.RUnlock()
@@ -171,7 +119,7 @@ func (c *shard) Get(id uint64, fileNum base.FileNum, offset uint64) Handle {
 		return Handle{}
 	}
 	atomic.AddInt64(&c.hits, 1)
-	return Handle{entry: e, value: value}
+	return Handle{value: value}
 }
 
 func (c *shard) Set(id uint64, fileNum base.FileNum, offset uint64, value *Value) Handle {
@@ -193,10 +141,9 @@ func (c *shard) Set(id uint64, fileNum base.FileNum, offset uint64, value *Value
 		if c.metaAdd(k, e) {
 			value.ref.trace("add-cold")
 			c.sizeCold += e.size
-			e.acquire()
 		} else {
 			value.ref.trace("skip-cold")
-			e.release()
+			e.free()
 			e = nil
 		}
 
@@ -213,9 +160,6 @@ func (c *shard) Set(id uint64, fileNum base.FileNum, offset uint64, value *Value
 			value.ref.trace("add-cold")
 			c.sizeCold += delta
 		}
-		// NB: the call to shard.evict() may evict "e", so we have to acquire a
-		// reference to it first.
-		e.acquire()
 		c.evict()
 
 	default:
@@ -235,17 +179,16 @@ func (c *shard) Set(id uint64, fileNum base.FileNum, offset uint64, value *Value
 		if c.metaAdd(k, e) {
 			value.ref.trace("add-hot")
 			c.sizeHot += e.size
-			e.acquire()
 		} else {
 			value.ref.trace("skip-hot")
-			e.release()
+			e.free()
 			e = nil
 		}
 	}
 
 	// Values are initialized with a reference count of 1. That reference count
 	// is being transferred to the returned Handle.
-	return Handle{entry: e, value: value}
+	return Handle{value: value}
 }
 
 // Delete deletes the cached value for the specified file and offset.
@@ -288,7 +231,7 @@ func (c *shard) Free() {
 	for c.handHot != nil {
 		e := c.handHot
 		c.metaDel(c.handHot)
-		e.release()
+		e.free()
 	}
 
 	c.blocks.free()
@@ -441,7 +384,7 @@ func (c *shard) metaEvict(e *entry) {
 	}
 	c.metaDel(e)
 	c.metaCheck(e)
-	e.release()
+	e.free()
 }
 
 func (c *shard) evict() {
@@ -515,7 +458,7 @@ func (c *shard) runHandTest() {
 		}
 		c.metaDel(e)
 		c.metaCheck(e)
-		e.release()
+		e.free()
 	}
 
 	c.handTest = c.handTest.next()
@@ -551,25 +494,6 @@ type Metrics struct {
 // maintains a map of the cached blocks for a particular fileNum. This allows
 // efficient eviction of all of the blocks for a file which is used when an
 // sstable is deleted from disk.
-//
-// Strong vs Weak Handles
-//
-// When a block is retrieved from the cache, a Handle is returned. The Handle
-// maintains a reference to the associated value and will prevent the value
-// from being removed. The caller must call Handle.Release() when they are done
-// using the value (failure to do so will result in a memory leak). Until
-// Handle.Release() is called, the value is pinned in memory.
-//
-// A Handle can be transformed into a WeakHandle by a call to Handle.Weak(). A
-// WeakHandle does not pin the associated value in memory, and instead allows
-// the value to be evicted from the cache and reclaimed by the Go GC. In order
-// to retrieve the value from a WeakHandle, the handle can be transformed back
-// into a strong handle by calling WeakHandle.Strong(). The returned strong
-// handle may be empty if the value has been evicted from the
-// cache. WeakHandle's are useful for avoiding the overhad of a cache
-// lookup. They are used for sstable index, filter, and range-del blocks, which
-// are frequently accessed, almost always in the cache, but which we want to
-// allow to be evicted under memory pressure.
 //
 // Memory Management
 //

--- a/internal/cache/clockpro_test.go
+++ b/internal/cache/clockpro_test.go
@@ -65,34 +65,6 @@ func testValue(cache *Cache, s string, repeat int) *Value {
 	return v
 }
 
-func TestWeakHandle(t *testing.T) {
-	cache := newShards(5, 1)
-	defer cache.Unref()
-
-	cache.Set(1, 1, 0, testValue(cache, "a", 5)).Release()
-	h := cache.Set(1, 0, 0, testValue(cache, "b", 5))
-	if v := h.Get(); string(v) != "bbbbb" {
-		t.Fatalf("expected bbbbb, but found %v", v)
-	}
-	w := h.Weak()
-	h.Release()
-	h = w.Strong()
-	if v := h.Get(); string(v) != "bbbbb" {
-		t.Fatalf("expected bbbbb, but found %v", v)
-	}
-	if h.Weak() != nil {
-		t.Fatalf("unexpectedly convert strong handle back to weak handle")
-	}
-	h.Release()
-	cache.Set(1, 2, 0, testValue(cache, "a", 5)).Release()
-	h = w.Strong()
-	if v := h.Get(); v != nil {
-		t.Fatalf("expected nil, but found %s", v)
-	}
-	h.Release()
-	w.Release()
-}
-
 func TestCacheDelete(t *testing.T) {
 	cache := newShards(100, 1)
 	defer cache.Unref()

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -169,7 +169,7 @@ compact         1   1.6 K          (size == estimated-debt)
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.4 K    5.9%  (score == hit-rate)
- tcache         1   672 B    0.0%  (score == hit-rate)
+ tcache         1   576 B    0.0%  (score == hit-rate)
  titers         0
  filter         -       -    0.0%  (score == utility)
 

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -33,7 +33,7 @@ compact         0   771 B          (size == estimated-debt)
 zmemtbl         1   256 K
    ztbl         0     0 B
  bcache         4   698 B    0.0%  (score == hit-rate)
- tcache         1   672 B    0.0%  (score == hit-rate)
+ tcache         1   576 B    0.0%  (score == hit-rate)
  titers         1
  filter         -       -    0.0%  (score == utility)
 
@@ -75,7 +75,7 @@ compact         1     0 B          (size == estimated-debt)
 zmemtbl         2   512 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   33.3%  (score == hit-rate)
- tcache         2   1.3 K   50.0%  (score == hit-rate)
+ tcache         2   1.1 K   50.0%  (score == hit-rate)
  titers         2
  filter         -       -    0.0%  (score == utility)
 
@@ -102,7 +102,7 @@ compact         1     0 B          (size == estimated-debt)
 zmemtbl         1   256 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   33.3%  (score == hit-rate)
- tcache         2   1.3 K   50.0%  (score == hit-rate)
+ tcache         2   1.1 K   50.0%  (score == hit-rate)
  titers         2
  filter         -       -    0.0%  (score == utility)
 
@@ -130,7 +130,7 @@ compact         1     0 B          (size == estimated-debt)
 zmemtbl         1   256 K
    ztbl         1   771 B
  bcache         4   698 B   33.3%  (score == hit-rate)
- tcache         1   672 B   50.0%  (score == hit-rate)
+ tcache         1   576 B   50.0%  (score == hit-rate)
  titers         1
  filter         -       -    0.0%  (score == utility)
 


### PR DESCRIPTION
Weak cache handles were introduced to reduce the overhead of looking up a
block in the cache. For blocks such as sstable index blocks, rather than
looking the block up in the cache, a weak handle would held a reference to
the cache entry. This reference could then be converted to a "strong
handle" and used to retrieve the cache value. Weak handles thus avoided the
sharding locking and the map lookup. But in order to implement weak
handles, additional locking and reference counting was necessary. Cache
entries needed to be reference counted, and the value pointed to be a cache
entry required a `RWMutex`. The overhead of the
`RWMutex` was showing up prominently in CPU profiles of read heavy 
workloads. And thus overhead was mainly coming from the normal
`Cache.Get()` code path, not from the weak handle code path. As an 
experiment, I disabled weak handles and saw a modest performance win, which
motivated fully ripping them outp. Note that ycsb A is 50% reads, ycsb B is
95% reads, and ycsb C is 100% reads.

```
name     old ops/sec  new ops/sec   delta
ycsb/A     769k ± 1%    768k ± 0%     ~     (p=1.000 n=10+7)
ycsb/B     804k ± 1%    819k ± 0%   +1.87%  (p=0.000 n=9+10)
ycsb/C    1.34M ± 1%   1.41M ± 1%   +5.13%  (p=0.000 n=10+10)
```

`Cache.Delete()` is used by `sstable.Writer` to preemptively remove blocks
from the cache in the unexpected case that a file number is reused. The
expectation is that the block won't be present. So do an initial check
using a shared lock which is less disruptive for concurrent accesses.

```
name     old ops/sec  new ops/sec   delta
ycsb/A     768k ± 0%    778k ± 1%   +1.22%  (p=0.000 n=7+9)
ycsb/B     819k ± 0%    818k ± 0%     ~     (p=0.211 n=10+9)
ycsb/D     612k ± 2%    641k ± 1%   +4.69%  (p=0.000 n=10+10)
```