### PR TITLE
*: Wait for deletion goroutines to finish in db.Close

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2687,6 +2687,7 @@ func (d *DB) doDeleteObsoleteFiles(jobID int) {
 		}
 	}
 	if len(filesToDelete) > 0 {
+		d.deleters.Add(1)
 		// Delete asynchronously if that could get held up in the pacer.
 		if d.opts.Experimental.MinDeletionRate > 0 {
 			go d.paceAndDeleteObsoleteFiles(jobID, filesToDelete)
@@ -2699,6 +2700,7 @@ func (d *DB) doDeleteObsoleteFiles(jobID int) {
 // Paces and eventually deletes the list of obsolete files passed in. db.mu
 // must NOT be held when calling this method.
 func (d *DB) paceAndDeleteObsoleteFiles(jobID int, files []obsoleteFile) {
+	defer d.deleters.Done()
 	pacer := (pacer)(nilPacer)
 	if d.opts.Experimental.MinDeletionRate > 0 {
 		pacer = newDeletionPacer(d.deletionLimiter, d.getDeletionPacerInfo)


### PR DESCRIPTION
db.Close() currently waits for "cleaner" jobs, but
cleaners can spawn asynchronous deletion goroutines that can
remain dangling after the cleaner goroutines have finished.

This change adds a WaitGroup on db that is incremented upon
starting a new paced deletion, and Done()'d when that finishes.
The Close() method calls Wait on that WaitGroup.

Fixes #1044.