### PR TITLE
internal/metamorphic: generate keys with suffixes

### DIFF
--- a/internal/metamorphic/generator_test.go
+++ b/internal/metamorphic/generator_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestGenerator(t *testing.T) {
 	rng := randvar.NewRand()
-	g := newGenerator(rng)
+	g := newGenerator(rng, defaultConfig())
 
 	g.newBatch()
 	g.newBatch()
@@ -61,7 +61,7 @@ func TestGenerator(t *testing.T) {
 		t.Logf("\n%s", g)
 	}
 
-	g = newGenerator(rng)
+	g = newGenerator(rng, defaultConfig())
 
 	g.newSnapshot()
 	g.newSnapshot()
@@ -94,7 +94,7 @@ func TestGenerator(t *testing.T) {
 		t.Logf("\n%s", g)
 	}
 
-	g = newGenerator(rng)
+	g = newGenerator(rng, defaultConfig())
 
 	g.newIndexedBatch()
 	g.newIndexedBatch()
@@ -129,7 +129,7 @@ func TestGeneratorRandom(t *testing.T) {
 	generateFromSeed := func() string {
 		rng := rand.New(rand.NewSource(seed))
 		count := ops.Uint64(rng)
-		return formatOps(generate(rng, count, defaultConfig))
+		return formatOps(generate(rng, count, defaultConfig()))
 	}
 
 	// Ensure that generate doesn't use any other source of randomness other

--- a/internal/metamorphic/key_manager_test.go
+++ b/internal/metamorphic/key_manager_test.go
@@ -169,12 +169,37 @@ func TestKeyManager_AddKey(t *testing.T) {
 	k1 := []byte("foo")
 	require.True(t, m.addNewKey(k1))
 	require.Len(t, m.globalKeys, 1)
+	require.Len(t, m.globalKeyPrefixes, 1)
 	require.Contains(t, m.globalKeys, k1)
+	require.Contains(t, m.globalKeyPrefixes, k1)
 	require.False(t, m.addNewKey(k1))
+	require.True(t, m.prefixExists([]byte("foo")))
+	require.False(t, m.prefixExists([]byte("bar")))
+
 	k2 := []byte("bar")
 	require.True(t, m.addNewKey(k2))
 	require.Len(t, m.globalKeys, 2)
+	require.Len(t, m.globalKeyPrefixes, 2)
 	require.Contains(t, m.globalKeys, k2)
+	require.Contains(t, m.globalKeyPrefixes, k2)
+	require.True(t, m.prefixExists([]byte("bar")))
+	k3 := []byte("bax@4")
+	require.True(t, m.addNewKey(k3))
+	require.Len(t, m.globalKeys, 3)
+	require.Len(t, m.globalKeyPrefixes, 3)
+	require.Contains(t, m.globalKeys, k3)
+	require.Contains(t, m.globalKeyPrefixes, []byte("bax"))
+	require.True(t, m.prefixExists([]byte("bax")))
+	k4 := []byte("foo@6")
+	require.True(t, m.addNewKey(k4))
+	require.Len(t, m.globalKeys, 4)
+	require.Len(t, m.globalKeyPrefixes, 3)
+	require.Contains(t, m.globalKeys, k4)
+	require.True(t, m.prefixExists([]byte("foo")))
+
+	require.Equal(t, [][]byte{
+		[]byte("foo"), []byte("bar"), []byte("bax"),
+	}, m.prefixes())
 }
 
 func TestKeyManager_GetOrInit(t *testing.T) {

--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/errorfs"
 	"github.com/cockroachdb/pebble/internal/randvar"
+	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/pmezard/go-difflib/difflib"
 	"github.com/stretchr/testify/require"
@@ -135,8 +136,9 @@ func testMetaRun(t *testing.T, runDir string, seed uint64, historyPath string) {
 	testOpts := &testOptions{opts: opts}
 	require.NoError(t, parseOptions(testOpts, string(optionsData)))
 
-	// Always use our custom comparer which provides a Split method.
-	opts.Comparer = &comparer
+	// Always use our custom comparer which provides a Split method, splitting
+	// keys at the trailing '@'.
+	opts.Comparer = testkeys.Comparer
 	// Use an archive cleaner to ease post-mortem debugging.
 	opts.Cleaner = base.ArchiveCleaner{}
 
@@ -263,7 +265,7 @@ func TestMeta(t *testing.T) {
 
 	// Generate a new set of random ops, writing them to <dir>/ops. These will be
 	// read by the child processes when performing a test run.
-	ops := generate(rng, opCount, defaultConfig)
+	ops := generate(rng, opCount, defaultConfig())
 	opsPath := filepath.Join(metaDir, "ops")
 	formattedOps := formatOps(ops)
 	require.NoError(t, ioutil.WriteFile(opsPath, []byte(formattedOps), 0644))

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -9,17 +9,10 @@ import (
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/randvar"
+	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/vfs"
 	"golang.org/x/exp/rand"
 )
-
-var comparer = func() pebble.Comparer {
-	c := *pebble.DefaultComparer
-	c.Split = func(a []byte) int {
-		return len(a)
-	}
-	return c
-}()
 
 func parseOptions(opts *testOptions, data string) error {
 	hooks := &pebble.ParseHooks{
@@ -77,7 +70,7 @@ func optionsToString(opts *testOptions) string {
 
 func defaultOptions() *pebble.Options {
 	opts := &pebble.Options{
-		Comparer:           &comparer,
+		Comparer:           testkeys.Comparer,
 		FS:                 vfs.NewMem(),
 		FormatMajorVersion: pebble.FormatNewest,
 		Levels: []pebble.LevelOptions{{

--- a/internal/metamorphic/parser_test.go
+++ b/internal/metamorphic/parser_test.go
@@ -31,7 +31,7 @@ func TestParser(t *testing.T) {
 }
 
 func TestParserRandom(t *testing.T) {
-	ops := generate(randvar.NewRand(), 10000, defaultConfig)
+	ops := generate(randvar.NewRand(), 10000, defaultConfig())
 	src := formatOps(ops)
 
 	parsedOps, err := parse([]byte(src))

--- a/internal/testkeys/testkeys.go
+++ b/internal/testkeys/testkeys.go
@@ -175,6 +175,18 @@ func Suffix(t int) []byte {
 	return b[:WriteSuffix(b, t)]
 }
 
+// SuffixLen returns the exact length of the given suffix when encoded.
+func SuffixLen(t int) int {
+	// Begin at 1 for the '@' delimiter, 1 for a single digit.
+	n := 2
+	t /= 10
+	for t > 0 {
+		t /= 10
+		n++
+	}
+	return n
+}
+
 // WriteSuffix writes the test keys suffix representation of timestamp t to dst,
 // returning the number of bytes written.
 func WriteSuffix(dst []byte, t int) int {

--- a/internal/testkeys/testkeys_test.go
+++ b/internal/testkeys/testkeys_test.go
@@ -153,6 +153,28 @@ func TestSuffix(t *testing.T) {
 	}
 }
 
+func TestSuffixLen(t *testing.T) {
+	testCases := map[int]int{
+		0:    2,
+		1:    2,
+		5:    2,
+		9:    2,
+		10:   3,
+		17:   3,
+		20:   3,
+		99:   3,
+		100:  4,
+		101:  4,
+		999:  4,
+		1000: 5,
+	}
+	for ts, want := range testCases {
+		if got := SuffixLen(ts); got != want {
+			t.Errorf("SuffixLen(%d) = %d, want %d", ts, got, want)
+		}
+	}
+}
+
 func keyspaceToString(ks Keyspace) string {
 	var buf bytes.Buffer
 	b := make([]byte, ks.MaxLen())


### PR DESCRIPTION
Generate keys with human-readable suffixes like '`@3`'. The key manager is
extended to track unique in-use prefixes as well. A fixed portion of new keys
are generated using an existing prefix but a new suffix.

New keys' suffixes are generated using a skewed-latest distribution, mimicking
MVCC timestamps