### PR TITLE
db: add Iterator.SetOptions for modifying iterator options 

### DIFF
--- a/db.go
+++ b/db.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/manual"
+	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -533,11 +534,13 @@ func (d *DB) getInternal(key []byte, b *Batch, s *Snapshot) ([]byte, io.Closer, 
 	}
 
 	i := &buf.dbi
+	pointIter := base.WrapIterWithStats(get)
 	*i = Iterator{
 		getIterAlloc: buf,
 		cmp:          d.cmp,
 		equal:        d.equal,
-		iter:         base.WrapIterWithStats(get),
+		iter:         pointIter,
+		pointIter:    pointIter,
 		merge:        d.merge,
 		split:        d.split,
 		readState:    readState,
@@ -911,7 +914,6 @@ func (d *DB) newIterInternal(batch *Batch, s *Snapshot, o *IterOptions) *Iterato
 		alloc:               buf,
 		cmp:                 d.cmp,
 		equal:               d.equal,
-		iter:                &buf.merging,
 		merge:               d.merge,
 		split:               d.split,
 		readState:           readState,
@@ -920,14 +922,11 @@ func (d *DB) newIterInternal(batch *Batch, s *Snapshot, o *IterOptions) *Iterato
 		batch:               batch,
 		newIters:            d.newIters,
 		seqNum:              seqNum,
+		newRangeKeyIter: func() rangekey.Iterator {
+			return d.newRangeKeyIter(seqNum, batch, readState, &dbi.opts)
+		},
 	}
 
-	if o.rangeKeys() {
-		// TODO(jackson): Pool range-key iterator objects.
-		dbi.rangeKey = &iteratorRangeKeyState{
-			rangeKeyIter: d.newRangeKeyIter(seqNum, batch, readState, o),
-		}
-	}
 	if o != nil {
 		dbi.opts = *o
 	}
@@ -936,17 +935,18 @@ func (d *DB) newIterInternal(batch *Batch, s *Snapshot, o *IterOptions) *Iterato
 }
 
 // finishInitializingIter is a helper for doing the non-trivial initialization
