### PR TITLE
sstable: unexport BlockIntervalFilter concrete type

### DIFF
--- a/sstable/block_property.go
+++ b/sstable/block_property.go
@@ -242,31 +242,33 @@ func (i interval) intersects(x interval) bool {
 	return i.upper > x.lower && i.lower < x.upper
 }
 
-// BlockIntervalFilter is an implementation of BlockPropertyFilter when the
+// blockIntervalFilter is an implementation of BlockPropertyFilter when the
 // corresponding collector is a BlockIntervalCollector. That is, the set is of
 // the form [lower, upper).
-type BlockIntervalFilter struct {
+type blockIntervalFilter struct {
 	name           string
 	filterInterval interval
 }
 
-// NewBlockIntervalFilter constructs a BlockIntervalFilter with the given name
-// and [lower, upper) bounds.
+// NewBlockIntervalFilter constructs a BlockPropertyFilter that filters blocks
+// based on an interval property collected by BlockIntervalCollector and the
+// given [lower, upper) bounds. The given name specifies the
+// BlockIntervalCollector's properties to read.
 func NewBlockIntervalFilter(
-	name string, lower uint64, upper uint64) *BlockIntervalFilter {
-	return &BlockIntervalFilter{
+	name string, lower uint64, upper uint64) BlockPropertyFilter {
+	return &blockIntervalFilter{
 		name:           name,
 		filterInterval: interval{lower: lower, upper: upper},
 	}
 }
 
 // Name implements the BlockPropertyFilter interface.
-func (b *BlockIntervalFilter) Name() string {
+func (b *blockIntervalFilter) Name() string {
 	return b.name
 }
 
 // Intersects implements the BlockPropertyFilter interface.
-func (b *BlockIntervalFilter) Intersects(prop []byte) (bool, error) {
+func (b *blockIntervalFilter) Intersects(prop []byte) (bool, error) {
 	var i interval
 	if err := i.decode(prop); err != nil {
 		return false, err

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -322,18 +322,18 @@ func TestBlockPropertiesEncoderDecoder(t *testing.T) {
 	require.True(t, decoder.done())
 }
 
-// filterWithTrueForEmptyProp is a wrapper for BlockIntervalFilter that
+// filterWithTrueForEmptyProp is a wrapper for BlockPropertyFilter that
 // delegates to it except when the property is empty, in which case it returns
 // true.
 type filterWithTrueForEmptyProp struct {
-	*BlockIntervalFilter
+	BlockPropertyFilter
 }
 
 func (b filterWithTrueForEmptyProp) Intersects(prop []byte) (bool, error) {
 	if len(prop) == 0 {
 		return true, nil
 	}
-	return b.BlockIntervalFilter.Intersects(prop)
+	return b.BlockPropertyFilter.Intersects(prop)
 }
 
 func TestBlockPropertiesFilterer_IntersectsUserPropsAndFinishInit(t *testing.T) {


### PR DESCRIPTION
Unexport the BlockIntervalFilter implementation of the BlockPropertyFilter,
modifiyng the signature of NewBlockIntervalFilter to return the interface type,
rather than a concrete type.

I think this makes the interface a little more intuitive, since the
BlockIntervalFilter currently provides no additional functionality.