### PR TITLE
crl-release-21.2: compaction: add L0CompactionFileThreshold compaction trigger

### DIFF
--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -606,6 +606,11 @@ func TestCompactionPickerL0(t *testing.T) {
 					if err != nil {
 						return err.Error()
 					}
+				case "l0_compaction_file_threshold":
+					opts.L0CompactionFileThreshold, err = strconv.Atoi(arg.Vals[0])
+					if err != nil {
+						return err.Error()
+					}
 				}
 			}
 

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -220,6 +220,7 @@ func randomOptions(rng *rand.Rand) *testOptions {
 	opts.Experimental.L0CompactionConcurrency = 1 + rng.Intn(4)    // 1-4
 	opts.Experimental.MinDeletionRate = 1 << uint(20+rng.Intn(10)) // 1MB - 1GB
 	opts.L0CompactionThreshold = 1 + rng.Intn(100)                 // 1 - 100
+	opts.L0CompactionFileThreshold = 1 << rng.Intn(11)             // 1 - 1024
 	opts.L0StopWritesThreshold = 1 + rng.Intn(100)                 // 1 - 100
 	if opts.L0StopWritesThreshold < opts.L0CompactionThreshold {
 		opts.L0StopWritesThreshold = opts.L0CompactionThreshold

--- a/options_test.go
+++ b/options_test.go
@@ -78,6 +78,7 @@ func TestOptionsString(t *testing.T) {
   flush_split_bytes=4194304
   format_major_version=1
   l0_compaction_concurrency=10
+  l0_compaction_file_threshold=500
   l0_compaction_threshold=4
   l0_stop_writes_threshold=12
   lbase_max_bytes=67108864

--- a/testdata/compaction_picker_L0
+++ b/testdata/compaction_picker_L0
@@ -11,6 +11,15 @@ pick-auto l0_compaction_threshold=1
 L0 -> L6
 L0: 000100
 
+pick-auto l0_compaction_file_threshold=1
+----
+L0 -> L6
+L0: 000100
+
+pick-auto l0_compaction_threshold=4 l0_compaction_file_threshold=2
+----
+nil
+
 # 1 L0 file, 1 Lbase file.
 
 define
@@ -67,9 +76,19 @@ L0 -> L6
 L0: 000100,000110
 L6: 000200
 
-pick-auto l0_compaction_threshold=3
+pick-auto l0_compaction_threshold=3 l0_compaction_file_threshold=512
 ----
 nil
+
+pick-auto l0_compaction_threshold=3 l0_compaction_file_threshold=3
+----
+nil
+
+pick-auto l0_compaction_threshold=3 l0_compaction_file_threshold=2
+----
+L0 -> L6
+L0: 000100,000110
+L6: 000200
 
 # 2 L0 files, with ikey overlap.
 
@@ -171,7 +190,7 @@ L0 -> L6
 L0: 000100,000110,000120
 L6: 000200
 
-pick-auto l0_compaction_threshold=6
+pick-auto l0_compaction_threshold=6 l0_compaction_file_threshold=512
 ----
 nil
 

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -148,7 +148,7 @@ zmemtbl         1   256 K
 
 disk-usage
 ----
-2.7 K
+2.8 K
 
 # Closing iter b will release the last zombie sstable and the last zombie memtable.
 


### PR DESCRIPTION
Add a L0CompactionFileThreshold option that provides an alternative compaction
picking score for L0. The score is computed as the number of non-compacting
files in L0 divided by the threshold. The existing L0CompactionThreshold score
is a function of the number of sublevels and is still used, with compaction
picking using the maximum of the two scores.

Fix #1623.

----

CockroachDB 21.2 backport of #1632.