### PR TITLE
pebble: add additional mechanism to schedule read compactions

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1559,6 +1559,19 @@ func (d *DB) flush1() error {
 	return err
 }
 
+// maybeScheduleCompactionAsync should be used when
+// we want to possibly schedule a compaction, but don't
+// want to eat the cost of running maybeScheduleCompaction.
+// This method should be launched in a separate goroutine.
+// d.mu must not be held when this is called.
+func (d *DB) maybeScheduleCompactionAsync() {
+	defer d.compactionSchedulers.Done()
+
+	d.mu.Lock()
+	d.maybeScheduleCompaction()
+	d.mu.Unlock()
+}
+
 // maybeScheduleCompaction schedules a compaction if necessary.
 //
 // d.mu must be held when calling this.
@@ -1653,8 +1666,9 @@ func (d *DB) maybeScheduleCompactionPicker(
 	for !d.opts.private.disableAutomaticCompactions && d.mu.compact.compactingCount < d.opts.MaxConcurrentCompactions {
 		env.inProgressCompactions = d.getInProgressCompactionInfoLocked(nil)
 		env.readCompactionEnv = readCompactionEnv{
-			readCompactions: &d.mu.compact.readCompactions,
-			flushing:        d.mu.compact.flushing || d.passedFlushThreshold(),
+			readCompactions:          &d.mu.compact.readCompactions,
+			flushing:                 d.mu.compact.flushing || d.passedFlushThreshold(),
+			rescheduleReadCompaction: &d.mu.compact.rescheduleReadCompaction,
 		}
 		pc := pickFunc(d.mu.versions.picker, env)
 		if pc == nil {

--- a/db.go
+++ b/db.go
@@ -243,6 +243,11 @@ type DB struct {
 	// could grab db.mu, it must *not* be held while deleters.Wait() is called.
 	deleters sync.WaitGroup
 
+	// During an iterator close, we may asynchronously schedule read compactions.
+	// We want to wait for those goroutines to finish, before closing the DB.
+	// compactionShedulers.Wait() should not be called while the DB.mu is held.
+	compactionSchedulers sync.WaitGroup
+
 	// The main mutex protecting internal DB state. This mutex encompasses many
 	// fields because those fields need to be accessed and updated atomically. In
 	// particular, the current version, log.*, mem.*, and snapshot list need to
@@ -339,6 +344,9 @@ type DB struct {
 			// readCompactions is a list of read triggered compactions. The next
 			// compaction to perform is as the start. New entries are added to the end.
 			readCompactions []readCompaction
+			// rescheduleReadCompaction indicates to an iterator that a read compaction
+			// should be scheduled.
+			rescheduleReadCompaction bool
 		}
 
 		cleaner struct {
@@ -1014,6 +1022,7 @@ func (d *DB) Close() error {
 	// Wait for all the deletion goroutines spawned by cleaning jobs to finish.
 	d.mu.Unlock()
 	d.deleters.Wait()
+	d.compactionSchedulers.Wait()
 	d.mu.Lock()
 	return err
 }


### PR DESCRIPTION
If the compaction picker tries to pick a read compaction, and returns
nil for any reason, then maybeScheduleCompactionPicker, won't schedule
additional compactions. In a read heavy workload, flushes might not happen
frequently enough to schedule additional read compactions. So, we need iterators
to schedule these compactions, when new compactions are added.

This pr will become more relevant when we merge #1200,
since #1200 increases the probability of the read compactions picker returning nil.

The other benefit of the pr is that it gets rid of the ridiculous variance in our ycsb/C/64
benchmarks.
```
arjunnair@Arjuns-MacBook-Pro rci % benchstat stat_master stat_m
name              old ops/sec  new ops/sec  delta
ycsb/A/values=64    860k ± 1%    863k ± 1%     ~     (p=0.690 n=5+5)
ycsb/C/values=64   2.04M ±30%   2.86M ± 3%  +40.51%  (p=0.008 n=5+5)
ycsb/B/values=64   1.11M ± 2%   1.14M ± 4%     ~     (p=0.056 n=5+5)

name              old read     new read     delta
ycsb/A/values=64   69.0G ± 1%   69.4G ± 1%     ~     (p=0.310 n=5+5)
ycsb/C/values=64   2.65G ± 5%   2.89G ± 4%   +9.34%  (p=0.008 n=5+5)
ycsb/B/values=64   40.1G ± 3%   49.4G ±23%     ~     (p=0.095 n=5+5)

name              old write    new write    delta
ycsb/A/values=64    101G ± 1%    102G ± 1%     ~     (p=0.310 n=5+5)
ycsb/C/values=64   2.57G ± 5%   2.81G ± 4%   +9.26%  (p=0.008 n=5+5)
ycsb/B/values=64   44.2G ± 3%   53.7G ±21%     ~     (p=0.056 n=5+5)

name              old r-amp    new r-amp    delta
ycsb/A/values=64    6.70 ± 0%    6.70 ± 0%     ~     (p=0.619 n=5+5)
ycsb/C/values=64    2.12 ± 2%    1.18 ± 3%  -44.41%  (p=0.000 n=4+5)
ycsb/B/values=64    3.86 ± 7%    3.70 ± 4%     ~     (p=0.087 n=5+5)

name              old w-amp    new w-amp    delta
ycsb/A/values=64    3.18 ± 0%    3.18 ± 0%     ~     (p=0.333 n=5+5)
ycsb/C/values=64    0.00         0.00          ~     (all equal)
ycsb/B/values=64    10.8 ± 3%    12.7 ±22%     ~     (p=0.151 n=5+5)
```

Resolves: #1316