### PR TITLE
sstable: fix bug with two-level indexes, block props and bounds

### DIFF
--- a/sstable/block_test.go
+++ b/sstable/block_test.go
@@ -189,20 +189,9 @@ func TestBlockIter2(t *testing.T) {
 						return err.Error()
 					}
 
-					for _, arg := range d.CmdArgs {
-						switch arg.Key {
-						case "globalSeqNum":
-							if len(arg.Vals) != 1 {
-								return fmt.Sprintf("%s: arg %s expects 1 value", d.Cmd, arg.Key)
-							}
-							v, err := strconv.Atoi(arg.Vals[0])
-							if err != nil {
-								return err.Error()
-							}
-							iter.globalSeqNum = uint64(v)
-						default:
-							return fmt.Sprintf("%s: unknown arg: %s", d.Cmd, arg.Key)
-						}
+					iter.globalSeqNum, err = scanGlobalSeqNum(d)
+					if err != nil {
+						return err.Error()
 					}
 
 					var b bytes.Buffer

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -226,26 +226,24 @@ func runBuildRawCmd(
 	return meta, r, nil
 }
 
-func runIterCmd(td *datadriven.TestData, r *Reader) string {
+func scanGlobalSeqNum(td *datadriven.TestData) (uint64, error) {
 	for _, arg := range td.CmdArgs {
 		switch arg.Key {
 		case "globalSeqNum":
 			if len(arg.Vals) != 1 {
-				return fmt.Sprintf("%s: arg %s expects 1 value", td.Cmd, arg.Key)
+				return 0, errors.Errorf("%s: arg %s expects 1 value", td.Cmd, arg.Key)
 			}
 			v, err := strconv.Atoi(arg.Vals[0])
 			if err != nil {
-				return err.Error()
+				return 0, err
 			}
-			r.Properties.GlobalSeqNum = uint64(v)
-		default:
-			return fmt.Sprintf("%s: unknown arg: %s", td.Cmd, arg.Key)
+			return uint64(v), nil
 		}
 	}
-	origIter, err := r.NewIter(nil /* lower */, nil /* upper */)
-	if err != nil {
-		return err.Error()
-	}
+	return 0, nil
+}
+
+func runIterCmd(td *datadriven.TestData, origIter Iterator) string {
 	iter := newIterAdapter(origIter)
 	defer iter.Close()
 

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -1473,7 +1473,7 @@ func (i *twoLevelIterator) SeekLT(key []byte) (*InternalKey, []byte) {
 		// exceeded. Note that the previous entry starts with keys <=
 		// ikey.UserKey since even though this is the current block's
 		// separator, the same user key can span multiple index blocks.
-		if i.lower != nil && i.cmp(ikey.UserKey, i.upper) < 0 {
+		if i.lower != nil && i.cmp(ikey.UserKey, i.lower) < 0 {
 			i.exhaustedBounds = -1
 		}
 	}

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -359,7 +359,16 @@ func runTestReader(t *testing.T, o WriterOptions, dir string, r *Reader, cacheSi
 				return ""
 
 			case "iter":
-				return runIterCmd(d, r)
+				seqNum, err := scanGlobalSeqNum(d)
+				if err != nil {
+					return err.Error()
+				}
+				r.Properties.GlobalSeqNum = seqNum
+				iter, err := r.NewIter(nil /* lower */, nil /* upper */)
+				if err != nil {
+					return err.Error()
+				}
+				return runIterCmd(d, iter)
 
 			case "get":
 				var b bytes.Buffer

--- a/sstable/testdata/block_properties
+++ b/sstable/testdata/block_properties
@@ -288,3 +288,106 @@ ranges: false
 build collectors=(nil-points-and-ranges)
 ----
 sstable: at least one interval collector must be provided
+
+# Test a small index-block-size and block-size, so every data block has one KV
+# and every index block points to one data block.
+
+build collectors=(suffix-point-keys-only) index-block-size=1 block-size=1
+a@1.SET.1:foo
+b@10.SET.2:bar
+c@15.SET.3:baz
+d@25.SET.4:bax
+e@3.SET.5:box
+f@5.SET.3:mop
+----
+point:    [a@1#1,1,f@5#3,1]
+rangedel: [#0,0,#0,0]
+rangekey: [#0,0,#0,0]
+seqnums:  [1,5]
+
+collectors
+----
+0: suffix-point-keys-only
+
+table-props
+----
+0: [1, 26)
+
+# Because of the tiny index block size, every index block should have the same
+# properties as the single data block contained in the table. Indentation shows
+# the hierarchy.
+
+block-props
+----
+b#72057594037927935,17:
+  0: [1, 2)
+  b#72057594037927935,17:
+    0: [1, 2)
+c#72057594037927935,17:
+  0: [10, 11)
+  c#72057594037927935,17:
+    0: [10, 11)
+d#72057594037927935,17:
+  0: [15, 16)
+  d#72057594037927935,17:
+    0: [15, 16)
+e#72057594037927935,17:
+  0: [25, 26)
+  e#72057594037927935,17:
+    0: [25, 26)
+f#72057594037927935,17:
+  0: [3, 4)
+  f#72057594037927935,17:
+    0: [3, 4)
+g#72057594037927935,17:
+  0: [5, 6)
+  g#72057594037927935,17:
+    0: [5, 6)
+
+# Test the same sstable, but with a larger index block size that fits multiple
+# (3) KV pairs. Each entry in the top-level index should hold the unioned ranges
+# of all the data blocks' properties.
+
+build collectors=(suffix-point-keys-only) index-block-size=64 block-size=1
+a@1.SET.1:foo
+b@10.SET.2:bar
+c@15.SET.3:baz
+d@25.SET.4:bax
+e@3.SET.5:box
+f@5.SET.3:mop
+----
+point:    [a@1#1,1,f@5#3,1]
+rangedel: [#0,0,#0,0]
+rangekey: [#0,0,#0,0]
+seqnums:  [1,5]
+
+collectors
+----
+0: suffix-point-keys-only
+
+block-props
+----
+d#72057594037927935,17:
+  0: [1, 16)
+  b#72057594037927935,17:
+    0: [1, 2)
+  c#72057594037927935,17:
+    0: [10, 11)
+  d#72057594037927935,17:
+    0: [15, 16)
+g#72057594037927935,17:
+  0: [3, 26)
+  e#72057594037927935,17:
+    0: [25, 26)
+  f#72057594037927935,17:
+    0: [3, 4)
+  g#72057594037927935,17:
+    0: [5, 6)
+
+# Regression test for a bug in boundary checking when skipping over irrelevant
+# index blocks in a two-level indexed sstable.
+
+iter lower=a upper=z point-key-filter=(suffix-point-keys-only,1,2)
+seek-lt h
+----
+<a@1:1>


### PR DESCRIPTION
Fix a bug that could result in an iterator being prematurely exhausted when
iterating in the reverse direction configured with block-property filtering and
a lower iterator bound.

If a reverse iteration operation on an sstable finds that the first index block
of the two-level index is excluded by the block property filter, it enters
`skipBackward` to move to the previous entry in the two-level index block.  If
a lower bound is set, `skipBackward` compares each key in the two-level index
to the iterator's bounds to exit early if the bounds have already been
exceeded. This comparison accidentally compared against the upper bound instead
of the lower bound.