### PR TITLE
internal/rangekey: add Coalescer, CoalescedSpan, Iter

### DIFF
--- a/internal/keyspan/iter.go
+++ b/internal/keyspan/iter.go
@@ -142,6 +142,14 @@ func (i *Iter) Prev() (*base.InternalKey, []byte) {
 	return &s.Start, s.End
 }
 
+// Current returns the current span.
+func (i *Iter) Current() *Span {
+	if i.Valid() {
+		return &i.spans[i.index]
+	}
+	return nil
+}
+
 // Key implements InternalIterator.Key, as documented in the internal/base
 // package.
 func (i *Iter) Key() *base.InternalKey {

--- a/internal/rangekey/coalescer.go
+++ b/internal/rangekey/coalescer.go
@@ -1,0 +1,407 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package rangekey
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/keyspan"
+)
+
+// CoalescedSpan describes the state of range keys within a user key span.
+type CoalescedSpan struct {
+	// LargestSeqNum holds the largest sequence number of any of the internal
+	// range keys coalesced into this span.
+	LargestSeqNum uint64
+	// Start and End hold the inclusive start user key and exclusive end user
+	// key.
+	Start, End []byte
+	// Items contains all of the span's Sets and Unsets, ordered by Suffix.
+	Items []SuffixItem
+	// Delete is true if a RANGEKEYDEL covering this user key span was coalesced
+	// into this span.
+	Delete bool
+}
+
+// SuffixItem describes either a set or unset of a value at a particular
+// suffix.
+type SuffixItem struct {
+	Suffix []byte
+	Value  []byte
+	Unset  bool
+}
+
+// Coalescer imposes range key semantics and coalesces fragments with the same
+// bounds. A Coalescer receives—through its Add method—a stream of internal
+// range keys (sets, unsets and deletes). Among overlapping fragments (which
+// must have the same bounds), fragments must be supplied in order of their
+// internal keys (descending by sequence number, descending by kind). Coalescer
+// drops any keys shadowed by more recent sets, unsets or deletes.
+//
+// A Coalescer expects to receive only fragmented range keys, such that if two
+// keys overlap in user key space, they have the same bounds. The caller should
+// fragment range keys before feeding them to the Coalescer by using the
+// internal/keyspan.Fragmenter type. When the coalescer has seen all the
+// overlapping fragments for a key span, it emits a coalesced span describing
+// the still extant logical range keys, including the Set suffix-value pairs,
+// the Unset suffixes and whether any lower-seqnumed spans should be Deleted.
+//
+// A Coalescer may also coalesce internal range keys in reverse order, through
+// AddReverse. Add and AddReverse calls may be made to the same coalescer, but
+// they must be separated by calls to Finish.
+//
+// The memory backing the CoalescedSpan.Items is only guaranteed to be unused
+// until the next Add or AddReverse call. Callers should make a copy of the
+// Items slice if they wish to retain it beyond the next call to Add or
+// AddReverse. Coalescer does not make copies of any user keys, suffixes or
+// values, and these byte slices inherit their original lifetimes: The user
+// keys, suffixes and values emitted are valid as long as the original buffers
+// supplied to Add or AddReverse are valid.
+//
+// Coalescence has subtle behavior with respect to sequence numbers. The
+// coalescer expects overlapping fragments to be added in sequence number
+// descending order. The first fragment has the largest sequence number. When a
+// coalesced span is emitted, it includes only the largest sequence number. All
+// other sequence numbers are forgotten. When a compaction constructs output
+// range keys from a coalesced span, it produces at most one RANGEKEYSET, one
+// RANGEKEYUNSET and one RANGEKEYDEL. Each one of these keys adopt the largest
+// sequence number.
+//
+// This has the potentially surprising effect of 'promoting' a key to a higher
+// sequence number. This is okay, because:
+//   - There are no other overlapping fragments within the coalesced span of
+//     sequence numbers (otherwise they would be in the compaction, due to the
+//     LSM invariant).
+//   - Range key sequence numbers are never compared to point key sequence
+//     numbers. Range keys and point keys have parallel existences.
+//   - Compactions only coalesce within snapshot stripes, calling Finish to
+//     start a new coalesced span if a snapshot separates previously Added
+//     fragments from the next fragment.
+//
+// Additionally, internal range keys at the same sequence number have subtle
+// mechanics:
+//   * RANGEKEYSETs shadow RANGEKEYUNSETs of the same suffix.
+//   * RANGEKEYDELs only apply to keys at lower sequence numbers.
+// This is required for ingestion. Ingested sstables are assigned a single
+// sequence number for the file, at which all of the file's keys are visible.
+// The RANGEKEYSET, RANGEKEYUNSET and RANGEKEYDEL key kinds are ordered such
+// that when Add-ing the keys with equal sequence numbers in order by their
+// kinds, the keys do not affect one another, where possible. Ingested sstables
+// are expected to be consistent with respect to the set/unset suffixes: A
+// given suffix should be set or unset but not both.
+type Coalescer struct {
+	emit      func(CoalescedSpan)
+	formatKey base.FormatKey
+
+	largestSeqNum uint64
+	prevKey       base.InternalKey
+	start, end    []byte
+	items         suffixItems
+	// delete, if set, indicates that the current pending span has seen a
+	// RangeKeyDelete over the span. During forward accumulation, this causes
+	// all subsequent spans to be dropped.
+	delete bool
+	// dir indicates the direction of accumulation (+1 or -1), or that there is
+	// no accumulated state (0)
+	dir int8
+}
+
+// Init initializes a coalescer.
+func (c *Coalescer) Init(cmp base.Compare, formatKey base.FormatKey, emit func(CoalescedSpan)) {
+	c.emit = emit
+	c.formatKey = formatKey
+	c.items.cmp = cmp
+}
+
+// Start returns the currently pending span's start key.
+func (c *Coalescer) Start() []byte {
+	return c.start
+}
+
+// Finish must be called after all spans have been added. It flushes the
+// remaining pending CoalescedSpan if any. Finish may also be called at any time
+// to flush the pending CoalescedSpan and reset the coalescer.
+func (c *Coalescer) Finish() {
+	if c.dir != 0 {
+		c.flush()
+	}
+}
+
+// Add adds a fragmented range key span to the coalescer. The requirement that
+// spans be fragmented requires that if two spans overlap, they must have the
+// same start and end bounds. Additionally, among overlapping fragments,
+// fragments must be added ordered by Span.Start (descending by sequence number,
+// key kind).
+func (c *Coalescer) Add(s keyspan.Span) error {
+	if c.dir == -1 {
+		panic("pebble: cannot change directions during range key coalescence")
+	}
+
+	// If s is the first fragment with new bounds, flush.
+	if c.dir != 0 && c.items.cmp(s.Start.UserKey, c.start) != 0 {
+		// TODO(jackson): Gate behind invariants.Enabled eventually.
+		if c.items.cmp(s.Start.UserKey, c.start) < 0 {
+			panic(fmt.Sprintf("pebble: range key key ordering invariant violated: %s < %s",
+				c.formatKey(s.Start.UserKey), c.formatKey(c.start)))
+		}
+		if c.items.cmp(s.Start.UserKey, c.end) < 0 {
+			panic(fmt.Sprintf("pebble: range key overlapping with distinct bounds: (%s,%s) <> (%s, %s)",
+				c.formatKey(s.Start.UserKey), c.formatKey(s.End),
+				c.formatKey(c.start), c.formatKey(c.end)))
+		}
+
+		// NB: flush sets dir to zero, so we'll initialize the new pending
+		// span's information immediately below.
+		c.flush()
+	}
+
+	if c.dir == 0 {
+		c.dir = +1
+		c.largestSeqNum = s.Start.SeqNum()
+		c.start = s.Start.UserKey
+		c.end = s.End
+	} else {
+		// TODO(jackson): Gate behind invariants.Enabled eventually.
+		if base.InternalCompare(c.items.cmp, s.Start, c.prevKey) < 0 {
+			panic(fmt.Sprintf("pebble: range key ordering invariant violated: %s < %s",
+				s.Start.Pretty(c.formatKey), c.prevKey.Pretty(c.formatKey)))
+		}
+		if c.items.cmp(s.End, c.end) != 0 {
+			panic(fmt.Sprintf("pebble: range keys overlapping with different end bounds: (%s,%s) <> (%s, %s)",
+				c.formatKey(s.Start.UserKey), c.formatKey(s.End),
+				c.formatKey(c.start), c.formatKey(c.end)))
+		}
+	}
+	c.prevKey = s.Start
+
+	if c.delete {
+		// An earlier fragment with the same bounds deleted this span within the
+		// range key space. We can skip any later range keys.
+		return nil
+	}
+
+	// NB: Within a given sequence number, keys are ordered as:
+	//   RangeKeySet > RangeKeyUnset > RangeKeyDelete
+	// This is significant, because this ensures that none of the range keys
+	// sharing a sequence number shadow each other.
+	switch s.Start.Kind() {
+	case base.InternalKeyKindRangeKeyUnset:
+		n := len(c.items.items)
+
+		// value represents a set of suffixes, guaranteed to not have
+		// duplicates.
+		value := s.Value
+		for len(value) > 0 {
+			suffix, rest, ok := DecodeSuffix(value)
+			if !ok {
+				return base.CorruptionErrorf("corrupt unset value: unable to decode suffix")
+			}
+			value = rest
+			if c.get(n, suffix) < n {
+				// This suffix is already set or unset at a higher sequence
+				// number. Skip.
+				continue
+			}
+			c.items.items = append(c.items.items, SuffixItem{
+				Suffix: suffix,
+				Unset:  true,
+			})
+		}
+		sort.Sort(c.items)
+	case base.InternalKeyKindRangeKeySet:
+		n := len(c.items.items)
+
+		// value represents a set of suffixes, guaranteed to not have
+		// duplicates.
+		value := s.Value
+		for len(value) > 0 {
+			sv, rest, ok := DecodeSuffixValue(value)
+			if !ok {
+				return base.CorruptionErrorf("corrupt set value: unable to decode suffix-value tuple")
+			}
+			value = rest
+			if c.get(n, sv.Suffix) < n {
+				// This suffix is already set or unset at a higher sequence
+				// number. Skip.
+				continue
+			}
+			c.items.items = append(c.items.items, SuffixItem{
+				Suffix: sv.Suffix,
+				Value:  sv.Value,
+			})
+		}
+		sort.Sort(c.items)
+	case base.InternalKeyKindRangeKeyDelete:
+		// Record that all subsequent fragments with the same bounds should be
+		// ignored, because they were deleted by this RangeKeyDelete.
+		c.delete = true
+	default:
+		return errors.Newf("pebble: unexpected range key kind %s", s.Start.Kind())
+	}
+	return nil
+}
+
+// AddReverse adds a fragmented range key span to the coalescer. The requirement
+// that spans be fragmented requires that if two spans overlap, they must have
+// the same start and end bounds. Additionally, among overlapping fragments,
+// fragments must be added ordered by Span.Start in reverse order (ascending by
+// sequence number, key kind).
+func (c *Coalescer) AddReverse(s keyspan.Span) error {
+	if c.dir == +1 {
+		panic("pebble: cannot change directions during range key coalescence")
+	}
+
+	// If s is the first fragment with new bounds, flush.
+	if c.dir != 0 && c.items.cmp(s.Start.UserKey, c.start) != 0 {
+		// TODO(jackson): Gate behind invariants.Enabled eventually.
+		if c.items.cmp(s.Start.UserKey, c.start) > 0 {
+			panic(fmt.Sprintf("pebble: range key key ordering invariant violated: %s > %s",
+				c.formatKey(s.Start.UserKey), c.formatKey(c.start)))
+		}
+		if c.items.cmp(s.End, c.start) > 0 {
+			panic(fmt.Sprintf("pebble: range key overlapping with distinct bounds: (%s,%s) <> (%s, %s)",
+				c.formatKey(s.Start.UserKey), c.formatKey(s.End),
+				c.formatKey(c.start), c.formatKey(c.end)))
+		}
+
+		// NB: flush sets dir to zero, so we'll initialize the new pending
+		// span's information immediately below.
+		c.flush()
+	}
+
+	if c.dir == 0 {
+		c.dir = -1
+		c.start = s.Start.UserKey
+		c.end = s.End
+	} else {
+		// TODO(jackson): Gate behind invariants.Enabled eventually.
+		if base.InternalCompare(c.items.cmp, s.Start, c.prevKey) > 0 {
+			panic(fmt.Sprintf("pebble: range key ordering invariant violated: %s > %s",
+				s.Start.Pretty(c.formatKey), c.prevKey.Pretty(c.formatKey)))
+		}
+		if c.items.cmp(s.End, c.end) != 0 {
+			panic(fmt.Sprintf("pebble: range keys overlapping with different end bounds: (%s,%s) <> (%s, %s)",
+				c.formatKey(s.Start.UserKey), c.formatKey(s.End),
+				c.formatKey(c.start), c.formatKey(c.end)))
+		}
+	}
+	c.prevKey = s.Start
+	c.largestSeqNum = s.Start.SeqNum()
+
+	// NB: Within a given sequence number, keys are ordered as:
+	//   RangeKeySet > RangeKeyUnset > RangeKeyDelete
+	// This is significant, because this ensures that none of the range keys
+	// sharing a sequence number shadow each other.
+	switch s.Start.Kind() {
+	case base.InternalKeyKindRangeKeyUnset:
+		n := len(c.items.items)
+
+		// value represents a set of suffixes, guaranteed to not have
+		// duplicates.
+		value := s.Value
+		for len(value) > 0 {
+			suffix, rest, ok := DecodeSuffix(value)
+			if !ok {
+				return base.CorruptionErrorf("corrupt unset value: unable to decode suffix")
+			}
+			value = rest
+			if i := c.get(n, suffix); i < n {
+				// This suffix is already set or unset at a lower sequence
+				// number. Replace it.
+				c.items.items[i] = SuffixItem{
+					Suffix: suffix,
+					Unset:  true,
+				}
+				continue
+			}
+			c.items.items = append(c.items.items, SuffixItem{
+				Suffix: suffix,
+				Unset:  true,
+			})
+		}
+		sort.Sort(c.items)
+	case base.InternalKeyKindRangeKeySet:
+		n := len(c.items.items)
+
+		// value represents a set of suffixes, guaranteed to not have
+		// duplicates.
+		value := s.Value
+		for len(value) > 0 {
+			sv, rest, ok := DecodeSuffixValue(value)
+			if !ok {
+				return base.CorruptionErrorf("corrupt set value: unable to decode suffix-value tuple")
+			}
+			value = rest
+			if i := c.get(n, sv.Suffix); i < n {
+				// This suffix is already set or unset at a lower sequence
+				// number. Replace it.
+				c.items.items[i] = SuffixItem{
+					Suffix: sv.Suffix,
+					Value:  sv.Value,
+				}
+				continue
+			}
+			c.items.items = append(c.items.items, SuffixItem{
+				Suffix: sv.Suffix,
+				Value:  sv.Value,
+			})
+		}
+		sort.Sort(c.items)
+	case base.InternalKeyKindRangeKeyDelete:
+		// Remove all existing items, because they're all deleted.
+		c.items.items = c.items.items[:0]
+		c.delete = true
+	default:
+		return errors.Newf("pebble: unexpected range key kind %s", s.Start.Kind())
+	}
+	return nil
+}
+
+// get searches for suffix among the first n items in c.items. If the suffix is
+// found, it returns the index of the item with the suffix. If the suffix is not
+// found, it returns n.
+func (c *Coalescer) get(n int, suffix []byte) (i int) {
+	// Binary search for the suffix to see if there's an existing entry with the
+	// suffix. Only binary search among the first n items.  get is called while
+	// appending new items with suffixes that may sort before existing items.
+	// The n parameter indicates what portion of the items slice is sorted and
+	// may contain relevant items.
+	i = sort.Search(n, func(i int) bool {
+		return c.items.cmp(c.items.items[i].Suffix, suffix) >= 0
+	})
+	if i < len(c.items.items) &&
+		c.items.cmp(c.items.items[i].Suffix, suffix) == 0 {
+		return i
+	}
+	return n
+}
+
+func (c *Coalescer) flush() {
+	c.emit(CoalescedSpan{
+		LargestSeqNum: c.largestSeqNum,
+		Start:         c.start,
+		End:           c.end,
+		Items:         c.items.items,
+		Delete:        c.delete,
+	})
+	// Clear all state of the flushed span.
+	*c = Coalescer{
+		emit:      c.emit,
+		formatKey: c.formatKey,
+		items:     suffixItems{cmp: c.items.cmp},
+	}
+}
+
+type suffixItems struct {
+	cmp   base.Compare
+	items []SuffixItem
+}
+
+func (s suffixItems) Len() int           { return len(s.items) }
+func (s suffixItems) Less(i, j int) bool { return s.cmp(s.items[i].Suffix, s.items[j].Suffix) < 0 }
+func (s suffixItems) Swap(i, j int)      { s.items[i], s.items[j] = s.items[j], s.items[i] }

