### PR TITLE
db: force flush memtables with range deletions after delay

### DIFF
--- a/flushable.go
+++ b/flushable.go
@@ -33,6 +33,9 @@ type flushableEntry struct {
 	// flushForced indicates whether a flush was forced on this memtable (either
 	// manual, or due to ingestion). Protected by DB.mu.
 	flushForced bool
+	// delayedFlushForced indicates whether a timer has been set to force a flush
+	// on this memtable at some point in the future. Protected by DB.mu
+	delayedFlushForced bool
 	// logNum corresponds to the WAL that contains the records present in the
 	// receiver.
 	logNum FileNum

--- a/open.go
+++ b/open.go
@@ -65,6 +65,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		abbreviatedKey:      opts.Comparer.AbbreviatedKey,
 		largeBatchThreshold: (opts.MemTableSize - int(memTableEmptySize)) / 2,
 		logRecycler:         logRecycler{limit: opts.MemTableStopWritesThreshold + 1},
+		closedCh:            make(chan struct{}),
 	}
 
 	defer func() {

--- a/options.go
+++ b/options.go
@@ -311,6 +311,12 @@ type Options struct {
 		// L0CompactionThreshold and L0StopWritesThreshold to refer to L0
 		// read amplification as opposed to the count of L0 files.
 		L0SublevelCompactions bool
+
+		// DeleteRangeFlushDelay configures how long the database should wait
+		// before forcing a flush of a memtable that contains a range
+		// deletion. Disk space cannot be reclaimed until the range deletion
+		// is flushed. No automatic flush occurs if zero.
+		DeleteRangeFlushDelay time.Duration
 	}
 
 	// Filters is a map from filter policy name to filter policy. It is used for
@@ -585,10 +591,12 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  cache_size=%d\n", cacheSize)
 	fmt.Fprintf(&buf, "  cleaner=%s\n", o.Cleaner)
 	fmt.Fprintf(&buf, "  comparer=%s\n", o.Comparer.Name)
+	fmt.Fprintf(&buf, "  delete_range_flush_delay=%s\n", o.Experimental.DeleteRangeFlushDelay)
 	fmt.Fprintf(&buf, "  disable_wal=%t\n", o.DisableWAL)
 	fmt.Fprintf(&buf, "  flush_split_bytes=%d\n", o.Experimental.FlushSplitBytes)
 	fmt.Fprintf(&buf, "  l0_compaction_threshold=%d\n", o.L0CompactionThreshold)
 	fmt.Fprintf(&buf, "  l0_stop_writes_threshold=%d\n", o.L0StopWritesThreshold)
+	fmt.Fprintf(&buf, "  l0_sublevel_compactions=%t\n", o.Experimental.L0SublevelCompactions)
 	fmt.Fprintf(&buf, "  lbase_max_bytes=%d\n", o.LBaseMaxBytes)
 	fmt.Fprintf(&buf, "  max_concurrent_compactions=%d\n", o.MaxConcurrentCompactions)
 	fmt.Fprintf(&buf, "  max_manifest_file_size=%d\n", o.MaxManifestFileSize)
@@ -736,6 +744,8 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 						o.Comparer, err = hooks.NewComparer(value)
 					}
 				}
+			case "delete_range_flush_delay":
+				o.Experimental.DeleteRangeFlushDelay, err = time.ParseDuration(value)
 			case "disable_wal":
 				o.DisableWAL, err = strconv.ParseBool(value)
 			case "flush_split_bytes":
@@ -744,6 +754,8 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				o.L0CompactionThreshold, err = strconv.Atoi(value)
 			case "l0_stop_writes_threshold":
 				o.L0StopWritesThreshold, err = strconv.Atoi(value)
+			case "l0_sublevel_compactions":
+				o.Experimental.L0SublevelCompactions, err = strconv.ParseBool(value)
 			case "lbase_max_bytes":
 				o.LBaseMaxBytes, err = strconv.ParseInt(value, 10, 64)
 			case "max_concurrent_compactions":

--- a/options_test.go
+++ b/options_test.go
@@ -6,6 +6,7 @@ package pebble
 
 import (
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -47,10 +48,12 @@ func TestOptionsString(t *testing.T) {
   cache_size=8388608
   cleaner=delete
   comparer=leveldb.BytewiseComparator
+  delete_range_flush_delay=0s
   disable_wal=false
   flush_split_bytes=0
   l0_compaction_threshold=4
   l0_stop_writes_threshold=12
+  l0_sublevel_compactions=false
   lbase_max_bytes=67108864
   max_concurrent_compactions=1
   max_manifest_file_size=134217728
@@ -184,6 +187,7 @@ func TestOptionsParse(t *testing.T) {
 			opts.Levels[0].BlockSize = 1024
 			opts.Levels[1].BlockSize = 2048
 			opts.Levels[2].BlockSize = 4096
+			opts.Experimental.DeleteRangeFlushDelay = 10 * time.Second
 			opts.EnsureDefaults()
 			str := opts.String()
 


### PR DESCRIPTION
When a range deletion is added to a memtable, set a timer. If the
memtable isn't flushed by the time the timer expires, force a flush to
ensure the range deletions are written to disk and may reclaim disk
space.

For now I put this feature behind an experimental option, thinking that
we may want to remove this feature altogether if delete-only compactions
alleviate the need for it.

https://github.com/cockroachdb/cockroach/pull/50508#pullrequestreview-435962162