### PR TITLE
db: avoid allocation in newIters

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -93,14 +93,6 @@ type Iterator interface {
 	SetCloseHook(fn func(i Iterator) error)
 }
 
-// FragmentIterator is a version of Iterator that wraps keyspan.FragmentIterator
-// instead of InternalIterator, and adds SetCloseHook.
-type FragmentIterator interface {
-	keyspan.FragmentIterator
-
-	SetCloseHook(fn func(i keyspan.FragmentIterator) error)
-}
-
 // singleLevelIterator iterates over an entire table of data. To seek for a given
 // key, it first looks in the index for the block that contains that key, and then
 // looks inside that block.
@@ -2218,7 +2210,7 @@ func (r *Reader) NewRawRangeDelIter() (keyspan.FragmentIterator, error) {
 // NewRawRangeKeyIter returns an internal iterator for the contents of the
 // range-key block for the table. Returns nil if the table does not contain any
 // range keys.
-func (r *Reader) NewRawRangeKeyIter() (FragmentIterator, error) {
+func (r *Reader) NewRawRangeKeyIter() (keyspan.FragmentIterator, error) {
 	if r.rangeKeyBH.Length == 0 {
 		return nil, nil
 	}


### PR DESCRIPTION
Avoid allocation in newIters by using the cached closeHook closure. This
optimization was lost in 09203fd9a780ce8c15bf8bec3c773ff028051e02. Some version
of this should be backported to 22.1.

```
name                                                    old time/op    new time/op    delta
MVCCGet_Pebble/batch=false/versions=1/valueSize=8-10      4.40µs ±12%    3.76µs ± 1%  -14.42%  (p=0.000 n=10+9)
MVCCGet_Pebble/batch=false/versions=10/valueSize=8-10     5.01µs ± 3%    4.49µs ± 1%  -10.32%  (p=0.000 n=10+10)
MVCCGet_Pebble/batch=false/versions=100/valueSize=8-10    9.56µs ± 2%    9.32µs ± 2%   -2.55%  (p=0.000 n=10+9)
MVCCGet_Pebble/batch=true/versions=1/valueSize=8-10       2.19µs ± 1%    2.15µs ± 0%   -1.71%  (p=0.000 n=10+9)
MVCCGet_Pebble/batch=true/versions=10/valueSize=8-10      3.06µs ± 2%    2.97µs ± 0%   -3.05%  (p=0.000 n=10+9)
MVCCGet_Pebble/batch=true/versions=100/valueSize=8-10     6.77µs ± 2%    6.50µs ± 1%   -3.93%  (p=0.000 n=9+9)

name                                                    old speed      new speed      delta
MVCCGet_Pebble/batch=false/versions=1/valueSize=8-10    1.83MB/s ±11%  2.13MB/s ± 1%  +16.40%  (p=0.000 n=10+9)
MVCCGet_Pebble/batch=false/versions=10/valueSize=8-10   1.60MB/s ± 3%  1.78MB/s ± 1%  +11.51%  (p=0.000 n=10+10)
MVCCGet_Pebble/batch=false/versions=100/valueSize=8-10   837kB/s ± 2%   859kB/s ± 2%   +2.62%  (p=0.000 n=10+9)
MVCCGet_Pebble/batch=true/versions=1/valueSize=8-10     3.66MB/s ± 1%  3.72MB/s ± 0%   +1.70%  (p=0.000 n=10+9)
MVCCGet_Pebble/batch=true/versions=10/valueSize=8-10    2.62MB/s ± 2%  2.70MB/s ± 0%   +3.17%  (p=0.000 n=10+9)
MVCCGet_Pebble/batch=true/versions=100/valueSize=8-10   1.18MB/s ± 2%  1.23MB/s ± 0%   +4.04%  (p=0.000 n=9+6)

name                                                    old allocs/op  new allocs/op  delta
MVCCGet_Pebble/batch=false/versions=1/valueSize=8-10        4.00 ± 0%      2.00 ± 0%  -50.00%  (p=0.000 n=10+10)
MVCCGet_Pebble/batch=false/versions=10/valueSize=8-10       4.00 ± 0%      2.00 ± 0%  -50.00%  (p=0.000 n=10+10)
MVCCGet_Pebble/batch=false/versions=100/valueSize=8-10      6.00 ± 0%      2.00 ± 0%  -66.67%  (p=0.000 n=10+10)
MVCCGet_Pebble/batch=true/versions=1/valueSize=8-10         2.00 ± 0%      2.00 ± 0%     ~     (all equal)
MVCCGet_Pebble/batch=true/versions=10/valueSize=8-10        2.00 ± 0%      2.00 ± 0%     ~     (all equal)
MVCCGet_Pebble/batch=true/versions=100/valueSize=8-10       3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.000 n=10+10)
```