### PR TITLE
db: clean up and optimize Iterator.{set,save}RangeKey

### DIFF
--- a/internal/keyspan/interleaving_iter_test.go
+++ b/internal/keyspan/interleaving_iter_test.go
@@ -73,7 +73,11 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 			fmt.Fprint(&buf, ".")
 			return
 		}
-		fmt.Fprintf(&buf, "PointKey: %s\nSpan: %s\n-", k.String(), iter.Span())
+		var s Span
+		if s2 := iter.Span(); s2 != nil {
+			s = *s2
+		}
+		fmt.Fprintf(&buf, "PointKey: %s\nSpan: %s\n-", k.String(), s)
 	}
 
 	datadriven.RunTest(t, filename, func(td *datadriven.TestData) string {


### PR DESCRIPTION
Remove the no longer required `InterleavingIter.span{Start,End}` fields. Change
the InterleavingIter method to return a pointer to its own internal span field,
and optimize the handling of this case where there is no range key.

This helps further reduce the overahead of simply enabling combined iteration.

```
name                                                             old time/op  new time/op  delta
IteratorScan/keys=100,r-amp=1,key-types=points-only-10           5.87µs ± 1%  5.92µs ± 1%     ~     (p=0.135 n=5+5)
IteratorScan/keys=100,r-amp=1,key-types=points-and-ranges-10     7.23µs ± 1%  6.66µs ± 1%   -7.87%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=3,key-types=points-only-10           10.4µs ± 0%  10.6µs ± 1%   +2.20%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=3,key-types=points-and-ranges-10     11.7µs ± 1%  11.3µs ± 1%   -3.48%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=7,key-types=points-only-10           15.6µs ± 0%  15.6µs ± 1%     ~     (p=0.222 n=5+5)
IteratorScan/keys=100,r-amp=7,key-types=points-and-ranges-10     17.2µs ± 0%  16.5µs ± 0%   -3.79%  (p=0.008 n=5+5)
IteratorScan/keys=100,r-amp=10,key-types=points-only-10          19.2µs ± 0%  19.2µs ± 2%     ~     (p=0.690 n=5+5)
IteratorScan/keys=100,r-amp=10,key-types=points-and-ranges-10    20.8µs ± 1%  19.5µs ± 1%   -6.50%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=1,key-types=points-only-10          44.9µs ± 0%  44.6µs ± 0%   -0.59%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=1,key-types=points-and-ranges-10    56.1µs ± 1%  49.2µs ± 0%  -12.26%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=3,key-types=points-only-10          77.7µs ± 0%  75.3µs ± 0%   -3.03%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=3,key-types=points-and-ranges-10    88.5µs ± 1%  80.0µs ± 0%   -9.59%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=7,key-types=points-only-10           105µs ± 1%   101µs ± 0%   -3.58%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=7,key-types=points-and-ranges-10     116µs ± 1%   106µs ± 0%   -8.14%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=10,key-types=points-only-10          118µs ± 0%   115µs ± 0%   -2.75%  (p=0.008 n=5+5)
IteratorScan/keys=1000,r-amp=10,key-types=points-and-ranges-10    130µs ± 0%   120µs ± 0%   -7.38%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=1,key-types=points-only-10          425µs ± 0%   413µs ± 0%   -2.78%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=1,key-types=points-and-ranges-10    531µs ± 0%   459µs ± 0%  -13.58%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=3,key-types=points-only-10          714µs ± 0%   708µs ± 0%   -0.88%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=3,key-types=points-and-ranges-10    818µs ± 0%   758µs ± 0%   -7.33%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=7,key-types=points-only-10          972µs ± 1%   960µs ± 1%   -1.27%  (p=0.032 n=5+5)
IteratorScan/keys=10000,r-amp=7,key-types=points-and-ranges-10   1.07ms ± 0%  1.02ms ± 0%   -5.09%  (p=0.008 n=5+5)
IteratorScan/keys=10000,r-amp=10,key-types=points-only-10        1.07ms ± 1%  1.08ms ± 1%   +1.17%  (p=0.032 n=5+5)
IteratorScan/keys=10000,r-amp=10,key-types=points-and-ranges-10  1.16ms ± 0%  1.13ms ± 1%   -3.22%  (p=0.008 n=5+5)
```