### PR TITLE
*: pass keyspan.Spans by pointer not value

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -795,7 +795,7 @@ func TestBatchRangeOps(t *testing.T) {
 
 			var buf bytes.Buffer
 			if fragmentIter != nil {
-				for s := fragmentIter.First(); s.Valid(); s = fragmentIter.Next() {
+				for s := fragmentIter.First(); s != nil; s = fragmentIter.Next() {
 					for i := range s.Keys {
 						s.Keys[i].Trailer = base.MakeTrailer(
 							s.Keys[i].SeqNum()&^base.InternalKeySeqNumBatch,
@@ -998,7 +998,7 @@ func scanInternalIterator(w io.Writer, ii internalIterator) {
 }
 
 func scanKeyspanIterator(w io.Writer, ki keyspan.FragmentIterator) {
-	for s := ki.First(); s.Valid(); s = ki.Next() {
+	for s := ki.First(); s != nil; s = ki.Next() {
 		fmt.Fprintln(w, s)
 	}
 }

--- a/compaction.go
+++ b/compaction.go
@@ -603,14 +603,14 @@ func newFlush(
 	}
 
 	updateRangeBounds := func(iter keyspan.FragmentIterator) {
-		if s := iter.First(); s.Valid() {
+		if s := iter.First(); s != nil {
 			if key := s.SmallestKey(); !smallestSet ||
 				base.InternalCompare(c.cmp, c.smallest, key) > 0 {
 				smallestSet = true
 				c.smallest = key.Clone()
 			}
 		}
-		if s := iter.Last(); s.Valid() {
+		if s := iter.Last(); s != nil {
 			if key := s.LargestKey(); !largestSet ||
 				base.InternalCompare(c.cmp, c.largest, key) < 0 {
 				largestSet = true
@@ -2194,7 +2194,7 @@ func (d *DB) runCompaction(
 			// added to the writer, eliding out-of-file range tombstones based
 			// on sequence number at this stage is difficult, and necessitates
 			// read-time logic to ignore range tombstones outside file bounds.
-			if rangedel.Encode(v, tw.Add); err != nil {
+			if rangedel.Encode(&v, tw.Add); err != nil {
 				return err
 			}
 		}

--- a/data_test.go
+++ b/data_test.go
@@ -519,7 +519,7 @@ func runBuildCmd(td *datadriven.TestData, d *DB, fs vfs.FS) error {
 	}
 
 	if rdi := b.newRangeDelIter(nil, math.MaxUint64); rdi != nil {
-		for s := rdi.First(); s.Valid(); s = rdi.Next() {
+		for s := rdi.First(); s != nil; s = rdi.Next() {
 			err := rangedel.Encode(s, func(k base.InternalKey, v []byte) error {
 				k.SetSeqNum(0)
 				return w.Add(k, v)
@@ -531,7 +531,7 @@ func runBuildCmd(td *datadriven.TestData, d *DB, fs vfs.FS) error {
 	}
 
 	if rki := b.newRangeKeyIter(nil, math.MaxUint64); rki != nil {
-		for s := rki.First(); s.Valid(); s = rki.Next() {
+		for s := rki.First(); s != nil; s = rki.Next() {
 			for _, k := range s.Keys {
 				var err error
 				switch k.Kind() {

--- a/error_iter.go
+++ b/error_iter.go
@@ -77,12 +77,12 @@ func newErrorKeyspanIter(err error) *errorKeyspanIter {
 	return &errorKeyspanIter{err: err}
 }
 
-func (*errorKeyspanIter) SeekGE(key []byte) keyspan.Span { return keyspan.Span{} }
-func (*errorKeyspanIter) SeekLT(key []byte) keyspan.Span { return keyspan.Span{} }
-func (*errorKeyspanIter) First() keyspan.Span            { return keyspan.Span{} }
-func (*errorKeyspanIter) Last() keyspan.Span             { return keyspan.Span{} }
-func (*errorKeyspanIter) Next() keyspan.Span             { return keyspan.Span{} }
-func (*errorKeyspanIter) Prev() keyspan.Span             { return keyspan.Span{} }
-func (i *errorKeyspanIter) Error() error                 { return i.err }
-func (i *errorKeyspanIter) Close() error                 { return i.err }
-func (*errorKeyspanIter) String() string                 { return "error" }
+func (*errorKeyspanIter) SeekGE(key []byte) *keyspan.Span { return nil }
+func (*errorKeyspanIter) SeekLT(key []byte) *keyspan.Span { return nil }
+func (*errorKeyspanIter) First() *keyspan.Span            { return nil }
+func (*errorKeyspanIter) Last() *keyspan.Span             { return nil }
+func (*errorKeyspanIter) Next() *keyspan.Span             { return nil }
+func (*errorKeyspanIter) Prev() *keyspan.Span             { return nil }
+func (i *errorKeyspanIter) Error() error                  { return i.err }
+func (i *errorKeyspanIter) Close() error                  { return i.err }
+func (*errorKeyspanIter) String() string                  { return "error" }

--- a/ingest.go
+++ b/ingest.go
@@ -126,7 +126,7 @@ func ingestLoad1(
 	if iter != nil {
 		defer iter.Close()
 		var smallest InternalKey
-		if s := iter.First(); s.Valid() {
+		if s := iter.First(); s != nil {
 			key := s.SmallestKey()
 			if err := ingestValidateKey(opts, &key); err != nil {
 				return nil, err
@@ -136,7 +136,7 @@ func ingestLoad1(
 		if err := iter.Error(); err != nil {
 			return nil, err
 		}
-		if s := iter.Last(); s.Valid() {
+		if s := iter.Last(); s != nil {
 			k := s.SmallestKey()
 			if err := ingestValidateKey(opts, &k); err != nil {
 				return nil, err
@@ -155,7 +155,7 @@ func ingestLoad1(
 		if iter != nil {
 			defer iter.Close()
 			var smallest InternalKey
-			if s := iter.First(); s.Valid() {
+			if s := iter.First(); s != nil {
 				key := s.SmallestKey()
 				if err := ingestValidateKey(opts, &key); err != nil {
 					return nil, err
@@ -165,7 +165,7 @@ func ingestLoad1(
 			if err := iter.Error(); err != nil {
 				return nil, err
 			}
-			if s := iter.Last(); s.Valid() {
+			if s := iter.Last(); s != nil {
 				k := s.SmallestKey()
 				if err := ingestValidateKey(opts, &k); err != nil {
 					return nil, err
@@ -412,10 +412,10 @@ func overlapWithIterator(
 	}
 	rangeDelItr := *rangeDelIter
 	rangeDel := rangeDelItr.SeekLT(meta.Smallest.UserKey)
-	if !rangeDel.Valid() {
+	if rangeDel == nil {
 		rangeDel = rangeDelItr.Next()
 	}
-	for ; rangeDel.Valid(); rangeDel = rangeDelItr.Next() {
+	for ; rangeDel != nil; rangeDel = rangeDelItr.Next() {
 		key := rangeDel.SmallestKey()
 		c := sstableKeyCompare(cmp, key, meta.Largest)
 		if c > 0 {

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -62,7 +62,8 @@ func TestIngestLoad(t *testing.T) {
 			for _, data := range strings.Split(td.Input, "\n") {
 				if strings.HasPrefix(data, "rangekey: ") {
 					data = strings.TrimPrefix(data, "rangekey: ")
-					err := rangekey.Encode(keyspan.ParseSpan(data), w.AddRangeKey)
+					s := keyspan.ParseSpan(data)
+					err := rangekey.Encode(&s, w.AddRangeKey)
 					if err != nil {
 						return err.Error()
 					}
@@ -1275,7 +1276,8 @@ func TestIngest_UpdateSequenceNumber(t *testing.T) {
 		for _, data := range strings.Split(input, "\n") {
 			if strings.HasPrefix(data, "rangekey: ") {
 				data = strings.TrimPrefix(data, "rangekey: ")
-				err := rangekey.Encode(keyspan.ParseSpan(data), w.AddRangeKey)
+				s := keyspan.ParseSpan(data)
+				err := rangekey.Encode(&s, w.AddRangeKey)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/keyspan/defragment_test.go
+++ b/internal/keyspan/defragment_test.go
@@ -23,7 +23,7 @@ import (
 func TestDefragmentingIter(t *testing.T) {
 	cmp := testkeys.Comparer.Compare
 	internalEqual := DefragmentInternal
-	alwaysEqual := DefragmentMethodFunc(func(_ base.Compare, _, _ Span) bool { return true })
+	alwaysEqual := DefragmentMethodFunc(func(_ base.Compare, _, _ *Span) bool { return true })
 	staticReducer := StaticDefragmentReducer
 	collectReducer := func(cur, next []Key) []Key {
 		c := keysBySeqNumKind(append(cur, next...))
@@ -266,7 +266,7 @@ var iterDelim = map[rune]bool{',': true, ' ': true, '(': true, ')': true, '"': t
 
 func runIterOp(w io.Writer, it FragmentIterator, op string) {
 	fields := strings.FieldsFunc(op, func(r rune) bool { return iterDelim[r] })
-	var s Span
+	var s *Span
 	switch strings.ToLower(fields[0]) {
 	case "first":
 		s = it.First()
@@ -284,7 +284,7 @@ func runIterOp(w io.Writer, it FragmentIterator, op string) {
 		panic(fmt.Sprintf("unrecognized iter op %q", fields[0]))
 	}
 	fmt.Fprintf(w, "%-10s", op)
-	if !s.Valid() {
+	if s == nil {
 		fmt.Fprintln(w, ".")
 		return
 	}

--- a/internal/keyspan/filter.go
+++ b/internal/keyspan/filter.go
@@ -10,7 +10,7 @@ package keyspan
 // the output Span, for example, to elice certain keys, or update the Span's
 // bounds if so desired. The output Span's Keys slice may be reused to reduce
 // allocations.
-type FilterFunc func(in Span, out *Span) (keep bool)
+type FilterFunc func(in *Span, out *Span) (keep bool)
 
 // filteringIter is a FragmentIterator that uses a FilterFunc to select which
 // Spans from the input iterator are returned in the output.
@@ -37,32 +37,32 @@ func Filter(iter FragmentIterator, filter FilterFunc) FragmentIterator {
 }
 
 // SeekGE implements FragmentIterator.
-func (i *filteringIter) SeekGE(key []byte) Span {
+func (i *filteringIter) SeekGE(key []byte) *Span {
 	return i.filter(i.iter.SeekGE(key), +1)
 }
 
 // SeekLT implements FragmentIterator.
-func (i *filteringIter) SeekLT(key []byte) Span {
+func (i *filteringIter) SeekLT(key []byte) *Span {
 	return i.filter(i.iter.SeekLT(key), -1)
 }
 
 // First implements FragmentIterator.
-func (i *filteringIter) First() Span {
+func (i *filteringIter) First() *Span {
 	return i.filter(i.iter.First(), +1)
 }
 
 // Last implements FragmentIterator.
-func (i *filteringIter) Last() Span {
+func (i *filteringIter) Last() *Span {
 	return i.filter(i.iter.Last(), -1)
 }
 
 // Next implements FragmentIterator.
-func (i *filteringIter) Next() Span {
+func (i *filteringIter) Next() *Span {
 	return i.filter(i.iter.Next(), +1)
 }
 
 // Prev implements FragmentIterator.
-func (i *filteringIter) Prev() Span {
+func (i *filteringIter) Prev() *Span {
 	return i.filter(i.iter.Prev(), -1)
 }
 
@@ -80,18 +80,18 @@ func (i *filteringIter) Close() error {
 // given Span. If the current Span is to be skipped, the iterator continues
 // iterating in the given direction until it lands on a Span that should be
 // returned, or the iterator becomes invalid.
-func (i *filteringIter) filter(span Span, dir int8) Span {
+func (i *filteringIter) filter(span *Span, dir int8) *Span {
 	if i.filterFn == nil {
 		return span
 	}
-	for i.Error() == nil && span.Valid() {
+	for i.Error() == nil && span != nil {
 		if keep := i.filterFn(span, &i.span); keep {
-			return i.span
+			return &i.span
 		}
 		if dir == +1 {
-			span = i.Next()
+			span = i.iter.Next()
 		} else {
-			span = i.Prev()
+			span = i.iter.Prev()
 		}
 	}
 	return span

--- a/internal/keyspan/filter_test.go
+++ b/internal/keyspan/filter_test.go
@@ -18,7 +18,7 @@ func TestFilteringIter(t *testing.T) {
 	// makeFilter returns a FilterFunc that will filter out all keys in a Span
 	// that are not of the given kind. Empty spans are skipped.
 	makeFilter := func(kind base.InternalKeyKind) FilterFunc {
-		return func(in Span, out *Span) (keep bool) {
+		return func(in *Span, out *Span) (keep bool) {
 			out.Start, out.End = in.Start, in.End
 			out.Keys = out.Keys[:0]
 			for _, k := range in.Keys {

--- a/internal/keyspan/fragmenter_test.go
+++ b/internal/keyspan/fragmenter_test.go
@@ -132,7 +132,7 @@ func TestFragmenter(t *testing.T) {
 	// tombstones looks like.
 	deleted := func(key []byte, seq, readSeq uint64) bool {
 		s := Get(cmp, iter, key)
-		return s.CoversAt(readSeq, seq)
+		return s != nil && s.CoversAt(readSeq, seq)
 	}
 
 	datadriven.RunTest(t, "testdata/fragmenter", func(d *datadriven.TestData) string {

--- a/internal/keyspan/interleaving_iter_test.go
+++ b/internal/keyspan/interleaving_iter_test.go
@@ -32,11 +32,11 @@ type maskingHooks struct {
 	maskSuffix []byte
 }
 
-func (m *maskingHooks) SpanChanged(s Span) {
+func (m *maskingHooks) SpanChanged(s *Span) {
 	// Find the smallest suffix of a key contained within the Span, excluding
 	// suffixes less than m.threshold.
 	m.maskSuffix = nil
-	if m.threshold == nil || len(s.Keys) == 0 {
+	if s == nil || m.threshold == nil || len(s.Keys) == 0 {
 		return
 	}
 	for i := range s.Keys {

--- a/internal/keyspan/internal_iter_shim.go
+++ b/internal/keyspan/internal_iter_shim.go
@@ -16,7 +16,7 @@ import "github.com/cockroachdb/pebble/internal/base"
 // keyspan.FragmentIterator with point keys.
 type InternalIteratorShim struct {
 	miter   MergingIter
-	span    Span
+	span    *Span
 	iterKey base.InternalKey
 }
 
@@ -31,7 +31,7 @@ func (i *InternalIteratorShim) Init(cmp base.Compare, iters ...FragmentIterator)
 
 // Span returns the span containing the full set of keys over the key span at
 // the current iterator position.
-func (i *InternalIteratorShim) Span() Span {
+func (i *InternalIteratorShim) Span() *Span {
 	return i.span
 }
 
@@ -57,10 +57,10 @@ func (i *InternalIteratorShim) SeekLT(key []byte) (*base.InternalKey, []byte) {
 // First implements (base.InternalIterator).First.
 func (i *InternalIteratorShim) First() (*base.InternalKey, []byte) {
 	i.span = i.miter.First()
-	for i.span.Valid() && i.span.Empty() {
+	for i.span != nil && i.span.Empty() {
 		i.span = i.miter.Next()
 	}
-	if !i.span.Valid() {
+	if i.span == nil {
 		return nil, nil
 	}
 	i.iterKey = base.InternalKey{UserKey: i.span.Start, Trailer: i.span.Keys[0].Trailer}
@@ -75,10 +75,10 @@ func (i *InternalIteratorShim) Last() (*base.InternalKey, []byte) {
 // Next implements (base.InternalIterator).Next.
 func (i *InternalIteratorShim) Next() (*base.InternalKey, []byte) {
 	i.span = i.miter.Next()
-	for i.span.Valid() && i.span.Empty() {
+	for i.span != nil && i.span.Empty() {
 		i.span = i.miter.Next()
 	}
-	if !i.span.Valid() {
+	if i.span == nil {
 		return nil, nil
 	}
 	i.iterKey = base.InternalKey{UserKey: i.span.Start, Trailer: i.span.Keys[0].Trailer}

--- a/internal/keyspan/iter.go
+++ b/internal/keyspan/iter.go
@@ -20,17 +20,17 @@ import (
 type FragmentIterator interface {
 	// SeekGE moves the iterator to the first span whose start key is greater
 	// than or equal to the given key.
-	SeekGE(key []byte) Span
+	SeekGE(key []byte) *Span
 
 	// SeekLT moves the iterator to the last span whose start key is less than
 	// the given key.
-	SeekLT(key []byte) Span
+	SeekLT(key []byte) *Span
 
 	// First moves the iterator to the first span.
-	First() Span
+	First() *Span
 
 	// Last moves the iterator to the last span.
-	Last() Span
+	Last() *Span
 
 	// Next moves the iterator to the next span.
 	//
@@ -38,7 +38,7 @@ type FragmentIterator interface {
 	// key/value pair due to either a prior call to SeekLT or Prev which
 	// returned an invalid span. It is not allowed to call Next when the
 	// previous call to SeekGE, SeekPrefixGE or Next returned an invalid span.
-	Next() Span
+	Next() *Span
 
 	// Prev moves the iterator to the previous span.
 	//
@@ -46,7 +46,7 @@ type FragmentIterator interface {
 	// key/value pair due to either a prior call to SeekGE or Next which
 	// returned an invalid span. It is not allowed to call Prev when the
 	// previous call to SeekLT or Prev returned an invalid span.
-	Prev() Span
+	Prev() *Span
 
 	// Error returns any accumulated error.
 	Error() error
@@ -96,7 +96,7 @@ func (i *Iter) Init(cmp base.Compare, spans []Span) {
 }
 
 // SeekGE implements FragmentIterator.SeekGE.
-func (i *Iter) SeekGE(key []byte) Span {
+func (i *Iter) SeekGE(key []byte) *Span {
 	// NB: manually inlined sort.Search is ~5% faster.
 	//
 	// Define f(-1) == false and f(n) == true.
@@ -115,13 +115,13 @@ func (i *Iter) SeekGE(key []byte) Span {
 	// i.index == upper, f(i.index-1) == false, and f(upper) (= f(i.index)) ==
 	// true => answer is i.index.
 	if i.index >= len(i.spans) {
-		return Span{}
+		return nil
 	}
-	return i.spans[i.index]
+	return &i.spans[i.index]
 }
 
 // SeekLT implements FragmentIterator.SeekLT.
-func (i *Iter) SeekLT(key []byte) Span {
+func (i *Iter) SeekLT(key []byte) *Span {
 	// NB: manually inlined sort.Search is ~5% faster.
 	//
 	// Define f(-1) == false and f(n) == true.
@@ -144,51 +144,51 @@ func (i *Iter) SeekLT(key []byte) Span {
 	// the largest whose key is < the key sought.
 	i.index--
 	if i.index < 0 {
-		return Span{}
+		return nil
 	}
-	return i.spans[i.index]
+	return &i.spans[i.index]
 }
 
 // First implements FragmentIterator.First.
-func (i *Iter) First() Span {
+func (i *Iter) First() *Span {
 	if len(i.spans) == 0 {
-		return Span{}
+		return nil
 	}
 	i.index = 0
-	return i.spans[i.index]
+	return &i.spans[i.index]
 }
 
 // Last implements FragmentIterator.Last.
-func (i *Iter) Last() Span {
+func (i *Iter) Last() *Span {
 	if len(i.spans) == 0 {
-		return Span{}
+		return nil
 	}
 	i.index = len(i.spans) - 1
-	return i.spans[i.index]
+	return &i.spans[i.index]
 }
 
 // Next implements FragmentIterator.Next.
-func (i *Iter) Next() Span {
+func (i *Iter) Next() *Span {
 	if i.index >= len(i.spans) {
-		return Span{}
+		return nil
 	}
 	i.index++
 	if i.index >= len(i.spans) {
-		return Span{}
+		return nil
 	}
-	return i.spans[i.index]
+	return &i.spans[i.index]
 }
 
 // Prev implements FragmentIterator.Prev.
-func (i *Iter) Prev() Span {
+func (i *Iter) Prev() *Span {
 	if i.index < 0 {
-		return Span{}
+		return nil
 	}
 	i.index--
 	if i.index < 0 {
-		return Span{}
+		return nil
 	}
-	return i.spans[i.index]
+	return &i.spans[i.index]
 }
 
 // Error implements FragmentIterator.Error.

--- a/internal/keyspan/level_iter.go
+++ b/internal/keyspan/level_iter.go
@@ -40,8 +40,8 @@ type LevelIter struct {
 	// key spaces. This is an optimization to avoid unnecessarily loading files
 	// in cases where range keys are sparse and rare. dir is set by every
 	// positioning operation, straddleDir is set to dir whenever a straddling
-	// Span is synthesized, and straddle is Valid() whenever the last positioning
-	// operation returned a synthesized straddle span.
+	// Span is synthesized and the last positioning operation returned a
+	// synthesized straddle span.
 	//
 	// Note that when a straddle span is initialized, iterFile is modified to
 	// point to the next file in the straddleDir direction. A change of direction
@@ -53,7 +53,7 @@ type LevelIter struct {
 	// The iter for the current file. It is nil under any of the following conditions:
 	// - files.Current() == nil
 	// - err != nil
-	// - straddle.Valid(), in which case iterFile is not nil and points to the
+	// - straddleDir != 0, in which case iterFile is not nil and points to the
 	//   next file (in the straddleDir direction).
 	// - some other constraint, like the bounds in opts, caused the file at index to not
 	//   be relevant to the iteration.
@@ -188,7 +188,7 @@ func (l *LevelIter) loadFile(file *manifest.FileMetadata, dir int) loadFileRetur
 }
 
 // SeekGE implements keyspan.FragmentIterator.
-func (l *LevelIter) SeekGE(key []byte) Span {
+func (l *LevelIter) SeekGE(key []byte) *Span {
 	l.dir = +1
 	l.err = nil // clear cached iteration error
 
@@ -216,20 +216,20 @@ func (l *LevelIter) SeekGE(key []byte) Span {
 			End:   f.SmallestRangeKey.UserKey,
 			Keys:  nil,
 		}
-		return l.straddle
+		return &l.straddle
 	}
 	loadFileIndicator := l.loadFile(f, +1)
 	if loadFileIndicator == noFileLoaded {
-		return Span{}
+		return nil
 	}
-	if span := l.iter.SeekGE(key); span.Valid() {
+	if span := l.iter.SeekGE(key); span != nil {
 		return span
 	}
 	return l.skipEmptyFileForward()
 }
 
 // SeekLT implements keyspan.FragmentIterator.
-func (l *LevelIter) SeekLT(key []byte) Span {
+func (l *LevelIter) SeekLT(key []byte) *Span {
 	l.dir = -1
 	l.err = nil // clear cached iteration error
 
@@ -257,54 +257,54 @@ func (l *LevelIter) SeekLT(key []byte) Span {
 			End:   key,
 			Keys:  nil,
 		}
-		return l.straddle
+		return &l.straddle
 	}
 	if l.loadFile(l.findFileLT(key), -1) == noFileLoaded {
-		return Span{}
+		return nil
 	}
-	if span := l.iter.SeekLT(key); span.Valid() {
+	if span := l.iter.SeekLT(key); span != nil {
 		return span
 	}
 	return l.skipEmptyFileBackward()
 }
 
 // First implements keyspan.FragmentIterator.
-func (l *LevelIter) First() Span {
+func (l *LevelIter) First() *Span {
 	l.dir = +1
 	l.err = nil // clear cached iteration error
 
 	if l.loadFile(l.files.First(), +1) == noFileLoaded {
-		return Span{}
+		return nil
 	}
-	if span := l.iter.First(); span.Valid() {
+	if span := l.iter.First(); span != nil {
 		return span
 	}
 	return l.skipEmptyFileForward()
 }
 
 // Last implements keyspan.FragmentIterator.
-func (l *LevelIter) Last() Span {
+func (l *LevelIter) Last() *Span {
 	l.dir = -1
 	l.err = nil // clear cached iteration error
 
 	if l.loadFile(l.files.Last(), -1) == noFileLoaded {
-		return Span{}
+		return nil
 	}
-	if span := l.iter.Last(); span.Valid() {
+	if span := l.iter.Last(); span != nil {
 		return span
 	}
 	return l.skipEmptyFileBackward()
 }
 
 // Next implements keyspan.FragmentIterator.
-func (l *LevelIter) Next() Span {
+func (l *LevelIter) Next() *Span {
 	l.dir = +1
 	if l.err != nil || (l.iter == nil && l.iterFile == nil) {
-		return Span{}
+		return nil
 	}
 
 	if l.iter != nil {
-		if span := l.iter.Next(); span.Valid() {
+		if span := l.iter.Next(); span != nil {
 			return span
 		}
 	}
@@ -312,22 +312,22 @@ func (l *LevelIter) Next() Span {
 }
 
 // Prev implements keyspan.FragmentIterator.
-func (l *LevelIter) Prev() Span {
+func (l *LevelIter) Prev() *Span {
 	l.dir = -1
 	if l.err != nil || (l.iter == nil && l.iterFile == nil) {
-		return Span{}
+		return nil
 	}
 
 	if l.iter != nil {
-		if span := l.iter.Prev(); span.Valid() {
+		if span := l.iter.Prev(); span != nil {
 			return span
 		}
 	}
 	return l.skipEmptyFileBackward()
 }
 
-func (l *LevelIter) skipEmptyFileForward() Span {
-	if !l.straddle.Valid() && l.keyType == manifest.KeyTypeRange &&
+func (l *LevelIter) skipEmptyFileForward() *Span {
+	if l.straddleDir == 0 && l.keyType == manifest.KeyTypeRange &&
 		l.iterFile != nil && l.iter != nil {
 		// We were at a file that had spans. Check if the next file that has
 		// spans is not directly adjacent to the current file i.e. there is a
@@ -337,7 +337,7 @@ func (l *LevelIter) skipEmptyFileForward() Span {
 		// Straddle spans are not created in rangedel mode.
 		if err := l.Close(); err != nil {
 			l.err = err
-			return Span{}
+			return nil
 		}
 		startKey := l.iterFile.LargestRangeKey.UserKey
 		// Resetting l.iterFile without loading the file into l.iter is okay and
@@ -345,7 +345,7 @@ func (l *LevelIter) skipEmptyFileForward() Span {
 		// which it should be due to the Close() call above.
 		l.iterFile = l.files.Next()
 		if l.iterFile == nil {
-			return Span{}
+			return nil
 		}
 		endKey := l.iterFile.SmallestRangeKey.UserKey
 		if l.cmp(startKey, endKey) < 0 {
@@ -356,16 +356,17 @@ func (l *LevelIter) skipEmptyFileForward() Span {
 				End:   endKey,
 			}
 			l.straddleDir = l.dir
-			return l.straddle
+			return &l.straddle
 		}
-	} else if l.straddle.Valid() && l.straddleDir < 0 {
+	} else if l.straddleDir < 0 {
 		// We were at a straddle key, but are now changing directions. l.iterFile
 		// was already moved backward by skipEmptyFileBackward, so advance it
 		// forward.
 		l.iterFile = l.files.Next()
 	}
 	l.straddle = Span{}
-	var span Span
+	l.straddleDir = 0
+	var span *Span
 	for span.Empty() {
 		fileToLoad := l.iterFile
 		if l.keyType == manifest.KeyTypePoint {
@@ -374,7 +375,7 @@ func (l *LevelIter) skipEmptyFileForward() Span {
 			fileToLoad = l.files.Next()
 		}
 		if l.loadFile(fileToLoad, +1) == noFileLoaded {
-			return Span{}
+			return nil
 		}
 		span = l.iter.First()
 		// In rangedel mode, we can expect to get empty files that we'd need to
@@ -386,18 +387,18 @@ func (l *LevelIter) skipEmptyFileForward() Span {
 	return span
 }
 
-func (l *LevelIter) skipEmptyFileBackward() Span {
+func (l *LevelIter) skipEmptyFileBackward() *Span {
 	// We were at a file that had spans. Check if the previous file that has
 	// spans is not directly adjacent to the current file i.e. there is a
 	// gap in the span keyspace between the two files. In that case, synthesize
 	// a "straddle span" in l.straddle and return that.
 	//
 	// Straddle spans are not created in rangedel mode.
-	if !l.straddle.Valid() && l.keyType == manifest.KeyTypeRange &&
+	if l.straddleDir == 0 && l.keyType == manifest.KeyTypeRange &&
 		l.iterFile != nil && l.iter != nil {
 		if err := l.Close(); err != nil {
 			l.err = err
-			return Span{}
+			return nil
 		}
 		endKey := l.iterFile.SmallestRangeKey.UserKey
 		// Resetting l.iterFile without loading the file into l.iter is okay and
@@ -405,7 +406,7 @@ func (l *LevelIter) skipEmptyFileBackward() Span {
 		// which it should be due to the Close() call above.
 		l.iterFile = l.files.Prev()
 		if l.iterFile == nil {
-			return Span{}
+			return nil
 		}
 		startKey := l.iterFile.LargestRangeKey.UserKey
 		if l.cmp(startKey, endKey) < 0 {
@@ -416,23 +417,24 @@ func (l *LevelIter) skipEmptyFileBackward() Span {
 				End:   endKey,
 			}
 			l.straddleDir = l.dir
-			return l.straddle
+			return &l.straddle
 		}
-	} else if l.straddle.Valid() && l.straddleDir > 0 {
+	} else if l.straddleDir > 0 {
 		// We were at a straddle key, but are now changing directions. l.iterFile
 		// was already advanced forward by skipEmptyFileForward, so move it
 		// backward.
 		l.iterFile = l.files.Prev()
 	}
 	l.straddle = Span{}
-	var span Span
+	l.straddleDir = 0
+	var span *Span
 	for span.Empty() {
 		fileToLoad := l.iterFile
 		if l.keyType == manifest.KeyTypePoint {
 			fileToLoad = l.files.Prev()
 		}
 		if l.loadFile(fileToLoad, -1) == noFileLoaded {
-			return Span{}
+			return nil
 		}
 		span = l.iter.Last()
 		// In rangedel mode, we can expect to get empty files that we'd need to

--- a/internal/keyspan/level_iter_test.go
+++ b/internal/keyspan/level_iter_test.go
@@ -319,18 +319,18 @@ func TestLevelIterEquivalence(t *testing.T) {
 		valid := true
 		for valid {
 			f1 := iter1.Next()
-			var f2 Span
+			var f2 *Span
 			for {
 				f2 = iter2.Next()
 				// The level iter could produce empty spans that straddle between
 				// files. Ignore those.
-				if !f2.Valid() || !f2.Empty() {
+				if f2 == nil || !f2.Empty() {
 					break
 				}
 			}
 
 			require.Equal(t, f1, f2, "failed on test case %q", tc.name)
-			valid = f1.Valid() && f2.Valid()
+			valid = f1 != nil && f2 != nil
 		}
 	}
 }

--- a/internal/keyspan/merging_iter.go
+++ b/internal/keyspan/merging_iter.go
@@ -260,7 +260,7 @@ func (l *mergingIterLevel) next() {
 		}
 		return
 	}
-	if s := l.iter.Next(); !s.Valid() {
+	if s := l.iter.Next(); s == nil {
 		l.heapKey = boundKey{kind: boundKindInvalid}
 	} else {
 		l.heapKey = boundKey{
@@ -280,7 +280,7 @@ func (l *mergingIterLevel) prev() {
 		}
 		return
 	}
-	if s := l.iter.Prev(); !s.Valid() {
+	if s := l.iter.Prev(); s == nil {
 		l.heapKey = boundKey{kind: boundKindInvalid}
 	} else {
 		l.heapKey = boundKey{
@@ -328,7 +328,7 @@ func (m *MergingIter) AddLevel(iter FragmentIterator) {
 
 // SeekGE moves the iterator to the first span with a start key greater than or
 // equal to key.
-func (m *MergingIter) SeekGE(key []byte) Span {
+func (m *MergingIter) SeekGE(key []byte) *Span {
 	m.invalidate() // clear state about current position
 	for i := range m.levels {
 		l := &m.levels[i]
@@ -342,7 +342,7 @@ func (m *MergingIter) SeekGE(key []byte) Span {
 		// Otherwise we use the start boundary of the next span which
 		// necessarily has a start ≥ key.
 		s := l.iter.SeekLT(key)
-		if s.Valid() && m.cmp(s.End, key) >= 0 {
+		if s != nil && m.cmp(s.End, key) >= 0 {
 			// s.End ≥ key
 			// We need to use this span's end bound.
 			l.heapKey = boundKey{
@@ -355,7 +355,7 @@ func (m *MergingIter) SeekGE(key []byte) Span {
 		// s.End < key
 		// The span `s` ends before key. Next to the first span with a Start ≥
 		// key, and use that.
-		if s = l.iter.Next(); !s.Valid() {
+		if s = l.iter.Next(); s == nil {
 			l.heapKey = boundKey{kind: boundKindInvalid}
 		} else {
 			l.heapKey = boundKey{
@@ -370,7 +370,7 @@ func (m *MergingIter) SeekGE(key []byte) Span {
 }
 
 // SeekLT moves the iterator to the last span with a start key less than key.
-func (m *MergingIter) SeekLT(key []byte) Span {
+func (m *MergingIter) SeekLT(key []byte) *Span {
 	// TODO(jackson): Evaluate whether there's an implementation of SeekLT
 	// independent of SeekGE that is more efficient. It's tricky, because the
 	// span we should return might straddle `key` itself.
@@ -390,18 +390,18 @@ func (m *MergingIter) SeekLT(key []byte) Span {
 	// Start user key < key: [b,l)#1. This requires examining bounds both < 'c'
 	// (the 'b' of [b,m)#1's start key) and bounds ≥ 'c' (the 'l' of ([a,l)#2's
 	// end key).
-	if s := m.SeekGE(key); !s.Valid() && m.err != nil {
-		return Span{}
+	if s := m.SeekGE(key); s == nil && m.err != nil {
+		return nil
 	}
 	// Prev to the previous span.
 	return m.Prev()
 }
 
 // First seeks the iterator to the first span.
-func (m *MergingIter) First() Span {
+func (m *MergingIter) First() *Span {
 	m.invalidate() // clear state about current position
 	for i := range m.levels {
-		if s := m.levels[i].iter.First(); !s.Valid() {
+		if s := m.levels[i].iter.First(); s == nil {
 			m.levels[i].heapKey = boundKey{kind: boundKindInvalid}
 		} else {
 			m.levels[i].heapKey = boundKey{
@@ -416,10 +416,10 @@ func (m *MergingIter) First() Span {
 }
 
 // Last seeks the iterator to the last span.
-func (m *MergingIter) Last() Span {
+func (m *MergingIter) Last() *Span {
 	m.invalidate() // clear state about current position
 	for i := range m.levels {
-		if s := m.levels[i].iter.Last(); !s.Valid() {
+		if s := m.levels[i].iter.Last(); s == nil {
 			m.levels[i].heapKey = boundKey{kind: boundKindInvalid}
 		} else {
 			m.levels[i].heapKey = boundKey{
@@ -434,12 +434,12 @@ func (m *MergingIter) Last() Span {
 }
 
 // Next advances the iterator to the next span.
-func (m *MergingIter) Next() Span {
+func (m *MergingIter) Next() *Span {
 	if m.err != nil {
-		return Span{}
+		return nil
 	}
 	if m.dir == +1 && (m.end == nil || m.start == nil) {
-		return Span{}
+		return nil
 	}
 	if m.dir != +1 {
 		m.switchToMinHeap()
@@ -448,12 +448,12 @@ func (m *MergingIter) Next() Span {
 }
 
 // Prev advances the iterator to the previous span.
-func (m *MergingIter) Prev() Span {
+func (m *MergingIter) Prev() *Span {
 	if m.err != nil {
-		return Span{}
+		return nil
 	}
 	if m.dir == -1 && (m.end == nil || m.start == nil) {
-		return Span{}
+		return nil
 	}
 	if m.dir != -1 {
 		m.switchToMaxHeap()
@@ -623,7 +623,7 @@ func (m *MergingIter) cmp(a, b []byte) int {
 	return m.heap.cmp(a, b)
 }
 
-func (m *MergingIter) findNextFragmentSet() Span {
+func (m *MergingIter) findNextFragmentSet() *Span {
 	// Each iteration of this loop considers a new merged span between unique
 	// user keys. An iteration may find that there exists no overlap for a given
 	// span, (eg, if the spans [a,b), [d, e) exist within level iterators, the
@@ -691,16 +691,16 @@ func (m *MergingIter) findNextFragmentSet() Span {
 		// we elide empty spans created by the mergingIter itself that don't overlap
 		// with any child iterator returned spans (i.e. empty spans that bridge two
 		// distinct child-iterator-defined spans).
-		if found, s := m.synthesizeKeys(+1); found && s.Valid() {
+		if found, s := m.synthesizeKeys(+1); found && s != nil {
 			return s
 		}
 	}
 	// Exhausted.
 	m.clear()
-	return Span{}
+	return nil
 }
 
-func (m *MergingIter) findPrevFragmentSet() Span {
+func (m *MergingIter) findPrevFragmentSet() *Span {
 	// Each iteration of this loop considers a new merged span between unique
 	// user keys. An iteration may find that there exists no overlap for a given
 	// span, (eg, if the spans [a,b), [d, e) exist within level iterators, the
@@ -767,13 +767,13 @@ func (m *MergingIter) findPrevFragmentSet() Span {
 		// we elide empty spans created by the mergingIter itself that don't overlap
 		// with any child iterator returned spans (i.e. empty spans that bridge two
 		// distinct child-iterator-defined spans).
-		if found, s := m.synthesizeKeys(-1); found && s.Valid() {
+		if found, s := m.synthesizeKeys(-1); found && s != nil {
 			return s
 		}
 	}
 	// Exhausted.
 	m.clear()
-	return Span{}
+	return nil
 }
 
 func (m *MergingIter) heapRoot() []byte {
@@ -793,7 +793,7 @@ func (m *MergingIter) heapRoot() []byte {
 //
 // The boolean return value, `found`, is true if the returned span overlaps
 // with a span returned by a child iterator.
-func (m *MergingIter) synthesizeKeys(dir int8) (bool, Span) {
+func (m *MergingIter) synthesizeKeys(dir int8) (bool, *Span) {
 	if invariants.Enabled {
 		if m.cmp(m.start, m.end) >= 0 {
 			panic(fmt.Sprintf("pebble: invariant violation: span start ≥ end: %s >= %s", m.start, m.end))
@@ -819,9 +819,9 @@ func (m *MergingIter) synthesizeKeys(dir int8) (bool, Span) {
 	}
 	if err := m.transformer.Transform(m.cmp, s, &m.span); err != nil {
 		m.err = err
-		return false, Span{}
+		return false, nil
 	}
-	return found, m.span
+	return found, &m.span
 }
 
 func (m *MergingIter) invalidate() {
@@ -990,7 +990,7 @@ type boundKey struct {
 	//
 	// If kind is boundKindFragmentStart, then key is span.Start. If kind is
 	// boundKindFragmentEnd, then key is span.End.
-	span Span
+	span *Span
 }
 
 func (k boundKey) valid() bool {

--- a/internal/keyspan/merging_iter_test.go
+++ b/internal/keyspan/merging_iter_test.go
@@ -24,7 +24,7 @@ func TestMergingIter(t *testing.T) {
 	var buf bytes.Buffer
 	var iter MergingIter
 
-	formatSpan := func(s Span) { fmt.Fprintln(&buf, s) }
+	formatSpan := func(s *Span) { fmt.Fprintln(&buf, s) }
 
 	datadriven.RunTest(t, "testdata/merging_iter", func(td *datadriven.TestData) string {
 		switch td.Cmd {
@@ -206,31 +206,31 @@ func testFragmenterEquivalenceOnce(t *testing.T, seed int64) {
 
 	type opKind struct {
 		weight int
-		fn     func() (str string, f Span, m Span)
+		fn     func() (str string, f *Span, m *Span)
 	}
 	ops := []opKind{
-		{weight: 2, fn: func() (string, Span, Span) {
+		{weight: 2, fn: func() (string, *Span, *Span) {
 			return "First()", fragmenterIter.First(), mergingIter.First()
 		}},
-		{weight: 2, fn: func() (string, Span, Span) {
+		{weight: 2, fn: func() (string, *Span, *Span) {
 			return "Last()", fragmenterIter.Last(), mergingIter.Last()
 		}},
-		{weight: 5, fn: func() (string, Span, Span) {
+		{weight: 5, fn: func() (string, *Span, *Span) {
 			k := testkeys.Key(ks, rng.Intn(ks.Count()))
 			return fmt.Sprintf("SeekGE(%q)", k),
 				fragmenterIter.SeekGE(k),
 				mergingIter.SeekGE(k)
 		}},
-		{weight: 5, fn: func() (string, Span, Span) {
+		{weight: 5, fn: func() (string, *Span, *Span) {
 			k := testkeys.Key(ks, rng.Intn(ks.Count()))
 			return fmt.Sprintf("SeekLT(%q)", k),
 				fragmenterIter.SeekLT(k),
 				mergingIter.SeekLT(k)
 		}},
-		{weight: 50, fn: func() (string, Span, Span) {
+		{weight: 50, fn: func() (string, *Span, *Span) {
 			return "Next()", fragmenterIter.Next(), mergingIter.Next()
 		}},
-		{weight: 50, fn: func() (string, Span, Span) {
+		{weight: 50, fn: func() (string, *Span, *Span) {
 			return "Prev()", fragmenterIter.Prev(), mergingIter.Prev()
 		}},
 	}

--- a/internal/keyspan/seek_test.go
+++ b/internal/keyspan/seek_test.go
@@ -47,8 +47,9 @@ func TestSeek(t *testing.T) {
 					return err.Error()
 				}
 				span := seek(cmp, iter, []byte(parts[0]))
-				if span.Valid() {
-					span = span.Visible(seq)
+				if span != nil {
+					visible := span.Visible(seq)
+					span = &visible
 				}
 				fmt.Fprintln(&buf, span)
 			}

--- a/internal/keyspan/span.go
+++ b/internal/keyspan/span.go
@@ -76,7 +76,7 @@ func (s *Span) Valid() bool {
 // An Empty span may be produced by Visible, or be produced by iterators in
 // order to surface the gaps between keys.
 func (s *Span) Empty() bool {
-	return len(s.Keys) == 0
+	return s == nil || len(s.Keys) == 0
 }
 
 // SmallestKey returns the smallest internal key defined by the span's keys.
@@ -274,7 +274,7 @@ func (s Span) Covers(seqNum uint64) bool {
 //
 // Keys with sequence numbers with the batch bit set are treated as always
 // visible.
-func (s Span) CoversAt(snapshot, seqNum uint64) bool {
+func (s *Span) CoversAt(snapshot, seqNum uint64) bool {
 	// NB: A key is visible at `snapshot` if its sequence number is strictly
 	// less than `snapshot`. See base.Visible.
 	for i := range s.Keys {

--- a/internal/keyspan/testdata/merging_iter
+++ b/internal/keyspan/testdata/merging_iter
@@ -25,7 +25,7 @@ e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
 h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)}
 l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
 q-z:{(#14,RANGEKEYSET,@9,mangos)}
-<invalid>
+<nil>
 
 # Test snapshot filtering.
 
@@ -54,7 +54,7 @@ e-f:{}
 h-j:{}
 l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
 q-z:{}
-<invalid>
+<nil>
 
 define
 b-d:{#10,RANGEKEYSET,@1,apples}
@@ -78,7 +78,7 @@ b-c:{(#10,RANGEKEYSET,@1,apples) (#3,RANGEKEYUNSET,@1)}
 c-d:{(#10,RANGEKEYSET,@1,apples)}
 e-h:{(#8,RANGEKEYDEL)}
 h-k:{(#5,RANGEKEYDEL)}
-<invalid>
+<nil>
 
 iter
 last
@@ -93,7 +93,7 @@ e-h:{(#8,RANGEKEYDEL)}
 c-d:{(#10,RANGEKEYSET,@1,apples)}
 b-c:{(#10,RANGEKEYSET,@1,apples) (#3,RANGEKEYUNSET,@1)}
 a-b:{(#3,RANGEKEYUNSET,@1)}
-<invalid>
+<nil>
 
 # Test changing directions at each iterator position, reverse to forward.
 iter
@@ -104,7 +104,7 @@ prev
 next
 ----
 h-k:{(#5,RANGEKEYDEL)}
-<invalid>
+<nil>
 h-k:{(#5,RANGEKEYDEL)}
 e-h:{(#8,RANGEKEYDEL)}
 h-k:{(#5,RANGEKEYDEL)}
@@ -162,7 +162,7 @@ e-h:{(#8,RANGEKEYDEL)}
 c-d:{(#10,RANGEKEYSET,@1,apples)}
 b-c:{(#10,RANGEKEYSET,@1,apples) (#3,RANGEKEYUNSET,@1)}
 a-b:{(#3,RANGEKEYUNSET,@1)}
-<invalid>
+<nil>
 a-b:{(#3,RANGEKEYUNSET,@1)}
 
 # Test changing directions at each iterator position, forward to reverse.
@@ -175,7 +175,7 @@ next
 prev
 ----
 a-b:{(#3,RANGEKEYUNSET,@1)}
-<invalid>
+<nil>
 a-b:{(#3,RANGEKEYUNSET,@1)}
 b-c:{(#10,RANGEKEYSET,@1,apples) (#3,RANGEKEYUNSET,@1)}
 a-b:{(#3,RANGEKEYUNSET,@1)}
@@ -218,7 +218,7 @@ b-c:{(#10,RANGEKEYSET,@1,apples) (#3,RANGEKEYUNSET,@1)}
 c-d:{(#10,RANGEKEYSET,@1,apples)}
 e-h:{(#8,RANGEKEYDEL)}
 h-k:{(#5,RANGEKEYDEL)}
-<invalid>
+<nil>
 h-k:{(#5,RANGEKEYDEL)}
 
 iter
@@ -266,7 +266,7 @@ e-h:{(#8,RANGEKEYDEL)}
 e-h:{(#8,RANGEKEYDEL)}
 h-k:{(#5,RANGEKEYDEL)}
 h-k:{(#5,RANGEKEYDEL)}
-<invalid>
+<nil>
 
 # Test SeekLT. Note that MergingIter's SeekLT implements the FragmentIterator's
 # SeekLT semantics. It returns the first fragment with a Start key < the search
@@ -297,8 +297,8 @@ seek-lt hh
 seek-lt k
 seek-lt z
 ----
-<invalid>
-<invalid>
+<nil>
+<nil>
 a-b:{(#3,RANGEKEYUNSET,@1)}
 a-b:{(#3,RANGEKEYUNSET,@1)}
 b-c:{(#10,RANGEKEYSET,@1,apples) (#3,RANGEKEYUNSET,@1)}
@@ -325,7 +325,7 @@ prev
 next
 ----
 a-f:{(#5,RANGEKEYDEL) (#4,RANGEKEYDEL)}
-<invalid>
+<nil>
 a-f:{(#5,RANGEKEYDEL) (#4,RANGEKEYDEL)}
 
 iter
@@ -334,7 +334,7 @@ next
 prev
 ----
 k-s:{(#5,RANGEKEYDEL) (#4,RANGEKEYDEL)}
-<invalid>
+<nil>
 k-s:{(#5,RANGEKEYDEL) (#4,RANGEKEYDEL)}
 
 define
@@ -354,10 +354,10 @@ prev
 next
 ----
 y-z:{(#5,RANGEKEYDEL)}
-<invalid>
+<nil>
 y-z:{(#5,RANGEKEYDEL)}
 w-x:{(#5,RANGEKEYDEL) (#4,RANGEKEYDEL) (#3,RANGEKEYDEL) (#1,RANGEKEYDEL)}
-<invalid>
+<nil>
 w-x:{(#5,RANGEKEYDEL) (#4,RANGEKEYDEL) (#3,RANGEKEYDEL) (#1,RANGEKEYDEL)}
 
 iter
@@ -397,8 +397,8 @@ rf-sn:{(#8,RANGEKEYDEL) (#7,RANGEKEYDEL) (#4,RANGEKEYDEL)}
 sn-sv:{(#10,RANGEKEYDEL) (#8,RANGEKEYDEL) (#7,RANGEKEYDEL) (#4,RANGEKEYDEL)}
 sv-wn:{(#10,RANGEKEYDEL) (#4,RANGEKEYDEL)}
 wn-yx:{(#4,RANGEKEYDEL)}
-<invalid>
-<invalid>
+<nil>
+<nil>
 wn-yx:{(#4,RANGEKEYDEL)}
 
 # Test that empty spans from child iterators are preserved
@@ -430,7 +430,7 @@ e-f:{}
 g-h:{(#8,RANGEKEYDEL)}
 h-k:{(#5,RANGEKEYDEL)}
 k-m:{}
-<invalid>
+<nil>
 
 iter
 last
@@ -449,4 +449,4 @@ e-f:{}
 c-d:{(#10,RANGEKEYSET,@1,apples)}
 b-c:{(#10,RANGEKEYSET,@1,apples) (#3,RANGEKEYUNSET,@1)}
 a-b:{(#3,RANGEKEYUNSET,@1)}
-<invalid>
+<nil>

--- a/internal/keyspan/testdata/seek
+++ b/internal/keyspan/testdata/seek
@@ -12,7 +12,7 @@ d 2
 b-d:{(#1,RANGEDEL)}
 b-d:{(#1,RANGEDEL)}
 b-d:{}
-<invalid>
+<nil>
 
 seek-le
 a 2
@@ -20,7 +20,7 @@ b 2
 b 1
 d 2
 ----
-<invalid>
+<nil>
 b-d:{(#1,RANGEDEL)}
 b-d:{}
 b-d:{(#1,RANGEDEL)}
@@ -45,7 +45,7 @@ b-d:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
 b-d:{(#2,RANGEDEL) (#1,RANGEDEL)}
 b-d:{(#1,RANGEDEL)}
 b-d:{}
-<invalid>
+<nil>
 
 seek-le
 a 4
@@ -55,7 +55,7 @@ b 2
 b 1
 d 4
 ----
-<invalid>
+<nil>
 b-d:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
 b-d:{(#2,RANGEDEL) (#1,RANGEDEL)}
 b-d:{(#1,RANGEDEL)}
@@ -88,7 +88,7 @@ d 3
 e 3
 f 3
 ----
-<invalid>
+<nil>
 b-d:{(#1,RANGEDEL)}
 d-f:{}
 d-f:{(#2,RANGEDEL)}
@@ -143,7 +143,7 @@ m-s:{(#1,RANGEDEL)}
 m-s:{}
 s-z:{(#1,RANGEDEL)}
 s-z:{}
-<invalid>
+<nil>
 
 seek-le
 a 4
@@ -232,7 +232,7 @@ s-z:{(#3,RANGEDEL)}
 s-z:{}
 s-z:{}
 s-z:{}
-<invalid>
+<nil>
 
 seek-le
 a 2

--- a/internal/keyspan/truncate.go
+++ b/internal/keyspan/truncate.go
@@ -12,7 +12,7 @@ import "github.com/cockroachdb/pebble/internal/base"
 func Truncate(
 	cmp base.Compare, iter FragmentIterator, lower, upper []byte, start, end *base.InternalKey,
 ) FragmentIterator {
-	return Filter(iter, func(in Span, out *Span) (keep bool) {
+	return Filter(iter, func(in *Span, out *Span) (keep bool) {
 		out.Start, out.End = in.Start, in.End
 		out.Keys = append(out.Keys[:0], in.Keys...)
 

--- a/internal/keyspan/truncate_test.go
+++ b/internal/keyspan/truncate_test.go
@@ -55,7 +55,7 @@ func TestTruncate(t *testing.T) {
 			tIter := Truncate(cmp, iter, lower, upper, startKey, endKey)
 			defer tIter.Close()
 			var truncated []Span
-			for s := tIter.First(); s.Valid(); s = tIter.Next() {
+			for s := tIter.First(); s != nil; s = tIter.Next() {
 				truncated = append(truncated, s.ShallowClone())
 			}
 			return formatAlphabeticSpans(truncated)

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -423,7 +423,7 @@ func (o *ingestOp) build(t *test, h *history, b *pebble.Batch, i int) (string, e
 
 	if rangeDelIter != nil {
 		// NB: The range tombstones have already been fragmented by the Batch.
-		for t := rangeDelIter.First(); t.Valid(); t = rangeDelIter.Next() {
+		for t := rangeDelIter.First(); t != nil; t = rangeDelIter.Next() {
 			// NB: We don't have to copy the key or value since we're reading from a
 			// batch which doesn't do prefix compression.
 			if err := w.DeleteRange(t.Start, t.End); err != nil {
@@ -472,7 +472,7 @@ func (o *ingestOp) collapseBatch(
 
 	if rangeDelIter != nil {
 		// NB: The range tombstones have already been fragmented by the Batch.
-		for t := rangeDelIter.First(); t.Valid(); t = rangeDelIter.Next() {
+		for t := rangeDelIter.First(); t != nil; t = rangeDelIter.Next() {
 			// NB: We don't have to copy the key or value since we're reading from a
 			// batch which doesn't do prefix compression.
 			if err := collapsed.DeleteRange(t.Start, t.End, nil); err != nil {

--- a/internal/rangedel/rangedel.go
+++ b/internal/rangedel/rangedel.go
@@ -13,7 +13,7 @@ import (
 // closure with the encoded internal keys that represent the Span's state. The
 // keys and values passed to emit are only valid until the closure returns.  If
 // emit returns an error, Encode stops and returns the error.
-func Encode(s keyspan.Span, emit func(k base.InternalKey, v []byte) error) error {
+func Encode(s *keyspan.Span, emit func(k base.InternalKey, v []byte) error) error {
 	for _, k := range s.Keys {
 		if k.Kind() != base.InternalKeyKindRangeDelete {
 			return base.CorruptionErrorf("pebble: rangedel.Encode cannot encode %s key", k.Kind())

--- a/internal/rangekey/coalesce.go
+++ b/internal/rangekey/coalesce.go
@@ -97,7 +97,7 @@ func (ui *UserIteratorConfig) Transform(cmp base.Compare, s keyspan.Span, dst *k
 //
 // This implementation is stateful, and must not be used on multiple
 // DefragmentingIters concurrently.
-func (ui *UserIteratorConfig) ShouldDefragment(cmp base.Compare, a, b keyspan.Span) bool {
+func (ui *UserIteratorConfig) ShouldDefragment(cmp base.Compare, a, b *keyspan.Span) bool {
 	// This implementation must only be used on spans that have transformed by
 	// ui.Transform. The transform applies shadowing and removes all keys
 	// besides the resulting Sets. Since shadowing has been applied, each Set

--- a/internal/rangekey/coalesce_test.go
+++ b/internal/rangekey/coalesce_test.go
@@ -82,7 +82,7 @@ func TestIter(t *testing.T) {
 				if i > 0 {
 					iterCmd = string(line[:i])
 				}
-				var s keyspan.Span
+				var s *keyspan.Span
 				switch iterCmd {
 				case "first":
 					s = iter.First()
@@ -311,7 +311,7 @@ var iterDelim = map[rune]bool{',': true, ' ': true, '(': true, ')': true, '"': t
 
 func runIterOp(w io.Writer, it keyspan.FragmentIterator, op string) {
 	fields := strings.FieldsFunc(op, func(r rune) bool { return iterDelim[r] })
-	var s keyspan.Span
+	var s *keyspan.Span
 	switch strings.ToLower(fields[0]) {
 	case "first":
 		s = it.First()
@@ -329,7 +329,7 @@ func runIterOp(w io.Writer, it keyspan.FragmentIterator, op string) {
 		panic(fmt.Sprintf("unrecognized iter op %q", fields[0]))
 	}
 	fmt.Fprintf(w, "%-10s", op)
-	if !s.Valid() {
+	if s == nil {
 		fmt.Fprintln(w, ".")
 		return
 	}

--- a/internal/rangekey/rangekey.go
+++ b/internal/rangekey/rangekey.go
@@ -61,7 +61,7 @@ import (
 // closure with the encoded internal keys that represent the Span's state. The
 // keys and values passed to emit are only valid until the closure returns.
 // If emit returns an error, Encode stops and returns the error.
-func Encode(s keyspan.Span, emit func(k base.InternalKey, v []byte) error) error {
+func Encode(s *keyspan.Span, emit func(k base.InternalKey, v []byte) error) error {
 	enc := Encoder{Emit: emit}
 	return enc.Encode(s)
 }
@@ -82,7 +82,7 @@ type Encoder struct {
 //
 // The encoded key-value pair passed to Emit is only valid until the closure
 // completes.
-func (e *Encoder) Encode(s keyspan.Span) error {
+func (e *Encoder) Encode(s *keyspan.Span) error {
 	if s.Empty() {
 		return nil
 	}
@@ -127,7 +127,7 @@ func (e *Encoder) Encode(s keyspan.Span) error {
 
 // flush constructs internal keys for accumulated key state, and emits the
 // internal keys.
-func (e *Encoder) flush(s keyspan.Span, seqNum uint64, del bool) error {
+func (e *Encoder) flush(s *keyspan.Span, seqNum uint64, del bool) error {
 	if len(e.sets) > 0 {
 		ik := base.MakeInternalKey(s.Start, seqNum, base.InternalKeyKindRangeKeySet)
 		l := EncodedSetValueLen(s.End, e.sets)

--- a/internal/rangekey/testdata/iter
+++ b/internal/rangekey/testdata/iter
@@ -23,7 +23,7 @@ e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
 h-j:{(#22,RANGEKEYDEL)}
 l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
 q-z:{(#14,RANGEKEYSET,@9,mangos)}
-<invalid>
+<nil>
 
 iter
 last
@@ -40,7 +40,7 @@ h-j:{(#22,RANGEKEYDEL)}
 e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
 c-d:{(#4,RANGEKEYSET,@3,coconut)}
 a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL)}
-<invalid>
+<nil>
 
 iter
 seek-ge cat
@@ -80,7 +80,7 @@ next
 e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
 c-d:{(#4,RANGEKEYSET,@3,coconut)}
 a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL)}
-<invalid>
+<nil>
 a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL)}
 c-d:{(#4,RANGEKEYSET,@3,coconut)}
 e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
@@ -100,7 +100,7 @@ e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
 h-j:{(#22,RANGEKEYDEL)}
 l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
 q-z:{(#14,RANGEKEYSET,@9,mangos)}
-<invalid>
+<nil>
 
 iter
 seek-ge a
@@ -127,11 +127,11 @@ seek-ge z
 prev
 seek-ge yeti
 ----
-<invalid>
+<nil>
 q-z:{(#14,RANGEKEYSET,@9,mangos)}
-<invalid>
+<nil>
 q-z:{(#14,RANGEKEYSET,@9,mangos)}
-<invalid>
+<nil>
 
 iter
 seek-ge h
@@ -146,7 +146,7 @@ prev
 next
 ----
 a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL)}
-<invalid>
+<nil>
 a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL)}
 
 iter
@@ -155,7 +155,7 @@ next
 prev
 ----
 q-z:{(#14,RANGEKEYSET,@9,mangos)}
-<invalid>
+<nil>
 q-z:{(#14,RANGEKEYSET,@9,mangos)}
 
 iter
@@ -167,12 +167,12 @@ seek-lt zoo
 next
 prev
 ----
-<invalid>
-<invalid>
+<nil>
+<nil>
 a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL)}
 q-z:{(#14,RANGEKEYSET,@9,mangos)}
 q-z:{(#14,RANGEKEYSET,@9,mangos)}
-<invalid>
+<nil>
 q-z:{(#14,RANGEKEYSET,@9,mangos)}
 
 define visible-seq-num=10

--- a/iterator.go
+++ b/iterator.go
@@ -1484,12 +1484,12 @@ func (i *Iterator) rangeKeyWithinLimit(limit []byte) bool {
 	return true
 }
 
-func (i *iteratorRangeKeyState) SpanChanged(s keyspan.Span) {
+func (i *iteratorRangeKeyState) SpanChanged(s *keyspan.Span) {
 	i.activeMaskSuffix = i.activeMaskSuffix[:0]
 
 	// Find the smallest suffix of a range key contained within the Span,
 	// excluding suffixes less than i.opts.RangeKeyMasking.Suffix.
-	if i.opts.RangeKeyMasking.Suffix == nil || s.Empty() {
+	if s == nil || i.opts.RangeKeyMasking.Suffix == nil || s.Empty() {
 		return
 	}
 	for j := range s.Keys {

--- a/level_checker.go
+++ b/level_checker.go
@@ -53,7 +53,7 @@ type simpleMergingIterLevel struct {
 
 	iterKey   *InternalKey
 	iterValue []byte
-	tombstone keyspan.Span
+	tombstone *keyspan.Span
 }
 
 type simpleMergingIter struct {
@@ -452,8 +452,8 @@ func addTombstonesFromIter(
 	}()
 
 	var prevTombstone keyspan.Span
-	for t := iter.First(); t.Valid(); t = iter.Next() {
-		t = t.Visible(seqNum)
+	for tomb := iter.First(); tomb != nil; tomb = iter.Next() {
+		t := tomb.Visible(seqNum)
 		if t.Empty() {
 			continue
 		}

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -192,7 +192,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 				}
 				frag.Finish()
 				for _, v := range tombstones {
-					if err := rangedel.Encode(v, w.Add); err != nil {
+					if err := rangedel.Encode(&v, w.Add); err != nil {
 						return err.Error()
 					}
 				}

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -233,7 +233,7 @@ func (lt *levelIterTest) runBuild(d *datadriven.TestData) string {
 	}
 	f.Finish()
 	for _, v := range tombstones {
-		if err := rangedel.Encode(v, w.Add); err != nil {
+		if err := rangedel.Encode(&v, w.Add); err != nil {
 			return err.Error()
 		}
 	}
@@ -355,10 +355,14 @@ func (i *levelIterTestIter) rangeDelSeek(
 ) (*InternalKey, []byte) {
 	var tombstone keyspan.Span
 	if i.rangeDelIter != nil {
+		var t *keyspan.Span
 		if dir < 0 {
-			tombstone = keyspan.SeekLE(i.levelIter.cmp, i.rangeDelIter, key).Visible(1000)
+			t = keyspan.SeekLE(i.levelIter.cmp, i.rangeDelIter, key)
 		} else {
-			tombstone = keyspan.SeekGE(i.levelIter.cmp, i.rangeDelIter, key).Visible(1000)
+			t = keyspan.SeekGE(i.levelIter.cmp, i.rangeDelIter, key)
+		}
+		if t != nil {
+			tombstone = t.Visible(1000)
 		}
 	}
 	if ikey == nil {

--- a/mem_table_test.go
+++ b/mem_table_test.go
@@ -362,7 +362,7 @@ func TestMemTableConcurrentDeleteRange(t *testing.T) {
 
 				var count int
 				it := m.newRangeDelIter(nil)
-				for s := it.SeekGE(start); s.Valid(); s = it.Next() {
+				for s := it.SeekGE(start); s != nil; s = it.Next() {
 					if m.cmp(s.Start, end) >= 0 {
 						break
 					}

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -218,7 +218,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 				}
 				frag.Finish()
 				for _, v := range tombstones {
-					if err := rangedel.Encode(v, w.Add); err != nil {
+					if err := rangedel.Encode(&v, w.Add); err != nil {
 						return err.Error()
 					}
 				}

--- a/range_keys.go
+++ b/range_keys.go
@@ -42,7 +42,7 @@ func (d *DB) applyFlushedRangeKeys(flushable []*flushableEntry) error {
 		}
 		d.maybeInitializeRangeKeys()
 
-		for s := iter.First(); s.Valid(); s = iter.Next() {
+		for s := iter.First(); s != nil; s = iter.Next() {
 			// flushable.newRangeKeyIter provides a FragmentIterator, which
 			// iterates over parsed keyspan.Spans.
 			//

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -946,7 +946,7 @@ func (w *Writer) coalesceSpans(span keyspan.Span) {
 
 	// NB: The span only contains range keys and is internally consistent (eg,
 	// no duplicate suffixes, no additional keys after a RANGEKEYDEL).
-	w.err = firstError(w.err, w.rangeKeyEncoder.Encode(w.rangeKeyCoalesced))
+	w.err = firstError(w.err, w.rangeKeyEncoder.Encode(&w.rangeKeyCoalesced))
 }
 
 func (w *Writer) addRangeKey(key InternalKey, value []byte) error {

--- a/sstable/writer_rangekey_test.go
+++ b/sstable/writer_rangekey_test.go
@@ -111,7 +111,7 @@ func TestWriter_RangeKeys(t *testing.T) {
 			defer iter.Close()
 
 			var buf bytes.Buffer
-			for s := iter.First(); s.Valid(); s = iter.Next() {
+			for s := iter.First(); s != nil; s = iter.Next() {
 				_, _ = fmt.Fprintf(&buf, "%s\n", s)
 			}
 			return buf.String()

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -134,7 +134,7 @@ func runDataDriven(t *testing.T, file string, parallelism bool) {
 			defer iter.Close()
 
 			var buf bytes.Buffer
-			for s := iter.First(); s.Valid(); s = iter.Next() {
+			for s := iter.First(); s != nil; s = iter.Next() {
 				fmt.Fprintf(&buf, "%s\n", s)
 			}
 			return buf.String()
@@ -150,7 +150,7 @@ func runDataDriven(t *testing.T, file string, parallelism bool) {
 			defer iter.Close()
 
 			var buf bytes.Buffer
-			for s := iter.First(); s.Valid(); s = iter.Next() {
+			for s := iter.First(); s != nil; s = iter.Next() {
 				fmt.Fprintf(&buf, "%s\n", s)
 			}
 			return buf.String()

--- a/table_stats.go
+++ b/table_stats.go
@@ -458,7 +458,7 @@ func foreachDefragmentedTombstone(
 	fn func([]byte, []byte, uint64, uint64) error,
 ) error {
 	// Use an equals func that will always merge abutting spans.
-	equal := keyspan.DefragmentMethodFunc(func(_ base.Compare, _, _ keyspan.Span) bool {
+	equal := keyspan.DefragmentMethodFunc(func(_ base.Compare, _, _ *keyspan.Span) bool {
 		return true
 	})
 	// Reduce keys by maintaining a slice of length two, corresponding to the
@@ -493,7 +493,7 @@ func foreachDefragmentedTombstone(
 	}
 	iter := keyspan.DefragmentingIter{}
 	iter.Init(cmp, rangeDelIter, equal, reducer)
-	for s := iter.First(); s.Valid(); s = iter.Next() {
+	for s := iter.First(); s != nil; s = iter.Next() {
 		if err := fn(s.Start, s.End, s.SmallestSeqNum(), s.LargestSeqNum()); err != nil {
 			_ = iter.Close()
 			return err

--- a/tool/find.go
+++ b/tool/find.go
@@ -444,7 +444,7 @@ func (f *findT) searchTables(searchKey []byte, refs []findRef) []findRef {
 				defer iter.Close()
 
 				var tombstones []keyspan.Span
-				for t := iter.First(); t.Valid(); t = iter.Next() {
+				for t := iter.First(); t != nil; t = iter.Next() {
 					if !t.Contains(r.Compare, searchKey) {
 						continue
 					}
@@ -464,9 +464,9 @@ func (f *findT) searchTables(searchKey []byte, refs []findRef) []findRef {
 			rangeDel := rangeDelIter.First()
 
 			foundRef := false
-			for key != nil || rangeDel.Valid() {
+			for key != nil || rangeDel != nil {
 				if key != nil &&
-					(!rangeDel.Valid() || r.Compare(key.UserKey, rangeDel.Start) < 0) {
+					(rangeDel == nil || r.Compare(key.UserKey, rangeDel.Start) < 0) {
 					if r.Compare(searchKey, key.UserKey) != 0 {
 						key, value = nil, nil
 						continue

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -401,7 +401,7 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 			defer iter.Close()
 
 			var tombstones []keyspan.Span
-			for t := iter.First(); t.Valid(); t = iter.Next() {
+			for t := iter.First(); t != nil; t = iter.Next() {
 				if s.end != nil && r.Compare(s.end, t.Start) <= 0 {
 					// The range tombstone lies after the scan range.
 					continue
@@ -428,8 +428,8 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 		count := s.count
 
 		var lastKey base.InternalKey
-		for key != nil || rangeDel.Valid() {
-			if key != nil && (!rangeDel.Valid() || r.Compare(key.UserKey, rangeDel.Start) < 0) {
+		for key != nil || rangeDel != nil {
+			if key != nil && (rangeDel == nil || r.Compare(key.UserKey, rangeDel.Start) < 0) {
 				// The filter specifies a prefix of the key.
 				//
 				// TODO(peter): Is using prefix comparison like this kosher for all


### PR DESCRIPTION
The first four commits are from #1743 and the fifth is from #1747, and they
should be reviewed in their respective PRs.

----

Previously the keyspan.Span type used to represent range deletions and range
keys was passed primarily by value, including through the FragmentIterator
interface. This was convenient when transforming spans (eg, truncating bounds),
but passing them by pointer is enough of a performance win to be worthwhile.

Informs cockroachdb/cockroach#82559.

```
name                                    old time/op    new time/op    delta
IteratorSeekNoRangeKeys/batch=false-10    4.28µs ± 1%    2.90µs ± 4%  -32.27%  (p=0.000 n=19+20)
IteratorSeekNoRangeKeys/batch=true-10     8.78µs ± 1%    5.37µs ± 1%  -38.86%  (p=0.000 n=20+20)

name                                    old alloc/op   new alloc/op   delta
IteratorSeekNoRangeKeys/batch=false-10     16.0B ± 0%     16.0B ± 0%     ~     (all equal)
IteratorSeekNoRangeKeys/batch=true-10       192B ± 0%      128B ± 0%  -33.33%  (p=0.000 n=20+20)
```