### PR TITLE
[DNM] sstable: add value blocks for storing older versions of a key

### DIFF
--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -6,6 +6,10 @@ package base
 
 import "fmt"
 
+// TODO(sumeer): change the InternalIterator interface to not eagerly return
+// the value. Implementations should continue to cache the value once asked to
+// return it, so that repeated calls to get the value are cheap.
+
 // InternalIterator iterates over a DB's key/value pairs in key order. Unlike
 // the Iterator interface, the returned keys are InternalKeys composed of the
 // user-key, a sequence number and a key kind. In forward iteration, key/value

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -206,6 +206,10 @@ type WriterOptions struct {
 
 	// Checksum specifies which checksum to use.
 	Checksum ChecksumType
+
+	// ValueBlocksAreEnabled indicates whether the writer should place older
+	// versions in value blocks.
+	ValueBlocksAreEnabled bool
 }
 
 func (o WriterOptions) ensureDefaults() WriterOptions {

--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -120,6 +120,10 @@ type Properties struct {
 	NumRangeKeySets uint64 `prop:"pebble.num.range-key-sets"`
 	// The number of RANGEKEYUNSETs in this table.
 	NumRangeKeyUnsets uint64 `prop:"pebble.num.range-key-unsets"`
+	// The number of value blocks in this table. Only serialized if > 0.
+	NumValueBlocks uint64 `prop:"pebble.num.value-blocks"`
+	// The number of values stored in value blocks. Only serialized if > 0.
+	NumValuesInValueBlocks uint64 `prop:"pebble.num.values.in.value-blocks"`
 	// Timestamp of the earliest key. 0 if unknown.
 	OldestKeyTime uint64 `prop:"rocksdb.oldest.key.time"`
 	// The name of the prefix extractor used in this table. Empty if no prefix
@@ -142,6 +146,9 @@ type Properties struct {
 	TopLevelIndexSize uint64 `prop:"rocksdb.top-level.index.size"`
 	// User collected properties.
 	UserProperties map[string]string
+	// True iff the use of value blocks is enabled. Only serialized if true.
+	ValueBlocksAreEnabled bool `prop:"pebble.value-blocks.enabled"`
+
 	// If filtering is enabled, was the filter created on the whole key.
 	WholeKeyFiltering bool `prop:"rocksdb.block.based.table.whole.key.filtering"`
 
@@ -340,6 +347,12 @@ func (p *Properties) save(w *rawBlockWriter) {
 		p.saveUvarint(m, unsafe.Offsetof(p.RawRangeKeyKeySize), p.RawRangeKeyKeySize)
 		p.saveUvarint(m, unsafe.Offsetof(p.RawRangeKeyValueSize), p.RawRangeKeyValueSize)
 	}
+	if p.NumValueBlocks > 0 {
+		p.saveUvarint(m, unsafe.Offsetof(p.NumValueBlocks), p.NumValueBlocks)
+	}
+	if p.NumValuesInValueBlocks > 0 {
+		p.saveUvarint(m, unsafe.Offsetof(p.NumValuesInValueBlocks), p.NumValuesInValueBlocks)
+	}
 	p.saveUvarint(m, unsafe.Offsetof(p.OldestKeyTime), p.OldestKeyTime)
 	if p.PrefixExtractorName != "" {
 		p.saveString(m, unsafe.Offsetof(p.PrefixExtractorName), p.PrefixExtractorName)
@@ -350,6 +363,9 @@ func (p *Properties) save(w *rawBlockWriter) {
 	}
 	p.saveUvarint(m, unsafe.Offsetof(p.RawKeySize), p.RawKeySize)
 	p.saveUvarint(m, unsafe.Offsetof(p.RawValueSize), p.RawValueSize)
+	if p.ValueBlocksAreEnabled {
+		p.saveBool(m, unsafe.Offsetof(p.ValueBlocksAreEnabled), p.ValueBlocksAreEnabled)
+	}
 	p.saveBool(m, unsafe.Offsetof(p.WholeKeyFiltering), p.WholeKeyFiltering)
 
 	keys := make([]string, 0, len(m))

--- a/sstable/raw_block.go
+++ b/sstable/raw_block.go
@@ -26,7 +26,7 @@ func (w *rawBlockWriter) add(key InternalKey, value []byte) {
 	w.curKey = w.curKey[:size]
 	copy(w.curKey, key.UserKey)
 
-	w.store(size, value)
+	w.store(size, value, false)
 }
 
 // rawBlockIter is an iterator over a single block of data. Unlike blockIter,

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/cockroachdb/pebble/internal/errorfs"
+	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
@@ -860,6 +861,102 @@ func TestValidateBlockChecksums(t *testing.T) {
 	}
 }
 
+// TestValueBlocks is a partial test of all the sstable logic involved in
+// writing and reading values in value blocks.
+//
+// TODO(sumeer): test other key kinds; add unit tests for the lower-level
+// components.
+func TestValueBlocks(t *testing.T) {
+	for _, bs := range []int{1, 20, 4096} {
+		t.Run(fmt.Sprintf("blockSize=%d", bs), func(t *testing.T) {
+			mem := vfs.NewMem()
+			f0, err := mem.Create("test")
+			require.NoError(t, err)
+
+			w := NewWriter(f0, WriterOptions{
+				Comparer:              testkeys.Comparer,
+				ValueBlocksAreEnabled: true,
+				BlockSize:             bs,
+				IndexBlockSize:        1 << 15,
+			})
+			type kvPair struct {
+				k InternalKey
+				v []byte
+			}
+			var kvPairs []kvPair
+			writeKeyValue := func(k []byte, v string) {
+				ikey := base.MakeInternalKey(k, 0, InternalKeyKindSet)
+				require.NoError(t, w.Add(ikey, []byte(v)))
+				kvPairs = append(kvPairs, kvPair{ikey.Clone(), []byte(v)})
+			}
+			var buf [10]byte
+			ks := testkeys.Alpha(5)
+			n := testkeys.WriteKeyAt(buf[:], ks, 0, 10)
+			writeKeyValue(buf[:n], "value_0_10")
+			n = testkeys.WriteKeyAt(buf[:], ks, 1, 20)
+			writeKeyValue(buf[:n], "value_1_20")
+			n = testkeys.WriteKeyAt(buf[:], ks, 1, 10)
+			writeKeyValue(buf[:n], "value_1_10")
+			n = testkeys.WriteKeyAt(buf[:], ks, 1, 9)
+			writeKeyValue(buf[:n], "value_1_9")
+			n = testkeys.WriteKeyAt(buf[:], ks, 1, 8)
+			writeKeyValue(buf[:n], "value_1_8")
+			n = testkeys.WriteKeyAt(buf[:], ks, 1, 7)
+			writeKeyValue(buf[:n], "value_1_7")
+			n = testkeys.WriteKeyAt(buf[:], ks, 1, 6)
+			writeKeyValue(buf[:n], "value_1_6")
+			n = testkeys.WriteKeyAt(buf[:], ks, 1, 3)
+			writeKeyValue(buf[:n], "value_1_3")
+			n = testkeys.WriteKeyAt(buf[:], ks, 2, 42)
+			writeKeyValue(buf[:n], "value_2_42")
+			n = testkeys.WriteKeyAt(buf[:], ks, 2, 21)
+			writeKeyValue(buf[:n], "value_2_21")
+
+			require.NoError(t, w.Close())
+
+			f1, err := mem.Open("test")
+			require.NoError(t, err)
+
+			r, err := NewReader(f1, ReaderOptions{
+				Comparer: testkeys.Comparer,
+			})
+			require.NoError(t, err)
+			defer r.Close()
+
+			for _, lazy := range []bool{false, true} {
+				t.Run(fmt.Sprintf("lazyValue=%t", lazy), func(t *testing.T) {
+					iiter, err := r.NewIter(nil, nil)
+					require.NoError(t, err)
+					iter := iiter.(*singleLevelIterator)
+					defer iter.Close()
+					k, v := iter.SeekGE(kvPairs[0].k.UserKey)
+					i := 0
+					fmt.Printf("iterate\n")
+					for ; i < len(kvPairs); i++ {
+						require.NotNil(t, k)
+						require.Equal(t, kvPairs[i].k, *k)
+						require.Equal(t, kvPairs[i].v, v)
+						fmt.Printf("%s=>%s\n", string(k.UserKey), string(v))
+						if lazy {
+							k = iter.NextLazyValue()
+							if k != nil {
+								v, err = iter.Value()
+								require.NoError(t, err)
+							} else {
+								v = nil
+							}
+						} else {
+							k, v = iter.Next()
+						}
+					}
+					require.Nil(t, v)
+					require.NoError(t, iter.Error())
+				})
+			}
+		})
+	}
+}
+
 func buildTestTable(
 	t *testing.T, numEntries uint64, blockSize, indexBlockSize int, compression Compression,
 ) *Reader {
@@ -1061,5 +1158,116 @@ func BenchmarkTableIterPrev(b *testing.B) {
 				it.Close()
 				r.Close()
 			})
+	}
+}
+
+// TODO(sumeer): add benchmark for 2 versions where the latest version has an
+// empty value. This mimics MVCC deletions and represents workloads which
+// create a high number of garbage rows by writing and deleting.
+
+// BenchmarkValueBlocks benchmarks iteration over a sstable that places values
+// of older key versions in value blocks.
+func BenchmarkValueBlocks(b *testing.B) {
+	numKeys := 10000
+	valueBlocksAreEnabled := true
+	for _, valueSize := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
+			for _, versions := range []int{1, 10, 100} {
+				b.Run(fmt.Sprintf("versions=%d", versions), func(b *testing.B) {
+					mem := vfs.NewMem()
+					f0, err := mem.Create("test")
+					require.NoError(b, err)
+					w := NewWriter(f0, WriterOptions{
+						Comparer:              testkeys.Comparer,
+						ValueBlocksAreEnabled: valueBlocksAreEnabled,
+						// Force single level index since the prototype is limited to singleLevelIterator
+						IndexBlockSize: 1 << 30,
+						BlockSize:      32 << 10,
+					})
+					var buf [10]byte
+					ks := testkeys.Alpha(5)
+					i := 0
+					rng := rand.New(rand.NewSource(0))
+					value := make([]byte, valueSize)
+					k := 0
+					for i < numKeys {
+						for j := 0; j < versions && i < numKeys; j++ {
+							n := testkeys.WriteKeyAt(buf[:], ks, k, 1000-j)
+							ikey := base.MakeInternalKey(buf[:n], 0, InternalKeyKindSet)
+							const letters = "abcdefghijklmnopqrstuvwxyz"
+							const lettersLen = len(letters)
+							for i := 0; i < len(value); i++ {
+								value[i] = letters[rng.Intn(lettersLen)]
+							}
+							require.NoError(b, w.Add(ikey, value))
+							i++
+						}
+						k++
+					}
+					require.NoError(b, w.Close())
+					meta, err := w.Metadata()
+					require.NoError(b, err)
+					fmt.Printf("value-size:%5d,versions:%3d,data-block-bytes:%9d,total-bytes:%9d,"+
+						"fraction-in-data-blocks:%.2f\n",
+						valueSize, versions, meta.Properties.DataSize, meta.Size,
+						float64(meta.Properties.DataSize)/float64(meta.Size))
+					// !needValue represents a workload where only the latest version's
+					// value is needed (which is stored inline). The benchmark mimics
+					// this by using NextLazyValue() and never calling Value() (since it
+					// is simpler than calling Value() only on the latest versions).
+					for _, needValue := range []bool{false, true} {
+						b.Run(fmt.Sprintf("needValue=%t", needValue), func(b *testing.B) {
+							// !hasCache represents a situation where all the steps into a
+							// new block result in a cache miss. That is, it is reading cold
+							// data.
+							for _, hasCache := range []bool{false, true} {
+								b.Run(fmt.Sprintf("hasCache=%t", hasCache), func(b *testing.B) {
+									f1, err := mem.Open("test")
+									require.NoError(b, err)
+									var c *cache.Cache
+									if hasCache {
+										c = cache.New(256 << 20)
+										defer c.Unref()
+									}
+									r, err := NewReader(f1, ReaderOptions{
+										Comparer: testkeys.Comparer,
+										Cache:    c,
+									})
+									require.NoError(b, err)
+									defer r.Close()
+
+									iiter, err := r.NewIter(nil, nil)
+									require.NoError(b, err)
+									iter := iiter.(*singleLevelIterator)
+									defer iter.Close()
+									b.ResetTimer()
+									var k *InternalKey
+									for i := 0; i < b.N; i++ {
+										if k == nil {
+											if i%numKeys != 0 {
+												panic(fmt.Sprintf(
+													"iterator should not be exhausted %d, %d", i, b.N))
+											}
+											k, _ = iter.SeekGE([]byte(""))
+										} else {
+											if needValue {
+												k, _ = iter.Next()
+											} else {
+												k = iter.NextLazyValue()
+											}
+											if k == nil {
+												i--
+											}
+										}
+									}
+									b.StopTimer()
+									require.NoError(b, iter.Error())
+								})
+							}
+						})
+					}
+				})
+			}
+		})
 	}
 }

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -87,6 +87,9 @@ The table file format looks like:
 [index block] (for single level index)
 [meta rangedel block] (optional)
 [meta range key block] (optional)
