### PR TITLE
internal/manifest: remove LevelIterator.Empty

### DIFF
--- a/get_iter.go
+++ b/get_iter.go
@@ -155,15 +155,14 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 		if g.level >= numLevels {
 			return nil, nil
 		}
-		metadataIter := g.version.Levels[g.level].Iter()
-		if metadataIter.Empty() {
+		if g.version.Levels[g.level].Empty() {
 			g.level++
 			continue
 		}
 
 		iterOpts := IterOptions{logger: g.logger}
 		g.levelIter.init(iterOpts, g.cmp, g.newIters,
-			metadataIter, manifest.Level(g.level), nil)
+			g.version.Levels[g.level].Iter(), manifest.Level(g.level), nil)
 		g.levelIter.initRangeDel(&g.rangeDelIter)
 		g.level++
 		g.iter = &g.levelIter

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -12,6 +12,11 @@ type LevelMetadata struct {
 	files []*FileMetadata
 }
 
+// Empty indicates whether there are any files in the level.
+func (lm *LevelMetadata) Empty() bool {
+	return lm.Len() == 0
+}
+
 // Len returns the number of files within the level.
 func (lm *LevelMetadata) Len() int {
 	return len(lm.files)
@@ -132,11 +137,6 @@ type LevelIterator struct {
 // position.
 func (i *LevelIterator) Clone() LevelIterator {
 	return *i
-}
-
-// Empty indicates whether there are remaining files in the iterator.
-func (i LevelIterator) Empty() bool {
-	return i.cur >= i.end
 }
 
 // Current returns the item at the current iterator position.

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -306,11 +306,11 @@ func (v *Version) Pretty(format base.FormatKey) string {
 		}
 	}
 	for level := 1; level < NumLevels; level++ {
-		iter := v.Levels[level].Iter()
-		if iter.Empty() {
+		if v.Levels[level].Empty() {
 			continue
 		}
 		fmt.Fprintf(&buf, "%d:\n", level)
+		iter := v.Levels[level].Iter()
 		for f := iter.First(); f != nil; f = iter.Next() {
 			fmt.Fprintf(&buf, "  %s:[%s-%s]\n", f.FileNum,
 				format(f.Smallest.UserKey), format(f.Largest.UserKey))
@@ -334,11 +334,11 @@ func (v *Version) DebugString(format base.FormatKey) string {
 		}
 	}
 	for level := 1; level < NumLevels; level++ {
-		iter := v.Levels[level].Iter()
-		if iter.Empty() {
+		if v.Levels[level].Empty() {
 			continue
 		}
 		fmt.Fprintf(&buf, "%d:\n", level)
+		iter := v.Levels[level].Iter()
 		for f := iter.First(); f != nil; f = iter.Next() {
 			fmt.Fprintf(&buf, "  %s:[%s-%s]\n", f.FileNum,
 				f.Smallest.Pretty(format), f.Largest.Pretty(format))

--- a/level_checker.go
+++ b/level_checker.go
@@ -645,13 +645,13 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 		mlevelAlloc = mlevelAlloc[1:]
 	}
 	for level := 1; level < len(current.Levels); level++ {
-		manifestIter := current.Levels[level].Iter()
-		if manifestIter.Empty() {
+		if current.Levels[level].Empty() {
 			continue
 		}
+
 		iterOpts := IterOptions{logger: c.logger}
 		li := &levelIter{}
-		li.init(iterOpts, c.cmp, c.newIters, manifestIter, manifest.Level(level), nil)
+		li.init(iterOpts, c.cmp, c.newIters, current.Levels[level].Iter(), manifest.Level(level), nil)
 		li.initRangeDel(&mlevelAlloc[0].rangeDelIter)
 		li.initSmallestLargestUserKey(&mlevelAlloc[0].smallestUserKey, nil, nil)
 		mlevelAlloc[0].iter = li

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -79,8 +79,7 @@ Check the contents of the MANIFEST files.
 
 func (m *manifestT) printLevels(v *manifest.Version) {
 	for level := range v.Levels {
-		iter := v.Levels[level].Iter()
-		if level == 0 && v.L0Sublevels != nil && !iter.Empty() {
+		if level == 0 && v.L0Sublevels != nil && !v.Levels[level].Empty() {
 			for sublevel := len(v.L0Sublevels.Levels) - 1; sublevel >= 0; sublevel-- {
 				fmt.Fprintf(stdout, "--- L0.%d ---\n", sublevel)
 				for _, f := range v.L0Sublevels.Levels[sublevel] {
@@ -93,6 +92,7 @@ func (m *manifestT) printLevels(v *manifest.Version) {
 			continue
 		}
 		fmt.Fprintf(stdout, "--- L%d ---\n", level)
+		iter := v.Levels[level].Iter()
 		for f := iter.First(); f != nil; f = iter.Next() {
 			fmt.Fprintf(stdout, "  %s:%d", f.FileNum, f.Size)
 			formatSeqNumRange(stdout, f.SmallestSeqNum, f.LargestSeqNum)


### PR DESCRIPTION
Remove the LevelIterator's Empty method and add an Empty method to the
LevelMetadata. It's trickier than expected to implement `Empty` when the
iterators are backed by B-Tree iterators, especially with the semantics
we've been relying on (eg, allowing it to be called on an unpositioned
iterator).