### PR TITLE
db: fix a few lazy initializations of Batch data

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -819,8 +819,11 @@ func (b *Batch) setSeqNum(seqNum uint64) {
 
 // SeqNum returns the batch sequence number which is applied to the first
 // record in the batch. The sequence number is incremented for each subsequent
-// record.
+// record. It returns zero if the batch is empty.
 func (b *Batch) SeqNum() uint64 {
+	if len(b.data) == 0 {
+		b.init(batchHeaderLen)
+	}
 	return binary.LittleEndian.Uint64(b.seqNumData())
 }
 
@@ -840,6 +843,9 @@ func (b *Batch) Count() uint32 {
 // Reader returns a BatchReader for the current batch contents. If the batch is
 // mutated, the new entries will not be visible to the reader.
 func (b *Batch) Reader() BatchReader {
+	if len(b.data) == 0 {
+		b.init(batchHeaderLen)
+	}
 	return b.data[batchHeaderLen:]
 }
 
@@ -878,6 +884,9 @@ type BatchReader []byte
 // MakeBatchReader constructs a BatchReader from a batch representation. The
 // header (containing the batch count and seqnum) is ignored.
 func MakeBatchReader(repr []byte) BatchReader {
+	if len(repr) <= batchHeaderLen {
+		return nil
+	}
 	return repr[batchHeaderLen:]
 }
 

--- a/batch_test.go
+++ b/batch_test.go
@@ -135,26 +135,55 @@ func TestBatchEmpty(t *testing.T) {
 	require.False(t, b.Empty())
 	b.Reset()
 	require.True(t, b.Empty())
+	// Reset may choose to reuse b.data, so clear it to the zero value in
+	// order to test the lazy initialization of b.data.
+	b = Batch{}
 
 	b.Merge(nil, nil, nil)
 	require.False(t, b.Empty())
 	b.Reset()
 	require.True(t, b.Empty())
+	b = Batch{}
 
 	b.Delete(nil, nil)
 	require.False(t, b.Empty())
 	b.Reset()
 	require.True(t, b.Empty())
+	b = Batch{}
 
 	b.DeleteRange(nil, nil, nil)
 	require.False(t, b.Empty())
 	b.Reset()
 	require.True(t, b.Empty())
+	b = Batch{}
 
 	b.LogData(nil, nil)
 	require.False(t, b.Empty())
 	b.Reset()
 	require.True(t, b.Empty())
+	b = Batch{}
+
+	_ = b.Reader()
+	require.True(t, b.Empty())
+	b.Reset()
+	require.True(t, b.Empty())
+	b = Batch{}
+
+	require.Equal(t, uint64(0), b.SeqNum())
+	require.True(t, b.Empty())
+	b.Reset()
+	require.True(t, b.Empty())
+	b = Batch{}
+
+	d, err := Open("", &Options{
+		FS: vfs.NewMem(),
+	})
+	require.NoError(t, err)
+	defer d.Close()
+	ib := newIndexedBatch(d, DefaultComparer)
+	iter := ib.NewIter(nil)
+	require.False(t, iter.First())
+	require.NoError(t, iter.Close())
 }
 
 func TestBatchReset(t *testing.T) {


### PR DESCRIPTION
Fix the `SeqNum` and `Reader` methods to handle a zero-value Batch that
has a nil `data` field. Also, fix MakeBatchReader to handle slices
shorter than the batch header.

Fix #909.