### PR TITLE
vfs: add AtomicMarker

### DIFF
--- a/vfs/atomicfs/marker.go
+++ b/vfs/atomicfs/marker.go
@@ -1,0 +1,210 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package vfs
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/oserror"
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+// LocateMarker loads the current state of a marker. It returns a handle
+// to the Marker that may be used to move the marker and the
+// current value of the marker.
+func LocateMarker(fs vfs.FS, dir, markerName string) (*Marker, string, error) {
+	ls, err := fs.List(dir)
+	if err != nil {
+		return nil, "", err
+	}
+	dirFD, err := fs.OpenDir(dir)
+	if err != nil {
+		return nil, "", err
+	}
+
+	var markerFilename string
+	var markerIteration uint64
+	var markerValue string
+	var obsolete []string
+	for _, filename := range ls {
+		if !strings.HasPrefix(filename, `marker.`) {
+			continue
+		}
+		// Any filenames with the `marker.` prefix are required to be
+		// well-formed and parse as markers.
+		name, iter, value, err := parseMarkerFilename(filename)
+		if err != nil {
+			return nil, "", errors.CombineErrors(err, dirFD.Close())
+		}
+		if name != markerName {
+			continue
+		}
+
+		if markerFilename == "" || markerIteration < iter {
+			if markerFilename != "" {
+				obsolete = append(obsolete, markerFilename)
+			}
+			markerFilename = filename
+			markerIteration = iter
+			markerValue = value
+		} else {
+			obsolete = append(obsolete, filename)
+		}
+	}
+
+	return &Marker{
+		fs:            fs,
+		dir:           dir,
+		dirFD:         dirFD,
+		name:          markerName,
+		filename:      markerFilename,
+		iter:          markerIteration,
+		obsoleteFiles: obsolete,
+	}, markerValue, nil
+}
+
+// A Marker provides an interface for marking a single file on the
+// filesystem. The marker may be atomically moved from name to name.
+// Marker is not safe for concurrent use. Multiple processes may not
+// read or move the same marker simulatenously. An Marker may only be
+// constructed through LocateMarker.
+//
+// Marker names must be unique within the directory.
+type Marker struct {
+	fs    vfs.FS
+	dir   string
+	dirFD vfs.File
+	// name identifies the marker.
+	name string
+	// filename contains the entire filename of the current marker. It
+	// has a format of `marker.<name>.<iter>.<value>`. It's not
+	// necessarily in sync with iter, since filename is only updated
+	// when the marker is successfully moved.
+	filename string
+	// iter holds the current iteration value. It matches the iteration
+	// value encoded within filename, if filename is non-empty. Iter is
+	// monotonically increasing over the lifetime of a marker. Actual
+	// marker files will always have a positive iter value.
+	iter uint64
+	// obsoleteFiles holds a list of files discovered by LocateMarker
+	// that are old values for this marker. These files may exist if the
+	// filesystem doesn't guarantee atomic renames (eg, if it's
+	// implemented as a link(newpath), remove(oldpath), and a crash in
+	// between may leave an entry at the old path).
+	obsoleteFiles []string
+}
+
+func markerFilename(name string, iter uint64, value string) string {
+	return fmt.Sprintf("marker.%s.%06d.%s", name, iter, value)
+}
+
+func parseMarkerFilename(s string) (name string, iter uint64, value string, err error) {
+	// Check for and remove the `marker.` prefix.
+	if !strings.HasPrefix(s, `marker.`) {
+		return "", 0, "", errors.Newf("invalid marker filename: %q", s)
+	}
+	s = s[len(`marker.`):]
+
+	// Extract the marker's name.
+	i := strings.IndexByte(s, '.')
+	if i == -1 {
+		return "", 0, "", errors.Newf("invalid marker filename: %q", s)
+	}
+	name = s[:i]
+	s = s[i+1:]
+
+	// Extract the marker's iteration number.
+	i = strings.IndexByte(s, '.')
+	if i == -1 {
+		return "", 0, "", errors.Newf("invalid marker filename: %q", s)
+	}
+	iter, err = strconv.ParseUint(s[:i], 10, 64)
+	if err != nil {
+		return "", 0, "", errors.Newf("invalid marker filename: %q", s)
+	}
+
+	// Everything after the iteration's `.` delimiter is the value.
+	s = s[i+1:]
+
+	return name, iter, s, nil
+}
+
+// Close releases all resources in use by the marker.
+func (a *Marker) Close() error {
+	return a.dirFD.Close()
+}
+
+// Move atomically moves the marker to mark the provided filename.
+// If Move returns a nil error, the new marker value is guaranteed to be
+// persisted to stable storage. If Move returns an error, the current
+// value of the marker may be the old value or the new value. Callers
+// may retry a Move error.
+//
+// If an error occurs while syncing the directory, Move panics.
+//
+// The provided filename does not need to exist on the filesystem.
+func (a *Marker) Move(filename string) error {
+	a.iter++
+	dstFilename := markerFilename(a.name, a.iter, filename)
+	dstPath := a.fs.PathJoin(a.dir, dstFilename)
+	oldFilename := a.filename
+
+	// The marker has never been placed. Create a new file.
+	f, err := a.fs.Create(dstPath)
+	if err != nil {
+		// On a distributed filesystem, an error doesn't guarantee that
+		// the file wasn't created. A retry of the same Move call will
+		// use a new iteration value, and try to a create a new file. If
+		// the errored invocation was actually successful in creating
+		// the file, we'll leak a file. That's okay, because the next
+		// time the marker is located we'll add it to the obsolete files
+		// list.
+		//
+		// Note that the unconditional increment of `a.iter` means that
+		// `a.iter` and `a.filename` are not necessarily in sync,
+		// because `a.filename` is only updated on success.
+		return err
+	}
+	a.filename = dstFilename
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	// Remove the now defunct file. If an error is surfaced, we record
+	// the file as an obsolete file.  The file's presence does not
+	// affect correctness, and it will be cleaned up the next time
+	// RemoveObsolete is called, either by this process or the next.
+	if oldFilename != "" {
+		if err := a.fs.Remove(a.fs.PathJoin(a.dir, oldFilename)); err != nil && !oserror.IsNotExist(err) {
+			a.obsoleteFiles = append(a.obsoleteFiles, oldFilename)
+		}
+	}
+
+	// Sync the directory to ensure marker movement is synced.
+	if err := a.dirFD.Sync(); err != nil {
+		// Fsync errors are unrecoverable.
+		// See https://wiki.postgresql.org/wiki/Fsync_Errors and
+		// https://danluu.com/fsyncgate.
+		panic(errors.WithStack(err))
+	}
+	return nil
+}
+
+// RemoveObsolete removes any obsolete files discovered while locating
+// the marker or files unable to be removed during Move.
+func (a *Marker) RemoveObsolete() error {
+	obsolete := a.obsoleteFiles
+	for _, filename := range obsolete {
+		if err := a.fs.Remove(a.fs.PathJoin(a.dir, filename)); err != nil && !oserror.IsNotExist(err) {
+			return err
+		}
+		a.obsoleteFiles = obsolete[1:]
+	}
+	a.obsoleteFiles = nil
+	return nil
+}

