### PR TITLE
*: Rebuild L0Sublevels if version application fails

### DIFF
--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -714,6 +714,16 @@ func (s *L0Sublevels) InitCompactingFileInfo(inProgress []L0Compaction) {
 
 	iter := s.levelMetadata.Iter()
 	for f := iter.First(); f != nil; f = iter.Next() {
+		if invariants.Enabled {
+			if !bytes.Equal(s.orderedIntervals[f.minIntervalIndex].startKey.key, f.Smallest.UserKey) {
+				panic(fmt.Sprintf("f.minIntervalIndex in FileMetadata out of sync with intervals in L0Sublevels: %s != %s",
+					s.formatKey(s.orderedIntervals[f.minIntervalIndex].startKey.key), s.formatKey(f.Smallest.UserKey)))
+			}
+			if !bytes.Equal(s.orderedIntervals[f.maxIntervalIndex+1].startKey.key, f.Largest.UserKey) {
+				panic(fmt.Sprintf("f.maxIntervalIndex in FileMetadata out of sync with intervals in L0Sublevels: %s != %s",
+					s.formatKey(s.orderedIntervals[f.maxIntervalIndex+1].startKey.key), s.formatKey(f.Smallest.UserKey)))
+			}
+		}
 		if !f.Compacting {
 			continue
 		}


### PR DESCRIPTION
If the compaction succeeds but version application fails
(eg. due to a manifest write/rotate error or so), we could
have a discrepancy where the last generated L0Sublevels was
belonging to a Version that never got added to versionSet.
This could mean that the interval indices in FileMetadata
are out of sync with the (now slightly older) L0Sublevels
that is in the actual currentVersion. This can cause panics
in future calls to InitCompactingFileInfo, and/or throw off
compaction picking functions. Fix this by regenerating
L0Sublevels in the currentVersion in case of an error.

Fixes #1781, #1669. Speculatively, that is.