### PR TITLE
db: clear the applied flag in Batch.Reset()

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -767,6 +767,7 @@ func (b *Batch) init(cap int) {
 func (b *Batch) Reset() {
 	b.count = 0
 	b.countRangeDels = 0
+	atomic.StoreUint32(&b.applied, 0)
 	if b.data != nil {
 		if cap(b.data) > batchMaxRetainedSize {
 			// If the capacity of the buffer is larger than our maximum

--- a/batch.go
+++ b/batch.go
@@ -275,24 +275,15 @@ func (b *Batch) release() {
 	// but necessary so that we can use atomic.StoreUint32 for the Batch.applied
 	// field. Without using an atomic to clear that field the Go race detector
 	// complains.
+	indexed := b.index != nil
 	b.Reset()
 	b.cmp = nil
 	b.formatKey = nil
 	b.abbreviatedKey = nil
-	b.memTableSize = 0
 
-	b.deferredOp = DeferredBatchOp{}
-	b.tombstones = nil
-	b.flushable = nil
-	b.commit = sync.WaitGroup{}
-	b.commitErr = nil
-	atomic.StoreUint32(&b.applied, 0)
-
-	if b.index == nil {
+	if !indexed {
 		batchPool.Put(b)
 	} else {
-		b.index.Reset()
-		b.index, b.rangeDelIndex = nil, nil
 		indexedBatchPool.Put((*indexedBatch)(unsafe.Pointer(b)))
 	}
 }
@@ -767,7 +758,17 @@ func (b *Batch) init(cap int) {
 func (b *Batch) Reset() {
 	b.count = 0
 	b.countRangeDels = 0
+	b.memTableSize = 0
+	b.deferredOp = DeferredBatchOp{}
+	b.tombstones = nil
+	b.flushable = nil
+	b.commit = sync.WaitGroup{}
+	b.commitErr = nil
 	atomic.StoreUint32(&b.applied, 0)
+	if b.index != nil {
+		b.index.Reset()
+		b.index, b.rangeDelIndex = nil, nil
+	}
 	if b.data != nil {
 		if cap(b.data) > batchMaxRetainedSize {
 			// If the capacity of the buffer is larger than our maximum

--- a/batch_test.go
+++ b/batch_test.go
@@ -250,7 +250,7 @@ func TestIndexedBatchReset(t *testing.T) {
 		}
 		return count
 	}
-	contains := func(ib *Batch) bool {
+	contains := func(ib *Batch, key, value string) bool {
 		found := false
 		iter := ib.NewIter(nil)
 		defer iter.Close()
@@ -266,14 +266,14 @@ func TestIndexedBatchReset(t *testing.T) {
 	b.Set([]byte(key), []byte(value), nil)
 	require.Equal(t, 1, indexCount(b.index))
 	require.Equal(t, 1, count(b))
-	require.True(t, contains(b))
+	require.True(t, contains(b, key, value))
 
 	// Use range delete to delete the above inserted key-value pair.
 	b.DeleteRange([]byte(key), []byte(value), nil)
 	require.NotNil(t, b.rangeDelIndex)
 	require.Equal(t, 1, indexCount(b.rangeDelIndex))
 	require.Equal(t, 0, count(b))
-	require.False(t, contains(b))
+	require.False(t, contains(b, key, value))
 }
 
 func TestFlushableBatchReset(t *testing.T) {

--- a/db.go
+++ b/db.go
@@ -523,6 +523,9 @@ func (d *DB) Apply(batch *Batch, opts *WriteOptions) error {
 	if err := d.closed.Load(); err != nil {
 		panic(err)
 	}
+	if atomic.LoadUint32(&batch.applied) != 0 {
+		panic("pebble: batch already applied")
+	}
 	if d.opts.ReadOnly {
 		return ErrReadOnly
 	}


### PR DESCRIPTION
Reset() is called when trying to explicitly reuse an existing Batch, but its applied flag is currently never reset in Reset(). The reused batch will be returned by the pending queue in commitPipeline.publish() in another concurrent commit request before its SeqNum gets set in prepare(). That causes a data race between b.setSeqNum() and b.SeqNum(). 

Another question I have is why fields like Batch.flushable, Batch.tombstones etc. not reset in Reset()? 