### PR TITLE
tool/logs: minor fixes

### DIFF
--- a/tool/logs/compaction.go
+++ b/tool/logs/compaction.go
@@ -587,7 +587,7 @@ func (s windowSummary) String() string {
 		}
 		sb.WriteString(fmt.Sprintf("total         %19d %7d %7d %7d %7d %7s %9s\n",
 			totalDef, totalMove, totalElision, totalDel, s.eventCount,
-			humanize.Uint64(totalBytes), totalTime.Truncate(time.Minute)))
+			humanize.Uint64(totalBytes), totalTime.Truncate(time.Second)))
 	}
 
 	// (Optional) Long running events.

--- a/tool/logs/compaction.go
+++ b/tool/logs/compaction.go
@@ -610,6 +610,28 @@ func (s windowSummary) String() string {
 	return sb.String()
 }
 
+// windowSummarySlice is a slice of windowSummary that sorts in order of start
+// time, node, then store.
+type windowsSummarySlice []windowSummary
+
+func (s windowsSummarySlice) Len() int {
+	return len(s)
+}
+
+func (s windowsSummarySlice) Less(i, j int) bool {
+	if !s[i].tStart.Equal(s[j].tStart) {
+		return s[i].tStart.Before(s[j].tStart)
+	}
+	if s[i].nodeID != s[j].nodeID {
+		return s[i].nodeID < s[j].nodeID
+	}
+	return s[i].storeID < s[j].storeID
+}
+
+func (s windowsSummarySlice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
 // eventSlice is a slice of events that sorts in order of node, store,
 // then event start time.
 type eventSlice []event
@@ -809,6 +831,10 @@ func (a *aggregator) aggregate() []windowSummary {
 			curWindow.longRunning = append(curWindow.longRunning, e)
 		}
 	}
+
+	// Windows are added in order of (node, store, time). Re-sort the windows by
+	// (time, node, store) for better presentation.
+	sort.Sort(windowsSummarySlice(windows))
 
 	return windows
 }

--- a/tool/logs/compaction.go
+++ b/tool/logs/compaction.go
@@ -545,7 +545,9 @@ func (s windowSummary) String() string {
 				s.flushedTime.Truncate(time.Second))
 		}
 
+		count := s.flushedCount
 		sum := s.flushedBytes
