### PR TITLE
db: refactor compaction startLevel, outputLevel

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -418,11 +418,13 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 		if err != nil {
 			return nil, err
 		}
-		return &compaction{
-			outputLevel: outputLevel,
-			smallest:    m.Smallest,
-			largest:     m.Largest,
-		}, nil
+		c := &compaction{
+			inputs:   []compactionLevel{{}, {level: outputLevel}},
+			smallest: m.Smallest,
+			largest:  m.Largest,
+		}
+		c.startLevel, c.outputLevel = &c.inputs[0], &c.inputs[1]
+		return c, nil
 	}
 
 	for _, line := range strings.Split(td.Input, "\n") {

--- a/db.go
+++ b/db.go
@@ -1458,9 +1458,8 @@ func (d *DB) getInProgressCompactionInfoLocked(finishing *compaction) (rv []comp
 	for c := range d.mu.compact.inProgress {
 		if len(c.flushing) == 0 && (finishing == nil || c != finishing) {
 			rv = append(rv, compactionInfo{
-				startLevel:  c.startLevel,
-				outputLevel: c.outputLevel,
 				inputs:      c.inputs,
+				outputLevel: c.outputLevel.level,
 			})
 		}
 	}

--- a/ingest.go
+++ b/ingest.go
@@ -445,7 +445,7 @@ func ingestTargetLevel(
 		// negative (else we'd have returned earlier).
 		overlaps := false
 		for c := range compactions {
-			if level != c.outputLevel {
+			if level != c.outputLevel.level {
 				continue
 			}
 			if cmp(meta.Smallest.UserKey, c.largest.UserKey) <= 0 &&


### PR DESCRIPTION
Refactor the `startLevel` and `outputLevel` fields of `compaction` to be
structs, encapsulating the level and input file list. Also, refactor the
inputs field to be a variable-length slice of these new
`compactionLevel` structs. This makes most codepaths more readable,
rather than relying on the implicit knowledge that `inputs[0]` is the
start level and `inputs[1]` is the output level. This will also allow
modeling compactions across more than two levels as a part of the
existing `compaction` struct.

Some codepaths that use `startLevel` and `outputLevel` might be able to
be refactored in terms of only `inputs` and made agnostic to the # of
levels involved in a compaction. I left that for future work.