### PR TITLE
db: add BenchmarkIteratorScan

### DIFF
--- a/db.go
+++ b/db.go
@@ -930,9 +930,7 @@ func (d *DB) newIterInternal(batch *Batch, s *Snapshot, o *IterOptions) *Iterato
 		batch:               batch,
 		newIters:            d.newIters,
 		seqNum:              seqNum,
-		newRangeKeyIter: func(it *iteratorRangeKeyState) keyspan.FragmentIterator {
-			return d.newRangeKeyIter(it, seqNum, batch, readState, &dbi.opts)
-		},
+		db:                  d,
 	}
 	if o != nil {
 		dbi.opts = *o
@@ -974,7 +972,7 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 		if dbi.rangeKey == nil {
 			dbi.rangeKey = iterRangeKeyStateAllocPool.Get().(*iteratorRangeKeyState)
 			dbi.rangeKey.keys.cmp = dbi.cmp
-			dbi.rangeKey.rangeKeyIter = dbi.newRangeKeyIter(dbi.rangeKey)
+			dbi.rangeKey.rangeKeyIter = dbi.db.newRangeKeyIter(dbi.rangeKey, dbi.seqNum, dbi.batch, dbi.readState, &dbi.opts)
 		}
 
 		// Wrap the point iterator (currently dbi.iter) with an interleaving

--- a/internal/testkeys/testdata/divvy
+++ b/internal/testkeys/testdata/divvy
@@ -1,0 +1,46 @@
+divvy alpha=1 portions=3
+----
+a d g j m p s v y
+b e h k n q t w z
+c f i l o r u x
+
+divvy alpha=1 portions=1
+----
+a b c d e f g h i j k l m n o p q r s t u v w x y z
+
+divvy alpha=1 portions=5
+----
+a f k p u z
+b g l q v
+c h m r w
+d i n s x
+e j o t y
+
+divvy alpha=2 portions=26
+----
+a az by cx dw ev fu gt hs ir jq kp lo mn nm ol pk qj ri sh tg uf ve wd xc yb za
+aa b bz cy dx ew fv gu ht is jr kq lp mo nn om pl qk rj si th ug vf we xd yc zb
+ab ba c cz dy ex fw gv hu it js kr lq mp no on pm ql rk sj ti uh vg wf xe yd zc
+ac bb ca d dz ey fx gw hv iu jt ks lr mq np oo pn qm rl sk tj ui vh wg xf ye zd
+ad bc cb da e ez fy gx hw iv ju kt ls mr nq op po qn rm sl tk uj vi wh xg yf ze
+ae bd cc db ea f fz gy hx iw jv ku lt ms nr oq pp qo rn sm tl uk vj wi xh yg zf
+af be cd dc eb fa g gz hy ix jw kv lu mt ns or pq qp ro sn tm ul vk wj xi yh zg
+ag bf ce dd ec fb ga h hz iy jx kw lv mu nt os pr qq rp so tn um vl wk xj yi zh
+ah bg cf de ed fc gb ha i iz jy kx lw mv nu ot ps qr rq sp to un vm wl xk yj zi
+ai bh cg df ee fd gc hb ia j jz ky lx mw nv ou pt qs rr sq tp uo vn wm xl yk zj
+aj bi ch dg ef fe gd hc ib ja k kz ly mx nw ov pu qt rs sr tq up vo wn xm yl zk
+ak bj ci dh eg ff ge hd ic jb ka l lz my nx ow pv qu rt ss tr uq vp wo xn ym zl
+al bk cj di eh fg gf he id jc kb la m mz ny ox pw qv ru st ts ur vq wp xo yn zm
+am bl ck dj ei fh gg hf ie jd kc lb ma n nz oy px qw rv su tt us vr wq xp yo zn
+an bm cl dk ej fi gh hg if je kd lc mb na o oz py qx rw sv tu ut vs wr xq yp zo
+ao bn cm dl ek fj gi hh ig jf ke ld mc nb oa p pz qy rx sw tv uu vt ws xr yq zp
+ap bo cn dm el fk gj hi ih jg kf le md nc ob pa q qz ry sx tw uv vu wt xs yr zq
+aq bp co dn em fl gk hj ii jh kg lf me nd oc pb qa r rz sy tx uw vv wu xt ys zr
+ar bq cp do en fm gl hk ij ji kh lg mf ne od pc qb ra s sz ty ux vw wv xu yt zs
+as br cq dp eo fn gm hl ik jj ki lh mg nf oe pd qc rb sa t tz uy vx ww xv yu zt
+at bs cr dq ep fo gn hm il jk kj li mh ng of pe qd rc sb ta u uz vy wx xw yv zu
+au bt cs dr eq fp go hn im jl kk lj mi nh og pf qe rd sc tb ua v vz wy xx yw zv
+av bu ct ds er fq gp ho in jm kl lk mj ni oh pg qf re sd tc ub va w wz xy yx zw
+aw bv cu dt es fr gq hp io jn km ll mk nj oi ph qg rf se td uc vb wa x xz yy zx
+ax bw cv du et fs gr hq ip jo kn lm ml nk oj pi qh rg sf te ud vc wb xa y yz zy
+ay bx cw dv eu ft gs hr iq jp ko ln mm nl ok pj qi rh sg tf ue vd wc xb ya z zz

--- a/internal/testkeys/testkeys_test.go
+++ b/internal/testkeys/testkeys_test.go
@@ -6,8 +6,10 @@ package testkeys
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/stretchr/testify/require"
 )
 