+[value block 0] (optional)
+[value block M-1] (optional)
+[meta value index block] (optional)
 [meta properties block]
 [metaindex block]
 [footer]
@@ -182,6 +185,7 @@ const (
 	rocksDBFormatVersion2 = 2
 
 	metaRangeKeyName   = "pebble.range_key"
+	metaValueIndexName = "pebble.value_index"
 	metaPropertiesName = "rocksdb.properties"
 	metaRangeDelName   = "rocksdb.range_del"
 	metaRangeDelV2Name = "rocksdb.range_del2"

--- a/sstable/value_block.go
+++ b/sstable/value_block.go
@@ -467,9 +467,71 @@ func (r *valueBlockReader) getValue(valueBytes []byte) ([]byte, error) {
 	default:
 		return nil, errors.Errorf("TODO6")
 	}
-	vh, err := decodeValueHandle(valueBytes)
-	if err != nil {
-		return nil, err
+	// Inlining the decoding here instead of a function call saves 5% in
+	// BenchmarkValueBlocks/valueSize=100/versions=10/needValue=true/hasCache=true.
+	var vh valueHandle
+	{
+		ptr := unsafe.Pointer(&valueBytes[1])
+		// Manually inlined uvarint decoding. Saves ~25% in
+		// BenchmarkValueBlocks/valueSize=100/versions=10/needValue=true/hasCache=true.
+		// Unrolling a loop for i:=0; i<3; i++, saves ~6%.
+		var v uint32
+		if a := *((*uint8)(ptr)); a < 128 {
+			v = uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 1)
+		} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+			v = uint32(b)<<7 | uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 2)
+		} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+			v = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 3)
+		} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+			v = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 4)
+		} else {
+			d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+			v = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 5)
+		}
+		vh.valueLen = v
+
+		if a := *((*uint8)(ptr)); a < 128 {
+			v = uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 1)
+		} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+			v = uint32(b)<<7 | uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 2)
+		} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+			v = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 3)
+		} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+			v = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 4)
+		} else {
+			d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+			v = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 5)
+		}
+		vh.blockNum = v
+
+		if a := *((*uint8)(ptr)); a < 128 {
+			v = uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 1)
+		} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+			v = uint32(b)<<7 | uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 2)
+		} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+			v = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 3)
+		} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+			v = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 4)
+		} else {
+			d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+			v = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 5)
+		}
+		vh.offsetInBlock = v
 	}
 	if r.vbiBlock == nil {
 		ch, err := r.bp.readBlock(r.vbih.h)

--- a/sstable/value_block.go
+++ b/sstable/value_block.go
@@ -1,0 +1,546 @@
+// Copyright 2021 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"encoding/binary"
+	"github.com/cespare/xxhash/v2"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/cache"
+	"github.com/cockroachdb/pebble/internal/crc"
+	"io"
+	"unsafe"
+)
+
+// TODO(sumeer): define a new sstable format version that allows for value
+// block. Such a format can have value blocks disables, in which case it will
+// look identical to its preceding format.
+
+// Value blocks are a mechanism designed for sstables storing MVCC data, where
+// there can be many versions of a key that need to be kept, but only the
+// latest value is typically read. See the documentation for Comparer.Split
+// regarding what are MVCC keys.
+//
+// Note that the notion of the latest value is local to the sstable. It is
+// possible that that latest value has been deleted by a sstable in a higher
+// level, and what is the latest value from the perspective of the whole LSM
+// is an older MVCC version. This only affects performance and not
+// correctness. This local knowledge is also why we continue to store these
+// older versions in the same sstable -- we need to be able to conveniently
+// read them.
+//
+// Data blocks contain two kinds of keys: those with inline values and those
+// with a value handle. These are distinguished by the first byte in the value
+// being either inlineValuePrefix or valueHandlePrefix.
+//
+// Older versions of a key map to a value which is an encoded valueHandle.
+// valueHandles refer to value blocks. Value blocks are simpler than normal
+// data blocks (that contain key-value pairs, and allow for binary search),
+// which makes them cheap for value retrieval purposes. A valueHandle is a
+// tuple (valueLen, blockNum, offsetInBlock), where blockNum is the 0 indexed
+// value block number and offsetInBlock is the byte offset in that block
+// containing the value. The valueHandle.valueLen is included since there are
+// multiple use cases in CockroachDB that need the value length but not the
+// value, for which we can avoid reading the value in the value block (see
+// https://github.com/cockroachdb/pebble/issues/1170#issuecomment-958203245)
+//
+// A value block has a checksum like other blocks, and is optionally
+// compressed. An uncompressed value block is a sequence of (varint encoded
+// value length, value bytes) tuples. The value length is redundant since the
+// valueHandle.valueLen already has the length, and is only to allow
+// additional validation (we may remove it since varint decoding shows up in
+// cpu profiles). The valueHandle.offsetInBlock points to the start of this
+// tuple. While writing a sstable, all the (possibly compressed) value blocks
+// need to be held in-memory until they can be written. Value blocks are
+// placed after the "meta rangedel" and "meta range key" blocks since value
+// blocks are considered less likely to be read.
+//
+// Since the (key, valueHandle) pair are written before there is any knowledge
+// of the byte offset of the value block in the file, or its compressed length,
+// we need another lookup to map the valueHandle.blockNum to the information
+// needed to read it from the file. This information is provided by the
+// "value index block". The "value index block" is referred to by the metaindex
+// block. The design intentionally avoids making the "value index block" a
+// general purpose key-value block, since each caller wants to lookup the information
+// for a particular blockNum (there is no need for SeekGE etc.). Instead, this
+// index block stores a sequence of (blockNum, blockOffset, blockLength) tuples,
+// where the blockNums are consecutive integers, and the tuples are encoded with
+// a fixed width encoding. This allows a reader to find the tuple for block K by
+// looking at the offset K*fixed-width. The fixed width for each field is decided
+// by looking at the maximum value of each of these fields: an extreme case of a
+// 100MB sstable with 2475 value blocks (~32KB each), has this tuple encoded using
+// 2+4+2=8 bytes, which means the uncompressed value index block is 2475*8=~19KB,
+// which is modest. Therefore, we don't support more than one value index block.
+// The metaindex block contains the valueBlockIndexHandle which in addition to
+// the BlockHandle also specifies the widths of these tuple fields.
+
+// valueHandle is stored with a key when the value is in a value block. This
+// handle is the pointer to that value.
+type valueHandle struct {
+	valueLen      uint32
+	blockNum      uint32
+	offsetInBlock uint32
+}
+
+// valueKind is the single byte prefix used to distinguish an inline value
+// from a valueHandle.
+type valueKind byte
+
+const (
+	valueHandlePrefix valueKind = '\xff'
+	inlineValuePrefix valueKind = '\x00'
+)
+
+const valueHandleMaxLen = 5*3 + 1
+
+func encodeValueHandle(dst []byte, v valueHandle) int {
+	dst[0] = byte(valueHandlePrefix)
+	n := 1
+	n += binary.PutUvarint(dst[n:], uint64(v.valueLen))
+	n += binary.PutUvarint(dst[n:], uint64(v.blockNum))
+	n += binary.PutUvarint(dst[n:], uint64(v.offsetInBlock))
+	return n
+}
+
+func decodeValueHandle(src []byte) (valueHandle, error) {
+	var vh valueHandle
+	if len(src) == 0 || src[0] != byte(valueHandlePrefix) {
+		return vh, errors.Errorf("TODO0")
+	}
+	ptr := unsafe.Pointer(&src[1])
+	for i := 0; i < 3; i++ {
+		// Manually inlined uvarint decoding. Saves ~25% in
+		// BenchmarkValueBlocks/valueSize=100/versions=10/needValue=true/hasCache=true.
+		var v uint32
+		if a := *((*uint8)(ptr)); a < 128 {
+			v = uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 1)
+		} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+			v = uint32(b)<<7 | uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 2)
+		} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+			v = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 3)
+		} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+			v = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 4)
+		} else {
+			d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+			v = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 5)
+		}
+		switch i {
+		case 0:
+			vh.valueLen = v
+		case 1:
+			vh.blockNum = v
+		case 2:
+			vh.offsetInBlock = v
+		}
+	}
+	return vh, nil
+}
+
+// valueBlocksIndexHandle is placed in the metaindex if there are any value blocks.
+// If there are no value blocks, there is no value blocks index, and no entry in the
+// metaindex. Note that the lack of entry in the metaindex should not be used to ascertain
+// whether the values are prefixed, since it is an emergent property of the data that
+// was written and not known beforehand.
+type valueBlocksIndexHandle struct {
+	h                     BlockHandle
+	blockNumByteLength    uint8
+	blockOffsetByteLength uint8
+	blockLengthByteLength uint8
+}
+
+const valueBlocksIndexHandleMaxLen = blockHandleMaxLenWithoutProperties + 3
+
+func init() {
+	// Const assertions. Is there a better way in Golang?
+	if valueHandleMaxLen > blockHandleLikelyMaxLen {
+		panic("")
+	}
+	if valueBlocksIndexHandleMaxLen > blockHandleLikelyMaxLen {
+		panic("")
+	}
+}
+
+func encodeValueBlocksIndexHandle(dst []byte, v valueBlocksIndexHandle) int {
+	n := encodeBlockHandle(dst, v.h)
+	dst[n] = v.blockNumByteLength
+	n++
+	dst[n] = v.blockOffsetByteLength
+	n++
+	dst[n] = v.blockLengthByteLength
+	n++
+	return n
+}
+
+func decodeValueBlocksIndexHandle(src []byte) (valueBlocksIndexHandle, int, error) {
+	var vbih valueBlocksIndexHandle
+	var n int
+	vbih.h, n = decodeBlockHandle(src)
+	if n <= 0 {
+		return vbih, 0, errors.Errorf("TODO4")
+	}
+	if len(src) != n+3 {
+		return vbih, 0, errors.Errorf("TODO5")
+	}
+	vbih.blockNumByteLength = src[n]
+	vbih.blockOffsetByteLength = src[n+1]
+	vbih.blockLengthByteLength = src[n+2]
+	return vbih, n + 3, nil
+}
+
+type valueBlocksAndIndexStats struct {
+	numValueBlocks uint64
+	// Includes both value blocks and value blocks index.
+	writtenBytes uint64
+}
+
+// TODO(sumeer): sync.Pools for valueBlockWriter and blockAndHandle etc.
+
+// valueBlockWriter writes a sequence of value blocks, and the value blocks
+// index, for a sstable.
+type valueBlockWriter struct {
+	blockSize    int
+	compression  Compression
+	checksumType ChecksumType
+
+	// Internal state.
+	buf             []byte
+	compressedBuf   []byte
+	blocks          []blockAndHandle
+	totalBlockBytes uint64
+
+	xxHasher *xxhash.Digest
+}
+
+type blockAndHandle struct {
+	block  []byte
+	handle BlockHandle
+}
+
+func (w *valueBlockWriter) addValue(v []byte) (valueHandle, error) {
+	vh := valueHandle{
+		valueLen:      uint32(len(v)),
+		blockNum:      uint32(len(w.blocks)),
+		offsetInBlock: uint32(len(w.buf)),
+	}
+	blockLen := int(vh.offsetInBlock+vh.valueLen) + uvarintLen(vh.valueLen)
+	if cap(w.buf) < blockLen {
+		size := w.blockSize + w.blockSize/2
+		if size < blockLen {
+			size = blockLen + blockLen/2
+		}
+		buf := make([]byte, blockLen, size)
+		copy(buf, w.buf)
+		w.buf = buf
+	} else {
+		w.buf = w.buf[:blockLen]
+	}
+	buf := w.buf[vh.offsetInBlock:]
+	n := binary.PutUvarint(buf, uint64(vh.valueLen))
+	buf = buf[n:]
+	n = copy(buf, v)
+	if n != len(buf) {
+		panic("incorrect length computation")
+	}
+	if len(w.buf) > w.blockSize {
+		// Compress the block and add to blocks.
+		if err := w.compressAndFlush(); err != nil {
+			return valueHandle{}, err
+		}
+	}
+	return vh, nil
+}
+
+func (w *valueBlockWriter) compressAndFlush() error {
+	// Compress the buffer, discarding the result if the improvement isn't at
+	// least 12.5%.
+	// TODO(sumeer): parallel compression.
+	var blockType blockType
+	blockType, w.compressedBuf =
+		compressBlock(w.compression, w.buf, w.compressedBuf[:cap(w.compressedBuf)])
+	var b []byte
+	if len(w.compressedBuf) < len(w.buf)-len(w.buf)/8 {
+		b = w.compressedBuf
+	} else {
+		blockType = noCompressionBlockType
+		b = w.buf
+	}
+	// Allocate the exact size needed, to not waste memory.
+	n := len(b)
+	block := make([]byte, n+blockTrailerLen)
+	copy(block, b)
+	block[n] = byte(blockType)
+
+	if err := w.computeChecksum(block); err != nil {
+		return err
+	}
+	bh := BlockHandle{Offset: w.totalBlockBytes, Length: uint64(n)}
+	w.totalBlockBytes += uint64(len(block))
+	w.blocks = append(w.blocks, blockAndHandle{
+		block:  block,
+		handle: bh,
+	})
+	w.buf = w.buf[:0]
+	return nil
+}
+
+func (w *valueBlockWriter) computeChecksum(block []byte) error {
+	n := len(block) - 4
+	var checksum uint32
+	switch w.checksumType {
+	case ChecksumTypeCRC32c:
+		checksum = crc.New(block[:n]).Value()
+	case ChecksumTypeXXHash64:
+		if w.xxHasher == nil {
+			w.xxHasher = xxhash.New()
+		} else {
+			w.xxHasher.Reset()
+		}
+		w.xxHasher.Write(block[:n])
+		checksum = uint32(w.xxHasher.Sum64())
+	default:
+		return errors.Newf("unsupported checksum type: %d", w.checksumType)
+	}
+	binary.LittleEndian.PutUint32(block[n:], checksum)
+	return nil
+}
+
+func (w *valueBlockWriter) finish(writer io.Writer, offset uint64) (
+	valueBlocksIndexHandle, valueBlocksAndIndexStats, error) {
+	if len(w.buf) > 0 {
+		if err := w.compressAndFlush(); err != nil {
+			return valueBlocksIndexHandle{}, valueBlocksAndIndexStats{}, err
+		}
+	}
+	n := len(w.blocks)
+	if n == 0 {
+		return valueBlocksIndexHandle{}, valueBlocksAndIndexStats{}, nil
+	}
+	largestOffset := uint64(0)
+	largestLength := uint64(0)
+	for i := range w.blocks {
+		_, err := writer.Write(w.blocks[i].block)
+		if err != nil {
+			return valueBlocksIndexHandle{}, valueBlocksAndIndexStats{}, err
+		}
+		w.blocks[i].handle.Offset += offset
+		largestOffset = w.blocks[i].handle.Offset
+		if largestLength < w.blocks[i].handle.Length {
+			largestLength = w.blocks[i].handle.Length
+		}
+	}
+	vbihOffset := offset + w.totalBlockBytes
+
+	vbih := valueBlocksIndexHandle{
+		h: BlockHandle{
+			Offset: vbihOffset,
+		},
+		blockNumByteLength:    uint8(lenLittleEndian(uint64(n - 1))),
+		blockOffsetByteLength: uint8(lenLittleEndian(largestOffset)),
+		blockLengthByteLength: uint8(lenLittleEndian(largestLength)),
+	}
+	var err error
+	if vbih, err = w.writeValueBlocksIndex(writer, vbih); err != nil {
+		return valueBlocksIndexHandle{}, valueBlocksAndIndexStats{}, err
+	}
+	stats := valueBlocksAndIndexStats{
+		numValueBlocks: uint64(n),
+		writtenBytes:   vbih.h.Offset + vbih.h.Length + blockTrailerLen - offset,
+	}
+	return vbih, stats, err
+}
+
+func (w *valueBlockWriter) writeValueBlocksIndex(
+	writer io.Writer, h valueBlocksIndexHandle) (valueBlocksIndexHandle, error) {
+	blockLen :=
+		int(h.blockNumByteLength+h.blockOffsetByteLength+h.blockLengthByteLength) * len(w.blocks)
+	h.h.Length = uint64(blockLen)
+	blockLen += blockTrailerLen
+	var buf []byte
+	if cap(w.buf) < blockLen {
+		buf = make([]byte, blockLen)
+		w.buf = buf
+	} else {
+		buf = w.buf[:blockLen]
+	}
+	b := buf
+	for i := range w.blocks {
+		littleEndianPut(uint64(i), b, int(h.blockNumByteLength))
+		b = b[int(h.blockNumByteLength):]
+		littleEndianPut(w.blocks[i].handle.Offset, b, int(h.blockOffsetByteLength))
+		b = b[int(h.blockOffsetByteLength):]
+		littleEndianPut(w.blocks[i].handle.Length, b, int(h.blockLengthByteLength))
+		b = b[int(h.blockLengthByteLength):]
+	}
+	if len(b) != blockTrailerLen {
+		panic("incorrect length calculation")
+	}
+	b[0] = byte(noCompressionBlockType)
+	if err := w.computeChecksum(buf); err != nil {
+		return valueBlocksIndexHandle{}, err
+	}
+	_, err := writer.Write(buf)
+	if err != nil {
+		return valueBlocksIndexHandle{}, err
+	}
+	return h, nil
+}
+
+func littleEndianPut(v uint64, b []byte, n int) {
+	_ = b[n-1] // bounds check
+	for i := 0; i < n; i++ {
+		b[i] = byte(v)
+		v = v >> 8
+	}
+}
+
+func littleEndianGet(b []byte, n int) uint64 {
+	_ = b[n-1] // bounds check
+	v := uint64(b[0])
+	for i := 1; i < n; i++ {
+		v |= uint64(b[i]) << (8 * i)
+	}
+	return v
+}
+
+func lenLittleEndian(v uint64) int {
+	n := 0
+	for i := 0; i < 8; i++ {
+		n++
+		v = v >> 8
+		if v == 0 {
+			break
+		}
+	}
+	return n
+}
+
+type blockProvider interface {
+	readBlock(h BlockHandle) (cache.Handle, error)
+}
+
+// valueBlockReader is used to retrieve both inline values and values in value
+// blocks. It is used when the sstable was written with
+// Properties.ValueBlocksAreEnabled.
+type valueBlockReader struct {
+	bp blockProvider
+	// Will be an empty handle if the sstable doesn't actually have any values
+	// in value blocks.
+	vbih valueBlocksIndexHandle
+	// The value blocks index is lazily retrieved the first time the reader
+	// needs to read a value that resides in a value block. It is then "cached"
+	// here.
+	vbiBlock []byte
+	vbiCache cache.Handle
+	// When sequentially iterating through all key-value pairs, the cost of
+	// repeatedly getting a block that is already in the cache and releasing the
+	// cache.Handle can be ~40% of the cpu overhead. So the reader remembers the
+	// last value block it retrieved, in case there is locality of access, and
+	// this value block can be used for the next value retrieval.
+	valueBlockNum uint32
+	valueBlock    []byte
+	valueBlockPtr unsafe.Pointer
+	valueCache    cache.Handle
+}
+
+func (r *valueBlockReader) close() {
+	r.vbiBlock = nil
+	r.vbiCache.Release()
+	r.valueCache.Release()
+}
+
+func (r *valueBlockReader) getValue(valueBytes []byte) ([]byte, error) {
+	if len(valueBytes) == 0 {
+		return nil, errors.Errorf("lacking valueKind prefix")
+	}
+	prefix := valueKind(valueBytes[0])
+	switch prefix {
+	case inlineValuePrefix:
+		return valueBytes[1:], nil
+	case valueHandlePrefix:
+	default:
+		return nil, errors.Errorf("TODO6")
+	}
+	vh, err := decodeValueHandle(valueBytes)
+	if err != nil {
+		return nil, err
+	}
+	if r.vbiBlock == nil {
+		ch, err := r.bp.readBlock(r.vbih.h)
+		if err != nil {
+			return nil, err
+		}
+		r.vbiCache = ch
+		r.vbiBlock = ch.Get()
+	}
+	if r.valueBlock == nil || r.valueBlockNum != vh.blockNum {
+		vbh, err := r.getBlockHandle(vh.blockNum)
+		if err != nil {
+			return nil, err
+		}
+		vbCacheHandle, err := r.bp.readBlock(vbh)
+		if err != nil {
+			return nil, err
+		}
+		r.valueBlockNum = vh.blockNum
+		r.valueCache.Release()
+		r.valueCache = vbCacheHandle
+		r.valueBlock = vbCacheHandle.Get()
+		r.valueBlockPtr = unsafe.Pointer(&r.valueBlock[0])
+	}
+	ptr := unsafe.Pointer(uintptr(r.valueBlockPtr) + uintptr(vh.offsetInBlock))
+	var n uint32
+	// Manually inlined uvarint decoding. Saves ~6% on
+	// BenchmarkValueBlocks/valueSize=100/versions=10/needValue=true/hasCache=true.
+	var valueLen uint32
+	if a := *((*uint8)(ptr)); a < 128 {
+		valueLen = uint32(a)
+		n = 1
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+		valueLen = uint32(b)<<7 | uint32(a)
+		n = 2
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+		valueLen = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+		n = 3
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+		valueLen = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+		n = 4
+	} else {
+		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+		valueLen = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+		n = 5
+	}
+	n += vh.offsetInBlock
+	if valueLen != vh.valueLen {
+		return nil, errors.Errorf("TODO8")
+	}
+	return r.valueBlock[n : n+valueLen], nil
+}
+
+func (r *valueBlockReader) getBlockHandle(blockNum uint32) (BlockHandle, error) {
+	indexEntryLen :=
+		int(r.vbih.blockNumByteLength + r.vbih.blockOffsetByteLength + r.vbih.blockLengthByteLength)
+	offsetInIndex := indexEntryLen * int(blockNum)
+	if len(r.vbiBlock) < offsetInIndex+indexEntryLen {
+		return BlockHandle{}, errors.Errorf("TODO9")
+	}
+	b := r.vbiBlock[offsetInIndex : offsetInIndex+indexEntryLen]
+	n := int(r.vbih.blockNumByteLength)
+	bn := littleEndianGet(b, n)
+	if uint32(bn) != blockNum {
+		return BlockHandle{}, errors.Errorf("TODO10")
+	}
+	b = b[n:]
+	n = int(r.vbih.blockOffsetByteLength)
+	blockOffset := littleEndianGet(b, n)
+	b = b[n:]
+	n = int(r.vbih.blockLengthByteLength)
+	blockLen := littleEndianGet(b, n)
+	return BlockHandle{Offset: blockOffset, Length: blockLen}, nil
+}

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -299,8 +299,10 @@ func (w *Writer) addPoint(key InternalKey, value []byte) error {
 		w.props.NumValuesInValueBlocks++
 		n := encodeValueHandle(w.tmp[:], vh)
 		// The encoded value handle includes the valueHandlePrefix.
+		// fmt.Printf("     older: block num: %d, current-bytes:%d\n", w.indexBlock.nEntries, len(w.block.buf))
 		w.block.addWithOptionalInlineValuePrefix(key, w.tmp[:n], false)
 	} else {
+		// fmt.Printf("new prefix: block num: %d, current-bytes:%d\n", w.indexBlock.nEntries, len(w.block.buf))
 		w.block.addWithOptionalInlineValuePrefix(key, value, isSetKey && w.valueBlockWriter != nil)
 	}
 

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -183,7 +183,7 @@ compact         1   2.3 K     0 B       0          (size == estimated-debt, scor
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.4 K    5.9%  (score == hit-rate)
- tcache         1   672 B    0.0%  (score == hit-rate)
+ tcache         1   712 B    0.0%  (score == hit-rate)
  titers         0
  filter         -       -    0.0%  (score == utility)
 

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -48,7 +48,7 @@ compact         0     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.5 K   46.7%  (score == hit-rate)
- tcache         1   672 B   50.0%  (score == hit-rate)
+ tcache         1   712 B   50.0%  (score == hit-rate)
  titers         0
  filter         -       -    0.0%  (score == utility)
 

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -34,7 +34,7 @@ compact         0     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         1   256 K
    ztbl         0     0 B
  bcache         4   698 B    0.0%  (score == hit-rate)
- tcache         1   672 B    0.0%  (score == hit-rate)
+ tcache         1   712 B    0.0%  (score == hit-rate)
  titers         1
  filter         -       -    0.0%  (score == utility)
 
@@ -81,7 +81,7 @@ compact         1     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         2   512 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   33.3%  (score == hit-rate)
- tcache         2   1.3 K   50.0%  (score == hit-rate)
+ tcache         2   1.4 K   50.0%  (score == hit-rate)
  titers         2
  filter         -       -    0.0%  (score == utility)
 
@@ -113,7 +113,7 @@ compact         1     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         1   256 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   33.3%  (score == hit-rate)
- tcache         2   1.3 K   50.0%  (score == hit-rate)
+ tcache         2   1.4 K   50.0%  (score == hit-rate)
  titers         2
  filter         -       -    0.0%  (score == utility)
 
@@ -142,7 +142,7 @@ compact         1     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         1   256 K
    ztbl         1   771 B
  bcache         4   698 B   33.3%  (score == hit-rate)
- tcache         1   672 B   50.0%  (score == hit-rate)
+ tcache         1   712 B   50.0%  (score == hit-rate)
  titers         1
  filter         -       -    0.0%  (score == utility)
 


### PR DESCRIPTION
When WriterOptions.ValueBlocksAreEnabled is set to true, older
versions of a key are written to a sequence of value blocks, and
the key contains a valueHandle which is a tuple
(valueLen, blockNum, offsetInBlock). The assumption here is
that most reads only need the value of the latest version, and
many reads that care about an older version only need the value
length.

Value blocks are a simple sequence of (varint encoded length,
value bytes) tuples such that given the uncompressed value
block, the valueHandle can cheaply read the value. The value
blocks index connects the blockNum in the valueHandle to the
location of the value block. It uses fixed width encoding to
avoid the expense of a general purpose key-value block.

See the comment at the top of value_block.go for details.

The following are preliminary results from a read benchmark,
after some performance tuning. The old numbers are master.
The needValue=false cases are the ones where value blocks are
expected to help.
- The versions=1 have no values in value blocks, and the slowdown
  is the extra call to valueBlockReader that needs to subslice
  to remove the single byte prefix.
- The hasCache=false case correspond to a cold cache, where there
  will be additional wasted decompression of values that we don't
  need (when needValue=false). As expected, when there is an
  improvement, it is larger with hasCache=false. For example the
  -97.83% below (almost 50x faster) compared with -79.89%.
- The needValue=true is where the code can be slower up to 2x.
  The higher slowdowns occur when the value size is smaller. In
  such cases more inline values can be packed into an ssblock and
  the code overhead of decoding the valueHandle, and the value
  length in the value block (all of these are varints) becomes
  a significant component.

This is a prototype in that there are no changes to the
InternalIterator interface, and the read path only works for
singleLevelIterator.

```
name                                                                        old time/op    new time/op    delta
ValueBlocks/valueSize=100/versions=1/needValue=false/hasCache=false-16        25.5ns ± 3%    25.9ns ± 2%   +1.50%  (p=0.028 n=10+10)
ValueBlocks/valueSize=100/versions=1/needValue=false/hasCache=true-16         15.6ns ± 1%    15.5ns ± 2%     ~     (p=0.268 n=9+10)
ValueBlocks/valueSize=100/versions=1/needValue=true/hasCache=false-16         27.3ns ± 3%    29.5ns ± 3%   +8.11%  (p=0.000 n=10+10)
ValueBlocks/valueSize=100/versions=1/needValue=true/hasCache=true-16          17.1ns ± 2%    19.2ns ± 2%  +12.74%  (p=0.000 n=10+10)
ValueBlocks/valueSize=100/versions=10/needValue=false/hasCache=false-16       26.7ns ± 2%    29.4ns ± 2%  +10.46%  (p=0.000 n=9+10)
ValueBlocks/valueSize=100/versions=10/needValue=false/hasCache=true-16        15.9ns ± 2%    15.2ns ± 3%   -4.63%  (p=0.000 n=9+10)
ValueBlocks/valueSize=100/versions=10/needValue=true/hasCache=false-16        26.7ns ± 2%    53.0ns ± 4%  +98.79%  (p=0.000 n=9+10)
ValueBlocks/valueSize=100/versions=10/needValue=true/hasCache=true-16         16.6ns ± 1%    26.7ns ± 2%  +61.05%  (p=0.000 n=9+9)
ValueBlocks/valueSize=100/versions=100/needValue=false/hasCache=false-16      28.3ns ± 4%    25.3ns ± 5%  -10.74%  (p=0.000 n=10+10)
ValueBlocks/valueSize=100/versions=100/needValue=false/hasCache=true-16       15.8ns ± 2%    14.9ns ± 1%   -5.66%  (p=0.000 n=10+10)
ValueBlocks/valueSize=100/versions=100/needValue=true/hasCache=false-16       29.4ns ± 4%    47.8ns ± 3%  +62.46%  (p=0.000 n=10+10)
ValueBlocks/valueSize=100/versions=100/needValue=true/hasCache=true-16        16.7ns ± 4%    26.1ns ± 3%  +56.04%  (p=0.000 n=10+10)
ValueBlocks/valueSize=1000/versions=1/needValue=false/hasCache=false-16        123ns ± 4%     125ns ± 7%     ~     (p=0.735 n=9+10)
ValueBlocks/valueSize=1000/versions=1/needValue=false/hasCache=true-16        23.0ns ± 5%    22.9ns ± 5%     ~     (p=0.684 n=10+10)
ValueBlocks/valueSize=1000/versions=1/needValue=true/hasCache=false-16         124ns ± 6%     131ns ± 7%   +5.76%  (p=0.008 n=9+10)
ValueBlocks/valueSize=1000/versions=1/needValue=true/hasCache=true-16         24.3ns ± 4%    26.4ns ± 3%   +8.26%  (p=0.000 n=10+10)
ValueBlocks/valueSize=1000/versions=10/needValue=false/hasCache=false-16       130ns ± 8%      27ns ± 4%  -79.10%  (p=0.000 n=10+10)
ValueBlocks/valueSize=1000/versions=10/needValue=false/hasCache=true-16       23.8ns ± 4%    16.6ns ± 2%  -30.00%  (p=0.000 n=10+10)
ValueBlocks/valueSize=1000/versions=10/needValue=true/hasCache=false-16        128ns ± 9%     164ns ±12%  +27.94%  (p=0.000 n=10+10)
ValueBlocks/valueSize=1000/versions=10/needValue=true/hasCache=true-16        25.0ns ± 4%    33.0ns ± 2%  +32.22%  (p=0.000 n=10+10)
ValueBlocks/valueSize=1000/versions=100/needValue=false/hasCache=false-16      123ns ± 9%      28ns ± 3%  -76.89%  (p=0.000 n=9+10)
ValueBlocks/valueSize=1000/versions=100/needValue=false/hasCache=true-16      23.0ns ± 2%    15.3ns ± 5%  -33.36%  (p=0.000 n=10+9)
ValueBlocks/valueSize=1000/versions=100/needValue=true/hasCache=false-16       132ns ± 2%     171ns ± 5%  +29.24%  (p=0.000 n=8+10)
ValueBlocks/valueSize=1000/versions=100/needValue=true/hasCache=true-16       24.3ns ± 3%    32.6ns ± 3%  +33.98%  (p=0.000 n=10+10)
ValueBlocks/valueSize=10000/versions=1/needValue=false/hasCache=false-16      1.45µs ± 8%    1.35µs ±10%   -6.41%  (p=0.015 n=10+10)
ValueBlocks/valueSize=10000/versions=1/needValue=false/hasCache=true-16       75.5ns ± 2%    76.7ns ± 5%     ~     (p=0.218 n=10+10)
ValueBlocks/valueSize=10000/versions=1/needValue=true/hasCache=false-16       1.34µs ± 3%    1.46µs ±16%   +9.03%  (p=0.022 n=9+10)
ValueBlocks/valueSize=10000/versions=1/needValue=true/hasCache=true-16        77.0ns ± 3%    79.9ns ± 3%   +3.80%  (p=0.000 n=9+10)
ValueBlocks/valueSize=10000/versions=10/needValue=false/hasCache=false-16     1.46µs ± 6%    0.13µs ± 3%  -91.15%  (p=0.000 n=9+9)
ValueBlocks/valueSize=10000/versions=10/needValue=false/hasCache=true-16      76.4ns ± 3%    21.4ns ± 2%  -72.06%  (p=0.000 n=10+10)
ValueBlocks/valueSize=10000/versions=10/needValue=true/hasCache=false-16      1.47µs ± 8%    1.56µs ± 7%   +5.72%  (p=0.013 n=9+10)
ValueBlocks/valueSize=10000/versions=10/needValue=true/hasCache=true-16       78.1ns ± 4%    76.1ns ± 2%   -2.52%  (p=0.009 n=10+10)
ValueBlocks/valueSize=10000/versions=100/needValue=false/hasCache=false-16    1.34µs ± 5%    0.03µs ± 2%  -97.83%  (p=0.000 n=9+10)
ValueBlocks/valueSize=10000/versions=100/needValue=false/hasCache=true-16     77.0ns ± 2%    15.5ns ± 2%  -79.89%  (p=0.000 n=8+10)
ValueBlocks/valueSize=10000/versions=100/needValue=true/hasCache=false-16     1.42µs ± 9%    1.49µs ± 2%   +5.28%  (p=0.007 n=10+9)
ValueBlocks/valueSize=10000/versions=100/needValue=true/hasCache=true-16      78.5ns ± 4%    73.0ns ± 4%   -7.01%  (p=0.000 n=10+9)
```

Informs #1170