### PR TITLE
tool/logs: various improvements

### DIFF
--- a/tool/logs/compaction_test.go
+++ b/tool/logs/compaction_test.go
@@ -222,7 +222,7 @@ func TestCompactionLogs(t *testing.T) {
 				}
 			}
 
-			a := newAggregator(window, longRunning, c.compactions, c.readAmps)
+			a := newAggregator(window, longRunning, c.events, c.readAmps)
 			windows := a.aggregate()
 
 			var b bytes.Buffer

--- a/tool/logs/testdata/compactions
+++ b/tool/logs/testdata/compactions
@@ -12,19 +12,19 @@ I211215 00:01:20.000000 21136 3@vendor/github.com/cockroachdb/pebble/event.go:60
 summarize
 ----
 node: 1, store: 1
-from: 211215 00:00
-  to: 211215 00:01
-______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
-        L2        L3         1         0         0         0         0         1      13 M       10s
-     total                   1         0         0         0         0         1      13 M        0s
-     r-amp       NaN
+   from: 211215 00:00
+     to: 211215 00:01
+  r-amp: NaN
+_kind______from______to___default____move___elide__delete___total___bytes______time
+compact      L2      L3         1       0       0       0       1    13 M       10s
+total                           1       0       0       0       1    13 M        0s
 node: 1, store: 1
-from: 211215 00:01
-  to: 211215 00:02
-______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
-       WAL        L0         0         0         0         0         1         1     1.0 M       10s
-     total                   0         0         0         0         1         1     1.0 M        0s
-     r-amp       NaN
+   from: 211215 00:01
+     to: 211215 00:02
+  r-amp: NaN
+_kind______from______to_____________________________________count___bytes______time
+flush                L0                                         1   1.0 M       10s
+total                                                               1.0 M
 
 # Same as the previous case, except that the start and end events are are split
 # across multiple files (one log line per file).
@@ -55,19 +55,19 @@ I211215 00:01:20.000000 21136 3@vendor/github.com/cockroachdb/pebble/event.go:60
 summarize
 ----
 node: 1, store: 1
-from: 211215 00:00
-  to: 211215 00:01
-______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
-        L2        L3         1         0         0         0         0         1      13 M       10s
-     total                   1         0         0         0         0         1      13 M        0s
-     r-amp       NaN
+   from: 211215 00:00
+     to: 211215 00:01
+  r-amp: NaN
+_kind______from______to___default____move___elide__delete___total___bytes______time
+compact      L2      L3         1       0       0       0       1    13 M       10s
+total                           1       0       0       0       1    13 M        0s
 node: 1, store: 1
-from: 211215 00:01
-  to: 211215 00:02
-______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
-       WAL        L0         0         0         0         0         1         1     1.0 M       10s
-     total                   0         0         0         0         1         1     1.0 M        0s
-     r-amp       NaN
+   from: 211215 00:01
+     to: 211215 00:02
+  r-amp: NaN
+_kind______from______to_____________________________________count___bytes______time
+flush                L0                                         1   1.0 M       10s
+total                                                               1.0 M
 
 # Read amplification from the Cockroach log, one within an existing window,
 # another outside of the existing window. The latter is not included.
@@ -110,12 +110,12 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
 summarize
 ----
 node: 1, store: 1
-from: 211215 00:00
-  to: 211215 00:01
-______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
-        L2        L3         1         0         0         0         0         1      13 M       10s
-     total                   1         0         0         0         0         1      13 M        0s
-     r-amp       5.0
+   from: 211215 00:00
+     to: 211215 00:01
+  r-amp: 5.0
+_kind______from______to___default____move___elide__delete___total___bytes______time
+compact      L2      L3         1       0       0       0       1    13 M       10s
+total                           1       0       0       0       1    13 M        0s
 
 # Long running compaction.
 
@@ -131,15 +131,15 @@ I211215 00:03:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compacti
 summarize long-running=1m
 ----
 node: 1, store: 1
