### PR TITLE
db: handle nil logger in EventListener.EnsureDefaults

### DIFF
--- a/event.go
+++ b/event.go
@@ -454,8 +454,12 @@ type EventListener struct {
 // for nil-ness before invoking.
 func (l *EventListener) EnsureDefaults(logger Logger) {
 	if l.BackgroundError == nil {
-		l.BackgroundError = func(err error) {
-			logger.Infof("background error: %s", err)
+		if logger != nil {
+			l.BackgroundError = func(err error) {
+				logger.Infof("background error: %s", err)
+			}
+		} else {
+			l.BackgroundError = func(error) {}
 		}
 	}
 	if l.CompactionBegin == nil {

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -378,6 +378,12 @@ func TestEventListenerRedact(t *testing.T) {
 	require.Equal(t, "[JOB 5] WAL delete error: unredacted error: ‹×›\n", log.String())
 }
 
+func TestEventListenerEnsureDefaultsBackgroundError(t *testing.T) {
+	e := EventListener{}
+	e.EnsureDefaults(nil)
+	e.BackgroundError(errors.New("an example error"))
+}
+
 func TestEventListenerEnsureDefaultsSetsAllCallbacks(t *testing.T) {
 	e := EventListener{}
 	e.EnsureDefaults(nil)


### PR DESCRIPTION
Previously, if a nil logger was passed into
`EventListener.EnsureDefaults`, a call to `BackgroundError` would panic
with a nil pointer. In CockroachDB we use `TeeEventListener`, which
calls `EnsureDefaults(nil)` on its two event listeners. One of these
didn't have `BackgroundError` set and would panic when a background
error occurred.