### PR TITLE
sstable: refactors WriterMetadata slice ownership

### DIFF
--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -208,9 +208,12 @@ func ParseInternalKey(s string) InternalKey {
 	return MakeInternalKey([]byte(ukey), seqNum, kind)
 }
 
+// InternalTrailerLen is the number of bytes used to encode InternalKey.Trailer.
+const InternalTrailerLen = 8
+
 // DecodeInternalKey decodes an encoded internal key. See InternalKey.Encode().
 func DecodeInternalKey(encodedKey []byte) InternalKey {
-	n := len(encodedKey) - 8
+	n := len(encodedKey) - InternalTrailerLen
 	var trailer uint64
 	if n >= 0 {
 		trailer = binary.LittleEndian.Uint64(encodedKey[n:])

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -32,8 +32,11 @@ var errWriterClosed = errors.New("pebble: writer is closed")
 
 // WriterMetadata holds info about a finished sstable.
 type WriterMetadata struct {
-	Size             uint64
-	SmallestPoint    InternalKey
+	Size          uint64
+	SmallestPoint InternalKey
+	// LargestPoint, LargestRangeKey, LargestRangeDel should not be accessed
+	// before Writer.Close is called, because they may only be set on
+	// Writer.Close.
 	LargestPoint     InternalKey
 	SmallestRangeDel InternalKey
 	LargestRangeDel  InternalKey
@@ -580,15 +583,35 @@ func (w *Writer) Add(key InternalKey, value []byte) error {
 }
 
 func (w *Writer) addPoint(key InternalKey, value []byte) error {
-	if !w.disableKeyOrderChecks && w.meta.LargestPoint.UserKey != nil {
-		// TODO(peter): Manually inlined version of base.InternalCompare(). This is
-		// 3.5% faster on BenchmarkWriter on go1.13. Remove if go1.14 or future
-		// versions show this to not be a performance win.
-		x := w.compare(w.meta.LargestPoint.UserKey, key.UserKey)
-		if x > 0 || (x == 0 && w.meta.LargestPoint.Trailer < key.Trailer) {
-			w.err = errors.Errorf("pebble: keys must be added in order: %s, %s",
-				w.meta.LargestPoint.Pretty(w.formatKey), key.Pretty(w.formatKey))
-			return w.err
+	if !w.disableKeyOrderChecks && w.dataBlockBuf.dataBlock.nEntries >= 1 {
+		// curKey is guaranteed to be the last point key which was added to the Writer.
+		// Inlining base.DecodeInternalKey has a 2-3% improve in the BenchmarkWriter
+		// benchmark.
+		encodedKey := w.dataBlockBuf.dataBlock.curKey
+		n := len(encodedKey) - base.InternalTrailerLen
+		var trailer uint64
+		if n >= 0 {
+			trailer = binary.LittleEndian.Uint64(encodedKey[n:])
+			encodedKey = encodedKey[:n:n]
+		} else {
+			trailer = uint64(InternalKeyKindInvalid)
+			encodedKey = nil
+		}
+		largestPointKey := InternalKey{
+			UserKey: encodedKey,
+			Trailer: trailer,
+		}
+
+		if largestPointKey.UserKey != nil {
+			// TODO(peter): Manually inlined version of base.InternalCompare(). This is
+			// 3.5% faster on BenchmarkWriter on go1.13. Remove if go1.14 or future
+			// versions show this to not be a performance win.
+			x := w.compare(largestPointKey.UserKey, key.UserKey)
+			if x > 0 || (x == 0 && largestPointKey.Trailer < key.Trailer) {
+				w.err = errors.Errorf("pebble: keys must be added in order: %s, %s",
+					largestPointKey.Pretty(w.formatKey), key.Pretty(w.formatKey))
+				return w.err
+			}
 		}
 	}
 
@@ -613,23 +636,18 @@ func (w *Writer) addPoint(key InternalKey, value []byte) error {
 	w.dataBlockBuf.dataBlock.add(key, value)
 
 	w.meta.updateSeqNum(key.SeqNum())
-	k := base.InternalKey{
-		// block.curKey contains the most recently added key to the block.
-		UserKey: w.dataBlockBuf.dataBlock.curKey[:len(w.dataBlockBuf.dataBlock.curKey)-8],
-		Trailer: key.Trailer,
-	}
-	w.meta.SetLargestPointKey(k)
-	if w.meta.SmallestPoint.UserKey == nil {
-		// NB: we clone w.meta.LargestPoint rather than "key", even though they are
-		// semantically identical, because we need to ensure that SmallestPoint.UserKey
-		// is not nil. This is required by WriterMetadata.Smallest in order to
-		// distinguish between an unset SmallestPoint and a zero-length one.
-		// NB: We don't clone this off of some alloc-pool since it will outlive this
-		// Writer as a field of the returned metadata that users like compaction.go
-		// then hang on to, and would otherwise continue to alias that whole pool's
-		// slice if we did so. So since we'll need to allocate it its own slice at
-		// some point anyway, we may as well do so here.
-		w.meta.SetSmallestPointKey(w.meta.LargestPoint.Clone())
+
+	if !w.meta.HasPointKeys {
+		k := base.DecodeInternalKey(w.dataBlockBuf.dataBlock.curKey)
+		// NB: We need to ensure that SmallestPoint.UserKey is set, so we create
+		// an InternalKey which is semantically identical to the key, but won't
+		// have a nil UserKey. We do this, because key.UserKey could be nil, and
+		// we don't want SmallestPoint.UserKey to be nil.
+		//
+		// todo(bananabrick): Determine if it's okay to have a nil SmallestPoint
+		// .UserKey now that we don't rely on a nil UserKey to determine if the
+		// key has been set or not.
+		w.meta.SetSmallestPointKey(k.Clone())
 	}
 
 	w.props.NumEntries++
@@ -1415,6 +1433,20 @@ func (w *Writer) Close() (err error) {
 		return w.err
 	}
 
+	// The w.meta.LargestPointKey is only used once the Writer is closed, so it is safe to set it
+	// when the Writer is closed.
+	//
+	// The following invariants ensure that setting the largest key at this point of a Writer close
+	// is correct:
+	// 1. Keys must only be added to the Writer in an increasing order.
+	// 2. The current w.dataBlockBuf is guaranteed to have the latest key added to the Writer. This
+	//    must be true, because a w.dataBlockBuf is only switched out when a dataBlock is flushed,
+	//    however, if a dataBlock is flushed, then we add a key to the new w.dataBlockBuf in the
+	//    addPoint function after the flush occurs.
+	if w.dataBlockBuf.dataBlock.nEntries >= 1 {
+		w.meta.SetLargestPointKey(base.DecodeInternalKey(w.dataBlockBuf.dataBlock.curKey))
+	}
+
 	// Finish the last data block, or force an empty data block if there
 	// aren't any data blocks at all.
 	if w.dataBlockBuf.dataBlock.nEntries > 0 || w.indexBlock.block.nEntries == 0 {
@@ -1685,13 +1717,19 @@ type PreviousPointKeyOpt struct {
 
 // UnsafeKey returns the last point key written to the writer to which this
 // option was passed during creation. The returned key points directly into
-// a buffer belonging the Writer. The value's lifetime ends the next time a
+// a buffer belonging to the Writer. The value's lifetime ends the next time a
 // point key is added to the Writer.
 func (o PreviousPointKeyOpt) UnsafeKey() base.InternalKey {
 	if o.w == nil {
 		return base.InvalidInternalKey
 	}
-	return o.w.meta.LargestPoint
+
+	if o.w.dataBlockBuf.dataBlock.nEntries >= 1 {
+		// o.w.dataBlockBuf.dataBlock.curKey is guaranteed to point to the last point key
+		// which was added to the Writer.
+		return base.DecodeInternalKey(o.w.dataBlockBuf.dataBlock.curKey)
+	}
+	return base.InternalKey{}
 }
 
 func (o *PreviousPointKeyOpt) writerApply(w *Writer) {


### PR DESCRIPTION
The WriterMetadata can outlive the Writer, and as such, it makes more
sense that byte slices in the WriterMetadata aren't owned by the Writer,
and are instead owned by the WriterMetadata.

It is unnecessary to update WriterMetadata.LargestPoint on every call to the
Writer's addPoint function. Instead, we can get away with updating it only
when the Writer is closed.

Prior to this pr, the WriterMetadata.LargestPoint was an InternKey with a UserKey
which directly pointed into the buffer owned by the dataBlockBuf. To prevent the
WriterMetadata from pointing into a buffer owned by the dataBlockBuf, it was required
to clone the key before updating WriterMetadata.LargestPoint.

However, doing this clone on every call to Writer.addPoint is prohibitively expensive.
So, we only update LargestPoint on Writer.Close.