### PR TITLE
[WIP] read triggered compaction based on numReads

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -34,7 +34,7 @@ type compactionPicker interface {
 	pickAuto(env compactionEnv) (pc *pickedCompaction)
 	pickManual(env compactionEnv, manual *manualCompaction) (c *pickedCompaction, retryLater bool)
 	pickElisionOnlyCompaction(env compactionEnv) (pc *pickedCompaction)
-
+	pickReadTriggeredCompaction(env compactionEnv, readCompaction *readCompaction) (pc *pickedCompaction)
 	forceBaseLevel1()
 }
 
@@ -404,10 +404,7 @@ func expandToAtomicUnit(
 }
 
 func newCompactionPicker(
-	v *version,
-	opts *Options,
-	inProgressCompactions []compactionInfo,
-	levelSizes [numLevels]int64,
+	v *version, opts *Options, inProgressCompactions []compactionInfo, levelSizes [numLevels]int64,
 ) compactionPicker {
 	p := &compactionPickerByScore{
 		opts:       opts,
@@ -1390,6 +1387,54 @@ func pickManualHelper(
 		return nil
 	}
 	return pc
+}
+
+func (p *compactionPickerByScore) pickReadTriggeredCompaction(
+	env compactionEnv, rc *readCompaction,
+) (pc *pickedCompaction) {
+	cmp := p.opts.Comparer.Compare
+	overlapSlice := p.vers.Overlaps(rc.level, cmp, rc.start, rc.end)
+	if overlapSlice.Empty() {
+		var shouldCompact bool
+		overlapSlice, shouldCompact = updateReadCompaction(p.vers, cmp, rc)
+		if !shouldCompact {
+			return nil
+		}
+	}
+	pc = newPickedCompaction(p.opts, p.vers, rc.level, p.baseLevel)
+	pc.startLevel.files = overlapSlice
+	if !pc.setupInputs() {
+		return nil
+	}
+	if inputRangeAlreadyCompacting(env, pc) {
+		return nil
+	}
+	return pc
+}
+
+func updateReadCompaction(
+	vers *version, cmp Compare, rc *readCompaction,
+) (slice manifest.LevelSlice, shouldCompact bool) {
+	numOverlap, topLevel := 0, 0
+	var topOverlapping manifest.LevelSlice
+	for l := 0; l < numLevels; l++ {
+		overlaps := vers.Overlaps(l, cmp, rc.start, rc.end)
+		if !overlaps.Empty() {
+			numOverlap++
+			if numOverlap >= 2 {
+				break
+			}
+			topOverlapping = overlaps
+			topLevel = l
+		}
+	}
+	if numOverlap >= 2 {
+		shouldCompact = true
+		rc.level = topLevel
+		return topOverlapping, true
+	}
+	return manifest.LevelSlice{}, false
+
 }
 
 func (p *compactionPickerByScore) forceBaseLevel1() {

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1434,7 +1434,6 @@ func updateReadCompaction(
 		return topOverlapping, true
 	}
 	return manifest.LevelSlice{}, false
-
 }
 
 func (p *compactionPickerByScore) forceBaseLevel1() {

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -98,6 +98,12 @@ func (p *compactionPickerForTesting) pickManual(
 	return pickManualHelper(p.opts, manual, p.vers, p.baseLevel), false
 }
 
+func (p *compactionPickerForTesting) pickReadTriggeredCompaction(
+	env compactionEnv, readCompaction *readCompaction,
+) (pc *pickedCompaction) {
+	return nil
+}
+
 func TestPickCompaction(t *testing.T) {
 	fileNums := func(files manifest.LevelSlice) string {
 		var ss []string

--- a/db.go
+++ b/db.go
@@ -309,6 +309,9 @@ type DB struct {
 			manual []*manualCompaction
 			// inProgress is the set of in-progress flushes and compactions.
 			inProgress map[*compaction]struct{}
+			// readCompactions is a list read triggered compactions. The next compaction
+			// is as the start. New entries are added to the end.
+			readCompactions []readCompaction
 		}
 
 		cleaner struct {

--- a/internal/manifest/level.go
+++ b/internal/manifest/level.go
@@ -23,6 +23,11 @@ func makeLevel(level, sublevel int) Level {
 	return Level(((sublevel + 1) << levelBits) | level)
 }
 
+// LevelInt returns the int representation of a Level
+func LevelInt(l Level) int {
+	return int(l) & levelMask
+}
+
 // L0Sublevel returns a Level representing the specified L0 sublevel.
 func L0Sublevel(sublevel int) Level {
 	if sublevel < 0 {

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -93,10 +93,13 @@ type FileMetadata struct {
 	// is true and IsIntraL0Compacting is false for an L0 file, the file must
 	// be part of a compaction to Lbase.
 	IsIntraL0Compacting bool
-	subLevel            int
-	l0Index             int
-	minIntervalIndex    int
-	maxIntervalIndex    int
+	Atomic              struct {
+		AllowedSeeks int64
+	}
+	subLevel         int
+	l0Index          int
+	minIntervalIndex int
+	maxIntervalIndex int
 
 	// True if user asked us to compact this file. This flag is only set and
 	// respected by RocksDB but exists here to preserve its value in the
@@ -255,10 +258,7 @@ const NumLevels = 7
 // NewVersion constructs a new Version with the provided files. It requires
 // the provided files are already well-ordered. It's intended for testing.
 func NewVersion(
-	cmp Compare,
-	formatKey base.FormatKey,
-	flushSplitBytes int64,
-	files [NumLevels][]*FileMetadata,
+	cmp Compare, formatKey base.FormatKey, flushSplitBytes int64, files [NumLevels][]*FileMetadata,
 ) *Version {
 	var v Version
 	for l := range files {

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -545,6 +545,31 @@ func (v *Version) Overlaps(level int, cmp Compare, start, end []byte) LevelSlice
 	return overlaps(v.Levels[level].Iter(), cmp, start, end)
 }
 
+// FileInLevel takes a level with a start and end key range to return the first file
+// that contains the range in that level.
+func (v *Version) FileInLevel(l int, cmp Compare, start, end []byte) (file *FileMetadata) {
+	if l == 0 {
+		l0Iter := v.Levels[0].Iter()
+		for i, meta := 0, l0Iter.First(); meta != nil; i, meta = i+1, l0Iter.Next() {
+			if cmp(meta.Largest.UserKey, start) >= 0 {
+				if cmp(meta.Smallest.UserKey, end) <= 0 {
+					return meta
+				}
+			}
+		}
+		return nil
+	}
+	iter := v.Levels[l].Iter()
+	file = iter.SeekGE(cmp, start)
+	if file == nil {
+		return nil
+	}
+	if cmp(file.Smallest.UserKey, end) > 0 {
+		return nil
+	}
+	return file
+}
+
 // CheckOrdering checks that the files are consistent with respect to
 // increasing file numbers (for level 0 files) and increasing and non-
 // overlapping internal key ranges (for level non-0 files).

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -581,7 +581,7 @@ func (b *BulkVersionEdit) Apply(
 			// same as the compaction of 40KB of data.  We are a little
 			// conservative and allow approximately one seek for every 16KB
 			// of data before triggering a compaction.
-			const readCompactionThreshold uint64 = 16384
+			const readCompactionThreshold uint64 = 8192
 			allowedSeeks := int64(f.Size / readCompactionThreshold)
 			atomic.StoreInt64(&f.Atomic.AllowedSeeks, allowedSeeks)
 


### PR DESCRIPTION
This is still very much work-in-progress. I am opening this PR to get some feedback on the approach I am taking and if I should consider something else.

To implement the read-triggered compactions from https://github.com/cockroachdb/pebble/issues/29, I followed the general approach taken by LevelDB. This meant setting a max allowed reads before compaction using the file size as a metric. They used 16KB per read (it is explained in the second comment of https://github.com/cockroachdb/pebble/issues/29).

My first approach used a simple counter on the `FileMetada` that would be incremented each time it was loaded from disk. To initiate the compaction, I would set `fileMetadata.MarkedForCompaction` and use the current codes `O(num-sstables)` search to find the compaction. This seemed unnecessary and also did not allow for possible future prioritization by `numReads`.

This PR contains my second approach which instead uses a `NewIter` wrapper function to set a compaction trigger that is run when `Iterator.Close()` is called. This determines if a read compaction is needed and adds it to a list in `db.mu.compact` (similar logic to manual compactions). From this list, each compaction is pulled in FIFO order.

Current TODO: Need a way of finding the level of the chosen file as it is needed by `compactionPicker`. 