--- a/internal/rangekey/coalescer.go
+++ b/internal/rangekey/coalescer.go
@@ -393,7 +393,10 @@ func (c *Coalescer) flush() {
 	*c = Coalescer{
 		emit:      c.emit,
 		formatKey: c.formatKey,
-		items:     suffixItems{cmp: c.items.cmp},
+		items: suffixItems{
+			cmp:   c.items.cmp,
+			items: c.items.items[:0],
+		},
 	}
 }
 

--- a/internal/rangekey/coalescer_test.go
+++ b/internal/rangekey/coalescer_test.go
@@ -1,0 +1,94 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package rangekey
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/cockroachdb/pebble/internal/keyspan"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoalescer(t *testing.T) {
+	var c Coalescer
+	var buf bytes.Buffer
+	c.Init(testkeys.Comparer.Compare, testkeys.Comparer.FormatKey, func(rks CoalescedSpan) {
+		formatRangeKeySpan(&buf, &rks)
+	})
+
+	datadriven.RunTest(t, "testdata/coalescer", func(td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "add":
+			buf.Reset()
+
+			lines := strings.Split(strings.TrimSpace(td.Input), "\n")
+			for _, line := range lines {
+				startKey, value := Parse(line)
+				endKey, splitValue, ok := DecodeEndKey(startKey.Kind(), value)
+				require.True(t, ok)
+				require.NoError(t, c.Add(keyspan.Span{
+					Start: startKey,
+					End:   endKey,
+					Value: splitValue,
+				}))
+			}
+			return buf.String()
+
+		case "add-reverse":
+			buf.Reset()
+
+			lines := strings.Split(strings.TrimSpace(td.Input), "\n")
+			for _, line := range lines {
+				startKey, value := Parse(line)
+				endKey, splitValue, ok := DecodeEndKey(startKey.Kind(), value)
+				require.True(t, ok)
+				require.NoError(t, c.AddReverse(keyspan.Span{
+					Start: startKey,
+					End:   endKey,
+					Value: splitValue,
+				}))
+			}
+			return buf.String()
+
+		case "finish":
+			buf.Reset()
+			c.Finish()
+			return buf.String()
+		default:
+			return fmt.Sprintf("unrecognized command %q", td.Cmd)
+		}
+	})
+}
+
+func formatRangeKeySpan(w io.Writer, rks *CoalescedSpan) {
+	if rks == nil {
+		fmt.Fprintf(w, ".")
+		return
+	}
+	fmt.Fprintf(w, "●   [%s, %s)#%d", rks.Start, rks.End, rks.LargestSeqNum)
+	if rks.Delete {
+		fmt.Fprintf(w, " (DEL)")
+	}
+	for i := range rks.Items {
+		fmt.Fprintln(w)
+		if i != len(rks.Items)-1 {
+			fmt.Fprint(w, "├──")
+		} else {
+			fmt.Fprint(w, "└──")
+		}
+		fmt.Fprintf(w, " %s", rks.Items[i].Suffix)
+		if rks.Items[i].Unset {
+			fmt.Fprint(w, " unset")
+		} else {
+			fmt.Fprintf(w, " : %s", rks.Items[i].Value)
+		}
+	}
+}

