### PR TITLE
sstable: reorganize sstable buffers and structs

### DIFF
--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -348,9 +348,9 @@ func TestWriter_BlockProperties_Errors(t *testing.T) {
 			case errSiteFinishBlock:
 				require.NoError(t, err)
 				// Addition of a second key completes the first block.
-				err = w.Add(k2, v2)
-				require.Error(t, err)
-				require.Equal(t, blockPropErr, err)
+				w.Add(k2, v2)
+				require.Error(t, w.Error())
+				require.Equal(t, blockPropErr, w.Error())
 			case errSiteFinishIndex:
 				require.NoError(t, err)
 				// Addition of a second key completes the first block.
@@ -358,15 +358,15 @@ func TestWriter_BlockProperties_Errors(t *testing.T) {
 				require.NoError(t, err)
 				// The index entry for the first block is added after the completion of
 				// the second block, which is triggered by adding a third key.
-				err = w.Add(k3, v3)
-				require.Error(t, err)
-				require.Equal(t, blockPropErr, err)
+				w.Add(k3, v3)
+				require.Error(t, w.Error())
+				require.Equal(t, blockPropErr, w.Error())
 			}
 
 			err = w.Close()
 			if tc == errSiteFinishTable {
 				require.Error(t, err)
-				require.Equal(t, blockPropErr, err)
+				require.Equal(t, blockPropErr, w.Error())
 			}
 		})
 	}


### PR DESCRIPTION
This pr aims to serve as a first step towards unifying the parallel compression vs
on parallel compression code paths, as suggested in this pr:
#1383 (review).

This pr organizes the buffers in the Writer in a way which makes it easier to reason
about the ownership of buffers/slices.

Future prs will add, a writeQueue, a compressionQueue, a mechanism to schedule parallel
compression based on cpu utilization.