### PR TITLE
docs: label new AMI in nightly benchmarks

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -54,6 +54,8 @@
         and preallocation bug fixed</div>
         <div class="annotation" data-date="20210326">Removed excess
         read samples for read-triggered compactions</div>
+        <div class="annotation" data-date="20210429">Switched to Ubuntu
+        20.04.2 LTS AMI</div>
       </div>
       <div class="section rows">
         <div>


### PR DESCRIPTION
Label the switch to the new AMI in the nightly benchmarks.

I'm not sure why exactly why throughput is down on the new AMI. The new AMI mounts ext4 with the 64-bit and metadata checksumming options, and uses Linux 5.4.0 instead of the previous 4.40.

fio shows higher average sequential write latency on the new AMI:
```
  write: io=294774MB, bw=335387KB/s, iops=1310, runt=900001msec
    clat (usec): min=73, max=1029, avg=81.63, stdev= 4.97
     lat (usec): min=76, max=1043, avg=84.46, stdev= 5.57
```
vs
```
  write: IOPS=1310, BW=328MiB/s (344MB/s)(288GiB/900001msec); 0 zone resets
    clat (usec): min=103, max=677, avg=113.44, stdev= 2.36
     lat (usec): min=105, max=678, avg=114.91, stdev= 2.38
```