### PR TITLE
*: Use keyspan.LevelIter for rangedels in compactions

### DIFF
--- a/db.go
+++ b/db.go
@@ -262,7 +262,7 @@ type DB struct {
 
 	tableCache           *tableCacheContainer
 	newIters             tableNewIters
-	tableNewRangeKeyIter keyspan.TableNewRangeKeyIter
+	tableNewRangeKeyIter keyspan.TableNewSpanIter
 
 	commit *commitPipeline
 

--- a/internal/keyspan/iter.go
+++ b/internal/keyspan/iter.go
@@ -58,15 +58,15 @@ type FragmentIterator interface {
 	Close() error
 }
 
-// TableNewRangeKeyIter creates a new range key iterator for the given file.
-type TableNewRangeKeyIter func(file *manifest.FileMetadata, iterOptions *RangeIterOptions) (FragmentIterator, error)
+// TableNewSpanIter creates a new iterator for spans for the given file.
+type TableNewSpanIter func(file *manifest.FileMetadata, iterOptions *SpanIterOptions) (FragmentIterator, error)
 
-// RangeIterOptions is a subset of IterOptions that are necessary to instantiate
-// per-sstable range key iterators.
-type RangeIterOptions struct {
-	// Filters can be used to avoid scanning tables and blocks in tables
+// SpanIterOptions is a subset of IterOptions that are necessary to instantiate
+// per-sstable span iterators.
+type SpanIterOptions struct {
+	// RangeKeyFilters can be used to avoid scanning tables and blocks in tables
 	// when iterating over range keys.
-	Filters []base.BlockPropertyFilter
+	RangeKeyFilters []base.BlockPropertyFilter
 }
 
 // Iter is an iterator over a set of fragmented spans.

--- a/internal/keyspan/testdata/level_iter
+++ b/internal/keyspan/testdata/level_iter
@@ -298,3 +298,98 @@ e-f:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000004.sst)
 b-e:{} (file = 000004.sst)
 a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000001.sst)
 .
