### PR TITLE
sstable: add range keys to sstable.Layout

### DIFF
--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -133,9 +133,9 @@ type Properties struct {
 	// Total raw key size.
 	RawKeySize uint64 `prop:"rocksdb.raw.key.size"`
 	// Total raw rangekey key size.
-	RawRangeKeyKeySize uint64 `prop:"pebble.raw.rangekey.key.size"`
+	RawRangeKeyKeySize uint64 `prop:"pebble.raw.range-key.key.size"`
 	// Total raw rangekey value size.
-	RawRangeKeyValueSize uint64 `prop:"pebble.raw.rangekey.value.size"`
+	RawRangeKeyValueSize uint64 `prop:"pebble.raw.range-key.value.size"`
 	// Total raw value size.
 	RawValueSize uint64 `prop:"rocksdb.raw.value.size"`
 	// Size of the top-level index if kTwoLevelIndexSearch is used.

--- a/sstable/testdata/writer
+++ b/sstable/testdata/writer
@@ -361,3 +361,25 @@ layout
        813  meta-index (33)
        851  leveldb-footer (48)
        899  EOF
+
+# Range keys, if present, are shown in the layout.
+
+build
+a.RANGEKEYSET.3:b [(@t3=foo)]
+b.RANGEKEYSET.2:c [(@t2=bar)]
+c.RANGEKEYSET.1:d [(@t1=baz)]
+----
+point:    [#0,0,#0,0]
+rangedel: [#0,0,#0,0]
+rangekey: [a#3,21,d#72057594037927935,21]
+seqnums:  [1,3]
+
+layout
+----
+         0  data (8)
+        13  index (21)
+        39  range-key (82)
+       126  properties (765)
+       896  meta-index (57)
+       958  footer (53)
+      1011  EOF


### PR DESCRIPTION
The `sstable.Layout` struct contains information pertaining to the
layout of an sstable. Add the range key block to the layout.

Related to #1339.