### PR TITLE
internal/keyspan: convert Iter to interface, add VisibleIter

### DIFF
--- a/internal/keyspan/seek_test.go
+++ b/internal/keyspan/seek_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 type iterAdapter struct {
-	*Iter
+	Iter
 }
 
 func (i *iterAdapter) verify(key *base.InternalKey, val []byte) (*base.InternalKey, []byte) {

--- a/internal/keyspan/testdata/visible_iter
+++ b/internal/keyspan/testdata/visible_iter
@@ -1,0 +1,85 @@
+define
+a.SET.2:b
+a.SET.1:b
+b.SET.2:c
+b.SET.1:c
+c.SET.2:d
+c.SET.1:d
+----
+
+iter seqnum=5
+seek-ge a
+seek-ge b
+seek-ge c
+seek-ge d
+seek-lt a
+seek-lt b
+seek-lt c
+seek-lt d
+----
+a-b#2
+b-c#2
+c-d#2
+.
+.
+a-b#1
+b-c#1
+c-d#1
+
+iter seqnum=2
+seek-ge a
+seek-ge b
+seek-ge c
+seek-ge d
+seek-lt a
+seek-lt b
+seek-lt c
+seek-lt d
+----
+a-b#1
+b-c#1
+c-d#1
+.
+.
+a-b#1
+b-c#1
+c-d#1
+
+iter seqnum=2
+first
+next
+next
+next
+last
+prev
+prev
+prev
+----
+a-b#1
+b-c#1
+c-d#1
+.
+c-d#1
+b-c#1
+a-b#1
+.
+
+define
+a.SET.11:b
+b.SET.10:b
+c.SET.12:c
+c.SET.10:c
+d.SET.20:d
+e.SET.14:d
+----
+
+iter seqnum=5
+first
+last
+seek-ge a
+seek-lt z
+----
+.
+.
+.
+.

--- a/internal/keyspan/truncate.go
+++ b/internal/keyspan/truncate.go
@@ -12,7 +12,7 @@ import "github.com/cockroachdb/pebble/internal/base"
 // are completely outside those bounds.
 func Truncate(
 	cmp base.Compare, iter base.InternalIterator, lower, upper []byte, start, end *base.InternalKey,
-) *Iter {
+) Iter {
 	var spans []Span
 	for key, value := iter.First(); key != nil; key, value = iter.Next() {
 		s := Span{

--- a/internal/keyspan/truncate_test.go
+++ b/internal/keyspan/truncate_test.go
@@ -53,7 +53,7 @@ func TestTruncate(t *testing.T) {
 			upper := []byte(parts[1])
 
 			truncated := Truncate(cmp, iter, lower, upper, startKey, endKey)
-			return formatSpans(truncated.spans)
+			return formatSpans(truncated.(*keyspanIter).spans)
 
 		default:
 			return fmt.Sprintf("unknown command: %s", d.Cmd)

--- a/internal/keyspan/visible.go
+++ b/internal/keyspan/visible.go
@@ -1,0 +1,138 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package keyspan
+
+import "github.com/cockroachdb/pebble/internal/base"
+
+// VisibleIter wraps an Iter, filtering out any spans not visible at the
+// snapshot sequence number SeqNum.
+type VisibleIter struct {
+	keyspanIter
+	SeqNum uint64
+}
+
+// Init initializes the visible iter to determine visiblity at the provided
+// snapshot seqNum and to iterate over the provided spans.
+func (i *VisibleIter) Init(cmp base.Compare, seqNum uint64, spans []Span) {
+	*i = VisibleIter{
+		keyspanIter: keyspanIter{
+			cmp:   cmp,
+			spans: spans,
+			index: -1,
+		},
+		SeqNum: seqNum,
+	}
+}
+
+// VisibleIter implements the base.InternalIterator interface.
+var _ base.InternalIterator = (*VisibleIter)(nil)
+
+// SeekGE implements InternalIterator.SeekGE, as documented in the
+// internal/base package.
+func (i *VisibleIter) SeekGE(key []byte) (*base.InternalKey, []byte) {
+	k, v := i.keyspanIter.SeekGE(key)
+	if k != nil && !k.Visible(i.SeqNum) {
+		return i.Next()
+	}
+	return k, v
+}
+
+// SeekPrefixGE implements InternalIterator.SeekPrefixGE, as documented in the
+// internal/base package.
+func (i *VisibleIter) SeekPrefixGE(prefix, key []byte, trySeekUsingNext bool) (*base.InternalKey, []byte) {
+	// This should never be called as prefix iteration is only done for point records.
+	panic("pebble: SeekPrefixGE unimplemented")
+}
+
+// SeekLT implements InternalIterator.SeekLT, as documented in the
+// internal/base package.
+func (i *VisibleIter) SeekLT(key []byte) (*base.InternalKey, []byte) {
+	k, v := i.keyspanIter.SeekLT(key)
+	if k != nil && !k.Visible(i.SeqNum) {
+		return i.Prev()
+	}
+	return k, v
+}
+
+// First implements InternalIterator.First, as documented in the internal/base
+// package.
+func (i *VisibleIter) First() (*base.InternalKey, []byte) {
+	k, v := i.keyspanIter.First()
+	if k != nil && !k.Visible(i.SeqNum) {
+		return i.Next()
+	}
+	return k, v
+}
+
+// Last implements InternalIterator.Last, as documented in the internal/base
+// package.
+func (i *VisibleIter) Last() (*base.InternalKey, []byte) {
+	k, v := i.keyspanIter.Last()
+	if k != nil && !k.Visible(i.SeqNum) {
+		return i.Prev()
+	}
+	return k, v
+}
+
+// Next implements InternalIterator.Next, as documented in the internal/base
+// package.
+func (i *VisibleIter) Next() (*base.InternalKey, []byte) {
+	k, v := i.keyspanIter.Next()
+	for k != nil && !k.Visible(i.SeqNum) {
+		k, v = i.keyspanIter.Next()
+	}
+	return k, v
+}
+
+// Prev implements InternalIterator.Prev, as documented in the internal/base
+// package.
+func (i *VisibleIter) Prev() (*base.InternalKey, []byte) {
+	k, v := i.keyspanIter.Prev()
+	for k != nil && !k.Visible(i.SeqNum) {
+		k, v = i.keyspanIter.Prev()
+	}
+	return k, v
+}
+
+// Key implements InternalIterator.Key, as documented in the internal/base
+// package.
+func (i *VisibleIter) Key() *base.InternalKey {
+	return i.keyspanIter.Key()
+}
+
+// Value implements InternalIterator.Value, as documented in the internal/base
+// package.
+func (i *VisibleIter) Value() []byte {
+	return i.keyspanIter.Value()
+}
+
+// Valid implements InternalIterator.Valid, as documented in the internal/base
+// package.
+func (i *VisibleIter) Valid() bool {
+	return i.keyspanIter.Valid()
+}
+
+// Error implements InternalIterator.Error, as documented in the internal/base
+// package.
+func (i *VisibleIter) Error() error {
+	return nil
+}
+
+// Close implements InternalIterator.Close, as documented in the internal/base
+// package.
+func (i *VisibleIter) Close() error {
+	return nil
+}
+
+// SetBounds implements InternalIterator.SetBounds, as documented in the
+// internal/base package.
+func (i *VisibleIter) SetBounds(lower, upper []byte) {
+	// This should never be called as bounds are only used for point records.
+	panic("pebble: SetBounds unimplemented")
+}
+
+func (i *VisibleIter) String() string {
+	return i.keyspanIter.String()
+}

--- a/internal/rangekey/iter.go
+++ b/internal/rangekey/iter.go
@@ -24,7 +24,7 @@ import (
 // Iter handles 'coalescing' spans on-the-fly, including dropping key spans that
 // are no longer relevant.
 type Iter struct {
-	iter      *keyspan.Iter
+	iter      keyspan.Iter
 	coalescer Coalescer
 	curr      CoalescedSpan
 	err       error
@@ -33,7 +33,7 @@ type Iter struct {
 }
 
 // Init initializes an iterator over a set of fragmented, coalesced spans.
-func (i *Iter) Init(cmp base.Compare, formatKey base.FormatKey, iter *keyspan.Iter) {
+func (i *Iter) Init(cmp base.Compare, formatKey base.FormatKey, iter keyspan.Iter) {
 	*i = Iter{
 		iter: iter,
 	}


### PR DESCRIPTION
Convert the Iter type to an interface.

Add a VisibleIter iterator that implements the interface but filters fragments
by sequence number. A VisibleIter takes a sequence number, indicating the
sequence number at which the iterator reads. Any Spans with start keys that are
not visible at that sequence number (because they were committed at a ≥
sequence number) are skipped.

This will be used to filter out range-key fragments that should be ignored.