### PR TITLE
cmd/pebble: add support for range deletions in ycsb benchmarks

### DIFF
--- a/cmd/pebble/badger.go
+++ b/cmd/pebble/badger.go
@@ -142,6 +142,10 @@ func (b badgerBatch) Delete(key []byte, _ *pebble.WriteOptions) error {
 	return b.txn.Delete(key)
 }
 
+func (b badgerBatch) DeleteRange(start, end []byte, _ *pebble.WriteOptions) error {
+	panic("badgerBatch.DeleteRange: unimplemented")
+}
+
 func (b badgerBatch) LogData(data []byte, _ *pebble.WriteOptions) error {
 	panic("badgerBatch.logData: unimplemented")
 }

--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -40,6 +40,7 @@ type batch interface {
 	Commit(opts *pebble.WriteOptions) error
 	Set(key, value []byte, opts *pebble.WriteOptions) error
 	Delete(key []byte, opts *pebble.WriteOptions) error
+	DeleteRange(start, end []byte, opts *pebble.WriteOptions) error
 	LogData(data []byte, opts *pebble.WriteOptions) error
 }
 


### PR DESCRIPTION
Extend the ycsb benchmarks to optionally allow layering in periodic
range deletions.

The use of basis points for configuring range deletion width is a
little bizarre, but it allows the use of a `internal/randvar` flag to
control the width.