### PR TITLE
db: allow method db.SSTables to return sstable properties

### DIFF
--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -197,7 +197,8 @@ func TestCheckpointCompaction(t *testing.T) {
 			}
 			// Check the checkpoint has all the sstables that the manifest
 			// claims it has.
-			for _, tables := range d2.SSTables() {
+			tableInfos, _ := d2.SSTables()
+			for _, tables := range tableInfos {
 				for _, tbl := range tables {
 					if _, err := fs.Stat(base.MakeFilename(fs, dir, base.FileTypeTable, tbl.FileNum)); err != nil {
 						t.Error(err)

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -248,7 +248,8 @@ func TestEventListener(t *testing.T) {
 
 		case "sstables":
 			var buf bytes.Buffer
-			for i, level := range d.SSTables() {
+			tableInfos, _ := d.SSTables()
+			for i, level := range tableInfos {
 				if len(level) == 0 {
 					continue
 				}

--- a/table_cache.go
+++ b/table_cache.go
@@ -56,6 +56,10 @@ func (c *tableCache) newIters(
 	return c.getShard(file.FileNum).newIters(file, opts, bytesIterated)
 }
 
+func (c *tableCache) getTableProperties(file *fileMetadata) (*sstable.Properties, error) {
+	return c.getShard(file.FileNum).getTableProperties(file)
+}
+
 func (c *tableCache) evict(fileNum FileNum) {
 	c.getShard(fileNum).evict(fileNum)
 }
@@ -229,6 +233,21 @@ func (c *tableCacheShard) newIters(
 	}
 	// NB: Translate a nil range-del iterator into a nil interface.
 	return iter, nil, nil
+}
+
+// getTableProperties return sst table properties for target file
+func (c *tableCacheShard) getTableProperties(file *fileMetadata) (*sstable.Properties, error) {
+	// Calling findNode gives us the responsibility of decrementing v's
+	// refCount. If opening the underlying table resulted in error, then we
+	// decrement this straight away. Otherwise, we pass that responsibility to
+	// the sstable iterator, which decrements when it is closed.
+	v := c.findNode(file)
+	defer c.unrefValue(v)
+	if v.err != nil {
+		return nil, v.err
+	}
+
+	return &v.reader.Properties, nil
 }
 
 // releaseNode releases a node from the tableCacheShard.

--- a/table_cache.go
+++ b/table_cache.go
@@ -237,16 +237,13 @@ func (c *tableCacheShard) newIters(
 
 // getTableProperties return sst table properties for target file
 func (c *tableCacheShard) getTableProperties(file *fileMetadata) (*sstable.Properties, error) {
-	// Calling findNode gives us the responsibility of decrementing v's
-	// refCount. If opening the underlying table resulted in error, then we
-	// decrement this straight away. Otherwise, we pass that responsibility to
-	// the sstable iterator, which decrements when it is closed.
+	// Calling findNode gives us the responsibility of decrementing v's refCount here
 	v := c.findNode(file)
 	defer c.unrefValue(v)
+
 	if v.err != nil {
 		return nil, v.err
 	}
-
 	return &v.reader.Properties, nil
 }
 


### PR DESCRIPTION
~Add an interface to `DB` to get all sst table properties. The interface is like rocksdb's `DB.GetPropertiesOfAllTables`.~

Extend to `DB.SSTables` function to allow return sstable.Properties in each TableInfo

This is useful in case there are  customized `TablePropertyCollector`s in the db, so we can use this API to fetch all the user properties.