### PR TITLE
base,sstable: include {loaded,cached} block counts...

### DIFF
--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -237,12 +237,12 @@ type InternalIteratorWithStats interface {
 // field is relevant for an InternalIterator implementation. The field values
 // are aggregated as one goes up the InternalIterator tree.
 type InternalIteratorStats struct {
-	// Bytes in the loaded blocks. If the block was compressed, this is the
-	// compressed bytes. Currently, only the second-level index and data blocks
-	// containing points are included.
-	BlockBytes uint64
-	// Subset of BlockBytes that were in the block cache.
-	BlockBytesInCache uint64
+	// Loaded blocks and their total size. If the block was compressed, this is
+	// the compressed bytes. Currently, only the second-level index and data
+	// blocks containing points are included.
+	Blocks, BlockBytes uint64
+	// Subset of blocks that were in the block cache and their total size.
+	BlocksInCache, BlockBytesInCache uint64
 
 	// The following can repeatedly count the same points if they are iterated
 	// over multiple times. Additionally, they may count a point twice when
@@ -264,7 +264,9 @@ type InternalIteratorStats struct {
 
 // Merge merges the stats in from into the given stats.
 func (s *InternalIteratorStats) Merge(from InternalIteratorStats) {
+	s.Blocks += from.Blocks
 	s.BlockBytes += from.BlockBytes
+	s.BlocksInCache += from.BlocksInCache
 	s.BlockBytesInCache += from.BlockBytesInCache
 	s.KeyBytes += from.KeyBytes
 	s.ValueBytes += from.ValueBytes

--- a/iterator.go
+++ b/iterator.go
@@ -2087,13 +2087,15 @@ func (stats *IteratorStats) SafeFormat(s redact.SafePrinter, verb rune) {
 	}
 	if stats.InternalStats != (InternalIteratorStats{}) {
 		s.SafeString(",\n(internal-stats: ")
-		s.Printf("(block-bytes: (total %s, cached %s)), "+
+		s.Printf("(blocks: (count %s, cached-count %s, bytes %s, cached-bytes %s)), "+
 			"(points: (count %s, key-bytes %s, value-bytes %s, tombstoned: %s))",
+			humanize.SI.Uint64(stats.InternalStats.Blocks),
+			humanize.SI.Uint64(stats.InternalStats.BlocksInCache),
 			humanize.IEC.Uint64(stats.InternalStats.BlockBytes),
 			humanize.IEC.Uint64(stats.InternalStats.BlockBytesInCache),
 			humanize.SI.Uint64(stats.InternalStats.PointCount),
-			humanize.SI.Uint64(stats.InternalStats.KeyBytes),
-			humanize.SI.Uint64(stats.InternalStats.ValueBytes),
+			humanize.IEC.Uint64(stats.InternalStats.KeyBytes),
+			humanize.IEC.Uint64(stats.InternalStats.ValueBytes),
 			humanize.SI.Uint64(stats.InternalStats.PointsCoveredByRangeTombstones),
 		)
 	}

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -406,8 +406,10 @@ func (i *singleLevelIterator) readBlockWithStats(
 	block, cacheHit, err := i.reader.readBlock(bh, nil /* transform */, raState)
 	if err == nil {
 		n := bh.Length
+		i.stats.Blocks++
 		i.stats.BlockBytes += n
 		if cacheHit {
+			i.stats.BlocksInCache++
 			i.stats.BlockBytesInCache += n
 		}
 	}

--- a/sstable/testdata/readerstats/iter
+++ b/sstable/testdata/readerstats/iter
@@ -35,25 +35,25 @@ first
 stats
 ----
 <a:1>
-{BlockBytes:34 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:1 BlockBytes:34 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 <b:2>
-{BlockBytes:34 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:1 BlockBytes:34 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 <c:3>
-{BlockBytes:68 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:2 BlockBytes:68 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 <d:4>
-{BlockBytes:68 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:2 BlockBytes:68 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 .
-{BlockBytes:68 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:2 BlockBytes:68 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 <a:1>
-{BlockBytes:102 BlockBytesInCache:34 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:3 BlockBytes:102 BlocksInCache:1 BlockBytesInCache:34 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 <b:2>
-{BlockBytes:102 BlockBytesInCache:34 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:3 BlockBytes:102 BlocksInCache:1 BlockBytesInCache:34 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 <c:3>
-{BlockBytes:136 BlockBytesInCache:68 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:4 BlockBytes:136 BlocksInCache:2 BlockBytesInCache:68 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 <d:4>
-{BlockBytes:136 BlockBytesInCache:68 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:4 BlockBytes:136 BlocksInCache:2 BlockBytesInCache:68 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 .
-{BlockBytes:136 BlockBytesInCache:68 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
-{BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:4 BlockBytes:136 BlocksInCache:2 BlockBytesInCache:68 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:0 BlockBytes:0 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 <a:1>
-{BlockBytes:34 BlockBytesInCache:34 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:1 BlockBytes:34 BlocksInCache:1 BlockBytesInCache:34 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}

--- a/testdata/iterator
+++ b/testdata/iterator
@@ -11,7 +11,7 @@ a:b
 .
 a:b
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=2
 seek-ge b
@@ -40,7 +40,7 @@ a:b
 .
 a:b
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 4, key-bytes 4 B, value-bytes 4 B, tombstoned: 0))
 
 iter seq=3
 seek-ge a
@@ -51,7 +51,7 @@ a:c
 .
 a:c
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 1, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 4, key-bytes 4 B, value-bytes 4 B, tombstoned: 0))
 
 iter seq=2
 seek-prefix-ge a
@@ -64,7 +64,7 @@ a:b
 err=pebble: unsupported reverse prefix iteration
 err=pebble: unsupported reverse prefix iteration
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=3
 seek-prefix-ge a
@@ -73,7 +73,7 @@ next
 a:c
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 
 define
@@ -86,7 +86,7 @@ seek-ge a
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 1 B, tombstoned: 0))
 
 iter seq=2
 seek-ge 1
@@ -95,14 +95,14 @@ next
 a:b
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 1 B, tombstoned: 0))
 
 iter seq=3
 seek-lt b
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 0)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 1 B, tombstoned: 0))
 
 iter seq=2
 seek-lt b
@@ -113,21 +113,21 @@ a:b
 .
 a:b
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 4, key-bytes 4 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=3
 seek-prefix-ge a
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 1 B, tombstoned: 0))
 
 iter seq=2
 seek-prefix-ge 1
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 1 B, tombstoned: 0))
 
 define
 a.DEL.2:
@@ -142,42 +142,42 @@ next
 b:c
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 3, key-bytes 3 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=3
 seek-ge a
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 3, key-bytes 3 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=2
 seek-ge a
 ----
 a:b
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 1 B, tombstoned: 0))
 
 iter seq=4
 seek-prefix-ge a
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 3, key-bytes 3 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=3
 seek-prefix-ge a
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 3, key-bytes 3 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=2
 seek-prefix-ge a
 ----
 a:b
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 1 B, tombstoned: 0))
 
 iter seq=2
 seek-prefix-ge a
