### PR TITLE
sstable: close `Writer` on `RewriteKeySuffixes` error

### DIFF
--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -46,6 +46,7 @@ func rewriteKeySuffixesInBlocks(
 	}
 
 	w := NewWriter(out, o)
+	defer w.Close()
 
 	for _, c := range w.propCollectors {
 		if _, ok := c.(SuffixReplaceableTableCollector); !ok {


### PR DESCRIPTION
This patch adds a `defer Writer.Close()` to close the writer on error,
preventing a goroutine leak.