### PR TITLE
*: address staticcheck lints

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1363,11 +1363,7 @@ func (d *DB) passedFlushThreshold() bool {
 	// while we're undergoing the ramp period on the memtable size. See
 	// DB.newMemTable().
 	minFlushSize := uint64(d.opts.MemTableSize) / 2
-	if size < minFlushSize {
-		return false
-	}
-
-	return true
+	return size >= minFlushSize
 }
 
 func (d *DB) maybeScheduleDelayedFlush(tbl *memTable) {

--- a/data_test.go
+++ b/data_test.go
@@ -599,10 +599,8 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 		d.updateTableStatsLocked(ve.NewFiles)
 	}
 
-	if levelMaxBytes != nil {
-		for l, maxBytes := range levelMaxBytes {
-			d.mu.versions.picker.(*compactionPickerByScore).levelMaxBytes[l] = maxBytes
-		}
+	for l, maxBytes := range levelMaxBytes {
+		d.mu.versions.picker.(*compactionPickerByScore).levelMaxBytes[l] = maxBytes
 	}
 
 	return d, nil

--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -18,23 +18,23 @@ type InternalKeyKind uint8
 // These constants are part of the file format, and should not be changed.
 const (
 	InternalKeyKindDelete  InternalKeyKind = 0
-	InternalKeyKindSet                     = 1
-	InternalKeyKindMerge                   = 2
-	InternalKeyKindLogData                 = 3
-	// InternalKeyKindColumnFamilyDeletion                     = 4
-	// InternalKeyKindColumnFamilyValue                        = 5
-	// InternalKeyKindColumnFamilyMerge                        = 6
-	InternalKeyKindSingleDelete = 7
-	// InternalKeyKindColumnFamilySingleDelete                 = 8
-	// InternalKeyKindBeginPrepareXID                          = 9
-	// InternalKeyKindEndPrepareXID                            = 10
-	// InternalKeyKindCommitXID                                = 11
-	// InternalKeyKindRollbackXID                              = 12
-	// InternalKeyKindNoop                                     = 13
-	// InternalKeyKindColumnFamilyRangeDelete                  = 14
-	InternalKeyKindRangeDelete = 15
-	// InternalKeyKindColumnFamilyBlobIndex                    = 16
-	// InternalKeyKindBlobIndex                                = 17
+	InternalKeyKindSet     InternalKeyKind = 1
+	InternalKeyKindMerge   InternalKeyKind = 2
+	InternalKeyKindLogData InternalKeyKind = 3
+	//InternalKeyKindColumnFamilyDeletion     InternalKeyKind = 4
+	//InternalKeyKindColumnFamilyValue        InternalKeyKind = 5
+	//InternalKeyKindColumnFamilyMerge        InternalKeyKind = 6
+	InternalKeyKindSingleDelete InternalKeyKind = 7
+	//InternalKeyKindColumnFamilySingleDelete InternalKeyKind = 8
+	//InternalKeyKindBeginPrepareXID          InternalKeyKind = 9
+	//InternalKeyKindEndPrepareXID            InternalKeyKind = 10
+	//InternalKeyKindCommitXID                InternalKeyKind = 11
+	//InternalKeyKindRollbackXID              InternalKeyKind = 12
+	//InternalKeyKindNoop                     InternalKeyKind = 13
+	//InternalKeyKindColumnFamilyRangeDelete  InternalKeyKind = 14
+	InternalKeyKindRangeDelete InternalKeyKind = 15
+	//InternalKeyKindColumnFamilyBlobIndex    InternalKeyKind = 16
+	//InternalKeyKindBlobIndex                InternalKeyKind = 17
 
 	// InternalKeyKindSeparator is a key used for separator / successor keys
 	// written to sstable block indexes.
@@ -43,7 +43,7 @@ const (
 	// keys written to block indexes with value "17" (when 17 happened to be the
 	// max value, and InternalKeyKindMax was therefore set to 17), remain stable
 	// when new key kinds are supported in Pebble.
-	InternalKeyKindSeparator = 17
+	InternalKeyKindSeparator InternalKeyKind = 17
 
 	// InternalKeyKindSetWithDelete keys are SET keys that have met with a
 	// DELETE or SINGLEDEL key in a prior compaction. This key kind is
@@ -77,7 +77,7 @@ const (
 	// when a range deletion tombstone is the largest key in an sstable. This is
 	// necessary because sstable boundaries are inclusive, while the end key of a
 	// range deletion tombstone is exclusive.
-	InternalKeyRangeDeleteSentinel = (InternalKeySeqNumMax << 8) | InternalKeyKindRangeDelete
+	InternalKeyRangeDeleteSentinel = (InternalKeySeqNumMax << 8) | uint64(InternalKeyKindRangeDelete)
 )
 
 var internalKeyKindNames = []string{

--- a/internal/batchskl/skl_test.go
+++ b/internal/batchskl/skl_test.go
@@ -111,7 +111,7 @@ type testStorage struct {
 
 func (d *testStorage) add(key string) uint32 {
 	offset := uint32(len(d.data))
-	d.data = append(d.data, base.InternalKeyKindSet)
+	d.data = append(d.data, uint8(base.InternalKeyKindSet))
 	var buf [binary.MaxVarintLen64]byte
 	n := binary.PutUvarint(buf[:], uint64(len(key)))
 	d.data = append(d.data, buf[:n]...)
@@ -121,7 +121,7 @@ func (d *testStorage) add(key string) uint32 {
 
 func (d *testStorage) addBytes(key []byte) uint32 {
 	offset := uint32(len(d.data))
-	d.data = append(d.data, base.InternalKeyKindSet)
+	d.data = append(d.data, uint8(base.InternalKeyKindSet))
 	var buf [binary.MaxVarintLen64]byte
 	n := binary.PutUvarint(buf[:], uint64(len(key)))
 	d.data = append(d.data, buf[:n]...)

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -1027,10 +1027,10 @@ func (s *L0Sublevels) PickBaseCompaction(
 		// nearby. Note that it is possible that those intervals
 		// have seed files at lower sub-levels so could be
 		// viable for compaction.
-		consideredIntervals.markBits(f.minIntervalIndex, f.maxIntervalIndex+1)
 		if f == nil {
 			return nil, errors.New("no seed file found in sublevel intervals")
 		}
+		consideredIntervals.markBits(f.minIntervalIndex, f.maxIntervalIndex+1)
 		if f.Compacting {
 			if f.IsIntraL0Compacting {
 				// If we're picking a base compaction and we came across a

--- a/internal/metamorphic/generator.go
+++ b/internal/metamorphic/generator.go
@@ -330,6 +330,7 @@ func (g *generator) newIter() {
 	if iters := g.readers[readerID]; iters != nil {
 		iters[iterID] = struct{}{}
 		g.iters[iterID] = iters
+	//lint:ignore SA9003 - readability
 	} else {
 		// NB: the DB object does not track its open iterators because it never
 		// closes.
@@ -368,6 +369,7 @@ func (g *generator) newIterUsingClone() {
 	if iters := g.iters[existingIterID]; iters != nil {
 		iters[iterID] = struct{}{}
 		g.iters[iterID] = iters
+	//lint:ignore SA9003 - readability
 	} else {
 		// NB: the DB object does not track its open iterators because it never
 		// closes.
@@ -389,6 +391,7 @@ func (g *generator) iterClose() {
 	if readerIters, ok := g.iters[iterID]; ok {
 		delete(g.iters, iterID)
 		delete(readerIters, iterID)
+	//lint:ignore SA9003 - readability
 	} else {
 		// NB: the DB object does not track its open iterators because it never
 		// closes.

--- a/internal/pacertoy/pebble/main.go
+++ b/internal/pacertoy/pebble/main.go
@@ -387,10 +387,6 @@ func main() {
 			fmt.Printf("_elapsed___memtbs____dirty_____fill____drain____cdebt__l0count___max-f-rate\n")
 		}
 
-		if (i % 7) == 0 {
-			//db.printLevels()
-		}
-
 		db.mu.Lock()
 		memtableCount := len(db.memtables)
 		db.mu.Unlock()

--- a/internal/pacertoy/rocksdb/main.go
+++ b/internal/pacertoy/rocksdb/main.go
@@ -350,10 +350,6 @@ func main() {
 			fmt.Printf("_elapsed___memtbs____dirty_____fill____drain____cdebt__l0count___max-w-rate\n")
 		}
 
-		if (i % 7) == 0 {
-			//db.printLevels()
-		}
-
 		db.mu.Lock()
 		memtableCount := len(db.memtables)
 		db.mu.Unlock()

--- a/open_test.go
+++ b/open_test.go
@@ -281,7 +281,7 @@ func TestOpenCrashWritingOptions(t *testing.T) {
 	// Open the database again, this time with a mocked filesystem that
 	// will only succeed in partially writing the OPTIONS file.
 	fs := optionsTornWriteFS{FS: memFS}
-	d, err = Open("", &Options{FS: fs})
+	_, err = Open("", &Options{FS: fs})
 	require.Error(t, err)
 
 	// Re-opening the database must succeed.
@@ -750,6 +750,7 @@ func TestCrashOpenCrashAfterWALCreation(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 		f, err = fs.Create(logs[0])
+		require.NoError(t, err)
 		_, err = f.Write(b)
 		require.NoError(t, err)
 		_, err = f.Write([]byte{0xde, 0xad, 0xbe, 0xef})

--- a/vfs/disk_heath_test.go
+++ b/vfs/disk_heath_test.go
@@ -48,7 +48,7 @@ type mockFS struct {
 }
 
 func (m mockFS) Create(name string) (File, error) {
-	return mockFile{syncDuration: m.syncDuration}, nil
+	return mockFile(m), nil
 }
 
 func (m mockFS) Link(oldname, newname string) error {
@@ -76,7 +76,7 @@ func (m mockFS) Rename(oldname, newname string) error {
 }
 
 func (m mockFS) ReuseForWrite(oldname, newname string) (File, error) {
-	return mockFile{syncDuration: m.syncDuration}, nil
+	return mockFile(m), nil
 }
 
 func (m mockFS) MkdirAll(dir string, perm os.FileMode) error {


### PR DESCRIPTION
Addresses the following lint checks:

- S1008: Simplify returning boolean expression.
- S1016: Use a type conversion instead of manually copying struct
  fields.
- S1031: Omit redundant nil check around loop.
- SA4006: A value assigned to a variable is never read before being
  overwritten.
- SA5011: Possible nil pointer dereference.
- SA9004: Only the first constant has an explicit type.

Addresses #1327.