### PR TITLE
internal/rangedel: format keys in Fragmenter panics

### DIFF
--- a/internal/rangedel/fragmenter_test.go
+++ b/internal/rangedel/fragmenter_test.go
@@ -32,10 +32,11 @@ func parseTombstone(t *testing.T, s string) Tombstone {
 	}
 }
 
-func buildTombstones(t *testing.T, cmp base.Compare, s string) []Tombstone {
+func buildTombstones(t *testing.T, cmp base.Compare, formatKey base.FormatKey, s string) []Tombstone {
 	var tombstones []Tombstone
 	f := &Fragmenter{
-		Cmp: cmp,
+		Cmp:    cmp,
+		Format: formatKey,
 		Emit: func(fragmented []Tombstone) {
 			tombstones = append(tombstones, fragmented...)
 		},
@@ -94,6 +95,7 @@ func formatTombstones(tombstones []Tombstone) string {
 
 func TestFragmenter(t *testing.T) {
 	cmp := base.DefaultComparer.Compare
+	fmtKey := base.DefaultComparer.FormatKey
 
 	var getRe = regexp.MustCompile(`(\w+)#(\d+)`)
 
@@ -128,7 +130,7 @@ func TestFragmenter(t *testing.T) {
 					}
 				}()
 
-				tombstones := buildTombstones(t, cmp, d.Input)
+				tombstones := buildTombstones(t, cmp, fmtKey, d.Input)
 				iter = NewIter(cmp, tombstones)
 				return formatTombstones(tombstones)
 			}()
@@ -165,7 +167,8 @@ func TestFragmenterDeleted(t *testing.T) {
 		switch d.Cmd {
 		case "build":
 			f := &Fragmenter{
-				Cmp: base.DefaultComparer.Compare,
+				Cmp:    base.DefaultComparer.Compare,
+				Format: base.DefaultComparer.FormatKey,
 				Emit: func(fragmented []Tombstone) {
 				},
 			}
@@ -197,6 +200,7 @@ func TestFragmenterDeleted(t *testing.T) {
 
 func TestFragmenterFlushTo(t *testing.T) {
 	cmp := base.DefaultComparer.Compare
+	fmtKey := base.DefaultComparer.FormatKey
 
 	datadriven.RunTest(t, "testdata/fragmenter_flush_to", func(d *datadriven.TestData) string {
 		switch d.Cmd {
@@ -208,7 +212,7 @@ func TestFragmenterFlushTo(t *testing.T) {
 					}
 				}()
 
-				tombstones := buildTombstones(t, cmp, d.Input)
+				tombstones := buildTombstones(t, cmp, fmtKey, d.Input)
 				return formatTombstones(tombstones)
 			}()
 
@@ -220,6 +224,7 @@ func TestFragmenterFlushTo(t *testing.T) {
 
 func TestFragmenterTruncateAndFlushTo(t *testing.T) {
 	cmp := base.DefaultComparer.Compare
+	fmtKey := base.DefaultComparer.FormatKey
 
 	datadriven.RunTest(t, "testdata/fragmenter_truncate_and_flush_to", func(d *datadriven.TestData) string {
 		switch d.Cmd {
@@ -231,7 +236,7 @@ func TestFragmenterTruncateAndFlushTo(t *testing.T) {
 					}
 				}()
 
-				tombstones := buildTombstones(t, cmp, d.Input)
+				tombstones := buildTombstones(t, cmp, fmtKey, d.Input)
 				return formatTombstones(tombstones)
 			}()
 

--- a/internal/rangedel/seek_test.go
+++ b/internal/rangedel/seek_test.go
@@ -61,12 +61,13 @@ func (i *iterAdapter) Prev() (*base.InternalKey, []byte) {
 
 func TestSeek(t *testing.T) {
 	cmp := base.DefaultComparer.Compare
+	fmtKey := base.DefaultComparer.FormatKey
 	iter := &iterAdapter{}
 
 	datadriven.RunTest(t, "testdata/seek", func(d *datadriven.TestData) string {
 		switch d.Cmd {
 		case "build":
-			tombstones := buildTombstones(t, cmp, d.Input)
+			tombstones := buildTombstones(t, cmp, fmtKey, d.Input)
 			iter.Iter = NewIter(cmp, tombstones)
 			return formatTombstones(tombstones)
 

--- a/internal/rangedel/testdata/fragmenter
+++ b/internal/rangedel/testdata/fragmenter
@@ -44,7 +44,7 @@ build
 2:   c-e
 1: a-c
 ----
-pebble: keys must be added in order: c#2,15 > a#1,15
+pebble: keys must be added in order: c#2,RANGEDEL > a#1,RANGEDEL
 
 build
 3: a-a

--- a/internal/rangedel/testdata/fragmenter_deleted
+++ b/internal/rangedel/testdata/fragmenter_deleted
@@ -28,7 +28,7 @@ a#1,1: true
 a#2,1: true
 a#3,1: false
 l#3,1: false
-e#3,1: pebble: keys must be in order: f#3,15 > e#3,1
+e#3,1: pebble: keys must be in order: f#3,RANGEDEL > e#3,SET
 f#2,1: true
 l#2,1: true
 m#2,1: false

--- a/internal/rangedel/truncate_test.go
+++ b/internal/rangedel/truncate_test.go
@@ -15,12 +15,13 @@ import (
 
 func TestTruncate(t *testing.T) {
 	cmp := base.DefaultComparer.Compare
+	fmtKey := base.DefaultComparer.FormatKey
 	var iter base.InternalIterator
 
 	datadriven.RunTest(t, "testdata/truncate", func(d *datadriven.TestData) string {
 		switch d.Cmd {
 		case "build":
-			tombstones := buildTombstones(t, cmp, d.Input)
+			tombstones := buildTombstones(t, cmp, fmtKey, d.Input)
 			iter = NewIter(cmp, tombstones)
 			return formatTombstones(tombstones)
 

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -164,7 +164,8 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 				}
 				var tombstones []rangedel.Tombstone
 				frag := rangedel.Fragmenter{
-					Cmp: cmp,
+					Cmp:    cmp,
+					Format: formatKey,
 					Emit: func(fragmented []rangedel.Tombstone) {
 						tombstones = append(tombstones, fragmented...)
 					},

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -188,7 +188,8 @@ func (lt *levelIterTest) runBuild(d *datadriven.TestData) string {
 	})
 	var tombstones []rangedel.Tombstone
 	f := rangedel.Fragmenter{
-		Cmp: lt.cmp.Compare,
+		Cmp:    lt.cmp.Compare,
+		Format: lt.cmp.FormatKey,
 		Emit: func(fragmented []rangedel.Tombstone) {
 			tombstones = append(tombstones, fragmented...)
 		},

--- a/mem_table.go
+++ b/mem_table.go
@@ -60,6 +60,7 @@ var memTableEmptySize = func() uint32 {
 // It is safe to call get, apply, newIter, and newRangeDelIter concurrently.
 type memTable struct {
 	cmp         Compare
+	formatKey   base.FormatKey
 	equal       Equal
 	arenaBuf    []byte
 	skl         arenaskl.Skiplist
@@ -109,6 +110,7 @@ func newMemTable(opts memTableOptions) *memTable {
 
 	m := &memTable{
 		cmp:        opts.Comparer.Compare,
+		formatKey:  opts.Comparer.FormatKey,
 		equal:      opts.Comparer.Equal,
 		arenaBuf:   opts.arenaBuf,
 		writerRefs: 1,
@@ -291,7 +293,8 @@ type rangeTombstoneFrags struct {
 func (f *rangeTombstoneFrags) get(m *memTable) []rangedel.Tombstone {
 	f.once.Do(func() {
 		frag := &rangedel.Fragmenter{
-			Cmp: m.cmp,
+			Cmp:    m.cmp,
+			Format: m.formatKey,
 			Emit: func(fragmented []rangedel.Tombstone) {
 				f.tombstones = append(f.tombstones, fragmented...)
 			},

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -129,6 +129,7 @@ func TestMergingIterNextPrev(t *testing.T) {
 func TestMergingIterCornerCases(t *testing.T) {
 	memFS := vfs.NewMem()
 	cmp := DefaultComparer.Compare
+	fmtKey := DefaultComparer.FormatKey
 	opts := (*Options)(nil).EnsureDefaults()
 	var v *version
 
@@ -191,7 +192,8 @@ func TestMergingIterCornerCases(t *testing.T) {
 				w := sstable.NewWriter(f, sstable.WriterOptions{})
 				var tombstones []rangedel.Tombstone
 				frag := rangedel.Fragmenter{
-					Cmp: cmp,
+					Cmp:    cmp,
+					Format: fmtKey,
 					Emit: func(fragmented []rangedel.Tombstone) {
 						tombstones = append(tombstones, fragmented...)
 					},

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -57,7 +57,8 @@ func runBuildCmd(td *datadriven.TestData, writerOpts WriterOptions) (*WriterMeta
 	w := NewWriter(f0, writerOpts)
 	var tombstones []rangedel.Tombstone
 	f := rangedel.Fragmenter{
-		Cmp: DefaultComparer.Compare,
+		Cmp:    DefaultComparer.Compare,
+		Format: DefaultComparer.FormatKey,
 		Emit: func(fragmented []rangedel.Tombstone) {
 			tombstones = append(tombstones, fragmented...)
 		},

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -1157,6 +1157,7 @@ func (c Comparers) readerApply(r *Reader) {
 	}
 	if comparer, ok := c[r.Properties.ComparerName]; ok {
 		r.Compare = comparer.Compare
+		r.FormatKey = comparer.FormatKey
 		r.Split = comparer.Split
 	}
 }
@@ -1206,7 +1207,7 @@ func (c *cacheOpts) writerApply(w *Writer) {
 
 // FileReopenOpt is specified if this reader is allowed to reopen additional
 // file descriptors for this file. Used to take advantage of OS-level readahead.
-type FileReopenOpt struct{
+type FileReopenOpt struct {
 	FS       vfs.FS
 	Filename string
 }
@@ -1255,6 +1256,7 @@ type Reader struct {
 	footerBH          BlockHandle
 	opts              ReaderOptions
 	Compare           Compare
+	FormatKey         base.FormatKey
 	Split             Split
 	mergerOK          bool
 	tableFilter       *tableFilterReader
@@ -1542,7 +1544,8 @@ func (r *Reader) transformRangeDelV1(b []byte) ([]byte, error) {
 		restartInterval: 1,
 	}
 	frag := rangedel.Fragmenter{
-		Cmp: r.Compare,
+		Cmp:    r.Compare,
+		Format: r.FormatKey,
 		Emit: func(fragmented []rangedel.Tombstone) {
 			for i := range fragmented {
 				t := &fragmented[i]
@@ -1860,6 +1863,7 @@ func NewReader(f vfs.File, o ReaderOptions, extraOpts ...ReaderOption) (*Reader,
 
 	if r.Properties.ComparerName == "" || o.Comparer.Name == r.Properties.ComparerName {
 		r.Compare = o.Comparer.Compare
+		r.FormatKey = o.Comparer.FormatKey
 		r.Split = o.Comparer.Split
 	}
 

--- a/sstable/testdata/writer
+++ b/sstable/testdata/writer
@@ -113,7 +113,7 @@ build
 b.RANGEDEL.1:c
 a.RANGEDEL.2:b
 ----
-pebble: keys must be added in order: b#1,15 > a#2,15
+pebble: keys must be added in order: b#1,RANGEDEL > a#2,RANGEDEL
 
 build-raw
 .RANGEDEL.1:b

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -169,7 +169,7 @@ compact         1   2.3 K          (size == estimated-debt)
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.4 K    5.9%  (score == hit-rate)
- tcache         1   608 B    0.0%  (score == hit-rate)
+ tcache         1   616 B    0.0%  (score == hit-rate)
  titers         0
  filter         -       -    0.0%  (score == utility)
 

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -33,7 +33,7 @@ compact         0     0 B          (size == estimated-debt)
 zmemtbl         1   256 K
    ztbl         0     0 B
  bcache         4   698 B    0.0%  (score == hit-rate)
- tcache         1   608 B    0.0%  (score == hit-rate)
+ tcache         1   616 B    0.0%  (score == hit-rate)
  titers         1
  filter         -       -    0.0%  (score == utility)
 
@@ -130,7 +130,7 @@ compact         1     0 B          (size == estimated-debt)
 zmemtbl         1   256 K
    ztbl         1   771 B
  bcache         4   698 B   33.3%  (score == hit-rate)
- tcache         1   608 B   50.0%  (score == hit-rate)
+ tcache         1   616 B   50.0%  (score == hit-rate)
  titers         1
  filter         -       -    0.0%  (score == utility)
 


### PR DESCRIPTION
Propagate the `base.FormatKey` type to `rangedel.Fragmenter`, and use it
format keys in the event of a panic. The raw key can cause tools to treat the
log file as a binary file and generally make it more difficult to debug.

Motivated by cockroachdb/cockroach#50963.