### PR TITLE
sstable: extend property collector API for suffix rewrites

### DIFF
--- a/sstable/options.go
+++ b/sstable/options.go
@@ -71,6 +71,28 @@ type TablePropertyCollector interface {
 	Name() string
 }
 
+// SuffixReplaceableTableCollector is an extension to the TablePropertyCollector
+// interface that allows a table property collector to indicate that it supports
+// being *updated* during suffix replacement, i.e. when an existing SST in which
+// all keys have the same key suffix is updated to have a new suffix.
+//
+// A collector which supports being updated in such cases must be able to derive
+// its updated value from its old value and the change being made to the suffix,
+// without needing to be passed each updated K/V.
+//
+// For example, a collector that only inspects values can simply copy its
+// previously computed property as-is, since key-suffix replacement does not
+// change values, while a collector that depends only on key suffixes, like one
+// which collected mvcc-timestamp bounds from timestamp-suffixed keys, can just
+// set its new bounds from the new suffix, as it is common to all keys, without
+// needing to recompute it from every key.
+type SuffixReplaceableTableCollector interface {
+	// UpdateKeySuffixes is called when a table is updated to change the suffix of
+	// all keys in the table, and is passed the old value for that prop, if any,
+	// for that table as well as the old and new suffix.
+	UpdateKeySuffixes(oldProps map[string]string, oldSuffix, newSuffix []byte) error
+}
+
 // ReaderOptions holds the parameters needed for reading an sstable.
 type ReaderOptions struct {
 	// Cache is used to cache uncompressed blocks from sstables.

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -802,7 +802,7 @@ func TestValidateBlockChecksums(t *testing.T) {
 			var bh BlockHandle
 			switch location {
 			case corruptionLocationData:
-				bh = layout.Data[rng.Intn(len(layout.Data))]
+				bh = layout.Data[rng.Intn(len(layout.Data))].BlockHandle
 			case corruptionLocationIndex:
 				bh = layout.Index[rng.Intn(len(layout.Index))]
 			case corruptionLocationTopIndex:

--- a/sstable/suffix_rewriter_test.go
+++ b/sstable/suffix_rewriter_test.go
@@ -4,11 +4,112 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/stretchr/testify/require"
 )
+
+func TestRewriteSuffixProps(t *testing.T) {
+	from, to := []byte("_212"), []byte("_646")
+
+	wOpts := WriterOptions{
+		FilterPolicy: bloom.FilterPolicy(10),
+		Comparer:     test4bSuffixComparer,
+		TablePropertyCollectors: []func() TablePropertyCollector{
+			intSuffixTablePropCollectorFn("ts3", 3), intSuffixTablePropCollectorFn("ts2", 2),
+		},
+		BlockPropertyCollectors: []func() BlockPropertyCollector{
+			keyCountCollectorFn("count"),
+			intSuffixIntervalCollectorFn("bp3", 3),
+			intSuffixIntervalCollectorFn("bp2", 2),
+			intSuffixIntervalCollectorFn("bp1", 1),
+		},
+		TableFormat: TableFormatPebblev2,
+	}
+
+	const keyCount = 1e5
+	// Setup our test SST.
+	sst := make4bSuffixTestSST(t, wOpts, []byte(from), keyCount)
+
+	expectedProps := make(map[string]string)
+	expectedProps["ts2.min"] = "46"
+	expectedProps["ts2.max"] = "46"
+	expectedProps["ts3.min"] = "646"
+	expectedProps["ts3.max"] = "646"
+
+	// Also expect to see the aggregated block properties with their updated value
+	// at the correct (new) shortIDs. Seeing the rolled up value here is almost an
+	// end-to-end test since we only fed them each block during rewrite.
+	expectedProps["count"] = string(append([]byte{1}, strconv.Itoa(keyCount)...))
+	expectedProps["bp2"] = string(interval{46, 47}.encode([]byte{2}))
+	expectedProps["bp3"] = string(interval{646, 647}.encode([]byte{0}))
+
+	// Swap the order of two of the props so they have new shortIDs, and remove
+	// one.
+	rwOpts := wOpts
+	rwOpts.BlockPropertyCollectors = rwOpts.BlockPropertyCollectors[:3]
+	rwOpts.BlockPropertyCollectors[0], rwOpts.BlockPropertyCollectors[1] = rwOpts.BlockPropertyCollectors[1], rwOpts.BlockPropertyCollectors[0]
+
+	// Rewrite the SST using updated options and check the returned props.
+	readerOpts := ReaderOptions{
+		Comparer: test4bSuffixComparer,
+		Filters:  map[string]base.FilterPolicy{wOpts.FilterPolicy.Name(): wOpts.FilterPolicy},
+	}
+	r, err := NewMemReader(sst, readerOpts)
+	require.NoError(t, err)
+	defer r.Close()
+
+	for _, byBlocks := range []bool{false, true} {
+		t.Run(fmt.Sprintf("byBlocks=%v", byBlocks), func(t *testing.T) {
+			rewrittenSST := &memFile{}
+			if byBlocks {
+				_, err := rewriteKeySuffixesInBlocks(r, rewrittenSST, rwOpts, from, to, 8)
+				require.NoError(t, err)
+			} else {
+				_, err := RewriteKeySuffixesViaWriter(r, rewrittenSST, rwOpts, from, to)
+				require.NoError(t, err)
+			}
+
+			// Check that a reader on the rewritten STT has the expected props.
+			rRewritten, err := NewMemReader(rewrittenSST.Bytes(), readerOpts)
+			require.NoError(t, err)
+			defer rRewritten.Close()
+			require.Equal(t, expectedProps, rRewritten.Properties.UserProperties)
+
+			// Compare the block level props from the data blocks in the layout.
+			layout, err := r.Layout()
+			require.NoError(t, err)
+			newLayout, err := rRewritten.Layout()
+			require.NoError(t, err)
+
+			ival := interval{}
+			for i := range layout.Data {
+				oldProps := make([][]byte, len(wOpts.BlockPropertyCollectors))
+				oldDecoder := blockPropertiesDecoder{layout.Data[i].Props}
+				for !oldDecoder.done() {
+					id, val, err := oldDecoder.next()
+					require.NoError(t, err)
+					oldProps[id] = val
+				}
+				newProps := make([][]byte, len(rwOpts.BlockPropertyCollectors))
+				newDecoder := blockPropertiesDecoder{newLayout.Data[i].Props}
+				for !newDecoder.done() {
+					id, val, err := newDecoder.next()
+					require.NoError(t, err)
+					newProps[id] = val
+				}
+				require.Equal(t, oldProps[0], newProps[1])
+				ival.decode(newProps[0])
+				require.Equal(t, interval{646, 647}, ival)
+				ival.decode(newProps[2])
+				require.Equal(t, interval{46, 47}, ival)
+			}
+		})
+	}
+}
 
 // memFile is a file-like struct that buffers all data written to it in memory.
 // Implements the writeCloseSyncer interface.
@@ -36,14 +137,35 @@ func (f *memFile) Flush() error {
 	return nil
 }
 
+func make4bSuffixTestSST(t testing.TB, writerOpts WriterOptions, suffix []byte, keys int) []byte {
+	key := make([]byte, 28)
+	copy(key[24:], suffix)
+
+	f := &memFile{}
+	w := NewWriter(f, writerOpts)
+	for i := 0; i < keys; i++ {
+		binary.BigEndian.PutUint64(key[:8], 123) // 16-byte shared prefix
+		binary.BigEndian.PutUint64(key[8:16], 456)
+		binary.BigEndian.PutUint64(key[16:], uint64(i))
+		if err := w.Set(key, key); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	return f.Bytes()
+}
+
 func BenchmarkRewriteSST(b *testing.B) {
+	from, to := []byte("_123"), []byte("_456")
 	writerOpts := WriterOptions{
 		FilterPolicy: bloom.FilterPolicy(10),
 		Comparer:     test4bSuffixComparer,
+		TableFormat:  TableFormatPebblev2,
 	}
 
-	key := make([]byte, 28)
-	copy(key[24:], "_123")
 	sizes := []int{100, 10000, 1e6}
 	compressions := []Compression{NoCompression, SnappyCompression}
 
@@ -54,21 +176,8 @@ func BenchmarkRewriteSST(b *testing.B) {
 
 		for size := range sizes {
 			writerOpts.Compression = compressions[comp]
-			f := &memFile{}
-			w := NewWriter(f, writerOpts)
-			for i := 0; i < sizes[size]; i++ {
-				binary.BigEndian.PutUint64(key[:8], 123) // 16-byte shared prefix
-				binary.BigEndian.PutUint64(key[8:16], 456)
-				binary.BigEndian.PutUint64(key[16:], uint64(i))
-				if err := w.Set(key, key); err != nil {
-					b.Fatal(err)
-				}
-			}
-
-			if err := w.Close(); err != nil {
-				b.Fatal(err)
-			}
-			r, err := NewMemReader(f.Bytes(), ReaderOptions{
+			sst := make4bSuffixTestSST(b, writerOpts, from, sizes[size])
+			r, err := NewMemReader(sst, ReaderOptions{
 				Comparer: test4bSuffixComparer,
 				Filters:  map[string]base.FilterPolicy{writerOpts.FilterPolicy.Name(): writerOpts.FilterPolicy},
 			})
@@ -89,7 +198,7 @@ func BenchmarkRewriteSST(b *testing.B) {
 						stat, _ := r.file.Stat()
 						b.SetBytes(stat.Size())
 						for i := 0; i < b.N; i++ {
-							if _, err := RewriteKeySuffixesViaWriter(r, &discardFile{}, writerOpts, []byte("_123"), []byte("_456")); err != nil {
+							if _, err := RewriteKeySuffixesViaWriter(r, &discardFile{}, writerOpts, from, to); err != nil {
 								b.Fatal(err)
 							}
 						}

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -213,7 +213,7 @@ func TestWriterClearCache(t *testing.T) {
 
 	foreachBH := func(layout *Layout, f func(bh BlockHandle)) {
 		for _, bh := range layout.Data {
-			f(bh)
+			f(bh.BlockHandle)
 		}
 		for _, bh := range layout.Index {
 			f(bh)


### PR DESCRIPTION
This adds a new optional interface that property collectors can implement
which allows them to support their collected properties being _updated_
during SST key-suffix replacement, with the following description:

```
// SuffixReplaceableBlockCollector is an extension to the BlockPropertyCollector
// interface that allows a block property collector to indicate that it supports
// being *updated* during suffix replacement, i.e. when an existing SST in which
// all keys have the same key suffix is updated to have a new suffix.
//
// A collector which supports being updated in such cases must be able to derive
// its updated value from its old value and the change being made to the suffix,
// without needing to be passed each updated K/V.
//
// For example, a collector that only inspects values can simply copy its
// previously computed property as-is, since key-suffix replacement does not
// change values, while a collector that depends only on key suffixes, like one
// which collected mvcc-timestamp bounds from timestamp-suffixed keys, can just
// set its new bounds from the new suffix, as it is common to all keys, without
// needing to recompute it from every key.
//
// An implementation of DataBlockIntervalCollector can also implement this
// interface, in which case the BlockPropertyCollector returned by passing it to
// NewBlockIntervalCollector will also implement this interface automatically.
type SuffixReplaceableBlockCollector interface {
	UpdateKeySuffixes(oldProp []byte, oldSuffix, newSuffix []byte) error
}
```

All property collectors passed in the WriterOptions to suffix-replacement
must implement this API, which in turn means that suffix replacement is
able to just copy over updated properties and does not need to pass every
updated k/v, sequentially, to a property collector to re-derive its value.