### PR TITLE
*: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# See http://editorconfig.org
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+# For non-go files, we indent with two spaces. In go files we indent
+# with tabs but still set indent_size to control the github web viewer.
+indent_size=2


### PR DESCRIPTION
This is the same config cockroachdb/cockroach uses, which causes
github to render diffs in Go sources, with their lovely hard tabs,
using a tabwidth of 2.