@@ -186,7 +186,7 @@ seek-prefix-ge b
 a:b
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 3, key-bytes 3 B, value-bytes 2 B, tombstoned: 0))
 
 define
 a.DEL.3:
@@ -205,7 +205,7 @@ seek-prefix-ge c
 .
 c:d
 stats: (interface (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 3, 4), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 7, key-bytes 7, value-bytes 4, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 7, key-bytes 7 B, value-bytes 4 B, tombstoned: 0))
 
 iter seq=3
 seek-prefix-ge a
@@ -216,7 +216,7 @@ a:b
 b:c
 .
 stats: (interface (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 3, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 5, key-bytes 5 B, value-bytes 3 B, tombstoned: 0))
 
 iter seq=3
 seek-ge a
@@ -227,7 +227,7 @@ a:b
 b:c
 .
 stats: (interface (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 3, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 5, key-bytes 5 B, value-bytes 3 B, tombstoned: 0))
 
 define
 a.SET.1:a
@@ -246,7 +246,7 @@ b:b
 c:c
 .
 stats: (interface (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 3, key-bytes 3 B, value-bytes 3 B, tombstoned: 0))
 
 iter seq=4
 seek-ge b
@@ -255,14 +255,14 @@ next
 b:b
 c:c
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=4
 seek-ge c
 ----
 c:c
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 1, key-bytes 1 B, value-bytes 1 B, tombstoned: 0))
 
 iter seq=4
 seek-lt a
@@ -279,7 +279,7 @@ a:a
 .
 a:a
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=4
 seek-lt c
@@ -292,7 +292,7 @@ a:a
 .
 a:a
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 2)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 3, key-bytes 3 B, value-bytes 3 B, tombstoned: 0))
 
 
 iter seq=4
@@ -308,7 +308,7 @@ a:a
 .
 a:a
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 3)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 3)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 4, key-bytes 4 B, value-bytes 4 B, tombstoned: 0))
 
 iter seq=4
 seek-prefix-ge a
