### PR TITLE
db: expose metrics on count and earliest seqnum of snapshots

### DIFF
--- a/db.go
+++ b/db.go
@@ -1337,6 +1337,10 @@ func (d *DB) Metrics() *Metrics {
 	for _, m := range d.mu.mem.queue {
 		metrics.MemTable.Size += m.totalBytes()
 	}
+	metrics.Snapshots.Count = d.mu.snapshots.count()
+	if metrics.Snapshots.Count > 0 {
+		metrics.Snapshots.EarliestSeqNum = d.mu.snapshots.earliest()
+	}
 	metrics.MemTable.Count = int64(len(d.mu.mem.queue))
 	metrics.MemTable.ZombieCount = atomic.LoadInt64(&d.atomic.memTableCount) - metrics.MemTable.Count
 	metrics.MemTable.ZombieSize = uint64(atomic.LoadInt64(&d.atomic.memTableReserved)) - metrics.MemTable.Size

--- a/metrics.go
+++ b/metrics.go
@@ -166,6 +166,13 @@ type Metrics struct {
 		ZombieCount int64
 	}
 
+	Snapshots struct {
+		// The number of currently open snapshots.
+		Count int
+		// The sequence number of the earliest, currently open snapshot.
+		EarliestSeqNum uint64
+	}
+
 	Table struct {
 		// The number of bytes present in obsolete tables which are no longer
 		// referenced by the current DB state or any open iterators.
@@ -306,6 +313,7 @@ func (m *Metrics) formatWAL(w redact.SafePrinter) {
 //      ztbl         0     0 B
 //    bcache         4   752 B    7.7%  (score == hit-rate)
 //    tcache         0     0 B    0.0%  (score == hit-rate)
+// snapshots         0               0  (score == earliest seq num)
 //    titers         0
 //    filter         -       -    0.0%  (score == utility)
 //
@@ -384,6 +392,10 @@ func (m *Metrics) SafeFormat(w redact.SafePrinter, _ rune) {
 		humanize.IEC.Uint64(m.Table.ZombieSize))
 	formatCacheMetrics(w, &m.BlockCache, "bcache")
 	formatCacheMetrics(w, &m.TableCache, "tcache")
+	w.Printf("  snaps %9d %7s %7d  (score == earliest seq num)\n",
+		redact.Safe(m.Snapshots.Count),
+		notApplicable,
+		redact.Safe(m.Snapshots.EarliestSeqNum))
 	w.Printf(" titers %9d\n", redact.Safe(m.TableIters))
 	w.Printf(" filter %9s %7s %6.1f%%  (score == utility)\n",
 		notApplicable,

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -38,6 +38,8 @@ func TestMetricsFormat(t *testing.T) {
 	m.MemTable.Count = 12
 	m.MemTable.ZombieSize = 13
 	m.MemTable.ZombieCount = 14
+	m.Snapshots.Count = 4
+	m.Snapshots.EarliestSeqNum = 1024
 	m.Table.ZombieSize = 15
 	m.Table.ZombieCount = 16
 	m.TableCache.Size = 17
@@ -89,6 +91,7 @@ zmemtbl        14    13 B
    ztbl        16    15 B
  bcache         2     1 B   42.9%  (score == hit-rate)
  tcache        18    17 B   48.7%  (score == hit-rate)
+  snaps         4       -    1024  (score == earliest seq num)
  titers        21
  filter         -       -   47.4%  (score == utility)
 `
@@ -224,6 +227,7 @@ zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         0     0 B    0.0%  (score == hit-rate)
  tcache         0     0 B    0.0%  (score == hit-rate)
+  snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)
 `

--- a/snapshot.go
+++ b/snapshot.go
@@ -82,6 +82,17 @@ func (l *snapshotList) empty() bool {
 	return l.root.next == &l.root
 }
 
+func (l *snapshotList) count() int {
+	if l.empty() {
+		return 0
+	}
+	var count int
+	for i := l.root.next; i != &l.root; i = i.next {
+		count++
+	}
+	return count
+}
+
 func (l *snapshotList) earliest() uint64 {
 	v := uint64(math.MaxUint64)
 	if !l.empty() {

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -184,6 +184,7 @@ zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.4 K    0.0%  (score == hit-rate)
  tcache         1   672 B    0.0%  (score == hit-rate)
+  snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)
 

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -49,6 +49,7 @@ zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.5 K   42.9%  (score == hit-rate)
  tcache         1   672 B   50.0%  (score == hit-rate)
+  snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)
 

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -35,6 +35,7 @@ zmemtbl         1   256 K
    ztbl         0     0 B
  bcache         4   698 B    0.0%  (score == hit-rate)
  tcache         1   672 B    0.0%  (score == hit-rate)
+  snaps         0       -       0  (score == earliest seq num)
  titers         1
  filter         -       -    0.0%  (score == utility)
 
@@ -82,6 +83,7 @@ zmemtbl         2   512 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   33.3%  (score == hit-rate)
  tcache         2   1.3 K   50.0%  (score == hit-rate)
+  snaps         0       -       0  (score == earliest seq num)
  titers         2
  filter         -       -    0.0%  (score == utility)
 
@@ -114,6 +116,7 @@ zmemtbl         1   256 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   33.3%  (score == hit-rate)
  tcache         2   1.3 K   50.0%  (score == hit-rate)
+  snaps         0       -       0  (score == earliest seq num)
  titers         2
  filter         -       -    0.0%  (score == utility)
 
@@ -143,6 +146,7 @@ zmemtbl         1   256 K
    ztbl         1   771 B
  bcache         4   698 B   33.3%  (score == hit-rate)
  tcache         1   672 B   50.0%  (score == hit-rate)
+  snaps         0       -       0  (score == earliest seq num)
  titers         1
  filter         -       -    0.0%  (score == utility)
 
@@ -175,6 +179,7 @@ zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         0     0 B   33.3%  (score == hit-rate)
  tcache         0     0 B   50.0%  (score == hit-rate)
+  snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)
 

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -28,5 +28,6 @@ zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         0     0 B    0.0%  (score == hit-rate)
  tcache         0     0 B    0.0%  (score == hit-rate)
+  snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)


### PR DESCRIPTION
Expose two new fields on Metrics, one recording the count of open snapshots and
the other recording the sequence number of the earliest snapshot.

Related to #1204.