+		totalTime := s.flushedTime
 		for l := 0; l < len(s.ingestedBytes); l++ {
 			if s.ingestedCount[l] == 0 {
 				continue
@@ -553,16 +555,19 @@ func (s windowSummary) String() string {
 			maybeWriteHeader()
 			fmt.Fprintf(&sb, "%-7s         %7s                                   %7d %7s\n",
 				"ingest", fmt.Sprintf("L%d", l), s.ingestedCount[l], humanize.Uint64(s.ingestedBytes[l]))
+			count += s.ingestedCount[l]
 			sum += s.ingestedBytes[l]
 		}
 		if headerWritten {
-			fmt.Fprintf(&sb, "total                                                           %9s\n", humanize.Uint64(sum))
+			fmt.Fprintf(&sb, "total                                                     %7d %7s %9s\n",
+				count, humanize.Uint64(sum), totalTime.Truncate(time.Second),
+			)
 		}
 	}
 
 	// Print compactions statistics.
 	if len(s.compactionCounts) > 0 {
-		sb.WriteString("_kind______from______to___default____move___elide__delete___total___bytes______time\n")
+		sb.WriteString("_kind______from______to___default____move___elide__delete___count___bytes______time\n")
 		var totalDef, totalMove, totalElision, totalDel int
 		var totalBytes uint64
 		var totalTime time.Duration

--- a/tool/logs/testdata/compactions
+++ b/tool/logs/testdata/compactions
@@ -15,7 +15,7 @@ node: 1, store: 1
    from: 211215 00:00
      to: 211215 00:01
   r-amp: NaN
-_kind______from______to___default____move___elide__delete___total___bytes______time
+_kind______from______to___default____move___elide__delete___count___bytes______time
 compact      L2      L3         1       0       0       0       1    13 M       10s
 total                           1       0       0       0       1    13 M       10s
 node: 1, store: 1
@@ -24,7 +24,7 @@ node: 1, store: 1
   r-amp: NaN
 _kind______from______to_____________________________________count___bytes______time
 flush                L0                                         1   1.0 M       10s
-total                                                               1.0 M
+total                                                           1   1.0 M       10s
 
 # Same as the previous case, except that the start and end events are are split
 # across multiple files (one log line per file).
@@ -58,7 +58,7 @@ node: 1, store: 1
    from: 211215 00:00
      to: 211215 00:01
   r-amp: NaN
-_kind______from______to___default____move___elide__delete___total___bytes______time
+_kind______from______to___default____move___elide__delete___count___bytes______time
 compact      L2      L3         1       0       0       0       1    13 M       10s
 total                           1       0       0       0       1    13 M       10s
 node: 1, store: 1
@@ -67,7 +67,7 @@ node: 1, store: 1
   r-amp: NaN
 _kind______from______to_____________________________________count___bytes______time
 flush                L0                                         1   1.0 M       10s
-total                                                               1.0 M
+total                                                           1   1.0 M       10s
 
 # Read amplification from the Cockroach log, one within an existing window,
 # another outside of the existing window. The latter is not included.
@@ -113,7 +113,7 @@ node: 1, store: 1
    from: 211215 00:00
      to: 211215 00:01
   r-amp: 5.0
-_kind______from______to___default____move___elide__delete___total___bytes______time
+_kind______from______to___default____move___elide__delete___count___bytes______time
 compact      L2      L3         1       0       0       0       1    13 M       10s
 total                           1       0       0       0       1    13 M       10s
 
@@ -134,7 +134,7 @@ node: 1, store: 1
    from: 211215 00:01
      to: 211215 00:02
   r-amp: NaN
-_kind______from______to___default____move___elide__delete___total___bytes______time
+_kind______from______to___default____move___elide__delete___count___bytes______time
 compact      L2      L3         1       0       0       0       1    13 M     2m10s
 total                           1       0       0       0       1    13 M     2m10s
 long-running events (descending runtime):
@@ -161,14 +161,14 @@ node: 1, store: 1
    from: 211215 00:01
      to: 211215 00:02
   r-amp: NaN
-_kind______from______to___default____move___elide__delete___total___bytes______time
+_kind______from______to___default____move___elide__delete___count___bytes______time
 compact      L2      L3         1       0       0       0       1    13 M       10s
 total                           1       0       0       0       1    13 M       10s
 node: 1, store: 2
    from: 211215 00:01
      to: 211215 00:02
   r-amp: NaN
-_kind______from______to___default____move___elide__delete___total___bytes______time
+_kind______from______to___default____move___elide__delete___count___bytes______time
 compact      L3      L4         1       0       0       0       1    13 M       10s
 total                           1       0       0       0       1    13 M       10s
 
@@ -195,14 +195,14 @@ node: 1, store: 1
    from: 211215 00:01
      to: 211215 00:02
   r-amp: NaN
-_kind______from______to___default____move___elide__delete___total___bytes______time
+_kind______from______to___default____move___elide__delete___count___bytes______time
 compact      L2      L3         1       0       0       0       1    13 M       10s
 total                           1       0       0       0       1    13 M       10s
 node: 2, store: 1
    from: 211215 00:01
      to: 211215 00:02
   r-amp: NaN
-_kind______from______to___default____move___elide__delete___total___bytes______time
+_kind______from______to___default____move___elide__delete___count___bytes______time
 compact      L3      L4         1       0       0       0       1    13 M       10s
 total                           1       0       0       0       1    13 M       10s
 
@@ -236,28 +236,28 @@ node: 2, store: 1
    from: 211215 00:00
      to: 211215 00:01
   r-amp: NaN
-_kind______from______to___default____move___elide__delete___total___bytes______time
+_kind______from______to___default____move___elide__delete___count___bytes______time
 compact      L3      L4         1       0       0       0       1    13 M       10s
 total                           1       0       0       0       1    13 M       10s
 node: 1, store: 1
    from: 211215 00:01
      to: 211215 00:02
   r-amp: NaN
-_kind______from______to___default____move___elide__delete___total___bytes______time
+_kind______from______to___default____move___elide__delete___count___bytes______time
 compact      L2      L3         1       0       0       0       1    13 M       10s
 total                           1       0       0       0       1    13 M       10s
 node: 1, store: 2
    from: 211215 00:02
      to: 211215 00:03
   r-amp: NaN
-_kind______from______to___default____move___elide__delete___total___bytes______time
+_kind______from______to___default____move___elide__delete___count___bytes______time
 compact      L1      L2         1       0       0       0       1    13 M       10s
 total                           1       0       0       0       1    13 M       10s
 node: 2, store: 2
    from: 211215 00:02
      to: 211215 00:03
   r-amp: NaN
-_kind______from______to___default____move___elide__delete___total___bytes______time
+_kind______from______to___default____move___elide__delete___count___bytes______time
 compact      L4      L5         1       0       0       0       1    13 M       10s
 total                           1       0       0       0       1    13 M       10s
 
@@ -293,7 +293,7 @@ node: ?, store: ?
    from: 211215 00:01
      to: 211215 00:02
   r-amp: 5.0
-_kind______from______to___default____move___elide__delete___total___bytes______time
+_kind______from______to___default____move___elide__delete___count___bytes______time
 compact      L2      L3         1       0       0       0       1    13 M       10s
 total                           1       0       0       0       1    13 M       10s
 
@@ -316,14 +316,14 @@ node: 1, store: 1
    from: 211215 00:01
      to: 211215 00:02
   r-amp: NaN
-_kind______from______to___default____move___elide__delete___total___bytes______time
+_kind______from______to___default____move___elide__delete___count___bytes______time
 compact      L2      L3         1       0       0       0       1    13 M       10s
 total                           1       0       0       0       1    13 M       10s
 node: 2, store: 2
    from: 211215 00:02
      to: 211215 00:03
   r-amp: NaN
-_kind______from______to___default____move___elide__delete___total___bytes______time
+_kind______from______to___default____move___elide__delete___count___bytes______time
 compact      L4      L5         1       0       0       0       1    13 M       10s
 total                           1       0       0       0       1    13 M       10s
 
@@ -372,7 +372,7 @@ node: 1, store: 1
    from: 220301 00:00
      to: 220301 00:01
   r-amp: 1.0
-_kind______from______to___default____move___elide__delete___total___bytes______time
+_kind______from______to___default____move___elide__delete___count___bytes______time
 compact      L2      L3         1       0       0       0       1    13 M       10s
 total                           1       0       0       0       1    13 M       10s
 
@@ -418,7 +418,7 @@ node: 24, store: 24
   r-amp: NaN
 _kind______from______to_____________________________________count___bytes______time
 flush                L0                                         1    19 M        0s
-total                                                                19 M
+total                                                           1    19 M        0s
 
 reset
 ----
@@ -438,11 +438,11 @@ node: 24, store: 24
 _kind______from______to_____________________________________count___bytes______time
 ingest               L0                                         9   140 M
 ingest               L5                                         3   3.0 K
-total                                                               140 M
+total                                                          12   140 M        0s
 node: 24, store: 24
    from: 220228 16:01
      to: 220228 16:02
   r-amp: NaN
 _kind______from______to_____________________________________count___bytes______time
 ingest               L0                                        12   160 M
-total                                                               160 M
+total                                                          12   160 M        0s

--- a/tool/logs/testdata/compactions
+++ b/tool/logs/testdata/compactions
@@ -206,7 +206,8 @@ _kind______from______to___default____move___elide__delete___total___bytes______t
 compact      L3      L4         1       0       0       0       1    13 M       10s
 total                           1       0       0       0       1    13 M       10s
 
-# Multiple nodes, multiple stores. Two separate pebble logs.
+# Multiple nodes, multiple stores. Two separate pebble logs. Output is sorted by
+# (time, node, store).
 
 reset
 ----
@@ -215,8 +216,8 @@ log
 I211215 00:01:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s1] 1216510  [JOB 1] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)
 I211215 00:01:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s1] 1216554  [JOB 1] compacted(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M) -> L3 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
 
