### PR TITLE
sstable: Fadvise sequential when max readahead size is reached

### DIFF
--- a/sstable/testdata/readahead
+++ b/sstable/testdata/readahead
@@ -178,26 +178,48 @@ read
 ----
 readahead:  262144
 numReads:   8
-size:       524288
+size:       262144
 prevSize:   262144
 limit:      466632
 
-# The readahead size should not increase beyond the max (512kb)
+# The readahead size should not increase beyond the max (256kb)
 
 read
 466632, 16
 ----
-readahead:  524288
+readahead:  262144
 numReads:   9
-size:       524288
-prevSize:   524288
-limit:      990920
+size:       262144
+prevSize:   262144
+limit:      728776
+
+# A cache read pushes the limit further ahead without issuing a readahead.
+
+cache-read
+728770, 16
+----
+readahead:  0
+numReads:   9
+size:       262144
+prevSize:   262144
+limit:      728786
 
 read
-1515208,16
+728780, 16
 ----
-readahead:  524288
+readahead:  262144
 numReads:   10
-size:       524288
-prevSize:   524288
-limit:      2039496
+size:       262144
+prevSize:   262144
+limit:      990924
+
+# An out-of-order cache read still resets readahead state.
+
+cache-read
+1200, 16
+----
+readahead:  0
+numReads:   1
+size:       65536
+prevSize:   0
+limit:      1216

--- a/table_cache.go
+++ b/table_cache.go
@@ -556,11 +556,12 @@ type tableCacheValue struct {
 func (v *tableCacheValue) load(meta *fileMetadata, c *tableCacheShard) {
 	// Try opening the fileTypeTable first.
 	var f vfs.File
-	f, v.err = c.fs.Open(base.MakeFilename(c.fs, c.dirname, fileTypeTable, meta.FileNum),
-		vfs.RandomReadsOption)
+	filename := base.MakeFilename(c.fs, c.dirname, fileTypeTable, meta.FileNum)
+	f, v.err = c.fs.Open(filename, vfs.RandomReadsOption)
 	if v.err == nil {
 		cacheOpts := private.SSTableCacheOpts(c.cacheID, meta.FileNum).(sstable.ReaderOption)
-		v.reader, v.err = sstable.NewReader(f, c.opts, cacheOpts, c.filterMetrics)
+		reopenOpt := sstable.FileReopenOpt{FS: c.fs, Filename: filename}
+		v.reader, v.err = sstable.NewReader(f, c.opts, cacheOpts, c.filterMetrics, reopenOpt)
 	}
 	if v.err == nil {
 		if meta.SmallestSeqNum == meta.LargestSeqNum {

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -169,7 +169,7 @@ compact         1   2.3 K          (size == estimated-debt)
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.4 K    5.9%  (score == hit-rate)
- tcache         1   576 B    0.0%  (score == hit-rate)
+ tcache         1   608 B    0.0%  (score == hit-rate)
  titers         0
  filter         -       -    0.0%  (score == utility)
 

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -33,7 +33,7 @@ compact         0     0 B          (size == estimated-debt)
 zmemtbl         1   256 K
    ztbl         0     0 B
  bcache         4   698 B    0.0%  (score == hit-rate)
- tcache         1   576 B    0.0%  (score == hit-rate)
+ tcache         1   608 B    0.0%  (score == hit-rate)
  titers         1
  filter         -       -    0.0%  (score == utility)
 
@@ -75,7 +75,7 @@ compact         1     0 B          (size == estimated-debt)
 zmemtbl         2   512 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   33.3%  (score == hit-rate)
- tcache         2   1.1 K   50.0%  (score == hit-rate)
+ tcache         2   1.2 K   50.0%  (score == hit-rate)
  titers         2
  filter         -       -    0.0%  (score == utility)
 
@@ -102,7 +102,7 @@ compact         1     0 B          (size == estimated-debt)
 zmemtbl         1   256 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   33.3%  (score == hit-rate)
- tcache         2   1.1 K   50.0%  (score == hit-rate)
+ tcache         2   1.2 K   50.0%  (score == hit-rate)
  titers         2
  filter         -       -    0.0%  (score == utility)
 
@@ -130,7 +130,7 @@ compact         1     0 B          (size == estimated-debt)
 zmemtbl         1   256 K
    ztbl         1   771 B
  bcache         4   698 B   33.3%  (score == hit-rate)
- tcache         1   576 B   50.0%  (score == hit-rate)
+ tcache         1   608 B   50.0%  (score == hit-rate)
  titers         1
  filter         -       -    0.0%  (score == utility)
 

--- a/vfs/fadvise_generic.go
+++ b/vfs/fadvise_generic.go
@@ -9,3 +9,7 @@ package vfs
 func fadviseRandom(f uintptr) error {
 	return nil
 }
+
+func fadviseSequential(f uintptr) error {
+	return nil
+}

--- a/vfs/fadvise_linux.go
+++ b/vfs/fadvise_linux.go
@@ -12,3 +12,8 @@ import "golang.org/x/sys/unix"
 func fadviseRandom(f uintptr) error {
 	return unix.Fadvise(int(f), 0, 0, unix.FADV_RANDOM)
 }
+
+// Calls Fadvise with FADV_SEQUENTIAL to enable readahead on a file descriptor.
+func fadviseSequential(f uintptr) error {
+	return unix.Fadvise(int(f), 0, 0, unix.FADV_SEQUENTIAL)
+}

--- a/vfs/prefetch_linux.go
+++ b/vfs/prefetch_linux.go
@@ -6,7 +6,9 @@
 
 package vfs
 
-import "syscall"
+import (
+	"syscall"
+)
 
 // Prefetch signals the OS (on supported platforms) to fetch the next size
 // bytes in file after offset into cache. Any subsequent reads in that range

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -191,13 +191,33 @@ type randomReadsOption struct{}
 
 // RandomReadsOption is an OpenOption that optimizes opened file handle for
 // random reads, by calling  fadvise() with POSIX_FADV_RANDOM on Linux systems
-// to disable readahead. Only works when specified to defaultFS.
+// to disable readahead.
 var RandomReadsOption OpenOption = &randomReadsOption{}
 
 // Apply implements the OpenOption interface.
 func (randomReadsOption) Apply(f File) {
-	if osFile, ok := f.(*os.File); ok {
-		_ = fadviseRandom(osFile.Fd())
+	type fd interface {
+		Fd() uintptr
+	}
+	if fdFile, ok := f.(fd); ok {
+		_ = fadviseRandom(fdFile.Fd())
+	}
+}
+
+type sequentialReadsOption struct{}
+
+// SequentialReadsOption is an OpenOption that optimizes opened file handle for
+// sequential reads, by calling fadvise() with POSIX_FADV_SEQUENTIAL on Linux
+// systems to enable readahead.
+var SequentialReadsOption OpenOption = &sequentialReadsOption{}
+
+// Apply implements the OpenOption interface.
+func (sequentialReadsOption) Apply(f File) {
+	type fd interface {
+		Fd() uintptr
+	}
+	if fdFile, ok := f.(fd); ok {
+		_ = fadviseSequential(fdFile.Fd())
 	}
 }
 


### PR DESCRIPTION
This updates the dynamic readhaead logic in singleLevelIterator
to call fadvise(FADV_SEQUENTIAL) when deviating from a sequential
access pattern seems very unlikely (i.e. when the max readahead
size has been reached).

In practice, this sort of dynamic fadvising() seems
to dramatically speed up TPCC-4k backups from taking 1h on avg
to around 20-25mins. It significantly reduces the number of
read IOPS, and makes the workload more CPU/write IO heavy instead
of being bottlenecked on reads.