### PR TITLE
vfs: add option to turn off sync-on-close in syncingFile

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -157,7 +157,8 @@ func (d *DB) Checkpoint(
 	fs := syncingFS{
 		FS: d.opts.FS,
 		syncOpts: vfs.SyncingFileOptions{
-			BytesPerSync: d.opts.BytesPerSync,
+			NoSyncOnClose: d.opts.NoSyncOnClose,
+			BytesPerSync:  d.opts.BytesPerSync,
 		},
 	}
 

--- a/compaction.go
+++ b/compaction.go
@@ -2103,7 +2103,8 @@ func (d *DB) runCompaction(
 			FileNum: fileNum,
 		})
 		file = vfs.NewSyncingFile(file, vfs.SyncingFileOptions{
-			BytesPerSync: d.opts.BytesPerSync,
+			NoSyncOnClose: d.opts.NoSyncOnClose,
+			BytesPerSync:  d.opts.BytesPerSync,
 		})
 		file = &compactionFile{
 			File:     file,

--- a/db.go
+++ b/db.go
@@ -1875,6 +1875,7 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 				newLogFile.Close()
 			} else if err == nil {
 				newLogFile = vfs.NewSyncingFile(newLogFile, vfs.SyncingFileOptions{
+					NoSyncOnClose:   d.opts.NoSyncOnClose,
 					BytesPerSync:    d.opts.WALBytesPerSync,
 					PreallocateSize: d.walPreallocateSize(),
 				})

--- a/ingest.go
+++ b/ingest.go
@@ -271,7 +271,8 @@ func ingestLink(
 	fs := syncingFS{
 		FS: opts.FS,
 		syncOpts: vfs.SyncingFileOptions{
-			BytesPerSync: opts.BytesPerSync,
+			NoSyncOnClose: opts.NoSyncOnClose,
+			BytesPerSync:  opts.BytesPerSync,
 		},
 	}
 

--- a/open.go
+++ b/open.go
@@ -422,6 +422,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		d.mu.mem.queue[len(d.mu.mem.queue)-1].logNum = newLogNum
 
 		logFile = vfs.NewSyncingFile(logFile, vfs.SyncingFileOptions{
+			NoSyncOnClose:   d.opts.NoSyncOnClose,
 			BytesPerSync:    d.opts.WALBytesPerSync,
 			PreallocateSize: d.walPreallocateSize(),
 		})

--- a/options.go
+++ b/options.go
@@ -640,6 +640,12 @@ type Options struct {
 	// externally when running a manual compaction, and internally for tests.
 	DisableAutomaticCompactions bool
 
+	// NoSyncOnClose decides whether the Pebble instance will enforce a
+	// close-time synchronization (e.g., fdatasync() or sync_file_range())
+	// on files it writes to. Setting this to true removes the guarantee for a
+	// sync on close. Some implementations can still issue a non-blocking sync.
+	NoSyncOnClose bool
+
 	// NumPrevManifest is the number of non-current or older manifests which
 	// we want to keep around for debugging purposes. By default, we're going
 	// to keep one older manifest.

--- a/vfs/syncing_file_test.go
+++ b/vfs/syncing_file_test.go
@@ -134,6 +134,57 @@ close: test [<nil>]
 	}
 }
 
+func TestSyncingFileNoSyncOnClose(t *testing.T) {
+	testCases := []struct {
+		useSyncRange bool
+		expectBefore int64
+		expectAfter  int64
+	}{
+		{false, 2 << 20, 2 << 20},
+		{true, 2 << 20, 3<<20 + 128},
+	}
+
+	for _, c := range testCases {
+		t.Run(fmt.Sprintf("useSyncRange=%v", c.useSyncRange), func(t *testing.T) {
+			tmpf, err := ioutil.TempFile("", "pebble-db-syncing-file-")
+			require.NoError(t, err)
+
+			filename := tmpf.Name()
+			require.NoError(t, tmpf.Close())
+			defer os.Remove(filename)
+
+			f, err := Default.Create(filename)
+			require.NoError(t, err)
+
+			var buf bytes.Buffer
+			lf := loggingFile{f, "test", &buf}
+
+			s := NewSyncingFile(lf, SyncingFileOptions{NoSyncOnClose: true, BytesPerSync: 8 << 10}).(*syncingFile)
+			s.useSyncRange = c.useSyncRange
+
+			write := func(n int64) {
+				t.Helper()
+				_, err := s.Write(make([]byte, n))
+				require.NoError(t, err)
+			}
+
+			const mb = 1 << 20
+			write(2 * mb) // Sync first 2MB
+			write(mb)     // No sync because syncToOffset = 3M-1M = 2M
+			write(128)    // No sync for the same reason
+
+			syncToBefore := atomic.LoadInt64(&s.atomic.syncOffset)
+			require.NoError(t, s.Close())
+			syncToAfter := atomic.LoadInt64(&s.atomic.syncOffset)
+
+			if syncToBefore != c.expectBefore || syncToAfter != c.expectAfter {
+				t.Fatalf("Expected syncTo before and after closing are %d %d but found %d %d",
+					c.expectBefore, c.expectAfter, syncToBefore, syncToAfter)
+			}
+		})
+	}
+}
+
 func BenchmarkSyncWrite(b *testing.B) {
 	const targetSize = 16 << 20
 


### PR DESCRIPTION
This commit adds NoSyncOnClose option to the syncingFile struct.
When this option is set to true (it is false by default), calling
Close() on a syncingFile will not trigger a Sync() on the file. If the
file system supports sync_file_range() system call, a Sync() will still be
called to synchronize the dirty data but the waiting flags are not set
so that the caller is usually not blocked.

Accordingly, a new option with the same name is added to the
Experimental section of Pebble's options. When it is set to true, the
syncingFiles opened by the db instance will have the NoSyncOnClose
option set.

A new test (TestSyncingFileNoSyncOnClose) is implemented.