### PR TITLE
sstable: reuse index block iterator in Layout

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -2478,6 +2478,7 @@ func (r *Reader) Layout() (*Layout, error) {
 	} else {
 		l.TopIndex = r.indexBH
 		topIter, _ := newBlockIter(r.Compare, indexH.Get())
+		iter := &blockIter{}
 		for key, value := topIter.First(); key != nil; key, value = topIter.Next() {
 			indexBH, err := decodeBlockHandleWithProperties(value)
 			if err != nil {
@@ -2490,7 +2491,9 @@ func (r *Reader) Layout() (*Layout, error) {
 			if err != nil {
 				return nil, err
 			}
-			iter, _ := newBlockIter(r.Compare, subIndex.Get())
+			if err := iter.init(r.Compare, subIndex.Get(), 0 /* globalSeqNum */); err != nil {
+				return nil, err
+			}
 			for key, value := iter.First(); key != nil; key, value = iter.Next() {
 				dataBH, err := decodeBlockHandleWithProperties(value)
 				if err != nil {
@@ -2499,6 +2502,7 @@ func (r *Reader) Layout() (*Layout, error) {
 				l.Data = append(l.Data, dataBH.BlockHandle)
 			}
 			subIndex.Release()
+			*iter = iter.resetForReuse()
 		}
 	}
 

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -1063,3 +1063,13 @@ func BenchmarkTableIterPrev(b *testing.B) {
 			})
 	}
 }
+
+func BenchmarkLayout(b *testing.B) {
+	r, _ := buildBenchmarkTable(b, WriterOptions{})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r.Layout()
+	}
+	b.StopTimer()
+	r.Close()
+}


### PR DESCRIPTION
```
name       old time/op    new time/op    delta
Layout-10    86.1µs ± 0%    85.8µs ± 0%   -0.43%  (p=0.000 n=9+10)

name       old alloc/op   new alloc/op   delta
Layout-10    58.9kB ± 0%    58.5kB ± 0%   -0.57%  (p=0.000 n=10+10)

name       old allocs/op  new allocs/op  delta
Layout-10      31.0 ± 0%      10.0 ± 0%  -67.74%  (p=0.000 n=10+10)
```