### PR TITLE
sstable: clarify comment on checksum input

### DIFF
--- a/sstable/table.go
+++ b/sstable/table.go
@@ -92,10 +92,11 @@ The table file format looks like:
 [footer]
 <end_of_file>
 
-Each block consists of some data and a 5 byte trailer: a 1 byte block type and
-a 4 byte checksum of the compressed data. The block type gives the per-block
-compression used; each block is compressed independently. The checksum
-algorithm is described in the pebble/crc package.
+Each block consists of some data and a 5 byte trailer: a 1 byte block type and a
+4 byte checksum. The checksum is computed over the compressed data and the first
+byte of the trailer (i.e. the block type), and is serialized as little-endian.
+The block type gives the per-block compression used; each block is compressed
+independently. The checksum algorithm is described in the pebble/crc package.
 
 The decompressed block data consists of a sequence of key/value entries
 followed by a trailer. Each key is encoded as a shared prefix length and a


### PR DESCRIPTION
Clarify a comment on the on-disk format of an sstable, specifically that
the checksum for a block is computed over both the compressed data and
the first byte of the trailer, and is serialized as little-endian.