### PR TITLE
internal/manual: track manually-allocated memory size and expose it through metrics

### DIFF
--- a/db.go
+++ b/db.go
@@ -1562,6 +1562,7 @@ func (d *DB) Metrics() *Metrics {
 	metrics.BlockCache = d.opts.Cache.Metrics()
 	metrics.TableCache, metrics.Filter = d.tableCache.metrics()
 	metrics.TableIters = int64(d.tableCache.iterCount())
+	metrics.ManualAllocSize = manual.ManualAllocSize()
 	return metrics
 }
 

--- a/db.go
+++ b/db.go
@@ -1562,7 +1562,7 @@ func (d *DB) Metrics() *Metrics {
 	metrics.BlockCache = d.opts.Cache.Metrics()
 	metrics.TableCache, metrics.Filter = d.tableCache.metrics()
 	metrics.TableIters = int64(d.tableCache.iterCount())
-	metrics.ManualAllocSize = manual.ManualAllocSize()
+	metrics.ManualAllocSize = manual.AllocSize()
 	return metrics
 }
 

--- a/internal/manual/manual.go
+++ b/internal/manual/manual.go
@@ -8,7 +8,6 @@ package manual
 import "C"
 
 import (
-	"sync/atomic"
 	"unsafe"
 )
 
@@ -48,7 +47,7 @@ func New(n int) []byte {
 		// it cannot allocate memory.
 		throw("out of memory")
 	}
-	atomic.AddInt64(&manualAllocSize, int64(n))
+	manualAllocSize.Add(int64(n))
 	// Interpret the C pointer as a pointer to a Go array, then slice.
 	return (*[MaxArrayLen]byte)(unsafe.Pointer(ptr))[:n:n]
 }
@@ -59,7 +58,7 @@ func Free(b []byte) {
 		if len(b) == 0 {
 			b = b[:cap(b)]
 		}
-		atomic.AddInt64(&manualAllocSize, -int64(len(b)))
+		manualAllocSize.Add(-int64(len(b)))
 		ptr := unsafe.Pointer(&b[0])
 		C.free(ptr)
 	}

--- a/internal/manual/manual.go
+++ b/internal/manual/manual.go
@@ -22,12 +22,6 @@ func throw(s string)
 // runtime page allocator and allocate large chunks of memory using mmap or
 // similar.
 
-var manualAllocSize int64
-
-func ManualAllocSize() uint64 {
-	return uint64(atomic.LoadInt64(&manualAllocSize))
-}
-
 // New allocates a slice of size n. The returned slice is from manually managed
 // memory and MUST be released by calling Free. Failure to do so will result in
 // a memory leak.

--- a/internal/manual/manual_alloc_size.go
+++ b/internal/manual/manual_alloc_size.go
@@ -2,10 +2,10 @@ package manual
 
 import "sync/atomic"
 
-var manualAllocSize int64
+var manualAllocSize atomic.Int64
 
 // AllocSize returns the size of memory that is currently manually
 // allocated (and not managed by the Go runtime)
 func AllocSize() uint64 {
-	return uint64(atomic.LoadInt64(&manualAllocSize))
+	return uint64(manualAllocSize.Load())
 }

--- a/internal/manual/manual_alloc_size.go
+++ b/internal/manual/manual_alloc_size.go
@@ -1,0 +1,11 @@
+package manual
+
+import "sync/atomic"
+
+var manualAllocSize int64
+
+// AllocSize returns the size of memory that is currently manually
+// allocated (and not managed by the Go runtime)
+func AllocSize() uint64 {
+	return uint64(atomic.LoadInt64(&manualAllocSize))
+}

--- a/metrics.go
+++ b/metrics.go
@@ -227,6 +227,9 @@ type Metrics struct {
 		BytesWritten uint64
 	}
 
+	// The current number of manually-allocated bytes
+	ManualAllocSize uint64
+
 	private struct {
 		optionsFileSize  uint64
 		manifestFileSize uint64


### PR DESCRIPTION
Because Pebble manages memory manually, it is not clear to me how to get accurate insight into memory consumption.  Is there an alternative solution than the changes introduced in this PR?