### PR TITLE
record: vectorize I/O using writev in LogWriter

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -413,6 +413,18 @@ func (c *compactionFile) Write(p []byte) (n int, err error) {
 	return n, err
 }
 
+// WriteV implements the vfs.VectorWriter interface.
+func (c *compactionFile) WriteV(bufs [][]byte) (n int, err error) {
+	n, err = vfs.WriteV(c.File, bufs)
+	if err != nil {
+		return n, err
+	}
+
+	*c.written += int64(n)
+	c.versions.incrementCompactionBytes(int64(n))
+	return n, err
+}
+
 type compactionKind string
 
 const (

--- a/internal/errorfs/errorfs.go
+++ b/internal/errorfs/errorfs.go
@@ -291,6 +291,13 @@ func (f *errorFile) Write(p []byte) (int, error) {
 	return f.file.Write(p)
 }
 
+func (f *errorFile) WriteV(bufs [][]byte) (n int, err error) {
+	if err := f.inj.MaybeError(OpWrite); err != nil {
+		return 0, err
+	}
+	return vfs.WriteV(f.file, bufs)
+}
+
 func (f *errorFile) Stat() (os.FileInfo, error) {
 	if err := f.inj.MaybeError(OpRead); err != nil {
 		return nil, err

--- a/vfs/disk_health.go
+++ b/vfs/disk_health.go
@@ -94,6 +94,14 @@ func (d *diskHealthCheckingFile) Write(p []byte) (n int, err error) {
 	return n, err
 }
 
+// WriteV implements the vfs.VectorWriter interface.
+func (d *diskHealthCheckingFile) WriteV(bufs [][]byte) (n int, err error) {
+	d.timeDiskOp(func() {
+		n, err = WriteV(d.File, bufs)
+	})
+	return n, err
+}
+
 // Close implements the io.Closer interface.
 func (d *diskHealthCheckingFile) Close() error {
 	d.stopTicker()

--- a/vfs/writev.go
+++ b/vfs/writev.go
@@ -1,0 +1,54 @@
+// Copyright 2012 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package vfs
+
+import (
+	"io"
+	"os"
+)
+
+// VectorWriter is a Writer with a WriteV method, which can efficiently
+// write collections of discontinuous buffers in a single operation.
+type VectorWriter interface {
+	io.Writer
+
+	// WriteV writes each of the byte slices to the underlying data stream, in
+	// order. It returns the number of bytes written across all bufs (0 <= n <=
+	// len(bufs)*len(bufs[..])) and any error encountered that caused the write
+	// to stop early. WriteV must return a non-nil error if it returns n <
+	// len(bufs)*len(bufs[..]). All retryable errors are dealt with in the
+	// implementation of WriteV.
+	//
+	// As with the vfs.File.Write() method, the vfs.VectorWriter.WriteV() method
+	// *is* allowed to modify the slices passed in, whether temporarily or
+	// permanently. Callers of WriteV() need to take this into account.
+	WriteV(bufs [][]byte) (n int, err error)
+}
+
+// WriteV writes each of the byte slices to the provided Writer, in
+// order. It returns the number of bytes written across all bufs (0 <= n
+// <= len(bufs)*len(bufs[..])) and any error encountered that caused the
+// write to stop early. WriteV must return a non-nil error if it returns
+// n < len(bufs)*len(bufs[..]).
+func WriteV(w io.Writer, bufs [][]byte) (n int, err error) {
+	if vw, ok := w.(VectorWriter); ok {
+		return vw.WriteV(bufs)
+	}
+	if f, ok := w.(*os.File); ok && writevSupported {
+		return writevFile(f, bufs)
+	}
+	for _, buf := range bufs {
+		var m int
+		m, err = w.Write(buf)
+		n += m
+		if err != nil {
+			return n, err
+		}
+		if m != len(buf) {
+			return n, io.ErrShortWrite
+		}
+	}
+	return n, nil
+}

--- a/vfs/writev_darwin.go
+++ b/vfs/writev_darwin.go
@@ -1,0 +1,17 @@
+// Copyright 2012 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build darwin
+
+package vfs
+
+import (
+	"syscall"
+	_ "unsafe" // required by go:linkname
+)
+
+// Copied from src/internal/poll/fd_writev_darwin.go.
+//go:linkname writev syscall.writev
+//go:noescape
+func writev(fd int, iovecs []syscall.Iovec) (n uintptr, err error)

--- a/vfs/writev_test.go
+++ b/vfs/writev_test.go
@@ -1,0 +1,96 @@
+// Copyright 2012 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package vfs
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteV(t *testing.T) {
+	f, err := ioutil.TempFile("", "pebble-db-writev-")
+	require.NoError(t, err)
+
+	filename := f.Name()
+	defer os.Remove(filename)
+
+	// Write "testing123" repeatedly with every permutation of chunks.
+	const str = "testing123"
+	var permute func(val []byte) [][][]byte
+	permute = func(val []byte) [][][]byte {
+		if len(val) == 2 {
+			// One group or two.
+			return [][][]byte{
+				{{val[0], val[1]}},
+				{{val[0]}, {val[1]}},
+			}
+		}
+		pre := val[0:1:1]
+		sufOpts := permute(val[1:])
+		res := make([][][]byte, 0, 2*len(sufOpts))
+		for _, sufOpt := range sufOpts {
+			// With pre alone.
+			resAlone := [][]byte{pre}
+			resAlone = append(resAlone, sufOpt...)
+			res = append(res, resAlone)
+			// With pre in first group.
+			resComb := [][]byte{append(pre, sufOpt[0]...)}
+			resComb = append(resComb, sufOpt[1:]...)
+			res = append(res, resComb)
+		}
+		return res
+	}
+	groups := permute([]byte(str))
+	require.Equal(t, 512, len(groups))
+
+	for _, g := range groups {
+		n, err := WriteV(f, g)
+		require.NoError(t, err)
+		require.Equal(t, len(str), n)
+	}
+
+	// Read the file back. Should match expectations.
+	exp := bytes.Repeat([]byte(str), len(groups))
+
+	_, err = f.Seek(0, 0)
+	require.NoError(t, err)
+	data, err := ioutil.ReadAll(f)
+	require.NoError(t, err)
+	require.Equal(t, exp, data)
+}
+
+func TestWriteVManyBuffers(t *testing.T) {
+	f, err := ioutil.TempFile("", "pebble-db-writev-")
+	require.NoError(t, err)
+
+	filename := f.Name()
+	defer os.Remove(filename)
+
+	// Write "testing123" repeatedly across many small buffers. We make sure to
+	// use at lease IOV_MAX (1024) buffers so that writevFile needs to iterate.
+	const str = "testing123"
+	const repeat = 3000
+	bufs := make([][]byte, repeat)
+	for i := range bufs {
+		bufs[i] = []byte(str)
+	}
+
+	n, err := WriteV(f, bufs)
+	require.NoError(t, err)
+	require.Equal(t, repeat*len(str), n)
+
+	// Read the file back. Should match expectations.
+	exp := bytes.Repeat([]byte(str), repeat)
+
+	_, err = f.Seek(0, 0)
+	require.NoError(t, err)
+	data, err := ioutil.ReadAll(f)
+	require.NoError(t, err)
+	require.Equal(t, exp, data)
+}

--- a/vfs/writev_unix.go
+++ b/vfs/writev_unix.go
@@ -1,0 +1,32 @@
+// Copyright 2012 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build dragonfly freebsd linux netbsd openbsd
+
+package vfs
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// Copied from src/internal/poll/fd_writev_unix.go.
+func writev(fd int, iovecs []syscall.Iovec) (uintptr, error) {
+	var (
+		r uintptr
+		e syscall.Errno
+	)
+	for {
+		r, _, e = syscall.Syscall(syscall.SYS_WRITEV, uintptr(fd), uintptr(unsafe.Pointer(&iovecs[0])), uintptr(len(iovecs)))
+		if e != syscall.EINTR {
+			break
+		}
+		// Repeat syscall on EINTR. If any bytes had already been written, a
+		// partial success would have been returned instead of the error.
+	}
+	if e != 0 {
+		return r, e
+	}
+	return r, nil
+}

--- a/vfs/writev_unix_shared.go
+++ b/vfs/writev_unix_shared.go
@@ -1,0 +1,96 @@
+// Copyright 2012 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build darwin dragonfly freebsd linux netbsd openbsd
+
+package vfs
+
+import (
+	"io"
+	"os"
+	"syscall"
+)
+
+const writevSupported = true
+
+// writevFile repeatedly issues writev calls to the provided file until the byte
+// buffers have been written in their entirety, or until an error is reached.
+//
+// Adapted from src/internal/poll/writev.go.
+func writevFile(f *os.File, bufs [][]byte) (n int, err error) {
+	fd := int(f.Fd())
+
+	// Limit the number of vectors that can be passed to writev at a time. We
+	// could read this limit from sysconf(_SC_IOV_MAX) on Linux and UIO_MAXIOV
+	// on Darwin, but the default across the systems all seem to be 1024 and the
+	// Go standard library doesn't even seem to jump through these hoops. If we
+	// ever get this wrong, we would see an EINVAL ("invalid argument") error
+	// from the writev call.
+	const maxVec = 1024
+
+	// We need to convert [][]byte to []syscall.Iovec before each syscall. To
+	// avoid heap allocations in the common case, we place a small array of
+	// syscall.Iovec objects on the stack. We tune the size to be just large
+	// enough to fit the maximum number of discontinuous buffers written by
+	// LogWriter.
+	var iovecArr [17]syscall.Iovec
+	iovecs := iovecArr[:]
+	for len(bufs) > 0 {
+		// Prepare the []syscall.Iovec.
+		iovecs = iovecs[:0]
+		for _, chunk := range bufs {
+			if len(chunk) == 0 {
+				continue
+			}
+			iovecs = append(iovecs, syscall.Iovec{
+				Base: &chunk[0],
+				Len:  uint64(len(chunk)),
+			})
+			if len(iovecs) == maxVec {
+				break
+			}
+		}
+		if len(iovecs) == 0 {
+			break
+		}
+
+		// Issue the WRITEV syscall.
+		var wrote uintptr
+		wrote, err = writev(fd, iovecs)
+		if wrote == ^uintptr(0) {
+			wrote = 0
+		}
+		n += int(wrote)
+		bufs = consume(bufs, int(wrote))
+		if err != nil {
+			if err == syscall.EINTR {
+				continue
+			}
+			break
+		}
+		if n == 0 {
+			err = io.ErrUnexpectedEOF
+			break
+		}
+	}
+	return n, err
+}
+
+// consume removes data from a slice of byte slices and returns the result.
+func consume(bufs [][]byte, n int) [][]byte {
+	for len(bufs) > 0 {
+		ln0 := len(bufs[0])
+		if ln0 > n {
+			bufs[0] = bufs[0][n:]
+			n = 0
+			break
+		}
+		n -= ln0
+		bufs = bufs[1:]
+	}
+	if n != 0 {
+		panic("unexpected bytes remaining in consume")
+	}
+	return bufs
+}

--- a/vfs/writev_unix_shared_test.go
+++ b/vfs/writev_unix_shared_test.go
@@ -1,0 +1,61 @@
+// Copyright 2012 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build darwin dragonfly freebsd linux netbsd openbsd
+
+package vfs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteVConsume(t *testing.T) {
+	testCases := []struct {
+		in      [][]byte
+		consume int
+		want    [][]byte
+	}{
+		{
+			in:      [][]byte{[]byte("foo"), []byte("bar")},
+			consume: 0,
+			want:    [][]byte{[]byte("foo"), []byte("bar")},
+		},
+		{
+			in:      [][]byte{[]byte("foo"), []byte("bar")},
+			consume: 2,
+			want:    [][]byte{[]byte("o"), []byte("bar")},
+		},
+		{
+			in:      [][]byte{[]byte("foo"), []byte("bar")},
+			consume: 3,
+			want:    [][]byte{[]byte("bar")},
+		},
+		{
+			in:      [][]byte{[]byte("foo"), []byte("bar")},
+			consume: 4,
+			want:    [][]byte{[]byte("ar")},
+		},
+		{
+			in:      [][]byte{nil, nil, nil, []byte("bar")},
+			consume: 1,
+			want:    [][]byte{[]byte("ar")},
+		},
+		{
+			in:      [][]byte{nil, nil, nil, []byte("foo")},
+			consume: 0,
+			want:    [][]byte{[]byte("foo")},
+		},
+		{
+			in:      [][]byte{nil, nil, nil},
+			consume: 0,
+			want:    [][]byte{},
+		},
+	}
+	for _, c := range testCases {
+		out := consume(c.in, c.consume)
+		require.Equal(t, c.want, out)
+	}
+}

--- a/vfs/writev_windows.go
+++ b/vfs/writev_windows.go
@@ -1,0 +1,17 @@
+// Copyright 2012 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build windows
+
+package vfs
+
+import "os"
+
+// Will prevent calls to writevFile from writev.go.
+const writevSupported = false
+
+// Never called.
+func writevFile(f *os.File, bufs [][]byte) (n int, err error) {
+	panic("unimplemented")
+}


### PR DESCRIPTION
This commit introduces the use of vectorized I/O (i.e. writev) calls in
the `LogWriter` when flushing multiple blocks at once. Vectorized writes
coalesce the system calls needed to write a collection of discontinuous
buffers to a single file. They can also provide an atomicity win, though
such atomicity is not needed here.

I was pleasantly surprised to see that this does result in a measurable
improvement to latency and throughput in write-heavy workloads (many
writes + large writes). I observed the following improvement on YCSB F
with 16KB writes and 16 worker threads when run on an n1-standard-16
instance with a local SSD.
```
$ pebble bench ycsb <dir> --workload=F --concurrency=16 --values=16384 --duration=1m

name             old ops/s    new ops/s    delta
insert_100_1kb    8.79k ± 4%   9.30k ± 3%   +5.77%  (p=0.016 n=5+5)
insert_100_2kb    8.09k ± 2%   8.77k ± 3%   +8.52%  (p=0.008 n=5+5)
insert_100_4kb    7.36k ± 1%   8.08k ± 3%   +9.71%  (p=0.008 n=5+5)
insert_100_8kb    5.13k ± 1%   5.58k ± 1%   +8.81%  (p=0.008 n=5+5)
insert_100_16kb   3.05k ± 1%   3.39k ± 1%  +11.05%  (p=0.008 n=5+5)
insert_100_32kb   1.68k ± 0%   2.18k ± 1%  +30.03%  (p=0.008 n=5+5)

name             old avg(ms)  new avg(ms)  delta
insert_100_1kb     1.84 ± 3%    1.74 ± 3%     ~     (p=0.079 n=5+5)
insert_100_2kb     1.96 ± 3%    1.84 ± 3%   -6.12%  (p=0.048 n=5+5)
insert_100_4kb     2.20 ± 0%    2.00 ± 0%   -9.09%  (p=0.008 n=5+5)
insert_100_8kb     3.10 ± 0%    2.90 ± 0%   -6.45%  (p=0.029 n=4+4)
insert_100_16kb    5.24 ± 1%    4.70 ± 0%  -10.31%  (p=0.008 n=5+5)
insert_100_32kb    9.50 ± 0%    7.36 ± 1%  -22.53%  (p=0.008 n=5+5)

name             old p99(ms)  new p99(ms)  delta
insert_100_1kb     7.30 ± 0%    7.18 ± 2%     ~     (p=0.167 n=5+5)
insert_100_2kb     7.54 ± 5%    7.38 ± 4%     ~     (p=0.484 n=5+5)
insert_100_4kb     7.90 ± 0%    7.82 ± 4%     ~     (p=0.968 n=4+5)
insert_100_8kb     13.6 ± 0%    14.4 ± 5%     ~     (p=0.079 n=4+5)
insert_100_16kb    22.0 ± 0%    23.1 ± 0%   +5.00%  (p=0.008 n=5+5)
insert_100_32kb    30.8 ± 2%    27.9 ± 2%   -9.53%  (p=0.008 n=5+5)
```