### PR TITLE
rangekey: fix formatting

### DIFF
--- a/internal/rangekey/rangekey_test.go
+++ b/internal/rangekey/rangekey_test.go
@@ -86,7 +86,7 @@ func TestUnsetValue_Roundtrip(t *testing.T) {
 		{
 			endKey: []byte("hello world"),
 			suffixes: [][]byte{
-				[]byte{},
+				{},
 				[]byte("foo"),
 				[]byte("bar"),
 				[]byte("bax"),


### PR DESCRIPTION
Update formatting in a file that landed after the previous formatting
change.