### PR TITLE
crl-release-20.1: db: fix mergingIter corner case surrounding range tombstones

### DIFF
--- a/level_iter.go
+++ b/level_iter.go
@@ -334,10 +334,10 @@ func (l *levelIter) verify(key *InternalKey, val []byte) (*InternalKey, []byte) 
 		// bounds as such keys are always range tombstones which will be skipped by
 		// the Iterator.
 		if l.lower != nil && key != l.smallestBoundary && l.cmp(key.UserKey, l.lower) < 0 {
-			l.logger.Fatalf("levelIter: lower bound violation: %s < %s\n%s", key, l.lower, debug.Stack())
+			l.logger.Fatalf("levelIter %s: lower bound violation: %s < %s\n%s", l.level, key, l.lower, debug.Stack())
 		}
 		if l.upper != nil && key != l.largestBoundary && l.cmp(key.UserKey, l.upper) > 0 {
-			l.logger.Fatalf("levelIter: upper bound violation: %s > %s\n%s", key, l.upper, debug.Stack())
+			l.logger.Fatalf("levelIter %s: upper bound violation: %s > %s\n%s", l.level, key, l.upper, debug.Stack())
 		}
 	}
 	return key, val

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -362,7 +362,32 @@ func (m *mergingIter) switchToMinHeap() {
 		if l == cur {
 			continue
 		}
-		if l.iterKey == nil || l.iterKey.Kind() == base.InternalKeyKindRangeDelete {
+
+		// If the iterator is exhausted, it may be out of bounds if range
+		// deletions modified our search key as we descended. we need to
+		// reposition it within the search bounds. If the current key is a
+		// range tombstone, the iterator might still be exhausted but at a
+		// sstable boundary sentinel. It would be okay to reposition an
+		// interator like this only through successive Next calls, except that
+		// it would violate the levelIter's invariants by causing it to return
+		// a key before the lower bound.
+		//
+		//           bounds = [ f, _ )
+		// L0:   [ b ]          [ f*                   z ]
+		// L1: [ a           |----|        k        y ]
+		// L2:    [  c  (d) ] [ e      g     m ]
+		// L3:             [                    x ]
+		//
+		// * - current key   [] - table bounds () - heap item
+		//
+		// In the above diagram, the L2 iterator is positioned at a sstable
+		// boundary (d) outside the lower bound (f). It arrived here from a
+		// seek whose seek-key was modified by a range tombstone. If we called
+		// Next on the L2 iterator, it would return e, violating its lower
+		// bound.  Instead, we seek it to >= f and Next from there.
+
+		if l.iterKey == nil || (l.iterKey.Kind() == base.InternalKeyKindRangeDelete &&
+			m.heap.cmp(l.iterKey.UserKey, m.lower) < 0) {
 			if m.lower != nil {
 				l.iterKey, l.iterValue = l.iter.SeekGE(m.lower)
 			} else {
@@ -411,7 +436,32 @@ func (m *mergingIter) switchToMaxHeap() {
 		if l == cur {
 			continue
 		}
-		if l.iterKey == nil || l.iterKey.Kind() == base.InternalKeyKindRangeDelete {
+
+		// If the iterator is exhausted, it may be out of bounds if range
+		// deletions modified our search key as we descended. we need to
+		// reposition it within the search bounds. If the current key is a
+		// range tombstone, the iterator might still be exhausted but at a
+		// sstable boundary sentinel. It would be okay to reposition an
+		// interator like this only through successive Prev calls, except that
+		// it would violate the levelIter's invariants by causing it to return
+		// a key beyond the upper bound.
+		//
+		//           bounds = [ _, g )
+		// L0:   [ b ]          [ f*                   z ]
+		// L1: [ a                |-------| k       y ]
+		// L2:    [  c   d  ]        h [(i)    m ]
+		// L3:             [  e                  x ]
+		//
+		// * - current key   [] - table bounds () - heap item
+		//
+		// In the above diagram, the L2 iterator is positioned at a sstable
+		// boundary (i) outside the upper bound (g). It arrived here from a
+		// seek whose seek-key was modified by a range tombstone. If we called
+		// Prev on the L2 iterator, it would return h, violating its upper
+		// bound.  Instead, we seek it to < g, and Prev from there.
+
+		if l.iterKey == nil || (l.iterKey.Kind() == base.InternalKeyKindRangeDelete &&
+			m.heap.cmp(l.iterKey.UserKey, m.upper) >= 0) {
 			if m.upper != nil {
 				l.iterKey, l.iterValue = l.iter.SeekLT(m.upper)
 			} else {

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -362,7 +362,7 @@ func (m *mergingIter) switchToMinHeap() {
 		if l == cur {
 			continue
 		}
-		if l.iterKey == nil {
+		if l.iterKey == nil || l.iterKey.Kind() == base.InternalKeyKindRangeDelete {
 			if m.lower != nil {
 				l.iterKey, l.iterValue = l.iter.SeekGE(m.lower)
 			} else {
@@ -411,7 +411,7 @@ func (m *mergingIter) switchToMaxHeap() {
 		if l == cur {
 			continue
 		}
-		if l.iterKey == nil {
+		if l.iterKey == nil || l.iterKey.Kind() == base.InternalKeyKindRangeDelete {
 			if m.upper != nil {
 				l.iterKey, l.iterValue = l.iter.SeekLT(m.upper)
 			} else {

--- a/testdata/merging_iter
+++ b/testdata/merging_iter
@@ -444,3 +444,61 @@ b#0,1:1
 a#0,1:1
 a#2,1:2
 .
+
+# Verify the upper bound is respected when switching directions at a RANGEDEL
+# boundary.
+
+define
+L
+kq.RANGEDEL.100 p.RANGEDEL.72057594037927935
+kq.RANGEDEL.100:p
+L
+b.SET.90 o.SET.65
+b.SET.90:90 cat.SET.70:70 g.SET.80:80 o.SET.65:65
+L
+a.SET.41 z.RANGEDEL.72057594037927935
+a.SET.41:41 koujdlp.MERGE.37:37 ok.SET.46:46 v.SET.43:43 v.RANGEDEL.19:z
+----
+1:
+  000019:[kq#100,RANGEDEL-p#72057594037927935,RANGEDEL]
+2:
+  000020:[b#90,SET-o#65,SET]
+3:
+  000021:[a#41,SET-z#72057594037927935,RANGEDEL]
+
+iter
+set-bounds upper=n
+seek-ge krgywquurww
+prev
+----
+p#72057594037927935,15:
+kq#100,15:
+
+# Verify the lower bound is respected when switching directions at a RANGEDEL
+# boundary.
+
+define
+L
+a.SET.103 jyk.RANGEDEL.72057594037927935
+a.SET.103:103 imd.SET.793:793 iwoeionch.SET.792:792 c.RANGEDEL.101:jyk
+L
+b.SET.90 o.SET.65
+b.SET.90:90 cat.SET.70:70 g.SET.80:80 o.SET.65:65
+L
+all.SET.0 zk.SET.722
+all.SET.0:0 c.SET.0:0 zk.SET.722:722
+----
+1:
+  000022:[a#103,SET-jyk#72057594037927935,RANGEDEL]
+2:
+  000023:[b#90,SET-o#65,SET]
+3:
+  000024:[all#0,SET-zk#722,SET]
+
+iter
+set-bounds lower=cz upper=jd
+seek-lt jd
+next
+----
+iwoeionch#792,1:792
+jyk#72057594037927935,15:


### PR DESCRIPTION
Backport of the mergingIter bug fix from #738 & #744.