### PR TITLE
internal/rangekey: configure Coalescer to drop spans not visible

### DIFF
--- a/internal/rangekey/interleaving_iter_test.go
+++ b/internal/rangekey/interleaving_iter_test.go
@@ -57,7 +57,7 @@ func TestInterleavingIter(t *testing.T) {
 					Value: v,
 				})
 			}
-			rangeKeyIter.Init(cmp, testkeys.Comparer.FormatKey, keyspan.NewIter(cmp, spans))
+			rangeKeyIter.Init(cmp, testkeys.Comparer.FormatKey, base.InternalKeySeqNumMax, keyspan.NewIter(cmp, spans))
 			iter.Init(&pointIter, &rangeKeyIter)
 			return "OK"
 		case "define-pointkeys":

--- a/internal/rangekey/iter.go
+++ b/internal/rangekey/iter.go
@@ -33,11 +33,11 @@ type Iter struct {
 }
 
 // Init initializes an iterator over a set of fragmented, coalesced spans.
-func (i *Iter) Init(cmp base.Compare, formatKey base.FormatKey, iter *keyspan.Iter) {
+func (i *Iter) Init(cmp base.Compare, formatKey base.FormatKey, visibleSeqNum uint64, iter *keyspan.Iter) {
 	*i = Iter{
 		iter: iter,
 	}
-	i.coalescer.Init(cmp, formatKey, func(span CoalescedSpan) {
+	i.coalescer.Init(cmp, formatKey, visibleSeqNum, func(span CoalescedSpan) {
 		i.curr = span
 	})
 }

--- a/internal/rangekey/testdata/coalescer
+++ b/internal/rangekey/testdata/coalescer
@@ -295,3 +295,32 @@ finish
 ----
 ●   [a, c)#5 (DEL)
 └── @5 : foo
+
+# Test coalescer filterrs out fragments that aren't visible at the specified
+# visible seqnum.
+
+set-visible-seqnum 10
+----
+OK
+
+add
+a.RANGEKEYSET.20  : c [(@20=foo5)]
+a.RANGEKEYSET.10  : c [(@10=foo5)]
+a.RANGEKEYSET.5   : c [(@5=foo5)]
+----
+
+finish
+----
+●   [a, c)#5
+└── @5 : foo5
+
+add-reverse
+a.RANGEKEYSET.5   : c [(@5=foo5)]
+a.RANGEKEYSET.10  : c [(@10=foo5)]
+a.RANGEKEYSET.20  : c [(@20=foo5)]
+----
+
+finish
+----
+●   [a, c)#5
+└── @5 : foo5


### PR DESCRIPTION
Allow the rangekey.Coalescer type to be configured with a visible sequence
number. If a span is added to the coalescer that must not be visible to reads
at the configured sequence number, then the coalescer drops the span.