### PR TITLE
keyspan: add Filter; refactor keyspan.Truncate to use Filter

### DIFF
--- a/internal/keyspan/defragment_test.go
+++ b/internal/keyspan/defragment_test.go
@@ -264,7 +264,7 @@ func debugContext(
 
 var iterDelim = map[rune]bool{',': true, ' ': true, '(': true, ')': true, '"': true}
 
-func runIterOp(w io.Writer, it *DefragmentingIter, op string) {
+func runIterOp(w io.Writer, it FragmentIterator, op string) {
 	fields := strings.FieldsFunc(op, func(r rune) bool { return iterDelim[r] })
 	var s Span
 	switch strings.ToLower(fields[0]) {

--- a/internal/keyspan/filter.go
+++ b/internal/keyspan/filter.go
@@ -1,0 +1,111 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package keyspan
+
+// FilterFunc defines a transform from the input Span into the output Span. The
+// function returns true if the Span should be returned by the iterator, and
+// false if the Span should be skipped. The FilterFunc is permitted to mutate
+// the output Span, for example, to elice certain keys, or update the Span's
+// bounds if so desired. The output Span's Keys slice may be reused to reduce
+// allocations.
+type FilterFunc func(in Span, out *Span) (keep bool)
+
+// FilteringIter is a FragmentIterator that uses a FilterFunc to select which
+// Spans from the input iterator are returned in the output.
+//
+// A note on Span lifetimes: as the FilterFunc reuses a Span with a mutable
+// slice of Keys to reduce allocations, Spans returned by this iterator are only
+// valid until the next relative or absolute positioning method is called.
+type FilteringIter struct {
+	iter     FragmentIterator
+	filterFn FilterFunc
+
+	// span is a mutable Span passed to the filterFn. The filterFn is free to
+	// mutate this Span. The slice of Keys in the Span is reused with every call
+	// to the filterFn.
+	span Span
+}
+
+var _ FragmentIterator = (*FilteringIter)(nil)
+
+// Filter returns a new FilteringIter that will filter the Spans from the
+// provided child iterator using the provided FilterFunc.
+func Filter(iter FragmentIterator, filter FilterFunc) *FilteringIter {
+	return &FilteringIter{iter: iter, filterFn: filter}
+}
+
+// SeekGE implements FragmentIterator.
+func (i *FilteringIter) SeekGE(key []byte) Span {
+	return i.filter(i.iter.SeekGE(key), +1)
+}
+
+// SeekLT implements FragmentIterator.
+func (i *FilteringIter) SeekLT(key []byte) Span {
+	return i.filter(i.iter.SeekLT(key), -1)
+}
+
+// First implements FragmentIterator.
+func (i *FilteringIter) First() Span {
+	return i.filter(i.iter.First(), +1)
+}
+
+// Last implements FragmentIterator.
+func (i *FilteringIter) Last() Span {
+	return i.filter(i.iter.Last(), -1)
+}
+
+// Next implements FragmentIterator.
+func (i *FilteringIter) Next() Span {
+	return i.filter(i.iter.Next(), +1)
+}
+
+// Prev implements FragmentIterator.
+func (i *FilteringIter) Prev() Span {
+	return i.filter(i.iter.Prev(), -1)
+}
+
+// Clone implements FragmentIterator.
+func (i *FilteringIter) Clone() FragmentIterator {
+	return &FilteringIter{
+		iter:     i.iter.Clone(),
+		filterFn: i.filterFn,
+	}
+}
+
+// Error implements FragmentIterator.
+func (i *FilteringIter) Error() error {
+	return i.iter.Error()
+}
+
+// Close implements FragmentIterator.
+func (i *FilteringIter) Close() error {
+	return i.iter.Close()
+}
+
+// SetBounds implements FragmentIterator.
+func (i *FilteringIter) SetBounds(lower, upper []byte) {
+	i.iter.SetBounds(lower, upper)
+}
+
+// filter uses the filterFn (if configured) to filter and possibly mutate the
+// given Span. If the current Span is to be skipped, the iterator continues
+// iterating in the given direction until it lands on a Span that should be
+// returned, or the iterator becomes invalid.
+func (i *FilteringIter) filter(span Span, dir int8) Span {
+	if i.filterFn == nil {
+		return span
+	}
+	for i.Error() == nil && span.Valid() {
+		if keep := i.filterFn(span, &i.span); keep {
+			return i.span
+		}
+		if dir == +1 {
+			span = i.Next()
+		} else {
+			span = i.Prev()
+		}
+	}
+	return span
+}

--- a/internal/keyspan/filter_test.go
+++ b/internal/keyspan/filter_test.go
@@ -1,0 +1,79 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package keyspan
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+)
+
+func TestFilteringIter(t *testing.T) {
+	// makeFilter returns a FilterFunc that will filter out all keys in a Span
+	// that are not of the given kind. Empty spans are skipped.
+	makeFilter := func(kind base.InternalKeyKind) FilterFunc {
+		return func(in Span, out *Span) (keep bool) {
+			out.Start, out.End = in.Start, in.End
+			out.Keys = out.Keys[:0]
+			for _, k := range in.Keys {
+				if k.Kind() != kind {
+					continue
+				}
+				out.Keys = append(out.Keys, k)
+			}
+			return len(out.Keys) > 0
+		}
+	}
+
+	cmp := testkeys.Comparer.Compare
+	var spans []Span
+	datadriven.RunTest(t, "testdata/filtering_iter", func(td *datadriven.TestData) string {
+		switch cmd := td.Cmd; cmd {
+		case "define":
+			spans = spans[:0]
+			lines := strings.Split(strings.TrimSpace(td.Input), "\n")
+			for _, line := range lines {
+				spans = append(spans, ParseSpan(line))
+			}
+			return ""
+
+		case "iter":
+			var filter FilterFunc
+			for _, cmdArg := range td.CmdArgs {
+				switch cmdArg.Key {
+				case "filter":
+					for _, s := range cmdArg.Vals {
+						switch s {
+						case "no-op":
+							filter = nil
+						case "key-kind-set":
+							filter = makeFilter(base.InternalKeyKindRangeKeySet)
+						case "key-kind-unset":
+							filter = makeFilter(base.InternalKeyKindRangeKeyUnset)
+						case "key-kind-del":
+							filter = makeFilter(base.InternalKeyKindRangeKeyDelete)
+						default:
+							return fmt.Sprintf("unknown filter: %s", s)
+						}
+					}
+				default:
+					return fmt.Sprintf("unknown command: %s", cmdArg.Key)
+				}
+			}
+			innerIter := NewIter(cmp, spans)
+			iter := Filter(innerIter, filter)
+			defer iter.Close()
+			s := runFragmentIteratorCmd(iter, td.Input, nil)
+			return s
+
+		default:
+			return fmt.Sprintf("unknown command: %s", cmd)
+		}
+	})
+}

--- a/internal/keyspan/testdata/filtering_iter
+++ b/internal/keyspan/testdata/filtering_iter
@@ -1,0 +1,86 @@
+# The following filters are available:
+# - no-op: passes through all spans.
+# - key-kind-{set,unset,del}: filters keys in spans with the given key kind.
+
+define
+a-c:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+c-d:{(#4,RANGEKEYSET,@3,bananas) (#3,RANGEKEYDEL)}
+d-e:{(#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
+----
+
+iter filter=no-op
+first
+next
+next
+next
+----
+a-c:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+c-d:{(#4,RANGEKEYSET,@3,bananas) (#3,RANGEKEYDEL)}
+d-e:{(#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
+.
+
+iter filter=key-kind-set
+first
+next
+next
+next
+----
+a-c:{(#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+c-d:{(#4,RANGEKEYSET,@3,bananas)}
+d-e:{(#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
+.
+
+iter filter=key-kind-set
+last
+prev
+prev
+prev
+----
+d-e:{(#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
+c-d:{(#4,RANGEKEYSET,@3,bananas)}
+a-c:{(#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+.
+
+iter filter=key-kind-set
+seek-ge a
+seek-ge c
+next
+seek-lt b
+prev
+next
+seek-lt z
+next
+----
+a-c:{(#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+c-d:{(#4,RANGEKEYSET,@3,bananas)}
+d-e:{(#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
+a-c:{(#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+.
+a-c:{(#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+d-e:{(#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
+.
+
+iter filter=key-kind-set
+set-bounds b cc
+first
+next
+next
+----
+.
+a-c:{(#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+c-d:{(#4,RANGEKEYSET,@3,bananas)}
+.
+
+iter filter=key-kind-unset
+first
+next
+----
+a-c:{(#3,RANGEKEYUNSET,@5)}
+.
+
+iter filter=key-kind-del
+first
+next
+----
+c-d:{(#3,RANGEKEYDEL)}
+.

--- a/internal/keyspan/truncate.go
+++ b/internal/keyspan/truncate.go
@@ -7,27 +7,29 @@ package keyspan
 import "github.com/cockroachdb/pebble/internal/base"
 
 // Truncate creates a new iterator where every span in the supplied iterator is
-// truncated to be contained within the range [lower, upper).  If start and end
+// truncated to be contained within the range [lower, upper). If start and end
 // are specified, filter out any spans that are completely outside those bounds.
 func Truncate(
 	cmp base.Compare, iter FragmentIterator, lower, upper []byte, start, end *base.InternalKey,
-) *Iter {
-	var spans []Span
-	for s := iter.First(); s.Valid(); s = iter.Next() {
+) FragmentIterator {
+	return Filter(iter, func(in Span, out *Span) (keep bool) {
+		out.Start, out.End = in.Start, in.End
+		out.Keys = append(out.Keys[:0], in.Keys...)
+
 		// Ignore this span if it lies completely outside [start, end].
 		//
 		// The comparison between s.End and start is by user key only, as
 		// the span is exclusive at s.End, so comparing by user keys
 		// is sufficient.
-		if start != nil && cmp(s.End, start.UserKey) <= 0 {
-			continue
+		if start != nil && cmp(in.End, start.UserKey) <= 0 {
+			return false
 		}
 		if end != nil {
-			v := cmp(s.Start, end.UserKey)
+			v := cmp(in.Start, end.UserKey)
 			switch {
 			case v > 0:
 				// Wholly outside the end bound. Skip it.
-				continue
+				return false
 			case v == 0:
 				// This span begins at the same user key as `end`. Whether or
 				// not any of the keys contained within the span are relevant is
@@ -36,9 +38,9 @@ func Truncate(
 				// keyspace between [k#inf, k#<end-seqnum>]. Since keys are
 				// sorted descending by Trailer within the span, we need to find
 				// the prefix of keys with larger trailers.
-				for i := range s.Keys {
-					if s.Keys[i].Trailer < end.Trailer {
-						s.Keys = s.Keys[:i]
+				for i := range in.Keys {
+					if in.Keys[i].Trailer < end.Trailer {
+						out.Keys = out.Keys[:i]
 						break
 					}
 				}
@@ -47,15 +49,12 @@ func Truncate(
 			}
 		}
 		// Truncate the bounds to lower and upper.
-		if cmp(s.Start, lower) < 0 {
-			s.Start = lower
+		if cmp(in.Start, lower) < 0 {
+			out.Start = lower
 		}
-		if cmp(s.End, upper) > 0 {
-			s.End = upper
+		if cmp(in.End, upper) > 0 {
+			out.End = upper
 		}
-		if !s.Empty() && cmp(s.Start, s.End) < 0 {
-			spans = append(spans, s.ShallowClone())
-		}
-	}
-	return NewIter(cmp, spans)
+		return !out.Empty() && cmp(out.Start, out.End) < 0
+	})
 }

--- a/internal/keyspan/truncate_test.go
+++ b/internal/keyspan/truncate_test.go
@@ -52,8 +52,13 @@ func TestTruncate(t *testing.T) {
 			lower := []byte(parts[0])
 			upper := []byte(parts[1])
 
-			truncated := Truncate(cmp, iter, lower, upper, startKey, endKey)
-			return formatAlphabeticSpans(truncated.spans)
+			tIter := Truncate(cmp, iter, lower, upper, startKey, endKey)
+			defer tIter.Close()
+			var truncated []Span
+			for s := tIter.First(); s.Valid(); s = tIter.Next() {
+				truncated = append(truncated, s.ShallowClone())
+			}
+			return formatAlphabeticSpans(truncated)
 
 		default:
 			return fmt.Sprintf("unknown command: %s", d.Cmd)


### PR DESCRIPTION
**keyspan: add keyspan.Filter**

Add a new `FragmentIterator` implementation, `filteringIter`, that
filters spans from a child iterator according to a filter function.

The filter function indicates whether the entire span should be output
by the iterator or be skipped. In the case that the span is output, the
filter function may also opt modify the span. For example, eliding
certain keys in the output or modifying the span's bounds.

**keyspan: implement Truncate in terms of Filter**

Currently, `keyspan.Truncate` returns a new FragmentIterator generated
by iterating over all spans in the input up front, truncating the bounds
for each span or dropping the span depending on where it lies relative
to the given bounds.

Refactor `Truncate` to function in terms of `keyspan.Filter`, where the
provided filter function uses the existing logic for determining whether
a span should be output, and if so, whether the spans's bounds should be
updated.

Using `Filter` has the benefit of removing the need to iterate over all
keys in the input iterator ahead of time. Instead, filtering is done as
the iterator moves over the spans of the underlying iterator.