### PR TITLE
internal/manifest: remove superflous for-loop

### DIFF
--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -292,7 +292,6 @@ func NewL0Sublevels(
 				subLevel <= interval.files[len(interval.files)-1].subLevel {
 				subLevel = interval.files[len(interval.files)-1].subLevel + 1
 			}
-			s.orderedIntervals[i].fileCount++
 			interval.estimatedBytes += interpolatedBytes
 			if f.minIntervalIndex < interval.filesMinIntervalIndex {
 				interval.filesMinIntervalIndex = f.minIntervalIndex
@@ -300,9 +299,7 @@ func NewL0Sublevels(
 			if f.maxIntervalIndex > interval.filesMaxIntervalIndex {
 				interval.filesMaxIntervalIndex = f.maxIntervalIndex
 			}
-		}
-		for i := f.minIntervalIndex; i <= f.maxIntervalIndex; i++ {
-			interval := &s.orderedIntervals[i]
+			interval.fileCount++
 			interval.files = append(interval.files, f)
 		}
 		f.subLevel = subLevel


### PR DESCRIPTION
When allocating files in a manifest version to one or more intervals,
the current implementation makes two passes over the covered intervals.
The work done in the second pass can be moved into the first pass.

Remove superfluous second for-loop.

Minor cleanup to reuse an existing variable to avoid indexing into the
slice of ordered intervals.