### PR TITLE
compaction: Don't call maybeThrottle if nilPacer passed in.

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2371,8 +2371,10 @@ func (d *DB) runCompaction(
 			}
 
 			atomic.StoreUint64(c.atomicBytesIterated, c.bytesIterated)
-			if err := pacer.maybeThrottle(c.bytesIterated); err != nil {
-				return nil, pendingOutputs, err
+			if pacer != nilPacer {
+				if err := pacer.maybeThrottle(c.bytesIterated); err != nil {
+					return nil, pendingOutputs, err
+				}
 			}
 			if key.Kind() == InternalKeyKindRangeDelete {
 				// Range tombstones are handled specially. They are fragmented and


### PR DESCRIPTION
Currently, maybeThrottle is called for every key written to a
compaction output. Since this is a hot path, and since calling
pacer.maybeThrottle requires dynamic dispatch, quite a bit of
CPU cycles were being spent in just repeatedly calling that
method, which did nothing in production uses of Pebble anyway.

This change updates compaction code to just not make that
call if the nilPacer is used as the compaction pacer, which
happens for all non-testing uses of Pebble right now.

Paired w/ @angelazxu on this.

Fixes #1030