### PR TITLE
compaction: test rebuilding L0Sublevels on logAndApply failure

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1647,6 +1647,7 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 		err = d.mu.versions.logAndApply(jobID, ve, c.metrics, false, /* forceRotation */
 			func() []compactionInfo { return d.getInProgressCompactionInfoLocked(c) })
 		if err != nil {
+			info.Err = err
 			// TODO(peter): untested.
 			d.mu.versions.obsoleteTables = append(d.mu.versions.obsoleteTables, pendingOutputs...)
 			d.mu.versions.incrementObsoleteTablesLocked(pendingOutputs)
@@ -2151,6 +2152,7 @@ func (d *DB) compact1(c *compaction, errChannel chan error) (err error) {
 			return d.getInProgressCompactionInfoLocked(c)
 		})
 		if err != nil {
+			info.Err = err
 			// TODO(peter): untested.
 			d.mu.versions.obsoleteTables = append(d.mu.versions.obsoleteTables, pendingOutputs...)
 			d.mu.versions.incrementObsoleteTablesLocked(pendingOutputs)


### PR DESCRIPTION
Add a test covering for the fix in #1784.

The test attempts to flush a table into an L0 that contains a single
interval. If the flush fails, the call to `logAndApply` fails, causing
the L0 sublevels to be rebuilt. Prior to #1784, the sublevels were not
rebuilt, which could result in inconsistent file metadata if the L0
intervals changed. In some cases could result in a panic (see #1669 and
#1781).

Sets any error present on the FlushInfo and CompactionInfo structs, if
`logAndApply` fails during the flush or compaction, respectively.