### PR TITLE
internal/metamorphic: parse empty string as nil

### DIFF
--- a/internal/metamorphic/parser.go
+++ b/internal/metamorphic/parser.go
@@ -250,7 +250,11 @@ func (p *parser) parseArgs(op op, methodName string, args []interface{}) {
 			if err != nil {
 				panic(err)
 			}
-			*t = []byte(s)
+			if len(s) == 0 {
+				*t = nil
+			} else {
+				*t = []byte(s)
+			}
 
 		case *objID:
 			pos, lit := p.scanToken(token.IDENT)

--- a/internal/metamorphic/parser_test.go
+++ b/internal/metamorphic/parser_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/cockroachdb/pebble/internal/randvar"
 	"github.com/kr/pretty"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParser(t *testing.T) {
@@ -41,4 +42,21 @@ func TestParserRandom(t *testing.T) {
 	if diff := pretty.Diff(ops, parsedOps); diff != nil {
 		t.Fatalf("%s\n%s", strings.Join(diff, "\n"), src)
 	}
+}
+
+func TestParserNilBounds(t *testing.T) {
+	formatted := formatOps([]op{
+		&newIterOp{
+			readerID: makeObjID(dbTag, 0),
+			iterID:   makeObjID(iterTag, 1),
+			lower:    nil,
+			upper:    nil,
+		},
+	})
+	parsedOps, err := parse([]byte(formatted))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(parsedOps))
+	v := parsedOps[0].(*newIterOp)
+	require.Nil(t, v.lower)
+	require.Nil(t, v.upper)
 }


### PR DESCRIPTION
The metamorphic tests generates some operations, like `opNewIter` that
sometimes have arguments and sometimes not. When formatted and printed
to disk, an operation formats its empty arguments as the empty string
`""`.

This causes a problem when parsing and replaying persisted operations.
The metamorphic tests would previously reconstruct the arguments as
empty, non-nil slices. This difference changes the behavior of some
operations. For example, iterator bounds `[]byte{}` and `nil` are
treated differently.

This commit changes parsing to treat empty arguments `""` as nil.