### PR TITLE
sstable: add RangeKeyIter iterator

### DIFF
--- a/sstable/external.go
+++ b/sstable/external.go
@@ -1,0 +1,142 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/rangekey"
+)
+
+var errCorruptRangeKey = base.CorruptionErrorf("pebble/table: corrupt range key entry")
+
+// RangeKeyIter provides an iterator over a sstable's range keys, surfacing
+// RangeKeySet, RangeKeyUnset and RangeKeyDelete keys. Although physically
+// overlapping range keys may be coalesced into a single internal key,
+// RangeKeyIter iterates over each as separate entries.
+type RangeKeyIter struct {
+	iter      base.InternalIterator
+	iterKey   *base.InternalKey
+	iterValue []byte
+	valueRem  []byte
+	curr      RangeKeyItem
+	err       error
+}
+
+func newRangeKeyIter(iter base.InternalIterator) *RangeKeyIter {
+	return &RangeKeyIter{iter: iter}
+}
+
+// RangeKeyItem represents a single RangeKeySet, RangeKeyUnset or RangeKeyDelete
+// item. Overlapping range keys may be stored physically as a single internal
+// key. A RangeKeyItem holds the state of just one of these items.
+type RangeKeyItem struct {
+	// Kind indicates which kind of internal range key is represented. It may be
+	// one of:
+	//
+	// - InternalKeyKindRangeKeySet
+	// - InternalKeyKindRangeKeyUnset
+	// - InternalKeyKindRangeKeyDelete
+	Kind InternalKeyKind
+	// SeqNum holds the internal sequence number of the range key.
+	SeqNum uint64
+	// Start is a user key forming the inclusive start boundary of the range
+	// key. All keys within the bounds [Start, End) are considered covered by
+	// the range key.
+	Start []byte
+	// End is a user key forming the exclusive end boundary of the range
+	// key. All keys within the bounds [Start, End) are considered covered by
+	// the range key.
+	End []byte
+	// Suffix is the suffix, if any, associated with a RangeKeySet or
+	// RangeKeyUnset. Suffix is always nil for RangeKeyDelete keys, and is
+	// optionally nil for RangeKeySet or RangeKeyUnset keys.
+	Suffix []byte
+	// Value is the user-provided value associated with a RangeKeySet. Value is
+	// nil for RangeKeyUnset and RangeKeyDelete keys.
+	Value []byte
+}
+
+// Close closes the range key iterator, releasing all acquired resources.
+func (i *RangeKeyIter) Close() error {
+	return i.iter.Close()
+}
+
+// Error returns any error encountered during iteration. If any positioning
+// method returns nil, the caller must check Error to distinguish between an
+// exhausted iterator and an error.
+func (i *RangeKeyIter) Error() error {
+	return firstError(i.err, i.iter.Error())
+}
+
+// First seeks the iterator to the first range key and returns it.
+func (i *RangeKeyIter) First() *RangeKeyItem {
+	i.iterKey, i.iterValue = i.iter.First()
+	return i.newInternalKey(i.iter.First())
+}
+
+// Next advances to the next range key and returns it.
+func (i *RangeKeyIter) Next() *RangeKeyItem {
+	if len(i.valueRem) > 0 {
+		if i.err = i.decodeNextItem(); i.err != nil {
+			return nil
+		}
+		return &i.curr
+	}
+	return i.newInternalKey(i.iter.Next())
+}
+
+func (i *RangeKeyIter) newInternalKey(ik *InternalKey, v []byte) *RangeKeyItem {
+	i.curr = RangeKeyItem{}
+	i.iterKey, i.iterValue = ik, v
+	if i.iterKey == nil {
+		return nil
+	}
+	endKey, value, ok := rangekey.DecodeEndKey(i.iterKey.Kind(), v)
+	if !ok {
+		panic("pebble: unable to decode rangekey end")
+	}
+	i.curr = RangeKeyItem{
+		Kind:   i.iterKey.Kind(),
+		SeqNum: i.iterKey.SeqNum(),
+		Start:  i.iterKey.UserKey,
+		End:    endKey,
+	}
+
+	// Decode the first suffix-value tuple (RANGEKEYSET) or suffix
+	// (RANGEKEYUNSET).
+	i.valueRem = value
+	if i.err = i.decodeNextItem(); i.err != nil {
+		return nil
+	}
+	return &i.curr
+}
+
+// decodeNextItem decodes the next suffix-value tuple or suffix, depending on
+// iterKey's kind, from `i.valueRem`.
+func (i *RangeKeyIter) decodeNextItem() error {
+	switch kind := i.iterKey.Kind(); kind {
+	case InternalKeyKindRangeKeySet:
+		sv, rest, ok := rangekey.DecodeSuffixValue(i.valueRem)
+		if !ok {
+			return errCorruptRangeKey
+		}
+		i.curr.Suffix = sv.Suffix
+		i.curr.Value = sv.Value
+		i.valueRem = rest
+	case InternalKeyKindRangeKeyUnset:
+		suffix, rest, ok := rangekey.DecodeSuffix(i.valueRem)
+		if !ok {
+			return errCorruptRangeKey
+		}
+		i.curr.Suffix = suffix
+		i.valueRem = rest
+	case InternalKeyKindRangeKeyDelete:
+	default:
+		panic(fmt.Sprintf("unrecognized rangekey kind %q", kind))
+	}
+	return nil
+}

