### PR TITLE
vfs: add FS.Attributes

### DIFF
--- a/internal/errorfs/errorfs.go
+++ b/internal/errorfs/errorfs.go
@@ -238,6 +238,13 @@ func (fs *FS) GetDiskUsage(path string) (vfs.DiskUsage, error) {
 	return fs.fs.GetDiskUsage(path)
 }
 
+// Attributes implements FS.Attributes.
+func (fs *FS) Attributes() vfs.Attributes {
+	attrs := fs.fs.Attributes()
+	attrs.Description = fmt.Sprintf("error-injecting( %s )", attrs.Description)
+	return attrs
+}
+
 // PathBase implements FS.PathBase.
 func (fs *FS) PathBase(p string) string {
 	return fs.fs.PathBase(p)

--- a/vfs/disk_full.go
+++ b/vfs/disk_full.go
@@ -5,6 +5,7 @@
 package vfs
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"sync"
@@ -342,6 +343,12 @@ func (fs *enospcFS) PathDir(path string) string {
 
 func (fs *enospcFS) GetDiskUsage(path string) (DiskUsage, error) {
 	return fs.inner.GetDiskUsage(path)
+}
+
+func (fs *enospcFS) Attributes() Attributes {
+	attrs := fs.inner.Attributes()
+	attrs.Description = fmt.Sprintf("disk-full-monitor( %s )", attrs.Description)
+	return attrs
 }
 
 type enospcFile struct {

--- a/vfs/disk_heath_test.go
+++ b/vfs/disk_heath_test.go
@@ -111,6 +111,10 @@ func (m mockFS) GetDiskUsage(path string) (DiskUsage, error) {
 	panic("unimplemented")
 }
 
+func (m mockFS) Attributes() Attributes {
+	panic("unimplemented")
+}
+
 var _ FS = &mockFS{}
 
 func TestDiskHealthChecking(t *testing.T) {

--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -500,6 +500,15 @@ func (*MemFS) GetDiskUsage(string) (DiskUsage, error) {
 	return DiskUsage{}, ErrUnsupported
 }
 
+// Attributes implements FS.Attributes.
+func (y *MemFS) Attributes() Attributes {
+	return Attributes{
+		Description:    fmt.Sprintf("%T", y),
+		InMemory:       true,
+		RenameIsAtomic: true,
+	}
+}
+
 // memNode holds a file's data or a directory's children, and implements os.FileInfo.
 type memNode struct {
 	name  string


### PR DESCRIPTION
Add a (vfs.FS).Attributes method that allows retrieving attributes about
a filesystem.

Extracted from #1227.