### PR TITLE
db: truncate tombstones to file bounds when calculating table stats

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -118,7 +118,7 @@ func ingestLoad1(
 		}
 	}
 
-	iter, err := r.NewRangeDelIter()
+	iter, err := r.NewRawRangeDelIter()
 	if err != nil {
 		return nil, err
 	}

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -94,7 +94,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 	newIters :=
 		func(meta *fileMetadata, opts *IterOptions, bytesIterated *uint64) (internalIterator, internalIterator, error) {
 			r := readers[meta.FileNum]
-			rangeDelIter, err := r.NewRangeDelIter()
+			rangeDelIter, err := r.NewRawRangeDelIter()
 			if err != nil {
 				return nil, nil, err
 			}

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -156,7 +156,7 @@ func (lt *levelIterTest) newIters(
 	if err != nil {
 		return nil, nil, err
 	}
-	rangeDelIter, err := lt.readers[meta.FileNum].NewRangeDelIter()
+	rangeDelIter, err := lt.readers[meta.FileNum].NewRawRangeDelIter()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -143,7 +143,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 	newIters :=
 		func(meta *fileMetadata, opts *IterOptions, bytesIterated *uint64) (internalIterator, internalIterator, error) {
 			r := readers[meta.FileNum]
-			rangeDelIter, err := r.NewRangeDelIter()
+			rangeDelIter, err := r.NewRawRangeDelIter()
 			if err != nil {
 				return nil, nil, err
 			}

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -1315,10 +1315,10 @@ func (r *Reader) NewCompactionIter(bytesIterated *uint64) (Iterator, error) {
 	}, nil
 }
 
-// NewRangeDelIter returns an internal iterator for the contents of the
-// range-del block for the table. Returns nil if the table does not contain any
-// range deletions.
-func (r *Reader) NewRangeDelIter() (base.InternalIterator, error) {
+// NewRawRangeDelIter returns an internal iterator for the contents of the
+// range-del block for the table. Returns nil if the table does not contain
+// any range deletions.
+func (r *Reader) NewRawRangeDelIter() (base.InternalIterator, error) {
 	if r.rangeDelBH.Length == 0 {
 		return nil, nil
 	}

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -74,7 +74,7 @@ func TestWriter(t *testing.T) {
 			return buf.String()
 
 		case "scan-range-del":
-			iter, err := r.NewRangeDelIter()
+			iter, err := r.NewRawRangeDelIter()
 			if err != nil {
 				return err.Error()
 			}

--- a/table_cache.go
+++ b/table_cache.go
@@ -206,7 +206,7 @@ func (c *tableCacheShard) newIters(
 
 	// NB: range-del iterator does not maintain a reference to the table, nor
 	// does it need to read from it after creation.
-	rangeDelIter, err := v.reader.NewRangeDelIter()
+	rangeDelIter, err := v.reader.NewRawRangeDelIter()
 	if err != nil {
 		_ = iter.Close()
 		return nil, nil, err

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -50,6 +50,19 @@ func TestTableStats(t *testing.T) {
 			d.mu.Unlock()
 			return ""
 
+		case "define":
+			require.NoError(t, d.Close())
+			loadedInfo = nil
+
+			d, err = runDBDefineCmd(td, opts)
+			if err != nil {
+				return err.Error()
+			}
+			d.mu.Lock()
+			s := d.mu.versions.currentVersion().String()
+			d.mu.Unlock()
+			return s
+
 		case "reopen":
 			require.NoError(t, d.Close())
 			loadedInfo = nil

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -99,7 +99,7 @@ compact a-e L1
 wait-pending-table-stats
 000008
 ----
-range-deletions-bytes-estimate: 1552
+range-deletions-bytes-estimate: 776
 
 # Same as above, except range tombstone covers multiple grandparent file boundaries.
 

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -110,3 +110,59 @@ wait-pending-table-stats
 000014
 ----
 (not found)
+
+# Test range tombstones that need to be truncated to file bounds. The
+# grandparent limit and small target file size ensures that our manual
+# compaction of L4->L5 will split the range tombstone across several files.
+
+define target-file-sizes=(100, 1)
+L4
+  a.RANGEDEL.8:f
+L5
+  b.SET.7:v
+L6
+  a.SET.1:v
+L6
+  b.SET.2:v
+L6
+  c.SET.3:v
+L6
+  d.SET.4:v
+L6
+  e.SET.5:v
+----
+4:
+  000004:[a-f]
+5:
+  000005:[b-b]
+6:
+  000006:[a-a]
+  000007:[b-b]
+  000008:[c-c]
+  000009:[d-d]
+  000010:[e-e]
+
+compact a-b L4
+----
+5:
+  000011:[a-b]
+  000012:[b-c]
+  000013:[c-d]
+  000014:[d-e]
+  000015:[e-f]
+6:
+  000006:[a-a]
+  000007:[b-b]
+  000008:[c-c]
+  000009:[d-d]
+  000010:[e-e]
+
+wait-pending-table-stats
+000011
+----
+range-deletions-bytes-estimate: 1542
+
+wait-pending-table-stats
+000012
+----
+range-deletions-bytes-estimate: 1542

--- a/tool/find.go
+++ b/tool/find.go
@@ -423,7 +423,7 @@ func (f *findT) searchTables(searchKey []byte, refs []findRef) []findRef {
 			// bit more work here to put them in a form that can be iterated in
 			// parallel with the point records.
 			rangeDelIter, err := func() (base.InternalIterator, error) {
-				iter, err := r.NewRangeDelIter()
+				iter, err := r.NewRawRangeDelIter()
 				if err != nil {
 					return nil, err
 				}

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -389,7 +389,7 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 		// bit more work here to put them in a form that can be iterated in
 		// parallel with the point records.
 		rangeDelIter, err := func() (base.InternalIterator, error) {
-			iter, err := r.NewRangeDelIter()
+			iter, err := r.NewRawRangeDelIter()
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Previously, when estimating the size of the data beneath a range
tombstone, the table stats collector was not truncating tombstones to
the bounds of the containing files. This resulted in overinflating the
estimate for fragmented tombstones earlier in the user key space.