### PR TITLE
db: add format major version for range keys

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -219,9 +219,6 @@ type Batch struct {
 
 	// The count of range key sets, unsets and deletes in the batch. Updated
 	// every time a RANGEKEYSET, RANGEKEYUNSET or RANGEKEYDEL key is added.
-	// TODO(jackson): This likely won't be necessary long-term, but it's useful
-	// for the in-memory only implementation in which these keys require special
-	// handling.
 	countRangeKeys uint64
 
 	// A deferredOp struct, stored in the Batch so that a pointer can be returned

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -70,11 +70,13 @@ const (
 	// FormatBlockPropertyCollector is a format major version that introduces
 	// BlockPropertyCollectors.
 	FormatBlockPropertyCollector
+	// FormatRangeKeys is a format major version that introduces range keys.
+	FormatRangeKeys
 	// FormatNewest always contains the most recent format major version.
 	// NB: When adding new versions, the MaxTableFormat method should also be
 	// updated to return the maximum allowable version for the new
 	// FormatMajorVersion.
-	FormatNewest FormatMajorVersion = FormatBlockPropertyCollector
+	FormatNewest FormatMajorVersion = FormatRangeKeys
 )
 
 // MaxTableFormat returns the maximum sstable.TableFormat that can be used at
@@ -86,6 +88,8 @@ func (v FormatMajorVersion) MaxTableFormat() sstable.TableFormat {
 		return sstable.TableFormatRocksDBv2
 	case FormatBlockPropertyCollector:
 		return sstable.TableFormatPebblev1
+	case FormatRangeKeys:
+		return sstable.TableFormatPebblev2
 	default:
 		panic(fmt.Sprintf("pebble: unsupported format major version: %s", v))
 	}
@@ -166,6 +170,9 @@ var formatMajorVersionMigrations = map[FormatMajorVersion]func(*DB) error{
 	},
 	FormatBlockPropertyCollector: func(d *DB) error {
 		return d.finalizeFormatVersUpgrade(FormatBlockPropertyCollector)
+	},
+	FormatRangeKeys: func(d *DB) error {
+		return d.finalizeFormatVersUpgrade(FormatRangeKeys)
 	},
 }
 

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -36,6 +36,8 @@ func TestRatchetFormat(t *testing.T) {
 	require.Equal(t, FormatSetWithDelete, d.FormatMajorVersion())
 	require.NoError(t, d.RatchetFormatMajorVersion(FormatBlockPropertyCollector))
 	require.Equal(t, FormatBlockPropertyCollector, d.FormatMajorVersion())
+	require.NoError(t, d.RatchetFormatMajorVersion(FormatRangeKeys))
+	require.Equal(t, FormatRangeKeys, d.FormatMajorVersion())
 	require.NoError(t, d.Close())
 
 	// If we Open the database again, leaving the default format, the
@@ -189,6 +191,7 @@ func TestFormatMajorVersions_TableFormat(t *testing.T) {
 		FormatVersioned:               sstable.TableFormatRocksDBv2,
 		FormatSetWithDelete:           sstable.TableFormatRocksDBv2,
 		FormatBlockPropertyCollector:  sstable.TableFormatPebblev1,
+		FormatRangeKeys:               sstable.TableFormatPebblev2,
 	}
 
 	// Valid versions.

--- a/open_test.go
+++ b/open_test.go
@@ -101,7 +101,7 @@ func TestNewDBFilenames(t *testing.T) {
 			"LOCK",
 			"MANIFEST-000001",
 			"OPTIONS-000003",
-			"marker.format-version.000004.005",
+			"marker.format-version.000005.006",
 			"marker.manifest.000001.MANIFEST-000001",
 		},
 	}

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -2066,6 +2066,7 @@ type Reader struct {
 	mergerOK          bool
 	checksumType      ChecksumType
 	tableFilter       *tableFilterReader
+	tableFormat       TableFormat
 	Properties        Properties
 }
 
@@ -2690,6 +2691,14 @@ func (r *Reader) EstimateDiskUsage(start, end []byte) (uint64, error) {
 	return endBH.Offset + endBH.Length + blockTrailerLen - startBH.Offset, nil
 }
 
