### PR TITLE
*: Add Compact.InProgressBytes metric to track in-progress writes

### DIFF
--- a/db.go
+++ b/db.go
@@ -1052,6 +1052,7 @@ func (d *DB) Metrics() *Metrics {
 	d.mu.Lock()
 	*metrics = d.mu.versions.metrics
 	metrics.Compact.EstimatedDebt = d.mu.versions.picker.estimatedCompactionDebt(0)
+	metrics.Compact.InProgressBytes = atomic.LoadInt64(&d.mu.versions.atomicInProgressBytes)
 	for _, m := range d.mu.mem.queue {
 		metrics.MemTable.Size += m.totalBytes()
 	}

--- a/metrics.go
+++ b/metrics.go
@@ -131,6 +131,10 @@ type Metrics struct {
 		// An estimate of the number of bytes that need to be compacted for the LSM
 		// to reach a stable state.
 		EstimatedDebt uint64
+		// Number of bytes present in sstables being written by in-progress
+		// compactions. This value will be zero if there are no in-progress
+		// compactions.
+		InProgressBytes int64
 	}
 
 	Flush struct {
@@ -289,10 +293,11 @@ func (m *Metrics) String() string {
 	total.format(&buf, "-")
 
 	fmt.Fprintf(&buf, "  flush %9d\n", m.Flush.Count)
-	fmt.Fprintf(&buf, "compact %9d %7s %7s  (size == estimated-debt)\n",
+	fmt.Fprintf(&buf, "compact %9d %7s %7s %7s  (size == estimated-debt, in = in-progress-bytes)\n",
 		m.Compact.Count,
 		humanize.IEC.Uint64(m.Compact.EstimatedDebt),
-		"")
+		"",
+		humanize.IEC.Int64(m.Compact.InProgressBytes))
 	fmt.Fprintf(&buf, " memtbl %9d %7s\n",
 		m.MemTable.Count,
 		humanize.IEC.Uint64(m.MemTable.Size))

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -22,25 +22,26 @@ func TestMetricsFormat(t *testing.T) {
 	m.BlockCache.Misses = 4
 	m.Compact.Count = 5
 	m.Compact.EstimatedDebt = 6
-	m.Flush.Count = 7
-	m.Filter.Hits = 8
-	m.Filter.Misses = 9
-	m.MemTable.Size = 10
-	m.MemTable.Count = 11
-	m.MemTable.ZombieSize = 12
-	m.MemTable.ZombieCount = 13
-	m.Table.ZombieSize = 14
-	m.Table.ZombieCount = 15
-	m.TableCache.Size = 16
-	m.TableCache.Count = 17
-	m.TableCache.Hits = 18
-	m.TableCache.Misses = 19
-	m.TableIters = 20
-	m.WAL.Files = 21
-	m.WAL.ObsoleteFiles = 22
-	m.WAL.Size = 23
-	m.WAL.BytesIn = 24
-	m.WAL.BytesWritten = 25
+	m.Compact.InProgressBytes = 7
+	m.Flush.Count = 8
+	m.Filter.Hits = 9
+	m.Filter.Misses = 10
+	m.MemTable.Size = 11
+	m.MemTable.Count = 12
+	m.MemTable.ZombieSize = 13
+	m.MemTable.ZombieCount = 14
+	m.Table.ZombieSize = 15
+	m.Table.ZombieCount = 16
+	m.TableCache.Size = 17
+	m.TableCache.Count = 18
+	m.TableCache.Hits = 19
+	m.TableCache.Misses = 20
+	m.TableIters = 21
+	m.WAL.Files = 22
+	m.WAL.ObsoleteFiles = 23
+	m.WAL.Size = 24
+	m.WAL.BytesIn = 25
+	m.WAL.BytesWritten = 26
 
 	for i := range m.Levels {
 		l := &m.Levels[i]
@@ -63,7 +64,7 @@ func TestMetricsFormat(t *testing.T) {
 
 	const expected = `
 __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___r-amp___w-amp
-    WAL        21    23 B       -    24 B       -       -       -       -    25 B       -       -       -     1.0
+    WAL        22    24 B       -    25 B       -       -       -       -    26 B       -       -       -     1.0
       0       101   102 B  103.00   104 B   104 B     112   106 B     113   217 B     221   107 B       1     2.1
       1       201   202 B  203.00   204 B   204 B     212   206 B     213   417 B     421   207 B       2     2.0
       2       301   302 B  303.00   304 B   304 B     312   306 B     313   617 B     621   307 B       3     2.0
@@ -72,15 +73,15 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5       601   602 B  603.00   604 B   604 B     612   606 B     613   1.2 K   1.2 K   607 B       6     2.0
       6       701   702 B       -   704 B   704 B     712   706 B     713   1.4 K   1.4 K   707 B       7     2.0
   total      2807   2.7 K       -   2.8 K   2.8 K   2.9 K   2.8 K   2.9 K   8.4 K   5.7 K   2.8 K      28     3.0
-  flush         7
-compact         5     6 B          (size == estimated-debt)
- memtbl        11    10 B
-zmemtbl        13    12 B
-   ztbl        15    14 B
+  flush         8
+compact         5     6 B             7 B  (size == estimated-debt, in = in-progress-bytes)
+ memtbl        12    11 B
+zmemtbl        14    13 B
+   ztbl        16    15 B
  bcache         2     1 B   42.9%  (score == hit-rate)
- tcache        17    16 B   48.6%  (score == hit-rate)
- titers        20
- filter         -       -   47.1%  (score == utility)
+ tcache        18    17 B   48.7%  (score == hit-rate)
+ titers        21
+ filter         -       -   47.4%  (score == utility)
 `
 	if s := "\n" + m.String(); expected != s {
 		t.Fatalf("expected%s\nbut found%s", expected, s)

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -164,7 +164,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6         1   770 B       -   1.5 K     0 B       0     0 B       0   770 B       1   1.5 K       1     0.5
   total         3   2.3 K       -   933 B   825 B       1     0 B       0   3.9 K       4   1.5 K       3     4.3
   flush         3
-compact         1   2.3 K          (size == estimated-debt)
+compact         1   2.3 K             0 B  (size == estimated-debt, in = in-progress-bytes)
  memtbl         1   256 K
 zmemtbl         0     0 B
    ztbl         0     0 B

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -42,7 +42,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6         1   833 B       -     0 B   833 B       1     0 B       0     0 B       0     0 B       1     0.0
   total         1   833 B       -   833 B   833 B       1     0 B       0   833 B       0     0 B       1     1.0
   flush         0
-compact         0     0 B          (size == estimated-debt)
+compact         0     0 B             0 B  (size == estimated-debt, in = in-progress-bytes)
  memtbl         1   256 K
 zmemtbl         0     0 B
    ztbl         0     0 B

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -28,7 +28,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6         0     0 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
   total         1   771 B       -    56 B     0 B       0     0 B       0   827 B       1     0 B       1    14.8
   flush         1
-compact         0     0 B          (size == estimated-debt)
+compact         0     0 B             0 B  (size == estimated-debt, in = in-progress-bytes)
  memtbl         1   256 K
 zmemtbl         1   256 K
    ztbl         0     0 B
@@ -70,7 +70,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6         1   778 B       -   1.5 K     0 B       0     0 B       0   778 B       1   1.5 K       1     0.5
   total         1   778 B       -    84 B     0 B       0     0 B       0   2.3 K       3   1.5 K       1    28.6
   flush         2
-compact         1     0 B          (size == estimated-debt)
+compact         1     0 B             0 B  (size == estimated-debt, in = in-progress-bytes)
  memtbl         1   256 K
 zmemtbl         2   512 K
    ztbl         2   1.5 K
@@ -97,7 +97,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6         1   778 B       -   1.5 K     0 B       0     0 B       0   778 B       1   1.5 K       1     0.5
   total         1   778 B       -    84 B     0 B       0     0 B       0   2.3 K       3   1.5 K       1    28.6
   flush         2
-compact         1     0 B          (size == estimated-debt)
+compact         1     0 B             0 B  (size == estimated-debt, in = in-progress-bytes)
  memtbl         1   256 K
 zmemtbl         1   256 K
    ztbl         2   1.5 K
@@ -125,7 +125,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6         1   778 B       -   1.5 K     0 B       0     0 B       0   778 B       1   1.5 K       1     0.5
   total         1   778 B       -    84 B     0 B       0     0 B       0   2.3 K       3   1.5 K       1    28.6
   flush         2
-compact         1     0 B          (size == estimated-debt)
+compact         1     0 B             0 B  (size == estimated-debt, in = in-progress-bytes)
  memtbl         1   256 K
 zmemtbl         1   256 K
    ztbl         1   771 B
@@ -152,7 +152,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6         1   778 B       -   1.5 K     0 B       0     0 B       0   778 B       1   1.5 K       1     0.5
   total         1   778 B       -    84 B     0 B       0     0 B       0   2.3 K       3   1.5 K       1    28.6
   flush         2
-compact         1     0 B          (size == estimated-debt)
+compact         1     0 B             0 B  (size == estimated-debt, in = in-progress-bytes)
  memtbl         1   256 K
 zmemtbl         0     0 B
    ztbl         0     0 B

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -21,7 +21,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6         0     0 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
   total         1   986 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
   flush         0
-compact         0     0 B          (size == estimated-debt)
+compact         0     0 B             0 B  (size == estimated-debt, in = in-progress-bytes)
  memtbl         1   256 K
 zmemtbl         0     0 B
    ztbl         0     0 B


### PR DESCRIPTION
Adds a metric, updated atomically, to track bytes in sstables
written by in-progress compactions so far. As a compaction happens,
it effectively doubles disk space used for that key range until
it finishes and the old files are cleaned up. If we run out of
disk space during a compaction, having more visibility into
how much extra disk space was being used by in-progress
compactions is helpful.

Fixes #862.