--- a/sstable/external_test.go
+++ b/sstable/external_test.go
@@ -1,0 +1,67 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRangeKeyIter(t *testing.T) {
+	var r *Reader
+	var buf bytes.Buffer
+	datadriven.RunTest(t, "testdata/range_key_iter", func(td *datadriven.TestData) string {
+		buf.Reset()
+
+		switch td.Cmd {
+		case "build":
+			var err error
+			r, err = runBuildRangeKeysCmd(td)
+			require.NoError(t, err)
+			return ""
+		case "iter":
+			iter, err := r.NewRangeKeyIter()
+			require.NoError(t, err)
+
+			lines := strings.Split(td.Input, "\n")
+			for _, line := range lines {
+				switch line {
+				case "first":
+					writeRangeKeyItem(&buf, iter.First())
+				case "next":
+					writeRangeKeyItem(&buf, iter.Next())
+				default:
+					return fmt.Sprintf("unrecognized iter command %q", line)
+				}
+			}
+			require.NoError(t, iter.Error())
+			require.NoError(t, iter.Close())
+			return buf.String()
+		default:
+			return fmt.Sprintf("unrecognized command %q", td.Cmd)
+		}
+	})
+}
+
+func writeRangeKeyItem(w io.Writer, rk *RangeKeyItem) {
+	if rk == nil {
+		fmt.Fprintln(w, ".")
+		return
+	}
+	fmt.Fprintf(w, "[%s, %s) #%d %s", rk.Start, rk.End, rk.SeqNum, rk.Kind.String())
+	switch rk.Kind {
+	case InternalKeyKindRangeKeySet:
+		fmt.Fprintf(w, " %s = %s", rk.Suffix, rk.Value)
+	case InternalKeyKindRangeKeyUnset:
+		fmt.Fprintf(w, " %s", rk.Suffix)
+	}
+	fmt.Fprintln(w)
+}

--- a/sstable/internal.go
+++ b/sstable/internal.go
@@ -21,6 +21,9 @@ const (
 	InternalKeySeqNumBatch         = base.InternalKeySeqNumBatch
 	InternalKeySeqNumMax           = base.InternalKeySeqNumMax
 	InternalKeyRangeDeleteSentinel = base.InternalKeyRangeDeleteSentinel
+	InternalKeyKindRangeKeyDelete  = base.InternalKeyKindRangeKeyDelete
+	InternalKeyKindRangeKeyUnset   = base.InternalKeyKindRangeKeyUnset
+	InternalKeyKindRangeKeySet     = base.InternalKeyKindRangeKeySet
 )
 
 // InternalKey exports the base.InternalKey type.

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -2192,6 +2192,16 @@ func (r *Reader) NewRawRangeKeyIter() (base.InternalIterator, error) {
 	return i, nil
 }
 
