### PR TITLE
db: fix WAL checksum error handling during upgrade

### DIFF
--- a/open.go
+++ b/open.go
@@ -229,6 +229,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		name string
 	}
 	var logFiles []fileNumAndName
+	var strictWALTail bool
 	for _, filename := range ls {
 		ft, fn, ok := base.ParseFilename(opts.FS, filename)
 		if !ok {
@@ -250,7 +251,8 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 				d.logRecycler.minRecycleLogNum = fn + 1
 			}
 		case fileTypeOptions:
-			if err := checkOptions(opts, opts.FS.PathJoin(dirname, filename)); err != nil {
+			strictWALTail, err = checkOptions(opts, opts.FS.PathJoin(dirname, filename))
+			if err != nil {
 				return nil, err
 			}
 		case fileTypeTemp:
@@ -271,7 +273,8 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	var ve versionEdit
 	for i, lf := range logFiles {
 		lastWAL := i == len(logFiles)-1
-		maxSeqNum, err := d.replayWAL(jobID, &ve, opts.FS, opts.FS.PathJoin(d.walDirname, lf.name), lf.num, lastWAL)
+		maxSeqNum, err := d.replayWAL(jobID, &ve, opts.FS,
+			opts.FS.PathJoin(d.walDirname, lf.name), lf.num, strictWALTail && !lastWAL)
 		if err != nil {
 			return nil, err
 		}
@@ -433,7 +436,7 @@ func GetVersion(dir string, fs vfs.FS) (string, error) {
 // d.mu must be held when calling this, but the mutex may be dropped and
 // re-acquired during the course of this method.
 func (d *DB) replayWAL(
-	jobID int, ve *versionEdit, fs vfs.FS, filename string, logNum FileNum, lastWAL bool,
+	jobID int, ve *versionEdit, fs vfs.FS, filename string, logNum FileNum, strictWALTail bool,
 ) (maxSeqNum uint64, err error) {
 	file, err := fs.Open(filename)
 	if err != nil {
@@ -504,7 +507,7 @@ func (d *DB) replayWAL(
 			// to otherwise treat them like EOF.
 			if err == io.EOF {
 				break
-			} else if record.IsInvalidRecord(err) && lastWAL {
+			} else if record.IsInvalidRecord(err) && !strictWALTail {
 				break
 			}
 			return 0, errors.Wrap(err, "pebble: error when replaying WAL")
@@ -577,16 +580,16 @@ func (d *DB) replayWAL(
 	return maxSeqNum, err
 }
 
-func checkOptions(opts *Options, path string) error {
+func checkOptions(opts *Options, path string) (strictWALTail bool, err error) {
 	f, err := opts.FS.Open(path)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer f.Close()
 
 	data, err := ioutil.ReadAll(f)
 	if err != nil {
-		return err
+		return false, err
 	}
-	return opts.Check(string(data))
+	return opts.checkOptions(string(data))
 }

--- a/open_test.go
+++ b/open_test.go
@@ -563,6 +563,72 @@ func TestTwoWALReplayCorrupt(t *testing.T) {
 	require.Error(t, err, "pebble: corruption")
 }
 
+// TestTwoWALReplayCorrupt tests WAL-replay behavior when the first of the two
+// WALs is corrupted with an sstable checksum error and the OPTIONS file does
+// not enable the private strict_wal_tail option, indicating that the WAL was
+// produced by a database that did not guarantee clean WAL tails. See #864.
+func TestTwoWALReplayPermissive(t *testing.T) {
+	// Use the real filesystem so that we can seek and overwrite WAL data
+	// easily.
+	dir, err := ioutil.TempDir("", "wal-replay")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	opts := &Options{
+		MemTableStopWritesThreshold: 4,
+		MemTableSize:                2048,
+	}
+	opts.EnsureDefaults()
+	d, err := Open(dir, opts)
+	require.NoError(t, err)
+	d.mu.Lock()
+	d.mu.compact.flushing = true
+	d.mu.Unlock()
+	require.NoError(t, d.Set([]byte("1"), []byte(strings.Repeat("a", 1024)), nil))
+	require.NoError(t, d.Set([]byte("2"), nil, nil))
+	d.mu.Lock()
+	d.mu.compact.flushing = false
+	d.mu.Unlock()
+	require.NoError(t, d.Close())
+
+	// We should have two WALs.
+	var logs []string
+	var optionFilename string
+	ls, err := vfs.Default.List(dir)
+	require.NoError(t, err)
+	for _, name := range ls {
+		if filepath.Ext(name) == ".log" {
+			logs = append(logs, name)
+		}
+		if strings.HasPrefix(filepath.Base(name), "OPTIONS") {
+			optionFilename = name
+		}
+	}
+	sort.Strings(logs)
+	if len(logs) < 2 {
+		t.Fatalf("expected at least two log files, found %d", len(logs))
+	}
+
+	// Corrupt the (n-1)th WAL by zeroing four bytes, 100 bytes from the end
+	// of the file.
+	f, err := os.OpenFile(filepath.Join(dir, logs[len(logs)-2]), os.O_RDWR, os.ModePerm)
+	require.NoError(t, err)
+	off, err := f.Seek(-100, 2)
+	require.NoError(t, err)
+	_, err = f.Write([]byte{0, 0, 0, 0})
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	t.Logf("zeored four bytes in %s at offset %d\n", logs[len(logs)-2], off)
+
+	// Remove the OPTIONS file containing the strict_wal_tail option.
+	require.NoError(t, vfs.Default.Remove(filepath.Join(dir, optionFilename)))
+
+	// Re-opening the database should not report the corruption.
+	d, err = Open(dir, nil)
+	require.NoError(t, err)
+	require.NoError(t, d.Close())
+}
+
 // TestOpenWALReplayReadOnlySeqNums tests opening a database:
 // * in read-only mode
 // * with multiple unflushed log files that must replayed

--- a/options_test.go
+++ b/options_test.go
@@ -64,6 +64,7 @@ func TestOptionsString(t *testing.T) {
   min_compaction_rate=4194304
   min_flush_rate=1048576
   merger=pebble.concatenate
+  strict_wal_tail=true
   table_property_collectors=[]
   wal_dir=
   wal_bytes_per_sync=0


### PR DESCRIPTION
A database that was created using RocksDB or a previous version of
Pebble does not guarantee that its closed WALs were closed cleanly.
Detect these cases by the absence of a special private
'strict_wal_tail' option. If this special option is missing from the
OPTIONS file, interpret WALs permissively as they're interpreted in the
RocksDB and Pebble versions that wrote them.

See cockroachdb/cockroach#52729.