### PR TITLE
docs: nightly benchmarks fixes and tweaks

### DIFF
--- a/docs/css/app.css
+++ b/docs/css/app.css
@@ -8,6 +8,19 @@ body {
     border-top: 1px solid #eee;
 }
 
+.columns {
+    display: flex;
+    flex-direction: row;
+    align-items: baseline;
+    justify-content: space-between;
+}
+
+.rows {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+}
+
 .center {
     margin: auto;
     width: 90%;
@@ -15,24 +28,15 @@ body {
     max-width: 1200px;
 }
 
-.left {
-    float: left;
-}
-
-.right {
-    float: right;
-}
-
 .section {
-    padding-top: 10px;
-    padding-bottom: 10px;
+    flex: 100%;
+    margin-top: 10px;
     overflow: auto;
 }
 
 .title {
     font-size: 24pt;
     font-weight: bold;
-    padding-top: 10px;
 }
 
 .subtitle {
@@ -42,6 +46,7 @@ body {
 
 .updated {
     font-size: 9pt;
+    text-align: right;
 }
 
 div.annotation {
@@ -76,7 +81,7 @@ path.line2 {
 }
 
 svg.chart {
-    width: 50%;
+    flex: 50%;
     height: 200px;
 }
 
@@ -84,4 +89,15 @@ text.hover {
     font-size: 8pt;
     font-weight: bold;
     filter: url(#textBackground);
+}
+
+@media only screen and (max-width: 900px) {
+    .columns {
+        flex-direction: column;
+    }
+
+    svg.chart {
+        width: 100%;
+        flex: auto;
+    }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,14 +7,12 @@
     <title>Pebble Benchmarks</title>
   </head>
   <body>
-    <div class="center">
+    <div class="center rows">
       <div class="section">
-        <span class="title">Pebble Benchmarks</span>
-        <span class="right">
-          </br>
-          <span class="updated"></span>
-        </span>
-        <br/>
+        <div class="columns">
+          <div class="title">Pebble Benchmarks</div>
+          <div class="updated">Last updated</div>
+        </div>
         <br/>
         <div class="overview">
           Benchmarks are run nightly using <a class="code"
@@ -32,47 +30,64 @@
         <div class="annotation" data-date="20200604">Increased
         LogWriter free blocks 4-&gt;16</div>
       </div>
-      <div class="section">
-        <span class="subtitle">YCSB A</span>
-        <span>(50% reads, 50% updates, zipf key distribution)</span>
-        <div class="right">
-          <b>Detail:</b>
-          <a id="readBytes" class="toggle">Bytes Read</a> |
-          <a id="writeBytes" class="toggle">Bytes Written</a> |
-          <a id="readAmp" class="toggle">Read Amp</a> |
-          <a id="writeAmp" class="toggle">Write Amp</a>
+      <div class="section rows">
+        <div class="columns">
+          <div>
+            <span class="subtitle">YCSB A</span>
+            <span>(50% reads, 50% updates, zipf key distribution)</span>
+          </div>
+          <div>
+            <b>Detail:</b>
+            <a id="readBytes" class="toggle">Bytes Read</a> |
+            <a id="writeBytes" class="toggle">Bytes Written</a> |
+            <a id="readAmp" class="toggle">Read Amp</a> |
+            <a id="writeAmp" class="toggle">Write Amp</a>
+          </div>
         </div>
-        <br/>
-        <svg class="chart left" data-key="ycsb/A/values=64"></svg>
-        <svg class="chart right" data-key="ycsb/A/values=1024"></svg>
+        <div class="columns">
+          <svg class="chart" data-key="ycsb/A/values=64"></svg>
+          <svg class="chart" data-key="ycsb/A/values=1024"></svg>
+        </div>
       </div>
-      <div class="section">
-        <span class="subtitle">YCSB B</span>
-        <span>(95 reads, 5% updates, zipf key distribution)</span>
-        <br/>
-        <svg class="chart left" data-key="ycsb/B/values=64"></svg>
-        <svg class="chart right" data-key="ycsb/B/values=1024"></svg>
+      <div class="section rows">
+        <div>
+          <span class="subtitle">YCSB B</span>
+          <span>(95 reads, 5% updates, zipf key distribution)</span>
+        </div>
+        <div class="columns">
+          <svg class="chart left" data-key="ycsb/B/values=64"></svg>
+          <svg class="chart right" data-key="ycsb/B/values=1024"></svg>
+        </div>
       </div>
-      <div class="section">      
-        <span class="subtitle">YCSB C</span>
-        <span>(100% reads, zipf key distribution)</span>
-        <br/>
-        <svg class="chart left" data-key="ycsb/C/values=64"></svg>
-        <svg class="chart right" data-key="ycsb/C/values=1024"></svg>
+      <div class="section rows">
+        <div>
+          <span class="subtitle">YCSB C</span>
+          <span>(100% reads, zipf key distribution)</span>
+        </div>
+        <div class="columns">
+          <svg class="chart left" data-key="ycsb/C/values=64"></svg>
+          <svg class="chart right" data-key="ycsb/C/values=1024"></svg>
+        </div>
       </div>
-      <div class="section">
-        <span class="subtitle">YCSB D</span>
-        <span>(95% reads, 5% updates, uniform key distribution)</span>
-        <br/>
-        <svg class="chart left" data-key="ycsb/D/values=64"></svg>
-        <svg class="chart right" data-key="ycsb/D/values=1024"></svg>
+      <div class="section rows">
+        <div>
+          <span class="subtitle">YCSB D</span>
+          <span>(95% reads, 5% updates, uniform key distribution)</span>
+        </div>
+        <div class="columns">
+          <svg class="chart left" data-key="ycsb/D/values=64"></svg>
+          <svg class="chart right" data-key="ycsb/D/values=1024"></svg>
+        </div>
       </div>
-      <div class="section">
-        <span class="subtitle">YCSB E</span>
-        <span>(95% scans, 5% updates, zipf key distribution)</span>
-        <br/>
-        <svg class="chart left" data-key="ycsb/E/values=64"></svg>
-        <svg class="chart right" data-key="ycsb/E/values=1024"></svg>
+      <div class="section rows">
+        <div>
+          <span class="subtitle">YCSB E</span>
+          <span>(95% scans, 5% updates, zipf key distribution)</span>
+        </div>
+        <div class="columns">
+          <svg class="chart left" data-key="ycsb/E/values=64"></svg>
+          <svg class="chart right" data-key="ycsb/E/values=1024"></svg>
+        </div>
       </div>
     </div>
     <script src="js/d3.v5.min.js"></script>

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -363,7 +363,8 @@ function renderChart(chart) {
             });
 
             const mouse = d3.mouse(this);
-            if (mouse && mouse[0]) {
+            if (mouse) {
+                mouse[0] -= margin.left; // adjust for rect.mouse position
                 const date = x.invert(mouse[0]);
                 const hover = hoverSeries(mouse);
                 d3.selectAll(".chart").each(function() {


### PR DESCRIPTION
#### docs: fix mouse position calculation on zoom/pan

#### docs: use flexbox for layout of nightly benchmarks page

Switch to a single column layout when the display is too narrow.