### PR TITLE
[prototype] db: use sublevels for l0 manual compactions

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1062,6 +1062,15 @@ func (c *compaction) newInputIter(newIters tableNewIters) (_ internalIterator, r
 		if err = addItersForLevel(c.startLevel); err != nil {
 			return nil, err
 		}
+	} else if c.version != nil && c.version.L0Sublevels != nil && c.startLevel.files.Len() == c.version.L0Sublevels.NumFiles() {
+		// This condition should only get triggered during a non concurrent manual
+		// compaction of the entire L0.
+		fmt.Println("using level iters for manual compaction")
+		for _, s := range c.version.L0SublevelFiles {
+			if err = addItersForLevel(&compactionLevel{0, s}); err != nil {
+				return nil, err
+			}
+		}
 	} else {
 		iter := c.startLevel.files.Iter()
 		for f := iter.First(); f != nil; f = iter.Next() {

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -254,6 +254,16 @@ type L0Sublevels struct {
 	addL0FilesCalled bool
 }
 
+// NumFiles returns the number of files in all of L0.
+// todo(bananabrick) : make this a variable which is set once.
+func (s *L0Sublevels) NumFiles() int {
+	t := 0
+	for i := 0; i < len(s.levelFiles); i++ {
+		t += len(s.levelFiles[i])
+	}
+	return t
+}
+
 type sublevelSorter []*FileMetadata
 
 // Len implements sort.Interface.

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -194,8 +194,8 @@ compact         1   2.3 K     0 B       0          (size == estimated-debt, scor
  memtbl         1   256 K
 zmemtbl         0     0 B
    ztbl         0     0 B
- bcache         8   1.4 K    0.0%  (score == hit-rate)
- tcache         1   680 B    0.0%  (score == hit-rate)
+ bcache         8   1.4 K   11.1%  (score == hit-rate)
+ tcache         1   680 B   40.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -81,8 +81,8 @@ compact         1     0 B     0 B       0          (size == estimated-debt, scor
  memtbl         1   256 K
 zmemtbl         2   512 K
    ztbl         2   1.5 K
- bcache         8   1.4 K   33.3%  (score == hit-rate)
- tcache         2   1.3 K   50.0%  (score == hit-rate)
+ bcache         8   1.4 K   42.9%  (score == hit-rate)
+ tcache         2   1.3 K   66.7%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         2
  filter         -       -    0.0%  (score == utility)
@@ -114,8 +114,8 @@ compact         1     0 B     0 B       0          (size == estimated-debt, scor
  memtbl         1   256 K
 zmemtbl         1   256 K
    ztbl         2   1.5 K
- bcache         8   1.4 K   33.3%  (score == hit-rate)
- tcache         2   1.3 K   50.0%  (score == hit-rate)
+ bcache         8   1.4 K   42.9%  (score == hit-rate)
+ tcache         2   1.3 K   66.7%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         2
  filter         -       -    0.0%  (score == utility)
@@ -144,8 +144,8 @@ compact         1     0 B     0 B       0          (size == estimated-debt, scor
  memtbl         1   256 K
 zmemtbl         1   256 K
    ztbl         1   771 B
- bcache         4   698 B   33.3%  (score == hit-rate)
- tcache         1   680 B   50.0%  (score == hit-rate)
+ bcache         4   698 B   42.9%  (score == hit-rate)
+ tcache         1   680 B   66.7%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         1
  filter         -       -    0.0%  (score == utility)
@@ -177,8 +177,8 @@ compact         1     0 B     0 B       0          (size == estimated-debt, scor
  memtbl         1   256 K
 zmemtbl         0     0 B
    ztbl         0     0 B
- bcache         0     0 B   33.3%  (score == hit-rate)
- tcache         0     0 B   50.0%  (score == hit-rate)
+ bcache         0     0 B   42.9%  (score == hit-rate)
+ tcache         0     0 B   66.7%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)


### PR DESCRIPTION
Explanation rephrased from [here](https://github.com/cockroachdb/pebble/issues/1533#issuecomment-1079553115)

Non-concurrent manual compactions try to use every single file in a single L1 -> Lbase compaction. Currently, we create table iters for each file in the manual compaction and then create a merging iter over the table iters.

In a manual compaction with massively inverted L0, we could end up creating 50-100k+ table iters, and then creating a merging iter over those.

Such a compaction is bad for the cache, and it is bad, because the merging iter is not performant with that many "levels".

Benchmarks:
A benchmark was run with an LSM with 45000 files and 56GB in L0. 
```
__level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___r-amp___w-amp
    WAL         1     0 B       -     0 B       -       -       -       -     0 B       -       -       -     0.0
      0     45815    56 G    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     643     0.0
      1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
      2      1817   7.1 G   50.34     0 B     0 B       0     0 B       0     0 B       0     0 B       1     0.0
      3      1378   7.8 G    5.64     0 B     0 B       0     0 B       0     0 B       0     0 B       1     0.0
      4       918   8.5 G    5.64     0 B     0 B       0     0 B       0     0 B       0     0 B       1     0.0
      5       772   9.4 G    0.63     0 B     0 B       0     0 B       0     0 B       0     0 B       1     0.0
      6       556    12 G       -     0 B     0 B       0     0 B       0     0 B       0     0 B       1     0.0
  total     51256   101 G       -     0 B     0 B       0     0 B       0     0 B       0     0 B     648     0.0
  flush         0
compact         0   382 G   3.8 G       1          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
  ctype         0       0       0       0       0       0  (default, delete, elision, move, read, rewrite)
 memtbl         1   256 K
zmemtbl         0     0 B
   ztbl         0     0 B
 bcache     9.5 K   128 M    0.1%  (score == hit-rate)
 tcache      51 K    33 M   53.1%  (score == hit-rate)
  snaps         0       -       0  (score == earliest seq num)
 titers       644
 filter         -       -    0.0%  (score == utility)
 ```

Once the lsm was generated, it was copied into two directories to ensure an identical start state.

The manual compaction without the current fix takes **155** minutes to complete, and the manual compaction with the current change takes **12** minutes to complete, which is a ~92% performance improvement.

There is a caveat to the shown performance improvement. It assumes that range deletes are sparse. Each range delete iter is added to the merging iter separately, so if lots of L0 files have range deletes, then the performance win will be less than 92%, although, I suspect the perf win will still be decent.


