### PR TITLE
crl-release-20.2: Fixing linting issues

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -670,7 +670,7 @@ func TestFlushableBatch(t *testing.T) {
 
 		case "dump":
 			if len(d.CmdArgs) != 1 || len(d.CmdArgs[0].Vals) != 1 || d.CmdArgs[0].Key != "seq" {
-				return fmt.Sprintf("dump seq=<value>\n")
+				return "dump seq=<value>\n"
 			}
 			seqNum, err := strconv.Atoi(d.CmdArgs[0].Vals[0])
 			if err != nil {

--- a/cmd/pebble/compact.go
+++ b/cmd/pebble/compact.go
@@ -344,7 +344,6 @@ func runReplay(cmd *cobra.Command, args []string) error {
 		select {
 		case <-time.After(time.Second):
 			quiesced = true
-			break
 		case <-waiterCh:
 			continue
 		}
@@ -377,7 +376,7 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 	fmt.Printf("__elapsed__compacts__w-amp__r-amp(_p50__p95__p99__max_)__space(_____amp__stable___final__average__)\n")
 	fmt.Printf("  %6.2fm  %8d  %5.2f         %3d  %3d  %3d  %3d         %9.2f  %6s  %6s  %7s\n",
-		time.Now().Sub(start).Minutes(),
+		time.Since(start).Minutes(),
 		m.Compact.Count,
 		totalWriteAmp(m),
 		rampHist.ValueAtQuantile(50),

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -856,7 +856,7 @@ func TestPickedCompactionSetupInputs(t *testing.T) {
 			switch d.Cmd {
 			case "setup-inputs":
 				if len(d.CmdArgs) != 2 {
-					return fmt.Sprintf("setup-inputs <start> <end>")
+					return "setup-inputs <start> <end>"
 				}
 
 				pc := &pickedCompaction{
@@ -886,7 +886,7 @@ func TestPickedCompactionSetupInputs(t *testing.T) {
 							pc.outputLevel.level = level
 							currentLevel = level
 						} else {
-							return fmt.Sprintf("outputLevel already set\n")
+							return "outputLevel already set\n"
 						}
 
 					default:

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1968,7 +1968,7 @@ func TestCompactionCheckOrdering(t *testing.T) {
 							c.outputLevel.level = level
 							files = &outputFiles
 						} else {
-							return fmt.Sprintf("outputLevel already set\n")
+							return "outputLevel already set\n"
 						}
 
 					default:

--- a/flushable.go
+++ b/flushable.go
@@ -68,7 +68,7 @@ func (e *flushableEntry) readerUnref() {
 		panic(fmt.Sprintf("pebble: inconsistent reference count: %d", v))
 	case v == 0:
 		if e.releaseMemAccounting == nil {
-			panic(fmt.Sprintf("pebble: memtable reservation already released"))
+			panic("pebble: memtable reservation already released")
 		}
 		e.releaseMemAccounting()
 		e.releaseMemAccounting = nil

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/exp v0.0.0-20200513190911-00229845015e
+	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/sys v0.0.0-20200519105757-fe76b779f299
 )
 

--- a/internal/arenaskl/arena.go
+++ b/internal/arenaskl/arena.go
@@ -83,7 +83,7 @@ func (a *Arena) alloc(size, align, overflow uint32) (uint32, uint32, error) {
 	}
 
 	// Return the aligned offset.
-	offset := (uint32(newSize) - padded + uint32(align)) & ^uint32(align)
+	offset := (uint32(newSize) - padded + align) & ^align
 	return offset, padded, nil
 }
 

--- a/internal/arenaskl/node.go
+++ b/internal/arenaskl/node.go
@@ -98,7 +98,7 @@ func newRawNode(arena *Arena, height uint32, keySize, valueSize uint32) (nd *nod
 
 	nd = (*node)(arena.getPointer(nodeOffset))
 	nd.keyOffset = nodeOffset + nodeSize
-	nd.keySize = uint32(keySize)
+	nd.keySize = keySize
 	nd.valueSize = valueIndex
 	nd.allocSize = allocSize
 	return

--- a/internal/base/comparer.go
+++ b/internal/base/comparer.go
@@ -212,8 +212,8 @@ func (p FormatBytes) Format(s fmt.State, c rune) {
 			continue
 		}
 		buf = append(buf, `\x`...)
-		buf = append(buf, lowerhex[byte(b)>>4])
-		buf = append(buf, lowerhex[byte(b)&0xF])
+		buf = append(buf, lowerhex[b>>4])
+		buf = append(buf, lowerhex[b&0xF])
 	}
 	s.Write(buf)
 }

--- a/internal/base/filenames.go
+++ b/internal/base/filenames.go
@@ -6,10 +6,10 @@ package base
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
+	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/redact"
 )
@@ -119,7 +119,7 @@ type Fataler interface {
 // with counts of the various types of files and invokes the provided fataler.
 // See cockroachdb/cockroach#56490.
 func MustExist(fs vfs.FS, filename string, fataler Fataler, err error) {
-	if err == nil || !os.IsNotExist(err) {
+	if err == nil || !oserror.IsNotExist(err) {
 		return
 	}
 

--- a/internal/cache/robin_hood_test.go
+++ b/internal/cache/robin_hood_test.go
@@ -50,7 +50,7 @@ func TestRobinHoodMap(t *testing.T) {
 			e := &entry{}
 			goMap[k] = e
 			rhMap.Put(k, e)
-			if len(goMap) != int(rhMap.Count()) {
+			if len(goMap) != rhMap.Count() {
 				t.Fatalf("map sizes differ: %d != %d", len(goMap), rhMap.Count())
 			}
 
@@ -60,7 +60,7 @@ func TestRobinHoodMap(t *testing.T) {
 			e := &entry{}
 			goMap[k] = e
 			rhMap.Put(k, e)
-			if len(goMap) != int(rhMap.Count()) {
+			if len(goMap) != rhMap.Count() {
 				t.Fatalf("map sizes differ: %d != %d", len(goMap), rhMap.Count())
 			}
 
@@ -69,7 +69,7 @@ func TestRobinHoodMap(t *testing.T) {
 			k := randomKey()
 			delete(goMap, k)
 			rhMap.Delete(k)
-			if len(goMap) != int(rhMap.Count()) {
+			if len(goMap) != rhMap.Count() {
 				t.Fatalf("map sizes differ: %d != %d", len(goMap), rhMap.Count())
 			}
 

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -1097,14 +1097,14 @@ func (s *L0Sublevels) extendFiles(
 func (s *L0Sublevels) PickIntraL0Compaction(
 	earliestUnflushedSeqNum uint64, minCompactionDepth int,
 ) (*L0CompactionFiles, error) {
-	var scoredIntervals []intervalAndScore
+	scoredIntervals := make([]intervalAndScore, len(s.orderedIntervals))
 	for i := range s.orderedIntervals {
 		interval := &s.orderedIntervals[i]
 		depth := interval.fileCount - interval.compactingFileCount
 		if minCompactionDepth > depth {
 			continue
 		}
-		scoredIntervals = append(scoredIntervals, intervalAndScore{interval: i, score: depth})
+		scoredIntervals[i] = intervalAndScore{interval: i, score: depth}
 	}
 	sort.Sort(intervalSorterByDecreasingScore(scoredIntervals))
 

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -157,7 +157,7 @@ func (o *flushOp) run(t *test, h *history) {
 }
 
 func (o *flushOp) String() string {
-	return fmt.Sprintf("db.Flush()")
+	return "db.Flush()"
 }
 
 // mergeOp models a Write.Merge operation.
@@ -689,7 +689,7 @@ func (o *dbRestartOp) run(t *test, h *history) {
 }
 
 func (o *dbRestartOp) String() string {
-	return fmt.Sprintf("db.Restart()")
+	return "db.Restart()"
 }
 
 func formatOps(ops []op) string {

--- a/internal/pacertoy/pebble/main.go
+++ b/internal/pacertoy/pebble/main.go
@@ -392,45 +392,43 @@ func main() {
 	var lastFill, lastDrain int64
 
 	for i := 0; ; i++ {
-		select {
-		case <-tick.C:
-			if (i % 20) == 0 {
-				fmt.Printf("_elapsed___memtbs____dirty_____fill____drain____cdebt__l0count___max-f-rate\n")
-			}
-
-			if (i % 7) == 0 {
-				//db.printLevels()
-			}
-
-			db.mu.Lock()
-			memtableCount := len(db.memtables)
-			db.mu.Unlock()
-			dirty := atomic.LoadInt64(&db.flushPacer.level)
-			fill := atomic.LoadInt64(&db.fill)
-			drain := atomic.LoadInt64(&db.drain)
-
-			db.compactionMu.Lock()
-			compactionL0 := len(db.L0)
-			db.compactionMu.Unlock()
-			totalCompactionBytes := atomic.LoadInt64(&db.compactionPacer.level)
-			compactionDebt := math.Max(float64(totalCompactionBytes)-l0CompactionThreshold*memtableSize, 0.0)
-			maxFlushRate := db.flushPacer.maxDrainer.Limit()
-
-			now := time.Now()
-			elapsed := now.Sub(lastNow).Seconds()
-			fmt.Printf("%8s %8d %8.1f %8.1f %8.1f %8.1f %8d %12.1f\n",
-				time.Duration(now.Sub(start).Seconds()+0.5)*time.Second,
-				memtableCount,
-				float64(dirty)/(1024.0*1024.0),
-				float64(fill-lastFill)/(1024.0*1024.0*elapsed),
-				float64(drain-lastDrain)/(1024.0*1024.0*elapsed),
-				compactionDebt/(1024.0*1024.0),
-				compactionL0,
-				maxFlushRate/(1024.0*1024.0))
-
-			lastNow = now
-			lastFill = fill
-			lastDrain = drain
+		<-tick.C
+		if (i % 20) == 0 {
+			fmt.Printf("_elapsed___memtbs____dirty_____fill____drain____cdebt__l0count___max-f-rate\n")
 		}
+
+		if (i % 7) == 0 {
+			//db.printLevels()
+		}
+
+		db.mu.Lock()
+		memtableCount := len(db.memtables)
+		db.mu.Unlock()
+		dirty := atomic.LoadInt64(&db.flushPacer.level)
+		fill := atomic.LoadInt64(&db.fill)
+		drain := atomic.LoadInt64(&db.drain)
+
+		db.compactionMu.Lock()
+		compactionL0 := len(db.L0)
+		db.compactionMu.Unlock()
+		totalCompactionBytes := atomic.LoadInt64(&db.compactionPacer.level)
+		compactionDebt := math.Max(float64(totalCompactionBytes)-l0CompactionThreshold*memtableSize, 0.0)
+		maxFlushRate := db.flushPacer.maxDrainer.Limit()
+
+		now := time.Now()
+		elapsed := now.Sub(lastNow).Seconds()
+		fmt.Printf("%8s %8d %8.1f %8.1f %8.1f %8.1f %8d %12.1f\n",
+			time.Duration(now.Sub(start).Seconds()+0.5)*time.Second,
+			memtableCount,
+			float64(dirty)/(1024.0*1024.0),
+			float64(fill-lastFill)/(1024.0*1024.0*elapsed),
+			float64(drain-lastDrain)/(1024.0*1024.0*elapsed),
+			compactionDebt/(1024.0*1024.0),
+			compactionL0,
+			maxFlushRate/(1024.0*1024.0))
+
+		lastNow = now
+		lastFill = fill
+		lastDrain = drain
 	}
 }

--- a/internal/pacertoy/rocksdb/main.go
+++ b/internal/pacertoy/rocksdb/main.go
@@ -355,45 +355,43 @@ func main() {
 	var lastFill, lastDrain int64
 
 	for i := 0; ; i++ {
-		select {
-		case <-tick.C:
-			if (i % 20) == 0 {
-				fmt.Printf("_elapsed___memtbs____dirty_____fill____drain____cdebt__l0count___max-w-rate\n")
-			}
-
-			if (i % 7) == 0 {
-				//db.printLevels()
-			}
-
-			db.mu.Lock()
-			memtableCount := len(db.memtables)
-			db.mu.Unlock()
-			dirty := atomic.LoadInt64(&db.flushPacer.level)
-			fill := atomic.LoadInt64(&db.fill)
-			drain := atomic.LoadInt64(&db.drain)
-
-			db.compactionMu.Lock()
-			compactionL0 := len(db.L0)
-			db.compactionMu.Unlock()
-			totalCompactionBytes := atomic.LoadInt64(&db.compactionPacer.level)
-			compactionDebt := math.Max(float64(totalCompactionBytes)-l0CompactionThreshold*memtableSize, 0.0)
-			maxWriteRate := db.writeLimiter.Limit()
-
-			now := time.Now()
-			elapsed := now.Sub(lastNow).Seconds()
-			fmt.Printf("%8s %8d %8.1f %8.1f %8.1f %8.1f %8d %12.1f\n",
-				time.Duration(now.Sub(start).Seconds()+0.5)*time.Second,
-				memtableCount,
-				float64(dirty)/(1024.0*1024.0),
-				float64(fill-lastFill)/(1024.0*1024.0*elapsed),
-				float64(drain-lastDrain)/(1024.0*1024.0*elapsed),
-				compactionDebt/(1024.0*1024.0),
-				compactionL0,
-				maxWriteRate/(1024.0*1024.0))
-
-			lastNow = now
-			lastFill = fill
-			lastDrain = drain
+		<-tick.C
+		if (i % 20) == 0 {
+			fmt.Printf("_elapsed___memtbs____dirty_____fill____drain____cdebt__l0count___max-w-rate\n")
 		}
+
+		if (i % 7) == 0 {
+			//db.printLevels()
+		}
+
+		db.mu.Lock()
+		memtableCount := len(db.memtables)
+		db.mu.Unlock()
+		dirty := atomic.LoadInt64(&db.flushPacer.level)
+		fill := atomic.LoadInt64(&db.fill)
+		drain := atomic.LoadInt64(&db.drain)
+
+		db.compactionMu.Lock()
+		compactionL0 := len(db.L0)
+		db.compactionMu.Unlock()
+		totalCompactionBytes := atomic.LoadInt64(&db.compactionPacer.level)
+		compactionDebt := math.Max(float64(totalCompactionBytes)-l0CompactionThreshold*memtableSize, 0.0)
+		maxWriteRate := db.writeLimiter.Limit()
+
+		now := time.Now()
+		elapsed := now.Sub(lastNow).Seconds()
+		fmt.Printf("%8s %8d %8.1f %8.1f %8.1f %8.1f %8d %12.1f\n",
+			time.Duration(now.Sub(start).Seconds()+0.5)*time.Second,
+			memtableCount,
+			float64(dirty)/(1024.0*1024.0),
+			float64(fill-lastFill)/(1024.0*1024.0*elapsed),
+			float64(drain-lastDrain)/(1024.0*1024.0*elapsed),
+			compactionDebt/(1024.0*1024.0),
+			compactionL0,
+			maxWriteRate/(1024.0*1024.0))
+
+		lastNow = now
+		lastFill = fill
+		lastDrain = drain
 	}
 }

--- a/internal/rangedel/iter_test.go
+++ b/internal/rangedel/iter_test.go
@@ -42,12 +42,12 @@ func TestIter(t *testing.T) {
 				switch parts[0] {
 				case "seek-ge":
 					if len(parts) != 2 {
-						return fmt.Sprintf("seek-ge <key>\n")
+						return "seek-ge <key>\n"
 					}
 					iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
 				case "seek-lt":
 					if len(parts) != 2 {
-						return fmt.Sprintf("seek-lt <key>\n")
+						return "seek-lt <key>\n"
 					}
 					iter.SeekLT([]byte(strings.TrimSpace(parts[1])))
 				case "first":

--- a/level_checker.go
+++ b/level_checker.go
@@ -423,8 +423,7 @@ func checkRangeTombstones(c *checkConfig) error {
 	}
 	// We now have truncated tombstones.
 	// Fragment them all.
-	var userKeys [][]byte
-	userKeys = collectAllUserKeys(c.cmp, tombstones)
+	userKeys := collectAllUserKeys(c.cmp, tombstones)
 	tombstones = fragmentUsingUserKeys(c.cmp, tombstones, userKeys)
 	return iterateAndCheckTombstones(c.cmp, c.formatKey, tombstones)
 }
@@ -502,7 +501,7 @@ func (v *userKeysSort) Swap(i, j int) {
 	v.buf[i], v.buf[j] = v.buf[j], v.buf[i]
 }
 func collectAllUserKeys(cmp Compare, tombstones []tombstoneWithLevel) [][]byte {
-	var keys [][]byte
+	keys := make([][]byte, 0, len(tombstones)*2)
 	for _, t := range tombstones {
 		keys = append(keys, t.Start.UserKey)
 		keys = append(keys, t.End)

--- a/metrics.go
+++ b/metrics.go
@@ -234,7 +234,7 @@ func (m *Metrics) formatWAL(buf *bytes.Buffer) {
 		writeAmp)
 }
 
-// Pretty-print the metrics, showing a line for the WAL, a line per-level, and
+// String pretty-prints the metrics, showing a line for the WAL, a line per-level, and
 // a total:
 //
 //   __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___w-amp

--- a/open_test.go
+++ b/open_test.go
@@ -562,7 +562,7 @@ func TestTwoWALReplayCorrupt(t *testing.T) {
 	t.Logf("zeored four bytes in %s at offset %d\n", logs[len(logs)-2], off)
 
 	// Re-opening the database should detect and report the corruption.
-	d, err = Open(dir, nil)
+	_, err = Open(dir, nil)
 	require.Error(t, err, "pebble: corruption")
 }
 

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -275,7 +275,7 @@ func (f footer) encode(buf []byte) []byte {
 			buf[i] = 0
 		}
 		n := encodeBlockHandle(buf[0:], f.metaindexBH)
-		n += encodeBlockHandle(buf[n:], f.indexBH)
+		encodeBlockHandle(buf[n:], f.indexBH)
 		copy(buf[len(buf)-len(levelDBMagic):], levelDBMagic)
 
 	case TableFormatRocksDBv2:
@@ -286,7 +286,7 @@ func (f footer) encode(buf []byte) []byte {
 		buf[0] = f.checksum
 		n := 1
 		n += encodeBlockHandle(buf[n:], f.metaindexBH)
-		n += encodeBlockHandle(buf[n:], f.indexBH)
+		encodeBlockHandle(buf[n:], f.indexBH)
 		binary.LittleEndian.PutUint32(buf[rocksDBVersionOffset:], rocksDBFormatVersion2)
 		copy(buf[len(buf)-len(rocksDBMagic):], rocksDBMagic)
 	}

--- a/tool/db.go
+++ b/tool/db.go
@@ -456,7 +456,7 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 }
 
 func propArgs(props []props, getProp func(*props) interface{}) []interface{} {
-	var args []interface{}
+	args := make([]interface{}, 0, len(props))
 	for _, p := range props {
 		args = append(args, getProp(&p))
 	}

--- a/vendor/golang.org/x/sync/AUTHORS
+++ b/vendor/golang.org/x/sync/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/sync/CONTRIBUTORS
+++ b/vendor/golang.org/x/sync/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,66 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"context"
+	"sync"
+)
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	errOnce sync.Once
+	err     error
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (g *Group) Go(f func() error) {
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}


### PR DESCRIPTION
This is a backport of #967 to 20.2, fixing the failing `TestLint` check.