### PR TITLE
db: reduce allocations in range key iteration

### DIFF
--- a/internal/keyspan/interleaving_iter_test.go
+++ b/internal/keyspan/interleaving_iter_test.go
@@ -90,10 +90,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 			}
 			keyspanIter.Init(cmp, noopTransform, NewIter(cmp, spans))
 			hooks.maskSuffix = nil
-			iter.Init(cmp, base.WrapIterWithStats(&pointIter), &keyspanIter, Hooks{
-				SpanChanged: hooks.SpanChanged,
-				SkipPoint:   hooks.SkipPoint,
-			}, nil, nil)
+			iter.Init(cmp, base.WrapIterWithStats(&pointIter), &keyspanIter, &hooks, nil, nil)
 			return "OK"
 		case "define-pointkeys":
 			var points []base.InternalKey
@@ -103,10 +100,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 			}
 			pointIter = pointIterator{cmp: cmp, keys: points}
 			hooks.maskSuffix = nil
-			iter.Init(cmp, base.WrapIterWithStats(&pointIter), &keyspanIter, Hooks{
-				SpanChanged: hooks.SpanChanged,
-				SkipPoint:   hooks.SkipPoint,
-			}, nil, nil)
+			iter.Init(cmp, base.WrapIterWithStats(&pointIter), &keyspanIter, &hooks, nil, nil)
 			return "OK"
 		case "iter":
 			buf.Reset()

--- a/range_keys.go
+++ b/range_keys.go
@@ -136,8 +136,6 @@ func (d *DB) newRangeKeyIter(
 	if len(frags) > 0 {
 		iters = append(iters, keyspan.NewIter(d.cmp, frags))
 	}
-	it.rangeKey.rangeKeyIter = rangekey.InitUserIteration(
-		d.cmp, seqNum, &it.rangeKey.alloc.merging, &it.rangeKey.alloc.defraging, iters...,
-	)
+	it.rangeKey.rangeKeyIter = it.rangeKey.alloc.Init(d.cmp, seqNum, iters...)
 	return it.rangeKey.rangeKeyIter
 }


### PR DESCRIPTION
Reduce allocations in the range-key iteration stack. Allocations are removed
from the defragmenting method's keys slices and the InterleavingIterator hooks
closures.

Additionally, this commit performs some setup for removing the allocations
produced by constructing closures to serve as `keyspan.Transform` and
`keyspan.DefragmentMethod`. Future work will adapt those two function types
into interfaces to avoid two additional allocations.

Time in scan benchmarks is largely flat.