-I211215 00:03:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s2] 1216510  [JOB 2] compacting(default) L1 [442555] (4.2 M) + L2 [445853] (8.4 M)
-I211215 00:03:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s2] 1216554  [JOB 2] compacted(default) L1 [442555] (4.2 M) + L2 [445853] (8.4 M) -> L2 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
+I211215 00:02:10.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n1,pebble,s2] 1216510  [JOB 2] compacting(default) L1 [442555] (4.2 M) + L2 [445853] (8.4 M)
+I211215 00:02:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n1,pebble,s2] 1216554  [JOB 2] compacted(default) L1 [442555] (4.2 M) + L2 [445853] (8.4 M) -> L2 [445883 445887] (13 M), in 0.3s, output rate 42 M/s
 ----
 0.log
 
@@ -231,6 +232,13 @@ I211215 00:02:20.000000 51831533 3@vendor/github.com/cockroachdb/pebble/compacti
 
 summarize
 ----
+node: 2, store: 1
+   from: 211215 00:00
+     to: 211215 00:01
+  r-amp: NaN
+_kind______from______to___default____move___elide__delete___total___bytes______time
+compact      L3      L4         1       0       0       0       1    13 M       10s
+total                           1       0       0       0       1    13 M       10s
 node: 1, store: 1
    from: 211215 00:01
      to: 211215 00:02
