### PR TITLE
db: change random generator for read sampling

### DIFF
--- a/internal/fastrand/fastrand.go
+++ b/internal/fastrand/fastrand.go
@@ -9,3 +9,7 @@ import _ "unsafe" // required by go:linkname
 // Uint32 returns a lock free uint32 value.
 //go:linkname Uint32 runtime.fastrand
 func Uint32() uint32
+
+// Uint32n returns a lock free uint32 value in the interval [0, n).
+//go:linkname Uint32n runtime.fastrandn
+func Uint32n(n uint32) uint32


### PR DESCRIPTION
The allocations in maybeSampleRead were 21.5% of object
allocations in a cockroachdb benchmark
(BenchmarkKV/Update). Read sampling now uses fastrand.
Additionally, we don't bother with executing the
sampling code when the iterator is not valid, since the
key and value fields are meaningless in that case.

There are microbenchmarks that show that this random
generator change is not slower.

BenchmarkSTFastRand-16       	553082136	         2.21 ns/op	       0 B/op	       0 allocs/op
BenchmarkSTDefaultRand/no-new-16         	228876657	         5.12 ns/op	       0 B/op	       0 allocs/op
BenchmarkSTDefaultRand/new-period=10-16  	48703587	        24.6 ns/op	       4 B/op	       0 allocs/op
BenchmarkSTDefaultRand/new-period=100-16 	92016868	        13.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkSTDefaultRand/new-period=1000-16         	98135948	        12.4 ns/op	       0 B/op	       0 allocs/op