### PR TITLE
ci: add tidy-check lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,3 +142,17 @@ jobs:
       env:
         GOOS: freebsd
       run: go build -v ./...
+
+  mod-tidy-check:
+    name: mod-tidy-check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: "1.17"
+
+    - name: mod-tidy-check
+      run: make mod-tidy-check

--- a/Makefile
+++ b/Makefile
@@ -48,3 +48,22 @@ mod-update:
 .PHONY: clean
 clean:
 	rm -f $(patsubst %,%.test,$(notdir $(shell go list ${PKG})))
+
+git_dirty := $(shell git status -s)
+
+.PHONY: git-clean-check
+git-clean-check:
+ifneq ($(git_dirty),)
+	@echo "Git repository is dirty!"
+	@false
+else
+	@echo "Git repository is clean."
+endif
+
+.PHONY: mod-tidy-check
+mod-tidy-check:
+ifneq ($(git_dirty),)
+	$(error tidy-check must be invoked on a clean repository)
+endif
+	@${GO} mod tidy
+	$(MAKE) git-clean-check


### PR DESCRIPTION
As dependencies are added and updated, the go.mod and go.sum file can
drift. This can result in unnecessary "noise" being introduced into
diffs.

Add a CI check that ensures that running `go mod tidy` on the repo
results in no change to the mod and sum files.