### PR TITLE
[crl-release-20.2] internal/manifest: Let L0Sublevels get GCd on non-newest Versions

### DIFF
--- a/db.go
+++ b/db.go
@@ -389,7 +389,7 @@ func (d *DB) getInternal(key []byte, b *Batch, s *Snapshot) ([]byte, io.Closer, 
 	get.key = key
 	get.batch = b
 	get.mem = readState.memtables
-	get.l0 = readState.current.L0Sublevels.Levels
+	get.l0 = readState.current.L0SublevelFiles
 	get.version = readState.current
 
 	// Strip off memtables which cannot possibly contain the seqNum being read
@@ -731,8 +731,8 @@ func (d *DB) newIterInternal(
 	// reference to elements in mlevels.
 	start := len(mlevels)
 	current := readState.current
-	for sl := 0; sl < len(current.L0Sublevels.Levels); sl++ {
-		if len(current.L0Sublevels.Levels[sl]) > 0 {
+	for sl := 0; sl < len(current.L0SublevelFiles); sl++ {
+		if len(current.L0SublevelFiles[sl]) > 0 {
 			mlevels = append(mlevels, mergingIterLevel{})
 		}
 	}
@@ -768,8 +768,8 @@ func (d *DB) newIterInternal(
 
 	// Add level iterators for the L0 sublevels, iterating from newest to
 	// oldest.
-	for i := len(current.L0Sublevels.Levels) - 1; i >= 0; i-- {
-		iter := manifest.NewLevelSlice(current.L0Sublevels.Levels[i]).Iter()
+	for i := len(current.L0SublevelFiles) - 1; i >= 0; i-- {
+		iter := manifest.NewLevelSlice(current.L0SublevelFiles[i]).Iter()
 		addLevelIterForFiles(iter, manifest.L0Sublevel(i))
 	}
 

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -540,7 +540,7 @@ func TestGetIter(t *testing.T) {
 			get.equal = equal
 			get.newIters = newIter
 			get.key = ikey.UserKey
-			get.l0 = v.L0Sublevels.Levels
+			get.l0 = v.L0SublevelFiles
 			get.version = v
 			get.snapshot = ikey.SeqNum() + 1
 

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -275,9 +275,18 @@ type Version struct {
 	// levels, sublevel n contains older tables (lower sequence numbers) than
 	// sublevel n+1.
 	//
+	// The L0Sublevels struct is mostly used for compaction picking. As most
+	// internal data structures in it are only necessary for compaction picking
+	// and not for iterator creation, the reference to L0Sublevels is nil'd
+	// after this version becomes the non-newest version, to reduce memory
+	// usage.
+	//
 	// L0Sublevels.Levels contains L0 files ordered by sublevels. All the files
-	// in Files[0] are in L0Sublevels.Levels.
-	L0Sublevels *L0Sublevels
+	// in Files[0] are in L0Sublevels.Levels. L0SublevelFiles is also set to
+	// a reference to that slice, as that slice is necessary for iterator
+	// creation and needs to outlast L0Sublevels.
+	L0Sublevels     *L0Sublevels
+	L0SublevelFiles [][]*FileMetadata
 
 	Levels [NumLevels]LevelMetadata
 
@@ -299,10 +308,10 @@ func (v *Version) String() string {
 // Pretty returns a string representation of the version.
 func (v *Version) Pretty(format base.FormatKey) string {
 	var buf bytes.Buffer
-	if v.L0Sublevels != nil {
-		for sublevel := len(v.L0Sublevels.Levels) - 1; sublevel >= 0; sublevel-- {
+	if len(v.L0SublevelFiles) > 0 {
+		for sublevel := len(v.L0SublevelFiles) - 1; sublevel >= 0; sublevel-- {
 			fmt.Fprintf(&buf, "0.%d:\n", sublevel)
-			for _, f := range v.L0Sublevels.Levels[sublevel] {
+			for _, f := range v.L0SublevelFiles[sublevel] {
 				fmt.Fprintf(&buf, "  %06d:[%s-%s]\n", f.FileNum,
 					format(f.Smallest.UserKey), format(f.Largest.UserKey))
 			}
@@ -327,10 +336,10 @@ func (v *Version) Pretty(format base.FormatKey) string {
 func (v *Version) DebugString(format base.FormatKey) string {
 	var buf bytes.Buffer
 
-	if v.L0Sublevels != nil {
-		for sublevel := len(v.L0Sublevels.Levels) - 1; sublevel >= 0; sublevel-- {
+	if len(v.L0SublevelFiles) > 0 {
+		for sublevel := len(v.L0SublevelFiles) - 1; sublevel >= 0; sublevel-- {
 			fmt.Fprintf(&buf, "0.%d:\n", sublevel)
-			for _, f := range v.L0Sublevels.Levels[sublevel] {
+			for _, f := range v.L0SublevelFiles[sublevel] {
 				fmt.Fprintf(&buf, "  %06d:[%s-%s]\n", f.FileNum,
 					f.Smallest.Pretty(format), f.Largest.Pretty(format))
 			}
@@ -412,6 +421,9 @@ func (v *Version) InitL0Sublevels(
 ) error {
 	var err error
 	v.L0Sublevels, err = NewL0Sublevels(&v.Levels[0], cmp, formatKey, flushSplitBytes)
+	if err == nil && v.L0Sublevels != nil {
+		v.L0SublevelFiles = v.L0Sublevels.Levels
+	}
 	return err
 }
 
@@ -513,8 +525,8 @@ func (v *Version) Overlaps(level int, cmp Compare, start, end []byte) LevelSlice
 // increasing file numbers (for level 0 files) and increasing and non-
 // overlapping internal key ranges (for level non-0 files).
 func (v *Version) CheckOrdering(cmp Compare, format base.FormatKey) error {
-	for sublevel := len(v.L0Sublevels.Levels) - 1; sublevel >= 0; sublevel-- {
-		iter := NewLevelSlice(v.L0Sublevels.Levels[sublevel]).Iter()
+	for sublevel := len(v.L0SublevelFiles) - 1; sublevel >= 0; sublevel-- {
+		iter := NewLevelSlice(v.L0SublevelFiles[sublevel]).Iter()
 		if err := CheckOrdering(cmp, format, L0Sublevel(sublevel), iter); err != nil {
 			return base.CorruptionErrorf("%s\n%s", err, v.DebugString(format))
 		}
@@ -601,6 +613,9 @@ func (l *VersionList) PushBack(v *Version) {
 	v.next = &l.root
 	v.next.prev = v
 	v.list = l
+	// Let L0Sublevels on the second newest version get GC'd, as it is no longer
+	// necessary. See the comment in Version.
+	v.prev.L0Sublevels = nil
 }
 
 // Remove removes the specified version from the list.

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -496,6 +496,7 @@ func (b *BulkVersionEdit) Apply(
 					}
 				} else {
 					v.L0Sublevels = curr.L0Sublevels
+					v.L0SublevelFiles = v.L0Sublevels.Levels
 				}
 			}
 			if curr == nil {

--- a/level_checker.go
+++ b/level_checker.go
@@ -402,11 +402,11 @@ func checkRangeTombstones(c *checkConfig) error {
 		return nil
 	}
 	// Now the levels with untruncated tombsones.
-	for i := len(current.L0Sublevels.Levels) - 1; i >= 0; i-- {
-		if len(current.L0Sublevels.Levels[i]) == 0 {
+	for i := len(current.L0SublevelFiles) - 1; i >= 0; i-- {
+		if len(current.L0SublevelFiles[i]) == 0 {
 			continue
 		}
-		err := addTombstonesFromLevel(manifest.NewLevelSlice(current.L0Sublevels.Levels[i]).Iter(), 0)
+		err := addTombstonesFromLevel(manifest.NewLevelSlice(current.L0SublevelFiles[i]).Iter(), 0)
 		if err != nil {
 			return err
 		}
@@ -616,8 +616,8 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 	// Determine the final size for mlevels so that there are no more
 	// reallocations. levelIter will hold a pointer to elements in mlevels.
 	start := len(mlevels)
-	for sublevel := len(current.L0Sublevels.Levels) - 1; sublevel >= 0; sublevel-- {
-		if len(current.L0Sublevels.Levels[sublevel]) == 0 {
+	for sublevel := len(current.L0SublevelFiles) - 1; sublevel >= 0; sublevel-- {
+		if len(current.L0SublevelFiles[sublevel]) == 0 {
 			continue
 		}
 		mlevels = append(mlevels, simpleMergingIterLevel{})
@@ -630,11 +630,11 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 	}
 	mlevelAlloc := mlevels[start:]
 	// Add L0 files by sublevel.
-	for sublevel := len(current.L0Sublevels.Levels) - 1; sublevel >= 0; sublevel-- {
-		if len(current.L0Sublevels.Levels[sublevel]) == 0 {
+	for sublevel := len(current.L0SublevelFiles) - 1; sublevel >= 0; sublevel-- {
+		if len(current.L0SublevelFiles[sublevel]) == 0 {
 			continue
 		}
-		manifestIter := manifest.NewLevelSlice(current.L0Sublevels.Levels[sublevel]).Iter()
+		manifestIter := manifest.NewLevelSlice(current.L0SublevelFiles[sublevel]).Iter()
 		iterOpts := IterOptions{logger: c.logger}
 		li := &levelIter{}
 		li.init(iterOpts, c.cmp, c.newIters, manifestIter,

--- a/tool/lsm.go
+++ b/tool/lsm.go
@@ -242,7 +242,7 @@ func (l *lsmT) buildEdits(edits []*manifest.VersionEdit) {
 		}
 		v := manifest.NewVersion(l.cmp.Compare, l.fmtKey.fn, 0, currentFiles)
 		edit.Sublevels = make(map[base.FileNum]int)
-		for sublevel, files := range v.L0Sublevels.Levels {
+		for sublevel, files := range v.L0SublevelFiles {
 			for _, f := range files {
 				if len(l.state.Edits) > 0 {
 					lastEdit := l.state.Edits[len(l.state.Edits)-1]

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -80,10 +80,10 @@ Check the contents of the MANIFEST files.
 func (m *manifestT) printLevels(v *manifest.Version) {
 	for level := range v.Levels {
 		iter := v.Levels[level].Iter()
-		if level == 0 && v.L0Sublevels != nil && !iter.Empty() {
-			for sublevel := len(v.L0Sublevels.Levels) - 1; sublevel >= 0; sublevel-- {
+		if level == 0 && len(v.L0SublevelFiles) > 0 && !iter.Empty() {
+			for sublevel := len(v.L0SublevelFiles) - 1; sublevel >= 0; sublevel-- {
 				fmt.Fprintf(stdout, "--- L0.%d ---\n", sublevel)
-				for _, f := range v.L0Sublevels.Levels[sublevel] {
+				for _, f := range v.L0SublevelFiles[sublevel] {
 					fmt.Fprintf(stdout, "  %s:%d", f.FileNum, f.Size)
 					formatSeqNumRange(stdout, f.SmallestSeqNum, f.LargestSeqNum)
 					formatKeyRange(stdout, m.fmtKey, &f.Smallest, &f.Largest)

--- a/version_set.go
+++ b/version_set.go
@@ -497,7 +497,7 @@ func (vs *versionSet) logAndApply(
 			}
 		}
 	}
-	vs.metrics.Levels[0].Sublevels = int32(len(newVersion.L0Sublevels.Levels))
+	vs.metrics.Levels[0].Sublevels = int32(len(newVersion.L0SublevelFiles))
 	return nil
 }
 


### PR DESCRIPTION
20.2 backport of #1117

---

This change adds a new slice, SublevelFiles, to the Version struct
for use in creating iterators. This slice is just a shallow copy
of L0Sublevels.Files.

L0Sublevels now gets set to nil when a version is no longer the
newest version. This allows it to get GC'd and prevents the
large slices inside it from hogging memory when there are lots of
versions.

Fixes #1116.