### PR TITLE
db: respect changed filters in SetOptions

### DIFF
--- a/testdata/iterator_block_interval_filter
+++ b/testdata/iterator_block_interval_filter
@@ -253,6 +253,37 @@ d0704:d
 d0704:d
 .
 
+# Repeat the above test, but calling set-options before iteration to set the
+# same filter. The results should be identical.
+iter id_lower_upper=(3,4,5) id_lower_upper=(5,7,9)
+set-options point-filters=reuse
+first
+next
+prev
+prev
+----
+.
+d0704:d
+.
+d0704:d
+.
+
+# Repeat the above test, but calling set-options before iteration to remove the
+# filter.
+iter id_lower_upper=(3,4,5) id_lower_upper=(5,7,9)
+set-options point-filters=none
+first
+next
+prev
+prev
+----
+.
+a1001:a
+b0902:b
+a1001:a
+.
+
+
 # Iterate with filter id=3 and id=5, where the two admitted sets are
 # non-empty, but the intersection is empty.
 iter id_lower_upper=(3,4,5) id_lower_upper=(5,8,9)

--- a/testdata/iterator_table_filter
+++ b/testdata/iterator_table_filter
@@ -48,3 +48,19 @@ iter filter=1
 first
 ----
 .
+
+# Set-options that reuses the filter should still see the filter apply.
+# Set-options that removes the filter should not.
+
+iter filter=4
+first
+set-options table-filter=reuse
+first
+set-options table-filter=none
+first
+----
+a:3
+.
+a:3
+.
+a:4


### PR DESCRIPTION
Rebuild the iterator stack if filters (block or table) are modified.

Fix #1621.