### PR TITLE
 sstable: add parallelized RewriteKeySuffixes function

### DIFF
--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -363,7 +363,7 @@ func runRewriteCmd(
 	}
 
 	f := &memFile{}
-	meta, err := RewriteKeySuffixes(r, f, opts, from, to)
+	meta, err := RewriteKeySuffixes(r, f, opts, from, to, 2)
 	if err != nil {
 		return nil, r, errors.Wrap(err, "rewrite failed")
 	}

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -3,27 +3,299 @@ package sstable
 import (
 	"bytes"
 	"os"
+	"sync"
 	"time"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/cache"
 )
 
-// RewriteKeySuffixes copies the sstable in the passed reader to out, but with
-// each key updated to have the byte suffix `from` replaced with `to`. It is
-// required that the SST consist of only SETs, and that every key have `from` as
-// its suffix, and furthermore the length of from must match the suffix length
-// designated by the Split() function if one is set in the WriterOptions.
+// RewriteKeySuffixes copies the content of the passed SSTable Reader to a new
+// sstable, written to `out`, in which the suffix `from` has is replaced with
+// `to` in every key. The input sstable must consist of only Sets and every key
+// must have `from` as its suffix as determined by the Split function of the
+// Comparer in the passed WriterOptions.
+//
+// Data blocks are rewritten in parallel by `concurrency` workers and then
+// assembled into a final SST. Filters are copied from the original SST without
+// modification as they are not affected by the suffix, while block and table
+// properties are only minimally recomputed.
+//
+// TODO(dt): Currently table and block properties are re-derived by passing each
+// property collector just one example key from each block. While this may be
+// sufficient for some property implementations, it is not correct in the
+// general case. Instead, a new API should be added to let collectors update
+// their collected value based on the change in suffix or indicate if that is
+// unsupported. Until that follow-up change however, this method should only be
+// used iff the collectors are verified to be correct with this behavior.
+//
+// TODO(dt): rework block reading to avoid cache.Set contention.
 func RewriteKeySuffixes(
-	r *Reader,
-	out writeCloseSyncer, o WriterOptions,
-	from, to []byte,
+	r *Reader, out writeCloseSyncer, o WriterOptions, from, to []byte, concurrency int,
 ) (*WriterMetadata, error) {
-	return iterateReaderIntoWriter(r, out, o, from, to)
+	if o.Comparer == nil || o.Comparer.Split == nil {
+		return nil, errors.New("a valid splitter is required to define suffix to replace replace suffix")
+	}
+	if concurrency < 1 {
+		return nil, errors.New("concurrency must be >= 1")
+	}
+
+	l, err := r.Layout()
+	if err != nil {
+		return nil, errors.Wrap(err, "reading layout")
+	}
+
+	w := NewWriter(out, o)
+
+	if err := rewriteDataBlocksToWriter(r, w, l.Data, from, to, w.split, concurrency); err != nil {
+		return nil, errors.Wrap(err, "rewriting data blocks")
+	}
+
+	// Copy over the filter block if it exists (rewriteDataBlocksToWriter will
+	// already have ensured this is valid if it exists).
+	var filterBlock cache.Handle
+	if w.filter != nil {
+		if l.Filter.Length == 0 {
+			return nil, errors.New("input table has no filter")
+		}
+		filterBlock, err = r.readBlock(l.Filter, nil, nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "reading filter")
+		}
+		w.filter = copyFilterWriter{
+			origPolicyName: w.filter.policyName(), origMetaName: w.filter.metaName(), data: filterBlock.Get(),
+		}
+	}
+
+	if err := w.Close(); err != nil {
+		filterBlock.Release()
+		return nil, err
+	}
+	filterBlock.Release()
+
+	return w.Metadata()
 }
 
