### PR TITLE
db: avoid an unnecessary iterator clone in levelIter construction

### DIFF
--- a/db.go
+++ b/db.go
@@ -755,10 +755,7 @@ func (d *DB) newIterInternal(
 	mlevels = mlevels[start:]
 
 	levels := buf.levels[:]
-	addLevelIterForFiles := func(files manifest.LevelSlice, level manifest.Level) {
-		if files.Empty() {
-			return
-		}
+	addLevelIterForFiles := func(files manifest.LevelIterator, level manifest.Level) {
 		var li *levelIter
 		if len(levels) > 0 {
 			li = &levels[0]
@@ -767,7 +764,7 @@ func (d *DB) newIterInternal(
 			li = &levelIter{}
 		}
 
-		li.init(dbi.opts, d.cmp, d.newIters, files.Iter(), level, nil)
+		li.init(dbi.opts, d.cmp, d.newIters, files, level, nil)
 		li.initRangeDel(&mlevels[0].rangeDelIter)
 		li.initSmallestLargestUserKey(&mlevels[0].smallestUserKey, &mlevels[0].largestUserKey,
 			&mlevels[0].isLargestUserKeyRangeDelSentinel)
@@ -779,12 +776,18 @@ func (d *DB) newIterInternal(
 	// Add level iterators for the L0 sublevels, iterating from newest to
 	// oldest.
 	for i := len(current.L0Sublevels.Levels) - 1; i >= 0; i-- {
-		addLevelIterForFiles(current.L0Sublevels.Levels[i], manifest.L0Sublevel(i))
+		if current.L0Sublevels.Levels[i].Empty() {
+			continue
+		}
+		addLevelIterForFiles(current.L0Sublevels.Levels[i].Iter(), manifest.L0Sublevel(i))
 	}
 
 	// Add level iterators for the non-empty non-L0 levels.
 	for level := 1; level < len(current.Levels); level++ {
-		addLevelIterForFiles(current.Levels[level].Slice(), manifest.Level(level))
+		if current.Levels[level].Empty() {
+			continue
+		}
+		addLevelIterForFiles(current.Levels[level].Iter(), manifest.Level(level))
 	}
 
 	buf.merging.init(&dbi.opts, d.cmp, finalMLevels...)


### PR DESCRIPTION
Previously, when creating a `levelIter`, we called
`(*LevelMetadata).Slice` once to create an immutable
`manifest.LevelSlice` for the level and then `(*LevelSlice).Iter` to
create a mutable iterator from the slice. Both of these functions
require a clone of the underlying B-Tree iterator. This commit updates
`newIterInternal` to call `Iter` directly on the `*LevelMetadata`,
avoiding extra allocations.

```
____optype__elapsed_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)
  read_100   600.0s      904666216      1507753.3      0.2      0.0      0.0      0.0   2952.8

Benchmarkycsb/C/values=64 904666216  1507753.3 ops/sec  1681696670 read  1628160788 write  3.22 r-amp  0.00 w-amp
```

In tests on my gceworker, current master achieves 1,442,248 ops/sec with
this benchmark, so this commit improves the benchmark's throughput by
~4%. The commit preceding the introduction of the B-Tree
achieves 1,574,408 ops/sec, so we still have a ~4% regression remaining.