### PR TITLE
db: add errorHandler and handle flush, compaction errors

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -809,6 +809,9 @@ func (d *DB) maybeScheduleFlush() {
 	if len(d.mu.mem.queue) <= 1 {
 		return
 	}
+	if d.mu.errorHandler.isBGWorkStopped() {
+		return
+	}
 
 	var n int
 	var size uint64
@@ -893,9 +896,11 @@ func (d *DB) flush() {
 	pprof.Do(context.Background(), flushLabels, func(context.Context) {
 		d.mu.Lock()
 		defer d.mu.Unlock()
-		if err := d.flush1(); err != nil {
-			// TODO(peter): count consecutive flush errors and backoff.
-			d.opts.EventListener.BackgroundError(err)
+		if !d.mu.errorHandler.isBGWorkStopped() {
+			if err := d.flush1(); err != nil {
+				// TODO(peter): count consecutive flush errors and backoff.
+				d.mu.errorHandler.setBGError(err, BgFlush)
+			}
 		}
 		d.mu.compact.flushing = false
 		// More flush work may have arrived while we were flushing, so schedule
@@ -1034,6 +1039,9 @@ func (d *DB) flush1() error {
 // d.mu must be held when calling this.
 func (d *DB) maybeScheduleCompaction() {
 	if d.closed.Load() != nil || d.opts.ReadOnly {
+		return
+	}
+	if d.mu.errorHandler.isBGWorkStopped() {
 		return
 	}
 	if d.mu.compact.compactingCount >= d.opts.MaxConcurrentCompactions {
@@ -1316,10 +1324,18 @@ func (d *DB) compact(c *compaction, errChannel chan error) {
 	pprof.Do(context.Background(), compactLabels, func(context.Context) {
 		d.mu.Lock()
 		defer d.mu.Unlock()
-		if err := d.compact1(c, errChannel); err != nil {
-			// TODO(peter): count consecutive compaction errors and backoff.
-			d.opts.EventListener.BackgroundError(err)
+
+		if d.mu.errorHandler.isBGWorkStopped() {
+			if errChannel != nil {
+				errChannel <- d.mu.errorHandler.getBGError()
+			}
+		} else {
+			if err := d.compact1(c, errChannel); err != nil {
+				// TODO(peter): count consecutive compaction errors and backoff.
+				d.mu.errorHandler.setBGError(err, BgCompaction)
+			}
 		}
+
 		d.mu.compact.compactingCount--
 		// The previous compaction may have produced too many files in a
 		// level, so reschedule another compaction if needed.

--- a/db.go
+++ b/db.go
@@ -232,6 +232,8 @@ type DB struct {
 	mu struct {
 		sync.Mutex
 
+		errorHandler errorHandler
+
 		// The ID of the next job. Job IDs are passed to event listener
 		// notifications and act as a mechanism for tying together the events and
 		// log messages for a single job such as a flush, compaction, or file

--- a/error_handler.go
+++ b/error_handler.go
@@ -1,0 +1,154 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"sync"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+// BackgroundErrorReason is an enum of possible operations whose failure may
+// put the DB in read-only mode depending on the severity.
+type BackgroundErrorReason uint8
+
+const (
+	// BgFlush is for errors during background flushes.
+	BgFlush BackgroundErrorReason = iota
+	// BgCompaction is for errors during background compactions.
+	BgCompaction
+
+	// TODO: Export these once we stop panicking for them.
+	// BgWrite is for errors in writing to WAL.
+	bgWrite
+	// BgMemtable is for errors in writing to memtable.
+	bgMemtable
+	// BgManifestWrite is for errors in writing to MANIFEST.
+	bgManifestWrite
+)
+
+// Severity of an error indicates whether recovery is possible and whether DB
+// will be placed in read-only mode or not.
+type Severity uint8
+
+const (
+	// SeverityNoError does not set the background error at all.
+	SeverityNoError Severity = 0
+	// SeveritySoftError does not place the DB in read-only mode and auto recovery
+	// is possible for some of the errors.
+	SeveritySoftError = 1
+	// SeverityHardError places the DB in read-only mode and recovery might be
+	// possible without needing to close then reopen the DB.
+	SeverityHardError = 2
+	// SeverityFatalError places the DB in read-only mode and recovery requires
+	// closing then reopening the DB.
+	SeverityFatalError = 3
+	// SeverityUnrecoverableError places the DB in read-only mode and could mean
+	// data loss, recovery from which is not possible.
+	SeverityUnrecoverableError = 4
+)
+
+// BackgroundError captures the error occurred during any background operation
+// along with its severity. An instance of this is passed in
+// EventListener.BackgroundError.
+type BackgroundError struct {
+	err      error
+	severity Severity
+	reason   BackgroundErrorReason
+}
+
+// Reason returns the operation during which the error occurred.
+func (b BackgroundError) Reason() BackgroundErrorReason {
+	return b.reason
+}
+
+// Severity returns the severity of the error.
+func (b BackgroundError) Severity() Severity {
+	return b.severity
+}
+
+// Unwrap returns the error that occurred during the background operation.
+func (b BackgroundError) Unwrap() error {
+	return b.err
+}
+
+func (b BackgroundError) Error() string {
+	if b.err != nil {
+		return b.err.Error()
+	}
+	return ""
+}
+
+type errorHandler struct {
+	// Set to db.mu.
+	mu   *sync.Mutex
+	opts *Options
+	err  BackgroundError
+}
+
+func (h *errorHandler) init(opts *Options, mu *sync.Mutex) {
+	h.opts = opts
+	h.mu = mu
+}
+
+// Returns true if DB is placed in read-only mode. Requires db.mu is held.
+func (h *errorHandler) isDBStopped() bool {
+	return h.err.err != nil && h.err.severity >= SeverityHardError
+}
+
+// Requires db.mu is held.
+func (h *errorHandler) isBGWorkStopped() bool {
+	return h.err.err != nil && h.err.severity >= SeverityHardError
+}
+
+func (h *errorHandler) getSeverity(err error, op BackgroundErrorReason) Severity {
+	if op == bgMemtable {
+		return SeverityFatalError
+	}
+	if vfs.IsNoSpaceError(err) {
+		switch op {
+		case BgCompaction:
+			return SeveritySoftError
+		case BgFlush, bgWrite, bgManifestWrite:
+			return SeverityHardError
+		default:
+			panic("unreachable")
+		}
+	}
+	if errors.Is(err, base.ErrCorruption) {
+		return SeverityUnrecoverableError
+	}
+	// Default severity for all other errors.
+	return SeverityFatalError
+}
+
+// Requires db.mu is held.
+func (h *errorHandler) setBGError(err error, op BackgroundErrorReason) {
+	if err == nil {
+		return
+	}
+	sev := h.getSeverity(err, op)
+	bgErr := BackgroundError{
+		err:      err,
+		severity: sev,
+		reason:   op,
+	}
+
+	h.mu.Unlock()
+	h.opts.EventListener.BackgroundError(bgErr)
+	h.mu.Lock()
+
+	if bgErr.severity > h.err.severity {
+		h.err = bgErr
+	}
+}
+
+// Requires db.mu is held.
+func (h *errorHandler) getBGError() error {
+	err := h.err
+	return &err
+}

--- a/internal/base/options.go
+++ b/internal/base/options.go
@@ -33,7 +33,7 @@ type FilterWriter interface {
 	// AddKey adds a key to the current filter block.
 	AddKey(key []byte)
 
-	// Finish appends to dst an encoded filter tha holds the current set of
+	// Finish appends to dst an encoded filter that holds the current set of
 	// keys. The writer state is reset after the call to Finish allowing the
 	// writer to be reused for the creation of additional filters.
 	Finish(dst []byte) []byte

--- a/open.go
+++ b/open.go
@@ -117,6 +117,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	d.mu.compact.cond.L = &d.mu.Mutex
 	d.mu.compact.inProgress = make(map[*compaction]struct{})
 	d.mu.snapshots.init()
+	d.mu.errorHandler.init(opts, &d.mu.Mutex)
 	// logSeqNum is the next sequence number that will be assigned. Start
 	// assigning sequence numbers from 1 to match rocksdb.
 	d.mu.versions.logSeqNum = 1


### PR DESCRIPTION
Add a db wide error state handled by an errorHandler to handle errors in
flush, compaction, WAL, memtable, MANIFEST write and decide whether the error
is severe enough to place the DB in read-only mode. This change only handles
errors in flush, compaction and will be followed up with to handle other scenarios
as well.