### PR TITLE
internal/keyspan: lift visibility filtering out of Seek{GE,LE}

### DIFF
--- a/internal/keyspan/seek.go
+++ b/internal/keyspan/seek.go
@@ -6,13 +6,9 @@ package keyspan
 
 import "github.com/cockroachdb/pebble/internal/base"
 
-// TODO(jackson): Move snapshot visiblity outside of SeekGE/SeekLE and into the
-// callsite. This should simplify the code some more.
-
 // SeekGE seeks to the span that contains the target key or the first span past
-// the target key. The snapshot parameter controls the visibility of keys (only
-// spans older than the snapshot sequence number are visible).
-func SeekGE(cmp base.Compare, iter FragmentIterator, key []byte, snapshot uint64) Span {
+// the target key.
+func SeekGE(cmp base.Compare, iter FragmentIterator, key []byte) Span {
 	// NB: We use SeekLT in order to land on the proper span for a search
 	// key that resides in the middle of a span. Consider the scenario:
 	//
@@ -35,21 +31,11 @@ func SeekGE(cmp base.Compare, iter FragmentIterator, key []byte, snapshot uint64
 		// guaranteed to lie at or past the search key.
 		iterSpan = iter.Next()
 	}
-	// The iterator is positioned at a valid iterSpan which is the first
-	// iterator position that satisfies the requirement that it contains or is
-	// past the target key. It may not be visible based on the snapshot. So now
-	// we only need to move forward and return the first span with visible keys.
-	iterSpan = iterSpan.Visible(snapshot)
-	for iterSpan.Valid() && iterSpan.Empty() {
-		iterSpan = iter.Next().Visible(snapshot)
-	}
 	return iterSpan
 }
 
-// SeekLE seeks to the span that contains or is before the target key.  The
-// snapshot parameter controls the visibility of keys (only spans older than the
-// snapshot sequence number are visible).
-func SeekLE(cmp base.Compare, iter FragmentIterator, key []byte, snapshot uint64) Span {
+// SeekLE seeks to the span that contains or is before the target key.
+func SeekLE(cmp base.Compare, iter FragmentIterator, key []byte) Span {
 	// NB: We use SeekLT in order to land on the proper span for a search
 	// key that resides in the middle of a span. Consider the scenario:
 	//
@@ -85,14 +71,6 @@ func SeekLE(cmp base.Compare, iter FragmentIterator, key []byte, snapshot uint64
 				iterSpan = iter.Prev()
 			}
 		}
-	}
-
-	// We're positioned at a span that contains or is before the search key. It
-	// may not be visible based on the snapshot. So now we only need to move
-	// backward and return the first span with visible keys.
-	iterSpan = iterSpan.Visible(snapshot)
-	for iterSpan.Valid() && iterSpan.Empty() {
-		iterSpan = iter.Prev().Visible(snapshot)
 	}
 	return iterSpan
 }

--- a/internal/keyspan/seek_test.go
+++ b/internal/keyspan/seek_test.go
@@ -46,7 +46,10 @@ func TestSeek(t *testing.T) {
 				if err != nil {
 					return err.Error()
 				}
-				span := seek(cmp, iter, []byte(parts[0]), seq)
+				span := seek(cmp, iter, []byte(parts[0]))
+				if span.Valid() {
+					span = span.Visible(seq)
+				}
 				fmt.Fprintln(&buf, span)
 			}
 			return buf.String()

