### PR TITLE
db: pipeline sstable block compression

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2144,7 +2144,13 @@ func (d *DB) runCompaction(
 		filenames = append(filenames, filename)
 		cacheOpts := private.SSTableCacheOpts(d.cacheID, fileNum).(sstable.WriterOption)
 		internalTableOpt := private.SSTableInternalTableOpt.(sstable.WriterOption)
-		tw = sstable.NewWriter(file, writerOpts, cacheOpts, internalTableOpt)
+		parallelCompressionOpt := sstable.ParallelCompressionOpt{
+			CompressionQueue: d.compressionQueue, WriteQueueSize: writerOpts.WriteQueueSize,
+		}
+		tw = sstable.NewWriter(
+			file, writerOpts, cacheOpts,
+			internalTableOpt, parallelCompressionOpt,
+		)
 
 		fileMeta.CreationTime = time.Now().Unix()
 		ve.NewFiles = append(ve.NewFiles, newFileEntry{

--- a/db.go
+++ b/db.go
@@ -1043,6 +1043,9 @@ func (d *DB) Close() error {
 	d.mu.Unlock()
 	d.deleters.Wait()
 	d.compactionSchedulers.Wait()
+
+	// NB: compressionQueue must only be closed, once all the compaction
+	// goroutines have stopped running.
 	if d.compressionQueue != nil {
 		d.compressionQueue.Close()
 	}

--- a/db.go
+++ b/db.go
@@ -401,7 +401,7 @@ type DB struct {
 
 	// compressionQueue is used to queue blocks which need to be compressed.
 	// Goroutines will read these blocks and process them in parallel.
-	compressionQueue *sstable.CompressionWorkersQueue
+	compressionQueue *sstable.CompressionQueue
 
 	// Normally equal to time.Now() but may be overridden in tests.
 	timeNow func() time.Time

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -191,6 +191,10 @@ func standardOptions() []*testOptions {
 [TestOptions]
  use_disk=true
 `,
+		22: `
+[Options]
+  max_compression_concurrency=5
+`,
 	}
 
 	opts := make([]*testOptions, len(stdOpts))
@@ -232,6 +236,10 @@ func randomOptions(rng *rand.Rand) *testOptions {
 	opts.MemTableStopWritesThreshold = 2 + rng.Intn(5) // 2 - 5
 	if rng.Intn(2) == 0 {
 		opts.WALDir = "wal"
+	}
+	if rng.Intn(4) == 0 {
+		// Enable this for a quarter of the random options.
+		opts.Experimental.MaxCompressionConcurrency = 1 + uint64(rng.Intn(6)) // 1 - 6
 	}
 	var lopts pebble.LevelOptions
 	lopts.BlockRestartInterval = 1 + rng.Intn(64)  // 1 - 64

--- a/open.go
+++ b/open.go
@@ -365,15 +365,17 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 
 	if opts.Experimental.MaxCompressionConcurrency >= 1 {
 		queueSize := opts.Experimental.MaxCompressionConcurrency
-		if opts.MaxConcurrentCompactions > int(queueSize) {
-			queueSize = uint64(opts.MaxConcurrentCompactions)
+
+		// +1 for flushes.
+		if opts.MaxConcurrentCompactions+1 > int(queueSize) {
+			queueSize = uint64(opts.MaxConcurrentCompactions) + 1
 		}
 
 		// We have MaxCompressionConcurrencyWorkers. We make the queue size equal to
 		// at least the MaxConcurrentCompactions since each compaction thread will
 		// be adding blocks to the queue for compression. Experimentally, we found that
 		// using a bufferSize equivalent to twice the queue size is appropriate.
-		d.compressionQueue = sstable.NewCompressionWorkersQueue(
+		d.compressionQueue = sstable.NewCompressionQueue(
 			int(queueSize), int(opts.Experimental.MaxCompressionConcurrency), 2*int(queueSize),
 		)
 	}

--- a/options.go
+++ b/options.go
@@ -1019,10 +1019,7 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 			case "wal_bytes_per_sync":
 				o.WALBytesPerSync, err = strconv.Atoi(value)
 			case "max_compression_concurrency":
-				compressionConcurrency, e := strconv.Atoi(value)
-				o.Experimental.MaxCompressionConcurrency = uint64(compressionConcurrency)
-				fmt.Println("set compression concurrency", o.Experimental.MaxCompressionConcurrency)
-				err = e
+				o.Experimental.MaxCompressionConcurrency, err = strconv.ParseUint(value, 10, 64)
 			default:
 				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key) {
 					return nil

--- a/options.go
+++ b/options.go
@@ -700,7 +700,7 @@ func (o *Options) EnsureDefaults() *Options {
 	}
 	// todo(bananabrick) : revert this
 	if o.Experimental.MaxCompressionConcurrency <= 1 {
-		o.Experimental.MaxCompressionConcurrency = 0
+		o.Experimental.MaxCompressionConcurrency = 1
 	}
 	o.initMaps()
 	return o

--- a/options.go
+++ b/options.go
@@ -700,7 +700,7 @@ func (o *Options) EnsureDefaults() *Options {
 	}
 	// todo(bananabrick) : revert this
 	if o.Experimental.MaxCompressionConcurrency <= 1 {
-		o.Experimental.MaxCompressionConcurrency = 0
+		o.Experimental.MaxCompressionConcurrency = 3
 	}
 	o.initMaps()
 	return o

--- a/options.go
+++ b/options.go
@@ -700,7 +700,7 @@ func (o *Options) EnsureDefaults() *Options {
 	}
 	// todo(bananabrick) : revert this
 	if o.Experimental.MaxCompressionConcurrency <= 1 {
-		o.Experimental.MaxCompressionConcurrency = 3
+		o.Experimental.MaxCompressionConcurrency = 0
 	}
 	o.initMaps()
 	return o

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -206,6 +206,10 @@ type WriterOptions struct {
 
 	// Checksum specifies which checksum to use.
 	Checksum ChecksumType
+
+	// WriteQueueSize determines the number of items which can be written
+	// to the Writer.writeQueue without blocking.
+	WriteQueueSize uint64
 }
 
 func (o WriterOptions) ensureDefaults() WriterOptions {

--- a/sstable/parallel_compression.go
+++ b/sstable/parallel_compression.go
@@ -1,0 +1,292 @@
+package sstable
+
+import (
+	"sync"
+)
+
+// Overall Algorithm:
+// We initialize a CompressionWorkersQueue, and launch
+// MaxCompressionConcurreny compression workers. Each worker
+// blocks on a channel waiting for a compression job which is
+// represented using a BlockCompressionCoordinator. Once the
+// compression job is complete, it writes the CompressedData
+// to the BlockCompressionCoordinator.doneCh.
+//
+// Each sstable Writer will have a writeQueueContainer which
+// launches a single worker to write blocks to disk.
+// BlockWriteCoordinators are queued in the writeQueueContainer
+// in the order in which the blocks need to be written to disk. The
+// worker will block on the BlockWriteCoordinator.doneCh as it waits
+// for the corresponding compression job to complete. Once the compression
+// job is complete, the worker will write the block to disk.
+
+// todo(bananabrick) : historic compression ratio for size.
+// Try and move indexBlock/meta.Size stuff to the main thread
+// to avoid writerMu.
+
+func copySliceToDst(dst *[]byte, src []byte) {
+	if len(src) > cap(*dst) {
+		// We assume that eventually dst will have enough cap
+		// to not require this allocation.
+		*dst = make([]byte, 2*len(src))
+	}
+	*dst = (*dst)[:len(src)]
+	copy(*dst, src)
+}
+
+func copySlice(b []byte) []byte {
+	x := make([]byte, len(b))
+	copy(x, b)
+	return x
+}
+
+func copyInternalKey(key InternalKey) InternalKey {
+	key.UserKey = copySlice(key.UserKey)
+	return key
+}
+
+// CompressedData is used to send the compressed block to the
+// writer thread.
+type CompressedData struct {
+	compressed  []byte
+	tmpBuf      [blockHandleLikelyMaxLen]byte
+	err         error
+	compressBuf []byte
+}
+
+// BlockCompressionCoordinator is added to the compression
+// queue to indicate a pending compression.
+type BlockCompressionCoordinator struct {
+	toCompress  []byte
+	compression Compression
+	checksum    ChecksumType
+
+	// doneCh is used to signal to the writer
+	// thread that the compression has been
+	// completed. doneCh should be a
+	// buffered channel of size 1.
+	doneCh chan<- *CompressedData
+}
+
+// BlockWriteCoordinator is added to the write queue
+// to maintain the order of block writes to disk.
+type BlockWriteCoordinator struct {
+	// doneCh is used to maintain write order
+	// in the write queue. doneCh should be a
+	// buffered channel of size 1.
+	doneCh <-chan *CompressedData
+
+	indexSep        InternalKey
+	props           []byte
+	indexProps      []byte
+	flushIndexBlock bool
+}
+
+// CompressionWorkersQueue is used to queue up blocks
+// which will get compressed in parallel.
+type CompressionWorkersQueue struct {
+	queue chan *BlockCompressionCoordinator
+
+	writeCoordinators       chan *BlockWriteCoordinator
+	compressionCoordinators chan *BlockCompressionCoordinator
+	compressedDataState     chan *CompressedData
+
+	// closeWG is used to wait for the background workers
+	// to finish executing.
+	closeWG sync.WaitGroup
+}
+
+func (qu *CompressionWorkersQueue) allocateBuffers(bufferSize int) {
+	for i := 0; i < bufferSize; i++ {
+		w := &BlockWriteCoordinator{}
+		c := &BlockCompressionCoordinator{}
+		data := &CompressedData{}
+
+		qu.writeCoordinators <- w
+		qu.compressionCoordinators <- c
+		qu.compressedDataState <- data
+	}
+}
+
+// NewCompressionWorkersQueue will start numWorkers goroutines to process
+// compression of blocks, and return a usable *CompressionWorkersQueue.
+func NewCompressionWorkersQueue(
+	maxSize int, numWorkers int, bufferSize int) *CompressionWorkersQueue {
+	qu := &CompressionWorkersQueue{}
+	qu.queue = make(chan *BlockCompressionCoordinator, maxSize)
+
+	qu.writeCoordinators = make(chan *BlockWriteCoordinator, bufferSize)
+	qu.compressionCoordinators = make(chan *BlockCompressionCoordinator, bufferSize)
+	qu.compressedDataState = make(chan *CompressedData, bufferSize)
+
+	qu.allocateBuffers(bufferSize)
+
+	for i := 0; i < numWorkers; i++ {
+		qu.closeWG.Add(1)
+		go qu.runWorker()
+	}
+
+	return qu
+}
+
+func (qu *CompressionWorkersQueue) runWorker() {
+	defer qu.closeWG.Done()
+
+	var checksumData checksumData
+	for {
+		toCompress := <-qu.queue
+		if toCompress == nil {
+			// The channel was closed. There might still be more
+			// blocks queued for compression, but we're going to ignore
+			// those.
+			// todo(bananabrick) : Might want to process every item
+			// added to the compression queue, so that the writer worker
+			// doesn't block when the the db is closed.
+			break
+		}
+		checksumData.checksumType = toCompress.checksum
+		compressedData := <-qu.compressedDataState
+		b, err := compressAndChecksum(
+			toCompress.toCompress, toCompress.compression,
+			&compressedData.compressBuf, &compressedData.tmpBuf,
+			&checksumData,
+		)
+		if err != nil {
+			compressedData.err = err
+		} else {
+			// b could be just returning toCompress.toCompress. Since
+			// we'll be releasing toCompress so that it can be re-used,
+			// we copy over the slice here.
+			copySliceToDst(&compressedData.compressed, b)
+		}
+
+		// This call will never block because the doneCh
+		// must be a buffered channel of size 1.
+		toCompress.doneCh <- compressedData
+
+		// Release the compression coordinator.
+		qu.releaseCompressionCoordinator(toCompress)
+	}
+}
+
+// todo(bananabrick) : We need to make sure that there are no references
+// to any of the fields of the values we're releasing. Add a reference
+// counted byte slice to make sure of this.
+func (qu *CompressionWorkersQueue) releaseCompressionCoordinator(c *BlockCompressionCoordinator) {
+	c.doneCh = nil
+	qu.compressionCoordinators <- c
+}
+
+func (qu *CompressionWorkersQueue) releaseWriteCoordinator(w *BlockWriteCoordinator) {
+	w.doneCh = nil
+	qu.writeCoordinators <- w
+}
+
+func (qu *CompressionWorkersQueue) releaseCompressedData(c *CompressedData) {
+	qu.compressedDataState <- c
+}
+
+// Close will only return after the goroutines started
+// by NewCompressionWorkersQueue have stopped running.
+// Items shouldn't be added to the queue once close has
+// been called.
+func (qu *CompressionWorkersQueue) Close() {
+	close(qu.queue)
+	qu.closeWG.Wait()
+}
+
+// writeQueueContainer is used to process compressed blocks
+// in parallel.
+type writeQueueContainer struct {
+	// queue is sequenced by the order of the writes to
+	// the file.
+	queue  chan *BlockWriteCoordinator
+	writer *Writer
+
+	// closeWG is used to wait for the background workers
+	// to finish executing.
+	closeWG sync.WaitGroup
+}
+
+// newwriteQueueContainer will start a single goroutine to process
+// compression of blocks, and return a usable *writeQueueContainer.
+func newWriteQueueContainer(maxSize int, w *Writer) *writeQueueContainer {
+	qu := &writeQueueContainer{}
+	qu.queue = make(chan *BlockWriteCoordinator, maxSize)
+	qu.writer = w
+
+	qu.closeWG.Add(1)
+	go qu.runWorker()
+
+	return qu
+}
+
+func (qu *writeQueueContainer) releaseBuffers(w *BlockWriteCoordinator, c *CompressedData) {
+	qu.writer.parallelWriterState.compressionQueueRef.releaseWriteCoordinator(w)
+	qu.writer.parallelWriterState.compressionQueueRef.releaseCompressedData(c)
+}
+
+func (qu *writeQueueContainer) runWorker() {
+	defer qu.closeWG.Done()
+
+	var err error
+	for {
+		blockWriteCoordinator := <-qu.queue
+		if blockWriteCoordinator == nil {
+			// If blockWriteCoordinator == nil, then
+			// we've already processed all other blocks
+			// since blocks are added to the queue in order.
+			// It's okay to break here.
+			break
+		}
+
+		compressedData := <-blockWriteCoordinator.doneCh
+		// If we've already encountered an error, then we don't
+		// want to write the current sstable using this worker.
+		if err != nil {
+			qu.releaseBuffers(blockWriteCoordinator, compressedData)
+			continue
+		}
+
+		if compressedData.err != nil {
+			err = compressedData.err
+			qu.writer.parallelWriterState.errCh <- err
+			qu.releaseBuffers(blockWriteCoordinator, compressedData)
+			continue
+		}
+
+		bh, err := qu.writer.writeBlockPostCompression(
+			compressedData.compressed, compressedData.tmpBuf,
+		)
+		if err != nil {
+			qu.writer.parallelWriterState.errCh <- err
+			qu.releaseBuffers(blockWriteCoordinator, compressedData)
+			continue
+		}
+
+		bhp := BlockHandleWithProperties{BlockHandle: bh, Props: blockWriteCoordinator.props}
+		encodedBHP := encodeBlockHandleWithProperties(compressedData.tmpBuf[:], bhp)
+		if err = qu.writer.addIndexEntry(
+			blockWriteCoordinator.indexSep, encodedBHP, bhp,
+			// We're copying indexProps here because addIndexEntry will end up holding a reference
+			// to this, and we don't want two references to the same byte slice, which can happen
+			// once we call qu.releaseBuffers.
+			blockWriteCoordinator.flushIndexBlock, copySlice(blockWriteCoordinator.indexProps),
+		); err != nil {
+			qu.writer.parallelWriterState.errCh <- err
+			qu.releaseBuffers(blockWriteCoordinator, compressedData)
+			continue
+		}
+
+		qu.releaseBuffers(blockWriteCoordinator, compressedData)
+	}
+}
+
+// finish will block until the last block written
+// to to the compression queue has been written to
+// the disk, assuming no errors occur.
+// The queue is no longer usable after finish is called.
+func (qu *writeQueueContainer) finish() {
+	close(qu.queue)
+	qu.closeWG.Wait()
+}

--- a/sstable/parallel_compression.go
+++ b/sstable/parallel_compression.go
@@ -75,9 +75,12 @@ type compressionTask struct {
 // writeTask is added to the write queue
 // to maintain the order of block writes to disk.
 type writeTask struct {
-	// doneCh is used to maintain write order
-	// in the write queue. doneCh is a
-	// buffered channel of size 1.
+	// doneCh is a buffered channel of size 1.
+	// The writer goroutine will wait on the doneCh
+	// in the writeTask for the corresponding compressionTask
+	// to complete. This ensures write order of the blocks
+	// to disk since writeTasks are added to the writeQueue
+	// in order.
 	// This channel will be read from at most once.
 	// The read from this channel will block until
 	// the corresponding compressionTask is complete.

--- a/sstable/parallel_compression.go
+++ b/sstable/parallel_compression.go
@@ -161,7 +161,7 @@ func NewCompressionQueue(
 func (qu *CompressionQueue) runWorker() {
 	defer qu.closeWG.Done()
 
-	var checksumData checksumData
+	var checksummer checksummer
 	for {
 		toCompress, ok := <-qu.queue
 		if !ok {
@@ -181,12 +181,12 @@ func (qu *CompressionQueue) runWorker() {
 			break
 		}
 
-		checksumData.checksumType = toCompress.checksum
+		checksummer.checksumType = toCompress.checksum
 		compressedData := <-qu.compressedDataBuffer
 		b, err := compressAndChecksum(
 			toCompress.toCompress, toCompress.compression,
 			&compressedData.compressBuf, &compressedData.tmpBuf,
-			&checksumData,
+			&checksummer,
 		)
 		if err != nil {
 			compressedData.err = err

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -500,8 +500,8 @@ func (w *Writer) maybeAddToFilter(key []byte) {
 }
 
 func (w *Writer) queueBlockForParallelCompression(key InternalKey) error {
-	compressionTask := <-w.parallelWriterState.compressionQueueRef.compressionTaskBuffer
-	writeTask := <-w.parallelWriterState.compressionQueueRef.writeTaskBuffer
+	compressionTask := w.parallelWriterState.compressionQueueRef.compressionTaskBuffer.Get().(*compressionTask)
+	writeTask := w.parallelWriterState.compressionQueueRef.writeTaskBuffer.Get().(*writeTask)
 
 	// We will share this channel so that the compression go routine, and the go routine which
 	// writes the block to disk can communicate.

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -478,7 +478,8 @@ func (w *Writer) queueBlockForParallelCompression(key InternalKey) error {
 	writeTask.flushIndexBlock = flushIndexBlock
 	writeTask.doneCh = doneCh
 
-	// Queue compression + write tasks.
+	// Queue compression + write tasks. It is important that
+	// the tasks are queued in the order here.
 	w.parallelWriterState.writeQueue.queue <- writeTask
 	w.parallelWriterState.compressionQueueRef.queue <- compressionTask
 


### PR DESCRIPTION
Compression of blocks and writing the blocks to a file consume enough cpu that we can extract performance wins by parallelizing compression of blocks, and writing blocks to disk in a separate goroutine. This pr introduces mechanisms which allow us to parallelize compression, and achieve performance gains.

perf difference for no parallel compression vs parallel compression with 5 compression workers on a machine with no IO/CPU bottleneck. Benchmark was run for 30 minutes.
```
name                old ops/sec  new ops/sec  delta
ycsb/E/values=1024   61.2k ± 3%   62.6k ± 4%     ~     (p=0.222 n=5+5)
ycsb/A/values=1024    192k ± 3%    194k ± 5%     ~     (p=0.310 n=5+5)
ycsb/D/values=1024    195k ± 5%    198k ± 3%     ~     (p=0.222 n=5+5)
ycsb/C/values=1024    878k ±24%    943k ± 5%     ~     (p=0.151 n=5+5)
ycsb/B/values=1024    345k ± 5%    351k ± 3%     ~     (p=0.222 n=5+5)
ycsb/F/values=1024   68.0k ±11%   85.2k ± 4%  +25.37%  (p=0.008 n=5+5)

name                old read     new read     delta
ycsb/E/values=1024    109G ± 3%    105G ± 3%   -4.36%  (p=0.008 n=5+5)
ycsb/A/values=1024   1.01T ± 3%   1.02T ± 5%     ~     (p=0.548 n=5+5)
ycsb/D/values=1024    307G ± 5%    305G ± 2%     ~     (p=0.841 n=5+5)
ycsb/C/values=1024   49.1G ± 4%   41.1G ± 5%  -16.41%  (p=0.008 n=5+5)
ycsb/B/values=1024    274G ± 4%    282G ± 3%     ~     (p=0.056 n=5+5)
ycsb/F/values=1024    908G ±22%   1693G ±21%  +86.47%  (p=0.008 n=5+5)

name                old write    new write    delta
ycsb/E/values=1024    121G ± 3%    117G ± 3%   -3.72%  (p=0.016 n=5+5)
ycsb/A/values=1024   1.20T ± 3%   1.21T ± 5%     ~     (p=0.421 n=5+5)
ycsb/D/values=1024    345G ± 5%    343G ± 2%     ~     (p=1.000 n=5+5)
ycsb/C/values=1024   49.1G ± 4%   41.0G ± 5%  -16.41%  (p=0.008 n=5+5)
ycsb/B/values=1024    310G ± 4%    319G ± 3%     ~     (p=0.056 n=5+5)
ycsb/F/values=1024   1.17T ±20%   2.02T ±17%  +72.79%  (p=0.008 n=5+5)

name                old r-amp    new r-amp    delta
ycsb/E/values=1024    7.78 ± 3%    7.06 ± 2%   -9.30%  (p=0.008 n=5+5)
ycsb/A/values=1024    7.05 ± 1%    6.72 ± 1%   -4.60%  (p=0.008 n=5+5)
ycsb/D/values=1024    6.89 ± 1%    6.61 ± 1%   -4.03%  (p=0.008 n=5+5)
ycsb/C/values=1024    2.63 ±48%    2.21 ± 3%     ~     (p=0.151 n=5+5)
ycsb/B/values=1024    5.76 ± 1%    5.57 ± 0%   -3.16%  (p=0.008 n=5+5)
ycsb/F/values=1024    0.00         0.00          ~     (all equal)

name                old w-amp    new w-amp    delta
ycsb/E/values=1024    20.3 ± 2%    19.1 ± 2%   -5.86%  (p=0.008 n=5+5)
ycsb/A/values=1024    6.42 ± 0%    6.39 ± 0%   -0.47%  (p=0.000 n=5+4)
ycsb/D/values=1024    18.1 ± 0%    17.7 ± 0%   -2.18%  (p=0.008 n=5+5)
ycsb/C/values=1024    0.00         0.00          ~     (all equal)
ycsb/B/values=1024    9.21 ± 1%    9.32 ± 1%     ~     (p=0.063 n=5+5)
ycsb/F/values=1024    8.76 ± 9%   12.14 ±20%  +38.53%  (p=0.008 n=5+5)
```

ycsb/F perf difference for no parallel compression vs parallel compression with 5 compression workers on a machine with an IO bottleneck, but no cpu bottleneck. Benchmark was run for 30 minutes.
```
arjunnair@Arjuns-MacBook-Pro dec23_1 % benchstat stat_0 stat_5
name                old ops/sec  new ops/sec  delta
ycsb/F/values=1024   43.7k ± 2%   46.5k ± 3%   +6.25%  (p=0.008 n=5+5)

name                old read     new read     delta
ycsb/F/values=1024    387G ± 4%    480G ± 1%  +24.09%  (p=0.008 n=5+5)

name                old write    new write    delta
ycsb/F/values=1024    556G ± 3%    660G ± 2%  +18.74%  (p=0.008 n=5+5)

name                old r-amp    new r-amp    delta
ycsb/F/values=1024    0.00         0.00          ~     (all equal)

name                old w-amp    new w-amp    delta
ycsb/F/values=1024    6.51 ± 1%    7.25 ± 1%  +11.37%  (p=0.008 n=5+5)
```
