### PR TITLE
db: prevent conflicting, concurrent L0->LBase compactions

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1114,14 +1114,16 @@ func (d *DB) removeInProgressCompaction(c *compaction) {
 		iter := cl.files.Iter()
 		for f := iter.First(); f != nil; f = iter.Next() {
 			if !f.Compacting {
-				d.opts.Logger.Fatalf("L%d->L%d: %s already being compacted", c.startLevel.level, c.outputLevel.level, f.FileNum)
+				d.opts.Logger.Fatalf("L%d->L%d: %s not being compacted", c.startLevel.level, c.outputLevel.level, f.FileNum)
 			}
 			f.Compacting = false
 			f.IsIntraL0Compacting = false
 		}
 	}
 	delete(d.mu.compact.inProgress, c)
-	d.mu.versions.currentVersion().L0Sublevels.InitCompactingFileInfo()
+
+	l0InProgress := inProgressL0Compactions(d.getInProgressCompactionInfoLocked(c))
+	d.mu.versions.currentVersion().L0Sublevels.InitCompactingFileInfo(l0InProgress)
 }
 
 func (d *DB) getCompactionPacerInfo() compactionPacerInfo {

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -43,6 +43,29 @@ type compactionPicker interface {
 type compactionInfo struct {
 	inputs      []compactionLevel
 	outputLevel int
+	smallest    InternalKey
+	largest     InternalKey
+}
+
+func (info compactionInfo) String() string {
+	var buf bytes.Buffer
+	var largest int
+	for i, in := range info.inputs {
+		if i > 0 {
+			fmt.Fprintf(&buf, " -> ")
+		}
+		fmt.Fprintf(&buf, "L%d", in.level)
+		in.files.Each(func(m *fileMetadata) {
+			fmt.Fprintf(&buf, " %s", m.FileNum)
+		})
+		if largest < in.level {
+			largest = in.level
+		}
+	}
+	if largest != info.outputLevel || len(info.inputs) == 1 {
+		fmt.Fprintf(&buf, " -> L%d", info.outputLevel)
+	}
+	return buf.String()
 }
 
 type sortCompactionLevelsDecreasingScore []candidateLevelInfo
@@ -913,7 +936,7 @@ func (p *compactionPickerByScore) pickAuto(env compactionEnv) (pc *pickedCompact
 			pc = pickL0(env, p.opts, p.vers, p.baseLevel)
 			// Fail-safe to protect against compacting the same sstable
 			// concurrently.
-			if pc != nil && !inputAlreadyCompacting(pc) {
+			if pc != nil && !inputRangeAlreadyCompacting(env, pc) {
 				pc.score = info.score
 				// TODO(peter): remove
 				if false {
@@ -932,7 +955,7 @@ func (p *compactionPickerByScore) pickAuto(env compactionEnv) (pc *pickedCompact
 
 		pc := pickAutoHelper(env, p.opts, p.vers, *info, p.baseLevel)
 		// Fail-safe to protect against compacting the same sstable concurrently.
-		if pc != nil && !inputAlreadyCompacting(pc) {
+		if pc != nil && !inputRangeAlreadyCompacting(env, pc) {
 			pc.score = info.score
 			// TODO(peter): remove
 			if false {
@@ -976,7 +999,7 @@ func (p *compactionPickerByScore) pickAuto(env compactionEnv) (pc *pickedCompact
 			info.file = iter.Take()
 			pc := pickAutoHelper(env, p.opts, p.vers, *info, p.baseLevel)
 			// Fail-safe to protect against compacting the same sstable concurrently.
-			if pc != nil && !inputAlreadyCompacting(pc) {
+			if pc != nil && !inputRangeAlreadyCompacting(env, pc) {
 				pc.score = info.score
 				return pc
 			}
@@ -1042,7 +1065,7 @@ func (p *compactionPickerByScore) pickElisionOnlyCompaction(env compactionEnv) (
 	p.elisionCandidate = nil
 
 	// Fail-safe to protect against compacting the same sstable concurrently.
-	if !inputAlreadyCompacting(pc) {
+	if !inputRangeAlreadyCompacting(env, pc) {
 		return pc
 	}
 	return nil
@@ -1265,7 +1288,7 @@ func (p *compactionPickerByScore) pickManual(
 		panic("pebble: compaction picked unexpected output level")
 	}
 	// Fail-safe to protect against compacting the same sstable concurrently.
-	if inputAlreadyCompacting(pc) {
+	if inputRangeAlreadyCompacting(env, pc) {
 		return nil, true
 	}
 	return pc, false
@@ -1290,13 +1313,58 @@ func (p *compactionPickerByScore) forceBaseLevel1() {
 	p.baseLevel = 1
 }
 
-func inputAlreadyCompacting(pc *pickedCompaction) bool {
+func inputRangeAlreadyCompacting(env compactionEnv, pc *pickedCompaction) bool {
 	for _, cl := range pc.inputs {
 		iter := cl.files.Iter()
 		for f := iter.First(); f != nil; f = iter.Next() {
 			if f.Compacting {
 				return true
 			}
+		}
+	}
+
+	// Look for active compactions outputting to the same region of the key
+	// space in the same output level. Two potential compactions may conflict
+	// without sharing input files if there are no files in the output level
+	// that overlap with the intersection of the compactions' key spaces.
+	//
+	// Consider an active L0->Lbase compaction compacting two L0 files one
+	// [a-f] and the other [t-z] into Lbase.
+	//
+	// L0
+	//     ↦ 000100  ↤                           ↦  000101   ↤
+	// L1
+	//     ↦ 000004  ↤
+	//     a b c d e f g h i j k l m n o p q r s t u v w x y z
+	//
+	// If a new file 000102 [j-p] is flushed while the existing compaction is
+	// still ongoing, new file would not be in any compacting sublevel
+	// intervals and would not overlap with any Lbase files that are also
+	// compacting. However, this compaction cannot be picked because the
+	// compaction's output key space [j-p] would overlap the existing
+	// compaction's output key space [a-z].
+	//
+	// L0
+	//     ↦ 000100* ↤       ↦   000102  ↤       ↦  000101*  ↤
+	// L1
+	//     ↦ 000004* ↤
+	//     a b c d e f g h i j k l m n o p q r s t u v w x y z
+	//
+	// * - currently compacting
+	if pc.outputLevel != nil && pc.outputLevel.level != 0 {
+		for _, c := range env.inProgressCompactions {
+			if pc.outputLevel.level != c.outputLevel {
+				continue
+			}
+			if base.InternalCompare(pc.cmp, c.largest, pc.smallest) < 0 ||
+				base.InternalCompare(pc.cmp, c.smallest, pc.largest) > 0 {
+				continue
+			}
+
+			// The picked compaction and the in-progress compaction c are
+			// outputting to the same region of the key space of the same
+			// level.
+			return true
 		}
 	}
 	return false

--- a/testdata/compaction_picker_L0
+++ b/testdata/compaction_picker_L0
@@ -182,9 +182,11 @@ define
 L0
    000100:i.SET.101-p.SET.102
    000110:j.SET.111-q.SET.112
-   000120:r.SET.113-s.SET.114 intra_l0_compacting
+   000120:r.SET.113-s.SET.114
 L6
    000200:f.SET.51-s.SET.52
+compactions
+  L0 000120 -> L0
 ----
 0.1:
   000110:[j#111,SET-q#112,SET]
@@ -193,6 +195,8 @@ L6
   000120:[r#113,SET-s#114,SET]
 6:
   000200:[f#51,SET-s#52,SET]
+compactions
+  L0 000120 -> L0
 
 pick-auto l0_compaction_threshold=2
 ----
@@ -209,7 +213,9 @@ L0
    000110:j.SET.111-q.SET.112
    000120:r.SET.113-s.SET.114
 L6
-   000200:f.SET.51-s.SET.52 compacting
+   000200:f.SET.51-s.SET.52
+compactions
+  L6 000200 -> L6
 ----
 0.1:
   000110:[j#111,SET-q#112,SET]
@@ -218,6 +224,8 @@ L6
   000120:[r#113,SET-s#114,SET]
 6:
   000200:[f#51,SET-s#52,SET]
+compactions
+  L6 000200 -> L6
 
 pick-auto l0_compaction_threshold=2
 ----
@@ -231,13 +239,48 @@ define
 L0
    000100:i.SET.101-p.SET.102
 L6
-   000200:f.SET.51-s.SET.52 compacting
+   000200:f.SET.51-s.SET.52
+compactions
+  L6 000200 -> L6
 ----
 0.0:
   000100:[i#101,SET-p#102,SET]
 6:
   000200:[f#51,SET-s#52,SET]
+compactions
+  L6 000200 -> L6
 
 pick-auto l0_compaction_threshold=1
+----
+nil
+
+# Test an in-progress L0->Lbase compaction with another L0 file that does not
+# overlap any of the compacting files in L0 or Lbase, but does overlap the
+# compaction's range. No new compaction should be picked because the
+# in-progress compaction's output tables could overlap the non-compacting
+# file.
+
+define
+L0
+  000010:a.SET.11-b.SET.12
+  000013:k.SET.23-n.SET.24
+  000011:x.SET.13-z.SET.25
+L1
+  000101:a.SET.1-f.SET.2
+  000102:w.SET.3-z.SET.4
+compactions
+  L0 000010 000011 -> L1 000101 000102
+----
+0.0:
+  000010:[a#11,SET-b#12,SET]
+  000013:[k#23,SET-n#24,SET]
+  000011:[x#13,SET-z#25,SET]
+1:
+  000101:[a#1,SET-f#2,SET]
+  000102:[w#3,SET-z#4,SET]
+compactions
+  L0 000010 000011 -> L1 000101 000102
+
+pick-auto l0_compaction_threshold=2
 ----
 nil

--- a/testdata/compaction_picker_concurrency
+++ b/testdata/compaction_picker_concurrency
@@ -1,0 +1,51 @@
+# Test a file L1.000203 that would be a candidate for a move compaction into
+# L2, except that it's bordered by two files participating in the same
+# compaction. This is possible if 000203 created by a L0->L1 compaction that
+# completed after the compaction of 000201 and 000202 began.
+#
+# The in-progress compaction of 000201 and 000202  will write an output table
+# to L2 that would conflict with 000203 if 000203 was moved into L2.
+#
+# NB: The L0 files are used to increase the permitted compaction concurrency.
+define
+L0
+  000301:a.SET.31-a.SET.31
+  000302:a.SET.32-a.SET.32
+  000303:a.SET.33-a.SET.33
+  000304:a.SET.34-a.SET.34
+  000305:a.SET.35-a.SET.35
+L1
+  000201:a.SET.21-b.SET.22
+  000203:k.SET.25-n.SET.26 size=512000000
+  000202:x.SET.23-z.SET.24
+L2
+  000101:a.SET.11-f.SET.12
+L3
+  000010:a.SET.1-z.SET.2
+compactions
+  L1 000201 000202 -> L2 000101
+----
+0.4:
+  000305:[a#35,SET-a#35,SET]
+0.3:
+  000304:[a#34,SET-a#34,SET]
+0.2:
+  000303:[a#33,SET-a#33,SET]
+0.1:
+  000302:[a#32,SET-a#32,SET]
+0.0:
+  000301:[a#31,SET-a#31,SET]
+1:
+  000201:[a#21,SET-b#22,SET]
+  000203:[k#25,SET-n#26,SET]
+  000202:[x#23,SET-z#24,SET]
+2:
+  000101:[a#11,SET-f#12,SET]
+3:
+  000010:[a#1,SET-z#2,SET]
+compactions
+  L1 000201 000202 -> L2 000101
+
+pick-auto l0_compaction_threshold=10
+----
+nil


### PR DESCRIPTION
Previously, it was possible for compaction picking to pick an L0->LBase
compaction that conflicted with an existing L0->LBase compaction under
specific conditions.

A flush of a new sstable constructs a new Version and sublevel
intervals. If a flushed table does not overlap any individual
currently-compacting files, its intervals within sublevels
datastructures are not marked as compacting, although the flushed table
may still overlap with the active compaction's key range (eg, if the new
sstable sits squarely between two compacting files' keyspaces). If no
files exist in LBase that intersect with the intersection of the newly
flushed sstable's keyspace and the active compaction's keyspace, a
new compaction of the flush sstable would be allowed to start.

This change augments our existing concurrent compaction failsafe to
compare picked L0->LBase compaction key ranges against the key ranges of
in-progress compactions, preventing the compaction if necessary.

I think we'll probably want to also adapt L0 sublevels to avoid picking
these base compactions earlier through passing active compactions into
InitCompactingFileInfo, but adding this to the failsafe also patches the
non-sublevels codepaths and will provide defense in depth once we fix
L0-sublevel picking.

Fix #875.