### PR TITLE
db: add Example_PrefixIteration

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -7,20 +7,16 @@ package pebble_test
 import (
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/vfs"
 )
 
 func Example() {
-	db, err := pebble.Open("demo", &pebble.Options{})
+	db, err := pebble.Open("", &pebble.Options{FS: vfs.NewMem()})
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer func() {
-		// Don't do this in real life, this is just example code.
-		_ = os.RemoveAll("demo")
-	}()
 	key := []byte("hello")
 	if err := db.Set(key, []byte("world"), pebble.Sync); err != nil {
 		log.Fatal(err)
@@ -37,5 +33,52 @@ func Example() {
 		log.Fatal(err)
 	}
 	// Output:
+	// hello world
+}
+
+func Example_prefixiteration() {
+	db, err := pebble.Open("", &pebble.Options{FS: vfs.NewMem()})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	keyUpperBound := func(b []byte) []byte {
+		end := make([]byte, len(b))
+		copy(end, b)
+		for i := len(end) - 1; i >= 0; i-- {
+			end[i] = end[i] + 1
+			if end[i] != 0 {
+				return end[:i+1]
+			}
+		}
+		return nil // no upper-bound
+	}
+
+	prefixIterOptions := func(prefix []byte) *pebble.IterOptions {
+		return &pebble.IterOptions{
+			LowerBound: prefix,
+			UpperBound: keyUpperBound(prefix),
+		}
+	}
+
+	keys := []string{"hello", "world", "hello world"}
+	for _, key := range keys {
+		if err := db.Set([]byte(key), nil, pebble.Sync); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	iter := db.NewIter(prefixIterOptions([]byte("hello")))
+	for iter.First(); iter.Valid(); iter.Next() {
+		fmt.Printf("%s\n", iter.Key())
+	}
+	if err := iter.Close(); err != nil {
+		log.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		log.Fatal(err)
+	}
+	// Output:
+	// hello
 	// hello world
 }

--- a/iterator.go
+++ b/iterator.go
@@ -357,11 +357,13 @@ func (i *Iterator) SeekGE(key []byte) bool {
 //
 //  iter := db.NewIter(&pebble.IterOptions{
 //    LowerBound: []byte("prefix"),
-//    UpperBound: []byte("prefix\0"), // Note the \0 suffix.
+//    UpperBound: []byte("prefiy"),
 //  })
-//  for key, value := iter.First(); key != nil; key, value = iter.Next() {
+//  for iter.First(); iter.Valid(); iter.Next() {
 //    // Only keys beginning with "prefix" will be visited.
 //  }
+//
+// See Example_prefixiteration for a working example.
 func (i *Iterator) SeekPrefixGE(key []byte) bool {
 	i.err = nil // clear cached iteration error
 


### PR DESCRIPTION
Add an example showing how to iterate over the keys containing a common
prefix. Fix the example of this same pattern in the comments above
`Iterator.SeekPrefixGE`.

Fix #907