### PR TITLE
*: clean up range key test cases

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1873,12 +1873,6 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 		// control over when compactions are run, disable stats by default.
 		opts.private.disableTableStats = true
 
-		// Disable automatic compactions to prevent the range key-only tables from
-		// being compacted away after they are created. Compactions do not yet
-		// understand that these tables need to remain in the LSM.
-		// TODO(travers): Revisit this once compactions support range keys.
-		opts.DisableAutomaticCompactions = true
-
 		return opts, nil
 	}
 
@@ -2072,10 +2066,6 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 				return ""
 
 			case "ingest":
-				// Compactions / flushes do not yet fully support range keys. The
-				// "ingest" operation exists to allow tables containing range keys to be
-				// added to the LSM via ingest, rather than a flush.
-				// TODO(travers): Revisit this once compactions support range keys.
 				if err = runBuildCmd(td, d, d.opts.FS); err != nil {
 					return err.Error()
 				}

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -321,8 +321,7 @@ a:b
 # - 000011: covered by range key hint [r, z), table contains only range keys.
 #
 
-# NOTE: as compactions do not yet fully support range keys, the LSM shown in the
-# example above is created bottom-up via ingestions.
+# NOTE: the LSM shown in the example above is created bottom-up via ingestions.
 
 reset
 ----

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -267,34 +267,46 @@ define
 
 # Start with a table that contains point and range keys, but no range dels or
 # range key dels.
-# TODO(travers): Once range keys in batches are flushed to tables, this testcase
-# can be updated to use the batch / flush combination.
-ingest ext0
+batch
 set a a
 range-key-set a b @1 foo
 range-key-unset a b @2
 ----
