### PR TITLE
db: fix tombstone elision, grandparent limit bug

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1496,6 +1496,26 @@ func (d *DB) runCompaction(
 	// finishOutput is called for an sstable with the first key of the next sstable, and for the
 	// last sstable with an empty key.
 	finishOutput := func(key []byte) error {
+		// If we haven't output any point records to the sstable (tw == nil)
+		// then the sstable will only contain range tombstones. The smallest
+		// key in the sstable will be the start key of the first range
+		// tombstone added. We need to ensure that this start key is distinct
+		// from the limit (key) passed to finishOutput, otherwise we would
+		// generate an sstable where the largest key is smaller than the
+		// smallest key due to how the largest key boundary is set below.
+		// TODO: It is unfortunate that we have to do this check here rather
+		// than when we decide to finish the sstable in the runCompaction
+		// loop. A better structure currently eludes us.
+		if tw == nil {
+			startKey := c.rangeDelFrag.Start()
+			if len(iter.tombstones) > 0 {
+				startKey = iter.tombstones[0].Start.UserKey
+			}
+			if d.cmp(startKey, key) == 0 {
+				return nil
+			}
+		}
+
 		// NB: clone the key because the data can be held on to by the call to
 		// compactionIter.Tombstones via rangedel.Fragmenter.FlushTo.
 		key = append([]byte(nil), key...)
@@ -1647,6 +1667,9 @@ func (d *DB) runCompaction(
 					c.largest.Pretty(d.opts.Comparer.FormatKey))
 			}
 		}
+		if err := meta.Validate(d.cmp, d.opts.Comparer.FormatKey); err != nil {
+			return err
+		}
 		return nil
 	}
 
@@ -1686,7 +1709,7 @@ func (d *DB) runCompaction(
 					limit = c.findL0Limit(startKey)
 				}
 			}
-		} else if c.rangeDelFrag.Empty() {
+		} else if c.rangeDelFrag.Empty() || len(ve.NewFiles) == 0 {
 			// In this case, `limit` will be a larger user key than `key.UserKey`, or
 			// nil. In either case, the inner loop will execute at least once to
 			// process `key`, and the input iterator will be advanced.

--- a/internal/manifest/testdata/version_check_ordering
+++ b/internal/manifest/testdata/version_check_ordering
@@ -144,7 +144,7 @@ check-ordering
 L1
   b.SET.1-a.SET.2
 ----
-L1 file 000001 has inconsistent bounds: b#1,SET vs a#2,SET
+L1 : file 000001 has inconsistent bounds: b#1,SET vs a#2,SET
 1:
   000001:[b#1,SET-a#2,SET]
 
@@ -160,7 +160,7 @@ L1
   a.SET.1-b.SET.2
   d.SET.3-c.SET.4
 ----
-L1 file 000002 has inconsistent bounds: d#3,SET vs c#4,SET
+L1 : file 000002 has inconsistent bounds: d#3,SET vs c#4,SET
 1:
   000001:[a#1,SET-b#2,SET]
   000002:[d#3,SET-c#4,SET]

--- a/testdata/compaction_check_ordering
+++ b/testdata/compaction_check_ordering
@@ -57,7 +57,7 @@ check-ordering
 L1
   b.SET.1-a.SET.2
 ----
-fatal: L1 file 000001 has inconsistent bounds: b#1,SET vs a#2,SET
+fatal: L1 : file 000001 has inconsistent bounds: b#1,SET vs a#2,SET
 
 check-ordering
 L1
@@ -71,7 +71,7 @@ L1
   a.SET.1-b.SET.2
   d.SET.3-c.SET.4
 ----
-fatal: L1 file 000002 has inconsistent bounds: d#3,SET vs c#4,SET
+fatal: L1 : file 000002 has inconsistent bounds: d#3,SET vs c#4,SET
 
 check-ordering
 L1

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -218,6 +218,42 @@ compact a-e L1
   000006:[a#0,SET-b#0,SET]
   000007:[c#0,SET-d#0,SET]
 
+# An elided range tombstone is the first item encountered by a compaction,
+# and the grandparent limit set by it extends to the next item, also a range
+# tombstone. The first item should be elided, and the second item should
+# reset the grandparent limit.
+
+define target-file-sizes=(1, 1, 1, 1)
+L1
+  a.RANGEDEL.4:d
+L1
+  grandparent.RANGEDEL.2:z
+  h.SET.3:v
+L2
+  grandparent.SET.1:v
+L3
+  grandparent.SET.0:v
+L3
+  m.SET.0:v
+----
+1:
+  000004:[a-d]
+  000005:[grandparent-z]
+2:
+  000006:[grandparent-grandparent]
+3:
+  000007:[grandparent-grandparent]
+  000008:[m-m]
+
+compact a-h L1
+----
+2:
+  000009:[grandparent#2,RANGEDEL-m#72057594037927935,RANGEDEL]
+  000010:[m#2,RANGEDEL-z#72057594037927935,RANGEDEL]
+3:
+  000007:[grandparent#0,SET-grandparent#0,SET]
+  000008:[m#0,SET-m#0,SET]
+
 # Setup such that grandparent overlap limit is exceeded multiple times at the same user key ("b").
 # Ensures the compaction output files are non-overlapping.
 


### PR DESCRIPTION
Previously, during compaction a tombstone that would eventually be
elided could be used to set a grandparent limit equal to the next key, a
tombstone with that same key as its start. This would cause the creation
of a table that starts and ends at the same user key, containing only a
range tombstone. The sstable end boundary would be set to the infinite
sequence number, violating the ordering of sstable boundaries.