### PR TITLE
crl-release-20.2: ci: enable CI for release branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,129 @@
+name: Test
+
+on:
+  push:
+    branches:
+    - master
+    - crl-release-*
+  pull_request:
+    branches:
+    - master
+    - crl-release-*
+
+jobs:
+
+  linux:
+    name: go${{ matrix.go }}-linux
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go:
+          - "1.15"
+          - "1.16"
+          - "1.17"
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up go${{ matrix.go }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go }}
+
+    - name: install golint
+      run: go get golang.org/x/lint/golint
+
+    - run: make test generate
+
+  linux-race:
+    name: go1.16-linux-race
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: "1.16"
+
+    - name: install golint
+      run: go get golang.org/x/lint/golint
+
+    - run: make testrace TAGS=
+
+  linux-no-invariants:
+    name: go1.16-linux-no-invariants
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: "1.16"
+
+    - name: install golint
+      run: go get golang.org/x/lint/golint
+
+    - run: make test TAGS=
+
+  linux-no-cgo:
+    name: go1.16-linux-no-cgo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: "1.16"
+
+    - name: install golint
+      run: go get golang.org/x/lint/golint
+
+    - run: CGO_ENABLED=0 make test TAGS=
+
+  darwin:
+    name: go1.16-macos
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: "1.16"
+
+    - name: install golint
+      run: go get golang.org/x/lint/golint
+
+    - run: make test
+
+  windows:
+    name: go1.16-windows
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: "1.16"
+
+    - run: go test -v ./...
+
+  freebsd:
+    name: go1.16-freebsd
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: "1.16"
+
+    - name: FreeBSD build
+      env:
+        GOOS: freebsd
+      run: go build -v ./...


### PR DESCRIPTION
Backport of #1304 to 20.2.

---

In order to increase confidence that backported changes to release
branches continue to compile and function as expected, enable CI on PRs
against, and and merges into release branches.