### PR TITLE
db: expose range-key masking

### DIFF
--- a/db.go
+++ b/db.go
@@ -783,6 +783,9 @@ func (d *DB) newIterInternal(batch *Batch, s *Snapshot, o *IterOptions) *Iterato
 	if o.rangeKeys() && d.opts.Experimental.RangeKeys == nil {
 		panic("pebble: range keys require the Experimental.RangeKeys option")
 	}
+	if o != nil && o.RangeKeyMasking.Suffix != nil && o.KeyTypes != IterKeyTypePointsAndRanges {
+		panic("pebble: range key masking requires IterKeyTypePointsAndRanges")
+	}
 
 	// Grab and reference the current readState. This prevents the underlying
 	// files in the associated version from being deleted if there is a current
@@ -948,7 +951,7 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 	// an interleaving iterator. The dbi.rangeKeysIter is an iterator into
 	// fragmented range keys read from the global range key arena.
 	if dbi.rangeKey != nil {
-		dbi.rangeKey.iter.Init(dbi.split, &buf.merging, dbi.rangeKey.rangeKeyIter, nil)
+		dbi.rangeKey.iter.Init(dbi.split, &buf.merging, dbi.rangeKey.rangeKeyIter, dbi.opts.RangeKeyMasking.Suffix)
 		dbi.iter = &dbi.rangeKey.iter
 	}
 	return dbi

--- a/internal/rangekey/iter.go
+++ b/internal/rangekey/iter.go
@@ -51,7 +51,7 @@ func (i *Iter) Clone() *Iter {
 	// Copying i.iter will copy its current position, which is harmless.
 	ki := &keyspan.Iter{}
 	*ki = *i.iter
-	// Init the new Iter to ensure err is clearer.
+	// Init the new Iter to ensure err is cleared.
 	newIter := &Iter{}
 	newIter.Init(i.coalescer.items.cmp, i.coalescer.formatKey, i.coalescer.visibleSeqNum, ki)
 	return newIter

--- a/options.go
+++ b/options.go
@@ -102,6 +102,11 @@ type IterOptions struct {
 	// KeyTypes configures which types of keys to iterate over: point keys,
 	// range keys, or both.
 	KeyTypes IterKeyType
+	// RangeKeyMasking can be used to enable automatic masking of point keys by
+	// range keys. Range key masking is only supported during combined range key
+	// and point key iteration mode (IterKeyTypePointsAndRanges).
+	RangeKeyMasking RangeKeyMasking
+
 	// Internal options.
 	logger Logger
 }
@@ -141,6 +146,31 @@ func (o *IterOptions) getLogger() Logger {
 		return DefaultLogger
 	}
 	return o.logger
+}
+
+// RangeKeyMasking configures automatic hiding of point keys by range keys. A
+// non-nil Suffix enables range-key masking. When enabled, range keys with
+// suffixes ≤ Suffix behave as masks. All point keys that are contained within a
+// masking range key's bounds and have suffixes less than the range key's suffix
+// are automatically skipped.
+//
+// Specifically, when configured with a RangeKeyMasking.Suffix _s_, and there
+// exists a range key with suffix _r_ covering a point key with suffix _p_, and
+//
+//     _s_ ≤ _r_ < _p_
+//
+// then the point key is elided.
+//
+// Range-key masking may only be used when iterating over both point keys and
+// range keys with IterKeyTypePointsAndRanges.
+type RangeKeyMasking struct {
+	// Suffix configures which range keys may mask point keys. Only range keys
+	// that are defined at suffixes less than or equal to Suffix will mask point
+	// keys.
+	Suffix []byte
+
+	// TODO(jackson): Add fields necessary for constructing and updating block
+	// property collectors.
 }
 
 // WriteOptions hold the optional per-query parameters for Set and Delete

