### PR TITLE
internal/cache: enable debug stack collection when tracing enabled

### DIFF
--- a/internal/cache/clockpro.go
+++ b/internal/cache/clockpro.go
@@ -671,22 +671,16 @@ func newShards(size int64, shards int) *Cache {
 		c := obj.(*Cache)
 		if v := atomic.LoadInt64(&c.refs); v != 0 {
 			c.tr.Lock()
-			fmt.Fprintf(os.Stderr, "pebble: cache (%p) has non-zero reference count: %d\n%s",
-				c, v, strings.Join(c.tr.msgs, "\n"))
+			fmt.Fprintf(os.Stderr,
+				"pebble: cache (%p) has non-zero reference count: %d\n", c, v)
+			if len(c.tr.msgs) > 0 {
+				fmt.Fprintf(os.Stderr, "%s\n", strings.Join(c.tr.msgs, "\n"))
+			}
 			c.tr.Unlock()
 			os.Exit(1)
 		}
 	})
 	return c
-}
-
-func (c *Cache) trace(msg string, refs int64) {
-	if invariants.Enabled {
-		s := fmt.Sprintf("%s: refs=%d\n%s", msg, refs, debug.Stack())
-		c.tr.Lock()
-		c.tr.msgs = append(c.tr.msgs, s)
-		c.tr.Unlock()
-	}
 }
 
 func (c *Cache) getShard(id uint64, fileNum base.FileNum, offset uint64) *shard {

--- a/internal/cache/clockpro_normal.go
+++ b/internal/cache/clockpro_normal.go
@@ -1,0 +1,10 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+//go:build !tracing
+// +build !tracing
+
+package cache
+
+func (c *Cache) trace(_ string, _ int64) {}

--- a/internal/cache/clockpro_tracing.go
+++ b/internal/cache/clockpro_tracing.go
@@ -1,0 +1,20 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+//go:build tracing
+// +build tracing
+
+package cache
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+func (c *Cache) trace(msg string, refs int64) {
+	s := fmt.Sprintf("%s: refs=%d\n%s", msg, refs, debug.Stack())
+	c.tr.Lock()
+	c.tr.msgs = append(c.tr.msgs, s)
+	c.tr.Unlock()
+}


### PR DESCRIPTION
Currently, when Pebble is built and run with the `invariants` build
flag, debug stack traces are collected in a slice of strings for every
invocation of `(*Cache).trace`.

For long running metamorphic tests, especially those that require
relatively more calls through the block cache (e.g. when the flush split
or target file size is very low), the collection of the debug stack
traces can cause the process to consume a large amount of memory. For
nightly metamorphic tests runs on a Linux machine, this can manifest as
the process being OOM-killed by the kernel at a certain point, resulting
in test failures.

Split the `(*Cache).trace(msg string)` method into two implementations,
toggled by the `tracing` and `!tracing` flags. The former preserves the
current behavior, appending the debug stack to a string slice. The
latter is a no-op method. This approach is similar to the implementation
of `refcnt`.

Closes #1499.