### PR TITLE
db: exclude empty batch range deletion, range key iterators

### DIFF
--- a/internal/keyspan/iter.go
+++ b/internal/keyspan/iter.go
@@ -86,6 +86,11 @@ func NewIter(cmp base.Compare, spans []Span) *Iter {
 	return i
 }
 
+// Count returns the number of spans contained by Iter.
+func (i *Iter) Count() int {
+	return len(i.spans)
+}
+
 // Init initializes an Iter with the provided spans.
 func (i *Iter) Init(cmp base.Compare, spans []Span) {
 	*i = Iter{

--- a/iterator.go
+++ b/iterator.go
@@ -1931,13 +1931,48 @@ func (i *Iterator) SetOptions(o *IterOptions) {
 		if nextBatchSeqNum != i.batchSeqNum {
 			i.batchSeqNum = nextBatchSeqNum
 			if i.pointIter != nil {
-				i.batchPointIter.snapshot = nextBatchSeqNum
-				i.batch.initRangeDelIter(&i.opts, &i.batchRangeDelIter, nextBatchSeqNum)
-				i.invalidate()
+				// NB: batch.countRangeDels monotonically increases over the
+				// lifetime of the batch.
+				if prevCount := i.batchRangeDelIter.Count(); int(i.batch.countRangeDels) == prevCount {
+					// No new range deletions have been added. We only need to
+					// update the batchIter's snapshot.
+					i.batchPointIter.snapshot = nextBatchSeqNum
+					i.invalidate()
+				} else if prevCount == 0 {
+					// When we constructed this iterator, there were no
+					// rangedels in the batch. Iterator construction will have
+					// excluded the batch rangedel iterator from the point
+					// iterator stack. We need to reconstruct the point iterator
+					// to add i.batchRangeDelIter into the iterator stack.
+					i.err = firstError(i.err, i.pointIter.Close())
+					i.pointIter = nil
+				} else {
+					// New range deletions have been added, and we already have
+					// a batch rangedel iterator. We can update the batch
+					// rangedel iterator in place.
+					i.batchPointIter.snapshot = nextBatchSeqNum
+					i.batch.initRangeDelIter(&i.opts, &i.batchRangeDelIter, nextBatchSeqNum)
+					i.invalidate()
+				}
 			}
-			if i.rangeKey != nil {
-				i.batch.initRangeKeyIter(&i.opts, &i.batchRangeKeyIter, nextBatchSeqNum)
-				i.invalidate()
+			// NB: batch.countRangeKeys monotonically increases over the
+			// lifetime of the batch.
+			if i.rangeKey != nil && int(i.batch.countRangeKeys) != i.batchRangeKeyIter.Count() {
+				if i.batchRangeKeyIter.Count() == 0 {
+					// When we constructed this iterator, there were no range
+					// keys in the batch. Iterator construction will have
+					// excluded the batch rangekey iterator from the range key
+					// iterator stack. We need to reconstruct the range key
+					// iterator to add i.batchRangeKeyIter into the iterator
+					// stack.
+					i.err = firstError(i.err, i.rangeKey.rangeKeyIter.Close())
+					i.rangeKey = nil
+				} else {
+					// No new range keys have been added. We only need to update
+					// the batchIter's snapshot.
+					i.batch.initRangeKeyIter(&i.opts, &i.batchRangeKeyIter, nextBatchSeqNum)
+					i.invalidate()
+				}
 			}
 		}
 	}

--- a/range_keys.go
+++ b/range_keys.go
@@ -110,7 +110,13 @@ func (d *DB) newRangeKeyIter(
 			it.rangeKey.iterConfig.AddLevel(newErrorKeyspanIter(ErrNotIndexed))
 		} else {
 			batch.initRangeKeyIter(&it.opts, &it.batchRangeKeyIter, batchSeqNum)
-			it.rangeKey.iterConfig.AddLevel(&it.batchRangeKeyIter)
+			// Only include the batch's range key iterator if it has any keys.
+			// NB: This can force reconstruction of the rangekey iterator stack
+			// in SetOptions if subsequently range keys are added. See
+			// SetOptions.
+			if it.batchRangeKeyIter.Count() > 0 {
+				it.rangeKey.iterConfig.AddLevel(&it.batchRangeKeyIter)
+			}
 		}
 	}
 


### PR DESCRIPTION
Since e32e94d86 Pebble has unconditionally included batch rangedel iterators
and batch rangekey iterators in the iterator stack. This was done to allow
SetOptions to update these batch iterators if rangedels or rangekeys were added
to the batch between iterator construction and the call to SetOptions.

In this commit, we update iterator construction to again exclude these empty
iterators. To compensate, SetOptions must now test whether any range deletions
or range keys existed at iterator construction, and recreate the point/range
key iterator stacks if necessary. Cases that require iterator reconstruction
are expected to be rare, whereas empty batch rangedel and rangekey iterators
are expected to be very common.

```
name                                    old time/op    new time/op    delta
IteratorSeekNoRangeKeys/batch=false-10    2.90µs ± 4%    2.93µs ± 0%   +1.25%  (p=0.000 n=20+17)
IteratorSeekNoRangeKeys/batch=true-10     5.37µs ± 1%    4.61µs ± 1%  -14.14%  (p=0.000 n=20+20)

name                                    old alloc/op   new alloc/op   delta
IteratorSeekNoRangeKeys/batch=false-10     16.0B ± 0%     16.0B ± 0%     ~     (all equal)
IteratorSeekNoRangeKeys/batch=true-10       128B ± 0%       32B ± 0%  -75.00%  (p=0.000 n=20+20)

name                                    old allocs/op  new allocs/op  delta
IteratorSeekNoRangeKeys/batch=false-10      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
IteratorSeekNoRangeKeys/batch=true-10       5.00 ± 0%      2.00 ± 0%  -60.00%  (p=0.000 n=20+20)
```