### PR TITLE
db: remove Options.TableFormat

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -7,6 +7,7 @@ package pebble_test
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/cockroachdb/pebble"
 )
@@ -16,6 +17,10 @@ func Example() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer func() {
+		// Don't do this in real life, this is just example code.
+		_ = os.RemoveAll("demo")
+	}()
 	key := []byte("hello")
 	if err := db.Set(key, []byte("world"), pebble.Sync); err != nil {
 		log.Fatal(err)

--- a/options_test.go
+++ b/options_test.go
@@ -236,12 +236,6 @@ func TestOptionsValidate(t *testing.T) {
 `,
 			`MemTableStopWritesThreshold .* must be >= 2`,
 		},
-		{`
-[Options]
-  table_format=leveldb
-`,
-			`TableFormatLevelDB not supported for DB`,
-		},
 	}
 
 	for _, c := range testCases {


### PR DESCRIPTION
Remove `Options.TableFormat` to reduce confusion. Only
`TableFormatRocksDBv2` was supported and there are no plans (or ability) to
support `TableFormatLevelDB`. This was originally added to allow writing
LevelDB format sstables, but that can still be done because
`sstable.Options` is distinct from `pebble.Options`.

Fixes #915