### PR TITLE
internal/rangekey: implement range-key masking

### DIFF
--- a/internal/rangekey/coalescer.go
+++ b/internal/rangekey/coalescer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 )
 
@@ -26,6 +27,27 @@ type CoalescedSpan struct {
 	// Delete is true if a RANGEKEYDEL covering this user key span was coalesced
 	// into this span.
 	Delete bool
+}
+
+// SmallestSetSuffix returns the smallest suffix of an actively set range key
+// (excluding suffixes that are unset or deleted), that's also greater than or
+// equal to (as defined by cmp) than the suffixThreshold argument.
+// SmallestSetSuffix returns nil if suffixThreshold is nil.
+func (s *CoalescedSpan) SmallestSetSuffix(cmp base.Compare, suffixThreshold []byte) []byte {
+	if suffixThreshold == nil {
+		return nil
+	}
+	// NB: s.Items is sorted in ascending order, so return the first matching
+	// suffix.
+	for i := range s.Items {
+		if invariants.Enabled && i > 0 && cmp(s.Items[i-1].Suffix, s.Items[i].Suffix) >= 0 {
+			panic("pebble: invariant violation: coalesced span's suffixes out-of-order")
+		}
+		if !s.Items[i].Unset && cmp(s.Items[i].Suffix, suffixThreshold) >= 0 {
+			return s.Items[i].Suffix
+		}
+	}
+	return nil
 }
 
 // HasSets returns true if the coalesced span contains any Sets. When several

--- a/internal/rangekey/coalescer_test.go
+++ b/internal/rangekey/coalescer_test.go
@@ -52,6 +52,48 @@ func TestHasSets(t *testing.T) {
 	}
 }
 
