### PR TITLE
tool,vfs: enable encrypted fs support for debug tool

### DIFF
--- a/tool/data_test.go
+++ b/tool/data_test.go
@@ -45,6 +45,9 @@ func runTests(t *testing.T, path string) {
 		require.NoError(t, err)
 
 		fs := vfs.NewMem()
+		vfsForDir := func(dir string) (vfs.FS, error) {
+			return fs, nil
+		}
 		t.Run(name, func(t *testing.T) {
 			datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
 				args := []string{d.Cmd}
@@ -112,7 +115,7 @@ func runTests(t *testing.T, path string) {
 					return &m
 				}()
 
-				tool := New(DefaultComparer(comparer), Comparers(altComparer), Mergers(merger), FS(fs))
+				tool := New(DefaultComparer(comparer), Comparers(altComparer), Mergers(merger), FS(vfsForDir))
 
 				c := &cobra.Command{}
 				c.AddCommand(tool.Commands...)

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -39,6 +39,7 @@ type T struct {
 	comparers       sstable.Comparers
 	mergers         sstable.Mergers
 	defaultComparer string
+	vfsForDir       vfs.DirFSRetriever
 }
 
 // A Option configures the Pebble introspection tool.
@@ -84,9 +85,9 @@ func Filters(filters ...FilterPolicy) Option {
 }
 
 // FS sets the filesystem implementation to use by the introspection tools.
-func FS(fs vfs.FS) Option {
+func FS(f vfs.DirFSRetriever) Option {
 	return func(t *T) {
-		t.opts.FS = fs
+		t.vfsForDir = f
 	}
 }
 
@@ -101,6 +102,7 @@ func New(opts ...Option) *T {
 		comparers:       make(sstable.Comparers),
 		mergers:         make(sstable.Mergers),
 		defaultComparer: base.DefaultComparer.Name,
+		vfsForDir:       vfs.DefaultFSForDir,
 	}
 
 	opts = append(opts,
@@ -112,7 +114,7 @@ func New(opts ...Option) *T {
 		opt(t)
 	}
 
-	t.db = newDB(&t.opts, t.comparers, t.mergers)
+	t.db = newDB(&t.opts, t.comparers, t.mergers, t.vfsForDir)
 	t.find = newFind(&t.opts, t.comparers, t.defaultComparer, t.mergers)
 	t.lsm = newLSM(&t.opts, t.comparers)
 	t.manifest = newManifest(&t.opts, t.comparers)

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -314,3 +314,11 @@ func Root(fs FS) FS {
 	}
 	return fs
 }
+
+// DirFSRetriever is a function that returns the FS for a directory.
+type DirFSRetriever func(dir string) (FS, error)
+
+// DefaultFSForDir is a DirFSRetriever that returns the default file system.
+func DefaultFSForDir(dir string) (FS, error) {
+	return Default, nil
+}


### PR DESCRIPTION
This commit introduces a new function type called DirFSRetriever,
which returns the filesystem for a directory. The FS option was
changed to accept such a function. This is useful for enabling
encrypted store support in the debug tool.