-// of an Iterator.
+// of an Iterator. It's invoked to perform the initial initialization of an
+// Iterator during NewIter or Clone, and to perform reinitialization due to a
+// change in IterOptions by a call to Iterator.SetOptions.
 func finishInitializingIter(buf *iterAlloc) *Iterator {
 	// Short-hand.
 	dbi := &buf.dbi
-	readState := dbi.readState
-	memtables := readState.memtables
+	memtables := dbi.readState.memtables
 	if dbi.opts.OnlyReadGuaranteedDurable {
 		memtables = nil
 	} else {
 		// We only need to read from memtables which contain sequence numbers older
-		// than seqNum. Trim off newer sstables.
+		// than seqNum. Trim off newer memtables.
 		for i := len(memtables) - 1; i >= 0; i-- {
 			if logSeqNum := memtables[i].logSeqNum; logSeqNum >= dbi.seqNum {
 				continue
@@ -956,19 +956,29 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 		}
 	}
 
-	if dbi.opts.pointKeys() {
-		dbi.iter = constructPointIter(dbi, dbi.batch, memtables, buf)
-	} else {
-		// This is a merging iterator with no levels, that produces nothing.
-		buf.merging.init(&dbi.opts, dbi.cmp, dbi.split)
-		dbi.iter = &buf.merging
-	}
+	// Construct the point iterator. This function either returns a pointer to
+	// dbi.merging (if points are enabled) or an emptyIter. If this is called
+	// during a SetOptions call and this Iterator has already initialized
+	// dbi.merging, constructPointIter returns the existing, unmodified point
+	// iterator which is stored in dbi.pointIter.
+	dbi.iter = constructPointIter(dbi, dbi.batch, memtables, buf)
 
-	// For the in-memory prototype of range keys, wrap the merging iterator with
-	// an interleaving iterator. The dbi.rangeKeysIter is an iterator into
-	// fragmented range keys read from the global range key arena.
-	if dbi.rangeKey != nil {
-		dbi.rangeKey.iter.Init(dbi.cmp, dbi.split, &buf.merging, dbi.rangeKey.rangeKeyIter, dbi.opts.RangeKeyMasking.Suffix)
+	// If range keys are enabled, construct the range key iterator stack too.
+	if dbi.opts.rangeKeys() {
+		if dbi.rangeKey == nil {
+			// TODO(jackson): Pool iteratorRangeKeyState.
+			dbi.rangeKey = &iteratorRangeKeyState{}
+			dbi.rangeKey.rangeKeyIter = dbi.newRangeKeyIter()
+		}
+
+		// Wrap the point iterator (currently dbi.iter) with an interleaving
+		// iterator that interleaves range keys pulled from
+		// dbi.rangeKey.rangeKeyIter.
+		//
+		// NB: The interleaving iterator is always reinitialized, even if
+		// dbi already had an initialized range key iterator, in case the point
+		// iterator changed or the range key masking suffix changed.
+		dbi.rangeKey.iter.Init(dbi.cmp, dbi.split, dbi.iter, dbi.rangeKey.rangeKeyIter, dbi.opts.RangeKeyMasking.Suffix)
 		dbi.iter = &dbi.rangeKey.iter
 		dbi.iter.SetBounds(dbi.opts.LowerBound, dbi.opts.UpperBound)
 	}
@@ -978,6 +988,17 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 func constructPointIter(
 	dbi *Iterator, batch *Batch, memtables flushableList, buf *iterAlloc,
 ) internalIteratorWithStats {
+	if !dbi.opts.pointKeys() {
+		return emptyIter
+	}
+	if dbi.pointIter != nil {
+		// The point iterator has already been constructed. This may be the case
+		// when an Iterator is being re-initialized during a call to SetOptions.
+		// Set the current bounds.
+		dbi.pointIter.SetBounds(dbi.opts.LowerBound, dbi.opts.UpperBound)
+		return dbi.pointIter
+	}
+
 	// Merging levels and levels from iterAlloc.
 	mlevels := buf.mlevels[:0]
 	levels := buf.levels[:0]
@@ -1064,6 +1085,7 @@ func constructPointIter(
 	buf.merging.init(&dbi.opts, dbi.cmp, dbi.split, mlevels...)
 	buf.merging.snapshot = dbi.seqNum
 	buf.merging.elideRangeTombstones = true
+	dbi.pointIter = &buf.merging
 	return &buf.merging
 }
 

--- a/error_iter.go
+++ b/error_iter.go
@@ -14,7 +14,7 @@ type errorIter struct {
 }
 
 // errorIter implements the base.InternalIterator interface.
-var _ base.InternalIterator = (*errorIter)(nil)
+var _ internalIteratorWithStats = (*errorIter)(nil)
 
 func newErrorIter(err error) *errorIter {
 	return &errorIter{err: err}
@@ -63,6 +63,8 @@ func (c *errorIter) String() string {
 }
 
 func (c *errorIter) SetBounds(lower, upper []byte) {}
+func (c *errorIter) Stats() InternalIteratorStats  { return InternalIteratorStats{} }
+func (c *errorIter) ResetStats()                   {}
 
 type errorKeyspanIter struct {
 	err error

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -50,7 +50,6 @@ func NewExternalIter(
 		alloc:               buf,
 		cmp:                 o.Comparer.Compare,
 		equal:               o.equal(),
-		iter:                &buf.merging,
 		merge:               o.Merger.Merge,
 		split:               o.Comparer.Split,
 		readState:           nil,
@@ -120,6 +119,8 @@ func NewExternalIter(
 	buf.merging.init(&dbi.opts, dbi.cmp, dbi.split, mlevels...)
 	buf.merging.snapshot = base.InternalKeySeqNumMax
 	buf.merging.elideRangeTombstones = true
+	dbi.pointIter = &buf.merging
+	dbi.iter = dbi.pointIter
 
 	if dbi.opts.rangeKeys() {
 		for _, r := range readers {

--- a/internal/metamorphic/config.go
+++ b/internal/metamorphic/config.go
@@ -29,6 +29,7 @@ const (
 	iterSeekLTWithLimit
 	iterSeekPrefixGE
 	iterSetBounds
+	iterSetOptions
 	newBatch
 	newIndexedBatch
 	newIter
@@ -94,6 +95,7 @@ func defaultConfig() config {
 			iterSeekLTWithLimit:  20,
 			iterSeekPrefixGE:     100,
 			iterSetBounds:        100,
+			iterSetOptions:       10,
 			newBatch:             5,
 			newIndexedBatch:      5,
 			newIter:              10,

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -637,6 +637,36 @@ func (o *iterSetBoundsOp) String() string {
 	return fmt.Sprintf("%s.SetBounds(%q, %q)", o.iterID, o.lower, o.upper)
 }
 
+// iterSetOptionsOp models an Iterator.SetOptions operation.
+type iterSetOptionsOp struct {
+	iterID   objID
+	lower    []byte
+	upper    []byte
+	keyTypes uint32 // pebble.IterKeyType
+
+	// rangeKeyMaskSuffix may be set if keyTypes is IterKeyTypePointsAndRanges
+	// to configure IterOptions.RangeKeyMasking.Suffix.
+	rangeKeyMaskSuffix []byte
+}
+
+func (o *iterSetOptionsOp) run(t *test, h *history) {
+	i := t.getIter(o.iterID)
+	i.SetOptions(&pebble.IterOptions{
+		LowerBound: o.lower,
+		UpperBound: o.upper,
+		KeyTypes:   pebble.IterKeyType(o.keyTypes),
+		RangeKeyMasking: pebble.RangeKeyMasking{
+			Suffix: o.rangeKeyMaskSuffix,
+		},
+	})
+	h.Recordf("%s // %v", o, i.Error())
+}
+
+func (o *iterSetOptionsOp) String() string {
+	return fmt.Sprintf("%s.SetOptions(%q, %q, %d /* key types */, %q /* masking suffix */)",
+		o.iterID, o.lower, o.upper, o.keyTypes, o.rangeKeyMaskSuffix)
+}
+
 // iterSeekGEOp models an Iterator.SeekGE[WithLimit] operation.
 type iterSeekGEOp struct {
 	iterID objID

--- a/internal/metamorphic/parser.go
+++ b/internal/metamorphic/parser.go
@@ -96,6 +96,8 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 		return &t.writerID, nil, []interface{}{&t.key, &t.value}
 	case *iterSetBoundsOp:
 		return &t.iterID, nil, []interface{}{&t.lower, &t.upper}
+	case *iterSetOptionsOp:
+		return &t.iterID, nil, []interface{}{&t.lower, &t.upper, &t.keyTypes, &t.rangeKeyMaskSuffix}
 	case *singleDeleteOp:
 		return &t.writerID, nil, []interface{}{&t.key, &t.maybeReplaceDelete}
 	case *rangeKeyDeleteOp:
@@ -139,6 +141,7 @@ var methods = map[string]*methodInfo{
 	"SeekPrefixGE":    makeMethod(iterSeekPrefixGEOp{}, iterTag),
 	"Set":             makeMethod(setOp{}, dbTag, batchTag),
 	"SetBounds":       makeMethod(iterSetBoundsOp{}, iterTag),
+	"SetOptions":      makeMethod(iterSetOptionsOp{}, iterTag),
 	"SingleDelete":    makeMethod(singleDeleteOp{}, dbTag, batchTag),
 }
 

--- a/internal/metamorphic/retryable.go
+++ b/internal/metamorphic/retryable.go
@@ -145,6 +145,10 @@ func (i *retryableIter) SetBounds(lower, upper []byte) {
 	i.iter.SetBounds(lower, upper)
 }
 
+func (i *retryableIter) SetOptions(opts *pebble.IterOptions) {
+	i.iter.SetOptions(opts)
+}
+
 func (i *retryableIter) Valid() bool {
 	return i.iter.Valid()
 }

--- a/options.go
+++ b/options.go
@@ -141,6 +141,9 @@ type IterOptions struct {
 	OnlyReadGuaranteedDurable bool
 	// Internal options.
 	logger Logger
+
+	// NB: If adding new Options, you must account for them in iterator
+	// construction and Iterator.SetOptions.
 }
 
 // GetLowerBound returns the LowerBound or nil if the receiver is nil.

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -294,11 +294,18 @@ a@9: (a@9, [a-d) @8=boop)
 
 # Perform the same thing but with a mask suffix below the range key's. All the
 # points should be visible again.
+#
+# Then use SetOptions to raise the mask. The masked points should disappear.
 
 combined-iter mask-suffix=@7
 seek-prefix-ge a
 next
 next
+next
+next
+next
+set-options key-types=both mask-suffix=@8
+seek-prefix-ge a
 next
 next
 next
@@ -308,6 +315,11 @@ a@10: (a@10, [a-d) @8=boop)
 a@9: (a@9, [a-d) @8=boop)
 a@3: (a#3, [a-d) @8=boop)
 a@2: (a@2, [a-d) @8=boop)
+.
+.
+a: (., [a-d) @8=boop)
+a@10: (a@10, [a-d) @8=boop)
+a@9: (a@9, [a-d) @8=boop)
 .
 
 reset
@@ -570,6 +582,41 @@ b: (b, [b-c) @5=bar)
 c: (c, .)
 cat: (., [cat-e) @3=bax)
 d: (d, [cat-e) @3=bax)
+.
+
+# Ensure bounds and key-types provided through SetOptions are respected.
+
+combined-iter lower=b upper=e
+first
+next
+next
+next
+next
+set-options lower=a upper=cat key-types=both
+first
+next
+next
+next
+set-options lower=a upper=cat key-types=point
+first
+next
+next
+next
+----
+b: (b, [b-c) @5=bar)
+c: (c, .)
+cat: (., [cat-e) @3=bax)
+d: (d, [cat-e) @3=bax)
+.
+.
+a: (a, [a-ap) @6=foo)
+ap: (., [ap-c) @5=bar)
+b: (b, [ap-c) @5=bar)
+c: (c, .)
+.
+a:a
+b:b
+c:c
 .
 
 # Test Prev-ing back over a synthetic range key marker. Synthetic range-key


### PR DESCRIPTION
Add a SetOptions method to Iterator allowing a user to modify the IterOptions
of an existing iterator. This is intended to be used within CockroachDB for
modifying the key types and range key mask suffix of an existing Iterator.

The point iterator stack and range iterator stack both are initialized only
when needed. If no longer needed, the iterator stacks are preserved (in
`Iterator.pointIter` and `Iterator.rangeKey.rangeKeyIter`) but left
disconnected from the Iterator's root internal iterator. This allows the
existing iterator stack to be reused if the Iterator is switched back to
including a key type.