### PR TITLE
internal/keyspan: reduce over defragmented spans

### DIFF
--- a/internal/keyspan/defragment.go
+++ b/internal/keyspan/defragment.go
@@ -6,6 +6,7 @@ package keyspan
 
 import (
 	"bytes"
+	"sort"
 
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
@@ -42,6 +43,26 @@ var DefragmentInternal DefragmentMethod = func(cmp base.Compare, a, b Span) bool
 		}
 	}
 	return true
+}
+
+// DefragmentReducer merges the current and next Key slices, returning a new Key
+// slice, and a bool indicating whether `cur` was modified.
+//
+// Implementations should modify and return `cur` to save on allocations, or
+// consider allocating a new slice, as the `cur` slice may be retained by the
+// DefragmentingIter and mutated. The `next` slice must not be mutated.
+type DefragmentReducer func(cur, next []Key) (keys []Key, modified bool)
+
+// StaticDefragmentReducer is a no-op DefragmentReducer that simply returns the
+// current key slice, effectively retaining the first set of keys encountered
+// for a defragmented span.
+//
+// This reducer can be used, for example, when the set of Keys for each Span
+// being reduced is not expected to change, and therefore the keys from the
+// first span encountered can be used without considering keys in subsequent
+// spans.
+var StaticDefragmentReducer DefragmentReducer = func(cur, _ []Key) ([]Key, bool) {
+	return cur, false /* never modified */
 }
 
 // iterPos is an enum indicating the position of the defragmenting iter's
@@ -93,13 +114,17 @@ type DefragmentingIter struct {
 	// these extended bounds.
 	curr    Span
 	currBuf []byte
-	keysBuf []Key
+	keysBuf keysBySeqNumKind
 	keyBuf  []byte
 
 	// equal is a comparison function for two spans. equal is called when two
 	// spans are abutting to determine whether they may be defragmented.
 	// equal does not itself check for adjacency for the two spans.
-	equal func(base.Compare, Span, Span) bool
+	equal DefragmentMethod
+
+	// reduce is the reducer function used to collect Keys across all spans that
+	// constitute a defragmented span.
+	reduce DefragmentReducer
 }
 
 // Assert that *DefragmentingIter implements the FragmentIterator interface.
@@ -107,8 +132,15 @@ var _ FragmentIterator = (*DefragmentingIter)(nil)
 
 // Init initializes the defragmenting iter using the provided defragment
 // method.
