### PR TITLE
internal/manifest: take a LevelSlice in L0Sublevels.PickBaseCompaction

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -996,7 +996,7 @@ func pickL0(env compactionEnv, opts *Options, vers *version, baseLevel int) (pc 
 	//
 	// TODO(bilal) Remove the minCompactionDepth parameter once fixing it at 1
 	// has been shown to not cause a performance regression.
-	lcf, err := vers.L0Sublevels.PickBaseCompaction(1, vers.Levels[baseLevel])
+	lcf, err := vers.L0Sublevels.PickBaseCompaction(1, vers.Levels[baseLevel].Slice())
 	if err != nil {
 		opts.Logger.Infof("error when picking base compaction: %s", err)
 		return

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -239,7 +239,7 @@ func NewL0Sublevels(
 		f.l0Index = i
 		keys = append(keys, intervalKey{key: f.Smallest.UserKey})
 		keys = append(keys, intervalKey{
-			key: f.Largest.UserKey,
+			key:       f.Largest.UserKey,
 			isLargest: f.Largest.Trailer != base.InternalKeyRangeDeleteSentinel,
 		})
 	}
@@ -840,7 +840,7 @@ func (is intervalSorterByDecreasingScore) Swap(i, j int) {
 // files that can be selected for compaction. Returns nil if no compaction is
 // possible.
 func (s *L0Sublevels) PickBaseCompaction(
-	minCompactionDepth int, baseFiles []*FileMetadata,
+	minCompactionDepth int, baseFiles LevelSlice,
 ) (*L0CompactionFiles, error) {
 	// For LBase compactions, we consider intervals in a greedy manner in the
 	// following order:
@@ -913,27 +913,20 @@ func (s *L0Sublevels) PickBaseCompaction(
 			// Check if the chosen compaction overlaps with any files
 			// in Lbase that have Compacting = true. If that's the case,
 			// this compaction cannot be chosen.
-			firstBaseIndex := sort.Search(len(baseFiles), func(i int) bool {
-				// An interval starting at ImmediateSuccessor(key) can never be the
-				// first interval of a compaction since no file can start at that
-				// interval.
-				return s.cmp(baseFiles[i].Largest.UserKey, s.orderedIntervals[c.minIntervalIndex].startKey.key) >= 0
-			})
-			// Exclusive
-			lastBaseIndex := sort.Search(len(baseFiles), func(i int) bool {
-				cmp := s.cmp(baseFiles[i].Smallest.UserKey, s.orderedIntervals[c.maxIntervalIndex+1].startKey.key)
+			baseIter := baseFiles.Iter()
+			// An interval starting at ImmediateSuccessor(key) can never be the
+			// first interval of a compaction since no file can start at that
+			// interval.
+			m := baseIter.SeekGE(s.cmp, s.orderedIntervals[c.minIntervalIndex].startKey.key)
+
+			var baseCompacting bool
+			for ; m != nil && !baseCompacting; m = baseIter.Next() {
+				cmp := s.cmp(m.Smallest.UserKey, s.orderedIntervals[c.maxIntervalIndex+1].startKey.key)
 				// Compaction is ending at exclusive bound of c.maxIntervalIndex+1
 				if cmp > 0 || (cmp == 0 && !s.orderedIntervals[c.maxIntervalIndex+1].startKey.isLargest) {
-					return true
-				}
-				return false
-			})
-			baseCompacting := false
-			for j := firstBaseIndex; j < lastBaseIndex; j++ {
-				if baseFiles[j].Compacting {
-					baseCompacting = true
 					break
 				}
+				baseCompacting = baseCompacting || m.Compacting
 			}
 			if baseCompacting {
 				continue

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -61,7 +61,7 @@ func TestL0Sublevels_LargeImportL0(t *testing.T) {
 	fmt.Printf("L0Sublevels:\n%s\n\n", sublevels)
 
 	for i := 0; ; i++ {
-		c, err := sublevels.PickBaseCompaction(2, nil)
+		c, err := sublevels.PickBaseCompaction(2, LevelSlice{})
 		require.NoError(t, err)
 		if c == nil {
 			break
@@ -362,7 +362,7 @@ func TestL0Sublevels(t *testing.T) {
 
 			var lcf *L0CompactionFiles
 			if pickBaseCompaction {
-				lcf, err = sublevels.PickBaseCompaction(minCompactionDepth, fileMetas[baseLevel])
+				lcf, err = sublevels.PickBaseCompaction(minCompactionDepth, NewLevelSlice(fileMetas[baseLevel]))
 				if err == nil && lcf != nil {
 					// Try to extend the base compaction into a more rectangular
 					// shape, using the smallest/largest keys of the files before
@@ -503,7 +503,7 @@ func BenchmarkL0SublevelsInitAndPick(b *testing.B) {
 		if sl == nil {
 			b.Fatal("expected non-nil L0Sublevels to be generated")
 		}
-		c, err := sl.PickBaseCompaction(2, nil)
+		c, err := sl.PickBaseCompaction(2, LevelSlice{})
 		require.NoError(b, err)
 		if c == nil {
 			b.Fatal("expected non-nil compaction to be generated")


### PR DESCRIPTION
Update the `(*manifest.L0Sublevels).PickBaseCompaction` method to take a
LevelSlice rather than a slice of `*FileMetadata`.