### PR TITLE
cmd/pebble: use read amp for pacing

### DIFF
--- a/cmd/pebble/compact.go
+++ b/cmd/pebble/compact.go
@@ -328,7 +328,8 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Average database size: %s\n", humanize.Uint64(sizeSum/sizeCount))
 	fmt.Printf("Read amplification: %d\n", ramp)
 	fmt.Printf("Total write amplification: %.2f\n", totalWriteAmp(m))
-	fmt.Printf("Space amplification: %.2f\n", float64(beforeSize)/float64(afterSize))
+	fmt.Printf("Space amplification: %.2f (%s, %s)\n", float64(beforeSize)/float64(afterSize),
+		humanize.Int64(int64(beforeSize)), humanize.Int64(int64(afterSize)))
 	return nil
 }
 


### PR DESCRIPTION
Use L0 read amplification to set pacing in `pebble bench compact run`,
rather than L0 byte size.

Also, print the actual before and after database sizes alongside the
space amplification.