### PR TITLE
manifest: add methods for extending table bounds

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2233,12 +2233,15 @@ func (d *DB) runCompaction(
 			)
 		}
 
-		meta.SmallestPointKey = writerMeta.SmallestPointKey(d.cmp)
-		meta.LargestPointKey = writerMeta.LargestPointKey(d.cmp)
-		meta.SmallestRangeKey = writerMeta.SmallestRangeKey
-		meta.LargestRangeKey = writerMeta.LargestRangeKey
-		meta.Smallest = writerMeta.Smallest(d.cmp)
-		meta.Largest = writerMeta.Largest(d.cmp)
+		if writerMeta.HasPointKeys {
+			meta.ExtendPointKeyBounds(d.cmp, writerMeta.SmallestPoint, writerMeta.LargestPoint)
+		}
+		if writerMeta.HasRangeDelKeys {
+			meta.ExtendPointKeyBounds(d.cmp, writerMeta.SmallestRangeDel, writerMeta.LargestRangeDel)
+		}
+		if writerMeta.HasRangeKeys {
+			meta.ExtendRangeKeyBounds(d.cmp, writerMeta.SmallestRangeKey, writerMeta.LargestRangeKey)
+		}
 
 		// Verify that the sstable bounds fall within the compaction input
 		// bounds. This is a sanity check that we don't have a logic error

--- a/data_test.go
+++ b/data_test.go
@@ -632,10 +632,12 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 		if len(parts) != 2 {
 			return nil, errors.Errorf("malformed table spec: %s", s)
 		}
-		return &fileMetadata{
-			Smallest: InternalKey{UserKey: []byte(parts[0])},
-			Largest:  InternalKey{UserKey: []byte(parts[1])},
-		}, nil
+		m := (&fileMetadata{}).ExtendPointKeyBounds(
+			opts.Comparer.Compare,
+			InternalKey{UserKey: []byte(parts[0])},
+			InternalKey{UserKey: []byte(parts[1])},
+		)
+		return m, nil
 	}
 
 	// Example, compact: a-c.

--- a/db.go
+++ b/db.go
@@ -1221,7 +1221,8 @@ func (d *DB) Compact(
 	}
 	iStart := base.MakeInternalKey(start, InternalKeySeqNumMax, InternalKeyKindMax)
 	iEnd := base.MakeInternalKey(end, 0, 0)
-	meta := []*fileMetadata{{Smallest: iStart, Largest: iEnd}}
+	m := (&fileMetadata{}).ExtendPointKeyBounds(d.cmp, iStart, iEnd)
+	meta := []*fileMetadata{m}
 
 	d.mu.Lock()
 	maxLevelWithFiles := 1

