### PR TITLE
[wip] compaction : Prevent compaction if it has happened already

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1172,6 +1172,11 @@ type readCompaction struct {
 	// between the read sampling and scheduling a compaction.
 	start []byte
 	end   []byte
+
+	// The file associated with the compaction.
+	// If the file no longer belongs in the same
+	// level, then we skip the compaction.
+	fileNum base.FileNum
 }
 
 func (d *DB) addInProgressCompaction(c *compaction) {

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1365,20 +1365,10 @@ func pickReadTriggeredCompactionHelper(
 		// compact the same key range again.
 		return nil
 	}
-	if overlapSlice.Len() != 1 {
+	iter := overlapSlice.Iter()
+	if f := iter.First(); f == nil || f.FileNum != rc.fileNum {
 		return nil
 	}
-	iter := overlapSlice.Iter()
-	for f := iter.First(); f != nil; f = iter.Next() {
-		if f.FileNum != rc.fileNum {
-			return nil
-		}
-	}
-
-	// TODO(bananabrick): Do we want to still check if the original file associated
-	// with the compaction still belongs in the version?
-	// We know that the range associated with that file belongs to
-	// p.vers.
 
 	pc = newPickedCompaction(p.opts, p.vers, rc.level, p.baseLevel)
 	pc.startLevel.files = overlapSlice

--- a/iterator.go
+++ b/iterator.go
@@ -383,9 +383,10 @@ func (i *Iterator) sampleRead() {
 		allowedSeeks := atomic.AddInt64(&topFile.Atomic.AllowedSeeks, -1)
 		if allowedSeeks == 0 {
 			read := readCompaction{
-				start: topFile.Smallest.UserKey,
-				end:   topFile.Largest.UserKey,
-				level: topLevel,
+				start:   topFile.Smallest.UserKey,
+				end:     topFile.Largest.UserKey,
+				level:   topLevel,
+				fileNum: topFile.FileNum,
 			}
 			i.readSampling.pendingCompactions = append(i.readSampling.pendingCompactions, read)
 		}
@@ -1235,8 +1236,10 @@ func (stats *IteratorStats) String() string {
 func (stats *IteratorStats) SafeFormat(s redact.SafePrinter, verb rune) {
 	for i := range stats.ForwardStepCount {
 		switch IteratorStatsKind(i) {
-		case InterfaceCall: s.SafeString("(interface (dir, seek, step): ")
-		case InternalIterCall: s.SafeString(", (internal (dir, seek, step): ")
+		case InterfaceCall:
+			s.SafeString("(interface (dir, seek, step): ")
+		case InternalIterCall:
+			s.SafeString(", (internal (dir, seek, step): ")
 		}
 		s.Printf("(fwd, %d, %d), (rev, %d, %d))",
 			redact.Safe(stats.ForwardSeekCount[i]), redact.Safe(stats.ForwardStepCount[i]),


### PR DESCRIPTION
If a file associated with a compaction has its level changed, or
if the file is no longer in the version, then prevent the compaction.

This is trying to implement fix 2 here: https://docs.google.com/document/d/1qnhunjPrR1FSgRQ8MgwDay_FGgd8CoRpcsoK0Iybu2o/edit