### PR TITLE
tool/logs: various improvements to compaction event parser

### DIFF
--- a/tool/logs/compaction_test.go
+++ b/tool/logs/compaction_test.go
@@ -24,11 +24,10 @@ const (
 	compactionEndLine   = `I211215 14:26:56.318543 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n5,pebble,s6] 1216554  [JOB 284925] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s`
 	flushStartLine      = `I211213 16:23:48.903751 21136 3@vendor/github.com/cockroachdb/pebble/event.go:599 ⋮ [n9,pebble,s8] 24 [JOB 10] flushing 2 memtables to L0`
 	flushEndLine        = `I211213 16:23:49.134464 21136 3@vendor/github.com/cockroachdb/pebble/event.go:603 ⋮ [n9,pebble,s8] 26 [JOB 10] flushed 2 memtables to L0 [1535806] (1.3 M), in 0.2s, output rate 5.8 M/s`
-	readAmpLine         = `I211215 14:55:15.802648 155 kv/kvserver/store.go:2668 ⋮ [n5,s6] 109057 +  total     44905   672 G       -   1.2 T   714 G   118 K   215 G    34 K   4.0 T   379 K   2.8 T     514     3.4`
+	readAmpLine         = `  total     31766   188 G       -   257 G   187 G    48 K   3.6 G     744   536 G    49 K   278 G       5     2.1`
 
 	compactionStartNoNodeStoreLine = `I211215 14:26:56.012382 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n?,pebble,s?] 1216510  [JOB 284925] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)`
 	flushStartNoNodeStoreLine      = `I211213 16:23:48.903751 21136 3@vendor/github.com/cockroachdb/pebble/event.go:599 ⋮ [n?,pebble,s?] 24 [JOB 10] flushing 2 memtables to L0`
-	readAmpNoNodeStoreLine         = `I211215 14:55:15.802648 155 kv/kvserver/store.go:2668 ⋮ [n?,s?] 109057 +  total     44905   672 G       -   1.2 T   714 G   118 K   215 G    34 K   4.0 T   379 K   2.8 T     514     3.4`
 )
 
 func TestCompactionLogs_Regex(t *testing.T) {
@@ -79,16 +78,13 @@ func TestCompactionLogs_Regex(t *testing.T) {
 			re:   compactionPattern,
 			line: compactionStartLine,
 			matches: map[int]string{
-				compactionPatternTimestampIdx: "211215 14:26:56.012382",
-				compactionPatternNode:         "5",
-				compactionPatternStore:        "6",
-				compactionPatternJobIdx:       "284925",
-				compactionPatternSuffixIdx:    "ing",
-				compactionPatternTypeIdx:      "default",
-				compactionPatternFromIdx:      "2",
-				compactionPatternToIdx:        "3",
-				compactionPatternDigitIdx:     "8.4",
-				compactionPatternUnitIdx:      "M",
+				compactionPatternJobIdx:    "284925",
+				compactionPatternSuffixIdx: "ing",
+				compactionPatternTypeIdx:   "default",
+				compactionPatternFromIdx:   "2",
+				compactionPatternToIdx:     "3",
+				compactionPatternDigitIdx:  "8.4",
+				compactionPatternUnitIdx:   "M",
 			},
 		},
 		{
@@ -96,16 +92,13 @@ func TestCompactionLogs_Regex(t *testing.T) {
 			re:   compactionPattern,
 			line: compactionStartNoNodeStoreLine,
 			matches: map[int]string{
-				compactionPatternTimestampIdx: "211215 14:26:56.012382",
-				compactionPatternNode:         "?",
-				compactionPatternStore:        "?",
-				compactionPatternJobIdx:       "284925",
-				compactionPatternSuffixIdx:    "ing",
-				compactionPatternTypeIdx:      "default",
-				compactionPatternFromIdx:      "2",
-				compactionPatternToIdx:        "3",
-				compactionPatternDigitIdx:     "8.4",
-				compactionPatternUnitIdx:      "M",
+				compactionPatternJobIdx:    "284925",
+				compactionPatternSuffixIdx: "ing",
+				compactionPatternTypeIdx:   "default",
+				compactionPatternFromIdx:   "2",
+				compactionPatternToIdx:     "3",
+				compactionPatternDigitIdx:  "8.4",
+				compactionPatternUnitIdx:   "M",
 			},
 		},
 		{
@@ -113,16 +106,13 @@ func TestCompactionLogs_Regex(t *testing.T) {
 			re:   compactionPattern,
 			line: compactionEndLine,
 			matches: map[int]string{
-				compactionPatternTimestampIdx: "211215 14:26:56.318543",
-				compactionPatternNode:         "5",
-				compactionPatternStore:        "6",
-				compactionPatternJobIdx:       "284925",
-				compactionPatternSuffixIdx:    "ed",
-				compactionPatternTypeIdx:      "default",
-				compactionPatternFromIdx:      "2",
-				compactionPatternToIdx:        "3",
-				compactionPatternDigitIdx:     "13",
-				compactionPatternUnitIdx:      "M",
+				compactionPatternJobIdx:    "284925",
+				compactionPatternSuffixIdx: "ed",
+				compactionPatternTypeIdx:   "default",
+				compactionPatternFromIdx:   "2",
+				compactionPatternToIdx:     "3",
+				compactionPatternDigitIdx:  "13",
+				compactionPatternUnitIdx:   "M",
 			},
 		},
 		{
@@ -130,13 +120,10 @@ func TestCompactionLogs_Regex(t *testing.T) {
 			re:   flushPattern,
 			line: flushStartLine,
 			matches: map[int]string{
-				flushPatternTimestampIdx: "211213 16:23:48.903751",
-				flushPatternNode:         "9",
-				flushPatternStore:        "8",
-				flushPatternJobIdx:       "10",
-				flushPatternSuffixIdx:    "ing",
-				flushPatternDigitIdx:     "",
-				flushPatternUnitIdx:      "",
+				flushPatternJobIdx:    "10",
+				flushPatternSuffixIdx: "ing",
+				flushPatternDigitIdx:  "",
+				flushPatternUnitIdx:   "",
 			},
 		},
 		{
@@ -144,13 +131,10 @@ func TestCompactionLogs_Regex(t *testing.T) {
 			re:   flushPattern,
 			line: flushStartNoNodeStoreLine,
 			matches: map[int]string{
-				flushPatternTimestampIdx: "211213 16:23:48.903751",
-				flushPatternNode:         "?",
-				flushPatternStore:        "?",
-				flushPatternJobIdx:       "10",
-				flushPatternSuffixIdx:    "ing",
-				flushPatternDigitIdx:     "",
-				flushPatternUnitIdx:      "",
+				flushPatternJobIdx:    "10",
+				flushPatternSuffixIdx: "ing",
+				flushPatternDigitIdx:  "",
+				flushPatternUnitIdx:   "",
 			},
 		},
 		{
@@ -158,35 +142,18 @@ func TestCompactionLogs_Regex(t *testing.T) {
 			re:   flushPattern,
 			line: flushEndLine,
 			matches: map[int]string{
-				flushPatternTimestampIdx: "211213 16:23:49.134464",
-				flushPatternNode:         "9",
-				flushPatternStore:        "8",
-				flushPatternJobIdx:       "10",
-				flushPatternSuffixIdx:    "ed",
-				flushPatternDigitIdx:     "1.3",
-				flushPatternUnitIdx:      "M",
+				flushPatternJobIdx:    "10",
+				flushPatternSuffixIdx: "ed",
+				flushPatternDigitIdx:  "1.3",
+				flushPatternUnitIdx:   "M",
 			},
 		},
 		{
-			name: "read amp",
+			name: "read amp suffix",
 			re:   readAmpPattern,
 			line: readAmpLine,
 			matches: map[int]string{
-				readAmpPatternTimestampIdx: "211215 14:55:15.802648",
-				readAmpPatternNode:         "5",
-				readAmpPatternStore:        "6",
-				readAmpPatternValueIdx:     "514",
-			},
-		},
-		{
-			name: "read amp - no node / store",
-			re:   readAmpPattern,
-			line: readAmpNoNodeStoreLine,
-			matches: map[int]string{
-				readAmpPatternTimestampIdx: "211215 14:55:15.802648",
-				readAmpPatternNode:         "?",
-				readAmpPatternStore:        "?",
-				readAmpPatternValueIdx:     "514",
+				readAmpPatternValueIdx: "5",
 			},
 		},
 	}
@@ -204,19 +171,19 @@ func TestCompactionLogs_Regex(t *testing.T) {
 
 func TestCompactionLogs(t *testing.T) {
 	var c *logEventCollector
-	var pebbleFileNum, cockroachFileNum int
+	var logNum int
 	resetFn := func() {
 		c = newEventCollector()
-		pebbleFileNum, cockroachFileNum = 0, 0
+		logNum = 0
 	}
 	resetFn()
 
 	dir := t.TempDir()
 	datadriven.RunTest(t, "testdata/compactions", func(td *datadriven.TestData) string {
 		switch td.Cmd {
-		case "pebble-log":
-			basename := fmt.Sprintf("pebble.%d.log", pebbleFileNum)
-			pebbleFileNum++
+		case "log":
+			basename := fmt.Sprintf("%d.log", logNum)
+			logNum++
 			f, err := os.Create(filepath.Join(dir, basename))
 			if err != nil {
 				panic(err)
@@ -226,24 +193,7 @@ func TestCompactionLogs(t *testing.T) {
 			}
 			_ = f.Close()
 
-			if err = parseLog(f.Name(), c, parsePebbleFn); err != nil {
-				return err.Error()
-			}
-			return basename
-
-		case "cockroach-log":
-			basename := fmt.Sprintf("cockroach.%d.log", cockroachFileNum)
-			cockroachFileNum++
-			f, err := os.Create(filepath.Join(dir, basename))
-			if err != nil {
-				panic(err)
-			}
-			if _, err := f.WriteString(td.Input); err != nil {
-				panic(err)
-			}
-			_ = f.Close()
-
-			if err = parseLog(f.Name(), c, parseCockroachFn); err != nil {
+			if err = parseLog(f.Name(), c); err != nil {
 				return err.Error()
 			}
 			return basename

--- a/tool/logs/testdata/compactions
+++ b/tool/logs/testdata/compactions
@@ -1,13 +1,13 @@
 # Single compaction and flush pair for a single node / store combination.
 
-pebble-log
+log
 I211215 00:00:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s1] 1216510  [JOB 1] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)
 I211215 00:00:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s1] 1216554  [JOB 1] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
 
 I211215 00:01:10.000000 21136 3@vendor/github.com/cockroachdb/pebble/event.go:599 ⋮ [n1,pebble,s1] 24 [JOB 2] flushing 2 memtables to L0
 I211215 00:01:20.000000 21136 3@vendor/github.com/cockroachdb/pebble/event.go:603 ⋮ [n1,pebble,s1] 26 [JOB 2] flushed 2 memtables to L0 [1535806] (1.3 M), in 0.2s, output rate 5.8 M/s
 ----
-pebble.0.log
+0.log
 
 summarize
 ----
@@ -32,25 +32,25 @@ ______from________to___default______move_____elide____delete_____flush_____total
 reset
 ----
 
-pebble-log
+log
 I211215 00:00:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s1] 1216510  [JOB 1] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)
 ----
-pebble.0.log
+0.log
 
-pebble-log
+log
 I211215 00:00:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s1] 1216554  [JOB 1] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
 ----
-pebble.1.log
+1.log
 
-pebble-log
+log
 I211215 00:01:10.000000 21136 3@vendor/github.com/cockroachdb/pebble/event.go:599 ⋮ [n1,pebble,s1] 24 [JOB 2] flushing 2 memtables to L0
 ----
-pebble.2.log
+2.log
 
-pebble-log
+log
 I211215 00:01:20.000000 21136 3@vendor/github.com/cockroachdb/pebble/event.go:603 ⋮ [n1,pebble,s1] 26 [JOB 2] flushed 2 memtables to L0 [1535806] (1.3 M), in 0.2s, output rate 5.8 M/s
 ----
-pebble.3.log
+3.log
 
 summarize
 ----
@@ -75,17 +75,37 @@ ______from________to___default______move_____elide____delete_____flush_____total
 reset
 ----
 
-pebble-log
+log
 I211215 00:00:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s1] 1216510  [JOB 1] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)
 I211215 00:00:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s1] 1216554  [JOB 1] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
 ----
-pebble.0.log
+0.log
 
-cockroach-log
-I211215 00:00:15.000000 155 kv/kvserver/store.go:2668 ⋮ [n1,s1] 109057 +  total     44905   672 G       -   1.2 T   714 G   118 K   215 G    34 K   4.0 T   379 K   2.8 T     514     3.4
-I211215 00:01:15.000000 155 kv/kvserver/store.go:2668 ⋮ [n1,s1] 109057 +  total     44905   672 G       -   1.2 T   714 G   118 K   215 G    34 K   4.0 T   379 K   2.8 T     999     3.4
+log
+I211215 00:00:15.000000 434 kv/kvserver/store.go:3251 ⋮ [n1,s1] 31356
+__level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___r-amp___w-amp
+    WAL         1    54 M       -    65 G       -       -       -       -    70 G       -       -       -     1.1
+      0         0     0 B    0.00    70 G    77 M     133     0 B       0    24 G    19 K   4.2 G       0     0.3
+      1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      2        14    34 M    0.96    18 G     0 B       0    17 M      10    49 G    14 K    55 G       1     2.7
+      3        42   207 M    0.96    12 G     0 B       0   939 M     280    43 G   7.3 K    46 G       1     3.4
+      4       264   1.5 G    0.99   9.1 G    18 M       6   824 M     152    31 G   4.5 K    35 G       1     3.4
+      5      7474    23 G    1.00   2.8 G   116 G    26 K   1.8 G     301   3.2 G     604   3.2 G       1     1.2
+      6     23972   164 G       -    98 G    70 G    22 K   1.6 K       1   129 G   3.8 K   135 G       1     1.3
+  total     31766   188 G       -   257 G   187 G    48 K   3.6 G     744   536 G    49 K   278 G       5     2.1
+I211215 00:01:15.000000 434 kv/kvserver/store.go:3251 ⋮ [n1,s1] 31356
+__level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___r-amp___w-amp
+    WAL         1    35 M       -    65 G       -       -       -       -    70 G       -       -       -     1.1
+      0         0     0 B    0.00    70 G    77 M     133     0 B       0    24 G    19 K   4.2 G       0     0.3
+      1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      2        14    34 M    0.95    18 G     0 B       0    17 M      10    49 G    14 K    55 G       1     2.7
+      3        42   207 M    0.96    12 G     0 B       0   939 M     280    43 G   7.3 K    46 G       1     3.4
+      4       264   1.5 G    0.99   9.1 G    18 M       6   824 M     152    31 G   4.5 K    35 G       1     3.4
+      5      7474    23 G    1.00   2.8 G   116 G    26 K   1.8 G     301   3.2 G     604   3.2 G       1     1.2
+      6     23972   164 G       -    98 G    70 G    22 K   1.6 K       1   129 G   3.8 K   135 G       1     1.3
+  total     31766   188 G       -   257 G   187 G    48 K   3.6 G     744   536 G    49 K   278 G       5     2.1
 ----
-cockroach.0.log
+1.log
 
 summarize
 ----
@@ -95,18 +115,18 @@ from: 211215 00:00
 ______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
         L2        L3         1         0         0         0         0         1      13 M       10s
      total                   1         0         0         0         0         1      13 M        0s
-     r-amp     514.0
+     r-amp       5.0
 
 # Long running compaction.
 
 reset
 ----
 
-pebble-log
+log
 I211215 00:01:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s1] 1216510  [JOB 1] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)
 I211215 00:03:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s1] 1216554  [JOB 1] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
 ----
