### PR TITLE
vfs: enabl no_sync_on_close option for syncingFile

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -157,7 +157,8 @@ func (d *DB) Checkpoint(
 	fs := syncingFS{
 		FS: d.opts.FS,
 		syncOpts: vfs.SyncingFileOptions{
-			BytesPerSync: d.opts.BytesPerSync,
+			NoSyncOnClose: d.opts.Experimental.NoSyncOnClose,
+			BytesPerSync:  d.opts.BytesPerSync,
 		},
 	}
 

--- a/compaction.go
+++ b/compaction.go
@@ -2097,7 +2097,8 @@ func (d *DB) runCompaction(
 			FileNum: fileNum,
 		})
 		file = vfs.NewSyncingFile(file, vfs.SyncingFileOptions{
-			BytesPerSync: d.opts.BytesPerSync,
+			NoSyncOnClose: d.opts.Experimental.NoSyncOnClose,
+			BytesPerSync:  d.opts.BytesPerSync,
 		})
 		file = &compactionFile{
 			File:     file,

--- a/db.go
+++ b/db.go
@@ -1863,6 +1863,7 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 				newLogFile.Close()
 			} else if err == nil {
 				newLogFile = vfs.NewSyncingFile(newLogFile, vfs.SyncingFileOptions{
+					NoSyncOnClose:   d.opts.Experimental.NoSyncOnClose,
 					BytesPerSync:    d.opts.WALBytesPerSync,
 					PreallocateSize: d.walPreallocateSize(),
 				})

--- a/ingest.go
+++ b/ingest.go
@@ -271,7 +271,8 @@ func ingestLink(
 	fs := syncingFS{
 		FS: opts.FS,
 		syncOpts: vfs.SyncingFileOptions{
-			BytesPerSync: opts.BytesPerSync,
+			NoSyncOnClose: opts.Experimental.NoSyncOnClose,
+			BytesPerSync:  opts.BytesPerSync,
 		},
 	}
 

--- a/open.go
+++ b/open.go
@@ -422,6 +422,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		d.mu.mem.queue[len(d.mu.mem.queue)-1].logNum = newLogNum
 
 		logFile = vfs.NewSyncingFile(logFile, vfs.SyncingFileOptions{
+			NoSyncOnClose:   d.opts.Experimental.NoSyncOnClose,
 			BytesPerSync:    d.opts.WALBytesPerSync,
 			PreallocateSize: d.walPreallocateSize(),
 		})

--- a/options.go
+++ b/options.go
@@ -517,6 +517,15 @@ type Options struct {
 		// compress and write blocks to disk. Otherwise, the writer will
 		// compress and write blocks to disk synchronously.
 		MaxWriterConcurrency int
+
+		// The NoSyncOnClose options decides whether the Pebble instance will
+		// enforce a synchronization (e.g., fdatasync() or sync_file_range())
+		// on ALL `syncingFile`s it writes to. Setting this option to true can
+		// make a syncingFile closing operation non-blocking.
+		// NOTE: if the underlying FS supports the sync_file_range() system
+		// call, the closing may still be blocked if there are too many dirty
+		// pages. However, this is not usually the case.
+		NoSyncOnClose bool
 	}
 
 	// Filters is a map from filter policy name to filter policy. It is used for

--- a/vfs/syncing_file.go
+++ b/vfs/syncing_file.go
@@ -12,6 +12,7 @@ import (
 
 // SyncingFileOptions holds the options for a syncingFile.
 type SyncingFileOptions struct {
+	NoSyncOnClose   bool // This value is false unless explicitly set
 	BytesPerSync    int
 	PreallocateSize int
 }
@@ -20,6 +21,8 @@ type syncingFile struct {
 	File
 	fd              uintptr
 	useSyncRange    bool
+	onClosing       bool
+	noSyncOnClose   bool
 	bytesPerSync    int64
 	preallocateSize int64
 	atomic          struct {
@@ -46,6 +49,7 @@ type syncingFile struct {
 func NewSyncingFile(f File, opts SyncingFileOptions) File {
 	s := &syncingFile{
 		File:            f,
+		noSyncOnClose:   bool(opts.NoSyncOnClose),
 		bytesPerSync:    int64(opts.BytesPerSync),
 		preallocateSize: int64(opts.PreallocateSize),
 	}
@@ -172,12 +176,16 @@ func (f *syncingFile) maybeSync() error {
 }
 
 func (f *syncingFile) Close() error {
-	// Sync any data that has been written but not yet synced. Note that if
-	// SyncFileRange was used, atomic.syncOffset will be less than
+	// Sync any data that has been written but not yet synced unless the file
+	// has noSyncOnClose option explicitly set.
+	// Note that if SyncFileRange was used, atomic.syncOffset will be less than
 	// atomic.offset. See syncingFile.syncToRange.
-	if atomic.LoadInt64(&f.atomic.offset) > atomic.LoadInt64(&f.atomic.syncOffset) {
-		if err := f.Sync(); err != nil {
-			return errors.WithStack(err)
+	f.onClosing = true
+	if !f.noSyncOnClose || f.useSyncRange {
+		if atomic.LoadInt64(&f.atomic.offset) > atomic.LoadInt64(&f.atomic.syncOffset) {
+			if err := f.Sync(); err != nil {
+				return errors.WithStack(err)
+			}
 		}
 	}
 	return errors.WithStack(f.File.Close())

--- a/vfs/syncing_file_linux.go
+++ b/vfs/syncing_file_linux.go
@@ -76,6 +76,14 @@ func (f *syncingFile) syncToRange(offset int64) error {
 		// waitAfter = 0x4
 	)
 
+	// The flags for the sync_file_range system call. Unless the file has
+	// noSyncOnClose explicitly set and it is being closed, the waitBefore
+	// flag will be set which may block the call.
+	flags := write
+	if !f.noSyncOnClose || !f.onClosing {
+		flags |= waitBefore
+	}
+
 	// Note that syncToRange is only called with an offset that is guaranteed to
 	// be less than atomic.offset (i.e. the write offset). This implies the
 	// syncingFile.Close will Sync the rest of the data, as well as the file's
@@ -91,7 +99,7 @@ func (f *syncingFile) syncToRange(offset int64) error {
 	// data accumulates, impacting other I/O operations.
 	var err error
 	f.timeDiskOp(func() {
-		err = syscall.SyncFileRange(int(f.fd), 0, offset, write|waitBefore)
+		err = syscall.SyncFileRange(int(f.fd), 0, offset, flags)
 	})
 	return err
 }


### PR DESCRIPTION
This commit adds NoSyncOnClose option to the syncingFile struct.
When this option is set to true (it is false by default), calling
Close() on a syncingFile will not trigger a Sync() on the file. If the
file system supports sync_file_range() system call, a Sync() will still be
called to synchronize the dirty data but the waiting flags are not set
so that the caller is usually not blocked.

Accordingly, a new option with the same name is added to the
Experimental section of Pebble's options. When it is set to true, the
syncingFiles opened by the db instance will have the NoSyncOnClose
option set.

A new test (TestSyncingFileNoSyncOnClose) is implemented.