### PR TITLE
internal/manifest: make small B-Tree adjustments

### DIFF
--- a/internal/manifest/btree.go
+++ b/internal/manifest/btree.go
@@ -700,6 +700,18 @@ func (is *iterStack) len() int {
 	return int(is.aLen)
 }
 
+func (is *iterStack) clone() iterStack {
+	// If the iterator is using the embedded iterStackArr, we only need to
+	// copy the struct itself.
+	if is.s == nil {
+		return *is
+	}
+	clone := *is
+	clone.s = make([]iterFrame, len(is.s))
+	copy(clone.s, is.s)
+	return clone
+}
+
 func (is *iterStack) reset() {
 	if is.aLen == -1 {
 		is.s = is.s[:0]
@@ -715,6 +727,12 @@ type iterator struct {
 	pos int16
 	cmp func(*FileMetadata, *FileMetadata) int
 	s   iterStack
+}
+
+func (i *iterator) clone() iterator {
+	c := *i
+	c.s = i.s.clone()
+	return c
 }
 
 func (i *iterator) reset() {


### PR DESCRIPTION
internal/manifest: prohibit overwritten keys in B-Tree

We will be using the B-Tree to organize FileMetadata within a level.
Items will be sorted using the Smallest key for positive-numbered levels
and the tuple of (LargestSeqNum, SmallestSeqNum, FileNum) for L0.
Both of these orderings provide a total ordering of the files within a
level, so an insert of an equal item indicates we're inserting a file's
metadata into a level twice. Treat this as a panic.

internal/manifest: update FileMetadata refcounts within B-Tree

This change updates the B-Tree to increment a file's reference count
when it's first added to a B-Tree node or when a node containing the
file is cloned, and decrement a file's reference count when a containing
B-Tree node is released.

Additionally, rename Reset to Release and augment it to return a slice
of file numbers whose reference counts were decremented to zero. The
intention is to use Release when a Version's reference count is
decremented to zero.

internal/manifest: add clone method to iterator

Add a clone method to the B-Tree iterator.