### PR TITLE
db: fix error checking in `ingestCleanup`

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -216,7 +216,7 @@ func ingestCleanup(fs vfs.FS, dirname string, meta []*fileMetadata) error {
 	for i := range meta {
 		target := base.MakeFilename(fs, dirname, fileTypeTable, meta[i].FileNum)
 		if err := fs.Remove(target); err != nil {
-			if firstErr != nil {
+			if firstErr == nil {
 				firstErr = err
 			}
 		}


### PR DESCRIPTION
By design, `ingestCleanup` attempts to return the first error
encountered when cleaning up set of ingested files. Currently, the check
condition never sets the error to be returned, resulting in the function
always returning `nil`.

Fix the check condition to set the return value the first time an error
is encountered.