### PR TITLE
internal/keyspan: preallocate merging iter levels, items

### DIFF
--- a/external_iterator.go
+++ b/external_iterator.go
@@ -137,7 +137,7 @@ func NewExternalIter(
 		dbi.rangeKey.cmp = o.Comparer.Compare
 		dbi.rangeKey.split = o.Comparer.Split
 		dbi.rangeKey.opts = &dbi.opts
-		dbi.rangeKey.rangeKeyIter = dbi.rangeKey.alloc.Init(
+		dbi.rangeKey.rangeKeyIter = dbi.rangeKey.iterConfig.Init(
 			o.Comparer.Compare,
 			base.InternalKeySeqNumMax,
 			rangeKeyIters...,

--- a/internal/rangekey/coalesce.go
+++ b/internal/rangekey/coalesce.go
@@ -45,6 +45,12 @@ func (ui *UserIteratorConfig) Init(
 	return &ui.diter
 }
 
+// AddLevel adds a new level to the bottom of the iterator stack. AddLevel
+// must be called after Init and before any other method on the iterator.
+func (ui *UserIteratorConfig) AddLevel(iter keyspan.FragmentIterator) {
+	ui.miter.AddLevel(iter)
+}
+
 // Transform implements the keyspan.Transformer interface for use with a
 // keyspan.MergingIter. It transforms spans by resolving range keys at the
 // provided snapshot sequence number. Shadowing of keys is resolved (eg, removal

--- a/iterator.go
+++ b/iterator.go
@@ -265,11 +265,11 @@ type iteratorRangeKeyState struct {
 	// Start and end boundaries, suffixes and values are all copied into buf.
 	buf []byte
 
-	// alloc holds fields that are used for the construction of the
-	// iterator stack, but do not need to be directly accessed during
-	// iteration. These fields are bundled within the
-	// iteratorRangeKeyState struct to reduce allocations.
-	alloc rangekey.UserIteratorConfig
+	// iterConfig holds fields that are used for the construction of the
+	// iterator stack, but do not need to be directly accessed during iteration.
+	// This struct is bundled within the iteratorRangeKeyState struct to reduce
+	// allocations.
+	iterConfig rangekey.UserIteratorConfig
 }
 
 var iterRangeKeyStateAllocPool = sync.Pool{


### PR DESCRIPTION
Take care of a pending TODO, and avoid allocations when the range-key iterator
stack has any child iterators. This has a minor effect on the MVCCGet
benchmarks that use a batch, which requires the batch to be included within the
range key merging iter.

```
name                                                    old time/op    new time/op    delta
MVCCGet_Pebble/batch=false/versions=1/valueSize=8-10      4.03µs ± 1%    4.06µs ± 1%  +0.61%  (p=0.026 n=9+10)
MVCCGet_Pebble/batch=false/versions=10/valueSize=8-10     4.90µs ± 1%    4.86µs ± 4%    ~     (p=0.210 n=10+10)
MVCCGet_Pebble/batch=false/versions=100/valueSize=8-10    9.91µs ± 2%    9.97µs ± 2%    ~     (p=0.271 n=10+10)
MVCCGet_Pebble/batch=true/versions=1/valueSize=8-10       2.54µs ± 2%    2.50µs ± 1%  -1.54%  (p=0.003 n=10+10)
MVCCGet_Pebble/batch=true/versions=10/valueSize=8-10      3.63µs ± 2%    3.38µs ± 2%  -6.99%  (p=0.000 n=10+10)
MVCCGet_Pebble/batch=true/versions=100/valueSize=8-10     7.90µs ± 1%    8.03µs ± 4%  +1.71%  (p=0.024 n=10+10)

name                                                    old speed      new speed      delta
MVCCGet_Pebble/batch=false/versions=1/valueSize=8-10    1.98MB/s ± 1%  1.97MB/s ± 0%  -0.51%  (p=0.024 n=9+7)
MVCCGet_Pebble/batch=false/versions=10/valueSize=8-10   1.63MB/s ± 1%  1.65MB/s ± 4%    ~     (p=0.137 n=10+10)
MVCCGet_Pebble/batch=false/versions=100/valueSize=8-10   807kB/s ± 2%   803kB/s ± 1%    ~     (p=0.290 n=10+10)
MVCCGet_Pebble/batch=true/versions=1/valueSize=8-10     3.15MB/s ± 2%  3.20MB/s ± 1%  +1.55%  (p=0.003 n=10+10)
MVCCGet_Pebble/batch=true/versions=10/valueSize=8-10    2.20MB/s ± 2%  2.36MB/s ± 1%  +7.38%  (p=0.000 n=10+9)
MVCCGet_Pebble/batch=true/versions=100/valueSize=8-10   1.01MB/s ± 1%  1.00MB/s ± 2%  -1.30%  (p=0.025 n=10+9)
```