### PR TITLE
internal/cache: update entry size in the etTest to etHot transition

### DIFF
--- a/internal/cache/clockpro.go
+++ b/internal/cache/clockpro.go
@@ -168,6 +168,7 @@ func (c *shard) Set(id uint64, fileNum base.FileNum, offset uint64, value *Value
 		c.metaDel(e)
 		c.metaCheck(e)
 
+		e.size = int64(len(value.buf))
 		c.coldTarget += e.size
 		if c.coldTarget > c.targetSize() {
 			c.coldTarget = c.targetSize()


### PR DESCRIPTION
When we set a value in the cache, the size of the  value isn't necessarily
the same size as the size of its previous value. We use the size of the
latest value when we're setting an entry which was either hot or cold.

After this PR, we also use the size of the latest value when setting an
entry which was in its test period.