### PR TITLE
db: use pointer for LevelSlice methods, use precomputed level sizes

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -688,7 +688,8 @@ func (c *compaction) setupInuseKeyRanges() {
 	// levels.
 	var input []userKeyRange
 	for ; level < numLevels; level++ {
-		iter := c.version.Overlaps(level, c.cmp, c.smallest.UserKey, c.largest.UserKey).Iter()
+		overlaps := c.version.Overlaps(level, c.cmp, c.smallest.UserKey, c.largest.UserKey)
+		iter := overlaps.Iter()
 		for m := iter.First(); m != nil; m = iter.Next() {
 			input = append(input, userKeyRange{m.Smallest.UserKey, m.Largest.UserKey})
 		}
@@ -1667,8 +1668,9 @@ func checkDeleteCompactionHints(
 		// The hint h will be resolved and dropped, regardless of whether
 		// there are any tables that can be deleted.
 		for l := h.tombstoneLevel + 1; l < numLevels; l++ {
-			overlaps := v.Overlaps(l, cmp, h.start, h.end).Iter()
-			for m := overlaps.First(); m != nil; m = overlaps.Next() {
+			overlaps := v.Overlaps(l, cmp, h.start, h.end)
+			iter := overlaps.Iter()
+			for m := iter.First(); m != nil; m = iter.Next() {
 				if m.Compacting || !h.canDelete(cmp, m, snapshots) || files[m] {
 					continue
 				}

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -580,13 +580,12 @@ func TestCompactionPickerL0(t *testing.T) {
 				baseLevel: baseLevel,
 			}
 			vs.picker = picker
-			var sizes [numLevels]int64
-			for l := 0; l < len(sizes); l++ {
+			for l := 0; l < len(picker.levelSizes); l++ {
 				version.Levels[l].Slice().Each(func(m *fileMetadata) {
-					sizes[l] += int64(m.Size)
+					picker.levelSizes[l] += int64(m.Size)
 				})
 			}
-			picker.initLevelMaxBytes(inProgressCompactions, sizes)
+			picker.initLevelMaxBytes(inProgressCompactions)
 
 			var buf bytes.Buffer
 			fmt.Fprint(&buf, version.DebugString(base.DefaultFormatter))

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1465,8 +1465,9 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 					tombstoneLevel := int(parseUint64(parts[0][1:]))
 					// Find the file in the current version.
 					v := d.mu.versions.currentVersion()
-					overlaps := v.Overlaps(tombstoneLevel, d.opts.Comparer.Compare, start, end).Iter()
-					for m := overlaps.First(); m != nil; m = overlaps.Next() {
+					overlaps := v.Overlaps(tombstoneLevel, d.opts.Comparer.Compare, start, end)
+					iter := overlaps.Iter()
+					for m := iter.First(); m != nil; m = iter.Next() {
 						if m.FileNum.String() == parts[1] {
 							tombstoneFile = m
 						}

--- a/ingest.go
+++ b/ingest.go
@@ -428,7 +428,8 @@ func ingestTargetLevel(
 		}
 
 		// Check boundary overlap.
-		if !v.Overlaps(level, cmp, meta.Smallest.UserKey, meta.Largest.UserKey).Empty() {
+		boundaryOverlaps := v.Overlaps(level, cmp, meta.Smallest.UserKey, meta.Largest.UserKey)
+		if !boundaryOverlaps.Empty() {
 			continue
 		}
 

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -444,8 +444,9 @@ func TestL0Sublevels(t *testing.T) {
 			return strconv.Itoa(sublevels.MaxDepthAfterOngoingCompactions())
 		case "l0-check-ordering":
 			for sublevel, files := range sublevels.levelFiles {
+				slice := NewLevelSliceSpecificOrder(files)
 				err := CheckOrdering(base.DefaultComparer.Compare, base.DefaultFormatter,
-					L0Sublevel(sublevel), NewLevelSliceSpecificOrder(files).Iter())
+					L0Sublevel(sublevel), slice.Iter())
 				if err != nil {
 					return err.Error()
 				}

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -172,12 +172,12 @@ func (ls LevelSlice) String() string {
 }
 
 // Empty indicates whether the slice contains any files.
-func (ls LevelSlice) Empty() bool {
+func (ls *LevelSlice) Empty() bool {
 	return emptyWithBounds(ls.iter, ls.start, ls.end)
 }
 
 // Iter constructs a LevelIterator that iterates over the slice.
-func (ls LevelSlice) Iter() LevelIterator {
+func (ls *LevelSlice) Iter() LevelIterator {
 	return LevelIterator{
 		start: ls.start,
 		end:   ls.end,
@@ -186,13 +186,13 @@ func (ls LevelSlice) Iter() LevelIterator {
 }
 
 // Len returns the number of files in the slice. Its runtime is constant.
-func (ls LevelSlice) Len() int {
+func (ls *LevelSlice) Len() int {
 	return ls.length
 }
 
 // SizeSum sums the size of all files in the slice. Its runtime is linear in
 // the length of the slice.
-func (ls LevelSlice) SizeSum() uint64 {
+func (ls *LevelSlice) SizeSum() uint64 {
 	var sum uint64
 	iter := ls.Iter()
 	for f := iter.First(); f != nil; f = iter.Next() {

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -455,7 +455,8 @@ func (v *Version) InitL0Sublevels(
 func (v *Version) Contains(level int, cmp Compare, m *FileMetadata) bool {
 	iter := v.Levels[level].Iter()
 	if level > 0 {
-		iter = v.Overlaps(level, cmp, m.Smallest.UserKey, m.Largest.UserKey).Iter()
+		overlaps := v.Overlaps(level, cmp, m.Smallest.UserKey, m.Largest.UserKey)
+		iter = overlaps.Iter()
 	}
 	for f := iter.First(); f != nil; f = iter.Next() {
 		if f == m {

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -248,9 +248,10 @@ func TestOverlaps(t *testing.T) {
 
 	cmp := base.DefaultComparer.Compare
 	for _, tc := range testCases {
-		o := v.Overlaps(tc.level, cmp, []byte(tc.ukey0), []byte(tc.ukey1)).Iter()
+		overlaps := v.Overlaps(tc.level, cmp, []byte(tc.ukey0), []byte(tc.ukey1))
+		iter := overlaps.Iter()
 		var s []string
-		for meta := o.First(); meta != nil; meta = o.Next() {
+		for meta := iter.First(); meta != nil; meta = iter.Next() {
 			s = append(s, fmt.Sprintf("m%02d", meta.FileNum%100))
 		}
 		got := strings.Join(s, " ")

--- a/level_checker.go
+++ b/level_checker.go
@@ -622,7 +622,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 		mlevels = append(mlevels, simpleMergingIterLevel{})
 	}
 	for level := 1; level < len(current.Levels); level++ {
-		if current.Levels[level].Slice().Empty() {
+		if current.Levels[level].Empty() {
 			continue
 		}
 		mlevels = append(mlevels, simpleMergingIterLevel{})

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -282,9 +282,9 @@ func TestLevelIterBoundaries(t *testing.T) {
 				return fmt.Sprintf("no existing iter")
 			}
 			if iter == nil {
+				slice := manifest.NewLevelSliceKeySorted(lt.cmp.Compare, lt.metas)
 				iter = newLevelIter(IterOptions{}, DefaultComparer.Compare, lt.newIters,
-					manifest.NewLevelSliceKeySorted(lt.cmp.Compare, lt.metas).Iter(),
-					manifest.Level(level), nil)
+					slice.Iter(), manifest.Level(level), nil)
 				// Fake up the range deletion initialization.
 				iter.initRangeDel(new(internalIterator))
 			}
@@ -373,9 +373,10 @@ func TestLevelIterSeek(t *testing.T) {
 			return lt.runBuild(d)
 
 		case "iter":
+			slice := manifest.NewLevelSliceKeySorted(lt.cmp.Compare, lt.metas)
 			iter := &levelIterTestIter{
 				levelIter: newLevelIter(IterOptions{}, DefaultComparer.Compare, lt.newIters,
-					manifest.NewLevelSliceKeySorted(lt.cmp.Compare, lt.metas).Iter(), manifest.Level(level), nil),
+					slice.Iter(), manifest.Level(level), nil),
 			}
 			defer iter.Close()
 			iter.initRangeDel(&iter.rangeDelIter)

--- a/table_stats.go
+++ b/table_stats.go
@@ -335,7 +335,8 @@ func (d *DB) estimateSizeBeneath(
 	// additional I/O to read the file's index blocks.
 	hintSeqNum = math.MaxUint64
 	for l := level + 1; l < numLevels; l++ {
-		iter := v.Overlaps(l, d.cmp, start, end).Iter()
+		overlaps := v.Overlaps(l, d.cmp, start, end)
+		iter := overlaps.Iter()
 		for file := iter.First(); file != nil; file = iter.Next() {
 			if d.cmp(start, file.Smallest.UserKey) <= 0 &&
 				d.cmp(file.Largest.UserKey, end) <= 0 {

--- a/version_set.go
+++ b/version_set.go
@@ -284,7 +284,8 @@ func (vs *versionSet) load(dirname string, opts *Options, mu *sync.Mutex) error 
 	for i := range vs.metrics.Levels {
 		l := &vs.metrics.Levels[i]
 		l.NumFiles = int64(newVersion.Levels[i].Len())
-		l.Size = int64(newVersion.Levels[i].Slice().SizeSum())
+		files := newVersion.Levels[i].Slice()
+		l.Size = int64(files.SizeSum())
 	}
 	vs.picker = newCompactionPicker(newVersion, vs.opts, nil, vs.metrics.levelSizes())
 	return nil
@@ -502,7 +503,8 @@ func (vs *versionSet) logAndApply(
 			if count := int64(newVersion.Levels[i].Len()); l.NumFiles != count {
 				vs.opts.Logger.Fatalf("versionSet metrics L%d NumFiles = %d, actual count = %d", i, l.NumFiles, count)
 			}
-			if size := int64(newVersion.Levels[i].Slice().SizeSum()); l.Size != size {
+			levelFiles := newVersion.Levels[i].Slice()
+			if size := int64(levelFiles.SizeSum()); l.Size != size {
 				vs.opts.Logger.Fatalf("versionSet metrics L%d Size = %d, actual size = %d", i, l.Size, size)
 			}
 		}


### PR DESCRIPTION
This commit contains a few optimizations as fallout from the integration
of the B-Tree:
  * Use a pointer receiver for LevelSlice methods.
  * Use precomputed level sizes in estimatedCompactionDebt.
  * Avoid unnecessary Empty calls on sublevel B-Trees in iterator
    initialization.