### PR TITLE
db: pool range-key iterator structs, remove Clone

### DIFF
--- a/db.go
+++ b/db.go
@@ -973,8 +973,7 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 	// If range keys are enabled, construct the range key iterator stack too.
 	if dbi.opts.rangeKeys() {
 		if dbi.rangeKey == nil {
-			// TODO(jackson): Pool iteratorRangeKeyState.
-			dbi.rangeKey = &iteratorRangeKeyState{}
+			dbi.rangeKey = iterRangeKeyStateAllocPool.Get().(*iteratorRangeKeyState)
 			dbi.rangeKey.keys.cmp = dbi.cmp
 			dbi.rangeKey.rangeKeyIter = dbi.newRangeKeyIter(dbi.rangeKey)
 		}

--- a/error_iter.go
+++ b/error_iter.go
@@ -77,14 +77,13 @@ func newErrorKeyspanIter(err error) *errorKeyspanIter {
 	return &errorKeyspanIter{err: err}
 }
 
-func (*errorKeyspanIter) SeekGE(key []byte) keyspan.Span    { return keyspan.Span{} }
-func (*errorKeyspanIter) SeekLT(key []byte) keyspan.Span    { return keyspan.Span{} }
-func (*errorKeyspanIter) First() keyspan.Span               { return keyspan.Span{} }
-func (*errorKeyspanIter) Last() keyspan.Span                { return keyspan.Span{} }
-func (*errorKeyspanIter) Next() keyspan.Span                { return keyspan.Span{} }
-func (*errorKeyspanIter) Prev() keyspan.Span                { return keyspan.Span{} }
-func (i *errorKeyspanIter) Clone() keyspan.FragmentIterator { return &errorKeyspanIter{err: i.err} }
-func (i *errorKeyspanIter) Error() error                    { return i.err }
-func (i *errorKeyspanIter) Close() error                    { return i.err }
-func (*errorKeyspanIter) String() string                    { return "error" }
-func (*errorKeyspanIter) SetBounds(lower, upper []byte)     {}
+func (*errorKeyspanIter) SeekGE(key []byte) keyspan.Span { return keyspan.Span{} }
+func (*errorKeyspanIter) SeekLT(key []byte) keyspan.Span { return keyspan.Span{} }
+func (*errorKeyspanIter) First() keyspan.Span            { return keyspan.Span{} }
+func (*errorKeyspanIter) Last() keyspan.Span             { return keyspan.Span{} }
+func (*errorKeyspanIter) Next() keyspan.Span             { return keyspan.Span{} }
+func (*errorKeyspanIter) Prev() keyspan.Span             { return keyspan.Span{} }
+func (i *errorKeyspanIter) Error() error                 { return i.err }
+func (i *errorKeyspanIter) Close() error                 { return i.err }
+func (*errorKeyspanIter) String() string                 { return "error" }
+func (*errorKeyspanIter) SetBounds(lower, upper []byte)  {}

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -133,8 +133,7 @@ func NewExternalIter(
 			}
 		}
 
-		// TODO(jackson): Pool range-key iterator objects.
-		dbi.rangeKey = &iteratorRangeKeyState{}
+		dbi.rangeKey = iterRangeKeyStateAllocPool.Get().(*iteratorRangeKeyState)
 		dbi.rangeKey.rangeKeyIter = rangekey.InitUserIteration(
 			o.Comparer.Compare,
 			base.InternalKeySeqNumMax,

--- a/internal/keyspan/defragment.go
+++ b/internal/keyspan/defragment.go
@@ -145,17 +145,6 @@ func (i *DefragmentingIter) Init(
 	}
 }
 
