### PR TITLE
internal/manifest: Create new LevelMetadata for range keys

### DIFF
--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -654,6 +654,11 @@ type Version struct {
 
 	Levels [NumLevels]LevelMetadata
 
+	// RangeKeyLevels holds a subset of the same files as Levels that contain range
+	// keys (i.e. fileMeta.HasRangeKeys == true). The memory amplification of this
+	// duplication should be minimal, as range keys are expected to be rare.
+	RangeKeyLevels [NumLevels]LevelMetadata
+
 	// The callback to invoke when the last reference to a version is
 	// removed. Will be called with list.mu held.
 	Deleted func(obsolete []*FileMetadata)


### PR DESCRIPTION
This change creates a new LevelMetadata btree just for
sstables containing range keys. This btree is incrementally
updated with sstable additions/deletions that contain range
keys. This should have a relatively light overhead, as
range keys and files containing range keys are expected to be
rare. This also has the benefit of reducing the time it takes
to determine whether files contain range keys.

Fixes #1742.