### PR TITLE
*: Have intra-L0 compactions follow flush sizes / splits

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1936,7 +1936,7 @@ func (d *DB) runCompaction(
 		return nil
 	}
 
-	splittingFlush := c.startLevel.level < 0 && c.outputLevel.level == 0 && d.opts.Experimental.FlushSplitBytes > 0
+	splitL0Outputs := c.outputLevel.level == 0 && d.opts.Experimental.FlushSplitBytes > 0
 
 	// finishOutput is called for an sstable with the first key of the next sstable, and for the
 	// last sstable with an empty key.
@@ -1964,7 +1964,7 @@ func (d *DB) runCompaction(
 		// NB: clone the key because the data can be held on to by the call to
 		// compactionIter.Tombstones via rangedel.Fragmenter.FlushTo.
 		key = append([]byte(nil), key...)
-		for _, v := range iter.Tombstones(key, splittingFlush) {
+		for _, v := range iter.Tombstones(key, splitL0Outputs) {
 			if tw == nil {
 				if err := newOutput(); err != nil {
 					return err
@@ -2133,9 +2133,9 @@ func (d *DB) runCompaction(
 					c.largest.Pretty(d.opts.Comparer.FormatKey))
 			}
 		}
-		// Verify that when splitting flushes, we never split different
+		// Verify that when splitting an output to L0, we never split different
 		// revisions of the same user key across two different sstables.
-		if splittingFlush {
+		if splitL0Outputs {
 			if err := c.errorOnUserKeyOverlap(ve); err != nil {
 				return err
 			}
@@ -2151,7 +2151,7 @@ func (d *DB) runCompaction(
 	// a new one. Some splitters can wrap other splitters, and
 	// the splitterGroup can be composed of multiple splitters. In this case,
 	// we start off with splitters for file sizes, grandparent limits, and (for
-	// flush splits) L0 limits, before wrapping them in an splitterGroup.
+	// L0 splits) L0 limits, before wrapping them in an splitterGroup.
 	//
 	// There is a complication here: we can't split outputs where the largest
 	// key on the left side has a seqnum of zero. This limitation
@@ -2171,7 +2171,7 @@ func (d *DB) runCompaction(
 	// our splitters with a nonZeroSeqNumSplitter.
 	//
 	// Another case where we may not be able to switch SSTables right away is
-	// when we are splitting a flush. We do not split the same user key
+	// when we are splitting an L0 output. We do not split the same user key
 	// across different sstables within one flush, so the userKeyChangeSplitter
 	// ensures we are at a user key change boundary when doing a split.
 	outputSplitters := []compactionOutputSplitter{
@@ -2179,7 +2179,7 @@ func (d *DB) runCompaction(
 		&grandparentLimitSplitter{c: c, ve: ve},
 	}
 	var splitter compactionOutputSplitter
-	if splittingFlush {
+	if splitL0Outputs {
 		// outputSplitters[0] is the file size splitter, which doesn't guarantee
 		// that all advised splits will be at user key change boundaries. Wrap
 		// it in a userKeyChangeSplitter.
@@ -2193,13 +2193,13 @@ func (d *DB) runCompaction(
 		cmp:       c.cmp,
 		splitters: outputSplitters,
 	}
-	// Flush splits don't need nonzero last-point-key seqnums at split
-	// boundaries because when flushing to L0, we are able to guarantee that
+	// Compactions to L0 don't need nonzero last-point-key seqnums at split
+	// boundaries because when writing to L0, we are able to guarantee that
 	// the end key of tombstones will also be truncated (through the
 	// TruncateAndFlushTo call), and no user keys will
 	// be split between sstables. So a nonZeroSeqNumSplitter is unnecessary
 	// in that case.
-	if !splittingFlush {
+	if !splitL0Outputs {
 		splitter = &nonZeroSeqNumSplitter{
 			c:        c,
 			splitter: splitter,
@@ -2223,7 +2223,7 @@ func (d *DB) runCompaction(
 			if split := splitter.shouldSplitBefore(key, tw); split != noSplit {
 				if split == splitNow {
 					limit = key.UserKey
-					if splittingFlush {
+					if splitL0Outputs {
 						// Flush all tombstones up until key.UserKey, and
 						// truncate them at that key.
 						//
@@ -2279,7 +2279,7 @@ func (d *DB) runCompaction(
 			// limit to nil ensures that we flush the entirety of the rangedel
 			// fragmenter when writing the last output.
 			limit = nil
-		case key == nil && splittingFlush && !c.rangeDelFrag.Empty():
+		case key == nil && splitL0Outputs && !c.rangeDelFrag.Empty():
 			// We ran out of keys with flush splits enabled, and have remaining
 			// buffered range tombstones. Set limit to nil so all range
 			// tombstones get flushed in the current sstable. Consider this

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1156,7 +1156,7 @@ func pickL0(env compactionEnv, opts *Options, vers *version, baseLevel int) (pc 
 	// compaction. Note that we pass in L0CompactionThreshold here as opposed to
 	// 1, since choosing a single sublevel intra-L0 compaction is
 	// counterproductive.
-	lcf, err = vers.L0Sublevels.PickIntraL0Compaction(env.earliestUnflushedSeqNum, opts.L0CompactionThreshold)
+	lcf, err = vers.L0Sublevels.PickIntraL0Compaction(env.earliestUnflushedSeqNum, minIntraL0Count)
 	if err != nil {
 		opts.Logger.Infof("error when picking intra-L0 compaction: %s", err)
 		return
@@ -1178,14 +1178,6 @@ func pickL0(env compactionEnv, opts *Options, vers *version, baseLevel int) (pc 
 		}
 
 		pc.smallest, pc.largest = manifest.KeyRange(pc.cmp, pc.startLevel.files.Iter())
-		// Output only a single sstable for intra-L0 compactions.
-		// Now that we have the ability to split flushes, we could conceivably
-		// split the output of intra-L0 compactions too. This may be unnecessary
-		// complexity -- the inputs to intra-L0 should be narrow in the key space
-		// (unlike flushes), so writing a single sstable should be ok.
-		pc.maxOutputFileSize = math.MaxUint64
-		pc.maxOverlapBytes = math.MaxUint64
-		pc.maxExpandedBytes = math.MaxUint64
 	}
 	return pc
 }

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -461,6 +461,7 @@ func TestCompactionPickerL0(t *testing.T) {
 	opts.Experimental.L0CompactionConcurrency = 1
 	var picker *compactionPickerByScore
 	var inProgressCompactions []compactionInfo
+	var pc *pickedCompaction
 
 	datadriven.RunTest(t, "testdata/compaction_picker_L0", func(td *datadriven.TestData) string {
 		switch td.Cmd {
@@ -607,7 +608,7 @@ func TestCompactionPickerL0(t *testing.T) {
 				}
 			}
 
-			pc := picker.pickAuto(compactionEnv{
+			pc = picker.pickAuto(compactionEnv{
 				bytesCompacted:          new(uint64),
 				earliestUnflushedSeqNum: math.MaxUint64,
 				inProgressCompactions:   inProgressCompactions,
@@ -627,6 +628,21 @@ func TestCompactionPickerL0(t *testing.T) {
 				return "nil"
 			}
 			return result.String()
+		case "max-output-file-size":
+			if pc == nil {
+				return "no compaction"
+			}
+			return fmt.Sprintf("%d", pc.maxOutputFileSize)
+		case "max-overlap-bytes":
+			if pc == nil {
+				return "no compaction"
+			}
+			return fmt.Sprintf("%d", pc.maxOverlapBytes)
+		case "max-expanded-bytes":
+			if pc == nil {
+				return "no compaction"
+			}
+			return fmt.Sprintf("%d", pc.maxExpandedBytes)
 		}
 		return fmt.Sprintf("unrecognized command: %s", td.Cmd)
 	})

--- a/testdata/compaction_picker_L0
+++ b/testdata/compaction_picker_L0
@@ -205,18 +205,26 @@ L0: 000100,000110
 L6: 000200
 
 # 3 L0 files (1 overlap), Lbase compacting.
-# Should choose an intra-L0 compaction.
+# Should choose an intra-L0 compaction. Note that intra-L0 compactions
+# don't follow l0_compaction_threshold, but rather a minIntraL0Count constant
+# in compaction_picker.go
 
 define
 L0
    000100:i.SET.101-p.SET.102
    000110:j.SET.111-q.SET.112
    000120:r.SET.113-s.SET.114
+   000130:i.SET.110-p.SET.110
+   000140:i.SET.120-p.SET.120
 L6
    000200:f.SET.51-s.SET.52
 compactions
   L6 000200 -> L6
 ----
+0.3:
+  000140:[i#120,SET-p#120,SET]
+0.2:
+  000130:[i#110,SET-p#110,SET]
 0.1:
   000110:[j#111,SET-q#112,SET]
 0.0:
@@ -227,10 +235,22 @@ compactions
 compactions
   L6 000200 -> L6
 
-pick-auto l0_compaction_threshold=2
+pick-auto
 ----
 L0 -> L0
-L0: 000100,000110
+L0: 000100,000110,000130,000140
+
+max-output-file-size
+----
+4194304
+
+max-overlap-bytes
+----
+41943040
+
+max-expanded-bytes
+----
+104857600
 
 # 1 L0 file. Should not choose any compaction, as an intra-L0 compaction
 # with one input is unhelpful.


### PR DESCRIPTION
This change updates output parameters of intra-L0 compactions to
obey flush sematics around file sizes, compaction expansions, and
grandparent / flush limits. This prevents cases where intra-L0
compactions unintentionally produce wide files bridging flush
split boundaries.