### PR TITLE
db: use lock free rand for skiplist

### DIFF
--- a/internal/fastrand/fastrand.go
+++ b/internal/fastrand/fastrand.go
@@ -1,0 +1,13 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package fastrand
+
+import (
+	_ "unsafe" // required by go:linkname
+)
+
+// Uint32 returns a lock free uint32 value.
+//go:linkname Uint32 runtime.fastrand
+func Uint32() uint32

--- a/internal/fastrand/fastrand_test.go
+++ b/internal/fastrand/fastrand_test.go
@@ -1,0 +1,47 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package fastrand
+
+import (
+	"golang.org/x/exp/rand"
+	"sync"
+	"testing"
+	"time"
+)
+
+type defaultRand struct {
+	mu sync.Mutex
+	src rand.PCGSource
+}
+
+func newDefaultRand() *defaultRand {
+	r := &defaultRand{}
+	r.src.Seed(uint64(time.Now().UnixNano()))
+	return r
+}
+
+func (r *defaultRand) Uint32() uint32 {
+	r.mu.Lock()
+	i := uint32(r.src.Uint64())
+	r.mu.Unlock()
+	return i
+}
+
+func BenchmarkFastRand(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			Uint32()
+		}
+	})
+}
+
+func BenchmarkDefaultRand(b *testing.B) {
+	r := newDefaultRand()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			r.Uint32()
+		}
+	})
+}


### PR DESCRIPTION
Currnely, when write in batch, pebble use a rand with mutex to generate random height for skiplist. This is so much slow where write is heavy. In my benchmark,  [`skiplist.randomheight`](https://github.com/cockroachdb/pebble/blob/master/internal/arenaskl/skl.go#L349-L360) costs about 1/3 of time. By replace it with [`runtime.fastrand`](https://golang.org/pkg/runtime/?m=all#fastrand) provided by go runtime, this costs disappears.

When there is little(or none) deleted keys in db, `isNextEntryDeleted` still takes more the 60% of the cpu times. So add a slice to record sub iters that contains deletes can eliminate this cost.