@@ -239,18 +247,11 @@ _kind______from______to___default____move___elide__delete___total___bytes______t
 compact      L2      L3         1       0       0       0       1    13 M       10s
 total                           1       0       0       0       1    13 M       10s
 node: 1, store: 2
-   from: 211215 00:03
-     to: 211215 00:04
+   from: 211215 00:02
+     to: 211215 00:03
   r-amp: NaN
 _kind______from______to___default____move___elide__delete___total___bytes______time
 compact      L1      L2         1       0       0       0       1    13 M       10s
-total                           1       0       0       0       1    13 M       10s
-node: 2, store: 1
-   from: 211215 00:00
-     to: 211215 00:01
-  r-amp: NaN
-_kind______from______to___default____move___elide__delete___total___bytes______time
-compact      L3      L4         1       0       0       0       1    13 M       10s
 total                           1       0       0       0       1    13 M       10s
 node: 2, store: 2
    from: 211215 00:02

--- a/tool/logs/testdata/compactions
+++ b/tool/logs/testdata/compactions
@@ -17,7 +17,7 @@ node: 1, store: 1
   r-amp: NaN
 _kind______from______to___default____move___elide__delete___total___bytes______time
 compact      L2      L3         1       0       0       0       1    13 M       10s
-total                           1       0       0       0       1    13 M        0s
+total                           1       0       0       0       1    13 M       10s
 node: 1, store: 1
    from: 211215 00:01
      to: 211215 00:02
@@ -60,7 +60,7 @@ node: 1, store: 1
   r-amp: NaN
 _kind______from______to___default____move___elide__delete___total___bytes______time
 compact      L2      L3         1       0       0       0       1    13 M       10s
-total                           1       0       0       0       1    13 M        0s
+total                           1       0       0       0       1    13 M       10s
 node: 1, store: 1
    from: 211215 00:01
      to: 211215 00:02
@@ -115,7 +115,7 @@ node: 1, store: 1
   r-amp: 5.0
 _kind______from______to___default____move___elide__delete___total___bytes______time
 compact      L2      L3         1       0       0       0       1    13 M       10s
-total                           1       0       0       0       1    13 M        0s
+total                           1       0       0       0       1    13 M       10s
 
 # Long running compaction.
 
@@ -136,7 +136,7 @@ node: 1, store: 1
   r-amp: NaN
 _kind______from______to___default____move___elide__delete___total___bytes______time
 compact      L2      L3         1       0       0       0       1    13 M     2m10s
-total                           1       0       0       0       1    13 M      2m0s
+total                           1       0       0       0       1    13 M     2m10s
 long-running events (descending runtime):
 _kind________from________to_______job______type_____start_______end____dur(s)_____bytes:
 compact        L2        L3         1   default  00:01:10  00:03:20       130      13 M
@@ -163,14 +163,14 @@ node: 1, store: 1
   r-amp: NaN
 _kind______from______to___default____move___elide__delete___total___bytes______time
 compact      L2      L3         1       0       0       0       1    13 M       10s
-total                           1       0       0       0       1    13 M        0s
+total                           1       0       0       0       1    13 M       10s
 node: 1, store: 2
    from: 211215 00:01
      to: 211215 00:02
   r-amp: NaN
 _kind______from______to___default____move___elide__delete___total___bytes______time
 compact      L3      L4         1       0       0       0       1    13 M       10s
-total                           1       0       0       0       1    13 M        0s
+total                           1       0       0       0       1    13 M       10s
 
 # Multiple nodes, single stores. Two separate pebble logs.
 
