### PR TITLE
compaction: fix nil pointer during errored compactions

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1964,9 +1964,11 @@ func (d *DB) runCompaction(
 	// deleted files in the new versionEdit pass a validation function before
 	// returning the edit.
 	defer func() {
-		err := validateVersionEdit(ve, d.opts.Experimental.KeyValidationFunc, d.opts.Comparer.FormatKey)
-		if err != nil {
-			d.opts.Logger.Fatalf("pebble: version edit validation failed: %s", err)
+		if ve != nil {
+			err := validateVersionEdit(ve, d.opts.Experimental.KeyValidationFunc, d.opts.Comparer.FormatKey)
+			if err != nil {
+				d.opts.Logger.Fatalf("pebble: version edit validation failed: %s", err)
+			}
 		}
 	}()
 
@@ -2530,10 +2532,6 @@ func (d *DB) runCompaction(
 func validateVersionEdit(
 	ve *versionEdit, validateFn func([]byte) error, format base.FormatKey,
 ) error {
-	if validateFn == nil {
-		return nil
-	}
-
 	validateMetaFn := func(f *manifest.FileMetadata) error {
 		for _, key := range []InternalKey{f.Smallest, f.Largest} {
 			if err := validateFn(key.UserKey); err != nil {

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -9,12 +9,14 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -948,20 +950,6 @@ func TestValidateVersionEdit(t *testing.T) {
 		vFunc   func([]byte) error
 		wantErr error
 	}{
-		{
-			desc: "validation function absent",
-			ve: &versionEdit{
-				NewFiles: []manifest.NewFileEntry{
-					{
-						Meta: &fileMetadata{
-							Smallest: manifest.InternalKey{UserKey: []byte(badKey)},
-							Largest:  manifest.InternalKey{UserKey: []byte("z")},
-						},
-					},
-				},
-			},
-			vFunc: nil,
-		},
 		{
 			desc: "single new file; start key",
 			ve: &versionEdit{
@@ -2770,6 +2758,29 @@ func TestCleanerCond(t *testing.T) {
 		wg.Wait()
 	}
 
+	require.NoError(t, d.Close())
+}
+
+func TestFlushError(t *testing.T) {
+	// Error the first five times we try to write a sstable.
+	errorOps := int32(3)
+	fs := errorfs.Wrap(vfs.NewMem(), errorfs.InjectorFunc(func(op errorfs.Op, path string) error {
+		if op == errorfs.OpCreate && filepath.Ext(path) == ".sst" && atomic.AddInt32(&errorOps, -1) >= 0 {
+			return errorfs.ErrInjected
+		}
+		return nil
+	}))
+	d, err := Open("", testingRandomized(&Options{
+		FS: fs,
+		EventListener: EventListener{
+			BackgroundError: func(err error) {
+				t.Log(err)
+			},
+		},
+	}))
+	require.NoError(t, err)
+	require.NoError(t, d.Set([]byte("a"), []byte("foo"), NoSync))
+	require.NoError(t, d.Flush())
 	require.NoError(t, d.Close())
 }
 

--- a/options.go
+++ b/options.go
@@ -583,6 +583,9 @@ func (o *Options) EnsureDefaults() *Options {
 	if o.Experimental.CompactionDebtConcurrency <= 0 {
 		o.Experimental.CompactionDebtConcurrency = 1 << 30 // 1 GB
 	}
+	if o.Experimental.KeyValidationFunc == nil {
+		o.Experimental.KeyValidationFunc = func([]byte) error { return nil }
+	}
 	if o.L0CompactionThreshold <= 0 {
 		o.L0CompactionThreshold = 4
 	}


### PR DESCRIPTION
Previously, if a compaction or flush errored and returned a nil version
edit while a `KeyValidationFunc` was configured, `validateVersionEdit`
would panic. This commit add a nil check, plus configures a no-op
KeyValidationFunc default.

Informs cockroachdb/cockroach#70443.