### PR TITLE
db: export keyspan.Span and keyspan.Key

### DIFF
--- a/rangekey/rangekey.go
+++ b/rangekey/rangekey.go
@@ -1,0 +1,30 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// Package rangekey provides functionality for working with range keys.
+package rangekey
+
+import (
+	"github.com/cockroachdb/pebble/internal/keyspan"
+	"github.com/cockroachdb/pebble/internal/rangekey"
+	"github.com/cockroachdb/pebble/sstable"
+)
+
+// Key exports the keyspan.Key type.
+type Key = keyspan.Key
+
+// Span exports the keyspan.Span type.
+type Span = keyspan.Span
+
+// IsRangeKey returns if this InternalKey is a range key. Alias for
+// rangekey.IsRangeKey.
+func IsRangeKey(ik sstable.InternalKey) bool {
+	return rangekey.IsRangeKey(ik.Kind())
+}
+
+// Decode decodes an InternalKey into a keyspan.Span, if it is a range key. If
+// keysDst is provided, keys will be appended to keysDst to reduce allocations.
+func Decode(ik sstable.InternalKey, val []byte, keysDst []keyspan.Key) (keyspan.Span, error) {
+	return rangekey.Decode(ik, val, keysDst)
+}

--- a/sstable/internal.go
+++ b/sstable/internal.go
@@ -4,11 +4,7 @@
 
 package sstable
 
-import (
-	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/internal/keyspan"
-	"github.com/cockroachdb/pebble/internal/rangekey"
-)
+import "github.com/cockroachdb/pebble/internal/base"
 
 // InternalKeyKind exports the base.InternalKeyKind type.
 type InternalKeyKind = base.InternalKeyKind
@@ -29,16 +25,3 @@ const (
 
 // InternalKey exports the base.InternalKey type.
 type InternalKey = base.InternalKey
-
-// IsRangeKey returns if this InternalKey is a range key. Alias for
-// rangekey.IsRangeKey.
-func IsRangeKey(ik InternalKey) bool {
-	return rangekey.IsRangeKey(ik.Kind())
-}
-
-// DecodeRangeKey decodes an InternalKey into a keyspan.Span, if it is a range
-// key. If keysDst is provided, keys will be appended to keysDst to reduce
-// allocations.
-func DecodeRangeKey(ik InternalKey, val []byte, keysDst []keyspan.Key) (keyspan.Span, error) {
-	return rangekey.Decode(ik, val, keysDst)
-}


### PR DESCRIPTION
Export two additional types for use in Cockroach.

See #1774.