### PR TITLE
release-20.1: internal/manifest: Relax L0 CheckOrdering invariants for flush splits

### DIFF
--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -417,8 +417,8 @@ func TestGetIter(t *testing.T) {
 		},
 
 		{
-			description: "broken invariants 2: non-increasing level 0 sequence numbers",
-			badOrdering: true,
+			description: "broken invariants 2: matching level 0 sequence numbers, considered acceptable",
+			badOrdering: false,
 			tables: []testTable{
 				{
 					level:   0,

--- a/internal/manifest/testdata/version_check_ordering
+++ b/internal/manifest/testdata/version_check_ordering
@@ -50,8 +50,8 @@ L0
 ----
 OK
 
-# Ensure that coincident sequence numbers are detected around sstables with
-# overlapping sequence numbers.
+# Coincident sequence numbers around sstables with overlapping sequence numbers
+# are possible due to flush splitting, so this is acceptable.
 check-ordering
 L0
   c.SET.3-d.SET.4
@@ -65,19 +65,9 @@ L0
   k.SET.16-n.SET.19
   m.SET.20-n.SET.20
 ----
-L0 flushed file 000007 has smallest sequence number coincident with an ingested file : <#15-#17> vs <#15-#15>
-0:
-  000001:[c#3,SET-d#4,SET]
-  000002:[a#1,SET-b#5,SET]
-  000003:[e#2,SET-f#7,SET]
-  000004:[g#6,SET-h#12,SET]
-  000005:[i#8,SET-j#13,SET]
-  000006:[b#15,SET-d#15,SET]
-  000007:[a#15,SET-j#17,SET]
-  000008:[m#18,SET-n#18,SET]
-  000009:[k#16,SET-n#19,SET]
-  000010:[m#20,SET-n#20,SET]
+OK
 
+# Ensure that sstables passed in a non-sorted order aree detected.
 check-ordering
 L0
   a.SET.3-d.SET.3
@@ -103,20 +93,14 @@ L0
   a.SET.3-d.SET.3
   a.SET.3-b.SET.3
 ----
-L0 file 000002 does not have strictly increasing largest seqnum: <#3-#3> vs <?-#3>
-0:
-  000001:[a#3,SET-d#3,SET]
-  000002:[a#3,SET-b#3,SET]
+OK
 
 check-ordering
 L0
   a.SET.3-d.SET.3
   a.SET.3-d.SET.5
 ----
-L0 flushed file 000002 has smallest sequence number coincident with an ingested file : <#3-#5> vs <#3-#3>
-0:
-  000001:[a#3,SET-d#3,SET]
-  000002:[a#3,SET-d#5,SET]
+OK
 
 check-ordering
 L0
@@ -130,10 +114,7 @@ L0
   a.SET.3-d.SET.5
   a.SET.5-d.SET.5
 ----
-L0 file 000002 does not have strictly increasing largest seqnum: <#5-#5> vs <?-#5>
-0:
-  000001:[a#3,SET-d#5,SET]
-  000002:[a#5,SET-d#5,SET]
+OK
 
 check-ordering
 L0
@@ -141,11 +122,7 @@ L0
   a.SET.5-d.SET.5
   a.SET.4-d.SET.6
 ----
-L0 flushed file 000003 has smallest sequence number coincident with an ingested file : <#4-#6> vs <#4-#4>
-0:
-  000001:[a#4,SET-d#4,SET]
-  000002:[a#5,SET-d#5,SET]
-  000003:[a#4,SET-d#6,SET]
+OK
 
 check-ordering
 L0

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -444,8 +444,11 @@ func CheckOrdering(cmp Compare, format base.Formatter, level int, files []*FileM
 		// We have 2 kinds of files:
 		// - Files with exactly one sequence number: these could be either ingested files
 		//   or flushed files. We cannot tell the difference between them based on FileMetadata,
-		//   so our consistency checking here uses the weaker checks assuming it is an ingested
-		//   file (except for the 0 sequence number case below).
+		//   so our consistency checking here uses the weaker checks assuming it is a narrow
+		//   flushed file. We cannot error on ingested files having sequence numbers coincident
+		//   with flushed files, as the seemingly ingested file could just be a flushed file
+		//   with just one key in it, which is a truncated range tombstone sharing sequence numbers
+		//   with other files in the same flush.
 		// - Files with multiple sequence numbers: these are necessarily flushed files.
 		//
 		// Three cases of overlapping sequence numbers:
@@ -480,15 +483,7 @@ func CheckOrdering(cmp Compare, format base.Formatter, level int, files []*FileM
 		// Since these types of SSTables violate most other sequence number
 		// overlap invariants, and handling this case is important for compatibility
 		// with future versions of pebble, this method relaxes most L0 invariant
-		// checks except for those concerning ingested SSTables.
-
-		// The largest sequence number of any file. Increasing.
-		var largestSeqNum uint64
-
-		// The ingested file sequence numbers that have not yet been checked to be compatible with
-		// flushed files.
-		// They are checked when largestFlushedSeqNum advances past them.
-		var uncheckedIngestedSeqNums []uint64
+		// checks.
 
 		for i := range files {
 			f := files[i]
@@ -503,36 +498,6 @@ func CheckOrdering(cmp Compare, format base.Formatter, level int, files []*FileM
 						errors.Safe(prev.SmallestSeqNum), errors.Safe(prev.LargestSeqNum),
 						errors.Safe(f.SmallestSeqNum), errors.Safe(f.LargestSeqNum))
 				}
-			}
-			if f.LargestSeqNum == 0 && f.LargestSeqNum == f.SmallestSeqNum {
-				// We don't add these to uncheckedIngestedSeqNums since there could be flushed
-				// files of the form [0, N] where N > 0.
-				continue
-			}
-			if i > 0 && largestSeqNum >= f.LargestSeqNum {
-				return errors.Errorf("L0 file %s does not have strictly increasing "+
-					"largest seqnum: <#%d-#%d> vs <?-#%d>",
-					errors.Safe(f.FileNum), errors.Safe(f.SmallestSeqNum),
-					errors.Safe(f.LargestSeqNum), errors.Safe(largestSeqNum))
-			}
-			largestSeqNum = f.LargestSeqNum
-			if f.SmallestSeqNum == f.LargestSeqNum {
-				// Ingested file.
-				uncheckedIngestedSeqNums = append(uncheckedIngestedSeqNums, f.LargestSeqNum)
-			} else {
-				// Flushed file.
-				// Check that unchecked ingested sequence numbers are not coincident with f.SmallestSeqNum.
-				// We do not need to check that they are not coincident with f.LargestSeqNum because we
-				// have already confirmed that LargestSeqNums were increasing.
-				for _, seq := range uncheckedIngestedSeqNums {
-					if seq == f.SmallestSeqNum {
-						return errors.Errorf("L0 flushed file %s has smallest sequence number coincident with an ingested file "+
-							": <#%d-#%d> vs <#%d-#%d>",
-							errors.Safe(f.FileNum), errors.Safe(f.SmallestSeqNum),
-							errors.Safe(f.LargestSeqNum), errors.Safe(seq), errors.Safe(seq))
-					}
-				}
-				uncheckedIngestedSeqNums = uncheckedIngestedSeqNums[:0]
 			}
 		}
 	} else {

--- a/testdata/compaction_check_ordering
+++ b/testdata/compaction_check_ordering
@@ -45,7 +45,7 @@ L0
   a.SET.3-d.SET.3
   a.SET.3-b.SET.3
 ----
-fatal: L0 file 000002 does not have strictly increasing largest seqnum: <#3-#3> vs <?-#3>
+OK
 
 check-ordering
 L1


### PR DESCRIPTION
20.1 backport of one of the two commits in #715 .

---

This change updates L0 ordering invariants to only check for files
being in a sorted order by largest sequence numbers. This is because
the strictly-increasing seqno check can no longer be done with
flush splits (in cases where the largest sequence number is by
the same split range tombstone). Similarly, the ingestion-related
checks for files having coincident sequence numbers would no longer
work for the same reason.