### PR TITLE
crl-release-21.2: ci: enable CI for release branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,13 @@ name: Test
 
 on:
   push:
-    branches: [ master ]
+    branches:
+    - master
+    - crl-release-*
   pull_request:
-    branches: [ master ]
+    branches:
+    - master
+    - crl-release-*
 
 jobs:
 


### PR DESCRIPTION
Backport of #1304 to 21.2.

---

In order to increase confidence that backported changes to release
branches continue to compile and function as expected, enable CI on PRs
against, and and merges into release branches.