@@ -173,6 +175,27 @@ func TestSuffixLen(t *testing.T) {
 			t.Errorf("SuffixLen(%d) = %d, want %d", ts, got, want)
 		}
 	}
+}
+
+func TestDivvy(t *testing.T) {
+	var buf bytes.Buffer
+	datadriven.RunTest(t, "testdata/divvy", func(d *datadriven.TestData) string {
+		buf.Reset()
+		switch d.Cmd {
+		case "divvy":
+			var alphaLen, portions int
+			d.ScanArgs(t, "alpha", &alphaLen)
+			d.ScanArgs(t, "portions", &portions)
+
+			input := Alpha(alphaLen)
+			for _, ks := range Divvy(input, portions) {
+				fmt.Fprintln(&buf, keyspaceToString(ks))
+			}
+			return buf.String()
+		default:
+			return fmt.Sprintf("unrecognized command %q", d.Cmd)
+		}
+	})
 }
 
 func keyspaceToString(ks Keyspace) string {

--- a/iterator.go
+++ b/iterator.go
@@ -184,8 +184,9 @@ type Iterator struct {
 	batch    *Batch
 	newIters tableNewIters
 	seqNum   uint64
-	// TODO(jackson): Remove when we no longer require the global arena.
-	newRangeKeyIter func(*iteratorRangeKeyState) keyspan.FragmentIterator
+	// TODO(jackson): Remove db when we no longer require the global arena for
+	// range keys. This reference is only temporary.
+	db *DB
 
 	// Keeping the bools here after all the 8 byte aligned fields shrinks the
 	// sizeof this struct by 24 bytes.
@@ -1941,7 +1942,7 @@ func (i *Iterator) Clone() (*Iterator, error) {
 		batch:               i.batch,
 		newIters:            i.newIters,
 		seqNum:              i.seqNum,
-		newRangeKeyIter:     i.newRangeKeyIter,
+		db:                  i.db,
 	}
 	return finishInitializingIter(buf), nil
 }

--- a/options.go
+++ b/options.go
@@ -73,6 +73,20 @@ const (
 	IterKeyTypePointsAndRanges
 )
 
+// String implements fmt.Stringer.
+func (t IterKeyType) String() string {
+	switch t {
+	case IterKeyTypePointsOnly:
+		return "points-only"
+	case IterKeyTypeRangesOnly:
+		return "ranges-only"
+	case IterKeyTypePointsAndRanges:
+		return "points-and-ranges"
+	default:
+		panic(fmt.Sprintf("unknown key type %d", t))
+	}
+}
+
 // IterOptions hold the optional per-query parameters for NewIter.
 //
 // Like Options, a nil *IterOptions is valid and means to use the default


### PR DESCRIPTION
**db: add BenchmarkIteratorScan**

Add a simple microbenchmark that benchmarks the construction of an iterator and
a scan across the entirety of a database's keyspace. Add variances for key
count, read-amplification and the kinds of keys iterated over.

Besides general utility in measuring iterator scan performance, it's expected
to be useful in optimizing the current iterator slow down with range-keys
enabled.

**db: remove newRangeKeyIter closure**

Avoid unnecessarily creating a closure over the *DB, resulting in an
allocation during iterator construction. This closure would have been
eliminated once range key state is fully ecapsulated by the `readState`. This
commit replaces the closure with a direct `*DB` reference for now to avoid the
allocation which may impact benchmarks, including with iterators that only
iterate over point keys.

```
name                                                             old time/op    new time/op    delta
IteratorScan/keys=100,r-amp=1,key-types=points-only-10             5.85µs ± 1%    5.78µs ± 1%   -1.20%  (p=0.016 n=5+5)
IteratorScan/keys=100,r-amp=1,key-types=points-and-ranges-10       9.20µs ± 1%    9.26µs ± 1%     ~     (p=0.421 n=5+5)
IteratorScan/keys=100,r-amp=3,key-types=points-only-10             10.4µs ± 0%    10.4µs ± 1%     ~     (p=0.690 n=5+5)
IteratorScan/keys=100,r-amp=3,key-types=points-and-ranges-10       14.2µs ± 1%    13.9µs ± 0%   -2.10%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=7,key-types=points-only-10             15.7µs ± 2%    15.5µs ± 0%     ~     (p=0.095 n=5+5)
IteratorScan/keys=100,r-amp=7,key-types=points-and-ranges-10       19.2µs ± 1%    19.1µs ± 0%     ~     (p=0.056 n=5+5)
IteratorScan/keys=100,r-amp=10,key-types=points-only-10            19.2µs ± 1%    19.0µs ± 1%     ~     (p=0.095 n=5+5)
IteratorScan/keys=100,r-amp=10,key-types=points-and-ranges-10      23.2µs ± 1%    23.1µs ± 0%     ~     (p=0.056 n=5+5)
IteratorScan/keys=1000,r-amp=1,key-types=points-only-10            44.8µs ± 0%    44.4µs ± 1%   -0.91%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=1,key-types=points-and-ranges-10      71.8µs ± 0%    71.4µs ± 0%   -0.48%  (p=0.016 n=5+5)
IteratorScan/keys=1000,r-amp=3,key-types=points-only-10            77.6µs ± 0%    76.9µs ± 0%   -0.98%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=3,key-types=points-and-ranges-10       105µs ± 0%     104µs ± 0%   -1.30%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=7,key-types=points-only-10             105µs ± 0%     105µs ± 0%   -0.74%  (p=0.016 n=5+5)
IteratorScan/keys=1000,r-amp=7,key-types=points-and-ranges-10       133µs ± 0%     133µs ± 0%   -0.54%  (p=0.032 n=5+5)
IteratorScan/keys=1000,r-amp=10,key-types=points-only-10            119µs ± 0%     119µs ± 0%   -0.52%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=10,key-types=points-and-ranges-10      147µs ± 1%     146µs ± 0%   -0.58%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=1,key-types=points-only-10            422µs ± 0%     420µs ± 1%     ~     (p=0.095 n=5+5)
IteratorScan/keys=10000,r-amp=1,key-types=points-and-ranges-10      663µs ± 2%     665µs ± 0%     ~     (p=0.151 n=5+5)
IteratorScan/keys=10000,r-amp=3,key-types=points-only-10            711µs ± 1%     711µs ± 1%     ~     (p=0.841 n=5+5)
IteratorScan/keys=10000,r-amp=3,key-types=points-and-ranges-10      966µs ± 1%     965µs ± 1%     ~     (p=0.841 n=5+5)
IteratorScan/keys=10000,r-amp=7,key-types=points-only-10            951µs ± 0%     951µs ± 1%     ~     (p=1.000 n=5+5)
IteratorScan/keys=10000,r-amp=7,key-types=points-and-ranges-10     1.20ms ± 0%    1.20ms ± 1%     ~     (p=0.841 n=5+5)
IteratorScan/keys=10000,r-amp=10,key-types=points-only-10          1.06ms ± 1%    1.06ms ± 0%     ~     (p=0.222 n=5+5)
IteratorScan/keys=10000,r-amp=10,key-types=points-and-ranges-10    1.30ms ± 0%    1.31ms ± 1%   +0.58%  (p=0.032 n=5+5)

name                                                             old alloc/op   new alloc/op   delta
IteratorScan/keys=100,r-amp=1,key-types=points-only-10              64.0B ± 0%     16.0B ± 0%  -75.00%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=1,key-types=points-and-ranges-10         200B ± 0%      152B ± 0%  -24.00%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=3,key-types=points-only-10              96.0B ± 0%     48.0B ± 0%  -50.00%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=3,key-types=points-and-ranges-10         232B ± 0%      184B ± 0%  -20.69%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=7,key-types=points-only-10               160B ± 0%      112B ± 0%  -30.00%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=7,key-types=points-and-ranges-10         296B ± 0%      248B ± 0%  -16.22%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=10,key-types=points-only-10              208B ± 0%      160B ± 0%  -23.08%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=10,key-types=points-and-ranges-10        344B ± 0%      296B ± 0%  -13.95%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=1,key-types=points-only-10             64.0B ± 0%     16.0B ± 0%  -75.00%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=1,key-types=points-and-ranges-10        200B ± 0%      152B ± 0%  -24.15%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=3,key-types=points-only-10             96.0B ± 0%     48.0B ± 0%     ~     (p=0.079 n=4+5)
IteratorScan/keys=1000,r-amp=3,key-types=points-and-ranges-10        233B ± 0%      185B ± 0%  -20.60%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=7,key-types=points-only-10              160B ± 0%      113B ± 0%  -29.55%  (p=0.000 n=5+4)
IteratorScan/keys=1000,r-amp=7,key-types=points-and-ranges-10        297B ± 0%      249B ± 0%  -16.16%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=10,key-types=points-only-10             209B ± 0%      161B ± 0%  -22.97%  (p=0.029 n=4+4)
IteratorScan/keys=1000,r-amp=10,key-types=points-and-ranges-10       346B ± 0%      298B ± 0%  -13.87%  (p=0.029 n=4+4)
IteratorScan/keys=10000,r-amp=1,key-types=points-only-10            66.4B ± 4%     20.0B ± 0%  -69.88%  (p=0.000 n=5+4)
IteratorScan/keys=10000,r-amp=1,key-types=points-and-ranges-10       208B ± 0%      160B ± 0%     ~     (p=0.079 n=4+5)
IteratorScan/keys=10000,r-amp=3,key-types=points-only-10             103B ± 1%       53B ± 7%  -48.86%  (p=0.016 n=4+5)
IteratorScan/keys=10000,r-amp=3,key-types=points-and-ranges-10       240B ± 2%      196B ± 0%  -18.47%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=7,key-types=points-only-10             170B ± 0%      117B ± 4%  -31.06%  (p=0.000 n=4+5)
IteratorScan/keys=10000,r-amp=7,key-types=points-and-ranges-10       312B ± 0%      259B ± 3%  -16.98%  (p=0.016 n=4+5)
IteratorScan/keys=10000,r-amp=10,key-types=points-only-10            220B ± 0%      172B ± 0%  -21.82%  (p=0.029 n=4+4)
IteratorScan/keys=10000,r-amp=10,key-types=points-and-ranges-10      362B ± 0%      314B ± 0%  -13.14%  (p=0.000 n=4+5)

name                                                             old allocs/op  new allocs/op  delta
IteratorScan/keys=100,r-amp=1,key-types=points-only-10               2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=1,key-types=points-and-ranges-10         8.00 ± 0%      7.00 ± 0%  -12.50%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=3,key-types=points-only-10               4.00 ± 0%      3.00 ± 0%  -25.00%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=3,key-types=points-and-ranges-10         10.0 ± 0%       9.0 ± 0%  -10.00%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=7,key-types=points-only-10               8.00 ± 0%      7.00 ± 0%  -12.50%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=7,key-types=points-and-ranges-10         14.0 ± 0%      13.0 ± 0%   -7.14%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=10,key-types=points-only-10              11.0 ± 0%      10.0 ± 0%   -9.09%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=10,key-types=points-and-ranges-10        17.0 ± 0%      16.0 ± 0%   -5.88%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=1,key-types=points-only-10              2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=1,key-types=points-and-ranges-10        8.00 ± 0%      7.00 ± 0%  -12.50%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=3,key-types=points-only-10              4.00 ± 0%      3.00 ± 0%  -25.00%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=3,key-types=points-and-ranges-10        10.0 ± 0%       9.0 ± 0%  -10.00%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=7,key-types=points-only-10              8.00 ± 0%      7.00 ± 0%  -12.50%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=7,key-types=points-and-ranges-10        14.0 ± 0%      13.0 ± 0%   -7.14%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=10,key-types=points-only-10             11.0 ± 0%      10.0 ± 0%   -9.09%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=10,key-types=points-and-ranges-10       17.0 ± 0%      16.0 ± 0%   -5.88%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=1,key-types=points-only-10             2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=1,key-types=points-and-ranges-10       8.00 ± 0%      7.00 ± 0%  -12.50%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=3,key-types=points-only-10             4.00 ± 0%      3.00 ± 0%  -25.00%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=3,key-types=points-and-ranges-10       10.0 ± 0%       9.0 ± 0%  -10.00%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=7,key-types=points-only-10             8.00 ± 0%      7.00 ± 0%  -12.50%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=7,key-types=points-and-ranges-10       14.0 ± 0%      13.0 ± 0%   -7.14%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=10,key-types=points-only-10            11.0 ± 0%      10.0 ± 0%   -9.09%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=10,key-types=points-and-ranges-10      17.0 ± 0%      16.0 ± 0%   -5.88%  (p=0.008 n=5+5)
```

Informs #1679.

