### PR TITLE
testdata: remove values from deletes

### DIFF
--- a/sstable/testdata/writer
+++ b/sstable/testdata/writer
@@ -14,11 +14,11 @@ scan-range-del
 
 build
 a.SET.1:a
-b.DEL.2:b
+b.DEL.2:
 c.MERGE.3:c
 d.RANGEDEL.4:e
 f.SET.5:f
-g.DEL.6:g
+g.DEL.6:
 h.MERGE.7:h
 i.RANGEDEL.8:j
 ----
@@ -28,11 +28,11 @@ seqnums: [1,8]
 
 build
 a.SET.1:a
-b.DEL.2:b
+b.DEL.2:
 c.MERGE.3:c
 d.RANGEDEL.4:e
 f.SET.5:f
-g.DEL.6:g
+g.DEL.6:
 h.MERGE.7:h
 i.RANGEDEL.8:j
 ----
@@ -43,10 +43,10 @@ seqnums: [1,8]
 scan
 ----
 a#1,1:a
-b#2,0:b
+b#2,0:
 c#3,2:c
 f#5,1:f
-g#6,0:g
+g#6,0:
 h#7,2:h
 
 scan-range-del

--- a/testdata/compaction_iter
+++ b/testdata/compaction_iter
@@ -969,9 +969,9 @@ a-c#2
 
 define
 a.RANGEDEL.3:d
-a.DEL.2:a
+a.DEL.2:
 a.SET.1:a
-d.DEL.2:a
+d.DEL.2:
 ----
 
 iter
@@ -981,7 +981,7 @@ next
 tombstones
 ----
 a#3,15:d
-d#2,0:a
+d#2,0:
 .
 a-d#3
 .
@@ -993,8 +993,8 @@ next
 next
 ----
 a#3,15:d
-a#2,0:a
-d#2,0:a
+a#2,0:
+d#2,0:
 .
 
 iter snapshots=2
@@ -1005,7 +1005,7 @@ next
 ----
 a#3,15:d
 a#1,1:a
-d#2,0:a
+d#2,0:
 .
 
 iter snapshots=1
@@ -1014,7 +1014,7 @@ next
 next
 ----
 a#3,15:d
-d#2,0:a
+d#2,0:
 .
 
 define
@@ -1060,7 +1060,7 @@ a-b#1
 
 define
 a.MERGE.5:5
-a.DEL.3:3
+a.DEL.3:
 a.MERGE.1:1
 ----
 

--- a/testdata/level_checker
+++ b/testdata/level_checker
@@ -348,7 +348,7 @@ merge processing error on key a#9,DEL in L1: fileNum=000032: finish failed
 define
 L
 a.MERGE.10 a.SINGLEDEL.9
-a.MERGE.10:fail-finish a.SINGLEDEL.9:fail-finish
+a.MERGE.10:fail-finish a.SINGLEDEL.9:
 ----
 Level 1
   file 0: [a#10,2-a#9,7]


### PR DESCRIPTION
Delete keys are not required to have accompanying values. Though they
may in practice, the presence of values for delete or single-delete
records in test data can be confusing.

Remove instances from test data where a DEL or SINGLEDEL has a value
set.