### PR TITLE
pebble: make tableCacheOpts read-only

### DIFF
--- a/table_cache.go
+++ b/table_cache.go
@@ -30,12 +30,17 @@ var tableCacheLabels = pprof.Labels("pebble", "table-cache")
 // tableCacheOpts contains the db specific fields
 // of a table cache. This is stored in the tableCacheContainer
 // along with the table cache.
+// NB: It is important to make sure that the fields in this
+// struct are read-only. Since the fields here are shared
+// by every single tableCacheShard, if non read-only fields
+// are updated, we could have unnecessary evictions of those
+// fields, and the surrounding fields from the CPU caches.
 type tableCacheOpts struct {
 	atomic struct {
 		// iterCount in the tableCacheOpts keeps track of iterators
 		// opened or closed by a DB. It's used to keep track of
 		// leaked iterators on a per-db level.
-		iterCount int32
+		iterCount *int32
 	}
 
 	logger        Logger
@@ -43,7 +48,7 @@ type tableCacheOpts struct {
 	dirname       string
 	fs            vfs.FS
 	opts          sstable.ReaderOptions
-	filterMetrics FilterMetrics
+	filterMetrics *FilterMetrics
 }
 
 // tableCacheContainer contains the table cache and
@@ -80,6 +85,8 @@ func newTableCacheContainer(
 	t.dbOpts.dirname = dirname
 	t.dbOpts.fs = fs
 	t.dbOpts.opts = opts.MakeReaderOptions()
+	t.dbOpts.filterMetrics = &FilterMetrics{}
+	t.dbOpts.atomic.iterCount = new(int32)
 	return t
 }
 
@@ -90,7 +97,7 @@ func (c *tableCacheContainer) close() error {
 	// by the DB using this container. Note that we'll still perform cleanup
 	// below in the case that there are leaked iterators.
 	var err error
-	if v := atomic.LoadInt32(&c.dbOpts.atomic.iterCount); v > 0 {
+	if v := atomic.LoadInt32(c.dbOpts.atomic.iterCount); v > 0 {
 		err = errors.Errorf("leaked iterators: %d", errors.Safe(v))
 	}
 
@@ -147,7 +154,7 @@ func (c *tableCacheContainer) withReader(meta *fileMetadata, fn func(*sstable.Re
 }
 
 func (c *tableCacheContainer) iterCount() int64 {
-	return int64(atomic.LoadInt32(&c.dbOpts.atomic.iterCount))
+	return int64(atomic.LoadInt32(c.dbOpts.atomic.iterCount))
 }
 
 // TableCache is a shareable cache for open sstables.
@@ -328,7 +335,7 @@ func (c *tableCacheShard) newIters(
 	iter.SetCloseHook(v.closeHook)
 
 	atomic.AddInt32(&c.atomic.iterCount, 1)
-	atomic.AddInt32(&dbOpts.atomic.iterCount, 1)
+	atomic.AddInt32(dbOpts.atomic.iterCount, 1)
 	if invariants.RaceEnabled {
 		c.mu.Lock()
 		c.mu.iters[iter] = debug.Stack()
@@ -502,7 +509,7 @@ func (c *tableCacheShard) findNode(meta *fileMetadata, dbOpts *tableCacheOpts) *
 		}
 		c.unrefValue(v)
 		atomic.AddInt32(&c.atomic.iterCount, -1)
-		atomic.AddInt32(&dbOpts.atomic.iterCount, -1)
+		atomic.AddInt32(dbOpts.atomic.iterCount, -1)
 		return nil
 	}
 	n.value = v
@@ -742,7 +749,7 @@ func (v *tableCacheValue) load(meta *fileMetadata, c *tableCacheShard, dbOpts *t
 	if v.err == nil {
 		cacheOpts := private.SSTableCacheOpts(dbOpts.cacheID, meta.FileNum).(sstable.ReaderOption)
 		reopenOpt := sstable.FileReopenOpt{FS: dbOpts.fs, Filename: v.filename}
-		v.reader, v.err = sstable.NewReader(f, dbOpts.opts, cacheOpts, &dbOpts.filterMetrics, reopenOpt)
+		v.reader, v.err = sstable.NewReader(f, dbOpts.opts, cacheOpts, dbOpts.filterMetrics, reopenOpt)
 	}
 	if v.err == nil {
 		if meta.SmallestSeqNum == meta.LargestSeqNum {


### PR DESCRIPTION
I see a small performance win with this pr, when I compare it to master.
tableCacheOpts is shared by every single shard. The theory is that
constant updates to the fields in the tableCacheOpts was causing those
fields, and the surrounding fields to be evicted from the CPU caches,
which was causing a slowdown compared to the table cache performance
before the shared table cache was introduced. When the table cache
was not shared, the fields in the tableCacheOpts weren't shared either.

```
arjunnair@Arjuns-MacBook-Pro abh % benchstat stat_master stat_tc
name              old ops/sec  new ops/sec  delta
ycsb/B/values=64    809k ± 4%    852k ± 7%  +5.28%  (p=0.000 n=9+10)

name              old read     new read     delta
ycsb/B/values=64   27.5G ±16%   27.8G ±16%    ~     (p=0.780 n=9+10)

name              old write    new write    delta
ycsb/B/values=64   30.6G ±14%   31.0G ±15%    ~     (p=0.780 n=9+10)

name              old r-amp    new r-amp    delta
ycsb/B/values=64    3.75 ± 2%    3.74 ± 2%    ~     (p=0.920 n=9+10)

name              old w-amp    new w-amp    delta
ycsb/B/values=64    9.87 ±23%    9.84 ±12%    ~     (p=0.593 n=10+10)
```