### PR TITLE
sstable: add data-driven test for block property collectors

### DIFF
--- a/sstable/testdata/block_properties
+++ b/sstable/testdata/block_properties
@@ -1,0 +1,104 @@
+# Two collectors are available:
+# - value-first - uses the first character of the value to construct an interval
+# - value-last - uses the last character of the value to construct an interval
+
+# Single collector.
+
+build collector=value-first
+a.SET.1:10
+b.SET.2:20
+c.SET.3:30
+----
+point:    [a#1,1,c#3,1]
+rangedel: [#0,0,#0,0]
+rangekey: [#0,0,#0,0]
+seqnums:  [1,3]
+
+# collectors returns the collectors used when writing the table, keyed by the
+# shortID of the collector.
+collectors
+----
+0: value-first
+
+# table-props returns the table-level properties, keyed by the shortID.
+table-props
+----
+0: [1, 3]
+
+# block-props returns the block-level properties. For each block, the separator
+# is printed, along with the properties for the block, keyed by the shortID.
+block-props
+----
+d#72057594037927935,17:
+  0: [1, 3]
+
+# Multiple collectors.
+
+build collector=value-first collector=value-last
+a.SET.1:17
+b.SET.2:29
+c.SET.3:38
+----
+point:    [a#1,1,c#3,1]
+rangedel: [#0,0,#0,0]
+rangekey: [#0,0,#0,0]
+seqnums:  [1,3]
+
+collectors
+----
+0: value-first
+1: value-last
+
+table-props
+----
+0: [1, 3]
+1: [7, 9]
+
+block-props
+----
+d#72057594037927935,17:
+  0: [1, 3]
+  1: [7, 9]
+
+# Reduce the block size to a value such that each block has at most two KV
+# pairs.
+
+build block-size=25 collector=value-first collector=value-last
+a.SET.1:15
+b.SET.2:86
+c.SET.3:72
+d.SET.4:21
+e.SET.5:47
+f.SET.6:54
+g.SET.7:63
+h.SET.8:38
+----
+point:    [a#1,1,h#8,1]
+rangedel: [#0,0,#0,0]
+rangekey: [#0,0,#0,0]
+seqnums:  [1,8]
+
+collectors
+----
+0: value-first
+1: value-last
+
+table-props
+----
+0: [1, 8]
+1: [1, 8]
+
+block-props
+----
+b#2,1:
+  0: [1, 8]
+  1: [5, 6]
+d#4,1:
+  0: [2, 7]
+  1: [1, 2]
+f#6,1:
+  0: [4, 5]
+  1: [4, 7]
+i#72057594037927935,17:
+  0: [3, 6]
+  1: [3, 8]


### PR DESCRIPTION
Add a data-driven test to demonstrate the creation of a sstable with one
or more interval collectors. The test prints out the table- and
block-level properties, as written to the index block of the sstable.