### PR TITLE
tool: add manifest summarize command

### DIFF
--- a/tool/testdata/manifest_summarize
+++ b/tool/testdata/manifest_summarize
@@ -1,0 +1,29 @@
+manifest summarize
+----
+requires at least 1 arg(s), only received 0
+
+manifest summarize
+../testdata/db-stage-2/MANIFEST-000001
+----
+MANIFEST-000001
+(no timestamps)
+---
+Estimated start time: 0001-01-01T00:00:00Z
+Estimated end time:   0001-01-01T00:00:00Z
+Estimated duration:   0s
+
+manifest summarize
+./testdata/find-db/MANIFEST-000001
+----
+MANIFEST-000001
+                     _______L0_______L1_______L2_______L3_______L4_______L5_______L6_____TOTAL
+2021-04-01T20:24:02Z
+        Ingest+Flush      2.4 K        .        .        .        .        .    808 B    3.2 K
+        Ingest+Flush    2.4 K/s        .        .        .        .        .  808 B/s  3.2 K/s
+       Compact (out)      2.4 K        .        .        .        .        .    898 B    3.3 K
+       Compact (out)    2.4 K/s        .        .        .        .        .  898 B/s  3.3 K/s
+2021-04-01T20:24:02Z
+---
+Estimated start time: 2021-04-01T20:24:02Z
+Estimated end time:   2021-04-01T20:24:02Z
+Estimated duration:   0s


### PR DESCRIPTION
Add a summarize command to the manifest tool. This command uses the most
recent sstable creation timestamp to estimate the current time of a
version edit and buckets statistics about version edits by hour.

Example output:
```
<...snip...>
                     _______L0_______L1_______L2_______L3_______L4_______L5_______L6_____TOTAL
2021-07-12T23:00:00Z
        Ingest+Flush      744 K        .        .        .        .        .        .    744 K
        Ingest+Flush    211 B/s        .        .        .        .        .        .  211 B/s
       Compact (out)      744 K        .        .        .        .        .        .    744 K
       Compact (out)    211 B/s        .        .        .        .        .        .  211 B/s
2021-07-13T00:00:00Z
        Ingest+Flush      596 K        .        .        .        .        .        .    596 K
        Ingest+Flush    169 B/s        .        .        .        .        .        .  169 B/s
       Compact (out)      596 K        .        .        .        .        .        .    596 K
       Compact (out)    169 B/s        .        .        .        .        .        .  169 B/s
2021-07-13T01:00:00Z
        Ingest+Flush       35 G        .        .        .        .        .        .     35 G
        Ingest+Flush     13 M/s        .        .        .        .        .        .   13 M/s
       Compact (out)       19 G        .    6.3 G    915 M     38 M     49 M    1.3 G     28 G
       Compact (out)    7.2 M/s        .  2.3 M/s  338 K/s   14 K/s   18 K/s  484 K/s   10 M/s
2021-07-13T01:46:08Z
---
Estimated start time: 2021-07-12T13:33:24Z
Estimated end time:   2021-07-13T01:46:08Z
Estimated duration:   12h12m44s
```