### PR TITLE
internal/keyspan: add FragmentIterator interface

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -856,7 +856,7 @@ func (b *Batch) newInternalIter(o *IterOptions) internalIterator {
 	}
 }
 
-func (b *Batch) newRangeDelIter(o *IterOptions) internalIterator {
+func (b *Batch) newRangeDelIter(o *IterOptions) keyspan.FragmentIterator {
 	if b.index == nil {
 		return newErrorIter(ErrNotIndexed)
 	}
@@ -1418,7 +1418,7 @@ func (b *flushableBatch) newFlushIter(o *IterOptions, bytesFlushed *uint64) inte
 	}
 }
 
-func (b *flushableBatch) newRangeDelIter(o *IterOptions) internalIterator {
+func (b *flushableBatch) newRangeDelIter(o *IterOptions) keyspan.FragmentIterator {
 	if len(b.tombstones) == 0 {
 		return nil
 	}

--- a/compaction.go
+++ b/compaction.go
@@ -68,7 +68,7 @@ func maxReadCompactionBytes(opts *Options, level int) uint64 {
 // calls to Close. It is used during compaction to ensure that rangeDelIters
 // are not closed prematurely.
 type noCloseIter struct {
-	base.InternalIterator
+	keyspan.FragmentIterator
 }
 
 func (i noCloseIter) Close() error {

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/cockroachdb/pebble/internal/errorfs"
+	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -2674,7 +2675,7 @@ func TestCompactionCheckOrdering(t *testing.T) {
 
 				newIters := func(
 					_ *manifest.FileMetadata, _ *IterOptions, _ *uint64,
-				) (internalIterator, internalIterator, error) {
+				) (internalIterator, keyspan.FragmentIterator, error) {
 					return &errorIter{}, nil, nil
 				}
 				result := "OK"

--- a/error_iter.go
+++ b/error_iter.go
@@ -4,7 +4,10 @@
 
 package pebble
 
-import "github.com/cockroachdb/pebble/internal/base"
+import (
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/keyspan"
+)
 
 type errorIter struct {
 	err error
@@ -12,6 +15,9 @@ type errorIter struct {
 
 // errorIter implements the base.InternalIterator interface.
 var _ base.InternalIterator = (*errorIter)(nil)
+
+// errorIter implements the keyspan.FragmentIterator interface.
+var _ keyspan.FragmentIterator = (*errorIter)(nil)
 
 func newErrorIter(err error) *errorIter {
 	return &errorIter{err: err}
@@ -47,12 +53,12 @@ func (c *errorIter) Prev() (*InternalKey, []byte) {
 	return nil, nil
 }
 
-func (c *errorIter) Key() *InternalKey {
+func (c *errorIter) End() []byte {
 	return nil
 }
 
-func (c *errorIter) Value() []byte {
-	return nil
+func (c *errorIter) Current() keyspan.Span {
+	return keyspan.Span{}
 }
 
 func (c *errorIter) Valid() bool {

--- a/flushable.go
+++ b/flushable.go
@@ -7,13 +7,15 @@ package pebble
 import (
 	"fmt"
 	"sync/atomic"
+
+	"github.com/cockroachdb/pebble/internal/keyspan"
 )
 
 // flushable defines the interface for immutable memtables.
 type flushable interface {
 	newIter(o *IterOptions) internalIterator
 	newFlushIter(o *IterOptions, bytesFlushed *uint64) internalIterator
-	newRangeDelIter(o *IterOptions) internalIterator
+	newRangeDelIter(o *IterOptions) keyspan.FragmentIterator
 	// inuseBytes returns the number of inuse bytes by the flushable.
 	inuseBytes() uint64
 	// totalBytes returns the total number of bytes allocated by the flushable.

--- a/get_iter.go
+++ b/get_iter.go
@@ -24,7 +24,7 @@ type getIter struct {
 	snapshot     uint64
 	key          []byte
 	iter         internalIterator
-	rangeDelIter internalIterator
+	rangeDelIter keyspan.FragmentIterator
 	tombstone    keyspan.Span
 	levelIter    levelIter
 	level        int

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 )
 
@@ -471,7 +472,7 @@ func TestGetIter(t *testing.T) {
 		m := map[FileNum]*memTable{}
 		newIter := func(
 			file *manifest.FileMetadata, _ *IterOptions, _ *uint64,
-		) (internalIterator, internalIterator, error) {
+		) (internalIterator, keyspan.FragmentIterator, error) {
 			d, ok := m[file.FileNum]
 			if !ok {
 				return nil, nil, errors.New("no such file")

--- a/ingest.go
+++ b/ingest.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/private"
 	"github.com/cockroachdb/pebble/sstable"
@@ -311,7 +312,7 @@ func ingestUpdateSeqNum(opts *Options, dirname string, seqNum uint64, meta []*fi
 }
 
 func overlapWithIterator(
-	iter internalIterator, rangeDelIter *internalIterator, meta *fileMetadata, cmp Compare,
+	iter internalIterator, rangeDelIter *keyspan.FragmentIterator, meta *fileMetadata, cmp Compare,
 ) bool {
 	// Check overlap with point operations.
 	//
@@ -417,7 +418,7 @@ func ingestTargetLevel(
 	for ; level < numLevels; level++ {
 		levelIter := newLevelIter(iterOps, cmp, nil /* split */, newIters,
 			v.Levels[level].Iter(), manifest.Level(level), nil)
-		var rangeDelIter internalIterator
+		var rangeDelIter keyspan.FragmentIterator
 		// Pass in a non-nil pointer to rangeDelIter so that levelIter.findFileGE sets it up for the target file.
 		levelIter.initRangeDel(&rangeDelIter)
 		overlap := overlapWithIterator(levelIter, &rangeDelIter, meta, cmp)

--- a/internal/keyspan/iter_test.go
+++ b/internal/keyspan/iter_test.go
@@ -39,25 +39,26 @@ func TestIter(t *testing.T) {
 				if len(parts) == 0 {
 					continue
 				}
+				var start *base.InternalKey
 				switch parts[0] {
 				case "seek-ge":
 					if len(parts) != 2 {
 						return "seek-ge <key>\n"
 					}
-					iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
+					start, _ = iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
 				case "seek-lt":
 					if len(parts) != 2 {
 						return "seek-lt <key>\n"
 					}
-					iter.SeekLT([]byte(strings.TrimSpace(parts[1])))
+					start, _ = iter.SeekLT([]byte(strings.TrimSpace(parts[1])))
 				case "first":
-					iter.First()
+					start, _ = iter.First()
 				case "last":
-					iter.Last()
+					start, _ = iter.Last()
 				case "next":
-					iter.Next()
+					start, _ = iter.Next()
 				case "prev":
-					iter.Prev()
+					start, _ = iter.Prev()
 				case "set-bounds":
 					if len(parts) != 3 {
 						return fmt.Sprintf("set-bounds expects 2 bounds, got %d", len(parts)-1)
@@ -76,7 +77,7 @@ func TestIter(t *testing.T) {
 					return fmt.Sprintf("unknown op: %s", parts[0])
 				}
 				if iter.Valid() {
-					fmt.Fprintf(&b, "%s-%s#%d\n", iter.Key().UserKey, iter.Value(), iter.Key().SeqNum())
+					fmt.Fprintf(&b, "%s-%s#%d\n", start.UserKey, iter.End(), start.SeqNum())
 				} else if err := iter.Error(); err != nil {
 					fmt.Fprintf(&b, "err=%v\n", err)
 				} else {

--- a/level_checker.go
+++ b/level_checker.go
@@ -48,7 +48,7 @@ import (
 // The per-level structure used by simpleMergingIter.
 type simpleMergingIterLevel struct {
 	iter            internalIterator
-	rangeDelIter    internalIterator
+	rangeDelIter    keyspan.FragmentIterator
 	smallestUserKey []byte
 
 	iterKey   *InternalKey

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -93,7 +93,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 
 	var fileNum FileNum
 	newIters :=
-		func(file *manifest.FileMetadata, opts *IterOptions, bytesIterated *uint64) (internalIterator, internalIterator, error) {
+		func(file *manifest.FileMetadata, opts *IterOptions, bytesIterated *uint64) (internalIterator, keyspan.FragmentIterator, error) {
 			r := readers[file.FileNum]
 			rangeDelIter, err := r.NewRawRangeDelIter()
 			if err != nil {

--- a/mem_table.go
+++ b/mem_table.go
@@ -224,7 +224,7 @@ func (m *memTable) newFlushIter(o *IterOptions, bytesFlushed *uint64) internalIt
 	return m.skl.NewFlushIter(bytesFlushed)
 }
 
-func (m *memTable) newRangeDelIter(*IterOptions) internalIterator {
+func (m *memTable) newRangeDelIter(*IterOptions) keyspan.FragmentIterator {
 	tombstones := m.tombstones.get()
 	if tombstones == nil {
 		return nil

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -21,7 +21,7 @@ type mergingIterLevel struct {
 	// configured with a levelIter, this pointer changes as sstable boundaries
 	// are crossed. See levelIter.initRangeDel and the Range Deletions comment
 	// below.
-	rangeDelIter internalIterator
+	rangeDelIter keyspan.FragmentIterator
 	// iterKey and iterValue cache the current key and value iter are pointed at.
 	iterKey   *InternalKey
 	iterValue []byte

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -147,7 +147,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 
 	var fileNum base.FileNum
 	newIters :=
-		func(file *manifest.FileMetadata, opts *IterOptions, bytesIterated *uint64) (internalIterator, internalIterator, error) {
+		func(file *manifest.FileMetadata, opts *IterOptions, bytesIterated *uint64) (internalIterator, keyspan.FragmentIterator, error) {
 			r := readers[file.FileNum]
 			rangeDelIter, err := r.NewRawRangeDelIter()
 			if err != nil {
@@ -569,7 +569,7 @@ func buildMergingIter(readers [][]*sstable.Reader, levelSlices []manifest.LevelS
 		level := len(readers) - 1 - i
 		newIters := func(
 			file *manifest.FileMetadata, opts *IterOptions, _ *uint64,
-		) (internalIterator, internalIterator, error) {
+		) (internalIterator, keyspan.FragmentIterator, error) {
 			iter, err := readers[levelIndex][file.FileNum].NewIter(
 				opts.LowerBound, opts.UpperBound)
 			if err != nil {

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -2119,7 +2119,7 @@ func (r *Reader) NewCompactionIter(bytesIterated *uint64) (Iterator, error) {
 // NewRawRangeDelIter returns an internal iterator for the contents of the
 // range-del block for the table. Returns nil if the table does not contain
 // any range deletions.
-func (r *Reader) NewRawRangeDelIter() (base.InternalIterator, error) {
+func (r *Reader) NewRawRangeDelIter() (keyspan.FragmentIterator, error) {
 	if r.rangeDelBH.Length == 0 {
 		return nil, nil
 	}
@@ -2131,6 +2131,9 @@ func (r *Reader) NewRawRangeDelIter() (base.InternalIterator, error) {
 	if err := i.initHandle(r.Compare, h, r.Properties.GlobalSeqNum); err != nil {
 		return nil, err
 	}
+	// NB: *blockIter implements keyspan.FragmentIter, assuming the raw value is
+	// is the span's end key, and the span has no other value. This is
+	// sufficient for range deletion tombstones, but not for range keys.
 	return i, nil
 }
 

--- a/table_cache.go
+++ b/table_cache.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/private"
 	"github.com/cockroachdb/pebble/sstable"
@@ -112,7 +113,7 @@ func (c *tableCacheContainer) close() error {
 
 func (c *tableCacheContainer) newIters(
 	file *manifest.FileMetadata, opts *IterOptions, bytesIterated *uint64,
-) (internalIterator, internalIterator, error) {
+) (internalIterator, keyspan.FragmentIterator, error) {
 	return c.tableCache.getShard(file.FileNum).newIters(file, opts, bytesIterated, &c.dbOpts)
 }
 
@@ -298,7 +299,7 @@ func (c *tableCacheShard) releaseLoop() {
 
 func (c *tableCacheShard) newIters(
 	file *manifest.FileMetadata, opts *IterOptions, bytesIterated *uint64, dbOpts *tableCacheOpts,
-) (internalIterator, internalIterator, error) {
+) (internalIterator, keyspan.FragmentIterator, error) {
 	// Calling findNode gives us the responsibility of decrementing v's
 	// refCount. If opening the underlying table resulted in error, then we
 	// decrement this straight away. Otherwise, we pass that responsibility to


### PR DESCRIPTION
Introduce a keyspan.FragmentIterator interface that is a superset of the
InternalIterator interface, with additional methods relevant for dealing with
fragmented key spans. This removes the assumption from `keyspan.Seek{GE,LE}`
that a key span's internal value is always the end key.

When iteration over range key blocks is integrated, we may introduce a small
type that wraps a `*blockIter` and implements the `FragmentIterator` interface
and decodes end keys from internal values.