### PR TITLE
compaction: use great-grandparents in the absence of grandparents

### DIFF
--- a/testdata/compaction_picker_L0
+++ b/testdata/compaction_picker_L0
@@ -239,6 +239,7 @@ pick-auto
 ----
 L0 -> L0
 L0: 000100,000110,000130,000140
+grandparents: 000200
 
 max-output-file-size
 ----

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -865,3 +865,45 @@ compact a-z L1
 2:
   000006:[b#0,SET-b#0,SET]
   000007:[c#0,SET-c#0,SET]
+
+# A range tombstone extends past the great-grandparent file boundary used to
+# limit the size of compactions. Verify the range tombstone is split at that
+# file boundary.
+
+define target-file-sizes=(1, 1, 1, 1)
+L1
+  a.SET.3:v
+L2
+  a.RANGEDEL.2:e
+L4
+  a.SET.0:v
+  b.SET.0:v
+L4
+  c.SET.0:v
+  d.SET.0:v
+----
+1:
+  000004:[a#3,SET-a#3,SET]
+2:
+  000005:[a#2,RANGEDEL-e#72057594037927935,RANGEDEL]
+4:
+  000006:[a#0,SET-b#0,SET]
+  000007:[c#0,SET-d#0,SET]
+
+wait-pending-table-stats
+000005
+----
+num-entries: 1
+num-deletions: 1
+point-deletions-bytes-estimate: 0
+range-deletions-bytes-estimate: 1552
+
+compact a-e L1
+----
+2:
+  000008:[a#3,SET-b#72057594037927935,RANGEDEL]
+  000009:[b#2,RANGEDEL-d#72057594037927935,RANGEDEL]
+  000010:[d#2,RANGEDEL-e#72057594037927935,RANGEDEL]
+4:
+  000006:[a#0,SET-b#0,SET]
+  000007:[c#0,SET-d#0,SET]


### PR DESCRIPTION
If a compaction has no grandparents, the output files will be immediately
eligible for a move compaction. At that point, they may excessively overlap
with the next level. Use overlapping files lower in the LSM in replace of the
grandparents if there are no grandparents.

Inspired by facebook/rocksdb#9051.