### PR TITLE
db: use L0 target file size, grandparent limit for intra L0 compactions

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -448,15 +448,9 @@ func newCompaction(pc *pickedCompaction, opts *Options, bytesCompacted *uint64) 
 	}
 	c.setupInuseKeyRanges()
 
-	switch {
-	case pc.readTriggered:
-		c.kind = compactionKindRead
-	case c.startLevel.level == numLevels-1:
-		// This compaction is an L6->L6 elision-only compaction to rewrite
-		// a sstable without unnecessary tombstones.
-		c.kind = compactionKindElisionOnly
-	case c.outputLevel.files.Empty() && c.startLevel.files.Len() == 1 &&
-		c.grandparents.SizeSum() <= c.maxOverlapBytes:
+	c.kind = pc.kind
+	if c.kind == compactionKindDefault && c.outputLevel.files.Empty() &&
+		c.startLevel.files.Len() == 1 && c.grandparents.SizeSum() <= c.maxOverlapBytes {
 		// This compaction can be converted into a trivial move from one level
 		// to the next. We avoid such a move if there is lots of overlapping
 		// grandparent data. Otherwise, the move could create a parent file

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1638,7 +1638,7 @@ func TestCompactionOutputLevel(t *testing.T) {
 				var start, base int
 				d.ScanArgs(t, "start", &start)
 				d.ScanArgs(t, "base", &base)
-				pc := newPickedCompaction(opts, version, start, base)
+				pc := newPickedCompaction(opts, version, start, defaultOutputLevel(start, base), base)
 				c := newCompaction(pc, opts, new(uint64))
 				return fmt.Sprintf("output=%d\nmax-output-file-size=%d\n",
 					c.outputLevel.level, c.maxOutputFileSize)

--- a/testdata/compaction_picker_L0
+++ b/testdata/compaction_picker_L0
@@ -242,11 +242,11 @@ L0: 000100,000110,000130,000140
 
 max-output-file-size
 ----
-4194304
+2097152
 
 max-overlap-bytes
 ----
-41943040
+20971520
 
 # 1 L0 file. Should not choose any compaction, as an intra-L0 compaction
 # with one input is unhelpful.


### PR DESCRIPTION
Previously, intra-L0 compactions used L1's target file size to populate
the compaction's max output file size, grandparent limit, etc. This
could result in intra-L0 compactions constructing outputs wider than
otherwise permitted when outputting to L0.

Also, replace the `readTriggered` bool on `pickedCompaction` with a
compaction kind that is directly thread through to `compaction.kind`.

Extracted these bits out of #1537, because they deserve their own
scrutiny and ability to atomically revert.