### PR TITLE
use GOMAXPROCS instead of NumCPU

### DIFF
--- a/internal/cache/clockpro.go
+++ b/internal/cache/clockpro.go
@@ -545,7 +545,7 @@ type Cache struct {
 //   defer c.Unref()
 //   d, err := pebble.Open(pebble.Options{Cache: c})
 func New(size int64) *Cache {
-	return newShards(size, 2*runtime.NumCPU())
+	return newShards(size, 2*runtime.GOMAXPROCS(0))
 }
 
 func newShards(size int64, shards int) *Cache {

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -244,7 +244,7 @@ func TestSnapshotRangeDeletionStress(t *testing.T) {
 	// Check that all the snapshots contain the expected number of keys.
 	// Iterating over so many keys is slow, so do it in parallel.
 	var wg sync.WaitGroup
-	sem := make(chan struct{}, runtime.NumCPU())
+	sem := make(chan struct{}, runtime.GOMAXPROCS(0))
 	for r := range snapshots {
 		wg.Add(1)
 		sem <- struct{}{}

--- a/table_cache.go
+++ b/table_cache.go
@@ -38,7 +38,7 @@ func (c *tableCache) init(cacheID uint64, dirname string, fs vfs.FS, opts *Optio
 	c.cache = opts.Cache
 	c.cache.Ref()
 
-	c.shards = make([]*tableCacheShard, runtime.NumCPU())
+	c.shards = make([]*tableCacheShard, runtime.GOMAXPROCS(0))
 	for i := range c.shards {
 		c.shards[i] = &tableCacheShard{}
 		c.shards[i].init(cacheID, dirname, fs, opts, size/len(c.shards))


### PR DESCRIPTION
GOMAXPROCS is usually the same with NumCPU, but it allows control; for
example, we limit GOMAXPROCS for race detector tests.