### PR TITLE
build: fix mod-update target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ generate:
 # temporarily hiding those files.
 mod-update:
 	mkdir -p cmd/pebble/_bak
-	mv cmd/pebble/{badger}.go cmd/pebble/_bak
+	mv cmd/pebble/badger.go cmd/pebble/_bak
 	${GO} get -u
 	${GO} mod tidy
 	${GO} mod vendor


### PR DESCRIPTION
[Bash brace expansion][1] requires "at least one unquoted comma or a valid
sequence expression", else it treats the filename as including the
curly-braces.

Remove the redundant curly-braces.

[1]: https://www.gnu.org/software/bash/manual/html_node/Brace-Expansion.html