### PR TITLE
*: Add error.Wrap() call to errors from wal/manifest record reader

### DIFF
--- a/open.go
+++ b/open.go
@@ -487,7 +487,7 @@ func (d *DB) replayWAL(
 			if err == io.EOF || err == record.ErrZeroedChunk || err == record.ErrInvalidChunk {
 				break
 			}
-			return 0, err
+			return 0, errors.Wrap(err, "pebble: error when replaying WAL")
 		}
 
 		if buf.Len() < batchHeaderLen {

--- a/version_set.go
+++ b/version_set.go
@@ -200,7 +200,8 @@ func (vs *versionSet) load(dirname string, opts *Options, mu *sync.Mutex) error 
 			break
 		}
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "pebble: error when loading manifest file %q",
+				errors.Safe(b))
 		}
 		var ve versionEdit
 		err = ve.Decode(r)


### PR DESCRIPTION
As part of investigating
https://github.com/cockroachdb/cockroach/issues/49747,
I'm trying to track down some io.ErrUnexpectedEOF errors
coming from Open(). These are two potential places they could
be coming from, so I'm going to add an error.Wrapf() and see which
of these it's coming from the next time it happens in CI.