### PR TITLE
internal: add `InternalKeyKindIngestSST`

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -75,6 +75,7 @@ func TestBatch(t *testing.T) {
 		{InternalKeyKindLogData, "", ""},
 		{InternalKeyKindRangeKeyDelete, "grass", "green"},
 		{InternalKeyKindRangeKeyDelete, "", ""},
+		{InternalKeyKindIngestSST, "1.sst,2.sst", ""},
 	}
 	var b Batch
 	for _, tc := range testCases {
@@ -93,6 +94,8 @@ func TestBatch(t *testing.T) {
 			_ = b.LogData([]byte(tc.key), nil)
 		case InternalKeyKindRangeKeyDelete:
 			_ = b.Experimental().RangeKeyDelete([]byte(tc.key), []byte(tc.value), nil)
+		case InternalKeyKindIngestSST:
+			_ = b.IngestSSTs([]byte(tc.key), nil)
 		}
 	}
 	verifyTestCases(&b, testCases)
@@ -136,6 +139,8 @@ func TestBatch(t *testing.T) {
 			copy(d.Key, key)
 			copy(d.Value, value)
 			d.Finish()
+		case InternalKeyKindIngestSST:
+			_ = b.IngestSSTs([]byte(tc.key), nil)
 		}
 	}
 	verifyTestCases(&b, testCases)

--- a/internal.go
+++ b/internal.go
@@ -22,6 +22,7 @@ const (
 	InternalKeyKindRangeKeySet     = base.InternalKeyKindRangeKeySet
 	InternalKeyKindRangeKeyUnset   = base.InternalKeyKindRangeKeyUnset
 	InternalKeyKindRangeKeyDelete  = base.InternalKeyKindRangeKeyDelete
+	InternalKeyKindIngestSST       = base.InternalKeyIngestSST
 	InternalKeyKindInvalid         = base.InternalKeyKindInvalid
 	InternalKeySeqNumBatch         = base.InternalKeySeqNumBatch
 	InternalKeySeqNumMax           = base.InternalKeySeqNumMax

--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -60,6 +60,10 @@ const (
 	InternalKeyKindRangeKeyUnset InternalKeyKind = 20
 	InternalKeyKindRangeKeySet   InternalKeyKind = 21
 
+	// InternalKeyIngestSST is used to distinguish a batch that corresponds to
+	// the WAL entry for ingested sstables that are added to the memtable queue.
+	InternalKeyIngestSST InternalKeyKind = 22
+
 	// This maximum value isn't part of the file format. It's unlikely,
 	// but future extensions may increase this value.
 	//
@@ -69,7 +73,7 @@ const (
 	// which sorts 'less than or equal to' any other valid internalKeyKind, when
 	// searching for any kind of internal key formed by a certain user key and
 	// seqNum.
-	InternalKeyKindMax InternalKeyKind = 21
+	InternalKeyKindMax InternalKeyKind = 22
 
 	// A marker for an invalid key.
 	InternalKeyKindInvalid InternalKeyKind = 255
@@ -107,6 +111,7 @@ var internalKeyKindNames = []string{
 	InternalKeyKindRangeKeySet:    "RANGEKEYSET",
 	InternalKeyKindRangeKeyUnset:  "RANGEKEYUNSET",
 	InternalKeyKindRangeKeyDelete: "RANGEKEYDEL",
+	InternalKeyIngestSST:          "INGEST",
 	InternalKeyKindInvalid:        "INVALID",
 }
 

--- a/internal/base/internal_test.go
+++ b/internal/base/internal_test.go
@@ -41,7 +41,7 @@ func TestInvalidInternalKey(t *testing.T) {
 		"\x01\x02\x03\x04\x05\x06\x07",
 		"foo",
 		"foo\x08\x07\x06\x05\x04\x03\x02",
-		"foo\x16\x07\x06\x05\x04\x03\x02\x01",
+		"foo\x17\x07\x06\x05\x04\x03\x02\x01",
 	}
 	for _, tc := range testCases {
 		k := DecodeInternalKey([]byte(tc))

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -509,6 +509,8 @@ func (o *ingestOp) collapseBatch(t *test, b *pebble.Batch) (*pebble.Batch, error
 				err = collapsed.Merge(key.UserKey, value, nil)
 			case pebble.InternalKeyKindLogData:
 				err = collapsed.LogData(key.UserKey, nil)
+			case pebble.InternalKeyKindIngestSST:
+				err = collapsed.IngestSSTs(key.UserKey, nil)
 			default:
 				err = errors.Errorf("unknown batch record kind: %d", key.Kind())
 			}

--- a/mem_table.go
+++ b/mem_table.go
@@ -213,8 +213,8 @@ func (m *memTable) apply(batch *Batch, seqNum uint64) error {
 		case InternalKeyKindRangeKeySet, InternalKeyKindRangeKeyUnset, InternalKeyKindRangeKeyDelete:
 			err = m.rangeKeySkl.Add(ikey, value)
 			rangeKeyCount++
-		case InternalKeyKindLogData:
-			// Don't increment seqNum for LogData, since these are not applied
+		case InternalKeyKindLogData, InternalKeyKindIngestSST:
+			// Don't increment seqNum for LogData or IngestSST, since these are not applied
 			// to the memtable.
 			seqNum--
 		default:

--- a/open.go
+++ b/open.go
@@ -637,6 +637,13 @@ func (d *DB) replayWAL(
 		seqNum := b.SeqNum()
 		maxSeqNum = seqNum + uint64(b.Count())
 
+		br := b.Reader()
+		if kind, _, _, _ := br.Next(); kind == InternalKeyKindIngestSST {
+			// TODO(mufeez): construct flushable of sstables and add to queue
+			buf.Reset()
+			continue
+		}
+
 		if b.memTableSize >= uint64(d.largeBatchThreshold) {
 			flushMem()
 			// Make a copy of the data slice since it is currently owned by buf and will


### PR DESCRIPTION
This PR adds a new InternalKeyKind that will be used to add a WAL entry when replaying/performing an ingest that adds ingested sstables to the memtable queue.