### PR TITLE
[crl-release-20.1] sstable: Clone LargestRange in case Writer mutates it

### DIFF
--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -17,6 +17,28 @@ import (
 	"github.com/cockroachdb/pebble/vfs"
 )
 
+// modifierFile modifies the slice passed into Write() in place. This is useful
+// to uncover any bugs that would otherwise occur in practice when using a
+// vfs.File wrapper that, for instance, encrypts in-place.
+type modifierFile struct {
+	vfs.File
+}
+
+func (m modifierFile) Write(p []byte) (n int, err error) {
+	n, err = m.File.Write(p)
+	for i := range p {
+		// Toggle all bits.
+		p[i] ^= 0xFF
+	}
+	return n, err
+}
+
+// Flush is a no-op. This is necessary to prevent sstable.Writer from doings its
+// own buffering.
+func (m modifierFile) Flush() error {
+	return nil
+}
+
 func runBuildCmd(td *datadriven.TestData, writerOpts WriterOptions) (*WriterMetadata, *Reader, error) {
 	mem := vfs.NewMem()
 	f0, err := mem.Create("test")
@@ -49,6 +71,8 @@ func runBuildCmd(td *datadriven.TestData, writerOpts WriterOptions) (*WriterMeta
 			if err != nil {
 				return nil, nil, err
 			}
+		case "modifier-file":
+			f0 = modifierFile{File: f0}
 		default:
 			return nil, nil, errors.Errorf("%s: unknown arg %s", td.Cmd, arg.Key)
 		}

--- a/sstable/testdata/writer
+++ b/sstable/testdata/writer
@@ -26,6 +26,20 @@ point:   [a#1,1,h#7,2]
 range:   [d#4,15,j#72057594037927935,15]
 seqnums: [1,8]
 
+build modifier-file
+a.SET.1:a
+b.DEL.2:b
+c.MERGE.3:c
+d.RANGEDEL.4:e
+f.SET.5:f
+g.DEL.6:g
+h.MERGE.7:h
+i.RANGEDEL.8:j
+----
+point:   [a#1,1,h#7,2]
+range:   [d#4,15,j#72057594037927935,15]
+seqnums: [1,8]
+
 scan
 ----
 a#1,1:a

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -570,8 +570,13 @@ func (w *Writer) Close() (err error) {
 			// added range tombstone will be the largest range tombstone key. Note
 			// that we need to make this into a range deletion sentinel because
 			// sstable boundaries are inclusive while the end key of a range deletion
-			// tombstone is exclusive.
-			w.meta.LargestRange = base.MakeRangeDeleteSentinelKey(w.rangeDelBlock.curValue)
+			// tombstone is exclusive. A Clone() is necessary as
+			// rangeDelBlock.curValue is the same slice that will get passed
+			// into w.writer, and some implementations of vfs.File mutate the
+			// slice passed into Write(). Also, w.meta will often outlive the
+			// blockWriter, and so cloning curValue allows the rangeDelBlock's
+			// internal buffer to get gc'd.
+			w.meta.LargestRange = base.MakeRangeDeleteSentinelKey(w.rangeDelBlock.curValue).Clone()
 		}
 		rangeDelBH, err = w.writeBlock(w.rangeDelBlock.finish(), NoCompression)
 		if err != nil {


### PR DESCRIPTION
This change ensures the slice backing writerMeta.LargestRange
is always solely owned by it. This avoids instances where it
could be mutated by vfs.File wrappers that modify slices passed into
Write() in-place.

This change is already made on master (in commit:
0e61248353a41502074e9be2481c420971fa1ad9) however the test needs to be
forward-ported to it.