### PR TITLE
db: copy user-provided bounds and optimize unchanged bounds

### DIFF
--- a/db.go
+++ b/db.go
@@ -861,6 +861,7 @@ func (d *DB) commitWrite(b *Batch, syncWG *sync.WaitGroup, syncErr *error) (*mem
 type iterAlloc struct {
 	dbi                 Iterator
 	keyBuf              []byte
+	boundsBuf           [2][]byte
 	prefixOrFullSeekKey []byte
 	merging             mergingIter
 	mlevels             [3 + numLevels]mergingIterLevel
@@ -927,6 +928,7 @@ func (d *DB) newIterInternal(batch *Batch, s *Snapshot, o *IterOptions) *Iterato
 		readState:           readState,
 		keyBuf:              buf.keyBuf,
 		prefixOrFullSeekKey: buf.prefixOrFullSeekKey,
+		boundsBuf:           buf.boundsBuf,
 		batch:               batch,
 		newIters:            d.newIters,
 		seqNum:              seqNum,
@@ -934,6 +936,7 @@ func (d *DB) newIterInternal(batch *Batch, s *Snapshot, o *IterOptions) *Iterato
 	}
 	if o != nil {
 		dbi.opts = *o
+		dbi.saveBounds(o.LowerBound, o.UpperBound)
 	}
 	dbi.opts.logger = d.opts.Logger
 	return finishInitializingIter(buf)
@@ -985,10 +988,8 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 		dbi.rangeKey.iter.Init(dbi.cmp, dbi.iter, dbi.rangeKey.rangeKeyIter, keyspan.Hooks{
 			SpanChanged: dbi.rangeKeySpanChanged,
 			SkipPoint:   dbi.rangeKeySkipPoint,
-		})
+		}, dbi.opts.LowerBound, dbi.opts.UpperBound)
 		dbi.iter = &dbi.rangeKey.iter
-		dbi.iter.SetBounds(dbi.opts.LowerBound, dbi.opts.UpperBound)
-		dbi.rangeKey.activeMaskSuffix = dbi.rangeKey.activeMaskSuffix[:0]
 	}
 	return dbi
 }
@@ -1000,10 +1001,6 @@ func constructPointIter(
 		return emptyIter
 	}
 	if dbi.pointIter != nil {
-		// The point iterator has already been constructed. This may be the case
-		// when an Iterator is being re-initialized during a call to SetOptions.
-		// Set the current bounds.
-		dbi.pointIter.SetBounds(dbi.opts.LowerBound, dbi.opts.UpperBound)
 		return dbi.pointIter
 	}
 

--- a/internal/keyspan/interleaving_iter_test.go
+++ b/internal/keyspan/interleaving_iter_test.go
@@ -93,7 +93,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 			iter.Init(cmp, base.WrapIterWithStats(&pointIter), &keyspanIter, Hooks{
 				SpanChanged: hooks.SpanChanged,
 				SkipPoint:   hooks.SkipPoint,
-			})
+			}, nil, nil)
 			return "OK"
 		case "define-pointkeys":
 			var points []base.InternalKey
@@ -106,7 +106,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 			iter.Init(cmp, base.WrapIterWithStats(&pointIter), &keyspanIter, Hooks{
 				SpanChanged: hooks.SpanChanged,
 				SkipPoint:   hooks.SkipPoint,
-			})
+			}, nil, nil)
 			return "OK"
 		case "iter":
 			buf.Reset()

