### PR TITLE
db: improve disk usage accounting metrics

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -371,7 +371,7 @@ func TestLargeBatch(t *testing.T) {
 	logNum := func() FileNum {
 		d.mu.Lock()
 		defer d.mu.Unlock()
-		return d.mu.log.queue[len(d.mu.log.queue)-1]
+		return d.mu.log.queue[len(d.mu.log.queue)-1].fileNum
 	}
 	fileSize := func(fileNum FileNum) int64 {
 		info, err := d.opts.FS.Stat(base.MakeFilename(d.opts.FS, "", fileTypeLog, fileNum))

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/cockroachdb/pebble/internal/humanize"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/require"
@@ -192,6 +193,9 @@ func TestMetrics(t *testing.T) {
 			d.mu.Unlock()
 
 			return d.Metrics().String()
+
+		case "disk-usage":
+			return humanize.IEC.Uint64(d.Metrics().DiskSpaceUsage()).String()
 
 		default:
 			return fmt.Sprintf("unknown command: %s", td.Cmd)

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -38,6 +38,10 @@ zmemtbl         1   256 K
  titers         1
  filter         -       -    0.0%  (score == utility)
 
+disk-usage
+----
+1.8 K
+
 batch
 set b 2
 ----
@@ -80,6 +84,10 @@ zmemtbl         2   512 K
  tcache         2   1.2 K   50.0%  (score == hit-rate)
  titers         2
  filter         -       -    0.0%  (score == utility)
+
+disk-usage
+----
+3.5 K
 
 # Closing iter a will release one of the zombie memtables.
 
@@ -138,6 +146,10 @@ zmemtbl         1   256 K
  titers         1
  filter         -       -    0.0%  (score == utility)
 
+disk-usage
+----
+2.7 K
+
 # Closing iter b will release the last zombie sstable and the last zombie memtable.
 
 iter-close b
@@ -165,3 +177,7 @@ zmemtbl         0     0 B
  tcache         0     0 B   50.0%  (score == hit-rate)
  titers         0
  filter         -       -    0.0%  (score == utility)
+
+disk-usage
+----
+1.9 K


### PR DESCRIPTION
Improve metrics surrounding disk space usage, by tracking physical WAL
sizes of both live and obsolete WALs, the OPTIONS file and the MANIFEST
file.

Expose a `(*pebble.Metrics).DiskSpaceUsage` function that handles
summing all the disk usage information from within `Metrics` into a
single value.

See cockroachdb/cockroach#56620.