### PR TITLE
*: Fix level mismatch bug when MarkedForCompaction = true

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -964,7 +964,16 @@ func (p *compactionPickerByScore) pickAuto(env compactionEnv) (pc *pickedCompact
 			if !f.MarkedForCompaction {
 				continue
 			}
-			info := &scores[level]
+			var info *candidateLevelInfo
+			for i := range scores {
+				if scores[i].level == level {
+					info = &scores[i]
+					break
+				}
+			}
+			if info == nil {
+				panic(fmt.Sprintf("could not find candidate level info for level %d", level))
+			}
 			info.file = iter.Take()
 			pc := pickAutoHelper(env, p.opts, p.vers, *info, p.baseLevel)
 			// Fail-safe to protect against compacting the same sstable concurrently.


### PR DESCRIPTION
When we call compactionPicker.calculateScores, the scores
returned are sorted by decreasing score, not by level. The
code to handle files with MarkedForCompaction = true
did not take this into account, and ended up pulling the
wrong level's candidateLevelInfo. Unfortunately,
that entire method seems to be untested, so this slipped
past our tests and got caught by a roachtest.

Will fix https://github.com/cockroachdb/cockroach/issues/53121
when this lands in Cockroach.