### PR TITLE
sstable: optimize seeks to use next

### DIFF
--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -52,11 +52,14 @@ import "fmt"
 // Last if there is an upper bound). This imposition is done in order to
 // elevate that enforcement to the caller (generally pebble.Iterator or
 // pebble.mergingIter) rather than having it duplicated in every
-// InternalIterator implementation. InternalIterator implementations are
-// required to respect the iterator bounds, never returning records outside of
-// the bounds with one exception: an iterator may generate synthetic RANGEDEL
-// marker records. See levelIter.syntheticBoundary for the sole existing
-// example of this behavior. [TODO(peter): can we eliminate this exception?]
+// InternalIterator implementation. Additionally, the caller needs to ensure
+// that SeekGE/SeekPrefixGE are not called with a key > the upper bound, and
+// SeekLT is not called with a key < the lower bound.
+// InternalIterator implementations are required to respect the iterator
+// bounds, never returning records outside of the bounds with one exception:
+// an iterator may generate synthetic RANGEDEL marker records. See
+// levelIter.syntheticBoundary for the sole existing example of this behavior.
+// [TODO(peter): can we eliminate this exception?]
 //
 // An iterator must be closed after use, but it is not necessary to read an
 // iterator until exhaustion.

--- a/iterator.go
+++ b/iterator.go
@@ -315,6 +315,8 @@ func (i *Iterator) SeekGE(key []byte) bool {
 	i.prefix = nil
 	if lowerBound := i.opts.GetLowerBound(); lowerBound != nil && i.cmp(key, lowerBound) < 0 {
 		key = lowerBound
+	} else if upperBound := i.opts.GetUpperBound(); upperBound != nil && i.cmp(key, upperBound) > 0 {
+		key = upperBound
 	}
 
 	i.iterKey, i.iterValue = i.iter.SeekGE(key)
@@ -370,6 +372,12 @@ func (i *Iterator) SeekPrefixGE(key []byte) bool {
 			return false
 		}
 		key = lowerBound
+	} else if upperBound := i.opts.GetUpperBound(); upperBound != nil && i.cmp(key, upperBound) > 0 {
+		if n := i.split(upperBound); !bytes.Equal(i.prefix, upperBound[:n]) {
+			i.err = errors.New("pebble: SeekPrefixGE supplied with key outside of upper bound")
+			return false
+		}
+		key = upperBound
 	}
 
 	i.iterKey, i.iterValue = i.iter.SeekPrefixGE(i.prefix, key)
