### PR TITLE
internal/keyspan: genercize masking

### DIFF
--- a/db.go
+++ b/db.go
@@ -978,9 +978,13 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 		// NB: The interleaving iterator is always reinitialized, even if
 		// dbi already had an initialized range key iterator, in case the point
 		// iterator changed or the range key masking suffix changed.
-		dbi.rangeKey.iter.Init(dbi.cmp, dbi.split, dbi.iter, dbi.rangeKey.rangeKeyIter, dbi.opts.RangeKeyMasking.Suffix)
+		dbi.rangeKey.iter.Init(dbi.cmp, dbi.split, dbi.iter, dbi.rangeKey.rangeKeyIter, keyspan.Hooks{
+			SpanChanged: dbi.rangeKeySpanChanged,
+			SkipPoint:   dbi.rangeKeySkipPoint,
+		})
 		dbi.iter = &dbi.rangeKey.iter
 		dbi.iter.SetBounds(dbi.opts.LowerBound, dbi.opts.UpperBound)
+		dbi.rangeKey.activeMaskSuffix = dbi.rangeKey.activeMaskSuffix[:0]
 	}
 	return dbi
 }

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -143,7 +143,10 @@ func NewExternalIter(
 			rangeKeyIters...,
 		)
 
-		dbi.rangeKey.iter.Init(dbi.cmp, dbi.split, &buf.merging, dbi.rangeKey.rangeKeyIter, dbi.opts.RangeKeyMasking.Suffix)
+		dbi.rangeKey.iter.Init(dbi.cmp, dbi.split, &buf.merging, dbi.rangeKey.rangeKeyIter, keyspan.Hooks{
+			SpanChanged: dbi.rangeKeySpanChanged,
+			SkipPoint:   dbi.rangeKeySkipPoint,
+		})
 		dbi.iter = &dbi.rangeKey.iter
 		dbi.iter.SetBounds(dbi.opts.LowerBound, dbi.opts.UpperBound)
 	}

--- a/internal/keyspan/testdata/interleaving_iter
+++ b/internal/keyspan/testdata/interleaving_iter
@@ -34,40 +34,40 @@ next
 next
 ----
 PointKey: a#72057594037927935,21
-RangeKey: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
 PointKey: artichoke#10,1
-RangeKey: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
 PointKey: artichoke#8,1
-RangeKey: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
 PointKey: c#72057594037927935,21