--- a/internal/rangekey/iter.go
+++ b/internal/rangekey/iter.go
@@ -1,0 +1,253 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package rangekey
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/keyspan"
+)
+
+// This Iter implementation iterates over 'coalesced spans' that are not easily
+// representable within the InternalIterator interface. Instead of iterating
+// over internal keys, this Iter exposes CoalescedSpans that represent a set of
+// overlapping fragments coalesced into a single internally consistent span.
+
+// Iter is an iterator over a set of fragmented, coalesced spans. It wraps a
+// keyspan.Iter containing fragmented keyspan.Spans with key kinds RANGEKEYSET,
+// RANGEKEYUNSET and RANGEKEYDEL. The spans within the keyspan.Iter must be
+// sorted by Start key, including by decreasing sequence number if user keys are
+// equal and key kind if sequence numbers are equal.
+//
+// Iter handles 'coalescing' spans on-the-fly, including dropping key spans that
+// are no longer relevant.
+type Iter struct {
+	iter      *keyspan.Iter
+	coalescer Coalescer
+	curr      CoalescedSpan
+	err       error
+	valid     bool
+	dir       int8
+}
+
+// Init initializes an iterator over a set of fragmented, coalesced spans.
+func (i *Iter) Init(cmp base.Compare, formatKey base.FormatKey, iter *keyspan.Iter) {
+	*i = Iter{
+		iter: iter,
+	}
+	i.coalescer.Init(cmp, formatKey, func(span CoalescedSpan) {
+		i.curr = span
+	})
+}
+
+// Error returns any accumulated error.
+func (i *Iter) Error() error {
+	return i.err
+}
+
+func (i *Iter) coalesceForward(k *base.InternalKey) *CoalescedSpan {
+	i.dir = +1
+	i.valid = false
+	// As long as we have a key and that key matches the coalescer's current
+	// start key, it must be coalesced.
+	// TODO(jackson): This key comparison is redundant with the one performed by
+	// Coalescer.Add. Tweaking the interfaces should be able to remove the
+	// comparison.
+	for k != nil && (!i.valid || i.coalescer.items.cmp(k.UserKey, i.coalescer.Start()) == 0) {
+		if err := i.coalescer.Add(*i.iter.Current()); err != nil {
+			i.valid, i.err = false, err
+			return nil
+		}
+		i.valid = true
+		k, _ = i.iter.Next()
+	}
+	// NB: Finish populates i.curr with the coalesced span.
+	i.coalescer.Finish()
+	if !i.valid {
+		return nil
+	}
+	return &i.curr
+}
+
+func (i *Iter) coalesceBackward(k *base.InternalKey) *CoalescedSpan {
+	i.dir = -1
+	i.valid = false
+	// As long as we have a key and that key matches the coalescer's current
+	// start key, it must be coalesced.
+	// TODO(jackson): This key comparison is redundant with the one performed by
+	// Coalescer.AddReverse. Tweaking the interfaces should be able to remove
+	// the comparison.
+	for k != nil && (!i.valid || i.coalescer.items.cmp(k.UserKey, i.coalescer.Start()) == 0) {
+		if err := i.coalescer.AddReverse(*i.iter.Current()); err != nil {
+			i.valid, i.err = false, err
+			return nil
+		}
+		i.valid = true
+		k, _ = i.iter.Prev()
+	}
+	// NB: Finish populates i.curr with the coalesced span.
+	i.coalescer.Finish()
+	if !i.valid {
+		return nil
+	}
+	return &i.curr
+}
+
+// SeekGE seeks the iterator to the first span covering a key greater than or
+// equal to key and returns it.
+func (i *Iter) SeekGE(key []byte) *CoalescedSpan {
+	k, _ := i.iter.SeekLT(key)
+	if s := i.iter.Current(); s != nil && i.coalescer.items.cmp(key, s.End) < 0 {
+		// We landed on a range key that begins before `key`, but extends beyond
+		// it. Since we performed a SeekLT, we're on the last fragment with
+		// those range key bounds and we need to coalesce backwards.
+		return i.coalesceBackward(k)
+	}
+	// It's still possible that the next key is a range key with a start key
+	// exactly equal to key. Move forward one. There's no point in checking
+	// whether the next fragment actually covers the search key, because if it
+	// doesn't it's still the first fragment covering a key ≥ the search key.
+	k, _ = i.iter.Next()
+	return i.coalesceForward(k)
+}
+
+// SeekLT seeks the iterator to the first span covering a key less than key and
+// returns it.
+func (i *Iter) SeekLT(key []byte) *CoalescedSpan {
+	k, _ := i.iter.SeekLT(key)
+	// We landed on the range key with the greatest start key that still sorts
+	// before `key`.  Since we performed a SeekLT, we're on the last fragment
+	// with those range key bounds and we need to coalesce backwards.
+	return i.coalesceBackward(k)
+}
+
+// First seeks the iterator to the first span and returns it.
+func (i *Iter) First() *CoalescedSpan {
+	i.dir = +1
+	k, _ := i.iter.First()
+	return i.coalesceForward(k)
+}
+
+// Last seeks the iterator to the last span and returns it.
+func (i *Iter) Last() *CoalescedSpan {
+	i.dir = -1
+	k, _ := i.iter.Last()
+	return i.coalesceBackward(k)
+}
+
+// Next advances to the next span and returns it.
+func (i *Iter) Next() *CoalescedSpan {
+	switch {
+	case i.dir == +1 && !i.iter.Valid():
+		// If we were already going forward and the underlying iterator is
+		// invalid, there is no next item. Don't move the iterator, just
+		// invalidate the iterator's position.
+		i.valid = false
+		return nil
+	case i.dir == -1 && !i.valid:
+		// If we were previously going backward and the iterator is positioned
+		// at the very beginning, we only need to Next once to position
+		// ourselves over the first fragment.
+		i.dir = +1
+		_, _ = i.iter.Next()
+	case i.dir == -1:
+		// Switching directions; We're currently positioned at the last of the
+		// previous set of fragments. The iterator is valid. In the example
+		// below, Current is the span formed by coalescing the y fragments. The
+		// ^ marks the i.iter position, over the last fragment of x.:
+		//   ... x x x y y y ...
+		//           ^
+		// We want to return the coalesced span after y (if it exists). We move
+		// the underlying iterator once to move over the first fragment of y
+		// [which necessarily must exist, since i.valid], coalesce forward to
+		// skip over the rest of y's fragments and land on the first fragment of
+		// z, if it exists.
+		i.dir = +1
+		if k, _ := i.iter.Next(); k == nil {
+			// Since i.valid, there must be a next fragment on the underlying
+			// span.
+			i.err = errors.Newf("pebble: invariant violation: next span must exist")
+			return nil
+		}
+		// Now we're positioned over the first fragment for the most recently
+		// returned coalesced span (y in the above example). The caller Next'd
+		// because they want the coalesced span after that, so Next() once [on
+		// this iter, not the inner iter] to skip over it.
+		if x := i.Next(); x == nil {
+			i.err = errors.Newf("pebble: invariant violation: next span must exist")
+			return nil
+		}
+		// Now we're positioned over the first fragment for the correct span,
+		// and may proceed as normal.
+	}
+	if !i.iter.Valid() {
+		i.valid = false
+		return nil
+	}
+	return i.coalesceForward(i.iter.Key())
+}
+
+// Prev steps back to the previous span and returns it.
+func (i *Iter) Prev() *CoalescedSpan {
+	switch {
+	case i.dir == -1 && !i.iter.Valid():
+		// If we were already going backward and the underlying iterator is
+		// invalid, there is no previous item. Don't move the iterator, just
+		// invalidate the iterator's position.
+		i.valid = false
+		return nil
+	case i.dir == +1 && !i.valid:
+		// If we were previously going forward and the iterator is positioned at
+		// the very end, we only need to Prev once to position ourselves over
+		// the last fragment.
+		i.dir = -1
+		_, _ = i.iter.Prev()
+	case i.dir == +1:
+		// Switching directions; We're currently positioned at the first of the
+		// next set of fragments. The iterator is valid. In the example
+		// below, Current is the span formed by coalescing the x fragments. The
+		// ^ marks the i.iter position, over the first fragment of y.:
+		//   ... x x x y y y ...
+		//             ^
+		// We want to return the coalesced span before x (if it exists). We move
+		// the underlying iterator once to move over the last fragment of x
+		// [which necessarily must exist, since i.valid], coalesce backward to
+		// skip over the rest of x's fragments and land on the first fragment of
+		// w, if it exists.
+		i.dir = -1
+		if k, _ := i.iter.Prev(); k == nil {
+			i.err = errors.Newf("pebble: invariant violation: next span must exist")
+			return nil
+		}
+		// Now we're positioned over the last fragment for the most recently
+		// returned coalesced span (x in the above example). The caller Prev'd
+		// because they want the coalesced span before that, so Prev() once [on
+		// this iter, not the inner iter] to skip over it.
+		if x := i.Prev(); x == nil {
+			i.err = errors.Newf("pebble: invariant violation: next span must exist")
+			return nil
+		}
+		// Now we're positioned over the last fragment for the correct span, and
+		// may proceed as normal.
+	}
+	if !i.iter.Valid() {
+		i.valid = false
+		return nil
+	}
+	return i.coalesceBackward(i.iter.Key())
+}
+
+// Current returns the span at the iterator's current position, if any.
+func (i *Iter) Current() *CoalescedSpan {
+	if !i.valid {
+		return nil
+	}
+	return &i.curr
+}
+
+// Valid returns true if the iterator is currently positioned over a span.
+func (i *Iter) Valid() bool {
+	return i.valid
+}

