### PR TITLE
internal/keyspan: add small performance improvements

### DIFF
--- a/internal/keyspan/interleaving_iter.go
+++ b/internal/keyspan/interleaving_iter.go
@@ -8,10 +8,8 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/invariants"
 )
-
-// TODO(jackson): The interleaving iterator has various invariants that it
-// asserts. We should eventually gate these behind `invariants.Enabled`.
 
 // A Hooks configures the interleaving iterator's behavior.
 type Hooks interface {
@@ -392,22 +390,24 @@ func (i *InterleavingIter) interleaveForward(lowerBound []byte) (*base.InternalK
 	// the next key.
 	for {
 		// Check invariants.
-		// INVARIANT: !pointKeyInterleaved
-		if i.pointKeyInterleaved {
-			panic("pebble: invariant violation: point key interleaved")
-		}
-		switch {
-		case !i.span.Valid():
-		case i.pointKey == nil:
-		default:
-			// INVARIANT: !keyspanInterleaved || pointKey < span.End
-			// The caller is responsible for advancing this span if it's already
-			// been interleaved and the span ends before the point key.
-			// Absolute positioning methods will never have already interleaved
-			// the span's start key, so only Next needs to handle the case where
-			// pointKey >= span.End.
-			if i.keyspanInterleaved && i.cmp(i.pointKey.UserKey, i.span.End) >= 0 {
-				panic("pebble: invariant violation: span interleaved, but point key >= span end")
+		if invariants.Enabled {
+			// INVARIANT: !pointKeyInterleaved
+			if i.pointKeyInterleaved {
+				panic("pebble: invariant violation: point key interleaved")
+			}
+			switch {
+			case !i.span.Valid():
+			case i.pointKey == nil:
+			default:
+				// INVARIANT: !keyspanInterleaved || pointKey < span.End
+				// The caller is responsible for advancing this span if it's already
+				// been interleaved and the span ends before the point key.
+				// Absolute positioning methods will never have already interleaved
+				// the span's start key, so only Next needs to handle the case where
+				// pointKey >= span.End.
+				if i.keyspanInterleaved && i.cmp(i.pointKey.UserKey, i.span.End) >= 0 {
+					panic("pebble: invariant violation: span interleaved, but point key >= span end")
+				}
 			}
 		}
 
@@ -501,9 +501,11 @@ func (i *InterleavingIter) interleaveBackward() (*base.InternalKey, []byte) {
 	// the next key.
 	for {
 		// Check invariants.
-		// INVARIANT: !pointKeyInterleaved
-		if i.pointKeyInterleaved {
-			panic("pebble: invariant violation: point key interleaved")
+		if invariants.Enabled {
+			// INVARIANT: !pointKeyInterleaved
+			if i.pointKeyInterleaved {
+				panic("pebble: invariant violation: point key interleaved")
+			}
 		}
 
 		// Interleave.
@@ -689,34 +691,33 @@ func (i *InterleavingIter) yieldSyntheticSpanMarker(lowerBound []byte) (*base.In
 }
 
 func (i *InterleavingIter) verify(k *base.InternalKey, v []byte) (*base.InternalKey, []byte) {
-	// TODO(jackson): Wrap the entire body of this function in an
-	// invariants.Enabled conditional, so that in production builds this
-	// function is empty and may be inlined away.
-
-	switch {
-	case k != nil && !i.keyspanInterleaved && !i.pointKeyInterleaved:
-		panic("pebble: invariant violation: both keys marked as noninterleaved")
-	case i.dir == -1 && k != nil && i.keyspanInterleaved == i.pointKeyInterleaved:
-		// During reverse iteration, if we're returning a key, either the span's
-		// start key must have been interleaved OR the current point key value
-		// is being returned, not both.
-		//
-		// This invariant holds because in reverse iteration the start key of the
-		// span behaves like a point. Once the start key is interleaved, we move
-		// the keyspan iterator to the previous span.
-		panic(fmt.Sprintf("pebble: invariant violation: interleaving (point %t, span %t)",
-			i.pointKeyInterleaved, i.keyspanInterleaved))
-	case i.dir == -1 && i.spanMarkerTruncated:
-		panic("pebble: invariant violation: truncated span key in reverse iteration")
-	case k != nil && i.lower != nil && i.cmp(k.UserKey, i.lower) < 0:
-		panic("pebble: invariant violation: key < lower bound")
-	case k != nil && i.upper != nil && i.cmp(k.UserKey, i.upper) >= 0:
-		panic("pebble: invariant violation: key ≥ upper bound")
-	case i.span.Valid() && k != nil && i.hooks != nil && i.pointKeyInterleaved &&
-		i.cmp(k.UserKey, i.spanStart) >= 0 && i.cmp(k.UserKey, i.spanEnd) < 0 && i.hooks.SkipPoint(k.UserKey):
-		panic("pebble: invariant violation: point key eligible for skipping returned")
+	// Wrap the entire function body in the invariants build tag, so that
+	// production builds elide this entire function.
+	if invariants.Enabled {
+		switch {
+		case k != nil && !i.keyspanInterleaved && !i.pointKeyInterleaved:
+			panic("pebble: invariant violation: both keys marked as noninterleaved")
+		case i.dir == -1 && k != nil && i.keyspanInterleaved == i.pointKeyInterleaved:
+			// During reverse iteration, if we're returning a key, either the span's
+			// start key must have been interleaved OR the current point key value
+			// is being returned, not both.
+			//
+			// This invariant holds because in reverse iteration the start key of the
+			// span behaves like a point. Once the start key is interleaved, we move
+			// the keyspan iterator to the previous span.
+			panic(fmt.Sprintf("pebble: invariant violation: interleaving (point %t, span %t)",
+				i.pointKeyInterleaved, i.keyspanInterleaved))
+		case i.dir == -1 && i.spanMarkerTruncated:
+			panic("pebble: invariant violation: truncated span key in reverse iteration")
+		case k != nil && i.lower != nil && i.cmp(k.UserKey, i.lower) < 0:
+			panic("pebble: invariant violation: key < lower bound")
+		case k != nil && i.upper != nil && i.cmp(k.UserKey, i.upper) >= 0:
+			panic("pebble: invariant violation: key ≥ upper bound")
+		case i.span.Valid() && k != nil && i.hooks != nil && i.pointKeyInterleaved &&
+			i.cmp(k.UserKey, i.spanStart) >= 0 && i.cmp(k.UserKey, i.spanEnd) < 0 && i.hooks.SkipPoint(k.UserKey):
+			panic("pebble: invariant violation: point key eligible for skipping returned")
+		}
 	}
-
 	return k, v
 }
 

--- a/internal/keyspan/span.go
+++ b/internal/keyspan/span.go
@@ -66,7 +66,7 @@ func (k Key) Kind() base.InternalKeyKind {
 }
 
 // Valid returns true if the span is defined.
-func (s Span) Valid() bool {
+func (s *Span) Valid() bool {
 	return s.Start != nil && s.End != nil
 }
 
@@ -75,13 +75,13 @@ func (s Span) Valid() bool {
 //
 // An Empty span may be produced by Visible, or be produced by iterators in
 // order to surface the gaps between keys.
-func (s Span) Empty() bool {
+func (s *Span) Empty() bool {
 	return len(s.Keys) == 0
 }
 
 // SmallestKey returns the smallest internal key defined by the span's keys.
 // It panics if the span contains no keys.
-func (s Span) SmallestKey() base.InternalKey {
+func (s *Span) SmallestKey() base.InternalKey {
 	if len(s.Keys) == 0 {
 		panic("pebble: Span contains no keys")
 	}
@@ -99,7 +99,7 @@ func (s Span) SmallestKey() base.InternalKey {
 // user key sort after the sentinel key.
 //
 // It panics if the span contains no keys.
-func (s Span) LargestKey() base.InternalKey {
+func (s *Span) LargestKey() base.InternalKey {
 	if len(s.Keys) == 0 {
 		panic("pebble: Span contains no keys")
 	}
@@ -110,7 +110,7 @@ func (s Span) LargestKey() base.InternalKey {
 
 // SmallestSeqNum returns the smallest sequence number of a key contained within
 // the span. It panics if the span contains no keys.
-func (s Span) SmallestSeqNum() uint64 {
+func (s *Span) SmallestSeqNum() uint64 {
 	if len(s.Keys) == 0 {
 		panic("pebble: Span contains no keys")
 	}
@@ -119,7 +119,7 @@ func (s Span) SmallestSeqNum() uint64 {
 
 // LargestSeqNum returns the largest sequence number of a key contained within
 // the span. It panics if the span contains no keys.
-func (s Span) LargestSeqNum() uint64 {
+func (s *Span) LargestSeqNum() uint64 {
 	if len(s.Keys) == 0 {
 		panic("pebble: Span contains no keys")
 	}
@@ -203,7 +203,7 @@ func (s Span) Visible(snapshot uint64) Span {
 
 // ShallowClone returns the span with a Keys slice owned by the span itself.
 // None of the key byte slices are cloned (see Span.DeepClone).
-func (s Span) ShallowClone() Span {
+func (s *Span) ShallowClone() Span {
 	c := Span{
 		Start: s.Start,
 		End:   s.End,
@@ -216,7 +216,7 @@ func (s Span) ShallowClone() Span {
 // DeepClone clones the span, creating copies of all contained slices. DeepClone
 // is intended for non-production code paths like tests, the level checker, etc
 // because it is allocation heavy.
-func (s Span) DeepClone() Span {
+func (s *Span) DeepClone() Span {
 	c := Span{
 		Start: make([]byte, len(s.Start)),
 		End:   make([]byte, len(s.End)),
@@ -239,7 +239,7 @@ func (s Span) DeepClone() Span {
 }
 
 // Contains returns true if the specified key resides within the span's bounds.
-func (s Span) Contains(cmp base.Compare, key []byte) bool {
+func (s *Span) Contains(cmp base.Compare, key []byte) bool {
 	return cmp(s.Start, key) <= 0 && cmp(key, s.End) < 0
 }
 


### PR DESCRIPTION
**internal/keyspan: gate invariant checks behind build tag**

Gate invariant checks within the InterleavingIter behind a build tag.

**internal/keyspan: use pointer receiver for most Span methods**

Calls into Span methods in hot paths (especially `Span.Valid()`) were prominent
in CPU profiles. Using pointer receivers reduces the amount of memcpy-ing, and
allows the compiler to inline.

----

```
name                                                            old time/op  new time/op  delta
IteratorScan/keys=100,r-amp=1,key-types=points-only-10          5.87µs ± 0%  5.85µs ± 0%   -0.24%  (p=0.007 n=8+9)
IteratorScan/keys=100,r-amp=1,key-types=points-and-ranges-10    8.81µs ± 3%  7.55µs ± 0%  -14.37%  (p=0.000 n=10+8)
IteratorScan/keys=100,r-amp=3,key-types=points-only-10          10.4µs ± 3%  10.4µs ± 0%     ~     (p=1.000 n=10+10)
IteratorScan/keys=100,r-amp=3,key-types=points-and-ranges-10    13.8µs ± 1%  12.3µs ± 0%  -10.70%  (p=0.000 n=9+10)
IteratorScan/keys=100,r-amp=7,key-types=points-only-10          15.7µs ± 2%  15.5µs ± 1%     ~     (p=0.060 n=10+10)
IteratorScan/keys=100,r-amp=7,key-types=points-and-ranges-10    19.0µs ± 2%  17.4µs ± 0%   -8.44%  (p=0.000 n=10+9)
IteratorScan/keys=100,r-amp=10,key-types=points-only-10         19.2µs ± 1%  18.9µs ± 0%   -1.30%  (p=0.000 n=8+10)
IteratorScan/keys=100,r-amp=10,key-types=points-and-ranges-10   22.9µs ± 2%  21.0µs ± 0%   -8.21%  (p=0.000 n=10+10)
IteratorScan/keys=1000,r-amp=1,key-types=points-only-10         44.8µs ± 1%  44.3µs ± 0%   -0.96%  (p=0.000 n=9+9)
IteratorScan/keys=1000,r-amp=1,key-types=points-and-ranges-10   71.5µs ± 3%  59.7µs ± 0%  -16.56%  (p=0.000 n=10+10)
IteratorScan/keys=1000,r-amp=3,key-types=points-only-10         77.4µs ± 0%  76.4µs ± 0%   -1.28%  (p=0.000 n=8+10)
IteratorScan/keys=1000,r-amp=3,key-types=points-and-ranges-10    104µs ± 1%    91µs ± 0%  -12.60%  (p=0.000 n=10+8)
IteratorScan/keys=1000,r-amp=7,key-types=points-only-10          104µs ± 1%   104µs ± 0%     ~     (p=0.579 n=10+10)
IteratorScan/keys=1000,r-amp=7,key-types=points-and-ranges-10    133µs ± 0%   119µs ± 1%  -10.50%  (p=0.000 n=10+10)
IteratorScan/keys=1000,r-amp=10,key-types=points-only-10         118µs ± 1%   117µs ± 1%   -0.75%  (p=0.004 n=10+9)
IteratorScan/keys=1000,r-amp=10,key-types=points-and-ranges-10   145µs ± 1%   130µs ± 0%  -10.35%  (p=0.000 n=10+8)
IteratorScan/keys=10000,r-amp=1,key-types=points-only-10         418µs ± 0%   422µs ± 2%     ~     (p=0.063 n=9+9)
IteratorScan/keys=10000,r-amp=1,key-types=points-and-ranges-10   667µs ± 2%   574µs ± 3%  -14.03%  (p=0.000 n=10+9)
IteratorScan/keys=10000,r-amp=3,key-types=points-only-10         719µs ± 1%   715µs ± 2%     ~     (p=0.661 n=9+10)
IteratorScan/keys=10000,r-amp=3,key-types=points-and-ranges-10   973µs ± 2%   846µs ± 1%  -13.12%  (p=0.002 n=10+4)
```