### PR TITLE
db: fix nil-pointer in external iterator range key iteration

### DIFF
--- a/db.go
+++ b/db.go
@@ -978,10 +978,7 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 	if dbi.opts.rangeKeys() {
 		if dbi.rangeKey == nil {
 			dbi.rangeKey = iterRangeKeyStateAllocPool.Get().(*iteratorRangeKeyState)
-			dbi.rangeKey.cmp = dbi.cmp
-			dbi.rangeKey.keys.cmp = dbi.cmp
-			dbi.rangeKey.split = dbi.split
-			dbi.rangeKey.opts = &dbi.opts
+			dbi.rangeKey.init(dbi.cmp, dbi.split, &dbi.opts)
 			dbi.rangeKey.rangeKeyIter = dbi.db.newRangeKeyIter(dbi, dbi.seqNum, dbi.batchSeqNum, dbi.batch, dbi.readState)
 		}
 

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -134,9 +134,7 @@ func NewExternalIter(
 		}
 
 		dbi.rangeKey = iterRangeKeyStateAllocPool.Get().(*iteratorRangeKeyState)
-		dbi.rangeKey.cmp = o.Comparer.Compare
-		dbi.rangeKey.split = o.Comparer.Split
-		dbi.rangeKey.opts = &dbi.opts
+		dbi.rangeKey.init(o.Comparer.Compare, o.Comparer.Split, &dbi.opts)
 		dbi.rangeKey.rangeKeyIter = dbi.rangeKey.iterConfig.Init(
 			o.Comparer.Compare,
 			base.InternalKeySeqNumMax,

--- a/iterator.go
+++ b/iterator.go
@@ -272,6 +272,13 @@ type iteratorRangeKeyState struct {
 	iterConfig rangekey.UserIteratorConfig
 }
 
+func (i *iteratorRangeKeyState) init(cmp base.Compare, split base.Split, opts *IterOptions) {
+	i.cmp = cmp
+	i.keys.cmp = cmp
+	i.split = split
+	i.opts = opts
+}
+
 var iterRangeKeyStateAllocPool = sync.Pool{
 	New: func() interface{} {
 		return &iteratorRangeKeyState{}

--- a/testdata/external_iterator
+++ b/testdata/external_iterator
@@ -145,3 +145,18 @@ e@5: (v, [a-k) @5=foo)
 k@3: (v, .)
 p@4: (v, .)
 .
+
+# Test that 'stacked' range keys (eg, multiple defined over the same keyspan at
+# varying suffixes) work  as expected.
+
+build stacked
+range-key-set a k @4 bar
+range-key-set a k @1 bax
+----
+
+iter files=(points, ag, ek, stacked)
+first
+next
+----
+a: (., [a-k) @5=foo, @4=bar, @1=bax)
+a@4: (v, [a-k) @5=foo, @4=bar, @1=bax)


### PR DESCRIPTION
Fix a bug where the external iterator initialization failed to initialize the
base.Compare to sort overlapping range keys by suffix.

Fix #1760.