### PR TITLE
db: fix flaky TestCompactionTombstoneElisionOnly

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1585,6 +1585,7 @@ func TestCompactionTombstoneElisionOnly(t *testing.T) {
 
 			case "maybe-compact":
 				d.mu.Lock()
+				d.opts.private.disableAutomaticCompactions = false
 				d.maybeScheduleCompaction()
 				s := compactionString()
 				d.mu.Unlock()

--- a/data_test.go
+++ b/data_test.go
@@ -370,6 +370,15 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 				}
 				levelMaxBytes[level] = size
 			}
+		case "auto-compactions":
+			switch arg.Vals[0] {
+			case "off":
+				opts.private.disableAutomaticCompactions = true
+			case "on":
+				opts.private.disableAutomaticCompactions = false
+			default:
+				return nil, errors.Errorf("Unrecognized %q %q arg value: %q", td.Cmd, arg.Key, arg.Vals[0])
+			}
 		default:
 			return nil, errors.Errorf("%s: unknown arg: %s", td.Cmd, arg.Key)
 		}

--- a/testdata/compaction_tombstone_elision_only
+++ b/testdata/compaction_tombstone_elision_only
@@ -151,7 +151,9 @@ close-snapshot
 # Test a table that contains both deletions and non-deletions, but whose
 # deletions remove the non-deletions. Set L5's max bytes low so that an
 # automatic compaction will be pursued when we call maybe-compact.
-define snapshots=(103) level-max-bytes=(L5 : 1000)
+# Automatic compactions need to be disabled to prevent a race where an
+# automatic compaction compacts before we've closen the snapshot.
+define snapshots=(103) level-max-bytes=(L5 : 1000) auto-compactions=off
 L5
 b.SET.200:<largeval> bb.SET.203:<largeval> cc.SET.204:<largeval>
 L5


### PR DESCRIPTION
Automatic compactions might pursue a compaction before the call to
`maybe-compact`.