### PR TITLE
db: add Pebble interface for CPU slot granter

### DIFF
--- a/db.go
+++ b/db.go
@@ -182,6 +182,18 @@ type ExperimentalWriter interface {
 	RangeKeyDelete(start, end []byte, opts *WriteOptions) error
 }
 
+// CPUWorkPermissionGranter is used to request permission to opportunistically
+// use additional CPUs to speed up internal background work. Each granted "proc"
+// can be used to spin up a CPU bound goroutine, i.e, if scheduled each such
+// goroutine can consume one P in the goroutine scheduler. The calls to
+// ReturnProcs can be a bit delayed, since Pebble interacts with this interface
+// in a coarse manner. So one should assume that the total number of granted
+// procs is a non tight upper bound on the CPU that will get consumed.
+type CPUWorkPermissionGranter interface {
+	TryGetProcs(count int) int
+	ReturnProcs(count int)
+}
+
 // DB provides a concurrent, persistent ordered key/value store.
 //
 // A DB's basic operations (Get, Set, Delete) should be self-explanatory. Get

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -211,6 +211,7 @@ func standardOptions() []*testOptions {
 		22: `
 [Options]
   max_writer_concurrency=2
+  force_writer_parallelism=true
 `,
 	}
 
@@ -260,6 +261,7 @@ func randomOptions(rng *rand.Rand) *testOptions {
 		// MaxWriterConcurrency to any value greater than or equal to 1 has the
 		// same effect currently.
 		opts.Experimental.MaxWriterConcurrency = 2
+		opts.Experimental.ForceWriterParallelism = true
 	}
 	var lopts pebble.LevelOptions
 	lopts.BlockRestartInterval = 1 + rng.Intn(64)  // 1 - 64

--- a/options_test.go
+++ b/options_test.go
@@ -101,6 +101,7 @@ func TestOptionsString(t *testing.T) {
   wal_dir=
   wal_bytes_per_sync=0
   max_writer_concurrency=0
+  force_writer_parallelism=false
 
 [Level "0"]
   block_restart_interval=16
@@ -230,6 +231,7 @@ func TestOptionsParse(t *testing.T) {
 			opts.Experimental.ReadSamplingMultiplier = 400
 			opts.Experimental.TableCacheShards = 500
 			opts.Experimental.MaxWriterConcurrency = 1
+			opts.Experimental.ForceWriterParallelism = true
 			opts.EnsureDefaults()
 			str := opts.String()
 

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -152,7 +152,7 @@ zmemtbl         1   256 K
 
 disk-usage
 ----
-2.8 K
+2.9 K
 
 # Closing iter b will release the last zombie sstable and the last zombie memtable.
 


### PR DESCRIPTION
CockroachDB has, or will have the ability to let Pebble know when
it can use additional CPU resources. Since Cockroach imports Pebble
and not the other way around, this pr defines a Pebble interface
which describes methods which Cockroach's slot granter should define.