### PR TITLE
db: remove RangeKeysArena

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -346,7 +346,6 @@ func TestIndexedBatchMutation(t *testing.T) {
 		FS:                 vfs.NewMem(),
 		FormatMajorVersion: FormatNewest,
 	}
-	opts.Experimental.RangeKeys = new(RangeKeysArena)
 	d, err := Open("", opts)
 	require.NoError(t, err)
 	defer func() { d.Close() }()
@@ -436,7 +435,6 @@ func TestIndexedBatch_GlobalVisibility(t *testing.T) {
 		FormatMajorVersion: FormatNewest,
 		Comparer:           testkeys.Comparer,
 	}
-	opts.Experimental.RangeKeys = new(RangeKeysArena)
 	d, err := Open("", opts)
 	require.NoError(t, err)
 	defer d.Close()
@@ -1185,7 +1183,6 @@ func TestBatchSpanCaching(t *testing.T) {
 		FS:                 vfs.NewMem(),
 		FormatMajorVersion: FormatNewest,
 	}
-	opts.Experimental.RangeKeys = new(RangeKeysArena)
 	d, err := Open("", opts)
 	require.NoError(t, err)
 	defer d.Close()

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1347,13 +1347,10 @@ func TestManualCompaction(t *testing.T) {
 
 				mem = vfs.NewMem()
 				opts := &Options{
-					FS:                 mem,
-					DebugCheck:         DebugCheckLevels,
-					FormatMajorVersion: randVersion(minVersion, maxVersion),
-				}
-				opts.DisableAutomaticCompactions = true
-				if opts.FormatMajorVersion >= FormatRangeKeys {
-					opts.Experimental.RangeKeys = new(RangeKeysArena)
+					FS:                          mem,
+					DebugCheck:                  DebugCheckLevels,
+					FormatMajorVersion:          randVersion(minVersion, maxVersion),
+					DisableAutomaticCompactions: true,
 				}
 
 				var err error

--- a/db.go
+++ b/db.go
@@ -473,11 +473,6 @@ type DB struct {
 		}
 	}
 
-	// rangeKeys is a temporary field so that Pebble can provide a non-durable
-	// implementation of range keys in advance of the real implementation.
-	// TODO(jackson): Remove this.
-	rangeKeys *RangeKeysArena
-
 	// Normally equal to time.Now() but may be overridden in tests.
 	timeNow func() time.Time
 }
@@ -747,9 +742,6 @@ func (d *DB) Apply(batch *Batch, opts *WriteOptions) error {
 		if d.split == nil {
 			return errNoSplit
 		}
-		if d.opts.Experimental.RangeKeys == nil {
-			panic("pebble: range keys require the Experimental.RangeKeys option")
-		}
 		if d.FormatMajorVersion() < FormatRangeKeys {
 			panic(fmt.Sprintf(
 				"pebble: range keys require at least format major version %d (current: %d)",
@@ -893,9 +885,6 @@ func (d *DB) newIterInternal(batch *Batch, s *Snapshot, o *IterOptions) *Iterato
 		panic(err)
 	}
 	if o.rangeKeys() {
-		if d.opts.Experimental.RangeKeys == nil {
-			panic("pebble: range keys require the Experimental.RangeKeys option")
-		}
 		if d.FormatMajorVersion() < FormatRangeKeys {
 			panic(fmt.Sprintf(
 				"pebble: range keys require at least format major version %d (current: %d)",

--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -148,10 +148,6 @@ func testMetaRun(t *testing.T, runDir string, seed uint64, historyPath string) {
 	// Use an archive cleaner to ease post-mortem debugging.
 	opts.Cleaner = base.ArchiveCleaner{}
 
-	// Enable experimental range keys support.
-	rangeKeysArena := &pebble.RangeKeysArena{}
-	opts.Experimental.RangeKeys = rangeKeysArena
-
 	// Set up the filesystem to use for the test. Note that by default we use an
 	// in-memory FS.
 	if testOpts.useDisk {

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1736,7 +1736,6 @@ func newTestkeysDatabase(t *testing.T, ks testkeys.Keyspace) *DB {
 		FS:                 vfs.NewMem(),
 		FormatMajorVersion: FormatRangeKeys,
 	}
-	dbOpts.Experimental.RangeKeys = new(RangeKeysArena)
 	d, err := Open("", dbOpts)
 	require.NoError(t, err)
 
@@ -2056,7 +2055,6 @@ func BenchmarkIteratorScan(b *testing.B) {
 					FS:                 vfs.NewMem(),
 					FormatMajorVersion: FormatNewest,
 				}
-				opts.Experimental.RangeKeys = new(RangeKeysArena)
 				opts.DisableAutomaticCompactions = true
 				d, err := Open("", opts)
 				require.NoError(b, err)
@@ -2112,7 +2110,6 @@ func BenchmarkIteratorSeekNoRangeKeys(b *testing.B) {
 		FS:                 vfs.NewMem(),
 		FormatMajorVersion: FormatNewest,
 	}
-	opts.Experimental.RangeKeys = new(RangeKeysArena)
 	d, err := Open("", opts)
 	require.NoError(b, err)
 	defer func() { require.NoError(b, d.Close()) }()

--- a/open.go
+++ b/open.go
@@ -75,7 +75,6 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		merge:               opts.Merger.Merge,
 		split:               opts.Comparer.Split,
 		abbreviatedKey:      opts.Comparer.AbbreviatedKey,
-		rangeKeys:           opts.Experimental.RangeKeys,
 		largeBatchThreshold: (opts.MemTableSize - int(memTableEmptySize)) / 2,
 		logRecycler:         logRecycler{limit: opts.MemTableStopWritesThreshold + 1},
 		closed:              new(atomic.Value),

--- a/options.go
+++ b/options.go
@@ -446,12 +446,6 @@ type Options struct {
 		// deletion pacing, which is also the default.
 		MinDeletionRate int
 
-		// RangeKeys enables the experimental use of range keys, stored in an
-		// in-memory nondurable arena. This option is only intended to be
-		// temporary, to allow the Pebble metamorphic tests to reuse the
-		// range-key arena across DB restarts.
-		RangeKeys *RangeKeysArena
-
 		// ReadCompactionRate controls the frequency of read triggered
 		// compactions by adjusting `AllowedSeeks` in manifest.FileMetadata:
 		//

--- a/range_keys_test.go
+++ b/range_keys_test.go
@@ -41,7 +41,6 @@ func TestRangeKeys(t *testing.T) {
 				Comparer:           testkeys.Comparer,
 				FormatMajorVersion: FormatRangeKeys,
 			}
-			opts.Experimental.RangeKeys = new(RangeKeysArena)
 
 			for _, cmdArgs := range td.CmdArgs {
 				if cmdArgs.Key != "format-major-version" {

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -30,7 +30,6 @@ func TestTableStats(t *testing.T) {
 	}
 	opts.DisableAutomaticCompactions = true
 	opts.Comparer = testkeys.Comparer
-	opts.Experimental.RangeKeys = new(RangeKeysArena)
 	opts.FormatMajorVersion = FormatRangeKeys
 
 	d, err := Open("", opts)


### PR DESCRIPTION
Now that range keys are persisted durably, remove the in-memory range keys
arena.