### PR TITLE
sstable/metamorphic: add Writer parallelism to the metamorphic tests

### DIFF
--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -183,6 +183,10 @@ func standardOptions() []*testOptions {
 [TestOptions]
  use_disk=true
 `,
+		22: `
+[Options]
+  enable_writer_parallelism=true
+`,
 	}
 
 	opts := make([]*testOptions, len(stdOpts))
@@ -224,6 +228,10 @@ func randomOptions(rng *rand.Rand) *testOptions {
 	opts.MemTableStopWritesThreshold = 2 + rng.Intn(5) // 2 - 5
 	if rng.Intn(2) == 0 {
 		opts.WALDir = "wal"
+	}
+	if rng.Intn(4) == 0 {
+		// Enable this for a quarter of the random options.
+		opts.Experimental.EnableWriterParallelism = true
 	}
 	var lopts pebble.LevelOptions
 	lopts.BlockRestartInterval = 1 + rng.Intn(64)  // 1 - 64

--- a/options_test.go
+++ b/options_test.go
@@ -99,6 +99,7 @@ func TestOptionsString(t *testing.T) {
   validate_on_ingest=false
   wal_dir=
   wal_bytes_per_sync=0
+  enable_writer_parallelism=false
 
 [Level "0"]
   block_restart_interval=16
@@ -227,6 +228,7 @@ func TestOptionsParse(t *testing.T) {
 			opts.Experimental.ReadCompactionRate = 300
 			opts.Experimental.ReadSamplingMultiplier = 400
 			opts.Experimental.TableCacheShards = 500
+			opts.Experimental.EnableWriterParallelism = true
 			opts.EnsureDefaults()
 			str := opts.String()
 

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -216,6 +216,11 @@ type WriterOptions struct {
 
 	// Checksum specifies which checksum to use.
 	Checksum ChecksumType
+
+	// ParallelismEnabled is used to indicate that the sstable Writer is allowed to compress
+	// data blocks and write datablocks to disk in parallel with the Writer client goroutine.
+	// goroutine.
+	ParallelismEnabled bool
 }
 
 func (o WriterOptions) ensureDefaults() WriterOptions {

--- a/sstable/testdata/size_estimate
+++ b/sstable/testdata/size_estimate
@@ -14,17 +14,38 @@ add_inflight 4
 ----
 4
 
+num_inflight_entries
+----
+1
+
+num_entries
+----
+1
+
 # After compression, entry only had a size of 3. The total size is the 3, but the
 # max estimated size yet is 4.
 entry_written 3 4 3
 ----
 4
 
-# Compression ratio is 0.75 at this point. The total size is 3, and the inflight size is
-# 4, so that returned size is uint64(6.75). 
+num_entries
+----
+1
+
+# There should be 0 inflight entries once the previous entry has been written.
+num_inflight_entries
+----
+0
+
+# Compression ratio is 0.75 at this point. The total size is 3, and the inflight
+# size is 4, so that returned size is uint64(6.75).
 add_inflight 5
 ----
 6
+
+num_entries
+----
+2
 
 # We don't clear the empty size, so even after clearing a size of 1 is returned.
 clear
@@ -40,26 +61,43 @@ add_inflight 5
 ----
 9
 
-# First inflight entry written. The entry didn't get compressed. The total size now is less than 9,
-# but the max estimated size should still be 9.
+num_entries
+----
+2
+
+num_inflight_entries
+----
+2
+
+# First inflight entry written. The entry didn't get compressed. The total size
+# now is less than 9, but the max estimated size should still be 9.
 entry_written 4 4 4
 ----
 9
 
-# At this point, inflightSize is 13, the totalSize is 4. The compression ratio is 1. So, the returned
-# size should be 17.
+num_entries
+----
+2
+
+num_inflight_entries
+----
+1
+
+# At this point, inflightSize is 13, the totalSize is 4. The compression ratio
+# is 1. So, the returned size should be 17.
 add_inflight 8
 ----
 17
 
 # One entry has been written.
-num_entries
+num_written_entries
 ----
 1
 
-# The inflight entry had a size of 5, but the entry added had a size of 3 because of compression/size estimation.
-# The compression ratio is 0.77 at this point. The inflightSize is 8. The true size is 13.16, but the maxEstimatedSize
-# is returned.
+# The inflight entry had a size of 5, but the entry added had a size of 3 because
+# of compression/size estimation. The compression ratio is 0.77 at this point.
+# The inflightSize is 8. The true size is 13.16, but the maxEstimatedSize is
+# returned.
 entry_written 7 5 3 
 ----
 17
@@ -69,7 +107,27 @@ entry_written 11 8 4
 ----
 17
 
-# The compression ratio is 0.64, and the inflight size is 20, 20*0.64 = 12.8, so the total size is uint64(12.8 + 11)
+num_written_entries
+----
+3
+
+# The compression ratio is 0.64, and the inflight size is 20, 20*0.64 = 12.8,
+# so the total size is uint64(12.8 + 11)
 add_inflight 20
 ----
 23
+
+num_inflight_entries
+----
+1
+
+# We can write an entry, but not it might not have an inflightSize, because it
+# was never inflight. In such a case, the numInflightEntries, shouldn't be
+# decreased.
+entry_written 11 0 4
+----
+28
+
+num_inflight_entries
+----
+1

--- a/sstable/write_queue.go
+++ b/sstable/write_queue.go
@@ -100,7 +100,6 @@ func (w *writeQueue) runWorker() {
 	w.wg.Done()
 }
 
-//lint:ignore U1000 - Will be used in a future pr.
 func (w *writeQueue) add(task *writeTask) {
 	w.tasks <- task
 }

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -262,25 +262,33 @@ func (c *coordinationState) init(parallelismEnabled bool, writer *Writer) {
 }
 
 type sizeEstimate struct {
-	// emptySize is the size when there is no inflight data, and numEntries is 0. emptySize is constant once set.
+	// emptySize is the size when there is no inflight data, and numEntries is 0.
+	// emptySize is constant once set.
 	emptySize uint64
 
-	// inflightSize is the estimated size of some inflight data which hasn't been written yet.
+	// inflightSize is the estimated size of some inflight data which hasn't been
+	// written yet.
 	inflightSize uint64
 
 	// totalSize is the total size of the data which has already been written.
 	totalSize uint64
 
-	// numEntries is the total number of entries which have already been written.
-	numEntries uint64
+	// numWrittenEntries is the total number of entries which have already been written.
+	numWrittenEntries uint64
+	// numInflightEntries is the total number of entries which are inflight, and
+	// haven't been written.
+	numInflightEntries uint64
 
-	// maxEstimatedSize stores the maximum result returned from sizeEstimate.size. It ensures that values returned
-	// from subsequent calls to Writer.EstimatedSize never decrease.
+	// maxEstimatedSize stores the maximum result returned from sizeEstimate.size.
+	// It ensures that values returned from subsequent calls to
+	// Writer.EstimatedSize never decrease.
 	maxEstimatedSize uint64
 
-	// We assume that the entries added to the sizeEstimate can be compressed. For this reason, we keep track of a
-	// compressedSize and an uncompressedSize to compute a compression ratio for the inflight entries. If the entries
-	// aren't being compressed, then compressedSize and uncompressedSize must be equal.
+	// We assume that the entries added to the sizeEstimate can be compressed.
+	// For this reason, we keep track of a compressedSize and an uncompressedSize
+	// to compute a compression ratio for the inflight entries. If the entries
+	// aren't being compressed, then compressedSize and uncompressedSize must be
+	// equal.
 	compressedSize   uint64
 	uncompressedSize uint64
 }
@@ -310,12 +318,19 @@ func (s *sizeEstimate) size() uint64 {
 }
 
 func (s *sizeEstimate) addInflight(size int) {
+	s.numInflightEntries++
 	s.inflightSize += uint64(size)
 }
 
 func (s *sizeEstimate) written(newTotalSize uint64, inflightSize int, finalEntrySize int) {
 	s.inflightSize -= uint64(inflightSize)
-	s.numEntries++
+
+	if inflightSize > 0 {
+		// This entry was previously inflight, so we should decrement inflight
+		// entries.
+		s.numInflightEntries--
+	}
+	s.numWrittenEntries++
 	s.totalSize = newTotalSize
 
 	s.uncompressedSize += uint64(inflightSize)
@@ -323,7 +338,8 @@ func (s *sizeEstimate) written(newTotalSize uint64, inflightSize int, finalEntry
 }
 
 func (s *sizeEstimate) clear() {
-	s.numEntries = 0
+	s.numWrittenEntries = 0
+	s.numInflightEntries = 0
 	s.inflightSize = 0
 	s.maxEstimatedSize = 0
 	s.totalSize = 0
@@ -363,15 +379,18 @@ func newIndexBlockBuf(useMutex bool) *indexBlockBuf {
 	return i
 }
 
-func (i *indexBlockBuf) shouldFlush(sep InternalKey, valueLen, targetBlockSize, sizeThreshold int) bool {
+func (i *indexBlockBuf) shouldFlush(
+	sep InternalKey, valueLen, targetBlockSize, sizeThreshold int,
+) bool {
 	if i.size.useMutex {
 		i.size.mu.Lock()
 		defer i.size.mu.Unlock()
 	}
 
+	nEntries := i.size.estimate.numWrittenEntries + i.size.estimate.numInflightEntries
 	return shouldFlush(
 		sep, valueLen, i.restartInterval, int(i.size.estimate.size()),
-		int(i.size.estimate.numEntries), targetBlockSize, sizeThreshold)
+		int(nEntries), targetBlockSize, sizeThreshold)
 }
 
 func (i *indexBlockBuf) add(key InternalKey, value []byte, inflightSize int) {

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -224,8 +224,12 @@ func TestSizeEstimate(t *testing.T) {
 				}
 				sizeEstimate.written(uint64(newSize), inflightSize, entrySize)
 				return fmt.Sprintf("%d", sizeEstimate.size())
+			case "num_written_entries":
+				return fmt.Sprintf("%d", sizeEstimate.numWrittenEntries)
+			case "num_inflight_entries":
+				return fmt.Sprintf("%d", sizeEstimate.numInflightEntries)
 			case "num_entries":
-				return fmt.Sprintf("%d", sizeEstimate.numEntries)
+				return fmt.Sprintf("%d", sizeEstimate.numWrittenEntries+sizeEstimate.numInflightEntries)
 			default:
 				return fmt.Sprintf("unknown command: %s", td.Cmd)
 			}

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -89,7 +89,7 @@ zmemtbl         2   512 K
 
 disk-usage
 ----
-3.5 K
+3.6 K
 
 # Closing iter a will release one of the zombie memtables.
 
@@ -185,4 +185,4 @@ zmemtbl         0     0 B
 
 disk-usage
 ----
-2.0 K
+2.1 K


### PR DESCRIPTION
This pr adds some scaffolding to enable parallelism in the sstable writer,
and adds support to the metamorphic tests to generate options which enable
Writer parallelism.