### PR TITLE
crl-release-22.1: internal/metamorphic: add support for an initial database state 

### DIFF
--- a/internal/metamorphic/generator.go
+++ b/internal/metamorphic/generator.go
@@ -63,12 +63,12 @@ type generator struct {
 	snapshots map[objID]objIDSet
 }
 
-func newGenerator(rng *rand.Rand, cfg config) *generator {
+func newGenerator(rng *rand.Rand, cfg config, km *keyManager) *generator {
 	g := &generator{
 		cfg:         cfg,
 		rng:         rng,
 		init:        &initOp{},
-		keyManager:  newKeyManager(),
+		keyManager:  km,
 		liveReaders: objIDSlice{makeObjID(dbTag, 0)},
 		liveWriters: objIDSlice{makeObjID(dbTag, 0)},
 		batches:     make(map[objID]objIDSet),
@@ -81,8 +81,8 @@ func newGenerator(rng *rand.Rand, cfg config) *generator {
 	return g
 }
 
-func generate(rng *rand.Rand, count uint64, cfg config) []op {
-	g := newGenerator(rng, cfg)
+func generate(rng *rand.Rand, count uint64, cfg config, km *keyManager) []op {
+	g := newGenerator(rng, cfg, km)
 
 	generators := []func(){
 		batchAbort:          g.batchAbort,

--- a/internal/metamorphic/generator_test.go
+++ b/internal/metamorphic/generator_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestGenerator(t *testing.T) {
 	rng := randvar.NewRand()
-	g := newGenerator(rng, defaultConfig())
+	g := newGenerator(rng, defaultConfig(), newKeyManager())
 
 	g.newBatch()
 	g.newBatch()
@@ -61,7 +61,7 @@ func TestGenerator(t *testing.T) {
 		t.Logf("\n%s", g)
 	}
 
-	g = newGenerator(rng, defaultConfig())
+	g = newGenerator(rng, defaultConfig(), newKeyManager())
 
 	g.newSnapshot()
 	g.newSnapshot()
@@ -94,7 +94,7 @@ func TestGenerator(t *testing.T) {
 		t.Logf("\n%s", g)
 	}
 
-	g = newGenerator(rng, defaultConfig())
+	g = newGenerator(rng, defaultConfig(), newKeyManager())
 
 	g.newIndexedBatch()
 	g.newIndexedBatch()
@@ -129,7 +129,7 @@ func TestGeneratorRandom(t *testing.T) {
 	generateFromSeed := func() string {
 		rng := rand.New(rand.NewSource(seed))
 		count := ops.Uint64(rng)
-		return formatOps(generate(rng, count, defaultConfig()))
+		return formatOps(generate(rng, count, defaultConfig(), newKeyManager()))
 	}
 
 	// Ensure that generate doesn't use any other source of randomness other

--- a/internal/metamorphic/key_manager.go
+++ b/internal/metamorphic/key_manager.go
@@ -3,9 +3,11 @@ package metamorphic
 import (
 	"fmt"
 	"sort"
+	"testing"
 
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/stretchr/testify/require"
 )
 
 // objKey is a tuple of (objID, key). This struct is used primarily as a map
@@ -445,4 +447,67 @@ func (k *keyManager) canTolerateApplyFailure(id objID) bool {
 		}
 	}
 	return true
+}
+
+func opWrittenKeys(untypedOp op) [][]byte {
+	switch t := untypedOp.(type) {
+	case *applyOp:
+	case *batchCommitOp:
+	case *checkpointOp:
+	case *closeOp:
+	case *compactOp:
+	case *dbRestartOp:
+	case *deleteOp:
+		return [][]byte{t.key}
+	case *deleteRangeOp:
+		return [][]byte{t.start, t.end}
+	case *flushOp:
+	case *getOp:
+	case *ingestOp:
+	case *initOp:
+	case *iterFirstOp:
+	case *iterLastOp:
+	case *iterNextOp:
+	case *iterPrevOp:
+	case *iterSeekGEOp:
+	case *iterSeekLTOp:
+	case *iterSeekPrefixGEOp:
+	case *iterSetBoundsOp:
+	case *mergeOp:
+		return [][]byte{t.key}
+	case *newBatchOp:
+	case *newIndexedBatchOp:
+	case *newIterOp:
+	case *newIterUsingCloneOp:
+	case *newSnapshotOp:
+	case *setOp:
+		return [][]byte{t.key}
+	case *singleDeleteOp:
+		return [][]byte{t.key}
+	}
+	return nil
+}
+
+func loadPrecedingKeys(t testing.TB, ops []op, cfg *config, m *keyManager) {
+	for _, op := range ops {
+		// Pretend we're generating all the operation's keys as potential new
+		// key, so that we update the key manager's keys and prefix sets.
+		for _, k := range opWrittenKeys(op) {
+			m.addNewKey(k)
+
+			// If the key has a suffix, ratchet up the suffix distribution if
+			// necessary.
+			if s := m.comparer.Split(k); s < len(k) {
+				suffix, err := testkeys.ParseSuffix(k[s:])
+				require.NoError(t, err)
+				if uint64(suffix) > cfg.suffixDist.Max() {
+					diff := int(uint64(suffix) - cfg.suffixDist.Max())
+					cfg.suffixDist.IncMax(diff)
+				}
+			}
+		}
+
+		// Update key tracking state.
+		m.update(op)
+	}
 }

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -134,7 +134,7 @@ func standardOptions() []*testOptions {
 `,
 		10: `
 [Options]
-  wal_dir=wal
+  wal_dir=data/wal
 `,
 		11: `
 [Level "0"]
@@ -224,7 +224,7 @@ func randomOptions(rng *rand.Rand) *testOptions {
 	opts.MemTableSize = 2 << (10 + uint(rng.Intn(16))) // 2KB - 256MB
 	opts.MemTableStopWritesThreshold = 2 + rng.Intn(5) // 2 - 5
 	if rng.Intn(2) == 0 {
-		opts.WALDir = "wal"
+		opts.WALDir = "data/wal"
 	}
 	var lopts pebble.LevelOptions
 	lopts.BlockRestartInterval = 1 + rng.Intn(64)  // 1 - 64

--- a/internal/metamorphic/options_test.go
+++ b/internal/metamorphic/options_test.go
@@ -1,0 +1,51 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package metamorphic
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupInitialState(t *testing.T) {
+	// Construct a small database in the test's TempDir.
+	initialStatePath := t.TempDir()
+	{
+		d, err := pebble.Open(initialStatePath, &pebble.Options{})
+		require.NoError(t, err)
+		const maxKeyLen = 2
+		ks := testkeys.Alpha(maxKeyLen)
+		var key [maxKeyLen]byte
+		for i := 0; i < ks.Count(); i++ {
+			n := testkeys.WriteKey(key[:], ks, i)
+			require.NoError(t, d.Set(key[:n], key[:n], pebble.NoSync))
+			if i%100 == 0 {
+				require.NoError(t, d.Flush())
+			}
+		}
+		require.NoError(t, d.Close())
+	}
+	require.NoError(t, vfs.Default.MkdirAll(filepath.Join(initialStatePath, "wal"), os.ModePerm))
+	ls, err := vfs.Default.List(initialStatePath)
+	require.NoError(t, err)
+
+	// setupInitialState with an initial state path set to the test's TempDir
+	// should populate opts.opts.FS with the directory's contents.
+	opts := &testOptions{
+		opts:             defaultOptions(),
+		initialStatePath: initialStatePath,
+		initialStateDesc: "test",
+	}
+	require.NoError(t, setupInitialState("", opts))
+	copied, err := opts.opts.FS.List("")
+	require.NoError(t, err)
+	require.ElementsMatch(t, ls, copied)
+}

--- a/internal/metamorphic/parser_test.go
+++ b/internal/metamorphic/parser_test.go
@@ -31,7 +31,7 @@ func TestParser(t *testing.T) {
 }
 
 func TestParserRandom(t *testing.T) {
-	ops := generate(randvar.NewRand(), 10000, defaultConfig())
+	ops := generate(randvar.NewRand(), 10000, defaultConfig(), newKeyManager())
 	src := formatOps(ops)
 
 	parsedOps, err := parse([]byte(src))

--- a/internal/randvar/randvar.go
+++ b/internal/randvar/randvar.go
@@ -19,4 +19,7 @@ type Dynamic interface {
 
 	// Increment the max value the variable will return.
 	IncMax(delta int)
+
+	// Read the current max value the variable will return.
+	Max() uint64
 }

--- a/internal/randvar/skewed_latest.go
+++ b/internal/randvar/skewed_latest.go
@@ -60,6 +60,13 @@ func (z *SkewedLatest) IncMax(delta int) {
 	z.mu.Unlock()
 }
 
+// Max returns max.
+func (z *SkewedLatest) Max() uint64 {
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	return z.mu.zipf.Max()
+}
+
 // Uint64 returns a random Uint64 between min and max, where keys near max are
 // most likely to be drawn.
 func (z *SkewedLatest) Uint64(rng *rand.Rand) uint64 {

--- a/internal/randvar/uniform.go
+++ b/internal/randvar/uniform.go
@@ -40,6 +40,11 @@ func (g *Uniform) IncMax(delta int) {
 	atomic.AddUint64(&g.max, uint64(delta))
 }
 
+// Max returns the max value of the distribution.
+func (g *Uniform) Max() uint64 {
+	return atomic.LoadUint64(&g.max)
+}
+
 // Uint64 returns a random Uint64 between min and max, drawn from a uniform
 // distribution.
 func (g *Uniform) Uint64(rng *rand.Rand) uint64 {

--- a/internal/randvar/zipf.go
+++ b/internal/randvar/zipf.go
@@ -120,6 +120,13 @@ func (z *Zipf) IncMax(delta int) {
 	z.mu.Unlock()
 }
 
+// Max returns the max.
+func (z *Zipf) Max() uint64 {
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	return z.mu.max
+}
+
 // Uint64 draws a new value between min and max, with probabilities according
 // to the Zipf distribution.
 func (z *Zipf) Uint64(rng *rand.Rand) uint64 {

--- a/internal/testkeys/testkeys.go
+++ b/internal/testkeys/testkeys.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 
 	"github.com/cockroachdb/pebble/internal/base"
 )
@@ -185,6 +186,11 @@ func SuffixLen(t int) int {
 		n++
 	}
 	return n
+}
+
+// ParseSuffix returns the integer representation of the encoded suffix.
+func ParseSuffix(s []byte) (int, error) {
+	return strconv.Atoi(strings.TrimPrefix(string(s), string(suffixDelim)))
 }
 
 // WriteSuffix writes the test keys suffix representation of timestamp t to dst,

--- a/options.go
+++ b/options.go
@@ -1006,7 +1006,7 @@ type ParseHooks struct {
 	NewComparer     func(name string) (*Comparer, error)
 	NewFilterPolicy func(name string) (FilterPolicy, error)
 	NewMerger       func(name string) (*Merger, error)
-	SkipUnknown     func(name string) bool
+	SkipUnknown     func(name, value string) bool
 }
 
 // Parse parses the options from the specified string. Note that certain
@@ -1024,7 +1024,7 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 			switch key {
 			case "pebble_version":
 			default:
-				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key) {
+				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key, value) {
 					return nil
 				}
 				return errors.Errorf("pebble: unknown option: %s.%s",
@@ -1152,7 +1152,7 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 			case "wal_bytes_per_sync":
 				o.WALBytesPerSync, err = strconv.Atoi(value)
 			default:
-				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key) {
+				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key, value) {
 					return nil
 				}
 				return errors.Errorf("pebble: unknown option: %s.%s",
@@ -1165,7 +1165,7 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 			if n, err := fmt.Sscanf(section, `Level "%d"`, &index); err != nil {
 				return err
 			} else if n != 1 {
-				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section) {
+				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section, value) {
 					return nil
 				}
 				return errors.Errorf("pebble: unknown section: %q", errors.Safe(section))
@@ -1213,14 +1213,14 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 			case "target_file_size":
 				l.TargetFileSize, err = strconv.ParseInt(value, 10, 64)
 			default:
-				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key) {
+				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key, value) {
 					return nil
 				}
 				return errors.Errorf("pebble: unknown option: %s.%s", errors.Safe(section), errors.Safe(key))
 			}
 			return err
 		}
-		if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key) {
+		if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key, value) {
 			return nil
 		}
 		return errors.Errorf("pebble: unknown section: %q", errors.Safe(section))

--- a/tool/db.go
+++ b/tool/db.go
@@ -200,7 +200,7 @@ func (d *dbT) loadOptions(dir string) error {
 			}
 			return nil, errors.Errorf("unknown merger %q", errors.Safe(name))
 		},
-		SkipUnknown: func(name string) bool {
+		SkipUnknown: func(name, value string) bool {
 			return true
 		},
 	}

--- a/vfs/clone.go
+++ b/vfs/clone.go
@@ -11,13 +11,35 @@ import (
 	"github.com/cockroachdb/errors/oserror"
 )
 
+type cloneOpts struct {
+	skip func(string) bool
+	sync bool
+}
+
+// A CloneOption configures the behavior of Clone.
+type CloneOption func(*cloneOpts)
+
+// CloneSkip configures Clone to skip files for which the provided function
+// returns true when passed the file's path.
+func CloneSkip(fn func(string) bool) CloneOption {
+	return func(co *cloneOpts) { co.skip = fn }
+}
+
+// CloneSync configures Clone to sync files and directories.
+var CloneSync CloneOption = func(o *cloneOpts) { o.sync = true }
+
 // Clone recursively copies a directory structure from srcFS to dstFS. srcPath
 // specifies the path in srcFS to copy from and must be compatible with the
 // srcFS path format. dstDir is the target directory in dstFS and must be
 // compatible with the dstFS path format. Returns (true,nil) on a successful
 // copy, (false,nil) if srcPath does not exist, and (false,err) if an error
 // occurred.
-func Clone(srcFS, dstFS FS, srcPath, dstPath string) (bool, error) {
+func Clone(srcFS, dstFS FS, srcPath, dstPath string, opts ...CloneOption) (bool, error) {
+	var o cloneOpts
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	srcFile, err := srcFS.Open(srcPath)
 	if err != nil {
 		if oserror.IsNotExist(err) {
@@ -47,11 +69,28 @@ func Clone(srcFS, dstFS FS, srcPath, dstPath string) (bool, error) {
 		// Sort the paths so we get deterministic test output.
 		sort.Strings(list)
 		for _, name := range list {
-			_, err := Clone(srcFS, dstFS, srcFS.PathJoin(srcPath, name), dstFS.PathJoin(dstPath, name))
+			if o.skip != nil && o.skip(srcFS.PathJoin(srcPath, name)) {
+				continue
+			}
+			_, err := Clone(srcFS, dstFS, srcFS.PathJoin(srcPath, name), dstFS.PathJoin(dstPath, name), opts...)
 			if err != nil {
 				return false, err
 			}
 		}
+
+		if o.sync {
+			dir, err := dstFS.OpenDir(dstPath)
+			if err != nil {
+				return false, err
+			}
+			if err := dir.Sync(); err != nil {
+				return false, err
+			}
+			if err := dir.Close(); err != nil {
+				return false, err
+			}
+		}
+
 		return true, nil
 	}
 
@@ -69,6 +108,12 @@ func Clone(srcFS, dstFS FS, srcPath, dstPath string) (bool, error) {
 	if _, err = dstFile.Write(data); err != nil {
 		return false, err
 	}
+	if o.sync {
+		if err := dstFile.Sync(); err != nil {
+			return false, err
+		}
+	}
+
 	if err := dstFile.Close(); err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Backport of #1635 to the 22.1 release branch.

Backporting this will allow us to test the upgrade from 21.2 to 22.2
as a part of #1612.