### PR TITLE
internal/manifest: add debug string with all table bounds

### DIFF
--- a/internal/manifest/testdata/file_metadata_bounds
+++ b/internal/manifest/testdata/file_metadata_bounds
@@ -3,8 +3,9 @@
 extend-point-key-bounds
 a.SET.0 - z.DEL.42
 ----
-combined: [a#0,1-z#42,0]
-  points: [a#0,1-z#42,0]
+000000:
+  combined: a#0,1-z#42,0
+    points: a#0,1-z#42,0
 
 # Rangedels only (single update).
 
@@ -14,8 +15,9 @@ reset
 extend-point-key-bounds
 a.RANGEDEL.0:z
 ----
-combined: [a#0,15-z#72057594037927935,15]
-  points: [a#0,15-z#72057594037927935,15]
+000000:
+  combined: a#0,15-z#72057594037927935,15
+    points: a#0,15-z#72057594037927935,15
 
 # Range keys only (single update).
 
@@ -25,8 +27,9 @@ reset
 extend-range-key-bounds
 a.RANGEKEYSET.0:z
 ----
-combined: [a#0,21-z#72057594037927935,21]
-  ranges: [a#0,21-z#72057594037927935,21]
+000000:
+  combined: a#0,21-z#72057594037927935,21
+    ranges: a#0,21-z#72057594037927935,21
 
 # Multiple updates with various key kinds.
 
@@ -36,33 +39,37 @@ reset
 extend-point-key-bounds
 m.SET.0 - n.SET.0
 ----
-combined: [m#0,1-n#0,1]
-  points: [m#0,1-n#0,1]
+000000:
+  combined: m#0,1-n#0,1
+    points: m#0,1-n#0,1
 
 # Extend the lower point key bound.
 
 extend-point-key-bounds
 j.SET.0 - k.SET.0
 ----
-combined: [j#0,1-n#0,1]
-  points: [j#0,1-n#0,1]
+000000:
+  combined: j#0,1-n#0,1
+    points: j#0,1-n#0,1
 
 # Extend the upper point key bound with a rangedel.
 
 extend-point-key-bounds
 k.RANGEDEL.0:o
 ----
-combined: [j#0,1-o#72057594037927935,15]
-  points: [j#0,1-o#72057594037927935,15]
+000000:
+  combined: j#0,1-o#72057594037927935,15
+    points: j#0,1-o#72057594037927935,15
 
 # Extend the lower bounds bound with a range key.
 
 extend-range-key-bounds
 a.RANGEKEYSET.42:m
 ----
-combined: [a#42,21-o#72057594037927935,15]
-  points: [j#0,1-o#72057594037927935,15]
-  ranges: [a#42,21-m#72057594037927935,21]
+000000:
+  combined: a#42,21-o#72057594037927935,15
+    points: j#0,1-o#72057594037927935,15
+    ranges: a#42,21-m#72057594037927935,21
 
 # Extend again with a wide range key (equal keys tiebreak on seqnums descending,
 # so the overall lower bound is unchanged).
@@ -70,9 +77,10 @@ combined: [a#42,21-o#72057594037927935,15]
 extend-range-key-bounds
 a.RANGEKEYSET.0:z
 ----
-combined: [a#42,21-z#72057594037927935,21]
-  points: [j#0,1-o#72057594037927935,15]
-  ranges: [a#42,21-z#72057594037927935,21]
+000000:
+  combined: a#42,21-z#72057594037927935,21
+    points: j#0,1-o#72057594037927935,15
+    ranges: a#42,21-z#72057594037927935,21
 
 # Extend again with a wide rangedel over the same range (equal keys and sequnums
 # tiebreak on key kind descending, so the overall upper bound is updated).
@@ -80,6 +88,7 @@ combined: [a#42,21-z#72057594037927935,21]
 extend-point-key-bounds
 a.RANGEDEL.0:z
 ----
-combined: [a#42,21-z#72057594037927935,15]
-  points: [a#0,15-z#72057594037927935,15]
-  ranges: [a#42,21-z#72057594037927935,21]
+000000:
+  combined: a#42,21-z#72057594037927935,15
+    points: a#0,15-z#72057594037927935,15
+    ranges: a#42,21-z#72057594037927935,21

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -221,8 +221,26 @@ func (m *FileMetadata) extendOverallBounds(cmp Compare, smallest, largest Intern
 	}
 }
 
+// String implements fmt.Stringer, printing the file number and the overall
+// table bounds.
 func (m *FileMetadata) String() string {
 	return fmt.Sprintf("%s:%s-%s", m.FileNum, m.Smallest, m.Largest)
+}
+
+// DebugString returns a verbose representation of FileMetadata, typically for
+// use in tests and debugging, returning the file number and the point, range
+// and overall bounds for the table.
+func (m *FileMetadata) DebugString() string {
+	var b bytes.Buffer
+	b.WriteString(fmt.Sprintf("%s:\n", m.FileNum.String()))
+	b.WriteString(fmt.Sprintf("  combined: %s-%s", m.Smallest, m.Largest))
+	if m.HasPointKeys {
+		b.WriteString(fmt.Sprintf("\n    points: %s-%s", m.SmallestPointKey, m.LargestPointKey))
+	}
+	if m.HasRangeKeys {
+		b.WriteString(fmt.Sprintf("\n    ranges: %s-%s", m.SmallestRangeKey, m.LargestRangeKey))
+	}
+	return b.String()
 }
 
 // Validate validates the metadata for consistency with itself, returning an


### PR DESCRIPTION
Currently, `manifest.(*FileMetadata).String()` prints the overall bounds
for the table. With the addition of range keys, there are situations
where the caller is interested in printing all bounds for the table -
points, ranges and the overall table bounds.

Add the `DebugString()` method, as a more verbose alternative to
`String()` that will print the file number followed by the overall
bounds, then the point and range key bounds (depending on which key
kinds are present in the table).

Update an existing test to make use of this new method.