### PR TITLE
sstable: add (*sstable.Writer).RangeKey{Set,Unset,Delete} methods

### DIFF
--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -142,7 +142,7 @@ func runBuildCmd(
 		n := rangekey.RecombinedValueLen(v.Start.Kind(), v.End, v.Value)
 		b := make([]byte, n)
 		_ = rangekey.RecombineValue(v.Start.Kind(), b, v.End, v.Value)
-		if err := w.AddInternalRangeKey(v.Start, b); err != nil {
+		if err := w.AddRangeKey(v.Start, b); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -198,7 +198,7 @@ func runBuildRawCmd(td *datadriven.TestData) (*WriterMetadata, *Reader, error) {
 			// Values for range keys must be converted into their "packed" form before
 			// being added to the Writer.
 			_, value := rangekey.Parse(data)
-			if err := w.AddInternalRangeKey(key, value); err != nil {
+			if err := w.AddRangeKey(key, value); err != nil {
 				return nil, nil, err
 			}
 		default:

--- a/sstable/testdata/writer_range_keys
+++ b/sstable/testdata/writer_range_keys
@@ -1,0 +1,176 @@
+# NOTE: The operations SET, UNSET, and DEL in this test file are aliases for
+# RANGEKEYSET, RANGEKEYUNSET and RANGEKEYDEL, respectively.
+
+# Keys must be added in order of start key.
+
+build
+SET b-d @3=foo
+SET a-c @5=bar
+----
+pebble: spans must be added in order: b > a
+
+# All disjoint RANGEKEYSETs.
+#
+#  ^
+#  |                •―――○    [e,f) SET @3=baz
+#  |        •―――○            [c,d) SET @2=bar
+#  |•―――――――○                [a,c) SET @1=foo
+#  |___________________________________
+#   a   b   c   d   e   f   g   h   i
+
+build
+SET a-c @1=foo
+SET c-d @2=bar
+SET e-f @3=baz
+----
+a.RANGEKEYSET.0: c [(@1=foo)]
+c.RANGEKEYSET.0: d [(@2=bar)]
+e.RANGEKEYSET.0: f [(@3=baz)]
+
+# Merge aligned RANGEKEYSETs.
+#
+#  ^
+#  |•―――――――○    [a,c) SET @3=baz
+#  |•―――――――○    [a,c) SET @1=bar
+#  |•―――――――○    [a,c) SET @2=foo
+#  |___________________________________
+#   a   b   c   d   e   f   g   h   i
+#
+# Note that suffixes are sorted in descending order of the timestamp value in
+# the suffix, rather than in lexical order.
+
+build
+SET a-c @2=foo
+SET a-c @1=bar
+SET a-c @3=baz
+----
+a.RANGEKEYSET.0: c [(@3=baz),(@2=foo),(@1=bar)]
+
+# Aligned spans, mixed range key kinds.
+#
+#  ^
+#  |                    •―――――――――――○    [f,i) DEL
+#  |                    •―――――――――――○    [f,i) SET   @9=v9
+#  |                    •―――――――――――○    [f,i) SET   @8=v8
+#  |                    •―――――――――――○    [f,i) SET   @7=v7
+#  |                    •―――――――――――○    [f,i) UNSET @6
+#  |                    •―――――――――――○    [f,i) SET   @5=v5
+#  |                    •―――――――――――○    [f,i) SET   @4=v4
+#  |            •―――○                    [d,e) SET   @9=v9
+#  |            •―――○                    [d,e) DEL
+#  |        •―――○                        [c,d) SET   @5=v5
+#  |        •―――○                        [c,d) SET   @2=v2
+#  |•―――――――○                            [a,c) UNSET @5
+#  |•―――――――○                            [a,c) SET   @1=v1
+#  |___________________________________
+#   a   b   c   d   e   f   g   h   i
+
+build
+SET a-c @1=v1
+UNSET a-c @5
+SET c-d @2=v2
+SET c-d @5=v5
+DEL d-e
+SET d-e @9=v9
+SET f-i @4=v4
+SET f-i @5=v5
+UNSET f-i @6
+SET f-i @7=v7
+SET f-i @8=v8
+SET f-i @9=v9
+DEL f-i
+----
+a.RANGEKEYSET.0: c [(@1=v1)]
+a.RANGEKEYUNSET.0: c [@5]
+c.RANGEKEYSET.0: d [(@5=v5),(@2=v2)]
+d.RANGEKEYSET.0: e [(@9=v9)]
+d.RANGEKEYDEL.0: e
+f.RANGEKEYSET.0: i [(@9=v9),(@8=v8),(@7=v7),(@5=v5),(@4=v4)]
+f.RANGEKEYUNSET.0: i [@6]
+f.RANGEKEYDEL.0: i
+
+# Merge overlapping RANGEKEYSETs.
+#
+#  ^
+#  |        •―――○           [c,d) SET @3=baz
+#  |    •―――――――――――――――○   [b,f) SET @2=bar
+#  |•―――――――○               [a,c) SET @1=foo
+#  |___________________________________
+#   a   b   c   d   e   f
+
+build
+SET a-c @1=foo
+SET b-f @2=bar
+SET c-d @3=baz
+----
+a.RANGEKEYSET.0: b [(@1=foo)]
+b.RANGEKEYSET.0: c [(@2=bar),(@1=foo)]
+c.RANGEKEYSET.0: d [(@3=baz),(@2=bar)]
+d.RANGEKEYSET.0: f [(@2=bar)]
+
+# Overlapping spans, mixed range keys kinds.
+#
+#  ^
+#  |                      •―――――○     [l,o) DEL
+#  |        •―――――――――――――――――――――――○ [e,q) SET   @4=baz
+#  |    •―○                           [c,d) DEL
+#  |    •―――――――――○                   [c,h) UNSET @3
+#  |  •―○                             [b,c) SET   @2=bar
+#  |•―――――――――――――――○                 [a,i) SET   @1=foo
+#  |___________________________________
+#   a b c d e f g h i j k l m n o p q
+
+build
+SET a-i @1=foo
+SET b-c @2=bar
+UNSET c-h @3
+DEL c-d
+SET e-q @4=baz
+DEL l-o
+----
+a.RANGEKEYSET.0: b [(@1=foo)]
+b.RANGEKEYSET.0: c [(@2=bar),(@1=foo)]
+c.RANGEKEYSET.0: d [(@1=foo)]
+c.RANGEKEYUNSET.0: d [@3]
+c.RANGEKEYDEL.0: d
+d.RANGEKEYSET.0: e [(@1=foo)]
+d.RANGEKEYUNSET.0: e [@3]
+e.RANGEKEYSET.0: h [(@4=baz),(@1=foo)]
+e.RANGEKEYUNSET.0: h [@3]
+h.RANGEKEYSET.0: i [(@4=baz),(@1=foo)]
+i.RANGEKEYSET.0: l [(@4=baz)]
+l.RANGEKEYSET.0: o [(@4=baz)]
+l.RANGEKEYDEL.0: o
+o.RANGEKEYSET.0: q [(@4=baz)]
+
+build
+UNSET a-b @1
+SET a-b @1=foo
+----
+a.RANGEKEYSET.0: b [(@1=foo)]
+
+# Within the same fragmented span, key kinds do not affect one another. SETs and
+# DELs will have their own records. A SET will eliminate an UNSET as the former
+# sorts before the latter in a fragmented and coalesced span with the same
+# sequence number.
+#
+#  ^
+#  |        •―――――――○        [c,e) SET   @2=bar
+#  |    •―――――――○            [b,d) UNSET @2
+#  |    •―――――――○            [b,d) UNSET @1
+#  |•―――――――○                [a,c) SET   @1=foo
+#  |___________________________________
+#   a   b   c   d   e   f   g   h   i
+
+build
+SET a-c @1=foo
+UNSET b-d @1
+UNSET b-d @2
+SET c-e @2=bar
+----
+a.RANGEKEYSET.0: b [(@1=foo)]
+b.RANGEKEYSET.0: c [(@1=foo)]
+b.RANGEKEYUNSET.0: c [@2]
+c.RANGEKEYSET.0: d [(@2=bar)]
+c.RANGEKEYUNSET.0: d [@1]
+d.RANGEKEYSET.0: e [(@2=bar)]

--- a/sstable/writer_rangekey_test.go
+++ b/sstable/writer_rangekey_test.go
@@ -1,0 +1,137 @@
+package sstable
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/cockroachdb/pebble/internal/keyspan"
+	"github.com/cockroachdb/pebble/internal/rangekey"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriter_RangeKeys(t *testing.T) {
+	var r *Reader
+	defer func() {
+		if r != nil {
+			require.NoError(t, r.Close())
+		}
+	}()
+
+	buildFn := func(td *datadriven.TestData) (*Reader, error) {
+		mem := vfs.NewMem()
+		f, err := mem.Create("test")
+		if err != nil {
+			return nil, err
+		}
+
+		// Use a "suffix-aware" Comparer, that will sort suffix-values in
+		// descending order of timestamp, rather than in lexical order.
+		cmp := testkeys.Comparer
+		w := NewWriter(f, WriterOptions{Comparer: cmp})
+		for _, data := range strings.Split(td.Input, "\n") {
+			// Format. One of:
+			// - SET $START-$END $SUFFIX=$VALUE
+			// - UNSET $START-$END $SUFFIX
+			// - DEL $START-$END
+			parts := strings.Split(data, " ")
+			kind, startEnd := parts[0], parts[1]
+
+			startEndSplit := bytes.Split([]byte(startEnd), []byte("-"))
+
+			var start, end, suffix, value []byte
+			start, end = startEndSplit[0], startEndSplit[1]
+
+			switch kind {
+			case "SET":
+				sv := bytes.Split([]byte(parts[2]), []byte("="))
+				suffix, value = sv[0], sv[1]
+				err = w.RangeKeySet(start, end, suffix, value)
+			case "UNSET":
+				suffix = []byte(parts[2])
+				err = w.RangeKeyUnset(start, end, suffix)
+			case "DEL":
+				err = w.RangeKeyDelete(start, end)
+			default:
+				return nil, errors.Newf("unexpected key kind: %s", kind)
+			}
+
+			if err != nil {
+				return nil, err
+			}
+
+			// Scramble the bytes in each of the input arrays. This helps with
+			// flushing out subtle bugs due to byte slice re-use.
+			for _, slice := range [][]byte{start, end, suffix, value} {
+				_, _ = rand.Read(slice)
+			}
+		}
+
+		if err = w.Close(); err != nil {
+			return nil, err
+		}
+
+		f, err = mem.Open("test")
+		if err != nil {
+			return nil, err
+		}
+
+		r, err = NewReader(f, ReaderOptions{Comparer: cmp})
+		if err != nil {
+			return nil, err
+		}
+
+		return r, nil
+	}
+
+	datadriven.RunTest(t, "testdata/writer_range_keys", func(td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "build":
+			if r != nil {
+				_ = r.Close()
+				r = nil
+			}
+
+			var err error
+			r, err = buildFn(td)
+			if err != nil {
+				return err.Error()
+			}
+
+			iter, err := r.NewRawRangeKeyIter()
+			if err != nil {
+				return err.Error()
+			}
+			defer iter.Close()
+
+			var buf bytes.Buffer
+			for key, val := iter.First(); key != nil; key, val = iter.Next() {
+				if !rangekey.IsRangeKey(key.Kind()) {
+					return fmt.Sprintf("expected range key kind; got %s", key.Kind())
+				}
+				end, rkVal, ok := rangekey.DecodeEndKey(key.Kind(), val)
+				if !ok {
+					return "could not decode end key"
+				}
+
+				span := keyspan.Span{
+					Start: *key,
+					End:   end,
+					Value: rkVal,
+				}
+				_, _ = fmt.Fprintf(&buf, "%s\n", rangekey.Format(base.DefaultComparer.FormatKey, span))
+			}
+			return buf.String()
+
+		default:
+			return fmt.Sprintf("unknown command: %s", td.Cmd)
+		}
+	})
+}


### PR DESCRIPTION

Users of `sstable.Writer` other than Pebble itself (e.g. Cockroach)
require a means of adding range keys to an sstable that is slightly more
flexible than the existing `AddRangeKey` method in the way in which key
spans can be added to the table.

Specifically, `AddRangeKey` requires that spans be sorted (start / end
key ascending, sequence number and key kind descending), in addition to
fragmented and coalesced (i.e. multiple suffixes within the same span
are coalesced into a single value).

Add the `RangeKey{Set,Unset,Delete}` methods on the `sstable.Writer`
that allow adding spans in order of start key. These methods have no
requirement that the spans be fragmented or coalesced. Instead, the
implementation handles the fragmenting of spans as keys are added. A
`keyspan.Fragmenter` emits completed spans into a `rangekey.coalescer`,
which aggregates the fragments for the same span into a
`rangekey.CoalescedSpan`, which can then be used to write the individual
`RangeKey{Set,Unset,Delete}` key / value pairs into the rang key block
in the sstable.

The new `RangeKey{Set,Unset,Delete}` methods have similar semantics to
the existing `Set,Delete,DeleteRange,Merge` methods that write the key /
value pairs at sequence number zero. In the range key case, these new
methods are intended to be used by external callers when preparing
sstables for ingestion.

Add a data-driven test specific to the new range key methods. These
tests are separate to the existing data driven test cases for the
`AddRangeKey` method, which has stricter requirements on how keys are
added (i.e. already ordered, fragmented and coalesced).

Rename `AddInternalRangeKey` to `AddRangeKey` to better match the
existing naming of `(*sstable.Writer).Add`.

Add new utility methods to the `rangekey` package to aid in encoding
range key values.

Related to #1339.

---

Some open questions:

- [x] Should the API allow for passing in multiple suffix / value pairs with the same start / end key - currently the caller would need to make multiple calls.
- [x] Safety guarantees of passing byte slices to the new functions. Specifically, we only perform a copy when a span is finalized. Depending on how the caller re-uses any byte slices, the underlying values in the fragmenter may change.