### PR TITLE
sstable: estimate indexBlock.estimatedSize()

### DIFF
--- a/sstable/block.go
+++ b/sstable/block.go
@@ -163,8 +163,13 @@ func (w *blockWriter) finish() []byte {
 	return result
 }
 
+// emptyBlockSize holds the size of an empty block. Every block ends
+// in a uint32 trailer encoding the number of restart points within the
+// block.
+const emptyBlockSize = 4
+
 func (w *blockWriter) estimatedSize() int {
-	return len(w.buf) + 4*(len(w.restarts)+1)
+	return len(w.buf) + 4*len(w.restarts) + emptyBlockSize
 }
 
 type blockEntry struct {


### PR DESCRIPTION
When parallelism is enabled, index blocks are only updated from the writeQueue goroutine.
However, the index block size needs to be accessed from the Writer client goroutine. The
index block size is accessed to determine the EstimatedSize of the sstable, and to also
determine if the index block needs to be flushed. We need to determine whether to flush index
blocks in the Writer client goroutine, to support block property collectors.