### PR TITLE
sstable: don't skip over errored blocks during iteration

### DIFF
--- a/tool/testdata/sstable_check
+++ b/tool/testdata/sstable_check
@@ -45,7 +45,7 @@ sstable check
 testdata/corrupted.sst
 ----
 corrupted.sst
-pebble/table: invalid table (checksum mismatch)
+pebble/table: invalid table 000000 (checksum mismatch at 0/57)
 
 sstable check
 testdata/bad-magic.sst


### PR DESCRIPTION
Noticed while investigating github.com/cockroachdb/cockroach#50445 using
`pebble sstable check`. `singleLevelIterator.skip{Forward,Backward}` was
previously ignoring errors when `loadBlock` returned false. Now it does
not.

Took the opportunity to improve the `checksum mismatch` error message.