### PR TITLE
db: flesh out CompactionInfo.Reason

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -100,6 +100,9 @@ type pickedCompaction struct {
 	// score of the chosen compaction. Taken from candidateLevelInfo.
 	score float64
 
+	// readTrigger is true if the compaction was triggered due to reads.
+	readTriggered bool
+
 	// startLevel is the level that is being compacted. Inputs from startLevel
 	// and outputLevel will be merged to produce a set of outputLevel files.
 	startLevel *compactionLevel
@@ -1373,6 +1376,7 @@ func pickReadTriggeredCompactionHelper(
 	if inputRangeAlreadyCompacting(env, pc) {
 		return nil
 	}
+	pc.readTriggered = true
 	return pc
 }
 

--- a/event.go
+++ b/event.go
@@ -74,18 +74,18 @@ func (i CompactionInfo) String() string {
 // SafeFormat implements redact.SafeFormatter.
 func (i CompactionInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 	if i.Err != nil {
-		w.Printf("[JOB %d] compaction to L%d error: %s",
-			redact.Safe(i.JobID), redact.Safe(i.Output.Level), i.Err)
+		w.Printf("[JOB %d] compaction(%s) to L%d error: %s",
+			redact.Safe(i.JobID), redact.SafeString(i.Reason), redact.Safe(i.Output.Level), i.Err)
 		return
 	}
 
 	if !i.Done {
-		w.Printf("[JOB %d] compacting ", redact.Safe(i.JobID))
+		w.Printf("[JOB %d] compacting(%s) ", redact.Safe(i.JobID), redact.SafeString(i.Reason))
 		w.Print(levelInfos(i.Input))
 		return
 	}
 	outputSize := tablesTotalSize(i.Output.Tables)
-	w.Printf("[JOB %d] compacted ", redact.Safe(i.JobID))
+	w.Printf("[JOB %d] compacted(%s) ", redact.Safe(i.JobID), redact.SafeString(i.Reason))
 	w.Print(levelInfos(i.Input))
 	w.Printf(" -> L%d [%s] (%s), in %.1fs, output rate %s/s",
 		redact.Safe(i.Output.Level),

--- a/metrics.go
+++ b/metrics.go
@@ -265,7 +265,7 @@ func (m *Metrics) formatWAL(w redact.SafePrinter) {
 //         6         1   825 B    0.00   1.6 K     0 B       0     0 B       0   825 B       1   1.6 K     0.5
 //     total         3   2.4 K       -   933 B   825 B       1     0 B       0   4.1 K       4   1.6 K     4.5
 //     flush         3
-//   compact         1   1.6 K          (size == estimated-debt)
+//   compact         1   1.6 K             0 B  (size == estimated-debt, in = in-progress-bytes)
 //    memtbl         1   4.0 M
 //   zmemtbl         0     0 B
 //      ztbl         0     0 B

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -89,7 +89,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted L2 [000005] (784 B) + L3 [000006] (784 B) -> L6 [] (0 B), in 1.0s, output rate 0 B/s
+  [JOB 100] compacted(delete-only) L2 [000005] (784 B) + L3 [000006] (784 B) -> L6 [] (0 B), in 1.0s, output rate 0 B/s
 
 # Verify that compaction correctly handles the presence of multiple
 # overlapping hints which might delete a file multiple times. All of the
@@ -130,7 +130,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted L2 [000006] (784 B) + L3 [000007] (784 B) -> L6 [] (0 B), in 1.0s, output rate 0 B/s
+  [JOB 100] compacted(delete-only) L2 [000006] (784 B) + L3 [000007] (784 B) -> L6 [] (0 B), in 1.0s, output rate 0 B/s
 
 # Test a range tombstone that is already compacted into L6.
 

--- a/testdata/compaction_read_triggered
+++ b/testdata/compaction_read_triggered
@@ -20,7 +20,7 @@ show-read-compactions
 
 maybe-compact
 ----
-[JOB 100] compacted L5 [000004] (784 B) + L6 [000005] (784 B) -> L6 [000006] (778 B), in 1.0s, output rate 778 B/s
+[JOB 100] compacted(read) L5 [000004] (784 B) + L6 [000005] (784 B) -> L6 [000006] (778 B), in 1.0s, output rate 778 B/s
 
 show-read-compactions
 ----
@@ -61,7 +61,7 @@ show-read-compactions
 
 maybe-compact
 ----
-[JOB 100] compacted L5 [000004] (784 B) + L6 [000005] (784 B) -> L6 [000006] (778 B), in 1.0s, output rate 778 B/s
+[JOB 100] compacted(read) L5 [000004] (784 B) + L6 [000005] (784 B) -> L6 [000006] (778 B), in 1.0s, output rate 778 B/s
 
 show-read-compactions
 ----
@@ -160,7 +160,7 @@ show-read-compactions
 
 maybe-compact
 ----
-[JOB 100] compacted L5 [000004] (784 B) + L6 [000005] (784 B) -> L6 [000006] (778 B), in 1.0s, output rate 778 B/s
+[JOB 100] compacted(read) L5 [000004] (784 B) + L6 [000005] (784 B) -> L6 [000006] (778 B), in 1.0s, output rate 778 B/s
 
 show-read-compactions
 ----

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -39,7 +39,7 @@ range-deletions-bytes-estimate: 0
 
 maybe-compact
 ----
-[JOB 100] compacted L6 [000004] (853 B) + L6 [] (0 B) -> L6 [] (0 B), in 1.0s, output rate 0 B/s
+[JOB 100] compacted(elision-only) L6 [000004] (853 B) + L6 [] (0 B) -> L6 [] (0 B), in 1.0s, output rate 0 B/s
 
 # Test a table that straddles a snapshot. It should not be compacted.
 define snapshots=(50)
@@ -81,7 +81,7 @@ range-deletions-bytes-estimate: 0
 
 maybe-compact
 ----
-[JOB 100] compacted L6 [000004] (783 B) + L6 [] (0 B) -> L6 [000005] (771 B), in 1.0s, output rate 771 B/s
+[JOB 100] compacted(elision-only) L6 [000004] (783 B) + L6 [] (0 B) -> L6 [000005] (771 B), in 1.0s, output rate 771 B/s
 
 version
 ----
@@ -129,7 +129,7 @@ close-snapshot
 close-snapshot
 103
 ----
-[JOB 100] compacted L6 [000004] (901 B) + L6 [] (0 B) -> L6 [] (0 B), in 1.0s, output rate 0 B/s
+[JOB 100] compacted(elision-only) L6 [000004] (901 B) + L6 [] (0 B) -> L6 [] (0 B), in 1.0s, output rate 0 B/s
 
 # Test a table that contains both deletions and non-deletions, but whose
 # non-deletions well outnumber its deletions. The table should not be
@@ -201,7 +201,7 @@ range-deletions-bytes-estimate: 16488
 
 maybe-compact
 ----
-[JOB 100] compacted L5 [000004 000005] (26 K) + L6 [000007] (17 K) -> L6 [000009] (25 K), in 1.0s, output rate 25 K/s
+[JOB 100] compacted(default) L5 [000004 000005] (26 K) + L6 [000007] (17 K) -> L6 [000009] (25 K), in 1.0s, output rate 25 K/s
 
 define level-max-bytes=(L5 : 1000) auto-compactions=off
 L5
@@ -235,4 +235,4 @@ range-deletions-bytes-estimate: 0
 
 maybe-compact
 ----
-[JOB 100] compacted L5 [000004] (794 B) + L6 [000006] (13 K) -> L6 [] (0 B), in 1.0s, output rate 0 B/s
+[JOB 100] compacted(default) L5 [000004] (794 B) + L6 [000006] (13 K) -> L6 [] (0 B), in 1.0s, output rate 0 B/s

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -82,7 +82,7 @@ sync: db
 [JOB 5] MANIFEST created 000010
 [JOB 5] flushed 1 memtable to L0 [000009] (770 B), in 1.0s, output rate 770 B/s
 [JOB 5] MANIFEST deleted 000007
-[JOB 6] compacting L0 [000006 000009] (1.5 K) + L6 [] (0 B)
+[JOB 6] compacting(default) L0 [000006 000009] (1.5 K) + L6 [] (0 B)
 create: db/000011.sst
 [JOB 6] compacting: sstable created 000011
 sync: db/000011.sst
@@ -97,7 +97,7 @@ close: db/CURRENT.000012.dbtmp
 rename: db/CURRENT.000012.dbtmp -> db/CURRENT
 sync: db
 [JOB 6] MANIFEST created 000012
-[JOB 6] compacted L0 [000006 000009] (1.5 K) + L6 [] (0 B) -> L6 [000011] (770 B), in 1.0s, output rate 770 B/s
+[JOB 6] compacted(default) L0 [000006 000009] (1.5 K) + L6 [] (0 B) -> L6 [000011] (770 B), in 1.0s, output rate 770 B/s
 [JOB 6] sstable deleted 000006
 [JOB 6] sstable deleted 000009
 [JOB 6] MANIFEST deleted 000010


### PR DESCRIPTION
Fill in `CompactionInfo.Reason` with the kind of compaction: default,
move, delete-only, elision-only, or read.

Fixes #1142