### PR TITLE
db: add OnlyReadGuaranteedDurable to IterOptions

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -353,6 +353,8 @@ func (p *commitPipeline) prepare(b *Batch, syncWAL bool) (*memTable, error) {
 	if syncWAL {
 		count++
 	}
+	// count represents the waiting needed for publish, and optionally the
+	// waiting needed for the WAL sync.
 	b.commit.Add(count)
 
 	var syncWG *sync.WaitGroup


### PR DESCRIPTION
This is only supported for Iterators created on the DB, and
excludes data in the memtable. This will be used for
https://github.com/cockroachdb/cockroach/issues/36262
which is a prerequisite for separating the state machine
into a different DB.

Note that RocksDB supports such behavior using a ReadTier
setting equal to kPersistedTier, which this PR does not adopt
because it was considered too flexible (and has limitations
like not supporting iterators). See
https://github.com/facebook/rocksdb/blob/f6d7ec1d02de1fa84eff61b7ac5a3c663bd63cd7/include/rocksdb/options.h#L1394-L1408
https://github.com/facebook/rocksdb/blob/f6d7ec1d02de1fa84eff61b7ac5a3c663bd63cd7/include/rocksdb/options.h#L1467-L1471

Additionally, if the exclusion of memtables is an implementation
decision, as outlined in the comment in IterOptions, it allows
us more flexibility in implementation in the future.