### PR TITLE
cmd: Address TODO on measuring scan read-amp

### DIFF
--- a/cmd/pebble/badger.go
+++ b/cmd/pebble/badger.go
@@ -45,7 +45,7 @@ func (b badgerDB) NewBatch() batch {
 	return &badgerBatch{txn}
 }
 
-func (b badgerDB) Scan(key []byte, count int64, reverse bool) error {
+func (b badgerDB) Scan(iter iterator, key []byte, count int64, reverse bool) error {
 	panic("badgerDB.Scan: unimplemented")
 }
 

--- a/cmd/pebble/boltdb.go
+++ b/cmd/pebble/boltdb.go
@@ -59,7 +59,7 @@ func (b boltDB) NewBatch() batch {
 	return boltDBBatch{tx: tx, bucket: bucket}
 }
 
-func (b boltDB) Scan(key []byte, count int64, reverse bool) error {
+func (b boltDB) Scan(iter iterator, key []byte, count int64, reverse bool) error {
 	panic("boltDB.Scan: unimplemented")
 }
 

--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -17,12 +17,13 @@ import (
 type DB interface {
 	NewIter(*pebble.IterOptions) iterator
 	NewBatch() batch
-	Scan(key []byte, count int64, reverse bool) error
+	Scan(iter iterator, key []byte, count int64, reverse bool) error
 	Metrics() *pebble.Metrics
 	Flush() error
 }
 
 type iterator interface {
+	SeekLT(key []byte) bool
 	SeekGE(key []byte) bool
 	Valid() bool
 	Key() []byte
@@ -120,9 +121,8 @@ func (p pebbleDB) NewBatch() batch {
 	return p.d.NewBatch()
 }
 
-func (p pebbleDB) Scan(key []byte, count int64, reverse bool) error {
+func (p pebbleDB) Scan(iter iterator, key []byte, count int64, reverse bool) error {
 	var data bytealloc.A
-	iter := p.d.NewIter(nil)
 	if reverse {
 		for i, valid := 0, iter.SeekLT(key); valid; valid = iter.Prev() {
 			data, _ = data.Copy(iter.Key())
@@ -142,7 +142,7 @@ func (p pebbleDB) Scan(key []byte, count int64, reverse bool) error {
 			}
 		}
 	}
-	return iter.Close()
+	return nil
 }
 
 func (p pebbleDB) Metrics() *pebble.Metrics {

--- a/cmd/pebble/rocksdb.go
+++ b/cmd/pebble/rocksdb.go
@@ -154,7 +154,7 @@ func (r rocksDB) NewBatch() batch {
 	return rocksDBBatch{r.d.NewBatch()}
 }
 
-func (r rocksDB) Scan(key []byte, count int64, reverse bool) error {
+func (r rocksDB) Scan(iter iterator, key []byte, count int64, reverse bool) error {
 	// TODO: unnecessary overhead here. Change the interface.
 	beginKey, _, ok := mvccSplitKey(key)
 	if !ok {


### PR DESCRIPTION
This change addresses a TODO in cmd/pebble/ycsb around
measuring read-amp of scan operations. This makes measuring
differences in ycsb/E performance easier.