### PR TITLE
cmd/pebble: support testkeys comparer

### DIFF
--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/tool"
 	"github.com/spf13/cobra"
 )
@@ -53,7 +54,7 @@ func main() {
 	}
 	rootCmd.AddCommand(benchCmd)
 
-	t := tool.New(tool.Comparers(mvccComparer), tool.Mergers(fauxMVCCMerger))
+	t := tool.New(tool.Comparers(mvccComparer, testkeys.Comparer), tool.Mergers(fauxMVCCMerger))
 	rootCmd.AddCommand(t.Commands...)
 
 	for _, cmd := range []*cobra.Command{compactNewCmd, compactRunCmd, scanCmd, syncCmd, tombstoneCmd, writeBenchCmd, ycsbCmd} {


### PR DESCRIPTION
Support using the pebble command with files that used the
internal/testkeys Comparer.