### PR TITLE
internal/base: adjust InternalCompare comment on key kinds

### DIFF
--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -212,8 +212,8 @@ func DecodeInternalKey(encodedKey []byte) InternalKey {
 // InternalCompare compares two internal keys using the specified comparison
 // function. For equal user keys, internal keys compare in descending sequence
 // number order. For equal user keys and sequence numbers, internal keys
-// compare in descending kind order (though this should never happen in
-// practice).
+// compare in descending kind order (this may happen in practice among range
+// keys).
 func InternalCompare(userCmp Compare, a, b InternalKey) int {
 	if x := userCmp(a.UserKey, b.UserKey); x != 0 {
 		return x


### PR DESCRIPTION
InternalCompare previously suggested that in practice keys will never have
equal user keys and sequence numbers. That's true, except in ingested sstables
with unusual constructions (not in practice in CockroachDB) and now range keys.