### PR TITLE
sstable: Fix bug in dynamic readahead

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -1896,7 +1896,7 @@ func (r *Reader) readBlock(
 					base.MustExist(r.fs, r.filename, panicFataler{}, err)
 				}
 			}
-			if raState.sequentialFile != nil {
+			if raState.sequentialFile == nil {
 				type fd interface {
 					Fd() uintptr
 				}


### PR DESCRIPTION
Turns out we weren't calling Prefetch() at all during sstable reader
dynamic readahead except in the very last readahead "step" before
switching to the POSIX_FADV_SEQUENTIAL file handle. Fix the if
conditional before the Prefetch() call.