### PR TITLE
tool: Enhance lsm visualization to show L0 sublevels

### DIFF
--- a/tool/data/lsm.css
+++ b/tool/data/lsm.css
@@ -78,10 +78,17 @@ body {
     height: 40px;
 }
 
+#checkbox-container {
+    float: right;
+    width: 170px;
+    height: 40px;
+    padding-top: 10px;
+}
+
 #slider {
     background-color: #fff;
     height: 40px;
-    width: calc(100% - 86px);
+    width: calc(100% - 256px);
 }
 
 #vis {

--- a/tool/data/lsm.js
+++ b/tool/data/lsm.js
@@ -10,11 +10,11 @@
 // heights to account for the increasing target file size.
 //
 // TODO(peter): Use the TargetFileSizes specified in the OPTIONS file.
-const levelHeights = [16, 16, 16, 16, 32, 64, 128];
-const levelOffsets = levelHeights.map((v, i) =>
-    levelHeights.slice(0, i + 1).reduce((sum, elem) => sum + elem, 24)
-);
+let levelHeights = [16, 16, 16, 16, 32, 64, 128];
+const offsetStart = 24;
+let levelOffsets = generateLevelOffsets();
 const lineStart = 105;
+const sublevelHeight = 16;
 let levelWidth = 0;
 
 {
@@ -31,25 +31,42 @@ let levelWidth = 0;
         .attr("type", "text")
         .attr("id", "index")
         .attr("autocomplete", "off");
+    let checkboxContainer = h
+        .append("div")
+        .attr("id", "checkbox-container");
+    checkboxContainer.append("input")
+        .attr("type", "checkbox")
+        .attr("id", "flatten-sublevels")
+        .on("change", () => {version.onCheckboxChange(d3.event.target.checked)});
+    checkboxContainer.append("label")
+        .attr("for", "flatten-sublevels")
+        .text("Show sublevels");
     h.append("svg").attr("id", "slider");
     c.append("svg").attr("id", "vis");
 }
 
 let vis = d3.select("#vis");
-vis
-    .append("text")
-    .attr("class", "help")
-    .attr("x", 10)
-    .attr("y", levelOffsets[6] + 30)
-    .text(
-        "(space: start/stop, left-arrow[+shift]: step-back, right-arrow[+shift]: step-forward)"
-    );
 
-let reason = vis
-    .append("text")
-    .attr("class", "reason")
-    .attr("x", 10)
-    .attr("y", 16);
+function renderHelp() {
+    vis
+        .append("text")
+        .attr("class", "help")
+        .attr("x", 10)
+        .attr("y", levelOffsets[6] + 30)
+        .text(
+            "(space: start/stop, left-arrow[+shift]: step-back, right-arrow[+shift]: step-forward)"
+        );
+}
+
+function renderReason() {
+    return vis
+        .append("text")
+        .attr("class", "reason")
+        .attr("x", 10)
+        .attr("y", 16);
+}
+
+let reason = renderReason();
 
 let index = d3.select("#index");
 
