### PR TITLE
internal/rawalloc: add benchmarks to show performance gain compare to…

### DIFF
--- a/internal/rawalloc/rawalloc_test.go
+++ b/internal/rawalloc/rawalloc_test.go
@@ -1,0 +1,32 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package rawalloc
+
+import (
+	"fmt"
+	"testing"
+)
+
+var sizes = []int{16, 100, 1024, 1024 * 10, 1024 * 100, 1024 * 1024}
+
+func BenchmarkRawalloc(b *testing.B) {
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("rawalloc-%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = New(size, size)
+			}
+		})
+	}
+}
+
+func BenchmarkMake(b *testing.B) {
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("make-%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = make([]byte, size)
+			}
+		})
+	}
+}


### PR DESCRIPTION
… make

goos: darwin
goarch: amd64
pkg: github.com/cockroachdb/pebble/internal/rawalloc
BenchmarkRawalloc16-12      	81675024	        14.6 ns/op
BenchmarkRawalloc100-12     	45012530	        25.5 ns/op
BenchmarkRawalloc1K-12      	 8933536	       124 ns/op
BenchmarkRawalloc10K-12     	 1515319	       774 ns/op
BenchmarkRawalloc100K-12    	  214456	      5842 ns/op
BenchmarkRawalloc1M-12      	   30844	     35806 ns/op
BenchmarkMake16-12          	62534037	        18.0 ns/op
BenchmarkMake100-12         	37792303	        29.8 ns/op
BenchmarkMake1K-12          	 8321911	       142 ns/op
BenchmarkMake10K-12         	 1282270	       935 ns/op
BenchmarkMake100K-12        	  137275	      8766 ns/op
BenchmarkMake1M-12          	   13593	     79304 ns/op
PASS
ok  	github.com/cockroachdb/pebble/internal/rawalloc	19.015s

Signed-off-by: Cholerae Hu <choleraehyq@gmail.com>