### PR TITLE
sstable,db: two small bounds related changes

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -184,7 +184,7 @@ func ingestLoad1(
 				if !ok {
 					return nil, errors.Newf("pebble: could not decode range end key")
 				}
-				meta.LargestRangeKey = base.MakeRangeKeySentinelKey(end).Clone()
+				meta.LargestRangeKey = base.MakeRangeKeySentinelKey(key.Kind(), end).Clone()
 				hasRanges = true // Implies smallest range key was also set.
 			}
 			if err := iter.Error(); err != nil {

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1243,8 +1243,8 @@ func TestIngest_UpdateSequenceNumber(t *testing.T) {
 
 			// Construct the file metadata from the writer metadata.
 			m := &fileMetadata{
-				SmallestPointKey: wm.SmallestPoint,
-				LargestPointKey:  maybeUpdateUpperBound(wm.LargestPoint),
+				SmallestPointKey: wm.SmallestPointKey(cmp),
+				LargestPointKey:  maybeUpdateUpperBound(wm.LargestPointKey(cmp)),
 				SmallestRangeKey: wm.SmallestRangeKey,
 				LargestRangeKey:  maybeUpdateUpperBound(wm.LargestRangeKey),
 				Smallest:         wm.Smallest(cmp),

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1236,7 +1236,7 @@ func TestIngest_UpdateSequenceNumber(t *testing.T) {
 				case k == base.InternalKeyKindRangeDelete:
 					key.Trailer = base.InternalKeyRangeDeleteSentinel
 				case rangekey.IsRangeKey(k):
-					key.Trailer = base.InternalKeyBoundaryRangeKey
+					return base.MakeRangeKeySentinelKey(k, key.UserKey)
 				}
 				return key
 			}

--- a/internal/base/internal_test.go
+++ b/internal/base/internal_test.go
@@ -4,7 +4,11 @@
 
 package base
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func (k InternalKey) encodedString() string {
 	buf := make([]byte, k.Size())
@@ -143,6 +147,68 @@ func TestInternalKeySeparator(t *testing.T) {
 			if cmp := InternalCompare(d.Compare, expected, result); cmp != 0 {
 				t.Fatalf("expected %s, but found %s", expected, result)
 			}
+		})
+	}
+}
+
+func TestIsExclusiveSentinel(t *testing.T) {
+	userKey := []byte("foo")
+	testCases := []struct {
+		name string
+		key  InternalKey
+		want bool
+	}{
+		{
+			name: "rangedel; max seqnum",
+			key:  MakeInternalKey(userKey, InternalKeySeqNumMax, InternalKeyKindRangeKeyDelete),
+			want: true,
+		},
+		{
+			name: "rangedel; non-max seqnum",
+			key:  MakeInternalKey(userKey, 42, InternalKeyKindRangeKeyDelete),
+			want: false,
+		},
+		{
+			name: "rangekeyset; max seqnum",
+			key:  MakeInternalKey(userKey, InternalKeySeqNumMax, InternalKeyKindRangeKeySet),
+			want: true,
+		},
+		{
+			name: "rangekeyset; non-max seqnum",
+			key:  MakeInternalKey(userKey, 42, InternalKeyKindRangeKeySet),
+			want: false,
+		},
+		{
+			name: "rangekeyunset; max seqnum",
+			key:  MakeInternalKey(userKey, InternalKeySeqNumMax, InternalKeyKindRangeKeyUnset),
+			want: true,
+		},
+		{
+			name: "rangekeyunset; non-max seqnum",
+			key:  MakeInternalKey(userKey, 42, InternalKeyKindRangeKeyUnset),
+			want: false,
+		},
+		{
+			name: "rangekeydel; max seqnum",
+			key:  MakeInternalKey(userKey, InternalKeySeqNumMax, InternalKeyKindRangeKeyDelete),
+			want: true,
+		},
+		{
+			name: "rangekeydel; non-max seqnum",
+			key:  MakeInternalKey(userKey, 42, InternalKeyKindRangeKeyDelete),
+			want: false,
+		},
+		{
+			name: "neither rangedel nor rangekey",
+			key:  MakeInternalKey(userKey, InternalKeySeqNumMax, InternalKeyKindSet),
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.key.IsExclusiveSentinel()
+			require.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -1470,7 +1470,7 @@ func (w *Writer) Close() (err error) {
 			w.err = errors.Newf("invalid end key: %s", w.rangeKeyBlock.curValue)
 			return w.err
 		}
-		w.meta.LargestRangeKey = base.MakeInternalKey(endKey, base.InternalKeySeqNumMax, key.Kind()).Clone()
+		w.meta.LargestRangeKey = base.MakeRangeKeySentinelKey(kind, endKey).Clone()
 		// TODO(travers): The lack of compression on the range key block matches the
 		// lack of compression on the range-del block. Revisit whether we want to
 		// enable compression on this block.

--- a/testdata/ingest_update_seqnums
+++ b/testdata/ingest_update_seqnums
@@ -16,7 +16,7 @@ file 0
 # Point keys only (range del lower bound).
 
 load
-a.RANGEDEL.0:c
+a.RANGEDEL.0:b
 c.SET.0:
 ----
 file 1
@@ -41,11 +41,11 @@ file 0:
     ranges: #0,0-#0,0
 file 1:
   combined: a#43,15-c#43,1
-    points: c#43,1-c#43,1
+    points: a#43,15-c#43,1
     ranges: #0,0-#0,0
 file 2:
   combined: a#44,1-c#72057594037927935,15
-    points: a#44,1-a#44,1
+    points: a#44,1-c#72057594037927935,15
     ranges: #0,0-#0,0
 
 # Reset to the starting sequence number and reset the slice of files. The


### PR DESCRIPTION
The first commit alters `(base.InternalKey).IsExclusiveSentinel` to handle all range key kinds - previously only a RANGEKEYSET with a max seqnum was considered a sentinel.

The second updates the smallest and largest point keys to be set using the helper methods, rather than referencing the smallest / largest fields directly.