-pebble.0.log
+0.log
 
 summarize long-running=1m
 ----
@@ -126,14 +146,14 @@ ______from________to_______job______type_____start_______end____dur(s)_____bytes
 reset
 ----
 
-pebble-log
+log
 I211215 00:01:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s1] 1216510  [JOB 1] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)
 I211215 00:01:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s1] 1216554  [JOB 1] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
 
 I211215 00:01:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s2] 1216510  [JOB 2] compacting(default) L3 [442555] (4.2 M) + L4 [445853] (8.4 M)
 I211215 00:01:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s2] 1216554  [JOB 2] compacted(default) L3 [442555] (4.2 M) + L4 [445853] (8.4 M) -> L4 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
 ----
-pebble.0.log
+0.log
 
 summarize
 ----
@@ -145,8 +165,8 @@ ______from________to___default______move_____elide____delete_____flush_____total
      total                   1         0         0         0         0         1      13 M        0s
      r-amp       NaN
 node: 1, store: 2
-from: 211215 00:02
-  to: 211215 00:03
+from: 211215 00:01
+  to: 211215 00:02
 ______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
         L3        L4         1         0         0         0         0         1      13 M       10s
      total                   1         0         0         0         0         1      13 M        0s
@@ -157,17 +177,17 @@ ______from________to___default______move_____elide____delete_____flush_____total
 reset
 ----
 