+// NewRangeKeyIter returns an iterator for the range keys contained within the
+// table.
+func (r *Reader) NewRangeKeyIter() (*RangeKeyIter, error) {
+	ii, err := r.NewRawRangeKeyIter()
+	if err != nil || ii == nil {
+		return nil, err
+	}
+	return newRangeKeyIter(ii), nil
+}
+
 func (r *Reader) readIndex() (cache.Handle, error) {
 	return r.readBlock(r.indexBH, nil /* transform */, nil /* readaheadState */)
 }

--- a/sstable/testdata/range_key_iter
+++ b/sstable/testdata/range_key_iter
@@ -1,0 +1,63 @@
+build
+SET a-c @1=foo
+SET c-d @2=bar
+SET e-f @3=baz
+----
+
+iter
+first
+next
+next
+next
+----
+[a, c) #0 RANGEKEYSET @1 = foo
+[c, d) #0 RANGEKEYSET @2 = bar
+[e, f) #0 RANGEKEYSET @3 = baz
+.
+
+build
+SET a-c @1=v1
+UNSET a-c @5
+SET c-d @2=v2
+SET c-d @5=v5
+DEL d-e
+SET d-e @9=v9
+SET f-i @4=v4
+SET f-i @5=v5
+UNSET f-i @6
+SET f-i @7=v7
+SET f-i @8=v8
+SET f-i @9=v9
+DEL f-i
+----
+
+iter
+first
+next
+next
+next
+next
+next
+next
+next
+next
+next
+next
+next
+next
+next
+----
+[a, c) #0 RANGEKEYSET @1 = v1
+[a, c) #0 RANGEKEYUNSET @5
+[c, d) #0 RANGEKEYSET @5 = v5
+[c, d) #0 RANGEKEYSET @2 = v2
+[d, e) #0 RANGEKEYSET @9 = v9
+[d, e) #0 RANGEKEYDEL
+[f, i) #0 RANGEKEYSET @9 = v9
+[f, i) #0 RANGEKEYSET @8 = v8
+[f, i) #0 RANGEKEYSET @7 = v7
+[f, i) #0 RANGEKEYSET @5 = v5
+[f, i) #0 RANGEKEYSET @4 = v4
+[f, i) #0 RANGEKEYUNSET @6
+[f, i) #0 RANGEKEYDEL
+.

--- a/sstable/writer_rangekey_test.go
+++ b/sstable/writer_rangekey_test.go
@@ -25,75 +25,6 @@ func TestWriter_RangeKeys(t *testing.T) {
 		}
 	}()
 
