### PR TITLE
docs: add an option to toggle per-chart scaling

### DIFF
--- a/docs/css/app.css
+++ b/docs/css/app.css
@@ -61,6 +61,10 @@ div.annotation {
     max-width: 800px;
 }
 
+.controls {
+    margin: 5px;
+}
+
 a {
     text-decoration: none;
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,15 +14,30 @@
           <div class="updated">Last updated</div>
         </div>
         <br/>
-        <div class="overview">
-          Benchmarks are run nightly using <a class="code"
-          href="https://github.com/cockroachdb/pebble/blob/master/cmd/pebble/ycsb.go">pebble
-          bench ycsb</a> on AWS c5d.4xlarge machines equipped with
-          local SSD storage. The AWS instances show remarkably high
-          instance to instance performance variability. In order to
-          smooth out that variability the benchmarks are run multiple
-          times each (using difference instances) and outliers are
-          excluded.
+        <div class="columns">
+          <div class="overview">
+            Benchmarks are run nightly using <a class="code"
+            href="https://github.com/cockroachdb/pebble/blob/master/cmd/pebble/ycsb.go">pebble
+            bench ycsb</a> on AWS c5d.4xlarge machines equipped with
+            local SSD storage. The AWS instances show remarkably high
+            instance to instance performance variability. In order to
+            smooth out that variability the benchmarks are run multiple
+            times each (using difference instances) and outliers are
+            excluded.
+          </div>
+          <div>
+            <div class="controls">
+              <b>Detail:</b>
+              <a id="readBytes" class="toggle">Bytes Read</a> |
+              <a id="writeBytes" class="toggle">Bytes Written</a> |
+              <a id="readAmp" class="toggle">Read Amp</a> |
+              <a id="writeAmp" class="toggle">Write Amp</a>
+            </div>
+            <div class="controls">
+              <b>Options:</b>
+              <a id="localMax">Local scale</a>
+            </div>
+          </div>
         </div>
         <hr class="divider"/>
         <div class="annotation" data-date="20200614">L0-sublevels and
@@ -39,18 +54,9 @@
         and preallocation bug fixed</div>
       </div>
       <div class="section rows">
-        <div class="columns">
-          <div>
-            <span class="subtitle">YCSB A</span>
-            <span>(50% reads, 50% updates, zipf key distribution)</span>
-          </div>
-          <div>
-            <b>Detail:</b>
-            <a id="readBytes" class="toggle">Bytes Read</a> |
-            <a id="writeBytes" class="toggle">Bytes Written</a> |
-            <a id="readAmp" class="toggle">Read Amp</a> |
-            <a id="writeAmp" class="toggle">Write Amp</a>
-          </div>
+        <div>
+          <span class="subtitle">YCSB A</span>
+          <span>(50% reads, 50% updates, zipf key distribution)</span>
         </div>
         <div class="columns">
           <svg class="chart" data-key="ycsb/A/values=64"></svg>


### PR DESCRIPTION
We've had some Pebble performance regressions go unnoticed, partially
because it can be difficult to see the regression visually within the
Pebble nightly benchmarks charts. It's especially difficult to see
fluctuations in benchmarks with significantly lower magnitude values
than the maximum across charts. For example, the ycsb/F/values=1024
workload has a throughput of about 26k ops/sec, compared to the
ycsb/c/values=64 workload's 2,800k ops/sec. This change adds a toggle to
the nightly benchmarks to scale each chart to its own maximum.

![Screen Shot 2021-01-22 at 1 17 04 PM](https://user-images.githubusercontent.com/867352/105529276-2932dd00-5cb4-11eb-818f-dacd0f957eb3.png)

A little 💪   Friday action.