### PR TITLE
compaction: change `conflictsWithInProgress` to check keyranges

### DIFF
--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -686,7 +686,7 @@ manual compaction did not block for ongoing
 remove-ongoing-compaction
 ----
 
-add-ongoing-compaction startLevel=5 outputLevel=6 start=a end=b
+add-ongoing-compaction startLevel=4 outputLevel=5 start=a end=b
 ----
 
 async-compact a-b L4
@@ -937,31 +937,6 @@ compact a-c L0 parallel
 3:
   000009:[a#0,SET-b#0,SET]
   000010:[c#0,SET-c#0,SET]
-
-add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=e
-----
-
-# While we allow 2 concurrent compactions, the ongoing compaction conflicts
-# with the compaction below, and thus the manual compaction is dropped with
-# no change to the LSM.
-
-async-compact a-d L1 parallel
-----
-manual compaction did not block for ongoing
-1:
-  000011:[a#3,SET-a#3,SET]
-  000012:[b#2,SET-b#2,SET]
-  000013:[c#2,SET-c#2,SET]
-2:
-  000006:[a#1,SET-b#1,SET]
-  000007:[c#1,SET-c#1,SET]
-  000008:[d#0,SET-d#0,SET]
-3:
-  000009:[a#0,SET-b#0,SET]
-  000010:[c#0,SET-c#0,SET]
-
-remove-ongoing-compaction
-----
 
 add-ongoing-compaction startLevel=3 outputLevel=4 start=a end=d
 ----

--- a/testdata/manual_compaction_set_with_del
+++ b/testdata/manual_compaction_set_with_del
@@ -687,7 +687,7 @@ manual compaction did not block for ongoing
 remove-ongoing-compaction
 ----
 
-add-ongoing-compaction startLevel=5 outputLevel=6 start=a end=b
+add-ongoing-compaction startLevel=4 outputLevel=5 start=a end=b
 ----
 
 async-compact a-b L4


### PR DESCRIPTION
In #1487, we decided to use the existing`conflictsWithInProgress` check 
which retries the compaction if the input/output level(s) conflict only when 
`parallelize=false`. We skip the check if`parallelize=true` because we allow 
multiple compactions to/from a level. We also rely on automatic compactions 
being disabled when executing parallel compactions since automatic 
compactions produce conflicts with the chosen keyranges and get dropped 
before scheduling.

This commit modifies `conflictsWithInProgress` to also check for conflicting
keyranges. So, a compaction is considered conflicting if it touches **the same
keyrange on the same level**. I think it would be helpful because then we can
be assured that `db.Compact` will function correctly regardless of disabling
automatic compactions.