-pebble-log
+log
 I211215 00:01:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s1] 1216510  [JOB 1] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)
 I211215 00:01:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s1] 1216554  [JOB 1] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
 ----
-pebble.0.log
+0.log
 
-pebble-log
+log
 I211215 00:01:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n2,pebble,s1] 1216510  [JOB 1] compacting(default) L3 [442555] (4.2 M) + L4 [445853] (8.4 M)
 I211215 00:01:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n2,pebble,s1] 1216554  [JOB 1] compacted(default) L3 [442555] (4.2 M) + L4 [445853] (8.4 M) -> L4 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
 ----
-pebble.1.log
+1.log
 
 summarize
 ----
@@ -179,8 +199,8 @@ ______from________to___default______move_____elide____delete_____flush_____total
      total                   1         0         0         0         0         1      13 M        0s
      r-amp       NaN
 node: 2, store: 1
-from: 211215 00:02
-  to: 211215 00:03
+from: 211215 00:01
+  to: 211215 00:02
 ______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
         L3        L4         1         0         0         0         0         1      13 M       10s
      total                   1         0         0         0         0         1      13 M        0s
@@ -191,23 +211,23 @@ ______from________to___default______move_____elide____delete_____flush_____total
 reset
 ----
 
-pebble-log
+log
 I211215 00:01:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s1] 1216510  [JOB 1] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)
 I211215 00:01:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s1] 1216554  [JOB 1] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
 
 I211215 00:03:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s2] 1216510  [JOB 2] compacting(default) L1 [442555] (4.2 M) + L2 [445853] (8.4 M)
 I211215 00:03:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s2] 1216554  [JOB 2] compacted(default) L1 [442555] (4.2 M) + L2 [445853] (8.4 M) -> L2 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
 ----