--- a/range_keys_test.go
+++ b/range_keys_test.go
@@ -44,7 +44,14 @@ func TestRangeKeys(t *testing.T) {
 			require.NoError(t, b.Commit(nil))
 			return fmt.Sprintf("wrote %d keys\n", count)
 		case "combined-iter":
-			iter := d.NewIter(&IterOptions{KeyTypes: IterKeyTypePointsAndRanges})
+			o := &IterOptions{KeyTypes: IterKeyTypePointsAndRanges}
+			for _, arg := range td.CmdArgs {
+				if arg.Key != "mask-suffix" {
+					continue
+				}
+				o.RangeKeyMasking.Suffix = []byte(arg.Vals[0])
+			}
+			iter := d.NewIter(o)
 			return runIterCmd(td, iter, true /* close iter */)
 		case "rangekey-iter":
 			iter := d.NewIter(&IterOptions{KeyTypes: IterKeyTypeRangesOnly})

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -31,6 +31,25 @@ cat: (., [cat-dog) @3=beep)
 d: (d, [cat-dog) @3=beep)
 .
 
+# Do the above forward iteration but with a mask suffix. The results should be
+# identical despite range keys serving as masks, because none of the point keys
+# have suffixes.
+
+combined-iter mask-suffix=@9
+seek-ge a
+next
+next
+next
+next
+next
+----
+a: (a, .)
+b: (b, [b-c) @5=boop)
+c: (c, .)
+cat: (., [cat-dog) @3=beep)
+d: (d, [cat-dog) @3=beep)
+.
+
 # Scan backward
 
 combined-iter
@@ -232,6 +251,39 @@ a@3: (a#3, [a-d) @8=boop)
 a@2: (a@2, [a-d) @8=boop)
 .
 
+# Perform the above iteration with range-key masking enabled at a suffix equal
+# to the range key's. The [a,d)@8 range key should serve as a masking, obscuring
+# the points a@3 and a@2.
+
+combined-iter mask-suffix=@8
+seek-prefix-ge a
+next
+next
+next
+----
+a: (., [a-d) @8=boop)
+a@10: (a@10, [a-d) @8=boop)
+a@9: (a@9, [a-d) @8=boop)
+.
+
+# Perform the same thing but with a mask suffix below the range key's. All the
+# points should be visible again.
+
+combined-iter mask-suffix=@7
+seek-prefix-ge a
+next
+next
+next
+next
+next
+----
+a: (., [a-d) @8=boop)
+a@10: (a@10, [a-d) @8=boop)
+a@9: (a@9, [a-d) @8=boop)
+a@3: (a#3, [a-d) @8=boop)
+a@2: (a@2, [a-d) @8=boop)
+.
+
 reset
 ----
 
@@ -269,6 +321,30 @@ b@10: (b@10, [b-c) @5=beep)
 bz@10: (bz@10, [b-c) @5=beep)
 bz@1: (bz@1, [b-c) @5=beep)
 c@100: (c@100, .)
+
+# Perform the same iteration with all range keys serving as masks. The bz@1
+# point key should be elided.
+
+combined-iter mask-suffix=@100
+seek-ge az
+next
+next
+next
+next
+next
+seek-ge bz@10
+next
+next
+----
+az@100: (az@100, .)
+az@10: (az@10, .)
+az@1: (az@1, .)
+b: (., [b-c) @5=beep)
+b@100: (b@100, [b-c) @5=beep)
+b@10: (b@10, [b-c) @5=beep)
+bz@10: (bz@10, [b-c) @5=beep)
+c@100: (c@100, .)
+c@10: (c@10, .)
 
 # Ensure that a cloned iterator includes range keys.
 
@@ -313,6 +389,37 @@ seek-prefix-ge ca@100
 ca: (., [c-d) @1000=boop, @1=bop)
 ca@100: (ca@100, [c-d) @1000=boop, @1=bop)
 ca@100: (ca@100, [c-d) @1000=boop, @1=bop)
+
+# Perform the same iteration as above, but with @1000 range-key masking. The
+# previously encountered point keys should be elided.
+
+combined-iter mask-suffix=@1000
+seek-prefix-ge ca
+next
+seek-prefix-ge ca@100
+----
+ca: (., [c-d) @1000=boop, @1=bop)
+.
+ca@100: (., [c-d) @1000=boop, @1=bop)
+
+# Test masked, non-prefixed iteration. We should see the range keys, but all the
+# points should be masked except those beginning with z which were excluded by
+# the range key's exclusive z end bound.
+
+combined-iter mask-suffix=@1000
+seek-ge ca
+next
+next
+next
+next
+next
+----
+ca: (., [c-d) @1000=boop, @1=bop)
+d: (., [d-e) @1000=boop, @1=bop)
+e: (., [e-z) @1000=boop)
+z@100: (z@100, .)
+z@10: (z@10, .)
+z@1: (z@1, .)
 
 reset
 ----


### PR DESCRIPTION
Expose a RangeKeyMasking struct on IterOptions for configuring automatic
masking of point keys by range keys. In #1425 naïve range-key masking was
implemented on the internal `rangekey.InterleavingIter` type. This change adds
the necessary public interface to enable range-key masking.