### PR TITLE
Ensure EventListener functions set all callbacks

### DIFF
--- a/event.go
+++ b/event.go
@@ -577,6 +577,10 @@ func TeeEventListener(a, b EventListener) EventListener {
 			a.CompactionEnd(info)
 			b.CompactionEnd(info)
 		},
+		DiskSlow: func(info DiskSlowInfo) {
+			a.DiskSlow(info)
+			b.DiskSlow(info)
+		},
 		FlushBegin: func(info FlushInfo) {
 			a.FlushBegin(info)
 			b.FlushBegin(info)
@@ -604,6 +608,10 @@ func TeeEventListener(a, b EventListener) EventListener {
 		TableIngested: func(info TableIngestInfo) {
 			a.TableIngested(info)
 			b.TableIngested(info)
+		},
+		TableStatsLoaded: func(info TableStatsInfo) {
+			a.TableStatsLoaded(info)
+			b.TableStatsLoaded(info)
 		},
 		WALCreated: func(info WALCreateInfo) {
 			a.WALCreated(info)


### PR DESCRIPTION
`TeeEventListener` was failing to set a `DiskSlow` or a `TableStatsLoaded` callback. This commit fixes this and adds testing to ensure that the following three functions all avoid this class of bug going forward:
- `(*EventListener).EnsureDefaults`
- `MakeLoggingEventListener`
- `TeeEventListener`