### PR TITLE
crl-release-20.2: db: prevent conflicting, concurrent L0->LBase compactions

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -767,14 +767,16 @@ func (d *DB) removeInProgressCompaction(c *compaction) {
 		iter := cl.files.Iter()
 		for f := iter.First(); f != nil; f = iter.Next() {
 			if !f.Compacting {
-				d.opts.Logger.Fatalf("L%d->L%d: %s already being compacted", c.startLevel.level, c.outputLevel.level, f.FileNum)
+				d.opts.Logger.Fatalf("L%d->L%d: %s not being compacted", c.startLevel.level, c.outputLevel.level, f.FileNum)
 			}
 			f.Compacting = false
 			f.IsIntraL0Compacting = false
 		}
 	}
 	delete(d.mu.compact.inProgress, c)
-	d.mu.versions.currentVersion().L0Sublevels.InitCompactingFileInfo()
+
+	l0InProgress := inProgressL0Compactions(d.getInProgressCompactionInfoLocked(c))
+	d.mu.versions.currentVersion().L0Sublevels.InitCompactingFileInfo(l0InProgress)
 }
 
 func (d *DB) getCompactionPacerInfo() compactionPacerInfo {

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -450,24 +450,14 @@ func TestCompactionPickerL0(t *testing.T) {
 		}
 		m.SmallestSeqNum = m.Smallest.SeqNum()
 		m.LargestSeqNum = m.Largest.SeqNum()
-
-		for _, field := range fields[1:] {
-			switch field {
-			case "intra_l0_compacting":
-				m.IsIntraL0Compacting = true
-				m.Compacting = true
-			case "base_compacting":
-				fallthrough
-			case "compacting":
-				m.Compacting = true
-			}
-		}
 		return m, nil
 	}
 
 	opts := (*Options)(nil).EnsureDefaults()
 	opts.Experimental.L0SublevelCompactions = true
+	opts.Experimental.L0CompactionConcurrency = 1
 	var picker *compactionPickerByScore
