### PR TITLE
sstable: require FilterPolicies, add IgnoreMissingFilters option

### DIFF
--- a/open_test.go
+++ b/open_test.go
@@ -960,9 +960,10 @@ func TestRocksDBNoFlushManifest(t *testing.T) {
 	comparer.Name = "cockroach_comparator"
 	merger.Name = "cockroach_merge_operator"
 	opts := &Options{
-		FS:       mem,
-		Comparer: &comparer,
-		Merger:   &merger,
+		FS:                   mem,
+		Comparer:             &comparer,
+		Merger:               &merger,
+		IgnoreMissingFilters: true,
 	}
 
 	// rocksdb-ingest-only is a RocksDB-generated db directory that has not had

--- a/options.go
+++ b/options.go
@@ -456,6 +456,10 @@ type Options struct {
 	// map during normal usage of a DB.
 	Filters map[string]FilterPolicy
 
+	// IgnoreMissingFilters allows opening sstables that have filter blocks that
+	// correspond to filter policies that are not configured.
+	IgnoreMissingFilters bool
+
 	// FlushSplitBytes denotes the target number of bytes per sublevel in
 	// each flush split interval (i.e. range between two flush split keys)
 	// in L0 sstables. When set to zero, only a single sstable is generated
@@ -1238,6 +1242,7 @@ func (o *Options) MakeReaderOptions() sstable.ReaderOptions {
 		readerOpts.Cache = o.Cache
 		readerOpts.Comparer = o.Comparer
 		readerOpts.Filters = o.Filters
+		readerOpts.IgnoreMissingFilters = o.IgnoreMissingFilters
 		if o.Merger != nil {
 			readerOpts.MergerName = o.Merger.Name
 		}

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -109,9 +109,12 @@ type ReaderOptions struct {
 
 	// Filters is a map from filter policy name to filter policy. It is used for
 	// debugging tools which may be used on multiple databases configured with
-	// different filter policies. It is not necessary to populate this filters
-	// map during normal usage of a DB.
+	// different filter policies.
 	Filters map[string]FilterPolicy
+
+	// IgnoreMissingFilters allows ignoring filter blocks that correspond to a
+	// FilterPolicy that is missing from the Filters map.
+	IgnoreMissingFilters bool
 
 	// Merger defines the associative merge operation to use for merging values
 	// written with {Batch,DB}.Merge. The MergerName is checked for consistency

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -226,7 +226,7 @@ func TestHamletReader(t *testing.T) {
 		f, err := os.Open(filepath.FromSlash(prebuiltSST))
 		require.NoError(t, err)
 
-		r, err := NewReader(f, ReaderOptions{})
+		r, err := NewReader(f, ReaderOptions{IgnoreMissingFilters: true})
 		require.NoError(t, err)
 
 		t.Run(
@@ -251,7 +251,7 @@ func TestInjectedErrors(t *testing.T) {
 		run := func(i int) (reterr error) {
 			f, err := os.Open(filepath.FromSlash(prebuiltSST))
 			require.NoError(t, err)
-			r, err := NewReader(errorfs.WrapFile(f, errorfs.OnIndex(int32(i))), ReaderOptions{})
+			r, err := NewReader(errorfs.WrapFile(f, errorfs.OnIndex(int32(i))), ReaderOptions{IgnoreMissingFilters: true})
 			if err != nil {
 				return firstError(err, f.Close())
 			}

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -123,6 +123,8 @@ func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
 		opts.Filters = map[string]FilterPolicy{
 			fp.Name(): fp,
 		}
+	} else {
+		opts.IgnoreMissingFilters = true
 	}
 
 	r, err := NewReader(f, opts)

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -183,7 +183,7 @@ compact         1   2.3 K     0 B       0          (size == estimated-debt, scor
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.4 K    0.0%  (score == hit-rate)
- tcache         1   672 B    0.0%  (score == hit-rate)
+ tcache         1   680 B    0.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -48,7 +48,7 @@ compact         0     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.5 K   42.9%  (score == hit-rate)
- tcache         1   672 B   50.0%  (score == hit-rate)
+ tcache         1   680 B   50.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -34,7 +34,7 @@ compact         0     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         1   256 K
    ztbl         0     0 B
  bcache         4   698 B    0.0%  (score == hit-rate)
- tcache         1   672 B    0.0%  (score == hit-rate)
+ tcache         1   680 B    0.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         1
  filter         -       -    0.0%  (score == utility)
@@ -145,7 +145,7 @@ compact         1     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         1   256 K
    ztbl         1   771 B
  bcache         4   698 B   33.3%  (score == hit-rate)
- tcache         1   672 B   50.0%  (score == hit-rate)
+ tcache         1   680 B   50.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         1
  filter         -       -    0.0%  (score == utility)


### PR DESCRIPTION
Previously if one forgot or misconfigured the FilterPolicy on a Reader,
it would just silently ignore existing filter blocks in the sstable.

This changes that, so that now the filter policy implementaiton must be
supplied for each filter block found in the sstable or an error will be
returned, unless the IgnoreMissingFilters option is passed (either in the
ReaderOptions, if creating a reader directly, or in the pebble Options
when opening a DB that expects to encounter existing SSTables with filters
that should be ignored.