-6:
-  000004:[a#1,RANGEKEYSET-b#72057594037927935,RANGEKEYUNSET]
 
-# Add a table that contains only point keys, to the right of the existing table
-# in L6.
-ingest ext0
-set c c
-----
-6:
-  000004:[a#1,RANGEKEYSET-b#72057594037927935,RANGEKEYUNSET]
-  000005:[c#2,SET-c#2,SET]
-
-# Add a table that contains a RANGEKEYDEL covering the first table in L6.
-ingest ext1
-range-key-del a b
+flush
 ----
 0.0:
-  000006:[a#3,RANGEKEYDEL-b#72057594037927935,RANGEKEYDEL]
+  000005:[a#3,RANGEKEYUNSET-b#72057594037927935,RANGEKEYSET]
+
+# Add a table that contains only point keys, to the right of the existing table.
+batch
+set c c
+----
+
+flush
+----
+0.0:
+  000005:[a#3,RANGEKEYUNSET-b#72057594037927935,RANGEKEYSET]
+  000007:[c#4,SET-c#4,SET]
+
+compact a-c
+----
 6:
-  000004:[a#1,RANGEKEYSET-b#72057594037927935,RANGEKEYUNSET]
-  000005:[c#2,SET-c#2,SET]
+  000008:[a#2,RANGEKEYSET-b#72057594037927935,RANGEKEYSET]
+  000009:[c#0,SET-c#0,SET]
+
+# Add a table that contains a RANGEKEYDEL covering the first table in L6.
+batch
+range-key-del a b
+----
+
+flush
+----
+0.0:
+  000011:[a#5,RANGEKEYDEL-b#72057594037927935,RANGEKEYDEL]
+6:
+  000008:[a#2,RANGEKEYSET-b#72057594037927935,RANGEKEYSET]
+  000009:[c#0,SET-c#0,SET]
 
 # Add one more table containing a RANGEDEL.
 batch
@@ -304,18 +316,18 @@ del-range a c
 flush
 ----
 0.1:
-  000008:[a#4,RANGEDEL-c#72057594037927935,RANGEDEL]
+  000013:[a#6,RANGEDEL-c#72057594037927935,RANGEDEL]
 0.0:
-  000006:[a#3,RANGEKEYDEL-b#72057594037927935,RANGEKEYDEL]
+  000011:[a#5,RANGEKEYDEL-b#72057594037927935,RANGEKEYDEL]
 6:
-  000004:[a#1,RANGEKEYSET-b#72057594037927935,RANGEKEYUNSET]
-  000005:[c#2,SET-c#2,SET]
+  000008:[a#2,RANGEKEYSET-b#72057594037927935,RANGEKEYSET]
+  000009:[c#0,SET-c#0,SET]
 
 # Compute stats on the table containing range key del. It should not show an
 # estimate for deleted point keys as there are no tables below it that contain
 # only range keys.
 wait-pending-table-stats
-000006
+000011
 ----
 num-entries: 0
 num-deletions: 0
@@ -324,17 +336,17 @@ point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
 # Compute stats on the table containing the range del. It should show an
-# estimate for deleted point keys, as a table below it (000004) contains point
-# keys. Note that even though table 000004 contains range keys, the range del
+# estimate for deleted point keys, as a table below it (000008) contains point
+# keys. Note that even though table 000008 contains range keys, the range del
 # estimates are non-zero, as this number is agnostic of range keys.
 wait-pending-table-stats
-000008
+000013
 ----
 num-entries: 1
 num-deletions: 1
 num-range-keys: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 991
+range-deletions-bytes-estimate: 915
 
 # Drop a range del and a range key del over the entire keyspace. This table can
 # delete everything underneath it.
@@ -343,28 +355,20 @@ del-range a z
 range-key-del a z
 ----
 0.2:
-  000009:[a#5,RANGEKEYDEL-z#72057594037927935,RANGEDEL]
+  000014:[a#7,RANGEKEYDEL-z#72057594037927935,RANGEDEL]
 0.1:
-  000008:[a#4,RANGEDEL-c#72057594037927935,RANGEDEL]
+  000013:[a#6,RANGEDEL-c#72057594037927935,RANGEDEL]
 0.0:
-  000006:[a#3,RANGEKEYDEL-b#72057594037927935,RANGEKEYDEL]
+  000011:[a#5,RANGEKEYDEL-b#72057594037927935,RANGEKEYDEL]
 6:
-  000004:[a#1,RANGEKEYSET-b#72057594037927935,RANGEKEYUNSET]
-  000005:[c#2,SET-c#2,SET]
+  000008:[a#2,RANGEKEYSET-b#72057594037927935,RANGEKEYSET]
+  000009:[c#0,SET-c#0,SET]
 
-wait-pending-table-stats
-000009
+compact a-z
 ----
-num-entries: 1
-num-deletions: 1
-num-range-keys: 1
-point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 1815
 
 # A hint for exclusively range key deletions that covers a table with point keys
 # should not contain an estimate for point keys.
-# TODO(travers): Once range keys in batches are flushed to tables, this testcase
-# can be updated to use the batch / flush combination.
 
 define
 ----
@@ -380,30 +384,40 @@ flush
   000005:[b#1,SET-b#1,SET]
 
 # A table with a mixture of point and range keys.
-ingest ext0
+batch
 set c c
 range-key-set d d @1 foo
 ----
+
+flush
+----
 0.0:
   000005:[b#1,SET-b#1,SET]
+  000007:[c#2,SET-c#2,SET]
+
+compact a-z
+----
 6:
-  000006:[c#2,SET-c#2,SET]
+  000008:[b#0,SET-b#0,SET]
+  000009:[c#0,SET-c#0,SET]
 
 # The table with the range key del, that spans the previous two tables.
-ingest ext0
+batch
 range-key-del a z
 ----
-0.1:
-  000007:[a#3,RANGEKEYDEL-z#72057594037927935,RANGEKEYDEL]
-0.0:
-  000005:[b#1,SET-b#1,SET]
-6:
-  000006:[c#2,SET-c#2,SET]
 
-# The hint on table 000007 does estimates zero size for range deleted point
+flush
+----
+0.0:
+  000011:[a#4,RANGEKEYDEL-z#72057594037927935,RANGEKEYDEL]
+6:
+  000008:[b#0,SET-b#0,SET]
+  000009:[c#0,SET-c#0,SET]
+
+# The hint on table 000011 does estimates zero size for range deleted point
 # keys.
 wait-pending-table-stats
-000007
+000011
 ----
 num-entries: 0
 num-deletions: 0


### PR DESCRIPTION
Now that range keys are handled in compactions, update some existing
data-driven test cases to make use of the batch/flush combination,
rather than using ingests (which was a hack around the fact that range
keys were not persisted).