### PR TITLE
release-20.1: internal/manual: panic with "out of memory" on allocation failure

### DIFF
--- a/internal/manual/manual.s
+++ b/internal/manual/manual.s
@@ -1,1 +1,0 @@
-// Empty assembly file to allow go:linkname to work.

--- a/internal/manual/manual.s
+++ b/internal/manual/manual.s
@@ -1,0 +1,1 @@
+// Empty assembly file to allow go:linkname to work.

--- a/internal/rawalloc/rawalloc.s
+++ b/internal/rawalloc/rawalloc.s
@@ -1,1 +1,0 @@
-// Empty assembly file to allow go:linkname to work.


### PR DESCRIPTION
Rather than returning a nil slice, panic with "out of memory" on allocation
failure in order to provide a clearer signal that allocation has failed.
The "out of memory" message matches the message the Go runtime uses.

Fixes #652.