### PR TITLE
sstable: Export internal/rangekey decoding functions

### DIFF
--- a/sstable/internal.go
+++ b/sstable/internal.go
@@ -4,7 +4,11 @@
 
 package sstable
 
-import "github.com/cockroachdb/pebble/internal/base"
+import (
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/keyspan"
+	"github.com/cockroachdb/pebble/internal/rangekey"
+)
 
 // InternalKeyKind exports the base.InternalKeyKind type.
 type InternalKeyKind = base.InternalKeyKind
@@ -25,3 +29,16 @@ const (
 
 // InternalKey exports the base.InternalKey type.
 type InternalKey = base.InternalKey
+
+// IsRangeKey returns if this InternalKey is a range key. Alias for
+// rangekey.IsRangeKey.
+func IsRangeKey(ik InternalKey) bool {
+	return rangekey.IsRangeKey(ik.Kind())
+}
+
+// DecodeRangeKey decodes an InternalKey into a keyspan.Span, if it is a range
+// key. If keysDst is provided, keys will be appended to keysDst to reduce
+// allocations.
+func DecodeRangeKey(ik InternalKey, val []byte, keysDst []keyspan.Key) (keyspan.Span, error) {
+	return rangekey.Decode(ik, val, keysDst)
+}


### PR DESCRIPTION
This change exports the IsRangeKey() and rangekey.Decode()
methods in the internal/rangekey package to the outside world.
Exporting these in the sstable package makes sense as they're
likely going to be used with BlockIntervalCollector, which exposes
internal keys.

Fixes #1774.