### PR TITLE
internal/manifest: use B-Tree for organizing level file metadata

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -177,7 +177,7 @@ func newPickedCompactionFromL0(
 			files = append(files, f)
 		}
 	}
-	pc.startLevel.files = manifest.NewLevelSlice(files)
+	pc.startLevel.files = manifest.NewLevelSliceSeqSorted(files)
 	return pc
 }
 
@@ -259,7 +259,7 @@ func (pc *pickedCompaction) setupInputs() bool {
 				}
 			}
 			if sizeSum+pc.outputLevel.files.SizeSum() < pc.maxExpandedBytes {
-				pc.startLevel.files = manifest.NewLevelSlice(newStartLevelFiles)
+				pc.startLevel.files = manifest.NewLevelSliceSeqSorted(newStartLevelFiles)
 				pc.smallest, pc.largest = manifest.KeyRange(pc.cmp,
 					pc.startLevel.files.Iter(), pc.outputLevel.files.Iter())
 			} else {
@@ -897,7 +897,7 @@ func (p *compactionPickerByScore) pickAuto(env compactionEnv) (pc *pickedCompact
 		if p.opts.Experimental.L0SublevelCompactions {
 			l0ReadAmp = p.vers.L0Sublevels.MaxDepthAfterOngoingCompactions()
 		} else {
-			l0ReadAmp = p.vers.Levels[0].Slice().Len()
+			l0ReadAmp = p.vers.Levels[0].Len()
 		}
 		compactionDebt := int(p.estimatedCompactionDebt(0))
 		ccSignal1 := n * p.opts.Experimental.L0CompactionConcurrency
@@ -1199,7 +1199,7 @@ func pickL0(env compactionEnv, opts *Options, vers *version, baseLevel int) (pc 
 }
 
 func pickIntraL0(env compactionEnv, opts *Options, vers *version) (pc *pickedCompaction) {
-	l0Files := vers.Levels[0].Slice()
+	l0Files := vers.Levels[0]
 	end := l0Files.Iter()
 	remaining := l0Files.Len()
 	for m := end.Last(); m != nil; m = end.Prev() {

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -563,7 +563,7 @@ func TestCompactionPickerL0(t *testing.T) {
 				}
 				for i, cl := range info.inputs {
 					files := compactionFiles[cl.level]
-					info.inputs[i].files = manifest.NewLevelSlice(files)
+					info.inputs[i].files = manifest.NewLevelSliceSeqSorted(files)
 					// Mark as intra-L0 compacting if the compaction is
 					// L0 -> L0.
 					if info.outputLevel == 0 {
@@ -791,7 +791,11 @@ func TestCompactionPickerConcurrency(t *testing.T) {
 				}
 				for i, cl := range info.inputs {
 					files := compactionFiles[cl.level]
-					info.inputs[i].files = manifest.NewLevelSlice(files)
+					if cl.level == 0 {
+						info.inputs[i].files = manifest.NewLevelSliceSeqSorted(files)
+					} else {
+						info.inputs[i].files = manifest.NewLevelSliceKeySorted(DefaultComparer.Compare, files)
+					}
 					// Mark as intra-L0 compacting if the compaction is
 					// L0 -> L0.
 					if info.outputLevel == 0 {

--- a/get_iter.go
+++ b/get_iter.go
@@ -30,7 +30,7 @@ type getIter struct {
 	level        int
 	batch        *Batch
 	mem          flushableList
-	l0           [][]*fileMetadata
+	l0           []manifest.LevelSlice
 	version      *version
 	iterKey      *InternalKey
 	iterValue    []byte
@@ -140,7 +140,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 		if g.level == 0 {
 			// Create iterators from L0 from newest to oldest.
 			if n := len(g.l0); n > 0 {
-				files := manifest.NewLevelSlice(g.l0[n-1]).Iter()
+				files := g.l0[n-1].Iter()
 				g.l0 = g.l0[:n-1]
 				iterOpts := IterOptions{logger: g.logger}
 				g.levelIter.init(iterOpts, g.cmp, g.newIters, files, manifest.L0Sublevel(n), nil)

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1131,15 +1131,20 @@ func BenchmarkManySSTablesNewVersion(b *testing.B) {
 			require.NoError(b, d.Ingest(paths))
 
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				n := strconv.Itoa(count + i)
-				f, err := mem.Create(n)
-				require.NoError(b, err)
-				w := sstable.NewWriter(f, sstable.WriterOptions{})
-				require.NoError(b, w.Set([]byte(n), nil))
-				require.NoError(b, w.Close())
-				require.NoError(b, d.Ingest([]string{n}))
-			}
+			runBenchmarkSSTables(b, d, mem, count)
+			require.NoError(b, d.Close())
 		})
+	}
+}
+
+func runBenchmarkSSTables(b *testing.B, d *DB, fs vfs.FS, count int) {
+	for i := 0; i < b.N; i++ {
+		n := strconv.Itoa(count + i)
+		f, err := fs.Create(n)
+		require.NoError(b, err)
+		w := sstable.NewWriter(f, sstable.WriterOptions{})
+		require.NoError(b, w.Set([]byte(n), nil))
+		require.NoError(b, w.Close())
+		require.NoError(b, d.Ingest([]string{n}))
 	}
 }

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -181,7 +181,8 @@ func (b *bitSet) clearAllBits() {
 type L0Sublevels struct {
 	// Levels are ordered from oldest sublevel to youngest sublevel in the
 	// outer slice, and the inner slice contains non-overlapping files for
-	// that sublevel in increasing key order.
+	// that sublevel in increasing key order. Levels is constructed from
+	// levelFiles and is used by callers that require a LevelSlice.
 	Levels     []LevelSlice
 	levelFiles [][]*FileMetadata
 

--- a/internal/manifest/level_metadata_test.go
+++ b/internal/manifest/level_metadata_test.go
@@ -1,0 +1,99 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package manifest
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/datadriven"
+)
+
+func TestLevelIterator(t *testing.T) {
+	var level LevelSlice
+	datadriven.RunTest(t, "testdata/level_iterator",
+		func(d *datadriven.TestData) string {
+			switch d.Cmd {
+			case "define":
+				var files []*FileMetadata
+				var startReslice int
+				var endReslice int
+				for _, metaStr := range strings.Split(d.Input, " ") {
+					switch metaStr {
+					case "[":
+						startReslice = len(files)
+						continue
+					case "]":
+						endReslice = len(files)
+						continue
+					case " ", "":
+						continue
+					default:
+						parts := strings.Split(metaStr, "-")
+						if len(parts) != 2 {
+							t.Fatalf("malformed table spec: %q", metaStr)
+						}
+						m := &FileMetadata{
+							FileNum:  base.FileNum(len(files) + 1),
+							Smallest: base.ParseInternalKey(strings.TrimSpace(parts[0])),
+							Largest:  base.ParseInternalKey(strings.TrimSpace(parts[1])),
+						}
+						m.SmallestSeqNum = m.Smallest.SeqNum()
+						m.LargestSeqNum = m.Largest.SeqNum()
+						files = append(files, m)
+					}
+				}
+				level = NewLevelSliceKeySorted(base.DefaultComparer.Compare, files)
+				level = level.Reslice(func(start, end *LevelIterator) {
+					for i := 0; i < startReslice; i++ {
+						start.Next()
+					}
+					for i := len(files); i > endReslice; i-- {
+						end.Prev()
+					}
+				})
+				return ""
+
+			case "iter":
+				iter := level.Iter()
+				var buf bytes.Buffer
+				for _, line := range strings.Split(d.Input, "\n") {
+					parts := strings.Fields(line)
+					if len(parts) == 0 {
+						continue
+					}
+					var m *FileMetadata
+					switch parts[0] {
+					case "first":
+						m = iter.First()
+					case "last":
+						m = iter.Last()
+					case "next":
+						m = iter.Next()
+					case "prev":
+						m = iter.Prev()
+					case "seek-ge":
+						m = iter.SeekGE(base.DefaultComparer.Compare, []byte(parts[1]))
+					case "seek-lt":
+						m = iter.SeekLT(base.DefaultComparer.Compare, []byte(parts[1]))
+					default:
+						return fmt.Sprintf("unknown command %q", parts[0])
+					}
+					if m == nil {
+						fmt.Fprintln(&buf, ".")
+					} else {
+						fmt.Fprintln(&buf, m)
+					}
+				}
+				return buf.String()
+
+			default:
+				return fmt.Sprintf("unknown command %q", d.Cmd)
+			}
+		})
+}

--- a/internal/manifest/testdata/level_iterator
+++ b/internal/manifest/testdata/level_iterator
@@ -1,0 +1,113 @@
+define
+[ ]
+----
+
+iter
+first
+last
+seek-lt a
+seek-lt z
+seek-ge a
+seek-ge z
+----
+.
+.
+.
+.
+.
+.
+
+define
+[ a.SET.1-b.SET.2 ]
+----
+
+iter
+last
+----
+000001:a#1,1-b#2,1
+
+iter
+first
+next
+prev
+prev
+----
+000001:a#1,1-b#2,1
+.
+000001:a#1,1-b#2,1
+.
+
+iter
+seek-ge a
+seek-ge b
+seek-ge c
+----
+000001:a#1,1-b#2,1
+000001:a#1,1-b#2,1
+.
+
+iter
+seek-lt a
+seek-lt b
+seek-lt z
+----
+.
+000001:a#1,1-b#2,1
+000001:a#1,1-b#2,1
+
+define
+[ b.SET.1-c.SET.2 ]
+----
+
+iter
+seek-ge a
+seek-ge d
+seek-lt a
+seek-lt z
+----
+000001:b#1,1-c#2,1
+.
+.
+000001:b#1,1-c#2,1
+
+
+define
+a.SET.1-b.SET.2 [ c.SET.3-d.SET.4 e.SET.5-f.SET.6 ] g.SET.7-h.SET.8
+----
+
+iter
+first
+prev
+last
+next
+----
+000002:c#3,1-d#4,1
+.
+000003:e#5,1-f#6,1
+.
+
+iter
+seek-ge a
+seek-ge b
+seek-ge c
+seek-ge h
+prev
+----
+000002:c#3,1-d#4,1
+000002:c#3,1-d#4,1
+000002:c#3,1-d#4,1
+.
+000003:e#5,1-f#6,1
+
+iter
+seek-lt b
+next
+seek-lt a
+next
+seek-lt z
+----
+.
+000002:c#3,1-d#4,1
+.
+000002:c#3,1-d#4,1
+000003:e#5,1-f#6,1

--- a/internal/manifest/testdata/version_edit_apply
+++ b/internal/manifest/testdata/version_edit_apply
@@ -165,5 +165,5 @@ edit
   L0
    2
 ----
-pebble: internal error: unknown deleted file L0.000002
+pebble: file deleted L0.000002 before it was inserted
 

--- a/internal/manifest/testdata/version_edit_apply
+++ b/internal/manifest/testdata/version_edit_apply
@@ -155,8 +155,7 @@ edit
 ----
 zombies [1 2]
 
-# Deletion of a non-existent table does not result in an entry in the
-# zombies map.
+# Deletion of a non-existent table results in an error.
 
 apply
  L0
@@ -166,6 +165,5 @@ edit
   L0
    2
 ----
-0.0:
-  000001:[a#1,SET-b#2,SET]
-zombies []
+pebble: internal error: unknown deleted file L0.000002
+

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/cockroachdb/pebble/vfs"
 )
 
-func makeLevelMetadata(files ...*FileMetadata) LevelMetadata {
-	return LevelMetadata{files: files}
+func levelMetadata(level int, files ...*FileMetadata) LevelMetadata {
+	return makeLevelMetadata(base.DefaultComparer.Compare, level, files)
 }
 
 func ikey(s string) InternalKey {
@@ -69,14 +69,15 @@ func TestIkeyRange(t *testing.T) {
 	for _, tc := range testCases {
 		var f []*FileMetadata
 		if tc.input != "" {
-			for _, s := range strings.Split(tc.input, " ") {
+			for i, s := range strings.Split(tc.input, " ") {
 				f = append(f, &FileMetadata{
+					FileNum:  base.FileNum(i),
 					Smallest: ikey(s[0:1]),
 					Largest:  ikey(s[2:3]),
 				})
 			}
 		}
-		levelMetadata := makeLevelMetadata(f...)
+		levelMetadata := makeLevelMetadata(base.DefaultComparer.Compare, 0, f)
 
 		sm, la := KeyRange(base.DefaultComparer.Compare, levelMetadata.Iter())
 		got := string(sm.UserKey) + "-" + string(la.UserKey)
@@ -157,20 +158,20 @@ func TestOverlaps(t *testing.T) {
 	m13 := &FileMetadata{
 		FileNum:  713,
 		Size:     1,
-		Smallest: base.ParseInternalKey("p.SET.7138"),
-		Largest:  base.ParseInternalKey("p.SET.7139"),
+		Smallest: base.ParseInternalKey("p.SET.7148"),
+		Largest:  base.ParseInternalKey("p.SET.7149"),
 	}
 	m14 := &FileMetadata{
 		FileNum:  714,
 		Size:     1,
-		Smallest: base.ParseInternalKey("p.SET.7148"),
-		Largest:  base.ParseInternalKey("u.SET.7149"),
+		Smallest: base.ParseInternalKey("p.SET.7138"),
+		Largest:  base.ParseInternalKey("u.SET.7139"),
 	}
 
 	v := Version{
 		Levels: [NumLevels]LevelMetadata{
-			0: makeLevelMetadata(m00, m01, m02, m03, m04, m05, m06, m07),
-			1: makeLevelMetadata(m10, m11, m12, m13, m14),
+			0: levelMetadata(0, m00, m01, m02, m03, m04, m05, m06, m07),
+			1: levelMetadata(1, m10, m11, m12, m13, m14),
 		},
 	}
 
@@ -330,20 +331,20 @@ func TestContains(t *testing.T) {
 	m13 := &FileMetadata{
 		FileNum:  713,
 		Size:     1,
-		Smallest: base.ParseInternalKey("p.SET.7138"),
-		Largest:  base.ParseInternalKey("p.SET.7139"),
+		Smallest: base.ParseInternalKey("p.SET.7148"),
+		Largest:  base.ParseInternalKey("p.SET.7149"),
 	}
 	m14 := &FileMetadata{
 		FileNum:  714,
 		Size:     1,
-		Smallest: base.ParseInternalKey("p.SET.7148"),
-		Largest:  base.ParseInternalKey("u.SET.7149"),
+		Smallest: base.ParseInternalKey("p.SET.7138"),
+		Largest:  base.ParseInternalKey("u.SET.7139"),
 	}
 
 	v := Version{
 		Levels: [NumLevels]LevelMetadata{
-			0: makeLevelMetadata(m00, m01, m02, m03, m04, m05, m06, m07),
-			1: makeLevelMetadata(m10, m11, m12, m13, m14),
+			0: levelMetadata(0, m00, m01, m02, m03, m04, m05, m06, m07),
+			1: levelMetadata(1, m10, m11, m12, m13, m14),
 		},
 	}
 

--- a/level_checker.go
+++ b/level_checker.go
@@ -403,10 +403,10 @@ func checkRangeTombstones(c *checkConfig) error {
 	}
 	// Now the levels with untruncated tombsones.
 	for i := len(current.L0Sublevels.Levels) - 1; i >= 0; i-- {
-		if len(current.L0Sublevels.Levels[i]) == 0 {
+		if current.L0Sublevels.Levels[i].Empty() {
 			continue
 		}
-		err := addTombstonesFromLevel(manifest.NewLevelSlice(current.L0Sublevels.Levels[i]).Iter(), 0)
+		err := addTombstonesFromLevel(current.L0Sublevels.Levels[i].Iter(), 0)
 		if err != nil {
 			return err
 		}
@@ -616,7 +616,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 	// reallocations. levelIter will hold a pointer to elements in mlevels.
 	start := len(mlevels)
 	for sublevel := len(current.L0Sublevels.Levels) - 1; sublevel >= 0; sublevel-- {
-		if len(current.L0Sublevels.Levels[sublevel]) == 0 {
+		if current.L0Sublevels.Levels[sublevel].Empty() {
 			continue
 		}
 		mlevels = append(mlevels, simpleMergingIterLevel{})
@@ -630,10 +630,10 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 	mlevelAlloc := mlevels[start:]
 	// Add L0 files by sublevel.
 	for sublevel := len(current.L0Sublevels.Levels) - 1; sublevel >= 0; sublevel-- {
-		if len(current.L0Sublevels.Levels[sublevel]) == 0 {
+		if current.L0Sublevels.Levels[sublevel].Empty() {
 			continue
 		}
-		manifestIter := manifest.NewLevelSlice(current.L0Sublevels.Levels[sublevel]).Iter()
+		manifestIter := current.L0Sublevels.Levels[sublevel].Iter()
 		iterOpts := IterOptions{logger: c.logger}
 		li := &levelIter{}
 		li.init(iterOpts, c.cmp, c.newIters, manifestIter,

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -524,7 +524,7 @@ func buildLevelsForMergingIterSeqSeek(
 			key, _ = iter.Last()
 			meta[j].Largest = key.Clone()
 		}
-		levelSlices[i] = manifest.NewLevelSlice(meta)
+		levelSlices[i] = manifest.NewLevelSliceSpecificOrder(meta)
 	}
 	return readers, levelSlices, keys
 }

--- a/tool/db.go
+++ b/tool/db.go
@@ -397,6 +397,7 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 
 		cmp := base.DefaultComparer
 		var bve manifest.BulkVersionEdit
+		bve.AddedByFileNum = make(map[base.FileNum]*manifest.FileMetadata)
 		rr := record.NewReader(f, 0 /* logNum */)
 		for {
 			r, err := rr.Next()

--- a/tool/lsm.go
+++ b/tool/lsm.go
@@ -243,7 +243,8 @@ func (l *lsmT) buildEdits(edits []*manifest.VersionEdit) {
 		v := manifest.NewVersion(l.cmp.Compare, l.fmtKey.fn, 0, currentFiles)
 		edit.Sublevels = make(map[base.FileNum]int)
 		for sublevel, files := range v.L0Sublevels.Levels {
-			for _, f := range files {
+			iter := files.Iter()
+			for f := iter.First(); f != nil; f = iter.Next() {
 				if len(l.state.Edits) > 0 {
 					lastEdit := l.state.Edits[len(l.state.Edits)-1]
 					if sublevel2, ok := lastEdit.Sublevels[f.FileNum]; ok && sublevel == sublevel2 {

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -82,12 +82,12 @@ func (m *manifestT) printLevels(v *manifest.Version) {
 		if level == 0 && v.L0Sublevels != nil && !v.Levels[level].Empty() {
 			for sublevel := len(v.L0Sublevels.Levels) - 1; sublevel >= 0; sublevel-- {
 				fmt.Fprintf(stdout, "--- L0.%d ---\n", sublevel)
-				for _, f := range v.L0Sublevels.Levels[sublevel] {
+				v.L0Sublevels.Levels[sublevel].Each(func(f *manifest.FileMetadata) {
 					fmt.Fprintf(stdout, "  %s:%d", f.FileNum, f.Size)
 					formatSeqNumRange(stdout, f.SmallestSeqNum, f.LargestSeqNum)
 					formatKeyRange(stdout, m.fmtKey, &f.Smallest, &f.Largest)
 					fmt.Fprintf(stdout, "\n")
-				}
+				})
 			}
 			continue
 		}
@@ -115,6 +115,7 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(stdout, "%s\n", arg)
 
 			var bve manifest.BulkVersionEdit
+			bve.AddedByFileNum = make(map[base.FileNum]*manifest.FileMetadata)
 			var cmp *base.Comparer
 			rr := record.NewReader(f, 0 /* logNum */)
 			for {
@@ -245,6 +246,7 @@ func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
 					break
 				}
 				var bve manifest.BulkVersionEdit
+				bve.AddedByFileNum = make(map[base.FileNum]*manifest.FileMetadata)
 				if err := bve.Accumulate(&ve); err != nil {
 					fmt.Fprintf(stderr, "%s\n", err)
 					ok = false

--- a/tool/testdata/manifest_dump
+++ b/tool/testdata/manifest_dump
@@ -170,12 +170,12 @@ MANIFEST-invalid
   last-seq-num:  20
   added:         L6 000002:0<#1-#4>[#0,DEL-#0,DEL]
 EOF
-pebble: internal error: L6 files 000001 and 000002 have overlapping ranges: [#0,DEL-#0,DEL] vs [#0,DEL-#0,DEL]
+pebble: files 000002 and 000001 collided on sort keys
 
 manifest check
 ./testdata/MANIFEST-invalid
 ----
-MANIFEST-invalid: offset: 65 err: pebble: internal error: L6 files 000001 and 000002 have overlapping ranges: [#0,DEL-#0,DEL] vs [#0,DEL-#0,DEL]
+MANIFEST-invalid: offset: 65 err: pebble: files 000002 and 000001 collided on sort keys
 Version state before failed Apply
 --- L0 ---
 --- L1 ---

--- a/version_set.go
+++ b/version_set.go
@@ -203,6 +203,7 @@ func (vs *versionSet) load(dirname string, opts *Options, mu *sync.Mutex) error 
 
 	// Read the versionEdits in the manifest file.
 	var bve bulkVersionEdit
+	bve.AddedByFileNum = make(map[base.FileNum]*fileMetadata)
 	manifest, err := vs.fs.Open(vs.fs.PathJoin(dirname, string(b)))
 	if err != nil {
 		return errors.Wrapf(err, "pebble: could not open manifest file %q for DB %q",
@@ -282,7 +283,7 @@ func (vs *versionSet) load(dirname string, opts *Options, mu *sync.Mutex) error 
 
 	for i := range vs.metrics.Levels {
 		l := &vs.metrics.Levels[i]
-		l.NumFiles = int64(newVersion.Levels[i].Slice().Len())
+		l.NumFiles = int64(newVersion.Levels[i].Len())
 		l.Size = int64(newVersion.Levels[i].Slice().SizeSum())
 	}
 	vs.picker = newCompactionPicker(newVersion, vs.opts, nil, vs.metrics.levelSizes())
@@ -498,7 +499,7 @@ func (vs *versionSet) logAndApply(
 			l.Sublevels = 1
 		}
 		if invariants.Enabled {
-			if count := int64(newVersion.Levels[i].Slice().Len()); l.NumFiles != count {
+			if count := int64(newVersion.Levels[i].Len()); l.NumFiles != count {
 				vs.opts.Logger.Fatalf("versionSet metrics L%d NumFiles = %d, actual count = %d", i, l.NumFiles, count)
 			}
 			if size := int64(newVersion.Levels[i].Slice().SizeSum()); l.Size != size {


### PR DESCRIPTION
internal/manifest: use B-Tree for organizing level file metadata

Update the LevelMetadata, LevelSlice, LevelIterator types to be backed
by a B-Tree, allowing logarithmic applications of version edits.


internal/manifest: add B-Tree Annotator

Add an Annotator type that allows external packages to define recursive
calculations over LevelMetadata and cache the results on B-Tree nodes.
Use this Annotator type to remove two O(# sstables) operations:
calculating the total compensated size of a level and finding the next
available elision-only compaction.

```
name                                        old time/op  new time/op  delta
ManySSTablesNewVersion/sstables=10-16        182µs ± 4%    62µs ± 1%  -66.20%  (p=0.010 n=6+4)
ManySSTablesNewVersion/sstables=1000-16      205µs ± 1%    65µs ± 5%  -68.31%  (p=0.016 n=5+4)
ManySSTablesNewVersion/sstables=10000-16     365µs ± 2%    65µs ± 4%  -82.35%  (p=0.016 n=5+4)
ManySSTablesNewVersion/sstables=100000-16   6.01ms ± 2%  0.08ms ± 5%  -98.71%  (p=0.010 n=6+4)
ManySSTablesNewVersion/sstables=1000000-16  73.3ms ± 2%   0.1ms ± 4%  -99.85%  (p=0.010 n=6+4)
```