### PR TITLE
tool: fix removing same file twice

### DIFF
--- a/tool/make_test_find_db.go
+++ b/tool/make_test_find_db.go
@@ -98,11 +98,6 @@ func (d *db) ingest(keyVals ...string) {
 	if err := d.db.Ingest([]string{path}); err != nil {
 		log.Fatal(err)
 	}
-
-	if err := fs.Remove(path); err != nil {
-		// TODO(peter): why is the remove sometimes failing under CI?
-		log.Print(err)
-	}
 }
 
 func (d *db) flush() {


### PR DESCRIPTION
I think the removed code block does not affect the result because DB.Ingest method deletes source files on success.