### PR TITLE
internal/keyspan: tweak DefragmentReducer return types

### DIFF
--- a/internal/keyspan/defragment_test.go
+++ b/internal/keyspan/defragment_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -24,8 +25,10 @@ func TestDefragmentingIter(t *testing.T) {
 	internalEqual := DefragmentInternal
 	alwaysEqual := func(_ base.Compare, _, _ Span) bool { return true }
 	staticReducer := StaticDefragmentReducer
-	collectReducer := func(cur, next []Key) ([]Key, bool) {
-		return append(cur, next...), true
+	collectReducer := func(cur, next []Key) []Key {
+		c := keysBySeqNumKind(append(cur, next...))
+		sort.Sort(&c)
+		return c
 	}
 
 	var buf bytes.Buffer

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -160,6 +160,20 @@ func TestForeachDefragmentedTombstone(t *testing.T) {
 		{
 			fragmented: []keyspan.Span{
 				mktomb("a", "c", 2),
+			},
+			want:    [][2]string{{"a", "c"}},
+			wantSeq: [][2]uint64{{2, 2}},
+		},
+		{
+			fragmented: []keyspan.Span{
+				mktomb("a", "c", 2, 1),
+			},
+			want:    [][2]string{{"a", "c"}},
+			wantSeq: [][2]uint64{{1, 2}},
+		},
+		{
+			fragmented: []keyspan.Span{
+				mktomb("a", "c", 2),
 				mktomb("e", "g", 2),
 				mktomb("l", "m", 2),
 				mktomb("v", "z", 2),
@@ -175,6 +189,15 @@ func TestForeachDefragmentedTombstone(t *testing.T) {
 			},
 			want:    [][2]string{{"a", "m"}},
 			wantSeq: [][2]uint64{{2, 5}},
+		},
+		{
+			fragmented: []keyspan.Span{
+				mktomb("a", "c", 1),
+				mktomb("c", "f", 5, 2),
+				mktomb("f", "m", 5),
+			},
+			want:    [][2]string{{"a", "m"}},
+			wantSeq: [][2]uint64{{1, 5}},
 		},
 		{
 			fragmented: []keyspan.Span{


### PR DESCRIPTION
Currently, the `keyspan.DefragmentReducer` implementation used for
defragmenting range deletions when computing table stats is inefficient
in that it retains all keys (with possibly duplicate items) in a slice
only to take the first and last item for the largest / smallest sequence
numbers, respectively. As both input slices to
`keyspan.DefragmentReducer` are sorted, a slice with length of at most
two can be used to maintain the largest and smallest keys for the
defragmented span. It also removes the O(n log n) sort in favor of O(n)
constant time operations.

Remove the boolean return value from the `keyspan.DefragmentReducer`,
instead documenting the requirement that the implementer to maintains
the contract that the keys in the output slice are sorted, in (sequence
number, kind) descending order.

Add additional test cases.