### PR TITLE
crl-release-20.1: vfs: Add vfs.Prefetch, use it for reading ahead data blocks

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -28,6 +28,17 @@ import (
 
 var errCorruptIndexEntry = errors.New("pebble/table: corrupt index entry")
 
+const (
+	// Constants for dynamic readahead of data blocks. Note that the size values
+	// make sense as some multiple of the default block size; and they should
+	// both be larger than the default block size.
+	minFileReadsForReadahead = 2
+	// TODO(bilal): Have the initial size value be a factor of the block size,
+	// as opposed to a hardcoded value.
+	initialReadaheadSize     = 64 << 10 /* 64KB */
+	maxReadaheadSize         = 512 << 10 /* 512KB */
+)
+
 // decodeBlockHandle returns the block handle encoded at the start of src, as
 // well as the number of bytes it occupies. It returns zero if given invalid
 // input.
@@ -72,6 +83,7 @@ type singleLevelIterator struct {
 	reader     *Reader
 	index      blockIter
 	data       blockIter
+	dataRS     readaheadState
 	dataBH     BlockHandle
 	err        error
 	closeHook  func(i Iterator) error
@@ -146,6 +158,7 @@ func (i *singleLevelIterator) init(r *Reader, lower, upper []byte) error {
 		_ = i.index.Close()
 		return err
 	}
+	i.dataRS.size = initialReadaheadSize
 	return nil
 }
 
@@ -196,7 +209,7 @@ func (i *singleLevelIterator) loadBlock() bool {
 		i.err = errCorruptIndexEntry
 		return false
 	}
-	block, err := i.reader.readBlock(i.dataBH, nil /* transform */)
+	block, err := i.reader.readBlock(i.dataBH, nil /* transform */, &i.dataRS)
 	if err != nil {
 		i.err = err
 		return false
@@ -591,7 +604,7 @@ func (i *twoLevelIterator) loadIndex() bool {
 		i.err = errors.New("pebble/table: corrupt top level index entry")
 		return false
 	}
-	indexBlock, err := i.reader.readBlock(h, nil /* transform */)
+	indexBlock, err := i.reader.readBlock(h, nil /* transform */, nil /* readaheadState */)
 	if err != nil {
 		i.err = err
 		return false
@@ -938,6 +951,155 @@ func (w *weakCachedBlock) release() {
 
 type blockTransform func([]byte) ([]byte, error)
 
+// readaheadState contains state variables related to readahead. Updated on
+// file reads.
+type readaheadState struct {
+	// Number of sequential reads.
+	numReads int64
+	// Size issued to the next call to Prefetch. Starts at or above
+	// initialReadaheadSize and grows exponentially until maxReadaheadSize.
+	size int64
+	// prevSize is the size used in the last Prefetch call.
+	prevSize int64
+	// The byte offset up to which the OS has been asked to read ahead / cached.
+	// When reading ahead, reads up to this limit should not incur an IO
+	// operation. Reads after this limit can benefit from a new call to
+	// Prefetch.
+	limit int64
+}
+
+// maybeReadahead updates state and determines whether to issue a readahead /
+// prefetch call for a block read at offset for blockLength bytes.
+// Returns a size value (greater than 0) that should be prefetched if readahead
+// would be beneficial.
+//
+// TODO(bilal): This method is only called when there's a cache miss. Reads
+// from the cache are completely invisible to the logic here and the state
+// variables in readaheadState. This is a big reason why the
+// readahead window in this method needs to be optimistic (that reading ahead
+// will generally help) by always extending the window to
+// rs.limit + maxReadaheadSize, to adjust for blocks that appear to be skipped
+// but were actually read from the cache. Update this method or add another
+// method to properly account for cache hits.
+func (rs *readaheadState) maybeReadahead(offset, blockLength int64) int64 {
+	currentReadEnd := offset + blockLength
+	if rs.numReads >= minFileReadsForReadahead {
+		// The minimum threshold of sequential reads to justify reading ahead
+		// has been reached.
+		// There are two intervals: the interval being read:
+		// [offset, currentReadEnd]
+		// as well as the interval where a read would benefit from read ahead:
+		// [rs.limit, rs.limit + rs.size]
+		// We increase the latter interval to
+		// [rs.limit, rs.limit + maxReadaheadSize] to account for cases where
+		// readahead may not be beneficial with a small readahead size, but over
+		// time the readahead size would increase exponentially to make it
+		// beneficial.
+		if currentReadEnd >= rs.limit && offset <= rs.limit + maxReadaheadSize {
+			// We are doing a read in the interval ahead of
+			// the last readahead range. In the diagrams below, ++++ is the last
+			// readahead range, ==== is the range represented by
+			// [rs.limit, rs.limit + maxReadaheadSize], and ---- is the range
+			// being read.
+			//
+			//               rs.limit           rs.limit + maxReadaheadSize
+			//         ++++++++++|===========================|
+			//
+			//              |-------------|
+			//            offset       currentReadEnd
+			//
+			// This case is also possible, as are all cases with an overlap
+			// between [rs.limit, rs.limit + maxReadaheadSize] and [offset,
+			// currentReadEnd]:
+			//
+			//               rs.limit           rs.limit + maxReadaheadSize
+			//         ++++++++++|===========================|
+			//
+			//                                            |-------------|
+			//                                         offset       currentReadEnd
+			//
+			//
+			rs.numReads++
+			rs.limit = offset + rs.size
+			rs.prevSize = rs.size
+			// Increase rs.size for the next read.
+			rs.size *= 2
+			if rs.size > maxReadaheadSize {
+				rs.size = maxReadaheadSize
+			}
+			return rs.prevSize
+		}
+		if currentReadEnd < rs.limit - rs.prevSize || offset > rs.limit + maxReadaheadSize {
+			// The above conditional has rs.limit > rs.prevSize to confirm that
+			// rs.limit - rs.prevSize would not underflow.
+			// We read too far away from rs.limit to benefit from readahead in
+			// any scenario. Reset all variables.
+			// The case where we read too far ahead:
+			//
+			// (rs.limit - rs.prevSize)    (rs.limit)   (rs.limit + maxReadaheadSize)
+			//                    |+++++++++++++|=============|
+			//
+			//                                                  |-------------|
+			//                                             offset       currentReadEnd
+			//
+			// Or too far behind:
+			//
+			// (rs.limit - rs.prevSize)    (rs.limit)   (rs.limit + maxReadaheadSize)
+			//                    |+++++++++++++|=============|
+			//
+			//    |-------------|
+			// offset       currentReadEnd
+			//
+			rs.numReads = 1
+			rs.limit = currentReadEnd
+			rs.size = initialReadaheadSize
+			rs.prevSize = 0
+			return 0
+		}
+		// Reads in the range [rs.limit - rs.prevSize, rs.limit] end up
+		// here. This is a read that is potentially benefitting from a past
+		// readahead, but there's no reason to issue a readahead call at the
+		// moment.
+		//
+		// (rs.limit - rs.prevSize)            (rs.limit + maxReadaheadSize)
+		//                    |+++++++++++++|===============|
+		//                             (rs.limit)
+		//
+		//                        |-------|
+		//                     offset    currentReadEnd
+		//
+		rs.numReads++
+		return 0
+	}
+	if currentReadEnd >= rs.limit && offset <= rs.limit + maxReadaheadSize {
+		// Blocks are being read sequentially and would benefit from readahead
+		// down the line.
+		//
+		//                       (rs.limit)   (rs.limit + maxReadaheadSize)
+		//                         |=============|
+		//
+		//                    |-------|
+		//                offset    currentReadEnd
+		//
+		rs.numReads++
+		return 0
+	}
+	// We read too far ahead of the last read, or before it. This indicates
+	// a random read, where readahead is not desirable. Reset all variables.
+	//
+	// (rs.limit - maxReadaheadSize)  (rs.limit)   (rs.limit + maxReadaheadSize)
+	//                     |+++++++++++++|=============|
+	//
+	//                                                    |-------|
+	//                                                offset    currentReadEnd
+	//
+	rs.numReads = 1
+	rs.limit = currentReadEnd
+	rs.size = initialReadaheadSize
+	rs.prevSize = 0
+	return 0
+}
+
 // ReaderOption provide an interface to do work on Reader while it is being
 // opened.
 type ReaderOption interface {
@@ -1211,7 +1373,7 @@ func (r *Reader) readWeakCachedBlock(
 
 	// Slow-path: read the index block from disk. This checks the cache again,
 	// but that is ok because somebody else might have inserted it for us.
-	h, err := r.readBlock(w.bh, transform)
+	h, err := r.readBlock(w.bh, transform, nil /* readaheadState */)
 	if err != nil {
 		return cache.Handle{}, err
 	}
@@ -1222,9 +1384,15 @@ func (r *Reader) readWeakCachedBlock(
 }
 
 // readBlock reads and decompresses a block from disk into memory.
-func (r *Reader) readBlock(bh BlockHandle, transform blockTransform) (cache.Handle, error) {
+func (r *Reader) readBlock(bh BlockHandle, transform blockTransform, raState *readaheadState) (cache.Handle, error) {
 	if h := r.opts.Cache.Get(r.cacheID, r.fileNum, bh.Offset); h.Get() != nil {
 		return h, nil
+	}
+
+	if raState != nil {
+		if readaheadSize := raState.maybeReadahead(int64(bh.Offset), int64(bh.Length + blockTrailerLen)); readaheadSize > 0 {
+			_ = vfs.Prefetch(r.file, bh.Offset, uint64(readaheadSize))
+		}
 	}
 
 	v := r.opts.Cache.Alloc(int(bh.Length + blockTrailerLen))
@@ -1336,7 +1504,7 @@ func (r *Reader) transformRangeDelV1(b []byte) ([]byte, error) {
 }
 
 func (r *Reader) readMetaindex(metaindexBH BlockHandle) error {
-	b, err := r.readBlock(metaindexBH, nil /* transform */)
+	b, err := r.readBlock(metaindexBH, nil /* transform */, nil /* readaheadState */)
 	if err != nil {
 		return err
 	}
@@ -1366,7 +1534,7 @@ func (r *Reader) readMetaindex(metaindexBH BlockHandle) error {
 	}
 
 	if bh, ok := meta[metaPropertiesName]; ok {
-		b, err = r.readBlock(bh, nil /* transform */)
+		b, err = r.readBlock(bh, nil /* transform */, nil /* readaheadState */)
 		if err != nil {
 			return err
 		}
@@ -1458,7 +1626,7 @@ func (r *Reader) Layout() (*Layout, error) {
 			}
 			l.Index = append(l.Index, indexBH)
 
-			subIndex, err := r.readBlock(indexBH, nil /* transform */)
+			subIndex, err := r.readBlock(indexBH, nil /* transform */, nil /* readaheadState */)
 			if err != nil {
 				return nil, err
 			}
@@ -1524,7 +1692,7 @@ func (r *Reader) EstimateDiskUsage(start, end []byte) (uint64, error) {
 		if n == 0 || n != len(val) {
 			return 0, errCorruptIndexEntry
 		}
-		startIdxBlock, err := r.readBlock(startIdxBH, nil /* transform */)
+		startIdxBlock, err := r.readBlock(startIdxBH, nil /* transform */, nil /* readaheadState */)
 		if err != nil {
 			return 0, err
 		}
@@ -1544,7 +1712,7 @@ func (r *Reader) EstimateDiskUsage(start, end []byte) (uint64, error) {
 			if n == 0 || n != len(val) {
 				return 0, errCorruptIndexEntry
 			}
-			endIdxBlock, err := r.readBlock(endIdxBH, nil /* transform */)
+			endIdxBlock, err := r.readBlock(endIdxBH, nil /* transform */, nil /* readaheadState */)
 			if err != nil {
 				return 0, err
 			}
@@ -1733,7 +1901,7 @@ func (l *Layout) Describe(
 			continue
 		}
 
-		h, err := r.readBlock(b.BlockHandle, nil /* transform */)
+		h, err := r.readBlock(b.BlockHandle, nil /* transform */, nil /* readaheadState */)
 		if err != nil {
 			fmt.Fprintf(w, "  [err: %s]\n", err)
 			continue

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -696,7 +696,7 @@ func TestMetaIndexEntriesSorted(t *testing.T) {
 	r, err := NewReader(f, ReaderOptions{})
 	require.NoError(t, err)
 
-	b, err := r.readBlock(r.metaIndexBH, nil /* transform */)
+	b, err := r.readBlock(r.metaIndexBH, nil /* transform */, nil /* attrs */)
 	require.NoError(t, err)
 	defer b.Release()
 

--- a/sstable/testdata/readahead
+++ b/sstable/testdata/readahead
@@ -1,0 +1,203 @@
+reset
+----
+
+read
+2048, 16
+----
+readahead:  0
+numReads:   1
+size:       65536
+prevSize:   0
+limit:      0
+
+read
+2096, 16
+----
+readahead:  0
+numReads:   2
+size:       65536
+prevSize:   0
+limit:      0
+
+read
+2112, 16
+----
+readahead:  65536
+numReads:   3
+size:       131072
+prevSize:   65536
+limit:      67648
+
+read
+8000, 16
+----
+readahead:  0
+numReads:   4
+size:       131072
+prevSize:   65536
+limit:      67648
+
+read
+8016, 16
+----
+readahead:  0
+numReads:   5
+size:       131072
+prevSize:   65536
+limit:      67648
+
+# The new limit is 2112 + 65536 = 67648.
+# Since the next read will end at 67646 + 1 = 67647,
+# it doesn't yet trigger a readahead.
+
+read
+67646, 1
+----
+readahead:  0
+numReads:   6
+size:       131072
+prevSize:   65536
+limit:      67648
+
+read
+67646, 2
+----
+readahead:  131072
+numReads:   7
+size:       262144
+prevSize:   131072
+limit:      198718
+
+read
+16192, 16
+----
+readahead:  0
+numReads:   1
+size:       65536
+prevSize:   0
+limit:      16208
+
+read
+16193, 16
+----
+readahead:  0
+numReads:   2
+size:       65536
+prevSize:   0
+limit:      16208
+
+# The next read is too far ahead to benefit from readahead
+# (i.e. 540497 > 16208 (limit) + (512 << 10) (maxReadaheadSize))
+# numReads should get reset to 1.
+
+read
+540497, 16
+----
+readahead:  0
+numReads:   1
+size:       65536
+prevSize:   0
+limit:      540513
+
+read
+7980, 16
+----
+readahead:  0
+numReads:   1
+size:       65536
+prevSize:   0
+limit:      7996
+
+read
+0, 16
+----
+readahead:  0
+numReads:   1
+size:       65536
+prevSize:   0
+limit:      16
+
+# Sizes should start from initial (64kb) again.
+
+read
+7780, 16
+----
+readahead:  0
+numReads:   2
+size:       65536
+prevSize:   0
+limit:      16
+
+read
+7680, 16
+----
+readahead:  65536
+numReads:   3
+size:       131072
+prevSize:   65536
+limit:      73216
+
+read
+7780, 16
+----
+readahead:  0
+numReads:   4
+size:       131072
+prevSize:   65536
+limit:      73216
+
+read
+7880, 16
+----
+readahead:  0
+numReads:   5
+size:       131072
+prevSize:   65536
+limit:      73216
+
+read
+7980, 16
+----
+readahead:  0
+numReads:   6
+size:       131072
+prevSize:   65536
+limit:      73216
+
+read
+73416, 16
+----
+readahead:  131072
+numReads:   7
+size:       262144
+prevSize:   131072
+limit:      204488
+
+read
+204488, 16
+----
+readahead:  262144
+numReads:   8
+size:       524288
+prevSize:   262144
+limit:      466632
+
+# The readahead size should not increase beyond the max (512kb)
+
+read
+466632, 16
+----
+readahead:  524288
+numReads:   9
+size:       524288
+prevSize:   524288
+limit:      990920
+
+read
+1515208,16
+----
+readahead:  524288
+numReads:   10
+size:       524288
+prevSize:   524288
+limit:      2039496

--- a/vfs/prefetch_generic.go
+++ b/vfs/prefetch_generic.go
@@ -1,0 +1,15 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build !linux
+
+package vfs
+
+// Prefetch signals the OS (on supported platforms) to fetch the next size
+// bytes in file after offset into cache. Any subsequent reads in that range
+// will not issue disk IO.
+func Prefetch(file File, offset uint64, size uint64) error {
+	// No-op.
+	return nil
+}

--- a/vfs/prefetch_linux.go
+++ b/vfs/prefetch_linux.go
@@ -1,0 +1,23 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build linux
+
+package vfs
+
+import "syscall"
+
+// Prefetch signals the OS (on supported platforms) to fetch the next size
+// bytes in file after offset into cache. Any subsequent reads in that range
+// will not issue disk IO.
+func Prefetch(file File, offset uint64, size uint64) error {
+	type fd interface {
+		Fd() uintptr
+	}
+	if f, ok := file.(fd); ok {
+		_, _, err := syscall.Syscall(syscall.SYS_READAHEAD, uintptr(f.Fd()), uintptr(offset), uintptr(size))
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
For sequential-like IO workload where we read
data blocks one after the other in quick succession,
signalling the OS to asynchronously bring them to
cache in advance can deliver significant savings in IOPS
dispatched. In IOPS-bound workloads such as backup on
an EBS disk, this delivers a 3x speedup. Presumably
aggregate queries and compactions will be faster
as well, though this hasn't been benchmarked in
practice yet.

This change maintains a counter for the number of data
block reads performed in a singleLevelIterator, and
when that count exceeds 2, a readahead system
call is made on Linux. RocksDB has almost
the exact same behaviour, including the same
min/max readahead sizes and read count thresholds.

Will address https://github.com/cockroachdb/cockroach/issues/49710
when it lands in cockraoch.