-func iterateReaderIntoWriter(
+var errBadKind = errors.New("key does not have expected kind (set)")
+
+type blockWithSpan struct {
+	start, end InternalKey
+	data       []byte
+}
+
+func rewriteBlocks(
+	r *Reader, restartInterval int, checksumType ChecksumType, compression Compression,
+	input []BlockHandle, output []blockWithSpan,
+	totalWorkers, worker int,
+	from, to []byte,
+	split Split,
+) error {
+	bw := blockWriter{
+		restartInterval: restartInterval,
+	}
+	buf := blockBuf{checksummer: checksummer{checksumType: checksumType}}
+	if checksumType == ChecksumTypeXXHash {
+		buf.checksummer.xxHasher = xxhash.New()
+	}
+
+	var blockAlloc []byte
+	var keyAlloc []byte
+	var scratch InternalKey
+	iter := &blockIter{}
+
+	// We'll assume all blocks are _roughly_ equal so round-robin static partition
+	// of each worker doing every ith block is probably enough.
+	for i := worker; i < len(input); i += totalWorkers {
+		bh := input[i]
+
+		h, err := r.readBlock(bh, nil /* transform */, nil /*rs*/)
+		if err != nil {
+			return err
+		}
+		inputBlock := h.Get()
+		if err := iter.init(r.Compare, inputBlock, r.Properties.GlobalSeqNum); err != nil {
+			h.Release()
+			return err
+		}
+
+		if cap(bw.restarts) < int(iter.restarts) {
+			bw.restarts = make([]uint32, 0, iter.restarts)
+		}
+		if cap(bw.buf) == 0 {
+			bw.buf = make([]byte, 0, len(inputBlock))
+		}
+		if cap(bw.restarts) < int(iter.numRestarts) {
+			bw.restarts = make([]uint32, 0, iter.numRestarts)
+		}
+
+		for key, val := iter.First(); key != nil; key, val = iter.Next() {
+			if key.Kind() != InternalKeyKindSet {
+				h.Release()
+				return errBadKind
+			}
+			si := split(key.UserKey)
+			oldSuffix := key.UserKey[si:]
+			if !bytes.Equal(oldSuffix, from) {
+				err := errors.Errorf("key has suffix %q, expected %q", oldSuffix, from)
+				h.Release()
+				return err
+			}
+			newLen := si + len(to)
+			if cap(scratch.UserKey) < newLen {
+				scratch.UserKey = make([]byte, 0, len(key.UserKey)*2+len(to)-len(from))
+			}
+
+			scratch.Trailer = key.Trailer
+			scratch.UserKey = scratch.UserKey[:newLen]
+			copy(scratch.UserKey, key.UserKey[:si])
+			copy(scratch.UserKey[si:], to)
+
+			bw.add(scratch, val)
+			if output[i].start.UserKey == nil {
+				keyAlloc, output[i].start = cloneKeyWithBuf(scratch, keyAlloc)
+			}
+		}
+		*iter = iter.resetForReuse()
+
+		keyAlloc, output[i].end = cloneKeyWithBuf(scratch, keyAlloc)
+		h.Release()
+
+		finished := compressAndChecksum(bw.finish(), compression, &buf)
+
+		// copy our finished block into the output buffer.
+		sz := len(finished) + blockTrailerLen
+		if cap(blockAlloc) < sz {
+			blockAlloc = make([]byte, sz*128)
+		}
+		output[i].data = blockAlloc[:sz:sz]
+		blockAlloc = blockAlloc[sz:]
+		copy(output[i].data, finished)
+		copy(output[i].data[len(finished):], buf.tmp[:blockTrailerLen])
+	}
+	return nil
+}
+
+func rewriteDataBlocksToWriter(r *Reader, w *Writer, data []BlockHandle, from, to []byte, split Split, concurrency int) error {
+	blocks := make([]blockWithSpan, len(data))
+
+	if w.filter != nil {
+		if r.Properties.FilterPolicyName != w.filter.policyName() {
+			return errors.New("mismatched filters")
+		}
+		if was, is := r.Properties.ComparerName, w.props.ComparerName; was != is {
+			return errors.Errorf("mismatched Comparer %s vs %s, replacement requires same splitter to copy filters", was, is)
+		}
+	}
+
+	g := &sync.WaitGroup{}
+	g.Add(concurrency)
+	errCh := make(chan error, concurrency)
+	for i := 0; i < concurrency; i++ {
+		worker := i
+		go func() {
+			defer g.Done()
+			err := rewriteBlocks(
+				r,
+				w.dataBlockBuf.dataBlock.restartInterval,
+				w.blockBuf.checksummer.checksumType,
+				w.compression,
+				data,
+				blocks,
+				concurrency,
+				worker,
+				from, to,
+				split,
+			)
+			if err != nil {
+				errCh <- err
+			}
+		}()
+	}
+	g.Wait()
+	close(errCh)
+	if err, ok := <-errCh; ok {
+		return err
+	}
+
+	for _, p := range w.propCollectors {
+		// TODO(dt): we're not passing value here. Perhaps we should have a separate
+		// method in the interface like AddSingleExampleKeyForTable(key) that an
+		// impl could choose to implement or not?
+		if err := p.Add(blocks[0].start, nil); err != nil {
+			return err
+		}
+	}
+
+	for i := range blocks {
+		// Write the rewritten block to the file.
+		n, err := w.writer.Write(blocks[i].data)
+		if err != nil {
+			return err
+		}
+
+		bh := BlockHandle{Offset: w.meta.Size, Length: uint64(n) - blockTrailerLen}
+		// Update the overall size.
+		w.meta.Size += uint64(n)
+
+		// Pass each block property collector the first key from the block, so that
+		// it can collect any properties for the block. This assumes that it'd
+		// collect the same property from this one key that it'd collect if passed
+		// all keys in the block.
+		// TODO(dt): perhaps we should add a method to the collector interface like
+		// AddExampleForBlock so that implementations can decide if they are okay
+		// with this? also ditto above, no value here.
+		for _, p := range w.blockPropCollectors {
+			if err := p.Add(blocks[i].start, nil); err != nil {
+				return err
+			}
+		}
+
+		var bhp BlockHandleWithProperties
+		if bhp, err = w.maybeAddBlockPropertiesToBlockHandle(bh); err != nil {
+			return err
+		}
+		var nextKey InternalKey
+		if i+1 < len(blocks) {
+			nextKey = blocks[i+1].start
+		}
+		if err = w.addIndexEntry(blocks[i].end, nextKey, bhp, w.dataBlockBuf.tmp[:]); err != nil {
+			return err
+		}
+	}
+
+	w.meta.updateSeqNum(blocks[0].start.SeqNum())
+	w.props.NumEntries = r.Properties.NumEntries
+	w.props.RawKeySize = r.Properties.RawKeySize
+	w.props.RawValueSize = r.Properties.RawValueSize
+	w.meta.SmallestPoint = blocks[0].start
+	w.meta.LargestPoint = blocks[len(blocks)-1].end
+	return nil
+}
+
+type copyFilterWriter struct {
+	origMetaName   string
+	origPolicyName string
+	data           []byte
+}
+
+func (copyFilterWriter) addKey(key []byte)         { panic("unimplemented") }
+func (c copyFilterWriter) finish() ([]byte, error) { return c.data, nil }
+func (c copyFilterWriter) metaName() string        { return c.origMetaName }
+func (c copyFilterWriter) policyName() string      { return c.origPolicyName }
+
+// RewriteKeySuffixesViaWriter is similar to RewriteKeySuffixes but uses just a
+// single loop over the Reader that writes each key to the Writer with the new
+// suffix. The is significantly slower than the parallelized rewriter, and does
+// more work to rederive filters, props, etc, however re-doing that work makes
+// it less restrictive -- props no longer need to
+func RewriteKeySuffixesViaWriter(
 	r *Reader, out writeCloseSyncer, o WriterOptions, from, to []byte,
 ) (*WriterMetadata, error) {
+	if o.Comparer == nil || o.Comparer.Split == nil {
+		return nil, errors.New("a valid splitter is required to define suffix to replace replace suffix")
+	}
+
 	w := NewWriter(out, o)
 	i, err := r.NewIter(nil, nil)
 	if err != nil {
@@ -37,13 +309,9 @@ func iterateReaderIntoWriter(
 		if k.Kind() != InternalKeyKindSet {
 			return nil, errors.New("invalid key type")
 		}
-		if !bytes.HasSuffix(k.UserKey, from) {
-			return nil, errors.New("mismatched key suffix")
-		}
-		if w.split != nil {
-			if s := len(k.UserKey) - w.split(k.UserKey); s != len(from) {
-				return nil, errors.Errorf("mismatched replacement (%d) vs Split (%d) suffix", len(from), s)
-			}
+		oldSuffix := k.UserKey[r.Split(k.UserKey):]
+		if !bytes.Equal(oldSuffix, from) {
+			return nil, errors.Errorf("key has suffix %q, expected %q", oldSuffix, from)
 		}
 		scratch.UserKey = append(scratch.UserKey[:0], k.UserKey[:len(k.UserKey)-len(from)]...)
 		scratch.UserKey = append(scratch.UserKey, to...)

--- a/sstable/suffix_rewriter_test.go
+++ b/sstable/suffix_rewriter_test.go
@@ -89,11 +89,22 @@ func BenchmarkRewriteSST(b *testing.B) {
 						stat, _ := r.file.Stat()
 						b.SetBytes(stat.Size())
 						for i := 0; i < b.N; i++ {
-							if _, err := iterateReaderIntoWriter(r, &discardFile{}, writerOpts, []byte("_123"), []byte("_456")); err != nil {
+							if _, err := RewriteKeySuffixesViaWriter(r, &discardFile{}, writerOpts, []byte("_123"), []byte("_456")); err != nil {
 								b.Fatal(err)
 							}
 						}
 					})
+					for _, concurrency := range []int{1, 2, 4, 8, 16} {
+						b.Run(fmt.Sprintf("RewriteKeySuffixes,concurrency=%d", concurrency), func(b *testing.B) {
+							stat, _ := r.file.Stat()
+							b.SetBytes(stat.Size())
+							for i := 0; i < b.N; i++ {
+								if _, err := RewriteKeySuffixes(r, &discardFile{}, writerOpts, []byte("_123"), []byte("_456"), concurrency); err != nil {
+									b.Fatal(err)
+								}
+							}
+						})
+					}
 				})
 			}
 		})