@@ -317,7 +317,7 @@ next
 a:a
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=4
 seek-prefix-ge b
@@ -326,7 +326,7 @@ next
 b:b
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 
 iter seq=4
@@ -336,7 +336,7 @@ next
 c:c
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 1, key-bytes 1 B, value-bytes 1 B, tombstoned: 0))
 
 
 iter seq=4
@@ -354,7 +354,7 @@ a:a
 c:c
 b:b
 stats: (interface (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 3, key-bytes 3 B, value-bytes 3 B, tombstoned: 0))
 
 define
 a.SET.b2:b
@@ -370,14 +370,14 @@ a:b
 .
 a:b
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 4, key-bytes 4 B, value-bytes 4 B, tombstoned: 0))
 
 iter seq=2
 seek-ge b
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 1, key-bytes 1 B, value-bytes 1 B, tombstoned: 0))
 
 iter seq=2
 seek-lt a
@@ -394,7 +394,7 @@ a:b
 .
 a:b
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=2
 seek-lt c
@@ -405,7 +405,7 @@ a:b
 .
 a:b
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 3, key-bytes 3 B, value-bytes 3 B, tombstoned: 0))
 
 iter seq=2
 seek-prefix-ge a
@@ -414,14 +414,14 @@ next
 a:b
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=2
 seek-prefix-ge b
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 1, key-bytes 1 B, value-bytes 1 B, tombstoned: 0))
 
 
 define
@@ -438,7 +438,7 @@ next
 a:a
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 3, value-bytes 3, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 3 B, value-bytes 3 B, tombstoned: 0))
 
 iter seq=5
 seek-prefix-ge a
@@ -447,14 +447,14 @@ next
 a:a
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 3, value-bytes 3, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 3 B, value-bytes 3 B, tombstoned: 0))
 
 iter seq=5
 seek-prefix-ge aa
 ----
 aa:aa
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 1, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=5
 seek-prefix-ge aa
@@ -463,7 +463,7 @@ next
 aa:aa
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 5, value-bytes 5, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 5 B, value-bytes 5 B, tombstoned: 0))
 
 iter seq=5
 seek-prefix-ge aa
@@ -472,7 +472,7 @@ next
 aa:aa
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 5, value-bytes 5, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 5 B, value-bytes 5 B, tombstoned: 0))
 
 iter seq=5
 seek-prefix-ge aaa
@@ -481,14 +481,14 @@ next
 aaa:aaa
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 4, value-bytes 4, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 4 B, value-bytes 4 B, tombstoned: 0))
 
 iter seq=5
 seek-prefix-ge aaa
 ----
 aaa:aaa
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 3, value-bytes 3, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 1, key-bytes 3 B, value-bytes 3 B, tombstoned: 0))
 
 iter seq=5
 seek-prefix-ge b
@@ -497,7 +497,7 @@ next
 b:b
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 1, key-bytes 1 B, value-bytes 1 B, tombstoned: 0))
 
 iter seq=5
 seek-prefix-ge aa
@@ -514,7 +514,7 @@ aa:aa
 a:a
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 1, 4)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 4)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 9, value-bytes 9, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 5, key-bytes 9 B, value-bytes 9 B, tombstoned: 0))
 
 iter seq=5
 seek-prefix-ge aa
@@ -531,7 +531,7 @@ aaa:aaa
 b:b
 .
 stats: (interface (dir, seek, step): (fwd, 2, 4), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 4), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 9, value-bytes 9, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 5, key-bytes 9 B, value-bytes 9 B, tombstoned: 0))
 
 iter seq=5
 seek-prefix-ge aaa
@@ -546,7 +546,7 @@ aaa:aaa
 b:b
 .
 stats: (interface (dir, seek, step): (fwd, 2, 3), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 3), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 9, value-bytes 9, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 4, key-bytes 9 B, value-bytes 9 B, tombstoned: 0))
 
 iter seq=5
 seek-prefix-ge aaa
@@ -559,7 +559,7 @@ aaa:aaa
 b:b
 .
 stats: (interface (dir, seek, step): (fwd, 2, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 7, value-bytes 7, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 3, key-bytes 7 B, value-bytes 7 B, tombstoned: 0))
 
 iter seq=5
 seek-prefix-ge aaa
@@ -576,7 +576,7 @@ aaa:aaa
 b:b
 .
 stats: (interface (dir, seek, step): (fwd, 1, 4), (rev, 1, 0)), (internal (dir, seek, step): (fwd, 2, 4), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 6, key-bytes 11, value-bytes 11, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 6, key-bytes 11 B, value-bytes 11 B, tombstoned: 0))
 
 
 iter seq=5
