### PR TITLE
ci: build and test against Go version 1.18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,9 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - "1.15"
           - "1.16"
           - "1.17"
+          - "1.18"
     steps:
     - uses: actions/checkout@v2
 
@@ -31,13 +31,13 @@ jobs:
         go-version: ${{ matrix.go }}
 
     - name: install crlfmt
-      run: go get github.com/cockroachdb/crlfmt
+      run: go install github.com/cockroachdb/crlfmt@b3eff0b
 
     - name: install golint
-      run: go get golang.org/x/lint/golint
+      run: go install golang.org/x/lint/golint@6edffad
 
     - name: install staticcheck
-      run: go get honnef.co/go/tools/cmd/staticcheck@2021.1.1
+      run: go install honnef.co/go/tools/cmd/staticcheck@2021.1.1
 
     - run: make test generate
 
@@ -53,13 +53,13 @@ jobs:
         go-version: "1.17"
 
     - name: install crlfmt
-      run: go get github.com/cockroachdb/crlfmt
+      run: go install github.com/cockroachdb/crlfmt@b3eff0b
 
     - name: install golint
-      run: go get golang.org/x/lint/golint
+      run: go install golang.org/x/lint/golint@6edffad
 
     - name: install staticcheck
-      run: go get honnef.co/go/tools/cmd/staticcheck@2021.1.1
+      run: go install honnef.co/go/tools/cmd/staticcheck@2021.1.1
 
     - run: make testrace TAGS=
 
@@ -75,13 +75,13 @@ jobs:
         go-version: "1.17"
 
     - name: install crlfmt
-      run: go get github.com/cockroachdb/crlfmt
+      run: go install github.com/cockroachdb/crlfmt@b3eff0b
 
     - name: install golint
-      run: go get golang.org/x/lint/golint
+      run: go install golang.org/x/lint/golint@6edffad
 
     - name: install staticcheck
-      run: go get honnef.co/go/tools/cmd/staticcheck@2021.1.1
+      run: go install honnef.co/go/tools/cmd/staticcheck@2021.1.1
 
     - run: make test TAGS=
 
@@ -97,13 +97,13 @@ jobs:
         go-version: "1.17"
 
     - name: install crlfmt
-      run: go get github.com/cockroachdb/crlfmt
+      run: go install github.com/cockroachdb/crlfmt@b3eff0b
 
     - name: install golint
-      run: go get golang.org/x/lint/golint
+      run: go install golang.org/x/lint/golint@6edffad
 
     - name: install staticcheck
-      run: go get honnef.co/go/tools/cmd/staticcheck@2021.1.1
+      run: go install honnef.co/go/tools/cmd/staticcheck@2021.1.1
 
     - run: CGO_ENABLED=0 make test TAGS=
 
@@ -119,13 +119,13 @@ jobs:
         go-version: "1.17"
 
     - name: install crlfmt
-      run: go get github.com/cockroachdb/crlfmt
+      run: go install github.com/cockroachdb/crlfmt@b3eff0b
 
     - name: install golint
-      run: go get golang.org/x/lint/golint
+      run: go install golang.org/x/lint/golint@6edffad
 
     - name: install staticcheck
-      run: go get honnef.co/go/tools/cmd/staticcheck@2021.1.1
+      run: go install honnef.co/go/tools/cmd/staticcheck@2021.1.1
 
     - run: make test
 

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -74,6 +74,9 @@ func TestLint(t *testing.T) {
 	})
 
 	t.Run("TestStaticcheck", func(t *testing.T) {
+		if strings.HasPrefix(runtime.Version(), "go1.18") {
+			t.Skip("Go 1.18 not yet supported. See: https://github.com/dominikh/go-tools/issues/1166")
+		}
 		t.Parallel()
 
 		if err := stream.ForEach(


### PR DESCRIPTION
Add Go version 1.18 to the build matrix. The "default" for the most
specific test suites (race, invariants, etc.) remains version 1.17.