### PR TITLE
internal/manifest: add (unused) B-Tree implementation

### DIFF
--- a/internal/manifest/btree.go
+++ b/internal/manifest/btree.go
@@ -1,0 +1,831 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package manifest
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+)
+
+const (
+	degree   = 16
+	maxItems = 2*degree - 1
+	minItems = degree - 1
+)
+
+type leafNode struct {
+	ref   int32
+	count int16
+	leaf  bool
+	items [maxItems]*FileMetadata
+}
+
+type node struct {
+	leafNode
+	children [maxItems + 1]*node
+}
+
+//go:nocheckptr casts a ptr to a smaller struct to a ptr to a larger struct.
+func leafToNode(ln *leafNode) *node {
+	return (*node)(unsafe.Pointer(ln))
+}
+
+func nodeToLeaf(n *node) *leafNode {
+	return (*leafNode)(unsafe.Pointer(n))
+}
+
+var leafPool = sync.Pool{
+	New: func() interface{} {
+		return new(leafNode)
+	},
+}
+
+var nodePool = sync.Pool{
+	New: func() interface{} {
+		return new(node)
+	},
+}
+
+func newLeafNode() *node {
+	n := leafToNode(leafPool.Get().(*leafNode))
+	n.leaf = true
+	n.ref = 1
+	return n
+}
+
+func newNode() *node {
+	n := nodePool.Get().(*node)
+	n.ref = 1
+	return n
+}
+
+// mut creates and returns a mutable node reference. If the node is not shared
+// with any other trees then it can be modified in place. Otherwise, it must be
+// cloned to ensure unique ownership. In this way, we enforce a copy-on-write
+// policy which transparently incorporates the idea of local mutations, like
+// Clojure's transients or Haskell's ST monad, where nodes are only copied
+// during the first time that they are modified between Clone operations.
+//
+// When a node is cloned, the provided pointer will be redirected to the new
+// mutable node.
+func mut(n **node) *node {
+	if atomic.LoadInt32(&(*n).ref) == 1 {
+		// Exclusive ownership. Can mutate in place.
+		return *n
+	}
+	// If we do not have unique ownership over the node then we
+	// clone it to gain unique ownership. After doing so, we can
+	// release our reference to the old node. We pass recursive
+	// as true because even though we just observed the node's
+	// reference count to be greater than 1, we might be racing
+	// with another call to decRef on this node.
+	c := (*n).clone()
+	(*n).decRef(true /* recursive */)
+	*n = c
+	return *n
+}
+
+// incRef acquires a reference to the node.
+func (n *node) incRef() {
+	atomic.AddInt32(&n.ref, 1)
+}
+
+// decRef releases a reference to the node. If requested, the method
+// will recurse into child nodes and decrease their refcounts as well.
+func (n *node) decRef(recursive bool) {
+	if atomic.AddInt32(&n.ref, -1) > 0 {
+		// Other references remain. Can't free.
+		return
+	}
+	// Clear and release node into memory pool.
+	if n.leaf {
+		ln := nodeToLeaf(n)
+		*ln = leafNode{}
+		leafPool.Put(ln)
+	} else {
+		// Release child references first, if requested.
+		if recursive {
+			for i := int16(0); i <= n.count; i++ {
+				n.children[i].decRef(true /* recursive */)
+			}
+		}
+		*n = node{}
+		nodePool.Put(n)
+	}
+}
+
+// clone creates a clone of the receiver with a single reference count.
+func (n *node) clone() *node {
+	var c *node
+	if n.leaf {
+		c = newLeafNode()
+	} else {
+		c = newNode()
+	}
+	// NB: copy field-by-field without touching n.ref to avoid
+	// triggering the race detector and looking like a data race.
+	c.count = n.count
+	c.items = n.items
+	if !c.leaf {
+		// Copy children and increase each refcount.
+		c.children = n.children
+		for i := int16(0); i <= c.count; i++ {
+			c.children[i].incRef()
+		}
+	}
+	return c
+}
+
+func (n *node) insertAt(index int, item *FileMetadata, nd *node) {
+	if index < int(n.count) {
+		copy(n.items[index+1:n.count+1], n.items[index:n.count])
+		if !n.leaf {
+			copy(n.children[index+2:n.count+2], n.children[index+1:n.count+1])
+		}
+	}
+	n.items[index] = item
+	if !n.leaf {
+		n.children[index+1] = nd
+	}
+	n.count++
+}
+
+func (n *node) pushBack(item *FileMetadata, nd *node) {
+	n.items[n.count] = item
+	if !n.leaf {
+		n.children[n.count+1] = nd
+	}
+	n.count++
+}
+
+func (n *node) pushFront(item *FileMetadata, nd *node) {
+	if !n.leaf {
+		copy(n.children[1:n.count+2], n.children[:n.count+1])
+		n.children[0] = nd
+	}
+	copy(n.items[1:n.count+1], n.items[:n.count])
+	n.items[0] = item
+	n.count++
+}
+
+// removeAt removes a value at a given index, pulling all subsequent values
+// back.
+func (n *node) removeAt(index int) (*FileMetadata, *node) {
+	var child *node
+	if !n.leaf {
+		child = n.children[index+1]
+		copy(n.children[index+1:n.count], n.children[index+2:n.count+1])
+		n.children[n.count] = nil
+	}
+	n.count--
+	out := n.items[index]
+	copy(n.items[index:n.count], n.items[index+1:n.count+1])
+	n.items[n.count] = nil
+	return out, child
+}
+
+// popBack removes and returns the last element in the list.
+func (n *node) popBack() (*FileMetadata, *node) {
+	n.count--
+	out := n.items[n.count]
+	n.items[n.count] = nil
+	if n.leaf {
+		return out, nil
+	}
+	child := n.children[n.count+1]
+	n.children[n.count+1] = nil
+	return out, child
+}
+
+// popFront removes and returns the first element in the list.
+func (n *node) popFront() (*FileMetadata, *node) {
+	n.count--
+	var child *node
+	if !n.leaf {
+		child = n.children[0]
+		copy(n.children[:n.count+1], n.children[1:n.count+2])
+		n.children[n.count+1] = nil
+	}
+	out := n.items[0]
+	copy(n.items[:n.count], n.items[1:n.count+1])
+	n.items[n.count] = nil
+	return out, child
+}
+
+// find returns the index where the given item should be inserted into this
+// list. 'found' is true if the item already exists in the list at the given
+// index.
+func (n *node) find(cmp func(*FileMetadata, *FileMetadata) int, item *FileMetadata) (index int, found bool) {
+	// Logic copied from sort.Search. Inlining this gave
+	// an 11% speedup on BenchmarkBTreeDeleteInsert.
+	i, j := 0, int(n.count)
+	for i < j {
+		h := int(uint(i+j) >> 1) // avoid overflow when computing h
+		// i ≤ h < j
+		v := cmp(item, n.items[h])
+		if v == 0 {
+			return h, true
+		} else if v > 0 {
+			i = h + 1
+		} else {
+			j = h
+		}
+	}
+	return i, false
+}
+
+// split splits the given node at the given index. The current node shrinks,
+// and this function returns the item that existed at that index and a new
+// node containing all items/children after it.
+//
+// Before:
+//
+//          +-----------+
+//          |   x y z   |
+//          +--/-/-\-\--+
+//
+// After:
+//
+//          +-----------+
+//          |     y     |
+//          +----/-\----+
+//              /   \
+//             v     v
+// +-----------+     +-----------+
+// |         x |     | z         |
+// +-----------+     +-----------+
+//
+func (n *node) split(i int) (*FileMetadata, *node) {
+	out := n.items[i]
+	var next *node
+	if n.leaf {
+		next = newLeafNode()
+	} else {
+		next = newNode()
+	}
+	next.count = n.count - int16(i+1)
+	copy(next.items[:], n.items[i+1:n.count])
+	for j := int16(i); j < n.count; j++ {
+		n.items[j] = nil
+	}
+	if !n.leaf {
+		copy(next.children[:], n.children[i+1:n.count+1])
+		for j := int16(i + 1); j <= n.count; j++ {
+			n.children[j] = nil
+		}
+	}
+	n.count = int16(i)
+	return out, next
+}
+
+// insert inserts a item into the subtree rooted at this node, making sure no
+// nodes in the subtree exceed maxItems items. Returns true if an existing item
+// was replaced and false if a item was inserted.
+func (n *node) insert(cmp func(*FileMetadata, *FileMetadata) int, item *FileMetadata) (replaced bool) {
+	i, found := n.find(cmp, item)
+	if found {
+		n.items[i] = item
+		return true
+	}
+	if n.leaf {
+		n.insertAt(i, item, nil)
+		return false
+	}
+	if n.children[i].count >= maxItems {
+		splitLa, splitNode := mut(&n.children[i]).split(maxItems / 2)
+		n.insertAt(i, splitLa, splitNode)
+
+		switch cmp := cmp(item, n.items[i]); {
+		case cmp < 0:
+			// no change, we want first split node
+		case cmp > 0:
+			i++ // we want second split node
+		default:
+			n.items[i] = item
+			return true
+		}
+	}
+	replaced = mut(&n.children[i]).insert(cmp, item)
+	return replaced
+}
+
+// removeMax removes and returns the maximum item from the subtree rooted
+// at this node.
+func (n *node) removeMax() *FileMetadata {
+	if n.leaf {
+		n.count--
+		out := n.items[n.count]
+		n.items[n.count] = nil
+		return out
+	}
+	child := mut(&n.children[n.count])
+	if child.count <= minItems {
+		n.rebalanceOrMerge(int(n.count))
+		return n.removeMax()
+	}
+	return child.removeMax()
+}
+
+// remove removes a item from the subtree rooted at this node. Returns
+// the item that was removed or nil if no matching item was found.
+func (n *node) remove(cmp func(*FileMetadata, *FileMetadata) int, item *FileMetadata) (out *FileMetadata) {
+	i, found := n.find(cmp, item)
+	if n.leaf {
+		if found {
+			out, _ = n.removeAt(i)
+			return out
+		}
+		return nil
+	}
+	if n.children[i].count <= minItems {
+		// Child not large enough to remove from.
+		n.rebalanceOrMerge(i)
+		return n.remove(cmp, item)
+	}
+	child := mut(&n.children[i])
+	if found {
+		// Replace the item being removed with the max item in our left child.
+		out = n.items[i]
+		n.items[i] = child.removeMax()
+		return out
+	}
+	// Latch is not in this node and child is large enough to remove from.
+	out = child.remove(cmp, item)
+	return out
+}
+
+// rebalanceOrMerge grows child 'i' to ensure it has sufficient room to remove
+// a item from it while keeping it at or above minItems.
+func (n *node) rebalanceOrMerge(i int) {
+	switch {
+	case i > 0 && n.children[i-1].count > minItems:
+		// Rebalance from left sibling.
+		//
+		//          +-----------+
+		//          |     y     |
+		//          +----/-\----+
+		//              /   \
+		//             v     v
+		// +-----------+     +-----------+
+		// |         x |     |           |
+		// +----------\+     +-----------+
+		//             \
+		//              v
+		//              a
+		//
+		// After:
+		//
+		//          +-----------+
+		//          |     x     |
+		//          +----/-\----+
+		//              /   \
+		//             v     v
+		// +-----------+     +-----------+
+		// |           |     | y         |
+		// +-----------+     +/----------+
+		//                   /
+		//                  v
+		//                  a
+		//
+		left := mut(&n.children[i-1])
+		child := mut(&n.children[i])
+		xLa, grandChild := left.popBack()
+		yLa := n.items[i-1]
+		child.pushFront(yLa, grandChild)
+		n.items[i-1] = xLa
+
+	case i < int(n.count) && n.children[i+1].count > minItems:
+		// Rebalance from right sibling.
+		//
+		//          +-----------+
+		//          |     y     |
+		//          +----/-\----+
+		//              /   \
+		//             v     v
+		// +-----------+     +-----------+
+		// |           |     | x         |
+		// +-----------+     +/----------+
+		//                   /
+		//                  v
+		//                  a
+		//
+		// After:
+		//
+		//          +-----------+
+		//          |     x     |
+		//          +----/-\----+
+		//              /   \
+		//             v     v
+		// +-----------+     +-----------+
+		// |         y |     |           |
+		// +----------\+     +-----------+
+		//             \
+		//              v
+		//              a
+		//
+		right := mut(&n.children[i+1])
+		child := mut(&n.children[i])
+		xLa, grandChild := right.popFront()
+		yLa := n.items[i]
+		child.pushBack(yLa, grandChild)
+		n.items[i] = xLa
+
+	default:
+		// Merge with either the left or right sibling.
+		//
+		//          +-----------+
+		//          |   u y v   |
+		//          +----/-\----+
+		//              /   \
+		//             v     v
+		// +-----------+     +-----------+
+		// |         x |     | z         |
+		// +-----------+     +-----------+
+		//
+		// After:
+		//
+		//          +-----------+
+		//          |    u v    |
+		//          +-----|-----+
+		//                |
+		//                v
+		//          +-----------+
+		//          |   x y z   |
+		//          +-----------+
+		//
+		if i >= int(n.count) {
+			i = int(n.count - 1)
+		}
+		child := mut(&n.children[i])
+		// Make mergeChild mutable, bumping the refcounts on its children if necessary.
+		_ = mut(&n.children[i+1])
+		mergeLa, mergeChild := n.removeAt(i)
+		child.items[child.count] = mergeLa
+		copy(child.items[child.count+1:], mergeChild.items[:mergeChild.count])
+		if !child.leaf {
+			copy(child.children[child.count+1:], mergeChild.children[:mergeChild.count+1])
+		}
+		child.count += mergeChild.count + 1
+
+		mergeChild.decRef(false /* recursive */)
+	}
+}
+
+// btree is an implementation of a B-Tree.
+//
+// btree stores FileMetadata in an ordered structure, allowing easy insertion,
+// removal, and iteration. The B-Tree stores items in order based on cmp. The
+// first level of the LSM uses a cmp function that compares sequence numbers.
+// All other levels compare using the FileMetadata.Smallest.
+//
+// Write operations are not safe for concurrent mutation by multiple
+// goroutines, but Read operations are.
+type btree struct {
+	root   *node
+	length int
+	cmp    func(*FileMetadata, *FileMetadata) int
+}
+
+// Reset removes all items from the btree. In doing so, it allows memory
+// held by the btree to be recycled. Failure to call this method before
+// letting a btree be GCed is safe in that it won't cause a memory leak,
+// but it will prevent btree nodes from being efficiently re-used.
+func (t *btree) Reset() {
+	if t.root != nil {
+		t.root.decRef(true /* recursive */)
+		t.root = nil
+	}
+	t.length = 0
+}
+
+// Clone clones the btree, lazily. It does so in constant time.
+func (t *btree) Clone() btree {
+	c := *t
+	if c.root != nil {
+		// Incrementing the reference count on the root node is sufficient to
+		// ensure that no node in the cloned tree can be mutated by an actor
+		// holding a reference to the original tree and vice versa. This
+		// property is upheld because the root node in the receiver btree and
+		// the returned btree will both necessarily have a reference count of at
+		// least 2 when this method returns. All tree mutations recursively
+		// acquire mutable node references (see mut) as they traverse down the
+		// tree. The act of acquiring a mutable node reference performs a clone
+		// if a node's reference count is greater than one. Cloning a node (see
+		// clone) increases the reference count on each of its children,
+		// ensuring that they have a reference count of at least 2. This, in
+		// turn, ensures that any of the child nodes that are modified will also
+		// be copied-on-write, recursively ensuring the immutability property
+		// over the entire tree.
+		c.root.incRef()
+	}
+	return c
+}
+
+// Delete removes a item equal to the passed in item from the tree.
+func (t *btree) Delete(item *FileMetadata) {
+	if t.root == nil || t.root.count == 0 {
+		return
+	}
+	if out := mut(&t.root).remove(t.cmp, item); out != nil {
+		t.length--
+	}
+	if t.root.count == 0 {
+		old := t.root
+		if t.root.leaf {
+			t.root = nil
+		} else {
+			t.root = t.root.children[0]
+		}
+		old.decRef(false /* recursive */)
+	}
+}
+
+// Set adds the given item to the tree. If a item in the tree already
+// equals the given one, it is replaced with the new item.
+func (t *btree) Set(item *FileMetadata) {
+	if t.root == nil {
+		t.root = newLeafNode()
+	} else if t.root.count >= maxItems {
+		splitLa, splitNode := mut(&t.root).split(maxItems / 2)
+		newRoot := newNode()
+		newRoot.count = 1
+		newRoot.items[0] = splitLa
+		newRoot.children[0] = t.root
+		newRoot.children[1] = splitNode
+		t.root = newRoot
+	}
+	if replaced := mut(&t.root).insert(t.cmp, item); !replaced {
+		t.length++
+	}
+}
+
+// MakeIter returns a new iterator object. It is not safe to continue using an
+// iterator after modifications are made to the tree. If modifications are made,
+// create a new iterator.
+func (t *btree) MakeIter() iterator {
+	return iterator{r: t.root, pos: -1, cmp: t.cmp}
+}
+
+// Height returns the height of the tree.
+func (t *btree) Height() int {
+	if t.root == nil {
+		return 0
+	}
+	h := 1
+	n := t.root
+	for !n.leaf {
+		n = n.children[0]
+		h++
+	}
+	return h
+}
+
+// Len returns the number of items currently in the tree.
+func (t *btree) Len() int {
+	return t.length
+}
+
+// String returns a string description of the tree. The format is
+// similar to the https://en.wikipedia.org/wiki/Newick_format.
+func (t *btree) String() string {
+	if t.length == 0 {
+		return ";"
+	}
+	var b strings.Builder
+	t.root.writeString(&b)
+	return b.String()
+}
+
+func (n *node) writeString(b *strings.Builder) {
+	if n.leaf {
+		for i := int16(0); i < n.count; i++ {
+			if i != 0 {
+				b.WriteString(",")
+			}
+			b.WriteString(n.items[i].String())
+		}
+		return
+	}
+	for i := int16(0); i <= n.count; i++ {
+		b.WriteString("(")
+		n.children[i].writeString(b)
+		b.WriteString(")")
+		if i < n.count {
+			b.WriteString(n.items[i].String())
+		}
+	}
+}
+
+// iterStack represents a stack of (node, pos) tuples, which captures
+// iteration state as an iterator descends a btree.
+type iterStack struct {
+	a    iterStackArr
+	aLen int16 // -1 when using s
+	s    []iterFrame
+}
+
+// Used to avoid allocations for stacks below a certain size.
+type iterStackArr [3]iterFrame
+
+type iterFrame struct {
+	n   *node
+	pos int16
+}
+
+func (is *iterStack) push(f iterFrame) {
+	if is.aLen == -1 {
+		is.s = append(is.s, f)
+	} else if int(is.aLen) == len(is.a) {
+		is.s = make([]iterFrame, int(is.aLen)+1, 2*int(is.aLen))
+		copy(is.s, is.a[:])
+		is.s[int(is.aLen)] = f
+		is.aLen = -1
+	} else {
+		is.a[is.aLen] = f
+		is.aLen++
+	}
+}
+
+func (is *iterStack) pop() iterFrame {
+	if is.aLen == -1 {
+		f := is.s[len(is.s)-1]
+		is.s = is.s[:len(is.s)-1]
+		return f
+	}
+	is.aLen--
+	return is.a[is.aLen]
+}
+
+func (is *iterStack) len() int {
+	if is.aLen == -1 {
+		return len(is.s)
+	}
+	return int(is.aLen)
+}
+
+func (is *iterStack) reset() {
+	if is.aLen == -1 {
+		is.s = is.s[:0]
+	} else {
+		is.aLen = 0
+	}
+}
+
+// iterator is responsible for search and traversal within a btree.
+type iterator struct {
+	r   *node
+	n   *node
+	pos int16
+	cmp func(*FileMetadata, *FileMetadata) int
+	s   iterStack
+}
+
+func (i *iterator) reset() {
+	i.n = i.r
+	i.pos = -1
+	i.s.reset()
+}
+
+func (i *iterator) descend(n *node, pos int16) {
+	i.s.push(iterFrame{n: n, pos: pos})
+	i.n = n.children[pos]
+	i.pos = 0
+}
+
+// ascend ascends up to the current node's parent and resets the position
+// to the one previously set for this parent node.
+func (i *iterator) ascend() {
+	f := i.s.pop()
+	i.n = f.n
+	i.pos = f.pos
+}
+
+// SeekGE seeks to the first item greater-than or equal to the provided
+// item.
+func (i *iterator) SeekGE(item *FileMetadata) {
+	i.reset()
+	if i.n == nil {
+		return
+	}
+	for {
+		pos, found := i.n.find(i.cmp, item)
+		i.pos = int16(pos)
+		if found {
+			return
+		}
+		if i.n.leaf {
+			if i.pos == i.n.count {
+				i.Next()
+			}
+			return
+		}
+		i.descend(i.n, i.pos)
+	}
+}
+
+// SeekLT seeks to the first item less-than the provided item.
+func (i *iterator) SeekLT(item *FileMetadata) {
+	i.reset()
+	if i.n == nil {
+		return
+	}
+	for {
+		pos, found := i.n.find(i.cmp, item)
+		i.pos = int16(pos)
+		if found || i.n.leaf {
+			i.Prev()
+			return
+		}
+		i.descend(i.n, i.pos)
+	}
+}
+
+// First seeks to the first item in the btree.
+func (i *iterator) First() {
+	i.reset()
+	if i.n == nil {
+		return
+	}
+	for !i.n.leaf {
+		i.descend(i.n, 0)
+	}
+	i.pos = 0
+}
+
+// Last seeks to the last item in the btree.
+func (i *iterator) Last() {
+	i.reset()
+	if i.n == nil {
+		return
+	}
+	for !i.n.leaf {
+		i.descend(i.n, i.n.count)
+	}
+	i.pos = i.n.count - 1
+}
+
+// Next positions the iterator to the item immediately following
+// its current position.
+func (i *iterator) Next() {
+	if i.n == nil {
+		return
+	}
+
+	if i.n.leaf {
+		i.pos++
+		if i.pos < i.n.count {
+			return
+		}
+		for i.s.len() > 0 && i.pos >= i.n.count {
+			i.ascend()
+		}
+		return
+	}
+
+	i.descend(i.n, i.pos+1)
+	for !i.n.leaf {
+		i.descend(i.n, 0)
+	}
+	i.pos = 0
+}
+
+// Prev positions the iterator to the item immediately preceding
+// its current position.
+func (i *iterator) Prev() {
+	if i.n == nil {
+		return
+	}
+
+	if i.n.leaf {
+		i.pos--
+		if i.pos >= 0 {
+			return
+		}
+		for i.s.len() > 0 && i.pos < 0 {
+			i.ascend()
+			i.pos--
+		}
+		return
+	}
+
+	i.descend(i.n, i.pos)
+	for !i.n.leaf {
+		i.descend(i.n, i.n.count)
+	}
+	i.pos = i.n.count - 1
+}
+
+// Valid returns whether the iterator is positioned at a valid position.
+func (i *iterator) Valid() bool {
+	return i.pos >= 0 && i.pos < i.n.count
+}
+
+// Cur returns the item at the iterator's current position. It is illegal
+// to call Cur if the iterator is not valid.
+func (i *iterator) Cur() *FileMetadata {
+	return i.n.items[i.pos]
+}

