### PR TITLE
db: bump 21.1 to include levelIter optimization

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1028,8 +1028,8 @@ func (c *compaction) newInputIter(newIters tableNewIters) (_ internalIterator, r
 
 	iterOpts := IterOptions{logger: c.logger}
 	addItersForLevel := func(iters []internalIterator, level *compactionLevel) ([]internalIterator, error) {
-		iters = append(iters, newLevelIter(iterOpts, c.cmp, newIters, level.files.Iter(),
-			manifest.Level(level.level), &c.bytesIterated))
+		iters = append(iters, newLevelIter(iterOpts, c.cmp, nil /* split */, newIters,
+			level.files.Iter(), manifest.Level(level.level), &c.bytesIterated))
 		// Add the range deletion iterator for each file as an independent level
 		// in mergingIter, as opposed to making a levelIter out of those. This
 		// is safer as levelIter expects all keys coming from underlying

--- a/db.go
+++ b/db.go
@@ -793,7 +793,7 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 			li = &levelIter{}
 		}
 
-		li.init(dbi.opts, dbi.cmp, dbi.newIters, files, level, nil)
+		li.init(dbi.opts, dbi.cmp, dbi.split, dbi.newIters, files, level, nil)
 		li.initRangeDel(&mlevels[0].rangeDelIter)
 		li.initSmallestLargestUserKey(&mlevels[0].smallestUserKey, &mlevels[0].largestUserKey,
 			&mlevels[0].isLargestUserKeyRangeDelSentinel)

--- a/get_iter.go
+++ b/get_iter.go
@@ -145,7 +145,8 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 				files := g.l0[n-1].Iter()
 				g.l0 = g.l0[:n-1]
 				iterOpts := IterOptions{logger: g.logger}
-				g.levelIter.init(iterOpts, g.cmp, g.newIters, files, manifest.L0Sublevel(n), nil)
+				g.levelIter.init(iterOpts, g.cmp, nil /* split */, g.newIters,
+					files, manifest.L0Sublevel(n), nil)
 				g.levelIter.initRangeDel(&g.rangeDelIter)
 				g.iter = &g.levelIter
 				g.iterKey, g.iterValue = g.iter.SeekGE(g.key)
@@ -163,7 +164,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 		}
 
 		iterOpts := IterOptions{logger: g.logger}
