### PR TITLE
internal/arenaskl: Overflow fixes

### DIFF
--- a/internal/arenaskl/node.go
+++ b/internal/arenaskl/node.go
@@ -26,8 +26,8 @@ import (
 
 // MaxNodeSize returns the maximum space needed for a node with the specified
 // key and value sizes.
-func MaxNodeSize(keySize, valueSize uint32) uint32 {
-	return uint32(maxNodeSize) + keySize + valueSize + align4
+func MaxNodeSize(keySize, valueSize uint32) uint64 {
+	return uint64(maxNodeSize) + uint64(keySize) + uint64(valueSize) + align4
 }
 
 type links struct {
@@ -70,6 +70,9 @@ func newNode(
 	valueSize := len(value)
 	if int64(len(value)) > math.MaxUint32 {
 		panic("value is too large")
+	}
+	if int64(len(value))+int64(keySize)+int64(maxNodeSize) > math.MaxUint32 {
+		panic("combined key and value size is too large")
 	}
 
 	nd, err = newRawNode(arena, height, uint32(keySize), uint32(valueSize))

--- a/mem_table.go
+++ b/mem_table.go
@@ -21,7 +21,7 @@ import (
 )
 
 func memTableEntrySize(keyBytes, valueBytes int) uint64 {
-	return uint64(arenaskl.MaxNodeSize(uint32(keyBytes)+8, uint32(valueBytes)))
+	return arenaskl.MaxNodeSize(uint32(keyBytes)+8, uint32(valueBytes))
 }
 
 // memTableEmptySize is the amount of allocated space in the arena when the


### PR DESCRIPTION
This change fixes some reproducible instances of uint32s
overflowing (eg. in batch.memTableSize) and resulting in
undesirable behaviour, such as large batches not using
the flushableBatch code path and going into the memtable
instead. Also adds a directed panic in case we write keys/values
longer than MaxUint32 combined.

Fixes cockroachdb/cockroach#78391.