@@ -590,7 +590,7 @@ aaa:aaa
 b:b
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 1, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 12, value-bytes 12, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 5, key-bytes 12 B, value-bytes 12 B, tombstoned: 0))
 
 iter seq=4
 seek-prefix-ge a
@@ -603,7 +603,7 @@ aa:aa
 aaa:aaa
 .
 stats: (interface (dir, seek, step): (fwd, 4, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 4, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 7, value-bytes 7, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 4, key-bytes 7 B, value-bytes 7 B, tombstoned: 0))
 
 iter seq=3
 seek-prefix-ge aaa
@@ -618,7 +618,7 @@ a:a
 aa:aa
 .
 stats: (interface (dir, seek, step): (fwd, 5, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 5, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 7, key-bytes 12, value-bytes 12, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 7, key-bytes 12 B, value-bytes 12 B, tombstoned: 0))
 
 define
 bb.DEL.2:
@@ -631,7 +631,7 @@ seek-prefix-ge bb
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 7, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 3, key-bytes 7 B, value-bytes 2 B, tombstoned: 0))
 
 
 # NB: RANGEDEL entries are ignored.
@@ -659,7 +659,7 @@ b:ab
 .
 b:ab
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 5), (rev, 1, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 15, key-bytes 15 B, value-bytes 15 B, tombstoned: 0))
 
 iter seq=3
 seek-ge a
@@ -668,7 +668,7 @@ next
 a:bc
 b:ab
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 4), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 10, value-bytes 10, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 10, key-bytes 10 B, value-bytes 10 B, tombstoned: 0))
 
 iter seq=2
 seek-ge a
@@ -677,7 +677,7 @@ next
 a:b
 b:a
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 10, value-bytes 10, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 10, key-bytes 10 B, value-bytes 10 B, tombstoned: 0))
 
 iter seq=4
 seek-lt c
@@ -690,7 +690,7 @@ a:bcd
 .
 a:bcd
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 2)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 1, 5)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 16, key-bytes 16, value-bytes 16, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 16, key-bytes 16 B, value-bytes 16 B, tombstoned: 0))
 
 iter seq=3
 seek-lt c
@@ -699,7 +699,7 @@ prev
 b:ab
 a:bc
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 4)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 10, value-bytes 10, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 10, key-bytes 10 B, value-bytes 10 B, tombstoned: 0))
 
 iter seq=2
 seek-lt c
@@ -708,7 +708,7 @@ prev
 b:a
 a:b
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 10, value-bytes 10, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 10, key-bytes 10 B, value-bytes 10 B, tombstoned: 0))
 
 iter seq=4
 seek-ge a
@@ -721,7 +721,7 @@ b:ab
 a:bcd
 b:ab
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 10), (rev, 1, 5)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 30, key-bytes 30, value-bytes 30, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 30, key-bytes 30 B, value-bytes 30 B, tombstoned: 0))
 
 iter seq=3
 seek-ge a
@@ -734,7 +734,7 @@ b:ab
 a:bc
 b:ab
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 8), (rev, 1, 4)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 30, key-bytes 30, value-bytes 30, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 30, key-bytes 30 B, value-bytes 30 B, tombstoned: 0))
 
 iter seq=2
 seek-ge a
@@ -747,7 +747,7 @@ b:a
 a:b
 b:a
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 4), (rev, 1, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 30, key-bytes 30, value-bytes 30, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 30, key-bytes 30 B, value-bytes 30 B, tombstoned: 0))
 
 iter seq=4
 seek-lt c
@@ -760,7 +760,7 @@ a:bcd
 b:ab
 a:bcd
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 2)), (internal (dir, seek, step): (fwd, 1, 5), (rev, 2, 10)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 30, key-bytes 30, value-bytes 30, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 30, key-bytes 30 B, value-bytes 30 B, tombstoned: 0))
 
 iter seq=3
 seek-lt c
@@ -773,7 +773,7 @@ a:bc
 b:ab
 a:bc
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 2)), (internal (dir, seek, step): (fwd, 1, 4), (rev, 2, 8)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 30, key-bytes 30, value-bytes 30, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 30, key-bytes 30 B, value-bytes 30 B, tombstoned: 0))
 
 iter seq=2
 seek-lt c
@@ -786,7 +786,7 @@ a:b
 b:a
 a:b
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 2)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 2, 4)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 30, key-bytes 30, value-bytes 30, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 30, key-bytes 30 B, value-bytes 30 B, tombstoned: 0))
 
 iter seq=3
 seek-prefix-ge a
