### PR TITLE
[dnm] reproduce a memory leak under -race

### DIFF
--- a/db.go
+++ b/db.go
@@ -8,7 +8,6 @@ package pebble // import "github.com/cockroachdb/pebble"
 import (
 	"fmt"
 	"io"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -16,7 +15,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/arenaskl"
 	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/manual"
 	"github.com/cockroachdb/pebble/internal/record"
@@ -1291,9 +1289,6 @@ func (d *DB) newMemTable(logNum FileNum, logSeqNum uint64) (*memTable, *flushabl
 		arenaBuf:  manual.New(int(size)),
 		logSeqNum: logSeqNum,
 	})
-	if invariants.Enabled {
-		runtime.SetFinalizer(mem, checkMemTable)
-	}
 
 	entry := d.newFlushableEntry(mem, logNum, logSeqNum)
 	entry.releaseMemAccounting = func() {

--- a/internal/cache/clockpro.go
+++ b/internal/cache/clockpro.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"runtime"
 	"runtime/debug"
-	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -566,18 +565,6 @@ func newShards(size int64, shards int) *Cache {
 		}
 		c.shards[i].blocks.init(16)
 		c.shards[i].files.init(16)
-	}
-	if !invariants.RaceEnabled {
-		runtime.SetFinalizer(c, func(obj interface{}) {
-			c := obj.(*Cache)
-			if v := atomic.LoadInt64(&c.refs); v != 0 {
-				c.tr.Lock()
-				fmt.Fprintf(os.Stderr, "pebble: cache (%p) has non-zero reference count: %d\n%s",
-					c, v, strings.Join(c.tr.msgs, "\n"))
-				c.tr.Unlock()
-				os.Exit(1)
-			}
-		})
 	}
 	return c
 }

--- a/internal/cache/entry_invariants.go
+++ b/internal/cache/entry_invariants.go
@@ -19,14 +19,6 @@ const entriesGoAllocated = true
 
 func entryAllocNew() *entry {
 	e := &entry{}
-	runtime.SetFinalizer(e, func(obj interface{}) {
-		e := obj.(*entry)
-		if v := e.ref.refs(); v != 0 {
-			fmt.Fprintf(os.Stderr, "%p: cache entry has non-zero reference count: %d\n%s",
-				e, v, e.ref.traces())
-			os.Exit(1)
-		}
-	})
 	return e
 }
 

