### PR TITLE
tool: Add `db checkpoint` command

### DIFF
--- a/internal/record/record.go
+++ b/internal/record/record.go
@@ -581,6 +581,9 @@ func (w *Writer) WriteRecord(p []byte) (int64, error) {
 
 // Size returns the current size of the file.
 func (w *Writer) Size() int64 {
+	if w == nil {
+		return 0
+	}
 	return w.blockNumber*blockSize + int64(w.j)
 }
 

--- a/tool/data_test.go
+++ b/tool/data_test.go
@@ -44,6 +44,7 @@ func runTests(t *testing.T, path string) {
 		name, err := filepath.Rel(root, path)
 		require.NoError(t, err)
 
+		fs := vfs.NewMem()
 		t.Run(name, func(t *testing.T) {
 			datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
 				args := []string{d.Cmd}
@@ -56,7 +57,6 @@ func runTests(t *testing.T, path string) {
 				// might be running on a sytem with a different path separator
 				// (e.g. Windows). Copy the input data into a mem filesystem which
 				// always uses "/" for the path separator.
-				fs := vfs.NewMem()
 				for i := range args {
 					src := normalize(args[i])
 					dest := vfs.Default.PathBase(src)

--- a/tool/testdata/db_checkpoint
+++ b/tool/testdata/db_checkpoint
@@ -1,0 +1,18 @@
+db checkpoint
+----
+accepts 2 arg(s), received 0
+
+db checkpoint
+non-existent
+----
+accepts 2 arg(s), received 1
+
+db checkpoint
+../testdata/db-stage-4
+../testdata/db-checkpoint1
+----
+
+db check
+../testdata/db-checkpoint1
+----
+checked 6 points and 0 tombstone


### PR DESCRIPTION
Adds a command to create a checkpoint of an existing pebble directory,
using the db.Checkpoint method. This needs to be exposed to the command
line for use in some of Cockroach's roachtests.

Also makes a change in Checkpoint() to better handle empty manifests.