### PR TITLE
sort.Slice cleanup

### DIFF
--- a/version_set.go
+++ b/version_set.go
@@ -85,7 +85,7 @@ type versionSet struct {
 	// on the creation of every version.
 	obsoleteFn        func(obsolete []*manifest.FileMetadata)
 	obsoleteTables    []*manifest.FileMetadata
-	obsoleteManifests []fileInfo
+	obsoleteManifests filesInfo
 	obsoleteOptions   []fileInfo
 
 	// Zombie tables which have been removed from the current version but are


### PR DESCRIPTION
Ideally is to have type safe non generic sort implementation to avoid interface allocation of sort.Interface, maybe custom sort package for all internal data structures go:generated by types_gen.go or smth like that. But sort.Sort not using reflection that much as sort.Slice so it will be better anyway.