### PR TITLE
release-20.1: db: wake all waiters on cleaner.cond on state transitions

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1676,7 +1676,7 @@ func (d *DB) disableFileDeletions() {
 	for d.mu.cleaner.cleaning {
 		d.mu.cleaner.cond.Wait()
 	}
-	d.mu.cleaner.cond.Signal()
+	d.mu.cleaner.cond.Broadcast()
 }
 
 // enableFileDeletions enables previously disabled file deletions. Note that if
@@ -1718,7 +1718,7 @@ func (d *DB) acquireCleaningTurn(waitForOngoing bool) bool {
 // d.mu must be held when calling this.
 func (d *DB) releaseCleaningTurn() {
 	d.mu.cleaner.cleaning = false
-	d.mu.cleaner.cond.Signal()
+	d.mu.cleaner.cond.Broadcast()
 }
 
 // deleteObsoleteFiles deletes those files that are no longer needed.

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1797,5 +1799,53 @@ func TestCompactFlushQueuedLargeBatch(t *testing.T) {
 	require.NoError(t, d.Set([]byte("a"), bytes.Repeat([]byte("v"), d.largeBatchThreshold), nil))
 
 	require.NoError(t, d.Compact([]byte("a"), []byte("a")))
+	require.NoError(t, d.Close())
+}
+
+// Regression test for #747. Test a problematic series of "cleaner" operations
+// that could previously lead to DB.disableFileDeletions blocking forever even
+// though no cleaning was in progress.
+func TestCleanerCond(t *testing.T) {
+	d, err := Open("", &Options{
+		FS: vfs.NewMem(),
+	})
+	require.NoError(t, err)
+
+	for i := 0; i < 10; i++ {
+		d.mu.Lock()
+		require.True(t, d.acquireCleaningTurn(true))
+		d.mu.Unlock()
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			d.mu.Lock()
+			if d.acquireCleaningTurn(true) {
+				d.releaseCleaningTurn()
+			}
+			d.mu.Unlock()
+		}()
+
+		runtime.Gosched()
+
+		go func() {
+			defer wg.Done()
+			d.mu.Lock()
+			d.disableFileDeletions()
+			d.enableFileDeletions()
+			d.mu.Unlock()
+		}()
+
+		runtime.Gosched()
+
+		d.mu.Lock()
+		d.releaseCleaningTurn()
+		d.mu.Unlock()
+
+		wg.Wait()
+	}
+
 	require.NoError(t, d.Close())
 }


### PR DESCRIPTION
Multiple goroutines can be blocked on `DB.mu.cleaner.cond` waiting for
cleaner conditions to change and the conditions being waited for
differ. We need to wake all of the waiters rather than a single one
because one of the waiters may not be able to make progress while
another can. In particular, if a waiter is blocked in
`DB.disableFileDeletions` and another waiter is blocked in
`DB.acquireCleaningTurn`, `DB.releaseCleaningTurn` needs to wake
both. If it wakes only one and the goroutine woken is the one in
`DB.acquireCleaningTurn`, that goroutine will not be able to make
progress because `DB.mu.cleaner.disabled` will be non-zero due to the
goroutine in `DB.disableFileDeletions`.

Fixes #743