### PR TITLE
vfs: return nil from RemoveAll for nonexistent paths

### DIFF
--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -334,7 +334,7 @@ func (y *MemFS) RemoveAll(fullname string) error {
 			}
 			_, ok := dir.children[frag]
 			if !ok {
-				return os.ErrNotExist
+				return nil
 			}
 			delete(dir.children, frag)
 		}

--- a/vfs/testdata/vfs
+++ b/vfs/testdata/vfs
@@ -109,6 +109,7 @@ define
 list /
 remove e
 remove-all e
+remove-all e
 list /
 ----
 a
@@ -116,6 +117,7 @@ b
 d
 e
 remove: e [file already exists]
+remove-all: e [<nil>]
 remove-all: e [<nil>]
 a
 b


### PR DESCRIPTION
The standard library's `os.RemoveAll` returns nil if the path does not
exist. Update the in-memory fs implementation to do the same.