### PR TITLE
[crl-release-20.2] *: Don't block flushes on cleaning turns

### DIFF
--- a/db.go
+++ b/db.go
@@ -912,7 +912,7 @@ func (d *DB) Close() error {
 	// prevented a new cleaning job when a readState was unrefed. If needed,
 	// synchronously delete obsolete files.
 	if len(d.mu.versions.obsoleteTables) > 0 {
-		d.deleteObsoleteFiles(d.mu.nextJobID)
+		d.deleteObsoleteFiles(d.mu.nextJobID, true /* waitForOngoing */)
 	}
 	return err
 }

--- a/flush_external.go
+++ b/flush_external.go
@@ -83,7 +83,7 @@ func flushExternalTable(untypedDB interface{}, path string, originalMeta *fileMe
 	}
 	d.updateReadStateLocked(d.opts.DebugCheck)
 	d.updateTableStatsLocked(ve.NewFiles)
-	d.deleteObsoleteFiles(jobID)
+	d.deleteObsoleteFiles(jobID, true /* waitForOngoing */)
 	d.maybeScheduleCompaction()
 	d.mu.Unlock()
 	return nil

--- a/flush_test.go
+++ b/flush_test.go
@@ -71,6 +71,18 @@ func TestManualFlush(t *testing.T) {
 			d.mu.Unlock()
 			return s
 
+		case "acquire-cleaning-turn":
+			d.mu.Lock()
+			d.acquireCleaningTurn(false)
+			d.mu.Unlock()
+			return ""
+
+		case "release-cleaning-turn":
+			d.mu.Lock()
+			d.releaseCleaningTurn()
+			d.mu.Unlock()
+			return ""
+
 		case "reset":
 			if err := d.Close(); err != nil {
 				return err.Error()

--- a/ingest.go
+++ b/ingest.go
@@ -685,7 +685,7 @@ func (d *DB) ingestApply(jobID int, meta []*fileMetadata) (*versionEdit, error) 
 	}
 	d.updateReadStateLocked(d.opts.DebugCheck)
 	d.updateTableStatsLocked(ve.NewFiles)
-	d.deleteObsoleteFiles(jobID)
+	d.deleteObsoleteFiles(jobID, false /* waitForOngoing */)
 	// The ingestion may have pushed a level over the threshold for compaction,
 	// so check to see if one is necessary and schedule it.
 	d.maybeScheduleCompaction()

--- a/open.go
+++ b/open.go
@@ -342,7 +342,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 
 	if !d.opts.ReadOnly {
 		d.scanObsoleteFiles(ls)
-		d.deleteObsoleteFiles(jobID)
+		d.deleteObsoleteFiles(jobID, true /* waitForOngoing */)
 	} else {
 		// All the log files are obsolete.
 		d.mu.versions.metrics.WAL.Files = int64(len(logFiles))

--- a/testdata/manual_flush
+++ b/testdata/manual_flush
@@ -75,3 +75,23 @@ async-flush
 ----
 0.0:
   000005:[a#1,SET-b#2,SET]
+
+# Test that synchronous flushes can happen even when a cleaning turn is held.
+reset
+----
+
+acquire-cleaning-turn
+----
+
+batch
+set a 1
+set b 2
+----
+
+flush
+----
+0.0:
+  000005:[a#1,SET-b#2,SET]
+
+release-cleaning-turn
+----


### PR DESCRIPTION
20.2 backport of #1124 

---

A flush isn't marked as complete (and flushing set to
false) until deleteObsoleteFiles returns. Currently,
deleteObsoleteFiles waits for other cleaning turns to complete
before doing its own cleaning. This could make flushes wait
for cleanup after large compactions, causing write stalls.

This change makes flushes move along and mark themselves as
completed if a cleaner job is already running, instead of waiting
for them. This allows for a lower impact on user-observed
write latency.