### PR TITLE
db: unexport Options.Min{Flush,Compaction}Rate

### DIFF
--- a/cmd/pebble/compact.go
+++ b/cmd/pebble/compact.go
@@ -102,8 +102,6 @@ func open(dir string, listener pebble.EventListener) (*replay.DB, error) {
 		MemTableSize:                64 << 20,
 		MemTableStopWritesThreshold: 4,
 		MaxConcurrentCompactions:    2,
-		MinCompactionRate:           4 << 20, // 4 MB/s
-		MinFlushRate:                1 << 20, // 1 MB/s
 		L0CompactionThreshold:       2,
 		L0StopWritesThreshold:       400,
 		LBaseMaxBytes:               64 << 20, // 64 MB

--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -67,8 +67,6 @@ func newPebbleDB(dir string) DB {
 		Merger: &pebble.Merger{
 			Name: "cockroach_merge_operator",
 		},
-		MinCompactionRate: 4 << 20, // 4 MB/s
-		MinFlushRate:      4 << 20, // 4 MB/s
 	}
 	opts.Experimental.L0SublevelCompactions = true
 

--- a/open.go
+++ b/open.go
@@ -105,8 +105,12 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		apply:         d.commitApply,
 		write:         d.commitWrite,
 	})
-	d.compactionLimiter = rate.NewLimiter(rate.Limit(d.opts.MinCompactionRate), d.opts.MinCompactionRate)
-	d.flushLimiter = rate.NewLimiter(rate.Limit(d.opts.MinFlushRate), d.opts.MinFlushRate)
+	d.compactionLimiter = rate.NewLimiter(
+		rate.Limit(d.opts.private.minCompactionRate),
+		d.opts.private.minCompactionRate)
+	d.flushLimiter = rate.NewLimiter(
+		rate.Limit(d.opts.private.minFlushRate),
+		d.opts.private.minFlushRate)
 	d.mu.nextJobID = 1
 	d.mu.mem.nextSize = opts.MemTableSize
 	if d.mu.mem.nextSize > initialMemTableSize {

--- a/options.go
+++ b/options.go
@@ -393,14 +393,6 @@ type Options struct {
 	// The default merger concatenates values.
 	Merger *Merger
 
-	// MinCompactionRate sets the minimum rate at which compactions occur. The
-	// default is 4 MB/s.
-	MinCompactionRate int
-
-	// MinFlushRate sets the minimum rate at which the MemTables are flushed. The
-	// default is 1 MB/s.
-	MinFlushRate int
-
 	// MaxConcurrentCompactions specifies the maximum number of concurrent
 	// compactions. The default is 1. Concurrent compactions are only performed
 	// when L0 read-amplification passes the L0CompactionConcurrency threshold.
@@ -452,6 +444,16 @@ type Options struct {
 
 		// A private option disable automatic compactions.
 		disableAutomaticCompactions bool
+
+		// minCompactionRate sets the minimum rate at which compactions occur. The
+		// default is 4 MB/s. Currently disabled as this option has no effect while
+		// private.enablePacing is false.
+		minCompactionRate int
+
+		// minFlushRate sets the minimum rate at which the MemTables are flushed. The
+		// default is 1 MB/s. Currently disabled as this option has no effect while
+		// private.enablePacing is false.
+		minFlushRate int
 	}
 }
 
@@ -524,17 +526,17 @@ func (o *Options) EnsureDefaults() *Options {
 	if o.Merger == nil {
 		o.Merger = DefaultMerger
 	}
-	if o.MinCompactionRate == 0 {
-		o.MinCompactionRate = 4 << 20 // 4 MB/s
+	if o.private.minCompactionRate == 0 {
+		o.private.minCompactionRate = 4 << 20 // 4 MB/s
 	}
-	if o.MinFlushRate == 0 {
-		o.MinFlushRate = 1 << 20 // 1 MB/s
+	if o.private.minFlushRate == 0 {
+		o.private.minFlushRate = 1 << 20 // 1 MB/s
 	}
 	if o.MaxConcurrentCompactions <= 0 {
 		o.MaxConcurrentCompactions = 1
 	}
 	if o.FS == nil {
-		o.FS = vfs.WithDiskHealthChecks(vfs.Default, 5 * time.Second,
+		o.FS = vfs.WithDiskHealthChecks(vfs.Default, 5*time.Second,
 			func(name string, duration time.Duration) {
 				o.EventListener.DiskSlow(DiskSlowInfo{
 					Path:     name,
@@ -621,8 +623,8 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  max_open_files=%d\n", o.MaxOpenFiles)
 	fmt.Fprintf(&buf, "  mem_table_size=%d\n", o.MemTableSize)
 	fmt.Fprintf(&buf, "  mem_table_stop_writes_threshold=%d\n", o.MemTableStopWritesThreshold)
-	fmt.Fprintf(&buf, "  min_compaction_rate=%d\n", o.MinCompactionRate)
-	fmt.Fprintf(&buf, "  min_flush_rate=%d\n", o.MinFlushRate)
+	fmt.Fprintf(&buf, "  min_compaction_rate=%d\n", o.private.minCompactionRate)
+	fmt.Fprintf(&buf, "  min_flush_rate=%d\n", o.private.minFlushRate)
 	fmt.Fprintf(&buf, "  merger=%s\n", o.Merger.Name)
 	fmt.Fprintf(&buf, "  table_property_collectors=[")
 	for i := range o.TablePropertyCollectors {
@@ -792,9 +794,9 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 			case "mem_table_stop_writes_threshold":
 				o.MemTableStopWritesThreshold, err = strconv.Atoi(value)
 			case "min_compaction_rate":
-				o.MinCompactionRate, err = strconv.Atoi(value)
+				o.private.minCompactionRate, err = strconv.Atoi(value)
 			case "min_flush_rate":
-				o.MinFlushRate, err = strconv.Atoi(value)
+				o.private.minFlushRate, err = strconv.Atoi(value)
 			case "merger":
 				switch value {
 				case "nullptr":


### PR DESCRIPTION
`Options.Min{Flush,Compaction}Rate` have no effect while
`private.enablePacing` is false. So unexport these fields in order to
reduce confusion.

Fixes #911