### PR TITLE
*: Allocate keyspan.LevelIters inside UserIteratorConfig

### DIFF
--- a/internal/rangekey/coalesce.go
+++ b/internal/rangekey/coalesce.go
@@ -19,6 +19,7 @@ type UserIteratorConfig struct {
 	snapshot   uint64
 	miter      keyspan.MergingIter
 	diter      keyspan.DefragmentingIter
+	liters     []keyspan.LevelIter
 	defragBufA keysBySuffix
 	defragBufB keysBySuffix
 	// defragBufAlloc defines two arrays used to preallocate defragBuf{A,B} keys
@@ -35,13 +36,14 @@ type UserIteratorConfig struct {
 // The snapshot sequence number parameter determines which keys are visible. Any
 // keys not visible at the provided snapshot are ignored.
 func (ui *UserIteratorConfig) Init(
-	cmp base.Compare, snapshot uint64, levelIters ...keyspan.FragmentIterator,
+	cmp base.Compare, snapshot uint64, iters ...keyspan.FragmentIterator,
 ) keyspan.FragmentIterator {
 	ui.snapshot = snapshot
 	ui.defragBufA.keys = ui.defragBufAlloc[0][:0]
 	ui.defragBufB.keys = ui.defragBufAlloc[1][:0]
-	ui.miter.Init(cmp, ui, levelIters...)
+	ui.miter.Init(cmp, ui, iters...)
 	ui.diter.Init(cmp, &ui.miter, ui, keyspan.StaticDefragmentReducer)
+	ui.liters = ui.liters[:0]
 	return &ui.diter
 }
 
@@ -49,6 +51,18 @@ func (ui *UserIteratorConfig) Init(
 // must be called after Init and before any other method on the iterator.
 func (ui *UserIteratorConfig) AddLevel(iter keyspan.FragmentIterator) {
 	ui.miter.AddLevel(iter)
+}
+
+// NewLevelIter returns a pointer to a newly allocated or reused
+// keyspan.LevelIter. The caller is responsible for calling Init() on this
+// instance.
+func (ui *UserIteratorConfig) NewLevelIter() *keyspan.LevelIter {
+	if len(ui.liters)+1 > cap(ui.liters) {
+		ui.liters = append(ui.liters, keyspan.LevelIter{})
+	} else {
+		ui.liters = ui.liters[:len(ui.liters)+1]
+	}
+	return &ui.liters[len(ui.liters)-1]
 }
 
 // Transform implements the keyspan.Transformer interface for use with a

--- a/range_keys.go
+++ b/range_keys.go
@@ -44,8 +44,6 @@ func (d *DB) newRangeKeyIter(
 	}
 
 	current := readState.current
-	// TODO(bilal): Roll the LevelIter allocation into it.rangeKey.iterConfig.
-	levelIters := make([]keyspan.LevelIter, 0)
 	// Next are the file levels: L0 sub-levels followed by lower levels.
 	//
 	// Add file-specific iterators for L0 files containing range keys. This is less
@@ -69,8 +67,7 @@ func (d *DB) newRangeKeyIter(
 		if current.RangeKeyLevels[level].Empty() {
 			continue
 		}
-		levelIters = append(levelIters, keyspan.LevelIter{})
-		li := &levelIters[len(levelIters)-1]
+		li := it.rangeKey.iterConfig.NewLevelIter()
 		spanIterOpts := keyspan.SpanIterOptions{RangeKeyFilters: it.opts.RangeKeyFilters}
 
 		li.Init(spanIterOpts, it.cmp, d.tableNewRangeKeyIter, current.RangeKeyLevels[level].Iter(),


### PR DESCRIPTION
Currently, we allocate a new slice of LevelIters every time
we create a new range key iterator stack. Address a TODO
in the code and pool these allocations inside a buffer
in UserIteratorConfig to allow for better memory reuse
and fewer allocations.