### PR TITLE
*: Add new WALBytesPerSync option, defaulting to 0

### DIFF
--- a/db.go
+++ b/db.go
@@ -1360,7 +1360,7 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 				newLogFile.Close()
 			} else if err == nil {
 				newLogFile = vfs.NewSyncingFile(newLogFile, vfs.SyncingFileOptions{
-					BytesPerSync:    d.opts.BytesPerSync,
+					BytesPerSync:    d.opts.WALBytesPerSync,
 					PreallocateSize: d.walPreallocateSize(),
 				})
 			}

--- a/open.go
+++ b/open.go
@@ -304,7 +304,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		d.mu.mem.queue[len(d.mu.mem.queue)-1].logNum = newLogNum
 
 		logFile = vfs.NewSyncingFile(logFile, vfs.SyncingFileOptions{
-			BytesPerSync:    d.opts.BytesPerSync,
+			BytesPerSync:    d.opts.WALBytesPerSync,
 			PreallocateSize: d.walPreallocateSize(),
 		})
 		d.mu.log.LogWriter = record.NewLogWriter(logFile, newLogNum)

--- a/options.go
+++ b/options.go
@@ -222,10 +222,11 @@ func (o *LevelOptions) EnsureDefaults() *LevelOptions {
 // apply to the DB at large; per-query options are defined by the IterOptions
 // and WriteOptions types.
 type Options struct {
-	// Sync sstables and the WAL periodically in order to smooth out writes to
-	// disk. This option does not provide any persistency guarantee, but is used
-	// to avoid latency spikes if the OS automatically decides to write out a
-	// large chunk of dirty filesystem buffers.
+	// Sync sstables periodically in order to smooth out writes to disk. This
+	// option does not provide any persistency guarantee, but is used to avoid
+	// latency spikes if the OS automatically decides to write out a large chunk
+	// of dirty filesystem buffers. This option only controls SSTable syncs; WAL
+	// syncs are controlled by WALBytesPerSync.
 	//
 	// The default value is 512KB.
 	BytesPerSync int
@@ -399,6 +400,17 @@ type Options struct {
 	// functions. A new TablePropertyCollector is created for each sstable built
 	// and lives for the lifetime of the table.
 	TablePropertyCollectors []func() TablePropertyCollector
+
+	// WALBytesPerSync sets the number of bytes to write to a WAL before calling
+	// Sync on it in the background. Just like with BytesPerSync above, this
+	// helps smooth out disk write latencies, and avoids cases where the OS
+	// writes a lot of buffered data to disk at once. However, this is less
+	// necessary with WALs, as many write operations already pass in
+	// Sync = true.
+	//
+	// The default value is 0, i.e. no background syncing. This matches the
+	// default behaviour in RocksDB.
+	WALBytesPerSync int
 
 	// WALDir specifies the directory to store write-ahead logs (WALs) in. If
 	// empty (the default), WALs will be stored in the same directory as sstables
@@ -622,6 +634,7 @@ func (o *Options) String() string {
 	}
 	fmt.Fprintf(&buf, "]\n")
 	fmt.Fprintf(&buf, "  wal_dir=%s\n", o.WALDir)
+	fmt.Fprintf(&buf, "  wal_bytes_per_sync=%d\n", o.WALBytesPerSync)
 
 	for i := range o.Levels {
 		l := &o.Levels[i]
@@ -804,6 +817,8 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				// TODO(peter): set o.TablePropertyCollectors
 			case "wal_dir":
 				o.WALDir = value
+			case "wal_bytes_per_sync":
+				o.WALBytesPerSync, err = strconv.Atoi(value)
 			default:
 				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key) {
 					return nil

--- a/options_test.go
+++ b/options_test.go
@@ -66,6 +66,7 @@ func TestOptionsString(t *testing.T) {
   merger=pebble.concatenate
   table_property_collectors=[]
   wal_dir=
+  wal_bytes_per_sync=0
 
 [Level "0"]
   block_restart_interval=16


### PR DESCRIPTION
This change splits the existing BytesPerSync option into two;
the original that now only governs sstable syncs, and a new
WALBytesPerSync option for WALs. The former's default is unchanged,
while the latter has a default of 0. This matches Cockroach+RocksDB
default behaviour where we have a similar bytes_per_sync value
for sstables, but we explicitly set wal_bytes_per_sync to 0.

This change is particularly beneficial in write/compaction
heavy workloads, such as sysbench. Here's a sysbench comparison
where old = #919 + #937, and new = old + this change:

```
name                                                old ops/sec  new ops/sec  delta
sysbench/oltp_read_write/nodes=3/cpu=32/conc=128     48.6k ± 5%   50.0k ± 3%     ~     (p=0.548 n=5+5)
sysbench/oltp_write_only/nodes=3/cpu=32/conc=128     27.4k ±14%   30.9k ± 4%     ~     (p=0.095 n=5+5)
sysbench/oltp_update_index/nodes=3/cpu=32/conc=128   14.7k ±17%   17.3k ± 4%     ~     (p=0.056 n=5+5)
sysbench/oltp_insert/nodes=3/cpu=32/conc=128         19.8k ±15%   22.6k ± 2%     ~     (p=0.056 n=5+5)
sysbench/oltp_delete/nodes=3/cpu=32/conc=128         45.9k ±12%   50.5k ± 4%     ~     (p=0.095 n=5+5)

name                                                old avg      new avg      delta
sysbench/oltp_read_write/nodes=3/cpu=32/conc=128      52.9 ± 5%    51.3 ± 3%     ~     (p=0.548 n=5+5)
sysbench/oltp_write_only/nodes=3/cpu=32/conc=128      28.3 ±13%    24.8 ± 4%     ~     (p=0.095 n=5+5)
sysbench/oltp_update_index/nodes=3/cpu=32/conc=128    8.83 ±16%    7.40 ± 4%     ~     (p=0.056 n=5+5)
sysbench/oltp_insert/nodes=3/cpu=32/conc=128          6.54 ±17%    5.66 ± 2%  -13.57%  (p=0.048 n=5+5)
sysbench/oltp_delete/nodes=3/cpu=32/conc=128          2.81 ±13%    2.54 ± 4%     ~     (p=0.087 n=5+5)

name                                                old p95      new p95      delta
sysbench/oltp_read_write/nodes=3/cpu=32/conc=128      91.1 ±11%    84.8 ± 2%     ~     (p=0.333 n=5+5)
sysbench/oltp_write_only/nodes=3/cpu=32/conc=128      58.7 ±29%    42.3 ± 5%     ~     (p=0.183 n=5+5)
sysbench/oltp_update_index/nodes=3/cpu=32/conc=128    27.2 ±33%    18.1 ± 5%  -33.52%  (p=0.040 n=5+5)
sysbench/oltp_insert/nodes=3/cpu=32/conc=128          19.0 ±31%    15.3 ± 2%     ~     (p=0.167 n=5+5)
sysbench/oltp_delete/nodes=3/cpu=32/conc=128          11.3 ± 9%    10.4 ± 5%     ~     (p=0.079 n=5+5)

name                                                old p99      new p99      delta
sysbench/oltp_read_write/nodes=3/cpu=32/conc=128       976 ±11%     864 ±22%     ~     (p=0.222 n=5+5)
sysbench/oltp_write_only/nodes=3/cpu=32/conc=128     1.15k ±24%   1.40k ±71%     ~     (p=0.841 n=5+5)
sysbench/oltp_update_index/nodes=3/cpu=32/conc=128   1.39k ±72%   1.10k ±27%     ~     (p=0.841 n=5+5)
sysbench/oltp_insert/nodes=3/cpu=32/conc=128           300 ±41%     345 ±38%     ~     (p=0.310 n=5+5)
sysbench/oltp_delete/nodes=3/cpu=32/conc=128           884 ±18%   1324 ±108%     ~     (p=0.841 n=5+5)
```

Doing a comparison where old = master, and new = #919 + #937 + this change,
we get:

```
name                                                old ops/sec  new ops/sec  delta
sysbench/oltp_read_write/nodes=3/cpu=32/conc=128     42.8k ±13%   50.0k ± 3%  +16.96%  (p=0.008 n=5+5)
sysbench/oltp_write_only/nodes=3/cpu=32/conc=128     21.4k ±19%   30.9k ± 4%  +44.84%  (p=0.008 n=5+5)
sysbench/oltp_update_index/nodes=3/cpu=32/conc=128   11.4k ±22%   17.3k ± 4%  +51.85%  (p=0.008 n=5+5)
sysbench/oltp_insert/nodes=3/cpu=32/conc=128         19.1k ±17%   22.6k ± 2%  +18.28%  (p=0.008 n=5+5)
sysbench/oltp_delete/nodes=3/cpu=32/conc=128         34.3k ±25%   50.5k ± 4%  +47.27%  (p=0.008 n=5+5)

name                                                old avg      new avg      delta
sysbench/oltp_read_write/nodes=3/cpu=32/conc=128      60.6 ±14%    51.3 ± 3%  -15.36%  (p=0.008 n=5+5)
sysbench/oltp_write_only/nodes=3/cpu=32/conc=128      36.8 ±18%    24.8 ± 4%  -32.49%  (p=0.008 n=5+5)
sysbench/oltp_update_index/nodes=3/cpu=32/conc=128    11.5 ±20%     7.4 ± 4%  -35.56%  (p=0.008 n=5+5)
sysbench/oltp_insert/nodes=3/cpu=32/conc=128          6.82 ±18%    5.66 ± 2%  -17.02%  (p=0.008 n=5+5)
sysbench/oltp_delete/nodes=3/cpu=32/conc=128          3.87 ±23%    2.54 ± 4%  -34.54%  (p=0.008 n=5+5)

name                                                old p95      new p95      delta
sysbench/oltp_read_write/nodes=3/cpu=32/conc=128       106 ±20%      85 ± 2%  -20.36%  (p=0.008 n=5+5)
sysbench/oltp_write_only/nodes=3/cpu=32/conc=128      77.7 ±28%    42.3 ± 5%  -45.55%  (p=0.008 n=5+5)
sysbench/oltp_update_index/nodes=3/cpu=32/conc=128    34.9 ±35%    18.1 ± 5%  -48.21%  (p=0.008 n=5+5)
sysbench/oltp_insert/nodes=3/cpu=32/conc=128          20.2 ±32%    15.3 ± 2%  -24.35%  (p=0.008 n=5+5)
sysbench/oltp_delete/nodes=3/cpu=32/conc=128          16.2 ±24%    10.4 ± 5%  -36.10%  (p=0.008 n=5+5)

name                                                old p99      new p99      delta
sysbench/oltp_read_write/nodes=3/cpu=32/conc=128       824 ±12%     864 ±22%     ~     (p=1.000 n=5+5)
sysbench/oltp_write_only/nodes=3/cpu=32/conc=128     1.15k ±70%   1.40k ±71%     ~     (p=0.310 n=5+5)
sysbench/oltp_update_index/nodes=3/cpu=32/conc=128     979 ±67%    1103 ±27%     ~     (p=0.548 n=5+5)
sysbench/oltp_insert/nodes=3/cpu=32/conc=128           282 ±11%     345 ±38%     ~     (p=0.151 n=5+5)
sysbench/oltp_delete/nodes=3/cpu=32/conc=128           637 ±67%   1324 ±108%     ~     (p=0.095 n=5+5)
```

One part of the fallout of #934.