### PR TITLE
Enable Travis CI caching of go toolchain artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ branches:
 install:
   - go get -v golang.org/x/lint/golint
 
+cache:
+  directories:
+    - $(go env GOCACHE)
+    - $(go env GOPATH)/pkg/mod
+
 matrix:
   include:
     - name: "go1.13.x-linux"


### PR DESCRIPTION
I found that I could cut my build times in half on another golang/Travis project by allowing go's caches to be reused across builds.