### PR TITLE
sstable: re-pool datablock buffers in the sstable Writer

### DIFF
--- a/sstable/block.go
+++ b/sstable/block.go
@@ -35,6 +35,16 @@ type blockWriter struct {
 	tmp             [4]byte
 }
 
+func (w *blockWriter) clear() {
+	*w = blockWriter{
+		buf:      w.buf[:0],
+		restarts: w.restarts[:0],
+		curKey:   w.curKey[:0],
+		curValue: w.curValue[:0],
+		prevKey:  w.prevKey[:0],
+	}
+}
+
 func (w *blockWriter) store(keySize int, value []byte) {
 	shared := 0
 	if w.nEntries == w.nextRestart {

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -196,7 +196,7 @@ type Writer struct {
 	rkBuf      []byte
 	// dataBlockBuf consists of the state which is currently owned by and used by
 	// the Writer client goroutine. This state can be handed off to other goroutines.
-	dataBlockBuf dataBlockBuf
+	dataBlockBuf *dataBlockBuf
 	// blockBuf consists of the state which is owned by and used by the Writer client
 	// goroutine.
 	blockBuf blockBuf
@@ -273,12 +273,7 @@ func (s *sizeEstimate) written(newTotalSize uint64, inflightSize int, finalEntry
 }
 
 func (s *sizeEstimate) clear() {
-	s.numEntries = 0
-	s.inflightSize = 0
-	s.maxEstimatedSize = 0
-	s.totalSize = 0
-	s.compressedSize = 0
-	s.uncompressedSize = 0
+	*s = sizeEstimate{emptySize: s.emptySize}
 }
 
 type indexBlockBuf struct {
@@ -294,6 +289,16 @@ type indexBlockBuf struct {
 	// restartInterval matches indexBlockBuf.block.restartInterval. We store it twice, because the `block`
 	// must only be accessed from the writeQueue goroutine.
 	restartInterval int
+}
+
+func (i *indexBlockBuf) clear() {
+	i.block.clear()
+	if i.size.useMutex {
+		i.size.mu.Lock()
+		defer i.size.mu.Unlock()
+	}
+	i.size.estimate.clear()
+	i.restartInterval = 0
 }
 
 var indexBlockBufPool = sync.Pool{
@@ -340,11 +345,6 @@ func (i *indexBlockBuf) add(key InternalKey, value []byte, inflightSize int) {
 
 func (i *indexBlockBuf) finish() []byte {
 	b := i.block.finish()
-	if i.size.useMutex {
-		i.size.mu.Lock()
-		defer i.size.mu.Unlock()
-	}
-	i.size.estimate.clear()
 	return b
 }
 
@@ -452,6 +452,15 @@ type blockBuf struct {
 	checksummer   checksummer
 }
 
+func (b *blockBuf) clear() {
+	// We can't assign b.compressedBuf[:0] to compressedBuf because snappy relies
+	// on the length of the buffer, and not the capacity to determine if it needs
+	// to make an allocation.
+	*b = blockBuf{
+		compressedBuf: b.compressedBuf, checksummer: b.checksummer,
+	}
+}
+
 // A dataBlockBuf holds all the state required to compress and write a data block to disk.
 // A dataBlockBuf begins its lifecycle owned by the Writer client goroutine. The Writer
 // client goroutine adds keys to the sstable, writing directly into a dataBlockBuf's blockWriter
@@ -483,9 +492,27 @@ type dataBlockBuf struct {
 	sepScratch []byte
 }
 
-func (d *dataBlockBuf) init(restartInterval int, checksumType ChecksumType) {
+func (d *dataBlockBuf) clear() {
+	d.blockBuf.clear()
+	d.dataBlock.clear()
+
+	d.uncompressed = nil
+	d.compressed = nil
+	d.dataBlockProps = nil
+	d.sepScratch = d.sepScratch[:0]
+}
+
+var dataBlockBufPool = sync.Pool{
+	New: func() interface{} {
+		return &dataBlockBuf{}
+	},
+}
+
+func newDataBlockBuf(restartInterval int, checksumType ChecksumType) *dataBlockBuf {
+	d := dataBlockBufPool.Get().(*dataBlockBuf)
 	d.dataBlock.restartInterval = restartInterval
 	d.checksummer.checksumType = checksumType
+	return d
 }
 
 func (d *dataBlockBuf) finish() {
@@ -1029,7 +1056,7 @@ func (w *Writer) flush(key InternalKey) error {
 	var err error
 
 	// We're finishing a data block.
-	err = w.finishDataBlockProps(&w.dataBlockBuf)
+	err = w.finishDataBlockProps(w.dataBlockBuf)
 	if err != nil {
 		return err
 	}
@@ -1044,12 +1071,14 @@ func (w *Writer) flush(key InternalKey) error {
 	// byte slice which supports "sep" will eventually be copied when "sep" is
 	// added to the index block.
 	prevKey := base.DecodeInternalKey(w.dataBlockBuf.dataBlock.curKey)
-	sep := w.indexEntrySep(prevKey, key, &w.dataBlockBuf)
-	// We determine that we should flush an index block from the Writer client goroutine, but
-	// we actually finish the index block from the writeQueue. When we determine that an index
-	// block should be flushed, we need to call BlockPropertyCollector.FinishIndexBlock. But
-	// block property collector calls must happen sequentially from the Writer client. Therefore,
-	// we need to determine that we are going to flush the index block from the Writer client.
+	sep := w.indexEntrySep(prevKey, key, w.dataBlockBuf)
+	// We determine that we should flush an index block from the Writer client
+	// goroutine, but we actually finish the index block from the writeQueue.
+	// When we determine that an index block should be flushed, we need to call
+	// BlockPropertyCollector.FinishIndexBlock. But block property collector
+	// calls must happen sequentially from the Writer client. Therefore, we need
+	// to determine that we are going to flush the index block from the Writer
+	// client.
 	shouldFlushIndexBlock := supportsTwoLevelIndex(w.tableFormat) && w.indexBlock.shouldFlush(
 		sep, encodedBHPEstimatedSize, w.indexBlockSize, w.indexBlockSizeThreshold,
 	)
@@ -1059,15 +1088,18 @@ func (w *Writer) flush(key InternalKey) error {
 	if shouldFlushIndexBlock {
 		flushableIndexBlock = w.indexBlock
 		w.indexBlock = newIndexBlockBuf()
-		// Call BlockPropertyCollector.FinishIndexBlock, since we've decided to flush the index block.
+		// Call BlockPropertyCollector.FinishIndexBlock, since we've decided to
+		// flush the index block.
 		indexProps, err = w.finishIndexBlockProps()
 		if err != nil {
 			return err
 		}
 	}
 
-	// We've called BlockPropertyCollector.FinishDataBlock, and, if necessary, BlockPropertyCollector.FinishIndexBlock.
-	// Since we've decided to finish the data block, we can call BlockPropertyCollector.AddPrevDataBlockToIndexBlock.
+	// We've called BlockPropertyCollector.FinishDataBlock, and, if necessary,
+	// BlockPropertyCollector.FinishIndexBlock. Since we've decided to finish
+	// the data block, we can call
+	// BlockPropertyCollector.AddPrevDataBlockToIndexBlock.
 	w.addPrevDataBlockToIndexBlockProps()
 
 	// Schedule a write.
@@ -1075,7 +1107,7 @@ func (w *Writer) flush(key InternalKey) error {
 	// We're setting compressionDone to indicate that compression of this block
 	// has already been completed.
 	writeTask.compressionDone <- true
-	writeTask.buf = &w.dataBlockBuf
+	writeTask.buf = w.dataBlockBuf
 	writeTask.indexEntrySep = sep
 	writeTask.inflightSize = estimatedUncompressedSize
 	writeTask.currIndexBlock = w.indexBlock
@@ -1086,7 +1118,9 @@ func (w *Writer) flush(key InternalKey) error {
 	// The writeTask corresponds to an unwritten index entry.
 	w.indexBlock.addInflight(writeTask.indexInflightSize)
 
+	w.dataBlockBuf = nil
 	err = w.coordination.writeQueue.addSync(writeTask)
+	w.dataBlockBuf = newDataBlockBuf(w.restartInterval, w.checksumType)
 
 	return err
 }
@@ -1136,7 +1170,7 @@ func (w *Writer) finishDataBlockProps(buf *dataBlockBuf) error {
 func (w *Writer) maybeAddBlockPropertiesToBlockHandle(
 	bh BlockHandle,
 ) (BlockHandleWithProperties, error) {
-	err := w.finishDataBlockProps(&w.dataBlockBuf)
+	err := w.finishDataBlockProps(w.dataBlockBuf)
 	if err != nil {
 		return BlockHandleWithProperties{}, err
 	}
@@ -1167,6 +1201,8 @@ func (w *Writer) indexEntrySep(prevKey, key InternalKey, dataBlockBuf *dataBlock
 // 1. addIndexEntry must not store references to the sep InternalKey, the tmp
 //    byte slice, bhp.Props. That is, these must be either deep copied or
 //    encoded.
+// 2. addIndexEntry must not hold references to the flushIndexBuf, and the writeTo
+//    indexBlockBufs.
 func (w *Writer) addIndexEntry(
 	sep InternalKey,
 	bhp BlockHandleWithProperties,
@@ -1211,12 +1247,12 @@ func (w *Writer) addPrevDataBlockToIndexBlockProps() {
 // aren't being written asynchronously.
 //
 // Invariant:
-// 1. addIndexEntry must not store references to the prevKey, key InternalKey's,
+// 1. addIndexEntrySync must not store references to the prevKey, key InternalKey's,
 //    the tmp byte slice. That is, these must be either deep copied or encoded.
 func (w *Writer) addIndexEntrySync(
 	prevKey, key InternalKey, bhp BlockHandleWithProperties, tmp []byte,
 ) error {
-	sep := w.indexEntrySep(prevKey, key, &w.dataBlockBuf)
+	sep := w.indexEntrySep(prevKey, key, w.dataBlockBuf)
 	shouldFlush := supportsTwoLevelIndex(
 		w.tableFormat) && w.indexBlock.shouldFlush(
 		sep, encodedBHPEstimatedSize, w.indexBlockSize, w.indexBlockSizeThreshold,
@@ -1228,7 +1264,8 @@ func (w *Writer) addIndexEntrySync(
 		flushableIndexBlock = w.indexBlock
 		w.indexBlock = newIndexBlockBuf()
 
-		// Call BlockPropertyCollector.FinishIndexBlock, since we've decided to flush the index block.
+		// Call BlockPropertyCollector.FinishIndexBlock, since we've decided to
+		// flush the index block.
 		props, err = w.finishIndexBlockProps()
 		if err != nil {
 			return err
@@ -1236,6 +1273,10 @@ func (w *Writer) addIndexEntrySync(
 	}
 
 	err = w.addIndexEntry(sep, bhp, tmp, flushableIndexBlock, w.indexBlock, 0, props)
+	if flushableIndexBlock != nil {
+		flushableIndexBlock.clear()
+		indexBlockBufPool.Put(flushableIndexBlock)
+	}
 	w.addPrevDataBlockToIndexBlockProps()
 	return err
 }
@@ -1484,7 +1525,7 @@ func (w *Writer) Close() (err error) {
 	//    however, if a dataBlock is flushed, then we add a key to the new w.dataBlockBuf in the
 	//    addPoint function after the flush occurs.
 	if w.dataBlockBuf.dataBlock.nEntries >= 1 {
-		w.meta.SetLargestPointKey(base.DecodeInternalKey(w.dataBlockBuf.dataBlock.curKey))
+		w.meta.SetLargestPointKey(base.DecodeInternalKey(w.dataBlockBuf.dataBlock.curKey).Clone())
 	}
 
 	// Finish the last data block, or force an empty data block if there
@@ -1720,6 +1761,13 @@ func (w *Writer) Close() (err error) {
 		return err
 	}
 
+	w.dataBlockBuf.clear()
+	dataBlockBufPool.Put(w.dataBlockBuf)
+	w.dataBlockBuf = nil
+	w.indexBlock.clear()
+	indexBlockBufPool.Put(w.indexBlock)
+	w.indexBlock = nil
+
 	// Make any future calls to Set or Close return an error.
 	w.err = errWriterClosed
 	return nil
@@ -1759,6 +1807,7 @@ type PreviousPointKeyOpt struct {
 // option was passed during creation. The returned key points directly into
 // a buffer belonging to the Writer. The value's lifetime ends the next time a
 // point key is added to the Writer.
+// Invariant: UnsafeKey isn't and shouldn't be called after the Writer is closed.
 func (o PreviousPointKeyOpt) UnsafeKey() base.InternalKey {
 	if o.w == nil {
 		return base.InvalidInternalKey
@@ -1826,7 +1875,7 @@ func NewWriter(f writeCloseSyncer, o WriterOptions, extraOpts ...WriterOption) *
 		},
 	}
 
-	w.dataBlockBuf.init(w.restartInterval, w.checksumType)
+	w.dataBlockBuf = newDataBlockBuf(w.restartInterval, w.checksumType)
 
 	w.blockBuf = blockBuf{
 		checksummer: checksummer{checksumType: o.Checksum},


### PR DESCRIPTION
Pooling gives us the ability to enable parallelism in the Writer.

```
name                                                          old time/op    new time/op    delta
Writer/block=4.0_K/filter=true/compression=NoCompression-16      114ms ±25%      98ms ± 5%     ~     (p=0.310 n=5+5)
Writer/block=4.0_K/filter=true/compression=Snappy-16             114ms ± 4%     112ms ± 3%     ~     (p=0.548 n=5+5)
Writer/block=4.0_K/filter=true/compression=ZSTD-16               1.12s ± 3%     1.09s ± 6%     ~     (p=0.310 n=5+5)
Writer/block=4.0_K/filter=false/compression=NoCompression-16    64.5ms ± 8%    61.7ms ± 2%     ~     (p=0.548 n=5+5)
Writer/block=4.0_K/filter=false/compression=Snappy-16           79.6ms ± 2%    79.4ms ± 2%     ~     (p=0.905 n=4+5)
Writer/block=4.0_K/filter=false/compression=ZSTD-16              1.08s ± 8%     1.10s ±16%     ~     (p=0.841 n=5+5)
Writer/block=32_K/filter=true/compression=NoCompression-16      93.6ms ± 4%    91.8ms ± 2%     ~     (p=0.310 n=5+5)
Writer/block=32_K/filter=true/compression=Snappy-16              110ms ±18%     104ms ± 3%     ~     (p=0.222 n=5+5)
Writer/block=32_K/filter=true/compression=ZSTD-16                254ms ± 4%     255ms ± 6%     ~     (p=0.905 n=4+5)
Writer/block=32_K/filter=false/compression=NoCompression-16     57.1ms ± 4%    57.7ms ± 2%     ~     (p=0.548 n=5+5)
Writer/block=32_K/filter=false/compression=Snappy-16            70.9ms ± 5%    75.5ms ±19%     ~     (p=0.421 n=5+5)
Writer/block=32_K/filter=false/compression=ZSTD-16               224ms ±10%     217ms ± 4%     ~     (p=0.548 n=5+5)

name                                                          old speed      new speed      delta
Writer/block=4.0_K/filter=true/compression=NoCompression-16    355MB/s ±22%   402MB/s ± 5%     ~     (p=0.310 n=5+5)
Writer/block=4.0_K/filter=true/compression=Snappy-16          97.0MB/s ± 4%  98.2MB/s ± 3%     ~     (p=0.548 n=5+5)
Writer/block=4.0_K/filter=true/compression=ZSTD-16            5.35MB/s ± 3%  5.51MB/s ± 7%     ~     (p=0.310 n=5+5)
Writer/block=4.0_K/filter=false/compression=NoCompression-16   595MB/s ± 7%   621MB/s ± 3%     ~     (p=0.548 n=5+5)
Writer/block=4.0_K/filter=false/compression=Snappy-16          118MB/s ±17%   123MB/s ± 2%     ~     (p=0.579 n=5+5)
Writer/block=4.0_K/filter=false/compression=ZSTD-16           4.40MB/s ± 7%  4.35MB/s ±14%     ~     (p=0.841 n=5+5)
Writer/block=32_K/filter=true/compression=NoCompression-16     417MB/s ± 4%   425MB/s ± 2%     ~     (p=0.310 n=5+5)
Writer/block=32_K/filter=true/compression=Snappy-16           73.4MB/s ±16%  77.5MB/s ± 3%     ~     (p=0.222 n=5+5)
Writer/block=32_K/filter=true/compression=ZSTD-16             12.6MB/s ±26%  13.4MB/s ± 7%     ~     (p=0.841 n=5+5)
Writer/block=32_K/filter=false/compression=NoCompression-16    663MB/s ± 4%   655MB/s ± 2%     ~     (p=0.548 n=5+5)
Writer/block=32_K/filter=false/compression=Snappy-16          95.7MB/s ± 5%  90.6MB/s ±17%     ~     (p=0.421 n=5+5)
Writer/block=32_K/filter=false/compression=ZSTD-16            9.73MB/s ± 9%  9.99MB/s ± 3%     ~     (p=0.444 n=5+5)

name                                                          old alloc/op   new alloc/op   delta
Writer/block=4.0_K/filter=true/compression=NoCompression-16     25.1MB ± 0%    25.1MB ± 0%   -0.06%  (p=0.008 n=5+5)
Writer/block=4.0_K/filter=true/compression=Snappy-16            25.1MB ± 0%    25.1MB ± 0%   -0.11%  (p=0.008 n=5+5)
Writer/block=4.0_K/filter=true/compression=ZSTD-16              84.2MB ± 0%    84.2MB ± 0%     ~     (p=0.841 n=5+5)
Writer/block=4.0_K/filter=false/compression=NoCompression-16     801kB ± 0%     784kB ± 0%   -2.10%  (p=0.008 n=5+5)
Writer/block=4.0_K/filter=false/compression=Snappy-16            836kB ± 0%     805kB ± 0%   -3.73%  (p=0.008 n=5+5)
Writer/block=4.0_K/filter=false/compression=ZSTD-16             59.9MB ± 0%    59.9MB ± 0%     ~     (p=0.548 n=5+5)
Writer/block=32_K/filter=true/compression=NoCompression-16      25.3MB ± 0%    25.1MB ± 0%   -0.52%  (p=0.008 n=5+5)
Writer/block=32_K/filter=true/compression=Snappy-16             25.5MB ± 0%    25.2MB ± 0%   -1.09%  (p=0.008 n=5+5)
Writer/block=32_K/filter=true/compression=ZSTD-16               74.2MB ± 0%    74.1MB ± 0%   -0.11%  (p=0.008 n=5+5)
Writer/block=32_K/filter=false/compression=NoCompression-16      953kB ± 0%     820kB ± 1%  -13.93%  (p=0.016 n=4+5)
Writer/block=32_K/filter=false/compression=Snappy-16            1.16MB ± 0%    0.87MB ± 2%  -24.91%  (p=0.016 n=4+5)
Writer/block=32_K/filter=false/compression=ZSTD-16              49.9MB ± 0%    49.8MB ± 0%   -0.16%  (p=0.008 n=5+5)

name                                                          old allocs/op  new allocs/op  delta
Writer/block=4.0_K/filter=true/compression=NoCompression-16        164 ± 4%       146 ± 3%  -10.87%  (p=0.008 n=5+5)
Writer/block=4.0_K/filter=true/compression=Snappy-16               171 ± 4%       150 ± 3%  -12.38%  (p=0.008 n=5+5)
Writer/block=4.0_K/filter=true/compression=ZSTD-16               85.3k ± 0%     85.3k ± 0%     ~     (p=1.000 n=5+5)
Writer/block=4.0_K/filter=false/compression=NoCompression-16       105 ± 1%        83 ± 1%  -20.46%  (p=0.008 n=5+5)
Writer/block=4.0_K/filter=false/compression=Snappy-16              112 ± 2%        87 ± 2%  -21.82%  (p=0.008 n=5+5)
Writer/block=4.0_K/filter=false/compression=ZSTD-16              85.2k ± 0%     85.2k ± 0%     ~     (p=0.548 n=5+5)
Writer/block=32_K/filter=true/compression=NoCompression-16         149 ± 2%       119 ± 2%  -20.16%  (p=0.008 n=5+5)
Writer/block=32_K/filter=true/compression=Snappy-16                154 ± 1%       121 ± 3%  -21.50%  (p=0.008 n=5+5)
Writer/block=32_K/filter=true/compression=ZSTD-16                10.6k ± 0%     10.6k ± 0%   -0.22%  (p=0.008 n=5+5)
Writer/block=32_K/filter=false/compression=NoCompression-16       97.0 ± 0%      66.4 ± 2%  -31.55%  (p=0.016 n=4+5)
Writer/block=32_K/filter=false/compression=Snappy-16               103 ± 1%        68 ± 5%  -33.79%  (p=0.008 n=5+5)
Writer/block=32_K/filter=false/compression=ZSTD-16               10.5k ± 0%     10.5k ± 0%   -0.22%  (p=0.008 n=5+5)