### PR TITLE
tool: add compaction log event aggregation tool

### DIFF
--- a/tool/db.go
+++ b/tool/db.go
@@ -6,10 +6,6 @@ package tool
 
 import (
 	"fmt"
-	"io"
-	"io/ioutil"
-	"text/tabwriter"
-
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/pebble"
@@ -18,7 +14,11 @@ import (
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/tool/logs"
 	"github.com/spf13/cobra"
+	"io"
+	"io/ioutil"
+	"text/tabwriter"
 )
 
 // dbT implements db-level tools, including both configuration state and the
@@ -28,6 +28,7 @@ type dbT struct {
 	Check      *cobra.Command
 	Checkpoint *cobra.Command
 	Get        *cobra.Command
+	Logs       *cobra.Command
 	LSM        *cobra.Command
 	Properties *cobra.Command
 	Scan       *cobra.Command
@@ -95,6 +96,7 @@ process.
 		Args: cobra.ExactArgs(2),
 		Run:  d.runGet,
 	}
+	d.Logs = logs.NewCmd()
 	d.LSM = &cobra.Command{
 		Use:   "lsm <dir>",
 		Short: "print LSM structure",
@@ -146,7 +148,7 @@ use by another process.
 		Run:  d.runSpace,
 	}
 
-	d.Root.AddCommand(d.Check, d.Checkpoint, d.Get, d.LSM, d.Properties, d.Scan, d.Set, d.Space)
+	d.Root.AddCommand(d.Check, d.Checkpoint, d.Get, d.Logs, d.LSM, d.Properties, d.Scan, d.Set, d.Space)
 	d.Root.PersistentFlags().BoolVarP(&d.verbose, "verbose", "v", false, "verbose output")
 
 	for _, cmd := range []*cobra.Command{d.Check, d.Checkpoint, d.Get, d.LSM, d.Properties, d.Scan, d.Set, d.Space} {

--- a/tool/logs/compaction.go
+++ b/tool/logs/compaction.go
@@ -1,0 +1,855 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package logs
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/humanize"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// Matches either a compaction or a memtable flush log line.
+	//
+	// A compaction start / end line resembles:
+	//   "compact(ed|ing)($TYPE) L($LEVEL)"
+	//
+	// A memtable flush start / end line resembles:
+	//   "flush(ed|ing) ($N) memtables to L($LEVEL)"
+	sentinelPattern          = regexp.MustCompile(`(?P<prefix>compact|flush)(?P<suffix>ed|ing)(?:\(.*\)\sL[0-9]|\s\d+\smemtables\sto\sL[0-9])`)
+	sentinelPatternPrefixIdx = sentinelPattern.SubexpIndex("prefix")
+	sentinelPatternSuffixIdx = sentinelPattern.SubexpIndex("suffix")
+
+	// Example compaction start and end log lines:
+	//
+	//   I211215 14:26:56.012382 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n5,pebble,s5] 1216510  [JOB 284925] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)
+	//   I211215 14:26:56.318543 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n5,pebble,s5] 1216554  [JOB 284925] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
+	//
+	// NOTE: we use the log timestamp to compute the compaction duration rather
+	// than the Pebble log output.
+	compactionPattern = regexp.MustCompile(
+		`^.` +
+			/* Timestamp       */ `(?P<timestamp>\d{6} \d{2}:\d{2}:\d{2}.\d{6}).*` +
+			/* Job ID          */ `\[JOB (?P<job>\d+)]\s` +
+			/* Start / end     */ `compact(?P<suffix>ed|ing)` +
+			/* Compaction type */ `\((?P<type>.*?)\) ` +
+			/* Start level     */ `L(?P<from>\d)(?:.*(?:\+|->)\s` +
+			/* End level       */ `L(?P<to>\d))?` +
+			/* Bytes           */ `(?:.*?\((?P<digit>.*?)\s(?P<unit>.*?)\))?`,
+	)
+	compactionPatternTimestampIdx = compactionPattern.SubexpIndex("timestamp")
+	compactionPatternJobIdx       = compactionPattern.SubexpIndex("job")
+	compactionPatternSuffixIdx    = compactionPattern.SubexpIndex("suffix")
+	compactionPatternTypeIdx      = compactionPattern.SubexpIndex("type")
+	compactionPatternFromIdx      = compactionPattern.SubexpIndex("from")
+	compactionPatternToIdx        = compactionPattern.SubexpIndex("to")
+	compactionPatternDigitIdx     = compactionPattern.SubexpIndex("digit")
+	compactionPatternUnitIdx      = compactionPattern.SubexpIndex("unit")
+
+	// Example memtable flush log lines:
+	//
+	//   I211213 16:23:48.903751 21136 3@vendor/github.com/cockroachdb/pebble/event.go:599 ⋮ [n9,pebble,s9] 24 [JOB 10] flushing 2 memtables to L0
+	//   I211213 16:23:49.134464 21136 3@vendor/github.com/cockroachdb/pebble/event.go:603 ⋮ [n9,pebble,s9] 26 [JOB 10] flushed 2 memtables to L0 [1535806] (1.3 M), in 0.2s, output rate 5.8 M/s
+	//
+	// NOTE: we use the log timestamp to compute the flush duration rather than
+	// the Pebble log output.
+	flushPattern = regexp.MustCompile(
+		`^.` +
+			/* Timestamp   */ `(?P<timestamp>\d{6} \d{2}:\d{2}:\d{2}.\d{6})\s.*` +
+			/* Job ID      */ `\[JOB (?P<job>\d+)]\s` +
+			/* Start / End */ `flush(?P<suffix>ed|ing)` +
+			/* Bytes       */ `(?:.*?\((?P<digit>.*?)\s(?P<unit>.*?)\))?`,
+	)
+	flushPatternTimestampIdx = flushPattern.SubexpIndex("timestamp")
+	flushPatternSuffixIdx    = flushPattern.SubexpIndex("suffix")
+	flushPatternJobIdx       = flushPattern.SubexpIndex("job")
+	flushPatternDigitIdx     = flushPattern.SubexpIndex("digit")
+	flushPatternUnitIdx      = flushPattern.SubexpIndex("unit")
+
+	// Example read-amp log line:
+	//
+	//   I211215 14:55:15.802648 155 kv/kvserver/store.go:2668 ⋮ [n5,s5] 109057 +  total     44905   672 G       -   1.2 T   714 G   118 K   215 G    34 K   4.0 T   379 K   2.8 T     514     3.4
+	//
+	// Match groups:
+	// - 1: datetime
+	// - 2: read-amp value
+	readAmpPattern = regexp.MustCompile(
+		`^.` +
+			`(?P<timestamp>\d{6} \d{2}:\d{2}:\d{2}.\d{6})` +
+			`\s.*total.*?(?P<value>\d+).{8}$`,
+	)
+	readAmpPatternTimestampIdx = readAmpPattern.SubexpIndex("timestamp")
+	readAmpPatternValueIdx     = readAmpPattern.SubexpIndex("value")
+)
+
+const (
+	// timeFmt matches the Cockroach log timestamp format.
+	// See: https://github.com/cockroachdb/cockroach/blob/master/pkg/util/log/format_crdb_v2.go
+	timeFmt = "060102 15:04:05.000000"
+
+	// timeFmtSlim is similar to timeFmt, except that it strips components with a
+	// lower granularity than a minute.
+	timeFmtSlim = "060102 15:04"
+
+	// timeFmtHrMinSec prints only the hour, minute and second of the time.
+	timeFmtHrMinSec = "15:04:05"
+
+	// pebbleLogPrefix is the well-known prefix for a pebble log file.
+	// See:https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20200728_log_modernization.md
+	pebbleLogPrefix = "cockroach-pebble"
+)
+
+// compactionType is the type of compaction. It tracks the types in
+// compaction.go. We copy the values here to avoid exporting the types in
+// compaction.go.
+type compactionType uint8
+
+const (
+	compactionTypeDefault compactionType = iota
+	compactionTypeFlush
+	compactionTypeMove
+	compactionTypeDeleteOnly
+	compactionTypeElisionOnly
+	compactionTypeRead
+)
+
+// String implements fmt.Stringer.
+func (c compactionType) String() string {
+	switch c {
+	case compactionTypeDefault:
+		return "default"
+	case compactionTypeMove:
+		return "move"
+	case compactionTypeDeleteOnly:
+		return "delete-only"
+	case compactionTypeElisionOnly:
+		return "elision-only"
+	case compactionTypeRead:
+		return "read"
+	default:
+		panic(errors.Newf("unknown compaction type: %s", c))
+	}
+}
+
+// parseCompactionType parses the given compaction type string and returns a
+// compactionType.
+func parseCompactionType(s string) (t compactionType, err error) {
+	switch s {
+	case "default":
+		t = compactionTypeDefault
+	case "move":
+		t = compactionTypeMove
+	case "delete-only":
+		t = compactionTypeDeleteOnly
+	case "elision-only":
+		t = compactionTypeElisionOnly
+	case "read":
+		t = compactionTypeRead
+	default:
+		err = errors.Newf("unknown compaction type: %s", s)
+	}
+	return
+}
+
+// compactionStart is a compaction start event.
+type compactionStart struct {
+	jobID     int
+	cType     compactionType
+	time      time.Time
+	fromLevel int
+	toLevel   int
+}
+
+// parseCompactionStart converts the given regular expression sub-matches for a
+// compaction start log line into a compactionStart event.
+func parseCompactionStart(matches []string) (compactionStart, error) {
+	var start compactionStart
+
+	// Parse start time.
+	tStart, err := time.Parse(timeFmt, matches[compactionPatternTimestampIdx])
+	if err != nil {
+		return start, errors.Newf("could not parse start time: %s", err)
+	}
+
+	// Parse job ID.
+	jobID, err := strconv.Atoi(matches[compactionPatternJobIdx])
+	if err != nil {
+		return start, errors.Newf("could not parse jobID: %s", err)
+	}
+
+	// Parse compaction type.
+	cType, err := parseCompactionType(matches[compactionPatternTypeIdx])
+	if err != nil {
+		return start, err
+	}
+
+	// Parse from-level.
+	from, err := strconv.Atoi(matches[compactionPatternFromIdx])
+	if err != nil {
+		return start, errors.Newf("could not parse from-level: %s", err)
+	}
+
+	// Parse to-level. For deletion and elision compactions, set the same level.
+	to := from
+	if cType != compactionTypeElisionOnly && cType != compactionTypeDeleteOnly {
+		to, err = strconv.Atoi(matches[compactionPatternToIdx])
+		if err != nil {
+			return start, errors.Newf("could not parse to-level: %s", err)
+		}
+	}
+
+	start = compactionStart{
+		jobID:     jobID,
+		cType:     cType,
+		time:      tStart,
+		fromLevel: from,
+		toLevel:   to,
+	}
+
+	return start, nil
+}
+
+// compactionEnd is a compaction end event.
+type compactionEnd struct {
+	jobID          int
+	time           time.Time
+	compactedBytes uint64
+}
+
+// parseCompactionEnd converts the given regular expression sub-matches for a
+// compaction end log line into a compactionEnd event.
+func parseCompactionEnd(matches []string) (compactionEnd, error) {
+	var end compactionEnd
+
+	// Parse end time.
+	tEnd, err := time.Parse(timeFmt, matches[compactionPatternTimestampIdx])
+	if err != nil {
+		return end, errors.Newf("could not parse start time: %s", err)
+	}
+
+	// Parse job ID.
+	jobID, err := strconv.Atoi(matches[compactionPatternJobIdx])
+	if err != nil {
+		return end, errors.Newf("could not parse jobID: %s", err)
+	}
+
+	end = compactionEnd{
+		jobID: jobID,
+		time:  tEnd,
+	}
+
+	// Optionally, if we have compacted bytes.
+	if matches[compactionPatternDigitIdx] != "" {
+		d, e := strconv.ParseFloat(matches[compactionPatternDigitIdx], 64)
+		if e != nil {
+			return end, errors.Newf("could not parse compacted bytes digit: %s", e)
+		}
+		end.compactedBytes = unHumanize(d, matches[compactionPatternUnitIdx])
+	}
+
+	return end, nil
+}
+
+// parseFlushStart converts the given regular expression sub-matches for a
+// memtable flush start log line into a compactionStart event.
+func parseFlushStart(matches []string) (compactionStart, error) {
+	var start compactionStart
+
+	// Parse start time.
+	tStart, err := time.Parse(timeFmt, matches[flushPatternTimestampIdx])
+	if err != nil {
+		return start, errors.Newf("could not parse start time: %s", err)
+	}
+
+	// Parse job ID.
+	jobID, err := strconv.Atoi(matches[flushPatternJobIdx])
+	if err != nil {
+		return start, errors.Newf("could not parse jobID: %s", err)
+	}
+
+	c := compactionStart{
+		jobID:     jobID,
+		cType:     compactionTypeFlush,
+		time:      tStart,
+		fromLevel: -1,
+		toLevel:   0,
+	}
+	return c, nil
+}
+
+// parseFlushEnd converts the given regular expression sub-matches for a
+// memtable flush end log line into a compactionEnd event.
+func parseFlushEnd(matches []string) (compactionEnd, error) {
+	var end compactionEnd
+
+	// Parse end time.
+	tEnd, err := time.Parse(timeFmt, matches[flushPatternTimestampIdx])
+	if err != nil {
+		return end, errors.Newf("could not parse start time: %s", err)
+	}
+
+	// Parse job ID.
+	jobID, err := strconv.Atoi(matches[flushPatternJobIdx])
+	if err != nil {
+		return end, errors.Newf("could not parse jobID: %s", err)
+	}
+
+	end = compactionEnd{
+		jobID: jobID,
+		time:  tEnd,
+	}
+
+	// Optionally, if we have flushed bytes.
+	if matches[flushPatternDigitIdx] != "" {
+		d, e := strconv.ParseFloat(matches[flushPatternDigitIdx], 64)
+		if e != nil {
+			return end, errors.Newf("could not parse flushed bytes digit: %s", e)
+		}
+		end.compactedBytes = unHumanize(d, matches[flushPatternUnitIdx])
+	}
+
+	return end, nil
+}
+
+// compaction represents an aggregated compaction event (i.e. the combination of
+// a start and end event).
+type compaction struct {
+	jobID          int
+	cType          compactionType
+	timeStart      time.Time
+	timeEnd        time.Time
+	fromLevel      int
+	toLevel        int
+	compactedBytes uint64
+}
+
+// readAmp represents a read-amp event.
+type readAmp struct {
+	time    time.Time
+	readAmp int
+}
+
+// logEventCollector keeps track of open compaction events and read-amp events
+// over the course of parsing log line events. Completed compaction events are
+// added to the collector once a matching start and end pair are encountered.
+// Read-amp events are added as they are encountered (the have no start / end
+// concept).
+type logEventCollector struct {
+	m           map[int]compactionStart
+	compactions []compaction
+	readAmps    []readAmp
+}
+
+// newEventCollector instantiates a new logEventCollector.
+func newEventCollector() *logEventCollector {
+	return &logEventCollector{
+		m: make(map[int]compactionStart),
+	}
+}
+
+// addCompactionStart adds a new compactionStart to the collector. The event is
+// tracked by its job ID.
+func (c *logEventCollector) addCompactionStart(start compactionStart) error {
+	if _, ok := c.m[start.jobID]; ok {
+		return errors.Newf("start event already seen for job %d", start.jobID)
+	}
+	c.m[start.jobID] = start
+	return nil
+}
+
+// addCompactionEnd completes the compaction event for the for the given
+// compactionEnd.
+func (c *logEventCollector) addCompactionEnd(end compactionEnd) {
+	start, ok := c.m[end.jobID]
+	if !ok {
+		_, _ = fmt.Fprintf(
+			os.Stderr,
+			"compaction end event missing start event for job ID %d; skipping", end.jobID)
+		return
+	}
+
+	// Remove the job from the collector once it has been matched.
+	delete(c.m, end.jobID)
+
+	c.compactions = append(c.compactions, compaction{
+		jobID:          start.jobID,
+		cType:          start.cType,
+		timeStart:      start.time,
+		timeEnd:        end.time,
+		fromLevel:      start.fromLevel,
+		toLevel:        start.toLevel,
+		compactedBytes: end.compactedBytes,
+	})
+}
+
+// addReadAmp adds the readAmp event to the collector.
+func (c *logEventCollector) addReadAmp(time time.Time, val int) {
+	c.readAmps = append(c.readAmps, readAmp{
+		time:    time,
+		readAmp: val,
+	})
+}
+
+// level is a level in the LSM. The WAL is level -1.
+type level int
+
+// String implements fmt.Stringer.
+func (l level) String() string {
+	if l == -1 {
+		return "WAL"
+	}
+	return "L" + strconv.Itoa(int(l))
+}
+
+// fromTo is a map key for (from, to) level tuples.
+type fromTo struct {
+	from, to level
+}
+
+// compactionTypeCount is a mapping from compaction type to count.
+type compactionTypeCount map[compactionType]int
+
+// windowSummary summarizes events in a window of time between a start and end
+// time. The window tracks:
+// - for each compaction type: counts, total bytes compacted, and total duration.
+// - read amp magnitudes
+type windowSummary struct {
+	tStart, tEnd     time.Time
+	eventCount       int
+	compactionCounts map[fromTo]compactionTypeCount
+	compactionBytes  map[fromTo]uint64
+	compactionTime   map[fromTo]time.Duration
+	readAmps         []readAmp
+	longRunning      []compaction
+}
+
+// String implements fmt.Stringer, returning a formatted window summary.
+func (s windowSummary) String() string {
+	type fromToCount struct {
+		ft       fromTo
+		counts   compactionTypeCount
+		bytes    uint64
+		duration time.Duration
+	}
+	var pairs []fromToCount
+	for k, v := range s.compactionCounts {
+		pairs = append(pairs, fromToCount{
+			ft:       k,
+			counts:   v,
+			bytes:    s.compactionBytes[k],
+			duration: s.compactionTime[k],
+		})
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		l, r := pairs[i], pairs[j]
+		if l.ft.from == r.ft.from {
+			return l.ft.to < r.ft.to
+		}
+		return l.ft.from < r.ft.from
+	})
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("from: %s\n", s.tStart.Format(timeFmtSlim)))
+	sb.WriteString(fmt.Sprintf("  to: %s\n", s.tEnd.Format(timeFmtSlim)))
+	sb.WriteString("______from________to___default______move_____elide____delete_____flush_____total_____bytes______time\n")
+
+	var totalDef, totalMove, totalElision, totalDel, totalFlush int
+	var totalBytes uint64
+	var totalTime time.Duration
+	for _, p := range pairs {
+		def := p.counts[compactionTypeDefault]
+		move := p.counts[compactionTypeMove]
+		elision := p.counts[compactionTypeElisionOnly]
+		del := p.counts[compactionTypeDeleteOnly]
+		flush := p.counts[compactionTypeFlush]
+		total := def + move + elision + del + flush
+
+		str := fmt.Sprintf("%10s %9s %9d %9d %9d %9d %9d %9d %9s %9s\n",
+			p.ft.from, p.ft.to, def, move, elision, del, flush, total,
+			humanize.Uint64(p.bytes), p.duration.Truncate(time.Second))
+		sb.WriteString(str)
+
+		totalDef += def
+		totalMove += move
+		totalElision += elision
+		totalDel += del
+		totalFlush += flush
+		totalBytes += p.bytes
+		totalTime += p.duration
+	}
+
+	var count, sum int
+	for _, ra := range s.readAmps {
+		count++
+		sum += ra.readAmp
+	}
+	sb.WriteString(fmt.Sprintf("     total %19d %9d %9d %9d %9d %9d %9s %9s\n",
+		totalDef, totalMove, totalElision, totalDel, totalFlush, s.eventCount,
+		humanize.Uint64(totalBytes), totalTime.Truncate(time.Minute)))
+	sb.WriteString(fmt.Sprintf("     r-amp%10.1f\n", float64(sum)/float64(count)))
+
+	// (Optional) Long running compactions.
+	if len(s.longRunning) > 0 {
+		sb.WriteString("\nlong-running compactions (descending runtime):\n")
+		sb.WriteString("______from________to_______job______type_____start_______end____dur(s)_____bytes:\n")
+		for _, e := range s.longRunning {
+			sb.WriteString(fmt.Sprintf("%10s %9s %9d %9s %9s %9s %9.0f %9s\n",
+				level(e.fromLevel), level(e.toLevel), e.jobID, e.cType,
+				e.timeStart.Format(timeFmtHrMinSec), e.timeEnd.Format(timeFmtHrMinSec),
+				e.timeEnd.Sub(e.timeStart).Seconds(), humanize.Uint64(e.compactedBytes)))
+		}
+	}
+
+	return sb.String()
+}
+
+// aggregator combines compaction and read-amp events within windows of fixed
+// duration and returns one aggregated windowSummary struct per window.
+type aggregator struct {
+	window           time.Duration
+	compactions      []compaction
+	readAmps         []readAmp
+	longRunningLimit time.Duration
+}
+
+// newAggregator returns a new aggregator.
+func newAggregator(
+	window, longRunningLimit time.Duration,
+	compactions []compaction,
+	readAmps []readAmp,
+) *aggregator {
+	return &aggregator{
+		window:           window,
+		compactions:      compactions,
+		readAmps:         readAmps,
+		longRunningLimit: longRunningLimit,
+	}
+}
+
+// aggregate aggregates the events into windows, returning the windowSummary for
+// each interval.
+func (a *aggregator) aggregate() []windowSummary {
+	if len(a.compactions) == 0 {
+		return nil
+	}
+
+	// Sort the compaction and read-amp slices by start time.
+	sort.Slice(a.compactions, func(i, j int) bool {
+		return a.compactions[i].timeStart.Before(a.compactions[j].timeEnd)
+	})
+	sort.Slice(a.readAmps, func(i, j int) bool {
+		return a.readAmps[i].time.Before(a.readAmps[j].time)
+	})
+
+	newWindow := func(start, end time.Time) windowSummary {
+		return windowSummary{
+			tStart:           start,
+			tEnd:             end,
+			compactionCounts: make(map[fromTo]compactionTypeCount),
+			compactionBytes:  make(map[fromTo]uint64),
+			compactionTime:   make(map[fromTo]time.Duration),
+		}
+	}
+	var windows []windowSummary
+	windowStart := a.compactions[0].timeStart.Truncate(a.window)
+	windowEnd := windowStart.Add(a.window)
+	curWindow := newWindow(windowStart, windowEnd)
+
+	var j int // index for read-amps
+	for i, e := range a.compactions {
+		// Update compaction counts.
+		ft := fromTo{level(e.fromLevel), level(e.toLevel)}
+		m, ok := curWindow.compactionCounts[ft]
+		if !ok {
+			m = make(compactionTypeCount)
+			curWindow.compactionCounts[ft] = m
+		}
+		m[e.cType]++
+		curWindow.eventCount++
+
+		// Update compacted bytes.
+		_, ok = curWindow.compactionBytes[ft]
+		if !ok {
+			curWindow.compactionBytes[ft] = 0
+		}
+		curWindow.compactionBytes[ft] += e.compactedBytes
+
+		// Update compaction time.
+		_, ok = curWindow.compactionTime[ft]
+		if !ok {
+			curWindow.compactionTime[ft] = 0
+		}
+		curWindow.compactionTime[ft] += e.timeEnd.Sub(e.timeStart)
+
+		// Add "long-running" compactions. Those that start in this window that have
+		// duration longer than the window interval.
+		if e.timeEnd.Sub(e.timeStart) > a.longRunningLimit {
+			curWindow.longRunning = append(curWindow.longRunning, e)
+		}
+
+		// If we're at the end of an interval, finalize the current window and start
+		// a new one.
+		if i == len(a.compactions)-1 || a.compactions[i+1].timeStart.After(windowEnd) {
+			// Collect read-amp values for the current window.
+			var readAmps []readAmp
+			for j < len(a.readAmps) {
+				ra := a.readAmps[j]
+
+				// Skip values before the current window.
+				if ra.time.Before(windowStart) {
+					j++
+					continue
+				}
+
+				// We've passed over the current window. Stop here.
+				if ra.time.After(windowEnd) {
+					break
+				}
+
+				// Collect this read-amp value.
+				readAmps = append(readAmps, ra)
+				j++
+			}
+			curWindow.readAmps = readAmps
+
+			// Sort long running compactions in descending order of duration.
+			sort.Slice(curWindow.longRunning, func(i, j int) bool {
+				l := curWindow.longRunning[i]
+				r := curWindow.longRunning[j]
+				return l.timeEnd.Sub(l.timeStart) > r.timeEnd.Sub(r.timeStart)
+			})
+
+			// Add the completed window to the set of windows.
+			windows = append(windows, curWindow)
+
+			// Start a new window.
+			windowStart = windowStart.Add(a.window)
+			windowEnd = windowEnd.Add(a.window)
+			curWindow = newWindow(windowStart, windowEnd)
+		}
+	}
+
+	return windows
+}
+
+type parseFn func(string, *logEventCollector) error
+
+// parseLog parses the log file with the given path, using the given parse
+// function to collect events in the given logEventCollector.
+func parseLog(path string, b *logEventCollector, parseFn parseFn) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		if err := parseFn(s.Text(), b); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// parseCompaction is a parseFn that parses parses and collects Pebble
+// compaction events.
+func parseCompaction(line string, b *logEventCollector) error {
+	matches := compactionPattern.FindStringSubmatch(line)
+	if matches == nil {
+		return nil
+	}
+
+	if len(matches) != 9 {
+		return errors.Newf(
+			"could not parse compaction start / end line; found %d matches: %s",
+			len(matches), line)
+	}
+
+	// "compacting": implies start line.
+	if matches[compactionPatternSuffixIdx] == "ing" {
+		start, err := parseCompactionStart(matches)
+		if err != nil {
+			return err
+		}
+		if err := b.addCompactionStart(start); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// "compacted": implies end line.
+	end, err := parseCompactionEnd(matches)
+	if err != nil {
+		return err
+	}
+
+	b.addCompactionEnd(end)
+	return nil
+}
+
+// parseFlush is a parseFn that parses parses and collects Pebble memtable flush
+// events.
+func parseFlush(line string, b *logEventCollector) error {
+	matches := flushPattern.FindStringSubmatch(line)
+	if matches == nil {
+		return nil
+	}
+
+	if len(matches) != 6 {
+		return errors.Newf(
+			"could not parse flush start / end line; found %d matches: %s",
+			len(matches), line)
+	}
+
+	if matches[flushPatternSuffixIdx] == "ing" {
+		start, err := parseFlushStart(matches)
+		if err != nil {
+			return err
+		}
+		return b.addCompactionStart(start)
+	}
+
+	end, err := parseFlushEnd(matches)
+	if err != nil {
+		return err
+	}
+
+	b.addCompactionEnd(end)
+	return nil
+}
+
+// parsePebbleFn is a parseFn that parses parses and collects Pebble log lines
+// into compaction events.
+func parsePebbleFn(line string, b *logEventCollector) error {
+	matches := sentinelPattern.FindStringSubmatch(line)
+	if matches == nil {
+		return nil
+	}
+
+	// Determine which regexp to apply by testing the first letter of the prefix.
+	switch matches[sentinelPatternPrefixIdx][0] {
+	case 'c':
+		return parseCompaction(line, b)
+	case 'f':
+		return parseFlush(line, b)
+	default:
+		return errors.Newf("unexpected line: neither compaction nor flush: %s", line)
+	}
+}
+
+// parsePebbleFn is a parseFn that parses parses and collects Cockroach log
+// lines into read-amp events.
+func parseCockroachFn(line string, b *logEventCollector) error {
+	matches := readAmpPattern.FindStringSubmatch(line)
+	if matches == nil {
+		return nil
+	}
+
+	// Parse start time.
+	t, err := time.Parse(timeFmt, matches[readAmpPatternTimestampIdx])
+	if err != nil {
+		return errors.Newf("could not parse start time: %s", err)
+	}
+
+	// Parse read-amp.
+	ra, err := strconv.Atoi(matches[readAmpPatternValueIdx])
+	if err != nil {
+		return errors.Newf("could not parse read-amp: %s", err)
+	}
+
+	b.addReadAmp(t, ra)
+	return nil
+}
+
+// runCompactionLogs is runnable function of the top-level cobra.Command that
+// parses and collects Pebble compaction events and LSM information.
+func runCompactionLogs(cmd *cobra.Command, args []string) error {
+	// The args contain a list of log files to read.
+	files := args
+
+	// Scan the log files collecting start and end compaction lines.
+	b := newEventCollector()
+	for _, file := range files {
+		// If the filename contains 'cockroach-pebble', parse as a Pebble log file.
+		if strings.HasPrefix(filepath.Base(file), pebbleLogPrefix) {
+			err := parseLog(file, b, parsePebbleFn)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		// Otherwise parse as a DB log.
+		if err := parseLog(file, b, parseCockroachFn); err != nil {
+			return err
+		}
+	}
+
+	window, err := cmd.Flags().GetDuration("window")
+	if err != nil {
+		return err
+	}
+
+	longRunningLimit, err := cmd.Flags().GetDuration("long-running-limit")
+	if err != nil {
+		return err
+	}
+	if longRunningLimit == 0 {
+		// Off by default. Set to infinite duration.
+		longRunningLimit = time.Duration(math.MaxInt64)
+	}
+
+	// Aggregate the lines.
+	a := newAggregator(window, longRunningLimit, b.compactions, b.readAmps)
+	summaries := a.aggregate()
+	for _, s := range summaries {
+		fmt.Printf("%s\n", s)
+	}
+
+	return nil
+}
+
+// unHumanize performs the opposite of humanize.Uint64, converting a
+// human-readable digit and unit into a raw number of bytes.
+func unHumanize(d float64, u string) uint64 {
+	if u == "" {
+		return uint64(d)
+	}
+
+	multiplier := uint64(1)
+	switch u {
+	case "B":
+		// no-op: treat as regular bytes.
+	case "K":
+		multiplier = 1 << 10
+	case "M":
+		multiplier = 1 << 20
+	case "G":
+		multiplier = 1 << 30
+	case "T":
+		multiplier = 1 << 40
+	case "P":
+		multiplier = 1 << 50
+	case "E":
+		multiplier = 1 << 60
+	default:
+		panic(errors.Newf("unknown unit %q", u))
+	}
+
+	return uint64(d) * multiplier
+}

--- a/tool/logs/compaction_test.go
+++ b/tool/logs/compaction_test.go
@@ -1,0 +1,139 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package logs
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	compactionStartLine = `I211215 14:26:56.012382 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n5,pebble,s5] 1216510  [JOB 284925] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)`
+	compactionEndLine   = `I211215 14:26:56.318543 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n5,pebble,s5] 1216554  [JOB 284925] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s`
+	flushStartLine      = `I211213 16:23:48.903751 21136 3@vendor/github.com/cockroachdb/pebble/event.go:599 ⋮ [n9,pebble,s9] 24 [JOB 10] flushing 2 memtables to L0`
+	flushEndLine        = `I211213 16:23:49.134464 21136 3@vendor/github.com/cockroachdb/pebble/event.go:603 ⋮ [n9,pebble,s9] 26 [JOB 10] flushed 2 memtables to L0 [1535806] (1.3 M), in 0.2s, output rate 5.8 M/s`
+	readAmpLine         = `I211215 14:55:15.802648 155 kv/kvserver/store.go:2668 ⋮ [n5,s5] 109057 +  total     44905   672 G       -   1.2 T   714 G   118 K   215 G    34 K   4.0 T   379 K   2.8 T     514     3.4`
+)
+
+func TestCompactionLogs_Regex(t *testing.T) {
+	tcs := []struct {
+		name    string
+		re      *regexp.Regexp
+		line    string
+		matches map[int]string
+	}{
+		{
+			name: "compaction start - sentinel",
+			re:   sentinelPattern,
+			line: compactionStartLine,
+			matches: map[int]string{
+				sentinelPatternPrefixIdx: "compact",
+				sentinelPatternSuffixIdx: "ing",
+			},
+		},
+		{
+			name: "compaction end - sentinel",
+			re:   sentinelPattern,
+			line: compactionEndLine,
+			matches: map[int]string{
+				sentinelPatternPrefixIdx: "compact",
+				sentinelPatternSuffixIdx: "ed",
+			},
+		},
+		{
+			name: "flush start - sentinel",
+			re:   sentinelPattern,
+			line: flushStartLine,
+			matches: map[int]string{
+				sentinelPatternPrefixIdx: "flush",
+				sentinelPatternSuffixIdx: "ing",
+			},
+		},
+		{
+			name: "flush end - sentinel",
+			re:   sentinelPattern,
+			line: flushEndLine,
+			matches: map[int]string{
+				sentinelPatternPrefixIdx: "flush",
+				sentinelPatternSuffixIdx: "ed",
+			},
+		},
+		{
+			name: "compaction start",
+			re:   compactionPattern,
+			line: compactionStartLine,
+			matches: map[int]string{
+				compactionPatternTimestampIdx: "211215 14:26:56.012382",
+				compactionPatternJobIdx:       "284925",
+				compactionPatternSuffixIdx:    "ing",
+				compactionPatternTypeIdx:      "default",
+				compactionPatternFromIdx:      "2",
+				compactionPatternToIdx:        "3",
+				compactionPatternDigitIdx:     "8.4",
+				compactionPatternUnitIdx:      "M",
+			},
+		},
+		{
+			name: "compaction end",
+			re:   compactionPattern,
+			line: compactionEndLine,
+			matches: map[int]string{
+				compactionPatternTimestampIdx: "211215 14:26:56.318543",
+				compactionPatternJobIdx:       "284925",
+				compactionPatternSuffixIdx:    "ed",
+				compactionPatternTypeIdx:      "default",
+				compactionPatternFromIdx:      "2",
+				compactionPatternToIdx:        "3",
+				compactionPatternDigitIdx:     "13",
+				compactionPatternUnitIdx:      "M",
+			},
+		},
+		{
+			name: "flush start",
+			re:   flushPattern,
+			line: flushStartLine,
+			matches: map[int]string{
+				flushPatternTimestampIdx: "211213 16:23:48.903751",
+				flushPatternJobIdx:       "10",
+				flushPatternSuffixIdx:    "ing",
+				flushPatternDigitIdx:     "",
+				flushPatternUnitIdx:      "",
+			},
+		},
+		{
+			name: "flush end",
+			re:   flushPattern,
+			line: flushEndLine,
+			matches: map[int]string{
+				flushPatternTimestampIdx: "211213 16:23:49.134464",
+				flushPatternJobIdx:       "10",
+				flushPatternSuffixIdx:    "ed",
+				flushPatternDigitIdx:     "1.3",
+				flushPatternUnitIdx:      "M",
+			},
+		},
+		{
+			name: "read amp",
+			re:   readAmpPattern,
+			line: readAmpLine,
+			matches: map[int]string{
+				readAmpPatternTimestampIdx: "211215 14:55:15.802648",
+				readAmpPatternValueIdx:     "514",
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			matches := tc.re.FindStringSubmatch(tc.line)
+			require.NotNil(t, matches)
+			for idx, want := range tc.matches {
+				require.Equal(t, want, matches[idx])
+			}
+		})
+	}
+}

--- a/tool/logs/tool.go
+++ b/tool/logs/tool.go
@@ -1,0 +1,32 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package logs
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCmd returns a new cobra.Command for parsing logs.
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "logs",
+		Short: "Scan and summarize logs",
+	}
+
+	compactionCmd := &cobra.Command{
+		Use:   "compactions",
+		Short: "Scan and summarize compaction logs",
+		RunE:  runCompactionLogs,
+	}
+	compactionCmd.Flags().Duration(
+		"window", 10*time.Minute, "time window in which to aggregate compactions")
+	compactionCmd.Flags().Duration(
+		"long-running-limit", 0, "log compactions with runtime greater than the limit")
+
+	cmd.AddCommand(compactionCmd)
+	return cmd
+}


