### PR TITLE
db: implement delete-only compactions

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1458,7 +1458,8 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 					tombstoneLevel := int(parseUint64(parts[0][1:]))
 					// Find the file in the current version.
 					v := d.mu.versions.currentVersion()
-					for _, m := range v.Overlaps(tombstoneLevel, d.opts.Comparer.Compare, start, end) {
+					overlaps := v.Overlaps(tombstoneLevel, d.opts.Comparer.Compare, start, end)
+					for m := overlaps.First(); m != nil; m = overlaps.Next() {
 						if m.FileNum.String() == parts[1] {
 							tombstoneFile = m
 						}

--- a/db.go
+++ b/db.go
@@ -292,6 +292,9 @@ type DB struct {
 			flushing bool
 			// The number of ongoing compactions.
 			compactingCount int
+			// The list of deletion hints, suggesting ranges for delete-only
+			// compactions.
+			deletionHints []deleteCompactionHint
 			// The list of manual compactions. The next manual compaction to perform
 			// is at the start of the list. New entries are added to the end.
 			manual []*manualCompaction
@@ -1453,10 +1456,14 @@ func (d *DB) getEarliestUnflushedSeqNumLocked() uint64 {
 func (d *DB) getInProgressCompactionInfoLocked(finishing *compaction) (rv []compactionInfo) {
 	for c := range d.mu.compact.inProgress {
 		if len(c.flushing) == 0 && (finishing == nil || c != finishing) {
-			rv = append(rv, compactionInfo{
+			info := compactionInfo{
 				inputs:      c.inputs,
-				outputLevel: c.outputLevel.level,
-			})
+				outputLevel: -1,
+			}
+			if c.outputLevel != nil {
+				info.outputLevel = c.outputLevel.level
+			}
+			rv = append(rv, info)
 		}
 	}
 	return

--- a/ingest.go
+++ b/ingest.go
@@ -445,7 +445,7 @@ func ingestTargetLevel(
 		// negative (else we'd have returned earlier).
 		overlaps := false
 		for c := range compactions {
-			if level != c.outputLevel.level {
+			if c.outputLevel == nil || level != c.outputLevel.level {
 				continue
 			}
 			if cmp(meta.Smallest.UserKey, c.largest.UserKey) <= 0 &&

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -499,14 +499,18 @@ func TestIngest(t *testing.T) {
 
 		mem = vfs.NewMem()
 		require.NoError(t, mem.MkdirAll("ext", 0755))
-
-		var err error
-		d, err = Open("", &Options{
+		opts := &Options{
 			FS:                    mem,
 			L0CompactionThreshold: 100,
 			L0StopWritesThreshold: 100,
 			DebugCheck:            DebugCheckLevels,
-		})
+		}
+		// Disable automatic compactions because otherwise we'll race with
+		// delete-only compactions triggered by ingesting range tombstones.
+		opts.private.disableAutomaticCompactions = true
+
+		var err error
+		d, err = Open("", opts)
 		require.NoError(t, err)
 	}
 	reset()

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -131,10 +131,10 @@ func (m *FileMetadata) lessSmallestKey(b *FileMetadata, cmp Compare) bool {
 
 // KeyRange returns the minimum smallest and maximum largest internalKey for
 // all the fileMetadata in f0 and f1.
-func KeyRange(ucmp Compare, f0, f1 []*FileMetadata) (smallest, largest InternalKey) {
+func KeyRange(ucmp Compare, fileSlices ...[]*FileMetadata) (smallest, largest InternalKey) {
 	first := true
-	for _, f := range [2][]*FileMetadata{f0, f1} {
-		for _, meta := range f {
+	for _, files := range fileSlices {
+		for _, meta := range files {
 			if first {
 				first = false
 				smallest, largest = meta.Smallest, meta.Largest

--- a/table_stats.go
+++ b/table_stats.go
@@ -128,7 +128,27 @@ func (d *DB) collectTableStats() {
 	}
 	d.mu.tableStats.cond.Broadcast()
 	d.maybeCollectTableStats()
-	d.mu.compact.deletionHints = append(d.mu.compact.deletionHints, hints...)
+	if len(hints) > 0 {
+		// Verify that all of the hint tombstones' files still exist in the
+		// current version. Otherwise, the tombstone itself may have been
+		// compacted into L6 and more recent keys may have had their sequence
+		// numbers zeroed.
+		//
+		// Note that it's possible that the tombstone file is being compacted
+		// presently. In that case, the file will be present in v. When the
+		// compaction finishes compacting the tombstone file, it will detect
+		// and clear the hint.
+		//
+		// See DB.maybeUpdateDeleteCompactionHints.
+		v := d.mu.versions.currentVersion()
+		keepHints := hints[:0]
+		for _, h := range hints {
+			if v.Contains(h.tombstoneLevel, d.cmp, h.tombstoneFile) {
+				keepHints = append(keepHints, h)
+			}
+		}
+		d.mu.compact.deletionHints = append(d.mu.compact.deletionHints, keepHints...)
+	}
 	if maybeCompact {
 		d.maybeScheduleCompaction()
 	}

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -1,0 +1,171 @@
+# The first few cases are adapted from this ASCII example. The y-axis is
+# sequence numbers and the x-axis is the user key space. LSM levels are
+# omitted from the visualization.
+#
+# 250
+#
+#       |-b...230:h-|
+# _____________________________________________________ snapshot #210
+# 200               |--h.RANGEDEL.200:r--|
+#
+# _____________________________________________________ snapshot #180
+#
+# 150                     +--------+
+#           +---------+   | 000003 |
+#           | 000002  |   |        |
+#           +_________+   |        |
+# 100_____________________|________|___________________ snapshot #100
+#                         +--------+
+# _____________________________________________________ snapshot #70
+#                             +---------------+
+#  50                         | 000001        |
+#                             |               |
+#                             +---------------+
+# ______________________________________________________________
+#     a b c d e f g h i j k l m n o p q r s t u v w x y z
+
+define snapshots=(70, 100, 180, 210)
+L0
+b.RANGEDEL.230:h h.RANGEDEL.200:r
+L2
+d.SET.110:d i.SET.140:i
+L3
+k.SET.90:k o.SET.150:o
+L4
+m.SET.30:m u.SET.60:u
+----
+0.0:
+  000004:[b#230,RANGEDEL-r#72057594037927935,RANGEDEL]
+2:
+  000005:[d#110,SET-i#140,SET]
+3:
+  000006:[k#90,SET-o#150,SET]
+4:
+  000007:[m#30,SET-u#60,SET]
+
+# Test a hint that is blocked by open snapshots. No compaction should occur
+# and the hint should not be removed.
+
+set-hints
+L0.000004 b-r 90 200-230
+----
+L0.000004 b-r seqnums(tombstone=200-230, file-smallest=90)
+
+maybe-compact
+----
+Deletion hints:
+  L0.000004 b-r seqnums(tombstone=200-230, file-smallest=90)
+Compactions:
+  (none)
+
+# Adopt the same LSM but without snapshots 100, 180 and 210.
+
+define snapshots=(70)
+L0
+b.RANGEDEL.230:h h.RANGEDEL.200:r
+L2
+d.SET.110:d i.SET.140:i
+L3
+k.SET.90:k o.SET.150:o
+L4
+m.SET.30:m u.SET.60:u
+----
+0.0:
+  000004:[b#230,RANGEDEL-r#72057594037927935,RANGEDEL]
+2:
+  000005:[d#110,SET-i#140,SET]
+3:
+  000006:[k#90,SET-o#150,SET]
+4:
+  000007:[m#30,SET-u#60,SET]
+
+set-hints
+L0.000004 b-r 90 200-230
+----
+L0.000004 b-r seqnums(tombstone=200-230, file-smallest=90)
+
+maybe-compact
+----
+Deletion hints:
+  (none)
+Compactions:
+  [JOB 100] compacted L2 [000005] (784 B) + L3 [000006] (784 B) -> L6 [] (0 B), in 1.0s, output rate 0 B/s
+
+# Verify that compaction correctly handles the presence of multiple
+# overlapping hints which might delete a file multiple times. All of the
+# resolvable hints should be removed.
+
+define snapshots=(70)
+L0
+a.RANGEDEL.300:k
+L1
+b.RANGEDEL.230:h h.RANGEDEL.200:r
+L2
+d.SET.110:d i.SET.140:i
+L3
+k.SET.90:k o.SET.150:o
+L4
+m.SET.30:m u.SET.60:u
+----
+0.0:
+  000004:[a#300,RANGEDEL-k#72057594037927935,RANGEDEL]
+1:
+  000005:[b#230,RANGEDEL-r#72057594037927935,RANGEDEL]
+2:
+  000006:[d#110,SET-i#140,SET]
+3:
+  000007:[k#90,SET-o#150,SET]
+4:
+  000008:[m#30,SET-u#60,SET]
+
+set-hints
+L0.000004 a-k 110 300-300
+L1.000005 b-r 90 200-230
+----
+L0.000004 a-k seqnums(tombstone=300-300, file-smallest=110)
+L1.000005 b-r seqnums(tombstone=200-230, file-smallest=90)
+
+maybe-compact
+----
+Deletion hints:
+  (none)
+Compactions:
+  [JOB 100] compacted L2 [000006] (784 B) + L3 [000007] (784 B) -> L6 [] (0 B), in 1.0s, output rate 0 B/s
+
+# Test a range tombstone that is already compacted into L6.
+
+define snapshots=(70)
+L0
+m.SET.300:m b.RANGEDEL.230:h h.RANGEDEL.200:r
+L2
+d.SET.110:d i.SET.140:i
+L3
+k.SET.90:k o.SET.150:o
+L4
+m.SET.30:m u.SET.60:u
+----
+0.0:
+  000004:[b#230,RANGEDEL-r#72057594037927935,RANGEDEL]
+2:
+  000005:[d#110,SET-i#140,SET]
+3:
+  000006:[k#90,SET-o#150,SET]
+4:
+  000007:[m#30,SET-u#60,SET]
+
+set-hints
+L0.000004 b-r 90 200-230
+----
+L0.000004 b-r seqnums(tombstone=200-230, file-smallest=90)
+
+compact a-z
+----
+5:
+  000008:[b#230,RANGEDEL-u#0,SET]
+
+maybe-compact
+----
+Deletion hints:
+  (none)
+Compactions:
+  (none)


### PR DESCRIPTION
Implement a new form of compaction that may delete files from any
number of levels without scanning when the files are known to be
completely covered by a range tombstone.

When the table stats collector calculates an estimate of the bytes
covered by a range deletion, it also looks for sstables that are
completely covered by the tombstone. If it finds any, it creates a
'delete compaction hint' with the user key range, the sequence number
range of the tombstones and the lowest sequence number of any of the
covered files.

Whenever considering a new compaction, Pebble checks all existing hints
to see if all of its sequence numbers fall into the same snapshot
stripe. If they do, it constructs a special delete-only compaction
that does not specify an output level and may contain inputs from
multiple levels. These compactions are handled specially, simply
constructing a manifest edit that drops the files without reading them.