### PR TITLE
internal/manifest: encode/decode range keys in manifest

### DIFF
--- a/internal/manifest/testdata/file_metadata_bounds
+++ b/internal/manifest/testdata/file_metadata_bounds
@@ -4,6 +4,7 @@ extend-point-key-bounds
 a.SET.0 - z.DEL.42
 ----
 000000:[a#0,SET-z#42,DEL] points:[a#0,SET-z#42,DEL]
+  bounds: (smallest=point,largest=point) (0x00000111)
 
 # Rangedels only (single update).
 
@@ -14,6 +15,7 @@ extend-point-key-bounds
 a.RANGEDEL.0:z
 ----
 000000:[a#0,RANGEDEL-z#72057594037927935,RANGEDEL] points:[a#0,RANGEDEL-z#72057594037927935,RANGEDEL]
+  bounds: (smallest=point,largest=point) (0x00000111)
 
 # Range keys only (single update).
 
@@ -24,6 +26,7 @@ extend-range-key-bounds
 a.RANGEKEYSET.0:z
 ----
 000000:[a#0,RANGEKEYSET-z#72057594037927935,RANGEKEYSET] ranges:[a#0,RANGEKEYSET-z#72057594037927935,RANGEKEYSET]
+  bounds: (smallest=range,largest=range) (0x00000000)
 
 # Multiple updates with various key kinds.
 
@@ -34,6 +37,7 @@ extend-point-key-bounds
 m.SET.0 - n.SET.0
 ----
 000000:[m#0,SET-n#0,SET] points:[m#0,SET-n#0,SET]
+  bounds: (smallest=point,largest=point) (0x00000111)
 
 # Extend the lower point key bound.
 
@@ -41,6 +45,7 @@ extend-point-key-bounds
 j.SET.0 - k.SET.0
 ----
 000000:[j#0,SET-n#0,SET] points:[j#0,SET-n#0,SET]
+  bounds: (smallest=point,largest=point) (0x00000111)
 
 # Extend the upper point key bound with a rangedel.
 
@@ -48,6 +53,7 @@ extend-point-key-bounds
 k.RANGEDEL.0:o
 ----
 000000:[j#0,SET-o#72057594037927935,RANGEDEL] points:[j#0,SET-o#72057594037927935,RANGEDEL]
+  bounds: (smallest=point,largest=point) (0x00000111)
 
 # Extend the lower bounds bound with a range key.
 
@@ -55,6 +61,7 @@ extend-range-key-bounds
 a.RANGEKEYSET.42:m
 ----
 000000:[a#42,RANGEKEYSET-o#72057594037927935,RANGEDEL] points:[j#0,SET-o#72057594037927935,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#72057594037927935,RANGEKEYSET]
+  bounds: (smallest=range,largest=point) (0x00000101)
 
 # Extend again with a wide range key (equal keys tiebreak on seqnums descending,
 # so the overall lower bound is unchanged).
@@ -63,11 +70,12 @@ extend-range-key-bounds
 a.RANGEKEYSET.0:z
 ----
 000000:[a#42,RANGEKEYSET-z#72057594037927935,RANGEKEYSET] points:[j#0,SET-o#72057594037927935,RANGEDEL] ranges:[a#42,RANGEKEYSET-z#72057594037927935,RANGEKEYSET]
+  bounds: (smallest=range,largest=range) (0x00000001)
 
-# Extend again with a wide rangedel over the same range (equal keys and sequnums
-# tiebreak on key kind descending, so the overall upper bound is updated).
+# Extend again with a wide rangedel over the same range.
 
 extend-point-key-bounds
-a.RANGEDEL.0:z
+A.RANGEDEL.0:y
 ----
-000000:[a#42,RANGEKEYSET-z#72057594037927935,RANGEDEL] points:[a#0,RANGEDEL-z#72057594037927935,RANGEDEL] ranges:[a#42,RANGEKEYSET-z#72057594037927935,RANGEKEYSET]
+000000:[A#0,RANGEDEL-z#72057594037927935,RANGEKEYSET] points:[A#0,RANGEDEL-y#72057594037927935,RANGEDEL] ranges:[a#42,RANGEKEYSET-z#72057594037927935,RANGEKEYSET]
+  bounds: (smallest=point,largest=range) (0x00000011)

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -64,6 +64,32 @@ func TestVersionEditRoundTrip(t *testing.T) {
 		base.DecodeInternalKey([]byte("Z\x01\xff\xfe\xfd\xfc\xfb\xfa\xf9")),
 	)
 
+	m3 := (&FileMetadata{
+		FileNum:      807,
+		Size:         8070,
+		CreationTime: 807050,
+	}).ExtendRangeKeyBounds(
+		cmp,
+		base.MakeInternalKey([]byte("aaa"), 0, base.InternalKeyKindRangeKeySet),
+		base.MakeRangeKeySentinelKey(base.InternalKeyKindRangeKeySet, []byte("zzz")),
+	)
+
+	m4 := (&FileMetadata{
+		FileNum:        809,
+		Size:           8090,
+		CreationTime:   809060,
+		SmallestSeqNum: 9,
+		LargestSeqNum:  11,
+	}).ExtendPointKeyBounds(
+		cmp,
+		base.MakeInternalKey([]byte("a"), 0, base.InternalKeyKindSet),
+		base.MakeInternalKey([]byte("m"), 0, base.InternalKeyKindSet),
+	).ExtendRangeKeyBounds(
+		cmp,
+		base.MakeInternalKey([]byte("l"), 0, base.InternalKeyKindRangeKeySet),
+		base.MakeRangeKeySentinelKey(base.InternalKeyKindRangeKeySet, []byte("z")),
+	)
+
 	testCases := []VersionEdit{
 		// An empty version edit.
 		{},
@@ -86,12 +112,20 @@ func TestVersionEditRoundTrip(t *testing.T) {
 			},
 			NewFiles: []NewFileEntry{
 				{
-					Level: 5,
+					Level: 4,
 					Meta:  m1,
 				},
 				{
-					Level: 6,
+					Level: 5,
 					Meta:  m2,
+				},
+				{
+					Level: 6,
+					Meta:  m3,
+				},
+				{
+					Level: 6,
+					Meta:  m4,
 				},
 			},
 		},

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -436,6 +436,33 @@ func TestExtendBounds(t *testing.T) {
 		}
 		return
 	}
+	format := func(m *FileMetadata) string {
+		var b bytes.Buffer
+		var smallest, largest string
+		switch m.boundTypeSmallest {
+		case boundTypePointKey:
+			smallest = "point"
+		case boundTypeRangeKey:
+			smallest = "range"
+		default:
+			return fmt.Sprintf("unknown bound type %d", m.boundTypeSmallest)
+		}
+		switch m.boundTypeLargest {
+		case boundTypePointKey:
+			largest = "point"
+		case boundTypeRangeKey:
+			largest = "range"
+		default:
+			return fmt.Sprintf("unknown bound type %d", m.boundTypeLargest)
+		}
+		bounds, err := m.boundsMarker()
+		if err != nil {
+			panic(err)
+		}
+		fmt.Fprintf(&b, "%s\n", m.DebugString(base.DefaultFormatter, true))
+		fmt.Fprintf(&b, "  bounds: (smallest=%s,largest=%s) (0x%08b)\n", smallest, largest, bounds)
+		return b.String()
+	}
 	m := &FileMetadata{}
 	datadriven.RunTest(t, "testdata/file_metadata_bounds", func(d *datadriven.TestData) string {
 		switch d.Cmd {
@@ -445,11 +472,11 @@ func TestExtendBounds(t *testing.T) {
 		case "extend-point-key-bounds":
 			u, l := parseBounds(d.Input)
 			m.ExtendPointKeyBounds(cmp, u, l)
-			return m.DebugString(base.DefaultFormatter, true)
+			return format(m)
 		case "extend-range-key-bounds":
 			u, l := parseBounds(d.Input)
 			m.ExtendRangeKeyBounds(cmp, u, l)
-			return m.DebugString(base.DefaultFormatter, true)
+			return format(m)
 		default:
 			return fmt.Sprintf("unknown command %s\n", d.Cmd)
 		}


### PR DESCRIPTION
Currently, only point key bounds for a table are present in a manifest
entry. With the addition of range keys, the manifest needs to track the
point and range key bounds, in addition to providing a mechanism to
infer the overall bounds for the table.

Adopt the following encoding scheme to incorporate range keys into the
manifest:

- if the table only contains point keys, the existing encoding applies -
  a new file entry is written with `tagNewFile4` and the smallest and
  largest point keys are used as the smallest and largest bounds for the
  table.

- else, the table contains range keys, and the new file is written with
  a new tag, `tagNewFile4RangeKeys` that extends `tagNewFile4`:

  - a "marker" byte is written that indicates if the table also has
    point keys, and how the bounds can be used to reconstruct the
    overall table bounds. In increasing order of bit significance:

    - if the table contains point keys, `1`, else `0`
    - if the smallest key is a point key, `1`, else `0`
    - if the largest key is a point key, `1`, else `0`

  - the smallest/largest pairs are written - first the point key bounds
    (if present), then the range key bounds.

- any custom tags are written (e.g. table marked for compaction, etc.).

This new encoding scheme uses no additional space in the manifest if
there are only point keys, and remains backwards compatible with the
existing manifest format. If range keys are present, each new file
requires two additional bytes (a varint with value `1` or `2` for the
smallest/largest keypair count, plus a byte for the bounds marker) on
top of what it takes to encode the smallest/largest point key bounds.

This approach also has the advantage of encoding enough information to
be able to fully reconstruct the overall table bounds at decode time,
rather than waiting until a `Compare` function is available to perform
the comparisons.