### PR TITLE
internal/manifest: narrow Overlaps to exclude RANGEDEL sentinel keys

### DIFF
--- a/compaction_iter.go
+++ b/compaction_iter.go
@@ -5,6 +5,7 @@
 package pebble
 
 import (
+	"fmt"
 	"io"
 	"sort"
 	"strconv"
@@ -456,9 +457,9 @@ func (i *compactionIter) skipInStripe() {
 
 func (i *compactionIter) iterNext() bool {
 	i.iterKey, i.iterValue = i.iter.Next()
-	// We should never see a range delete sentinel in the compaction input.
-	if i.iterKey != nil && i.iterKey.Trailer == InternalKeyRangeDeleteSentinel {
-		panic("pebble: unexpected range delete sentinel in compaction input")
+	// We should never see an exclusive sentinel in the compaction input.
+	if i.iterKey != nil && i.iterKey.IsExclusiveSentinel() {
+		panic(fmt.Sprintf("pebble: unexpected exclusive sentinel in compaction input, trailer = %x", i.iterKey.Trailer))
 	}
 	return i.iterKey != nil
 }

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -1098,7 +1098,7 @@ func TestPickedCompactionSetupInputs(t *testing.T) {
 				}
 				pc.version = newVersion(opts, files)
 				pc.startLevel.files = pc.version.Overlaps(pc.startLevel.level, pc.cmp,
-					[]byte(args[0].String()), []byte(args[1].String()))
+					[]byte(args[0].String()), []byte(args[1].String()), false /* exclusiveEnd */)
 
 				var isCompacting bool
 				if !pc.setupInputs(opts, availBytes) {

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1721,7 +1721,8 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 					if !force {
 						// Find the file in the current version.
 						v := d.mu.versions.currentVersion()
-						overlaps := v.Overlaps(tombstoneLevel, d.opts.Comparer.Compare, start, end)
+						overlaps := v.Overlaps(tombstoneLevel, d.opts.Comparer.Compare, start,
+							end, true /* exclusiveEnd */)
 						iter := overlaps.Iter()
 						for m := iter.First(); m != nil; m = iter.Next() {
 							if m.FileNum.String() == parts[1] {

--- a/db.go
+++ b/db.go
@@ -1126,7 +1126,7 @@ func (d *DB) Compact(
 	maxLevelWithFiles := 1
 	cur := d.mu.versions.currentVersion()
 	for level := 0; level < numLevels; level++ {
-		overlaps := cur.Overlaps(level, d.cmp, start, end)
+		overlaps := cur.Overlaps(level, d.cmp, start, end, iEnd.IsExclusiveSentinel())
 		if !overlaps.Empty() {
 			maxLevelWithFiles = level + 1
 		}
@@ -1400,7 +1400,7 @@ func (d *DB) EstimateDiskUsage(start, end []byte) (uint64, error) {
 			// We can only use `Overlaps` to restrict `files` at L1+ since at L0 it
 			// expands the range iteratively until it has found a set of files that
 			// do not overlap any other L0 files outside that set.
-			overlaps := readState.current.Overlaps(level, d.opts.Comparer.Compare, start, end)
+			overlaps := readState.current.Overlaps(level, d.opts.Comparer.Compare, start, end, false /* exclusiveEnd */)
 			iter = overlaps.Iter()
 		}
 		for file := iter.First(); file != nil; file = iter.Next() {

--- a/ingest.go
+++ b/ingest.go
@@ -428,7 +428,8 @@ func ingestTargetLevel(
 		}
 
 		// Check boundary overlap.
-		boundaryOverlaps := v.Overlaps(level, cmp, meta.Smallest.UserKey, meta.Largest.UserKey)
+		boundaryOverlaps := v.Overlaps(level, cmp, meta.Smallest.UserKey,
+			meta.Largest.UserKey, meta.Largest.IsExclusiveSentinel())
 		if !boundaryOverlaps.Empty() {
 			continue
 		}

--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -143,7 +143,7 @@ func MakeInternalKey(userKey []byte, seqNum uint64, kind InternalKeyKind) Intern
 }
 
 // MakeSearchKey constructs an internal key that is appropriate for searching
-// for a the specified user key. The search key contain the maximual sequence
+// for a the specified user key. The search key contain the maximal sequence
 // number and kind ensuring that it sorts before any other internal keys for
 // the same user key.
 func MakeSearchKey(userKey []byte) InternalKey {
@@ -340,6 +340,15 @@ func (k InternalKey) String() string {
 // Pretty returns a formatter for the key.
 func (k InternalKey) Pretty(f FormatKey) fmt.Formatter {
 	return prettyInternalKey{k, f}
+}
+
+// IsExclusiveSentinel returns whether this internal key excludes point keys
+// with the same user key if used as an end boundary. See the comment on
+// InternalKeyRangeDeletionSentinel.
+func (k InternalKey) IsExclusiveSentinel() bool {
+	// TODO(jackson): This may need to change to include separate sentinels for
+	// range key unsets and deletes.
+	return k.Trailer == InternalKeyRangeDeleteSentinel || k.Trailer == InternalKeyBoundaryRangeKey
 }
 
 type prettyInternalKey struct {

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -238,7 +238,7 @@ func NewL0Sublevels(
 		keys = append(keys, intervalKey{key: f.Smallest.UserKey})
 		keys = append(keys, intervalKey{
 			key:       f.Largest.UserKey,
-			isLargest: f.Largest.Trailer != base.InternalKeyRangeDeleteSentinel,
+			isLargest: !f.Largest.IsExclusiveSentinel(),
 		})
 	}
 	keys = sortAndDedup(keys, cmp)
@@ -269,7 +269,7 @@ func NewL0Sublevels(
 					cmp,
 					intervalKey{
 						key:       f.Largest.UserKey,
-						isLargest: f.Largest.Trailer != base.InternalKeyRangeDeleteSentinel},
+						isLargest: !f.Largest.IsExclusiveSentinel()},
 					keys[f.minIntervalIndex+index]) <= 0
 			})
 		if f.maxIntervalIndex == len(keys) {
@@ -381,7 +381,7 @@ func (s *L0Sublevels) InitCompactingFileInfo(inProgress []L0Compaction) {
 	// compacting.
 	for _, c := range inProgress {
 		startIK := intervalKey{key: c.Smallest.UserKey, isLargest: false}
-		endIK := intervalKey{key: c.Largest.UserKey, isLargest: c.Largest.Trailer != base.InternalKeyRangeDeleteSentinel}
+		endIK := intervalKey{key: c.Largest.UserKey, isLargest: !c.Largest.IsExclusiveSentinel()}
 		start := sort.Search(len(s.orderedIntervals), func(i int) bool {
 			return intervalKeyCompare(s.cmp, s.orderedIntervals[i].startKey, startIK) >= 0
 		})

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -161,7 +161,7 @@ func visualizeSublevels(
 				buf.WriteByte(middleChar)
 				lastChar++
 			}
-			if f.Largest.Trailer == base.InternalKeyRangeDeleteSentinel &&
+			if f.Largest.IsExclusiveSentinel() &&
 				j < len(files)-1 && files[j+1].Smallest.UserKey[0] == f.Largest.UserKey[0] {
 				// This case happens where two successive files have
 				// matching end/start user keys but where the left-side file

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -72,7 +72,8 @@ func (lm *LevelMetadata) Slice() LevelSlice {
 // key-sorted (eg, non-L0).
 func (lm *LevelMetadata) Find(cmp base.Compare, m *FileMetadata) *LevelFile {
 	// TODO(jackson): Add an assertion that lm is key-sorted.
-	o := overlaps(lm.Iter(), cmp, m.Smallest.UserKey, m.Largest.UserKey)
+	o := overlaps(lm.Iter(), cmp, m.Smallest.UserKey,
+		m.Largest.UserKey, m.Largest.IsExclusiveSentinel())
 	iter := o.Iter()
 	for f := iter.First(); f != nil; f = iter.Next() {
 		if f == m {

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -608,7 +608,8 @@ func (b *BulkVersionEdit) Apply(
 
 		// Check consistency of the level in the vicinity of our edits.
 		if sm != nil && la != nil {
-			overlap := overlaps(v.Levels[level].Iter(), cmp, sm.Smallest.UserKey, la.Largest.UserKey)
+			overlap := overlaps(v.Levels[level].Iter(), cmp, sm.Smallest.UserKey,
+				la.Largest.UserKey, la.Largest.IsExclusiveSentinel())
 			// overlap contains all of the added files. We want to ensure that
 			// the added files are consistent with neighboring existing files
 			// too, so reslice the overlap to pull in a neighbor on each side.

--- a/level_checker.go
+++ b/level_checker.go
@@ -128,7 +128,7 @@ func (m *simpleMergingIter) step() bool {
 	item := &m.heap.items[0]
 	l := &m.levels[item.index]
 	// Sentinels are not relevant for this point checking.
-	if item.key.Trailer != InternalKeyRangeDeleteSentinel && item.key.Visible(m.snapshot) {
+	if !item.key.IsExclusiveSentinel() && item.key.Visible(m.snapshot) {
 		m.numPoints++
 		keyChanged := m.heap.cmp(item.key.UserKey, m.lastKey.UserKey) != 0
 		if !keyChanged {

--- a/level_iter.go
+++ b/level_iter.go
@@ -226,7 +226,7 @@ func (l *levelIter) findFileGE(key []byte) *fileMetadata {
 	// (see the comment in that function).
 
 	m := l.files.SeekGE(l.cmp, key)
-	for m != nil && m.Largest.Trailer == InternalKeyRangeDeleteSentinel &&
+	for m != nil && m.Largest.IsExclusiveSentinel() &&
 		l.cmp(m.Largest.UserKey, key) == 0 {
 		m = l.files.Next()
 	}
@@ -354,7 +354,7 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) loadFileReturnIndicato
 			*l.largestUserKey = file.Largest.UserKey
 		}
 		if l.isLargestUserKeyRangeDelSentinel != nil {
-			*l.isLargestUserKeyRangeDelSentinel = file.Largest.Trailer == InternalKeyRangeDeleteSentinel
+			*l.isLargestUserKeyRangeDelSentinel = file.Largest.IsExclusiveSentinel()
 		}
 		return newFileLoaded
 	}

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -400,7 +400,7 @@ func (m *mergingIter) switchToMinHeap() {
 		// bound.  Instead, we seek it to >= f and Next from there.
 
 		if l.iterKey == nil || (m.lower != nil && l.isSyntheticIterBoundsKey &&
-			l.iterKey.Trailer == InternalKeyRangeDeleteSentinel &&
+			l.iterKey.IsExclusiveSentinel() &&
 			m.heap.cmp(l.iterKey.UserKey, m.lower) <= 0) {
 			if m.lower != nil {
 				l.iterKey, l.iterValue = l.iter.SeekGE(m.lower, false /* trySeekUsingNext */)
@@ -475,8 +475,7 @@ func (m *mergingIter) switchToMaxHeap() {
 		// bound.  Instead, we seek it to < g, and Prev from there.
 
 		if l.iterKey == nil || (m.upper != nil && l.isSyntheticIterBoundsKey &&
-			l.iterKey.Trailer == InternalKeyRangeDeleteSentinel &&
-			m.heap.cmp(l.iterKey.UserKey, m.upper) >= 0) {
+			l.iterKey.IsExclusiveSentinel() && m.heap.cmp(l.iterKey.UserKey, m.upper) >= 0) {
 			if m.upper != nil {
 				l.iterKey, l.iterValue = l.iter.SeekLT(m.upper)
 			} else {

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -105,7 +105,7 @@ wait-pending-table-stats
 num-entries: 2
 num-deletions: 1
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 776
+range-deletions-bytes-estimate: 31
 
 # Same as above, except range tombstone covers multiple grandparent file boundaries.
 

--- a/testdata/manual_compaction_set_with_del
+++ b/testdata/manual_compaction_set_with_del
@@ -105,7 +105,7 @@ wait-pending-table-stats
 num-entries: 2
 num-deletions: 1
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 776
+range-deletions-bytes-estimate: 31
 
 # Same as above, except range tombstone covers multiple grandparent file boundaries.
 

--- a/testdata/range_del
+++ b/testdata/range_del
@@ -641,9 +641,9 @@ L1
 ----
 mem: 1
 1:
-  000004:[a-a]
-  000005:[a-a]
-  000006:[a-a]
+  000004:[a#3,SET-a#3,SET]
+  000005:[a#2,SET-a#2,SET]
+  000006:[a#1,SET-a#1,SET]
 
 get seq=1
 a
@@ -720,9 +720,9 @@ L1
 ----
 mem: 1
 1:
-  000004:[a-a]
-  000005:[a-a]
-  000006:[a-a]
+  000004:[a#3,MERGE-a#3,MERGE]
+  000005:[a#2,MERGE-a#2,MERGE]
+  000006:[a#1,MERGE-a#1,MERGE]
 
 get seq=1
 a
@@ -803,11 +803,11 @@ L3
 ----
 mem: 1
 1:
-  000004:[a-a]
+  000004:[a#3,MERGE-a#3,MERGE]
 2:
-  000005:[a-a]
+  000005:[a#2,MERGE-a#2,MERGE]
 3:
-  000006:[a-a]
+  000006:[a#1,MERGE-a#1,MERGE]
 
 get seq=1
 a
@@ -916,13 +916,13 @@ L3
 ----
 mem: 1
 0.0:
-  000004:[a-d]
+  000004:[a#4,SET-d#4,SET]
 1:
-  000005:[a-d]
+  000005:[a#3,SET-d#3,SET]
 2:
-  000006:[a-d]
+  000006:[a#2,RANGEDEL-d#2,SET]
 3:
-  000007:[a-d]
+  000007:[a#1,SET-d#1,SET]
 
 get seq=2
 a
@@ -1042,11 +1042,11 @@ L2
 ----
 mem: 1
 1:
-  000004:[a-b]
-  000005:[b-c]
-  000006:[c-d]
+  000004:[a#2,RANGEDEL-b#72057594037927935,RANGEDEL]
+  000005:[b#2,RANGEDEL-c#72057594037927935,RANGEDEL]
+  000006:[c#2,RANGEDEL-d#72057594037927935,RANGEDEL]
 2:
-  000007:[a-d]
+  000007:[a#1,SET-d#1,SET]
 
 get seq=2
 a
@@ -1138,9 +1138,9 @@ L2
 ----
 mem: 1
 1:
-  000004:[a-b]
+  000004:[a#1,RANGEDEL-b#72057594037927935,RANGEDEL]
 2:
-  000005:[a-a]
+  000005:[a#2,SET-a#2,SET]
 
 get seq=3
 a
@@ -1163,23 +1163,23 @@ L0
 ----
 mem: 1
 0.1:
-  000005:[a-a]
-  000006:[c-c]
+  000005:[a#2,SET-a#2,SET]
+  000006:[c#3,SET-c#3,SET]
 0.0:
-  000004:[a-e]
+  000004:[a#1,RANGEDEL-e#72057594037927935,RANGEDEL]
 
 compact a-e
 ----
 1:
-  000007:[a-c]
-  000008:[c-e]
+  000007:[a#2,SET-c#72057594037927935,RANGEDEL]
+  000008:[c#3,SET-e#72057594037927935,RANGEDEL]
 
 compact d-e
 ----
 1:
-  000007:[a-c]
+  000007:[a#2,SET-c#72057594037927935,RANGEDEL]
 2:
-  000008:[c-e]
+  000008:[c#3,SET-e#72057594037927935,RANGEDEL]
 
 iter seq=4
 seek-ge b
@@ -1201,23 +1201,23 @@ L0
 ----
 mem: 1
 0.1:
-  000005:[a-a]
-  000006:[c-c]
+  000005:[a#2,SET-a#2,SET]
+  000006:[c#3,SET-c#3,SET]
 0.0:
-  000004:[a-e]
+  000004:[a#1,RANGEDEL-e#72057594037927935,RANGEDEL]
 
 compact a-e
 ----
 1:
-  000007:[a-c]
-  000008:[c-e]
+  000007:[a#2,SET-c#72057594037927935,RANGEDEL]
+  000008:[c#3,SET-e#72057594037927935,RANGEDEL]
 
 compact a-b
 ----
 1:
-  000008:[c-e]
+  000008:[c#3,SET-e#72057594037927935,RANGEDEL]
 2:
-  000007:[a-c]
+  000007:[a#2,SET-c#72057594037927935,RANGEDEL]
 
 iter seq=4
 seek-lt d
@@ -1247,29 +1247,29 @@ L2
 ----
 mem: 1
 0.1:
-  000005:[a-a]
-  000006:[c-c]
+  000005:[a#2,SET-a#2,SET]
+  000006:[c#3,SET-c#3,SET]
 0.0:
-  000004:[a-e]
+  000004:[a#1,RANGEDEL-e#72057594037927935,RANGEDEL]
 2:
-  000007:[d-d]
+  000007:[d#0,SET-d#0,SET]
 
 compact a-b
 ----
 1:
-  000008:[a-c]
-  000009:[c-d]
-  000010:[d-e]
+  000008:[a#2,SET-c#72057594037927935,RANGEDEL]
+  000009:[c#3,SET-d#72057594037927935,RANGEDEL]
+  000010:[d#1,RANGEDEL-e#72057594037927935,RANGEDEL]
 2:
-  000007:[d-d]
+  000007:[d#0,SET-d#0,SET]
 
 compact d-e
 ----
 1:
-  000008:[a-c]
+  000008:[a#2,SET-c#72057594037927935,RANGEDEL]
+  000009:[c#3,SET-d#72057594037927935,RANGEDEL]
 3:
-  000013:[c-d]
-  000014:[d-e]
+  000011:[d#1,RANGEDEL-e#72057594037927935,RANGEDEL]
 
 get seq=4
 c
@@ -1278,11 +1278,12 @@ c:v
 
 compact a-b L1
 ----
+1:
+  000009:[c#3,SET-d#72057594037927935,RANGEDEL]
 2:
-  000015:[a-c]
+  000008:[a#2,SET-c#72057594037927935,RANGEDEL]
 3:
-  000013:[c-d]
-  000014:[d-e]
+  000011:[d#1,RANGEDEL-e#72057594037927935,RANGEDEL]
 
 get seq=4
 c
@@ -1306,34 +1307,34 @@ L2
 ----
 mem: 1
 0.1:
-  000005:[a-a]
-  000006:[c-c]
+  000005:[a#2,SET-a#2,SET]
+  000006:[c#3,SET-c#3,SET]
 0.0:
-  000004:[a-e]
-  000007:[f-f]
+  000004:[a#1,RANGEDEL-e#72057594037927935,RANGEDEL]
+  000007:[f#4,SET-f#4,SET]
 2:
-  000008:[d-d]
+  000008:[d#0,SET-d#0,SET]
 
 compact a-b
 ----
 0.0:
-  000007:[f-f]
+  000007:[f#4,SET-f#4,SET]
 1:
-  000009:[a-c]
-  000010:[c-d]
-  000011:[d-e]
+  000009:[a#2,SET-c#72057594037927935,RANGEDEL]
+  000010:[c#3,SET-d#72057594037927935,RANGEDEL]
+  000011:[d#1,RANGEDEL-e#72057594037927935,RANGEDEL]
 2:
-  000008:[d-d]
+  000008:[d#0,SET-d#0,SET]
 
 compact d-e
 ----
 0.0:
-  000007:[f-f]
+  000007:[f#4,SET-f#4,SET]
 1:
-  000009:[a-c]
+  000009:[a#2,SET-c#72057594037927935,RANGEDEL]
+  000010:[c#3,SET-d#72057594037927935,RANGEDEL]
 3:
-  000014:[c-d]
-  000015:[d-e]
+  000012:[d#1,RANGEDEL-e#72057594037927935,RANGEDEL]
 
 get seq=4
 c
@@ -1343,20 +1344,20 @@ c:v
 compact f-f L0
 ----
 1:
-  000009:[a-c]
-  000007:[f-f]
+  000009:[a#2,SET-c#72057594037927935,RANGEDEL]
+  000010:[c#3,SET-d#72057594037927935,RANGEDEL]
+  000007:[f#4,SET-f#4,SET]
 3:
-  000014:[c-d]
-  000015:[d-e]
+  000012:[d#1,RANGEDEL-e#72057594037927935,RANGEDEL]
 
 compact a-f L1
 ----
 2:
-  000016:[a-c]
-  000017:[f-f]
+  000013:[a#2,SET-c#72057594037927935,RANGEDEL]
+  000014:[c#3,SET-d#72057594037927935,RANGEDEL]
+  000015:[f#4,SET-f#4,SET]
 3:
-  000014:[c-d]
-  000015:[d-e]
+  000012:[d#1,RANGEDEL-e#72057594037927935,RANGEDEL]
 
 get seq=4
 c
@@ -1376,13 +1377,13 @@ L2
 ----
 mem: 1
 0.1:
-  000005:[a-f]
+  000005:[a#4,RANGEDEL-f#72057594037927935,RANGEDEL]
 0.0:
-  000004:[a-f]
+  000004:[a#3,RANGEDEL-f#72057594037927935,RANGEDEL]
 1:
-  000006:[b-e]
+  000006:[b#2,RANGEDEL-e#72057594037927935,RANGEDEL]
 2:
-  000007:[c-d]
+  000007:[c#1,RANGEDEL-d#72057594037927935,RANGEDEL]
 
 wait-pending-table-stats
 000007
@@ -1439,13 +1440,13 @@ L3
 ----
 mem: 1
 0.0:
-  000004:[a-d]
+  000004:[a#4,SET-d#4,SET]
 1:
-  000005:[a-d]
+  000005:[a#3,SET-d#3,SET]
 2:
-  000006:[a-d]
+  000006:[a#2,RANGEDEL-d#2,SET]
 3:
-  000007:[a-d]
+  000007:[a#1,SET-d#1,SET]
 
 wait-pending-table-stats
 000007
@@ -1461,7 +1462,7 @@ wait-pending-table-stats
 num-entries: 2
 num-deletions: 1
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 787
+range-deletions-bytes-estimate: 42
 
 wait-pending-table-stats
 000005
@@ -1497,14 +1498,14 @@ L2
 ----
 mem: 1
 0.1:
-  000004:[a-z]
+  000004:[a#6,RANGEDEL-z#72057594037927935,RANGEDEL]
 0.0:
-  000005:[a-d]
-  000006:[e-z]
+  000005:[a#5,RANGEDEL-d#72057594037927935,RANGEDEL]
+  000006:[e#4,RANGEDEL-z#72057594037927935,RANGEDEL]
 1:
-  000007:[a-c]
+  000007:[a#2,SET-c#2,SET]
 2:
-  000008:[x-x]
+  000008:[x#1,SET-x#1,SET]
 
 wait-pending-table-stats
 000005

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -39,7 +39,7 @@ wait-pending-table-stats
 num-entries: 1
 num-deletions: 1
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 796
+range-deletions-bytes-estimate: 51
 
 reopen
 ----
@@ -57,7 +57,7 @@ wait-pending-table-stats
 num-entries: 1
 num-deletions: 1
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 796
+range-deletions-bytes-estimate: 51
 
 compact a-c
 ----
@@ -176,7 +176,7 @@ wait-pending-table-stats
 num-entries: 1
 num-deletions: 1
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 1542
+range-deletions-bytes-estimate: 771
 
 wait-pending-table-stats
 000012
@@ -184,7 +184,7 @@ wait-pending-table-stats
 num-entries: 1
 num-deletions: 1
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 1542
+range-deletions-bytes-estimate: 771
 
 define snapshots=(10)
 L6


### PR DESCRIPTION
When the largest key in a sstable is a range tombstone, the sstable's largest
boundary is set to the range deletion sentinel with the tombstone's exclusive
end boundary and the maximum sequence number. The range deletion sentinel
serves as a marker, indicating that the file's bounds end immediately before
the first key with the sentinel's user key.

In many places such as growing compactions or determining atomic compaction
units, Pebble considers the sentinel as exclusive and avoids unnecessarily
including files that share the same user key but only as a sentinel's exclusive
end bounary.

The `(*manifest.Version).Overlaps` method did not share this logic and only
considered user keys. This method is used during compaction picking when
finding the initial compaction inputs, for determining in-use key ranges,
grandparent files, etc.

This change adapts this method to consider a file with a largest user key equal
to the search range's start user key nonoverlapping if the file's largest key
is a range deletion sentinel. Additionally, Overlaps now takes an exclusiveEnd
parameter, indicating whether the end user key provided to Overlaps should
similarly be treated as an exclusive bound.

This change is expected to reduce write amplification in the presence of range
deletions by avoiding unnecessarily pulling in files due to perceived overlap.

Additionally, some of these RangeDeletionSentinel comparisons are updated to
use a new (*InternalKey).IsExclusiveSentinel helper. With the introduction of
range keys, we will have additional exclusive end boundary key kinds.