### PR TITLE
internal/rangekey: add DefragmentingIter

### DIFF
--- a/db.go
+++ b/db.go
@@ -1062,7 +1062,7 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 	// an interleaving iterator. The dbi.rangeKeysIter is an iterator into
 	// fragmented range keys read from the global range key arena.
 	if dbi.rangeKey != nil {
-		dbi.rangeKey.iter.Init(dbi.split, &buf.merging, dbi.rangeKey.rangeKeyIter, dbi.opts.RangeKeyMasking.Suffix)
+		dbi.rangeKey.iter.Init(dbi.cmp, dbi.split, &buf.merging, dbi.rangeKey.rangeKeyIter, dbi.opts.RangeKeyMasking.Suffix)
 		dbi.iter = &dbi.rangeKey.iter
 	}
 	return dbi

--- a/internal/rangekey/defragment.go
+++ b/internal/rangekey/defragment.go
@@ -1,0 +1,453 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package rangekey
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/internal/keyspan"
+)
+
+// bufferReuseMaxCapacity is the maximum capacity of a DefragmentingIter buffer
+// that DefragmentingIter will reuse. Buffers greater than this will be
+// discarded and reallocated as necessary.
+const bufferReuseMaxCapacity = 10 << 10 // 10 KB
+
+// DefragmentMethod configures the type of defragmentation performed by the
+// DefragmentingIter.
+type DefragmentMethod int8
+
+const (
+	// DefragmentInternal configures a DefragmentingIter to defragment spans of
+	// range keys only if they have the same internal state. Put another away,
+	// if two range key spans would synethsize into identical internal keys
+	// (RANGEKEYSET, RANGEKEYDEL, RANGEKEYUNSET), not considering their
+	// different bounds, then they're eligible for defragmenting.
+	//
+	// This defragmenting method is intended for compactions that may see
+	// internal range keys fragments that may now be joined, because the state
+	// that required their fragmentation has been dropped.
+	DefragmentInternal DefragmentMethod = iota
+	// DefragmentLogical configures a DefragmentingIter to defragment spans of
+	// range keys if their external, user-visible state is identical.
+	// specifically, this defragmenting method ignores all state besides the set
+	// suffix-value tuples. it's intended for use during user iteration, when
+	// the wrapped range key iterator is merging range keys across all levels of
+	// the lsm.
+	//
+	// Consider the fragments:
+	//     a.RANGEKEYSET.5: c [(@5=foo)]  \
+	//     a.RANGEKEYUNSET.5:c [@4]        - CoalescedSpan{@5=foo, unset(@4)}
+	//     a.RANGEKEYSET.3: c [(@4=foo)]  /
+	//     c.RANGEKEYSET.4: c [(@5=foo)]   - CoalescedSpan{@5=foo}
+	//
+	// DefragmentLogical will merge these two coalesced spans because they're
+	// abutting. It ignores unsets and deletes, whose existence during iteration
+	// varies depending on compactions.
+	DefragmentLogical
+)
+
+// iterPos is an enum indicating the position of the defragmenting iter's
+// wrapped iter. The defragmenting iter must look ahead or behind when
+// defragmenting forward or backwards respectively, and this enum records that
+// current position.
+type iterPos int8
+
+const (
+	iterPosPrev iterPos = -1
+	iterPosCurr iterPos = 0
+	iterPosNext iterPos = +1
+)
+
+// DefragmentingIter wraps a range key iterator, defragmenting physical
+// fragmentation during iteration.
+//
+// During flushes and compactions, range keys may be split at sstable
+// boundaries. This fragmentation can produce internal range key bounds that do
+// not match any of the bounds ever supplied to a user range-key operation. This
+// physical fragmentation is necessary to avoid excessively wide sstables.
+//
+// The defragmenting iterator undoes this physical fragmentation, joining spans
+// with abutting bounds and equal state. The defragmenting iterator supports two
+// separate methods of determining what is "equal state" for a span. The user
+// may configure which of the methods of defragmentation they desire at Init
+// through passing a DefragmentMethod enum value:
+//
+// DefragmentLogical is intended for use during user iteration, joining adjacent
+// CoalescedSpans if the user-observable logical state is identical.
+// Specifically, DefragmentLogical defragments abutting spans if the set of
+// range key suffix-value tuples are identical. This may be used to hide
+// physical fragmentation from the end user during iteration, ensuring the only
+// fragmentation observable is the fragmentation introduced by the user's own
+// operations.
+//
+// DefragmentInternal is intended for use during compactions, joining adjacent
+// CoalescedSpans if the internal state is identical between two spans. Range
+// keys covering a span [a, c) may be split into two sstables, as two spans
+// [a,b) and [b,c). These range keys' sstables may eventually both be inputs to
+// the same compaction, and a DefragmentingIter configured with
+// DefragmentInternal may join the two spans back together before outputting to
+// a single sstable.
+//
+// Seeking (SeekGE, SeekLT) poses an obstacle to defragmentation. A seek may
+// land on a physical fragment in the middle of several fragments that must be
+// defragmented. A seek first degfragments in the opposite direction of
+// iteration to find the beginning of the defragmented span, and then
+// defragments in the iteration direction, ensuring it's found a whole
+// defragmented span.
+type DefragmentingIter struct {
+	cmp      base.Compare
+	split    base.Split
+	iter     Iter
+	iterSpan *CoalescedSpan
+	iterPos  iterPos
+	method   DefragmentMethod
+
+	// curr holds the range key span at the current iterator position. currBuf
+	// is a buffer that may be used when copying keys for curr. currBuf is
+	// cleared between positioning methods.
+	//
+	// keyBuf is a buffer specifically for the defragmented start key when
+	// defragmenting backwards or the defragmented end key when defragmenting
+	// forwards. These bounds are overwritten repeatedly during defragmentation,
+	// and the defragmentation routines overwrite keyBuf repeatedly to store
+	// these extended bounds.
+	curr    CoalescedSpan
+	currBuf []byte
+	keyBuf  []byte
+
+	// equalState is a comparison function for two coalesced range key spans.
+	// The value of equalState is dependent on the method of defragmenting being
+	// performed: internal or logical. The implementations of this function that
+	// may be used are equalRangeKeyInternal and equalRangeKeyLogical.
+	//
+	// equalState does not check for adjacency for the two spans.
+	equalState func(cmp base.Compare, a, b *CoalescedSpan) bool
+}
+
+// Assert that *DefragmentingIter implements the rangekey.Iterator interface.
+var _ Iterator = (*DefragmentingIter)(nil)
+
+// Init initializes the defragmenting iter using the provided defragmentation
+// method.
+func (i *DefragmentingIter) Init(
+	cmp base.Compare,
+	split base.Split,
+	formatKey base.FormatKey,
+	visibleSeqNum uint64,
+	defragmentMethod DefragmentMethod,
+	iter keyspan.FragmentIterator,
+) {
+	*i = DefragmentingIter{cmp: cmp, split: split, method: defragmentMethod}
+	i.iter.Init(cmp, formatKey, visibleSeqNum, iter)
+	switch i.method {
+	case DefragmentInternal:
+		i.equalState = equalRangeKeyInternal
+	case DefragmentLogical:
+		i.equalState = equalRangeKeyLogical
+	default:
+		panic(fmt.Sprintf("pebble: unrecognized defragment method: %d", defragmentMethod))
+	}
+}
+
+// Valid returns true if the iterator is currently positioned over a span.
+func (i *DefragmentingIter) Valid() bool {
+	return i.iter.Valid()
+}
+
+// Clone clones the iterator, returning an independent iterator over the same
+// state. This method is temporary and may be deleted once range keys' state is
+// properly reflected in readState.
+func (i *DefragmentingIter) Clone() Iterator {
+	// TODO(jackson): Delete Clone() when range-key state is incorporated into
+	// readState.
+	c := &DefragmentingIter{}
+	c.Init(i.cmp, i.split, i.iter.coalescer.formatKey, i.iter.coalescer.visibleSeqNum, i.method, i.iter.iter.Clone())
+	return c
+}
+
+// Error returns any accumulated error.
+func (i *DefragmentingIter) Error() error {
+	return i.iter.Error()
+}
+
+// Current returns the span at the iterator's current position.
+func (i *DefragmentingIter) Current() *CoalescedSpan {
+	return &i.curr
+}
+
+// SeekGE seeks the iterator to the first span covering a key greater than or
+// equal to key and returns it.
+func (i *DefragmentingIter) SeekGE(key []byte) *CoalescedSpan {
+	i.iterSpan = i.iter.SeekGE(key)
+	// Defragment backward to find the beginning of the defragmented span.
+	i.defragmentBackward()
+	// Next once back onto the span.
+	i.iterSpan = i.iter.Next()
+	// Defragment the full span from its beginning.
+	return i.defragmentForward()
+}
+
+// SeekLT seeks the iterator to the first span covering a key less than key and
+// returns it.
+func (i *DefragmentingIter) SeekLT(key []byte) *CoalescedSpan {
+	i.iterSpan = i.iter.SeekLT(key)
+	// Defragment forward to find the end of the defragmented span.
+	i.defragmentForward()
+	// Prev once back onto the span.
+	i.iterSpan = i.iter.Prev()
+	// Defragment the full span from its end.
+	return i.defragmentBackward()
+}
+
+// First seeks the iterator to the first span and returns it.
+func (i *DefragmentingIter) First() *CoalescedSpan {
+	i.iterSpan = i.iter.First()
+	return i.defragmentForward()
+}
+
+// Last seeks the iterator to the last span and returns it.
+func (i *DefragmentingIter) Last() *CoalescedSpan {
+	i.iterSpan = i.iter.Last()
+	return i.defragmentBackward()
+}
+
+// Next advances to the next span and returns it.
+func (i *DefragmentingIter) Next() *CoalescedSpan {
+	switch i.iterPos {
+	case iterPosPrev:
+		// Switching diections; The iterator is currently positioned over the
+		// last fragment of the previous set of fragments. In the below diagram,
+		// the iterator is positioned over the last span that contributes to
+		// the defragmented x position. We want to be positioned over the first
+		// span that contributes to the z position.
+		//
+		//   x x x y y y z z z
+		//       ^       ^
+		//      old     new
+		//
+		// Next once to move onto y, defragment forward to land on the first z
+		// position.
+		i.iterSpan = i.iter.Next()
+		if i.iterSpan == nil {
+			panic("pebble: invariant violation: no next span while switching directions")
+		}
+		// We're now positioned on the first span that was defragmented into the
+		// current iterator position. Skip over the rest of the current iterator
+		// position's constitutent fragments. In the above example, this would
+		// land on the first 'z'.
+		i.defragmentForward()
+
+		// Now that we're positioned over the first of the next set of
+		// fragments, defragment forward.
+		return i.defragmentForward()
+	case iterPosCurr:
+		// iterPosCurr is only used when the iter is exhausted.
+		if invariants.Enabled && i.iterSpan != nil {
+			panic("pebble: invariant violation: iterPosCurr with iterSpan set")
+		}
+
+		i.iterSpan = i.iter.Next()
+		return i.defragmentForward()
+	case iterPosNext:
+		// Already at the next span.
+		return i.defragmentForward()
+	default:
+		panic("unreachable")
+	}
+}
+
+// Prev steps back to the previous span and returns it.
+func (i *DefragmentingIter) Prev() *CoalescedSpan {
+	switch i.iterPos {
+	case iterPosPrev:
+		// Already at the previous span.
+		return i.defragmentBackward()
+	case iterPosCurr:
+		// iterPosCurr is only used when the iter is exhausted.
+		if invariants.Enabled && i.iterSpan != nil {
+			panic("pebble: invariant violation: iterPosCurr with iterSpan set")
+		}
+
+		i.iterSpan = i.iter.Prev()
+		return i.defragmentBackward()
+	case iterPosNext:
+		// Switching diections; The iterator is currently positioned over the
+		// first fragment of the next set of fragments. In the below diagram,
+		// the iterator is positioned over the first span that contributes to
+		// the defragmented z position. We want to be positioned over the last
+		// span that contributes to the x position.
+		//
+		//   x x x y y y z z z
+		//       ^       ^
+		//      new     old
+		//
+		// Prev once to move onto y, defragment backward to land on the last x
+		// position.
+		i.iterSpan = i.iter.Prev()
+		if i.iterSpan == nil {
+			panic("pebble: invariant violation: no previous span while switching directions")
+		}
+		// We're now positioned on the last span that was defragmented into the
+		// current iterator position. Skip over the rest of the current iterator
+		// position's constitutent fragments. In the above example, this would
+		// land on the last 'x'.
+		i.defragmentBackward()
+
+		// Now that we're positioned over the last of the prev set of
+		// fragments, defragment backward.
+		return i.defragmentBackward()
+	default:
+		panic("unreachable")
+	}
+}
+
+// defragmentForward defragments spans in the forward direction, starting from
+// i.iter's current position.
+func (i *DefragmentingIter) defragmentForward() *CoalescedSpan {
+	if i.iterSpan == nil {
+		i.iterPos = iterPosCurr
+		return nil
+	}
+	i.saveCurrent(i.iterSpan)
+
+	i.iterPos = iterPosNext
+	i.iterSpan = i.iter.Next()
+	for i.iterSpan != nil {
+		if !i.equalState(i.cmp, i.iterSpan, &i.curr) {
+			// Not a continuation.
+			break
+		}
+		if i.cmp(i.curr.End, i.iterSpan.Start) != 0 {
+			// Not a continuation.
+			break
+		}
+		i.keyBuf = append(i.keyBuf[:0], i.iterSpan.End...)
+		i.curr.End = i.keyBuf
+		i.iterSpan = i.iter.Next()
+	}
+	return &i.curr
+}
+
+// defragmentBackward defragments spans in the backward direction, starting from
+// i.iter's current position.
+func (i *DefragmentingIter) defragmentBackward() *CoalescedSpan {
+	if i.iterSpan == nil {
+		i.iterPos = iterPosCurr
+		return nil
+	}
+	i.saveCurrent(i.iterSpan)
+
+	i.iterPos = iterPosPrev
+	i.iterSpan = i.iter.Prev()
+	for i.iterSpan != nil {
+		if !i.equalState(i.cmp, i.iterSpan, &i.curr) {
+			// Not a continuation.
+			break
+		}
+		if i.cmp(i.curr.Start, i.iterSpan.End) != 0 {
+			// Not a continuation.
+			break
+		}
+		i.keyBuf = append(i.keyBuf[:0], i.iterSpan.Start...)
+		i.curr.Start = i.keyBuf
+		i.iterSpan = i.iter.Prev()
+	}
+	return &i.curr
+}
+
+func (i *DefragmentingIter) saveCurrent(cs *CoalescedSpan) {
+	i.currBuf = i.currBuf[:0]
+	i.keyBuf = i.keyBuf[:0]
+	if cap(i.currBuf) > bufferReuseMaxCapacity {
+		i.currBuf = nil
+	}
+	if cap(i.keyBuf) > bufferReuseMaxCapacity {
+		i.keyBuf = nil
+	}
+	i.curr = CoalescedSpan{
+		LargestSeqNum: cs.LargestSeqNum,
+		Start:         i.saveBytes(cs.Start),
+		End:           i.saveBytes(cs.End),
+		Delete:        cs.Delete,
+	}
+	// When defragmenting based on logical range key state (eg, disregarding
+	// internal unsets, deletes), clear any fields not used for equality
+	// comparisons. This isn't strictly necessary, but it's deceiving to return
+	// the fields set to the user for the defragmented bounds
+	// [i.curr.Start, i.curr.End) because these fields are /not/ guaranteed to
+	// be accurate for the entire bounds.
+	if i.method == DefragmentLogical {
+		i.curr.Delete = false
+		i.curr.LargestSeqNum = 0
+	}
+	for j := range cs.Items {
+		// Similar to above, skip unsets that aren't relevant during logical
+		// defragmentation.
+		if i.method == DefragmentLogical && cs.Items[j].Unset {
+			continue
+		}
+		i.curr.Items = append(i.curr.Items, SuffixItem{
+			Unset:  cs.Items[j].Unset,
+			Suffix: i.saveBytes(cs.Items[j].Suffix),
+			Value:  i.saveBytes(cs.Items[j].Value),
+		})
+	}
+}
+
+func (i *DefragmentingIter) saveBytes(b []byte) []byte {
+	if b == nil {
+		return nil
+	}
+	ret := append(i.currBuf, b...)
+	i.currBuf = ret[len(ret):]
+	return ret
+}
+
+func equalRangeKeyInternal(cmp base.Compare, a, b *CoalescedSpan) bool {
+	if a.LargestSeqNum != b.LargestSeqNum || a.Delete != b.Delete || len(a.Items) != len(b.Items) {
+		return false
+	}
+	for i := 0; i < len(a.Items); i++ {
+		if a.Items[i].Unset != b.Items[i].Unset ||
+			cmp(a.Items[i].Suffix, b.Items[i].Suffix) != 0 ||
+			!bytes.Equal(a.Items[i].Value, b.Items[i].Value) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalRangeKeyLogical(cmp base.Compare, a, b *CoalescedSpan) bool {
+	ai, bi := 0, 0
+	for ai < len(a.Items) || bi < len(b.Items) {
+		// Skip any unset suffix items.
+		switch {
+		case ai < len(a.Items) && a.Items[ai].Unset:
+			ai++
+			continue
+		case bi < len(b.Items) && b.Items[bi].Unset:
+			bi++
+			continue
+		}
+
+		// If either is exhausted and the other has a non-Unset suffix item,
+		// then they must not be equal.
+		if ai >= len(a.Items) || bi >= len(b.Items) {
+			return false
+		}
+		// Since everything is sorted, the sets must be exactly equal in suffix
+		// and value if the set of keys are equal.
+		if cmp(a.Items[ai].Suffix, b.Items[bi].Suffix) != 0 ||
+			!bytes.Equal(a.Items[ai].Value, b.Items[bi].Value) {
+			return false
+		}
+		ai, bi = ai+1, bi+1
+	}
+	return true
+}

--- a/internal/rangekey/defragment_test.go
+++ b/internal/rangekey/defragment_test.go
@@ -1,0 +1,293 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package rangekey
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/cockroachdb/pebble/internal/keyspan"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/pmezard/go-difflib/difflib"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefragmentingIter(t *testing.T) {
+	cmp := testkeys.Comparer.Compare
+	split := testkeys.Comparer.Split
+	fmtKey := testkeys.Comparer.FormatKey
+
+	var buf bytes.Buffer
+	var spans []keyspan.Span
+	datadriven.RunTest(t, "testdata/defragmenting_iter", func(td *datadriven.TestData) string {
+		buf.Reset()
+		switch td.Cmd {
+		case "define":
+			spans = spans[:0]
+			lines := strings.Split(strings.TrimSpace(td.Input), "\n")
+			for _, line := range lines {
+				startKey, value := Parse(line)
+				endKey, v, ok := DecodeEndKey(startKey.Kind(), value)
+				require.True(t, ok)
+				spans = append(spans, keyspan.Span{
+					Start: startKey,
+					End:   endKey,
+					Value: v,
+				})
+			}
+			return ""
+		case "iter":
+			var methodStr string
+			var method DefragmentMethod
+			td.ScanArgs(t, "method", &methodStr)
+			switch methodStr {
+			case "internal":
+				method = DefragmentInternal
+			case "logical":
+				method = DefragmentLogical
+			default:
+				panic(fmt.Sprintf("unrecognized defragment method %q", methodStr))
+			}
+			var iter DefragmentingIter
+			iter.Init(cmp, split, fmtKey, base.InternalKeySeqNumMax, method, keyspan.NewIter(cmp, spans))
+			for _, line := range strings.Split(td.Input, "\n") {
+				runIterOp(&buf, &iter, line)
+			}
+			return strings.TrimSpace(buf.String())
+		default:
+			return fmt.Sprintf("unrecognized command %q", td.Cmd)
+		}
+	})
+}
+
+func TestDefragmentingIter_Randomized(t *testing.T) {
+	seed := time.Now().UnixNano()
+	for i := int64(0); i < 100; i++ {
+		testDefragmentingIteRandomizedOnce(t, seed+i)
+	}
+}
+
+func TestDefragmentingIter_RandomizedFixedSeed(t *testing.T) {
+	const seed = 1644617922104685000
+	testDefragmentingIteRandomizedOnce(t, seed)
+}
+
+func testDefragmentingIteRandomizedOnce(t *testing.T, seed int64) {
+	cmp := testkeys.Comparer.Compare
+	split := testkeys.Comparer.Split
+	formatKey := testkeys.Comparer.FormatKey
+
+	rng := rand.New(rand.NewSource(seed))
+	t.Logf("seed = %d", seed)
+
+	// Use a key space of alphanumeric strings, with a random max length between
+	// 1-2. Repeat keys are more common at the lower max lengths.
+	ks := testkeys.Alpha(rng.Intn(2) + 1)
+
+	// Generate between 1-15 range keys.
+	const maxRangeKeys = 15
+	var original, fragmented []keyspan.Span
+	numRangeKeys := 1 + rng.Intn(maxRangeKeys)
+	for i := 0; i < numRangeKeys; i++ {
+		startIdx := rng.Intn(ks.Count())
+		endIdx := rng.Intn(ks.Count())
+		for startIdx == endIdx {
+			endIdx = rng.Intn(ks.Count())
+		}
+		if startIdx > endIdx {
+			startIdx, endIdx = endIdx, startIdx
+		}
+
+		var sv SuffixValue
+		// Generate suffixes 0, 1, 2, or 3 with 0 indicating none.
+		if suffix := rng.Intn(4); suffix > 0 {
+			sv.Suffix = testkeys.Suffix(suffix)
+		}
+		sv.Value = []byte(fmt.Sprintf("v%d", rng.Intn(3)))
+		encodedSuffixValue := make([]byte, EncodedSetSuffixValuesLen([]SuffixValue{sv}))
+		EncodeSetSuffixValues(encodedSuffixValue, []SuffixValue{sv})
+
+		start := testkeys.Key(ks, startIdx)
+		end := testkeys.Key(ks, endIdx)
+		original = append(original, keyspan.Span{
+			Start: base.MakeInternalKey(start, uint64(i), base.InternalKeyKindRangeKeySet),
+			End:   end,
+			Value: encodedSuffixValue,
+		})
+
+		for startIdx < endIdx {
+			width := rng.Intn(endIdx-startIdx) + 1
+			start := testkeys.Key(ks, startIdx)
+			end := testkeys.Key(ks, startIdx+width)
+			fragmented = append(fragmented, keyspan.Span{
+				Start: base.MakeInternalKey(start, uint64(i), base.InternalKeyKindRangeKeySet),
+				End:   end,
+				Value: encodedSuffixValue,
+			})
+			startIdx += width
+		}
+	}
+
+	// Both the original and the deliberately fragmented spans may contain
+	// overlaps, so we need to sort and fragment them.
+	original = fragment(cmp, formatKey, original)
+	fragmented = fragment(cmp, formatKey, fragmented)
+	var referenceIter, fragmentedIter DefragmentingIter
+	referenceIter.Init(cmp, split, formatKey, base.InternalKeySeqNumMax,
+		DefragmentLogical, keyspan.NewIter(cmp, original))
+	fragmentedIter.Init(cmp, split, formatKey, base.InternalKeySeqNumMax,
+		DefragmentLogical, keyspan.NewIter(cmp, fragmented))
+
+	// Generate 100 random operations and run them against both iterators.
+	const numIterOps = 100
+	type opKind struct {
+		weight int
+		fn     func() string
+	}
+	ops := []opKind{
+		{weight: 2, fn: func() string { return "first" }},
+		{weight: 2, fn: func() string { return "last" }},
+		{weight: 50, fn: func() string { return "next" }},
+		{weight: 50, fn: func() string { return "prev" }},
+		{weight: 5, fn: func() string {
+			k := testkeys.Key(ks, rng.Intn(ks.Count()))
+			return fmt.Sprintf("seekge(%s)", k)
+		}},
+		{weight: 5, fn: func() string {
+			k := testkeys.Key(ks, rng.Intn(ks.Count()))
+			return fmt.Sprintf("seeklt(%s)", k)
+		}},
+	}
+	var totalWeight int
+	for _, op := range ops {
+		totalWeight += op.weight
+	}
+	var referenceHistory, fragmentedHistory bytes.Buffer
+	for i := 0; i < numIterOps; i++ {
+		p := rng.Intn(totalWeight)
+		opIndex := 0
+		if i == 0 {
+			// First op is always a First().
+		} else {
+			for i, op := range ops {
+				if p < op.weight {
+					opIndex = i
+					break
+				}
+				p -= op.weight
+			}
+		}
+		op := ops[opIndex].fn()
+		runIterOp(&referenceHistory, &referenceIter, op)
+		runIterOp(&fragmentedHistory, &fragmentedIter, op)
+		if !bytes.Equal(referenceHistory.Bytes(), fragmentedHistory.Bytes()) {
+			t.Fatal(debugContext(cmp, formatKey, original, fragmented,
+				referenceHistory.String(), fragmentedHistory.String()))
+		}
+	}
+}
+
+func fragment(cmp base.Compare, formatKey base.FormatKey, spans []keyspan.Span) []keyspan.Span {
+	keyspan.Sort(cmp, spans)
+	var fragments []keyspan.Span
+	f := keyspan.Fragmenter{
+		Cmp:    cmp,
+		Format: formatKey,
+		Emit: func(emittedFrags []keyspan.Span) {
+			fragments = append(fragments, emittedFrags...)
+		},
+	}
+	for _, s := range spans {
+		f.Add(s)
+	}
+	f.Finish()
+	return fragments
+}
+
+func debugContext(cmp base.Compare, formatKey base.FormatKey, original, fragmented []keyspan.Span, refHistory, fragHistory string) string {
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, "Reference:")
+	printRangeKeys(&buf, cmp, formatKey, original)
+	fmt.Fprintln(&buf)
+	fmt.Fprintln(&buf, "Fragmented:")
+	printRangeKeys(&buf, cmp, formatKey, fragmented)
+	fmt.Fprintln(&buf)
+	fmt.Fprintln(&buf, "\nOperations diff:")
+	diff, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:       difflib.SplitLines(refHistory),
+		B:       difflib.SplitLines(fragHistory),
+		Context: 5,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Fprintln(&buf, diff)
+	return buf.String()
+}
+
+var iterDelim = map[rune]bool{',': true, ' ': true, '(': true, ')': true, '"': true}
+
+func runIterOp(w io.Writer, it *DefragmentingIter, op string) {
+	fields := strings.FieldsFunc(op, func(r rune) bool { return iterDelim[r] })
+	var s *CoalescedSpan
+	switch strings.ToLower(fields[0]) {
+	case "first":
+		s = it.First()
+	case "last":
+		s = it.Last()
+	case "seekge":
+		s = it.SeekGE([]byte(fields[1]))
+	case "seeklt":
+		s = it.SeekLT([]byte(fields[1]))
+	case "next":
+		s = it.Next()
+	case "prev":
+		s = it.Prev()
+	default:
+		panic(fmt.Sprintf("unrecognized iter op %q", fields[0]))
+	}
+	fmt.Fprintf(w, "%-10s", op)
+	if s == nil {
+		fmt.Fprintln(w, ".")
+		return
+	}
+	printRangeKey(w, s)
+}
+
+func printRangeKeys(w io.Writer, cmp base.Compare, formatKey base.FormatKey, spans []keyspan.Span) {
+	var c Coalescer
+	c.Init(cmp, formatKey, base.InternalKeySeqNumMax, func(s CoalescedSpan) {
+		printRangeKey(w, &s)
+	})
+	for _, s := range spans {
+		c.Add(s)
+	}
+	c.Finish()
+}
+
+func printRangeKey(w io.Writer, s *CoalescedSpan) {
+	fmt.Fprintf(w, "[%s, %s): ", s.Start, s.End)
+	if s.Delete {
+		fmt.Fprintf(w, " DEL")
+	}
+	for j, item := range s.Items {
+		if j > 0 || s.Delete {
+			fmt.Fprint(w, ", ")
+		}
+		if item.Unset {
+			fmt.Fprintf(w, "%q = <unset>", item.Suffix)
+		} else {
+			fmt.Fprintf(w, "%q = %q", item.Suffix, item.Value)
+		}
+	}
+	fmt.Fprintln(w)
+}

--- a/internal/rangekey/interleaving_iter.go
+++ b/internal/rangekey/interleaving_iter.go
@@ -92,9 +92,10 @@ import (
 // All range keys, including those acting as masks, are exposed during
 // iteration.
 type InterleavingIter struct {
+	cmp                    base.Compare
 	split                  base.Split
 	pointIter              base.InternalIterator
-	rangeKeyIter           *Iter
+	rangeKeyIter           Iterator
 	maskingThresholdSuffix []byte
 	maskSuffix             []byte
 
@@ -161,21 +162,19 @@ var _ base.InternalIterator = &InterleavingIter{}
 // will act as a mask, hiding all point keys with suffixes > the range key's
 // suffix within their user key bounds.
 func (i *InterleavingIter) Init(
+	cmp base.Compare,
 	split base.Split,
 	pointIter base.InternalIterator,
-	rangeKeyIter *Iter,
+	rangeKeyIter Iterator,
 	maskingThresholdSuffix []byte,
 ) {
 	*i = InterleavingIter{
+		cmp:                    cmp,
 		split:                  split,
 		pointIter:              pointIter,
 		rangeKeyIter:           rangeKeyIter,
 		maskingThresholdSuffix: maskingThresholdSuffix,
 	}
-}
-
-func (i *InterleavingIter) cmp(a, b []byte) int {
-	return i.rangeKeyIter.coalescer.items.cmp(a, b)
 }
 
 // SeekGE implements (base.InternalIterator).SeekGE.

--- a/internal/rangekey/interleaving_iter_test.go
+++ b/internal/rangekey/interleaving_iter_test.go
@@ -55,7 +55,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 		switch td.Cmd {
 		case "set-masking-threshold":
 			maskingThreshold = []byte(strings.TrimSpace(td.Input))
-			iter.Init(testkeys.Comparer.Split, &pointIter, &rangeKeyIter, maskingThreshold)
+			iter.Init(cmp, testkeys.Comparer.Split, &pointIter, &rangeKeyIter, maskingThreshold)
 			return "OK"
 		case "define-rangekeys":
 			var spans []keyspan.Span
@@ -71,7 +71,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 				})
 			}
 			rangeKeyIter.Init(cmp, testkeys.Comparer.FormatKey, base.InternalKeySeqNumMax, keyspan.NewIter(cmp, spans))
-			iter.Init(testkeys.Comparer.Split, &pointIter, &rangeKeyIter, maskingThreshold)
+			iter.Init(cmp, testkeys.Comparer.Split, &pointIter, &rangeKeyIter, maskingThreshold)
 			return "OK"
 		case "define-pointkeys":
 			var points []base.InternalKey
@@ -80,7 +80,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 				points = append(points, base.ParseInternalKey(line))
 			}
 			pointIter = pointIterator{cmp: cmp, keys: points}