@@ -63,6 +80,12 @@ function humanize(s) {
     let suffix = iecSuffixes[Math.floor(e)];
     let val = Math.floor(s / Math.pow(1024, e) * 10 + 0.5) / 10;
     return val.toFixed(val < 10 ? 1 : 0) + suffix;
+}
+
+function generateLevelOffsets() {
+    return levelHeights.map((v, i) =>
+        levelHeights.slice(0, i + 1).reduce((sum, elem) => sum + elem, offsetStart)
+    );
 }
 
 function styleWidth(e) {
@@ -80,13 +103,64 @@ let sliderX, sliderHandle;
 // The version object holds the current LSM state.
 let version = {
     levels: [[], [], [], [], [], [], []],
+    sublevels: [],
+    numSublevels: 0,
+    showSublevels: false,
+    // Generated after every change using setLevelsInfo().
+    levelsInfo: [],
     // The version edit index.
     index: -1,
+
+    init: function() {
+        for (let edit of data.Edits) {
+            if (edit.Sublevels === null || edit.Sublevels === undefined) {
+                continue;
+            }
+            for (let [file, sublevel] of Object.entries(edit.Sublevels)) {
+                if (sublevel >= this.numSublevels) {
+                    this.numSublevels = sublevel + 1;
+                }
+            }
+        }
+        for (let i = 0; i < this.numSublevels; i++) {
+            this.sublevels.push([]);
+        }
+        d3.select("#checkbox-container label")
+            .text("Show sublevels (" + this.numSublevels.toString() + ")");
+        this.setHeights();
+        this.setLevelsInfo();
+        renderHelp();
+    },
+
+    setHeights: function() {
+        // Update the height of level 0 to account for the number of sublevels,
+        // if there are any.
+        if (this.numSublevels > 0 && this.showSublevels === true) {
+            levelHeights[0] = sublevelHeight * this.numSublevels;
+        } else {
+            levelHeights[0] = sublevelHeight;
+        }
+        levelOffsets = generateLevelOffsets();
+    },
+
+    onCheckboxChange: function(value) {
+        this.showSublevels = value;
+        vis.selectAll("*")
+            .remove();
+        reason = renderReason();
+        this.setHeights();
+        this.setLevelsInfo();
+        renderHelp();
+
+        this.render(true);
+        this.updateSize();
+    },
 
     // Set the version edit index. This steps either forward or
     // backward through the version edits, applying or unapplying each
     // edit.
     set: function(index) {
+        let prevIndex = this.index;
         if (index < 0) {
             index = 0;
         } else if (index >= data.Edits.length) {
@@ -120,9 +194,33 @@ let version = {
             }
         }
 
+        // Build the sublevels from this.levels[0]. They need to be rebuilt from
+        // scratch each time there's a change to L0.
+        this.sublevels = [];
+        while(this.sublevels.length < this.numSublevels) {
+            this.sublevels.push([]);
+        }
+        for (let file of this.levels[0]) {
+            let sublevel = data.Edits[this.index].Sublevels[file];
+            this.sublevels[sublevel].push(file);
+        }
+
         // Sort the levels.
         for (let i in this.levels) {
             if (i == 0) {
+                for (let j in this.sublevels) {
+                    this.sublevels[j].sort(function(a, b) {
+                        let fa = data.Files[a];
+                        let fb = data.Files[b];
+                        if (fa.Smallest < fb.Smallest) {
+                            return -1;
+                        }
+                        if (fa.Smallest > fb.Smallest) {
+                            return +1;
+                        }
+                        return 0;
+                    });
+                }
                 this.levels[i].sort(function(a, b) {
                     let fa = data.Files[a];
                     let fb = data.Files[b];
@@ -155,7 +253,8 @@ let version = {
             }
         }
 
-        this.render();
+        this.updateLevelsInfo();
+        this.render(prevIndex === -1);
     },
 
     // Add the specified sstables to the specifed level.
@@ -178,8 +277,14 @@ let version = {
     },
 
     // Return the size of the sstables in a level.
-    size: function(level) {
-        return this.levels[level].reduce(
+    size: function(level, sublevel) {
+        if (level == 0 && sublevel !== null && sublevel !== undefined) {
+            return this.sublevels[sublevel].reduce(
+                (sum, elem) => sum + data.Files[elem].Size,
+                0
+            );
+        }
+        return (this.levels[level] || []).reduce(
             (sum, elem) => sum + data.Files[elem].Size,
             0
         );
@@ -192,8 +297,8 @@ let version = {
     },
 
     scale: function(level) {
-        return levelWidth < this.levels[level].length
-            ? levelWidth / this.levels[level].length
+        return levelWidth < this.levelsInfo[level].files.length
+            ? levelWidth / this.levelsInfo[level].files.length
             : 1;
     },
 
@@ -235,7 +340,65 @@ let version = {
         return s;
     },
 
-    render: function() {
+    setLevelsInfo: function() {
+        let sublevelCount = this.numSublevels;
+        let levelsInfo = [];
+        let levelsStart = 1;
+        if (this.showSublevels === true) {
+            levelsInfo = this.sublevels.map((files, sublevel) => ({
+                files: files,
+                levelString: "L0." + sublevel.toString(),
+                levelDisplayString: (sublevel === this.numSublevels - 1 ?
+                    "L0." : "&nbsp;&nbsp;&nbsp;&nbsp;.") + sublevel.toString(),
+                levelClass: "L0-" + sublevel.toString(),
+                level: 0,
+                offset: offsetStart + (sublevelHeight * (sublevelCount - sublevel)),
+                height: sublevelHeight,
+                size: humanize(this.size(0, sublevel)),
+            }));
+            if (levelsInfo.length === 0) {
+                levelsStart = 0;
+            }
+            levelsInfo.reverse();
+        } else {
+            levelsStart = 0;
+        }
+
+        levelsInfo = levelsInfo.concat(this.levels.slice(levelsStart).map((files, level) => ({
+            files: files,
+            levelString: "L" + (level+levelsStart).toString(),
+            levelDisplayString: "L" + (level+levelsStart).toString(),
+            levelClass: "L" + (level+levelsStart).toString(),
+            level: level,
+            offset: levelOffsets[level+levelsStart],
+            height: levelHeights[level+levelsStart],
+            size: humanize(this.size(level+levelsStart)),
+        })));
+        this.levelsInfo = levelsInfo;
+    },
+
+    updateLevelsInfo: function() {
+        let levelsStart = 1;
+        if (this.showSublevels === true) {
+            this.sublevels.forEach((files, sublevel) => {
+                this.levelsInfo[this.numSublevels - (sublevel + 1)].files = files;
+                this.levelsInfo[this.numSublevels - (sublevel + 1)].size = humanize(this.size(0, sublevel));
+            });
+            if (this.numSublevels === 0) {
+                levelsStart = 0;
+            }
+        } else {
+            levelsStart = 0;
+        }
+
+        this.levels.slice(levelsStart).forEach((files, level) => {
+            let sublevelOffset = this.showSublevels === true ? this.numSublevels : 0;
+            this.levelsInfo[sublevelOffset + level].files = files;
+            this.levelsInfo[sublevelOffset + level].size = humanize(this.size(levelsStart + level));
+        });
+    },
+
+    render: function(redraw) {
         let version = this;
 
         vis.interrupt();
@@ -247,51 +410,62 @@ let version = {
         // Render the text for each level: sstable count and size.
         vis
             .selectAll("text.levels")
-            .data(this.levels)
+            .data(this.levelsInfo)
             .enter()
             .append("text")
             .attr("class", "levels")
             .attr("x", 10)
-            .attr("y", (d, i) => levelOffsets[i])
-            .text((d, i) => "L" + i);
+            .attr("y", d => d.offset)
+            .html(d => d.levelDisplayString);
         vis
             .selectAll("text.counts")
-            .data(this.levels)
-            .text((d, i) => d.length)
+            .data(this.levelsInfo)
+            .text((d, i) => d.files.length)
             .enter()
             .append("text")
             .attr("class", "counts")
             .attr("text-anchor", "end")
             .attr("x", 55)
-            .attr("y", (d, i) => levelOffsets[i])
-            .text((d, i) => d.length);
+            .attr("y", d => d.offset)
+            .text(d => d.files.length);
         vis
             .selectAll("text.sizes")
-            .data(this.levels)
-            .text((d, i) => humanize(version.size(i)))
+            .data(this.levelsInfo)
+            .text((d, i) => d.size)
             .enter()
             .append("text")
             .attr("class", "sizes")
             .attr("text-anchor", "end")
             .attr("x", 100)
-            .attr("y", (d, i) => levelOffsets[i])
-            .text((d, i) => humanize(version.size(i)));
+            .attr("y", (d, i) => d.offset)
+            .text(d => d.size);
 
         // Render each of the levels. Each level is composed of an
         // outer group which provides a clipping recentangle, an inner
         // group defining the coordinate system, an overlap rectangle
         // to capture mouse events, an indicator rectangle used to
         // display sstable overlaps, and the per-sstable rectangles.
-        for (let i in this.levels) {
-            let g = vis
-                .selectAll("g.clip" + i)
-                .select("g")
-                .data([i]);
-            let clipG = g
-                .enter()
-                .append("g")
-                .attr("class", "clip" + i)
-                .attr("clip-path", "url(#L" + i + ")");
+        for (let i in this.levelsInfo) {
+            let g, clipG;
+            if (redraw === false) {
+                g = vis
+                    .selectAll("g.clip" + this.levelsInfo[i].levelClass)
+                    .select("g")
+                    .data([i]);
+                clipG = g
+                    .enter()
+                    .append("g")
+                    .attr("class", "clipRect clip" + this.levelsInfo[i].levelClass)
+                    .attr("clip-path", "url(#" + this.levelsInfo[i].levelClass + ")");
+            } else {
+                clipG = vis
+                    .append("g")
+                    .attr("class", "clipRect clip" + this.levelsInfo[i].levelClass)
+                    .attr("clip-path", "url(#" + this.levelsInfo[i].levelClass + ")")
+                    .data([i]);
+                g = clipG
+                    .append("g");
+            }
             clipG
                 .append("g")
                 .attr(
@@ -299,7 +473,7 @@ let version = {
                     "translate(" +
                         lineStart +
                         "," +
-                        levelOffsets[i] +
+                        this.levelsInfo[i].offset +
                         ") scale(1,-1)"
                 );
             clipG.append("rect").attr("class", "indicator");
@@ -308,9 +482,9 @@ let version = {
             clipG
                 .append("rect")
                 .attr("x", lineStart)
-                .attr("y", levelOffsets[i] - levelHeights[i])
+                .attr("y", this.levelsInfo[i].offset - this.levelsInfo[i].height)
                 .attr("width", levelWidth)
-                .attr("height", levelHeights[i])
+                .attr("height", this.levelsInfo[i].height)
                 .attr("opacity", 0)
                 .attr("pointer-events", "all")
                 .on("mousemove", i => version.onMouseMove(i))
@@ -326,7 +500,7 @@ let version = {
                 "translate(" +
                     lineStart +
                     "," +
-                    levelOffsets[i] +
+                    this.levelsInfo[i].offset +
                     ") scale(" +
                     s +
                     "," +
@@ -335,12 +509,12 @@ let version = {
             );
 
             // Render the sstables for the level.
-            let level = g.selectAll("rect.L" + i).data(this.levels[i], d => d);
+            let level = g.selectAll("rect." + this.levelsInfo[i].levelClass).data(this.levelsInfo[i].files);
             level.attr("fill", "#555").attr("x", (fileNum, i) => i);
             level
                 .enter()
                 .append("rect")
-                .attr("class", "L" + i)
+                .attr("class", this.levelsInfo[i].levelClass + " sstable")
                 .attr("id", fileNum => fileNum)
                 .attr("fill", "red")
                 .attr("x", (fileNum, i) => i)
@@ -356,7 +530,7 @@ let version = {
 
     onMouseMove: function(i) {
         i = Number(i);
-        if (this.levels[i].length == 0) {
+        if (Number.isNaN(i) || i >= this.levelsInfo.length || this.levelsInfo[i].files.length === 0) {
             return;
         }
 
@@ -367,29 +541,29 @@ let version = {
         let index = Math.round(mousex / this.scale(i));
         if (index < 0) {
             index = 0;
-        } else if (index >= this.levels[i].length) {
-            index = this.levels[i].length - 1;
+        } else if (index >= this.levelsInfo[i].files.length) {
+            index = this.levelsInfo[i].files.length - 1;
         }
-        let fileNum = this.levels[i][index];
+        let fileNum = this.levelsInfo[i].files[index];
         let meta = data.Files[fileNum];
 
         // Find the start and end index of the tables
         // that overlap with filenum.
         let overlapInfo = "";
-        for (let j = 1; j < this.levels.length; j++) {
-            if (this.levels[j].length == 0) {
+        for (let j = 1; j < this.levelsInfo.length; j++) {
+            if (this.levelsInfo[i].files.length === 0) {
                 continue;
             }
-            let indicator = vis.select("g.clip" + j + " rect.indicator");
+            let indicator = vis.select("g.clip" + this.levelsInfo[j].levelClass + " rect.indicator");
             indicator
                 .attr("fill", "black")
                 .attr("opacity", 0.3)
-                .attr("y", levelOffsets[j] - levelHeights[j])
-                .attr("height", levelHeights[j]);
-            if (j == i) {
+                .attr("y", this.levelsInfo[j].offset - this.levelsInfo[j].height)
+                .attr("height", this.levelsInfo[j].height);
+            if (j === i) {
                 continue;
             }
-            let fileNums = this.levels[j];
+            let fileNums = this.levelsInfo[j].files;
             for (let k in fileNums) {
                 let other = data.Files[fileNums[k]];
                 if (other.Largest < meta.Smallest) {
@@ -403,23 +577,23 @@ let version = {
                         break;
                     }
                 }
-                if (k == t) {
+                if (k === t) {
                     indicator.attr("x", lineStart + s * t).attr("width", s);
                 } else {
                     indicator
                         .attr("x", lineStart + s * t)
                         .attr("width", Math.max(0.5, s * (k - t)));
                 }
-                if (i + 1 == j && k > t) {
-                    let overlapSize = this.levels[j]
+                if (i + 1 === j && k > t) {
+                    let overlapSize = this.levelsInfo[j].files
                         .slice(t, k)
                         .reduce((sum, elem) => sum + data.Files[elem].Size, 0);
 
                     overlapInfo =
                         " overlaps " +
                         (k - t) +
-                        " @ L" +
-                        j +
+                        " @ " +
+                        this.levelsInfo[j].levelString +
                         " (" +
                         humanize(overlapSize) +
                         ")";
@@ -430,8 +604,8 @@ let version = {
 
         // TODO(peter): display smallest/largest key.
         reason.text(
-            "[L" +
-                i +
+            "[" +
+                this.levelsInfo[i].levelString +
                 " " +
                 fileNum +
                 " (" +
@@ -442,113 +616,114 @@ let version = {
         );
 
         vis
-            .select("g.clip" + i + " rect.indicator")
+            .select("g.clip" + this.levelsInfo[i].levelClass + " rect.indicator")
             .attr("x", lineStart + this.scale(i) * index)
             .attr("width", 1);
-    }
+    },
+
+    // Recalculate structures related to the page width.
+    updateSize: function() {
+        let svg = d3.select("#slider").html("");
+
+        let margin = { right: 10, left: 10 };
+
+        let width = styleWidth(d3.select("#slider")) - margin.left - margin.right,
+            height = styleHeight(svg);
+
+        sliderX = d3
+            .scaleLinear()
+            .domain([0, data.Edits.length - 1])
+            .range([0, width])
+            .clamp(true);
+
+        let slider = svg
+            .append("g")
+            .attr("class", "slider")
+            .attr("transform", "translate(" + margin.left + "," + height / 2 + ")");
+
+        slider
+            .append("line")
+            .attr("class", "track")
+            .attr("x1", sliderX.range()[0])
+            .attr("x2", sliderX.range()[1])
+            .select(function() {
+                return this.parentNode.appendChild(this.cloneNode(true));
+            })
+            .attr("class", "track-inset")
+            .select(function() {
+                return this.parentNode.appendChild(this.cloneNode(true));
+            })
+            .attr("class", "track-overlay")
+            .call(
+                d3
+                    .drag()
+                    .on("start.interrupt", function() {
+                        slider.interrupt();
+                    })
+                    .on("start drag", function() {
+                        version.set(Math.round(sliderX.invert(d3.event.x)));
+                    })
+            );
+
+        slider
+            .insert("g", ".track-overlay")
+            .attr("class", "ticks")
+            .attr("transform", "translate(0," + 18 + ")")
+            .selectAll("text")
+            .data(sliderX.ticks(10))
+            .enter()
+            .append("text")
+            .attr("x", sliderX)
+            .attr("text-anchor", "middle")
+            .text(function(d) {
+                return d;
+            });
+
+        sliderHandle = slider
+            .insert("circle", ".track-overlay")
+            .attr("class", "handle")
+            .attr("r", 9)
+            .attr("cx", sliderX(version.index));
+
+        levelWidth = styleWidth(vis) - 10 - lineStart;
+        let lineEnd = lineStart + levelWidth;
+
+        vis
+            .selectAll("line")
+            .data(this.levelsInfo)
+            .attr("x2", lineEnd)
+            .enter()
+            .append("line")
+            .attr("x1", lineStart)
+            .attr("x2", lineEnd)
+            .attr("y1", d => d.offset)
+            .attr("y2", d => d.offset)
+            .attr("stroke", "#ddd");
+
+        vis
+            .selectAll("defs clipPath rect")
+            .data(this.levelsInfo)
+            .attr("width", lineEnd - lineStart)
+            .enter()
+            .append("defs")
+            .append("clipPath")
+            .attr("id", d => d.levelClass)
+            .append("rect")
+            .attr("x", lineStart)
+            .attr("y", d => d.offset - d.height)
+            .attr("width", lineEnd - lineStart)
+            .attr("height", d => d.height);
+    },
 };
 
-// Recalculate structures related to the page width.
-function updateSize() {
-    let svg = d3.select("#slider").html("");
-
-    let margin = { right: 10, left: 10 };
-
-    let width = styleWidth(d3.select("#slider")) - margin.left - margin.right,
-        height = styleHeight(svg);
-
-    sliderX = d3
-        .scaleLinear()
-        .domain([0, data.Edits.length - 1])
-        .range([0, width])
-        .clamp(true);
-
-    let slider = svg
-        .append("g")
-        .attr("class", "slider")
-        .attr("transform", "translate(" + margin.left + "," + height / 2 + ")");
-
-    slider
-        .append("line")
-        .attr("class", "track")
-        .attr("x1", sliderX.range()[0])
-        .attr("x2", sliderX.range()[1])
-        .select(function() {
-            return this.parentNode.appendChild(this.cloneNode(true));
-        })
-        .attr("class", "track-inset")
-        .select(function() {
-            return this.parentNode.appendChild(this.cloneNode(true));
-        })
-        .attr("class", "track-overlay")
-        .call(
-            d3
-                .drag()
-                .on("start.interrupt", function() {
-                    slider.interrupt();
-                })
-                .on("start drag", function() {
-                    version.set(Math.round(sliderX.invert(d3.event.x)));
-                })
-        );
-
-    slider
-        .insert("g", ".track-overlay")
-        .attr("class", "ticks")
-        .attr("transform", "translate(0," + 18 + ")")
-        .selectAll("text")
-        .data(sliderX.ticks(10))
-        .enter()
-        .append("text")
-        .attr("x", sliderX)
-        .attr("text-anchor", "middle")
-        .text(function(d) {
-            return d;
-        });
-
-    sliderHandle = slider
-        .insert("circle", ".track-overlay")
-        .attr("class", "handle")
-        .attr("r", 9)
-        .attr("cx", sliderX(version.index));
-
-    levelWidth = styleWidth(vis) - 10 - lineStart;
-    let lineEnd = lineStart + levelWidth;
-
-    vis
-        .selectAll("line")
-        .data(levelOffsets)
-        .attr("x2", lineEnd)
-        .enter()
-        .append("line")
-        .attr("x1", lineStart)
-        .attr("x2", lineEnd)
-        .attr("y1", d => d)
-        .attr("y2", d => d)
-        .attr("stroke", "#ddd");
-
-    vis
-        .selectAll("defs clipPath rect")
-        .data(version.levels)
-        .attr("width", lineEnd - lineStart)
-        .enter()
-        .append("defs")
-        .append("clipPath")
-        .attr("id", (d, i) => "L" + i)
-        .append("rect")
-        .attr("x", lineStart)
-        .attr("y", (d, i) => levelOffsets[i] - levelHeights[i])
-        .attr("width", lineEnd - lineStart)
-        .attr("height", (d, i) => levelHeights[i]);
-}
-
 window.onload = function() {
-    updateSize();
+    version.init();
+    version.updateSize();
     version.set(0);
 };
 
 window.addEventListener("resize", function() {
-    updateSize();
+    version.updateSize();
     version.render();
 });
 


### PR DESCRIPTION
The bulk of the JS changes were to allow for dynamically
determined heights of levels and number of sublevels,
as well as to effectively redraw sstables and levels when the
"flatten sublevels" checkmark is toggled.

In the process I also found and fixed
a bug where we were not rendering the sstables in the very first
version edit until the slider was moved forward and backward at least
once.

Fixes #661.