### PR TITLE
vfs/atomicfs: add Marker NextIter method

### DIFF
--- a/vfs/atomicfs/marker.go
+++ b/vfs/atomicfs/marker.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package vfs
+package atomicfs
 
 import (
 	"fmt"
@@ -193,6 +193,13 @@ func (a *Marker) Move(filename string) error {
 		panic(errors.WithStack(err))
 	}
 	return nil
+}
+
+// NextIter returns the next iteration number that the marker will use.
+// Clients may use this number for formulating filenames that are
+// unused.
+func (a *Marker) NextIter() uint64 {
+	return a.iter + 1
 }
 
 // RemoveObsolete removes any obsolete files discovered while locating

--- a/vfs/atomicfs/marker_test.go
+++ b/vfs/atomicfs/marker_test.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package vfs
+package atomicfs
 
 import (
 	"bytes"
@@ -116,6 +116,14 @@ func TestMarker(t *testing.T) {
 				return err.Error()
 			}
 			return ""
+
+		case "next-iter":
+			var dir, marker string
+			td.ScanArgs(t, "dir", &dir)
+			td.ScanArgs(t, "marker", &marker)
+			m := markers[memFS.PathJoin(dir, marker)]
+			require.NotNil(t, m)
+			return fmt.Sprintf("%d", m.NextIter())
 
 		case "remove-obsolete":
 			var dir, marker string

--- a/vfs/atomicfs/testdata/marker
+++ b/vfs/atomicfs/testdata/marker
@@ -10,6 +10,14 @@ mkdir-all data
 locate dir=data marker=foo
 ----
 
+next-iter  dir=data marker=foo
+----
+1
+
+next-iter  dir=data marker=foo
+----
+1
+
 # The directory should still be empty.
 list data
 ----
@@ -23,10 +31,18 @@ list data
 ----
 marker.foo.000001.MANIFEST-000010
 
+next-iter  dir=data marker=foo
+----
+2
+
 # Moving the marker should move the existing marker file.
 move dir=data marker=foo
 MANIFEST-000016
 ----
+
+next-iter  dir=data marker=foo
+----
+3
 
 list data
 ----


### PR DESCRIPTION
Add a NextIter method that allows clients to query an atomic marker for
its next iteration sequence number. In some usages, client code needs to
create a new file and then move the marker to the new file's path.
Creating the new file must not overrwrite the existing marked file.
Incorporating the marker's iteration number into the filename provides a
simple scheme client code may follow.