### PR TITLE
internal/cache: restrict when finalizers are used

### DIFF
--- a/internal/cache/clockpro.go
+++ b/internal/cache/clockpro.go
@@ -567,16 +567,18 @@ func newShards(size int64, shards int) *Cache {
 		c.shards[i].blocks.init(16)
 		c.shards[i].files.init(16)
 	}
-	runtime.SetFinalizer(c, func(obj interface{}) {
-		c := obj.(*Cache)
-		if v := atomic.LoadInt64(&c.refs); v != 0 {
-			c.tr.Lock()
-			fmt.Fprintf(os.Stderr, "pebble: cache (%p) has non-zero reference count: %d\n%s",
-				c, v, strings.Join(c.tr.msgs, "\n"))
-			c.tr.Unlock()
-			os.Exit(1)
-		}
-	})
+	if !invariants.RaceEnabled {
+		runtime.SetFinalizer(c, func(obj interface{}) {
+			c := obj.(*Cache)
+			if v := atomic.LoadInt64(&c.refs); v != 0 {
+				c.tr.Lock()
+				fmt.Fprintf(os.Stderr, "pebble: cache (%p) has non-zero reference count: %d\n%s",
+					c, v, strings.Join(c.tr.msgs, "\n"))
+				c.tr.Unlock()
+				os.Exit(1)
+			}
+		})
+	}
 	return c
 }
 

--- a/internal/cache/robin_hood.go
+++ b/internal/cache/robin_hood.go
@@ -134,13 +134,15 @@ func maxDistForSize(size uint32) uint32 {
 func newRobinHoodMap(initialCapacity int) *robinHoodMap {
 	m := &robinHoodMap{}
 	m.init(initialCapacity)
-	runtime.SetFinalizer(m, func(obj interface{}) {
-		m := obj.(*robinHoodMap)
-		if m.entries.ptr != nil {
-			fmt.Fprintf(os.Stderr, "%p: robin-hood map not freed\n", m)
-			os.Exit(1)
-		}
-	})
+	if invariants.Enabled {
+		runtime.SetFinalizer(m, func(obj interface{}) {
+			m := obj.(*robinHoodMap)
+			if m.entries.ptr != nil {
+				fmt.Fprintf(os.Stderr, "%p: robin-hood map not freed\n", m)
+				os.Exit(1)
+			}
+		})
+	}
 	return m
 }
 


### PR DESCRIPTION
Only install the `Cache` finalizer, which checks that the cache has been
properly reference counted, when the "race" build tag is *not*
specified. We only specify this finalizer for non-race builds because
there appears to be a bug in the race detectors handling of
finalizers. But we want this finalizer enabled for non-race builds as
mishandling of cache reference counts is a common error (both in Pebble
and CRDB tests).

Only install the `robinHoodMap` finalizer, which checks that the map has
been properly closed, when the "invariants" build tag is specified. This
finalizer has not been catching problems since the initial introduction
of manual memory management, because the lifetime of the `robinHoodMap`
is tied to the `Cache` lifetime.