### PR TITLE
Clean up travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,31 +23,6 @@ matrix:
       go: 1.15.x
       os: linux
       script: make test generate
-    - name: "go1.15.x-linux-race"
-      go: 1.15.x
-      os: linux
-      script: make testrace TAGS=
-    - name: "go1.15.x-linux-no-invariants"
-      go: 1.15.x
-      os: linux
-      script: make test TAGS=
-    - name: "go1.15.x-linux-no-cgo"
-      go: 1.15.x
-      os: linux
-      script: CGO_ENABLED=0 make test TAGS=
-    - name: "go1.15.x-darwin"
-      go: 1.15.x
-      os: osx
-      script: make test
-    - name: "go1.15.x-windows"
-      go: 1.15.x
-      os: windows
-      script: go test ./...
-    - name: "go1.15.x-freebsd"
-      go: 1.15.x
-      os: linux
-      # NB: "env: GOOS=freebsd" does not have the desired effect.
-      script: GOOS=freebsd go build -v ./...
     - name: "go1.16.x-linux"
       go: 1.16.x
       os: linux


### PR DESCRIPTION
Removed all go1.15.x test variants except `go1.15.x-linux`, similar to
https://github.com/cockroachdb/pebble/pull/983.