### PR TITLE
sstable: allow range key property collection

### DIFF
--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1088,7 +1088,7 @@ func (bi *testBlockIntervalCollector) Add(key InternalKey, value []byte) error {
 	return nil
 }
 
-func (bi *testBlockIntervalCollector) FinishDataBlock() (lower uint64, upper uint64, err error) {
+func (bi *testBlockIntervalCollector) FinishBlock() (lower uint64, upper uint64, err error) {
 	bi.initialized = false
 	l, u := bi.lower, bi.upper
 	bi.lower, bi.upper = 0, 0
@@ -1118,7 +1118,7 @@ func TestIteratorBlockIntervalFilter(t *testing.T) {
 		for _, c := range collectors {
 			coll := c
 			bpCollectors = append(bpCollectors, func() BlockPropertyCollector {
-				return sstable.NewBlockIntervalCollector(
+				return sstable.NewDataBlockIntervalCollector(
 					fmt.Sprintf("%d", coll.id),
 					&testBlockIntervalCollector{numLength: 2, offsetFromEnd: coll.offset})
 			})
@@ -1240,7 +1240,7 @@ func TestIteratorRandomizedBlockIntervalFilter(t *testing.T) {
 		FormatMajorVersion: FormatNewest,
 		BlockPropertyCollectors: []func() BlockPropertyCollector{
 			func() BlockPropertyCollector {
-				return sstable.NewBlockIntervalCollector("0", &testBlockIntervalCollector{
+				return sstable.NewDataBlockIntervalCollector("0", &testBlockIntervalCollector{
 					numLength: 2,
 				})
 			},
@@ -1553,7 +1553,7 @@ func BenchmarkBlockPropertyFilter(b *testing.B) {
 				FormatMajorVersion: FormatNewest,
 				BlockPropertyCollectors: []func() BlockPropertyCollector{
 					func() BlockPropertyCollector {
-						return sstable.NewBlockIntervalCollector("0", &testBlockIntervalCollector{
+						return sstable.NewDataBlockIntervalCollector("0", &testBlockIntervalCollector{
 							numLength: 3,
 						})
 					},

--- a/sstable/testdata/block_properties
+++ b/sstable/testdata/block_properties
@@ -102,3 +102,78 @@ f#6,1:
 i#72057594037927935,17:
   0: [3, 7)
   1: [3, 9)
+
+
+# Table contains range-keys.
+
+build collector=range-key
+a@3.RANGEKEYSET.3:b [(@3=foo)]
+b@2.RANGEKEYSET.2:c [(@2=bar)]
+c@1.RANGEKEYSET.1:d [(@1=baz)]
+----
+point:    [#0,0,#0,0]
+rangedel: [#0,0,#0,0]
+rangekey: [a@3#3,21,d#72057594037927935,21]
+seqnums:  [1,3]
+
+collectors
+----
+0: range-key
+
+table-props
+----
+0: [1, 4)
+
+# Table contains range-keys with multiple suffix-values and different range key
+# kinds.
+
+build collector=range-key
+a@300.RANGEKEYSET.3:b [(@90=foo,@80=bar,@70=baz)]
+b@200.RANGEKEYUNSET.2:c [@60,@50,@40]
+c@100.RANGEKEYDEL.1:d
+----
+point:    [#0,0,#0,0]
+rangedel: [#0,0,#0,0]
+rangekey: [a@300#3,21,d#72057594037927935,19]
+seqnums:  [1,3]
+
+collectors
+----
+0: range-key
+
+table-props
+----
+0: [40, 301)
+
+# Table contains a mixture of point and range keys, with three collectors.
+
+build collector=value-first collector=range-key collector=value-last
+a@60.SET.6:123
+a@50.RANGEKEYSET.5:b [(@3=foo)]
+b@40.SET.4:456
+b@30.RANGEKEYDEL.3:c
+c@20.SET.2:789
+c@10.RANGEKEYUNSET.1:d [@5]
+----
+point:    [a@60#6,1,c@20#2,1]
+rangedel: [#0,0,#0,0]
+rangekey: [a@50#5,21,d#72057594037927935,20]
+seqnums:  [1,6]
+
+collectors
+----
+0: value-first
+1: range-key
+2: value-last
+
+table-props
+----
+0: [1, 8)
+1: [3, 51)
+2: [3, 10)
+
+block-props
+----
+d#72057594037927935,17:
+  0: [1, 8)
+  2: [3, 10)

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -446,6 +446,12 @@ func (w *Writer) addRangeKey(key InternalKey, value []byte) error {
 		}
 	}
 
+	for i := range w.blockPropCollectors {
+		if err := w.blockPropCollectors[i].Add(key, value); err != nil {
+			return err
+		}
+	}
+
 	// TODO(travers): Add an invariant-gated check to ensure that suffix-values
 	// are sorted within coalesced spans.
 


### PR DESCRIPTION
Note for reviewers: treat this as preliminary. It's possible that I'm missing something obvious that would allow for a simpler implementation.

Some assumptions on my side that I'd appreciate some confirmation on:

- we'd like to be able to store range key properties independently of point key properties (i.e. separate user key and range key entries in the properties block)
- we'd like to implement separate collectors and filters for range keys (or quite possibly "combined" collectors and filters that apply to any type of key)
- the only place range key properties are stored is the properties block (i.e. range key properties are "table level" properties), as we aren't encoding them in the index like we do for point key properties

TODOs:

- [x] Split out range key kind check into its own function
- [ ] Additional unit test coverage for `RangeKeyBlockIntervalCollector` 
- [ ] Add filtering on the read-path + tests

---

Currently, when point keys are added to an sstable, the key is run
through each of the block property collectors configured on the
`sstable.Writer`. Range keys are not included.

Allow range keys to run through the same block property collector
pipeline by looping through all configured collectors on the writer and
passing the range key. Any struct that implements
`sstable.BlockPropertyCollector` is allowed to accept any type of key
kind. It is up to the implementation to filter out keys that are not
applicable. This allows for flexibility in crafting collectors that can
take specific types of keys, or combinations of key kinds (e.g. point-
and range-key specific collectors, or table-wide "global" collectors).

Rename the existing `DataBlockIntervalCollector` interface to
`BlockIntervalCollector`, and rename the `FinishDataBlock` method to
`FinishBlock`. Both of these change are intended to make the interface
applicable to keys other than point keys that may have dedicated blocks
in the sstable, as is the case for range keys.

Rename the existing `BlockIntervalCollector` struct to
`DataBlockIntervalCollector`. To make the struct specific to point keys,
ignore range key kinds in calls to `Add.

Add a new `BlockPropertyCollector` helper implementation,
`RangeKeyBlockIntervalCollector`, that operates exclusively on range
keys. All other keys kinds are ignored. The collector is intended to
support maintaining an upper and lower bound on the MVCC timestamps
present in a range key block in an sstable.

Add a test implementation of a `BlockIntervalCollector` and a
data-driven that demonstrates maintaining upper and lower bounds on
point and range keys with integer suffixes (e.g. `a@100.SET:foo`,
`b@200.RANGEKEYSET:bar [(@100=baz)]`, etc.).

One downside with this implementation is that the
`BlockPropertyCollector` interface contains methods such as
`FinishDataBlock` and `FinishIndexBlock` that are not applicable to
range keys (range keys are all in a single block, and do not have an
index block, respectively). However, retaining these specific methods
allows for implementations to be created that could support both point
and range keys (for example, if creating a collector whose properties
are intended to be applicable to all key kinds).

Alternatives approaches considered, with relative downsides:

- adding a new member field to `BlockIntervalCollector` for tracking the
  range key interval. The downside with this approach is that it
  requires that both the point and range key intervals be encoded into
  the properties for the table and block with the same name. This make
  it difficult to disambiguate the intervals on the read path.

- have member fields for both point and range key collectors in
  `sstable.Writer`. The downside with this approach is that it requires
  more intrusive changes to the `Writer` to call the specific type of
  property collector on the write path, which does not scale nicely to
  support various block types that require property collection (i.e.
  potentially supporting range-dels in the future). There is also some
  nuance to managing separate collections of collectors with the
  `shortID` mapping that is used when encoding the properties in the
  properties and index blocks (i.e. need to be careful not to re-use the
  same ordinals, etc.).