--- a/vfs/atomicfs/marker_test.go
+++ b/vfs/atomicfs/marker_test.go
@@ -1,0 +1,276 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package vfs
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/cockroachdb/pebble/internal/errorfs"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarker_FilenameRoundtrip(t *testing.T) {
+	filenames := []string{
+		"marker.foo.000003.MANIFEST-000021",
+		"marker.bar.000003.MANIFEST-000021",
+		"marker.version.000003.1",
+		"marker.version.000003.1.2.3.4",
+		"marker.current.500000.MANIFEST-000001",
+		"marker.current.18446744073709551615.MANIFEST-000001",
+	}
+	for _, testFilename := range filenames {
+		t.Run(testFilename, func(t *testing.T) {
+			name, iter, value, err := parseMarkerFilename(testFilename)
+			require.NoError(t, err)
+
+			filename := markerFilename(name, iter, value)
+			require.Equal(t, testFilename, filename)
+		})
+	}
+}
+
+func TestMarker_Parsefilename(t *testing.T) {
+	testCases := map[string]func(require.TestingT, error, ...interface{}){
+		"marker.current.000003.MANIFEST-000021":  require.NoError,
+		"marker.current.10.MANIFEST-000021":      require.NoError,
+		"marker.v.10.1.2.3.4":                    require.NoError,
+		"marker.name.18446744073709551615.value": require.NoError,
+		"marke.current.000003.MANIFEST-000021":   require.Error,
+		"marker.current.foo.MANIFEST-000021":     require.Error,
+		"marker.current.ffffff.MANIFEST-000021":  require.Error,
+	}
+	for filename, assert := range testCases {
+		t.Run(filename, func(t *testing.T) {
+			_, _, _, err := parseMarkerFilename(filename)
+			assert(t, err)
+		})
+	}
+}
+
+func TestMarker(t *testing.T) {
+	markers := map[string]*Marker{}
+	memFS := vfs.NewMem()
+
+	var buf bytes.Buffer
+	datadriven.RunTest(t, "testdata/marker", func(td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "list":
+			ls, err := memFS.List(td.CmdArgs[0].String())
+			if err != nil {
+				return err.Error()
+			}
+			sort.Strings(ls)
+			buf.Reset()
+			for _, filename := range ls {
+				fmt.Fprintln(&buf, filename)
+			}
+			return buf.String()
+
+		case "locate":
+			var dir, marker string
+			td.ScanArgs(t, "dir", &dir)
+			td.ScanArgs(t, "marker", &marker)
+			m, v, err := LocateMarker(memFS, dir, marker)
+			if err != nil {
+				return err.Error()
+			}
+			p := memFS.PathJoin(dir, marker)
+			if oldMarker := markers[p]; oldMarker != nil {
+				if err := oldMarker.Close(); err != nil {
+					return err.Error()
+				}
+			}
+
+			markers[p] = m
+			return v
+
+		case "mkdir-all":
+			if len(td.CmdArgs) != 1 {
+				return "usage: mkdir-all <dir>"
+			}
+			if err := memFS.MkdirAll(td.CmdArgs[0].String(), os.ModePerm); err != nil {
+				return err.Error()
+			}
+			return ""
+
+		case "move":
+			var dir, marker string
+			td.ScanArgs(t, "dir", &dir)
+			td.ScanArgs(t, "marker", &marker)
+			m := markers[memFS.PathJoin(dir, marker)]
+			require.NotNil(t, m)
+			err := m.Move(td.Input)
+			if err != nil {
+				return err.Error()
+			}
+			return ""
+
+		case "remove-obsolete":
+			var dir, marker string
+			td.ScanArgs(t, "dir", &dir)
+			td.ScanArgs(t, "marker", &marker)
+			m := markers[memFS.PathJoin(dir, marker)]
+			require.NotNil(t, m)
+			obsoleteCount := len(m.obsoleteFiles)
+			require.NoError(t, m.RemoveObsolete())
+			removedCount := obsoleteCount - len(m.obsoleteFiles)
+			return fmt.Sprintf("Removed %d files.", removedCount)
+
+		case "touch":
+			for _, filename := range strings.Split(td.Input, "\n") {
+				f, err := memFS.Create(filename)
+				if err != nil {
+					return err.Error()
+				}
+				if err := f.Close(); err != nil {
+					return err.Error()
+				}
+			}
+			return ""
+
+		default:
+			panic(fmt.Sprintf("unknown command %q", td.Cmd))
+		}
+	})
+}
+
+func TestMarker_StrictSync(t *testing.T) {
+	// Use an in-memory FS that strictly enforces syncs.
+	mem := vfs.NewStrictMem()
+	syncDir := func(dir string) {
+		fdir, err := mem.OpenDir(dir)
+		require.NoError(t, err)
+		require.NoError(t, fdir.Sync())
+		require.NoError(t, fdir.Close())
+	}
+
+	require.NoError(t, mem.MkdirAll("foo", os.ModePerm))
+	syncDir("")
+	m, v, err := LocateMarker(mem, "foo", "bar")
+	require.NoError(t, err)
+	require.Equal(t, "", v)
+	require.NoError(t, m.Move("hello"))
+	require.NoError(t, m.Close())
+
+	// Discard any unsynced writes to make sure we set up the test
+	// preconditions correctly.
+	mem.ResetToSyncedState()
+	m, v, err = LocateMarker(mem, "foo", "bar")
+	require.NoError(t, err)
+	require.Equal(t, "hello", v)
+	require.NoError(t, m.Move("hello-world"))
+	require.NoError(t, m.Close())
+
+	// Discard any unsynced writes.
+	mem.ResetToSyncedState()
+	m, v, err = LocateMarker(mem, "foo", "bar")
+	require.NoError(t, err)
+	require.Equal(t, "hello-world", v)
+	require.NoError(t, m.Close())
+}
+
+// TestMarker_FaultTolerance attempts a series of operations on atomic
+// markers, injecting errors at successively higher indexed operations.
+// It completes when an error is never injected, because the index is
+// higher than the number of filesystem operations performed by the
+// test.
+func TestMarker_FaultTolerance(t *testing.T) {
+	done := false
+	for i := 1; !done && i < 1000; i++ {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			count := int32(i)
+			inj := errorfs.InjectorFunc(func(op errorfs.Op, path string) error {
+				// Don't inject on Sync errors. They're fatal.
+				if op == errorfs.OpFileSync {
+					return nil
+				}
+				if v := atomic.AddInt32(&count, -1); v == 0 {
+					return errorfs.ErrInjected
+				}
+				return nil
+			})
+
+			mem := vfs.NewMem()
+			fs := errorfs.Wrap(mem, inj)
+			markers := map[string]*Marker{}
+			ops := []struct {
+				op    string
+				name  string
+				value string
+			}{
+				{op: "locate", name: "foo", value: ""},
+				{op: "locate", name: "foo", value: ""},
+				{op: "locate", name: "bar", value: ""},
+				{op: "rm-obsolete", name: "foo"},
+				{op: "move", name: "bar", value: "california"},
+				{op: "rm-obsolete", name: "bar"},
+				{op: "move", name: "bar", value: "california"},
+				{op: "move", name: "bar", value: "new-york"},
+				{op: "locate", name: "bar", value: "new-york"},
+				{op: "move", name: "bar", value: "california"},
+				{op: "rm-obsolete", name: "bar"},
+				{op: "locate", name: "bar", value: "california"},
+				{op: "move", name: "foo", value: "connecticut"},
+				{op: "locate", name: "foo", value: "connecticut"},
+			}
+
+			for _, op := range ops {
+				runOp := func() error {
+					switch op.op {
+					case "locate":
+						m, v, err := LocateMarker(fs, "", op.name)
+						if err != nil {
+							return err
+						}
+						require.NotNil(t, m)
+						require.Equal(t, op.value, v)
+						if existingMarker := markers[op.name]; existingMarker != nil {
+							require.NoError(t, existingMarker.Close())
+						}
+						markers[op.name] = m
+						return nil
+					case "move":
+						m := markers[op.name]
+						require.NotNil(t, m)
+						return m.Move(op.value)
+					case "rm-obsolete":
+						m := markers[op.name]
+						require.NotNil(t, m)
+						return m.RemoveObsolete()
+					default:
+						panic("unreachable")
+					}
+				}
+
+				// Run the operation, if it fails with the injected
+				// error, retry it exactly once. The retry should always
+				// succeed.
+				err := runOp()
+				if errors.Is(err, errorfs.ErrInjected) {
+					err = runOp()
+				}
+				require.NoError(t, err)
+			}
+
+			for _, m := range markers {
+				require.NoError(t, m.Close())
+			}
+
+			// Stop if the number of operations in the test case is
+			// fewer than `i`.
+			done = atomic.LoadInt32(&count) > 0
+		})
+	}
+}

