### PR TITLE
db: fix compactionIter for a combination of Merge and SingleDelete

### DIFF
--- a/testdata/compaction_iter
+++ b/testdata/compaction_iter
@@ -779,6 +779,35 @@ a#2,1:b
 .
 
 define
+a.MERGE.6:b
+a.SINGLEDEL.5:
+a.SET.4:a
+----
+
+iter
+first
+next
+----
+a#6,1:b[base]
+.
+
+# Non-deterministic use of SINGLEDEL where there are two older SETs that have
+# not been deleted or single deleted. It is permitted to shadow both.
+define
+a.MERGE.6:b
+a.SINGLEDEL.5:
+a.SET.4:a
+a.SET.3:a
+----
+
+iter
+first
+next
+----
+a#6,1:b[base]
+.
+
+define
 a.SINGLEDEL.2:
 a.SET.1:b
 b.SET.3:c


### PR DESCRIPTION
SingleDelete semantics are  deterministic when followed by
a single older Set followed by nothing or another older
Delete/SingleDelete. And it is permissible for there to be an
arbitrary combination of non-SingleDeletes younger than the
youngest SingleDelete.

compactionIter was not correctly handling Merge followed
by an older SingleDelete.

Additionally, there were a number of places, including the
above, where compactionIter.err was being set, but
compactionIter.valid was left as true. Those are now fixed.

Fixes #1099