### PR TITLE
db: update comment on L0StopWritesThreshold

### DIFF
--- a/options.go
+++ b/options.go
@@ -530,10 +530,8 @@ type Options struct {
 	// The amount of L0 read-amplification necessary to trigger an L0 compaction.
 	L0CompactionThreshold int
 
-	// Hard limit on L0 read-amplification. Writes are stopped when this
-	// threshold is reached. If Experimental.L0SublevelCompactions is enabled
-	// this threshold is measured against the number of L0 sublevels. Otherwise
-	// it is measured against the number of files in L0.
+	// Hard limit on L0 read-amplification, computed as the number of L0
+	// sublevels. Writes are stopped when this threshold is reached.
 	L0StopWritesThreshold int
 
 	// The maximum number of bytes for LBase. The base level is the level which


### PR DESCRIPTION
The current comment mentions that the threshold is used relative to L0
sublevel count only when the `Experimental.L0SublevelCompactions` option
is enabled. As of 32a5180f, the L0 sublevel count is always used.

Update the comment.

Touches cockroachdb/cockroach#79956.