### PR TITLE
batch: exclude range keys from primary flushable batch iterator

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -696,6 +696,12 @@ func TestFlushableBatch(t *testing.T) {
 					batch.Merge(ikey.UserKey, value, nil)
 				case InternalKeyKindRangeDelete:
 					batch.DeleteRange(ikey.UserKey, value, nil)
+				case InternalKeyKindRangeKeyDelete:
+					batch.Experimental().RangeKeyDelete(ikey.UserKey, value, nil)
+				case InternalKeyKindRangeKeySet:
+					batch.Experimental().RangeKeySet(ikey.UserKey, value, value, value, nil)
+				case InternalKeyKindRangeKeyUnset:
+					batch.Experimental().RangeKeyUnset(ikey.UserKey, value, value, nil)
 				}
 			}
 			b = newFlushableBatch(batch, DefaultComparer)

--- a/testdata/flushable_batch
+++ b/testdata/flushable_batch
@@ -6,7 +6,14 @@ b.DEL.2:
 c.SET.1:1
 c.MERGE.2:2
 1.RANGEDEL.3:
+2.RANGEKEYSET.4:
+2.RANGEKEYDEL.5:
+2.RANGEKEYUNSET.6:
 ----
+
+# TODO(jackson): This test includes RANGEDELs but not RANGEKEYs, because this
+# test doesn't yet incoporate a RANGEKEY iterator. Once we have a RANGEKEY
+# flushable batch iterator, update this test to incorporate it.
 
 dump seq=0
 ----


### PR DESCRIPTION
Like range tombstones, range keys are handled separately from point keys.
During flushes and compactions, they will appear in a separate iterator. This
change prevents range keys from appearing in a flushable batch's point
iterator.