+
+# Test files with range keys and rangedels
+
+define
+file
+  a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)}
+  point:a.SET.1:foo
+  point:b.SET.1:foo
+file
+  c-e:{(#3,RANGEKEYSET,@3,baz) (#3,RANGEKEYSET,@1,bar)}
+  point:c.RANGEDEL.2:f
+  point:d.SET.1:foo
+file
+  g-h:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)}
+  i-j:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)}
+  point:f.RANGEDEL.2:g
+----
+
+iter rangedel
+first
+next
+next
+next
+----
+c-f:{(#2,RANGEDEL)} (file = 000002.sst)
+f-g:{(#2,RANGEDEL)} (file = 000003.sst)
+.
+.
+
+iter rangedel
+last
+prev
+prev
+prev
+----
+f-g:{(#2,RANGEDEL)} (file = 000003.sst)
+c-f:{(#2,RANGEDEL)} (file = 000002.sst)
+.
+.
+
+iter rangedel
+seek-ge c
+next
+next
+----
+c-f:{(#2,RANGEDEL)} (file = 000002.sst)
+f-g:{(#2,RANGEDEL)} (file = 000003.sst)
+.
+
+iter rangedel
+seek-lt ff
+prev
+next
+prev
+prev
+----
+f-g:{(#2,RANGEDEL)} (file = 000003.sst)
+c-f:{(#2,RANGEDEL)} (file = 000002.sst)
+f-g:{(#2,RANGEDEL)} (file = 000003.sst)
+c-f:{(#2,RANGEDEL)} (file = 000002.sst)
+.
+
+close-iter
+----
+ok
+
+# Test that a regular LevelIter ignores rangedels and emits straddle spans.
+
+iter
+first
+next
+next
+next
+next
+next
+----
+a-b:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000001.sst)
+b-c:{} (file = 000001.sst)
+c-e:{(#3,RANGEKEYSET,@3,baz) (#3,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+e-g:{} (file = 000002.sst)
+g-h:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000003.sst)
+i-j:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000003.sst)
+
+iter
+seek-ge c
+next
+next
+next
+next
+----
+c-e:{(#3,RANGEKEYSET,@3,baz) (#3,RANGEKEYSET,@1,bar)} (file = 000002.sst)
+e-g:{} (file = 000002.sst)
+g-h:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000003.sst)
+i-j:{(#2,RANGEKEYSET,@3,foo) (#1,RANGEKEYSET,@1,bar)} (file = 000003.sst)
+.

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -277,6 +277,52 @@ const (
 	KeyTypeRange
 )
 
+type keyTypeAnnotator struct{}
+
+var _ Annotator = keyTypeAnnotator{}
+
+func (k keyTypeAnnotator) Zero(dst interface{}) interface{} {
+	var val *KeyType
+	if dst != nil {
+		val = dst.(*KeyType)
+	} else {
+		val = new(KeyType)
+	}
+	*val = KeyTypePoint
+	return val
+}
+
+func (k keyTypeAnnotator) Accumulate(m *FileMetadata, dst interface{}) (interface{}, bool) {
+	v := dst.(*KeyType)
+	switch *v {
+	case KeyTypePoint:
+		if m.HasRangeKeys {
+			*v = KeyTypePointAndRange
+		}
+	case KeyTypePointAndRange:
+		// Do nothing.
+	default:
+		panic("unexpected key type")
+	}
+	return v, true
+}
+
+func (k keyTypeAnnotator) Merge(src interface{}, dst interface{}) interface{} {
+	v := dst.(*KeyType)
+	srcVal := src.(*KeyType)
+	switch *v {
+	case KeyTypePoint:
+		if *srcVal == KeyTypePointAndRange {
+			*v = KeyTypePointAndRange
+		}
+	case KeyTypePointAndRange:
+		// Do nothing.
+	default:
+		panic("unexpected key type")
+	}
+	return v
+}
+
 // LevelIterator iterates over a set of files' metadata. Its zero value is an
 // empty iterator.
 type LevelIterator struct {

--- a/table_cache.go
+++ b/table_cache.go
@@ -120,7 +120,7 @@ func (c *tableCacheContainer) newIters(
 }
 
 func (c *tableCacheContainer) newRangeKeyIter(
-	file *manifest.FileMetadata, opts *keyspan.RangeIterOptions,
+	file *manifest.FileMetadata, opts *keyspan.SpanIterOptions,
 ) (keyspan.FragmentIterator, error) {
 	return c.tableCache.getShard(file.FileNum).newRangeKeyIter(file, opts, &c.dbOpts)
 }
@@ -402,7 +402,7 @@ func (c *tableCacheShard) newIters(
 }
 
 func (c *tableCacheShard) newRangeKeyIter(
-	file *manifest.FileMetadata, opts *keyspan.RangeIterOptions, dbOpts *tableCacheOpts,
+	file *manifest.FileMetadata, opts *keyspan.SpanIterOptions, dbOpts *tableCacheOpts,
 ) (keyspan.FragmentIterator, error) {
 	// Calling findNode gives us the responsibility of decrementing v's
 	// refCount. If opening the underlying table resulted in error, then we
@@ -418,7 +418,7 @@ func (c *tableCacheShard) newRangeKeyIter(
 	ok := true
 	var err error
 	if opts != nil {
-		ok, _, err = c.checkAndIntersectFilters(v, nil, opts.Filters)
+		ok, _, err = c.checkAndIntersectFilters(v, nil, opts.RangeKeyFilters)
 	}
 	if err != nil {
 		c.unrefValue(v)

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -974,3 +974,43 @@ compact a-d parallel hide-file-num
   [b#0,SET-b#0,SET]
   [c#0,SET-c#0,SET]
   [d#0,SET-d#0,SET]
+
+# Create a contrived compaction that forces point key and rangedel iterators
+# to stay in sync to emit a correct view of visible and deleted keys. Note that
+# Pebble no longer produces range tombstones that go outside a file's bounds,
+# but past versions of pebble did, and we should still be able to handle those
+# well.
+
+define target-file-sizes=(1, 1, 1, 1, 1, 1) snapshots=(390)
+L3  start=tmgc.MERGE.391 end=tmgc.MERGE.391
+  tmgc.MERGE.391:foo
+	tmgc.RANGEDEL.331:udkatvs
+L3 start=tmgc.MERGE.384 end=tmgc.MERGE.384
+  tmgc.MERGE.384:bar
+  tmgc.RANGEDEL.383:tvsalezade
+  tmgc.RANGEDEL.331:tvsalezade
+L3 start=tmgc.RANGEDEL.383 end=tvsalezade.RANGEDEL.72057594037927935
+  tmgc.RANGEDEL.383:tvsalezade
+  tmgc.SET.375:baz
+  tmgc.RANGEDEL.356:tvsalezade
+----
+3:
+  000004:[tmgc#391,MERGE-tmgc#391,MERGE]
+  000005:[tmgc#384,MERGE-tmgc#384,MERGE]
+  000006:[tmgc#383,RANGEDEL-tvsalezade#72057594037927935,RANGEDEL]
+
+compact a-z L3
+----
+4:
+  000007:[tmgc#391,MERGE-tmgc#384,MERGE]
+
+# baz should NOT be visible in the value.
+
+iter
+first
+next
+next
+----
+tmgc:barfoo
+.
+.


### PR DESCRIPTION
This change updates compaction.newInputIters to create
a keyspan.LevelIter containing all rangedel iterators
in a level, instead of the old way of exposing all rangedel
iterators directly to the merging iter. This makes the merging
iter more efficient as it has to manage a smaller heap (especially
for very large compactions), and also reduces the amount of
files that need to be front-opened and rangedel blocks that need
to be front-loaded before the compaction can begin. The LevelIter
can lazily open files as it goes through the compaction.

Also adds a rangedel mode to keyspan.LevelIter that makes it
find files based on point key bounds instead of on range
key bounds.

Fixes #1645