### PR TITLE
internal/manifest: Don't create new sublevel if overlap is on sentinel key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ testrace: test
 
 .PHONY: stress stressrace
 stressrace: testflags += -race
-stress stressrace: testflags += -exec 'stress ${STRESSFLAGS}' -timeout 0
+stress stressrace: testflags += -exec 'stress ${STRESSFLAGS}' -timeout 0 -test.v
 stress stressrace: test
 
 .PHONY: stressmeta

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -154,6 +154,17 @@ func visualizeSublevels(
 				buf.WriteByte(middleChar)
 				lastChar++
 			}
+			if f.Largest.Trailer == base.InternalKeyRangeDeleteSentinel &&
+				j < len(files)-1 && files[j+1].Smallest.UserKey[0] == f.Largest.UserKey[0] {
+				// This case happens where two successive files have
+				// matching end/start user keys but where the left-side file
+				// has the sentinel key as its end key trailer. In this case
+				// we print the sstables as:
+				//
+				// a------d------g
+				//
+				continue
+			}
 			buf.WriteByte(middleChar)
 			buf.WriteByte(f.Largest.UserKey[0])
 			if j < len(files)-1 {

--- a/internal/manifest/testdata/l0_sublevels
+++ b/internal/manifest/testdata/l0_sublevels
@@ -1028,3 +1028,24 @@ L0.1:                 f++++++h                n---o
 L0.0:                 f+++g h++++++j k+++l    n---o
 L6:    a------------------------------------------o p---------s
        aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss
+
+# Ensure that two L0 sstables where one ends at a rangedel sentinel key and
+# the other starts at the same user key occupy the same sublevel.
+
+define
+L0
+  000004:a.SET.2-d.RANGEDEL.72057594037927935
+  000005:d.SET.3-g.SET.5
+L6
+  000001:a.SET.0-o.SET.0
+  000008:p.SET.0-s.SET.0
+----
+file count: 2, sublevels: 1, intervals: 3
+flush split keys(2): [d, g]
+0.0: file count: 2, bytes: 512, width (mean, max): 1.0, 1, interval range: [0, 1]
+	000004:a#2,1-d#72057594037927935,15
+	000005:d#3,1-g#5,1
+compacting file count: 0, base compacting intervals: none
+L0.0:  a--------d---------g
+L6:    a------------------------------------------o p---------s
+       aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss


### PR DESCRIPTION


Currently the interval / sublevel calculation considers all user
keys to be the same, and all sstable start/end boundary user keys to be
contained (i.e. inclusive) in those files. However this is not
true if the end key has a trailer matching the sentinel key,
which happens a lot when we truncate rangedel tombstones
as part of flush splits.

This change updates sublevel generation to treat the sstable
end key as exclusive if it's the sentinel key. Interestingly enough,
all other interval logic is written well enough to "just work", making
this a simpler change than I was expecting.

Also add -test.v as a flag when running stress* with the makefile.
Something changed recently (go 1.14 I think?) that prevents the test
command from printing the number of runs / failures unless this
flag is passed in.