-from: 211215 00:01
-  to: 211215 00:02
-______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
-        L2        L3         1         0         0         0         0         1      13 M     2m10s
-     total                   1         0         0         0         0         1      13 M      2m0s
-     r-amp       NaN
-long-running compactions (descending runtime):
-______from________to_______job______type_____start_______end____dur(s)_____bytes:
-        L2        L3         1   default  00:01:10  00:03:20       130      13 M
+   from: 211215 00:01
+     to: 211215 00:02
+  r-amp: NaN
+_kind______from______to___default____move___elide__delete___total___bytes______time
+compact      L2      L3         1       0       0       0       1    13 M     2m10s
+total                           1       0       0       0       1    13 M      2m0s
+long-running events (descending runtime):
+_kind________from________to_______job______type_____start_______end____dur(s)_____bytes:
+compact        L2        L3         1   default  00:01:10  00:03:20       130      13 M
 
 # Single node, multiple stores.
 
@@ -158,19 +158,19 @@ I211215 00:01:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compacti
 summarize
 ----
 node: 1, store: 1
-from: 211215 00:01
-  to: 211215 00:02
-______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
-        L2        L3         1         0         0         0         0         1      13 M       10s
-     total                   1         0         0         0         0         1      13 M        0s
-     r-amp       NaN
+   from: 211215 00:01
+     to: 211215 00:02
+  r-amp: NaN
+_kind______from______to___default____move___elide__delete___total___bytes______time
+compact      L2      L3         1       0       0       0       1    13 M       10s
+total                           1       0       0       0       1    13 M        0s
 node: 1, store: 2
-from: 211215 00:01
-  to: 211215 00:02
-______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
-        L3        L4         1         0         0         0         0         1      13 M       10s
-     total                   1         0         0         0         0         1      13 M        0s
-     r-amp       NaN
+   from: 211215 00:01
+     to: 211215 00:02
+  r-amp: NaN
+_kind______from______to___default____move___elide__delete___total___bytes______time
+compact      L3      L4         1       0       0       0       1    13 M       10s
+total                           1       0       0       0       1    13 M        0s
 
 # Multiple nodes, single stores. Two separate pebble logs.
 
@@ -192,19 +192,19 @@ I211215 00:01:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compacti
 summarize
 ----
 node: 1, store: 1
-from: 211215 00:01
-  to: 211215 00:02
-______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
-        L2        L3         1         0         0         0         0         1      13 M       10s
-     total                   1         0         0         0         0         1      13 M        0s
-     r-amp       NaN
+   from: 211215 00:01
+     to: 211215 00:02
+  r-amp: NaN
+_kind______from______to___default____move___elide__delete___total___bytes______time
+compact      L2      L3         1       0       0       0       1    13 M       10s
+total                           1       0       0       0       1    13 M        0s
 node: 2, store: 1
-from: 211215 00:01
-  to: 211215 00:02
-______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
-        L3        L4         1         0         0         0         0         1      13 M       10s
-     total                   1         0         0         0         0         1      13 M        0s
-     r-amp       NaN
+   from: 211215 00:01
+     to: 211215 00:02
+  r-amp: NaN
+_kind______from______to___default____move___elide__delete___total___bytes______time
+compact      L3      L4         1       0       0       0       1    13 M       10s
+total                           1       0       0       0       1    13 M        0s
 
 # Multiple nodes, multiple stores. Two separate pebble logs.
 
@@ -232,33 +232,33 @@ I211215 00:02:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compacti
 summarize
 ----
 node: 1, store: 1
-from: 211215 00:01
-  to: 211215 00:02
-______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
-        L2        L3         1         0         0         0         0         1      13 M       10s
-     total                   1         0         0         0         0         1      13 M        0s
-     r-amp       NaN
+   from: 211215 00:01
+     to: 211215 00:02
+  r-amp: NaN
+_kind______from______to___default____move___elide__delete___total___bytes______time
+compact      L2      L3         1       0       0       0       1    13 M       10s
+total                           1       0       0       0       1    13 M        0s
 node: 1, store: 2
