### PR TITLE
internal/keyspan: replace calls to Span.Visible

### DIFF
--- a/internal/keyspan/fragmenter.go
+++ b/internal/keyspan/fragmenter.go
@@ -248,7 +248,7 @@ func (f *Fragmenter) Covers(key base.InternalKey, snapshot uint64) bool {
 			// NB: A range deletion tombstone does not delete a point operation
 			// at the same sequence number, and broadly a span is not considered
 			// to cover a point operation at the same sequence number.
-			if s.Visible(snapshot).Covers(seqNum) {
+			if s.CoversAt(snapshot, seqNum) {
 				return true
 			}
 		}

--- a/internal/keyspan/fragmenter_test.go
+++ b/internal/keyspan/fragmenter_test.go
@@ -131,8 +131,8 @@ func TestFragmenter(t *testing.T) {
 	// number. This is a simple version of what full processing of range
 	// tombstones looks like.
 	deleted := func(key []byte, seq, readSeq uint64) bool {
-		s := Get(cmp, iter, key, readSeq)
-		return s.Covers(seq)
+		s := Get(cmp, iter, key)
+		return s.CoversAt(readSeq, seq)
 	}
 
 	datadriven.RunTest(t, "testdata/fragmenter", func(d *datadriven.TestData) string {

--- a/internal/keyspan/get.go
+++ b/internal/keyspan/get.go
@@ -11,7 +11,7 @@ import "github.com/cockroachdb/pebble/internal/base"
 // parameter controls the visibility of spans (only spans older than the
 // snapshot sequence number are visible). The iterator must contain
 // fragmented spans: no span may overlap another.
-func Get(cmp base.Compare, iter FragmentIterator, key []byte, snapshot uint64) Span {
+func Get(cmp base.Compare, iter FragmentIterator, key []byte) Span {
 	// NB: We use SeekLT in order to land on the proper span for a search
 	// key that resides in the middle of a span. Consider the scenario:
 	//
@@ -49,5 +49,5 @@ func Get(cmp base.Compare, iter FragmentIterator, key []byte, snapshot uint64) S
 			return Span{}
 		}
 	}
-	return iterSpan.Visible(snapshot)
+	return iterSpan
 }

--- a/internal/keyspan/merging_iter.go
+++ b/internal/keyspan/merging_iter.go
@@ -48,9 +48,13 @@ var noopTransform Transformer = TransformerFunc(func(_ base.Compare, s Span, dst
 // sequence number.
 func visibleTransform(snapshot uint64) Transformer {
 	return TransformerFunc(func(_ base.Compare, s Span, dst *Span) error {
-		s = s.Visible(snapshot)
 		dst.Start, dst.End = s.Start, s.End
-		dst.Keys = append(dst.Keys[:0], s.Keys...)
+		dst.Keys = dst.Keys[:0]
+		for _, k := range s.Keys {
+			if base.Visible(k.SeqNum(), snapshot) {
+				dst.Keys = append(dst.Keys, k)
+			}
+		}
 		return nil
 	})
 }

--- a/internal/keyspan/span_test.go
+++ b/internal/keyspan/span_test.go
@@ -51,3 +51,48 @@ func TestSpan_Visible(t *testing.T) {
 		}
 	})
 }
+
+func TestSpan_VisibleAt(t *testing.T) {
+	var s Span
+	datadriven.RunTest(t, "testdata/visible_at", func(d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "define":
+			s = ParseSpan(d.Input)
+			return fmt.Sprint(s)
+		case "visible-at":
+			var buf bytes.Buffer
+			for _, line := range strings.Split(d.Input, "\n") {
+				snapshot, err := strconv.ParseUint(line, 10, 64)
+				require.NoError(t, err)
+				fmt.Fprintf(&buf, "%-2d: %t\n", snapshot, s.VisibleAt(snapshot))
+			}
+			return buf.String()
+		default:
+			return fmt.Sprintf("unknown command: %s", d.Cmd)
+		}
+	})
+}
+
+func TestSpan_CoversAt(t *testing.T) {
+	var s Span
+	datadriven.RunTest(t, "testdata/covers_at", func(d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "define":
+			s = ParseSpan(d.Input)
+			return fmt.Sprint(s)
+		case "covers-at":
+			var buf bytes.Buffer
+			for _, line := range strings.Split(d.Input, "\n") {
+				fields := strings.Fields(line)
+				snapshot, err := strconv.ParseUint(fields[0], 10, 64)
+				require.NoError(t, err)
+				seqNum, err := strconv.ParseUint(fields[1], 10, 64)
+				require.NoError(t, err)
+				fmt.Fprintf(&buf, "%d %d : %t\n", snapshot, seqNum, s.CoversAt(snapshot, seqNum))
+			}
+			return buf.String()
+		default:
+			return fmt.Sprintf("unknown command: %s", d.Cmd)
+		}
+	})
+}

