### PR TITLE
db: fix race in NewSnapshot

### DIFF
--- a/db.go
+++ b/db.go
@@ -789,11 +789,11 @@ func (d *DB) NewSnapshot() *Snapshot {
 		panic(ErrClosed)
 	}
 
+	d.mu.Lock()
 	s := &Snapshot{
 		db:     d,
 		seqNum: atomic.LoadUint64(&d.mu.versions.visibleSeqNum),
 	}
-	d.mu.Lock()
 	d.mu.snapshots.pushBack(s)
 	d.mu.Unlock()
 	return s

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/cockroachdb/pebble/vfs"
@@ -279,6 +280,70 @@ func TestSnapshotRangeDeletionStress(t *testing.T) {
 			}
 		}(r)
 	}
+	wg.Wait()
+	require.NoError(t, d.Close())
+}
+
+// TestNewSnapshotRace tests atomicity of NewSnapshot.
+//
+// It tests for a regression of a previous race condition in which NewSnapshot
+// would retrieve the visible sequence number for a new snapshot before
+// locking the database mutex to add the snapshot. A write and flush that
+// that occurred between the reading of the sequence number and appending the
+// snapshot could drop keys required by the snapshot.
+func TestNewSnapshotRace(t *testing.T) {
+	const runs = 10
+	d, err := Open("", &Options{FS: vfs.NewMem()})
+	require.NoError(t, err)
+
+	v := []byte(`foo`)
+	ch := make(chan string)
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		for k := range ch {
+			if err := d.Set([]byte(k), v, nil); err != nil {
+				t.Error(err)
+				return
+			}
+			if err := d.Flush(); err != nil {
+				t.Error(err)
+				return
+			}
+		}
+	}()
+	for i := 0; i < runs; i++ {
+		// This main test goroutine sets `k` before creating a new snapshot.
+		// The key `k` should always be present within the snapshot.
+		k := fmt.Sprintf("key%06d", i)
+		require.NoError(t, d.Set([]byte(k), v, nil))
+
+		// Lock d.mu in another goroutine so that our call to NewSnapshot
+		// will need to contend for d.mu.
+		wg.Add(1)
+		locked := make(chan struct{})
+		go func() {
+			defer wg.Done()
+			d.mu.Lock()
+			close(locked)
+			time.Sleep(20 * time.Millisecond)
+			d.mu.Unlock()
+		}()
+		<-locked
+
+		// Tell the other goroutine to overwrite `k` with a later sequence
+		// number. It's indeterminate which key we'll read, but we should
+		// always read one of them.
+		ch <- k
+		s := d.NewSnapshot()
+		_, c, err := s.Get([]byte(k))
+		require.NoError(t, err)
+		require.NoError(t, c.Close())
+		require.NoError(t, s.Close())
+	}
+	close(ch)
 	wg.Wait()
 	require.NoError(t, d.Close())
 }


### PR DESCRIPTION
Fix a race in NewSnapshot that could cause recently-written keys to be
missing. Previously, NewSnapshot's reading of the current sequence
number and appending to the database's snapshot list was not atomic.
This meant that a concurrent write and flush or compaction might cause
keys at the snapshot number to be dropped. This commit locks d.mu before
reading the current sequence number, which prevents flushes and
compactions from reading d.mu.snapshots before we've updated it.

Also, this commit adds a new test case to exercise this race. The test
case doesn't reliably fail before the fix, but run under `stress` it
fails within the first batch of runs.

Discovered as a part of investigating cockroachdb/cockroach#50182.