--- a/sstable/testdata/rewriter
+++ b/sstable/testdata/rewriter
@@ -8,13 +8,13 @@ rangedel: [#0,0,#0,0]
 rangekey: [#0,0,#0,0]
 seqnums:  [1,1]
 
-# rewrite from=xyz to=123 block-size=1 index-block-size=1 filter
-# ----
-# rewrite failed: rewriting data blocks: no splitter, cannot copy filters
+rewrite from=xyz to=123 block-size=1 index-block-size=1 filter
+----
+rewrite failed: a valid splitter is required to define suffix to replace replace suffix
 
-# rewrite from=xyz to=123 block-size=1 index-block-size=1 filter comparer-split-4b-suffix
-# ----
-# rewrite failed: rewriting data blocks: mismatched Comparer leveldb.BytewiseComparator vs comparer-split-4b-suffix, replacement requires same splitter to copy filters
+rewrite from=xyz to=123 block-size=1 index-block-size=1 filter comparer-split-4b-suffix
+----
+rewrite failed: rewriting data blocks: mismatched Comparer leveldb.BytewiseComparator vs comparer-split-4b-suffix, replacement requires same splitter to copy filters
 
 build block-size=1 index-block-size=1 filter comparer-split-4b-suffix
 aa_xyz.SET.1:a
@@ -28,11 +28,11 @@ seqnums:  [1,1]
 
 rewrite from=yz to=23 block-size=1 index-block-size=1 filter comparer-split-4b-suffix
 ----
-rewrite failed: mismatched replacement (2) vs Split (4) suffix
+rewrite failed: rewriting data blocks: key has suffix "_xyz", expected "yz"
 
 rewrite from=a_xyz to=a_123 block-size=1 index-block-size=1 filter comparer-split-4b-suffix
 ----
-rewrite failed: mismatched replacement (5) vs Split (4) suffix
+rewrite failed: rewriting data blocks: key has suffix "_xyz", expected "a_xyz"
 
 build block-size=1 index-block-size=1 filter comparer-split-4b-suffix
 a_xyz.SET.1:a


### PR DESCRIPTION
This adds a function to the sstable package that can replace some suffix
with another suffix from every key in an sstable, assuming enforcing
that the sstable consists of only Sets.

If the replacement is passed a filter policy, rather than build new
filters, the filter blocks from the original sstable are copied over,
but only after checking that it used the same filter policy and the same
splitter, and that that splitter splits the same length that as is being
replaced i.e. that the pre-replacement filter remains valid
post-replacement.

Data blocks are rewritten in parallel. This informs a few choices in how
it does so: rewritten keys are not passed to `addPoint`, but rather are
directly handed to a worker-local blockWriter. Finished blocks are not
immediately flushed to the output or added to the index, but rather are
added to a buffer, which is then iterated and flushed at the end.

A significant implication of not passing each key to `addPoint` is that
individual KVs are not passed to the table and block property collectors
during rewriting. Instead, when flushing the finished blocks, each table
collector is passed just the first key of the table and each block prop
collector is passed the first key of each block. For the collectors that
CockroachDB uses, to which only the timestamp key suffix is relevant,
this approach may be sufficient, as during replacement all keys in all
blocks have the same suffix. However extending the collector API could
allow this to be more general, e.g. either by making a separate API for
this approach, like AddOneKeyForBlock, or by making the collectors able
to collect and aggregate partial results, so each rewriter could have a
local partial collector and then merge their results. However as the
simple approach of just passing one key per block to the existing API
appears sufficient for CockroachDB, this is left for later exploration.

Benchmarking this implementation compared to simply opening a writer and
feeding each key from a reader to it shows modest gains even without the
addition of concurrency, just from skipping rebuilding filters and props
from every key, with a 12M SST rewriting at about 33% faster. With the
addition of concurrency=8, this jumps to about a 7.5x speedup over the
naive read/write iteration, of 5x over concurrency=1.

```
BenchmarkRewriter
    writer_test.go:357: rewriting a 12 M SSTable
BenchmarkRewriter/RewriteKeySuffixes,concurrency=1
BenchmarkRewriter/RewriteKeySuffixes,concurrency=1-10                130          91251942 ns/op
BenchmarkRewriter/RewriteKeySuffixes,concurrency=8
BenchmarkRewriter/RewriteKeySuffixes,concurrency=8-10                666          18205387 ns/op
BenchmarkRewriter/read-and-write-new-sst
BenchmarkRewriter/read-and-write-new-sst-10                           88         134926796 ns/op
```