### PR TITLE
*: add includesBase argument to ValueMerger.Finish

### DIFF
--- a/compaction_iter.go
+++ b/compaction_iter.go
@@ -321,7 +321,10 @@ func (i *compactionIter) Next() (*InternalKey, []byte) {
 				change = i.mergeNext(valueMerger)
 			}
 			if i.err == nil {
-				i.value, i.valueCloser, i.err = valueMerger.Finish()
+				// includesBase is true whenever we've transformed the MERGE record
+				// into a SET.
+				includesBase := i.key.Kind() == InternalKeyKindSet
+				i.value, i.valueCloser, i.err = valueMerger.Finish(includesBase)
 			}
 			if i.err == nil {
 				// A non-skippable entry does not necessarily cover later merge

--- a/db_test.go
+++ b/db_test.go
@@ -530,7 +530,7 @@ func (m *closableMerger) MergeOlder(value []byte) error {
 	return nil
 }
 
-func (m *closableMerger) Finish() ([]byte, io.Closer, error) {
+func (m *closableMerger) Finish(includesBase bool) ([]byte, io.Closer, error) {
 	return m.lastBuf, m, nil
 }
 

--- a/internal/base/merger.go
+++ b/internal/base/merger.go
@@ -48,9 +48,16 @@ type ValueMerger interface {
 	// Finish must be the last function called on the ValueMerger. The caller
 	// must not call any other ValueMerger functions after calling Finish.
 	//
+	// If `includesBase` is true, the oldest merge operand was part of the
+	// merge. This will always be the true during normal iteration, but may be
+	// false during compaction when only a subset of operands may be
+	// available. Note that `includesBase` is set to true conservatively: a false
+	// value means that we could not definitely determine that the base merge
+	// operand was included.
+	//
 	// If a Closer is returned, the returned slice will remain valid until it is
 	// closed. The caller must arrange for the closer to be eventually closed.
-	Finish() ([]byte, io.Closer, error)
+	Finish(includesBase bool) ([]byte, io.Closer, error)
 }
 
 // Merger defines an associative merge operation. The merge operation merges
@@ -93,7 +100,7 @@ func (a *AppendValueMerger) MergeOlder(value []byte) error {
 }
 
 // Finish returns the buffer that was constructed on-demand in `Merge{OlderNewer}()` calls.
-func (a *AppendValueMerger) Finish() ([]byte, io.Closer, error) {
+func (a *AppendValueMerger) Finish(includesBase bool) ([]byte, io.Closer, error) {
 	return a.buf, nil, nil
 }
 

--- a/iterator.go
+++ b/iterator.go
@@ -113,7 +113,7 @@ func (i *Iterator) findNextEntry() bool {
 				i.mergeNext(key, valueMerger)
 			}
 			if i.err == nil {
-				i.value, i.valueCloser, i.err = valueMerger.Finish()
+				i.value, i.valueCloser, i.err = valueMerger.Finish(true /* includesBase */)
 			}
 			return i.err == nil
 
@@ -169,7 +169,7 @@ func (i *Iterator) findPrevEntry() bool {
 				// We've iterated to the previous user key.
 				i.pos = iterPosPrev
 				if valueMerger != nil {
-					i.value, i.valueCloser, i.err = valueMerger.Finish()
+					i.value, i.valueCloser, i.err = valueMerger.Finish(true /* includesBase */)
 				}
 				return i.err == nil
 			}
@@ -232,7 +232,7 @@ func (i *Iterator) findPrevEntry() bool {
 	if i.valid {
 		i.pos = iterPosPrev
 		if valueMerger != nil {
-			i.value, i.valueCloser, i.err = valueMerger.Finish()
+			i.value, i.valueCloser, i.err = valueMerger.Finish(true /* includesBase */)
 		}
 		return i.err == nil
 	}

--- a/level_checker.go
+++ b/level_checker.go
@@ -151,7 +151,7 @@ func (m *simpleMergingIter) step() bool {
 		// Ongoing series of MERGE records ends with a MERGE record.
 		if keyChanged && m.valueMerger != nil {
 			var closer io.Closer
-			_, closer, m.err = m.valueMerger.Finish()
+			_, closer, m.err = m.valueMerger.Finish(true /* includesBase */)
 			if m.err == nil && closer != nil {
 				m.err = closer.Close()
 			}
@@ -162,7 +162,7 @@ func (m *simpleMergingIter) step() bool {
 			switch item.key.Kind() {
 			case InternalKeyKindSingleDelete, InternalKeyKindDelete:
 				var closer io.Closer
-				_, closer, m.err = m.valueMerger.Finish()
+				_, closer, m.err = m.valueMerger.Finish(true /* includesBase */)
 				if m.err == nil && closer != nil {
 					m.err = closer.Close()
 				}
@@ -171,7 +171,7 @@ func (m *simpleMergingIter) step() bool {
 				m.err = m.valueMerger.MergeOlder(item.value)
 				if m.err == nil {
 					var closer io.Closer
-					_, closer, m.err = m.valueMerger.Finish()
+					_, closer, m.err = m.valueMerger.Finish(true /* includesBase */)
 					if m.err == nil && closer != nil {
 						m.err = closer.Close()
 					}
@@ -252,7 +252,7 @@ func (m *simpleMergingIter) step() bool {
 		// Last record was a MERGE record.
 		if m.valueMerger != nil {
 			var closer io.Closer
-			_, closer, m.err = m.valueMerger.Finish()
+			_, closer, m.err = m.valueMerger.Finish(true /* includesBase */)
 			if m.err == nil && closer != nil {
 				m.err = closer.Close()
 			}

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -63,7 +63,7 @@ func (f *failMerger) MergeOlder(value []byte) error {
 	return nil
 }
 
-func (f *failMerger) Finish() ([]byte, io.Closer, error) {
+func (f *failMerger) Finish(includesBase bool) ([]byte, io.Closer, error) {
 	if string(f.lastBuf) == "fail-finish" {
 		f.lastBuf = nil
 		return nil, nil, errors.New("finish failed")

--- a/testdata/compaction_iter
+++ b/testdata/compaction_iter
@@ -142,7 +142,7 @@ first
 next
 next
 ----
-a#3,1:bcd
+a#3,1:bcd[base]
 b#2,2:ab
 .
 
@@ -153,7 +153,7 @@ next
 next
 ----
 a#3,2:d
-a#2,1:bc
+a#2,1:bc[base]
 b#2,2:ab
 .
 
@@ -444,7 +444,7 @@ next
 tombstones
 ----
 a#3,15:c
-b#5,1:de
+b#5,1:de[base]
 d#5,2:bc
 d#3,15:f
 .
@@ -888,7 +888,7 @@ iter
 first
 next
 ----
-a#2,1:ab
+a#2,1:ab[base]
 .
 
 iter snapshots=2
@@ -904,7 +904,7 @@ iter snapshots=3
 first
 next
 ----
-a#2,1:ab
+a#2,1:ab[base]
 .
 
 iter snapshots=(2,3,4)
@@ -1039,21 +1039,21 @@ iter
 first
 next
 ----
-a#5,1:5
+a#5,1:5[base]
 .
 
 iter allow-zero-seqnum=true
 first
 next
 ----
-a#0,1:5
+a#0,1:5[base]
 .
 
 iter elide-tombstones=true
 first
 next
 ----
-a#5,1:5
+a#5,1:5[base]
 .
 
 iter snapshots=2
@@ -1061,7 +1061,7 @@ first
 next
 next
 ----
-a#5,1:5
+a#5,1:5[base]
 a#1,2:1
 .
 
@@ -1070,7 +1070,7 @@ first
 next
 next
 ----
-a#5,1:5
+a#5,1:5[base]
 a#1,2:1
 .
 
@@ -1090,7 +1090,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5
+b#5,1:5[base]
 .
 
 iter allow-zero-seqnum=true
@@ -1099,7 +1099,7 @@ next
 next
 ----
 a#3,15:c
-b#0,1:5
+b#0,1:5[base]
 .
 
 iter snapshots=2
@@ -1108,7 +1108,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5
+b#5,1:5[base]
 b#1,2:1
 
 define
@@ -1124,7 +1124,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5
+b#5,1:5[base]
 .
 
 iter snapshots=2
@@ -1133,5 +1133,5 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5
+b#5,1:5[base]
 b#1,2:1


### PR DESCRIPTION
Add an `includesBase` argument to `ValueMerger.Finish`.  If
`includesBase` is true, the oldest merge operand was part of the
merge. This will always be the true during normal iteration, but may be
false during compaction when only a subset of operands may be
available. Note that `includesBase` is set to true conservatively: a
false value means that we could not definitely determine that the base
merge operand was included.

Fixes #617
Closes #625