-func (i *DefragmentingIter) Init(cmp base.Compare, iter FragmentIterator, equal DefragmentMethod) {
-	*i = DefragmentingIter{cmp: cmp, iter: iter, equal: equal}
+func (i *DefragmentingIter) Init(
+	cmp base.Compare, iter FragmentIterator, equal DefragmentMethod, reducer DefragmentReducer,
+) {
+	*i = DefragmentingIter{
+		cmp:    cmp,
+		iter:   iter,
+		equal:  equal,
+		reduce: reducer,
+	}
 }
 
 // Clone clones the iterator, returning an independent iterator over the same
@@ -118,7 +150,7 @@ func (i *DefragmentingIter) Clone() FragmentIterator {
 	// TODO(jackson): Delete Clone() when range-key state is incorporated into
 	// readState.
 	c := &DefragmentingIter{}
-	c.Init(i.cmp, i.iter.Clone(), i.equal)
+	c.Init(i.cmp, i.iter.Clone(), i.equal, i.reduce)
 	return c
 }
 
@@ -292,6 +324,7 @@ func (i *DefragmentingIter) defragmentForward() Span {
 
 	i.iterPos = iterPosNext
 	i.iterSpan = i.iter.Next()
+	var modified, keysBufModified bool
 	for i.iterSpan.Valid() {
 		if i.cmp(i.curr.End, i.iterSpan.Start) != 0 {
 			// Not a continuation.
@@ -303,8 +336,15 @@ func (i *DefragmentingIter) defragmentForward() Span {
 		}
 		i.keyBuf = append(i.keyBuf[:0], i.iterSpan.End...)
 		i.curr.End = i.keyBuf
+		i.keysBuf, modified = i.reduce(i.keysBuf, i.iterSpan.Keys)
+		keysBufModified = keysBufModified || modified
 		i.iterSpan = i.iter.Next()
 	}
+	if keysBufModified {
+		// Only sort if the keys were changed.
+		sort.Sort(&i.keysBuf)
+	}
+	i.curr.Keys = i.keysBuf
 	return i.curr
 }
 
@@ -319,6 +359,7 @@ func (i *DefragmentingIter) defragmentBackward() Span {
 
 	i.iterPos = iterPosPrev
 	i.iterSpan = i.iter.Prev()
+	var modified, keysBufModified bool
 	for i.iterSpan.Valid() {
 		if i.cmp(i.curr.Start, i.iterSpan.End) != 0 {
 			// Not a continuation.
@@ -330,8 +371,15 @@ func (i *DefragmentingIter) defragmentBackward() Span {
 		}
 		i.keyBuf = append(i.keyBuf[:0], i.iterSpan.Start...)
 		i.curr.Start = i.keyBuf
+		i.keysBuf, modified = i.reduce(i.keysBuf, i.iterSpan.Keys)
+		keysBufModified = keysBufModified || modified
 		i.iterSpan = i.iter.Prev()
 	}
+	if keysBufModified {
+		// Only sort if the keys were changed.
+		sort.Sort(&i.keysBuf)
+	}
+	i.curr.Keys = i.keysBuf
 	return i.curr
 }
 

--- a/internal/keyspan/span.go
+++ b/internal/keyspan/span.go
@@ -188,7 +188,7 @@ func (s Span) Covers(seqNum uint64) bool {
 
 // String returns a string representation of the span.
 func (s Span) String() string {
-	return fmt.Sprintf("%s", prettySpan{Span: s, formatKey: base.DefaultFormatter})
+	return fmt.Sprint(prettySpan{Span: s, formatKey: base.DefaultFormatter})
 }
 
 // Pretty returns a formatter for the span.

--- a/internal/keyspan/testdata/defragmenting_iter
+++ b/internal/keyspan/testdata/defragmenting_iter
@@ -139,3 +139,29 @@ seeklt h  f-t:{(#3,RANGEKEYSET,@3,bananas)}
 seeklt p  f-t:{(#3,RANGEKEYSET,@3,bananas)}
 seeklt t  f-t:{(#3,RANGEKEYSET,@3,bananas)}
 seeklt z  t-z:{(#4,RANGEKEYSET,@2,oranges)}
+
+# Test iteration with a reducer that collects keys across all spans that
+# constitute a defragmented span. Abutting spans are always combined.
+
+define
+a-b:{(#3,RANGEDEL) (#2,RANGEDEL)}
+b-c:{(#4,RANGEDEL) (#1,RANGEDEL)}
+c-d:{(#5,RANGEDEL)}
+e-f:{(#1,RANGEDEL)}
+f-g:{(#2,RANGEDEL)}
+----
+
+iter equal=always reducer=collect
+first
+next
+next
+last
+prev
+prev
+----
+first     a-d:{(#5,RANGEDEL) (#4,RANGEDEL) (#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
+next      e-g:{(#2,RANGEDEL) (#1,RANGEDEL)}
+next      .
+last      e-g:{(#2,RANGEDEL) (#1,RANGEDEL)}
+prev      a-d:{(#5,RANGEDEL) (#4,RANGEDEL) (#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
+prev      .

--- a/internal/rangekey/coalesce.go
+++ b/internal/rangekey/coalesce.go
@@ -28,7 +28,7 @@ func InitUserIteration(
 	levelIters ...keyspan.FragmentIterator,
 ) keyspan.FragmentIterator {
 	miter.Init(cmp, userIterationTransform(snapshot), levelIters...)
-	diter.Init(cmp, miter, userIterationDefragmenter())
+	diter.Init(cmp, miter, userIterationDefragmenter(), keyspan.StaticDefragmentReducer)
 	return diter
 }
 


### PR DESCRIPTION
**internal/keyspan: reduce over defragmented spans**

Currently, when the `keyspan.DefragmentingIter` defragment spans, the
keys for all the spans are assumed to be equal, so the keys from the
first span in the defragmented set can be used.

Allow the caller to provide a "reducer" that determines how keys in
spans that are being defragmented are to be collected. This is useful,
for example, when defragmenting fragmented range del fragments, where
the keys in abutting spans are not necessarily equal.

Use a default, no-op reducer for all existing calls to
`(*keyspan.DefragmentingIter).Init()` that adopts the current behavior,
using the keys from the first span.

**db: implement rangedel defragmentation using keyspan.DefragmentingIter**

Address an existing TODO by replacing the custom defragmenting logic
with a `keyspan.DefragmentingIter. The iter is initialized with an
equals function that will always combine abutting spans, and a reducer
that will collect keys across all spans that constitute a defragmented
span.