### PR TITLE
internal/mkbench: be more permissive in data.js parsing

### DIFF
--- a/internal/mkbench/mkbench.go
+++ b/internal/mkbench/mkbench.go
@@ -91,6 +91,8 @@ func (l *loader) loadCooked(path string) {
 		log.Fatal(err)
 	}
 
+	data = bytes.TrimSpace(data)
+
 	prefix := []byte("data = ")
 	if !bytes.HasPrefix(data, prefix) {
 		log.Fatalf("missing '%s' prefix", prefix)
@@ -129,7 +131,7 @@ func (l *loader) loadCooked(path string) {
 
 func (l *loader) loadRaw(dir string) {
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if !info.Mode().IsRegular() {
+		if info == nil || !info.Mode().IsRegular() {
 			return nil
 		}
 


### PR DESCRIPTION
Trim off trailing whitespace before removing the fixed prefix and
suffix. This fixes an overly strict bit of parsing encountered where a
manual edit of `data.js` caused a trailing newline to be added to the
file.

Don't segfault if the `data` directory does not exist.