### PR TITLE
sstable: fix test suffix collector's handling of range keys

### DIFF
--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -842,7 +842,7 @@ func (c *suffixIntervalCollector) Add(key InternalKey, value []byte) error {
 		if !c.initialized {
 			c.lower, c.upper = uts, uts+1
 			c.initialized = true
-			return nil
+			continue
 		}
 		if uts < c.lower {
 			c.lower = uts


### PR DESCRIPTION
If uninitialized, previously the test suffixIntervalCollector block property
collector would only include the first key in its computed interval. This would
fail to capture all the range keys' suffixes.