### PR TITLE
internal/manifest: use LevelMetadata in L0 sublevels

### DIFF
--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -12,13 +12,18 @@ type LevelMetadata struct {
 	files []*FileMetadata
 }
 
+// Len returns the number of files within the level.
+func (lm *LevelMetadata) Len() int {
+	return len(lm.files)
+}
+
 // Iter constructs a LevelIterator over the entire level.
-func (lm LevelMetadata) Iter() LevelIterator {
+func (lm *LevelMetadata) Iter() LevelIterator {
 	return LevelIterator{files: lm.files, end: len(lm.files)}
 }
 
 // Slice constructs a slice containing the entire level.
-func (lm LevelMetadata) Slice() LevelSlice {
+func (lm *LevelMetadata) Slice() LevelSlice {
 	return LevelSlice{files: lm.files, end: len(lm.files)}
 }
 

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -400,7 +400,7 @@ func (v *Version) InitL0Sublevels(
 	cmp Compare, formatKey base.FormatKey, flushSplitBytes int64,
 ) error {
 	var err error
-	v.L0Sublevels, err = NewL0Sublevels(v.Levels[0].Slice().Collect(), cmp, formatKey, flushSplitBytes)
+	v.L0Sublevels, err = NewL0Sublevels(&v.Levels[0], cmp, formatKey, flushSplitBytes)
 	return err
 }
 

--- a/tool/lsm.go
+++ b/tool/lsm.go
@@ -240,15 +240,12 @@ func (l *lsmT) buildEdits(edits []*manifest.VersionEdit) {
 			edit.Added[nf.Level] = append(edit.Added[nf.Level], nf.Meta.FileNum)
 			currentFiles[nf.Level] = append(currentFiles[nf.Level], nf.Meta)
 		}
-		sublevels, err := manifest.NewL0Sublevels(currentFiles[0], l.cmp.Compare, l.fmtKey.fn, 0)
-		if err != nil {
-			panic(err)
-		}
+		v := manifest.NewVersion(l.cmp.Compare, l.fmtKey.fn, 0, currentFiles)
 		edit.Sublevels = make(map[base.FileNum]int)
-		for sublevel, files := range sublevels.Levels {
+		for sublevel, files := range v.L0Sublevels.Levels {
 			for _, f := range files {
 				if len(l.state.Edits) > 0 {
-					lastEdit := l.state.Edits[len(l.state.Edits) - 1]
+					lastEdit := l.state.Edits[len(l.state.Edits)-1]
 					if sublevel2, ok := lastEdit.Sublevels[f.FileNum]; ok && sublevel == sublevel2 {
 						continue
 					}


### PR DESCRIPTION
Refactor the L0 sublevels code to take a `*LevelMetadata` and avoid
direct use of the underlying `[]*FileMetadata`. The L0 sublevel
data structures still build their own `[]*FileMetadata` slices which I
don't intend on changing, but this change will avoid the unnecessary
copying of the entire L0 btree into a slice.