```
name                                                             old time/op    new time/op    delta
IteratorScan/keys=100,r-amp=1,key-types=points-only-10             5.79µs ± 0%    5.81µs ± 1%     ~     (p=0.190 n=4+5)
IteratorScan/keys=100,r-amp=1,key-types=points-and-ranges-10       9.03µs ± 0%    8.91µs ± 1%   -1.32%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=3,key-types=points-only-10             10.3µs ± 0%    10.4µs ± 1%   +0.77%  (p=0.016 n=5+5)
IteratorScan/keys=100,r-amp=3,key-types=points-and-ranges-10       14.0µs ± 0%    13.9µs ± 1%     ~     (p=0.222 n=5+5)
IteratorScan/keys=100,r-amp=7,key-types=points-only-10             15.6µs ± 0%    15.8µs ± 1%   +1.00%  (p=0.032 n=5+5)
IteratorScan/keys=100,r-amp=7,key-types=points-and-ranges-10       19.0µs ± 0%    19.3µs ± 1%   +1.55%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=10,key-types=points-only-10            18.9µs ± 1%    19.4µs ± 2%   +2.83%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=10,key-types=points-and-ranges-10      22.9µs ± 0%    23.3µs ± 2%   +1.92%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=1,key-types=points-only-10            44.3µs ± 0%    44.6µs ± 2%     ~     (p=0.167 n=5+5)
IteratorScan/keys=1000,r-amp=1,key-types=points-and-ranges-10      70.9µs ± 0%    71.0µs ± 0%   +0.25%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=3,key-types=points-only-10            77.4µs ± 0%    77.7µs ± 0%   +0.46%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=3,key-types=points-and-ranges-10       105µs ± 0%     105µs ± 0%   +0.78%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=7,key-types=points-only-10             104µs ± 0%     105µs ± 1%   +0.84%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=7,key-types=points-and-ranges-10       133µs ± 0%     134µs ± 0%   +1.18%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=10,key-types=points-only-10            119µs ± 0%     119µs ± 0%   +0.53%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=10,key-types=points-and-ranges-10      146µs ± 0%     148µs ± 1%   +1.54%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=1,key-types=points-only-10            418µs ± 1%     418µs ± 1%     ~     (p=1.000 n=5+5)
IteratorScan/keys=10000,r-amp=1,key-types=points-and-ranges-10      662µs ± 1%     667µs ± 1%     ~     (p=0.056 n=5+5)
IteratorScan/keys=10000,r-amp=3,key-types=points-only-10            722µs ± 2%     713µs ± 1%     ~     (p=0.095 n=5+5)
IteratorScan/keys=10000,r-amp=3,key-types=points-and-ranges-10      977µs ± 1%     978µs ± 1%     ~     (p=1.000 n=5+5)
IteratorScan/keys=10000,r-amp=7,key-types=points-only-10            989µs ± 3%     972µs ± 1%     ~     (p=0.548 n=5+5)
IteratorScan/keys=10000,r-amp=7,key-types=points-and-ranges-10     1.24ms ± 2%    1.24ms ± 1%     ~     (p=1.000 n=5+5)
IteratorScan/keys=10000,r-amp=10,key-types=points-only-10          1.09ms ± 1%    1.08ms ± 2%     ~     (p=0.548 n=5+5)
IteratorScan/keys=10000,r-amp=10,key-types=points-and-ranges-10    1.33ms ± 0%    1.34ms ± 2%     ~     (p=1.000 n=5+5)

name                                                             old alloc/op   new alloc/op   delta
IteratorScan/keys=100,r-amp=1,key-types=points-only-10              16.0B ± 0%     16.0B ± 0%     ~     (all equal)
IteratorScan/keys=100,r-amp=1,key-types=points-and-ranges-10         152B ± 0%       48B ± 0%  -68.42%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=3,key-types=points-only-10              48.0B ± 0%     48.0B ± 0%     ~     (all equal)
IteratorScan/keys=100,r-amp=3,key-types=points-and-ranges-10         184B ± 0%       80B ± 0%  -56.52%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=7,key-types=points-only-10               112B ± 0%      112B ± 0%     ~     (all equal)
IteratorScan/keys=100,r-amp=7,key-types=points-and-ranges-10         248B ± 0%      144B ± 0%  -41.94%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=10,key-types=points-only-10              160B ± 0%      160B ± 0%     ~     (all equal)
IteratorScan/keys=100,r-amp=10,key-types=points-and-ranges-10        296B ± 0%      192B ± 0%  -35.14%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=1,key-types=points-only-10             16.0B ± 0%     16.0B ± 0%     ~     (all equal)
IteratorScan/keys=1000,r-amp=1,key-types=points-and-ranges-10        152B ± 0%       48B ± 0%  -68.50%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=3,key-types=points-only-10             48.0B ± 0%     48.0B ± 0%     ~     (all equal)
IteratorScan/keys=1000,r-amp=3,key-types=points-and-ranges-10        185B ± 0%       81B ± 1%  -56.43%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=7,key-types=points-only-10              113B ± 0%      113B ± 0%     ~     (all equal)
IteratorScan/keys=1000,r-amp=7,key-types=points-and-ranges-10        249B ± 0%      145B ± 0%  -41.67%  (p=0.000 n=5+4)
IteratorScan/keys=1000,r-amp=10,key-types=points-only-10             161B ± 0%      161B ± 0%     ~     (all equal)
IteratorScan/keys=1000,r-amp=10,key-types=points-and-ranges-10       297B ± 0%      194B ± 0%  -34.72%  (p=0.000 n=5+4)
IteratorScan/keys=10000,r-amp=1,key-types=points-only-10            18.4B ±13%     17.8B ±12%     ~     (p=1.000 n=5+5)
IteratorScan/keys=10000,r-amp=1,key-types=points-and-ranges-10       156B ± 2%       55B ± 9%  -64.71%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=3,key-types=points-only-10            56.0B ± 0%     51.8B ± 8%     ~     (p=0.167 n=5+5)
IteratorScan/keys=10000,r-amp=3,key-types=points-and-ranges-10       196B ± 0%       89B ± 7%  -54.59%  (p=0.000 n=4+5)
IteratorScan/keys=10000,r-amp=7,key-types=points-only-10             123B ± 0%      121B ± 6%     ~     (p=0.333 n=4+5)
IteratorScan/keys=10000,r-amp=7,key-types=points-and-ranges-10       264B ± 0%      148B ± 0%  -43.94%  (p=0.029 n=4+4)
IteratorScan/keys=10000,r-amp=10,key-types=points-only-10            172B ± 0%      168B ± 4%     ~     (p=0.651 n=4+5)
IteratorScan/keys=10000,r-amp=10,key-types=points-and-ranges-10      314B ± 0%      210B ± 0%  -32.99%  (p=0.000 n=4+5)

name                                                             old allocs/op  new allocs/op  delta
IteratorScan/keys=100,r-amp=1,key-types=points-only-10               1.00 ± 0%      1.00 ± 0%     ~     (all equal)
IteratorScan/keys=100,r-amp=1,key-types=points-and-ranges-10         7.00 ± 0%      3.00 ± 0%  -57.14%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=3,key-types=points-only-10               3.00 ± 0%      3.00 ± 0%     ~     (all equal)
IteratorScan/keys=100,r-amp=3,key-types=points-and-ranges-10         9.00 ± 0%      5.00 ± 0%  -44.44%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=7,key-types=points-only-10               7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IteratorScan/keys=100,r-amp=7,key-types=points-and-ranges-10         13.0 ± 0%       9.0 ± 0%  -30.77%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=10,key-types=points-only-10              10.0 ± 0%      10.0 ± 0%     ~     (all equal)
IteratorScan/keys=100,r-amp=10,key-types=points-and-ranges-10        16.0 ± 0%      12.0 ± 0%  -25.00%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=1,key-types=points-only-10              1.00 ± 0%      1.00 ± 0%     ~     (all equal)
IteratorScan/keys=1000,r-amp=1,key-types=points-and-ranges-10        7.00 ± 0%      3.00 ± 0%  -57.14%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=3,key-types=points-only-10              3.00 ± 0%      3.00 ± 0%     ~     (all equal)
IteratorScan/keys=1000,r-amp=3,key-types=points-and-ranges-10        9.00 ± 0%      5.00 ± 0%  -44.44%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=7,key-types=points-only-10              7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IteratorScan/keys=1000,r-amp=7,key-types=points-and-ranges-10        13.0 ± 0%       9.0 ± 0%  -30.77%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=10,key-types=points-only-10             10.0 ± 0%      10.0 ± 0%     ~     (all equal)
IteratorScan/keys=1000,r-amp=10,key-types=points-and-ranges-10       16.0 ± 0%      12.0 ± 0%  -25.00%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=1,key-types=points-only-10             1.00 ± 0%      1.00 ± 0%     ~     (all equal)
IteratorScan/keys=10000,r-amp=1,key-types=points-and-ranges-10       7.00 ± 0%      3.00 ± 0%  -57.14%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=3,key-types=points-only-10             3.00 ± 0%      3.00 ± 0%     ~     (all equal)
IteratorScan/keys=10000,r-amp=3,key-types=points-and-ranges-10       9.00 ± 0%      5.00 ± 0%  -44.44%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=7,key-types=points-only-10             7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IteratorScan/keys=10000,r-amp=7,key-types=points-and-ranges-10       13.0 ± 0%       9.0 ± 0%  -30.77%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=10,key-types=points-only-10            10.0 ± 0%      10.0 ± 0%     ~     (all equal)
IteratorScan/keys=10000,r-amp=10,key-types=points-and-ranges-10      16.0 ± 0%      12.0 ± 0%  -25.00%  (p=0.008 n=5+5)
```