### PR TITLE
vfs: capture operation type affected by disk slowness

### DIFF
--- a/event.go
+++ b/event.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/pebble/internal/humanize"
 	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/redact"
 )
 
@@ -118,6 +119,8 @@ func (i levelInfos) SafeFormat(w redact.SafePrinter, _ rune) {
 type DiskSlowInfo struct {
 	// Path of file being written to.
 	Path string
+	// Operation being performed on the file.
+	OpType vfs.OpType
 	// Duration that has elapsed since this disk operation started.
 	Duration time.Duration
 }
@@ -128,8 +131,8 @@ func (i DiskSlowInfo) String() string {
 
 // SafeFormat implements redact.SafeFormatter.
 func (i DiskSlowInfo) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Printf("disk slowness detected: write to file %s has been ongoing for %0.1fs",
-		i.Path, redact.Safe(i.Duration.Seconds()))
+	w.Printf("disk slowness detected: %s on file %s has been ongoing for %0.1fs",
+		redact.Safe(i.OpType.String()), i.Path, redact.Safe(i.Duration.Seconds()))
 }
 
 // FlushInfo contains the info for a flush event.

--- a/options.go
+++ b/options.go
@@ -806,9 +806,10 @@ func (o *Options) EnsureDefaults() *Options {
 
 	if o.FS == nil {
 		o.FS = vfs.WithDiskHealthChecks(vfs.Default, 5*time.Second,
-			func(name string, duration time.Duration) {
+			func(name string, op vfs.OpType, duration time.Duration) {
 				o.EventListener.DiskSlow(DiskSlowInfo{
 					Path:     name,
+					OpType:   op,
 					Duration: duration,
 				})
 			})

--- a/vfs/disk_heath_test.go
+++ b/vfs/disk_heath_test.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 type mockFile struct {
@@ -114,23 +116,74 @@ func (m mockFS) GetDiskUsage(path string) (DiskUsage, error) {
 var _ FS = &mockFS{}
 
 func TestDiskHealthChecking(t *testing.T) {
-	diskSlow := make(chan time.Duration, 100)
-	slowThreshold := 1 * time.Second
-	mockFS := &mockFS{syncDuration: 3 * time.Second}
-	fs := WithDiskHealthChecks(mockFS, slowThreshold, func(s string, duration time.Duration) {
-		diskSlow <- duration
-	})
-	dhFile, _ := fs.Create("test")
-	defer dhFile.Close()
-
-	dhFile.Sync()
-
-	select {
-	case d := <-diskSlow:
-		if d.Seconds() < slowThreshold.Seconds() {
-			t.Fatalf("expected %0.1f to be greater than threshold %0.1f", d.Seconds(), slowThreshold.Seconds())
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("disk stall detector did not detect slow disk operation")
+	const (
+		slowThreshold = 1 * time.Second
+		syncDuration  = 3 * time.Second
+	)
+	testCases := []struct {
+		op OpType
+		fn func(f File)
+	}{
+		{
+			OpTypeWrite,
+			func(f File) { f.Write([]byte("uh oh")) },
+		},
+		{
+			OpTypeSync,
+			func(f File) { f.Sync() },
+		},
 	}
+	for _, tc := range testCases {
+		t.Run(tc.op.String(), func(t *testing.T) {
+			type info struct {
+				op       OpType
+				duration time.Duration
+			}
+			diskSlow := make(chan info, 1)
+			mockFS := &mockFS{syncDuration: syncDuration}
+			fs := WithDiskHealthChecks(mockFS, slowThreshold, func(s string, op OpType, duration time.Duration) {
+				diskSlow <- info{
+					op:       op,
+					duration: duration,
+				}
+			})
+			dhFile, _ := fs.Create("test")
+			defer dhFile.Close()
+
+			tc.fn(dhFile)
+			select {
+			case i := <-diskSlow:
+				d := i.duration
+				if d.Seconds() < slowThreshold.Seconds() {
+					t.Fatalf("expected %0.1f to be greater than threshold %0.1f", d.Seconds(), slowThreshold.Seconds())
+				}
+				require.Equal(t, tc.op, i.op)
+			case <-time.After(5 * time.Second):
+				t.Fatal("disk stall detector did not detect slow disk operation")
+			}
+		})
+	}
+}
+
+func TestDiskHealthChecking_Underflow(t *testing.T) {
+	f := &mockFile{}
+	hcFile := newDiskHealthCheckingFile(f, 1*time.Second, func(opType OpType, duration time.Duration) {
+		// We expect to panic before sending the event.
+		t.Fatalf("unexpected slow disk event")
+	})
+	defer hcFile.Close()
+
+	// Set the file creation to the UNIX epoch, which is earlier than the max
+	// offset of the health check.
+	tEpoch := time.Unix(0, 0)
+	hcFile.createTime = time.Unix(0, 0)
+
+	// Assert that the time since the epoch (in nanoseconds) is indeed greater
+	// than the max offset.
+	require.True(t, time.Since(tEpoch).Nanoseconds() > 1<<nOffsetBits-1)
+
+	// Attempting to start the clock for a new operation on the file should
+	// trigger a panic, as the calculated offset from the file creation time would
+	// result in integer overflow.
+	require.Panics(t, func() { _, _ = hcFile.Write([]byte("uh oh")) })
 }

--- a/vfs/fd_test.go
+++ b/vfs/fd_test.go
@@ -22,7 +22,7 @@ func TestFileWrappersHaveFd(t *testing.T) {
 	defer os.Remove(filename)
 
 	// File wrapper case 1: Check if diskHealthCheckingFile has Fd().
-	fs2 := WithDiskHealthChecks(Default, 10*time.Second, func(s string, duration time.Duration) {})
+	fs2 := WithDiskHealthChecks(Default, 10*time.Second, func(s string, op OpType, duration time.Duration) {})
 	f2, err := fs2.Open(filename)
 	require.NoError(t, err)
 	if _, ok := f2.(fdGetter); !ok {

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -313,3 +313,13 @@ func TestVFSRootDirName(t *testing.T) {
 		require.Equal(t, exp, fi.Name())
 	}
 }
+
+// TestOpType is intended to catch operations that have been added without an
+// associated string, which could result in a runtime panic.
+func TestOpType(t *testing.T) {
+	for i := 0; i <= int(opTypeMax); i++ {
+		require.NotPanics(t, func() {
+			_ = OpType(i).String()
+		})
+	}
+}


### PR DESCRIPTION
Currently, if a Pebble DB is backed by `vfs.FS` that is wrapped with a
`vfs.diskHealthCheckingFS`, the DB can be made aware of operations that
are taking longer than some threshold. Typically these "disk slowness"
events are capture to the Pebble event log.

The current implementation does not make any distinction between the
operation type (write, sync, etc.) that was observed as slow.

Capture the type of operation being performed when emitting a disk
slowness event into the event log.