### PR TITLE
metamorphic: transform percentage of SINGLEDEL ops to DELETE ops

### DIFF
--- a/internal/metamorphic/generator.go
+++ b/internal/metamorphic/generator.go
@@ -843,6 +843,12 @@ func (g *generator) writerSingleDelete() {
 	g.add(&singleDeleteOp{
 		writerID: writerID,
 		key:      key,
+		// Keys eligible for single deletes can be removed with a regular
+		// delete. Mutate a percentage of SINGLEDEL ops into DELETEs. Note that
+		// here we are only determining whether the replacement *could* happen.
+		// At test runtime, the `replaceSingleDelete` test option must also be
+		// set to true for the single delete to be replaced.
+		maybeReplaceDelete: g.rng.Float64() < 0.25,
 	})
 	g.tryRepositionBatchIters(writerID)
 }

--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -256,8 +256,10 @@ func TestMeta(t *testing.T) {
 		})
 	}
 
-	// Perform runs with random options.
-	for i := 0; i < 20; i++ {
+	// Perform runs with random options. We make an arbitrary choice to run with
+	// as many random options as we have standard options.
+	nOpts := len(options)
+	for i := 0; i < nOpts; i++ {
 		name := fmt.Sprintf("random-%03d", i)
 		names = append(names, name)
 		opts := randomOptions(rng)

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -39,6 +39,9 @@ func parseOptions(opts *testOptions, data string) error {
 			case "TestOptions.ingest_using_apply":
 				opts.ingestUsingApply = true
 				return true
+			case "TestOptions.replace_single_delete":
+				opts.replaceSingleDelete = true
+				return true
 			default:
 				return false
 			}
@@ -50,7 +53,7 @@ func parseOptions(opts *testOptions, data string) error {
 
 func optionsToString(opts *testOptions) string {
 	str := opts.opts.String()
-	if opts.strictFS || opts.ingestUsingApply {
+	if opts.strictFS || opts.ingestUsingApply || opts.replaceSingleDelete {
 		str += "\n[TestOptions]\n"
 	}
 	if opts.strictFS {
@@ -58,6 +61,9 @@ func optionsToString(opts *testOptions) string {
 	}
 	if opts.ingestUsingApply {
 		str += "  ingest_using_apply=true\n"
+	}
+	if opts.replaceSingleDelete {
+		str += "  replace_single_delete=true\n"
 	}
 	return str
 }
@@ -79,6 +85,8 @@ type testOptions struct {
 	strictFS bool
 	// Use Batch.Apply rather than DB.Ingest.
 	ingestUsingApply bool
+	// Replace a SINGLEDEL with a DELETE.
+	replaceSingleDelete bool
 }
 
 func standardOptions() []*testOptions {
@@ -166,6 +174,10 @@ func standardOptions() []*testOptions {
 [TestOptions]
   ingest_using_apply=true
 `,
+		20: `
+[TestOptions]
+  replace_single_delete=true
+`,
 	}
 
 	opts := make([]*testOptions, len(stdOpts))
@@ -214,5 +226,6 @@ func randomOptions(rng *rand.Rand) *testOptions {
 		opts.DisableWAL = false
 	}
 	testOpts.ingestUsingApply = rng.Intn(2) != 0
+	testOpts.replaceSingleDelete = rng.Intn(2) != 0
 	return testOpts
 }

--- a/internal/metamorphic/parser.go
+++ b/internal/metamorphic/parser.go
@@ -97,7 +97,7 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	case *iterSetBoundsOp:
 		return &t.iterID, nil, []interface{}{&t.lower, &t.upper}
 	case *singleDeleteOp:
-		return &t.writerID, nil, []interface{}{&t.key}
+		return &t.writerID, nil, []interface{}{&t.key, &t.maybeReplaceDelete}
 	}
 	panic(fmt.Sprintf("unsupported op type: %T", op))
 }
@@ -261,6 +261,14 @@ func (p *parser) parseArgs(op op, methodName string, args []interface{}) {
 			} else {
 				*t = []byte(s)
 			}
+
+		case *bool:
+			_, lit := p.scanToken(token.IDENT)
+			b, err := strconv.ParseBool(lit)
+			if err != nil {
+				panic(err)
+			}
+			*t = b
 
 		case *objID:
 			pos, lit := p.scanToken(token.IDENT)


### PR DESCRIPTION
Generated SINGLEDEL operations are eligible for transformation into less
restrictive DELETE operations.

Transform a fixed percentage of SINGLEDEL operations at generation time
into DELETEs to further exercise the delete execution paths.

Related to cockroachdb/cockroach#69414.