### PR TITLE
db: avoid go1.14 unsafe pointer conversion violations

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -832,21 +832,21 @@ func (b *Batch) Reader() BatchReader {
 func batchDecodeStr(data []byte) (odata []byte, s []byte, ok bool) {
 	var v uint32
 	var n int
-	src := (*[5]uint8)(unsafe.Pointer(&data[0]))
-	if a := (*src)[0]; a < 128 {
+	ptr := unsafe.Pointer(&data[0])
+	if a := *((*uint8)(ptr)); a < 128 {
 		v = uint32(a)
 		n = 1
-	} else if a, b := a&0x7f, (*src)[1]; b < 128 {
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
 		v = uint32(b)<<7 | uint32(a)
 		n = 2
-	} else if b, c := b&0x7f, (*src)[2]; c < 128 {
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
 		v = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 		n = 3
-	} else if c, d := c&0x7f, (*src)[3]; d < 128 {
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
 		v = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 		n = 4
 	} else {
-		d, e := d&0x7f, (*src)[4]
+		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
 		v = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 		n = 5
 	}

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -305,61 +305,58 @@ func (i *blockIter) readEntry() {
 	// TODO(peter): remove this hack if go:inline is ever supported.
 
 	var shared uint32
-	src := (*[5]uint8)(ptr)
-	if a := (*src)[0]; a < 128 {
+	if a := *((*uint8)(ptr)); a < 128 {
 		shared = uint32(a)
 		ptr = unsafe.Pointer(uintptr(ptr) + 1)
-	} else if a, b := a&0x7f, (*src)[1]; b < 128 {
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
 		shared = uint32(b)<<7 | uint32(a)
 		ptr = unsafe.Pointer(uintptr(ptr) + 2)
-	} else if b, c := b&0x7f, (*src)[2]; c < 128 {
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
 		shared = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 		ptr = unsafe.Pointer(uintptr(ptr) + 3)
-	} else if c, d := c&0x7f, (*src)[3]; d < 128 {
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
 		shared = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 		ptr = unsafe.Pointer(uintptr(ptr) + 4)
 	} else {
-		d, e := d&0x7f, (*src)[4]
+		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
 		shared = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 		ptr = unsafe.Pointer(uintptr(ptr) + 5)
 	}
 
 	var unshared uint32
-	src = (*[5]uint8)(ptr)
-	if a := (*src)[0]; a < 128 {
+	if a := *((*uint8)(ptr)); a < 128 {
 		unshared = uint32(a)
 		ptr = unsafe.Pointer(uintptr(ptr) + 1)
-	} else if a, b := a&0x7f, (*src)[1]; b < 128 {
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
 		unshared = uint32(b)<<7 | uint32(a)
 		ptr = unsafe.Pointer(uintptr(ptr) + 2)
-	} else if b, c := b&0x7f, (*src)[2]; c < 128 {
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
 		unshared = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 		ptr = unsafe.Pointer(uintptr(ptr) + 3)
-	} else if c, d := c&0x7f, (*src)[3]; d < 128 {
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
 		unshared = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 		ptr = unsafe.Pointer(uintptr(ptr) + 4)
 	} else {
-		d, e := d&0x7f, (*src)[4]
+		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
 		unshared = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 		ptr = unsafe.Pointer(uintptr(ptr) + 5)
 	}
 
 	var value uint32
-	src = (*[5]uint8)(ptr)
-	if a := (*src)[0]; a < 128 {
+	if a := *((*uint8)(ptr)); a < 128 {
 		value = uint32(a)
 		ptr = unsafe.Pointer(uintptr(ptr) + 1)
-	} else if a, b := a&0x7f, (*src)[1]; b < 128 {
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
 		value = uint32(b)<<7 | uint32(a)
 		ptr = unsafe.Pointer(uintptr(ptr) + 2)
-	} else if b, c := b&0x7f, (*src)[2]; c < 128 {
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
 		value = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 		ptr = unsafe.Pointer(uintptr(ptr) + 3)
-	} else if c, d := c&0x7f, (*src)[3]; d < 128 {
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
 		value = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 		ptr = unsafe.Pointer(uintptr(ptr) + 4)
 	} else {
-		d, e := d&0x7f, (*src)[4]
+		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
 		value = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 		ptr = unsafe.Pointer(uintptr(ptr) + 5)
 	}
@@ -447,32 +444,31 @@ func (i *blockIter) SeekGE(key []byte) (*InternalKey, []byte) {
 			// sought. See the comment in readEntry for why we manually inline the
 			// varint decoding.
 			var v1 uint32
-			src := (*[5]uint8)(ptr)
-			if a := (*src)[0]; a < 128 {
+			if a := *((*uint8)(ptr)); a < 128 {
 				v1 = uint32(a)
 				ptr = unsafe.Pointer(uintptr(ptr) + 1)
-			} else if a, b := a&0x7f, (*src)[1]; b < 128 {
+			} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
 				v1 = uint32(b)<<7 | uint32(a)
 				ptr = unsafe.Pointer(uintptr(ptr) + 2)
-			} else if b, c := b&0x7f, (*src)[2]; c < 128 {
+			} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
 				v1 = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 				ptr = unsafe.Pointer(uintptr(ptr) + 3)
-			} else if c, d := c&0x7f, (*src)[3]; d < 128 {
+			} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
 				v1 = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 				ptr = unsafe.Pointer(uintptr(ptr) + 4)
 			} else {
-				d, e := d&0x7f, (*src)[4]
+				d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
 				v1 = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 				ptr = unsafe.Pointer(uintptr(ptr) + 5)
 			}
 
-			if src := (*[5]uint8)(ptr); (*src)[0] < 128 {
+			if *((*uint8)(ptr)) < 128 {
 				ptr = unsafe.Pointer(uintptr(ptr) + 1)
-			} else if (*src)[1] < 128 {
+			} else if *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))) < 128 {
 				ptr = unsafe.Pointer(uintptr(ptr) + 2)
-			} else if (*src)[2] < 128 {
+			} else if *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))) < 128 {
 				ptr = unsafe.Pointer(uintptr(ptr) + 3)
-			} else if (*src)[3] < 128 {
+			} else if *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))) < 128 {
 				ptr = unsafe.Pointer(uintptr(ptr) + 4)
 			} else {
 				ptr = unsafe.Pointer(uintptr(ptr) + 5)
@@ -559,32 +555,31 @@ func (i *blockIter) SeekLT(key []byte) (*InternalKey, []byte) {
 			// sought. See the comment in readEntry for why we manually inline the
 			// varint decoding.
 			var v1 uint32
-			src := (*[5]uint8)(ptr)
-			if a := (*src)[0]; a < 128 {
+			if a := *((*uint8)(ptr)); a < 128 {
 				v1 = uint32(a)
 				ptr = unsafe.Pointer(uintptr(ptr) + 1)
-			} else if a, b := a&0x7f, (*src)[1]; b < 128 {
+			} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
 				v1 = uint32(b)<<7 | uint32(a)
 				ptr = unsafe.Pointer(uintptr(ptr) + 2)
-			} else if b, c := b&0x7f, (*src)[2]; c < 128 {
+			} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
 				v1 = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 				ptr = unsafe.Pointer(uintptr(ptr) + 3)
-			} else if c, d := c&0x7f, (*src)[3]; d < 128 {
+			} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
 				v1 = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 				ptr = unsafe.Pointer(uintptr(ptr) + 4)
 			} else {
-				d, e := d&0x7f, (*src)[4]
+				d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
 				v1 = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 				ptr = unsafe.Pointer(uintptr(ptr) + 5)
 			}
 
