### PR TITLE
internal/manifest: Let L0Sublevels get GCd on non-newest Versions

### DIFF
--- a/db.go
+++ b/db.go
@@ -419,7 +419,7 @@ func (d *DB) getInternal(key []byte, b *Batch, s *Snapshot) ([]byte, io.Closer, 
 		key: key,
 		batch: b,
 		mem: readState.memtables,
-		l0: readState.current.L0Sublevels.Levels,
+		l0: readState.current.L0SublevelFiles,
 		version: readState.current,
 	}
 
@@ -786,7 +786,7 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 	// reference to elements in mlevels.
 	start := len(mlevels)
 	current := readState.current
-	for sl := 0; sl < len(current.L0Sublevels.Levels); sl++ {
+	for sl := 0; sl < len(current.L0SublevelFiles); sl++ {
 		mlevels = append(mlevels, mergingIterLevel{})
 	}
 	for level := 1; level < len(current.Levels); level++ {
@@ -819,8 +819,8 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 
 	// Add level iterators for the L0 sublevels, iterating from newest to
 	// oldest.
-	for i := len(current.L0Sublevels.Levels) - 1; i >= 0; i-- {
-		addLevelIterForFiles(current.L0Sublevels.Levels[i].Iter(), manifest.L0Sublevel(i))
+	for i := len(current.L0SublevelFiles) - 1; i >= 0; i-- {
+		addLevelIterForFiles(current.L0SublevelFiles[i].Iter(), manifest.L0Sublevel(i))
 	}
 
 	// Add level iterators for the non-empty non-L0 levels.

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -540,7 +540,7 @@ func TestGetIter(t *testing.T) {
 			get.equal = equal
 			get.newIters = newIter
 			get.key = ikey.UserKey
-			get.l0 = v.L0Sublevels.Levels
+			get.l0 = v.L0SublevelFiles
 			get.version = v
 			get.snapshot = ikey.SeqNum() + 1
 

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -530,6 +530,7 @@ func (b *BulkVersionEdit) Apply(
 					}
 				} else {
 					v.L0Sublevels = curr.L0Sublevels
+					v.L0SublevelFiles = v.L0Sublevels.Levels
 				}
 			}
 			continue

--- a/level_checker.go
+++ b/level_checker.go
@@ -402,11 +402,11 @@ func checkRangeTombstones(c *checkConfig) error {
 		return nil
 	}
 	// Now the levels with untruncated tombsones.
-	for i := len(current.L0Sublevels.Levels) - 1; i >= 0; i-- {
-		if current.L0Sublevels.Levels[i].Empty() {
+	for i := len(current.L0SublevelFiles) - 1; i >= 0; i-- {
+		if current.L0SublevelFiles[i].Empty() {
 			continue
 		}
-		err := addTombstonesFromLevel(current.L0Sublevels.Levels[i].Iter(), 0)
+		err := addTombstonesFromLevel(current.L0SublevelFiles[i].Iter(), 0)
 		if err != nil {
 			return err
 		}
@@ -615,8 +615,8 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 	// Determine the final size for mlevels so that there are no more
 	// reallocations. levelIter will hold a pointer to elements in mlevels.
 	start := len(mlevels)
-	for sublevel := len(current.L0Sublevels.Levels) - 1; sublevel >= 0; sublevel-- {
-		if current.L0Sublevels.Levels[sublevel].Empty() {
+	for sublevel := len(current.L0SublevelFiles) - 1; sublevel >= 0; sublevel-- {
+		if current.L0SublevelFiles[sublevel].Empty() {
 			continue
 		}
 		mlevels = append(mlevels, simpleMergingIterLevel{})
@@ -629,11 +629,11 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 	}
 	mlevelAlloc := mlevels[start:]
 	// Add L0 files by sublevel.
-	for sublevel := len(current.L0Sublevels.Levels) - 1; sublevel >= 0; sublevel-- {
-		if current.L0Sublevels.Levels[sublevel].Empty() {
+	for sublevel := len(current.L0SublevelFiles) - 1; sublevel >= 0; sublevel-- {
+		if current.L0SublevelFiles[sublevel].Empty() {
 			continue
 		}
-		manifestIter := current.L0Sublevels.Levels[sublevel].Iter()
+		manifestIter := current.L0SublevelFiles[sublevel].Iter()
 		iterOpts := IterOptions{logger: c.logger}
 		li := &levelIter{}
 		li.init(iterOpts, c.cmp, nil /* split */, c.newIters, manifestIter,

--- a/tool/lsm.go
+++ b/tool/lsm.go
@@ -242,7 +242,7 @@ func (l *lsmT) buildEdits(edits []*manifest.VersionEdit) {
 		}
 		v := manifest.NewVersion(l.cmp.Compare, l.fmtKey.fn, 0, currentFiles)
 		edit.Sublevels = make(map[base.FileNum]int)
-		for sublevel, files := range v.L0Sublevels.Levels {
+		for sublevel, files := range v.L0SublevelFiles {
 			iter := files.Iter()
 			for f := iter.First(); f != nil; f = iter.Next() {
 				if len(l.state.Edits) > 0 {

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -79,10 +79,10 @@ Check the contents of the MANIFEST files.
 
 func (m *manifestT) printLevels(v *manifest.Version) {
 	for level := range v.Levels {
-		if level == 0 && v.L0Sublevels != nil && !v.Levels[level].Empty() {
-			for sublevel := len(v.L0Sublevels.Levels) - 1; sublevel >= 0; sublevel-- {
+		if level == 0 && len(v.L0SublevelFiles) > 0 && !v.Levels[level].Empty() {
+			for sublevel := len(v.L0SublevelFiles) - 1; sublevel >= 0; sublevel-- {
 				fmt.Fprintf(stdout, "--- L0.%d ---\n", sublevel)
-				v.L0Sublevels.Levels[sublevel].Each(func(f *manifest.FileMetadata) {
+				v.L0SublevelFiles[sublevel].Each(func(f *manifest.FileMetadata) {
 					fmt.Fprintf(stdout, "  %s:%d", f.FileNum, f.Size)
 					formatSeqNumRange(stdout, f.SmallestSeqNum, f.LargestSeqNum)
 					formatKeyRange(stdout, m.fmtKey, &f.Smallest, &f.Largest)

--- a/version_set.go
+++ b/version_set.go
@@ -509,7 +509,7 @@ func (vs *versionSet) logAndApply(
 			}
 		}
 	}
-	vs.metrics.Levels[0].Sublevels = int32(len(newVersion.L0Sublevels.Levels))
+	vs.metrics.Levels[0].Sublevels = int32(len(newVersion.L0SublevelFiles))
 
 	vs.picker = newCompactionPicker(newVersion, vs.opts, inProgress, vs.metrics.levelSizes())
 	if !vs.dynamicBaseLevel {


### PR DESCRIPTION
This change adds a new slice, SublevelFiles, to the Version struct
for use in creating iterators. This slice is just a shallow copy
of L0Sublevels.Files.

L0Sublevels now gets set to nil when a version is no longer the
newest version. This allows it to get GC'd and prevents the
large slices inside it from hogging memory when there are lots of
versions.

Fixes #1116.