--- a/internal/cache/entry_normal.go
+++ b/internal/cache/entry_normal.go
@@ -7,7 +7,6 @@
 package cache
 
 import (
-	"runtime"
 	"sync"
 	"unsafe"
 
@@ -53,9 +52,6 @@ type entryAllocCache struct {
 
 func newEntryAllocCache() *entryAllocCache {
 	c := &entryAllocCache{}
-	if !entriesGoAllocated {
-		runtime.SetFinalizer(c, freeEntryAllocCache)
-	}
 	return c
 }
 

--- a/internal/cache/robin_hood.go
+++ b/internal/cache/robin_hood.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math/bits"
 	"os"
-	"runtime"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -134,15 +133,6 @@ func maxDistForSize(size uint32) uint32 {
 func newRobinHoodMap(initialCapacity int) *robinHoodMap {
 	m := &robinHoodMap{}
 	m.init(initialCapacity)
-	if invariants.Enabled {
-		runtime.SetFinalizer(m, func(obj interface{}) {
-			m := obj.(*robinHoodMap)
-			if m.entries.ptr != nil {
-				fmt.Fprintf(os.Stderr, "%p: robin-hood map not freed\n", m)
-				os.Exit(1)
-			}
-		})
-	}
 	return m
 }
 

--- a/internal/cache/value_invariants.go
+++ b/internal/cache/value_invariants.go
@@ -27,14 +27,6 @@ func newValue(n int) *Value {
 	b := manual.New(n)
 	v := &Value{buf: b}
 	v.ref.init(1)
-	runtime.SetFinalizer(v, func(obj interface{}) {
-		v := obj.(*Value)
-		if v.buf != nil {
-			fmt.Fprintf(os.Stderr, "%p: cache value was not freed: refs=%d\n%s",
-				v, v.refs(), v.ref.traces())
-			os.Exit(1)
-		}
-	})
 	return v
 }
 

--- a/open.go
+++ b/open.go
@@ -363,7 +363,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	d.maybeScheduleFlush()
 	d.maybeScheduleCompaction()
 
-	if invariants.Enabled {
+	if !opts.NoFinalizer && invariants.Enabled {
 		runtime.SetFinalizer(d, func(obj interface{}) {
 			d := obj.(*DB)
 			if err := d.closed.Load(); err == nil {

--- a/open.go
+++ b/open.go
@@ -362,6 +362,8 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	d.maybeScheduleFlush()
 	d.maybeScheduleCompaction()
 
+	d.fileLock, fileLock = fileLock, nil
+
 	if !opts.NoFinalizer {
 		// Holding on to `d` leaks memory, but holding on only
 		// to `d.commit` does as well!
@@ -380,7 +382,6 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		})
 	}
 
-	d.fileLock, fileLock = fileLock, nil
 	return d, nil
 }
 

--- a/open.go
+++ b/open.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"runtime"
 	"sort"
 	"time"
 
@@ -363,24 +362,6 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	d.maybeScheduleCompaction()
 
 	d.fileLock, fileLock = fileLock, nil
-
-	if !opts.NoFinalizer {
-		// Holding on to `d` leaks memory, but holding on only
-		// to `d.commit` does as well!
-		runtime.SetFinalizer(d, func(obj interface{}) {
-			// Nothing here!
-		})
-	} else {
-		// Holding on to an empty DB does not leak. If we added
-		// a populated `d.commit` in, it would leak. However,
-		// holding on to `isolatedCommit` (not referenced from `d`)
-		// does not leak.
-		// Holding on to a copy of `d` does not leak.
-		dcpy := *d
-		runtime.SetFinalizer(&dcpy, func(obj interface{}) {
-			// Nothing here as well, however this causes no leak!
-		})
-	}
 
 	return d, nil
 }

--- a/open.go
+++ b/open.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"runtime"
 	"sort"
 	"time"
@@ -365,11 +364,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 
 	if !opts.NoFinalizer && invariants.Enabled {
 		runtime.SetFinalizer(d, func(obj interface{}) {
-			d := obj.(*DB)
-			if err := d.closed.Load(); err == nil {
-				fmt.Fprintf(os.Stderr, "%p: unreferenced DB not closed\n", d)
-				os.Exit(1)
-			}
+			// Nothing here!
 		})
 	}
 

--- a/open.go
+++ b/open.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/arenaskl"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
-	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/manual"
 	"github.com/cockroachdb/pebble/internal/rate"
 	"github.com/cockroachdb/pebble/internal/record"
@@ -362,9 +361,14 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	d.maybeScheduleFlush()
 	d.maybeScheduleCompaction()
 
-	if !opts.NoFinalizer && invariants.Enabled {
+	if !opts.NoFinalizer {
 		runtime.SetFinalizer(d, func(obj interface{}) {
 			// Nothing here!
+		})
+	} else {
+		fauxD := &DB{}
+		runtime.SetFinalizer(fauxD, func(obj interface{}) {
+			// Nothing here as well, however this causes no leak!
 		})
 	}
 

--- a/options.go
+++ b/options.go
@@ -219,6 +219,7 @@ func (o *LevelOptions) EnsureDefaults() *LevelOptions {
 // apply to the DB at large; per-query options are defined by the IterOptions
 // and WriteOptions types.
 type Options struct {
+	NoFinalizer bool
 	// Sync sstables periodically in order to smooth out writes to disk. This
 	// option does not provide any persistency guarantee, but is used to avoid
 	// latency spikes if the OS automatically decides to write out a large chunk

--- a/options.go
+++ b/options.go
@@ -219,7 +219,6 @@ func (o *LevelOptions) EnsureDefaults() *LevelOptions {
 // apply to the DB at large; per-query options are defined by the IterOptions
 // and WriteOptions types.
 type Options struct {
-	NoFinalizer bool
 	// Sync sstables periodically in order to smooth out writes to disk. This
 	// option does not provide any persistency guarantee, but is used to avoid
 	// latency spikes if the OS automatically decides to write out a large chunk

--- a/repro_test.go
+++ b/repro_test.go
@@ -1,0 +1,71 @@
+package pebble
+
+import (
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"runtime/pprof"
+	"testing"
+	"time"
+)
+
+func TestWithFinalizer(t *testing.T) {
+	testFoo(t, true)
+}
+
+func TestWithoutFinalizer(t *testing.T) {
+	testFoo(t, false)
+}
+
+func testFoo(t *testing.T, finalizer bool) {
+	// Try our best to release what we can.
+	debug.SetGCPercent(10) // default is 100, so this makes it more aggressive
+	for i := 0; i < 5; i++ {
+		debug.FreeOSMemory()
+		runtime.GC()
+	}
+
+	// Write heap profile after cleanup.
+	f, err := os.Create("heap.pprof")
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.NoError(t, pprof.WriteHeapProfile(f))
+	require.NoError(t, f.Close())
+
+	// Do the actual work in a goroutine to make sure the restriction for
+	// long-running goroutines described here does not apply to `-count N`:
+	//
+	// https://golang.org/doc/articles/race_detector#Runtime_Overheads
+	ch := make(chan struct{})
+	go func() {
+		defer close(ch)
+
+		var opts Options
+		opts.EnsureDefaults()
+		opts.FS = vfs.NewMem()
+		opts.NoFinalizer = !finalizer
+		db, err := Open("foo", &opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Close(); err != nil {
+			panic(err)
+		}
+	}()
+	<-ch
+
+	// Cheap version of leaktest; if we leak goroutines they
+	// can reference memory.
+	for i := 0; i < 2; i++ {
+		if ng := runtime.NumGoroutine(); ng > 10 {
+			if i == 0 {
+				time.Sleep(time.Second)
+			} else {
+				t.Fatal(ng)
+			}
+		}
+	}
+}

--- a/repro_test.go
+++ b/repro_test.go
@@ -46,9 +46,13 @@ func testFoo(t *testing.T, finalizer bool) {
 		var opts Options
 		opts.EnsureDefaults()
 		opts.FS = vfs.NewMem()
-		opts.NoFinalizer = !finalizer
 
 		db, err := Open("foo", &opts)
+
+		if finalizer {
+			runtime.SetFinalizer(db, func(interface{}) {})
+		}
+
 		require.NoError(t, err)
 		require.NoError(t, db.Close())
 	}()

--- a/repro_test.go
+++ b/repro_test.go
@@ -47,13 +47,10 @@ func testFoo(t *testing.T, finalizer bool) {
 		opts.EnsureDefaults()
 		opts.FS = vfs.NewMem()
 		opts.NoFinalizer = !finalizer
+
 		db, err := Open("foo", &opts)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := db.Close(); err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, db.Close())
 	}()
 	<-ch
 

--- a/repro_test.go
+++ b/repro_test.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 	"runtime/debug"
 	"runtime/pprof"
-	"sync"
 	"testing"
 	"time"
 )
@@ -43,17 +42,6 @@ func testFoo(t *testing.T, finalizer bool) {
 	ch := make(chan struct{})
 	go func() {
 		defer close(ch)
-
-		if !finalizer {
-			// Making only a commit pipeline does not leak.
-			commit := newCommitPipeline(commitEnv{
-				logSeqNum:     new(uint64),
-				visibleSeqNum: new(uint64),
-				apply:         func(b *Batch, mem *memTable) error { return nil },
-				write:         func(b *Batch, wg *sync.WaitGroup, err *error) (*memTable, error) { return nil, nil },
-			})
-			runtime.SetFinalizer(commit, func(obj interface{}) {})
-		}
 
 		var opts Options
 		opts.EnsureDefaults()

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
 	"sort"
 	"sync"
 	"unsafe"
@@ -164,9 +163,6 @@ var _ base.InternalIterator = (*singleLevelIterator)(nil)
 var singleLevelIterPool = sync.Pool{
 	New: func() interface{} {
 		i := &singleLevelIterator{}
-		if invariants.Enabled {
-			runtime.SetFinalizer(i, checkSingleLevelIterator)
-		}
 		return i
 	},
 }
@@ -174,9 +170,6 @@ var singleLevelIterPool = sync.Pool{
 var twoLevelIterPool = sync.Pool{
 	New: func() interface{} {
 		i := &twoLevelIterator{}
-		if invariants.Enabled {
-			runtime.SetFinalizer(i, checkTwoLevelIterator)
-		}
 		return i
 	},
 }


### PR DESCRIPTION
I've been pulling on https://github.com/cockroachdb/cockroach/pull/61342 and I
think there is a general problem, but I was isolate a leak to `pebble` and due
to the smaller number of moving parts it seems attractive to figure it out
here.

In short, it looks like a single use of `SetFinalizer((*DB), func(interface{}){})`
leads to memory not being reclaimed (as evidenced by ever-growing RSS and heap
profiles) when run with `-count 10000`.

Demonstrate a memory leak under -race

```
$ for t in With Without;
        do go test -race -run Test${t}Finalizer -count 100 -failfast && \
        go tool pprof -top heap.pprof | grep Showing;
done

ok      github.com/cockroachdb/pebble   2.278s
Showing nodes accounting for 11500.83kB, 100% of 11500.83kB total
ok      github.com/cockroachdb/pebble   1.846s
Showing nodes accounting for 0, 0% of 0 total
```

So ~no memory is retained between tests if the finalizer on `*DB`
is avoided. We leak approx 0.1mb/iteration otherwise.

For example, with 1000 iterations:

```
ok      github.com/cockroachdb/pebble   56.246s
Showing nodes accounting for 128.59MB, 96.98% of 132.59MB total
ok      github.com/cockroachdb/pebble   22.952s
Showing nodes accounting for 1MB, 100% of 1MB total
```

Without `-race`:

```
// 1000 iters
ok      github.com/cockroachdb/pebble   5.651s
Showing nodes accounting for 1024.22kB, 100% of 1024.22kB total
ok      github.com/cockroachdb/pebble   5.611s
Showing nodes accounting for 1024.69kB, 100% of 1024.69kB total

// 10000 iters
ok      github.com/cockroachdb/pebble   70.016s
Showing nodes accounting for 0, 0% of 0 total
ok      github.com/cockroachdb/pebble   68.865s
Showing nodes accounting for 512.19kB, 100% of 512.19kB total
```

Confusingly, this isn't as easy to isolate as I would've thought.
