### PR TITLE
*: Add diskHealthChecking{FS,File}, use it to wrap disk writes 

### DIFF
--- a/options.go
+++ b/options.go
@@ -477,9 +477,6 @@ func (o *Options) EnsureDefaults() *Options {
 	if o.Comparer == nil {
 		o.Comparer = DefaultComparer
 	}
-	if o.FS == nil {
-		o.FS = vfs.Default
-	}
 	if o.Experimental.L0CompactionConcurrency <= 0 {
 		o.Experimental.L0CompactionConcurrency = 10
 	}
@@ -535,6 +532,15 @@ func (o *Options) EnsureDefaults() *Options {
 	}
 	if o.MaxConcurrentCompactions <= 0 {
 		o.MaxConcurrentCompactions = 1
+	}
+	if o.FS == nil {
+		o.FS = vfs.WithDiskHealthChecks(vfs.Default, 5 * time.Second,
+			func(name string, duration time.Duration) {
+				o.EventListener.DiskSlow(DiskSlowInfo{
+					Path:     name,
+					Duration: duration,
+				})
+			})
 	}
 
 	o.initMaps()

--- a/vfs/disk_health.go
+++ b/vfs/disk_health.go
@@ -1,0 +1,177 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package vfs
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// defaultTickInterval is the default interval between two ticks of each
+	// diskHealthCheckingFile loop iteration.
+	defaultTickInterval = 2 * time.Second
+)
+
+// diskHealthCheckingFile is a File wrapper to detect slow disk operations, and
+// call onSlowDisk if a disk operation is seen to exceed diskSlowThreshold.
+//
+// This struct creates a goroutine (in startTicker()) that, at every tick
+// interval, sees if there's a disk operation taking longer than the specified
+// duration. This setup is preferable to creating a new timer at every disk
+// operation, as it reduces overhead per disk operation.
+type diskHealthCheckingFile struct {
+	File
+
+	onSlowDisk         func(time.Duration)
+	diskSlowThreshold  time.Duration
+	tickInterval       time.Duration
+
+	stopper        chan struct{}
+	lastWriteNanos int64
+}
+
+// newDiskHealthCheckingFile instantiates a new diskHealthCheckingFile, with the
+// specified time threshold and event listener.
+func newDiskHealthCheckingFile(
+	file File, diskSlowThreshold time.Duration, onSlowDisk func(time.Duration),
+) *diskHealthCheckingFile {
+	return &diskHealthCheckingFile{
+		File:               file,
+		onSlowDisk:         onSlowDisk,
+		diskSlowThreshold:  diskSlowThreshold,
+		tickInterval:       defaultTickInterval,
+
+		stopper: make(chan struct{}),
+	}
+}
+
+// startTicker starts a new goroutine with a ticker to monitor disk operations.
+// Can only be called if the ticker goroutine isn't running already.
+func (d *diskHealthCheckingFile) startTicker() {
+	if d.diskSlowThreshold == 0 {
+		return
+	}
+
+	go func() {
+		ticker := time.NewTicker(d.tickInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-d.stopper:
+				return
+
+			case <-ticker.C:
+				lastWriteNanos := atomic.LoadInt64(&d.lastWriteNanos)
+				if lastWriteNanos == 0 {
+					continue
+				}
+				lastWrite := time.Unix(0, lastWriteNanos)
+				now := time.Now()
+				if lastWrite.Add(d.diskSlowThreshold).Before(now) {
+					// diskSlowThreshold was exceeded. Call the passed-in
+					// listener.
+					d.onSlowDisk(now.Sub(lastWrite))
+				}
+			}
+		}
+	}()
+}
+
+// stopTicker stops the goroutine started in startTicker.
+func (d *diskHealthCheckingFile) stopTicker() {
+	close(d.stopper)
+}
+
+// Write implements the io.Writer interface.
+func (d *diskHealthCheckingFile) Write(p []byte) (n int, err error) {
+	d.timeDiskOp(func() {
+		n, err = d.File.Write(p)
+	})
+	return n, err
+}
+
+// Close implements the io.Closer interface.
+func (d *diskHealthCheckingFile) Close() error {
+	d.stopTicker()
+	return d.File.Close()
+}
+
+// Sync implements the io.Syncer interface.
+func (d *diskHealthCheckingFile) Sync() (err error) {
+	d.timeDiskOp(func() {
+		err = d.File.Sync()
+	})
+	return err
+}
+
+// timeDiskOp runs the specified closure and makes its timing visible to the
+// monitoring goroutine, in case it exceeds one of the slow disk durations.
+func (d *diskHealthCheckingFile) timeDiskOp(op func()) {
+	if d == nil {
+		op()
+		return
+	}
+
+	atomic.StoreInt64(&d.lastWriteNanos, time.Now().UnixNano())
+	defer func() {
+		atomic.StoreInt64(&d.lastWriteNanos, 0)
+	}()
+	op()
+}
+
+type diskHealthCheckingFS struct {
+	FS
+
+	diskSlowThreshold time.Duration
+	onSlowDisk        func(string, time.Duration)
+}
+
+// WithDiskHealthChecks wraps an FS and ensures that all
+// write-oriented created with that FS are wrapped with disk health detection
+// checks. Disk operations that are observed to take longer than
+// diskSlowThreshold trigger an onSlowDisk call.
+func WithDiskHealthChecks(
+	fs FS, diskSlowThreshold time.Duration, onSlowDisk func(string, time.Duration),
+) FS {
+	return diskHealthCheckingFS{
+		FS:                   fs,
+		diskSlowThreshold:    diskSlowThreshold,
+		onSlowDisk:           onSlowDisk,
+	}
+}
+
+// Create implements the vfs.FS interface.
+func (d diskHealthCheckingFS) Create(name string) (File, error) {
+	f, err := d.FS.Create(name)
+	if err != nil {
+		return f, err
+	}
+	if d.diskSlowThreshold == 0 {
+		return f, nil
+	}
+	checkingFile := newDiskHealthCheckingFile(f, d.diskSlowThreshold, func(duration time.Duration) {
+		d.onSlowDisk(name, duration)
+	})
+	checkingFile.startTicker()
+	return checkingFile, nil
+}
+
+// ReuseForWrite implements the vfs.FS interface.
+func (d diskHealthCheckingFS) ReuseForWrite(oldname, newname string) (File, error) {
+	f, err := d.FS.ReuseForWrite(oldname, newname)
+	if err != nil {
+		return f, err
+	}
+	if d.diskSlowThreshold == 0 {
+		return f, nil
+	}
+	checkingFile := newDiskHealthCheckingFile(f, d.diskSlowThreshold, func(duration time.Duration) {
+		d.onSlowDisk(newname, duration)
+	})
+	checkingFile.startTicker()
+	return checkingFile, nil
+}

