### PR TITLE
Fixing linting issues

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -699,7 +699,7 @@ func TestFlushableBatch(t *testing.T) {
 
 		case "dump":
 			if len(d.CmdArgs) != 1 || len(d.CmdArgs[0].Vals) != 1 || d.CmdArgs[0].Key != "seq" {
-				return fmt.Sprintf("dump seq=<value>\n")
+				return "dump seq=<value>\n"
 			}
 			seqNum, err := strconv.Atoi(d.CmdArgs[0].Vals[0])
 			if err != nil {

--- a/cmd/pebble/compact.go
+++ b/cmd/pebble/compact.go
@@ -342,7 +342,6 @@ func runReplay(cmd *cobra.Command, args []string) error {
 		select {
 		case <-time.After(time.Second):
 			quiesced = true
-			break
 		case <-waiterCh:
 			continue
 		}
@@ -375,7 +374,7 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 	fmt.Printf("__elapsed__compacts__w-amp__r-amp(_p50__p95__p99__max_)__space(_____amp__stable___final__average__)\n")
 	fmt.Printf("  %6.2fm  %8d  %5.2f         %3d  %3d  %3d  %3d         %9.2f  %6s  %6s  %7s\n",
-		time.Now().Sub(start).Minutes(),
+		time.Since(start).Minutes(),
 		m.Compact.Count,
 		totalWriteAmp(m),
 		rampHist.ValueAtQuantile(50),

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -906,7 +906,7 @@ func TestPickedCompactionSetupInputs(t *testing.T) {
 			switch d.Cmd {
 			case "setup-inputs":
 				if len(d.CmdArgs) != 2 {
-					return fmt.Sprintf("setup-inputs <start> <end>")
+					return "setup-inputs <start> <end>"
 				}
 
 				pc := &pickedCompaction{
@@ -936,7 +936,7 @@ func TestPickedCompactionSetupInputs(t *testing.T) {
 							pc.outputLevel.level = level
 							currentLevel = level
 						} else {
-							return fmt.Sprintf("outputLevel already set\n")
+							return "outputLevel already set\n"
 						}
 
 					default:

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2002,7 +2002,7 @@ func TestCompactionCheckOrdering(t *testing.T) {
 							c.outputLevel.level = level
 							files = &outputFiles
 						} else {
-							return fmt.Sprintf("outputLevel already set\n")
+							return "outputLevel already set\n"
 						}
 
 					default:
@@ -2139,7 +2139,7 @@ func TestCompactionOutputSplitters(t *testing.T) {
 				if shouldSplit == splitNow {
 					main.onNewOutput(&key)
 				}
-				return fmt.Sprintf("%s", shouldSplit)
+				return shouldSplit.String()
 			default:
 				return fmt.Sprintf("unknown command: %s", d.Cmd)
 			}

--- a/data_test.go
+++ b/data_test.go
@@ -69,17 +69,17 @@ func runIterCmd(d *datadriven.TestData, iter *Iterator) string {
 		switch parts[0] {
 		case "seek-ge":
 			if len(parts) != 2 {
-				return fmt.Sprintf("seek-ge <key>\n")
+				return "seek-ge <key>\n"
 			}
 			valid = iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
 		case "seek-prefix-ge":
 			if len(parts) != 2 {
-				return fmt.Sprintf("seek-prefix-ge <key>\n")
+				return "seek-prefix-ge <key>\n"
 			}
 			valid = iter.SeekPrefixGE([]byte(strings.TrimSpace(parts[1])))
 		case "seek-lt":
 			if len(parts) != 2 {
-				return fmt.Sprintf("seek-lt <key>\n")
+				return "seek-lt <key>\n"
 			}
 			valid = iter.SeekLT([]byte(strings.TrimSpace(parts[1])))
 		case "first":
@@ -92,7 +92,7 @@ func runIterCmd(d *datadriven.TestData, iter *Iterator) string {
 			valid = iter.Prev()
 		case "set-bounds":
 			if len(parts) <= 1 || len(parts) > 3 {
-				return fmt.Sprintf("set-bounds lower=<lower> upper=<upper>\n")
+				return "set-bounds lower=<lower> upper=<upper>\n"
 			}
 			var lower []byte
 			var upper []byte
@@ -145,19 +145,19 @@ func runInternalIterCmd(d *datadriven.TestData, iter internalIterator, opts ...i
 		switch parts[0] {
 		case "seek-ge":
 			if len(parts) != 2 {
-				return fmt.Sprintf("seek-ge <key>\n")
+				return "seek-ge <key>\n"
 			}
 			prefix = nil
 			key, value = iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
 		case "seek-prefix-ge":
 			if len(parts) != 2 {
-				return fmt.Sprintf("seek-prefix-ge <key>\n")
+				return "seek-prefix-ge <key>\n"
 			}
 			prefix = []byte(strings.TrimSpace(parts[1]))
 			key, value = iter.SeekPrefixGE(prefix, prefix /* key */)
 		case "seek-lt":
 			if len(parts) != 2 {
-				return fmt.Sprintf("seek-lt <key>\n")
+				return "seek-lt <key>\n"
 			}
 			prefix = nil
 			key, value = iter.SeekLT([]byte(strings.TrimSpace(parts[1])))
@@ -173,7 +173,7 @@ func runInternalIterCmd(d *datadriven.TestData, iter internalIterator, opts ...i
 			key, value = iter.Prev()
 		case "set-bounds":
 			if len(parts) <= 1 || len(parts) > 3 {
-				return fmt.Sprintf("set-bounds lower=<lower> upper=<upper>\n")
+				return "set-bounds lower=<lower> upper=<upper>\n"
 			}
 			var lower []byte
 			var upper []byte
@@ -537,7 +537,7 @@ func (d *DB) waitTableStats() {
 }
 
 func runIngestCmd(td *datadriven.TestData, d *DB, fs vfs.FS) error {
-	var paths []string
+	paths := make([]string, 0, len(td.CmdArgs))
 	for _, arg := range td.CmdArgs {
 		paths = append(paths, arg.String())
 	}

--- a/flushable.go
+++ b/flushable.go
@@ -68,7 +68,7 @@ func (e *flushableEntry) readerUnref() {
 		panic(fmt.Sprintf("pebble: inconsistent reference count: %d", v))
 	case v == 0:
 		if e.releaseMemAccounting == nil {
-			panic(fmt.Sprintf("pebble: memtable reservation already released"))
+			panic("pebble: memtable reservation already released")
 		}
 		e.releaseMemAccounting()
 		e.releaseMemAccounting = nil

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/exp v0.0.0-20200513190911-00229845015e
+	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/sys v0.0.0-20200519105757-fe76b779f299
 )
 

--- a/go.sum
+++ b/go.sum
@@ -57,7 +57,15 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/arenaskl/arena.go
+++ b/internal/arenaskl/arena.go
@@ -83,7 +83,7 @@ func (a *Arena) alloc(size, align, overflow uint32) (uint32, uint32, error) {
 	}
 
 	// Return the aligned offset.
-	offset := (uint32(newSize) - padded + uint32(align)) & ^uint32(align)
+	offset := (uint32(newSize) - padded + align) & ^align
 	return offset, padded, nil
 }
 

--- a/internal/arenaskl/node.go
+++ b/internal/arenaskl/node.go
@@ -98,7 +98,7 @@ func newRawNode(arena *Arena, height uint32, keySize, valueSize uint32) (nd *nod
 
 	nd = (*node)(arena.getPointer(nodeOffset))
 	nd.keyOffset = nodeOffset + nodeSize
-	nd.keySize = uint32(keySize)
+	nd.keySize = keySize
 	nd.valueSize = valueIndex
 	nd.allocSize = allocSize
 	return

--- a/internal/base/comparer.go
+++ b/internal/base/comparer.go
@@ -212,8 +212,8 @@ func (p FormatBytes) Format(s fmt.State, c rune) {
 			continue
 		}
 		buf = append(buf, `\x`...)
-		buf = append(buf, lowerhex[byte(b)>>4])
-		buf = append(buf, lowerhex[byte(b)&0xF])
+		buf = append(buf, lowerhex[b>>4])
+		buf = append(buf, lowerhex[b&0xF])
 	}
 	s.Write(buf)
 }

--- a/internal/cache/robin_hood_test.go
+++ b/internal/cache/robin_hood_test.go
@@ -50,7 +50,7 @@ func TestRobinHoodMap(t *testing.T) {
 			e := &entry{}
 			goMap[k] = e
 			rhMap.Put(k, e)
-			if len(goMap) != int(rhMap.Count()) {
+			if len(goMap) != rhMap.Count() {
 				t.Fatalf("map sizes differ: %d != %d", len(goMap), rhMap.Count())
 			}
 
@@ -60,7 +60,7 @@ func TestRobinHoodMap(t *testing.T) {
 			e := &entry{}
 			goMap[k] = e
 			rhMap.Put(k, e)
-			if len(goMap) != int(rhMap.Count()) {
+			if len(goMap) != rhMap.Count() {
 				t.Fatalf("map sizes differ: %d != %d", len(goMap), rhMap.Count())
 			}
 
@@ -69,7 +69,7 @@ func TestRobinHoodMap(t *testing.T) {
 			k := randomKey()
 			delete(goMap, k)
 			rhMap.Delete(k)
-			if len(goMap) != int(rhMap.Count()) {
+			if len(goMap) != rhMap.Count() {
 				t.Fatalf("map sizes differ: %d != %d", len(goMap), rhMap.Count())
 			}
 

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -1100,14 +1100,14 @@ func (s *L0Sublevels) extendFiles(
 func (s *L0Sublevels) PickIntraL0Compaction(
 	earliestUnflushedSeqNum uint64, minCompactionDepth int,
 ) (*L0CompactionFiles, error) {
-	var scoredIntervals []intervalAndScore
+	scoredIntervals := make([]intervalAndScore, len(s.orderedIntervals))
 	for i := range s.orderedIntervals {
 		interval := &s.orderedIntervals[i]
 		depth := interval.fileCount - interval.compactingFileCount
 		if minCompactionDepth > depth {
 			continue
 		}
-		scoredIntervals = append(scoredIntervals, intervalAndScore{interval: i, score: depth})
+		scoredIntervals[i] = intervalAndScore{interval: i, score: depth}
 	}
 	sort.Sort(intervalSorterByDecreasingScore(scoredIntervals))
 

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -157,7 +157,7 @@ func (o *flushOp) run(t *test, h *history) {
 }
 
 func (o *flushOp) String() string {
-	return fmt.Sprintf("db.Flush()")
+	return "db.Flush()"
 }
 
 // mergeOp models a Write.Merge operation.
@@ -689,7 +689,7 @@ func (o *dbRestartOp) run(t *test, h *history) {
 }
 
 func (o *dbRestartOp) String() string {
-	return fmt.Sprintf("db.Restart()")
+	return "db.Restart()"
 }
 
 func formatOps(ops []op) string {

--- a/internal/pacertoy/pebble/main.go
+++ b/internal/pacertoy/pebble/main.go
@@ -391,45 +391,43 @@ func main() {
 	var lastFill, lastDrain int64
 
 	for i := 0; ; i++ {
-		select {
-		case <-tick.C:
-			if (i % 20) == 0 {
-				fmt.Printf("_elapsed___memtbs____dirty_____fill____drain____cdebt__l0count___max-f-rate\n")
-			}
-
-			if (i % 7) == 0 {
-				//db.printLevels()
-			}
-
-			db.mu.Lock()
-			memtableCount := len(db.memtables)
-			db.mu.Unlock()
-			dirty := atomic.LoadInt64(&db.flushPacer.level)
-			fill := atomic.LoadInt64(&db.fill)
-			drain := atomic.LoadInt64(&db.drain)
-
-			db.compactionMu.Lock()
-			compactionL0 := len(db.L0)
-			db.compactionMu.Unlock()
-			totalCompactionBytes := atomic.LoadInt64(&db.compactionPacer.level)
-			compactionDebt := math.Max(float64(totalCompactionBytes)-l0CompactionThreshold*memtableSize, 0.0)
-			maxFlushRate := db.flushPacer.maxDrainer.Limit()
-
-			now := time.Now()
-			elapsed := now.Sub(lastNow).Seconds()
-			fmt.Printf("%8s %8d %8.1f %8.1f %8.1f %8.1f %8d %12.1f\n",
-				time.Duration(now.Sub(start).Seconds()+0.5)*time.Second,
-				memtableCount,
-				float64(dirty)/(1024.0*1024.0),
-				float64(fill-lastFill)/(1024.0*1024.0*elapsed),
-				float64(drain-lastDrain)/(1024.0*1024.0*elapsed),
-				compactionDebt/(1024.0*1024.0),
-				compactionL0,
-				maxFlushRate/(1024.0*1024.0))
-
-			lastNow = now
-			lastFill = fill
-			lastDrain = drain
+		<-tick.C
+		if (i % 20) == 0 {
+			fmt.Printf("_elapsed___memtbs____dirty_____fill____drain____cdebt__l0count___max-f-rate\n")
 		}
+
+		if (i % 7) == 0 {
+			//db.printLevels()
+		}
+
+		db.mu.Lock()
+		memtableCount := len(db.memtables)
+		db.mu.Unlock()
+		dirty := atomic.LoadInt64(&db.flushPacer.level)
+		fill := atomic.LoadInt64(&db.fill)
+		drain := atomic.LoadInt64(&db.drain)
+
+		db.compactionMu.Lock()
+		compactionL0 := len(db.L0)
+		db.compactionMu.Unlock()
+		totalCompactionBytes := atomic.LoadInt64(&db.compactionPacer.level)
+		compactionDebt := math.Max(float64(totalCompactionBytes)-l0CompactionThreshold*memtableSize, 0.0)
+		maxFlushRate := db.flushPacer.maxDrainer.Limit()
+
+		now := time.Now()
+		elapsed := now.Sub(lastNow).Seconds()
+		fmt.Printf("%8s %8d %8.1f %8.1f %8.1f %8.1f %8d %12.1f\n",
+			time.Duration(now.Sub(start).Seconds()+0.5)*time.Second,
+			memtableCount,
+			float64(dirty)/(1024.0*1024.0),
+			float64(fill-lastFill)/(1024.0*1024.0*elapsed),
+			float64(drain-lastDrain)/(1024.0*1024.0*elapsed),
+			compactionDebt/(1024.0*1024.0),
+			compactionL0,
+			maxFlushRate/(1024.0*1024.0))
+
+		lastNow = now
+		lastFill = fill
+		lastDrain = drain
 	}
 }

--- a/internal/rangedel/iter_test.go
+++ b/internal/rangedel/iter_test.go
@@ -42,12 +42,12 @@ func TestIter(t *testing.T) {
 				switch parts[0] {
 				case "seek-ge":
 					if len(parts) != 2 {
-						return fmt.Sprintf("seek-ge <key>\n")
+						return "seek-ge <key>\n"
 					}
 					iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
 				case "seek-lt":
 					if len(parts) != 2 {
-						return fmt.Sprintf("seek-lt <key>\n")
+						return "seek-lt <key>\n"
 					}
 					iter.SeekLT([]byte(strings.TrimSpace(parts[1])))
 				case "first":

--- a/level_checker.go
+++ b/level_checker.go
@@ -423,8 +423,7 @@ func checkRangeTombstones(c *checkConfig) error {
 	}
 	// We now have truncated tombstones.
 	// Fragment them all.
-	var userKeys [][]byte
-	userKeys = collectAllUserKeys(c.cmp, tombstones)
+	userKeys := collectAllUserKeys(c.cmp, tombstones)
 	tombstones = fragmentUsingUserKeys(c.cmp, tombstones, userKeys)
 	return iterateAndCheckTombstones(c.cmp, c.formatKey, tombstones)
 }
@@ -502,7 +501,7 @@ func (v *userKeysSort) Swap(i, j int) {
 	v.buf[i], v.buf[j] = v.buf[j], v.buf[i]
 }
 func collectAllUserKeys(cmp Compare, tombstones []tombstoneWithLevel) [][]byte {
-	var keys [][]byte
+	keys := make([][]byte, 0, len(tombstones)*2)
 	for _, t := range tombstones {
 		keys = append(keys, t.Start.UserKey)
 		keys = append(keys, t.End)

--- a/metrics.go
+++ b/metrics.go
@@ -246,7 +246,7 @@ func (m *Metrics) formatWAL(buf *bytes.Buffer) {
 		writeAmp)
 }
 
-// Pretty-print the metrics, showing a line for the WAL, a line per-level, and
+// String pretty-prints the metrics, showing a line for the WAL, a line per-level, and
 // a total:
 //
 //   __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___w-amp

--- a/open_test.go
+++ b/open_test.go
@@ -559,7 +559,7 @@ func TestTwoWALReplayCorrupt(t *testing.T) {
 	t.Logf("zeored four bytes in %s at offset %d\n", logs[len(logs)-2], off)
 
 	// Re-opening the database should detect and report the corruption.
-	d, err = Open(dir, nil)
+	_, err = Open(dir, nil)
 	require.Error(t, err, "pebble: corruption")
 }
 

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -643,7 +643,7 @@ func buildTestTable(
 	r, err := NewReader(f1, ReaderOptions{
 		Cache: c,
 	}, FileReopenOpt{
-		FS: mem,
+		FS:       mem,
 		Filename: "test",
 	})
 	require.NoError(t, err)

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -275,7 +275,7 @@ func (f footer) encode(buf []byte) []byte {
 			buf[i] = 0
 		}
 		n := encodeBlockHandle(buf[0:], f.metaindexBH)
-		n += encodeBlockHandle(buf[n:], f.indexBH)
+		encodeBlockHandle(buf[n:], f.indexBH)
 		copy(buf[len(buf)-len(levelDBMagic):], levelDBMagic)
 
 	case TableFormatRocksDBv2:
@@ -286,7 +286,7 @@ func (f footer) encode(buf []byte) []byte {
 		buf[0] = f.checksum
 		n := 1
 		n += encodeBlockHandle(buf[n:], f.metaindexBH)
-		n += encodeBlockHandle(buf[n:], f.indexBH)
+		encodeBlockHandle(buf[n:], f.indexBH)
 		binary.LittleEndian.PutUint32(buf[rocksDBVersionOffset:], rocksDBFormatVersion2)
 		copy(buf[len(buf)-len(rocksDBMagic):], rocksDBMagic)
 	}

--- a/tool/db.go
+++ b/tool/db.go
@@ -80,8 +80,8 @@ Creates a Pebble checkpoint in the specified destination directory. A checkpoint
 is a point-in-time snapshot of DB state. Requires that the specified
 database not be in use by another process.
 `,
-		Args:  cobra.ExactArgs(2),
-		Run:   d.runCheckpoint,
+		Args: cobra.ExactArgs(2),
+		Run:  d.runCheckpoint,
 	}
 	d.LSM = &cobra.Command{
 		Use:   "lsm <dir>",
@@ -274,7 +274,7 @@ func (d *dbT) runCheck(cmd *cobra.Command, args []string) {
 
 type nonReadOnly struct{}
 
-func (n nonReadOnly) apply (opts *pebble.Options) {
+func (n nonReadOnly) apply(opts *pebble.Options) {
 	opts.ReadOnly = false
 }
 
@@ -495,7 +495,7 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 }
 
 func propArgs(props []props, getProp func(*props) interface{}) []interface{} {
-	var args []interface{}
+	args := make([]interface{}, 0, len(props))
 	for _, p := range props {
 		args = append(args, getProp(&p))
 	}

--- a/vendor/golang.org/x/sync/AUTHORS
+++ b/vendor/golang.org/x/sync/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/sync/CONTRIBUTORS
+++ b/vendor/golang.org/x/sync/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,66 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"context"
+	"sync"
+)
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	errOnce sync.Once
+	err     error
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (g *Group) Go(f func() error) {
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}


### PR DESCRIPTION
Hey! Thanks for this very cool project.

In this PR, I tried to sparingly fix a couple of linting issues:
* Remove useless `fmt.Sprintf` calls
* `time.Now().Sub(start)` => `time.Since(start)`
* Slice pre-allocations (whenever it was possible)
* Ineffective type casts
* Ineffective assignments
* Useless select / case on a single channel
* Fixing a test that was calling `t.Fatal` within goroutines which is not allowed. I replaced it by a standard `errorgroup` (hopefully it's compliant with your standards)
* Missing gofmts