--- a/flush_external.go
+++ b/flush_external.go
@@ -30,17 +30,17 @@ func flushExternalTable(untypedDB interface{}, path string, originalMeta *fileMe
 	d.mu.Unlock()
 
 	m := &fileMetadata{
-		FileNum:          fileNum,
-		Size:             originalMeta.Size,
-		CreationTime:     time.Now().Unix(),
-		SmallestPointKey: originalMeta.SmallestPointKey,
-		LargestPointKey:  originalMeta.LargestPointKey,
-		SmallestRangeKey: originalMeta.SmallestRangeKey,
-		LargestRangeKey:  originalMeta.LargestRangeKey,
-		Smallest:         originalMeta.Smallest,
-		Largest:          originalMeta.Largest,
-		SmallestSeqNum:   originalMeta.SmallestSeqNum,
-		LargestSeqNum:    originalMeta.LargestSeqNum,
+		FileNum:        fileNum,
+		Size:           originalMeta.Size,
+		CreationTime:   time.Now().Unix(),
+		SmallestSeqNum: originalMeta.SmallestSeqNum,
+		LargestSeqNum:  originalMeta.LargestSeqNum,
+	}
+	if originalMeta.HasPointKeys {
+		m.ExtendPointKeyBounds(d.cmp, originalMeta.SmallestPointKey, originalMeta.LargestPointKey)
+	}
+	if originalMeta.HasRangeKeys {
+		m.ExtendRangeKeyBounds(d.cmp, originalMeta.SmallestRangeKey, originalMeta.LargestRangeKey)
 	}
 
 	// Hard link the sstable into the DB directory.

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -496,18 +496,11 @@ func TestGetIter(t *testing.T) {
 					t.Fatalf("desc=%q: memtable Set: %v", desc, err)
 				}
 
+				meta.ExtendPointKeyBounds(cmp, ikey, ikey)
 				if i == 0 {
-					meta.Smallest = ikey
 					meta.SmallestSeqNum = ikey.SeqNum()
-					meta.Largest = ikey
 					meta.LargestSeqNum = ikey.SeqNum()
 				} else {
-					if base.InternalCompare(cmp, ikey, meta.Smallest) < 0 {
-						meta.Smallest = ikey
-					}
-					if base.InternalCompare(cmp, ikey, meta.Largest) > 0 {
-						meta.Largest = ikey
-					}
 					if meta.SmallestSeqNum > ikey.SeqNum() {
 						meta.SmallestSeqNum = ikey.SeqNum()
 					}

--- a/internal/manifest/btree_test.go
+++ b/internal/manifest/btree_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func newItem(k InternalKey) *FileMetadata {
-	return &FileMetadata{
-		Smallest: k,
-		Largest:  k,
-	}
+	m := (&FileMetadata{}).ExtendPointKeyBounds(
+		base.DefaultComparer.Compare, k, k,
+	)
+	return m
 }
 
 func cmp(a, b *FileMetadata) int {

--- a/internal/manifest/level_metadata_test.go
+++ b/internal/manifest/level_metadata_test.go
@@ -38,11 +38,12 @@ func TestLevelIterator(t *testing.T) {
 						if len(parts) != 2 {
 							t.Fatalf("malformed table spec: %q", metaStr)
 						}
-						m := &FileMetadata{
-							FileNum:  base.FileNum(len(files) + 1),
-							Smallest: base.ParseInternalKey(strings.TrimSpace(parts[0])),
-							Largest:  base.ParseInternalKey(strings.TrimSpace(parts[1])),
-						}
+						m := &FileMetadata{FileNum: base.FileNum(len(files) + 1)}
+						m.ExtendPointKeyBounds(
+							base.DefaultComparer.Compare,
+							base.ParseInternalKey(strings.TrimSpace(parts[0])),
+							base.ParseInternalKey(strings.TrimSpace(parts[1])),
+						)
 						m.SmallestSeqNum = m.Smallest.SeqNum()
 						m.LargestSeqNum = m.Largest.SeqNum()
 						files = append(files, m)

--- a/internal/manifest/testdata/file_metadata_bounds
+++ b/internal/manifest/testdata/file_metadata_bounds
@@ -1,0 +1,85 @@
+# Points only (single update).
+
+extend-point-key-bounds
+a.SET.0 - z.DEL.42
+----
+combined: [a#0,1-z#42,0]
+  points: [a#0,1-z#42,0]
+
+# Rangedels only (single update).
+
+reset
+----
+
+extend-point-key-bounds
+a.RANGEDEL.0:z
+----
+combined: [a#0,15-z#72057594037927935,15]
+  points: [a#0,15-z#72057594037927935,15]
+
+# Range keys only (single update).
+
+reset
+----
+
+extend-range-key-bounds
+a.RANGEKEYSET.0:z
+----
+combined: [a#0,21-z#72057594037927935,21]
+  ranges: [a#0,21-z#72057594037927935,21]
+
+# Multiple updates with various key kinds.
+
+reset
+----
+
+extend-point-key-bounds
+m.SET.0 - n.SET.0
+----
+combined: [m#0,1-n#0,1]
+  points: [m#0,1-n#0,1]
+
+# Extend the lower point key bound.
+
+extend-point-key-bounds
+j.SET.0 - k.SET.0
+----
+combined: [j#0,1-n#0,1]
+  points: [j#0,1-n#0,1]
+
+# Extend the upper point key bound with a rangedel.
+
+extend-point-key-bounds
+k.RANGEDEL.0:o
+----
+combined: [j#0,1-o#72057594037927935,15]
+  points: [j#0,1-o#72057594037927935,15]
+
+# Extend the lower bounds bound with a range key.
+
+extend-range-key-bounds
+a.RANGEKEYSET.42:m
+----
+combined: [a#42,21-o#72057594037927935,15]
+  points: [j#0,1-o#72057594037927935,15]
+  ranges: [a#42,21-m#72057594037927935,21]
+
+# Extend again with a wide range key (equal keys tiebreak on seqnums descending,
+# so the overall lower bound is unchanged).
+
+extend-range-key-bounds
+a.RANGEKEYSET.0:z
+----
+combined: [a#42,21-z#72057594037927935,21]
+  points: [j#0,1-o#72057594037927935,15]
+  ranges: [a#42,21-z#72057594037927935,21]
+
+# Extend again with a wide rangedel over the same range (equal keys and sequnums
+# tiebreak on key kind descending, so the overall upper bound is updated).
+
+extend-point-key-bounds
+a.RANGEDEL.0:z
+----
+combined: [a#42,21-z#72057594037927935,15]
+  points: [a#0,15-z#72057594037927935,15]
+  ranges: [a#42,21-z#72057594037927935,21]

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -252,17 +252,29 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 					}
 				}
 			}
+			smallestPointKey := base.DecodeInternalKey(smallest)
+			largestPointKey := base.DecodeInternalKey(largest)
 			v.NewFiles = append(v.NewFiles, NewFileEntry{
 				Level: level,
 				Meta: &FileMetadata{
 					FileNum:             fileNum,
 					Size:                size,
 					CreationTime:        int64(creationTime),
-					Smallest:            base.DecodeInternalKey(smallest),
-					Largest:             base.DecodeInternalKey(largest),
+					SmallestPointKey:    smallestPointKey,
+					LargestPointKey:     largestPointKey,
+					HasPointKeys:        true,
 					SmallestSeqNum:      smallestSeqNum,
 					LargestSeqNum:       largestSeqNum,
 					markedForCompaction: markedForCompaction,
+					// TODO(travers): For now the smallest and largest keys are pinned to
+					// the smallest and largest point keys, as these are the only types of
+					// keys supported in the manifest. This will need to change when the
+					// manifest is updated to support range keys, which will most likely
+					// leverage a bitset to infer which key types (points or ranges) are
+					// used for the overall smallest and largest keys.
+					Smallest:  smallestPointKey,
+					Largest:   largestPointKey,
+					boundsSet: true,
 				},
 			})
 

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -29,6 +29,7 @@ func ikey(s string) InternalKey {
 }
 
 func TestIkeyRange(t *testing.T) {
+	cmp := base.DefaultComparer.Compare
 	testCases := []struct {
 		input, want string
 	}{
@@ -73,11 +74,10 @@ func TestIkeyRange(t *testing.T) {
 		var f []*FileMetadata
 		if tc.input != "" {
 			for i, s := range strings.Split(tc.input, " ") {
-				f = append(f, &FileMetadata{
-					FileNum:  base.FileNum(i),
-					Smallest: ikey(s[0:1]),
-					Largest:  ikey(s[2:3]),
-				})
+				m := (&FileMetadata{
+					FileNum: base.FileNum(i),
+				}).ExtendPointKeyBounds(cmp, ikey(s[0:1]), ikey(s[2:3]))
+				f = append(f, m)
 			}
 		}
 		levelMetadata := makeLevelMetadata(base.DefaultComparer.Compare, 0, f)
@@ -124,85 +124,93 @@ func TestOverlaps(t *testing.T) {
 }
 
 func TestContains(t *testing.T) {
-	m00 := &FileMetadata{
-		FileNum:  700,
-		Size:     1,
-		Smallest: base.ParseInternalKey("b.SET.7008"),
-		Largest:  base.ParseInternalKey("e.SET.7009"),
+	cmp := base.DefaultComparer.Compare
+	newFileMeta := func(fileNum base.FileNum, size uint64, smallest, largest base.InternalKey) *FileMetadata {
+		m := (&FileMetadata{
+			FileNum: fileNum,
+			Size:    size,
+		}).ExtendPointKeyBounds(cmp, smallest, largest)
+		return m
 	}
-	m01 := &FileMetadata{
-		FileNum:  701,
-		Size:     1,
-		Smallest: base.ParseInternalKey("c.SET.7018"),
-		Largest:  base.ParseInternalKey("f.SET.7019"),
-	}
-	m02 := &FileMetadata{
-		FileNum:  702,
-		Size:     1,
-		Smallest: base.ParseInternalKey("f.SET.7028"),
-		Largest:  base.ParseInternalKey("g.SET.7029"),
-	}
-	m03 := &FileMetadata{
-		FileNum:  703,
-		Size:     1,
-		Smallest: base.ParseInternalKey("x.SET.7038"),
-		Largest:  base.ParseInternalKey("y.SET.7039"),
-	}
-	m04 := &FileMetadata{
-		FileNum:  704,
-		Size:     1,
-		Smallest: base.ParseInternalKey("n.SET.7048"),
-		Largest:  base.ParseInternalKey("p.SET.7049"),
-	}
-	m05 := &FileMetadata{
-		FileNum:  705,
-		Size:     1,
-		Smallest: base.ParseInternalKey("p.SET.7058"),
-		Largest:  base.ParseInternalKey("p.SET.7059"),
-	}
-	m06 := &FileMetadata{
-		FileNum:  706,
-		Size:     1,
-		Smallest: base.ParseInternalKey("p.SET.7068"),
-		Largest:  base.ParseInternalKey("u.SET.7069"),
-	}
-	m07 := &FileMetadata{
-		FileNum:  707,
-		Size:     1,
-		Smallest: base.ParseInternalKey("r.SET.7078"),
-		Largest:  base.ParseInternalKey("s.SET.7079"),
-	}
+	m00 := newFileMeta(
+		700,
+		1,
+		base.ParseInternalKey("b.SET.7008"),
+		base.ParseInternalKey("e.SET.7009"),
+	)
+	m01 := newFileMeta(
+		701,
+		1,
+		base.ParseInternalKey("c.SET.7018"),
+		base.ParseInternalKey("f.SET.7019"),
+	)
+	m02 := newFileMeta(
+		702,
+		1,
+		base.ParseInternalKey("f.SET.7028"),
+		base.ParseInternalKey("g.SET.7029"),
+	)
+	m03 := newFileMeta(
+		703,
+		1,
+		base.ParseInternalKey("x.SET.7038"),
+		base.ParseInternalKey("y.SET.7039"),
+	)
+	m04 := newFileMeta(
+		704,
+		1,
+		base.ParseInternalKey("n.SET.7048"),
+		base.ParseInternalKey("p.SET.7049"),
+	)
+	m05 := newFileMeta(
+		705,
+		1,
+		base.ParseInternalKey("p.SET.7058"),
+		base.ParseInternalKey("p.SET.7059"),
+	)
+	m06 := newFileMeta(
+		706,
+		1,
+		base.ParseInternalKey("p.SET.7068"),
+		base.ParseInternalKey("u.SET.7069"),
+	)
+	m07 := newFileMeta(
+		707,
+		1,
+		base.ParseInternalKey("r.SET.7078"),
+		base.ParseInternalKey("s.SET.7079"),
+	)
 
-	m10 := &FileMetadata{
-		FileNum:  710,
-		Size:     1,
-		Smallest: base.ParseInternalKey("d.SET.7108"),
-		Largest:  base.ParseInternalKey("g.SET.7109"),
-	}
-	m11 := &FileMetadata{
-		FileNum:  711,
-		Size:     1,
-		Smallest: base.ParseInternalKey("g.SET.7118"),
-		Largest:  base.ParseInternalKey("j.SET.7119"),
-	}
-	m12 := &FileMetadata{
-		FileNum:  712,
-		Size:     1,
-		Smallest: base.ParseInternalKey("n.SET.7128"),
-		Largest:  base.ParseInternalKey("p.SET.7129"),
-	}
-	m13 := &FileMetadata{
-		FileNum:  713,
-		Size:     1,
-		Smallest: base.ParseInternalKey("p.SET.7148"),
-		Largest:  base.ParseInternalKey("p.SET.7149"),
-	}
-	m14 := &FileMetadata{
-		FileNum:  714,
-		Size:     1,
-		Smallest: base.ParseInternalKey("p.SET.7138"),
-		Largest:  base.ParseInternalKey("u.SET.7139"),
-	}
+	m10 := newFileMeta(
+		710,
+		1,
+		base.ParseInternalKey("d.SET.7108"),
+		base.ParseInternalKey("g.SET.7109"),
+	)
+	m11 := newFileMeta(
+		711,
+		1,
+		base.ParseInternalKey("g.SET.7118"),
+		base.ParseInternalKey("j.SET.7119"),
+	)
+	m12 := newFileMeta(
+		712,
+		1,
+		base.ParseInternalKey("n.SET.7128"),
+		base.ParseInternalKey("p.SET.7129"),
+	)
+	m13 := newFileMeta(
+		713,
+		1,
+		base.ParseInternalKey("p.SET.7148"),
+		base.ParseInternalKey("p.SET.7149"),
+	)
+	m14 := newFileMeta(
+		714,
+		1,
+		base.ParseInternalKey("p.SET.7138"),
+		base.ParseInternalKey("u.SET.7139"),
+	)
 
 	v := Version{
 		Levels: [NumLevels]LevelMetadata{
@@ -255,7 +263,6 @@ func TestContains(t *testing.T) {
 		{2, m14, false},
 	}
 
-	cmp := base.DefaultComparer.Compare
 	for _, tc := range testCases {
 		got := v.Contains(tc.level, cmp, tc.file)
 		if got != tc.want {
@@ -279,15 +286,16 @@ func TestVersionUnref(t *testing.T) {
 func TestCheckOrdering(t *testing.T) {
 	cmp := base.DefaultComparer.Compare
 	fmtKey := base.DefaultComparer.FormatKey
-	parseMeta := func(s string) FileMetadata {
+	parseMeta := func(s string) *FileMetadata {
 		parts := strings.Split(s, "-")
 		if len(parts) != 2 {
 			t.Fatalf("malformed table spec: %s", s)
 		}
-		m := FileMetadata{
-			Smallest: base.ParseInternalKey(strings.TrimSpace(parts[0])),
-			Largest:  base.ParseInternalKey(strings.TrimSpace(parts[1])),
-		}
+		m := (&FileMetadata{}).ExtendPointKeyBounds(
+			cmp,
+			base.ParseInternalKey(strings.TrimSpace(parts[0])),
+			base.ParseInternalKey(strings.TrimSpace(parts[1])),
+		)
 		m.SmallestSeqNum = m.Smallest.SeqNum()
 		m.LargestSeqNum = m.Largest.SeqNum()
 		return m
@@ -317,7 +325,7 @@ func TestCheckOrdering(t *testing.T) {
 						meta := parseMeta(data)
 						meta.FileNum = fileNum
 						fileNum++
-						*files = append(*files, &meta)
+						*files = append(*files, meta)
 					}
 				}
 
@@ -436,4 +444,57 @@ func TestCheckConsistency(t *testing.T) {
 				return fmt.Sprintf("unknown command: %s", d.Cmd)
 			}
 		})
+}
+
+func TestExtendBounds(t *testing.T) {
+	cmp := base.DefaultComparer.Compare
+	parseBounds := func(line string) (lower, upper InternalKey) {
+		parts := strings.Split(line, "-")
+		if len(parts) == 1 {
+			parts = strings.Split(parts[0], ":")
+			start, end := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+			lower = base.ParseInternalKey(start)
+			switch k := lower.Kind(); k {
+			case base.InternalKeyKindRangeDelete:
+				upper = base.MakeRangeDeleteSentinelKey([]byte(end))
+			case base.InternalKeyKindRangeKeySet, base.InternalKeyKindRangeKeyUnset, base.InternalKeyKindRangeKeyDelete:
+				upper = base.MakeRangeKeySentinelKey(k, []byte(end))
+			default:
+				panic(fmt.Sprintf("unknown kind %s with end key", k))
+			}
+		} else {
+			l, u := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+			lower, upper = base.ParseInternalKey(l), base.ParseInternalKey(u)
+		}
+		return
+	}
+	format := func(m *FileMetadata) string {
+		var b bytes.Buffer
+		fmt.Fprintf(&b, "combined: [%s-%s]\n", m.Smallest, m.Largest)
+		if m.HasPointKeys {
+			fmt.Fprintf(&b, "  points: [%s-%s]\n", m.SmallestPointKey, m.LargestPointKey)
+		}
+		if m.HasRangeKeys {
+			fmt.Fprintf(&b, "  ranges: [%s-%s]\n", m.SmallestRangeKey, m.LargestRangeKey)
+		}
+		return b.String()
+	}
+	m := &FileMetadata{}
+	datadriven.RunTest(t, "testdata/file_metadata_bounds", func(d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "reset":
+			m = &FileMetadata{}
+			return ""
+		case "extend-point-key-bounds":
+			u, l := parseBounds(d.Input)
+			m.ExtendPointKeyBounds(cmp, u, l)
+			return format(m)
+		case "extend-range-key-bounds":
+			u, l := parseBounds(d.Input)
+			m.ExtendRangeKeyBounds(cmp, u, l)
+			return format(m)
+		default:
+			return fmt.Sprintf("unknown command %s\n", d.Cmd)
+		}
+	})
 }

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -135,11 +135,10 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 				keys := strings.Fields(line)
 				smallestKey := base.ParseInternalKey(keys[0])
 				largestKey := base.ParseInternalKey(keys[1])
-				*li = append(*li, &fileMetadata{
-					FileNum:  fileNum,
-					Smallest: smallestKey,
-					Largest:  largestKey,
-				})
+				m := (&fileMetadata{
+					FileNum: fileNum,
+				}).ExtendRangeKeyBounds(cmp, smallestKey, largestKey)
+				*li = append(*li, m)
 
 				i++
 				line = lines[i]

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -302,8 +302,12 @@ func rewriteDataBlocksToWriter(
 	w.props.NumEntries = r.Properties.NumEntries
 	w.props.RawKeySize = r.Properties.RawKeySize
 	w.props.RawValueSize = r.Properties.RawValueSize
-	w.meta.SmallestPoint = blocks[0].start
-	w.meta.LargestPoint = blocks[len(blocks)-1].end
+	// NB: we set the smallest / largest fields directly here, rather than via the
+	// Set* methods, as we know we only have point keys.
+	smallest, largest := blocks[0].start, blocks[len(blocks)-1].end
+	w.meta.SmallestPoint, w.meta.Smallest = smallest, smallest
+	w.meta.LargestPoint, w.meta.Largest = largest, largest
+	w.meta.HasPointKeys = true
 	return nil
 }
 


### PR DESCRIPTION
**Note for reviewers**

This is a fairly sizable patch given the many places where the smallest / largest fields were being set directly (and hence the motivation for the patch in the first place). Fortunately most of the diff comes from updating tests.

It might be beneficial to first review the updates in the `manifest` package (`version.go` and `version_edit.go`, and  corresponding data-driven test in `file_metadata_bounds`. Then review the non-test updates to use the new methods in the following:
- `compaction.go`
- `db.go`
- `flush_external.go`
- `ingest.go`

The remainder of the changes are to test files, and are fairly mechanical changes, so probably don't need as much scrutiny.

Fortunately, Reviewable seems to group the test and non-test files 👍 

---

Currently, `FileMetadata` exposes three pairs of keys representing
bounds for a table - one each for point keys, range keys and the overall
bounds for a table. The pair for the overall bounds for the table are a
function of the point and range pairs and could technically be derived,
but instead these overall bounds are materialized on the `FileMetadata`
struct directly for performance reasons (it is faster to dereference the
struct fields than making a function call to perform one or more
comparisons).

With the addition of two pairs of bounds in #1521 for the point and
range bounds, there is a risk that a caller forgets to set a pair of
bounds, violating the invariant that the overall point and range bounds
are internally consistent with the point and range key bounds.

To mitigate this risk, introduce methods on `manifest.FileMetadata` that
can be used to "extend" the point or range key bounds for a table. These
methods will maintain the invariant that the overall bounds for the
table are computed directly from the point and range bounds.

The methods, `MaybeExtend{Point,Range}KeyBounds`, are intended for
"optimistic" use - a table's point, range and / or overall bounds may
not necessarily be extended by a call to the respective methods if the
existing bounds are smaller or larger than the provided bounds. This
confines the comparisons to these method calls, as opposed to having the
caller perform the checks to determine when bounds should be updated. As
these fields are set once and read multiple times, this is considered a
reasonable compromise.

Update all existing call sites that directly set the existing
`FileMetadata` smallest / largest bound fields to instead use the new
methods for extending bounds. The only remaining call sites that set
fields directly are limited to the `manifest` package and one call site
in `ingest.go` that needs to mutate sequence numbers. These calls sites
that store values in the fields directly are explicitly commented to
indicate why the fields are being set directly.

One alternative considered was to unexport the smallest / largest fields
and gate access behind methods. However, as mentioned above, for
performance reasons it beneficial to keep these fields exported.