### PR TITLE
db: fix estimated compaction debt calculation

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -908,11 +908,11 @@ func TestCompaction(t *testing.T) {
 		t.Fatalf("db Close: %v", err)
 	}
 
-	if !(mockLimiter.allowCount > 0) {
-		t.Errorf("limiter allow: got %d, want >%d", mockLimiter.allowCount, 0)
+	if mockLimiter.allowCount != 0 {
+		t.Errorf("limiter allow: got %d, want %d", mockLimiter.allowCount, 0)
 	}
-	if mockLimiter.waitCount != 0 {
-		t.Errorf("limiter wait: got %d, want %d", mockLimiter.waitCount, 0)
+	if mockLimiter.waitCount == 0 {
+		t.Errorf("limiter wait: got %d, want >%d", mockLimiter.waitCount, 0)
 	}
 }
 

--- a/testdata/compaction_picker_estimated_debt
+++ b/testdata/compaction_picker_estimated_debt
@@ -51,13 +51,13 @@ init 1
 5: 10
 6: 10
 ----
-38
+48
 
 init 1
 0: 10
 6: 100
 ----
-19
+0
 
 init 1
 0: 10
@@ -65,13 +65,13 @@ init 1
 5: 10
 6: 100
 ----
-89
+90
 
 init 1
 0: 10
 6: 1000
 ----
-19
+0
 
 init 1
 5: 101
@@ -95,3 +95,14 @@ init 1000
 6: 10000
 ----
 6000
+
+# Regression test case which was previously computing an overly large
+# estimated debt due to faulty handling of L0.
+
+init 64
+0: 236
+4: 113
+5: 480
+6: 2457
+----
+2574

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -164,7 +164,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6         1   770 B    0.00   1.5 K     0 B       0     0 B       0   770 B       1   1.5 K       1     0.5
   total         3   2.3 K       -   933 B   825 B       1     0 B       0   3.9 K       4   1.5 K       3     4.3
   flush         3
-compact         1   1.6 K          (size == estimated-debt)
+compact         1   2.3 K          (size == estimated-debt)
  memtbl         1   256 K
 zmemtbl         0     0 B
    ztbl         0     0 B

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -28,7 +28,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
   total         1   771 B       -    56 B     0 B       0     0 B       0   827 B       1     0 B       1    14.8
   flush         1
-compact         0   771 B          (size == estimated-debt)
+compact         0     0 B          (size == estimated-debt)
  memtbl         1   256 K
 zmemtbl         1   256 K
    ztbl         0     0 B

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -21,7 +21,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
   total         1   986 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
   flush         0
-compact         0   986 B          (size == estimated-debt)
+compact         0     0 B          (size == estimated-debt)
  memtbl         1   256 K
 zmemtbl         0     0 B
    ztbl         0     0 B


### PR DESCRIPTION
The previous calculation was assuming multiple L0->Lbase compactions
that would overlap with everything in Lbase. In reality, L0->Lbase
compactions currently will take everything from L0. With L0 sublevels,
L0->Lbase compactions will only overlap with a fraction of Lbase.

Fixed the calculation to not include "move-based" compactions in the
debt. For example, if L0 has data but Lbase is empty, we can move the
sstables directly from L0 to Lbase.