### PR TITLE
 db: close tableCache on open error

### DIFF
--- a/open.go
+++ b/open.go
@@ -73,9 +73,10 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		// look for the return of a nil DB pointer.
 		if r := recover(); db == nil {
 			// Release our references to the Cache. Note that both the DB, and
-			// tableCache have a reference and we need to release both.
+			// tableCache have a reference. The tableCache.Close will release
+			// the tableCache's reference.
 			opts.Cache.Unref()
-			opts.Cache.Unref()
+			_ = d.tableCache.Close()
 			for _, mem := range d.mu.mem.queue {
 				switch t := mem.flushable.(type) {
 				case *memTable:


### PR DESCRIPTION
 If an error occurs during Open, close the tableCache. Previously, this
 was unnecessary because we already accounted for unrefing the cache
 twice: once for the tableCache and once for the db. Now that the
 tableCache may have # shards gorouintes that are spawned by init(), we
 need to clean them up too.

 This was caught by the goroutine leak detector in
 pkg/cli.TestOpenExistingStore test in Cockroach.