### PR DESCRIPTION
Add a tool that summarizes compaction events within fixed fixed windows
of time from a collection of Pebble and Cockroach log files. Each window
summary dispays the count of compactions between pairs of levels,
grouped by compaction type. The average read-amp value for the window is
also printed.

For example, a sample window summary:

```
$ pebble db compactions --long-running-limit 1m ./cockroach*.log
... snip ...
from: 211215 14:20
  to: 211215 14:30
______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
       WAL        L0         0         0         0         0      1277      1277      17 G     6m48s
        L0        L0         2         0         0         0         0         2     401 M        6s
        L0        L2       122         1         0         0         0       123      38 G    23m14s
        L2        L2         0         0         0         1         0         1       0 B        0s
        L2        L3       874        24         0         0         0       898      11 G     5m14s
        L3        L3         0         0         0         2         0         2       0 B        0s
        L3        L4       140         4         0         0         0       144     2.9 G     1m22s
        L4        L4         0         0         0         1         0         1       0 B        0s
        L5        L5         0         0         0         4         0         4       0 B        0s
        L6        L6         0         0         0         7         0         7       0 B        0s
     total                1138        29         0        15      1277      2459      70 G     36m0s
     r-amp     312.0

from: 211215 14:30
  to: 211215 14:40
______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
       WAL        L0         0         0         0         0       967       967      13 G      6m6s
        L0        L0         1         0         0         0         0         1     181 M        2s
        L0        L2       112         0         0         0         0       112      40 G    24m25s
        L2        L2         0         0         0         3         0         3       0 B        0s
        L2        L3       625        62         0         0         0       687     7.0 G      3m9s
        L3        L3         0         0         0         2         0         2       0 B        0s
        L3        L4       151        13         0         0         0       164     3.4 G     1m36s
        L5        L5         0         0         0         6         0         6       0 B        0s
        L6        L6         0         0         0         3         0         3       0 B        0s
     total                 889        75         0        14       967      1945      64 G     35m0s
     r-amp     483.0

long-running compactions:
______from________to_______job______type_______duration:
        L0        L2    289303   default   1m32.622376s
        L0        L2    290260   default     1m4.85556s
... snip ...
```

This tool is useful for investigating where compaction time is spent in
various time intervals.