### PR TITLE
internal/metamorphic: add block-property filter coverage 

### DIFF
--- a/db.go
+++ b/db.go
@@ -1078,10 +1078,7 @@ func constructPointIter(
 
 		li.init(dbi.opts, dbi.cmp, dbi.split, dbi.newIters, files, level, nil)
 		li.initRangeDel(&mlevels[mlevelsIndex].rangeDelIter)
-		li.initSmallestLargestUserKey(&mlevels[mlevelsIndex].smallestUserKey,
-			&mlevels[mlevelsIndex].largestUserKey,
-			&mlevels[mlevelsIndex].isLargestUserKeyRangeDelSentinel)
-		li.initIsSyntheticIterBoundsKey(&mlevels[mlevelsIndex].isSyntheticIterBoundsKey)
+		li.initBoundaryContext(&mlevels[mlevelsIndex].levelIterBoundaryContext)
 		mlevels[mlevelsIndex].iter = li
 
 		levelsIndex++

--- a/internal/metamorphic/parser.go
+++ b/internal/metamorphic/parser.go
@@ -77,7 +77,7 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	case *newIndexedBatchOp:
 		return nil, &t.batchID, nil
 	case *newIterOp:
-		return &t.readerID, &t.iterID, []interface{}{&t.lower, &t.upper, &t.keyTypes, &t.rangeKeyMaskSuffix}
+		return &t.readerID, &t.iterID, []interface{}{&t.lower, &t.upper, &t.keyTypes, &t.filterMin, &t.filterMax, &t.rangeKeyMaskSuffix}
 	case *newIterUsingCloneOp:
 		return &t.existingIterID, &t.iterID, []interface{}{&t.refreshBatch}
 	case *newSnapshotOp:
@@ -97,7 +97,7 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	case *iterSetBoundsOp:
 		return &t.iterID, nil, []interface{}{&t.lower, &t.upper}
 	case *iterSetOptionsOp:
-		return &t.iterID, nil, []interface{}{&t.lower, &t.upper, &t.keyTypes, &t.rangeKeyMaskSuffix}
+		return &t.iterID, nil, []interface{}{&t.lower, &t.upper, &t.keyTypes, &t.filterMin, &t.filterMax, &t.rangeKeyMaskSuffix}
 	case *singleDeleteOp:
 		return &t.writerID, nil, []interface{}{&t.key, &t.maybeReplaceDelete}
 	case *rangeKeyDeleteOp:
@@ -261,6 +261,14 @@ func (p *parser) parseArgs(op op, methodName string, args []interface{}) {
 				panic(err)
 			}
 			*t = uint32(val)
+
+		case *uint64:
+			_, lit := p.scanToken(token.INT)
+			val, err := strconv.ParseUint(lit, 0, 64)
+			if err != nil {
+				panic(err)
+			}
+			*t = uint64(val)
 
 		case *[]byte:
 			_, lit := p.scanToken(token.STRING)

--- a/internal/metamorphic/test.go
+++ b/internal/metamorphic/test.go
@@ -215,11 +215,16 @@ func (t *test) setBatch(id objID, b *pebble.Batch) {
 	t.batches[id.slot()] = b
 }
 
-func (t *test) setIter(id objID, i *pebble.Iterator) {
+func (t *test) setIter(id objID, i *pebble.Iterator, filterMin, filterMax uint64) {
 	if id.tag() != iterTag {
 		panic(fmt.Sprintf("invalid iter ID: %s", id))
 	}
-	t.iters[id.slot()] = &retryableIter{iter: i, lastKey: nil}
+	t.iters[id.slot()] = &retryableIter{
+		iter:      i,
+		lastKey:   nil,
+		filterMin: filterMin,
+		filterMax: filterMax,
+	}
 }
 
 func (t *test) setSnapshot(id objID, s *pebble.Snapshot) {

--- a/level_checker.go
+++ b/level_checker.go
@@ -47,9 +47,9 @@ import (
 
 // The per-level structure used by simpleMergingIter.
 type simpleMergingIterLevel struct {
-	iter            internalIterator
-	rangeDelIter    keyspan.FragmentIterator
-	smallestUserKey []byte
+	iter         internalIterator
+	rangeDelIter keyspan.FragmentIterator
+	levelIterBoundaryContext
 
 	iterKey   *InternalKey
 	iterValue []byte
@@ -636,7 +636,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 		li.init(iterOpts, c.cmp, nil /* split */, c.newIters, manifestIter,
 			manifest.L0Sublevel(sublevel), nil)
 		li.initRangeDel(&mlevelAlloc[0].rangeDelIter)
-		li.initSmallestLargestUserKey(&mlevelAlloc[0].smallestUserKey, nil, nil)
+		li.initBoundaryContext(&mlevelAlloc[0].levelIterBoundaryContext)
 		mlevelAlloc[0].iter = li
 		mlevelAlloc = mlevelAlloc[1:]
 	}
@@ -650,7 +650,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 		li.init(iterOpts, c.cmp, nil /* split */, c.newIters,
 			current.Levels[level].Iter(), manifest.Level(level), nil)
 		li.initRangeDel(&mlevelAlloc[0].rangeDelIter)
-		li.initSmallestLargestUserKey(&mlevelAlloc[0].smallestUserKey, nil, nil)
+		li.initBoundaryContext(&mlevelAlloc[0].levelIterBoundaryContext)
 		mlevelAlloc[0].iter = li
 		mlevelAlloc = mlevelAlloc[1:]
 	}

--- a/level_iter.go
+++ b/level_iter.go
@@ -73,7 +73,17 @@ type levelIter struct {
 	//   be relevant to the iteration.
 	iter     internalIteratorWithStats
 	iterFile *fileMetadata
-	newIters tableNewIters
+	// filteredIter is an optional interface that may be implemented by internal
+	// iterators that perform filtering of keys. When a new file's iterator is
+	// opened, it's tested to see if it implements filteredIter. If it does,
+	// it's stored here to allow the level iterator to recognize when keys were
+	// omitted from iteration results due to filtering. This is important when a
+	// file contains range deletions that may delete keys from other files. The
+	// levelIter must not advance to the next file until the mergingIter has
+	// advanced beyond the file's bounds. See
+	// levelIterBoundaryContext.isIgnorableBoundaryKey.
+	filteredIter filteredIter
+	newIters     tableNewIters
 	// When rangeDelIterPtr != nil, the caller requires that *rangeDelIterPtr must
 	// point to a range del iterator corresponding to the current file. When this
 	// iterator returns nil, *rangeDelIterPtr should also be set to nil. Whenever
@@ -90,7 +100,7 @@ type levelIter struct {
 	// stats accumulates the stats of iters that have been closed.
 	stats InternalIteratorStats
 
-	// Pointer into this level's entry into `mergingIterLevel::levelIterBoundaryContext`.
+	// Pointer into this level's entry in `mergingIterLevel::levelIterBoundaryContext`.
 	// We populate it with the corresponding bounds for the currently opened file. It is used for
 	// two purposes (described for forward iteration. The explanation for backward iteration is
 	// similar.)
@@ -145,6 +155,29 @@ type levelIter struct {
 	// which construct "impossible" situations (e.g. seeking to a key before the
 	// lower bound).
 	disableInvariants bool
+}
+
+// filteredIter is an additional interface implemented by iterators that may
+// skip over point keys during iteration. The sstable.Iterator implements this
+// interface.
+type filteredIter interface {
+	// MaybeFilteredKeys may be called when an iterator is exhausted, indicating
+	// whether or not the iterator's last positioning method may have skipped
+	// any keys due to low-level filters.
+	//
+	// When an iterator is configured to use block-property filters, the
+	// low-level iterator may skip over blocks or whole sstables of keys.
+	// Implementations that implement skipping must implement this interface.
+	// Higher-level iterators require it to preserve invariants (eg, a levelIter
+	// used in a mergingIter must keep the file's range-del iterator open until
+	// the mergingIter has moved past the file's bounds, even if all of the
+	// file's point keys were filtered).
+	//
+	// MaybeFilteredKeys may always return false positives, that is it may
+	// return true when no keys were filtered. It should only be called when the
+	// iterator is exhausted. It must never return false negatives when the
+	// iterator is exhausted.
+	MaybeFilteredKeys() bool
 }
 
 // levelIter implements the base.InternalIterator interface.
@@ -275,6 +308,7 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) loadFileReturnIndicato
 	l.largestBoundary = nil
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
+		l.boundaryContext.isIgnorableBoundaryKey = false
 	}
 	if l.iterFile == file {
 		if l.err != nil {
@@ -333,6 +367,15 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) loadFileReturnIndicato
 		if l.err != nil {
 			return noFileLoaded
 		}
+		if rangeDelIter != nil {
+			if fi, ok := iter.(filteredIter); ok {
+				l.filteredIter = fi
+			} else {
+				l.filteredIter = nil
+			}
+		} else {
+			l.filteredIter = nil
+		}
 		if l.rangeDelIterPtr != nil {
 			*l.rangeDelIterPtr = rangeDelIter
 			l.rangeDelIterCopy = rangeDelIter
@@ -372,6 +415,7 @@ func (l *levelIter) SeekGE(key []byte, trySeekUsingNext bool) (*InternalKey, []b
 	l.err = nil // clear cached iteration error
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
+		l.boundaryContext.isIgnorableBoundaryKey = false
 	}
 
 	// NB: the top-level Iterator has already adjusted key based on
@@ -397,6 +441,7 @@ func (l *levelIter) SeekPrefixGE(
 	l.err = nil // clear cached iteration error
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
+		l.boundaryContext.isIgnorableBoundaryKey = false
 	}
 
 	// NB: the top-level Iterator has already adjusted key based on
@@ -416,9 +461,8 @@ func (l *levelIter) SeekPrefixGE(
 	// When SeekPrefixGE returns nil, we have not necessarily reached the end of
 	// the sstable. All we know is that a key with prefix does not exist in the
 	// current sstable. We do know that the key lies within the bounds of the
-	// table as findFileGE found the table where key <= meta.Largest. We treat
-	// this case the same as SeekGE where an upper-bound resides within the
-	// sstable and generate a synthetic boundary key.
+	// table as findFileGE found the table where key <= meta.Largest. We return
+	// the table's bound with isIgnorableBoundaryKey set.
 	if l.rangeDelIterPtr != nil && *l.rangeDelIterPtr != nil {
 		if l.tableOpts.UpperBound != nil {
 			l.syntheticBoundary.UserKey = l.tableOpts.UpperBound
@@ -426,14 +470,18 @@ func (l *levelIter) SeekPrefixGE(
 			l.largestBoundary = &l.syntheticBoundary
 			if l.boundaryContext != nil {
 				l.boundaryContext.isSyntheticIterBoundsKey = true
+				l.boundaryContext.isIgnorableBoundaryKey = false
 			}
 			return l.verify(l.largestBoundary, nil)
 		}
-		l.syntheticBoundary = l.iterFile.LargestPointKey
-		l.syntheticBoundary.SetKind(InternalKeyKindRangeDelete)
-		l.largestBoundary = &l.syntheticBoundary
+		// Return the file's largest bound, ensuring this file stays open until
+		// the mergingIter advances beyond the file's bounds. We set
+		// isIgnorableBoundaryKey to signal that the actual key returned should
+		// be ignored, and does not represent a real key in the database.
+		l.largestBoundary = &l.iterFile.LargestPointKey
 		if l.boundaryContext != nil {
 			l.boundaryContext.isSyntheticIterBoundsKey = false
+			l.boundaryContext.isIgnorableBoundaryKey = true
 		}
 		return l.verify(l.largestBoundary, nil)
 	}
@@ -455,6 +503,7 @@ func (l *levelIter) SeekLT(key []byte) (*InternalKey, []byte) {
 	l.err = nil // clear cached iteration error
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
+		l.boundaryContext.isIgnorableBoundaryKey = false
 	}
 
 	// NB: the top-level Iterator has already adjusted key based on
@@ -472,6 +521,7 @@ func (l *levelIter) First() (*InternalKey, []byte) {
 	l.err = nil // clear cached iteration error
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
+		l.boundaryContext.isIgnorableBoundaryKey = false
 	}
 
 	// NB: the top-level Iterator will call SeekGE if IterOptions.LowerBound is
@@ -489,6 +539,7 @@ func (l *levelIter) Last() (*InternalKey, []byte) {
 	l.err = nil // clear cached iteration error
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
+		l.boundaryContext.isIgnorableBoundaryKey = false
 	}
 
 	// NB: the top-level Iterator will call SeekLT if IterOptions.UpperBound is
@@ -508,6 +559,7 @@ func (l *levelIter) Next() (*InternalKey, []byte) {
 	}
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
+		l.boundaryContext.isIgnorableBoundaryKey = false
 	}
 
 	switch {
@@ -548,6 +600,7 @@ func (l *levelIter) Prev() (*InternalKey, []byte) {
 	}
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
+		l.boundaryContext.isIgnorableBoundaryKey = false
 	}
 
 	switch {
@@ -634,6 +687,32 @@ func (l *levelIter) skipEmptyFileForward() (*InternalKey, []byte) {
 				l.largestBoundary = &l.iterFile.LargestPointKey
 				return l.largestBoundary, nil
 			}
+			// If the last point iterator positioning op might've skipped keys,
+			// it's possible the file's range deletions are still relevant to
+			// other levels. Return the largest boundary as a special ignorable
+			// marker to avoid advancing to the next file.
+			//
+			// The sstable iterator cannot guarantee that keys were skipped. A
+			// SeekGE that lands on a index separator k only knows that the
+			// block at the index entry contains keys ≤ k. We can't know whether
+			// there were actually keys between the seek key and the index
+			// separator key. If the block is then excluded due to block
+			// property filters, the iterator does not know whether keys were
+			// actually skipped by the block's exclusion.
+			//
+			// Since MaybeFilteredKeys cannot guarantee that keys were skipped,
+			// it's possible l.iterFile.Largest was already returned. Returning
+			// l.iterFile.Largest again is a violation of the strict
+			// monotonicity normally provided. The mergingIter's heap can
+			// tolerate this repeat key and in this case will keep the level at
+			// the top of the heap and immediately skip the entry, advancing to
+			// the next file.
+			if *l.rangeDelIterPtr != nil && l.filteredIter != nil &&
+				l.filteredIter.MaybeFilteredKeys() {
+				l.largestBoundary = &l.iterFile.Largest
+				l.boundaryContext.isIgnorableBoundaryKey = true
+				return l.largestBoundary, nil
+			}
 		}
 
 		// Current file was exhausted. Move to the next file.
@@ -693,6 +772,31 @@ func (l *levelIter) skipEmptyFileBackward() (*InternalKey, []byte) {
 			// If the boundary is a range deletion tombstone, return that key.
 			if l.iterFile.SmallestPointKey.Kind() == InternalKeyKindRangeDelete {
 				l.smallestBoundary = &l.iterFile.SmallestPointKey
+				return l.smallestBoundary, nil
+			}
+			// If the last point iterator positioning op skipped keys, it's
+			// possible the file's range deletions are still relevant to other
+			// levels. Return the smallest boundary as a special ignorable key
+			// to avoid advancing to the next file.
+			//
+			// The sstable iterator cannot guarantee that keys were skipped.  A
+			// SeekGE that lands on a index separator k only knows that the
+			// block at the index entry contains keys ≤ k. We can't know whether
+			// there were actually keys between the seek key and the index
+			// separator key. If the block is then excluded due to block
+			// property filters, the iterator does not know whether keys were
+			// actually skipped by the block's exclusion.
+			//
+			// Since MaybeFilteredKeys cannot guarantee that keys were skipped,
+			// it's possible l.iterFile.Smallest was already returned. Returning
+			// l.iterFile.Smallest again is a violation of the strict
+			// monotonicity normally provided. The mergingIter's heap can
+			// tolerate this repeat key and in this case will keep the level at
+			// the top of the heap and immediately skip the entry, advancing to
+			// the next file.
+			if *l.rangeDelIterPtr != nil && l.filteredIter != nil && l.filteredIter.MaybeFilteredKeys() {
+				l.smallestBoundary = &l.iterFile.Smallest
+				l.boundaryContext.isIgnorableBoundaryKey = true
 				return l.smallestBoundary, nil
 			}
 		}

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -26,12 +26,10 @@ type mergingIterLevel struct {
 	iterKey   *InternalKey
 	iterValue []byte
 
-	// smallestUserKey, largestUserKey, isLargestUserKeyRangeDelSentinel are set using the sstable
-	// boundary keys when using levelIter. See levelIter comment and the Range Deletions comment
-	// below.
-	smallestUserKey, largestUserKey  []byte
-	isLargestUserKeyRangeDelSentinel bool
-	isSyntheticIterBoundsKey         bool
+	// levelIterBoundaryContext's fields are set when using levelIter, in order
+	// to surface sstable boundary keys and file-level context. See levelIter
+	// comment and the Range Deletions comment below.
+	levelIterBoundaryContext
 
 	// tombstone caches the tombstone rangeDelIter is currently pointed at. If
 	// tombstone is nil, there are no further tombstones within the
@@ -40,6 +38,22 @@ type mergingIterLevel struct {
 	// positioning tombstones at lower levels which cannot possibly shadow the
 	// current key.
 	tombstone *keyspan.Span
+}
+
+type levelIterBoundaryContext struct {
+	// smallestUserKey and largestUserKey are populated with the smallest and
+	// largest boundaries of the current file.
+	smallestUserKey, largestUserKey []byte
+	// isLargestUserKeyRangeDelSentinel is set to true when a file's largest
+	// boundary is an exclusive range deletion sentinel. If true, the file does
+	// not contain any keys with the provided user key, and the largestUserKey
+	// bound is exclusive.
+	isLargestUserKeyRangeDelSentinel bool
+	// isSyntheticIterBoundsKey is set to true iff the key returned by the level
+	// iterator is a synthetic key derived from the iterator bounds. This is
+	// used to prevent the mergingIter from being stuck at such a synthetic key
+	// if it becomes the top element of the heap.
+	isSyntheticIterBoundsKey bool
 }
 
 // mergingIter provides a merged view of multiple iterators from different

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -251,9 +251,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 				i := len(levelIters)
 				levelIters = append(levelIters, mergingIterLevel{iter: li})
 				li.initRangeDel(&levelIters[i].rangeDelIter)
-				li.initSmallestLargestUserKey(
-					&levelIters[i].smallestUserKey, &levelIters[i].largestUserKey, &levelIters[i].isLargestUserKeyRangeDelSentinel)
-				li.initIsSyntheticIterBoundsKey(&levelIters[i].isSyntheticIterBoundsKey)
+				li.initBoundaryContext(&levelIters[i].levelIterBoundaryContext)
 			}
 			miter := &mergingIter{}
 			miter.init(nil /* opts */, cmp, func(a []byte) int { return len(a) }, levelIters...)
@@ -585,10 +583,7 @@ func buildMergingIter(readers [][]*sstable.Reader, levelSlices []manifest.LevelS
 			func(a []byte) int { return len(a) }, newIters, levelSlices[i].Iter(),
 			manifest.Level(level), nil)
 		l.initRangeDel(&mils[level].rangeDelIter)
-		l.initSmallestLargestUserKey(
-			&mils[level].smallestUserKey, &mils[level].largestUserKey,
-			&mils[level].isLargestUserKeyRangeDelSentinel)
-		l.initIsSyntheticIterBoundsKey(&mils[level].isSyntheticIterBoundsKey)
+		l.initBoundaryContext(&mils[level].levelIterBoundaryContext)
 		mils[level].iter = l
 	}
 	m := &mergingIter{}

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -7,6 +7,7 @@ package sstable
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"math"
 	"math/rand"
 	"sort"
@@ -1171,7 +1172,10 @@ func TestBlockProperties(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			return runIterCmd(td, iter)
+			return runIterCmd(td, iter, runIterCmdEveryOp(func(w io.Writer) {
+				// After every op, point the value of MaybeFilteredKeys.
+				fmt.Fprintf(w, " MaybeFilteredKeys()=%t", iter.MaybeFilteredKeys())
+			}))
 
 		default:
 			return fmt.Sprintf("unknown command: %s", td.Cmd)

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -1549,7 +1549,7 @@ func (i *twoLevelIterator) Last() (*InternalKey, []byte) {
 		// the previous entry starts with keys <= ikey.UserKey since even
 		// though this is the current block's separator, the same user key
 		// can span multiple index blocks.
-		if i.lower != nil && i.cmp(ikey.UserKey, i.upper) < 0 {
+		if i.lower != nil && i.cmp(ikey.UserKey, i.lower) < 0 {
 			i.exhaustedBounds = -1
 		}
 	}
@@ -1654,7 +1654,7 @@ func (i *twoLevelIterator) skipBackward() (*InternalKey, []byte) {
 			// the previous entry starts with keys <= ikey.UserKey since even
 			// though this is the current block's separator, the same user key
 			// can span multiple index blocks.
-			if i.lower != nil && i.cmp(ikey.UserKey, i.upper) < 0 {
+			if i.lower != nil && i.cmp(ikey.UserKey, i.lower) < 0 {
 				i.exhaustedBounds = -1
 				// Next iteration will return.
 			}

--- a/sstable/testdata/block_properties
+++ b/sstable/testdata/block_properties
@@ -387,6 +387,54 @@ g#72057594037927935,17:
 # Regression test for a bug in boundary checking when skipping over irrelevant
 # index blocks in a two-level indexed sstable.
 
+iter lower=a point-key-filter=(suffix-point-keys-only,1,2)
+seek-lt h
+last
+----
+<a@1:1>
+<a@1:1>
+
+# Same as above, but each index block holds 2 keys. This exercises a variant of
+# the above bug. Specifically, the bounds check performed /within/ skipBackward,
+# instead of within SeekLT and Last.
+
+build collectors=(suffix-point-keys-only) index-block-size=48 block-size=1
+a@1.SET.1:foo
+b@10.SET.2:bar
+c@15.SET.3:baz
+d@25.SET.4:bax
+e@3.SET.5:box
+f@5.SET.3:mop
+----
+point:    [a@1#1,1,f@5#3,1]
+rangedel: [#0,0,#0,0]
+rangekey: [#0,0,#0,0]
+seqnums:  [1,5]
+
+block-props
+----
+c#72057594037927935,17:
+  0: [1, 11)
+  b#72057594037927935,17:
+    0: [1, 2)
+  c#72057594037927935,17:
+    0: [10, 11)
+e#72057594037927935,17:
+  0: [15, 26)
+  d#72057594037927935,17:
+    0: [15, 16)
+  e#72057594037927935,17:
+    0: [25, 26)
+g#72057594037927935,17:
+  0: [3, 6)
+  f#72057594037927935,17:
+    0: [3, 4)
+  g#72057594037927935,17:
+    0: [5, 6)
+
+# Regression test for a bug in boundary checking when skipping over irrelevant
+# index blocks in a two-level indexed sstable.
+
 iter lower=a upper=z point-key-filter=(suffix-point-keys-only,1,2)
 seek-lt h
 ----

--- a/sstable/testdata/block_properties
+++ b/sstable/testdata/block_properties
@@ -391,8 +391,8 @@ iter lower=a point-key-filter=(suffix-point-keys-only,1,2)
 seek-lt h
 last
 ----
-<a@1:1>
-<a@1:1>
+<a@1:1> MaybeFilteredKeys()=true
+<a@1:1> MaybeFilteredKeys()=true
 
 # Same as above, but each index block holds 2 keys. This exercises a variant of
 # the above bug. Specifically, the bounds check performed /within/ skipBackward,
@@ -438,4 +438,234 @@ g#72057594037927935,17:
 iter lower=a upper=z point-key-filter=(suffix-point-keys-only,1,2)
 seek-lt h
 ----
-<a@1:1>
+<a@1:1> MaybeFilteredKeys()=true
+
+# Test MaybeFilteredKeys().
+
+# Use timestamp range [1,9), which matches a@1, e@3 and f@5 and filters
+# a continuous section of three keys b@10, c@15 and d@25.
+
+iter point-key-filter=(suffix-point-keys-only,1,9)
+first
+next
+next
+next
+seek-ge b
+seek-ge e@3
+----
+<a@1:1> MaybeFilteredKeys()=false
+<e@3:5> MaybeFilteredKeys()=true
+<f@5:3> MaybeFilteredKeys()=false
+. MaybeFilteredKeys()=false
+<e@3:5> MaybeFilteredKeys()=true
+<e@3:5> MaybeFilteredKeys()=false
+
+
+# NB: `seek-ge e` and `seek-ge dog` return MaybeFilteredKeys()=true, despite no
+# filtered keys existing within the range [e,e@3) or [dog,e@3). This is a
+# consequence of the index separator `e`. After seeking the index block, the
+# iterator only knows that the first block MAY contain keys ≤ e. However, it can
+# be skipped regardless, because block properties filters exclude it. In this
+# case, the iterator still returns MaybeFilteredKeys()=true, since keys MAY have
+# been excluded by the filter.
+
+iter point-key-filter=(suffix-point-keys-only,1,9)
+seek-ge e
+seek-ge dog
+----
+<e@3:5> MaybeFilteredKeys()=true
+<e@3:5> MaybeFilteredKeys()=true
+
+iter point-key-filter=(suffix-point-keys-only,1,100)
+first
+next
+next
+next
+next
+next
+next
+seek-lt d
+seek-ge d
+----
+<a@1:1> MaybeFilteredKeys()=false
+<b@10:2> MaybeFilteredKeys()=false
+<c@15:3> MaybeFilteredKeys()=false
+<d@25:4> MaybeFilteredKeys()=false
+<e@3:5> MaybeFilteredKeys()=false
+<f@5:3> MaybeFilteredKeys()=false
+. MaybeFilteredKeys()=false
+<c@15:3> MaybeFilteredKeys()=false
+<d@25:4> MaybeFilteredKeys()=false
+
+# [10,16) intersects {b@10, c@15}.
+
+iter point-key-filter=(suffix-point-keys-only,10,16)
+last
+prev
+prev
+seek-lt a
+seek-lt c
+seek-lt ca
+seek-lt f
+seek-lt e
+seek-lt d
+----
+<c@15:3> MaybeFilteredKeys()=true
+<b@10:2> MaybeFilteredKeys()=false
+. MaybeFilteredKeys()=true
+. MaybeFilteredKeys()=true
+<b@10:2> MaybeFilteredKeys()=false
+<c@15:3> MaybeFilteredKeys()=false
+<c@15:3> MaybeFilteredKeys()=true
+<c@15:3> MaybeFilteredKeys()=true
+<c@15:3> MaybeFilteredKeys()=false
+
+# Test monotonically increasing bounds optimization, with the first seek
+# filtering keys. The subsequent seek must not reuse the current iterator
+# position and improperly returning MaybeFilteredKeys=false when keys were
+# filtered.
+
+iter point-key-filter=(suffix-point-keys-only,10,16)
+set-bounds lower=b upper=ee
+seek-ge d
+set-bounds lower=ee upper=g
+seek-ge ee
+----
+. MaybeFilteredKeys()=false
+. MaybeFilteredKeys()=true
+. MaybeFilteredKeys()=true
+. MaybeFilteredKeys()=true
+
+iter point-key-filter=(suffix-point-keys-only,10,16)
+set-bounds lower=a upper=b
+seek-ge a
+set-bounds lower=b upper=e
+seek-ge b
+seek-ge bb
+----
+. MaybeFilteredKeys()=false
+. MaybeFilteredKeys()=true
+. MaybeFilteredKeys()=true
+<b@10:2> MaybeFilteredKeys()=true
+<c@15:3> MaybeFilteredKeys()=false
+
+# Test monotonically decreasing bounds optimization, with the first seek
+# filtering keys. The subsequent seek must not reuse the current iterator
+# position and improperly returning MaybeFilteredKeys=false when keys were
+# filtered.
+
+iter point-key-filter=(suffix-point-keys-only,10,16)
+set-bounds lower=e upper=f
+seek-lt f
+set-bounds lower=c upper=e
+seek-lt e
+set-bounds lower=a upper=c
+seek-lt c
+seek-lt b
+----
+. MaybeFilteredKeys()=false
+. MaybeFilteredKeys()=true
+. MaybeFilteredKeys()=true
+<c@15:3> MaybeFilteredKeys()=true
+. MaybeFilteredKeys()=true
+<b@10:2> MaybeFilteredKeys()=false
+. MaybeFilteredKeys()=true
+
+# The below case tests try-seek-using-next.
+#
+# The `seek-ge aa` does not reposition the iterator. This case should preserve
+# the existing MaybeFilteredKeys()=true value.
+#
+# The `seek-ge c@16` and seek-ge c@19` must also return MaybeFilteredKeys()=true.
+
+iter point-key-filter=(suffix-point-keys-only,10,16)
+seek-ge a
+seek-ge aa true
+seek-ge bb true
+seek-ge c@16 true
+seek-ge c@19 true
+----
+<b@10:2> MaybeFilteredKeys()=true
+<b@10:2> MaybeFilteredKeys()=true
+<c@15:3> MaybeFilteredKeys()=false
+. MaybeFilteredKeys()=true
+. MaybeFilteredKeys()=true
+
+# Test another case of monotonically increasing bounds optimization, with a
+# different index block structure. The first seek down below should filter keys,
+# and leave the top-level index positioned at the last index block. The
+# subsequent seek must return MaybeFilteredKeys=true when keys were filtered.
+
+build collectors=(suffix-point-keys-only) index-block-size=1 block-size=64
+a@1.SET.1:foo
+b@10.SET.2:bar
+c@15.SET.3:baz
+d@25.SET.4:bax
+e@3.SET.5:box
+f@5.SET.3:mop
+----
+point:    [a@1#1,1,f@5#3,1]
+rangedel: [#0,0,#0,0]
+rangekey: [#0,0,#0,0]
+seqnums:  [1,5]
+
+block-props
+----
+d#72057594037927935,17:
+  0: [1, 16)
+  d#72057594037927935,17:
+    0: [1, 16)
+g#72057594037927935,17:
+  0: [3, 26)
+  g#72057594037927935,17:
+    0: [3, 26)
+
+iter point-key-filter=(suffix-point-keys-only,1,2)
+set-bounds lower=b upper=e
+seek-ge d
+set-bounds lower=e upper=g
+seek-ge ee
+----
+. MaybeFilteredKeys()=false
+. MaybeFilteredKeys()=true
+. MaybeFilteredKeys()=true
+. MaybeFilteredKeys()=true
+
+# Test another case of monotonically increasing bounds optimization, with a new
+# index block structure: This one has only one level. The first seek down below
+# should filter keys, and leave the index positioned at the last index block.
+# The subsequent seek must return MaybeFilteredKeys=true when keys were
+# filtered.
+
+build collectors=(suffix-point-keys-only) block-size=32
+a@1.SET.1:foo
+b@10.SET.2:bar
+c@15.SET.3:baz
+d@25.SET.4:bax
+e@3.SET.5:box
+f@5.SET.3:mop
+----
+point:    [a@1#1,1,f@5#3,1]
+rangedel: [#0,0,#0,0]
+rangekey: [#0,0,#0,0]
+seqnums:  [1,5]
+
+block-props
+----
+c#72057594037927935,17:
+  0: [1, 11)
+e#72057594037927935,17:
+  0: [15, 26)
+g#72057594037927935,17:
+  0: [3, 6)
+
+iter point-key-filter=(suffix-point-keys-only,1,2)
+set-bounds lower=b upper=ee
+seek-ge d
+set-bounds lower=ee upper=g
+seek-ge ee
+----
+. MaybeFilteredKeys()=false
+. MaybeFilteredKeys()=true
+. MaybeFilteredKeys()=true
+. MaybeFilteredKeys()=true

--- a/testdata/level_iter_seek
+++ b/testdata/level_iter_seek
@@ -56,16 +56,16 @@ c#7,1:c
 d#72057594037927935,15:
 .
 
-# There is no point key with d, but since there is a rangedel, levelIter
-# returns a synthetic boundary key using the largest key, f, in the file.
+# There is no point key with d, but since there is a rangedel, levelIter returns
+# the boundary key using the largest key, f, in the file.
 iter
 seek-prefix-ge d
 ----
-f/d-e:{(#6,RANGEDEL)}#5,15:
+f/d-e:{(#6,RANGEDEL)}#5,1:
 
 # Tests a sequence of SeekPrefixGE with monotonically increasing keys, some of
 # which are present and some not (so fail the bloom filter match). The seek to
-# cc returns a synthetic boundary key.
+# cc returns a boundary key.
 iter
 seek-prefix-ge aa
 seek-prefix-ge c
@@ -77,7 +77,7 @@ seek-prefix-ge h
 ----
 ./<invalid>#0,0:
 c/d-e:{(#6,RANGEDEL)}#7,1:c
-f/d-e:{(#6,RANGEDEL)}#5,15:
+f/d-e:{(#6,RANGEDEL)}#5,1:
 f/<invalid>#5,1:f
 g/<invalid>#4,1:g
 ./<invalid>#0,0:


### PR DESCRIPTION
**sstable: fix additional bounds check bugs**

In 4406dabc a bounds-checking bug was fixed in the two-level index
iterator's SeekLT method. The same bug existed within Last and
skipBackward and was missed.

**db: refactor levelIter/mergingIter boundary interface**

The levelIter and mergingIter are tightly coupled in a few places, with the
levelIter passing additional context to the mergingIter by writing into fields
owned by the mergingIter. This commit is a small refactor to organize these
fields together into a `levelIterBoundaryContext` struct. This is in
preparation for adding an additional field.

**db: don't filter range deletions based on point-key block filters**

Previously, if an iterator configured with a block-property filter encountered
a table that contained all excluded point keys, the iterator would skip the
table entirely, including its range deletions. An iterator configured with a
block-property filter could observe keys outside the filtered range that no
longer exist.

This behavior was fine from CockroachDB's perspective, which always pairs a
filtered iterator with an unfiltered iterator, seeking the latter in tandem.
The behavior is likely to be surprising in non-CockroachDB use cases.
Additionally, the behavior is an obstacle to range-key masking which must
respect range deletions for keys not covered by the masking range key.

This change requires additional coordination between the mergingIter and
levelIter to ensure that a levelIter doesn't close a file while other levels
still require its range deletions. This coordination takes the form a new
`isIgnorableBoundaryKey` field. The levelIter may return a file's smallest or
largest boundary key [without any value], setting `isIgnorableBoundaryKey` to
true to signal the key doesn't repesent a real KV pair. This scheme is also
extended to SeekPrefixGE, which previously synthesized a RANGEDEL key to serve
a similar purpose.

**internal/metamorphic: add block-property filter coverage**

Add test coverage for block-property filters to the metamorphic tests.
Division of keys into blocks are nondeterministic, so this introduces
nondeterminism into Iterator behavior. To account for this, the metamorphic
test's iterator wrapper is adjusted to skip any keys that are eligible for
filtering.

Fix https://github.com/cockroachdb/pebble/issues/1725.