### PR TITLE
crl-release-20.2: db: fix WAL checksum error handling from previous versions

### DIFF
--- a/open_test.go
+++ b/open_test.go
@@ -563,6 +563,72 @@ func TestTwoWALReplayCorrupt(t *testing.T) {
 	require.Error(t, err, "pebble: corruption")
 }
 
+// TestTwoWALReplayCorrupt tests WAL-replay behavior when the first of the two
+// WALs is corrupted with an sstable checksum error and the OPTIONS file does
+// not enable the private strict_wal_tail option, indicating that the WAL was
+// produced by a database that did not guarantee clean WAL tails. See #864.
+func TestTwoWALReplayPermissive(t *testing.T) {
+	// Use the real filesystem so that we can seek and overwrite WAL data
+	// easily.
+	dir, err := ioutil.TempDir("", "wal-replay")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	opts := &Options{
+		MemTableStopWritesThreshold: 4,
+		MemTableSize:                2048,
+	}
+	opts.EnsureDefaults()
+	d, err := Open(dir, opts)
+	require.NoError(t, err)
+	d.mu.Lock()
+	d.mu.compact.flushing = true
+	d.mu.Unlock()
+	require.NoError(t, d.Set([]byte("1"), []byte(strings.Repeat("a", 1024)), nil))
+	require.NoError(t, d.Set([]byte("2"), nil, nil))
+	d.mu.Lock()
+	d.mu.compact.flushing = false
+	d.mu.Unlock()
+	require.NoError(t, d.Close())
+
+	// We should have two WALs.
+	var logs []string
+	var optionFilename string
+	ls, err := vfs.Default.List(dir)
+	require.NoError(t, err)
+	for _, name := range ls {
+		if filepath.Ext(name) == ".log" {
+			logs = append(logs, name)
+		}
+		if strings.HasPrefix(filepath.Base(name), "OPTIONS") {
+			optionFilename = name
+		}
+	}
+	sort.Strings(logs)
+	if len(logs) < 2 {
+		t.Fatalf("expected at least two log files, found %d", len(logs))
+	}
+
+	// Corrupt the (n-1)th WAL by zeroing four bytes, 100 bytes from the end
+	// of the file.
+	f, err := os.OpenFile(filepath.Join(dir, logs[len(logs)-2]), os.O_RDWR, os.ModePerm)
+	require.NoError(t, err)
+	off, err := f.Seek(-100, 2)
+	require.NoError(t, err)
+	_, err = f.Write([]byte{0, 0, 0, 0})
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	t.Logf("zeored four bytes in %s at offset %d\n", logs[len(logs)-2], off)
+
+	// Remove the OPTIONS file containing the strict_wal_tail option.
+	require.NoError(t, vfs.Default.Remove(filepath.Join(dir, optionFilename)))
+
+	// Re-opening the database should not report the corruption.
+	d, err = Open(dir, nil)
+	require.NoError(t, err)
+	require.NoError(t, d.Close())
+}
+
 // TestOpenWALReplayReadOnlySeqNums tests opening a database:
 // * in read-only mode
 // * with multiple unflushed log files that must replayed

