### PR TITLE
sstable: circumvent a dataBlockBuf race in the sstable Writer

### DIFF
--- a/sstable/write_queue.go
+++ b/sstable/write_queue.go
@@ -74,7 +74,6 @@ func (w *writeQueue) performWrite(task *writeTask) error {
 }
 
 func (w *writeQueue) releaseBuffers(task *writeTask) {
-	dataBlockBufPool.Put(task.buf)
 	task.buf = nil
 
 	// This index block is no longer used by the Writer, so we can add it back to the pool.

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -229,7 +229,7 @@ type Writer struct {
 	rkBuf      []byte
 	// dataBlockBuf consists of the state which is currently owned by and used by
 	// the Writer client goroutine. This state can be handed off to other goroutines.
-	dataBlockBuf *dataBlockBuf
+	dataBlockBuf dataBlockBuf
 	// blockBuf consists of the state which is owned by and used by the Writer client
 	// goroutine.
 	blockBuf blockBuf
@@ -512,17 +512,9 @@ type dataBlockBuf struct {
 	sepScratch []byte
 }
 
-var dataBlockBufPool = sync.Pool{
-	New: func() interface{} {
-		return &dataBlockBuf{}
-	},
-}
-
-func newDataBlockBuf(restartInterval int, checksumType ChecksumType) *dataBlockBuf {
-	d := dataBlockBufPool.Get().(*dataBlockBuf)
+func (d *dataBlockBuf) init(restartInterval int, checksumType ChecksumType) {
 	d.dataBlock.restartInterval = restartInterval
 	d.checksummer.checksumType = checksumType
-	return d
 }
 
 func (d *dataBlockBuf) finish() {
@@ -1050,7 +1042,7 @@ func (w *Writer) flush(key InternalKey) error {
 	var err error
 
 	// We're finishing a data block.
-	err = w.finishDataBlockProps(w.dataBlockBuf)
+	err = w.finishDataBlockProps(&w.dataBlockBuf)
 	if err != nil {
 		return err
 	}
@@ -1060,7 +1052,7 @@ func (w *Writer) flush(key InternalKey) error {
 
 	// Determine if the index block should be flushed.
 	prevKey := base.DecodeInternalKey(w.dataBlockBuf.dataBlock.curKey)
-	sep := w.indexEntrySep(prevKey, key, w.dataBlockBuf)
+	sep := w.indexEntrySep(prevKey, key, &w.dataBlockBuf)
 	// We determine that we should flush an index block from the Writer client goroutine, but
 	// we actually finish the index block from the writeQueue. When we determine that an index
 	// block should be flushed, we need to call BlockPropertyCollector.FinishIndexBlock. But
@@ -1091,7 +1083,7 @@ func (w *Writer) flush(key InternalKey) error {
 	// We're setting compressionDone to indicate that compression of this block
 	// has already been completed.
 	writeTask.compressionDone <- true
-	writeTask.buf = w.dataBlockBuf
+	writeTask.buf = &w.dataBlockBuf
 	writeTask.indexEntrySep = sep
 	writeTask.inflightSize = estimatedUncompressedSize
 	writeTask.currIndexBlock = w.indexBlock
@@ -1102,9 +1094,7 @@ func (w *Writer) flush(key InternalKey) error {
 	// The writeTask corresponds to an unwritten index entry.
 	w.indexBlock.addInflight(writeTask.indexInflightSize)
 
-	w.dataBlockBuf = nil
 	err = w.coordination.writeQueue.addSync(writeTask)
-	w.dataBlockBuf = newDataBlockBuf(w.restartInterval, w.checksumType)
 
 	return err
 }
@@ -1154,7 +1144,7 @@ func (w *Writer) finishDataBlockProps(buf *dataBlockBuf) error {
 func (w *Writer) maybeAddBlockPropertiesToBlockHandle(
 	bh BlockHandle,
 ) (BlockHandleWithProperties, error) {
-	err := w.finishDataBlockProps(w.dataBlockBuf)
+	err := w.finishDataBlockProps(&w.dataBlockBuf)
 	if err != nil {
 		return BlockHandleWithProperties{}, err
 	}
@@ -1215,7 +1205,7 @@ func (w *Writer) addPrevDataBlockToIndexBlockProps() {
 // called synchronously once Writer.Close is called. addIndexEntrySync should only be called if we're sure that
 // index entries aren't being written asynchronously.
 func (w *Writer) addIndexEntrySync(prevKey, key InternalKey, bhp BlockHandleWithProperties, tmp []byte) error {
-	sep := w.indexEntrySep(prevKey, key, w.dataBlockBuf)
+	sep := w.indexEntrySep(prevKey, key, &w.dataBlockBuf)
 	shouldFlush := supportsTwoLevelIndex(
 		w.tableFormat) && w.indexBlock.shouldFlush(
 		sep, encodedBHPEstimatedSize, w.indexBlockSize, w.indexBlockSizeThreshold,
@@ -1794,7 +1784,7 @@ func NewWriter(f writeCloseSyncer, o WriterOptions, extraOpts ...WriterOption) *
 		coalescer: rangekey.Coalescer{},
 	}
 
-	w.dataBlockBuf = newDataBlockBuf(w.restartInterval, w.checksumType)
+	w.dataBlockBuf.init(w.restartInterval, w.checksumType)
 
 	w.blockBuf = blockBuf{
 		checksummer: checksummer{checksumType: o.Checksum},


### PR DESCRIPTION
Previously, in the addPoint function, we would store a reference to w.dataBlockBuf.dataBlock.curKey
in the Writer.meta.

```
	k := base.InternalKey{
		// block.curKey contains the most recently added key to the block.
		UserKey: w.dataBlockBuf.dataBlock.curKey[:len(w.dataBlockBuf.dataBlock.curKey)-8],
		Trailer: key.Trailer,
	}
	w.meta.SetLargestPointKey(w.compare, k)
```
This slice is owned by the dataBlockBuf, which can be added back to the sync.Pool, and re-used by
another compaction/flush.

For now, we use a single dataBlockBuf in the Writer, to get rid of this race.

Fixes: https://github.com/cockroachdb/cockroach/issues/77194, https://github.com/cockroachdb/cockroach/issues/77189