### PR TITLE
Add .gitignore; ignore profiling artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Profiling artifacts.
+cpu.*.prof
+heap.prof
+mutex.prof


### PR DESCRIPTION
Add a .gitignore.

Ignore pprof artifacts generated by benchmarks.