### PR TITLE
vfs: prevent double locking from the same process

### DIFF
--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -90,7 +90,7 @@ type FS interface {
 	// file will release the lock prematurely.
 	//
 	// Attempting to lock a file that is already locked by the current process
-	// has undefined behavior.
+	// returns an error and leaves the existing lock untouched.
 	//
 	// Lock is not yet implemented on other operating systems, and calling it
 	// will return an error.


### PR DESCRIPTION
The behavior of vfs.Default.Lock-ing the same file twice was undefined
in the VFS interface. In practice, on Unix the lock would be dropped
because closing the second attempt's file descriptor would release the
first file descriptor's hold on the lock.

I don't believe this to have caused any problems in practice, but it
seems prudent to handle this case, because transparently dropped locks
are difficult to debug.

This was inspired by facebook/rocksdb#1780 and the associated fix.