### PR TITLE
*: Add trySeekUsingNext optimization to SeekGE

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -249,11 +249,19 @@ func runInternalIterCmd(d *datadriven.TestData, iter internalIterator, opts ...i
 		var value []byte
 		switch parts[0] {
 		case "seek-ge":
-			if len(parts) != 2 {
-				return "seek-ge <key>\n"
+			if len(parts) < 2 || len(parts) > 3 {
+				return "seek-ge <key> [<try-seek-using-next>]\n"
 			}
 			prefix = nil
-			key, value = iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
+			trySeekUsingNext := false
+			if len(parts) == 3 {
+				var err error
+				trySeekUsingNext, err = strconv.ParseBool(parts[2])
+				if err != nil {
+					return err.Error()
+				}
+			}
+			key, value = iter.SeekGE([]byte(strings.TrimSpace(parts[1])), trySeekUsingNext)
 		case "seek-prefix-ge":
 			if len(parts) != 2 && len(parts) != 3 {
 				return "seek-prefix-ge <key> [<try-seek-using-next>]\n"

--- a/error_iter.go
+++ b/error_iter.go
@@ -23,7 +23,7 @@ func newErrorIter(err error) *errorIter {
 	return &errorIter{err: err}
 }
 
-func (c *errorIter) SeekGE(key []byte) (*InternalKey, []byte) {
+func (c *errorIter) SeekGE(key []byte, trySeekUsingNext bool) (*InternalKey, []byte) {
 	return nil, nil
 }
 

--- a/get_iter.go
+++ b/get_iter.go
@@ -44,7 +44,7 @@ func (g *getIter) String() string {
 	return fmt.Sprintf("len(l0)=%d, len(mem)=%d, level=%d", len(g.l0), len(g.mem), g.level)
 }
 
-func (g *getIter) SeekGE(key []byte) (*InternalKey, []byte) {
+func (g *getIter) SeekGE(key []byte, trySeekUsingNext bool) (*InternalKey, []byte) {
 	panic("pebble: SeekGE unimplemented")
 }
 
@@ -119,7 +119,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 			g.iter = g.batch.newInternalIter(nil)
 			g.rangeDelIter = g.batch.newRangeDelIter(nil)
 			g.batch = nil
-			g.iterKey, g.iterValue = g.iter.SeekGE(g.key)
+			g.iterKey, g.iterValue = g.iter.SeekGE(g.key, false /* trySeekUsingNext */)
 			continue
 		}
 
@@ -135,7 +135,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 			g.iter = m.newIter(nil)
 			g.rangeDelIter = m.newRangeDelIter(nil)
 			g.mem = g.mem[:n-1]
-			g.iterKey, g.iterValue = g.iter.SeekGE(g.key)
+			g.iterKey, g.iterValue = g.iter.SeekGE(g.key, false /* trySeekUsingNext */)
 			continue
 		}
 
@@ -149,7 +149,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 					files, manifest.L0Sublevel(n), nil)
 				g.levelIter.initRangeDel(&g.rangeDelIter)
 				g.iter = &g.levelIter
-				g.iterKey, g.iterValue = g.iter.SeekGE(g.key)
+				g.iterKey, g.iterValue = g.iter.SeekGE(g.key, false /* trySeekUsingNext */)
 				continue
 			}
 			g.level++
@@ -169,7 +169,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 		g.levelIter.initRangeDel(&g.rangeDelIter)
 		g.level++
 		g.iter = &g.levelIter
-		g.iterKey, g.iterValue = g.iter.SeekGE(g.key)
+		g.iterKey, g.iterValue = g.iter.SeekGE(g.key, false /* trySeekUsingNext */)
 	}
 }
 

