### PR TITLE
*: Skip over files with no point keys in point key levelIter

### DIFF
--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -137,7 +137,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 				largestKey := base.ParseInternalKey(keys[1])
 				m := (&fileMetadata{
 					FileNum: fileNum,
-				}).ExtendRangeKeyBounds(cmp, smallestKey, largestKey)
+				}).ExtendPointKeyBounds(cmp, smallestKey, largestKey)
 				*li = append(*li, m)
 
 				i++

--- a/level_iter.go
+++ b/level_iter.go
@@ -196,7 +196,7 @@ func (l *levelIter) init(
 	l.split = split
 	l.iterFile = nil
 	l.newIters = newIters
-	l.files = files
+	l.files = files.Filter(manifest.KeyTypePoint)
 	l.bytesIterated = bytesIterated
 }
 
@@ -231,8 +231,8 @@ func (l *levelIter) findFileGE(key []byte) *fileMetadata {
 	// (see the comment in that function).
 
 	m := l.files.SeekGE(l.cmp, key)
-	for m != nil && m.Largest.IsExclusiveSentinel() &&
-		l.cmp(m.Largest.UserKey, key) == 0 {
+	for m != nil && m.LargestPointKey.IsExclusiveSentinel() &&
+		l.cmp(m.LargestPointKey.UserKey, key) == 0 {
 		m = l.files.Next()
 	}
 	return m

--- a/testdata/level_iter_seek
+++ b/testdata/level_iter_seek
@@ -341,3 +341,51 @@ a/c-e#4#1,1:a
 e/<empty>#4,1:e
 i/<empty>#6,1:i
 j/<empty>#7,1:j
+
+# Verify that we do not open files that do not have point keys.
+
+clear
+----
+
+build
+a.SET.9:a
+b.SET.8:b
+----
+0: a#9,1-b#8,1
+
+build
+c.SET.7:c
+d.RANGEDEL.6:e
+f.SET.5:f
+----
+0: a#9,1-b#8,1
+1: c#7,1-f#5,1
+
+build format=pebblev2
+g.RANGEKEYSET.6:h
+----
+0: a#9,1-b#8,1
+1: c#7,1-f#5,1
+2: g#0,21-h#72057594037927935,21
+
+build
+i.SET.4:i
+j.SET.3:j
+----
+0: a#9,1-b#8,1
+1: c#7,1-f#5,1
+2: g#0,21-h#72057594037927935,21
+3: i#4,1-j#3,1
+
+iter
+seek-ge f
+next
+----
+f/<empty>#5,1:f
+i#4,1:i
+
+# The below count should be 2, as we skip over the rangekey-only file.
+
+iters-created
+----
+2


### PR DESCRIPTION
This change updates the LevelMetadata Seek{GE,LT} calls to
support specifying whether we are interested in files with
point keys, range keys, or both/combined. In future changes,
we will optimize this seek to be more efficient if we want
to skip over files with no range keys.