+func TestSmallestSetSuffix(t *testing.T) {
+	testCases := []struct {
+		span      *CoalescedSpan
+		threshold []byte
+		want      []byte
+	}{
+		{
+			span:      &CoalescedSpan{Items: []SuffixItem{{Suffix: []byte("foo")}}},
+			threshold: []byte("apple"),
+			want:      []byte("foo"),
+		},
+		{
+			span:      &CoalescedSpan{Items: []SuffixItem{{Suffix: []byte("foo")}}},
+			threshold: []byte("xyz"),
+			want:      nil,
+		},
+		{
+			span:      &CoalescedSpan{Items: []SuffixItem{{Suffix: []byte("foo")}}},
+			threshold: []byte("foo"),
+			want:      []byte("foo"),
+		},
+		{
+			span: &CoalescedSpan{Items: []SuffixItem{
+				{Suffix: []byte("ace")},
+				{Suffix: []byte("bar"), Unset: true},
+				{Suffix: []byte("foo")},
+			}},
+			threshold: []byte("apple"),
+			want:      []byte("foo"),
+		},
+	}
+	for _, tc := range testCases {
+		got := tc.span.SmallestSetSuffix(base.DefaultComparer.Compare, tc.threshold)
+		if !bytes.Equal(got, tc.want) {
+			var buf bytes.Buffer
+			formatRangeKeySpan(&buf, tc.span)
+			t.Errorf("%s.SmallestSetSuffix(%q) = %q, want %q",
+				buf.String(), tc.threshold, got, tc.want)
+		}
+	}
+}
+
 func TestCoalescer(t *testing.T) {
 	var c Coalescer
 	var buf bytes.Buffer

--- a/internal/rangekey/interleaving_iter.go
+++ b/internal/rangekey/interleaving_iter.go
@@ -51,9 +51,52 @@ import (
 //
 // InterleavedIter elides range keys that do not contain any visible range keys
 // (eg, internal range key spans that contain only Unsets and Deletes).
+//
+// Masking
+//
+// An InterleavingIter may be configured to treat range keys as masks. If a
+// non-nil maskingThresholdSuffix is passed to Init, masking is enabled. Masking
+// hides point keys, transparently skipping over the keys. Whether or not a
+// point key is masked is determined by comparing the point key's suffix, the
+// overlapping range keys' suffixes, and the maskingTreshresholdSuffix. When
+// configured with a range-key masking threshold _t_, and there exists a range key
+// with suffix _r_ covering a point key with suffix _p_, and
+//
+//     _t_ ≤ _r_ < _p_
+//
+// then the point key is elided. Consider the following rendering, where
+// suffixes with higher integers sort before suffixes with lower integers:
+//
+//          ^
+//       @9 |        •―――――――――――――――○ [e,m)@9
+//     s  8 |                      • l@8
+//     u  7 |------------------------------------ @7 masking
+//     f  6 |      [h,q)@6 •―――――――――――――――――○     threshold
+//     f  5 |              • h@5
+//     f  4 |                          • n@4
+//     i  3 |          •―――――――――――○ [f,l)@3
+//     x  2 |  • b@2
+//        1 |
+//        0 |___________________________________
+//           a b c d e f g h i j k l m n o p q
+//
+// An iterator scanning the entire keyspace with the masking threshold set to @7
+// will observe point keys b@2 and l@8. The range keys [h,q)@6 and [f,l)@3 serve
+// as masks, because cmp(@6,@7) ≥ 0 and cmp(@3,@7) ≥ 0. The range key [e,m)@9
+// does not serve as a mask, because cmp(@9,@7) < 0.
+//
+// Although point l@8 falls within the user key bounds of [e,m)@9, [e,m)@9 is
+// non-masking due to its suffix. The point key l@8 also falls within the user
+// key bounds of [h,q)@6, but since cmp(@6,@8) ≥ 0, l@8 is unmasked.
+//
+// All range keys, including those acting as masks, are exposed during
+// iteration.
 type InterleavingIter struct {
-	pointIter    base.InternalIterator
-	rangeKeyIter *Iter
+	split                  base.Split
+	pointIter              base.InternalIterator
+	rangeKeyIter           *Iter
+	maskingThresholdSuffix []byte
+	maskSuffix             []byte
 
 	// lower and upper hold the iteration bounds set through SetBounds.
 	lower, upper []byte
@@ -110,10 +153,22 @@ var _ base.InternalIterator = &InterleavingIter{}
 
 // Init initializes the InterleavingIter to interleave point keys from pointIter
 // with range keys from rangeKeyIter.
-func (i *InterleavingIter) Init(pointIter base.InternalIterator, rangeKeyIter *Iter) {
+//
+// If maskingThresholdSuffix is non-nil, masking of point keys by range keys is
+// enabled. Any range keys encountered with a suffix > maskingThresholdSuffix
+// will act as a mask, hiding all point keys with suffixes > the range key's
+// suffix within their user key bounds.
+func (i *InterleavingIter) Init(
+	split base.Split,
+	pointIter base.InternalIterator,
+	rangeKeyIter *Iter,
+	maskingThresholdSuffix []byte,
+) {
 	*i = InterleavingIter{
-		pointIter:    pointIter,
-		rangeKeyIter: rangeKeyIter,
+		split:                  split,
+		pointIter:              pointIter,
+		rangeKeyIter:           rangeKeyIter,
+		maskingThresholdSuffix: maskingThresholdSuffix,
 	}
 }
 
@@ -314,120 +369,174 @@ func (i *InterleavingIter) Prev() (*base.InternalKey, []byte) {
 }
 
 func (i *InterleavingIter) interleaveForward(lowerBound []byte) (*base.InternalKey, []byte) {
-	// Check invariants.
-	// INVARIANT: !pointKeyInterleaved
-	if i.pointKeyInterleaved {
-		panic("pebble: invariant violation: point key interleaved")
-	}
-	switch {
-	case i.rangeKey == nil:
-	case i.pointKey == nil:
-		// INVARIANT: rangeKey.HasSets()
-		if !i.rangeKey.HasSets() {
-			panic("pebble: invariant violation: range-key span without visible Sets")
-		}
-	default:
-		// INVARIANT: rangeKey.HasSets()
-		if !i.rangeKey.HasSets() {
-			panic("pebble: invariant violation: range-key span without visible Sets")
-		}
-		// INVARIANT: !rangeKeyInterleaved || pointKey < rangeKey.End
-		// The caller is responsible for advancing this range key if it's
-		// already been interleaved and the range key ends before the point key.
-		// Absolute positioning methods will never have already interleaved the
-		// range key, so only Next needs to handle the case where
-		// pointKey >= rangeKey.End.
-		if i.rangeKeyInterleaved && i.cmp(i.pointKey.UserKey, i.rangeKey.End) >= 0 {
-			panic("pebble: invariant violation: range key interleaved, but point key >= range key end")
-		}
-	}
-
-	// Interleave.
-	switch {
-	case i.rangeKey == nil:
-		// If we're out of range keys, just return the point key.
-		return i.yieldPointKey(false /* covered */)
-	case i.pointKey == nil:
+	// This loop determines whether a point key or a range key should be
+	// interleaved on each iteration. If masking is disabled, this loop executes
+	// for exactly one iteration. If masking is enabled and a masked key is
+	// determined to be interleaved next, this loop continues until the
+	// interleaved key is unmasked.
+	for {
+		// Check invariants.
+		// INVARIANT: !pointKeyInterleaved
 		if i.pointKeyInterleaved {
-			panic("pebble: invariant violation: point key already interleaved")
+			panic("pebble: invariant violation: point key interleaved")
 		}
-		// If we're out of point keys, we need to return a range key marker. If
-		// the current range key has already been interleaved, advance it. Since
-		// there are no more point keys, we don't need to worry about advancing
-		// past the current point key.
-		if i.rangeKeyInterleaved {
-			i.nextRangeKey(i.rangeKeyIter.Next())
-			if i.rangeKey == nil {
-				return i.yieldNil()
+		switch {
+		case i.rangeKey == nil:
+		case i.pointKey == nil:
+			// INVARIANT: rangeKey.HasSets()
+			if !i.rangeKey.HasSets() {
+				panic("pebble: invariant violation: range-key span without visible Sets")
+			}
+		default:
+			// INVARIANT: rangeKey.HasSets()
+			if !i.rangeKey.HasSets() {
+				panic("pebble: invariant violation: range-key span without visible Sets")
+			}
+			// INVARIANT: !rangeKeyInterleaved || pointKey < rangeKey.End
+			// The caller is responsible for advancing this range key if it's
+			// already been interleaved and the range key ends before the point key.
+			// Absolute positioning methods will never have already interleaved the
+			// range key, so only Next needs to handle the case where
+			// pointKey >= rangeKey.End.
+			if i.rangeKeyInterleaved && i.cmp(i.pointKey.UserKey, i.rangeKey.End) >= 0 {
+				panic("pebble: invariant violation: range key interleaved, but point key >= range key end")
 			}
 		}
-		return i.yieldSyntheticRangeKeyMarker(lowerBound)
-	default:
-		if i.cmp(i.pointKey.UserKey, i.rangeKey.Start) >= 0 {
-			// The range key starts before the point key. If we haven't
-			// interleaved it, we should.
-			if !i.rangeKeyInterleaved {
-				return i.yieldSyntheticRangeKeyMarker(lowerBound)
-			}
 
-			// Otherwise, the range key is already interleaved and we need to
-			// return the point key. The current range key necessarily must
-			// cover the point key:
-			//
-			// Since the range key's start is less than or equal to the point
-			// key, the only way for this range key to not cover the point would
-			// be if the range key's end is less than or equal to the point.
-			// (For example range key = [a, b), point key = c).
-			//
-			// However, the invariant at the beginning of the function
-			// guarantees that if:
-			//  * we have both a point key and a range key
-			//  * and the range key has already been interleaved
-			// => then the point key must be less than the range key's end, and
-			//    the point key must be covered by the current range key.
-			return i.yieldPointKey(true /* covered */)
+		// Interleave.
+		switch {
+		case i.rangeKey == nil:
+			// If we're out of range keys, just return the point key.
+			return i.yieldPointKey(false /* covered */)
+		case i.pointKey == nil:
+			if i.pointKeyInterleaved {
+				panic("pebble: invariant violation: point key already interleaved")
+			}
+			// If we're out of point keys, we need to return a range key marker. If
+			// the current range key has already been interleaved, advance it. Since
+			// there are no more point keys, we don't need to worry about advancing
+			// past the current point key.
+			if i.rangeKeyInterleaved {
+				i.nextRangeKey(i.rangeKeyIter.Next())
+				if i.rangeKey == nil {
+					return i.yieldNil()
+				}
+			}
+			return i.yieldSyntheticRangeKeyMarker(lowerBound)
+		default:
+			if i.cmp(i.pointKey.UserKey, i.rangeKey.Start) >= 0 {
+				// The range key starts before the point key. If we haven't
+				// interleaved it, we should.
+				if !i.rangeKeyInterleaved {
+					return i.yieldSyntheticRangeKeyMarker(lowerBound)
+				}
+
+				// Otherwise, the range key is already interleaved and we need to
+				// return the point key. The current range key necessarily must
+				// cover the point key:
+				//
+				// Since the range key's start is less than or equal to the point
+				// key, the only way for this range key to not cover the point would
+				// be if the range key's end is less than or equal to the point.
+				// (For example range key = [a, b), point key = c).
+				//
+				// However, the invariant at the beginning of the function
+				// guarantees that if:
+				//  * we have both a point key and a range key
+				//  * and the range key has already been interleaved
+				// => then the point key must be less than the range key's end, and
+				//    the point key must be covered by the current range key.
+
+				// The range key covers the point key. The point key might be
+				// masked too if range-key masking is enabled.
+				if i.maskSuffix != nil {
+					pointSuffix := i.pointKey.UserKey[i.split(i.pointKey.UserKey):]
+					if len(pointSuffix) > 0 && i.cmp(i.maskSuffix, pointSuffix) < 0 {
+						// A range key in the current coalesced span masks this
+						// point key. Skip the point key.
+						i.pointKey, i.pointVal = i.pointIter.Next()
+						// We may have just invalidated the invariant that
+						// ensures the range key's End is > the point key, so
+						// reestablish it before the next iteration.
+						if i.pointKey != nil && i.cmp(i.pointKey.UserKey, i.rangeKey.End) >= 0 {
+							i.nextRangeKey(i.rangeKeyIter.Next())
+						}
+						continue
+					}
+				}
+
+				// Point key is unmasked but covered.
+				return i.yieldPointKey(true /* covered */)
+			}
+			return i.yieldPointKey(false /* covered */)
 		}
-		return i.yieldPointKey(false /* covered */)
 	}
 }
 
 func (i *InterleavingIter) interleaveBackward() (*base.InternalKey, []byte) {
-	// Check invariants.
-	// INVARIANT: !pointKeyInterleaved
-	if i.pointKeyInterleaved {
-		panic("pebble: invariant violation: point key interleaved")
-	}
-	switch {
-	case i.rangeKey == nil:
-	case i.pointKey == nil:
-		// INVARAINT: rangeKey.HasSets()
-		if i.rangeKey != nil && !i.rangeKey.HasSets() {
-			panic("pebble: invariant violation: range-key span without visible Sets")
+	// This loop determines whether a point key or a range key should be
+	// interleaved on each iteration. If masking is disabled, this loop executes
+	// for exactly one iteration. If masking is enabled and a masked key is
+	// determined to be interleaved next, this loop continues until the
+	// interleaved key is unmasked.
+	for {
+		// Check invariants.
+		// INVARIANT: !pointKeyInterleaved
+		if i.pointKeyInterleaved {
+			panic("pebble: invariant violation: point key interleaved")
 		}
-	default:
-		// INVARAINT: rangeKey.HasSets()
-		if i.rangeKey != nil && !i.rangeKey.HasSets() {
-			panic("pebble: invariant violation: range-key span without visible Sets")
+		switch {
+		case i.rangeKey == nil:
+		case i.pointKey == nil:
+			// INVARAINT: rangeKey.HasSets()
+			if i.rangeKey != nil && !i.rangeKey.HasSets() {
+				panic("pebble: invariant violation: range-key span without visible Sets")
+			}
+		default:
+			// INVARAINT: rangeKey.HasSets()
+			if i.rangeKey != nil && !i.rangeKey.HasSets() {
+				panic("pebble: invariant violation: range-key span without visible Sets")
+			}
 		}
-	}
 
-	// Interleave.
-	switch {
-	case i.rangeKey == nil:
-		// If we're out of range keys, just return the point key.
-		return i.yieldPointKey(false /* covered */)
-	case i.pointKey == nil:
-		// If we're out of point keys, we need to return a range key marker.
-		return i.yieldSyntheticRangeKeyMarker(i.lower)
-	default:
-		// If the range key's start key is greater than the point key, return a
-		// marker for the range key.
-		if i.cmp(i.rangeKey.Start, i.pointKey.UserKey) > 0 {
+		// Interleave.
+		switch {
+		case i.rangeKey == nil:
+			// If we're out of range keys, just return the point key.
+			return i.yieldPointKey(false /* covered */)
+		case i.pointKey == nil:
+			// If we're out of point keys, we need to return a range key marker.
 			return i.yieldSyntheticRangeKeyMarker(i.lower)
+		default:
+			// If the range key's start key is greater than the point key, return a
+			// marker for the range key.
+			if i.cmp(i.rangeKey.Start, i.pointKey.UserKey) > 0 {
+				return i.yieldSyntheticRangeKeyMarker(i.lower)
+			}
+			// We have a range key but it has not been interleaved and begins at
+			// a key equal to or before the current point key. The point key
+			// should be interleaved next, if it's not masked.
+			if i.cmp(i.pointKey.UserKey, i.rangeKey.End) < 0 {
+				// The range key covers the point key. The point key might be
+				// masked too if range-key masking is enabled.
+
+				// Since this point key is covered by the range key, it might be
+				// masked by the range key if range-key masking is enabled.
+				if i.maskSuffix != nil {
+					pointSuffix := i.pointKey.UserKey[i.split(i.pointKey.UserKey):]
+					if len(pointSuffix) > 0 && i.cmp(i.maskSuffix, pointSuffix) < 0 {
+						// A range key in the current coalesced span masks this
+						// point key. Skip the point key.
+						i.pointKey, i.pointVal = i.pointIter.Prev()
+						continue
+					}
+				}
+
+				// Point key is unmasked but covered.
+				return i.yieldPointKey(true /* covered */)
+			}
+			return i.yieldPointKey(false /* covered */)
 		}
-		// We have a range key but it has not been interleaved and begins at a
-		// key before the current point key. Return the point key.
-		return i.yieldPointKey(i.cmp(i.pointKey.UserKey, i.rangeKey.End) < 0)
 	}
 }
 
@@ -530,6 +639,11 @@ func (i *InterleavingIter) verify(k *base.InternalKey, v []byte) (*base.Internal
 		panic("pebble: invariant violation: key ≥ lower bound")
 	case i.HasRangeKey() && len(i.rangeKeyItems) == 0:
 		panic("pebble: invariant violation: range key with no items")
+	case i.rangeKey != nil && k != nil && i.maskSuffix != nil && i.pointKeyInterleaved &&
+		i.split(k.UserKey) != len(k.UserKey) &&
+		i.cmp(i.maskSuffix, k.UserKey[i.split(k.UserKey):]) < 0 &&
+		i.cmp(k.UserKey, i.rangeKeyStart) >= 0 && i.cmp(k.UserKey, i.rangeKeyEnd) < 0:
+		panic("pebble: invariant violation: point key eligible for masking returned")
 	}
 
 	return k, v
@@ -539,12 +653,14 @@ func (i *InterleavingIter) saveRangeKey(rk *CoalescedSpan) {
 	i.rangeKeyInterleaved = false
 	i.rangeKeyMarkerTruncated = false
 	i.rangeKey = rk
+	i.maskSuffix = nil
 	if rk == nil {
 		i.rangeKeyItems = nil
 		i.rangeKeyStart = nil
 		i.rangeKeyEnd = nil
 		return
 	}
+	i.maskSuffix = rk.SmallestSetSuffix(i.cmp, i.maskingThresholdSuffix)
 	i.rangeKeyItems = rk.Items
 	i.rangeKeyStart = rk.Start
 	i.rangeKeyEnd = rk.End

--- a/internal/rangekey/testdata/interleaving_iter_masking
+++ b/internal/rangekey/testdata/interleaving_iter_masking
@@ -1,0 +1,470 @@
+# Test the scenario illustrated in the below visualization.
+#
+#        ^
+#     @9 |        •―――――――――――――――○ [e,m)@9
+#   s  8 |                      • l@8
+#   u  7 |------------------------------------ @7 masking
+#   f  6 |      [h,q)@6 •―――――――――――――――――○     threshold
+#   f  5 |              • h@5
+#   f  4 |                          • n@4
+#   i  3 |          •―――――――――――○ [f,l)@3
+#   x  2 |  • b@2
+#      1 |
+#      0 |___________________________________
+#         a b c d e f g h i j k l m n o p q
+#
+
+define-rangekeys
+e.RANGEKEYSET.1 : f [(@9=foo)]
+f.RANGEKEYSET.1 : h [(@9=foo),(@3=bar)]
+h.RANGEKEYSET.1 : l [(@9=foo),(@6=bax),(@3=bar)]
+l.RANGEKEYSET.1 : m [(@9=foo),(@6=bax)]
+m.RANGEKEYSET.1 : q [(@6=bax)]
+----
+OK
+
+define-pointkeys
+b@2.SET.1
+h@5.SET.1
+l@8.SET.1
+n@4.SET.1
+----
+OK
+
+set-masking-threshold
+@7
+----
+OK
+
+iter
+first
+next
+next
+next
+next
+next
+next
+next
+----
+PointKey: b@2#1,1
+RangeKey: .
+-
+PointKey: e#72057594037927935,21
+RangeKey: [e, f)
+└── @9 : foo
+-
+PointKey: f#72057594037927935,21
+RangeKey: [f, h)
+├── @9 : foo
+└── @3 : bar
+-
+PointKey: h#72057594037927935,21
+RangeKey: [h, l)
+├── @9 : foo
+├── @6 : bax
+└── @3 : bar
+-
+PointKey: l#72057594037927935,21
+RangeKey: [l, m)
+├── @9 : foo
+└── @6 : bax
+-
+PointKey: l@8#1,1
+RangeKey: [l, m)
+├── @9 : foo
+└── @6 : bax
+-
+PointKey: m#72057594037927935,21
+RangeKey: [m, q)
+└── @6 : bax
+-
+.
+
+iter
+last
+prev
+prev
+prev
+prev
+prev
+prev
+prev
+----
+PointKey: m#72057594037927935,21
+RangeKey: [m, q)
+└── @6 : bax
+-
+PointKey: l@8#1,1
+RangeKey: [l, m)
+├── @9 : foo
+└── @6 : bax
+-
+PointKey: l#72057594037927935,21
+RangeKey: [l, m)
+├── @9 : foo
+└── @6 : bax
+-
+PointKey: h#72057594037927935,21
+RangeKey: [h, l)
+├── @9 : foo
+├── @6 : bax
+└── @3 : bar
+-
+PointKey: f#72057594037927935,21
+RangeKey: [f, h)
+├── @9 : foo
+└── @3 : bar
+-
+PointKey: e#72057594037927935,21
+RangeKey: [e, f)
+└── @9 : foo
+-
+PointKey: b@2#1,1
+RangeKey: .
+-
+.
+
+iter
+seek-ge a
+seek-ge c
+seek-ge h
+seek-ge i
+seek-ge l
+next
+seek-ge m
+seek-ge r
+----
+PointKey: b@2#1,1
+RangeKey: .
+-
+PointKey: e#72057594037927935,21
+RangeKey: [e, f)
+└── @9 : foo
+-
+PointKey: h#72057594037927935,21
+RangeKey: [h, l)
+├── @9 : foo
+├── @6 : bax
+└── @3 : bar
+-
+PointKey: i#72057594037927935,21
+RangeKey: [h, l)
+├── @9 : foo
+├── @6 : bax
+└── @3 : bar
+-
+PointKey: l#72057594037927935,21
+RangeKey: [l, m)
+├── @9 : foo
+└── @6 : bax
+-
+PointKey: l@8#1,1
+RangeKey: [l, m)
+├── @9 : foo
+└── @6 : bax
+-
+PointKey: m#72057594037927935,21
+RangeKey: [m, q)
+└── @6 : bax
+-
+.
+
+# Setting the masking threshold to @9 should result in l@8 being masked by
+# [e,m)@9.
+
+set-masking-threshold
+@9
+----
+OK
+
+iter
+seek-ge l
+next
+seek-lt l
+seek-lt ll
+prev
+----
+PointKey: l#72057594037927935,21
+RangeKey: [l, m)
+├── @9 : foo
+└── @6 : bax
+-
+PointKey: m#72057594037927935,21
+RangeKey: [m, q)
+└── @6 : bax
+-
+PointKey: h#72057594037927935,21
+RangeKey: [h, l)
+├── @9 : foo
+├── @6 : bax
+└── @3 : bar
+-
+PointKey: l#72057594037927935,21
+RangeKey: [l, m)
+├── @9 : foo
+└── @6 : bax
+-
+PointKey: h#72057594037927935,21
+RangeKey: [h, l)
+├── @9 : foo
+├── @6 : bax
+└── @3 : bar
+-
+
+iter
+seek-ge l
+next
+----
+PointKey: l#72057594037927935,21
+RangeKey: [l, m)
+├── @9 : foo
+└── @6 : bax
+-
+PointKey: m#72057594037927935,21
+RangeKey: [m, q)
+└── @6 : bax
+-
+
+define-rangekeys
+a.RANGEKEYSET.1 : c [(@5=apples),(@2=bananas)]
+----
+OK
+
+define-pointkeys
+a.SET.1
+a@3.SET.1
+a@12.SET.1
+b@2.SET.1
+----
+OK
+
+set-masking-threshold
+@10
+----
+OK
+
+# Test that both a@3 and b@2 are masked by the rangekey.
+# The unsuffixed point key 'a' and the point key at a higher timestamp 'a@12'
+# are not masked.
+
+iter
+first
+next
+next
+next
+----
+PointKey: a#72057594037927935,21
+RangeKey: [a, c)
+├── @5 : apples
+└── @2 : bananas
+-
+PointKey: a#1,1
+RangeKey: [a, c)
+├── @5 : apples
+└── @2 : bananas
+-
+PointKey: a@12#1,1
+RangeKey: [a, c)
+├── @5 : apples
+└── @2 : bananas
+-
+.
+
+iter
+last
+prev
+prev
+prev
+----
+PointKey: a@12#1,1
+RangeKey: [a, c)
+├── @5 : apples
+└── @2 : bananas
+-
+PointKey: a#1,1
+RangeKey: [a, c)
+├── @5 : apples
+└── @2 : bananas
+-
+PointKey: a#72057594037927935,21
+RangeKey: [a, c)
+├── @5 : apples
+└── @2 : bananas
+-
+.
+
+# Try the same test, but with a range key that sorts before the masking
+# threshold (eg, higher MVCC timestamp). Nothing should be masked.
+
+define-rangekeys
+a.RANGEKEYSET.2 : c [(@20=apples)]
+----
+OK
+
+iter
+first
+next
+next
+next
+next
+next
+----
+PointKey: a#72057594037927935,21
+RangeKey: [a, c)
+└── @20 : apples
+-
+PointKey: a#1,1
+RangeKey: [a, c)
+└── @20 : apples
+-
+PointKey: a@3#1,1
+RangeKey: [a, c)
+└── @20 : apples
+-
+PointKey: a@12#1,1
+RangeKey: [a, c)
+└── @20 : apples
+-
+PointKey: b@2#1,1
+RangeKey: [a, c)
+└── @20 : apples
+-
+.
+
+iter
+last
+prev
+prev
+prev
+prev
+prev
+----
+PointKey: b@2#1,1
+RangeKey: [a, c)
+└── @20 : apples
+-
+PointKey: a@12#1,1
+RangeKey: [a, c)
+└── @20 : apples
+-
+PointKey: a@3#1,1
+RangeKey: [a, c)
+└── @20 : apples
+-
+PointKey: a#1,1
+RangeKey: [a, c)
+└── @20 : apples
+-
+PointKey: a#72057594037927935,21
+RangeKey: [a, c)
+└── @20 : apples
+-
+.
+
+# Try the original test, but with an internal range key containing just an
+# Unset, and no Set. Nothing should be masked. No range keys should be surfaced,
+# because there are none.
+
+define-rangekeys
+a.RANGEKEYUNSET.1 : c [@5,@2]
+----
+OK
+
+iter
+first
+next
+next
+next
+next
+----
+PointKey: a#1,1
+RangeKey: .
+-
+PointKey: a@3#1,1
+RangeKey: .
+-
+PointKey: a@12#1,1
+RangeKey: .
+-
+PointKey: b@2#1,1
+RangeKey: .
+-
+.
+
+iter
+last
+prev
+prev
+prev
+prev
+----
+PointKey: b@2#1,1
+RangeKey: .
+-
+PointKey: a@12#1,1
+RangeKey: .
+-
+PointKey: a@3#1,1
+RangeKey: .
+-
+PointKey: a#1,1
+RangeKey: .
+-
+.
+
+# Test a scenario where a point key is masked in the forward direction, which in
+# turn requires nexting to the next range key as well.
+
+define-rangekeys
+a.RANGEKEYSET.1 : c [(@5=apples)]
+c.RANGEKEYSET.1 : z [(@10=bananas)]
+----
+OK
+
+define-pointkeys
+b@3.SET.2
+d@9.SET.4
+j@11.SET.3
+----
+OK
+
+set-masking-threshold
+@20
+----
+OK
+
+iter
+first
+next
+next
+----
+PointKey: a#72057594037927935,21
+RangeKey: [a, c)
+└── @5 : apples
+-
+PointKey: c#72057594037927935,21
+RangeKey: [c, z)
+└── @10 : bananas
+-
+PointKey: j@11#3,1
+RangeKey: [c, z)
+└── @10 : bananas
+-
+
+iter
+last
+prev
+prev
+----
+PointKey: j@11#3,1
+RangeKey: [c, z)
+└── @10 : bananas
+-
+PointKey: c#72057594037927935,21
+RangeKey: [c, z)
+└── @10 : bananas
+-
+PointKey: a#72057594037927935,21
+RangeKey: [a, c)
+└── @5 : apples
+-


### PR DESCRIPTION
Extend the InterleavingIter to also implement naïve range-key masking. When
configured with a range-key masking threshold _t_, and there exists a range key
with suffix _r_ covering a point key with suffix _p_, and

	_t_ <= _r_ < _p_

then the point key is elided.