### PR TITLE
db,record: add internal metrics for throughput, latency and utilization

### DIFF
--- a/internal/base/metrics.go
+++ b/internal/base/metrics.go
@@ -1,0 +1,76 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package base
+
+import "time"
+
+// ThroughputMetric is used to measure the byte throughput of some component
+// that performs work in a single-threaded manner. The throughput can be
+// approximated by Bytes/(WorkDuration+IdleTime). The idle time is represented
+// separately, so that the user of this metric could approximate the peak
+// throughput as Bytes/WorkTime. The metric is designed to be cumulative (see
+// Merge).
+type ThroughputMetric struct {
+	// Bytes is the processes bytes by the component.
+	Bytes int64
+	// WorkDuration is the duration that the component spent doing work.
+	WorkDuration time.Duration
+	// IdleDuration is the duration that the component was idling, waiting for
+	// work.
+	IdleDuration time.Duration
+}
+
+// Merge accumulates the information from another throughput metric.
+func (tm *ThroughputMetric) Merge(x ThroughputMetric) {
+	tm.Bytes += x.Bytes
+	tm.WorkDuration += x.WorkDuration
+	tm.IdleDuration += x.IdleDuration
+}
+
+// PeakRate returns the approximate peak rate if there was no idling.
+func (tm *ThroughputMetric) PeakRate() int64 {
+	if tm.Bytes == 0 {
+		return 0
+	}
+	return int64((float64(tm.Bytes) / float64(tm.WorkDuration)) * float64(time.Second))
+}
+
+// Rate returns the observed rate.
+func (tm *ThroughputMetric) Rate() int64 {
+	if tm.Bytes == 0 {
+		return 0
+	}
+	return int64((float64(tm.Bytes) / float64(tm.WorkDuration+tm.IdleDuration)) *
+		float64(time.Second))
+}
+
+// GaugeSampleMetric is used to measure a gauge value (e.g. queue length) by
+// accumulating samples of that gauge.
+type GaugeSampleMetric struct {
+	// The sum of all the samples.
+	sampleSum int64
+	// The number of samples.
+	count int64
+}
+
+// AddSample adds the given sample.
+func (gsm *GaugeSampleMetric) AddSample(sample int64) {
+	gsm.sampleSum += sample
+	gsm.count++
+}
+
+// Merge accumulates the information from another gauge metric.
+func (gsm *GaugeSampleMetric) Merge(x GaugeSampleMetric) {
+	gsm.sampleSum += x.sampleSum
+	gsm.count += x.count
+}
+
+// Mean returns the mean value.
+func (gsm *GaugeSampleMetric) Mean() float64 {
+	if gsm.count == 0 {
+		return 0
+	}
+	return float64(gsm.sampleSum) / float64(gsm.count)
+}

--- a/internal/base/metrics_test.go
+++ b/internal/base/metrics_test.go
@@ -1,0 +1,45 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package base
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestThroughputMetric(t *testing.T) {
+	m1 := ThroughputMetric{
+		Bytes:        10,
+		WorkDuration: time.Millisecond,
+		IdleDuration: 9 * time.Millisecond,
+	}
+	var m2 ThroughputMetric
+	m2.Merge(m1)
+	require.Equal(t, m1, m2)
+	m2.Merge(m1)
+	doubleM1 := ThroughputMetric{
+		Bytes:        2 * m1.Bytes,
+		WorkDuration: 2 * m1.WorkDuration,
+		IdleDuration: 2 * m1.IdleDuration,
+	}
+	require.Equal(t, doubleM1, m2)
+	require.EqualValues(t, 10*100, m1.Rate())
+	require.EqualValues(t, 10*1000, m1.PeakRate())
+}
+
+func TestGaugeSampleMetric(t *testing.T) {
+	g1 := GaugeSampleMetric{}
+	g1.AddSample(10)
+	g1.AddSample(20)
+	g2 := GaugeSampleMetric{}
+	g2.Merge(g1)
+	g2.AddSample(60)
+	require.EqualValues(t, 30, g2.Mean())
+	require.EqualValues(t, 3, g2.count)
+	require.EqualValues(t, 15, g1.Mean())
+	require.EqualValues(t, 2, g1.count)
+}

