### PR TITLE
sstable: fix bug with overall bound setting

### DIFF
--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -302,11 +302,7 @@ func rewriteDataBlocksToWriter(
 	w.props.NumEntries = r.Properties.NumEntries
 	w.props.RawKeySize = r.Properties.RawKeySize
 	w.props.RawValueSize = r.Properties.RawValueSize
-	// NB: we set the smallest / largest fields directly here, rather than via the
-	// Set* methods, as we know we only have point keys.
-	smallest, largest := blocks[0].start, blocks[len(blocks)-1].end
-	w.meta.SmallestPoint, w.meta.Smallest = smallest, smallest
-	w.meta.LargestPoint, w.meta.Largest = largest, largest
+	w.meta.SmallestPoint, w.meta.LargestPoint = blocks[0].start, blocks[len(blocks)-1].end
 	w.meta.HasPointKeys = true
 	return nil
 }

--- a/sstable/testdata/rewriter
+++ b/sstable/testdata/rewriter
@@ -3,10 +3,8 @@ a_xyz.SET.1:a
 b_xyz.SET.1:b
 c_xyz.SET.1:c
 ----
-point:    [a_xyz#1,1,c_xyz#1,1]
-rangedel: [#0,0,#0,0]
-rangekey: [#0,0,#0,0]
-seqnums:  [1,1]
+point:    [a_xyz#1,1-c_xyz#1,1]
+seqnums:  [1-1]
 
 rewrite from=xyz to=123 block-size=1 index-block-size=1 filter
 ----
@@ -21,10 +19,8 @@ aa_xyz.SET.1:a
 ba_xyz.SET.1:b
 ca_xyz.SET.1:c
 ----
-point:    [aa_xyz#1,1,ca_xyz#1,1]
-rangedel: [#0,0,#0,0]
-rangekey: [#0,0,#0,0]
-seqnums:  [1,1]
+point:    [aa_xyz#1,1-ca_xyz#1,1]
+seqnums:  [1-1]
 
 rewrite from=yz to=23 block-size=1 index-block-size=1 filter comparer-split-4b-suffix
 ----
@@ -39,10 +35,8 @@ a_xyz.SET.1:a
 b_xyz.SET.1:b
 c_xyz.SET.1:c
 ----
-point:    [a_xyz#1,1,c_xyz#1,1]
-rangedel: [#0,0,#0,0]
-rangekey: [#0,0,#0,0]
-seqnums:  [1,1]
+point:    [a_xyz#1,1-c_xyz#1,1]
+seqnums:  [1-1]
 
 layout
 ----
@@ -76,10 +70,8 @@ c
 
 rewrite from=_xyz to=_123 block-size=1 index-block-size=1 filter comparer-split-4b-suffix
 ----
-point:    [a_123#1,1,c_123#1,1]
-rangedel: [#0,0,#0,0]
-rangekey: [#0,0,#0,0]
-seqnums:  [1,1]
+point:    [a_123#1,1-c_123#1,1]
+seqnums:  [1-1]
 
 layout
 ----
@@ -113,10 +105,8 @@ c
 
 rewrite from=_123 to=_456 block-size=1 index-block-size=1 filter comparer-split-4b-suffix concurrency=2
 ----
-point:    [a_456#1,1,c_456#1,1]
-rangedel: [#0,0,#0,0]
-rangekey: [#0,0,#0,0]
-seqnums:  [1,1]
+point:    [a_456#1,1-c_456#1,1]
+seqnums:  [1-1]
 
 layout
 ----
@@ -150,10 +140,8 @@ c
 
 rewrite from=_456 to=_xyz block-size=1 index-block-size=1 filter comparer-split-4b-suffix concurrency=3
 ----
-point:    [a_xyz#1,1,c_xyz#1,1]
-rangedel: [#0,0,#0,0]
-rangekey: [#0,0,#0,0]
-seqnums:  [1,1]
+point:    [a_xyz#1,1-c_xyz#1,1]
+seqnums:  [1-1]
 
 layout
 ----
@@ -188,10 +176,8 @@ c
 
 rewrite from=_xyz to=_123 block-size=1 index-block-size=1 filter comparer-split-4b-suffix concurrency=4
 ----
-point:    [a_123#1,1,c_123#1,1]
-rangedel: [#0,0,#0,0]
-rangekey: [#0,0,#0,0]
-seqnums:  [1,1]
+point:    [a_123#1,1-c_123#1,1]
+seqnums:  [1-1]
 
 layout
 ----

--- a/sstable/testdata/writer
+++ b/sstable/testdata/writer
@@ -1,10 +1,8 @@
 build
 a.SET.1:a
 ----
-point:    [a#1,1,a#1,1]
-rangedel: [#0,0,#0,0]
-rangekey: [#0,0,#0,0]
-seqnums:  [1,1]
+point:    [a#1,1-a#1,1]
+seqnums:  [1-1]
 
 scan
 ----
@@ -29,10 +27,10 @@ j.RANGEKEYDEL.9:k
 k.RANGEKEYUNSET.10:l [@t5]
 l.RANGEKEYSET.11:m [(@t10=foo)]
 ----
-point:    [a#1,1,h#7,2]
-rangedel: [d#4,15,j#72057594037927935,15]
-rangekey: [j#9,19,m#72057594037927935,21]
-seqnums:  [1,11]
+point:    [a#1,1-h#7,2]
+rangedel: [d#4,15-j#72057594037927935,15]
+rangekey: [j#9,19-m#72057594037927935,21]
+seqnums:  [1-11]
 
 build
 a.SET.1:a
@@ -44,10 +42,9 @@ g.DEL.6:
 h.MERGE.7:h
 i.RANGEDEL.8:j
 ----
-point:    [a#1,1,h#7,2]
-rangedel: [d#4,15,j#72057594037927935,15]
-rangekey: [#0,0,#0,0]
-seqnums:  [1,8]
+point:    [a#1,1-h#7,2]
+rangedel: [d#4,15-j#72057594037927935,15]
+seqnums:  [1-8]
 
 scan
 ----
@@ -72,10 +69,8 @@ a.RANGEDEL.3:m
 f.RANGEDEL.2:s
 j.RANGEDEL.1:z
 ----
-point:    [#0,0,#0,0]
-rangedel: [a#3,15,z#72057594037927935,15]
-rangekey: [#0,0,#0,0]
-seqnums:  [1,3]
+rangedel: [a#3,15-z#72057594037927935,15]
+seqnums:  [1-3]
 
 scan
 ----
@@ -102,28 +97,25 @@ build
 a.RANGEDEL.3:b
 b.SET.4:c
 ----
-point:    [b#4,1,b#4,1]
-rangedel: [a#3,15,b#72057594037927935,15]
-rangekey: [#0,0,#0,0]
-seqnums:  [3,4]
+point:    [b#4,1-b#4,1]
+rangedel: [a#3,15-b#72057594037927935,15]
+seqnums:  [3-4]
 
 build
 a.RANGEDEL.3:b
 b.SET.2:c
 ----
-point:    [b#2,1,b#2,1]
-rangedel: [a#3,15,b#72057594037927935,15]
-rangekey: [#0,0,#0,0]
-seqnums:  [2,3]
+point:    [b#2,1-b#2,1]
+rangedel: [a#3,15-b#72057594037927935,15]
+seqnums:  [2-3]
 
 build
 a.RANGEDEL.3:c
 b.SET.2:c
 ----
-point:    [b#2,1,b#2,1]
-rangedel: [a#3,15,c#72057594037927935,15]
-rangekey: [#0,0,#0,0]
-seqnums:  [2,3]
+point:    [b#2,1-b#2,1]
+rangedel: [a#3,15-c#72057594037927935,15]
+seqnums:  [2-3]
 
 # Keys must be added in order.
 
@@ -148,10 +140,8 @@ pebble: keys must be added in order: b#1,RANGEDEL > a#2,RANGEDEL
 build-raw
 .RANGEDEL.1:b
 ----
-point:    [#0,0,#0,0]
-rangedel: [#1,15,b#72057594037927935,15]
-rangekey: [#0,0,#0,0]
-seqnums:  [1,1]
+rangedel: [#1,15-b#72057594037927935,15]
+seqnums:  [1-1]
 
 build-raw
 a.RANGEDEL.1:c
@@ -175,10 +165,8 @@ build-raw
 a.RANGEDEL.1:c
 c.RANGEDEL.2:d
 ----
-point:    [#0,0,#0,0]
-rangedel: [a#1,15,d#72057594037927935,15]
-rangekey: [#0,0,#0,0]
-seqnums:  [1,2]
+rangedel: [a#1,15-d#72057594037927935,15]
+seqnums:  [1-2]
 
 build-raw
 a.RANGEKEYSET.1:b [(@t10=foo)]
@@ -208,10 +196,8 @@ build-raw
 a.RANGEKEYSET.1:c [(@t10=foo)]
 c.RANGEKEYSET.2:d [(@t10=foo)]
 ----
-point:    [#0,0,#0,0]
-rangedel: [#0,0,#0,0]
-rangekey: [a#1,21,d#72057594037927935,21]
-seqnums:  [1,2]
+rangekey: [a#1,21-d#72057594037927935,21]
+seqnums:  [1-2]
 
 # Range keys may have perfectly aligned spans (including sequence numbers),
 # though the key kinds must be ordered (descending).
@@ -227,10 +213,8 @@ a.RANGEKEYSET.1:b [(@t10=foo)]
 a.RANGEKEYUNSET.1:b [@t10]
 a.RANGEKEYDEL.1:b
 ----
-point:    [#0,0,#0,0]
-rangedel: [#0,0,#0,0]
-rangekey: [a#1,21,b#72057594037927935,19]
-seqnums:  [1,1]
+rangekey: [a#1,21-b#72057594037927935,19]
+seqnums:  [1-1]
 
 # The range-del-v1 format supports unfragmented and unsorted range
 # tombstones.
@@ -239,10 +223,8 @@ build-raw range-del-v1
 a.RANGEDEL.1:c
 a.RANGEDEL.2:c
 ----
-point:    [#0,0,#0,0]
-rangedel: [a#2,15,c#72057594037927935,15]
-rangekey: [#0,0,#0,0]
-seqnums:  [1,2]
+rangedel: [a#2,15-c#72057594037927935,15]
+seqnums:  [1-2]
 
 scan-range-del
 ----
@@ -253,10 +235,8 @@ build-raw range-del-v1
 a.RANGEDEL.1:c
 b.RANGEDEL.2:d
 ----
-point:    [#0,0,#0,0]
-rangedel: [a#1,15,d#72057594037927935,15]
-rangekey: [#0,0,#0,0]
-seqnums:  [1,2]
+rangedel: [a#1,15-d#72057594037927935,15]
+seqnums:  [1-2]
 
 scan-range-del
 ----
@@ -269,10 +249,8 @@ build-raw range-del-v1
 a.RANGEDEL.2:c
 a.RANGEDEL.1:d
 ----
-point:    [#0,0,#0,0]
-rangedel: [a#2,15,d#72057594037927935,15]
-rangekey: [#0,0,#0,0]
-seqnums:  [1,2]
+rangedel: [a#2,15-d#72057594037927935,15]
+seqnums:  [1-2]
 
 scan-range-del
 ----
@@ -289,10 +267,8 @@ j.RANGEDEL.1:z
 f.RANGEDEL.2:s
 a.RANGEDEL.3:m
 ----
-point:    [#0,0,#0,0]
-rangedel: [a#3,15,z#72057594037927935,15]
-rangekey: [#0,0,#0,0]
-seqnums:  [1,3]
+rangedel: [a#3,15-z#72057594037927935,15]
+seqnums:  [1-3]
 
 scan-range-del
 ----
@@ -313,10 +289,8 @@ a.SET.1:a
 b.SET.1:b
 c.SET.1:c
 ----
-point:    [a#1,1,c#1,1]
-rangedel: [#0,0,#0,0]
-rangekey: [#0,0,#0,0]
-seqnums:  [1,1]
+point:    [a#1,1-c#1,1]
+seqnums:  [1-1]
 
 layout
 ----
@@ -346,10 +320,8 @@ a.SET.1:a
 b.SET.1:b
 c.SET.1:c
 ----
-point:    [a#1,1,c#1,1]
-rangedel: [#0,0,#0,0]
-rangekey: [#0,0,#0,0]
-seqnums:  [1,1]
+point:    [a#1,1-c#1,1]
+seqnums:  [1-1]
 
 layout
 ----
@@ -369,10 +341,8 @@ a.RANGEKEYSET.3:b [(@t3=foo)]
 b.RANGEKEYSET.2:c [(@t2=bar)]
 c.RANGEKEYSET.1:d [(@t1=baz)]
 ----
-point:    [#0,0,#0,0]
-rangedel: [#0,0,#0,0]
-rangekey: [a#3,21,d#72057594037927935,21]
-seqnums:  [1,3]
+rangekey: [a#3,21-d#72057594037927935,21]
+seqnums:  [1-3]
 
 layout
 ----

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -38,6 +38,21 @@ func runDataDriven(t *testing.T, file string) {
 		}
 	}()
 
+	format := func(m *WriterMetadata) string {
+		var b bytes.Buffer
+		if m.HasPointKeys {
+			fmt.Fprintf(&b, "point:    [%s-%s]\n", m.SmallestPoint, m.LargestPoint)
+		}
+		if m.HasRangeDelKeys {
+			fmt.Fprintf(&b, "rangedel: [%s-%s]\n", m.SmallestRangeDel, m.LargestRangeDel)
+		}
+		if m.HasRangeKeys {
+			fmt.Fprintf(&b, "rangekey: [%s-%s]\n", m.SmallestRangeKey, m.LargestRangeKey)
+		}
+		fmt.Fprintf(&b, "seqnums:  [%d-%d]\n", m.SmallestSeqNum, m.LargestSeqNum)
+		return b.String()
+	}
+
 	datadriven.RunTest(t, file, func(td *datadriven.TestData) string {
 		switch td.Cmd {
 		case "build":
@@ -53,11 +68,7 @@ func runDataDriven(t *testing.T, file string) {
 			if err != nil {
 				return err.Error()
 			}
-			return fmt.Sprintf("point:    [%s,%s]\nrangedel: [%s,%s]\nrangekey: [%s,%s]\nseqnums:  [%d,%d]\n",
-				meta.SmallestPoint, meta.LargestPoint,
-				meta.SmallestRangeDel, meta.LargestRangeDel,
-				meta.SmallestRangeKey, meta.LargestRangeKey,
-				meta.SmallestSeqNum, meta.LargestSeqNum)
+			return format(meta)
 
 		case "build-raw":
 			if r != nil {
@@ -72,11 +83,7 @@ func runDataDriven(t *testing.T, file string) {
 			if err != nil {
 				return err.Error()
 			}
-			return fmt.Sprintf("point:    [%s,%s]\nrangedel: [%s,%s]\nrangekey: [%s,%s]\nseqnums:  [%d,%d]\n",
-				meta.SmallestPoint, meta.LargestPoint,
-				meta.SmallestRangeDel, meta.LargestRangeDel,
-				meta.SmallestRangeKey, meta.LargestRangeKey,
-				meta.SmallestSeqNum, meta.LargestSeqNum)
+			return format(meta)
 
 		case "scan":
 			origIter, err := r.NewIter(nil /* lower */, nil /* upper */)
@@ -163,11 +170,7 @@ func runDataDriven(t *testing.T, file string) {
 			if err != nil {
 				return err.Error()
 			}
-			return fmt.Sprintf("point:    [%s,%s]\nrangedel: [%s,%s]\nrangekey: [%s,%s]\nseqnums:  [%d,%d]\n",
-				meta.SmallestPoint, meta.LargestPoint,
-				meta.SmallestRangeDel, meta.LargestRangeDel,
-				meta.SmallestRangeKey, meta.LargestRangeKey,
-				meta.SmallestSeqNum, meta.LargestSeqNum)
+			return format(meta)
 
 		default:
 			return fmt.Sprintf("unknown command: %s", td.Cmd)


### PR DESCRIPTION
Currently, the overall smallest / largest keys for `WriterMetadata` are
set if no point, range delete, or range key has been set on the table.
In the case where the largest key is set first, the check evaluates to
false (as at least one of the booleans is true), and the subsequent
check to compare the provided key to the smallest key also evaluates to
false, as there is rarely a key that sorts before a nil-valued user key
and zero trailer (the zero value of the field).

Update the check to instead use separate booleans for the smallest and
largest fields.

Improve test coverage by printing the overall table bounds in the
data-driven tests.

Move all boolean fields in `WriterMetadata` to the end of the struct.
This reduces the struct size from `680` bytes to `672` bytes, even with
the addition of the two boolean fields.