### PR TITLE
db: write range keys to memtables

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -453,7 +453,7 @@ func TestBatchGet(t *testing.T) {
 		memTableSize int
 	}{
 		{"build", 64 << 20},
-		{"build", 1 << 10},
+		{"build", 2 << 10},
 		{"apply", 64 << 20},
 	}
 

--- a/compaction.go
+++ b/compaction.go
@@ -1495,6 +1495,11 @@ func (d *DB) flush1() (didFlush bool, err error) {
 		d.updateReadStateLocked(d.opts.DebugCheck)
 		d.updateTableStatsLocked(ve.NewFiles)
 	}
+	if err == nil {
+		// TODO(jackson): Remove this when range keys are persisted to sstables.
+		err = d.applyFlushedRangeKeys(flushed)
+	}
+
 	d.deleteObsoleteFiles(jobID, false /* waitForOngoing */)
 
 	// Mark all the memtables we flushed as flushed. Note that we do this last so

--- a/db.go
+++ b/db.go
@@ -776,16 +776,6 @@ func (d *DB) commitApply(b *Batch, mem *memTable) error {
 		d.mu.Unlock()
 	}
 
-	// If the batch contains range keys, add them to the range key skiplist.
-	// This is temporary, while we work on implementing range keys. It allows us
-	// to provide an implementation of range keys that aren't persisted, so
-	// CockroachDB packages may build and prototype against them.
-	// TODO(jackson): When the durable implementation is complete, remove this
-	// and the range-key arena.
-	if b.countRangeKeys > 0 {
-		d.applyBatchRangeKeys(b)
-	}
-
 	if mem.writerUnref() {
 		d.mu.Lock()
 		d.maybeScheduleFlush()

--- a/error_test.go
+++ b/error_test.go
@@ -371,7 +371,7 @@ func TestDBWALRotationCrash(t *testing.T) {
 		opts := &Options{
 			FS:           fs,
 			Logger:       panicLogger{},
-			MemTableSize: 1024,
+			MemTableSize: 2048,
 		}
 		opts.private.disableTableStats = true
 		d, err := Open("", opts)

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -127,7 +127,7 @@ func standardOptions() []*testOptions {
 `,
 		8: `
 [Options]
-  mem_table_size=1000
+  mem_table_size=2000
 `,
 		9: `
 [Options]
@@ -221,7 +221,7 @@ func randomOptions(rng *rand.Rand) *testOptions {
 	opts.LBaseMaxBytes = 1 << uint(rng.Intn(30))       // 1B - 1GB
 	opts.MaxConcurrentCompactions = rng.Intn(4)        // 0-3
 	opts.MaxManifestFileSize = 1 << uint(rng.Intn(30)) // 1B  - 1GB
-	opts.MemTableSize = 1 << (10 + uint(rng.Intn(17))) // 1KB - 256MB
+	opts.MemTableSize = 2 << (10 + uint(rng.Intn(16))) // 2KB - 256MB
 	opts.MemTableStopWritesThreshold = 2 + rng.Intn(5) // 2 - 5
 	if rng.Intn(2) == 0 {
 		opts.WALDir = "wal"

--- a/internal/rangekey/rangekey.go
+++ b/internal/rangekey/rangekey.go
@@ -138,7 +138,7 @@ func DecodeEndKey(kind base.InternalKeyKind, data []byte) (endKey, value []byte,
 		return data, nil, true
 	case base.InternalKeyKindRangeKeySet, base.InternalKeyKindRangeKeyUnset:
 		v, n := binary.Uvarint(data)
-		if n <= 0 {
+		if n <= 0 || uint64(n)+v >= uint64(len(data)) {
 			return nil, nil, false
 		}
 		endKey, value = data[n:n+int(v)], data[n+int(v):]

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1361,7 +1361,7 @@ func TestIteratorRandomizedBlockIntervalFilter(t *testing.T) {
 	opts.FlushSplitBytes = 1 << rng.Intn(8)       // 1B - 256B
 	opts.L0CompactionThreshold = 1 << rng.Intn(2) // 1-2
 	opts.LBaseMaxBytes = 1 << rng.Intn(10)        // 1B - 1KB
-	opts.MemTableSize = 1 << 10                   // 1KB
+	opts.MemTableSize = 2 << 10                   // 2KB
 	var lopts LevelOptions
 	lopts.BlockSize = 1 << rng.Intn(8)      // 1B - 256B
 	lopts.IndexBlockSize = 1 << rng.Intn(8) // 1B - 256B

--- a/range_keys_test.go
+++ b/range_keys_test.go
@@ -82,6 +82,12 @@ func TestRangeKeys(t *testing.T) {
 			}
 			count := b.Count()
 			return fmt.Sprintf("wrote %d keys\n", count)
+		case "flush":
+			err := d.Flush()
+			if err != nil {
+				return err.Error()
+			}
+			return ""
 		case "indexed-batch":
 			b = d.NewIndexedBatch()
 			require.NoError(t, runBatchDefineCmd(td, b))

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -185,6 +185,19 @@ next
 c: (c, .)
 d: (d, [d-dog) @3=beep)
 
+# Reading through the database after flushing, we should still see the
+# beginning of the cat-dog range key now beginning at 'd'.
+
+flush
+----
+
+combined-iter
+seek-ge b
+next
+----
+c: (c, .)
+d: (d, [d-dog) @3=beep)
+
 reset
 ----
 


### PR DESCRIPTION
This change moves where we copy range keys into the global in-memory arena.
Previously, we copied them in at batch application. Now, range keys are first
copied into a memtable's arena. Then, when the memtable is flushed, they're
copied again into the global in-memory arena.

This change increases the minimum memtable size beyond 1KB, as a consequence of
the additional skiplist's minimum size.