### PR TITLE
db: refactor experimental writer API, expose on DB

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -131,7 +131,7 @@ func TestBatch(t *testing.T) {
 		case InternalKeyKindLogData:
 			_ = b.LogData([]byte(tc.key), nil)
 		case InternalKeyKindRangeKeyDelete:
-			d := b.Experimental().RangeKeyDeleteDeferred(len(key), len(value))
+			d := b.Experimental().(experimentalBatch).RangeKeyDeleteDeferred(len(key), len(value))
 			copy(d.Key, key)
 			copy(d.Value, value)
 			d.Finish()

--- a/db.go
+++ b/db.go
@@ -138,6 +138,47 @@ type Writer interface {
 	//
 	// It is safe to modify the contents of the arguments after Set returns.
 	Set(key, value []byte, o *WriteOptions) error
+
+	// Experimental returns the experimental write API.
+	Experimental() ExperimentalWriter
+}
+
+// ExperimentalWriter provides access to experimental features of a Batch.
+type ExperimentalWriter interface {
+	Writer
+
+	// RangeKeySet sets a range key mapping the key range [start, end) at the MVCC
+	// timestamp suffix to value. The suffix is optional. If any portion of the key
+	// range [start, end) is already set by a range key with the same suffix value,
+	// RangeKeySet overrides it.
+	//
+	// It is safe to modify the contents of the arguments after RangeKeySet returns.
+	//
+	// WARNING: This is an experimental feature with limited functionality.
+	RangeKeySet(start, end, suffix, value []byte, opts *WriteOptions) error
+
+	// RangeKeyUnset removes a range key mapping the key range [start, end) at the
+	// MVCC timestamp suffix. The suffix may be omitted to remove an unsuffixed
+	// range key. RangeKeyUnset only removes portions of range keys that fall within
+	// the [start, end) key span, and only range keys with suffixes that exactly
+	// match the unset suffix.
+	//
+	// It is safe to modify the contents of the arguments after RangeKeyUnset
+	// returns.
+	//
+	// WARNING: This is an experimental feature with limited functionality.
+	RangeKeyUnset(start, end, suffix []byte, opts *WriteOptions) error
+
+	// RangeKeyDelete deletes all of the range keys in the range [start,end)
+	// (inclusive on start, exclusive on end). It does not delete point keys (for
+	// that use DeleteRange). RangeKeyDelete removes all range keys within the
+	// bounds, including those with or without suffixes.
+	//
+	// It is safe to modify the contents of the arguments after RangeKeyDelete
+	// returns.
+	//
+	// WARNING: This is an experimental feature with limited functionality.
+	RangeKeyDelete(start, end []byte, opts *WriteOptions) error
 }
 
 // DB provides a concurrent, persistent ordered key/value store.
@@ -593,6 +634,54 @@ func (d *DB) LogData(data []byte, opts *WriteOptions) error {
 	b := newBatch(d)
 	_ = b.LogData(data, opts)
 	if err := d.Apply(b, opts); err != nil {
+		return err
+	}
+	// Only release the batch on success.
+	b.release()
+	return nil
+}
+
+// Experimental returns the experimental write API.
+func (d *DB) Experimental() ExperimentalWriter {
+	return experimentalDB{d}
+}
+
+type experimentalDB struct {
+	*DB
+}
+
+// RangeKeySet implements the ExperimentalWriter interface.
+func (e experimentalDB) RangeKeySet(start, end, suffix, value []byte, opts *WriteOptions) error {
+	b := newBatch(e.DB)
+	eb := b.Experimental()
+	_ = eb.RangeKeySet(start, end, suffix, value, opts)
+	if err := e.Apply(b, opts); err != nil {
+		return err
+	}
+	// Only release the batch on success.
+	b.release()
+	return nil
+}
+
+// RangeKeyUnset implements the ExperimentalWriter interface.
+func (e experimentalDB) RangeKeyUnset(start, end, suffix []byte, opts *WriteOptions) error {
+	b := newBatch(e.DB)
+	eb := b.Experimental()
+	_ = eb.RangeKeyUnset(start, end, suffix, opts)
+	if err := e.Apply(b, opts); err != nil {
+		return err
+	}
+	// Only release the batch on success.
+	b.release()
+	return nil
+}
+
+// RangeKeyDelete implements the ExperimentalWriter interface.
+func (e experimentalDB) RangeKeyDelete(start, end []byte, opts *WriteOptions) error {
+	b := newBatch(e.DB)
+	eb := b.Experimental()
+	_ = eb.RangeKeyDelete(start, end, opts)
+	if err := e.Apply(b, opts); err != nil {
 		return err
 	}
 	// Only release the batch on success.


### PR DESCRIPTION
Refactor the interface for the experimental write API that exposes range keys,
creating an ExperimentalWriter interface with two implementations: one backed
by a `*Batch` and one backed by a `*DB`. This refactor is necessary so that the
metamorphic tests may apply range keys to both `*DB`s and `*Batch`s.