### PR TITLE
make number of cache shards configurable

### DIFF
--- a/options_test.go
+++ b/options_test.go
@@ -5,6 +5,7 @@
 package pebble
 
 import (
+	"runtime"
 	"testing"
 	"time"
 
@@ -40,6 +41,9 @@ func TestLevelOptions(t *testing.T) {
 }
 
 func TestOptionsString(t *testing.T) {
+	n := runtime.GOMAXPROCS(8)
+	defer runtime.GOMAXPROCS(n)
+
 	const expected = `[Version]
   pebble_version=0.1
 
@@ -68,6 +72,7 @@ func TestOptionsString(t *testing.T) {
   read_compaction_rate=16000
   read_sampling_multiplier=16
   strict_wal_tail=true
+  table_cache_shards=8
   table_property_collectors=[]
   wal_dir=
   wal_bytes_per_sync=0
@@ -198,6 +203,7 @@ func TestOptionsParse(t *testing.T) {
 			opts.Experimental.MinDeletionRate = 200
 			opts.Experimental.ReadCompactionRate = 300
 			opts.Experimental.ReadSamplingMultiplier = 400
+			opts.Experimental.TableCacheShards = 500
 			opts.EnsureDefaults()
 			str := opts.String()
 

--- a/table_cache.go
+++ b/table_cache.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"runtime"
 	"runtime/debug"
 	"runtime/pprof"
 	"sync"
@@ -38,7 +37,7 @@ func (c *tableCache) init(cacheID uint64, dirname string, fs vfs.FS, opts *Optio
 	c.cache = opts.Cache
 	c.cache.Ref()
 
-	c.shards = make([]*tableCacheShard, runtime.GOMAXPROCS(0))
+	c.shards = make([]*tableCacheShard, opts.Experimental.TableCacheShards)
 	for i := range c.shards {
 		c.shards[i] = &tableCacheShard{}
 		c.shards[i].init(cacheID, dirname, fs, opts, size/len(c.shards))

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -40,7 +40,7 @@ zmemtbl         1   256 K
 
 disk-usage
 ----
-1.8 K
+1.9 K
 
 batch
 set b 2
@@ -180,4 +180,4 @@ zmemtbl         0     0 B
 
 disk-usage
 ----
-1.9 K
+2.0 K


### PR DESCRIPTION
Users should be able to control the number of cache shards.
In my case, I've got 30k+ idle goroutines on my 64cores server with 500~600 (logically partitioned) db instances.