### PR TITLE
db: integrate range keys into indexed batches

### DIFF
--- a/db.go
+++ b/db.go
@@ -912,7 +912,7 @@ func (d *DB) newIterInternal(batch *Batch, s *Snapshot, o *IterOptions) *Iterato
 	if o.rangeKeys() {
 		// TODO(jackson): Pool range-key iterator objects.
 		dbi.rangeKey = &iteratorRangeKeyState{
-			rangeKeyIter: d.newRangeKeyIter(seqNum, o),
+			rangeKeyIter: d.newRangeKeyIter(seqNum, batch, readState, o),
 		}
 	}
 	if o != nil {

--- a/flushable.go
+++ b/flushable.go
@@ -16,6 +16,7 @@ type flushable interface {
 	newIter(o *IterOptions) internalIterator
 	newFlushIter(o *IterOptions, bytesFlushed *uint64) internalIterator
 	newRangeDelIter(o *IterOptions) keyspan.FragmentIterator
+	newRangeKeyIter(o *IterOptions) keyspan.FragmentIterator
 	// inuseBytes returns the number of inuse bytes by the flushable.
 	inuseBytes() uint64
 	// totalBytes returns the total number of bytes allocated by the flushable.

--- a/mem_table.go
+++ b/mem_table.go
@@ -232,6 +232,11 @@ func (m *memTable) newRangeDelIter(*IterOptions) keyspan.FragmentIterator {
 	return keyspan.NewIter(m.cmp, tombstones)
 }
 
+func (m *memTable) newRangeKeyIter(*IterOptions) keyspan.FragmentIterator {
+	// TODO(jackson): Implement once range keys are written to the memtable.
+	return nil
+}
+
 func (m *memTable) availBytes() uint32 {
 	a := m.skl.Arena()
 	if atomic.LoadInt32(&m.writerRefs) == 1 {
@@ -279,7 +284,9 @@ type keySpanFrags struct {
 
 type splitValue func(kind base.InternalKeyKind, rawValue []byte) (endKey []byte, value []byte, err error)
 
-func rangeDelSplitValue(kind base.InternalKeyKind, rawValue []byte) (endKey []byte, value []byte, err error) {
+func rangeDelSplitValue(
+	kind base.InternalKeyKind, rawValue []byte,
+) (endKey []byte, value []byte, err error) {
 	if kind != base.InternalKeyKindRangeDelete {
 		panic(fmt.Sprintf("pebble: rangeDelSplitValue called on %s key kind", kind))
 	}

--- a/range_keys_test.go
+++ b/range_keys_test.go
@@ -16,9 +16,21 @@ import (
 
 func TestRangeKeys(t *testing.T) {
 	var d *DB
+	var b *Batch
+	newIter := func(o *IterOptions) *Iterator {
+		if b != nil {
+			return b.NewIter(o)
+		}
+		return d.NewIter(o)
+	}
+
 	datadriven.RunTest(t, "testdata/rangekeys", func(td *datadriven.TestData) string {
 		switch td.Cmd {
 		case "reset":
+			if b != nil {
+				require.NoError(t, b.Close())
+				b = nil
+			}
 			if d != nil {
 				require.NoError(t, d.Close())
 			}
@@ -43,6 +55,19 @@ func TestRangeKeys(t *testing.T) {
 			count := b.Count()
 			require.NoError(t, b.Commit(nil))
 			return fmt.Sprintf("wrote %d keys\n", count)
+		case "indexed-batch":
+			b = d.NewIndexedBatch()
+			require.NoError(t, runBatchDefineCmd(td, b))
+			count := b.Count()
+			return fmt.Sprintf("created indexed batch with %d keys\n", count)
+		case "commit-batch":
+			if b == nil {
+				return "no pending batch"
+			}
+			count := b.Count()
+			require.NoError(t, d.Apply(b, nil))
+			b = nil
+			return fmt.Sprintf("wrote %d keys\n", count)
 		case "combined-iter":
 			o := &IterOptions{KeyTypes: IterKeyTypePointsAndRanges}
 			for _, arg := range td.CmdArgs {
@@ -51,14 +76,14 @@ func TestRangeKeys(t *testing.T) {
 				}
 				o.RangeKeyMasking.Suffix = []byte(arg.Vals[0])
 			}
-			iter := d.NewIter(o)
+			iter := newIter(o)
 			return runIterCmd(td, iter, true /* close iter */)
 		case "rangekey-iter":
-			iter := d.NewIter(&IterOptions{KeyTypes: IterKeyTypeRangesOnly})
+			iter := newIter(&IterOptions{KeyTypes: IterKeyTypeRangesOnly})
 			return runIterCmd(td, iter, true /* close iter */)
 		case "scan-rangekeys":
 			var buf bytes.Buffer
-			iter := d.NewIter(&IterOptions{KeyTypes: IterKeyTypeRangesOnly})
+			iter := newIter(&IterOptions{KeyTypes: IterKeyTypeRangesOnly})
 			defer iter.Close()
 			for iter.First(); iter.Valid(); iter.Next() {
 				start, end := iter.RangeBounds()

--- a/testdata/batch_range_ops
+++ b/testdata/batch_range_ops
@@ -4,6 +4,7 @@ set b 2
 merge c 3
 del-range a c
 del d
+range-key-set b c @4 value
 ----
 
 scan
@@ -16,6 +17,10 @@ d#32,0:
 scan range-del
 ----
 a#27,15:c
+
+scan range-key
+----
+b#35,21:c (span value: 0240340576616c7565)
 
 clear
 ----
@@ -35,6 +40,25 @@ b#27,15:c
 b#22,15:c
 b#17,15:c
 c#27,15:d
+
+clear
+----
+
+define
+range-key-del a b
+range-key-del b c
+range-key-del a c
+range-key-del b d
+----
+
+scan range-key
+----
+a#22,19:b
+a#12,19:b
+b#27,19:c
+b#22,19:c
+b#17,19:c
+c#27,19:d
 
 clear
 ----
@@ -102,3 +126,27 @@ scan range-del
 ----
 a#12,15:b
 c#17,15:d
+
+# Verify that adding a range key via Batch.Apply invalidates the
+# cached fragmented range keys.
+
+clear
+----
+
+define
+range-key-set a c @2 v
+----
+
+scan range-key
+----
+a#12,21:c (span value: 0240320176)
+
+apply
+range-key-unset a b @2
+----
+
+scan range-key
+----
+a#23,20:b (span value: 024032)
+a#12,21:b (span value: 0240320176)
+b#12,21:c (span value: 0240320176)

--- a/testdata/flushable_batch
+++ b/testdata/flushable_batch
@@ -7,13 +7,11 @@ c.SET.1:1
 c.MERGE.2:2
 1.RANGEDEL.3:
 2.RANGEKEYSET.4:
-2.RANGEKEYDEL.5:
-2.RANGEKEYUNSET.6:
+1.RANGEKEYDEL.3:
+2.RANGEKEYUNSET.3:
 ----
 
-# TODO(jackson): This test includes RANGEDELs but not RANGEKEYs, because this
-# test doesn't yet incoporate a RANGEKEY iterator. Once we have a RANGEKEY
-# flushable batch iterator, update this test to incorporate it.
+# NB: The range keys get fragmented.
 
 dump seq=0
 ----
@@ -24,6 +22,11 @@ b#2,1:1
 c#5,2:2
 c#4,1:1
 1#6,15:3
+1#8,19:2
+2#9,20:3
+2#8,19:3
+2#7,21:3
+3#7,21:4
 
 dump seq=100
 ----
@@ -34,6 +37,11 @@ b#102,1:1
 c#105,2:2
 c#104,1:1
 1#106,15:3
+1#108,19:2
+2#109,20:3
+2#108,19:3
+2#107,21:3
+3#107,21:4
 
 define
 c.SET.1:1

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -156,10 +156,27 @@ b [b-c) @5=boop
 # Delete the b-c range key and the beginning of the cat-dog range key,
 # truncating it to now begin at 'd'.
 
-batch
+indexed-batch
 range-key-del b d
 ----
+created indexed batch with 1 keys
+
+# Reading through the indexed batch, we should see the beginning of the cat-dog
+# range key now beginning at 'd'.
+
+combined-iter
+seek-ge b
+next
+----
+c: (c, .)
+d: (d, [d-dog) @3=beep)
+
+commit-batch
+----
 wrote 1 keys
+
+# Reading through the database after applying the batch, we should still see the
+# beginning of the cat-dog range key now beginning at 'd'.
 
 combined-iter
 seek-ge b


### PR DESCRIPTION
Support reading range keys through an indexed batch. This commit integrates the
new rangekey merging iterator, allowing merging of range keys from a batch and
the global in-memory arena.