### PR TITLE
db: improve godoc documentation

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,36 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/cockroachdb/pebble"
+)
+
+func Example() {
+	db, err := pebble.Open("demo", &pebble.Options{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	key := []byte("hello")
+	if err := db.Set(key, []byte("world"), pebble.Sync); err != nil {
+		log.Fatal(err)
+	}
+	value, closer, err := db.Get(key)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s %s\n", key, value)
+	if err := closer.Close(); err != nil {
+		log.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		log.Fatal(err)
+	}
+	// Output:
+	// hello world
+}

--- a/iterator.go
+++ b/iterator.go
@@ -351,6 +351,17 @@ func (i *Iterator) SeekGE(key []byte) bool {
 //   SeekPrefixGE("a@0") -> "a@1"
 //   Next()              -> "a@2"
 //   Next()              -> EOF
+//
+// If you're just looking to iterate over keys with a shared prefix, as
+// defined by the configured comparer, set iterator bounds instead:
+//
+//  iter := db.NewIter(&pebble.IterOptions{
+//    LowerBound: []byte("prefix"),
+//    UpperBound: []byte("prefix\0"), // Note the \0 suffix.
+//  })
+//  for key, value := iter.First(); key != nil; key, value = iter.Next() {
+//    // Only keys beginning with "prefix" will be visited.
+//  }
 func (i *Iterator) SeekPrefixGE(key []byte) bool {
 	i.err = nil // clear cached iteration error
 

--- a/snapshot.go
+++ b/snapshot.go
@@ -48,10 +48,10 @@ func (s *Snapshot) NewIter(o *IterOptions) *Iterator {
 	return s.db.newIterInternal(nil /* batchIter */, nil /* batchRangeDelIter */, s, o)
 }
 
-// Close closes the snapshot, releasing its resources. Close must be
-// called. Failure to do so while result in a tiny memory leak, and a large
-// leak of resources on disk due to the entries the snapshot is preventing from
-// being deleted.
+// Close closes the snapshot, releasing its resources. Close must be called.
+// Failure to do so will result in a tiny memory leak and a large leak of
+// resources on disk due to the entries the snapshot is preventing from being
+// deleted.
 func (s *Snapshot) Close() error {
 	if s.db == nil {
 		panic(ErrClosed)


### PR DESCRIPTION
Makes a handful of improvements to the godoc documentation:

* Add a suggestion to `SeekPrefixGE`'s comment, directing readers to
  iterator bounds for constraining an iterator to a prefix of keys. (Close #907.)
* Fix a spelling mistake in the `(*Snapshot).Close` godoc comment.
* Add the 'hello world' example in the repository README as a compiled
  godoc example.