### PR TITLE
internal/rate: add Limiter.Delay{,N}

### DIFF
--- a/cmd/pebble/random.go
+++ b/cmd/pebble/random.go
@@ -95,9 +95,8 @@ func wait(l *rate.Limiter) {
 		return
 	}
 
-	now := time.Now()
-	r := l.ReserveN(now, 1)
-	if d := r.DelayFrom(now); d > 0 {
+	d := l.DelayN(time.Now(), 1)
+	if d > 0 && d != rate.InfDuration {
 		time.Sleep(d)
 	}
 }

--- a/internal/rate/rate.go
+++ b/internal/rate/rate.go
@@ -258,6 +258,19 @@ func (lim *Limiter) WaitN(ctx context.Context, n int) (err error) {
 	}
 }
 
+// Delay is shorthand for DelayN(time.Now(), 1).
+func (lim *Limiter) Delay() time.Duration {
+	return lim.DelayN(time.Now(), 1)
+}
+
+// DelayN returns the delay to wait to permit n events to happen. Zero duration
+// means act immediately. InfDuration means the limiter cannot grant the tokens
+// requested within the maximum wait time.
+func (lim *Limiter) DelayN(now time.Time, n int) time.Duration {
+	r := lim.reserveN(now, n, InfDuration)
+	return r.DelayFrom(now)
+}
+
 // SetLimit is shorthand for SetLimitAt(time.Now(), newLimit).
 func (lim *Limiter) SetLimit(newLimit Limit) {
 	lim.SetLimitAt(time.Now(), newLimit)

--- a/pacer_test.go
+++ b/pacer_test.go
@@ -6,7 +6,6 @@ package pebble
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -22,9 +21,9 @@ type mockCountLimiter struct {
 	burst      int
 }
 
-func (m *mockCountLimiter) WaitN(ctx context.Context, n int) error {
+func (m *mockCountLimiter) DelayN(now time.Time, n int) time.Duration {
 	m.waitCount += n
-	return nil
+	return 0
 }
 
 func (m *mockCountLimiter) AllowN(now time.Time, n int) bool {
@@ -41,9 +40,9 @@ type mockPrintLimiter struct {
 	burst int
 }
 
-func (m *mockPrintLimiter) WaitN(ctx context.Context, n int) error {
+func (m *mockPrintLimiter) DelayN(now time.Time, n int) time.Duration {
 	fmt.Fprintf(&m.buf, "wait: %d\n", n)
-	return nil
+	return 0
 }
 
 func (m *mockPrintLimiter) AllowN(now time.Time, n int) bool {


### PR DESCRIPTION
Add `Limiter.Delay{,N}` as an alternative to `Limiter.Reserve{,N}` that
is more convenient for mocking (because the internal fields of a
`Reservation` are not exported). This allows using `DelayN` in the
`internalPacer` implementation rather than the timer allocation heavy
`WaitN`.