### PR TITLE
vfs: add OpenForAppend method

### DIFF
--- a/internal/errorfs/errorfs.go
+++ b/internal/errorfs/errorfs.go
@@ -31,6 +31,8 @@ const (
 	OpLink
 	// OpOpen describes a file open operation.
 	OpOpen
+	// OpOpenForAppend describes a file open-for-append operation.
+	OpOpenForAppend
 	// OpOpenDir describes a directory open operation.
 	OpOpenDir
 	// OpRemove describes a remove file operation.
@@ -70,7 +72,7 @@ const (
 // OpKind returns the operation's kind.
 func (o Op) OpKind() OpKind {
 	switch o {
-	case OpOpen, OpOpenDir, OpList, OpStat, OpGetDiskUsage, OpFileRead, OpFileReadAt, OpFileStat:
+	case OpOpen, OpOpenForAppend, OpOpenDir, OpList, OpStat, OpGetDiskUsage, OpFileRead, OpFileReadAt, OpFileStat:
 		return OpKindRead
 	case OpCreate, OpLink, OpRemove, OpRemoveAll, OpRename, OpReuseForRewrite, OpMkdirAll, OpLock, OpFileClose, OpFileWrite, OpFileSync, OpFileFlush:
 		return OpKindWrite
@@ -215,6 +217,19 @@ func (fs *FS) Open(name string, opts ...vfs.OpenOption) (vfs.File, error) {
 	for _, opt := range opts {
 		opt.Apply(ef)
 	}
+	return ef, nil
+}
+
+// OpenForAppend implements FS.OpenForAppend.
+func (fs *FS) OpenForAppend(name string) (vfs.File, error) {
+	if err := fs.inj.MaybeError(OpOpenForAppend, name); err != nil {
+		return nil, err
+	}
+	f, err := fs.fs.OpenForAppend(name)
+	if err != nil {
+		return nil, err
+	}
+	ef := &errorFile{name, f, fs.inj}
 	return ef, nil
 }
 

--- a/vfs/disk_full.go
+++ b/vfs/disk_full.go
@@ -230,6 +230,17 @@ func (fs *enospcFS) Open(name string, opts ...OpenOption) (File, error) {
 	return f, err
 }
 
+func (fs *enospcFS) OpenForAppend(name string) (File, error) {
+	f, err := fs.inner.OpenForAppend(name)
+	if f != nil {
+		f = WithFd(f, enospcFile{
+			fs:    fs,
+			inner: f,
+		})
+	}
+	return f, err
+}
+
 func (fs *enospcFS) OpenDir(name string) (File, error) {
 	f, err := fs.inner.OpenDir(name)
 	if f != nil {

--- a/vfs/disk_heath_test.go
+++ b/vfs/disk_heath_test.go
@@ -59,6 +59,10 @@ func (m mockFS) Open(name string, opts ...OpenOption) (File, error) {
 	panic("unimplemented")
 }
 
+func (m mockFS) OpenForAppend(name string) (File, error) {
+	panic("unimplemented")
+}
+
 func (m mockFS) OpenDir(name string) (File, error) {
 	panic("unimplemented")
 }

--- a/vfs/mem_fs_test.go
+++ b/vfs/mem_fs_test.go
@@ -41,6 +41,8 @@ func runTestCases(t *testing.T, testCases []string, fs *MemFS) {
 			err = fs.Link(s[1], s[2])
 		case "open":
 			g, err = fs.Open(s[1])
+		case "openForAppend":
+			g, err = fs.OpenForAppend(s[1])
 		case "openDir":
 			g, err = fs.OpenDir(s[1])
 		case "mkdirall":
@@ -167,6 +169,16 @@ func TestBasics(t *testing.T) {
 		"10a: reuseForWrite /bar/caz/z /bar/z",
 		"10b: open /bar/caz/z fails",
 		"10c: open /bar/z",
+		// OpenForAppend
+		"11a: f = create /bax",
+		"11b: f.write abcde",
+		"11c: f.close",
+		"11d: f = openForAppend /bax",
+		"11e: f.write fghij",
+		"11f: f.close",
+		"11g: f = open /bax",
+		"11h: f.read 10 == abcdefghij",
+		"11i: f.close",
 	}
 	runTestCases(t, testCases, fs)
 }


### PR DESCRIPTION
Add OpenForAppend method to the vfs.FS interface. This is intended for
codepaths that write data to a temporary file, rename it to perform an
atomic switchover, and need to continue to append to the file at its new
path.

This was possible on Linux with the previous VFS interface because the
file descriptor is associated with the underlying file, not the path.
On Windows, this behavior requires a 'share flag' to be set when the
file was opened. Go does not set this flag by default (see
golang/go#32088).