### PR TITLE
db: use manifest.NewVersion constructor in tests

### DIFF
--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -196,6 +196,24 @@ func overlaps(files []*FileMetadata, cmp Compare, start, end []byte) (lower, upp
 // NumLevels is the number of levels a Version contains.
 const NumLevels = 7
 
+// NewVersion constructs a new Version with the provided files. It assumes
+// the provided files are already well-ordered. It's intended for testing.
+func NewVersion(
+	cmp Compare,
+	formatKey base.FormatKey,
+	flushSplitBytes int64,
+	files [NumLevels][]*FileMetadata,
+) *Version {
+	var v Version
+	for i := range files {
+		v.Levels[i] = files[i]
+	}
+	if err := v.InitL0Sublevels(cmp, formatKey, flushSplitBytes); err != nil {
+		panic(err)
+	}
+	return &v
+}
+
 // Version is a collection of file metadata for on-disk tables at various
 // levels. In-memory DBs are written to level-0 tables, and compactions
 // migrate data from level N to level N+1. The tables map internal keys (which

--- a/level_checker.go
+++ b/level_checker.go
@@ -413,9 +413,6 @@ func checkRangeTombstones(c *checkConfig) error {
 		level++
 	}
 	for i := 1; i < len(current.Levels); i++ {
-		if len(current.Levels[i]) == 0 {
-			continue
-		}
 		if err := addTombstonesFromLevel(current.Levels[i].Iter(), i); err != nil {
 			return err
 		}
@@ -626,7 +623,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 		mlevels = append(mlevels, simpleMergingIterLevel{})
 	}
 	for level := 1; level < len(current.Levels); level++ {
-		if len(current.Levels[level]) == 0 {
+		if current.Levels[level].Slice().Empty() {
 			continue
 		}
 		mlevels = append(mlevels, simpleMergingIterLevel{})

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -235,12 +235,17 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 					return fmt.Sprintf("unknown arg: %s", arg.Key)
 				}
 			}
-			version := &version{}
+
+			var files [numLevels][]*fileMetadata
 			for i := range levels {
 				// Start from level 1 in this test.
-				version.Levels[i+1] = levels[i]
+				files[i+1] = levels[i]
 			}
-			version.InitL0Sublevels(base.DefaultComparer.Compare, base.DefaultFormatter, 0)
+			version := manifest.NewVersion(
+				base.DefaultComparer.Compare,
+				base.DefaultFormatter,
+				0,
+				files)
 			readState := &readState{current: version}
 			c := &checkConfig{
 				cmp:       cmp,

--- a/version_set.go
+++ b/version_set.go
@@ -524,8 +524,9 @@ func (vs *versionSet) createManifest(
 	snapshot := versionEdit{
 		ComparerName: vs.cmpName,
 	}
-	for level, fileMetadata := range vs.currentVersion().Levels {
-		for _, meta := range fileMetadata {
+	for level, levelMetadata := range vs.currentVersion().Levels {
+		iter := levelMetadata.Iter()
+		for meta := iter.First(); meta != nil; meta = iter.Next() {
 			snapshot.NewFiles = append(snapshot.NewFiles, newFileEntry{
 				Level: level,
 				Meta:  meta,
@@ -597,8 +598,9 @@ func (vs *versionSet) currentVersion() *version {
 func (vs *versionSet) addLiveFileNums(m map[FileNum]struct{}) {
 	current := vs.currentVersion()
 	for v := vs.versions.Front(); true; v = v.Next() {
-		for _, ff := range v.Levels {
-			for _, f := range ff {
+		for _, lm := range v.Levels {
+			iter := lm.Iter()
+			for f := iter.First(); f != nil; f = iter.Next() {
 				m[f.FileNum] = struct{}{}
 			}
 		}


### PR DESCRIPTION
In test cases, use a new NewVersion function to construct versions in
tests. Also, update a few additional call sites to use
manifest.LevelIterator.