### PR TITLE
manifest: small optimizations to NewL0Sublevels

### DIFF
--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -21,13 +21,14 @@ import (
 )
 
 func readManifest(filename string) (*Version, error) {
-	f, err := os.Open("testdata/MANIFEST_import")
+	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
 	rr := record.NewReader(f, 0 /* logNum */)
 	var v *Version
+	addedByFileNum := make(map[base.FileNum]*FileMetadata)
 	for {
 		r, err := rr.Next()
 		if err == io.EOF {
@@ -41,7 +42,7 @@ func readManifest(filename string) (*Version, error) {
 			return nil, err
 		}
 		var bve BulkVersionEdit
-		bve.AddedByFileNum = make(map[base.FileNum]*FileMetadata)
+		bve.AddedByFileNum = addedByFileNum
 		if err := bve.Accumulate(&ve); err != nil {
 			return nil, err
 		}
@@ -49,7 +50,6 @@ func readManifest(filename string) (*Version, error) {
 			return nil, err
 		}
 	}
-	fmt.Printf("L0 filecount: %d\n", v.Levels[0].Len())
 	return v, nil
 }
 


### PR DESCRIPTION
- instead of maintaining the slices in levelFiles in
  sorted order, which is O(n^2), the code appends and
  sorts at the end.
- the search for maxIntervalIndex is pruned to start
  at minIntervalIndex.

Benchmark results (the K benchmark uses the recent
customer issue MANIFEST that I can't include here):

```
name                    old time/op    new time/op    delta
L0SublevelsInit-16        6.92ms ± 0%    6.69ms ± 0%   ~     (p=1.000 n=1+1)
L0SublevelsInitK-16     4.57s ± 0%     4.31s ± 0%   ~     (p=1.000 n=1+1)

name                    old alloc/op   new alloc/op   delta
L0SublevelsInit-16        3.03MB ± 0%    3.03MB ± 0%   ~     (p=1.000 n=1+1)
L0SublevelsInitK-16    1.20GB ± 0%    1.20GB ± 0%   ~     (p=1.000 n=1+1)

name                    old allocs/op  new allocs/op  delta
L0SublevelsInit-16         33.8k ± 0%     33.8k ± 0%   ~     (p=1.000 n=1+1)
L0SublevelsInitK-16     4.33M ± 0%     4.33M ± 0%   ~     (p=1.000 n=1+1)
```