### PR TITLE
docs: add benchmark annotation for data quality issue

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -59,6 +59,8 @@
         <div class="annotation" data-date="20211018">Read compaction fixes</div>
         <div class="annotation" data-date="20211109">Bumped benchmark
           runtime to 90 minutes</div>
+        <div class="annotation" data-date="20220330">Data quality issue introduced (YCSB A only)</div>
+        <div class="annotation" data-date="20220526">Data quality issue fixed (YCSB A only)</div>
       </div>
       <div class="section rows">
         <div>


### PR DESCRIPTION
Add an annotation to the Pebble nightly benchmarks page for the data
quality issue in YCSB between late-March and late-May.

See cockroachdb/cockroach#81871.