### PR TITLE
db: panic on 'no such file or directory' error

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -1818,6 +1818,12 @@ func (r *Reader) readBlock(
 						raState.sequentialFile = f
 						file = f
 					}
+
+					// If we tried to load a table that doesn't exist, panic
+					// immediately.  Something is seriously wrong if a table
+					// doesn't exist.
+					// See cockroachdb/cockroach#56490.
+					base.MustExist(r.fs, r.filename, panicFataler{}, err)
 				}
 			}
 			if raState.sequentialFile != nil {
@@ -2443,4 +2449,10 @@ func (l *Layout) Describe(
 
 		h.Release()
 	}
+}
+
+type panicFataler struct{}
+
+func (panicFataler) Fatalf(format string, args ...interface{}) {
+	panic(errors.Errorf(format, args...))
 }

--- a/table_cache.go
+++ b/table_cache.go
@@ -87,6 +87,7 @@ func (c *tableCache) withReader(meta *fileMetadata, fn func(*sstable.Reader) err
 	v := s.findNode(meta)
 	defer s.unrefValue(v)
 	if v.err != nil {
+		base.MustExist(s.fs, v.filename, s.logger, v.err)
 		return v.err
 	}
 	return fn(v.reader)
@@ -187,7 +188,8 @@ func (c *tableCacheShard) newIters(
 	// the sstable iterator, which decrements when it is closed.
 	v := c.findNode(file)
 	if v.err != nil {
-		c.unrefValue(v)
+		defer c.unrefValue(v)
+		base.MustExist(c.fs, v.filename, c.logger, v.err)
 		return nil, nil, v.err
 	}
 
@@ -575,6 +577,7 @@ func (c *tableCacheShard) Close() error {
 type tableCacheValue struct {
 	closeHook func(i sstable.Iterator) error
 	reader    *sstable.Reader
+	filename  string
 	err       error
 	loaded    chan struct{}
 	// Reference count for the value. The reader is closed when the reference
@@ -585,11 +588,11 @@ type tableCacheValue struct {
 func (v *tableCacheValue) load(meta *fileMetadata, c *tableCacheShard) {
 	// Try opening the fileTypeTable first.
 	var f vfs.File
-	filename := base.MakeFilename(c.fs, c.dirname, fileTypeTable, meta.FileNum)
-	f, v.err = c.fs.Open(filename, vfs.RandomReadsOption)
+	v.filename = base.MakeFilename(c.fs, c.dirname, fileTypeTable, meta.FileNum)
+	f, v.err = c.fs.Open(v.filename, vfs.RandomReadsOption)
 	if v.err == nil {
 		cacheOpts := private.SSTableCacheOpts(c.cacheID, meta.FileNum).(sstable.ReaderOption)
-		reopenOpt := sstable.FileReopenOpt{FS: c.fs, Filename: filename}
+		reopenOpt := sstable.FileReopenOpt{FS: c.fs, Filename: v.filename}
 		v.reader, v.err = sstable.NewReader(f, c.opts, cacheOpts, c.filterMetrics, reopenOpt)
 	}
 	if v.err == nil {


### PR DESCRIPTION
Panic immediately if opening a sstable ever fails with a file not found
error. This ensures we panic with the stack trace that actually produced
the error, rather than an indirect stack trace like an iterator close.

Some tests rely on the ability to retry filesystem errors loading a
table, so we restrict the panics to 'no such file' errors. This change
is for the 20.2 branch only. In the master branch, we can plumb the same
information by wrapping the error with a stack trace from within the
vfs.FS implementation.

Also, annotate the panic error with a summary of the number of files of
each type currently in the data directory. This may help us ascertain
whether the entire data directory has been wiped from underneath an
active database or just a single table is missing.

Informs cockroachdb/cockroach#56490.

This is a master branch port of #988.