### PR TITLE
crl-release-20.2: internal/base: provide more context in MustExist

### DIFF
--- a/db.go
+++ b/db.go
@@ -1337,8 +1337,10 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 				if recycleLogNum > 0 {
 					recycleLogName := base.MakeFilename(d.opts.FS, d.walDirname, fileTypeLog, recycleLogNum)
 					newLogFile, err = d.opts.FS.ReuseForWrite(recycleLogName, newLogName)
+					base.MustExist(d.opts.FS, newLogName, d.opts.Logger, err)
 				} else {
 					newLogFile, err = d.opts.FS.Create(newLogName)
+					base.MustExist(d.opts.FS, newLogName, d.opts.Logger, err)
 				}
 			}
 

--- a/internal/base/filenames.go
+++ b/internal/base/filenames.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/cockroachdb/redact"
 )
 
 // FileNum is an internal DB indentifier for a file.
@@ -124,9 +125,13 @@ func MustExist(fs vfs.FS, filename string, fataler Fataler, err error) {
 
 	ls, lsErr := fs.List(fs.PathDir(filename))
 	if lsErr != nil {
-		fataler.Fatalf("%s:\n%s\n%s", fs.PathBase(filename), err, lsErr)
+		// TODO(jackson): if oserror.IsNotExist(lsErr), the the data directory
+		// doesn't exist anymore. Another process likely deleted it before
+		// killing the process. We want to fatal the process, but without
+		// triggering error reporting like Sentry.
+		fataler.Fatalf("%s:\norig err: %s\nlist err: %s", redact.Safe(fs.PathBase(filename)), err, lsErr)
 	}
-	var total, unknown, tables, logs int
+	var total, unknown, tables, logs, manifests int
 	total = len(ls)
 	for _, f := range ls {
 		typ, _, ok := ParseFilename(fs, f)
@@ -139,9 +144,11 @@ func MustExist(fs vfs.FS, filename string, fataler Fataler, err error) {
 			tables++
 		case FileTypeLog:
 			logs++
+		case FileTypeManifest:
+			manifests++
 		}
 	}
 
-	fataler.Fatalf("%s:\n%s\ndirectory contains %d files, %d unknown, %d tables, %d logs",
-		fs.PathBase(filename), err, total, unknown, tables, logs)
+	fataler.Fatalf("%s:\n%s\ndirectory contains %d files, %d unknown, %d tables, %d logs, %d manifests",
+		fs.PathBase(filename), err, total, unknown, tables, logs, manifests)
 }

--- a/internal/base/filenames_test.go
+++ b/internal/base/filenames_test.go
@@ -98,8 +98,8 @@ func TestMustExist(t *testing.T) {
 	var buf bufferFataler
 	filename := fs.PathJoin("..", "..", "testdata", "db-stage-4", "000000.sst")
 
-	MustExist(vfs.Default, filename, &buf, err)
+	MustExist(fs, filename, &buf, err)
 	require.Equal(t, `000000.sst:
 file does not exist
-directory contains 10 files, 3 unknown, 1 tables, 1 logs`, buf.buf.String())
+directory contains 10 files, 3 unknown, 1 tables, 1 logs, 1 manifests`, buf.buf.String())
 }


### PR DESCRIPTION
Provide a little more context in base.MustExist, by reporting the count
of manifests. Also, call MustExist from `makeRoomForWrite` to get
context during failed log rotations.

20.2 backport of #1014. 