### PR TITLE
pebble: Export table cache related constants for use in cockroach

### DIFF
--- a/db.go
+++ b/db.go
@@ -26,12 +26,12 @@ import (
 )
 
 const (
-	// minTableCacheSize is the minimum size of the table cache.
-	minTableCacheSize = 64
+	// MinTableCacheSize is the minimum size of the table cache, for a given store.
+	MinTableCacheSize = 64
 
-	// numNonTableCacheFiles is an approximation for the number of MaxOpenFiles
-	// that we don't use for table caches.
-	numNonTableCacheFiles = 10
+	// NumNonTableCacheFiles is an approximation for the number of MaxOpenFiles
+	// that we don't use for table caches, for a given store.
+	NumNonTableCacheFiles = 10
 )
 
 var (

--- a/open.go
+++ b/open.go
@@ -105,9 +105,9 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		d.equal = bytes.Equal
 	}
 
-	tableCacheSize := opts.MaxOpenFiles - numNonTableCacheFiles
-	if tableCacheSize < minTableCacheSize {
-		tableCacheSize = minTableCacheSize
+	tableCacheSize := opts.MaxOpenFiles - NumNonTableCacheFiles
+	if tableCacheSize < MinTableCacheSize {
+		tableCacheSize = MinTableCacheSize
 	}
 	d.tableCache = newTableCacheContainer(opts.TableCache, d.cacheID, dirname, opts.FS, d.opts, tableCacheSize)
 	d.newIters = d.tableCache.newIters


### PR DESCRIPTION
To configure the shared TableCache from cockroach, we need to export
NumNonTableCacheFiles, MinTableCacheSize  to make cache size calculations
from cockroach.