### PR TITLE
sstable: use exclusive upper bounds in valueCharBlockIntervalCollector

### DIFF
--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -747,8 +747,8 @@ func TestBlockPropertiesFilterer_Intersects(t *testing.T) {
 }
 
 // valueCharBlockIntervalCollector implements DataBlockIntervalCollector by
-// maintaining the lower and upped bound of a fixed character position in the
-// value, when represented as an integer.
+// maintaining the (inclusive) lower and (exclusive) upper bound of a fixed
+// character position in the value, when represented as an integer.
 type valueCharBlockIntervalCollector struct {
 	charIdx      int
 	initialized  bool
@@ -770,15 +770,15 @@ func (c *valueCharBlockIntervalCollector) Add(_ InternalKey, value []byte) error
 	}
 	uval := uint64(val)
 	if !c.initialized {
-		c.lower, c.upper = uval, uval
+		c.lower, c.upper = uval, uval+1
 		c.initialized = true
 		return nil
 	}
 	if uval < c.lower {
 		c.lower = uval
 	}
-	if uval > c.upper {
-		c.upper = uval
+	if uval >= c.upper {
+		c.upper = uval + 1
 	}
 
 	return nil
@@ -869,7 +869,7 @@ func TestBlockProperties(t *testing.T) {
 				if err := i.decode([]byte(val[1:])); err != nil {
 					return err.Error()
 				}
-				lines = append(lines, fmt.Sprintf("%d: [%d, %d]", id, i.lower, i.upper))
+				lines = append(lines, fmt.Sprintf("%d: [%d, %d)", id, i.lower, i.upper))
 			}
 			linesSorted := sort.StringSlice(lines)
 			linesSorted.Sort()
@@ -903,7 +903,7 @@ func TestBlockProperties(t *testing.T) {
 					if err := i.decode(prop); err != nil {
 						return err.Error()
 					}
-					lines = append(lines, fmt.Sprintf("  %d: [%d, %d]\n", id, i.lower, i.upper))
+					lines = append(lines, fmt.Sprintf("  %d: [%d, %d)\n", id, i.lower, i.upper))
 				}
 				linesSorted := sort.StringSlice(lines)
 				linesSorted.Sort()

--- a/sstable/testdata/block_properties
+++ b/sstable/testdata/block_properties
@@ -23,14 +23,14 @@ collectors
 # table-props returns the table-level properties, keyed by the shortID.
 table-props
 ----
-0: [1, 3]
+0: [1, 4)
 
 # block-props returns the block-level properties. For each block, the separator
 # is printed, along with the properties for the block, keyed by the shortID.
 block-props
 ----
 d#72057594037927935,17:
-  0: [1, 3]
+  0: [1, 4)
 
 # Multiple collectors.
 
@@ -51,14 +51,14 @@ collectors
 
 table-props
 ----
-0: [1, 3]
-1: [7, 9]
+0: [1, 4)
+1: [7, 10)
 
 block-props
 ----
 d#72057594037927935,17:
-  0: [1, 3]
-  1: [7, 9]
+  0: [1, 4)
+  1: [7, 10)
 
 # Reduce the block size to a value such that each block has at most two KV
 # pairs.
@@ -85,20 +85,20 @@ collectors
 
 table-props
 ----
-0: [1, 8]
-1: [1, 8]
+0: [1, 9)
+1: [1, 9)
 
 block-props
 ----
 b#2,1:
-  0: [1, 8]
-  1: [5, 6]
+  0: [1, 9)
+  1: [5, 7)
 d#4,1:
-  0: [2, 7]
-  1: [1, 2]
+  0: [2, 8)
+  1: [1, 3)
 f#6,1:
-  0: [4, 5]
-  1: [4, 7]
+  0: [4, 6)
+  1: [4, 8)
 i#72057594037927935,17:
-  0: [3, 6]
-  1: [3, 8]
+  0: [3, 7)
+  1: [3, 9)


### PR DESCRIPTION
A `DataBlockIntervalCollector` implementation should return an exclusive
upper bound from calls to `FinishDataBlock`.

Update the `valueCharBlockIntervalCollector` test implementation to
maintain an exclusive upper bound.

Update data-driven test print intervals of the form `[from, to)` (i.e.
exclusive upper bound).

Closes #1423.