### PR TITLE
tool: Only encode sublevel changes in lsm json object

### DIFF
--- a/tool/data/lsm.js
+++ b/tool/data/lsm.js
@@ -202,7 +202,10 @@ let version = {
             this.sublevels.push([]);
         }
         for (let file of this.levels[0]) {
-            let sublevel = data.Edits[this.index].Sublevels[file];
+            let sublevel = null;
+            for (let i = index; i >= 0 && (sublevel === null || sublevel === undefined); i--) {
+                sublevel = data.Edits[i].Sublevels[file];
+            }
             this.sublevels[sublevel].push(file);
         }
 

--- a/tool/lsm.go
+++ b/tool/lsm.go
@@ -36,7 +36,7 @@ type lsmVersionEdit struct {
 	Added map[int][]base.FileNum `json:",omitempty"`
 	// Map from level to files deleted from the level.
 	Deleted map[int][]base.FileNum `json:",omitempty"`
-	// L0 sublevel structure for all files at this point.
+	// L0 sublevels for any files with changed sublevels so far.
 	Sublevels map[base.FileNum]int `json:",omitempty"`
 }
 
@@ -247,6 +247,12 @@ func (l *lsmT) buildEdits(edits []*manifest.VersionEdit) {
 		edit.Sublevels = make(map[base.FileNum]int)
 		for sublevel, files := range sublevels.Levels {
 			for _, f := range files {
+				if len(l.state.Edits) > 0 {
+					lastEdit := l.state.Edits[len(l.state.Edits) - 1]
+					if sublevel2, ok := lastEdit.Sublevels[f.FileNum]; ok && sublevel == sublevel2 {
+						continue
+					}
+				}
 				edit.Sublevels[f.FileNum] = sublevel
 			}
 		}

--- a/tool/lsm_data.go
+++ b/tool/lsm_data.go
@@ -310,7 +310,10 @@ let version = {
             this.sublevels.push([]);
         }
         for (let file of this.levels[0]) {
-            let sublevel = data.Edits[this.index].Sublevels[file];
+            let sublevel = null;
+            for (let i = index; i >= 0 && (sublevel === null || sublevel === undefined); i--) {
+                sublevel = data.Edits[i].Sublevels[file];
+            }
             this.sublevels[sublevel].push(file);
         }
 


### PR DESCRIPTION
This change updates the LSM visualization generator to
only add L0 files to the sublevel field in edits in the
json object if the sublevel changed in that edit. To make
this work, there's a client-side JS change
to iterate back along edits to find the last set sublevel
for each L0 file. This significantly cuts down on JSON parsing time.

Fixes #764.