### PR TITLE
sstable: Revert "Revert "sstable: reduce allocations during index flushing""

### DIFF
--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -145,7 +145,18 @@ type Writer struct {
 	// either the output of w.split (i.e. a prefix extractor) if w.split is not
 	// nil, or the full keys otherwise.
 	filter          filterWriter
-	indexPartitions []indexBlockWriterAndBlockProperties
+	indexPartitions []indexBlockAndBlockProperties
+
+	// sepScratch is reusable scratch space for computing separator keys.
+	sepScratch []byte
+
+	// indexBlockAlloc is used to bulk-allocate byte slices used to store index
+	// blocks in indexPartitions. These live until the index finishes.
+	indexBlockAlloc []byte
+	// indexSepAlloc is used to bulk-allocate index block seperator slices stored
+	// in indexPartitions. These live until the index finishes.
+	indexSepAlloc []byte
+
 	// To allow potentially overlapping (i.e. un-fragmented) range keys spans to
 	// be added to the Writer, a keyspan.Fragmenter and rangekey.Coalescer are
 	// used to retain the keys and values, emitting fragmented, coalesced spans as
@@ -191,9 +202,13 @@ func (w *Writer) Error() error {
 	return w.err
 }
 
-type indexBlockWriterAndBlockProperties struct {
-	writer     blockWriter
+type indexBlockAndBlockProperties struct {
+	nEntries int
+	// sep is the last key added to this block, for computing a separator later.
+	sep        InternalKey
 	properties []byte
+	// block is the encoded block produced by blockWriter.finish.
+	block []byte
 }
 
 // Set sets the value for the given key. The sequence number is set to
@@ -312,6 +327,11 @@ func (w *Writer) addPoint(key InternalKey, value []byte) error {
 		// semantically identical, because we need to ensure that SmallestPoint.UserKey
 		// is not nil. This is required by WriterMetadata.Smallest in order to
 		// distinguish between an unset SmallestPoint and a zero-length one.
+		// NB: We don't clone this off of some alloc-pool since it will outlive this
+		// Writer as a field of the returned metadata that users like compaction.go
+		// then hang on to, and would otherwise continue to alias that whole pool's
+		// slice if we did so. So since we'll need to allocate it its own slice at
+		// some point anyway, we may as well do so here.
 		w.meta.SmallestPoint = w.meta.LargestPoint.Clone()
 	}
 
@@ -751,16 +771,25 @@ func (w *Writer) addIndexEntry(prevKey, key InternalKey, bhp BlockHandleWithProp
 		// In particular, it must have a non-zero length.
 		return nil
 	}
+
+	// Make a rough guess that we want key-sized scratch to compute the separator.
+	if cap(w.sepScratch) < key.Size() {
+		w.sepScratch = make([]byte, 0, key.Size()*2)
+	}
+
 	var sep InternalKey
 	if key.UserKey == nil && key.Trailer == 0 {
-		sep = prevKey.Successor(w.compare, w.successor, nil)
+		sep = prevKey.Successor(w.compare, w.successor, w.sepScratch[:0])
 	} else {
-		sep = prevKey.Separator(w.compare, w.separator, nil, key)
+		sep = prevKey.Separator(w.compare, w.separator, w.sepScratch[:0], key)
 	}
 	encoded := encodeBlockHandleWithProperties(tmp, bhp)
 
 	if supportsTwoLevelIndex(w.tableFormat) &&
 		shouldFlush(sep, encoded, &w.indexBlock, w.indexBlockSize, w.indexBlockSizeThreshold) {
+		if cap(w.indexPartitions) == 0 {
+			w.indexPartitions = make([]indexBlockAndBlockProperties, 0, 32)
+		}
 		// Enable two level indexes if there is more than one index block.
 		w.twoLevelIndex = true
 		if err := w.finishIndexBlock(); err != nil {
@@ -805,6 +834,19 @@ func shouldFlush(
 	return newSize > blockSize
 }
 
+const keyAllocSize = 256 << 10
+
+func cloneKeyWithBuf(k InternalKey, buf []byte) ([]byte, InternalKey) {
+	if len(k.UserKey) == 0 {
+		return buf, k
+	}
+	if len(buf) < len(k.UserKey) {
+		buf = make([]byte, len(k.UserKey)+keyAllocSize)
+	}
+	n := copy(buf, k.UserKey)
+	return buf[n:], InternalKey{UserKey: buf[:n:n], Trailer: k.Trailer}
+}
+
 // finishIndexBlock finishes the current index block and adds it to the top
 // level index block. This is only used when two level indexes are enabled.
 func (w *Writer) finishIndexBlock() error {
@@ -819,14 +861,17 @@ func (w *Writer) finishIndexBlock() error {
 			w.blockPropsEncoder.addProp(shortID(i), scratch)
 		}
 	}
-	w.indexPartitions = append(w.indexPartitions,
-		indexBlockWriterAndBlockProperties{
-			writer:     w.indexBlock,
-			properties: w.blockPropsEncoder.props(),
-		})
-	w.indexBlock = blockWriter{
-		restartInterval: 1,
+	part := indexBlockAndBlockProperties{nEntries: w.indexBlock.nEntries, properties: w.blockPropsEncoder.props()}
+	w.indexSepAlloc, part.sep = cloneKeyWithBuf(base.DecodeInternalKey(w.indexBlock.curKey), w.indexSepAlloc)
+	bk := w.indexBlock.finish()
+	if len(w.indexBlockAlloc) < len(bk) {
+		// Allocate enough bytes for approximately 16 index blocks.
+		w.indexBlockAlloc = make([]byte, len(bk)*16)
 	}
+	n := copy(w.indexBlockAlloc, bk)
+	part.block = w.indexBlockAlloc[:n:n]
+	w.indexBlockAlloc = w.indexBlockAlloc[n:]
+	w.indexPartitions = append(w.indexPartitions, part)
 	return nil
 }
 
@@ -838,9 +883,9 @@ func (w *Writer) writeTwoLevelIndex() (BlockHandle, error) {
 
 	for i := range w.indexPartitions {
 		b := &w.indexPartitions[i]
-		w.props.NumDataBlocks += uint64(b.writer.nEntries)
-		sep := base.DecodeInternalKey(b.writer.curKey)
-		data := b.writer.finish()
+		w.props.NumDataBlocks += uint64(b.nEntries)
+
+		data := b.block
 		w.props.IndexSize += uint64(len(data))
 		bh, err := w.writeBlock(data, w.compression, &w.blockBuf)
 		if err != nil {
@@ -851,7 +896,7 @@ func (w *Writer) writeTwoLevelIndex() (BlockHandle, error) {
 			Props:       b.properties,
 		}
 		encoded := encodeBlockHandleWithProperties(w.blockBuf.tmp[:], bhp)
-		w.topLevelIndexBlock.add(sep, encoded)
+		w.topLevelIndexBlock.add(b.sep, encoded)
 	}
 
 	// NB: RocksDB includes the block trailer length in the index size


### PR DESCRIPTION
This reverts commit 9791c0f4c0526c9397312bb7a4021415b50513f1, and fixes
the memory usage issue in the original commit it reverts, which was caused by
the fact that the `Metadata` outlived the `Writer`, and since a key in that
metadata was backed by a portion of the Writer's allocation pooling slice,
the entire slice remained in-use. Instead, the field for the metadata is
restored to being allocated individually, so that only it needs to be
kept after the writer finishes.