### PR TITLE
vfs: Add fdFileWrapper to re-implement Fd() method on file wrappers

### DIFF
--- a/vfs/disk_health.go
+++ b/vfs/disk_health.go
@@ -157,7 +157,7 @@ func (d diskHealthCheckingFS) Create(name string) (File, error) {
 		d.onSlowDisk(name, duration)
 	})
 	checkingFile.startTicker()
-	return checkingFile, nil
+	return WithFd(f, checkingFile), nil
 }
 
 // ReuseForWrite implements the vfs.FS interface.
@@ -173,5 +173,5 @@ func (d diskHealthCheckingFS) ReuseForWrite(oldname, newname string) (File, erro
 		d.onSlowDisk(newname, duration)
 	})
 	checkingFile.startTicker()
-	return checkingFile, nil
+	return WithFd(f, checkingFile), nil
 }

--- a/vfs/fd.go
+++ b/vfs/fd.go
@@ -1,0 +1,42 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package vfs
+
+// fdGetter is an interface for a file with an Fd() method. A lot of
+// File related optimizations (eg. Prefetch(), WAL recycling) rely on the
+// existence of the Fd method to return a raw file descriptor.
+type fdGetter interface {
+	Fd() uintptr
+}
+
+// fdFileWrapper is a File wrapper that also exposes an Fd() method. Used to
+// wrap outer (wrapped) Files that could unintentionally hide the Fd() method
+// exposed by the inner (unwrapped) File. It effectively lets the Fd() method
+// bypass the outer File and go to the inner File.
+type fdFileWrapper struct {
+	File
+
+	// All methods usually pass through to File above, except for Fd(), which
+	// bypasses it and gets called directly on the inner file.
+	inner fdGetter
+}
+
+func (f *fdFileWrapper) Fd() uintptr {
+	return f.inner.Fd()
+}
+
+// WithFd takes an inner (unwrapped) and an outer (wrapped) vfs.File,
+// and returns an fdFileWrapper if the inner file has an Fd() method. Use this
+// method to fix the hiding of the Fd() method and the subsequent unintentional
+// disabling of Fd-related file optimizations.
+func WithFd(inner, outer File) File {
+	if f, ok := inner.(fdGetter); ok {
+		return &fdFileWrapper{
+			File:  outer,
+			inner: f,
+		}
+	}
+	return outer
+}

--- a/vfs/fd_test.go
+++ b/vfs/fd_test.go
@@ -1,0 +1,37 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package vfs
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileWrappersHaveFd(t *testing.T) {
+	// Use the real filesystem so that we can test vfs.Default, which returns
+	// files with Fd().
+	tmpf, err := ioutil.TempFile("", "pebble-db-fd-file")
+	require.NoError(t, err)
+	filename := tmpf.Name()
+	defer os.Remove(filename)
+
+	// File wrapper case 1: Check if diskHealthCheckingFile has Fd().
+	fs2 := WithDiskHealthChecks(Default, 10 * time.Second, func(s string, duration time.Duration) {})
+	f2, err := fs2.Open(filename)
+	require.NoError(t, err)
+	if _, ok := f2.(fdGetter); !ok {
+		t.Fatal("expected diskHealthCheckingFile to export Fd() method")
+	}
+	// File wrapper case 2: Check if syncingFile has Fd().
+	f3 := NewSyncingFile(f2, SyncingFileOptions{BytesPerSync: 8 << 10 /* 8 KB */})
+	if _, ok := f3.(fdGetter); !ok {
+		t.Fatal("expected syncingFile to export Fd() method")
+	}
+	require.NoError(t, f2.Close())
+}

--- a/vfs/syncing_file.go
+++ b/vfs/syncing_file.go
@@ -75,12 +75,12 @@ func NewSyncingFile(f File, opts SyncingFileOptions) File {
 	if s.syncData == nil {
 		s.syncData = s.File.Sync
 	}
-	return s
+	return WithFd(f, s)
 }
 
 // NB: syncingFile.Write is unsafe for concurrent use!
 func (f *syncingFile) Write(p []byte) (n int, err error) {
-	_ = f.preallocate(atomic.LoadInt64(&f.atomic.offset) + int64(n))
+	_ = f.preallocate(atomic.LoadInt64(&f.atomic.offset))
 
 	n, err = f.File.Write(p)
 	if err != nil {

--- a/vfs/syncing_file_test.go
+++ b/vfs/syncing_file_test.go
@@ -32,6 +32,7 @@ func TestSyncingFile(t *testing.T) {
 		t.Fatalf("failed to wrap: %p != %p", f, s)
 	}
 	s = NewSyncingFile(f, SyncingFileOptions{BytesPerSync: 8 << 10 /* 8 KB */})
+	s = s.(*fdFileWrapper).File
 	s.(*syncingFile).fd = 1
 	s.(*syncingFile).syncTo = func(offset int64) error {
 		s.(*syncingFile).ratchetSyncOffset(offset)


### PR DESCRIPTION
Pebble relies on the existence of an `Fd() uintptr` method on file
handles for some optimizations (eg. WAL preallocation, Prefetch).
However, two of Pebble's own file wrappers used in production,
namely diskHealthCheckingFile and syncingFile, "hide" this
method even if the underlying os.File had it.

This change adds another type, fdFileWrapper, that embeds an "outer"
vfs.File while also reimplementing an Fd() method that bypasses
that outer vfs.File and passes through to the inner file.

Fixes #1047.