### PR TITLE
crl-release-21.2: db: disable table stats by default in TestCompactionDeleteOnlyHints

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1669,6 +1669,11 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 						},
 					},
 				}
+
+				// Disable stats by default. This can be overridden with the
+				// 'enable-table-stats=true' option to the 'define' command.
+				opts.private.disableTableStats = true
+
 				var err error
 				d, err = runDBDefineCmd(td, opts)
 				if err != nil {

--- a/data_test.go
+++ b/data_test.go
@@ -444,6 +444,12 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 			default:
 				return nil, errors.Errorf("Unrecognized %q %q arg value: %q", td.Cmd, arg.Key, arg.Vals[0])
 			}
+		case "enable-table-stats":
+			enable, err := strconv.ParseBool(arg.Vals[0])
+			if err != nil {
+				return nil, errors.Errorf("%s: could not parse %q as bool: %s", td.Cmd, arg.Vals[0], err)
+			}
+			opts.private.disableTableStats = !enable
 		default:
 			return nil, errors.Errorf("%s: unknown arg: %s", td.Cmd, arg.Key)
 		}

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -177,8 +177,9 @@ Compactions:
 # This is a regression test for pebble#1285.
 
 # Create an sstable at L6. We expect that the SET survives the following
-# sequence of compactions.
-define snapshots=(10, 25)
+# sequence of compactions. Note that this test depends on stats being present on
+# the sstables, so we re-enable the off-by-default option.
+define snapshots=(10, 25) enable-table-stats=true
 L6
 a.SET.20:b a.RANGEDEL.15:z
 ----


### PR DESCRIPTION
This is a backport of #1305 for 21.2.

---

A previous PR, #1293, removed a DB option that disabled table stat
collection for `TestCompactionDeleteOnlyHints`. Without this option
disabled, the test becomes racy, given the way in which table stats are
collected asynchronously, and how deletion hints can be updated based on
these hints.

Add an option to `define`, `enable-table-stats` that allows a
data-driven test to set this value.

Bring back the explicit disabling of table stats, and selectively enable
for the test case that relies on the stats being present.