### PR TITLE
batch: add RangeKey{Set,Unset,Delete} methods

### DIFF
--- a/internal.go
+++ b/internal.go
@@ -19,6 +19,9 @@ const (
 	InternalKeyKindRangeDelete     = base.InternalKeyKindRangeDelete
 	InternalKeyKindMax             = base.InternalKeyKindMax
 	InternalKeyKindSetWithDelete   = base.InternalKeyKindSetWithDelete
+	InternalKeyKindRangeKeySet     = base.InternalKeyKindRangeKeySet
+	InternalKeyKindRangeKeyUnset   = base.InternalKeyKindRangeKeyUnset
+	InternalKeyKindRangeKeyDelete  = base.InternalKeyKindRangeKeyDelete
 	InternalKeyKindInvalid         = base.InternalKeyKindInvalid
 	InternalKeySeqNumBatch         = base.InternalKeySeqNumBatch
 	InternalKeySeqNumMax           = base.InternalKeySeqNumMax

--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -51,6 +51,15 @@ const (
 	// https://github.com/cockroachdb/pebble/issues/1255.
 	InternalKeyKindSetWithDelete InternalKeyKind = 18
 
+	// InternalKeyKindRangeKeyDelete removes all range keys within a key range.
+	// See the internal/rangekey package for more details.
+	InternalKeyKindRangeKeyDelete InternalKeyKind = 19
+	// InternalKeyKindRangeKeySet and InternalKeyKindRangeUnset represent
+	// keys that set and unset values associated with ranges of key
+	// space. See the internal/rangekey package for more details.
+	InternalKeyKindRangeKeyUnset InternalKeyKind = 20
+	InternalKeyKindRangeKeySet   InternalKeyKind = 21
+
 	// This maximum value isn't part of the file format. It's unlikely,
 	// but future extensions may increase this value.
 	//
@@ -60,7 +69,7 @@ const (
 	// which sorts 'less than or equal to' any other valid internalKeyKind, when
 	// searching for any kind of internal key formed by a certain user key and
 	// seqNum.
-	InternalKeyKindMax InternalKeyKind = 18
+	InternalKeyKindMax InternalKeyKind = 21
 
 	// A marker for an invalid key.
 	InternalKeyKindInvalid InternalKeyKind = 255
@@ -81,15 +90,18 @@ const (
 )
 
 var internalKeyKindNames = []string{
-	InternalKeyKindDelete:        "DEL",
-	InternalKeyKindSet:           "SET",
-	InternalKeyKindMerge:         "MERGE",
-	InternalKeyKindLogData:       "LOGDATA",
-	InternalKeyKindSingleDelete:  "SINGLEDEL",
-	InternalKeyKindRangeDelete:   "RANGEDEL",
-	InternalKeyKindSeparator:     "SEPARATOR",
-	InternalKeyKindSetWithDelete: "SETWITHDEL",
-	InternalKeyKindInvalid:       "INVALID",
+	InternalKeyKindDelete:         "DEL",
+	InternalKeyKindSet:            "SET",
+	InternalKeyKindMerge:          "MERGE",
+	InternalKeyKindLogData:        "LOGDATA",
+	InternalKeyKindSingleDelete:   "SINGLEDEL",
+	InternalKeyKindRangeDelete:    "RANGEDEL",
+	InternalKeyKindSeparator:      "SEPARATOR",
+	InternalKeyKindSetWithDelete:  "SETWITHDEL",
+	InternalKeyKindRangeKeySet:    "RANGEKEYSET",
+	InternalKeyKindRangeKeyUnset:  "RANGEKEYUNSET",
+	InternalKeyKindRangeKeyDelete: "RANGEKEYDEL",
+	InternalKeyKindInvalid:        "INVALID",
 }
 
 func (k InternalKeyKind) String() string {
@@ -146,14 +158,17 @@ func MakeRangeDeleteSentinelKey(userKey []byte) InternalKey {
 }
 
 var kindsMap = map[string]InternalKeyKind{
-	"DEL":        InternalKeyKindDelete,
-	"SINGLEDEL":  InternalKeyKindSingleDelete,
-	"RANGEDEL":   InternalKeyKindRangeDelete,
-	"SET":        InternalKeyKindSet,
-	"MERGE":      InternalKeyKindMerge,
-	"INVALID":    InternalKeyKindInvalid,
-	"SEPARATOR":  InternalKeyKindSeparator,
-	"SETWITHDEL": InternalKeyKindSetWithDelete,
+	"DEL":           InternalKeyKindDelete,
+	"SINGLEDEL":     InternalKeyKindSingleDelete,
+	"RANGEDEL":      InternalKeyKindRangeDelete,
+	"SET":           InternalKeyKindSet,
+	"MERGE":         InternalKeyKindMerge,
+	"INVALID":       InternalKeyKindInvalid,
+	"SEPARATOR":     InternalKeyKindSeparator,
+	"SETWITHDEL":    InternalKeyKindSetWithDelete,
+	"RANGEKEYSET":   InternalKeyKindRangeKeySet,
+	"RANGEKEYUNSET": InternalKeyKindRangeKeyUnset,
+	"RANGEKEYDEL":   InternalKeyKindRangeKeyDelete,
 }
 
 // ParseInternalKey parses the string representation of an internal key. The

--- a/internal/base/internal_test.go
+++ b/internal/base/internal_test.go
@@ -37,14 +37,13 @@ func TestInvalidInternalKey(t *testing.T) {
 		"\x01\x02\x03\x04\x05\x06\x07",
 		"foo",
 		"foo\x08\x07\x06\x05\x04\x03\x02",
-		"foo\x13\x07\x06\x05\x04\x03\x02\x01",
+		"foo\x16\x07\x06\x05\x04\x03\x02\x01",
 	}
 	for _, tc := range testCases {
 		k := DecodeInternalKey([]byte(tc))
 		if k.Valid() {
 			t.Errorf("%q is a valid key, want invalid", tc)
 		}
-
 		// Invalid key kind because the key doesn't have an 8 byte trailer.
 		if k.Kind() == InternalKeyKindInvalid && k.UserKey != nil {
 			t.Errorf("expected nil UserKey after decoding encodedKey=%q", tc)

--- a/internal/rangekey/rangekey.go
+++ b/internal/rangekey/rangekey.go
@@ -1,0 +1,334 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// Package rangekey provides facilities for encoding, decoding and merging range
+// keys.
+//
+// Range keys map a span of keyspan `[start, end)`, at an optional suffix, to a
+// value.
+//
+// # Encoding
+//
+// Unlike other Pebble keys, range keys encode several fields of information:
+// start key, end key, suffix and value. Internally within Pebble and its
+// sstables, all keys including range keys are represented as a key-value tuple.
+// Range keys map to internal key-value tuples by mapping the start key to the
+// key and encoding the remainder of the fields in the value.
+//
+// ## `RANGEKEYSET`
+//
+// A `RANGEKEYSET` represents one more range keys set over a single region of
+// user key space. Each represented range key must have a unique suffix.  A
+// `RANGEKEYSET` encapsulates a start key, an end key and a set of SuffixValue
+// pairs.
+//
+// A `RANGEKEYSET` key's user key holds the start key. Its value is a varstring
+// end key, followed by a set of SuffixValue pairs. A `RANGEKEYSET` may have
+// multiple SuffixValue pairs if the keyspan was set at multiple unique suffix
+// values.
+//
+// ## `RANGEKEYUNSET`
+//
+// A `RANGEKEYUNSET` represents the removal of range keys at specific suffixes
+// over a single region of user key space. A `RANGEKEYUNSET` encapsulates a
+// start key, an end key and a set of suffixes.
+//
+// A `RANGEKEYUNSET` key's user key holds the start key. Its value is a
+// varstring end key, followed by a set of suffixes. A `RANGEKEYUNSET` may have
+// multiple suffixes if the keyspan was unset at multiple unique suffixes.
+//
+// ## `RANGEKEYDEL`
+//
+// A `RANGEKEYDEL` represents the removal of all range keys over a single region
+// of user key space, regardless of suffix. A `RANGEKEYDEL` encapsulates a
+// start key and an end key. The end key is stored in the value, without any
+// varstring length prefixing.
+package rangekey
+
+// TODO(jackson): Document the encoding of RANGEKEYSET and RANGEKEYUNSET values
+// once we're confident they're stable.
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/keyspan"
+)
+
+// SuffixValue represents a tuple of a suffix and a corresponding value. A
+// physical RANGEKEYSET key may contain many logical RangeKeySets, each
+// represented with a separate SuffixValue tuple.
+type SuffixValue struct {
+	Suffix []byte
+	Value  []byte
+}
+
+// EncodedSetValueLen precomputes the length of a RangeKeySet's value when
+// encoded.  It may be used to construct a buffer of the appropriate size before
+// encoding.
+func EncodedSetValueLen(endKey []byte, suffixValues []SuffixValue) int {
+	n := lenVarint(len(endKey))
+	n += len(endKey)
+	for i := 0; i < len(suffixValues); i++ {
+		n += lenVarint(len(suffixValues[i].Suffix))
+		n += len(suffixValues[i].Suffix)
+		n += lenVarint(len(suffixValues[i].Value))
+		n += len(suffixValues[i].Value)
+	}
+
+	return n
+}
+
+// EncodeSetValue encodes a RangeKeySet's value into dst. The length of dst must
+// be greater than or equal to EncodedSetValueLen. EncodeSetValue returns the
+// number of bytes written, which should always equal the EncodedSetValueLen
+// with the same arguments.
+func EncodeSetValue(dst []byte, endKey []byte, suffixValues []SuffixValue) int {
+	// First encode the end key as a varstring.
+	n := binary.PutUvarint(dst, uint64(len(endKey)))
+	n += copy(dst[n:], endKey)
+
+	// Encode the list of (suffix, value-len) tuples.
+	for i := 0; i < len(suffixValues); i++ {
+		// Encode the length of the suffix.
+		n += binary.PutUvarint(dst[n:], uint64(len(suffixValues[i].Suffix)))
+
+		// Encode the suffix itself.
+		n += copy(dst[n:], suffixValues[i].Suffix)
+
+		// Encode the value length.
+		n += binary.PutUvarint(dst[n:], uint64(len(suffixValues[i].Value)))
+
+		// Encode the value itself.
+		n += copy(dst[n:], suffixValues[i].Value)
+	}
+	return n
+}
+
+// DecodeEndKey reads the end key from the beginning of a range key (RANGEKEYSET,
+// RANGEKEYUNSET or RANGEKEYDEL)'s physical encoded value. Both sets and unsets
+// encode the range key, plus additional data in the value.
+func DecodeEndKey(kind base.InternalKeyKind, data []byte) (endKey, value []byte, ok bool) {
+	switch kind {
+	case base.InternalKeyKindRangeKeyDelete:
+		// No splitting is necessary for range key deletes. The value is the end
+		// key, and there is no additional associated value.
+		return data, nil, true
+	case base.InternalKeyKindRangeKeySet, base.InternalKeyKindRangeKeyUnset:
+		v, n := binary.Uvarint(data)
+		if n <= 0 {
+			return nil, nil, false
+		}
+		endKey, value = data[n:n+int(v)], data[n+int(v):]
+		return endKey, value, true
+	default:
+		panic(errors.Newf("key kind %s is not a range key kind", kind))
+	}
+}
+
+// DecodeSuffixValue decodes a single encoded SuffixValue from a RangeKeySet's
+// split value. The end key must have already been stripped from the
+// RangeKeySet's value (see DecodeEndKey).
+func DecodeSuffixValue(data []byte) (sv SuffixValue, rest []byte, ok bool) {
+	// Decode the suffix.
+	sv.Suffix, data, ok = decodeVarstring(data)
+	if !ok {
+		return SuffixValue{}, nil, false
+	}
+	// Decode the value.
+	sv.Value, data, ok = decodeVarstring(data)
+	if !ok {
+		return SuffixValue{}, nil, false
+	}
+	return sv, data, true
+}
+
+// EncodedUnsetValueLen precomputes the length of a RangeKeyUnset's value when
+// encoded.  It may be used to construct a buffer of the appropriate size before
+// encoding.
+func EncodedUnsetValueLen(endKey []byte, suffixes [][]byte) int {
+	n := lenVarint(len(endKey))
+	n += len(endKey)
+
+	for i := 0; i < len(suffixes); i++ {
+		n += lenVarint(len(suffixes[i]))
+		n += len(suffixes[i])
+	}
+	return n
+}
+
+// EncodeUnsetValue encodes a RangeKeyUnset's value into dst. The length of dst
+// must be greater than or equal to EncodedUnsetValueLen. EncodeUnsetValue
+// returns the number of bytes written, which should always equal the
+// EncodedUnsetValueLen with the same arguments.
+func EncodeUnsetValue(dst []byte, endKey []byte, suffixes [][]byte) int {
+	// First encode the end key as a varstring.
+	n := binary.PutUvarint(dst, uint64(len(endKey)))
+	n += copy(dst[n:], endKey)
+
+	// Encode the list of suffix varstrings.
+	for i := 0; i < len(suffixes); i++ {
+		//  Encode the length of the suffix.
+		n += binary.PutUvarint(dst[n:], uint64(len(suffixes[i])))
+
+		// Encode the suffix itself.
+		n += copy(dst[n:], suffixes[i])
+	}
+	return n
+}
+
+// DecodeSuffix decodes a single suffix from the beginning of data. If decoding
+// suffixes from a RangeKeyUnset's value, the end key must have already been
+// stripped from the RangeKeyUnset's value (see DecodeEndKey).
+func DecodeSuffix(data []byte) (suffix, rest []byte, ok bool) {
+	return decodeVarstring(data)
+}
+
+func decodeVarstring(data []byte) (v, rest []byte, ok bool) {
+	// Decode the length of the string.
+	l, n := binary.Uvarint(data)
+	if n <= 0 {
+		return nil, nil, ok
+	}
+
+	// Extract the string itself.
+	return data[n : n+int(l)], data[n+int(l):], true
+}
+
+// Format returns a formatter for the range key (either a RANGEKEYSET,
+// RANGEKEYUNSET or RANGEKEYDEL) represented by s. The formatting returned is
+// parseable with Parse.
+func Format(formatKey base.FormatKey, s keyspan.Span) fmt.Formatter {
+	return prettyRangeKeySpan{Span: s, formatKey: formatKey}
+}
+
+type prettyRangeKeySpan struct {
+	keyspan.Span
+	formatKey base.FormatKey
+}
+
+func (k prettyRangeKeySpan) Format(s fmt.State, c rune) {
+	fmt.Fprintf(s, "%s.%s.%d: %s",
+		k.formatKey(k.Start.UserKey),
+		k.Start.Kind(),
+		k.Start.SeqNum(),
+		k.End)
+	switch k.Start.Kind() {
+	case base.InternalKeyKindRangeKeySet:
+		fmt.Fprint(s, " [")
+		value := k.Value
+		for len(value) > 0 {
+			if len(value) < len(k.Value) {
+				fmt.Fprint(s, ",")
+			}
+			sv, rest, ok := DecodeSuffixValue(value)
+			if !ok {
+				panic(base.CorruptionErrorf("corrupt set value: unable to decode suffix-value tuple"))
+			}
+			value = rest
+			fmt.Fprintf(s, "(%s=%s)", k.formatKey(sv.Suffix), sv.Value)
+		}
+		fmt.Fprint(s, "]")
+	case base.InternalKeyKindRangeKeyUnset:
+		fmt.Fprint(s, " [")
+		value := k.Value
+		for len(value) > 0 {
+			if len(value) < len(k.Value) {
+				fmt.Fprint(s, ",")
+			}
+			suffix, rest, ok := DecodeSuffix(value)
+			if !ok {
+				panic(base.CorruptionErrorf("corrupt unset value: unable to decode suffix"))
+			}
+			value = rest
+			fmt.Fprint(s, k.formatKey(suffix))
+		}
+		fmt.Fprint(s, "]")
+	case base.InternalKeyKindRangeKeyDelete:
+		if len(k.Value) > 0 {
+			panic("unexpected value on a RANGEKEYDEL")
+		}
+		// No additional value to format.
+	default:
+		panic(fmt.Sprintf("%s keys are not range keys", k.Start.Kind()))
+	}
+}
+
+// Parse parses a string representation of a range key (eg, RANGEKEYSET,
+// RANGEKEYUNSET or RANGEKEYDEL). Parse is used in tests and debugging
+// facilities. It's exported for use in tests outside of the rangekey package.
+//
+// Parse expects the input string to be in one of the three formats:
+// - start.RANGEKEYSET.seqnum: end [(s1=v1), (s2=v2), (s3=v3)]
+// - start.RANGEKEYUNSET.seqnum: end [s1, s2, s3]
+// - start.RANGEKEYDEL.seqnum: end
+//
+// For example:
+// - a.RANGEKEYSET.5: c [(@t10=foo), (@t9=bar)]
+// - a.RANGEKEYUNSET.5: c [@t10, @t9]
+// - a.RANGEKEYDEL.5: c
+func Parse(s string) (key base.InternalKey, value []byte) {
+	sep := strings.IndexByte(s, ':')
+	if sep == -1 {
+		panic("range key string representation missing key-value separator :")
+	}
+	startKey := base.ParseInternalKey(strings.TrimSpace(s[:sep]))
+
+	switch startKey.Kind() {
+	case base.InternalKeyKindRangeKeySet:
+		openBracket := strings.IndexByte(s[sep:], '[')
+		closeBracket := strings.IndexByte(s[sep:], ']')
+		endKey := strings.TrimSpace(s[sep+1 : sep+openBracket])
+		itemStrs := strings.Split(s[sep+openBracket+1:sep+closeBracket], ",")
+
+		var suffixValues []SuffixValue
+		for _, itemStr := range itemStrs {
+			itemStr = strings.Trim(itemStr, "() \n\t")
+			i := strings.IndexByte(itemStr, '=')
+			if i == -1 {
+				panic(fmt.Sprintf("range key string %q missing '=' key,value tuple delim", s))
+			}
+			suffixValues = append(suffixValues, SuffixValue{
+				Suffix: []byte(strings.TrimSpace(itemStr[:i])),
+				Value:  []byte(strings.TrimSpace(itemStr[i+1:])),
+			})
+		}
+		value = make([]byte, EncodedSetValueLen([]byte(endKey), suffixValues))
+		EncodeSetValue(value, []byte(endKey), suffixValues)
+		return startKey, value
+
+	case base.InternalKeyKindRangeKeyUnset:
+		openBracket := strings.IndexByte(s[sep:], '[')
+		closeBracket := strings.IndexByte(s[sep:], ']')
+		endKey := strings.TrimSpace(s[sep+1 : sep+openBracket])
+		itemStrs := strings.Split(s[sep+openBracket+1:sep+closeBracket], ",")
+
+		var suffixes [][]byte
+		for _, itemStr := range itemStrs {
+			suffixes = append(suffixes, []byte(strings.TrimSpace(itemStr)))
+		}
+		value = make([]byte, EncodedUnsetValueLen([]byte(endKey), suffixes))
+		EncodeUnsetValue(value, []byte(endKey), suffixes)
+		return startKey, value
+
+	case base.InternalKeyKindRangeKeyDelete:
+		return startKey, []byte(strings.TrimSpace(s[sep+1:]))
+
+	default:
+		panic(fmt.Sprintf("key kind %q not a range key", startKey.Kind()))
+	}
+}
+
+func lenVarint(v int) (n int) {
+	x := uint32(v)
+	n++
+	for x >= 0x80 {
+		x >>= 7
+		n++
+	}
+	return n
+}

--- a/internal/rangekey/rangekey_test.go
+++ b/internal/rangekey/rangekey_test.go
@@ -1,0 +1,148 @@
+package rangekey
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/keyspan"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetValue_Roundtrip(t *testing.T) {
+	testCases := []struct {
+		endKey       []byte
+		suffixValues []SuffixValue
+	}{
+		{
+			endKey: []byte("hello"),
+			suffixValues: []SuffixValue{
+				{Suffix: []byte{}, Value: []byte("world")},
+			},
+		},
+		{
+			endKey: []byte("hello world"),
+			suffixValues: []SuffixValue{
+				{Suffix: []byte("foo"), Value: []byte("bar")},
+			},
+		},
+		{
+			endKey: []byte("hello world"),
+			suffixValues: []SuffixValue{
+				{Suffix: []byte(""), Value: []byte("boop")},
+				{Suffix: []byte("foo"), Value: []byte("beep")},
+				{Suffix: []byte("bar"), Value: []byte("bop")},
+				{Suffix: []byte("bax"), Value: []byte("boink")},
+				{Suffix: []byte("zoop"), Value: []byte("zoink")},
+			},
+		},
+	}
+
+	var b []byte
+	for _, tc := range testCases {
+		l := EncodedSetValueLen(tc.endKey, tc.suffixValues)
+
+		if l <= cap(b) {
+			b = b[:l]
+		} else {
+			b = make([]byte, l)
+		}
+
+		n := EncodeSetValue(b, tc.endKey, tc.suffixValues)
+		require.Equal(t, l, n)
+
+		var endKey, rest []byte
+		var ok bool
+		endKey, rest, ok = DecodeEndKey(base.InternalKeyKindRangeKeySet, b[:n])
+		require.True(t, ok)
+
+		var suffixValues []SuffixValue
+		for len(rest) > 0 {
+			var sv SuffixValue
+			var ok bool
+			sv, rest, ok = DecodeSuffixValue(rest)
+			require.True(t, ok)
+			suffixValues = append(suffixValues, sv)
+		}
+		require.Equal(t, tc.endKey, endKey)
+		require.Equal(t, tc.suffixValues, suffixValues)
+	}
+}
+
+func TestUnsetValue_Roundtrip(t *testing.T) {
+	testCases := []struct {
+		endKey   []byte
+		suffixes [][]byte
+	}{
+		{
+			endKey:   []byte("hello"),
+			suffixes: [][]byte{{}},
+		},
+		{
+			endKey:   []byte("hello world"),
+			suffixes: [][]byte{[]byte("foo")},
+		},
+		{
+			endKey: []byte("hello world"),
+			suffixes: [][]byte{
+				[]byte{},
+				[]byte("foo"),
+				[]byte("bar"),
+				[]byte("bax"),
+				[]byte("zoop"),
+			},
+		},
+	}
+
+	var b []byte
+	for _, tc := range testCases {
+		l := EncodedUnsetValueLen(tc.endKey, tc.suffixes)
+
+		if l <= cap(b) {
+			b = b[:l]
+		} else {
+			b = make([]byte, l)
+		}
+
+		n := EncodeUnsetValue(b, tc.endKey, tc.suffixes)
+		require.Equal(t, l, n)
+
+		var ok bool
+		var endKey, rest []byte
+		endKey, rest, ok = DecodeEndKey(base.InternalKeyKindRangeKeyUnset, b[:n])
+		require.True(t, ok)
+		var suffixes [][]byte
+		for len(rest) > 0 {
+			var ok bool
+			var suffix []byte
+			suffix, rest, ok = DecodeSuffix(rest)
+			require.True(t, ok)
+			suffixes = append(suffixes, suffix)
+		}
+		require.Equal(t, tc.endKey, endKey)
+		require.Equal(t, tc.suffixes, suffixes)
+	}
+}
+
+func TestParseFormatRoundtrip(t *testing.T) {
+	testCases := []string{
+		"a.RANGEKEYSET.100: c [(@t22=foo),(@t1=bar)]",
+		"apples.RANGEKEYSET.5: bananas [(@t1=bar)]",
+		"cat.RANGEKEYUNSET.5: catatonic [@t9,@t8,@t7,@t6,@t5]",
+		"a.RANGEKEYDEL.5: catatonic",
+	}
+	for _, in := range testCases {
+		k, v := Parse(in)
+		endKey, restValue, ok := DecodeEndKey(k.Kind(), v)
+		require.True(t, ok)
+		got := fmt.Sprintf("%s", Format(testkeys.Comparer.FormatKey, keyspan.Span{
+			Start: k,
+			End:   endKey,
+			Value: restValue,
+		}))
+		if got != in {
+			t.Errorf("Format(Parse(%q)) = %q, want %q", in, got, in)
+		}
+	}
+}

--- a/mem_table.go
+++ b/mem_table.go
@@ -193,6 +193,8 @@ func (m *memTable) apply(batch *Batch, seqNum uint64) error {
 			// Don't increment seqNum for LogData, since these are not applied
 			// to the memtable.
 			seqNum--
+		case InternalKeyKindRangeKeySet, InternalKeyKindRangeKeyUnset, InternalKeyKindRangeKeyDelete:
+			// TODO(jackson): Implement.
 		default:
 			err = ins.Add(&m.skl, ikey, value)
 		}

--- a/range_keys_test.go
+++ b/range_keys_test.go
@@ -1,0 +1,38 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+package pebble
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRangeKeys(t *testing.T) {
+	d, err := Open("", &Options{
+		FS:       vfs.NewMem(),
+		Comparer: testkeys.Comparer,
+	})
+	require.NoError(t, err)
+	defer d.Close()
+
+	b := d.NewBatch()
+	b.Experimental().RangeKeySet([]byte("a"), []byte("c"), []byte("@t10"), []byte("hello world"), nil)
+	b.Experimental().RangeKeySet([]byte("b"), []byte("f"), []byte("@t20"), []byte("hello monde"), nil)
+	require.NoError(t, b.Commit(nil))
+
+	b = d.NewBatch()
+	b.Experimental().RangeKeySet([]byte("h"), []byte("q"), []byte("@t30"), []byte("foo"), nil)
+	require.NoError(t, b.Commit(nil))
+
+	b = d.NewBatch()
+	b.Experimental().RangeKeyUnset([]byte("e"), []byte("j"), []byte("@t20"), nil)
+	b.Experimental().RangeKeyUnset([]byte("e"), []byte("j"), []byte("@t10"), nil)
+	b.Experimental().RangeKeyUnset([]byte("e"), []byte("j"), []byte("@t30"), nil)
+	require.NoError(t, b.Commit(nil))
+
+	// TODO(jackson): Fill out when implemented.
+}


### PR DESCRIPTION
Add key kinds for range key sets, unsets and deletes. Add corresponding methods
to the Batch, behind an experimental type. With this commit, these keys may be
encoded into a batch but are discarded when committed.