### PR TITLE
cmd/pebble: enable L0-sublevel compactions and flush splits

### DIFF
--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -69,6 +69,11 @@ func newPebbleDB(dir string) DB {
 		MinCompactionRate: 4 << 20, // 4 MB/s
 		MinFlushRate:      4 << 20, // 4 MB/s
 	}
+	opts.Experimental.L0SublevelCompactions = true
+	// This value for FlushSplitBytes was arrived through some experimentation
+	// with TPCC import performance. More experimentation might be needed to
+	// optimize this for other workloads.
+	opts.Experimental.FlushSplitBytes = 10 << 20 // 10 MB
 
 	for i := 0; i < len(opts.Levels); i++ {
 		l := &opts.Levels[i]


### PR DESCRIPTION
Enable L0-sublevel compactions and flush splits for the `pebble bench`
commands.