### PR TITLE
db: add point tombstone compensation

### DIFF
--- a/cmd/pebble/rocksdb.go
+++ b/cmd/pebble/rocksdb.go
@@ -404,7 +404,7 @@ func (b crdbPebbleDBBatch) Set(key, value []byte, _ *pebble.WriteOptions) error 
 	return b.batch.Put(storage.MVCCKey{Key: userKey, Timestamp: ts}, value)
 }
 
-func (b crdbPebbleDBBatch) Delete(data []byte, _ *pebble.WriteOptions) error {
+func (b crdbPebbleDBBatch) Delete(key []byte, _ *pebble.WriteOptions) error {
 	userKey, _, ok := mvccSplitKey(key)
 	if !ok {
 		panic("mvccSplitKey failed")

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -442,7 +442,8 @@ type candidateLevelInfo struct {
 func compensatedSize(f *fileMetadata) uint64 {
 	sz := f.Size
 	// Add in the estimate of disk space that may be reclaimed by compacting
-	// the file's range tombstones.
+	// the file's tombstones.
+	sz += f.Stats.PointDeletionsBytesEstimate
 	sz += f.Stats.RangeDeletionsBytesEstimate
 	return sz
 }

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1531,7 +1531,7 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 		})
 }
 
-func TestCompactionTombstoneElisionOnly(t *testing.T) {
+func TestCompactionTombstones(t *testing.T) {
 	var d *DB
 	var compactInfo *CompactionInfo // protected by d.mu
 
@@ -1551,7 +1551,7 @@ func TestCompactionTombstoneElisionOnly(t *testing.T) {
 		return s
 	}
 
-	datadriven.RunTest(t, "testdata/compaction_tombstone_elision_only",
+	datadriven.RunTest(t, "testdata/compaction_tombstones",
 		func(td *datadriven.TestData) string {
 			switch td.Cmd {
 			case "define":

--- a/data_test.go
+++ b/data_test.go
@@ -561,6 +561,7 @@ func runTableStatsCmd(td *datadriven.TestData, d *DB) string {
 			var b bytes.Buffer
 			fmt.Fprintf(&b, "num-entries: %d\n", f.Stats.NumEntries)
 			fmt.Fprintf(&b, "num-deletions: %d\n", f.Stats.NumDeletions)
+			fmt.Fprintf(&b, "point-deletions-bytes-estimate: %d\n", f.Stats.PointDeletionsBytesEstimate)
 			fmt.Fprintf(&b, "range-deletions-bytes-estimate: %d\n", f.Stats.RangeDeletionsBytesEstimate)
 			return b.String()
 		}

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -48,6 +48,9 @@ type TableStats struct {
 	// The number of point and range deletion entries in the table.
 	NumDeletions uint64
 	// Estimate of the total disk space that may be dropped by this table's
+	// point deletions by compacting them.
+	PointDeletionsBytesEstimate uint64
+	// Estimate of the total disk space that may be dropped by this table's
 	// range deletions by compacting them. This estimate is at data-block
 	// granularity and is not updated if compactions beneath the table reduce
 	// the amount of reclaimable disk space. It also does not account for

--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -142,6 +142,11 @@ type Properties struct {
 	Loaded map[uintptr]struct{}
 }
 
+// NumPointDeletions returns the number of point deletions in this table.
+func (p *Properties) NumPointDeletions() uint64 {
+	return p.NumDeletions - p.NumRangeDeletions
+}
+
 func (p *Properties) String() string {
 	var buf bytes.Buffer
 	v := reflect.ValueOf(*p)

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -76,7 +76,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 1
-point-deletions-bytes-estimate: 13
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
 maybe-compact
@@ -114,7 +114,7 @@ wait-pending-table-stats
 ----
 num-entries: 6
 num-deletions: 2
-point-deletions-bytes-estimate: 13
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 76
 
 maybe-compact
@@ -146,7 +146,7 @@ wait-pending-table-stats
 ----
 num-entries: 11
 num-deletions: 1
-point-deletions-bytes-estimate: 13
+point-deletions-bytes-estimate: 149
 range-deletions-bytes-estimate: 0
 
 close-snapshot
@@ -225,7 +225,7 @@ wait-pending-table-stats
 ----
 num-entries: 3
 num-deletions: 3
-point-deletions-bytes-estimate: 6184
+point-deletions-bytes-estimate: 13167
 range-deletions-bytes-estimate: 0
 
 # By plain file size, 000005 should be picked because it is larger and

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -13,6 +13,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 2
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
 maybe-compact
@@ -33,6 +34,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 2
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
 maybe-compact
@@ -52,6 +54,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 26
 
 maybe-compact
@@ -73,6 +76,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 1
+point-deletions-bytes-estimate: 13
 range-deletions-bytes-estimate: 0
 
 maybe-compact
@@ -110,6 +114,7 @@ wait-pending-table-stats
 ----
 num-entries: 6
 num-deletions: 2
+point-deletions-bytes-estimate: 13
 range-deletions-bytes-estimate: 76
 
 maybe-compact
@@ -141,6 +146,7 @@ wait-pending-table-stats
 ----
 num-entries: 11
 num-deletions: 1
+point-deletions-bytes-estimate: 13
 range-deletions-bytes-estimate: 0
 
 close-snapshot
@@ -183,6 +189,7 @@ wait-pending-table-stats
 ----
 num-entries: 5
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 16488
 
 # Because we set max bytes low, maybe-compact will trigger an automatic
@@ -195,3 +202,37 @@ range-deletions-bytes-estimate: 16488
 maybe-compact
 ----
 [JOB 100] compacted L5 [000004 000005] (26 K) + L6 [000007] (17 K) -> L6 [000009] (25 K), in 1.0s, output rate 25 K/s
+
+define level-max-bytes=(L5 : 1000) auto-compactions=off
+L5
+a.DEL.101: b.DEL.102: c.DEL.103:
+L5
+m.SET.107:<largeval>
+L6
+a.SET.001:<largeval> b.SET.002:<largeval> c.SET.003:<largeval>
+L6
+f.SET.007:<largeval> x.SET.008:<largeval> z.SET.009:<largeval>
+----
+5:
+  000004:[a#101,DEL-c#103,DEL]
+  000005:[m#107,SET-m#107,SET]
+6:
+  000006:[a#1,SET-c#3,SET]
+  000007:[f#7,SET-z#9,SET]
+
+wait-pending-table-stats
+000004
+----
+num-entries: 3
+num-deletions: 3
+point-deletions-bytes-estimate: 6184
+range-deletions-bytes-estimate: 0
+
+# By plain file size, 000005 should be picked because it is larger and
+# overlaps the same amount of data in L6. However, 000004 has a high
+# point-deletions-bytes-estimate, and the compaction picker should pick 000004
+# instead.
+
+maybe-compact
+----
+[JOB 100] compacted L5 [000004] (794 B) + L6 [000006] (13 K) -> L6 [] (0 B), in 1.0s, output rate 0 B/s

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -72,6 +72,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 0
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
 build ext1
@@ -341,6 +342,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 2
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 1666
 
 # A set operation takes precedence over a range deletion at the same

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -86,6 +86,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 1552
 
 compact a-e L1
@@ -103,6 +104,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 776
 
 # Same as above, except range tombstone covers multiple grandparent file boundaries.

--- a/testdata/range_del
+++ b/testdata/range_del
@@ -1389,6 +1389,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
 wait-pending-table-stats
@@ -1396,6 +1397,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 836
 
 wait-pending-table-stats
@@ -1403,6 +1405,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 1672
 
 wait-pending-table-stats
@@ -1410,6 +1413,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 2
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 1672
 
 
@@ -1448,6 +1452,7 @@ wait-pending-table-stats
 ----
 num-entries: 4
 num-deletions: 0
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
 wait-pending-table-stats
@@ -1455,6 +1460,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 787
 
 wait-pending-table-stats
@@ -1462,6 +1468,7 @@ wait-pending-table-stats
 ----
 num-entries: 3
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 68
 
 wait-pending-table-stats
@@ -1469,6 +1476,7 @@ wait-pending-table-stats
 ----
 num-entries: 4
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 100
 
 # Multiple Range deletions in a table.
@@ -1503,6 +1511,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 782
 
 wait-pending-table-stats
@@ -1510,6 +1519,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 771
 
 wait-pending-table-stats
@@ -1517,4 +1527,5 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 2
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 1553

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -14,7 +14,7 @@ wait-pending-table-stats
 ----
 num-entries: 3
 num-deletions: 1
-point-deletions-bytes-estimate: 13
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
 compact a-c

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -1,24 +1,26 @@
 batch
 set a 1
 set b 2
+del c
 ----
 
 flush
 ----
 0.0:
-  000005:[a#1,SET-b#2,SET]
+  000005:[a#1,SET-c#3,DEL]
 
 wait-pending-table-stats
 000005
 ----
-num-entries: 2
-num-deletions: 0
+num-entries: 3
+num-deletions: 1
+point-deletions-bytes-estimate: 13
 range-deletions-bytes-estimate: 0
 
 compact a-c
 ----
 6:
-  000005:[a-b]
+  000005:[a-c]
 
 batch
 del-range a c
@@ -27,16 +29,17 @@ del-range a c
 flush
 ----
 0.0:
-  000007:[a#3,RANGEDEL-c#72057594037927935,RANGEDEL]
+  000007:[a#4,RANGEDEL-c#72057594037927935,RANGEDEL]
 6:
-  000005:[a#1,SET-b#2,SET]
+  000005:[a#1,SET-c#3,DEL]
 
 wait-pending-table-stats
 000007
 ----
 num-entries: 1
 num-deletions: 1
-range-deletions-bytes-estimate: 784
+point-deletions-bytes-estimate: 0
+range-deletions-bytes-estimate: 796
 
 reopen
 ----
@@ -53,7 +56,8 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
-range-deletions-bytes-estimate: 784
+point-deletions-bytes-estimate: 0
+range-deletions-bytes-estimate: 796
 
 compact a-c
 ----
@@ -74,7 +78,7 @@ set b 2
 flush
 ----
 0.0:
-  000012:[a#4,SET-b#5,SET]
+  000012:[a#5,SET-b#6,SET]
 
 compact a-c
 ----
@@ -89,6 +93,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 0
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
 # Test a file that is deleted by a compaction before its table stats are
@@ -104,9 +109,9 @@ del-range a c
 flush
 ----
 0.0:
-  000014:[a#6,RANGEDEL-c#72057594037927935,RANGEDEL]
+  000014:[a#7,RANGEDEL-c#72057594037927935,RANGEDEL]
 6:
-  000012:[a#4,SET-b#5,SET]
+  000012:[a#5,SET-b#6,SET]
 
 compact a-c
 ----
@@ -170,6 +175,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 1542
 
 wait-pending-table-stats
@@ -177,6 +183,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 1542
 
 define snapshots=(10)
@@ -191,4 +198,5 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 26

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -311,7 +311,7 @@ func (s *sstableT) runProperties(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(tw, "records\t%d\n", r.Properties.NumEntries)
 		fmt.Fprintf(tw, "  set\t%d\n", r.Properties.NumEntries-
 			(r.Properties.NumDeletions+r.Properties.NumMergeOperands))
-		fmt.Fprintf(tw, "  delete\t%d\n", r.Properties.NumDeletions-r.Properties.NumRangeDeletions)
+		fmt.Fprintf(tw, "  delete\t%d\n", r.Properties.NumPointDeletions())
 		fmt.Fprintf(tw, "  range-delete\t%d\n", r.Properties.NumRangeDeletions)
 		fmt.Fprintf(tw, "  merge\t%d\n", r.Properties.NumMergeOperands)
 		fmt.Fprintf(tw, "  global-seq-num\t%d\n", r.Properties.GlobalSeqNum)


### PR DESCRIPTION
Add an estimate of the disk space that may be reclaimed by compacting
point tombstones to the compensated size used in compaction heuristics.

At the end of a 20-minute test on my gceworker using the tombstone
benchmark, the size of the queue keyspace was 16 M as opposed to 1 G
without this commit.

Fix #1016.