### PR TITLE
internal/base: split MakeFilename into MakeFile{path,name}

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -183,7 +183,7 @@ func (d *DB) Checkpoint(
 
 	{
 		// Link or copy the OPTIONS.
-		srcPath := base.MakeFilename(fs, d.dirname, fileTypeOptions, optionsFileNum)
+		srcPath := base.MakeFilepath(fs, d.dirname, fileTypeOptions, optionsFileNum)
 		destPath := fs.PathJoin(destDir, fs.PathBase(srcPath))
 		ckErr = vfs.LinkOrCopy(fs, srcPath, destPath)
 		if ckErr != nil {
@@ -220,7 +220,7 @@ func (d *DB) Checkpoint(
 		// reference sstables that aren't in our checkpoint. For a
 		// similar reason, we need to limit how much of the MANIFEST we
 		// copy.
-		srcPath := base.MakeFilename(fs, d.dirname, fileTypeManifest, manifestFileNum)
+		srcPath := base.MakeFilepath(fs, d.dirname, fileTypeManifest, manifestFileNum)
 		destPath := fs.PathJoin(destDir, fs.PathBase(srcPath))
 		ckErr = vfs.LimitedCopy(fs, srcPath, destPath, manifestSize)
 		if ckErr != nil {
@@ -251,7 +251,7 @@ func (d *DB) Checkpoint(
 	for l := range current.Levels {
 		iter := current.Levels[l].Iter()
 		for f := iter.First(); f != nil; f = iter.Next() {
-			srcPath := base.MakeFilename(fs, d.dirname, fileTypeTable, f.FileNum)
+			srcPath := base.MakeFilepath(fs, d.dirname, fileTypeTable, f.FileNum)
 			destPath := fs.PathJoin(destDir, fs.PathBase(srcPath))
 			ckErr = vfs.LinkOrCopy(fs, srcPath, destPath)
 			if ckErr != nil {
@@ -268,7 +268,7 @@ func (d *DB) Checkpoint(
 		if logNum == 0 {
 			continue
 		}
-		srcPath := base.MakeFilename(fs, d.walDirname, fileTypeLog, logNum)
+		srcPath := base.MakeFilepath(fs, d.walDirname, fileTypeLog, logNum)
 		destPath := fs.PathJoin(destDir, fs.PathBase(srcPath))
 		ckErr = vfs.Copy(fs, srcPath, destPath)
 		if ckErr != nil {

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -202,7 +202,7 @@ func TestCheckpointCompaction(t *testing.T) {
 			tableInfos, _ := d2.SSTables()
 			for _, tables := range tableInfos {
 				for _, tbl := range tables {
-					if _, err := fs.Stat(base.MakeFilename(fs, dir, base.FileTypeTable, tbl.FileNum)); err != nil {
+					if _, err := fs.Stat(base.MakeFilepath(fs, dir, base.FileTypeTable, tbl.FileNum)); err != nil {
 						t.Error(err)
 						return
 					}

--- a/cmd/pebble/compact_new.go
+++ b/cmd/pebble/compact_new.go
@@ -61,12 +61,12 @@ func runCompactNew(cmd *cobra.Command, args []string) error {
 
 		for _, f := range logItem.ve.NewFiles {
 			// First look in the archive, because that's likely where it is.
-			srcPath := base.MakeFilename(vfs.Default, archiveDir, base.FileTypeTable, f.Meta.FileNum)
-			dstPath := base.MakeFilename(vfs.Default, workloadDst, base.FileTypeTable, f.Meta.FileNum)
+			srcPath := base.MakeFilepath(vfs.Default, archiveDir, base.FileTypeTable, f.Meta.FileNum)
+			dstPath := base.MakeFilepath(vfs.Default, workloadDst, base.FileTypeTable, f.Meta.FileNum)
 			err := vfs.LinkOrCopy(vfs.Default, srcPath, dstPath)
 			if oserror.IsNotExist(err) {
 				// Maybe it's still in the data directory.
-				srcPath = base.MakeFilename(vfs.Default, src, base.FileTypeTable, f.Meta.FileNum)
+				srcPath = base.MakeFilepath(vfs.Default, src, base.FileTypeTable, f.Meta.FileNum)
 				err = vfs.LinkOrCopy(vfs.Default, srcPath, dstPath)
 			}
 			if err != nil {

--- a/compaction.go
+++ b/compaction.go
@@ -2094,7 +2094,7 @@ func (d *DB) runCompaction(
 		pendingOutputs = append(pendingOutputs, fileMeta)
 		d.mu.Unlock()
 
-		filename := base.MakeFilename(d.opts.FS, d.dirname, fileTypeTable, fileNum)
+		filename := base.MakeFilepath(d.opts.FS, d.dirname, fileTypeTable, fileNum)
 		file, err := d.opts.FS.Create(filename)
 		if err != nil {
 			return err
@@ -2837,7 +2837,7 @@ func (d *DB) paceAndDeleteObsoleteFiles(jobID int, files []obsoleteFile) {
 	}
 
 	for _, of := range files {
-		path := base.MakeFilename(d.opts.FS, of.dir, of.fileType, of.fileNum)
+		path := base.MakeFilepath(d.opts.FS, of.dir, of.fileType, of.fileNum)
 		if of.fileType == fileTypeTable {
 			_ = pacer.maybeThrottle(of.fileSize)
 			d.mu.Lock()

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -842,7 +842,7 @@ func TestCompaction(t *testing.T) {
 		for _, levelMetadata := range v.Levels {
 			iter := levelMetadata.Iter()
 			for meta := iter.First(); meta != nil; meta = iter.Next() {
-				f, err := mem.Open(base.MakeFilename(mem, "", fileTypeTable, meta.FileNum))
+				f, err := mem.Open(base.MakeFilepath(mem, "", fileTypeTable, meta.FileNum))
 				if err != nil {
 					return "", "", errors.WithStack(err)
 				}

--- a/db.go
+++ b/db.go
@@ -1488,7 +1488,7 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 			// Open will treat the previous log as corrupt.
 			err = d.mu.log.Close()
 
-			newLogName := base.MakeFilename(d.opts.FS, d.walDirname, fileTypeLog, newLogNum)
+			newLogName := base.MakeFilepath(d.opts.FS, d.walDirname, fileTypeLog, newLogNum)
 
 			// Try to use a recycled log file. Recycling log files is an important
 			// performance optimization as it is faster to sync a file that has
@@ -1501,7 +1501,7 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 			if err == nil {
 				recycleLog, recycleOK = d.logRecycler.peek()
 				if recycleOK {
-					recycleLogName := base.MakeFilename(d.opts.FS, d.walDirname, fileTypeLog, recycleLog.fileNum)
+					recycleLogName := base.MakeFilepath(d.opts.FS, d.walDirname, fileTypeLog, recycleLog.fileNum)
 					newLogFile, err = d.opts.FS.ReuseForWrite(recycleLogName, newLogName)
 					base.MustExist(d.opts.FS, newLogName, d.opts.Logger, err)
 				} else {

--- a/db_test.go
+++ b/db_test.go
@@ -375,7 +375,7 @@ func TestLargeBatch(t *testing.T) {
 		return d.mu.log.queue[len(d.mu.log.queue)-1].fileNum
 	}
 	fileSize := func(fileNum FileNum) int64 {
-		info, err := d.opts.FS.Stat(base.MakeFilename(d.opts.FS, "", fileTypeLog, fileNum))
+		info, err := d.opts.FS.Stat(base.MakeFilepath(d.opts.FS, "", fileTypeLog, fileNum))
 		require.NoError(t, err)
 		return info.Size()
 	}

--- a/filenames.go
+++ b/filenames.go
@@ -34,8 +34,8 @@ const (
 // use. Newer versions of Pebble running newer format major versions do
 // not use the CURRENT file. See setCurrentFunc in version_set.go.
 func setCurrentFile(dirname string, fs vfs.FS, fileNum FileNum) error {
-	newFilename := base.MakeFilename(fs, dirname, fileTypeCurrent, fileNum)
-	oldFilename := base.MakeFilename(fs, dirname, fileTypeTemp, fileNum)
+	newFilename := base.MakeFilepath(fs, dirname, fileTypeCurrent, fileNum)
+	oldFilename := base.MakeFilepath(fs, dirname, fileTypeTemp, fileNum)
 	fs.Remove(oldFilename)
 	f, err := fs.Create(oldFilename)
 	if err != nil {

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -95,11 +95,7 @@ var formatMajorVersionMigrations = map[FormatMajorVersion]func(*DB) error{
 		// guaranteed to exist, because we unconditionally locate it
 		// during Open.
 		manifestFileNum := d.mu.versions.manifestFileNum
-		filename := d.mu.versions.fs.PathBase(base.MakeFilename(
-			d.mu.versions.fs,
-			d.mu.versions.dirname,
-			fileTypeManifest,
-			manifestFileNum))
+		filename := base.MakeFilename(fileTypeManifest, manifestFileNum)
 		if err := d.mu.versions.manifestMarker.Move(filename); err != nil {
 			return errors.Wrap(err, "moving manifest marker")
 		}

--- a/ingest.go
+++ b/ingest.go
@@ -214,7 +214,7 @@ func ingestSortAndVerify(cmp Compare, meta []*fileMetadata, paths []string) erro
 func ingestCleanup(fs vfs.FS, dirname string, meta []*fileMetadata) error {
 	var firstErr error
 	for i := range meta {
-		target := base.MakeFilename(fs, dirname, fileTypeTable, meta[i].FileNum)
+		target := base.MakeFilepath(fs, dirname, fileTypeTable, meta[i].FileNum)
 		if err := fs.Remove(target); err != nil {
 			firstErr = firstError(firstErr, err)
 		}
@@ -235,7 +235,7 @@ func ingestLink(
 	}
 
 	for i := range paths {
-		target := base.MakeFilename(fs, dirname, fileTypeTable, meta[i].FileNum)
+		target := base.MakeFilepath(fs, dirname, fileTypeTable, meta[i].FileNum)
 		var err error
 		if _, ok := opts.FS.(*vfs.MemFS); ok && opts.DebugCheck != nil {
 			// The combination of MemFS+Ingest+DebugCheck produces awkwardness around

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1176,7 +1176,7 @@ func TestIngestCleanup(t *testing.T) {
 			// Create the files in the VFS.
 			metaMap := make(map[base.FileNum]vfs.File)
 			for _, fn := range fns {
-				path := base.MakeFilename(mem, "", base.FileTypeTable, fn)
+				path := base.MakeFilepath(mem, "", base.FileTypeTable, fn)
 				f, err := mem.Create(path)
 				metaMap[fn] = f
 				require.NoError(t, err)

--- a/internal/base/filenames.go
+++ b/internal/base/filenames.go
@@ -36,26 +36,31 @@ const (
 )
 
 // MakeFilename builds a filename from components.
-func MakeFilename(fs vfs.FS, dirname string, fileType FileType, fileNum FileNum) string {
+func MakeFilename(fileType FileType, fileNum FileNum) string {
 	switch fileType {
 	case FileTypeLog:
-		return fs.PathJoin(dirname, fmt.Sprintf("%s.log", fileNum))
+		return fmt.Sprintf("%s.log", fileNum)
 	case FileTypeLock:
-		return fs.PathJoin(dirname, "LOCK")
+		return "LOCK"
 	case FileTypeTable:
-		return fs.PathJoin(dirname, fmt.Sprintf("%s.sst", fileNum))
+		return fmt.Sprintf("%s.sst", fileNum)
 	case FileTypeManifest:
-		return fs.PathJoin(dirname, fmt.Sprintf("MANIFEST-%s", fileNum))
+		return fmt.Sprintf("MANIFEST-%s", fileNum)
 	case FileTypeCurrent:
-		return fs.PathJoin(dirname, "CURRENT")
+		return "CURRENT"
 	case FileTypeOptions:
-		return fs.PathJoin(dirname, fmt.Sprintf("OPTIONS-%s", fileNum))
+		return fmt.Sprintf("OPTIONS-%s", fileNum)
 	case FileTypeOldTemp:
-		return fs.PathJoin(dirname, fmt.Sprintf("CURRENT.%s.dbtmp", fileNum))
+		return fmt.Sprintf("CURRENT.%s.dbtmp", fileNum)
 	case FileTypeTemp:
-		return fs.PathJoin(dirname, fmt.Sprintf("temporary.%s.dbtmp", fileNum))
+		return fmt.Sprintf("temporary.%s.dbtmp", fileNum)
 	}
 	panic("unreachable")
+}
+
+// MakeFilepath builds a filepath from components.
+func MakeFilepath(fs vfs.FS, dirname string, fileType FileType, fileNum FileNum) string {
+	return fs.PathJoin(dirname, MakeFilename(fileType, fileNum))
 }
 
 // ParseFilename parses the components from a filename.

--- a/internal/base/filenames_test.go
+++ b/internal/base/filenames_test.go
@@ -72,7 +72,7 @@ func TestFilenameRoundTrip(t *testing.T) {
 			fileNums = []FileNum{0, 1, 2, 3, 10, 42, 99, 1001}
 		}
 		for _, fileNum := range fileNums {
-			filename := MakeFilename(fs, "foo", fileType, fileNum)
+			filename := MakeFilepath(fs, "foo", fileType, fileNum)
 			gotFT, gotFN, gotOK := ParseFilename(fs, filename)
 			if !gotOK {
 				t.Errorf("could not parse %q", filename)

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -598,7 +598,7 @@ func (v *Version) CheckConsistency(dirname string, fs vfs.FS) error {
 	for level, files := range v.Levels {
 		iter := files.Iter()
 		for f := iter.First(); f != nil; f = iter.Next() {
-			path := base.MakeFilename(fs, dirname, base.FileTypeTable, f.FileNum)
+			path := base.MakeFilepath(fs, dirname, base.FileTypeTable, f.FileNum)
 			info, err := fs.Stat(path)
 			if err != nil {
 				buf.WriteString("L%d: %s: %v\n")

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -557,7 +557,7 @@ func TestCheckConsistency(t *testing.T) {
 					if err != nil {
 						return err.Error()
 					}
-					path := base.MakeFilename(mem, dir, base.FileTypeTable, m.FileNum)
+					path := base.MakeFilepath(mem, dir, base.FileTypeTable, m.FileNum)
 					_ = mem.Remove(path)
 					f, err := mem.Create(path)
 					if err != nil {

--- a/open.go
+++ b/open.go
@@ -179,7 +179,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	}
 
 	// Lock the database directory.
-	fileLock, err := opts.FS.Lock(base.MakeFilename(opts.FS, dirname, fileTypeLock, 0))
+	fileLock, err := opts.FS.Lock(base.MakeFilepath(opts.FS, dirname, fileTypeLock, 0))
 	if err != nil {
 		d.dataDir.Close()
 		if d.dataDir != d.walDir {
@@ -369,7 +369,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 			return nil, err
 		}
 
-		newLogName := base.MakeFilename(opts.FS, d.walDirname, fileTypeLog, newLogNum)
+		newLogName := base.MakeFilepath(opts.FS, d.walDirname, fileTypeLog, newLogNum)
 		d.mu.log.queue = append(d.mu.log.queue, fileInfo{fileNum: newLogNum, fileSize: 0})
 		logFile, err := opts.FS.Create(newLogName)
 		if err != nil {
@@ -400,8 +400,8 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	if !d.opts.ReadOnly {
 		// Write the current options to disk.
 		d.optionsFileNum = d.mu.versions.getNextFileNum()
-		tmpPath := base.MakeFilename(opts.FS, dirname, fileTypeTemp, d.optionsFileNum)
-		optionsPath := base.MakeFilename(opts.FS, dirname, fileTypeOptions, d.optionsFileNum)
+		tmpPath := base.MakeFilepath(opts.FS, dirname, fileTypeTemp, d.optionsFileNum)
+		optionsPath := base.MakeFilepath(opts.FS, dirname, fileTypeOptions, d.optionsFileNum)
 
 		// Write them to a temporary file first, in case we crash before
 		// we're done. A corrupt options file prevents opening the
@@ -740,7 +740,7 @@ func Peek(dirname string, fs vfs.FS) (*DBDesc, error) {
 		FormatMajorVersion: vers,
 	}
 	if exists {
-		desc.ManifestFilename = base.MakeFilename(fs, dirname, fileTypeManifest, manifestFileNum)
+		desc.ManifestFilename = base.MakeFilepath(fs, dirname, fileTypeManifest, manifestFileNum)
 	}
 	return desc, nil
 }

--- a/table_cache.go
+++ b/table_cache.go
@@ -59,8 +59,8 @@ type tableCacheContainer struct {
 // newTableCacheContainer will panic if the underlying cache in the table cache
 // doesn't match Options.Cache.
 func newTableCacheContainer(
-	tc *TableCache, cacheID uint64, dirname string,
-	fs vfs.FS, opts *Options, size int) *tableCacheContainer {
+	tc *TableCache, cacheID uint64, dirname string, fs vfs.FS, opts *Options, size int,
+) *tableCacheContainer {
 	// We will release a ref to table cache acquired here when tableCacheContainer.close is called.
 	if tc != nil {
 		if tc.cache != opts.Cache {
@@ -290,8 +290,7 @@ func (c *tableCacheShard) releaseLoop() {
 }
 
 func (c *tableCacheShard) newIters(
-	file *manifest.FileMetadata, opts *IterOptions, bytesIterated *uint64,
-	dbOpts *tableCacheOpts,
+	file *manifest.FileMetadata, opts *IterOptions, bytesIterated *uint64, dbOpts *tableCacheOpts,
 ) (internalIterator, internalIterator, error) {
 	// Calling findNode gives us the responsibility of decrementing v's
 	// refCount. If opening the underlying table resulted in error, then we
@@ -350,7 +349,9 @@ func (c *tableCacheShard) newIters(
 }
 
 // getTableProperties return sst table properties for target file
-func (c *tableCacheShard) getTableProperties(file *fileMetadata, dbOpts *tableCacheOpts) (*sstable.Properties, error) {
+func (c *tableCacheShard) getTableProperties(
+	file *fileMetadata, dbOpts *tableCacheOpts,
+) (*sstable.Properties, error) {
 	// Calling findNode gives us the responsibility of decrementing v's refCount here
 	v := c.findNode(file, dbOpts)
 	defer c.unrefValue(v)
@@ -737,7 +738,7 @@ type tableCacheValue struct {
 func (v *tableCacheValue) load(meta *fileMetadata, c *tableCacheShard, dbOpts *tableCacheOpts) {
 	// Try opening the fileTypeTable first.
 	var f vfs.File
-	v.filename = base.MakeFilename(dbOpts.fs, dbOpts.dirname, fileTypeTable, meta.FileNum)
+	v.filename = base.MakeFilepath(dbOpts.fs, dbOpts.dirname, fileTypeTable, meta.FileNum)
 	f, v.err = dbOpts.fs.Open(v.filename, vfs.RandomReadsOption)
 	if v.err == nil {
 		cacheOpts := private.SSTableCacheOpts(dbOpts.cacheID, meta.FileNum).(sstable.ReaderOption)

--- a/tool/db.go
+++ b/tool/db.go
@@ -626,7 +626,7 @@ func (p *props) update(o props) {
 }
 
 func (d *dbT) addProps(dir string, m *manifest.FileMetadata, p *props) error {
-	path := base.MakeFilename(d.opts.FS, dir, base.FileTypeTable, m.FileNum)
+	path := base.MakeFilepath(d.opts.FS, dir, base.FileTypeTable, m.FileNum)
 	f, err := d.opts.FS.Open(path)
 	if err != nil {
 		return err

--- a/version_set.go
+++ b/version_set.go
@@ -177,7 +177,7 @@ func (vs *versionSet) create(
 
 	vs.opts.EventListener.ManifestCreated(ManifestCreateInfo{
 		JobID:   jobID,
-		Path:    base.MakeFilename(vs.fs, vs.dirname, fileTypeManifest, vs.manifestFileNum),
+		Path:    base.MakeFilepath(vs.fs, vs.dirname, fileTypeManifest, vs.manifestFileNum),
 		FileNum: vs.manifestFileNum,
 		Err:     err,
 	})
@@ -199,7 +199,7 @@ func (vs *versionSet) load(
 	vs.init(dirname, opts, marker, setCurrent, mu)
 
 	vs.manifestFileNum = manifestFileNum
-	manifestPath := base.MakeFilename(opts.FS, dirname, fileTypeManifest, vs.manifestFileNum)
+	manifestPath := base.MakeFilepath(opts.FS, dirname, fileTypeManifest, vs.manifestFileNum)
 	manifestFilename := opts.FS.PathBase(manifestPath)
 
 	// Read the versionEdits in the manifest file.
@@ -424,7 +424,7 @@ func (vs *versionSet) logAndApply(
 			if err := vs.createManifest(vs.dirname, newManifestFileNum, minUnflushedLogNum, nextFileNum); err != nil {
 				vs.opts.EventListener.ManifestCreated(ManifestCreateInfo{
 					JobID:   jobID,
-					Path:    base.MakeFilename(vs.fs, vs.dirname, fileTypeManifest, newManifestFileNum),
+					Path:    base.MakeFilepath(vs.fs, vs.dirname, fileTypeManifest, newManifestFileNum),
 					FileNum: newManifestFileNum,
 					Err:     err,
 				})
@@ -461,7 +461,7 @@ func (vs *versionSet) logAndApply(
 			}
 			vs.opts.EventListener.ManifestCreated(ManifestCreateInfo{
 				JobID:   jobID,
-				Path:    base.MakeFilename(vs.fs, vs.dirname, fileTypeManifest, newManifestFileNum),
+				Path:    base.MakeFilepath(vs.fs, vs.dirname, fileTypeManifest, newManifestFileNum),
 				FileNum: newManifestFileNum,
 			})
 		}
@@ -566,7 +566,7 @@ func (vs *versionSet) createManifest(
 	dirname string, fileNum, minUnflushedLogNum, nextFileNum FileNum,
 ) (err error) {
 	var (
-		filename     = base.MakeFilename(vs.fs, dirname, fileTypeManifest, fileNum)
+		filename     = base.MakeFilepath(vs.fs, dirname, fileTypeManifest, fileNum)
 		manifestFile vfs.File
 		manifest     *record.Writer
 	)
@@ -722,11 +722,7 @@ func setCurrentFunc(
 
 func setCurrentFuncMarker(marker *atomicfs.Marker, fs vfs.FS, dirname string) func(FileNum) error {
 	return func(manifestFileNum FileNum) error {
-		path := base.MakeFilename(fs, dirname, fileTypeManifest, manifestFileNum)
-		// TODO(jackson): Refactor MakeFilename to return just the base
-		// and add MakePath for constructing the dirname-prefixed path.
-		filename := fs.PathBase(path)
-		return marker.Move(filename)
+		return marker.Move(base.MakeFilename(fileTypeManifest, manifestFileNum))
 	}
 }
 
@@ -776,7 +772,7 @@ func findCurrentManifest(
 
 func readCurrentFile(fs vfs.FS, dirname string) (FileNum, error) {
 	// Read the CURRENT file to find the current manifest file.
-	current, err := fs.Open(base.MakeFilename(fs, dirname, fileTypeCurrent, 0))
+	current, err := fs.Open(base.MakeFilepath(fs, dirname, fileTypeCurrent, 0))
 	if err != nil {
 		return 0, errors.Wrapf(err, "pebble: could not open CURRENT file for DB %q", dirname)
 	}


### PR DESCRIPTION
Split the MakeFilename utility into two variants, one that returns just
the base filename and one that returns the dirname-prefixed filepath.