+// TableFormat returns the format version for the table.
+func (r *Reader) TableFormat() (TableFormat, error) {
+	if r.err != nil {
+		return TableFormatUnspecified, r.err
+	}
+	return r.tableFormat, nil
+}
+
 // ReadableFile describes subset of vfs.File required for reading SSTs.
 type ReadableFile interface {
 	io.ReaderAt
@@ -2735,6 +2744,7 @@ func NewReader(f ReadableFile, o ReaderOptions, extraOpts ...ReaderOption) (*Rea
 		return nil, r.Close()
 	}
 	r.checksumType = footer.checksum
+	r.tableFormat = footer.format
 	// Read the metaindex.
 	if err := r.readMetaindex(footer.metaindexBH); err != nil {
 		r.err = err

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -860,6 +860,35 @@ func TestValidateBlockChecksums(t *testing.T) {
 	}
 }
 
+func TestReader_TableFormat(t *testing.T) {
+	test := func(t *testing.T, want TableFormat) {
+		fs := vfs.NewMem()
+		f, err := fs.Create("test")
+		require.NoError(t, err)
+
+		opts := WriterOptions{TableFormat: want}
+		w := NewWriter(f, opts)
+		err = w.Close()
+		require.NoError(t, err)
+
+		f, err = fs.Open("test")
+		require.NoError(t, err)
+		r, err := NewReader(f, ReaderOptions{})
+		require.NoError(t, err)
+		defer r.Close()
+
+		got, err := r.TableFormat()
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	}
+
+	for tf := TableFormatLevelDB; tf <= TableFormatMax; tf++ {
+		t.Run(tf.String(), func(t *testing.T) {
+			test(t, tf)
+		})
+	}
+}
+
 func buildTestTable(
 	t *testing.T, numEntries uint64, blockSize, indexBlockSize int, compression Compression,
 ) *Reader {

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -31,6 +31,9 @@ sync: db
 create: db/marker.format-version.000004.005
 close: db/marker.format-version.000004.005
 sync: db
+create: db/marker.format-version.000005.006
+close: db/marker.format-version.000005.006
+sync: db
 sync: db/MANIFEST-000001
 create: db/000002.log
 sync: db
@@ -96,9 +99,9 @@ close:
 open-dir: checkpoints/checkpoint1
 link: db/OPTIONS-000003 -> checkpoints/checkpoint1/OPTIONS-000003
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.005
-sync: checkpoints/checkpoint1/marker.format-version.000001.005
-close: checkpoints/checkpoint1/marker.format-version.000001.005
+create: checkpoints/checkpoint1/marker.format-version.000001.006
+sync: checkpoints/checkpoint1/marker.format-version.000001.006
+close: checkpoints/checkpoint1/marker.format-version.000001.006
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 create: checkpoints/checkpoint1/MANIFEST-000001
@@ -153,7 +156,7 @@ CURRENT
 LOCK
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000004.005
+marker.format-version.000005.006
 marker.manifest.000001.MANIFEST-000001
 
 list checkpoints/checkpoint1
@@ -163,7 +166,7 @@ list checkpoints/checkpoint1
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.005
+marker.format-version.000001.006
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint1 readonly

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -38,6 +38,10 @@ create: db/marker.format-version.000004.005
 close: db/marker.format-version.000004.005
 sync: db
 upgraded to format version: 005
+create: db/marker.format-version.000005.006
+close: db/marker.format-version.000005.006
+sync: db
+upgraded to format version: 006
 create: db/MANIFEST-000003
 close: db/MANIFEST-000001
 sync: db/MANIFEST-000003
@@ -183,7 +187,7 @@ compact         1   2.3 K     0 B       0          (size == estimated-debt, scor
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.4 K    0.0%  (score == hit-rate)
- tcache         1   672 B    0.0%  (score == hit-rate)
+ tcache         1   680 B    0.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)
@@ -205,9 +209,9 @@ close:
 open-dir: checkpoint
 link: db/OPTIONS-000004 -> checkpoint/OPTIONS-000004
 open-dir: checkpoint
-create: checkpoint/marker.format-version.000001.005
-sync: checkpoint/marker.format-version.000001.005
-close: checkpoint/marker.format-version.000001.005
+create: checkpoint/marker.format-version.000001.006
+sync: checkpoint/marker.format-version.000001.006
+close: checkpoint/marker.format-version.000001.006
 sync: checkpoint
 close: checkpoint
 create: checkpoint/MANIFEST-000017

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -48,7 +48,7 @@ compact         0     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.5 K   42.9%  (score == hit-rate)
- tcache         1   672 B   50.0%  (score == hit-rate)
+ tcache         1   680 B   50.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)

--- a/testdata/ingest_load
+++ b/testdata/ingest_load
@@ -67,3 +67,10 @@ b.SET.0:
 a.RANGEDEL.0:b
 ----
 1: a#0,15-b#0,1
+
+# Loading tables at an unsupported table format results in an error.
+# Write a table at version 6 (Pebble,v2) into a DB at version 5 (Pebble,v1).
+load writer-version=6 db-version=5
+a.SET.1:
+----
+pebble: table with format (Pebble,v2) unsupported at DB format major version 5, (Pebble,v1)

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -34,7 +34,7 @@ compact         0     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         1   256 K
    ztbl         0     0 B
  bcache         4   698 B    0.0%  (score == hit-rate)
- tcache         1   672 B    0.0%  (score == hit-rate)
+ tcache         1   680 B    0.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         1
  filter         -       -    0.0%  (score == utility)
@@ -145,7 +145,7 @@ compact         1     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         1   256 K
    ztbl         1   771 B
  bcache         4   698 B   33.3%  (score == hit-rate)
- tcache         1   672 B   50.0%  (score == hit-rate)
+ tcache         1   680 B   50.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         1
  filter         -       -    0.0%  (score == utility)

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -498,3 +498,23 @@ prev-limit y
 x: valid (., [x-z) @5=boop)
 .
 x: valid (., [x-z) @5=boop)
+
+# Applying range keys to a DB running with a version that doesn't support them
+# results in an error. Range keys were added in version 6.
+reset format-major-version=5
+----
+
+batch
+range-key-set a   z   @5 boop
+----
+pebble: range keys require at least format major version 6 (current: 5)
+
+# Constructing iterator over range keys on a DB that doesn't support them
+# results in an error.
+
+reset format-major-version=5
+----
+
+combined-iter
+----
+pebble: range keys require at least format major version 6 (current: 5)


### PR DESCRIPTION
Introduce a new format major version for range keys, with associated
table format `Pebble,v2`. When the DB is opened at this version, it is
free to make use of range key features.

Related to #1339.