### PR TITLE
db: fix SetOptions batch range{del,key} refresh logic

### DIFF
--- a/range_keys.go
+++ b/range_keys.go
@@ -19,12 +19,12 @@ func (d *DB) newRangeKeyIter(
 		if batch.index == nil {
 			it.rangeKey.iterConfig.AddLevel(newErrorKeyspanIter(ErrNotIndexed))
 		} else {
-			batch.initRangeKeyIter(&it.opts, &it.batchRangeKeyIter, batchSeqNum)
 			// Only include the batch's range key iterator if it has any keys.
 			// NB: This can force reconstruction of the rangekey iterator stack
 			// in SetOptions if subsequently range keys are added. See
 			// SetOptions.
-			if it.batchRangeKeyIter.Count() > 0 {
+			if batch.countRangeKeys > 0 {
+				batch.initRangeKeyIter(&it.opts, &it.batchRangeKeyIter, batchSeqNum)
 				it.rangeKey.iterConfig.AddLevel(&it.batchRangeKeyIter)
 			}
 		}

--- a/testdata/indexed_batch_mutation
+++ b/testdata/indexed_batch_mutation
@@ -403,3 +403,57 @@ next
 ----
 foo: (foo, .)
 .
+
+reset
+----
+
+new-batch
+range-key-set a c @1 poi
+range-key-set b d @2 yaya
+----
+
+new-iter i1
+----
+
+# The batch contains 2 range keys, but the skiplist of fragmented range keys
+# contains 3 elements (a-b, b-c, c-d).
+
+iter iter=i1
+first
+next
+next
+----
+a: (., [a-b) @1=poi)
+b: (., [b-c) @2=yaya, @1=poi)
+c: (., [c-d) @2=yaya)
+
+# Add a new range key to the batch. The batch contains 3 internal range keys,
+# and the skiplist of fragmented range keys contains 3 elements.
+
+mutate
+range-key-set e f @3 foo
+----
+
+# Refreshing the iterator's view of the batch through SetOptions should surface
+# the new range key. An earlier bug incorrectly compared the number of
+# fragmented range keys to the number of internal batch range keys in order to
+# determine when to refresh the iterator.
+
+iter iter=i1
+first
+next
+next
+set-options
+first
+next
+next
+next
+----
+a: (., [a-b) @1=poi)
+b: (., [b-c) @2=yaya, @1=poi)
+c: (., [c-d) @2=yaya)
+.
+a: (., [a-b) @1=poi)
+b: (., [b-c) @2=yaya, @1=poi)
+c: (., [c-d) @2=yaya)
+e: (., [e-f) @3=foo)


### PR DESCRIPTION
The commit a015e5a0c introduced an optimization to avoid refreshing batch
rangedel and rangekey iterators when no rangedel or rangekey mutations were
applied.

This optimization had a bug: It compared unlike numbers to determine whether to
refresh. The batch's `count{RangeDels,RangeKeys}` fields record the number of
rangedels or range keys added to the batch and are monotonically increasing.
The count of spans in the `keyspan.Iter` on the other hand was the count of
fragments. This bug could result in erroroneously not refreshing the iterator's
view if the previous number of fragments matched the current number of batch
keys.

This commit adapts SetOptions to not avoid calls to initRangeDelIter and
initRangeKeyIter in these cases: These functions already avoid refragmenting
the spans if unnecessary, so there should be little cost to calling them
unconditionally. The logic to reconstruct the point / range key iterator in
SetOptions when a batch goes from zero rangedels/rangekeys to nonzero
rangedels/rangekeys is preserved.