### PR TITLE
internal/rangekey: reduce range-key iteration allocations

### DIFF
--- a/internal/keyspan/defragment_test.go
+++ b/internal/keyspan/defragment_test.go
@@ -23,7 +23,7 @@ import (
 func TestDefragmentingIter(t *testing.T) {
 	cmp := testkeys.Comparer.Compare
 	internalEqual := DefragmentInternal
-	alwaysEqual := func(_ base.Compare, _, _ Span) bool { return true }
+	alwaysEqual := DefragmentMethodFunc(func(_ base.Compare, _, _ Span) bool { return true })
 	staticReducer := StaticDefragmentReducer
 	collectReducer := func(cur, next []Key) []Key {
 		c := keysBySeqNumKind(append(cur, next...))

--- a/internal/rangekey/coalesce_test.go
+++ b/internal/rangekey/coalesce_test.go
@@ -66,10 +66,10 @@ func TestIter(t *testing.T) {
 			for _, line := range lines {
 				spans = append(spans, keyspan.ParseSpan(line))
 			}
-			transform := func(cmp base.Compare, s keyspan.Span, dst *keyspan.Span) error {
+			transform := keyspan.TransformerFunc(func(cmp base.Compare, s keyspan.Span, dst *keyspan.Span) error {
 				s = s.Visible(visibleSeqNum)
 				return Coalesce(cmp, s, dst)
-			}
+			})
 			iter.Init(cmp, transform, keyspan.NewIter(cmp, spans))
 			return "OK"
 		case "iter":

--- a/table_stats.go
+++ b/table_stats.go
@@ -458,7 +458,9 @@ func foreachDefragmentedTombstone(
 	fn func([]byte, []byte, uint64, uint64) error,
 ) error {
 	// Use an equals func that will always merge abutting spans.
-	equal := func(_ base.Compare, _, _ keyspan.Span) bool { return true }
+	equal := keyspan.DefragmentMethodFunc(func(_ base.Compare, _, _ keyspan.Span) bool {
+		return true
+	})
 	// Reduce keys by maintaining a slice of length two, corresponding to the
 	// largest and smallest keys in the defragmented span. This maintains the
 	// contract that the emitted slice is sorted by (SeqNum, Kind) descending.


### PR DESCRIPTION
Remove the two remaining excess allocations incured when iterating with range
keys enabled, in the absence of any committed range keys. This brings the
number of allocations to parity with iteration with points only.

The two removed allocations stemmed from use of closures constructed at
iteration construction. These closures have been replaced with interfaces.

```
name                                                             old time/op    new time/op    delta
IteratorScan/keys=100,r-amp=1,key-types=points-only-10             5.76µs ± 0%    5.87µs ± 0%   +1.86%  (p=0.000 n=8+8)
IteratorScan/keys=100,r-amp=1,key-types=points-and-ranges-10       8.81µs ± 2%    8.81µs ± 3%     ~     (p=0.684 n=10+10)
IteratorScan/keys=100,r-amp=3,key-types=points-only-10             10.1µs ± 2%    10.4µs ± 3%     ~     (p=0.063 n=10+10)
IteratorScan/keys=100,r-amp=3,key-types=points-and-ranges-10       13.4µs ± 3%    13.8µs ± 1%   +2.83%  (p=0.022 n=10+9)
IteratorScan/keys=100,r-amp=7,key-types=points-only-10             15.5µs ± 0%    15.7µs ± 2%   +1.41%  (p=0.028 n=9+10)
IteratorScan/keys=100,r-amp=7,key-types=points-and-ranges-10       18.8µs ± 1%    19.0µs ± 2%     ~     (p=0.123 n=10+10)
IteratorScan/keys=100,r-amp=10,key-types=points-only-10            19.0µs ± 1%    19.2µs ± 1%     ~     (p=0.146 n=10+8)
IteratorScan/keys=100,r-amp=10,key-types=points-and-ranges-10      22.7µs ± 2%    22.9µs ± 2%   +0.99%  (p=0.011 n=10+10)
IteratorScan/keys=1000,r-amp=1,key-types=points-only-10            44.5µs ± 0%    44.8µs ± 1%   +0.60%  (p=0.002 n=10+9)
IteratorScan/keys=1000,r-amp=1,key-types=points-and-ranges-10      71.8µs ± 0%    71.5µs ± 3%     ~     (p=0.052 n=10+10)
IteratorScan/keys=1000,r-amp=3,key-types=points-only-10            77.4µs ± 1%    77.4µs ± 0%     ~     (p=0.633 n=10+8)
IteratorScan/keys=1000,r-amp=3,key-types=points-and-ranges-10       104µs ± 0%     104µs ± 1%   -0.43%  (p=0.023 n=10+10)
IteratorScan/keys=1000,r-amp=7,key-types=points-only-10             104µs ± 1%     104µs ± 1%     ~     (p=0.393 n=10+10)
IteratorScan/keys=1000,r-amp=7,key-types=points-and-ranges-10       132µs ± 1%     133µs ± 0%     ~     (p=0.063 n=10+10)
IteratorScan/keys=1000,r-amp=10,key-types=points-only-10            118µs ± 1%     118µs ± 1%     ~     (p=0.853 n=10+10)
IteratorScan/keys=1000,r-amp=10,key-types=points-and-ranges-10      145µs ± 0%     145µs ± 1%     ~     (p=0.579 n=10+10)
IteratorScan/keys=10000,r-amp=1,key-types=points-only-10            417µs ± 0%     418µs ± 0%     ~     (p=0.113 n=10+9)
IteratorScan/keys=10000,r-amp=1,key-types=points-and-ranges-10      671µs ± 0%     667µs ± 2%   -0.54%  (p=0.043 n=10+10)
IteratorScan/keys=10000,r-amp=3,key-types=points-only-10            708µs ± 2%     719µs ± 1%   +1.54%  (p=0.004 n=10+9)
IteratorScan/keys=10000,r-amp=3,key-types=points-and-ranges-10      971µs ± 1%     973µs ± 2%     ~     (p=0.739 n=10+10)
IteratorScan/keys=10000,r-amp=7,key-types=points-only-10            948µs ± 1%     965µs ± 3%   +1.82%  (p=0.004 n=10+10)
IteratorScan/keys=10000,r-amp=7,key-types=points-and-ranges-10     1.20ms ± 1%    1.22ms ± 1%   +1.22%  (p=0.004 n=10+10)
IteratorScan/keys=10000,r-amp=10,key-types=points-only-10          1.05ms ± 1%    1.07ms ± 1%   +1.86%  (p=0.000 n=10+10)
IteratorScan/keys=10000,r-amp=10,key-types=points-and-ranges-10    1.31ms ± 1%    1.32ms ± 1%   +1.17%  (p=0.000 n=10+9)

name                                                             old alloc/op   new alloc/op   delta
IteratorScan/keys=100,r-amp=1,key-types=points-only-10              16.0B ± 0%     16.0B ± 0%     ~     (all equal)
IteratorScan/keys=100,r-amp=1,key-types=points-and-ranges-10        48.0B ± 0%     16.0B ± 0%  -66.67%  (p=0.000 n=10+10)
IteratorScan/keys=100,r-amp=3,key-types=points-only-10              48.0B ± 0%     48.0B ± 0%     ~     (all equal)
IteratorScan/keys=100,r-amp=3,key-types=points-and-ranges-10        80.0B ± 0%     48.0B ± 0%  -40.00%  (p=0.000 n=10+10)
IteratorScan/keys=100,r-amp=7,key-types=points-only-10               112B ± 0%      112B ± 0%     ~     (all equal)
IteratorScan/keys=100,r-amp=7,key-types=points-and-ranges-10         144B ± 0%      112B ± 0%  -22.22%  (p=0.000 n=10+10)
IteratorScan/keys=100,r-amp=10,key-types=points-only-10              160B ± 0%      160B ± 0%     ~     (all equal)
IteratorScan/keys=100,r-amp=10,key-types=points-and-ranges-10        192B ± 0%      160B ± 0%  -16.67%  (p=0.000 n=10+10)
IteratorScan/keys=1000,r-amp=1,key-types=points-only-10             16.0B ± 0%     16.0B ± 0%     ~     (all equal)
IteratorScan/keys=1000,r-amp=1,key-types=points-and-ranges-10       48.0B ± 0%     16.0B ± 0%  -66.67%  (p=0.000 n=9+9)
IteratorScan/keys=1000,r-amp=3,key-types=points-only-10             48.0B ± 0%     48.0B ± 0%     ~     (all equal)
IteratorScan/keys=1000,r-amp=3,key-types=points-and-ranges-10       81.0B ± 0%     48.6B ± 1%  -40.00%  (p=0.000 n=8+10)
IteratorScan/keys=1000,r-amp=7,key-types=points-only-10              113B ± 0%      113B ± 0%     ~     (all equal)
IteratorScan/keys=1000,r-amp=7,key-types=points-and-ranges-10        145B ± 0%      113B ± 0%  -21.91%  (p=0.000 n=10+10)
IteratorScan/keys=1000,r-amp=10,key-types=points-only-10             161B ± 0%      161B ± 0%     ~     (all equal)
IteratorScan/keys=1000,r-amp=10,key-types=points-and-ranges-10       194B ± 0%      162B ± 0%  -16.49%  (p=0.000 n=9+8)
IteratorScan/keys=10000,r-amp=1,key-types=points-only-10            18.8B ±15%     18.8B ±15%     ~     (p=1.000 n=10+10)
IteratorScan/keys=10000,r-amp=1,key-types=points-and-ranges-10      54.3B ± 8%     24.0B ± 0%  -55.80%  (p=0.000 n=10+6)
IteratorScan/keys=10000,r-amp=3,key-types=points-only-10            53.0B ± 8%     53.8B ± 9%     ~     (p=0.577 n=10+10)
IteratorScan/keys=10000,r-amp=3,key-types=points-and-ranges-10      88.8B ± 7%     60.4B ± 1%  -31.95%  (p=0.000 n=10+7)
IteratorScan/keys=10000,r-amp=7,key-types=points-only-10             122B ± 0%      122B ± 0%     ~     (p=0.082 n=9+9)
IteratorScan/keys=10000,r-amp=7,key-types=points-and-ranges-10       160B ± 0%      123B ± 6%  -23.00%  (p=0.000 n=9+10)
IteratorScan/keys=10000,r-amp=10,key-types=points-only-10            169B ± 4%      172B ± 0%     ~     (p=0.294 n=10+8)
IteratorScan/keys=10000,r-amp=10,key-types=points-and-ranges-10      206B ± 5%      178B ± 0%  -13.51%  (p=0.000 n=10+8)

name                                                             old allocs/op  new allocs/op  delta
IteratorScan/keys=100,r-amp=1,key-types=points-only-10               1.00 ± 0%      1.00 ± 0%     ~     (all equal)
IteratorScan/keys=100,r-amp=1,key-types=points-and-ranges-10         3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=10+10)
IteratorScan/keys=100,r-amp=3,key-types=points-only-10               3.00 ± 0%      3.00 ± 0%     ~     (all equal)
IteratorScan/keys=100,r-amp=3,key-types=points-and-ranges-10         5.00 ± 0%      3.00 ± 0%  -40.00%  (p=0.000 n=10+10)
IteratorScan/keys=100,r-amp=7,key-types=points-only-10               7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IteratorScan/keys=100,r-amp=7,key-types=points-and-ranges-10         9.00 ± 0%      7.00 ± 0%  -22.22%  (p=0.000 n=10+10)
IteratorScan/keys=100,r-amp=10,key-types=points-only-10              10.0 ± 0%      10.0 ± 0%     ~     (all equal)
IteratorScan/keys=100,r-amp=10,key-types=points-and-ranges-10        12.0 ± 0%      10.0 ± 0%  -16.67%  (p=0.000 n=10+10)
IteratorScan/keys=1000,r-amp=1,key-types=points-only-10              1.00 ± 0%      1.00 ± 0%     ~     (all equal)
IteratorScan/keys=1000,r-amp=1,key-types=points-and-ranges-10        3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=10+10)
IteratorScan/keys=1000,r-amp=3,key-types=points-only-10              3.00 ± 0%      3.00 ± 0%     ~     (all equal)
IteratorScan/keys=1000,r-amp=3,key-types=points-and-ranges-10        5.00 ± 0%      3.00 ± 0%  -40.00%  (p=0.000 n=10+10)
IteratorScan/keys=1000,r-amp=7,key-types=points-only-10              7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IteratorScan/keys=1000,r-amp=7,key-types=points-and-ranges-10        9.00 ± 0%      7.00 ± 0%  -22.22%  (p=0.000 n=10+10)
IteratorScan/keys=1000,r-amp=10,key-types=points-only-10             10.0 ± 0%      10.0 ± 0%     ~     (all equal)
IteratorScan/keys=1000,r-amp=10,key-types=points-and-ranges-10       12.0 ± 0%      10.0 ± 0%  -16.67%  (p=0.000 n=10+10)
IteratorScan/keys=10000,r-amp=1,key-types=points-only-10             1.00 ± 0%      1.00 ± 0%     ~     (all equal)
IteratorScan/keys=10000,r-amp=1,key-types=points-and-ranges-10       3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=10+10)
IteratorScan/keys=10000,r-amp=3,key-types=points-only-10             3.00 ± 0%      3.00 ± 0%     ~     (all equal)
IteratorScan/keys=10000,r-amp=3,key-types=points-and-ranges-10       5.00 ± 0%      3.00 ± 0%  -40.00%  (p=0.000 n=10+10)
IteratorScan/keys=10000,r-amp=7,key-types=points-only-10             7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IteratorScan/keys=10000,r-amp=7,key-types=points-and-ranges-10       9.00 ± 0%      7.00 ± 0%  -22.22%  (p=0.000 n=10+10)
IteratorScan/keys=10000,r-amp=10,key-types=points-only-10            10.0 ± 0%      10.0 ± 0%     ~     (all equal)
IteratorScan/keys=10000,r-amp=10,key-types=points-and-ranges-10      12.0 ± 0%      10.0 ± 0%  -16.67%  (p=0.000 n=10+10)
```