### PR TITLE
Add method to get remaining storage capacity in Batch

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -727,6 +727,11 @@ func (b *Batch) newRangeDelIter(o *IterOptions) internalIterator {
 	return rangedel.NewIter(b.cmp, b.tombstones)
 }
 
+// Capacity returns the amount of space left in storage till hitting max size
+func (b *Batch) Capacity() int {
+	return maxMemTableSize - len(b.data)
+}
+
 // Commit applies the batch to its parent writer.
 func (b *Batch) Commit(o *WriteOptions) error {
 	return b.db.Apply(b, o)


### PR DESCRIPTION
Adds method `Capacity` that reports back the remaining bytes that can be stored before hitting max limit. This will allow user to call proactively call `Commit` and flush changes before hitting the panic in the `grow` function.