-pebble.0.log
+0.log
 
-pebble-log
+log
 I211215 00:00:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n2,pebble,s1] 1216510  [JOB 1] compacting(default) L3 [442555] (4.2 M) + L4 [445853] (8.4 M)
 I211215 00:00:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n2,pebble,s1] 1216554  [JOB 1] compacted(default) L3 [442555] (4.2 M) + L4 [445853] (8.4 M) -> L4 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
 
 I211215 00:02:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n2,pebble,s2] 1216510  [JOB 2] compacting(default) L4 [442555] (4.2 M) + L5 [445853] (8.4 M)
 I211215 00:02:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n2,pebble,s2] 1216554  [JOB 2] compacted(default) L4 [442555] (4.2 M) + L5 [445853] (8.4 M) -> L5 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
 ----
-pebble.1.log
+1.log
 
 summarize
 ----
@@ -219,22 +239,22 @@ ______from________to___default______move_____elide____delete_____flush_____total
      total                   1         0         0         0         0         1      13 M        0s
      r-amp       NaN
 node: 1, store: 2
-from: 211215 00:02
-  to: 211215 00:03
+from: 211215 00:03
+  to: 211215 00:04
 ______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
         L1        L2         1         0         0         0         0         1      13 M       10s
      total                   1         0         0         0         0         1      13 M        0s
      r-amp       NaN
 node: 2, store: 1
