### PR TITLE
internal/metamorphic: use at least FormatRangeKeys

### DIFF
--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -203,10 +203,10 @@ func randomOptions(rng *rand.Rand) *testOptions {
 	opts.Cache = cache.New(1 << uint(rng.Intn(30))) // 1B - 1GB
 	opts.DisableWAL = rng.Intn(2) == 0
 	opts.FlushSplitBytes = 1 << rng.Intn(20) // 1B - 1MB
-	// The metamorphic test exercises the latest SingleDelete semantics, that
-	// require SetWithDelete so we cannot use an older FormatMajorVersion.
-	opts.FormatMajorVersion = pebble.FormatSetWithDelete
-	n := int(pebble.FormatNewest - pebble.FormatSetWithDelete)
+	// The metamorphic test exercise range keys, so so we cannot use an older
+	// FormatMajorVersion than pebble.FormatRangeKeys.
+	opts.FormatMajorVersion = pebble.FormatRangeKeys
+	n := int(pebble.FormatNewest - opts.FormatMajorVersion)
 	if n > 0 {
 		opts.FormatMajorVersion += pebble.FormatMajorVersion(rng.Intn(n))
 	}


### PR DESCRIPTION
Now that range keys are gated behind a format major version and the metamorphic
tests write range keys, we must use at least FormatRangeKeys in the metamorphic
tests.

Fix merge skew from #1497 and #1503.