### PR TITLE
sstable: add direct block reading to suffix rewriter

### DIFF
--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -58,12 +58,7 @@ func runBuildCmd(
 	td *datadriven.TestData, writerOpts *WriterOptions,
 ) (*WriterMetadata, *Reader, error) {
 
-	mem := vfs.NewMem()
-	f0, err := mem.Create("test")
-	if err != nil {
-		return nil, nil, err
-	}
-
+	f0 := &memFile{}
 	if err := optsFromArgs(td, writerOpts); err != nil {
 		return nil, nil, err
 	}
@@ -154,17 +149,13 @@ func runBuildCmd(
 		return nil, nil, err
 	}
 
-	f1, err := mem.Open("test")
-	if err != nil {
-		return nil, nil, err
-	}
 	readerOpts := ReaderOptions{Comparer: writerOpts.Comparer}
 	if writerOpts.FilterPolicy != nil {
 		readerOpts.Filters = map[string]FilterPolicy{
 			writerOpts.FilterPolicy.Name(): writerOpts.FilterPolicy,
 		}
 	}
-	r, err := NewReader(f1, readerOpts)
+	r, err := NewMemReader(f0.Data(), readerOpts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -363,7 +354,7 @@ func runRewriteCmd(
 	}
 
 	f := &memFile{}
-	meta, err := RewriteKeySuffixes(r, f, opts, from, to, 2)
+	meta, err := rewriteKeySuffixesInBlocks(r, f, opts, from, to, 2)
 	if err != nil {
 		return nil, r, errors.Wrap(err, "rewrite failed")
 	}
@@ -375,7 +366,7 @@ func runRewriteCmd(
 	}
 	r.Close()
 
-	r, err = NewReader(vfs.NewMemFile(f.Data()), readerOpts)
+	r, err = NewMemReader(f.Data(), readerOpts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sstable/suffix_rewriter_test.go
+++ b/sstable/suffix_rewriter_test.go
@@ -99,7 +99,7 @@ func BenchmarkRewriteSST(b *testing.B) {
 							stat, _ := r.file.Stat()
 							b.SetBytes(stat.Size())
 							for i := 0; i < b.N; i++ {
-								if _, err := RewriteKeySuffixes(r, &discardFile{}, writerOpts, []byte("_123"), []byte("_456"), concurrency); err != nil {
+								if _, err := rewriteKeySuffixesInBlocks(r, &discardFile{}, writerOpts, []byte("_123"), []byte("_456"), concurrency); err != nil {
 									b.Fatal(err)
 								}
 							}


### PR DESCRIPTION
This switches suffix rewriter workers from calling Reader.readBlock to using a
new helper instead, which avoids cache.Cache.Alloc/Free/Set/Release for these
once-read blocks, eliminating a significant source of contention between the
worker goroutines, and significantly improving throughput. Additionally, one
extra copy is removed by casting the underlying 'file' wrapper around the in-mem
SST byte slice, to just slice the block out of it directly instead of reading it
using ReaderAt into another buffer, and a single decompression buffer is reused
across all blocks instead of allocating a new one each time, again because we
know these are read only once so there is no need to allocate a new one for some
cache.

```
name                                                                        old speed      new speed      delta
RewriteSST/NoCompression/keys=10000/ReaderWriterLoop-10                      369MB/s ± 0%   368MB/s ± 2%     ~     (p=0.548 n=5+5)
RewriteSST/NoCompression/keys=10000/RewriteKeySuffixes,concurrency=1-10      547MB/s ± 0%   576MB/s ± 1%   +5.36%  (p=0.016 n=4+5)
RewriteSST/NoCompression/keys=10000/RewriteKeySuffixes,concurrency=2-10      921MB/s ± 2%   975MB/s ± 4%   +5.82%  (p=0.016 n=5+5)
RewriteSST/NoCompression/keys=10000/RewriteKeySuffixes,concurrency=4-10     1.31GB/s ± 1%  1.39GB/s ± 0%   +5.82%  (p=0.008 n=5+5)
RewriteSST/NoCompression/keys=10000/RewriteKeySuffixes,concurrency=8-10     1.35GB/s ±11%  1.43GB/s ± 4%     ~     (p=0.056 n=5+5)
RewriteSST/NoCompression/keys=10000/RewriteKeySuffixes,concurrency=16-10    1.27GB/s ± 1%  1.34GB/s ± 1%   +5.35%  (p=0.016 n=5+4)
RewriteSST/NoCompression/keys=1000000/ReaderWriterLoop-10                    373MB/s ± 0%   365MB/s ± 1%   -2.03%  (p=0.008 n=5+5)
RewriteSST/NoCompression/keys=1000000/RewriteKeySuffixes,concurrency=1-10    568MB/s ± 0%   608MB/s ± 0%   +7.05%  (p=0.016 n=4+5)
RewriteSST/NoCompression/keys=1000000/RewriteKeySuffixes,concurrency=2-10   1.05GB/s ± 1%  1.13GB/s ± 0%   +7.00%  (p=0.016 n=5+4)
RewriteSST/NoCompression/keys=1000000/RewriteKeySuffixes,concurrency=4-10   1.91GB/s ± 1%  2.07GB/s ± 0%   +8.03%  (p=0.008 n=5+5)
RewriteSST/NoCompression/keys=1000000/RewriteKeySuffixes,concurrency=8-10   3.14GB/s ± 2%  3.59GB/s ± 0%  +14.20%  (p=0.016 n=4+5)
RewriteSST/NoCompression/keys=1000000/RewriteKeySuffixes,concurrency=16-10  2.90GB/s ± 2%  3.35GB/s ± 0%  +15.74%  (p=0.016 n=5+4)
RewriteSST/Snappy/keys=10000/ReaderWriterLoop-10                            87.0MB/s ± 1%  87.8MB/s ± 0%   +0.91%  (p=0.016 n=5+5)
RewriteSST/Snappy/keys=10000/RewriteKeySuffixes,concurrency=1-10             127MB/s ± 1%   137MB/s ± 0%   +7.95%  (p=0.008 n=5+5)
RewriteSST/Snappy/keys=10000/RewriteKeySuffixes,concurrency=2-10             215MB/s ±10%   240MB/s ± 0%  +12.00%  (p=0.016 n=5+4)
RewriteSST/Snappy/keys=10000/RewriteKeySuffixes,concurrency=4-10             320MB/s ± 1%   348MB/s ± 1%   +8.77%  (p=0.008 n=5+5)
RewriteSST/Snappy/keys=10000/RewriteKeySuffixes,concurrency=8-10             341MB/s ± 1%   379MB/s ± 1%  +11.32%  (p=0.036 n=5+3)
```