### PR TITLE
internal/keyspan: Add LevelIter for range keys 

### DIFF
--- a/db.go
+++ b/db.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/arenaskl"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/manual"
 	"github.com/cockroachdb/pebble/record"
@@ -261,7 +262,7 @@ type DB struct {
 
 	tableCache           *tableCacheContainer
 	newIters             tableNewIters
-	tableNewRangeKeyIter tableNewRangeKeyIter
+	tableNewRangeKeyIter keyspan.TableNewRangeKeyIter
 
 	commit *commitPipeline
 

--- a/internal/base/options.go
+++ b/internal/base/options.go
@@ -63,3 +63,14 @@ type FilterPolicy interface {
 	// NewWriter creates a new FilterWriter.
 	NewWriter(ftype FilterType) FilterWriter
 }
+
+// BlockPropertyFilter is used in an Iterator to filter sstables and blocks
+// within the sstable. It should not maintain any per-sstable state, and must
+// be thread-safe.
+type BlockPropertyFilter interface {
+	// Name returns the name of the block property collector.
+	Name() string
+	// Intersects returns true if the set represented by prop intersects with
+	// the set in the filter.
+	Intersects(prop []byte) (bool, error)
+}

--- a/internal/keyspan/iter_test.go
+++ b/internal/keyspan/iter_test.go
@@ -14,6 +14,65 @@ import (
 	"github.com/cockroachdb/pebble/internal/datadriven"
 )
 
+func runFragmentIteratorCmd(iter FragmentIterator, input string, extraInfo func() string) string {
+	var b bytes.Buffer
+	for _, line := range strings.Split(input, "\n") {
+		parts := strings.Fields(line)
+		if len(parts) == 0 {
+			continue
+		}
+		var span Span
+		switch parts[0] {
+		case "seek-ge":
+			if len(parts) != 2 {
+				return "seek-ge <key>\n"
+			}
+			span = iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
+		case "seek-lt":
+			if len(parts) != 2 {
+				return "seek-lt <key>\n"
+			}
+			span = iter.SeekLT([]byte(strings.TrimSpace(parts[1])))
+		case "first":
+			span = iter.First()
+		case "last":
+			span = iter.Last()
+		case "next":
+			span = iter.Next()
+		case "prev":
+			span = iter.Prev()
+		case "set-bounds":
+			if len(parts) != 3 {
+				return fmt.Sprintf("set-bounds expects 2 bounds, got %d", len(parts)-1)
+			}
+			l, u := []byte(parts[1]), []byte(parts[2])
+			if parts[1] == "." {
+				l = nil
+			}
+			if parts[2] == "." {
+				u = nil
+			}
+			iter.SetBounds(l, u)
+			fmt.Fprintf(&b, ".\n")
+			continue
+		default:
+			return fmt.Sprintf("unknown op: %s", parts[0])
+		}
+		if span.Valid() {
+			fmt.Fprintf(&b, "%s", span)
+			if extraInfo != nil {
+				fmt.Fprintf(&b, " (%s)", extraInfo())
+			}
+			b.WriteByte('\n')
+		} else if err := iter.Error(); err != nil {
+			fmt.Fprintf(&b, "err=%v\n", err)
+		} else {
+			fmt.Fprintf(&b, ".\n")
+		}
+	}
+	return b.String()
+}
+
 func TestIter(t *testing.T) {
 	var spans []Span
 	datadriven.RunTest(t, "testdata/iter", func(d *datadriven.TestData) string {
@@ -29,59 +88,7 @@ func TestIter(t *testing.T) {
 			iter := NewIter(base.DefaultComparer.Compare, spans)
 			defer iter.Close()
 
-			var b bytes.Buffer
-			for _, line := range strings.Split(d.Input, "\n") {
-				parts := strings.Fields(line)
-				if len(parts) == 0 {
-					continue
-				}
-				var span Span
-				switch parts[0] {
-				case "seek-ge":
-					if len(parts) != 2 {
-						return "seek-ge <key>\n"
-					}
-					span = iter.SeekGE([]byte(strings.TrimSpace(parts[1])))
-				case "seek-lt":
-					if len(parts) != 2 {
-						return "seek-lt <key>\n"
-					}
-					span = iter.SeekLT([]byte(strings.TrimSpace(parts[1])))
-				case "first":
-					span = iter.First()
-				case "last":
-					span = iter.Last()
-				case "next":
-					span = iter.Next()
-				case "prev":
-					span = iter.Prev()
-				case "set-bounds":
-					if len(parts) != 3 {
-						return fmt.Sprintf("set-bounds expects 2 bounds, got %d", len(parts)-1)
-					}
-					l, u := []byte(parts[1]), []byte(parts[2])
-					if parts[1] == "." {
-						l = nil
-					}
-					if parts[2] == "." {
-						u = nil
-					}
-					iter.SetBounds(l, u)
-					fmt.Fprintf(&b, ".\n")
-					continue
-				default:
-					return fmt.Sprintf("unknown op: %s", parts[0])
-				}
-				if span.Valid() {
-					fmt.Fprintln(&b, span)
-				} else if err := iter.Error(); err != nil {
-					fmt.Fprintf(&b, "err=%v\n", err)
-				} else {
-					fmt.Fprintf(&b, ".\n")
-				}
-			}
-			return b.String()
-
+			return runFragmentIteratorCmd(iter, d.Input, nil)
 		default:
 			return fmt.Sprintf("unknown command: %s", d.Cmd)
 		}

--- a/internal/keyspan/level_iter.go
+++ b/internal/keyspan/level_iter.go
@@ -1,0 +1,492 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package keyspan
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/internal/manifest"
+)
+
+// Logger defines an interface for writing log messages.
+type Logger interface {
+	Infof(format string, args ...interface{})
+	Fatalf(format string, args ...interface{})
+}
+
+// LevelIter provides a merged view of the range keys from sstables in a level.
+// It takes advantage of level invaraints to only have one sstable range
+// key block open at once time, opened using the newIter function passed in.
+type LevelIter struct {
+	logger Logger
+	cmp    base.Compare
+	// The lower/upper bounds for iteration as specified at creation or the most
+	// recent call to SetBounds. These slices could point to the same underlying
+	// memory as {Lower,Upper}Bounds in the passed-in RangeIterOptions, and also
+	// returned as part of Spans when the iterator is at bounds. While the
+	// bounds in tableOpts could be set to nil if they don't apply to the current
+	// file, the bounds here will remain unmodified until reset or updated by the
+	// caller using SetBounds.
+	lower []byte
+	upper []byte
+	// The LSM level this LevelIter is initialized for. Used in logging.
+	level manifest.Level
+	// The iter for the current file. It is nil under any of the following conditions:
+	// - files.Current() == nil
+	// - err != nil
+	// - some other constraint, like the bounds in opts, caused the file at index to not
+	//   be relevant to the iteration.
+	iter     FragmentIterator
+	iterFile *manifest.FileMetadata
+	newIter  TableNewRangeKeyIter
+	files    manifest.LevelIterator
+	err      error
+
+	// The options that were passed in. If bounds do not need to be checked for
+	// the current file, tableOpts.{Lower,Upper}Bound could be set to nil.
+	tableOpts RangeIterOptions
+
+	// Set to true if the last positioning operation put us beyond the bounds.
+	// The underlying iterator is left valid to allow relative positioning
+	// operations that could make the iterator valid again.
+	exhaustedBounds bool
+
+	// TODO(bilal): Add InternalIteratorStats.
+}
+
+// LevelIter implements the keyspan.FragmentIterator interface.
+var _ FragmentIterator = (*LevelIter)(nil)
+
+// newLevelIter returns a LevelIter.
+func newLevelIter(
+	opts RangeIterOptions,
+	cmp base.Compare,
+	newIter TableNewRangeKeyIter,
+	files manifest.LevelIterator,
+	level manifest.Level,
+	logger Logger,
+) *LevelIter {
+	l := &LevelIter{}
+	l.Init(opts, cmp, newIter, files, level, logger)
+	return l
+}
+
+// Init initializes a LevelIter.
+func (l *LevelIter) Init(
+	opts RangeIterOptions,
+	cmp base.Compare,
+	newIter TableNewRangeKeyIter,
+	files manifest.LevelIterator,
+	level manifest.Level,
+	logger Logger,
+) {
+	l.err = nil
+	l.level = level
+	l.logger = logger
+	l.lower = opts.LowerBound
+	l.upper = opts.UpperBound
+	l.tableOpts.Filters = opts.Filters
+	l.cmp = cmp
+	l.iterFile = nil
+	l.newIter = newIter
+	l.files = files.Filter(manifest.KeyTypeRange)
+}
+
+// Clone implements the keyspan.FragmentIterator interface
+func (l *LevelIter) Clone() FragmentIterator {
+	l2 := &LevelIter{
+		logger:    l.logger,
+		cmp:       l.cmp,
+		lower:     append([]byte(nil), l.lower...),
+		upper:     append([]byte(nil), l.upper...),
+		level:     l.level,
+		iter:      l.iter.Clone(),
+		iterFile:  l.iterFile,
+		newIter:   l.newIter,
+		files:     l.files.Clone(),
+		err:       l.err,
+		tableOpts: l.tableOpts,
+	}
+	return l2
+}
+
+func (l *LevelIter) findFileGE(key []byte) *manifest.FileMetadata {
+	// Find the earliest file whose largest key is >= key.
+	//
+	// If the earliest file has its largest key == key and that largest key is a
+	// range deletion sentinel, we know that we manufactured this sentinel to convert
+	// the exclusive range deletion end key into an inclusive key (reminder: [start, end)#seqnum
+	// is the form of a range deletion sentinel which can contribute a largest key = end#sentinel).
+	// In this case we don't return this as the earliest file since there is nothing actually
+	// equal to key in it.
+
+	m := l.files.SeekGE(l.cmp, key)
+	for m != nil && m.LargestRangeKey.IsExclusiveSentinel() &&
+		l.cmp(m.LargestRangeKey.UserKey, key) == 0 {
+		m = l.files.Next()
+	}
+	return m
+}
+
+func (l *LevelIter) findFileLT(key []byte) *manifest.FileMetadata {
+	// Find the last file whose smallest key is < key.
+	return l.files.SeekLT(l.cmp, key)
+}
+
+// Init the iteration bounds for the current table. Returns -1 if the table
+// lies fully before the lower bound, +1 if the table lies fully after the
+// upper bound, and 0 if the table overlaps the iteration bounds.
+func (l *LevelIter) initTableBounds(f *manifest.FileMetadata) int {
+	l.tableOpts.LowerBound = l.lower
+	l.tableOpts.UpperBound = l.upper
+	if l.tableOpts.LowerBound != nil {
+		if cmp := l.cmp(f.LargestRangeKey.UserKey, l.tableOpts.LowerBound); cmp < 0 ||
+			(cmp == 0 && f.LargestRangeKey.IsExclusiveSentinel()) {
+			// The largest key in the sstable is smaller than the lower bound.
+			return -1
+		}
+		if l.cmp(l.tableOpts.LowerBound, f.SmallestRangeKey.UserKey) <= 0 {
+			// The lower bound is smaller or equal to the smallest key in the
+			// table. Iteration within the table does not need to check the lower
+			// bound.
+			l.tableOpts.LowerBound = nil
+		}
+	}
+	if l.tableOpts.UpperBound != nil {
+		if l.cmp(f.SmallestRangeKey.UserKey, l.tableOpts.UpperBound) >= 0 {
+			// The smallest key in the sstable is greater than or equal to the upper
+			// bound.
+			return 1
+		}
+		if l.cmp(l.tableOpts.UpperBound, f.LargestRangeKey.UserKey) > 0 {
+			// The upper bound is greater than the largest key in the
+			// table. Iteration within the table does not need to check the upper
+			// bound. NB: tableOpts.UpperBound is exclusive and f.Largest is inclusive.
+			l.tableOpts.UpperBound = nil
+		}
+	}
+	return 0
+}
+
+type loadFileReturnIndicator int8
+
+const (
+	noFileLoaded loadFileReturnIndicator = iota
+	fileAlreadyLoaded
+	newFileLoaded
+)
+
+func (l *LevelIter) loadFile(file *manifest.FileMetadata, dir int) loadFileReturnIndicator {
+	indicator := noFileLoaded
+	if l.iterFile == file {
+		if l.err != nil {
+			return noFileLoaded
+		}
+		if l.iter != nil {
+			// We are already at the file, but we would need to check for bounds.
+			// Set indicator accordingly.
+			indicator = fileAlreadyLoaded
+		}
+		// We were already at file, but don't have an iterator, probably because the file was
+		// beyond the iteration bounds. It may still be, but it is also possible that the bounds
+		// have changed. We handle that below.
+	}
+
+	// Note that LevelIter.Close() can be called multiple times.
+	if indicator != fileAlreadyLoaded {
+		if err := l.Close(); err != nil {
+			return noFileLoaded
+		}
+	}
+
+	for {
+		l.iterFile = file
+		if file == nil {
+			return noFileLoaded
+		}
+
+		switch l.initTableBounds(file) {
+		case -1:
+			// The largest key in the sstable is smaller than the lower bound.
+			if dir < 0 {
+				l.exhaustedBounds = true
+				return noFileLoaded
+			}
+			file = l.files.Next()
+			indicator = noFileLoaded
+			continue
+		case +1:
+			// The smallest key in the sstable is greater than or equal to the upper
+			// bound.
+			if dir > 0 {
+				l.exhaustedBounds = true
+				return noFileLoaded
+			}
+			file = l.files.Prev()
+			indicator = noFileLoaded
+			continue
+		}
+		// case 0: The current file overlaps with the iteration bounds. We could
+		// still have to check returned Spans based on bounds.
+
+		if indicator != fileAlreadyLoaded {
+			l.iter, l.err = l.newIter(l.files.Current(), &l.tableOpts)
+			indicator = newFileLoaded
+		}
+		if l.err != nil {
+			return noFileLoaded
+		}
+		return indicator
+	}
+}
+
+// In race builds we verify that the keys returned by LevelIter lie within
+// [lower,upper).
+func (l *LevelIter) verify(span Span) Span {
+	if invariants.Enabled && span.Valid() {
+		// Confirm that bounds checking is working.
+		if l.lower != nil && l.cmp(span.End, l.lower) <= 0 {
+			l.logger.Fatalf("LevelIter %s: lower bound violation: %s <= %s\n%s", l.level, span.End, l.lower, debug.Stack())
+		}
+		// Note that we are checking span.End here, and not key. We expect that
+		// the corresponding end key for this range key has already been populated
+		// into span.
+		if l.upper != nil && l.cmp(span.Start, l.upper) >= 0 {
+			l.logger.Fatalf("LevelIter %s: upper bound violation: %s >= %s\n%s", l.level, span.Start, l.upper, debug.Stack())
+		}
+	}
+	return span
+}
+
+// checkLowerBound checks the span according to the lower bound. Could also
+// invalidate the entire iterator if we are beyond bounds.
+func (l *LevelIter) checkLowerBound(span Span) Span {
+	if l.cmp(l.tableOpts.LowerBound, span.End) >= 0 {
+		// Completely past bound.
+		l.exhaustedBounds = true
+		return Span{}
+	}
+	return span
+}
+
+// checkUpperBound checks the span according to the upper bound. Could also
+// invalidate the entire iterator if we are beyond bounds.
+func (l *LevelIter) checkUpperBound(span Span) Span {
+	if l.cmp(span.Start, l.tableOpts.UpperBound) >= 0 {
+		// Past bound.
+		l.exhaustedBounds = true
+		return Span{}
+	}
+	return span
+}
+
+// SeekGE implements keyspan.FragmentIterator.
+func (l *LevelIter) SeekGE(key []byte) Span {
+	l.err = nil // clear cached iteration error
+	l.exhaustedBounds = false
+
+	loadFileIndicator := l.loadFile(l.findFileGE(key), +1)
+	if loadFileIndicator == noFileLoaded {
+		return Span{}
+	}
+	if span := l.iter.SeekGE(key); span.Valid() {
+		if l.tableOpts.LowerBound != nil {
+			span = l.checkLowerBound(span)
+		}
+		if l.tableOpts.UpperBound != nil {
+			span = l.checkUpperBound(span)
+		}
+		return l.verify(span)
+	}
+	return l.verify(l.skipEmptyFileForward())
+}
+
+// SeekLT implements keyspan.FragmentIterator.
+func (l *LevelIter) SeekLT(key []byte) Span {
+	l.err = nil // clear cached iteration error
+	l.exhaustedBounds = false
+
+	// NB: the top-level Iterator has already adjusted key based on
+	// IterOptions.UpperBound.
+	if l.loadFile(l.findFileLT(key), -1) == noFileLoaded {
+		return Span{}
+	}
+	if span := l.iter.SeekLT(key); span.Valid() {
+		if l.tableOpts.LowerBound != nil {
+			span = l.checkLowerBound(span)
+		}
+		if l.tableOpts.UpperBound != nil {
+			span = l.checkUpperBound(span)
+		}
+		return l.verify(span)
+	}
+	return l.verify(l.skipEmptyFileBackward())
+}
+
+// First implements keyspan.FragmentIterator.
+func (l *LevelIter) First() Span {
+	l.err = nil // clear cached iteration error
+	l.exhaustedBounds = false
+
+	if l.loadFile(l.files.First(), +1) == noFileLoaded {
+		return Span{}
+	}
+	if span := l.iter.First(); span.Valid() {
+		// We only need to check for the upper bound here, as the toplevel Iter
+		// should have turned a First call into a SeekGE if we had a lower bound
+		if l.tableOpts.UpperBound != nil {
+			span = l.checkUpperBound(span)
+		}
+		return l.verify(span)
+	}
+	return l.verify(l.skipEmptyFileForward())
+}
+
+// Last implements keyspan.FragmentIterator.
+func (l *LevelIter) Last() Span {
+	l.err = nil // clear cached iteration error
+	l.exhaustedBounds = false
+
+	if l.loadFile(l.files.Last(), -1) == noFileLoaded {
+		return Span{}
+	}
+	if span := l.iter.Last(); span.Valid() {
+		if l.tableOpts.LowerBound != nil {
+			span = l.checkLowerBound(span)
+		}
+		if l.tableOpts.UpperBound != nil {
+			span = l.checkUpperBound(span)
+		}
+		return l.verify(span)
+	}
+	return l.verify(l.skipEmptyFileBackward())
+}
+
+// Next implements keyspan.FragmentIterator.
+func (l *LevelIter) Next() Span {
+	if l.err != nil || l.iter == nil {
+		return Span{}
+	}
+	l.exhaustedBounds = false
+
+	if span := l.iter.Next(); span.Valid() {
+		if l.tableOpts.LowerBound != nil {
+			span = l.checkLowerBound(span)
+		}
+		if l.tableOpts.UpperBound != nil {
+			span = l.checkUpperBound(span)
+		}
+		return l.verify(span)
+	}
+	return l.verify(l.skipEmptyFileForward())
+}
+
+// Prev implements keyspan.FragmentIterator.
+func (l *LevelIter) Prev() Span {
+	if l.err != nil || l.iter == nil {
+		return Span{}
+	}
+	l.exhaustedBounds = false
+
+	if span := l.iter.Prev(); span.Valid() {
+		if l.tableOpts.LowerBound != nil {
+			span = l.checkLowerBound(span)
+		}
+		if l.tableOpts.UpperBound != nil {
+			span = l.checkUpperBound(span)
+		}
+		return l.verify(span)
+	}
+	return l.verify(l.skipEmptyFileBackward())
+}
+
+func (l *LevelIter) skipEmptyFileForward() Span {
+	// TODO(bilal): Instead of skipping forward until the next file with a range
+	// key and returning the first span, return an empty span (i.e. a Span with
+	// start/end but no keys) until the next file that could return a range key
+	// without necessarily opening that file.
+	var span Span
+	for ; span.Empty(); span = l.iter.First() {
+		// Current file was exhausted. Move to the next file.
+		if l.loadFile(l.files.Next(), +1) == noFileLoaded {
+			return Span{}
+		}
+	}
+	if l.tableOpts.UpperBound != nil {
+		span = l.checkUpperBound(span)
+	}
+	return span
+}
+
+func (l *LevelIter) skipEmptyFileBackward() Span {
+	// TODO(bilal): Instead of skipping backward until the previous file with a
+	// range key and returning the last span, return an empty span (i.e. a Span
+	// with start/end but no keys) until the prev file that could return a range
+	// key without necessarily opening that file.
+	var span Span
+	for ; span.Empty(); span = l.iter.Last() {
+		// Current file was exhausted. Move to the previous file.
+		if l.loadFile(l.files.Prev(), -1) == noFileLoaded {
+			return Span{}
+		}
+	}
+	if l.tableOpts.LowerBound != nil {
+		span = l.checkLowerBound(span)
+	}
+	return span
+}
+
+// Error implements keyspan.FragmentIterator.
+func (l *LevelIter) Error() error {
+	if l.err != nil || l.iter == nil {
+		return l.err
+	}
+	return l.iter.Error()
+}
+
+// Close implements keyspan.FragmentIterator.
+func (l *LevelIter) Close() error {
+	if l.iter != nil {
+		l.err = l.iter.Close()
+		l.iter = nil
+	}
+	return l.err
+}
+
+// SetBounds implements keyspan.FragmentIterator.
+func (l *LevelIter) SetBounds(lower, upper []byte) {
+	l.lower = lower
+	l.upper = upper
+
+	if l.iter == nil {
+		return
+	}
+
+	// Update tableOpts.{Lower,Upper}Bound in case the new boundaries fall within
+	// the boundaries of the current table.
+	if l.initTableBounds(l.iterFile) != 0 {
+		// The table does not overlap the bounds. Close() will set LevelIter.err if
+		// an error occurs.
+		_ = l.Close()
+		return
+	}
+
+	// We do not call SetBounds on l.iter, as range key block iterators do not
+	// support SetBounds.
+	//
+	// TODO(bilal): Update fragmentBlockIter to do bounds checking as well.
+	l.exhaustedBounds = true
+}
+
+// String implements keyspan.FragmentIterator.
+func (l *LevelIter) String() string {
+	if l.iterFile != nil {
+		return fmt.Sprintf("%s: fileNum=%s", l.level, l.iterFile.FileNum)
+	}
+	return fmt.Sprintf("%s: fileNum=<nil>", l.level)
+}

--- a/internal/keyspan/level_iter_test.go
+++ b/internal/keyspan/level_iter_test.go
@@ -1,0 +1,439 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package keyspan
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLevelIterEquivalence(t *testing.T) {
+	type level [][]Span
+	testCases := []struct {
+		name   string
+		levels []level
+	}{
+		{
+			"single level, no gaps, no overlaps",
+			[]level{
+				{
+					{
+						Span{
+							Start: []byte("a"),
+							End:   []byte("b"),
+							Keys: []Key{{
+								Trailer: base.MakeTrailer(2, base.InternalKeyKindRangeKeySet),
+								Suffix:  nil,
+								Value:   []byte("foo"),
+							}},
+						},
+						Span{
+							Start: []byte("b"),
+							End:   []byte("c"),
+							Keys: []Key{{
+								Trailer: base.MakeTrailer(2, base.InternalKeyKindRangeKeySet),
+								Suffix:  nil,
+								Value:   []byte("foo"),
+							}},
+						},
+						Span{
+							Start: []byte("c"),
+							End:   []byte("d"),
+							Keys: []Key{{
+								Trailer: base.MakeTrailer(2, base.InternalKeyKindRangeKeySet),
+								Suffix:  nil,
+								Value:   []byte("foo"),
+							}},
+						},
+					},
+					{
+						Span{
+							Start: []byte("d"),
+							End:   []byte("e"),
+							Keys: []Key{{
+								Trailer: base.MakeTrailer(2, base.InternalKeyKindRangeKeySet),
+								Suffix:  nil,
+								Value:   []byte("foo"),
+							}},
+						},
+						Span{
+							Start: []byte("e"),
+							End:   []byte("f"),
+							Keys: []Key{{
+								Trailer: base.MakeTrailer(2, base.InternalKeyKindRangeKeySet),
+								Suffix:  nil,
+								Value:   []byte("foo"),
+							}},
+						},
+						Span{
+							Start: []byte("f"),
+							End:   []byte("g"),
+							Keys: []Key{{
+								Trailer: base.MakeTrailer(2, base.InternalKeyKindRangeKeySet),
+								Suffix:  nil,
+								Value:   []byte("foo"),
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			"single level, overlapping fragments",
+			[]level{
+				{
+					{
+						Span{
+							Start: []byte("a"),
+							End:   []byte("b"),
+							Keys: []Key{
+								{
+									Trailer: base.MakeTrailer(4, base.InternalKeyKindRangeKeySet),
+									Suffix:  nil,
+									Value:   []byte("bar"),
+								},
+								{
+									Trailer: base.MakeTrailer(2, base.InternalKeyKindRangeKeySet),
+									Suffix:  nil,
+									Value:   []byte("foo"),
+								},
+							},
+						},
+						Span{
+							Start: []byte("b"),
+							End:   []byte("c"),
+							Keys: []Key{
+								{
+									Trailer: base.MakeTrailer(4, base.InternalKeyKindRangeKeySet),
+									Suffix:  nil,
+									Value:   []byte("bar"),
+								},
+								{
+									Trailer: base.MakeTrailer(2, base.InternalKeyKindRangeKeySet),
+									Suffix:  nil,
+									Value:   []byte("foo"),
+								},
+							},
+						},
+						Span{
+							Start: []byte("c"),
+							End:   []byte("d"),
+							Keys: []Key{{
+								Trailer: base.MakeTrailer(2, base.InternalKeyKindRangeKeySet),
+								Suffix:  nil,
+								Value:   []byte("foo"),
+							}},
+						},
+					},
+					{
+						Span{
+							Start: []byte("d"),
+							End:   []byte("e"),
+							Keys: []Key{{
+								Trailer: base.MakeTrailer(2, base.InternalKeyKindRangeKeySet),
+								Suffix:  nil,
+								Value:   []byte("foo"),
+							}},
+						},
+						Span{
+							Start: []byte("e"),
+							End:   []byte("f"),
+							Keys: []Key{{
+								Trailer: base.MakeTrailer(2, base.InternalKeyKindRangeKeySet),
+								Suffix:  nil,
+								Value:   []byte("foo"),
+							}},
+						},
+						Span{
+							Start: []byte("f"),
+							End:   []byte("g"),
+							Keys: []Key{{
+								Trailer: base.MakeTrailer(2, base.InternalKeyKindRangeKeySet),
+								Suffix:  nil,
+								Value:   []byte("foo"),
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			"single level, gaps between files and range keys",
+			[]level{
+				{
+					{
+						Span{
+							Start: []byte("a"),
+							End:   []byte("b"),
+							Keys: []Key{{
+								Trailer: base.MakeTrailer(2, base.InternalKeyKindRangeKeySet),
+								Suffix:  nil,
+								Value:   []byte("foo"),
+							}},
+						},
+						Span{
+							Start: []byte("c"),
+							End:   []byte("d"),
+							Keys: []Key{{
+								Trailer: base.MakeTrailer(2, base.InternalKeyKindRangeKeySet),
+								Suffix:  nil,
+								Value:   []byte("foo"),
+							}},
+						},
+						Span{
+							Start: []byte("e"),
+							End:   []byte("f"),
+							Keys: []Key{{
+								Trailer: base.MakeTrailer(2, base.InternalKeyKindRangeKeySet),
+								Suffix:  nil,
+								Value:   []byte("foo"),
+							}},
+						},
+					},
+					{
+						Span{
+							Start: []byte("g"),
+							End:   []byte("h"),
+							Keys: []Key{{
+								Trailer: base.MakeTrailer(2, base.InternalKeyKindRangeKeySet),
+								Suffix:  nil,
+								Value:   []byte("foo"),
+							}},
+						},
+						Span{
+							Start: []byte("i"),
+							End:   []byte("j"),
+							Keys: []Key{{
+								Trailer: base.MakeTrailer(2, base.InternalKeyKindRangeKeySet),
+								Suffix:  nil,
+								Value:   []byte("foo"),
+							}},
+						},
+						Span{
+							Start: []byte("k"),
+							End:   []byte("l"),
+							Keys: []Key{{
+								Trailer: base.MakeTrailer(2, base.InternalKeyKindRangeKeySet),
+								Suffix:  nil,
+								Value:   []byte("foo"),
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			"two levels, one with overlapping unset",
+			[]level{
+				{
+					{
+						Span{
+							Start: []byte("a"),
+							End:   []byte("h"),
+							Keys: []Key{{
+								Trailer: base.MakeTrailer(2, base.InternalKeyKindRangeKeySet),
+								Suffix:  nil,
+								Value:   []byte("foo"),
+							}},
+						},
+					},
+					{
+						Span{
+							Start: []byte("l"),
+							End:   []byte("u"),
+							Keys: []Key{{
+								Trailer: base.MakeTrailer(2, base.InternalKeyKindRangeKeyUnset),
+								Suffix:  nil,
+								Value:   nil,
+							}},
+						},
+					},
+				},
+				{
+					{
+						Span{
+							Start: []byte("e"),
+							End:   []byte("r"),
+							Keys: []Key{{
+								Trailer: base.MakeTrailer(1, base.InternalKeyKindRangeKeySet),
+								Suffix:  nil,
+								Value:   []byte("foo"),
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		var fileIters []FragmentIterator
+		var levelIters []FragmentIterator
+		var iter1, iter2 MergingIter
+		for j, level := range tc.levels {
+			j := j // Copy for use in closures down below.
+			var levelIter LevelIter
+			var metas []*manifest.FileMetadata
+			for k, file := range level {
+				fileIters = append(fileIters, NewIter(base.DefaultComparer.Compare, file))
+				meta := &manifest.FileMetadata{
+					FileNum:          base.FileNum(k + 1),
+					Size:             1024,
+					SmallestSeqNum:   2,
+					LargestSeqNum:    2,
+					SmallestRangeKey: base.MakeInternalKey(file[0].Start, file[0].SmallestKey().SeqNum(), file[0].SmallestKey().Kind()),
+					LargestRangeKey:  base.MakeExclusiveSentinelKey(file[len(file)-1].LargestKey().Kind(), file[len(file)-1].End),
+					HasPointKeys:     false,
+					HasRangeKeys:     true,
+				}
+				meta.ExtendRangeKeyBounds(base.DefaultComparer.Compare, meta.SmallestRangeKey, meta.LargestRangeKey)
+				metas = append(metas, meta)
+			}
+
+			tableNewIters := func(file *manifest.FileMetadata, iterOptions *RangeIterOptions) (FragmentIterator, error) {
+				return NewIter(base.DefaultComparer.Compare, tc.levels[j][file.FileNum-1]), nil
+			}
+			// Add all the fileMetadatas to L6.
+			b := &manifest.BulkVersionEdit{}
+			b.Added[6] = metas
+			v, _, err := b.Apply(nil, base.DefaultComparer.Compare, base.DefaultFormatter, 0, 0)
+			require.NoError(t, err)
+			levelIter.Init(RangeIterOptions{}, base.DefaultComparer.Compare, tableNewIters, v.Levels[6].Iter(), 0, nil)
+			levelIters = append(levelIters, &levelIter)
+		}
+
+		iter1.Init(base.DefaultComparer.Compare, VisibleTransform(base.InternalKeySeqNumMax), fileIters...)
+		iter2.Init(base.DefaultComparer.Compare, VisibleTransform(base.InternalKeySeqNumMax), levelIters...)
+		// Check iter1 and iter2 for equivalence.
+
+		require.Equal(t, iter1.First(), iter2.First(), "failed on test case %q", tc.name)
+		valid := true
+		for valid {
+			f1 := iter1.Next()
+			f2 := iter2.Next()
+
+			require.Equal(t, f1, f2, "failed on test case %q", tc.name)
+			valid = f1.Valid() && f2.Valid()
+		}
+	}
+}
+
+type testLogger struct {
+	t *testing.T
+}
+
+// Infof implements the Logger.Infof interface.
+func (t *testLogger) Infof(format string, args ...interface{}) {
+	_ = log.Output(2, fmt.Sprintf(format, args...))
+}
+
+// Fatalf implements the Logger.Fatalf interface.
+func (t *testLogger) Fatalf(format string, args ...interface{}) {
+	_ = log.Output(2, fmt.Sprintf(format, args...))
+	t.t.Fail()
+}
+
+func TestLevelIter(t *testing.T) {
+	var level [][]Span
+	var metas []*manifest.FileMetadata
+	var pointKey *base.InternalKey
+	var iter FragmentIterator
+	var extraInfo func() string
+
+	datadriven.RunTest(t, "testdata/level_iter", func(d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "define":
+			level = level[:0]
+			metas = metas[:0]
+			if iter != nil {
+				iter.Close()
+				iter = nil
+			}
+			var currentFile []Span
+			for _, key := range strings.Split(d.Input, "\n") {
+				if strings.HasPrefix(key, "file") {
+					// Skip the very first file creation.
+					if len(level) != 0 || len(currentFile) != 0 {
+						meta := &manifest.FileMetadata{
+							FileNum: base.FileNum(len(level) + 1),
+						}
+						if len(currentFile) > 0 {
+							smallest := base.MakeInternalKey(currentFile[0].Start, currentFile[0].SmallestKey().SeqNum(), currentFile[0].SmallestKey().Kind())
+							largest := base.MakeExclusiveSentinelKey(currentFile[len(currentFile)-1].LargestKey().Kind(), currentFile[len(currentFile)-1].End)
+							meta.ExtendRangeKeyBounds(base.DefaultComparer.Compare, smallest, largest)
+						}
+						if pointKey != nil {
+							meta.ExtendPointKeyBounds(base.DefaultComparer.Compare, *pointKey, *pointKey)
+						}
+						level = append(level, currentFile)
+						metas = append(metas, meta)
+						currentFile = nil
+						pointKey = nil
+					}
+					continue
+				}
+				key = strings.TrimSpace(key)
+				if strings.HasPrefix(key, "point:") {
+					key = strings.TrimPrefix(key, "point:")
+					j := strings.Index(key, ":")
+					ikey := base.ParseInternalKey(key[:j])
+					pointKey = &ikey
+					continue
+				}
+				span := ParseSpan(key)
+				currentFile = append(currentFile, span)
+			}
+			meta := &manifest.FileMetadata{
+				FileNum: base.FileNum(len(level) + 1),
+			}
+			level = append(level, currentFile)
+			if len(currentFile) > 0 {
+				smallest := base.MakeInternalKey(currentFile[0].Start, currentFile[0].SmallestKey().SeqNum(), currentFile[0].SmallestKey().Kind())
+				largest := base.MakeExclusiveSentinelKey(currentFile[len(currentFile)-1].LargestKey().Kind(), currentFile[len(currentFile)-1].End)
+				meta.ExtendRangeKeyBounds(base.DefaultComparer.Compare, smallest, largest)
+			}
+			if pointKey != nil {
+				meta.ExtendPointKeyBounds(base.DefaultComparer.Compare, *pointKey, *pointKey)
+			}
+			metas = append(metas, meta)
+			return ""
+		case "num-files":
+			return fmt.Sprintf("%d", len(level))
+		case "iter":
+			if iter == nil {
+				var lastFileNum base.FileNum
+				tableNewIters := func(file *manifest.FileMetadata, iterOptions *RangeIterOptions) (FragmentIterator, error) {
+					spans := level[file.FileNum-1]
+					lastFileNum = file.FileNum
+					return NewIter(base.DefaultComparer.Compare, spans), nil
+				}
+				b := &manifest.BulkVersionEdit{}
+				b.Added[6] = metas
+				v, _, err := b.Apply(nil, base.DefaultComparer.Compare, base.DefaultFormatter, 0, 0)
+				require.NoError(t, err)
+				iter = newLevelIter(RangeIterOptions{}, base.DefaultComparer.Compare, tableNewIters, v.Levels[6].Iter(), 6, &testLogger{t})
+				extraInfo = func() string {
+					return fmt.Sprintf("file = %s.sst", lastFileNum)
+				}
+			}
+
+			return runFragmentIteratorCmd(iter, d.Input, extraInfo)
+
+		default:
+			return fmt.Sprintf("unknown command: %s", d.Cmd)
+		}
+	})
+
+	if iter != nil {
+		iter.Close()
+	}
+}

--- a/internal/keyspan/merging_iter.go
+++ b/internal/keyspan/merging_iter.go
@@ -623,7 +623,7 @@ func (m *MergingIter) heapRoot() *boundKey {
 func (m *MergingIter) synthesizeKeys(dir int8) {
 	if invariants.Enabled {
 		if m.cmp(m.start, m.end) >= 0 {
-			panic("pebble: invariant violation: span start ≥ end")
+			panic(fmt.Sprintf("pebble: invariant violation: span start ≥ end: %s >= %s", m.start, m.end))
 		}
 	}
 

--- a/internal/keyspan/testdata/level_iter
+++ b/internal/keyspan/testdata/level_iter
@@ -1,0 +1,161 @@
+
+# Simple case.
+
+define
+file
+  a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)}
+file
+  b-c:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)}
+  c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)}
+----
+
+iter
+seek-ge a
+seek-ge b
+seek-ge c
+seek-ge d
+seek-lt a
+seek-lt b
+seek-lt c
+seek-lt d
+----
+a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000001.sst)
+b-c:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+.
+.
+a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000001.sst)
+b-c:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+
+iter
+first
+next
+next
+next
+----
+a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000001.sst)
+b-c:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+.
+
+iter
+last
+prev
+prev
+prev
+----
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+b-c:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000001.sst)
+.
+
+# Set some bounds
+
+iter
+set-bounds a d
+seek-ge a
+seek-ge b
+seek-ge c
+seek-ge d
+seek-lt a
+seek-lt b
+seek-lt c
+seek-lt d
+----
+.
+a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000001.sst)
+b-c:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+.
+.
+a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000001.sst)
+b-c:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+
+# Set a bound that excludes entire range keys.
+
+iter
+set-bounds b c
+seek-ge b
+next
+prev
+next
+seek-lt c
+prev
+next
+----
+.
+b-c:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+.
+b-c:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+.
+b-c:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+.
+.
+
+# Set a bound that falls between ranges.
+
+iter
+set-bounds aa cc
+seek-ge aa
+prev
+next
+next
+next
+----
+.
+b-c:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000001.sst)
+b-c:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+.
+
+iter
+seek-lt cc
+prev
+prev
+prev
+----
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+b-c:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000001.sst)
+.
+
+# Test skipping over empty/point-key-only files in both directions.
+
+define
+file
+  a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)}
+file
+  point:b.SET.1:foo
+file
+  c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)}
+  d-e:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)}
+----
+
+num-files
+----
+3
+
+iter
+first
+next
+next
+next
+----
+a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000001.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000003.sst)
+d-e:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000003.sst)
+.
+
+iter
+last
+prev
+prev
+prev
+----
+d-e:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000003.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000003.sst)
+a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000001.sst)
+.

--- a/level_iter.go
+++ b/level_iter.go
@@ -21,9 +21,6 @@ type tableNewIters func(
 	file *manifest.FileMetadata, opts *IterOptions, bytesIterated *uint64,
 ) (internalIterator, keyspan.FragmentIterator, error)
 
-// tableNewRangeKeyIter creates a new range key iterator for the given file.
-type tableNewRangeKeyIter func(file *manifest.FileMetadata, opts *IterOptions) (keyspan.FragmentIterator, error)
-
 // levelIter provides a merged view of the sstables in a level.
 //
 // levelIter is used during compaction and as part of the Iterator

--- a/options.go
+++ b/options.go
@@ -56,7 +56,7 @@ type TablePropertyCollector = sstable.TablePropertyCollector
 type BlockPropertyCollector = sstable.BlockPropertyCollector
 
 // BlockPropertyFilter exports the sstable.BlockPropertyFilter type.
-type BlockPropertyFilter = sstable.BlockPropertyFilter
+type BlockPropertyFilter = base.BlockPropertyFilter
 
 // IterKeyType configures which types of keys an iterator should surface.
 type IterKeyType int8

--- a/sstable/block_property.go
+++ b/sstable/block_property.go
@@ -110,13 +110,7 @@ type SuffixReplaceableBlockCollector interface {
 // BlockPropertyFilter is used in an Iterator to filter sstables and blocks
 // within the sstable. It should not maintain any per-sstable state, and must
 // be thread-safe.
-type BlockPropertyFilter interface {
-	// Name returns the name of the block property collector.
-	Name() string
-	// Intersects returns true if the set represented by prop intersects with
-	// the set in the filter.
-	Intersects(prop []byte) (bool, error)
-}
+type BlockPropertyFilter = base.BlockPropertyFilter
 
 // BlockIntervalCollector is a helper implementation of BlockPropertyCollector
 // for users who want to represent a set of the form [lower,upper) where both

--- a/table_cache.go
+++ b/table_cache.go
@@ -120,7 +120,7 @@ func (c *tableCacheContainer) newIters(
 }
 
 func (c *tableCacheContainer) newRangeKeyIter(
-	file *manifest.FileMetadata, opts *IterOptions,
+	file *manifest.FileMetadata, opts *keyspan.RangeIterOptions,
 ) (keyspan.FragmentIterator, error) {
 	return c.tableCache.getShard(file.FileNum).newRangeKeyIter(file, opts, &c.dbOpts)
 }
@@ -402,7 +402,7 @@ func (c *tableCacheShard) newIters(
 }
 
 func (c *tableCacheShard) newRangeKeyIter(
-	file *manifest.FileMetadata, opts *IterOptions, dbOpts *tableCacheOpts,
+	file *manifest.FileMetadata, opts *keyspan.RangeIterOptions, dbOpts *tableCacheOpts,
 ) (keyspan.FragmentIterator, error) {
 	// Calling findNode gives us the responsibility of decrementing v's
 	// refCount. If opening the underlying table resulted in error, then we
@@ -418,7 +418,7 @@ func (c *tableCacheShard) newRangeKeyIter(
 	ok := true
 	var err error
 	if opts != nil {
-		ok, _, err = c.checkAndIntersectFilters(v, opts.TableFilter, opts.RangeKeyFilters)
+		ok, _, err = c.checkAndIntersectFilters(v, nil, opts.Filters)
 	}
 	if err != nil {
 		c.unrefValue(v)


### PR DESCRIPTION
When reading range keys directly from sstables, we will
need to instantiate levelIters for each level that contains
sstables that could contain range keys. This change adds
a levelIter that implements keyspan.FragmentIterator and
takes advantage of level invariants to only have one sstable's
range key block iter open at once. On top of that,
as fragmentBoundIterator does not currently support
SetBounds or truncation of spans based on iterator bounds, those
features are provided by LevelIter.

Also moves TableNewRangeKeyIter from the base package to
internal/keyspan.

First commit is #1568 . 