### PR TITLE
db: rework backward limit interactions with range keys

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -179,24 +179,28 @@ func runIterCmd(d *datadriven.TestData, iter *Iterator, closeIter bool) string {
 			fmt.Fprintf(&b, "err=%v\n", err)
 		} else if valid != iter.Valid() {
 			fmt.Fprintf(&b, "mismatched valid states: %t vs %t\n", valid, iter.Valid())
-		} else if valid {
+		} else {
 			switch {
 			case iter.opts.rangeKeys() && iter.opts.pointKeys():
 				hasPoint, hasRange := iter.HasPointAndRange()
-				fmt.Fprintf(&b, "%s:%s (", iter.Key(), validityStateStr)
-				if hasPoint {
-					fmt.Fprintf(&b, "%s, ", iter.Value())
+				if !hasPoint && !hasRange {
+					fmt.Fprintf(&b, ".%s", validityStateStr)
 				} else {
-					fmt.Fprint(&b, "., ")
+					fmt.Fprintf(&b, "%s:%s (", iter.Key(), validityStateStr)
+					if hasPoint {
+						fmt.Fprintf(&b, "%s, ", iter.Value())
+					} else {
+						fmt.Fprint(&b, "., ")
+					}
+					if hasRange {
+						start, end := iter.RangeBounds()
+						fmt.Fprintf(&b, "[%s-%s)", start, end)
+						writeRangeKeys(&b, iter)
+					} else {
+						fmt.Fprint(&b, ".")
+					}
+					fmt.Fprint(&b, ")")
 				}
-				if hasRange {
-					start, end := iter.RangeBounds()
-					fmt.Fprintf(&b, "[%s-%s)", start, end)
-					writeRangeKeys(&b, iter)
-				} else {
-					fmt.Fprint(&b, ".")
-				}
-				fmt.Fprint(&b, ")")
 			case iter.opts.rangeKeys():
 				if iter.Valid() {
 					hasPoint, hasRange := iter.HasPointAndRange()
@@ -210,11 +214,13 @@ func runIterCmd(d *datadriven.TestData, iter *Iterator, closeIter bool) string {
 					fmt.Fprint(&b, ".")
 				}
 			default:
-				fmt.Fprintf(&b, "%s:%s%s", iter.Key(), iter.Value(), validityStateStr)
+				if valid {
+					fmt.Fprintf(&b, "%s:%s%s", iter.Key(), iter.Value(), validityStateStr)
+				} else {
+					fmt.Fprintf(&b, ".%s\n", validityStateStr)
+				}
 			}
 			fmt.Fprintln(&b)
-		} else {
-			fmt.Fprintf(&b, ".%s\n", validityStateStr)
 		}
 	}
 	return b.String()

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -447,9 +447,9 @@ seek-lt-limit z y
 next
 prev-limit y
 ----
-x: valid (., [x-z) @5=boop)
+y: at-limit (., [x-z) @5=boop)
 .
-x: valid (., [x-z) @5=boop)
+y: at-limit (., [x-z) @5=boop)
 
 # Test limited forward iteration. Since range keys are interleaved at the start
 # boundaries, the iterator is guaranteed to encounter covering range keys
@@ -478,6 +478,28 @@ seek-lt-limit z y
 next
 prev-limit y
 ----
-x: valid (., [x-z) @5=boop)
+y: at-limit (., [x-z) @5=boop)
 .
+y: at-limit (., [x-z) @5=boop)
+
+batch
+set xray foo
+----
+wrote 1 keys
+
+combined-iter
+seek-lt-limit z y
+prev-limit y
+next
+prev-limit y
+prev-limit a
+prev-limit a
+prev-limit a
+----
+y: at-limit (., [x-z) @5=boop)
+y: at-limit (., [x-z) @5=boop)
+.
+y: at-limit (., [x-z) @5=boop)
+xray: valid (foo, [x-z) @5=boop)
 x: valid (., [x-z) @5=boop)
+. exhausted


### PR DESCRIPTION
SeekLTWithLimit and PrevWithLimit allow iteration with a temporary lower bound.
This limited iteration mode complicates range key iteration, because we must
guarantee that an iterator will reveal any range keys covering the span between
the limit and the preceding iterator position.

Previously, this was achieved by ignoring limits in the presence of covering
range keys. This complicates metamorphic testing, which requires deterministic
behavior. While range key boundaries will never be deterministic, point keys
and the range keys that cover them are. However ignoring limits during reverse
iteration made which point keys would be surfaced nondeterministic. (When an
iterator landed on a point key beyond the limit but covered by a range key, the
point key could be deleted or it could not. Regardless, this iterator position
was surfaced to the user.)

This change adapts the behavior during reverse, limited iteration to revert to
the behavior of always returning IterAtLimit as soon as the limit is passed.
However, if there exists a range key that ends after the limit, the range key
is accessible at this `IterAtLimit` position.

The implementation and documentation of this change is incomplete in this
commit, but I wanted to put this up to solicit feedback on the iterator
interface. It's unusual, because if the iterator lands on one of these iterator
positions the iterator consumer sees:

* `IterValidityState == IterAtLimit`
* `Key() == limit`
* `Valid() == false`
* `HasPointAndRange() = (false, true)`
* `RangeKeyBounds() = (correct range key bounds)`
* `RangeKeys() = (correct range keys)`

Thoughts?