### PR TITLE
sstable: use package-level error in place of runtime allocation

### DIFF
--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -21,6 +21,8 @@ import (
 	"github.com/cockroachdb/pebble/internal/private"
 )
 
+var errWriterClosed = errors.New("pebble: writer is closed")
+
 // WriterMetadata holds info about a finished sstable.
 type WriterMetadata struct {
 	Size           uint64
@@ -806,7 +808,7 @@ func (w *Writer) Close() (err error) {
 	}
 
 	// Make any future calls to Set or Close return an error.
-	w.err = errors.New("pebble: writer is closed")
+	w.err = errWriterClosed
 	return nil
 }
 


### PR DESCRIPTION
Currently, `sstable.(*Writer).Close`, calls `errors.New` on the happy
path when finalizing an sstable. While this call is relatively
inexpensive and infrequent, it is unnecessary.

Extract out error definition into a package-level variable that can be
referenced throughout the course of the program's runtime.