### PR TITLE
db: fix TestSplitUserKeyMigration flake

### DIFF
--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -243,6 +243,7 @@ func TestSplitUserKeyMigration(t *testing.T) {
 							fmt.Fprintln(&buf, info)
 						},
 					},
+					DisableAutomaticCompactions: true,
 				}
 				var err error
 				if d, err = runDBDefineCmd(td, opts); err != nil {
@@ -268,6 +269,7 @@ func TestSplitUserKeyMigration(t *testing.T) {
 					buf.Reset()
 				}
 				opts.FS = fs
+				opts.DisableAutomaticCompactions = true
 				var err error
 				d, err = Open("", opts)
 				if err != nil {
@@ -311,6 +313,18 @@ func TestSplitUserKeyMigration(t *testing.T) {
 			case "marked-file-count":
 				m := d.Metrics()
 				return fmt.Sprintf("%d files marked for compaction", m.Compact.MarkedFiles)
+			case "disable-automatic-compactions":
+				d.mu.Lock()
+				defer d.mu.Unlock()
+				switch v := td.CmdArgs[0].String(); v {
+				case "true":
+					d.opts.DisableAutomaticCompactions = true
+				case "false":
+					d.opts.DisableAutomaticCompactions = false
+				default:
+					return fmt.Sprintf("unknown value %q", v)
+				}
+				return ""
 			default:
 				return fmt.Sprintf("unrecognized command %q", td.Cmd)
 			}

--- a/testdata/split_user_key_migration
+++ b/testdata/split_user_key_migration
@@ -60,6 +60,9 @@ marked-file-count
 ----
 2 files marked for compaction
 
+disable-automatic-compactions false
+----
+
 # Ratcheting to 007 should force compaction of any files still marked for
 # compaction.
 
@@ -130,6 +133,9 @@ format-major-version
 marked-file-count
 ----
 5 files marked for compaction
+
+disable-automatic-compactions false
+----
 
 ratchet-format-major-version 007
 ----


### PR DESCRIPTION
Prevent automatic compactions from compacting away marked files before we get
an opportunity to check for their presence.

Fix #1571.