### PR TITLE
sstable: remove obsolete linter ignore directive

### DIFF
--- a/sstable/write_queue.go
+++ b/sstable/write_queue.go
@@ -114,7 +114,6 @@ func (w *writeQueue) runWorker() {
 	w.wg.Done()
 }
 
-//lint:ignore U1000 - Will be used in a future pr.
 func (w *writeQueue) add(task *writeTask) {
 	w.tasks <- task
 }


### PR DESCRIPTION
This method is now used. Addresses the following warning:

```
--- FAIL: TestLint (0.71s)
    --- FAIL: TestLint/TestStaticcheck (42.53s)
        lint_test.go:86:
            sstable/write_queue.go:117:1: this linter directive didn't match anything; should it be removed? ()
```