### PR TITLE
internal/keyspan: Emit empty spans where there are no range keys

### DIFF
--- a/internal/keyspan/internal_iter_shim.go
+++ b/internal/keyspan/internal_iter_shim.go
@@ -57,7 +57,10 @@ func (i *InternalIteratorShim) SeekLT(key []byte) (*base.InternalKey, []byte) {
 // First implements (base.InternalIterator).First.
 func (i *InternalIteratorShim) First() (*base.InternalKey, []byte) {
 	i.span = i.miter.First()
-	if i.span.Empty() {
+	for i.span.Valid() && i.span.Empty() {
+		i.span = i.miter.Next()
+	}
+	if !i.span.Valid() {
 		return nil, nil
 	}
 	i.iterKey = base.InternalKey{UserKey: i.span.Start, Trailer: i.span.Keys[0].Trailer}
@@ -72,7 +75,10 @@ func (i *InternalIteratorShim) Last() (*base.InternalKey, []byte) {
 // Next implements (base.InternalIterator).Next.
 func (i *InternalIteratorShim) Next() (*base.InternalKey, []byte) {
 	i.span = i.miter.Next()
-	if i.span.Empty() {
+	for i.span.Valid() && i.span.Empty() {
+		i.span = i.miter.Next()
+	}
+	if !i.span.Valid() {
 		return nil, nil
 	}
 	i.iterKey = base.InternalKey{UserKey: i.span.Start, Trailer: i.span.Keys[0].Trailer}

--- a/internal/keyspan/level_iter_test.go
+++ b/internal/keyspan/level_iter_test.go
@@ -319,7 +319,15 @@ func TestLevelIterEquivalence(t *testing.T) {
 		valid := true
 		for valid {
 			f1 := iter1.Next()
-			f2 := iter2.Next()
+			var f2 Span
+			for {
+				f2 = iter2.Next()
+				// The level iter could produce empty spans that straddle between
+				// files. Ignore those.
+				if !f2.Valid() || !f2.Empty() {
+					break
+				}
+			}
 
 			require.Equal(t, f1, f2, "failed on test case %q", tc.name)
 			valid = f1.Valid() && f2.Valid()

--- a/internal/keyspan/testdata/defragmenting_iter
+++ b/internal/keyspan/testdata/defragmenting_iter
@@ -165,3 +165,78 @@ next      .
 last      e-g:{(#2,RANGEDEL) (#1,RANGEDEL)}
 prev      a-d:{(#5,RANGEDEL) (#4,RANGEDEL) (#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
 prev      .
+
+# Test defragmentation of non-empty (i.e. more than one value) fragments, while
+# empty fragments are left untouched.
+
+define
+a-c:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+c-d:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+d-e:{}
+e-f:{}
+g-h:{(#1,RANGEKEYSET,@3,bananas)}
+----
+
+iter
+first
+next
+next
+next
+next
+----
+first     a-d:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+next      d-e:{}
+next      e-f:{}
+next      g-h:{(#1,RANGEKEYSET,@3,bananas)}
+next      .
+
+iter
+last
+prev
+prev
+prev
+prev
+----
+last      g-h:{(#1,RANGEKEYSET,@3,bananas)}
+prev      e-f:{}
+prev      d-e:{}
+prev      a-d:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+prev      .
+
+iter
+seekge d
+next
+prev
+seekge e
+next
+prev
+prev
+prev
+----
+seekge d  d-e:{}
+next      e-f:{}
+prev      d-e:{}
+seekge e  e-f:{}
+next      g-h:{(#1,RANGEKEYSET,@3,bananas)}
+prev      e-f:{}
+prev      d-e:{}
+prev      a-d:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+
+iter
+seeklt e
+next
+prev
+seeklt f
+next
+prev
+prev
+prev
+----
+seeklt e  d-e:{}
+next      e-f:{}
+prev      d-e:{}
+seeklt f  e-f:{}
+next      g-h:{(#1,RANGEKEYSET,@3,bananas)}
+prev      e-f:{}
+prev      d-e:{}
+prev      a-d:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}

--- a/internal/keyspan/testdata/level_iter
+++ b/internal/keyspan/testdata/level_iter
@@ -92,7 +92,7 @@ b-c:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
 .
 b-c:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
 .
-.
+b-c:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
 
 # Set a bound that falls between ranges.
 
@@ -145,9 +145,9 @@ next
 next
 ----
 a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000001.sst)
+b-c:{} (file = 000001.sst)
 c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000003.sst)
 d-e:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000003.sst)
-.
 
 iter
 last
@@ -157,5 +157,222 @@ prev
 ----
 d-e:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000003.sst)
 c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000003.sst)
+b-c:{} (file = 000003.sst)
+a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000001.sst)
+
+# Test straddle keys between files.
+
+define
+file
+  a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)}
+file
+  c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)}
+file
+  e-f:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)}
+file
+  g-h:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)}
+----
+
+iter
+first
+next
+next
+next
+next
+next
+next
+next
+----
+a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000001.sst)
+b-c:{} (file = 000001.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+d-e:{} (file = 000002.sst)
+e-f:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000003.sst)
+f-g:{} (file = 000003.sst)
+g-h:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000004.sst)
+.
+
+iter
+last
+prev
+prev
+prev
+prev
+prev
+prev
+prev
+----
+g-h:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000004.sst)
+f-g:{} (file = 000004.sst)
+e-f:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000003.sst)
+d-e:{} (file = 000003.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+b-c:{} (file = 000002.sst)
+a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000001.sst)
+.
+
+# The below case seeks into a file straddle, then iterates forward and back to
+# it, and confirms that changing iterator directions on a straddle does the
+# right thing.
+
+iter
+seek-ge bb
+next
+prev
+next
+prev
+prev
+----
+bb-c:{} (file = 000001.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+b-c:{} (file = 000002.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+b-c:{} (file = 000002.sst)
+a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000001.sst)
+
+# The same case as above, but with inverted directions.
+
+iter
+seek-lt dd
+prev
+next
+prev
+next
+next
+----
+d-dd:{} (file = 000001.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+d-e:{} (file = 000002.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+d-e:{} (file = 000002.sst)
+e-f:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000003.sst)
+
+# Above two cases, but with bounds at straddles
+
+iter
+set-bounds bb dd
+seek-ge bb
+next
+prev
+next
+prev
+prev
+----
+.
+bb-c:{} (file = 000003.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+b-c:{} (file = 000002.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+b-c:{} (file = 000002.sst)
+.
+
+iter
+seek-lt dd
+prev
+next
+prev
+next
+next
+----
+d-dd:{} (file = 000002.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+d-e:{} (file = 000002.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+d-e:{} (file = 000002.sst)
+.
+
+# Seeks right at the bound should return nothing.
+
+iter
+seek-lt bb
+----
+.
+
+iter
+seek-ge dd
+----
+.
+
+# Similar cases as above, but with iter bounds at file bounds instead of at
+# straddles.
+
+iter
+set-bounds b d
+seek-ge bb
+next
+prev
+next
+prev
+prev
+----
+.
+bb-c:{} (file = 000002.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+b-c:{} (file = 000002.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+b-c:{} (file = 000002.sst)
+.
+
+iter
+seek-lt d
+prev
+next
+prev
+prev
+next
+next
+----
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+b-c:{} (file = 000002.sst)
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+b-c:{} (file = 000002.sst)
+.
+c-d:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+.
+
+# A bunch of files with point keys only should not fragment straddles.
+
+define
+file
+  a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)}
+file
+  point:c.SET.1:foo
+file
+  point:d.SET.1:foo
+file
+  e-f:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)}
+file
+  point:g.SET.1:foo
+file
+  h-i:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)}
+----
+
+iter
+first
+next
+next
+next
+next
+next
+----
+a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000001.sst)
+b-e:{} (file = 000001.sst)
+e-f:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000004.sst)
+f-h:{} (file = 000004.sst)
+h-i:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000006.sst)
+.
+
+iter
+last
+prev
+prev
+prev
+prev
+prev
+----
+h-i:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000006.sst)
+f-h:{} (file = 000006.sst)
+e-f:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000004.sst)
+b-e:{} (file = 000004.sst)
 a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000001.sst)
 .

