### PR TITLE
compaction: add support for concurrent manual compactions

### DIFF
--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -68,7 +68,7 @@ func TestCheckpoint(t *testing.T) {
 			}
 			buf.Reset()
 			d := dbs[td.CmdArgs[0].String()]
-			if err := d.Compact(nil, []byte("\xff")); err != nil {
+			if err := d.Compact(nil, []byte("\xff"), false); err != nil {
 				return err.Error()
 			}
 			return buf.String()
@@ -163,7 +163,7 @@ func TestCheckpointCompaction(t *testing.T) {
 		defer cancel()
 		defer wg.Done()
 		for ctx.Err() == nil {
-			if err := d.Compact([]byte("key"), []byte("key999999")); err != nil {
+			if err := d.Compact([]byte("key"), []byte("key999999"), false); err != nil {
 				t.Error(err)
 				return
 			}

--- a/cleaner_test.go
+++ b/cleaner_test.go
@@ -54,7 +54,7 @@ func TestArchiveCleaner(t *testing.T) {
 			}
 			buf.Reset()
 			d := dbs[td.CmdArgs[0].String()]
-			if err := d.Compact(nil, []byte("\xff")); err != nil {
+			if err := d.Compact(nil, []byte("\xff"), false); err != nil {
 				return err.Error()
 			}
 			return buf.String()

--- a/cmd/pebble/compact.go
+++ b/cmd/pebble/compact.go
@@ -367,7 +367,7 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	if err := iter.Close(); err != nil {
 		return err
 	}
-	if err := d.Compact(first, last); err != nil {
+	if err := d.Compact(first, last, false); err != nil {
 		return err
 	}
 	afterSize := totalSize(d.Metrics())

--- a/compaction.go
+++ b/compaction.go
@@ -641,12 +641,13 @@ func (c *compaction) setupInuseKeyRanges() {
 	if c.outputLevel.level == 0 {
 		level = 0
 	}
-	c.inuseKeyRanges = calculateInuseKeyRanges(c.version, c.cmp, level,
-		c.smallest.UserKey, c.largest.UserKey)
+	c.inuseKeyRanges = calculateInuseKeyRanges(
+		c.version, c.cmp, level, numLevels-1, c.smallest.UserKey, c.largest.UserKey,
+	)
 }
 
 func calculateInuseKeyRanges(
-	v *version, cmp base.Compare, level int, smallest, largest []byte,
+	v *version, cmp base.Compare, level, maxLevel int, smallest, largest []byte,
 ) []manifest.UserKeyRange {
 	// Use two slices, alternating which one is input and which one is output
 	// as we descend the LSM.
@@ -660,7 +661,7 @@ func calculateInuseKeyRanges(
 		level++
 	}
 
-	for ; level < numLevels; level++ {
+	for ; level <= maxLevel; level++ {
 		// NB: We always treat `largest` as inclusive for simplicity, because
 		// there's little consequence to calculating slightly broader in-use key
 		// ranges.
@@ -1096,8 +1097,9 @@ type manualCompaction struct {
 	level       int
 	outputLevel int
 	done        chan error
-	start       InternalKey
-	end         InternalKey
+	start       []byte
+	end         []byte
+	split       bool
 }
 
 type readCompaction struct {
@@ -1552,7 +1554,7 @@ func (d *DB) maybeScheduleCompactionPicker(
 	// cheap and reduce future compaction work.
 	if len(d.mu.compact.deletionHints) > 0 &&
 		d.mu.compact.compactingCount < d.opts.MaxConcurrentCompactions &&
-		!d.opts.private.disableAutomaticCompactions {
+		!d.opts.DisableAutomaticCompactions {
 		v := d.mu.versions.currentVersion()
 		snapshots := d.mu.snapshots.toSlice()
 		inputs, unresolvedHints := checkDeleteCompactionHints(d.cmp, v, d.mu.compact.deletionHints, snapshots)
@@ -1587,7 +1589,7 @@ func (d *DB) maybeScheduleCompactionPicker(
 		}
 	}
 
-	for !d.opts.private.disableAutomaticCompactions && d.mu.compact.compactingCount < d.opts.MaxConcurrentCompactions {
+	for !d.opts.DisableAutomaticCompactions && d.mu.compact.compactingCount < d.opts.MaxConcurrentCompactions {
 		env.inProgressCompactions = d.getInProgressCompactionInfoLocked(nil)
 		env.readCompactionEnv = readCompactionEnv{
 			readCompactions:          &d.mu.compact.readCompactions,

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -304,8 +304,8 @@ func TestCompactionPickerTargetLevel(t *testing.T) {
 				manual := &manualCompaction{
 					done:  make(chan error, 1),
 					level: startLevel,
-					start: iStart,
-					end:   iEnd,
+					start: iStart.UserKey,
+					end:   iEnd.UserKey,
 				}
 
 				pc, retryLater := pickerByScore.pickManual(compactionEnv{

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"math/rand"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"runtime"
 	"sort"
@@ -1124,11 +1125,47 @@ func TestManualCompaction(t *testing.T) {
 			DebugCheck:         DebugCheckLevels,
 			FormatMajorVersion: randVersion(minVersion, maxVersion),
 		}
-		opts.private.disableAutomaticCompactions = true
+		opts.DisableAutomaticCompactions = true
 
 		var err error
 		d, err = Open("", opts)
 		require.NoError(t, err)
+	}
+
+	// d.mu must be held when calling.
+	createOngoingCompaction := func(start, end []byte, startLevel, outputLevel int) (ongoingCompaction *compaction) {
+		ongoingCompaction = &compaction{
+			inputs:   []compactionLevel{{level: startLevel}, {level: outputLevel}},
+			smallest: InternalKey{UserKey: start},
+			largest:  InternalKey{UserKey: end},
+		}
+		ongoingCompaction.startLevel = &ongoingCompaction.inputs[0]
+		ongoingCompaction.outputLevel = &ongoingCompaction.inputs[1]
+		// Mark files as compacting.
+		curr := d.mu.versions.currentVersion()
+		ongoingCompaction.startLevel.files = curr.Overlaps(startLevel, d.cmp, start, end, false)
+		ongoingCompaction.outputLevel.files = curr.Overlaps(outputLevel, d.cmp, start, end, false)
+		for _, cl := range ongoingCompaction.inputs {
+			iter := cl.files.Iter()
+			for f := iter.First(); f != nil; f = iter.Next() {
+				f.Compacting = true
+			}
+		}
+		d.mu.compact.inProgress[ongoingCompaction] = struct{}{}
+		d.mu.compact.compactingCount++
+		return
+	}
+
+	// d.mu must be held when calling.
+	deleteOngoingCompaction := func(ongoingCompaction *compaction) {
+		for _, cl := range ongoingCompaction.inputs {
+			iter := cl.files.Iter()
+			for f := iter.First(); f != nil; f = iter.Next() {
+				f.Compacting = false
+			}
+		}
+		delete(d.mu.compact.inProgress, ongoingCompaction)
+		d.mu.compact.compactingCount--
 	}
 
 	runTest := func(t *testing.T, testData string, minVersion, maxVersion FormatMajorVersion) {
@@ -1158,7 +1195,12 @@ func TestManualCompaction(t *testing.T) {
 				if err := runCompactCmd(td, d); err != nil {
 					return err.Error()
 				}
-				return runLSMCmd(td, d)
+				s := runLSMCmd(td, d)
+				if td.HasArg("hide-file-num") {
+					re := regexp.MustCompile(`([0-9]*):\[`)
+					s = re.ReplaceAllString(s, "[")
+				}
+				return s
 
 			case "define":
 				if d != nil {
@@ -1173,7 +1215,7 @@ func TestManualCompaction(t *testing.T) {
 					DebugCheck:         DebugCheckLevels,
 					FormatMajorVersion: randVersion(minVersion, maxVersion),
 				}
-				opts.private.disableAutomaticCompactions = true
+				opts.DisableAutomaticCompactions = true
 
 				var err error
 				if d, err = runDBDefineCmd(td, opts); err != nil {
@@ -1251,8 +1293,7 @@ func TestManualCompaction(t *testing.T) {
 				}
 
 				d.mu.Lock()
-				delete(d.mu.compact.inProgress, ongoingCompaction)
-				d.mu.compact.compactingCount--
+				deleteOngoingCompaction(ongoingCompaction)
 				ongoingCompaction = nil
 				d.maybeScheduleCompaction()
 				d.mu.Unlock()
@@ -1264,23 +1305,20 @@ func TestManualCompaction(t *testing.T) {
 			case "add-ongoing-compaction":
 				var startLevel int
 				var outputLevel int
+				var start string
+				var end string
 				td.ScanArgs(t, "startLevel", &startLevel)
 				td.ScanArgs(t, "outputLevel", &outputLevel)
-				ongoingCompaction = &compaction{
-					inputs: []compactionLevel{{level: startLevel}, {level: outputLevel}},
-				}
-				ongoingCompaction.startLevel = &ongoingCompaction.inputs[0]
-				ongoingCompaction.outputLevel = &ongoingCompaction.inputs[1]
+				td.ScanArgs(t, "start", &start)
+				td.ScanArgs(t, "end", &end)
 				d.mu.Lock()
-				d.mu.compact.inProgress[ongoingCompaction] = struct{}{}
-				d.mu.compact.compactingCount++
+				ongoingCompaction = createOngoingCompaction([]byte(start), []byte(end), startLevel, outputLevel)
 				d.mu.Unlock()
 				return ""
 
 			case "remove-ongoing-compaction":
 				d.mu.Lock()
-				delete(d.mu.compact.inProgress, ongoingCompaction)
-				d.mu.compact.compactingCount--
+				deleteOngoingCompaction(ongoingCompaction)
 				ongoingCompaction = nil
 				d.mu.Unlock()
 				return ""
@@ -1926,7 +1964,7 @@ func TestCompactionTombstones(t *testing.T) {
 
 			case "maybe-compact":
 				d.mu.Lock()
-				d.opts.private.disableAutomaticCompactions = false
+				d.opts.DisableAutomaticCompactions = false
 				d.maybeScheduleCompaction()
 				s := compactionString()
 				d.mu.Unlock()
@@ -2165,7 +2203,7 @@ func TestCompactionReadTriggered(t *testing.T) {
 
 			case "maybe-compact":
 				d.mu.Lock()
-				d.opts.private.disableAutomaticCompactions = false
+				d.opts.DisableAutomaticCompactions = false
 				d.maybeScheduleCompaction()
 				s := compactionString()
 				d.mu.Unlock()
@@ -2342,7 +2380,7 @@ func TestCompactionInuseKeyRangesRandomized(t *testing.T) {
 			maxWidth := rng.Intn(endKeyspace-s) + 1
 			e := rng.Intn(maxWidth) + s
 			sKey, eKey := makeUserKey(s), makeUserKey(e)
-			keyRanges := calculateInuseKeyRanges(v, opts.Comparer.Compare, l, sKey, eKey)
+			keyRanges := calculateInuseKeyRanges(v, opts.Comparer.Compare, l, numLevels-1, sKey, eKey)
 
 			for level := l; level < numLevels; level++ {
 				for _, f := range files[level] {
@@ -2596,7 +2634,7 @@ func TestCompactionErrorCleanup(t *testing.T) {
 	d.mu.Lock()
 	initialSetupDone = true
 	d.mu.Unlock()
-	err = d.Compact([]byte("a"), []byte("d"))
+	err = d.Compact([]byte("a"), []byte("d"), false)
 	require.Error(t, err, "injected error")
 
 	d.mu.Lock()
@@ -2875,7 +2913,7 @@ func TestCompactFlushQueuedMemTable(t *testing.T) {
 		}
 	}
 
-	require.NoError(t, d.Compact([]byte("a"), []byte("a\x00")))
+	require.NoError(t, d.Compact([]byte("a"), []byte("a\x00"), false))
 	d.mu.Lock()
 	require.Equal(t, 1, len(d.mu.mem.queue))
 	d.mu.Unlock()
@@ -2908,7 +2946,7 @@ func TestCompactFlushQueuedLargeBatch(t *testing.T) {
 	require.Greater(t, len(d.mu.mem.queue), 1)
 	d.mu.Unlock()
 
-	require.NoError(t, d.Compact([]byte("a"), []byte("a\x00")))
+	require.NoError(t, d.Compact([]byte("a"), []byte("a\x00"), false))
 	d.mu.Lock()
 	require.Equal(t, 1, len(d.mu.mem.queue))
 	d.mu.Unlock()
@@ -3030,7 +3068,237 @@ func TestCompactionInvalidBounds(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	defer db.Close()
-	require.NoError(t, db.Compact([]byte("a"), []byte("b")))
-	require.Error(t, db.Compact([]byte("a"), []byte("a")))
-	require.Error(t, db.Compact([]byte("b"), []byte("a")))
+	require.NoError(t, db.Compact([]byte("a"), []byte("b"), false))
+	require.Error(t, db.Compact([]byte("a"), []byte("a"), false))
+	require.Error(t, db.Compact([]byte("b"), []byte("a"), false))
+}
+
+func Test_calculateInuseKeyRanges(t *testing.T) {
+	opts := (*Options)(nil).EnsureDefaults()
+	cmp := base.DefaultComparer.Compare
+	tests := []struct {
+		name     string
+		v        *version
+		level    int
+		depth    int
+		smallest []byte
+		largest  []byte
+		want     []manifest.UserKeyRange
+	}{
+		{
+			name: "No files in next level",
+			v: newVersion(opts, [numLevels][]*fileMetadata{
+				1: {
+					{
+						FileNum:  1,
+						Size:     1,
+						Smallest: base.ParseInternalKey("a.SET.2"),
+						Largest:  base.ParseInternalKey("c.SET.2"),
+					},
+					{
+						FileNum:  2,
+						Size:     1,
+						Smallest: base.ParseInternalKey("d.SET.2"),
+						Largest:  base.ParseInternalKey("e.SET.2"),
+					},
+				},
+			}),
+			level:    1,
+			depth:    2,
+			smallest: []byte("a"),
+			largest:  []byte("e"),
+			want: []manifest.UserKeyRange{
+				{
+					Start: []byte("a"),
+					End:   []byte("c"),
+				},
+				{
+					Start: []byte("d"),
+					End:   []byte("e"),
+				},
+			},
+		},
+		{
+			name: "No overlapping key ranges",
+			v: newVersion(opts, [numLevels][]*fileMetadata{
+				1: {
+					{
+						FileNum:  1,
+						Size:     1,
+						Smallest: base.ParseInternalKey("a.SET.1"),
+						Largest:  base.ParseInternalKey("c.SET.1"),
+					},
+					{
+						FileNum:  2,
+						Size:     1,
+						Smallest: base.ParseInternalKey("l.SET.1"),
+						Largest:  base.ParseInternalKey("p.SET.1"),
+					},
+				},
+				2: {
+					{
+						FileNum:  3,
+						Size:     1,
+						Smallest: base.ParseInternalKey("d.SET.1"),
+						Largest:  base.ParseInternalKey("i.SET.1"),
+					},
+					{
+						FileNum:  4,
+						Size:     1,
+						Smallest: base.ParseInternalKey("s.SET.1"),
+						Largest:  base.ParseInternalKey("w.SET.1"),
+					},
+				},
+			}),
+			level:    1,
+			depth:    2,
+			smallest: []byte("a"),
+			largest:  []byte("z"),
+			want: []manifest.UserKeyRange{
+				{
+					Start: []byte("a"),
+					End:   []byte("c"),
+				},
+				{
+					Start: []byte("d"),
+					End:   []byte("i"),
+				},
+				{
+					Start: []byte("l"),
+					End:   []byte("p"),
+				},
+				{
+					Start: []byte("s"),
+					End:   []byte("w"),
+				},
+			},
+		},
+		{
+			name: "First few non-overlapping, followed by overlapping",
+			v: newVersion(opts, [numLevels][]*fileMetadata{
+				1: {
+					{
+						FileNum:  1,
+						Size:     1,
+						Smallest: base.ParseInternalKey("a.SET.1"),
+						Largest:  base.ParseInternalKey("c.SET.1"),
+					},
+					{
+						FileNum:  2,
+						Size:     1,
+						Smallest: base.ParseInternalKey("d.SET.1"),
+						Largest:  base.ParseInternalKey("e.SET.1"),
+					},
+					{
+						FileNum:  3,
+						Size:     1,
+						Smallest: base.ParseInternalKey("n.SET.1"),
+						Largest:  base.ParseInternalKey("o.SET.1"),
+					},
+					{
+						FileNum:  4,
+						Size:     1,
+						Smallest: base.ParseInternalKey("p.SET.1"),
+						Largest:  base.ParseInternalKey("q.SET.1"),
+					},
+				},
+				2: {
+					{
+						FileNum:  5,
+						Size:     1,
+						Smallest: base.ParseInternalKey("m.SET.1"),
+						Largest:  base.ParseInternalKey("q.SET.1"),
+					},
+					{
+						FileNum:  6,
+						Size:     1,
+						Smallest: base.ParseInternalKey("s.SET.1"),
+						Largest:  base.ParseInternalKey("w.SET.1"),
+					},
+				},
+			}),
+			level:    1,
+			depth:    2,
+			smallest: []byte("a"),
+			largest:  []byte("z"),
+			want: []manifest.UserKeyRange{
+				{
+					Start: []byte("a"),
+					End:   []byte("c"),
+				},
+				{
+					Start: []byte("d"),
+					End:   []byte("e"),
+				},
+				{
+					Start: []byte("m"),
+					End:   []byte("q"),
+				},
+				{
+					Start: []byte("s"),
+					End:   []byte("w"),
+				},
+			},
+		},
+		{
+			name: "All overlapping",
+			v: newVersion(opts, [numLevels][]*fileMetadata{
+				1: {
+					{
+						FileNum:  1,
+						Size:     1,
+						Smallest: base.ParseInternalKey("d.SET.1"),
+						Largest:  base.ParseInternalKey("e.SET.1"),
+					},
+					{
+						FileNum:  2,
+						Size:     1,
+						Smallest: base.ParseInternalKey("n.SET.1"),
+						Largest:  base.ParseInternalKey("o.SET.1"),
+					},
+					{
+						FileNum:  3,
+						Size:     1,
+						Smallest: base.ParseInternalKey("p.SET.1"),
+						Largest:  base.ParseInternalKey("q.SET.1"),
+					},
+				},
+				2: {
+					{
+						FileNum:  4,
+						Size:     1,
+						Smallest: base.ParseInternalKey("a.SET.1"),
+						Largest:  base.ParseInternalKey("c.SET.1"),
+					},
+					{
+						FileNum:  5,
+						Size:     1,
+						Smallest: base.ParseInternalKey("d.SET.1"),
+						Largest:  base.ParseInternalKey("w.SET.1"),
+					},
+				},
+			}),
+			level:    1,
+			depth:    2,
+			smallest: []byte("a"),
+			largest:  []byte("z"),
+			want: []manifest.UserKeyRange{
+				{
+					Start: []byte("a"),
+					End:   []byte("c"),
+				},
+				{
+					Start: []byte("d"),
+					End:   []byte("w"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := calculateInuseKeyRanges(tt.v, cmp, tt.level, tt.depth, tt.smallest, tt.largest); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("calculateInuseKeyRanges() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/db_test.go
+++ b/db_test.go
@@ -891,7 +891,7 @@ func TestCacheEvict(t *testing.T) {
 		require.NoError(t, d.Delete(key, nil))
 	}
 
-	require.NoError(t, d.Compact([]byte("0"), []byte("1")))
+	require.NoError(t, d.Compact([]byte("0"), []byte("1"), false))
 
 	require.NoError(t, d.Close())
 
@@ -919,7 +919,7 @@ func TestRollManifest(t *testing.T) {
 		FS:                    vfs.NewMem(),
 		NumPrevManifest:       int(toPreserve),
 	}
-	opts.private.disableAutomaticCompactions = true
+	opts.DisableAutomaticCompactions = true
 	opts.testingRandomized()
 	d, err := Open("", opts)
 	require.NoError(t, err)
@@ -1004,7 +1004,7 @@ func TestDBClosed(t *testing.T) {
 
 	require.True(t, errors.Is(catch(func() { _ = d.Close() }), ErrClosed))
 
-	require.True(t, errors.Is(catch(func() { _ = d.Compact(nil, nil) }), ErrClosed))
+	require.True(t, errors.Is(catch(func() { _ = d.Compact(nil, nil, false) }), ErrClosed))
 	require.True(t, errors.Is(catch(func() { _ = d.Flush() }), ErrClosed))
 	require.True(t, errors.Is(catch(func() { _, _ = d.AsyncFlush() }), ErrClosed))
 
@@ -1043,7 +1043,7 @@ func TestDBConcurrentCommitCompactFlush(t *testing.T) {
 			var err error
 			switch i % 3 {
 			case 0:
-				err = d.Compact(nil, []byte("\xff"))
+				err = d.Compact(nil, []byte("\xff"), false)
 			case 1:
 				err = d.Flush()
 			case 2:
@@ -1142,7 +1142,7 @@ func TestCloseCleanerRace(t *testing.T) {
 		it := db.NewIter(nil)
 		require.NotNil(t, it)
 		require.NoError(t, db.DeleteRange([]byte("a"), []byte("b"), Sync))
-		require.NoError(t, db.Compact([]byte("a"), []byte("b")))
+		require.NoError(t, db.Compact([]byte("a"), []byte("b"), false))
 		// Only the iterator is keeping the sstables alive.
 		files, err := mem.List("/")
 		require.NoError(t, err)
@@ -1266,7 +1266,7 @@ func BenchmarkNewIterReadAmp(b *testing.B) {
 				FS:                    vfs.NewMem(),
 				L0StopWritesThreshold: 1000,
 			}
-			opts.private.disableAutomaticCompactions = true
+			opts.DisableAutomaticCompactions = true
 
 			d, err := Open("", opts)
 			require.NoError(b, err)

--- a/error_test.go
+++ b/error_test.go
@@ -114,7 +114,7 @@ func TestErrors(t *testing.T) {
 		if err := d.Flush(); err != nil {
 			return err
 		}
-		if err := d.Compact(nil, []byte("\xff")); err != nil {
+		if err := d.Compact(nil, []byte("\xff"), false); err != nil {
 			return err
 		}
 
@@ -182,7 +182,7 @@ func TestRequireReadError(t *testing.T) {
 		require.NoError(t, d.Set(key1, value, nil))
 		require.NoError(t, d.Set(key2, value, nil))
 		require.NoError(t, d.Flush())
-		require.NoError(t, d.Compact(key1, key2))
+		require.NoError(t, d.Compact(key1, key2, false))
 		require.NoError(t, d.DeleteRange(key1, key2, nil))
 		require.NoError(t, d.Set(key1, value, nil))
 		require.NoError(t, d.Flush())
@@ -284,7 +284,7 @@ func TestCorruptReadError(t *testing.T) {
 		require.NoError(t, d.Set(key1, value, nil))
 		require.NoError(t, d.Set(key2, value, nil))
 		require.NoError(t, d.Flush())
-		require.NoError(t, d.Compact(key1, key2))
+		require.NoError(t, d.Compact(key1, key2, false))
 		require.NoError(t, d.DeleteRange(key1, key2, nil))
 		require.NoError(t, d.Set(key1, value, nil))
 		require.NoError(t, d.Flush())

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -189,7 +189,7 @@ func TestEventListener(t *testing.T) {
 			if err := d.Set([]byte("a"), nil, nil); err != nil {
 				return err.Error()
 			}
-			if err := d.Compact([]byte("a"), []byte("b")); err != nil {
+			if err := d.Compact([]byte("a"), []byte("b"), false); err != nil {
 				return err.Error()
 			}
 			return buf.String()

--- a/flush_test.go
+++ b/flush_test.go
@@ -22,7 +22,7 @@ func TestManualFlush(t *testing.T) {
 			FS:                    vfs.NewMem(),
 			L0CompactionThreshold: 10,
 		}
-		opts.private.disableAutomaticCompactions = true
+		opts.DisableAutomaticCompactions = true
 		return opts
 	}
 	d, err := Open("", getOptions())

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -68,7 +68,7 @@ func testBasicDB(d *DB) error {
 	if err := d.Flush(); err != nil {
 		return err
 	}
-	if err := d.Compact(nil, []byte("\xff")); err != nil {
+	if err := d.Compact(nil, []byte("\xff"), false); err != nil {
 		return err
 	}
 

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -515,7 +515,7 @@ func TestIngest(t *testing.T) {
 		}
 		// Disable automatic compactions because otherwise we'll race with
 		// delete-only compactions triggered by ingesting range tombstones.
-		opts.private.disableAutomaticCompactions = true
+		opts.DisableAutomaticCompactions = true
 
 		var err error
 		d, err = Open("", opts)
@@ -794,7 +794,7 @@ func TestConcurrentIngestCompact(t *testing.T) {
 
 			compact := func(start, end string) {
 				t.Helper()
-				require.NoError(t, d.Compact([]byte(start), []byte(end)))
+				require.NoError(t, d.Compact([]byte(start), []byte(end), false))
 			}
 
 			lsm := func() string {
@@ -1503,6 +1503,6 @@ func runBenchmarkManySSTablesInUseKeyRanges(b *testing.B, d *DB, count int) {
 	smallest := []byte("0")
 	largest := []byte("z")
 	for i := 0; i < b.N; i++ {
-		_ = calculateInuseKeyRanges(v, d.cmp, 0, smallest, largest)
+		_ = calculateInuseKeyRanges(v, d.cmp, 0, numLevels-1, smallest, largest)
 	}
 }

--- a/internal/datadriven/datadriven.go
+++ b/internal/datadriven/datadriven.go
@@ -25,6 +25,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/cockroachdb/errors"
 )
 
 var (
@@ -229,47 +231,28 @@ type TestData struct {
 // td.ScanArgs(t, "arg3", &i2, &i3, &i4)
 func (td *TestData) ScanArgs(t *testing.T, key string, dests ...interface{}) {
 	t.Helper()
-	var arg CmdArg
-	for i := range td.CmdArgs {
-		if td.CmdArgs[i].Key == key {
-			arg = td.CmdArgs[i]
-			break
-		}
-	}
-	if arg.Key == "" {
+	arg := td.findArg(key)
+	if arg == nil {
 		t.Fatalf("missing argument: %s", key)
 	}
-	if len(dests) != len(arg.Vals) {
-		t.Fatalf("%s: got %d destinations, but %d values", arg.Key, len(dests), len(arg.Vals))
+	err := arg.scan(dests...)
+	if err != nil {
+		t.Fatal(err)
 	}
+}
 
-	for i := range dests {
-		val := arg.Vals[i]
-		switch dest := dests[i].(type) {
-		case *string:
-			*dest = val
-		case *int:
-			n, err := strconv.ParseInt(val, 10, 64)
-			if err != nil {
-				t.Fatal(err)
-			}
-			*dest = int(n) // assume 64bit ints
-		case *uint64:
-			n, err := strconv.ParseUint(val, 10, 64)
-			if err != nil {
-				t.Fatal(err)
-			}
-			*dest = n
-		case *bool:
-			b, err := strconv.ParseBool(val)
-			if err != nil {
-				t.Fatal(err)
-			}
-			*dest = b
-		default:
-			t.Fatalf("unsupported type %T for destination #%d (might be easy to add it)", dest, i+1)
+// HasArg determines if `key` appears in CmdArgs.
+func (td *TestData) HasArg(key string) bool {
+	return td.findArg(key) != nil
+}
+
+func (td *TestData) findArg(key string) *CmdArg {
+	for i := range td.CmdArgs {
+		if td.CmdArgs[i].Key == key {
+			return &td.CmdArgs[i]
 		}
 	}
+	return nil
 }
 
 // CmdArg contains information about an argument on the directive line. An
@@ -293,6 +276,41 @@ func (arg CmdArg) String() string {
 	default:
 		return fmt.Sprintf("%s=(%s)", arg.Key, strings.Join(arg.Vals, ", "))
 	}
+}
+
+func (arg CmdArg) scan(dests ...interface{}) error {
+	if len(dests) != len(arg.Vals) {
+		return errors.Errorf("%s: got %d destinations, but %d values", arg.Key, len(dests), len(arg.Vals))
+	}
+
+	for i := range dests {
+		val := arg.Vals[i]
+		switch dest := dests[i].(type) {
+		case *string:
+			*dest = val
+		case *int:
+			n, err := strconv.ParseInt(val, 10, 64)
+			if err != nil {
+				return err
+			}
+			*dest = int(n) // assume 64bit ints
+		case *uint64:
+			n, err := strconv.ParseUint(val, 10, 64)
+			if err != nil {
+				return err
+			}
+			*dest = n
+		case *bool:
+			b, err := strconv.ParseBool(val)
+			if err != nil {
+				return err
+			}
+			*dest = b
+		default:
+			return errors.Errorf("unsupported type %T for destination #%d (might be easy to add it)", dest, i+1)
+		}
+	}
+	return nil
 }
 
 // Fatalf wraps a fatal testing error with test file position information, so

--- a/internal/metamorphic/generator.go
+++ b/internal/metamorphic/generator.go
@@ -362,8 +362,9 @@ func (g *generator) dbCompact() {
 		start, end = end, start
 	}
 	g.add(&compactOp{
-		start: start,
-		end:   end,
+		start:       start,
+		end:         end,
+		parallelize: g.rng.Float64() < 0.5,
 	})
 }
 

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -99,19 +99,20 @@ func (o *closeOp) String() string {
 
 // compactOp models a DB.Compact operation.
 type compactOp struct {
-	start []byte
-	end   []byte
+	start       []byte
+	end         []byte
+	parallelize bool
 }
 
 func (o *compactOp) run(t *test, h *history) {
 	err := withRetries(func() error {
-		return t.db.Compact(o.start, o.end)
+		return t.db.Compact(o.start, o.end, o.parallelize)
 	})
 	h.Recordf("%s // %v", o, err)
 }
 
 func (o *compactOp) String() string {
-	return fmt.Sprintf("db.Compact(%q, %q)", o.start, o.end)
+	return fmt.Sprintf("db.Compact(%q, %q, %t /* parallelize */)", o.start, o.end, o.parallelize)
 }
 
 // deleteOp models a Write.Delete operation.

--- a/internal/metamorphic/parser.go
+++ b/internal/metamorphic/parser.go
@@ -49,7 +49,7 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	case *closeOp:
 		return &t.objID, nil, nil
 	case *compactOp:
-		return nil, nil, []interface{}{&t.start, &t.end}
+		return nil, nil, []interface{}{&t.start, &t.end, &t.parallelize}
 	case *batchCommitOp:
 		return &t.batchID, nil, nil
 	case *dbRestartOp:

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -845,7 +845,7 @@ func TestIteratorNextPrev(t *testing.T) {
 		opts := &Options{FS: mem}
 		// Automatic compactions may compact away tombstones from L6, making
 		// some testcases non-deterministic.
-		opts.private.disableAutomaticCompactions = true
+		opts.DisableAutomaticCompactions = true
 		var err error
 		d, err = Open("", opts)
 		require.NoError(t, err)
@@ -1239,7 +1239,7 @@ func TestIteratorBlockIntervalFilter(t *testing.T) {
 
 		// Automatic compactions may compact away tombstones from L6, making
 		// some testcases non-deterministic.
-		opts.private.disableAutomaticCompactions = true
+		opts.DisableAutomaticCompactions = true
 		var err error
 		d, err = Open("", opts)
 		require.NoError(t, err)
@@ -1680,7 +1680,7 @@ func BenchmarkBlockPropertyFilter(b *testing.B) {
 			}
 			require.NoError(b, batch.Commit(nil))
 			require.NoError(b, d.Flush())
-			require.NoError(b, d.Compact(nil, []byte{0xFF}))
+			require.NoError(b, d.Compact(nil, []byte{0xFF}, false))
 
 			for _, filter := range []bool{false, true} {
 				b.Run(fmt.Sprintf("filter=%t", filter), func(b *testing.B) {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -109,7 +109,7 @@ func TestMetrics(t *testing.T) {
 	// Prevent foreground flushes and compactions from triggering asynchronous
 	// follow-up compactions. This avoids asynchronously-scheduled work from
 	// interfering with the expected metrics output and reduces test flakiness.
-	opts.private.disableAutomaticCompactions = true
+	opts.DisableAutomaticCompactions = true
 
 	d, err := Open("", opts)
 	require.NoError(t, err)

--- a/open_test.go
+++ b/open_test.go
@@ -380,7 +380,7 @@ func TestOpenReadOnly(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify various write operations fail in read-only mode.
-		require.EqualValues(t, ErrReadOnly, d.Compact(nil, []byte("\xff")))
+		require.EqualValues(t, ErrReadOnly, d.Compact(nil, []byte("\xff"), false))
 		require.EqualValues(t, ErrReadOnly, d.Flush())
 		require.EqualValues(t, ErrReadOnly, func() error { _, err := d.AsyncFlush(); return err }())
 
@@ -845,7 +845,7 @@ func TestOpenWALReplayReadOnlySeqNums(t *testing.T) {
 	// written to the MANIFEST. This produces a MANIFEST where the `logSeqNum`
 	// is greater than the sequence numbers contained in the
 	// `minUnflushedLogNum` log file
-	require.NoError(t, d.Compact([]byte("a"), []byte("a\x00")))
+	require.NoError(t, d.Compact([]byte("a"), []byte("a\x00"), false))
 
 	// While the MANIFEST is still in this state, copy all the files in the
 	// database to a new directory.

--- a/options.go
+++ b/options.go
@@ -548,9 +548,16 @@ type Options struct {
 	Merger *Merger
 
 	// MaxConcurrentCompactions specifies the maximum number of concurrent
-	// compactions. The default is 1. Concurrent compactions are only performed
-	// when L0 read-amplification passes the L0CompactionConcurrency threshold.
+	// compactions. The default is 1. Concurrent compactions are performed
+	// - when L0 read-amplification passes the L0CompactionConcurrency threshold
+	// - for automatic background compactions
+	// - when a manual compaction for a level is split and parallelized
 	MaxConcurrentCompactions int
+
+	// DisableAutomaticCompactions dictates whether automatic compactions are
+	// scheduled or not. The default is false (enabled). This option is only used
+	// externally when running a manual compaction, and internally for tests.
+	DisableAutomaticCompactions bool
 
 	// NumPrevManifest is the number of non-current or older manifests which
 	// we want to keep around for debugging purposes. By default, we're going
@@ -629,9 +636,6 @@ type Options struct {
 
 		// A private option to disable stats collection.
 		disableTableStats bool
-
-		// A private option disable automatic compactions.
-		disableAutomaticCompactions bool
 
 		// minCompactionRate sets the minimum rate at which compactions occur. The
 		// default is 4 MB/s. Currently disabled as this option has no effect while

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -109,7 +109,7 @@ func TestSnapshot(t *testing.T) {
 					if len(keys) != 2 {
 						return fmt.Sprintf("malformed key range: %s", parts[1])
 					}
-					err = d.Compact([]byte(keys[0]), []byte(keys[1]))
+					err = d.Compact([]byte(keys[0]), []byte(keys[1]), false)
 				default:
 					return fmt.Sprintf("unknown op: %s", parts[0])
 				}

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -323,7 +323,7 @@ func TestSharedTableCacheUseAfterOneFree(t *testing.T) {
 	require.NoError(t, db2.Set(start, nil, nil))
 	require.NoError(t, db2.Flush())
 	require.NoError(t, db2.DeleteRange(start, end, nil))
-	require.NoError(t, db2.Compact(start, end))
+	require.NoError(t, db2.Compact(start, end, false))
 }
 
 // A basic test which makes sure that a shared table cache is usable
@@ -361,7 +361,7 @@ func TestSharedTableCacheUsable(t *testing.T) {
 	require.NoError(t, db1.Set(start, nil, nil))
 	require.NoError(t, db1.Flush())
 	require.NoError(t, db1.DeleteRange(start, end, nil))
-	require.NoError(t, db1.Compact(start, end))
+	require.NoError(t, db1.Compact(start, end, false))
 
 	start = []byte("x")
 	end = []byte("y")
@@ -370,7 +370,7 @@ func TestSharedTableCacheUsable(t *testing.T) {
 	require.NoError(t, db2.Set(start, []byte{'a'}, nil))
 	require.NoError(t, db2.Flush())
 	require.NoError(t, db2.DeleteRange(start, end, nil))
-	require.NoError(t, db2.Compact(start, end))
+	require.NoError(t, db2.Compact(start, end, false))
 }
 
 func TestSharedTableConcurrent(t *testing.T) {
@@ -413,7 +413,7 @@ func TestSharedTableConcurrent(t *testing.T) {
 			require.NoError(t, db.Set(start, nil, nil))
 			require.NoError(t, db.Flush())
 			require.NoError(t, db.DeleteRange(start, end, nil))
-			require.NoError(t, db.Compact(start, end))
+			require.NoError(t, db.Compact(start, end, false))
 		}
 		wg.Done()
 	}
@@ -807,7 +807,7 @@ func TestTableCacheEvictClose(t *testing.T) {
 	require.NoError(t, db.Set(start, nil, nil))
 	require.NoError(t, db.Flush())
 	require.NoError(t, db.DeleteRange(start, end, nil))
-	require.NoError(t, db.Compact(start, end))
+	require.NoError(t, db.Compact(start, end, false))
 	require.NoError(t, db.Close())
 	close(errs)
 

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -27,7 +27,7 @@ func TestTableStats(t *testing.T) {
 			},
 		},
 	}
-	opts.private.disableAutomaticCompactions = true
+	opts.DisableAutomaticCompactions = true
 
 	d, err := Open("", opts)
 	require.NoError(t, err)

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -644,7 +644,7 @@ L0
   000005:[a#2,SET-a#2,SET]
   000004:[b#1,SET-b#1,SET]
 
-add-ongoing-compaction startLevel=0 outputLevel=1
+add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=b
 ----
 
 async-compact a-b L0
@@ -660,7 +660,7 @@ compact a-b L1
   000008:[a#0,SET-a#0,SET]
   000009:[b#0,SET-b#0,SET]
 
-add-ongoing-compaction startLevel=0 outputLevel=1
+add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=b
 ----
 
 async-compact a-b L2
@@ -670,7 +670,7 @@ manual compaction blocked until ongoing finished
   000010:[a#0,SET-a#0,SET]
   000011:[b#0,SET-b#0,SET]
 
-add-ongoing-compaction startLevel=0 outputLevel=1
+add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=b
 ----
 
 set-concurrent-compactions num=2
@@ -686,7 +686,7 @@ manual compaction did not block for ongoing
 remove-ongoing-compaction
 ----
 
-add-ongoing-compaction startLevel=5 outputLevel=6
+add-ongoing-compaction startLevel=5 outputLevel=6 start=a end=b
 ----
 
 async-compact a-b L4
@@ -858,3 +858,142 @@ compact a-z L1
 2:
   000006:[b#0,SET-b#0,SET]
   000007:[c#0,SET-c#0,SET]
+
+define target-file-sizes=(1, 1, 1, 1)
+L0
+  a.SET.3:v
+  b.SET.2:v
+L2
+  a.SET.1:v
+L3
+  a.SET.0:v
+  b.SET.0:v
+L3
+  c.SET.0:v
+----
+0.0:
+  000004:[a#3,SET-b#2,SET]
+2:
+  000005:[a#1,SET-a#1,SET]
+3:
+  000006:[a#0,SET-b#0,SET]
+  000007:[c#0,SET-c#0,SET]
+
+set-concurrent-compactions num=3
+----
+
+compact a-c parallel hide-file-num
+----
+4:
+  [a#0,SET-a#0,SET]
+  [b#0,SET-b#0,SET]
+  [c#0,SET-c#0,SET]
+
+define target-file-sizes=(1, 1, 1, 1)
+L0
+  a.SET.3:v
+  b.SET.2:v
+L0
+  a.SET.2:v
+  c.SET.2:v
+L2
+  a.SET.1:v
+  b.SET.1:v
+L2
+  c.SET.1:v
+L2
+  d.SET.0:v
+L3
+  a.SET.0:v
+  b.SET.0:v
+L3
+  c.SET.0:v
+----
+0.1:
+  000004:[a#3,SET-b#2,SET]
+0.0:
+  000005:[a#2,SET-c#2,SET]
+2:
+  000006:[a#1,SET-b#1,SET]
+  000007:[c#1,SET-c#1,SET]
+  000008:[d#0,SET-d#0,SET]
+3:
+  000009:[a#0,SET-b#0,SET]
+  000010:[c#0,SET-c#0,SET]
+
+set-concurrent-compactions num=2
+----
+
+compact a-c L0 parallel
+----
+1:
+  000011:[a#3,SET-a#3,SET]
+  000012:[b#2,SET-b#2,SET]
+  000013:[c#2,SET-c#2,SET]
+2:
+  000006:[a#1,SET-b#1,SET]
+  000007:[c#1,SET-c#1,SET]
+  000008:[d#0,SET-d#0,SET]
+3:
+  000009:[a#0,SET-b#0,SET]
+  000010:[c#0,SET-c#0,SET]
+
+add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=e
+----
+
+# While we allow 2 concurrent compactions, the ongoing compaction conflicts
+# with the compaction below, and thus the manual compaction is dropped with
+# no change to the LSM.
+
+async-compact a-d L1 parallel
+----
+manual compaction did not block for ongoing
+1:
+  000011:[a#3,SET-a#3,SET]
+  000012:[b#2,SET-b#2,SET]
+  000013:[c#2,SET-c#2,SET]
+2:
+  000006:[a#1,SET-b#1,SET]
+  000007:[c#1,SET-c#1,SET]
+  000008:[d#0,SET-d#0,SET]
+3:
+  000009:[a#0,SET-b#0,SET]
+  000010:[c#0,SET-c#0,SET]
+
+remove-ongoing-compaction
+----
+
+add-ongoing-compaction startLevel=3 outputLevel=4 start=a end=d
+----
+
+# We allow 2 maximum concurrent compactions. The operation below generates
+# 2 concurrent compactions (a-b, c) from L1 to L2. With 1 ongoing compaction with
+# output level L4, there is no conflict and thus the concurrent compactions should
+# be queued up and executed sequentially. We ensure that the compactions finish and
+# that the final result of the compactions is correct.
+
+async-compact a-d L1 parallel
+----
+manual compaction did not block for ongoing
+2:
+  000014:[a#3,SET-a#3,SET]
+  000015:[b#2,SET-b#2,SET]
+  000016:[c#2,SET-c#2,SET]
+  000008:[d#0,SET-d#0,SET]
+3:
+  000009:[a#0,SET-b#0,SET]
+  000010:[c#0,SET-c#0,SET]
+
+remove-ongoing-compaction
+----
+
+set-concurrent-compactions num=3
+----
+
+compact a-d parallel hide-file-num
+----
+4:
+  [a#0,SET-a#0,SET]
+  [b#0,SET-b#0,SET]
+  [c#0,SET-c#0,SET]
+  [d#0,SET-d#0,SET]

--- a/testdata/manual_compaction_set_with_del
+++ b/testdata/manual_compaction_set_with_del
@@ -645,7 +645,7 @@ L0
   000005:[a#2,SET-a#2,SET]
   000004:[b#1,SET-b#1,SET]
 
-add-ongoing-compaction startLevel=0 outputLevel=1
+add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=z
 ----
 
 async-compact a-b L0
@@ -661,7 +661,7 @@ compact a-b L1
   000008:[a#0,SET-a#0,SET]
   000009:[b#0,SET-b#0,SET]
 
-add-ongoing-compaction startLevel=0 outputLevel=1
+add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=z
 ----
 
 async-compact a-b L2
@@ -671,7 +671,7 @@ manual compaction blocked until ongoing finished
   000010:[a#0,SET-a#0,SET]
   000011:[b#0,SET-b#0,SET]
 
-add-ongoing-compaction startLevel=0 outputLevel=1
+add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=z
 ----
 
 set-concurrent-compactions num=2
@@ -687,7 +687,7 @@ manual compaction did not block for ongoing
 remove-ongoing-compaction
 ----
 
-add-ongoing-compaction startLevel=5 outputLevel=6
+add-ongoing-compaction startLevel=5 outputLevel=6 start=a end=b
 ----
 
 async-compact a-b L4

--- a/tool/make_test_find_db.go
+++ b/tool/make_test_find_db.go
@@ -124,7 +124,7 @@ func (d *db) flush() {
 }
 
 func (d *db) compact(start, end string) {
-	if err := d.db.Compact([]byte(start), []byte(end)); err != nil {
+	if err := d.db.Compact([]byte(start), []byte(end), false); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
This PR introduces concurrent execution for manual compactions - previously done one at a time, level by level.

This is achieved by splitting a single manual compaction for a level into
multiple compactions with non-overlapping key ranges. When compacted, the
output ranges of these compactions do not conflict and can thus be
performed in parallel.

A new parameter has been added to db.Compact, which determines whether or
not to split a single manual compaction into its encompassing non-overlapping
keyranges. Moreover, the changes in this PR rely on automatic compactions
being disabled when compactions are split to avoid conflicts.

Resolves https://github.com/cockroachdb/pebble/issues/1404