### PR TITLE
vfs: fix error return by MemFS.Remove for non-empty dir

### DIFF
--- a/vfs/errors_unix.go
+++ b/vfs/errors_unix.go
@@ -7,9 +7,13 @@
 package vfs
 
 import (
+	"syscall"
+
 	"github.com/cockroachdb/errors"
 	"golang.org/x/sys/unix"
 )
+
+var errNotEmpty = syscall.ENOTEMPTY
 
 // IsNoSpaceError returns true if the given error indicates that the disk is
 // out of space.

--- a/vfs/errors_windows.go
+++ b/vfs/errors_windows.go
@@ -11,6 +11,8 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+var errNotEmpty = windows.ERROR_DIR_NOT_EMPTY
+
 // IsNoSpaceError returns true if the given error indicates that the disk is
 // out of space.
 func IsNoSpaceError(err error) bool {

--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -319,7 +319,7 @@ func (y *MemFS) Remove(fullname string) error {
 				return oserror.ErrInvalid
 			}
 			if len(child.children) > 0 {
-				return oserror.ErrExist
+				return errNotEmpty
 			}
 			delete(dir.children, frag)
 		}


### PR DESCRIPTION
`MemFS.Remove` was previously returning `EEXIST` when attempting to
remove a non-empty directory. Now it returns `ENOTEMPTY` which matches
the behavior of unix filesystems and the `rmdir` system call.