-from: 211215 00:03
-  to: 211215 00:04
+from: 211215 00:00
+  to: 211215 00:01
 ______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
         L3        L4         1         0         0         0         0         1      13 M       10s
      total                   1         0         0         0         0         1      13 M        0s
      r-amp       NaN
 node: 2, store: 2
-from: 211215 00:04
-  to: 211215 00:05
+from: 211215 00:02
+  to: 211215 00:03
 ______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
         L4        L5         1         0         0         0         0         1      13 M       10s
      total                   1         0         0         0         0         1      13 M        0s
@@ -245,16 +265,26 @@ ______from________to___default______move_____elide____delete_____flush_____total
 reset
 ----
 
-pebble-log
+log
 I211215 00:01:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n?,pebble,s?] 1216510  [JOB 1] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)
 I211215 00:01:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n?,pebble,s?] 1216554  [JOB 1] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
 ----
-pebble.0.log
+0.log
 
-cockroach-log
-I211215 00:01:15.000000 155 kv/kvserver/store.go:2668 ⋮ [n?,s?] 109057 +  total     44905   672 G       -   1.2 T   714 G   118 K   215 G    34 K   4.0 T   379 K   2.8 T     514     3.4
+log
+I211215 00:01:15.000000 434 kv/kvserver/store.go:3251 ⋮ [n?,s?] 31356
+__level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___r-amp___w-amp
+    WAL         1    54 M       -    65 G       -       -       -       -    70 G       -       -       -     1.1
+      0         0     0 B    0.00    70 G    77 M     133     0 B       0    24 G    19 K   4.2 G       0     0.3
+      1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      2        14    34 M    0.96    18 G     0 B       0    17 M      10    49 G    14 K    55 G       1     2.7
+      3        42   207 M    0.96    12 G     0 B       0   939 M     280    43 G   7.3 K    46 G       1     3.4
+      4       264   1.5 G    0.99   9.1 G    18 M       6   824 M     152    31 G   4.5 K    35 G       1     3.4
+      5      7474    23 G    1.00   2.8 G   116 G    26 K   1.8 G     301   3.2 G     604   3.2 G       1     1.2
+      6     23972   164 G       -    98 G    70 G    22 K   1.6 K       1   129 G   3.8 K   135 G       1     1.3
+  total     31766   188 G       -   257 G   187 G    48 K   3.6 G     744   536 G    49 K   278 G       5     2.1
 ----
