### PR TITLE
tool: include version edit index in dump output

### DIFF
--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -117,6 +117,7 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 			var bve manifest.BulkVersionEdit
 			bve.AddedByFileNum = make(map[base.FileNum]*manifest.FileMetadata)
 			var cmp *base.Comparer
+			var editIdx int
 			rr := record.NewReader(f, 0 /* logNum */)
 			for {
 				offset := rr.Offset()
@@ -138,7 +139,7 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 				}
 
 				empty := true
-				fmt.Fprintf(stdout, "%d\n", offset)
+				fmt.Fprintf(stdout, "%d/%d\n", offset, editIdx)
 				if ve.ComparerName != "" {
 					empty = false
 					fmt.Fprintf(stdout, "  comparer:     %s", ve.ComparerName)
@@ -197,6 +198,7 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 					// `LogNum == 0`.
 					fmt.Fprintf(stdout, "  <empty>\n")
 				}
+				editIdx++
 			}
 
 			if cmp != nil {

--- a/tool/testdata/manifest_dump
+++ b/tool/testdata/manifest_dump
@@ -6,7 +6,7 @@ manifest dump
 ../testdata/db-stage-2/MANIFEST-000001
 ----
 MANIFEST-000001
-0
+0/0
   next-file-num: 2
 EOF
 
@@ -14,11 +14,11 @@ manifest dump
 ../testdata/db-stage-4/MANIFEST-000005
 ----
 MANIFEST-000005
-0
+0/0
   comparer:     leveldb.BytewiseComparator
-35
+35/1
   <empty>
-44
+44/2
   log-num:       4
   next-file-num: 6
   last-seq-num:  5
@@ -38,11 +38,11 @@ manifest dump
 --key=%x
 ----
 MANIFEST-000005
-0
+0/0
   comparer:     leveldb.BytewiseComparator
-35
+35/1
   <empty>
-44
+44/2
   log-num:       4
   next-file-num: 6
   last-seq-num:  5
@@ -62,11 +62,11 @@ manifest dump
 --key=null
 ----
 MANIFEST-000005
-0
+0/0
   comparer:     leveldb.BytewiseComparator
-35
+35/1
   <empty>
-44
+44/2
   log-num:       4
   next-file-num: 6
   last-seq-num:  5
@@ -86,11 +86,11 @@ manifest dump
 --key=pretty
 ----
 MANIFEST-000005
-0
+0/0
   comparer:     leveldb.BytewiseComparator
-35
+35/1
   <empty>
-44
+44/2
   log-num:       4
   next-file-num: 6
   last-seq-num:  5
@@ -110,11 +110,11 @@ manifest dump
 --key=pretty:test-comparer
 ----
 MANIFEST-000005
-0
+0/0
   comparer:     leveldb.BytewiseComparator
-35
+35/1
   <empty>
-44
+44/2
   log-num:       4
   next-file-num: 6
   last-seq-num:  5
@@ -157,13 +157,13 @@ manifest dump
 ./testdata/MANIFEST-invalid
 ----
 MANIFEST-invalid
-0
+0/0
   comparer:     leveldb.BytewiseComparator
   log-num:       2
   next-file-num: 5
   last-seq-num:  20
   added:         L6 000001:0<#2-#5>[#0,DEL-#0,DEL]
-65
+65/1
   comparer:     leveldb.BytewiseComparator
   log-num:       3
   next-file-num: 5
@@ -192,49 +192,49 @@ manifest dump
 ./testdata/find-db/MANIFEST-000001
 ----
 MANIFEST-000001
-0
+0/0
   comparer:     alt-comparer
   next-file-num: 2
-25
+25/1
   log-num:       2
   next-file-num: 3
-36
+36/2
   log-num:       4
   next-file-num: 6
   last-seq-num:  5
   added:         L0 000005:784<#1-#5>[aaa#1,SET-ccc#5,MERGE] (2021-04-01T20:24:02Z)
-88
+88/3
   next-file-num: 6
   last-seq-num:  5
   deleted:       L0 000005
   added:         L6 000005:784<#1-#5>[aaa#1,SET-ccc#5,MERGE] (2021-04-01T20:24:02Z)
-141
+141/4
   next-file-num: 7
   last-seq-num:  6
   added:         L0 000006:817<#6-#6>[bbb#6,SET-ccc#6,SET] (2021-04-01T20:24:02Z)
-191
+191/5
   next-file-num: 8
   last-seq-num:  7
   added:         L6 000007:808<#7-#7>[ddd#7,SET-ddd#7,SET] (2021-04-01T20:24:02Z)
-241
+241/6
   next-file-num: 9
   last-seq-num:  7
   deleted:       L0 000006
   deleted:       L6 000005
   added:         L6 000008:791<#0-#6>[aaa#0,SET-ccc#0,MERGE] (2021-04-01T20:24:02Z)
-297
+297/7
   log-num:       9
   next-file-num: 11
   last-seq-num:  10
   added:         L0 000010:834<#8-#10>[aaa#8,DEL-eee#72057594037927935,RANGEDEL] (2021-04-01T20:24:02Z)
-349
+349/8
   next-file-num: 12
   last-seq-num:  10
   deleted:       L0 000010
   deleted:       L6 000007
   deleted:       L6 000008
   added:         L6 000011:898<#0-#10>[aaa#8,DEL-eee#72057594037927935,RANGEDEL] (2021-04-01T20:24:02Z)
-408
+408/9
   next-file-num: 12
   last-seq-num:  10
   deleted:       L6 000011


### PR DESCRIPTION
The version edit index is useful for correlating a version edit to the
corresponding version edit in the LSM visualizer.

Related to #1177.