--- a/internal/keyspan/testdata/seek
+++ b/internal/keyspan/testdata/seek
@@ -11,7 +11,7 @@ d 2
 ----
 b-d:{(#1,RANGEDEL)}
 b-d:{(#1,RANGEDEL)}
-<invalid>
+b-d:{}
 <invalid>
 
 seek-le
@@ -22,7 +22,7 @@ d 2
 ----
 <invalid>
 b-d:{(#1,RANGEDEL)}
-<invalid>
+b-d:{}
 b-d:{(#1,RANGEDEL)}
 
 build
@@ -44,7 +44,7 @@ b-d:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
 b-d:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
 b-d:{(#2,RANGEDEL) (#1,RANGEDEL)}
 b-d:{(#1,RANGEDEL)}
-<invalid>
+b-d:{}
 <invalid>
 
 seek-le
@@ -59,7 +59,7 @@ d 4
 b-d:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
 b-d:{(#2,RANGEDEL) (#1,RANGEDEL)}
 b-d:{(#1,RANGEDEL)}
-<invalid>
+b-d:{}
 b-d:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
 
 build
@@ -76,7 +76,7 @@ d 3
 e 3
 ----
 b-d:{(#1,RANGEDEL)}
-<invalid>
+d-f:{}
 d-f:{(#2,RANGEDEL)}
 d-f:{(#2,RANGEDEL)}
 
@@ -90,7 +90,7 @@ f 3
 ----
 <invalid>
 b-d:{(#1,RANGEDEL)}
-b-d:{(#1,RANGEDEL)}
+d-f:{}
 d-f:{(#2,RANGEDEL)}
 d-f:{(#2,RANGEDEL)}
 d-f:{(#2,RANGEDEL)}
@@ -127,22 +127,22 @@ s 1
 z 2
 ----
 a-f:{(#3,RANGEDEL)}
-f-j:{(#2,RANGEDEL)}
-j-m:{(#1,RANGEDEL)}
-<invalid>
+a-f:{}
+a-f:{}
+a-f:{}
 f-j:{(#3,RANGEDEL) (#2,RANGEDEL)}
 f-j:{(#2,RANGEDEL)}
-j-m:{(#1,RANGEDEL)}
-<invalid>
+f-j:{}
+f-j:{}
 j-m:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
 j-m:{(#2,RANGEDEL) (#1,RANGEDEL)}
 j-m:{(#1,RANGEDEL)}
-<invalid>
+j-m:{}
 m-s:{(#2,RANGEDEL) (#1,RANGEDEL)}
 m-s:{(#1,RANGEDEL)}
-<invalid>
+m-s:{}
 s-z:{(#1,RANGEDEL)}
-<invalid>
+s-z:{}
 <invalid>
 
 seek-le
@@ -166,22 +166,22 @@ s 1
 z 2
 ----
 a-f:{(#3,RANGEDEL)}
-<invalid>
-<invalid>
-<invalid>
+a-f:{}
+a-f:{}
+a-f:{}
 f-j:{(#3,RANGEDEL) (#2,RANGEDEL)}
 f-j:{(#2,RANGEDEL)}
-<invalid>
-<invalid>
+f-j:{}
+f-j:{}
 j-m:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
 j-m:{(#2,RANGEDEL) (#1,RANGEDEL)}
 j-m:{(#1,RANGEDEL)}
-<invalid>
+j-m:{}
 m-s:{(#2,RANGEDEL) (#1,RANGEDEL)}
 m-s:{(#1,RANGEDEL)}
-<invalid>
+m-s:{}
 s-z:{(#1,RANGEDEL)}
-<invalid>
+s-z:{}
 s-z:{(#1,RANGEDEL)}
 
 build
@@ -216,22 +216,22 @@ s 1
 z 4
 ----
 a-f:{(#1,RANGEDEL)}
-<invalid>
+a-f:{}
 f-j:{(#2,RANGEDEL) (#1,RANGEDEL)}
 f-j:{(#1,RANGEDEL)}
-<invalid>
+f-j:{}
 j-m:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
 j-m:{(#2,RANGEDEL) (#1,RANGEDEL)}
 j-m:{(#1,RANGEDEL)}
-<invalid>
+j-m:{}
 m-s:{(#3,RANGEDEL) (#2,RANGEDEL)}
 m-s:{(#2,RANGEDEL)}
-<invalid>
-<invalid>
+m-s:{}
+m-s:{}
 s-z:{(#3,RANGEDEL)}
-<invalid>
-<invalid>
-<invalid>
+s-z:{}
+s-z:{}
+s-z:{}
 <invalid>
 
 seek-le
@@ -257,25 +257,25 @@ z 3
 z 2
 ----
 a-f:{(#1,RANGEDEL)}
-<invalid>
+a-f:{}
 f-j:{(#2,RANGEDEL) (#1,RANGEDEL)}
 f-j:{(#1,RANGEDEL)}
-<invalid>
+f-j:{}
 j-m:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
 j-m:{(#2,RANGEDEL) (#1,RANGEDEL)}
 j-m:{(#1,RANGEDEL)}
-<invalid>
+j-m:{}
 m-s:{(#3,RANGEDEL) (#2,RANGEDEL)}
 m-s:{(#2,RANGEDEL)}
-j-m:{(#1,RANGEDEL)}
-<invalid>
+m-s:{}
+m-s:{}
 s-z:{(#3,RANGEDEL)}
-m-s:{(#2,RANGEDEL)}
-j-m:{(#1,RANGEDEL)}
-<invalid>
+s-z:{}
+s-z:{}
+s-z:{}
 s-z:{(#3,RANGEDEL)}
-m-s:{(#2,RANGEDEL)}
-j-m:{(#1,RANGEDEL)}
+s-z:{}
+s-z:{}
 
 build
 1: a-c
@@ -286,11 +286,12 @@ build
 a-c:{(#5,RANGEDEL) (#3,RANGEDEL) (#1,RANGEDEL)}
 c-e:{(#5,RANGEDEL)}
 
-# Regression test for a bug where seek-le was failing to find the most
-# recent version of a tombstone. The problematic case was "seek-le c
-# 4". The seeking code was finding the tombstone c-e#5, determining it
-# wasn't visible and then return the immediately preceding tombstone
-# a-c#1, instead of the correct tombstone a-c#3.
+# Regression test for a bug where seek-le was failing to find the most recent
+# version of a tombstone. The bug existed when seek-{ge,le} performed snapshot
+# filtering, and the problematic case was "seek-le c 4". The seeking code was
+# finding the tombstone c-e#5, determining it wasn't visible and then return the
+# immediately preceding tombstone a-c#1. Now we return c-e:{} immediately,
+# because the span c-e covers c and contains no visible keys.
 
 seek-le
 c 1
@@ -300,9 +301,9 @@ c 4
 c 5
 c 6
 ----
-<invalid>
-a-c:{(#1,RANGEDEL)}
-a-c:{(#1,RANGEDEL)}
-a-c:{(#3,RANGEDEL) (#1,RANGEDEL)}
-a-c:{(#3,RANGEDEL) (#1,RANGEDEL)}
+c-e:{}
+c-e:{}
+c-e:{}
+c-e:{}
+c-e:{}
 c-e:{(#5,RANGEDEL)}

--- a/level_checker.go
+++ b/level_checker.go
@@ -117,7 +117,7 @@ func (m *simpleMergingIter) positionRangeDels() {
 		if l.rangeDelIter == nil {
 			continue
 		}
-		l.tombstone = keyspan.SeekGE(m.heap.cmp, l.rangeDelIter, item.key.UserKey, m.snapshot)
+		l.tombstone = keyspan.SeekGE(m.heap.cmp, l.rangeDelIter, item.key.UserKey).Visible(m.snapshot)
 	}
 }
 

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -356,9 +356,9 @@ func (i *levelIterTestIter) rangeDelSeek(
 	var tombstone keyspan.Span
 	if i.rangeDelIter != nil {
 		if dir < 0 {
-			tombstone = keyspan.SeekLE(i.levelIter.cmp, i.rangeDelIter, key, 1000)
+			tombstone = keyspan.SeekLE(i.levelIter.cmp, i.rangeDelIter, key).Visible(1000)
 		} else {
-			tombstone = keyspan.SeekGE(i.levelIter.cmp, i.rangeDelIter, key, 1000)
+			tombstone = keyspan.SeekGE(i.levelIter.cmp, i.rangeDelIter, key).Visible(1000)
 		}
 	}
 	if ikey == nil {


### PR DESCRIPTION
Alter `keyspan.SeekGE` and `keyspan.SeekLE` to omit any sequence number
filtering. The caller must now filter a Span's keys if necessary. This avoids
extra work in the case that there are no visible keys overlapping the search
key. Previously SeekGE and SeekLE would next or prev until they found a visible
key. Now, the caller can simply use the empty span.

This is partially motivated by the batch range deletion slowdown observed in
#1675.