### PR TITLE
sstable: re-work `TableFormat` enum values

### DIFF
--- a/sstable/options.go
+++ b/sstable/options.go
@@ -54,12 +54,13 @@ type FilterPolicy = base.FilterPolicy
 // format is format version 0.
 type TableFormat uint32
 
-// The available table formats. Note that these values are not (and should not)
-// be serialized to disk. TableFormatRocksDBv2 is the default if otherwise
-// unspecified.
+// The available table formats, representing the tuple (magic number, version
+// number). Note that these values are not (and should not) be serialized to
+// disk.
 const (
-	TableFormatRocksDBv2 TableFormat = iota
+	TableFormatUnspecified TableFormat = iota
 	TableFormatLevelDB
+	TableFormatRocksDBv2
 )
 
 // TablePropertyCollector provides a hook for collecting user-defined
@@ -232,6 +233,9 @@ func (o WriterOptions) ensureDefaults() WriterOptions {
 	}
 	if o.Checksum == ChecksumTypeNone {
 		o.Checksum = ChecksumTypeCRC32c
+	}
+	if o.TableFormat == TableFormatUnspecified {
+		o.TableFormat = TableFormatRocksDBv2
 	}
 	return o
 }

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -402,6 +402,9 @@ func (f footer) encode(buf []byte) []byte {
 		encodeBlockHandle(buf[n:], f.indexBH)
 		binary.LittleEndian.PutUint32(buf[rocksDBVersionOffset:], rocksDBFormatVersion2)
 		copy(buf[len(buf)-len(rocksDBMagic):], rocksDBMagic)
+
+	default:
+		panic("sstable: unspecified table format version")
 	}
 
 	return buf
@@ -413,6 +416,7 @@ func supportsTwoLevelIndex(format TableFormat) bool {
 		return false
 	case TableFormatRocksDBv2:
 		return true
+	default:
+		panic("sstable: unspecified table format version")
 	}
-	return true
 }


### PR DESCRIPTION
Once [Table format version RFC][1] is implemented, the `TableFormat`
enum will include at least two more values for two new Pebble-specific
table features.

In anticipation of the change, re-work the existing enum values to
introduce an "unknown" format version (for when the value is unspecified
and assumes the default value), and order the two existing values in
terms of their natural "lineage" (e.g. LevelDB begat RocksDB, which
begat ..., etc.).

In locations where an unspecified `TableFormat` makes its way all the
way down to the sstable, panic. This ensures that a table format version
is selected explicitly.

[1]: https://github.com/cockroachdb/pebble/pull/1450