### PR TITLE
vfs: wrap defaultFS errors with a stack trace

### DIFF
--- a/vfs/dir_unix.go
+++ b/vfs/dir_unix.go
@@ -9,8 +9,11 @@ package vfs
 import (
 	"os"
 	"syscall"
+
+	"github.com/cockroachdb/errors"
 )
 
 func (defaultFS) OpenDir(name string) (File, error) {
-	return os.OpenFile(name, syscall.O_CLOEXEC, 0)
+	f, err := os.OpenFile(name, syscall.O_CLOEXEC, 0)
+	return f, errors.WithStack(err)
 }

--- a/vfs/dir_windows.go
+++ b/vfs/dir_windows.go
@@ -9,6 +9,8 @@ package vfs
 import (
 	"os"
 	"syscall"
+
+	"github.com/cockroachdb/errors"
 )
 
 type windowsDir struct {
@@ -24,7 +26,7 @@ func (windowsDir) Sync() error {
 func (defaultFS) OpenDir(name string) (File, error) {
 	f, err := os.OpenFile(name, syscall.O_CLOEXEC, 0)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return windowsDir{f}, nil
 }

--- a/vfs/errors_unix_test.go
+++ b/vfs/errors_unix_test.go
@@ -1,0 +1,20 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build darwin dragonfly freebsd linux openbsd
+
+package vfs
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func TestIsNoSpaceError(t *testing.T) {
+	err := errors.WithStack(unix.ENOSPC)
+	require.True(t, IsNoSpaceError(err))
+}

--- a/vfs/syncing_file.go
+++ b/vfs/syncing_file.go
@@ -4,7 +4,11 @@
 
 package vfs
 
-import "sync/atomic"
+import (
+	"sync/atomic"
+
+	"github.com/cockroachdb/errors"
+)
 
 // SyncingFileOptions holds the options for a syncingFile.
 type SyncingFileOptions struct {
@@ -80,7 +84,7 @@ func (f *syncingFile) Write(p []byte) (n int, err error) {
 
 	n, err = f.File.Write(p)
 	if err != nil {
-		return n, err
+		return n, errors.WithStack(err)
 	}
 	// The offset is updated atomically so that it can be accessed safely from
 	// Sync.
@@ -156,7 +160,7 @@ func (f *syncingFile) maybeSync() error {
 	}
 
 	if f.fd == 0 {
-		return f.Sync()
+		return errors.WithStack(f.Sync())
 	}
 
 	// Note that syncTo will always be called with an offset < atomic.offset. The
@@ -164,7 +168,7 @@ func (f *syncingFile) maybeSync() error {
 	// which do not support syncing a portion of the file). The syncTo
 	// implementation must call ratchetSyncOffset with as much of the file as it
 	// has synced.
-	return f.syncTo(syncToOffset)
+	return errors.WithStack(f.syncTo(syncToOffset))
 }
 
 func (f *syncingFile) Close() error {
@@ -173,8 +177,8 @@ func (f *syncingFile) Close() error {
 	// atomic.offset. See syncingFile.syncToRange.
 	if atomic.LoadInt64(&f.atomic.offset) > atomic.LoadInt64(&f.atomic.syncOffset) {
 		if err := f.Sync(); err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	}
-	return f.File.Close()
+	return errors.WithStack(f.File.Close())
 }

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 )
 
@@ -127,17 +128,18 @@ var Default FS = defaultFS{}
 type defaultFS struct{}
 
 func (defaultFS) Create(name string) (File, error) {
-	return os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC|syscall.O_CLOEXEC, 0666)
+	f, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC|syscall.O_CLOEXEC, 0666)
+	return f, errors.WithStack(err)
 }
 
 func (defaultFS) Link(oldname, newname string) error {
-	return os.Link(oldname, newname)
+	return errors.WithStack(os.Link(oldname, newname))
 }
 
 func (defaultFS) Open(name string, opts ...OpenOption) (File, error) {
 	file, err := os.OpenFile(name, os.O_RDONLY|syscall.O_CLOEXEC, 0)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	for _, opt := range opts {
 		opt.Apply(file)
@@ -146,26 +148,27 @@ func (defaultFS) Open(name string, opts ...OpenOption) (File, error) {
 }
 
 func (defaultFS) Remove(name string) error {
-	return os.Remove(name)
+	return errors.WithStack(os.Remove(name))
 }
 
 func (defaultFS) RemoveAll(name string) error {
-	return os.RemoveAll(name)
+	return errors.WithStack(os.RemoveAll(name))
 }
 
 func (defaultFS) Rename(oldname, newname string) error {
-	return os.Rename(oldname, newname)
+	return errors.WithStack(os.Rename(oldname, newname))
 }
 
 func (fs defaultFS) ReuseForWrite(oldname, newname string) (File, error) {
 	if err := fs.Rename(oldname, newname); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
-	return os.OpenFile(newname, os.O_RDWR|os.O_CREATE|syscall.O_CLOEXEC, 0666)
+	f, err := os.OpenFile(newname, os.O_RDWR|os.O_CREATE|syscall.O_CLOEXEC, 0666)
+	return f, errors.WithStack(err)
 }
 
 func (defaultFS) MkdirAll(dir string, perm os.FileMode) error {
-	return os.MkdirAll(dir, perm)
+	return errors.WithStack(os.MkdirAll(dir, perm))
 }
 
 func (defaultFS) List(dir string) ([]string, error) {
@@ -174,11 +177,13 @@ func (defaultFS) List(dir string) ([]string, error) {
 		return nil, err
 	}
 	defer f.Close()
-	return f.Readdirnames(-1)
+	dirnames, err := f.Readdirnames(-1)
+	return dirnames, errors.WithStack(err)
 }
 
 func (defaultFS) Stat(name string) (os.FileInfo, error) {
-	return os.Stat(name)
+	finfo, err := os.Stat(name)
+	return finfo, errors.WithStack(err)
 }
 
 func (defaultFS) PathBase(path string) string {


### PR DESCRIPTION
Many filesystem errors don't get surfaced immediately and instead are
cached on an iterator to be exposed by a call to `Error`. This can make
it difficult to ascertain the source of an I/O error (for example
cockroachdb/cockroach#55351). This commit updates the vfs.Default
fileystem to wrap all of its errors with a current stack trace.
Filesystem errors are expected to be relatively infrequent, so this
wrapping is not expected to hinder performance.