### PR TITLE
internal/keyspan: implement SetBounds on Iter

### DIFF
--- a/internal/keyspan/iter_test.go
+++ b/internal/keyspan/iter_test.go
@@ -58,6 +58,20 @@ func TestIter(t *testing.T) {
 					iter.Next()
 				case "prev":
 					iter.Prev()
+				case "set-bounds":
+					if len(parts) != 3 {
+						return fmt.Sprintf("set-bounds expects 2 bounds, got %d", len(parts)-1)
+					}
+					l, u := []byte(parts[1]), []byte(parts[2])
+					if parts[1] == "." {
+						l = nil
+					}
+					if parts[2] == "." {
+						u = nil
+					}
+					iter.SetBounds(l, u)
+					fmt.Fprintf(&b, ".\n")
+					continue
 				default:
 					return fmt.Sprintf("unknown op: %s", parts[0])
 				}

--- a/internal/keyspan/testdata/iter
+++ b/internal/keyspan/testdata/iter
@@ -72,3 +72,94 @@ c-d#2
 c-d#1
 .
 c-d#1
+
+
+# a.SET.2:b
+# a.SET.1:b
+# b.SET.2:c
+# b.SET.1:c
+# c.SET.2:d
+# c.SET.1:d
+
+iter
+set-bounds x z
+first
+last
+seek-ge x
+seek-lt z
+----
+.
+.
+.
+.
+.
+
+iter
+set-bounds cap cat
+first
+last
+seek-ge c
+next
+next
+seek-lt cat
+prev
+prev
+----
+.
+c-d#2
+c-d#1
+c-d#2
+c-d#1
+.
+c-d#1
+c-d#2
+.
+
+iter
+set-bounds a cc
+first
+next
+next
+next
+next
+next
+next
+----
+.
+a-b#2
+a-b#1
+b-c#2
+b-c#1
+c-d#2
+c-d#1
+.
+
+iter
+set-bounds a c
+first
+next
+next
+next
+next
+----
+.
+a-b#2
+a-b#1
+b-c#2
+b-c#1
+.
+
+iter
+set-bounds b cc
+first
+next
+next
+next
+next
+----
+.
+b-c#2
+b-c#1
+c-d#2
+c-d#1
+.


### PR DESCRIPTION
The `keyspan.Iter` implementation previously did not implement `SetBounds`,
because Pebble never needs to set bounds on range deletion iterators. When
range keys are fully integrated, propagating bounds to range-key fragment
iterators (specifically range-key levelIters) will be an important optimization
to avoid needing to load range-key blocks beyond the iterator bounds. The
memtable and batch range keys will occupy levels above the range-key levelIters
in the form of `keyspan.Iter`s. Pushing bounds checks down requires the
memtable and batch range keys `keyspan.Iter`s to enforce bounds checks.

SetBounds will continue to be unused on `keyspan.Iter`s that expose range
deletion tombstones.