### PR TITLE
compaction: use sstable writer for detecting user key changes

### DIFF
--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -836,6 +836,27 @@ type WriterOption interface {
 	writerApply(*Writer)
 }
 
+// PreviousPointKeyOpt is a WriterOption that provides access to the last
+// point key written to the writer while building a sstable.
+type PreviousPointKeyOpt struct {
+	w *Writer
+}
+
+// UnsafeKey returns the last point key written to the writer to which this
+// option was passed during creation. The returned key points directly into
+// a buffer belonging the Writer. The value's lifetime ends the next time a
+// point key is added to the Writer.
+func (o PreviousPointKeyOpt) UnsafeKey() base.InternalKey {
+	if o.w == nil {
+		return base.InvalidInternalKey
+	}
+	return o.w.meta.LargestPoint
+}
+
+func (o *PreviousPointKeyOpt) writerApply(w *Writer) {
+	o.w = w
+}
+
 // internalTableOpt is a WriterOption that sets properties for sstables being
 // created by the db itself (i.e. through flushes and compactions), as opposed
 // to those meant for ingestion.

--- a/testdata/compaction_output_splitters
+++ b/testdata/compaction_output_splitters
@@ -107,10 +107,6 @@ should-split-before food.SET.4
 ----
 no-split
 
-set-should-split child0 no-split
-----
-ok
-
 should-split-before food2.SET.4
 ----
 split-now


### PR DESCRIPTION
The `userKeyChangeSplitter` is responsible for avoiding splits within a
user key during flushes. Previously, it worked by recording the current
user key when a split is requested. This introduced a delay in
splitting. When the split is requested, the current key might already be
different than the last key written to the sstable. This change alters
the `userKeyChangeSplitter` to read the last written point key from the
current sstable writer and the last written range key from the range
deletion fragmenter.

This has a couple advantages:
a) It avoids an extra copy of a user key.
b) It may split sooner, closer to the target file size. This is a
   practical concern in writing unit tests that involves flushes and
   small target file sizes. If we prevent splitting user keys across
   outputs in compactions too, it will become a practical concern there
   too.
c) It exposes the previous point key to the broader compaction loop,
   which is necessary for narrowing the conditions during which the
   compaction loop must flush all/additional range tombstones.
   Currently, we ignore the splitters' suggested split point during
   flushes because we may have already output a key with the user key to
   the current sstable. Future commits will be able to read this
   previous point key and use the splitters' suggestion if the previous
   point key's user key is not equal to the splitters' suggestion.