### PR TITLE
db: copy ingested sstables' range keys into in-memory arena 

### DIFF
--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -682,3 +682,25 @@ prev-limit c
 ----
 .
 . at-limit
+
+# Test ingestion of range keys.
+
+reset
+----
+
+build ext0
+range-key-set a b @1 foo
+range-key-set c d @2 bar
+----
+
+ingest ext0
+----
+
+combined-iter
+first
+next
+next
+----
+a: (., [a-b) @1=foo)
+c: (., [c-d) @2=bar)
+.


### PR DESCRIPTION
To unblock more work above Pebble, this commit copies range keys in
ingested sstables into the global in-memory arena. This hack may be
removed when range keys are properly persisted, and Iterator reads
range-key sstable state.

Edit: This commit isn't quite right yet. The memtable overlap code needs
to be adjusted which is dependent on the range-key level iterator.

This commit is rebased over #1587.