### PR TITLE
db: switch compaction concurrency signal from level score to L0 read-amp

### DIFF
--- a/db.go
+++ b/db.go
@@ -1279,11 +1279,11 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 				continue
 			}
 		}
-		l0FileCount := len(d.mu.versions.currentVersion().Levels[0])
+		l0ReadAmp := len(d.mu.versions.currentVersion().Levels[0])
 		if d.opts.Experimental.L0SublevelCompactions {
-			l0FileCount = d.mu.versions.currentVersion().L0Sublevels.ReadAmplification()
+			l0ReadAmp = d.mu.versions.currentVersion().L0Sublevels.ReadAmplification()
 		}
-		if l0FileCount >= d.opts.L0StopWritesThreshold {
+		if l0ReadAmp >= d.opts.L0StopWritesThreshold {
 			// There are too many level-0 files, so we wait.
 			if !stalled {
 				stalled = true

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -185,6 +185,7 @@ func randomOptions(rng *rand.Rand) *testOptions {
 	opts.Cache = cache.New(1 << uint(rng.Intn(30))) // 1B - 1GB
 	opts.DisableWAL = rng.Intn(2) == 0
 	opts.Experimental.FlushSplitBytes = 1 << rng.Intn(20)       // 1B - 1MB
+	opts.Experimental.L0CompactionConcurrency = 1 + rng.Intn(4) // 1-4
 	opts.Experimental.L0SublevelCompactions = rng.Intn(2) == 0
 	opts.L0CompactionThreshold = 1 + rng.Intn(100) // 1 - 100
 	opts.L0StopWritesThreshold = 1 + rng.Intn(100) // 1 - 100

--- a/options_test.go
+++ b/options_test.go
@@ -51,6 +51,7 @@ func TestOptionsString(t *testing.T) {
   delete_range_flush_delay=0s
   disable_wal=false
   flush_split_bytes=0
+  l0_compaction_concurrency=10
   l0_compaction_threshold=4
   l0_stop_writes_threshold=12
   l0_sublevel_compactions=false
@@ -210,6 +211,12 @@ func TestOptionsValidate(t *testing.T) {
 		expected string
 	}{
 		{``, ``},
+		{`
+[Options]
+  l0_compaction_concurrency=0
+`,
+			`L0CompactionConcurrency \(0\) must be >= 1`,
+		},
 		{`
 [Options]
   l0_compaction_threshold=2

--- a/testdata/compaction_picker_target_level
+++ b/testdata/compaction_picker_target_level
@@ -88,7 +88,6 @@ base: 4
 queue
 ----
 L4->L5: 10.0
-L4->L5: 3.3
 
 init 1
 4: 1
@@ -155,7 +154,6 @@ base: 6
 queue
 ----
 L0->L6: 125.0
-L0->L6: 100.0
 
 init 1
 0: 5
@@ -194,7 +192,6 @@ queue
 ----
 L4->L5: 10.0
 L4->L5: 7.7
-L4->L5: 6.0
 
 pick ongoing=(5,6)
 ----
@@ -256,7 +253,7 @@ L0->L0: 4.5
 # (i.e. has a score >= highPriorityThreshold).
 
 init 1
-0: 17
+0: 20
 5: 1
 6: 10
 ----
@@ -267,16 +264,16 @@ base: 4
 
 queue
 ----
-L0->L4: 425.0
-L0->L0: 4.0
+L0->L4: 500.0
+L0->L0: 4.8
 
 pick ongoing=(0,4,4,5)
 ----
-L0->L0: 4.0
+L0->L0: 4.8
 
 pick ongoing=(4,5)
 ----
-L0->L4: 425.0
+L0->L4: 500.0
 
 # Verify we can start concurrent Ln->Ln+1 compactions given sufficient
 # priority.
@@ -293,7 +290,6 @@ base: 5
 queue
 ----
 L5->L6: 5.2
-L5->L6: 3.5
 
 pick
 ----
@@ -301,21 +297,13 @@ L5->L6: 5.2
 
 pick ongoing=(5,6)
 ----
-L5->L6: 3.5
-
-pick ongoing=(5,6,5,6)
-----
-no compaction
-
-pick ongoing=(5,6,5,6,5,6)
-----
 no compaction
 
 # Verify that successive manual compactions interleaved with an automatic
 # compaction does not trigger an error.
 
 init 5
-0: 7
+0: 10
 5: 10
 6: 5
 ----
@@ -326,9 +314,8 @@ base: 5
 
 queue
 ----
-L5->L6: 8.0
-L5->L6: 6.0
-L5->L6: 4.6
+L5->L6: 9.2
+L5->L6: 6.9
 
 pick_manual level=0 start=0 end=12
 ----
@@ -336,7 +323,7 @@ L0->L5, retryLater = false
 
 pick
 ----
-L5->L6: 8.0
+L5->L6: 9.2
 
 # Assume the above two compactions (one manual L0 -> L5 and one automatic
 # L5 -> L6) have run, and Lbase = L6 now, but the manual compaction code is


### PR DESCRIPTION
Change the signal used to adjust compaction concurrency from the level
compaction score to L0 read-amp. The level compaction score worked
reasonably for small data sizes, but had the deficiency that the
compaction score tends to decrease over time as the DB size
increases. The level score is based on level size and target level
size. The speed at which this score can change decreases as the level
size gets larger because the input rate of new data is limited. In
contrast, L0 read amp tends to be a reflection of the data input rate
and independent of the DB size (modulo the effect that a larger DB size
tends to have higher write amplification which slows down compacting out
of L0).

The before and after numbers are slightly deceiving as the recent change
to compaction scoring hurt the `kv0/enc=false/nodes=3/size=64kb`,
`kv95/enc=false/nodes=3/size=4kb` and `kv95/enc=false/nodes=3/size=64kb`
workloads for the 10m duration they run at by default. All we're seeing
on those workloads is recovery back to their previous values. The
improvement on `kv0/enc=false/nodes=3/size=4kb` is real and is due to
the smaller number of concurrent compactions.

```
name                              old ops/sec  new ops/sec  delta
kv0/enc=false/nodes=3              21.4k ± 4%   21.3k ± 3%     ~     (p=1.000 n=10+9)
kv0/enc=false/nodes=3/size=4kb     3.00k ± 1%   3.66k ± 1%  +22.24%  (p=0.000 n=10+10)
kv0/enc=false/nodes=3/size=64kb      218 ± 1%     256 ± 2%  +17.38%  (p=0.000 n=10+10)
kv95/enc=false/nodes=3             46.7k ± 4%   45.8k ± 2%   -1.96%  (p=0.019 n=10+10)
kv95/enc=false/nodes=3/size=4kb    37.1k ± 2%   37.1k ± 3%     ~     (p=0.912 n=10+10)
kv95/enc=false/nodes=3/size=64kb   4.44k ± 1%   5.19k ± 1%  +16.98%  (p=0.000 n=10+8)
ycsb/A/nodes=3                     22.5k ± 2%   22.5k ± 2%     ~     (p=0.579 n=10+10)
ycsb/B/nodes=3                     40.8k ± 3%   41.4k ± 5%     ~     (p=0.218 n=10+10)
ycsb/C/nodes=3                     56.7k ± 2%   56.3k ± 1%     ~     (p=0.356 n=10+9)
ycsb/D/nodes=3                     44.6k ± 2%   45.3k ± 1%   +1.49%  (p=0.003 n=10+8)
ycsb/E/nodes=3                     6.11k ± 3%   6.03k ± 2%   -1.35%  (p=0.013 n=9+10)
ycsb/F/nodes=3                     9.73k ± 5%  10.13k ± 5%   +4.07%  (p=0.009 n=10+10)
```