### PR TITLE
db: support SetOptions on iterators created through NewExternalIter

### DIFF
--- a/testdata/external_iterator
+++ b/testdata/external_iterator
@@ -160,3 +160,20 @@ next
 ----
 a: (., [a-k) @5=foo, @4=bar, @1=bax)
 a@4: (v, [a-k) @5=foo, @4=bar, @1=bax)
+
+# Test mutating the external iterator's options through SetOptions.
+
+iter files=(points, ag, ek)
+set-options key-types=point
+first
+next
+set-options lower=e upper=p
+first
+next
+----
+.
+a@4:v
+c@2:v
+.
+e@5:v
+k@3:v


### PR DESCRIPTION
Allow iterators constructed through NewExternalIter to be reconfigured using
SetOptions. This required some restructuring of the external iterator
initialization code. Also, document and enforce the limitations around
unsupported IterOptions for external iterators.