### PR TITLE
db: fix race between opts.EnsureDefaults and opts.MakeWriterOptions

### DIFF
--- a/commit_test.go
+++ b/commit_test.go
@@ -234,7 +234,10 @@ func BenchmarkCommitPipeline(b *testing.B) {
 	for _, parallelism := range []int{1, 2, 4, 8, 16, 32, 64, 128} {
 		b.Run(fmt.Sprintf("parallel=%d", parallelism), func(b *testing.B) {
 			b.SetParallelism(parallelism)
-			mem := newMemTable(memTableOptions{})
+			var opts *Options
+			opts = opts.EnsureDefaults()
+			memOptions := memTableOptions{size: opts.MemTableSize, cmp: opts.Comparer}
+			mem := newMemTable(memOptions)
 			wal := record.NewLogWriter(ioutil.Discard, 0 /* logNum */)
 
 			nullCommitEnv := commitEnv{
@@ -252,7 +255,10 @@ func BenchmarkCommitPipeline(b *testing.B) {
 					for {
 						err := mem.prepare(b)
 						if err == arenaskl.ErrArenaFull {
-							mem = newMemTable(memTableOptions{})
+							var opts *Options
+							opts = opts.EnsureDefaults()
+							memOptions := memTableOptions{size: opts.MemTableSize, cmp: opts.Comparer}
+							mem = newMemTable(memOptions)
 							continue
 						}
 						if err != nil {

--- a/data_test.go
+++ b/data_test.go
@@ -548,7 +548,8 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 				}
 				// Add a memtable layer.
 				if !d.mu.mem.mutable.empty() {
-					d.mu.mem.mutable = newMemTable(memTableOptions{Options: d.opts})
+					d.mu.mem.mutable = newMemTable(memTableOptions{
+						size: d.opts.MemTableSize, cmp: d.opts.Comparer})
 					entry := d.newFlushableEntry(d.mu.mem.mutable, 0, 0)
 					entry.readerRefs++
 					d.mu.mem.queue = append(d.mu.mem.queue, entry)
@@ -565,7 +566,7 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 					return nil, err
 				}
 				fields = fields[1:]
-				mem = newMemTable(memTableOptions{Options: d.opts})
+				mem = newMemTable(memTableOptions{size: d.opts.MemTableSize, cmp: d.opts.Comparer})
 			}
 		}
 

--- a/db.go
+++ b/db.go
@@ -1410,7 +1410,8 @@ func (d *DB) newMemTable(logNum FileNum, logSeqNum uint64) (*memTable, *flushabl
 	releaseAccountingReservation := d.opts.Cache.Reserve(size)
 
 	mem := newMemTable(memTableOptions{
-		Options:   d.opts,
+		size:      d.opts.MemTableSize,
+		cmp:       d.opts.Comparer,
 		arenaBuf:  manual.New(int(size)),
 		logSeqNum: logSeqNum,
 	})

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -481,7 +481,10 @@ func TestGetIter(t *testing.T) {
 
 		var files [numLevels][]*fileMetadata
 		for _, tt := range tc.tables {
-			d := newMemTable(memTableOptions{})
+			var opts *Options
+			opts = opts.EnsureDefaults()
+			memOptions := memTableOptions{size: opts.MemTableSize, cmp: opts.Comparer}
+			d := newMemTable(memOptions)
 			m[tt.fileNum] = d
 
 			meta := &fileMetadata{

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -393,7 +393,7 @@ func TestIngestMemtableOverlaps(t *testing.T) {
 						}
 					}
 
-					mem = newMemTable(memTableOptions{Options: opts})
+					mem = newMemTable(memTableOptions{size: opts.MemTableSize, cmp: opts.Comparer})
 					if err := mem.apply(b, 0); err != nil {
 						return err.Error()
 					}

--- a/mem_table.go
+++ b/mem_table.go
@@ -82,11 +82,10 @@ type memTable struct {
 	logSeqNum uint64
 }
 
-// memTableOptions holds configuration used when creating a memTable. All of
-// the fields are optional and will be filled with defaults if not specified
-// which is used by tests.
+// memTableOptions holds configuration used when creating a memTable.
+// Required fields in memTableOptions should be specified.
 type memTableOptions struct {
-	*Options
+	cmp       *base.Comparer
 	arenaBuf  []byte
 	size      int
 	logSeqNum uint64
@@ -100,18 +99,12 @@ func checkMemTable(obj interface{}) {
 	}
 }
 
-// newMemTable returns a new MemTable of the specified size. If size is zero,
-// Options.MemTableSize is used instead.
+// newMemTable returns a new MemTable of the specified size.
 func newMemTable(opts memTableOptions) *memTable {
-	opts.Options = opts.Options.EnsureDefaults()
-	if opts.size == 0 {
-		opts.size = opts.MemTableSize
-	}
-
 	m := &memTable{
-		cmp:        opts.Comparer.Compare,
-		formatKey:  opts.Comparer.FormatKey,
-		equal:      opts.Comparer.Equal,
+		cmp:        opts.cmp.Compare,
+		formatKey:  opts.cmp.FormatKey,
+		equal:      opts.cmp.Equal,
 		arenaBuf:   opts.arenaBuf,
 		writerRefs: 1,
 		logSeqNum:  opts.logSeqNum,

--- a/mem_table_test.go
+++ b/mem_table_test.go
@@ -90,7 +90,10 @@ func ikey(s string) InternalKey {
 
 func TestMemTableBasic(t *testing.T) {
 	// Check the empty DB.
-	m := newMemTable(memTableOptions{})
+	var opts *Options
+	opts = opts.EnsureDefaults()
+	memOptions := memTableOptions{size: opts.MemTableSize, cmp: opts.Comparer}
+	m := newMemTable(memOptions)
 	if got, want := m.count(), 0; got != want {
 		t.Fatalf("0.count: got %v, want %v", got, want)
 	}
@@ -137,7 +140,10 @@ func TestMemTableBasic(t *testing.T) {
 }
 
 func TestMemTableCount(t *testing.T) {
-	m := newMemTable(memTableOptions{})
+	var opts *Options
+	opts = opts.EnsureDefaults()
+	memOptions := memTableOptions{size: opts.MemTableSize, cmp: opts.Comparer}
+	m := newMemTable(memOptions)
 	for i := 0; i < 200; i++ {
 		if j := m.count(); j != i {
 			t.Fatalf("count: got %d, want %d", j, i)
@@ -147,7 +153,10 @@ func TestMemTableCount(t *testing.T) {
 }
 
 func TestMemTableBytesIterated(t *testing.T) {
-	m := newMemTable(memTableOptions{})
+	var opts *Options
+	opts = opts.EnsureDefaults()
+	memOptions := memTableOptions{size: opts.MemTableSize, cmp: opts.Comparer}
+	m := newMemTable(memOptions)
 	for i := 0; i < 200; i++ {
 		bytesIterated := m.bytesIterated(t)
 		expected := m.inuseBytes()
@@ -159,7 +168,10 @@ func TestMemTableBytesIterated(t *testing.T) {
 }
 
 func TestMemTableEmpty(t *testing.T) {
-	m := newMemTable(memTableOptions{})
+	var opts *Options
+	opts = opts.EnsureDefaults()
+	memOptions := memTableOptions{size: opts.MemTableSize, cmp: opts.Comparer}
+	m := newMemTable(memOptions)
 	if !m.empty() {
 		t.Errorf("got !empty, want empty")
 	}
@@ -173,7 +185,10 @@ func TestMemTableEmpty(t *testing.T) {
 func TestMemTable1000Entries(t *testing.T) {
 	// Initialize the DB.
 	const N = 1000
-	m0 := newMemTable(memTableOptions{})
+	var opts *Options
+	opts = opts.EnsureDefaults()
+	memOptions := memTableOptions{size: opts.MemTableSize, cmp: opts.Comparer}
+	m0 := newMemTable(memOptions)
 	for i := 0; i < N; i++ {
 		k := ikey(strconv.Itoa(i))
 		v := []byte(strings.Repeat("x", i))
@@ -248,7 +263,10 @@ func TestMemTableIter(t *testing.T) {
 		datadriven.RunTest(t, testdata, func(d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "define":
-				mem = newMemTable(memTableOptions{})
+				var opts *Options
+				opts = opts.EnsureDefaults()
+				memOptions := memTableOptions{size: opts.MemTableSize, cmp: opts.Comparer}
+				mem = newMemTable(memOptions)
 				for _, key := range strings.Split(d.Input, "\n") {
 					j := strings.Index(key, ":")
 					if err := mem.set(base.ParseInternalKey(key[:j]), []byte(key[j+1:])); err != nil {
@@ -305,7 +323,10 @@ func TestMemTableDeleteRange(t *testing.T) {
 				return err.Error()
 			}
 			if mem == nil {
-				mem = newMemTable(memTableOptions{})
+				var opts *Options
+				opts = opts.EnsureDefaults()
+				memOptions := memTableOptions{size: opts.MemTableSize, cmp: opts.Comparer}
+				mem = newMemTable(memOptions)
 			}
 			if err := mem.apply(b, seqNum); err != nil {
 				return err.Error()
@@ -345,7 +366,10 @@ func TestMemTableConcurrentDeleteRange(t *testing.T) {
 	// tombstones, and then immediately retrieve them verifying that the
 	// tombstones they've added are all present.
 
-	m := newMemTable(memTableOptions{Options: &Options{MemTableSize: 64 << 20}})
+	var opts *Options
+	opts = opts.EnsureDefaults()
+	memOptions := memTableOptions{size: 64 << 20, cmp: opts.Comparer}
+	m := newMemTable(memOptions)
 
 	const workers = 10
 	eg, _ := errgroup.WithContext(context.Background())
@@ -384,7 +408,10 @@ func TestMemTableConcurrentDeleteRange(t *testing.T) {
 }
 
 func buildMemTable(b *testing.B) (*memTable, [][]byte) {
-	m := newMemTable(memTableOptions{})
+	var opts *Options
+	opts = opts.EnsureDefaults()
+	memOptions := memTableOptions{size: opts.MemTableSize, cmp: opts.Comparer}
+	m := newMemTable(memOptions)
 	var keys [][]byte
 	var ikey InternalKey
 	for i := 0; ; i++ {


### PR DESCRIPTION
When we call the `newMemTable` function, we used to call `Options.EnsureDefaults`.
This leads to writes on the `Options` struct, which interfere with reads on the
struct.

The `newMemTable` function doesn't use most of the fields in an `Options` struct,
so we refactor the `EnsureDefaults` function call out of the `newMemTable` function
and only pass fields required by `newMemTable`.
Fixes: #1437