### PR TITLE
vfs: Add FS.GetFreeSpace, IsNoSpaceError

### DIFF
--- a/internal/errorfs/errorfs.go
+++ b/internal/errorfs/errorfs.go
@@ -162,6 +162,14 @@ func (fs *FS) OpenDir(name string) (vfs.File, error) {
 	return &errorFile{f, fs.inj}, nil
 }
 
+// GetFreeSpace implements FS.GetFreeSpace.
+func (fs *FS) GetFreeSpace(path string) (uint64, error) {
+	if err := fs.inj.MaybeError(OpRead); err != nil {
+		return 0, err
+	}
+	return fs.fs.GetFreeSpace(path)
+}
+
 // PathBase implements FS.PathBase.
 func (fs *FS) PathBase(p string) string {
 	return fs.fs.PathBase(p)

--- a/vfs/disk_usage_unix.go
+++ b/vfs/disk_usage_unix.go
@@ -1,0 +1,19 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build darwin linux openbsd dragonfly freebsd
+
+package vfs
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func (defaultFS) GetFreeSpace(path string) (uint64, error) {
+	stat := unix.Statfs_t{}
+	if err := unix.Statfs(path, &stat); err != nil {
+		return 0, err
+	}
+	return uint64(stat.Bsize) * stat.Bfree, nil
+}

--- a/vfs/disk_usage_windows.go
+++ b/vfs/disk_usage_windows.go
@@ -1,0 +1,21 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build windows
+
+package vfs
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+func (defaultFS) GetFreeSpace(path string) (uint64, error) {
+	var freeSpace uint64
+	p, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, err
+	}
+	err = windows.GetDiskFreeSpaceEx(p, &freeSpace, nil, nil)
+	return freeSpace, err
+}

--- a/vfs/errors_unix.go
+++ b/vfs/errors_unix.go
@@ -1,0 +1,19 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build darwin dragonfly freebsd linux openbsd
+
+package vfs
+
+import (
+	"github.com/cockroachdb/errors"
+
+	"golang.org/x/sys/unix"
+)
+
+// IsNoSpaceError returns true if the given error indicates that the disk is
+// out of space.
+func IsNoSpaceError(err error) bool {
+	return errors.Is(err, unix.ENOSPC)
+}

--- a/vfs/errors_windows.go
+++ b/vfs/errors_windows.go
@@ -1,0 +1,20 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build windows
+
+package vfs
+
+import (
+	"github.com/cockroachdb/errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// IsNoSpaceError returns true if the given error indicates that the disk is
+// out of space.
+func IsNoSpaceError(err error) bool {
+	return errors.Is(err, windows.ERROR_DISK_FULL) ||
+		errors.Is(err, windows.ERROR_HANDLE_DISK_FULL)
+}

--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -492,6 +492,11 @@ func (*MemFS) PathDir(p string) string {
 	return path.Dir(p)
 }
 
+// GetFreeSpace implements FS.GetFreeSpace.
+func (*MemFS) GetFreeSpace(string) (uint64, error) {
+	return 0, errors.New("pebble: not supported")
+}
+
 // memNode holds a file's data or a directory's children, and implements os.FileInfo.
 type memNode struct {
 	name  string

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -112,6 +112,10 @@ type FS interface {
 
 	// PathDir returns all but the last element of path, typically the path's directory.
 	PathDir(path string) string
+
+	// GetFreeSpace returns the amount of free disk space for the filesystem
+	// where path is any file or directory within that filesystem.
+	GetFreeSpace(path string) (uint64, error)
 }
 
 // Default is a FS implementation backed by the underlying operating system's

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -238,3 +238,13 @@ func TestVFS(t *testing.T) {
 		})
 	}
 }
+
+func TestVFSGetFreeSpace(t *testing.T) {
+	dir, err := ioutil.TempDir("", "test-free-space")
+	require.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(dir)
+	}()
+	_, err = Default.GetFreeSpace(dir)
+	require.Nil(t, err)
+}


### PR DESCRIPTION
In future when we want to auto recover from no space errors, we'll need to check for free disk space and recover if it is above a certain threshold. For that purpose, this change adds the OS-specific way of getting the free disk space and also checking if an error is a no space error.