### PR TITLE
sstable: document and confirm ownership invariants in the Writer

### DIFF
--- a/sstable/write_queue.go
+++ b/sstable/write_queue.go
@@ -2,6 +2,8 @@ package sstable
 
 import (
 	"sync"
+
+	"github.com/cockroachdb/pebble/internal/base"
 )
 
 type writeTask struct {
@@ -73,16 +75,19 @@ func (w *writeQueue) performWrite(task *writeTask) error {
 	return nil
 }
 
+// It is necessary to ensure that none of the buffers in the writeTask,
+// dataBlockBuf, indexBlockBuf, are pointed to by another struct.
 func (w *writeQueue) releaseBuffers(task *writeTask) {
-	task.buf = nil
-
-	// This index block is no longer used by the Writer, so we can add it back to the pool.
+	// This index block is no longer used by the Writer, so we can add it back
+	// to the pool.
 	if task.flushableIndexBlock != nil {
 		indexBlockBufPool.Put(task.flushableIndexBlock)
-		task.flushableIndexBlock = nil
 	}
-	task.currIndexBlock = nil
 
+	*task = writeTask{
+		indexEntrySep:   base.InvalidInternalKey,
+		compressionDone: task.compressionDone,
+	}
 	writeTaskPool.Put(task)
 }
 

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -315,7 +315,7 @@ func (s *sizeEstimate) clear() {
 }
 
 type indexBlockBuf struct {
-	// block will only be accessed from the writeQueue goroutine.
+	// block will only be accessed from the writeQueue.
 	block blockWriter
 
 	size struct {
@@ -1050,7 +1050,12 @@ func (w *Writer) flush(key InternalKey) error {
 	w.dataBlockBuf.finish()
 	w.dataBlockBuf.compressAndChecksum(w.compression)
 
-	// Determine if the index block should be flushed.
+	// Determine if the index block should be flushed. Since we're accessing the
+	// dataBlockBuf.dataBlock.curKey here, we have to make sure that once we start
+	// to pool the dataBlockBufs, the curKey isn't used by the Writer once the
+	// dataBlockBuf is added back to a sync.Pool. In this particular case, the
+	// byte slice which supports "sep" will eventually be copied when "sep" is
+	// added to the index block.
 	prevKey := base.DecodeInternalKey(w.dataBlockBuf.dataBlock.curKey)
 	sep := w.indexEntrySep(prevKey, key, &w.dataBlockBuf)
 	// We determine that we should flush an index block from the Writer client goroutine, but
@@ -1166,9 +1171,15 @@ func (w *Writer) indexEntrySep(prevKey, key InternalKey, dataBlockBuf *dataBlock
 	return sep
 }
 
-// addIndexEntry adds an index entry for the specified key and block handle. addIndexEntry can be called from
-// both the Writer client goroutine, and the writeQueue goroutine. If the flushIndexBuf != nil, then the
-// indexProps, as they're used when the index block is finished.
+// addIndexEntry adds an index entry for the specified key and block handle.
+// addIndexEntry can be called from both the Writer client goroutine, and the
+// writeQueue goroutine. If the flushIndexBuf != nil, then the indexProps, as
+// they're used when the index block is finished.
+//
+// Invariant:
+// 1. addIndexEntry must not store references to the sep InternalKey, the tmp
+//    byte slice, bhp.Props. That is, these must be either deep copied or
+//    encoded.
 func (w *Writer) addIndexEntry(
 	sep InternalKey, bhp BlockHandleWithProperties, tmp []byte,
 	flushIndexBuf *indexBlockBuf, writeTo *indexBlockBuf, inflightSize int, indexProps []byte) error {
@@ -1201,10 +1212,16 @@ func (w *Writer) addPrevDataBlockToIndexBlockProps() {
 	}
 }
 
-// addIndexEntrySync adds an index entry for the specified key and block handle. Writer.addIndexEntry is only
-// called synchronously once Writer.Close is called. addIndexEntrySync should only be called if we're sure that
-// index entries aren't being written asynchronously.
-func (w *Writer) addIndexEntrySync(prevKey, key InternalKey, bhp BlockHandleWithProperties, tmp []byte) error {
+// addIndexEntrySync adds an index entry for the specified key and block handle.
+// Writer.addIndexEntry is only called synchronously once Writer.Close is called.
+// addIndexEntrySync should only be called if we're sure that index entries
+// aren't being written asynchronously.
+//
+// Invariant:
+// 1. addIndexEntry must not store references to the prevKey, key InternalKey's,
+//    the tmp byte slice. That is, these must be either deep copied or encoded.
+func (w *Writer) addIndexEntrySync(
+	prevKey, key InternalKey, bhp BlockHandleWithProperties, tmp []byte) error {
 	sep := w.indexEntrySep(prevKey, key, &w.dataBlockBuf)
 	shouldFlush := supportsTwoLevelIndex(
 		w.tableFormat) && w.indexBlock.shouldFlush(
@@ -1272,6 +1289,12 @@ func cloneKeyWithBuf(k InternalKey, buf []byte) ([]byte, InternalKey) {
 	return buf[n:], InternalKey{UserKey: buf[:n:n], Trailer: k.Trailer}
 }
 
+// Invariants: The byte slice returned by finishIndexBlockProps is heap-allocated
+//  and has its own lifetime, independent of the Writer and the blockPropsEncoder,
+// and it is safe to:
+// 1. Reuse w.blockPropsEncoder without first encoding the byte slice returned.
+// 2. Store the byte slice in the Writer since it is a copy and not supported by
+//    an underlying buffer.
 func (w *Writer) finishIndexBlockProps() ([]byte, error) {
 	w.blockPropsEncoder.resetProps()
 	for i := range w.blockPropCollectors {
@@ -1289,6 +1312,13 @@ func (w *Writer) finishIndexBlockProps() ([]byte, error) {
 
 // finishIndexBlock finishes the current index block and adds it to the top
 // level index block. This is only used when two level indexes are enabled.
+//
+// Invariants:
+// 1. The props slice passed into finishedIndexBlock must not be a
+//    owned by any other struct, since it will be stored in the Writer.indexPartitions
+//    slice.
+// 2. None of the buffers owned by indexBuf will be shallow copied and stored elsewhere.
+//    That is, it must be safe to reuse indexBuf after finishIndexBlock has been called.
 func (w *Writer) finishIndexBlock(indexBuf *indexBlockBuf, props []byte) error {
 	part := indexBlockAndBlockProperties{
 		nEntries: indexBuf.block.nEntries, properties: props,


### PR DESCRIPTION
As part of this pr, we documented some invariants which must be maintained in the Writer,
and also swept through the code to ensure that the documented invariants are met.

There is also a minor cleanup of the writeQueue.releaseBuffers function