### PR TITLE
pebble: call db.Close for these tests.

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1420,6 +1420,12 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 		return v
 	}
 	var d *DB
+	defer func() {
+		if d != nil {
+			require.NoError(t, d.Close())
+		}
+	}()
+
 	var compactInfo *CompactionInfo // protected by d.mu
 
 	datadriven.RunTest(t, "testdata/compaction_delete_only_hints",
@@ -1538,6 +1544,12 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 
 func TestCompactionTombstones(t *testing.T) {
 	var d *DB
+	defer func() {
+		if d != nil {
+			require.NoError(t, d.Close())
+		}
+	}()
+
 	var compactInfo *CompactionInfo // protected by d.mu
 
 	compactionString := func() string {
@@ -1641,6 +1653,12 @@ func TestCompactionTombstones(t *testing.T) {
 
 func TestCompactionReadTriggered(t *testing.T) {
 	var d *DB
+	defer func() {
+		if d != nil {
+			require.NoError(t, d.Close())
+		}
+	}()
+
 	var compactInfo *CompactionInfo // protected by d.mu
 
 	compactionString := func() string {

--- a/db_test.go
+++ b/db_test.go
@@ -1089,6 +1089,11 @@ func TestSSTables(t *testing.T) {
 		FS: vfs.NewMem(),
 	})
 	require.NoError(t, err)
+	defer func() {
+		if d != nil {
+			require.NoError(t, d.Close())
+		}
+	}()
 
 	// Create two sstables.
 	require.NoError(t, d.Set([]byte("hello"), nil, nil))


### PR DESCRIPTION
Our DB finalizer currently doesn't run consistently, or in some
situations, it doesn't seem to run ever. This is showcased in this
pr: #1234.

However, the finalizer starts to runs consistently in one of the cases described in the pr
linked above, and detected some leaks.

The tests here are the ones which were causing the failures. So, we
gracefully cleanup in these tests by calling db.Close. There could be
other tests which aren't calling `db.Close`, but the tests pass for now.