### PR TITLE
tool: add FS option

### DIFF
--- a/tool/data_test.go
+++ b/tool/data_test.go
@@ -107,8 +107,7 @@ func runTests(t *testing.T, path string) {
 					return &m
 				}()
 
-				tool := New(DefaultComparer(comparer), Mergers(merger))
-				tool.setFS(fs)
+				tool := New(DefaultComparer(comparer), Mergers(merger), FS(fs))
 
 				c := &cobra.Command{}
 				c.AddCommand(tool.Commands...)

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -83,6 +83,13 @@ func Filters(filters ...FilterPolicy) Option {
 	}
 }
 
+// FS sets the filesystem implementation to use by the introspection tools.
+func FS(fs vfs.FS) Option {
+	return func(t *T) {
+		t.opts.FS = fs
+	}
+}
+
 // New creates a new introspection tool.
 func New(opts ...Option) *T {
 	t := &T{
@@ -120,9 +127,4 @@ func New(opts ...Option) *T {
 		t.wal.Root,
 	}
 	return t
-}
-
-// setFS sets the filesystem implementation to use by the introspection tools.
-func (t *T) setFS(fs vfs.FS) {
-	t.opts.FS = fs
 }


### PR DESCRIPTION
Add `FS` option to set the filesystem to use by the introspection
tool. This replaces the prior `T.setFS` method which was used by the
datadriven tests.