### PR TITLE
db: add experimental, in-memory range keys implementation

### DIFF
--- a/db.go
+++ b/db.go
@@ -405,6 +405,11 @@ type DB struct {
 		}
 	}
 
+	// rangeKeys is a temporary field so that Pebble can provide a non-durable
+	// implementation of range keys in advance of the real implementation.
+	// TODO(jackson): Remove this.
+	rangeKeys *RangeKeysArena
+
 	// Normally equal to time.Now() but may be overridden in tests.
 	timeNow func() time.Time
 }
@@ -624,6 +629,9 @@ func (d *DB) Apply(batch *Batch, opts *WriteOptions) error {
 		if d.split == nil {
 			return errNoSplit
 		}
+		if d.opts.Experimental.RangeKeys == nil {
+			panic("pebble: range keys require the Experimental.RangeKeys option")
+		}
 		// TODO(jackson): Assert that all range key operands are suffixless.
 
 		// TODO(jackson): Once the format major version for range keys is
@@ -672,6 +680,16 @@ func (d *DB) commitApply(b *Batch, mem *memTable) error {
 		d.mu.Lock()
 		d.maybeScheduleDelayedFlush(mem)
 		d.mu.Unlock()
+	}
+
+	// If the batch contains range keys, add them to the range key skiplist.
+	// This is temporary, while we work on implementing range keys. It allows us
+	// to provide an implementation of range keys that aren't persisted, so
+	// CockroachDB packages may build and prototype against them.
+	// TODO(jackson): When the durable implementation is complete, remove this
+	// and the range-key arena.
+	if b.countRangeKeys > 0 {
+		d.applyBatchRangeKeys(b)
 	}
 
 	if mem.writerUnref() {
@@ -762,6 +780,9 @@ func (d *DB) newIterInternal(batch *Batch, s *Snapshot, o *IterOptions) *Iterato
 	if err := d.closed.Load(); err != nil {
 		panic(err)
 	}
+	if o.rangeKeys() && d.opts.Experimental.RangeKeys == nil {
+		panic("pebble: range keys require the Experimental.RangeKeys option")
+	}
 
 	// Grab and reference the current readState. This prevents the underlying
 	// files in the associated version from being deleted if there is a current
@@ -794,6 +815,13 @@ func (d *DB) newIterInternal(batch *Batch, s *Snapshot, o *IterOptions) *Iterato
 		batch:               batch,
 		newIters:            d.newIters,
 		seqNum:              seqNum,
+	}
+
+	if o.rangeKeys() {
+		// TODO(jackson): Pool range-key iterator objects.
+		dbi.rangeKey = &iteratorRangeKeyState{
+			rangeKeyIter: d.newRangeKeyIter(seqNum, o),
+		}
 	}
 	if o != nil {
 		dbi.opts = *o
@@ -843,73 +871,86 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 		numMergingLevels++
 		numLevelIters++
 	}
-	if numMergingLevels > cap(mlevels) {
-		mlevels = make([]mergingIterLevel, 0, numMergingLevels)
-	}
-	if numLevelIters > cap(levels) {
-		levels = make([]levelIter, 0, numLevelIters)
-	}
 
-	// Top-level is the batch, if any.
-	if batch != nil {
-		mlevels = append(mlevels, mergingIterLevel{
-			iter:         batch.newInternalIter(&dbi.opts),
-			rangeDelIter: batch.newRangeDelIter(&dbi.opts),
-		})
-	}
-
-	// Next are the memtables.
-	for i := len(memtables) - 1; i >= 0; i-- {
-		mem := memtables[i]
-		// We only need to read from memtables which contain sequence numbers older
-		// than seqNum.
-		if logSeqNum := mem.logSeqNum; logSeqNum >= seqNum {
-			continue
+	if dbi.opts.pointKeys() {
+		if numMergingLevels > cap(mlevels) {
+			mlevels = make([]mergingIterLevel, 0, numMergingLevels)
 		}
-		mlevels = append(mlevels, mergingIterLevel{
-			iter:         mem.newIter(&dbi.opts),
-			rangeDelIter: mem.newRangeDelIter(&dbi.opts),
-		})
-	}
-
-	// Next are the file levels: L0 sub-levels followed by lower levels.
-	mlevelsIndex := len(mlevels)
-	levelsIndex := len(levels)
-	mlevels = mlevels[:numMergingLevels]
-	levels = levels[:numLevelIters]
-
-	addLevelIterForFiles := func(files manifest.LevelIterator, level manifest.Level) {
-		li := &levels[levelsIndex]
-
-		li.init(dbi.opts, dbi.cmp, dbi.split, dbi.newIters, files, level, nil)
-		li.initRangeDel(&mlevels[mlevelsIndex].rangeDelIter)
-		li.initSmallestLargestUserKey(&mlevels[mlevelsIndex].smallestUserKey,
-			&mlevels[mlevelsIndex].largestUserKey,
-			&mlevels[mlevelsIndex].isLargestUserKeyRangeDelSentinel)
-		li.initIsSyntheticIterBoundsKey(&mlevels[mlevelsIndex].isSyntheticIterBoundsKey)
-		mlevels[mlevelsIndex].iter = li
-
-		levelsIndex++
-		mlevelsIndex++
-	}
-
-	// Add level iterators for the L0 sublevels, iterating from newest to
-	// oldest.
-	for i := len(current.L0SublevelFiles) - 1; i >= 0; i-- {
-		addLevelIterForFiles(current.L0SublevelFiles[i].Iter(), manifest.L0Sublevel(i))
-	}
-
-	// Add level iterators for the non-empty non-L0 levels.
-	for level := 1; level < len(current.Levels); level++ {
-		if current.Levels[level].Empty() {
-			continue
+		if numLevelIters > cap(levels) {
+			levels = make([]levelIter, 0, numLevelIters)
 		}
-		addLevelIterForFiles(current.Levels[level].Iter(), manifest.Level(level))
+
+		// Top-level is the batch, if any.
+		if batch != nil {
+			mlevels = append(mlevels, mergingIterLevel{
+				iter:         batch.newInternalIter(&dbi.opts),
+				rangeDelIter: batch.newRangeDelIter(&dbi.opts),
+			})
+		}
+
+		// Next are the memtables.
+		for i := len(memtables) - 1; i >= 0; i-- {
+			mem := memtables[i]
+			// We only need to read from memtables which contain sequence numbers older
+			// than seqNum.
+			if logSeqNum := mem.logSeqNum; logSeqNum >= seqNum {
+				continue
+			}
+			mlevels = append(mlevels, mergingIterLevel{
+				iter:         mem.newIter(&dbi.opts),
+				rangeDelIter: mem.newRangeDelIter(&dbi.opts),
+			})
+		}
+
+		// Next are the file levels: L0 sub-levels followed by lower levels.
+		mlevelsIndex := len(mlevels)
+		levelsIndex := len(levels)
+		mlevels = mlevels[:numMergingLevels]
+		levels = levels[:numLevelIters]
+
+		addLevelIterForFiles := func(files manifest.LevelIterator, level manifest.Level) {
+			li := &levels[levelsIndex]
+
+			li.init(dbi.opts, dbi.cmp, dbi.split, dbi.newIters, files, level, nil)
+			li.initRangeDel(&mlevels[mlevelsIndex].rangeDelIter)
+			li.initSmallestLargestUserKey(&mlevels[mlevelsIndex].smallestUserKey,
+				&mlevels[mlevelsIndex].largestUserKey,
+				&mlevels[mlevelsIndex].isLargestUserKeyRangeDelSentinel)
+			li.initIsSyntheticIterBoundsKey(&mlevels[mlevelsIndex].isSyntheticIterBoundsKey)
+			mlevels[mlevelsIndex].iter = li
+
+			levelsIndex++
+			mlevelsIndex++
+		}
+
+		// Add level iterators for the L0 sublevels, iterating from newest to
+		// oldest.
+		for i := len(current.L0SublevelFiles) - 1; i >= 0; i-- {
+			addLevelIterForFiles(current.L0SublevelFiles[i].Iter(), manifest.L0Sublevel(i))
+		}
+
+		// Add level iterators for the non-empty non-L0 levels.
+		for level := 1; level < len(current.Levels); level++ {
+			if current.Levels[level].Empty() {
+				continue
+			}
+			addLevelIterForFiles(current.Levels[level].Iter(), manifest.Level(level))
+		}
+		buf.merging.init(&dbi.opts, dbi.cmp, dbi.split, mlevels...)
+		buf.merging.snapshot = seqNum
+		buf.merging.elideRangeTombstones = true
+	} else {
+		// This is a merging iterator with no levels, that produces nothing.
+		buf.merging.init(&dbi.opts, dbi.cmp, dbi.split)
 	}
 
-	buf.merging.init(&dbi.opts, dbi.cmp, dbi.split, mlevels...)
-	buf.merging.snapshot = seqNum
-	buf.merging.elideRangeTombstones = true
+	// For the in-memory prototype of range keys, wrap the merging iterator with
+	// an interleaving iterator. The dbi.rangeKeysIter is an iterator into
+	// fragmented range keys read from the global range key arena.
+	if dbi.rangeKey != nil {
+		dbi.rangeKey.iter.Init(&buf.merging, dbi.rangeKey.rangeKeyIter)
+		dbi.iter = &dbi.rangeKey.iter
+	}
 	return dbi
 }
 

--- a/internal/keyspan/doc.go
+++ b/internal/keyspan/doc.go
@@ -6,7 +6,8 @@
 // meaning it contains both an internal key kind and a sequence number.
 //
 // Spans are used within Pebble as an in-memory representation of range
-// deletion tombstones. Spans are fragmented at overlapping key
-// boundaries by the Fragmenter type. This package's various iteration
-// facilities require these non-overlapping fragmented spans.
+// deletion tombstones, and range key sets, unsets and deletes. Spans
+// are fragmented at overlapping key boundaries by the Fragmenter type.
+// This package's various iteration facilities require these
+// non-overlapping fragmented spans.
 package keyspan

--- a/internal/rangekey/iter.go
+++ b/internal/rangekey/iter.go
@@ -42,6 +42,21 @@ func (i *Iter) Init(cmp base.Compare, formatKey base.FormatKey, visibleSeqNum ui
 	})
 }
 
+// Clone clones the iterator, returning an independent iterator over the same
+// state. This method is temporary and may be deleted once range keys' state is
+// properly reflected in readState.
+func (i *Iter) Clone() *Iter {
+	// TODO(jackson): Remove this method when the range keys' state is included
+	// in the readState.
+	// Copying i.iter will copy its current position, which is harmless.
+	ki := &keyspan.Iter{}
+	*ki = *i.iter
+	// Init the new Iter to ensure err is clearer.
+	newIter := &Iter{}
+	newIter.Init(i.coalescer.items.cmp, i.coalescer.formatKey, i.coalescer.visibleSeqNum, ki)
+	return newIter
+}
+
 // Error returns any accumulated error.
 func (i *Iter) Error() error {
 	return i.err

--- a/open.go
+++ b/open.go
@@ -75,6 +75,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		merge:               opts.Merger.Merge,
 		split:               opts.Comparer.Split,
 		abbreviatedKey:      opts.Comparer.AbbreviatedKey,
+		rangeKeys:           opts.Experimental.RangeKeys,
 		largeBatchThreshold: (opts.MemTableSize - int(memTableEmptySize)) / 2,
 		logRecycler:         logRecycler{limit: opts.MemTableStopWritesThreshold + 1},
 		closed:              new(atomic.Value),

--- a/range_keys.go
+++ b/range_keys.go
@@ -1,0 +1,98 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"sync"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/arenaskl"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/keyspan"
+	"github.com/cockroachdb/pebble/internal/rangekey"
+)
+
+const rangeKeyArenaSize = 1 << 20
+
+// RangeKeysArena is an in-memory arena in which range keys are stored.
+//
+// This is a temporary type that will eventually be removed.
+type RangeKeysArena struct {
+	once      sync.Once
+	skl       arenaskl.Skiplist
+	arena     *arenaskl.Arena
+	fragCache keySpanCache
+}
+
+// applyBatchRangeKeys is a temporary hack to support in-memory only range keys.
+// We use much of the same code that we will use for the memtable, but we use a
+// separate arena that exists beyond the lifetime of any individual memtable.
+// For as long as we're relying on this hack, a single *pebble.DB may only store
+// as many range keys as fit in this arena.
+func (d *DB) applyBatchRangeKeys(b *Batch) error {
+	d.maybeInitializeRangeKeys()
+
+	seqNum := b.SeqNum()
+	startSeqNum := seqNum
+	for r := b.Reader(); ; seqNum++ {
+		kind, ukey, value, ok := r.Next()
+		if !ok {
+			break
+		}
+		switch kind {
+		case InternalKeyKindLogData:
+			// Don't increment seqNum for LogData, since these are not applied
+			// to the memtable.
+			seqNum--
+			continue
+		case InternalKeyKindRangeKeySet, InternalKeyKindRangeKeyUnset, InternalKeyKindRangeKeyDelete:
+			ikey := base.MakeInternalKey(ukey, seqNum, kind)
+			if err := d.rangeKeys.skl.Add(ikey, value); err != nil {
+				return err
+			}
+		default:
+			// This method only applies range keys; ignore all other key kinds.
+		}
+	}
+	if seqNum != startSeqNum+uint64(b.Count()) {
+		return base.CorruptionErrorf("pebble: inconsistent batch count: %d vs %d",
+			errors.Safe(seqNum), errors.Safe(startSeqNum+uint64(b.Count())))
+	}
+	d.rangeKeys.fragCache.invalidate(uint32(b.countRangeKeys))
+	return nil
+}
+
+func (d *DB) maybeInitializeRangeKeys() {
+	// Lazily construct the global range key arena, so that tests that
+	// don't use range keys don't need to allocate this long-lived
+	// buffer.
+	d.rangeKeys.once.Do(func() {
+		arenaBuf := make([]byte, rangeKeyArenaSize)
+		d.rangeKeys.arena = arenaskl.NewArena(arenaBuf)
+		d.rangeKeys.skl.Reset(d.rangeKeys.arena, d.cmp)
+		d.rangeKeys.fragCache = keySpanCache{
+			cmp:       d.cmp,
+			formatKey: d.opts.Comparer.FormatKey,
+			skl:       &d.rangeKeys.skl,
+			splitValue: func(kind base.InternalKeyKind, rawValue []byte) (endKey []byte, value []byte, err error) {
+				var ok bool
+				endKey, value, ok = rangekey.DecodeEndKey(kind, rawValue)
+				if !ok {
+					err = base.CorruptionErrorf("unable to decode end key for key of kind %s", kind)
+				}
+				// NB: This value encodes a series of (suffix,value) tuples.
+				return endKey, value, err
+			},
+		}
+	})
+}
+
+func (d *DB) newRangeKeyIter(seqNum uint64, opts *IterOptions) *rangekey.Iter {
+	d.maybeInitializeRangeKeys()
+	frags := d.rangeKeys.fragCache.get()
+	iter := &rangekey.Iter{}
+	iter.Init(d.cmp, d.opts.Comparer.FormatKey, seqNum, keyspan.NewIter(d.cmp, frags))
+	return iter
+}

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -1,0 +1,376 @@
+reset
+----
+
+# Use the key string as the value so that it's easy to tell when we surface the
+# wrong value.
+
+batch
+set a a
+set b b
+set c c
+set d d
+range-key-set b   c   @5 boop
+range-key-set cat dog @3 beep
+----
+wrote 6 keys
+
+# Scan forward
+
+combined-iter
+seek-ge a
+next
+next
+next
+next
+next
+----
+a: (a, .)
+b: (b, [b-c) @5=boop)
+c: (c, .)
+cat: (., [cat-dog) @3=beep)
+d: (d, [cat-dog) @3=beep)
+.
+
+# Scan backward
+
+combined-iter
+seek-lt z
+prev
+prev
+prev
+prev
+prev
+----
+d: (d, [cat-dog) @3=beep)
+cat: (., [cat-dog) @3=beep)
+c: (c, .)
+b: (b, [b-c) @5=boop)
+a: (a, .)
+.
+
+combined-iter
+seek-ge ace
+seek-ge b
+seek-ge c
+seek-ge cab
+seek-ge cat
+seek-ge d
+seek-ge day
+seek-ge dog
+----
+b: (b, [b-c) @5=boop)
+b: (b, [b-c) @5=boop)
+c: (c, .)
+cat: (., [cat-dog) @3=beep)
+cat: (., [cat-dog) @3=beep)
+d: (d, [cat-dog) @3=beep)
+day: (., [cat-dog) @3=beep)
+.
+
+combined-iter
+seek-lt 1
+seek-lt ace
+seek-lt b
+seek-lt c
+seek-lt cab
+seek-lt cat
+seek-lt d
+seek-lt day
+seek-lt dog
+seek-lt zebra
+----
+.
+a: (a, .)
+a: (a, .)
+b: (b, [b-c) @5=boop)
+c: (c, .)
+c: (c, .)
+cat: (., [cat-dog) @3=beep)
+d: (d, [cat-dog) @3=beep)
+d: (d, [cat-dog) @3=beep)
+d: (d, [cat-dog) @3=beep)
+
+rangekey-iter
+first
+next
+next
+set-bounds lower=bat upper=catatonic
+first
+next
+next
+----
+b [b-c) @5=boop
+cat [cat-dog) @3=beep
+.
+.
+bat [bat-c) @5=boop
+cat [cat-catatonic) @3=beep
+.
+
+rangekey-iter
+seek-ge bat
+----
+bat [b-c) @5=boop
+
+# Delete 'b': The Iterator should still stop at b because of the range key
+# with a start boundary at b.
+
+batch
+del b
+----
+wrote 1 keys
+
+combined-iter
+seek-ge b
+seek-ge ace
+----
+b: (., [b-c) @5=boop)
+b: (., [b-c) @5=boop)
+
+rangekey-iter
+seek-ge b
+seek-ge ace
+----
+b [b-c) @5=boop
+b [b-c) @5=boop
+
+# Delete the b-c range key and the beginning of the cat-dog range key,
+# truncating it to now begin at 'd'.
+
+batch
+range-key-del b d
+----
+wrote 1 keys
+
+combined-iter
+seek-ge b
+next
+----
+c: (c, .)
+d: (d, [d-dog) @3=beep)
+
+reset
+----
+
+batch
+range-key-set c d @1 boop
+range-key-set apple c @3 beep
+range-key-set ace apple @3 beep
+set a a1
+set b b1
+set c c1
+del a
+set b b2
+set c c2
+----
+wrote 9 keys
+
+# Test that reverse iteration surfaces range key start boundaries alongside
+# point keys at the same key.
+
+combined-iter
+last
+prev
+prev
+prev
+prev
+----
+c: (c2, [c-d) @1=boop)
+b: (b2, [apple-c) @3=beep)
+apple: (., [apple-c) @3=beep)
+ace: (., [ace-apple) @3=beep)
+.
+
+# Test that forward iteration surfaces range key start boundaries alongside
+# point keys at the same key.
+
+combined-iter
+first
+next
+next
+next
+next
+----
+ace: (., [ace-apple) @3=beep)
+apple: (., [apple-c) @3=beep)
+b: (b2, [apple-c) @3=beep)
+c: (c2, [c-d) @1=boop)
+.
+
+combined-iter
+seek-prefix-ge b
+next
+----
+b: (b2, [apple-c) @3=beep)
+.
+
+reset
+----
+
+batch
+range-key-set a d @8 boop
+set a@2 a@2
+set a@3 a#3
+set a@9 a@9
+set a@10 a@10
+set b b
+----
+wrote 6 keys
+
+combined-iter
+seek-prefix-ge a
+next
+next
+next
+next
+next
+----
+a: (., [a-d) @8=boop)
+a@10: (a@10, [a-d) @8=boop)
+a@9: (a@9, [a-d) @8=boop)
+a@3: (a#3, [a-d) @8=boop)
+a@2: (a@2, [a-d) @8=boop)
+.
+
+reset
+----
+
+# For all prefixes a, aa, ab, ... zz, write 3 keys at timestamps @1, @10, @100.
+# This populates a total of (26**2 + 26) * 3 = 2106 keys.
+
+populate keylen=2 timestamps=(1, 10, 100)
+----
+wrote 2106 keys
+
+batch
+range-key-set   b c @5 beep
+range-key-unset c d @1
+range-key-del   d e
+----
+wrote 3 keys
+
+combined-iter
+seek-ge az
+next
+next
+next
+next
+next
+seek-ge bz@10
+next
+next
+----
+az@100: (az@100, .)
+az@10: (az@10, .)
+az@1: (az@1, .)
+b: (., [b-c) @5=beep)
+b@100: (b@100, [b-c) @5=beep)
+b@10: (b@10, [b-c) @5=beep)
+bz@10: (bz@10, [b-c) @5=beep)
+bz@1: (bz@1, [b-c) @5=beep)
+c@100: (c@100, .)
+
+# Ensure that a cloned iterator includes range keys.
+
+combined-iter
+seek-ge bz@10
+clone
+seek-ge bz@10
+----
+bz@10: (bz@10, [b-c) @5=beep)
+.
+bz@10: (bz@10, [b-c) @5=beep)
+
+# Within a batch, later writes overwrite earlier writes. Here, the range-key-del
+# of [bat, bus) overwrites the earlier writes of [b,c) and [b,e).
+
+batch
+range-key-set   b c @5 beep
+range-key-set   b e @1 bop
+range-key-set   c z @1000 boop
+range-key-del   bat bus
+----
+wrote 4 keys
+
+scan-rangekeys
+----
+[b, bat)
+ @5=beep, @1=bop
+[bus, c)
+ @5=beep, @1=bop
+[c, d)
+ @1000=boop, @1=bop
+[d, e)
+ @1000=boop, @1=bop
+[e, z)
+ @1000=boop
+
+combined-iter
+seek-prefix-ge ca
+next
+seek-prefix-ge ca@100
+----
+ca: (., [c-d) @1000=boop, @1=bop)
+ca@100: (ca@100, [c-d) @1000=boop, @1=bop)
+ca@100: (ca@100, [c-d) @1000=boop, @1=bop)
+
+reset
+----
+
+batch
+range-key-set x z @5 boop
+----
+wrote 1 keys
+
+combined-iter
+last
+next
+prev
+----
+x: (., [x-z) @5=boop)
+.
+x: (., [x-z) @5=boop)
+
+# Test limited reverse iteration. The seek-lt-limit z y must see the [x-z) range
+# key because it covers a key within the range [y, z). The range key start
+# boundary isn't until x.
+
+combined-iter
+seek-lt-limit z y
+next
+prev-limit y
+----
+x: valid (., [x-z) @5=boop)
+.
+x: valid (., [x-z) @5=boop)
+
+# Test limited forward iteration. Since range keys are interleaved at the start
+# boundaries, the iterator is guaranteed to encounter covering range keys
+# without any special casing in the implementation.
+
+combined-iter
+seek-ge-limit w y
+prev
+next-limit y
+----
+x: valid (., [x-z) @5=boop)
+.
+x: valid (., [x-z) @5=boop)
+
+# Test another limited backward iteration case where there exists a deleted
+# point key and the underlying internalIterator is Prev'd to a key beyond the
+# limit. This should still surface the covering range key.
+
+batch
+del yy
+----
+wrote 1 keys
+
+combined-iter
+seek-lt-limit z y
+next
+prev-limit y
+----
+x: valid (., [x-z) @5=boop)
+.
+x: valid (., [x-z) @5=boop)


### PR DESCRIPTION
This change adds experimental, in-memory support for range keys. If a database
is configured with the `Experimental.RangeKeys` field set, batches containing
range keys may be committed. The range keys are applied to a fixed-size
in-memory arena. The `pebble.Iterator` type is extended to surface these range
keys when an iterator's `IterOptions.KeyTypes` option is set to
`IterKeyTypeRangesOnly` or `IterKeyTypePointsAndRanges`.

With this change, range keys are non-durable. When a database is closed, all
committed range keys are lost.