### PR TITLE
*: make memFile.Write mutate its input buffer

### DIFF
--- a/ingest_test.go
+++ b/ingest_test.go
@@ -244,7 +244,9 @@ func TestIngestLink(t *testing.T) {
 				require.NoError(t, err)
 
 				contents[j] = []byte(fmt.Sprintf("data%d", j))
-				_, err = f.Write(contents[j])
+				// memFile.Write will modify the supplied buffer when invariants are
+				// enabled, so provide a throw-away copy.
+				_, err = f.Write(append([]byte(nil), contents[j]...))
 				require.NoError(t, err)
 				require.NoError(t, f.Close())
 			}

--- a/sstable/testdata/writer
+++ b/sstable/testdata/writer
@@ -26,7 +26,7 @@ point:   [a#1,1,h#7,2]
 range:   [d#4,15,j#72057594037927935,15]
 seqnums: [1,8]
 
-build modifier-file
+build
 a.SET.1:a
 b.DEL.2:b
 c.MERGE.3:c


### PR DESCRIPTION
When invariants are enabled, `memFile.Write` will mutate its input
buffer (invert all the bits) in order to try and flush out bugs in
Pebble which assume the buffer supplied to `Write` is not
modified. Enabling invariants also has the effect of wrapping `memFile`
in a `flushFile` which defines a `Flush()` method. This disables the use
of `bufio.Writer` by `sstable.Writer` which helps to suss out bugs
relating to the mutation of the write buffer.