### PR TITLE
internal/base: provide more context in MustExist

### DIFF
--- a/db.go
+++ b/db.go
@@ -1378,8 +1378,10 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 				if recycleLogNum > 0 {
 					recycleLogName := base.MakeFilename(d.opts.FS, d.walDirname, fileTypeLog, recycleLogNum)
 					newLogFile, err = d.opts.FS.ReuseForWrite(recycleLogName, newLogName)
+					base.MustExist(d.opts.FS, newLogName, d.opts.Logger, err)
 				} else {
 					newLogFile, err = d.opts.FS.Create(newLogName)
+					base.MustExist(d.opts.FS, newLogName, d.opts.Logger, err)
 				}
 			}
 

--- a/internal/base/filenames_test.go
+++ b/internal/base/filenames_test.go
@@ -98,8 +98,8 @@ func TestMustExist(t *testing.T) {
 	var buf bufferFataler
 	filename := fs.PathJoin("..", "..", "testdata", "db-stage-4", "000000.sst")
 
-	MustExist(vfs.Default, filename, &buf, err)
+	MustExist(fs, filename, &buf, err)
 	require.Equal(t, `000000.sst:
 file does not exist
-directory contains 10 files, 3 unknown, 1 tables, 1 logs`, buf.buf.String())
+directory contains 10 files, 3 unknown, 1 tables, 1 logs, 1 manifests`, buf.buf.String())
 }


### PR DESCRIPTION
Provide a little more context in base.MustExist, by reporting the count
of manifests. Also, call MustExist from `makeRoomForWrite` to get
context during failed log rotations.