### PR TITLE
vfs: Add comment on vfs.File.Write about modifying input in-place

### DIFF
--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -22,6 +22,9 @@ type File interface {
 	io.Closer
 	io.Reader
 	io.ReaderAt
+	// Unlike the specification for io.Writer.Write(), the vfs.File.Write()
+	// method *is* allowed to modify the slice passed in, whether temporarily
+	// or permanently. Callers of Write() need to take this into account.
 	io.Writer
 	Stat() (os.FileInfo, error)
 	Sync() error


### PR DESCRIPTION
Unlike io.Writer, implementations of vfs.File *are* allowed to modify
the slice passed into Write() in-place, and are also not required to
reset its value to what it was at call time. All callers of
Write() on a vfs.File in Pebble and elsewhere need to take this
into account.

This change adds a comment on vfs.File clarifying this.