### PR TITLE
db: enhance Iterator with limited iteration mode

### DIFF
--- a/internal/metamorphic/config.go
+++ b/internal/metamorphic/config.go
@@ -18,9 +18,13 @@ const (
 	iterFirst
 	iterLast
 	iterNext
+	iterNextWithLimit
 	iterPrev
+	iterPrevWithLimit
 	iterSeekGE
+	iterSeekGEWithLimit
 	iterSeekLT
+	iterSeekLTWithLimit
 	iterSeekPrefixGE
 	iterSetBounds
 	newBatch
@@ -56,34 +60,38 @@ type config struct {
 var defaultConfig = config{
 	// dbClose is not in this list since it is deterministically generated once, at the end of the test.
 	ops: []int{
-		batchAbort:         5,
-		batchCommit:        5,
-		dbCheckpoint:       1,
-		dbCompact:          1,
-		dbFlush:            2,
-		dbRestart:          2,
-		iterClose:          5,
-		iterFirst:          100,
-		iterLast:           100,
-		iterNext:           100,
-		iterPrev:           100,
-		iterSeekGE:         100,
-		iterSeekLT:         100,
-		iterSeekPrefixGE:   100,
-		iterSetBounds:      100,
-		newBatch:           5,
-		newIndexedBatch:    5,
-		newIter:            10,
-		newIterUsingClone:  5,
-		newSnapshot:        10,
-		readerGet:          100,
-		snapshotClose:      10,
-		writerApply:        10,
-		writerDelete:       100,
-		writerDeleteRange:  50,
-		writerIngest:       100,
-		writerMerge:        100,
-		writerSet:          100,
-		writerSingleDelete: 25,
+		batchAbort:          5,
+		batchCommit:         5,
+		dbCheckpoint:        1,
+		dbCompact:           1,
+		dbFlush:             2,
+		dbRestart:           2,
+		iterClose:           5,
+		iterFirst:           100,
+		iterLast:            100,
+		iterNext:            100,
+		iterNextWithLimit:   20,
+		iterPrev:            100,
+		iterPrevWithLimit:   20,
+		iterSeekGE:          100,
+		iterSeekGEWithLimit: 20,
+		iterSeekLT:          100,
+		iterSeekLTWithLimit: 20,
+		iterSeekPrefixGE:    100,
+		iterSetBounds:       100,
+		newBatch:            5,
+		newIndexedBatch:     5,
+		newIter:             10,
+		newIterUsingClone:   5,
+		newSnapshot:         10,
+		readerGet:           100,
+		snapshotClose:       10,
+		writerApply:         10,
+		writerDelete:        100,
+		writerDeleteRange:   50,
+		writerIngest:        100,
+		writerMerge:         100,
+		writerSet:           100,
+		writerSingleDelete:  25,
 	},
 }

--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -42,7 +42,14 @@ var (
 		"the directory storing test state")
 	disk = flag.Bool("disk", false,
 		"whether to use an in-mem DB or on-disk (in-mem is significantly faster)")
-	// TODO: default error rate to a non-zero value
+	// TODO: default error rate to a non-zero value. Currently, retrying is
+	// non-deterministic because of the Ierator.*WithLimit() methods since
+	// they may say that the Iterator is not valid, but be positioned at a
+	// certain key that can be returned in the future if the limit is changed.
+	// Since that key is hidden from clients of Iterator, the retryableIter
+	// using SeekGE will not necessarily position the Iterator that saw an
+	// injected error at the same place as an Iterator that did not see that
+	// error.
 	errorRate = flag.Float64("error-rate", 0.0,
 		"rate of errors injected into filesystem operations (0 ≤ r < 1)")
 	failRE = flag.String("fail", "",

--- a/internal/metamorphic/parser.go
+++ b/internal/metamorphic/parser.go
@@ -83,13 +83,13 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	case *newSnapshotOp:
 		return nil, &t.snapID, nil
 	case *iterNextOp:
-		return &t.iterID, nil, nil
+		return &t.iterID, nil, []interface{}{&t.limit}
 	case *iterPrevOp:
-		return &t.iterID, nil, nil
+		return &t.iterID, nil, []interface{}{&t.limit}
 	case *iterSeekLTOp:
-		return &t.iterID, nil, []interface{}{&t.key}
+		return &t.iterID, nil, []interface{}{&t.key, &t.limit}
 	case *iterSeekGEOp:
-		return &t.iterID, nil, []interface{}{&t.key}
+		return &t.iterID, nil, []interface{}{&t.key, &t.limit}
 	case *iterSeekPrefixGEOp:
 		return &t.iterID, nil, []interface{}{&t.key}
 	case *setOp:

--- a/internal/metamorphic/retryable.go
+++ b/internal/metamorphic/retryable.go
@@ -81,10 +81,22 @@ func (i *retryableIter) Next() bool {
 	return valid
 }
 
+func (i *retryableIter) NextWithLimit(limit []byte) pebble.IterValidityState {
+	var validity pebble.IterValidityState
+	i.withRetry(func() { validity = i.iter.NextWithLimit(limit) })
+	return validity
+}
+
 func (i *retryableIter) Prev() bool {
 	var valid bool
 	i.withRetry(func() { valid = i.iter.Prev() })
 	return valid
+}
+
+func (i *retryableIter) PrevWithLimit(limit []byte) pebble.IterValidityState {
+	var validity pebble.IterValidityState
+	i.withRetry(func() { validity = i.iter.PrevWithLimit(limit) })
+	return validity
 }
 
 func (i *retryableIter) SeekGE(key []byte) bool {
@@ -93,10 +105,22 @@ func (i *retryableIter) SeekGE(key []byte) bool {
 	return valid
 }
 
+func (i *retryableIter) SeekGEWithLimit(key []byte, limit []byte) pebble.IterValidityState {
+	var validity pebble.IterValidityState
+	i.withRetry(func() { validity = i.iter.SeekGEWithLimit(key, limit) })
+	return validity
+}
+
 func (i *retryableIter) SeekLT(key []byte) bool {
 	var valid bool
 	i.withRetry(func() { valid = i.iter.SeekLT(key) })
 	return valid
+}
+
+func (i *retryableIter) SeekLTWithLimit(key []byte, limit []byte) pebble.IterValidityState {
+	var validity pebble.IterValidityState
+	i.withRetry(func() { validity = i.iter.SeekLTWithLimit(key, limit) })
+	return validity
 }
 
 func (i *retryableIter) SeekPrefixGE(key []byte) bool {

--- a/testdata/iterator
+++ b/testdata/iterator
@@ -1284,3 +1284,116 @@ iter seq=4
 first
 ----
 .
+
+# Exercise iteration with limits, when there are no deletes.
+define
+a.SET.1:a
+b.SET.1:b
+c.SET.1:c
+d.SET.1:d
+----
+
+iter seq=2
+seek-ge-limit a b
+next-limit b
+prev-limit a
+next-limit b
+next-limit b
+seek-lt-limit d d
+prev-limit d
+next-limit e
+prev-limit d
+prev-limit c
+prev-limit b
+prev-limit a
+prev-limit a
+next-limit a
+next-limit b
+----
+a:a valid
+. at-limit
+a:a valid
+. at-limit
+. at-limit
+. at-limit
+. at-limit
+d:d valid
+. at-limit
+c:c valid
+b:b valid
+a:a valid
+. exhausted
+. at-limit
+a:a valid
+
+# Exercise iteration with limits when we have deletes.
+
+define
+a.SET.1:a
+b.DEL.3:
+b.SET.2:b
+c.DEL.3:
+c.SET.2:c
+d.SET.1:d
+----
+
+iter seq=4
+seek-ge-limit a b
+next-limit b
+prev-limit a
+prev-limit a
+next-limit b
+next-limit b
+next-limit b
+prev-limit a
+next-limit c
+prev-limit b
+next-limit c
+next-limit d
+next-limit e
+next-limit e
+prev-limit d
+next-limit e
+----
+a:a valid
+. at-limit
+a:a valid
+. exhausted
+a:a valid
+. at-limit
+. at-limit
+a:a valid
+. at-limit
+. at-limit
+. at-limit
+. at-limit
+d:d valid
+. exhausted
+d:d valid
+. exhausted
+
+iter seq=4
+seek-ge-limit b d
+next-limit d
+prev-limit b
+next-limit e
+----
+. at-limit
+. at-limit
+. at-limit
+d:d valid
+
+iter seq=4
+seek-lt-limit d c
+prev-limit c
+prev-limit b
+prev-limit a
+prev-limit a
+next-limit b
+----
+. at-limit
+. at-limit
+. at-limit
+a:a valid
+. exhausted
+a:a valid


### PR DESCRIPTION
Limited iteration mode is a best-effort way for the caller
to specify an exclusive forward or inclusive reverse limit
on each limited-iteration call. The limit lasts only for
the duration of the call. The limit is exclusive for
forward iteration and inclusive for reverse iteration.

Iterator supports WithLimit variants for SeekGE, SeekLT,
Next, Prev. These are motivated by the O(N^2) complexity
we observe when doing coordinated iteration over the
lock table and MVCC keys in CockroachDB where all the
intents in the lock table are deleted but have not yet
been compacted away. The O(N^2) complexity arises in two
cases:
- Limited scans: the extreme is a limited scan with a
  limit of 1. Each successive scan traverses N, N-1, ...
  locks.
- Mix of forward/reverse iteration in a single scan: A
  Next/SeekGE will incur a cost of N and the Prev/SeekLT
  another cost of N.
  This situation could be potentially fixed with a narrower
  solution, given the constrained way that the combination of
  forward and backward iteration is used in CockroachDB
  code, but it would be fragile. The limited iteration mode
  solves it in a more general way.

The implementation of limited iteration eschews
best-effort behavior (though that would reduce some
comparisons) so that it can be deterministic and be
tested via the metamorphic test.

The existing seek optimizations are impacted in the
following way:
- Use next before seeking:
  - Repeated seeks (forward or reverse) with monotonic
    bounds: this optimization operates at mergingIter
    and below and is therefore unaffected by whatever
    Iterator may be doing with the keys exposed by
    mergingIter.
  - monotonic SeekPrefixGE: SeekPrefixGE does not
    expose a limited iteration variant since the
    prefix comparison performed by Iterator already
    ensures the absence of quadratic behavior.
- Noop seeks (forward and reverse): this optimization
  happens purely in Iterator. It is altered to account
  for limited iteration, and forks into 2 paths,
  (a) truly a noop, (b) the limit on the preceding
  seek has positioned the iterator at a key that is
  outside the limit. In case (b) the underlying
  mergingIter does not need to be seeked, but there
  is work to be done in finding an appropriate
  prev or next entry.

See https://github.com/sumeerbhola/cockroach/tree/iter_coord
for the corresponding CockroachDB change that uses
these methods.