### PR TITLE
internal/manifest: add LevelMetadata type alias

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -584,11 +584,15 @@ func (c *compaction) newInputIter(newIters tableNewIters) (_ internalIterator, r
 	// Check that the LSM ordering invariants are ok in order to prevent
 	// generating corrupted sstables due to a violation of those invariants.
 	if c.startLevel.level >= 0 {
-		if err := manifest.CheckOrdering(c.cmp, c.formatKey, manifest.Level(c.startLevel.level), c.startLevel.files); err != nil {
+		err := manifest.CheckOrdering(c.cmp, c.formatKey, manifest.Level(c.startLevel.level),
+			manifest.SliceLevelIterator(c.startLevel.files))
+		if err != nil {
 			c.logger.Fatalf("%s", err)
 		}
 	}
-	if err := manifest.CheckOrdering(c.cmp, c.formatKey, manifest.Level(c.outputLevel.level), c.outputLevel.files); err != nil {
+	err := manifest.CheckOrdering(c.cmp, c.formatKey, manifest.Level(c.outputLevel.level),
+		manifest.SliceLevelIterator(c.outputLevel.files))
+	if err != nil {
 		c.logger.Fatalf("%s", err)
 	}
 

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -95,7 +95,7 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "no compaction",
 			version: version{
-				Levels: [numLevels][]*fileMetadata{
+				Levels: [numLevels]manifest.LevelMetadata{
 					0: []*fileMetadata{
 						{
 							FileNum:  100,
@@ -112,7 +112,7 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "1 L0 file",
 			version: version{
-				Levels: [numLevels][]*fileMetadata{
+				Levels: [numLevels]manifest.LevelMetadata{
 					0: []*fileMetadata{
 						{
 							FileNum:  100,
@@ -134,7 +134,7 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "2 L0 files (0 overlaps)",
 			version: version{
-				Levels: [numLevels][]*fileMetadata{
+				Levels: [numLevels]manifest.LevelMetadata{
 					0: []*fileMetadata{
 						{
 							FileNum:  100,
@@ -162,7 +162,7 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "2 L0 files, with ikey overlap",
 			version: version{
-				Levels: [numLevels][]*fileMetadata{
+				Levels: [numLevels]manifest.LevelMetadata{
 					0: []*fileMetadata{
 						{
 							FileNum:  100,
@@ -190,7 +190,7 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "2 L0 files, with ukey overlap",
 			version: version{
-				Levels: [numLevels][]*fileMetadata{
+				Levels: [numLevels]manifest.LevelMetadata{
 					0: []*fileMetadata{
 						{
 							FileNum:  100,
@@ -218,7 +218,7 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "1 L0 file, 2 L1 files (0 overlaps)",
 			version: version{
-				Levels: [numLevels][]*fileMetadata{
+				Levels: [numLevels]manifest.LevelMetadata{
 					0: []*fileMetadata{
 						{
 							FileNum:  100,
@@ -254,7 +254,7 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "1 L0 file, 2 L1 files (1 overlap), 4 L2 files (3 overlaps)",
 			version: version{
-				Levels: [numLevels][]*fileMetadata{
+				Levels: [numLevels]manifest.LevelMetadata{
 					0: []*fileMetadata{
 						{
 							FileNum:  100,
@@ -316,7 +316,7 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "4 L1 files, 2 L2 files, can grow",
 			version: version{
-				Levels: [numLevels][]*fileMetadata{
+				Levels: [numLevels]manifest.LevelMetadata{
 					1: []*fileMetadata{
 						{
 							FileNum:  200,
@@ -370,7 +370,7 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "4 L1 files, 2 L2 files, can't grow (range)",
 			version: version{
-				Levels: [numLevels][]*fileMetadata{
+				Levels: [numLevels]manifest.LevelMetadata{
 					1: []*fileMetadata{
 						{
 							FileNum:  200,
@@ -424,7 +424,7 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "4 L1 files, 2 L2 files, can't grow (size)",
 			version: version{
-				Levels: [numLevels][]*fileMetadata{
+				Levels: [numLevels]manifest.LevelMetadata{
 					1: []*fileMetadata{
 						{
 							FileNum:  200,
@@ -527,7 +527,7 @@ func TestElideTombstone(t *testing.T) {
 			desc:  "non-empty",
 			level: 1,
 			version: version{
-				Levels: [numLevels][]*fileMetadata{
+				Levels: [numLevels]manifest.LevelMetadata{
 					1: []*fileMetadata{
 						{
 							Smallest: base.ParseInternalKey("c.SET.801"),
@@ -597,7 +597,7 @@ func TestElideTombstone(t *testing.T) {
 			desc:  "repeated ukey",
 			level: 1,
 			version: version{
-				Levels: [numLevels][]*fileMetadata{
+				Levels: [numLevels]manifest.LevelMetadata{
 					6: []*fileMetadata{
 						{
 							Smallest: base.ParseInternalKey("i.SET.401"),
@@ -674,7 +674,7 @@ func TestElideRangeTombstone(t *testing.T) {
 			desc:  "non-empty",
 			level: 1,
 			version: version{
-				Levels: [numLevels][]*fileMetadata{
+				Levels: [numLevels]manifest.LevelMetadata{
 					1: []*fileMetadata{
 						{
 							Smallest: base.ParseInternalKey("c.SET.801"),
@@ -743,7 +743,7 @@ func TestElideRangeTombstone(t *testing.T) {
 			desc:  "flushing",
 			level: -1,
 			version: version{
-				Levels: [numLevels][]*fileMetadata{
+				Levels: [numLevels]manifest.LevelMetadata{
 					0: []*fileMetadata{
 						{
 							Smallest: base.ParseInternalKey("h.SET.901"),
@@ -1234,7 +1234,7 @@ func TestCompactionFindL0Limit(t *testing.T) {
 		func(d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "define":
-				fileMetas := [manifest.NumLevels][]*manifest.FileMetadata{}
+				fileMetas := [manifest.NumLevels]manifest.LevelMetadata{}
 				baseLevel := manifest.NumLevels - 1
 				level := 0
 				var err error
@@ -1547,7 +1547,7 @@ func TestCompactionInuseKeyRanges(t *testing.T) {
 				inputs:    []compactionLevel{{}, {}},
 			}
 			c.startLevel, c.outputLevel = &c.inputs[0], &c.inputs[1]
-			var files *[]*fileMetadata
+			var currentLevel int
 			fileNum := FileNum(1)
 
 			for _, data := range strings.Split(td.Input, "\n") {
@@ -1557,13 +1557,13 @@ func TestCompactionInuseKeyRanges(t *testing.T) {
 					if err != nil {
 						return err.Error()
 					}
-					files = &c.version.Levels[level]
+					currentLevel = level
 
 				default:
 					meta := parseMeta(data)
 					meta.FileNum = fileNum
 					fileNum++
-					*files = append(*files, meta)
+					c.version.Levels[currentLevel] = append(c.version.Levels[currentLevel], meta)
 				}
 			}
 			return c.version.DebugString(c.formatKey)

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -431,8 +431,9 @@ func TestL0Sublevels(t *testing.T) {
 			return strconv.Itoa(sublevels.MaxDepthAfterOngoingCompactions())
 		case "l0-check-ordering":
 			for sublevel, files := range sublevels.Levels {
-				if err := CheckOrdering(base.DefaultComparer.Compare,
-					base.DefaultFormatter, L0Sublevel(sublevel), files); err != nil {
+				err := CheckOrdering(base.DefaultComparer.Compare, base.DefaultFormatter,
+					L0Sublevel(sublevel), SliceLevelIterator(files))
+				if err != nil {
 					return err.Error()
 				}
 			}

--- a/internal/manifest/level_iterator.go
+++ b/internal/manifest/level_iterator.go
@@ -6,6 +6,16 @@ package manifest
 
 import "sort"
 
+// LevelMetadata contains metadata for all of the files within
+// a level of the LSM.
+// TODO(jackson): Convert to an opaque struct.
+type LevelMetadata []*FileMetadata
+
+// Iter constructs a LevelIterator over the entire level.
+func (lm LevelMetadata) Iter() LevelIterator {
+	return LevelIterator{files: lm}
+}
+
 // SliceLevelIterator constructs a LevelIterator over the provided slice.  This
 // function is expected to be a temporary adapter between interfaces.
 // TODO(jackson): Revisit once the conversion of Version.Files to a btree is

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -235,7 +235,7 @@ type Version struct {
 	// in Files[0] are in L0Sublevels.Levels.
 	L0Sublevels *L0Sublevels
 
-	Levels [NumLevels][]*FileMetadata
+	Levels [NumLevels]LevelMetadata
 
 	// The callback to invoke when the last reference to a version is
 	// removed. Will be called with list.mu held.
@@ -255,25 +255,22 @@ func (v *Version) String() string {
 // Pretty returns a string representation of the version.
 func (v *Version) Pretty(format base.FormatKey) string {
 	var buf bytes.Buffer
-	for level := 0; level < NumLevels; level++ {
-		if len(v.Levels[level]) == 0 {
-			continue
-		}
-
-		if level == 0 {
-			for sublevel := len(v.L0Sublevels.Levels) - 1; sublevel >= 0; sublevel-- {
-				fmt.Fprintf(&buf, "0.%d:\n", sublevel)
-				for _, f := range v.L0Sublevels.Levels[sublevel] {
-					fmt.Fprintf(&buf, "  %06d:[%s-%s]\n", f.FileNum,
-						format(f.Smallest.UserKey), format(f.Largest.UserKey))
-				}
+	if v.L0Sublevels != nil {
+		for sublevel := len(v.L0Sublevels.Levels) - 1; sublevel >= 0; sublevel-- {
+			fmt.Fprintf(&buf, "0.%d:\n", sublevel)
+			for _, f := range v.L0Sublevels.Levels[sublevel] {
+				fmt.Fprintf(&buf, "  %06d:[%s-%s]\n", f.FileNum,
+					format(f.Smallest.UserKey), format(f.Largest.UserKey))
 			}
+		}
+	}
+	for level := 1; level < NumLevels; level++ {
+		iter := v.Levels[level].Iter()
+		if iter.Empty() {
 			continue
 		}
-
 		fmt.Fprintf(&buf, "%d:\n", level)
-		for j := range v.Levels[level] {
-			f := v.Levels[level][j]
+		for f := iter.First(); f != nil; f = iter.Next() {
 			fmt.Fprintf(&buf, "  %s:[%s-%s]\n", f.FileNum,
 				format(f.Smallest.UserKey), format(f.Largest.UserKey))
 		}
@@ -285,25 +282,23 @@ func (v *Version) Pretty(format base.FormatKey) string {
 // sequence number and kind information for the sstable boundaries.
 func (v *Version) DebugString(format base.FormatKey) string {
 	var buf bytes.Buffer
-	for level := 0; level < NumLevels; level++ {
-		if len(v.Levels[level]) == 0 {
-			continue
-		}
 
-		if level == 0 {
-			for sublevel := len(v.L0Sublevels.Levels) - 1; sublevel >= 0; sublevel-- {
-				fmt.Fprintf(&buf, "0.%d:\n", sublevel)
-				for _, f := range v.L0Sublevels.Levels[sublevel] {
-					fmt.Fprintf(&buf, "  %06d:[%s-%s]\n", f.FileNum,
-						f.Smallest.Pretty(format), f.Largest.Pretty(format))
-				}
+	if v.L0Sublevels != nil {
+		for sublevel := len(v.L0Sublevels.Levels) - 1; sublevel >= 0; sublevel-- {
+			fmt.Fprintf(&buf, "0.%d:\n", sublevel)
+			for _, f := range v.L0Sublevels.Levels[sublevel] {
+				fmt.Fprintf(&buf, "  %06d:[%s-%s]\n", f.FileNum,
+					f.Smallest.Pretty(format), f.Largest.Pretty(format))
 			}
+		}
+	}
+	for level := 1; level < NumLevels; level++ {
+		iter := v.Levels[level].Iter()
+		if iter.Empty() {
 			continue
 		}
-
 		fmt.Fprintf(&buf, "%d:\n", level)
-		for j := range v.Levels[level] {
-			f := v.Levels[level][j]
+		for f := iter.First(); f != nil; f = iter.Next() {
 			fmt.Fprintf(&buf, "  %s:[%s-%s]\n", f.FileNum,
 				f.Smallest.Pretty(format), f.Largest.Pretty(format))
 		}
@@ -348,10 +343,12 @@ func (v *Version) UnrefLocked() {
 }
 
 func (v *Version) unrefFiles() []base.FileNum {
+	// TODO(jackson): Move responsibility of ref-ing of individual files into
+	// the LevelMetadata type.
 	var obsolete []base.FileNum
 	for _, files := range v.Levels {
-		for i := range files {
-			f := files[i]
+		iter := files.Iter()
+		for f := iter.First(); f != nil; f = iter.Next() {
 			if atomic.AddInt32(&f.refs, -1) == 0 {
 				obsolete = append(obsolete, f.FileNum)
 			}
@@ -379,7 +376,7 @@ func (v *Version) InitL0Sublevels(
 // searches among the files. If level is zero, Contains scans the entire
 // level.
 func (v *Version) Contains(level int, cmp Compare, m *FileMetadata) bool {
-	iter := LevelIterator{files: v.Levels[level]}
+	iter := v.Levels[level].Iter()
 	if level > 0 {
 		iter = v.Overlaps(level, cmp, m.Smallest.UserKey, m.Largest.UserKey)
 	}
@@ -468,13 +465,14 @@ func (v *Version) Overlaps(level int, cmp Compare, start, end []byte) LevelItera
 // overlapping internal key ranges (for level non-0 files).
 func (v *Version) CheckOrdering(cmp Compare, format base.FormatKey) error {
 	for sublevel := len(v.L0Sublevels.Levels) - 1; sublevel >= 0; sublevel-- {
-		if err := CheckOrdering(cmp, format, L0Sublevel(sublevel), v.L0Sublevels.Levels[sublevel]); err != nil {
+		iter := SliceLevelIterator(v.L0Sublevels.Levels[sublevel])
+		if err := CheckOrdering(cmp, format, L0Sublevel(sublevel), iter); err != nil {
 			return errors.Errorf("%s\n%s", err, v.DebugString(format))
 		}
 	}
 
-	for level, files := range v.Levels {
-		if err := CheckOrdering(cmp, format, Level(level), files); err != nil {
+	for level, lm := range v.Levels {
+		if err := CheckOrdering(cmp, format, Level(level), lm.Iter()); err != nil {
 			return errors.Errorf("%s\n%s", err, v.DebugString(format))
 		}
 	}
@@ -488,7 +486,8 @@ func (v *Version) CheckConsistency(dirname string, fs vfs.FS) error {
 	var args []interface{}
 
 	for level, files := range v.Levels {
-		for _, f := range files {
+		iter := files.Iter()
+		for f := iter.First(); f != nil; f = iter.Next() {
 			path := base.MakeFilename(fs, dirname, base.FileTypeTable, f.FileNum)
 			info, err := fs.Stat(path)
 			if err != nil {
@@ -573,7 +572,7 @@ func (l *VersionList) Remove(v *Version) {
 // CheckOrdering checks that the files are consistent with respect to
 // seqnums (for level 0 files -- see detailed comment below) and increasing and non-
 // overlapping internal key ranges (for non-level 0 files).
-func CheckOrdering(cmp Compare, format base.FormatKey, level Level, files []*FileMetadata) error {
+func CheckOrdering(cmp Compare, format base.FormatKey, level Level, files LevelIterator) error {
 	// The invariants to check for L0 sublevels are the same as the ones to
 	// check for all other levels. However, if L0 is not organized into
 	// sublevels, or if all L0 files are being passed in, we do the legacy L0
@@ -623,31 +622,30 @@ func CheckOrdering(cmp Compare, format base.FormatKey, level Level, files []*Fil
 		// with future versions of pebble, this method relaxes most L0 invariant
 		// checks.
 
-		for i := range files {
-			f := files[i]
-			if i > 0 {
-				// Validate that the sorting is sane.
-				prev := files[i-1]
-				if prev.LargestSeqNum == 0 && f.LargestSeqNum == prev.LargestSeqNum {
-					// Multiple files satisfying case 2 mentioned above.
-				} else if !prev.lessSeqNum(f) {
-					return errors.Errorf("L0 files %s and %s are not properly ordered: <#%d-#%d> vs <#%d-#%d>",
-						errors.Safe(prev.FileNum), errors.Safe(f.FileNum),
-						errors.Safe(prev.SmallestSeqNum), errors.Safe(prev.LargestSeqNum),
-						errors.Safe(f.SmallestSeqNum), errors.Safe(f.LargestSeqNum))
-				}
+		var prev *FileMetadata
+		for f := files.First(); f != nil; f, prev = files.Next(), f {
+			if prev == nil {
+				continue
+			}
+			// Validate that the sorting is sane.
+			if prev.LargestSeqNum == 0 && f.LargestSeqNum == prev.LargestSeqNum {
+				// Multiple files satisfying case 2 mentioned above.
+			} else if !prev.lessSeqNum(f) {
+				return errors.Errorf("L0 files %s and %s are not properly ordered: <#%d-#%d> vs <#%d-#%d>",
+					errors.Safe(prev.FileNum), errors.Safe(f.FileNum),
+					errors.Safe(prev.SmallestSeqNum), errors.Safe(prev.LargestSeqNum),
+					errors.Safe(f.SmallestSeqNum), errors.Safe(f.LargestSeqNum))
 			}
 		}
 	} else {
-		for i := range files {
-			f := files[i]
+		var prev *FileMetadata
+		for f := files.First(); f != nil; f, prev = files.Next(), f {
 			if base.InternalCompare(cmp, f.Smallest, f.Largest) > 0 {
 				return errors.Errorf("%s file %s has inconsistent bounds: %s vs %s",
 					errors.Safe(level), errors.Safe(f.FileNum),
 					f.Smallest.Pretty(format), f.Largest.Pretty(format))
 			}
-			if i > 0 {
-				prev := files[i-1]
+			if prev != nil {
 				if !prev.lessSmallestKey(f, cmp) {
 					return errors.Errorf("%s files %s and %s are not properly ordered: [%s-%s] vs [%s-%s]",
 						errors.Safe(level), errors.Safe(prev.FileNum), errors.Safe(f.FileNum),

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -560,7 +560,7 @@ func (b *BulkVersionEdit) Apply(
 			if err := v.InitL0Sublevels(cmp, formatKey, flushSplitBytes); err != nil {
 				return nil, nil, errors.Wrap(err, "pebble: internal error")
 			}
-			if err := CheckOrdering(cmp, formatKey, Level(0), v.Levels[level]); err != nil {
+			if err := CheckOrdering(cmp, formatKey, Level(0), v.Levels[level].Iter()); err != nil {
 				return nil, nil, errors.Wrap(err, "pebble: internal error")
 			}
 			continue

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -169,7 +169,7 @@ func TestOverlaps(t *testing.T) {
 	}
 
 	v := Version{
-		Levels: [NumLevels][]*FileMetadata{
+		Levels: [NumLevels]LevelMetadata{
 			0: {m00, m01, m02, m03, m04, m05, m06, m07},
 			1: {m10, m11, m12, m13, m14},
 		},
@@ -342,7 +342,7 @@ func TestContains(t *testing.T) {
 	}
 
 	v := Version{
-		Levels: [NumLevels][]*FileMetadata{
+		Levels: [NumLevels]LevelMetadata{
 			0: {m00, m01, m02, m03, m04, m05, m06, m07},
 			1: {m10, m11, m12, m13, m14},
 		},
@@ -436,7 +436,7 @@ func TestCheckOrdering(t *testing.T) {
 				// avoid repeating it, and make it the inverse of
 				// Version.DebugString().
 				v := Version{}
-				var files *[]*FileMetadata
+				var files *LevelMetadata
 				fileNum := base.FileNum(1)
 
 				for _, data := range strings.Split(d.Input, "\n") {
@@ -505,7 +505,7 @@ func TestCheckConsistency(t *testing.T) {
 			switch d.Cmd {
 			case "check-consistency":
 				v := Version{}
-				var files *[]*FileMetadata
+				var files *LevelMetadata
 
 				for _, data := range strings.Split(d.Input, "\n") {
 					switch data {

--- a/level_checker.go
+++ b/level_checker.go
@@ -368,10 +368,10 @@ func checkRangeTombstones(c *checkConfig) error {
 	}
 
 	current := c.readState.current
-	addTombstonesFromLevel := func(files *[]*fileMetadata, lsmLevel int) error {
-		for j := 0; j < len(*files); j++ {
-			lower, upper := getAtomicUnitBounds(c.cmp, *files, j)
-			f := (*files)[j]
+	addTombstonesFromLevel := func(files []*fileMetadata, lsmLevel int) error {
+		for j := 0; j < len(files); j++ {
+			lower, upper := getAtomicUnitBounds(c.cmp, files, j)
+			f := files[j]
 			iterToClose, iter, err := c.newIters(f, nil, nil)
 			if err != nil {
 				return err
@@ -405,7 +405,7 @@ func checkRangeTombstones(c *checkConfig) error {
 		if len(current.L0Sublevels.Levels[i]) == 0 {
 			continue
 		}
-		if err := addTombstonesFromLevel(&current.L0Sublevels.Levels[i], 0); err != nil {
+		if err := addTombstonesFromLevel(current.L0Sublevels.Levels[i], 0); err != nil {
 			return err
 		}
 		level++
@@ -414,7 +414,7 @@ func checkRangeTombstones(c *checkConfig) error {
 		if len(current.Levels[i]) == 0 {
 			continue
 		}
-		files := &current.Levels[i]
+		files := current.Levels[i]
 		if err := addTombstonesFromLevel(files, i); err != nil {
 			return err
 		}


### PR DESCRIPTION
Update `Version.Levels` to be an array of `LevelMetadata` types, which
for now is just an alias of `[]*FileMetadata`. This allows the
incremental introduction of methods to the `LevelMetadata` struct before
completely obscuring its internals.

Also, update `CheckOrdering`, `(*Version).Pretty`,
`(*Version).DebugString` and `(*Version).CheckConsistency` to use the
`LevelIterator` type to iterate over level metadata.