### PR TITLE
sstable: add a writeQueue to the sstable writer

### DIFF
--- a/sstable/write_queue.go
+++ b/sstable/write_queue.go
@@ -1,0 +1,111 @@
+package sstable
+
+import (
+	"sync"
+
+	"github.com/cockroachdb/pebble/internal/base"
+)
+
+type writeTask struct {
+	// Since writeTasks are pooled, the compressionDone channel will be re-used.
+	// It is necessary that any writes to the channel have already been read,
+	// before adding the writeTask back to the pool.
+	compressionDone chan bool
+	buf             *dataBlockBuf
+	// todo(bananabrick) : Remove the indexSepKey field once Writer.addIndexEntry is
+	// refactored to not require the indexSepKey.
+	indexSepKey InternalKey
+}
+
+// Note that only the Writer client goroutine will be adding tasks to the writeQueue.
+// Both the Writer client and the compression goroutines will be able to write to
+// writeTask.compressionDone to indicate that the compression job associated with
+// a writeTask has finished.
+type writeQueue struct {
+	tasks  chan *writeTask
+	wg     sync.WaitGroup
+	writer *Writer
+
+	// err represents an error which is encountered when the write queue attempts
+	// to write a block to disk. The error is stored here to skip unnecessary block
+	// writes once the first error is encountered.
+	err error
+}
+
+func newWriteQueue(size int, writer *Writer) *writeQueue {
+	w := &writeQueue{}
+	w.tasks = make(chan *writeTask, size)
+	w.writer = writer
+
+	w.wg.Add(1)
+	go w.runWorker()
+	return w
+}
+
+func (w *writeQueue) performWrite(task *writeTask) error {
+	var bh BlockHandle
+	var bhp BlockHandleWithProperties
+
+	var err error
+	if bh, err = w.writer.writeCompressedBlock(task.buf.compressed, task.buf.tmp[:]); err != nil {
+		return err
+	}
+
+	if bhp, err = w.writer.maybeAddBlockPropertiesToBlockHandle(bh); err != nil {
+		return err
+	}
+
+	prevKey := base.DecodeInternalKey(task.buf.dataBlock.curKey)
+	if err = w.writer.addIndexEntry(prevKey, task.indexSepKey, bhp, task.buf.tmp[:]); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (w *writeQueue) releaseBuffers(task *writeTask) {
+	dataBlockBufPool.Put(task.buf)
+	task.buf = nil
+	writeTaskPool.Put(task)
+}
+
+func (w *writeQueue) runWorker() {
+	for task := range w.tasks {
+		<-task.compressionDone
+
+		if w.err == nil {
+			w.err = w.performWrite(task)
+		}
+
+		w.releaseBuffers(task)
+	}
+	w.wg.Done()
+}
+
+//lint:ignore U1000 - Will be used in a future pr.
+func (w *writeQueue) add(task *writeTask) {
+	w.tasks <- task
+}
+
+// addSync will perform the writeTask synchronously with the caller goroutine. Calls to addSync
+// are no longer valid once writeQueue.add has been called at least once.
+func (w *writeQueue) addSync(task *writeTask) error {
+	// This should instantly return without blocking.
+	<-task.compressionDone
+
+	if w.err == nil {
+		w.err = w.performWrite(task)
+	}
+
+	w.releaseBuffers(task)
+
+	return w.err
+}
+
+// finish should only be called once no more tasks will be added to the writeQueue.
+// finish will return any error which was encountered while tasks were processed.
+func (w *writeQueue) finish() error {
+	close(w.tasks)
+	w.wg.Wait()
+	return w.err
+}

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -304,7 +304,7 @@ func (c *testBlockPropCollector) FinishTable(_ []byte) ([]byte, error) {
 	return nil, nil
 }
 
-func TestWriter_BlockProperties_Errors(t *testing.T) {
+func TestWriterBlockPropertiesErrors(t *testing.T) {
 	blockPropErr := errors.Newf("block property collector failed")
 	testCases := []blockPropErrSite{
 		errSiteAdd,
@@ -349,8 +349,8 @@ func TestWriter_BlockProperties_Errors(t *testing.T) {
 				require.NoError(t, err)
 				// Addition of a second key completes the first block.
 				w.Add(k2, v2)
-				require.Error(t, w.Error())
-				require.Equal(t, blockPropErr, w.Error())
+				require.Error(t, w.err)
+				require.Equal(t, blockPropErr, w.err)
 			case errSiteFinishIndex:
 				require.NoError(t, err)
 				// Addition of a second key completes the first block.
@@ -359,14 +359,14 @@ func TestWriter_BlockProperties_Errors(t *testing.T) {
 				// The index entry for the first block is added after the completion of
 				// the second block, which is triggered by adding a third key.
 				w.Add(k3, v3)
-				require.Error(t, w.Error())
-				require.Equal(t, blockPropErr, w.Error())
+				require.Error(t, w.err)
+				require.Equal(t, blockPropErr, w.err)
 			}
 
 			err = w.Close()
 			if tc == errSiteFinishTable {
 				require.Error(t, err)
-				require.Equal(t, blockPropErr, w.Error())
+				require.Equal(t, blockPropErr, w.err)
 			}
 		})
 	}


### PR DESCRIPTION
This pr adds a writeQueue to the sstable writer. The queue is used to
write data blocks to disk. Currently, the queue will run synchronously
with the Writer client goroutine.

A writeTask, along with a dataBlockBuf is passed to the writerQueue. The
Writer Client goroutine will block until the writeQueue finishes writing
the block to disk.