### PR TITLE
internal/keyspan: fix Iter bounds checking

### DIFF
--- a/internal/keyspan/iter.go
+++ b/internal/keyspan/iter.go
@@ -174,19 +174,19 @@ func (i *Iter) SeekLT(key []byte) Span {
 
 // First implements FragmentIterator.First.
 func (i *Iter) First() Span {
+	i.index = i.lower
 	if i.upper <= i.lower {
 		return Span{}
 	}
-	i.index = i.lower
 	return i.spans[i.index]
 }
 
 // Last implements FragmentIterator.Last.
 func (i *Iter) Last() Span {
+	i.index = i.upper - 1
 	if i.upper <= i.lower {
 		return Span{}
 	}
-	i.index = i.upper - 1
 	return i.spans[i.index]
 }
 

--- a/internal/keyspan/testdata/iter
+++ b/internal/keyspan/testdata/iter
@@ -116,3 +116,35 @@ next
 b-c:{(#2,SET) (#1,SET)}
 c-d:{(#2,SET) (#1,SET)}
 .
+
+# Test behavior around bounds. Previously, there existed a bug where bounds
+# the iterator's index was not set during absolute positioning calls that return
+# zero elements. This allowed releative positioning methods to surface
+# out-of-bounds values because only the bound in the direction of iteration is
+# checked.
+
+iter
+last
+set-bounds a a
+first
+prev
+prev
+----
+c-d:{(#2,SET) (#1,SET)}
+.
+.
+.
+.
+
+iter
+first
+set-bounds d d
+last
+next
+next
+----
+a-b:{(#2,SET) (#1,SET)}
+.
+.
+.
+.


### PR DESCRIPTION
This commit fixes a bug in the keyspan.Iter bounds checking. Previously, if the
configured bounds excluded all spans, an Iter could surface an out-of-bounds
Span. If the caller called First/Last, the Iter would correctly return an
invalid span. If the caller then moved in the opposite direction calling
Prev/Next, the result was dependent on the iterator's state before the bounds
were set.