### PR TITLE
compaction: add key validation for compacted files

### DIFF
--- a/options.go
+++ b/options.go
@@ -350,6 +350,19 @@ type Options struct {
 		// The default value is the number of logical CPUs, which can be
 		// limited by runtime.GOMAXPROCS.
 		TableCacheShards int
+
+		// KeyValidationFunc is a function to validate a user key in an SSTable.
+		//
+		// Currently, this function is used to validate the smallest and largest
+		// keys in an SSTable undergoing compaction. In this case, returning an
+		// error from the validation function will result in a panic at runtime,
+		// given that there is rarely any way of recovering from malformed keys
+		// present in compacted files. By default, validation is not performed.
+		//
+		// Additional use-cases may be added in the future.
+		//
+		// NOTE: callers should take care to not mutate the key being validated.
+		KeyValidationFunc func(userKey []byte) error
 	}
 
 	// Filters is a map from filter policy name to filter policy. It is used for


### PR DESCRIPTION
Currently, in cases where invalid keys are present in a file that is
being created or deleted as part of a compaction, either due to
corruption or programmer error, pebble will silently propagate the
corruption, which may not be detected until much later. At such time,
the corruption may have propagated to multiple files.

Add a new experimental option, `CompactionKeyValidationFunc` that when
provided will be used to validate both the smallest and largest key in
both new and deleted files in `versionEdit`s constructed as part of a
compaction.

In the case of a key that fails validation, as there is rarely any
effective remediation that can be taken, pebble will log a fatal error
and exit.

The new option is marked as experimental. In the case where no
validation function is provided, no validation is performed on the files
in the new `versionEdit`.

Closes #1202.