### PR TITLE
sstable: vectorize shared prefix byte comparison

### DIFF
--- a/internal/base/comparer.go
+++ b/internal/base/comparer.go
@@ -191,6 +191,12 @@ func SharedPrefixLen(a, b []byte) int {
 	if n > len(b) {
 		n = len(b)
 	}
+	asUint64 := func(c []byte, i int) uint64 {
+		return binary.LittleEndian.Uint64(c[i:])
+	}
+	for i < n-7 && asUint64(a, i) == asUint64(b, i) {
+		i += 8
+	}
 	for i < n && a[i] == b[i] {
 		i++
 	}

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -194,8 +194,10 @@ func (f discardFile) Sync() error {
 func BenchmarkWriter(b *testing.B) {
 	keys := make([][]byte, 1e6)
 	for i := range keys {
-		key := make([]byte, 8)
-		binary.BigEndian.PutUint64(key, uint64(i))
+		key := make([]byte, 24)
+		binary.BigEndian.PutUint64(key[:8], 123) // 16-byte shared prefix
+		binary.BigEndian.PutUint64(key[8:16], 456)
+		binary.BigEndian.PutUint64(key[16:], uint64(i))
 		keys[i] = key
 	}
 


### PR DESCRIPTION
This commit optimizes `SharedPrefixLen` and its inlined version in `blockWriter.store` by "vectorizing" byte comparisons when computing the shared prefix length of two byte slices. As 6cd3310 noted, `blockWriter.store` is called for every single key written to a table, so micro-optimizations like this have an impact.

```
name               old time/op    new time/op    delta
Writer/Default-16     101ms ± 3%      94ms ± 3%  -6.73%  (p=0.000 n=19+20)
Writer/Zstd-16        257ms ± 5%     251ms ± 4%  -2.55%  (p=0.000 n=19+18)
```

On a node that was busy performing compactions, I found this inlined version of `SharedPrefixLen` to be responsible for **2.39%** of total CPU time before this change.

```
Type: cpu
Time: Jun 8, 2021 at 4:55am (UTC)
Duration: 5.12s, Total samples = 10.86s (212.21%)
Active filters:
   focus=blockWriter\).store
Showing nodes accounting for 0.63s, 5.80% of 10.86s total
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context 	 	 
----------------------------------------------------------+-------------
                                             0.22s   100% |   github.com/cockroachdb/pebble/sstable.(*blockWriter).add /go/src/github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/pebble/sstable/block.go:123
     0.22s  2.03%  2.03%      0.22s  2.03%                | github.com/cockroachdb/pebble/sstable.(*blockWriter).store /go/src/github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/pebble/sstable/block.go:47
----------------------------------------------------------+-------------
                                             0.04s   100% |   github.com/cockroachdb/pebble/sstable.(*blockWriter).add /go/src/github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/pebble/sstable/block.go:123
     0.04s  0.37%  2.39%      0.04s  0.37%                | github.com/cockroachdb/pebble/sstable.(*blockWriter).store /go/src/github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/pebble/sstable/block.go:48
----------------------------------------------------------+-------------
```