### PR TITLE
 internal/batchskl: Fix arm32 machine compilation fails to pass about maxNodesSize type from MaxUint32 to MaxInt32 

### DIFF
--- a/internal/batchskl/skl.go
+++ b/internal/batchskl/skl.go
@@ -70,7 +70,7 @@ const (
 	maxHeight    = 20
 	maxNodeSize  = int(unsafe.Sizeof(node{}))
 	linksSize    = int(unsafe.Sizeof(links{}))
-	maxNodesSize = math.MaxUint32
+	maxNodesSize = math.MaxInt32
 )
 
 var (


### PR DESCRIPTION
…maxNodesSize type from MaxUint32 to MaxInt32

Signed-off-by: attleewang <attleewang@tencent.com>

## Problem:
I refer to cockroachdb/pebble in the code and find that it cannot be  builded on arm32 machines. As:
![image](https://user-images.githubusercontent.com/57479557/158043717-23cf775f-717e-4577-a17e-158930ca6837.png)

## Reason
After inspection it was found：
allocSize is int type, but maxNodesSize is math.MaxUint32 type: 
![image](https://user-images.githubusercontent.com/57479557/158043667-9513378e-e1b9-493d-9d15-a09dcccd56cf.png)

## Resolve

Just change the type of maxNodesSize from math.MaxUint32 to math.MaxInt32 and it works

