### PR TITLE
*: Add IterOption to optionally read L6 filter blocks.

### DIFF
--- a/level_iter.go
+++ b/level_iter.go
@@ -189,6 +189,8 @@ func (l *levelIter) init(
 	l.upper = opts.UpperBound
 	l.tableOpts.TableFilter = opts.TableFilter
 	l.tableOpts.PointKeyFilters = opts.PointKeyFilters
+	l.tableOpts.UseL6Filters = opts.UseL6Filters
+	l.tableOpts.level = l.level
 	l.cmp = cmp
 	l.split = split
 	l.iterFile = nil

--- a/options.go
+++ b/options.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/humanize"
+	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -139,8 +140,19 @@ type IterOptions struct {
 	// weight than creating an iterator, so we have opted to support this
 	// iterator option.
 	OnlyReadGuaranteedDurable bool
+	// UseL6Filters allows the caller to opt into reading filter blocks for L6
+	// sstables. Helpful if a lot of SeekPrefixGEs are expected in quick
+	// succession, that are also likely to not yield a single key. Filter blocks in
+	// L6 can be relatively large, often larger than data blocks, so the benefit of
+	// loading them in the cache is minimized if the probability of the key
+	// existing is not low or if we just expect a one-time Seek (where loading the
+	// data block directly is better).
+	UseL6Filters bool
 	// Internal options.
 	logger Logger
+	// Level corresponding to this file. Only passed in if constructed by a
+	// levelIter.
+	level manifest.Level
 
 	// NB: If adding new Options, you must account for them in iterator
 	// construction and Iterator.SetOptions.

--- a/table_cache.go
+++ b/table_cache.go
@@ -364,11 +364,15 @@ func (c *tableCacheShard) newIters(
 	}
 
 	var iter sstable.Iterator
+	useFilter := true
+	if opts != nil {
+		useFilter = manifest.LevelToInt(opts.level) != 6 || opts.UseL6Filters
+	}
 	if bytesIterated != nil {
 		iter, err = v.reader.NewCompactionIter(bytesIterated)
 	} else {
 		iter, err = v.reader.NewIterWithBlockPropertyFilters(
-			opts.GetLowerBound(), opts.GetUpperBound(), filterer)
+			opts.GetLowerBound(), opts.GetUpperBound(), filterer, useFilter)
 	}
 	if err != nil {
 		c.unrefValue(v)


### PR DESCRIPTION
This change adds an IterOption, defaulting to false,
that lets the caller opt into reading L6 filter blocks
if they exist on the sstable. Adding this option
allows for a low-risk, low-behaviour-change enabling
of always writing filter blocks to L6 sstables, as we
will not be reading them by default.

Necessary to unblock cockroachdb/cockroach#80980 .