### PR TITLE
pebble: Unflake TestCacheEvict

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -819,11 +819,11 @@ func TestCacheEvict(t *testing.T) {
 
 	require.NoError(t, d.Compact([]byte("0"), []byte("1")))
 
+	require.NoError(t, d.Close())
+
 	if size := cache.Size(); size != 0 {
 		t.Fatalf("expected empty cache, but found %d", size)
 	}
-
-	require.NoError(t, d.Close())
 }
 
 func TestFlushEmpty(t *testing.T) {


### PR DESCRIPTION
TestCacheEvict fails infrequently because the cache size isn't 0
at the end of the test. I believe this is due to files getting deleted
asynchronously.

If we call db.Close before checking the cache size, then the files
should be deleted because db.Close deletes the files.

Resolves: #1239