### PR TITLE
*: don't use SetFinalizer in race builds

### DIFF
--- a/db.go
+++ b/db.go
@@ -8,7 +8,6 @@ package pebble // import "github.com/cockroachdb/pebble"
 import (
 	"fmt"
 	"io"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -670,12 +669,12 @@ func (d *DB) commitWrite(b *Batch, syncWG *sync.WaitGroup, syncErr *error) (*mem
 }
 
 type iterAlloc struct {
-	dbi                  Iterator
-	keyBuf               []byte
-	prefixOrFullSeekKey  []byte
-	merging              mergingIter
-	mlevels              [3 + numLevels]mergingIterLevel
-	levels               [3 + numLevels]levelIter
+	dbi                 Iterator
+	keyBuf              []byte
+	prefixOrFullSeekKey []byte
+	merging             mergingIter
+	mlevels             [3 + numLevels]mergingIterLevel
+	levels              [3 + numLevels]levelIter
 }
 
 var iterAllocPool = sync.Pool{
@@ -1293,9 +1292,9 @@ func (d *DB) newMemTable(logNum FileNum, logSeqNum uint64) (*memTable, *flushabl
 		arenaBuf:  manual.New(int(size)),
 		logSeqNum: logSeqNum,
 	})
-	if invariants.Enabled {
-		runtime.SetFinalizer(mem, checkMemTable)
-	}
+
+	// Note: this is a no-op if invariants are disabled or race is enabled.
+	invariants.SetFinalizer(mem, checkMemTable)
 
 	entry := d.newFlushableEntry(mem, logNum, logSeqNum)
 	entry.releaseMemAccounting = func() {

--- a/internal/cache/entry_normal.go
+++ b/internal/cache/entry_normal.go
@@ -2,12 +2,11 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 //
-// +build !invariants,!tracing
+// +build !invariants,!tracing race
 
 package cache
 
 import (
-	"runtime"
 	"sync"
 	"unsafe"
 
@@ -54,7 +53,9 @@ type entryAllocCache struct {
 func newEntryAllocCache() *entryAllocCache {
 	c := &entryAllocCache{}
 	if !entriesGoAllocated {
-		runtime.SetFinalizer(c, freeEntryAllocCache)
+		// Note: this is a no-op if invariants and tracing are disabled or race is
+		// enabled.
+		invariants.SetFinalizer(c, freeEntryAllocCache)
 	}
 	return c
 }

--- a/internal/cache/robin_hood.go
+++ b/internal/cache/robin_hood.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math/bits"
 	"os"
-	"runtime"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -134,15 +133,15 @@ func maxDistForSize(size uint32) uint32 {
 func newRobinHoodMap(initialCapacity int) *robinHoodMap {
 	m := &robinHoodMap{}
 	m.init(initialCapacity)
-	if invariants.Enabled {
-		runtime.SetFinalizer(m, func(obj interface{}) {
-			m := obj.(*robinHoodMap)
-			if m.entries.ptr != nil {
-				fmt.Fprintf(os.Stderr, "%p: robin-hood map not freed\n", m)
-				os.Exit(1)
-			}
-		})
-	}
+
+	// Note: this is a no-op if invariants are disabled or race is enabled.
+	invariants.SetFinalizer(m, func(obj interface{}) {
+		m := obj.(*robinHoodMap)
+		if m.entries.ptr != nil {
+			fmt.Fprintf(os.Stderr, "%p: robin-hood map not freed\n", m)
+			os.Exit(1)
+		}
+	})
 	return m
 }
 

--- a/internal/cache/value_normal.go
+++ b/internal/cache/value_normal.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-// +build !invariants,!tracing
+// +build !invariants,!tracing race
 
 package cache
 

--- a/internal/invariants/finalizer_off.go
+++ b/internal/invariants/finalizer_off.go
@@ -1,0 +1,13 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build !invariants,!tracing race
+
+package invariants
+
+// SetFinalizer is a wrapper around runtime.SetFinalizer that is a no-op under
+// race builds or if neither the invariants or tracing build tags are
+// specified.
+func SetFinalizer(obj, finalizer interface{}) {
+}

--- a/internal/invariants/finalizer_on.go
+++ b/internal/invariants/finalizer_on.go
@@ -1,0 +1,16 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build invariants,!race tracing,!race
+
+package invariants
+
+import "runtime"
+
+// SetFinalizer is a wrapper around runtime.SetFinalizer that is a no-op under
+// race builds or if neither the invariants or tracing build tags are
+// specified.
+func SetFinalizer(obj, finalizer interface{}) {
+	runtime.SetFinalizer(obj, finalizer)
+}

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -115,6 +115,21 @@ func TestLint(t *testing.T) {
 		}
 	})
 
+	t.Run("TestSetFinalizer", func(t *testing.T) {
+		t.Parallel()
+
+		if err := stream.ForEach(
+			stream.Sequence(
+				dirCmd(t, pkg.Dir, "git", "grep", "runtime\\.SetFinalizer("),
+				stream.GrepNot(`^vendor/`), // ignore vendor
+				stream.GrepNot(`^internal/invariants/finalizer_on.go`),
+			), func(s string) {
+				t.Errorf("\n%s <- please use the \"invariants.SetFinalizer\" equivalent instead", s)
+			}); err != nil {
+			t.Error(err)
+		}
+	})
+
 	t.Run("TestForbiddenImports", func(t *testing.T) {
 		t.Parallel()
 

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
 	"sort"
 	"sync"
 	"unsafe"
@@ -165,9 +164,8 @@ var _ base.InternalIterator = (*singleLevelIterator)(nil)
 var singleLevelIterPool = sync.Pool{
 	New: func() interface{} {
 		i := &singleLevelIterator{}
-		if invariants.Enabled {
-			runtime.SetFinalizer(i, checkSingleLevelIterator)
-		}
+		// Note: this is a no-op if invariants are disabled or race is enabled.
+		invariants.SetFinalizer(i, checkSingleLevelIterator)
 		return i
 	},
 }
@@ -175,9 +173,8 @@ var singleLevelIterPool = sync.Pool{
 var twoLevelIterPool = sync.Pool{
 	New: func() interface{} {
 		i := &twoLevelIterator{}
-		if invariants.Enabled {
-			runtime.SetFinalizer(i, checkTwoLevelIterator)
-		}
+		// Note: this is a no-op if invariants are disabled or race is enabled.
+		invariants.SetFinalizer(i, checkTwoLevelIterator)
 		return i
 	},
 }


### PR DESCRIPTION
Disable all use of `SetFinalizer` in race builds so that finalizers are
never used when running CRDB tests. The use of finalizers causes some
unexplained rapid memory leak when running CRDB tests. Previously
finalizers were sometimes enabled if invariants were enabled which is
true in race builds. All use of `SetFinalizer` is now protected behind
the equivalent of `invariants.Enabled && !invariants.RaceEnabled`.

Fixes #1086