### PR TITLE
db: remove Iterator.SetBounds optimization for unchanging bounds

### DIFF
--- a/testdata/iterator
+++ b/testdata/iterator
@@ -961,14 +961,15 @@ next
 b:b
 .
 
-# The second set-bounds is a noop.
 iter seq=2
 set-bounds lower=b
 seek-ge a
 set-bounds lower=b
+seek-ge a
 ----
 .
 b:b
+.
 b:b
 
 iter seq=2


### PR DESCRIPTION
Also clarify the semantics on when bounds slices can be mutated
by the caller.
This optimization was the cause of the failures in CockroachDB's
cdc/bank/cluster-recovery test. There is no new test here since
the contract is now on the caller's side (there will be a
CockroachDB test to ensure that the contract is not being
violated).