### PR TITLE
db: add experimental DB.RegisterFlushCompletedCallback

### DIFF
--- a/db.go
+++ b/db.go
@@ -396,6 +396,8 @@ type DB struct {
 			// readCompactions is a readCompactionQueue which keeps track of the
 			// compactions which we might have to perform.
 			readCompactions readCompactionQueue
+			// See DB.RegisterFlushCompletedCallback.
+			flushCompletedCallback func()
 		}
 
 		cleaner struct {

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1439,6 +1439,10 @@ func TestIteratorGuaranteedDurable(t *testing.T) {
 		failFunc(t, d.NewIndexedBatch())
 	})
 	t.Run("db", func(t *testing.T) {
+		cbCount := int32(0)
+		d.RegisterFlushCompletedCallback(func() {
+			atomic.AddInt32(&cbCount, 1)
+		})
 		d.Set([]byte("k"), []byte("v"), nil)
 		foundKV := func(o *IterOptions) bool {
 			iter := d.NewIter(o)
@@ -1448,7 +1452,24 @@ func TestIteratorGuaranteedDurable(t *testing.T) {
 		}
 		require.True(t, foundKV(nil))
 		require.False(t, foundKV(&iterOptions))
+		require.Equal(t, int32(0), atomic.LoadInt32(&cbCount))
 		require.NoError(t, d.Flush())
+		flushDone := func() bool {
+			return atomic.LoadInt32(&cbCount) >= 1
+		}
+		// Hand-rolled version of testutils.SucceedsSoon. We need this since
+		// Flush is actually async.
+		done := func(f func() bool) bool {
+			start := time.Now()
+			delay := time.Millisecond
+			done := f()
+			for ; !done && time.Since(start) < time.Second*5; delay *= 2 {
+				time.Sleep(delay)
+				done = f()
+			}
+			return done
+		}(flushDone)
+		require.True(t, done)
 		require.True(t, foundKV(nil))
 		require.True(t, foundKV(&iterOptions))
 	})


### PR DESCRIPTION
This will be used in CockroachDB's loosely coupled raft log
truncation (see
https://github.com/cockroachdb/cockroach/blob/c5d146b536aaf70f0b91aa38f88d62b967ac8411/pkg/kv/kvserver/raft_log_queue.go#L959-L967
in a WIP PR).

This is done via a registration function instead of adding
to the Options passed to Open since it simplifies integration
in CockroachDB -- kvserver.NewStore is given an already open
DB.

This interface is subject to change, hence it is marked
experimental with a warning regarding usage.