-from: 211215 00:03
-  to: 211215 00:04
-______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
-        L1        L2         1         0         0         0         0         1      13 M       10s
-     total                   1         0         0         0         0         1      13 M        0s
-     r-amp       NaN
+   from: 211215 00:03
+     to: 211215 00:04
+  r-amp: NaN
+_kind______from______to___default____move___elide__delete___total___bytes______time
+compact      L1      L2         1       0       0       0       1    13 M       10s
+total                           1       0       0       0       1    13 M        0s
 node: 2, store: 1
-from: 211215 00:00
-  to: 211215 00:01
-______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
-        L3        L4         1         0         0         0         0         1      13 M       10s
-     total                   1         0         0         0         0         1      13 M        0s
-     r-amp       NaN
+   from: 211215 00:00
+     to: 211215 00:01
+  r-amp: NaN
+_kind______from______to___default____move___elide__delete___total___bytes______time
+compact      L3      L4         1       0       0       0       1    13 M       10s
+total                           1       0       0       0       1    13 M        0s
 node: 2, store: 2
-from: 211215 00:02
-  to: 211215 00:03
-______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
-        L4        L5         1         0         0         0         0         1      13 M       10s
-     total                   1         0         0         0         0         1      13 M        0s
-     r-amp       NaN
+   from: 211215 00:02
+     to: 211215 00:03
+  r-amp: NaN
+_kind______from______to___default____move___elide__delete___total___bytes______time
+compact      L4      L5         1       0       0       0       1    13 M       10s
+total                           1       0       0       0       1    13 M        0s
 
 # Log lines with an absent node / store are aggregated.
 
@@ -289,12 +289,12 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
 summarize
 ----
 node: ?, store: ?
-from: 211215 00:01
-  to: 211215 00:02
-______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
-        L2        L3         1         0         0         0         0         1      13 M       10s
-     total                   1         0         0         0         0         1      13 M        0s
-     r-amp       5.0
+   from: 211215 00:01
+     to: 211215 00:02
+  r-amp: 5.0
+_kind______from______to___default____move___elide__delete___total___bytes______time
+compact      L2      L3         1       0       0       0       1    13 M       10s
+total                           1       0       0       0       1    13 M        0s
 
 # The same Job ID interleaved for multiple nodes / stores.
 
@@ -312,19 +312,19 @@ I211215 00:02:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compacti
 summarize
 ----
 node: 1, store: 1
-from: 211215 00:01
-  to: 211215 00:02
-______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
-        L2        L3         1         0         0         0         0         1      13 M       10s
-     total                   1         0         0         0         0         1      13 M        0s
-     r-amp       NaN
+   from: 211215 00:01
+     to: 211215 00:02
+  r-amp: NaN
+_kind______from______to___default____move___elide__delete___total___bytes______time
+compact      L2      L3         1       0       0       0       1    13 M       10s
+total                           1       0       0       0       1    13 M        0s
 node: 2, store: 2
-from: 211215 00:02
-  to: 211215 00:03
-______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
-        L4        L5         1         0         0         0         0         1      13 M       10s
-     total                   1         0         0         0         0         1      13 M        0s
-     r-amp       NaN
+   from: 211215 00:02
+     to: 211215 00:03
+  r-amp: NaN
+_kind______from______to___default____move___elide__delete___total___bytes______time
+compact      L4      L5         1       0       0       0       1    13 M       10s
+total                           1       0       0       0       1    13 M        0s
 
 # Read amp matching should remain backwards compatible.
 
@@ -368,12 +368,12 @@ I220301 00:00:30.000000 315 kv/kvserver/store.go:2713 ⋮ [n1,s1] 78 + filter   
 summarize
 ----
 node: 1, store: 1
-from: 220301 00:00
-  to: 220301 00:01
-______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
-        L2        L3         1         0         0         0         0         1      13 M       10s
-     total                   1         0         0         0         0         1      13 M        0s
-     r-amp       1.0
+   from: 220301 00:00
+     to: 220301 00:01
+  r-amp: 1.0
+_kind______from______to___default____move___elide__delete___total___bytes______time
+compact      L2      L3         1       0       0       0       1    13 M       10s
+total                           1       0       0       0       1    13 M        0s
 
 reset
 ----
@@ -412,9 +412,36 @@ I220228 14:44:32.138686 18460916022 3@vendor/github.com/cockroachdb/pebble/compa
 summarize
 ----
 node: 24, store: 24
