### PR TITLE
vfs: use Bavail in GetFreeSpace

### DIFF
--- a/vfs/disk_usage_linux.go
+++ b/vfs/disk_usage_linux.go
@@ -15,7 +15,7 @@ func (defaultFS) GetFreeSpace(path string) (uint64, error) {
 	}
 
 	// We use stat.Frsize here rather than stat.Bsize because on
-	// Linux Bfree is in Frsize units.
+	// Linux Bavail is in Frsize units.
 	//
 	// On most filesystems Frsize and Bsize will be set to the
 	// same value, but on some filesystems bsize returns the
@@ -32,5 +32,5 @@ func (defaultFS) GetFreeSpace(path string) (uint64, error) {
 	//
 	// [1] https://man7.org/linux/man-pages/man2/statfs.2.html
 	// [2] https://man7.org/linux/man-pages/man3/statvfs.3.html
-	return uint64(stat.Frsize) * stat.Bfree, nil
+	return uint64(stat.Frsize) * uint64(stat.Bavail), nil
 }

--- a/vfs/disk_usage_unix.go
+++ b/vfs/disk_usage_unix.go
@@ -13,5 +13,5 @@ func (defaultFS) GetFreeSpace(path string) (uint64, error) {
 	if err := unix.Statfs(path, &stat); err != nil {
 		return 0, err
 	}
-	return uint64(stat.Bsize) * stat.Bfree, nil
+	return uint64(stat.Bsize) * uint64(stat.Bavail), nil
 }


### PR DESCRIPTION
Some environments reserve free disk blocks for root users, and a
non-root user has less disk space available than the value calculated
from `Bfree` indicates. Note that CockroachDB already uses `Bavail` for
computing store capacity metrics, although it relies on the
github.com/elastic/gosigar module for the calculation.

https://github.com/elastic/gosigar/blob/v0.14.1/sigar_unix.go#L23

See facebook/rocksdb#8370.