### PR TITLE
cmd/pebble: specify format major version

### DIFF
--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -57,6 +57,7 @@ func newPebbleDB(dir string) DB {
 		Cache:                       cache,
 		Comparer:                    mvccComparer,
 		DisableWAL:                  disableWAL,
+		FormatMajorVersion:          pebble.FormatNewest,
 		L0CompactionThreshold:       2,
 		L0StopWritesThreshold:       1000,
 		LBaseMaxBytes:               64 << 20, // 64 MB


### PR DESCRIPTION
In the cmd/pebble benchmark tool, configure the database to use the
most-recent format major version.