--- a/vfs/disk_heath_test.go
+++ b/vfs/disk_heath_test.go
@@ -1,0 +1,136 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package vfs
+
+import (
+	"io"
+	"os"
+	"testing"
+	"time"
+)
+
+type mockFile struct {
+	syncDuration time.Duration
+}
+
+func (m mockFile) Close() error {
+	return nil
+}
+
+func (m mockFile) Read(p []byte) (n int, err error) {
+	panic("unimplemented")
+}
+
+func (m mockFile) ReadAt(p []byte, off int64) (n int, err error) {
+	panic("unimplemented")
+}
+
+func (m mockFile) Write(p []byte) (n int, err error) {
+	time.Sleep(m.syncDuration)
+	return len(p), nil
+}
+
+func (m mockFile) Stat() (os.FileInfo, error) {
+	panic("unimplemented")
+}
+
+func (m mockFile) Sync() error {
+	time.Sleep(m.syncDuration)
+	return nil
+}
+
+var _ File = &mockFile{}
+
+type mockFS struct{
+	syncDuration time.Duration
+}
+
+func (m mockFS) Create(name string) (File, error) {
+	return mockFile{syncDuration: m.syncDuration}, nil
+}
+
+func (m mockFS) Link(oldname, newname string) error {
+	panic("unimplemented")
+}
+
+func (m mockFS) Open(name string, opts ...OpenOption) (File, error) {
+	panic("unimplemented")
+}
+
+func (m mockFS) OpenDir(name string) (File, error) {
+	panic("unimplemented")
+}
+
+func (m mockFS) Remove(name string) error {
+	panic("unimplemented")
+}
+
+func (m mockFS) RemoveAll(name string) error {
+	panic("unimplemented")
+}
+
+func (m mockFS) Rename(oldname, newname string) error {
+	panic("unimplemented")
+}
+
+func (m mockFS) ReuseForWrite(oldname, newname string) (File, error) {
+	return mockFile{syncDuration: m.syncDuration}, nil
+}
+
+func (m mockFS) MkdirAll(dir string, perm os.FileMode) error {
+	panic("unimplemented")
+}
+
+func (m mockFS) Lock(name string) (io.Closer, error) {
+	panic("unimplemented")
+}
+
+func (m mockFS) List(dir string) ([]string, error) {
+	panic("unimplemented")
+}
+
+func (m mockFS) Stat(name string) (os.FileInfo, error) {
+	panic("unimplemented")
+}
+
+func (m mockFS) PathBase(path string) string {
+	panic("unimplemented")
+}
+
+func (m mockFS) PathJoin(elem ...string) string {
+	panic("unimplemented")
+}
+
+func (m mockFS) PathDir(path string) string {
+	panic("unimplemented")
+}
+
+func (m mockFS) GetFreeSpace(path string) (uint64, error) {
+	panic("unimplemented")
+}
+
+var _ FS = &mockFS{}
+
+func TestDiskHealthChecking(t *testing.T) {
+	diskSlow := make(chan time.Duration, 100)
+	slowThreshold := 1 * time.Second
+	mockFS := &mockFS{syncDuration: 3 * time.Second}
+	fs := WithDiskHealthChecks(mockFS, slowThreshold, func(s string, duration time.Duration) {
+		diskSlow <- duration
+	})
+	dhFile, _ := fs.Create("test")
+	defer dhFile.Close()
+
+	dhFile.Sync()
+
+	select {
+	case d := <-diskSlow:
+		if d.Seconds() < slowThreshold.Seconds() {
+			t.Fatalf("expected %0.1f to be greater than threshold %0.1f", d.Seconds(), slowThreshold.Seconds())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("disk stall detector did not detect slow disk operation")
+	}
+}


### PR DESCRIPTION
This change adds a diskHealthChecker struct that stores fields for
logging and reporting slow disk operations using a new EventListener.

The diskHealthChecker is supposed to be instantiated
once-per-file-opened-for-writing, and it's created when a diskHealthCheckingFS
has a file Create()d on it. This FS wraps around vfs.Default when a new Options()
is created. That FS then creates file instances where the write, close, and sync
operations are monitored for slowness.

Having a monitoring goroutine per writer is more efficient than
starting/stopping timers at every disk operation, so the diskHealthChecker
spins up one goroutine in startTicker() to check for any slowness in the
ongoing disk operation.