@@ -197,14 +197,14 @@ node: 1, store: 1
   r-amp: NaN
 _kind______from______to___default____move___elide__delete___total___bytes______time
 compact      L2      L3         1       0       0       0       1    13 M       10s
-total                           1       0       0       0       1    13 M        0s
+total                           1       0       0       0       1    13 M       10s
 node: 2, store: 1
    from: 211215 00:01
      to: 211215 00:02
   r-amp: NaN
 _kind______from______to___default____move___elide__delete___total___bytes______time
 compact      L3      L4         1       0       0       0       1    13 M       10s
-total                           1       0       0       0       1    13 M        0s
+total                           1       0       0       0       1    13 M       10s
 
 # Multiple nodes, multiple stores. Two separate pebble logs.
 
@@ -237,28 +237,28 @@ node: 1, store: 1
   r-amp: NaN
 _kind______from______to___default____move___elide__delete___total___bytes______time
 compact      L2      L3         1       0       0       0       1    13 M       10s
-total                           1       0       0       0       1    13 M        0s
+total                           1       0       0       0       1    13 M       10s
 node: 1, store: 2
    from: 211215 00:03
      to: 211215 00:04
   r-amp: NaN
 _kind______from______to___default____move___elide__delete___total___bytes______time
 compact      L1      L2         1       0       0       0       1    13 M       10s
-total                           1       0       0       0       1    13 M        0s
+total                           1       0       0       0       1    13 M       10s
 node: 2, store: 1
    from: 211215 00:00
      to: 211215 00:01
   r-amp: NaN
 _kind______from______to___default____move___elide__delete___total___bytes______time
 compact      L3      L4         1       0       0       0       1    13 M       10s
-total                           1       0       0       0       1    13 M        0s
+total                           1       0       0       0       1    13 M       10s
 node: 2, store: 2
    from: 211215 00:02
      to: 211215 00:03
   r-amp: NaN
 _kind______from______to___default____move___elide__delete___total___bytes______time
 compact      L4      L5         1       0       0       0       1    13 M       10s
-total                           1       0       0       0       1    13 M        0s
+total                           1       0       0       0       1    13 M       10s
 
 # Log lines with an absent node / store are aggregated.
 
@@ -294,7 +294,7 @@ node: ?, store: ?
   r-amp: 5.0
 _kind______from______to___default____move___elide__delete___total___bytes______time
 compact      L2      L3         1       0       0       0       1    13 M       10s
-total                           1       0       0       0       1    13 M        0s
+total                           1       0       0       0       1    13 M       10s
 
 # The same Job ID interleaved for multiple nodes / stores.
 
@@ -317,14 +317,14 @@ node: 1, store: 1
   r-amp: NaN
 _kind______from______to___default____move___elide__delete___total___bytes______time
 compact      L2      L3         1       0       0       0       1    13 M       10s
-total                           1       0       0       0       1    13 M        0s
+total                           1       0       0       0       1    13 M       10s
 node: 2, store: 2
    from: 211215 00:02
      to: 211215 00:03
   r-amp: NaN
 _kind______from______to___default____move___elide__delete___total___bytes______time
 compact      L4      L5         1       0       0       0       1    13 M       10s
-total                           1       0       0       0       1    13 M        0s
+total                           1       0       0       0       1    13 M       10s
 
 # Read amp matching should remain backwards compatible.
 
@@ -373,7 +373,7 @@ node: 1, store: 1
   r-amp: 1.0
 _kind______from______to___default____move___elide__delete___total___bytes______time
 compact      L2      L3         1       0       0       0       1    13 M       10s
-total                           1       0       0       0       1    13 M        0s
+total                           1       0       0       0       1    13 M       10s
 
 reset
 ----


### PR DESCRIPTION
**tool/logs: fix total time calculation**

Alter the truncation for the total time field to truncate to seconds,
rather than minutes. This ensures the total time aligns with the
individual times.

**tool/logs: sort output by (start, node, store)**

Currently the output of the compaction log tool sorts by (node, store,
start). When diagnosing issues, one typically wants to look at all
stores in a given time slice, before moving to the next window.

Re-sort the computed windows by (time, node, store) to improve the
presentation.

**tool/logs: print total flush / ingestion counts and durations**

Print the total count and duration of flushes and ingestions.

Update the total count column for compactions to be named "count", to
align with the column name for flushes / ingestions.