### PR TITLE
db: use compaction picker's scores directly in Metrics

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -34,16 +34,16 @@ type compactionPickerForTesting struct {
 
 var _ compactionPicker = &compactionPickerForTesting{}
 
+func (p *compactionPickerForTesting) getScores([]compactionInfo) [numLevels]float64 {
+	return [numLevels]float64{}
+}
+
 func (p *compactionPickerForTesting) getBaseLevel() int {
 	return p.baseLevel
 }
 
 func (p *compactionPickerForTesting) getEstimatedMaxWAmp() float64 {
 	return 0
-}
-
-func (p *compactionPickerForTesting) getLevelMaxBytes() [numLevels]int64 {
-	return [numLevels]int64{}
 }
 
 func (p *compactionPickerForTesting) estimatedCompactionDebt(l0ExtraSize uint64) uint64 {

--- a/db.go
+++ b/db.go
@@ -1019,11 +1019,10 @@ func (d *DB) Metrics() *Metrics {
 		metrics.WAL.Size += d.mu.mem.queue[i].logSize
 	}
 	metrics.WAL.BytesWritten = metrics.Levels[0].BytesIn + metrics.WAL.Size
-	metrics.Levels[0].Score = float64(metrics.Levels[0].NumFiles) / float64(d.opts.L0CompactionThreshold)
 	if p := d.mu.versions.picker; p != nil {
-		levelMaxBytes := p.getLevelMaxBytes()
-		for level := 1; level < numLevels; level++ {
-			metrics.Levels[level].Score = float64(metrics.Levels[level].Size) / float64(levelMaxBytes[level])
+		compactions := d.getInProgressCompactionInfoLocked(nil)
+		for level, score := range p.getScores(compactions) {
+			metrics.Levels[level].Score = score
 		}
 	}
 	metrics.Table.ZombieCount = int64(len(d.mu.versions.zombieTables))


### PR DESCRIPTION
This change tweaks the compaction picker interface to expose a getScores
method rather than a getLevelMaxBytes method, so that (*db).Metrics does
not need to duplicate score calculation logic to include
compaction-picking scores.

This was motivated by the change to a min-overlapping ratio heuristic
with compensated sizes. With compensated sizes, accurate scores cannot
be computed with just real level file sizes.

I figured it was okay to expose scores through the interface because
compactionPickerByScore is currently the only non-test implementation
and the concept of 'scores' already leaks through into the Metrics
output.