### PR TITLE
*: optimize SeekPrefixGE to use Next

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -944,7 +944,11 @@ func (i *batchIter) SeekGE(key []byte) (*InternalKey, []byte) {
 	return ikey, i.Value()
 }
 
-func (i *batchIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
+func (i *batchIter) SeekPrefixGE(
+	prefix, key []byte, trySeekUsingNext bool,
+) (*base.InternalKey, []byte) {
+	// Ignore trySeekUsingNext since the batch may have changed, so using Next
+	// would be incorrect.
 	i.err = nil // clear cached iteration error
 	return i.SeekGE(key)
 }
@@ -1282,7 +1286,11 @@ func (i *flushableBatchIter) SeekGE(key []byte) (*InternalKey, []byte) {
 
 // SeekPrefixGE implements internalIterator.SeekPrefixGE, as documented in the
 // pebble package.
-func (i *flushableBatchIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
+func (i *flushableBatchIter) SeekPrefixGE(
+	prefix, key []byte, trySeekUsingNext bool,
+) (*base.InternalKey, []byte) {
+	// Ignore trySeekUsingNext since flushable batches are not user-facing, so
+	// optimizing prefix seeks is not important.
 	return i.SeekGE(key)
 }
 
@@ -1443,7 +1451,9 @@ func (i *flushFlushableBatchIter) SeekGE(key []byte) (*InternalKey, []byte) {
 	panic("pebble: SeekGE unimplemented")
 }
 
-func (i *flushFlushableBatchIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
+func (i *flushFlushableBatchIter) SeekPrefixGE(
+	prefix, key []byte, trySeekUsingNext bool,
+) (*base.InternalKey, []byte) {
 	panic("pebble: SeekPrefixGE unimplemented")
 }
 

--- a/data_test.go
+++ b/data_test.go
@@ -168,11 +168,19 @@ func runInternalIterCmd(d *datadriven.TestData, iter internalIterator, opts ...i
 			prefix = nil
 			key, value = iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
 		case "seek-prefix-ge":
-			if len(parts) != 2 {
-				return "seek-prefix-ge <key>\n"
+			if len(parts) != 2 && len(parts) != 3 {
+				return "seek-prefix-ge <key> [<try-seek-using-next>]\n"
 			}
 			prefix = []byte(strings.TrimSpace(parts[1]))
-			key, value = iter.SeekPrefixGE(prefix, prefix /* key */)
+			trySeekUsingNext := false
+			if len(parts) == 3 {
+				var err error
+				trySeekUsingNext, err = strconv.ParseBool(parts[2])
+				if err != nil {
+					return err.Error()
+				}
+			}
+			key, value = iter.SeekPrefixGE(prefix, prefix /* key */, trySeekUsingNext)
 		case "seek-lt":
 			if len(parts) != 2 {
 				return "seek-lt <key>\n"

--- a/error_iter.go
+++ b/error_iter.go
@@ -21,7 +21,9 @@ func (c *errorIter) SeekGE(key []byte) (*InternalKey, []byte) {
 	return nil, nil
 }
 
-func (c *errorIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
+func (c *errorIter) SeekPrefixGE(
+	prefix, key []byte, trySeekUsingNext bool,
+) (*base.InternalKey, []byte) {
 	return nil, nil
 }
 

--- a/get_iter.go
+++ b/get_iter.go
@@ -48,7 +48,9 @@ func (g *getIter) SeekGE(key []byte) (*InternalKey, []byte) {
 	panic("pebble: SeekGE unimplemented")
 }
 
-func (g *getIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
+func (g *getIter) SeekPrefixGE(
+	prefix, key []byte, trySeekUsingNext bool,
+) (*base.InternalKey, []byte) {
 	panic("pebble: SeekPrefixGE unimplemented")
 }
 

--- a/internal/arenaskl/flush_iterator.go
+++ b/internal/arenaskl/flush_iterator.go
@@ -38,7 +38,9 @@ func (it *flushIterator) SeekGE(key []byte) (*base.InternalKey, []byte) {
 	panic("pebble: SeekGE unimplemented")
 }
 
-func (it *flushIterator) SeekPrefixGE(prefix, key []byte) (*base.InternalKey, []byte) {
+func (it *flushIterator) SeekPrefixGE(
+	prefix, key []byte, trySeekUsingNext bool,
+) (*base.InternalKey, []byte) {
 	panic("pebble: SeekPrefixGE unimplemented")
 }
 

--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -110,7 +110,33 @@ type InternalIterator interface {
 	// not supporting reverse iteration in prefix iteration mode until a
 	// different positioning routine (SeekGE, SeekLT, First or Last) switches the
 	// iterator out of prefix iteration.
-	SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte)
+	//
+	// trySeekUsingNext is a performance optimization that callers can use to
+	// indicate that they have not done any action to move this iterator
+	// beyond the first key that would be found if this iterator were to
+	// honestly do the indicated seek. For example, say the caller did a
+	// SeekPrefixGE(k1...), followed by SeekPrefixGE(k2...) where k1 <= k2,
+	// without any intermediate positioning calls. The caller can safely
+	// specify true for this parameter in the second call. As another example,
+	// say the caller did do one call to Next between the two SeekPrefixGE
+	// calls, and k1 < k2. Again, the caller can safely specify a true value
+	// for this parameter. Note that a false value is always safe. The callee
+	// is free to ignore the true value if its implementation does not permit
+	// this optimization.
+	// - We make the caller do this determination since a string comparison of
+	//   k1, k2 is not necessarily cheap, and there may be many iterators in
+	//   the iterator stack. Doing it once at the root of the iterator stack
+	//   is cheaper.
+	// - This optimization could also be applied to SeekGE and SeekLT (where
+	//   it would be trySeekUsingPrev). We currently only do it for
+	//   SeekPrefixGE because this is where this optimization helps the
+	//   performance of CockroachDB. The SeekGE and SeekLT cases in
+	//   CockroachDB are typically accompanied with bounds that change between
+	//   seek calls, and is optimized inside certain iterator implementations,
+	//   like singleLevelIterator, without any extra parameter passing (though
+	//   the same amortization of string comparisons could be done to improve
+	//   that optimization, by making the root of the iterator stack do it).
+	SeekPrefixGE(prefix, key []byte, trySeekUsingNext bool) (*InternalKey, []byte)
 
 	// SeekLT moves the iterator to the last key/value pair whose key is less
 	// than the given key. Returns the key and value if the iterator is pointing

--- a/internal/rangedel/iter.go
+++ b/internal/rangedel/iter.go
@@ -55,7 +55,7 @@ func (i *Iter) SeekGE(key []byte) (*base.InternalKey, []byte) {
 
 // SeekPrefixGE implements InternalIterator.SeekPrefixGE, as documented in the
 // internal/base package.
-func (i *Iter) SeekPrefixGE(prefix, key []byte) (*base.InternalKey, []byte) {
+func (i *Iter) SeekPrefixGE(prefix, key []byte, trySeekUsingNext bool) (*base.InternalKey, []byte) {
 	// This should never be called as prefix iteration is only done for point records.
 	panic("pebble: SeekPrefixGE unimplemented")
 }

--- a/internal_test.go
+++ b/internal_test.go
@@ -34,8 +34,8 @@ func (i *internalIterAdapter) SeekGE(key []byte) bool {
 	return i.update(i.internalIterator.SeekGE(key))
 }
 
-func (i *internalIterAdapter) SeekPrefixGE(prefix, key []byte) bool {
-	return i.update(i.internalIterator.SeekPrefixGE(prefix, key))
+func (i *internalIterAdapter) SeekPrefixGE(prefix, key []byte, trySeekUsingNext bool) bool {
+	return i.update(i.internalIterator.SeekPrefixGE(prefix, key, trySeekUsingNext))
 }
 
 func (i *internalIterAdapter) SeekLT(key []byte) bool {

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -87,7 +87,9 @@ func (f *fakeIter) SeekGE(key []byte) (*InternalKey, []byte) {
 	return nil, nil
 }
 
-func (f *fakeIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
+func (f *fakeIter) SeekPrefixGE(
+	prefix, key []byte, trySeekUsingNext bool,
+) (*base.InternalKey, []byte) {
 	return f.SeekGE(key)
 }
 
@@ -248,8 +250,10 @@ func (i *invalidatingIter) SeekGE(key []byte) (*InternalKey, []byte) {
 	return i.update(i.iter.SeekGE(key))
 }
 
-func (i *invalidatingIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
-	return i.update(i.iter.SeekPrefixGE(prefix, key))
+func (i *invalidatingIter) SeekPrefixGE(
+	prefix, key []byte, trySeekUsingNext bool,
+) (*base.InternalKey, []byte) {
+	return i.update(i.iter.SeekPrefixGE(prefix, key, trySeekUsingNext))
 }
 
 func (i *invalidatingIter) SeekLT(key []byte) (*InternalKey, []byte) {

--- a/level_iter.go
+++ b/level_iter.go
@@ -264,7 +264,15 @@ func (l *levelIter) initTableBounds(f *fileMetadata) int {
 	return 0
 }
 
-func (l *levelIter) loadFile(file *fileMetadata, dir int) bool {
+type loadFileReturnIndicator int8
+
+const (
+	noFileLoaded loadFileReturnIndicator = iota
+	fileAlreadyLoaded
+	newFileLoaded
+)
+
+func (l *levelIter) loadFile(file *fileMetadata, dir int) loadFileReturnIndicator {
 	l.smallestBoundary = nil
 	l.largestBoundary = nil
 	if l.isSyntheticIterBoundsKey != nil {
@@ -272,7 +280,7 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) bool {
 	}
 	if l.iterFile == file {
 		if l.err != nil {
-			return false
+			return noFileLoaded
 		}
 		if l.iter != nil {
 			// We don't bother comparing the file bounds with the iteration bounds when we have
@@ -281,7 +289,7 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) bool {
 			if l.rangeDelIterPtr != nil {
 				*l.rangeDelIterPtr = l.rangeDelIterCopy
 			}
-			return true
+			return fileAlreadyLoaded
 		}
 		// We were already at file, but don't have an iterator, probably because the file was
 		// beyond the iteration bounds. It may still be, but it is also possible that the bounds
@@ -293,20 +301,20 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) bool {
 	// when the levelIter will switch it. Note that levelIter.Close() can be
 	// called multiple times.
 	if err := l.Close(); err != nil {
-		return false
+		return noFileLoaded
 	}
 
 	for {
 		l.iterFile = file
 		if file == nil {
-			return false
+			return noFileLoaded
 		}
 
 		switch l.initTableBounds(file) {
 		case -1:
 			// The largest key in the sstable is smaller than the lower bound.
 			if dir < 0 {
-				return false
+				return noFileLoaded
 			}
 			file = l.files.Next()
 			continue
@@ -314,7 +322,7 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) bool {
 			// The smallest key in the sstable is greater than or equal to the upper
 			// bound.
 			if dir > 0 {
-				return false
+				return noFileLoaded
 			}
 			file = l.files.Prev()
 			continue
@@ -323,7 +331,7 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) bool {
 		var rangeDelIter internalIterator
 		l.iter, rangeDelIter, l.err = l.newIters(l.files.Current(), &l.tableOpts, l.bytesIterated)
 		if l.err != nil {
-			return false
+			return noFileLoaded
 		}
 		if l.rangeDelIterPtr != nil {
 			*l.rangeDelIterPtr = rangeDelIter
@@ -340,7 +348,7 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) bool {
 		if l.isLargestUserKeyRangeDelSentinel != nil {
 			*l.isLargestUserKeyRangeDelSentinel = file.Largest.Trailer == InternalKeyRangeDeleteSentinel
 		}
-		return true
+		return newFileLoaded
 	}
 }
 
@@ -372,7 +380,7 @@ func (l *levelIter) SeekGE(key []byte) (*InternalKey, []byte) {
 
 	// NB: the top-level Iterator has already adjusted key based on
 	// IterOptions.LowerBound.
-	if !l.loadFile(l.findFileGE(key), +1) {
+	if l.loadFile(l.findFileGE(key), +1) == noFileLoaded {
 		return nil, nil
 	}
 	if ikey, val := l.iter.SeekGE(key); ikey != nil {
@@ -381,7 +389,9 @@ func (l *levelIter) SeekGE(key []byte) (*InternalKey, []byte) {
 	return l.verify(l.skipEmptyFileForward())
 }
 
-func (l *levelIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
+func (l *levelIter) SeekPrefixGE(
+	prefix, key []byte, trySeekUsingNext bool,
+) (*base.InternalKey, []byte) {
 	l.err = nil // clear cached iteration error
 	if l.isSyntheticIterBoundsKey != nil {
 		*l.isSyntheticIterBoundsKey = false
@@ -389,10 +399,16 @@ func (l *levelIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
 
 	// NB: the top-level Iterator has already adjusted key based on
 	// IterOptions.LowerBound.
-	if !l.loadFile(l.findFileGE(key), +1) {
+	loadFileIndicator := l.loadFile(l.findFileGE(key), +1)
+	if loadFileIndicator == noFileLoaded {
 		return nil, nil
 	}
-	if key, val := l.iter.SeekPrefixGE(prefix, key); key != nil {
+	if loadFileIndicator == newFileLoaded {
+		// File changed, so l.iter has changed, and that iterator is not
+		// positioned appropriately.
+		trySeekUsingNext = false
+	}
+	if key, val := l.iter.SeekPrefixGE(prefix, key, trySeekUsingNext); key != nil {
 		return l.verify(key, val)
 	}
 	// When SeekPrefixGE returns nil, we have not necessarily reached the end of
@@ -430,7 +446,7 @@ func (l *levelIter) SeekLT(key []byte) (*InternalKey, []byte) {
 
 	// NB: the top-level Iterator has already adjusted key based on
 	// IterOptions.UpperBound.
-	if !l.loadFile(l.findFileLT(key), -1) {
+	if l.loadFile(l.findFileLT(key), -1) == noFileLoaded {
 		return nil, nil
 	}
 	if key, val := l.iter.SeekLT(key); key != nil {
@@ -447,7 +463,7 @@ func (l *levelIter) First() (*InternalKey, []byte) {
 
 	// NB: the top-level Iterator will call SeekGE if IterOptions.LowerBound is
 	// set.
-	if !l.loadFile(l.files.First(), +1) {
+	if l.loadFile(l.files.First(), +1) == noFileLoaded {
 		return nil, nil
 	}
 	if key, val := l.iter.First(); key != nil {
@@ -464,7 +480,7 @@ func (l *levelIter) Last() (*InternalKey, []byte) {
 
 	// NB: the top-level Iterator will call SeekLT if IterOptions.UpperBound is
 	// set.
-	if !l.loadFile(l.files.Last(), -1) {
+	if l.loadFile(l.files.Last(), -1) == noFileLoaded {
 		return nil, nil
 	}
 	if key, val := l.iter.Last(); key != nil {
@@ -495,7 +511,7 @@ func (l *levelIter) Next() (*InternalKey, []byte) {
 			return nil, nil
 		}
 		// We're stepping past the boundary key, so now we can load the next file.
-		if l.loadFile(l.files.Next(), +1) {
+		if l.loadFile(l.files.Next(), +1) != noFileLoaded {
 			if key, val := l.iter.First(); key != nil {
 				return l.verify(key, val)
 			}
@@ -535,7 +551,7 @@ func (l *levelIter) Prev() (*InternalKey, []byte) {
 			return nil, nil
 		}
 		// We're stepping past the boundary key, so now we can load the prev file.
-		if l.loadFile(l.files.Prev(), -1) {
+		if l.loadFile(l.files.Prev(), -1) != noFileLoaded {
 			if key, val := l.iter.Last(); key != nil {
 				return l.verify(key, val)
 			}
@@ -608,7 +624,7 @@ func (l *levelIter) skipEmptyFileForward() (*InternalKey, []byte) {
 		}
 
 		// Current file was exhausted. Move to the next file.
-		if !l.loadFile(l.files.Next(), +1) {
+		if l.loadFile(l.files.Next(), +1) == noFileLoaded {
 			return nil, nil
 		}
 	}
@@ -669,7 +685,7 @@ func (l *levelIter) skipEmptyFileBackward() (*InternalKey, []byte) {
 		}
 
 		// Current file was exhausted. Move to the previous file.
-		if !l.loadFile(l.files.Prev(), -1) {
+		if l.loadFile(l.files.Prev(), -1) == noFileLoaded {
 			return nil, nil
 		}
 	}

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -605,7 +605,9 @@ func (i *blockIter) SeekGE(key []byte) (*InternalKey, []byte) {
 
 // SeekPrefixGE implements internalIterator.SeekPrefixGE, as documented in the
 // pebble package.
-func (i *blockIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
+func (i *blockIter) SeekPrefixGE(
+	prefix, key []byte, trySeekUsingNext bool,
+) (*base.InternalKey, []byte) {
 	// This should never be called as prefix iteration is handled by sstable.Iterator.
 	panic("pebble: SeekPrefixGE unimplemented")
 }

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -202,11 +202,19 @@ func runIterCmd(td *datadriven.TestData, r *Reader) string {
 			prefix = nil
 			iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
 		case "seek-prefix-ge":
-			if len(parts) != 2 {
-				return fmt.Sprintf("seek-prefix-ge <key>\n")
+			if len(parts) != 2 && len(parts) != 3 {
+				return fmt.Sprintf("seek-prefix-ge <key> [<try-seek-using-next>]\n")
 			}
 			prefix = []byte(strings.TrimSpace(parts[1]))
-			iter.SeekPrefixGE(prefix, prefix /* key */)
+			trySeekUsingNext := false
+			if len(parts) == 3 {
+				var err error
+				trySeekUsingNext, err = strconv.ParseBool(parts[2])
+				if err != nil {
+					return err.Error()
+				}
+			}
+			iter.SeekPrefixGE(prefix, prefix /* key */, trySeekUsingNext)
 		case "seek-lt":
 			if len(parts) != 2 {
 				return fmt.Sprintf("seek-lt <key>\n")

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -57,8 +57,8 @@ func (i *iterAdapter) SeekGE(key []byte) bool {
 	return i.update(i.Iterator.SeekGE(key))
 }
 
-func (i *iterAdapter) SeekPrefixGE(prefix, key []byte) bool {
-	return i.update(i.Iterator.SeekPrefixGE(prefix, key))
+func (i *iterAdapter) SeekPrefixGE(prefix, key []byte, trySeekUsingNext bool) bool {
+	return i.update(i.Iterator.SeekPrefixGE(prefix, key, trySeekUsingNext))
 }
 
 func (i *iterAdapter) SeekLT(key []byte) bool {

--- a/sstable/testdata/prefixreader/iter
+++ b/sstable/testdata/prefixreader/iter
@@ -255,3 +255,16 @@ AA
 <err: pebble: not found>
 D
 C
+
+iter
+seek-prefix-ge a false
+seek-prefix-ge a true
+seek-prefix-ge aa true
+seek-prefix-ge d true
+seek-prefix-ge c false
+----
+<a:1>
+<a:1>
+<aa:2>
+<d:4>
+<c:3>

--- a/sstable/testdata/reader/iter
+++ b/sstable/testdata/reader/iter
@@ -240,6 +240,23 @@ next
 .
 <a:1>
 
+# Verify the optimization to use next when doing SeekPrefixGE.
+
+iter
+seek-prefix-ge a false
+seek-prefix-ge a true
+seek-prefix-ge b true
+seek-prefix-ge c true
+seek-prefix-ge d true
+seek-prefix-ge e true
+----
+<a:1>
+<a:1>
+<b:2>
+<c:3>
+<d:4>
+.
+
 # Verify that iteration from before the beginning or after the end of
 # the sstable does not "wrap around". A bug previously allowed this to
 # happen by letting the data block iterator and index iterator get out

--- a/testdata/iterator
+++ b/testdata/iterator
@@ -143,6 +143,38 @@ seek-prefix-ge a
 ----
 a:b
 
+iter seq=2
+seek-prefix-ge a
+seek-prefix-ge b
+----
+a:b
+.
+
+define
+a.DEL.3:
+a.SET.1:b
+b.DEL.3:
+b.SET.2:c
+c.SET.3:d
+----
+
+iter seq=4
+seek-prefix-ge a
+seek-prefix-ge b
+seek-prefix-ge c
+----
+.
+.
+c:d
+
+iter seq=3
+seek-prefix-ge a
+seek-prefix-ge b
+seek-prefix-ge c
+----
+a:b
+b:c
+.
 
 define
 a.SET.1:a
@@ -240,6 +272,14 @@ seek-prefix-ge d
 ----
 .
 
+iter seq=4
+seek-prefix-ge a
+seek-prefix-ge c
+seek-prefix-ge b
+----
+a:a
+c:c
+b:b
 
 define
 a.SET.b2:b
@@ -436,6 +476,29 @@ aaa:aaa
 b:b
 .
 
+iter seq=4
+seek-prefix-ge a
+seek-prefix-ge aa
+seek-prefix-ge aaa
+seek-prefix-ge b
+----
+a:a
+aa:aa
+aaa:aaa
+.
+
+iter seq=3
+seek-prefix-ge aaa
+seek-prefix-ge b
+seek-prefix-ge a
+seek-prefix-ge aa
+seek-prefix-ge aaa
+----
+.
+.
+a:a
+aa:aa
+.
 
 define
 bb.DEL.2:
@@ -898,6 +961,7 @@ next
 b:b
 .
 
+# The second set-bounds is a noop.
 iter seq=2
 set-bounds lower=b
 seek-ge a
@@ -905,7 +969,7 @@ set-bounds lower=b
 ----
 .
 b:b
-.
+b:b
 
 iter seq=2
 seek-ge a

--- a/testdata/level_iter_seek
+++ b/testdata/level_iter_seek
@@ -202,3 +202,78 @@ next
 d/<empty>#2,1:d
 a/a-b#1#1,15:
 d#2,1:d
+
+# Verify SeekPrefixGE correctness with trySeekUsingNext=true
+clear
+----
+
+build
+a.SET.1:a
+b.SET.2:b
+c.RANGEDEL.4:e
+----
+0: a#1,1-e#72057594037927935,15
+
+build
+e.SET.4:e
+f.SINGLEDEL.5:
+f.SET.4:f
+g.SET.6:g
+h.SINGLEDEL.7:
+----
+0: a#1,1-e#72057594037927935,15
+1: e#4,1-h#7,7
+
+build
+h.SET.6:h
+i.SET.6:i
+----
+0: a#1,1-e#72057594037927935,15
+1: e#4,1-h#7,7
+2: h#6,1-i#6,1
+
+build
+j.SET.7:j
+----
+0: a#1,1-e#72057594037927935,15
+1: e#4,1-h#7,7
+2: h#6,1-i#6,1
+3: j#7,1-j#7,1
+
+# Seeks to immediately following keys.
+iter
+seek-prefix-ge a true
+seek-prefix-ge a true
+seek-prefix-ge b true
+next
+seek-prefix-ge c true
+seek-prefix-ge d true
+seek-prefix-ge f true
+seek-prefix-ge g true
+seek-prefix-ge h true
+seek-prefix-ge i true
+seek-prefix-ge j true
+----
+a/c-e#4#1,1:a
+a/c-e#4#1,1:a
+b/c-e#4#2,1:b
+e#72057594037927935,15:
+e/c-e#4#72057594037927935,15:
+e/c-e#4#72057594037927935,15:
+f/<empty>#5,7:
+g/<empty>#6,1:g
+h/<empty>#7,7:
+i/<empty>#6,1:i
+j/<empty>#7,1:j
+
+# Seeks to keys that are in the next file, so cannot use Next.
+iter
+seek-prefix-ge a true
+seek-prefix-ge e true
+seek-prefix-ge i true
+seek-prefix-ge j true
+----
+a/c-e#4#1,1:a
+e/<empty>#4,1:e
+i/<empty>#6,1:i
+j/<empty>#7,1:j

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -203,7 +203,7 @@ func (s *sstableT) runCheck(cmd *cobra.Command, args []string) {
 			if prefixIter != nil {
 				n := r.Split(key.UserKey)
 				prefix := key.UserKey[:n]
-				key2, _ := prefixIter.SeekPrefixGE(prefix, key.UserKey)
+				key2, _ := prefixIter.SeekPrefixGE(prefix, key.UserKey, false)
 				if key2 == nil {
 					fmt.Fprintf(stdout, "WARNING: PREFIX ITERATION FAILURE!\n")
 					if s.fmtKey.spec != "null" {


### PR DESCRIPTION
CockroachDB uses SeekPrefixGE on the Put path to read
the existing value for a key. For a batch of Puts, the
common case is to use the same Iterator with a sequence
of SeekPrefixGE calls (with no intermediate Next calls).
These seek calls use keys that are sorted in ascending
order.

For a CockroachDB benchmark that does
`UPDATE bench.kv SET v = v + 1 WHERE k IN (...)`
for a batch of 100 keys, we see the following benefit

```
name                                old time/op    new time/op    delta
KVAndStorageUsingSQL/versions=2-16    3.27ms ± 2%    2.07ms ± 2%  -36.69%  (p=0.008 n=5+5)
KVAndStorageUsingSQL/versions=4-16    3.28ms ± 1%    2.07ms ± 0%  -36.90%  (p=0.008 n=5+5)
KVAndStorageUsingSQL/versions=8-16    3.65ms ± 1%    2.44ms ± 1%  -33.01%  (p=0.008 n=5+5)
```

Note that the above query also does a batch of 100 scans
to read the value for each key (the put is not
responsible for computing v + 1), which is not being
optimized here (it is already optimized to use Next).

This optimization is also needed to recover
the performance losses caused by using separated
intents as discussed in detail in
cockroachdb/cockroach#59397

Additionally, this PR optimizes away the allocation
of the Iterator.prefix byte slice.

The following are results from new benchmarks.
The arenaskl.Iterator and levelIter benchmarks show
speedup when this optimization is successful and small
slowdowns when it is not (higher skip settings). The
mergingIter shows speedup even with higher skip since
there are many sparse levels where we are already
beyond the next seek key, which benefit from this
optimization.

arenaskl.Iterator benchmark
```
BenchmarkSeekPrefixGE/skip=1/use-next=false-16         	 3059583	       388 ns/op	      22 B/op	       2 allocs/op
BenchmarkSeekPrefixGE/skip=1/use-next=true-16          	 7317049	       157 ns/op	      22 B/op	       2 allocs/op
BenchmarkSeekPrefixGE/skip=2/use-next=false-16         	 3095071	       382 ns/op	      22 B/op	       2 allocs/op
BenchmarkSeekPrefixGE/skip=2/use-next=true-16          	 7035187	       173 ns/op	      22 B/op	       2 allocs/op
BenchmarkSeekPrefixGE/skip=4/use-next=false-16         	 3015534	       398 ns/op	      22 B/op	       2 allocs/op
BenchmarkSeekPrefixGE/skip=4/use-next=true-16          	 5753680	       211 ns/op	      22 B/op	       2 allocs/op
BenchmarkSeekPrefixGE/skip=8/use-next=false-16         	 3046408	       403 ns/op	      22 B/op	       2 allocs/op
BenchmarkSeekPrefixGE/skip=8/use-next=true-16          	 2495090	       488 ns/op	      22 B/op	       2 allocs/op
BenchmarkSeekPrefixGE/skip=16/use-next=false-16        	 2754469	       419 ns/op	      22 B/op	       2 allocs/op
BenchmarkSeekPrefixGE/skip=16/use-next=true-16         	 2462174	       484 ns/op	      22 B/op	       2 allocs/op
```

levelIter benchmark
```
BenchmarkLevelIterSeqSeekPrefixGE/skip=1/use-next=false-16         	 2033031	       593 ns/op
BenchmarkLevelIterSeqSeekPrefixGE/skip=1/use-next=true-16          	12691249	        95.3 ns/op
BenchmarkLevelIterSeqSeekPrefixGE/skip=2/use-next=false-16         	 2035592	       593 ns/op
BenchmarkLevelIterSeqSeekPrefixGE/skip=2/use-next=true-16          	10188423	       117 ns/op
BenchmarkLevelIterSeqSeekPrefixGE/skip=4/use-next=false-16         	 2030196	       588 ns/op
BenchmarkLevelIterSeqSeekPrefixGE/skip=4/use-next=true-16          	 6742580	       173 ns/op
BenchmarkLevelIterSeqSeekPrefixGE/skip=8/use-next=false-16         	 1827902	       712 ns/op
BenchmarkLevelIterSeqSeekPrefixGE/skip=8/use-next=true-16          	 1454386	       761 ns/op
BenchmarkLevelIterSeqSeekPrefixGE/skip=16/use-next=false-16        	 1442826	       833 ns/op
BenchmarkLevelIterSeqSeekPrefixGE/skip=16/use-next=true-16         	 1280570	       936 ns/op
```

mergingIter benchmark
```
BenchmarkMergingIterSeqSeekPrefixGE/skip=1/use-next=false-16         	  700455	      1710 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergingIterSeqSeekPrefixGE/skip=1/use-next=true-16          	 2429803	       505 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergingIterSeqSeekPrefixGE/skip=2/use-next=false-16         	  683803	      1694 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergingIterSeqSeekPrefixGE/skip=2/use-next=true-16          	 2300224	       520 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergingIterSeqSeekPrefixGE/skip=4/use-next=false-16         	  668989	      1751 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergingIterSeqSeekPrefixGE/skip=4/use-next=true-16          	 2111007	       568 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergingIterSeqSeekPrefixGE/skip=8/use-next=false-16         	  658203	      1817 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergingIterSeqSeekPrefixGE/skip=8/use-next=true-16          	  998536	      1191 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergingIterSeqSeekPrefixGE/skip=16/use-next=false-16        	  620912	      1990 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergingIterSeqSeekPrefixGE/skip=16/use-next=true-16         	  856705	      1343 ns/op	       0 B/op	       0 allocs/op
```