-from: 220228 14:44
-  to: 220228 14:45
-______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
-       WAL        L0         0         0         0         0         1         1      19 M        0s
-     total                   0         0         0         0         1         1      19 M        0s
-     r-amp       NaN
+   from: 220228 14:44
+     to: 220228 14:45
+  r-amp: NaN
+_kind______from______to_____________________________________count___bytes______time
+flush                L0                                         1    19 M        0s
+total                                                                19 M
+
+reset
+----
+
+log
+I220228 16:01:22.487906 18476248525 3@vendor/github.com/cockroachdb/pebble/ingest.go:637 ⋮ [n24,pebble,s24] 33430782  [JOB 10211226] ingested L0:21818678 (1.8 K), L0:21818683 (1.2 K), L0:21818679 (1.6 K), L0:21818680 (1.1 K), L0:21818681 (1.1 K), L0:21818682 (160 M)
+45127:I220228 15:58:45.538681 18475981755 3@vendor/github.com/cockroachdb/pebble/ingest.go:637 ⋮ [n24,pebble,s24] 33424719  [JOB 10210743] ingested L0:21814543 (1.4 K), L0:21814548 (1.2 K), L5:21814544 (1.4 K), L5:21814545 (1.1 K), L5:21814546 (1.1 K), L0:21814547 (140 M)
+----
+0.log
+
+summarize
+----
+node: 24, store: 24
+   from: 220228 15:58
+     to: 220228 15:59
+  r-amp: NaN
+_kind______from______to_____________________________________count___bytes______time
+ingest               L0                                         9   140 M
+ingest               L5                                         3   3.0 K
+total                                                               140 M
+node: 24, store: 24
+   from: 220228 16:01
+     to: 220228 16:02
+  r-amp: NaN
+_kind______from______to_____________________________________count___bytes______time
+ingest               L0                                        12   160 M
+total                                                               160 M

--- a/tool/logs/testdata/compactions
+++ b/tool/logs/testdata/compactions
@@ -374,3 +374,47 @@ ______from________to___default______move_____elide____delete_____flush_____total
         L2        L3         1         0         0         0         0         1      13 M       10s
      total                   1         0         0         0         0         1      13 M        0s
      r-amp       1.0
