### PR TITLE
internal/metamorphic: generate deterministically from prng seed

### DIFF
--- a/internal/metamorphic/parser_test.go
+++ b/internal/metamorphic/parser_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/cockroachdb/pebble/internal/randvar"
 	"github.com/kr/pretty"
 )
 
@@ -29,7 +30,7 @@ func TestParser(t *testing.T) {
 }
 
 func TestParserRandom(t *testing.T) {
-	ops := generate(10000, defaultConfig)
+	ops := generate(randvar.NewRand(), 10000, defaultConfig)
 	src := formatOps(ops)
 
 	parsedOps, err := parse([]byte(src))

--- a/internal/metamorphic/utils.go
+++ b/internal/metamorphic/utils.go
@@ -6,6 +6,7 @@ package metamorphic
 
 import (
 	"fmt"
+	"sort"
 
 	"golang.org/x/exp/rand"
 )
@@ -55,6 +56,10 @@ func (i objID) String() string {
 // element is required.
 type objIDSlice []objID
 
+func (s objIDSlice) Len() int           { return len(s) }
+func (s objIDSlice) Less(i, j int) bool { return s[i] < s[j] }
+func (s objIDSlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
 // Remove removes the specified integer from the set.
 //
 // TODO(peter): If this proves slow, we can replace this implementation with a
@@ -77,6 +82,17 @@ func (s *objIDSlice) rand(rng *rand.Rand) objID {
 
 // objIDSet is an unordered set of object IDs.
 type objIDSet map[objID]struct{}
+
+// sortedKeys returns a sorted slice of the set's keys for deterministc
+// iteration.
+func (s objIDSet) sorted() []objID {
+	keys := make(objIDSlice, 0, len(s))
+	for id := range s {
+		keys = append(keys, id)
+	}
+	sort.Sort(keys)
+	return keys
+}
 
 // firstError returns the first non-nil error of err0 and err1, or nil if both
 // are nil.


### PR DESCRIPTION
Generate tests operations and random options deterministically from a
pseudorandom number generator seed. On failure, print the seed alondside
the test results.

Add a new `--seed` flag for passing a specific seed, allowing
re-executing a full metamorphic test run on the same SHA from just the
seed.

We may want to augment the seed with a small checksum over the
operations and options to ensure that accidental introduction of outside
randomness or use of a seed on a different SHA doesn't confuse us.

Close #785.