### PR TITLE
db: clear range key count during Batch Reset

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -936,9 +936,11 @@ func (b *Batch) init(cap int) {
 func (b *Batch) Reset() {
 	b.count = 0
 	b.countRangeDels = 0
+	b.countRangeKeys = 0
 	b.memTableSize = 0
 	b.deferredOp = DeferredBatchOp{}
 	b.tombstones = nil
+	b.rangeKeys = nil
 	b.flushable = nil
 	b.commit = sync.WaitGroup{}
 	b.commitErr = nil


### PR DESCRIPTION
Previously, if a Batch was Reset its running count of range keys was not reset.