### PR TITLE
db: fix nil pointer dereference in compaction

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1821,7 +1821,11 @@ func (d *DB) runCompaction(
 			// In this case, `limit` will be a larger user key than `key.UserKey`, or
 			// nil. In either case, the inner loop will execute at least once to
 			// process `key`, and the input iterator will be advanced.
-			limit = c.findGrandparentLimit(key.UserKey)
+			if key != nil {
+				limit = c.findGrandparentLimit(key.UserKey)
+			} else { // !c.rangeDelFrag.Empty()
+				limit = c.findGrandparentLimit(c.rangeDelFrag.Start())
+			}
 		} else {
 			// There is a range tombstone spanning from the last file into the
 			// current one. Therefore this file's smallest boundary will overlap the

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -748,3 +748,30 @@ compact a-q L1
   000008:[a#1,SET-c#1,SET]
   000009:[ff#1,SET-ff#1,SET]
   000010:[k#1,SET-k#1,SET]
+
+# Test a case where a new output file is started, there are no previous output
+# files, there are no additional keys (key = nil) and the rangedel fragmenter
+# is non-empty.
+define target-file-sizes=(1, 1, 1)
+L1
+  a.RANGEDEL.10:b
+  d.RANGEDEL.9:e
+  q.RANGEDEL.8:r
+L2
+  g.RANGEDEL.7:h
+L3
+  q.SET.6:6
+----
+1:
+  000004:[a-r]
+2:
+  000005:[g-h]
+3:
+  000006:[q-q]
+
+compact a-r L1
+----
+2:
+  000007:[q#8,RANGEDEL-r#72057594037927935,RANGEDEL]
+3:
+  000006:[q#6,SET-q#6,SET]


### PR DESCRIPTION
This is another piece of fallout from the never-ending saga of
grandparent limits and elided tombstones.

A compaction of two files that only contain range tombstones may elide
all the tombstones up to a grandparent limit. When finishOutput is
called, the conditional introduced in #809 recognizes that the resulting
table has no point tombstones and the limit is equal to the fragmenter's
start key, so it skips creating a table.

However, if the compaction inputs have no more keys, the outer loop
restarts with a nil key and a pending tombstone in the range deletion
fragmenter. Previously, a compaction like this would panic when trying
to set a grandparent limit using a nil key. This updates this condition
to use the rangedel fragmenter start key to find the new grandparent
limit in this case.