-			iter.Init(testkeys.Comparer.Split, &pointIter, &rangeKeyIter, maskingThreshold)
+			iter.Init(cmp, testkeys.Comparer.Split, &pointIter, &rangeKeyIter, maskingThreshold)
 			return "OK"
 		case "iter":
 			buf.Reset()

--- a/internal/rangekey/testdata/defragmenting_iter
+++ b/internal/rangekey/testdata/defragmenting_iter
@@ -1,0 +1,128 @@
+define
+a.RANGEKEYUNSET.3 : c [@5]
+a.RANGEKEYSET.2   : c [(@5=apples)]
+a.RANGEKEYSET.1   : c [(@3=bananas)]
+c.RANGEKEYSET.4   : d [(@3=bananas)]
+d.RANGEKEYSET.4   : e [(@3=bananas)]
+d.RANGEKEYSET.4   : e [(@1=pineapple)]
+----
+
+# Iterating with logical defragmentation should combine [a,c) and [c,d)
+# fragments.
+
+iter method=logical
+first
+next
+next
+last
+prev
+prev
+----
+first     [a, d): "@3" = "bananas"
+next      [d, e): "@3" = "bananas", "@1" = "pineapple"
+next      .
+last      [d, e): "@3" = "bananas", "@1" = "pineapple"
+prev      [a, d): "@3" = "bananas"
+prev      .
+
+iter method=internal
+first
+next
+next
+next
+last
+prev
+prev
+prev
+----
+first     [a, c): "@5" = <unset>, "@3" = "bananas"
+next      [c, d): "@3" = "bananas"
+next      [d, e): "@3" = "bananas", "@1" = "pineapple"
+next      .
+last      [d, e): "@3" = "bananas", "@1" = "pineapple"
+prev      [c, d): "@3" = "bananas"
+prev      [a, c): "@5" = <unset>, "@3" = "bananas"
+prev      .
+
+# Test a scenario that SHOULD result in internal defragmentation ([a,c) and
+# [c,d) should be merged.
+
+define
+a.RANGEKEYUNSET.3 : c [@5]
+a.RANGEKEYSET.2   : c [(@5=apples)]
+a.RANGEKEYSET.1   : c [(@3=bananas)]
+c.RANGEKEYUNSET.3 : d [@5]
+c.RANGEKEYSET.2   : d [(@3=bananas)]
+d.RANGEKEYSET.3   : e [(@3=bananas)]
+----
+
+iter method=internal
+first
+next
+next
+----
+first     [a, d): "@5" = <unset>, "@3" = "bananas"
+next      [d, e): "@3" = "bananas"
+next      .
+
+# Test defragmenting in both directions at seek keys.
+
+define
+a.RANGEKEYUNSET.3 : f [@5]
+a.RANGEKEYSET.2   : f [(@5=apples)]
+a.RANGEKEYSET.1   : f [(@3=bananas)]
+f.RANGEKEYSET.3   : h [(@3=bananas)]
+h.RANGEKEYSET.3   : p [(@3=bananas)]
+p.RANGEKEYSET.3   : t [(@3=bananas)]
+----
+
+iter method=logical
+seekge b
+prev
+seekge b
+next
+seeklt d
+next
+seeklt d
+prev
+----
+seekge b  [a, t): "@3" = "bananas"
+prev      .
+seekge b  [a, t): "@3" = "bananas"
+next      .
+seeklt d  [a, t): "@3" = "bananas"
+next      .
+seeklt d  [a, t): "@3" = "bananas"
+prev      .
+
+iter method=logical
+seeklt d
+next
+prev
+----
+seeklt d  [a, t): "@3" = "bananas"
+next      .
+prev      [a, t): "@3" = "bananas"
+
+# Test next-ing and prev-ing around seek keys.
+
+define
+a.RANGEKEYUNSET.3 : f [@5]
+a.RANGEKEYSET.2   : f [(@5=apples)]
+a.RANGEKEYSET.1   : f [(@3=bananas)]
+f.RANGEKEYSET.3   : h [(@3=bananas)]
+h.RANGEKEYSET.3   : p [(@3=bananas)]
+p.RANGEKEYSET.3   : t [(@3=bananas)]
+t.RANGEKEYSET.4   : z [(@2=oranges)]
+----
+
+iter method=logical
+seekge r
+prev
+next
+next
+----
+seekge r  [a, t): "@3" = "bananas"
+prev      .
+next      [a, t): "@3" = "bananas"
+next      [t, z): "@2" = "oranges"

