### PR TITLE
internal/manifest: Have flush split bytes account for # of sublevels

### DIFF
--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -70,10 +70,6 @@ func newPebbleDB(dir string) DB {
 		MinFlushRate:      4 << 20, // 4 MB/s
 	}
 	opts.Experimental.L0SublevelCompactions = true
-	// This value for FlushSplitBytes was arrived through some experimentation
-	// with TPCC import performance. More experimentation might be needed to
-	// optimize this for other workloads.
-	opts.Experimental.FlushSplitBytes = 10 << 20 // 10 MB
 
 	for i := 0; i < len(opts.Levels); i++ {
 		l := &opts.Levels[i]
@@ -87,6 +83,7 @@ func newPebbleDB(dir string) DB {
 		l.EnsureDefaults()
 	}
 	opts.Levels[6].FilterPolicy = nil
+	opts.Experimental.FlushSplitBytes = opts.Levels[0].TargetFileSize
 
 	opts.EnsureDefaults()
 

--- a/compaction.go
+++ b/compaction.go
@@ -40,8 +40,8 @@ func expandedCompactionByteSizeLimit(opts *Options, level int) uint64 {
 	return uint64(25 * opts.Level(level).TargetFileSize)
 }
 
-// maxGrandparentOverlapBytes is the maximum bytes of overlap with level+2
-// before we stop building a single file in a level to level+1 compaction.
+// maxGrandparentOverlapBytes is the maximum bytes of overlap with level+1
+// before we stop building a single file in a level-1 to level compaction.
 func maxGrandparentOverlapBytes(opts *Options, level int) uint64 {
 	return uint64(10 * opts.Level(level).TargetFileSize)
 }

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -15,12 +15,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 )
 
-// TODO(bilal):
-//  - Integrate compaction picking logic with the rest of pebble.
-//  - Refactor away slicing and indexing for simplicity and stronger correctness
-//    guarantees, especially in extendCandidateToRectangle and
-//    Pick{Base,IntraL0}Compactions.
-
 // Intervals are of the form [start, end) with no gap between intervals. Each
 // file overlaps perfectly with a sequence of intervals. This perfect overlap
 // occurs because the union of file boundary keys is used to pick intervals.
@@ -317,6 +311,9 @@ func NewL0Sublevels(
 		}
 	}
 	var cumulativeBytes uint64
+	// Multiply flushSplitMaxBytes by the number of sublevels. This prevents
+	// excessive flush splitting when the number of sublevels increases.
+	flushSplitMaxBytes *= int64(len(s.Levels))
 	for i := 0; i < len(s.orderedIntervals); i++ {
 		interval := &s.orderedIntervals[i]
 		if flushSplitMaxBytes > 0 && cumulativeBytes > uint64(flushSplitMaxBytes) &&

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -416,6 +416,9 @@ func TestL0Sublevels(t *testing.T) {
 					builder.WriteString(", ")
 				}
 			}
+			if len(flushSplitKeys) == 0 {
+				builder.WriteString("none")
+			}
 			return builder.String()
 		case "max-depth-after-ongoing-compactions":
 			return strconv.Itoa(sublevels.MaxDepthAfterOngoingCompactions())

--- a/internal/manifest/testdata/l0_sublevels
+++ b/internal/manifest/testdata/l0_sublevels
@@ -6,7 +6,7 @@ L0
   000003:e.SET.5-j.SET.7
 ----
 file count: 3, sublevels: 3, intervals: 5
-flush split keys(3): [b, e, j]
+flush split keys(2): [b, j]
 0.2: file count: 1, bytes: 256, width (mean, max): 2.0, 2, interval range: [0, 1]
 	000009:a#10,1-b#10,1
 0.1: file count: 1, bytes: 256, width (mean, max): 3.0, 3, interval range: [1, 3]
@@ -82,7 +82,7 @@ L6
   000008:g.SET.0-s.SET.0
 ----
 file count: 7, sublevels: 5, intervals: 10
-flush split keys(5): [b, d, f, g, h]
+flush split keys(3): [d, f, g]
 0.4: file count: 1, bytes: 256, width (mean, max): 2.0, 2, interval range: [5, 6]
 	000010:f#11,1-g#11,1
 0.3: file count: 1, bytes: 256, width (mean, max): 4.0, 4, interval range: [5, 8]
@@ -140,7 +140,7 @@ L6
   000008:g.SET.0-s.SET.0
 ----
 file count: 7, sublevels: 5, intervals: 10
-flush split keys(5): [b, d, f, g, h]
+flush split keys(3): [d, f, g]
 0.4: file count: 1, bytes: 256, width (mean, max): 2.0, 2, interval range: [5, 6]
 	000010:f#11,1-g#11,1
 0.3: file count: 1, bytes: 256, width (mean, max): 4.0, 4, interval range: [5, 8]
