### PR TITLE
db: fix NewIter regression resulting in extra memtable levels

### DIFF
--- a/db.go
+++ b/db.go
@@ -955,11 +955,10 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 		// We only need to read from memtables which contain sequence numbers older
 		// than seqNum. Trim off newer memtables.
 		for i := len(memtables) - 1; i >= 0; i-- {
-			if logSeqNum := memtables[i].logSeqNum; logSeqNum >= dbi.seqNum {
-				continue
+			if logSeqNum := memtables[i].logSeqNum; logSeqNum < dbi.seqNum {
+				break
 			}
-			memtables = memtables[:i+1]
-			break
+			memtables = memtables[:i]
 		}
 	}
 


### PR DESCRIPTION
In 1b227d2c the trimming of memtables introduced a regression. The regression
would needlessly include all memtables if all memtables had sequence numbers
more recent than the iterator's sequence number.

The impact of this fix is exaggerated on the `NewIterReadAmp` benchmark,
because the one unnecessary included memtable increases the number of merging
levels beyond the iterAlloc preallocated array length.

```
name                  old time/op    new time/op    delta
NewIterReadAmp/10-10    2.18µs ± 2%    1.63µs ± 2%  -24.87%  (p=0.008 n=5+5)

name                  old alloc/op   new alloc/op   delta
NewIterReadAmp/10-10    2.37kB ± 0%    0.05kB ± 0%  -97.98%  (p=0.008 n=5+5)

name                  old allocs/op  new allocs/op  delta
NewIterReadAmp/10-10      3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.008 n=5+5)
```

Fix #1679.