-		g.levelIter.init(iterOpts, g.cmp, g.newIters,
+		g.levelIter.init(iterOpts, g.cmp, nil /* split */, g.newIters,
 			g.version.Levels[g.level].Iter(), manifest.Level(g.level), nil)
 		g.levelIter.initRangeDel(&g.rangeDelIter)
 		g.level++

--- a/ingest.go
+++ b/ingest.go
@@ -417,7 +417,8 @@ func ingestTargetLevel(
 
 	level := baseLevel
 	for ; level < numLevels; level++ {
-		levelIter := newLevelIter(iterOps, cmp, newIters, v.Levels[level].Iter(), manifest.Level(level), nil)
+		levelIter := newLevelIter(iterOps, cmp, nil /* split */, newIters,
+			v.Levels[level].Iter(), manifest.Level(level), nil)
 		var rangeDelIter internalIterator
 		// Pass in a non-nil pointer to rangeDelIter so that levelIter.findFileGE sets it up for the target file.
 		levelIter.initRangeDel(&rangeDelIter)

--- a/internal/metamorphic/config.go
+++ b/internal/metamorphic/config.go
@@ -18,9 +18,13 @@ const (
 	iterFirst
 	iterLast
 	iterNext
+	iterNextWithLimit
 	iterPrev
+	iterPrevWithLimit
 	iterSeekGE
+	iterSeekGEWithLimit
 	iterSeekLT
+	iterSeekLTWithLimit
 	iterSeekPrefixGE
 	iterSetBounds
 	newBatch
@@ -56,34 +60,38 @@ type config struct {
 var defaultConfig = config{
 	// dbClose is not in this list since it is deterministically generated once, at the end of the test.
 	ops: []int{
-		batchAbort:         5,
-		batchCommit:        5,
-		dbCheckpoint:       1,
-		dbCompact:          1,
-		dbFlush:            2,
-		dbRestart:          2,
-		iterClose:          5,
-		iterFirst:          100,
-		iterLast:           100,
-		iterNext:           100,
-		iterPrev:           100,
-		iterSeekGE:         100,
-		iterSeekLT:         100,
-		iterSeekPrefixGE:   100,
-		iterSetBounds:      100,
-		newBatch:           5,
-		newIndexedBatch:    5,
-		newIter:            10,
-		newIterUsingClone:  5,
-		newSnapshot:        10,
-		readerGet:          100,
-		snapshotClose:      10,
-		writerApply:        10,
-		writerDelete:       100,
-		writerDeleteRange:  50,
-		writerIngest:       100,
-		writerMerge:        100,
-		writerSet:          100,
-		writerSingleDelete: 25,
+		batchAbort:          5,
+		batchCommit:         5,
+		dbCheckpoint:        1,
+		dbCompact:           1,
+		dbFlush:             2,
+		dbRestart:           2,
+		iterClose:           5,
+		iterFirst:           100,
+		iterLast:            100,
+		iterNext:            100,
+		iterNextWithLimit:   20,
+		iterPrev:            100,
+		iterPrevWithLimit:   20,
+		iterSeekGE:          100,
+		iterSeekGEWithLimit: 20,
+		iterSeekLT:          100,
+		iterSeekLTWithLimit: 20,
+		iterSeekPrefixGE:    100,
+		iterSetBounds:       100,
+		newBatch:            5,
+		newIndexedBatch:     5,
+		newIter:             10,
+		newIterUsingClone:   5,
+		newSnapshot:         10,
+		readerGet:           100,
+		snapshotClose:       10,
+		writerApply:         10,
+		writerDelete:        100,
+		writerDeleteRange:   50,
+		writerIngest:        100,
+		writerMerge:         100,
+		writerSet:           100,
+		writerSingleDelete:  25,
 	},
 }

--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -42,7 +42,14 @@ var (
 		"the directory storing test state")
 	disk = flag.Bool("disk", false,
 		"whether to use an in-mem DB or on-disk (in-mem is significantly faster)")
-	// TODO: default error rate to a non-zero value
+	// TODO: default error rate to a non-zero value. Currently, retrying is
+	// non-deterministic because of the Ierator.*WithLimit() methods since
+	// they may say that the Iterator is not valid, but be positioned at a
+	// certain key that can be returned in the future if the limit is changed.
+	// Since that key is hidden from clients of Iterator, the retryableIter
+	// using SeekGE will not necessarily position the Iterator that saw an
+	// injected error at the same place as an Iterator that did not see that
+	// error.
 	errorRate = flag.Float64("error-rate", 0.0,
 		"rate of errors injected into filesystem operations (0 ≤ r < 1)")
 	failRE = flag.String("fail", "",

--- a/internal/metamorphic/parser.go
+++ b/internal/metamorphic/parser.go
@@ -83,13 +83,13 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	case *newSnapshotOp:
 		return nil, &t.snapID, nil
 	case *iterNextOp:
-		return &t.iterID, nil, nil
+		return &t.iterID, nil, []interface{}{&t.limit}
 	case *iterPrevOp:
-		return &t.iterID, nil, nil
+		return &t.iterID, nil, []interface{}{&t.limit}
 	case *iterSeekLTOp:
-		return &t.iterID, nil, []interface{}{&t.key}
+		return &t.iterID, nil, []interface{}{&t.key, &t.limit}
 	case *iterSeekGEOp:
-		return &t.iterID, nil, []interface{}{&t.key}
+		return &t.iterID, nil, []interface{}{&t.key, &t.limit}
 	case *iterSeekPrefixGEOp:
 		return &t.iterID, nil, []interface{}{&t.key}
 	case *setOp:

--- a/internal/metamorphic/retryable.go
+++ b/internal/metamorphic/retryable.go
@@ -81,10 +81,22 @@ func (i *retryableIter) Next() bool {
 	return valid
 }
 
+func (i *retryableIter) NextWithLimit(limit []byte) pebble.IterValidityState {
+	var validity pebble.IterValidityState
+	i.withRetry(func() { validity = i.iter.NextWithLimit(limit) })
+	return validity
+}
+
 func (i *retryableIter) Prev() bool {
 	var valid bool
 	i.withRetry(func() { valid = i.iter.Prev() })
 	return valid
+}
+
+func (i *retryableIter) PrevWithLimit(limit []byte) pebble.IterValidityState {
+	var validity pebble.IterValidityState
+	i.withRetry(func() { validity = i.iter.PrevWithLimit(limit) })
+	return validity
 }
 
 func (i *retryableIter) SeekGE(key []byte) bool {
@@ -93,10 +105,22 @@ func (i *retryableIter) SeekGE(key []byte) bool {
 	return valid
 }
 
+func (i *retryableIter) SeekGEWithLimit(key []byte, limit []byte) pebble.IterValidityState {
+	var validity pebble.IterValidityState
+	i.withRetry(func() { validity = i.iter.SeekGEWithLimit(key, limit) })
+	return validity
+}
+
 func (i *retryableIter) SeekLT(key []byte) bool {
 	var valid bool
 	i.withRetry(func() { valid = i.iter.SeekLT(key) })
 	return valid
+}
+
+func (i *retryableIter) SeekLTWithLimit(key []byte, limit []byte) pebble.IterValidityState {
+	var validity pebble.IterValidityState
+	i.withRetry(func() { validity = i.iter.SeekLTWithLimit(key, limit) })
+	return validity
 }
 
 func (i *retryableIter) SeekPrefixGE(key []byte) bool {

--- a/level_checker.go
+++ b/level_checker.go
@@ -636,7 +636,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 		manifestIter := current.L0Sublevels.Levels[sublevel].Iter()
 		iterOpts := IterOptions{logger: c.logger}
 		li := &levelIter{}
-		li.init(iterOpts, c.cmp, c.newIters, manifestIter,
+		li.init(iterOpts, c.cmp, nil /* split */, c.newIters, manifestIter,
 			manifest.L0Sublevel(sublevel), nil)
 		li.initRangeDel(&mlevelAlloc[0].rangeDelIter)
 		li.initSmallestLargestUserKey(&mlevelAlloc[0].smallestUserKey, nil, nil)
@@ -650,7 +650,8 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 
 		iterOpts := IterOptions{logger: c.logger}
 		li := &levelIter{}
-		li.init(iterOpts, c.cmp, c.newIters, current.Levels[level].Iter(), manifest.Level(level), nil)
+		li.init(iterOpts, c.cmp, nil /* split */, c.newIters,
+			current.Levels[level].Iter(), manifest.Level(level), nil)
 		li.initRangeDel(&mlevelAlloc[0].rangeDelIter)
 		li.initSmallestLargestUserKey(&mlevelAlloc[0].smallestUserKey, nil, nil)
 		mlevelAlloc[0].iter = li

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -81,7 +81,8 @@ func TestLevelIter(t *testing.T) {
 			}
 
 			iter := newLevelIter(opts, DefaultComparer.Compare,
-				newIters, files.Iter(), manifest.Level(level), nil)
+				func(a []byte) int { return len(a) }, newIters, files.Iter(), manifest.Level(level),
+				nil)
 			defer iter.Close()
 			// Fake up the range deletion initialization.
 			iter.initRangeDel(new(internalIterator))
@@ -122,7 +123,8 @@ func TestLevelIter(t *testing.T) {
 			}
 
 			iter := newLevelIter(opts, DefaultComparer.Compare,
-				newIters2, files.Iter(), manifest.Level(level), nil)
+				func(a []byte) int { return len(a) }, newIters2, files.Iter(),
+				manifest.Level(level), nil)
 			iter.SeekGE([]byte(key))
 			lower, upper := tableOpts.GetLowerBound(), tableOpts.GetUpperBound()
 			return fmt.Sprintf("[%s,%s]\n", lower, upper)
@@ -283,8 +285,9 @@ func TestLevelIterBoundaries(t *testing.T) {
 			}
 			if iter == nil {
 				slice := manifest.NewLevelSliceKeySorted(lt.cmp.Compare, lt.metas)
-				iter = newLevelIter(IterOptions{}, DefaultComparer.Compare, lt.newIters,
-					slice.Iter(), manifest.Level(level), nil)
+				iter = newLevelIter(IterOptions{}, DefaultComparer.Compare,
+					func(a []byte) int { return len(a) }, lt.newIters, slice.Iter(),
+					manifest.Level(level), nil)
 				// Fake up the range deletion initialization.
 				iter.initRangeDel(new(internalIterator))
 			}
@@ -377,8 +380,9 @@ func TestLevelIterSeek(t *testing.T) {
 		case "iter":
 			slice := manifest.NewLevelSliceKeySorted(lt.cmp.Compare, lt.metas)
 			iter := &levelIterTestIter{
-				levelIter: newLevelIter(IterOptions{}, DefaultComparer.Compare, lt.newIters,
-					slice.Iter(), manifest.Level(level), nil),
+				levelIter: newLevelIter(IterOptions{}, DefaultComparer.Compare,
+					func(a []byte) int { return len(a) }, lt.newIters, slice.Iter(),
+					manifest.Level(level), nil),
 			}
 			defer iter.Close()
 			iter.initRangeDel(&iter.rangeDelIter)
@@ -479,8 +483,7 @@ func BenchmarkLevelIterSeekGE(b *testing.B) {
 								iter, err := readers[file.FileNum].NewIter(nil /* lower */, nil /* upper */)
 								return iter, nil, err
 							}
-							l := newLevelIter(IterOptions{}, DefaultComparer.Compare,
-								newIters, metas.Iter(), manifest.Level(level), nil)
+							l := newLevelIter(IterOptions{}, DefaultComparer.Compare, nil, newIters, metas.Iter(), manifest.Level(level), nil)
 							rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 
 							b.ResetTimer()
@@ -522,8 +525,7 @@ func BenchmarkLevelIterSeqSeekGEWithBounds(b *testing.B) {
 									opts.LowerBound, opts.UpperBound)
 								return iter, nil, err
 							}
-							l := newLevelIter(IterOptions{}, DefaultComparer.Compare,
-								newIters, metas.Iter(), manifest.Level(level), nil)
+							l := newLevelIter(IterOptions{}, DefaultComparer.Compare, nil, newIters, metas.Iter(), manifest.Level(level), nil)
 							// Fake up the range deletion initialization, to resemble the usage
 							// in a mergingIter.
 							l.initRangeDel(new(internalIterator))
@@ -571,7 +573,8 @@ func BenchmarkLevelIterSeqSeekPrefixGE(b *testing.B) {
 			b.Run(fmt.Sprintf("skip=%d/use-next=%t", skip, useNext),
 				func(b *testing.B) {
 					l := newLevelIter(IterOptions{}, DefaultComparer.Compare,
-						newIters, metas.Iter(), manifest.Level(level), nil)
+						func(a []byte) int { return len(a) }, newIters, metas.Iter(),
+						manifest.Level(level), nil)
 					// Fake up the range deletion initialization, to resemble the usage
 					// in a mergingIter.
 					l.initRangeDel(new(internalIterator))
@@ -613,8 +616,7 @@ func BenchmarkLevelIterNext(b *testing.B) {
 								iter, err := readers[file.FileNum].NewIter(nil /* lower */, nil /* upper */)
 								return iter, nil, err
 							}
-							l := newLevelIter(IterOptions{}, DefaultComparer.Compare,
-								newIters, metas.Iter(), manifest.Level(level), nil)
+							l := newLevelIter(IterOptions{}, DefaultComparer.Compare, nil, newIters, metas.Iter(), manifest.Level(level), nil)
 
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {
@@ -648,8 +650,7 @@ func BenchmarkLevelIterPrev(b *testing.B) {
 								iter, err := readers[file.FileNum].NewIter(nil /* lower */, nil /* upper */)
 								return iter, nil, err
 							}
-							l := newLevelIter(IterOptions{}, DefaultComparer.Compare,
-								newIters, metas.Iter(), manifest.Level(level), nil)
+							l := newLevelIter(IterOptions{}, DefaultComparer.Compare, nil, newIters, metas.Iter(), manifest.Level(level), nil)
 
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {

--- a/testdata/iterator
+++ b/testdata/iterator
@@ -1284,3 +1284,116 @@ iter seq=4
 first
 ----
 .
+
+# Exercise iteration with limits, when there are no deletes.
+define
+a.SET.1:a
+b.SET.1:b
+c.SET.1:c
+d.SET.1:d
+----
+
+iter seq=2
+seek-ge-limit a b
+next-limit b
+prev-limit a
+next-limit b
+next-limit b
+seek-lt-limit d d
+prev-limit d
+next-limit e
+prev-limit d
+prev-limit c
+prev-limit b
+prev-limit a
+prev-limit a
+next-limit a
+next-limit b
+----
+a:a valid
+. at-limit
+a:a valid
+. at-limit
+. at-limit
+. at-limit
+. at-limit
+d:d valid
+. at-limit
+c:c valid
+b:b valid
+a:a valid
+. exhausted
+. at-limit
+a:a valid
+
+# Exercise iteration with limits when we have deletes.
+
+define
+a.SET.1:a
+b.DEL.3:
+b.SET.2:b
+c.DEL.3:
+c.SET.2:c
+d.SET.1:d
+----
+
+iter seq=4
+seek-ge-limit a b
+next-limit b
+prev-limit a
+prev-limit a
+next-limit b
+next-limit b
+next-limit b
+prev-limit a
+next-limit c
+prev-limit b
+next-limit c
+next-limit d
+next-limit e
+next-limit e
+prev-limit d
+next-limit e
+----
+a:a valid
+. at-limit
+a:a valid
+. exhausted
+a:a valid
+. at-limit
+. at-limit
+a:a valid
+. at-limit
+. at-limit
+. at-limit
+. at-limit
+d:d valid
+. exhausted
+d:d valid
+. exhausted
+
+iter seq=4
+seek-ge-limit b d
+next-limit d
+prev-limit b
+next-limit e
+----
+. at-limit
+. at-limit
+. at-limit
+d:d valid
+
+iter seq=4
+seek-lt-limit d c
+prev-limit c
+prev-limit b
+prev-limit a
+prev-limit a
+next-limit b
+----
+. at-limit
+. at-limit
+. at-limit
+a:a valid
+. exhausted
+a:a valid

--- a/testdata/level_iter_seek
+++ b/testdata/level_iter_seek
@@ -56,10 +56,32 @@ c#7,1:c
 d#72057594037927935,15:
 .
 
+# There is no point key with d, but since there is a rangedel, levelIter
+# returns a synthetic boundary key using the largest key, f, in the file.
 iter
 seek-prefix-ge d
 ----
 f/d-e#6#5,15:
+
+# Tests a sequence of SeekPrefixGE with monotonically increasing keys, some of
+# which are present and some not (so fail the bloom filter match). The seek to
+# cc returns a synthetic boundary key.
+iter
+seek-prefix-ge aa
+seek-prefix-ge c
+seek-prefix-ge cc
+seek-prefix-ge f
+seek-prefix-ge g
+seek-prefix-ge gg
+seek-prefix-ge h
+----
+./<empty>#0,0:
+c/d-e#6#7,1:c
+f/d-e#6#5,15:
+f/<empty>#5,1:f
+g/<empty>#4,1:g
+./<empty>#0,0:
+h/<empty>#3,1:h
 
 iter
 set-bounds lower=d


### PR DESCRIPTION
This optimization was identified as helping with the tpccbench regression
as discussed in https://github.com/cockroachdb/cockroach/issues/62078

See
https://github.com/cockroachdb/cockroach/issues/62078#issuecomment-803003586
for the risk discussion.
