### PR TITLE
docs: add a couple benchmark annotations

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -31,6 +31,10 @@
         LogWriter free blocks 4-&gt;16</div>
         <div class="annotation" data-date="20200706">Began tracking
         ycsb/E read-amp</div>
+        <div class="annotation" data-date="20201022">Level metadata
+        switched to use a B-Tree</div>
+        <div class="annotation" data-date="20201222">Enabled
+        read-triggered compactions</div>
       </div>
       <div class="section rows">
         <div class="columns">


### PR DESCRIPTION
Add annotations to the nightly benchmarks for the switch to a B-Tree and
the enabling of read-triggered compactions.