### PR TITLE
vfs: allow MemFS to be Open()'d at "/" or ""

### DIFF
--- a/vfs/mem_fs_test.go
+++ b/vfs/mem_fs_test.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func runTestCases(t *testing.T, testCases []string, fs *MemFS) {
@@ -112,7 +114,23 @@ func runTestCases(t *testing.T, testCases []string, fs *MemFS) {
 			}
 		}
 	}
+
+	// Both "" and "/" are allowed to be used to refer to the root of the FS
+	// for the purposes of cloning.
+	checkClonedIsEquivalent(t, fs, "")
+	checkClonedIsEquivalent(t, fs, "/")
 }
+
+// Test that the FS can be cloned and that the clone serializes identically.
+func checkClonedIsEquivalent(t *testing.T, fs *MemFS, path string) {
+	t.Helper()
+	clone := NewMem()
+	cloned, err := Clone(fs, clone, path, path)
+	require.NoError(t, err)
+	require.True(t, cloned)
+	require.Equal(t, fs.String(), clone.String())
+}
+
 func TestBasics(t *testing.T) {
 	fs := NewMem()
 	testCases := []string{
@@ -167,6 +185,9 @@ func TestBasics(t *testing.T) {
 		"10a: reuseForWrite /bar/caz/z /bar/z",
 		"10b: open /bar/caz/z fails",
 		"10c: open /bar/z",
+		// Opening the root directory works.
+		"11a: f = open /",
+		"11b: f.stat.name == /",
 	}
 	runTestCases(t, testCases, fs)
 }

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -295,3 +295,21 @@ func TestVFSCreateLinkSemantics(t *testing.T) {
 		})
 	}
 }
+
+// TestVFSRootDirName ensures that opening the root directory on both the
+// Default and MemFS works and returns a File which has the name of the
+// path separator for the FS (always sep for MemFS).
+func TestVFSRootDirName(t *testing.T) {
+	for _, fs := range []FS{Default, NewMem()} {
+		rootDir, err := fs.Open("/")
+		require.NoError(t, err)
+		fi, err := rootDir.Stat()
+		require.NoError(t, err)
+
+		exp := sep
+		if fs == Default {
+			exp = string(os.PathSeparator)
+		}
+		require.Equal(t, exp, fi.Name())
+	}
+}


### PR DESCRIPTION
Before this change, a call to Open for "/" would result in `pebble/vfs: empty
file name` because the root directory has no name. This prevented use of
vfs.Clone on MemFS at the root of the FS.