### PR TITLE
WIP - meta: add sequence generator; add SET -> DEL -> SINGLEDEL sequence

### DIFF
--- a/internal/metamorphic/config.go
+++ b/internal/metamorphic/config.go
@@ -41,6 +41,7 @@ const (
 	writerMerge
 	writerSet
 	writerSingleDelete
+	pickScenario
 )
 
 type config struct {
@@ -93,5 +94,6 @@ var defaultConfig = config{
 		writerMerge:         100,
 		writerSet:           100,
 		writerSingleDelete:  25,
+		pickScenario:        100,
 	},
 }

--- a/internal/metamorphic/generator.go
+++ b/internal/metamorphic/generator.go
@@ -91,7 +91,9 @@ func newGenerator(rng *rand.Rand) *generator {
 
 	// Specific scenarios for which to generate operations for.
 	// TODO(travers): Add additional sequences.
-	g.scenarios = []*sequenceGenerator{}
+	g.scenarios = []*sequenceGenerator{
+		makeDelToSingleDelSequence(g.randValue(4, 12), func() []byte { return g.randValue(4, 12) }),
+	}
 
 	return g
 }

--- a/internal/metamorphic/scenario.go
+++ b/internal/metamorphic/scenario.go
@@ -1,0 +1,82 @@
+package metamorphic
+
+import (
+	"github.com/cockroachdb/pebble/internal/randvar"
+	"golang.org/x/exp/rand"
+)
+
+// makeDelToSingleDelSequence returns a sequenceGenerator that will generate
+// sequences of the form:
+//
+//   (SET -> GET)+ -> DELETE -> GET -> SET -> GET -> SINGLEDEL -> GET+
+//
+// i.e. one or more SETs, followed by a DELETE, followed by a single SET. This
+// SET is then removed via a SINGLEDEL. GETs are interspersed between all
+// operations. The sequence completes with a fixed number of GETs, to simulate
+// fetching the key after it has been single-deleted.
+//
+// This sequenceGenerator is regression test for cockroachdb/cockroach#69414.
+func makeDelToSingleDelSequence(key []byte, valueFn func() []byte) *sequenceGenerator {
+	reader, writer := makeObjID(dbTag, 0), makeObjID(dbTag, 0)
+
+	var statePrev opType
+	var doneDel, doneSingleDel bool
+	var setCount, trailingGetCount int
+	return newSequenceGenerator(
+		transitionMap{
+			writerSet: func(rng *rand.Rand) (current op, next opType) {
+				setCount++
+				current = &setOp{writerID: writer, key: key, value: valueFn()}
+				statePrev = writerSet
+				next = readerGet
+				return
+			},
+			writerDelete: func(rng *rand.Rand) (current op, next opType) {
+				doneDel = true
+				current = &deleteOp{writerID: writer, key: key}
+				statePrev = writerDelete
+				next = readerGet
+				return
+			},
+			writerSingleDelete: func(rng *rand.Rand) (current op, next opType) {
+				doneSingleDel = true
+				current = &singleDeleteOp{writerID: writer, key: key}
+				statePrev = writerSingleDelete
+				next = readerGet
+				return
+			},
+			readerGet: func(rng *rand.Rand) (current op, next opType) {
+				switch statePrev {
+				case writerSet:
+					if doneDel && setCount > 1 {
+						// Transition to SINGLEDEL only when we've performed a
+						// DEL followed by a single SET.
+						next = writerSingleDelete
+					} else {
+						// Else, bias towards performing more sets.
+						r := randvar.NewWeighted(rng, 0.8, 0.2)
+						next = []opType{writerSet, writerDelete}[r.Int()]
+					}
+				case writerDelete:
+					// Transition back to SET after performing a DELETE.
+					next = writerSet
+				case writerSingleDelete, readerGet:
+					// Perform a fixed number of trailing GETs to fetch the key
+					// after it has been single-deleted.
+					if doneSingleDel && trailingGetCount == 10 {
+						next = stateDone
+						return
+					}
+					trailingGetCount++
+					next = readerGet
+				}
+
+				current = &getOp{readerID: reader, key: key}
+				statePrev = readerGet
+				return
+			},
+		},
+		// Start with a SET.
+		writerSet,
+	)
+}