--- a/iterator.go
+++ b/iterator.go
@@ -195,7 +195,7 @@ type iteratorRangeKeyState struct {
 	// rangeKeyIter is temporarily an iterator into a single global in-memory
 	// range keys arena. This will need to be reworked when we have a merging
 	// range key iterator.
-	rangeKeyIter *rangekey.Iter
+	rangeKeyIter rangekey.Iterator
 	iter         rangekey.InterleavingIter
 	// rangeKeyOnly is set to true if at the current iterator position there is
 	// no point key, only a range key start boundary.

--- a/range_keys.go
+++ b/range_keys.go
@@ -91,7 +91,7 @@ func (d *DB) maybeInitializeRangeKeys() {
 
 func (d *DB) newRangeKeyIter(
 	seqNum uint64, batch *Batch, readState *readState, opts *IterOptions,
-) *rangekey.Iter {
+) rangekey.Iterator {
 	d.maybeInitializeRangeKeys()
 
 	// TODO(jackson): Preallocate iters, mergingIter, rangeKeyIter in a
@@ -125,9 +125,9 @@ func (d *DB) newRangeKeyIter(
 		iters = append(iters, keyspan.NewIter(d.cmp, frags))
 	}
 
-	iter := &rangekey.Iter{}
+	iter := &rangekey.DefragmentingIter{}
 	miter := &rangekey.MergingIter{}
 	miter.Init(d.cmp, iters...)
-	iter.Init(d.cmp, d.opts.Comparer.FormatKey, seqNum, miter)
+	iter.Init(d.cmp, d.split, d.opts.Comparer.FormatKey, seqNum, rangekey.DefragmentLogical, miter)
 	return iter
 }

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -202,34 +202,30 @@ set c c2
 wrote 9 keys
 
 # Test that reverse iteration surfaces range key start boundaries alongside
-# point keys at the same key.
+# point keys at the same key, and defragments logically equivalent ranges.
 
 combined-iter
 last
 prev
 prev
 prev
-prev
 ----
 c: (c2, [c-d) @1=boop)
-b: (b2, [apple-c) @3=beep)
-apple: (., [apple-c) @3=beep)
-ace: (., [ace-apple) @3=beep)
+b: (b2, [ace-c) @3=beep)
+ace: (., [ace-c) @3=beep)
 .
 
 # Test that forward iteration surfaces range key start boundaries alongside
-# point keys at the same key.
+# point keys at the same key, and defragments logically equivalent ranges.
 
 combined-iter
 first
 next
 next
 next
-next
 ----
-ace: (., [ace-apple) @3=beep)
-apple: (., [apple-c) @3=beep)
-b: (b2, [apple-c) @3=beep)
+ace: (., [ace-c) @3=beep)
+b: (b2, [ace-c) @3=beep)
 c: (c2, [c-d) @1=boop)
 .
 
@@ -237,7 +233,7 @@ combined-iter
 seek-prefix-ge b
 next
 ----
-b: (b2, [apple-c) @3=beep)
+b: (b2, [ace-c) @3=beep)
 .
 
 reset
@@ -391,9 +387,7 @@ scan-rangekeys
  @5=beep, @1=bop
 [bus, c)
  @5=beep, @1=bop
-[c, d)
- @1000=boop, @1=bop
-[d, e)
+[c, e)
  @1000=boop, @1=bop
 [e, z)
  @1000=boop
@@ -403,9 +397,10 @@ seek-prefix-ge ca
 next
 seek-prefix-ge ca@100
 ----
-ca: (., [c-d) @1000=boop, @1=bop)
-ca@100: (ca@100, [c-d) @1000=boop, @1=bop)
-ca@100: (ca@100, [c-d) @1000=boop, @1=bop)
+ca: (., [c-e) @1000=boop, @1=bop)
+ca@100: (ca@100, [c-e) @1000=boop, @1=bop)
+ca@100: (ca@100, [c-e) @1000=boop, @1=bop)
+
 
 # Perform the same iteration as above, but with @1000 range-key masking. The
 # previously encountered point keys should be elided.
@@ -415,9 +410,9 @@ seek-prefix-ge ca
 next
 seek-prefix-ge ca@100
 ----
-ca: (., [c-d) @1000=boop, @1=bop)
+ca: (., [c-e) @1000=boop, @1=bop)
 .
-ca@100: (., [c-d) @1000=boop, @1=bop)
+ca@100: (., [c-e) @1000=boop, @1=bop)
 
 # Test masked, non-prefixed iteration. We should see the range keys, but all the
 # points should be masked except those beginning with z which were excluded by
@@ -431,12 +426,12 @@ next
 next
 next
 ----
-ca: (., [c-d) @1000=boop, @1=bop)
-d: (., [d-e) @1000=boop, @1=bop)
+ca: (., [c-e) @1000=boop, @1=bop)
 e: (., [e-z) @1000=boop)
 z@100: (z@100, .)
 z@10: (z@10, .)
 z@1: (z@1, .)
+za@100: (za@100, .)
 
 reset
 ----


### PR DESCRIPTION
Add a DefragmentingIter that wraps a range key iterator, defragmenting
physical fragmentation of range keys during iteration.

During flushes and compactions, range keys may be split at sstable
boundaries. This fragmentation can produce internal range-key bounds that do
not match any of the bounds ever supplied to a user range-key operation. This
physical fragmentation is necessary to avoid excessively wide sstables.

The defragmenting iterator undoes this physical fragmentation, joining spans
with abutting bounds and equal state. The defragmenting iterator supports two
separate methods of determining what is "equal state" for a span. The user
may configure which of the methods of defragmentation they desire at Init
through passing a DefragmentKind enum value:

DefragmentLogical is intended for use during user iteration, joining adjacent
CoalescedSpans if the user-observable logical state is identical.
Specifically, DefragmentLogical defragments abutting spans if the set of
range key suffix-value tuples are identical. This may be used to hide
physical fragmentation from the end user during iteration, ensuring the only
fragmentation observable is the fragmentation introduced by the user's own
operations.

DefragmentInternal is intended for use during compactions, joining adjacent
CoalescedSpans if the internal state is identical between two spans. Range
keys covering a span [a, c) may be split into two sstables, as two spans
[a,b) and [b,c). These range keys' sstables may eventually both be inputs to
the same compaction, and a DefragmentingIter configured with
DefragmentInternal may join the two spans back together before outputting to
a single sstable.

Seeking (SeekGE, SeekLT) poses an obstacle to defragmentation. A seek may
land on a physical fragment in the middle of several fragments that must be
defragmented. A seek first degfragments in the opposite direction of iteration
to find the beginning of the defragmented span, and then defragments in the
iteration direction, ensuring it's found a whole defragmented span.