### PR TITLE
db: use manifest.LevelIterator in additional places

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -119,9 +119,9 @@ func (d *DB) Checkpoint(destDir string) (err error) {
 
 	// Link or copy the sstables.
 	for l := range current.Levels {
-		level := current.Levels[l]
-		for i := range level {
-			srcPath := base.MakeFilename(fs, d.dirname, fileTypeTable, level[i].FileNum)
+		iter := current.Levels[l].Iter()
+		for f := iter.First(); f != nil; f = iter.Next() {
+			srcPath := base.MakeFilename(fs, d.dirname, fileTypeTable, f.FileNum)
 			destPath := fs.PathJoin(destDir, fs.PathBase(srcPath))
 			if err := vfs.LinkOrCopy(fs, srcPath, destPath); err != nil {
 				return err

--- a/data_test.go
+++ b/data_test.go
@@ -507,8 +507,9 @@ func runTableStatsCmd(td *datadriven.TestData, d *DB) string {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	v := d.mu.versions.currentVersion()
-	for _, files := range v.Levels {
-		for _, f := range files {
+	for _, levelMetadata := range v.Levels {
+		iter := levelMetadata.Iter()
+		for f := iter.First(); f != nil; f = iter.Next() {
 			if f.FileNum != fileNum {
 				continue
 			}

--- a/db.go
+++ b/db.go
@@ -734,7 +734,7 @@ func (d *DB) newIterInternal(
 		}
 	}
 	for level := 1; level < len(current.Levels); level++ {
-		if len(current.Levels[level]) == 0 {
+		if current.Levels[level].Iter().Empty() {
 			continue
 		}
 		mlevels = append(mlevels, mergingIterLevel{})
@@ -1139,7 +1139,7 @@ func (d *DB) EstimateDiskUsage(start, end []byte) (uint64, error) {
 
 	var totalSize uint64
 	for level, files := range readState.current.Levels {
-		iter := manifest.SliceLevelIterator(files)
+		iter := files.Iter()
 		if level > 0 {
 			// We can only use `Overlaps` to restrict `files` at L1+ since at L0 it
 			// expands the range iteratively until it has found a set of files that

--- a/get_iter.go
+++ b/get_iter.go
@@ -155,7 +155,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 		if g.level >= numLevels {
 			return nil, nil
 		}
-		if len(g.version.Levels[g.level]) == 0 {
+		if g.version.Levels[g.level].Iter().Empty() {
 			g.level++
 			continue
 		}

--- a/table_stats.go
+++ b/table_stats.go
@@ -203,8 +203,9 @@ func (d *DB) loadNewFileStats(rs *readState, pending []manifest.NewFileEntry) ([
 func (d *DB) scanReadStateTableStats(rs *readState, fill []collectedStats) ([]collectedStats, []deleteCompactionHint, bool) {
 	moreRemain := false
 	var hints []deleteCompactionHint
-	for l, ff := range rs.current.Levels {
-		for _, f := range ff {
+	for l, levelMetadata := range rs.current.Levels {
+		iter := levelMetadata.Iter()
+		for f := iter.First(); f != nil; f = iter.Next() {
 			// NB: We're not holding d.mu which protects f.Stats, but only the
 			// active stats collection job updates f.Stats for active files,
 			// and we ensure only one goroutine runs it at a time through

--- a/tool/db.go
+++ b/tool/db.go
@@ -389,8 +389,9 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 		var total props
 		var all []props
 		for _, l := range v.Levels {
+			iter := l.Iter()
 			var level props
-			for _, t := range l {
+			for t := iter.First(); t != nil; t = iter.Next() {
 				err := d.addProps(dirname, t, &level)
 				if err != nil {
 					return err

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -79,7 +79,8 @@ Check the contents of the MANIFEST files.
 
 func (m *manifestT) printLevels(v *manifest.Version) {
 	for level := range v.Levels {
-		if level == 0 && v.L0Sublevels != nil && len(v.Levels[level]) > 0 {
+		iter := v.Levels[level].Iter()
+		if level == 0 && v.L0Sublevels != nil && !iter.Empty() {
 			for sublevel := len(v.L0Sublevels.Levels) - 1; sublevel >= 0; sublevel-- {
 				fmt.Fprintf(stdout, "--- L0.%d ---\n", sublevel)
 				for _, f := range v.L0Sublevels.Levels[sublevel] {
@@ -92,8 +93,7 @@ func (m *manifestT) printLevels(v *manifest.Version) {
 			continue
 		}
 		fmt.Fprintf(stdout, "--- L%d ---\n", level)
-		for j := range v.Levels[level] {
-			f := v.Levels[level][j]
+		for f := iter.First(); f != nil; f = iter.Next() {
 			fmt.Fprintf(stdout, "  %s:%d", f.FileNum, f.Size)
 			formatSeqNumRange(stdout, f.SmallestSeqNum, f.LargestSeqNum)
 			formatKeyRange(stdout, m.fmtKey, &f.Smallest, &f.Largest)


### PR DESCRIPTION
Convert a handful of various usages of `(*Version).Levels` to use an
iterator rather than ranging over the slice of file metadata.