### PR TITLE
crl-release-20.2: Have Intra-L0 compactions follow flush sizes, plus compaction-debt-based concurrency

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1126,7 +1126,7 @@ func pickL0(env compactionEnv, opts *Options, vers *version, baseLevel int) (pc 
 	// compaction. Note that we pass in L0CompactionThreshold here as opposed to
 	// 1, since choosing a single sublevel intra-L0 compaction is
 	// counterproductive.
-	lcf, err = vers.L0Sublevels.PickIntraL0Compaction(env.earliestUnflushedSeqNum, opts.L0CompactionThreshold)
+	lcf, err = vers.L0Sublevels.PickIntraL0Compaction(env.earliestUnflushedSeqNum, minIntraL0Count)
 	if err != nil {
 		opts.Logger.Infof("error when picking intra-L0 compaction: %s", err)
 		return
@@ -1146,14 +1146,6 @@ func pickL0(env compactionEnv, opts *Options, vers *version, baseLevel int) (pc 
 		}
 
 		pc.smallest, pc.largest = manifest.KeyRange(pc.cmp, pc.startLevel.files.Iter())
-		// Output only a single sstable for intra-L0 compactions.
-		// Now that we have the ability to split flushes, we could conceivably
-		// split the output of intra-L0 compactions too. This may be unnecessary
-		// complexity -- the inputs to intra-L0 should be narrow in the key space
-		// (unlike flushes), so writing a single sstable should be ok.
-		pc.maxOutputFileSize = math.MaxUint64
-		pc.maxOverlapBytes = math.MaxUint64
-		pc.maxExpandedBytes = math.MaxUint64
 	}
 	return pc
 }

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -458,6 +458,7 @@ func TestCompactionPickerL0(t *testing.T) {
 	opts.Experimental.L0CompactionConcurrency = 1
 	var picker *compactionPickerByScore
 	var inProgressCompactions []compactionInfo
+	var pc *pickedCompaction
 
 	datadriven.RunTest(t, "testdata/compaction_picker_L0", func(td *datadriven.TestData) string {
 		switch td.Cmd {
@@ -598,7 +599,7 @@ func TestCompactionPickerL0(t *testing.T) {
 				}
 			}
 
-			pc := picker.pickAuto(compactionEnv{
+			pc = picker.pickAuto(compactionEnv{
 				bytesCompacted:          new(uint64),
 				earliestUnflushedSeqNum: math.MaxUint64,
 				inProgressCompactions:   inProgressCompactions,
@@ -618,6 +619,21 @@ func TestCompactionPickerL0(t *testing.T) {
 				return "nil"
 			}
 			return result.String()
+		case "max-output-file-size":
+			if pc == nil {
+				return "no compaction"
+			}
+			return fmt.Sprintf("%d", pc.maxOutputFileSize)
+		case "max-overlap-bytes":
+			if pc == nil {
+				return "no compaction"
+			}
+			return fmt.Sprintf("%d", pc.maxOverlapBytes)
+		case "max-expanded-bytes":
+			if pc == nil {
+				return "no compaction"
+			}
+			return fmt.Sprintf("%d", pc.maxExpandedBytes)
 		}
 		return fmt.Sprintf("unrecognized command: %s", td.Cmd)
 	})

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -814,6 +814,16 @@ func TestCompactionPickerConcurrency(t *testing.T) {
 					if err != nil {
 						return err.Error()
 					}
+				case "l0_compaction_concurrency":
+					opts.Experimental.L0CompactionConcurrency, err = strconv.Atoi(arg.Vals[0])
+					if err != nil {
+						return err.Error()
+					}
+				case "compaction_debt_concurrency":
+					opts.Experimental.CompactionDebtConcurrency, err = strconv.Atoi(arg.Vals[0])
+					if err != nil {
+						return err.Error()
+					}
 				}
 			}
 

--- a/options.go
+++ b/options.go
@@ -305,9 +305,18 @@ type Options struct {
 		FlushSplitBytes int64
 
 		// The threshold of L0 read-amplification at which compaction concurrency
-		// is enabled. Every multiple of this value enables another concurrent
+		// is enabled (if CompactionDebtConcurrency was not already exceeded).
+		// Every multiple of this value enables another concurrent
 		// compaction up to MaxConcurrentCompactions.
 		L0CompactionConcurrency int
+
+		// CompactionDebtConcurrency controls the threshold of compaction debt
+		// at which additional compaction concurrency slots are added. For every
+		// multiple of this value in compaction debt bytes, an additional
+		// concurrent compaction is added. This works "on top" of
+		// L0CompactionConcurrency, so the higher of the count of compaction
+		// concurrency slots as determined by the two options is chosen.
+		CompactionDebtConcurrency int
 
 		// L0SublevelCompactions enables the use of L0 sublevel-based compaction
 		// picking logic. Defaults to false for now. This logic will become
@@ -491,6 +500,9 @@ func (o *Options) EnsureDefaults() *Options {
 	}
 	if o.Experimental.L0CompactionConcurrency <= 0 {
 		o.Experimental.L0CompactionConcurrency = 10
+	}
+	if o.Experimental.CompactionDebtConcurrency <= 0 {
+		o.Experimental.CompactionDebtConcurrency = 1 << 30 // 1 GB
 	}
 	if o.L0CompactionThreshold <= 0 {
 		o.L0CompactionThreshold = 4

--- a/testdata/compaction_picker_L0
+++ b/testdata/compaction_picker_L0
@@ -205,18 +205,26 @@ L0: 000100,000110
 L6: 000200
 
 # 3 L0 files (1 overlap), Lbase compacting.
-# Should choose an intra-L0 compaction.
+# Should choose an intra-L0 compaction. Note that intra-L0 compactions
+# don't follow l0_compaction_threshold, but rather a minIntraL0Count constant
+# in compaction_picker.go
 
 define
 L0
    000100:i.SET.101-p.SET.102
    000110:j.SET.111-q.SET.112
    000120:r.SET.113-s.SET.114
+   000130:i.SET.110-p.SET.110
+   000140:i.SET.120-p.SET.120
 L6
    000200:f.SET.51-s.SET.52
 compactions
   L6 000200 -> L6
 ----
+0.3:
+  000140:[i#120,SET-p#120,SET]
+0.2:
+  000130:[i#110,SET-p#110,SET]
 0.1:
   000110:[j#111,SET-q#112,SET]
 0.0:
@@ -227,10 +235,22 @@ compactions
 compactions
   L6 000200 -> L6
 
-pick-auto l0_compaction_threshold=2
+pick-auto
 ----
 L0 -> L0
-L0: 000100,000110
+L0: 000100,000110,000130,000140
+
+max-output-file-size
+----
+4194304
+
+max-overlap-bytes
+----
+41943040
+
+max-expanded-bytes
+----
+104857600
 
 # 1 L0 file. Should not choose any compaction, as an intra-L0 compaction
 # with one input is unhelpful.

--- a/testdata/compaction_picker_concurrency
+++ b/testdata/compaction_picker_concurrency
@@ -49,3 +49,124 @@ compactions
 pick-auto l0_compaction_threshold=10
 ----
 nil
+
+# Test that lowering L0CompactionConcurrency opens up more compaction slots.
+
+define
+L0
+  000301:a.SET.31-a.SET.31
+  000302:a.SET.32-a.SET.32
+  000303:a.SET.33-a.SET.33
+  000304:a.SET.34-a.SET.34
+  000305:a.SET.35-a.SET.35
+L1
+  000201:a.SET.21-b.SET.22
+  000203:k.SET.25-n.SET.26
+  000202:x.SET.23-z.SET.24
+L2
+  000101:a.SET.11-f.SET.12
+L3
+  000010:a.SET.1-z.SET.2
+compactions
+  L1 000202 -> L2 000101
+----
+0.4:
+  000305:[a#35,SET-a#35,SET]
+0.3:
+  000304:[a#34,SET-a#34,SET]
+0.2:
+  000303:[a#33,SET-a#33,SET]
+0.1:
+  000302:[a#32,SET-a#32,SET]
+0.0:
+  000301:[a#31,SET-a#31,SET]
+1:
+  000201:[a#21,SET-b#22,SET]
+  000203:[k#25,SET-n#26,SET]
+  000202:[x#23,SET-z#24,SET]
+2:
+  000101:[a#11,SET-f#12,SET]
+3:
+  000010:[a#1,SET-z#2,SET]
+compactions
+  L1 000202 -> L2 000101
+
+pick-auto l0_compaction_concurrency=10
+----
+nil
+
+pick-auto l0_compaction_concurrency=5
+----
+L0 -> L1
+L0: 000301,000302,000303,000304,000305
+L1: 000201
+grandparents: 000101
+
+pick-auto l0_compaction_concurrency=1
+----
+L0 -> L1
+L0: 000301,000302,000303,000304,000305
+L1: 000201
+grandparents: 000101
+
+# Test that lowering CompactionDebtConcurrency opens up more concurrent
+# compaction slots.
+
+# Test that lowering L0CompactionConcurrency opens up more compaction slots.
+
+define
+L0
+  000301:a.SET.31-a.SET.31 size=64000
+  000302:a.SET.32-a.SET.32 size=64000
+  000303:a.SET.33-a.SET.33 size=64000
+  000304:a.SET.34-a.SET.34 size=64000
+  000305:a.SET.35-a.SET.35 size=64000
+L1
+  000201:a.SET.21-b.SET.22 size=640000
+  000203:k.SET.25-n.SET.26 size=640000
+  000202:x.SET.23-z.SET.24 size=640000
+L2
+  000101:a.SET.11-f.SET.12 size=6400000
+L3
+  000010:a.SET.1-z.SET.2
+compactions
+  L1 000202 -> L2 000101
+----
+0.4:
+  000305:[a#35,SET-a#35,SET]
+0.3:
+  000304:[a#34,SET-a#34,SET]
+0.2:
+  000303:[a#33,SET-a#33,SET]
+0.1:
+  000302:[a#32,SET-a#32,SET]
+0.0:
+  000301:[a#31,SET-a#31,SET]
+1:
+  000201:[a#21,SET-b#22,SET]
+  000203:[k#25,SET-n#26,SET]
+  000202:[x#23,SET-z#24,SET]
+2:
+  000101:[a#11,SET-f#12,SET]
+3:
+  000010:[a#1,SET-z#2,SET]
+compactions
+  L1 000202 -> L2 000101
+
+pick-auto l0_compaction_concurrency=10 compaction_debt_concurrency=5120000
+----
+nil
+
+pick-auto l0_compaction_concurrency=10 compaction_debt_concurrency=512000
+----
+L0 -> L1
+L0: 000301,000302,000303,000304,000305
+L1: 000201
+grandparents: 000101
+
+pick-auto l0_compaction_concurrency=5 compaction_debt_concurrency=5120000
+----
+L0 -> L1
+L0: 000301,000302,000303,000304,000305
+L1: 000201
+grandparents: 000101


### PR DESCRIPTION
20.2 backport of #919 and #937

---

*: Have intra-L0 compactions follow flush sizes / splits

This change updates output parameters of intra-L0 compactions to
obey flush sematics around file sizes, compaction expansions, and
grandparent / flush limits. This prevents cases where intra-L0
compactions unintentionally produce wide files bridging flush
split boundaries.

Furthermore, the minimum threshold for overlaps before
an intra-L0 copmaction is chosen was bumped up to a constant of
minIntraL0Count (currently 4) to match RocksDB behaviour.

---

*: Add compaction-debt based signal for compaction concurrency 

Adds a new option, defaulting to 1GB, called CompactionDebtConcurrency
that works similarly to L0CompactionConcurrency in that it adds one
additional concurrent compaction slot per CompactionDebtConcurrency
bytes of compaction debt, up to MaxCompactionConcurrency.

The motivation behind this change is to not result in steep drops
in compaction concurrency right after a large base compaction finishes.
This is necessary in write-heavy workloads where we need to maintain
a high compaction concurrency throughout a workload, and to continue
moving files down from Lbase onto lower levels to keep pace with
flushes.