@@ -795,7 +795,7 @@ next
 a:bc
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 8, key-bytes 8, value-bytes 8, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 8, key-bytes 8 B, value-bytes 8 B, tombstoned: 0))
 
 iter seq=2
 seek-prefix-ge a
@@ -804,7 +804,7 @@ next
 a:b
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 10, value-bytes 10, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 10, key-bytes 10 B, value-bytes 10 B, tombstoned: 0))
 
 iter seq=4
 seek-prefix-ge a
@@ -813,7 +813,7 @@ next
 a:bcd
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 8, key-bytes 8, value-bytes 8, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 8, key-bytes 8 B, value-bytes 8 B, tombstoned: 0))
 
 iter seq=2
 seek-prefix-ge a
@@ -822,7 +822,7 @@ next
 a:b
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 10, value-bytes 10, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 10, key-bytes 10 B, value-bytes 10 B, tombstoned: 0))
 
 iter seq=3
 seek-prefix-ge a
@@ -831,7 +831,7 @@ next
 a:bc
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 8, key-bytes 8, value-bytes 8, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 8, key-bytes 8 B, value-bytes 8 B, tombstoned: 0))
 
 iter seq=3
 seek-prefix-ge c
@@ -844,14 +844,14 @@ seek-prefix-ge 1
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 4, key-bytes 4 B, value-bytes 4 B, tombstoned: 0))
 
 iter seq=3
 seek-prefix-ge a
 ----
 a:bc
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 6, key-bytes 6, value-bytes 6, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 6, key-bytes 6 B, value-bytes 6 B, tombstoned: 0))
 
 
 # NB: RANGEDEL entries are ignored.
@@ -881,7 +881,7 @@ a:bc
 .
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 4), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 12, key-bytes 16, value-bytes 12, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 12, key-bytes 16 B, value-bytes 12 B, tombstoned: 0))
 
 iter seq=2
 seek-prefix-ge a
@@ -892,7 +892,7 @@ a:b
 .
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 14, key-bytes 18, value-bytes 14, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 14, key-bytes 18 B, value-bytes 14 B, tombstoned: 0))
 
 iter seq=4
 seek-prefix-ge a
@@ -901,7 +901,7 @@ next
 a:bcd
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 8, key-bytes 10, value-bytes 8, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 8, key-bytes 10 B, value-bytes 8 B, tombstoned: 0))
 
 iter seq=2
 seek-prefix-ge a
@@ -910,7 +910,7 @@ next
 a:b
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 14, value-bytes 10, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 10, key-bytes 14 B, value-bytes 10 B, tombstoned: 0))
 
 iter seq=3
 seek-prefix-ge aa
@@ -919,14 +919,14 @@ next
 aa:ab
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 6, key-bytes 10, value-bytes 6, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 6, key-bytes 10 B, value-bytes 6 B, tombstoned: 0))
 
 iter seq=4
 seek-prefix-ge aa
 ----
 aa:ab
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 6, key-bytes 10, value-bytes 6, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 6, key-bytes 10 B, value-bytes 6 B, tombstoned: 0))
 
 define
 a.SET.1:a
@@ -944,7 +944,7 @@ a:a
 a:a
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=2 lower=b
 seek-ge a
@@ -955,7 +955,7 @@ b:b
 b:b
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=2 lower=c
 seek-ge a
@@ -966,7 +966,7 @@ c:c
 c:c
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=2 lower=d
 seek-ge a
@@ -977,7 +977,7 @@ d:d
 d:d
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=2 lower=e
 seek-ge a
@@ -996,7 +996,7 @@ c:c
 c:c
 .
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 2, 0)), (internal (dir, seek, step): (fwd, 0, 2), (rev, 2, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 5, key-bytes 5 B, value-bytes 5 B, tombstoned: 0))
 
 iter seq=2 upper=c
 seek-lt d
@@ -1007,7 +1007,7 @@ b:b
 b:b
 .
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 2, 0)), (internal (dir, seek, step): (fwd, 0, 2), (rev, 2, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 5, key-bytes 5 B, value-bytes 5 B, tombstoned: 0))
 
 iter seq=2 upper=b
 seek-lt d
@@ -1018,7 +1018,7 @@ a:a
 a:a
 .
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 2, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 2, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 3, key-bytes 3 B, value-bytes 3 B, tombstoned: 0))
 
 iter seq=2 upper=a
 seek-lt d
