### PR TITLE
release-21.2: internal/batchskl: return error on index overflow

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -62,13 +62,13 @@ type DeferredBatchOp struct {
 // have been filled into Key and Value. Not calling Finish or not
 // copying/encoding keys will result in an incomplete index, and calling Finish
 // twice may result in a panic.
-func (d DeferredBatchOp) Finish() {
+func (d DeferredBatchOp) Finish() error {
 	if d.index != nil {
 		if err := d.index.Add(d.offset); err != nil {
-			// We never add duplicate entries, so an error should never occur.
-			panic(err)
+			return err
 		}
 	}
+	return nil
 }
 
 // A Batch is a sequence of Sets, Merges, Deletes, and/or DeleteRanges that are
@@ -357,8 +357,7 @@ func (b *Batch) Apply(batch *Batch, _ *WriteOptions) error {
 					err = b.index.Add(uint32(offset))
 				}
 				if err != nil {
-					// We never add duplicate entries, so an error should never occur.
-					panic(err)
+					return err
 				}
 			}
 			b.memTableSize += memTableEntrySize(len(key), len(value))
@@ -475,8 +474,7 @@ func (b *Batch) Set(key, value []byte, _ *WriteOptions) error {
 	// in go1.13 will remove the need for this.
 	if b.index != nil {
 		if err := b.index.Add(deferredOp.offset); err != nil {
-			// We never add duplicate entries, so an error should never occur.
-			panic(err)
+			return err
 		}
 	}
 	return nil
@@ -505,8 +503,7 @@ func (b *Batch) Merge(key, value []byte, _ *WriteOptions) error {
 	// in go1.13 will remove the need for this.
 	if b.index != nil {
 		if err := b.index.Add(deferredOp.offset); err != nil {
-			// We never add duplicate entries, so an error should never occur.
-			panic(err)
+			return err
 		}
 	}
 	return nil
@@ -532,8 +529,7 @@ func (b *Batch) Delete(key []byte, _ *WriteOptions) error {
 	// in go1.13 will remove the need for this.
 	if b.index != nil {
 		if err := b.index.Add(deferredOp.offset); err != nil {
-			// We never add duplicate entries, so an error should never occur.
-			panic(err)
+			return err
 		}
 	}
 	return nil
@@ -560,8 +556,7 @@ func (b *Batch) SingleDelete(key []byte, _ *WriteOptions) error {
 	// in go1.13 will remove the need for this.
 	if b.index != nil {
 		if err := b.index.Add(deferredOp.offset); err != nil {
-			// We never add duplicate entries, so an error should never occur.
-			panic(err)
+			return err
 		}
 	}
 	return nil
@@ -590,8 +585,7 @@ func (b *Batch) DeleteRange(start, end []byte, _ *WriteOptions) error {
 	// in go1.13 will remove the need for this.
 	if deferredOp.index != nil {
 		if err := deferredOp.index.Add(deferredOp.offset); err != nil {
-			// We never add duplicate entries, so an error should never occur.
-			panic(err)
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
This is a backport of #1486 to 21.2.

---

Currently, the raw data for a skiplist node is stored in a byte slice,
which is indexed into with a `uint32`. In situations where a large
number of nodes are added to the skiplist (on the order of 100 M), the
addition of a node can result in integer overflow which results in a
runtime panic.

Rather than panic, check that the addition of a new node would not
result in an overflow. In the situation where an overflow would occur,
return an error to the caller.

Propagate potential errors for the skip list to external callers. Prior
to this, it was assumed that the addition of a node would never return
an error and the top level methods would panic. Exposing the error
allows external callers to make a determination at runtime as to how the
overflow should be handled.

The altered implementation is slightly faster:

```
name                   old time/op  new time/op  delta
ReadWrite/frac_0-16     724ns ±17%   690ns ± 3%  -4.65%  (p=0.016 n=20+19)
ReadWrite/frac_10-16    694ns ± 3%   687ns ± 2%  -1.03%  (p=0.010 n=17+16)
ReadWrite/frac_20-16    682ns ± 7%   694ns ±15%    ~     (p=0.641 n=17+20)
ReadWrite/frac_30-16    655ns ± 6%   658ns ± 5%    ~     (p=0.443 n=17+18)
ReadWrite/frac_40-16    636ns ±14%   655ns ±10%    ~     (p=0.271 n=18+19)
ReadWrite/frac_50-16    611ns ±11%   594ns ± 4%  -2.87%  (p=0.013 n=18+20)
ReadWrite/frac_60-16    595ns ±15%   559ns ± 3%  -6.03%  (p=0.004 n=20+20)
ReadWrite/frac_70-16    546ns ±18%   497ns ± 2%  -8.93%  (p=0.000 n=19+20)
ReadWrite/frac_80-16    419ns ± 5%   428ns ± 3%  +2.19%  (p=0.000 n=18+20)
ReadWrite/frac_90-16    327ns ± 7%   333ns ± 3%    ~     (p=0.055 n=20+20)
ReadWrite/frac_100-16  21.9ns ± 5%  21.9ns ± 5%    ~     (p=0.569 n=20+20)
```

Closes #1258.