### PR TITLE
pebble: fix dropped test error

### DIFF
--- a/version_set_test.go
+++ b/version_set_test.go
@@ -96,6 +96,7 @@ func TestVersionSetSeqNums(t *testing.T) {
 		require.NoError(t, err)
 		var ve versionEdit
 		err = ve.Decode(r)
+		require.NoError(t, err)
 		if ve.LastSeqNum != 0 {
 			lastSeqNum = ve.LastSeqNum
 		}


### PR DESCRIPTION
This fixes a dropped test error in the `pebble` package.