--- a/internal/rangekey/testdata/coalescer
+++ b/internal/rangekey/testdata/coalescer
@@ -1,0 +1,297 @@
+# All disjoint RANGEKEYSETs.
+
+add
+a.RANGEKEYSET.10: c [(@t5=foo)]
+----
+
+add
+c.RANGEKEYSET.4: d [(@t3=foo)]
+----
+●   [a, c)#10
+└── @t5 : foo
+
+add
+e.RANGEKEYSET.20: f [(@t5=bar),(@t3=foo)]
+----
+●   [c, d)#4
+└── @t3 : foo
+
+finish
+----
+●   [e, f)#20
+├── @t5 : bar
+└── @t3 : foo
+
+# All disjoint RANGEKEYSETs in reverse.
+
+add-reverse
+e.RANGEKEYSET.20: f [(@t5=bar),(@t3=foo)]
+----
+
+add-reverse
+c.RANGEKEYSET.4: d [(@t3=foo)]
+----
+●   [e, f)#20
+├── @t5 : bar
+└── @t3 : foo
+
+add-reverse
+a.RANGEKEYSET.10: c [(@t5=foo)]
+----
+●   [c, d)#4
+└── @t3 : foo
+
+finish
+----
+●   [a, c)#10
+└── @t5 : foo
+
+# Merge overlapping RANGEKEYSETs.
+
+add
+a.RANGEKEYSET.10: c [(@t5=foo5)]
+a.RANGEKEYSET.4:  c [(@t3=foo3)]
+a.RANGEKEYSET.4:  c [(@t2=foo2)]
+----
+
+finish
+----
+●   [a, c)#10
+├── @t5 : foo5
+├── @t3 : foo3
+└── @t2 : foo2
+
+# All disjoint RANGEKEYUNSETs.
+
+add
+a.RANGEKEYUNSET.10: c [@t5]
+----
+
+add
+c.RANGEKEYUNSET.4:  d [@t3]
+----
+●   [a, c)#10
+└── @t5 unset
+
+add
+e.RANGEKEYUNSET.20: f [@t5,@t3]
+----
+●   [c, d)#4
+└── @t3 unset
+
+finish
+----
+●   [e, f)#20
+├── @t5 unset
+└── @t3 unset
+
+# All disjoint RANGEKEYUNSETs in reverse.
+
+add-reverse
+e.RANGEKEYUNSET.20: f [@t5,@t3]
+----
+
+add-reverse
+c.RANGEKEYUNSET.4:  d [@t3]
+----
+●   [e, f)#20
+├── @t5 unset
+└── @t3 unset
+
+add-reverse
+a.RANGEKEYUNSET.10: c [@t5]
+----
+●   [c, d)#4
+└── @t3 unset
+
+finish
+----
+●   [a, c)#10
+└── @t5 unset
+
+# Merge overlapping RANGEKEYUNSETs.
+
+add
+a.RANGEKEYUNSET.10: c [@t5]
+----
+
+add
+a.RANGEKEYUNSET.4: c [@t3]
+----
+
+add
+a.RANGEKEYUNSET.4: c [@t2]
+----
+
+finish
+----
+●   [a, c)#10
+├── @t5 unset
+├── @t3 unset
+└── @t2 unset
+
+# Merge overlapping RANGEKEYUNSETs in reverse.
+
+add-reverse
+a.RANGEKEYUNSET.4: c [@t2]
+----
+
+add-reverse
+a.RANGEKEYUNSET.4: c [@t3]
+----
+
+add-reverse
+a.RANGEKEYUNSET.10: c [@t5]
+----
+
+finish
+----
+●   [a, c)#10
+├── @t5 unset
+├── @t3 unset
+└── @t2 unset
+
+# Unsets may partially remove sets.
+
+add
+a.RANGEKEYUNSET.10 : c [@t100]
+a.RANGEKEYSET.9    : c [(@t100=v100), (@t50=v50)]
+c.RANGEKEYSET.9    : d [(@t100=v100), (@t50=v50)]
+----
+●   [a, c)#10
+├── @t100 unset
+└── @t50 : v50
+
+finish
+----
+●   [c, d)#9
+├── @t100 : v100
+└── @t50 : v50
+
+# Unsets may partially remove sets in reverse.
+
+add-reverse
+c.RANGEKEYSET.9    : d [(@t100=v100), (@t50=v50)]
+a.RANGEKEYSET.9    : c [(@t100=v100), (@t50=v50)]
+a.RANGEKEYUNSET.10 : c [@t100]
+----
+●   [c, d)#9
+├── @t100 : v100
+└── @t50 : v50
+
+finish
+----
+●   [a, c)#10
+├── @t100 unset
+└── @t50 : v50
+
+# Unsets may wholly remove sets.
+
+add
+b.RANGEKEYUNSET.10 : c [@t3,@t2,@t1]
+b.RANGEKEYSET.8    : c [(@t3=v3),(@t2=v2),(@t1=v1)]
+----
+
+finish
+----
+●   [b, c)#10
+├── @t3 unset
+├── @t2 unset
+└── @t1 unset
+
+# Unsets may wholly remove sets in reverse.
+
+add-reverse
+b.RANGEKEYSET.8    : c [(@t3=v3),(@t2=v2),(@t1=v1)]
+b.RANGEKEYUNSET.10 : c [@t3,@t2,@t1]
+----
+
+finish
+----
+●   [b, c)#10
+├── @t3 unset
+├── @t2 unset
+└── @t1 unset
+
+
+# Sets may shadow unsets.
+
+add
+a.RANGEKEYSET.5   : c [(@t5=v5)]
+a.RANGEKEYUNSET.4 : c [@t5]
+----
+
+finish
+----
+●   [a, c)#5
+└── @t5 : v5
+
+# Sets may shadow unsets in reverse.
+
+add-reverse
+a.RANGEKEYUNSET.4 : c [@t5]
+a.RANGEKEYSET.5   : c [(@t5=v5)]
+----
+
+finish
+----
+●   [a, c)#5
+└── @t5 : v5
+
+# Deletes shadow Sets and Unsets, but not at the same sequence number.
+
+add
+a.RANGEKEYSET.10  : c [(@t5=foo5)]
+a.RANGEKEYDEL.10  : c
+a.RANGEKEYUNSET.8 : c [@t1]
+a.RANGEKEYSET.4   : c [(@t3=foo3)]
+a.RANGEKEYSET.4   : c [(@t2=foo2)]
+----
+
+finish
+----
+●   [a, c)#10 (DEL)
+└── @t5 : foo5
+
+# Deletes shadow Sets and Unsets, but not at the same sequence number, in
+# reverse
+
+add-reverse
+a.RANGEKEYSET.4   : c [(@t2=foo2)]
+a.RANGEKEYSET.4   : c [(@t3=foo3)]
+a.RANGEKEYUNSET.8 : c [@t1]
+a.RANGEKEYDEL.10  : c
+a.RANGEKEYSET.10  : c [(@t5=foo5)]
+----
+
+finish
+----
+●   [a, c)#10 (DEL)
+└── @t5 : foo5
+
+# Within a sequence number, none of the internal range keys affect one another.
+
+add
+a.RANGEKEYSET.5   : c [(@t5=foo)]
+a.RANGEKEYUNSET.5 : c [@t5]
+a.RANGEKEYDEL.5   : c
+----
+
+finish
+----
+●   [a, c)#5 (DEL)
+└── @t5 : foo
+
+# Within a sequence number, none of the internal range keys affect one another,
+# in reverse.
+
+add-reverse
+a.RANGEKEYDEL.5   : c
+a.RANGEKEYUNSET.5 : c [@t5]
+a.RANGEKEYSET.5   : c [(@t5=foo)]
+----
+
+finish
+----
+●   [a, c)#5 (DEL)
+└── @t5 : foo

