### PR TITLE
db: reduce getInternal allocations of getIter and Iterator alternative

### DIFF
--- a/db.go
+++ b/db.go
@@ -376,6 +376,29 @@ func (d *DB) Get(key []byte) ([]byte, io.Closer, error) {
 	return d.getInternal(key, nil /* batch */, nil /* snapshot */)
 }
 
+type getIterAlloc struct {
+	dbi                 Iterator
+	keyBuf              []byte
+	get                 getIter
+}
+
+func (*getIterAlloc) SetPrefixOrFullSeekKey([]byte) {
+}
+
+func (g *getIterAlloc) SetKeyBuf(b []byte) {
+	g.keyBuf = b
+}
+
+func (g *getIterAlloc) Release() {
+	getIterAllocPool.Put(g)
+}
+
+var getIterAllocPool = sync.Pool{
+	New: func() interface{} {
+		return &getIterAlloc{}
+	},
+}
+
 func (d *DB) getInternal(key []byte, b *Batch, s *Snapshot) ([]byte, io.Closer, error) {
 	if err := d.closed.Load(); err != nil {
 		panic(err)
@@ -395,22 +418,21 @@ func (d *DB) getInternal(key []byte, b *Batch, s *Snapshot) ([]byte, io.Closer, 
 		seqNum = atomic.LoadUint64(&d.mu.versions.atomic.visibleSeqNum)
 	}
 
-	var buf struct {
-		dbi Iterator
-		get getIter
-	}
+	buf := getIterAllocPool.Get().(*getIterAlloc)
 
 	get := &buf.get
-	get.logger = d.opts.Logger
-	get.cmp = d.cmp
-	get.equal = d.equal
-	get.newIters = d.newIters
-	get.snapshot = seqNum
-	get.key = key
-	get.batch = b
-	get.mem = readState.memtables
-	get.l0 = readState.current.L0Sublevels.Levels
-	get.version = readState.current
+	*get = getIter{
+		logger: d.opts.Logger,
+		cmp: d.cmp,
+		equal: d.equal,
+		newIters: d.newIters,
+		snapshot: seqNum,
+		key: key,
+		batch: b,
+		mem: readState.memtables,
+		l0: readState.current.L0Sublevels.Levels,
+		version: readState.current,
+	}
 
 	// Strip off memtables which cannot possibly contain the seqNum being read
 	// at.
@@ -423,12 +445,16 @@ func (d *DB) getInternal(key []byte, b *Batch, s *Snapshot) ([]byte, io.Closer, 
 	}
 
 	i := &buf.dbi
-	i.cmp = d.cmp
-	i.equal = d.equal
-	i.merge = d.merge
-	i.split = d.split
-	i.iter = get
-	i.readState = readState
+	*i = Iterator{
+		alloc:               buf,
+		cmp:                 d.cmp,
+		equal:               d.equal,
+		iter:                get,
+		merge:               d.merge,
+		split:               d.split,
+		readState:           readState,
+		keyBuf:              buf.keyBuf,
+	}
 
 	if !i.First() {
 		err := i.Close()
@@ -675,6 +701,18 @@ type iterAlloc struct {
 	merging             mergingIter
 	mlevels             [3 + numLevels]mergingIterLevel
 	levels              [3 + numLevels]levelIter
+}
+
+func (i *iterAlloc) SetPrefixOrFullSeekKey(b []byte) {
+	i.prefixOrFullSeekKey = b
+}
+
+func (i *iterAlloc) SetKeyBuf(b []byte) {
+	i.keyBuf = b
+}
+
+func (i *iterAlloc) Release() {
+	iterAllocPool.Put(i)
 }
 
 var iterAllocPool = sync.Pool{


### PR DESCRIPTION
Preferred over https://github.com/cockroachdb/pebble/pull/1094, polymorphism is better than conditionals