### PR TITLE
vfs: modify Create to remove and create existing files

### DIFF
--- a/vfs/syncing_file_test.go
+++ b/vfs/syncing_file_test.go
@@ -22,6 +22,7 @@ func TestSyncingFile(t *testing.T) {
 	require.NoError(t, err)
 
 	filename := tmpf.Name()
+	require.NoError(t, tmpf.Close())
 	defer os.Remove(filename)
 
 	f, err := Default.Create(filename)
@@ -89,6 +90,7 @@ close: test [<nil>]
 			require.NoError(t, err)
 
 			filename := tmpf.Name()
+			require.NoError(t, tmpf.Close())
 			defer os.Remove(filename)
 
 			f, err := Default.Create(filename)


### PR DESCRIPTION
Previously, vfs.FS.Create's documented contract was to truncate the file
at the named path if it exists. This was the contract implemented by
vfs.Default but not the contract implemented by *vfs.MemFS, which
replaced the existing file with a new inode. This commit updates the
documented contract and the vfs.Default implementation to match
*vfs.MemFS.

Removing and recreating the file is more resistant to misuse in the
presence of hardlinks. With this change, only `ResuseForWrite` may be
used to open and modify an existing file limiting the surface area for
accidental modification of immutable sstables.

Unfortunately, I don't think there's a way to make the removal and
creation atomic, like `O_TRUNC` was, so there's a now a loop within
`Create` to handle concurrent operations from other threads.

Fix #1205.