### PR TITLE
db: wake all waiters on cleaner.cond on state transitions

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1824,7 +1824,7 @@ func (d *DB) disableFileDeletions() {
 	for d.mu.cleaner.cleaning {
 		d.mu.cleaner.cond.Wait()
 	}
-	d.mu.cleaner.cond.Signal()
+	d.mu.cleaner.cond.Broadcast()
 }
 
 // enableFileDeletions enables previously disabled file deletions. Note that if
@@ -1866,7 +1866,7 @@ func (d *DB) acquireCleaningTurn(waitForOngoing bool) bool {
 // d.mu must be held when calling this.
 func (d *DB) releaseCleaningTurn() {
 	d.mu.cleaner.cleaning = false
-	d.mu.cleaner.cond.Signal()
+	d.mu.cleaner.cond.Broadcast()
 }
 
 // deleteObsoleteFiles deletes those files that are no longer needed.


### PR DESCRIPTION
Multiple goroutines can be blocked on `DB.mu.cleaner.cond` waiting for
cleaner conditions to change and the conditions being waited for
differ. We need to wake all of the waiters rather than a single one
because one of the waiters may not be able to make progress while
another can. In particular, if a waiter is blocked in
`DB.disableFileDeletions` and another waiter is blocked in
`DB.acquireCleaningTurn`, `DB.releaseCleaningTurn` needs to wake
both. If it wakes only one and the goroutine woken is the one in
`DB.acquireCleaningTurn`, that goroutine will not be able to make
progress because `DB.mu.cleaner.disabled` will be non-zero due to the
goroutine in `DB.disableFileDeletions`.

Fixes #743