--- a/internal/keyspan/testdata/merging_iter
+++ b/internal/keyspan/testdata/merging_iter
@@ -44,10 +44,16 @@ first
 next
 next
 next
+next
+next
+next
 ----
 a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas)}
 c-d:{(#4,RANGEKEYSET,@3,coconut)}
+e-f:{}
+h-j:{}
 l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
+q-z:{}
 <invalid>
 
 define
@@ -394,3 +400,53 @@ wn-yx:{(#4,RANGEKEYDEL)}
 <invalid>
 <invalid>
 wn-yx:{(#4,RANGEKEYDEL)}
+
+# Test that empty spans from child iterators are preserved
+define
+b-d:{#10,RANGEKEYSET,@1,apples}
+e-f:{}
+g-h:{#8,RANGEKEYDEL}
+--
+a-c:{#3,RANGEKEYUNSET,@1}
+h-k:{#5,RANGEKEYDEL}
+k-m:{}
+----
+2 levels
+
+iter
+first
+next
+next
+next
+next
+next
+next
+next
+----
+a-b:{(#3,RANGEKEYUNSET,@1)}
+b-c:{(#10,RANGEKEYSET,@1,apples) (#3,RANGEKEYUNSET,@1)}
+c-d:{(#10,RANGEKEYSET,@1,apples)}
+e-f:{}
+g-h:{(#8,RANGEKEYDEL)}
+h-k:{(#5,RANGEKEYDEL)}
+k-m:{}
+<invalid>
+
+iter
+last
+prev
+prev
+prev
+prev
+prev
+prev
+prev
+----
+k-m:{}
+h-k:{(#5,RANGEKEYDEL)}
+g-h:{(#8,RANGEKEYDEL)}
+e-f:{}
+c-d:{(#10,RANGEKEYSET,@1,apples)}
+b-c:{(#10,RANGEKEYSET,@1,apples) (#3,RANGEKEYUNSET,@1)}
+a-b:{(#3,RANGEKEYUNSET,@1)}
+<invalid>

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -595,7 +595,7 @@ func (m *mergingIter) isNextEntryDeleted(item *mergingIterItem) bool {
 		//
 		// For a tombstone at the same level as the key, the file bounds are trivially satisfied.
 		if (l.smallestUserKey == nil || m.heap.cmp(l.smallestUserKey, item.key.UserKey) <= 0) &&
-			l.tombstone.Contains(m.heap.cmp, item.key.UserKey) {
+			l.tombstone.Contains(m.heap.cmp, item.key.UserKey) && !l.tombstone.Empty() {
 			if level < item.index {
 				// We could also do m.seekGE(..., level + 1). The levels from
 				// [level + 1, item.index) are already after item.key so seeking them may be
@@ -767,7 +767,7 @@ func (m *mergingIter) isPrevEntryDeleted(item *mergingIterItem) bool {
 			cmpResult := m.heap.cmp(l.largestUserKey, item.key.UserKey)
 			withinLargestSSTableBound = cmpResult > 0 || (cmpResult == 0 && !l.isLargestUserKeyRangeDelSentinel)
 		}
-		if withinLargestSSTableBound && l.tombstone.Contains(m.heap.cmp, item.key.UserKey) {
+		if withinLargestSSTableBound && l.tombstone.Contains(m.heap.cmp, item.key.UserKey) && !l.tombstone.Empty() {
 			if level < item.index {
 				// We could also do m.seekLT(..., level + 1). The levels from
 				// [level + 1, item.index) are already before item.key so seeking them may be

--- a/testdata/external_iterator
+++ b/testdata/external_iterator
@@ -62,6 +62,41 @@ d: (., [d-e) @3=bar)
 f: (f, .)
 .
 
+# Test including range keys with empty spans and a merge in between. At no point
+# should an empty span be returned.
+
+build 6
+merge bb ac
+----
+
+iter files=(6, 5, 4, 3, 2, 1)
+seek-lt c
+prev
+next
+next
+----
+bb: (ac, .)
+b: (b, .)
+bb: (ac, .)
+d: (., [d-e) @3=bar)
+
+iter files=(6, 5, 4, 3, 2, 1)
+seek-ge b
+next
+prev
+prev
+next
+next
+next
+----
+b: (b, .)
+bb: (ac, .)
+b: (b, .)
+a: (a, [a-b) @2=foo)
+b: (b, .)
+bb: (ac, .)
+d: (., [d-e) @3=bar)
+
 # Test range keys that overlap each other with identical state. These
 # should be defragmented and exposed as a single range key.
 


### PR DESCRIPTION
This change updates keyspan.LevelIter to emit empty Spans (i.e.
spans with valid start/end but no values/Keys) between files.
This is used as an optimization to avoid loading the next file
after a file has been exhausted.

To preserve this optimization up the iterator stack, the
merging iter and defragmenting iter were also updated to
special-case empty spans returned by child iterators and
preserve them as-is instead of defragmenting them
or iterating beyond them.

Fixes #1605