### PR TITLE
internal/metamorphic: add checkpointOp, compactOp and flushOp

### DIFF
--- a/internal/metamorphic/config.go
+++ b/internal/metamorphic/config.go
@@ -9,7 +9,10 @@ type opType int
 const (
 	batchAbort opType = iota
 	batchCommit
+	dbCheckpoint
 	dbClose
+	dbCompact
+	dbFlush
 	dbRestart
 	iterClose
 	iterFirst
@@ -53,6 +56,9 @@ var defaultConfig = config{
 	ops: []int{
 		batchAbort:        5,
 		batchCommit:       5,
+		dbCheckpoint:      1,
+		dbCompact:         1,
+		dbFlush:           2,
 		dbRestart:         2,
 		iterClose:         10,
 		iterFirst:         100,

--- a/internal/metamorphic/generator.go
+++ b/internal/metamorphic/generator.go
@@ -80,6 +80,9 @@ func generate(count uint64, cfg config) []op {
 	generators := []func(){
 		batchAbort:        g.batchAbort,
 		batchCommit:       g.batchCommit,
+		dbCheckpoint:      g.dbCheckpoint,
+		dbCompact:         g.dbCompact,
+		dbFlush:           g.dbFlush,
 		dbRestart:         g.dbRestart,
 		iterClose:         g.iterClose,
 		iterFirst:         g.iterFirst,
@@ -241,6 +244,27 @@ func (g *generator) dbClose() {
 		g.snapshotClose()
 	}
 	g.add(&closeOp{objID: makeObjID(dbTag, 0)})
+}
+
+func (g *generator) dbCheckpoint() {
+	g.add(&checkpointOp{})
+}
+
+func (g *generator) dbCompact() {
+	// Generate new key(s) with a 1% probability.
+	start := g.randKey(0.01)
+	end := g.randKey(0.01)
+	if bytes.Compare(start, end) > 0 {
+		start, end = end, start
+	}
+	g.add(&compactOp{
+		start: start,
+		end:   end,
+	})
+}
+
+func (g *generator) dbFlush() {
+	g.add(&flushOp{})
 }
 
 func (g *generator) dbRestart() {

--- a/internal/metamorphic/parser.go
+++ b/internal/metamorphic/parser.go
@@ -44,8 +44,12 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	switch t := op.(type) {
 	case *applyOp:
 		return &t.writerID, nil, []interface{}{&t.batchID}
+	case *checkpointOp:
+		return nil, nil, nil
 	case *closeOp:
 		return &t.objID, nil, nil
+	case *compactOp:
+		return nil, nil, []interface{}{&t.start, &t.end}
 	case *batchCommitOp:
 		return &t.batchID, nil, nil
 	case *dbRestartOp:
@@ -56,6 +60,8 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 		return &t.writerID, nil, []interface{}{&t.start, &t.end}
 	case *iterFirstOp:
 		return &t.iterID, nil, nil
+	case *flushOp:
+		return nil, nil, nil
 	case *getOp:
 		return &t.readerID, nil, []interface{}{&t.key}
 	case *ingestOp:
@@ -94,11 +100,14 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 
 var methods = map[string]*methodInfo{
 	"Apply":           makeMethod(applyOp{}, dbTag, batchTag),
+	"Checkpoint":      makeMethod(checkpointOp{}, dbTag),
 	"Close":           makeMethod(closeOp{}, dbTag, batchTag, iterTag, snapTag),
 	"Commit":          makeMethod(batchCommitOp{}, batchTag),
+	"Compact":         makeMethod(compactOp{}, dbTag),
 	"Delete":          makeMethod(deleteOp{}, dbTag, batchTag),
 	"DeleteRange":     makeMethod(deleteRangeOp{}, dbTag, batchTag),
 	"First":           makeMethod(iterFirstOp{}, iterTag),
+	"Flush":           makeMethod(flushOp{}, dbTag),
 	"Get":             makeMethod(getOp{}, dbTag, batchTag, snapTag),
 	"Ingest":          makeMethod(ingestOp{}, dbTag),
 	"Init":            makeMethod(initOp{}, dbTag),


### PR DESCRIPTION
Add new operations to the metamorphic tests for manual `Compact`, `Flush`
calls and `Checkpoint` calls.

Fix #753.