### PR TITLE
compaction: Invalidate limit when a splitter defers a split suggestion

### DIFF
--- a/testdata/compaction_output_splitters
+++ b/testdata/compaction_output_splitters
@@ -17,41 +17,41 @@ init main array
 ----
 ok
 
-set-should-split child0 false
+set-should-split child0 no-split
 ----
 ok
 
-set-should-split child1 false
-----
-ok
-
-should-split-before foo.SET.2
-----
-false
-
-set-should-split child1 true
+set-should-split child1 no-split
 ----
 ok
 
 should-split-before foo.SET.2
 ----
-true
+no-split
 
-set-should-split child1 false
+set-should-split child1 split-now
 ----
 ok
 
 should-split-before foo.SET.2
 ----
-false
+split-now
 
-set-should-split child0 true
+set-should-split child1 no-split
 ----
 ok
 
 should-split-before foo.SET.2
 ----
-true
+no-split
+
+set-should-split child0 split-now
+----
+ok
+
+should-split-before foo.SET.2
+----
+split-now
 
 # userKeyChangeSplitter tests
 
@@ -69,51 +69,51 @@ ok
 
 should-split-before foo.SET.6
 ----
-false
+no-split
 
 should-split-before foo.SET.5
 ----
-false
+no-split
 
-set-should-split child0 true
+set-should-split child0 split-now
 ----
 ok
 
 should-split-before foo.SET.4
 ----
-false
+no-split
 
 should-split-before foo.SET.3
 ----
-false
+no-split
 
 should-split-before food.SET.6
 ----
-true
+split-now
 
-set-should-split child0 false
+set-should-split child0 no-split
 ----
 ok
 
 should-split-before food.SET.5
 ----
-false
+no-split
 
-set-should-split child0 true
+set-should-split child0 split-now
 ----
 ok
 
 should-split-before food.SET.4
 ----
-false
+no-split
 
-set-should-split child0 false
+set-should-split child0 no-split
 ----
 ok
 
 should-split-before food2.SET.4
 ----
-true
+split-now
 
 # nonZeroSeqNumSplitter tests
 
@@ -129,76 +129,76 @@ init main nonzeroseqnum tombstone
 ----
 ok
 
-set-should-split child0 false
+set-should-split child0 no-split
 ----
 ok
 
 should-split-before foo.SET.5
 ----
-false
+no-split
 
 should-split-before foo.RANGEDEL.0
 ----
-false
+no-split
 
-set-should-split child0 true
+set-should-split child0 split-now
 ----
 ok
 
-# This should be true, as the last point key is foo.SET.5.
+# This should be split-now, as the last point key is foo.SET.5.
 
 should-split-before foo.SET.0
 ----
-true
+split-now
 
-set-should-split child0 false
+set-should-split child0 no-split
 ----
 ok
 
 should-split-before food.SET.0
 ----
-false
+no-split
 
-set-should-split child0 true
+set-should-split child0 split-now
 ----
 ok
 
 should-split-before food1.SET.0
 ----
-false
+split-soon
 
-# Even though we've set should-split-before to false for the child splitter,
+# Even though we've set should-split-before to no-split for the child splitter,
 # nonZeroSeqNumSplitter "remembers" it and splits at the next good split point.
 
-set-should-split child0 false
+set-should-split child0 no-split
 ----
 ok
 
 should-split-before food2.SET.0
 ----
-false
+no-split
 
 should-split-before food3.SET.4
 ----
-false
+no-split
 
-# This one should be true, as the previous point seqnum is nonzero.
+# This one should be split-now, as the previous point seqnum is nonzero.
 
 should-split-before food4.SET.2
 ----
-true
+split-now
 
 should-split-before food4.SET.0
 ----
-false
+no-split
 
-set-should-split child0 true
+set-should-split child0 split-now
 ----
 ok
 
 should-split-before food5.SET.3
 ----
-true
+split-now
 
 reset
 ----
@@ -219,18 +219,18 @@ init main nonzeroseqnum
 ----
 ok
 
-set-should-split child0 false
+set-should-split child0 no-split
 ----
 ok
 
 should-split-before food.SET.0
 ----
-false
+no-split
 
-set-should-split child0 true
+set-should-split child0 split-now
 ----
 ok
 
 should-split-before food1.SET.0
 ----
-true
+split-now

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -772,3 +772,47 @@ compact a-r L1
   000007:[q#8,RANGEDEL-r#72057594037927935,RANGEDEL]
 3:
   000006:[q#6,SET-q#6,SET]
+
+
+# Test a case where the output ends one key after a grandparent limit is
+# crossed, but we couldn't have split outputs at that key due to the point
+# key before that having a zero seqnum.
+define target-file-sizes=(100, 100, 100)
+L1
+  a.RANGEDEL.10:b
+  b.SET.0:foo
+  d.RANGEDEL.0:e
+  j.SET.10:foo
+L2
+  f.RANGEDEL.7:g
+L3
+  c.SET.6:6
+L3
+  c.SET.5:5
+L3
+  c.SET.4:4
+L4
+  a.SET.0:0
+  f.SET.0:0
+----
+1:
+  000004:[a-j]
+2:
+  000005:[f-g]
+3:
+  000006:[c-c]
+  000007:[c-c]
+  000008:[c-c]
+4:
+  000009:[a-f]
+
+compact a-r L1
+----
+2:
+  000010:[a#10,RANGEDEL-j#10,SET]
+3:
+  000006:[c#6,SET-c#6,SET]
+  000007:[c#5,SET-c#5,SET]
+  000008:[c#4,SET-c#4,SET]
+4:
+  000009:[a#0,SET-f#0,SET]


### PR DESCRIPTION
Currently, it's possible for the nonZeroSeqNumSplitter to "withhold"
a compaction split suggestion in such a way that the `limit` variable
in the compaction loop is exceeded, only to advise a compaction split
at a later point.

This is usually not a concern as we just reset `limit`
when that compaction split is actually advised, but if the compaction
were to run out of keys in this narrow window, we would leave the limit
at a non-nil past key, which would violate an invariant in the rangedel
fragmenter as it can't truncate range tombstones to a passed key.

Similar logic already existed in older iteration of this code, which
is in use in the crl-release-20.2 branch. A refactor here introduced
this bug.

This change allows for a 3-way return value from shouldSplitBefore;
in the case where limit has been exceeded, we resort to resetting the
limit like before.

Will address cockroachdb/cockroach#54284 when this lands in cockroach
master.