### PR TITLE
db: improve use-after-free test coverage for compactions

### DIFF
--- a/internal/cache/value_invariants.go
+++ b/internal/cache/value_invariants.go
@@ -43,9 +43,9 @@ func newValue(n int) *Value {
 func (v *Value) free() {
 	// When "invariants" are enabled set the value contents to 0xff in order to
 	// cache use-after-free bugs.
-	// for i := range v.buf {
-	// 	v.buf[i] = 0xff
-	// }
+	for i := range v.buf {
+		v.buf[i] = 0xff
+	}
 	manual.Free(v.buf)
 	// Setting Value.buf to nil is needed for correctness of the leak checking
 	// that is performed when the "invariants" or "tracing" build tags are

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -187,6 +187,10 @@ type blockEntry struct {
 // tombstones are always encoded with a restart interval of 1. This per-block
 // key stability guarantee is sufficient for range tombstones as they are
 // always encoded in a single block.
+//
+// A blockIter also provides a value stability guarantee for range deletions
+// since there is only a single range deletion block per sstable and the
+// blockIter will not release the bytes for the block until it is closed.
 type blockIter struct {
 	cmp Compare
 	// offset is the byte index that marks where the current key/value is


### PR DESCRIPTION
To increase confidence that use-after-free bugs are not present on
compaction codepaths, use the `invalidatingIter` wrapper to mutate the
previous key and value during iteration.

Alter the `invalidatingIter` to avoid zeroing range deletion key / value
pairs, which aligns with the current assumption
`(*compactionIter).Next()`.

Add an in-line comment to point out that storage of a reference to the
previous key / value pairs is safe for range deletion keys during
compaction iteration.

Enable some previously dead code to mutate released byte slices. This
allows for easier detection of use-after-free-type bugs.