### PR TITLE
db: clarify global seqnum comment within Ingest

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -585,8 +585,10 @@ func (d *DB) Ingest(paths []string) error {
 			return
 		}
 
-		// Update the sequence number for all of the sstables, both in the metadata
-		// and the global sequence number property on disk.
+		// Update the sequence number for all of the sstables in the
+		// metadata. Writing the metadata to the manifest when the
+		// version edit is applied is the mechanism that persists the
+		// sequence number. The sstables themselves are left unmodified.
 		if err = ingestUpdateSeqNum(d.opts, d.dirname, seqNum, meta); err != nil {
 			return
 		}


### PR DESCRIPTION
Ingested sstables have all-zero sequence numbers. A sequence number
isn't assigned to the ingested sstables until during Ingest. The
sequence number assigned is persisted by updating the file metadata that
is written to the manifest. When an ingested sstable must be read, the
reader detects that the smallest sequence number equals the largest
sequence number and on-the-fly rewrites the sstable's keys to that
sequence number.

This comment has confused me for a while. It suggests that
`ingestUpdateSeqNum` updates the ingested sstables' properties to record
the assigned sequence number. There is a global sequence number
property, but it's never updated on-disk. Instead, its value is replaced
in-memory when the sstable metadata's smallest and largest sequence
numbers are equal.