### PR TITLE
db: use locked suffix for function names; simplify boolean expression

### DIFF
--- a/open.go
+++ b/open.go
@@ -441,7 +441,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	}
 	d.mu.tableStats.cond.L = &d.mu.Mutex
 	if !d.opts.ReadOnly && !d.opts.private.disableTableStats {
-		d.maybeCollectTableStats()
+		d.maybeCollectTableStatsLocked()
 	}
 	d.calculateDiskAvailableBytes()
 

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -48,7 +48,7 @@ func TestTableStats(t *testing.T) {
 		case "enable":
 			d.mu.Lock()
 			d.opts.private.disableTableStats = false
-			d.maybeCollectTableStats()
+			d.maybeCollectTableStatsLocked()
 			d.mu.Unlock()
 			return ""
 


### PR DESCRIPTION
Use "Locked" as a suffix for function names that should only be called
when locked.

Use a single boolean expression as the return value of
`(*DB).shouldCollectTableStatsLocked`.

Follow-up from #1322.