--- a/internal/keyspan/testdata/covers_at
+++ b/internal/keyspan/testdata/covers_at
@@ -1,0 +1,91 @@
+define
+a-b:{(#5,RANGEDEL) (#3,RANGEDEL)}
+----
+a-b:{(#5,RANGEDEL) (#3,RANGEDEL)}
+
+covers-at
+6 6
+6 5
+6 4
+6 2
+6 3
+5 5
+5 4
+5 3
+5 2
+4 5
+4 1
+3 9
+3 2
+3 1
+3 0
+2 0
+1 0
+----
+6 6 : false
+6 5 : false
+6 4 : true
+6 2 : true
+6 3 : true
+5 5 : false
+5 4 : false
+5 3 : false
+5 2 : true
+4 5 : false
+4 1 : true
+3 9 : false
+3 2 : false
+3 1 : false
+3 0 : false
+2 0 : false
+1 0 : false
+
+# The below sequence number is the minimal batch sequence number (eg, a RANGEDEL
+# written right at the beginning of the batch.) In the tests below, all other
+# batch sequence numbers are not covered by it.
+
+define
+a-c:{(#36028797018963968,RANGEDEL)}
+----
+a-c:{(#36028797018963968,RANGEDEL)}
+
+covers-at
+100 90000
+100 90
+0 0
+33 36028797018964068
+33 36028797018963968
+----
+100 90000 : true
+100 90 : true
+0 0 : true
+33 36028797018964068 : false
+33 36028797018963968 : false
+
+# The below sequence number is a batch sequence number for offset 100.
+
+define
+a-c:{(#36028797018964068,RANGEDEL)}
+----
+a-c:{(#36028797018964068,RANGEDEL)}
+
+covers-at
+10 10
+----
+10 10 : true
+
+# The below sequence number is a batch sequence number for offset 200. It should
+# not be covered.
+
+covers-at
+100 36028797018964168
+----
+100 36028797018964168 : false
+
+# The below sequence number is a batch sequence number for offset 0. It should
+# be covered.
+
+covers-at
+100 36028797018963968
+----
+100 36028797018963968 : true

--- a/internal/keyspan/testdata/visible_at
+++ b/internal/keyspan/testdata/visible_at
@@ -1,0 +1,58 @@
+define
+a-b:{(#5,RANGEKEYSET) (#3,RANGEKEYSET)}
+----
+a-b:{(#5,RANGEKEYSET) (#3,RANGEKEYSET)}
+
+visible-at
+6
+5
+4
+3
+2
+1
+----
+6 : true
+5 : true
+4 : true
+3 : false
+2 : false
+1 : false
+
+# NB: #36028797018963996 and #36028797018963995 are sequence numbers with the
+# batch bit set. These keys should always be visible.
+
+define
+a-c:{(#36028797018963996,RANGEKEYSET) (#36028797018963995,RANGEKEYSET)}
+----
+a-c:{(#36028797018963996,RANGEKEYSET) (#36028797018963995,RANGEKEYSET)}
+
+visible-at
+5
+1
+----
+5 : true
+1 : true
+
+define
+a-c:{(#36028797018963996,RANGEKEYSET) (#36028797018963995,RANGEKEYSET) (#10,RANGEKEYSET) (#9,RANGEKEYSET) (#4,RANGEKEYSET) (#1,RANGEKEYSET)}
+----
+a-c:{(#36028797018963996,RANGEKEYSET) (#36028797018963995,RANGEKEYSET) (#10,RANGEKEYSET) (#9,RANGEKEYSET) (#4,RANGEKEYSET) (#1,RANGEKEYSET)}
+
+visible-at
+12
+10
+8
+7
+4
+3
+2
+1
+----
+12: true
+10: true
+8 : true
+7 : true
+4 : true
+3 : true
+2 : true
+1 : true

--- a/level_checker.go
+++ b/level_checker.go
@@ -117,7 +117,7 @@ func (m *simpleMergingIter) positionRangeDels() {
 		if l.rangeDelIter == nil {
 			continue
 		}
-		l.tombstone = keyspan.SeekGE(m.heap.cmp, l.rangeDelIter, item.key.UserKey).Visible(m.snapshot)
+		l.tombstone = keyspan.SeekGE(m.heap.cmp, l.rangeDelIter, item.key.UserKey)
 	}
 }
 
@@ -207,7 +207,7 @@ func (m *simpleMergingIter) step() bool {
 			}
 			if (lvl.smallestUserKey == nil || m.heap.cmp(lvl.smallestUserKey, item.key.UserKey) <= 0) &&
 				lvl.tombstone.Contains(m.heap.cmp, item.key.UserKey) {
-				if lvl.tombstone.Covers(item.key.SeqNum()) {
+				if lvl.tombstone.CoversAt(m.snapshot, item.key.SeqNum()) {
 					m.err = errors.Errorf("tombstone %s in %s deletes key %s in %s",
 						lvl.tombstone.Pretty(m.formatKey), lvl.iter, item.key.Pretty(m.formatKey),
 						l.iter)


### PR DESCRIPTION
The Span.Visible method returns a Span with the subset of keys visible at the
provided sequence number. Batch sequence numbers may force this method to
allocate under some circumstances, so it's preferrable to use narrower
methods that do not need to allocate.

Add two such narrower methods, VisibleAt and CoversAt, and use them to remove
calls to Span.Visible for range deletions during point iteration.