### PR TITLE
sstable: add RewriteKeySuffixes function

### DIFF
--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -326,7 +326,7 @@ func runTestReader(t *testing.T, o WriterOptions, dir string, r *Reader) {
 					r = nil
 				}
 				var err error
-				_, r, err = runBuildCmd(d, o)
+				_, r, err = runBuildCmd(d, &o)
 				if err != nil {
 					return err.Error()
 				}

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -1,0 +1,95 @@
+package sstable
+
+import (
+	"bytes"
+	"os"
+	"time"
+
+	"github.com/cockroachdb/errors"
+)
+
+// RewriteKeySuffixes copies the sstable in the passed reader to out, but with
+// each key updated to have the byte suffix `from` replaced with `to`. It is
+// required that the SST consist of only SETs, and that every key have `from` as
+// its suffix, and furthermore the length of from must match the suffix length
+// designated by the Split() function if one is set in the WriterOptions.
+func RewriteKeySuffixes(
+	r *Reader,
+	out writeCloseSyncer, o WriterOptions,
+	from, to []byte,
+) (*WriterMetadata, error) {
+	return iterateReaderIntoWriter(r, out, o, from, to)
+}
+
+func iterateReaderIntoWriter(
+	r *Reader, out writeCloseSyncer, o WriterOptions, from, to []byte,
+) (*WriterMetadata, error) {
+	w := NewWriter(out, o)
+	i, err := r.NewIter(nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer i.Close()
+
+	k, v := i.First()
+	var scratch InternalKey
+	for k != nil {
+		if k.Kind() != InternalKeyKindSet {
+			return nil, errors.New("invalid key type")
+		}
+		if !bytes.HasSuffix(k.UserKey, from) {
+			return nil, errors.New("mismatched key suffix")
+		}
+		if w.split != nil {
+			if s := len(k.UserKey) - w.split(k.UserKey); s != len(from) {
+				return nil, errors.Errorf("mismatched replacement (%d) vs Split (%d) suffix", len(from), s)
+			}
+		}
+		scratch.UserKey = append(scratch.UserKey[:0], k.UserKey[:len(k.UserKey)-len(from)]...)
+		scratch.UserKey = append(scratch.UserKey, to...)
+		scratch.Trailer = k.Trailer
+
+		if w.addPoint(scratch, v); err != nil {
+			return nil, err
+		}
+		k, v = i.Next()
+	}
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+	return &w.meta, nil
+}
+
+// NewMemReader opens a reader over the SST stored in the passed []byte.
+func NewMemReader(sst []byte, o ReaderOptions) (*Reader, error) {
+	return NewReader(memReader{sst, bytes.NewReader(sst), sizeOnlyStat(int64(len(sst)))}, o)
+}
+
+// memReader is a thin wrapper around a []byte such that it can be passed to an
+// sstable.Reader. It supports concurrent use, and does so without locking in
+// contrast to the heavier read/write vfs.MemFile.
+type memReader struct {
+	b []byte
+	r *bytes.Reader
+	s sizeOnlyStat
+}
+
+var _ ReadableFile = memReader{}
+
+// ReadAt implements io.ReaderAt.
+func (m memReader) ReadAt(p []byte, off int64) (n int, err error) { return m.r.ReadAt(p, off) }
+
+// Close implements io.Closer.
+func (memReader) Close() error { return nil }
+
+// Stat implements ReadableFile.
+func (m memReader) Stat() (os.FileInfo, error) { return m.s, nil }
+
+type sizeOnlyStat int64
+
+func (s sizeOnlyStat) Size() int64      { return int64(s) }
+func (sizeOnlyStat) IsDir() bool        { panic(errors.AssertionFailedf("unimplemented")) }
+func (sizeOnlyStat) ModTime() time.Time { panic(errors.AssertionFailedf("unimplemented")) }
+func (sizeOnlyStat) Mode() os.FileMode  { panic(errors.AssertionFailedf("unimplemented")) }
+func (sizeOnlyStat) Name() string       { panic(errors.AssertionFailedf("unimplemented")) }
+func (sizeOnlyStat) Sys() interface{}   { panic(errors.AssertionFailedf("unimplemented")) }

--- a/sstable/suffix_rewriter_test.go
+++ b/sstable/suffix_rewriter_test.go
@@ -1,0 +1,101 @@
+package sstable
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/pebble/bloom"
+	"github.com/cockroachdb/pebble/internal/base"
+)
+
+// memFile is a file-like struct that buffers all data written to it in memory.
+// Implements the writeCloseSyncer interface.
+type memFile struct {
+	bytes.Buffer
+}
+
+// Close implements the writeCloseSyncer interface.
+func (*memFile) Close() error {
+	return nil
+}
+
+// Sync implements the writeCloseSyncer interface.
+func (*memFile) Sync() error {
+	return nil
+}
+
+// Data returns the in-memory buffer behind this MemFile.
+func (f *memFile) Data() []byte {
+	return f.Bytes()
+}
+
+// Flush is implemented so it prevents buffering inside Writter.
+func (f *memFile) Flush() error {
+	return nil
+}
+
+func BenchmarkRewriteSST(b *testing.B) {
+	writerOpts := WriterOptions{
+		FilterPolicy: bloom.FilterPolicy(10),
+		Comparer:     test4bSuffixComparer,
+	}
+
+	key := make([]byte, 28)
+	copy(key[24:], "_123")
+	sizes := []int{100, 10000, 1e6}
+	compressions := []Compression{NoCompression, SnappyCompression}
+
+	files := make([][]*Reader, len(compressions))
+
+	for comp := range compressions {
+		files[comp] = make([]*Reader, len(sizes))
+
+		for size := range sizes {
+			writerOpts.Compression = compressions[comp]
+			f := &memFile{}
+			w := NewWriter(f, writerOpts)
+			for i := 0; i < sizes[size]; i++ {
+				binary.BigEndian.PutUint64(key[:8], 123) // 16-byte shared prefix
+				binary.BigEndian.PutUint64(key[8:16], 456)
+				binary.BigEndian.PutUint64(key[16:], uint64(i))
+				if err := w.Set(key, key); err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			if err := w.Close(); err != nil {
+				b.Fatal(err)
+			}
+			r, err := NewMemReader(f.Bytes(), ReaderOptions{
+				Comparer: test4bSuffixComparer,
+				Filters:  map[string]base.FilterPolicy{writerOpts.FilterPolicy.Name(): writerOpts.FilterPolicy},
+			})
+			if err != nil {
+				b.Fatal(err)
+			}
+			files[comp][size] = r
+		}
+	}
+
+	b.ResetTimer()
+	for comp := range compressions {
+		b.Run(compressions[comp].String(), func(b *testing.B) {
+			for sz := range sizes {
+				r := files[comp][sz]
+				b.Run(fmt.Sprintf("keys=%d", sizes[sz]), func(b *testing.B) {
+					b.Run("ReaderWriterLoop", func(b *testing.B) {
+						stat, _ := r.file.Stat()
+						b.SetBytes(stat.Size())
+						for i := 0; i < b.N; i++ {
+							if _, err := iterateReaderIntoWriter(r, &discardFile{}, writerOpts, []byte("_123"), []byte("_456")); err != nil {
+								b.Fatal(err)
+							}
+						}
+					})
+				})
+			}
+		})
+	}
+}

--- a/sstable/testdata/rewriter
+++ b/sstable/testdata/rewriter
@@ -1,0 +1,217 @@
+build block-size=1 index-block-size=1 filter
+a_xyz.SET.1:a
+b_xyz.SET.1:b
+c_xyz.SET.1:c
+----
+point:   [a_xyz#1,1,c_xyz#1,1]
+range:   [#0,0,#0,0]
+seqnums: [1,1]
+
+# rewrite from=xyz to=123 block-size=1 index-block-size=1 filter
+# ----
+# rewrite failed: rewriting data blocks: no splitter, cannot copy filters
+
+# rewrite from=xyz to=123 block-size=1 index-block-size=1 filter comparer-split-4b-suffix
+# ----
+# rewrite failed: rewriting data blocks: mismatched Comparer leveldb.BytewiseComparator vs comparer-split-4b-suffix, replacement requires same splitter to copy filters
+
+build block-size=1 index-block-size=1 filter comparer-split-4b-suffix
+aa_xyz.SET.1:a
+ba_xyz.SET.1:b
+ca_xyz.SET.1:c
+----
+point:   [aa_xyz#1,1,ca_xyz#1,1]
+range:   [#0,0,#0,0]
+seqnums: [1,1]
+
+rewrite from=yz to=23 block-size=1 index-block-size=1 filter comparer-split-4b-suffix
+----
+rewrite failed: mismatched replacement (2) vs Split (4) suffix
+
+rewrite from=a_xyz to=a_123 block-size=1 index-block-size=1 filter comparer-split-4b-suffix
+----
+rewrite failed: mismatched replacement (5) vs Split (4) suffix
+
+build block-size=1 index-block-size=1 filter comparer-split-4b-suffix
+a_xyz.SET.1:a
+b_xyz.SET.1:b
+c_xyz.SET.1:c
+----
+point:   [a_xyz#1,1,c_xyz#1,1]
+range:   [#0,0,#0,0]
+seqnums: [1,1]
+
+layout
+----
+         0  data (25)
+        30  data (25)
+        60  data (25)
+        90  filter (69)
+       164  index (22)
+       191  index (22)
+       218  index (22)
+       245  top-index (48)
+       298  properties (767)
+      1070  meta-index (79)
+      1154  footer (53)
+      1207  EOF
+
+scan
+----
+a_xyz#1,1:a
+b_xyz#1,1:b
+c_xyz#1,1:c
+
+get
+b_xyz
+f_xyz
+c_xyz
+----
+b
+get f_xyz: pebble: not found
+c
+
+rewrite from=_xyz to=_123 block-size=1 index-block-size=1 filter comparer-split-4b-suffix
+----
+point:   [a_123#1,1,c_123#1,1]
+range:   [#0,0,#0,0]
+seqnums: [1,1]
+
+layout
+----
+         0  data (25)
+        30  data (25)
+        60  data (25)
+        90  filter (69)
+       164  index (22)
+       191  index (22)
+       218  index (22)
+       245  top-index (48)
+       298  properties (767)
+      1070  meta-index (79)
+      1154  footer (53)
+      1207  EOF
+
+scan
+----
+a_123#1,1:a
+b_123#1,1:b
+c_123#1,1:c
+
+get
+b_123
+f_123
+c_123
+----
+b
+get f_123: pebble: not found
+c
+
+rewrite from=_123 to=_456 block-size=1 index-block-size=1 filter comparer-split-4b-suffix concurrency=2
+----
+point:   [a_456#1,1,c_456#1,1]
+range:   [#0,0,#0,0]
+seqnums: [1,1]
+
+layout
+----
+         0  data (25)
+        30  data (25)
+        60  data (25)
+        90  filter (69)
+       164  index (22)
+       191  index (22)
+       218  index (22)
+       245  top-index (48)
+       298  properties (767)
+      1070  meta-index (79)
+      1154  footer (53)
+      1207  EOF
+
+scan
+----
+a_456#1,1:a
+b_456#1,1:b
+c_456#1,1:c
+
+get
+b_456
+f_456
+c_456
+----
+b
+get f_456: pebble: not found
+c
+
+rewrite from=_456 to=_xyz block-size=1 index-block-size=1 filter comparer-split-4b-suffix concurrency=3
+----
+point:   [a_xyz#1,1,c_xyz#1,1]
+range:   [#0,0,#0,0]
+seqnums: [1,1]
+
+layout
+----
+         0  data (25)
+        30  data (25)
+        60  data (25)
+        90  filter (69)
+       164  index (22)
+       191  index (22)
+       218  index (22)
+       245  top-index (48)
+       298  properties (767)
+      1070  meta-index (79)
+      1154  footer (53)
+      1207  EOF
+
+scan
+----
+a_xyz#1,1:a
+b_xyz#1,1:b
+c_xyz#1,1:c
+
+get
+b_xyz
+f_xyz
+c_xyz
+----
+b
+get f_xyz: pebble: not found
+c
+
+
+rewrite from=_xyz to=_123 block-size=1 index-block-size=1 filter comparer-split-4b-suffix concurrency=4
+----
+point:   [a_123#1,1,c_123#1,1]
+range:   [#0,0,#0,0]
+seqnums: [1,1]
+
+layout
+----
+         0  data (25)
+        30  data (25)
+        60  data (25)
+        90  filter (69)
+       164  index (22)
+       191  index (22)
+       218  index (22)
+       245  top-index (48)
+       298  properties (767)
+      1070  meta-index (79)
+      1154  footer (53)
+      1207  EOF
+
+scan
+----
+a_123#1,1:a
+b_123#1,1:b
+c_123#1,1:c
+
+get
+b_123
+f_123
+c_123
+----
+b
+get f_123: pebble: not found
+c

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -397,7 +397,8 @@ func (w *Writer) maybeFlush(key InternalKey, value []byte) error {
 	if bhp, err = w.maybeAddBlockPropertiesToBlockHandle(bh); err != nil {
 		return err
 	}
-	if err = w.addIndexEntry(key, bhp); err != nil {
+	prevKey := base.DecodeInternalKey(w.block.curKey)
+	if err = w.addIndexEntry(prevKey, key, bhp); err != nil {
 		return err
 	}
 	return nil
@@ -427,13 +428,12 @@ func (w *Writer) maybeAddBlockPropertiesToBlockHandle(
 }
 
 // addIndexEntry adds an index entry for the specified key and block handle.
-func (w *Writer) addIndexEntry(key InternalKey, bhp BlockHandleWithProperties) error {
+func (w *Writer) addIndexEntry(prevKey, key InternalKey, bhp BlockHandleWithProperties) error {
 	if bhp.Length == 0 {
 		// A valid blockHandle must be non-zero.
 		// In particular, it must have a non-zero length.
 		return nil
 	}
-	prevKey := base.DecodeInternalKey(w.block.curKey)
 	var sep InternalKey
 	if key.UserKey == nil && key.Trailer == 0 {
 		if len(w.keyAlloc) < len(prevKey.UserKey) {
@@ -661,7 +661,8 @@ func (w *Writer) Close() (err error) {
 		if bhp, err = w.maybeAddBlockPropertiesToBlockHandle(bh); err != nil {
 			return err
 		}
-		if err = w.addIndexEntry(InternalKey{}, bhp); err != nil {
+		prevKey := base.DecodeInternalKey(w.block.curKey)
+		if err = w.addIndexEntry(prevKey, InternalKey{}, bhp); err != nil {
 			return err
 		}
 	}

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/pebble/bloom"
@@ -36,7 +37,7 @@ func TestWriter(t *testing.T) {
 			}
 			var meta *WriterMetadata
 			var err error
-			meta, r, err = runBuildCmd(td, WriterOptions{})
+			meta, r, err = runBuildCmd(td, &WriterOptions{})
 			if err != nil {
 				return err.Error()
 			}
@@ -75,6 +76,18 @@ func TestWriter(t *testing.T) {
 			}
 			return buf.String()
 
+		case "get":
+			var buf bytes.Buffer
+			for _, k := range strings.Split(td.Input, "\n") {
+				value, err := r.get([]byte(k))
+				if err != nil {
+					fmt.Fprintf(&buf, "get %s: %s\n", k, err.Error())
+				} else {
+					fmt.Fprintf(&buf, "%s\n", value)
+				}
+			}
+			return buf.String()
+
 		case "scan-range-del":
 			iter, err := r.NewRawRangeDelIter()
 			if err != nil {
@@ -96,8 +109,16 @@ func TestWriter(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
+			verbose := false
+			if len(td.CmdArgs) > 0 {
+				if td.CmdArgs[0].Key == "verbose" {
+					verbose = true
+				} else {
+					return "unknown arg"
+				}
+			}
 			var buf bytes.Buffer
-			l.Describe(&buf, false, r, nil)
+			l.Describe(&buf, verbose, r, nil)
 			return buf.String()
 
 		default:
@@ -243,4 +264,18 @@ func BenchmarkWriter(b *testing.B) {
 			}
 		})
 	}
+}
+
+var test4bSuffixComparer = &base.Comparer{
+	Compare:   base.DefaultComparer.Compare,
+	Equal:     base.DefaultComparer.Equal,
+	Separator: base.DefaultComparer.Separator,
+	Successor: base.DefaultComparer.Successor,
+	Split: func(key []byte) int {
+		if len(key) > 4 {
+			return len(key) - 4
+		}
+		return len(key)
+	},
+	Name: "comparer-split-4b-suffix",
 }

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -21,6 +21,14 @@ import (
 )
 
 func TestWriter(t *testing.T) {
+	runDataDriven(t, "testdata/writer")
+}
+
+func TestRewriter(t *testing.T) {
+	runDataDriven(t, "testdata/rewriter")
+}
+
+func runDataDriven(t *testing.T, file string) {
 	var r *Reader
 	defer func() {
 		if r != nil {
@@ -28,7 +36,7 @@ func TestWriter(t *testing.T) {
 		}
 	}()
 
-	datadriven.RunTest(t, "testdata/writer", func(td *datadriven.TestData) string {
+	datadriven.RunTest(t, file, func(td *datadriven.TestData) string {
 		switch td.Cmd {
 		case "build":
 			if r != nil {
@@ -120,6 +128,21 @@ func TestWriter(t *testing.T) {
 			var buf bytes.Buffer
 			l.Describe(&buf, verbose, r, nil)
 			return buf.String()
+
+		case "rewrite":
+			var meta *WriterMetadata
+			var err error
+			meta, r, err = runRewriteCmd(td, r, WriterOptions{})
+			if err != nil {
+				return err.Error()
+			}
+			if err != nil {
+				return err.Error()
+			}
+			return fmt.Sprintf("point:   [%s,%s]\nrange:   [%s,%s]\nseqnums: [%d,%d]\n",
+				meta.SmallestPoint, meta.LargestPoint,
+				meta.SmallestRange, meta.LargestRange,
+				meta.SmallestSeqNum, meta.LargestSeqNum)
 
 		default:
 			return fmt.Sprintf("unknown command: %s", td.Cmd)


### PR DESCRIPTION
Pulling this out of #1377, as it is just the Reader->Writer loop implementation,
along with the associated tests and benchmark, to get that benchmark in place
for any other Reader or Writer performance work to check, and so #1377 can then
be just about the parallel-block version.

----

This adds a function to the sstable package that can replace some suffix
with another suffix from every key in an sstable, assuming enforcing
that the sstable consists of only Sets.

For now, this is done by opening a new Writer and simply iterating every
key from the original SST using a reader, replacing the suffix and then
passing it to the writer. However a follow-up change may improve this
implementation by leveraging knowledge of the reader and writer internal
details, such as processing data blocks in parallel or copying, rather
than recomputing filters and props.

For now this simple implementation is added as-is, to get tests and an
initial benchmark in place.

```
name                                                       time/op
RewriteSST/NoCompression/keys=100/ReaderWriterLoop-10        29.8µs ± 2%
RewriteSST/NoCompression/keys=10000/ReaderWriterLoop-10      1.30ms ± 1%
RewriteSST/NoCompression/keys=1000000/ReaderWriterLoop-10     129ms ± 3%
RewriteSST/Snappy/keys=100/ReaderWriterLoop-10               31.7µs ± 2%
RewriteSST/Snappy/keys=10000/ReaderWriterLoop-10             1.40ms ± 1%
RewriteSST/Snappy/keys=1000000/ReaderWriterLoop-10            137ms ± 3%

name                                                       speed
RewriteSST/NoCompression/keys=100/ReaderWriterLoop-10       194MB/s ± 2%
RewriteSST/NoCompression/keys=10000/ReaderWriterLoop-10     368MB/s ± 1%
RewriteSST/NoCompression/keys=1000000/ReaderWriterLoop-10   371MB/s ± 3%
RewriteSST/Snappy/keys=100/ReaderWriterLoop-10             70.3MB/s ± 2%
RewriteSST/Snappy/keys=10000/ReaderWriterLoop-10           87.3MB/s ± 1%
RewriteSST/Snappy/keys=1000000/ReaderWriterLoop-10         88.1MB/s ± 3%

name                                                       alloc/op
RewriteSST/NoCompression/keys=100/ReaderWriterLoop-10         302kB ± 0%
RewriteSST/NoCompression/keys=10000/ReaderWriterLoop-10       551kB ± 0%
RewriteSST/NoCompression/keys=1000000/ReaderWriterLoop-10    25.5MB ± 0%
RewriteSST/Snappy/keys=100/ReaderWriterLoop-10                302kB ± 0%
RewriteSST/Snappy/keys=10000/ReaderWriterLoop-10              551kB ± 0%
RewriteSST/Snappy/keys=1000000/ReaderWriterLoop-10           25.5MB ± 0%

name                                                       allocs/op
RewriteSST/NoCompression/keys=100/ReaderWriterLoop-10          92.0 ± 0%
RewriteSST/NoCompression/keys=10000/ReaderWriterLoop-10         122 ± 0%
RewriteSST/NoCompression/keys=1000000/ReaderWriterLoop-10       168 ± 0%
RewriteSST/Snappy/keys=100/ReaderWriterLoop-10                 92.0 ± 0%
RewriteSST/Snappy/keys=10000/ReaderWriterLoop-10                122 ± 0%
RewriteSST/Snappy/keys=1000000/ReaderWriterLoop-10              168 ± 0%

```