### PR TITLE
sstable: Add ChecksumType to API

### DIFF
--- a/sstable/options.go
+++ b/sstable/options.go
@@ -59,6 +59,17 @@ const (
 	TableFormatLevelDB
 )
 
+// ChecksumType specifies the checksum used for blocks. The default is CRC32c.
+type ChecksumType uint32
+
+// The available checksum types. Note that these values are not (and should not)
+// be serialized to disk (for the constants that are persisted, see table.go).
+const (
+	ChecksumTypeCRC32c ChecksumType = iota
+	ChecksumTypeNone
+	ChecksumTypeXXHash
+)
+
 // TablePropertyCollector provides a hook for collecting user-defined
 // properties based on the keys and values stored in an sstable. A new
 // TablePropertyCollector is created for an sstable when the sstable is being
@@ -195,6 +206,9 @@ type WriterOptions struct {
 	// functions. A new TablePropertyCollector is created for each sstable built
 	// and lives for the lifetime of the table.
 	TablePropertyCollectors []func() TablePropertyCollector
+
+	// Checksum specifies which checksum to use.
+	Checksum ChecksumType
 }
 
 func (o WriterOptions) ensureDefaults() WriterOptions {

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -718,7 +718,7 @@ func TestFooterRoundTrip(t *testing.T) {
 		TableFormatLevelDB,
 	} {
 		t.Run(fmt.Sprintf("format=%d", format), func(t *testing.T) {
-			for _, checksum := range []uint8{checksumCRC32c} {
+			for _, checksum := range []ChecksumType{ChecksumTypeCRC32c} {
 				t.Run(fmt.Sprintf("checksum=%d", checksum), func(t *testing.T) {
 					footer := footer{
 						format:      format,
@@ -763,7 +763,7 @@ func TestFooterRoundTrip(t *testing.T) {
 }
 
 func TestReadFooter(t *testing.T) {
-	encode := func(format TableFormat, checksum uint8) string {
+	encode := func(format TableFormat, checksum ChecksumType) string {
 		f := footer{
 			format:   format,
 			checksum: checksum,
@@ -780,8 +780,8 @@ func TestReadFooter(t *testing.T) {
 		{strings.Repeat("a", rocksDBFooterLen), "bad magic number"},
 		{encode(TableFormatLevelDB, 0)[1:], "file size is too small"},
 		{encode(TableFormatRocksDBv2, 0)[1:], "footer too short"},
-		{encode(TableFormatRocksDBv2, noChecksum), "unsupported checksum type"},
-		{encode(TableFormatRocksDBv2, checksumXXHash), "unsupported checksum type"},
+		{encode(TableFormatRocksDBv2, ChecksumTypeNone), "unsupported checksum type"},
+		{encode(TableFormatRocksDBv2, ChecksumTypeXXHash), "unsupported checksum type"},
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {


### PR DESCRIPTION
This change does not alter the set of supported checksums -- it is still only crc32c.

This change adds `ChecksumType` to the public API so that `Writer` can be configured with
a requested checksum type (only CRC32c is for now) and alters `Reader` to actually use the
checksum type it read from the footer, rather than assuming it will always have been CRC.