### PR TITLE
[DNM] *: Add ReadCompactionAdded event to event listener

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1140,8 +1140,9 @@ type readCompaction struct {
 	level int
 	// Key ranges are used instead of file handles as versions could change
 	// between the read sampling and scheduling a compaction.
-	start []byte
-	end   []byte
+	start   []byte
+	end     []byte
+	tableInfo manifest.TableInfo
 }
 
 func (d *DB) addInProgressCompaction(c *compaction) {

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1359,6 +1359,9 @@ func pickReadTriggeredCompactionHelper(
 ) (pc *pickedCompaction) {
 	cmp := p.opts.Comparer.Compare
 	overlapSlice := p.vers.Overlaps(rc.level, cmp, rc.start, rc.end)
+	p.opts.Logger.Infof("pickReadTriggeredCompactionHelper: L%d [%s] (%s - %s)",
+		rc.level, rc.tableInfo.FileNum, rc.tableInfo.Smallest.Pretty(p.opts.Comparer.FormatKey),
+		rc.tableInfo.Largest.Pretty(p.opts.Comparer.FormatKey))
 	if overlapSlice.Empty() {
 		var shouldCompact bool
 		// If the file for the given key range has moved levels since the compaction
@@ -1367,9 +1370,12 @@ func pickReadTriggeredCompactionHelper(
 		if !shouldCompact {
 			return nil
 		}
+		p.opts.Logger.Infof("pickReadTriggeredCompactionHelper: updated level to L%d",
+			rc.level)
 	}
 	pc = newPickedCompaction(p.opts, p.vers, rc.level, p.baseLevel)
 	pc.startLevel.files = overlapSlice
+	p.opts.Logger.Infof("pickReadTriggeredCompactionHelper: overlaps %s", overlapSlice.String())
 	if !pc.setupInputs() {
 		return nil
 	}

--- a/iterator.go
+++ b/iterator.go
@@ -355,6 +355,7 @@ func (i *Iterator) sampleRead() {
 				start: topFile.Smallest.UserKey,
 				end:   topFile.Largest.UserKey,
 				level: topLevel,
+				tableInfo: topFile.TableInfo(),
 			}
 			i.readSampling.pendingCompactions = append(i.readSampling.pendingCompactions, read)
 		}
@@ -1021,6 +1022,12 @@ func (i *Iterator) Close() error {
 			i.readState.db.mu.Lock()
 			i.readState.db.mu.compact.readCompactions = append(i.readState.db.mu.compact.readCompactions, i.readSampling.pendingCompactions...)
 			i.readState.db.mu.Unlock()
+			for j := range i.readSampling.pendingCompactions {
+				i.readState.db.opts.Logger.Infof("read compaction appended: %s", LevelInfo{
+					Level:  i.readSampling.pendingCompactions[j].level,
+					Tables: []TableInfo{i.readSampling.pendingCompactions[j].tableInfo},
+				})
+			}
 		}
 
 		i.readState.unref()


### PR DESCRIPTION
This change, which is *not* meant for merging into a release
or master branch, is solely to add a logging event for when
a read compaction is appended to the db's slice. This is to help
inform #1143.

A custom build produced by this will be test-run on internal clusters affected
by #1143.