### PR TITLE
internal/rangekey: fix invariant violation during SeekGE(upper-bound)

### DIFF
--- a/internal/rangekey/testdata/interleaving_iter
+++ b/internal/rangekey/testdata/interleaving_iter
@@ -774,3 +774,28 @@ PointKey: k#1,1
 RangeKey: [j, l)
 └── @1 : v0
 -
+
+# Test a seek that moves the lower bound beyond the upper bound.
+
+define-rangekeys
+a.RANGEKEYSET.10  : d [(@5=apples)]
+----
+OK
+
+define-pointkeys
+b.SET.8
+----
+OK
+
+
+iter
+set-bounds a c
+seek-ge c
+----
+.
+
+iter
+set-bounds a c
+seek-lt a
+----
+.


### PR DESCRIPTION
Previously, if an iterator had an upper bound set and a user seeked to the
upper bound using SeekGE, the interleaving iterator would panic with an
invariant violation.

If SeekGE(k) discovers a range key overlapping the search key k, the
interleaving iterator returns a synthetic range-key marker truncated to k.
However, the upper-bound check during `nextRangeKey` is performed against the
truncated range-key start bound, which passes if the original range key's start
is less than the upper bound. This resulted in the interleaving iterator
returning a synthetic range-key marker at the same user key as the upper bound,
a violation of the upper-bound invariant.

Discovered via the metamorphic tests.