### PR TITLE
pebble: fix compilation failure on 32bits machine

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -798,7 +798,7 @@ func (b *Batch) countData() []byte {
 
 func (b *Batch) grow(n int) {
 	newSize := len(b.data) + n
-	if newSize >= maxBatchSize {
+	if uint64(newSize) >= maxBatchSize {
 		panic(ErrBatchTooLarge)
 	}
 	if newSize > cap(b.data) {

--- a/bloom/bloom.go
+++ b/bloom/bloom.go
@@ -111,7 +111,7 @@ func hash(b []byte) uint32 {
 		seed = 0xbc9f1d34
 		m    = 0xc6a4a793
 	)
-	h := uint32(seed) ^ uint32(len(b)*m)
+	h := uint32(seed) ^ uint32(uint64(uint32(len(b))*m))
 	for ; len(b) >= 4; b = b[4:] {
 		h += uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 | uint32(b[3])<<24
 		h *= m

--- a/data_test.go
+++ b/data_test.go
@@ -384,7 +384,7 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 			flushed:   make(chan struct{}),
 		}}
 		c := newFlush(d.opts, d.mu.versions.currentVersion(),
-			d.mu.versions.picker.getBaseLevel(), toFlush, &d.bytesFlushed)
+			d.mu.versions.picker.getBaseLevel(), toFlush, &d.atomic.bytesFlushed)
 		c.disableRangeTombstoneElision = true
 		newVE, _, err := d.runCompaction(0, c, nilPacer)
 		if err != nil {

--- a/db.go
+++ b/db.go
@@ -160,6 +160,33 @@ type Writer interface {
 //		Comparer: myComparer,
 //	})
 type DB struct {
+	// WARNING: The following struct `atomic` contains fields which are accessed
+	// atomically.
+	//
+	// Go allocations are guaranteed to be 64-bit aligned which we take advantage
+	// of by placing the 64-bit fields which we access atomically at the beginning
+	// of the DB struct. For more information, see https://golang.org/pkg/sync/atomic/#pkg-note-BUG.
+	atomic struct {
+		// The count and size of referenced memtables. This includes memtables
+		// present in DB.mu.mem.queue, as well as memtables that have been flushed
+		// but are still referenced by an inuse readState.
+		memTableCount    int64
+		memTableReserved int64 // number of bytes reserved in the cache for memtables
+
+		// bytesFlushed is the number of bytes flushed in the current flush. This
+		// must be read/written atomically since it is accessed by both the flush
+		// and compaction routines.
+		bytesFlushed uint64
+
+		// bytesCompacted is the number of bytes compacted in the current compaction.
+		// This is used as a dummy variable to increment during compaction, and the
+		// value is not used anywhere.
+		bytesCompacted uint64
+
+		// The size of the current log file (i.e. db.mu.log.queue[len(queue)-1].
+		logSize uint64
+	}
+
 	cacheID        uint64
 	dirname        string
 	walDirname     string
@@ -190,7 +217,6 @@ type DB struct {
 		sync.RWMutex
 		val *readState
 	}
-
 	// logRecycler holds a set of log file numbers that are available for
 	// reuse. Writing to a recycled log file is faster than to a new log file on
 	// some common filesystems (xfs, and ext3/4) due to avoiding metadata
@@ -200,24 +226,8 @@ type DB struct {
 	closed   atomic.Value
 	closedCh chan struct{}
 
-	// The count and size of referenced memtables. This includes memtables
-	// present in DB.mu.mem.queue, as well as memtables that have been flushed
-	// but are still referenced by an inuse readState.
-	memTableCount    int64
-	memTableReserved int64 // number of bytes reserved in the cache for memtables
-
 	compactionLimiter limiter
-
-	// bytesFlushed is the number of bytes flushed in the current flush. This
-	// must be read/written atomically since it is accessed by both the flush
-	// and compaction routines.
-	bytesFlushed uint64
-	// bytesCompacted is the number of bytes compacted in the current compaction.
-	// This is used as a dummy variable to increment during compaction, and the
-	// value is not used anywhere.
-	bytesCompacted uint64
-
-	flushLimiter limiter
+	flushLimiter      limiter
 
 	// The main mutex protecting internal DB state. This mutex encompasses many
 	// fields because those fields need to be accessed and updated atomically. In
@@ -239,8 +249,9 @@ type DB struct {
 		nextJobID int
 
 		// The collection of immutable versions and state about the log and visible
-		// sequence numbers.
-		versions versionSet
+		// sequence numbers. Use the pointer here to ensure the atomic fields in
+		// version set are aligned properly.
+		versions *versionSet
 
 		log struct {
 			// The queue of logs, containing both flushed and unflushed logs. The
@@ -248,8 +259,6 @@ type DB struct {
 			// delimeter between flushed and unflushed logs is
 			// versionSet.minUnflushedLogNum.
 			queue []FileNum
-			// The size of the current log file (i.e. queue[len(queue)-1].
-			size uint64
 			// The number of input bytes to the log. This is the raw size of the
 			// batches written to the WAL, without the overhead of the record
 			// envelopes.
@@ -372,7 +381,7 @@ func (d *DB) getInternal(key []byte, b *Batch, s *Snapshot) ([]byte, io.Closer, 
 	if s != nil {
 		seqNum = s.seqNum
 	} else {
-		seqNum = atomic.LoadUint64(&d.mu.versions.visibleSeqNum)
+		seqNum = atomic.LoadUint64(&d.mu.versions.atomic.visibleSeqNum)
 	}
 
 	var buf struct {
@@ -644,7 +653,7 @@ func (d *DB) commitWrite(b *Batch, syncWG *sync.WaitGroup, syncErr *error) (*mem
 		}
 	}
 
-	atomic.StoreUint64(&d.mu.log.size, uint64(size))
+	atomic.StoreUint64(&d.atomic.logSize, uint64(size))
 	return mem, err
 }
 
@@ -682,7 +691,7 @@ func (d *DB) newIterInternal(
 	if s != nil {
 		seqNum = s.seqNum
 	} else {
-		seqNum = atomic.LoadUint64(&d.mu.versions.visibleSeqNum)
+		seqNum = atomic.LoadUint64(&d.mu.versions.atomic.visibleSeqNum)
 	}
 
 	// Bundle various structures under a single umbrella in order to allocate
@@ -828,7 +837,7 @@ func (d *DB) NewSnapshot() *Snapshot {
 	d.mu.Lock()
 	s := &Snapshot{
 		db:     d,
-		seqNum: atomic.LoadUint64(&d.mu.versions.visibleSeqNum),
+		seqNum: atomic.LoadUint64(&d.mu.versions.atomic.visibleSeqNum),
 	}
 	d.mu.snapshots.pushBack(s)
 	d.mu.Unlock()
@@ -899,7 +908,7 @@ func (d *DB) Close() error {
 		for _, mem := range d.mu.mem.queue {
 			mem.readerUnref()
 		}
-		if reserved := atomic.LoadInt64(&d.memTableReserved); reserved != 0 {
+		if reserved := atomic.LoadInt64(&d.atomic.memTableReserved); reserved != 0 {
 			return errors.Errorf("leaked memtable reservation: %d", errors.Safe(reserved))
 		}
 	}
@@ -930,7 +939,7 @@ func (d *DB) Compact(
 
 	iStart := base.MakeInternalKey(start, InternalKeySeqNumMax, InternalKeyKindMax)
 	iEnd := base.MakeInternalKey(end, 0, 0)
-	meta := []*fileMetadata{&fileMetadata{Smallest: iStart, Largest: iEnd}}
+	meta := []*fileMetadata{{Smallest: iStart, Largest: iEnd}}
 
 	d.mu.Lock()
 	maxLevelWithFiles := 1
@@ -1052,15 +1061,15 @@ func (d *DB) Metrics() *Metrics {
 	d.mu.Lock()
 	*metrics = d.mu.versions.metrics
 	metrics.Compact.EstimatedDebt = d.mu.versions.picker.estimatedCompactionDebt(0)
-	metrics.Compact.InProgressBytes = atomic.LoadInt64(&d.mu.versions.atomicInProgressBytes)
+	metrics.Compact.InProgressBytes = atomic.LoadInt64(&d.mu.versions.atomic.atomicInProgressBytes)
 	for _, m := range d.mu.mem.queue {
 		metrics.MemTable.Size += m.totalBytes()
 	}
 	metrics.MemTable.Count = int64(len(d.mu.mem.queue))
-	metrics.MemTable.ZombieCount = atomic.LoadInt64(&d.memTableCount) - metrics.MemTable.Count
-	metrics.MemTable.ZombieSize = uint64(atomic.LoadInt64(&d.memTableReserved)) - metrics.MemTable.Size
+	metrics.MemTable.ZombieCount = atomic.LoadInt64(&d.atomic.memTableCount) - metrics.MemTable.Count
+	metrics.MemTable.ZombieSize = uint64(atomic.LoadInt64(&d.atomic.memTableReserved)) - metrics.MemTable.Size
 	metrics.WAL.ObsoleteFiles = int64(recycledLogs)
-	metrics.WAL.Size = atomic.LoadUint64(&d.mu.log.size)
+	metrics.WAL.Size = atomic.LoadUint64(&d.atomic.logSize)
 	metrics.WAL.BytesIn = d.mu.log.bytesIn // protected by d.mu
 	for i, n := 0, len(d.mu.mem.queue)-1; i < n; i++ {
 		metrics.WAL.Size += d.mu.mem.queue[i].logSize
@@ -1200,8 +1209,8 @@ func (d *DB) newMemTable(logNum FileNum, logSeqNum uint64) (*memTable, *flushabl
 		}
 	}
 
-	atomic.AddInt64(&d.memTableCount, 1)
-	atomic.AddInt64(&d.memTableReserved, int64(size))
+	atomic.AddInt64(&d.atomic.memTableCount, 1)
+	atomic.AddInt64(&d.atomic.memTableReserved, int64(size))
 	releaseAccountingReservation := d.opts.Cache.Reserve(size)
 
 	mem := newMemTable(memTableOptions{
@@ -1217,8 +1226,8 @@ func (d *DB) newMemTable(logNum FileNum, logSeqNum uint64) (*memTable, *flushabl
 	entry.releaseMemAccounting = func() {
 		manual.Free(mem.arenaBuf)
 		mem.arenaBuf = nil
-		atomic.AddInt64(&d.memTableCount, -1)
-		atomic.AddInt64(&d.memTableReserved, -int64(size))
+		atomic.AddInt64(&d.atomic.memTableCount, -1)
+		atomic.AddInt64(&d.atomic.memTableReserved, -int64(size))
 		releaseAccountingReservation()
 	}
 	return mem, entry
@@ -1430,7 +1439,7 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 				logSeqNum += uint64(b.Count())
 			}
 		} else {
-			logSeqNum = atomic.LoadUint64(&d.mu.versions.logSeqNum)
+			logSeqNum = atomic.LoadUint64(&d.mu.versions.atomic.logSeqNum)
 		}
 
 		// Create a new memtable, scheduling the previous one for flushing. We do

--- a/db_test.go
+++ b/db_test.go
@@ -386,7 +386,7 @@ func TestLargeBatch(t *testing.T) {
 
 	startLogNum := logNum()
 	startLogStartSize := fileSize(startLogNum)
-	startSeqNum := atomic.LoadUint64(&d.mu.versions.logSeqNum)
+	startSeqNum := atomic.LoadUint64(&d.mu.versions.atomic.logSeqNum)
 
 	// Write a key with a value larger than the memtable size.
 	require.NoError(t, d.Set([]byte("a"), bytes.Repeat([]byte("a"), 512), nil))
@@ -735,7 +735,7 @@ func TestMemTableReservation(t *testing.T) {
 
 	checkReserved := func(expected int64) {
 		t.Helper()
-		if reserved := atomic.LoadInt64(&d.memTableReserved); expected != reserved {
+		if reserved := atomic.LoadInt64(&d.atomic.memTableReserved); expected != reserved {
 			t.Fatalf("expected %d reserved, but found %d", expected, reserved)
 		}
 	}

--- a/level_checker.go
+++ b/level_checker.go
@@ -565,7 +565,7 @@ func (d *DB) CheckLevels(stats *CheckLevelsStats) error {
 
 	// Determine the seqnum to read at after grabbing the read state (current and
 	// memtables) above.
-	seqNum := atomic.LoadUint64(&d.mu.versions.visibleSeqNum)
+	seqNum := atomic.LoadUint64(&d.mu.versions.atomic.visibleSeqNum)
 
 	checkConfig := &checkConfig{
 		logger:    d.opts.Logger,

--- a/options.go
+++ b/options.go
@@ -917,7 +917,7 @@ func (o *Options) Validate() error {
 		fmt.Fprintf(&buf, "L0StopWritesThreshold (%d) must be >= L0CompactionThreshold (%d)\n",
 			o.L0StopWritesThreshold, o.L0CompactionThreshold)
 	}
-	if o.MemTableSize >= maxMemTableSize {
+	if uint64(o.MemTableSize) >= maxMemTableSize {
 		fmt.Fprintf(&buf, "MemTableSize (%s) must be < %s\n",
 			humanize.Uint64(uint64(o.MemTableSize)), humanize.Uint64(maxMemTableSize))
 	}

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -435,11 +435,11 @@ func TestTableCacheClockPro(t *testing.T) {
 			tables[key] = true
 		}
 
-		oldHits := atomic.LoadInt64(&cache.hits)
+		oldHits := atomic.LoadInt64(&cache.atomic.hits)
 		v := cache.findNode(&fileMetadata{FileNum: FileNum(key)})
 		cache.unrefValue(v)
 
-		hit := atomic.LoadInt64(&cache.hits) != oldHits
+		hit := atomic.LoadInt64(&cache.atomic.hits) != oldHits
 		wantHit := fields[1][0] == 'h'
 		if hit != wantHit {
 			t.Errorf("%d: cache hit mismatch: got %v, want %v\n", line, hit, wantHit)

--- a/version_set.go
+++ b/version_set.go
@@ -36,6 +36,27 @@ type versionList = manifest.VersionList
 // like it sounds: a delta from the previous version. Version edits are logged
 // to the MANIFEST file, which is replayed at startup.
 type versionSet struct {
+	// WARNING: The following struct `atomic` contains fields are accessed atomically.
+	//
+	// Go allocations are guaranteed to be 64-bit aligned which we take advantage
+	// of by placing the 64-bit fields which we access atomically at the beginning
+	// of the versionSet struct.
+	// For more information, see https://golang.org/pkg/sync/atomic/#pkg-note-BUG.
+	atomic struct {
+		logSeqNum uint64 // next seqNum to use for WAL writes
+
+		// The upper bound on sequence numbers that have been assigned so far.
+		// A suffix of these sequence numbers may not have been written to a
+		// WAL. Both logSeqNum and visibleSeqNum are atomically updated by the
+		// commitPipeline.
+		visibleSeqNum uint64 // visible seqNum (<= logSeqNum)
+
+		// Number of bytes present in sstables being written by in-progress
+		// compactions. This value will be zero if there are no in-progress
+		// compactions. Updated and read atomically.
+		atomicInProgressBytes int64
+	}
+
 	// Immutable fields.
 	dirname string
 	// Set to DB.mu.
@@ -72,18 +93,6 @@ type versionSet struct {
 	// The next file number. A single counter is used to assign file numbers
 	// for the WAL, MANIFEST, sstable, and OPTIONS files.
 	nextFileNum FileNum
-
-	// The upper bound on sequence numbers that have been assigned so far.
-	// A suffix of these sequence numbers may not have been written to a
-	// WAL. Both logSeqNum and visibleSeqNum are atomically updated by the
-	// commitPipeline.
-	logSeqNum     uint64 // next seqNum to use for WAL writes
-	visibleSeqNum uint64 // visible seqNum (<= logSeqNum)
-
-	// Number of bytes present in sstables being written by in-progress
-	// compactions. This value will be zero if there are no in-progress
-	// compactions. Updated and read atomically.
-	atomicInProgressBytes int64
 
 	// The current manifest file number.
 	manifestFileNum FileNum
@@ -244,7 +253,7 @@ func (vs *versionSet) load(dirname string, opts *Options, mu *sync.Mutex) error 
 			// (assuming no WALs contain higher sequence numbers than the
 			// manifest's LastSeqNum). Increment LastSeqNum by 1 to get the
 			// next sequence number that will be assigned.
-			vs.logSeqNum = ve.LastSeqNum + 1
+			vs.atomic.logSeqNum = ve.LastSeqNum + 1
 		}
 	}
 	// We have already set vs.nextFileNum = 2 at the beginning of the
@@ -363,7 +372,7 @@ func (vs *versionSet) logAndApply(
 	// in an unflushed memtable. logSeqNum is the _next_ sequence number that
 	// will be assigned, so subtract that by 1 to get the upper bound on the
 	// last assigned sequence number.
-	logSeqNum := atomic.LoadUint64(&vs.logSeqNum)
+	logSeqNum := atomic.LoadUint64(&vs.atomic.logSeqNum)
 	ve.LastSeqNum = logSeqNum - 1
 	if logSeqNum == 0 {
 		// logSeqNum is initialized to 1 in Open() if there are no previous WAL
@@ -513,7 +522,7 @@ func (vs *versionSet) incrementFlushes() {
 }
 
 func (vs *versionSet) incrementCompactionBytes(numBytes int64) {
-	atomic.AddInt64(&vs.atomicInProgressBytes, numBytes)
+	atomic.AddInt64(&vs.atomic.atomicInProgressBytes, numBytes)
 }
 
 // createManifest creates a manifest file that contains a snapshot of vs.

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -104,5 +104,5 @@ func TestVersionSetSeqNums(t *testing.T) {
 	// 2 ingestions happened, so LastSeqNum should equal 2.
 	require.Equal(t, uint64(2), lastSeqNum)
 	// logSeqNum is always one greater than the last assigned sequence number.
-	require.Equal(t, d.mu.versions.logSeqNum, lastSeqNum+1)
+	require.Equal(t, d.mu.versions.atomic.logSeqNum, lastSeqNum+1)
 }


### PR DESCRIPTION
This PR mainly fixes a few compilation failures on 32bits machine.

The most important one is field alignment on 32bits machine. According the the go issue https://golang.org/pkg/sync/atomic/#pkg-note-BUG. `On 32 bit platforms, only 64-bit aligned fields can be atomic.`
But in the pebble codebase, uint64/int64 atomic fields are not aligned properly which will lead to crash.