### PR TITLE
db: fix Iterator direction switching behavior

### DIFF
--- a/compaction_iter.go
+++ b/compaction_iter.go
@@ -242,7 +242,7 @@ func (i *compactionIter) Next() (*InternalKey, []byte) {
 	//   snapshot stripe.
 	// - `skip && pos == iterPosCur`: We are at the key that has been returned.
 	//   To move forward we skip skippable entries in the stripe.
-	if i.pos == iterPosCur {
+	if i.pos == iterPosCurForward {
 		if i.skip {
 			i.skipInStripe()
 		} else {
@@ -250,7 +250,7 @@ func (i *compactionIter) Next() (*InternalKey, []byte) {
 		}
 	}
 
-	i.pos = iterPosCur
+	i.pos = iterPosCurForward
 	i.valid = false
 	for i.iterKey != nil {
 		if i.iterKey.Kind() == InternalKeyKindRangeDelete {

--- a/iterator.go
+++ b/iterator.go
@@ -12,12 +12,18 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 )
 
+// iterPos describes the state of the internal iterator, in terms of whether it is
+// at the position returned to the user (cur), one ahead of the position returned
+// (next for forward iteration and prev for reverse iteration). The cur position
+// is split into two states, for forward and reverse iteration, since we need to
+// differentiate for switching directions.
 type iterPos int8
 
 const (
-	iterPosCur  iterPos = 0
-	iterPosNext iterPos = 1
-	iterPosPrev iterPos = -1
+	iterPosCurForward iterPos = 0
+	iterPosNext       iterPos = 1
+	iterPosPrev       iterPos = -1
+	iterPosCurReverse iterPos = -2
 )
 
 var errReversePrefixIteration = errors.New("pebble: unsupported reverse prefix iteration")
@@ -74,7 +80,7 @@ type Iterator struct {
 
 func (i *Iterator) findNextEntry() bool {
 	i.valid = false
-	i.pos = iterPosCur
+	i.pos = iterPosCurForward
 
 	// Close the closer for the current value if one was open.
 	if i.valueCloser != nil {
@@ -149,7 +155,7 @@ func (i *Iterator) nextUserKey() {
 
 func (i *Iterator) findPrevEntry() bool {
 	i.valid = false
-	i.pos = iterPosCur
+	i.pos = iterPosCurReverse
 
 	// Close the closer for the current value if one was open.
 	if i.valueCloser != nil {
@@ -229,6 +235,7 @@ func (i *Iterator) findPrevEntry() bool {
 		}
 	}
 
+	// i.iterKey == nil, so broke out of the preceding loop.
 	if i.valid {
 		i.pos = iterPosPrev
 		if valueMerger != nil {
@@ -446,8 +453,24 @@ func (i *Iterator) Next() bool {
 		return false
 	}
 	switch i.pos {
-	case iterPosCur:
+	case iterPosCurForward:
 		i.nextUserKey()
+	case iterPosCurReverse:
+		// Switching directions.
+		// Unless the iterator was exhausted, reverse iteration needs to
+		// position the iterator at iterPosPrev.
+		if i.iterKey != nil {
+			i.err = errors.New("switching from reverse to forward but iter is not at prev")
+			i.valid = false
+			return false
+		}
+		// We're positioned before the first key. Need to reposition to point to
+		// the first key.
+		if lowerBound := i.opts.GetLowerBound(); lowerBound != nil {
+			i.iterKey, i.iterValue = i.iter.SeekGE(lowerBound)
+		} else {
+			i.iterKey, i.iterValue = i.iter.First()
+		}
 	case iterPosPrev:
 		// The underlying iterator is pointed to the previous key (this can only
 		// happen when switching iteration directions). We set i.valid to false
@@ -482,13 +505,21 @@ func (i *Iterator) Prev() bool {
 		return false
 	}
 	switch i.pos {
-	case iterPosCur:
+	case iterPosCurForward:
+		// Switching directions, and will handle this below.
+	case iterPosCurReverse:
 		i.prevUserKey()
 	case iterPosNext:
 		// The underlying iterator is pointed to the next key (this can only happen
-		// when switching iteration directions). We set i.valid to false here to
-		// force the calls to prevUserKey to save the current key i.iter is
-		// pointing at in order to determine when the prev user-key is reached.
+		// when switching iteration directions). We will handle this below.
+	case iterPosPrev:
+	}
+	if i.pos == iterPosCurForward || i.pos == iterPosNext {
+		stepAgain := i.pos == iterPosNext
+		// Switching direction.
+		// We set i.valid to false here to force the calls to prevUserKey to
+		// save the current key i.iter is pointing at in order to determine
+		// when the prev user-key is reached.
 		i.valid = false
 		if i.iterKey == nil {
 			// We're positioned after the last key. Need to reposition to point to
@@ -501,8 +532,9 @@ func (i *Iterator) Prev() bool {
 		} else {
 			i.prevUserKey()
 		}
-		i.prevUserKey()
-	case iterPosPrev:
+		if stepAgain {
+			i.prevUserKey()
+		}
 	}
 	return i.findPrevEntry()
 }
@@ -583,7 +615,16 @@ func (i *Iterator) SetBounds(lower, upper []byte) {
 	i.prefix = nil
 	i.iterKey = nil
 	i.iterValue = nil
-	i.pos = iterPosCur
+	// This switch statement isn't necessary for correctness since callers
+	// should call a repositioning method. We could have arbitrarily set i.pos
+	// to one of the values. But it results in more intuitive behavior in
+	// tests, which do not always reposition.
+	switch i.pos {
+	case iterPosCurForward, iterPosNext:
+		i.pos = iterPosCurForward
+	case iterPosCurReverse, iterPosPrev:
+		i.pos = iterPosCurReverse
+	}
 	i.valid = false
 
 	i.opts.LowerBound = lower

--- a/testdata/iterator
+++ b/testdata/iterator
@@ -9,7 +9,7 @@ prev
 ----
 a:b
 .
-.
+a:b
 
 iter seq=2
 seek-ge b
@@ -34,7 +34,7 @@ prev
 ----
 a:b
 .
-.
+a:b
 
 iter seq=3
 seek-ge a
@@ -43,7 +43,7 @@ prev
 ----
 a:c
 .
-.
+a:c
 
 iter seq=2
 seek-prefix-ge a
@@ -93,7 +93,7 @@ next
 ----
 a:b
 .
-.
+a:b
 
 iter seq=3
 seek-prefix-ge a
@@ -185,7 +185,7 @@ next
 ----
 a:a
 .
-.
+a:a
 
 iter seq=4
 seek-lt c
@@ -196,7 +196,7 @@ next
 b:b
 a:a
 .
-.
+a:a
 
 
 iter seq=4
@@ -210,7 +210,7 @@ c:c
 b:b
 a:a
 .
-.
+a:a
 
 iter seq=4
 seek-prefix-ge a
@@ -253,7 +253,7 @@ prev
 ----
 a:b
 .
-.
+a:b
 
 iter seq=2
 seek-ge b
@@ -272,7 +272,7 @@ next
 ----
 a:b
 .
-.
+a:b
 
 iter seq=2
 seek-lt c
@@ -281,7 +281,7 @@ next
 ----
 a:b
 .
-.
+a:b
 
 iter seq=2
 seek-prefix-ge a
@@ -472,7 +472,7 @@ prev
 a:bcd
 b:ab
 .
-.
+b:ab
 
 iter seq=3
 seek-ge a
@@ -497,7 +497,7 @@ next
 b:ab
 a:bcd
 .
-.
+a:bcd
 
 iter seq=3
 seek-lt c
@@ -951,6 +951,9 @@ last
 .
 a:a
 
+# The prev call after "set-bounds upper=c" will assume that the iterator
+# is exhausted due to having stepped up to c. Which means prev should step
+# back to below c, hence returning b.
 iter seq=2
 last
 next
@@ -960,8 +963,11 @@ prev
 d:d
 .
 .
-.
+b:b
 
+# The next call after "set-bounds lower=b" will assume that the iterator
+# is exhausted due to having stepped below b. Which means next should step
+# up to b (or higher), hence returning b.
 iter seq=2
 first
 prev
@@ -971,7 +977,7 @@ next
 a:a
 .
 .
-.
+b:b
 
 iter seq=2
 set-bounds lower=b

--- a/testdata/snapshot
+++ b/testdata/snapshot
@@ -14,7 +14,7 @@ prev
 ----
 a:1
 .
-.
+a:1
 
 iter snapshot=2
 first
@@ -25,7 +25,7 @@ prev
 a:1
 b:2
 .
-.
+b:2
 
 iter snapshot=3
 first
@@ -38,7 +38,7 @@ a:1
 b:2
 c:3
 .
-.
+c:3
 
 define
 set a 1
@@ -56,7 +56,7 @@ prev
 ----
 a:1
 .
-.
+a:1
 
 iter snapshot=2
 first
@@ -65,7 +65,7 @@ prev
 ----
 a:2
 .
-.
+a:2
 
 iter snapshot=3
 first
@@ -74,7 +74,7 @@ prev
 ----
 a:3
 .
-.
+a:3
 
 define
 set a 1
@@ -93,7 +93,7 @@ prev
 ----
 a:1
 .
-.
+a:1
 
 iter snapshot=2
 first
@@ -102,7 +102,7 @@ prev
 ----
 a:2
 .
-.
+a:2
 
 iter snapshot=3
 first
@@ -111,7 +111,7 @@ prev
 ----
 a:3
 .
-.
+a:3
 
 define
 merge a 1
@@ -130,7 +130,7 @@ prev
 ----
 a:1
 .
-.
+a:1
 
 iter snapshot=2
 first
@@ -139,7 +139,7 @@ prev
 ----
 a:12
 .
-.
+a:12
 
 iter snapshot=3
 first
@@ -148,4 +148,4 @@ prev
 ----
 a:123
 .
-.
+a:123


### PR DESCRIPTION
Prior to this change, a switch in direction would
work only if the iterator was at the next (prev)
position for forward (reverse) iteration and the
direction was switching to reverse (forward).
It the iterator was exhausted, it would be at the
cur position, and we would not recognize that
the direction had changed.

The pos field now explicitly tracks the direction of
the current position. And there is additional
error checking for invariants.