### PR TITLE
db: remove unnecessary newIters allocation, inline sort.Search

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -911,7 +911,7 @@ func (c *compaction) newInputIter(newIters tableNewIters) (_ internalIterator, r
 	newRangeDelIter := func(
 		f manifest.LevelFile, _ *IterOptions, bytesIterated *uint64,
 	) (internalIterator, internalIterator, error) {
-		iter, rangeDelIter, err := newIters(f, nil /* iter options */, &c.bytesIterated)
+		iter, rangeDelIter, err := newIters(f.FileMetadata, nil /* iter options */, &c.bytesIterated)
 		if err == nil {
 			// TODO(peter): It is mildly wasteful to open the point iterator only to
 			// immediately close it. One way to solve this would be to add new
@@ -1010,7 +1010,7 @@ func (c *compaction) newInputIter(newIters tableNewIters) (_ internalIterator, r
 	} else {
 		iter := c.startLevel.files.Iter()
 		for f := iter.First(); f != nil; f = iter.Next() {
-			iter, rangeDelIter, err := newIters(iter.Take(), nil /* iter options */, &c.bytesIterated)
+			iter, rangeDelIter, err := newIters(iter.Current(), nil /* iter options */, &c.bytesIterated)
 			if err != nil {
 				return nil, errors.Wrapf(err, "pebble: could not open table %s", errors.Safe(f.FileNum))
 			}

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2026,7 +2026,7 @@ func TestCompactionCheckOrdering(t *testing.T) {
 				}
 
 				newIters := func(
-					_ manifest.LevelFile, _ *IterOptions, _ *uint64,
+					_ *manifest.FileMetadata, _ *IterOptions, _ *uint64,
 				) (internalIterator, internalIterator, error) {
 					return &errorIter{}, nil, nil
 				}

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -470,7 +470,7 @@ func TestGetIter(t *testing.T) {
 		// m is a map from file numbers to DBs.
 		m := map[FileNum]*memTable{}
 		newIter := func(
-			file manifest.LevelFile, _ *IterOptions, _ *uint64,
+			file *manifest.FileMetadata, _ *IterOptions, _ *uint64,
 		) (internalIterator, internalIterator, error) {
 			d, ok := m[file.FileNum]
 			if !ok {

--- a/ingest.go
+++ b/ingest.go
@@ -401,7 +401,7 @@ func ingestTargetLevel(
 			continue
 		}
 
-		iter, rangeDelIter, err := newIters(iter.Take(), nil, nil)
+		iter, rangeDelIter, err := newIters(iter.Current(), nil, nil)
 		if err != nil {
 			return 0, err
 		}

--- a/internal/manifest/btree_test.go
+++ b/internal/manifest/btree_test.go
@@ -622,7 +622,9 @@ func BenchmarkBTreeInsert(b *testing.B) {
 			var tr btree
 			tr.cmp = cmp
 			for _, item := range insertP {
-				require.NoError(b, tr.insert(item))
+				if err := tr.insert(item); err != nil {
+					b.Fatal(err)
+				}
 				i++
 				if i >= b.N {
 					return
@@ -642,7 +644,9 @@ func BenchmarkBTreeDelete(b *testing.B) {
 			var tr btree
 			tr.cmp = cmp
 			for _, item := range insertP {
-				require.NoError(b, tr.insert(item))
+				if err := tr.insert(item); err != nil {
+					b.Fatal(err)
+				}
 			}
 			b.StartTimer()
 			for _, item := range removeP {
@@ -666,13 +670,17 @@ func BenchmarkBTreeDeleteInsert(b *testing.B) {
 		var tr btree
 		tr.cmp = cmp
 		for _, item := range insertP {
-			require.NoError(b, tr.insert(item))
+			if err := tr.insert(item); err != nil {
+				b.Fatal(err)
+			}
 		}
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			item := insertP[i%count]
 			tr.delete(item)
-			require.NoError(b, tr.insert(item))
+			if err := tr.insert(item); err != nil {
+				b.Fatal(err)
+			}
 		}
 	})
 }
@@ -685,14 +693,18 @@ func BenchmarkBTreeDeleteInsertCloneOnce(b *testing.B) {
 		var tr btree
 		tr.cmp = cmp
 		for _, item := range insertP {
-			require.NoError(b, tr.insert(item))
+			if err := tr.insert(item); err != nil {
+				b.Fatal(err)
+			}
 		}
 		tr = tr.clone()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			item := insertP[i%count]
 			tr.delete(item)
-			require.NoError(b, tr.insert(item))
+			if err := tr.insert(item); err != nil {
+				b.Fatal(err)
+			}
 		}
 	})
 }
@@ -708,7 +720,9 @@ func BenchmarkBTreeDeleteInsertCloneEachTime(b *testing.B) {
 				tr.cmp = cmp
 				trRelease.cmp = cmp
 				for _, item := range insertP {
-					require.NoError(b, tr.insert(item))
+					if err := tr.insert(item); err != nil {
+						b.Fatal(err)
+					}
 				}
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
@@ -719,7 +733,9 @@ func BenchmarkBTreeDeleteInsertCloneEachTime(b *testing.B) {
 					}
 					tr = tr.clone()
 					tr.delete(item)
-					require.NoError(b, tr.insert(item))
+					if err := tr.insert(item); err != nil {
+						b.Fatal(err)
+					}
 				}
 			})
 		})
@@ -748,7 +764,9 @@ func BenchmarkBTreeIterSeekGE(b *testing.B) {
 		for i := 0; i < count; i++ {
 			s := key(i)
 			keys = append(keys, s)
-			require.NoError(b, tr.insert(newItem(s)))
+			if err := tr.insert(newItem(s)); err != nil {
+				b.Fatal(err)
+			}
 		}
 
 		b.ResetTimer()
@@ -780,7 +798,9 @@ func BenchmarkBTreeIterSeekLT(b *testing.B) {
 		for i := 0; i < count; i++ {
 			k := key(i)
 			keys = append(keys, k)
-			require.NoError(b, tr.insert(newItem(k)))
+			if err := tr.insert(newItem(k)); err != nil {
+				b.Fatal(err)
+			}
 		}
 
 		b.ResetTimer()
@@ -818,7 +838,9 @@ func BenchmarkBTreeIterNext(b *testing.B) {
 	const size = 2 * maxItems
 	for i := 0; i < count; i++ {
 		item := newItem(key(i))
-		require.NoError(b, tr.insert(item))
+		if err := tr.insert(item); err != nil {
+			b.Fatal(err)
+		}
 	}
 
 	it := tr.iter()
@@ -841,7 +863,9 @@ func BenchmarkBTreeIterPrev(b *testing.B) {
 	const size = 2 * maxItems
 	for i := 0; i < count; i++ {
 		item := newItem(key(i))
-		require.NoError(b, tr.insert(item))
+		if err := tr.insert(item); err != nil {
+			b.Fatal(err)
+		}
 	}
 
 	it := tr.iter()

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -303,7 +303,7 @@ func (i *LevelIterator) Clone() LevelIterator {
 }
 
 // Current returns the item at the current iterator position.
-func (i LevelIterator) Current() *FileMetadata {
+func (i *LevelIterator) Current() *FileMetadata {
 	if !i.iter.valid() {
 		return nil
 	}
@@ -439,7 +439,7 @@ func (i *LevelIterator) seek(fn func(*FileMetadata) bool) *FileMetadata {
 // Take constructs a LevelFile containing the file at the iterator's current
 // position. Take panics if the iterator is not currently positioned over a
 // file.
-func (i LevelIterator) Take() LevelFile {
+func (i *LevelIterator) Take() LevelFile {
 	m := i.Current()
 	if m == nil {
 		panic("Take called on invalid LevelIterator")

--- a/level_checker.go
+++ b/level_checker.go
@@ -373,7 +373,7 @@ func checkRangeTombstones(c *checkConfig) error {
 			lf := files.Take()
 			atomicUnit, _ := expandToAtomicUnit(c.cmp, lf.Slice())
 			lower, upper := manifest.KeyRange(c.cmp, atomicUnit.Iter())
-			iterToClose, iter, err := c.newIters(lf, nil, nil)
+			iterToClose, iter, err := c.newIters(lf.FileMetadata, nil, nil)
 			if err != nil {
 				return err
 			}

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -93,7 +93,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 
 	var fileNum FileNum
 	newIters :=
-		func(file manifest.LevelFile, opts *IterOptions, bytesIterated *uint64) (internalIterator, internalIterator, error) {
+		func(file *manifest.FileMetadata, opts *IterOptions, bytesIterated *uint64) (internalIterator, internalIterator, error) {
 			r := readers[file.FileNum]
 			rangeDelIter, err := r.NewRawRangeDelIter()
 			if err != nil {

--- a/level_iter.go
+++ b/level_iter.go
@@ -17,7 +17,7 @@ import (
 // number. If bytesIterated is specified, it is incremented as the given file is
 // iterated through.
 type tableNewIters func(
-	file manifest.LevelFile, opts *IterOptions, bytesIterated *uint64,
+	file *manifest.FileMetadata, opts *IterOptions, bytesIterated *uint64,
 ) (internalIterator, internalIterator, error)
 
 // levelIter provides a merged view of the sstables in a level.
@@ -321,7 +321,7 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) bool {
 		}
 
 		var rangeDelIter internalIterator
-		l.iter, rangeDelIter, l.err = l.newIters(l.files.Take(), &l.tableOpts, l.bytesIterated)
+		l.iter, rangeDelIter, l.err = l.newIters(l.files.Current(), &l.tableOpts, l.bytesIterated)
 		if l.err != nil {
 			return false
 		}

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -31,7 +31,7 @@ func TestLevelIter(t *testing.T) {
 	var files manifest.LevelSlice
 
 	newIters := func(
-		file manifest.LevelFile, opts *IterOptions, bytesIterated *uint64,
+		file *manifest.FileMetadata, opts *IterOptions, bytesIterated *uint64,
 	) (internalIterator, internalIterator, error) {
 		f := *iters[file.FileNum]
 		f.lower = opts.GetLowerBound()
@@ -115,7 +115,7 @@ func TestLevelIter(t *testing.T) {
 
 			var tableOpts *IterOptions
 			newIters2 := func(
-				file manifest.LevelFile, opts *IterOptions, bytesIterated *uint64,
+				file *manifest.FileMetadata, opts *IterOptions, bytesIterated *uint64,
 			) (internalIterator, internalIterator, error) {
 				tableOpts = opts
 				return newIters(file, opts, nil)
@@ -150,7 +150,7 @@ func newLevelIterTest() *levelIterTest {
 }
 
 func (lt *levelIterTest) newIters(
-	file manifest.LevelFile, opts *IterOptions, _ *uint64,
+	file *manifest.FileMetadata, opts *IterOptions, _ *uint64,
 ) (internalIterator, internalIterator, error) {
 	iter, err := lt.readers[file.FileNum].NewIter(opts.LowerBound, opts.UpperBound)
 	if err != nil {
@@ -471,7 +471,7 @@ func BenchmarkLevelIterSeekGE(b *testing.B) {
 							readers, metas, keys, cleanup := buildLevelIterTables(b, blockSize, restartInterval, count)
 							defer cleanup()
 							newIters := func(
-								file manifest.LevelFile, _ *IterOptions, _ *uint64,
+								file *manifest.FileMetadata, _ *IterOptions, _ *uint64,
 							) (internalIterator, internalIterator, error) {
 								iter, err := readers[file.FileNum].NewIter(nil /* lower */, nil /* upper */)
 								return iter, nil, err
@@ -513,7 +513,7 @@ func BenchmarkLevelIterSeqSeekGEWithBounds(b *testing.B) {
 							// This newIters is cheaper than in practice since it does not do
 							// tableCacheShard.findNode.
 							newIters := func(
-								file manifest.LevelFile, opts *IterOptions, _ *uint64,
+								file *manifest.FileMetadata, opts *IterOptions, _ *uint64,
 							) (internalIterator, internalIterator, error) {
 								iter, err := readers[file.FileNum].NewIter(
 									opts.LowerBound, opts.UpperBound)
@@ -555,7 +555,7 @@ func BenchmarkLevelIterNext(b *testing.B) {
 							readers, metas, _, cleanup := buildLevelIterTables(b, blockSize, restartInterval, count)
 							defer cleanup()
 							newIters := func(
-								file manifest.LevelFile, _ *IterOptions, _ *uint64,
+								file *manifest.FileMetadata, _ *IterOptions, _ *uint64,
 							) (internalIterator, internalIterator, error) {
 								iter, err := readers[file.FileNum].NewIter(nil /* lower */, nil /* upper */)
 								return iter, nil, err
@@ -590,7 +590,7 @@ func BenchmarkLevelIterPrev(b *testing.B) {
 							readers, metas, _, cleanup := buildLevelIterTables(b, blockSize, restartInterval, count)
 							defer cleanup()
 							newIters := func(
-								file manifest.LevelFile, _ *IterOptions, _ *uint64,
+								file *manifest.FileMetadata, _ *IterOptions, _ *uint64,
 							) (internalIterator, internalIterator, error) {
 								iter, err := readers[file.FileNum].NewIter(nil /* lower */, nil /* upper */)
 								return iter, nil, err

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -143,7 +143,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 
 	var fileNum base.FileNum
 	newIters :=
-		func(file manifest.LevelFile, opts *IterOptions, bytesIterated *uint64) (internalIterator, internalIterator, error) {
+		func(file *manifest.FileMetadata, opts *IterOptions, bytesIterated *uint64) (internalIterator, internalIterator, error) {
 			r := readers[file.FileNum]
 			rangeDelIter, err := r.NewRawRangeDelIter()
 			if err != nil {
@@ -550,7 +550,7 @@ func BenchmarkMergingIterSeqSeekGEWithBounds(b *testing.B) {
 					levelIndex := i
 					level := len(readers) - 1 - i
 					newIters := func(
-						file manifest.LevelFile, opts *IterOptions, _ *uint64,
+						file *manifest.FileMetadata, opts *IterOptions, _ *uint64,
 					) (internalIterator, internalIterator, error) {
 						iter, err := readers[levelIndex][file.FileNum].NewIter(
 							opts.LowerBound, opts.UpperBound)

--- a/table_cache.go
+++ b/table_cache.go
@@ -51,7 +51,7 @@ func (c *tableCache) getShard(fileNum FileNum) *tableCacheShard {
 }
 
 func (c *tableCache) newIters(
-	file manifest.LevelFile, opts *IterOptions, bytesIterated *uint64,
+	file *manifest.FileMetadata, opts *IterOptions, bytesIterated *uint64,
 ) (internalIterator, internalIterator, error) {
 	return c.getShard(file.FileNum).newIters(file, opts, bytesIterated)
 }
@@ -179,13 +179,13 @@ func (c *tableCacheShard) releaseLoop() {
 }
 
 func (c *tableCacheShard) newIters(
-	file manifest.LevelFile, opts *IterOptions, bytesIterated *uint64,
+	file *manifest.FileMetadata, opts *IterOptions, bytesIterated *uint64,
 ) (internalIterator, internalIterator, error) {
 	// Calling findNode gives us the responsibility of decrementing v's
 	// refCount. If opening the underlying table resulted in error, then we
 	// decrement this straight away. Otherwise, we pass that responsibility to
 	// the sstable iterator, which decrements when it is closed.
-	v := c.findNode(file.FileMetadata)
+	v := c.findNode(file)
 	if v.err != nil {
 		c.unrefValue(v)
 		return nil, nil, v.err

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -193,7 +192,7 @@ func testTableCacheRandomAccess(t *testing.T, concurrent bool) {
 			fileNum, sleepTime := rng.Intn(tableCacheTestNumTables), rng.Intn(1000)
 			rngMu.Unlock()
 			iter, _, err := c.newIters(
-				manifest.LevelFile{FileMetadata: &fileMetadata{FileNum: FileNum(fileNum)}},
+				&fileMetadata{FileNum: FileNum(fileNum)},
 				nil, /* iter options */
 				nil /* bytes iterated */)
 			if err != nil {
@@ -249,7 +248,7 @@ func TestTableCacheFrequentlyUsed(t *testing.T) {
 	for i := 0; i < N; i++ {
 		for _, j := range [...]int{pinned0, i % tableCacheTestNumTables, pinned1} {
 			iter, _, err := c.newIters(
-				manifest.LevelFile{FileMetadata: &fileMetadata{FileNum: FileNum(j)}},
+				&fileMetadata{FileNum: FileNum(j)},
 				nil, /* iter options */
 				nil /* bytes iterated */)
 			if err != nil {
@@ -283,7 +282,7 @@ func TestTableCacheEvictions(t *testing.T) {
 	for i := 0; i < N; i++ {
 		j := rng.Intn(tableCacheTestNumTables)
 		iter, _, err := c.newIters(
-			manifest.LevelFile{FileMetadata: &fileMetadata{FileNum: FileNum(j)}},
+			&fileMetadata{FileNum: FileNum(j)},
 			nil, /* iter options */
 			nil /* bytes iterated */)
 		if err != nil {
@@ -325,7 +324,7 @@ func TestTableCacheIterLeak(t *testing.T) {
 	require.NoError(t, err)
 
 	iter, _, err := c.newIters(
-		manifest.LevelFile{FileMetadata: &fileMetadata{FileNum: 0}},
+		&fileMetadata{FileNum: 0},
 		nil, /* iter options */
 		nil /* bytes iterated */)
 	require.NoError(t, err)
@@ -347,7 +346,7 @@ func TestTableCacheRetryAfterFailure(t *testing.T) {
 
 	fs.setOpenError(true /* enabled */)
 	if _, _, err := c.newIters(
-		manifest.LevelFile{FileMetadata: &fileMetadata{FileNum: 0}},
+		&fileMetadata{FileNum: 0},
 		nil, /* iter options */
 		nil /* bytes iterated */); err == nil {
 		t.Fatalf("expected failure, but found success")
@@ -355,7 +354,7 @@ func TestTableCacheRetryAfterFailure(t *testing.T) {
 	fs.setOpenError(false /* enabled */)
 	var iter internalIterator
 	iter, _, err = c.newIters(
-		manifest.LevelFile{FileMetadata: &fileMetadata{FileNum: 0}},
+		&fileMetadata{FileNum: 0},
 		nil, /* iter options */
 		nil /* bytes iterated */)
 	require.NoError(t, err)


### PR DESCRIPTION
Together these commits reclaim some of the lost ycsb C performance,
but not all. In a single run of the three commits, the commit preceding
the B-Tree integration achieved 1,574,408 ops/sec, the commit with
the B-Tree integrated achieved 1,343,757 ops/sec and this commit
achieved 1,442,248 ops/sec. I'm going to keep investigating, but
figured I'd put these commits up first.

---

db: remove unnecessary allocation from newIters calls

When the B-Tree was integrated with the LevelMetadata, the `newIters`
signature changed to take a `manifest.LevelFile` which includes a
`manifest.LevelSlice` capturing the file's position within the level.
This required cloning B-Tree iterators whenever a new iterator was
created. This change stemmed from refactor confusion around
`newRangeDelIter` when constructing a compaction input iterator. That
helper function requires `manifest.LevelFile` for expanding to atomic
compaction units.

internal/manifest: inline sort.Search in iterator.seek

Inline `sort.Search` in `iterator.seek`, like we already did in
`(*node).find`. Also, remove calls to `require.NoError` in the
benchmarks because its use of `t.Helper` significantly slows down the
benchmarks and adds noise.

```
BTreeIter-24                                                 7.83ns ± 1%  7.92ns ± 1%   +1.09%  (p=0.016 n=5+4)
BTreeIterSeekGE/count=16-24                                   151ns ± 5%   140ns ± 3%   -7.12%  (p=0.000 n=5+4)
BTreeIterSeekGE/count=128-24                                  239ns ± 1%   223ns ± 1%   -6.77%  (p=0.016 n=5+4)
BTreeIterSeekGE/count=1024-24                                 354ns ± 2%   328ns ± 1%   -7.29%  (p=0.016 n=5+4)
BTreeIterSeekGE/count=8192-24                                 509ns ± 2%   474ns ± 1%   -6.86%  (p=0.016 n=5+4)
BTreeIterSeekGE/count=65536-24                               1.02µs ± 0%  0.96µs ± 1%   -5.49%  (p=0.000 n=5+4)
BTreeIterSeekLT/count=16-24                                   154ns ± 0%   146ns ± 1%   -5.51%  (p=0.029 n=4+4)
BTreeIterSeekLT/count=128-24                                  246ns ± 4%   231ns ± 1%   -6.28%  (p=0.016 n=5+4)
BTreeIterSeekLT/count=1024-24                                 363ns ± 2%   338ns ± 1%   -6.85%  (p=0.016 n=5+4)
BTreeIterSeekLT/count=8192-24                                 524ns ± 1%   494ns ± 1%   -5.75%  (p=0.016 n=5+4)
BTreeIterSeekLT/count=65536-24                               1.05µs ± 3%  1.00µs ± 2%   -4.83%  (p=0.016 n=5+4)
BTreeIterNext-24                                             6.37ns ± 1%  5.74ns ± 1%  -10.00%  (p=0.036 n=5+3)
BTreeIterPrev-24                                             26.9ns ± 1%  26.5ns ± 0%   -1.56%  (p=0.036 n=5+3)
```