### PR TITLE
tool: constrain lsm visualizer b/w start and end version numbers

### DIFF
--- a/tool/data/lsm.js
+++ b/tool/data/lsm.js
@@ -99,6 +99,7 @@ function styleHeight(e) {
 }
 
 let sliderX, sliderHandle;
+let offsetSliderX;
 
 // The version object holds the current LSM state.
 let version = {
@@ -204,6 +205,9 @@ let version = {
         for (let file of this.levels[0]) {
             let sublevel = null;
             for (let i = index; i >= 0 && (sublevel === null || sublevel === undefined); i--) {
+                if (data.Edits[i].Sublevels == null || data.Edits[i].Sublevels == undefined) {
+                  continue;
+                }
                 sublevel = data.Edits[i].Sublevels[file];
             }
             this.sublevels[sublevel].push(file);
@@ -529,7 +533,7 @@ let version = {
         }
 
         sliderHandle.attr("cx", sliderX(version.index));
-        index.node().value = version.index;
+        index.node().value = version.index + data.StartEdit;
     },
 
     onMouseMove: function(i) {
@@ -640,6 +644,13 @@ let version = {
             .range([0, width])
             .clamp(true);
 
+        // Used only to generate offset ticks for slider.
+        // sliderX is used to index into the data.Edits array (0-indexed).
+        offsetSliderX = d3
+          .scaleLinear()
+          .domain([data.StartEdit, data.StartEdit + data.Edits.length - 1])
+          .range([0, width]);
+
         let slider = svg
             .append("g")
             .attr("class", "slider")
@@ -674,10 +685,10 @@ let version = {
             .attr("class", "ticks")
             .attr("transform", "translate(0," + 18 + ")")
             .selectAll("text")
-            .data(sliderX.ticks(10))
+            .data(offsetSliderX.ticks(10))
             .enter()
             .append("text")
-            .attr("x", sliderX)
+            .attr("x", offsetSliderX)
             .attr("text-anchor", "middle")
             .text(function(d) {
                 return d;
@@ -774,6 +785,9 @@ document.addEventListener("keydown", function(e) {
 
 index.on("input", function() {
     if (!isNaN(+this.value)) {
-        version.set(Number(this.value));
+        const val = Number(this.value) - data.StartEdit;
+        if (val >= 0) {
+            version.set(val);
+        }
     }
 });


### PR DESCRIPTION
This change introduces 2 new CLI arguments for the lsm tool: `start-edit` and `end-edit`. 

These can be used to visualize only a contiguous range of manifest edits. I have also added an offset in the visualizer to make it explicit what the manifest edit range is.

![image](https://user-images.githubusercontent.com/19630228/149036721-b94ee644-3f0a-4523-83f2-fcd8de991201.png)

Resolves https://github.com/cockroachdb/cockroach/issues/74537

Tested with [MANIFEST](https://github.com/cockroachdb/pebble/files/7857097/MANIFEST.sumeer-heuristics.zip)

