### PR TITLE
db: add Len method to Batch

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -791,6 +791,11 @@ func (b *Batch) Empty() bool {
 	return len(b.data) <= batchHeaderLen
 }
 
+// Len returns the current size of the batch in bytes.
+func (b *Batch) Len() int {
+	return len(b.data)
+}
+
 // Repr returns the underlying batch representation. It is not safe to modify
 // the contents. Reset() will not change the contents of the returned value,
 // though any other mutation operation may do so.

--- a/batch.go
+++ b/batch.go
@@ -793,7 +793,10 @@ func (b *Batch) Empty() bool {
 
 // Len returns the current size of the batch in bytes.
 func (b *Batch) Len() int {
-	return len(b.data) + batchHeaderLen
+	if len(b.data) <= batchHeaderLen {
+		return batchHeaderLen
+	}
+	return len(b.data)
 }
 
 // Repr returns the underlying batch representation. It is not safe to modify

--- a/batch.go
+++ b/batch.go
@@ -793,7 +793,7 @@ func (b *Batch) Empty() bool {
 
 // Len returns the current size of the batch in bytes.
 func (b *Batch) Len() int {
-	return len(b.data)
+	return len(b.data) + batchHeaderLen
 }
 
 // Repr returns the underlying batch representation. It is not safe to modify

--- a/batch_test.go
+++ b/batch_test.go
@@ -145,6 +145,30 @@ func TestBatch(t *testing.T) {
 	verifyTestCases(&b, testCases)
 }
 
+func TestBatchLen(t *testing.T) {
+	var b Batch
+
+	requireLenAndReprEq := func(size int) {
+		require.Equal(t, size, b.Len())
+		require.Equal(t, size, len(b.Repr()))
+	}
+
+	requireLenAndReprEq(batchHeaderLen)
+
+	key := "test-key"
+	value := "test-value"
+
+	err := b.Set([]byte(key), []byte(value), nil)
+	require.NoError(t, err)
+
+	requireLenAndReprEq(33)
+
+	err = b.Delete([]byte(key), nil)
+	require.NoError(t, err)
+
+	requireLenAndReprEq(43)
+}
+
 func TestBatchEmpty(t *testing.T) {
 	var b Batch
 	require.True(t, b.Empty())


### PR DESCRIPTION
Add a new `Batch.Len` method that returns the current
size of the batch.

This method can be used to control the max size of Batches on 
small devices / low memory servers that need to deal with larger
than memory data.
It is also less expensive to call than `len(batch.Repr())` and can be 
used almost for free before every call to `Batch.Set` to monitor the
size of the batch, commit it if it reached a threshold and start a new
batch.
