### PR TITLE
ci: pin macOS builds to macos-11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,7 +97,7 @@ jobs:
 
   darwin:
     name: go1.16-macos
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
Rather than using `macos-latest` and having the build environment
change, pin the build to `macos-11`.