### PR TITLE
*: address staticcheck lint check S1039

### DIFF
--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -278,10 +278,10 @@ func TestLevelIterBoundaries(t *testing.T) {
 				}
 			}
 			if !cont && iter != nil {
-				return fmt.Sprintf("preceding iter was not closed")
+				return "preceding iter was not closed"
 			}
 			if cont && iter == nil {
-				return fmt.Sprintf("no existing iter")
+				return "no existing iter"
 			}
 			if iter == nil {
 				slice := manifest.NewLevelSliceKeySorted(lt.cmp.Compare, lt.metas)

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -152,12 +152,12 @@ func TestSnapshot(t *testing.T) {
 					iter.Last()
 				case "seek-ge":
 					if len(parts) != 2 {
-						return fmt.Sprintf("seek-ge <key>\n")
+						return "seek-ge <key>\n"
 					}
 					iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
 				case "seek-lt":
 					if len(parts) != 2 {
-						return fmt.Sprintf("seek-lt <key>\n")
+						return "seek-lt <key>\n"
 					}
 					iter.SeekLT([]byte(strings.TrimSpace(parts[1])))
 				case "next":

--- a/sstable/block_test.go
+++ b/sstable/block_test.go
@@ -181,12 +181,12 @@ func TestBlockIter2(t *testing.T) {
 						switch parts[0] {
 						case "seek-ge":
 							if len(parts) != 2 {
-								return fmt.Sprintf("seek-ge <key>\n")
+								return "seek-ge <key>\n"
 							}
 							iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
 						case "seek-lt":
 							if len(parts) != 2 {
-								return fmt.Sprintf("seek-lt <key>\n")
+								return "seek-lt <key>\n"
 							}
 							iter.SeekLT([]byte(strings.TrimSpace(parts[1])))
 						case "first":

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -197,13 +197,13 @@ func runIterCmd(td *datadriven.TestData, r *Reader) string {
 		switch parts[0] {
 		case "seek-ge":
 			if len(parts) != 2 {
-				return fmt.Sprintf("seek-ge <key>\n")
+				return "seek-ge <key>\n"
 			}
 			prefix = nil
 			iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
 		case "seek-prefix-ge":
 			if len(parts) != 2 && len(parts) != 3 {
-				return fmt.Sprintf("seek-prefix-ge <key> [<try-seek-using-next>]\n")
+				return "seek-prefix-ge <key> [<try-seek-using-next>]\n"
 			}
 			prefix = []byte(strings.TrimSpace(parts[1]))
 			trySeekUsingNext := false
@@ -217,7 +217,7 @@ func runIterCmd(td *datadriven.TestData, r *Reader) string {
 			iter.SeekPrefixGE(prefix, prefix /* key */, trySeekUsingNext)
 		case "seek-lt":
 			if len(parts) != 2 {
-				return fmt.Sprintf("seek-lt <key>\n")
+				return "seek-lt <key>\n"
 			}
 			prefix = nil
 			iter.SeekLT([]byte(strings.TrimSpace(parts[1])))
@@ -235,7 +235,7 @@ func runIterCmd(td *datadriven.TestData, r *Reader) string {
 			iter.Prev()
 		case "set-bounds":
 			if len(parts) <= 1 || len(parts) > 3 {
-				return fmt.Sprintf("set-bounds lower=<lower> upper=<upper>\n")
+				return "set-bounds lower=<lower> upper=<upper>\n"
 			}
 			var lower []byte
 			var upper []byte

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -152,44 +152,44 @@ func runTestVFS(t *testing.T, baseFS FS, dir string) {
 			for _, line := range strings.Split(td.Input, "\n") {
 				parts := strings.Fields(line)
 				if len(parts) == 0 {
-					return fmt.Sprintf("<op> [<args>]")
+					return "<op> [<args>]"
 				}
 
 				switch parts[0] {
 				case "clone":
 					if len(parts) != 3 {
-						return fmt.Sprintf("clone <src> <dest>")
+						return "clone <src> <dest>"
 					}
 					_, _ = Clone(fs, fs, fs.PathJoin(dir, parts[1]), fs.PathJoin(dir, parts[2]))
 
 				case "create":
 					if len(parts) != 2 {
-						return fmt.Sprintf("create <name>")
+						return "create <name>"
 					}
 					f, _ := fs.Create(fs.PathJoin(dir, parts[1]))
 					f.Close()
 
 				case "link":
 					if len(parts) != 3 {
-						return fmt.Sprintf("link <oldname> <newname>")
+						return "link <oldname> <newname>"
 					}
 					_ = fs.Link(fs.PathJoin(dir, parts[1]), fs.PathJoin(dir, parts[2]))
 
 				case "link-or-copy":
 					if len(parts) != 3 {
-						return fmt.Sprintf("link-or-copy <oldname> <newname>")
+						return "link-or-copy <oldname> <newname>"
 					}
 					_ = LinkOrCopy(fs, fs.PathJoin(dir, parts[1]), fs.PathJoin(dir, parts[2]))
 
 				case "reuseForWrite":
 					if len(parts) != 3 {
-						return fmt.Sprintf("reuseForWrite <oldname> <newname>")
+						return "reuseForWrite <oldname> <newname>"
 					}
 					_, _ = fs.ReuseForWrite(fs.PathJoin(dir, parts[1]), fs.PathJoin(dir, parts[2]))
 
 				case "list":
 					if len(parts) != 2 {
-						return fmt.Sprintf("list <dir>")
+						return "list <dir>"
 					}
 					paths, _ := fs.List(fs.PathJoin(dir, parts[1]))
 					sort.Strings(paths)
@@ -199,19 +199,19 @@ func runTestVFS(t *testing.T, baseFS FS, dir string) {
 
 				case "mkdir":
 					if len(parts) != 2 {
-						return fmt.Sprintf("mkdir <dir>")
+						return "mkdir <dir>"
 					}
 					_ = fs.MkdirAll(fs.PathJoin(dir, parts[1]), 0755)
 
 				case "remove":
 					if len(parts) != 2 {
-						return fmt.Sprintf("remove <name>")
+						return "remove <name>"
 					}
 					_ = fs.Remove(fs.PathJoin(dir, parts[1]))
 
 				case "remove-all":
 					if len(parts) != 2 {
-						return fmt.Sprintf("remove-all <name>")
+						return "remove-all <name>"
 					}
 					_ = fs.RemoveAll(fs.PathJoin(dir, parts[1]))
 				}


### PR DESCRIPTION
Address S1039 – Unnecessary use of `fmt.Sprint`.

Addresses #1327.