### PR TITLE
internal/cache: fix memory corruption when CGO_ENABLED=0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ matrix:
       go: 1.15.x
       os: linux
       script: make test TAGS=
+    - name: "go1.15.x-linux-no-cgo"
+      go: 1.15.x
+      os: linux
+      script: CGO_ENABLED=0 make test TAGS=
     - name: "go1.15.x-darwin"
       go: 1.15.x
       os: osx

--- a/internal/cache/cgo_disabled.go
+++ b/internal/cache/cgo_disabled.go
@@ -1,0 +1,9 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build !cgo
+
+package cache
+
+const cgoEnabled = false

--- a/internal/cache/cgo_enabled.go
+++ b/internal/cache/cgo_enabled.go
@@ -1,0 +1,9 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build cgo
+
+package cache
+
+const cgoEnabled = true

--- a/internal/cache/entry_normal.go
+++ b/internal/cache/entry_normal.go
@@ -21,7 +21,11 @@ const (
 	// Avoid using runtime.SetFinalizer in race builds as finalizers tickle a bug
 	// in the Go race detector in go1.15 and earlier versions. This requires that
 	// entries are Go allocated rather than manually allocated.
-	entriesGoAllocated = invariants.RaceEnabled
+	//
+	// If cgo is disabled we need to allocate the entries using the Go allocator
+	// and is violates the Go GC rules to put Go pointers (such as the entry
+	// pointer fields) into untyped memory (i.e. a []byte).
+	entriesGoAllocated = invariants.RaceEnabled || !cgoEnabled
 )
 
 var entryAllocPool = sync.Pool{


### PR DESCRIPTION
If cgo is disabled, `manual.New` allocates memory using
`make([]byte,...)`. The cache was using this memory as if it was
manually allocated, and casting it to Go structs and then storing Go
pointers inside the structs. But a Go pointer stored inside of a
`[]byte` is invisible to the Go GC, so the GC was merrily reclaiming the
memory which would lead to all sorts of badness in the cache, often
resulting in segfaults or violations of refcount invariants.

Now, when cgo is disabled, the `entry` and `Value` structs are directly
allocated using the Go allocator. The cache code mostly supported this
mode of operation already when the `invariants` tag. The difference
between disabling cgo and enabling invariants is that the latter also
has the effect of adding the finalizers uses for leak detection.

Fixes #1010