@@ -1035,7 +1035,7 @@ next
 b:b
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 1, key-bytes 1 B, value-bytes 1 B, tombstoned: 0))
 
 iter seq=2
 set-bounds lower=a
@@ -1048,7 +1048,7 @@ a:a
 a:a
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=2
 set-bounds lower=b
@@ -1061,7 +1061,7 @@ b:b
 b:b
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=2
 set-bounds lower=c
@@ -1074,7 +1074,7 @@ c:c
 c:c
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=2
 set-bounds lower=d
@@ -1087,7 +1087,7 @@ d:d
 d:d
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=2
 set-bounds lower=e
@@ -1110,7 +1110,7 @@ c:c
 c:c
 .
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 2, 0)), (internal (dir, seek, step): (fwd, 0, 2), (rev, 2, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 5, key-bytes 5 B, value-bytes 5 B, tombstoned: 0))
 
 iter seq=2
 set-bounds upper=c
@@ -1123,7 +1123,7 @@ b:b
 b:b
 .
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 2, 0)), (internal (dir, seek, step): (fwd, 0, 2), (rev, 2, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 5, key-bytes 5 B, value-bytes 5 B, tombstoned: 0))
 
 iter seq=2
 set-bounds upper=b
@@ -1136,7 +1136,7 @@ a:a
 a:a
 .
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 2, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 2, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 3, key-bytes 3 B, value-bytes 3 B, tombstoned: 0))
 
 iter seq=2
 set-bounds upper=a
@@ -1159,7 +1159,7 @@ c:c
 d:d
 .
 stats: (interface (dir, seek, step): (fwd, 0, 2), (rev, 1, 0)), (internal (dir, seek, step): (fwd, 0, 3), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 4, key-bytes 4 B, value-bytes 4 B, tombstoned: 0))
 
 iter seq=2
 set-bounds lower=b upper=c
@@ -1170,7 +1170,7 @@ next
 b:b
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 1, key-bytes 1 B, value-bytes 1 B, tombstoned: 0))
 
 iter seq=2
 set-bounds lower=b
@@ -1183,7 +1183,7 @@ b:b
 .
 b:b
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=2
 seek-ge a
@@ -1192,7 +1192,7 @@ set-bounds upper=e
 a:a
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 1, key-bytes 1 B, value-bytes 1 B, tombstoned: 0))
 
 iter seq=2
 set-bounds lower=b
@@ -1203,7 +1203,7 @@ set-bounds upper=e
 b:b
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 1, key-bytes 1 B, value-bytes 1 B, tombstoned: 0))
 
 iter seq=2
 set-bounds lower=b
@@ -1212,7 +1212,7 @@ first
 .
 b:b
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 1, key-bytes 1 B, value-bytes 1 B, tombstoned: 0))
 
 iter seq=2
 set-bounds upper=b
@@ -1221,7 +1221,7 @@ first
 .
 a:a
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 1, key-bytes 1 B, value-bytes 1 B, tombstoned: 0))
 
 iter seq=2
 set-bounds lower=b
@@ -1230,7 +1230,7 @@ last
 .
 d:d
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 0)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=2
 set-bounds upper=b
@@ -1239,7 +1239,7 @@ last
 .
 a:a
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 0)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 1, key-bytes 1 B, value-bytes 1 B, tombstoned: 0))
 
 # The prev call after "set-bounds upper=c" will assume that the iterator
 # is exhausted due to having stepped up to c. Which means prev should step
@@ -1255,7 +1255,7 @@ d:d
 .
 b:b
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 2), (rev, 2, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 5, key-bytes 5 B, value-bytes 5 B, tombstoned: 0))
 
 # The next call after "set-bounds lower=b" will assume that the iterator
 # is exhausted due to having stepped below b. Which means next should step
@@ -1271,7 +1271,7 @@ a:a
 .
 b:b
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=2
 set-bounds lower=b
@@ -1282,7 +1282,7 @@ next
 b:b
 c:c
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 3, key-bytes 3 B, value-bytes 3 B, tombstoned: 0))
 
 iter seq=2
 set-bounds upper=d
@@ -1293,7 +1293,7 @@ prev
 c:c
 b:b
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 3, key-bytes 3 B, value-bytes 3 B, tombstoned: 0))
 
 define
 a.SET.1:a
@@ -1311,7 +1311,7 @@ a:a
 a:a
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 
 iter seq=2 lower=aa
@@ -1327,7 +1327,7 @@ next
 a:a
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 1, key-bytes 1 B, value-bytes 1 B, tombstoned: 0))
 
 iter seq=2 lower=a upper=aaa
 seek-prefix-ge a