-cockroach.0.log
+1.log
 
 summarize
 ----
@@ -264,4 +294,83 @@ from: 211215 00:01
 ______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
         L2        L3         1         0         0         0         0         1      13 M       10s
      total                   1         0         0         0         0         1      13 M        0s
-     r-amp     514.0
+     r-amp       5.0
+
+# The same Job ID interleaved for multiple nodes / stores.
+
+reset
+----
+
+log
+I211215 00:01:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s1] 1216510  [JOB 1] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)
+I211215 00:02:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n2,pebble,s2] 1216510  [JOB 1] compacting(default) L4 [442555] (4.2 M) + L5 [445853] (8.4 M)
+I211215 00:01:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s1] 1216554  [JOB 1] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
+I211215 00:02:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n2,pebble,s2] 1216554  [JOB 1] compacted(default) L4 [442555] (4.2 M) + L5 [445853] (8.4 M) -> L5 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
+----
+0.log
+
+summarize
+----
+node: 1, store: 1
+from: 211215 00:01
+  to: 211215 00:02
+______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
+        L2        L3         1         0         0         0         0         1      13 M       10s
+     total                   1         0         0         0         0         1      13 M        0s
+     r-amp       NaN
+node: 2, store: 2
+from: 211215 00:02
+  to: 211215 00:03
+______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
+        L4        L5         1         0         0         0         0         1      13 M       10s
+     total                   1         0         0         0         0         1      13 M        0s
+     r-amp       NaN
+
+# Read amp matching should remain backwards compatible.
+
+reset
+----
+
+log
+I220301 00:00:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s1] 1216510  [JOB 1] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)
+I220301 00:00:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s1] 1216554  [JOB 1] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
+----
+0.log
+
+log
+I220301 00:00:30.000000 200 1@gossip/gossip.go:1500 ⋮ [n1] 74  node has connected to cluster via gossip
+I220301 00:00:30.000000 200 kv/kvserver/stores.go:269 ⋮ [n1] 75  wrote 0 node addresses to persistent storage
+I220301 00:00:30.000000 319 2@server/status/runtime.go:569 ⋮ [n1] 76  runtime stats: 154 MiB RSS, 273 goroutines (stacks: 2.5 MiB), 42 MiB/71 MiB Go alloc/total (heap fragmentation: 11 MiB, heap reserved: 3.9 MiB, heap released: 4.2 MiB), 3.2 MiB/5.6 MiB CGO alloc/total (0.0 CGO/sec), 0.0/0.0 %(u/s)time, 0.0 %gc (0x), 425 KiB/500 KiB (r/w)net
+I220301 00:00:30.000000 319 2@server/status/runtime.go:569 ⋮ [n1] 77  runtime stats: 159 MiB RSS, 266 goroutines (stacks: 3.3 MiB), 42 MiB/78 MiB Go alloc/total (heap fragmentation: 12 MiB, heap reserved: 6.7 MiB, heap released: 64 MiB), 4.4 MiB/6.8 MiB CGO alloc/total (0.4 CGO/sec), 2.9/2.1 %(u/s)time, 0.0 %gc (0x), 335 KiB/323 KiB (r/w)net
+I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78
+I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78 +__level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___r-amp___w-amp
+I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78 +    WAL         3   779 K       -   773 K       -       -       -       -   779 K       -       -       -     1.0
+I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78 +      0         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78 +      1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78 +      2         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78 +      3         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78 +      4         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78 +      5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78 +      6         0     0 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78 +  total         0     0 B       -   779 K     0 B       0     0 B       0   779 K       0     0 B       1     1.0
+I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78 +  flush         0
+I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78 +compact         0     0 B             0 B  (size == estimated-debt, in = in-progress-bytes)
+I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78 + memtbl         3   1.8 M
+I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78 +zmemtbl         0     0 B
+I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78 +   ztbl         0     0 B
+I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78 + bcache         0     0 B    0.0%  (score == hit-rate)
+I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78 + tcache         0     0 B    0.0%  (score == hit-rate)
+I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78 + titers         0
+I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78 + filter         -       -    0.0%  (score == utility)
+----
+1.log
+
+summarize
+----
+node: 1, store: 1
+from: 220301 00:00
+  to: 220301 00:01
+______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
+        L2        L3         1         0         0         0         0         1      13 M       10s
+     total                   1         0         0         0         0         1      13 M        0s
+     r-amp       1.0


### PR DESCRIPTION
An accumulation of improvements, based on using the tool as part of
various "real-world" debugging exercises.

**Accept any file as an input.** Previously, filenames were inspected to
determine how the log lines should be parsed. Rely instead on the
regular expressions.

**Rework the windowing algorithm.** Previously log lines could be
grouped into the wrong window based on the start and end timestamps.
Improve the windowing.

**Group by node, store and job.** Previously events were grouped only by
job ID. In the event that a store stopped and restarted and logged to
the same file, duplicate events could be dropped.

**Update read-amp parsing**. Newer versions of Cockroach print the LSM
debug as a single log event, with a single timestamp prefix. Update the
parser to split parsing of the read amp value into a prefix line (with
the timestamp, node and store) and a suffix line (with the read amp
value itself). This involves skipping over intermediary lines in the log
stream, between the prefix and suffix.