### PR TITLE
db: schedule sstable validation on ingestion

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -691,5 +691,99 @@ func (d *DB) ingestApply(jobID int, meta []*fileMetadata) (*versionEdit, error) 
 	// The ingestion may have pushed a level over the threshold for compaction,
 	// so check to see if one is necessary and schedule it.
 	d.maybeScheduleCompaction()
+	d.maybeValidateSSTablesLocked(ve.NewFiles)
 	return ve, nil
+}
+
+// maybeValidateSSTablesLocked adds the slice of newFileEntrys to the pending
+// queue of files to be validated, when the feature is enabled.
+// DB.mu must be locked when calling.
+func (d *DB) maybeValidateSSTablesLocked(newFiles []newFileEntry) {
+	// Only add to the validation queue when the feature is enabled.
+	if !d.opts.Experimental.ValidateOnIngest {
+		return
+	}
+
+	d.mu.tableValidation.pending = append(d.mu.tableValidation.pending, newFiles...)
+	if d.shouldValidateSSTablesLocked() {
+		go d.validateSSTables()
+	}
+}
+
+// shouldValidateSSTablesLocked returns true if SSTable validation should run.
+// DB.mu must be locked when calling.
+func (d *DB) shouldValidateSSTablesLocked() bool {
+	return !d.mu.tableValidation.validating &&
+		d.closed.Load() == nil &&
+		d.opts.Experimental.ValidateOnIngest &&
+		len(d.mu.tableValidation.pending) > 0
+}
+
+// validateSSTables runs a round of validation on the tables in the pending
+// queue.
+func (d *DB) validateSSTables() {
+	d.mu.Lock()
+	if !d.shouldValidateSSTablesLocked() {
+		d.mu.Unlock()
+		return
+	}
+
+	pending := d.mu.tableValidation.pending
+	d.mu.tableValidation.pending = nil
+	d.mu.tableValidation.validating = true
+	jobID := d.mu.nextJobID
+	d.mu.nextJobID++
+	rs := d.loadReadState()
+
+	// Drop DB.mu before performing IO.
+	d.mu.Unlock()
+
+	// Validate all tables in the pending queue. This could lead to a situation
+	// where we are starving IO from other tasks due to having to page through
+	// all the blocks in all the sstables in the queue.
+	// TODO(travers): Add some form of pacing to avoid IO starvation.
+	for _, f := range pending {
+		// The file may have been moved or deleted since it was ingested, in
+		// which case we skip.
+		if !rs.current.Contains(f.Level, d.cmp, f.Meta) {
+			// Assume the file was moved to a lower level. It is rare enough
+			// that a table is moved or deleted between the time it was ingested
+			// and the time the validation routine runs that the overall cost of
+			// this inner loop is tolerably low, when amortized over all
+			// ingested tables.
+			found := false
+			for i := f.Level + 1; i < numLevels; i++ {
+				if rs.current.Contains(i, d.cmp, f.Meta) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+
+		err := d.tableCache.withReader(f.Meta, func(r *sstable.Reader) error {
+			return r.ValidateBlockChecksums()
+		})
+		if err != nil {
+			// TODO(travers): Hook into the corruption reporting pipeline, once
+			// available. See pebble#1192.
+			d.opts.Logger.Fatalf("pebble: encountered corruption during ingestion: %s", err)
+		}
+
+		d.opts.EventListener.TableValidated(TableValidatedInfo{
+			JobID: jobID,
+			Meta:  f.Meta,
+		})
+	}
+	rs.unref()
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.mu.tableValidation.validating = false
+	d.mu.tableValidation.cond.Broadcast()
+	if d.shouldValidateSSTablesLocked() {
+		go d.validateSSTables()
+	}
 }

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -219,8 +219,9 @@ func randomOptions(rng *rand.Rand) *testOptions {
 	}
 	opts.Experimental.L0CompactionConcurrency = 1 + rng.Intn(4)    // 1-4
 	opts.Experimental.MinDeletionRate = 1 << uint(20+rng.Intn(10)) // 1MB - 1GB
-	opts.L0CompactionThreshold = 1 + rng.Intn(100)                 // 1 - 100
-	opts.L0StopWritesThreshold = 1 + rng.Intn(100)                 // 1 - 100
+	opts.Experimental.ValidateOnIngest = rng.Intn(2) != 0
+	opts.L0CompactionThreshold = 1 + rng.Intn(100) // 1 - 100
+	opts.L0StopWritesThreshold = 1 + rng.Intn(100) // 1 - 100
 	if opts.L0StopWritesThreshold < opts.L0CompactionThreshold {
 		opts.L0StopWritesThreshold = opts.L0CompactionThreshold
 	}

--- a/open.go
+++ b/open.go
@@ -440,6 +440,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		d.mu.versions.metrics.WAL.Files = int64(len(logFiles))
 	}
 	d.mu.tableStats.cond.L = &d.mu.Mutex
+	d.mu.tableValidation.cond.L = &d.mu.Mutex
 	if !d.opts.ReadOnly && !d.opts.private.disableTableStats {
 		d.maybeCollectTableStats()
 	}

--- a/options.go
+++ b/options.go
@@ -363,6 +363,12 @@ type Options struct {
 		//
 		// NOTE: callers should take care to not mutate the key being validated.
 		KeyValidationFunc func(userKey []byte) error
+
+		// ValidateOnIngest schedules validation of sstables after they have
+		// been ingested.
+		//
+		// By default, this value is false.
+		ValidateOnIngest bool
 	}
 
 	// Filters is a map from filter policy name to filter policy. It is used for
@@ -767,6 +773,7 @@ func (o *Options) String() string {
 		fmt.Fprintf(&buf, "%s", o.TablePropertyCollectors[i]().Name())
 	}
 	fmt.Fprintf(&buf, "]\n")
+	fmt.Fprintf(&buf, "  validate_on_ingest=%t\n", o.Experimental.ValidateOnIngest)
 	fmt.Fprintf(&buf, "  wal_dir=%s\n", o.WALDir)
 	fmt.Fprintf(&buf, "  wal_bytes_per_sync=%d\n", o.WALBytesPerSync)
 
@@ -979,6 +986,8 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				}
 			case "table_property_collectors":
 				// TODO(peter): set o.TablePropertyCollectors
+			case "validate_on_ingest":
+				o.Experimental.ValidateOnIngest, err = strconv.ParseBool(value)
 			case "wal_dir":
 				o.WALDir = value
 			case "wal_bytes_per_sync":

--- a/options_test.go
+++ b/options_test.go
@@ -96,6 +96,7 @@ func TestOptionsString(t *testing.T) {
   strict_wal_tail=true
   table_cache_shards=8
   table_property_collectors=[]
+  validate_on_ingest=false
   wal_dir=
   wal_bytes_per_sync=0
 

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -148,7 +148,7 @@ zmemtbl         1   256 K
 
 disk-usage
 ----
-2.7 K
+2.8 K
 
 # Closing iter b will release the last zombie sstable and the last zombie memtable.
 


### PR DESCRIPTION
Currently, when Pebble ingests an sstable, it validates the block
checksums necessary for it to retrieve the smallest and largest keys in
the table.

Wire up the block checksum validation codepath from #1240, scheduling
the validation of the ingested sstable on a background goroutine.

This ingestion validation is gated on a new experimental DB option,
`ValidateOnIngest`, which is initially off by default.

See #1203.