### PR TITLE
crl-release-21.2: db: set smallest / largest keys for elision-only compactions

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1115,6 +1115,7 @@ func (p *compactionPickerByScore) pickElisionOnlyCompaction(
 	if isCompacting {
 		return nil
 	}
+	pc.smallest, pc.largest = manifest.KeyRange(pc.cmp, pc.startLevel.files.Iter())
 	// Fail-safe to protect against compacting the same sstable concurrently.
 	if !inputRangeAlreadyCompacting(env, pc) {
 		return pc

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1669,7 +1669,6 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 						},
 					},
 				}
-				opts.private.disableTableStats = true
 				var err error
 				d, err = runDBDefineCmd(td, opts)
 				if err != nil {
@@ -1685,7 +1684,21 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 				d.mu.Unlock()
 				return s
 
+			// TODO(travers): Rather than setting hints manually, rely on the
+			// code itself to generate the hints, and instead assert in tests
+			// that the hints are as expected. However, this directive still
+			// needs to allow for hints to be forcibly added.
 			case "set-hints":
+				force := false
+				for _, arg := range td.CmdArgs {
+					switch arg.Key {
+					case "force":
+						force, _ = strconv.ParseBool(arg.Vals[0])
+					default:
+						return fmt.Sprintf("%s: unknown arg: %s", td.Cmd, arg.Key)
+					}
+				}
+
 				d.mu.Lock()
 				defer d.mu.Unlock()
 				d.mu.compact.deletionHints = d.mu.compact.deletionHints[:0]
@@ -1698,18 +1711,27 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 
 					var tombstoneFile *fileMetadata
 					tombstoneLevel := int(parseUint64(parts[0][1:]))
-					// Find the file in the current version.
-					v := d.mu.versions.currentVersion()
-					overlaps := v.Overlaps(tombstoneLevel, d.opts.Comparer.Compare, start, end)
-					iter := overlaps.Iter()
-					for m := iter.First(); m != nil; m = iter.Next() {
-						if m.FileNum.String() == parts[1] {
-							tombstoneFile = m
+
+					if !force {
+						// Find the file in the current version.
+						v := d.mu.versions.currentVersion()
+						overlaps := v.Overlaps(tombstoneLevel, d.opts.Comparer.Compare, start, end)
+						iter := overlaps.Iter()
+						for m := iter.First(); m != nil; m = iter.Next() {
+							if m.FileNum.String() == parts[1] {
+								tombstoneFile = m
+							}
+						}
+					} else {
+						// Set file number to the value provided in the input.
+						tombstoneFile = &fileMetadata{
+							FileNum: base.FileNum(parseUint64(parts[1])),
 						}
 					}
+
 					h := deleteCompactionHint{
-						start:                   []byte(parts[2]),
-						end:                     []byte(parts[3]),
+						start:                   start,
+						end:                     end,
 						fileSmallestSeqNum:      parseUint64(parts[4]),
 						tombstoneLevel:          tombstoneLevel,
 						tombstoneFile:           tombstoneFile,
@@ -1719,6 +1741,21 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 					d.mu.compact.deletionHints = append(d.mu.compact.deletionHints, h)
 					fmt.Fprintln(&buf, h.String())
 				}
+				return buf.String()
+
+			case "get-hints":
+				var buf bytes.Buffer
+				d.mu.Lock()
+				defer d.mu.Unlock()
+
+				hints := d.mu.compact.deletionHints
+				if len(hints) == 0 {
+					return "(none)"
+				}
+				for _, h := range hints {
+					buf.WriteString(h.String() + "\n")
+				}
+
 				return buf.String()
 
 			case "maybe-compact":
@@ -1757,6 +1794,59 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 				s := d.mu.versions.currentVersion().DebugString(base.DefaultFormatter)
 				d.mu.Unlock()
 				return s
+
+			case "close-snapshot":
+				seqNum, err := strconv.ParseUint(strings.TrimSpace(td.Input), 0, 64)
+				if err != nil {
+					return err.Error()
+				}
+				d.mu.Lock()
+				var s *Snapshot
+				l := &d.mu.snapshots
+				for i := l.root.next; i != &l.root; i = i.next {
+					if i.seqNum == seqNum {
+						s = i
+					}
+				}
+				d.mu.Unlock()
+				if s == nil {
+					return "(not found)"
+				} else if err := s.Close(); err != nil {
+					return err.Error()
+				}
+
+				compactionString := func() string {
+					for d.mu.compact.compactingCount > 0 {
+						d.mu.compact.cond.Wait()
+					}
+
+					s := "(none)"
+					if compactInfo != nil {
+						// JobID's aren't deterministic, especially w/ table stats
+						// enabled. Use a fixed job ID for data-driven test output.
+						compactInfo.JobID = 100
+						s = compactInfo.String()
+						compactInfo = nil
+					}
+					return s
+				}
+
+				d.mu.Lock()
+				// Closing the snapshot may have triggered a compaction.
+				str := compactionString()
+				d.mu.Unlock()
+				return str
+
+			case "wait-pending-table-stats":
+				return runTableStatsCmd(td, d)
+
+			case "iter":
+				snap := Snapshot{
+					db:     d,
+					seqNum: InternalKeySeqNumMax,
+				}
+				iter := snap.NewIter(nil)
+				return runIterCmd(td, iter, true)
 
 			default:
 				return fmt.Sprintf("unknown command: %s", td.Cmd)

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -169,3 +169,83 @@ Deletion hints:
   (none)
 Compactions:
   (none)
+
+# A deletion hint present on an sstable in a higher level should NOT result in a
+# deletion-only compaction incorrectly removing an sstable in L6 following an
+# elision-only compaction that zeroes the sequence numbers in an L6 table.
+#
+# This is a regression test for pebble#1285.
+
+# Create an sstable at L6. We expect that the SET survives the following
+# sequence of compactions.
+define snapshots=(10, 25)
+L6
+a.SET.20:b a.RANGEDEL.15:z
+----
+6:
+  000004:[a#20,SET-z#72057594037927935,RANGEDEL]
+
+# Place a compaction hint on a non-existent table in a higher level in the LSM.
+#
+# The selection of the sequence numbers for the hints is nuanced, and warrants
+# some explanation. The largest tombstone sequence number (27) and file smallest
+# sequence number (0) were chosen such that they fall into different snapshot
+# stripes, which ensures the hint is not resolved and dropped. The deletion
+# range 5-27 is also chosen such that it covers the sequence number range from
+# the table, i.e. 15-20, which *appears* to make the keys eligible for deletion.
+set-hints force=true
+L0.000001 a-z 0 5-27
+----
+L0.000001 a-z seqnums(tombstone=5-27, file-smallest=0)
+
+# Populate stats on the table. Without stats on the table, an elision-only
+# compaction cannot take place.
+wait-pending-table-stats
+000004
+----
+num-entries: 2
+num-deletions: 1
+point-deletions-bytes-estimate: 0
+range-deletions-bytes-estimate: 26
+
+# Hints on the table are unchanged, as the new sstable is at L6, and hints are
+# not generated on tables at this level.
+get-hints
+----
+L0.000001 a-z seqnums(tombstone=5-27, file-smallest=0)
+
+# Closing snapshot 10 triggers an elision-only compaction in L6, as the earliest
+# snapshot that remains open is 25, and this is greater than the largest
+# sequence number present in the L6 sstable (i.e. 20).
+close-snapshot
+10
+----
+[JOB 100] compacted(elision-only) L6 [000004] (850 B) + L6 [] (0 B) -> L6 [000005] (771 B), in 1.0s, output rate 771 B/s
+
+# The deletion hint was removed by the elision-only compaction.
+get-hints
+----
+(none)
+
+# The LSM contains the key, as expected.
+iter
+first
+next
+----
+a:b
+.
+
+# Closing the next snapshot should NOT trigger another compaction, as the
+# deletion hint was removed in the elision-only compaction.
+close-snapshot
+25
+----
+(none)
+
+# The key remains in the LSM.
+iter
+first
+next
+----
+a:b
+.


### PR DESCRIPTION
This is a backport of #1293.

---

Currently, when an elision-only compaction is picked, the smallest /
largest keys on the `pickedCompaction` struct are not set. This can
result in a situation where deletion hints are not correctly removed.

This in turn can result in entries being incorrectly removed from L6
sstables when the elided sequence numbers cause a compaction hint to be
retained (as `h.start` is always compares as greater-than the nil struct
for the smallest user key in the picked compaction).

Set the smallest and largest key on an elision-only `pickedCompaction`.

Add an additional data-driven test to guard against regression.

Fixes #1285.

Informs #1298.