--- a/iterator.go
+++ b/iterator.go
@@ -168,6 +168,12 @@ type Iterator struct {
 	value       []byte
 	valueBuf    []byte
 	valueCloser io.Closer
+	// boundsBuf holds two buffers used to store the lower and upper bounds.
+	// Whenever the Iterator's bounds change, the new bounds are copied into
+	// boundsBuf[boundsBufIdx]. The two bounds share a slice to reduce
+	// allocations. opts.LowerBound and opts.UpperBound point into this slice.
+	boundsBuf    [2][]byte
+	boundsBufIdx int
 	// iterKey, iterValue reflect the latest position of iter, except when
 	// SetBounds is called. In that case, these are explicitly set to nil.
 	iterKey             *InternalKey
@@ -195,6 +201,12 @@ type Iterator struct {
 	// iterValidityState==IterAtLimit <=>
 	//  pos==iterPosCurForwardPaused || pos==iterPosCurReversePaused
 	iterValidityState IterValidityState
+	// Set to true by SetBounds, SetOptions. Causes the Iterator to appear
+	// exhausted externally, while preserving the correct iterValidityState for
+	// the iterator's internal state. Preserving the correct internal validity
+	// is used for SeekPrefixGE(..., trySeekUsingNext), and SeekGE/SeekLT
+	// optimizations after "no-op" calls to SetBounds and SetOptions.
+	requiresReposition bool
 	// The position of iter. When this is iterPos{Prev,Next} the iter has been
 	// moved past the current key-value, which can only happen if
 	// iterValidityState=IterValid, i.e., there is something to return to the
@@ -925,6 +937,7 @@ func (i *Iterator) SeekGEWithLimit(key []byte, limit []byte) IterValidityState {
 	// the SeekGE following this should not make any assumption about iterator
 	// position.
 	i.lastPositioningOp = unknownLastPositionOp
+	i.requiresReposition = false
 	i.err = nil // clear cached iteration error
 	i.hasPrefix = false
 	i.stats.ForwardSeekCount[InterfaceCall]++
@@ -1041,6 +1054,7 @@ func (i *Iterator) SeekPrefixGE(key []byte) bool {
 	// the SeekPrefixGE following this should not make any assumption about
 	// iterator position.
 	i.lastPositioningOp = unknownLastPositionOp
+	i.requiresReposition = false
 	i.err = nil // clear cached iteration error
 	i.stats.ForwardSeekCount[InterfaceCall]++
 
@@ -1148,6 +1162,7 @@ func (i *Iterator) SeekLTWithLimit(key []byte, limit []byte) IterValidityState {
 	// the SeekLT following this should not make any assumption about iterator
 	// position.
 	i.lastPositioningOp = unknownLastPositionOp
+	i.requiresReposition = false
 	i.err = nil // clear cached iteration error
 	i.hasPrefix = false
 	i.stats.ReverseSeekCount[InterfaceCall]++
@@ -1205,6 +1220,7 @@ func (i *Iterator) First() bool {
 	i.err = nil // clear cached iteration error
 	i.hasPrefix = false
 	i.lastPositioningOp = unknownLastPositionOp
+	i.requiresReposition = false
 	i.stats.ForwardSeekCount[InterfaceCall]++
 	if lowerBound := i.opts.GetLowerBound(); lowerBound != nil {
 		i.iterKey, i.iterValue = i.iter.SeekGE(lowerBound, false /* trySeekUsingNext */)
@@ -1224,6 +1240,7 @@ func (i *Iterator) Last() bool {
 	i.err = nil // clear cached iteration error
 	i.hasPrefix = false
 	i.lastPositioningOp = unknownLastPositionOp
+	i.requiresReposition = false
 	i.stats.ReverseSeekCount[InterfaceCall]++
 	if upperBound := i.opts.GetUpperBound(); upperBound != nil {
 		i.iterKey, i.iterValue = i.iter.SeekLT(upperBound)
@@ -1264,6 +1281,7 @@ func (i *Iterator) NextWithLimit(limit []byte) IterValidityState {
 		return i.iterValidityState
 	}
 	i.lastPositioningOp = unknownLastPositionOp
+	i.requiresReposition = false
 	switch i.pos {
 	case iterPosCurForward:
 		i.nextUserKey()
@@ -1347,6 +1365,7 @@ func (i *Iterator) PrevWithLimit(limit []byte) IterValidityState {
 		return i.iterValidityState
 	}
 	i.lastPositioningOp = unknownLastPositionOp
+	i.requiresReposition = false
 	if i.hasPrefix {
 		i.err = errReversePrefixIteration
 		i.iterValidityState = IterExhausted
@@ -1653,7 +1672,7 @@ func (i *Iterator) RangeKeys() []RangeKeyData {
 // Valid returns true if the iterator is positioned at a valid key/value pair
 // and false otherwise.
 func (i *Iterator) Valid() bool {
-	return i.iterValidityState == IterValid
+	return i.iterValidityState == IterValid && !i.requiresReposition
 }
 
 // Error returns any accumulated error.
@@ -1752,6 +1771,13 @@ func (i *Iterator) Close() error {
 		} else {
 			alloc.prefixOrFullSeekKey = i.prefixOrFullSeekKey
 		}
+		for j := range i.boundsBuf {
+			if cap(i.boundsBuf[j]) >= maxKeyBufCacheSize {
+				alloc.boundsBuf[j] = nil
+			} else {
+				alloc.boundsBuf[j] = i.boundsBuf[j]
+			}
+		}
 		*i = Iterator{}
 		iterAllocPool.Put(alloc)
 	} else if alloc := i.getIterAlloc; alloc != nil {
@@ -1766,24 +1792,38 @@ func (i *Iterator) Close() error {
 	return err
 }
 
-// SetBounds sets the lower and upper bounds for the iterator. Note that:
-// - The slices provided in this SetBounds must not be changed by the caller
-//   until the iterator is closed, or a subsequent SetBounds or SetOptions has
-//   returned. This is because comparisons between the existing and new bounds
-//   are sometimes used to optimize seeking.
-// - If the bounds are not changing from the existing ones, it would be
-//   worthwhile for the caller to avoid calling SetBounds, since that allows
-//   for more seek optimizations. Note that the callee cannot itself look to
-//   see if the bounds are not changing and ignore the call, since the caller
-//   may then start mutating the underlying slices. Specifically, consider
-//   SetBounds(l1, u1), SetBounds(l2, u2) where l1=l2 and u1=u2. The callee
-//   cannot ignore the second call and keep using l1, u1, since the contract
-//   with the caller allows the caller to mutate l1, u1 after the second call
-//   returns, as mentioned in the previous bullet (ignoring in the callee
-//   resulted in a hard to find bug).
-// - The iterator will always be invalidated and must be repositioned with a
-//   call to SeekGE, SeekPrefixGE, SeekLT, First, or Last.
+// SetBounds sets the lower and upper bounds for the iterator. Once SetBounds
+// returns, the caller is free to mutate the provided slices.
+//
+// The iterator will always be invalidated and must be repositioned with a call
+// to SeekGE, SeekPrefixGE, SeekLT, First, or Last.
 func (i *Iterator) SetBounds(lower, upper []byte) {
+	// Ensure that the Iterator appears exhausted, regardless of whether we
+	// actually have to invalidate the internal iterator. Optimizations that
+	// avoid exhaustion are an internal implementation detail that shouldn't
+	// leak through the interface. The caller should still call an absolute
+	// positioning method to reposition the iterator.
+	i.requiresReposition = true
+
+	if ((i.opts.LowerBound == nil) == (lower == nil)) &&
+		((i.opts.UpperBound == nil) == (upper == nil)) &&
+		i.equal(i.opts.LowerBound, lower) &&
+		i.equal(i.opts.UpperBound, upper) {
+		// Unchanged, noop.
+		return
+	}
+
+	// Copy the user-provided bounds into an Iterator-owned buffer, and set them
+	// on i.opts.{Lower,Upper}Bound.
+	i.saveBounds(lower, upper)
+
+	i.iter.SetBounds(i.opts.LowerBound, i.opts.UpperBound)
+	// If the iterator has an open point iterator that's not currently being
+	// used, propagate the new bounds to it.
+	if i.pointIter != nil && !i.opts.pointKeys() {
+		i.pointIter.SetBounds(i.opts.LowerBound, i.opts.UpperBound)
+	}
+
 	// Even though this is not a positioning operation, the alteration of the
 	// bounds means we cannot optimize Seeks by using Next.
 	i.lastPositioningOp = unknownLastPositionOp
@@ -1801,10 +1841,28 @@ func (i *Iterator) SetBounds(lower, upper []byte) {
 		i.pos = iterPosCurReverse
 	}
 	i.iterValidityState = IterExhausted
+}
 
-	i.opts.LowerBound = lower
-	i.opts.UpperBound = upper
-	i.iter.SetBounds(lower, upper)
+func (i *Iterator) saveBounds(lower, upper []byte) {
+	// Copy the user-provided bounds into an Iterator-owned buffer. We can't
+	// overwrite the current bounds, because some internal iterators compare old
+	// and new bounds for optimizations.
+
+	buf := i.boundsBuf[i.boundsBufIdx][:0]
+	if lower != nil {
+		buf = append(buf, lower...)
+		i.opts.LowerBound = buf
+	} else {
+		i.opts.LowerBound = nil
+	}
+	if upper != nil {
+		buf = append(buf, upper...)
+		i.opts.UpperBound = buf[len(buf)-len(upper):]
+	} else {
+		i.opts.UpperBound = nil
+	}
+	i.boundsBuf[i.boundsBufIdx] = buf
+	i.boundsBufIdx = 1 - i.boundsBufIdx
 }
 
 // SetOptions sets new iterator options for the iterator. Note that the lower
@@ -1822,8 +1880,78 @@ func (i *Iterator) SetBounds(lower, upper []byte) {
 //
 // If only lower and upper bounds need to be modified, prefer SetBounds.
 func (i *Iterator) SetOptions(o *IterOptions) {
-	// Even though this is not a positioning operation, the alteration of the
-	// bounds means we cannot optimize Seeks by using Next.
+	// Ensure that the Iterator appears exhausted, regardless of whether we
+	// actually have to invalidate the internal iterator. Optimizations that
+	// avoid exhaustion are an internal implementation detail that shouldn't
+	// leak through the interface. The caller should still call an absolute
+	// positioning method to reposition the iterator.
+	i.requiresReposition = true
+
+	// Check if global state requires we close all internal iterators.
+	//
+	// If the Iterator is in an error state, invalidate the existing iterators
+	// so that we reconstruct an iterator state from scratch.
+	//
+	// If OnlyReadGuaranteedDurable changed, the iterator stacks are incorrect,
+	// improperly including or excluding memtables. Invalidate them so that
+	// finishInitializingIter will reconstruct them.
+	//
+	// If either the original options or the new options specify a table filter,
+	// we need to reconstruct the iterator stacks. If they both supply a table
+	// filter, we can't be certain that it's the same filter since we have no
+	// mechanism to compare the filter closures.
+	closeBoth := i.err != nil ||
+		o.OnlyReadGuaranteedDurable != i.opts.OnlyReadGuaranteedDurable ||
+		o.TableFilter != nil || i.opts.TableFilter != nil
+
+	// If either options specify block property filters for an iterator stack,
+	// reconstruct it.
+	if i.pointIter != nil && (closeBoth || len(o.PointKeyFilters) > 0 || len(i.opts.PointKeyFilters) > 0) {
+		i.err = firstError(i.err, i.pointIter.Close())
+		i.pointIter = nil
+	}
+	if i.rangeKey != nil && (closeBoth || len(o.RangeKeyFilters) > 0 || len(i.opts.RangeKeyFilters) > 0) {
+		i.err = firstError(i.err, i.rangeKey.rangeKeyIter.Close())
+		i.rangeKey = nil
+	}
+
+	boundsEqual := ((i.opts.LowerBound == nil) == (o.LowerBound == nil)) &&
+		((i.opts.UpperBound == nil) == (o.UpperBound == nil)) &&
+		i.equal(i.opts.LowerBound, o.LowerBound) &&
+		i.equal(i.opts.UpperBound, o.UpperBound)
+
+	if (i.pointIter != nil || !i.opts.pointKeys()) &&
+		(i.rangeKey != nil || !i.opts.rangeKeys()) &&
+		boundsEqual && o.KeyTypes == i.opts.KeyTypes &&
+		i.equal(o.RangeKeyMasking.Suffix, i.opts.RangeKeyMasking.Suffix) &&
+		o.UseL6Filters == i.opts.UseL6Filters {
+		// Fast path. The options are identical. This preserves the
+		// Seek-using-Next optimizations.
+		return
+	}
+
+	// The options changed. Save the new ones to i.opts.
+	if boundsEqual {
+		// Copying the options into i.opts will overwrite LowerBound and
+		// UpperBound fields with the user-provided slices. We need to hold on
+		// to the Pebble-owned slices, so save them and re-set them after the
+		// copy.
+		lower, upper := i.opts.LowerBound, i.opts.UpperBound
+		i.opts = *o
+		i.opts.LowerBound, i.opts.UpperBound = lower, upper
+	} else {
+		i.opts = *o
+		i.saveBounds(o.LowerBound, o.UpperBound)
+		// Propagate the changed bounds to the existing point iterator.
+		// NB: We propagate i.opts.{Lower,Upper}Bound, not o.{Lower,Upper}Bound
+		// because i.opts now point to buffers owned by Pebble.
+		if i.pointIter != nil {
+			i.pointIter.SetBounds(i.opts.LowerBound, i.opts.UpperBound)
+		}
+	}
+
+	// Even though this is not a positioning operation, the invalidation of the
+	// iterator stack means we cannot optimize Seeks by using Next.
 	i.lastPositioningOp = unknownLastPositionOp
 	i.hasPrefix = false
 	i.iterKey = nil
@@ -1840,39 +1968,6 @@ func (i *Iterator) SetOptions(o *IterOptions) {
 		i.pos = iterPosCurReverse
 	}
 	i.iterValidityState = IterExhausted
-
-	var closePoint, closeRange bool
-	// If OnlyReadGuaranteedDurable changed, the iterator stacks are incorrect,
-	// improperly including or excluding memtables. Invalidate them so that
-	// finishInitializingIter will reconstruct them.
-	closePoint = closePoint || i.opts.OnlyReadGuaranteedDurable != o.OnlyReadGuaranteedDurable
-	closeRange = closeRange || i.opts.OnlyReadGuaranteedDurable != o.OnlyReadGuaranteedDurable
-
-	// If either the original options or the new options specify a table filter,
-	// we need to reconstruct the iterator stacks. If they both supply a table
-	// filter, we can't be certain that it's the same filter since we have no
-	// mechanism to compare the filter closures.
-	closePoint = closePoint || i.opts.TableFilter != nil || o.TableFilter != nil
-	closeRange = closeRange || i.opts.TableFilter != nil || o.TableFilter != nil
-
-	// If either options specify block property filters for an iterator stack,
-	// reconstruct it.
-	// TODO(jackson): Expose a InternalIterator.SetOptions function and
-	// propagate changed filters to the existing iterator stack. There will
-	// likely be complications with determinism.
-	closePoint = closePoint || len(i.opts.PointKeyFilters) > 0 || len(o.PointKeyFilters) > 0
-	closeRange = closeRange || len(i.opts.RangeKeyFilters) > 0 || len(o.RangeKeyFilters) > 0
-
-	if closePoint && i.pointIter != nil {
-		i.err = firstError(i.err, i.pointIter.Close())
-		i.pointIter = nil
-	}
-	if closeRange && i.rangeKey != nil {
-		i.err = firstError(i.err, i.rangeKey.iter.Close())
-		i.rangeKey = nil
-	}
-
-	i.opts = *o
 	finishInitializingIter(i.alloc)
 }
 
@@ -1902,16 +1997,7 @@ func (i *Iterator) Stats() IteratorStats {
 
 // Clone creates a new Iterator over the same underlying data, i.e., over the
 // same {batch, memtables, sstables}). It starts with the same IterOptions but
-// is not positioned. Note that IterOptions is not deep-copied, so the
-// LowerBound and UpperBound slices will share memory with the original
-// Iterator. Iterators assume that these bound slices are not mutated by the
-// callers, for the lifetime of use by an Iterator. The lifetime of use spans
-// from the Iterator creation/SetBounds call to the next SetBounds call. If
-// the caller is tracking this lifetime in order to reuse memory of these
-// slices, it must remember that now the lifetime of use is due to multiple
-// Iterators. The simplest behavior the caller can adopt to decouple lifetimes
-// is to call SetBounds on the new Iterator, immediately after Clone returns,
-// with different bounds slices.
+// is not positioned.
 //
 // Callers can use Clone if they need multiple iterators that need to see
 // exactly the same underlying state of the DB. This should not be used to
@@ -1939,11 +2025,13 @@ func (i *Iterator) Clone() (*Iterator, error) {
 		readState:           readState,
 		keyBuf:              buf.keyBuf,
 		prefixOrFullSeekKey: buf.prefixOrFullSeekKey,
+		boundsBuf:           buf.boundsBuf,
 		batch:               i.batch,
 		newIters:            i.newIters,
 		seqNum:              i.seqNum,
 		db:                  i.db,
 	}
+	dbi.saveBounds(i.opts.LowerBound, i.opts.UpperBound)
 	return finishInitializingIter(buf), nil
 }
 

--- a/testdata/iterator
+++ b/testdata/iterator
@@ -1175,7 +1175,7 @@ stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, 
 iter seq=2
 set-bounds lower=b
 seek-ge a
-set-bounds lower=b
+set-bounds lower=b upper=z
 seek-ge a
 ----
 .

--- a/testdata/iterator_bounds_lifetimes
+++ b/testdata/iterator_bounds_lifetimes
@@ -1,0 +1,83 @@
+new-iter label=first lower=bar upper=foo
+----
+first: ("bar", "foo") boundsBufIdx=1
+
+iter label=first
+first
+next
+----
+bb@29:bb@29
+bc@30:bc@30
+
+# Clone an iterator from the original iterator. The clone should have its own
+# copy of the bounds.
+
+clone from=first to=second
+----
+first: ("bar", "foo") boundsBufIdx=1
+second: ("bar", "foo") boundsBufIdx=1
+
+iter label=second
+last
+prev
+----
+fo@150:fo@150
+fn@149:fn@149
+
+# Changing the bounds on the original should leave the clone's bounds unchanged.
+
+set-bounds label=first lower=boop
+----
+first: ("boop", <nil>) boundsBufIdx=0
+second: ("bar", "foo") boundsBufIdx=1
+
+iter label=first
+seek-ge goop
+----
+gp@178:gp@178
+
+iter label=second
+prev
+----
+fm@148:fm@148
+
+set-bounds label=first lower=boop upper=bop
+----
+first: ("boop", "bop") boundsBufIdx=1
+second: ("bar", "foo") boundsBufIdx=1
+
+# Changing the bounds on the clone should leave the original's bounds unchanged.
+
+set-options label=second lower=a upper=z
+----
+first: ("boop", "bop") boundsBufIdx=1
+second: ("a", "z") boundsBufIdx=0
+
+# Test no-op set-options. The boundsBufIdx should remain unchanged, reflecting
+# that the bounds were not copied again.
+
+set-options label=second lower=a upper=z
+----
+first: ("boop", "bop") boundsBufIdx=1
+second: ("a", "z") boundsBufIdx=0
+
+# Test SetOptions with unchanged bounds but changes to other options. SetOptions
+# should hold onto the existing bounds buffers. The boundsBufIdx should still
+# remain unchanged, reflecting that the bounds were not copied.
+
+set-options label=second lower=a upper=z key-types=both
+----
+first: ("boop", "bop") boundsBufIdx=1
+second: ("a", "z") boundsBufIdx=0
+
+iter label=second
+seek-ge foo
+----
+fp@151: (fp@151, .)
+
+close label=first
+----
+second: ("a", "z") boundsBufIdx=0
+
+close label=second
+----

--- a/testdata/iterator_seek_opt
+++ b/testdata/iterator_seek_opt
@@ -177,9 +177,10 @@ stats: (interface (dir, seek, step): (fwd, 16, 1), (rev, 0, 1)), (internal (dir,
 SeekGEs with trySeekUsingNext: 6
 SeekPrefixGEs with trySeekUsingNext: 4
 
-# Shifting bounds, with non-overlapping and monotonic bounds. We don't call
-# trySeekUsingNext=true at all here as the set-bounds sits in between every two
-# seeks, but the results are still correct and within bounds.
+# Shifting bounds, with non-overlapping and monotonic bounds. A set-bounds sits
+# between every two seeks. We don't call trySeekUsingNext=true when the bounds
+# are set to unequal bounds, but the results are still correct and within
+# bounds. We do call trySeekUsingNext=true when the set bounds are identical.
 
 iter
 set-bounds lower=a upper=c
@@ -201,14 +202,26 @@ stats: (interface (dir, seek, step): (fwd, 18, 1), (rev, 0, 1)), (internal (dir,
 SeekGEs with trySeekUsingNext: 6
 SeekPrefixGEs with trySeekUsingNext: 4
 
+# NB: Equal bounds.
+
+iter
+set-bounds lower=c upper=e
+seek-ge d
+----
+.
+d:2
+stats: (interface (dir, seek, step): (fwd, 19, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 18, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 8
+SeekPrefixGEs with trySeekUsingNext: 4
+
 iter
 set-bounds lower=a upper=c
 seek-prefix-ge b
 ----
 .
 b:1
-stats: (interface (dir, seek, step): (fwd, 19, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 18, 1), (rev, 0, 3))
-SeekGEs with trySeekUsingNext: 6
+stats: (interface (dir, seek, step): (fwd, 20, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 19, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 8
 SeekPrefixGEs with trySeekUsingNext: 4
 
 iter
@@ -217,6 +230,88 @@ seek-prefix-ge c
 ----
 .
 c:1
-stats: (interface (dir, seek, step): (fwd, 20, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 19, 1), (rev, 0, 3))
-SeekGEs with trySeekUsingNext: 6
+stats: (interface (dir, seek, step): (fwd, 21, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 20, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 8
 SeekPrefixGEs with trySeekUsingNext: 4
+
+# NB: Equal bounds.
+
+iter
+set-bounds lower=c upper=e
+seek-prefix-ge d
+----
+.
+d:2
+stats: (interface (dir, seek, step): (fwd, 22, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 21, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 8
+SeekPrefixGEs with trySeekUsingNext: 6
+
+# Shifting bounds, with non-overlapping and monotonic bounds, but using
+# SetOptions. A set-options sits between every two seeks. We don't call
+# trySeekUsingNext=true when the bounds are set to unequal bounds, but the
+# results are still correct and within bounds. We do call trySeekUsingNext=true
+# when the set bounds are identical.
+
+iter
+set-options lower=a upper=c
+seek-ge b
+----
+.
+b:1
+stats: (interface (dir, seek, step): (fwd, 23, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 22, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 8
+SeekPrefixGEs with trySeekUsingNext: 6
+
+iter
+set-options lower=c upper=e
+seek-ge c
+----
+.
+c:1
+stats: (interface (dir, seek, step): (fwd, 24, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 23, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 8
+SeekPrefixGEs with trySeekUsingNext: 6
+
+# NB: Equal bounds.
+
+iter
+set-options lower=c upper=e
+seek-ge d
+----
+.
+d:2
+stats: (interface (dir, seek, step): (fwd, 25, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 24, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 10
+SeekPrefixGEs with trySeekUsingNext: 6
+
+iter
+set-options lower=a upper=c
+seek-prefix-ge b
+----
+.
+b:1
+stats: (interface (dir, seek, step): (fwd, 26, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 25, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 10
+SeekPrefixGEs with trySeekUsingNext: 6
+
+iter
+set-options lower=c upper=e
+seek-prefix-ge c
+----
+.
+c:1
+stats: (interface (dir, seek, step): (fwd, 27, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 26, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 10
+SeekPrefixGEs with trySeekUsingNext: 6
+
+# NB: Equal bounds.
+
+iter
+set-options lower=c upper=e
+seek-prefix-ge d
+----
+.
+d:2
+stats: (interface (dir, seek, step): (fwd, 28, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 27, 1), (rev, 0, 3))
+SeekGEs with trySeekUsingNext: 10
+SeekPrefixGEs with trySeekUsingNext: 8


### PR DESCRIPTION
When a new iterator is constructed or when an existing iterator's bounds are
modified, copy the bounds into a Pebble-allocated slice. This gives Pebble
control over the lifetime of the bound buffers and allows Pebble to restore the
optimization for unchanged bounds that was removed in https://github.com/cockroachdb/pebble/pull/1073.

Two buffers are used, one for the current bounds and one for old bounds. This
scheme allows low-level internal iterators in Pebble to compare new and old
bounds so that context-dependent optimizations may be applied.

These bounds buffers are pooled on the `iterAlloc` to reduce allocations.

These new semantics are simpler and allow Pebble's SetOptions to perform more
optimizations. They come at the cost of the additional key copies, regardless
of whether the Iterator's bounds will change.

Alternative to #1667.