### PR TITLE
internal/record: bump LogWriter pending queue size

### DIFF
--- a/internal/record/log_writer.go
+++ b/internal/record/log_writer.go
@@ -293,7 +293,7 @@ func NewLogWriter(w io.Writer, logNum base.FileNum) *LogWriter {
 		// number is used as a validation check and using only the low 32-bits is
 		// sufficient for that purpose.
 		logNum: uint32(logNum),
-		free:   make(chan *block, 4),
+		free:   make(chan *block, 16),
 		afterFunc: func(d time.Duration, f func()) syncTimer {
 			return time.AfterFunc(d, f)
 		},
@@ -367,7 +367,7 @@ func (w *LogWriter) flushLoop(context.Context) {
 
 	// The list of full blocks that need to be written. This is copied from
 	// f.pending on every loop iteration, though the number of elements is small
-	// (usually 1, max 4).
+	// (usually 1, max 16).
 	pending := make([]*block, 0, cap(f.pending))
 
 	for {

--- a/internal/record/record_test.go
+++ b/internal/record/record_test.go
@@ -1001,7 +1001,7 @@ func TestRecycleLogWithPartialRecord(t *testing.T) {
 }
 
 func BenchmarkRecordWrite(b *testing.B) {
-	for _, size := range []int{8, 16, 32, 64, 128} {
+	for _, size := range []int{8, 16, 32, 64, 256, 1028, 4096, 65_536} {
 		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
 			w := NewLogWriter(ioutil.Discard, 0 /* logNum */)
 			defer w.Close()


### PR DESCRIPTION
Bump LogWriter's pending queue size from 4 to 16. The impact is muted
and not statistically significant with small records but at larger
record sizes the impact is appreciable.

This may help with cockroachdb/cockroach#49750, but I don't think it's
the primary issue. I'm going to try to measure its impact on Cockroach
workloads with roachtests.

```
name                       old time/op    new time/op    delta
RecordWrite/size=8-16        32.7ns ± 5%    32.2ns ± 5%     ~     (p=0.055 n=24+25)
RecordWrite/size=16-16       33.8ns ± 7%    33.6ns ± 5%     ~     (p=0.663 n=23+25)
RecordWrite/size=32-16       36.6ns ± 4%    36.6ns ± 9%     ~     (p=0.755 n=23+24)
RecordWrite/size=64-16       41.5ns ± 5%    41.5ns ±12%     ~     (p=0.890 n=24+24)
RecordWrite/size=256-16      68.2ns ± 5%    67.9ns ± 8%     ~     (p=0.679 n=24+24)
RecordWrite/size=1028-16      134ns ± 8%     125ns ± 7%   -6.44%  (p=0.000 n=23+23)
RecordWrite/size=4096-16      357ns ±15%     340ns ± 8%   -4.90%  (p=0.001 n=24+24)
RecordWrite/size=65536-16    5.76µs ±10%    5.17µs ± 7%  -10.32%  (p=0.000 n=25+25)

name                       old speed      new speed      delta
RecordWrite/size=8-16       245MB/s ± 5%   249MB/s ± 5%     ~     (p=0.055 n=24+25)
RecordWrite/size=16-16      472MB/s ± 7%   476MB/s ± 6%     ~     (p=0.532 n=24+25)
RecordWrite/size=32-16      875MB/s ± 4%   875MB/s ± 8%     ~     (p=0.792 n=23+24)
RecordWrite/size=64-16     1.54GB/s ± 5%  1.54GB/s ±11%     ~     (p=0.945 n=24+25)
RecordWrite/size=256-16    3.76GB/s ± 5%  3.77GB/s ± 7%     ~     (p=0.690 n=24+24)
RecordWrite/size=1028-16   7.69GB/s ± 7%  8.22GB/s ± 7%   +6.93%  (p=0.000 n=23+23)
RecordWrite/size=4096-16   11.4GB/s ±13%  12.1GB/s ± 7%   +5.58%  (p=0.001 n=25+24)
RecordWrite/size=65536-16  11.4GB/s ±11%  12.7GB/s ± 7%  +11.39%  (p=0.000 n=25+25)
```