--- a/internal/rangekey/testdata/iter
+++ b/internal/rangekey/testdata/iter
@@ -1,0 +1,238 @@
+define
+a.RANGEKEYSET.10  : c [(@t5=apples)]
+a.RANGEKEYDEL.10  : c
+a.RANGEKEYUNSET.8 : c [@t1]
+a.RANGEKEYSET.4   : c [(@t3=bananas)]
+a.RANGEKEYSET.4   : c [(@t2=oranges)]
+c.RANGEKEYSET.4   : d [(@t3=coconut)]
+e.RANGEKEYSET.20  : f [(@t5=pineapple),(@t3=guava)]
+h.RANGEKEYDEL.22  : j
+h.RANGEKEYSET.21  : j [(@t5=peaches),(@t3=starfruit)]
+l.RANGEKEYUNSET.2 : m [@t9,@t5]
+q.RANGEKEYSET.14  : z [(@t9=mangos)]
+----
+OK
+
+iter
+first
+next
+next
+next
+next
+next
+next
+----
+●   [a, c)#10 (DEL)
+└── @t5 : apples
+●   [c, d)#4
+└── @t3 : coconut
+●   [e, f)#20
+├── @t5 : pineapple
+└── @t3 : guava
+●   [h, j)#22 (DEL)
+●   [l, m)#2
+├── @t9 unset
+└── @t5 unset
+●   [q, z)#14
+└── @t9 : mangos
+.
+
+iter
+last
+prev
+prev
+prev
+prev
+prev
+prev
+----
+●   [q, z)#14
+└── @t9 : mangos
+●   [l, m)#2
+├── @t9 unset
+└── @t5 unset
+●   [h, j)#22 (DEL)
+●   [e, f)#20
+├── @t5 : pineapple
+└── @t3 : guava
+●   [c, d)#4
+└── @t3 : coconut
+●   [a, c)#10 (DEL)
+└── @t5 : apples
+.
+
+iter
+seek-ge cat
+prev
+next
+next
+next
+----
+●   [c, d)#4
+└── @t3 : coconut
+●   [a, c)#10 (DEL)
+└── @t5 : apples
+●   [c, d)#4
+└── @t3 : coconut
+●   [e, f)#20
+├── @t5 : pineapple
+└── @t3 : guava
+●   [h, j)#22 (DEL)
+
+iter
+seek-ge c
+prev
+next
+next
+next
+----
+●   [c, d)#4
+└── @t3 : coconut
+●   [a, c)#10 (DEL)
+└── @t5 : apples
+●   [c, d)#4
+└── @t3 : coconut
+●   [e, f)#20
+├── @t5 : pineapple
+└── @t3 : guava
+●   [h, j)#22 (DEL)
+
+iter
+seek-ge cat
+seek-ge c
+prev
+prev
+next
+next
+next
+----
+●   [c, d)#4
+└── @t3 : coconut
+●   [c, d)#4
+└── @t3 : coconut
+●   [a, c)#10 (DEL)
+└── @t5 : apples
+.
+●   [a, c)#10 (DEL)
+└── @t5 : apples
+●   [c, d)#4
+└── @t3 : coconut
+●   [e, f)#20
+├── @t5 : pineapple
+└── @t3 : guava
+
+iter
+seek-ge dog
+next
+prev
+next
+next
+next
+next
+----
+●   [e, f)#20
+├── @t5 : pineapple
+└── @t3 : guava
+●   [h, j)#22 (DEL)
+●   [e, f)#20
+├── @t5 : pineapple
+└── @t3 : guava
+●   [h, j)#22 (DEL)
+●   [l, m)#2
+├── @t9 unset
+└── @t5 unset
+●   [q, z)#14
+└── @t9 : mangos
+.
+
+iter
+seek-ge a
+seek-ge ace
+seek-ge bat
+seek-ge c
+----
+●   [a, c)#10 (DEL)
+└── @t5 : apples
+●   [a, c)#10 (DEL)
+└── @t5 : apples
+●   [a, c)#10 (DEL)
+└── @t5 : apples
+●   [c, d)#4
+└── @t3 : coconut
+
+iter
+seek-ge 1
+seek-ge c1
+----
+●   [a, c)#10 (DEL)
+└── @t5 : apples
+●   [c, d)#4
+└── @t3 : coconut
+
+iter
+seek-ge zoo
+prev
+seek-ge z
+prev
+seek-ge yeti
+----
+.
+●   [q, z)#14
+└── @t9 : mangos
+.
+●   [q, z)#14
+└── @t9 : mangos
+●   [q, z)#14
+└── @t9 : mangos
+
+iter
+seek-ge h
+seek-ge j
+----
+●   [h, j)#22 (DEL)
+●   [l, m)#2
+├── @t9 unset
+└── @t5 unset
+
+iter
+first
+prev
+next
+----
+●   [a, c)#10 (DEL)
+└── @t5 : apples
+.
+●   [a, c)#10 (DEL)
+└── @t5 : apples
+
+iter
+last
+next
+prev
+----
+●   [q, z)#14
+└── @t9 : mangos
+.
+●   [q, z)#14
+└── @t9 : mangos
+
+iter
+seek-lt a
+seek-lt 0
+seek-lt aa
+seek-lt z
+seek-lt zoo
+next
+prev
+----
+.
+.
+●   [a, c)#10 (DEL)
+└── @t5 : apples
+●   [q, z)#14
+└── @t9 : mangos
+●   [q, z)#14
+└── @t9 : mangos
+.
+●   [q, z)#14
+└── @t9 : mangos


### PR DESCRIPTION
internal/rangekey: add Coalescer, CoalescedSpan

Add a Coalescer type that may 'coalesce' overlapping range key fragments into a
single CoalescedSpan. A CoalescedSpan represents the aggregate of all the
information from the individual range keys coalesced. A CoalesecedSpan is always
internally consistent, meaning that all necessary shadowing of keys is applied.

Coalescer is expected to be used in compactions, coalescing any overlapping
range key fragments from compaction inputs, and emitting CoalescedSpans that may
be used to construct the range keys persisted to outputs. It is also expected to
be used during iteration, for coalescing snapshot-separated overlapping range
keys and for respecting unsets and deletes across levels. Additional interface
changes may be necessary to support all of the above use cases.

internal/rangekeys: add Iter

Add an iterator that wraps a range key keyspan.Iter and performs on-the-fly
coalescing of range keys. This may be used to implement range-key iteration over
the memtable's range keys. It may also be useful elsewhere with extensions.