### PR TITLE
tool/logs: aggregate compaction logs by node and store ID

### DIFF
--- a/tool/logs/compaction_test.go
+++ b/tool/logs/compaction_test.go
@@ -5,18 +5,30 @@
 package logs
 
 import (
+	"bytes"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
 	"regexp"
 	"testing"
+	"time"
 
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/stretchr/testify/require"
 )
 
 const (
-	compactionStartLine = `I211215 14:26:56.012382 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n5,pebble,s5] 1216510  [JOB 284925] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)`
-	compactionEndLine   = `I211215 14:26:56.318543 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n5,pebble,s5] 1216554  [JOB 284925] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s`
-	flushStartLine      = `I211213 16:23:48.903751 21136 3@vendor/github.com/cockroachdb/pebble/event.go:599 ⋮ [n9,pebble,s9] 24 [JOB 10] flushing 2 memtables to L0`
-	flushEndLine        = `I211213 16:23:49.134464 21136 3@vendor/github.com/cockroachdb/pebble/event.go:603 ⋮ [n9,pebble,s9] 26 [JOB 10] flushed 2 memtables to L0 [1535806] (1.3 M), in 0.2s, output rate 5.8 M/s`
-	readAmpLine         = `I211215 14:55:15.802648 155 kv/kvserver/store.go:2668 ⋮ [n5,s5] 109057 +  total     44905   672 G       -   1.2 T   714 G   118 K   215 G    34 K   4.0 T   379 K   2.8 T     514     3.4`
+	compactionStartLine = `I211215 14:26:56.012382 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n5,pebble,s6] 1216510  [JOB 284925] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)`
+	compactionEndLine   = `I211215 14:26:56.318543 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n5,pebble,s6] 1216554  [JOB 284925] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s`
+	flushStartLine      = `I211213 16:23:48.903751 21136 3@vendor/github.com/cockroachdb/pebble/event.go:599 ⋮ [n9,pebble,s8] 24 [JOB 10] flushing 2 memtables to L0`
+	flushEndLine        = `I211213 16:23:49.134464 21136 3@vendor/github.com/cockroachdb/pebble/event.go:603 ⋮ [n9,pebble,s8] 26 [JOB 10] flushed 2 memtables to L0 [1535806] (1.3 M), in 0.2s, output rate 5.8 M/s`
+	readAmpLine         = `I211215 14:55:15.802648 155 kv/kvserver/store.go:2668 ⋮ [n5,s6] 109057 +  total     44905   672 G       -   1.2 T   714 G   118 K   215 G    34 K   4.0 T   379 K   2.8 T     514     3.4`
+
+	compactionStartNoNodeStoreLine = `I211215 14:26:56.012382 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n?,pebble,s?] 1216510  [JOB 284925] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)`
+	flushStartNoNodeStoreLine      = `I211213 16:23:48.903751 21136 3@vendor/github.com/cockroachdb/pebble/event.go:599 ⋮ [n?,pebble,s?] 24 [JOB 10] flushing 2 memtables to L0`
+	readAmpNoNodeStoreLine         = `I211215 14:55:15.802648 155 kv/kvserver/store.go:2668 ⋮ [n?,s?] 109057 +  total     44905   672 G       -   1.2 T   714 G   118 K   215 G    34 K   4.0 T   379 K   2.8 T     514     3.4`
 )
 
 func TestCompactionLogs_Regex(t *testing.T) {
@@ -68,6 +80,25 @@ func TestCompactionLogs_Regex(t *testing.T) {
 			line: compactionStartLine,
 			matches: map[int]string{
 				compactionPatternTimestampIdx: "211215 14:26:56.012382",
+				compactionPatternNode:         "5",
+				compactionPatternStore:        "6",
+				compactionPatternJobIdx:       "284925",
+				compactionPatternSuffixIdx:    "ing",
+				compactionPatternTypeIdx:      "default",
+				compactionPatternFromIdx:      "2",
+				compactionPatternToIdx:        "3",
+				compactionPatternDigitIdx:     "8.4",
+				compactionPatternUnitIdx:      "M",
+			},
+		},
+		{
+			name: "compaction start - no node / store",
+			re:   compactionPattern,
+			line: compactionStartNoNodeStoreLine,
+			matches: map[int]string{
+				compactionPatternTimestampIdx: "211215 14:26:56.012382",
+				compactionPatternNode:         "?",
+				compactionPatternStore:        "?",
 				compactionPatternJobIdx:       "284925",
 				compactionPatternSuffixIdx:    "ing",
 				compactionPatternTypeIdx:      "default",
@@ -83,6 +114,8 @@ func TestCompactionLogs_Regex(t *testing.T) {
 			line: compactionEndLine,
 			matches: map[int]string{
 				compactionPatternTimestampIdx: "211215 14:26:56.318543",
+				compactionPatternNode:         "5",
+				compactionPatternStore:        "6",
 				compactionPatternJobIdx:       "284925",
 				compactionPatternSuffixIdx:    "ed",
 				compactionPatternTypeIdx:      "default",
@@ -98,6 +131,22 @@ func TestCompactionLogs_Regex(t *testing.T) {
 			line: flushStartLine,
 			matches: map[int]string{
 				flushPatternTimestampIdx: "211213 16:23:48.903751",
+				flushPatternNode:         "9",
+				flushPatternStore:        "8",
+				flushPatternJobIdx:       "10",
+				flushPatternSuffixIdx:    "ing",
+				flushPatternDigitIdx:     "",
+				flushPatternUnitIdx:      "",
+			},
+		},
+		{
+			name: "flush start - no node / store",
+			re:   flushPattern,
+			line: flushStartNoNodeStoreLine,
+			matches: map[int]string{
+				flushPatternTimestampIdx: "211213 16:23:48.903751",
+				flushPatternNode:         "?",
+				flushPatternStore:        "?",
 				flushPatternJobIdx:       "10",
 				flushPatternSuffixIdx:    "ing",
 				flushPatternDigitIdx:     "",
@@ -110,6 +159,8 @@ func TestCompactionLogs_Regex(t *testing.T) {
 			line: flushEndLine,
 			matches: map[int]string{
 				flushPatternTimestampIdx: "211213 16:23:49.134464",
+				flushPatternNode:         "9",
+				flushPatternStore:        "8",
 				flushPatternJobIdx:       "10",
 				flushPatternSuffixIdx:    "ed",
 				flushPatternDigitIdx:     "1.3",
@@ -122,6 +173,19 @@ func TestCompactionLogs_Regex(t *testing.T) {
 			line: readAmpLine,
 			matches: map[int]string{
 				readAmpPatternTimestampIdx: "211215 14:55:15.802648",
+				readAmpPatternNode:         "5",
+				readAmpPatternStore:        "6",
+				readAmpPatternValueIdx:     "514",
+			},
+		},
+		{
+			name: "read amp - no node / store",
+			re:   readAmpPattern,
+			line: readAmpNoNodeStoreLine,
+			matches: map[int]string{
+				readAmpPatternTimestampIdx: "211215 14:55:15.802648",
+				readAmpPatternNode:         "?",
+				readAmpPatternStore:        "?",
 				readAmpPatternValueIdx:     "514",
 			},
 		},
@@ -136,4 +200,94 @@ func TestCompactionLogs_Regex(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCompactionLogs(t *testing.T) {
+	var c *logEventCollector
+	var pebbleFileNum, cockroachFileNum int
+	resetFn := func() {
+		c = newEventCollector()
+		pebbleFileNum, cockroachFileNum = 0, 0
+	}
+	resetFn()
+
+	dir := t.TempDir()
+	datadriven.RunTest(t, "testdata/compactions", func(td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "pebble-log":
+			basename := fmt.Sprintf("pebble.%d.log", pebbleFileNum)
+			pebbleFileNum++
+			f, err := os.Create(filepath.Join(dir, basename))
+			if err != nil {
+				panic(err)
+			}
+			if _, err = f.WriteString(td.Input); err != nil {
+				panic(err)
+			}
+			_ = f.Close()
+
+			if err = parseLog(f.Name(), c, parsePebbleFn); err != nil {
+				return err.Error()
+			}
+			return basename
+
+		case "cockroach-log":
+			basename := fmt.Sprintf("cockroach.%d.log", cockroachFileNum)
+			cockroachFileNum++
+			f, err := os.Create(filepath.Join(dir, basename))
+			if err != nil {
+				panic(err)
+			}
+			if _, err := f.WriteString(td.Input); err != nil {
+				panic(err)
+			}
+			_ = f.Close()
+
+			if err = parseLog(f.Name(), c, parseCockroachFn); err != nil {
+				return err.Error()
+			}
+			return basename
+
+		case "summarize":
+			window := 1 * time.Minute
+			longRunning := time.Duration(math.MaxInt64)
+
+			var err error
+			for _, cmdArg := range td.CmdArgs {
+				switch cmdArg.Key {
+				case "window":
+					window, err = time.ParseDuration(cmdArg.Vals[0])
+					if err != nil {
+						panic(errors.Newf("could not parse window: %s", err))
+					}
+
+				case "long-running":
+					longRunning, err = time.ParseDuration(cmdArg.Vals[0])
+					if err != nil {
+						panic(errors.Newf("could not parse long-running: %s", err))
+					}
+
+				default:
+					panic(errors.Newf("unknown arg %q", cmdArg.Key))
+				}
+			}
+
+			a := newAggregator(window, longRunning, c.compactions, c.readAmps)
+			windows := a.aggregate()
+
+			var b bytes.Buffer
+			for _, w := range windows {
+				b.WriteString(w.String())
+			}
+
+			return b.String()
+
+		case "reset":
+			resetFn()
+			return ""
+
+		default:
+			return fmt.Sprintf("unknown command %q", td.Cmd)
+		}
+	})
 }

--- a/tool/logs/testdata/compactions
+++ b/tool/logs/testdata/compactions
@@ -1,0 +1,267 @@
+# Single compaction and flush pair for a single node / store combination.
+
+pebble-log
+I211215 00:00:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s1] 1216510  [JOB 1] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)
+I211215 00:00:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s1] 1216554  [JOB 1] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
+
+I211215 00:01:10.000000 21136 3@vendor/github.com/cockroachdb/pebble/event.go:599 ⋮ [n1,pebble,s1] 24 [JOB 2] flushing 2 memtables to L0
+I211215 00:01:20.000000 21136 3@vendor/github.com/cockroachdb/pebble/event.go:603 ⋮ [n1,pebble,s1] 26 [JOB 2] flushed 2 memtables to L0 [1535806] (1.3 M), in 0.2s, output rate 5.8 M/s
+----
+pebble.0.log
+
+summarize
+----
+node: 1, store: 1
+from: 211215 00:00
+  to: 211215 00:01
+______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
+        L2        L3         1         0         0         0         0         1      13 M       10s
+     total                   1         0         0         0         0         1      13 M        0s
+     r-amp       NaN
+node: 1, store: 1
+from: 211215 00:01
+  to: 211215 00:02
+______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
+       WAL        L0         0         0         0         0         1         1     1.0 M       10s
+     total                   0         0         0         0         1         1     1.0 M        0s
+     r-amp       NaN
+
+# Same as the previous case, except that the start and end events are are split
+# across multiple files (one log line per file).
+
+reset
+----
+
+pebble-log
+I211215 00:00:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s1] 1216510  [JOB 1] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)
+----
+pebble.0.log
+
+pebble-log
+I211215 00:00:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s1] 1216554  [JOB 1] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
+----
+pebble.1.log
+
+pebble-log
+I211215 00:01:10.000000 21136 3@vendor/github.com/cockroachdb/pebble/event.go:599 ⋮ [n1,pebble,s1] 24 [JOB 2] flushing 2 memtables to L0
+----
+pebble.2.log
+
+pebble-log
+I211215 00:01:20.000000 21136 3@vendor/github.com/cockroachdb/pebble/event.go:603 ⋮ [n1,pebble,s1] 26 [JOB 2] flushed 2 memtables to L0 [1535806] (1.3 M), in 0.2s, output rate 5.8 M/s
+----
+pebble.3.log
+
+summarize
+----
+node: 1, store: 1
+from: 211215 00:00
+  to: 211215 00:01
+______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
+        L2        L3         1         0         0         0         0         1      13 M       10s
+     total                   1         0         0         0         0         1      13 M        0s
+     r-amp       NaN
+node: 1, store: 1
+from: 211215 00:01
+  to: 211215 00:02
+______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
+       WAL        L0         0         0         0         0         1         1     1.0 M       10s
+     total                   0         0         0         0         1         1     1.0 M        0s
+     r-amp       NaN
+
+# Read amplification from the Cockroach log, one within an existing window,
+# another outside of the existing window. The latter is not included.
+
+reset
+----
+
+pebble-log
+I211215 00:00:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s1] 1216510  [JOB 1] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)
+I211215 00:00:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s1] 1216554  [JOB 1] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
+----
+pebble.0.log
+
+cockroach-log
+I211215 00:00:15.000000 155 kv/kvserver/store.go:2668 ⋮ [n1,s1] 109057 +  total     44905   672 G       -   1.2 T   714 G   118 K   215 G    34 K   4.0 T   379 K   2.8 T     514     3.4
+I211215 00:01:15.000000 155 kv/kvserver/store.go:2668 ⋮ [n1,s1] 109057 +  total     44905   672 G       -   1.2 T   714 G   118 K   215 G    34 K   4.0 T   379 K   2.8 T     999     3.4
+----
+cockroach.0.log
+
+summarize
+----
+node: 1, store: 1
+from: 211215 00:00
+  to: 211215 00:01
+______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
+        L2        L3         1         0         0         0         0         1      13 M       10s
+     total                   1         0         0         0         0         1      13 M        0s
+     r-amp     514.0
+
+# Long running compaction.
+
+reset
+----
+
+pebble-log
+I211215 00:01:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s1] 1216510  [JOB 1] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)
+I211215 00:03:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s1] 1216554  [JOB 1] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
+----
+pebble.0.log
+
+summarize long-running=1m
+----
+node: 1, store: 1
+from: 211215 00:01
+  to: 211215 00:02
+______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
+        L2        L3         1         0         0         0         0         1      13 M     2m10s
+     total                   1         0         0         0         0         1      13 M      2m0s
+     r-amp       NaN
+long-running compactions (descending runtime):
+______from________to_______job______type_____start_______end____dur(s)_____bytes:
+        L2        L3         1   default  00:01:10  00:03:20       130      13 M
+
+# Single node, multiple stores.
+
+reset
+----
+
+pebble-log
+I211215 00:01:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s1] 1216510  [JOB 1] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)
+I211215 00:01:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s1] 1216554  [JOB 1] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
+
+I211215 00:01:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s2] 1216510  [JOB 2] compacting(default) L3 [442555] (4.2 M) + L4 [445853] (8.4 M)
+I211215 00:01:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s2] 1216554  [JOB 2] compacted(default) L3 [442555] (4.2 M) + L4 [445853] (8.4 M) -> L4 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
+----
+pebble.0.log
+
+summarize
+----
+node: 1, store: 1
+from: 211215 00:01
+  to: 211215 00:02
+______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
+        L2        L3         1         0         0         0         0         1      13 M       10s
+     total                   1         0         0         0         0         1      13 M        0s
+     r-amp       NaN
+node: 1, store: 2
+from: 211215 00:02
+  to: 211215 00:03
+______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
+        L3        L4         1         0         0         0         0         1      13 M       10s
+     total                   1         0         0         0         0         1      13 M        0s
+     r-amp       NaN
+
+# Multiple nodes, single stores. Two separate pebble logs.
+
+reset
+----
+
+pebble-log
+I211215 00:01:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s1] 1216510  [JOB 1] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)
+I211215 00:01:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s1] 1216554  [JOB 1] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
+----
+pebble.0.log
+
+pebble-log
+I211215 00:01:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n2,pebble,s1] 1216510  [JOB 1] compacting(default) L3 [442555] (4.2 M) + L4 [445853] (8.4 M)
+I211215 00:01:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n2,pebble,s1] 1216554  [JOB 1] compacted(default) L3 [442555] (4.2 M) + L4 [445853] (8.4 M) -> L4 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
+----
+pebble.1.log
+
+summarize
+----
+node: 1, store: 1
+from: 211215 00:01
+  to: 211215 00:02
+______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
+        L2        L3         1         0         0         0         0         1      13 M       10s
+     total                   1         0         0         0         0         1      13 M        0s
+     r-amp       NaN
+node: 2, store: 1
+from: 211215 00:02
+  to: 211215 00:03
+______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
+        L3        L4         1         0         0         0         0         1      13 M       10s
+     total                   1         0         0         0         0         1      13 M        0s
+     r-amp       NaN
+
+# Multiple nodes, multiple stores. Two separate pebble logs.
+
+reset
+----
+
+pebble-log
+I211215 00:01:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s1] 1216510  [JOB 1] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)
+I211215 00:01:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s1] 1216554  [JOB 1] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
+
+I211215 00:03:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s2] 1216510  [JOB 2] compacting(default) L1 [442555] (4.2 M) + L2 [445853] (8.4 M)
+I211215 00:03:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s2] 1216554  [JOB 2] compacted(default) L1 [442555] (4.2 M) + L2 [445853] (8.4 M) -> L2 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
+----
+pebble.0.log
+
+pebble-log
+I211215 00:00:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n2,pebble,s1] 1216510  [JOB 1] compacting(default) L3 [442555] (4.2 M) + L4 [445853] (8.4 M)
+I211215 00:00:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n2,pebble,s1] 1216554  [JOB 1] compacted(default) L3 [442555] (4.2 M) + L4 [445853] (8.4 M) -> L4 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
+
+I211215 00:02:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n2,pebble,s2] 1216510  [JOB 2] compacting(default) L4 [442555] (4.2 M) + L5 [445853] (8.4 M)
+I211215 00:02:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n2,pebble,s2] 1216554  [JOB 2] compacted(default) L4 [442555] (4.2 M) + L5 [445853] (8.4 M) -> L5 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
+----
+pebble.1.log
+
+summarize
+----
+node: 1, store: 1
+from: 211215 00:01
+  to: 211215 00:02
+______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
+        L2        L3         1         0         0         0         0         1      13 M       10s
+     total                   1         0         0         0         0         1      13 M        0s
+     r-amp       NaN
+node: 1, store: 2
+from: 211215 00:02
+  to: 211215 00:03
+______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
+        L1        L2         1         0         0         0         0         1      13 M       10s
+     total                   1         0         0         0         0         1      13 M        0s
+     r-amp       NaN
+node: 2, store: 1
+from: 211215 00:03
+  to: 211215 00:04
+______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
+        L3        L4         1         0         0         0         0         1      13 M       10s
+     total                   1         0         0         0         0         1      13 M        0s
+     r-amp       NaN
+node: 2, store: 2
+from: 211215 00:04
+  to: 211215 00:05
+______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
+        L4        L5         1         0         0         0         0         1      13 M       10s
+     total                   1         0         0         0         0         1      13 M        0s
+     r-amp       NaN
+
+# Log lines with an absent node / store are aggregated.
+
+reset
+----
+
+pebble-log
+I211215 00:01:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n?,pebble,s?] 1216510  [JOB 1] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)
+I211215 00:01:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n?,pebble,s?] 1216554  [JOB 1] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
+----
+pebble.0.log
+
+cockroach-log
+I211215 00:01:15.000000 155 kv/kvserver/store.go:2668 ⋮ [n?,s?] 109057 +  total     44905   672 G       -   1.2 T   714 G   118 K   215 G    34 K   4.0 T   379 K   2.8 T     514     3.4
+----
+cockroach.0.log
+
+summarize
+----
+node: ?, store: ?
+from: 211215 00:01
+  to: 211215 00:02
+______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
+        L2        L3         1         0         0         0         0         1      13 M       10s
+     total                   1         0         0         0         0         1      13 M        0s
+     r-amp     514.0


### PR DESCRIPTION
For collections of logs with multiple nodes stores and stores,
compaction summaries should be aggregated across node and store
boundaries to provide more meaningful results. This also avoids errors
when duplicate Job IDs are encountered from different nodes / stores.

Aggregate by node and store ID.

Add a data driven test harness to provide additional coverage using real
log data.