### PR TITLE
compaction: Don't do a move compaction within L0.

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -748,6 +748,9 @@ func pickL0(env compactionEnv, opts *Options, vers *version, baseLevel int) (c *
 		}
 		if len(c.inputs[0]) == 0 {
 			opts.Logger.Fatalf("empty compaction chosen")
+		} else if len(c.inputs[0]) == 1 {
+			// A single-file intra-L0 compaction is unproductive.
+			return nil
 		}
 		c.smallest, c.largest = manifest.KeyRange(c.cmp, c.inputs[0], nil)
 		c.setupInuseKeyRanges()

--- a/testdata/compaction_picker_L0
+++ b/testdata/compaction_picker_L0
@@ -199,3 +199,21 @@ pick-auto l0_compaction_threshold=2
 ----
 L0 -> L0
 L0: 000100,000110
+
+# 1 L0 file. Should not choose any compaction, as an intra-L0 compaction
+# with one input is unhelpful.
+
+define
+L0
+   000100:i.SET.101-p.SET.102
+L6
+   000200:f.SET.51-s.SET.52 compacting
+----
+0.0:
+  000100:[i#101,SET-p#102,SET]
+6:
+  000200:[f#51,SET-s#52,SET]
+
+pick-auto l0_compaction_threshold=1
+----
+nil


### PR DESCRIPTION
Currently, if an intra-L0 compaction ends up being a move
compaction, we would trigger an assertion as the file would
appear to be deleted and added to the same level in the same
version edit.

Found via the metamorphic test.