### PR TITLE
cmd/pebble: close batches after committing them

### DIFF
--- a/cmd/pebble/badger.go
+++ b/cmd/pebble/badger.go
@@ -126,6 +126,10 @@ type badgerBatch struct {
 	txn *badger.Txn
 }
 
+func (b badgerBatch) Close() error {
+	return nil
+}
+
 func (b badgerBatch) Commit(opts *pebble.WriteOptions) error {
 	return b.txn.Commit()
 }

--- a/cmd/pebble/boltdb.go
+++ b/cmd/pebble/boltdb.go
@@ -149,6 +149,10 @@ type boltDBBatch struct {
 	bucket *bolt.Bucket
 }
 
+func (b boltDBBatch) Close() error {
+	return nil
+}
+
 func (b boltDBBatch) Commit(opts *pebble.WriteOptions) error {
 	return b.tx.Commit()
 }

--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -35,6 +35,7 @@ type iterator interface {
 }
 
 type batch interface {
+	Close() error
 	Commit(opts *pebble.WriteOptions) error
 	Set(key, value []byte, opts *pebble.WriteOptions) error
 	LogData(data []byte, opts *pebble.WriteOptions) error

--- a/cmd/pebble/rocksdb.go
+++ b/cmd/pebble/rocksdb.go
@@ -107,6 +107,11 @@ func (i rocksDBIterator) Close() error {
 	return nil
 }
 
+func (b rocksDBBatch) Close() error {
+	b.batch.Close()
+	return nil
+}
+
 func (b rocksDBBatch) Commit(opts *pebble.WriteOptions) error {
 	return b.batch.Commit(opts.Sync)
 }
@@ -353,6 +358,11 @@ func (i crdbPebbleDBIterator) Prev() bool {
 
 func (i crdbPebbleDBIterator) Close() error {
 	i.iter.Close()
+	return nil
+}
+
+func (b crdbPebbleDBBatch) Close() error {
+	b.batch.Close()
 	return nil
 }
 

--- a/cmd/pebble/ycsb.go
+++ b/cmd/pebble/ycsb.go
@@ -334,6 +334,7 @@ func (y *ycsb) init(db DB, wg *sync.WaitGroup) {
 		if err := b.Commit(y.writeOpts); err != nil {
 			log.Fatal(err)
 		}
+		_ = b.Close()
 		fmt.Printf("inserted keys [%d-%d)\n",
 			1+ycsbConfig.prepopulatedKeys,
 			1+ycsbConfig.prepopulatedKeys+ycsbConfig.initialKeys)
@@ -441,6 +442,7 @@ func (y *ycsb) insert(db DB, buf *ycsbBuf) {
 	if err := b.Commit(y.writeOpts); err != nil {
 		log.Fatal(err)
 	}
+	_ = b.Close()
 	atomic.AddUint64(&y.numKeys[ycsbInsert], uint64(len(keyNums)))
 
 	for i := range keyNums {
@@ -490,6 +492,7 @@ func (y *ycsb) update(db DB, buf *ycsbBuf) {
 	if err := b.Commit(y.writeOpts); err != nil {
 		log.Fatal(err)
 	}
+	_ = b.Close()
 	atomic.AddUint64(&y.numKeys[ycsbUpdate], uint64(count))
 }
 


### PR DESCRIPTION
Batches are not released for reuse unless they are closed. This plugs a
significant source of GC pressure in `bench ycsb`.