### PR TITLE
internal/metamorphic: add support for an initial database state

### DIFF
--- a/internal/metamorphic/generator.go
+++ b/internal/metamorphic/generator.go
@@ -64,12 +64,12 @@ type generator struct {
 	snapshots map[objID]objIDSet
 }
 
-func newGenerator(rng *rand.Rand, cfg config) *generator {
+func newGenerator(rng *rand.Rand, cfg config, km *keyManager) *generator {
 	g := &generator{
 		cfg:             cfg,
 		rng:             rng,
 		init:            &initOp{},
-		keyManager:      newKeyManager(),
+		keyManager:      km,
 		liveReaders:     objIDSlice{makeObjID(dbTag, 0)},
 		liveWriters:     objIDSlice{makeObjID(dbTag, 0)},
 		batches:         make(map[objID]objIDSet),
@@ -83,8 +83,8 @@ func newGenerator(rng *rand.Rand, cfg config) *generator {
 	return g
 }
 
-func generate(rng *rand.Rand, count uint64, cfg config) []op {
-	g := newGenerator(rng, cfg)
+func generate(rng *rand.Rand, count uint64, cfg config, km *keyManager) []op {
+	g := newGenerator(rng, cfg, km)
 
 	generators := []func(){
 		batchAbort:           g.batchAbort,

--- a/internal/metamorphic/generator_test.go
+++ b/internal/metamorphic/generator_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestGenerator(t *testing.T) {
 	rng := randvar.NewRand()
-	g := newGenerator(rng, defaultConfig())
+	g := newGenerator(rng, defaultConfig(), newKeyManager())
 
 	g.newBatch()
 	g.newBatch()
@@ -61,7 +61,7 @@ func TestGenerator(t *testing.T) {
 		t.Logf("\n%s", g)
 	}
 
-	g = newGenerator(rng, defaultConfig())
+	g = newGenerator(rng, defaultConfig(), newKeyManager())
 
 	g.newSnapshot()
 	g.newSnapshot()
@@ -94,7 +94,7 @@ func TestGenerator(t *testing.T) {
 		t.Logf("\n%s", g)
 	}
 
-	g = newGenerator(rng, defaultConfig())
+	g = newGenerator(rng, defaultConfig(), newKeyManager())
 
 	g.newIndexedBatch()
 	g.newIndexedBatch()
@@ -129,7 +129,7 @@ func TestGeneratorRandom(t *testing.T) {
 	generateFromSeed := func() string {
 		rng := rand.New(rand.NewSource(seed))
 		count := ops.Uint64(rng)
-		return formatOps(generate(rng, count, defaultConfig()))
+		return formatOps(generate(rng, count, defaultConfig(), newKeyManager()))
 	}
 
 	// Ensure that generate doesn't use any other source of randomness other

--- a/internal/metamorphic/key_manager_test.go
+++ b/internal/metamorphic/key_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/cockroachdb/pebble/internal/randvar"
 	"github.com/stretchr/testify/require"
 )
 
@@ -484,4 +485,34 @@ func TestKeyManager(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOpWrittenKeys(t *testing.T) {
+	for name, info := range methods {
+		t.Run(name, func(t *testing.T) {
+			// Any operations that exist in methods but are not handled in
+			// opWrittenKeys will result in a panic, failing the subtest.
+			opWrittenKeys(info.constructor())
+		})
+	}
+}
+
+func TestLoadPrecedingKeys(t *testing.T) {
+	rng := randvar.NewRand()
+	cfg := defaultConfig()
+	km := newKeyManager()
+	ops := generate(rng, 1000, cfg, km)
+
+	cfg2 := defaultConfig()
+	km2 := newKeyManager()
+	loadPrecedingKeys(t, ops, &cfg2, km2)
+
+	// NB: We can't assert equality, because the original run may not have
+	// ever used the max of the distribution.
+	require.Greater(t, cfg2.writeSuffixDist.Max(), uint64(1))
+
+	// NB: We can't assert equality, because the original run may have generated
+	// keys that it didn't end up using in operations.
+	require.Subset(t, km.globalKeys, km2.globalKeys)
+	require.Subset(t, km.globalKeyPrefixes, km2.globalKeyPrefixes)
 }

--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -69,6 +69,22 @@ var (
 the result of the run from the first options file in the list. Example, -compare
 random-003,standard-000. The dir flag should have the directory containing these directories.
 Example, -dir _meta/200610-203012.077`)
+
+	// The following options may be used for split-version metamorphic testing.
+	// To perform split-version testing, the client runs the metamorphic tests
+	// on an earlier Pebble SHA passing the `--keep` flag. The client then
+	// switches to the later Pebble SHA, setting the below options to point to
+	// the `ops` file and one of the previous run's data directories.
+	previousOps = flag.String("previous-ops", "",
+		"path to an ops file, used to prepopulate the set of keys operations draw from")
+	initialStatePath = flag.String("initial-state", "",
+		"path to a database's data directory, used to prepopulate the test run's databases")
+	initialStateDesc = flag.String("initial-state-desc", "",
+		`a human-readable description of the initial database state.
+		If set this parameter is written to the OPTIONS to aid in
+		debugging. It's intended to describe the lineage of a
+		database's state, including sufficient information for
+		reproduction (eg, SHA, prng seed, etc).`)
 )
 
 func init() {
@@ -159,6 +175,16 @@ func testMetaRun(t *testing.T, runDir string, seed uint64, historyPath string) {
 			opts.FS = vfs.NewMem()
 		}
 	}
+
+	dir := opts.FS.PathJoin(runDir, "data")
+	// Set up the initial database state if configured to start from a non-empty
+	// database. By default tests start from an empty database, but split
+	// version testing may configure a previous metamorphic tests's database
+	// state as the initial state.
+	if testOpts.initialStatePath != "" {
+		require.NoError(t, setupInitialState(dir, testOpts))
+	}
+
 	// Wrap the filesystem with one that will inject errors into read
 	// operations with *errorRate probability.
 	opts.FS = errorfs.Wrap(opts.FS, errorfs.WithProbability(errorfs.OpKindRead, *errorRate))
@@ -170,15 +196,15 @@ func testMetaRun(t *testing.T, runDir string, seed uint64, historyPath string) {
 	historyFile, err := os.Create(historyPath)
 	require.NoError(t, err)
 	defer historyFile.Close()
-
 	writers := []io.Writer{historyFile}
+
 	if testing.Verbose() {
 		writers = append(writers, os.Stdout)
 	}
 	h := newHistory(*failRE, writers...)
 
 	m := newTest(ops)
-	require.NoError(t, m.init(h, opts.FS.PathJoin(runDir, "data"), testOpts))
+	require.NoError(t, m.init(h, dir, testOpts))
 	for m.step(h) {
 		if err := h.Error(); err != nil {
 			fmt.Fprintf(os.Stderr, "Seed: %d\n", seed)
@@ -269,7 +295,21 @@ func TestMeta(t *testing.T) {
 
 	// Generate a new set of random ops, writing them to <dir>/ops. These will be
 	// read by the child processes when performing a test run.
-	ops := generate(rng, opCount, defaultConfig())
+	km := newKeyManager()
+	cfg := defaultConfig()
+	if *previousOps != "" {
+		// During split-version testing, we load keys from an `ops` file
+		// produced by a metamorphic test run of an earlier Pebble version.
+		// Seeding the keys ensure we generate interesting operations, including
+		// ones with key shadowing, merging, etc.
+		opsPath := filepath.Join(filepath.Dir(filepath.Clean(*previousOps)), "ops")
+		opsData, err := ioutil.ReadFile(opsPath)
+		require.NoError(t, err)
+		ops, err := parse(opsData)
+		require.NoError(t, err)
+		loadPrecedingKeys(t, ops, &cfg, km)
+	}
+	ops := generate(rng, opCount, cfg, km)
 	opsPath := filepath.Join(metaDir, "ops")
 	formattedOps := formatOps(ops)
 	require.NoError(t, ioutil.WriteFile(opsPath, []byte(formattedOps), 0644))
@@ -329,28 +369,40 @@ func TestMeta(t *testing.T) {
 		}
 	}
 
-	// Perform runs with the standard options.
+	// Create the standard options.
 	var names []string
 	options := map[string]*testOptions{}
 	for i, opts := range standardOptions() {
 		name := fmt.Sprintf("standard-%03d", i)
 		names = append(names, name)
 		options[name] = opts
-		t.Run(name, func(t *testing.T) {
-			runOptions(t, opts)
-		})
 	}
 
-	// Perform runs with random options. We make an arbitrary choice to run with
-	// as many random options as we have standard options.
+	// Create random options. We make an arbitrary choice to run with as many
+	// random options as we have standard options.
 	nOpts := len(options)
 	for i := 0; i < nOpts; i++ {
 		name := fmt.Sprintf("random-%03d", i)
 		names = append(names, name)
 		opts := randomOptions(rng)
 		options[name] = opts
+	}
+
+	// If the user provided the path to an initial database state to use, update
+	// all the options to pull from it.
+	if *initialStatePath != "" {
+		for _, o := range options {
+			var err error
+			o.initialStatePath, err = filepath.Abs(*initialStatePath)
+			require.NoError(t, err)
+			o.initialStateDesc = *initialStateDesc
+		}
+	}
+
+	// Run the options.
+	for _, name := range names {
 		t.Run(name, func(t *testing.T) {
-			runOptions(t, opts)
+			runOptions(t, options[name])
 		})
 	}
 

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -134,7 +134,7 @@ func standardOptions() []*testOptions {
 `,
 		10: `
 [Options]
-  wal_dir=wal
+  wal_dir=data/wal
 `,
 		11: `
 [Level "0"]
@@ -224,7 +224,7 @@ func randomOptions(rng *rand.Rand) *testOptions {
 	opts.MemTableSize = 2 << (10 + uint(rng.Intn(16))) // 2KB - 256MB
 	opts.MemTableStopWritesThreshold = 2 + rng.Intn(5) // 2 - 5
 	if rng.Intn(2) == 0 {
-		opts.WALDir = "wal"
+		opts.WALDir = "data/wal"
 	}
 	var lopts pebble.LevelOptions
 	lopts.BlockRestartInterval = 1 + rng.Intn(64)  // 1 - 64

--- a/internal/metamorphic/options_test.go
+++ b/internal/metamorphic/options_test.go
@@ -1,0 +1,51 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package metamorphic
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupInitialState(t *testing.T) {
+	// Construct a small database in the test's TempDir.
+	initialStatePath := t.TempDir()
+	{
+		d, err := pebble.Open(initialStatePath, &pebble.Options{})
+		require.NoError(t, err)
+		const maxKeyLen = 2
+		ks := testkeys.Alpha(maxKeyLen)
+		var key [maxKeyLen]byte
+		for i := 0; i < ks.Count(); i++ {
+			n := testkeys.WriteKey(key[:], ks, i)
+			require.NoError(t, d.Set(key[:n], key[:n], pebble.NoSync))
+			if i%100 == 0 {
+				require.NoError(t, d.Flush())
+			}
+		}
+		require.NoError(t, d.Close())
+	}
+	require.NoError(t, vfs.Default.MkdirAll(filepath.Join(initialStatePath, "wal"), os.ModePerm))
+	ls, err := vfs.Default.List(initialStatePath)
+	require.NoError(t, err)
+
+	// setupInitialState with an initial state path set to the test's TempDir
+	// should populate opts.opts.FS with the directory's contents.
+	opts := &testOptions{
+		opts:             defaultOptions(),
+		initialStatePath: initialStatePath,
+		initialStateDesc: "test",
+	}
+	require.NoError(t, setupInitialState("", opts))
+	copied, err := opts.opts.FS.List("")
+	require.NoError(t, err)
+	require.ElementsMatch(t, ls, copied)
+}

--- a/internal/metamorphic/parser_test.go
+++ b/internal/metamorphic/parser_test.go
@@ -31,7 +31,7 @@ func TestParser(t *testing.T) {
 }
 
 func TestParserRandom(t *testing.T) {
-	ops := generate(randvar.NewRand(), 10000, defaultConfig())
+	ops := generate(randvar.NewRand(), 10000, defaultConfig(), newKeyManager())
 	src := formatOps(ops)
 
 	parsedOps, err := parse([]byte(src))

--- a/internal/testkeys/testkeys.go
+++ b/internal/testkeys/testkeys.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 
 	"github.com/cockroachdb/pebble/internal/base"
 )
@@ -185,6 +186,11 @@ func SuffixLen(t int) int {
 		n++
 	}
 	return n
+}
+
+// ParseSuffix returns the integer representation of the encoded suffix.
+func ParseSuffix(s []byte) (int, error) {
+	return strconv.Atoi(strings.TrimPrefix(string(s), string(suffixDelim)))
 }
 
 // WriteSuffix writes the test keys suffix representation of timestamp t to dst,

--- a/options.go
+++ b/options.go
@@ -1009,7 +1009,7 @@ type ParseHooks struct {
 	NewComparer     func(name string) (*Comparer, error)
 	NewFilterPolicy func(name string) (FilterPolicy, error)
 	NewMerger       func(name string) (*Merger, error)
-	SkipUnknown     func(name string) bool
+	SkipUnknown     func(name, value string) bool
 }
 
 // Parse parses the options from the specified string. Note that certain
@@ -1027,7 +1027,7 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 			switch key {
 			case "pebble_version":
 			default:
-				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key) {
+				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key, value) {
 					return nil
 				}
 				return errors.Errorf("pebble: unknown option: %s.%s",
@@ -1155,7 +1155,7 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 			case "wal_bytes_per_sync":
 				o.WALBytesPerSync, err = strconv.Atoi(value)
 			default:
-				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key) {
+				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key, value) {
 					return nil
 				}
 				return errors.Errorf("pebble: unknown option: %s.%s",
@@ -1168,7 +1168,7 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 			if n, err := fmt.Sscanf(section, `Level "%d"`, &index); err != nil {
 				return err
 			} else if n != 1 {
-				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section) {
+				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section, value) {
 					return nil
 				}
 				return errors.Errorf("pebble: unknown section: %q", errors.Safe(section))
@@ -1216,14 +1216,14 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 			case "target_file_size":
 				l.TargetFileSize, err = strconv.ParseInt(value, 10, 64)
 			default:
-				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key) {
+				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key, value) {
 					return nil
 				}
 				return errors.Errorf("pebble: unknown option: %s.%s", errors.Safe(section), errors.Safe(key))
 			}
 			return err
 		}
-		if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key) {
+		if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key, value) {
 			return nil
 		}
 		return errors.Errorf("pebble: unknown section: %q", errors.Safe(section))

--- a/tool/db.go
+++ b/tool/db.go
@@ -200,7 +200,7 @@ func (d *dbT) loadOptions(dir string) error {
 			}
 			return nil, errors.Errorf("unknown merger %q", errors.Safe(name))
 		},
-		SkipUnknown: func(name string) bool {
+		SkipUnknown: func(name, value string) bool {
 			return true
 		},
 	}

--- a/vfs/clone.go
+++ b/vfs/clone.go
@@ -11,13 +11,35 @@ import (
 	"github.com/cockroachdb/errors/oserror"
 )
 
+type cloneOpts struct {
+	skip func(string) bool
+	sync bool
+}
+
+// A CloneOption configures the behavior of Clone.
+type CloneOption func(*cloneOpts)
+
+// CloneSkip configures Clone to skip files for which the provided function
+// returns true when passed the file's path.
+func CloneSkip(fn func(string) bool) CloneOption {
+	return func(co *cloneOpts) { co.skip = fn }
+}
+
+// CloneSync configures Clone to sync files and directories.
+var CloneSync CloneOption = func(o *cloneOpts) { o.sync = true }
+
 // Clone recursively copies a directory structure from srcFS to dstFS. srcPath
 // specifies the path in srcFS to copy from and must be compatible with the
 // srcFS path format. dstDir is the target directory in dstFS and must be
 // compatible with the dstFS path format. Returns (true,nil) on a successful
 // copy, (false,nil) if srcPath does not exist, and (false,err) if an error
 // occurred.
-func Clone(srcFS, dstFS FS, srcPath, dstPath string) (bool, error) {
+func Clone(srcFS, dstFS FS, srcPath, dstPath string, opts ...CloneOption) (bool, error) {
+	var o cloneOpts
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	srcFile, err := srcFS.Open(srcPath)
 	if err != nil {
 		if oserror.IsNotExist(err) {
@@ -47,11 +69,28 @@ func Clone(srcFS, dstFS FS, srcPath, dstPath string) (bool, error) {
 		// Sort the paths so we get deterministic test output.
 		sort.Strings(list)
 		for _, name := range list {
-			_, err := Clone(srcFS, dstFS, srcFS.PathJoin(srcPath, name), dstFS.PathJoin(dstPath, name))
+			if o.skip != nil && o.skip(srcFS.PathJoin(srcPath, name)) {
+				continue
+			}
+			_, err := Clone(srcFS, dstFS, srcFS.PathJoin(srcPath, name), dstFS.PathJoin(dstPath, name), opts...)
 			if err != nil {
 				return false, err
 			}
 		}
+
+		if o.sync {
+			dir, err := dstFS.OpenDir(dstPath)
+			if err != nil {
+				return false, err
+			}
+			if err := dir.Sync(); err != nil {
+				return false, err
+			}
+			if err := dir.Close(); err != nil {
+				return false, err
+			}
+		}
+
 		return true, nil
 	}
 
@@ -69,6 +108,12 @@ func Clone(srcFS, dstFS FS, srcPath, dstPath string) (bool, error) {
 	if _, err = dstFile.Write(data); err != nil {
 		return false, err
 	}
+	if o.sync {
+		if err := dstFile.Sync(); err != nil {
+			return false, err
+		}
+	}
+
 	if err := dstFile.Close(); err != nil {
 		return false, err
 	}


### PR DESCRIPTION
**internal/metamorphic: use a wal_dir within the data directory**

When constructing database options to exercise the `wal_dir` option, use a
subdirectory of the `data` directory. This ensures that the `--keep`
command-line flag preserves these runs' WALs. Previously, `--keep` would
erroneously not preserve log files for runs with the `wal_dir` option set.

**vfs: add CloneSync, CloneSkip options for vfs.Clone**

**internal/metamorphic: add support for an initial database state**

Adjust the metamorphic tests to support three new command-line flags:

`--previous-ops` — The path of a previous metamorphic test's `ops` file. The
ops file is read to prepopulate the op generator's key set, ensuring the test
generates operations that frequently draw from the keys that already exist in
the database.

`--initial-state` — The path of a previous metamorphic run's `data` directory,
containing the state at the end of the test. Before each run of the metamorphic
test, the contents of the initial state directory are copied into the test's
VFS.

`--initial-state-desc` — A human-readable string describing the origin of
`initial-state`. This parameter has no functional purpose, but it's persisted
within the `OPTIONS` file to record the historical lineage of a test database
to aid in reproduction.

Subsequent work will build a small harness that takes multiple
`metamorphic.test` binaries (eg, generated from
`go test -c ./internal/metamorphic`) built from separate SHAs,
and invokes the metamorphic tests, propagating data directories from
older SHA runs to newer SHA runs.

Informs #1612.