### PR TITLE
db: add test that shows effects of InternalKeyKind ordering for inges…

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -296,6 +296,11 @@ func runBatchDefineCmd(d *datadriven.TestData, b *Batch) error {
 				return errors.Errorf("%s expects 1 argument", parts[0])
 			}
 			err = b.Delete([]byte(parts[1]), nil)
+		case "singledel":
+			if len(parts) != 2 {
+				return errors.Errorf("%s expects 1 argument", parts[0])
+			}
+			err = b.SingleDelete([]byte(parts[1]), nil)
 		case "del-range":
 			if len(parts) != 3 {
 				return errors.Errorf("%s expects 2 arguments", parts[0])

--- a/testdata/iterator_next_prev
+++ b/testdata/iterator_next_prev
@@ -226,3 +226,36 @@ prev
 .
 a:a
 .
+
+reset
+----
+
+# Test demonstrating inadvertent exposure of ordering effects of the
+# InternalKeyKind numbering. We build an sst with a (del/singledel, set) pair
+# for two user keys. When ingested, all 4 keys have the same seqnum. The set
+# overrides the del, and the singedel overrides the set.
+#
+# The test input setup looks peculiar because the build uses an indexed batch,
+# and iterates over it to write to the sst, so we need to place the set after
+# the del, and the singledel after the set in order for the batch ordering to
+# be one that is suitable for feeding into the sstable writer. All 4 keys are
+# being written to the sst (notice the bounds in the ingest).
+
+build ext1
+del a
+set a 1
+set b 2
+singledel b
+----
+
+ingest ext1
+----
+6:
+  000004:[a#1,SET-b#1,SET]
+
+iter
+first
+next
+----
+a:1
+.


### PR DESCRIPTION
…ted sstables

There is no reason why Del and SingleDel should behave differently
from the perspective of the user.

InternalKeyKind numbers can be used to assist the implementation
of the desired semantics but they should not be dictating what
semantics the user sees.