+	var inProgressCompactions []compactionInfo
 
 	datadriven.RunTest(t, "testdata/compaction_picker_L0", func(td *datadriven.TestData) string {
 		switch td.Cmd {
@@ -476,14 +466,20 @@ func TestCompactionPickerL0(t *testing.T) {
 			baseLevel := manifest.NumLevels - 1
 			level := 0
 			var err error
-			for _, data := range strings.Split(td.Input, "\n") {
-				data = strings.TrimSpace(data)
+			lines := strings.Split(td.Input, "\n")
+			var compactionLines []string
+
+			for len(lines) > 0 {
+				data := strings.TrimSpace(lines[0])
+				lines = lines[1:]
 				switch data {
 				case "L0", "L1", "L2", "L3", "L4", "L5", "L6":
 					level, err = strconv.Atoi(data[1:])
 					if err != nil {
 						return err.Error()
 					}
+				case "compactions":
+					compactionLines, lines = lines, nil
 				default:
 					meta, err := parseMeta(data)
 					if err != nil {
@@ -496,7 +492,76 @@ func TestCompactionPickerL0(t *testing.T) {
 				}
 			}
 
+			// Parse in-progress compactions in the form of:
+			//   L0 000001 -> L2 000005
+			inProgressCompactions = nil
+			for len(compactionLines) > 0 {
+				parts := strings.Fields(compactionLines[0])
+				compactionLines = compactionLines[1:]
+
+				var level int
+				var info compactionInfo
+				first := true
+				compactionFiles := map[int][]*fileMetadata{}
+				for _, p := range parts {
+					switch p {
+					case "L0", "L1", "L2", "L3", "L4", "L5", "L6":
+						var err error
+						level, err = strconv.Atoi(p[1:])
+						if err != nil {
+							return err.Error()
+						}
+						if len(info.inputs) > 0 && info.inputs[len(info.inputs)-1].level == level {
+							// eg, L0 -> L0 compaction or L6 -> L6 compaction
+							continue
+						}
+						if info.outputLevel < level {
+							info.outputLevel = level
+						}
+						info.inputs = append(info.inputs, compactionLevel{level: level})
+					case "->":
+						continue
+					default:
+						fileNum, err := strconv.Atoi(p)
+						if err != nil {
+							return err.Error()
+						}
+						var compactFile *fileMetadata
+						for _, m := range fileMetas[level] {
+							if m.FileNum == FileNum(fileNum) {
+								compactFile = m
+							}
+						}
+						if compactFile == nil {
+							return fmt.Sprintf("cannot find compaction file %s", FileNum(fileNum))
+						}
+						compactFile.Compacting = true
+						if first || base.InternalCompare(DefaultComparer.Compare, info.largest, compactFile.Largest) < 0 {
+							info.largest = compactFile.Largest
+						}
+						if first || base.InternalCompare(DefaultComparer.Compare, info.smallest, compactFile.Smallest) > 0 {
+							info.smallest = compactFile.Smallest
+						}
+						first = false
+						compactionFiles[level] = append(compactionFiles[level], compactFile)
+					}
+				}
+				for i, cl := range info.inputs {
+					files := compactionFiles[cl.level]
+					info.inputs[i].files = manifest.NewLevelSlice(files)
+					// Mark as intra-L0 compacting if the compaction is
+					// L0 -> L0.
+					if info.outputLevel == 0 {
+						for _, f := range files {
+							f.IsIntraL0Compacting = true
+						}
+					}
+				}
+				inProgressCompactions = append(inProgressCompactions, info)
+			}
+
 			version := newVersion(opts, fileMetas)
+			version.L0Sublevels.InitCompactingFileInfo(inProgressL0Compactions(inProgressCompactions))
 			vs := &versionSet{
 				opts:    opts,
 				cmp:     DefaultComparer.Compare,
@@ -510,26 +575,17 @@ func TestCompactionPickerL0(t *testing.T) {
 				baseLevel: baseLevel,
 			}
 			vs.picker = picker
-			inProgressCompactions := []compactionInfo{}
-			for level, files := range version.Levels {
-				files.Slice().Each(func(f *fileMetadata) {
-					if f.Compacting {
-						c := compactionInfo{
-							inputs: []compactionLevel{
-								{level: level},
-								{level: level + 1, files: manifest.NewLevelSlice([]*fileMetadata{f})},
-							},
-							outputLevel: level + 1,
-						}
-						if f.IsIntraL0Compacting {
-							c.outputLevel = c.inputs[0].level
-						}
-						inProgressCompactions = append(inProgressCompactions, c)
-					}
-				})
-			}
 			picker.initLevelMaxBytes(inProgressCompactions)
-			return version.DebugString(base.DefaultFormatter)
+
+			var buf bytes.Buffer
+			fmt.Fprint(&buf, version.DebugString(base.DefaultFormatter))
+			if len(inProgressCompactions) > 0 {
+				fmt.Fprintln(&buf, "compactions")
+				for _, c := range inProgressCompactions {
+					fmt.Fprintf(&buf, "  %s\n", c.String())
+				}
+			}
+			return buf.String()
 		case "pick-auto":
 			for _, arg := range td.CmdArgs {
 				var err error
@@ -545,6 +601,210 @@ func TestCompactionPickerL0(t *testing.T) {
 			pc := picker.pickAuto(compactionEnv{
 				bytesCompacted:          new(uint64),
 				earliestUnflushedSeqNum: math.MaxUint64,
+				inProgressCompactions:   inProgressCompactions,
+			})
+			var result strings.Builder
+			if pc != nil {
+				c := newCompaction(pc, opts, new(uint64))
+				fmt.Fprintf(&result, "L%d -> L%d\n", pc.startLevel.level, pc.outputLevel.level)
+				fmt.Fprintf(&result, "L%d: %s\n", pc.startLevel.level, fileNums(pc.startLevel.files))
+				if !pc.outputLevel.files.Empty() {
+					fmt.Fprintf(&result, "L%d: %s\n", pc.outputLevel.level, fileNums(pc.outputLevel.files))
+				}
+				if !c.grandparents.Empty() {
+					fmt.Fprintf(&result, "grandparents: %s\n", fileNums(c.grandparents))
+				}
+			} else {
+				return "nil"
+			}
+			return result.String()
+		}
+		return fmt.Sprintf("unrecognized command: %s", td.Cmd)
+	})
+}
+
+func TestCompactionPickerConcurrency(t *testing.T) {
+	fileNums := func(files manifest.LevelSlice) string {
+		var ss []string
+		files.Each(func(f *fileMetadata) {
+			ss = append(ss, f.FileNum.String())
+		})
+		sort.Strings(ss)
+		return strings.Join(ss, ",")
+	}
+
+	parseMeta := func(s string) (*fileMetadata, error) {
+		parts := strings.Split(s, ":")
+		fileNum, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return nil, err
+		}
+		fields := strings.Fields(parts[1])
+		parts = strings.Split(fields[0], "-")
+		if len(parts) != 2 {
+			return nil, errors.Errorf("malformed table spec: %s", s)
+		}
+		m := &fileMetadata{
+			FileNum:  base.FileNum(fileNum),
+			Size:     1028,
+			Smallest: base.ParseInternalKey(strings.TrimSpace(parts[0])),
+			Largest:  base.ParseInternalKey(strings.TrimSpace(parts[1])),
+		}
+		for _, p := range fields[1:] {
+			if strings.HasPrefix(p, "size=") {
+				v, err := strconv.Atoi(strings.TrimPrefix(p, "size="))
+				if err != nil {
+					return nil, err
+				}
+				m.Size = uint64(v)
+			}
+		}
+		m.SmallestSeqNum = m.Smallest.SeqNum()
+		m.LargestSeqNum = m.Largest.SeqNum()
+		return m, nil
+	}
+
+	opts := (*Options)(nil).EnsureDefaults()
+	opts.Experimental.L0SublevelCompactions = true
+	opts.Experimental.L0CompactionConcurrency = 1
+	var picker *compactionPickerByScore
+	var inProgressCompactions []compactionInfo
+
+	datadriven.RunTest(t, "testdata/compaction_picker_concurrency", func(td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "define":
+			fileMetas := [manifest.NumLevels][]*fileMetadata{}
+			level := 0
+			var err error
+			lines := strings.Split(td.Input, "\n")
+			var compactionLines []string
+
+			for len(lines) > 0 {
+				data := strings.TrimSpace(lines[0])
+				lines = lines[1:]
+				switch data {
+				case "L0", "L1", "L2", "L3", "L4", "L5", "L6":
+					level, err = strconv.Atoi(data[1:])
+					if err != nil {
+						return err.Error()
+					}
+				case "compactions":
+					compactionLines, lines = lines, nil
+				default:
+					meta, err := parseMeta(data)
+					if err != nil {
+						return err.Error()
+					}
+					fileMetas[level] = append(fileMetas[level], meta)
+				}
+			}
+
+			// Parse in-progress compactions in the form of:
+			//   L0 000001 -> L2 000005
+			inProgressCompactions = nil
+			for len(compactionLines) > 0 {
+				parts := strings.Fields(compactionLines[0])
+				compactionLines = compactionLines[1:]
+
+				var level int
+				var info compactionInfo
+				first := true
+				compactionFiles := map[int][]*fileMetadata{}
+				for _, p := range parts {
+					switch p {
+					case "L0", "L1", "L2", "L3", "L4", "L5", "L6":
+						var err error
+						level, err = strconv.Atoi(p[1:])
+						if err != nil {
+							return err.Error()
+						}
+						if len(info.inputs) > 0 && info.inputs[len(info.inputs)-1].level == level {
+							// eg, L0 -> L0 compaction or L6 -> L6 compaction
+							continue
+						}
+						if info.outputLevel < level {
+							info.outputLevel = level
+						}
+						info.inputs = append(info.inputs, compactionLevel{level: level})
+					case "->":
+						continue
+					default:
+						fileNum, err := strconv.Atoi(p)
+						if err != nil {
+							return err.Error()
+						}
+						var compactFile *fileMetadata
+						for _, m := range fileMetas[level] {
+							if m.FileNum == FileNum(fileNum) {
+								compactFile = m
+							}
+						}
+						if compactFile == nil {
+							return fmt.Sprintf("cannot find compaction file %s", FileNum(fileNum))
+						}
+						compactFile.Compacting = true
+						if first || base.InternalCompare(DefaultComparer.Compare, info.largest, compactFile.Largest) < 0 {
+							info.largest = compactFile.Largest
+						}
+						if first || base.InternalCompare(DefaultComparer.Compare, info.smallest, compactFile.Smallest) > 0 {
+							info.smallest = compactFile.Smallest
+						}
+						first = false
+						compactionFiles[level] = append(compactionFiles[level], compactFile)
+					}
+				}
+				for i, cl := range info.inputs {
+					files := compactionFiles[cl.level]
+					info.inputs[i].files = manifest.NewLevelSlice(files)
+					// Mark as intra-L0 compacting if the compaction is
+					// L0 -> L0.
+					if info.outputLevel == 0 {
+						for _, f := range files {
+							f.IsIntraL0Compacting = true
+						}
+					}
+				}
+				inProgressCompactions = append(inProgressCompactions, info)
+			}
+
+			version := newVersion(opts, fileMetas)
+			version.L0Sublevels.InitCompactingFileInfo(inProgressL0Compactions(inProgressCompactions))
+			vs := &versionSet{
+				opts:    opts,
+				cmp:     DefaultComparer.Compare,
+				cmpName: DefaultComparer.Name,
+			}
+			vs.versions.Init(nil)
+			vs.append(version)
+			picker = newCompactionPicker(version, opts, inProgressCompactions).(*compactionPickerByScore)
+			vs.picker = picker
+
+			var buf bytes.Buffer
+			fmt.Fprint(&buf, version.DebugString(base.DefaultFormatter))
+			if len(inProgressCompactions) > 0 {
+				fmt.Fprintln(&buf, "compactions")
+				for _, c := range inProgressCompactions {
+					fmt.Fprintf(&buf, "  %s\n", c.String())
+				}
+			}
+			return buf.String()
+
+		case "pick-auto":
+			for _, arg := range td.CmdArgs {
+				var err error
+				switch arg.Key {
+				case "l0_compaction_threshold":
+					opts.L0CompactionThreshold, err = strconv.Atoi(arg.Vals[0])
+					if err != nil {
+						return err.Error()
+					}
+				}
+			}
+
+			pc := picker.pickAuto(compactionEnv{
+				bytesCompacted:          new(uint64),
+				earliestUnflushedSeqNum: math.MaxUint64,
+				inProgressCompactions:   inProgressCompactions,
 			})
 			var result strings.Builder
 			if pc != nil {

--- a/db.go
+++ b/db.go
@@ -1474,6 +1474,8 @@ func (d *DB) getInProgressCompactionInfoLocked(finishing *compaction) (rv []comp
 		if len(c.flushing) == 0 && (finishing == nil || c != finishing) {
 			info := compactionInfo{
 				inputs:      c.inputs,
+				smallest:    c.smallest,
+				largest:     c.largest,
 				outputLevel: -1,
 			}
 			if c.outputLevel != nil {
@@ -1483,6 +1485,25 @@ func (d *DB) getInProgressCompactionInfoLocked(finishing *compaction) (rv []comp
 		}
 	}
 	return
+}
+
+func inProgressL0Compactions(inProgress []compactionInfo) []manifest.L0Compaction {
+	var compactions []manifest.L0Compaction
+	for _, info := range inProgress {
+		l0 := false
+		for _, cl := range info.inputs {
+			l0 = l0 || cl.level == 0
+		}
+		if !l0 {
+			continue
+		}
+		compactions = append(compactions, manifest.L0Compaction{
+			Smallest:  info.smallest,
+			Largest:   info.largest,
+			IsIntraL0: info.outputLevel == 0,
+		})
+	}
+	return compactions
 }
 
 // firstError returns the first non-nil error of err0 and err1, or nil if both

--- a/testdata/compaction_picker_L0
+++ b/testdata/compaction_picker_L0
@@ -182,9 +182,11 @@ define
 L0
    000100:i.SET.101-p.SET.102
    000110:j.SET.111-q.SET.112
-   000120:r.SET.113-s.SET.114 intra_l0_compacting
+   000120:r.SET.113-s.SET.114
 L6
    000200:f.SET.51-s.SET.52
+compactions
+  L0 000120 -> L0
 ----
 0.1:
   000110:[j#111,SET-q#112,SET]
@@ -193,6 +195,8 @@ L6
   000120:[r#113,SET-s#114,SET]
 6:
   000200:[f#51,SET-s#52,SET]
+compactions
+  L0 000120 -> L0
 
 pick-auto l0_compaction_threshold=2
 ----
@@ -209,7 +213,9 @@ L0
    000110:j.SET.111-q.SET.112
    000120:r.SET.113-s.SET.114
 L6
-   000200:f.SET.51-s.SET.52 compacting
+   000200:f.SET.51-s.SET.52
+compactions
+  L6 000200 -> L6
 ----
 0.1:
   000110:[j#111,SET-q#112,SET]
@@ -218,6 +224,8 @@ L6
   000120:[r#113,SET-s#114,SET]
 6:
   000200:[f#51,SET-s#52,SET]
+compactions
+  L6 000200 -> L6
 
 pick-auto l0_compaction_threshold=2
 ----
@@ -231,13 +239,48 @@ define
 L0
    000100:i.SET.101-p.SET.102
 L6
-   000200:f.SET.51-s.SET.52 compacting
+   000200:f.SET.51-s.SET.52
+compactions
+  L6 000200 -> L6
 ----
 0.0:
   000100:[i#101,SET-p#102,SET]
 6:
   000200:[f#51,SET-s#52,SET]
+compactions
+  L6 000200 -> L6
 
 pick-auto l0_compaction_threshold=1
+----
+nil
+
+# Test an in-progress L0->Lbase compaction with another L0 file that does not
+# overlap any of the compacting files in L0 or Lbase, but does overlap the
+# compaction's range. No new compaction should be picked because the
+# in-progress compaction's output tables could overlap the non-compacting
+# file.
+
+define
+L0
+  000010:a.SET.11-b.SET.12
+  000013:k.SET.23-n.SET.24
+  000011:x.SET.13-z.SET.25
+L1
+  000101:a.SET.1-f.SET.2
+  000102:w.SET.3-z.SET.4
+compactions
+  L0 000010 000011 -> L1 000101 000102
+----
+0.0:
+  000010:[a#11,SET-b#12,SET]
+  000013:[k#23,SET-n#24,SET]
+  000011:[x#13,SET-z#25,SET]
+1:
+  000101:[a#1,SET-f#2,SET]
+  000102:[w#3,SET-z#4,SET]
+compactions
+  L0 000010 000011 -> L1 000101 000102
+
+pick-auto l0_compaction_threshold=2
 ----
 nil

--- a/testdata/compaction_picker_concurrency
+++ b/testdata/compaction_picker_concurrency
@@ -1,0 +1,51 @@
+# Test a file L1.000203 that would be a candidate for a move compaction into
+# L2, except that it's bordered by two files participating in the same
+# compaction. This is possible if 000203 created by a L0->L1 compaction that
+# completed after the compaction of 000201 and 000202 began.
+#
+# The in-progress compaction of 000201 and 000202  will write an output table
+# to L2 that would conflict with 000203 if 000203 was moved into L2.
+#
+# NB: The L0 files are used to increase the permitted compaction concurrency.
+define
+L0
+  000301:a.SET.31-a.SET.31
+  000302:a.SET.32-a.SET.32
+  000303:a.SET.33-a.SET.33
+  000304:a.SET.34-a.SET.34
+  000305:a.SET.35-a.SET.35
+L1
+  000201:a.SET.21-b.SET.22
+  000203:k.SET.25-n.SET.26 size=512000000
+  000202:x.SET.23-z.SET.24
+L2
+  000101:a.SET.11-f.SET.12
+L3
+  000010:a.SET.1-z.SET.2
+compactions
+  L1 000201 000202 -> L2 000101
+----
+0.4:
+  000305:[a#35,SET-a#35,SET]
+0.3:
+  000304:[a#34,SET-a#34,SET]
+0.2:
+  000303:[a#33,SET-a#33,SET]
+0.1:
+  000302:[a#32,SET-a#32,SET]
+0.0:
+  000301:[a#31,SET-a#31,SET]
+1:
+  000201:[a#21,SET-b#22,SET]
+  000203:[k#25,SET-n#26,SET]
+  000202:[x#23,SET-z#24,SET]
+2:
+  000101:[a#11,SET-f#12,SET]
+3:
+  000010:[a#1,SET-z#2,SET]
+compactions
+  L1 000201 000202 -> L2 000101
+
+pick-auto l0_compaction_threshold=10
+----
+nil

--- a/version_set.go
+++ b/version_set.go
@@ -263,7 +263,7 @@ func (vs *versionSet) load(dirname string, opts *Options, mu *sync.Mutex) error 
 	if err != nil {
 		return err
 	}
-	newVersion.L0Sublevels.InitCompactingFileInfo()
+	newVersion.L0Sublevels.InitCompactingFileInfo(nil /* in-progress compactions */)
 	vs.append(newVersion)
 
 	vs.picker = newCompactionPicker(newVersion, vs.opts, nil)
@@ -452,7 +452,9 @@ func (vs *versionSet) logAndApply(
 
 	// Now that DB.mu is held again, initialize compacting file info in
 	// L0Sublevels.
-	newVersion.L0Sublevels.InitCompactingFileInfo()
+	inProgress := inProgressCompactions()
+
+	newVersion.L0Sublevels.InitCompactingFileInfo(inProgressL0Compactions(inProgress))
 
 	// Update the zombie tables set first, as installation of the new version
 	// will unref the previous version which could result in addObsoleteLocked
@@ -472,7 +474,7 @@ func (vs *versionSet) logAndApply(
 		}
 		vs.manifestFileNum = newManifestFileNum
 	}
-	vs.picker = newCompactionPicker(newVersion, vs.opts, inProgressCompactions())
+	vs.picker = newCompactionPicker(newVersion, vs.opts, inProgress)
 	if !vs.dynamicBaseLevel {
 		vs.picker.forceBaseLevel1()
 	}


### PR DESCRIPTION
Backport of #885.

----

Previously, it was possible for compaction picking to pick an L0->LBase
compaction that conflicted with an existing L0->LBase compaction under
specific conditions.

A flush of a new sstable constructs a new Version and sublevel
intervals. If a flushed table does not overlap any individual
currently-compacting files, its intervals within sublevels
datastructures are not marked as compacting, although the flushed table
may still overlap with the active compaction's key range (eg, if the new
sstable sits squarely between two compacting files' keyspaces). If no
files exist in LBase that intersect with the intersection of the newly
flushed sstable's keyspace and the active compaction's keyspace, a
new compaction of the flush sstable would be allowed to start.

This change augments our existing concurrent compaction failsafe to
compare picked L0->LBase compaction key ranges against the key ranges of
in-progress compactions, preventing the compaction if necessary.

Fix #875.

internal/manifest: mark full compaction range as base compacting

Update L0Sublevels to mark all the intervals contained within a base
compaction as base compacting, even if none of the intervals' files are
compacting. This is possible if a file was flushed, splitting existing
compacting intervals.