### PR TITLE
sstable: add range key support to BlockIntervalCollector

### DIFF
--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1224,7 +1224,9 @@ func TestIteratorBlockIntervalFilter(t *testing.T) {
 			bpCollectors = append(bpCollectors, func() BlockPropertyCollector {
 				return sstable.NewBlockIntervalCollector(
 					fmt.Sprintf("%d", coll.id),
-					&testBlockIntervalCollector{numLength: 2, offsetFromEnd: coll.offset})
+					&testBlockIntervalCollector{numLength: 2, offsetFromEnd: coll.offset},
+					nil, /* range key collector */
+				)
 			})
 		}
 		opts := &Options{
@@ -1344,9 +1346,9 @@ func TestIteratorRandomizedBlockIntervalFilter(t *testing.T) {
 		FormatMajorVersion: FormatNewest,
 		BlockPropertyCollectors: []func() BlockPropertyCollector{
 			func() BlockPropertyCollector {
-				return sstable.NewBlockIntervalCollector("0", &testBlockIntervalCollector{
-					numLength: 2,
-				})
+				return sstable.NewBlockIntervalCollector(
+					"0", &testBlockIntervalCollector{numLength: 2}, nil, /* range key collector */
+				)
 			},
 		},
 	}
@@ -1657,9 +1659,9 @@ func BenchmarkBlockPropertyFilter(b *testing.B) {
 				FormatMajorVersion: FormatNewest,
 				BlockPropertyCollectors: []func() BlockPropertyCollector{
 					func() BlockPropertyCollector {
-						return sstable.NewBlockIntervalCollector("0", &testBlockIntervalCollector{
-							numLength: 3,
-						})
+						return sstable.NewBlockIntervalCollector(
+							"0", &testBlockIntervalCollector{numLength: 3}, nil, /* range key collector */
+						)
 					},
 				},
 			}

--- a/sstable/testdata/block_properties
+++ b/sstable/testdata/block_properties
@@ -1,10 +1,14 @@
-# Two collectors are available:
+# The following collectors are available:
 # - value-first - uses the first character of the value to construct an interval
 # - value-last - uses the last character of the value to construct an interval
+# - suffix - constructs an interval from the '@timestamp' suffix of each key
+# - suffix-point-keys-only - same as "suffix", but only applies to point keys
+# - suffix-range-keys-only - same as "suffix", but only applies to range keys
+# - nil-points-and-ranges - a trivial collector with neither a point nor range collector
 
 # Single collector.
 
-build collector=value-first
+build collectors=(value-first)
 a.SET.1:10
 b.SET.2:20
 c.SET.3:30
@@ -34,7 +38,7 @@ d#72057594037927935,17:
 
 # Multiple collectors.
 
-build collector=value-first collector=value-last
+build collectors=(value-first,value-last)
 a.SET.1:17
 b.SET.2:29
 c.SET.3:38
@@ -63,7 +67,7 @@ d#72057594037927935,17:
 # Reduce the block size to a value such that each block has at most two KV
 # pairs.
 
-build block-size=25 collector=value-first collector=value-last
+build block-size=25 collectors=(value-first,value-last)
 a.SET.1:15
 b.SET.2:86
 c.SET.3:72
@@ -102,3 +106,185 @@ f#6,1:
 i#72057594037927935,17:
   0: [3, 7)
   1: [3, 9)
+
+# Range keys contribute to the table-level property but do not affect point key
+# data blocks.
+
+build collectors=(suffix)
+a@5.SET.1:foo
+b@10.SET.2:bar
+c@15.SET.3:baz
+d@10.RANGEKEYSET.4: e@15 [(@20=foo)]
+e@15.RANGEKEYUNSET.5: f@20 [@25]
+f@20.RANGEKEYDEL.6: z@25
+----
+point:    [a@5#1,1,c@15#3,1]
+rangedel: [#0,0,#0,0]
+rangekey: [d@10#4,21,z@25#72057594037927935,19]
+seqnums:  [1,6]
+
+collectors
+----
+0: suffix
+
+block-props
+----
+d#72057594037927935,17:
+  0: [5, 16)
+
+table-props
+----
+0: [5, 26)
+
+# Same as the above, but only collect point key properties.
+
+build collectors=(suffix-point-keys-only)
+a@5.SET.1:foo
+b@10.SET.2:bar
+c@15.SET.3:baz
+d@10.RANGEKEYSET.4: e@15 [(@20=foo)]
+e@15.RANGEKEYUNSET.5: f@20 [@25]
+f@20.RANGEKEYDEL.6: z@25
+----
+point:    [a@5#1,1,c@15#3,1]
+rangedel: [#0,0,#0,0]
+rangekey: [d@10#4,21,z@25#72057594037927935,19]
+seqnums:  [1,6]
+
+collectors
+----
+0: suffix-point-keys-only
+
+block-props
+----
+d#72057594037927935,17:
+  0: [5, 16)
+
+table-props
+----
+0: [5, 16)
+
+# Same as the above, but only collect range key properties.
+
+build collectors=(suffix-range-keys-only)
+a@5.SET.1:foo
+b@10.SET.2:bar
+c@15.SET.3:baz
+d@10.RANGEKEYSET.4: e@15 [(@20=foo)]
+e@15.RANGEKEYUNSET.5: f@20 [@25]
+f@20.RANGEKEYDEL.6: z@25
+----
+point:    [a@5#1,1,c@15#3,1]
+rangedel: [#0,0,#0,0]
+rangekey: [d@10#4,21,z@25#72057594037927935,19]
+seqnums:  [1,6]
+
+collectors
+----
+0: suffix-range-keys-only
+
+block-props
+----
+d#72057594037927935,17:
+
+table-props
+----
+0: [20, 26)
+
+# Create a table with multiple data blocks and a range key block. Two block
+# property collectors are used, one for range keys and one for point keys, each
+# acting independently.
+
+build block-size=1 collectors=(suffix-point-keys-only,suffix-range-keys-only)
+a@5.SET.1:foo
+b@10.SET.2:bar
+c@15.SET.3:baz
+d@10.RANGEKEYSET.4: e@15 [(@20=foo)]
+e@15.RANGEKEYUNSET.5: f@20 [@25]
+f@20.RANGEKEYDEL.6: z@25
+----
+point:    [a@5#1,1,c@15#3,1]
+rangedel: [#0,0,#0,0]
+rangekey: [d@10#4,21,z@25#72057594037927935,19]
+seqnums:  [1,6]
+
+collectors
+----
+0: suffix-point-keys-only
+1: suffix-range-keys-only
+
+block-props
+----
+b#72057594037927935,17:
+  0: [5, 6)
+c#72057594037927935,17:
+  0: [10, 11)
+d#72057594037927935,17:
+  0: [15, 16)
+
+table-props
+----
+0: [5, 16)
+1: [20, 26)
+
+# Partially matching point key filter.
+
+filter point-filter=(suffix-point-keys-only,10,20)
+----
+points: true, blocks=[1,2]
+ranges: true (no filters provided)
+
+# Non-matching point key filter.
+
+filter point-filter=(suffix-point-keys-only,100,200)
+----
+points: false
+ranges: true (no filters provided)
+
+# Partially matching range key filter.
+
+filter range-filter=(suffix-range-keys-only,10,25)
+----
+points: true (no filters provided)
+ranges: true
+
+# Non-matching range key filter.
+
+filter range-filter=(suffix-range-keys-only,100,200)
+----
+points: true (no filters provided)
+ranges: false
+
+# Matching point and range key filter.
+
+filter point-filter=(suffix-point-keys-only,10,20) range-filter=(suffix-range-keys-only,10,25)
+----
+points: true, blocks=[1,2]
+ranges: true
+
+# Matching point key filter and non-matching range key filter.
+
+filter point-filter=(suffix-point-keys-only,10,20) range-filter=(suffix-range-keys-only,100,200)
+----
+points: true, blocks=[1,2]
+ranges: false
+
+# Non-matching point key filter and matching range key filter.
+
+filter point-filter=(suffix-point-keys-only,100,200) range-filter=(suffix-range-keys-only,10,25)
+----
+points: false
+ranges: true
+
+# Non-matching point and range key filter.
+
+filter point-filter=(suffix-point-keys-only,100,200) range-filter=(suffix-range-keys-only,100,100)
+----
+points: false
+ranges: false
+
+# Providing a nil collector for both points and ranges is a user-error.
+
+build collectors=(nil-points-and-ranges)
+----
+sstable: at least one interval collector must be provided

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -618,6 +618,12 @@ func (w *Writer) addRangeKey(key InternalKey, value []byte) error {
 		panic(errors.Errorf("pebble: invalid range key type: %s", key.Kind()))
 	}
 
+	for i := range w.blockPropCollectors {
+		if err := w.blockPropCollectors[i].Add(key, value); err != nil {
+			return err
+		}
+	}
+
 	// Add the key to the block.
 	w.rangeKeyBlock.add(key, value)
 	return nil


### PR DESCRIPTION
Currently, the `sstable.BlockIntervalCollector` exists as a helper
struct to which an implementation of
`sstable.DataBlockIntervalCollector` is passed. The latter contains the
user-defined logic for converting a key and value in an associated
interval that can be maintained.

The `BlockIntervalCollector` struct handles the logic required to
implement `sstable.BlockPropertyCollector`, encoding the interval as a
property when the data block is completed, and maintaining index-block-
and table-level intervals.

Update `sstable.Writer` to pass through range keys to each block
property collector as they are added to the writer.

As range and point keys can be thought of as existing in separate
keyspaces within the same LSM, range keys only contribute to table level
intervals (unioned with the point key interval), rather than block- and
index-level intervals.

Another way to rationalize this decision is to consider that range keys
are contained in a single, dedicated block in the SSTable, while the
point keys can span multiple blocks and have an associated index entry
into which the properties for the specific block are encoded. Block
level filtering applies to point keys only, whereas table-level
filtering takes the union of the point and range key intervals for the
table.

One downside of taking the union of the range and point keys for the
table level interval is an increased rate of false positives when
filtering tables based on an interval and the range key interval is
wider than the point key interval.

This change alters the `NewBlockIntervalCollector` function to take in
two `DataBlockIntervalCollector`s, one for point and range keys. This is
required to track the intervals separately within the
`BlockIntervalCollector`. The caller has the flexibility of passing in
`nil` for one (or both) of the collectors, in which case either point or
range keys (or both) will be ignored by the collector. This can be used,
for example, to construct a collectors that apply exclusively to either
point or range keys.