### PR TITLE
[wip] : read triggered compaction fixes

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1179,10 +1179,17 @@ type readCompaction struct {
 	end   []byte
 }
 
-// The maximum number of elements in the readCompactions queue.
-// We want to limit the number of elements so that we don't
-// pick older compactions which we no longer care for.
-const readCompactionMaxQueueSize = 5
+const (
+	// The maximum number of elements in the readCompactions queue.
+	// We want to limit the number of elements so that we don't
+	// pick older compactions which we no longer care for.
+	readCompactionMaxQueueSize = 5
+
+	// If the level which we're compacting out of has
+	// a low score, then skip the read compaction.
+	// TODO(bananbrick) : What should this limit be?
+	readCompactionSkipScore = 0.5
+)
 
 type readCompactionQueue struct {
 	// readCompactions is ordered by how old the compactions are.

--- a/compaction.go
+++ b/compaction.go
@@ -46,6 +46,11 @@ func maxGrandparentOverlapBytes(opts *Options, level int) uint64 {
 	return uint64(10 * opts.Level(level).TargetFileSize)
 }
 
+func maxReadCompactionBytes(opts *Options, level int) uint64 {
+	// TODO(bananabrick): What should this limit be?
+	return uint64(5 * opts.Level(level).TargetFileSize)
+}
+
 // noCloseIter wraps around an internal iterator, intercepting and eliding
 // calls to Close. It is used during compaction to ensure that rangeDelIters
 // are not closed prematurely.

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -17,10 +17,7 @@ import (
 
 // The minimum count for an intra-L0 compaction. This matches the RocksDB
 // heuristic.
-const (
-	minIntraL0Count            = 4
-	ReadCompactionMaxQueueSize = 5
-)
+const minIntraL0Count = 4
 
 type compactionEnv struct {
 	bytesCompacted          *uint64
@@ -38,7 +35,7 @@ type compactionPicker interface {
 	pickAuto(env compactionEnv) (pc *pickedCompaction)
 	pickManual(env compactionEnv, manual *manualCompaction) (c *pickedCompaction, retryLater bool)
 	pickElisionOnlyCompaction(env compactionEnv) (pc *pickedCompaction)
-	pickReadTriggeredCompaction(env compactionEnv) (pc *pickedCompaction)
+	pickReadTriggeredCompaction(env compactionEnv, scores [7]candidateLevelInfo) (pc *pickedCompaction)
 	forceBaseLevel1()
 }
 
@@ -1007,7 +1004,7 @@ func (p *compactionPickerByScore) pickAuto(env compactionEnv) (pc *pickedCompact
 		return pc
 	}
 
-	if pc := p.pickReadTriggeredCompaction(env); pc != nil {
+	if pc := p.pickReadTriggeredCompaction(env, scores); pc != nil {
 		return pc
 	}
 
@@ -1344,7 +1341,7 @@ func pickManualHelper(
 }
 
 func (p *compactionPickerByScore) pickReadTriggeredCompaction(
-	env compactionEnv,
+	env compactionEnv, scores [7]candidateLevelInfo,
 ) (pc *pickedCompaction) {
 	// If a flush is in-progress or expected to happen soon, it means more writes are taking place. We would
 	// soon be scheduling more write focussed compactions. In this case, skip read compactions as they are
@@ -1354,7 +1351,7 @@ func (p *compactionPickerByScore) pickReadTriggeredCompaction(
 	}
 	for env.readCompactionEnv.readCompactions.size > 0 {
 		rc := env.readCompactionEnv.readCompactions.remove()
-		if pc = pickReadTriggeredCompactionHelper(p, rc, env); pc != nil {
+		if pc = pickReadTriggeredCompactionHelper(p, rc, env, scores); pc != nil {
 			break
 		}
 	}
@@ -1362,7 +1359,7 @@ func (p *compactionPickerByScore) pickReadTriggeredCompaction(
 }
 
 func pickReadTriggeredCompactionHelper(
-	p *compactionPickerByScore, rc *readCompaction, env compactionEnv,
+	p *compactionPickerByScore, rc *readCompaction, env compactionEnv, scores [7]candidateLevelInfo,
 ) (pc *pickedCompaction) {
 	cmp := p.opts.Comparer.Compare
 	overlapSlice := p.vers.Overlaps(rc.level, cmp, rc.start, rc.end)
@@ -1383,6 +1380,12 @@ func pickReadTriggeredCompactionHelper(
 
 	pc = newPickedCompaction(p.opts, p.vers, rc.level, p.baseLevel)
 	pc.startLevel.files = overlapSlice
+
+	if pc.startLevel.level < numLevels &&
+		scores[pc.startLevel.level].score <= readCompactionSkipScore {
+		return nil
+	}
+
 	if !pc.setupInputs() {
 		return nil
 	}

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1361,14 +1361,9 @@ func pickReadTriggeredCompactionHelper(
 ) (pc *pickedCompaction) {
 	cmp := p.opts.Comparer.Compare
 	overlapSlice := p.vers.Overlaps(rc.level, cmp, rc.start, rc.end)
+	// TODO: Do we want to drop this compaction if the overlap slice
 	if overlapSlice.Empty() {
-		var shouldCompact bool
-		// If the file for the given key range has moved levels since the compaction
-		// was scheduled, check to see if the range still has overlapping files
-		overlapSlice, shouldCompact = updateReadCompaction(p.vers, cmp, rc)
-		if !shouldCompact {
-			return nil
-		}
+		return nil
 	}
 	pc = newPickedCompaction(p.opts, p.vers, rc.level, p.baseLevel)
 	pc.startLevel.files = overlapSlice

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1733,12 +1733,12 @@ func TestCompactionReadTriggered(t *testing.T) {
 			case "show-read-compactions":
 				d.mu.Lock()
 				var sb strings.Builder
-				if len(d.mu.compact.readCompactions) == 0 {
-					sb.WriteString("(none)")
-				}
-				for _, rc := range d.mu.compact.readCompactions {
-					sb.WriteString(fmt.Sprintf("(level: %d, start: %s, end: %s)\n", rc.level, string(rc.start), string(rc.end)))
-				}
+				// if len(d.mu.compact.readCompactions) == 0 {
+				// 	sb.WriteString("(none)")
+				// }
+				// for _, rc := range d.mu.compact.readCompactions {
+				// 	sb.WriteString(fmt.Sprintf("(level: %d, start: %s, end: %s)\n", rc.level, string(rc.start), string(rc.end)))
+				// }
 				d.mu.Unlock()
 				return sb.String()
 

--- a/db.go
+++ b/db.go
@@ -319,9 +319,8 @@ type DB struct {
 			manual []*manualCompaction
 			// inProgress is the set of in-progress flushes and compactions.
 			inProgress map[*compaction]struct{}
-			// readCompactions is a list of read triggered compactions. The next
-			// compaction to perform is as the start. New entries are added to the end.
-			readCompactions []readCompaction
+			// readCompactions is a queue of read triggered compactions.
+			readCompactions *readCompactionQueue
 		}
 
 		cleaner struct {

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -602,12 +602,12 @@ func TestReadSampling(t *testing.T) {
 
 			d.mu.Lock()
 			var sb strings.Builder
-			if len(d.mu.compact.readCompactions) == 0 {
+			if d.mu.compact.readCompactions.size == 0 {
 				sb.WriteString("(none)")
 			}
-			for _, rc := range d.mu.compact.readCompactions {
-				sb.WriteString(fmt.Sprintf("(level: %d, start: %s, end: %s)\n", rc.level, string(rc.start), string(rc.end)))
-			}
+			// for _, rc := range d.mu.compact.readCompactions {
+			// 	sb.WriteString(fmt.Sprintf("(level: %d, start: %s, end: %s)\n", rc.level, string(rc.start), string(rc.end)))
+			// }
 			d.mu.Unlock()
 			return sb.String()
 


### PR DESCRIPTION
This is a WIP pr which will be used to test rtc fixes. Each of the fixes is written as a separate commit.

1. Limit queue size to 5.

2. Drop compaction if the level has changed, or the file is not in the same level in the version.

3. Disregard the compaction if it's too wide.

4. Disregard the compaction if the input level score is already low.

Note: Tests will be fixed later.