### PR TITLE
*: use crlfmt to enforce style

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,9 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
 
+    - name: install crlfmt
+      run: go get github.com/cockroachdb/crlfmt
+
     - name: install golint
       run: go get golang.org/x/lint/golint
 
@@ -48,6 +51,9 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: "1.17"
+
+    - name: install crlfmt
+      run: go get github.com/cockroachdb/crlfmt
 
     - name: install golint
       run: go get golang.org/x/lint/golint
@@ -68,6 +74,9 @@ jobs:
       with:
         go-version: "1.17"
 
+    - name: install crlfmt
+      run: go get github.com/cockroachdb/crlfmt
+
     - name: install golint
       run: go get golang.org/x/lint/golint
 
@@ -87,6 +96,9 @@ jobs:
       with:
         go-version: "1.17"
 
+    - name: install crlfmt
+      run: go get github.com/cockroachdb/crlfmt
+
     - name: install golint
       run: go get golang.org/x/lint/golint
 
@@ -105,6 +117,9 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: "1.17"
+
+    - name: install crlfmt
+      run: go get github.com/cockroachdb/crlfmt
 
     - name: install golint
       run: go get golang.org/x/lint/golint

--- a/cmd/pebble/fsbench.go
+++ b/cmd/pebble/fsbench.go
@@ -245,8 +245,9 @@ func createBench(benchName string, benchDescription string) fsBenchmark {
 
 // This benchmark prepopulates a directory with some files of a given size. Then, it creates and deletes
 // a file of some size, while measuring only the performance of the delete.
-func deleteBench(benchName string, benchDescription string, preNumFiles int,
-	preFileSize int, fileSize int) fsBenchmark {
+func deleteBench(
+	benchName string, benchDescription string, preNumFiles int, preFileSize int, fileSize int,
+) fsBenchmark {
 
 	createBench := func(dirpath string) *fsBench {
 		bench := &fsBench{}
@@ -312,7 +313,9 @@ func deleteBench(benchName string, benchDescription string, preNumFiles int,
 // This benchmark creates some files in a directory, and then measures the performance
 // of the vfs.Remove function.
 // fileSize is in bytes.
-func deleteUniformBench(benchName string, benchDescription string, numFiles int, fileSize int) fsBenchmark {
+func deleteUniformBench(
+	benchName string, benchDescription string, numFiles int, fileSize int,
+) fsBenchmark {
 	createBench := func(dirpath string) *fsBench {
 		bench := &fsBench{}
 		mkDir(dirpath)
@@ -377,8 +380,9 @@ func deleteUniformBench(benchName string, benchDescription string, numFiles int,
 // Tests the performance of syncing data to disk.
 // Only measures the sync performance.
 // The writes will be synced after every writeSize bytes have been written.
-func writeSyncBench(benchName string, benchDescription string,
-	maxFileSize int, writeSize int) fsBenchmark {
+func writeSyncBench(
+	benchName string, benchDescription string, maxFileSize int, writeSize int,
+) fsBenchmark {
 
 	if writeSize > maxFileSize {
 		log.Fatalln("File write threshold is greater than max file size.")
@@ -449,8 +453,9 @@ func writeSyncBench(benchName string, benchDescription string,
 
 // Tests the peformance of calling the vfs.GetDiskUsage call on a directory,
 // as the number of files/total size of files in the directory grows.
-func diskUsageBench(benchName string, benchDescription string,
-	maxFileSize int, writeSize int) fsBenchmark {
+func diskUsageBench(
+	benchName string, benchDescription string, maxFileSize int, writeSize int,
+) fsBenchmark {
 
 	if writeSize > maxFileSize {
 		log.Fatalln("File write threshold is greater than max file size.")

--- a/compaction_iter.go
+++ b/compaction_iter.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 
 	"github.com/cockroachdb/errors"
-
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/bytealloc"
 	"github.com/cockroachdb/pebble/internal/keyspan"

--- a/ingest.go
+++ b/ingest.go
@@ -46,11 +46,7 @@ func ingestValidateKey(opts *Options, key *InternalKey) error {
 }
 
 func ingestLoad1(
-	opts *Options,
-	fmv FormatMajorVersion,
-	path string,
-	cacheID uint64,
-	fileNum FileNum,
+	opts *Options, fmv FormatMajorVersion, path string, cacheID uint64, fileNum FileNum,
 ) (*fileMetadata, error) {
 	stat, err := opts.FS.Stat(path)
 	if err != nil {
@@ -199,11 +195,7 @@ func ingestLoad1(
 }
 
 func ingestLoad(
-	opts *Options,
-	fmv FormatMajorVersion,
-	paths []string,
-	cacheID uint64,
-	pending []FileNum,
+	opts *Options, fmv FormatMajorVersion, paths []string, cacheID uint64, pending []FileNum,
 ) ([]*fileMetadata, []string, error) {
 	meta := make([]*fileMetadata, 0, len(paths))
 	newPaths := make([]string, 0, len(paths))
@@ -343,10 +335,7 @@ func ingestMemtableOverlaps(cmp Compare, mem flushable, meta []*fileMetadata) bo
 }
 
 func ingestUpdateSeqNum(
-	cmp Compare,
-	format base.FormatKey,
-	seqNum uint64,
-	meta []*fileMetadata,
+	cmp Compare, format base.FormatKey, seqNum uint64, meta []*fileMetadata,
 ) error {
 	setSeqFn := func(k base.InternalKey) base.InternalKey {
 		return base.MakeInternalKey(k.UserKey, seqNum, k.Kind())
@@ -732,7 +721,9 @@ type ingestTargetLevelFunc func(
 	meta *fileMetadata,
 ) (int, error)
 
-func (d *DB) ingestApply(jobID int, meta []*fileMetadata, findTargetLevel ingestTargetLevelFunc) (*versionEdit, error) {
+func (d *DB) ingestApply(
+	jobID int, meta []*fileMetadata, findTargetLevel ingestTargetLevelFunc,
+) (*versionEdit, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 

--- a/internal/batchskl/skl.go
+++ b/internal/batchskl/skl.go
@@ -273,8 +273,10 @@ func (s *Skiplist) NewIter(lower, upper []byte) Iterator {
 	return Iterator{list: s, lower: lower, upper: upper}
 }
 
-func (s *Skiplist) newNode(height,
-	offset, keyStart, keyEnd uint32, abbreviatedKey uint64) (uint32, error) {
+func (s *Skiplist) newNode(
+	height,
+	offset, keyStart, keyEnd uint32, abbreviatedKey uint64,
+) (uint32, error) {
 	if height < 1 || height > maxHeight {
 		panic("height cannot be less than one or greater than the max height")
 	}

--- a/internal/keyspan/merging_iter_test.go
+++ b/internal/keyspan/merging_iter_test.go
@@ -381,7 +381,9 @@ func (i *mergingIterAdapter) SeekGE(key []byte, trySeekUsingNext bool) (*base.In
 	return i.firstFrag()
 }
 
-func (i *mergingIterAdapter) SeekPrefixGE(prefix, key []byte, trySeekUsingNext bool) (*base.InternalKey, []byte) {
+func (i *mergingIterAdapter) SeekPrefixGE(
+	prefix, key []byte, trySeekUsingNext bool,
+) (*base.InternalKey, []byte) {
 	panic("unimplemented")
 }
 

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -343,7 +343,9 @@ func NewL0Sublevels(
 // of old fileIntervals, into result. Returns the new result and a slice of ints
 // mapping old interval indices to new ones. The added intervalKeys do not
 // need to be sorted; they get sorted and deduped in this function.
-func mergeIntervals(old, result []fileInterval, added []intervalKeyTemp, compare Compare) ([]fileInterval, []int) {
+func mergeIntervals(
+	old, result []fileInterval, added []intervalKeyTemp, compare Compare,
+) ([]fileInterval, []int) {
 	sorter := intervalKeySorter{keys: added, cmp: compare}
 	sort.Sort(sorter)
 
@@ -440,7 +442,9 @@ func mergeIntervals(old, result []fileInterval, added []intervalKeyTemp, compare
 // were to another flushed file that was split into a separate sstable during
 // flush. Any other non-nil error means L0Sublevels generation failed in the same
 // way as NewL0Sublevels would likely fail.
-func (s *L0Sublevels) AddL0Files(files []*FileMetadata, flushSplitMaxBytes int64, levelMetadata *LevelMetadata) (*L0Sublevels, error) {
+func (s *L0Sublevels) AddL0Files(
+	files []*FileMetadata, flushSplitMaxBytes int64, levelMetadata *LevelMetadata,
+) (*L0Sublevels, error) {
 	if invariants.Enabled && s.addL0FilesCalled {
 		panic("AddL0Files called twice on the same receiver")
 	}

--- a/internal/rangekey/coalescer.go
+++ b/internal/rangekey/coalescer.go
@@ -148,7 +148,9 @@ type Coalescer struct {
 }
 
 // Init initializes a coalescer.
-func (c *Coalescer) Init(cmp base.Compare, formatKey base.FormatKey, visibleSeqNum uint64, emit func(CoalescedSpan)) {
+func (c *Coalescer) Init(
+	cmp base.Compare, formatKey base.FormatKey, visibleSeqNum uint64, emit func(CoalescedSpan),
+) {
 	c.emit = emit
 	c.formatKey = formatKey
 	c.visibleSeqNum = visibleSeqNum

--- a/internal/rangekey/interleaving_iter.go
+++ b/internal/rangekey/interleaving_iter.go
@@ -205,7 +205,9 @@ func (i *InterleavingIter) SeekGE(key []byte, trySeekUsingNext bool) (*base.Inte
 //
 // NB: In accordance with the base.InternalIterator contract:
 //   i.lower ≤ key
-func (i *InterleavingIter) SeekPrefixGE(prefix, key []byte, trySeekUsingNext bool) (*base.InternalKey, []byte) {
+func (i *InterleavingIter) SeekPrefixGE(
+	prefix, key []byte, trySeekUsingNext bool,
+) (*base.InternalKey, []byte) {
 	i.pointKey, i.pointVal = i.pointIter.SeekPrefixGE(prefix, key, trySeekUsingNext)
 	i.pointKeyInterleaved = false
 	i.nextRangeKey(i.rangeKeyIter.SeekGE(key))
@@ -594,7 +596,9 @@ func (i *InterleavingIter) yieldPointKey(covered bool) (*base.InternalKey, []byt
 	return i.verify(i.pointKey, i.pointVal)
 }
 
-func (i *InterleavingIter) yieldSyntheticRangeKeyMarker(lowerBound []byte) (*base.InternalKey, []byte) {
+func (i *InterleavingIter) yieldSyntheticRangeKeyMarker(
+	lowerBound []byte,
+) (*base.InternalKey, []byte) {
 	i.rangeKeyMarker.UserKey = i.rangeKey.Start
 	i.rangeKeyMarker.Trailer = base.InternalKeyBoundaryRangeKey
 	i.rangeKeyInterleaved = true

--- a/internal/rangekey/interleaving_iter_test.go
+++ b/internal/rangekey/interleaving_iter_test.go
@@ -162,7 +162,9 @@ func (i *pointIterator) SeekGE(key []byte, trySeekUsingNext bool) (*base.Interna
 	return &i.keys[i.index], nil
 }
 
-func (i *pointIterator) SeekPrefixGE(prefix, key []byte, trySeekUsingNext bool) (*base.InternalKey, []byte) {
+func (i *pointIterator) SeekPrefixGE(
+	prefix, key []byte, trySeekUsingNext bool,
+) (*base.InternalKey, []byte) {
 	return i.SeekGE(key, trySeekUsingNext)
 }
 

--- a/iterator.go
+++ b/iterator.go
@@ -11,14 +11,13 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/redact"
-
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/fastrand"
 	"github.com/cockroachdb/pebble/internal/humanize"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/rangekey"
+	"github.com/cockroachdb/redact"
 )
 
 // iterPos describes the state of the internal iterator, in terms of whether it

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -16,15 +16,14 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/pebble/internal/keyspan"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/rand"
-
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/rand"
 )
 
 var testKeyValuePairs = []string{
@@ -469,7 +468,9 @@ func (m *deletableSumValueMerger) Finish(includesBase bool) ([]byte, io.Closer, 
 	return []byte(strconv.FormatInt(m.sum, 10)), nil, nil
 }
 
-func (m *deletableSumValueMerger) DeletableFinish(includesBase bool) ([]byte, bool, io.Closer, error) {
+func (m *deletableSumValueMerger) DeletableFinish(
+	includesBase bool,
+) ([]byte, bool, io.Closer, error) {
 	value, closer, err := m.Finish(includesBase)
 	return value, len(value) == 0, closer, err
 }
@@ -922,7 +923,9 @@ func (i *iterSeekOptWrapper) SeekGE(key []byte, trySeekUsingNext bool) (*Interna
 	return i.internalIterator.SeekGE(key, trySeekUsingNext)
 }
 
-func (i *iterSeekOptWrapper) SeekPrefixGE(prefix, key []byte, trySeekUsingNext bool) (*InternalKey, []byte) {
+func (i *iterSeekOptWrapper) SeekPrefixGE(
+	prefix, key []byte, trySeekUsingNext bool,
+) (*InternalKey, []byte) {
 	if trySeekUsingNext {
 		*i.seekPrefixGEUsingNext++
 	}

--- a/merger.go
+++ b/merger.go
@@ -25,9 +25,9 @@ type DeletableValueMerger = base.DeletableValueMerger
 // DefaultMerger exports the base.DefaultMerger variable.
 var DefaultMerger = base.DefaultMerger
 
-func finishValueMerger(valueMerger ValueMerger, includesBase bool) (
-	value []byte, needDelete bool, closer io.Closer, err error,
-) {
+func finishValueMerger(
+	valueMerger ValueMerger, includesBase bool,
+) (value []byte, needDelete bool, closer io.Closer, err error) {
 	if valueMerger2, ok := valueMerger.(DeletableValueMerger); ok {
 		value, needDelete, closer, err = valueMerger2.DeletableFinish(includesBase)
 	} else {

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -40,10 +40,7 @@ type recordWriter interface {
 }
 
 func testGeneratorWriter(
-	t *testing.T,
-	reset func(),
-	gen func() (string, bool),
-	newWriter func(io.Writer) recordWriter,
+	t *testing.T, reset func(), gen func() (string, bool), newWriter func(io.Writer) recordWriter,
 ) {
 	buf := new(bytes.Buffer)
 

--- a/sstable/block_property.go
+++ b/sstable/block_property.go
@@ -176,8 +176,7 @@ type DataBlockIntervalCollector interface {
 // should be provided, rather than the same collector passed in twice (see the
 // comment on BlockIntervalCollector for more detail)
 func NewBlockIntervalCollector(
-	name string,
-	pointCollector, rangeCollector DataBlockIntervalCollector,
+	name string, pointCollector, rangeCollector DataBlockIntervalCollector,
 ) BlockPropertyCollector {
 	if pointCollector == nil && rangeCollector == nil {
 		panic("sstable: at least one interval collector must be provided")
@@ -327,7 +326,9 @@ type suffixReplacementBlockCollectorWrapper struct {
 }
 
 // UpdateKeySuffixes implements the SuffixReplaceableBlockCollector interface.
-func (w *suffixReplacementBlockCollectorWrapper) UpdateKeySuffixes(oldProp []byte, from, to []byte) error {
+func (w *suffixReplacementBlockCollectorWrapper) UpdateKeySuffixes(
+	oldProp []byte, from, to []byte,
+) error {
 	return w.BlockIntervalCollector.points.(SuffixReplaceableBlockCollector).UpdateKeySuffixes(oldProp, from, to)
 }
 
@@ -343,8 +344,7 @@ type blockIntervalFilter struct {
 // based on an interval property collected by BlockIntervalCollector and the
 // given [lower, upper) bounds. The given name specifies the
 // BlockIntervalCollector's properties to read.
-func NewBlockIntervalFilter(
-	name string, lower uint64, upper uint64) BlockPropertyFilter {
+func NewBlockIntervalFilter(name string, lower uint64, upper uint64) BlockPropertyFilter {
 	return &blockIntervalFilter{
 		name:           name,
 		filterInterval: interval{lower: lower, upper: upper},
@@ -488,7 +488,8 @@ func releaseBlockPropertiesFilterer(filterer *BlockPropertiesFilterer) {
 // additionally initializes the shortIDToFiltersIndex for the filters that are
 // relevant to this sstable.
 func (f *BlockPropertiesFilterer) IntersectsUserPropsAndFinishInit(
-	userProperties map[string]string) (bool, error) {
+	userProperties map[string]string,
+) (bool, error) {
 	for i := range f.filters {
 		props, ok := userProperties[f.filters[i].Name()]
 		if !ok {

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -1236,7 +1236,9 @@ func (p *intSuffixTablePropCollector) Finish(userProps map[string]string) error 
 
 func (p *intSuffixTablePropCollector) Name() string { return p.name }
 
-func (p *intSuffixTablePropCollector) UpdateKeySuffixes(oldProps map[string]string, from, to []byte) error {
+func (p *intSuffixTablePropCollector) UpdateKeySuffixes(
+	oldProps map[string]string, from, to []byte,
+) error {
 	return p.setFromSuffix(to)
 }
 

--- a/sstable/compression.go
+++ b/sstable/compression.go
@@ -75,7 +75,9 @@ func decompressBlock(cache *cache.Cache, blockType blockType, b []byte) (*cache.
 }
 
 // compressBlock compresses an SST block, using compressBuf as the desired destination.
-func compressBlock(compression Compression, b []byte, compressedBuf []byte) (blockType blockType, compressed []byte) {
+func compressBlock(
+	compression Compression, b []byte, compressedBuf []byte,
+) (blockType blockType, compressed []byte) {
 	switch compression {
 	case SnappyCompression:
 		return snappyCompressionBlockType, snappy.Encode(compressedBuf, b)

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -167,7 +167,9 @@ func runBuildCmd(
 	return meta, r, nil
 }
 
-func runBuildRawCmd(td *datadriven.TestData, opts *WriterOptions) (*WriterMetadata, *Reader, error) {
+func runBuildRawCmd(
+	td *datadriven.TestData, opts *WriterOptions,
+) (*WriterMetadata, *Reader, error) {
 	mem := vfs.NewMem()
 	f0, err := mem.Create("test")
 	if err != nil {

--- a/sstable/filter.go
+++ b/sstable/filter.go
@@ -4,9 +4,7 @@
 
 package sstable
 
-import (
-	"sync/atomic"
-)
+import "sync/atomic"
 
 // FilterMetrics holds metrics for the filter policy.
 type FilterMetrics struct {

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -25,7 +25,12 @@ import (
 // Any block and table property collectors configured in the WriterOptions must
 // implement SuffixReplaceableTableCollector/SuffixReplaceableBlockCollector.
 func RewriteKeySuffixes(
-	sst []byte, rOpts ReaderOptions, out writeCloseSyncer, o WriterOptions, from, to []byte, concurrency int,
+	sst []byte,
+	rOpts ReaderOptions,
+	out writeCloseSyncer,
+	o WriterOptions,
+	from, to []byte,
+	concurrency int,
 ) (*WriterMetadata, error) {
 	r, err := NewMemReader(sst, rOpts)
 	if err != nil {
@@ -98,8 +103,12 @@ type blockWithSpan struct {
 }
 
 func rewriteBlocks(
-	r *Reader, restartInterval int, checksumType ChecksumType, compression Compression,
-	input []BlockHandleWithProperties, output []blockWithSpan,
+	r *Reader,
+	restartInterval int,
+	checksumType ChecksumType,
+	compression Compression,
+	input []BlockHandleWithProperties,
+	output []blockWithSpan,
 	totalWorkers, worker int,
 	from, to []byte,
 	split Split,
@@ -189,10 +198,12 @@ func rewriteBlocks(
 }
 
 func rewriteDataBlocksToWriter(
-	r *Reader, w *Writer,
+	r *Reader,
+	w *Writer,
 	data []BlockHandleWithProperties,
 	from, to []byte,
-	split Split, concurrency int,
+	split Split,
+	concurrency int,
 ) error {
 	blocks := make([]blockWithSpan, len(data))
 

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -313,7 +313,9 @@ func newIndexBlockBuf() *indexBlockBuf {
 	return i
 }
 
-func (i *indexBlockBuf) shouldFlush(sep InternalKey, valueLen, targetBlockSize, sizeThreshold int) bool {
+func (i *indexBlockBuf) shouldFlush(
+	sep InternalKey, valueLen, targetBlockSize, sizeThreshold int,
+) bool {
 	if i.size.useMutex {
 		i.size.mu.Lock()
 		defer i.size.mu.Unlock()
@@ -378,7 +380,9 @@ type dataBlockEstimates struct {
 // newTotalSize is the new w.meta.Size. inflightSize is the uncompressed block size estimate which
 // was previously added to sizeEstimate.inflightSize. writtenSize is the compressed size of the block
 // which was written to disk.
-func (d *dataBlockEstimates) dataBlockWritten(newTotalSize uint64, inflightSize int, writtenSize int) {
+func (d *dataBlockEstimates) dataBlockWritten(
+	newTotalSize uint64, inflightSize int, writtenSize int,
+) {
 	if d.useMutex {
 		d.mu.Lock()
 		defer d.mu.Unlock()
@@ -493,7 +497,9 @@ func (d *dataBlockBuf) compressAndChecksum(c Compression) {
 	d.compressed = compressAndChecksum(d.uncompressed, c, &d.blockBuf)
 }
 
-func (d *dataBlockBuf) shouldFlush(key InternalKey, valueLen, targetBlockSize, sizeThreshold int) bool {
+func (d *dataBlockBuf) shouldFlush(
+	key InternalKey, valueLen, targetBlockSize, sizeThreshold int,
+) bool {
 	return shouldFlush(
 		key, valueLen, d.dataBlock.restartInterval, d.dataBlock.estimatedSize(),
 		d.dataBlock.nEntries, targetBlockSize, sizeThreshold)
@@ -1164,8 +1170,14 @@ func (w *Writer) indexEntrySep(prevKey, key InternalKey, dataBlockBuf *dataBlock
 //    byte slice, bhp.Props. That is, these must be either deep copied or
 //    encoded.
 func (w *Writer) addIndexEntry(
-	sep InternalKey, bhp BlockHandleWithProperties, tmp []byte,
-	flushIndexBuf *indexBlockBuf, writeTo *indexBlockBuf, inflightSize int, indexProps []byte) error {
+	sep InternalKey,
+	bhp BlockHandleWithProperties,
+	tmp []byte,
+	flushIndexBuf *indexBlockBuf,
+	writeTo *indexBlockBuf,
+	inflightSize int,
+	indexProps []byte,
+) error {
 	if bhp.Length == 0 {
 		// A valid blockHandle must be non-zero.
 		// In particular, it must have a non-zero length.
@@ -1204,7 +1216,8 @@ func (w *Writer) addPrevDataBlockToIndexBlockProps() {
 // 1. addIndexEntry must not store references to the prevKey, key InternalKey's,
 //    the tmp byte slice. That is, these must be either deep copied or encoded.
 func (w *Writer) addIndexEntrySync(
-	prevKey, key InternalKey, bhp BlockHandleWithProperties, tmp []byte) error {
+	prevKey, key InternalKey, bhp BlockHandleWithProperties, tmp []byte,
+) error {
 	sep := w.indexEntrySep(prevKey, key, &w.dataBlockBuf)
 	shouldFlush := supportsTwoLevelIndex(
 		w.tableFormat) && w.indexBlock.shouldFlush(
@@ -1230,8 +1243,9 @@ func (w *Writer) addIndexEntrySync(
 }
 
 func shouldFlush(
-	key InternalKey, valueLen int, restartInterval, estimatedBlockSize,
-	numEntries, targetBlockSize, sizeThreshold int,
+	key InternalKey,
+	valueLen int,
+	restartInterval, estimatedBlockSize, numEntries, targetBlockSize, sizeThreshold int,
 ) bool {
 	if numEntries == 0 {
 		return false
@@ -1380,9 +1394,7 @@ func compressAndChecksum(b []byte, compression Compression, blockBuf *blockBuf) 
 	return b
 }
 
-func (w *Writer) writeCompressedBlock(
-	block []byte, blockTrailerBuf []byte,
-) (BlockHandle, error) {
+func (w *Writer) writeCompressedBlock(block []byte, blockTrailerBuf []byte) (BlockHandle, error) {
 	bh := BlockHandle{Offset: w.meta.Size, Length: uint64(len(block))}
 
 	if w.cacheID != 0 && w.fileNum != 0 {

--- a/table_cache.go
+++ b/table_cache.go
@@ -307,7 +307,8 @@ func (c *tableCacheShard) releaseLoop() {
 // for intersection with any available table and block-level properties. Returns
 // true for ok if this table should be read by this iterator.
 func (c *tableCacheShard) checkAndIntersectFilters(
-	v *tableCacheValue, tableFilter func(userProps map[string]string) bool,
+	v *tableCacheValue,
+	tableFilter func(userProps map[string]string) bool,
 	blockPropertyFilters []BlockPropertyFilter,
 ) (ok bool, filterer *sstable.BlockPropertiesFilterer, err error) {
 	if tableFilter != nil &&

--- a/tool/db.go
+++ b/tool/db.go
@@ -6,6 +6,10 @@ package tool
 
 import (
 	"fmt"
+	"io"
+	"io/ioutil"
+	"text/tabwriter"
+
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/pebble"
@@ -16,9 +20,6 @@ import (
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/tool/logs"
 	"github.com/spf13/cobra"
-	"io"
-	"io/ioutil"
-	"text/tabwriter"
 )
 
 // dbT implements db-level tools, including both configuration state and the

--- a/tool/util.go
+++ b/tool/util.go
@@ -268,11 +268,7 @@ func formatKeyRange(w io.Writer, fmtKey keyFormatter, start, end *base.InternalK
 }
 
 func formatKeyValue(
-	w io.Writer,
-	fmtKey keyFormatter,
-	fmtValue valueFormatter,
-	key *base.InternalKey,
-	value []byte,
+	w io.Writer, fmtKey keyFormatter, fmtValue valueFormatter, key *base.InternalKey, value []byte,
 ) {
 	if key.Kind() == base.InternalKeyKindRangeDelete {
 		if fmtKey.spec != "null" {


### PR DESCRIPTION
A mechanical change to format all files using `crlfmt` (excluding files in the vendor directory), and apply a lint check to enforce via CI. This is similar to the test in Cockroach.