### PR TITLE
db: compute file count and size metrics incrementally

### DIFF
--- a/cmd/pebble/compact.go
+++ b/cmd/pebble/compact.go
@@ -235,7 +235,7 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	stopSamplingRAmp := startSamplingRAmp(rd)
 
 	var replayedCount int
-	var sizeSum, sizeCount uint64
+	var sizeSum, sizeCount int64
 	var ref *manifest.Version
 	for _, li := range hist {
 		// Maintain ref as the reference database's version for calculating
@@ -387,7 +387,7 @@ func runReplay(cmd *cobra.Command, args []string) error {
 		float64(beforeSize)/float64(afterSize),
 		humanize.Int64(int64(beforeSize)),
 		humanize.Int64(int64(afterSize)),
-		humanize.Uint64(sizeSum/sizeCount))
+		humanize.Int64(sizeSum/sizeCount))
 	return nil
 }
 
@@ -405,8 +405,8 @@ func totalWriteAmp(m *pebble.Metrics) float64 {
 	return total.WriteAmp()
 }
 
-func totalSize(m *pebble.Metrics) uint64 {
-	sz := m.WAL.Size
+func totalSize(m *pebble.Metrics) int64 {
+	sz := int64(m.WAL.Size)
 	for _, lm := range m.Levels {
 		sz += lm.Size
 	}

--- a/data_test.go
+++ b/data_test.go
@@ -485,7 +485,7 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 		jobID := d.mu.nextJobID
 		d.mu.nextJobID++
 		d.mu.versions.logLock()
-		if err := d.mu.versions.logAndApply(jobID, ve, nil, d.dataDir, func() []compactionInfo {
+		if err := d.mu.versions.logAndApply(jobID, ve, newFileMetrics(ve.NewFiles), d.dataDir, func() []compactionInfo {
 			return nil
 		}); err != nil {
 			return nil, err

--- a/flush_external.go
+++ b/flush_external.go
@@ -63,7 +63,12 @@ func flushExternalTable(untypedDB interface{}, path string, originalMeta *fileMe
 		NewFiles: []newFileEntry{newFileEntry{Level: 0, Meta: m}},
 	}
 	metrics := map[int]*LevelMetrics{
-		0: &LevelMetrics{BytesIngested: m.Size, TablesIngested: 1},
+		0: &LevelMetrics{
+			NumFiles:       1,
+			Size:           int64(m.Size),
+			BytesIngested:  m.Size,
+			TablesIngested: 1,
+		},
 	}
 	err := d.mu.versions.logAndApply(jobID, ve, metrics, d.dataDir, func() []compactionInfo {
 		return d.getInProgressCompactionInfoLocked(nil)

--- a/ingest.go
+++ b/ingest.go
@@ -676,6 +676,8 @@ func (d *DB) ingestApply(jobID int, meta []*fileMetadata) (*versionEdit, error) 
 			levelMetrics = &LevelMetrics{}
 			metrics[f.Level] = levelMetrics
 		}
+		levelMetrics.NumFiles++
+		levelMetrics.Size += int64(m.Size)
 		levelMetrics.BytesIngested += m.Size
 		levelMetrics.TablesIngested++
 	}

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -553,6 +553,15 @@ func TestIngest(t *testing.T) {
 		case "lsm":
 			return runLSMCmd(td, d)
 
+		case "metrics":
+			// The asynchronous loading of table stats can change metrics, so
+			// wait for all the tables' stats to be loaded.
+			d.mu.Lock()
+			d.waitTableStats()
+			d.mu.Unlock()
+
+			return d.Metrics().String()
+
 		case "wait-pending-table-stats":
 			return runTableStatsCmd(td, d)
 

--- a/metrics.go
+++ b/metrics.go
@@ -38,7 +38,7 @@ type LevelMetrics struct {
 	// The total number of files in the level.
 	NumFiles int64
 	// The total size in bytes of the files in the level.
-	Size uint64
+	Size int64
 	// The level's compaction score.
 	Score float64
 	// The number of incoming bytes from other levels read during
@@ -74,6 +74,8 @@ type LevelMetrics struct {
 
 // Add updates the counter metrics for the level.
 func (m *LevelMetrics) Add(u *LevelMetrics) {
+	m.NumFiles += u.NumFiles
+	m.Size += u.Size
 	m.BytesIn += u.BytesIn
 	m.BytesIngested += u.BytesIngested
 	m.BytesMoved += u.BytesMoved
@@ -100,7 +102,7 @@ func (m *LevelMetrics) WriteAmp() float64 {
 func (m *LevelMetrics) format(buf *bytes.Buffer, score string) {
 	fmt.Fprintf(buf, "%9d %7s %7s %7s %7s %7s %7s %7s %7s %7s %7s %7d %7.1f\n",
 		m.NumFiles,
-		humanize.IEC.Uint64(m.Size),
+		humanize.IEC.Int64(m.Size),
 		score,
 		humanize.IEC.Uint64(m.BytesIn),
 		humanize.IEC.Uint64(m.BytesIngested),
@@ -199,8 +201,6 @@ func (m *Metrics) Total() LevelMetrics {
 		l := &m.Levels[level]
 		total.Add(l)
 		total.Sublevels += l.Sublevels
-		total.NumFiles += l.NumFiles
-		total.Size += l.Size
 	}
 	// Compute total bytes-in as the bytes written to the WAL + bytes ingested.
 	total.BytesIn = m.WAL.BytesWritten + total.BytesIngested
@@ -278,8 +278,6 @@ func (m *Metrics) String() string {
 		l.format(&buf, score)
 		total.Add(l)
 		total.Sublevels += l.Sublevels
-		total.NumFiles += l.NumFiles
-		total.Size += l.Size
 	}
 	// Compute total bytes-in as the bytes written to the WAL + bytes ingested.
 	total.BytesIn = m.WAL.BytesWritten + total.BytesIngested

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -47,7 +47,7 @@ func TestMetricsFormat(t *testing.T) {
 		base := uint64((i + 1) * 100)
 		l.Sublevels = int32(i + 1)
 		l.NumFiles = int64(base) + 1
-		l.Size = base + 2
+		l.Size = int64(base) + 2
 		l.Score = float64(base) + 3
 		l.BytesIn = base + 4
 		l.BytesIngested = base + 4

--- a/open.go
+++ b/open.go
@@ -310,7 +310,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		// newLogNum. There should be no difference in using either value.
 		ve.MinUnflushedLogNum = newLogNum
 		d.mu.versions.logLock()
-		if err := d.mu.versions.logAndApply(jobID, &ve, nil, d.dataDir, func() []compactionInfo {
+		if err := d.mu.versions.logAndApply(jobID, &ve, newFileMetrics(ve.NewFiles), d.dataDir, func() []compactionInfo {
 			return nil
 		}); err != nil {
 			return nil, err

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -29,6 +29,28 @@ lsm
 6:
   000006:[a#1,SET-b#1,SET]
 
+metrics
+----
+__level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___r-amp___w-amp
+    WAL         1     0 B       -     0 B       -       -       -       -     0 B       -       -       -     0.0
+      0         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      2         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      3         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      4         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      6         1   833 B       -     0 B   833 B       1     0 B       0     0 B       0     0 B       1     0.0
+  total         1   833 B       -   833 B   833 B       1     0 B       0   833 B       0     0 B       1     1.0
+  flush         0
+compact         0     0 B          (size == estimated-debt)
+ memtbl         1   256 K
+zmemtbl         0     0 B
+   ztbl         0     0 B
+ bcache         8   1.5 K   46.7%  (score == hit-rate)
+ tcache         1   616 B   50.0%  (score == hit-rate)
+ titers         0
+ filter         -       -    0.0%  (score == utility)
+
 iter
 seek-ge a
 next


### PR DESCRIPTION
Previously, level sizes were recomputed from scratch with each new
version. This showed up in CPU profiles of stores with large numbers of
sstables (#718). This change updates logAndApply callers to populate the
passed LevelMetrics' `NumFiles` and `Size` fields with the incremental
diff of each version edit.