### PR TITLE
compaction: Ensure that user keys aren't split across SSTs when flushing

### DIFF
--- a/testdata/compaction_error_on_user_key_overlap
+++ b/testdata/compaction_error_on_user_key_overlap
@@ -1,0 +1,20 @@
+
+error-on-user-key-overlap
+a.SET.2-b.SET.3
+c.SET.4-d.SET.5
+----
+OK
+
+# If the end key is the rangedel sentinel key, no error should be returned.
+
+error-on-user-key-overlap
+a.SET.2-c.RANGEDEL.72057594037927935
+c.SET.4-d.SET.5
+----
+OK
+
+error-on-user-key-overlap
+a.SET.2-c.SET.5
+c.SET.4-d.SET.5
+----
+pebble: compaction split user key across two sstables: c#5,SET in 000001 and 000002


### PR DESCRIPTION
This change updates output finishing logic in compaction.go to ensure
that the flush errors out if different revisions of a user key fall into two
separate sstables. This invariant is already ensured by other compaction
output logic, but it's worthwhile to have an extra sanity check around this
invariant.