+
+reset
+----
+
+log
+I220228 14:44:31.497272 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1366 ⋮ [n24,pebble,s24] 33267888  [JOB 10197855] flushing 1 memtable to L0
+I220228 14:44:31.497485 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267889  [JOB 10197855] flushing: sstable created 21731018
+I220228 14:44:31.527038 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267892  [JOB 10197855] flushing: sstable created 21731020
+I220228 14:44:31.542944 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267894  [JOB 10197855] flushing: sstable created 21731021
+I220228 14:44:31.553581 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267895  [JOB 10197855] flushing: sstable created 21731022
+I220228 14:44:31.554585 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267896  [JOB 10197855] flushing: sstable created 21731023
+I220228 14:44:31.569928 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267897  [JOB 10197855] flushing: sstable created 21731024
+I220228 14:44:31.624309 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267899  [JOB 10197855] flushing: sstable created 21731025
+I220228 14:44:31.685531 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267901  [JOB 10197855] flushing: sstable created 21731026
+I220228 14:44:31.686009 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267902  [JOB 10197855] flushing: sstable created 21731027
+I220228 14:44:31.686415 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267903  [JOB 10197855] flushing: sstable created 21731028
+I220228 14:44:31.780892 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267906  [JOB 10197855] flushing: sstable created 21731030
+I220228 14:44:31.790911 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267907  [JOB 10197855] flushing: sstable created 21731031
+I220228 14:44:31.904614 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267911  [JOB 10197855] flushing: sstable created 21731033
+I220228 14:44:31.905835 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267912  [JOB 10197855] flushing: sstable created 21731034
+I220228 14:44:31.906860 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267913  [JOB 10197855] flushing: sstable created 21731035
+I220228 14:44:31.907602 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267914  [JOB 10197855] flushing: sstable created 21731036
+I220228 14:44:32.019173 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267920  [JOB 10197855] flushing: sstable created 21731037
+I220228 14:44:32.019714 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267921  [JOB 10197855] flushing: sstable created 21731038
+I220228 14:44:32.020161 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267922  [JOB 10197855] flushing: sstable created 21731039
+I220228 14:44:32.100117 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267925  [JOB 10197855] flushing: sstable created 21731040
+I220228 14:44:32.100609 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267926  [JOB 10197855] flushing: sstable created 21731041
+I220228 14:44:32.101065 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267927  [JOB 10197855] flushing: sstable created 21731042
+I220228 14:44:32.101494 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267928  [JOB 10197855] flushing: sstable created 21731043
+I220228 14:44:32.102569 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267929  [JOB 10197855] flushing: sstable created 21731044
+I220228 14:44:32.106284 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1985 ⋮ [n24,pebble,s24] 33267930  [JOB 10197855] flushing: sstable created 21731045
+I220228 14:44:32.138686 18460916022 3@vendor/github.com/cockroachdb/pebble/compaction.go:1423 ⋮ [n24,pebble,s24] 33267931  [JOB 10197855] flushed 1 memtable to L0 [21731018 21731020 21731021 21731022 21731023 21731024 21731025 21731026 21731027 21731028 21731030 21731031 21731033 21731034 21731035 21731036 21731037 21731038 21731039 21731040 21731041 21731042 21731043 21731044 21731045] (19 M), in 0.6s, output rate 31 M/s
+----
+0.log
+
+summarize
+----
+node: 24, store: 24
+from: 220228 14:44
+  to: 220228 14:45
+______from________to___default______move_____elide____delete_____flush_____total_____bytes______time
+       WAL        L0         0         0         0         0         1         1      19 M        0s
+     total                   0         0         0         0         1         1      19 M        0s
+     r-amp       NaN


### PR DESCRIPTION
**tool/logs: fix single memtable flushes**

This commit adds a few additional adjustments to the compaction log
tool.

1. Previously, single memtable flushes were not picked up because the
   regular expression required plural "memtables".
2. To make mistakes like the above more detectable, simplify the
   'sentinel' regular expression to be less prescriptive.
3. Previously a truncated log line would stop log analyzing with an
   error. These log lines are possible if a process exits ungracefully
   before it's able to fully flush the log buffer. Parsing errors are
   now accumulated and logged to stderr (so that they may also be
   ignored by being redirected to /dev/null) at the end.
   
**tool/logs: add ingested events, reorganize output**

Add support for parsing out ingested sstable events. Lift these new
ingested events and flushes into a separate table. This is intended to
help while investigating read-amplification issues by making it easy to
compare totals of data entering the LSM to totals of data descending the
LSM in compactions. If L0 is growing, totals flushed and ingested into
L0 will exceed totals compacted out of L0.

```
node: 24, store: 24
   from: 220228 15:10
     to: 220228 15:20
  r-amp: NaN
_kind______from______to_____________________________________count___bytes______time
flush                L0                                       222   3.5 G     4m29s
ingest               L0                                       774   7.4 G
ingest               L1                                         3   3.0 K
ingest               L2                                         3   3.0 K
ingest               L3                                        39    39 K
ingest               L4                                        43   556 M
ingest               L5                                       213   398 M
ingest               L6                                         5   822 M
total                                                                13 G
_kind______from______to___default____move___elide__delete___total___bytes______time
compact      L0      L0         4       0       0       0       4   447 M       41s
compact      L0      L1        42       0       0       0      42    12 G     22m7s
compact      L1      L2       182     200       0       0     382   2.9 G      3m7s
compact      L2      L2         0       0       0       1       1     0 B        0s
compact      L2      L3       122      30       0       0     152   2.8 G      4m9s
compact      L3      L3         0       0       0       1       1     0 B        0s
compact      L3      L4        19      12       0       0      31   637 M      1m0s
compact      L4      L4         0       0       0      11      11     0 B        0s
compact      L6      L6         0       0       0       1       1     0 B        0s
total                         369     242       0      14     625    19 G     31m0s
```
