### PR TITLE
db: workaround SetFinalizer(*DB) memory leak

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -773,7 +773,9 @@ func TestMemTableReservationLeak(t *testing.T) {
 	require.NoError(t, err)
 
 	d.mu.Lock()
-	d.mu.mem.queue[len(d.mu.mem.queue)-1].readerRef()
+	last := d.mu.mem.queue[len(d.mu.mem.queue)-1]
+	last.readerRef()
+	defer last.readerUnref()
 	d.mu.Unlock()
 	if err := d.Close(); err == nil {
 		t.Fatalf("expected failure, but found success")


### PR DESCRIPTION
Workaround a limitation with finalizers on cyclic data
structures. Rather than setting a finalizer on `*DB`, we set the
finalizer on `DB.closed` which is the atomic value that is being checked
by the finalizer. Additionally, we don't need the finalizer to run in
the event that `DB.Close()` has been called, so we clear the finalizer
there.