### PR TITLE
*: Build release branches on travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 branches:
   only:
   - master
+  - /^crl-release-\d+\.\d+$/
 
 install:
   - go get -v golang.org/x/lint/golint


### PR DESCRIPTION
Currently, only the master branch is built. This change
updates .travis.yml to also build the release branches after
every change.