### PR TITLE
db: add in-progress compaction count metric

### DIFF
--- a/db.go
+++ b/db.go
@@ -1183,6 +1183,7 @@ func (d *DB) Metrics() *Metrics {
 	*metrics = d.mu.versions.metrics
 	metrics.Compact.EstimatedDebt = d.mu.versions.picker.estimatedCompactionDebt(0)
 	metrics.Compact.InProgressBytes = atomic.LoadInt64(&d.mu.versions.atomic.atomicInProgressBytes)
+	metrics.Compact.NumInProgress = int64(d.mu.compact.compactingCount)
 	for _, m := range d.mu.mem.queue {
 		metrics.MemTable.Size += m.totalBytes()
 	}

--- a/metrics.go
+++ b/metrics.go
@@ -140,6 +140,8 @@ type Metrics struct {
 		// compactions. This value will be zero if there are no in-progress
 		// compactions.
 		InProgressBytes int64
+		// Number of compactions that are in-progress.
+		NumInProgress int64
 	}
 
 	Flush struct {
@@ -297,7 +299,7 @@ func (m *Metrics) formatWAL(w redact.SafePrinter) {
 //         6         1   825 B    0.00   1.6 K     0 B       0     0 B       0   825 B       1   1.6 K     0.5
 //     total         3   2.4 K       -   933 B   825 B       1     0 B       0   4.1 K       4   1.6 K     4.5
 //     flush         3
-//   compact         1   1.6 K             0 B          (size == estimated-debt, in = in-progress-bytes)
+//   compact         1   1.6 K     0 B       1          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
 //     ctype         0       0       0       0       0  (default, delete, elision, move, read)
 //    memtbl         1   4.0 M
 //   zmemtbl         0     0 B
@@ -359,11 +361,11 @@ func (m *Metrics) SafeFormat(w redact.SafePrinter, _ rune) {
 	total.format(w, notApplicable)
 
 	w.Printf("  flush %9d\n", redact.Safe(m.Flush.Count))
-	w.Printf("compact %9d %7s %7s %7s %7s  (size == estimated-debt, in = in-progress-bytes)\n",
+	w.Printf("compact %9d %7s %7s %7d %7s  (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)\n",
 		redact.Safe(m.Compact.Count),
 		humanize.IEC.Uint64(m.Compact.EstimatedDebt),
-		redact.SafeString(""),
 		humanize.IEC.Int64(m.Compact.InProgressBytes),
+		redact.Safe(m.Compact.NumInProgress),
 		redact.SafeString(""))
 	w.Printf("  ctype %9d %7d %7d %7d %7d  (default, delete, elision, move, read)\n",
 		redact.Safe(m.Compact.DefaultCount),

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -30,6 +30,7 @@ func TestMetricsFormat(t *testing.T) {
 	m.Compact.ReadCount = 31
 	m.Compact.EstimatedDebt = 6
 	m.Compact.InProgressBytes = 7
+	m.Compact.NumInProgress = 2
 	m.Flush.Count = 8
 	m.Filter.Hits = 9
 	m.Filter.Misses = 10
@@ -81,7 +82,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6       701   702 B       -   704 B   704 B     712   706 B     713   1.4 K   1.4 K   707 B       7     2.0
   total      2807   2.7 K       -   2.8 K   2.8 K   2.9 K   2.8 K   2.9 K   8.4 K   5.7 K   2.8 K      28     3.0
   flush         8
-compact         5     6 B             7 B          (size == estimated-debt, in = in-progress-bytes)
+compact         5     6 B     7 B       2          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype        27      28      29      30      31  (default, delete, elision, move, read)
  memtbl        12    11 B
 zmemtbl        14    13 B
@@ -216,7 +217,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6         0     0 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
   total         0     0 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
   flush         0
-compact         0     0 B             0 B          (size == estimated-debt, in = in-progress-bytes)
+compact         0     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         0       0       0       0       0  (default, delete, elision, move, read)
  memtbl         0     0 B
 zmemtbl         0     0 B

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -177,7 +177,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6         1   770 B       -   1.5 K     0 B       0     0 B       0   770 B       1   1.5 K       1     0.5
   total         3   2.3 K       -   933 B   825 B       1     0 B       0   3.9 K       4   1.5 K       3     4.3
   flush         3
-compact         1   2.3 K             0 B          (size == estimated-debt, in = in-progress-bytes)
+compact         1   2.3 K     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0  (default, delete, elision, move, read)
  memtbl         1   256 K
 zmemtbl         0     0 B

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -42,7 +42,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6         1   833 B       -     0 B   833 B       1     0 B       0     0 B       0     0 B       1     0.0
   total         1   833 B       -   833 B   833 B       1     0 B       0   833 B       0     0 B       1     1.0
   flush         0
-compact         0     0 B             0 B          (size == estimated-debt, in = in-progress-bytes)
+compact         0     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         0       0       0       0       0  (default, delete, elision, move, read)
  memtbl         1   256 K
 zmemtbl         0     0 B

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -28,7 +28,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6         0     0 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
   total         1   771 B       -    56 B     0 B       0     0 B       0   827 B       1     0 B       1    14.8
   flush         1
-compact         0     0 B             0 B          (size == estimated-debt, in = in-progress-bytes)
+compact         0     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         0       0       0       0       0  (default, delete, elision, move, read)
  memtbl         1   256 K
 zmemtbl         1   256 K
@@ -75,7 +75,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6         1   778 B       -   1.5 K     0 B       0     0 B       0   778 B       1   1.5 K       1     0.5
   total         1   778 B       -    84 B     0 B       0     0 B       0   2.3 K       3   1.5 K       1    28.6
   flush         2
-compact         1     0 B             0 B          (size == estimated-debt, in = in-progress-bytes)
+compact         1     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0  (default, delete, elision, move, read)
  memtbl         1   256 K
 zmemtbl         2   512 K
@@ -107,7 +107,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6         1   778 B       -   1.5 K     0 B       0     0 B       0   778 B       1   1.5 K       1     0.5
   total         1   778 B       -    84 B     0 B       0     0 B       0   2.3 K       3   1.5 K       1    28.6
   flush         2
-compact         1     0 B             0 B          (size == estimated-debt, in = in-progress-bytes)
+compact         1     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0  (default, delete, elision, move, read)
  memtbl         1   256 K
 zmemtbl         1   256 K
@@ -136,7 +136,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6         1   778 B       -   1.5 K     0 B       0     0 B       0   778 B       1   1.5 K       1     0.5
   total         1   778 B       -    84 B     0 B       0     0 B       0   2.3 K       3   1.5 K       1    28.6
   flush         2
-compact         1     0 B             0 B          (size == estimated-debt, in = in-progress-bytes)
+compact         1     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0  (default, delete, elision, move, read)
  memtbl         1   256 K
 zmemtbl         1   256 K
@@ -168,7 +168,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6         1   778 B       -   1.5 K     0 B       0     0 B       0   778 B       1   1.5 K       1     0.5
   total         1   778 B       -    84 B     0 B       0     0 B       0   2.3 K       3   1.5 K       1    28.6
   flush         2
-compact         1     0 B             0 B          (size == estimated-debt, in = in-progress-bytes)
+compact         1     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0  (default, delete, elision, move, read)
  memtbl         1   256 K
 zmemtbl         0     0 B

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -21,7 +21,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       6         0     0 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
   total         1   986 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
   flush         0
-compact         0     0 B             0 B          (size == estimated-debt, in = in-progress-bytes)
+compact         0     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         0       0       0       0       0  (default, delete, elision, move, read)
  memtbl         1   256 K
 zmemtbl         0     0 B


### PR DESCRIPTION
To better gauge compaction concurrency, add the
`Compact.InProgressCount` field to the `Metrics` struct. The value of
this field indicates the number of in-progress compactions.