### PR TITLE
release-20.1: internal/record: Handle ErrUnexpectedEOFs like invalid records

### DIFF
--- a/internal/record/record.go
+++ b/internal/record/record.go
@@ -149,6 +149,13 @@ var (
 	ErrInvalidChunk = errors.New("pebble/record: invalid chunk")
 )
 
+// IsInvalidRecord returns true if the error matches one of the error types
+// returned for invalid records. These are treated in a way similar to io.EOF
+// in recovery code.
+func IsInvalidRecord(err error) bool {
+	return err == ErrZeroedChunk || err == ErrInvalidChunk || err == io.ErrUnexpectedEOF
+}
+
 // Reader reads records from an underlying io.Reader.
 type Reader struct {
 	// r is the underlying reader.

--- a/open.go
+++ b/open.go
@@ -470,7 +470,7 @@ func (d *DB) replayWAL(
 			// preallocation and WAL recycling. We need to distinguish these errors
 			// from EOF in order to recognize that the record was truncated, but want
 			// to otherwise treat them like EOF.
-			if err == io.EOF || err == record.ErrZeroedChunk || err == record.ErrInvalidChunk {
+			if err == io.EOF || record.IsInvalidRecord(err) {
 				break
 			}
 			return 0, err


### PR DESCRIPTION
When coming across an io.EOF error when reading the next 32kb
block in a multi-chunk record during WAL/manifest recovery, we return
an ErrUnexpectedEOF which gets passed through to the Open() caller.
This change updates manifest/WAL recovery code to instead stop recovery
at that point and to ignore the last record, as that record did not
get written to disk completely at the time of the crash.