### PR TITLE
release-20.1: db: bump nextFileNum past obsolete file numbers on Open

### DIFF
--- a/open.go
+++ b/open.go
@@ -215,6 +215,13 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		if !ok {
 			continue
 		}
+
+		// Don't reuse any obsolete file numbers to avoid modifying an
+		// ingested sstable's original external file.
+		if d.mu.versions.nextFileNum <= fn {
+			d.mu.versions.nextFileNum = fn + 1
+		}
+
 		switch ft {
 		case fileTypeLog:
 			if fn >= d.mu.versions.minUnflushedLogNum {


### PR DESCRIPTION
20.1 backport of #788.