### PR TITLE
db: fix Go microbenchmarks to clean up correctly

### DIFF
--- a/internal/arenaskl/skl_test.go
+++ b/internal/arenaskl/skl_test.go
@@ -811,6 +811,7 @@ func BenchmarkIterPrev(b *testing.B) {
 	}
 
 	it := l.NewIter(nil, nil)
+	_, _ = it.Last()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		key, _ := it.Prev()

--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -29,7 +29,8 @@ import "fmt"
 //
 // The relative positioning methods can be used in conjunction with any of the
 // absolute positioning methods with one exception: SeekPrefixGE does not
-// support reverse iteration via Prev.
+// support reverse iteration via Prev. It is undefined to call relative
+// positioning methods without ever calling an absolute positioning method.
 //
 // InternalIterators can optionally implement a prefix iteration mode. This
 // mode is entered by calling SeekPrefixGE and exited by any other absolute

--- a/mem_table_test.go
+++ b/mem_table_test.go
@@ -398,7 +398,7 @@ func BenchmarkMemTableIterSeekGE(b *testing.B) {
 func BenchmarkMemTableIterNext(b *testing.B) {
 	m, _ := buildMemTable(b)
 	iter := m.newIter(nil)
-
+	_, _ = iter.First()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		key, _ := iter.Next()
@@ -412,7 +412,7 @@ func BenchmarkMemTableIterNext(b *testing.B) {
 func BenchmarkMemTableIterPrev(b *testing.B) {
 	m, _ := buildMemTable(b)
 	iter := m.newIter(nil)
-
+	_, _ = iter.Last()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		key, _ := iter.Prev()


### PR DESCRIPTION
Fix the Go `levelIter` and `mergingIter` microbenchmarks to clean up
`*sstable.Readers` before exiting.

Also fix the memtable benchmarks to use an absolute positioning method
before a relative positioning and document this requirement on the
`InternalIterator` interface.

Fix #902.