### PR TITLE
db: add a new option StrictSync

### DIFF
--- a/commit_test.go
+++ b/commit_test.go
@@ -34,6 +34,7 @@ type testCommitEnv struct {
 
 func (e *testCommitEnv) env() commitEnv {
 	return commitEnv{
+		opts:          &Options{},
 		logSeqNum:     &e.logSeqNum,
 		visibleSeqNum: &e.visibleSeqNum,
 		apply:         e.apply,
@@ -187,6 +188,7 @@ func TestCommitPipelineWALClose(t *testing.T) {
 	wal := record.NewLogWriter(sf, 0 /* logNum */)
 	var walDone sync.WaitGroup
 	testEnv := commitEnv{
+		opts:          &Options{},
 		logSeqNum:     new(uint64),
 		visibleSeqNum: new(uint64),
 		apply: func(b *Batch, mem *memTable) error {

--- a/commit_test.go
+++ b/commit_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -324,6 +325,7 @@ func TestCommitPipelineStrictSync(t *testing.T) {
 		close(sf.blocked)
 		// busy loop to wait for the seq num to be published
 		for atomic.LoadUint64(testEnv.visibleSeqNum) != uint64(count+1) {
+			runtime.Gosched()
 		}
 		// check expected Sync() and Write() are all invoked before makeVisible()
 		require.Equal(t, 1, len(sf.syncCalled))

--- a/internal/record/log_writer.go
+++ b/internal/record/log_writer.go
@@ -135,11 +135,12 @@ func (q *syncQueue) pop(head, tail uint32, s syncer, err error) error {
 		// Queue is empty.
 		return nil
 	}
+	// Synchronize the WAL if any one of the involved slots has the sync flag set.
 	for tt := tail; err == nil && s != nil && tt != head; tt++ {
 		if q.slots[tt&uint32(len(q.slots)-1)].sync {
 			err = s.Sync()
+			break
 		}
-		break
 	}
 	for ; tail != head; tail++ {
 		slot := &q.slots[tail&uint32(len(q.slots)-1)]

--- a/internal/record/log_writer_test.go
+++ b/internal/record/log_writer_test.go
@@ -38,7 +38,7 @@ func TestSyncQueue(t *testing.T) {
 				return
 			}
 			head, tail := q.load()
-			q.pop(head, tail, nil)
+			q.pop(head, tail, nil, nil)
 		}
 	}()
 
@@ -54,7 +54,7 @@ func TestSyncQueue(t *testing.T) {
 				// syncQueue is a single-producer, single-consumer queue. We need to
 				// provide mutual exclusion on the producer side.
 				commitMu.Lock()
-				q.push(wg, new(error))
+				q.push(true, wg, new(error))
 				commitMu.Unlock()
 				wg.Wait()
 			}
@@ -94,7 +94,7 @@ func TestFlusherCond(t *testing.T) {
 			}
 
 			head, tail := q.load()
-			q.pop(head, tail, nil)
+			q.pop(head, tail, nil, nil)
 		}
 	}()
 
@@ -114,7 +114,7 @@ func TestFlusherCond(t *testing.T) {
 				// syncQueue is a single-producer, single-consumer queue. We need to
 				// provide mutual exclusion on the producer side.
 				commitMu.Lock()
-				q.push(wg, new(error))
+				q.push(true, wg, new(error))
 				commitMu.Unlock()
 				c.Signal()
 				wg.Wait()
@@ -141,7 +141,7 @@ func TestSyncError(t *testing.T) {
 	var syncErr error
 	var syncWG sync.WaitGroup
 	syncWG.Add(1)
-	_, err = w.SyncRecord([]byte("hello"), &syncWG, &syncErr)
+	_, err = w.SyncRecord([]byte("hello"), true, &syncWG, &syncErr)
 	require.NoError(t, err)
 	syncWG.Wait()
 	if injectedErr != syncErr {
@@ -173,7 +173,7 @@ func TestSyncRecord(t *testing.T) {
 	for i := 0; i < 100000; i++ {
 		var syncWG sync.WaitGroup
 		syncWG.Add(1)
-		offset, err := w.SyncRecord([]byte("hello"), &syncWG, &syncErr)
+		offset, err := w.SyncRecord([]byte("hello"), true, &syncWG, &syncErr)
 		require.NoError(t, err)
 		syncWG.Wait()
 		require.NoError(t, syncErr)
@@ -231,7 +231,7 @@ func TestMinSyncInterval(t *testing.T) {
 	syncRecord := func(n int) *sync.WaitGroup {
 		wg := &sync.WaitGroup{}
 		wg.Add(1)
-		_, err := w.SyncRecord(bytes.Repeat([]byte{'a'}, n), wg, new(error))
+		_, err := w.SyncRecord(bytes.Repeat([]byte{'a'}, n), true, wg, new(error))
 		require.NoError(t, err)
 		return wg
 	}
@@ -300,7 +300,7 @@ func TestMinSyncIntervalClose(t *testing.T) {
 	syncRecord := func(n int) *sync.WaitGroup {
 		wg := &sync.WaitGroup{}
 		wg.Add(1)
-		_, err := w.SyncRecord(bytes.Repeat([]byte{'a'}, n), wg, new(error))
+		_, err := w.SyncRecord(bytes.Repeat([]byte{'a'}, n), true, wg, new(error))
 		require.NoError(t, err)
 		return wg
 	}

--- a/open.go
+++ b/open.go
@@ -101,6 +101,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	d.tableCache.init(d.cacheID, dirname, opts.FS, d.opts, tableCacheSize)
 	d.newIters = d.tableCache.newIters
 	d.commit = newCommitPipeline(commitEnv{
+		opts:          d.opts,
 		logSeqNum:     &d.mu.versions.logSeqNum,
 		visibleSeqNum: &d.mu.versions.visibleSeqNum,
 		apply:         d.commitApply,

--- a/open.go
+++ b/open.go
@@ -101,7 +101,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	d.tableCache.init(d.cacheID, dirname, opts.FS, d.opts, tableCacheSize)
 	d.newIters = d.tableCache.newIters
 	d.commit = newCommitPipeline(commitEnv{
-		opts:          d.opts,
+		strictSync:    d.opts.StrictSync,
 		logSeqNum:     &d.mu.versions.logSeqNum,
 		visibleSeqNum: &d.mu.versions.visibleSeqNum,
 		apply:         d.commitApply,

--- a/options.go
+++ b/options.go
@@ -441,10 +441,11 @@ type Options struct {
 	WALMinSyncInterval func() time.Duration
 
 	// StrictSync indicates that the DB should only make incoming records
-	// visible once they are fully written and synchronized onto the underlying
-	// disk. If not set (the default), incoming records are made visible as soon
-	// as they are applied into the MemTable. This makes writes more performant
-	// at the risk of losing some visible records after a DB restart, e.g. crash.
+	// visible once they are written and synchronized (when WriteOptions.Sync=true)
+	// onto the underlying disk. If not set (the default), incoming records are
+	// made visible as soon as they are applied into the MemTable. This makes
+	// writes more performant at the risk of losing some visible records after a
+	// DB restart, e.g. crash.
 	StrictSync bool
 
 	// private options are only used by internal tests.

--- a/options.go
+++ b/options.go
@@ -440,6 +440,13 @@ type Options struct {
 	// changing options dynamically?
 	WALMinSyncInterval func() time.Duration
 
+	// StrictSync indicates that the DB should only make incoming records
+	// visible once they are fully written and synchronized onto the underlying
+	// disk. If not set (the default), incoming records are made visible as soon
+	// as they are applied into the MemTable. This makes writes more performant
+	// at the risk of losing some visible records after a DB restart, e.g. crash.
+	StrictSync bool
+
 	// private options are only used by internal tests.
 	private struct {
 		// TODO(peter): A private option to enable flush/compaction pacing. Only used


### PR DESCRIPTION
StrictSync indicates that the DB should only make incoming records visible
once they are fully written and synchronized onto the underlying disk. This
is RocksDB's default behavior. If not set (the default), incoming records
are made visible as soon as they are applied into the MemTable. This makes
writes more performant at the risk of losing some visible records after a
DB restart, e.g. crash.