--- a/options.go
+++ b/options.go
@@ -461,8 +461,19 @@ type Options struct {
 	// changing options dynamically?
 	WALMinSyncInterval func() time.Duration
 
-	// private options are only used by internal tests.
+	// private options are only used by internal tests or are used internally
+	// for facilitating upgrade paths of unconfigurable functionality.
 	private struct {
+		// strictWALTail configures whether or not a database's WALs created
+		// prior to the most recent one should be interpreted strictly,
+		// requiring a clean EOF. RocksDB 6.2.1 and the version of Pebble
+		// included in CockroachDB 20.1 do not guarantee that closed WALs end
+		// cleanly. If this option is set within an OPTIONS file, Pebble
+		// interprets previous WALs strictly, requiring a clean EOF.
+		// Otherwise, it interprets them permissively in the same manner as
+		// RocksDB 6.2.1.
+		strictWALTail bool
+
 		// TODO(peter): A private option to enable flush/compaction pacing. Only used
 		// by tests. Compaction/flush pacing is disabled until we fix the impact on
 		// throughput.
@@ -557,8 +568,9 @@ func (o *Options) EnsureDefaults() *Options {
 	if o.MaxConcurrentCompactions <= 0 {
 		o.MaxConcurrentCompactions = 1
 	}
+	o.private.strictWALTail = true
 	if o.FS == nil {
-		o.FS = vfs.WithDiskHealthChecks(vfs.Default, 5 * time.Second,
+		o.FS = vfs.WithDiskHealthChecks(vfs.Default, 5*time.Second,
 			func(name string, duration time.Duration) {
 				o.EventListener.DiskSlow(DiskSlowInfo{
 					Path:     name,
@@ -648,6 +660,7 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  min_compaction_rate=%d\n", o.MinCompactionRate)
 	fmt.Fprintf(&buf, "  min_flush_rate=%d\n", o.MinFlushRate)
 	fmt.Fprintf(&buf, "  merger=%s\n", o.Merger.Name)
+	fmt.Fprintf(&buf, "  strict_wal_tail=%t\n", o.private.strictWALTail)
 	fmt.Fprintf(&buf, "  table_property_collectors=[")
 	for i := range o.TablePropertyCollectors {
 		if i > 0 {
@@ -820,6 +833,8 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				o.MinCompactionRate, err = strconv.Atoi(value)
 			case "min_flush_rate":
 				o.MinFlushRate, err = strconv.Atoi(value)
+			case "strict_wal_tail":
+				o.private.strictWALTail, err = strconv.ParseBool(value)
 			case "merger":
 				switch value {
 				case "nullptr":
@@ -920,11 +935,9 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 	})
 }
 
-// Check verifies the options are compatible with the previous options
-// serialized by Options.String(). For example, the Comparer and Merger must be
-// the same, or data will not be able to be properly read from the DB.
-func (o *Options) Check(s string) error {
-	return parseOptions(s, func(section, key, value string) error {
+func (o *Options) checkOptions(s string) (strictWALTail bool, err error) {
+	// TODO(jackson): Refactor to avoid awkwardness of the strictWALTail return value.
+	return strictWALTail, parseOptions(s, func(section, key, value string) error {
 		switch section + "." + key {
 		case "Options.comparer":
 			if value != o.Comparer.Name {
@@ -938,9 +951,22 @@ func (o *Options) Check(s string) error {
 				return errors.Errorf("pebble: merger name from file %q != merger name from options %q",
 					errors.Safe(value), errors.Safe(o.Merger.Name))
 			}
+		case "Options.strict_wal_tail":
+			strictWALTail, err = strconv.ParseBool(value)
+			if err != nil {
+				return errors.Errorf("pebble: error parsing strict_wal_tail value %q: %w", value, err)
+			}
 		}
 		return nil
 	})
+}
+
+// Check verifies the options are compatible with the previous options
+// serialized by Options.String(). For example, the Comparer and Merger must be
+// the same, or data will not be able to be properly read from the DB.
+func (o *Options) Check(s string) error {
+	_, err := o.checkOptions(s)
+	return err
 }
 
 // Validate verifies that the options are mutually consistent. For example,

--- a/options_test.go
+++ b/options_test.go
@@ -64,6 +64,7 @@ func TestOptionsString(t *testing.T) {
   min_compaction_rate=4194304
   min_flush_rate=1048576
   merger=pebble.concatenate
+  strict_wal_tail=true
   table_property_collectors=[]
   wal_dir=
   wal_bytes_per_sync=0


### PR DESCRIPTION
Backport of #948.

It was a mostly clean cherrypick, just had a mini conflict with the
privatization of the `minCompactionRate`, `minFlushRate`.