### PR TITLE
db: close previous WAL before linking next WAL

### DIFF
--- a/internal/errorfs/errorfs.go
+++ b/internal/errorfs/errorfs.go
@@ -62,7 +62,7 @@ func (ii *InjectIndex) MaybeError(op Op) error {
 func WithProbability(op Op, p float64) Injector {
 	mu := new(sync.Mutex)
 	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
-	return injectorFunc(func(currOp Op) error {
+	return InjectorFunc(func(currOp Op) error {
 		mu.Lock()
 		defer mu.Unlock()
 		if currOp == op && rnd.Float64() < p {
@@ -72,9 +72,12 @@ func WithProbability(op Op, p float64) Injector {
 	})
 }
 
-type injectorFunc func(Op) error
+// InjectorFunc implements the Injector interface for a function with
+// MaybeError's signature.
+type InjectorFunc func(Op) error
 
-func (f injectorFunc) MaybeError(op Op) error { return f(op) }
+// MaybeError implements the Injector interface.
+func (f InjectorFunc) MaybeError(op Op) error { return f(op) }
 
 // Injector injects errors into FS operations.
 type Injector interface {

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -27,10 +27,10 @@ sync: db/000002.log
 
 flush db
 ----
-create: db/000004.log
-sync: db
 sync: db/000002.log
 close: db/000002.log
+create: db/000004.log
+sync: db
 create: db/000005.sst
 sync: db/000005.sst
 close: db/000005.sst
@@ -46,10 +46,10 @@ sync: db/000004.log
 
 flush db
 ----
-reuseForWrite: db/000002.log -> db/000006.log
-sync: db
 sync: db/000004.log
 close: db/000004.log
+reuseForWrite: db/000002.log -> db/000006.log
+sync: db
 create: db/000007.sst
 sync: db/000007.sst
 close: db/000007.sst
@@ -88,10 +88,10 @@ checkpoint checkpoint1: file already exists
 
 compact db
 ----
-reuseForWrite: db/000004.log -> db/000008.log
-sync: db
 sync: db/000006.log
 close: db/000006.log
+reuseForWrite: db/000004.log -> db/000008.log
+sync: db
 create: db/000009.sst
 sync: db/000009.sst
 close: db/000009.sst

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -29,10 +29,10 @@ sync: wal/000002.log
 
 flush db
 ----
-create: wal/000004.log
-sync: wal
 sync: wal/000002.log
 close: wal/000002.log
+create: wal/000004.log
+sync: wal
 create: db/000005.sst
 sync: db/000005.sst
 close: db/000005.sst
@@ -48,10 +48,10 @@ sync: wal/000004.log
 
 compact db
 ----
-create: wal/000006.log
-sync: wal
 sync: wal/000004.log
 close: wal/000004.log
+create: wal/000006.log
+sync: wal
 create: db/000007.sst
 sync: db/000007.sst
 close: db/000007.sst

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -34,10 +34,10 @@ sync: db
 flush
 ----
 sync: wal/000002.log
-create: wal/000005.log
-sync: wal
 sync: wal/000002.log
 close: wal/000002.log
+create: wal/000005.log
+sync: wal
 [JOB 2] WAL created 000005
 [JOB 3] flushing 1 memtable to L0
 create: db/000006.sst
@@ -60,10 +60,10 @@ sync: db
 compact
 ----
 sync: wal/000005.log
-reuseForWrite: wal/000002.log -> wal/000008.log
-sync: wal
 sync: wal/000005.log
 close: wal/000005.log
+reuseForWrite: wal/000002.log -> wal/000008.log
+sync: wal
 [JOB 4] WAL created 000008 (recycled 000002)
 [JOB 5] flushing 1 memtable to L0
 create: db/000009.sst
@@ -108,10 +108,10 @@ disable-file-deletions
 flush
 ----
 sync: wal/000008.log
-reuseForWrite: wal/000005.log -> wal/000013.log
-sync: wal
 sync: wal/000008.log
 close: wal/000008.log
+reuseForWrite: wal/000005.log -> wal/000013.log
+sync: wal
 [JOB 7] WAL created 000013 (recycled 000005)
 [JOB 8] flushing 1 memtable to L0
 create: db/000014.sst


### PR DESCRIPTION
In #871, Open started interpreting any WAL older than the most recent
one more strictly, erroring if it encountered any invalid chunks while
reading the log. This was enabled by a new EOF trailer chunk that's
written when a WAL is closed, ensuring that previous WALs end cleanly
and unambiguously.

However, during a WAL rotation, a crash before the previous WAL was
cleanly closed could leave the previous WAL with recycled garbage at its
tail.

This change updates WAL rotation to close the previous WAL first,
then create/rename the next WAL.