### PR TITLE
*: Add compaction-debt based signal for compaction concurrency

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -885,9 +885,13 @@ func (p *compactionPickerByScore) pickFile(level, outputLevel int) (manifest.Lev
 // for a forced compaction (identified by FileMetadata.MarkedForCompaction).
 func (p *compactionPickerByScore) pickAuto(env compactionEnv) (pc *pickedCompaction) {
 	// Compaction concurrency is controlled by L0 read-amp. We allow one
-	// additional compaction per L0CompactionConcurrency sublevels. Compaction
-	// concurrency is tied to L0 sublevels as that signal is independent of the
-	// database size.
+	// additional compaction per L0CompactionConcurrency sublevels, as well as
+	// one additional compaction per CompactionDebtConcurrency bytes of
+	// compaction debt. Compaction concurrency is tied to L0 sublevels as that
+	// signal is independent of the database size. We tack on the compaction
+	// debt as a second signal to prevent compaction concurrency from dropping
+	// significantly right after a base compaction finishes, and before those
+	// bytes have been compacted further down the LSM.
 	if n := len(env.inProgressCompactions); n > 0 {
 		var l0ReadAmp int
 		if p.opts.Experimental.L0SublevelCompactions {
@@ -895,7 +899,10 @@ func (p *compactionPickerByScore) pickAuto(env compactionEnv) (pc *pickedCompact
 		} else {
 			l0ReadAmp = p.vers.Levels[0].Slice().Len()
 		}
-		if l0ReadAmp < n*p.opts.Experimental.L0CompactionConcurrency {
+		compactionDebt := int(p.estimatedCompactionDebt(0))
+		ccSignal1 := n *p.opts.Experimental.L0CompactionConcurrency
+		ccSignal2 := n *p.opts.Experimental.CompactionDebtConcurrency
+		if l0ReadAmp < ccSignal1 && compactionDebt < ccSignal2 {
 			return nil
 		}
 	}

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -829,6 +829,16 @@ func TestCompactionPickerConcurrency(t *testing.T) {
 					if err != nil {
 						return err.Error()
 					}
+				case "l0_compaction_concurrency":
+					opts.Experimental.L0CompactionConcurrency, err = strconv.Atoi(arg.Vals[0])
+					if err != nil {
+						return err.Error()
+					}
+				case "compaction_debt_concurrency":
+					opts.Experimental.CompactionDebtConcurrency, err = strconv.Atoi(arg.Vals[0])
+					if err != nil {
+						return err.Error()
+					}
 				}
 			}
 

--- a/testdata/compaction_picker_concurrency
+++ b/testdata/compaction_picker_concurrency
@@ -49,3 +49,124 @@ compactions
 pick-auto l0_compaction_threshold=10
 ----
 nil
+
+# Test that lowering L0CompactionConcurrency opens up more compaction slots.
+
+define
+L0
+  000301:a.SET.31-a.SET.31
+  000302:a.SET.32-a.SET.32
+  000303:a.SET.33-a.SET.33
+  000304:a.SET.34-a.SET.34
+  000305:a.SET.35-a.SET.35
+L1
+  000201:a.SET.21-b.SET.22
+  000203:k.SET.25-n.SET.26
+  000202:x.SET.23-z.SET.24
+L2
+  000101:a.SET.11-f.SET.12
+L3
+  000010:a.SET.1-z.SET.2
+compactions
+  L1 000202 -> L2 000101
+----
+0.4:
+  000305:[a#35,SET-a#35,SET]
+0.3:
+  000304:[a#34,SET-a#34,SET]
+0.2:
+  000303:[a#33,SET-a#33,SET]
+0.1:
+  000302:[a#32,SET-a#32,SET]
+0.0:
+  000301:[a#31,SET-a#31,SET]
+1:
+  000201:[a#21,SET-b#22,SET]
+  000203:[k#25,SET-n#26,SET]
+  000202:[x#23,SET-z#24,SET]
+2:
+  000101:[a#11,SET-f#12,SET]
+3:
+  000010:[a#1,SET-z#2,SET]
+compactions
+  L1 000202 -> L2 000101
+
+pick-auto l0_compaction_concurrency=10
+----
+nil
+
+pick-auto l0_compaction_concurrency=5
+----
+L0 -> L1
+L0: 000301,000302,000303,000304,000305
+L1: 000201
+grandparents: 000101
+
+pick-auto l0_compaction_concurrency=1
+----
+L0 -> L1
+L0: 000301,000302,000303,000304,000305
+L1: 000201
+grandparents: 000101
+
+# Test that lowering CompactionDebtConcurrency opens up more concurrent
+# compaction slots.
+
+# Test that lowering L0CompactionConcurrency opens up more compaction slots.
+
+define
+L0
+  000301:a.SET.31-a.SET.31 size=64000
+  000302:a.SET.32-a.SET.32 size=64000
+  000303:a.SET.33-a.SET.33 size=64000
+  000304:a.SET.34-a.SET.34 size=64000
+  000305:a.SET.35-a.SET.35 size=64000
+L1
+  000201:a.SET.21-b.SET.22 size=640000
+  000203:k.SET.25-n.SET.26 size=640000
+  000202:x.SET.23-z.SET.24 size=640000
+L2
+  000101:a.SET.11-f.SET.12 size=6400000
+L3
+  000010:a.SET.1-z.SET.2
+compactions
+  L1 000202 -> L2 000101
+----
+0.4:
+  000305:[a#35,SET-a#35,SET]
+0.3:
+  000304:[a#34,SET-a#34,SET]
+0.2:
+  000303:[a#33,SET-a#33,SET]
+0.1:
+  000302:[a#32,SET-a#32,SET]
+0.0:
+  000301:[a#31,SET-a#31,SET]
+1:
+  000201:[a#21,SET-b#22,SET]
+  000203:[k#25,SET-n#26,SET]
+  000202:[x#23,SET-z#24,SET]
+2:
+  000101:[a#11,SET-f#12,SET]
+3:
+  000010:[a#1,SET-z#2,SET]
+compactions
+  L1 000202 -> L2 000101
+
+pick-auto l0_compaction_concurrency=10 compaction_debt_concurrency=5120000
+----
+nil
+
+pick-auto l0_compaction_concurrency=10 compaction_debt_concurrency=512000
+----
+L0 -> L1
+L0: 000301,000302,000303,000304,000305
+L1: 000201
+grandparents: 000101
+
+pick-auto l0_compaction_concurrency=5 compaction_debt_concurrency=5120000
+----
+L0 -> L1
+L0: 000301,000302,000303,000304,000305
+L1: 000201
+grandparents: 000101


### PR DESCRIPTION
Adds a new option, defaulting to 800mb, called CompactionDebtConcurrency
that works similarly to L0CompactionConcurrency in that it adds one
additional concurrent compaction slot per CompactionDebtConcurrency
bytes of compaction debt, up to MaxCompactionConcurrency.

The motivation behind this change is to not result in steep drops
in compaction concurrency right after a large base compaction finishes.
This is necessary in write-heavy workloads where we need to maintain
a high compaction concurrency throughout a workload, and to continue
moving files down from Lbase onto lower levels to keep pace with
flushes.

Furthermore, this change removes flushes from the count of
in-progress compactions when calculating concurrency.

These changes (plus #919) resulted in a slight but noticeable improvement
in P95 latency in sysbench workloads:

```
name                                                    old ops/sec  new ops/sec  delta
sysbench/oltp_read_write/nodes=3/cpu=32/conc=128         42.8k ±13%   48.6k ± 5%  +13.53%  (p=0.016 n=5+5)
sysbench/oltp_point_select/nodes=3/cpu=32/conc=128       93.0k ± 4%   93.8k ± 5%     ~     (p=0.690 n=5+5)
sysbench/oltp_read_only/nodes=3/cpu=32/conc=128          82.9k ± 3%   83.3k ± 3%     ~     (p=0.841 n=5+5)
sysbench/oltp_update_non_index/nodes=3/cpu=32/conc=128   28.2k ±33%   33.3k ±27%     ~     (p=0.222 n=5+5)
sysbench/oltp_write_only/nodes=3/cpu=32/conc=128         21.4k ±19%   27.4k ±14%     ~     (p=0.151 n=5+5)
sysbench/oltp_update_index/nodes=3/cpu=32/conc=128       11.4k ±22%   14.7k ±17%     ~     (p=0.095 n=5+5)
sysbench/oltp_insert/nodes=3/cpu=32/conc=128             19.1k ±17%   19.8k ±15%     ~     (p=0.548 n=5+5)
sysbench/oltp_delete/nodes=3/cpu=32/conc=128             34.3k ±25%   45.9k ±12%     ~     (p=0.056 n=5+5)

name                                                    old avg      new avg      delta
sysbench/oltp_read_write/nodes=3/cpu=32/conc=128          60.6 ±14%    52.9 ± 5%  -12.74%  (p=0.016 n=5+5)
sysbench/oltp_point_select/nodes=3/cpu=32/conc=128        1.38 ± 4%    1.36 ± 5%     ~     (p=0.722 n=5+5)
sysbench/oltp_read_only/nodes=3/cpu=32/conc=128           24.7 ± 3%    24.6 ± 3%     ~     (p=0.746 n=5+5)
sysbench/oltp_update_non_index/nodes=3/cpu=32/conc=128    4.91 ±37%    4.04 ±30%     ~     (p=0.222 n=5+5)
sysbench/oltp_write_only/nodes=3/cpu=32/conc=128          36.8 ±18%    28.3 ±13%     ~     (p=0.151 n=5+5)
sysbench/oltp_update_index/nodes=3/cpu=32/conc=128        11.5 ±20%     8.8 ±16%     ~     (p=0.095 n=5+5)
sysbench/oltp_insert/nodes=3/cpu=32/conc=128              6.82 ±18%    6.54 ±17%     ~     (p=0.548 n=5+5)
sysbench/oltp_delete/nodes=3/cpu=32/conc=128              3.87 ±23%    2.81 ±13%     ~     (p=0.056 n=5+5)

name                                                    old p95      new p95      delta
sysbench/oltp_read_write/nodes=3/cpu=32/conc=128           106 ±20%      91 ±11%     ~     (p=0.198 n=5+5)
sysbench/oltp_point_select/nodes=3/cpu=32/conc=128        2.58 ±11%    2.44 ± 6%     ~     (p=0.270 n=5+5)
sysbench/oltp_read_only/nodes=3/cpu=32/conc=128           38.9 ± 0%    38.2 ± 0%   -1.77%  (p=0.029 n=4+4)
sysbench/oltp_update_non_index/nodes=3/cpu=32/conc=128    18.6 ±60%    13.4 ±44%     ~     (p=0.222 n=5+5)
sysbench/oltp_write_only/nodes=3/cpu=32/conc=128          77.7 ±28%    58.7 ±29%     ~     (p=0.198 n=5+5)
sysbench/oltp_update_index/nodes=3/cpu=32/conc=128        34.9 ±35%    27.2 ±33%     ~     (p=0.222 n=5+5)
sysbench/oltp_insert/nodes=3/cpu=32/conc=128              20.2 ±32%    19.0 ±31%     ~     (p=0.500 n=5+5)
sysbench/oltp_delete/nodes=3/cpu=32/conc=128              16.2 ±24%    11.3 ± 9%  -30.48%  (p=0.016 n=5+5)

name                                                    old p99      new p99      delta
sysbench/oltp_read_write/nodes=3/cpu=32/conc=128           824 ±12%     976 ±11%  +18.49%  (p=0.032 n=5+5)
sysbench/oltp_point_select/nodes=3/cpu=32/conc=128         444 ±15%     522 ±25%     ~     (p=0.222 n=5+5)
sysbench/oltp_read_only/nodes=3/cpu=32/conc=128            498 ±20%     722 ±55%     ~     (p=0.095 n=5+5)
sysbench/oltp_update_non_index/nodes=3/cpu=32/conc=128     760 ±17%     789 ± 5%     ~     (p=0.421 n=5+5)
sysbench/oltp_write_only/nodes=3/cpu=32/conc=128         1.15k ±70%   1.15k ±24%     ~     (p=0.310 n=5+5)
sysbench/oltp_update_index/nodes=3/cpu=32/conc=128         979 ±67%    1390 ±72%     ~     (p=0.548 n=5+5)
sysbench/oltp_insert/nodes=3/cpu=32/conc=128               282 ±11%     300 ±41%     ~     (p=1.000 n=5+5)
sysbench/oltp_delete/nodes=3/cpu=32/conc=128               637 ±67%     884 ±18%     ~     (p=0.151 n=5+5)
```

One set of the improvements as part of #934.