### PR TITLE
db: tweak the compaction concurrency heuristics

### DIFF
--- a/testdata/compaction_picker_target_level
+++ b/testdata/compaction_picker_target_level
@@ -193,12 +193,6 @@ queue
 L4->L5: 10.0
 L4->L5: 9.0
 L4->L5: 8.0
-L4->L5: 7.0
-L4->L5: 6.0
-L4->L5: 5.0
-L4->L5: 4.0
-L4->L5: 3.0
-L4->L5: 2.0
 
 pick ongoing=(5,6)
 ----
@@ -210,7 +204,7 @@ L0->L0: 2.2
 
 pick ongoing=(0,0,0,4)
 ----
-L0->L0: 2.0
+no compaction
 
 init_cp
 ----
@@ -221,7 +215,7 @@ pick ongoing=(0,5)
 L0->L0: 2.2
 
 init 1
-0: 10
+0: 20
 6: 10
 ----
 
@@ -231,36 +225,36 @@ base: 5
 
 queue
 ----
-L0->L5: 2.5
-L0->L0: 2.2
+L0->L5: 5.0
+L0->L0: 4.8
 
 pick
 ----
-L0->L5: 2.5
+L0->L5: 5.0
 
 pick ongoing=(0,5)
 ----
-L0->L0: 2.2
+L0->L0: 4.8
 
 # An intra-L0 compaction is only queued if there is an in-progress
 # L0->Lbase compaction.
 
 pick ongoing=(0,0)
 ----
-L0->L5: 2.2
+L0->L5: 4.8
 
 # Pick another intra-L0 compaction even if there is one already in
 # progress.
 
 pick ongoing=(0,0,0,5)
 ----
-L0->L0: 2.0
+L0->L0: 4.5
 
 # We'll only pick a concurrent compaction if it is "high" priority
-# (i.e. has a score >= 1.5).
+# (i.e. has a score >= highPriorityThreshold).
 
 init 1
-0: 7
+0: 17
 5: 1
 6: 10
 ----
@@ -271,12 +265,12 @@ base: 5
 
 queue
 ----
-L0->L5: 1.8
-L0->L0: 1.5
+L0->L5: 4.2
+L0->L0: 4.0
 
 pick ongoing=(0,5,5,6)
 ----
-L0->L0: 1.5
+L0->L0: 4.0
 
 pick ongoing=(5,6)
 ----
@@ -298,7 +292,6 @@ queue
 ----
 L5->L6: 4.0
 L5->L6: 3.0
-L5->L6: 2.0
 
 pick
 ----
@@ -310,7 +303,7 @@ L5->L6: 3.0
 
 pick ongoing=(5,6,5,6)
 ----
-L5->L6: 2.0
+no compaction
 
 pick ongoing=(5,6,5,6,5,6)
 ----
@@ -332,8 +325,6 @@ base: 5
 queue
 ----
 L5->L6: 2.0
-L5->L6: 1.8
-L5->L6: 1.6
 
 pick_manual level=0 start=0 end=12
 ----


### PR DESCRIPTION
Reduce how aggressively concurrent compactions are
triggered. Previously, concurrent compactions were only allowed for
levels with a score >= 1.5, independently of how many concurrent
compactions were already in progress. In write-heavy workloads with
large values, concurrent compactions were occurring too frequently,
starving log writes of disk bandwidth. This commit changes the heuristic
so that the threshold for allowing a concurrent compaction is dependent
on the number of concurrent compactions already in progress using the
formula: 2^num-in-progress-compactions. So the first concurrent
compaction will only be performed if a level has a score >= 2, the next
will be performed only if a level has a score >= 4, etc.

There is still work to be done on large-value handling, but this does
move the needle. The ycsb benchmarks are included below to show that
they are not impacted by this change.

name                              old ops/sec  new ops/sec  delta
kv0/enc=false/nodes=3              21.0k ±10%   21.1k ± 3%     ~     (p=0.780 n=10+9)
kv0/enc=false/nodes=3/size=4kb     2.63k ± 1%   2.98k ± 1%  +13.33%  (p=0.000 n=10+10)
kv0/enc=false/nodes=3/size=64kb      248 ± 1%     258 ± 1%   +4.34%  (p=0.000 n=10+9)
kv95/enc=false/nodes=3             45.8k ± 4%   45.3k ± 7%     ~     (p=0.280 n=10+10)
kv95/enc=false/nodes=3/size=4kb    36.5k ± 4%   36.9k ± 4%     ~     (p=0.247 n=10+10)
kv95/enc=false/nodes=3/size=64kb   4.98k ± 1%   5.20k ± 1%   +4.45%  (p=0.000 n=10+10)
ycsb/A/nodes=3                     22.2k ± 5%   22.6k ± 5%     ~     (p=0.113 n=10+9)
ycsb/B/nodes=3                     40.1k ± 2%   40.2k ± 4%     ~     (p=0.529 n=10+10)
ycsb/C/nodes=3                     55.8k ± 4%   55.8k ± 1%     ~     (p=0.965 n=10+8)
ycsb/D/nodes=3                     44.7k ± 4%   44.9k ± 5%     ~     (p=0.796 n=10+10)
ycsb/E/nodes=3                     6.00k ± 3%   5.98k ± 1%     ~     (p=0.393 n=10+10)
ycsb/F/nodes=3                     2.04k ±19%   1.96k ±19%     ~     (p=0.481 n=10+10)

I also looked at using the RocksDB compaction concurrency heuristic
which is to enable concurrency only when the number of L0 sstables
exceeds 2x the L0 compaction threshold. That also provided an
improvement, but it was smaller than the improvement seen from the
change in this commit. (Old is with the RocksDB heuristic, and new is
the heuristic in this commit).

name                              old ops/sec  new ops/sec  delta
kv0/enc=false/nodes=3/size=4kb     2.85k ± 1%   2.98k ± 1%   +4.64%  (p=0.000 n=9+10)
kv0/enc=false/nodes=3/size=64kb      247 ± 1%     258 ± 1%   +4.44%  (p=0.000 n=10+9)
kv95/enc=false/nodes=3/size=4kb    36.8k ± 2%   36.9k ± 4%     ~     (p=1.000 n=9+10)
kv95/enc=false/nodes=3/size=64kb   4.96k ± 0%   5.20k ± 1%   +4.90%  (p=0.000 n=10+10)