### PR TITLE
tool: add pretty-printed keys to the LSM visualization tool

### DIFF
--- a/tool/lsm_data.go
+++ b/tool/lsm_data.go
@@ -718,7 +718,6 @@ let version = {
             }
         }
 
-        // TODO(peter): display smallest/largest key.
         reason.text(
             "[" +
                 this.levelsInfo[i].levelString +
@@ -728,6 +727,11 @@ let version = {
                 humanize(data.Files[fileNum].Size) +
                 ")" +
                 overlapInfo +
+                "<" +
+                data.Keys[data.Files[fileNum].Smallest].Pretty +
+                ", " +
+                data.Keys[data.Files[fileNum].Largest].Pretty +
+                ">" +
                 "]"
         );
 


### PR DESCRIPTION
<img width="1904" alt="image" src="https://user-images.githubusercontent.com/1443719/173083030-2f8649d2-b60a-4326-a3df-aa297e5643b2.png">

**tool: add pretty-printed keys to the LSM visualization tool**

This commit adds pretty-printed keys to the LSM visualization tool.