### PR TITLE
internal/rate: skip two flaky tests on darwin

### DIFF
--- a/internal/rate/rate_test.go
+++ b/internal/rate/rate_test.go
@@ -382,8 +382,9 @@ func runWait(t *testing.T, lim *Limiter, w wait) {
 }
 
 func TestWaitSimple(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("flaky on Windows")
+	switch runtime.GOOS {
+	case "windows", "darwin":
+		t.Skip("flaky; see #1256")
 	}
 
 	lim := NewLimiter(10, 3)
@@ -399,8 +400,9 @@ func TestWaitSimple(t *testing.T) {
 }
 
 func TestWaitCancel(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("flaky on Windows")
+	switch runtime.GOOS {
+	case "windows", "darwin":
+		t.Skip("flaky; see #1187")
 	}
 
 	lim := NewLimiter(10, 3)


### PR DESCRIPTION
Both `TestWaitSimple` and `TestWaitCancel` are very flaky on darwin.

Disable until both #1187 and #1256 can be addressed.