--- a/ingest.go
+++ b/ingest.go
@@ -333,7 +333,7 @@ func overlapWithIterator(
 	//    means boundary < L and hence is similar to 1).
 	// 4) boundary == L and L is sentinel,
 	//    we'll always overlap since for any values of i,j ranges [i, k) and [j, k) always overlap.
-	key, _ := iter.SeekGE(meta.Smallest.UserKey)
+	key, _ := iter.SeekGE(meta.Smallest.UserKey, false /* trySeekUsingNext */)
 	if key != nil {
 		c := sstableKeyCompare(cmp, *key, meta.Largest)
 		if c <= 0 {

--- a/internal/arenaskl/flush_iterator.go
+++ b/internal/arenaskl/flush_iterator.go
@@ -34,7 +34,7 @@ func (it *flushIterator) String() string {
 	return "memtable"
 }
 
-func (it *flushIterator) SeekGE(key []byte) (*base.InternalKey, []byte) {
+func (it *flushIterator) SeekGE(key []byte, tryNextUsingSeek bool) (*base.InternalKey, []byte) {
 	panic("pebble: SeekGE unimplemented")
 }
 

--- a/internal/arenaskl/iterator.go
+++ b/internal/arenaskl/iterator.go
@@ -78,26 +78,7 @@ func (it *Iterator) Error() error {
 // pointing at a valid entry, and (nil, nil) otherwise. Note that SeekGE only
 // checks the upper bound. It is up to the caller to ensure that key is greater
 // than or equal to the lower bound.
-func (it *Iterator) SeekGE(key []byte) (*base.InternalKey, []byte) {
-	_, it.nd, _ = it.seekForBaseSplice(key)
-	if it.nd == it.list.tail {
-		return nil, nil
-	}
-	it.decodeKey()
-	if it.upper != nil && it.list.cmp(it.upper, it.key.UserKey) <= 0 {
-		it.nd = it.list.tail
-		return nil, nil
-	}
-	return &it.key, it.value()
-}
-
-// SeekPrefixGE moves the iterator to the first entry whose key is greater than
-// or equal to the given key. This method is equivalent to SeekGE and is
-// provided so that an arenaskl.Iterator implements the
-// internal/base.InternalIterator interface.
-func (it *Iterator) SeekPrefixGE(
-	prefix, key []byte, trySeekUsingNext bool,
-) (*base.InternalKey, []byte) {
+func (it *Iterator) SeekGE(key []byte, trySeekUsingNext bool) (*base.InternalKey, []byte) {
 	if trySeekUsingNext {
 		if it.nd == it.list.tail {
 			// Iterator is done.
@@ -121,7 +102,26 @@ func (it *Iterator) SeekPrefixGE(
 			return &it.key, it.value()
 		}
 	}
-	return it.SeekGE(key)
+	_, it.nd, _ = it.seekForBaseSplice(key)
+	if it.nd == it.list.tail {
+		return nil, nil
+	}
+	it.decodeKey()
+	if it.upper != nil && it.list.cmp(it.upper, it.key.UserKey) <= 0 {
+		it.nd = it.list.tail
+		return nil, nil
+	}
+	return &it.key, it.value()
+}
+
+// SeekPrefixGE moves the iterator to the first entry whose key is greater than
+// or equal to the given key. This method is equivalent to SeekGE and is
+// provided so that an arenaskl.Iterator implements the
+// internal/base.InternalIterator interface.
+func (it *Iterator) SeekPrefixGE(
+	prefix, key []byte, trySeekUsingNext bool,
+) (*base.InternalKey, []byte) {
+	return it.SeekGE(key, trySeekUsingNext)
 }
 
 // SeekLT moves the iterator to the last entry whose key is less than the given

--- a/internal/arenaskl/skl_test.go
+++ b/internal/arenaskl/skl_test.go
@@ -59,8 +59,8 @@ func (i *iterAdapter) String() string {
 	return "iter-adapter"
 }
 
-func (i *iterAdapter) SeekGE(key []byte) bool {
-	return i.update(i.Iterator.SeekGE(key))
+func (i *iterAdapter) SeekGE(key []byte, trySeekUsingNext bool) bool {
+	return i.update(i.Iterator.SeekGE(key, trySeekUsingNext))
 }
 
 func (i *iterAdapter) SeekPrefixGE(prefix, key []byte, trySeekUsingNext bool) bool {
@@ -159,7 +159,7 @@ func TestEmpty(t *testing.T) {
 	it.Last()
 	require.False(t, it.Valid())
 
-	require.False(t, it.SeekGE(key))
+	require.False(t, it.SeekGE(key, false /* trySeekUsingNext */))
 	require.False(t, it.Valid())
 }
 
@@ -198,19 +198,19 @@ func TestBasic(t *testing.T) {
 			add(makeIkey("key3"), makeValue(3))
 			add(makeIkey("key2"), makeValue(2))
 
-			require.True(t, it.SeekGE(makeKey("key")))
+			require.True(t, it.SeekGE(makeKey("key"), false /* trySeekUsingNext */))
 			require.True(t, it.Valid())
 			require.NotEqual(t, "key", it.Key().UserKey)
 
-			require.True(t, it.SeekGE(makeKey("key1")))
+			require.True(t, it.SeekGE(makeKey("key1"), false /* trySeekUsingNext */))
 			require.EqualValues(t, "key1", it.Key().UserKey)
 			require.EqualValues(t, makeValue(1), it.Value())
 
-			require.True(t, it.SeekGE(makeKey("key2")))
+			require.True(t, it.SeekGE(makeKey("key2"), false /* trySeekUsingNext */))
 			require.EqualValues(t, "key2", it.Key().UserKey)
 			require.EqualValues(t, makeValue(2), it.Value())
 
-			require.True(t, it.SeekGE(makeKey("key3")))
+			require.True(t, it.SeekGE(makeKey("key3"), false /* trySeekUsingNext */))
 			require.EqualValues(t, "key3", it.Key().UserKey)
 			require.EqualValues(t, makeValue(3), it.Value())
 
@@ -220,7 +220,7 @@ func TestBasic(t *testing.T) {
 			key.SetSeqNum(2)
 			add(key, nil)
 
-			require.True(t, it.SeekGE(makeKey("a")))
+			require.True(t, it.SeekGE(makeKey("a"), false /* trySeekUsingNext */))
 			require.True(t, it.Valid())
 			require.EqualValues(t, "a", it.Key().UserKey)
 			require.EqualValues(t, 2, it.Key().SeqNum())
@@ -236,7 +236,7 @@ func TestBasic(t *testing.T) {
 			key.SetSeqNum(1)
 			add(key, nil)
 
-			require.True(t, it.SeekGE(makeKey("b")))
+			require.True(t, it.SeekGE(makeKey("b"), false /* trySeekUsingNext */))
 			require.True(t, it.Valid())
 			require.EqualValues(t, "b", it.Key().UserKey)
 			require.EqualValues(t, 2, it.Key().SeqNum())
@@ -282,7 +282,7 @@ func TestConcurrentBasic(t *testing.T) {
 					defer wg.Done()
 
 					it := newIterAdapter(l.NewIter(nil, nil))
-					require.True(t, it.SeekGE(makeKey(fmt.Sprintf("%05d", i))))
+					require.True(t, it.SeekGE(makeKey(fmt.Sprintf("%05d", i)), false /* trySeekUsingNext */))
 					require.EqualValues(t, fmt.Sprintf("%05d", i), it.Key().UserKey)
 				}(i)
 			}
@@ -335,7 +335,7 @@ func TestConcurrentOneKey(t *testing.T) {
 					defer wg.Done()
 
 					it := newIterAdapter(l.NewIter(nil, nil))
-					it.SeekGE(key)
+					it.SeekGE(key, false /* trySeekUsingNext */)
 					require.True(t, it.Valid())
 					require.True(t, bytes.Equal(key, it.Key().UserKey))
 
@@ -367,7 +367,7 @@ func TestSkiplistAdd(t *testing.T) {
 			// Add nil key and value (treated same as empty).
 			err := add(base.InternalKey{}, nil)
 			require.Nil(t, err)
-			require.True(t, it.SeekGE([]byte{}))
+			require.True(t, it.SeekGE([]byte{}, false /* trySeekUsingNext */))
 			require.EqualValues(t, []byte{}, it.Key().UserKey)
 			require.EqualValues(t, []byte{}, it.Value())
 
@@ -382,35 +382,35 @@ func TestSkiplistAdd(t *testing.T) {
 			// Add empty key and value (treated same as nil).
 			err = add(makeIkey(""), []byte{})
 			require.Nil(t, err)
-			require.True(t, it.SeekGE([]byte{}))
+			require.True(t, it.SeekGE([]byte{}, false /* trySeekUsingNext */))
 			require.EqualValues(t, []byte{}, it.Key().UserKey)
 			require.EqualValues(t, []byte{}, it.Value())
 
 			// Add to empty list.
 			err = add(makeIntKey(2), makeValue(2))
 			require.Nil(t, err)
-			require.True(t, it.SeekGE(makeKey("00002")))
+			require.True(t, it.SeekGE(makeKey("00002"), false /* trySeekUsingNext */))
 			require.EqualValues(t, "00002", it.Key().UserKey)
 			require.EqualValues(t, makeValue(2), it.Value())
 
 			// Add first element in non-empty list.
 			err = add(makeIntKey(1), makeValue(1))
 			require.Nil(t, err)
-			require.True(t, it.SeekGE(makeKey("00001")))
+			require.True(t, it.SeekGE(makeKey("00001"), false /* trySeekUsingNext */))
 			require.EqualValues(t, "00001", it.Key().UserKey)
 			require.EqualValues(t, makeValue(1), it.Value())
 
 			// Add last element in non-empty list.
 			err = add(makeIntKey(4), makeValue(4))
 			require.Nil(t, err)
-			require.True(t, it.SeekGE(makeKey("00004")))
+			require.True(t, it.SeekGE(makeKey("00004"), false /* trySeekUsingNext */))
 			require.EqualValues(t, "00004", it.Key().UserKey)
 			require.EqualValues(t, makeValue(4), it.Value())
 
 			// Add element in middle of list.
 			err = add(makeIntKey(3), makeValue(3))
 			require.Nil(t, err)
-			require.True(t, it.SeekGE(makeKey("00003")))
+			require.True(t, it.SeekGE(makeKey("00003"), false /* trySeekUsingNext */))
 			require.EqualValues(t, "00003", it.Key().UserKey)
 			require.EqualValues(t, makeValue(3), it.Value())
 
@@ -457,7 +457,7 @@ func TestConcurrentAdd(t *testing.T) {
 
 						key := makeIntKey(i)
 						if add(key, nil) == nil {
-							require.True(t, it.SeekGE(key.UserKey))
+							require.True(t, it.SeekGE(key.UserKey, false /* trySeekUsingNext */))
 							require.EqualValues(t, key, it.Key())
 						}
 
@@ -544,28 +544,66 @@ func TestIteratorSeekGEAndSeekPrefixGE(t *testing.T) {
 		ins.Add(l, makeIntKey(v), makeValue(v))
 	}
 
-	require.True(t, it.SeekGE(makeKey("")))
+	require.True(t, it.SeekGE(makeKey(""), false /* trySeekUsingNext */))
 	require.True(t, it.Valid())
 	require.EqualValues(t, "01000", it.Key().UserKey)
 	require.EqualValues(t, "v01000", it.Value())
 
-	require.True(t, it.SeekGE(makeKey("01000")))
+	require.True(t, it.SeekGE(makeKey("01000"), false /* trySeekUsingNext */))
 	require.True(t, it.Valid())
 	require.EqualValues(t, "01000", it.Key().UserKey)
 	require.EqualValues(t, "v01000", it.Value())
 
-	require.True(t, it.SeekGE(makeKey("01005")))
+	require.True(t, it.SeekGE(makeKey("01005"), false /* trySeekUsingNext */))
 	require.True(t, it.Valid())
 	require.EqualValues(t, "01010", it.Key().UserKey)
 	require.EqualValues(t, "v01010", it.Value())
 
-	require.True(t, it.SeekGE(makeKey("01010")))
+	require.True(t, it.SeekGE(makeKey("01010"), false /* trySeekUsingNext */))
 	require.True(t, it.Valid())
 	require.EqualValues(t, "01010", it.Key().UserKey)
 	require.EqualValues(t, "v01010", it.Value())
 
-	require.False(t, it.SeekGE(makeKey("99999")))
+	require.False(t, it.SeekGE(makeKey("99999"), false /* trySeekUsingNext */))
 	require.False(t, it.Valid())
+
+	// Test SeekGE with trySeekUsingNext optimization.
+	{
+		require.True(t, it.SeekGE(makeKey("01000"), false /* trySeekUsingNext */))
+		require.True(t, it.Valid())
+		require.EqualValues(t, "01000", it.Key().UserKey)
+		require.EqualValues(t, "v01000", it.Value())
+
+		// Seeking to the same key.
+		require.True(t, it.SeekGE(makeKey("01000"), true /* trySeekUsingNext */))
+		require.True(t, it.Valid())
+		require.EqualValues(t, "01000", it.Key().UserKey)
+		require.EqualValues(t, "v01000", it.Value())
+
+		// Seeking to a nearby key that can be reached using Next.
+		require.True(t, it.SeekGE(makeKey("01020"), true /* trySeekUsingNext */))
+		require.True(t, it.Valid())
+		require.EqualValues(t, "01020", it.Key().UserKey)
+		require.EqualValues(t, "v01020", it.Value())
+
+		// Seeking to a key that cannot be reached using Next.
+		require.True(t, it.SeekGE(makeKey("01200"), true /* trySeekUsingNext */))
+		require.True(t, it.Valid())
+		require.EqualValues(t, "01200", it.Key().UserKey)
+		require.EqualValues(t, "v01200", it.Value())
+
+		// Seeking to an earlier key, but the caller lies. Incorrect result.
+		require.True(t, it.SeekGE(makeKey("01100"), true /* trySeekUsingNext */))
+		require.True(t, it.Valid())
+		require.EqualValues(t, "01200", it.Key().UserKey)
+		require.EqualValues(t, "v01200", it.Value())
+
+		// Telling the truth works.
+		require.True(t, it.SeekGE(makeKey("01100"), false /* trySeekUsingNext */))
+		require.True(t, it.Valid())
+		require.EqualValues(t, "01100", it.Key().UserKey)
+		require.EqualValues(t, "v01100", it.Value())
+	}
 
 	// Test SeekPrefixGE with trySeekUsingNext optimization.
 	{
@@ -607,11 +645,11 @@ func TestIteratorSeekGEAndSeekPrefixGE(t *testing.T) {
 
 	// Test seek for empty key.
 	ins.Add(l, base.InternalKey{}, nil)
-	require.True(t, it.SeekGE([]byte{}))
+	require.True(t, it.SeekGE([]byte{}, false /* trySeekUsingNext */))
 	require.True(t, it.Valid())
 	require.EqualValues(t, "", it.Key().UserKey)
 
-	require.True(t, it.SeekGE(makeKey("")))
+	require.True(t, it.SeekGE(makeKey(""), false /* trySeekUsingNext */))
 	require.True(t, it.Valid())
 	require.EqualValues(t, "", it.Key().UserKey)
 }
@@ -683,7 +721,7 @@ func TestIteratorBounds(t *testing.T) {
 	// SeekGE within the lower and upper bound succeeds.
 	for i := 3; i <= 6; i++ {
 		k := key(i)
-		require.True(t, it.SeekGE(k))
+		require.True(t, it.SeekGE(k, false /* trySeekUsingNext */))
 		require.EqualValues(t, string(k), string(it.Key().UserKey))
 	}
 
@@ -691,16 +729,16 @@ func TestIteratorBounds(t *testing.T) {
 	// checked).
 	for i := 1; i < 3; i++ {
 		k := key(i)
-		require.True(t, it.SeekGE(k))
+		require.True(t, it.SeekGE(k, false /* trySeekUsingNext */))
 		require.EqualValues(t, string(k), string(it.Key().UserKey))
 	}
 
 	// SeekGE beyond the upper bound fails.
 	for i := 7; i < 10; i++ {
-		require.False(t, it.SeekGE(key(i)))
+		require.False(t, it.SeekGE(key(i), false /* trySeekUsingNext */))
 	}
 
-	require.True(t, it.SeekGE(key(6)))
+	require.True(t, it.SeekGE(key(6), false /* trySeekUsingNext */))
 	require.EqualValues(t, "00006", it.Key().UserKey)
 	require.EqualValues(t, "v00006", it.Value())
 
@@ -786,7 +824,7 @@ func BenchmarkReadWrite(b *testing.B) {
 
 				for pb.Next() {
 					if rng.Float32() < readFrac {
-						key, _ := it.SeekGE(randomKey(rng, buf).UserKey)
+						key, _ := it.SeekGE(randomKey(rng, buf).UserKey, false /* trySeekUsingNext */)
 						if key != nil {
 							_ = key
 							count++

--- a/internal/keyspan/iter.go
+++ b/internal/keyspan/iter.go
@@ -67,7 +67,7 @@ func NewIter(cmp base.Compare, spans []Span) *Iter {
 
 // SeekGE implements InternalIterator.SeekGE, as documented in the
 // internal/base package.
-func (i *Iter) SeekGE(key []byte) (*base.InternalKey, []byte) {
+func (i *Iter) SeekGE(key []byte, trySeekUsingNext bool) (*base.InternalKey, []byte) {
 	// NB: manually inlined sort.Seach is ~5% faster.
 	//
 	// Define f(-1) == false and f(n) == true.

--- a/internal/keyspan/iter_test.go
+++ b/internal/keyspan/iter_test.go
@@ -45,7 +45,7 @@ func TestIter(t *testing.T) {
 					if len(parts) != 2 {
 						return "seek-ge <key>\n"
 					}
-					start, _ = iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
+					start, _ = iter.SeekGE([]byte(strings.TrimSpace(parts[1])), false /* trySeekUsingNext */)
 				case "seek-lt":
 					if len(parts) != 2 {
 						return "seek-lt <key>\n"

--- a/internal/rangekey/interleaving_iter.go
+++ b/internal/rangekey/interleaving_iter.go
@@ -186,8 +186,8 @@ func (i *InterleavingIter) cmp(a, b []byte) int {
 //
 // NB: In accordance with the base.InternalIterator contract:
 //   i.lower ≤ key
-func (i *InterleavingIter) SeekGE(key []byte) (*base.InternalKey, []byte) {
-	i.pointKey, i.pointVal = i.pointIter.SeekGE(key)
+func (i *InterleavingIter) SeekGE(key []byte, trySeekUsingNext bool) (*base.InternalKey, []byte) {
+	i.pointKey, i.pointVal = i.pointIter.SeekGE(key, trySeekUsingNext)
 	i.pointKeyInterleaved = false
 	i.nextRangeKey(i.rangeKeyIter.SeekGE(key))
 	i.dir = +1

--- a/internal/rangekey/interleaving_iter_test.go
+++ b/internal/rangekey/interleaving_iter_test.go
@@ -105,7 +105,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 				case "prev":
 					formatKey(iter.Prev())
 				case "seek-ge":
-					formatKey(iter.SeekGE([]byte(strings.TrimSpace(line[i:]))))
+					formatKey(iter.SeekGE([]byte(strings.TrimSpace(line[i:])), false /* trySeekUsingNext */))
 				case "seek-lt":
 					formatKey(iter.SeekLT([]byte(strings.TrimSpace(line[i:]))))
 				case "set-bounds":
@@ -146,7 +146,7 @@ type pointIterator struct {
 
 var _ base.InternalIterator = &pointIterator{}
 
-func (i *pointIterator) SeekGE(key []byte) (*base.InternalKey, []byte) {
+func (i *pointIterator) SeekGE(key []byte, trySeekUsingNext bool) (*base.InternalKey, []byte) {
 	i.index = sort.Search(len(i.keys), func(j int) bool {
 		return i.cmp(i.keys[j].UserKey, key) >= 0
 	})
@@ -160,7 +160,7 @@ func (i *pointIterator) SeekGE(key []byte) (*base.InternalKey, []byte) {
 }
 
 func (i *pointIterator) SeekPrefixGE(prefix, key []byte, trySeekUsingNext bool) (*base.InternalKey, []byte) {
-	return i.SeekGE(key)
+	return i.SeekGE(key, trySeekUsingNext)
 }
 
 func (i *pointIterator) SeekLT(key []byte) (*base.InternalKey, []byte) {

--- a/internal_test.go
+++ b/internal_test.go
@@ -30,8 +30,8 @@ func (i *internalIterAdapter) String() string {
 	return "internal-iter-adapter"
 }
 
-func (i *internalIterAdapter) SeekGE(key []byte) bool {
-	return i.update(i.internalIterator.SeekGE(key))
+func (i *internalIterAdapter) SeekGE(key []byte, trySeekUsingNext bool) bool {
+	return i.update(i.internalIterator.SeekGE(key, trySeekUsingNext))
 }
 
 func (i *internalIterAdapter) SeekPrefixGE(prefix, key []byte, trySeekUsingNext bool) bool {

--- a/level_iter.go
+++ b/level_iter.go
@@ -380,7 +380,7 @@ func (l *levelIter) verify(key *InternalKey, val []byte) (*InternalKey, []byte) 
 	return key, val
 }
 
-func (l *levelIter) SeekGE(key []byte) (*InternalKey, []byte) {
+func (l *levelIter) SeekGE(key []byte, trySeekUsingNext bool) (*InternalKey, []byte) {
 	l.err = nil // clear cached iteration error
 	if l.isSyntheticIterBoundsKey != nil {
 		*l.isSyntheticIterBoundsKey = false
@@ -388,10 +388,16 @@ func (l *levelIter) SeekGE(key []byte) (*InternalKey, []byte) {
 
 	// NB: the top-level Iterator has already adjusted key based on
 	// IterOptions.LowerBound.
-	if l.loadFile(l.findFileGE(key), +1) == noFileLoaded {
+	loadFileIndicator := l.loadFile(l.findFileGE(key), +1)
+	if loadFileIndicator == noFileLoaded {
 		return nil, nil
 	}
-	if ikey, val := l.iter.SeekGE(key); ikey != nil {
+	if loadFileIndicator == newFileLoaded {
+		// File changed, so l.iter has changed, and that iterator is not
+		// positioned appropriately.
+		trySeekUsingNext = false
+	}
+	if ikey, val := l.iter.SeekGE(key, trySeekUsingNext); ikey != nil {
 		return l.verify(ikey, val)
 	}
 	return l.verify(l.skipEmptyFileForward())

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -125,7 +125,7 @@ func TestLevelIter(t *testing.T) {
 			iter := newLevelIter(opts, DefaultComparer.Compare,
 				func(a []byte) int { return len(a) }, newIters2, files.Iter(),
 				manifest.Level(level), nil)
-			iter.SeekGE([]byte(key))
+			iter.SeekGE([]byte(key), false /* trySeekUsingNext */)
 			lower, upper := tableOpts.GetLowerBound(), tableOpts.GetUpperBound()
 			return fmt.Sprintf("[%s,%s]\n", lower, upper)
 
@@ -348,8 +348,8 @@ func (i *levelIterTestIter) String() string {
 	return "level-iter-test"
 }
 
-func (i *levelIterTestIter) SeekGE(key []byte) (*InternalKey, []byte) {
-	ikey, val := i.levelIter.SeekGE(key)
+func (i *levelIterTestIter) SeekGE(key []byte, trySeekUsingNext bool) (*InternalKey, []byte) {
+	ikey, val := i.levelIter.SeekGE(key, trySeekUsingNext)
 	return i.rangeDelSeek(key, ikey, val, 1)
 }
 
@@ -488,7 +488,7 @@ func BenchmarkLevelIterSeekGE(b *testing.B) {
 
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {
-								l.SeekGE(keys[rng.Intn(len(keys))])
+								l.SeekGE(keys[rng.Intn(len(keys))], false /* trySeekUsingNext */)
 							}
 							l.Close()
 						})
@@ -535,7 +535,7 @@ func BenchmarkLevelIterSeqSeekGEWithBounds(b *testing.B) {
 								pos := i % (keyCount - 1)
 								l.SetBounds(keys[pos], keys[pos+1])
 								// SeekGE will return keys[pos].
-								k, _ := l.SeekGE(keys[pos])
+								k, _ := l.SeekGE(keys[pos], false /* trySeekUsingNext */)
 								// Next() will get called once and return nil.
 								for k != nil {
 									k, _ = l.Next()

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -350,7 +350,7 @@ func (m *mergingIter) initMaxRangeDelIters(oldTopLevel int) {
 func (m *mergingIter) switchToMinHeap() {
 	if m.heap.len() == 0 {
 		if m.lower != nil {
-			m.SeekGE(m.lower)
+			m.SeekGE(m.lower, false /* trySeekUsingNext */)
 		} else {
 			m.First()
 		}
@@ -403,7 +403,7 @@ func (m *mergingIter) switchToMinHeap() {
 			l.iterKey.Trailer == InternalKeyRangeDeleteSentinel &&
 			m.heap.cmp(l.iterKey.UserKey, m.lower) <= 0) {
 			if m.lower != nil {
-				l.iterKey, l.iterValue = l.iter.SeekGE(m.lower)
+				l.iterKey, l.iterValue = l.iter.SeekGE(m.lower, false /* trySeekUsingNext */)
 			} else {
 				l.iterKey, l.iterValue = l.iter.First()
 			}
@@ -829,7 +829,7 @@ func (m *mergingIter) seekGE(key []byte, level int, trySeekUsingNext bool) {
 		if m.prefix != nil {
 			l.iterKey, l.iterValue = l.iter.SeekPrefixGE(m.prefix, key, trySeekUsingNext)
 		} else {
-			l.iterKey, l.iterValue = l.iter.SeekGE(key)
+			l.iterKey, l.iterValue = l.iter.SeekGE(key, trySeekUsingNext)
 		}
 
 		if rangeDelIter := l.rangeDelIter; rangeDelIter != nil {
@@ -881,10 +881,10 @@ func (m *mergingIter) String() string {
 // SeekGE implements base.InternalIterator.SeekGE. Note that SeekGE only checks
 // the upper bound. It is up to the caller to ensure that key is greater than
 // or equal to the lower bound.
-func (m *mergingIter) SeekGE(key []byte) (*InternalKey, []byte) {
+func (m *mergingIter) SeekGE(key []byte, trySeekUsingNext bool) (*InternalKey, []byte) {
 	m.err = nil // clear cached iteration error
 	m.prefix = nil
-	m.seekGE(key, 0 /* start level */, false /* trySeekUsingNext */)
+	m.seekGE(key, 0 /* start level */, trySeekUsingNext)
 	return m.findNextEntry()
 }
 

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -357,7 +357,7 @@ func BenchmarkMergingIterSeekGE(b *testing.B) {
 
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {
-								m.SeekGE(keys[rng.Intn(len(keys))])
+								m.SeekGE(keys[rng.Intn(len(keys))], false /* trySeekUsingNext */)
 							}
 							m.Close()
 						})
@@ -621,7 +621,7 @@ func BenchmarkMergingIterSeqSeekGEWithBounds(b *testing.B) {
 					pos := i % (keyCount - 1)
 					m.SetBounds(keys[pos], keys[pos+1])
 					// SeekGE will return keys[pos].
-					k, _ := m.SeekGE(keys[pos])
+					k, _ := m.SeekGE(keys[pos], false /* trySeekUsingNext */)
 					for k != nil {
 						k, _ = m.Next()
 					}

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -518,7 +518,7 @@ func (i *blockIter) cacheEntry() {
 
 // SeekGE implements internalIterator.SeekGE, as documented in the pebble
 // package.
-func (i *blockIter) SeekGE(key []byte) (*InternalKey, []byte) {
+func (i *blockIter) SeekGE(key []byte, trySeekUsingNext bool) (*InternalKey, []byte) {
 	i.clearCache()
 
 	ikey := base.MakeSearchKey(key)

--- a/sstable/block_test.go
+++ b/sstable/block_test.go
@@ -183,7 +183,7 @@ func TestBlockIter2(t *testing.T) {
 							if len(parts) != 2 {
 								return "seek-ge <key>\n"
 							}
-							iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
+							iter.SeekGE([]byte(strings.TrimSpace(parts[1])), false /* trySeekUsingNext */)
 						case "seek-lt":
 							if len(parts) != 2 {
 								return "seek-lt <key>\n"
@@ -249,7 +249,7 @@ func TestBlockIterKeyStability(t *testing.T) {
 	// restart-interval of 1 so that prefix compression was not performed.
 	for j := range expected {
 		keys := [][]byte{}
-		for key, _ := i.SeekGE(expected[j]); key != nil; key, _ = i.Next() {
+		for key, _ := i.SeekGE(expected[j], false /* trySeekUsingNext */); key != nil; key, _ = i.Next() {
 			check(key.UserKey)
 			keys = append(keys, key.UserKey)
 		}
@@ -338,7 +338,7 @@ func BenchmarkBlockIterSeekGE(b *testing.B) {
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					k := keys[rng.Intn(len(keys))]
-					it.SeekGE(k)
+					it.SeekGE(k, false /* trySeekUsingNext */)
 					if testing.Verbose() {
 						if !it.Valid() {
 							b.Fatal("expected to find key")

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -259,11 +259,19 @@ func runIterCmd(td *datadriven.TestData, r *Reader) string {
 		}
 		switch parts[0] {
 		case "seek-ge":
-			if len(parts) != 2 {
-				return "seek-ge <key>\n"
+			if len(parts) < 2 || len(parts) > 3 {
+				return "seek-ge <key> [<try-seek-using-next]\n"
 			}
 			prefix = nil
-			iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
+			trySeekUsingNext := false
+			if len(parts) == 3 {
+				var err error
+				trySeekUsingNext, err = strconv.ParseBool(parts[2])
+				if err != nil {
+					return err.Error()
+				}
+			}
+			iter.SeekGE([]byte(strings.TrimSpace(parts[1])), trySeekUsingNext)
 		case "seek-prefix-ge":
 			if len(parts) != 2 && len(parts) != 3 {
 				return "seek-prefix-ge <key> [<try-seek-using-next>]\n"

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -59,7 +59,7 @@ func (r *Reader) get(key []byte) (value []byte, err error) {
 	if err != nil {
 		return nil, err
 	}
-	ikey, value := i.SeekGE(key)
+	ikey, value := i.SeekGE(key, false /* trySeekUsingNext */)
 
 	if ikey == nil || r.Compare(key, ikey.UserKey) != 0 {
 		err := i.Close()
@@ -104,8 +104,8 @@ func (i *iterAdapter) String() string {
 	return "iter-adapter"
 }
 
-func (i *iterAdapter) SeekGE(key []byte) bool {
-	return i.update(i.Iterator.SeekGE(key))
+func (i *iterAdapter) SeekGE(key []byte, trySeekUsingNext bool) bool {
+	return i.update(i.Iterator.SeekGE(key, trySeekUsingNext))
 }
 
 func (i *iterAdapter) SeekPrefixGE(prefix, key []byte, trySeekUsingNext bool) bool {
@@ -975,7 +975,7 @@ func BenchmarkTableIterSeekGE(b *testing.B) {
 
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					it.SeekGE(keys[rng.Intn(len(keys))])
+					it.SeekGE(keys[rng.Intn(len(keys))], false /* trySeekUsingNext */)
 				}
 
 				b.StopTimer()

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -147,7 +147,7 @@ func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
 			return err
 		}
 		i := newIterAdapter(iter)
-		if !i.SeekGE([]byte(k)) || string(i.Key().UserKey) != k {
+		if !i.SeekGE([]byte(k), false /* trySeekUsingNext */) || string(i.Key().UserKey) != k {
 			return errors.Errorf("Find %q: key was not in the table", k)
 		}
 		if k1 := i.Key().UserKey; len(k1) != cap(k1) {
@@ -197,7 +197,7 @@ func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
 			return err
 		}
 		i := newIterAdapter(iter)
-		if i.SeekGE([]byte(s)) && s == string(i.Key().UserKey) {
+		if i.SeekGE([]byte(s), false /* trySeekUsingNext */) && s == string(i.Key().UserKey) {
 			return errors.Errorf("Find %q: unexpectedly found key in the table", s)
 		}
 		if err := i.Close(); err != nil {
@@ -227,7 +227,7 @@ func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
 			return err
 		}
 		n, i := 0, newIterAdapter(iter)
-		for valid := i.SeekGE([]byte(ct.start)); valid; valid = i.Next() {
+		for valid := i.SeekGE([]byte(ct.start), false /* trySeekUsingNext */); valid; valid = i.Next() {
 			n++
 		}
 		if n != ct.count {
@@ -303,7 +303,7 @@ func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
 
 		if lower != nil {
 			n := 0
-			for valid := i.SeekGE(lower); valid; valid = i.Next() {
+			for valid := i.SeekGE(lower, false /* trySeekUsingNext */); valid; valid = i.Next() {
 				n++
 			}
 			if expected := upperIdx - lowerIdx; expected != n {

--- a/sstable/testdata/reader/iter
+++ b/sstable/testdata/reader/iter
@@ -240,6 +240,24 @@ next
 .
 <a:1>
 
+
+# Verify the optimization to use next when doing SeekGE.
+
+iter
+seek-ge a false
+seek-ge a true
+seek-ge b true
+seek-ge c true
+seek-ge d true
+seek-ge e true
+----
+<a:1>
+<a:1>
+<b:2>
+<c:3>
+<d:4>
+.
+
 # Verify the optimization to use next when doing SeekPrefixGE.
 
 iter

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -446,7 +446,7 @@ func testTableCacheRandomAccess(t *testing.T, concurrent bool) {
 				errc <- errors.Errorf("i=%d, fileNum=%d: find: %v", i, fileNum, err)
 				return
 			}
-			key, value := iter.SeekGE([]byte("k"))
+			key, value := iter.SeekGE([]byte("k"), false /* trySeekUsingNext */)
 			if concurrent {
 				time.Sleep(time.Duration(sleepTime) * time.Microsecond)
 			}

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -182,7 +182,7 @@ compact         1   2.3 K     0 B       0          (size == estimated-debt, scor
  memtbl         1   256 K
 zmemtbl         0     0 B
    ztbl         0     0 B
- bcache         8   1.4 K    5.9%  (score == hit-rate)
+ bcache         8   1.4 K    0.0%  (score == hit-rate)
  tcache         1   672 B    0.0%  (score == hit-rate)
  titers         0
  filter         -       -    0.0%  (score == utility)

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -47,7 +47,7 @@ compact         0     0 B     0 B       0          (size == estimated-debt, scor
  memtbl         1   256 K
 zmemtbl         0     0 B
    ztbl         0     0 B
- bcache         8   1.5 K   46.7%  (score == hit-rate)
+ bcache         8   1.5 K   42.9%  (score == hit-rate)
  tcache         1   672 B   50.0%  (score == hit-rate)
  titers         0
  filter         -       -    0.0%  (score == utility)

--- a/testdata/iterator
+++ b/testdata/iterator
@@ -198,6 +198,16 @@ b:c
 .
 stats: (interface (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 3, 0), (rev, 0, 0))
 
+iter seq=3
+seek-ge a
+seek-ge b
+seek-ge c
+----
+a:b
+b:c
+.
+stats: (interface (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 3, 0), (rev, 0, 0))
+
 define
 a.SET.1:a
 b.SET.2:b

--- a/testdata/iterator_seek_opt
+++ b/testdata/iterator_seek_opt
@@ -1,0 +1,222 @@
+
+define auto-compactions=off
+L0
+  a.SET.4:4
+L1
+  a.SET.3:3
+L2
+  d.SET.2:2
+L3
+  b.SET.1:1
+  c.SET.1:1
+  d.SET.1:1
+  e.SET.1:1
+----
+0.0:
+  000004:[a#4,SET-a#4,SET]
+1:
+  000005:[a#3,SET-a#3,SET]
+2:
+  000006:[d#2,SET-d#2,SET]
+3:
+  000007:[b#1,SET-e#1,SET]
+
+# Simple case: three successive seeks, at increasing keys. Should use
+# trySeekUsingNext.
+
+iter
+seek-ge a
+----
+a:4
+stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0))
+SeekGEs with trySeekUsingNext: 0
+SeekPrefixGEs with trySeekUsingNext: 0
+
+iter
+seek-ge b
+----
+b:1
+stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 0))
+SeekGEs with trySeekUsingNext: 2
+SeekPrefixGEs with trySeekUsingNext: 0
+
+iter
+seek-ge c
+----
+c:1
+stats: (interface (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 3, 0), (rev, 0, 0))
+SeekGEs with trySeekUsingNext: 4
+SeekPrefixGEs with trySeekUsingNext: 0
+
+# Seek at a lower key. Should not call with trySeekUsingNext = true.
+
+iter
+seek-ge bb
+----
+c:1
+stats: (interface (dir, seek, step): (fwd, 4, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 4, 0), (rev, 0, 0))
+SeekGEs with trySeekUsingNext: 4
+SeekPrefixGEs with trySeekUsingNext: 0
+
+# Seek at a greater key than last seek, but lands on the same key. Should
+# not call internalIterator at all.
+
+iter
+seek-ge bbb
+----
+c:1
+stats: (interface (dir, seek, step): (fwd, 5, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 4, 0), (rev, 0, 0))
+SeekGEs with trySeekUsingNext: 4
+SeekPrefixGEs with trySeekUsingNext: 0
+
+# A step followed by a seek should not call with trySeekUsingNext = true.
+
+iter
+next
+seek-ge e
+----
+d:2
+e:1
+stats: (interface (dir, seek, step): (fwd, 6, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 5, 1), (rev, 0, 0))
+SeekGEs with trySeekUsingNext: 4
+SeekPrefixGEs with trySeekUsingNext: 0
+
+iter
+prev
+seek-ge b
+----
+d:2
+b:1
+stats: (interface (dir, seek, step): (fwd, 7, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 6, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 4
+SeekPrefixGEs with trySeekUsingNext: 0
+
+# SeekPrefixGE simple case.
+
+iter
+seek-prefix-ge a
+----
+a:4
+stats: (interface (dir, seek, step): (fwd, 8, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 7, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 4
+SeekPrefixGEs with trySeekUsingNext: 0
+
+iter
+seek-prefix-ge b
+----
+b:1
+stats: (interface (dir, seek, step): (fwd, 9, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 8, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 4
+SeekPrefixGEs with trySeekUsingNext: 2
+
+iter
+seek-prefix-ge c
+----
+c:1
+stats: (interface (dir, seek, step): (fwd, 10, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 9, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 4
+SeekPrefixGEs with trySeekUsingNext: 4
+
+# Seek at a lower key. Should not call with trySeekUsingNext = true.
+
+iter
+seek-prefix-ge bb
+----
+.
+stats: (interface (dir, seek, step): (fwd, 11, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 10, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 4
+SeekPrefixGEs with trySeekUsingNext: 4
+
+# Shifting bounds followed by SeekGEs. The one immediately after a bounds change
+# does not use trySeekUsingNext, but successive ones do (while still respecting
+# bounds).
+
+iter
+set-bounds lower=a upper=aa
+seek-ge a
+----
+.
+a:4
+stats: (interface (dir, seek, step): (fwd, 12, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 11, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 4
+SeekPrefixGEs with trySeekUsingNext: 4
+
+iter
+set-bounds lower=a upper=c
+seek-ge b
+----
+.
+b:1
+stats: (interface (dir, seek, step): (fwd, 13, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 12, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 4
+SeekPrefixGEs with trySeekUsingNext: 4
+
+iter
+seek-ge bb
+----
+.
+stats: (interface (dir, seek, step): (fwd, 14, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 13, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 5
+SeekPrefixGEs with trySeekUsingNext: 4
+
+iter
+set-bounds lower=a upper=d
+seek-ge bbb
+----
+.
+c:1
+stats: (interface (dir, seek, step): (fwd, 15, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 14, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 5
+SeekPrefixGEs with trySeekUsingNext: 4
+
+iter
+seek-ge cc
+----
+.
+stats: (interface (dir, seek, step): (fwd, 16, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 15, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 4
+
+# Shifting bounds, with non-overlapping and monotonic bounds. We don't call
+# trySeekUsingNext=true at all here as the set-bounds sits in between every two
+# seeks, but the results are still correct and within bounds.
+
+iter
+set-bounds lower=a upper=c
+seek-ge b
+----
+.
+b:1
+stats: (interface (dir, seek, step): (fwd, 17, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 16, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 4
+
+iter
+set-bounds lower=c upper=e
+seek-ge c
+----
+.
+c:1
+stats: (interface (dir, seek, step): (fwd, 18, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 17, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 4
+
+iter
+set-bounds lower=a upper=c
+seek-prefix-ge b
+----
+.
+b:1
+stats: (interface (dir, seek, step): (fwd, 19, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 18, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 4
+
+iter
+set-bounds lower=c upper=e
+seek-prefix-ge c
+----
+.
+c:1
+stats: (interface (dir, seek, step): (fwd, 20, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 19, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 4

--- a/tool/find.go
+++ b/tool/find.go
@@ -427,7 +427,7 @@ func (f *findT) searchTables(searchKey []byte, refs []findRef) []findRef {
 				return err
 			}
 			defer iter.Close()
-			key, value := iter.SeekGE(searchKey)
+			key, value := iter.SeekGE(searchKey, false /* trySeekUsingNext */)
 
 			// We configured sstable.Reader to return raw tombstones which requires a
 			// bit more work here to put them in a form that can be iterated in

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -383,7 +383,7 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 			return
 		}
 		defer iter.Close()
-		key, value := iter.SeekGE(s.start)
+		key, value := iter.SeekGE(s.start, false /* trySeekUsingNext */)
 
 		// We configured sstable.Reader to return raw tombstones which requires a
 		// bit more work here to put them in a form that can be iterated in


### PR DESCRIPTION
This change takes the trySeekUsingNext optimization that
exists in SeekPrefixGE and applies that to SeekGE as well. It
is expected to help out a lot in cockroachdb/cockroach#66410
as the CheckSSTCollisions call in Cockroach repeatedly
calls SeekGE on the engine iterator in bad cases of
ingested sst <> engine overlap.


Also adds a small optimization to not reload a block in blockIter
if we landed on the same data block after a Seek.