### PR TITLE
Finalizer test

### DIFF
--- a/db.go
+++ b/db.go
@@ -208,7 +208,7 @@ type DB struct {
 	dataDir  vfs.File
 	walDir   vfs.File
 
-	tableCache tableCache
+	tableCache *tableCache
 	newIters   tableNewIters
 
 	commit *commitPipeline

--- a/finalizer_test.go
+++ b/finalizer_test.go
@@ -1,0 +1,47 @@
+// Copyright 2012 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+func TestDBFinalizerCalled(t *testing.T) {
+	var mm sync.Mutex
+	var dbFinalizerRun *sync.Cond = sync.NewCond(&mm)
+	// Wait until the finalizer is run.
+	doneCh := make(chan bool)
+	go func() {
+		dbFinalizerRun.L.Lock()
+		dbFinalizerRun.Wait()
+		dbFinalizerRun.L.Unlock()
+		doneCh <- true
+	}()
+
+	{
+		mem := vfs.NewMem()
+		d, err := Open("", &Options{
+			FS:              mem,
+			DBFinalizerCond: dbFinalizerRun,
+		})
+		if err != nil {
+			t.Errorf("DB didn't open.")
+		}
+		d.closed.Load()
+	}
+
+	runtime.GC()
+
+	select {
+	case <-doneCh:
+	case <-time.After(time.Second * 10):
+		t.Errorf("DB finalizer never ran.")
+	}
+}

--- a/open.go
+++ b/open.go
@@ -390,6 +390,9 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	// tied to the lifetime of DB: the DB.closed atomic.Value.
 	dPtr := fmt.Sprintf("%p", d)
 	invariants.SetFinalizer(d.closed, func(obj interface{}) {
+		if opts.DBFinalizerCond != nil {
+			opts.DBFinalizerCond.Broadcast()
+		}
 		v := obj.(*atomic.Value)
 		if err := v.Load(); err == nil {
 			fmt.Fprintf(os.Stderr, "%s: unreferenced DB not closed\n", dPtr)

--- a/open.go
+++ b/open.go
@@ -100,6 +100,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	if tableCacheSize < minTableCacheSize {
 		tableCacheSize = minTableCacheSize
 	}
+	d.tableCache = &tableCache{}
 	d.tableCache.init(d.cacheID, dirname, opts.FS, d.opts, tableCacheSize)
 	d.newIters = d.tableCache.newIters
 	d.commit = newCommitPipeline(commitEnv{

--- a/options.go
+++ b/options.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -246,6 +247,8 @@ type Options struct {
 	//
 	// The default value uses the same ordering as bytes.Compare.
 	Comparer *Comparer
+
+	DBFinalizerCond *sync.Cond
 
 	// DebugCheck is invoked, if non-nil, whenever a new version is being
 	// installed. Typically, this is set to pebble.DebugCheckLevels in tests


### PR DESCRIPTION
On the first commit of this pull request, if I run `go test -tags 'invariants'  -run TestDBFinalizerCalled`, I see the test fail because the finalizer is not called.

Then, if I make a small change in the second commit of this pr, where I turn the `tableCache` in the `DB` struct into a pointer, we see that the finalizer is called, when `go test -tags 'invariants'  -run TestDBFinalizerCalled` is run.

So it seems like:
1. The finalizer isn't being run for most of our tests on the master branch.
2. We're not gracefully closing the db for our tests, but we've missed these because the finalizer isn't run.
3. For some reason, storing a pointer to the `tableCache` in the DB causes the finalizer to be called consistently.