### PR TITLE
vfs: export ErrUnsupported

### DIFF
--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -497,7 +497,7 @@ func (*MemFS) PathDir(p string) string {
 
 // GetDiskUsage implements FS.GetDiskUsage.
 func (*MemFS) GetDiskUsage(string) (DiskUsage, error) {
-	return DiskUsage{}, errors.New("pebble: not supported")
+	return DiskUsage{}, ErrUnsupported
 }
 
 // memNode holds a file's data or a directory's children, and implements os.FileInfo.

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -324,3 +324,6 @@ func Root(fs FS) FS {
 	}
 	return fs
 }
+
+// ErrUnsupported may be returned a FS when it does not support an operation.
+var ErrUnsupported = errors.New("pebble: not supported")


### PR DESCRIPTION
Export an `ErrUnsupported` error that may be used with `errors.Is` by
clients to handle unsupported errors differently. I anticipate using
this within CockroachDB in codepaths that require disk usage capacity
calculations. Today, those codepaths use brittle mechanisms for
detecting whether the store's filesystem is in-memory. I'd like to
refactor these callsites to unconditionally call `GetDiskUsage`,
treating `ErrUnsupported` as we do in-memory stores today.