### PR TITLE
vfs,sstable: split out subset of vfs.File used for reading

### DIFF
--- a/sstable/table.go
+++ b/sstable/table.go
@@ -73,7 +73,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/vfs"
 )
 
 /*
@@ -203,7 +202,7 @@ type footer struct {
 	footerBH    BlockHandle
 }
 
-func readFooter(f vfs.File) (footer, error) {
+func readFooter(f ReadableFile) (footer, error) {
 	var footer footer
 	stat, err := f.Stat()
 	if err != nil {

--- a/vfs/prefetch_generic.go
+++ b/vfs/prefetch_generic.go
@@ -7,9 +7,9 @@
 package vfs
 
 // Prefetch signals the OS (on supported platforms) to fetch the next size
-// bytes in file after offset into cache. Any subsequent reads in that range
-// will not issue disk IO.
-func Prefetch(file File, offset uint64, size uint64) error {
+// bytes in file (as returned by os.File.Fd()) after offset into cache. Any
+// subsequent reads in that range will not issue disk IO.
+func Prefetch(file uintptr, offset uint64, size uint64) error {
 	// No-op.
 	return nil
 }

--- a/vfs/prefetch_linux.go
+++ b/vfs/prefetch_linux.go
@@ -9,15 +9,9 @@ package vfs
 import "syscall"
 
 // Prefetch signals the OS (on supported platforms) to fetch the next size
-// bytes in file after offset into cache. Any subsequent reads in that range
-// will not issue disk IO.
-func Prefetch(file File, offset uint64, size uint64) error {
-	type fd interface {
-		Fd() uintptr
-	}
-	if f, ok := file.(fd); ok {
-		_, _, err := syscall.Syscall(syscall.SYS_READAHEAD, uintptr(f.Fd()), uintptr(offset), uintptr(size))
-		return err
-	}
-	return nil
+// bytes in file (as returned by os.File.Fd()) after offset into cache. Any
+// subsequent reads in that range will not issue disk IO.
+func Prefetch(file uintptr, offset uint64, size uint64) error {
+	_, _, err := syscall.Syscall(syscall.SYS_READAHEAD, uintptr(file), uintptr(offset), uintptr(size))
+	return err
 }


### PR DESCRIPTION
This adds vfs.ReadableFile to describe the interface needed by sstable.Reader: ReadAt, Stat and Close.
Breaking this subset out of vfs.File can make it easier to implement a readable file, for example one
backed by a read-only connection to remote storage.