### PR TITLE
sstable: add suffix replacement block transform

### DIFF
--- a/sstable/options.go
+++ b/sstable/options.go
@@ -188,6 +188,31 @@ type WriterOptions struct {
 	// with the value stored in the sstable when it was written.
 	MergerName string
 
+	// SuffixPlaceholder enables key suffix replacement. When
+	// SuffixPlaceholder is set, Comparer.Split must be set as well.
+	// Suffix replacement only occurs within the suffix after the index
+	// returned by Split.  Additionally, a suffix placeholder prevents
+	// key sharing after the index returned by Split. It also causes the
+	// Writer to ignore the comparer's Successor and Separator
+	// implementations, using identity functions instead.
+	//
+	// The placeholder suffix must produce a valid key. Additionally the
+	// suffix must be unused and never used as a replacement suffix
+	// value.
+	//
+	// When a SuffixPlaceholder is set, all added keys must contain a a
+	// suffix exactly equal to the SuffixPlaceholder.  That is,
+	// k[Split(k)] must equal SuffixPlaceholder.
+	//
+	// When configured with a SuffixPlaceholder, Writer includes a
+	// SuffixReplacement table property indicating the placeholder and the
+	// intent to replace. A SSTable created with a non-empty SuffixPlaceholder
+	// cannot be read by Reader until modified by ReplaceSuffix to embed a
+	// replacement suffix.
+	//
+	// Range tombstones are not subject to suffix replacement.
+	SuffixPlaceholder []byte
+
 	// TableFormat specifies the format version for writing sstables. The default
 	// is TableFormatRocksDBv2 which creates RocksDB compatible sstables. Use
 	// TableFormatLevelDB to create LevelDB compatible sstable which can be used

--- a/sstable/raw_block.go
+++ b/sstable/raw_block.go
@@ -85,6 +85,14 @@ func (i *rawBlockIter) readEntry() {
 	i.nextOffset = int32(uintptr(ptr)-uintptr(i.ptr)) + int32(value)
 }
 
+func (i *rawBlockIter) valueLocation() (offset, length uint32) {
+	ptr := unsafe.Pointer(uintptr(i.ptr) + uintptr(i.offset))
+	_ /*shared*/, ptr = decodeVarint(ptr)
+	unshared, ptr := decodeVarint(ptr)
+	value, ptr := decodeVarint(ptr)
+	return uint32(uintptr(ptr) + uintptr(unshared) - uintptr(i.ptr) - uintptr(i.offset)), value
+}
+
 func (i *rawBlockIter) loadEntry() {
 	i.readEntry()
 	i.ikey.UserKey = i.key

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -179,7 +179,7 @@ compact         1   2.3 K             0 B          (size == estimated-debt, in =
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.4 K    5.9%  (score == hit-rate)
- tcache         1   616 B    0.0%  (score == hit-rate)
+ tcache         1   640 B    0.0%  (score == hit-rate)
  titers         0
  filter         -       -    0.0%  (score == utility)
 

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -48,7 +48,7 @@ compact         0     0 B             0 B          (size == estimated-debt, in =
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.5 K   46.7%  (score == hit-rate)
- tcache         1   616 B   50.0%  (score == hit-rate)
+ tcache         1   640 B   50.0%  (score == hit-rate)
  titers         0
  filter         -       -    0.0%  (score == utility)
 

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -34,7 +34,7 @@ compact         0     0 B             0 B          (size == estimated-debt, in =
 zmemtbl         1   256 K
    ztbl         0     0 B
  bcache         4   698 B    0.0%  (score == hit-rate)
- tcache         1   616 B    0.0%  (score == hit-rate)
+ tcache         1   640 B    0.0%  (score == hit-rate)
  titers         1
  filter         -       -    0.0%  (score == utility)
 
@@ -81,7 +81,7 @@ compact         1     0 B             0 B          (size == estimated-debt, in =
 zmemtbl         2   512 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   33.3%  (score == hit-rate)
- tcache         2   1.2 K   50.0%  (score == hit-rate)
+ tcache         2   1.3 K   50.0%  (score == hit-rate)
  titers         2
  filter         -       -    0.0%  (score == utility)
 
@@ -113,7 +113,7 @@ compact         1     0 B             0 B          (size == estimated-debt, in =
 zmemtbl         1   256 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   33.3%  (score == hit-rate)
- tcache         2   1.2 K   50.0%  (score == hit-rate)
+ tcache         2   1.3 K   50.0%  (score == hit-rate)
  titers         2
  filter         -       -    0.0%  (score == utility)
 
@@ -142,7 +142,7 @@ compact         1     0 B             0 B          (size == estimated-debt, in =
 zmemtbl         1   256 K
    ztbl         1   771 B
  bcache         4   698 B   33.3%  (score == hit-rate)
- tcache         1   616 B   50.0%  (score == hit-rate)
+ tcache         1   640 B   50.0%  (score == hit-rate)
  titers         1
  filter         -       -    0.0%  (score == utility)
 


### PR DESCRIPTION
In CockroachDB, there exist processes that build and ingest sstables.
These sstables have timestamp-suffixed MVCC keys. Today, these keys'
timestamps are dated in the past and rewrite history. This rewriting
violates invariants in parts of the system. We would like to support
ingesting these sstables with recent, invariant-maintaing MVCC
timestamps. However, ingestion is used during bulk operations, and
rewriting large sstables' keys with a recent MVCC timestamp is
infeasibly expensive.

This change introduces a facility for constructing an sstable with a
placeholder suffix. When using this facility, a caller specifies a
SuffixPlaceholder write option. The caller is also required to configure
a Comparer that contains a non-nil Split function. When configured with
a suffix placeholder, the sstable writer requires that all keys'
suffixes (as determined by Split) exactly match the provided
SuffixPlaceholder. An sstable constructed in this fashion is still
incomplete and unable to be read unless explicitly permitted through the
AllowUnreplacedSuffix option.

When a caller would like to complete an sstable constructed with a
suffix placeholder, they may call ReplaceSuffix providing the
original placeholder value and the replacement value. The placeholder
and replacement values are required to be equal lengths. ReplaceSuffix
performs an O(1) write to record the replacement value.

After a suffix replacement the resulting sstable is complete, and
sstable readers may read the sstable. Readers detect the sstable
property and apply a block transform to replace suffix placeholders with
the replacement value on the fly as blocks are loaded.

See cockroachdb/cockroach#70422.