### PR TITLE
travis: add go 1.16 CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,35 @@ matrix:
       os: linux
       # NB: "env: GOOS=freebsd" does not have the desired effect.
       script: GOOS=freebsd go build -v ./...
+    - name: "go1.16.x-linux"
+      go: 1.16.x
+      os: linux
+      script: make test generate
+    - name: "go1.16.x-linux-race"
+      go: 1.16.x
+      os: linux
+      script: make testrace TAGS=
+    - name: "go1.16.x-linux-no-invariants"
+      go: 1.16.x
+      os: linux
+      script: make test TAGS=
+    - name: "go1.16.x-linux-no-cgo"
+      go: 1.16.x
+      os: linux
+      script: CGO_ENABLED=0 make test TAGS=
+    - name: "go1.16.x-darwin"
+      go: 1.16.x
+      os: osx
+      script: make test
+    - name: "go1.16.x-windows"
+      go: 1.16.x
+      os: windows
+      script: go test ./...
+    - name: "go1.16.x-freebsd"
+      go: 1.16.x
+      os: linux
+      # NB: "env: GOOS=freebsd" does not have the desired effect.
+      script: GOOS=freebsd go build -v ./...
 
 notifications:
   email:


### PR DESCRIPTION
This adds go 1.16 to the TravisCI build/test matrix.