### PR TITLE
internal/rangekey: add IsRangeKey helper

### DIFF
--- a/internal/rangekey/rangekey.go
+++ b/internal/rangekey/rangekey.go
@@ -347,6 +347,18 @@ func RecombineValue(kind base.InternalKeyKind, dst, endKey, userValue []byte) in
 	return n
 }
 
+// IsRangeKey returns true if the given key kind is one of the range key kinds.
+func IsRangeKey(kind base.InternalKeyKind) bool {
+	switch kind {
+	case base.InternalKeyKindRangeKeyDelete,
+		base.InternalKeyKindRangeKeyUnset,
+		base.InternalKeyKindRangeKeySet:
+		return true
+	default:
+		return false
+	}
+}
+
 func lenVarint(v int) (n int) {
 	x := uint32(v)
 	n++

--- a/internal/rangekey/rangekey_test.go
+++ b/internal/rangekey/rangekey_test.go
@@ -171,3 +171,36 @@ func TestRecombinedValueLen_RoundTrip(t *testing.T) {
 		})
 	}
 }
+
+func TestIsRangeKey(t *testing.T) {
+	testCases := []struct {
+		kind base.InternalKeyKind
+		want bool
+	}{
+		{
+			kind: base.InternalKeyKindRangeKeyDelete,
+			want: true,
+		},
+		{
+			kind: base.InternalKeyKindRangeKeyUnset,
+			want: true,
+		},
+		{
+			kind: base.InternalKeyKindRangeKeyDelete,
+			want: true,
+		},
+		{
+			kind: base.InternalKeyKindDelete,
+			want: false,
+		},
+		{
+			kind: base.InternalKeyKindSet,
+			want: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			require.Equal(t, tc.want, IsRangeKey(tc.kind))
+		})
+	}
+}


### PR DESCRIPTION
Add a helper function that returns true if the given key kind is a range
key kind, and false otherwise. This will help reduce the boilerplate of
checking for the presence of one of the three kinds.