### PR TITLE
compaction: use Equal in compaction iterator

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -405,6 +405,7 @@ func (k compactionKind) String() string {
 type compaction struct {
 	kind      compactionKind
 	cmp       Compare
+	equal     Equal
 	formatKey base.FormatKey
 	logger    Logger
 	version   *version
@@ -519,6 +520,7 @@ func newCompaction(pc *pickedCompaction, opts *Options, bytesCompacted *uint64) 
 	c := &compaction{
 		kind:                compactionKindDefault,
 		cmp:                 pc.cmp,
+		equal:               opts.equal(),
 		formatKey:           opts.Comparer.FormatKey,
 		score:               pc.score,
 		inputs:              pc.inputs,
@@ -563,6 +565,7 @@ func newDeleteOnlyCompaction(opts *Options, cur *version, inputs []compactionLev
 	c := &compaction{
 		kind:      compactionKindDeleteOnly,
 		cmp:       opts.Comparer.Compare,
+		equal:     opts.equal(),
 		formatKey: opts.Comparer.FormatKey,
 		logger:    opts.Logger,
 		version:   cur,
@@ -651,6 +654,7 @@ func newFlush(
 	c := &compaction{
 		kind:                compactionKindFlush,
 		cmp:                 opts.Comparer.Compare,
+		equal:               opts.equal(),
 		formatKey:           opts.Comparer.FormatKey,
 		logger:              opts.Logger,
 		version:             cur,
@@ -2070,7 +2074,7 @@ func (d *DB) runCompaction(
 		return nil, pendingOutputs, err
 	}
 	c.allowedZeroSeqNum = c.allowZeroSeqNum()
-	iter := newCompactionIter(c.cmp, c.formatKey, d.merge, iiter, snapshots,
+	iter := newCompactionIter(c.cmp, c.equal, c.formatKey, d.merge, iiter, snapshots,
 		&c.rangeDelFrag, c.allowedZeroSeqNum, c.elideTombstone,
 		c.elideRangeTombstone, d.FormatMajorVersion())
 

--- a/compaction_iter.go
+++ b/compaction_iter.go
@@ -147,7 +147,7 @@ import (
 // exported function, and before a subsequent call to Next advances the iterator
 // and mutates the contents of the returned key and value.
 type compactionIter struct {
-	cmp   Compare
+	equal Equal
 	merge Merge
 	iter  internalIterator
 	err   error
@@ -213,6 +213,7 @@ type compactionIter struct {
 
 func newCompactionIter(
 	cmp Compare,
+	equal Equal,
 	formatKey base.FormatKey,
 	merge Merge,
 	iter internalIterator,
@@ -224,7 +225,7 @@ func newCompactionIter(
 	formatVersion FormatMajorVersion,
 ) *compactionIter {
 	i := &compactionIter{
-		cmp:                 cmp,
+		equal:               equal,
 		merge:               merge,
 		iter:                iter,
 		snapshots:           snapshots,
@@ -487,7 +488,7 @@ func (i *compactionIter) nextInStripe() stripeChangeType {
 		return newStripe
 	}
 	key := i.iterKey
-	if i.cmp(i.key.UserKey, key.UserKey) != 0 {
+	if !i.equal(i.key.UserKey, key.UserKey) {
 		i.curSnapshotIdx, i.curSnapshotSeqNum = snapshotIndex(key.SeqNum(), i.snapshots)
 		return newStripe
 	}

--- a/compaction_iter_test.go
+++ b/compaction_iter_test.go
@@ -106,6 +106,7 @@ func TestCompactionIter(t *testing.T) {
 
 		return newCompactionIter(
 			DefaultComparer.Compare,
+			DefaultComparer.Equal,
 			DefaultComparer.FormatKey,
 			merge,
 			iter,

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1391,6 +1391,7 @@ func TestCompactionFindGrandparentLimit(t *testing.T) {
 			case "compact":
 				c := &compaction{
 					cmp:          cmp,
+					equal:        DefaultComparer.Equal,
 					grandparents: manifest.NewLevelSliceKeySorted(cmp, grandparents),
 				}
 				if len(d.CmdArgs) != 1 {
@@ -1517,6 +1518,7 @@ func TestCompactionFindL0Limit(t *testing.T) {
 			case "flush":
 				c := &compaction{
 					cmp:      cmp,
+					equal:    DefaultComparer.Equal,
 					version:  vers,
 					l0Limits: vers.L0Sublevels.FlushSplitKeys(),
 					inputs:   []compactionLevel{{level: -1}, {level: 0}},
@@ -1610,6 +1612,7 @@ func TestCompactionAtomicUnitBounds(t *testing.T) {
 			case "atomic-unit-bounds":
 				c := &compaction{
 					cmp:    cmp,
+					equal:  DefaultComparer.Equal,
 					inputs: []compactionLevel{{files: files}, {}},
 				}
 				c.startLevel, c.outputLevel = &c.inputs[0], &c.inputs[1]
@@ -2203,6 +2206,7 @@ func TestCompactionInuseKeyRanges(t *testing.T) {
 		case "define":
 			c = &compaction{
 				cmp:       DefaultComparer.Compare,
+				equal:     DefaultComparer.Equal,
 				formatKey: DefaultComparer.FormatKey,
 				inputs:    []compactionLevel{{}, {}},
 			}

--- a/open.go
+++ b/open.go
@@ -71,7 +71,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		walDirname:          opts.WALDir,
 		opts:                opts,
 		cmp:                 opts.Comparer.Compare,
-		equal:               opts.Comparer.Equal,
+		equal:               opts.equal(),
 		merge:               opts.Merger.Merge,
 		split:               opts.Comparer.Split,
 		abbreviatedKey:      opts.Comparer.AbbreviatedKey,
@@ -113,10 +113,6 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 			}
 		}
 	}()
-
-	if d.equal == nil {
-		d.equal = bytes.Equal
-	}
 
 	tableCacheSize := TableCacheSize(opts.MaxOpenFiles)
 	d.tableCache = newTableCacheContainer(opts.TableCache, d.cacheID, dirname, opts.FS, d.opts, tableCacheSize)

--- a/options.go
+++ b/options.go
@@ -764,6 +764,13 @@ func (o *Options) EnsureDefaults() *Options {
 	return o
 }
 
+func (o *Options) equal() Equal {
+	if o.Comparer.Equal == nil {
+		return bytes.Equal
+	}
+	return o.Comparer.Equal
+}
+
 // initMaps initializes the Comparers, Filters, and Mergers maps.
 func (o *Options) initMaps() {
 	for i := range o.Levels {


### PR DESCRIPTION
Use Equal rather than Compare to compare user keys in the compaction iterator.
The compaction iterator only needs to detect when a user key changes, and does
not need to order the user keys.

The Equal function is a special case comparator for when a caller only needs to
determine if two user keys are equal. It implements `Compare(a, b) == 0`.
The user-provided `Equal` function may possibly be more performant, allowing
for less decoding and direct use of intrinsics. 

CockroachDB uses the default `Equal` implementation: `bytes.Equal`. I didn't
perform benchmarks, but this is expected to be more performant than
CockroachDB's `Compare` function which must split the user key from the MVCC
timestamp.