-			if src := (*[5]uint8)(ptr); (*src)[0] < 128 {
+			if *((*uint8)(ptr)) < 128 {
 				ptr = unsafe.Pointer(uintptr(ptr) + 1)
-			} else if (*src)[1] < 128 {
+			} else if *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))) < 128 {
 				ptr = unsafe.Pointer(uintptr(ptr) + 2)
-			} else if (*src)[2] < 128 {
+			} else if *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))) < 128 {
 				ptr = unsafe.Pointer(uintptr(ptr) + 3)
-			} else if (*src)[3] < 128 {
+			} else if *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))) < 128 {
 				ptr = unsafe.Pointer(uintptr(ptr) + 4)
 			} else {
 				ptr = unsafe.Pointer(uintptr(ptr) + 5)

--- a/sstable/unsafe.go
+++ b/sstable/unsafe.go
@@ -11,21 +11,20 @@ func getBytes(ptr unsafe.Pointer, length int) []byte {
 }
 
 func decodeVarint(ptr unsafe.Pointer) (uint32, unsafe.Pointer) {
-	src := (*[5]uint8)(ptr)
-	if a := (*src)[0]; a < 128 {
+	if a := *((*uint8)(ptr)); a < 128 {
 		return uint32(a),
 			unsafe.Pointer(uintptr(ptr) + 1)
-	} else if a, b := a&0x7f, (*src)[1]; b < 128 {
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
 		return uint32(b)<<7 | uint32(a),
 			unsafe.Pointer(uintptr(ptr) + 2)
-	} else if b, c := b&0x7f, (*src)[2]; c < 128 {
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
 		return uint32(c)<<14 | uint32(b)<<7 | uint32(a),
 			unsafe.Pointer(uintptr(ptr) + 3)
-	} else if c, d := c&0x7f, (*src)[3]; d < 128 {
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
 		return uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a),
 			unsafe.Pointer(uintptr(ptr) + 4)
 	} else {
-		d, e := d&0x7f, (*src)[4]
+		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
 		return uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a),
 			unsafe.Pointer(uintptr(ptr) + 5)
 	}


### PR DESCRIPTION
go1.14 introduced runtime checks in race builds that unsafe pointer
conversions are "safe". One of these checks is to verify that the type
being cast to fits within the available bytes of the source of the
cast. This was being violated in `batchDecodeStr` when the string being
decoded from was smaller than 5 bytes. The use of `*[5]uint8` in
`batchDecodeStr` was a convenience. The exact same code is produced if
we do pointer arithemetic on a `*uint8`, it is just somewhat more
verbose.