-RangeKey: c-d:{(#4,RANGEKEYSET,@3,coconut)}
+Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
 -
 PointKey: carrot#13,1
-RangeKey: c-d:{(#4,RANGEKEYSET,@3,coconut)}
+Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
 -
 PointKey: cauliflower#9,0
-RangeKey: c-d:{(#4,RANGEKEYSET,@3,coconut)}
+Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
 -
 PointKey: e#72057594037927935,21
-RangeKey: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
+Span: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
 -
 PointKey: h#72057594037927935,21
-RangeKey: h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)}
+Span: h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)}
 -
 PointKey: l#72057594037927935,21
-RangeKey: l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
+Span: l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
 -
 PointKey: parsnip#3,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: q#72057594037927935,21
-RangeKey: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
 PointKey: tomato#2,1
-RangeKey: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
 
 # Test set-bounds passes through to the underlying point iterator and truncates
@@ -80,10 +80,10 @@ next
 next
 ----
 PointKey: b#72057594037927935,21
-RangeKey: b-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+Span: b-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
 PointKey: c#72057594037927935,21
-RangeKey: c-carrot:{(#4,RANGEKEYSET,@3,coconut)}
+Span: c-carrot:{(#4,RANGEKEYSET,@3,coconut)}
 -
 .
 
@@ -98,10 +98,10 @@ prev
 prev
 ----
 PointKey: c#72057594037927935,21
-RangeKey: c-carrot:{(#4,RANGEKEYSET,@3,coconut)}
+Span: c-carrot:{(#4,RANGEKEYSET,@3,coconut)}
 -
 PointKey: b#72057594037927935,21
-RangeKey: b-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+Span: b-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
 .
 
@@ -116,19 +116,19 @@ seek-ge yyy
 seek-ge z
 ----
 PointKey: a#72057594037927935,21
-RangeKey: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
 PointKey: a#72057594037927935,21
-RangeKey: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
 PointKey: parsnip#3,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: yyy#72057594037927935,21
-RangeKey: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
 PointKey: zucchini#12,2
-RangeKey: <invalid>
+Span: <invalid>
 -
 
 iter
@@ -143,31 +143,31 @@ next
 next
 ----
 PointKey: zucchini#12,2
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: tomato#2,1
-RangeKey: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
 PointKey: q#72057594037927935,21
-RangeKey: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
 PointKey: parsnip#3,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: l#72057594037927935,21
-RangeKey: l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
+Span: l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
 -
 PointKey: parsnip#3,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: q#72057594037927935,21
-RangeKey: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
 PointKey: tomato#2,1
-RangeKey: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
 PointKey: zucchini#12,2
-RangeKey: <invalid>
+Span: <invalid>
 -
 
 iter
@@ -178,19 +178,19 @@ seek-ge parsnip
 next
 ----
 PointKey: tomato#72057594037927935,21
-RangeKey: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
 PointKey: tomato#2,1
-RangeKey: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
 PointKey: q#72057594037927935,21
-RangeKey: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
 PointKey: parsnip#3,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: q#72057594037927935,21
-RangeKey: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
 
 iter
@@ -199,10 +199,10 @@ prev
 seek-lt a
 ----
 PointKey: q#72057594037927935,21
-RangeKey: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
 PointKey: parsnip#3,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 .
 
@@ -233,16 +233,16 @@ next
 next
 ----
 PointKey: a#72057594037927935,21
-RangeKey: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
 PointKey: a#10,1
-RangeKey: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
 PointKey: a#8,1
-RangeKey: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
 PointKey: b#13,1
-RangeKey: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
 
 iter
@@ -261,28 +261,28 @@ next
 next
 ----
 PointKey: ab#72057594037927935,21
-RangeKey: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
 PointKey: b#13,1
-RangeKey: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
 PointKey: c#72057594037927935,21
-RangeKey: c-d:{(#4,RANGEKEYSET,@3,coconut)}
+Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
 -
 PointKey: c#9,0
-RangeKey: c-d:{(#4,RANGEKEYSET,@3,coconut)}
+Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
 -
 PointKey: d#3,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: e#72057594037927935,21
-RangeKey: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
+Span: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
 -
 PointKey: e#2,1
-RangeKey: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
+Span: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
 -
 PointKey: h#72057594037927935,21
-RangeKey: h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)}
+Span: h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)}
 -
 
 define-rangekeys
@@ -309,22 +309,22 @@ next
 next
 ----
 PointKey: a#72057594037927935,21
-RangeKey: a-z:{(#5,RANGEKEYSET,@5,apples)}
+Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
 PointKey: a#10,1
-RangeKey: a-z:{(#5,RANGEKEYSET,@5,apples)}
+Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
 PointKey: a#8,1
-RangeKey: a-z:{(#5,RANGEKEYSET,@5,apples)}
+Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
 PointKey: b#13,1
-RangeKey: a-z:{(#5,RANGEKEYSET,@5,apples)}
+Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
 PointKey: c#9,0
-RangeKey: a-z:{(#5,RANGEKEYSET,@5,apples)}
+Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
 PointKey: d#3,1
-RangeKey: a-z:{(#5,RANGEKEYSET,@5,apples)}
+Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
 
 # Switch to reverse within a range key.
@@ -335,10 +335,10 @@ seek-ge b
 prev
 ----
 PointKey: b#72057594037927935,21
-RangeKey: a-z:{(#5,RANGEKEYSET,@5,apples)}
+Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
 PointKey: a#8,1
-RangeKey: a-z:{(#5,RANGEKEYSET,@5,apples)}
+Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
 
 # Switch to reverse after a seek-ge. Reverse iteration should not revisit the
@@ -353,19 +353,19 @@ prev
 prev
 ----
 PointKey: b#72057594037927935,21
-RangeKey: a-z:{(#5,RANGEKEYSET,@5,apples)}
+Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
 PointKey: b#13,1
-RangeKey: a-z:{(#5,RANGEKEYSET,@5,apples)}
+Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
 PointKey: a#8,1
-RangeKey: a-z:{(#5,RANGEKEYSET,@5,apples)}
+Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
 PointKey: a#10,1
-RangeKey: a-z:{(#5,RANGEKEYSET,@5,apples)}
+Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
 PointKey: a#72057594037927935,21
-RangeKey: a-z:{(#5,RANGEKEYSET,@5,apples)}
+Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
 
 # Switch to forward iteration after a seek-lt.
@@ -375,10 +375,10 @@ seek-lt c
 next
 ----
 PointKey: b#13,1
-RangeKey: a-z:{(#5,RANGEKEYSET,@5,apples)}
+Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
 PointKey: c#9,0
-RangeKey: a-z:{(#5,RANGEKEYSET,@5,apples)}
+Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
 
 iter
@@ -387,13 +387,13 @@ prev
 next
 ----
 PointKey: b#13,1
-RangeKey: a-z:{(#5,RANGEKEYSET,@5,apples)}
+Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
 PointKey: a#8,1
-RangeKey: a-z:{(#5,RANGEKEYSET,@5,apples)}
+Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
 PointKey: b#13,1
-RangeKey: a-z:{(#5,RANGEKEYSET,@5,apples)}
+Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
 
 # Test sparse range keys.
@@ -426,22 +426,22 @@ next
 next
 ----
 PointKey: a#9,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: ace#72057594037927935,21
-RangeKey: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
+Span: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
 -
 PointKey: b#13,1
-RangeKey: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
+Span: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
 -
 PointKey: ace#72057594037927935,21
-RangeKey: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
+Span: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
 -
 PointKey: b#13,1
-RangeKey: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
+Span: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
 -
 PointKey: c#9,0
-RangeKey: <invalid>
+Span: <invalid>
 -
 
 iter
@@ -449,10 +449,10 @@ seek-lt ace
 seek-lt zoo
 ----
 PointKey: a#9,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: z#3,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 
 iter
@@ -462,13 +462,13 @@ next
 next
 ----
 PointKey: z#3,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: y#3,1
-RangeKey: x-z:{(#6,RANGEKEYSET,@6,v5)}
+Span: x-z:{(#6,RANGEKEYSET,@6,v5)}
 -
 PointKey: z#3,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 .
 
@@ -479,16 +479,16 @@ seek-ge m
 prev
 ----
 PointKey: d#18,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: m#4,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: m#4,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: d#18,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 
 # First, Last, SeekLT and SeekGE elide spans without Sets.
@@ -511,16 +511,16 @@ seek-ge a
 seek-lt d
 ----
 PointKey: b#72057594037927935,21
-RangeKey: b-d:{(#5,RANGEKEYDEL)}
+Span: b-d:{(#5,RANGEKEYDEL)}
 -
 PointKey: f#72057594037927935,21
-RangeKey: f-g:{(#6,RANGEKEYDEL)}
+Span: f-g:{(#6,RANGEKEYDEL)}
 -
 PointKey: b#72057594037927935,21
-RangeKey: b-d:{(#5,RANGEKEYDEL)}
+Span: b-d:{(#5,RANGEKEYDEL)}
 -
 PointKey: c#8,1
-RangeKey: b-d:{(#5,RANGEKEYDEL)}
+Span: b-d:{(#5,RANGEKEYDEL)}
 -
 
 # Test a scenario where Next is out of point keys, the current range key has
@@ -543,13 +543,13 @@ next
 next
 ----
 PointKey: w#72057594037927935,21
-RangeKey: w-y:{(#5,RANGEKEYSET,@1,v1)}
+Span: w-y:{(#5,RANGEKEYSET,@1,v1)}
 -
 PointKey: x#8,1
-RangeKey: w-y:{(#5,RANGEKEYSET,@1,v1)}
+Span: w-y:{(#5,RANGEKEYSET,@1,v1)}
 -
 PointKey: y#72057594037927935,21
-RangeKey: y-z:{(#5,RANGEKEYDEL)}
+Span: y-z:{(#5,RANGEKEYDEL)}
 -
 
 # Test a scenario where we change direction on a synthetic range key boundary
@@ -559,7 +559,7 @@ first
 prev
 ----
 PointKey: w#72057594037927935,21
-RangeKey: w-y:{(#5,RANGEKEYSET,@1,v1)}
+Span: w-y:{(#5,RANGEKEYSET,@1,v1)}
 -
 .
 
@@ -579,13 +579,13 @@ prev
 next
 ----
 PointKey: c#72057594037927935,21
-RangeKey: a-z:{(#5,RANGEKEYSET,@1,v1)}
+Span: a-z:{(#5,RANGEKEYSET,@1,v1)}
 -
 PointKey: a#72057594037927935,21
-RangeKey: a-z:{(#5,RANGEKEYSET,@1,v1)}
+Span: a-z:{(#5,RANGEKEYSET,@1,v1)}
 -
 PointKey: z#8,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 
 iter
@@ -597,13 +597,13 @@ prev
 prev
 ----
 PointKey: a#72057594037927935,21
-RangeKey: a-c:{(#5,RANGEKEYSET,@1,v1)}
+Span: a-c:{(#5,RANGEKEYSET,@1,v1)}
 -
 PointKey: z#8,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: c#72057594037927935,21
-RangeKey: c-z:{(#5,RANGEKEYSET,@1,v1)}
+Span: c-z:{(#5,RANGEKEYSET,@1,v1)}
 -
 .
 
@@ -634,25 +634,25 @@ prev
 next
 ----
 PointKey: z#1,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: v#1,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: v#2,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: s#1,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: j#72057594037927935,21
-RangeKey: j-l:{(#3,RANGEKEYSET,@1,v0)}
+Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
 -
 PointKey: g#1,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: j#72057594037927935,21
-RangeKey: j-l:{(#3,RANGEKEYSET,@1,v0)}
+Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
 -
 
 # Test switching directions after exhausting a range key iterator.
@@ -678,19 +678,19 @@ next
 prev
 ----
 PointKey: a#1,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: j#72057594037927935,21
-RangeKey: j-l:{(#3,RANGEKEYSET,@1,v0)}
+Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
 -
 PointKey: k#1,1
-RangeKey: j-l:{(#3,RANGEKEYSET,@1,v0)}
+Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
 -
 PointKey: m#1,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: k#1,1
-RangeKey: j-l:{(#3,RANGEKEYSET,@1,v0)}
+Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
 -
 
 # Test a seek that moves the lower bound beyond the upper bound.

--- a/internal/keyspan/testdata/interleaving_iter_masking
+++ b/internal/keyspan/testdata/interleaving_iter_masking
@@ -47,25 +47,25 @@ next
 next
 ----
 PointKey: b@2#1,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: e#72057594037927935,21
-RangeKey: e-f:{(#1,RANGEKEYSET,@9,foo)}
+Span: e-f:{(#1,RANGEKEYSET,@9,foo)}
 -
 PointKey: f#72057594037927935,21
-RangeKey: f-h:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@3,bar)}
+Span: f-h:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@3,bar)}
 -
 PointKey: h#72057594037927935,21
-RangeKey: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
+Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
 -
 PointKey: l#72057594037927935,21
-RangeKey: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
+Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 -
 PointKey: l@8#1,1
-RangeKey: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
+Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 -
 PointKey: m#72057594037927935,21
-RangeKey: m-q:{(#1,RANGEKEYSET,@6,bax)}
+Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
 -
 .
 
@@ -80,25 +80,25 @@ prev
 prev
 ----
 PointKey: m#72057594037927935,21
-RangeKey: m-q:{(#1,RANGEKEYSET,@6,bax)}
+Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
 -
 PointKey: l@8#1,1
-RangeKey: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
+Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 -
 PointKey: l#72057594037927935,21
-RangeKey: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
+Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 -
 PointKey: h#72057594037927935,21
-RangeKey: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
+Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
 -
 PointKey: f#72057594037927935,21
-RangeKey: f-h:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@3,bar)}
+Span: f-h:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@3,bar)}
 -
 PointKey: e#72057594037927935,21
-RangeKey: e-f:{(#1,RANGEKEYSET,@9,foo)}
+Span: e-f:{(#1,RANGEKEYSET,@9,foo)}
 -
 PointKey: b@2#1,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 .
 
@@ -113,25 +113,25 @@ seek-ge m
 seek-ge r
 ----
 PointKey: b@2#1,1
-RangeKey: <invalid>
+Span: <invalid>
 -
 PointKey: e#72057594037927935,21
-RangeKey: e-f:{(#1,RANGEKEYSET,@9,foo)}
+Span: e-f:{(#1,RANGEKEYSET,@9,foo)}
 -
 PointKey: h#72057594037927935,21
-RangeKey: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
+Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
 -
 PointKey: i#72057594037927935,21
-RangeKey: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
+Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
 -
 PointKey: l#72057594037927935,21
-RangeKey: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
+Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 -
 PointKey: l@8#1,1
-RangeKey: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
+Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 -
 PointKey: m#72057594037927935,21
-RangeKey: m-q:{(#1,RANGEKEYSET,@6,bax)}
+Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
 -
 .
 
@@ -151,19 +151,19 @@ seek-lt ll
 prev
 ----
 PointKey: l#72057594037927935,21
-RangeKey: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
+Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 -
 PointKey: m#72057594037927935,21
-RangeKey: m-q:{(#1,RANGEKEYSET,@6,bax)}
+Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
 -
 PointKey: h#72057594037927935,21
-RangeKey: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
+Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
 -
 PointKey: l#72057594037927935,21
-RangeKey: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
+Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 -
 PointKey: h#72057594037927935,21
-RangeKey: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
+Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
 -
 
 iter
@@ -171,10 +171,10 @@ seek-ge l
 next
 ----
 PointKey: l#72057594037927935,21
-RangeKey: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
+Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 -
 PointKey: m#72057594037927935,21
-RangeKey: m-q:{(#1,RANGEKEYSET,@6,bax)}
+Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
 -
 
 define-rangekeys
@@ -206,13 +206,13 @@ next
 next
 ----
 PointKey: a#72057594037927935,21
-RangeKey: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
+Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
 -
 PointKey: a#1,1
-RangeKey: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
+Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
 -
 PointKey: a@12#1,1
-RangeKey: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
+Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
 -
 .
 
@@ -223,13 +223,13 @@ prev
 prev
 ----
 PointKey: a@12#1,1
-RangeKey: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
+Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
 -
 PointKey: a#1,1
-RangeKey: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
+Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
 -
 PointKey: a#72057594037927935,21
-RangeKey: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
+Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
 -
 .
 
@@ -250,19 +250,19 @@ next
 next
 ----
 PointKey: a#72057594037927935,21
-RangeKey: a-c:{(#2,RANGEKEYSET,@20,apples)}
+Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
 -
 PointKey: a#1,1
-RangeKey: a-c:{(#2,RANGEKEYSET,@20,apples)}
+Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
 -
 PointKey: a@3#1,1
-RangeKey: a-c:{(#2,RANGEKEYSET,@20,apples)}
+Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
 -
 PointKey: a@12#1,1
-RangeKey: a-c:{(#2,RANGEKEYSET,@20,apples)}
+Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
 -
 PointKey: b@2#1,1
-RangeKey: a-c:{(#2,RANGEKEYSET,@20,apples)}
+Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
 -
 .
 
@@ -275,19 +275,19 @@ prev
 prev
 ----
 PointKey: b@2#1,1
-RangeKey: a-c:{(#2,RANGEKEYSET,@20,apples)}
+Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
 -
 PointKey: a@12#1,1
-RangeKey: a-c:{(#2,RANGEKEYSET,@20,apples)}
+Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
 -
 PointKey: a@3#1,1
-RangeKey: a-c:{(#2,RANGEKEYSET,@20,apples)}
+Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
 -
 PointKey: a#1,1
-RangeKey: a-c:{(#2,RANGEKEYSET,@20,apples)}
+Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
 -
 PointKey: a#72057594037927935,21
-RangeKey: a-c:{(#2,RANGEKEYSET,@20,apples)}
+Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
 -
 .
 
@@ -308,13 +308,13 @@ next
 next
 ----
 PointKey: a#72057594037927935,21
-RangeKey: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
+Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 -
 PointKey: a#1,1
-RangeKey: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
+Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 -
 PointKey: a@12#1,1
-RangeKey: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
+Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 -
 .
 .
@@ -327,13 +327,13 @@ prev
 prev
 ----
 PointKey: a@12#1,1
-RangeKey: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
+Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 -
 PointKey: a#1,1
-RangeKey: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
+Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 -
 PointKey: a#72057594037927935,21
-RangeKey: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
+Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 -
 .
 .
@@ -365,13 +365,13 @@ next
 next
 ----
 PointKey: a#72057594037927935,21
-RangeKey: a-c:{(#1,RANGEKEYSET,@5,apples)}
+Span: a-c:{(#1,RANGEKEYSET,@5,apples)}
 -
 PointKey: c#72057594037927935,21
-RangeKey: c-z:{(#1,RANGEKEYSET,@10,bananas)}
+Span: c-z:{(#1,RANGEKEYSET,@10,bananas)}
 -
 PointKey: j@11#3,1
-RangeKey: c-z:{(#1,RANGEKEYSET,@10,bananas)}
+Span: c-z:{(#1,RANGEKEYSET,@10,bananas)}
 -
 
 iter
@@ -380,11 +380,11 @@ prev
 prev
 ----
 PointKey: j@11#3,1
-RangeKey: c-z:{(#1,RANGEKEYSET,@10,bananas)}
+Span: c-z:{(#1,RANGEKEYSET,@10,bananas)}
 -
 PointKey: c#72057594037927935,21
-RangeKey: c-z:{(#1,RANGEKEYSET,@10,bananas)}
+Span: c-z:{(#1,RANGEKEYSET,@10,bananas)}
 -
 PointKey: a#72057594037927935,21
-RangeKey: a-c:{(#1,RANGEKEYSET,@5,apples)}
+Span: a-c:{(#1,RANGEKEYSET,@5,apples)}
 -


### PR DESCRIPTION
Refactor range-key masking by lifting most of the range key particulars up onto
the `*pebble.Iterator` type, exposing narrowly-defined hooks that allow it
control the interleaving iterator's behavior.

In future work, the SpanChanged hook can be used to avoid unnecessary copying
of range-key state.