### PR TITLE
*: Implement deletion pacing of obsolete compaction files

### DIFF
--- a/db.go
+++ b/db.go
@@ -228,6 +228,7 @@ type DB struct {
 
 	compactionLimiter limiter
 	flushLimiter      limiter
+	deletionLimiter   limiter
 
 	// The main mutex protecting internal DB state. This mutex encompasses many
 	// fields because those fields need to be accessed and updated atomically. In

--- a/internal/manifest/btree_test.go
+++ b/internal/manifest/btree_test.go
@@ -470,7 +470,7 @@ func TestBTreeCloneConcurrentOperations(t *testing.T) {
 		}
 	}
 
-	var obsolete []base.FileNum
+	var obsolete []*FileMetadata
 	for i := range trees {
 		obsolete = append(obsolete, trees[i].release()...)
 	}

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -25,7 +25,7 @@ func (lm *LevelMetadata) clone() LevelMetadata {
 	}
 }
 
-func (lm *LevelMetadata) release() (obsolete []base.FileNum) {
+func (lm *LevelMetadata) release() (obsolete []*FileMetadata) {
 	return lm.tree.release()
 }
 

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -323,7 +323,7 @@ type Version struct {
 
 	// The callback to invoke when the last reference to a version is
 	// removed. Will be called with list.mu held.
-	Deleted func(obsolete []base.FileNum)
+	Deleted func(obsolete []*FileMetadata)
 
 	// The list the version is linked into.
 	list *VersionList
@@ -426,8 +426,8 @@ func (v *Version) UnrefLocked() {
 	}
 }
 
-func (v *Version) unrefFiles() []base.FileNum {
-	var obsolete []base.FileNum
+func (v *Version) unrefFiles() []*FileMetadata {
+	var obsolete []*FileMetadata
 	for _, lm := range v.Levels {
 		obsolete = append(obsolete, lm.release()...)
 	}

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -406,7 +406,7 @@ func TestContains(t *testing.T) {
 func TestVersionUnref(t *testing.T) {
 	list := &VersionList{}
 	list.Init(&sync.Mutex{})
-	v := &Version{Deleted: func([]base.FileNum) {}}
+	v := &Version{Deleted: func([]*FileMetadata) {}}
 	v.Ref()
 	list.PushBack(v)
 	v.Unref()

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -187,8 +187,9 @@ func randomOptions(rng *rand.Rand) *testOptions {
 	opts.Experimental.FlushSplitBytes = 1 << rng.Intn(20)       // 1B - 1MB
 	opts.Experimental.L0CompactionConcurrency = 1 + rng.Intn(4) // 1-4
 	opts.Experimental.L0SublevelCompactions = rng.Intn(2) == 0
-	opts.L0CompactionThreshold = 1 + rng.Intn(100) // 1 - 100
-	opts.L0StopWritesThreshold = 1 + rng.Intn(100) // 1 - 100
+	opts.Experimental.MinDeletionRate = 1 << uint(20 + rng.Intn(10)) // 1MB - 1GB
+	opts.L0CompactionThreshold = 1 + rng.Intn(100)                   // 1 - 100
+	opts.L0StopWritesThreshold = 1 + rng.Intn(100)                   // 1 - 100
 	if opts.L0StopWritesThreshold < opts.L0CompactionThreshold {
 		opts.L0StopWritesThreshold = opts.L0CompactionThreshold
 	}

--- a/metrics.go
+++ b/metrics.go
@@ -160,6 +160,11 @@ type Metrics struct {
 	}
 
 	Table struct {
+		// The number of bytes present in obsolete tables which are no longer
+		// referenced by the current DB state or any open iterators.
+		ObsoleteSize uint64
+		// The count of obsolete tables.
+		ObsoleteCount int64
 		// The number of bytes present in zombie tables which are no longer
 		// referenced by the current DB state but are still in use by an iterator.
 		ZombieSize uint64

--- a/open.go
+++ b/open.go
@@ -113,6 +113,9 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	d.flushLimiter = rate.NewLimiter(
 		rate.Limit(d.opts.private.minFlushRate),
 		d.opts.private.minFlushRate)
+	d.deletionLimiter = rate.NewLimiter(
+		rate.Limit(d.opts.Experimental.MinDeletionRate),
+		d.opts.Experimental.MinDeletionRate)
 	d.mu.nextJobID = 1
 	d.mu.mem.nextSize = opts.MemTableSize
 	if d.mu.mem.nextSize > initialMemTableSize {

--- a/options.go
+++ b/options.go
@@ -320,6 +320,17 @@ type Options struct {
 		// deletion. Disk space cannot be reclaimed until the range deletion
 		// is flushed. No automatic flush occurs if zero.
 		DeleteRangeFlushDelay time.Duration
+
+		// MinDeletionRate is the minimum number of bytes per second that would
+		// be deleted. Deletion pacing is used to slow down deletions when
+		// compactions finish up or readers close, and newly-obsolete files need
+		// cleaning up. Deleting lots of files at once can cause disk latency to
+		// go up on some SSDs, which this functionality guards against. This is a
+		// minimum as the maximum is theoretically unlimited; pacing is disabled
+		// when there are too many obsolete files relative to live bytes, or
+		// there isn't enough disk space available. Setting this to 0 disables
+		// deletion pacing, which is also the default.
+		MinDeletionRate int
 	}
 
 	// Filters is a map from filter policy name to filter policy. It is used for

--- a/testdata/compaction_pacer_maybe_throttle
+++ b/testdata/compaction_pacer_maybe_throttle
@@ -244,3 +244,76 @@ currentTotal: 14
 slowdownThreshold: 10
 ----
 allow: 3
+
+init deletion
+burst: 10
+bytesIterated: 5
+slowdownThreshold: 10
+freeBytes: 100
+obsoleteBytes: 1
+liveBytes: 100
+----
+wait: 5
+
+# As freeBytes > slowdownThreshold and obsoleteBytesRatio < 0.20,
+# all 50 bytes should be asked to wait.
+
+init deletion
+burst: 10
+bytesIterated: 50
+slowdownThreshold: 10
+freeBytes: 100
+obsoleteBytes: 1
+liveBytes: 100
+----
+wait: 10
+wait: 10
+wait: 10
+wait: 10
+wait: 10
+
+# As freeBytes < slowdownThreshold, all 50 bytes should be allowed through.
+
+init deletion
+burst: 10
+bytesIterated: 50
+slowdownThreshold: 10
+freeBytes: 5
+obsoleteBytes: 1
+liveBytes: 100
+----
+allow: 10
+allow: 10
+allow: 10
+allow: 10
+allow: 10
+
+# As obsoleteBytesRatio > 0.20, all 50 bytes should be allowed through.
+
+init deletion
+burst: 10
+bytesIterated: 50
+slowdownThreshold: 10
+freeBytes: 500
+obsoleteBytes: 50
+liveBytes: 100
+----
+allow: 10
+allow: 10
+allow: 10
+allow: 10
+allow: 10
+
+# When obsolete ratio unknown, all 50 bytes should be allowed through.
+
+init deletion
+burst: 10
+bytesIterated: 50
+slowdownThreshold: 10
+freeBytes: 500
+----
+allow: 10
+allow: 10
+allow: 10
+allow: 10
+allow: 10


### PR DESCRIPTION
Currently, file deletions are not rate limited at all. This is
usually not an issue, however if a lot of bytes are deleted
all at once, this could slow down or even stall disk writes on
some SSDs, if an ssd-level garbage collection run gets kicked off.
As it's hard to detect when this would happen in advance, it makes
sense to be pacing deletions at some rate all the time.

This PR implements deletionPacer, which works in some ways like
{compaction,flush}Pacer, except the threshold it has (i.e. free
space on disk in bytes) is treated as a minimum rather than a
maximum for inducing slowness, unlike the other pacers that are
based on read-amplification. The deletion pacer is disabled by
default to make most tests more deterministic, however it will
most likely be enabled in cockroach.

Fixes #129.