### PR TITLE
db: disable automatic compactions in `MetricsTest`

### DIFF
--- a/metrics_test.go
+++ b/metrics_test.go
@@ -98,10 +98,17 @@ zmemtbl        14    13 B
 }
 
 func TestMetrics(t *testing.T) {
-	d, err := Open("", &Options{
+	opts := &Options{
 		FS:                    vfs.NewMem(),
 		L0CompactionThreshold: 8,
-	})
+	}
+
+	// Prevent foreground flushes and compactions from triggering asynchronous
+	// follow-up compactions. This avoids asynchronously-scheduled work from
+	// interfering with the expected metrics output and reduces test flakiness.
+	opts.private.disableAutomaticCompactions = true
+
+	d, err := Open("", opts)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, d.Close())


### PR DESCRIPTION
Following a flush, compaction, or metrics gathering, a follow-up
compaction may be scheduled (which in-turn may schedule more
compactions, etc.). This introduces race conditions into the
`MetricsTest` when the metrics output is compared against the test
fixture, but there may have been background work scheduled which can
alter the test output.

Disable automatic compactions for `MetricsTest`.

Fixes #1478.