### PR TITLE
db: add option to flush WAL in Checkpoint

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -12,13 +12,93 @@ import (
 	"github.com/cockroachdb/pebble/vfs"
 )
 
+
+// checkpointOptions hold the optional parameters to construct checkpoint
+// snapshots.
+type checkpointOptions struct {
+	// flushWAL set to true will force a flush and sync of the WAL prior to
+	// checkpointing.
+	flushWAL bool
+}
+
+// CheckpointOption set optional parameters used by `DB.Checkpoint`.
+type CheckpointOption func(*checkpointOptions)
+
+// WithFlushedWAL enables flushing and syncing the WAL prior to constructing a
+// checkpoint. This guarantees that any writes committed before calling
+// DB.Checkpoint will be part of that checkpoint.
+//
+// Note that this setting can only be useful in cases when some writes are
+// performed with Sync = false. Otherwise, the guarantee will already be met.
+//
+// Passing this option is functionally equivalent to calling
+// DB.LogData(nil, Sync) right before DB.Checkpoint.
+func WithFlushedWAL() CheckpointOption {
+	return func(opt *checkpointOptions) {
+		opt.flushWAL = true
+	}
+}
+
+// mkdirAllAndSyncParents creates destDir and any of its missing parents.
+// Those missing parents, as well as the closest existing ancestor, are synced.
+// Returns a handle to the directory created at destDir.
+func mkdirAllAndSyncParents(fs vfs.FS, destDir string) (vfs.File, error) {
+	// Collect paths for all directories between destDir (excluded) and its
+	// closest existing ancestor (included).
+	var parentPaths []string
+	foundExistingAncestor := false
+	for parentPath := fs.PathDir(destDir); parentPath != "."; parentPath = fs.PathDir(parentPath) {
+		parentPaths = append(parentPaths, parentPath)
+		_, err := fs.Stat(parentPath)
+		if err == nil {
+			// Exit loop at the closest existing ancestor.
+			foundExistingAncestor = true
+			break
+		}
+		if !oserror.IsNotExist(err) {
+			return nil, err
+		}
+	}
+	// Handle empty filesystem edge case.
+	if !foundExistingAncestor {
+		parentPaths = append(parentPaths, "")
+	}
+	// Create destDir and any of its missing parents.
+	if err := fs.MkdirAll(destDir, 0755); err != nil {
+		return nil, err
+	}
+	// Sync all the parent directories up to the closest existing ancestor,
+	// included.
+	for _, parentPath := range parentPaths {
+		parentDir, err := fs.OpenDir(parentPath)
+		if err != nil {
+			return nil, err
+		}
+		err = parentDir.Sync()
+		if err != nil {
+			_ = parentDir.Close()
+			return nil, err
+		}
+		err = parentDir.Close()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return fs.OpenDir(destDir)
+}
+
 // Checkpoint constructs a snapshot of the DB instance in the specified
 // directory. The WAL, MANIFEST, OPTIONS, and sstables will be copied into the
 // snapshot. Hard links will be used when possible. Beware of the significant
 // space overhead for a checkpoint if hard links are disabled. Also beware that
 // even if hard links are used, the space overhead for the checkpoint will
 // increase over time as the DB performs compactions.
-func (d *DB) Checkpoint(destDir string) (err error) {
+func (d *DB) Checkpoint(destDir string, opts ...CheckpointOption) (ckErr error /* used in deferred cleanup */) {
+	opt := &checkpointOptions{}
+	for _, fn := range opts {
+		fn(opt)
+	}
+
 	if _, err := d.opts.FS.Stat(destDir); !oserror.IsNotExist(err) {
 		if err == nil {
 			return &os.PathError{
@@ -30,6 +110,13 @@ func (d *DB) Checkpoint(destDir string) (err error) {
 		return err
 	}
 
+	if opt.flushWAL && !d.opts.DisableWAL {
+		// Write an empty log-data record to flush and sync the WAL.
+		if err := d.LogData(nil /* data */, Sync); err != nil {
+			return err
+		}
+	}
+
 	// Disable file deletions.
 	d.mu.Lock()
 	d.disableFileDeletions()
@@ -39,9 +126,8 @@ func (d *DB) Checkpoint(destDir string) (err error) {
 		d.enableFileDeletions()
 	}()
 
-	// TODO(peter): RocksDB provides the option to flush if the WAL size is too
-	// large, or roll the manifest if the MANIFEST size is too large. Should we
-	// do this too?
+	// TODO(peter): RocksDB provides the option to roll the manifest if the
+	// MANIFEST size is too large. Should we do this too?
 
 	// Lock the manifest before getting the current version. We need the
 	// length of the manifest that we read to match the current version that
@@ -69,21 +155,14 @@ func (d *DB) Checkpoint(destDir string) (err error) {
 			BytesPerSync: d.opts.BytesPerSync,
 		},
 	}
-	// TODO(peter): We don't call sync on the parent directory of destDir. In
-	// fact, if multiple directories are created, we don't call sync on any of
-	// the parent directories.
-	if err := fs.MkdirAll(destDir, 0755); err != nil {
-		return err
-	}
-	dir, err := fs.OpenDir(destDir)
-	if err != nil {
-		return err
-	}
 
+	// Create the dir and its parents (if necessary), and sync them.
+	var dir vfs.File
 	defer func() {
-		dir.Close()
-
-		if err != nil {
+		if dir != nil {
+			_ = dir.Close()
+		}
+		if ckErr != nil {
 			// Attempt to cleanup on error.
 			paths, _ := fs.List(destDir)
 			for _, path := range paths {
@@ -92,13 +171,18 @@ func (d *DB) Checkpoint(destDir string) (err error) {
 			_ = fs.Remove(destDir)
 		}
 	}()
+	dir, ckErr = mkdirAllAndSyncParents(fs, destDir)
+	if ckErr != nil {
+		return ckErr
+	}
 
 	{
 		// Link or copy the OPTIONS.
 		srcPath := base.MakeFilename(fs, d.dirname, fileTypeOptions, optionsFileNum)
 		destPath := fs.PathJoin(destDir, fs.PathBase(srcPath))
-		if err := vfs.LinkOrCopy(fs, srcPath, destPath); err != nil {
-			return err
+		ckErr = vfs.LinkOrCopy(fs, srcPath, destPath)
+		if ckErr != nil {
+			return ckErr
 		}
 	}
 
@@ -110,11 +194,13 @@ func (d *DB) Checkpoint(destDir string) (err error) {
 		// MANIFEST we copy.
 		srcPath := base.MakeFilename(fs, d.dirname, fileTypeManifest, manifestFileNum)
 		destPath := fs.PathJoin(destDir, fs.PathBase(srcPath))
-		if err := vfs.LimitedCopy(fs, srcPath, destPath, manifestSize); err != nil {
-			return err
+		ckErr = vfs.LimitedCopy(fs, srcPath, destPath, manifestSize)
+		if ckErr != nil {
+			return ckErr
 		}
-		if err := setCurrentFile(destDir, fs, manifestFileNum); err != nil {
-			return err
+		ckErr = setCurrentFile(destDir, fs, manifestFileNum)
+		if ckErr != nil {
+			return ckErr
 		}
 	}
 
@@ -124,8 +210,9 @@ func (d *DB) Checkpoint(destDir string) (err error) {
 		for f := iter.First(); f != nil; f = iter.Next() {
 			srcPath := base.MakeFilename(fs, d.dirname, fileTypeTable, f.FileNum)
 			destPath := fs.PathJoin(destDir, fs.PathBase(srcPath))
-			if err := vfs.LinkOrCopy(fs, srcPath, destPath); err != nil {
-				return err
+			ckErr = vfs.LinkOrCopy(fs, srcPath, destPath)
+			if ckErr != nil {
+				return ckErr
 			}
 		}
 	}
@@ -140,11 +227,18 @@ func (d *DB) Checkpoint(destDir string) (err error) {
 		}
 		srcPath := base.MakeFilename(fs, d.walDirname, fileTypeLog, logNum)
 		destPath := fs.PathJoin(destDir, fs.PathBase(srcPath))
-		if err := vfs.Copy(fs, srcPath, destPath); err != nil {
-			return err
+		ckErr = vfs.Copy(fs, srcPath, destPath)
+		if ckErr != nil {
+			return ckErr
 		}
 	}
 
-	// Sync the destination directory.
-	return dir.Sync()
+	// Sync and close the checkpoint directory.
+	ckErr = dir.Sync()
+	if ckErr != nil {
+		return ckErr
+	}
+	ckErr = dir.Close()
+	dir = nil
+	return ckErr
 }

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -62,29 +62,35 @@ set g 10
 ----
 sync: db/000006.log
 
-checkpoint db checkpoint1
+checkpoint db checkpoints/checkpoint1
 ----
-mkdir-all: checkpoint1 0755
-open-dir: checkpoint1
-link: db/OPTIONS-000003 -> checkpoint1/OPTIONS-000003
-create: checkpoint1/MANIFEST-000001
-sync: checkpoint1/MANIFEST-000001
-close: checkpoint1/MANIFEST-000001
-create: checkpoint1/CURRENT.000001.dbtmp
-sync: checkpoint1/CURRENT.000001.dbtmp
-close: checkpoint1/CURRENT.000001.dbtmp
-rename: checkpoint1/CURRENT.000001.dbtmp -> checkpoint1/CURRENT
-link: db/000005.sst -> checkpoint1/000005.sst
-link: db/000007.sst -> checkpoint1/000007.sst
-create: checkpoint1/000006.log
-sync: checkpoint1/000006.log
-close: checkpoint1/000006.log
-sync: checkpoint1
-close: checkpoint1
+mkdir-all: checkpoints/checkpoint1 0755
+open-dir: checkpoints
+sync: checkpoints
+close: checkpoints
+open-dir: 
+sync: 
+close: 
+open-dir: checkpoints/checkpoint1
+link: db/OPTIONS-000003 -> checkpoints/checkpoint1/OPTIONS-000003
+create: checkpoints/checkpoint1/MANIFEST-000001
+sync: checkpoints/checkpoint1/MANIFEST-000001
+close: checkpoints/checkpoint1/MANIFEST-000001
+create: checkpoints/checkpoint1/CURRENT.000001.dbtmp
+sync: checkpoints/checkpoint1/CURRENT.000001.dbtmp
+close: checkpoints/checkpoint1/CURRENT.000001.dbtmp
+rename: checkpoints/checkpoint1/CURRENT.000001.dbtmp -> checkpoints/checkpoint1/CURRENT
+link: db/000005.sst -> checkpoints/checkpoint1/000005.sst
+link: db/000007.sst -> checkpoints/checkpoint1/000007.sst
+create: checkpoints/checkpoint1/000006.log
+sync: checkpoints/checkpoint1/000006.log
+close: checkpoints/checkpoint1/000006.log
+sync: checkpoints/checkpoint1
+close: checkpoints/checkpoint1
 
-checkpoint db checkpoint1
+checkpoint db checkpoints/checkpoint1
 ----
-checkpoint checkpoint1: file already exists
+checkpoint checkpoints/checkpoint1: file already exists
 
 compact db
 ----
@@ -118,7 +124,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 
-list checkpoint1
+list checkpoints/checkpoint1
 ----
 000005.sst
 000006.log
@@ -127,12 +133,12 @@ CURRENT
 MANIFEST-000001
 OPTIONS-000003
 
-open checkpoint1 readonly
+open checkpoints/checkpoint1 readonly
 ----
-open-dir: checkpoint1
-lock: checkpoint1/LOCK
+open-dir: checkpoints/checkpoint1
+lock: checkpoints/checkpoint1/LOCK
 
-scan checkpoint1
+scan checkpoints/checkpoint1
 ----
 a 1
 b 5

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -184,6 +184,9 @@ sstables
 checkpoint
 ----
 mkdir-all: checkpoint 0755
+open-dir: 
+sync: 
+close: 
 open-dir: checkpoint
 link: db/OPTIONS-000004 -> checkpoint/OPTIONS-000004
 create: checkpoint/MANIFEST-000017


### PR DESCRIPTION
    
    This commit adds a new DB.Checkpoint option to flush and sync the WAL
    during checkpoint construction.
    
    This can be useful when performing writes with `Sync` set to `false`,
    previously these might otherwise not have been included in the
    checkpoint.
    
    Fixes #795.
