### PR TITLE
vfs: Use frsize in GetFreeSpace

### DIFF
--- a/vfs/disk_usage_linux.go
+++ b/vfs/disk_usage_linux.go
@@ -1,0 +1,36 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build linux
+
+package vfs
+
+import "golang.org/x/sys/unix"
+
+func (defaultFS) GetFreeSpace(path string) (uint64, error) {
+	stat := unix.Statfs_t{}
+	if err := unix.Statfs(path, &stat); err != nil {
+		return 0, err
+	}
+
+	// We use stat.Frsize here rather than stat.Bsize because on
+	// Linux Bfree is in Frsize units.
+	//
+	// On most filesystems Frsize and Bsize will be set to the
+	// same value, but on some filesystems bsize returns the
+	// "optimal transfer block size"[1] which may be different
+	// (typically larger) than the actual block size.
+	//
+	// This confusion is cleared up in the statvfs[2] libc function,
+	// but the statfs system call used above varies across
+	// platforms.
+	//
+	// Frsize is used by GNU coreutils and other libraries, so
+	// this also helps ensure that we get the same results as one
+	// would get if they ran `df` on the given path.
+	//
+	// [1] https://man7.org/linux/man-pages/man2/statfs.2.html
+	// [2] https://man7.org/linux/man-pages/man3/statvfs.3.html
+	return uint64(stat.Frsize) * stat.Bfree, nil
+}

--- a/vfs/disk_usage_unix.go
+++ b/vfs/disk_usage_unix.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-// +build darwin linux openbsd dragonfly freebsd
+// +build darwin openbsd dragonfly freebsd
 
 package vfs
 


### PR DESCRIPTION
On linux, the Statfs struct contains an Frsize field that should be
preferred over the bsize field.

For example, consider the following example program:

```go
package main

import (
	"fmt"
	"os"

	"golang.org/x/sys/unix"
)

func main() {
	path := os.Args[1]
	var fs unix.Statfs_t
	if err := unix.Statfs(path, &fs); err != nil {
		fmt.Fprintf(os.Stderr, "fatal error: %s", err.Error())
	}
	fmt.Printf("{\n Bfree: %d\n BAvail: %d\n Bsize: %d\n Frsize: %d\n}\n\n", fs.Bfree, fs.Bavail, fs.Bsize, fs.Frsize)
	fmt.Printf("Free KB with Bsize:   (%d*%8d)/1024 = %d\n", fs.Bfree, fs.Bsize, (fs.Bfree*uint64(fs.Bsize))/1024)
	fmt.Printf("Free KB with Frsize:  (%d*%8d)/1024 = %d\n\n", fs.Bfree, fs.Frsize, (fs.Bfree*uint64(fs.Frsize))/1024)
        fmt.Printf("Avail KB with Bsize:  (%d*%8d)/1024 = %d\n", fs.Bavail, fs.Bsize, (fs.Bavail*uint64(fs.Bsize))/1024)
	fmt.Printf("Avail KB with Frsize: (%d*%8d)/1024 = %d\n", fs.Bavail, fs.Frsize, (fs.Bavail*uint64(fs.Frsize))/1024)
}
```

When we compare the output of this program to GNU df, we can see that
we get different results because of the difference between bsize and
frsize:

```
> df -k /src/
Filesystem     1K-blocks      Used Available Use% Mounted on
grpcfuse       976797816 157703540 803678340  17% /src
> ./statfs_test /src/
{
 Bfree: 204773569
 BAvail: 200919585
 Bsize: 1048576
 Frsize: 4096
}

Free KB with Bsize:   (204773569* 1048576)/1024 = 209688134656
Free KB with Frsize:  (204773569*    4096)/1024 = 819094276

Avail KB with Bsize:  (200919585* 1048576)/1024 = 205741655040
Avail KB with Frsize: (200919585*    4096)/1024 = 803678340
```

* Notes

- The impact of this is likely minimal as on most production
  filesystems we care about bsize and frsize will be the same.

- The statvfs manual page calls out that at least f_blocks is in
  frsize units, but that isn't _really_ relevant here as on Linux Go
  calls that statfs system call directly rather than using the libc
  wrapper. Unfortunately the statfs manual page gives no such guidance:

  https://man7.org/linux/man-pages/man3/statvfs.3.html
  https://man7.org/linux/man-pages/man2/statfs.2.html

- GNU df uses gnulib which uses frsize for the blocksize on linux 2.6
  to 2.6.36, after 2.6.36 it uses the statvfs wrapper, preferring frsize
  but falling back to bsize:

  https://github.com/coreutils/gnulib/blob/6466d2540a841d91d8d5ddafd5a2e54f601954b9/lib/fsusage.c#L146-L149
  https://github.com/coreutils/gnulib/blob/6466d2540a841d91d8d5ddafd5a2e54f601954b9/lib/fsusage.c#L167

- glibc fills in the statvfs frsize field directly from the bsize
  field on linux, falling back to bsize for older kernels:

  https://github.com/bminor/glibc/blob/035c012e32c11e84d64905efaf55e74f704d3668/sysdeps/unix/sysv/linux/internal_statvfs.c#L31-L37

- Linux will set frsize to bsize of the underlying filesystem doesn't
  set it:

  https://github.com/torvalds/linux/blob/master/fs/statfs.c#L67-L68

  It appears to have done this for as long as linux has used
  git (since 2.6.12-rc2). Given this, I've elided any fallback logic,
  but can happily add it if we think users are on 16+ year old
  kernels.

- Unfortunately the grpcfuse filesystem above is a closed-source
  component of docker-for-mac so it is hard to say what it does.

- To add to the fun, on FreeBSD, OpenBSD, and Darwin I think the
  current use of Bsize is correct based on my reading of their man pages
  and struct definitions:

  https://man.openbsd.org/statfs.2
  https://www.freebsd.org/cgi/man.cgi?query=statfs&sektion=2&n=1
  https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/statfs.2.html