### PR TITLE
vfs: return nil from MemFS.RemoveAll if parent doesn't exist

### DIFF
--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -327,7 +327,7 @@ func (y *MemFS) Remove(fullname string) error {
 
 // RemoveAll implements FS.RemoveAll.
 func (y *MemFS) RemoveAll(fullname string) error {
-	return y.walk(fullname, func(dir *memNode, frag string, final bool) error {
+	err := y.walk(fullname, func(dir *memNode, frag string, final bool) error {
 		if final {
 			if frag == "" {
 				return errors.New("pebble/vfs: empty file name")
@@ -340,6 +340,12 @@ func (y *MemFS) RemoveAll(fullname string) error {
 		}
 		return nil
 	})
+	// Match os.RemoveAll which returns a nil error even if the parent
+	// directories don't exist.
+	if os.IsNotExist(err) {
+		err = nil
+	}
+	return err
 }
 
 // Rename implements FS.Rename.

--- a/vfs/testdata/vfs
+++ b/vfs/testdata/vfs
@@ -110,6 +110,7 @@ list /
 remove e
 remove-all e
 remove-all e
+remove-all e/a/b/c
 list /
 ----
 a
@@ -119,6 +120,7 @@ e
 remove: e [file already exists]
 remove-all: e [<nil>]
 remove-all: e [<nil>]
+remove-all: e/a/b/c [<nil>]
 a
 b
 d


### PR DESCRIPTION
Update MemFS's RemoveAll implementation to return a nil error when the
parents don't exist. This matches the behavior of os.RemoveAll.

I missed this case in bb2f856b.