### PR TITLE
sstable: fix properties block location in docs

### DIFF
--- a/sstable/table.go
+++ b/sstable/table.go
@@ -86,8 +86,8 @@ The table file format looks like:
 [meta filter block] (optional)
 [index block] (for single level index)
 [meta range key block] (optional)
-[meta properties block]
 [meta rangedel block] (optional)
+[meta properties block]
 [metaindex block]
 [footer]
 <end_of_file>


### PR DESCRIPTION
The properties block is written after any range deletion block that may
be present in the sstable.

Fix the docs.

Follow-up from #1400.