### PR TITLE
db: ensure HasPointAndRange returns false after SetOptions

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -221,12 +221,16 @@ func runIterCmd(d *datadriven.TestData, iter *Iterator, closeIter bool) string {
 			return fmt.Sprintf("unknown op: %s", parts[0])
 		}
 
-		if validityState == IterValid {
-			valid = true
-		}
+		valid = valid || validityState == IterValid
 		if valid != iter.Valid() {
 			fmt.Fprintf(&b, "mismatched valid states: %t vs %t\n", valid, iter.Valid())
 		}
+		hasPoint, hasRange := iter.HasPointAndRange()
+		hasEither := hasPoint || hasRange
+		if hasEither != valid {
+			fmt.Fprintf(&b, "mismatched valid/HasPointAndRange states: valid=%t HasPointAndRange=(%t,%t)\n", valid, hasPoint, hasRange)
+		}
+
 		if valid {
 			validityState = IterValid
 		}

--- a/iterator.go
+++ b/iterator.go
@@ -1639,10 +1639,10 @@ func (i *Iterator) saveRangeKey() {
 // HasPointAndRange indicates whether there exists a point key, a range key or
 // both at the current iterator position.
 func (i *Iterator) HasPointAndRange() (hasPoint, hasRange bool) {
-	if i.iterValidityState != IterValid {
+	if i.iterValidityState != IterValid || i.requiresReposition {
 		return false, false
 	}
-	if !i.opts.rangeKeys() {
+	if i.opts.KeyTypes == IterKeyTypePointsOnly {
 		return true, false
 	}
 	return !i.rangeKey.rangeKeyOnly, i.rangeKey.hasRangeKey


### PR DESCRIPTION
Fix a bug where a call to SetOptions would invalidate the Iterator (such that
Valid returns false), but HasPointAndRange could continue returning values from
the previous iterator state.

Add an assertion within the datadriven test output to ensure Valid and
HasPointAndRange are always consistent with one another.

Fix #1735.