### PR TITLE
db: add NextPrefix method to Iterator 

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1132,6 +1132,10 @@ func (i *batchIter) Next() (*InternalKey, []byte) {
 	return ikey, i.Value()
 }
 
+func (i *batchIter) NextPrefix(int) (*InternalKey, []byte) {
+	return i.Next()
+}
+
 func (i *batchIter) Prev() (*InternalKey, []byte) {
 	ikey := i.iter.Prev()
 	if ikey == nil {
@@ -1537,6 +1541,10 @@ func (i *flushableBatchIter) Next() (*InternalKey, []byte) {
 		return nil, nil
 	}
 	return &i.key, i.Value()
+}
+
+func (i *flushableBatchIter) NextPrefix(int) (*InternalKey, []byte) {
+	return i.Next()
 }
 
 func (i *flushableBatchIter) Prev() (*InternalKey, []byte) {

--- a/error_iter.go
+++ b/error_iter.go
@@ -49,6 +49,10 @@ func (c *errorIter) Next() (*InternalKey, []byte) {
 	return nil, nil
 }
 
+func (c *errorIter) NextPrefix(int) (*InternalKey, []byte) {
+	return nil, nil
+}
+
 func (c *errorIter) Prev() (*InternalKey, []byte) {
 	return nil, nil
 }

--- a/get_iter.go
+++ b/get_iter.go
@@ -173,6 +173,10 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 	}
 }
 
+func (g *getIter) NextPrefix(int) (*InternalKey, []byte) {
+	panic("pebble: NextPrefix unimplemented")
+}
+
 func (g *getIter) Prev() (*InternalKey, []byte) {
 	panic("pebble: Prev unimplemented")
 }

--- a/internal/arenaskl/flush_iterator.go
+++ b/internal/arenaskl/flush_iterator.go
@@ -75,6 +75,14 @@ func (it *flushIterator) Next() (*base.InternalKey, []byte) {
 	return &it.key, it.value()
 }
 
+// NextPrefix advances to the next position. Returns the key and value if the
+// iterator is pointing at a valid entry, and (nil, nil) otherwise.  Note:
+// flushIterator.NextPrefix mirrors the implementation of Iterator.NextPrefix
+// due to performance. Keep the two in sync.
+func (it *flushIterator) NextPrefix(int) (*base.InternalKey, []byte) {
+	return it.Next()
+}
+
 func (it *flushIterator) Prev() (*base.InternalKey, []byte) {
 	panic("pebble: Prev unimplemented")
 }

--- a/internal/arenaskl/iterator.go
+++ b/internal/arenaskl/iterator.go
@@ -194,6 +194,12 @@ func (it *Iterator) Next() (*base.InternalKey, []byte) {
 	return &it.key, it.value()
 }
 
