### PR TITLE
sstable: Free cache value when checksum type is corrupt

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -1922,6 +1922,7 @@ func (r *Reader) readBlock(
 	case ChecksumTypeXXHash64:
 		computedChecksum = uint32(xxhash.Sum64(b[:bh.Length+1]))
 	default:
+		r.opts.Cache.Free(v)
 		return cache.Handle{}, errors.Errorf("unsupported checksum type: %d", r.checksumType)
 	}
 


### PR DESCRIPTION
In all the instances in `Reader.readBlock` where we return
an error, we free the cache handle before returning the error.
One exception to this was the switch for the checksum type,
so this change adds that Free there as well.