--- a/internal/metamorphic/scenario_test.go
+++ b/internal/metamorphic/scenario_test.go
@@ -1,0 +1,86 @@
+package metamorphic
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/rand"
+)
+
+func TestDelToSingleDel(t *testing.T) {
+	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
+	g := newGenerator(rng)
+
+	key := g.randValue(4, 12)
+	valueFn := func() []byte { return g.randValue(4, 12) }
+	s := makeDelToSingleDelSequence(key, valueFn)
+
+	// Track the positions of each operation in the sequence.
+	var sets, gets, dels, singleDels []int
+	var i int
+	for {
+		op := s.next(rng)
+		if op == nil {
+			break
+		}
+		fmt.Println(op)
+		switch op.(type) {
+		case *setOp:
+			sets = append(sets, i)
+		case *getOp:
+			gets = append(gets, i)
+		case *deleteOp:
+			dels = append(dels, i)
+		case *singleDeleteOp:
+			singleDels = append(singleDels, i)
+		}
+		i++
+	}
+
+	// All ops occurred at least once.
+	if sets == nil || gets == nil || dels == nil || singleDels == nil {
+		t.Fatalf("expected each operation to occur at least once")
+	}
+
+	// Exactly one SINGLEDEL.
+	require.Len(t, singleDels, 1)
+
+	// A single SET in between the DELETE and SINGLEDEL.
+	idxSingleDel := singleDels[0]
+	idxLastDel := dels[len(dels)-1]
+	cnt := countOps(sets, func(i int) bool {
+		return i > idxLastDel && i < idxSingleDel
+	})
+	require.Equal(t, 1, cnt)
+
+	// No SETs or DELs after the SINGLEDEL.
+	idxLastSet := sets[len(sets)-1]
+	require.Less(t, idxLastSet, idxSingleDel)
+	require.Less(t, idxLastDel, idxSingleDel)
+
+	// A single GET follows every SET and DEL.
+	cnt = countOps(gets, func(i int) bool {
+		return i < idxSingleDel && i%2 == 1 /* odd numbered indices */
+	})
+	require.Equal(t, cnt, len(sets)+len(dels))
+
+	// A fixed number of GETS (10) following the SINGLEDEL.
+	cnt = countOps(gets, func(i int) bool {
+		return i > idxSingleDel
+	})
+	require.Equal(t, 10, cnt)
+}
+
+// countOps returns the number of operations with indices satisfying the given
+// predicate.
+func countOps(is []int, predicate func(i int) bool) int {
+	var count int
+	for _, idx := range is {
+		if predicate(idx) {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/metamorphic/sequence.go
+++ b/internal/metamorphic/sequence.go
@@ -1,0 +1,49 @@
+package metamorphic
+
+import "golang.org/x/exp/rand"
+
+// transitionFn is a node in the state machine graph. The node is a function
+// that generates the op resulting from moving to this node and the next opType
+// representing the next state in the state machine.
+type transitionFn func(rng *rand.Rand) (current op, next opType)
+
+// transitionMap is a blueprint for generating sequences of ops. It functions as
+// a graph representing a state machine. Each node in the graph is a function
+// returning the current op and the next opType to transition to.
+type transitionMap map[opType]transitionFn
+
+// stateDone is the terminal state for the state machine.
+var stateDone opType = -1
+
+// sequenceGenerator generates a sequence of ops from an transitionMap
+// corresponding to a specific sequenceGenerator.
+type sequenceGenerator struct {
+	tMap      transitionMap
+	nextState opType
+	steps     int
+}
+
+// newSequenceGenerator constructs a new sequenceGenerator with the given
+// transition map, post-ops, and the initial state of the sequence.
+func newSequenceGenerator(m transitionMap, initial opType) *sequenceGenerator {
+	return &sequenceGenerator{
+		tMap:      m,
+		nextState: initial,
+	}
+}
+
+// next generates the next ops from the transitionMap state machine, and
+// transitions the transitionMap to the next state.
+func (g *sequenceGenerator) next(rng *rand.Rand) op {
+	if g.nextState == stateDone {
+		return nil
+	}
+
+	// Randomly pick the next state to transition into. Generate the op from
+	// this transition and move to the next state.
+	var o op
+	o, g.nextState = g.tMap[g.nextState](rng)
+	g.steps++
+
+	return o
+}

--- a/internal/metamorphic/sequence_test.go
+++ b/internal/metamorphic/sequence_test.go
@@ -1,0 +1,68 @@
+package metamorphic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/rand"
+)
+
+func TestSequenceGenerator(t *testing.T) {
+	n := 10
+	key, value := []byte("foo"), []byte("bar")
+
+	// A simple state machine that alternates states between GET and SET n times
+	// before transitioning into a terminal state.
+	tMap := transitionMap{
+		readerGet: func(rng *rand.Rand) (current op, next opType) {
+			current = &getOp{key: key, readerID: makeObjID(dbTag, 0)}
+			n--
+			if n > 0 {
+				next = writerSet
+			} else {
+				next = stateDone
+			}
+			return
+		},
+		writerSet: func(rng *rand.Rand) (current op, next opType) {
+			current = &setOp{key: key, value: value, writerID: makeObjID(dbTag, 0)}
+			n--
+			if n > 0 {
+				next = readerGet
+			} else {
+				next = stateDone
+			}
+			return
+		},
+	}
+
+	rng := rand.New(rand.NewSource(0))
+	g := newSequenceGenerator(tMap, readerGet)
+
+	// Generate the sequence from the state machine, counting GETs and SETs.
+	var nGet, nSet int
+	var last opType
+	for {
+		op := g.next(rng)
+		if op == nil {
+			break // Terminal state.
+		}
+		switch op.(type) {
+		case *getOp:
+			nGet++
+			if last > 0 {
+				require.Equal(t, writerSet, last)
+			}
+			last = readerGet
+		case *setOp:
+			nSet++
+			require.Equal(t, readerGet, last)
+			last = writerSet
+		default:
+			t.Fatalf("unknown op type: %s", op)
+		}
+	}
+
+	require.Equal(t, nGet, 5)
+	require.Equal(t, nSet, 5)
+}


### PR DESCRIPTION
This first commit in this PR adds the concept of a "sequence generator" to produce random sequences governed by a state machine.

The second adds a sequence to reproduce the bug we were seeing in cockroachdb/cockroach#69414.