### PR TITLE
sstable: Rewrite suffixes of range keys in RewriteKeySuffixes

### DIFF
--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -1193,8 +1193,12 @@ func keyCountCollectorFn(name string) func() BlockPropertyCollector {
 
 func (p *keyCountCollector) Name() string { return p.name }
 
-func (p *keyCountCollector) Add(_ InternalKey, _ []byte) error {
-	p.block++
+func (p *keyCountCollector) Add(k InternalKey, _ []byte) error {
+	if rangekey.IsRangeKey(k.Kind()) {
+		p.table++
+	} else {
+		p.block++
+	}
 	return nil
 }
 


### PR DESCRIPTION
Currently, sstable.RewriteKeySuffixes only rewrites suffixes
of point keys. This method is used to set MVCC timestamps
in ingested SSTs, so it must also be able to support range keys
containing non-overlapping range keys. This change adds a simple,
non-concurrent code path to rewriting the range key block with
updated suffixes.

Fixes #1765.