### PR TITLE
db: mark corruption errors

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -321,7 +321,7 @@ func (b *Batch) Apply(batch *Batch, _ *WriteOptions) error {
 		return nil
 	}
 	if len(batch.data) < batchHeaderLen {
-		return errors.New("pebble: invalid batch")
+		return base.CorruptionErrorf("pebble: invalid batch")
 	}
 
 	offset := len(b.data)
@@ -654,7 +654,7 @@ func (b *Batch) Repr() []byte {
 // Batch is no longer in use.
 func (b *Batch) SetRepr(data []byte) error {
 	if len(data) < batchHeaderLen {
-		return errors.New("invalid batch")
+		return base.CorruptionErrorf("invalid batch")
 	}
 	b.data = data
 	b.count = uint64(binary.LittleEndian.Uint32(b.countData()))
@@ -980,7 +980,7 @@ func (i *batchIter) Value() []byte {
 	offset, _, keyEnd := i.iter.KeyInfo()
 	data := i.batch.data
 	if len(data[offset:]) == 0 {
-		i.err = errors.New("corrupted batch")
+		i.err = base.CorruptionErrorf("corrupted batch")
 		return nil
 	}
 
@@ -1363,12 +1363,12 @@ func (i *flushableBatchIter) Key() *InternalKey {
 func (i *flushableBatchIter) Value() []byte {
 	p := i.data[i.offsets[i.index].offset:]
 	if len(p) == 0 {
-		i.err = errors.New("corrupted batch")
+		i.err = base.CorruptionErrorf("corrupted batch")
 		return nil
 	}
 	kind := InternalKeyKind(p[0])
 	if kind > InternalKeyKindMax {
-		i.err = errors.New("corrupted batch")
+		i.err = base.CorruptionErrorf("corrupted batch")
 		return nil
 	}
 	var value []byte
@@ -1378,7 +1378,7 @@ func (i *flushableBatchIter) Value() []byte {
 		keyEnd := i.offsets[i.index].keyEnd
 		_, value, ok = batchDecodeStr(i.data[keyEnd:])
 		if !ok {
-			i.err = errors.New("corrupted batch")
+			i.err = base.CorruptionErrorf("corrupted batch")
 			return nil
 		}
 	}
@@ -1462,12 +1462,12 @@ func (i flushFlushableBatchIter) Prev() (*InternalKey, []byte) {
 func (i flushFlushableBatchIter) valueSize() uint64 {
 	p := i.data[i.offsets[i.index].offset:]
 	if len(p) == 0 {
-		i.err = errors.New("corrupted batch")
+		i.err = base.CorruptionErrorf("corrupted batch")
 		return 0
 	}
 	kind := InternalKeyKind(p[0])
 	if kind > InternalKeyKindMax {
-		i.err = errors.New("corrupted batch")
+		i.err = base.CorruptionErrorf("corrupted batch")
 		return 0
 	}
 	var length uint64
@@ -1476,7 +1476,7 @@ func (i flushFlushableBatchIter) valueSize() uint64 {
 		keyEnd := i.offsets[i.index].keyEnd
 		v, n := binary.Uvarint(i.data[keyEnd:])
 		if n <= 0 {
-			i.err = errors.New("corrupted batch")
+			i.err = base.CorruptionErrorf("corrupted batch")
 			return 0
 		}
 		length = v + uint64(n)

--- a/compaction.go
+++ b/compaction.go
@@ -517,13 +517,13 @@ func (c *compaction) newInputIter(newIters tableNewIters) (_ internalIterator, r
 		err := manifest.CheckOrdering(c.cmp, c.formatKey,
 			manifest.Level(c.startLevel.level), c.startLevel.files.Iter())
 		if err != nil {
-			c.logger.Fatalf("%s", err)
+			return nil, err
 		}
 	}
 	err := manifest.CheckOrdering(c.cmp, c.formatKey,
 		manifest.Level(c.outputLevel.level), c.outputLevel.files.Iter())
 	if err != nil {
-		c.logger.Fatalf("%s", err)
+		return nil, err
 	}
 
 	iters := make([]internalIterator, 0, 2*c.startLevel.files.Len()+1)

--- a/compaction_iter.go
+++ b/compaction_iter.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/bytealloc"
 	"github.com/cockroachdb/pebble/internal/rangedel"
 )
@@ -337,10 +338,13 @@ func (i *compactionIter) Next() (*InternalKey, []byte) {
 				}
 				return &i.key, i.value
 			}
+			if i.err != nil {
+				i.err = base.MarkCorruptionError(i.err)
+			}
 			return nil, nil
 
 		default:
-			i.err = errors.Errorf("invalid internal key kind: %d", errors.Safe(i.iterKey.Kind()))
+			i.err = base.CorruptionErrorf("invalid internal key kind: %d", errors.Safe(i.iterKey.Kind()))
 			return nil, nil
 		}
 	}
@@ -492,7 +496,7 @@ func (i *compactionIter) mergeNext(valueMerger ValueMerger) stripeChangeType {
 			}
 
 		default:
-			i.err = errors.Errorf("invalid internal key kind: %d", errors.Safe(i.iterKey.Kind()))
+			i.err = base.CorruptionErrorf("invalid internal key kind: %d", errors.Safe(i.iterKey.Kind()))
 			return sameStripeSkippable
 		}
 	}
@@ -528,7 +532,7 @@ func (i *compactionIter) singleDeleteNext() bool {
 			continue
 
 		default:
-			i.err = errors.Errorf("invalid internal key kind: %d", errors.Safe(i.iterKey.Kind()))
+			i.err = base.CorruptionErrorf("invalid internal key kind: %d", errors.Safe(i.iterKey.Kind()))
 			return false
 		}
 	}

--- a/ingest.go
+++ b/ingest.go
@@ -33,11 +33,11 @@ func sstableKeyCompare(userCmp Compare, a, b InternalKey) int {
 
 func ingestValidateKey(opts *Options, key *InternalKey) error {
 	if key.Kind() == InternalKeyKindInvalid {
-		return errors.Errorf("pebble: external sstable has corrupted key: %s",
+		return base.CorruptionErrorf("pebble: external sstable has corrupted key: %s",
 			key.Pretty(opts.Comparer.FormatKey))
 	}
 	if key.SeqNum() != 0 {
-		return errors.Errorf("pebble: external sstable has non-zero seqnum: %s",
+		return base.CorruptionErrorf("pebble: external sstable has non-zero seqnum: %s",
 			key.Pretty(opts.Comparer.FormatKey))
 	}
 	return nil

--- a/internal/base/error.go
+++ b/internal/base/error.go
@@ -4,7 +4,27 @@
 
 package base
 
-import "github.com/cockroachdb/errors"
+import (
+	"github.com/cockroachdb/errors"
+)
 
 // ErrNotFound means that a get or delete call did not find the requested key.
 var ErrNotFound = errors.New("pebble: not found")
+
+// ErrCorruption is a marker to indicate that data in a file (WAL, MANIFEST,
+// sstable) isn't in the expected format.
+var ErrCorruption = errors.New("pebble: corruption")
+
+// MarkCorruptionError marks given error as a corruption error.
+func MarkCorruptionError(err error) error {
+	if errors.Is(err, ErrCorruption) {
+		return err
+	}
+	return errors.Mark(err, ErrCorruption)
+}
+
+// CorruptionErrorf formats according to a format specifier and returns
+// the string as an error value that is marked as a corruption error.
+func CorruptionErrorf(format string, args ...interface{}) error {
+	return errors.Mark(errors.Newf(format, args...), ErrCorruption)
+}

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -41,7 +41,9 @@ func readManifest(filename string) (*Version, error) {
 			return nil, err
 		}
 		var bve BulkVersionEdit
-		bve.Accumulate(&ve)
+		if err := bve.Accumulate(&ve); err != nil {
+			return nil, err
+		}
 		if v, _, err = bve.Apply(v, base.DefaultComparer.Compare, base.DefaultFormatter, 10<<20); err != nil {
 			return nil, err
 		}

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -341,7 +341,9 @@ func TestVersionEditApply(t *testing.T) {
 				}
 
 				bve := BulkVersionEdit{}
-				bve.Accumulate(ve)
+				if err := bve.Accumulate(ve); err != nil {
+					return err.Error()
+				}
 				newv, zombies, err := bve.Apply(v, base.DefaultComparer.Compare, base.DefaultFormatter, 10<<20)
 				if err != nil {
 					return err.Error()

--- a/internal/record/record.go
+++ b/internal/record/record.go
@@ -141,12 +141,12 @@ var (
 
 	// ErrZeroedChunk is returned if a chunk is encountered that is zeroed. This
 	// usually occurs due to log file preallocation.
-	ErrZeroedChunk = errors.New("pebble/record: zeroed chunk")
+	ErrZeroedChunk = base.CorruptionErrorf("pebble/record: zeroed chunk")
 
 	// ErrInvalidChunk is returned if a chunk is encountered with an invalid
 	// header, length, or checksum. This usually occurs when a log is recycled,
 	// but can also occur due to corruption.
-	ErrInvalidChunk = errors.New("pebble/record: invalid chunk")
+	ErrInvalidChunk = base.CorruptionErrorf("pebble/record: invalid chunk")
 )
 
 // IsInvalidRecord returns true if the error matches one of the error types
@@ -185,7 +185,7 @@ type Reader struct {
 
 // NewReader returns a new reader. If the file contains records encoded using
 // the recyclable record format, then the log number in those records must
-// match the specifed logNum.
+// match the specified logNum.
 func NewReader(r io.Reader, logNum base.FileNum) *Reader {
 	return &Reader{
 		r:        r,

--- a/iterator.go
+++ b/iterator.go
@@ -9,6 +9,7 @@ import (
 	"io"
 
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
 )
 
 type iterPos int8
@@ -117,7 +118,7 @@ func (i *Iterator) findNextEntry() bool {
 			return i.err == nil
 
 		default:
-			i.err = errors.Errorf("pebble: invalid internal key kind: %d", errors.Safe(key.Kind()))
+			i.err = base.CorruptionErrorf("pebble: invalid internal key kind: %d", errors.Safe(key.Kind()))
 			return false
 		}
 	}
@@ -223,7 +224,7 @@ func (i *Iterator) findPrevEntry() bool {
 			continue
 
 		default:
-			i.err = errors.Errorf("pebble: invalid internal key kind: %d", errors.Safe(key.Kind()))
+			i.err = base.CorruptionErrorf("pebble: invalid internal key kind: %d", errors.Safe(key.Kind()))
 			return false
 		}
 	}
@@ -300,7 +301,7 @@ func (i *Iterator) mergeNext(key InternalKey, valueMerger ValueMerger) {
 			continue
 
 		default:
-			i.err = errors.Errorf("pebble: invalid internal key kind: %d", errors.Safe(key.Kind()))
+			i.err = base.CorruptionErrorf("pebble: invalid internal key kind: %d", errors.Safe(key.Kind()))
 			return
 		}
 	}

--- a/mem_table.go
+++ b/mem_table.go
@@ -183,7 +183,7 @@ func (m *memTable) prepare(batch *Batch) error {
 
 func (m *memTable) apply(batch *Batch, seqNum uint64) error {
 	if seqNum < m.logSeqNum {
-		return errors.Errorf("pebble: batch seqnum %d is less than memtable creation seqnum %d",
+		return base.CorruptionErrorf("pebble: batch seqnum %d is less than memtable creation seqnum %d",
 			errors.Safe(seqNum), errors.Safe(m.logSeqNum))
 	}
 
@@ -213,8 +213,8 @@ func (m *memTable) apply(batch *Batch, seqNum uint64) error {
 		}
 	}
 	if seqNum != startSeqNum+uint64(batch.Count()) {
-		panic(errors.Errorf("pebble: inconsistent batch count: %d vs %d",
-			errors.Safe(seqNum), errors.Safe(startSeqNum+uint64(batch.Count()))))
+		return base.CorruptionErrorf("pebble: inconsistent batch count: %d vs %d",
+			errors.Safe(seqNum), errors.Safe(startSeqNum+uint64(batch.Count())))
 	}
 	if tombstoneCount != 0 {
 		m.tombstones.invalidate(tombstoneCount)

--- a/open.go
+++ b/open.go
@@ -502,7 +502,7 @@ func (d *DB) replayWAL(
 		}
 
 		if buf.Len() < batchHeaderLen {
-			return 0, errors.Errorf("pebble: corrupt log file %q (num %s)",
+			return 0, base.CorruptionErrorf("pebble: corrupt log file %q (num %s)",
 				filename, errors.Safe(logNum))
 		}
 

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -8,7 +8,6 @@ import (
 	"encoding/binary"
 	"unsafe"
 
-	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
 )
@@ -256,7 +255,7 @@ func (i *blockIter) String() string {
 func (i *blockIter) init(cmp Compare, block block, globalSeqNum uint64) error {
 	numRestarts := int32(binary.LittleEndian.Uint32(block[len(block)-4:]))
 	if numRestarts == 0 {
-		return errors.New("pebble/table: invalid table (block has no restart points)")
+		return base.CorruptionErrorf("pebble/table: invalid table (block has no restart points)")
 	}
 	i.cmp = cmp
 	i.restarts = int32(len(block)) - 4*(1+numRestarts)

--- a/sstable/raw_block.go
+++ b/sstable/raw_block.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"unsafe"
 
-	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
 )
 
 type rawBlockWriter struct {
@@ -57,7 +57,7 @@ func newRawBlockIter(cmp Compare, block block) (*rawBlockIter, error) {
 func (i *rawBlockIter) init(cmp Compare, block block) error {
 	numRestarts := int32(binary.LittleEndian.Uint32(block[len(block)-4:]))
 	if numRestarts == 0 {
-		return errors.New("pebble/table: invalid table (block has no restart points)")
+		return base.CorruptionErrorf("pebble/table: invalid table (block has no restart points)")
 	}
 	i.cmp = cmp
 	i.restarts = int32(len(block)) - 4*(1+numRestarts)

--- a/testdata/compaction_check_ordering
+++ b/testdata/compaction_check_ordering
@@ -16,7 +16,7 @@ L0
   c.SET.3-d.SET.4
   a.SET.1-b.SET.2
 ----
-fatal: L0 files 000001 and 000002 are not properly ordered: <#3-#4> vs <#1-#2>
+L0 files 000001 and 000002 are not properly ordered: <#3-#4> vs <#1-#2>
 
 # Seqnum overlaps are allowed in L0 as long as no key ranges overlap.
 check-ordering
@@ -31,14 +31,14 @@ L0
   a.SET.3-d.SET.3
   a.SET.1-b.SET.2
 ----
-fatal: L0 files 000001 and 000002 are not properly ordered: <#3-#3> vs <#1-#2>
+L0 files 000001 and 000002 are not properly ordered: <#3-#3> vs <#1-#2>
 
 check-ordering
 L0
   a.SET.2-d.SET.4
   a.SET.3-b.SET.3
 ----
-fatal: L0 files 000001 and 000002 are not properly ordered: <#2-#4> vs <#3-#3>
+L0 files 000001 and 000002 are not properly ordered: <#2-#4> vs <#3-#3>
 
 check-ordering
 L0
@@ -57,7 +57,7 @@ check-ordering
 L1
   b.SET.1-a.SET.2
 ----
-fatal: L1 : file 000001 has inconsistent bounds: b#1,SET vs a#2,SET
+L1 : file 000001 has inconsistent bounds: b#1,SET vs a#2,SET
 
 check-ordering
 L1
@@ -71,7 +71,7 @@ L1
   a.SET.1-b.SET.2
   d.SET.3-c.SET.4
 ----
-fatal: L1 : file 000002 has inconsistent bounds: d#3,SET vs c#4,SET
+L1 : file 000002 has inconsistent bounds: d#3,SET vs c#4,SET
 
 check-ordering
 L1
@@ -85,14 +85,14 @@ L1
   a.SET.1-b.SET.2
   b.SET.2-d.SET.4
 ----
-fatal: L1 files 000001 and 000002 have overlapping ranges: [a#1,SET-b#2,SET] vs [b#2,SET-d#4,SET]
+L1 files 000001 and 000002 have overlapping ranges: [a#1,SET-b#2,SET] vs [b#2,SET-d#4,SET]
 
 check-ordering
 L1
   a.SET.1-c.SET.2
   b.SET.3-d.SET.4
 ----
-fatal: L1 files 000001 and 000002 have overlapping ranges: [a#1,SET-c#2,SET] vs [b#3,SET-d#4,SET]
+L1 files 000001 and 000002 have overlapping ranges: [a#1,SET-c#2,SET] vs [b#3,SET-d#4,SET]
 
 check-ordering
 L1
@@ -109,4 +109,4 @@ L2
   b.SET.3-d.SET.4
   c.SET.5-e.SET.6
 ----
-fatal: L2 files 000002 and 000003 have overlapping ranges: [b#3,SET-d#4,SET] vs [c#5,SET-e#6,SET]
+L2 files 000002 and 000003 have overlapping ranges: [b#3,SET-d#4,SET] vs [c#5,SET-e#6,SET]

--- a/tool/db.go
+++ b/tool/db.go
@@ -372,7 +372,9 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 			if err != nil {
 				return err
 			}
-			bve.Accumulate(&ve)
+			if err := bve.Accumulate(&ve); err != nil {
+				return err
+			}
 			if ve.ComparerName != "" {
 				cmp = d.comparers[ve.ComparerName]
 				d.fmtKey.setForComparer(ve.ComparerName, d.comparers)

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -131,7 +131,10 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 					fmt.Fprintf(stdout, "%s\n", err)
 					break
 				}
-				bve.Accumulate(&ve)
+				if err := bve.Accumulate(&ve); err != nil {
+					fmt.Fprintf(stdout, "%s\n", err)
+					break
+				}
 
 				empty := true
 				fmt.Fprintf(stdout, "%d\n", offset)
@@ -242,7 +245,11 @@ func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
 					break
 				}
 				var bve manifest.BulkVersionEdit
-				bve.Accumulate(&ve)
+				if err := bve.Accumulate(&ve); err != nil {
+					fmt.Fprintf(stderr, "%s\n", err)
+					ok = false
+					return
+				}
 
 				empty := true
 				if ve.ComparerName != "" {


### PR DESCRIPTION
For better error handling, we need to classify errors to decide their severity and accordingly handle them. This change marks errors that indicate data corruption in WAL, MANIFEST, sstable. In future when we introduce ErrorHandler, these will be treated as unrecoverable errors.