### PR TITLE
db: capture stack trace of closed call for ErrClosed

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -914,26 +914,26 @@ func TestDBClosed(t *testing.T) {
 		return nil
 	}
 
-	require.EqualValues(t, ErrClosed, catch(func() { _ = d.Close() }))
+	require.True(t, errors.Is(catch(func() { _ = d.Close() }), ErrClosed))
 
-	require.EqualValues(t, ErrClosed, catch(func() { _ = d.Compact(nil, nil) }))
-	require.EqualValues(t, ErrClosed, catch(func() { _ = d.Flush() }))
-	require.EqualValues(t, ErrClosed, catch(func() { _, _ = d.AsyncFlush() }))
+	require.True(t, errors.Is(catch(func() { _ = d.Compact(nil, nil) }), ErrClosed))
+	require.True(t, errors.Is(catch(func() { _ = d.Flush() }), ErrClosed))
+	require.True(t, errors.Is(catch(func() { _, _ = d.AsyncFlush() }), ErrClosed))
 
-	require.EqualValues(t, ErrClosed, catch(func() { _, _, _ = d.Get(nil) }))
-	require.EqualValues(t, ErrClosed, catch(func() { _ = d.Delete(nil, nil) }))
-	require.EqualValues(t, ErrClosed, catch(func() { _ = d.DeleteRange(nil, nil, nil) }))
-	require.EqualValues(t, ErrClosed, catch(func() { _ = d.Ingest(nil) }))
-	require.EqualValues(t, ErrClosed, catch(func() { _ = d.LogData(nil, nil) }))
-	require.EqualValues(t, ErrClosed, catch(func() { _ = d.Merge(nil, nil, nil) }))
-	require.EqualValues(t, ErrClosed, catch(func() { _ = d.Set(nil, nil, nil) }))
+	require.True(t, errors.Is(catch(func() { _, _, _ = d.Get(nil) }), ErrClosed))
+	require.True(t, errors.Is(catch(func() { _ = d.Delete(nil, nil) }), ErrClosed))
+	require.True(t, errors.Is(catch(func() { _ = d.DeleteRange(nil, nil, nil) }), ErrClosed))
+	require.True(t, errors.Is(catch(func() { _ = d.Ingest(nil) }), ErrClosed))
+	require.True(t, errors.Is(catch(func() { _ = d.LogData(nil, nil) }), ErrClosed))
+	require.True(t, errors.Is(catch(func() { _ = d.Merge(nil, nil, nil) }), ErrClosed))
+	require.True(t, errors.Is(catch(func() { _ = d.Set(nil, nil, nil) }), ErrClosed))
 
-	require.EqualValues(t, ErrClosed, catch(func() { _ = d.NewSnapshot() }))
+	require.True(t, errors.Is(catch(func() { _ = d.NewSnapshot() }), ErrClosed))
 
 	b := d.NewIndexedBatch()
-	require.EqualValues(t, ErrClosed, catch(func() { _ = b.Commit(nil) }))
-	require.EqualValues(t, ErrClosed, catch(func() { _ = d.Apply(b, nil) }))
-	require.EqualValues(t, ErrClosed, catch(func() { _ = b.NewIter(nil) }))
+	require.True(t, errors.Is(catch(func() { _ = b.Commit(nil) }), ErrClosed))
+	require.True(t, errors.Is(catch(func() { _ = d.Apply(b, nil) }), ErrClosed))
+	require.True(t, errors.Is(catch(func() { _ = b.NewIter(nil) }), ErrClosed))
 }
 
 func TestDBConcurrentCommitCompactFlush(t *testing.T) {

--- a/flush_external.go
+++ b/flush_external.go
@@ -5,7 +5,6 @@
 package pebble
 
 import (
-	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/pebble/internal/private"
@@ -17,8 +16,8 @@ import (
 // replay package rather than calling this private hook directly.
 func flushExternalTable(untypedDB interface{}, path string, originalMeta *fileMetadata) error {
 	d := untypedDB.(*DB)
-	if atomic.LoadInt32(&d.closed) != 0 {
-		panic(ErrClosed)
+	if err := d.closed.Load(); err != nil {
+		panic(err)
 	}
 	if d.opts.ReadOnly {
 		return ErrReadOnly

--- a/ingest.go
+++ b/ingest.go
@@ -6,7 +6,6 @@ package pebble
 
 import (
 	"sort"
-	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -496,8 +495,8 @@ func ingestTargetLevel(
 // https://github.com/cockroachdb/pebble/issues/25 for an idea for how to fix
 // this hiccup.
 func (d *DB) Ingest(paths []string) error {
-	if atomic.LoadInt32(&d.closed) != 0 {
-		panic(ErrClosed)
+	if err := d.closed.Load(); err != nil {
+		panic(err)
 	}
 	if d.opts.ReadOnly {
 		return ErrReadOnly

--- a/open.go
+++ b/open.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"runtime"
 	"sort"
-	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -354,7 +353,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	if invariants.Enabled {
 		runtime.SetFinalizer(d, func(obj interface{}) {
 			d := obj.(*DB)
-			if atomic.LoadInt32(&d.closed) == 0 {
+			if err := d.closed.Load(); err == nil {
 				fmt.Fprintf(os.Stderr, "%p: unreferenced DB not closed\n", d)
 				os.Exit(1)
 			}

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -200,9 +201,9 @@ func TestSnapshotClosed(t *testing.T) {
 
 	snap := d.NewSnapshot()
 	require.NoError(t, snap.Close())
-	require.EqualValues(t, ErrClosed, catch(func() { _ = snap.Close() }))
-	require.EqualValues(t, ErrClosed, catch(func() { _, _, _ = snap.Get(nil) }))
-	require.EqualValues(t, ErrClosed, catch(func() { snap.NewIter(nil) }))
+	require.True(t, errors.Is(catch(func() { _ = snap.Close() }), ErrClosed))
+	require.True(t, errors.Is(catch(func() { _, _, _ = snap.Get(nil) }), ErrClosed))
+	require.True(t, errors.Is(catch(func() { snap.NewIter(nil) }), ErrClosed))
 
 	require.NoError(t, d.Close())
 }


### PR DESCRIPTION
Capture the stack trace of the first call to `Close` in the `ErrClosed`
error that is returned when an operation is performed on a closed DB.