### PR TITLE
workload: Fix NewSource race in the ycsb workload.

### DIFF
--- a/cmd/pebble/ycsb.go
+++ b/cmd/pebble/ycsb.go
@@ -251,7 +251,6 @@ type ycsb struct {
 	writeOpts    *pebble.WriteOptions
 	weights      ycsbWeights
 	reg          *histogramRegistry
-	ops          *randvar.Weighted
 	keyDist      randvar.Dynamic
 	batchDist    randvar.Static
 	scanDist     randvar.Static
@@ -273,7 +272,6 @@ func newYcsb(
 	y := &ycsb{
 		reg:       newHistogramRegistry(),
 		weights:   weights,
-		ops:       randvar.NewWeighted(nil, weights...),
 		keyDist:   keyDist,
 		batchDist: batchDist,
 		scanDist:  scanDist,
@@ -367,12 +365,13 @@ func (y *ycsb) run(db DB, wg *sync.WaitGroup) {
 
 	buf := &ycsbBuf{rng: randvar.NewRand()}
 
+	ops := randvar.NewWeighted(nil, y.weights...)
 	for {
 		wait(y.limiter)
 
 		start := time.Now()
 
-		op := y.ops.Int()
+		op := ops.Int()
 		switch op {
 		case ycsbInsert:
 			y.insert(db, buf)


### PR DESCRIPTION
randvar.NewWeighted eventually leads to  us calling rand.NewSource.
But Sources created using NewSource aren't safe for concurrent use
and I was seeing a race in the ycsb workload. While the race was
only in the workload, it's worth a fix.

From the go docs,
```
The default Source is safe for concurrent use by multiple goroutines,
but Sources created by NewSource are not.
```
Fixes: https://github.com/cockroachdb/pebble/issues/1222