### PR TITLE
*: move test-only code into test files

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2039,6 +2039,14 @@ func TestCompactionReadTriggeredQueue(t *testing.T) {
 	)
 }
 
+func (qu *readCompactionQueue) at(i int) *readCompaction {
+	if i >= qu.size {
+		return nil
+	}
+
+	return qu.queue[i]
+}
+
 func TestCompactionReadTriggered(t *testing.T) {
 	var d *DB
 	defer func() {

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -482,7 +482,6 @@ func TestGetIter(t *testing.T) {
 		var files [numLevels][]*fileMetadata
 		for _, tt := range tc.tables {
 			d := newMemTable(memTableOptions{})
-			defer d.close()
 			m[tt.fileNum] = d
 
 			meta := &fileMetadata{

--- a/mem_table.go
+++ b/mem_table.go
@@ -149,25 +149,6 @@ func (m *memTable) readyForFlush() bool {
 	return atomic.LoadInt32(&m.writerRefs) == 0
 }
 
-// Get gets the value for the given key. It returns ErrNotFound if the DB does
-// not contain the key.
-func (m *memTable) get(key []byte) (value []byte, err error) {
-	it := m.skl.NewIter(nil, nil)
-	ikey, val := it.SeekGE(key)
-	if ikey == nil {
-		return nil, ErrNotFound
-	}
-	if !m.equal(key, ikey.UserKey) {
-		return nil, ErrNotFound
-	}
-	switch ikey.Kind() {
-	case InternalKeyKindDelete, InternalKeyKindSingleDelete:
-		return nil, ErrNotFound
-	default:
-		return val, nil
-	}
-}
-
 // Prepare reserves space for the batch in the memtable and references the
 // memtable preventing it from being flushed until the batch is applied. Note
 // that prepare is not thread-safe, while apply is. The caller must call
@@ -260,10 +241,6 @@ func (m *memTable) inuseBytes() uint64 {
 
 func (m *memTable) totalBytes() uint64 {
 	return uint64(m.skl.Arena().Capacity())
-}
-
-func (m *memTable) close() error {
-	return nil
 }
 
 // empty returns whether the MemTable has no key/value pairs.

--- a/read_compaction_queue.go
+++ b/read_compaction_queue.go
@@ -26,18 +26,9 @@ type readCompactionQueue struct {
 	size int
 }
 
-func (qu *readCompactionQueue) at(i int) *readCompaction {
-	if i >= qu.size {
-		return nil
-	}
-
-	return qu.queue[i]
-}
-
 // combine should be used to combine an older queue with a newer
 // queue.
-func (qu *readCompactionQueue) combine(
-	newQu *readCompactionQueue, cmp base.Compare) {
+func (qu *readCompactionQueue) combine(newQu *readCompactionQueue, cmp base.Compare) {
 
 	for i := 0; i < newQu.size; i++ {
 		qu.add(newQu.queue[i], cmp)

--- a/sstable/compression_cgo.go
+++ b/sstable/compression_cgo.go
@@ -12,17 +12,6 @@ import (
 	"github.com/DataDog/zstd"
 )
 
-// useStandardZstdLib indicates whether the zstd implementation is a port of the
-// official one in the facebook/zstd repository.
-//
-// This constant is only used in tests. Some tests rely on reproducibility of
-// SST files, but a custom implementation of zstd will produce different
-// compression result. So those tests have to be disabled in such cases.
-//
-// We cannot always use the official facebook/zstd implementation since it
-// relies on CGo.
-const useStandardZstdLib = true
-
 // decodeZstd decompresses b with the Zstandard algorithm.
 // It reuses the preallocated capacity of decodedBuf if it is sufficient.
 // On success, it returns the decoded byte slice.

--- a/sstable/compression_cgo_test.go
+++ b/sstable/compression_cgo_test.go
@@ -1,0 +1,18 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build cgo
+
+package sstable
+
+// useStandardZstdLib indicates whether the zstd implementation is a port of the
+// official one in the facebook/zstd repository.
+//
+// This constant is only used in tests. Some tests rely on reproducibility of
+// SST files, but a custom implementation of zstd will produce different
+// compression result. So those tests have to be disabled in such cases.
+//
+// We cannot always use the official facebook/zstd implementation since it
+// relies on CGo.
+const useStandardZstdLib = true

--- a/sstable/compression_nocgo.go
+++ b/sstable/compression_nocgo.go
@@ -6,20 +6,7 @@
 
 package sstable
 
-import (
-	"github.com/klauspost/compress/zstd"
-)
-
-// useStandardZstdLib indicates whether the zstd implementation is a port of the
-// official one in the facebook/zstd repository.
-//
-// This constant is only used in tests. Some tests rely on reproducibility of
-// SST files, but a custom implementation of zstd will produce different
-// compression result. So those tests have to be disabled in such cases.
-//
-// We cannot always use the official facebook/zstd implementation since it
-// relies on CGo.
-const useStandardZstdLib = false
+import "github.com/klauspost/compress/zstd"
 
 // decodeZstd decompresses b with the Zstandard algorithm.
 // It reuses the preallocated capacity of decodedBuf if it is sufficient.

--- a/sstable/compression_nocgo_test.go
+++ b/sstable/compression_nocgo_test.go
@@ -1,0 +1,18 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build !cgo
+
+package sstable
+
+// useStandardZstdLib indicates whether the zstd implementation is a port of the
+// official one in the facebook/zstd repository.
+//
+// This constant is only used in tests. Some tests rely on reproducibility of
+// SST files, but a custom implementation of zstd will produce different
+// compression result. So those tests have to be disabled in such cases.
+//
+// We cannot always use the official facebook/zstd implementation since it
+// relies on CGo.
+const useStandardZstdLib = false

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -30,6 +30,55 @@ import (
 	"golang.org/x/exp/rand"
 )
 
+// get is a testing helper that simulates a read and helps verify bloom filters
+// until they are available through iterators.
+func (r *Reader) get(key []byte) (value []byte, err error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	if r.tableFilter != nil {
+		dataH, err := r.readFilter()
+		if err != nil {
+			return nil, err
+		}
+		var lookupKey []byte
+		if r.Split != nil {
+			lookupKey = key[:r.Split(key)]
+		} else {
+			lookupKey = key
+		}
+		mayContain := r.tableFilter.mayContain(dataH.Get(), lookupKey)
+		dataH.Release()
+		if !mayContain {
+			return nil, base.ErrNotFound
+		}
+	}
+
+	i, err := r.NewIter(nil /* lower */, nil /* upper */)
+	if err != nil {
+		return nil, err
+	}
+	ikey, value := i.SeekGE(key)
+
+	if ikey == nil || r.Compare(key, ikey.UserKey) != 0 {
+		err := i.Close()
+		if err == nil {
+			err = base.ErrNotFound
+		}
+		return nil, err
+	}
+
+	// The value will be "freed" when the iterator is closed, so make a copy
+	// which will outlast the lifetime of the iterator.
+	newValue := make([]byte, len(value))
+	copy(newValue, value)
+	if err := i.Close(); err != nil {
+		return nil, err
+	}
+	return newValue, nil
+}
+
 // iterAdapter adapts the new Iterator API which returns the key and value from
 // positioning methods (Seek*, First, Last, Next, Prev) to the old API which
 // returned a boolean corresponding to Valid. Only used by test code.
@@ -108,18 +157,18 @@ func (i *iterAdapter) SetBounds(lower, upper []byte) {
 func TestReader(t *testing.T) {
 	writerOpts := map[string]WriterOptions{
 		// No bloom filters.
-		"default": WriterOptions{},
-		"bloom10bit": WriterOptions{
+		"default": {},
+		"bloom10bit": {
 			// The standard policy.
 			FilterPolicy: bloom.FilterPolicy(10),
 			FilterType:   base.TableFilter,
 		},
-		"bloom1bit": WriterOptions{
+		"bloom1bit": {
 			// A policy with many false positives.
 			FilterPolicy: bloom.FilterPolicy(1),
 			FilterType:   base.TableFilter,
 		},
-		"bloom100bit": WriterOptions{
+		"bloom100bit": {
 			// A policy unlikely to have false positives.
 			FilterPolicy: bloom.FilterPolicy(100),
 			FilterType:   base.TableFilter,


### PR DESCRIPTION
Move some code that's only used within test builds into test files. In
the case of `(*memTable).close`, remove it altogether because it's a
no-op.

For some reason I don't understand, the `staticcheck` linter surfaced
these on a work-in-progress branch of mine that didn't touch anything
related to these, but doesn't surface them on master.

```
mem_table.go:154:20: func (*memTable).get is unused (U1000)
mem_table.go:265:20: func (*memTable).close is unused (U1000)
mem_table.go:270:20: func (*memTable).empty is unused (U1000)
read_compaction_queue.go:29:32: func (*readCompactionQueue).at is unused (U1000)
sstable/compression_cgo.go:24:7: const useStandardZstdLib is unused (U1000)
sstable/reader.go:2060:18: func (*Reader).get is unused (U1000)
```