### PR TITLE
release-20.1: sstable: Fadvise sequential when max readahead size is reached

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -35,8 +35,8 @@ const (
 	minFileReadsForReadahead = 2
 	// TODO(bilal): Have the initial size value be a factor of the block size,
 	// as opposed to a hardcoded value.
-	initialReadaheadSize     = 64 << 10 /* 64KB */
-	maxReadaheadSize         = 512 << 10 /* 512KB */
+	initialReadaheadSize = 64 << 10  /* 64KB */
+	maxReadaheadSize     = 256 << 10 /* 256KB */
 )
 
 // decodeBlockHandle returns the block handle encoded at the start of src, as
@@ -490,6 +490,10 @@ func (i *singleLevelIterator) Close() error {
 	}
 	err = firstError(err, i.data.Close())
 	err = firstError(err, i.index.Close())
+	if i.dataRS.sequentialFile != nil {
+		err = firstError(err, i.dataRS.sequentialFile.Close())
+		i.dataRS.sequentialFile = nil
+	}
 	err = firstError(err, i.err)
 	*i = i.resetForReuse()
 	singleLevelIterPool.Put(i)
@@ -833,6 +837,10 @@ func (i *twoLevelIterator) Close() error {
 	err = firstError(err, i.data.Close())
 	err = firstError(err, i.index.Close())
 	err = firstError(err, i.topLevelIndex.Close())
+	if i.dataRS.sequentialFile != nil {
+		err = firstError(err, i.dataRS.sequentialFile.Close())
+		i.dataRS.sequentialFile = nil
+	}
 	err = firstError(err, i.err)
 	*i = twoLevelIterator{
 		singleLevelIterator: i.singleLevelIterator.resetForReuse(),
@@ -966,23 +974,66 @@ type readaheadState struct {
 	// operation. Reads after this limit can benefit from a new call to
 	// Prefetch.
 	limit int64
+	// sequentialFile holds a file descriptor to the same underlying File,
+	// except with fadvise(FADV_SEQUENTIAL) called on it to take advantage of
+	// OS-level readahead. Initialized when the iterator has been consistently
+	// reading blocks in a sequential access pattern. Once this is non-nil,
+	// the other variables in readaheadState don't matter much as we defer
+	// to OS-level readahead.
+	sequentialFile vfs.File
+}
+
+func (rs *readaheadState) recordCacheHit(offset, blockLength int64) {
+	currentReadEnd := offset + blockLength
+	if rs.sequentialFile != nil {
+		// Using OS-level readahead instead, so do nothing.
+		return
+	}
+	if rs.numReads >= minFileReadsForReadahead {
+		if currentReadEnd >= rs.limit && offset <= rs.limit+maxReadaheadSize {
+			// This is a read that would have resulted in a readahead, had it
+			// not been a cache hit.
+			rs.limit = currentReadEnd
+			return
+		}
+		if currentReadEnd < rs.limit-rs.prevSize || offset > rs.limit+maxReadaheadSize {
+			// We read too far away from rs.limit to benefit from readahead in
+			// any scenario. Reset all variables.
+			rs.numReads = 1
+			rs.limit = currentReadEnd
+			rs.size = initialReadaheadSize
+			rs.prevSize = 0
+			return
+		}
+		// Reads in the range [rs.limit - rs.prevSize, rs.limit] end up
+		// here. This is a read that is potentially benefitting from a past
+		// readahead.
+		return
+	}
+	if currentReadEnd >= rs.limit && offset <= rs.limit+maxReadaheadSize {
+		// Blocks are being read sequentially and would benefit from readahead
+		// down the line.
+		rs.numReads++
+		return
+	}
+	// We read too far ahead of the last read, or before it. This indicates
+	// a random read, where readahead is not desirable. Reset all variables.
+	rs.numReads = 1
+	rs.limit = currentReadEnd
+	rs.size = initialReadaheadSize
+	rs.prevSize = 0
 }
 
 // maybeReadahead updates state and determines whether to issue a readahead /
 // prefetch call for a block read at offset for blockLength bytes.
 // Returns a size value (greater than 0) that should be prefetched if readahead
 // would be beneficial.
-//
-// TODO(bilal): This method is only called when there's a cache miss. Reads
-// from the cache are completely invisible to the logic here and the state
-// variables in readaheadState. This is a big reason why the
-// readahead window in this method needs to be optimistic (that reading ahead
-// will generally help) by always extending the window to
-// rs.limit + maxReadaheadSize, to adjust for blocks that appear to be skipped
-// but were actually read from the cache. Update this method or add another
-// method to properly account for cache hits.
 func (rs *readaheadState) maybeReadahead(offset, blockLength int64) int64 {
 	currentReadEnd := offset + blockLength
+	if rs.sequentialFile != nil {
+		// Using OS-level readahead instead, so do nothing.
+		return 0
+	}
 	if rs.numReads >= minFileReadsForReadahead {
 		// The minimum threshold of sequential reads to justify reading ahead
 		// has been reached.
@@ -1167,6 +1218,20 @@ func (c *cacheOpts) writerApply(w *Writer) {
 	}
 }
 
+// FileReopenOpt is specified if this reader is allowed to reopen additional
+// file descriptors for this file. Used to take advantage of OS-level readahead.
+type FileReopenOpt struct{
+	FS       vfs.FS
+	Filename string
+}
+
+func (f FileReopenOpt) readerApply(r *Reader) {
+	if r.fs == nil {
+		r.fs = f.FS
+		r.filename = f.Filename
+	}
+}
+
 // rawTombstonesOpt is a Reader open option for specifying that range
 // tombstones returned by Reader.NewRangeDelIter() should not be
 // fragmented. Used by debug tools to get a raw view of the tombstones
@@ -1189,6 +1254,8 @@ func init() {
 // Reader is a table reader.
 type Reader struct {
 	file              vfs.File
+	fs                vfs.FS
+	filename          string
 	cacheID           uint64
 	fileNum           base.FileNum
 	rawTombstones     bool
@@ -1386,18 +1453,42 @@ func (r *Reader) readWeakCachedBlock(
 // readBlock reads and decompresses a block from disk into memory.
 func (r *Reader) readBlock(bh BlockHandle, transform blockTransform, raState *readaheadState) (cache.Handle, error) {
 	if h := r.opts.Cache.Get(r.cacheID, r.fileNum, bh.Offset); h.Get() != nil {
+		if raState != nil {
+			raState.recordCacheHit(int64(bh.Offset), int64(bh.Length+blockTrailerLen))
+		}
 		return h, nil
 	}
+	file := r.file
 
 	if raState != nil {
-		if readaheadSize := raState.maybeReadahead(int64(bh.Offset), int64(bh.Length + blockTrailerLen)); readaheadSize > 0 {
-			_ = vfs.Prefetch(r.file, bh.Offset, uint64(readaheadSize))
+		if raState.sequentialFile != nil {
+			file = raState.sequentialFile
+		} else if readaheadSize := raState.maybeReadahead(int64(bh.Offset), int64(bh.Length+blockTrailerLen)); readaheadSize > 0 {
+			if readaheadSize >= maxReadaheadSize {
+				// We've reached the maximum readahead size. Beyond this
+				// point, rely on OS-level readahead. Note that we can only
+				// reopen a new file handle with this optimization if
+				// r.fs != nil. This reader must have been created with the
+				// FileReopenOpt for this field to be set.
+				if r.fs != nil {
+					f, err := r.fs.Open(r.filename, vfs.SequentialReadsOption)
+					if err == nil {
+						// Use this new file handle for all sequential reads by
+						// this iterator going forward.
+						raState.sequentialFile = f
+						file = f
+					}
+				}
+			}
+			if raState.sequentialFile != nil {
+				_ = vfs.Prefetch(r.file, bh.Offset, uint64(readaheadSize))
+			}
 		}
 	}
 
 	v := r.opts.Cache.Alloc(int(bh.Length + blockTrailerLen))
 	b := v.Buf()
-	if _, err := r.file.ReadAt(b, int64(bh.Offset)); err != nil {
+	if _, err := file.ReadAt(b, int64(bh.Offset)); err != nil {
 		r.opts.Cache.Free(v)
 		return cache.Handle{}, err
 	}

--- a/sstable/testdata/readahead
+++ b/sstable/testdata/readahead
@@ -178,26 +178,48 @@ read
 ----
 readahead:  262144
 numReads:   8
-size:       524288
+size:       262144
 prevSize:   262144
 limit:      466632
 
-# The readahead size should not increase beyond the max (512kb)
+# The readahead size should not increase beyond the max (256kb)
 
 read
 466632, 16
 ----
-readahead:  524288
+readahead:  262144
 numReads:   9
-size:       524288
-prevSize:   524288
-limit:      990920
+size:       262144
+prevSize:   262144
+limit:      728776
+
+# A cache read pushes the limit further ahead without issuing a readahead.
+
+cache-read
+728770, 16
+----
+readahead:  0
+numReads:   9
+size:       262144
+prevSize:   262144
+limit:      728786
 
 read
-1515208,16
+728780, 16
 ----
-readahead:  524288
+readahead:  262144
 numReads:   10
-size:       524288
-prevSize:   524288
-limit:      2039496
+size:       262144
+prevSize:   262144
+limit:      990924
+
+# An out-of-order cache read still resets readahead state.
+
+cache-read
+1200, 16
+----
+readahead:  0
+numReads:   1
+size:       65536
+prevSize:   0
+limit:      1216

--- a/table_cache.go
+++ b/table_cache.go
@@ -450,11 +450,12 @@ type tableCacheNode struct {
 func (n *tableCacheNode) load(c *tableCacheShard) {
 	// Try opening the fileTypeTable first.
 	var f vfs.File
-	f, n.err = c.fs.Open(base.MakeFilename(c.fs, c.dirname, fileTypeTable, n.meta.FileNum),
-		vfs.RandomReadsOption)
+	filename := base.MakeFilename(c.fs, c.dirname, fileTypeTable, n.meta.FileNum)
+	f, n.err = c.fs.Open(filename, vfs.RandomReadsOption)
 	if n.err == nil {
 		cacheOpts := private.SSTableCacheOpts(c.cacheID, n.meta.FileNum).(sstable.ReaderOption)
-		n.reader, n.err = sstable.NewReader(f, c.opts, cacheOpts, c.filterMetrics)
+		reopenOpt := sstable.FileReopenOpt{FS: c.fs, Filename: filename}
+		n.reader, n.err = sstable.NewReader(f, c.opts, cacheOpts, c.filterMetrics, reopenOpt)
 	}
 	if n.err == nil {
 		if n.meta.SmallestSeqNum == n.meta.LargestSeqNum {

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -169,7 +169,7 @@ compact         1   1.6 K          (size == estimated-debt)
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.4 K    5.9%  (score == hit-rate)
- tcache         1   672 B    0.0%  (score == hit-rate)
+ tcache         1   704 B    0.0%  (score == hit-rate)
  titers         0
  filter         -       -    0.0%  (score == utility)
 

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -33,7 +33,7 @@ compact         0   771 B          (size == estimated-debt)
 zmemtbl         1   256 K
    ztbl         0     0 B
  bcache         3   677 B    0.0%  (score == hit-rate)
- tcache         1   672 B    0.0%  (score == hit-rate)
+ tcache         1   704 B    0.0%  (score == hit-rate)
  titers         1
  filter         -       -    0.0%  (score == utility)
 
@@ -75,7 +75,7 @@ compact         1     0 B          (size == estimated-debt)
 zmemtbl         2   512 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   27.3%  (score == hit-rate)
- tcache         2   1.3 K   60.0%  (score == hit-rate)
+ tcache         2   1.4 K   60.0%  (score == hit-rate)
  titers         3
  filter         -       -    0.0%  (score == utility)
 
@@ -102,7 +102,7 @@ compact         1     0 B          (size == estimated-debt)
 zmemtbl         1   256 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   27.3%  (score == hit-rate)
- tcache         2   1.3 K   60.0%  (score == hit-rate)
+ tcache         2   1.4 K   60.0%  (score == hit-rate)
  titers         3
  filter         -       -    0.0%  (score == utility)
 
@@ -130,7 +130,7 @@ compact         1     0 B          (size == estimated-debt)
 zmemtbl         1   256 K
    ztbl         1   771 B
  bcache         4   698 B   27.3%  (score == hit-rate)
- tcache         1   672 B   60.0%  (score == hit-rate)
+ tcache         1   704 B   60.0%  (score == hit-rate)
  titers         1
  filter         -       -    0.0%  (score == utility)
 

--- a/vfs/fadvise_generic.go
+++ b/vfs/fadvise_generic.go
@@ -9,3 +9,7 @@ package vfs
 func fadviseRandom(f uintptr) error {
 	return nil
 }
+
+func fadviseSequential(f uintptr) error {
+	return nil
+}

--- a/vfs/fadvise_linux.go
+++ b/vfs/fadvise_linux.go
@@ -12,3 +12,8 @@ import "golang.org/x/sys/unix"
 func fadviseRandom(f uintptr) error {
 	return unix.Fadvise(int(f), 0, 0, unix.FADV_RANDOM)
 }
+
+// Calls Fadvise with FADV_SEQUENTIAL to enable readahead on a file descriptor.
+func fadviseSequential(f uintptr) error {
+	return unix.Fadvise(int(f), 0, 0, unix.FADV_SEQUENTIAL)
+}

--- a/vfs/prefetch_linux.go
+++ b/vfs/prefetch_linux.go
@@ -6,7 +6,9 @@
 
 package vfs
 
-import "syscall"
+import (
+	"syscall"
+)
 
 // Prefetch signals the OS (on supported platforms) to fetch the next size
 // bytes in file after offset into cache. Any subsequent reads in that range

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -191,13 +191,33 @@ type randomReadsOption struct{}
 
 // RandomReadsOption is an OpenOption that optimizes opened file handle for
 // random reads, by calling  fadvise() with POSIX_FADV_RANDOM on Linux systems
-// to disable readahead. Only works when specified to defaultFS.
+// to disable readahead.
 var RandomReadsOption OpenOption = &randomReadsOption{}
 
 // Apply implements the OpenOption interface.
 func (randomReadsOption) Apply(f File) {
-	if osFile, ok := f.(*os.File); ok {
-		_ = fadviseRandom(osFile.Fd())
+	type fd interface {
+		Fd() uintptr
+	}
+	if fdFile, ok := f.(fd); ok {
+		_ = fadviseRandom(fdFile.Fd())
+	}
+}
+
+type sequentialReadsOption struct{}
+
+// SequentialReadsOption is an OpenOption that optimizes opened file handle for
+// sequential reads, by calling fadvise() with POSIX_FADV_SEQUENTIAL on Linux
+// systems to enable readahead.
+var SequentialReadsOption OpenOption = &sequentialReadsOption{}
+
+// Apply implements the OpenOption interface.
+func (sequentialReadsOption) Apply(f File) {
+	type fd interface {
+		Fd() uintptr
+	}
+	if fdFile, ok := f.(fd); ok {
+		_ = fadviseSequential(fdFile.Fd())
 	}
 }
 


### PR DESCRIPTION
20.1 Backport of #817 

---

This updates the dynamic readhaead logic in singleLevelIterator
and sstable.Reader to spin up a new file descriptor with
fadvise(FADV_SEQUENTIAL) called on it, to take advantage of OS
level readahead instead of continuing to use pebble-driven
readahead.

In practice, this reliance on OS-level readahead
to dramatically speed up TPCC-4k full backups from taking 1h on avg
to around 20-25mins. It significantly reduces the number of
read IOPS, and makes the workload more CPU/write IO heavy instead
of being bottlenecked on reads.