### PR TITLE
sstable: Update Reader to isolate and report corruption

### DIFF
--- a/internal/manifest/spans.go
+++ b/internal/manifest/spans.go
@@ -1,0 +1,77 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package manifest
+
+import (
+	"sort"
+
+	"github.com/cockroachdb/pebble/internal/base"
+)
+
+// Span is a key span as part of a set of Spans. A span is inclusive on both ends,
+// as motivated by file bounds in FileMetadata.
+type Span struct {
+	Start, End []byte
+}
+
+// Equal checks whether two spans are equal.
+func (s *Span) Equal(other Span, cmp base.Compare) bool {
+	return cmp(s.Start, other.Start) == 0 && cmp(s.End, other.End) == 0
+}
+
+// Spans is a de-duplicated set of disjoint spans. Adding a duplicate span
+// using Add is a no-op, and adding an overlapping span merges it into existing
+// overlapping spans. Not safe for concurrent use.
+type Spans struct {
+	Cmp base.Compare
+
+	spans []Span
+}
+
+// Add appends the specified span to the end of the spanset. Sorting/merging
+// is done as part of Finish if necessary.
+func (s *Spans) Add(span Span) {
+	s.spans = append(s.spans, span)
+}
+
+// Finish sorts the underlying spanset. Must be called after a sequence of Add
+// operations that were not sorted, to maintain sort order. Does not need to be
+// called if entries in Add were sorted.
+func (s *Spans) Finish() {
+	// Sort the spans by start key.
+	sort.Slice(s.spans, func(i, j int) bool {
+		return s.Cmp(s.spans[i].Start, s.spans[j].Start) < 0
+	})
+
+	// Iterate through the sorted spans. Three possible cases:
+	// 1) The RHS span is completely covered by the LHS span -> delete RHS span
+	// 2) The RHS span has a partial overlap with the LHS span -> change LHS
+	//    span's end key and delete RHS span.
+	// 3) The RHS span does not overlap at all with LHS span -> do nothing
+	for i := 1; i < len(s.spans); {
+		if s.Cmp(s.spans[i-1].End, s.spans[i].Start) < 0 {
+			// No overlap - case 3.
+			i++
+			continue
+		}
+		if s.Cmp(s.spans[i-1].End, s.spans[i].End) < 0 {
+			// Partial overlap - case 2. Extend i-1's end.
+			s.spans[i-1].End = s.spans[i].End
+		}
+		// Cases 1 and 2. Delete RHS span. Note that we do *not* increment i.
+		n := copy(s.spans[i:], s.spans[i+1:])
+		s.spans = s.spans[:i+n]
+	}
+}
+
+// Get returns the underlying, sorted SpanSet.
+func (s *Spans) Get() []Span {
+	return s.spans
+}
+
+// Empty returns if the spanset is empty.
+func (s *Spans) Empty() bool {
+	return len(s.spans) == 0
+}

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -418,7 +418,7 @@ func TestVersionUnref(t *testing.T) {
 func TestCheckOrdering(t *testing.T) {
 	cmp := base.DefaultComparer.Compare
 	fmtKey := base.DefaultComparer.FormatKey
-	parseMeta := func(s string) FileMetadata {
+	parseMeta := func(s string) *FileMetadata {
 		parts := strings.Split(s, "-")
 		if len(parts) != 2 {
 			t.Fatalf("malformed table spec: %s", s)
@@ -429,7 +429,7 @@ func TestCheckOrdering(t *testing.T) {
 		}
 		m.SmallestSeqNum = m.Smallest.SeqNum()
 		m.LargestSeqNum = m.Largest.SeqNum()
-		return m
+		return &m
 	}
 
 	datadriven.RunTest(t, "testdata/version_check_ordering",
@@ -456,7 +456,7 @@ func TestCheckOrdering(t *testing.T) {
 						meta := parseMeta(data)
 						meta.FileNum = fileNum
 						fileNum++
-						*files = append(*files, &meta)
+						*files = append(*files, meta)
 					}
 				}
 

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"unsafe"
 
 	"github.com/cespare/xxhash/v2"
@@ -20,6 +21,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/crc"
 	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/private"
 	"github.com/cockroachdb/pebble/internal/rangedel"
 	"github.com/cockroachdb/pebble/vfs"
@@ -287,21 +289,59 @@ func (i *singleLevelIterator) loadBlock() bool {
 	i.dataBH, n = decodeBlockHandle(v)
 	if n == 0 || n != len(v) {
 		i.err = errCorruptIndexEntry
+		i.reader.maybeReportCorruption()
 		return false
 	}
 	block, err := i.reader.readBlock(i.dataBH, nil /* transform */, &i.dataRS)
 	if err != nil {
+		if errors.Is(err, base.ErrCorruption) {
+			i.maybeFindDataBlockCorruption()
+		}
 		i.err = err
 		return false
 	}
 	i.err = i.data.initHandle(i.cmp, block, i.reader.Properties.GlobalSeqNum)
 	if i.err != nil {
+		if errors.Is(err, base.ErrCorruption) {
+			i.maybeFindDataBlockCorruption()
+		}
 		// The block is partially loaded, and we don't want it to appear valid.
 		i.data.invalidate()
 		return false
 	}
 	i.initBounds()
 	return true
+}
+
+func (i *singleLevelIterator) maybeFindDataBlockCorruption() {
+	if i.reader.corruptionRep == nil {
+		// No-op.
+		return
+	}
+
+	if old := atomic.SwapInt32(&i.reader.fileMeta.Atomic.IsCorrupt, 1); old == 0 {
+		// We are the first reader to find corruption on this file. Start the
+		// file corruption finding goroutine, which will populate CorruptSpans.
+		fileMeta := i.reader.fileMeta
+		reader := i.reader
+		go func() {
+			spans, err := reader.FindCorruptSpans()
+			if err != nil && !errors.Is(err, base.ErrCorruption) {
+				spans.Add(manifest.Span{
+					Start: fileMeta.Smallest.UserKey,
+					End:   fileMeta.Largest.UserKey,
+				})
+				spans.Finish()
+			}
+			fileMeta.Mu.Lock()
+			fileMeta.Mu.CorruptSpans = spans
+			fileMeta.Mu.Unlock()
+
+			for _, span := range spans.Get() {
+				reader.corruptionRep.ReportCorruption(span.Start, span.End)
+			}
+		}()
+	}
 }
 
 func (i *singleLevelIterator) initBoundsForAlreadyLoadedBlock() {
@@ -956,15 +996,22 @@ func (i *twoLevelIterator) loadIndex() bool {
 	}
 	h, n := decodeBlockHandle(i.topLevelIndex.Value())
 	if n == 0 || n != len(i.topLevelIndex.Value()) {
+		i.reader.maybeReportCorruption()
 		i.err = base.CorruptionErrorf("pebble/table: corrupt top level index entry")
 		return false
 	}
 	indexBlock, err := i.reader.readBlock(h, nil /* transform */, nil /* readaheadState */)
 	if err != nil {
+		if errors.Is(err, base.ErrCorruption) {
+			i.reader.maybeReportCorruption()
+		}
 		i.err = err
 		return false
 	}
 	i.err = i.index.initHandle(i.cmp, indexBlock, i.reader.Properties.GlobalSeqNum)
+	if i.err != nil && errors.Is(i.err, base.ErrCorruption) {
+		i.reader.maybeReportCorruption()
+	}
 	return i.err == nil
 }
 
@@ -983,6 +1030,9 @@ func (i *twoLevelIterator) init(r *Reader, lower, upper []byte) error {
 	i.cmp = r.Compare
 	err = i.topLevelIndex.initHandle(i.cmp, topLevelIndexH, r.Properties.GlobalSeqNum)
 	if err != nil {
+		if errors.Is(err, base.ErrCorruption) {
+			i.reader.maybeReportCorruption()
+		}
 		// blockIter.Close releases topLevelIndexH and always returns a nil error
 		_ = i.topLevelIndex.Close()
 		return err
@@ -1660,6 +1710,34 @@ func (f FileReopenOpt) readerApply(r *Reader) {
 	}
 }
 
+// CorruptionReporter is an interface for reporting sstable corruption.
+type CorruptionReporter interface {
+	// ReportCorruption reports an instance of sstable corruption. The sstable
+	// Reader will call this method before returning a CorruptionError if an
+	// instance of sstable corruption was detected. The reporter is expected
+	// to inform any callers to stop issuing more read requests over the
+	// user-key range [start, end], as those will return CorruptionErrors again.
+	// This method is also expected to be idempotent; multiple successive calls
+	// should be acceptable. A report of a wider key range after a report of
+	// a narrower range is also possible, as well as any arbitrary combination
+	// of a report of overlapping ranges.
+	ReportCorruption(start, end []byte)
+}
+
+// CorruptionReportingOpt is specified for any Readers that are connected to
+// a CorruptionReporter for reporting sstable corruption.
+type CorruptionReportingOpt struct {
+	CR       CorruptionReporter
+	FileMeta *manifest.FileMetadata
+}
+
+func (c CorruptionReportingOpt) readerApply(r *Reader) {
+	r.corruptionRep = c.CR
+	r.fileMeta = c.FileMeta
+}
+
+func (CorruptionReportingOpt) preApply() {}
+
 // rawTombstonesOpt is a Reader open option for specifying that range
 // tombstones returned by Reader.NewRangeDelIter() should not be
 // fragmented. Used by debug tools to get a raw view of the tombstones
@@ -1703,6 +1781,8 @@ type Reader struct {
 	checksumType      ChecksumType
 	tableFilter       *tableFilterReader
 	Properties        Properties
+	corruptionRep     CorruptionReporter
+	fileMeta          *manifest.FileMetadata
 }
 
 // Close implements DB.Close, as documented in the pebble package.
@@ -1847,15 +1927,36 @@ func (r *Reader) NewRawRangeDelIter() (base.InternalIterator, error) {
 }
 
 func (r *Reader) readIndex() (cache.Handle, error) {
-	return r.readBlock(r.indexBH, nil /* transform */, nil /* readaheadState */)
+	handle, err := r.readBlock(r.indexBH, nil /* transform */, nil /* readaheadState */)
+	if err != nil {
+		if errors.Is(err, base.ErrCorruption) {
+			r.maybeReportCorruption()
+		}
+		return handle, err
+	}
+	return handle, nil
 }
 
 func (r *Reader) readFilter() (cache.Handle, error) {
-	return r.readBlock(r.filterBH, nil /* transform */, nil /* readaheadState */)
+	handle, err := r.readBlock(r.filterBH, nil /* transform */, nil /* readaheadState */)
+	if err != nil {
+		if errors.Is(err, base.ErrCorruption) {
+			r.maybeReportCorruption()
+		}
+		return handle, err
+	}
+	return handle, nil
 }
 
 func (r *Reader) readRangeDel() (cache.Handle, error) {
-	return r.readBlock(r.rangeDelBH, r.rangeDelTransform, nil /* readaheadState */)
+	handle, err := r.readBlock(r.rangeDelBH, r.rangeDelTransform, nil /* readaheadState */)
+	if err != nil {
+		if errors.Is(err, base.ErrCorruption) {
+			r.maybeReportCorruption()
+		}
+		return handle, err
+	}
+	return handle, nil
 }
 
 // readBlock reads and decompresses a block from disk into memory.
@@ -1966,6 +2067,31 @@ func (r *Reader) readBlock(
 	return h, nil
 }
 
+// maybeReportCorruption reports the entire sstable as corrupt to the corruption
+// reporter, if one exists. For use when corruption is in a part of the sstable
+// (eg. footer, index, or properties blocks) that makes finding a narrower bound
+// for corruption harder. For isolating data block corruption, see
+// singleLevelIterator.maybeFindDataBlockCorruption.
+func (r *Reader) maybeReportCorruption() {
+	if r.corruptionRep == nil {
+		return
+	}
+	if old := atomic.SwapInt32(&r.fileMeta.Atomic.IsCorrupt, 1); old == 0 {
+		spanToAdd := manifest.Span{
+			Start: r.fileMeta.Smallest.UserKey,
+			End:   r.fileMeta.Largest.UserKey,
+		}
+		spans := manifest.Spans{Cmp: r.Compare}
+		spans.Add(spanToAdd)
+
+		r.fileMeta.Mu.Lock()
+		r.fileMeta.Mu.CorruptSpans = spans
+		r.fileMeta.Mu.Unlock()
+
+		r.corruptionRep.ReportCorruption(spanToAdd.Start, spanToAdd.End)
+	}
+}
+
 func (r *Reader) transformRangeDelV1(b []byte) ([]byte, error) {
 	// Convert v1 (RocksDB format) range-del blocks to v2 blocks on the fly. The
 	// v1 format range-del blocks have unfragmented and unsorted range
@@ -2012,12 +2138,16 @@ func (r *Reader) transformRangeDelV1(b []byte) ([]byte, error) {
 func (r *Reader) readMetaindex(metaindexBH BlockHandle) error {
 	b, err := r.readBlock(metaindexBH, nil /* transform */, nil /* readaheadState */)
 	if err != nil {
+		if errors.Is(err, base.ErrCorruption) {
+			r.maybeReportCorruption()
+		}
 		return err
 	}
 	data := b.Get()
 	defer b.Release()
 
 	if uint64(len(data)) != metaindexBH.Length {
+		r.maybeReportCorruption()
 		return base.CorruptionErrorf("pebble/table: unexpected metaindex block size: %d vs %d",
 			errors.Safe(len(data)), errors.Safe(metaindexBH.Length))
 	}
@@ -2031,6 +2161,7 @@ func (r *Reader) readMetaindex(metaindexBH BlockHandle) error {
 	for valid := i.First(); valid; valid = i.Next() {
 		bh, n := decodeBlockHandle(i.Value())
 		if n == 0 {
+			r.maybeReportCorruption()
 			return base.CorruptionErrorf("pebble/table: invalid table (bad filter block handle)")
 		}
 		meta[string(i.Key().UserKey)] = bh
@@ -2042,12 +2173,18 @@ func (r *Reader) readMetaindex(metaindexBH BlockHandle) error {
 	if bh, ok := meta[metaPropertiesName]; ok {
 		b, err = r.readBlock(bh, nil /* transform */, nil /* readaheadState */)
 		if err != nil {
+			if errors.Is(err, base.ErrCorruption) {
+				r.maybeReportCorruption()
+			}
 			return err
 		}
 		r.propertiesBH = bh
 		err := r.Properties.load(b.Get(), bh.Offset)
 		b.Release()
 		if err != nil {
+			if errors.Is(err, base.ErrCorruption) {
+				r.maybeReportCorruption()
+			}
 			return err
 		}
 	}
@@ -2077,6 +2214,7 @@ func (r *Reader) readMetaindex(metaindexBH BlockHandle) error {
 				case TableFilter:
 					r.tableFilter = newTableFilterReader(fp)
 				default:
+					r.maybeReportCorruption()
 					return base.CorruptionErrorf("unknown filter type: %v", errors.Safe(t.ftype))
 				}
 
@@ -2089,6 +2227,138 @@ func (r *Reader) readMetaindex(metaindexBH BlockHandle) error {
 		}
 	}
 	return nil
+}
+
+// FindCorruptSpans returns corrupt spans found in this sstable. If the error
+// returned is not of type ErrCorruption, the set of spans returned could have
+// been incomplete.
+func (r *Reader) FindCorruptSpans() (manifest.Spans, error) {
+	spans := manifest.Spans{Cmp: r.Compare}
+	if r.err != nil {
+		return spans, r.err
+	}
+	if r.fileMeta == nil {
+		return spans, errors.New("cannot find corrupt spans on a Reader created without the corruption reporting option")
+	}
+
+	fullFileSpan := manifest.Span{Start: r.fileMeta.Smallest.UserKey, End: r.fileMeta.Largest.UserKey}
+	indexH, err := r.readIndex()
+	if err != nil {
+		if errors.Is(err, base.ErrCorruption) {
+			spans.Add(fullFileSpan)
+		}
+		return spans, err
+	}
+	defer indexH.Release()
+
+	dataBlocks := make([]BlockHandle, 0, r.Properties.NumDataBlocks)
+
+	if r.Properties.IndexPartitions == 0 {
+		iter, _ := newBlockIter(r.Compare, indexH.Get())
+		for key, value := iter.First(); key != nil; key, value = iter.Next() {
+			bh, n := decodeBlockHandle(value)
+			if n == 0 || n != len(value) {
+				// The block handle itself is corrupt. We could narrow the
+				// corruption bounds based on surrounding index entries, but
+				// those could be corrupt too, so just resort to treating the
+				// entire file as corrupt as a safer bet.
+				spans.Add(fullFileSpan)
+				return spans, errCorruptIndexEntry
+			}
+			dataBlocks = append(dataBlocks, bh)
+		}
+	} else {
+		topIter, _ := newBlockIter(r.Compare, indexH.Get())
+		corruptSecondLevelBlock := false
+		lastUserKey := make([]byte, len(r.fileMeta.Smallest.UserKey))
+		copy(lastUserKey, r.fileMeta.Smallest.UserKey)
+		for key, value := topIter.First(); key != nil; key, value = topIter.Next() {
+			indexBH, n := decodeBlockHandle(value)
+			if n == 0 || n != len(value) {
+				// The block handle itself is corrupt. We could narrow the
+				// corruption bounds based on surrounding index entries, but
+				// those could be corrupt too, so just resort to treating the
+				// entire file as corrupt as a safer bet.
+				spans.Add(fullFileSpan)
+				spans.Finish()
+				return spans, errCorruptIndexEntry
+			}
+
+			subIndex, err := r.readBlock(indexBH, nil /* transform */, nil /* readaheadState */)
+			if err != nil {
+				if errors.Is(err, base.ErrCorruption) {
+					corruptSecondLevelBlock = true
+					continue
+				}
+				return spans, err
+			} else if corruptSecondLevelBlock {
+				corruptSecondLevelBlock = false
+				spans.Add(manifest.Span{
+					Start: lastUserKey,
+					End:   append([]byte(nil), key.UserKey...),
+				})
+			}
+			iter, _ := newBlockIter(r.Compare, subIndex.Get())
+			for key, value := iter.First(); key != nil; key, value = iter.Next() {
+				dataBH, n := decodeBlockHandle(value)
+				if n == 0 || n != len(value) {
+					corruptSecondLevelBlock = true
+					break
+				}
+				dataBlocks = append(dataBlocks, dataBH)
+			}
+			subIndex.Release()
+			if !corruptSecondLevelBlock {
+				// This block was read successfully.
+				lastUserKey = append(lastUserKey[:0], key.UserKey...)
+			}
+		}
+		if corruptSecondLevelBlock {
+			// We ended the outer index iteration with a sequence of unreadable
+			// second level index blocks.
+			spans.Add(manifest.Span{
+				Start: lastUserKey,
+				End:   r.fileMeta.Largest.UserKey,
+			})
+		}
+	}
+
+	lastUserKey := make([]byte, len(r.fileMeta.Smallest.UserKey))
+	copy(lastUserKey, r.fileMeta.Smallest.UserKey)
+	foundCorruptBlock := false
+
+	for _, bh := range dataBlocks {
+		dataBlock, err := r.readBlock(bh, nil /* transform */, nil /* readaheadState */)
+		if err != nil && errors.Is(err, base.ErrCorruption) {
+			foundCorruptBlock = true
+		} else if err != nil {
+			return spans, nil
+		} else {
+			iter, _ := newBlockIter(r.Compare, dataBlock.Get())
+			lastKey, _ := iter.Last()
+			if foundCorruptBlock {
+				key, _ := iter.First()
+				spans.Add(manifest.Span{
+					Start: lastUserKey,
+					End:   append([]byte(nil), key.UserKey...),
+				})
+				// Allocate a new buffer for the next lastUserKey.
+				lastUserKey = make([]byte, 0, len(lastKey.UserKey))
+			}
+			foundCorruptBlock = false
+			lastUserKey = append(lastUserKey[:0], lastKey.UserKey...)
+			dataBlock.Release()
+		}
+	}
+	if foundCorruptBlock {
+		spans.Add(manifest.Span{
+			Start: lastUserKey,
+			End:   r.fileMeta.Largest.UserKey,
+		})
+	}
+
+	spans.Finish()
+	return spans, nil
 }
 
 // Layout returns the layout (block organization) for an sstable.
@@ -2345,6 +2615,9 @@ func NewReader(f ReadableFile, o ReaderOptions, extraOpts ...ReaderOption) (*Rea
 
 	footer, err := readFooter(f)
 	if err != nil {
+		if errors.Is(err, base.ErrCorruption) {
+			r.maybeReportCorruption()
+		}
 		r.err = err
 		return nil, r.Close()
 	}

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -174,7 +174,7 @@ compact         1   2.3 K             0 B          (size == estimated-debt, in =
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.4 K    5.9%  (score == hit-rate)
- tcache         1   616 B    0.0%  (score == hit-rate)
+ tcache         1   640 B    0.0%  (score == hit-rate)
  titers         0
  filter         -       -    0.0%  (score == utility)
 

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -48,7 +48,7 @@ compact         0     0 B             0 B          (size == estimated-debt, in =
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.5 K   46.7%  (score == hit-rate)
- tcache         1   616 B   50.0%  (score == hit-rate)
+ tcache         1   640 B   50.0%  (score == hit-rate)
  titers         0
  filter         -       -    0.0%  (score == utility)
 

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -34,7 +34,7 @@ compact         0     0 B             0 B          (size == estimated-debt, in =
 zmemtbl         1   256 K
    ztbl         0     0 B
  bcache         4   698 B    0.0%  (score == hit-rate)
- tcache         1   616 B    0.0%  (score == hit-rate)
+ tcache         1   640 B    0.0%  (score == hit-rate)
  titers         1
  filter         -       -    0.0%  (score == utility)
 
@@ -81,7 +81,7 @@ compact         1     0 B             0 B          (size == estimated-debt, in =
 zmemtbl         2   512 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   33.3%  (score == hit-rate)
- tcache         2   1.2 K   50.0%  (score == hit-rate)
+ tcache         2   1.3 K   50.0%  (score == hit-rate)
  titers         2
  filter         -       -    0.0%  (score == utility)
 
@@ -113,7 +113,7 @@ compact         1     0 B             0 B          (size == estimated-debt, in =
 zmemtbl         1   256 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   33.3%  (score == hit-rate)
- tcache         2   1.2 K   50.0%  (score == hit-rate)
+ tcache         2   1.3 K   50.0%  (score == hit-rate)
  titers         2
  filter         -       -    0.0%  (score == utility)
 
@@ -142,7 +142,7 @@ compact         1     0 B             0 B          (size == estimated-debt, in =
 zmemtbl         1   256 K
    ztbl         1   771 B
  bcache         4   698 B   33.3%  (score == hit-rate)
- tcache         1   616 B   50.0%  (score == hit-rate)
+ tcache         1   640 B   50.0%  (score == hit-rate)
  titers         1
  filter         -       -    0.0%  (score == utility)
 


### PR DESCRIPTION
If an sstable reader comes across corruption, whether through
mismatching sizes or checksums or something else, it now
calls a CorruptionReporter method if a CorruptionReportingOpt
was specified upon creation. If this corruption was observed
in a data block, it tries to isolate it more narrowly than
the file's bounds if possible (and if not, it reports the
entire file's bounds as corrupt).

Currently only used in tests, but eventually this will thread
into Cockroach.

Fixes #1192.