### PR TITLE
sstable: use a single level index in block property data driven test

### DIFF
--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -895,7 +895,10 @@ func TestBlockProperties(t *testing.T) {
 				_ = r.Close()
 				r = nil
 			}
-			opts := WriterOptions{TableFormat: TableFormatPebblev2}
+			opts := WriterOptions{
+				TableFormat:    TableFormatPebblev2,
+				IndexBlockSize: math.MaxInt32, // Force a single level index for simplicity.
+			}
 			for _, cmd := range td.CmdArgs {
 				switch cmd.Key {
 				case "block-size":


### PR DESCRIPTION
The existing test uses the top level index block to enumerate the
blocks. In the case that a table has a multi-level index, for
correctness, the test should enumerate blocks by traversing the
multi-level index. Currently, in cases where there is a multi-level
index, the test works as the number of index blocks in the top level
block equals the number of data blocks (by virtue of setting a low value
for the block size).

For simplicity, force the tables to be written with a single-level
index.