### PR TITLE
sstable: rename {Smallest,Largest}Range to {Smallest,Largest}RangeDel

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2265,15 +2265,15 @@ func (d *DB) runCompaction(
 			// This is not the first output file. Bound the smallest range key by the
 			// previous tables largest key.
 			prevMeta := ve.NewFiles[n-2].Meta
-			if writerMeta.SmallestRange.UserKey != nil {
-				c := d.cmp(writerMeta.SmallestRange.UserKey, prevMeta.Largest.UserKey)
+			if writerMeta.SmallestRangeDel.UserKey != nil {
+				c := d.cmp(writerMeta.SmallestRangeDel.UserKey, prevMeta.Largest.UserKey)
 				if c < 0 {
 					return errors.Errorf(
 						"pebble: smallest range tombstone start key is less than previous sstable largest key: %s < %s",
-						writerMeta.SmallestRange.Pretty(d.opts.Comparer.FormatKey),
+						writerMeta.SmallestRangeDel.Pretty(d.opts.Comparer.FormatKey),
 						prevMeta.Largest.Pretty(d.opts.Comparer.FormatKey))
 				}
-				if c == 0 && prevMeta.Largest.SeqNum() <= writerMeta.SmallestRange.SeqNum() {
+				if c == 0 && prevMeta.Largest.SeqNum() <= writerMeta.SmallestRangeDel.SeqNum() {
 					// The user key portion of the range boundary start key is equal to
 					// the previous table's largest key. We need the tables to be
 					// key-space partitioned, so force the boundary to a key that we know
@@ -2305,12 +2305,12 @@ func (d *DB) runCompaction(
 					// https://github.com/cockroachdb/pebble/pull/479#pullrequestreview-340600654
 					// into docs/range_deletions.md and reference the correctness
 					// argument here. Note that that comment might be slightly incorrect.
-					writerMeta.SmallestRange.SetSeqNum(prevMeta.Largest.SeqNum() - 1)
+					writerMeta.SmallestRangeDel.SetSeqNum(prevMeta.Largest.SeqNum() - 1)
 				}
 			}
 		}
 
-		if splitKey != nil && writerMeta.LargestRange.UserKey != nil {
+		if splitKey != nil && writerMeta.LargestRangeDel.UserKey != nil {
 			// The current file is not the last output file and there is a range tombstone in it.
 			// If the tombstone extends into the next file, then truncate it for the purposes of
 			// computing meta.Largest. For example, say the next file's first key is c#7,1 and the
@@ -2319,9 +2319,9 @@ func (d *DB) runCompaction(
 			// c#inf where inf is the InternalKeyRangeDeleteSentinel. Note that this is just for
 			// purposes of bounds computation -- the current sstable will end up with a Largest key
 			// of c#7,1 so the range tombstone in the current file will be able to delete c#7.
-			if d.cmp(writerMeta.LargestRange.UserKey, splitKey) >= 0 {
-				writerMeta.LargestRange.UserKey = splitKey
-				writerMeta.LargestRange.Trailer = InternalKeyRangeDeleteSentinel
+			if d.cmp(writerMeta.LargestRangeDel.UserKey, splitKey) >= 0 {
+				writerMeta.LargestRangeDel.UserKey = splitKey
+				writerMeta.LargestRangeDel.Trailer = InternalKeyRangeDeleteSentinel
 			}
 		}
 

--- a/sstable/testdata/rewriter
+++ b/sstable/testdata/rewriter
@@ -3,9 +3,9 @@ a_xyz.SET.1:a
 b_xyz.SET.1:b
 c_xyz.SET.1:c
 ----
-point:   [a_xyz#1,1,c_xyz#1,1]
-range:   [#0,0,#0,0]
-seqnums: [1,1]
+point:    [a_xyz#1,1,c_xyz#1,1]
+rangedel: [#0,0,#0,0]
+seqnums:  [1,1]
 
 # rewrite from=xyz to=123 block-size=1 index-block-size=1 filter
 # ----
@@ -20,9 +20,9 @@ aa_xyz.SET.1:a
 ba_xyz.SET.1:b
 ca_xyz.SET.1:c
 ----
-point:   [aa_xyz#1,1,ca_xyz#1,1]
-range:   [#0,0,#0,0]
-seqnums: [1,1]
+point:    [aa_xyz#1,1,ca_xyz#1,1]
+rangedel: [#0,0,#0,0]
+seqnums:  [1,1]
 
 rewrite from=yz to=23 block-size=1 index-block-size=1 filter comparer-split-4b-suffix
 ----
@@ -37,9 +37,9 @@ a_xyz.SET.1:a
 b_xyz.SET.1:b
 c_xyz.SET.1:c
 ----
-point:   [a_xyz#1,1,c_xyz#1,1]
-range:   [#0,0,#0,0]
-seqnums: [1,1]
+point:    [a_xyz#1,1,c_xyz#1,1]
+rangedel: [#0,0,#0,0]
+seqnums:  [1,1]
 
 layout
 ----
@@ -73,9 +73,9 @@ c
 
 rewrite from=_xyz to=_123 block-size=1 index-block-size=1 filter comparer-split-4b-suffix
 ----
-point:   [a_123#1,1,c_123#1,1]
-range:   [#0,0,#0,0]
-seqnums: [1,1]
+point:    [a_123#1,1,c_123#1,1]
+rangedel: [#0,0,#0,0]
+seqnums:  [1,1]
 
 layout
 ----
@@ -109,9 +109,9 @@ c
 
 rewrite from=_123 to=_456 block-size=1 index-block-size=1 filter comparer-split-4b-suffix concurrency=2
 ----
-point:   [a_456#1,1,c_456#1,1]
-range:   [#0,0,#0,0]
-seqnums: [1,1]
+point:    [a_456#1,1,c_456#1,1]
+rangedel: [#0,0,#0,0]
+seqnums:  [1,1]
 
 layout
 ----
@@ -145,9 +145,9 @@ c
 
 rewrite from=_456 to=_xyz block-size=1 index-block-size=1 filter comparer-split-4b-suffix concurrency=3
 ----
-point:   [a_xyz#1,1,c_xyz#1,1]
-range:   [#0,0,#0,0]
-seqnums: [1,1]
+point:    [a_xyz#1,1,c_xyz#1,1]
+rangedel: [#0,0,#0,0]
+seqnums:  [1,1]
 
 layout
 ----
@@ -182,9 +182,9 @@ c
 
 rewrite from=_xyz to=_123 block-size=1 index-block-size=1 filter comparer-split-4b-suffix concurrency=4
 ----
-point:   [a_123#1,1,c_123#1,1]
-range:   [#0,0,#0,0]
-seqnums: [1,1]
+point:    [a_123#1,1,c_123#1,1]
+rangedel: [#0,0,#0,0]
+seqnums:  [1,1]
 
 layout
 ----

--- a/sstable/testdata/writer
+++ b/sstable/testdata/writer
@@ -1,9 +1,9 @@
 build
 a.SET.1:a
 ----
-point:   [a#1,1,a#1,1]
-range:   [#0,0,#0,0]
-seqnums: [1,1]
+point:    [a#1,1,a#1,1]
+rangedel: [#0,0,#0,0]
+seqnums:  [1,1]
 
 scan
 ----
@@ -22,9 +22,9 @@ g.DEL.6:
 h.MERGE.7:h
 i.RANGEDEL.8:j
 ----
-point:   [a#1,1,h#7,2]
-range:   [d#4,15,j#72057594037927935,15]
-seqnums: [1,8]
+point:    [a#1,1,h#7,2]
+rangedel: [d#4,15,j#72057594037927935,15]
+seqnums:  [1,8]
 
 build
 a.SET.1:a
@@ -36,9 +36,9 @@ g.DEL.6:
 h.MERGE.7:h
 i.RANGEDEL.8:j
 ----
-point:   [a#1,1,h#7,2]
-range:   [d#4,15,j#72057594037927935,15]
-seqnums: [1,8]
+point:    [a#1,1,h#7,2]
+rangedel: [d#4,15,j#72057594037927935,15]
+seqnums:  [1,8]
 
 scan
 ----
@@ -63,9 +63,9 @@ a.RANGEDEL.3:m
 f.RANGEDEL.2:s
 j.RANGEDEL.1:z
 ----
-point:   [#0,0,#0,0]
-range:   [a#3,15,z#72057594037927935,15]
-seqnums: [1,3]
+point:    [#0,0,#0,0]
+rangedel: [a#3,15,z#72057594037927935,15]
+seqnums:  [1,3]
 
 scan
 ----
@@ -89,25 +89,25 @@ build
 a.RANGEDEL.3:b
 b.SET.4:c
 ----
-point:   [b#4,1,b#4,1]
-range:   [a#3,15,b#72057594037927935,15]
-seqnums: [3,4]
+point:    [b#4,1,b#4,1]
+rangedel: [a#3,15,b#72057594037927935,15]
+seqnums:  [3,4]
 
 build
 a.RANGEDEL.3:b
 b.SET.2:c
 ----
-point:   [b#2,1,b#2,1]
-range:   [a#3,15,b#72057594037927935,15]
-seqnums: [2,3]
+point:    [b#2,1,b#2,1]
+rangedel: [a#3,15,b#72057594037927935,15]
+seqnums:  [2,3]
 
 build
 a.RANGEDEL.3:c
 b.SET.2:c
 ----
-point:   [b#2,1,b#2,1]
-range:   [a#3,15,c#72057594037927935,15]
-seqnums: [2,3]
+point:    [b#2,1,b#2,1]
+rangedel: [a#3,15,c#72057594037927935,15]
+seqnums:  [2,3]
 
 # Keys must be added in order.
 
@@ -132,9 +132,9 @@ pebble: keys must be added in order: b#1,RANGEDEL > a#2,RANGEDEL
 build-raw
 .RANGEDEL.1:b
 ----
-point:   [#0,0,#0,0]
-range:   [#1,15,b#72057594037927935,15]
-seqnums: [1,1]
+point:    [#0,0,#0,0]
+rangedel: [#1,15,b#72057594037927935,15]
+seqnums:  [1,1]
 
 build-raw
 a.RANGEDEL.1:c
@@ -158,9 +158,9 @@ build-raw
 a.RANGEDEL.1:c
 c.RANGEDEL.2:d
 ----
-point:   [#0,0,#0,0]
-range:   [a#1,15,d#72057594037927935,15]
-seqnums: [1,2]
+point:    [#0,0,#0,0]
+rangedel: [a#1,15,d#72057594037927935,15]
+seqnums:  [1,2]
 
 # The range-del-v1 format supports unfragmented and unsorted range
 # tombstones.
@@ -169,9 +169,9 @@ build-raw range-del-v1
 a.RANGEDEL.1:c
 a.RANGEDEL.2:c
 ----
-point:   [#0,0,#0,0]
-range:   [a#2,15,c#72057594037927935,15]
-seqnums: [1,2]
+point:    [#0,0,#0,0]
+rangedel: [a#2,15,c#72057594037927935,15]
+seqnums:  [1,2]
 
 scan-range-del
 ----
@@ -182,9 +182,9 @@ build-raw range-del-v1
 a.RANGEDEL.1:c
 b.RANGEDEL.2:d
 ----
-point:   [#0,0,#0,0]
-range:   [a#1,15,d#72057594037927935,15]
-seqnums: [1,2]
+point:    [#0,0,#0,0]
+rangedel: [a#1,15,d#72057594037927935,15]
+seqnums:  [1,2]
 
 scan-range-del
 ----
@@ -197,9 +197,9 @@ build-raw range-del-v1
 a.RANGEDEL.2:c
 a.RANGEDEL.1:d
 ----
-point:   [#0,0,#0,0]
-range:   [a#2,15,d#72057594037927935,15]
-seqnums: [1,2]
+point:    [#0,0,#0,0]
+rangedel: [a#2,15,d#72057594037927935,15]
+seqnums:  [1,2]
 
 scan-range-del
 ----
@@ -216,9 +216,9 @@ j.RANGEDEL.1:z
 f.RANGEDEL.2:s
 a.RANGEDEL.3:m
 ----
-point:   [#0,0,#0,0]
-range:   [a#3,15,z#72057594037927935,15]
-seqnums: [1,3]
+point:    [#0,0,#0,0]
+rangedel: [a#3,15,z#72057594037927935,15]
+seqnums:  [1,3]
 
 scan-range-del
 ----
@@ -239,9 +239,9 @@ a.SET.1:a
 b.SET.1:b
 c.SET.1:c
 ----
-point:   [a#1,1,c#1,1]
-range:   [#0,0,#0,0]
-seqnums: [1,1]
+point:    [a#1,1,c#1,1]
+rangedel: [#0,0,#0,0]
+seqnums:  [1,1]
 
 layout
 ----
@@ -271,9 +271,9 @@ a.SET.1:a
 b.SET.1:b
 c.SET.1:c
 ----
-point:   [a#1,1,c#1,1]
-range:   [#0,0,#0,0]
-seqnums: [1,1]
+point:    [a#1,1,c#1,1]
+rangedel: [#0,0,#0,0]
+seqnums:  [1,1]
 
 layout
 ----

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -49,9 +49,9 @@ func runDataDriven(t *testing.T, file string) {
 			if err != nil {
 				return err.Error()
 			}
-			return fmt.Sprintf("point:   [%s,%s]\nrange:   [%s,%s]\nseqnums: [%d,%d]\n",
+			return fmt.Sprintf("point:    [%s,%s]\nrangedel: [%s,%s]\nseqnums:  [%d,%d]\n",
 				meta.SmallestPoint, meta.LargestPoint,
-				meta.SmallestRange, meta.LargestRange,
+				meta.SmallestRangeDel, meta.LargestRangeDel,
 				meta.SmallestSeqNum, meta.LargestSeqNum)
 
 		case "build-raw":
@@ -65,9 +65,9 @@ func runDataDriven(t *testing.T, file string) {
 			if err != nil {
 				return err.Error()
 			}
-			return fmt.Sprintf("point:   [%s,%s]\nrange:   [%s,%s]\nseqnums: [%d,%d]\n",
+			return fmt.Sprintf("point:    [%s,%s]\nrangedel: [%s,%s]\nseqnums:  [%d,%d]\n",
 				meta.SmallestPoint, meta.LargestPoint,
-				meta.SmallestRange, meta.LargestRange,
+				meta.SmallestRangeDel, meta.LargestRangeDel,
 				meta.SmallestSeqNum, meta.LargestSeqNum)
 
 		case "scan":
@@ -139,9 +139,9 @@ func runDataDriven(t *testing.T, file string) {
 			if err != nil {
 				return err.Error()
 			}
-			return fmt.Sprintf("point:   [%s,%s]\nrange:   [%s,%s]\nseqnums: [%d,%d]\n",
+			return fmt.Sprintf("point:    [%s,%s]\nrangedel: [%s,%s]\nseqnums:  [%d,%d]\n",
 				meta.SmallestPoint, meta.LargestPoint,
-				meta.SmallestRange, meta.LargestRange,
+				meta.SmallestRangeDel, meta.LargestRangeDel,
 				meta.SmallestSeqNum, meta.LargestSeqNum)
 
 		default:


### PR DESCRIPTION
Ahead of an upcoming change that stores the smallest and largest
rangekeys in the metadata of an sstable, update the existing fields for
rangedels to explicitly refer to range _deletions_. This will avoid
confusion and naming collisions with range _keys_.