### PR TITLE
*: Update level_checker and Version.CheckOrdering for flush splits

### DIFF
--- a/cmd/pebble/compact.go
+++ b/cmd/pebble/compact.go
@@ -255,7 +255,7 @@ func runReplay(cmd *cobra.Command, args []string) error {
 		// We keep the current database's L0 read amplification equal to the
 		// reference database's L0 read amplification at the same point in its
 		// execution. If we've exceeded it, wait for compactions to catch up.
-		var skipCh <-chan time.Time = nil
+		var skipCh <-chan time.Time
 		for skip := false; !skip; {
 			refReadAmplification := ref.L0SubLevels.ReadAmplification()
 

--- a/compaction.go
+++ b/compaction.go
@@ -735,8 +735,8 @@ func (c *compaction) newInputIter(newIters tableNewIters) (_ internalIterator, r
 
 	iterOpts := IterOptions{logger: c.logger}
 	if c.startLevel != 0 {
-		iters = append(iters, newLevelIter(iterOpts, c.cmp, newIters, c.inputs[0], c.startLevel, &c.bytesIterated))
-		iters = append(iters, newLevelIter(iterOpts, c.cmp, newRangeDelIter, c.inputs[0], c.startLevel, &c.bytesIterated))
+		iters = append(iters, newLevelIter(iterOpts, c.cmp, newIters, c.inputs[0], c.startLevel, invalidSublevel, &c.bytesIterated))
+		iters = append(iters, newLevelIter(iterOpts, c.cmp, newRangeDelIter, c.inputs[0], c.startLevel, invalidSublevel, &c.bytesIterated))
 	} else {
 		for i := range c.inputs[0] {
 			f := c.inputs[0][i]
@@ -751,8 +751,8 @@ func (c *compaction) newInputIter(newIters tableNewIters) (_ internalIterator, r
 		}
 	}
 
-	iters = append(iters, newLevelIter(iterOpts, c.cmp, newIters, c.inputs[1], c.outputLevel, &c.bytesIterated))
-	iters = append(iters, newLevelIter(iterOpts, c.cmp, newRangeDelIter, c.inputs[1], c.outputLevel, &c.bytesIterated))
+	iters = append(iters, newLevelIter(iterOpts, c.cmp, newIters, c.inputs[1], c.outputLevel, invalidSublevel, &c.bytesIterated))
+	iters = append(iters, newLevelIter(iterOpts, c.cmp, newRangeDelIter, c.inputs[1], c.outputLevel, invalidSublevel, &c.bytesIterated))
 	return newMergingIter(c.logger, c.cmp, iters...), nil
 }
 

--- a/db.go
+++ b/db.go
@@ -711,7 +711,7 @@ func (d *DB) newIterInternal(
 	mlevels = mlevels[start:]
 
 	levels := buf.levels[:]
-	addLevelIterForFiles := func(files []*manifest.FileMetadata, level int) {
+	addLevelIterForFiles := func(files []*manifest.FileMetadata, level int, sublevel int) {
 		if len(files) == 0 {
 			return
 		}
@@ -723,7 +723,7 @@ func (d *DB) newIterInternal(
 			li = &levelIter{}
 		}
 
-		li.init(dbi.opts, d.cmp, d.newIters, files, level, nil)
+		li.init(dbi.opts, d.cmp, d.newIters, files, level, sublevel, nil)
 		li.initRangeDel(&mlevels[0].rangeDelIter)
 		li.initSmallestLargestUserKey(&mlevels[0].smallestUserKey, &mlevels[0].largestUserKey,
 			&mlevels[0].isLargestUserKeyRangeDelSentinel)
@@ -734,12 +734,12 @@ func (d *DB) newIterInternal(
 	// Add level iterators for the L0 sublevels, iterating from newest to
 	// oldest.
 	for i := len(current.L0SubLevels.Files) - 1; i >= 0; i-- {
-		addLevelIterForFiles(current.L0SubLevels.Files[i], 0)
+		addLevelIterForFiles(current.L0SubLevels.Files[i], 0, i)
 	}
 
 	// Add level iterators for the non-empty non-L0 levels.
 	for level := 1; level < len(current.Files); level++ {
-		addLevelIterForFiles(current.Files[level], level)
+		addLevelIterForFiles(current.Files[level], level, invalidSublevel)
 	}
 
 	buf.merging.init(&dbi.opts, d.cmp, finalMLevels...)

--- a/get_iter.go
+++ b/get_iter.go
@@ -142,7 +142,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 				files := g.l0[n-1]
 				g.l0 = g.l0[:n-1]
 				iterOpts := IterOptions{logger: g.logger}
-				g.levelIter.init(iterOpts, g.cmp, g.newIters, files, 0, nil)
+				g.levelIter.init(iterOpts, g.cmp, g.newIters, files, 0, n, nil)
 				g.levelIter.initRangeDel(&g.rangeDelIter)
 				g.iter = &g.levelIter
 				g.iterKey, g.iterValue = g.iter.SeekGE(g.key)
@@ -160,7 +160,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 		}
 
 		iterOpts := IterOptions{logger: g.logger}
-		g.levelIter.init(iterOpts, g.cmp, g.newIters, g.version.Files[g.level], g.level, nil)
+		g.levelIter.init(iterOpts, g.cmp, g.newIters, g.version.Files[g.level], g.level, invalidSublevel,nil)
 		g.levelIter.initRangeDel(&g.rangeDelIter)
 		g.level++
 		g.iter = &g.levelIter

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -417,8 +417,8 @@ func TestGetIter(t *testing.T) {
 		},
 
 		{
-			description: "broken invariants 2: non-increasing level 0 sequence numbers",
-			badOrdering: true,
+			description: "broken invariants 2: matching level 0 sequence numbers, considered acceptable",
+			badOrdering: false,
 			tables: []testTable{
 				{
 					level:   0,

--- a/ingest.go
+++ b/ingest.go
@@ -405,7 +405,7 @@ func ingestTargetLevel(
 
 	level := baseLevel
 	for ; level < numLevels; level++ {
-		levelIter := newLevelIter(iterOps, cmp, newIters, v.Files[level], level, nil)
+		levelIter := newLevelIter(iterOps, cmp, newIters, v.Files[level], level, invalidSublevel, nil)
 		var rangeDelIter internalIterator
 		// Pass in a non-nil pointer to rangeDelIter so that levelIter.findFileGE sets it up for the target file.
 		levelIter.initRangeDel(&rangeDelIter)

--- a/internal/manifest/testdata/version_check_ordering
+++ b/internal/manifest/testdata/version_check_ordering
@@ -67,7 +67,7 @@ L0
 ----
 OK
 
-# Ensure that sstables passed in a non-sorted order aree detected.
+# Ensure that sstables passed in a non-sorted order are detected.
 check-ordering
 L0
   a.SET.3-d.SET.3

--- a/internal/manifest/testdata/version_check_ordering
+++ b/internal/manifest/testdata/version_check_ordering
@@ -50,8 +50,8 @@ L0
 ----
 OK
 
-# Ensure that coincident sequence numbers are detected around sstables with
-# overlapping sequence numbers.
+# Coincident sequence numbers around sstables with overlapping sequence numbers
+# are possible due to flush splitting, so this is acceptable.
 check-ordering
 L0
   c.SET.3-d.SET.4
@@ -65,21 +65,9 @@ L0
   k.SET.16-n.SET.19
   m.SET.20-n.SET.20
 ----
-L0 flushed file 000007 has smallest sequence number coincident with an ingested file : <#15-#17> vs <#15-#15>
-0.2:
-  000007:[a#15,SET-j#17,SET]
-  000010:[m#20,SET-n#20,SET]
-0.1:
-  000006:[b#15,SET-d#15,SET]
-  000009:[k#16,SET-n#19,SET]
-0.0:
-  000002:[a#1,SET-b#5,SET]
-  000001:[c#3,SET-d#4,SET]
-  000003:[e#2,SET-f#7,SET]
-  000004:[g#6,SET-h#12,SET]
-  000005:[i#8,SET-j#13,SET]
-  000008:[m#18,SET-n#18,SET]
+OK
 
+# Ensure that sstables passed in a non-sorted order aree detected.
 check-ordering
 L0
   a.SET.3-d.SET.3
@@ -107,22 +95,14 @@ L0
   a.SET.3-d.SET.3
   a.SET.3-b.SET.3
 ----
-L0 file 000002 does not have strictly increasing largest seqnum: <#3-#3> vs <?-#3>
-0.1:
-  000002:[a#3,SET-b#3,SET]
-0.0:
-  000001:[a#3,SET-d#3,SET]
+OK
 
 check-ordering
 L0
   a.SET.3-d.SET.3
   a.SET.3-d.SET.5
 ----
-L0 flushed file 000002 has smallest sequence number coincident with an ingested file : <#3-#5> vs <#3-#3>
-0.1:
-  000002:[a#3,SET-d#5,SET]
-0.0:
-  000001:[a#3,SET-d#3,SET]
+OK
 
 check-ordering
 L0
@@ -136,11 +116,7 @@ L0
   a.SET.3-d.SET.5
   a.SET.5-d.SET.5
 ----
-L0 file 000002 does not have strictly increasing largest seqnum: <#5-#5> vs <?-#5>
-0.1:
-  000002:[a#5,SET-d#5,SET]
-0.0:
-  000001:[a#3,SET-d#5,SET]
+OK
 
 check-ordering
 L0
@@ -148,13 +124,7 @@ L0
   a.SET.5-d.SET.5
   a.SET.4-d.SET.6
 ----
-L0 flushed file 000003 has smallest sequence number coincident with an ingested file : <#4-#6> vs <#4-#4>
-0.2:
-  000003:[a#4,SET-d#6,SET]
-0.1:
-  000002:[a#5,SET-d#5,SET]
-0.0:
-  000001:[a#4,SET-d#4,SET]
+OK
 
 check-ordering
 L0

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -239,6 +239,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 				// Start from level 1 in this test.
 				version.Files[i+1] = levels[i]
 			}
+			version.InitL0Sublevels(base.DefaultComparer.Compare, base.DefaultFormatter)
 			readState := &readState{current: version}
 			c := &checkConfig{
 				cmp:       cmp,

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -79,7 +79,7 @@ func TestLevelIter(t *testing.T) {
 				}
 			}
 
-			iter := newLevelIter(opts, DefaultComparer.Compare, newIters, files, level, nil)
+			iter := newLevelIter(opts, DefaultComparer.Compare, newIters, files, level, invalidSublevel, nil)
 			defer iter.Close()
 			// Fake up the range deletion initialization.
 			iter.initRangeDel(new(internalIterator))
@@ -119,7 +119,7 @@ func TestLevelIter(t *testing.T) {
 				return newIters(meta, opts, nil)
 			}
 
-			iter := newLevelIter(opts, DefaultComparer.Compare, newIters2, files, level, nil)
+			iter := newLevelIter(opts, DefaultComparer.Compare, newIters2, files, level, invalidSublevel, nil)
 			iter.SeekGE([]byte(key))
 			lower, upper := tableOpts.GetLowerBound(), tableOpts.GetUpperBound()
 			return fmt.Sprintf("[%s,%s]\n", lower, upper)
@@ -256,7 +256,7 @@ func TestLevelIterBoundaries(t *testing.T) {
 			return lt.runBuild(d)
 
 		case "iter":
-			iter := newLevelIter(IterOptions{}, DefaultComparer.Compare, lt.newIters, lt.files, level, nil)
+			iter := newLevelIter(IterOptions{}, DefaultComparer.Compare, lt.newIters, lt.files, level, invalidSublevel, nil)
 			defer iter.Close()
 			// Fake up the range deletion initialization.
 			iter.initRangeDel(new(internalIterator))
@@ -330,7 +330,7 @@ func TestLevelIterSeek(t *testing.T) {
 
 		case "iter":
 			iter := &levelIterTestIter{
-				levelIter: newLevelIter(IterOptions{}, DefaultComparer.Compare, lt.newIters, lt.files, level, nil),
+				levelIter: newLevelIter(IterOptions{}, DefaultComparer.Compare, lt.newIters, lt.files, level, invalidSublevel, nil),
 			}
 			defer iter.Close()
 			iter.initRangeDel(&iter.rangeDelIter)
@@ -425,7 +425,7 @@ func BenchmarkLevelIterSeekGE(b *testing.B) {
 								iter, err := readers[meta.FileNum].NewIter(nil /* lower */, nil /* upper */)
 								return iter, nil, err
 							}
-							l := newLevelIter(IterOptions{}, DefaultComparer.Compare, newIters, files, level, nil)
+							l := newLevelIter(IterOptions{}, DefaultComparer.Compare, newIters, files, level, invalidSublevel, nil)
 							rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 
 							b.ResetTimer()
@@ -454,7 +454,7 @@ func BenchmarkLevelIterNext(b *testing.B) {
 								iter, err := readers[meta.FileNum].NewIter(nil /* lower */, nil /* upper */)
 								return iter, nil, err
 							}
-							l := newLevelIter(IterOptions{}, DefaultComparer.Compare, newIters, files, level, nil)
+							l := newLevelIter(IterOptions{}, DefaultComparer.Compare, newIters, files, level, invalidSublevel, nil)
 
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {
@@ -486,7 +486,7 @@ func BenchmarkLevelIterPrev(b *testing.B) {
 								iter, err := readers[meta.FileNum].NewIter(nil /* lower */, nil /* upper */)
 								return iter, nil, err
 							}
-							l := newLevelIter(IterOptions{}, DefaultComparer.Compare, newIters, files, level, nil)
+							l := newLevelIter(IterOptions{}, DefaultComparer.Compare, newIters, files, level, invalidSublevel, nil)
 
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -236,7 +236,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 					continue
 				}
 				li := &levelIter{}
-				li.init(IterOptions{}, cmp, newIters, l, i, nil)
+				li.init(IterOptions{}, cmp, newIters, l, i, invalidSublevel, nil)
 				i := len(levelIters)
 				levelIters = append(levelIters, mergingIterLevel{iter: li})
 				li.initRangeDel(&levelIters[i].rangeDelIter)

--- a/testdata/compaction_check_ordering
+++ b/testdata/compaction_check_ordering
@@ -45,7 +45,7 @@ L0
   a.SET.3-d.SET.3
   a.SET.3-b.SET.3
 ----
-fatal: L0 file 000002 does not have strictly increasing largest seqnum: <#3-#3> vs <?-#3>
+OK
 
 check-ordering
 L1


### PR DESCRIPTION
This change is in anticipation for #675 (and has an exact copy of the original
two commits from that PR). Basically, it relaxes invariants checked in
`Version.CheckOrdering` and the `level_checker` (used in tests) to account
for cases where sstables can have matching start or end (or both) sequence
numbers. These cases are possible when range tombstones are truncated to
file bounds when flushing.