### PR TITLE
release-21.2: compaction: fix nil pointer during errored compactions

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1964,9 +1964,11 @@ func (d *DB) runCompaction(
 	// deleted files in the new versionEdit pass a validation function before
 	// returning the edit.
 	defer func() {
-		err := validateVersionEdit(ve, d.opts.Experimental.KeyValidationFunc, d.opts.Comparer.FormatKey)
-		if err != nil {
-			d.opts.Logger.Fatalf("pebble: version edit validation failed: %s", err)
+		if ve != nil {
+			err := validateVersionEdit(ve, d.opts.Experimental.KeyValidationFunc, d.opts.Comparer.FormatKey)
+			if err != nil {
+				d.opts.Logger.Fatalf("pebble: version edit validation failed: %s", err)
+			}
 		}
 	}()
 
@@ -2529,10 +2531,6 @@ func (d *DB) runCompaction(
 func validateVersionEdit(
 	ve *versionEdit, validateFn func([]byte) error, format base.FormatKey,
 ) error {
-	if validateFn == nil {
-		return nil
-	}
-
 	validateMetaFn := func(f *manifest.FileMetadata) error {
 		for _, key := range []InternalKey{f.Smallest, f.Largest} {
 			if err := validateFn(key.UserKey); err != nil {

--- a/options.go
+++ b/options.go
@@ -575,6 +575,9 @@ func (o *Options) EnsureDefaults() *Options {
 	if o.Experimental.CompactionDebtConcurrency <= 0 {
 		o.Experimental.CompactionDebtConcurrency = 1 << 30 // 1 GB
 	}
+	if o.Experimental.KeyValidationFunc == nil {
+		o.Experimental.KeyValidationFunc = func([]byte) error { return nil }
+	}
 	if o.L0CompactionThreshold <= 0 {
 		o.L0CompactionThreshold = 4
 	}


### PR DESCRIPTION
Previously, if a compaction or flush errored and returned a nil version
edit while a `KeyValidationFunc` was configured, `validateVersionEdit`
would panic. This commit add a nil check, plus configures a no-op
KeyValidationFunc default.

Backport of #1281.