### PR TITLE
internal/manifest: add FileIterator struct

### DIFF
--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -561,8 +561,8 @@ func TestCompactionPickerL0(t *testing.T) {
 				if len(pc.outputLevel.files) > 0 {
 					fmt.Fprintf(&result, "L%d: %s\n", pc.outputLevel.level, fileNums(pc.outputLevel.files))
 				}
-				if len(c.grandparents) > 0 {
-					fmt.Fprintf(&result, "grandparents: %s\n", fileNums(c.grandparents))
+				if !c.grandparents.Empty() {
+					fmt.Fprintf(&result, "grandparents: %s\n", fileNums(c.grandparents.Collect()))
 				}
 			} else {
 				return "nil"
@@ -638,7 +638,7 @@ func TestPickedCompactionSetupInputs(t *testing.T) {
 					pc.outputLevel.level = pc.startLevel.level + 1
 				}
 				pc.startLevel.files = pc.version.Overlaps(pc.startLevel.level, pc.cmp,
-					[]byte(d.CmdArgs[0].String()), []byte(d.CmdArgs[1].String()))
+					[]byte(d.CmdArgs[0].String()), []byte(d.CmdArgs[1].String())).Collect()
 
 				pc.setupInputs()
 

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -494,7 +494,7 @@ func TestPickCompaction(t *testing.T) {
 			c := newCompaction(pc, opts, env.bytesCompacted)
 			got0 := fileNums(c.startLevel.files)
 			got1 := fileNums(c.outputLevel.files)
-			got2 := fileNums(c.grandparents)
+			got2 := fileNums(c.grandparents.Collect())
 			got = got0 + " " + got1 + " " + got2
 		}
 		if got != tc.want {
@@ -1148,7 +1148,7 @@ func TestCompactionFindGrandparentLimit(t *testing.T) {
 			case "compact":
 				c := &compaction{
 					cmp:          cmp,
-					grandparents: grandparents,
+					grandparents: manifest.SliceLevelIterator(grandparents),
 				}
 				if len(d.CmdArgs) != 1 {
 					return fmt.Sprintf("%s expects 1 argument", d.Cmd)

--- a/db.go
+++ b/db.go
@@ -929,7 +929,7 @@ func (d *DB) Compact(
 	maxLevelWithFiles := 1
 	cur := d.mu.versions.currentVersion()
 	for level := 0; level < numLevels; level++ {
-		if len(cur.Overlaps(level, d.cmp, start, end)) > 0 {
+		if !cur.Overlaps(level, d.cmp, start, end).Empty() {
 			maxLevelWithFiles = level + 1
 		}
 	}
@@ -1136,19 +1136,15 @@ func (d *DB) EstimateDiskUsage(start, end []byte) (uint64, error) {
 
 	var totalSize uint64
 	for level, files := range readState.current.Levels {
+		iter := manifest.SliceLevelIterator(files)
 		if level > 0 {
 			// We can only use `Overlaps` to restrict `files` at L1+ since at L0 it
 			// expands the range iteratively until it has found a set of files that
 			// do not overlap any other L0 files outside that set.
-			files = readState.current.Overlaps(level, d.opts.Comparer.Compare, start, end)
+			iter = readState.current.Overlaps(level, d.opts.Comparer.Compare, start, end)
 		}
-		for fileIdx, file := range files {
-			if level > 0 && fileIdx > 0 && fileIdx < len(files)-1 {
-				// The files to the left and the right at least partially overlap
-				// with `file`, which means `file` is fully contained within the
-				// range specified by `[start, end]`.
-				totalSize += file.Size
-			} else if d.opts.Comparer.Compare(start, file.Smallest.UserKey) <= 0 &&
+		for file := iter.First(); file != nil; file = iter.Next() {
+			if d.opts.Comparer.Compare(start, file.Smallest.UserKey) <= 0 &&
 				d.opts.Comparer.Compare(file.Largest.UserKey, end) <= 0 {
 				// The range fully contains the file, so skip looking it up in
 				// table cache/looking at its indexes, and add the full file size.

--- a/ingest.go
+++ b/ingest.go
@@ -432,7 +432,7 @@ func ingestTargetLevel(
 		}
 
 		// Check boundary overlap.
-		if len(v.Overlaps(level, cmp, meta.Smallest.UserKey, meta.Largest.UserKey)) != 0 {
+		if !v.Overlaps(level, cmp, meta.Smallest.UserKey, meta.Largest.UserKey).Empty() {
 			continue
 		}
 

--- a/internal/manifest/level_iterator.go
+++ b/internal/manifest/level_iterator.go
@@ -1,0 +1,77 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package manifest
+
+import "sort"
+
+// SliceLevelIterator constructs a LevelIterator over the provided slice.  This
+// function is expected to be a temporary adapter between interfaces.
+// TODO(jackson): Revisit once the conversion of Version.Files to a btree is
+// complete.
+func SliceLevelIterator(files []*FileMetadata) LevelIterator {
+	return LevelIterator{files: files, cur: 0}
+}
+
+// LevelIterator iterates over a set of files' metadata.
+type LevelIterator struct {
+	files []*FileMetadata
+	cur   int
+}
+
+// Collect returns a slice of all the files in the iterator, irrespective of
+// the current iterator position. The returned slice is owned by the iterator.
+// This method is intended to be a temporary adatpter between interfaces, and
+// callers should prefer using the iterator directory when possible.
+//
+// TODO(jackson): Revisit once the conversion of Version.Files to a btree is
+// complete.
+func (i LevelIterator) Collect() []*FileMetadata {
+	return i.files
+}
+
+// SizeSum sums the size of all files in the iterator, irrespective of the
+// current iterator position.
+func (i LevelIterator) SizeSum() uint64 {
+	var sum uint64
+	for _, f := range i.files {
+		sum += f.Size
+	}
+	return sum
+}
+
+// Empty indicates whether there are remaining files in the iterator.
+func (i LevelIterator) Empty() bool {
+	return i.cur >= len(i.files)
+}
+
+// First seeks to the first file in the iterator and returns it.
+func (i *LevelIterator) First() *FileMetadata {
+	i.cur = 0
+	if i.cur >= len(i.files) {
+		return nil
+	}
+	return i.files[i.cur]
+}
+
+// Next advances the iterator to the next file and returns it.
+func (i *LevelIterator) Next() *FileMetadata {
+	i.cur++
+	if i.cur >= len(i.files) {
+		return nil
+	}
+	return i.files[i.cur]
+}
+
+// SeekGE seeks to the first file in the iterator's file set with a largest
+// user key less than or equal to the provided user key.
+func (i *LevelIterator) SeekGE(cmp Compare, userKey []byte) *FileMetadata {
+	i.cur = sort.Search(len(i.files), func(j int) bool {
+		return cmp(userKey, i.files[j].Largest.UserKey) <= 0
+	})
+	if i.cur >= len(i.files) {
+		return nil
+	}
+	return i.files[i.cur]
+}

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -379,12 +379,11 @@ func (v *Version) InitL0Sublevels(
 // searches among the files. If level is zero, Contains scans the entire
 // level.
 func (v *Version) Contains(level int, cmp Compare, m *FileMetadata) bool {
-	files := v.Levels[level]
+	iter := LevelIterator{files: v.Levels[level]}
 	if level > 0 {
-		files = v.Overlaps(level, cmp, m.Smallest.UserKey, m.Largest.UserKey)
+		iter = v.Overlaps(level, cmp, m.Smallest.UserKey, m.Largest.UserKey)
 	}
-
-	for _, f := range files {
+	for f := iter.First(); f != nil; f = iter.Next() {
 		if f == m {
 			return true
 		}
@@ -400,11 +399,12 @@ func (v *Version) Contains(level int, cmp Compare, m *FileMetadata) bool {
 // and the computation is repeated until [start, end] stabilizes.
 // The returned files are a subsequence of the input files, i.e., the ordering
 // is not changed.
-func (v *Version) Overlaps(level int, cmp Compare, start, end []byte) (ret []*FileMetadata) {
+func (v *Version) Overlaps(level int, cmp Compare, start, end []byte) LevelIterator {
 	if level == 0 {
 		// Indices that have been selected as overlapping.
 		selectedIndices := make([]bool, len(v.Levels[level]))
 		numSelected := 0
+		var iter LevelIterator
 		for {
 			restart := false
 			for i, selected := range selectedIndices {
@@ -442,25 +442,25 @@ func (v *Version) Overlaps(level int, cmp Compare, start, end []byte) (ret []*Fi
 			}
 
 			if !restart {
-				ret = make([]*FileMetadata, 0, numSelected)
+				iter.files = make([]*FileMetadata, 0, numSelected)
 				for i, selected := range selectedIndices {
 					if selected {
-						ret = append(ret, v.Levels[level][i])
+						iter.files = append(iter.files, v.Levels[level][i])
 					}
 				}
 				break
 			}
 			// Continue looping to retry the files that were not selected.
 		}
-		return
+		return iter
 	}
 
-	files := v.Levels[level]
-	lower, upper := overlaps(files, cmp, start, end)
-	if lower >= upper {
-		return nil
+	var iter LevelIterator
+	lower, upper := overlaps(v.Levels[level], cmp, start, end)
+	if lower < upper {
+		iter.files = v.Levels[level][lower:upper]
 	}
-	return files[lower:upper]
+	return iter
 }
 
 // CheckOrdering checks that the files are consistent with respect to

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -249,9 +249,9 @@ func TestOverlaps(t *testing.T) {
 	cmp := base.DefaultComparer.Compare
 	for _, tc := range testCases {
 		o := v.Overlaps(tc.level, cmp, []byte(tc.ukey0), []byte(tc.ukey1))
-		s := make([]string, len(o))
-		for i, meta := range o {
-			s[i] = fmt.Sprintf("m%02d", meta.FileNum%100)
+		var s []string
+		for meta := o.First(); meta != nil; meta = o.Next() {
+			s = append(s, fmt.Sprintf("m%02d", meta.FileNum%100))
 		}
 		got := strings.Join(s, " ")
 		if got != tc.want {


### PR DESCRIPTION
Add a FileIterator type to hide the underlying representation of a slice
of a level's files. Switch `(*Version).Overlaps` to return a
`FileIterator`. Some call sites are a little burdensome to convert all
at once, so add a temporary `OverlapsSlice` method that returns the
previous `[]*FileMetadata` return type.

This is in preparation for representing `Version.Files` using a btree.

This might not be the final return type of `(*Version).Overlaps`. I've
experimented with refactors that use a `LevelSlice` type and a
`FileIterator` type that seemed promising but more refined and ergonomic
types can come later.