@@ -185,7 +185,7 @@ OK
 describe
 ----
 file count: 7, sublevels: 5, intervals: 10
-flush split keys(5): [b, d, f, g, h]
+flush split keys(3): [d, f, g]
 0.4: file count: 1, bytes: 256, width (mean, max): 2.0, 2, interval range: [5, 6]
 	000010:f#11,1-g#11,1
 0.3: file count: 1, bytes: 256, width (mean, max): 4.0, 4, interval range: [5, 8]
@@ -226,7 +226,7 @@ L6
   000008:g.SET.0-s.SET.0
 ----
 file count: 5, sublevels: 4, intervals: 5
-flush split keys(3): [g, h, p]
+flush split keys(2): [g, p]
 0.3: file count: 1, bytes: 256, width (mean, max): 1.0, 1, interval range: [0, 0]
 	000010:f#11,1-g#11,1
 0.2: file count: 1, bytes: 256, width (mean, max): 4.0, 4, interval range: [0, 3]
@@ -271,7 +271,7 @@ L6
   000008:g.SET.0-s.SET.0
 ----
 file count: 5, sublevels: 4, intervals: 5
-flush split keys(3): [g, h, p]
+flush split keys(2): [g, p]
 0.3: file count: 1, bytes: 256, width (mean, max): 1.0, 1, interval range: [0, 0]
 	000010:f#11,1-g#11,1
 0.2: file count: 1, bytes: 256, width (mean, max): 4.0, 4, interval range: [0, 3]
@@ -320,7 +320,7 @@ L6
   000008:g.SET.0-s.SET.0
 ----
 file count: 5, sublevels: 4, intervals: 5
-flush split keys(3): [g, h, p]
+flush split keys(2): [g, p]
 0.3: file count: 1, bytes: 256, width (mean, max): 4.0, 4, interval range: [0, 3]
 	000009:f#12,1-p#12,1
 0.2: file count: 1, bytes: 256, width (mean, max): 1.0, 1, interval range: [0, 0]
@@ -381,7 +381,7 @@ L6
   000008:g.SET.0-s.SET.0
 ----
 file count: 5, sublevels: 4, intervals: 5
-flush split keys(3): [g, h, p]
+flush split keys(2): [g, p]
 0.3: file count: 1, bytes: 256, width (mean, max): 4.0, 4, interval range: [0, 3]
 	000009:f#12,1-p#12,1
 0.2: file count: 1, bytes: 256, width (mean, max): 1.0, 1, interval range: [0, 0]
@@ -426,7 +426,7 @@ L6
   000008:g.SET.0-s.SET.0
 ----
 file count: 5, sublevels: 4, intervals: 5
-flush split keys(3): [g, h, p]
+flush split keys(2): [g, p]
 0.3: file count: 1, bytes: 256, width (mean, max): 4.0, 4, interval range: [0, 3]
 	000009:f#12,1-p#12,1
 0.2: file count: 1, bytes: 256, width (mean, max): 1.0, 1, interval range: [0, 0]
@@ -483,7 +483,7 @@ L6
   000008:g.SET.0-s.SET.0 compacting
 ----
 file count: 5, sublevels: 4, intervals: 5
-flush split keys(3): [g, h, p]
+flush split keys(2): [g, p]
 0.3: file count: 1, bytes: 256, width (mean, max): 4.0, 4, interval range: [0, 3]
 	000009:f#12,1-p#12,1
 0.2: file count: 1, bytes: 256, width (mean, max): 1.0, 1, interval range: [0, 0]
@@ -578,7 +578,7 @@ L6
   000008:g.SET.0-s.SET.0
 ----
 file count: 5, sublevels: 4, intervals: 5
-flush split keys(3): [g, h, p]
+flush split keys(2): [g, p]
 0.3: file count: 1, bytes: 256, width (mean, max): 4.0, 4, interval range: [0, 3]
 	000009:f#12,1-p#12,1
 0.2: file count: 1, bytes: 104859600, width (mean, max): 1.0, 1, interval range: [0, 0]
@@ -642,7 +642,7 @@ L6
   000008:g.SET.0-s.SET.0
 ----
 file count: 7, sublevels: 4, intervals: 9
-flush split keys(5): [g, h, j, l, p]
+flush split keys(4): [g, h, l, p]
 0.3: file count: 1, bytes: 256, width (mean, max): 8.0, 8, interval range: [0, 7]
 	000009:f#12,1-p#12,1
 0.2: file count: 1, bytes: 256, width (mean, max): 1.0, 1, interval range: [0, 0]
@@ -705,7 +705,7 @@ L6
   000008:g.SET.0-s.SET.0
 ----
 file count: 7, sublevels: 4, intervals: 9
