### PR TITLE
internal/rangekey: fix range key iteration bug

### DIFF
--- a/internal/rangekey/coalescer.go
+++ b/internal/rangekey/coalescer.go
@@ -160,6 +160,11 @@ func (c *Coalescer) Start() []byte {
 	return c.start
 }
 
+// Pending returns true if there exists a pending span in the coalescer.
+func (c *Coalescer) Pending() bool {
+	return len(c.items.items) > 0 || c.delete
+}
+
 // Finish must be called after all spans have been added. It flushes the
 // remaining pending CoalescedSpan if any. Finish may also be called at any time
 // to flush the pending CoalescedSpan and reset the coalescer.

--- a/internal/rangekey/coalescer_test.go
+++ b/internal/rangekey/coalescer_test.go
@@ -168,6 +168,15 @@ func TestIter(t *testing.T) {
 		buf.Reset()
 		switch td.Cmd {
 		case "define":
+			visibleSeqNum := base.InternalKeySeqNumMax
+			for _, arg := range td.CmdArgs {
+				if arg.Key == "visible-seq-num" {
+					var err error
+					visibleSeqNum, err = strconv.ParseUint(arg.Vals[0], 10, 64)
+					require.NoError(t, err)
+				}
+			}
+
 			var spans []keyspan.Span
 			lines := strings.Split(strings.TrimSpace(td.Input), "\n")
 			for _, line := range lines {
@@ -180,7 +189,7 @@ func TestIter(t *testing.T) {
 					Value: v,
 				})
 			}
-			iter.Init(cmp, testkeys.Comparer.FormatKey, base.InternalKeySeqNumMax, keyspan.NewIter(cmp, spans))
+			iter.Init(cmp, testkeys.Comparer.FormatKey, visibleSeqNum, keyspan.NewIter(cmp, spans))
 			return "OK"
 		case "iter":
 			buf.Reset()

--- a/internal/rangekey/testdata/iter
+++ b/internal/rangekey/testdata/iter
@@ -236,3 +236,42 @@ prev
 .
 ●   [q, z)#14
 └── @9 : mangos
+
+define visible-seq-num=10
+a.RANGEKEYSET.8  : c [(@5=apples)]
+a.RANGEKEYSET.7  : c [(@3=bananas)]
+a.RANGEKEYSET.4  : c [(@2=oranges)]
+c.RANGEKEYSET.12 : d [(@3=coconut)]
+c.RANGEKEYSET.5  : d [(@1=coconut)]
+d.RANGEKEYSET.5  : f [(@1=coconut)]
+d.RANGEKEYSET.15 : f [(@2=oranges)]
+----
+OK
+
+iter
+first
+next
+next
+----
+●   [a, c)#8
+├── @5 : apples
+├── @3 : bananas
+└── @2 : oranges
+●   [c, d)#5
+└── @1 : coconut
+●   [d, f)#5
+└── @1 : coconut
+
+iter
+last
+prev
+prev
+----
+●   [d, f)#5
+└── @1 : coconut
+●   [c, d)#5
+└── @1 : coconut
+●   [a, c)#8
+├── @5 : apples
+├── @3 : bananas
+└── @2 : oranges


### PR DESCRIPTION
Previously, if the first fragment with new bounds was not visible at the read
sequence number and was elided by the Coalescer, the range key iterator would
improperly stop coalescing, repeating the previously returned range key.

Discovered while integrating range keys into the metamorphic tests.