### PR TITLE
cmd/pebble: sample read amp throughout compaction benchmarks

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -181,6 +181,17 @@ type Metrics struct {
 	}
 }
 
+// ReadAmp returns the current read amplification of the database.
+// It's computed as the number of sublevels in L0 + the number of non-empty
+// levels below L0.
+func (m *Metrics) ReadAmp() int {
+	var ramp int32
+	for _, l := range m.Levels {
+		ramp += l.Sublevels
+	}
+	return int(ramp)
+}
+
 const notApplicable = "-"
 
 func (m *Metrics) formatWAL(buf *bytes.Buffer) {


### PR DESCRIPTION
Over the course of a compaction benchmark, sample the database's read
amplification periodically and print a few quantiles at the end. This
change also reformats the final stat output to look like:

```

__elapsed__compacts__w-amp__r-amp(_p50__p95__p99__max_)__space(_____amp__stable___final__average__)
    3.00m       153   1.10           2    5    5    5          62279.23    64 G   1.1 M     32 G
```