### PR TITLE
crl-release-20.2: db: panic on 'no such file or directory' error

### DIFF
--- a/internal/base/filenames.go
+++ b/internal/base/filenames.go
@@ -6,6 +6,7 @@ package base
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -105,4 +106,42 @@ func parseFileNum(s string) (fileNum FileNum, ok bool) {
 		return fileNum, false
 	}
 	return FileNum(u), true
+}
+
+// A Fataler fatals a process with a message when called.
+type Fataler interface {
+	Fatalf(format string, args ...interface{})
+}
+
+// MustExist checks if err is an error indicating a file does not exist.
+// If it is, it lists the containing directory's files to annotate the error
+// with counts of the various types of files and invokes the provided fataler.
+// See cockroachdb/cockroach#56490.
+func MustExist(fs vfs.FS, filename string, fataler Fataler, err error) {
+	if err == nil || !os.IsNotExist(err) {
+		return
+	}
+
+	ls, lsErr := fs.List(fs.PathDir(filename))
+	if lsErr != nil {
+		fataler.Fatalf("%s:\n%s\n%s", fs.PathBase(filename), err, lsErr)
+	}
+	var total, unknown, tables, logs int
+	total = len(ls)
+	for _, f := range ls {
+		typ, _, ok := ParseFilename(fs, f)
+		if !ok {
+			unknown++
+			continue
+		}
+		switch typ {
+		case FileTypeTable:
+			tables++
+		case FileTypeLog:
+			logs++
+		}
+	}
+
+	fataler.Fatalf("%s:\n%s\ndirectory contains %d files, %d unknown, %d tables, %d logs",
+		fs.PathBase(filename), err, total, unknown, tables, logs)
 }

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -1444,6 +1444,12 @@ func (r *Reader) readBlock(
 						raState.sequentialFile = f
 						file = f
 					}
+
+					// If we tried to load a table that doesn't exist, panic
+					// immediately.  Something is seriously wrong if a table
+					// doesn't exist.
+					// See cockroachdb/cockroach#56490.
+					base.MustExist(r.fs, r.filename, panicFataler{}, err)
 				}
 			}
 			if raState.sequentialFile != nil {
@@ -2069,4 +2075,10 @@ func (l *Layout) Describe(
 
 		h.Release()
 	}
+}
+
+type panicFataler struct{}
+
+func (panicFataler) Fatalf(format string, args ...interface{}) {
+	panic(errors.Errorf(format, args...))
 }


### PR DESCRIPTION
Panic immediately if opening a sstable ever fails with a file not found
error. This ensures we panic with the stack trace that actually produced
the error, rather than an indirect stack trace like an iterator close.

Some tests rely on the ability to retry filesystem errors loading a
table, so we restrict the panics to 'no such file' errors. This change
is for the 20.2 branch only. In the master branch, we can plumb the same
information by wrapping the error with a stack trace from within the
vfs.FS implementation.

Also, annotate the panic error with a summary of the number of files of
each type currently in the data directory. This may help us ascertain
whether the entire data directory has been wiped from underneath an
active database or just a single table is missing.

Informs cockroachdb/cockroach#56490.