### PR TITLE
*: Always pick base compactions with minCompactionDepth = 1

### DIFF
--- a/internal/manifest/testdata/l0_sublevels
+++ b/internal/manifest/testdata/l0_sublevels
@@ -1049,11 +1049,11 @@ L6:    a------------------------------------------o p---------s
 pick-base-compaction min_depth=2
 ----
 compaction picked with stack depth reduction 3
-000006,000005,000004,000010,000007
+000006,000005,000004,000010,000007,000011,000009
 seed interval: f-g
 L0.2:                 f+++g
-L0.1:                 f++++++h                n---o
-L0.0:                 f+++g h++++++j k+++l    n---o
+L0.1:                 f++++++h                n+++o
+L0.0:                 f+++g h++++++j k+++l    n+++o
 L6:    a------------------------------------------o p---------s
        aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss
 

--- a/testdata/compaction_picker_L0
+++ b/testdata/compaction_picker_L0
@@ -32,6 +32,12 @@ L6: 000200
 
 pick-auto l0_compaction_threshold=2
 ----
+L0 -> L6
+L0: 000100
+L6: 000200
+
+pick-auto l0_compaction_threshold=3
+----
 nil
 
 # 2 L0 files, no overlaps.
@@ -56,6 +62,12 @@ L0: 000100,000110
 L6: 000200
 
 pick-auto l0_compaction_threshold=2
+----
+L0 -> L6
+L0: 000100,000110
+L6: 000200
+
+pick-auto l0_compaction_threshold=3
 ----
 nil
 
@@ -148,6 +160,18 @@ L0: 000100,000110,000120
 L6: 000200
 
 pick-auto l0_compaction_threshold=3
+----
+L0 -> L6
+L0: 000100,000110,000120
+L6: 000200
+
+pick-auto l0_compaction_threshold=4
+----
+L0 -> L6
+L0: 000100,000110,000120
+L6: 000200
+
+pick-auto l0_compaction_threshold=6
 ----
 nil
 


### PR DESCRIPTION
This change updates the call to PickBaseCompaction for sublevel
compactions to use a min compaction depth of 1. This allows for
base compactions where we would completely "clear out" L0,
something that was not happening with the previous setup. To
compensate for this change, we account for L0CompactionThreshold
in the L0 score instead, by dividing the existing score with it.

This change also calls p.grow when trying to optionally grow
a compaction. This calls version.Overlaps, which is more
optimistic in picking overlapping L0 files than
extendCandidateToRectangle. This helps in reducing write-amp
in some workloads.

In practice, this seems to work better in read-heavy benchmarks
where sublevel compactions would fail to clear out L0 while
having them disabled would clear out L0 and result in better
read performance:

	name              old ops/sec  new ops/sec  delta
	ycsb/C/values=64   64.6k ± 7%   68.0k ± 5%  +5.18%  (p=0.035 n=6+7)

	name              old read     new read     delta
	ycsb/C/values=64   3.53G ± 5%   3.50G ± 6%    ~     (p=0.445 n=6+7)

	name              old write    new write    delta
	ycsb/C/values=64   5.42G ± 3%   5.38G ± 4%    ~     (p=0.445 n=6+7)

	name              old r-amp    new r-amp    delta
	ycsb/C/values=64    5.75 ± 1%    5.24 ± 2%  -8.92%  (p=0.001 n=6+7)

	name              old w-amp    new w-amp    delta
	ycsb/C/values=64    5.40 ± 3%    5.36 ± 4%    ~     (p=0.421 n=6+7)