@@ -1336,7 +1336,7 @@ next
 a:a
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 3, value-bytes 3, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 3 B, value-bytes 3 B, tombstoned: 0))
 
 iter seq=2 lower=a upper=b
 seek-prefix-ge a
@@ -1345,7 +1345,7 @@ next
 a:a
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 3, value-bytes 3, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 3 B, value-bytes 3 B, tombstoned: 0))
 
 iter seq=2 lower=a upper=c
 seek-prefix-ge a
@@ -1354,14 +1354,14 @@ next
 a:a
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 3, value-bytes 3, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 3 B, value-bytes 3 B, tombstoned: 0))
 
 iter seq=2 lower=a upper=aaa
 seek-prefix-ge aa
 ----
 aa:aa
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 1, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 iter seq=2 lower=a upper=aaa
 seek-prefix-ge aa
@@ -1370,7 +1370,7 @@ next
 aa:aa
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 1, key-bytes 2 B, value-bytes 2 B, tombstoned: 0))
 
 # NB: RANGEDEL entries are ignored.
 define
@@ -1390,7 +1390,7 @@ a:a
 b:b
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 5, key-bytes 5 B, value-bytes 5 B, tombstoned: 0))
 
 define
 a.SINGLEDEL.1:
@@ -1401,7 +1401,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 0, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 1, key-bytes 1 B, value-bytes 0 B, tombstoned: 0))
 
 define
 a.SINGLEDEL.2:
@@ -1413,7 +1413,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 0, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 0 B, tombstoned: 0))
 
 define
 a.SINGLEDEL.2:
@@ -1425,7 +1425,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 0, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 0 B, tombstoned: 0))
 
 define
 a.SINGLEDEL.2:
@@ -1437,7 +1437,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 0, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 0 B, tombstoned: 0))
 
 define
 a.SINGLEDEL.2:
@@ -1449,7 +1449,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 1 B, tombstoned: 0))
 
 define
 a.SET.2:b
@@ -1463,7 +1463,7 @@ next
 a:b
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 2, key-bytes 2 B, value-bytes 1 B, tombstoned: 0))
 
 define
 a.SINGLEDEL.2:
@@ -1478,7 +1478,7 @@ next
 b:c
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 3, key-bytes 3 B, value-bytes 2 B, tombstoned: 0))
 
 define
 a.SINGLEDEL.3:
@@ -1491,7 +1491,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 3, key-bytes 3 B, value-bytes 2 B, tombstoned: 0))
 
 define
 a.SINGLEDEL.3:
@@ -1504,7 +1504,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 3, key-bytes 3 B, value-bytes 2 B, tombstoned: 0))
 
 define
 a.SINGLEDEL.4:
@@ -1518,7 +1518,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 4), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 6, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 4, key-bytes 4 B, value-bytes 6 B, tombstoned: 0))
 
 define
 a.SINGLEDEL.4:
@@ -1532,7 +1532,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 4), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 6, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 4, key-bytes 4 B, value-bytes 6 B, tombstoned: 0))
 
 define
 a.SINGLEDEL.4:
@@ -1546,7 +1546,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 4), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 3, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 4, key-bytes 4 B, value-bytes 3 B, tombstoned: 0))
 
 define
 a.SINGLEDEL.3:
@@ -1559,7 +1559,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 4, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 3, key-bytes 3 B, value-bytes 4 B, tombstoned: 0))
 
 # Exercise iteration with limits, when there are no deletes.
 define
@@ -1602,7 +1602,7 @@ a:a valid
 . at-limit
 a:a valid
 stats: (interface (dir, seek, step): (fwd, 1, 6), (rev, 1, 7)), (internal (dir, seek, step): (fwd, 3, 3), (rev, 1, 6)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 11, key-bytes 11, value-bytes 11, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 11, key-bytes 11 B, value-bytes 11 B, tombstoned: 0))
 
 # Exercise iteration with limits when we have deletes.
 
@@ -1650,7 +1650,7 @@ d:d valid
 d:d valid
 . exhausted
 stats: (interface (dir, seek, step): (fwd, 1, 10), (rev, 0, 5)), (internal (dir, seek, step): (fwd, 3, 13), (rev, 1, 8)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 21, key-bytes 21, value-bytes 14, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 21, key-bytes 21 B, value-bytes 14 B, tombstoned: 0))
 
 iter seq=4
 seek-ge-limit b d
@@ -1663,7 +1663,7 @@ next-limit e
 . at-limit
 d:d valid
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 9), (rev, 0, 5)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 15, key-bytes 15, value-bytes 9, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 15, key-bytes 15 B, value-bytes 9 B, tombstoned: 0))
 
 iter seq=4
 seek-lt-limit d c
