### PR TITLE
vfs: refactor GetFreeSpace into GetDiskUsage

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1335,12 +1335,12 @@ func (d *DB) getFlushPacerInfo() flushPacerInfo {
 
 func (d *DB) getDeletionPacerInfo() deletionPacerInfo {
 	var pacerInfo deletionPacerInfo
-	// Call GetFreeSpace after every file deletion. This may seem inefficient,
+	// Call GetDiskUsage after every file deletion. This may seem inefficient,
 	// but in practice this was observed to take constant time, regardless of
 	// volume size used, at least on linux with ext4 and zfs. All invocations
 	// take 10 microseconds or less.
-	if space, err := d.opts.FS.GetFreeSpace(d.dirname); err == nil {
-		pacerInfo.freeBytes = space
+	if space, err := d.opts.FS.GetDiskUsage(d.dirname); err == nil {
+		pacerInfo.freeBytes = space.AvailBytes
 	}
 	d.mu.Lock()
 	pacerInfo.obsoleteBytes = d.mu.versions.metrics.Table.ObsoleteSize

--- a/internal/errorfs/errorfs.go
+++ b/internal/errorfs/errorfs.go
@@ -166,12 +166,12 @@ func (fs *FS) OpenDir(name string) (vfs.File, error) {
 	return &errorFile{f, fs.inj}, nil
 }
 
-// GetFreeSpace implements FS.GetFreeSpace.
-func (fs *FS) GetFreeSpace(path string) (uint64, error) {
+// GetDiskUsage implements FS.GetDiskUsage.
+func (fs *FS) GetDiskUsage(path string) (vfs.DiskUsage, error) {
 	if err := fs.inj.MaybeError(OpRead); err != nil {
-		return 0, err
+		return vfs.DiskUsage{}, err
 	}
-	return fs.fs.GetFreeSpace(path)
+	return fs.fs.GetDiskUsage(path)
 }
 
 // PathBase implements FS.PathBase.

--- a/vfs/disk_full.go
+++ b/vfs/disk_full.go
@@ -340,8 +340,8 @@ func (fs *enospcFS) PathDir(path string) string {
 	return fs.inner.PathDir(path)
 }
 
-func (fs *enospcFS) GetFreeSpace(path string) (uint64, error) {
-	return fs.inner.GetFreeSpace(path)
+func (fs *enospcFS) GetDiskUsage(path string) (DiskUsage, error) {
+	return fs.inner.GetDiskUsage(path)
 }
 
 type enospcFile struct {

--- a/vfs/disk_heath_test.go
+++ b/vfs/disk_heath_test.go
@@ -107,7 +107,7 @@ func (m mockFS) PathDir(path string) string {
 	panic("unimplemented")
 }
 
-func (m mockFS) GetFreeSpace(path string) (uint64, error) {
+func (m mockFS) GetDiskUsage(path string) (DiskUsage, error) {
 	panic("unimplemented")
 }
 

--- a/vfs/disk_usage_unix.go
+++ b/vfs/disk_usage_unix.go
@@ -8,10 +8,18 @@ package vfs
 
 import "golang.org/x/sys/unix"
 
-func (defaultFS) GetFreeSpace(path string) (uint64, error) {
+func (defaultFS) GetDiskUsage(path string) (DiskUsage, error) {
 	stat := unix.Statfs_t{}
 	if err := unix.Statfs(path, &stat); err != nil {
-		return 0, err
+		return DiskUsage{}, err
 	}
-	return uint64(stat.Bsize) * uint64(stat.Bavail), nil
+
+	freeBytes := uint64(stat.Bsize) * uint64(stat.Bfree)
+	availBytes := uint64(stat.Bsize) * uint64(stat.Bavail)
+	totalBytes := uint64(stat.Bsize) * uint64(stat.Blocks)
+	return DiskUsage{
+		AvailBytes: availBytes,
+		TotalBytes: totalBytes,
+		UsedBytes:  totalBytes - freeBytes,
+	}, nil
 }

--- a/vfs/disk_usage_windows.go
+++ b/vfs/disk_usage_windows.go
@@ -8,12 +8,14 @@ package vfs
 
 import "golang.org/x/sys/windows"
 
-func (defaultFS) GetFreeSpace(path string) (uint64, error) {
-	var freeSpace uint64
+func (defaultFS) GetDiskUsage(path string) (DiskUsage, error) {
 	p, err := windows.UTF16PtrFromString(path)
 	if err != nil {
-		return 0, err
+		return DiskUsage{}, err
 	}
-	err = windows.GetDiskFreeSpaceEx(p, &freeSpace, nil, nil)
-	return freeSpace, err
+	var freeBytes uint64
+	du := DiskUsage{}
+	err = windows.GetDiskFreeSpaceEx(p, &du.AvailBytes, &du.TotalBytes, &freeBytes)
+	du.UsedBytes = du.TotalBytes - freeBytes
+	return du, err
 }

--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -495,9 +495,9 @@ func (*MemFS) PathDir(p string) string {
 	return path.Dir(p)
 }
 
-// GetFreeSpace implements FS.GetFreeSpace.
-func (*MemFS) GetFreeSpace(string) (uint64, error) {
-	return 0, errors.New("pebble: not supported")
+// GetDiskUsage implements FS.GetDiskUsage.
+func (*MemFS) GetDiskUsage(string) (DiskUsage, error) {
+	return DiskUsage{}, errors.New("pebble: not supported")
 }
 
 // memNode holds a file's data or a directory's children, and implements os.FileInfo.

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -119,9 +119,19 @@ type FS interface {
 	// PathDir returns all but the last element of path, typically the path's directory.
 	PathDir(path string) string
 
-	// GetFreeSpace returns the amount of free disk space for the filesystem
-	// where path is any file or directory within that filesystem.
-	GetFreeSpace(path string) (uint64, error)
+	// GetDiskUsage returns disk space statistics for the filesystem where
+	// path is any file or directory within that filesystem.
+	GetDiskUsage(path string) (DiskUsage, error)
+}
+
+// DiskUsage summarizes disk space usage on a filesystem.
+type DiskUsage struct {
+	// Total disk space available to the current process in bytes.
+	AvailBytes uint64
+	// Total disk space in bytes.
+	TotalBytes uint64
+	// Used disk space in bytes.
+	UsedBytes uint64
 }
 
 // Default is a FS implementation backed by the underlying operating system's

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -241,12 +241,12 @@ func TestVFS(t *testing.T) {
 	}
 }
 
-func TestVFSGetFreeSpace(t *testing.T) {
+func TestVFSGetDiskUsage(t *testing.T) {
 	dir, err := ioutil.TempDir("", "test-free-space")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(dir)
 	}()
-	_, err = Default.GetFreeSpace(dir)
+	_, err = Default.GetDiskUsage(dir)
 	require.Nil(t, err)
 }


### PR DESCRIPTION
Refactor GetFreeSpace into GetDiskUsage, exposing a total disk space
capacity value too. I anticipate using this within CockroachDB, rather
than using the gosigar package.