### PR TITLE
db: use incrementally-computed sizes in initLevelMaxBytes

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -187,6 +187,14 @@ type Metrics struct {
 	}
 }
 
+func (m *Metrics) levelSizes() [numLevels]int64 {
+	var sizes [numLevels]int64
+	for i := 0; i < len(sizes); i++ {
+		sizes[i] = m.Levels[i].Size
+	}
+	return sizes
+}
+
 // ReadAmp returns the current read amplification of the database.
 // It's computed as the number of sublevels in L0 + the number of non-empty
 // levels below L0.


### PR DESCRIPTION
The `versionSet` incrementally computes stats on each level, including
the total size of the level. Use those sizes in the compaction picker's
`initLevelMaxBytes` rather than recomputing the sizes from scratch.

```
name                                        old time/op  new time/op  delta
ManySSTablesNewVersion/sstables=10-16        186µs ± 7%   182µs ± 4%     ~     (p=0.310 n=6+6)
ManySSTablesNewVersion/sstables=1000-16      212µs ± 7%   205µs ± 1%   -3.58%  (p=0.030 n=6+5)
ManySSTablesNewVersion/sstables=10000-16     376µs ± 3%   365µs ± 2%   -2.89%  (p=0.030 n=6+5)
ManySSTablesNewVersion/sstables=100000-16   6.05ms ± 3%  6.01ms ± 2%     ~     (p=0.818 n=6+6)
ManySSTablesNewVersion/sstables=1000000-16  84.0ms ± 4%  73.3ms ± 2%  -12.74%  (p=0.002 n=6+6)
```