### PR TITLE
internal/manifest: refactor TestCheckOrdering to use ParseVersionDebug

### DIFF
--- a/internal/manifest/testdata/version_check_ordering
+++ b/internal/manifest/testdata/version_check_ordering
@@ -1,20 +1,24 @@
+# Note: when specifying test cases with tables in L0, the L0 files should be
+# specified in seqnum descending order, as the test case input is parsed as the
+# inverse of `(*FileMetadata).DebugString`.
+
 check-ordering
-L0
-  a.SET.1-b.SET.2
+0:
+  000001:[a#1,SET-b#2,SET]
 ----
 OK
 
 check-ordering
-L0
-  a.SET.1-b.SET.2
-  c.SET.3-d.SET.4
+0:
+  000002:[c#3,SET-d#4,SET]
+  000001:[a#1,SET-b#2,SET]
 ----
 OK
 
 check-ordering
-L0
-  c.SET.3-d.SET.4
-  a.SET.1-b.SET.2
+0:
+  000002:[a#1,SET-b#2,SET]
+  000001:[c#3,SET-d#4,SET]
 ----
 L0 files 000001 and 000002 are not properly ordered: <#3-#4> vs <#1-#2>
 0.0:
@@ -22,56 +26,56 @@ L0 files 000001 and 000002 are not properly ordered: <#3-#4> vs <#1-#2>
   000001:[c#3,SET-d#4,SET]
 
 check-ordering
-L0
-  c.SET.3-d.SET.4
-  a.SET.1-b.SET.5
-  e.SET.2-f.SET.7
-  g.SET.6-h.SET.12
-  i.SET.8-j.SET.13
-  b.SET.15-d.SET.15
-  a.SET.14-j.SET.17
-  k.SET.16-n.SET.19
+0:
+  000008:[k#16,SET-n#19,SET]
+  000007:[a#14,SET-j#17,SET]
+  000006:[b#15,SET-d#15,SET]
+  000005:[i#8,SET-j#13,SET]
+  000004:[g#6,SET-h#12,SET]
+  000003:[e#2,SET-f#7,SET]
+  000002:[a#1,SET-b#5,SET]
+  000001:[c#3,SET-d#4,SET]
 ----
 OK
 
 # Add some ingested SSTables around the 14-19 seqnum cases.
 check-ordering
-L0
-  c.SET.3-d.SET.4
-  a.SET.1-b.SET.5
-  e.SET.2-f.SET.7
-  g.SET.6-h.SET.12
-  i.SET.8-j.SET.13
-  b.SET.15-d.SET.15
-  a.SET.14-j.SET.17
-  m.SET.18-n.SET.18
-  k.SET.16-n.SET.19
-  m.SET.20-n.SET.20
+0:
+  000010:[m#20,SET-n#20,SET]
+  000009:[k#16,SET-n#19,SET]
+  000008:[m#18,SET-n#18,SET]
+  000007:[a#14,SET-j#17,SET]
+  000006:[b#15,SET-d#15,SET]
+  000005:[i#8,SET-j#13,SET]
+  000004:[g#6,SET-h#12,SET]
+  000003:[e#2,SET-f#7,SET]
+  000002:[a#1,SET-b#5,SET]
+  000001:[c#3,SET-d#4,SET]
 ----
 OK
 
 # Coincident sequence numbers around sstables with overlapping sequence numbers
 # are possible due to flush splitting, so this is acceptable.
 check-ordering
-L0
-  c.SET.3-d.SET.4
-  a.SET.1-b.SET.5
-  e.SET.2-f.SET.7
-  g.SET.6-h.SET.12
-  i.SET.8-j.SET.13
-  b.SET.15-d.SET.15
-  a.SET.15-j.SET.17
-  m.SET.18-n.SET.18
-  k.SET.16-n.SET.19
-  m.SET.20-n.SET.20
+0:
+  000010:[m#20,SET-n#20,SET]
+  000009:[k#16,SET-n#19,SET]
+  000008:[m#18,SET-n#18,SET]
+  000007:[a#15,SET-j#17,SET]
+  000006:[b#15,SET-d#15,SET]
+  000005:[i#8,SET-j#13,SET]
+  000004:[g#6,SET-h#12,SET]
+  000003:[e#2,SET-f#7,SET]
+  000002:[a#1,SET-b#5,SET]
+  000001:[c#3,SET-d#4,SET]
 ----
 OK
 
 # Ensure that sstables passed in a non-sorted order are detected.
 check-ordering
-L0
-  a.SET.3-d.SET.3
-  a.SET.1-b.SET.2
+0:
+  000002:[a#1,SET-b#2,SET]
+  000001:[a#3,SET-d#3,SET]
 ----
 L0 files 000001 and 000002 are not properly ordered: <#3-#3> vs <#1-#2>
 0.1:
@@ -80,9 +84,9 @@ L0 files 000001 and 000002 are not properly ordered: <#3-#3> vs <#1-#2>
   000001:[a#3,SET-d#3,SET]
 
 check-ordering
-L0
-  a.SET.2-d.SET.4
-  a.SET.3-b.SET.3
+0:
+  000002:[a#3,SET-b#3,SET]
+  000001:[a#2,SET-d#4,SET]
 ----
 L0 files 000001 and 000002 are not properly ordered: <#2-#4> vs <#3-#3>
 0.1:
@@ -91,74 +95,74 @@ L0 files 000001 and 000002 are not properly ordered: <#2-#4> vs <#3-#3>
   000001:[a#2,SET-d#4,SET]
 
 check-ordering
-L0
-  a.SET.3-d.SET.3
-  a.SET.3-b.SET.3
+0:
+  000002:[a#3,SET-b#3,SET]
+  000001:[a#3,SET-d#3,SET]
 ----
 OK
 
 check-ordering
-L0
-  a.SET.3-d.SET.3
-  a.SET.3-d.SET.5
+0:
+  000002:[a#3,SET-d#5,SET]
+  000001:[a#3,SET-d#3,SET]
 ----
 OK
 
 check-ordering
-L0
-  a.SET.4-d.SET.4
-  a.SET.3-d.SET.5
+0:
+  000002:[a#3,SET-d#5,SET]
+  000001:[a#4,SET-d#4,SET]
 ----
 OK
 
 check-ordering
-L0
-  a.SET.3-d.SET.5
-  a.SET.5-d.SET.5
+0:
+  000002:[a#5,SET-d#5,SET]
+  000001:[a#3,SET-d#5,SET]
 ----
 OK
 
 check-ordering
-L0
-  a.SET.4-d.SET.4
-  a.SET.5-d.SET.5
-  a.SET.4-d.SET.6
+0:
+  000003:[a#4,SET-d#6,SET]
+  000002:[a#5,SET-d#5,SET]
+  000001:[a#4,SET-d#4,SET]
 ----
 OK
 
 check-ordering
-L0
-  a.SET.0-d.SET.0
-  a.SET.0-d.SET.0
-  a.SET.0-d.SET.3
+0:
+  000003:[a#0,SET-d#3,SET]
+  000002:[a#0,SET-d#0,SET]
+  000001:[a#0,SET-d#0,SET]
 ----
 OK
 
 check-ordering
-L1
-  a.SET.1-b.SET.2
+1:
+  000001:[a#1,SET-b#2,SET]
 ----
 OK
 
 check-ordering
-L1
-  b.SET.1-a.SET.2
+1:
+  000001:[b#1,SET-a#2,SET]
 ----
 L1 : file 000001 has inconsistent bounds: b#1,SET vs a#2,SET
 1:
   000001:[b#1,SET-a#2,SET]
 
 check-ordering
-L1
-  a.SET.1-b.SET.2
-  c.SET.3-d.SET.4
+1:
+  000001:[a#1,SET-b#2,SET]
+  000002:[c#3,SET-d#4,SET]
 ----
 OK
 
 check-ordering
-L1
-  a.SET.1-b.SET.2
-  d.SET.3-c.SET.4
+1:
+  000001:[a#1,SET-b#2,SET]
+  000002:[d#3,SET-c#4,SET]
 ----
 L1 : file 000002 has inconsistent bounds: d#3,SET vs c#4,SET
 1:
@@ -166,16 +170,16 @@ L1 : file 000002 has inconsistent bounds: d#3,SET vs c#4,SET
   000002:[d#3,SET-c#4,SET]
 
 check-ordering
-L1
-  a.SET.1-b.SET.2
-  b.SET.1-d.SET.4
+1:
+  000001:[a#1,SET-b#2,SET]
+  000002:[b#1,SET-d#4,SET]
 ----
 OK
 
 check-ordering
-L1
-  a.SET.1-b.SET.2
-  b.SET.2-d.SET.4
+1:
+  000001:[a#1,SET-b#2,SET]
+  000002:[b#2,SET-d#4,SET]
 ----
 L1 files 000001 and 000002 have overlapping ranges: [a#1,SET-b#2,SET] vs [b#2,SET-d#4,SET]
 1:
@@ -183,9 +187,9 @@ L1 files 000001 and 000002 have overlapping ranges: [a#1,SET-b#2,SET] vs [b#2,SE
   000002:[b#2,SET-d#4,SET]
 
 check-ordering
-L1
-  a.SET.1-c.SET.2
-  b.SET.3-d.SET.4
+1:
+  000001:[a#1,SET-c#2,SET]
+  000002:[b#3,SET-d#4,SET]
 ----
 L1 files 000001 and 000002 have overlapping ranges: [a#1,SET-c#2,SET] vs [b#3,SET-d#4,SET]
 1:
@@ -193,19 +197,19 @@ L1 files 000001 and 000002 have overlapping ranges: [a#1,SET-c#2,SET] vs [b#3,SE
   000002:[b#3,SET-d#4,SET]
 
 check-ordering
-L1
-  a.SET.1-c.SET.2
-L2
-  b.SET.3-d.SET.4
+1:
+  000001:[a#1,SET-c#2,SET]
+2:
+  000002:[b#3,SET-d#4,SET]
 ----
 OK
 
 check-ordering
-L1
-  a.SET.1-c.SET.2
-L2
-  b.SET.3-d.SET.4
-  c.SET.5-e.SET.6
+1:
+  000001:[a#1,SET-c#2,SET]
+2:
+  000002:[b#3,SET-d#4,SET]
+  000003:[c#5,SET-e#6,SET]
 ----
 L2 files 000002 and 000003 have overlapping ranges: [b#3,SET-d#4,SET] vs [c#5,SET-e#6,SET]
 1:


### PR DESCRIPTION
Addresses an existing TODO, reusing the existing `ParseVersionDebug`
method to parse the testdata input to `TestcheckOrdering`, and
eliminating some duplicated code.

Update testdata input to reflect being parsed from the inverse of the
`DebugString` method.

For test cases involving L0, rewrite the test case to specify L0 files
in reverse order, to line up with how `DebugString` would print the
corresponding version.