### PR TITLE
tool: remove use of runtime.SetFinalizer

### DIFF
--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -139,10 +139,11 @@ inclusive-inclusive range specified by --start and --end.
 
 func (s *sstableT) newReader(f vfs.File) (*sstable.Reader, error) {
 	o := sstable.ReaderOptions{
-		Cache:    s.opts.Cache,
+		Cache:    pebble.NewCache(128 << 20 /* 128 MB */),
 		Comparer: s.opts.Comparer,
 		Filters:  s.opts.Filters,
 	}
+	defer o.Cache.Unref()
 	return sstable.NewReader(f, o, s.comparers, s.mergers,
 		private.SSTableRawTombstonesOpt.(sstable.ReaderOption))
 }

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -5,8 +5,6 @@
 package tool
 
 import (
-	"runtime"
-
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -87,11 +85,8 @@ func Filters(filters ...FilterPolicy) Option {
 
 // New creates a new introspection tool.
 func New(opts ...Option) *T {
-	cache := pebble.NewCache(128 << 20 /* 128 MB */)
-
 	t := &T{
 		opts: pebble.Options{
-			Cache:    cache,
 			Filters:  make(map[string]FilterPolicy),
 			FS:       vfs.Default,
 			ReadOnly: true,
@@ -124,10 +119,6 @@ func New(opts ...Option) *T {
 		t.sstable.Root,
 		t.wal.Root,
 	}
-
-	runtime.SetFinalizer(t, func(obj interface{}) {
-		cache.Unref()
-	})
 	return t
 }
 


### PR DESCRIPTION
Previously, we were using a cache that lived for the lifetime of
`tool.T`. Now we create a cache in the various tools as needed. This
required sprinkling a few missing `*.Close()` calls in various places.