### PR TITLE
sstable: fix sstable.Writer key order checks for nil keys

### DIFF
--- a/flush_test.go
+++ b/flush_test.go
@@ -114,3 +114,17 @@ func TestFlushDelRangeEmptyKey(t *testing.T) {
 	require.NoError(t, d.Flush())
 	require.NoError(t, d.Close())
 }
+
+// TestFlushEmptyKey tests that flushing an empty key does not trigger that key
+// order invariant assertions.
+func TestFlushEmptyKey(t *testing.T) {
+	d, err := Open("", &Options{FS: vfs.NewMem()})
+	require.NoError(t, err)
+	require.NoError(t, d.Set(nil, []byte("hello"), nil))
+	require.NoError(t, d.Flush())
+	val, closer, err := d.Get(nil)
+	require.NoError(t, err)
+	require.Equal(t, val, []byte("hello"))
+	require.NoError(t, closer.Close())
+	require.NoError(t, d.Close())
+}

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -220,7 +220,7 @@ func (w *Writer) Add(key InternalKey, value []byte) error {
 }
 
 func (w *Writer) addPoint(key InternalKey, value []byte) error {
-	if !w.disableKeyOrderChecks {
+	if !w.disableKeyOrderChecks && w.meta.LargestPoint.UserKey != nil {
 		// TODO(peter): Manually inlined version of base.InternalCompare(). This is
 		// 3.5% faster on BenchmarkWriter on go1.13. Remove if go1.14 or future
 		// versions show this to not be a performance win.
@@ -246,8 +246,14 @@ func (w *Writer) addPoint(key InternalKey, value []byte) error {
 	w.block.add(key, value)
 
 	w.meta.updateSeqNum(key.SeqNum())
-	if w.props.NumEntries == 0 {
+	if w.meta.SmallestPoint.UserKey == nil {
 		w.meta.SmallestPoint = key.Clone()
+		// Ensure that SmallestPoint.UserKey is not nil. This is required by
+		// WriterMetadata.Smallest in order to distinguish between an unset
+		// SmallestPoint and a zero-length one.
+		if w.meta.SmallestPoint.UserKey == nil {
+			w.meta.SmallestPoint.UserKey = make([]byte, 0)
+		}
 	}
 	// block.curKey contains the most recently added key to the block.
 	w.meta.LargestPoint.UserKey = w.block.curKey[:len(w.block.curKey)-8]


### PR DESCRIPTION
Fix the `sstable.Writer.addPoint` key order check which was incorrectly
firing when a nil user key was added to the DB. The problem was that
comparing the zero value of `w.meta.LargestPoint` vs a nil user-key was
simply invalid. Instead, we need to avoid this check when a point record
has never been added to the sstable, similar to what is done in
`sstable.Writer.addTombstone`.

Also fix the setting of `w.meta.SmallestPoint` to ensure that
`w.meta.SmallestPoint.UserKey` is always non-nil after a point record
has been added. This is necessary for `WriterMetadata.Smallest` to work
correctly so that the sstable bounds can be set correctly if the
smallest record in an sstable as a nil or zero-length user key.

Fixes #1133