### PR TITLE
db: extend documentation on ingested file overlap; improve test cases

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -441,18 +441,54 @@ func ingestTargetLevel(
 	compactions map[*compaction]struct{},
 	meta *fileMetadata,
 ) (int, error) {
-	// Find the lowest level which does not have any files which overlap meta.
-	// We search from L0 to L6 looking for whether there are any files in the level
+	// Find the lowest level which does not have any files which overlap meta. We
+	// search from L0 to L6 looking for whether there are any files in the level
 	// which overlap meta. We want the "lowest" level (where lower means
 	// increasing level number) in order to reduce write amplification.
 	//
-	// There are 2 kinds of overlap we need to check for: file boundary overlap and data overlap.
-	// Data overlap implies file boundary overlap.
-	// We can always ingest to L0.
-	// Now, to place meta at level i where i > 0:
-	// - there must not be any data overlap with levels <= i,
-	//   since that will violate the sequence number invariant.
-	// - no file boundary overlap with level i.
+	// There are 2 kinds of overlap we need to check for: file boundary overlap
+	// and data overlap. Data overlap implies file boundary overlap. Note that it
+	// is always possible to ingest into L0.
+	//
+	// To place meta at level i where i > 0:
+	// - there must not be any data overlap with levels <= i, since that will
+	//   violate the sequence number invariant.
+	// - no file boundary overlap with level i, since that will violate the
+	//   invariant that files do not overlap in levels i > 0.
+	//
+	// The file boundary overlap check is simpler to conceptualize. Consider the
+	// following example, in which the ingested file lies completely before or
+	// after the file being considered.
+	//
+	//   |--|           |--|  ingested file: [a,b] or [f,g]
+	//         |-----|        existing file: [c,e]
+	//  _____________________
+	//   a  b  c  d  e  f  g
+	//
+	// In both cases the ingested file can move to considering the next level.
+	//
+	// File boundary overlap does not necessarily imply data overlap. The check
+	// for data overlap is a little more nuanced. Consider the following examples:
+	//
+	//  1. No data overlap:
+	//
+	//          |-|   |--|    ingested file: [cc-d] or [ee-ff]
+	//  |*--*--*----*------*| existing file: [a-g], points: [a, b, c, dd, g]
+	//  _____________________
+	//   a  b  c  d  e  f  g
+	//
+	// In this case the ingested files can "fall through" this level. The checks
+	// continue at the next level.
+	//
+	//  2. Data overlap:
+	//
+	//            |--|        ingested file: [d-e]
+	//  |*--*--*----*------*| existing file: [a-g], points: [a, b, c, dd, g]
+	//  _____________________
+	//   a  b  c  d  e  f  g
+	//
+	// In this case the file cannot be ingested into this level as the point 'dd'
+	// is in the way.
 
 	targetLevel := 0
 
@@ -484,7 +520,8 @@ func ingestTargetLevel(
 		levelIter := newLevelIter(iterOps, cmp, nil /* split */, newIters,
 			v.Levels[level].Iter(), manifest.Level(level), nil)
 		var rangeDelIter keyspan.FragmentIterator
-		// Pass in a non-nil pointer to rangeDelIter so that levelIter.findFileGE sets it up for the target file.
+		// Pass in a non-nil pointer to rangeDelIter so that levelIter.findFileGE
+		// sets it up for the target file.
 		levelIter.initRangeDel(&rangeDelIter)
 		overlap := overlapWithIterator(levelIter, &rangeDelIter, meta, cmp)
 		levelIter.Close() // Closes range del iter as well.
@@ -501,10 +538,10 @@ func ingestTargetLevel(
 
 		// Check boundary overlap with any ongoing compactions.
 		//
-		// We cannot check for data overlap with the new SSTs compaction will produce
-		// since compaction hasn't been done yet.
-		// However, there's no need to check since all keys in them will either be from
-		// c.startLevel or c.outputLevel, both levels having their data overlap already tested
+		// We cannot check for data overlap with the new SSTs compaction will
+		// produce since compaction hasn't been done yet. However, there's no need
+		// to check since all keys in them will either be from c.startLevel or
+		// c.outputLevel, both levels having their data overlap already tested
 		// negative (else we'd have returned earlier).
 		overlaps := false
 		for c := range compactions {

--- a/testdata/ingest_target_level
+++ b/testdata/ingest_target_level
@@ -15,17 +15,26 @@ L5
 5:
   000004:[b#1,SET-c#2,SET]
 
+# Overlapping cases.
 target
 a-b
 b-c
 c-d
-a-aa
-d-e
-bb-bb
 ----
 4
 4
 4
+
+# Non-overlapping cases:
+# - Ingested file lies entirely before the existing file.
+# - Ingested file lies entirely after the existing file.
+# - Ingested file has no data overlap (falls through the middle of the existing
+#   file).
+target
+a-aa
+d-e
+bb-bb
+----
 6
 6
 6
@@ -52,16 +61,25 @@ L3
 3:
   000007:[g#1,SET-h#2,SET]
 
+# Files overlap with L0. Files ingested into L0.
 target
 b-c
 d-e
-g-m
-i-m
-c-c
 ----
 0
 0
+
+# Files overlap with L3. Files ingested into L2.
+target
+g-m
+----
 2
+
+# No overlap. Files ingested into L6.
+target
+i-m
+c-c
+----
 6
 6
 
@@ -82,6 +100,7 @@ L6
   000006:[a#2,SET-a#2,SET]
   000007:[c#1,SET-c#1,SET]
 
+# The ingested file slips through the gaps in both L5 and L6.
 target
 b-b
 ----
@@ -105,6 +124,8 @@ L6
   000006:[a#2,SET-a#2,SET]
   000007:[c#1,SET-c#1,SET]
 
+# The ingested file cannot reach L6 as there is a compaction outputting a file
+# into the range [a,c].
 target
 b-b
 ----
@@ -123,17 +144,62 @@ L2
 2:
   000005:[a#1,RANGEDEL-g#72057594037927935,RANGEDEL]
 
+# Overlapping cases:
+# - The ingested file overlaps with with [c,c].
+# - The rangedel over [d,g) keeps the ingested file in L0.
+# - Ditto.
 target
-cc-cc
 c-c
-g-g
 d-d
 e-e
+----
+0
+0
+0
+
+# Non-overlapping cases:
+# - The ingested file [cc,cc] slips through L0, but is kept at L1 by the
+#   rangedel in L2.
+# - The ingested file is to completely to right of all files.
+# - The ingested file is to the left of all files in L0, but is kept at L1 by
+#   the rangedel in L2.
+target
+cc-cc
+g-g
 a-a
 ----
 1
-0
 6
-0
-0
 1
+
+# A more complicated example demonstrating data overlap.
+#            |--|        ingested file: [d-e] - data overlap
+#          |-|           ingested file: [cc-d] - no data overlap
+#                |--|    ingested file: [ee-ff] - no data overlap
+#  |*--*--*----*------*| existing file: [a-g], points: [a, b, c, dd, g]
+#  _____________________
+#   a  b  c  d  e  f  g
+define
+L1
+  a.SET.0:a
+  b.SET.0:b
+  c.SET.0:c
+  dd.SET.0:dd
+  g.SET.0:g
+----
+1:
+  000004:[a#0,SET-g#0,SET]
+
+# Data overlap.
+target
+d-e
+----
+0
+
+# No data overlap.
+target
+cc-d
+ee-ff
+----
+6
+6


### PR DESCRIPTION
There is some nuance in determining when an ingested file overlaps with
one or more files in a level, as file boundary overlap _and_ data
overlap is considered.

Pad out the existing documentation, providing examples to demonstrate
how boundary and data overlap are used to pick a level for ingestion.

Rework the existing data-drive test cases, splitting up and documenting
the various scenarios.

Motivated by cockroachdb/cockroach#80589.