### PR TITLE
db: expose facility for retrieving batch count

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -24,6 +24,7 @@ import (
 )
 
 const (
+	batchCountOffset     = 8
 	batchHeaderLen       = 12
 	batchInitialSize     = 1 << 10 // 1 KB
 	batchMaxRetainedSize = 1 << 20 // 1 MB
@@ -886,13 +887,15 @@ func batchDecodeStr(data []byte) (odata []byte, s []byte, ok bool) {
 // BatchReader iterates over the entries contained in a batch.
 type BatchReader []byte
 
-// MakeBatchReader constructs a BatchReader from a batch representation. The
-// header (containing the batch count and seqnum) is ignored.
-func MakeBatchReader(repr []byte) BatchReader {
+// ReadBatch constructs a BatchReader from a batch representation.  The
+// header is not validated. ReadBatch returns a new batch reader and the
+// count of entries contained within the batch.
+func ReadBatch(repr []byte) (r BatchReader, count uint32) {
 	if len(repr) <= batchHeaderLen {
-		return nil
+		return nil, count
 	}
-	return repr[batchHeaderLen:]
+	count = binary.LittleEndian.Uint32(repr[batchCountOffset:batchHeaderLen])
+	return repr[batchHeaderLen:], count
 }
 
 // Next returns the next entry in this batch. The final return value is false

--- a/batch_test.go
+++ b/batch_test.go
@@ -372,6 +372,10 @@ func TestBatchIncrement(t *testing.T) {
 		if got != want {
 			t.Errorf("input=%d: got %d, want %d", tc, got, want)
 		}
+		_, count := ReadBatch(b.Repr())
+		if got != want {
+			t.Errorf("input=%d: got %d, want %d", tc, count, want)
+		}
 	}
 
 	err := func() (err error) {


### PR DESCRIPTION
Refactor MakeBatchReader into ReadBatch, which returns a batch reader
and the entry count within the batch. This will allow the removal of
code within CockroachDB's storage package that parses the count out of a
batch manually. The CockroachDB storage package should be insulated from
Pebble batch serialization.