@@ -1680,7 +1680,7 @@ a:a valid
 . exhausted
 a:a valid
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 4)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 5)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 6, key-bytes 6, value-bytes 4, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 6, key-bytes 6 B, value-bytes 4 B, tombstoned: 0))
 
 # NB: Zero values are skipped by deletable merger.
 define merger=deletable
@@ -1707,7 +1707,7 @@ prev
 .
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 2)), (internal (dir, seek, step): (fwd, 1, 8), (rev, 1, 8)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 16, key-bytes 16, value-bytes 24, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 16, key-bytes 16 B, value-bytes 24 B, tombstoned: 0))
 
 iter seq=4
 seek-ge a
@@ -1722,4 +1722,4 @@ b:3
 b:3
 a:2
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 2)), (internal (dir, seek, step): (fwd, 1, 6), (rev, 1, 6)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 16, key-bytes 16, value-bytes 24, tombstoned: 0))
+(internal-stats: (blocks: (count 0, cached-count 0, bytes 0 B, cached-bytes 0 B)), (points: (count 16, key-bytes 16 B, value-bytes 24 B, tombstoned: 0))

--- a/testdata/level_iter_seek
+++ b/testdata/level_iter_seek
@@ -109,21 +109,21 @@ reset-stats
 stats
 ----
 a/<invalid>#9,1:a
-{BlockBytes:34 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
-{BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:1 BlockBytes:34 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:0 BlockBytes:0 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 b#8,1:b
-{BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:0 BlockBytes:0 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 c#7,1:c
-{BlockBytes:34 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:1 BlockBytes:34 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 f#5,1:f
-{BlockBytes:34 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:1 BlockBytes:34 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 g#4,1:g
-{BlockBytes:68 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:2 BlockBytes:68 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 h#3,1:h
-{BlockBytes:68 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:2 BlockBytes:68 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 .
-{BlockBytes:68 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
-{BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:2 BlockBytes:68 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:0 BlockBytes:0 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 
 iter
 set-bounds lower=d

--- a/testdata/merging_iter
+++ b/testdata/merging_iter
@@ -40,8 +40,8 @@ c#27,1:27
 e#72057594037927935,15:
 e#10,1:10
 g#20,1:20
-{BlockBytes:72 BlockBytesInCache:0 KeyBytes:5 ValueBytes:8 PointCount:5 PointsCoveredByRangeTombstones:0}
-{BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:2 BlockBytes:72 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:5 ValueBytes:8 PointCount:5 PointsCoveredByRangeTombstones:0}
+{Blocks:0 BlockBytes:0 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 
 # seekGE() should not allow the rangedel to act on points in the lower sstable that are after it.
 iter
@@ -582,11 +582,11 @@ next
 stats
 ----
 a#30,1:30
-{BlockBytes:75 BlockBytesInCache:0 KeyBytes:1 ValueBytes:2 PointCount:1 PointsCoveredByRangeTombstones:0}
-{BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{Blocks:1 BlockBytes:75 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:1 ValueBytes:2 PointCount:1 PointsCoveredByRangeTombstones:0}
+{Blocks:0 BlockBytes:0 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 f#21,1:21
-{BlockBytes:0 BlockBytesInCache:0 KeyBytes:5 ValueBytes:10 PointCount:5 PointsCoveredByRangeTombstones:4}
+{Blocks:0 BlockBytes:0 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:5 ValueBytes:10 PointCount:5 PointsCoveredByRangeTombstones:4}
 g#72057594037927935,15:
-{BlockBytes:0 BlockBytesInCache:0 KeyBytes:6 ValueBytes:10 PointCount:6 PointsCoveredByRangeTombstones:4}
+{Blocks:0 BlockBytes:0 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:6 ValueBytes:10 PointCount:6 PointsCoveredByRangeTombstones:4}
 .
-{BlockBytes:0 BlockBytesInCache:0 KeyBytes:6 ValueBytes:10 PointCount:6 PointsCoveredByRangeTombstones:4}
+{Blocks:0 BlockBytes:0 BlocksInCache:0 BlockBytesInCache:0 KeyBytes:6 ValueBytes:10 PointCount:6 PointsCoveredByRangeTombstones:4}


### PR DESCRIPTION
...in iterator stats. Similar to the byte counts exported in #1538,
these numbers can come in handy when reasoning about block cache hit
rates for slow scans. Fix up some stat pretty printing units while here.