--- a/metrics.go
+++ b/metrics.go
@@ -7,10 +7,12 @@ package pebble
 import (
 	"fmt"
 
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/humanize"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/redact"
+	"github.com/codahale/hdrhistogram"
 )
 
 // CacheMetrics holds metrics for the block and table cache.
@@ -18,6 +20,10 @@ type CacheMetrics = cache.Metrics
 
 // FilterMetrics holds metrics for the filter policy
 type FilterMetrics = sstable.FilterMetrics
+
+// ThroughputMetric is a cumulative throughput metric. See the detailed
+// comment in base.
+type ThroughputMetric = base.ThroughputMetric
 
 func formatCacheMetrics(w redact.SafePrinter, m *CacheMetrics, name redact.SafeString) {
 	w.Printf("%7s %9s %7s %6.1f%%  (score == hit-rate)\n",
@@ -415,4 +421,42 @@ func hitRate(hits, misses int64) float64 {
 		return 0
 	}
 	return 100 * float64(hits) / float64(sum)
+}
+
+// InternalIntervalMetrics exposes metrics about internal subsystems, that can
+// be useful for deep observability purposes, and for higher-level admission
+// control systems that are trying to estimate the capacity of the DB. These
+// are experimental and subject to change, since they expose internal
+// implementation details, so do not rely on these without discussion with the
+// Pebble team.
+// These represent the metrics over the interval of time from the last call to
+// retrieve these metrics. These are not cumulative, unlike Metrics. The main
+// challenge in making these cumulative is the hdrhistogram.Histogram, which
+// does not have the ability to subtract a histogram from a preceding metric
+// retrieval.
+type InternalIntervalMetrics struct {
+	// LogWriter metrics.
+	LogWriter struct {
+		// WriteThroughput is the WAL throughput.
+		WriteThroughput ThroughputMetric
+		// PendingBufferUtilization is the utilization of the WAL writer's
+		// finite-sized pending blocks buffer. It provides an additional signal
+		// regarding how close to "full" the WAL writer is. The value is in the
+		// interval [0,1].
+		PendingBufferUtilization float64
+		// SyncQueueUtilization is the utilization of the WAL writer's
+		// finite-sized queue of work that is waiting to sync. The value is in the
+		// interval [0,1].
+		SyncQueueUtilization float64
+		// SyncLatencyMicros is a distribution of the fsync latency observed by
+		// the WAL writer. It can be nil if there were no fsyncs.
+		SyncLatencyMicros *hdrhistogram.Histogram
+	}
+	// Flush loop metrics.
+	Flush struct {
+		// WriteThroughput is the flushing throughput.
+		WriteThroughput ThroughputMetric
+	}
+	// NB: the LogWriter throughput and the Flush throughput are not directly
+	// comparable because the former does not compress, unlike the latter.
 }

--- a/open.go
+++ b/open.go
@@ -143,6 +143,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	d.mu.cleaner.cond.L = &d.mu.Mutex
 	d.mu.compact.cond.L = &d.mu.Mutex
 	d.mu.compact.inProgress = make(map[*compaction]struct{})
+	d.mu.compact.noOngoingFlushStartTime = time.Now()
 	d.mu.snapshots.init()
 	// logSeqNum is the next sequence number that will be assigned. Start
 	// assigning sequence numbers from 1 to match rocksdb.


### PR DESCRIPTION
These are explicitly marked as subject to change since they are
exposing implementation of Pebble sub-systems.
They are useful for CockroachDB admission control for estimating
peak throughput, for generating write tokens. Utilization also
allows better understanding how close to the edge we are, before
a write can experience some kind of stall.

Based on some CockroachDB kv0 experimentation, one can drive the
flush pipeline to 100% utilization, resulting in write stalls.
The log writer can also surprisingly be driven to high time
utilization and high pending buffer utilization, in cases where
sync latency is high (say due to write bandwidth saturation of the
disk). This is a justification for exposing these metrics.