### PR TITLE
db: support configuring iterator during Clone

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -190,10 +190,10 @@ func TestBatchEmpty(t *testing.T) {
 	ib := newIndexedBatch(d, DefaultComparer)
 	iter := ib.NewIter(nil)
 	require.False(t, iter.First())
-	iter2, err := iter.Clone()
+	iter2, err := iter.Clone(CloneOptions{})
 	require.NoError(t, err)
 	require.NoError(t, iter.Close())
-	_, err = iter.Clone()
+	_, err = iter.Clone(CloneOptions{})
 	require.True(t, err != nil)
 	require.False(t, iter2.First())
 	require.NoError(t, iter2.Close())
@@ -294,7 +294,7 @@ func TestIndexedBatchReset(t *testing.T) {
 	count := func(ib *Batch) int {
 		iter := ib.NewIter(nil)
 		defer iter.Close()
-		iter2, err := iter.Clone()
+		iter2, err := iter.Clone(CloneOptions{})
 		require.NoError(t, err)
 		defer iter2.Close()
 		var count [2]int
@@ -309,7 +309,7 @@ func TestIndexedBatchReset(t *testing.T) {
 	contains := func(ib *Batch, key, value string) bool {
 		iter := ib.NewIter(nil)
 		defer iter.Close()
-		iter2, err := iter.Clone()
+		iter2, err := iter.Clone(CloneOptions{})
 		require.NoError(t, err)
 		defer iter2.Close()
 		var found [2]bool
@@ -399,10 +399,12 @@ func TestIndexedBatchMutation(t *testing.T) {
 			return ""
 		case "clone":
 			var from, to string
+			var refreshBatchView bool
 			td.ScanArgs(t, "from", &from)
 			td.ScanArgs(t, "to", &to)
+			td.ScanArgs(t, "refresh-batch", &refreshBatchView)
 			var err error
-			iters[to], err = iters[from].Clone()
+			iters[to], err = iters[from].Clone(CloneOptions{RefreshBatchView: refreshBatchView})
 			if err != nil {
 				return err.Error()
 			}
@@ -1265,7 +1267,7 @@ func TestBatchSpanCaching(t *testing.T) {
 			if len(itersForReadKey) == 0 {
 				continue
 			}
-			iter, err := itersForReadKey[rng.Intn(len(itersForReadKey))].Clone()
+			iter, err := itersForReadKey[rng.Intn(len(itersForReadKey))].Clone(CloneOptions{})
 			require.NoError(t, err)
 			checkIter(iter, readKey)
 			iters[readKey] = append(iters[readKey], iter)

--- a/internal/metamorphic/generator.go
+++ b/internal/metamorphic/generator.go
@@ -542,9 +542,12 @@ func (g *generator) newIterUsingClone() {
 		// closes.
 	}
 
+	// TODO(jackson): Exercise changing iterator options as a part of Clone.
+
 	g.add(&newIterUsingCloneOp{
 		existingIterID: existingIterID,
 		iterID:         iterID,
+		refreshBatch:   g.rng.Intn(2) == 1,
 	})
 }
 

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -609,11 +609,12 @@ func (o *newIterOp) String() string {
 type newIterUsingCloneOp struct {
 	existingIterID objID
 	iterID         objID
+	refreshBatch   bool
 }
 
 func (o *newIterUsingCloneOp) run(t *test, h *history) {
 	iter := t.getIter(o.existingIterID)
-	i, err := iter.iter.Clone()
+	i, err := iter.iter.Clone(pebble.CloneOptions{})
 	if err != nil {
 		panic(err)
 	}
@@ -622,7 +623,7 @@ func (o *newIterUsingCloneOp) run(t *test, h *history) {
 }
 
 func (o *newIterUsingCloneOp) String() string {
-	return fmt.Sprintf("%s = %s.Clone()", o.iterID, o.existingIterID)
+	return fmt.Sprintf("%s = %s.Clone(%t)", o.iterID, o.existingIterID, o.refreshBatch)
 }
 
 // iterSetBoundsOp models an Iterator.SetBounds operation.

--- a/internal/metamorphic/parser.go
+++ b/internal/metamorphic/parser.go
@@ -79,7 +79,7 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	case *newIterOp:
 		return &t.readerID, &t.iterID, []interface{}{&t.lower, &t.upper, &t.keyTypes, &t.rangeKeyMaskSuffix}
 	case *newIterUsingCloneOp:
-		return &t.existingIterID, &t.iterID, nil
+		return &t.existingIterID, &t.iterID, []interface{}{&t.refreshBatch}
 	case *newSnapshotOp:
 		return nil, &t.snapID, nil
 	case *iterNextOp:

--- a/iterator.go
+++ b/iterator.go
@@ -2083,20 +2083,43 @@ func (i *Iterator) Stats() IteratorStats {
 	return stats
 }
 
+// CloneOptions configures an iterator constructed through Iterator.Clone.
+type CloneOptions struct {
+	// IterOptions, if non-nil, define the iterator options to configure a
+	// cloned iterator. If nil, the clone adopts the same IterOptions as the
+	// iterator being cloned.
+	IterOptions *IterOptions
+	// RefreshBatchView may be set to true when cloning an Iterator over an
+	// indexed batch. When false, the clone adopts the same (possibly stale)
+	// view of the indexed batch as the cloned Iterator. When true, the clone is
+	// constructed with a refreshed view of the batch, observing all of the
+	// batch's mutations at the time of the Clone. If the cloned iterator was
+	// not constructed to read over an indexed batch, RefreshVatchView has no
+	// effect.
+	RefreshBatchView bool
+}
+
 // Clone creates a new Iterator over the same underlying data, i.e., over the
-// same {batch, memtables, sstables}). It starts with the same IterOptions but
-// is not positioned.
+// same {batch, memtables, sstables}). The resulting iterator is not positioned.
+// It starts with the same IterOptions, unless opts.IterOptions is set.
 //
-// When called on an Iterator over an indexed batch, the clone inherits the
-// iterator's current (possibly stale) view of the batch. Callers may call
-// SetOptions to refresh the clone's view to include all batch mutations.
+// When called on an Iterator over an indexed batch, the clone's visibility of
+// the indexed batch is determined by CloneOptions.RefreshBatchView. If false,
+// the clone inherits the iterator's current (possibly stale) view of the batch,
+// and callers may call SetOptions to subsequently refresh the clone's view to
+// include all batch mutations. If true, the clone is constructed with a
+// complete view of the indexed batch's mutations at the time of the Clone.
 //
 // Callers can use Clone if they need multiple iterators that need to see
 // exactly the same underlying state of the DB. This should not be used to
 // extend the lifetime of the data backing the original Iterator since that
 // will cause an increase in memory and disk usage (use NewSnapshot for that
 // purpose).
-func (i *Iterator) Clone() (*Iterator, error) {
+func (i *Iterator) Clone(opts CloneOptions) (*Iterator, error) {
+	if opts.IterOptions == nil {
+		opts.IterOptions = &i.opts
+	}
+
 	readState := i.readState
 	if readState == nil {
 		return nil, errors.Errorf("cannot Clone a closed Iterator")
@@ -2108,7 +2131,7 @@ func (i *Iterator) Clone() (*Iterator, error) {
 	buf := iterAllocPool.Get().(*iterAlloc)
 	dbi := &buf.dbi
 	*dbi = Iterator{
-		opts:                i.opts,
+		opts:                *opts.IterOptions,
 		alloc:               buf,
 		cmp:                 i.cmp,
 		equal:               i.equal,
@@ -2124,7 +2147,14 @@ func (i *Iterator) Clone() (*Iterator, error) {
 		seqNum:              i.seqNum,
 		db:                  i.db,
 	}
-	dbi.saveBounds(i.opts.LowerBound, i.opts.UpperBound)
+	dbi.saveBounds(dbi.opts.LowerBound, dbi.opts.UpperBound)
+
+	// If the caller requested the clone have a current view of the indexed
+	// batch, set the clone's batch sequence number appropriately.
+	if i.batch != nil && opts.RefreshBatchView {
+		dbi.batchSeqNum = (uint64(len(i.batch.data)) | base.InternalKeySeqNumBatch)
+	}
+
 	return finishInitializingIter(buf), nil
 }
 

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1545,7 +1545,7 @@ func TestIteratorBoundsLifetimes(t *testing.T) {
 			td.ScanArgs(t, "from", &from)
 			td.ScanArgs(t, "to", &to)
 			var err error
-			iterators[to], err = iterators[from].Clone()
+			iterators[to], err = iterators[from].Clone(CloneOptions{})
 			if err != nil {
 				return err.Error()
 			}

--- a/testdata/indexed_batch_mutation
+++ b/testdata/indexed_batch_mutation
@@ -167,7 +167,7 @@ foo: (foo, .)
 
 # Clone i1 to create i2.
 
-clone from=i1 to=i2
+clone from=i1 to=i2 refresh-batch=false
 ----
 
 # i1 unchanged.
@@ -196,6 +196,18 @@ foo: (foo, .)
 a: (., [a-z) @1=boop)
 bar: (bar, [a-z) @1=boop)
 .
+
+# Clone i1 to create i3, this time passing RefreshBatchView: true. This clone
+# should view the updated view of the underlying batch.
+clone from=i1 to=i3 refresh-batch=true
+----
+
+iter iter=i3
+first
+next
+----
+a: (., [a-z) @1=boop)
+bar: (bar, [a-z) @1=boop)
 
 # i1 should still have the old, stale view of the batch.
 
@@ -265,12 +277,12 @@ a: (., [a-z) @2=bax, @1=boop)
 foo: (foo, [a-z) @2=bax, @1=boop)
 .
 
-# Clone i1 to create i3.
+# Clone i1 to create i4.
 
-clone from=i1 to=i3
+clone from=i1 to=i4 refresh-batch=false
 ----
 
-iter iter=i3
+iter iter=i4
 first
 next
 next
@@ -279,10 +291,10 @@ a: (., [a-z) @2=bax, @1=boop)
 foo: (foo, [a-z) @2=bax, @1=boop)
 .
 
-# Refresh i3's view of its batch. It should still not see the newly committed
+# Refresh i4's view of its batch. It should still not see the newly committed
 # writes.
 
-iter iter=i3
+iter iter=i4
 set-options
 first
 next
@@ -293,13 +305,13 @@ a: (., [a-z) @2=bax, @1=boop)
 foo: (foo, [a-z) @2=bax, @1=boop)
 .
 
-# Create a new iterator i4 over the indexed batch [not a Clone]. It should see
+# Create a new iterator i5 over the indexed batch [not a Clone]. It should see
 # all committed writes and uncommitted writes.
 
-new-iter i4
+new-iter i5
 ----
 
-iter iter=i4
+iter iter=i5
 first
 next
 next
@@ -329,7 +341,7 @@ a: (., [a-z) @2=bax, @1=boop)
 foo: (foo, [a-z) @2=bax, @1=boop)
 .
 
-iter iter=i3
+iter iter=i4
 first
 next
 next
@@ -394,7 +406,7 @@ a: (., [a-z) @1=foo)
 # were created. It should not use the cached fragments of range deletions or
 # range keys, and should not see the effects of either.
 
-clone from=i1 to=i3
+clone from=i1 to=i3 refresh-batch=false
 ----
 
 iter iter=i3

--- a/testdata/iterator_next_prev
+++ b/testdata/iterator_next_prev
@@ -175,6 +175,23 @@ b:b
 b:b
 .
 
+# Test that a cloned iterator set with new bounds, respects the new bounds and
+# options.
+iter
+set-bounds lower=a upper=d
+first
+next
+clone lower=a upper=z key-types=both
+seek-ge a
+next
+----
+.
+b:b
+.
+.
+b: (b, .)
+e: (e, .)
+
 # Test that the cloned iterator respects the seq num.
 iter seq=2
 set-bounds lower=a upper=f

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -584,6 +584,41 @@ cat: (., [cat-e) @3=bax)
 d: (d, [cat-e) @3=bax)
 .
 
+# Ensure bounds provided during clone are propagated to cloned iterators.
+
+combined-iter lower=b upper=e
+first
+next
+next
+next
+next
+clone lower=a upper=cat key-types=both
+first
+next
+next
+next
+clone lower=a upper=cat key-types=point
+first
+next
+next
+next
+----
+b: (b, [b-c) @5=bar)
+c: (c, .)
+cat: (., [cat-e) @3=bax)
+d: (d, [cat-e) @3=bax)
+.
+.
+a: (a, [a-ap) @6=foo)
+ap: (., [ap-c) @5=bar)
+b: (b, [ap-c) @5=bar)
+c: (c, .)
+.
+a:a
+b:b
+c:c
+.
+
 # Ensure bounds and key-types provided through SetOptions are respected.
 
 combined-iter lower=b upper=e


### PR DESCRIPTION
When creating an iterator through Clone, CockroachDB clones and then
immediately calls SetOptions. This adds unnecessary key comparisons to compute
the delta in the options, and if the options changed significantly, adds
unnecessary iterator stack construction.

Add a CloneOptions parameter to Clone that allows the user to optionally
specify IterOptions to construct the iterator with. Additionally, add a field
to support constructing the clone with a refreshed view of the indexed batch,
when cloning an iterator over an indexed batch.

Close #1712.