+// NextPrefix advances to the next position. Returns the key and value if the
+// iterator is pointing at a valid entry, and (nil, nil) otherwise.
+func (it *Iterator) NextPrefix(int) (*base.InternalKey, []byte) {
+	return it.Next()
+}
+
 // Prev moves to the previous position. Returns the key and value if the
 // iterator is pointing at a valid entry, and (nil, nil) otherwise.
 func (it *Iterator) Prev() (*base.InternalKey, []byte) {

--- a/internal/keyspan/iter.go
+++ b/internal/keyspan/iter.go
@@ -168,6 +168,12 @@ func (i *Iter) Next() (*base.InternalKey, []byte) {
 	return &s.Start, s.End
 }
 
+// NextPrefix implements InternalIterator.NextPrefix, as documented in the
+// internal/base package.
+func (i *Iter) NextPrefix(int) (*base.InternalKey, []byte) {
+	return i.Next()
+}
+
 // Prev implements InternalIterator.Prev, as documented in the internal/base
 // package.
 func (i *Iter) Prev() (*base.InternalKey, []byte) {

--- a/internal/metamorphic/config.go
+++ b/internal/metamorphic/config.go
@@ -21,6 +21,7 @@ const (
 	iterLast
 	iterNext
 	iterNextWithLimit
+	iterNextPrefix
 	iterPrev
 	iterPrevWithLimit
 	iterSeekGE
@@ -83,6 +84,7 @@ func defaultConfig() config {
 			iterLast:            100,
 			iterNext:            100,
 			iterNextWithLimit:   20,
+			iterNextPrefix:      20,
 			iterPrev:            100,
 			iterPrevWithLimit:   20,
 			iterSeekGE:          100,

--- a/internal/metamorphic/generator.go
+++ b/internal/metamorphic/generator.go
@@ -96,6 +96,7 @@ func generate(rng *rand.Rand, count uint64, cfg config) []op {
 		iterLast:            g.iterLast,
 		iterNext:            g.iterNext,
 		iterNextWithLimit:   g.iterNextWithLimit,
+		iterNextPrefix:      g.iterNextPrefix,
 		iterPrev:            g.iterPrev,
 		iterPrevWithLimit:   g.iterPrevWithLimit,
 		iterSeekGE:          g.iterSeekGE,
@@ -693,9 +694,19 @@ func (g *generator) iterNextWithLimit() {
 		return
 	}
 
-	g.add(&iterNextOp{
+	g.add(&iterNextWithLimitOp{
 		iterID: g.liveIters.rand(g.rng),
 		limit:  g.randKeyToRead(0.001), // 0.1% new keys
+	})
+}
+
+func (g *generator) iterNextPrefix() {
+	if len(g.liveIters) == 0 {
+		return
+	}
+
+	g.add(&iterNextPrefixOp{
+		iterID: g.liveIters.rand(g.rng),
 	})
 }
 

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -703,22 +703,15 @@ func (o *iterLastOp) String() string {
 	return fmt.Sprintf("%s.Last()", o.iterID)
 }
 
-// iterNextOp models an Iterator.Next[WithLimit] operation.
+// iterNextOp models an Iterator.Next[WithLimit,Prefix] operation.
 type iterNextOp struct {
 	iterID objID
-	limit  []byte
 }
 
 func (o *iterNextOp) run(t *test, h *history) {
 	i := t.getIter(o.iterID)
-	var valid bool
-	var validStr string
-	if o.limit == nil {
-		valid = i.Next()
-		validStr = validBoolToStr(valid)
-	} else {
-		valid, validStr = validityStateToStr(i.NextWithLimit(o.limit))
-	}
+	valid := i.Next()
+	validStr := validBoolToStr(valid)
 	if valid {
 		h.Recordf("%s // [%s,%q,%q] %v", o, validStr, i.Key(), i.Value(), i.Error())
 	} else {
@@ -727,7 +720,47 @@ func (o *iterNextOp) run(t *test, h *history) {
 }
 
 func (o *iterNextOp) String() string {
-	return fmt.Sprintf("%s.Next(%q)", o.iterID, o.limit)
+	return fmt.Sprintf("%s.Next()", o.iterID)
+}
+
+// iterNextWithLimitOp models an Iterator.NextWithLimit operation.
+type iterNextWithLimitOp struct {
+	iterID objID
+	limit  []byte
+}
+
+func (o *iterNextWithLimitOp) run(t *test, h *history) {
+	i := t.getIter(o.iterID)
+	valid, validStr := validityStateToStr(i.NextWithLimit(o.limit))
+	if valid {
+		h.Recordf("%s // [%s,%q,%q] %v", o, validStr, i.Key(), i.Value(), i.Error())
+	} else {
+		h.Recordf("%s // [%s] %v", o, validStr, i.Error())
+	}
+}
+
+func (o *iterNextWithLimitOp) String() string {
+	return fmt.Sprintf("%s.NextWithLimit(%q)", o.iterID, o.limit)
+}
+
+// iterNextPrefixOp models an Iterator.NextPrefix operation.
+type iterNextPrefixOp struct {
+	iterID objID
+}
+
+func (o *iterNextPrefixOp) run(t *test, h *history) {
+	i := t.getIter(o.iterID)
+	valid := i.NextPrefix()
+	validStr := validBoolToStr(valid)
+	if valid {
+		h.Recordf("%s // [%s,%q,%q] %v", o, validStr, i.Key(), i.Value(), i.Error())
+	} else {
+		h.Recordf("%s // [%s] %v", o, validStr, i.Error())
+	}
+}
+
+func (o *iterNextPrefixOp) String() string {
+	return fmt.Sprintf("%s.NextPrefix()", o.iterID)
 }
 
 // iterPrevOp models an Iterator.Prev[WithLimit] operation.

--- a/internal/metamorphic/parser.go
+++ b/internal/metamorphic/parser.go
@@ -83,7 +83,11 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	case *newSnapshotOp:
 		return nil, &t.snapID, nil
 	case *iterNextOp:
+		return &t.iterID, nil, nil
+	case *iterNextWithLimitOp:
 		return &t.iterID, nil, []interface{}{&t.limit}
+	case *iterNextPrefixOp:
+		return &t.iterID, nil, nil
 	case *iterPrevOp:
 		return &t.iterID, nil, []interface{}{&t.limit}
 	case *iterSeekLTOp:
@@ -123,6 +127,8 @@ var methods = map[string]*methodInfo{
 	"NewIter":         makeMethod(newIterOp{}, dbTag, batchTag, snapTag),
 	"NewSnapshot":     makeMethod(newSnapshotOp{}, dbTag),
 	"Next":            makeMethod(iterNextOp{}, iterTag),
+	"NextWithLimit":   makeMethod(iterNextWithLimitOp{}, iterTag),
+	"NextPrefix":      makeMethod(iterNextPrefixOp{}, iterTag),
 	"Prev":            makeMethod(iterPrevOp{}, iterTag),
 	"Restart":         makeMethod(dbRestartOp{}, dbTag),
 	"SeekGE":          makeMethod(iterSeekGEOp{}, iterTag),

--- a/internal/metamorphic/retryable.go
+++ b/internal/metamorphic/retryable.go
@@ -87,6 +87,12 @@ func (i *retryableIter) NextWithLimit(limit []byte) pebble.IterValidityState {
 	return validity
 }
 
+func (i *retryableIter) NextPrefix() bool {
+	var valid bool
+	i.withRetry(func() { valid = i.iter.NextPrefix() })
+	return valid
+}
+
 func (i *retryableIter) Prev() bool {
 	var valid bool
 	i.withRetry(func() { valid = i.iter.Prev() })

--- a/internal/rangekey/interleaving_iter_test.go
+++ b/internal/rangekey/interleaving_iter_test.go
@@ -210,6 +210,10 @@ func (i *pointIterator) Next() (*base.InternalKey, []byte) {
 	return &i.keys[i.index], nil
 }
 
+func (i *pointIterator) NextPrefix(int) (*base.InternalKey, []byte) {
+	return i.Next()
+}
+
 func (i *pointIterator) Prev() (*base.InternalKey, []byte) {
 	i.index--
 	if i.index < 0 || i.index >= len(i.keys) {

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -982,7 +982,7 @@ func TestBlockProperties(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			i, err := newBlockIter(r.Compare, bh.Get())
+			i, err := newBlockIter(r.Compare, r.Split, bh.Get())
 			if err != nil {
 				return err.Error()
 			}
@@ -1072,7 +1072,7 @@ func TestBlockProperties(t *testing.T) {
 
 					var blocks []int
 					var i int
-					iter, _ := newBlockIter(r.Compare, indexH.Get())
+					iter, _ := newBlockIter(r.Compare, r.Split, indexH.Get())
 					for key, value := iter.First(); key != nil; key, value = iter.Next() {
 						bh, err := decodeBlockHandleWithProperties(value)
 						if err != nil {

--- a/sstable/block_test.go
+++ b/sstable/block_test.go
@@ -151,7 +151,7 @@ func TestBlockIter2(t *testing.T) {
 					return ""
 
 				case "iter":
-					iter, err := newBlockIter(bytes.Compare, block)
+					iter, err := newBlockIter(bytes.Compare, nil, block)
 					if err != nil {
 						return err.Error()
 					}
@@ -229,7 +229,7 @@ func TestBlockIterKeyStability(t *testing.T) {
 	}
 	block := w.finish()
 
-	i, err := newBlockIter(bytes.Compare, block)
+	i, err := newBlockIter(bytes.Compare, nil, block)
 	require.NoError(t, err)
 
 	// Check that the supplied slice resides within the bounds of the block.
@@ -289,7 +289,7 @@ func TestBlockIterReverseDirections(t *testing.T) {
 
 	for targetPos := 0; targetPos < w.restartInterval; targetPos++ {
 		t.Run("", func(t *testing.T) {
-			i, err := newBlockIter(bytes.Compare, block)
+			i, err := newBlockIter(bytes.Compare, nil, block)
 			require.NoError(t, err)
 
 			pos := 3
@@ -329,7 +329,7 @@ func BenchmarkBlockIterSeekGE(b *testing.B) {
 					w.add(ikey, nil)
 				}
 
-				it, err := newBlockIter(bytes.Compare, w.finish())
+				it, err := newBlockIter(bytes.Compare, nil, w.finish())
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -371,7 +371,7 @@ func BenchmarkBlockIterSeekLT(b *testing.B) {
 					w.add(ikey, nil)
 				}
 
-				it, err := newBlockIter(bytes.Compare, w.finish())
+				it, err := newBlockIter(bytes.Compare, nil, w.finish())
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -417,7 +417,7 @@ func BenchmarkBlockIterNext(b *testing.B) {
 					w.add(ikey, nil)
 				}
 
-				it, err := newBlockIter(bytes.Compare, w.finish())
+				it, err := newBlockIter(bytes.Compare, nil, w.finish())
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -449,7 +449,7 @@ func BenchmarkBlockIterPrev(b *testing.B) {
 					w.add(ikey, nil)
 				}
 
-				it, err := newBlockIter(bytes.Compare, w.finish())
+				it, err := newBlockIter(bytes.Compare, nil, w.finish())
 				if err != nil {
 					b.Fatal(err)
 				}


### PR DESCRIPTION
Expose a NextPrefix method on *pebble.Iterator that may be called when the user
wishes to move to the next key prefix (as determined by Comparer.Split).
NextPrefix guarantees that it will move to the next key prefix.

Here's a benchmark comparison of two versions of the benchmark. On the 'old'
benchmark, there is no NextPrefix optimization and the benchmark manually
checks for a new unique prefix. In the 'new' benchmark, the benchmark uses
NextPrefix and omits the manual checks since NextPrefix guarantees the next
returned key will be a new prefix:

```
name                         old time/op    new time/op    delta
NextPrefix/versions=1-24        135µs ± 0%     130µs ± 1%   -4.25%  (p=0.000 n=10+10)
NextPrefix/versions=2-24        313µs ± 1%     154µs ± 0%  -50.97%  (p=0.000 n=10+10)
NextPrefix/versions=10-24      1.71ms ± 0%    0.35ms ± 1%  -79.70%  (p=0.000 n=10+10)
NextPrefix/versions=100-24     12.0ms ± 3%     2.6ms ± 2%  -78.37%  (p=0.000 n=10+9)
NextPrefix/versions=1000-24     142ms ± 1%      53ms ± 1%  -62.72%  (p=0.000 n=10+10)

name                         old alloc/op   new alloc/op   delta
NextPrefix/versions=1-24        10.0B ± 0%     10.0B ± 0%     ~     (all equal)
NextPrefix/versions=2-24        13.0B ± 0%     10.0B ± 0%  -23.08%  (p=0.002 n=8+10)
NextPrefix/versions=10-24       35.4B ± 2%     13.0B ± 0%  -63.28%  (p=0.000 n=10+10)
NextPrefix/versions=100-24       137B ±29%       36B ± 0%  -73.66%  (p=0.000 n=10+8)
NextPrefix/versions=1000-24    3.26kB ± 2%    1.24kB ± 4%  -61.92%  (p=0.000 n=9+8)

name                         old allocs/op  new allocs/op  delta
NextPrefix/versions=1-24         1.00 ± 0%      1.00 ± 0%     ~     (all equal)
NextPrefix/versions=2-24         1.00 ± 0%      1.00 ± 0%     ~     (all equal)
NextPrefix/versions=10-24        1.00 ± 0%      1.00 ± 0%     ~     (all equal)
NextPrefix/versions=100-24       1.40 ±43%      1.00 ± 0%     ~     (p=0.087 n=10+10)
NextPrefix/versions=1000-24      28.4 ± 5%      11.0 ± 0%  -61.23%  (p=0.000 n=8+8)
```