### PR TITLE
crl-release-20.1: db: fix tombstone elision, grandparent limit bug

### DIFF
--- a/internal/manifest/testdata/version_check_ordering
+++ b/internal/manifest/testdata/version_check_ordering
@@ -142,7 +142,7 @@ check-ordering
 L1
   b.SET.1-a.SET.2
 ----
-L1 file 000001 has inconsistent bounds: b#1,SET vs a#2,SET
+L1 : file 000001 has inconsistent bounds: b#1,SET vs a#2,SET
 1:
   000001:[b#1,SET-a#2,SET]
 
@@ -158,7 +158,7 @@ L1
   a.SET.1-b.SET.2
   d.SET.3-c.SET.4
 ----
-L1 file 000002 has inconsistent bounds: d#3,SET vs c#4,SET
+L1 : file 000002 has inconsistent bounds: d#3,SET vs c#4,SET
 1:
   000001:[a#1,SET-b#2,SET]
   000002:[d#3,SET-c#4,SET]

--- a/internal/rangedel/fragmenter.go
+++ b/internal/rangedel/fragmenter.go
@@ -328,6 +328,16 @@ func (f *Fragmenter) FlushTo(key []byte) {
 	}
 }
 
+// Start returns the start key of the first tombstone in the pending buffer,
+// or nil if there are no pending tombstones. The start key of all pending
+// tombstones is the same as that of the first one.
+func (f *Fragmenter) Start() []byte {
+	if len(f.pending) > 0 {
+		return f.pending[0].Start.UserKey
+	}
+	return nil
+}
+
 // Flushes all pending tombstones up to key (exclusive).
 func (f *Fragmenter) truncateAndFlush(key []byte) {
 	f.flushedKey = append(f.flushedKey[:0], key...)

--- a/testdata/compaction_check_ordering
+++ b/testdata/compaction_check_ordering
@@ -57,7 +57,7 @@ check-ordering
 L1
   b.SET.1-a.SET.2
 ----
-fatal: L1 file 000001 has inconsistent bounds: b#1,SET vs a#2,SET
+fatal: L1 : file 000001 has inconsistent bounds: b#1,SET vs a#2,SET
 
 check-ordering
 L1
@@ -71,7 +71,7 @@ L1
   a.SET.1-b.SET.2
   d.SET.3-c.SET.4
 ----
-fatal: L1 file 000002 has inconsistent bounds: d#3,SET vs c#4,SET
+fatal: L1 : file 000002 has inconsistent bounds: d#3,SET vs c#4,SET
 
 check-ordering
 L1

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -208,6 +208,42 @@ compact a-e L1
   000006:[a#0,SET-b#0,SET]
   000007:[c#0,SET-d#0,SET]
 
+# An elided range tombstone is the first item encountered by a compaction,
+# and the grandparent limit set by it extends to the next item, also a range
+# tombstone. The first item should be elided, and the second item should
+# reset the grandparent limit.
+
+define target-file-sizes=(1, 1, 1, 1)
+L1
+  a.RANGEDEL.4:d
+L1
+  grandparent.RANGEDEL.2:z
+  h.SET.3:v
+L2
+  grandparent.SET.1:v
+L3
+  grandparent.SET.0:v
+L3
+  m.SET.0:v
+----
+1:
+  000004:[a-d]
+  000005:[grandparent-z]
+2:
+  000006:[grandparent-grandparent]
+3:
+  000007:[grandparent-grandparent]
+  000008:[m-m]
+
+compact a-h L1
+----
+2:
+  000009:[grandparent#2,RANGEDEL-m#72057594037927935,RANGEDEL]
+  000010:[m#2,RANGEDEL-z#72057594037927935,RANGEDEL]
+3:
+  000007:[grandparent#0,SET-grandparent#0,SET]
+  000008:[m#0,SET-m#0,SET]
+
 # Setup such that grandparent overlap limit is exceeded multiple times at the same user key ("b").
 # Ensures the compaction output files are non-overlapping.
 


### PR DESCRIPTION
Backport of #809. The patch did not apply cleanly, so it
deserves a critical eye.