### PR TITLE
crl-release-22.1: compaction: incorporate L0 size into compaction priority

### DIFF
--- a/testdata/compaction_picker_target_level
+++ b/testdata/compaction_picker_target_level
@@ -195,7 +195,7 @@ L4->L5: 7.7
 
 pick ongoing=(5,6)
 ----
-no compaction
+L0->L4: 1.0
 
 pick ongoing=(0,4)
 ----
@@ -224,11 +224,11 @@ base: 4
 
 queue
 ----
-L0->L4: 1000.0
+L0->L4: 2000.0
 
 pick
 ----
-L0->L4: 1000.0
+L0->L4: 2000.0
 
 pick ongoing=(0,4)
 ----
@@ -249,7 +249,7 @@ base: 4
 
 queue
 ----
-L0->L4: 1000.0
+L0->L4: 2000.0
 
 pick ongoing=(0,4,4,5)
 ----
@@ -257,7 +257,7 @@ no compaction
 
 pick ongoing=(4,5)
 ----
-L0->L4: 1000.0
+L0->L4: 2000.0
 
 # Verify we can start concurrent Ln->Ln+1 compactions given sufficient
 # priority.


### PR DESCRIPTION
Currently, L0's compaction picking score is determined only by the
number of sublevels. This doesn't account for scenarios where L0
consists of many non-overlapping files. Adjust the compaction heuristic
to the maximum of scores computed from sublevels and size.

See #1623.