--- a/internal/manifest/btree_test.go
+++ b/internal/manifest/btree_test.go
@@ -1,0 +1,640 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package manifest
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/stretchr/testify/require"
+)
+
+func newItem(k InternalKey) *FileMetadata {
+	return &FileMetadata{
+		Smallest: k,
+		Largest:  k,
+	}
+}
+
+func cmp(a, b *FileMetadata) int {
+	return cmpKey(a.Smallest, b.Smallest)
+}
+
+func cmpKey(a, b InternalKey) int {
+	return base.InternalCompare(base.DefaultComparer.Compare, a, b)
+}
+
+//////////////////////////////////////////
+//        Invariant verification        //
+//////////////////////////////////////////
+
+// Verify asserts that the tree's structural invariants all hold.
+func (t *btree) Verify(tt *testing.T) {
+	if t.length == 0 {
+		require.Nil(tt, t.root)
+		return
+	}
+	t.verifyLeafSameDepth(tt)
+	t.verifyCountAllowed(tt)
+	t.isSorted(tt)
+}
+
+func (t *btree) verifyLeafSameDepth(tt *testing.T) {
+	h := t.Height()
+	t.root.verifyDepthEqualToHeight(tt, 1, h)
+}
+
+func (n *node) verifyDepthEqualToHeight(t *testing.T, depth, height int) {
+	if n.leaf {
+		require.Equal(t, height, depth, "all leaves should have the same depth as the tree height")
+	}
+	n.recurse(func(child *node, _ int16) {
+		child.verifyDepthEqualToHeight(t, depth+1, height)
+	})
+}
+
+func (t *btree) verifyCountAllowed(tt *testing.T) {
+	t.root.verifyCountAllowed(tt, true)
+}
+
+func (n *node) verifyCountAllowed(t *testing.T, root bool) {
+	if !root {
+		require.GreaterOrEqual(t, n.count, int16(minItems), "item count %d must be in range [%d,%d]", n.count, minItems, maxItems)
+		require.LessOrEqual(t, n.count, int16(maxItems), "item count %d must be in range [%d,%d]", n.count, minItems, maxItems)
+	}
+	for i, item := range n.items {
+		if i < int(n.count) {
+			require.NotNil(t, item, "item below count")
+		} else {
+			require.Nil(t, item, "item above count")
+		}
+	}
+	if !n.leaf {
+		for i, child := range n.children {
+			if i <= int(n.count) {
+				require.NotNil(t, child, "node below count")
+			} else {
+				require.Nil(t, child, "node above count")
+			}
+		}
+	}
+	n.recurse(func(child *node, _ int16) {
+		child.verifyCountAllowed(t, false)
+	})
+}
+
+func (t *btree) isSorted(tt *testing.T) {
+	t.root.isSorted(tt, t.cmp)
+}
+
+func (n *node) isSorted(t *testing.T, cmp func(*FileMetadata, *FileMetadata) int) {
+	for i := int16(1); i < n.count; i++ {
+		require.LessOrEqual(t, cmp(n.items[i-1], n.items[i]), 0)
+	}
+	if !n.leaf {
+		for i := int16(0); i < n.count; i++ {
+			prev := n.children[i]
+			next := n.children[i+1]
+
+			require.LessOrEqual(t, cmp(prev.items[prev.count-1], n.items[i]), 0)
+			require.LessOrEqual(t, cmp(n.items[i], next.items[0]), 0)
+		}
+	}
+	n.recurse(func(child *node, _ int16) {
+		child.isSorted(t, cmp)
+	})
+}
+
+func (n *node) recurse(f func(child *node, pos int16)) {
+	if !n.leaf {
+		for i := int16(0); i <= n.count; i++ {
+			f(n.children[i], i)
+		}
+	}
+}
+
+//////////////////////////////////////////
+//              Unit Tests              //
+//////////////////////////////////////////
+
+func key(i int) InternalKey {
+	if i < 0 || i > 99999 {
+		panic("key out of bounds")
+	}
+	return base.MakeInternalKey([]byte(fmt.Sprintf("%05d", i)), 0, base.InternalKeyKindSet)
+}
+
+func keyWithMemo(i int, memo map[int]InternalKey) InternalKey {
+	if s, ok := memo[i]; ok {
+		return s
+	}
+	s := key(i)
+	memo[i] = s
+	return s
+}
+
+func randomInternalKey(rng *rand.Rand, n int) InternalKey {
+	return key(rng.Intn(n))
+}
+
+func checkIter(t *testing.T, it iterator, start, end int, keyMemo map[int]InternalKey) {
+	i := start
+	for it.First(); it.Valid(); it.Next() {
+		item := it.Cur()
+		expected := keyWithMemo(i, keyMemo)
+		if cmpKey(expected, item.Smallest) != 0 {
+			t.Fatalf("expected %s, but found %s", expected, item.Smallest)
+		}
+		i++
+	}
+	if i != end {
+		t.Fatalf("expected %d, but at %d", end, i)
+	}
+
+	for it.Last(); it.Valid(); it.Prev() {
+		i--
+		item := it.Cur()
+		expected := keyWithMemo(i, keyMemo)
+		if cmpKey(expected, item.Smallest) != 0 {
+			t.Fatalf("expected %s, but found %s", expected, item.Smallest)
+		}
+	}
+	if i != start {
+		t.Fatalf("expected %d, but at %d: %+v", start, i, it)
+	}
+}
+
+// TestBTree tests basic btree operations.
+func TestBTree(t *testing.T) {
+	var tr btree
+	tr.cmp = cmp
+	keyMemo := make(map[int]InternalKey)
+
+	// With degree == 16 (max-items/node == 31) we need 513 items in order for
+	// there to be 3 levels in the tree. The count here is comfortably above
+	// that.
+	const count = 768
+
+	// Add keys in sorted order.
+	for i := 0; i < count; i++ {
+		tr.Set(newItem(key(i)))
+		tr.Verify(t)
+		if e := i + 1; e != tr.Len() {
+			t.Fatalf("expected length %d, but found %d", e, tr.Len())
+		}
+		checkIter(t, tr.MakeIter(), 0, i+1, keyMemo)
+	}
+
+	// Delete keys in sorted order.
+	for i := 0; i < count; i++ {
+		tr.Delete(newItem(key(i)))
+		tr.Verify(t)
+		if e := count - (i + 1); e != tr.Len() {
+			t.Fatalf("expected length %d, but found %d", e, tr.Len())
+		}
+		checkIter(t, tr.MakeIter(), i+1, count, keyMemo)
+	}
+
+	// Add keys in reverse sorted order.
+	for i := 0; i < count; i++ {
+		tr.Set(newItem(key(count - i)))
+		tr.Verify(t)
+		if e := i + 1; e != tr.Len() {
+			t.Fatalf("expected length %d, but found %d", e, tr.Len())
+		}
+		checkIter(t, tr.MakeIter(), count-i, count+1, keyMemo)
+	}
+
+	// Delete keys in reverse sorted order.
+	for i := 0; i < count; i++ {
+		tr.Delete(newItem(key(count - i)))
+		tr.Verify(t)
+		if e := count - (i + 1); e != tr.Len() {
+			t.Fatalf("expected length %d, but found %d", e, tr.Len())
+		}
+		checkIter(t, tr.MakeIter(), 1, count-i, keyMemo)
+	}
+}
+
+// TestBTreeSeek tests basic btree iterator operations.
+func TestBTreeSeek(t *testing.T) {
+	const count = 513
+
+	var tr btree
+	tr.cmp = cmp
+	for i := 0; i < count; i++ {
+		tr.Set(newItem(key(i * 2)))
+	}
+
+	it := tr.MakeIter()
+	for i := 0; i < 2*count-1; i++ {
+		it.SeekGE(newItem(key(i)))
+		if !it.Valid() {
+			t.Fatalf("%d: expected valid iterator", i)
+		}
+		item := it.Cur()
+		expected := key(2 * ((i + 1) / 2))
+		if cmpKey(expected, item.Smallest) != 0 {
+			t.Fatalf("%d: expected %s, but found %s", i, expected, item.Smallest)
+		}
+	}
+	it.SeekGE(newItem(key(2*count - 1)))
+	if it.Valid() {
+		t.Fatalf("expected invalid iterator")
+	}
+
+	for i := 1; i < 2*count; i++ {
+		it.SeekLT(newItem(key(i)))
+		if !it.Valid() {
+			t.Fatalf("%d: expected valid iterator", i)
+		}
+		item := it.Cur()
+		expected := key(2 * ((i - 1) / 2))
+		if cmpKey(expected, item.Smallest) != 0 {
+			t.Fatalf("%d: expected %s, but found %s", i, expected, item.Smallest)
+		}
+	}
+	it.SeekLT(newItem(key(0)))
+	if it.Valid() {
+		t.Fatalf("expected invalid iterator")
+	}
+}
+
+// TestBTreeCloneConcurrentOperations tests that cloning a btree returns a new
+// btree instance which is an exact logical copy of the original but that can be
+// modified independently going forward.
+func TestBTreeCloneConcurrentOperations(t *testing.T) {
+	const cloneTestSize = 1000
+	p := perm(cloneTestSize)
+
+	var trees []*btree
+	treeC, treeDone := make(chan *btree), make(chan struct{})
+	go func() {
+		for b := range treeC {
+			trees = append(trees, b)
+		}
+		close(treeDone)
+	}()
+
+	var wg sync.WaitGroup
+	var populate func(tr *btree, start int)
+	populate = func(tr *btree, start int) {
+		t.Logf("Starting new clone at %v", start)
+		treeC <- tr
+		for i := start; i < cloneTestSize; i++ {
+			tr.Set(p[i])
+			if i%(cloneTestSize/5) == 0 {
+				wg.Add(1)
+				c := tr.Clone()
+				go populate(&c, i+1)
+			}
+		}
+		wg.Done()
+	}
+
+	wg.Add(1)
+	var tr btree
+	tr.cmp = cmp
+	go populate(&tr, 0)
+	wg.Wait()
+	close(treeC)
+	<-treeDone
+
+	t.Logf("Starting equality checks on %d trees", len(trees))
+	want := rang(0, cloneTestSize-1)
+	for i, tree := range trees {
+		if !reflect.DeepEqual(want, all(tree)) {
+			t.Errorf("tree %v mismatch", i)
+		}
+	}
+
+	t.Log("Removing half of items from first half")
+	toRemove := want[cloneTestSize/2:]
+	for i := 0; i < len(trees)/2; i++ {
+		tree := trees[i]
+		wg.Add(1)
+		go func() {
+			for _, item := range toRemove {
+				tree.Delete(item)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	t.Log("Checking all values again")
+	for i, tree := range trees {
+		var wantpart []*FileMetadata
+		if i < len(trees)/2 {
+			wantpart = want[:cloneTestSize/2]
+		} else {
+			wantpart = want
+		}
+		if got := all(tree); !reflect.DeepEqual(wantpart, got) {
+			t.Errorf("tree %v mismatch, want %v got %v", i, len(want), len(got))
+		}
+	}
+}
+
+// TestIterStack tests the interface of the iterStack type.
+func TestIterStack(t *testing.T) {
+	f := func(i int) iterFrame { return iterFrame{pos: int16(i)} }
+	var is iterStack
+	for i := 1; i <= 2*len(iterStackArr{}); i++ {
+		var j int
+		for j = 0; j < i; j++ {
+			is.push(f(j))
+		}
+		require.Equal(t, j, is.len())
+		for j--; j >= 0; j-- {
+			require.Equal(t, f(j), is.pop())
+		}
+		is.reset()
+	}
+}
+
+//////////////////////////////////////////
+//              Benchmarks              //
+//////////////////////////////////////////
+
+// perm returns a random permutation of items with keys in the range [0, n).
+func perm(n int) (out []*FileMetadata) {
+	for _, i := range rand.Perm(n) {
+		out = append(out, newItem(key(i)))
+	}
+	return out
+}
+
+// rang returns an ordered list of items with keys in the range [m, n].
+func rang(m, n int) (out []*FileMetadata) {
+	for i := m; i <= n; i++ {
+		out = append(out, newItem(key(i)))
+	}
+	return out
+}
+
+// all extracts all items from a tree in order as a slice.
+func all(tr *btree) (out []*FileMetadata) {
+	it := tr.MakeIter()
+	it.First()
+	for it.Valid() {
+		out = append(out, it.Cur())
+		it.Next()
+	}
+	return out
+}
+
+func forBenchmarkSizes(b *testing.B, f func(b *testing.B, count int)) {
+	for _, count := range []int{16, 128, 1024, 8192, 65536} {
+		b.Run(fmt.Sprintf("count=%d", count), func(b *testing.B) {
+			f(b, count)
+		})
+	}
+}
+
+// BenchmarkBTreeInsert measures btree insertion performance.
+func BenchmarkBTreeInsert(b *testing.B) {
+	forBenchmarkSizes(b, func(b *testing.B, count int) {
+		insertP := perm(count)
+		b.ResetTimer()
+		for i := 0; i < b.N; {
+			var tr btree
+			tr.cmp = cmp
+			for _, item := range insertP {
+				tr.Set(item)
+				i++
+				if i >= b.N {
+					return
+				}
+			}
+		}
+	})
+}
+
+// BenchmarkBTreeDelete measures btree deletion performance.
+func BenchmarkBTreeDelete(b *testing.B) {
+	forBenchmarkSizes(b, func(b *testing.B, count int) {
+		insertP, removeP := perm(count), perm(count)
+		b.ResetTimer()
+		for i := 0; i < b.N; {
+			b.StopTimer()
+			var tr btree
+			tr.cmp = cmp
+			for _, item := range insertP {
+				tr.Set(item)
+			}
+			b.StartTimer()
+			for _, item := range removeP {
+				tr.Delete(item)
+				i++
+				if i >= b.N {
+					return
+				}
+			}
+			if tr.Len() > 0 {
+				b.Fatalf("tree not empty: %s", &tr)
+			}
+		}
+	})
+}
+
+// BenchmarkBTreeDeleteInsert measures btree deletion and insertion performance.
+func BenchmarkBTreeDeleteInsert(b *testing.B) {
+	forBenchmarkSizes(b, func(b *testing.B, count int) {
+		insertP := perm(count)
+		var tr btree
+		tr.cmp = cmp
+		for _, item := range insertP {
+			tr.Set(item)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			item := insertP[i%count]
+			tr.Delete(item)
+			tr.Set(item)
+		}
+	})
+}
+
+// BenchmarkBTreeDeleteInsertCloneOnce measures btree deletion and insertion
+// performance after the tree has been copy-on-write cloned once.
+func BenchmarkBTreeDeleteInsertCloneOnce(b *testing.B) {
+	forBenchmarkSizes(b, func(b *testing.B, count int) {
+		insertP := perm(count)
+		var tr btree
+		for _, item := range insertP {
+			tr.Set(item)
+		}
+		tr = tr.Clone()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			item := insertP[i%count]
+			tr.Delete(item)
+			tr.Set(item)
+		}
+	})
+}
+
+// BenchmarkBTreeDeleteInsertCloneEachTime measures btree deletion and insertion
+// performance while the tree is repeatedly copy-on-write cloned.
+func BenchmarkBTreeDeleteInsertCloneEachTime(b *testing.B) {
+	for _, reset := range []bool{false, true} {
+		b.Run(fmt.Sprintf("reset=%t", reset), func(b *testing.B) {
+			forBenchmarkSizes(b, func(b *testing.B, count int) {
+				insertP := perm(count)
+				var tr, trReset btree
+				tr.cmp = cmp
+				trReset.cmp = cmp
+				for _, item := range insertP {
+					tr.Set(item)
+				}
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					item := insertP[i%count]
+					if reset {
+						trReset.Reset()
+						trReset = tr
+					}
+					tr = tr.Clone()
+					tr.Delete(item)
+					tr.Set(item)
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkBTreeMakeIter measures the cost of creating a btree iterator.
+func BenchmarkBTreeMakeIter(b *testing.B) {
+	var tr btree
+	tr.cmp = cmp
+	for i := 0; i < b.N; i++ {
+		it := tr.MakeIter()
+		it.First()
+	}
+}
+
+// BenchmarkBTreeIterSeekGE measures the cost of seeking a btree iterator
+// forward.
+func BenchmarkBTreeIterSeekGE(b *testing.B) {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	forBenchmarkSizes(b, func(b *testing.B, count int) {
+		var keys []InternalKey
+		var tr btree
+		tr.cmp = cmp
+
+		for i := 0; i < count; i++ {
+			s := key(i)
+			keys = append(keys, s)
+			tr.Set(newItem(s))
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			k := keys[rng.Intn(len(keys))]
+			it := tr.MakeIter()
+			it.SeekGE(newItem(k))
+			if testing.Verbose() {
+				if !it.Valid() {
+					b.Fatal("expected to find key")
+				}
+				if cmpKey(k, it.Cur().Smallest) != 0 {
+					b.Fatalf("expected %s, but found %s", k, it.Cur().Smallest)
+				}
+			}
+		}
+	})
+}
+
+// BenchmarkBTreeIterSeekLT measures the cost of seeking a btree iterator
+// backward.
+func BenchmarkBTreeIterSeekLT(b *testing.B) {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	forBenchmarkSizes(b, func(b *testing.B, count int) {
+		var keys []InternalKey
+		var tr btree
+		tr.cmp = cmp
+
+		for i := 0; i < count; i++ {
+			k := key(i)
+			keys = append(keys, k)
+			tr.Set(newItem(k))
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			j := rng.Intn(len(keys))
+			k := keys[j]
+			it := tr.MakeIter()
+			it.SeekLT(newItem(k))
+			if testing.Verbose() {
+				if j == 0 {
+					if it.Valid() {
+						b.Fatal("unexpected key")
+					}
+				} else {
+					if !it.Valid() {
+						b.Fatal("expected to find key")
+					}
+					k := keys[j-1]
+					if cmpKey(k, it.Cur().Smallest) != 0 {
+						b.Fatalf("expected %s, but found %s", k, it.Cur().Smallest)
+					}
+				}
+			}
+		}
+	})
+}
+
+// BenchmarkBTreeIterNext measures the cost of seeking a btree iterator to the
+// next item in the tree.
+func BenchmarkBTreeIterNext(b *testing.B) {
+	var tr btree
+	tr.cmp = cmp
+
+	const count = 8 << 10
+	const size = 2 * maxItems
+	for i := 0; i < count; i++ {
+		item := newItem(key(i))
+		tr.Set(item)
+	}
+
+	it := tr.MakeIter()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !it.Valid() {
+			it.First()
+		}
+		it.Next()
+	}
+}
+
+// BenchmarkBTreeIterPrev measures the cost of seeking a btree iterator to the
+// previous item in the tree.
+func BenchmarkBTreeIterPrev(b *testing.B) {
+	var tr btree
+	tr.cmp = cmp
+
+	const count = 8 << 10
+	const size = 2 * maxItems
+	for i := 0; i < count; i++ {
+		item := newItem(key(i))
+		tr.Set(item)
+	}
+
+	it := tr.MakeIter()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !it.Valid() {
+			it.First()
+		}
+		it.Prev()
+	}
+}


### PR DESCRIPTION
Copy over the B-Tree implementation from Cockroach's
[pkg/util/interval](https://github.com/cockroachdb/cockroach/tree/master/pkg/util/interval) package, stripping its intervals and
go_generics generation.

This PR only adds the B-Tree implementation with minor modifications.
It does not change `LevelMetadata` to use the B-Tree.