### PR TITLE
db: use uint64 for batch's memTableSize

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -187,7 +187,13 @@ type Batch struct {
 	formatKey      base.FormatKey
 	abbreviatedKey AbbreviatedKey
 
-	memTableSize uint32
+	// An upper bound on required space to add this batch to a memtable.
+	// Note that although batches are limited to 4 GiB in size, that limit
+	// applies to len(data), not the memtable size. The upper bound on the
+	// size of a memtable node is larger than the overhead of the batch's log
+	// encoding, so memTableSize is larger than len(data) and may overflow a
+	// uint32.
+	memTableSize uint64
 
 	// The db to which the batch will be committed. Do not change this field
 	// after the batch has been created as it might invalidate internal state.

--- a/mem_table.go
+++ b/mem_table.go
@@ -18,8 +18,8 @@ import (
 	"github.com/cockroachdb/pebble/internal/rangedel"
 )
 
-func memTableEntrySize(keyBytes, valueBytes int) uint32 {
-	return arenaskl.MaxNodeSize(uint32(keyBytes)+8, uint32(valueBytes))
+func memTableEntrySize(keyBytes, valueBytes int) uint64 {
+	return uint64(arenaskl.MaxNodeSize(uint32(keyBytes)+8, uint32(valueBytes)))
 }
 
 // memTableEmptySize is the amount of allocated space in the arena when the
@@ -174,10 +174,10 @@ func (m *memTable) get(key []byte) (value []byte, err error) {
 // writerUnref() after the batch has been applied.
 func (m *memTable) prepare(batch *Batch) error {
 	avail := m.availBytes()
-	if batch.memTableSize > avail {
+	if batch.memTableSize > uint64(avail) {
 		return arenaskl.ErrArenaFull
 	}
-	m.reserved += batch.memTableSize
+	m.reserved += uint32(batch.memTableSize)
 
 	m.writerRef()
 	return nil

--- a/open.go
+++ b/open.go
@@ -529,7 +529,7 @@ func (d *DB) replayWAL(
 		seqNum := b.SeqNum()
 		maxSeqNum = seqNum + uint64(b.Count())
 
-		if b.memTableSize >= uint32(d.largeBatchThreshold) {
+		if b.memTableSize >= uint64(d.largeBatchThreshold) {
 			flushMem()
 			// Make a copy of the data slice since it is currently owned by buf and will
 			// be reused in the next iteration.


### PR DESCRIPTION
The upper bound on a memtable node's memory overhead is higher than
a batch's wire encoding, which means a batch's memtable size grows
faster than the batch's backing byte slice.

We enforce a maxBatchSize on size of the batch's backing byte
slice. Previously, if a batch approached the maxBatchSize but didn't
cross it, the memTableSize, a uint32, could overflow. This overflow
would cause Pebble to incorrectly add the batch to the memtable rather
than the flush list and to reserve the wrong amount of space in the
memtable.

This commit fixes the issue by tracking the batch's memTableSize using a
uint64.

See cockroachdb/cockroach#58004.