### PR TITLE
internal/rangedel: Skip range tombstones outside a file's bounds

### DIFF
--- a/internal/rangedel/testdata/truncate
+++ b/internal/rangedel/testdata/truncate
@@ -24,6 +24,38 @@ truncate a-e
 1:  b-d
 2:    de
 
+# The second range tombstone should be elided, as it starts after the
+# specified file end key.
+
+truncate a-e endKey=(d.SET.3)
+----
+1:  b-d
+
+# The second range tombstone should be back in the below example, as the
+# specified end key has a trailer (RANGEDEL.2) exactly matching that of the
+# rangedel tombstone's start key.
+
+truncate a-e endKey=(d.RANGEDEL.2)
+----
+1:  b-d
+2:    de
+
+truncate a-e endKey=(d.SET.1)
+----
+1:  b-d
+2:    de
+
+# Similarly, truncate range tombstones that end before the start key.
+
+truncate a-e startKey=(d.SET.3)
+----
+2:    de
+
+truncate a-e startKey=(c.SET.3)
+----
+1:  b-d
+2:    de
+
 truncate a-f
 ----
 1:  b-d

--- a/internal/rangedel/truncate.go
+++ b/internal/rangedel/truncate.go
@@ -8,12 +8,26 @@ import "github.com/cockroachdb/pebble/internal/base"
 
 // Truncate creates a new iterator where every tombstone in the supplied
 // iterator is truncated to be contained within the range [lower, upper).
-func Truncate(cmp base.Compare, iter base.InternalIterator, lower, upper []byte) *Iter {
+// If start and end are specified, filter out any range tombstones that
+// are completely outside those bounds.
+func Truncate(cmp base.Compare, iter base.InternalIterator, lower, upper []byte, start, end *base.InternalKey) *Iter {
 	var tombstones []Tombstone
 	for key, value := iter.First(); key != nil; key, value = iter.Next() {
 		t := Tombstone{
 			Start: *key,
 			End:   value,
+		}
+		// Ignore this tombstone if it lies completely outside [start, end].
+		// The comparison between t.End and start is by user key only, as
+		// the range tombstone is exclusive at t.End, so comparing by user keys
+		// is sufficient. Alternatively, the below comparison can be seen to
+		// be logically equivalent to:
+		// InternalKey{UserKey: t.End, SeqNum: SeqNumMax} < start
+		if start != nil && cmp(t.End, start.UserKey) <= 0 {
+			continue
+		}
+		if end != nil && base.InternalCompare(cmp, t.Start, *end) > 0 {
+			continue
 		}
 		if cmp(t.Start.UserKey, lower) < 0 {
 			t.Start.UserKey = lower

--- a/internal/rangedel/truncate_test.go
+++ b/internal/rangedel/truncate_test.go
@@ -28,17 +28,30 @@ func TestTruncate(t *testing.T) {
 			if len(d.Input) > 0 {
 				t.Fatalf("unexpected input: %s", d.Input)
 			}
-			if len(d.CmdArgs) != 1 {
-				t.Fatalf("expected 1 argument: %s", d.CmdArgs)
+			if len(d.CmdArgs) < 1 || len(d.CmdArgs) > 3 {
+				t.Fatalf("expected 1-3 arguments: %s", d.CmdArgs)
 			}
 			parts := strings.Split(d.CmdArgs[0].String(), "-")
+			var startKey, endKey *base.InternalKey
+			if len(d.CmdArgs) > 1 {
+				for _, arg := range d.CmdArgs[1:] {
+					switch arg.Key {
+					case "startKey":
+						startKey = &base.InternalKey{}
+						*startKey = base.ParseInternalKey(arg.Vals[0])
+					case "endKey":
+						endKey = &base.InternalKey{}
+						*endKey = base.ParseInternalKey(arg.Vals[0])
+					}
+				}
+			}
 			if len(parts) != 2 {
 				t.Fatalf("malformed arg: %s", d.CmdArgs[0])
 			}
 			lower := []byte(parts[0])
 			upper := []byte(parts[1])
 
-			truncated := Truncate(cmp, iter, lower, upper)
+			truncated := Truncate(cmp, iter, lower, upper, startKey, endKey)
 			return formatTombstones(truncated.tombstones)
 
 		default:

--- a/table_stats.go
+++ b/table_stats.go
@@ -267,7 +267,8 @@ func (d *DB) loadTableStats(
 		defer rangeDelIter.Close()
 		// Truncate tombstones to the containing file's bounds if necessary.
 		// See docs/range_deletions.md for why this is necessary.
-		rangeDelIter = rangedel.Truncate(d.cmp, rangeDelIter, meta.Smallest.UserKey, meta.Largest.UserKey)
+		rangeDelIter = rangedel.Truncate(
+			d.cmp, rangeDelIter, meta.Smallest.UserKey, meta.Largest.UserKey, nil, nil)
 		err = foreachDefragmentedTombstone(rangeDelIter, d.cmp,
 			func(startUserKey, endUserKey []byte, smallestSeqNum, largestSeqNum uint64) error {
 				estimate, hintSeqNum, err := d.estimateSizeBeneath(v, level, meta, startUserKey, endUserKey)


### PR DESCRIPTION
This change updates rangedel.Truncate, which is used to wrap file-specific
range tombstone iterators during compaction, to ignore any range tombstones
outside a file's bounds.

As the non-L0 compaction writing logic
writes untruncated range tombstones on both sides of an SST split
between versions of the same user key (see comments around
fragmenter.FlushTo), it's possible for the compaction mergingIter
to have a rangedel iterator pointing to a range tombstone on the
left-hand side of a split while the same level's point key iterator
has moved onto the right-side file. This could cause a deleted
key in the right-side file to resurface even if it's covered by
a range del tombstone in that same file.

This issue only occurs during
compactions, as non-compaction levelIters manage the rangeDelIter
handle in their respective mergingIter entry and ensure it's pointing
to the same file as the point key iterator.

Fixes #827 . See discussion on that issue for a detailed description
of a bug that helped uncover this issue.