### PR TITLE
crl-release-20.2: db: add point tombstone compensation 

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1055,7 +1055,9 @@ func pickElisionOnly(picker compactionPicker, env compactionEnv) *pickedCompacti
 // calling `pickFunc` to pick automatic compactions.
 //
 // d.mu must be held when calling this.
-func (d *DB) maybeScheduleCompactionPicker(pickFunc func(compactionPicker, compactionEnv) *pickedCompaction) {
+func (d *DB) maybeScheduleCompactionPicker(
+	pickFunc func(compactionPicker, compactionEnv) *pickedCompaction,
+) {
 	if d.closed.Load() != nil || d.opts.ReadOnly {
 		return
 	}

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -125,9 +125,7 @@ type pickedCompaction struct {
 	version *version
 }
 
-func newPickedCompaction(
-	opts *Options, cur *version, startLevel, baseLevel int,
-) *pickedCompaction {
+func newPickedCompaction(opts *Options, cur *version, startLevel, baseLevel int) *pickedCompaction {
 	if startLevel > 0 && startLevel < baseLevel {
 		panic(fmt.Sprintf("invalid compaction: start level %d should not be empty (base level %d)",
 			startLevel, baseLevel))
@@ -158,7 +156,9 @@ func newPickedCompaction(
 	return pc
 }
 
-func newPickedCompactionFromL0(lcf *manifest.L0CompactionFiles, opts *Options, vers *version, baseLevel int, isBase bool) *pickedCompaction {
+func newPickedCompactionFromL0(
+	lcf *manifest.L0CompactionFiles, opts *Options, vers *version, baseLevel int, isBase bool,
+) *pickedCompaction {
 	pc := newPickedCompaction(opts, vers, 0, baseLevel)
 	pc.lcf = lcf
 	if !isBase {
@@ -1019,7 +1019,9 @@ func (p *compactionPickerByScore) pickAuto(env compactionEnv) (pc *pickedCompact
 
 // pickElisionOnlyCompaction looks for compactions of sstables in the
 // bottommost level containing obsolete records that may now be dropped.
-func (p *compactionPickerByScore) pickElisionOnlyCompaction(env compactionEnv) (pc *pickedCompaction) {
+func (p *compactionPickerByScore) pickElisionOnlyCompaction(
+	env compactionEnv,
+) (pc *pickedCompaction) {
 	if p.elisionThreshold == nil || (p.elisionCandidate != nil && p.elisionCandidate.Compacting) {
 		var lowestCandidateSeqNum uint64 = math.MaxUint64
 		var lowestCandidate manifest.LevelFile

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -407,7 +407,8 @@ type candidateLevelInfo struct {
 func compensatedSize(f *fileMetadata) uint64 {
 	sz := f.Size
 	// Add in the estimate of disk space that may be reclaimed by compacting
-	// the file's range tombstones.
+	// the file's tombstones.
+	sz += f.Stats.PointDeletionsBytesEstimate
 	sz += f.Stats.RangeDeletionsBytesEstimate
 	return sz
 }

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -78,7 +78,9 @@ func (p *compactionPickerForTesting) pickAuto(env compactionEnv) (pc *pickedComp
 	return pickAutoHelper(env, p.opts, p.vers, cInfo, p.baseLevel)
 }
 
-func (p *compactionPickerForTesting) pickElisionOnlyCompaction(env compactionEnv) (pc *pickedCompaction) {
+func (p *compactionPickerForTesting) pickElisionOnlyCompaction(
+	env compactionEnv,
+) (pc *pickedCompaction) {
 	return nil
 }
 
@@ -1576,6 +1578,7 @@ func TestCompactionTombstones(t *testing.T) {
 
 			case "maybe-compact":
 				d.mu.Lock()
+				d.opts.private.disableAutomaticCompactions = false
 				d.maybeScheduleCompaction()
 				s := compactionString()
 				d.mu.Unlock()

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1520,7 +1520,7 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 		})
 }
 
-func TestCompactionTombstoneElisionOnly(t *testing.T) {
+func TestCompactionTombstones(t *testing.T) {
 	var d *DB
 	var compactInfo *CompactionInfo // protected by d.mu
 
@@ -1540,7 +1540,7 @@ func TestCompactionTombstoneElisionOnly(t *testing.T) {
 		return s
 	}
 
-	datadriven.RunTest(t, "testdata/compaction_tombstone_elision_only",
+	datadriven.RunTest(t, "testdata/compaction_tombstones",
 		func(td *datadriven.TestData) string {
 			switch td.Cmd {
 			case "define":

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -48,6 +48,9 @@ type TableStats struct {
 	// The number of point and range deletion entries in the table.
 	NumDeletions uint64
 	// Estimate of the total disk space that may be dropped by this table's
+	// point deletions by compacting them.
+	PointDeletionsBytesEstimate uint64
+	// Estimate of the total disk space that may be dropped by this table's
 	// range deletions by compacting them. This estimate is at data-block
 	// granularity and is not updated if compactions beneath the table reduce
 	// the amount of reclaimable disk space. It also does not account for

--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -142,6 +142,11 @@ type Properties struct {
 	Loaded map[uintptr]struct{}
 }
 
+// NumPointDeletions returns the number of point deletions in this table.
+func (p *Properties) NumPointDeletions() uint64 {
+	return p.NumDeletions - p.NumRangeDeletions
+}
+
 func (p *Properties) String() string {
 	var buf bytes.Buffer
 	v := reflect.ValueOf(*p)

--- a/table_stats.go
+++ b/table_stats.go
@@ -260,11 +260,11 @@ func (d *DB) loadTableStats(
 			// We could write the ranges of 'clusters' of point tombstones to
 			// a sstable property and call averageValueSizeBeneath for each of
 			// these narrower ranges to improve the estimate.
-			avgValSize, err := d.averageValueSizeBeneath(v, level, meta)
+			avgKeySize, avgValSize, err := d.averageEntrySizeBeneath(v, level, meta)
 			if err != nil {
 				return err
 			}
-			stats.PointDeletionsBytesEstimate = pointDeletionsBytesEstimate(&r.Properties, avgValSize)
+			stats.PointDeletionsBytesEstimate = pointDeletionsBytesEstimate(&r.Properties, avgKeySize, avgValSize)
 		}
 
 		if r.Properties.NumRangeDeletions == 0 {
@@ -335,30 +335,49 @@ func (d *DB) loadTableStats(
 	return stats, compactionHints, nil
 }
 
-func (d *DB) averageValueSizeBeneath(
+func (d *DB) averageEntrySizeBeneath(
 	v *version, level int, meta *fileMetadata,
-) (avgValueSize uint64, err error) {
+) (avgKeySize, avgValueSize uint64, err error) {
 	// Find all files in lower levels that overlap with meta,
 	// summing their value sizes and entry counts.
-	var valSum, entryCount uint64
+	var fileSum, keySum, valSum, entryCount uint64
 	for l := level + 1; l < numLevels; l++ {
 		overlaps := v.Overlaps(l, d.cmp, meta.Smallest.UserKey, meta.Largest.UserKey)
 		iter := overlaps.Iter()
 		for file := iter.First(); file != nil; file = iter.Next() {
 			err := d.tableCache.withReader(file, func(r *sstable.Reader) (err error) {
+				fileSum += file.Size
 				entryCount += r.Properties.NumEntries
+				keySum += r.Properties.RawKeySize
 				valSum += r.Properties.RawValueSize
 				return nil
 			})
 			if err != nil {
-				return 0, err
+				return 0, 0, err
 			}
 		}
 	}
 	if entryCount == 0 {
-		return 0, nil
+		return 0, 0, nil
 	}
-	return valSum / entryCount, nil
+	// RawKeySize and RawValueSize are uncompressed totals. Scale them
+	// according to the data size to account for compression, index blocks and
+	// metadata overhead. Eg:
+	//
+	//    Compression rate        ×  Average uncompressed key size
+	//
+	//                            ↓
+	//
+	//         FileSize              RawKeySize
+	//   -----------------------  ×  ----------
+	//   RawKeySize+RawValueSize     NumEntries
+	//
+	// We refactor the calculation to avoid error from rounding/truncation.
+	totalSizePerEntry := fileSum / entryCount
+	uncompressedSum := keySum + valSum
+	avgKeySize = keySum * totalSizePerEntry / uncompressedSum
+	avgValueSize = valSum * totalSizePerEntry / uncompressedSum
+	return avgKeySize, avgValueSize, err
 }
 
 func (d *DB) estimateSizeBeneath(
@@ -487,12 +506,12 @@ func maybeSetStatsFromProperties(meta *fileMetadata, props *sstable.Properties) 
 
 	var pointEstimate uint64
 	if props.NumEntries > 0 {
-		// Use the file's own average value size as an estimate. This doesn't
-		// require any additional IO and since the number of point deletions
-		// in the file is low, the error introduced by this crude estimate is
-		// expected to be small.
-		avgValSize := props.RawValueSize / props.NumEntries
-		pointEstimate = pointDeletionsBytesEstimate(props, avgValSize)
+		// Use the file's own average key and value sizes as an estimate. This
+		// doesn't require any additional IO and since the number of point
+		// deletions in the file is low, the error introduced by this crude
+		// estimate is expected to be small.
+		avgKeySize, avgValSize := estimateEntrySizes(meta.Size, props)
+		pointEstimate = pointDeletionsBytesEstimate(props, avgKeySize, avgValSize)
 	}
 
 	meta.Stats = manifest.TableStats{
@@ -505,7 +524,7 @@ func maybeSetStatsFromProperties(meta *fileMetadata, props *sstable.Properties) 
 	return true
 }
 
-func pointDeletionsBytesEstimate(props *sstable.Properties, avgValSize uint64) uint64 {
+func pointDeletionsBytesEstimate(props *sstable.Properties, avgKeySize, avgValSize uint64) uint64 {
 	if props.NumEntries == 0 {
 		return 0
 	}
@@ -521,7 +540,29 @@ func pointDeletionsBytesEstimate(props *sstable.Properties, avgValSize uint64) u
 	// because point tombstones can slow range iterations even when they don't
 	// cover a key. It may be beneficial in the future to more accurately
 	// estimate which tombstones cover keys and which do not.
-	avgKeySize := props.RawKeySize / props.NumEntries
 	numPointDels := props.NumPointDeletions()
 	return numPointDels*avgKeySize + numPointDels*(avgKeySize+avgValSize)
+}
+
+func estimateEntrySizes(
+	fileSize uint64, props *sstable.Properties,
+) (avgKeySize, avgValSize uint64) {
+	// RawKeySize and RawValueSize are uncompressed totals. Scale them
+	// according to the data size to account for compression, index blocks and
+	// metadata overhead. Eg:
+	//
+	//    Compression rate        ×  Average uncompressed key size
+	//
+	//                            ↓
+	//
+	//         FileSize              RawKeySize
+	//   -----------------------  ×  ----------
+	//   RawKeySize+RawValueSize     NumEntries
+	//
+	// We refactor the calculation to avoid error from rounding/truncation.
+	fileSizePerEntry := fileSize / props.NumEntries
+	uncompressedSum := props.RawKeySize + props.RawValueSize
+	avgKeySize = props.RawKeySize * fileSizePerEntry / uncompressedSum
+	avgValSize = props.RawValueSize * fileSizePerEntry / uncompressedSum
+	return avgKeySize, avgValSize
 }

--- a/table_stats.go
+++ b/table_stats.go
@@ -253,10 +253,23 @@ func (d *DB) loadTableStats(
 	err := d.tableCache.withReader(meta, func(r *sstable.Reader) (err error) {
 		stats.NumEntries = r.Properties.NumEntries
 		stats.NumDeletions = r.Properties.NumDeletions
+		if r.Properties.NumPointDeletions() > 0 {
+			// TODO(jackson): If the file has a wide keyspace, the average
+			// value size beneath the entire file might not be representative
+			// of the size of the keys beneath the point tombstones.
+			// We could write the ranges of 'clusters' of point tombstones to
+			// a sstable property and call averageValueSizeBeneath for each of
+			// these narrower ranges to improve the estimate.
+			avgValSize, err := d.averageValueSizeBeneath(v, level, meta)
+			if err != nil {
+				return err
+			}
+			stats.PointDeletionsBytesEstimate = pointDeletionsBytesEstimate(&r.Properties, avgValSize)
+		}
+
 		if r.Properties.NumRangeDeletions == 0 {
 			return nil
 		}
-
 		// We iterate over the defragmented range tombstones, which ensures
 		// we don't double count ranges deleted at different sequence numbers.
 		// Also, merging abutting tombstones reduces the number of calls to
@@ -320,6 +333,32 @@ func (d *DB) loadTableStats(
 	}
 	stats.Valid = true
 	return stats, compactionHints, nil
+}
+
+func (d *DB) averageValueSizeBeneath(
+	v *version, level int, meta *fileMetadata,
+) (avgValueSize uint64, err error) {
+	// Find all files in lower levels that overlap with meta,
+	// summing their value sizes and entry counts.
+	var valSum, entryCount uint64
+	for l := level + 1; l < numLevels; l++ {
+		overlaps := v.Overlaps(l, d.cmp, meta.Smallest.UserKey, meta.Largest.UserKey)
+		iter := overlaps.Iter()
+		for file := iter.First(); file != nil; file = iter.Next() {
+			err := d.tableCache.withReader(file, func(r *sstable.Reader) (err error) {
+				entryCount += r.Properties.NumEntries
+				valSum += r.Properties.RawValueSize
+				return nil
+			})
+			if err != nil {
+				return 0, err
+			}
+		}
+	}
+	if entryCount == 0 {
+		return 0, nil
+	}
+	return valSum / entryCount, nil
 }
 
 func (d *DB) estimateSizeBeneath(
@@ -436,11 +475,53 @@ func maybeSetStatsFromProperties(meta *fileMetadata, props *sstable.Properties) 
 	if props.NumRangeDeletions != 0 {
 		return false
 	}
+
+	// If a table is more than 10% point deletions, don't calculate the
+	// PointDeletionsBytesEstimate statistic using our limited knowledge. The
+	// table stats collector can populate the stats and calculate an average
+	// of value size of all the tables beneath the table in the LSM, which
+	// will be more accurate.
+	if props.NumDeletions > props.NumEntries/10 {
+		return false
+	}
+
+	var pointEstimate uint64
+	if props.NumEntries > 0 {
+		// Use the file's own average value size as an estimate. This doesn't
+		// require any additional IO and since the number of point deletions
+		// in the file is low, the error introduced by this crude estimate is
+		// expected to be small.
+		avgValSize := props.RawValueSize / props.NumEntries
+		pointEstimate = pointDeletionsBytesEstimate(props, avgValSize)
+	}
+
 	meta.Stats = manifest.TableStats{
 		Valid:                       true,
 		NumEntries:                  props.NumEntries,
 		NumDeletions:                props.NumDeletions,
+		PointDeletionsBytesEstimate: pointEstimate,
 		RangeDeletionsBytesEstimate: 0,
 	}
 	return true
+}
+
+func pointDeletionsBytesEstimate(props *sstable.Properties, avgValSize uint64) uint64 {
+	if props.NumEntries == 0 {
+		return 0
+	}
+	// Estimate the potential space to reclaim using the table's own
+	// properties. There may or may not be keys covered by any individual
+	// point tombstone. If not, compacting the point tombstone into L6 will at
+	// least allow us to drop the point deletion key and will reclaim the key
+	// bytes. If there are covered key(s), we also get to drop key and value
+	// bytes for each covered key.
+	//
+	// We estimate assuming that each point tombstone on average covers 1 key.
+	// This is almost certainly an overestimate, but that's probably okay
+	// because point tombstones can slow range iterations even when they don't
+	// cover a key. It may be beneficial in the future to more accurately
+	// estimate which tombstones cover keys and which do not.
+	avgKeySize := props.RawKeySize / props.NumEntries
+	numPointDels := props.NumPointDeletions()
+	return numPointDels*avgKeySize + numPointDels*(avgKeySize+avgValSize)
 }

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -76,7 +76,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 1
-point-deletions-bytes-estimate: 18
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
 maybe-compact
@@ -114,7 +114,7 @@ wait-pending-table-stats
 ----
 num-entries: 6
 num-deletions: 2
-point-deletions-bytes-estimate: 18
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 76
 
 maybe-compact
@@ -146,7 +146,7 @@ wait-pending-table-stats
 ----
 num-entries: 11
 num-deletions: 1
-point-deletions-bytes-estimate: 18
+point-deletions-bytes-estimate: 149
 range-deletions-bytes-estimate: 0
 
 close-snapshot
@@ -176,5 +176,14 @@ wait-pending-table-stats
 ----
 num-entries: 3
 num-deletions: 3
-point-deletions-bytes-estimate: 12342
+point-deletions-bytes-estimate: 13167
 range-deletions-bytes-estimate: 0
+
+# By plain file size, 000005 should be picked because it is larger and
+# overlaps the same amount of data in L6. However, 000004 has a high
+# point-deletions-bytes-estimate, and the compaction picker should pick 000004
+# instead.
+
+maybe-compact
+----
+[JOB 100] compacted L5 [000004] (794 B) + L6 [000006] (13 K) -> L6 [] (0 B), in 1.0s, output rate 0 B/s

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -13,6 +13,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 2
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
 maybe-compact
@@ -33,6 +34,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 2
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
 maybe-compact
@@ -52,6 +54,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 26
 
 maybe-compact
@@ -73,6 +76,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 1
+point-deletions-bytes-estimate: 18
 range-deletions-bytes-estimate: 0
 
 maybe-compact
@@ -110,6 +114,7 @@ wait-pending-table-stats
 ----
 num-entries: 6
 num-deletions: 2
+point-deletions-bytes-estimate: 18
 range-deletions-bytes-estimate: 76
 
 maybe-compact
@@ -141,9 +146,35 @@ wait-pending-table-stats
 ----
 num-entries: 11
 num-deletions: 1
+point-deletions-bytes-estimate: 18
 range-deletions-bytes-estimate: 0
 
 close-snapshot
 15
 ----
 (none)
+
+define level-max-bytes=(L5 : 1000) auto-compactions=off
+L5
+a.DEL.101: b.DEL.102: c.DEL.103:
+L5
+m.SET.107:<largeval>
+L6
+a.SET.001:<largeval> b.SET.002:<largeval> c.SET.003:<largeval>
+L6
+f.SET.007:<largeval> x.SET.008:<largeval> z.SET.009:<largeval>
+----
+5:
+  000004:[a#101,DEL-c#103,DEL]
+  000005:[m#107,SET-m#107,SET]
+6:
+  000006:[a#1,SET-c#3,SET]
+  000007:[f#7,SET-z#9,SET]
+
+wait-pending-table-stats
+000004
+----
+num-entries: 3
+num-deletions: 3
+point-deletions-bytes-estimate: 12342
+range-deletions-bytes-estimate: 0

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -72,6 +72,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 0
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
 build ext1
@@ -341,6 +342,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 2
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 1666
 
 # A set operation takes precedence over a range deletion at the same

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -86,6 +86,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 1552
 
 compact a-e L1
@@ -103,6 +104,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 776
 
 # Same as above, except range tombstone covers multiple grandparent file boundaries.

--- a/testdata/range_del
+++ b/testdata/range_del
@@ -1389,6 +1389,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
 wait-pending-table-stats
@@ -1396,6 +1397,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 836
 
 wait-pending-table-stats
@@ -1403,6 +1405,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 1672
 
 wait-pending-table-stats
@@ -1410,6 +1413,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 2
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 1672
 
 
@@ -1448,6 +1452,7 @@ wait-pending-table-stats
 ----
 num-entries: 4
 num-deletions: 0
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
 wait-pending-table-stats
@@ -1455,6 +1460,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 787
 
 wait-pending-table-stats
@@ -1462,6 +1468,7 @@ wait-pending-table-stats
 ----
 num-entries: 3
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 68
 
 wait-pending-table-stats
@@ -1469,6 +1476,7 @@ wait-pending-table-stats
 ----
 num-entries: 4
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 100
 
 # Multiple Range deletions in a table.
@@ -1503,6 +1511,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 782
 
 wait-pending-table-stats
@@ -1510,6 +1519,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 771
 
 wait-pending-table-stats
@@ -1517,4 +1527,5 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 2
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 1553

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -1,24 +1,26 @@
 batch
 set a 1
 set b 2
+del c
 ----
 
 flush
 ----
 0.0:
-  000005:[a#1,SET-b#2,SET]
+  000005:[a#1,SET-c#3,DEL]
 
 wait-pending-table-stats
 000005
 ----
-num-entries: 2
-num-deletions: 0
+num-entries: 3
+num-deletions: 1
+point-deletions-bytes-estimate: 18
 range-deletions-bytes-estimate: 0
 
 compact a-c
 ----
 6:
-  000005:[a-b]
+  000005:[a-c]
 
 batch
 del-range a c
@@ -27,16 +29,17 @@ del-range a c
 flush
 ----
 0.0:
-  000007:[a#3,RANGEDEL-c#72057594037927935,RANGEDEL]
+  000007:[a#4,RANGEDEL-c#72057594037927935,RANGEDEL]
 6:
-  000005:[a#1,SET-b#2,SET]
+  000005:[a#1,SET-c#3,DEL]
 
 wait-pending-table-stats
 000007
 ----
 num-entries: 1
 num-deletions: 1
-range-deletions-bytes-estimate: 784
+point-deletions-bytes-estimate: 0
+range-deletions-bytes-estimate: 796
 
 reopen
 ----
@@ -53,7 +56,8 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
-range-deletions-bytes-estimate: 784
+point-deletions-bytes-estimate: 0
+range-deletions-bytes-estimate: 796
 
 compact a-c
 ----
@@ -74,7 +78,7 @@ set b 2
 flush
 ----
 0.0:
-  000012:[a#4,SET-b#5,SET]
+  000012:[a#5,SET-b#6,SET]
 
 compact a-c
 ----
@@ -89,6 +93,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 0
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
 # Test a file that is deleted by a compaction before its table stats are
@@ -104,9 +109,9 @@ del-range a c
 flush
 ----
 0.0:
-  000014:[a#6,RANGEDEL-c#72057594037927935,RANGEDEL]
+  000014:[a#7,RANGEDEL-c#72057594037927935,RANGEDEL]
 6:
-  000012:[a#4,SET-b#5,SET]
+  000012:[a#5,SET-b#6,SET]
 
 compact a-c
 ----
@@ -170,6 +175,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 1542
 
 wait-pending-table-stats
@@ -177,6 +183,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 1542
 
 define snapshots=(10)
@@ -191,4 +198,5 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 1
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 26

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -14,7 +14,7 @@ wait-pending-table-stats
 ----
 num-entries: 3
 num-deletions: 1
-point-deletions-bytes-estimate: 18
+point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
 compact a-c

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -311,7 +311,7 @@ func (s *sstableT) runProperties(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(tw, "records\t%d\n", r.Properties.NumEntries)
 		fmt.Fprintf(tw, "  set\t%d\n", r.Properties.NumEntries-
 			(r.Properties.NumDeletions+r.Properties.NumMergeOperands))
-		fmt.Fprintf(tw, "  delete\t%d\n", r.Properties.NumDeletions-r.Properties.NumRangeDeletions)
+		fmt.Fprintf(tw, "  delete\t%d\n", r.Properties.NumPointDeletions())
 		fmt.Fprintf(tw, "  range-delete\t%d\n", r.Properties.NumRangeDeletions)
 		fmt.Fprintf(tw, "  merge\t%d\n", r.Properties.NumMergeOperands)
 		fmt.Fprintf(tw, "  global-seq-num\t%d\n", r.Properties.GlobalSeqNum)


### PR DESCRIPTION
This is a 20.2 backport of #1018. I'm teeing this up for the 20.2.4 release, but we can let the master branch bake for a bit.

db: add point tombstone compensation 

Add an estimate of the disk space that may be reclaimed by compacting
point tombstones to the compensated size used in compaction heuristics.

db: scale point tombstone averages according to file size