### PR TITLE
options: enable read based compactions

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -184,7 +184,7 @@ func (i *Iterator) maybeSampleRead() {
 		return
 	}
 	samplingPeriod := readBytesPeriod * i.readState.db.opts.Experimental.ReadSamplingMultiplier
-	if samplingPeriod == 0 {
+	if samplingPeriod <= 0 {
 		return
 	}
 	if i.readSampling.rand == nil || i.readSampling.randvar == nil {

--- a/options.go
+++ b/options.go
@@ -330,15 +330,12 @@ type Options struct {
 		// conservative and allow approximately one seek for every 16KB
 		// of data before triggering a compaction.
 		// ```
-		// TODO(aadityasondhi): Experiment with this to find a good value
 		ReadCompactionRate int64
 
 		// ReadSamplingMultiplier is a multiplier for the readSamplingPeriod in
 		// iterator.maybeSampleRead() to control the frequency of read sampling
-		// to trigger a read triggered compaction. A value of 0 prevents sampling
+		// to trigger a read triggered compaction. A value of -1 prevents sampling
 		// and disables read triggered compactions.
-		//
-		// TODO(aadityasondhi): Experiment with this to find a good value
 		ReadSamplingMultiplier uint64
 	}
 
@@ -600,8 +597,8 @@ func (o *Options) EnsureDefaults() *Options {
 	if o.Experimental.ReadCompactionRate == 0 {
 		o.Experimental.ReadCompactionRate = 16000
 	}
-	if o.Experimental.ReadSamplingMultiplier != 0 {
-		o.Experimental.ReadSamplingMultiplier = 0
+	if o.Experimental.ReadSamplingMultiplier == 0 {
+		o.Experimental.ReadSamplingMultiplier = 1
 	}
 
 	o.initMaps()


### PR DESCRIPTION
This change enables read based compactions by default and sets the read
sampling threshold. This is based on the findings in
https://github.com/cockroachdb/pebble/issues/29.