-flush split keys(5): [g, h, j, l, p]
+flush split keys(4): [g, h, l, p]
 0.3: file count: 1, bytes: 256, width (mean, max): 8.0, 8, interval range: [0, 7]
 	000009:f#12,1-p#12,1
 0.2: file count: 1, bytes: 256, width (mean, max): 1.0, 1, interval range: [0, 0]
@@ -754,7 +754,7 @@ L6
   000008:g.SET.0-s.SET.0
 ----
 file count: 7, sublevels: 4, intervals: 9
-flush split keys(5): [g, h, j, l, p]
+flush split keys(4): [g, h, l, p]
 0.3: file count: 1, bytes: 256, width (mean, max): 8.0, 8, interval range: [0, 7]
 	000009:f#12,1-p#12,1
 0.2: file count: 1, bytes: 256, width (mean, max): 1.0, 1, interval range: [0, 0]
@@ -796,7 +796,7 @@ L6
   000008:g.SET.0-s.SET.0
 ----
 file count: 3, sublevels: 3, intervals: 6
-flush split keys(1): [e]
+flush split keys(0): []
 0.2: file count: 1, bytes: 16, width (mean, max): 2.0, 2, interval range: [3, 4]
 	000003:f#9,1-j#11,1
 0.1: file count: 1, bytes: 16, width (mean, max): 3.0, 3, interval range: [1, 3]
@@ -823,7 +823,7 @@ read-amp
 
 flush-split-keys
 ----
-flush user split keys: e
+flush user split keys: none
 
 # Reduce flush_split_max_bytes by 1, and there should also be a split key at c.
 
@@ -837,7 +837,7 @@ L6
   000008:g.SET.0-s.SET.0
 ----
 file count: 3, sublevels: 3, intervals: 6
-flush split keys(2): [c, e]
+flush split keys(1): [j]
 0.2: file count: 1, bytes: 16, width (mean, max): 2.0, 2, interval range: [3, 4]
 	000003:f#9,1-j#11,1
 0.1: file count: 1, bytes: 16, width (mean, max): 3.0, 3, interval range: [1, 3]
@@ -853,41 +853,69 @@ L6:    a---------------f g------------------------------------s
 
 flush-split-keys
 ----
-flush user split keys: c, e
-
-# Reduce flush_split_max_bytes by 1, and there should also be a split key at c.
-
-define flush_split_max_bytes=31
-L0
-  000001:a.SET.2-e.SET.5 size=64
-  000002:c.SET.6-g.SET.8 size=16
-  000003:f.SET.9-j.SET.11 size=16
-L6
-  000007:a.SET.0-f.SET.0
-  000008:g.SET.0-s.SET.0
-----
-file count: 3, sublevels: 3, intervals: 6
-flush split keys(2): [c, e]
-0.2: file count: 1, bytes: 16, width (mean, max): 2.0, 2, interval range: [3, 4]
-	000003:f#9,1-j#11,1
-0.1: file count: 1, bytes: 16, width (mean, max): 3.0, 3, interval range: [1, 3]
-	000002:c#6,1-g#8,1
-0.0: file count: 1, bytes: 64, width (mean, max): 2.0, 2, interval range: [0, 1]
-	000001:a#2,1-e#5,1
-compacting file count: 0, base compacting intervals: none
-L0.2:                 f------------j
-L0.1:        c------------g
-L0.0:  a------------e
-L6:    a---------------f g------------------------------------s
-       aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss
-
-flush-split-keys
-----
-flush user split keys: c, e
+flush user split keys: j
 
 max-depth-after-ongoing-compactions
 ----
 2
