### PR TITLE
mkbench: use benchmark data to infer names

### DIFF
--- a/internal/mkbench/testdata/write-throughput/summary.json
+++ b/internal/mkbench/testdata/write-throughput/summary.json
@@ -1,13 +1,13 @@
 {
-	"size=1024": [
+	"write/values=1024": [
 		{
-			"name": "size=1024",
+			"name": "write/values=1024",
 			"date": "20211027",
 			"opsSec": 58825,
 			"summaryPath": "20211027-pebble-write-size=1024-run_1-summary.json"
 		},
 		{
-			"name": "size=1024",
+			"name": "write/values=1024",
 			"date": "20211028",
 			"opsSec": 65525,
 			"summaryPath": "20211028-pebble-write-size=1024-run_1-summary.json"


### PR DESCRIPTION
Currently, the benchmark data parser for the write-throughput benchmarks
attempts to infer the benchmark workload name (e.g. `write/values=1024`)
from the directory structure.

Match the behavior of the YCSB benchmark data parser by using the raw
data from the file.

Flatten a nested map used as a "multi-map" by instead using a struct as
the map key.

Related to #1369.