### PR TITLE
cmd/pebble: add sustainable write throughput benchmark

### DIFF
--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -45,6 +45,7 @@ func main() {
 		tombstoneCmd,
 		ycsbCmd,
 		fsBenchCmd,
+		writeBenchCmd,
 	)
 
 	rootCmd := &cobra.Command{
@@ -56,7 +57,7 @@ func main() {
 	t := tool.New(tool.Comparers(mvccComparer), tool.Mergers(fauxMVCCMerger))
 	rootCmd.AddCommand(t.Commands...)
 
-	for _, cmd := range []*cobra.Command{compactNewCmd, compactRunCmd, scanCmd, syncCmd, tombstoneCmd, ycsbCmd} {
+	for _, cmd := range []*cobra.Command{compactNewCmd, compactRunCmd, scanCmd, syncCmd, tombstoneCmd, writeBenchCmd, ycsbCmd} {
 		cmd.Flags().BoolVarP(
 			&verbose, "verbose", "v", false, "enable verbose event logging")
 	}
@@ -64,7 +65,7 @@ func main() {
 		cmd.Flags().Int64Var(
 			&cacheSize, "cache", 1<<30, "cache size")
 	}
-	for _, cmd := range []*cobra.Command{scanCmd, syncCmd, tombstoneCmd, ycsbCmd, fsBenchCmd} {
+	for _, cmd := range []*cobra.Command{scanCmd, syncCmd, tombstoneCmd, ycsbCmd, fsBenchCmd, writeBenchCmd} {
 		cmd.Flags().DurationVarP(
 			&duration, "duration", "d", 10*time.Second, "the duration to run (0, run forever)")
 	}

--- a/cmd/pebble/write_bench_test.go
+++ b/cmd/pebble/write_bench_test.go
@@ -1,0 +1,79 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindOptimalSplit(t *testing.T) {
+	testCases := []struct {
+		passes, fails []int
+		interval      int
+		want          int
+	}{
+		{
+			// Not enough data.
+			passes:   []int{},
+			fails:    []int{},
+			interval: 50,
+			want:     -1,
+		},
+		{
+			// Not enough data.
+			passes:   []int{1, 2, 3},
+			fails:    []int{},
+			interval: 50,
+			want:     -1,
+		},
+		{
+			// Not enough data.
+			passes:   []int{},
+			fails:    []int{1, 2, 3},
+			interval: 50,
+			want:     -1,
+		},
+		{
+			// Trivial example.
+			passes:   []int{10},
+			fails:    []int{20},
+			interval: 5,
+			want:     15,
+		},
+		{
+			// Example given in the doc comment for the function.
+			passes:   []int{100, 210, 300, 380, 450, 470, 490, 510, 520},
+			fails:    []int{310, 450, 560, 610, 640, 700, 720, 810},
+			interval: 50,
+			want:     550,
+		},
+		{
+			// Empirical data from an actual test run (~1hr).
+			passes: []int{
+				1000, 1100, 1300, 1700, 2500, 4100, 7300, 13700, 26500, 52100,
+				52100, 52100, 26500, 26600, 26800, 27200, 28000, 29600, 32800,
+				32800, 32900, 32900, 33000, 33000, 33100, 33100, 33100, 33100,
+				33100, 33100, 33000, 33100, 33000, 32900, 33000, 33200, 33600,
+				34400, 36000,
+			},
+			fails: []int{
+				103300, 52200, 52200, 52100, 39200, 33100, 33200, 33300, 33200,
+				33200, 33200, 33200, 33200, 33100, 33300, 33100, 33100, 33000,
+				39200, 36100,
+			},
+			interval: 50,
+			want:     33100,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			split := findOptimalSplit(tc.passes, tc.fails, tc.interval)
+			require.Equal(t, tc.want, split)
+		})
+	}
+}


### PR DESCRIPTION
Add a pebble sub-command that runs YCSB F (100% writes) at varying
levels of sustained write load (ops/sec) to determine an optimal value
of write throughput.

The benchmark works by maintaining a fixed amount of write load on the
DB for a fixed amount of time. If the database can handle the sustained
load - determined by a heuristic that takes into account the number of
files in L0 sub-levels, the number of L0 sub-levels, and whether the DB
has encountered a write stall (i.e.  measured load on the DB drops to
zero) - the load is increased on the DB.

Load increases exponentially from an initial load. If the DB fails the
heuristic at the given write load, the load on the DB is paused for a
period of time (the cool-off period) before returning to the last value
at which the DB could handle the load. The exponent is then reset and
the process repeats from this new initial value. This allows the
benchmark to converge on and oscillate around the optimal write load.

The values of load at which the DB passes and fails the heuristic are
maintained over the duration of the benchmark. On completion of the
benchmark, an "optimal" value is computed. The optimal value is computed
as the value that minimizes the mis-classification of the recorded
"passes" and "fails"". This can be visualized as a point on the x-axis
that separates the passes and fails into the left and right half-planes,
minimizing the number of fails that fall to the left of this point (i.e.
mis-classified fails) and the number of passes that fall to the right
(i.e. mis-classified passes).

The resultant "optimal sustained write load" value provides an estimate
of the write load that the DB can sustain without failing the target
heuristic.

----

Open questions and TODOs:

- [x] Are the current heuristics sufficient? Are there other signals we should be considering?
- [x] Record more data for each pass / fail (i.e. elapsed time, clock time, pass / fail, limit, measured ops / sec, num. levels, etc.). This would allow for slicing the benchmark across various dimensions.
- [x] Improved partitioning algorithm (was thinking something like a one-dimensional [Support Vector Machine](https://en.wikipedia.org/wiki/Support-vector_machine)). Open to thoughts / ideas on this. What we have now seems to give a reasonable value.
- [x] At higher loads (i.e. when running with `--values=16`), the shared rate-limiter becomes inaccurate and results in measured values of load that vary significantly from the desired load. Consider using something like per-writer rate limiters, with the desired load distributed across all rate-limiters.
- [x] We currently report a single value for the optimal write load. I've observed that this value depends on the number of levels that are currently in-use. For example, when L2 opens up, the write throughput increases for a few minutes as compactions move data from L0 into L2, but then write load appears to taper off as the DB can't compact out of L0 fast enough, and we exceed the `L0-sublevels <= 20` heuristic.
- [x] Add jitter to the increment. Introducing randomness into the benchmark could help avoid situations where the benchmark gets stuck in a "loop" (e.g. passes at level X, fails at X + n, repeat ...).