### PR TITLE
compaction: add L0CompactionFileThreshold compaction trigger

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -825,11 +825,32 @@ func (p *compactionPickerByScore) calculateL0Score(
 	var info candidateLevelInfo
 	info.outputLevel = p.baseLevel
 
-	// If L0Sublevels are present, we use the sublevel count as opposed to
-	// the L0 file count to score this level. The base vs intra-L0
-	// compaction determination happens in pickAuto, not here.
+	// If L0Sublevels are present, use the sublevel count to calculate the
+	// score. The base vs intra-L0 compaction determination happens in pickAuto,
+	// not here.
 	info.score = float64(2*p.vers.L0Sublevels.MaxDepthAfterOngoingCompactions()) /
 		float64(p.opts.L0CompactionThreshold)
+
+	// Also calculate a score based on the file count but use it only if it
+	// produces a higher score than the sublevel-based one. This heuristic is
+	// designed to accommodate cases where L0 is accumulating non-overlapping
+	// files in L0. Letting too many non-overlapping files accumulate in few
+	// sublevels is undesirable, because:
+	// 1) we can produce a massive backlog to compact once files do overlap.
+	// 2) constructing L0 sublevels has a runtime that grows superlinearly with
+	//    the number of files in L0 and must be done while holding D.mu.
+	noncompactingFiles := p.vers.Levels[0].Len()
+	for _, c := range inProgressCompactions {
+		for _, cl := range c.inputs {
+			if cl.level == 0 {
+				noncompactingFiles -= cl.files.Len()
+			}
+		}
+	}
+	fileScore := float64(noncompactingFiles) / float64(p.opts.L0CompactionFileThreshold)
+	if info.score < fileScore {
+		info.score = fileScore
+	}
 	return info
 }
 

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -513,6 +513,11 @@ func TestCompactionPickerL0(t *testing.T) {
 					if err != nil {
 						return err.Error()
 					}
+				case "l0_compaction_file_threshold":
+					opts.L0CompactionFileThreshold, err = strconv.Atoi(arg.Vals[0])
+					if err != nil {
+						return err.Error()
+					}
 				}
 			}
 

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -212,8 +212,9 @@ func randomOptions(rng *rand.Rand) *testOptions {
 	opts.Experimental.L0CompactionConcurrency = 1 + rng.Intn(4)    // 1-4
 	opts.Experimental.MinDeletionRate = 1 << uint(20+rng.Intn(10)) // 1MB - 1GB
 	opts.Experimental.ValidateOnIngest = rng.Intn(2) != 0
-	opts.L0CompactionThreshold = 1 + rng.Intn(100) // 1 - 100
-	opts.L0StopWritesThreshold = 1 + rng.Intn(100) // 1 - 100
+	opts.L0CompactionThreshold = 1 + rng.Intn(100)     // 1 - 100
+	opts.L0CompactionFileThreshold = 1 << rng.Intn(11) // 1 - 1024
+	opts.L0StopWritesThreshold = 1 + rng.Intn(100)     // 1 - 100
 	if opts.L0StopWritesThreshold < opts.L0CompactionThreshold {
 		opts.L0StopWritesThreshold = opts.L0CompactionThreshold
 	}

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1372,10 +1372,11 @@ func TestIteratorRandomizedBlockIntervalFilter(t *testing.T) {
 		fmt.Printf("seed: %d\n", seed)
 	}
 	rng := rand.New(rand.NewSource(seed))
-	opts.FlushSplitBytes = 1 << rng.Intn(8)       // 1B - 256B
-	opts.L0CompactionThreshold = 1 << rng.Intn(2) // 1-2
-	opts.LBaseMaxBytes = 1 << rng.Intn(10)        // 1B - 1KB
-	opts.MemTableSize = 2 << 10                   // 2KB
+	opts.FlushSplitBytes = 1 << rng.Intn(8)            // 1B - 256B
+	opts.L0CompactionThreshold = 1 << rng.Intn(2)      // 1-2
+	opts.L0CompactionFileThreshold = 1 << rng.Intn(11) // 1-1024
+	opts.LBaseMaxBytes = 1 << rng.Intn(11)             // 1B - 1KB
+	opts.MemTableSize = 2 << 10                        // 2KB
 	var lopts LevelOptions
 	lopts.BlockSize = 1 << rng.Intn(8)      // 1B - 256B
 	lopts.IndexBlockSize = 1 << rng.Intn(8) // 1B - 256B

--- a/options.go
+++ b/options.go
@@ -524,6 +524,9 @@ type Options struct {
 	// The default value uses the underlying operating system's file system.
 	FS vfs.FS
 
+	// The count of L0 files necessary to trigger an L0 compaction.
+	L0CompactionFileThreshold int
+
 	// The amount of L0 read-amplification necessary to trigger an L0 compaction.
 	L0CompactionThreshold int
 
@@ -718,6 +721,32 @@ func (o *Options) EnsureDefaults() *Options {
 	if o.L0CompactionThreshold <= 0 {
 		o.L0CompactionThreshold = 4
 	}
+	if o.L0CompactionFileThreshold <= 0 {
+		// Some justification for the default of 500:
+		// Why not smaller?:
+		// - The default target file size for L0 is 2MB, so 500 files is <= 1GB
+		//   of data. At observed compaction speeds of > 20MB/s, L0 can be
+		//   cleared of all files in < 1min, so this backlog is not huge.
+		// - 500 files is low overhead for instantiating L0 sublevels from
+		//   scratch.
+		// - Lower values were observed to cause excessive and inefficient
+		//   compactions out of L0 in a TPCC import benchmark.
+		// Why not larger?:
+		// - More than 1min to compact everything out of L0.
+		// - CockroachDB's admission control system uses a threshold of 1000
+		//   files to start throttling writes to Pebble. Using 500 here gives
+		//   us headroom between when Pebble should start compacting L0 and
+		//   when the admission control threshold is reached.
+		//
+		// We can revisit this default in the future based on better
+		// experimental understanding.
+		//
+		// TODO(jackson): Experiment with slightly lower thresholds [or higher
+		// admission control thresholds] to see whether a higher L0 score at the
+		// threshold (currently 2.0) is necessary for some workloads to avoid
+		// starving L0 in favor of lower-level compactions.
+		o.L0CompactionFileThreshold = 500
+	}
 	if o.L0StopWritesThreshold <= 0 {
 		o.L0StopWritesThreshold = 12
 	}
@@ -877,6 +906,7 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  flush_split_bytes=%d\n", o.FlushSplitBytes)
 	fmt.Fprintf(&buf, "  format_major_version=%d\n", o.FormatMajorVersion)
 	fmt.Fprintf(&buf, "  l0_compaction_concurrency=%d\n", o.Experimental.L0CompactionConcurrency)
+	fmt.Fprintf(&buf, "  l0_compaction_file_threshold=%d\n", o.L0CompactionFileThreshold)
 	fmt.Fprintf(&buf, "  l0_compaction_threshold=%d\n", o.L0CompactionThreshold)
 	fmt.Fprintf(&buf, "  l0_stop_writes_threshold=%d\n", o.L0StopWritesThreshold)
 	fmt.Fprintf(&buf, "  lbase_max_bytes=%d\n", o.LBaseMaxBytes)
@@ -1064,6 +1094,8 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				}
 			case "l0_compaction_concurrency":
 				o.Experimental.L0CompactionConcurrency, err = strconv.Atoi(value)
+			case "l0_compaction_file_threshold":
+				o.L0CompactionFileThreshold, err = strconv.Atoi(value)
 			case "l0_compaction_threshold":
 				o.L0CompactionThreshold, err = strconv.Atoi(value)
 			case "l0_stop_writes_threshold":

--- a/options_test.go
+++ b/options_test.go
@@ -79,6 +79,7 @@ func TestOptionsString(t *testing.T) {
   flush_split_bytes=4194304
   format_major_version=1
   l0_compaction_concurrency=10
+  l0_compaction_file_threshold=500
   l0_compaction_threshold=4
   l0_stop_writes_threshold=12
   lbase_max_bytes=67108864

--- a/testdata/compaction_picker_L0
+++ b/testdata/compaction_picker_L0
@@ -11,6 +11,15 @@ pick-auto l0_compaction_threshold=1
 L0 -> L6
 L0: 000100
 
+pick-auto l0_compaction_file_threshold=1
+----
+L0 -> L6
+L0: 000100
+
+pick-auto l0_compaction_threshold=4 l0_compaction_file_threshold=2
+----
+nil
+
 # 1 L0 file, 1 Lbase file.
 
 define
@@ -67,9 +76,19 @@ L0 -> L6
 L0: 000100,000110
 L6: 000200
 
-pick-auto l0_compaction_threshold=3
+pick-auto l0_compaction_threshold=3 l0_compaction_file_threshold=512
 ----
 nil
+
+pick-auto l0_compaction_threshold=3 l0_compaction_file_threshold=3
+----
+nil
+
+pick-auto l0_compaction_threshold=3 l0_compaction_file_threshold=2
+----
+L0 -> L6
+L0: 000100,000110
+L6: 000200
 
 # 2 L0 files, with ikey overlap.
 
@@ -171,7 +190,7 @@ L0 -> L6
 L0: 000100,000110,000120
 L6: 000200
 
-pick-auto l0_compaction_threshold=6
+pick-auto l0_compaction_threshold=6 l0_compaction_file_threshold=512
 ----
 nil
 

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -89,7 +89,7 @@ zmemtbl         2   512 K
 
 disk-usage
 ----
-3.5 K
+3.6 K
 
 # Closing iter a will release one of the zombie memtables.
 
@@ -185,4 +185,4 @@ zmemtbl         0     0 B
 
 disk-usage
 ----
-2.0 K
+2.1 K


### PR DESCRIPTION
Add a L0CompactionFileThreshold option that provides an alternative compaction
picking score for L0. The score is computed as the number of non-compacting
files in L0 divided by the threshold. The existing L0CompactionThreshold score
is a function of the number of sublevels and is still used, with compaction
picking using the maximum of the two scores.

Fix #1623.
Supersedes #1624.