### PR TITLE
db: check ordering invariant for sublevel compactions

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2720,12 +2720,37 @@ func TestCompactionCheckOrdering(t *testing.T) {
 				}
 				c.startLevel, c.outputLevel = &c.inputs[0], &c.inputs[1]
 				var startFiles, outputFiles []*fileMetadata
+				var sublevels []manifest.LevelSlice
 				var files *[]*fileMetadata
+				var sublevel []*fileMetadata
+				var parsingSublevel bool
 				fileNum := FileNum(1)
 
+				switchSublevel := func() {
+					if sublevel != nil {
+						sublevels = append(
+							sublevels, manifest.NewLevelSliceSpecificOrder(sublevel),
+						)
+						sublevel = nil
+					}
+					parsingSublevel = false
+				}
+
 				for _, data := range strings.Split(d.Input, "\n") {
-					switch data {
-					case "L0", "L1", "L2", "L3", "L4", "L5", "L6":
+					if data[0] == 'L' && len(data) == 4 {
+						// Format L0.{sublevel}.
+						switchSublevel()
+						level, err := strconv.Atoi(data[1:2])
+						if err != nil {
+							return err.Error()
+						}
+						if c.startLevel.level == -1 {
+							c.startLevel.level = level
+							files = &startFiles
+						}
+						parsingSublevel = true
+					} else if data[0] == 'L' {
+						switchSublevel()
 						level, err := strconv.Atoi(data[1:])
 						if err != nil {
 							return err.Error()
@@ -2742,17 +2767,21 @@ func TestCompactionCheckOrdering(t *testing.T) {
 						} else {
 							return "outputLevel already set\n"
 						}
-
-					default:
+					} else {
 						meta := parseMeta(data)
 						meta.FileNum = fileNum
 						fileNum++
 						*files = append(*files, meta)
+						if parsingSublevel {
+							sublevel = append(sublevel, meta)
+						}
 					}
 				}
 
+				switchSublevel()
 				c.startLevel.files = manifest.NewLevelSliceSpecificOrder(startFiles)
 				c.outputLevel.files = manifest.NewLevelSliceSpecificOrder(outputFiles)
+				c.l0ManualCompactionFiles = sublevels
 				if c.outputLevel.level == -1 {
 					c.outputLevel.level = 0
 				}

--- a/testdata/compaction_check_ordering
+++ b/testdata/compaction_check_ordering
@@ -110,3 +110,52 @@ L2
   c.SET.5-e.SET.6
 ----
 L2 files 000002 and 000003 have overlapping ranges: [b#3,SET-d#4,SET] vs [c#5,SET-e#6,SET]
+
+# Single sublevel, ordering is fine.
+check-ordering
+L0.0
+  a.SET.1-b.SET.2
+  b.SET.1-d.SET.5
+----
+OK
+
+# Single sublevel, ordering is incorrect.
+check-ordering
+L0.0
+  a.SET.1-b.SET.2
+  b.SET.2-d.SET.4
+----
+L0.0 files 000001 and 000002 have overlapping ranges: [a#1,SET-b#2,SET] vs [b#2,SET-d#4,SET]
+
+# Two sublevels, but ordering is fine.
+check-ordering
+L0.0
+  a.SET.1-b.SET.2
+  c.SET.3-d.SET.4
+L0.1
+  a.SET.5-b.SET.6
+  c.SET.6-d.SET.8
+----
+OK
+
+# Two sublevels, but first ordering is broken
+check-ordering
+L0.0
+  a.SET.1-b.SET.2
+  b.SET.3-d.SET.4
+L0.1
+  a.SET.5-b.SET.6
+  c.SET.6-d.SET.8
+----
+L0.0 files 000001 and 000002 have overlapping ranges: [a#1,SET-b#2,SET] vs [b#3,SET-d#4,SET]
+
+# Two sublevels, but second ordering is broken
+check-ordering
+L0.0
+  a.SET.1-b.SET.2
+  b.SET.1-d.SET.4
+L0.1
+  a.SET.5-b.SET.6
+  b.SET.7-d.SET.8
+----
+L0.1 files 000003 and 000004 have overlapping ranges: [a#5,SET-b#6,SET] vs [b#7,SET-d#8,SET]


### PR DESCRIPTION
This ordering invariant is crucial to ensure that we're not writing
corrupted data to disk.