### PR TITLE
vfs: add Clone method to *MemFS

### DIFF
--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -86,6 +86,11 @@ type MemFS struct {
 	ignoreSyncs bool
 }
 
+// Clone copies the deep-copies the contents of the MemFS into a new MemFS.
+func (y *MemFS) Clone() *MemFS {
+	return makeMemFSClone(y).clonedFS
+}
+
 var _ FS = &MemFS{}
 
 // String dumps the contents of the MemFS.

--- a/vfs/mem_fs_clone.go
+++ b/vfs/mem_fs_clone.go
@@ -1,0 +1,55 @@
+package vfs
+
+// memFSClone contains state used to clone a MemFS.
+// It exists as a struct as opposed to just passing the map
+// through some clone methods largely to facilitate cloning
+// of files for testing.
+type memFSClone struct {
+	clonedFS    *MemFS
+	clonedNodes map[*memNode]*memNode
+}
+
+func makeMemFSClone(src *MemFS) memFSClone {
+	src.mu.Lock()
+	defer src.mu.Unlock()
+	cc := memFSClone{
+		clonedNodes: make(map[*memNode]*memNode),
+		clonedFS: &MemFS{
+			strict:      src.strict,
+			ignoreSyncs: src.ignoreSyncs,
+		},
+	}
+
+	cc.clonedFS.root = cc.cloneNode(src.root)
+	return cc
+}
+
+func (cc memFSClone) cloneNode(f *memNode) *memNode {
+	if cloned, exists := cc.clonedNodes[f]; exists {
+		return cloned
+	}
+	cloned := &memNode{
+		name:           f.name,
+		isDir:          f.isDir,
+		refs:           f.refs,
+		children:       make(map[string]*memNode, len(f.children)),
+		syncedChildren: make(map[string]*memNode, len(f.syncedChildren)),
+	}
+	copyNodeData(cloned, f)
+	cc.clonedNodes[f] = cloned
+	for name, c := range f.children {
+		cloned.children[name] = cc.cloneNode(c)
+	}
+	for name, c := range f.syncedChildren {
+		cloned.syncedChildren[name] = cc.cloneNode(c)
+	}
+	return cloned
+}
+
+func copyNodeData(dst, src *memNode) {
+	src.mu.Lock()
+	defer src.mu.Unlock()
+	dst.mu.data = src.mu.data
+	dst.mu.modTime = src.mu.modTime
+	dst.mu.syncedData = src.mu.syncedData
+}


### PR DESCRIPTION
I have some tests I'm writing where it'll be handy to reuse the engine state
to quickly spin up a fully loaded node. I considered writing something to copy
one FS into another (if such a thing exists and works, please point me at it).
For my needs, this seemed simpler.

The testing is potentially too cheeky, it clones the FS before each test case
and then runs the case twice, once on the clone and one on the FS and makes
sure that both pass. Feedback appreciated.