@@ -382,8 +390,10 @@ func (i *Iterator) SeekPrefixGE(key []byte) bool {
 func (i *Iterator) SeekLT(key []byte) bool {
 	i.err = nil // clear cached iteration error
 	i.prefix = nil
-	if upperBound := i.opts.GetUpperBound(); upperBound != nil && i.cmp(key, upperBound) >= 0 {
+	if upperBound := i.opts.GetUpperBound(); upperBound != nil && i.cmp(key, upperBound) > 0 {
 		key = upperBound
+	} else if lowerBound := i.opts.GetLowerBound(); lowerBound != nil && i.cmp(key, lowerBound) < 0 {
+		key = lowerBound
 	}
 
 	i.iterKey, i.iterValue = i.iter.SeekLT(key)

--- a/level_iter.go
+++ b/level_iter.go
@@ -72,8 +72,8 @@ type levelIter struct {
 	iter     internalIterator
 	iterFile *fileMetadata
 	newIters tableNewIters
-	// When rangeDelIter != nil, the caller requires that a range del iterator
-	// corresponding to the current file be placed in *rangeDelIter. When this
+	// When rangeDelIter != nil, the caller requires that *rangeDelIter must point
+	// to a range del iterator corresponding to the current file. When this
 	// iterator returns nil, *rangeDelIter should also be set to nil. Whenever
 	// a non-nil internalIterator is placed in rangeDelIter, a copy is placed
 	// in rangeDelIterCopy. This is done for the following special case:

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -238,6 +238,9 @@ type blockIter struct {
 	cached      []blockEntry
 	cachedBuf   []byte
 	cacheHandle cache.Handle
+	// The first key in the block. This is used by the caller to set bounds
+	// for block iteration for already loaded blocks.
+	firstKey InternalKey
 }
 
 // blockIter implements the base.InternalIterator interface.
@@ -266,6 +269,7 @@ func (i *blockIter) init(cmp Compare, block block, globalSeqNum uint64) error {
 	i.fullKey = i.fullKey[:0]
 	i.val = nil
 	i.clearCache()
+	i.readFirstKey()
 	return nil
 }
 
@@ -284,11 +288,16 @@ func (i *blockIter) invalidate() {
 	i.data = nil
 }
 
+func (i *blockIter) isInvalid() bool {
+	return i.data == nil
+}
+
 func (i *blockIter) resetForReuse() blockIter {
 	return blockIter{
 		fullKey:   i.fullKey[:0],
 		cached:    i.cached[:0],
 		cachedBuf: i.cachedBuf[:0],
+		data:      nil,
 	}
 }
 
@@ -374,6 +383,76 @@ func (i *blockIter) readEntry() {
 	ptr = unsafe.Pointer(uintptr(ptr) + uintptr(unshared))
 	i.val = getBytes(ptr, int(value))
 	i.nextOffset = int32(uintptr(ptr)-uintptr(i.ptr)) + int32(value)
+}
+
+func (i *blockIter) readFirstKey() {
+	ptr := i.ptr
+
+	// This is an ugly performance hack. Reading entries from blocks is one of
+	// the inner-most routines and decoding the 3 varints per-entry takes a
+	// significant time. Neither go1.11 or go1.12 will inline decodeVarint for
+	// us, so we do it manually. This provides a 10-15% performance improvement
+	// on blockIter benchmarks on both go1.11 and go1.12.
+	//
+	// TODO(peter): remove this hack if go:inline is ever supported.
+
+	var shared uint32
+	if a := *((*uint8)(ptr)); a < 128 {
+		shared = uint32(a)
+		ptr = unsafe.Pointer(uintptr(ptr) + 1)
+	} else {
+		panic("first key in block should not share")
+	}
+	if shared != 0 {
+		panic("first key in block should not share")
+	}
+
+	var unshared uint32
+	if a := *((*uint8)(ptr)); a < 128 {
+		unshared = uint32(a)
+		ptr = unsafe.Pointer(uintptr(ptr) + 1)
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+		unshared = uint32(b)<<7 | uint32(a)
+		ptr = unsafe.Pointer(uintptr(ptr) + 2)
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+		unshared = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+		ptr = unsafe.Pointer(uintptr(ptr) + 3)
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+		unshared = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+		ptr = unsafe.Pointer(uintptr(ptr) + 4)
+	} else {
+		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+		unshared = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+		ptr = unsafe.Pointer(uintptr(ptr) + 5)
+	}
+
+	// Skip the value length.
+	if a := *((*uint8)(ptr)); a < 128 {
+		ptr = unsafe.Pointer(uintptr(ptr) + 1)
+	} else if a := *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); a < 128 {
+		ptr = unsafe.Pointer(uintptr(ptr) + 2)
+	} else if a := *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); a < 128 {
+		ptr = unsafe.Pointer(uintptr(ptr) + 3)
+	} else if a := *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); a < 128 {
+		ptr = unsafe.Pointer(uintptr(ptr) + 4)
+	} else {
+		ptr = unsafe.Pointer(uintptr(ptr) + 5)
+	}
+
+	firstKey := getBytes(ptr, int(unshared))
+	// Manually inlining base.DecodeInternalKey provides a 5-10% speedup on
+	// BlockIter benchmarks.
+	if n := len(firstKey) - 8; n >= 0 {
+		i.firstKey.Trailer = binary.LittleEndian.Uint64(firstKey[n:])
+		i.firstKey.UserKey = firstKey[:n:n]
+		if i.globalSeqNum != 0 {
+			i.firstKey.SetSeqNum(i.globalSeqNum)
+		}
+	} else {
+		// TODO: propagate this error?
+		i.firstKey.Trailer = uint64(InternalKeyKindInvalid)
+		i.firstKey.UserKey = nil
+	}
 }
 
 func (i *blockIter) decodeInternalKey(key []byte) {


### PR DESCRIPTION
This is a WIP and has the changes for singleLevelIterator.SeekGE.
It requires strengthening the requirement that the user call SeekGE
with a key that respects the lower bound.

The SeqSeek benchmarks are better
```
name                                                 old time/op    new time/op    delta
LevelIterSeqSeekGEWithBounds/restart=16/count=5-16     661ns ± 1%     152ns ± 1%  -76.96%  (p=0.000 n=8+9)
MergingIterSeqSeekGEWithBounds/levelCount=5-16        1.97µs ± 2%    0.72µs ± 2%  -63.37%  (p=0.000 n=9+10)
```

Overall, between this and the preceding PR, the MergingIterSeqSeek
benchmark shows a 5x improvement.

I'd like some feedback before adding SeekLT, SeekPrefixGE, and the
twoLevelIterator changes.

The more complete microbenchmark results comparing with master show
some slowdown, possibly because of wasted work when there is poor
locality. I need to investigate some more.
```
name                                            old time/op    new time/op    delta
MergingIterSeekGE/restart=16/count=1-16            783ns ± 6%     771ns ± 2%     ~     (p=0.986 n=10+9)
MergingIterSeekGE/restart=16/count=2-16           1.58µs ± 3%    1.59µs ± 2%   +1.07%  (p=0.045 n=10+9)
MergingIterSeekGE/restart=16/count=3-16           2.36µs ± 1%    2.41µs ± 2%   +2.07%  (p=0.000 n=8+10)
MergingIterSeekGE/restart=16/count=4-16           3.21µs ± 3%    3.26µs ± 2%   +1.64%  (p=0.005 n=10+9)
MergingIterSeekGE/restart=16/count=5-16           4.07µs ± 3%    4.16µs ± 1%   +2.10%  (p=0.008 n=10+9)
MergingIterNext/restart=16/count=1-16             37.4ns ± 0%    36.8ns ± 0%   -1.59%  (p=0.000 n=9+8)
MergingIterNext/restart=16/count=2-16             60.1ns ± 2%    60.3ns ± 1%     ~     (p=0.195 n=10+10)
MergingIterNext/restart=16/count=3-16             76.5ns ± 1%    76.4ns ± 1%     ~     (p=0.984 n=10+9)
MergingIterNext/restart=16/count=4-16             88.6ns ± 1%    88.7ns ± 2%     ~     (p=0.826 n=10+9)
MergingIterNext/restart=16/count=5-16              104ns ± 1%     105ns ± 1%   +1.42%  (p=0.003 n=9+8)
MergingIterPrev/restart=16/count=1-16             50.5ns ± 2%    55.6ns ± 4%  +10.07%  (p=0.000 n=10+10)
MergingIterPrev/restart=16/count=2-16             74.2ns ± 1%    78.5ns ± 1%   +5.88%  (p=0.000 n=10+8)
MergingIterPrev/restart=16/count=3-16             90.9ns ± 2%    99.4ns ± 5%   +9.32%  (p=0.000 n=9+10)
MergingIterPrev/restart=16/count=4-16              101ns ± 0%     108ns ± 1%   +7.30%  (p=0.000 n=8+8)
MergingIterPrev/restart=16/count=5-16              117ns ± 3%     135ns ± 7%  +15.04%  (p=0.000 n=10+10)
MergingIterSeqSeekGEWithBounds/levelCount=5-16    3.68µs ±11%    0.75µs ± 3%  -79.58%  (p=0.000 n=10+9)

name                                                old time/op    new time/op    delta
LevelIterSeekGE/restart=16/count=5-16                 1.29µs ± 3%    1.48µs ±13%  +14.78%  (p=0.000 n=10+9)
LevelIterSeqSeekGEWithBounds/restart=16/count=5-16     892ns ± 2%     155ns ± 1%  -82.59%  (p=0.000 n=10+8)
LevelIterNext/restart=16/count=5-16                   19.0ns ± 2%    20.6ns ±11%   +8.64%  (p=0.000 n=10+10)
```