-// Clone clones the iterator, returning an independent iterator over the same
-// state. This method is temporary and may be deleted once range keys' state is
-// properly reflected in readState.
-func (i *DefragmentingIter) Clone() FragmentIterator {
-	// TODO(jackson): Delete Clone() when range-key state is incorporated into
-	// readState.
-	c := &DefragmentingIter{}
-	c.Init(i.cmp, i.iter.Clone(), i.equal, i.reduce)
-	return c
-}
-
 // Error returns any accumulated error.
 func (i *DefragmentingIter) Error() error {
 	return i.iter.Error()

--- a/internal/keyspan/filter.go
+++ b/internal/keyspan/filter.go
@@ -66,14 +66,6 @@ func (i *filteringIter) Prev() Span {
 	return i.filter(i.iter.Prev(), -1)
 }
 
-// Clone implements FragmentIterator.
-func (i *filteringIter) Clone() FragmentIterator {
-	return &filteringIter{
-		iter:     i.iter.Clone(),
-		filterFn: i.filterFn,
-	}
-}
-
 // Error implements FragmentIterator.
 func (i *filteringIter) Error() error {
 	return i.iter.Error()

--- a/internal/keyspan/iter.go
+++ b/internal/keyspan/iter.go
@@ -50,9 +50,6 @@ type FragmentIterator interface {
 	// previous call to SeekLT or Prev returned an invalid span.
 	Prev() Span
 
-	// Clone returns an unpositioned iterator containing the same spans.
-	Clone() FragmentIterator
-
 	// Error returns any accumulated error.
 	Error() error
 
@@ -248,13 +245,6 @@ func (i *Iter) SetBounds(lower, upper []byte) {
 			return i.cmp(i.spans[j].Start, upper) >= 0
 		})
 	}
-}
-
-// Clone implements FragmentIterator.Clone.
-func (i *Iter) Clone() FragmentIterator {
-	cloneIter := &Iter{}
-	*cloneIter = *i
-	return cloneIter
 }
 
 func (i *Iter) String() string {

--- a/internal/keyspan/level_iter.go
+++ b/internal/keyspan/level_iter.go
@@ -113,24 +113,6 @@ func (l *LevelIter) Init(
 	l.files = files.Filter(manifest.KeyTypeRange)
 }
 
-// Clone implements the keyspan.FragmentIterator interface
-func (l *LevelIter) Clone() FragmentIterator {
-	l2 := &LevelIter{
-		logger:    l.logger,
-		cmp:       l.cmp,
-		lower:     append([]byte(nil), l.lower...),
-		upper:     append([]byte(nil), l.upper...),
-		level:     l.level,
-		iter:      l.iter.Clone(),
-		iterFile:  l.iterFile,
-		newIter:   l.newIter,
-		files:     l.files.Clone(),
-		err:       l.err,
-		tableOpts: l.tableOpts,
-	}
-	return l2
-}
-
 func (l *LevelIter) findFileGE(key []byte) *manifest.FileMetadata {
 	// Find the earliest file whose largest key is >= key.
 	//

--- a/internal/keyspan/merging_iter.go
+++ b/internal/keyspan/merging_iter.go
@@ -729,18 +729,6 @@ func (m *MergingIter) prevEntry() {
 	}
 }
 
-// Clone clones the merging iterator and its underlying iterators.
-func (m *MergingIter) Clone() FragmentIterator {
-	// TODO(jackson): Remove when range-key state is included in readState.
-	var iters []FragmentIterator
-	for l := range m.levels {
-		iters = append(iters, m.levels[l].iter.iter.Clone())
-	}
-	dup := &MergingIter{}
-	dup.Init(m.cmp, m.transform, iters...)
-	return dup
-}
-
 // DebugString returns a string representing the current internal state of the
 // merging iterator and its heap for debugging purposes.
 func (m *MergingIter) DebugString() string {

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -1120,13 +1120,6 @@ func (i *fragmentBlockIter) Error() error {
 	return i.err
 }
 
-// Clone implements (keyspan.FragmentIterator).Clone, as documented in the
-// internal/keyspan package.
-func (i *fragmentBlockIter) Clone() keyspan.FragmentIterator {
-	// TODO(jackson): Remove keyspan.FragmentIterator.Clone.
-	panic("unimplemented")
-}
-
 // Close implements (base.InternalIterator).Close, as documented in the
 // internal/base package.
 func (i *fragmentBlockIter) Close() error {


### PR DESCRIPTION
Add a sync.Pool for pooling of the iteratorRangeKeyState struct which holds an
iterator's range key iterator stack.

Additionally, remove the (keyspan.FragmentIterator).Clone method. This method
is no longer necessary now that visibility of range keys is enforced by the
keyspan.MergingIter's transform, which hides keys created more recently than
the cloned iterator's sequence number.