### PR TITLE
db: optimize SetBounds and SetOptions for unchanging bounds 

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1240,8 +1240,8 @@ func (i *batchIter) Close() error {
 	return i.err
 }
 
-func (i *batchIter) SetBounds(lower, upper []byte) {
-	i.iter.SetBounds(lower, upper)
+func (i *batchIter) SetBounds(lower, upper []byte, equal bool) {
+	i.iter.SetBounds(lower, upper, equal)
 }
 
 type flushableBatchEntry struct {
@@ -1679,7 +1679,7 @@ func (i *flushableBatchIter) Close() error {
 	return i.err
 }
 
-func (i *flushableBatchIter) SetBounds(lower, upper []byte) {
+func (i *flushableBatchIter) SetBounds(lower, upper []byte, equal bool) {
 	i.lower = lower
 	i.upper = upper
 }

--- a/data_test.go
+++ b/data_test.go
@@ -153,7 +153,7 @@ func runIterCmd(d *datadriven.TestData, iter *Iterator, closeIter bool) string {
 			valid = iter.Valid()
 		case "set-options":
 			const usageString = "set-options [lower=<lower>] [upper=<upper>] [key-types=point|range|both] [mask-suffix=<suffix>] [only-durable=<bool>] [table-filter=reuse|none] [point-filters=reuse|none]\n"
-			var opts IterOptions
+			opts := iter.opts
 			for _, part := range parts[1:] {
 				arg := strings.SplitN(part, "=", 2)
 				if len(arg) != 2 {
@@ -165,6 +165,7 @@ func runIterCmd(d *datadriven.TestData, iter *Iterator, closeIter bool) string {
 					case "reuse":
 						opts.PointKeyFilters = iter.opts.PointKeyFilters
 					case "none":
+						opts.PointKeyFilters = nil
 					default:
 						return fmt.Sprintf("set-options: unknown arg point-filter=%q:\n%s", arg[1], usageString)
 					}
@@ -190,6 +191,7 @@ func runIterCmd(d *datadriven.TestData, iter *Iterator, closeIter bool) string {
 					case "reuse":
 						opts.TableFilter = iter.opts.TableFilter
 					case "none":
+						opts.TableFilter = nil
 					default:
 						return fmt.Sprintf("set-options: unknown arg table-filter=%q:\n%s", arg[1], usageString)
 					}
@@ -364,7 +366,7 @@ func runInternalIterCmd(d *datadriven.TestData, iter internalIterator, opts ...i
 					return fmt.Sprintf("set-bounds: unknown arg: %s", arg)
 				}
 			}
-			iter.SetBounds(lower, upper)
+			iter.SetBounds(lower, upper, false /* equal */)
 			continue
 		case "stats":
 			ii, ok := iter.(internalIteratorWithStats)

--- a/db.go
+++ b/db.go
@@ -988,9 +988,8 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 		dbi.rangeKey.iter.Init(dbi.cmp, dbi.iter, dbi.rangeKey.rangeKeyIter, keyspan.Hooks{
 			SpanChanged: dbi.rangeKeySpanChanged,
 			SkipPoint:   dbi.rangeKeySkipPoint,
-		})
+		}, dbi.opts.LowerBound, dbi.opts.UpperBound)
 		dbi.iter = &dbi.rangeKey.iter
-		dbi.iter.SetBounds(dbi.opts.LowerBound, dbi.opts.UpperBound)
 		dbi.rangeKey.activeMaskSuffix = dbi.rangeKey.activeMaskSuffix[:0]
 	}
 	return dbi
@@ -1005,8 +1004,7 @@ func constructPointIter(
 	if dbi.pointIter != nil {
 		// The point iterator has already been constructed. This may be the case
 		// when an Iterator is being re-initialized during a call to SetOptions.
-		// Set the current bounds.
-		dbi.pointIter.SetBounds(dbi.opts.LowerBound, dbi.opts.UpperBound)
+		// SetOptions already set the appropriate bounds.
 		return dbi.pointIter
 	}
 

--- a/error_iter.go
+++ b/error_iter.go
@@ -62,9 +62,9 @@ func (c *errorIter) String() string {
 	return "error"
 }
 
-func (c *errorIter) SetBounds(lower, upper []byte) {}
-func (c *errorIter) Stats() InternalIteratorStats  { return InternalIteratorStats{} }
-func (c *errorIter) ResetStats()                   {}
+func (c *errorIter) SetBounds(lower, upper []byte, equal bool) {}
+func (c *errorIter) Stats() InternalIteratorStats              { return InternalIteratorStats{} }
+func (c *errorIter) ResetStats()                               {}
 
 type errorKeyspanIter struct {
 	err error

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -145,9 +145,9 @@ func NewExternalIter(
 		dbi.rangeKey.iter.Init(dbi.cmp, &buf.merging, dbi.rangeKey.rangeKeyIter, keyspan.Hooks{
 			SpanChanged: dbi.rangeKeySpanChanged,
 			SkipPoint:   dbi.rangeKeySkipPoint,
-		})
+		}, dbi.opts.LowerBound, dbi.opts.UpperBound)
 		dbi.iter = &dbi.rangeKey.iter
-		dbi.iter.SetBounds(dbi.opts.LowerBound, dbi.opts.UpperBound)
+		dbi.iter.SetBounds(dbi.opts.LowerBound, dbi.opts.UpperBound, false /* equal */)
 	}
 
 	// Close all the opened sstable.Readers when the Iterator is closed.

--- a/get_iter.go
+++ b/get_iter.go
@@ -206,6 +206,6 @@ func (g *getIter) Close() error {
 	return g.err
 }
 
-func (g *getIter) SetBounds(lower, upper []byte) {
+func (g *getIter) SetBounds(lower, upper []byte, equal bool) {
 	panic("pebble: SetBounds unimplemented")
 }

--- a/internal/arenaskl/iterator.go
+++ b/internal/arenaskl/iterator.go
@@ -224,10 +224,10 @@ func (it *Iterator) Tail() bool {
 	return it.nd == it.list.tail
 }
 
-// SetBounds sets the lower and upper bounds for the iterator. Note that the
-// result of Next and Prev will be undefined until the iterator has been
+// SetBounds sets the lower and upper bounds for the iterator. If equal is false,
+// the result of Next and Prev will be undefined until the iterator has been
 // repositioned with SeekGE, SeekPrefixGE, SeekLT, First, or Last.
-func (it *Iterator) SetBounds(lower, upper []byte) {
+func (it *Iterator) SetBounds(lower, upper []byte, equal bool) {
 	it.lower = lower
 	it.upper = upper
 }

--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -206,10 +206,14 @@ type InternalIterator interface {
 	// called after the iterator has been closed.
 	Close() error
 
-	// SetBounds sets the lower and upper bounds for the iterator. Note that the
-	// result of Next and Prev will be undefined until the iterator has been
-	// repositioned with SeekGE, SeekPrefixGE, SeekLT, First, or Last.
-	SetBounds(lower, upper []byte)
+	// SetBounds sets the lower and upper bounds for the iterator. If equal is
+	// true, the provided bounds are logically equal to the previous bounds.
+	//
+	// The iterator replaces its internal bounds with the new bounds. If equal
+	// is false, the result of Next and Prev will be undefined until the
+	// iterator has been repositioned with SeekGE, SeekPrefixGE, SeekLT, First,
+	// or Last.
+	SetBounds(lower, upper []byte, equal bool)
 
 	fmt.Stringer
 }

--- a/internal/batchskl/iterator.go
+++ b/internal/batchskl/iterator.go
@@ -181,7 +181,7 @@ func (it *Iterator) String() string {
 // SetBounds sets the lower and upper bounds for the iterator. Note that the
 // result of Next and Prev will be undefined until the iterator has been
 // repositioned with SeekGE, SeekLT, First, or Last.
-func (it *Iterator) SetBounds(lower, upper []byte) {
+func (it *Iterator) SetBounds(lower, upper []byte, equal bool) {
 	it.lower = lower
 	it.upper = upper
 }

--- a/internal/keyspan/interleaving_iter_test.go
+++ b/internal/keyspan/interleaving_iter_test.go
@@ -93,7 +93,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 			iter.Init(cmp, base.WrapIterWithStats(&pointIter), &keyspanIter, Hooks{
 				SpanChanged: hooks.SpanChanged,
 				SkipPoint:   hooks.SkipPoint,
-			})
+			}, nil, nil)
 			return "OK"
 		case "define-pointkeys":
 			var points []base.InternalKey
@@ -106,12 +106,12 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 			iter.Init(cmp, base.WrapIterWithStats(&pointIter), &keyspanIter, Hooks{
 				SpanChanged: hooks.SpanChanged,
 				SkipPoint:   hooks.SkipPoint,
-			})
+			}, nil, nil)
 			return "OK"
 		case "iter":
 			buf.Reset()
 			// Clear any previous bounds.
-			iter.SetBounds(nil, nil)
+			iter.SetBounds(nil, nil, false /* equal */)
 			lines := strings.Split(strings.TrimSpace(td.Input), "\n")
 			for _, line := range lines {
 				bufLen := buf.Len()
@@ -146,7 +146,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 					if bounds[1] == "." {
 						u = nil
 					}
-					iter.SetBounds(l, u)
+					iter.SetBounds(l, u, false /* equal */)
 				default:
 					return fmt.Sprintf("unrecognized iter command %q", iterCmd)
 				}
@@ -252,6 +252,6 @@ func (i *pointIterator) Prev() (*base.InternalKey, []byte) {
 func (i *pointIterator) Close() error   { return nil }
 func (i *pointIterator) Error() error   { return nil }
 func (i *pointIterator) String() string { return "test-point-iterator" }
-func (i *pointIterator) SetBounds(lower, upper []byte) {
+func (i *pointIterator) SetBounds(lower, upper []byte, equal bool) {
 	i.lower, i.upper = lower, upper
 }

--- a/internal/keyspan/internal_iter_shim.go
+++ b/internal/keyspan/internal_iter_shim.go
@@ -101,7 +101,7 @@ func (i *InternalIteratorShim) Close() error {
 }
 
 // SetBounds implements (base.InternalIterator).SetBounds.
-func (i *InternalIteratorShim) SetBounds(lower, upper []byte) {
+func (i *InternalIteratorShim) SetBounds(lower, upper []byte, equal bool) {
 }
 
 // String implements fmt.Stringer.

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -210,7 +210,7 @@ func (f *fakeIter) Close() error {
 	return f.closeErr
 }
 
-func (f *fakeIter) SetBounds(lower, upper []byte) {
+func (f *fakeIter) SetBounds(lower, upper []byte, equal bool) {
 	f.lower = lower
 	f.upper = upper
 }
@@ -305,8 +305,8 @@ func (i *invalidatingIter) Close() error {
 	return i.iter.Close()
 }
 
-func (i *invalidatingIter) SetBounds(lower, upper []byte) {
-	i.iter.SetBounds(lower, upper)
+func (i *invalidatingIter) SetBounds(lower, upper []byte, equal bool) {
+	i.iter.SetBounds(lower, upper, equal)
 }
 
 func (i *invalidatingIter) String() string {

--- a/level_iter.go
+++ b/level_iter.go
@@ -744,7 +744,7 @@ func (l *levelIter) Close() error {
 	return l.err
 }
 
-func (l *levelIter) SetBounds(lower, upper []byte) {
+func (l *levelIter) SetBounds(lower, upper []byte, equal bool) {
 	l.lower = lower
 	l.upper = upper
 
@@ -760,8 +760,7 @@ func (l *levelIter) SetBounds(lower, upper []byte) {
 		_ = l.Close()
 		return
 	}
-
-	l.iter.SetBounds(l.tableOpts.LowerBound, l.tableOpts.UpperBound)
+	l.iter.SetBounds(l.tableOpts.LowerBound, l.tableOpts.UpperBound, equal)
 }
 
 func (l *levelIter) String() string {

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -562,7 +562,7 @@ func BenchmarkLevelIterSeqSeekGEWithBounds(b *testing.B) {
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {
 								pos := i % (keyCount - 1)
-								l.SetBounds(keys[pos], keys[pos+1])
+								l.SetBounds(keys[pos], keys[pos+1], false /* equal */)
 								// SeekGE will return keys[pos].
 								k, _ := l.SeekGE(keys[pos], false /* trySeekUsingNext */)
 								// Next() will get called once and return nil.

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -1086,14 +1086,16 @@ func (m *mergingIter) Close() error {
 	return m.err
 }
 
-func (m *mergingIter) SetBounds(lower, upper []byte) {
-	m.prefix = nil
+func (m *mergingIter) SetBounds(lower, upper []byte, equal bool) {
 	m.lower = lower
 	m.upper = upper
 	for i := range m.levels {
-		m.levels[i].iter.SetBounds(lower, upper)
+		m.levels[i].iter.SetBounds(lower, upper, equal)
 	}
-	m.heap.clear()
+	if !equal {
+		m.prefix = nil
+		m.heap.clear()
+	}
 }
 
 func (m *mergingIter) DebugString() string {

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -618,7 +618,7 @@ func BenchmarkMergingIterSeqSeekGEWithBounds(b *testing.B) {
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					pos := i % (keyCount - 1)
-					m.SetBounds(keys[pos], keys[pos+1])
+					m.SetBounds(keys[pos], keys[pos+1], false /* equal */)
 					// SeekGE will return keys[pos].
 					k, _ := m.SeekGE(keys[pos], false /* trySeekUsingNext */)
 					for k != nil {

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -950,7 +950,7 @@ func (i *blockIter) Close() error {
 	return nil
 }
 
-func (i *blockIter) SetBounds(lower, upper []byte) {
+func (i *blockIter) SetBounds(lower, upper []byte, equal bool) {
 	// This should never be called as bounds are handled by sstable.Iterator.
 	panic("pebble: SetBounds unimplemented")
 }

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -326,7 +326,7 @@ func runIterCmd(td *datadriven.TestData, r *Reader) string {
 					return fmt.Sprintf("set-bounds: unknown arg: %s", arg)
 				}
 			}
-			iter.SetBounds(lower, upper)
+			iter.SetBounds(lower, upper, false /* equal */)
 		case "stats":
 			fmt.Fprintf(&b, "%+v\n", iter.Stats())
 			continue

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -1052,7 +1052,21 @@ func disableBoundsOpt(bound []byte, ptr uintptr) bool {
 
 // SetBounds implements internalIterator.SetBounds, as documented in the pebble
 // package.
-func (i *singleLevelIterator) SetBounds(lower, upper []byte) {
+func (i *singleLevelIterator) SetBounds(lower, upper []byte, equal bool) {
+	if equal {
+		i.lower = lower
+		i.upper = upper
+		// If block{Lower,Upper} are non-nil, they're set to lower/upper
+		// respectively.
+		if i.blockLower != nil {
+			i.blockLower = lower
+		}
+		if i.blockUpper != nil {
+			i.blockUpper = upper
+		}
+		return
+	}
+
 	i.boundsCmp = 0
 	if i.positionedUsingLatestBounds {
 		if i.upper != nil && lower != nil && i.cmp(i.upper, lower) <= 0 {

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -149,8 +149,8 @@ func (i *iterAdapter) Valid() bool {
 	return i.key != nil
 }
 
-func (i *iterAdapter) SetBounds(lower, upper []byte) {
-	i.Iterator.SetBounds(lower, upper)
+func (i *iterAdapter) SetBounds(lower, upper []byte, equal bool) {
+	i.Iterator.SetBounds(lower, upper, equal)
 	i.key = nil
 }
 

--- a/testdata/iterator
+++ b/testdata/iterator
@@ -1175,7 +1175,7 @@ stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, 
 iter seq=2
 set-bounds lower=b
 seek-ge a
-set-bounds lower=b
+set-bounds lower=b upper=z
 seek-ge a
 ----
 .

--- a/testdata/iterator_seek_opt
+++ b/testdata/iterator_seek_opt
@@ -177,9 +177,10 @@ stats: (interface (dir, seek, step): (fwd, 16, 1), (rev, 0, 1)), (internal (dir,
 SeekGEs with trySeekUsingNext: 6
 SeekPrefixGEs with trySeekUsingNext: 4
 
-# Shifting bounds, with non-overlapping and monotonic bounds. We don't call
-# trySeekUsingNext=true at all here as the set-bounds sits in between every two
-# seeks, but the results are still correct and within bounds.
+# Shifting bounds, with non-overlapping and monotonic bounds. A set-bounds sits
+# between every two seeks. We don't call trySeekUsingNext=true when the bounds
+# are set to unequal bounds, but the results are still correct and within
+# bounds. We do call trySeekUsingNext=true when the set bounds are identical.
 
 iter
 set-bounds lower=a upper=c
@@ -201,14 +202,26 @@ stats: (interface (dir, seek, step): (fwd, 18, 1), (rev, 0, 1)), (internal (dir,
 SeekGEs with trySeekUsingNext: 6
 SeekPrefixGEs with trySeekUsingNext: 4
 
+# NB: Equal bounds.
+
+iter
+set-bounds lower=c upper=e
+seek-ge d
+----
+.
+d:2
+stats: (interface (dir, seek, step): (fwd, 19, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 18, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 8
+SeekPrefixGEs with trySeekUsingNext: 4
+
 iter
 set-bounds lower=a upper=c
 seek-prefix-ge b
 ----
 .
 b:1
-stats: (interface (dir, seek, step): (fwd, 19, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 18, 1), (rev, 0, 3))
-SeekGEs with trySeekUsingNext: 6
+stats: (interface (dir, seek, step): (fwd, 20, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 19, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 8
 SeekPrefixGEs with trySeekUsingNext: 4
 
 iter
@@ -217,6 +230,88 @@ seek-prefix-ge c
 ----
 .
 c:1
-stats: (interface (dir, seek, step): (fwd, 20, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 19, 1), (rev, 0, 3))
-SeekGEs with trySeekUsingNext: 6
+stats: (interface (dir, seek, step): (fwd, 21, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 20, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 8
 SeekPrefixGEs with trySeekUsingNext: 4
+
+# NB: Equal bounds.
+
+iter
+set-bounds lower=c upper=e
+seek-prefix-ge d
+----
+.
+d:2
+stats: (interface (dir, seek, step): (fwd, 22, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 21, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 8
+SeekPrefixGEs with trySeekUsingNext: 6
+
+# Shifting bounds, with non-overlapping and monotonic bounds, but using
+# SetOptions. A set-options sits between every two seeks. We don't call
+# trySeekUsingNext=true when the bounds are set to unequal bounds, but the
+# results are still correct and within bounds. We do call trySeekUsingNext=true
+# when the set bounds are identical.
+
+iter
+set-options lower=a upper=c
+seek-ge b
+----
+.
+b:1
+stats: (interface (dir, seek, step): (fwd, 23, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 22, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 8
+SeekPrefixGEs with trySeekUsingNext: 6
+
+iter
+set-options lower=c upper=e
+seek-ge c
+----
+.
+c:1
+stats: (interface (dir, seek, step): (fwd, 24, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 23, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 8
+SeekPrefixGEs with trySeekUsingNext: 6
+
+# NB: Equal bounds.
+
+iter
+set-options lower=c upper=e
+seek-ge d
+----
+.
+d:2
+stats: (interface (dir, seek, step): (fwd, 25, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 24, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 10
+SeekPrefixGEs with trySeekUsingNext: 6
+
+iter
+set-options lower=a upper=c
+seek-prefix-ge b
+----
+.
+b:1
+stats: (interface (dir, seek, step): (fwd, 26, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 25, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 10
+SeekPrefixGEs with trySeekUsingNext: 6
+
+iter
+set-options lower=c upper=e
+seek-prefix-ge c
+----
+.
+c:1
+stats: (interface (dir, seek, step): (fwd, 27, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 26, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 10
+SeekPrefixGEs with trySeekUsingNext: 6
+
+# NB: Equal bounds.
+
+iter
+set-options lower=c upper=e
+seek-prefix-ge d
+----
+.
+d:2
+stats: (interface (dir, seek, step): (fwd, 28, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 27, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 10
+SeekPrefixGEs with trySeekUsingNext: 8


### PR DESCRIPTION
Restore the SetBounds optimization that avoids invalidating the iterator during
a call to SetBounds if the bounds are unchanged. This optimization was removed
in https://github.com/cockroachdb/pebble/pull/1073 because the previous version of this optimization improperly retained
the old bounds which might be mutated by the user. In this reintroduction of
the optimization, a call to SetBounds with unchanged bounds still propagates
the new bounds down the entire iterator tree. However, if the bounds are equal,
the iterator state is not invalidated, allowing subsequent seeks to take
advantage of optimizations like try-seek-using-next.

Additionally, apply the same optimization to SetOptions.