--- a/vfs/atomicfs/testdata/marker
+++ b/vfs/atomicfs/testdata/marker
@@ -1,0 +1,102 @@
+# Errors if the containing directory does not exist.
+locate dir=bar marker=foo
+----
+open bar/: file does not exist
+
+mkdir-all data
+----
+
+# Loads a nonexistent marker correctly.
+locate dir=data marker=foo
+----
+
+# The directory should still be empty.
+list data
+----
+
+# Moving the marker for the first time should create a marker file.
+move dir=data marker=foo
+MANIFEST-000010
+----
+
+list data
+----
+marker.foo.000001.MANIFEST-000010
+
+# Moving the marker should move the existing marker file.
+move dir=data marker=foo
+MANIFEST-000016
+----
+
+list data
+----
+marker.foo.000002.MANIFEST-000016
+
+# Create non-marker files.
+touch
+data/MANIFEST-000016
+data/CURRENT
+data/000004.sst
+----
+
+# Re-locate the marker. It should be unchanged.
+locate dir=data marker=foo
+----
+MANIFEST-000016
+
+# Locate a new marker.
+locate dir=data marker=bar
+----
+
+move dir=data marker=bar
+MANIFEST-000016
+----
+
+list data
+----
+000004.sst
+CURRENT
+MANIFEST-000016
+marker.bar.000001.MANIFEST-000016
+marker.foo.000002.MANIFEST-000016
+
+move dir=data marker=foo
+MANIFEST-000021
+----
+
+list data
+----
+000004.sst
+CURRENT
+MANIFEST-000016
+marker.bar.000001.MANIFEST-000016
+marker.foo.000003.MANIFEST-000021
+
+touch
+data/marker.bar.000009.MANIFEST-000099
+----
+
+list data
+----
+000004.sst
+CURRENT
+MANIFEST-000016
+marker.bar.000001.MANIFEST-000016
+marker.bar.000009.MANIFEST-000099
+marker.foo.000003.MANIFEST-000021
+
+locate dir=data marker=bar
+----
+MANIFEST-000099
+
+remove-obsolete dir=data marker=bar
+----
+Removed 1 files.
+
+list data
+----
+000004.sst
+CURRENT
+MANIFEST-000016
+marker.bar.000009.MANIFEST-000099
+marker.foo.000003.MANIFEST-000021


### PR DESCRIPTION
Add an AtomicMarker type that may be used for maintaining a 'marker' on
a single file and moving it atomically. This is useful when code
requires atomically switching from one file to another.

This PR would be in replace of #1244.