### PR TITLE
sstable: consolidate checksum types

### DIFF
--- a/sstable/options.go
+++ b/sstable/options.go
@@ -62,18 +62,6 @@ const (
 	TableFormatLevelDB
 )
 
-// ChecksumType specifies the checksum used for blocks. The default is CRC32c.
-type ChecksumType uint32
-
-// The available checksum types. Note that these values are not (and should not)
-// be serialized to disk (for the constants that are persisted, see table.go).
-const (
-	ChecksumTypeCRC32c ChecksumType = iota
-	ChecksumTypeNone
-	ChecksumTypeXXHash
-	ChecksumTypeXXHash64
-)
-
 // TablePropertyCollector provides a hook for collecting user-defined
 // properties based on the keys and values stored in an sstable. A new
 // TablePropertyCollector is created for an sstable when the sstable is being
@@ -236,6 +224,9 @@ func (o WriterOptions) ensureDefaults() WriterOptions {
 	}
 	if o.MergerName == "" {
 		o.MergerName = base.DefaultMerger.Name
+	}
+	if o.Checksum == ChecksumTypeNone {
+		o.Checksum = ChecksumTypeCRC32c
 	}
 	return o
 }

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -150,11 +150,6 @@ const (
 	levelDBFormatVersion  = 0
 	rocksDBFormatVersion2 = 2
 
-	noChecksum       = 0
-	checksumCRC32c   = 1
-	checksumXXHash   = 2
-	checksumXXHash64 = 3
-
 	// The block type gives the per-block compression format.
 	// These constants are part of the file format and should not be changed.
 	// They are different from the Compression constants because the latter
@@ -188,6 +183,17 @@ const (
 	// This should be removed if we ever decide to diverge from the RocksDB
 	// properties block.
 	rocksDBCompressionOptions = "window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; "
+)
+
+// ChecksumType specifies the checksum used for blocks.
+type ChecksumType byte
+
+// The available checksum types.
+const (
+	ChecksumTypeNone     ChecksumType = 0
+	ChecksumTypeCRC32c   ChecksumType = 1
+	ChecksumTypeXXHash   ChecksumType = 2
+	ChecksumTypeXXHash64 ChecksumType = 3
 )
 
 // legacy (LevelDB) footer format:
@@ -255,10 +261,10 @@ func readFooter(f ReadableFile) (footer, error) {
 			return footer, base.CorruptionErrorf("pebble/table: unsupported format version %d", errors.Safe(version))
 		}
 		footer.format = TableFormatRocksDBv2
-		switch uint8(buf[0]) {
-		case checksumCRC32c:
+		switch ChecksumType(buf[0]) {
+		case ChecksumTypeCRC32c:
 			footer.checksum = ChecksumTypeCRC32c
-		case checksumXXHash64:
+		case ChecksumTypeXXHash64:
 			footer.checksum = ChecksumTypeXXHash64
 		default:
 			return footer, base.CorruptionErrorf("pebble/table: unsupported checksum type %d", errors.Safe(footer.checksum))
@@ -305,13 +311,13 @@ func (f footer) encode(buf []byte) []byte {
 		}
 		switch f.checksum {
 		case ChecksumTypeNone:
-			buf[0] = noChecksum
+			buf[0] = byte(ChecksumTypeNone)
 		case ChecksumTypeCRC32c:
-			buf[0] = checksumCRC32c
+			buf[0] = byte(ChecksumTypeCRC32c)
 		case ChecksumTypeXXHash:
-			buf[0] = checksumXXHash
+			buf[0] = byte(ChecksumTypeXXHash)
 		case ChecksumTypeXXHash64:
-			buf[0] = checksumXXHash64
+			buf[0] = byte(ChecksumTypeXXHash64)
 		default:
 			panic("unknown checksum type")
 		}


### PR DESCRIPTION
Currently, there exists an exported `type sstable.ChecksumType uint32`,
intended to be used as an enum, in addition to an unexported `byte` used
for the on-disk representation.

Consolidate the two types, changing the exported type to be an alias for
`byte` and removing the unexported type.