+
+define flush_split_max_bytes=64
+L0
+  000001:a.SET.2-d.SET.5 size=64
+  000002:e.SET.6-g.SET.8 size=64
+  000003:h.SET.9-j.SET.11 size=16
+L6
+  000007:a.SET.0-f.SET.0
+  000008:g.SET.0-s.SET.0
+----
+file count: 3, sublevels: 1, intervals: 6
+flush split keys(1): [g]
+0.0: file count: 3, bytes: 144, width (mean, max): 1.0, 1, interval range: [0, 4]
+	000001:a#2,1-d#5,1
+	000002:e#6,1-g#8,1
+	000003:h#9,1-j#11,1
+compacting file count: 0, base compacting intervals: none
+L0.0:  a---------d e------g h------j
+L6:    a---------------f g------------------------------------s
+       aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss
+
+flush-split-keys
+----
+flush user split keys: g
+
+# The calculation for flush split bytes multiplies the specified max bytes
+# parameter with the number of sublevels. In the case below, that should mean
+# a flush split key would not be emitted at d despite the estimated bytes tally
+# exceeding 64 bytes. Instead, it would be emitted when 64 * 2 = 128 bytes have
+# been exceeded.
+
+define flush_split_max_bytes=64
+L0
+  000001:a.SET.2-d.SET.5 size=64
+  000004:d.SET.12-e.SET.12 size=64
+  000002:e.SET.6-g.SET.8 size=64
+  000003:h.SET.9-j.SET.11 size=16
+L6
+  000007:a.SET.0-f.SET.0
+  000008:g.SET.0-s.SET.0
+----
+file count: 4, sublevels: 2, intervals: 8
+flush split keys(1): [e]
+0.1: file count: 1, bytes: 64, width (mean, max): 3.0, 3, interval range: [1, 3]
+	000004:d#12,1-e#12,1
+0.0: file count: 3, bytes: 144, width (mean, max): 1.7, 2, interval range: [0, 6]
+	000001:a#2,1-d#5,1
+	000002:e#6,1-g#8,1
+	000003:h#9,1-j#11,1
+compacting file count: 0, base compacting intervals: none
+L0.1:           d---e
+L0.0:  a---------d e------g h------j
+L6:    a---------------f g------------------------------------s
+       aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss
+
+flush-split-keys
+----
+flush user split keys: e
 
 # Ensure that the compaction picker doesn't error out when all seed files are
 # compacting.
@@ -906,7 +934,7 @@ L6
   000008:g.SET.0-s.SET.0
 ----
 file count: 7, sublevels: 4, intervals: 9
-flush split keys(5): [g, h, j, l, p]
+flush split keys(4): [g, h, l, p]
 0.3: file count: 1, bytes: 256, width (mean, max): 8.0, 8, interval range: [0, 7]
 	000009:f#12,1-p#12,1
 0.2: file count: 1, bytes: 256, width (mean, max): 1.0, 1, interval range: [0, 0]
@@ -957,7 +985,7 @@ L6
   000008:p.SET.0-s.SET.0
 ----
 file count: 7, sublevels: 3, intervals: 9
-flush split keys(5): [g, h, j, l, o]
+flush split keys(4): [g, h, l, o]
 0.2: file count: 1, bytes: 256, width (mean, max): 1.0, 1, interval range: [0, 0]
 	000010:f#11,1-g#11,1
 0.1: file count: 2, bytes: 512, width (mean, max): 2.0, 3, interval range: [0, 7]
@@ -1000,7 +1028,7 @@ L6
   000008:p.SET.0-s.SET.0
 ----
 file count: 7, sublevels: 3, intervals: 9
-flush split keys(5): [g, h, j, l, o]
+flush split keys(4): [g, h, l, o]
 0.2: file count: 1, bytes: 256, width (mean, max): 1.0, 1, interval range: [0, 0]
 	000010:f#11,1-g#11,1
 0.1: file count: 2, bytes: 512, width (mean, max): 2.0, 3, interval range: [0, 7]

--- a/options.go
+++ b/options.go
@@ -289,16 +289,16 @@ type Options struct {
 	// out of the experimental group, or made the non-adjustable default. These
 	// options may change at any time, so do not rely on them.
 	Experimental struct {
-		// FlushSplitBytes denotes the target number of bytes in each
-		// flush split interval (i.e. range between two flush split keys) in
-		// L0 sstables. When set to zero, only a single sstable is generated
+		// FlushSplitBytes denotes the target number of bytes per sublevel in
+		// each flush split interval (i.e. range between two flush split keys)
+		// in L0 sstables. When set to zero, only a single sstable is generated
 		// by each flush. When set to a non-zero value, flushes are split at
 		// points to meet L0's TargetFileSize, any grandparent-related overlap
-		// options, and at boundary keys of L0 flush split intervals (each of
-		// which are targeted to contain around FlushSplitBytes bytes across
-		// all L0 sstables). Splitting sstables during flush allows increased
-		// compaction flexibility and concurrency when those tables are
-		// compacted to lower levels.
+		// options, and at boundary keys of L0 flush split intervals (which are
+		// targeted to contain around FlushSplitBytes bytes in each sublevel
+		// between pairs of boundary keys). Splitting sstables during flush
+		// allows increased compaction flexibility and concurrency when those
+		// tables are compacted to lower levels.
 		//
 		// TODO(bilal): Experiment with this option to pick a good value.
 		FlushSplitBytes int64


### PR DESCRIPTION
Currently, the calculation of flush split bytes does not account
    for the "height" of L0 sublevels; as the number of sublevels
    increases, flush split keys are emitted closer to one another,
    as more bytes are covered between keys close together as more
    SSTables overlap. This change updates the flush split calculation
    to multiply the passed-in flush split bytes constant with the
    sublevel count.

This change also updates the target flush file size to match
    that of Lbase-1 as opposed to L0. This seems to perform
    better in practice with scan-heavy benchmarks.

First commit is #796 