### PR TITLE
db: add elision-only L6 compactions

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -519,6 +519,8 @@ func runTableStatsCmd(td *datadriven.TestData, d *DB) string {
 			}
 
 			var b bytes.Buffer
+			fmt.Fprintf(&b, "num-entries: %d\n", f.Stats.NumEntries)
+			fmt.Fprintf(&b, "num-deletions: %d\n", f.Stats.NumDeletions)
 			fmt.Fprintf(&b, "range-deletions-bytes-estimate: %d\n", f.Stats.RangeDeletionsBytesEstimate)
 			return b.String()
 		}

--- a/ingest.go
+++ b/ingest.go
@@ -79,10 +79,7 @@ func ingestLoad1(
 	// disallowing removal of an open file. Under MemFS, if we don't populate
 	// meta.Stats here, the file will be loaded into the table cache for
 	// calculating stats before we can remove the original link.
-	if r.Properties.NumRangeDeletions == 0 {
-		meta.Stats.Valid = true
-		meta.Stats.RangeDeletionsBytesEstimate = 0
-	}
+	maybeSetStatsFromProperties(meta, &r.Properties)
 
 	smallestSet, largestSet := false, false
 	empty := true

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -117,13 +117,16 @@ func TestIngestLoadRand(t *testing.T) {
 			expected[i].Largest = keys[len(keys)-1]
 
 			w := sstable.NewWriter(f, sstable.WriterOptions{})
+			var count uint64
 			for i := range keys {
 				if i > 0 && base.InternalCompare(cmp, keys[i-1], keys[i]) == 0 {
 					// Duplicate key, ignore.
 					continue
 				}
 				w.Add(keys[i], nil)
+				count++
 			}
+			expected[i].Stats.NumEntries = count
 			require.NoError(t, w.Close())
 
 			meta, err := w.Metadata()

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -43,12 +43,20 @@ type TableStats struct {
 	// Valid true if stats have been loaded for the table. The rest of the
 	// structure is populated only if true.
 	Valid bool
-	// Estimate of the total disk space that may be reclaimed by compacting
-	// this table's range deletions to the bottom of the LSM. This estimate is
-	// at data-block granularity and is not updated if compactions beneath the
-	// table reduce the amount of reclaimable disk space. It also does not
-	// account for overlapping data in L0 and ignores L0 sublevels, but the
-	// error that introduces is expected to be small.
+	// The total number of entries in the table.
+	NumEntries uint64
+	// The number of point and range deletion entries in the table.
+	NumDeletions uint64
+	// Estimate of the total disk space that may be dropped by this table's
+	// range deletions by compacting them. This estimate is at data-block
+	// granularity and is not updated if compactions beneath the table reduce
+	// the amount of reclaimable disk space. It also does not account for
+	// overlapping data in L0 and ignores L0 sublevels, but the error that
+	// introduces is expected to be small.
+	//
+	// Tables in the bottommost level of the LSM may have a nonzero estimate
+	// if snapshots or move compactions prevented the elision of their range
+	// tombstones.
 	RangeDeletionsBytesEstimate uint64
 }
 

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -585,10 +585,12 @@ func TestIteratorNextPrev(t *testing.T) {
 
 		mem = vfs.NewMem()
 		require.NoError(t, mem.MkdirAll("ext", 0755))
+		opts := &Options{FS: mem}
+		// Automatic compactions may compact away tombstones from L6, making
+		// some testcases non-deterministic.
+		opts.private.disableAutomaticCompactions = true
 		var err error
-		d, err = Open("", &Options{
-			FS: mem,
-		})
+		d, err = Open("", opts)
 		require.NoError(t, err)
 	}
 	reset()

--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -105,7 +105,8 @@ type Properties struct {
 	MergerName string `prop:"rocksdb.merge.operator"`
 	// The number of blocks in this table.
 	NumDataBlocks uint64 `prop:"rocksdb.num.data.blocks"`
-	// The number of deletion entries in this table.
+	// The number of deletion entries in this table, including both point and
+	// range deletions.
 	NumDeletions uint64 `prop:"rocksdb.deleted.keys"`
 	// The number of entries in this table.
 	NumEntries uint64 `prop:"rocksdb.num.entries"`

--- a/testdata/compaction_tombstone_elision_only
+++ b/testdata/compaction_tombstone_elision_only
@@ -1,0 +1,149 @@
+# Test an L6 file that contains range tombstones, but whose keys are not in
+# the last snapshot stripe. The tombstones wouldn't be elided, so no
+# compaction is pursued.
+define snapshots=(70, 100, 180, 210)
+L6
+b.RANGEDEL.230:h h.RANGEDEL.200:r
+----
+6:
+  000004:[b#230,RANGEDEL-r#72057594037927935,RANGEDEL]
+
+wait-pending-table-stats
+000004
+----
+num-entries: 2
+num-deletions: 2
+range-deletions-bytes-estimate: 0
+
+maybe-compact
+----
+(none)
+
+# Test the same scenario, but the file is in the last stripe. Since the file
+# only contains deletes, no new sstable is written.
+define snapshots=(270, 300, 380, 410)
+L6
+b.RANGEDEL.230:h h.RANGEDEL.200:r
+----
+6:
+  000004:[b#230,RANGEDEL-r#72057594037927935,RANGEDEL]
+
+wait-pending-table-stats
+000004
+----
+num-entries: 2
+num-deletions: 2
+range-deletions-bytes-estimate: 0
+
+maybe-compact
+----
+[JOB 100] compacted L6 [000004] (853 B) + L6 [] (0 B) -> L6 [] (0 B), in 1.0s, output rate 0 B/s
+
+# Test a table that straddles a snapshot. It should not be compacted.
+define snapshots=(50)
+L6
+a.SET.55:a b.RANGEDEL.5:h
+----
+6:
+  000004:[a#55,SET-h#72057594037927935,RANGEDEL]
+
+wait-pending-table-stats
+000004
+----
+num-entries: 2
+num-deletions: 1
+range-deletions-bytes-estimate: 26
+
+maybe-compact
+----
+(none)
+
+# Test a table with a point deletion and a non-deletion entry. The table
+# should be compacted, and a new table with the point tombstone should be
+# written.
+define
+L6
+a.SET.55:a b.DEL.5:
+----
+6:
+  000004:[a#55,SET-b#5,DEL]
+
+wait-pending-table-stats
+000004
+----
+num-entries: 2
+num-deletions: 1
+range-deletions-bytes-estimate: 0
+
+maybe-compact
+----
+[JOB 100] compacted L6 [000004] (783 B) + L6 [] (0 B) -> L6 [000005] (771 B), in 1.0s, output rate 771 B/s
+
+version
+----
+6:
+  000005:[a#0,SET-a#0,SET]
+
+# Checking for a compaction again should not trigger a compaction, because
+# 000005 does not contain deletions.
+
+maybe-compact
+----
+(none)
+
+maybe-compact
+----
+(none)
+
+# Test a table that contains both deletions and non-deletions, but whose
+# deletions remove the non-deletions. The compaction should not create a new
+# table, but shouldn't happen until the snapshots are removed.
+define snapshots=(59, 103)
+L6
+a.DEL.60: a.SET.55:a b.SET.100:b c.SET.101:c d.SET.102:d b.RANGEDEL.103:z
+----
+6:
+  000004:[a#60,DEL-z#72057594037927935,RANGEDEL]
+
+wait-pending-table-stats
+000004
+----
+num-entries: 6
+num-deletions: 2
+range-deletions-bytes-estimate: 76
+
+maybe-compact
+----
+(none)
+
+close-snapshot
+59
+----
+(none)
+
+close-snapshot
+103
+----
+[JOB 100] compacted L6 [000004] (901 B) + L6 [] (0 B) -> L6 [] (0 B), in 1.0s, output rate 0 B/s
+
+# Test a table that contains both deletions and non-deletions, but whose
+# non-deletions well outnumber its deletions. The table should not be
+# compacted because it falls beneath the threshold.
+define snapshots=(15)
+L6
+a.DEL.20: a.SET.1:a b.SET.2:b c.SET.3:c d.SET.4:d e.SET.5:e f.SET.6:f g.SET.7:g h.SET.8:h i.SET.9:i j.SET.10:j
+----
+6:
+  000004:[a#20,DEL-j#10,SET]
+
+wait-pending-table-stats
+000004
+----
+num-entries: 11
+num-deletions: 1
+range-deletions-bytes-estimate: 0
+
+close-snapshot
+15
+----
+(none)

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -70,6 +70,8 @@ b:2
 wait-pending-table-stats
 000006
 ----
+num-entries: 2
+num-deletions: 0
 range-deletions-bytes-estimate: 0
 
 build ext1
@@ -337,6 +339,8 @@ y: pebble: not found
 wait-pending-table-stats
 000015
 ----
+num-entries: 2
+num-deletions: 2
 range-deletions-bytes-estimate: 1666
 
 # A set operation takes precedence over a range deletion at the same

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -84,6 +84,8 @@ L3
 wait-pending-table-stats
 000005
 ----
+num-entries: 1
+num-deletions: 1
 range-deletions-bytes-estimate: 1552
 
 compact a-e L1
@@ -99,6 +101,8 @@ compact a-e L1
 wait-pending-table-stats
 000008
 ----
+num-entries: 2
+num-deletions: 1
 range-deletions-bytes-estimate: 776
 
 # Same as above, except range tombstone covers multiple grandparent file boundaries.

--- a/testdata/range_del
+++ b/testdata/range_del
@@ -1387,21 +1387,29 @@ mem: 1
 wait-pending-table-stats
 000007
 ----
+num-entries: 1
+num-deletions: 1
 range-deletions-bytes-estimate: 0
 
 wait-pending-table-stats
 000006
 ----
+num-entries: 1
+num-deletions: 1
 range-deletions-bytes-estimate: 836
 
 wait-pending-table-stats
 000004
 ----
+num-entries: 1
+num-deletions: 1
 range-deletions-bytes-estimate: 1672
 
 wait-pending-table-stats
 000005
 ----
+num-entries: 2
+num-deletions: 2
 range-deletions-bytes-estimate: 1672
 
 
@@ -1438,21 +1446,29 @@ mem: 1
 wait-pending-table-stats
 000007
 ----
+num-entries: 4
+num-deletions: 0
 range-deletions-bytes-estimate: 0
 
 wait-pending-table-stats
 000006
 ----
+num-entries: 2
+num-deletions: 1
 range-deletions-bytes-estimate: 787
 
 wait-pending-table-stats
 000005
 ----
+num-entries: 3
+num-deletions: 1
 range-deletions-bytes-estimate: 68
 
 wait-pending-table-stats
 000004
 ----
+num-entries: 4
+num-deletions: 1
 range-deletions-bytes-estimate: 100
 
 # Multiple Range deletions in a table.
@@ -1485,14 +1501,20 @@ mem: 1
 wait-pending-table-stats
 000005
 ----
+num-entries: 1
+num-deletions: 1
 range-deletions-bytes-estimate: 782
 
 wait-pending-table-stats
 000006
 ----
+num-entries: 1
+num-deletions: 1
 range-deletions-bytes-estimate: 771
 
 wait-pending-table-stats
 000004
 ----
+num-entries: 2
+num-deletions: 2
 range-deletions-bytes-estimate: 1553

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -11,6 +11,8 @@ flush
 wait-pending-table-stats
 000005
 ----
+num-entries: 2
+num-deletions: 0
 range-deletions-bytes-estimate: 0
 
 compact a-c
@@ -32,6 +34,8 @@ flush
 wait-pending-table-stats
 000007
 ----
+num-entries: 1
+num-deletions: 1
 range-deletions-bytes-estimate: 784
 
 reopen
@@ -47,6 +51,8 @@ wait-loaded-initial
 wait-pending-table-stats
 000007
 ----
+num-entries: 1
+num-deletions: 1
 range-deletions-bytes-estimate: 784
 
 compact a-c
@@ -81,6 +87,8 @@ enable
 wait-pending-table-stats
 000012
 ----
+num-entries: 2
+num-deletions: 0
 range-deletions-bytes-estimate: 0
 
 # Test a file that is deleted by a compaction before its table stats are
@@ -160,9 +168,27 @@ compact a-b L4
 wait-pending-table-stats
 000011
 ----
+num-entries: 1
+num-deletions: 1
 range-deletions-bytes-estimate: 1542
 
 wait-pending-table-stats
 000012
 ----
+num-entries: 1
+num-deletions: 1
 range-deletions-bytes-estimate: 1542
+
+define snapshots=(10)
+L6
+  e.SET.5:5 a.RANGEDEL.15:z
+----
+6:
+  000004:[a-z]
+
+wait-pending-table-stats
+000004
+----
+num-entries: 2
+num-deletions: 1
+range-deletions-bytes-estimate: 26


### PR DESCRIPTION
Add a new, low-priority compaction type for compacting files in the
bottommost level of the LSM that contain tombstones that may be elided.

If no other compactions are found, the compaction picker scans L6
file metadata looking for files that contain tombstones and whose
sequence numbers fall entirely in the last snapshot stripe. If it finds
one, it creates a new L6 -> L6 compaction with the file's atomic
compaction unit.

See #838 