### PR TITLE
sstable: gofmt -s for go 1.17

### DIFF
--- a/sstable/block_property.go
+++ b/sstable/block_property.go
@@ -102,8 +102,8 @@ type BlockPropertyFilter interface {
 // Users must not expect this to preserve differences between empty sets --
 // they will all get turned into the semantically equivalent [0,0).
 type BlockIntervalCollector struct {
-	name    string
-	dbic    DataBlockIntervalCollector
+	name string
+	dbic DataBlockIntervalCollector
 
 	blockInterval interval
 	indexInterval interval
@@ -182,7 +182,7 @@ type interval struct {
 
 func (i interval) encode(buf []byte) []byte {
 	if i.lower < i.upper {
-		var encoded [binary.MaxVarintLen64*2]byte
+		var encoded [binary.MaxVarintLen64 * 2]byte
 		n := binary.PutUvarint(encoded[:], i.lower)
 		n += binary.PutUvarint(encoded[n:], i.upper-i.lower)
 		buf = append(buf, encoded[:n]...)
@@ -246,7 +246,7 @@ func (i interval) intersects(x interval) bool {
 // corresponding collector is a BlockIntervalCollector. That is, the set is of
 // the form [lower, upper).
 type BlockIntervalFilter struct {
-	name string
+	name           string
 	filterInterval interval
 }
 
@@ -255,7 +255,7 @@ type BlockIntervalFilter struct {
 func NewBlockIntervalFilter(
 	name string, lower uint64, upper uint64) *BlockIntervalFilter {
 	return &BlockIntervalFilter{
-		name: name,
+		name:           name,
 		filterInterval: interval{lower: lower, upper: upper},
 	}
 }
@@ -282,7 +282,7 @@ type shortID uint8
 
 type blockPropertiesEncoder struct {
 	propsBuf []byte
-	scratch []byte
+	scratch  []byte
 }
 
 func (e *blockPropertiesEncoder) getScratchForProp() []byte {
@@ -296,24 +296,24 @@ func (e *blockPropertiesEncoder) resetProps() {
 func (e *blockPropertiesEncoder) addProp(id shortID, scratch []byte) {
 	const lenID = 1
 	lenProp := uvarintLen(uint32(len(scratch)))
-	n :=  lenID + lenProp + len(scratch)
-	if cap(e.propsBuf) - len(e.propsBuf) < n {
+	n := lenID + lenProp + len(scratch)
+	if cap(e.propsBuf)-len(e.propsBuf) < n {
 		size := len(e.propsBuf) + 2*n
 		if size < 2*cap(e.propsBuf) {
-			size = 2*cap(e.propsBuf)
+			size = 2 * cap(e.propsBuf)
 		}
 		buf := make([]byte, len(e.propsBuf), size)
 		copy(buf, e.propsBuf)
 		e.propsBuf = buf
 	}
 	pos := len(e.propsBuf)
-	b := e.propsBuf[pos:pos+lenID]
+	b := e.propsBuf[pos : pos+lenID]
 	b[0] = byte(id)
 	pos += lenID
-	b = e.propsBuf[pos:pos+lenProp]
+	b = e.propsBuf[pos : pos+lenProp]
 	n = binary.PutUvarint(b, uint64(len(scratch)))
 	pos += n
-	b = e.propsBuf[pos:pos+len(scratch)]
+	b = e.propsBuf[pos : pos+len(scratch)]
 	pos += len(scratch)
 	copy(b, scratch)
 	e.propsBuf = e.propsBuf[0:pos]
@@ -344,10 +344,10 @@ func (d *blockPropertiesDecoder) next() (id shortID, prop []byte, err error) {
 	id = shortID(d.props[0])
 	propLen, m := binary.Uvarint(d.props[lenID:])
 	n := lenID + m
-	if m <= 0 || propLen == 0 || (n + int(propLen)) > len(d.props) {
+	if m <= 0 || propLen == 0 || (n+int(propLen)) > len(d.props) {
 		return 0, nil, base.CorruptionErrorf("corrupt block property length")
 	}
-	prop = d.props[n:n+int(propLen)]
+	prop = d.props[n : n+int(propLen)]
 	d.props = d.props[n+int(propLen):]
 	return id, prop, nil
 }
@@ -450,7 +450,7 @@ func (f *BlockPropertiesFilterer) intersects(props []byte) (bool, error) {
 			}
 			id = int(shortID)
 		} else {
-			id = math.MaxUint8+1
+			id = math.MaxUint8 + 1
 		}
 		for i < len(f.shortIDToFiltersIndex) && id > i {
 			if f.shortIDToFiltersIndex[i] >= 0 {

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -18,37 +18,37 @@ func TestIntervalEncodeDecode(t *testing.T) {
 		name  string
 		lower uint64
 		upper uint64
-		len int
+		len   int
 	}{
 		{
-			name: "empty zero",
+			name:  "empty zero",
 			lower: 0,
 			upper: 0,
-			len: 0,
+			len:   0,
 		},
 		{
-			name: "empty non-zero",
+			name:  "empty non-zero",
 			lower: 5,
 			upper: 5,
-			len: 0,
+			len:   0,
 		},
 		{
-			name: "empty lower > upper",
+			name:  "empty lower > upper",
 			lower: math.MaxUint64,
-			upper: math.MaxUint64-1,
-			len: 0,
+			upper: math.MaxUint64 - 1,
+			len:   0,
 		},
 		{
-			name: "small",
+			name:  "small",
 			lower: 50,
 			upper: 61,
-			len: 2,
+			len:   2,
 		},
 		{
-			name: "big",
+			name:  "big",
 			lower: 0,
 			upper: math.MaxUint64,
-			len: 11,
+			len:   11,
 		},
 	}
 	for _, tc := range testCases {
@@ -63,7 +63,7 @@ func TestIntervalEncodeDecode(t *testing.T) {
 				expectedInterval = interval{}
 			}
 			// Arbitrary initial value.
-			arbitraryInterval := interval{lower: 1000, upper:1000}
+			arbitraryInterval := interval{lower: 1000, upper: 1000}
 			i2 := arbitraryInterval
 			i2.decode(b1)
 			require.Equal(t, expectedInterval, i2)
@@ -77,52 +77,52 @@ func TestIntervalEncodeDecode(t *testing.T) {
 
 func TestIntervalUnionIntersects(t *testing.T) {
 	testCases := []struct {
-		name  string
-		i1 interval
-		i2 interval
-		union interval
+		name       string
+		i1         interval
+		i2         interval
+		union      interval
 		intersects bool
 	}{
 		{
-			name: "empty and empty",
-			i1: interval{},
-			i2: interval{},
-			union: interval{},
+			name:       "empty and empty",
+			i1:         interval{},
+			i2:         interval{},
+			union:      interval{},
 			intersects: false,
 		},
 		{
-			name: "empty and empty non-zero",
-			i1: interval{},
-			i2: interval{100, 99},
-			union: interval{},
+			name:       "empty and empty non-zero",
+			i1:         interval{},
+			i2:         interval{100, 99},
+			union:      interval{},
 			intersects: false,
 		},
 		{
-			name: "empty and non-empty",
-			i1: interval{},
-			i2: interval{80, 100},
-			union: interval{80, 100},
+			name:       "empty and non-empty",
+			i1:         interval{},
+			i2:         interval{80, 100},
+			union:      interval{80, 100},
 			intersects: false,
 		},
 		{
-			name: "disjoint sets",
-			i1: interval{50, 60},
-			i2: interval{math.MaxUint64-5, math.MaxUint64},
-			union: interval{50, math.MaxUint64},
+			name:       "disjoint sets",
+			i1:         interval{50, 60},
+			i2:         interval{math.MaxUint64 - 5, math.MaxUint64},
+			union:      interval{50, math.MaxUint64},
 			intersects: false,
 		},
 		{
-			name: "adjacent sets",
-			i1: interval{50, 60},
-			i2: interval{60, 100},
-			union: interval{50, 100},
+			name:       "adjacent sets",
+			i1:         interval{50, 60},
+			i2:         interval{60, 100},
+			union:      interval{50, 100},
 			intersects: false,
 		},
 		{
-			name: "overlapping sets",
-			i1: interval{50, 60},
-			i2: interval{59, 120},
-			union: interval{50, 120},
+			name:       "overlapping sets",
+			i1:         interval{50, 60},
+			i2:         interval{59, 120},
+			union:      interval{50, 120},
 			intersects: true,
 		},
 	}
@@ -230,27 +230,27 @@ func TestBlockIntervalCollector(t *testing.T) {
 
 func TestBlockIntervalFilter(t *testing.T) {
 	testCases := []struct {
-		name  string
-		filter interval
-		prop interval
+		name       string
+		filter     interval
+		prop       interval
 		intersects bool
 	}{
 		{
-			name: "non-empty and empty",
-			filter: interval{10, 15},
-			prop: interval{},
+			name:       "non-empty and empty",
+			filter:     interval{10, 15},
+			prop:       interval{},
 			intersects: false,
 		},
 		{
-			name: "does not intersect",
-			filter: interval{10, 15},
-			prop: interval{15, 20},
+			name:       "does not intersect",
+			filter:     interval{10, 15},
+			prop:       interval{15, 20},
 			intersects: false,
 		},
 		{
-			name: "intersects",
-			filter: interval{10, 15},
-			prop: interval{14, 20},
+			name:       "intersects",
+			filter:     interval{10, 15},
+			prop:       interval{14, 20},
 			intersects: true,
 		},
 	}
@@ -323,6 +323,7 @@ func TestBlockPropertiesEncoderDecoder(t *testing.T) {
 type filterWithTrueForEmptyProp struct {
 	*BlockIntervalFilter
 }
+
 func (b filterWithTrueForEmptyProp) Intersects(prop []byte) (bool, error) {
 	if len(prop) == 0 {
 		return true, nil
@@ -353,15 +354,15 @@ func TestBlockPropertiesFilterer_IntersectsUserPropsAndFinishInit(t *testing.T) 
 	prop10Str := string(prop10)
 	type filter struct {
 		name string
-		i interval
+		i    interval
 	}
-	testCases := []struct{
-		name string
+	testCases := []struct {
+		name      string
 		userProps map[string]string
-		filters []filter
+		filters   []filter
 
 		// Expected results
-		intersects bool
+		intersects            bool
 		shortIDToFiltersIndex []int
 	}{
 		{
@@ -494,206 +495,205 @@ func TestBlockPropertiesFilterer_Intersects(t *testing.T) {
 	encoder.addProp(bic10Id, prop)
 	props0And10 := encoder.props()
 	type filter struct {
-		shortID shortID
-		i interval
+		shortID                shortID
+		i                      interval
 		intersectsForEmptyProp bool
 	}
-	testCases := []struct{
-		name string
+	testCases := []struct {
+		name  string
 		props []byte
 		// filters must be in ascending order of shortID.
-		filters []filter
+		filters    []filter
 		intersects bool
 	}{
 		{
-			name: "no filter, empty props",
-			props: emptyProps,
+			name:       "no filter, empty props",
+			props:      emptyProps,
 			intersects: true,
 		},
 		{
-			name: "no filter",
-			props: props0And10,
+			name:       "no filter",
+			props:      props0And10,
 			intersects: true,
 		},
 		{
-			name: "filter 0, empty props, does not intersect",
-			props: emptyProps,
-			filters: []filter{
-				{
-					shortID: 0,
-					i: interval{5, 15},
-				},
-			},
-			intersects: false,
-		},
-		{
-			name: "filter 10, empty props, does not intersect",
+			name:  "filter 0, empty props, does not intersect",
 			props: emptyProps,
 			filters: []filter{
 				{
 					shortID: 0,
-					i: interval{105, 111},
+					i:       interval{5, 15},
 				},
 			},
 			intersects: false,
 		},
 		{
-			name: "filter 0, intersects",
+			name:  "filter 10, empty props, does not intersect",
+			props: emptyProps,
+			filters: []filter{
+				{
+					shortID: 0,
+					i:       interval{105, 111},
+				},
+			},
+			intersects: false,
+		},
+		{
+			name:  "filter 0, intersects",
 			props: props0And10,
 			filters: []filter{
 				{
 					shortID: 0,
-					i: interval{5, 15},
+					i:       interval{5, 15},
 				},
 			},
 			intersects: true,
 		},
 		{
-			name: "filter 0, does not intersect",
+			name:  "filter 0, does not intersect",
 			props: props0And10,
 			filters: []filter{
 				{
 					shortID: 0,
-					i: interval{20, 25},
+					i:       interval{20, 25},
 				},
 			},
 			intersects: false,
 		},
 		{
-			name: "filter 10, intersects",
+			name:  "filter 10, intersects",
 			props: props0And10,
 			filters: []filter{
 				{
 					shortID: 10,
-					i: interval{105, 111},
+					i:       interval{105, 111},
 				},
 			},
 			intersects: true,
 		},
 		{
-			name: "filter 10, does not intersect",
+			name:  "filter 10, does not intersect",
 			props: props0And10,
 			filters: []filter{
 				{
 					shortID: 10,
-					i: interval{105, 110},
+					i:       interval{105, 110},
 				},
 			},
 			intersects: false,
 		},
 		{
-			name: "filter 5, does not intersect since no property",
+			name:  "filter 5, does not intersect since no property",
 			props: props0And10,
 			filters: []filter{
 				{
 					shortID: 5,
-					i: interval{105, 110},
+					i:       interval{105, 110},
 				},
 			},
 			intersects: false,
 		},
 		{
-			name: "filter 0 and 5, intersects and not intersects means overall not intersects",
+			name:  "filter 0 and 5, intersects and not intersects means overall not intersects",
 			props: props0And10,
 			filters: []filter{
 				{
 					shortID: 0,
-					i: interval{5, 15},
+					i:       interval{5, 15},
 				},
 				{
 					shortID: 5,
-					i: interval{105, 110},
+					i:       interval{105, 110},
 				},
 			},
 			intersects: false,
 		},
 		{
-			name: "filter 0, 5, 7, 11, all intersect",
+			name:  "filter 0, 5, 7, 11, all intersect",
 			props: props0And10,
 			filters: []filter{
 				{
 					shortID: 0,
-					i: interval{5, 15},
+					i:       interval{5, 15},
 				},
 				{
-					shortID: 5,
-					i: interval{105, 110},
+					shortID:                5,
+					i:                      interval{105, 110},
 					intersectsForEmptyProp: true,
 				},
 				{
-					shortID: 7,
-					i: interval{105, 110},
+					shortID:                7,
+					i:                      interval{105, 110},
 					intersectsForEmptyProp: true,
 				},
 				{
-					shortID: 11,
-					i: interval{105, 110},
-					intersectsForEmptyProp: true,
-				},
-			},
-			intersects: true,
-		},
-		{
-			name: "filter 0, 5, 7, 10, 11, all intersect",
-			props: props0And10,
-			filters: []filter{
-				{
-					shortID: 0,
-					i: interval{5, 15},
-				},
-				{
-					shortID: 5,
-					i: interval{105, 110},
-					intersectsForEmptyProp: true,
-				},
-				{
-					shortID: 7,
-					i: interval{105, 110},
-					intersectsForEmptyProp: true,
-				},
-				{
-					shortID: 10,
-					i: interval{105, 111},
-				},
-				{
-					shortID: 11,
-					i: interval{105, 110},
+					shortID:                11,
+					i:                      interval{105, 110},
 					intersectsForEmptyProp: true,
 				},
 			},
 			intersects: true,
 		},
 		{
-			name: "filter 0, 5, 7, 10, 11, all intersect except for 10",
+			name:  "filter 0, 5, 7, 10, 11, all intersect",
 			props: props0And10,
 			filters: []filter{
 				{
 					shortID: 0,
-					i: interval{5, 15},
+					i:       interval{5, 15},
 				},
 				{
-					shortID: 5,
-					i: interval{105, 110},
+					shortID:                5,
+					i:                      interval{105, 110},
 					intersectsForEmptyProp: true,
 				},
 				{
-					shortID: 7,
-					i: interval{105, 110},
+					shortID:                7,
+					i:                      interval{105, 110},
 					intersectsForEmptyProp: true,
 				},
 				{
 					shortID: 10,
-					i: interval{105, 110},
+					i:       interval{105, 111},
 				},
 				{
-					shortID: 11,
-					i: interval{105, 110},
+					shortID:                11,
+					i:                      interval{105, 110},
+					intersectsForEmptyProp: true,
+				},
+			},
+			intersects: true,
+		},
+		{
+			name:  "filter 0, 5, 7, 10, 11, all intersect except for 10",
+			props: props0And10,
+			filters: []filter{
+				{
+					shortID: 0,
+					i:       interval{5, 15},
+				},
+				{
+					shortID:                5,
+					i:                      interval{105, 110},
+					intersectsForEmptyProp: true,
+				},
+				{
+					shortID:                7,
+					i:                      interval{105, 110},
+					intersectsForEmptyProp: true,
+				},
+				{
+					shortID: 10,
+					i:       interval{105, 110},
+				},
+				{
+					shortID:                11,
+					i:                      interval{105, 110},
 					intersectsForEmptyProp: true,
 				},
 			},
 			intersects: false,
 		},
-
 	}
 
 	for _, tc := range testCases {

--- a/sstable/compression_cgo.go
+++ b/sstable/compression_cgo.go
@@ -2,6 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
+//go:build cgo
 // +build cgo
 
 package sstable

--- a/sstable/compression_cgo_test.go
+++ b/sstable/compression_cgo_test.go
@@ -2,6 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
+//go:build cgo
 // +build cgo
 
 package sstable

--- a/sstable/compression_nocgo.go
+++ b/sstable/compression_nocgo.go
@@ -2,6 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
+//go:build !cgo
 // +build !cgo
 
 package sstable

--- a/sstable/compression_nocgo_test.go
+++ b/sstable/compression_nocgo_test.go
@@ -2,6 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
+//go:build !cgo
 // +build !cgo
 
 package sstable


### PR DESCRIPTION
Noticed I was seeing spurious diffs when making unrelated edits to files in this
package, so just running everything though 'gofmt -s -w', as of go 1.17.2.