### PR TITLE
tool: Allow vertical scrolling if visualization overflows

### DIFF
--- a/tool/data/lsm.css
+++ b/tool/data/lsm.css
@@ -60,6 +60,7 @@ body {
 #container {
     height: 100vh;
     width: 100%;
+    overflow-y: scroll;
 }
 
 #header {

--- a/tool/data/lsm.js
+++ b/tool/data/lsm.js
@@ -141,6 +141,7 @@ let version = {
             levelHeights[0] = sublevelHeight;
         }
         levelOffsets = generateLevelOffsets();
+        vis.style("height", levelOffsets[6] + 100);
     },
 
     onCheckboxChange: function(value) {

--- a/tool/lsm_data.go
+++ b/tool/lsm_data.go
@@ -65,6 +65,7 @@ body {
 #container {
     height: 100vh;
     width: 100%;
+    overflow-y: scroll;
 }
 
 #header {
@@ -248,6 +249,7 @@ let version = {
             levelHeights[0] = sublevelHeight;
         }
         levelOffsets = generateLevelOffsets();
+        vis.style("height", levelOffsets[6] + 100);
     },
 
     onCheckboxChange: function(value) {


### PR DESCRIPTION
Currently, our css height calculation works on the viewport
height, which is not influenced by content height. This change
dynamically sets the height of the svg element using JS, and
updates the container div to use scrollbars when its child
node overflows.