### PR TITLE
docs: use local scale by default on nightly benchmarks page

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -681,6 +681,10 @@ window.onload = function init() {
         d3.selectAll(".updated")
             .text("Last updated: " + d3.timeFormat("%b %e, %Y")(lastUpdate));
     })
+
+    // By default, display each panel with its local max, which makes spotting
+    // regressions simpler.
+    toggleLocalMax();
 };
 
 window.onpopstate = function() {


### PR DESCRIPTION
The Pebble nightly benchmarks page is currently loaded with each panel
using the same range on its y-axis, which is computed from the max
across all panels. This makes spotting regressions difficult, without
toggling "Local scale".

Load the page with "Local scale" by default.