### PR TITLE
sstable: return err from `(BlockPropertyCollector).FinishTable`

### DIFF
--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -527,7 +527,7 @@ func (w *Writer) maybeAddBlockPropertiesToBlockHandle(
 	for i := range w.blockPropCollectors {
 		scratch := w.blockPropsEncoder.getScratchForProp()
 		if scratch, err = w.blockPropCollectors[i].FinishDataBlock(scratch); err != nil {
-			return BlockHandleWithProperties{}, nil
+			return BlockHandleWithProperties{}, err
 		}
 		if len(scratch) > 0 {
 			w.blockPropsEncoder.addProp(shortID(i), scratch)


### PR DESCRIPTION
Currently, when finalizing the properties for a table, any error
returned by the `BlockPropertyCollector` is silently ignored.

Return any error returned by the collector.