### PR TITLE
compaction: merge in-use key ranges level-by-level

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -767,53 +767,117 @@ func newFlush(
 
 func (c *compaction) setupInuseKeyRanges() {
 	level := c.outputLevel.level + 1
-
-	var input []manifest.UserKeyRange
 	if c.outputLevel.level == 0 {
-		// Level 0 can contain overlapping sstables, so we need to check it
-		// for overlaps. Rather than collect overlapping sstables through
-		// version.Overlaps, we use the L0 Sublevels structure to calculate
-		// the merged in-use key ranges.
-		input = c.version.L0Sublevels.InUseKeyRanges(c.smallest.UserKey, c.largest.UserKey)
+		level = 0
+	}
+	c.inuseKeyRanges = calculateInuseKeyRanges(c.version, c.cmp, level,
+		c.smallest.UserKey, c.largest.UserKey)
+}
+
+func calculateInuseKeyRanges(
+	v *version, cmp base.Compare, level int, smallest, largest []byte,
+) []manifest.UserKeyRange {
+	// Use two slices, alternating which one is input and which one is output
+	// as we descend the LSM.
+	var input, output []manifest.UserKeyRange
+
+	// L0 requires special treatment, since sstables within L0 may overlap.
+	// We use the L0 Sublevels structure to efficiently calculate the merged
+	// in-use key ranges.
+	if level == 0 {
+		output = v.L0Sublevels.InUseKeyRanges(smallest, largest)
+		level++
 	}
 
-	// Gather up the raw list of key ranges from overlapping tables in lower
-	// levels.
 	for ; level < numLevels; level++ {
-		overlaps := c.version.Overlaps(level, c.cmp, c.smallest.UserKey, c.largest.UserKey)
+		overlaps := v.Overlaps(level, cmp, smallest, largest)
 		iter := overlaps.Iter()
-		for m := iter.First(); m != nil; m = iter.Next() {
-			input = append(input, manifest.UserKeyRange{
-				Start: m.Smallest.UserKey,
-				End:   m.Largest.UserKey,
-			})
+
+		// We may already have in-use key ranges from higher levels. Iterate
+		// through both our accumulated in-use key ranges and this level's
+		// files, merging the two.
+		//
+		// Tables higher within the LSM have broader key spaces. We use this
+		// when possible to seek past a level's files that are contained by
+		// our current accumulated in-use key ranges. This helps avoid
+		// per-sstable work during flushes or compactions in high levels which
+		// overlap the majority of the LSM's sstables.
+		input, output = output, input
+		output = output[:0]
+
+		var currFile *fileMetadata
+		var currAccum *manifest.UserKeyRange
+		if len(input) > 0 {
+			currAccum, input = &input[0], input[1:]
+		}
+
+		// If we have an accumulated key range and its start is ≤ smallest,
+		// we can seek to the accumulated range's end. Otherwise, we need to
+		// start at the first overlapping file within the level.
+		if currAccum != nil && cmp(currAccum.Start, smallest) <= 0 {
+			currFile = seekGT(&iter, cmp, currAccum.End)
+		} else {
+			currFile = iter.First()
+		}
+
+		for currFile != nil || currAccum != nil {
+			// If we've exhausted either the files in the level or the
+			// accumulated key ranges, we just need to append the one we have.
+			// If we have both a currFile and a currAccum, they either overlap
+			// or they're disjoint. If they're disjoint, we append whichever
+			// one sorts first and move on to the next file or range. If they
+			// overlap, we merge them into currAccum and proceed to the next
+			// file.
+			switch {
+			case currAccum == nil || (currFile != nil && cmp(currFile.Largest.UserKey, currAccum.Start) < 0):
+				// This file is strictly before the current accumulated range,
+				// or there are no more accumulated ranges.
+				output = append(output, manifest.UserKeyRange{
+					Start: currFile.Smallest.UserKey,
+					End:   currFile.Largest.UserKey,
+				})
+				currFile = iter.Next()
+			case currFile == nil || (currAccum != nil && cmp(currAccum.End, currFile.Smallest.UserKey) < 0):
+				// The current accumulated key range is strictly before the
+				// current file, or there are no more files.
+				output = append(output, *currAccum)
+				currAccum = nil
+				if len(input) > 0 {
+					currAccum, input = &input[0], input[1:]
+				}
+			default:
+				// The current accumulated range and the current file overlap.
+				// Adjust the accumulated range to be the union.
+				if cmp(currFile.Smallest.UserKey, currAccum.Start) < 0 {
+					currAccum.Start = currFile.Smallest.UserKey
+				}
+				if cmp(currFile.Largest.UserKey, currAccum.End) > 0 {
+					currAccum.End = currFile.Largest.UserKey
+				}
+
+				// Extending `currAccum`'s end boundary may have caused it to
+				// overlap with `input` key ranges that we haven't processed
+				// yet. Merge any such key ranges.
+				for len(input) > 0 && cmp(input[0].Start, currAccum.End) <= 0 {
+					if cmp(input[0].End, currAccum.End) > 0 {
+						currAccum.End = input[0].End
+					}
+					input = input[1:]
+				}
+				// Seek the level iterator past our current accumulated end.
+				currFile = seekGT(&iter, cmp, currAccum.End)
+			}
 		}
 	}
+	return output
+}
 
-	if len(input) == 0 {
-		// Nothing more to do.
-		return
+func seekGT(iter *manifest.LevelIterator, cmp base.Compare, key []byte) *manifest.FileMetadata {
+	f := iter.SeekGE(cmp, key)
+	for f != nil && cmp(f.Largest.UserKey, key) == 0 {
+		f = iter.Next()
 	}
-
-	// Sort the raw list of key ranges by start key.
-	sort.Slice(input, func(i, j int) bool {
-		return c.cmp(input[i].Start, input[j].Start) < 0
-	})
-
-	// Take the first input as the first output. This key range is guaranteed to
-	// have the smallest start key (or share the smallest start key) with another
-	// range. Loop over the remaining input key ranges and either add a new
-	// output, or merge with the last output.
-	c.inuseKeyRanges = input[:1]
-	for _, v := range input[1:] {
-		last := &c.inuseKeyRanges[len(c.inuseKeyRanges)-1]
-		switch {
-		case c.cmp(last.End, v.Start) < 0:
-			c.inuseKeyRanges = append(c.inuseKeyRanges, v)
-		case c.cmp(last.End, v.End) < 0:
-			last.End = v.End
-		}
-	}
+	return f
 }
 
 // findGrandparentLimit takes the start user key for a table and returns the

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -521,7 +521,8 @@ func (s *L0Sublevels) ReadAmplification() int {
 	return amp
 }
 
-// UserKeyRange encodes a key range in user key space.
+// UserKeyRange encodes a key range in user key space. A UserKeyRange's Start
+// and End boundaries are both inclusive.
 type UserKeyRange struct {
 	Start, End []byte
 }

--- a/testdata/compaction_inuse_key_ranges
+++ b/testdata/compaction_inuse_key_ranges
@@ -192,3 +192,218 @@ b-dd
 .
 .
 .
+
+define
+L1
+  a.SET.6-b.SET.6
+  d.SET.6-g.SET.6
+L2
+  c.SET.5-d.SET.5
+  i.SET.5-j.SET.5
+L3
+  b.SET.1-c.SET.1
+L4
+  f.SET.1-k.SET.1
+L6
+  m.SET.1-z.SET.1
+----
+1:
+  000001:[a#6,SET-b#6,SET]
+  000002:[d#6,SET-g#6,SET]
+2:
+  000003:[c#5,SET-d#5,SET]
+  000004:[i#5,SET-j#5,SET]
+3:
+  000005:[b#1,SET-c#1,SET]
+4:
+  000006:[f#1,SET-k#1,SET]
+6:
+  000007:[m#1,SET-z#1,SET]
+
+inuse-key-ranges
+5 a z
+5 a b
+5 m z
+5 m zz
+5 mm zz
+5 l x
+5 l zz
+----
+m-z
+.
+m-z
+m-z
+m-z
+m-z
+m-z
+
+inuse-key-ranges
+3 a z
+3 f k
+3 k m
+3 l ll
+3 b n
+----
+f-k m-z
+f-k
+f-k m-z
+.
+f-k m-z
+
+inuse-key-ranges
+2 a z
+----
+b-c f-k m-z
+
+inuse-key-ranges
+1 a z
+----
+b-d f-k m-z
+
+inuse-key-ranges
+0 a z
+0 a k
+0 a b
+0 bb bc
+0 f k
+----
+a-k m-z
+a-k
+a-c
+b-c
+d-k
+
+define
+L1
+  m.SET.6-p.SET.6
+L2
+  j.SET.5-n.SET.5
+  o.SET.5-t.SET.5
+L3
+  e.SET.2-k.SET.2
+  s.SET.2-x.SET.2
+L4
+  a.SET.1-f.SET.1
+  w.SET.1-z.SET.1
+----
+1:
+  000001:[m#6,SET-p#6,SET]
+2:
+  000002:[j#5,SET-n#5,SET]
+  000003:[o#5,SET-t#5,SET]
+3:
+  000004:[e#2,SET-k#2,SET]
+  000005:[s#2,SET-x#2,SET]
+4:
+  000006:[a#1,SET-f#1,SET]
+  000007:[w#1,SET-z#1,SET]
+
+inuse-key-ranges
+3 a z
+2 a z
+1 a z
+0 a z
+0 a n
+0 a mm
+0 a nn
+0 p z
+0 pp z
+0 oo z
+----
+a-f w-z
+a-k s-z
+a-n o-z
+a-z
+a-p
+a-p
+a-p
+m-z
+o-z
+m-z
+
+define
+L1
+  a.SET.6-c.SET.6
+L2
+  b.SET.5-b.SET.5
+  bb.SET.5-bb.SET.5
+  cc.SET.5-cc.SET.5
+----
+1:
+  000001:[a#6,SET-c#6,SET]
+2:
+  000002:[b#5,SET-b#5,SET]
+  000003:[bb#5,SET-bb#5,SET]
+  000004:[cc#5,SET-cc#5,SET]
+
+inuse-key-ranges
+0 a c
+0 a cc
+----
+a-c
+a-c cc-cc
+
+define
+L1
+  a.SET.6-c.SET.6
+L2
+  b.SET.5-b.SET.5
+  bb.SET.5-bb.SET.5
+  bc.SET.5-c.SET.5
+  c.SET.5-c.SET.5
+  c.SET.5-d.SET.5
+----
+1:
+  000001:[a#6,SET-c#6,SET]
+2:
+  000002:[b#5,SET-b#5,SET]
+  000003:[bb#5,SET-bb#5,SET]
+  000004:[bc#5,SET-c#5,SET]
+  000005:[c#5,SET-c#5,SET]
+  000006:[c#5,SET-d#5,SET]
+
+inuse-key-ranges
+0 a c
+0 a cc
+0 a d
+0 c c
+----
+a-d
+a-d
+a-d
+a-d
+
+
+define
+L0
+  d.SET.7-i.SET.7
+L1
+  a.SET.6-a.SET.6
+  d.SET.6-d.SET.6
+  h.SET.6-i.SET.6
+L2
+  b.SET.5-b.SET.5
+  c.SET.5-c.SET.5
+  e.SET.5-e.SET.5
+L3
+  bb.SET.4-bb.SET.4
+----
+0.0:
+  000001:[d#7,SET-i#7,SET]
+1:
+  000002:[a#6,SET-a#6,SET]
+  000003:[d#6,SET-d#6,SET]
+  000004:[h#6,SET-i#6,SET]
+2:
+  000005:[b#5,SET-b#5,SET]
+  000006:[c#5,SET-c#5,SET]
+  000007:[e#5,SET-e#5,SET]
+3:
+  000008:[bb#4,SET-bb#4,SET]
+
+inuse-key-ranges
+0 a z
+1 a z
+----
+a-a b-b bb-bb c-c d-i
+b-b bb-bb c-c e-e


### PR DESCRIPTION
When computing in-use key ranges for a compaction, merge the intervals
for each level before descending to the next level. This allows for an
optimization where a level iterator may be seeked to the current
accumulated key range's end boundary. Since higher-level tables tend to
be broader, this should help reduce per-sstable work when setting up
flushes/compactions in stores with many sstables.

Pebble benchmarks are largely even.

```
name                old ops/sec  new ops/sec  delta
ycsb/D/values=1024    209k ±10%    206k ± 6%    ~     (p=0.312 n=10+14)
ycsb/C/values=1024    895k ±13%    940k ±16%    ~     (p=0.103 n=10+15)
ycsb/A/values=1024   80.8k ± 1%   80.6k ± 2%    ~     (p=0.643 n=10+15)
ycsb/B/values=1024    383k ± 7%    384k ± 7%    ~     (p=0.978 n=10+15)
ycsb/E/values=1024   63.1k ± 9%   62.8k ± 7%    ~     (p=0.935 n=10+15)
ycsb/F/values=1024   26.9k ± 3%   27.0k ± 2%    ~     (p=0.605 n=10+15)
ycsb/F/values=64      239k ± 1%    238k ± 0%  -0.46%  (p=0.021 n=10+12)
ycsb/C/values=64     2.32M ±24%   2.55M ±37%    ~     (p=0.177 n=10+15)
ycsb/E/values=64      212k ± 6%    215k ± 5%    ~     (p=0.261 n=10+15)
ycsb/B/values=64     1.11M ± 8%   1.13M ±16%    ~     (p=0.428 n=10+15)
ycsb/A/values=64      824k ± 6%    846k ± 6%    ~     (p=0.235 n=10+14)
ycsb/D/values=64      914k ± 4%    935k ±14%    ~     (p=0.194 n=9+15)
```

It's difficult to write a natural microbenchmark for this because
flushes or compactions will change the shape of the LSM during the benchmark,
and it's costly to set up the requisite number of files. I added a
really contrived benchmark that demonstrates the extreme best case for
the optimization, where one files span across all the other files.

```
name                                                      old time/op    new time/op    delta
ManySSTables/calculateInuseKeyRanges/sstables=10-24         4.48µs ± 1%    3.22µs ± 1%   -28.15%  (p=0.008 n=5+5)
ManySSTables/calculateInuseKeyRanges/sstables=1000-24        272µs ± 1%       4µs ± 1%   -98.61%  (p=0.008 n=5+5)
ManySSTables/calculateInuseKeyRanges/sstables=10000-24      3.74ms ± 1%    0.00ms ± 1%   -99.90%  (p=0.008 n=5+5)
ManySSTables/calculateInuseKeyRanges/sstables=100000-24     53.3ms ± 2%     0.0ms ± 1%   -99.99%  (p=0.008 n=5+5)
ManySSTables/calculateInuseKeyRanges/sstables=1000000-24     826ms ±34%       0ms ± 5%  -100.00%  (p=0.008 n=5+5)

name                                                      old alloc/op   new alloc/op   delta
ManySSTables/calculateInuseKeyRanges/sstables=10-24         3.15kB ± 0%    1.87kB ± 0%   -40.61%  (p=0.008 n=5+5)
ManySSTables/calculateInuseKeyRanges/sstables=1000-24        100kB ± 0%       2kB ± 0%   -98.13%  (p=0.008 n=5+5)
ManySSTables/calculateInuseKeyRanges/sstables=10000-24      2.57MB ± 0%    0.00MB ± 0%   -99.93%  (p=0.000 n=4+5)
ManySSTables/calculateInuseKeyRanges/sstables=100000-24     26.6MB ± 0%     0.0MB ± 0%   -99.99%  (p=0.008 n=5+5)
ManySSTables/calculateInuseKeyRanges/sstables=1000000-24     252MB ± 0%       0MB ± 0%  -100.00%  (p=0.008 n=5+5)

name                                                      old allocs/op  new allocs/op  delta
ManySSTables/calculateInuseKeyRanges/sstables=10-24           20.0 ± 0%      19.0 ± 0%    -5.00%  (p=0.008 n=5+5)
ManySSTables/calculateInuseKeyRanges/sstables=1000-24         26.0 ± 0%      19.0 ± 0%   -26.92%  (p=0.008 n=5+5)
ManySSTables/calculateInuseKeyRanges/sstables=10000-24        36.0 ± 0%      19.0 ± 0%   -47.22%  (p=0.008 n=5+5)
ManySSTables/calculateInuseKeyRanges/sstables=100000-24       47.4 ± 1%      14.0 ± 0%   -70.46%  (p=0.008 n=5+5)
ManySSTables/calculateInuseKeyRanges/sstables=1000000-24      76.4 ± 9%      19.0 ± 0%   -75.13%  (p=0.008 n=5+5)
```

Fix #718.