### PR TITLE
*: Introduce read triggered compaction heuristic

### DIFF
--- a/cmd/pebble/compact.go
+++ b/cmd/pebble/compact.go
@@ -240,7 +240,7 @@ func runReplay(cmd *cobra.Command, args []string) error {
 		// read amplification.
 		var bve manifest.BulkVersionEdit
 		bve.Accumulate(&li.ve)
-		ref, _, err = bve.Apply(ref, mvccCompare, nil, 0)
+		ref, _, err = bve.Apply(ref, mvccCompare, nil, 0, 0)
 		if err != nil {
 			return err
 		}

--- a/db.go
+++ b/db.go
@@ -310,6 +310,9 @@ type DB struct {
 			manual []*manualCompaction
 			// inProgress is the set of in-progress flushes and compactions.
 			inProgress map[*compaction]struct{}
+			// readCompactions is a list of read triggered compactions. The next
+			// compaction to perform is as the start. New entries are added to the end.
+			readCompactions []readCompaction
 		}
 
 		cleaner struct {

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -46,7 +46,7 @@ func readManifest(filename string) (*Version, error) {
 		if err := bve.Accumulate(&ve); err != nil {
 			return nil, err
 		}
-		if v, _, err = bve.Apply(v, base.DefaultComparer.Compare, base.DefaultFormatter, 10<<20); err != nil {
+		if v, _, err = bve.Apply(v, base.DefaultComparer.Compare, base.DefaultFormatter, 10<<20, 32000); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/manifest/level.go
+++ b/internal/manifest/level.go
@@ -23,6 +23,11 @@ func makeLevel(level, sublevel int) Level {
 	return Level(((sublevel + 1) << levelBits) | level)
 }
 
+// LevelToInt returns the int representation of a Level
+func LevelToInt(l Level) int {
+	return int(l) & levelMask
+}
+
 // L0Sublevel returns a Level representing the specified L0 sublevel.
 func L0Sublevel(sublevel int) Level {
 	if sublevel < 0 {

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -96,10 +96,18 @@ type FileMetadata struct {
 	// is true and IsIntraL0Compacting is false for an L0 file, the file must
 	// be part of a compaction to Lbase.
 	IsIntraL0Compacting bool
-	subLevel            int
-	l0Index             int
-	minIntervalIndex    int
-	maxIntervalIndex    int
+	// Fields inside the Atomic struct should be accessed atomically.
+	Atomic struct {
+		// AllowedSeeks is used to determine if a file should be picked for
+		// a read triggered compaction. It is decremented when read sampling
+		// in pebble.Iterator after every after every positioning operation
+		// that returns a user key (eg. Next, Prev, SeekGE, SeekLT, etc).
+		AllowedSeeks int64
+	}
+	subLevel         int
+	l0Index          int
+	minIntervalIndex int
+	maxIntervalIndex int
 
 	// True if user asked us to compact this file. This flag is only set and
 	// respected by RocksDB but exists here to preserve its value in the
@@ -258,10 +266,7 @@ const NumLevels = 7
 // NewVersion constructs a new Version with the provided files. It requires
 // the provided files are already well-ordered. It's intended for testing.
 func NewVersion(
-	cmp Compare,
-	formatKey base.FormatKey,
-	flushSplitBytes int64,
-	files [NumLevels][]*FileMetadata,
+	cmp Compare, formatKey base.FormatKey, flushSplitBytes int64, files [NumLevels][]*FileMetadata,
 ) *Version {
 	var v Version
 	for l := range files {

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -352,7 +352,7 @@ func TestVersionEditApply(t *testing.T) {
 				if err := bve.Accumulate(ve); err != nil {
 					return err.Error()
 				}
-				newv, zombies, err := bve.Apply(v, base.DefaultComparer.Compare, base.DefaultFormatter, 10<<20)
+				newv, zombies, err := bve.Apply(v, base.DefaultComparer.Compare, base.DefaultFormatter, 10<<20, 32000)
 				if err != nil {
 					return err.Error()
 				}

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -1062,3 +1062,13 @@ func (m *mergingIter) DebugString() string {
 	}
 	return buf.String()
 }
+
+func (m *mergingIter) ForEachLevelIter(fn func(li *levelIter) bool) {
+	for _, iter := range m.levels {
+		if li, ok := iter.iter.(*levelIter); ok {
+			if done := fn(li); done {
+				break
+			}
+		}
+	}
+}

--- a/testdata/compaction_picker_read_triggered
+++ b/testdata/compaction_picker_read_triggered
@@ -1,0 +1,108 @@
+# Verify that pickAuto picks read triggered compactions that are scheduled and LSM is in good shape. This ensures
+# that read triggered compactions are lower priority than score based ones. This also verifies that only the files
+# within the range set in a readCompaction are chosen for compaction.
+define
+L5
+  000101:a.SET.11-f.SET.12 size=10
+  000102:g.SET.11-l.SET.12 size=10
+L6
+  000010:a.SET.1-f.SET.2 size=100
+  000011:g.SET.1-l.SET.2 size=100
+----
+5:
+  000101:[a#11,SET-f#12,SET]
+  000102:[g#11,SET-l#12,SET]
+6:
+  000010:[a#1,SET-f#2,SET]
+  000011:[g#1,SET-l#2,SET]
+
+pick-auto
+----
+nil
+
+add-read-compaction
+5: a-f
+----
+
+show-read-compactions
+----
+(level: 5, start: a, end: f)
+
+pick-auto
+----
+L5 -> L6
+L5: 000101
+L6: 000010
+
+show-read-compactions
+----
+(none)
+
+
+# Verify that pickAuto does not pick read triggered compactions when the LSM is in bad shape and instead schedules a
+# score-based one.
+define
+L5
+  000101:a.SET.11-f.SET.12 size=1000000000
+L6
+  000010:a.SET.1-f.SET.2 size=1000000000
+----
+5:
+  000101:[a#11,SET-f#12,SET]
+6:
+  000010:[a#1,SET-f#2,SET]
+
+add-read-compaction
+5: a-f
+----
+
+show-read-compactions
+----
+(level: 5, start: a, end: f)
+
+pick-auto
+----
+L5 -> L6
+L5: 000101
+L6: 000010
+
+show-read-compactions
+----
+(level: 5, start: a, end: f)
+
+
+# Test case where there is mismatch in the level of chosen read compaction and current version, but the correct target
+# file is in L0. PickReadTriggeredCompaction should be able to handle this and the L0 file that overlaps in the same
+# key range to compact.
+define
+L0
+  010001:a.SET.11-b.SET.12 size=10
+L5
+  000101:a.SET.11-d.SET.12 size=100
+L6
+  000010:a.SET.1-e.SET.2 size=1000
+----
+0.0:
+  010001:[a#11,SET-b#12,SET]
+5:
+  000101:[a#11,SET-d#12,SET]
+6:
+  000010:[a#1,SET-e#2,SET]
+
+add-read-compaction
+4: a-b
+----
+
+show-read-compactions
+----
+(level: 4, start: a, end: b)
+
+pick-auto
+----
+L0 -> L5
+L0: 010001
+L5: 000101
+
+show-read-compactions
+----
+(none)

--- a/testdata/compaction_read_triggered
+++ b/testdata/compaction_read_triggered
@@ -1,0 +1,172 @@
+# A simple case of read compaction, 2 files in different levels with overlapping ranges
+define
+L5
+a.SET.55:a b.SET.5:b
+L6
+a.SET.55:a b.SET.5:b
+----
+5:
+  000004:[a#55,SET-b#5,SET]
+6:
+  000005:[a#55,SET-b#5,SET]
+
+add-read-compaction
+5: a-b
+----
+
+show-read-compactions
+----
+(level: 5, start: a, end: b)
+
+maybe-compact
+----
+[JOB 100] compacted L5 [000004] (784 B) + L6 [000005] (784 B) -> L6 [000006] (778 B), in 1.0s, output rate 778 B/s
+
+show-read-compactions
+----
+(none)
+
+version
+----
+6:
+  000006:[a#0,SET-b#0,SET]
+
+# Check to make sure another compaction will not take place
+
+maybe-compact
+----
+(none)
+
+
+# Test case where there is mismatch in the level of chosen read compaction and current version.
+# PickReadTriggeredCompaction should be able to handle this and pick the next file that overlaps in the same key range to compact.
+define
+L5
+a.SET.55:a b.SET.5:b
+L6
+a.SET.55:a b.SET.5:b
+----
+5:
+  000004:[a#55,SET-b#5,SET]
+6:
+  000005:[a#55,SET-b#5,SET]
+
+add-read-compaction
+4: a-b
+----
+
+show-read-compactions
+----
+(level: 4, start: a, end: b)
+
+maybe-compact
+----
+[JOB 100] compacted L5 [000004] (784 B) + L6 [000005] (784 B) -> L6 [000006] (778 B), in 1.0s, output rate 778 B/s
+
+show-read-compactions
+----
+(none)
+
+version
+----
+6:
+  000006:[a#0,SET-b#0,SET]
+
+# Check to make sure another compaction will not take place
+
+maybe-compact
+----
+(none)
+
+
+# Test case where there is mismatch in the level of chosen read compaction and current version, but NO overlaps
+# No compaction should take place
+define
+L5
+a.SET.55:a b.SET.5:b
+L6
+d.SET.55:d e.SET.5:e
+----
+5:
+  000004:[a#55,SET-b#5,SET]
+6:
+  000005:[d#55,SET-e#5,SET]
+
+add-read-compaction
+4: a-b
+----
+
+show-read-compactions
+----
+(level: 4, start: a, end: b)
+
+maybe-compact
+----
+(none)
+
+show-read-compactions
+----
+(none)
+
+version
+----
+5:
+  000004:[a#55,SET-b#5,SET]
+6:
+  000005:[d#55,SET-e#5,SET]
+
+
+# Case where there is an in-progress flush. No compaction should occur while flushing is true.
+define
+L5
+a.SET.55:a b.SET.5:b
+L6
+a.SET.55:a b.SET.5:b
+----
+5:
+  000004:[a#55,SET-b#5,SET]
+6:
+  000005:[a#55,SET-b#5,SET]
+
+add-read-compaction flushing=true
+5: a-b
+----
+
+show-read-compactions
+----
+(level: 5, start: a, end: b)
+
+maybe-compact
+----
+(none)
+
+show-read-compactions
+----
+(level: 5, start: a, end: b)
+
+version
+----
+5:
+  000004:[a#55,SET-b#5,SET]
+6:
+  000005:[a#55,SET-b#5,SET]
+
+add-read-compaction flushing=false
+----
+
+show-read-compactions
+----
+(level: 5, start: a, end: b)
+
+maybe-compact
+----
+[JOB 100] compacted L5 [000004] (784 B) + L6 [000005] (784 B) -> L6 [000006] (778 B), in 1.0s, output rate 778 B/s
+
+show-read-compactions
+----
+(none)
+
+version
+----
+6:
+  000006:[a#0,SET-b#0,SET]

--- a/testdata/iterator_read_sampling
+++ b/testdata/iterator_read_sampling
@@ -1,0 +1,299 @@
+# Test with overlapping keys across levels, should pick top level to compact after allowed-seeks goes to 0
+# Verify that Iterator.First(), Iterator.SeekGE() and Iterator.Next() call maybe sample read.
+define auto-compactions=off
+L0
+  a.SET.4:4
+L1
+  a.SET.3:3
+L2
+  d.SET.2:2
+L3
+  d.SET.1:1
+----
+0.0:
+  000004:[a#4,SET-a#4,SET]
+1:
+  000005:[a#3,SET-a#3,SET]
+2:
+  000006:[d#2,SET-d#2,SET]
+3:
+  000007:[d#1,SET-d#1,SET]
+
+set allowed-seeks=2
+----
+
+
+iter
+first
+----
+a:4
+
+iter-read-compactions
+----
+(none)
+
+iter
+first
+----
+a:4
+
+iter-read-compactions
+----
+(level: 0, start: a, end: a)
+
+read-compactions
+----
+(none)
+
+close-iter
+----
+
+read-compactions
+----
+(level: 0, start: a, end: a)
+
+iter
+seek-ge d
+----
+d:2
+
+iter
+prev
+----
+a:4
+
+iter
+next
+----
+d:2
+
+iter-read-compactions
+----
+(level: 2, start: d, end: d)
+
+close-iter
+----
+
+read-compactions
+----
+(level: 0, start: a, end: a)
+(level: 2, start: d, end: d)
+
+
+
+# Verify that Iterator.Last(), Iterator.SeekLT() and Iterator.Prev() call maybe sample read.
+define auto-compactions=off
+L0
+  a.SET.4:4
+  c.SET.8:8
+L1
+  a.SET.3:3
+  c.SET.9:9
+L2
+  d.SET.2:2
+  l.SET.7:7
+L3
+  d.SET.1:1
+  l.SET.8:8
+----
+0.0:
+  000004:[a#4,SET-c#8,SET]
+1:
+  000005:[a#3,SET-c#9,SET]
+2:
+  000006:[d#2,SET-l#7,SET]
+3:
+  000007:[d#1,SET-l#8,SET]
+
+set allowed-seeks=2
+----
+
+
+iter
+last
+----
+l:8
+
+iter-read-compactions
+----
+(none)
+
+iter
+last
+----
+l:8
+
+iter-read-compactions
+----
+(level: 2, start: d, end: l)
+
+read-compactions
+----
+(none)
+
+close-iter
+----
+
+read-compactions
+----
+(level: 2, start: d, end: l)
+
+iter
+seek-lt d
+----
+c:9
+
+iter
+next
+----
+d:2
+
+iter
+prev
+----
+c:9
+
+iter-read-compactions
+----
+(level: 0, start: a, end: c)
+
+close-iter
+----
+
+read-compactions
+----
+(level: 2, start: d, end: l)
+(level: 0, start: a, end: c)
+
+
+# For Iterator.Last(), Iterator.SeekLT() and Iterator.Prev(), if the key is the first key of the file or
+# the only key, sampling skips it because the iterator has already moved past it.
+define auto-compactions=off
+L0
+  a.SET.4:4
+L1
+  a.SET.3:3
+L2
+  d.SET.2:2
+L3
+  d.SET.1:1
+----
+0.0:
+  000004:[a#4,SET-a#4,SET]
+1:
+  000005:[a#3,SET-a#3,SET]
+2:
+  000006:[d#2,SET-d#2,SET]
+3:
+  000007:[d#1,SET-d#1,SET]
+
+set allowed-seeks=2
+----
+
+
+iter
+last
+----
+d:2
+
+iter-read-compactions
+----
+(none)
+
+iter
+last
+----
+d:2
+
+iter-read-compactions
+----
+(none)
+
+read-compactions
+----
+(none)
+
+close-iter
+----
+
+read-compactions
+----
+(none)
+
+iter
+seek-lt d
+----
+a:4
+
+iter
+next
+----
+d:2
+
+iter
+prev
+----
+a:4
+
+iter-read-compactions
+----
+(none)
+
+close-iter
+----
+
+read-compactions
+----
+(none)
+
+
+
+
+# Test with no overlapping keys across levels, should not pick any compaction
+define auto-compactions=off
+L0
+  a.SET.4:4
+L1
+  b.SET.3:3
+L2
+  c.SET.2:2
+L3
+  d.SET.1:1
+----
+0.0:
+  000004:[a#4,SET-a#4,SET]
+1:
+  000005:[b#3,SET-b#3,SET]
+2:
+  000006:[c#2,SET-c#2,SET]
+3:
+  000007:[d#1,SET-d#1,SET]
+
+set allowed-seeks=3
+----
+
+iter
+first
+----
+a:4
+
+iter
+first
+----
+a:4
+
+iter
+first
+----
+a:4
+
+iter-read-compactions
+----
+(none)
+
+close-iter
+----
+
+read-compactions
+----
+(none)

--- a/tool/db.go
+++ b/tool/db.go
@@ -478,7 +478,7 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 				d.fmtValue.setForComparer(ve.ComparerName, d.comparers)
 			}
 		}
-		v, _, err := bve.Apply(nil /* version */, cmp.Compare, d.fmtKey.fn, d.opts.FlushSplitBytes)
+		v, _, err := bve.Apply(nil /* version */, cmp.Compare, d.fmtKey.fn, d.opts.FlushSplitBytes, d.opts.Experimental.ReadCompactionRate)
 		if err != nil {
 			return err
 		}

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -200,7 +200,7 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 			}
 
 			if cmp != nil {
-				v, _, err := bve.Apply(nil /* version */, cmp.Compare, m.fmtKey.fn, 0)
+				v, _, err := bve.Apply(nil /* version */, cmp.Compare, m.fmtKey.fn, 0, m.opts.Experimental.ReadCompactionRate)
 				if err != nil {
 					fmt.Fprintf(stdout, "%s\n", err)
 					return
@@ -277,7 +277,7 @@ func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
 				}
 				// TODO(sbhola): add option to Apply that reports all errors instead of
 				// one error.
-				newv, _, err := bve.Apply(v, cmp.Compare, m.fmtKey.fn, 0)
+				newv, _, err := bve.Apply(v, cmp.Compare, m.fmtKey.fn, 0, m.opts.Experimental.ReadCompactionRate)
 				if err != nil {
 					fmt.Fprintf(stdout, "%s: offset: %d err: %s\n",
 						arg, offset, err)

--- a/version_set.go
+++ b/version_set.go
@@ -274,7 +274,7 @@ func (vs *versionSet) load(dirname string, opts *Options, mu *sync.Mutex) error 
 	}
 	vs.markFileNumUsed(vs.minUnflushedLogNum)
 
-	newVersion, _, err := bve.Apply(nil, vs.cmp, opts.Comparer.FormatKey, opts.FlushSplitBytes)
+	newVersion, _, err := bve.Apply(nil, vs.cmp, opts.Comparer.FormatKey, opts.FlushSplitBytes, opts.Experimental.ReadCompactionRate)
 	if err != nil {
 		return err
 	}
@@ -407,7 +407,7 @@ func (vs *versionSet) logAndApply(
 		}
 
 		var err error
-		newVersion, zombies, err = bve.Apply(currentVersion, vs.cmp, vs.opts.Comparer.FormatKey, vs.opts.FlushSplitBytes)
+		newVersion, zombies, err = bve.Apply(currentVersion, vs.cmp, vs.opts.Comparer.FormatKey, vs.opts.FlushSplitBytes, vs.opts.Experimental.ReadCompactionRate)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Previously, our compactions were triggered on write based heuristics.
This change introduces compactions based on high read activity to improve
read performance in read-heavy workloads. It is inspired from LevelDB's
read based compaction heuristic which is outlined in the following issue:
https://github.com/cockroachdb/pebble/issues/29.

These compactions are triggered using an `AllowedSeeks` parameter on
each file's `FileMetadata`. Reads are sampled based on a rate defined in
`iterator.MaybeSampleRead()`. If a read is sampled, `AllowedSeeks` is
decremented on the file in the top-most level containing the key. Once
`AllowedSeeks` reaches 0, a compaction for the key range is scheduled.

Read triggered compactions are only considered if no other compaction is
possible at the time. This helps prioritize score based compactions to
maintain a healthy LSM shape.

The results of this change in benchmarks are outlined in the github
issue: https://github.com/cockroachdb/pebble/issues/29.

Fixes https://github.com/cockroachdb/pebble/issues/29.