### PR TITLE
cmd/pebble: add tombstone benchmark

### DIFF
--- a/cmd/pebble/badger.go
+++ b/cmd/pebble/badger.go
@@ -138,6 +138,10 @@ func (b badgerBatch) Set(key, value []byte, _ *pebble.WriteOptions) error {
 	return b.txn.Set(key, value)
 }
 
+func (b badgerBatch) Delete(key []byte, _ *pebble.WriteOptions) error {
+	return b.txn.Delete(key)
+}
+
 func (b badgerBatch) LogData(data []byte, _ *pebble.WriteOptions) error {
 	panic("badgerBatch.logData: unimplemented")
 }

--- a/cmd/pebble/boltdb.go
+++ b/cmd/pebble/boltdb.go
@@ -161,6 +161,10 @@ func (b boltDBBatch) Set(key, value []byte, _ *pebble.WriteOptions) error {
 	return b.bucket.Put(key, value)
 }
 
+func (b boltDBBatch) Delete(key []byte, _ *pebble.WriteOptions) error {
+	return b.bucket.Delete(key)
+}
+
 func (b boltDBBatch) LogData(data []byte, _ *pebble.WriteOptions) error {
 	panic("boltDBBatch.logData: unimplemented")
 }

--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -39,6 +39,7 @@ type batch interface {
 	Close() error
 	Commit(opts *pebble.WriteOptions) error
 	Set(key, value []byte, opts *pebble.WriteOptions) error
+	Delete(key []byte, opts *pebble.WriteOptions) error
 	LogData(data []byte, opts *pebble.WriteOptions) error
 }
 

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -39,10 +39,11 @@ func main() {
 		compactRunCmd,
 	)
 	benchCmd.AddCommand(
+		compactCmd,
 		scanCmd,
 		syncCmd,
+		tombstoneCmd,
 		ycsbCmd,
-		compactCmd,
 	)
 
 	rootCmd := &cobra.Command{
@@ -54,15 +55,15 @@ func main() {
 	t := tool.New(tool.Comparers(mvccComparer), tool.Mergers(fauxMVCCMerger))
 	rootCmd.AddCommand(t.Commands...)
 
-	for _, cmd := range []*cobra.Command{compactNewCmd, compactRunCmd, scanCmd, syncCmd, ycsbCmd} {
+	for _, cmd := range []*cobra.Command{compactNewCmd, compactRunCmd, scanCmd, syncCmd, tombstoneCmd, ycsbCmd} {
 		cmd.Flags().BoolVarP(
 			&verbose, "verbose", "v", false, "enable verbose event logging")
 	}
-	for _, cmd := range []*cobra.Command{compactRunCmd, scanCmd, syncCmd, ycsbCmd} {
+	for _, cmd := range []*cobra.Command{compactRunCmd, scanCmd, syncCmd, tombstoneCmd, ycsbCmd} {
 		cmd.Flags().Int64Var(
 			&cacheSize, "cache", 1<<30, "cache size")
 	}
-	for _, cmd := range []*cobra.Command{scanCmd, syncCmd, ycsbCmd} {
+	for _, cmd := range []*cobra.Command{scanCmd, syncCmd, tombstoneCmd, ycsbCmd} {
 		cmd.Flags().IntVarP(
 			&concurrency, "concurrency", "c", 1, "number of concurrent workers")
 		cmd.Flags().BoolVar(

--- a/cmd/pebble/queue.go
+++ b/cmd/pebble/queue.go
@@ -1,0 +1,116 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/internal/randvar"
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/rand"
+)
+
+var queueConfig struct {
+	size   int
+	values *randvar.BytesFlag
+}
+
+func initQueue(cmd *cobra.Command) {
+	cmd.Flags().IntVar(
+		&queueConfig.size, "queue-size", 256,
+		"size of the queue to maintain")
+	queueConfig.values = randvar.NewBytesFlag("16384")
+	cmd.Flags().Var(
+		queueConfig.values, "queue-values",
+		"queue value size distribution [{zipf,uniform}:]min[-max][/<target-compression>]")
+}
+
+func queueTest() test {
+	var (
+		ops         int64 // atomic
+		lastOps     int64
+		lastElapsed time.Duration
+	)
+	return test{
+		init: func(d DB, wg *sync.WaitGroup) {
+			var (
+				value []byte
+				rng   = rand.New(rand.NewSource(1449168817))
+				queue = make([][]byte, queueConfig.size)
+			)
+			for i := 0; i < queueConfig.size; i++ {
+				b := d.NewBatch()
+				queue[i] = mvccEncode(nil, encodeUint32Ascending([]byte("queue-"), uint32(i)), uint64(i+1), 0)
+				value = queueConfig.values.Bytes(rng, value)
+				b.Set(queue[i], value, pebble.NoSync)
+				if err := b.Commit(pebble.NoSync); err != nil {
+					log.Fatal(err)
+				}
+			}
+			if err := d.Flush(); err != nil {
+				log.Fatal(err)
+			}
+
+			limiter := maxOpsPerSec.newRateLimiter()
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				for i := queueConfig.size; ; i++ {
+					idx := i % queueConfig.size
+
+					// Delete the tail.
+					b := d.NewBatch()
+					if err := b.Delete(queue[idx], pebble.Sync); err != nil {
+						log.Fatal(err)
+					}
+					if err := b.Commit(pebble.Sync); err != nil {
+						log.Fatal(err)
+					}
+					_ = b.Close()
+					wait(limiter)
+
+					// Write a new head.
+					b = d.NewBatch()
+					queue[idx] = mvccEncode(queue[idx][:0], encodeUint32Ascending([]byte("queue-"), uint32(i)), uint64(i+1), 0)
+					value = queueConfig.values.Bytes(rng, value)
+					b.Set(queue[idx], value, nil)
+					if err := b.Commit(pebble.Sync); err != nil {
+						log.Fatal(err)
+					}
+					_ = b.Close()
+					wait(limiter)
+					atomic.AddInt64(&ops, 1)
+				}
+			}()
+		},
+		tick: func(elapsed time.Duration, i int) {
+			if i%20 == 0 {
+				fmt.Println("Queue___elapsed_______ops/sec")
+			}
+
+			curOps := atomic.LoadInt64(&ops)
+			dur := elapsed - lastElapsed
+			fmt.Printf("%15s %13.1f\n",
+				time.Duration(elapsed.Seconds()+0.5)*time.Second,
+				float64(curOps-lastOps)/dur.Seconds(),
+			)
+			lastOps = curOps
+			lastElapsed = elapsed
+		},
+		done: func(elapsed time.Duration) {
+			curOps := atomic.LoadInt64(&ops)
+			fmt.Println("\nQueue___elapsed___ops/sec(cum)")
+			fmt.Printf("%13.1fs %14.1f\n\n",
+				elapsed.Seconds(),
+				float64(curOps)/elapsed.Seconds())
+		},
+	}
+}

--- a/cmd/pebble/rocksdb.go
+++ b/cmd/pebble/rocksdb.go
@@ -404,6 +404,16 @@ func (b crdbPebbleDBBatch) Set(key, value []byte, _ *pebble.WriteOptions) error 
 	return b.batch.Put(storage.MVCCKey{Key: userKey, Timestamp: ts}, value)
 }
 
+func (b crdbPebbleDBBatch) Delete(data []byte, _ *pebble.WriteOptions) error {
+	userKey, _, ok := mvccSplitKey(key)
+	if !ok {
+		panic("mvccSplitKey failed")
+	}
+	ts := hlc.Timestamp{WallTime: 1}
+
+	return b.batch.Clear(storage.MVCCKey{Key: userKey, Timestamp: ts})
+}
+
 func (b crdbPebbleDBBatch) LogData(data []byte, _ *pebble.WriteOptions) error {
 	return b.batch.LogData(data)
 }

--- a/cmd/pebble/tombstone.go
+++ b/cmd/pebble/tombstone.go
@@ -1,0 +1,92 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/pebble/internal/humanize"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	// NB: the tombstone workload piggybacks off the existing flags and
+	// configs for the queue and ycsb workloads.
+	initQueue(tombstoneCmd)
+	initYCSB(tombstoneCmd)
+}
+
+var tombstoneCmd = &cobra.Command{
+	Use:   "tombstone <dir>",
+	Short: "run the mixed-workload point tombstone benchmark",
+	Long: `
+Run a customizable YCSB workload, alongside a single-writer, fixed-sized queue
+workload. This command is intended for evaluating compaction heuristics
+surrounding point tombstones.
+	`,
+	Args: cobra.ExactArgs(1),
+	RunE: runTombstoneCmd,
+}
+
+func runTombstoneCmd(cmd *cobra.Command, args []string) error {
+	if wipe && ycsbConfig.prepopulatedKeys > 0 {
+		return errors.New("--wipe and --prepopulated-keys both specified which is nonsensical")
+	}
+
+	weights, err := ycsbParseWorkload(ycsbConfig.workload)
+	if err != nil {
+		return err
+	}
+
+	keyDist, err := ycsbParseKeyDist(ycsbConfig.keys)
+	if err != nil {
+		return err
+	}
+
+	batchDist := ycsbConfig.batch
+	scanDist := ycsbConfig.scans
+	if err != nil {
+		return err
+	}
+
+	valueDist := ycsbConfig.values
+	y := newYcsb(weights, keyDist, batchDist, scanDist, valueDist)
+	q := queueTest()
+
+	queueStart := []byte("queue-")
+	queueEnd := append(append([]byte{}, queueStart...), 0xFF)
+
+	var pdb pebbleDB
+	runTest(args[0], test{
+		init: func(d DB, wg *sync.WaitGroup) {
+			pdb = d.(pebbleDB)
+			y.init(d, wg)
+			q.init(d, wg)
+		},
+		tick: func(elapsed time.Duration, i int) {
+			if i%20 == 0 {
+				fmt.Println("________elapsed______queue_size")
+			}
+			queueSize, err := pdb.d.EstimateDiskUsage(queueStart, queueEnd)
+			if err != nil {
+				log.Fatal(err)
+			}
+			fmt.Printf("%15s %15s\n", time.Duration(elapsed.Seconds()+0.5)*time.Second, humanize.Uint64(queueSize))
+		},
+		done: func(elapsed time.Duration) {
+			fmt.Println("________elapsed______queue_size")
+			queueSize, err := pdb.d.EstimateDiskUsage(queueStart, queueEnd)
+			if err != nil {
+				log.Fatal(err)
+			}
+			fmt.Printf("%15s %15s\n", elapsed.Truncate(time.Second), humanize.Uint64(queueSize))
+		},
+	})
+	return nil
+}

--- a/cmd/pebble/ycsb.go
+++ b/cmd/pebble/ycsb.go
@@ -83,30 +83,34 @@ Standard workloads:
 }
 
 func init() {
+	initYCSB(ycsbCmd)
+}
+
+func initYCSB(cmd *cobra.Command) {
 	ycsbConfig.batch = randvar.NewFlag("1")
-	ycsbCmd.Flags().Var(
+	cmd.Flags().Var(
 		ycsbConfig.batch, "batch",
 		"batch size distribution [{zipf,uniform}:]min[-max]")
-	ycsbCmd.Flags().StringVar(
+	cmd.Flags().StringVar(
 		&ycsbConfig.keys, "keys", "zipf", "latest, uniform, or zipf")
-	ycsbCmd.Flags().IntVar(
+	cmd.Flags().IntVar(
 		&ycsbConfig.initialKeys, "initial-keys", 10000,
 		"initial number of keys to insert before beginning workload")
-	ycsbCmd.Flags().IntVar(
+	cmd.Flags().IntVar(
 		&ycsbConfig.prepopulatedKeys, "prepopulated-keys", 0,
 		"number of keys that were previously inserted into the database")
-	ycsbCmd.Flags().Uint64VarP(
+	cmd.Flags().Uint64VarP(
 		&ycsbConfig.numOps, "num-ops", "n", 0,
 		"maximum number of operations (0 means unlimited)")
 	ycsbConfig.scans = randvar.NewFlag("zipf:1-1000")
-	ycsbCmd.Flags().Var(
+	cmd.Flags().Var(
 		ycsbConfig.scans, "scans",
 		"scan length distribution [{zipf,uniform}:]min[-max]")
-	ycsbCmd.Flags().StringVar(
+	cmd.Flags().StringVar(
 		&ycsbConfig.workload, "workload", "B",
 		"workload type (A-F) or spec (read=X,update=Y,...)")
 	ycsbConfig.values = randvar.NewBytesFlag("1000")
-	ycsbCmd.Flags().Var(
+	cmd.Flags().Var(
 		ycsbConfig.values, "values",
 		"value size distribution [{zipf,uniform}:]min[-max][/<target-compression>]")
 }


### PR DESCRIPTION
Add a benchmark for evaluating compaction surrounding point tombstones.
The bunchmarks runs a configurable YCSB workload, alongside a
single-writer queue workload. The queue workload maintains a
fixed-length queue, removing the tail with a point delete.