### PR TITLE
db: fix bug in seek noop optimization and add more testing

### DIFF
--- a/internal/metamorphic/config.go
+++ b/internal/metamorphic/config.go
@@ -26,6 +26,7 @@ const (
 	newBatch
 	newIndexedBatch
 	newIter
+	newIterUsingClone
 	newSnapshot
 	readerGet
 	snapshotClose
@@ -72,6 +73,7 @@ var defaultConfig = config{
 		newBatch:          5,
 		newIndexedBatch:   5,
 		newIter:           10,
+		newIterUsingClone: 5,
 		newSnapshot:       10,
 		readerGet:         100,
 		snapshotClose:     10,

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -508,6 +508,26 @@ func (o *newIterOp) String() string {
 		o.iterID, o.readerID, o.lower, o.upper)
 }
 
+// newIterUsingCloneOp models a Iterator.Clone operation.
+type newIterUsingCloneOp struct {
+	existingIterID objID
+	iterID         objID
+}
+
+func (o *newIterUsingCloneOp) run(t *test, h *history) {
+	iter := t.getIter(o.existingIterID)
+	i, err := iter.iter.Clone()
+	if err != nil {
+		panic(err)
+	}
+	t.setIter(o.iterID, i)
+	h.Recordf("%s // %v", o, i.Error())
+}
+
+func (o *newIterUsingCloneOp) String() string {
+	return fmt.Sprintf("%s = %s.Clone()", o.iterID, o.existingIterID)
+}
+
 // iterSetBoundsOp models an Iterator.SetBounds operation.
 type iterSetBoundsOp struct {
 	iterID objID

--- a/internal/metamorphic/parser.go
+++ b/internal/metamorphic/parser.go
@@ -78,6 +78,8 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 		return nil, &t.batchID, nil
 	case *newIterOp:
 		return &t.readerID, &t.iterID, []interface{}{&t.lower, &t.upper}
+	case *newIterUsingCloneOp:
+		return &t.existingIterID, &t.iterID, nil
 	case *newSnapshotOp:
 		return nil, &t.snapID, nil
 	case *iterNextOp:
@@ -101,6 +103,7 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 var methods = map[string]*methodInfo{
 	"Apply":           makeMethod(applyOp{}, dbTag, batchTag),
 	"Checkpoint":      makeMethod(checkpointOp{}, dbTag),
+	"Clone":           makeMethod(newIterUsingCloneOp{}, iterTag),
 	"Close":           makeMethod(closeOp{}, dbTag, batchTag, iterTag, snapTag),
 	"Commit":          makeMethod(batchCommitOp{}, batchTag),
 	"Compact":         makeMethod(compactOp{}, dbTag),

--- a/testdata/iterator_seek_opt_errors
+++ b/testdata/iterator_seek_opt_errors
@@ -1,0 +1,87 @@
+define
+a.SET.1:a
+b.SET.1:b
+c.SET.1:c
+d.SET.1:d
+----
+
+# Exercise noop optimization with no errors
+
+iter
+seek-ge aa
+seek-ge aa
+seek-ge aaa
+seek-ge b
+seek-ge bb
+----
+b:b
+b:b
+b:b
+b:b
+c:c
+
+iter
+seek-lt ddd
+seek-lt ddd
+seek-lt dd
+seek-lt d
+seek-lt c
+----
+d:d
+d:d
+d:d
+c:c
+b:b
+
+# Exercise errors which should prevent seek optimizations.
+
+iter seek-error=(0,1)
+seek-ge a
+seek-ge b
+seek-ge c
+seek-ge d
+----
+err=injecting error
+err=injecting error
+c:c
+d:d
+
+iter seek-error=(1)
+seek-ge d
+seek-ge a
+seek-ge b
+seek-ge b
+----
+d:d
+err=injecting error
+b:b
+b:b
+
+iter seek-error=(0,1)
+seek-lt e
+seek-lt d
+seek-lt c
+seek-lt b
+----
+err=injecting error
+err=injecting error
+b:b
+a:a
+
+iter seek-error=(1)
+seek-lt b
+seek-lt e
+seek-lt e
+----
+a:a
+err=injecting error
+d:d
+
+iter seek-error=(1)
+seek-prefix-ge d
+seek-prefix-ge a
+seek-prefix-ge b
+----
+d:d
+err=injecting error
+b:b


### PR DESCRIPTION
- SeekLT had a bug that included the equality case in
  the comparison.
- Added an explicit error handling test, that checks
  that the optimization is not used when the
  InternalIterator returns an error. This test also
  exercises some non-error cases, including the bug.
- Added randomization on when the optimization is
  applied when invariants.Enabled is true.
- Added a comment explaining why this optimization
  is not used when the batch is non-nil. Also, we
  no longer copy the seek key when batch is non-nil,
  since that copy is wasted.
- Added support for Iterator.Clone to the metamorphic
  test.