### PR TITLE
internal/cache: prevent coldTarget from becoming greater than targetSize

### DIFF
--- a/internal/cache/clockpro.go
+++ b/internal/cache/clockpro.go
@@ -251,6 +251,16 @@ func (c *shard) Free() {
 func (c *shard) Reserve(n int) {
 	c.mu.Lock()
 	c.reservedSize += int64(n)
+
+	// Changing c.reservedSize will either increase or decrease
+	// the targetSize. But we want coldTarget to be in the range
+	// [0, targetSize]. So, if c.targetSize decreases, make sure
+	// that the coldTarget fits within the limits.
+	targetSize := c.targetSize()
+	if c.coldTarget > targetSize {
+		c.coldTarget = targetSize
+	}
+
 	c.evict()
 	c.mu.Unlock()
 }

--- a/internal/cache/clockpro_test.go
+++ b/internal/cache/clockpro_test.go
@@ -249,3 +249,31 @@ func BenchmarkCacheGet(b *testing.B) {
 		}
 	})
 }
+
+func TestReserveColdTarget(t *testing.T) {
+	// If coldTarget isn't updated when we call shard.Reserve,
+	// then we unnecessarily remove nodes from the
+	// cache.
+
+	cache := newShards(100, 1)
+	defer cache.Unref()
+
+	for i := 0; i < 50; i++ {
+		cache.Set(uint64(i+1), 0, 0, testValue(cache, "a", 1)).Release()
+	}
+
+	if cache.Size() != 50 {
+		require.Equal(t, 50, cache.Size(), "nodes were unnecessarily evicted from the cache")
+	}
+
+	// There won't be enough space left for 50 nodes in the cache after
+	// we call shard.Reserve. This should trigger a call to evict.
+	cache.Reserve(51)
+
+	// If we don't update coldTarget in Reserve then the cache gets emptied to
+	// size 0. In shard.Evict, we loop until shard.Size() < shard.targetSize().
+	// Therefore, 100 - 51 = 49, but we evict one more node.
+	if cache.Size() != 48 {
+		t.Fatalf("expected positive cache size %d, but found %d", 48, cache.Size())
+	}
+}


### PR DESCRIPTION
We try to keep shard.coldTarget in the range [0, shard.targetSize()].
This can be seen here:
https://github.com/cockroachdb/pebble/blob/master/internal/cache/clockpro.go#L172,
and here:
https://github.com/cockroachdb/pebble/blob/master/internal/cache/clockpro.go#L465.

However, when we call Cache.Reserve, we end up either increasing or decreasing,
shard.reservedSize, which in turn changes the shard.targetSize(). But we don't
update shard.coldTarget to keep it <= shard.targetSize().

shard.coldTarget not being updated, can cause unnecessary evictions from the cache
as shown in the test.