### PR TITLE
internal/manifest: calculate L0 in-use key ranges using sublevels

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -124,7 +124,7 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "no compaction",
 			version: newVersion(opts, [numLevels][]*fileMetadata{
-				0: []*fileMetadata{
+				0: {
 					{
 						FileNum:  100,
 						Size:     1,
@@ -139,7 +139,7 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "1 L0 file",
 			version: newVersion(opts, [numLevels][]*fileMetadata{
-				0: []*fileMetadata{
+				0: {
 					{
 						FileNum:  100,
 						Size:     1,
@@ -159,7 +159,7 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "2 L0 files (0 overlaps)",
 			version: newVersion(opts, [numLevels][]*fileMetadata{
-				0: []*fileMetadata{
+				0: {
 					{
 						FileNum:  100,
 						Size:     1,
@@ -185,7 +185,7 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "2 L0 files, with ikey overlap",
 			version: newVersion(opts, [numLevels][]*fileMetadata{
-				0: []*fileMetadata{
+				0: {
 					{
 						FileNum:  100,
 						Size:     1,
@@ -211,7 +211,7 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "2 L0 files, with ukey overlap",
 			version: newVersion(opts, [numLevels][]*fileMetadata{
-				0: []*fileMetadata{
+				0: {
 					{
 						FileNum:  100,
 						Size:     1,
@@ -237,7 +237,7 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "1 L0 file, 2 L1 files (0 overlaps)",
 			version: newVersion(opts, [numLevels][]*fileMetadata{
-				0: []*fileMetadata{
+				0: {
 					{
 						FileNum:  100,
 						Size:     1,
@@ -245,7 +245,7 @@ func TestPickCompaction(t *testing.T) {
 						Largest:  base.ParseInternalKey("i.SET.102"),
 					},
 				},
-				1: []*fileMetadata{
+				1: {
 					{
 						FileNum:  200,
 						Size:     1,
@@ -271,7 +271,7 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "1 L0 file, 2 L1 files (1 overlap), 4 L2 files (3 overlaps)",
 			version: newVersion(opts, [numLevels][]*fileMetadata{
-				0: []*fileMetadata{
+				0: {
 					{
 						FileNum:  100,
 						Size:     1,
@@ -279,7 +279,7 @@ func TestPickCompaction(t *testing.T) {
 						Largest:  base.ParseInternalKey("t.SET.102"),
 					},
 				},
-				1: []*fileMetadata{
+				1: {
 					{
 						FileNum:  200,
 						Size:     1,
@@ -293,7 +293,7 @@ func TestPickCompaction(t *testing.T) {
 						Largest:  base.ParseInternalKey("j.SET.212"),
 					},
 				},
-				2: []*fileMetadata{
+				2: {
 					{
 						FileNum:  300,
 						Size:     1,
@@ -331,7 +331,7 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "4 L1 files, 2 L2 files, can grow",
 			version: newVersion(opts, [numLevels][]*fileMetadata{
-				1: []*fileMetadata{
+				1: {
 					{
 						FileNum:  200,
 						Size:     1,
@@ -357,7 +357,7 @@ func TestPickCompaction(t *testing.T) {
 						Largest:  base.ParseInternalKey("l2.SET.232"),
 					},
 				},
-				2: []*fileMetadata{
+				2: {
 					{
 						FileNum:  300,
 						Size:     1,
@@ -383,7 +383,7 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "4 L1 files, 2 L2 files, can't grow (range)",
 			version: newVersion(opts, [numLevels][]*fileMetadata{
-				1: []*fileMetadata{
+				1: {
 					{
 						FileNum:  200,
 						Size:     1,
@@ -409,7 +409,7 @@ func TestPickCompaction(t *testing.T) {
 						Largest:  base.ParseInternalKey("l2.SET.232"),
 					},
 				},
-				2: []*fileMetadata{
+				2: {
 					{
 						FileNum:  300,
 						Size:     1,
@@ -435,7 +435,7 @@ func TestPickCompaction(t *testing.T) {
 		{
 			desc: "4 L1 files, 2 L2 files, can't grow (size)",
 			version: newVersion(opts, [numLevels][]*fileMetadata{
-				1: []*fileMetadata{
+				1: {
 					{
 						FileNum:  200,
 						Size:     expandedCompactionByteSizeLimit(opts, 1) - 1,
@@ -461,7 +461,7 @@ func TestPickCompaction(t *testing.T) {
 						Largest:  base.ParseInternalKey("l2.SET.232"),
 					},
 				},
-				2: []*fileMetadata{
+				2: {
 					{
 						FileNum:  300,
 						Size:     expandedCompactionByteSizeLimit(opts, 2) - 1,
@@ -539,7 +539,7 @@ func TestElideTombstone(t *testing.T) {
 			desc:  "non-empty",
 			level: 1,
 			version: newVersion(opts, [numLevels][]*fileMetadata{
-				1: []*fileMetadata{
+				1: {
 					{
 						Smallest: base.ParseInternalKey("c.SET.801"),
 						Largest:  base.ParseInternalKey("g.SET.800"),
@@ -549,7 +549,7 @@ func TestElideTombstone(t *testing.T) {
 						Largest:  base.ParseInternalKey("y.SET.700"),
 					},
 				},
-				2: []*fileMetadata{
+				2: {
 					{
 						Smallest: base.ParseInternalKey("d.SET.601"),
 						Largest:  base.ParseInternalKey("h.SET.600"),
@@ -559,7 +559,7 @@ func TestElideTombstone(t *testing.T) {
 						Largest:  base.ParseInternalKey("t.SET.500"),
 					},
 				},
-				3: []*fileMetadata{
+				3: {
 					{
 						Smallest: base.ParseInternalKey("f.SET.401"),
 						Largest:  base.ParseInternalKey("g.SET.400"),
@@ -569,7 +569,7 @@ func TestElideTombstone(t *testing.T) {
 						Largest:  base.ParseInternalKey("x.SET.300"),
 					},
 				},
-				4: []*fileMetadata{
+				4: {
 					{
 						Smallest: base.ParseInternalKey("f.SET.201"),
 						Largest:  base.ParseInternalKey("m.SET.200"),
@@ -607,7 +607,7 @@ func TestElideTombstone(t *testing.T) {
 			desc:  "repeated ukey",
 			level: 1,
 			version: newVersion(opts, [numLevels][]*fileMetadata{
-				6: []*fileMetadata{
+				6: {
 					{
 						Smallest: base.ParseInternalKey("i.SET.401"),
 						Largest:  base.ParseInternalKey("i.SET.400"),
@@ -684,7 +684,7 @@ func TestElideRangeTombstone(t *testing.T) {
 			desc:  "non-empty",
 			level: 1,
 			version: newVersion(opts, [numLevels][]*fileMetadata{
-				1: []*fileMetadata{
+				1: {
 					{
 						Smallest: base.ParseInternalKey("c.SET.801"),
 						Largest:  base.ParseInternalKey("g.SET.800"),
@@ -694,7 +694,7 @@ func TestElideRangeTombstone(t *testing.T) {
 						Largest:  base.ParseInternalKey("y.SET.700"),
 					},
 				},
-				2: []*fileMetadata{
+				2: {
 					{
 						Smallest: base.ParseInternalKey("d.SET.601"),
 						Largest:  base.ParseInternalKey("h.SET.600"),
@@ -704,7 +704,7 @@ func TestElideRangeTombstone(t *testing.T) {
 						Largest:  base.ParseInternalKey("t.SET.500"),
 					},
 				},
-				3: []*fileMetadata{
+				3: {
 					{
 						Smallest: base.ParseInternalKey("f.SET.401"),
 						Largest:  base.ParseInternalKey("g.SET.400"),
@@ -714,7 +714,7 @@ func TestElideRangeTombstone(t *testing.T) {
 						Largest:  base.ParseInternalKey("x.SET.300"),
 					},
 				},
-				4: []*fileMetadata{
+				4: {
 					{
 						Smallest: base.ParseInternalKey("f.SET.201"),
 						Largest:  base.ParseInternalKey("m.SET.200"),
@@ -751,13 +751,13 @@ func TestElideRangeTombstone(t *testing.T) {
 			desc:  "flushing",
 			level: -1,
 			version: newVersion(opts, [numLevels][]*fileMetadata{
-				0: []*fileMetadata{
+				0: {
 					{
 						Smallest: base.ParseInternalKey("h.SET.901"),
 						Largest:  base.ParseInternalKey("j.SET.900"),
 					},
 				},
-				1: []*fileMetadata{
+				1: {
 					{
 						Smallest: base.ParseInternalKey("c.SET.801"),
 						Largest:  base.ParseInternalKey("g.SET.800"),
@@ -1838,7 +1838,7 @@ func TestCompactionInuseKeyRanges(t *testing.T) {
 						if i > 0 {
 							fmt.Fprintf(&buf, " ")
 						}
-						fmt.Fprintf(&buf, "%s-%s", r.start, r.end)
+						fmt.Fprintf(&buf, "%s-%s", r.Start, r.End)
 					}
 					fmt.Fprintf(&buf, "\n")
 				}

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -521,6 +521,71 @@ func (s *L0Sublevels) ReadAmplification() int {
 	return amp
 }
 
+// UserKeyRange encodes a key range in user key space.
+type UserKeyRange struct {
+	Start, End []byte
+}
+
+// InUseKeyRanges returns the merged table bounds of L0 files overlapping the
+// provided user key range. The returned key ranges are sorted and
+// nonoverlapping.
+func (s *L0Sublevels) InUseKeyRanges(smallest, largest []byte) []UserKeyRange {
+	// Binary search to find the provided keys within the intervals.
+	startIK := intervalKey{key: smallest, isLargest: false}
+	endIK := intervalKey{key: largest, isLargest: true}
+	start := sort.Search(len(s.orderedIntervals), func(i int) bool {
+		return intervalKeyCompare(s.cmp, s.orderedIntervals[i].startKey, startIK) > 0
+	})
+	if start > 0 {
+		// Back up to the first interval with a start key <= startIK.
+		start--
+	}
+	end := sort.Search(len(s.orderedIntervals), func(i int) bool {
+		return intervalKeyCompare(s.cmp, s.orderedIntervals[i].startKey, endIK) > 0
+	})
+
+	var keyRanges []UserKeyRange
+	var curr *UserKeyRange
+	for i := start; i < end; {
+		// Intervals with no files are not in use and can be skipped, once we
+		// end the current UserKeyRange.
+		if s.orderedIntervals[i].fileCount == 0 {
+			curr = nil
+			i++
+			continue
+		}
+
+		// If curr is nil, start a new in-use key range.
+		if curr == nil {
+			keyRanges = append(keyRanges, UserKeyRange{
+				Start: s.orderedIntervals[i].startKey.key,
+			})
+			curr = &keyRanges[len(keyRanges)-1]
+		}
+
+		// If the filesMaxIntervalIndex is not the current index, we can jump
+		// to the max index, knowing that all intermediary intervals are
+		// overlapped by some file.
+		if maxIdx := s.orderedIntervals[i].filesMaxIntervalIndex; maxIdx != i {
+			// Note that end may be less than or equal to maxIdx if we're
+			// concerned with a key range that ends before the interval at
+			// maxIdx starts. We must set curr.End now, before making that
+			// leap, because this iteration may be the last.
+			i = maxIdx
+			curr.End = s.orderedIntervals[i+1].startKey.key
+			continue
+		}
+
+		// No files overlapping with this interval overlap with the next
+		// interval. Update the current end to be the next interval's start
+		// key. Note that curr is not necessarily finished, because there may
+		// be an abutting non-empty interval.
+		curr.End = s.orderedIntervals[i+1].startKey.key
+		i++
+	}
+	return keyRanges
+}
+
 // FlushSplitKeys returns a slice of user keys to split flushes at.
 // Used by flushes to avoid writing sstables that straddle these split keys.
 // These should be interpreted as the keys to start the next sstable (not the

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -5,6 +5,7 @@
 package manifest
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"math"
@@ -426,6 +427,26 @@ func TestL0Sublevels(t *testing.T) {
 			return builder.String()
 		case "read-amp":
 			return strconv.Itoa(sublevels.ReadAmplification())
+		case "in-use-key-ranges":
+			var buf bytes.Buffer
+			for _, data := range strings.Split(strings.TrimSpace(td.Input), "\n") {
+				keyRange := strings.Split(strings.TrimSpace(data), "-")
+				smallest := []byte(strings.TrimSpace(keyRange[0]))
+				largest := []byte(strings.TrimSpace(keyRange[1]))
+
+				keyRanges := sublevels.InUseKeyRanges(smallest, largest)
+				for i, r := range keyRanges {
+					fmt.Fprintf(&buf, "%s-%s", sublevels.formatKey(r.Start), sublevels.formatKey(r.End))
+					if i < len(keyRanges)-1 {
+						fmt.Fprint(&buf, ", ")
+					}
+				}
+				if len(keyRanges) == 0 {
+					fmt.Fprint(&buf, ".")
+				}
+				fmt.Fprintln(&buf)
+			}
+			return buf.String()
 		case "flush-split-keys":
 			var builder strings.Builder
 			builder.WriteString("flush user split keys: ")

--- a/internal/manifest/testdata/l0_sublevels
+++ b/internal/manifest/testdata/l0_sublevels
@@ -2,6 +2,35 @@
 define
 L0
   000009:a.SET.10-b.SET.10
+  000007:c.SET.6-d.SET.8
+  000003:e.SET.5-j.SET.7
+----
+file count: 3, sublevels: 1, intervals: 6
+flush split keys(3): [b, d, j]
+0.0: file count: 3, bytes: 768, width (mean, max): 1.0, 1, interval range: [0, 4]
+	000009:a#10,1-b#10,1
+	000007:c#6,1-d#8,1
+	000003:e#5,1-j#7,1
+compacting file count: 0, base compacting intervals: none
+L0.0:  a---b c---d e---------------j
+       aa bb cc dd ee ff gg hh ii jj
+
+in-use-key-ranges
+a-z
+a-c
+aa-cc
+f-g
+e-j
+----
+a-b, c-d, e-j
+a-b, c-d
+a-b, c-d
+e-j
+e-j
+
+define
+L0
+  000009:a.SET.10-b.SET.10
   000007:b.SET.6-j.SET.8
   000003:e.SET.5-j.SET.7
 ----
@@ -18,6 +47,21 @@ L0.2:  a---b
 L0.1:     b------------------------j
 L0.0:              e---------------j
        aa bb cc dd ee ff gg hh ii jj
+
+in-use-key-ranges
+a-z
+a-b
+a-aa
+b-bb
+b-j
+j-j
+----
+a-j
+a-j
+a-b
+b-j
+b-j
+e-j
 
 define no_initialize
 L0.2
@@ -125,6 +169,11 @@ L6:    a---------------f g------------------------------------s
 # overlap with base files that overlap with L0 files in the seed interval.
 # Marking 0002 as compacting should be enough to exclude both from the
 # chosen compaction.
+
+in-use-key-ranges
+a-z
+----
+a-b, c-d, e-i
 
 define
 L0
@@ -243,6 +292,11 @@ L0.1:                 f------h
 L0.0:                 f---g                   n------p
 L6:    a---------------f g------------------------------------s
        aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss
+
+in-use-key-ranges
+a-z
+----
+f-p
 
 pick-base-compaction min_depth=3
 ----
@@ -817,6 +871,11 @@ read-amp
 ----
 2
 
+in-use-key-ranges
+a-z
+----
+a-j
+
 # The comparison of a cumulative count of interpolated bytes and
 # flushSplitMaxBytes is a <, so even though the cumulative count equals 32 after
 # a-c, we do not emit a flush split key until the end of the next interval, c-e.
@@ -912,6 +971,21 @@ L0.1:           d---e
 L0.0:  a---------d e------g h------j
 L6:    a---------------f g------------------------------------s
        aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss
+
+in-use-key-ranges
+b-b
+dd-e
+dd-i
+dd-h
+dd-j
+dd-s
+----
+a-d
+d-g
+d-g, h-j
+d-g, h-j
+d-g, h-j
+d-g, h-j
 
 flush-split-keys
 ----
@@ -1057,6 +1131,13 @@ L0.0:                 f+++g h++++++j k+++l    n+++o
 L6:    a------------------------------------------o p---------s
        aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss
 
+in-use-key-ranges
+a-z
+n-o
+----
+f-j, k-l, n-o
+n-o
+
 # Ensure that two L0 sstables where one ends at a rangedel sentinel key and
 # the other starts at the same user key occupy the same sublevel.
 
@@ -1077,3 +1158,83 @@ compacting file count: 0, base compacting intervals: none
 L0.0:  a--------d---------g
 L6:    a------------------------------------------o p---------s
        aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss
+
+in-use-key-ranges
+a-z
+a-g
+b-c
+----
+a-g
+a-g
+a-d
+
+define
+L0
+  000004:a.SET.2-d.RANGEDEL.72057594037927935
+  000005:d.SET.3-g.SET.5
+  000006:f.SET.4-i.SET.6
+  000008:g.SET.7-i.SET.7
+  000007:h.SET.7-m.SET.7
+  000008:m.SET.7-p.SET.7
+  000009:q.SET.7-r.SET.7
+----
+file count: 7, sublevels: 4, intervals: 10
+flush split keys(4): [f, g, i, r]
+0.3: file count: 1, bytes: 256, width (mean, max): 3.0, 3, interval range: [3, 5]
+	000008:g#7,1-i#7,1
+0.2: file count: 1, bytes: 256, width (mean, max): 2.0, 2, interval range: [5, 6]
+	000007:h#7,1-m#7,1
+0.1: file count: 1, bytes: 256, width (mean, max): 4.0, 4, interval range: [2, 5]
+	000006:f#4,1-i#6,1
+0.0: file count: 3, bytes: 768, width (mean, max): 1.7, 3, interval range: [0, 8]
+	000004:a#2,1-d#72057594037927935,15
+	000005:d#3,1-g#5,1
+	000009:q#7,1-r#7,1
+compacting file count: 0, base compacting intervals: none
+L0.3:                    g------i
+L0.2:                       h---------------m
+L0.1:                 f---------i
+L0.0:  a--------d---------g                            q---r
+       aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr
+
+in-use-key-ranges
+f-m
+f-n
+f-l
+ff-m
+ff-n
+ff-l
+----
+f-m
+f-m
+f-m
+f-m
+f-m
+f-m
+
+in-use-key-ranges
+n-o
+m-q
+l-qq
+----
+.
+i-m, q-r
+i-m, q-r
+
+in-use-key-ranges
+a-z
+g-l
+----
+a-m, q-r
+g-m
+
+in-use-key-ranges
+a-ff
+a-gg
+a-i
+d-d
+----
+a-g
+a-i
+a-m
+d-g

--- a/testdata/compaction_inuse_key_ranges
+++ b/testdata/compaction_inuse_key_ranges
@@ -129,3 +129,66 @@ inuse-key-ranges
 0 a z
 ----
 a-j k-z
+
+define
+L0
+  a.SET.1-b.SET.1
+  c.SET.1-d.SET.1
+  f.SET.1-g.SET.1
+  i.SET.1-j.SET.1
+L6
+  a.SET.0-i.SET.0
+  k.SET.0-z.SET.0
+----
+0.0:
+  000001:[a#1,SET-b#1,SET]
+  000002:[c#1,SET-d#1,SET]
+  000003:[f#1,SET-g#1,SET]
+  000004:[i#1,SET-j#1,SET]
+6:
+  000005:[a#0,SET-i#0,SET]
+  000006:[k#0,SET-z#0,SET]
+
+inuse-key-ranges
+0 a z
+----
+a-j k-z
+
+define
+L0
+  a.SET.1-b.SET.1
+  aa.SET.1-ab.SET.1
+  b.SET.2-d.SET.1
+  bb.SET.1-dd.SET.1
+  c.SET.1-d.SET.1
+  e.SET.1-m.SET.1
+  g.SET.1-p.SET.1
+----
+0.3:
+  000005:[c#1,SET-d#1,SET]
+0.2:
+  000004:[bb#1,SET-dd#1,SET]
+0.1:
+  000002:[aa#1,SET-ab#1,SET]
+  000003:[b#2,SET-d#1,SET]
+  000007:[g#1,SET-p#1,SET]
+0.0:
+  000001:[a#1,SET-b#1,SET]
+  000006:[e#1,SET-m#1,SET]
+
+inuse-key-ranges
+0 a z
+0 e p
+0 e f
+0 b c
+0 q r
+0 1 2
+0 ddd dddd
+----
+a-dd e-p
+e-p
+e-m
+b-dd
+.
+.
+.


### PR DESCRIPTION
Use the existing structure of L0 sublevels when calculating in-use key
ranges for L0. The sublevel intervals are already sorted and can be used
to efficiently construct the in-use key ranges. The max interval index
of overlapping intervals allows us to skip over swaths of the keyspace
that are known to be covered.

In a subsequent PR, I'll adapt the setupInuseKeyRange function to use
the in-use bounds of higher levels to seek among files in the lower
levels.

Informs #718.