### PR TITLE
sstable: support for replacing key suffixes during reads

### DIFF
--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -339,3 +339,27 @@ func (p *Properties) save(w *rawBlockWriter) {
 		w.add(InternalKey{UserKey: []byte(key)}, m[key])
 	}
 }
+
+// SuffixReplacementPropCollector is a predefined collector that can be used to
+// set the value of the special user-property used for suffix replacement.
+type SuffixReplacementPropCollector struct {
+	From, To []byte
+}
+
+var _ TablePropertyCollector = SuffixReplacementPropCollector{}
+
+// Add implements the TablePropertyCollector inferface.
+func (SuffixReplacementPropCollector) Add(_ InternalKey, _ []byte) error {
+	return nil
+}
+
+// Finish implements the TablePropertyCollector inferface.
+func (s SuffixReplacementPropCollector) Finish(userProps map[string]string) error {
+	userProps[PropSuffixReplacement] = string(append(s.From, s.To...))
+	return nil
+}
+
+// Name implements the TablePropertyCollector inferface.
+func (SuffixReplacementPropCollector) Name() string {
+	return "SuffixReplacement"
+}

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -169,7 +169,7 @@ compact         1   2.3 K             0 B          (size == estimated-debt, in =
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.4 K    5.9%  (score == hit-rate)
- tcache         1   616 B    0.0%  (score == hit-rate)
+ tcache         1   640 B    0.0%  (score == hit-rate)
  titers         0
  filter         -       -    0.0%  (score == utility)
 

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -48,7 +48,7 @@ compact         0     0 B             0 B          (size == estimated-debt, in =
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.5 K   46.7%  (score == hit-rate)
- tcache         1   616 B   50.0%  (score == hit-rate)
+ tcache         1   640 B   50.0%  (score == hit-rate)
  titers         0
  filter         -       -    0.0%  (score == utility)
 

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -34,7 +34,7 @@ compact         0     0 B             0 B          (size == estimated-debt, in =
 zmemtbl         1   256 K
    ztbl         0     0 B
  bcache         4   698 B    0.0%  (score == hit-rate)
- tcache         1   616 B    0.0%  (score == hit-rate)
+ tcache         1   640 B    0.0%  (score == hit-rate)
  titers         1
  filter         -       -    0.0%  (score == utility)
 
@@ -81,7 +81,7 @@ compact         1     0 B             0 B          (size == estimated-debt, in =
 zmemtbl         2   512 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   33.3%  (score == hit-rate)
- tcache         2   1.2 K   50.0%  (score == hit-rate)
+ tcache         2   1.3 K   50.0%  (score == hit-rate)
  titers         2
  filter         -       -    0.0%  (score == utility)
 
@@ -113,7 +113,7 @@ compact         1     0 B             0 B          (size == estimated-debt, in =
 zmemtbl         1   256 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   33.3%  (score == hit-rate)
- tcache         2   1.2 K   50.0%  (score == hit-rate)
+ tcache         2   1.3 K   50.0%  (score == hit-rate)
  titers         2
  filter         -       -    0.0%  (score == utility)
 
@@ -142,7 +142,7 @@ compact         1     0 B             0 B          (size == estimated-debt, in =
 zmemtbl         1   256 K
    ztbl         1   771 B
  bcache         4   698 B   33.3%  (score == hit-rate)
- tcache         1   616 B   50.0%  (score == hit-rate)
+ tcache         1   640 B   50.0%  (score == hit-rate)
  titers         1
  filter         -       -    0.0%  (score == utility)
 


### PR DESCRIPTION
In CockroachDB we have processes that build and then ingest SSTables.
These SSTables have timestamp-suffixed keys, and often take a non-trivial
amount of time to construct and then transport to where they will be added.
If these processes what the timestamps encoded on those keys to be the time
_at which the file was actually added_ that can pose a significant challenge.
You _could_, while adding, iterate the entire SST to re-encode every key with
a new, addition-time timestamp suffix, but that too could take O(n) time for a
larger SSTable.

Instead, this adds the ability to simply make an O(1) size edit to the props, to
note a suffix to replace with some other value. Using this, such a process can
construct all of its keys with placeholder, then, when it actually knows the real
addition time, simply map the placeholder to that value with these props.

At read-time, specifically when a block is loaded, after it is decompressed but
before it is cached, if the file specifies this replacement every key in the block
is edited to replace the mapped suffix. The edited suffix of a key must not be
shared with a prior key, and only the data and index blocks are edited, so filters
if present must be only on the unedited prefix of keys (this is true for CRDB
as we already do not include the MVCC timestamp suffix in filters).

Also included here is a helper to make the above mentioned edits to props on 
an in-memory representation of an SSTable (i.e. what Cockroach typically has
when during the evaluation of AddSSTableRequest when it would assign such 
a timestamp). Ideally this helper would take a File-like API that supported writing
at an offset to be able to update on-disk files as well, but this can be done when 
needed.