### PR TITLE
internal/keyspan: emit fragmented spans ordered by (seqnum, kind)

### DIFF
--- a/internal/keyspan/testdata/fragmenter_emit_order
+++ b/internal/keyspan/testdata/fragmenter_emit_order
@@ -1,0 +1,25 @@
+build
+a.RANGEKEYSET.5 b
+a.RANGEKEYSET.4 b
+a.RANGEKEYUNSET.6 b
+----
+a#6,RANGEKEYUNSET b
+a#5,RANGEKEYSET b
+a#4,RANGEKEYSET b
+-
+
+# Test that keys emitted together that share the same sequence number are
+# ordered by key kind, descending.
+# NB: RANGEKEYSET > RANGEKEYUNSET > RANGEKEYDEL
+
+build
+b.RANGEKEYSET.5 c
+b.RANGEKEYUNSET.5 d
+b.RANGEKEYDEL.5 c
+----
+b#5,RANGEKEYSET c
+b#5,RANGEKEYUNSET c
+b#5,RANGEKEYDEL c
+-
+c#5,RANGEKEYUNSET d
+-


### PR DESCRIPTION
Previously, emitted fragmented spans were guaranteed to be ordered by start key
sequence number, descending. Among keys with the same sequence number, the
ordering was undefined. This was fine for range deletions, for which there only
exist a single key kind. However, for range keys, there are three unique key kinds.