### PR TITLE
crl-release-22.1: db: fix newIters allocation regression

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -93,14 +93,6 @@ type Iterator interface {
 	SetCloseHook(fn func(i Iterator) error)
 }
 
-// FragmentIterator is a version of Iterator that wraps keyspan.FragmentIterator
-// instead of InternalIterator, and adds SetCloseHook.
-type FragmentIterator interface {
-	keyspan.FragmentIterator
-
-	SetCloseHook(fn func(i keyspan.FragmentIterator) error)
-}
-
 // singleLevelIterator iterates over an entire table of data. To seek for a given
 // key, it first looks in the index for the block that contains that key, and then
 // looks inside that block.
@@ -2211,7 +2203,7 @@ func (r *Reader) NewRawRangeDelIter() (keyspan.FragmentIterator, error) {
 // NewRawRangeKeyIter returns an internal iterator for the contents of the
 // range-key block for the table. Returns nil if the table does not contain any
 // range keys.
-func (r *Reader) NewRawRangeKeyIter() (FragmentIterator, error) {
+func (r *Reader) NewRawRangeKeyIter() (keyspan.FragmentIterator, error) {
 	if r.rangeKeyBH.Length == 0 {
 		return nil, nil
 	}

--- a/table_cache.go
+++ b/table_cache.go
@@ -373,9 +373,7 @@ func (c *tableCacheShard) newIters(
 		return nil, nil, err
 	}
 	// NB: v.closeHook takes responsibility for calling unrefValue(v) here.
-	iter.SetCloseHook(func(i sstable.Iterator) error {
-		return v.closeHook(i)
-	})
+	iter.SetCloseHook(v.closeHook)
 
 	atomic.AddInt32(&c.atomic.iterCount, 1)
 	atomic.AddInt32(dbOpts.atomic.iterCount, 1)
@@ -429,20 +427,14 @@ func (c *tableCacheShard) newRangeKeyIter(
 		return emptyIter, err
 	}
 
-	var iter sstable.FragmentIterator
-	// TODO(bilal): We are currently passing through the raw blockIter for range
-	// keys. This iter does not support bounds (eg. SetBounds will panic).
-	// Any future users of the iter returned by this function need to make any
-	// bounds-specific optimizations themselves.
+	var iter keyspan.FragmentIterator
 	iter, err = v.reader.NewRawRangeKeyIter()
+	// iter is a block iter that holds the entire value of the block in memory.
+	// No need to hold onto a ref of the cache value.
+	c.unrefValue(v)
 	if err != nil || iter == nil {
-		c.unrefValue(v)
 		return nil, err
 	}
-	// NB: v.closeHook takes responsibility for calling unrefValue(v) here.
-	iter.SetCloseHook(func(i keyspan.FragmentIterator) error {
-		return v.closeHook(i)
-	})
 
 	atomic.AddInt32(&c.atomic.iterCount, 1)
 	atomic.AddInt32(dbOpts.atomic.iterCount, 1)
@@ -601,7 +593,7 @@ func (c *tableCacheShard) findNode(meta *fileMetadata, dbOpts *tableCacheOpts) *
 	}
 	// Cache the closure invoked when an iterator is closed. This avoids an
 	// allocation on every call to newIters.
-	v.closeHook = func(i base.InternalIterator) error {
+	v.closeHook = func(i sstable.Iterator) error {
 		if invariants.RaceEnabled {
 			c.mu.Lock()
 			delete(c.mu.iters, i)
@@ -831,7 +823,7 @@ func (c *tableCacheShard) Close() error {
 }
 
 type tableCacheValue struct {
-	closeHook func(i base.InternalIterator) error
+	closeHook func(i sstable.Iterator) error
 	reader    *sstable.Reader
 	filename  string
 	err       error


### PR DESCRIPTION
CockroachDB 22.1 backport of #1757 and a tiny bit of #1738 to remove use of
the close hook for rangekey iterators.

----

Avoid an allocation when constructing newIters by using a cached closeHook
closure.