### PR TITLE
internal/manifest: unexport LevelMetadata files

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -718,9 +718,9 @@ func (d *DB) addInProgressCompaction(c *compaction) {
 	}
 
 	if (isIntraL0 || isBase) && c.version.L0Sublevels != nil {
-		l0Inputs := [][]*fileMetadata{c.startLevel.files.Collect()}
+		l0Inputs := []manifest.LevelSlice{c.startLevel.files}
 		if isIntraL0 {
-			l0Inputs = append(l0Inputs, c.outputLevel.files.Collect())
+			l0Inputs = append(l0Inputs, c.outputLevel.files)
 		}
 		if err := c.version.L0Sublevels.UpdateStateForStartedCompaction(l0Inputs, isBase); err != nil {
 			d.opts.Logger.Fatalf("could not update state for compaction: %s", err)

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -599,11 +599,12 @@ func (s *L0Sublevels) checkCompaction(c *L0CompactionFiles) error {
 // compaction must be involving L0 SSTables. It's assumed that the Compacting
 // and IsIntraL0Compacting fields are already set on all FileMetadatas passed
 // in.
-func (s *L0Sublevels) UpdateStateForStartedCompaction(inputs [][]*FileMetadata, isBase bool) error {
+func (s *L0Sublevels) UpdateStateForStartedCompaction(inputs []LevelSlice, isBase bool) error {
 	minIntervalIndex := -1
 	maxIntervalIndex := 0
 	for i := range inputs {
-		for _, f := range inputs[i] {
+		iter := inputs[i].Iter()
+		for f := iter.First(); f != nil; f = iter.Next() {
 			for i := f.minIntervalIndex; i <= f.maxIntervalIndex; i++ {
 				interval := &s.orderedIntervals[i]
 				interval.compactingFileCount++

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -8,17 +8,18 @@ import "sort"
 
 // LevelMetadata contains metadata for all of the files within
 // a level of the LSM.
-// TODO(jackson): Convert to an opaque struct.
-type LevelMetadata []*FileMetadata
+type LevelMetadata struct {
+	files []*FileMetadata
+}
 
 // Iter constructs a LevelIterator over the entire level.
 func (lm LevelMetadata) Iter() LevelIterator {
-	return LevelIterator{files: lm, end: len(lm)}
+	return LevelIterator{files: lm.files, end: len(lm.files)}
 }
 
 // Slice constructs a slice containing the entire level.
 func (lm LevelMetadata) Slice() LevelSlice {
-	return LevelSlice{files: lm, end: len(lm)}
+	return LevelSlice{files: lm.files, end: len(lm.files)}
 }
 
 // LevelFile holds a file's metadata along with its position

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -206,7 +206,7 @@ func NewVersion(
 ) *Version {
 	var v Version
 	for i := range files {
-		v.Levels[i] = files[i]
+		v.Levels[i].files = files[i]
 	}
 	if err := v.InitL0Sublevels(cmp, formatKey, flushSplitBytes); err != nil {
 		panic(err)
@@ -385,7 +385,7 @@ func (v *Version) InitL0Sublevels(
 	cmp Compare, formatKey base.FormatKey, flushSplitBytes int64,
 ) error {
 	var err error
-	v.L0Sublevels, err = NewL0Sublevels(v.Levels[0], cmp, formatKey, flushSplitBytes)
+	v.L0Sublevels, err = NewL0Sublevels(v.Levels[0].Slice().Collect(), cmp, formatKey, flushSplitBytes)
 	return err
 }
 
@@ -417,16 +417,18 @@ func (v *Version) Contains(level int, cmp Compare, m *FileMetadata) bool {
 func (v *Version) Overlaps(level int, cmp Compare, start, end []byte) LevelSlice {
 	if level == 0 {
 		// Indices that have been selected as overlapping.
-		selectedIndices := make([]bool, len(v.Levels[level]))
+		l0 := v.Levels[level].Slice()
+		l0Iter := l0.Iter()
+		selectedIndices := make([]bool, l0.Len())
 		numSelected := 0
 		var slice LevelSlice
 		for {
 			restart := false
-			for i, selected := range selectedIndices {
+			for i, meta := 0, l0Iter.First(); meta != nil; i, meta = i+1, l0Iter.Next() {
+				selected := selectedIndices[i]
 				if selected {
 					continue
 				}
-				meta := v.Levels[level][i]
 				smallest := meta.Smallest.UserKey
 				largest := meta.Largest.UserKey
 				if cmp(largest, start) < 0 {
@@ -458,9 +460,9 @@ func (v *Version) Overlaps(level int, cmp Compare, start, end []byte) LevelSlice
 
 			if !restart {
 				slice.files = make([]*FileMetadata, 0, numSelected)
-				for i, selected := range selectedIndices {
-					if selected {
-						slice.files = append(slice.files, v.Levels[level][i])
+				for i, meta := 0, l0Iter.First(); meta != nil; i, meta = i+1, l0Iter.Next() {
+					if selectedIndices[i] {
+						slice.files = append(slice.files, meta)
 					}
 				}
 				slice.end = len(slice.files)
@@ -472,9 +474,9 @@ func (v *Version) Overlaps(level int, cmp Compare, start, end []byte) LevelSlice
 	}
 
 	var slice LevelSlice
-	lower, upper := overlaps(v.Levels[level], cmp, start, end)
+	lower, upper := overlaps(v.Levels[level].files, cmp, start, end)
 	if lower < upper {
-		slice.files = v.Levels[level]
+		slice.files = v.Levels[level].files
 		slice.start = lower
 		slice.end = upper
 	}

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -501,11 +501,11 @@ func (b *BulkVersionEdit) Apply(
 			if curr == nil {
 				continue
 			}
-			files := curr.Levels[level]
-			v.Levels[level] = files
+			levelMetadata := curr.Levels[level]
+			v.Levels[level] = levelMetadata
 			// We still have to bump the ref count for all files.
-			for i := range files {
-				atomic.AddInt32(&files[i].refs, 1)
+			for i := range levelMetadata.files {
+				atomic.AddInt32(&levelMetadata.files[i].refs, 1)
 			}
 			continue
 		}
@@ -513,7 +513,7 @@ func (b *BulkVersionEdit) Apply(
 		// Some edits on this level.
 		var currFiles []*FileMetadata
 		if curr != nil {
-			currFiles = curr.Levels[level]
+			currFiles = curr.Levels[level].files
 		}
 		addedFiles := b.Added[level]
 		deletedMap := b.Deleted[level]
@@ -523,7 +523,7 @@ func (b *BulkVersionEdit) Apply(
 				"pebble: internal error: No current or added files but have deleted files: %d",
 				errors.Safe(len(deletedMap)))
 		}
-		v.Levels[level] = make([]*FileMetadata, 0, n)
+		v.Levels[level].files = make([]*FileMetadata, 0, n)
 		// We have 2 lists of files, currFiles and addedFiles either of which (but not both) can
 		// be empty.
 		// - currFiles is internally consistent, since it comes from curr.
@@ -553,10 +553,10 @@ func (b *BulkVersionEdit) Apply(
 						continue
 					}
 					atomic.AddInt32(&f.refs, 1)
-					v.Levels[level] = append(v.Levels[level], f)
+					v.Levels[level].files = append(v.Levels[level].files, f)
 				}
 			}
-			SortBySeqNum(v.Levels[level])
+			SortBySeqNum(v.Levels[level].files)
 			if err := v.InitL0Sublevels(cmp, formatKey, flushSplitBytes); err != nil {
 				return nil, nil, errors.Wrap(err, "pebble: internal error")
 			}
@@ -599,10 +599,10 @@ func (b *BulkVersionEdit) Apply(
 				}
 				removeZombie(cf.FileNum)
 				atomic.AddInt32(&cf.refs, 1)
-				v.Levels[level] = append(v.Levels[level], cf)
+				v.Levels[level].files = append(v.Levels[level].files, cf)
 			}
 			currFiles = currFiles[j:]
-			numFiles := len(v.Levels[level])
+			numFiles := len(v.Levels[level].files)
 			if numFiles > 0 {
 				// We expect k to typically be large, and we can avoid doing consistency
 				// checks of the files within that set of k, since they are already mutually
@@ -612,8 +612,8 @@ func (b *BulkVersionEdit) Apply(
 				// its predecessor either came from currFiles or addedFiles, and both are ones
 				// which we need to check against f for consistency (since we have not checked
 				// addedFiles for internal consistency).
-				if base.InternalCompare(cmp, v.Levels[level][numFiles-1].Largest, f.Smallest) >= 0 {
-					cf := v.Levels[level][numFiles-1]
+				if base.InternalCompare(cmp, v.Levels[level].files[numFiles-1].Largest, f.Smallest) >= 0 {
+					cf := v.Levels[level].files[numFiles-1]
 					return nil, nil, errors.Errorf(
 						"pebble: internal error: L%d files %s and %s have overlapping ranges: [%s-%s] vs [%s-%s]",
 						errors.Safe(level), errors.Safe(cf.FileNum), errors.Safe(f.FileNum),
@@ -621,7 +621,7 @@ func (b *BulkVersionEdit) Apply(
 						f.Smallest.Pretty(formatKey), f.Largest.Pretty(formatKey))
 				}
 			}
-			v.Levels[level] = append(v.Levels[level], f)
+			v.Levels[level].files = append(v.Levels[level].files, f)
 		}
 		// Add any remaining files in currFiles that are after all the added files.
 		for i := range currFiles {
@@ -632,7 +632,7 @@ func (b *BulkVersionEdit) Apply(
 			}
 			removeZombie(f.FileNum)
 			atomic.AddInt32(&f.refs, 1)
-			v.Levels[level] = append(v.Levels[level], f)
+			v.Levels[level].files = append(v.Levels[level].files, f)
 		}
 	}
 	return v, zombies, nil

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -314,7 +314,7 @@ func TestVersionEditApply(t *testing.T) {
 								if v == nil {
 									v = new(Version)
 								}
-								v.Levels[level] = append(v.Levels[level], meta)
+								v.Levels[level].files = append(v.Levels[level].files, meta)
 							} else {
 								ve.NewFiles =
 									append(ve.NewFiles, NewFileEntry{Level: level, Meta: meta})
@@ -334,7 +334,7 @@ func TestVersionEditApply(t *testing.T) {
 				}
 
 				if v != nil {
-					SortBySeqNum(v.Levels[0])
+					SortBySeqNum(v.Levels[0].files)
 					if err := v.InitL0Sublevels(base.DefaultComparer.Compare, base.DefaultFormatter, 10<<20); err != nil {
 						return err.Error()
 					}

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -170,8 +170,8 @@ func TestOverlaps(t *testing.T) {
 
 	v := Version{
 		Levels: [NumLevels]LevelMetadata{
-			0: {m00, m01, m02, m03, m04, m05, m06, m07},
-			1: {m10, m11, m12, m13, m14},
+			0: {files: []*FileMetadata{m00, m01, m02, m03, m04, m05, m06, m07}},
+			1: {files: []*FileMetadata{m10, m11, m12, m13, m14}},
 		},
 	}
 
@@ -343,8 +343,8 @@ func TestContains(t *testing.T) {
 
 	v := Version{
 		Levels: [NumLevels]LevelMetadata{
-			0: {m00, m01, m02, m03, m04, m05, m06, m07},
-			1: {m10, m11, m12, m13, m14},
+			0: {files: []*FileMetadata{m00, m01, m02, m03, m04, m05, m06, m07}},
+			1: {files: []*FileMetadata{m10, m11, m12, m13, m14}},
 		},
 	}
 
@@ -436,7 +436,7 @@ func TestCheckOrdering(t *testing.T) {
 				// avoid repeating it, and make it the inverse of
 				// Version.DebugString().
 				v := Version{}
-				var files *LevelMetadata
+				var files *[]*FileMetadata
 				fileNum := base.FileNum(1)
 
 				for _, data := range strings.Split(d.Input, "\n") {
@@ -446,7 +446,7 @@ func TestCheckOrdering(t *testing.T) {
 						if err != nil {
 							return err.Error()
 						}
-						files = &v.Levels[level]
+						files = &v.Levels[level].files
 
 					default:
 						meta := parseMeta(data)
@@ -505,7 +505,7 @@ func TestCheckConsistency(t *testing.T) {
 			switch d.Cmd {
 			case "check-consistency":
 				v := Version{}
-				var files *LevelMetadata
+				var files *[]*FileMetadata
 
 				for _, data := range strings.Split(d.Input, "\n") {
 					switch data {
@@ -514,7 +514,7 @@ func TestCheckConsistency(t *testing.T) {
 						if err != nil {
 							return err.Error()
 						}
-						files = &v.Levels[level]
+						files = &v.Levels[level].files
 
 					default:
 						m, err := parseMeta(data)


### PR DESCRIPTION
Refactor the `LevelMetadata` type into a struct with its file metadata
slice unexported. This ensures that all usages outside of the manifest
package are agonstic to the in-memory representation of a level's file
metadata.