### PR TITLE
db: respect IterOptions bounds during range-key iteration

### DIFF
--- a/db.go
+++ b/db.go
@@ -1064,6 +1064,7 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 	if dbi.rangeKey != nil {
 		dbi.rangeKey.iter.Init(dbi.cmp, dbi.split, &buf.merging, dbi.rangeKey.rangeKeyIter, dbi.opts.RangeKeyMasking.Suffix)
 		dbi.iter = &dbi.rangeKey.iter
+		dbi.iter.SetBounds(dbi.opts.LowerBound, dbi.opts.UpperBound)
 	}
 	return dbi
 }

--- a/range_keys_test.go
+++ b/range_keys_test.go
@@ -98,10 +98,14 @@ func TestRangeKeys(t *testing.T) {
 		case "combined-iter":
 			o := &IterOptions{KeyTypes: IterKeyTypePointsAndRanges}
 			for _, arg := range td.CmdArgs {
-				if arg.Key != "mask-suffix" {
-					continue
+				switch arg.Key {
+				case "mask-suffix":
+					o.RangeKeyMasking.Suffix = []byte(arg.Vals[0])
+				case "lower":
+					o.LowerBound = []byte(arg.Vals[0])
+				case "upper":
+					o.UpperBound = []byte(arg.Vals[0])
 				}
-				o.RangeKeyMasking.Suffix = []byte(arg.Vals[0])
 			}
 			var iter *Iterator
 			var err error

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -513,3 +513,48 @@ reset format-major-version=5
 combined-iter
 ----
 pebble: range keys require at least format major version 6 (current: 5)
+
+# Test iterator bounds provided via IterOptions.
+
+reset
+----
+
+batch
+set a a
+set b b
+set c c
+set d d
+set f f
+range-key-set a   ap  @6 foo
+range-key-set ap  c   @5 bar
+range-key-set cat zoo @3 bax
+----
+wrote 8 keys
+
+# Ensure bounds provided at initialization are respected, and propagated to
+# cloned iterators.
+
+combined-iter lower=b upper=e
+first
+next
+next
+next
+next
+clone
+first
+next
+next
+next
+next
+----
+b: (b, [b-c) @5=bar)
+c: (c, .)
+cat: (., [cat-e) @3=bax)
+d: (d, [cat-e) @3=bax)
+.
+.
+b: (b, [b-c) @5=bar)
+c: (c, .)
+cat: (., [cat-e) @3=bax)
+d: (d, [cat-e) @3=bax)
+.


### PR DESCRIPTION
Previously, iterators configured to iterate over range keys would only truncate
range-keys to bounds that had been set after iterator creation through
SetBounds.

Fix #1519.