### PR TITLE
db: use LevelSlice.SizeSum where applicable

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -46,14 +46,6 @@ func maxGrandparentOverlapBytes(opts *Options, level int) uint64 {
 	return uint64(10 * opts.Level(level).TargetFileSize)
 }
 
-// totalSize returns the total size of all the files in f.
-func totalSize(f []*fileMetadata) (size uint64) {
-	for _, x := range f {
-		size += x.Size
-	}
-	return size
-}
-
 // noCloseIter wraps around an internal iterator, intercepting and eliding
 // calls to Close. It is used during compaction to ensure that rangeDelIters
 // are not closed prematurely.

--- a/version_set.go
+++ b/version_set.go
@@ -266,8 +266,8 @@ func (vs *versionSet) load(dirname string, opts *Options, mu *sync.Mutex) error 
 
 	for i := range vs.metrics.Levels {
 		l := &vs.metrics.Levels[i]
-		l.NumFiles = int64(len(newVersion.Levels[i]))
-		l.Size = uint64(totalSize(newVersion.Levels[i]))
+		l.NumFiles = int64(newVersion.Levels[i].Slice().Len())
+		l.Size = uint64(newVersion.Levels[i].Slice().SizeSum())
 	}
 	return nil
 }
@@ -476,8 +476,8 @@ func (vs *versionSet) logAndApply(
 	}
 	for i := range vs.metrics.Levels {
 		l := &vs.metrics.Levels[i]
-		l.NumFiles = int64(len(newVersion.Levels[i]))
-		l.Size = uint64(totalSize(newVersion.Levels[i]))
+		l.NumFiles = int64(newVersion.Levels[i].Slice().Len())
+		l.Size = uint64(newVersion.Levels[i].Slice().SizeSum())
 		l.Sublevels = 0
 		if l.NumFiles > 0 {
 			l.Sublevels = 1


### PR DESCRIPTION
Replace the remaining uses of `totalSize` with calls to the
`manifest.LevelSlice` type's `SizeSum` method, and delete `totalSize`.