### PR TITLE
internal/keyspan: clean up InterleavingIter

### DIFF
--- a/db.go
+++ b/db.go
@@ -978,7 +978,7 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 		// NB: The interleaving iterator is always reinitialized, even if
 		// dbi already had an initialized range key iterator, in case the point
 		// iterator changed or the range key masking suffix changed.
-		dbi.rangeKey.iter.Init(dbi.cmp, dbi.split, dbi.iter, dbi.rangeKey.rangeKeyIter, keyspan.Hooks{
+		dbi.rangeKey.iter.Init(dbi.cmp, dbi.iter, dbi.rangeKey.rangeKeyIter, keyspan.Hooks{
 			SpanChanged: dbi.rangeKeySpanChanged,
 			SkipPoint:   dbi.rangeKeySkipPoint,
 		})

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -143,7 +143,7 @@ func NewExternalIter(
 			rangeKeyIters...,
 		)
 
-		dbi.rangeKey.iter.Init(dbi.cmp, dbi.split, &buf.merging, dbi.rangeKey.rangeKeyIter, keyspan.Hooks{
+		dbi.rangeKey.iter.Init(dbi.cmp, &buf.merging, dbi.rangeKey.rangeKeyIter, keyspan.Hooks{
 			SpanChanged: dbi.rangeKeySpanChanged,
 			SkipPoint:   dbi.rangeKeySkipPoint,
 		})

--- a/internal/keyspan/interleaving_iter_test.go
+++ b/internal/keyspan/interleaving_iter_test.go
@@ -90,7 +90,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 			}
 			keyspanIter.Init(cmp, noopTransform, NewIter(cmp, spans))
 			hooks.maskSuffix = nil
-			iter.Init(cmp, testkeys.Comparer.Split, base.WrapIterWithStats(&pointIter), &keyspanIter, Hooks{
+			iter.Init(cmp, base.WrapIterWithStats(&pointIter), &keyspanIter, Hooks{
 				SpanChanged: hooks.SpanChanged,
 				SkipPoint:   hooks.SkipPoint,
 			})
@@ -103,7 +103,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 			}
 			pointIter = pointIterator{cmp: cmp, keys: points}
 			hooks.maskSuffix = nil
-			iter.Init(cmp, testkeys.Comparer.Split, base.WrapIterWithStats(&pointIter), &keyspanIter, Hooks{
+			iter.Init(cmp, base.WrapIterWithStats(&pointIter), &keyspanIter, Hooks{
 				SpanChanged: hooks.SpanChanged,
 				SkipPoint:   hooks.SkipPoint,
 			})

--- a/internal/keyspan/testdata/interleaving_iter
+++ b/internal/keyspan/testdata/interleaving_iter
@@ -54,10 +54,10 @@ Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
 PointKey: e#72057594037927935,21
 Span: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
 -
-PointKey: h#72057594037927935,21
+PointKey: h#72057594037927935,19
 Span: h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)}
 -
-PointKey: l#72057594037927935,21
+PointKey: l#72057594037927935,20
 Span: l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
 -
 PointKey: parsnip#3,1
@@ -154,7 +154,7 @@ Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 PointKey: parsnip#3,1
 Span: <invalid>
 -
-PointKey: l#72057594037927935,21
+PointKey: l#72057594037927935,20
 Span: l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
 -
 PointKey: parsnip#3,1
@@ -281,7 +281,7 @@ Span: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
 PointKey: e#2,1
 Span: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
 -
-PointKey: h#72057594037927935,21
+PointKey: h#72057594037927935,19
 Span: h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)}
 -
 
@@ -510,13 +510,13 @@ last
 seek-ge a
 seek-lt d
 ----
-PointKey: b#72057594037927935,21
+PointKey: b#72057594037927935,19
 Span: b-d:{(#5,RANGEKEYDEL)}
 -
-PointKey: f#72057594037927935,21
+PointKey: f#72057594037927935,19
 Span: f-g:{(#6,RANGEKEYDEL)}
 -
-PointKey: b#72057594037927935,21
+PointKey: b#72057594037927935,19
 Span: b-d:{(#5,RANGEKEYDEL)}
 -
 PointKey: c#8,1
@@ -548,7 +548,7 @@ Span: w-y:{(#5,RANGEKEYSET,@1,v1)}
 PointKey: x#8,1
 Span: w-y:{(#5,RANGEKEYSET,@1,v1)}
 -
-PointKey: y#72057594037927935,21
+PointKey: y#72057594037927935,19
 Span: y-z:{(#5,RANGEKEYDEL)}
 -
 

--- a/internal/keyspan/testdata/interleaving_iter_masking
+++ b/internal/keyspan/testdata/interleaving_iter_masking
@@ -307,7 +307,7 @@ next
 next
 next
 ----
-PointKey: a#72057594037927935,21
+PointKey: a#72057594037927935,20
 Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 -
 PointKey: a#1,1
@@ -332,7 +332,7 @@ Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 PointKey: a#1,1
 Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 -
-PointKey: a#72057594037927935,21
+PointKey: a#72057594037927935,20
 Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 -
 .


### PR DESCRIPTION
Remove superfluous Split parameter. Split was required for implementing
masking, but a direct implementation of masking was replaced with generic
Hooks.

Also, don't interleave a synthetic marker for empty spans. The synthetic marker
doesn't serve any purpose if there are no keys defined over the span. This
allows us to return a synthetic marker using an arbitrary Key's kind (rather
than always using RANGEKEYSET, even if the Span contained no RANGEKEYSET keys).