### PR TITLE
*: Make sublevel compactions default, remove legacy code

### DIFF
--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -29,7 +29,8 @@ func TestCheckpoint(t *testing.T) {
 	var buf syncedBuffer
 	mem := vfs.NewMem()
 	opts := &Options{
-		FS: loggingFS{mem, &buf},
+		FS:                    loggingFS{mem, &buf},
+		L0CompactionThreshold: 10,
 	}
 
 	datadriven.RunTest(t, "testdata/checkpoint", func(td *datadriven.TestData) string {

--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -68,7 +68,6 @@ func newPebbleDB(dir string) DB {
 			Name: "cockroach_merge_operator",
 		},
 	}
-	opts.Experimental.L0SublevelCompactions = true
 
 	for i := 0; i < len(opts.Levels); i++ {
 		l := &opts.Levels[i]
@@ -82,7 +81,7 @@ func newPebbleDB(dir string) DB {
 		l.EnsureDefaults()
 	}
 	opts.Levels[6].FilterPolicy = nil
-	opts.Experimental.FlushSplitBytes = opts.Levels[0].TargetFileSize
+	opts.FlushSplitBytes = opts.Levels[0].TargetFileSize
 
 	opts.EnsureDefaults()
 

--- a/compaction.go
+++ b/compaction.go
@@ -665,7 +665,7 @@ func newFlush(
 		}
 	}
 
-	if opts.Experimental.FlushSplitBytes > 0 {
+	if opts.FlushSplitBytes > 0 {
 		c.maxOutputFileSize = uint64(opts.Level(0).TargetFileSize)
 		c.maxOverlapBytes = maxGrandparentOverlapBytes(opts, 0)
 		c.grandparents = c.version.Overlaps(baseLevel, c.cmp,
@@ -1968,7 +1968,7 @@ func (d *DB) runCompaction(
 		return nil
 	}
 
-	splitL0Outputs := c.outputLevel.level == 0 && d.opts.Experimental.FlushSplitBytes > 0
+	splitL0Outputs := c.outputLevel.level == 0 && d.opts.FlushSplitBytes > 0
 
 	// finishOutput is called for an sstable with the first key of the next sstable, and for the
 	// last sstable with an empty key.

--- a/compaction.go
+++ b/compaction.go
@@ -939,7 +939,7 @@ func (c *compaction) newInputIter(newIters tableNewIters) (_ internalIterator, r
 			// boundaries at write time. Because we're doing the truncation at read
 			// time, we follow RocksDB's lead and do not truncate tombstones to
 			// atomic unit boundaries at compaction time.
-			atomicUnit, _ := expandToAtomicUnit(c.cmp, f.Slice())
+			atomicUnit, _ := expandToAtomicUnit(c.cmp, f.Slice(), true /* disableIsCompacting */)
 			lowerBound, upperBound := manifest.KeyRange(c.cmp, atomicUnit.Iter())
 			// Range deletion tombstones are often written to sstables
 			// untruncated on the end key side. However, they are still only

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -54,7 +54,13 @@ func loadVersion(d *datadriven.TestData) (*version, *Options, [numLevels]int64, 
 				return nil, nil, sizes, err.Error()
 			}
 			for i := uint64(1); sizes[level] < int64(size); i++ {
-				key := base.MakeInternalKey([]byte(fmt.Sprintf("%04d", i)), i, InternalKeyKindSet)
+				var key InternalKey
+				if level == 0 {
+					// For L0, make `size` overlapping files.
+					key = base.MakeInternalKey([]byte(fmt.Sprintf("%04d", 1)), i, InternalKeyKindSet)
+				} else {
+					key = base.MakeInternalKey([]byte(fmt.Sprintf("%04d", i)), i, InternalKeyKindSet)
+				}
 				m := &fileMetadata{
 					Smallest:       key,
 					Largest:        key,
@@ -458,7 +464,6 @@ func TestCompactionPickerL0(t *testing.T) {
 	}
 
 	opts := (*Options)(nil).EnsureDefaults()
-	opts.Experimental.L0SublevelCompactions = true
 	opts.Experimental.L0CompactionConcurrency = 1
 	var picker *compactionPickerByScore
 	var inProgressCompactions []compactionInfo
@@ -690,7 +695,6 @@ func TestCompactionPickerConcurrency(t *testing.T) {
 	}
 
 	opts := (*Options)(nil).EnsureDefaults()
-	opts.Experimental.L0SublevelCompactions = true
 	opts.Experimental.L0CompactionConcurrency = 1
 	var picker *compactionPickerByScore
 	var inProgressCompactions []compactionInfo

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -1037,7 +1037,7 @@ func TestPickedCompactionExpandInputs(t *testing.T) {
 					_ = iter.Next()
 				}
 
-				inputs, _ := expandToAtomicUnit(cmp, iter.Take().Slice())
+				inputs, _ := expandToAtomicUnit(cmp, iter.Take().Slice(), true /* disableIsCompacting */)
 
 				var buf bytes.Buffer
 				inputs.Each(func(f *fileMetadata) {

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1398,7 +1398,7 @@ func TestCompactionAtomicUnitBounds(t *testing.T) {
 				for i := int64(0); i < index; i++ {
 					_ = iter.Next()
 				}
-				atomicUnit, _ := expandToAtomicUnit(c.cmp, iter.Take().Slice())
+				atomicUnit, _ := expandToAtomicUnit(c.cmp, iter.Take().Slice(), true /* disableIsCompacting */)
 				lower, upper := manifest.KeyRange(c.cmp, atomicUnit.Iter())
 				return fmt.Sprintf("%s-%s\n", lower.UserKey, upper.UserKey)
 

--- a/db.go
+++ b/db.go
@@ -1331,12 +1331,7 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 				continue
 			}
 		}
-		var l0ReadAmp int
-		if d.opts.Experimental.L0SublevelCompactions {
-			l0ReadAmp = d.mu.versions.currentVersion().L0Sublevels.ReadAmplification()
-		} else {
-			l0ReadAmp = d.mu.versions.currentVersion().Levels[0].Len()
-		}
+		l0ReadAmp := d.mu.versions.currentVersion().L0Sublevels.ReadAmplification()
 		if l0ReadAmp >= d.opts.L0StopWritesThreshold {
 			// There are too many level-0 files, so we wait.
 			if !stalled {

--- a/db_test.go
+++ b/db_test.go
@@ -645,7 +645,8 @@ func TestSingleDeleteFlush(t *testing.T) {
 
 func TestUnremovableSingleDelete(t *testing.T) {
 	d, err := Open("", &Options{
-		FS: vfs.NewMem(),
+		FS:                    vfs.NewMem(),
+		L0CompactionThreshold: 8,
 	})
 	require.NoError(t, err)
 	defer func() {

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -142,10 +142,11 @@ func TestEventListener(t *testing.T) {
 		case "open":
 			buf.Reset()
 			opts := &Options{
-				FS:                  loggingFS{mem, &buf},
-				EventListener:       MakeLoggingEventListener(&buf),
-				MaxManifestFileSize: 1,
-				WALDir:              "wal",
+				FS:                    loggingFS{mem, &buf},
+				EventListener:         MakeLoggingEventListener(&buf),
+				MaxManifestFileSize:   1,
+				L0CompactionThreshold: 10,
+				WALDir:                "wal",
 			}
 			// The table stats collector runs asynchronously and its
 			// timing is less predictable. It increments nextJobID, which

--- a/flush_test.go
+++ b/flush_test.go
@@ -17,9 +17,15 @@ import (
 )
 
 func TestManualFlush(t *testing.T) {
-	d, err := Open("", &Options{
-		FS: vfs.NewMem(),
-	})
+	getOptions := func() *Options {
+		opts := &Options{
+			FS:                    vfs.NewMem(),
+			L0CompactionThreshold: 10,
+		}
+		opts.private.disableAutomaticCompactions = true
+		return opts
+	}
+	d, err := Open("", getOptions())
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, d.Close())
@@ -75,9 +81,7 @@ func TestManualFlush(t *testing.T) {
 			if err := d.Close(); err != nil {
 				return err.Error()
 			}
-			d, err = Open("", &Options{
-				FS: vfs.NewMem(),
-			})
+			d, err = Open("", getOptions())
 			if err != nil {
 				return err.Error()
 			}

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -596,8 +596,9 @@ func TestIngestError(t *testing.T) {
 
 		inj := errorfs.OnIndex(-1)
 		d, err := Open("", &Options{
-			FS:     errorfs.Wrap(mem, inj),
-			Logger: panicLogger{},
+			FS:                    errorfs.Wrap(mem, inj),
+			Logger:                panicLogger{},
+			L0CompactionThreshold: 8,
 		})
 		require.NoError(t, err)
 		// Force the creation of an L0 sstable that overlaps with the tables

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -184,9 +184,8 @@ func randomOptions(rng *rand.Rand) *testOptions {
 	opts.BytesPerSync = 1 << uint(rng.Intn(28))     // 1B - 256MB
 	opts.Cache = cache.New(1 << uint(rng.Intn(30))) // 1B - 1GB
 	opts.DisableWAL = rng.Intn(2) == 0
-	opts.Experimental.FlushSplitBytes = 1 << rng.Intn(20)       // 1B - 1MB
+	opts.FlushSplitBytes = 1 << rng.Intn(20)       // 1B - 1MB
 	opts.Experimental.L0CompactionConcurrency = 1 + rng.Intn(4) // 1-4
-	opts.Experimental.L0SublevelCompactions = rng.Intn(2) == 0
 	opts.Experimental.MinDeletionRate = 1 << uint(20 + rng.Intn(10)) // 1MB - 1GB
 	opts.L0CompactionThreshold = 1 + rng.Intn(100)                   // 1 - 100
 	opts.L0StopWritesThreshold = 1 + rng.Intn(100)                   // 1 - 100

--- a/level_checker.go
+++ b/level_checker.go
@@ -371,7 +371,7 @@ func checkRangeTombstones(c *checkConfig) error {
 	addTombstonesFromLevel := func(files manifest.LevelIterator, lsmLevel int) error {
 		for f := files.First(); f != nil; f = files.Next() {
 			lf := files.Take()
-			atomicUnit, _ := expandToAtomicUnit(c.cmp, lf.Slice())
+			atomicUnit, _ := expandToAtomicUnit(c.cmp, lf.Slice(), true /* disableIsCompacting */)
 			lower, upper := manifest.KeyRange(c.cmp, atomicUnit.Iter())
 			iterToClose, iter, err := c.newIters(lf.FileMetadata, nil, nil)
 			if err != nil {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -90,7 +90,8 @@ zmemtbl        14    13 B
 
 func TestMetrics(t *testing.T) {
 	d, err := Open("", &Options{
-		FS: vfs.NewMem(),
+		FS:                    vfs.NewMem(),
+		L0CompactionThreshold: 8,
 	})
 	require.NoError(t, err)
 	defer func() {

--- a/options_test.go
+++ b/options_test.go
@@ -50,11 +50,10 @@ func TestOptionsString(t *testing.T) {
   comparer=leveldb.BytewiseComparator
   delete_range_flush_delay=0s
   disable_wal=false
-  flush_split_bytes=0
+  flush_split_bytes=4194304
   l0_compaction_concurrency=10
   l0_compaction_threshold=4
   l0_stop_writes_threshold=12
-  l0_sublevel_compactions=false
   lbase_max_bytes=67108864
   max_concurrent_compactions=1
   max_manifest_file_size=134217728

--- a/testdata/compaction_picker_target_level
+++ b/testdata/compaction_picker_target_level
@@ -141,7 +141,7 @@ base: 6
 
 queue
 ----
-L0->L6: 100.0
+L0->L6: 200.0
 
 init 1
 0: 5
@@ -153,7 +153,7 @@ base: 6
 
 queue
 ----
-L0->L6: 125.0
+L0->L6: 250.0
 
 init 1
 0: 5
@@ -224,30 +224,15 @@ base: 4
 
 queue
 ----
-L0->L4: 500.0
-L0->L0: 4.8
+L0->L4: 1000.0
 
 pick
 ----
-L0->L4: 500.0
+L0->L4: 1000.0
 
 pick ongoing=(0,4)
 ----
-L0->L0: 4.8
-
-# An intra-L0 compaction is only queued if there is an in-progress
-# L0->Lbase compaction.
-
-pick ongoing=(0,0)
-----
-L0->L4: 475.0
-
-# Pick another intra-L0 compaction even if there is one already in
-# progress.
-
-pick ongoing=(0,0,0,4)
-----
-L0->L0: 4.5
+no compaction
 
 # We'll only pick a concurrent compaction if it is "high" priority
 # (i.e. has a score >= highPriorityThreshold).
@@ -264,16 +249,15 @@ base: 4
 
 queue
 ----
-L0->L4: 500.0
-L0->L0: 4.8
+L0->L4: 1000.0
 
 pick ongoing=(0,4,4,5)
 ----
-L0->L0: 4.8
+no compaction
 
 pick ongoing=(4,5)
 ----
-L0->L4: 500.0
+L0->L4: 1000.0
 
 # Verify we can start concurrent Ln->Ln+1 compactions given sufficient
 # priority.

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -155,7 +155,7 @@ metrics
 ----
 __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___r-amp___w-amp
     WAL         1    27 B       -    48 B       -       -       -       -   108 B       -       -       -     2.2
-      0         2   1.6 K    0.50    81 B   825 B       1     0 B       0   2.3 K       3     0 B       2    28.5
+      0         2   1.6 K    0.40    81 B   825 B       1     0 B       0   2.3 K       3     0 B       2    28.5
       1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       2         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       3         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -592,7 +592,7 @@ a:3
 # sstable after the next point key is added, rather than continuing to
 # add keys indefinitely (or till the size limit is reached).
 
-define target-file-sizes=(1, 1, 52) snapshots=(2)
+define target-file-sizes=(100, 1, 52) snapshots=(2)
 L1
   a.SET.3:3
   b.RANGEDEL.3:e

--- a/tool/db.go
+++ b/tool/db.go
@@ -302,6 +302,9 @@ type nonReadOnly struct{}
 
 func (n nonReadOnly) apply(opts *pebble.Options) {
 	opts.ReadOnly = false
+	// Increase the L0 compaction threshold to reduce the likelihood of an
+	// unintended compaction changing test output.
+	opts.L0CompactionThreshold = 10
 }
 
 func (d *dbT) runCheckpoint(cmd *cobra.Command, args []string) {
@@ -475,7 +478,7 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 				d.fmtValue.setForComparer(ve.ComparerName, d.comparers)
 			}
 		}
-		v, _, err := bve.Apply(nil /* version */, cmp.Compare, d.fmtKey.fn, d.opts.Experimental.FlushSplitBytes)
+		v, _, err := bve.Apply(nil /* version */, cmp.Compare, d.fmtKey.fn, d.opts.FlushSplitBytes)
 		if err != nil {
 			return err
 		}

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -12,7 +12,7 @@ db lsm
 ----
 __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___r-amp___w-amp
     WAL         1     0 B       -     0 B       -       -       -       -     0 B       -       -       -     0.0
-      0         1   986 B    0.25     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      0         1   986 B    0.50     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       2         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       3         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0

--- a/version_set.go
+++ b/version_set.go
@@ -274,7 +274,7 @@ func (vs *versionSet) load(dirname string, opts *Options, mu *sync.Mutex) error 
 	}
 	vs.markFileNumUsed(vs.minUnflushedLogNum)
 
-	newVersion, _, err := bve.Apply(nil, vs.cmp, opts.Comparer.FormatKey, opts.Experimental.FlushSplitBytes)
+	newVersion, _, err := bve.Apply(nil, vs.cmp, opts.Comparer.FormatKey, opts.FlushSplitBytes)
 	if err != nil {
 		return err
 	}
@@ -407,7 +407,7 @@ func (vs *versionSet) logAndApply(
 		}
 
 		var err error
-		newVersion, zombies, err = bve.Apply(currentVersion, vs.cmp, vs.opts.Comparer.FormatKey, vs.opts.Experimental.FlushSplitBytes)
+		newVersion, zombies, err = bve.Apply(currentVersion, vs.cmp, vs.opts.Comparer.FormatKey, vs.opts.FlushSplitBytes)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Now that sublevel compactions (and flush splits) have shipped
in one stable release, it's worthwhile to move the `FlushSplitBytes`
parameter out of the Experimental sub-struct, have it default to
2*L0 Target file size (same as Cockroach), and make sublevel
compactions the only supported option.

A lot of test changes to account for the sublevel compactions /
flush split default world. L0 Compaction threshold was bumped up
in some tests to account for the fact that sublevel compactions
multiply sublevel count by 2, instead of just looking at file count.