-	buildFn := func(td *datadriven.TestData) (*Reader, error) {
-		mem := vfs.NewMem()
-		f, err := mem.Create("test")
-		if err != nil {
-			return nil, err
-		}
-
-		// Use a "suffix-aware" Comparer, that will sort suffix-values in
-		// descending order of timestamp, rather than in lexical order.
-		cmp := testkeys.Comparer
-		w := NewWriter(f, WriterOptions{
-			Comparer:    cmp,
-			TableFormat: TableFormatPebblev2,
-		})
-		for _, data := range strings.Split(td.Input, "\n") {
-			// Format. One of:
-			// - SET $START-$END $SUFFIX=$VALUE
-			// - UNSET $START-$END $SUFFIX
-			// - DEL $START-$END
-			parts := strings.Split(data, " ")
-			kind, startEnd := parts[0], parts[1]
-
-			startEndSplit := bytes.Split([]byte(startEnd), []byte("-"))
-
-			var start, end, suffix, value []byte
-			start, end = startEndSplit[0], startEndSplit[1]
-
-			switch kind {
-			case "SET":
-				sv := bytes.Split([]byte(parts[2]), []byte("="))
-				suffix, value = sv[0], sv[1]
-				err = w.RangeKeySet(start, end, suffix, value)
-			case "UNSET":
-				suffix = []byte(parts[2])
-				err = w.RangeKeyUnset(start, end, suffix)
-			case "DEL":
-				err = w.RangeKeyDelete(start, end)
-			default:
-				return nil, errors.Newf("unexpected key kind: %s", kind)
-			}
-
-			if err != nil {
-				return nil, err
-			}
-
-			// Scramble the bytes in each of the input arrays. This helps with
-			// flushing out subtle bugs due to byte slice re-use.
-			for _, slice := range [][]byte{start, end, suffix, value} {
-				_, _ = rand.Read(slice)
-			}
-		}
-
-		if err = w.Close(); err != nil {
-			return nil, err
-		}
-
-		f, err = mem.Open("test")
-		if err != nil {
-			return nil, err
-		}
-
-		r, err = NewReader(f, ReaderOptions{Comparer: cmp})
-		if err != nil {
-			return nil, err
-		}
-
-		return r, nil
-	}
-
 	datadriven.RunTest(t, "testdata/writer_range_keys", func(td *datadriven.TestData) string {
 		switch td.Cmd {
 		case "build":
@@ -103,7 +34,7 @@ func TestWriter_RangeKeys(t *testing.T) {
 			}
 
 			var err error
-			r, err = buildFn(td)
+			r, err = runBuildRangeKeysCmd(td)
 			if err != nil {
 				return err.Error()
 			}
@@ -137,4 +68,67 @@ func TestWriter_RangeKeys(t *testing.T) {
 			return fmt.Sprintf("unknown command: %s", td.Cmd)
 		}
 	})
+}
+
+func runBuildRangeKeysCmd(td *datadriven.TestData) (*Reader, error) {
+	mem := vfs.NewMem()
+	f, err := mem.Create("test")
+	if err != nil {
+		return nil, err
+	}
+
+	// Use a "suffix-aware" Comparer, that will sort suffix-values in
+	// descending order of timestamp, rather than in lexical order.
+	cmp := testkeys.Comparer
+	w := NewWriter(f, WriterOptions{
+		Comparer:    cmp,
+		TableFormat: TableFormatPebblev2,
+	})
+	for _, data := range strings.Split(td.Input, "\n") {
+		// Format. One of:
+		// - SET $START-$END $SUFFIX=$VALUE
+		// - UNSET $START-$END $SUFFIX
+		// - DEL $START-$END
+		parts := strings.Split(data, " ")
+		kind, startEnd := parts[0], parts[1]
+
+		startEndSplit := bytes.Split([]byte(startEnd), []byte("-"))
+
+		var start, end, suffix, value []byte
+		start, end = startEndSplit[0], startEndSplit[1]
+
+		switch kind {
+		case "SET":
+			sv := bytes.Split([]byte(parts[2]), []byte("="))
+			suffix, value = sv[0], sv[1]
+			err = w.RangeKeySet(start, end, suffix, value)
+		case "UNSET":
+			suffix = []byte(parts[2])
+			err = w.RangeKeyUnset(start, end, suffix)
+		case "DEL":
+			err = w.RangeKeyDelete(start, end)
+		default:
+			return nil, errors.Newf("unexpected key kind: %s", kind)
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		// Scramble the bytes in each of the input arrays. This helps with
+		// flushing out subtle bugs due to byte slice re-use.
+		for _, slice := range [][]byte{start, end, suffix, value} {
+			_, _ = rand.Read(slice)
+		}
+	}
+
+	if err = w.Close(); err != nil {
+		return nil, err
+	}
+
+	f, err = mem.Open("test")
+	if err != nil {
+		return nil, err
+	}
+	return NewReader(f, ReaderOptions{Comparer: cmp})
 }


### PR DESCRIPTION
Add a range key iterator type intended to be used externally for reading the
range-keys contained within an sstable. The interface is simple, providing
forward iteration from beginning to end only. Each individual range key is
surfaced separately, even if coalesced into single physical fragments.