### PR TITLE
db: add migration to rewrite atomic compaction units

### DIFF
--- a/flush_external.go
+++ b/flush_external.go
@@ -74,7 +74,7 @@ func flushExternalTable(untypedDB interface{}, path string, originalMeta *fileMe
 			TablesIngested: 1,
 		},
 	}
-	err := d.mu.versions.logAndApply(jobID, ve, metrics, func() []compactionInfo {
+	err := d.mu.versions.logAndApply(jobID, ve, metrics, false /* forceRotation */, func() []compactionInfo {
 		return d.getInProgressCompactionInfoLocked(nil)
 	})
 	if err != nil {

--- a/ingest.go
+++ b/ingest.go
@@ -584,7 +584,10 @@ func (d *DB) Ingest(paths []string) error {
 	if d.opts.ReadOnly {
 		return ErrReadOnly
 	}
+	return d.ingest(paths, ingestTargetLevel)
+}
 
+func (d *DB) ingest(paths []string, targetLevelFunc ingestTargetLevelFunc) error {
 	// Allocate file numbers for all of the files being ingested and mark them as
 	// pending in order to prevent them from being deleted. Note that this causes
 	// the file number ordering to be out of alignment with sequence number
@@ -681,7 +684,7 @@ func (d *DB) Ingest(paths []string) error {
 
 		// Assign the sstables to the correct level in the LSM and apply the
 		// version edit.
-		ve, err = d.ingestApply(jobID, meta)
+		ve, err = d.ingestApply(jobID, meta, targetLevelFunc)
 	}
 
 	d.commit.AllocateSeqNum(len(meta), prepare, apply)
@@ -719,7 +722,17 @@ func (d *DB) Ingest(paths []string) error {
 	return err
 }
 
-func (d *DB) ingestApply(jobID int, meta []*fileMetadata) (*versionEdit, error) {
+type ingestTargetLevelFunc func(
+	newIters tableNewIters,
+	iterOps IterOptions,
+	cmp Compare,
+	v *version,
+	baseLevel int,
+	compactions map[*compaction]struct{},
+	meta *fileMetadata,
+) (int, error)
+
+func (d *DB) ingestApply(jobID int, meta []*fileMetadata, findTargetLevel ingestTargetLevelFunc) (*versionEdit, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -744,7 +757,7 @@ func (d *DB) ingestApply(jobID int, meta []*fileMetadata) (*versionEdit, error) 
 		m := meta[i]
 		f := &ve.NewFiles[i]
 		var err error
-		f.Level, err = ingestTargetLevel(d.newIters, iterOps, d.cmp, current, baseLevel, d.mu.compact.inProgress, m)
+		f.Level, err = findTargetLevel(d.newIters, iterOps, d.cmp, current, baseLevel, d.mu.compact.inProgress, m)
 		if err != nil {
 			d.mu.versions.logUnlock()
 			return nil, err
@@ -760,7 +773,7 @@ func (d *DB) ingestApply(jobID int, meta []*fileMetadata) (*versionEdit, error) 
 		levelMetrics.BytesIngested += m.Size
 		levelMetrics.TablesIngested++
 	}
-	if err := d.mu.versions.logAndApply(jobID, ve, metrics, func() []compactionInfo {
+	if err := d.mu.versions.logAndApply(jobID, ve, metrics, false /* forceRotation */, func() []compactionInfo {
 		return d.getInProgressCompactionInfoLocked(nil)
 	}); err != nil {
 		return nil, err

--- a/internal/manifest/btree.go
+++ b/internal/manifest/btree.go
@@ -575,6 +575,26 @@ func (n *node) rebalanceOrMerge(i int) {
 	}
 }
 
+func (n *node) invalidateAnnotation(a Annotator) {
+	// Find this annotator's annotation on this node.
+	var annot *annotation
+	for i := range n.annot {
+		if n.annot[i].annotator == a {
+			annot = &n.annot[i]
+		}
+	}
+
+	if annot != nil && annot.valid {
+		annot.valid = false
+		annot.v = a.Zero(annot.v)
+	}
+	if !n.leaf {
+		for i := int16(0); i <= n.count; i++ {
+			n.children[i].invalidateAnnotation(a)
+		}
+	}
+}
+
 func (n *node) annotation(a Annotator) (interface{}, bool) {
 	// Find this annotator's annotation on this node.
 	var annot *annotation

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -57,7 +57,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 		CreationTime:        806040,
 		SmallestSeqNum:      3,
 		LargestSeqNum:       5,
-		markedForCompaction: true,
+		MarkedForCompaction: true,
 	}).ExtendPointKeyBounds(
 		cmp,
 		base.DecodeInternalKey([]byte("A\x00\x01\x02\x03\x04\x05\x06\x07")),

--- a/metrics.go
+++ b/metrics.go
@@ -133,6 +133,7 @@ type Metrics struct {
 		ElisionOnlyCount int64
 		MoveCount        int64
 		ReadCount        int64
+		RewriteCount     int64
 		// An estimate of the number of bytes that need to be compacted for the LSM
 		// to reach a stable state.
 		EstimatedDebt uint64
@@ -142,6 +143,10 @@ type Metrics struct {
 		InProgressBytes int64
 		// Number of compactions that are in-progress.
 		NumInProgress int64
+		// MarkedFiles is a count of files that are marked for
+		// compaction. Such files are compacted in a rewrite compaction
+		// when no other compactions are picked.
+		MarkedFiles int
 	}
 
 	Flush struct {
@@ -375,12 +380,13 @@ func (m *Metrics) SafeFormat(w redact.SafePrinter, _ rune) {
 		humanize.IEC.Int64(m.Compact.InProgressBytes),
 		redact.Safe(m.Compact.NumInProgress),
 		redact.SafeString(""))
-	w.Printf("  ctype %9d %7d %7d %7d %7d  (default, delete, elision, move, read)\n",
+	w.Printf("  ctype %9d %7d %7d %7d %7d %7d  (default, delete, elision, move, read, rewrite)\n",
 		redact.Safe(m.Compact.DefaultCount),
 		redact.Safe(m.Compact.DeleteOnlyCount),
 		redact.Safe(m.Compact.ElisionOnlyCount),
 		redact.Safe(m.Compact.MoveCount),
-		redact.Safe(m.Compact.ReadCount))
+		redact.Safe(m.Compact.ReadCount),
+		redact.Safe(m.Compact.RewriteCount))
 	w.Printf(" memtbl %9d %7s\n",
 		redact.Safe(m.MemTable.Count),
 		humanize.IEC.Uint64(m.MemTable.Size))

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -27,6 +27,7 @@ func TestMetricsFormat(t *testing.T) {
 	m.Compact.ElisionOnlyCount = 29
 	m.Compact.MoveCount = 30
 	m.Compact.ReadCount = 31
+	m.Compact.RewriteCount = 32
 	m.Compact.EstimatedDebt = 6
 	m.Compact.InProgressBytes = 7
 	m.Compact.NumInProgress = 2
@@ -84,7 +85,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   total      2807   2.7 K       -   2.8 K   2.8 K   2.9 K   2.8 K   2.9 K   8.4 K   5.7 K   2.8 K      28     3.0
   flush         8
 compact         5     6 B     7 B       2          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
-  ctype        27      28      29      30      31  (default, delete, elision, move, read)
+  ctype        27      28      29      30      31      32  (default, delete, elision, move, read, rewrite)
  memtbl        12    11 B
 zmemtbl        14    13 B
    ztbl        16    15 B
@@ -227,7 +228,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   total         0     0 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
   flush         0
 compact         0     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
-  ctype         0       0       0       0       0  (default, delete, elision, move, read)
+  ctype         0       0       0       0       0       0  (default, delete, elision, move, read, rewrite)
  memtbl         0     0 B
 zmemtbl         0     0 B
    ztbl         0     0 B

--- a/open.go
+++ b/open.go
@@ -237,7 +237,6 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		if err := d.mu.versions.currentVersion().CheckConsistency(dirname, opts.FS); err != nil {
 			return nil, err
 		}
-
 	}
 
 	// If the Options specify a format major version higher than the
@@ -370,7 +369,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		// crash before the manifest is synced could leave two WALs with
 		// unclean tails.
 		d.mu.versions.logLock()
-		if err := d.mu.versions.logAndApply(jobID, &ve, newFileMetrics(ve.NewFiles), func() []compactionInfo {
+		if err := d.mu.versions.logAndApply(jobID, &ve, newFileMetrics(ve.NewFiles), false /* forceRotation */, func() []compactionInfo {
 			return nil
 		}); err != nil {
 			return nil, err

--- a/open_test.go
+++ b/open_test.go
@@ -101,7 +101,7 @@ func TestNewDBFilenames(t *testing.T) {
 			"LOCK",
 			"MANIFEST-000001",
 			"OPTIONS-000003",
-			"marker.format-version.000005.006",
+			"marker.format-version.000007.008",
 			"marker.manifest.000001.MANIFEST-000001",
 		},
 	}

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -34,6 +34,12 @@ sync: db
 create: db/marker.format-version.000005.006
 close: db/marker.format-version.000005.006
 sync: db
+create: db/marker.format-version.000006.007
+close: db/marker.format-version.000006.007
+sync: db
+create: db/marker.format-version.000007.008
+close: db/marker.format-version.000007.008
+sync: db
 sync: db/MANIFEST-000001
 create: db/000002.log
 sync: db
@@ -99,9 +105,9 @@ close:
 open-dir: checkpoints/checkpoint1
 link: db/OPTIONS-000003 -> checkpoints/checkpoint1/OPTIONS-000003
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.006
-sync: checkpoints/checkpoint1/marker.format-version.000001.006
-close: checkpoints/checkpoint1/marker.format-version.000001.006
+create: checkpoints/checkpoint1/marker.format-version.000001.008
+sync: checkpoints/checkpoint1/marker.format-version.000001.008
+close: checkpoints/checkpoint1/marker.format-version.000001.008
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 create: checkpoints/checkpoint1/MANIFEST-000001
@@ -156,7 +162,7 @@ CURRENT
 LOCK
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000005.006
+marker.format-version.000007.008
 marker.manifest.000001.MANIFEST-000001
 
 list checkpoints/checkpoint1
@@ -166,7 +172,7 @@ list checkpoints/checkpoint1
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.006
+marker.format-version.000001.008
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint1 readonly

--- a/testdata/compaction_picker_L0
+++ b/testdata/compaction_picker_L0
@@ -389,3 +389,25 @@ pick-auto
 ----
 L0 -> L6
 L0: 000051,000053
+
+# At low priority, find and compact marked-for-compaction files.
+
+define
+L0
+  000049:t.SET.22-t.SET.22
+L6
+  000045:f.SET.0-x.SET.0
+----
+0.0:
+  000049:[t#22,SET-t#22,SET]
+6:
+  000045:[f#0,SET-x#0,SET]
+
+mark-for-compaction file=000049
+----
+marked L0.000049
+
+pick-auto l0_compaction_threshold=1000
+----
+L0 -> L0
+L0: 000049

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -42,6 +42,14 @@ create: db/marker.format-version.000005.006
 close: db/marker.format-version.000005.006
 sync: db
 upgraded to format version: 006
+create: db/marker.format-version.000006.007
+close: db/marker.format-version.000006.007
+sync: db
+upgraded to format version: 007
+create: db/marker.format-version.000007.008
+close: db/marker.format-version.000007.008
+sync: db
+upgraded to format version: 008
 create: db/MANIFEST-000003
 close: db/MANIFEST-000001
 sync: db/MANIFEST-000003
@@ -65,10 +73,10 @@ sync: wal/000002.log
 close: wal/000002.log
 create: wal/000005.log
 sync: wal
-[JOB 2] WAL created 000005
-[JOB 3] flushing 1 memtable to L0
+[JOB 3] WAL created 000005
+[JOB 4] flushing 1 memtable to L0
 create: db/000006.sst
-[JOB 3] flushing: sstable created 000006
+[JOB 4] flushing: sstable created 000006
 sync: db/000006.sst
 close: db/000006.sst
 sync: db
@@ -78,9 +86,9 @@ sync: db/MANIFEST-000007
 create: db/marker.manifest.000003.MANIFEST-000007
 close: db/marker.manifest.000003.MANIFEST-000007
 sync: db
-[JOB 3] MANIFEST created 000007
-[JOB 3] flushed 1 memtable to L0 [000006] (770 B), in 1.0s (2.0s total), output rate 770 B/s
-[JOB 3] MANIFEST deleted 000001
+[JOB 4] MANIFEST created 000007
+[JOB 4] flushed 1 memtable to L0 [000006] (770 B), in 1.0s (2.0s total), output rate 770 B/s
+[JOB 4] MANIFEST deleted 000001
 
 compact
 ----
@@ -89,10 +97,10 @@ sync: wal/000005.log
 close: wal/000005.log
 reuseForWrite: wal/000002.log -> wal/000008.log
 sync: wal
-[JOB 4] WAL created 000008 (recycled 000002)
-[JOB 5] flushing 1 memtable to L0
+[JOB 5] WAL created 000008 (recycled 000002)
+[JOB 6] flushing 1 memtable to L0
 create: db/000009.sst
-[JOB 5] flushing: sstable created 000009
+[JOB 6] flushing: sstable created 000009
 sync: db/000009.sst
 close: db/000009.sst
 sync: db
@@ -102,12 +110,12 @@ sync: db/MANIFEST-000010
 create: db/marker.manifest.000004.MANIFEST-000010
 close: db/marker.manifest.000004.MANIFEST-000010
 sync: db
-[JOB 5] MANIFEST created 000010
-[JOB 5] flushed 1 memtable to L0 [000009] (770 B), in 1.0s (2.0s total), output rate 770 B/s
-[JOB 5] MANIFEST deleted 000003
-[JOB 6] compacting(default) L0 [000006 000009] (1.5 K) + L6 [] (0 B)
+[JOB 6] MANIFEST created 000010
+[JOB 6] flushed 1 memtable to L0 [000009] (770 B), in 1.0s (2.0s total), output rate 770 B/s
+[JOB 6] MANIFEST deleted 000003
+[JOB 7] compacting(default) L0 [000006 000009] (1.5 K) + L6 [] (0 B)
 create: db/000011.sst
-[JOB 6] compacting: sstable created 000011
+[JOB 7] compacting: sstable created 000011
 sync: db/000011.sst
 close: db/000011.sst
 sync: db
@@ -117,11 +125,11 @@ sync: db/MANIFEST-000012
 create: db/marker.manifest.000005.MANIFEST-000012
 close: db/marker.manifest.000005.MANIFEST-000012
 sync: db
-[JOB 6] MANIFEST created 000012
-[JOB 6] compacted(default) L0 [000006 000009] (1.5 K) + L6 [] (0 B) -> L6 [000011] (770 B), in 1.0s (2.0s total), output rate 770 B/s
-[JOB 6] sstable deleted 000006
-[JOB 6] sstable deleted 000009
-[JOB 6] MANIFEST deleted 000007
+[JOB 7] MANIFEST created 000012
+[JOB 7] compacted(default) L0 [000006 000009] (1.5 K) + L6 [] (0 B) -> L6 [000011] (770 B), in 1.0s (2.0s total), output rate 770 B/s
+[JOB 7] sstable deleted 000006
+[JOB 7] sstable deleted 000009
+[JOB 7] MANIFEST deleted 000007
 
 disable-file-deletions
 ----
@@ -133,10 +141,10 @@ sync: wal/000008.log
 close: wal/000008.log
 reuseForWrite: wal/000005.log -> wal/000013.log
 sync: wal
-[JOB 7] WAL created 000013 (recycled 000005)
-[JOB 8] flushing 1 memtable to L0
+[JOB 8] WAL created 000013 (recycled 000005)
+[JOB 9] flushing 1 memtable to L0
 create: db/000014.sst
-[JOB 8] flushing: sstable created 000014
+[JOB 9] flushing: sstable created 000014
 sync: db/000014.sst
 close: db/000014.sst
 sync: db
@@ -146,17 +154,17 @@ sync: db/MANIFEST-000015
 create: db/marker.manifest.000006.MANIFEST-000015
 close: db/marker.manifest.000006.MANIFEST-000015
 sync: db
-[JOB 8] MANIFEST created 000015
-[JOB 8] flushed 1 memtable to L0 [000014] (770 B), in 1.0s (2.0s total), output rate 770 B/s
+[JOB 9] MANIFEST created 000015
+[JOB 9] flushed 1 memtable to L0 [000014] (770 B), in 1.0s (2.0s total), output rate 770 B/s
 
 enable-file-deletions
 ----
-[JOB 9] MANIFEST deleted 000010
+[JOB 10] MANIFEST deleted 000010
 
 ingest
 ----
 link: ext/0 -> db/000016.sst
-[JOB 10] ingesting: sstable created 000016
+[JOB 11] ingesting: sstable created 000016
 sync: db
 create: db/MANIFEST-000017
 close: db/MANIFEST-000015
@@ -164,9 +172,9 @@ sync: db/MANIFEST-000017
 create: db/marker.manifest.000007.MANIFEST-000017
 close: db/marker.manifest.000007.MANIFEST-000017
 sync: db
-[JOB 10] MANIFEST created 000017
-[JOB 10] MANIFEST deleted 000012
-[JOB 10] ingested L0:000016 (825 B)
+[JOB 11] MANIFEST created 000017
+[JOB 11] MANIFEST deleted 000012
+[JOB 11] ingested L0:000016 (825 B)
 
 metrics
 ----
@@ -182,7 +190,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   total         3   2.3 K       -   933 B   825 B       1     0 B       0   3.9 K       4   1.5 K       3     4.3
   flush         3
 compact         1   2.3 K     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
-  ctype         1       0       0       0       0  (default, delete, elision, move, read)
+  ctype         1       0       0       0       0       0  (default, delete, elision, move, read, rewrite)
  memtbl         1   256 K
 zmemtbl         0     0 B
    ztbl         0     0 B
@@ -209,9 +217,9 @@ close:
 open-dir: checkpoint
 link: db/OPTIONS-000004 -> checkpoint/OPTIONS-000004
 open-dir: checkpoint
-create: checkpoint/marker.format-version.000001.006
-sync: checkpoint/marker.format-version.000001.006
-close: checkpoint/marker.format-version.000001.006
+create: checkpoint/marker.format-version.000001.008
+sync: checkpoint/marker.format-version.000001.008
+close: checkpoint/marker.format-version.000001.008
 sync: checkpoint
 close: checkpoint
 create: checkpoint/MANIFEST-000017

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -43,7 +43,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   total         1   833 B       -   833 B   833 B       1     0 B       0   833 B       0     0 B       1     1.0
   flush         0
 compact         0     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
-  ctype         0       0       0       0       0  (default, delete, elision, move, read)
+  ctype         0       0       0       0       0       0  (default, delete, elision, move, read, rewrite)
  memtbl         1   256 K
 zmemtbl         0     0 B
    ztbl         0     0 B

--- a/testdata/ingest_load
+++ b/testdata/ingest_load
@@ -89,11 +89,11 @@ a.RANGEDEL.0:b
   ranges: #0,0-#0,0
 
 # Loading tables at an unsupported table format results in an error.
-# Write a table at version 6 (Pebble,v2) into a DB at version 5 (Pebble,v1).
-load writer-version=6 db-version=5
+# Write a table at version 7 (Pebble,v2) into a DB at version 6 (Pebble,v1).
+load writer-version=8 db-version=7
 a.SET.1:
 ----
-pebble: table with format (Pebble,v2) unsupported at DB format major version 5, (Pebble,v1)
+pebble: table with format (Pebble,v2) unsupported at DB format major version 7, (Pebble,v1)
 
 # Tables with range keys only.
 

--- a/testdata/marked_for_compaction
+++ b/testdata/marked_for_compaction
@@ -1,0 +1,28 @@
+define
+L0
+  c.SET.11:foo
+L1
+  c.SET.0:foo
+  d.SET.0:foo
+----
+0.0:
+  000004:[c#11,SET-c#11,SET] points:[c#11,SET-c#11,SET]
+1:
+  000005:[c#0,SET-d#0,SET] points:[c#0,SET-d#0,SET]
+
+mark-for-compaction file=000005
+----
+marked L1.000005
+
+mark-for-compaction file=000004
+----
+marked L0.000004
+
+maybe-compact
+----
+[JOB 100] compacted(rewrite) L1 [000005] (779 B) + L1 [] (0 B) -> L1 [000006] (779 B), in 1.0s (2.0s total), output rate 779 B/s
+[JOB 100] compacted(rewrite) L0 [000004] (773 B) + L0 [] (0 B) -> L0 [000007] (773 B), in 1.0s (2.0s total), output rate 773 B/s
+0.0:
+  000007:[c#11,SET-c#11,SET] points:[c#11,SET-c#11,SET]
+1:
+  000006:[c#0,SET-d#0,SET] points:[c#0,SET-d#0,SET]

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -29,7 +29,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   total         1   771 B       -    56 B     0 B       0     0 B       0   827 B       1     0 B       1    14.8
   flush         1
 compact         0     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
-  ctype         0       0       0       0       0  (default, delete, elision, move, read)
+  ctype         0       0       0       0       0       0  (default, delete, elision, move, read, rewrite)
  memtbl         1   256 K
 zmemtbl         1   256 K
    ztbl         0     0 B
@@ -77,7 +77,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   total         1   778 B       -    84 B     0 B       0     0 B       0   2.3 K       3   1.5 K       1    28.6
   flush         2
 compact         1     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
-  ctype         1       0       0       0       0  (default, delete, elision, move, read)
+  ctype         1       0       0       0       0       0  (default, delete, elision, move, read, rewrite)
  memtbl         1   256 K
 zmemtbl         2   512 K
    ztbl         2   1.5 K
@@ -110,7 +110,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   total         1   778 B       -    84 B     0 B       0     0 B       0   2.3 K       3   1.5 K       1    28.6
   flush         2
 compact         1     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
-  ctype         1       0       0       0       0  (default, delete, elision, move, read)
+  ctype         1       0       0       0       0       0  (default, delete, elision, move, read, rewrite)
  memtbl         1   256 K
 zmemtbl         1   256 K
    ztbl         2   1.5 K
@@ -140,7 +140,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   total         1   778 B       -    84 B     0 B       0     0 B       0   2.3 K       3   1.5 K       1    28.6
   flush         2
 compact         1     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
-  ctype         1       0       0       0       0  (default, delete, elision, move, read)
+  ctype         1       0       0       0       0       0  (default, delete, elision, move, read, rewrite)
  memtbl         1   256 K
 zmemtbl         1   256 K
    ztbl         1   771 B
@@ -173,7 +173,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   total         1   778 B       -    84 B     0 B       0     0 B       0   2.3 K       3   1.5 K       1    28.6
   flush         2
 compact         1     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
-  ctype         1       0       0       0       0  (default, delete, elision, move, read)
+  ctype         1       0       0       0       0       0  (default, delete, elision, move, read, rewrite)
  memtbl         1   256 K
 zmemtbl         0     0 B
    ztbl         0     0 B

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -508,24 +508,24 @@ x: valid (., [x-z) @5=boop)
 x: valid (., [x-z) @5=boop)
 
 # Applying range keys to a DB running with a version that doesn't support them
-# results in an error. Range keys were added in version 6.
-reset format-major-version=5
+# results in an error. Range keys were added in version 7.
+reset format-major-version=6
 ----
 
 batch
 range-key-set a   z   @5 boop
 ----
-pebble: range keys require at least format major version 6 (current: 5)
+pebble: range keys require at least format major version 8 (current: 6)
 
 # Constructing iterator over range keys on a DB that doesn't support them
 # results in an error.
 
-reset format-major-version=5
+reset format-major-version=6
 ----
 
 combined-iter
 ----
-pebble: range keys require at least format major version 6 (current: 5)
+pebble: range keys require at least format major version 8 (current: 6)
 
 # Test iterator bounds provided via IterOptions.
 

--- a/testdata/split_user_key_migration
+++ b/testdata/split_user_key_migration
@@ -1,0 +1,148 @@
+define
+L1
+d.SET.110:d e.SET.140:e
+----
+1:
+  000004:[d#110,SET-e#140,SET] points:[d#110,SET-e#140,SET]
+
+reopen
+----
+OK
+
+# The current public Pebble interface offers no way of constructing a multi-file
+# atomic compaction unit, so use the force-ingest command to force an ingestion
+# into L1.
+
+build ef
+set e e
+set f f
+----
+
+force-ingest paths=(ef) level=1
+----
+1:
+  000004:[d#110,SET-e#140,SET] points:[d#110,SET-e#140,SET]
+  000008:[e#1,SET-f#1,SET] points:[e#1,SET-f#1,SET]
+
+format-major-version
+----
+005
+
+marked-file-count
+----
+0 files marked for compaction
+
+ratchet-format-major-version 006
+----
+
+format-major-version
+----
+006
+
+# Upgrading to format major version 006 should've marked files for compaction.
+
+marked-file-count
+----
+2 files marked for compaction
+
+reopen
+----
+OK
+
+format-major-version
+----
+006
+
+# Ensure the files previously marked for compaction are still marked for
+# compaction.
+
+marked-file-count
+----
+2 files marked for compaction
+
+# Ratcheting to 007 should force compaction of any files still marked for
+# compaction.
+
+ratchet-format-major-version 007
+----
+[JOB 100] compacted(rewrite) L1 [000004 000008] (1.6 K) + L1 [] (0 B) -> L1 [000013] (786 B), in 1.0s (2.0s total), output rate 786 B/s
+
+format-major-version
+----
+007
+
+lsm
+----
+1:
+  000013:[d#0,SET-f#0,SET]
+
+# Reset to a new LSM.
+
+define
+L1
+b.SET.0:b c.SET.5:c
+L1
+m.SET.0:m l.SET.5:l
+L1
+x.SET.0:x y.SET.5:y
+----
+1:
+  000004:[b#0,SET-c#5,SET] points:[b#0,SET-c#5,SET]
+  000005:[l#5,SET-m#0,SET] points:[l#5,SET-m#0,SET]
+  000006:[x#0,SET-y#5,SET] points:[x#0,SET-y#5,SET]
+
+build ab
+set a a
+set b b
+----
+
+build cd
+set c c
+set d d
+----
+
+build wx
+set w w
+set x x
+----
+
+force-ingest paths=(ab, cd, wx) level=1
+----
+1:
+  000007:[a#1,SET-b#1,SET] points:[a#1,SET-b#1,SET]
+  000004:[b#0,SET-c#5,SET] points:[b#0,SET-c#5,SET]
+  000008:[c#2,SET-d#2,SET] points:[c#2,SET-d#2,SET]
+  000005:[l#5,SET-m#0,SET] points:[l#5,SET-m#0,SET]
+  000009:[w#3,SET-x#3,SET] points:[w#3,SET-x#3,SET]
+  000006:[x#0,SET-y#5,SET] points:[x#0,SET-y#5,SET]
+
+format-major-version
+----
+005
+
+ratchet-format-major-version 006
+----
+
+format-major-version
+----
+006
+
+marked-file-count
+----
+5 files marked for compaction
+
+ratchet-format-major-version 007
+----
+[JOB 100] compacted(rewrite) L1 [000007 000004 000008] (2.4 K) + L1 [] (0 B) -> L1 [000011] (794 B), in 1.0s (2.0s total), output rate 794 B/s
+[JOB 100] compacted(rewrite) L1 [000009 000006] (1.6 K) + L1 [] (0 B) -> L1 [000012] (786 B), in 1.0s (2.0s total), output rate 786 B/s
+
+lsm
+----
+1:
+  000011:[a#0,SET-d#0,SET]
+  000005:[l#5,SET-m#0,SET]
+  000012:[w#0,SET-y#0,SET]
+
+format-major-version
+----
+007

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -22,7 +22,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   total         1   986 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
   flush         0
 compact         0     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
-  ctype         0       0       0       0       0  (default, delete, elision, move, read)
+  ctype         0       0       0       0       0       0  (default, delete, elision, move, read, rewrite)
  memtbl         1   256 K
 zmemtbl         0     0 B
    ztbl         0     0 B

--- a/version_set.go
+++ b/version_set.go
@@ -346,6 +346,7 @@ func (vs *versionSet) logAndApply(
 	jobID int,
 	ve *versionEdit,
 	metrics map[int]*LevelMetrics,
+	forceRotation bool,
 	inProgressCompactions func() []compactionInfo,
 ) error {
 	if !vs.writing {
@@ -394,7 +395,7 @@ func (vs *versionSet) logAndApply(
 	// is too large.
 	var newManifestFileNum FileNum
 	var prevManifestFileSize uint64
-	if vs.manifest == nil || vs.manifest.Size() >= vs.opts.MaxManifestFileSize {
+	if forceRotation || vs.manifest == nil || vs.manifest.Size() >= vs.opts.MaxManifestFileSize {
 		newManifestFileNum = vs.getNextFileNum()
 		prevManifestFileSize = uint64(vs.manifest.Size())
 	}
@@ -550,6 +551,10 @@ func (vs *versionSet) incrementCompactions(kind compactionKind) {
 	case compactionKindRead:
 		vs.metrics.Compact.Count++
 		vs.metrics.Compact.ReadCount++
+
+	case compactionKindRewrite:
+		vs.metrics.Compact.Count++
+		vs.metrics.Compact.RewriteCount++
 	}
 }
 


### PR DESCRIPTION
Add two new format major versions FormatSplitUserKeysMarked and
FormatMarkCompacted that together may be used to guarantee that all sstables
within the table form their own atomic compaction unit. Previous versions of
Pebble (before #1470) and RocksDB allowed keys with identical user keys to be
split across multiple tables within a level. This produced a set of files known
as an 'atomic compaction unit' that must be compacted together to preserve the
LSM invariant.

The first format major version FormatSplitUserKeysMarked may be used to
guarantee that every file that is member to a multi-file atomic compaction unit
is marked for compaction. The 'marked-for-compaction' file metadata field is
currently unused by Pebble, but is repurposed here to record the intent to
recompact these files with split user keys. If ratcheting to
FormatSplitUserKeysMarked discovers files with split user keys, it marks them
for compaction and then rotates the manifest to ensure that the updated file
metadata is persisted durably.

This commit introduces a new rewrite compaction type. During compaction picking
if no other productive compaction is picked, the compaction picker looks for
files marked for compaction. It uses a manifest.Annotator to avoid a linear
search through the file metadata. If a marked file exists, it picks a
compaction that outputs into the file's existing level, pulling in its atomic
compaction unit if necessary.

The second format major version FormatMarkCompacted is used to guarantee that
no files that are marked for compaction exist. This may be used in a subequent
CockroachDB release (22.2) to ensure that all files marked for compaction by
the FormatSplitUserKeysMarked format major version have been compacted away.
Ratcheting to this format major version blocks until all the marked files are
compacted.

Together these format major versions will allow us to remove code necessary to
handle these atomic compaction units, when we increase the minimum format major
version supported by Pebble.

Close #1495.