### PR TITLE
db: lazily construct combined iterator 

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1265,7 +1265,7 @@ func (i *batchIter) SeekPrefixGE(
 	return i.SeekGE(key, flags)
 }
 
-func (i *batchIter) SeekLT(key []byte) (*InternalKey, []byte) {
+func (i *batchIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, []byte) {
 	i.err = nil // clear cached iteration error
 	ikey := i.iter.SeekLT(key)
 	for ikey != nil && ikey.SeqNum() >= i.snapshot {
@@ -1667,7 +1667,7 @@ func (i *flushableBatchIter) SeekPrefixGE(
 
 // SeekLT implements internalIterator.SeekLT, as documented in the pebble
 // package.
-func (i *flushableBatchIter) SeekLT(key []byte) (*InternalKey, []byte) {
+func (i *flushableBatchIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, []byte) {
 	i.err = nil // clear cached iteration error
 	ikey := base.MakeSearchKey(key)
 	i.index = sort.Search(len(i.offsets), func(j int) bool {
@@ -1831,7 +1831,9 @@ func (i *flushFlushableBatchIter) SeekPrefixGE(
 	panic("pebble: SeekPrefixGE unimplemented")
 }
 
-func (i *flushFlushableBatchIter) SeekLT(key []byte) (*InternalKey, []byte) {
+func (i *flushFlushableBatchIter) SeekLT(
+	key []byte, flags base.SeekLTFlags,
+) (*InternalKey, []byte) {
 	panic("pebble: SeekLT unimplemented")
 }
 

--- a/batch.go
+++ b/batch.go
@@ -1244,7 +1244,7 @@ func (i *batchIter) String() string {
 	return "batch"
 }
 
-func (i *batchIter) SeekGE(key []byte, trySeekUsingNext bool) (*InternalKey, []byte) {
+func (i *batchIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, []byte) {
 	// Ignore trySeekUsingNext since the batch may have changed, so using Next
 	// would be incorrect.
 	i.err = nil // clear cached iteration error
@@ -1259,10 +1259,10 @@ func (i *batchIter) SeekGE(key []byte, trySeekUsingNext bool) (*InternalKey, []b
 }
 
 func (i *batchIter) SeekPrefixGE(
-	prefix, key []byte, trySeekUsingNext bool,
+	prefix, key []byte, flags base.SeekGEFlags,
 ) (*base.InternalKey, []byte) {
 	i.err = nil // clear cached iteration error
-	return i.SeekGE(key, trySeekUsingNext)
+	return i.SeekGE(key, flags)
 }
 
 func (i *batchIter) SeekLT(key []byte) (*InternalKey, []byte) {
@@ -1638,9 +1638,9 @@ func (i *flushableBatchIter) String() string {
 }
 
 // SeekGE implements internalIterator.SeekGE, as documented in the pebble
-// package. Ignore trySeekUsingNext since we don't expect this optimization
-// to provide much benefit here at the moment.
-func (i *flushableBatchIter) SeekGE(key []byte, trySeekUsingNext bool) (*InternalKey, []byte) {
+// package. Ignore flags.TrySeekUsingNext() since we don't expect this
+// optimization to provide much benefit here at the moment.
+func (i *flushableBatchIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, []byte) {
 	i.err = nil // clear cached iteration error
 	ikey := base.MakeSearchKey(key)
 	i.index = sort.Search(len(i.offsets), func(j int) bool {
@@ -1660,9 +1660,9 @@ func (i *flushableBatchIter) SeekGE(key []byte, trySeekUsingNext bool) (*Interna
 // SeekPrefixGE implements internalIterator.SeekPrefixGE, as documented in the
 // pebble package.
 func (i *flushableBatchIter) SeekPrefixGE(
-	prefix, key []byte, trySeekUsingNext bool,
+	prefix, key []byte, flags base.SeekGEFlags,
 ) (*base.InternalKey, []byte) {
-	return i.SeekGE(key, trySeekUsingNext)
+	return i.SeekGE(key, flags)
 }
 
 // SeekLT implements internalIterator.SeekLT, as documented in the pebble
@@ -1819,12 +1819,14 @@ func (i *flushFlushableBatchIter) String() string {
 	return "flushable-batch"
 }
 
-func (i *flushFlushableBatchIter) SeekGE(key []byte, trySeekUsingNext bool) (*InternalKey, []byte) {
+func (i *flushFlushableBatchIter) SeekGE(
+	key []byte, flags base.SeekGEFlags,
+) (*InternalKey, []byte) {
 	panic("pebble: SeekGE unimplemented")
 }
 
 func (i *flushFlushableBatchIter) SeekPrefixGE(
-	prefix, key []byte, trySeekUsingNext bool,
+	prefix, key []byte, flags base.SeekGEFlags,
 ) (*base.InternalKey, []byte) {
 	panic("pebble: SeekPrefixGE unimplemented")
 }

--- a/batch.go
+++ b/batch.go
@@ -1595,6 +1595,8 @@ func (b *flushableBatch) newRangeKeyIter(o *IterOptions) keyspan.FragmentIterato
 	return keyspan.NewIter(b.cmp, b.rangeKeys)
 }
 
+func (b *flushableBatch) containsRangeKeys() bool { return len(b.rangeKeys) > 0 }
+
 func (b *flushableBatch) inuseBytes() uint64 {
 	return uint64(len(b.data) - batchHeaderLen)
 }

--- a/data_test.go
+++ b/data_test.go
@@ -357,29 +357,29 @@ func runInternalIterCmd(d *datadriven.TestData, iter internalIterator, opts ...i
 				return "seek-ge <key> [<try-seek-using-next>]\n"
 			}
 			prefix = nil
-			trySeekUsingNext := false
+			var flags base.SeekGEFlags
 			if len(parts) == 3 {
-				var err error
-				trySeekUsingNext, err = strconv.ParseBool(parts[2])
-				if err != nil {
+				if trySeekUsingNext, err := strconv.ParseBool(parts[2]); err != nil {
 					return err.Error()
+				} else if trySeekUsingNext {
+					flags = flags.EnableTrySeekUsingNext()
 				}
 			}
-			key, value = iter.SeekGE([]byte(strings.TrimSpace(parts[1])), trySeekUsingNext)
+			key, value = iter.SeekGE([]byte(strings.TrimSpace(parts[1])), flags)
 		case "seek-prefix-ge":
 			if len(parts) != 2 && len(parts) != 3 {
 				return "seek-prefix-ge <key> [<try-seek-using-next>]\n"
 			}
 			prefix = []byte(strings.TrimSpace(parts[1]))
-			trySeekUsingNext := false
+			var flags base.SeekGEFlags
 			if len(parts) == 3 {
-				var err error
-				trySeekUsingNext, err = strconv.ParseBool(parts[2])
-				if err != nil {
+				if trySeekUsingNext, err := strconv.ParseBool(parts[2]); err != nil {
 					return err.Error()
+				} else if trySeekUsingNext {
+					flags = flags.EnableTrySeekUsingNext()
 				}
 			}
-			key, value = iter.SeekPrefixGE(prefix, prefix /* key */, trySeekUsingNext)
+			key, value = iter.SeekPrefixGE(prefix, prefix /* key */, flags)
 		case "seek-lt":
 			if len(parts) != 2 {
 				return "seek-lt <key>\n"

--- a/data_test.go
+++ b/data_test.go
@@ -385,7 +385,7 @@ func runInternalIterCmd(d *datadriven.TestData, iter internalIterator, opts ...i
 				return "seek-lt <key>\n"
 			}
 			prefix = nil
-			key, value = iter.SeekLT([]byte(strings.TrimSpace(parts[1])))
+			key, value = iter.SeekLT([]byte(strings.TrimSpace(parts[1])), base.SeekLTFlagsNone)
 		case "first":
 			prefix = nil
 			key, value = iter.First()

--- a/error_iter.go
+++ b/error_iter.go
@@ -30,7 +30,7 @@ func (c *errorIter) SeekPrefixGE(
 	return nil, nil
 }
 
-func (c *errorIter) SeekLT(key []byte) (*InternalKey, []byte) {
+func (c *errorIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, []byte) {
 	return nil, nil
 }
 

--- a/error_iter.go
+++ b/error_iter.go
@@ -20,12 +20,12 @@ func newErrorIter(err error) *errorIter {
 	return &errorIter{err: err}
 }
 
-func (c *errorIter) SeekGE(key []byte, trySeekUsingNext bool) (*InternalKey, []byte) {
+func (c *errorIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, []byte) {
 	return nil, nil
 }
 
 func (c *errorIter) SeekPrefixGE(
-	prefix, key []byte, trySeekUsingNext bool,
+	prefix, key []byte, flags base.SeekGEFlags,
 ) (*base.InternalKey, []byte) {
 	return nil, nil
 }

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -158,9 +158,9 @@ func finishInitializingExternal(it *Iterator) {
 				}
 			}
 		}
-		it.rangeKey.iter.Init(it.cmp, it.iter, it.rangeKey.rangeKeyIter, it.rangeKey,
+		it.rangeKey.iiter.Init(it.cmp, it.iter, it.rangeKey.rangeKeyIter, it.rangeKey,
 			it.opts.LowerBound, it.opts.UpperBound)
-		it.iter = &it.rangeKey.iter
+		it.iter = &it.rangeKey.iiter
 	}
 }
 

--- a/flushable.go
+++ b/flushable.go
@@ -17,6 +17,7 @@ type flushable interface {
 	newFlushIter(o *IterOptions, bytesFlushed *uint64) internalIterator
 	newRangeDelIter(o *IterOptions) keyspan.FragmentIterator
 	newRangeKeyIter(o *IterOptions) keyspan.FragmentIterator
+	containsRangeKeys() bool
 	// inuseBytes returns the number of inuse bytes by the flushable.
 	inuseBytes() uint64
 	// totalBytes returns the total number of bytes allocated by the flushable.

--- a/get_iter.go
+++ b/get_iter.go
@@ -57,7 +57,7 @@ func (g *getIter) SeekPrefixGE(
 	panic("pebble: SeekPrefixGE unimplemented")
 }
 
-func (g *getIter) SeekLT(key []byte) (*InternalKey, []byte) {
+func (g *getIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, []byte) {
 	panic("pebble: SeekLT unimplemented")
 }
 

--- a/get_iter.go
+++ b/get_iter.go
@@ -47,12 +47,12 @@ func (g *getIter) String() string {
 	return fmt.Sprintf("len(l0)=%d, len(mem)=%d, level=%d", len(g.l0), len(g.mem), g.level)
 }
 
-func (g *getIter) SeekGE(key []byte, trySeekUsingNext bool) (*InternalKey, []byte) {
+func (g *getIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, []byte) {
 	panic("pebble: SeekGE unimplemented")
 }
 
 func (g *getIter) SeekPrefixGE(
-	prefix, key []byte, trySeekUsingNext bool,
+	prefix, key []byte, flags base.SeekGEFlags,
 ) (*base.InternalKey, []byte) {
 	panic("pebble: SeekPrefixGE unimplemented")
 }
@@ -126,7 +126,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 			}
 			g.iter = g.batch.newInternalIter(nil)
 			g.rangeDelIter = g.batch.newRangeDelIter(nil, g.batch.nextSeqNum())
-			g.iterKey, g.iterValue = g.iter.SeekGE(g.key, false /* trySeekUsingNext */)
+			g.iterKey, g.iterValue = g.iter.SeekGE(g.key, base.SeekGEFlagsNone)
 			g.batch = nil
 			continue
 		}
@@ -143,7 +143,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 			g.iter = m.newIter(nil)
 			g.rangeDelIter = m.newRangeDelIter(nil)
 			g.mem = g.mem[:n-1]
-			g.iterKey, g.iterValue = g.iter.SeekGE(g.key, false /* trySeekUsingNext */)
+			g.iterKey, g.iterValue = g.iter.SeekGE(g.key, base.SeekGEFlagsNone)
 			continue
 		}
 
@@ -157,7 +157,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 					files, manifest.L0Sublevel(n), nil)
 				g.levelIter.initRangeDel(&g.rangeDelIter)
 				g.iter = &g.levelIter
-				g.iterKey, g.iterValue = g.iter.SeekGE(g.key, false /* trySeekUsingNext */)
+				g.iterKey, g.iterValue = g.iter.SeekGE(g.key, base.SeekGEFlagsNone)
 				continue
 			}
 			g.level++
@@ -177,7 +177,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 		g.levelIter.initRangeDel(&g.rangeDelIter)
 		g.level++
 		g.iter = &g.levelIter
-		g.iterKey, g.iterValue = g.iter.SeekGE(g.key, false /* trySeekUsingNext */)
+		g.iterKey, g.iterValue = g.iter.SeekGE(g.key, base.SeekGEFlagsNone)
 	}
 }
 

--- a/ingest.go
+++ b/ingest.go
@@ -398,7 +398,7 @@ func overlapWithIterator(
 	//    means boundary < L and hence is similar to 1).
 	// 4) boundary == L and L is sentinel,
 	//    we'll always overlap since for any values of i,j ranges [i, k) and [j, k) always overlap.
-	key, _ := iter.SeekGE(meta.Smallest.UserKey, false /* trySeekUsingNext */)
+	key, _ := iter.SeekGE(meta.Smallest.UserKey, base.SeekGEFlagsNone)
 	if key != nil {
 		c := sstableKeyCompare(cmp, *key, meta.Largest)
 		if c <= 0 {

--- a/internal/arenaskl/flush_iterator.go
+++ b/internal/arenaskl/flush_iterator.go
@@ -44,7 +44,7 @@ func (it *flushIterator) SeekPrefixGE(
 	panic("pebble: SeekPrefixGE unimplemented")
 }
 
-func (it *flushIterator) SeekLT(key []byte) (*base.InternalKey, []byte) {
+func (it *flushIterator) SeekLT(key []byte, flags base.SeekLTFlags) (*base.InternalKey, []byte) {
 	panic("pebble: SeekLT unimplemented")
 }
 

--- a/internal/arenaskl/flush_iterator.go
+++ b/internal/arenaskl/flush_iterator.go
@@ -34,12 +34,12 @@ func (it *flushIterator) String() string {
 	return "memtable"
 }
 
-func (it *flushIterator) SeekGE(key []byte, tryNextUsingSeek bool) (*base.InternalKey, []byte) {
+func (it *flushIterator) SeekGE(key []byte, flags base.SeekGEFlags) (*base.InternalKey, []byte) {
 	panic("pebble: SeekGE unimplemented")
 }
 
 func (it *flushIterator) SeekPrefixGE(
-	prefix, key []byte, trySeekUsingNext bool,
+	prefix, key []byte, flags base.SeekGEFlags,
 ) (*base.InternalKey, []byte) {
 	panic("pebble: SeekPrefixGE unimplemented")
 }

--- a/internal/arenaskl/iterator.go
+++ b/internal/arenaskl/iterator.go
@@ -78,8 +78,8 @@ func (it *Iterator) Error() error {
 // pointing at a valid entry, and (nil, nil) otherwise. Note that SeekGE only
 // checks the upper bound. It is up to the caller to ensure that key is greater
 // than or equal to the lower bound.
-func (it *Iterator) SeekGE(key []byte, trySeekUsingNext bool) (*base.InternalKey, []byte) {
-	if trySeekUsingNext {
+func (it *Iterator) SeekGE(key []byte, flags base.SeekGEFlags) (*base.InternalKey, []byte) {
+	if flags.TrySeekUsingNext() {
 		if it.nd == it.list.tail {
 			// Iterator is done.
 			return nil, nil
@@ -119,9 +119,9 @@ func (it *Iterator) SeekGE(key []byte, trySeekUsingNext bool) (*base.InternalKey
 // provided so that an arenaskl.Iterator implements the
 // internal/base.InternalIterator interface.
 func (it *Iterator) SeekPrefixGE(
-	prefix, key []byte, trySeekUsingNext bool,
+	prefix, key []byte, flags base.SeekGEFlags,
 ) (*base.InternalKey, []byte) {
-	return it.SeekGE(key, trySeekUsingNext)
+	return it.SeekGE(key, flags)
 }
 
 // SeekLT moves the iterator to the last entry whose key is less than the given

--- a/internal/arenaskl/iterator.go
+++ b/internal/arenaskl/iterator.go
@@ -128,7 +128,7 @@ func (it *Iterator) SeekPrefixGE(
 // key. Returns the key and value if the iterator is pointing at a valid entry,
 // and (nil, nil) otherwise. Note that SeekLT only checks the lower bound. It
 // is up to the caller to ensure that key is less than the upper bound.
-func (it *Iterator) SeekLT(key []byte) (*base.InternalKey, []byte) {
+func (it *Iterator) SeekLT(key []byte, flags base.SeekLTFlags) (*base.InternalKey, []byte) {
 	// NB: the top-level Iterator has already adjusted key based on
 	// the upper-bound.
 	it.nd, _, _ = it.seekForBaseSplice(key)

--- a/internal/arenaskl/skl_test.go
+++ b/internal/arenaskl/skl_test.go
@@ -67,8 +67,8 @@ func (i *iterAdapter) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) b
 	return i.update(i.Iterator.SeekPrefixGE(prefix, key, flags))
 }
 
-func (i *iterAdapter) SeekLT(key []byte) bool {
-	return i.update(i.Iterator.SeekLT(key))
+func (i *iterAdapter) SeekLT(key []byte, flags base.SeekLTFlags) bool {
+	return i.update(i.Iterator.SeekLT(key, flags))
 }
 
 func (i *iterAdapter) First() bool {
@@ -669,38 +669,38 @@ func TestIteratorSeekLT(t *testing.T) {
 		ins.Add(l, makeIntKey(v), makeValue(v))
 	}
 
-	require.False(t, it.SeekLT(makeKey("")))
+	require.False(t, it.SeekLT(makeKey(""), base.SeekLTFlagsNone))
 	require.False(t, it.Valid())
 
-	require.False(t, it.SeekLT(makeKey("01000")))
+	require.False(t, it.SeekLT(makeKey("01000"), base.SeekLTFlagsNone))
 	require.False(t, it.Valid())
 
-	require.True(t, it.SeekLT(makeKey("01001")))
+	require.True(t, it.SeekLT(makeKey("01001"), base.SeekLTFlagsNone))
 	require.True(t, it.Valid())
 	require.EqualValues(t, "01000", it.Key().UserKey)
 	require.EqualValues(t, "v01000", it.Value())
 
-	require.True(t, it.SeekLT(makeKey("01005")))
+	require.True(t, it.SeekLT(makeKey("01005"), base.SeekLTFlagsNone))
 	require.True(t, it.Valid())
 	require.EqualValues(t, "01000", it.Key().UserKey)
 	require.EqualValues(t, "v01000", it.Value())
 
-	require.True(t, it.SeekLT(makeKey("01991")))
+	require.True(t, it.SeekLT(makeKey("01991"), base.SeekLTFlagsNone))
 	require.True(t, it.Valid())
 	require.EqualValues(t, "01990", it.Key().UserKey)
 	require.EqualValues(t, "v01990", it.Value())
 
-	require.True(t, it.SeekLT(makeKey("99999")))
+	require.True(t, it.SeekLT(makeKey("99999"), base.SeekLTFlagsNone))
 	require.True(t, it.Valid())
 	require.EqualValues(t, "01990", it.Key().UserKey)
 	require.EqualValues(t, "v01990", it.Value())
 
 	// Test seek for empty key.
 	ins.Add(l, base.InternalKey{}, nil)
-	require.False(t, it.SeekLT([]byte{}))
+	require.False(t, it.SeekLT([]byte{}, base.SeekLTFlagsNone))
 	require.False(t, it.Valid())
 
-	require.True(t, it.SeekLT(makeKey("\x01")))
+	require.True(t, it.SeekLT(makeKey("\x01"), base.SeekLTFlagsNone))
 	require.True(t, it.Valid())
 	require.EqualValues(t, "", it.Key().UserKey)
 }
@@ -747,23 +747,23 @@ func TestIteratorBounds(t *testing.T) {
 
 	// SeekLT within the lower and upper bound succeeds.
 	for i := 4; i <= 7; i++ {
-		require.True(t, it.SeekLT(key(i)))
+		require.True(t, it.SeekLT(key(i), base.SeekLTFlagsNone))
 		require.EqualValues(t, string(key(i-1)), string(it.Key().UserKey))
 	}
 
 	// SeekLT beyond the upper bound still succeeds (only the lower bound is
 	// checked).
 	for i := 8; i < 9; i++ {
-		require.True(t, it.SeekLT(key(8)))
+		require.True(t, it.SeekLT(key(8), base.SeekLTFlagsNone))
 		require.EqualValues(t, string(key(i-1)), string(it.Key().UserKey))
 	}
 
 	// SeekLT before the lower bound fails.
 	for i := 1; i < 4; i++ {
-		require.False(t, it.SeekLT(key(i)))
+		require.False(t, it.SeekLT(key(i), base.SeekLTFlagsNone))
 	}
 
-	require.True(t, it.SeekLT(key(4)))
+	require.True(t, it.SeekLT(key(4), base.SeekLTFlagsNone))
 	require.EqualValues(t, "00003", it.Key().UserKey)
 	require.EqualValues(t, "v00003", it.Value())
 

--- a/internal/arenaskl/skl_test.go
+++ b/internal/arenaskl/skl_test.go
@@ -59,12 +59,12 @@ func (i *iterAdapter) String() string {
 	return "iter-adapter"
 }
 
-func (i *iterAdapter) SeekGE(key []byte, trySeekUsingNext bool) bool {
-	return i.update(i.Iterator.SeekGE(key, trySeekUsingNext))
+func (i *iterAdapter) SeekGE(key []byte, flags base.SeekGEFlags) bool {
+	return i.update(i.Iterator.SeekGE(key, flags))
 }
 
-func (i *iterAdapter) SeekPrefixGE(prefix, key []byte, trySeekUsingNext bool) bool {
-	return i.update(i.Iterator.SeekPrefixGE(prefix, key, trySeekUsingNext))
+func (i *iterAdapter) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) bool {
+	return i.update(i.Iterator.SeekPrefixGE(prefix, key, flags))
 }
 
 func (i *iterAdapter) SeekLT(key []byte) bool {
@@ -159,7 +159,7 @@ func TestEmpty(t *testing.T) {
 	it.Last()
 	require.False(t, it.Valid())
 
-	require.False(t, it.SeekGE(key, false /* trySeekUsingNext */))
+	require.False(t, it.SeekGE(key, base.SeekGEFlagsNone))
 	require.False(t, it.Valid())
 }
 
@@ -198,19 +198,19 @@ func TestBasic(t *testing.T) {
 			add(makeIkey("key3"), makeValue(3))
 			add(makeIkey("key2"), makeValue(2))
 
-			require.True(t, it.SeekGE(makeKey("key"), false /* trySeekUsingNext */))
+			require.True(t, it.SeekGE(makeKey("key"), base.SeekGEFlagsNone))
 			require.True(t, it.Valid())
 			require.NotEqual(t, "key", it.Key().UserKey)
 
-			require.True(t, it.SeekGE(makeKey("key1"), false /* trySeekUsingNext */))
+			require.True(t, it.SeekGE(makeKey("key1"), base.SeekGEFlagsNone))
 			require.EqualValues(t, "key1", it.Key().UserKey)
 			require.EqualValues(t, makeValue(1), it.Value())
 
-			require.True(t, it.SeekGE(makeKey("key2"), false /* trySeekUsingNext */))
+			require.True(t, it.SeekGE(makeKey("key2"), base.SeekGEFlagsNone))
 			require.EqualValues(t, "key2", it.Key().UserKey)
 			require.EqualValues(t, makeValue(2), it.Value())
 
-			require.True(t, it.SeekGE(makeKey("key3"), false /* trySeekUsingNext */))
+			require.True(t, it.SeekGE(makeKey("key3"), base.SeekGEFlagsNone))
 			require.EqualValues(t, "key3", it.Key().UserKey)
 			require.EqualValues(t, makeValue(3), it.Value())
 
@@ -220,7 +220,7 @@ func TestBasic(t *testing.T) {
 			key.SetSeqNum(2)
 			add(key, nil)
 
-			require.True(t, it.SeekGE(makeKey("a"), false /* trySeekUsingNext */))
+			require.True(t, it.SeekGE(makeKey("a"), base.SeekGEFlagsNone))
 			require.True(t, it.Valid())
 			require.EqualValues(t, "a", it.Key().UserKey)
 			require.EqualValues(t, 2, it.Key().SeqNum())
@@ -236,7 +236,7 @@ func TestBasic(t *testing.T) {
 			key.SetSeqNum(1)
 			add(key, nil)
 
-			require.True(t, it.SeekGE(makeKey("b"), false /* trySeekUsingNext */))
+			require.True(t, it.SeekGE(makeKey("b"), base.SeekGEFlagsNone))
 			require.True(t, it.Valid())
 			require.EqualValues(t, "b", it.Key().UserKey)
 			require.EqualValues(t, 2, it.Key().SeqNum())
@@ -282,7 +282,7 @@ func TestConcurrentBasic(t *testing.T) {
 					defer wg.Done()
 
 					it := newIterAdapter(l.NewIter(nil, nil))
-					require.True(t, it.SeekGE(makeKey(fmt.Sprintf("%05d", i)), false /* trySeekUsingNext */))
+					require.True(t, it.SeekGE(makeKey(fmt.Sprintf("%05d", i)), base.SeekGEFlagsNone))
 					require.EqualValues(t, fmt.Sprintf("%05d", i), it.Key().UserKey)
 				}(i)
 			}
@@ -335,7 +335,7 @@ func TestConcurrentOneKey(t *testing.T) {
 					defer wg.Done()
 
 					it := newIterAdapter(l.NewIter(nil, nil))
-					it.SeekGE(key, false /* trySeekUsingNext */)
+					it.SeekGE(key, base.SeekGEFlagsNone)
 					require.True(t, it.Valid())
 					require.True(t, bytes.Equal(key, it.Key().UserKey))
 
@@ -367,7 +367,7 @@ func TestSkiplistAdd(t *testing.T) {
 			// Add nil key and value (treated same as empty).
 			err := add(base.InternalKey{}, nil)
 			require.Nil(t, err)
-			require.True(t, it.SeekGE([]byte{}, false /* trySeekUsingNext */))
+			require.True(t, it.SeekGE([]byte{}, base.SeekGEFlagsNone))
 			require.EqualValues(t, []byte{}, it.Key().UserKey)
 			require.EqualValues(t, []byte{}, it.Value())
 
@@ -382,35 +382,35 @@ func TestSkiplistAdd(t *testing.T) {
 			// Add empty key and value (treated same as nil).
 			err = add(makeIkey(""), []byte{})
 			require.Nil(t, err)
-			require.True(t, it.SeekGE([]byte{}, false /* trySeekUsingNext */))
+			require.True(t, it.SeekGE([]byte{}, base.SeekGEFlagsNone))
 			require.EqualValues(t, []byte{}, it.Key().UserKey)
 			require.EqualValues(t, []byte{}, it.Value())
 
 			// Add to empty list.
 			err = add(makeIntKey(2), makeValue(2))
 			require.Nil(t, err)
-			require.True(t, it.SeekGE(makeKey("00002"), false /* trySeekUsingNext */))
+			require.True(t, it.SeekGE(makeKey("00002"), base.SeekGEFlagsNone))
 			require.EqualValues(t, "00002", it.Key().UserKey)
 			require.EqualValues(t, makeValue(2), it.Value())
 
 			// Add first element in non-empty list.
 			err = add(makeIntKey(1), makeValue(1))
 			require.Nil(t, err)
-			require.True(t, it.SeekGE(makeKey("00001"), false /* trySeekUsingNext */))
+			require.True(t, it.SeekGE(makeKey("00001"), base.SeekGEFlagsNone))
 			require.EqualValues(t, "00001", it.Key().UserKey)
 			require.EqualValues(t, makeValue(1), it.Value())
 
 			// Add last element in non-empty list.
 			err = add(makeIntKey(4), makeValue(4))
 			require.Nil(t, err)
-			require.True(t, it.SeekGE(makeKey("00004"), false /* trySeekUsingNext */))
+			require.True(t, it.SeekGE(makeKey("00004"), base.SeekGEFlagsNone))
 			require.EqualValues(t, "00004", it.Key().UserKey)
 			require.EqualValues(t, makeValue(4), it.Value())
 
 			// Add element in middle of list.
 			err = add(makeIntKey(3), makeValue(3))
 			require.Nil(t, err)
-			require.True(t, it.SeekGE(makeKey("00003"), false /* trySeekUsingNext */))
+			require.True(t, it.SeekGE(makeKey("00003"), base.SeekGEFlagsNone))
 			require.EqualValues(t, "00003", it.Key().UserKey)
 			require.EqualValues(t, makeValue(3), it.Value())
 
@@ -457,7 +457,7 @@ func TestConcurrentAdd(t *testing.T) {
 
 						key := makeIntKey(i)
 						if add(key, nil) == nil {
-							require.True(t, it.SeekGE(key.UserKey, false /* trySeekUsingNext */))
+							require.True(t, it.SeekGE(key.UserKey, base.SeekGEFlagsNone))
 							require.EqualValues(t, key, it.Key())
 						}
 
@@ -544,62 +544,62 @@ func TestIteratorSeekGEAndSeekPrefixGE(t *testing.T) {
 		ins.Add(l, makeIntKey(v), makeValue(v))
 	}
 
-	require.True(t, it.SeekGE(makeKey(""), false /* trySeekUsingNext */))
+	require.True(t, it.SeekGE(makeKey(""), base.SeekGEFlagsNone))
 	require.True(t, it.Valid())
 	require.EqualValues(t, "01000", it.Key().UserKey)
 	require.EqualValues(t, "v01000", it.Value())
 
-	require.True(t, it.SeekGE(makeKey("01000"), false /* trySeekUsingNext */))
+	require.True(t, it.SeekGE(makeKey("01000"), base.SeekGEFlagsNone))
 	require.True(t, it.Valid())
 	require.EqualValues(t, "01000", it.Key().UserKey)
 	require.EqualValues(t, "v01000", it.Value())
 
-	require.True(t, it.SeekGE(makeKey("01005"), false /* trySeekUsingNext */))
+	require.True(t, it.SeekGE(makeKey("01005"), base.SeekGEFlagsNone))
 	require.True(t, it.Valid())
 	require.EqualValues(t, "01010", it.Key().UserKey)
 	require.EqualValues(t, "v01010", it.Value())
 
-	require.True(t, it.SeekGE(makeKey("01010"), false /* trySeekUsingNext */))
+	require.True(t, it.SeekGE(makeKey("01010"), base.SeekGEFlagsNone))
 	require.True(t, it.Valid())
 	require.EqualValues(t, "01010", it.Key().UserKey)
 	require.EqualValues(t, "v01010", it.Value())
 
-	require.False(t, it.SeekGE(makeKey("99999"), false /* trySeekUsingNext */))
+	require.False(t, it.SeekGE(makeKey("99999"), base.SeekGEFlagsNone))
 	require.False(t, it.Valid())
 
 	// Test SeekGE with trySeekUsingNext optimization.
 	{
-		require.True(t, it.SeekGE(makeKey("01000"), false /* trySeekUsingNext */))
+		require.True(t, it.SeekGE(makeKey("01000"), base.SeekGEFlagsNone))
 		require.True(t, it.Valid())
 		require.EqualValues(t, "01000", it.Key().UserKey)
 		require.EqualValues(t, "v01000", it.Value())
 
 		// Seeking to the same key.
-		require.True(t, it.SeekGE(makeKey("01000"), true /* trySeekUsingNext */))
+		require.True(t, it.SeekGE(makeKey("01000"), base.SeekGEFlagsNone.EnableTrySeekUsingNext()))
 		require.True(t, it.Valid())
 		require.EqualValues(t, "01000", it.Key().UserKey)
 		require.EqualValues(t, "v01000", it.Value())
 
 		// Seeking to a nearby key that can be reached using Next.
-		require.True(t, it.SeekGE(makeKey("01020"), true /* trySeekUsingNext */))
+		require.True(t, it.SeekGE(makeKey("01020"), base.SeekGEFlagsNone.EnableTrySeekUsingNext()))
 		require.True(t, it.Valid())
 		require.EqualValues(t, "01020", it.Key().UserKey)
 		require.EqualValues(t, "v01020", it.Value())
 
 		// Seeking to a key that cannot be reached using Next.
-		require.True(t, it.SeekGE(makeKey("01200"), true /* trySeekUsingNext */))
+		require.True(t, it.SeekGE(makeKey("01200"), base.SeekGEFlagsNone.EnableTrySeekUsingNext()))
 		require.True(t, it.Valid())
 		require.EqualValues(t, "01200", it.Key().UserKey)
 		require.EqualValues(t, "v01200", it.Value())
 
 		// Seeking to an earlier key, but the caller lies. Incorrect result.
-		require.True(t, it.SeekGE(makeKey("01100"), true /* trySeekUsingNext */))
+		require.True(t, it.SeekGE(makeKey("01100"), base.SeekGEFlagsNone.EnableTrySeekUsingNext()))
 		require.True(t, it.Valid())
 		require.EqualValues(t, "01200", it.Key().UserKey)
 		require.EqualValues(t, "v01200", it.Value())
 
 		// Telling the truth works.
-		require.True(t, it.SeekGE(makeKey("01100"), false /* trySeekUsingNext */))
+		require.True(t, it.SeekGE(makeKey("01100"), base.SeekGEFlagsNone))
 		require.True(t, it.Valid())
 		require.EqualValues(t, "01100", it.Key().UserKey)
 		require.EqualValues(t, "v01100", it.Value())
@@ -607,37 +607,37 @@ func TestIteratorSeekGEAndSeekPrefixGE(t *testing.T) {
 
 	// Test SeekPrefixGE with trySeekUsingNext optimization.
 	{
-		require.True(t, it.SeekPrefixGE(makeKey("01000"), makeKey("01000"), false))
+		require.True(t, it.SeekPrefixGE(makeKey("01000"), makeKey("01000"), base.SeekGEFlagsNone))
 		require.True(t, it.Valid())
 		require.EqualValues(t, "01000", it.Key().UserKey)
 		require.EqualValues(t, "v01000", it.Value())
 
 		// Seeking to the same key.
-		require.True(t, it.SeekPrefixGE(makeKey("01000"), makeKey("01000"), true))
+		require.True(t, it.SeekPrefixGE(makeKey("01000"), makeKey("01000"), base.SeekGEFlagsNone.EnableTrySeekUsingNext()))
 		require.True(t, it.Valid())
 		require.EqualValues(t, "01000", it.Key().UserKey)
 		require.EqualValues(t, "v01000", it.Value())
 
 		// Seeking to a nearby key that can be reached using Next.
-		require.True(t, it.SeekPrefixGE(makeKey("01020"), makeKey("01020"), true))
+		require.True(t, it.SeekPrefixGE(makeKey("01020"), makeKey("01020"), base.SeekGEFlagsNone.EnableTrySeekUsingNext()))
 		require.True(t, it.Valid())
 		require.EqualValues(t, "01020", it.Key().UserKey)
 		require.EqualValues(t, "v01020", it.Value())
 
 		// Seeking to a key that cannot be reached using Next.
-		require.True(t, it.SeekPrefixGE(makeKey("01200"), makeKey("01200"), true))
+		require.True(t, it.SeekPrefixGE(makeKey("01200"), makeKey("01200"), base.SeekGEFlagsNone.EnableTrySeekUsingNext()))
 		require.True(t, it.Valid())
 		require.EqualValues(t, "01200", it.Key().UserKey)
 		require.EqualValues(t, "v01200", it.Value())
 
 		// Seeking to an earlier key, but the caller lies. Incorrect result.
-		require.True(t, it.SeekPrefixGE(makeKey("01100"), makeKey("01100"), true))
+		require.True(t, it.SeekPrefixGE(makeKey("01100"), makeKey("01100"), base.SeekGEFlagsNone.EnableTrySeekUsingNext()))
 		require.True(t, it.Valid())
 		require.EqualValues(t, "01200", it.Key().UserKey)
 		require.EqualValues(t, "v01200", it.Value())
 
 		// Telling the truth works.
-		require.True(t, it.SeekPrefixGE(makeKey("01100"), makeKey("01100"), false))
+		require.True(t, it.SeekPrefixGE(makeKey("01100"), makeKey("01100"), base.SeekGEFlagsNone))
 		require.True(t, it.Valid())
 		require.EqualValues(t, "01100", it.Key().UserKey)
 		require.EqualValues(t, "v01100", it.Value())
@@ -645,11 +645,11 @@ func TestIteratorSeekGEAndSeekPrefixGE(t *testing.T) {
 
 	// Test seek for empty key.
 	ins.Add(l, base.InternalKey{}, nil)
-	require.True(t, it.SeekGE([]byte{}, false /* trySeekUsingNext */))
+	require.True(t, it.SeekGE([]byte{}, base.SeekGEFlagsNone))
 	require.True(t, it.Valid())
 	require.EqualValues(t, "", it.Key().UserKey)
 
-	require.True(t, it.SeekGE(makeKey(""), false /* trySeekUsingNext */))
+	require.True(t, it.SeekGE(makeKey(""), base.SeekGEFlagsNone))
 	require.True(t, it.Valid())
 	require.EqualValues(t, "", it.Key().UserKey)
 }
@@ -721,7 +721,7 @@ func TestIteratorBounds(t *testing.T) {
 	// SeekGE within the lower and upper bound succeeds.
 	for i := 3; i <= 6; i++ {
 		k := key(i)
-		require.True(t, it.SeekGE(k, false /* trySeekUsingNext */))
+		require.True(t, it.SeekGE(k, base.SeekGEFlagsNone))
 		require.EqualValues(t, string(k), string(it.Key().UserKey))
 	}
 
@@ -729,16 +729,16 @@ func TestIteratorBounds(t *testing.T) {
 	// checked).
 	for i := 1; i < 3; i++ {
 		k := key(i)
-		require.True(t, it.SeekGE(k, false /* trySeekUsingNext */))
+		require.True(t, it.SeekGE(k, base.SeekGEFlagsNone))
 		require.EqualValues(t, string(k), string(it.Key().UserKey))
 	}
 
 	// SeekGE beyond the upper bound fails.
 	for i := 7; i < 10; i++ {
-		require.False(t, it.SeekGE(key(i), false /* trySeekUsingNext */))
+		require.False(t, it.SeekGE(key(i), base.SeekGEFlagsNone))
 	}
 
-	require.True(t, it.SeekGE(key(6), false /* trySeekUsingNext */))
+	require.True(t, it.SeekGE(key(6), base.SeekGEFlagsNone))
 	require.EqualValues(t, "00006", it.Key().UserKey)
 	require.EqualValues(t, "v00006", it.Value())
 
@@ -824,7 +824,7 @@ func BenchmarkReadWrite(b *testing.B) {
 
 				for pb.Next() {
 					if rng.Float32() < readFrac {
-						key, _ := it.SeekGE(randomKey(rng, buf).UserKey, false /* trySeekUsingNext */)
+						key, _ := it.SeekGE(randomKey(rng, buf).UserKey, base.SeekGEFlagsNone)
 						if key != nil {
 							_ = key
 							count++
@@ -920,17 +920,20 @@ func BenchmarkSeekPrefixGE(b *testing.B) {
 					k = []byte(fmt.Sprintf("%05d", j))
 				}
 				makeKey()
-				it.SeekPrefixGE(k, k, false)
+				it.SeekPrefixGE(k, k, base.SeekGEFlagsNone)
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					j += skip
-					trySeekUsingNext := useNext
+					var flags base.SeekGEFlags
+					if useNext {
+						flags = flags.EnableTrySeekUsingNext()
+					}
 					if j >= count {
 						j = 0
-						trySeekUsingNext = false
+						flags = flags.DisableTrySeekUsingNext()
 					}
 					makeKey()
-					it.SeekPrefixGE(k, k, trySeekUsingNext)
+					it.SeekPrefixGE(k, k, flags)
 				}
 			})
 		}

--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -91,23 +91,7 @@ type InternalIterator interface {
 	// is pointing at a valid entry, and (nil, nil) otherwise. Note that SeekGE
 	// only checks the upper bound. It is up to the caller to ensure that key
 	// is greater than or equal to the lower bound.
-	//
-	// trySeekUsingNext is a performance optimization that callers can use to
-	// indicate that they have not done any action to move this iterator beyond
-	// the first key that would be found if this iterator were to honestly do
-	// the intended seek. For example, say the caller did a
-	// SeekGE(k1...), followed by SeekGE(k2...) where k1 <= k2, without any
-	// intermediate positioning calls. The caller can safely specify true for this
-	// parameter in the second call. As another example, say the caller did do one
-	// call to Next between the two Seek calls, and k1 < k2. Again, the caller can
-	// safely specify a true value for this parameter. Note that a false value is
-	// always safe. The callee is free to ignore the true value if its
-	// implementation does not permit this optimization.
-	// - We make the caller do this determination since a string comparison of
-	//   k1, k2 is not necessarily cheap, and there may be many iterators in
-	//   the iterator stack. Doing it once at the root of the iterator stack
-	//   is cheaper.
-	SeekGE(key []byte, trySeekUsingNext bool) (*InternalKey, []byte)
+	SeekGE(key []byte, flags SeekGEFlags) (*InternalKey, []byte)
 
 	// SeekPrefixGE moves the iterator to the first key/value pair whose key is
 	// greater than or equal to the given key. Returns the key and value if the
@@ -132,33 +116,7 @@ type InternalIterator interface {
 	// not supporting reverse iteration in prefix iteration mode until a
 	// different positioning routine (SeekGE, SeekLT, First or Last) switches the
 	// iterator out of prefix iteration.
-	//
-	// trySeekUsingNext is a performance optimization that callers can use to
-	// indicate that they have not done any action to move this iterator
-	// beyond the first key that would be found if this iterator were to
-	// honestly do the indicated seek. For example, say the caller did a
-	// SeekPrefixGE(k1...), followed by SeekPrefixGE(k2...) where k1 <= k2,
-	// without any intermediate positioning calls. The caller can safely
-	// specify true for this parameter in the second call. As another example,
-	// say the caller did do one call to Next between the two SeekPrefixGE
-	// calls, and k1 < k2. Again, the caller can safely specify a true value
-	// for this parameter. Note that a false value is always safe. The callee
-	// is free to ignore the true value if its implementation does not permit
-	// this optimization.
-	// - We make the caller do this determination since a string comparison of
-	//   k1, k2 is not necessarily cheap, and there may be many iterators in
-	//   the iterator stack. Doing it once at the root of the iterator stack
-	//   is cheaper.
-	// - This optimization could also be applied to SeekLT (where it would be
-	//   trySeekUsingPrev). We currently only do it for SeekPrefixGE and SeekGE
-	//   because this is where this optimization helps the performance of
-	//   CockroachDB. The SeekLT cases in CockroachDB are typically accompanied
-	//   with bounds that change between seek calls, and is optimized inside
-	//   certain iterator implementations, like singleLevelIterator, without any
-	//   extra parameter passing (though the same amortization of string
-	//   comparisons could be done to improve that optimization, by making the
-	//   root of the iterator stack do it).
-	SeekPrefixGE(prefix, key []byte, trySeekUsingNext bool) (*InternalKey, []byte)
+	SeekPrefixGE(prefix, key []byte, flags SeekGEFlags) (*InternalKey, []byte)
 
 	// SeekLT moves the iterator to the last key/value pair whose key is less
 	// than the given key. Returns the key and value if the iterator is pointing
@@ -223,6 +181,56 @@ type InternalIterator interface {
 	SetBounds(lower, upper []byte)
 
 	fmt.Stringer
+}
+
+// SeekGEFlags holds flags that may configure the behavior of a seek. Not all
+// flags are relevant to all iterators.
+type SeekGEFlags uint8
+
+const (
+	seekGEFlagTrySeekUsingNext uint8 = iota
+)
+
+// SeekGEFlagsNone is the default value of SeekGEFlags, with all flags disabled.
+const SeekGEFlagsNone = SeekGEFlags(0)
+
+// TrySeekUsingNext indicates whether a performance optimization was enabled
+// by a caller, indicating the caller has not done any action to move this
+// iterator beyond the first key that would be found if this iterator were to
+// honestly do the intended seek. For example, say the caller did a
+// SeekGE(k1...), followed by SeekGE(k2...) where k1 <= k2, without any
+// intermediate positioning calls. The caller can safely specify true for this
+// parameter in the second call. As another example, say the caller did do one
+// call to Next between the two Seek calls, and k1 < k2. Again, the caller can
+// safely specify a true value for this parameter. Note that a false value is
+// always safe. The callee is free to ignore the true value if its
+// implementation does not permit this optimization.
+//
+// We make the caller do this determination since a string comparison of k1, k2
+// is not necessarily cheap, and there may be many iterators in the iterator
+// stack. Doing it once at the root of the iterator stack is cheaper.
+//
+// This optimization could also be applied to SeekLT (where it would be
+// trySeekUsingPrev). We currently only do it for SeekPrefixGE and SeekGE
+// because this is where this optimization helps the performance of CockroachDB.
+// The SeekLT cases in CockroachDB are typically accompanied with bounds that
+// change between seek calls, and is optimized inside certain iterator
+// implementations, like singleLevelIterator, without any extra parameter
+// passing (though the same amortization of string comparisons could be done to
+// improve that optimization, by making the root of the iterator stack do it).
+func (s SeekGEFlags) TrySeekUsingNext() bool { return (s & (1 << seekGEFlagTrySeekUsingNext)) != 0 }
+
+// EnableTrySeekUsingNext returns the provided flags with the
+// try-seek-using-next optimization enabled. See TrySeekUsingNext for an
+// explanation of this optimization.
+func (s SeekGEFlags) EnableTrySeekUsingNext() SeekGEFlags {
+	return s | (1 << seekGEFlagTrySeekUsingNext)
+}
+
+// DisableTrySeekUsingNext returns the provided flags with the
+// try-seek-using-next optimization disabled.
+func (s SeekGEFlags) DisableTrySeekUsingNext() SeekGEFlags {
+	return s &^ (1 << seekGEFlagTrySeekUsingNext)
 }
 
 // InternalIteratorWithStats extends InternalIterator to expose stats.

--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -123,7 +123,7 @@ type InternalIterator interface {
 	// at a valid entry, and (nil, nil) otherwise. Note that SeekLT only checks
 	// the lower bound. It is up to the caller to ensure that key is less than
 	// the upper bound.
-	SeekLT(key []byte) (*InternalKey, []byte)
+	SeekLT(key []byte, flags SeekLTFlags) (*InternalKey, []byte)
 
 	// First moves the iterator the the first key/value pair. Returns the key and
 	// value if the iterator is pointing at a valid entry, and (nil, nil)
@@ -232,6 +232,13 @@ func (s SeekGEFlags) EnableTrySeekUsingNext() SeekGEFlags {
 func (s SeekGEFlags) DisableTrySeekUsingNext() SeekGEFlags {
 	return s &^ (1 << seekGEFlagTrySeekUsingNext)
 }
+
+// SeekLTFlags holds flags that may configure the behavior of a seek. Not all
+// flags are relevant to all iterators.
+type SeekLTFlags uint8
+
+// SeekLTFlagsNone is the default value of SeekLTFlags, with all flags disabled.
+const SeekLTFlagsNone = SeekLTFlags(0)
 
 // InternalIteratorWithStats extends InternalIterator to expose stats.
 type InternalIteratorWithStats interface {

--- a/internal/base/iterator_test.go
+++ b/internal/base/iterator_test.go
@@ -5,6 +5,7 @@
 package base
 
 import (
+	"fmt"
 	"math/rand"
 	"reflect"
 	"testing"
@@ -33,4 +34,77 @@ func TestInternalIteratorStatsMerge(t *testing.T) {
 	}
 	to.Merge(from)
 	require.Equal(t, expected, to)
+}
+
+func TestFlags(t *testing.T) {
+	t.Run("SeekGEFlags", func(t *testing.T) {
+		f := SeekGEFlagsNone
+		flags := []flag{
+			{
+				"TrySeekUsingNext",
+				func() bool { return f.TrySeekUsingNext() },
+				func() { f = f.EnableTrySeekUsingNext() },
+				func() { f = f.DisableTrySeekUsingNext() },
+			},
+			{
+				"RelativeSeek",
+				func() bool { return f.RelativeSeek() },
+				func() { f = f.EnableRelativeSeek() },
+				func() { f = f.DisableRelativeSeek() },
+			},
+		}
+		ref := make([]bool, len(flags))
+		checkCombination(t, 0, flags, ref)
+	})
+	t.Run("SeekLTFlags", func(t *testing.T) {
+		f := SeekLTFlagsNone
+		flags := []flag{
+			{
+				"RelativeSeek",
+				func() bool { return f.RelativeSeek() },
+				func() { f = f.EnableRelativeSeek() },
+				func() { f = f.DisableRelativeSeek() },
+			},
+		}
+		ref := make([]bool, len(flags))
+		checkCombination(t, 0, flags, ref)
+	})
+}
+
+type flag struct {
+	label string
+	pred  func() bool
+	set   func()
+	unset func()
+}
+
+func checkCombination(t *testing.T, i int, flags []flag, ref []bool) {
+	if i >= len(ref) {
+		// Verify that ref matches the flag predicates.
+		for j := 0; j < i; j++ {
+			if got := flags[j].pred(); ref[j] != got {
+				t.Errorf("%s() = %t, want %t", flags[j].label, got, ref[j])
+			}
+		}
+		return
+	}
+
+	// flag i remains unset.
+	t.Run(fmt.Sprintf("%s begin unset", flags[i].label), func(t *testing.T) {
+		checkCombination(t, i+1, flags, ref)
+	})
+
+	// set flag i
+	ref[i] = true
+	flags[i].set()
+	t.Run(fmt.Sprintf("%s set", flags[i].label), func(t *testing.T) {
+		checkCombination(t, i+1, flags, ref)
+	})
+
+	// unset flag i
+	ref[i] = false
+	flags[i].unset()
+	t.Run(fmt.Sprintf("%s unset", flags[i].label), func(t *testing.T) {
+		checkCombination(t, i+1, flags, ref)
+	})
 }

--- a/internal/keyspan/interleaving_iter.go
+++ b/internal/keyspan/interleaving_iter.go
@@ -208,8 +208,8 @@ func (i *InterleavingIter) SeekPrefixGE(
 }
 
 // SeekLT implements (base.InternalIterator).SeekLT.
-func (i *InterleavingIter) SeekLT(key []byte) (*base.InternalKey, []byte) {
-	i.pointKey, i.pointVal = i.pointIter.SeekLT(key)
+func (i *InterleavingIter) SeekLT(key []byte, flags base.SeekLTFlags) (*base.InternalKey, []byte) {
+	i.pointKey, i.pointVal = i.pointIter.SeekLT(key, flags)
 	i.pointKeyInterleaved = false
 	i.keyspanSeekLT(key)
 	i.dir = -1
@@ -377,7 +377,7 @@ func (i *InterleavingIter) Prev() (*base.InternalKey, []byte) {
 		case i.pointKey == nil && i.upper == nil:
 			i.pointKey, i.pointVal = i.pointIter.Last()
 		case i.pointKey == nil && i.upper != nil:
-			i.pointKey, i.pointVal = i.pointIter.SeekLT(i.upper)
+			i.pointKey, i.pointVal = i.pointIter.SeekLT(i.upper, base.SeekLTFlagsNone)
 		default:
 			i.pointKey, i.pointVal = i.pointIter.Prev()
 		}

--- a/internal/keyspan/interleaving_iter.go
+++ b/internal/keyspan/interleaving_iter.go
@@ -179,8 +179,8 @@ func (i *InterleavingIter) Init(
 //
 // NB: In accordance with the base.InternalIterator contract:
 //   i.lower ≤ key
-func (i *InterleavingIter) SeekGE(key []byte, trySeekUsingNext bool) (*base.InternalKey, []byte) {
-	i.pointKey, i.pointVal = i.pointIter.SeekGE(key, trySeekUsingNext)
+func (i *InterleavingIter) SeekGE(key []byte, flags base.SeekGEFlags) (*base.InternalKey, []byte) {
+	i.pointKey, i.pointVal = i.pointIter.SeekGE(key, flags)
 	i.pointKeyInterleaved = false
 	i.keyspanSeekGE(key)
 	i.dir = +1
@@ -198,9 +198,9 @@ func (i *InterleavingIter) SeekGE(key []byte, trySeekUsingNext bool) (*base.Inte
 // NB: In accordance with the base.InternalIterator contract:
 //   i.lower ≤ key
 func (i *InterleavingIter) SeekPrefixGE(
-	prefix, key []byte, trySeekUsingNext bool,
+	prefix, key []byte, flags base.SeekGEFlags,
 ) (*base.InternalKey, []byte) {
-	i.pointKey, i.pointVal = i.pointIter.SeekPrefixGE(prefix, key, trySeekUsingNext)
+	i.pointKey, i.pointVal = i.pointIter.SeekPrefixGE(prefix, key, flags)
 	i.pointKeyInterleaved = false
 	i.keyspanSeekGE(key)
 	i.dir = +1
@@ -256,7 +256,7 @@ func (i *InterleavingIter) Next() (*base.InternalKey, []byte) {
 		case i.pointKey == nil && i.lower == nil:
 			i.pointKey, i.pointVal = i.pointIter.First()
 		case i.pointKey == nil && i.lower != nil:
-			i.pointKey, i.pointVal = i.pointIter.SeekGE(i.lower, false)
+			i.pointKey, i.pointVal = i.pointIter.SeekGE(i.lower, base.SeekGEFlagsNone)
 		default:
 			i.pointKey, i.pointVal = i.pointIter.Next()
 		}

--- a/internal/keyspan/interleaving_iter_test.go
+++ b/internal/keyspan/interleaving_iter_test.go
@@ -131,7 +131,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 				case "seek-ge":
 					formatKey(iter.SeekGE([]byte(strings.TrimSpace(line[i:])), base.SeekGEFlagsNone))
 				case "seek-lt":
-					formatKey(iter.SeekLT([]byte(strings.TrimSpace(line[i:]))))
+					formatKey(iter.SeekLT([]byte(strings.TrimSpace(line[i:])), base.SeekLTFlagsNone))
 				case "set-bounds":
 					bounds := strings.Fields(line[i:])
 					if len(bounds) != 2 {
@@ -189,7 +189,7 @@ func (i *pointIterator) SeekPrefixGE(
 	return i.SeekGE(key, flags)
 }
 
-func (i *pointIterator) SeekLT(key []byte) (*base.InternalKey, []byte) {
+func (i *pointIterator) SeekLT(key []byte, flags base.SeekLTFlags) (*base.InternalKey, []byte) {
 	i.index = sort.Search(len(i.keys), func(j int) bool {
 		return i.cmp(i.keys[j].UserKey, key) >= 0
 	})

--- a/internal/keyspan/interleaving_iter_test.go
+++ b/internal/keyspan/interleaving_iter_test.go
@@ -129,7 +129,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 				case "prev":
 					formatKey(iter.Prev())
 				case "seek-ge":
-					formatKey(iter.SeekGE([]byte(strings.TrimSpace(line[i:])), false /* trySeekUsingNext */))
+					formatKey(iter.SeekGE([]byte(strings.TrimSpace(line[i:])), base.SeekGEFlagsNone))
 				case "seek-lt":
 					formatKey(iter.SeekLT([]byte(strings.TrimSpace(line[i:]))))
 				case "set-bounds":
@@ -170,7 +170,7 @@ type pointIterator struct {
 
 var _ base.InternalIterator = &pointIterator{}
 
-func (i *pointIterator) SeekGE(key []byte, trySeekUsingNext bool) (*base.InternalKey, []byte) {
+func (i *pointIterator) SeekGE(key []byte, flags base.SeekGEFlags) (*base.InternalKey, []byte) {
 	i.index = sort.Search(len(i.keys), func(j int) bool {
 		return i.cmp(i.keys[j].UserKey, key) >= 0
 	})
@@ -184,9 +184,9 @@ func (i *pointIterator) SeekGE(key []byte, trySeekUsingNext bool) (*base.Interna
 }
 
 func (i *pointIterator) SeekPrefixGE(
-	prefix, key []byte, trySeekUsingNext bool,
+	prefix, key []byte, flags base.SeekGEFlags,
 ) (*base.InternalKey, []byte) {
-	return i.SeekGE(key, trySeekUsingNext)
+	return i.SeekGE(key, flags)
 }
 
 func (i *pointIterator) SeekLT(key []byte) (*base.InternalKey, []byte) {

--- a/internal/keyspan/internal_iter_shim.go
+++ b/internal/keyspan/internal_iter_shim.go
@@ -50,7 +50,9 @@ func (i *InternalIteratorShim) SeekPrefixGE(
 }
 
 // SeekLT implements (base.InternalIterator).SeekLT.
-func (i *InternalIteratorShim) SeekLT(key []byte) (*base.InternalKey, []byte) {
+func (i *InternalIteratorShim) SeekLT(
+	key []byte, flags base.SeekLTFlags,
+) (*base.InternalKey, []byte) {
 	panic("unimplemented")
 }
 

--- a/internal/keyspan/internal_iter_shim.go
+++ b/internal/keyspan/internal_iter_shim.go
@@ -37,14 +37,14 @@ func (i *InternalIteratorShim) Span() *Span {
 
 // SeekGE implements (base.InternalIterator).SeekGE.
 func (i *InternalIteratorShim) SeekGE(
-	key []byte, trySeekUsingNext bool,
+	key []byte, flags base.SeekGEFlags,
 ) (*base.InternalKey, []byte) {
 	panic("unimplemented")
 }
 
 // SeekPrefixGE implements (base.InternalIterator).SeekPrefixGE.
 func (i *InternalIteratorShim) SeekPrefixGE(
-	prefix, key []byte, trySeekUsingNext bool,
+	prefix, key []byte, flags base.SeekGEFlags,
 ) (*base.InternalKey, []byte) {
 	panic("unimplemented")
 }

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -169,9 +169,11 @@ type FileMetadata struct {
 	//
 	// Protected by DB.mu.
 	MarkedForCompaction bool
-	// HasPointKeys and HasRangeKeys track whether the table contains point and
-	// range keys, respectively.
+	// HasPointKeys tracks whether the table contains point keys (including
+	// RANGEDELs). If a table contains only range deletions, HasPointsKeys is
+	// still true.
 	HasPointKeys bool
+	// HasRangeKeys tracks whether the table contains any range keys.
 	HasRangeKeys bool
 	// smallestSet and largestSet track whether the overall bounds have been set.
 	boundsSet bool

--- a/internal_test.go
+++ b/internal_test.go
@@ -40,8 +40,8 @@ func (i *internalIterAdapter) SeekPrefixGE(prefix, key []byte, flags base.SeekGE
 	return i.update(i.internalIterator.SeekPrefixGE(prefix, key, flags))
 }
 
-func (i *internalIterAdapter) SeekLT(key []byte) bool {
-	return i.update(i.internalIterator.SeekLT(key))
+func (i *internalIterAdapter) SeekLT(key []byte, flags base.SeekLTFlags) bool {
+	return i.update(i.internalIterator.SeekLT(key, flags))
 }
 
 func (i *internalIterAdapter) First() bool {

--- a/internal_test.go
+++ b/internal_test.go
@@ -4,6 +4,8 @@
 
 package pebble
 
+import "github.com/cockroachdb/pebble/internal/base"
+
 // internalIterAdapter adapts the new internalIterator interface which returns
 // the key and value from positioning methods (Seek*, First, Last, Next, Prev)
 // to the old interface which returned a boolean corresponding to Valid. Only
@@ -30,12 +32,12 @@ func (i *internalIterAdapter) String() string {
 	return "internal-iter-adapter"
 }
 
-func (i *internalIterAdapter) SeekGE(key []byte, trySeekUsingNext bool) bool {
-	return i.update(i.internalIterator.SeekGE(key, trySeekUsingNext))
+func (i *internalIterAdapter) SeekGE(key []byte, flags base.SeekGEFlags) bool {
+	return i.update(i.internalIterator.SeekGE(key, flags))
 }
 
-func (i *internalIterAdapter) SeekPrefixGE(prefix, key []byte, trySeekUsingNext bool) bool {
-	return i.update(i.internalIterator.SeekPrefixGE(prefix, key, trySeekUsingNext))
+func (i *internalIterAdapter) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) bool {
+	return i.update(i.internalIterator.SeekPrefixGE(prefix, key, flags))
 }
 
 func (i *internalIterAdapter) SeekLT(key []byte) bool {

--- a/iterator.go
+++ b/iterator.go
@@ -1229,7 +1229,7 @@ func (i *Iterator) SeekLTWithLimit(key []byte, limit []byte) IterValidityState {
 		}
 	}
 	if seekInternalIter {
-		i.iterKey, i.iterValue = i.iter.SeekLT(key)
+		i.iterKey, i.iterValue = i.iter.SeekLT(key, base.SeekLTFlagsNone)
 		i.stats.ReverseSeekCount[InternalIterCall]++
 	}
 	i.findPrevEntry(limit)
@@ -1271,7 +1271,7 @@ func (i *Iterator) Last() bool {
 	i.requiresReposition = false
 	i.stats.ReverseSeekCount[InterfaceCall]++
 	if upperBound := i.opts.GetUpperBound(); upperBound != nil {
-		i.iterKey, i.iterValue = i.iter.SeekLT(upperBound)
+		i.iterKey, i.iterValue = i.iter.SeekLT(upperBound, base.SeekLTFlagsNone)
 		i.stats.ReverseSeekCount[InternalIterCall]++
 	} else {
 		i.iterKey, i.iterValue = i.iter.Last()
@@ -1441,7 +1441,7 @@ func (i *Iterator) PrevWithLimit(limit []byte) IterValidityState {
 			// We're positioned after the last key. Need to reposition to point to
 			// the last key.
 			if upperBound := i.opts.GetUpperBound(); upperBound != nil {
-				i.iterKey, i.iterValue = i.iter.SeekLT(upperBound)
+				i.iterKey, i.iterValue = i.iter.SeekLT(upperBound, base.SeekLTFlagsNone)
 				i.stats.ReverseSeekCount[InternalIterCall]++
 			} else {
 				i.iterKey, i.iterValue = i.iter.Last()

--- a/iterator.go
+++ b/iterator.go
@@ -190,12 +190,11 @@ type Iterator struct {
 	// Following fields used when constructing an iterator stack, eg, in Clone
 	// and SetOptions or when re-fragmenting a batch's range keys/range dels.
 	// Non-nil if this Iterator includes a Batch.
-	batch    *Batch
-	newIters tableNewIters
-	seqNum   uint64
-	// TODO(jackson): Remove db when we no longer require the global arena for
-	// range keys. This reference is only temporary.
-	db *DB
+	batch            *Batch
+	newIters         tableNewIters
+	newIterRangeKey  keyspan.TableNewSpanIter
+	lazyCombinedIter lazyCombinedIter
+	seqNum           uint64
 	// batchSeqNum is used by Iterators over indexed batches to detect when the
 	// underlying batch has been mutated. The batch beneath an indexed batch may
 	// be mutated while the Iterator is open, but new keys are not surfaced
@@ -243,11 +242,10 @@ type iteratorRangeKeyState struct {
 	opts  *IterOptions
 	cmp   base.Compare
 	split base.Split
-	// rangeKeyIter is temporarily an iterator into a single global in-memory
-	// range keys arena. This will need to be reworked when we have a merging
-	// range key iterator.
+	// rangeKeyIter holds the range key iterator stack that iterates over the
+	// merged spans across the entirety of the LSM.
 	rangeKeyIter keyspan.FragmentIterator
-	iter         keyspan.InterleavingIter
+	iiter        keyspan.InterleavingIter
 	// activeMaskSuffix holds the suffix of a range key currently acting as a
 	// mask, hiding point keys with suffixes greater than it. activeMaskSuffix
 	// is only ever non-nil if IterOptions.RangeKeyMasking.Suffix is non-nil.
@@ -302,7 +300,7 @@ func (s bySuffix) Swap(i, j int)      { s.data[i], s.data[j] = s.data[j], s.data
 // The iterator position resulting from a SeekGE or SeekPrefixGE that lands on a
 // straddling range key without a coincident point key is such a position.
 func (i *Iterator) isEphemeralPosition() bool {
-	return i.opts.rangeKeys() && i.rangeKey.rangeKeyOnly && !i.equal(i.rangeKey.start, i.key)
+	return i.opts.rangeKeys() && i.rangeKey != nil && i.rangeKey.rangeKeyOnly && !i.equal(i.rangeKey.start, i.key)
 }
 
 type lastPositioningOpKind int8
@@ -377,7 +375,7 @@ type readSampling struct {
 func (i *Iterator) findNextEntry(limit []byte) {
 	i.iterValidityState = IterExhausted
 	i.pos = iterPosCurForward
-	if i.opts.rangeKeys() {
+	if i.opts.rangeKeys() && i.rangeKey != nil {
 		i.rangeKey.rangeKeyOnly = false
 	}
 
@@ -674,7 +672,7 @@ func (i *Iterator) sampleRead() {
 func (i *Iterator) findPrevEntry(limit []byte) {
 	i.iterValidityState = IterExhausted
 	i.pos = iterPosCurReverse
-	if i.opts.rangeKeys() {
+	if i.opts.rangeKeys() && i.rangeKey != nil {
 		i.rangeKey.rangeKeyOnly = false
 	}
 
@@ -1479,10 +1477,10 @@ type RangeKeyData struct {
 // This awkwardness exists because range keys are interleaved at their inclusive
 // start positions. Note that limit is inclusive.
 func (i *Iterator) rangeKeyWithinLimit(limit []byte) bool {
-	if !i.opts.rangeKeys() {
+	if i.rangeKey == nil || !i.opts.rangeKeys() {
 		return false
 	}
-	s := i.rangeKey.iter.Span()
+	s := i.rangeKey.iiter.Span()
 	if s == nil {
 		// If there are no covering range keys, it is safe to to pause
 		// immediately.
@@ -1579,10 +1577,10 @@ func (i *iteratorRangeKeyState) SkipPoint(userKey []byte) bool {
 // buffers, so it must only be used if the underlying iterator's position
 // matches the top-level iterator (eg, i.pos = iterPosCur*).
 func (i *Iterator) setRangeKey() {
-	if !i.opts.rangeKeys() {
+	if i.rangeKey == nil || !i.opts.rangeKeys() {
 		return
 	}
-	s := i.rangeKey.iter.Span()
+	s := i.rangeKey.iiter.Span()
 	if s == nil {
 		i.rangeKey.hasRangeKey = false
 		if i.rangeKey.start != nil {
@@ -1618,10 +1616,10 @@ func (i *Iterator) setRangeKey() {
 // circumstances the underlying iterator will be advanced to the next user key
 // before returning to the user.
 func (i *Iterator) saveRangeKey() {
-	if !i.opts.rangeKeys() {
+	if i.rangeKey == nil || !i.opts.rangeKeys() {
 		return
 	}
-	s := i.rangeKey.iter.Span()
+	s := i.rangeKey.iiter.Span()
 	if s == nil {
 		i.rangeKey.hasRangeKey = false
 		return
@@ -1661,7 +1659,7 @@ func (i *Iterator) HasPointAndRange() (hasPoint, hasRange bool) {
 	if i.opts.KeyTypes == IterKeyTypePointsOnly {
 		return true, false
 	}
-	return !i.rangeKey.rangeKeyOnly, i.rangeKey.hasRangeKey
+	return i.rangeKey == nil || !i.rangeKey.rangeKeyOnly, i.rangeKey != nil && i.rangeKey.hasRangeKey
 }
 
 // RangeBounds returns the start (inclusive) and end (exclusive) bounds of the
@@ -1669,7 +1667,7 @@ func (i *Iterator) HasPointAndRange() (hasPoint, hasRange bool) {
 // bounds if there is no range key covering the current iterator position, or
 // the iterator is not configured to surface range keys.
 func (i *Iterator) RangeBounds() (start, end []byte) {
-	if !i.opts.rangeKeys() || !i.rangeKey.hasRangeKey {
+	if i.rangeKey == nil || !i.opts.rangeKeys() || !i.rangeKey.hasRangeKey {
 		return nil, nil
 	}
 	return i.rangeKey.start, i.rangeKey.end
@@ -1695,7 +1693,7 @@ func (i *Iterator) Value() []byte {
 // current iterator position. The range bounds may be retrieved separately
 // through Iterator.RangeBounds().
 func (i *Iterator) RangeKeys() []RangeKeyData {
-	if !i.opts.rangeKeys() || !i.rangeKey.hasRangeKey {
+	if i.rangeKey == nil || !i.opts.rangeKeys() || !i.rangeKey.hasRangeKey {
 		return nil
 	}
 	return i.rangeKey.keys.data
@@ -1942,8 +1940,11 @@ func (i *Iterator) SetOptions(o *IterOptions) {
 		i.rangeKey = nil
 	}
 
-	// If the iterator is backed by a batch that's been mutated, refresh it
-	// and invalidate the iterator to prevent seek-using-next optimizations.
+	// If the iterator is backed by a batch that's been mutated, refresh its
+	// existing point and range-key iterators, and invalidate the iterator to
+	// prevent seek-using-next optimizations. If we don't yet have a point-key
+	// iterator or range-key iterator but we require one, it'll be created in
+	// the slow path that reconstructs the iterator in finishInitializingIter.
 	if i.batch != nil {
 		nextBatchSeqNum := (uint64(len(i.batch.data)) | base.InternalKeySeqNumBatch)
 		if nextBatchSeqNum != i.batchSeqNum {
@@ -2003,21 +2004,38 @@ func (i *Iterator) SetOptions(o *IterOptions) {
 		}
 	}
 
+	// Reset combinedIterState.initialized in case the iterator key types
+	// changed. If there's already a range key iterator stack, the combined
+	// iterator is already initialized.  Additionally, if the iterator is not
+	// configured to include range keys, mark it as initialized to signal that
+	// lower level iterators should not trigger a switch to combined iteration.
+	i.lazyCombinedIter.combinedIterState = combinedIterState{
+		initialized: i.rangeKey != nil || !i.opts.rangeKeys(),
+	}
+
 	boundsEqual := ((i.opts.LowerBound == nil) == (o.LowerBound == nil)) &&
 		((i.opts.UpperBound == nil) == (o.UpperBound == nil)) &&
 		i.equal(i.opts.LowerBound, o.LowerBound) &&
 		i.equal(i.opts.UpperBound, o.UpperBound)
 
-	if (i.pointIter != nil || !i.opts.pointKeys()) &&
-		(i.rangeKey != nil || !i.opts.rangeKeys()) &&
-		boundsEqual && o.KeyTypes == i.opts.KeyTypes &&
+	if boundsEqual && o.KeyTypes == i.opts.KeyTypes &&
+		(i.pointIter != nil || !i.opts.pointKeys()) &&
+		(i.rangeKey != nil || !i.opts.rangeKeys() || i.opts.KeyTypes == IterKeyTypePointsAndRanges) &&
 		i.equal(o.RangeKeyMasking.Suffix, i.opts.RangeKeyMasking.Suffix) &&
 		o.UseL6Filters == i.opts.UseL6Filters {
-		// Fast path. The options are identical. This preserves the
-		// Seek-using-Next optimizations as long as the iterator wasn't
-		// already invalidated up above.
-		return
+		// The options are identical, so we can likely use the fast path. In
+		// addition to all the above constraints, we cannot use the fast path if
+		// configured to perform lazy combined iteration but an indexed batch
+		// used by the iterator now contains range keys. Lazy combined iteration
+		// is not compatible with batch range keys because we always need to
+		// merge the batch's range keys into iteration.
+		if i.rangeKey != nil || !i.opts.rangeKeys() || i.batch == nil || i.batch.countRangeKeys == 0 {
+			// Fast path. This preserves the Seek-using-Next optimizations as
+			// long as the iterator wasn't already invalidated up above.
+			return
+		}
 	}
+	// Slow path.
 
 	// The options changed. Save the new ones to i.opts.
 	if boundsEqual {
@@ -2156,8 +2174,8 @@ func (i *Iterator) Clone(opts CloneOptions) (*Iterator, error) {
 		batch:               i.batch,
 		batchSeqNum:         i.batchSeqNum,
 		newIters:            i.newIters,
+		newIterRangeKey:     i.newIterRangeKey,
 		seqNum:              i.seqNum,
-		db:                  i.db,
 	}
 	dbi.saveBounds(dbi.opts.LowerBound, dbi.opts.UpperBound)
 

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -100,7 +100,7 @@ func (f *fakeIter) SeekPrefixGE(
 	return f.SeekGE(key, flags)
 }
 
-func (f *fakeIter) SeekLT(key []byte) (*InternalKey, []byte) {
+func (f *fakeIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, []byte) {
 	f.valid = false
 	for f.index = len(f.keys) - 1; f.index >= 0; f.index-- {
 		if DefaultComparer.Compare(key, f.key().UserKey) > 0 {
@@ -279,8 +279,8 @@ func (i *invalidatingIter) SeekPrefixGE(
 	return i.update(i.iter.SeekPrefixGE(prefix, key, flags))
 }
 
-func (i *invalidatingIter) SeekLT(key []byte) (*InternalKey, []byte) {
-	return i.update(i.iter.SeekLT(key))
+func (i *invalidatingIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, []byte) {
+	return i.update(i.iter.SeekLT(key, flags))
 }
 
 func (i *invalidatingIter) First() (*InternalKey, []byte) {
@@ -1048,13 +1048,13 @@ func (i *errorSeekIter) SeekPrefixGE(
 	return i.internalIterator.SeekPrefixGE(prefix, key, flags)
 }
 
-func (i *errorSeekIter) SeekLT(key []byte) (*InternalKey, []byte) {
+func (i *errorSeekIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, []byte) {
 	if i.tryInjectError() {
 		return nil, nil
 	}
 	i.err = nil
 	i.seekCount++
-	return i.internalIterator.SeekLT(key)
+	return i.internalIterator.SeekLT(key, flags)
 }
 
 func (i *errorSeekIter) tryInjectError() bool {

--- a/level_iter.go
+++ b/level_iter.go
@@ -411,7 +411,7 @@ func (l *levelIter) verify(key *InternalKey, val []byte) (*InternalKey, []byte) 
 	return key, val
 }
 
-func (l *levelIter) SeekGE(key []byte, trySeekUsingNext bool) (*InternalKey, []byte) {
+func (l *levelIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, []byte) {
 	l.err = nil // clear cached iteration error
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
@@ -427,16 +427,16 @@ func (l *levelIter) SeekGE(key []byte, trySeekUsingNext bool) (*InternalKey, []b
 	if loadFileIndicator == newFileLoaded {
 		// File changed, so l.iter has changed, and that iterator is not
 		// positioned appropriately.
-		trySeekUsingNext = false
+		flags = flags.DisableTrySeekUsingNext()
 	}
-	if ikey, val := l.iter.SeekGE(key, trySeekUsingNext); ikey != nil {
+	if ikey, val := l.iter.SeekGE(key, flags); ikey != nil {
 		return l.verify(ikey, val)
 	}
 	return l.verify(l.skipEmptyFileForward())
 }
 
 func (l *levelIter) SeekPrefixGE(
-	prefix, key []byte, trySeekUsingNext bool,
+	prefix, key []byte, flags base.SeekGEFlags,
 ) (*base.InternalKey, []byte) {
 	l.err = nil // clear cached iteration error
 	if l.boundaryContext != nil {
@@ -453,9 +453,9 @@ func (l *levelIter) SeekPrefixGE(
 	if loadFileIndicator == newFileLoaded {
 		// File changed, so l.iter has changed, and that iterator is not
 		// positioned appropriately.
-		trySeekUsingNext = false
+		flags = flags.DisableTrySeekUsingNext()
 	}
-	if key, val := l.iter.SeekPrefixGE(prefix, key, trySeekUsingNext); key != nil {
+	if key, val := l.iter.SeekPrefixGE(prefix, key, flags); key != nil {
 		return l.verify(key, val)
 	}
 	// When SeekPrefixGE returns nil, we have not necessarily reached the end of
@@ -485,13 +485,13 @@ func (l *levelIter) SeekPrefixGE(
 		}
 		return l.verify(l.largestBoundary, nil)
 	}
-	// It is possible that we are here because bloom filter matching failed.
-	// In that case it is likely that all keys matching the prefix are wholly
+	// It is possible that we are here because bloom filter matching failed.  In
+	// that case it is likely that all keys matching the prefix are wholly
 	// within the current file and cannot be in the subsequent file. In that
 	// case we don't want to go to the next file, since loading and seeking in
 	// there has some cost. Additionally, for sparse key spaces, loading the
-	// next file will defeat the optimization for the next SeekPrefixGE that
-	// is called with trySeekUsingNext=true, since for sparse key spaces it is
+	// next file will defeat the optimization for the next SeekPrefixGE that is
+	// called with flags.TrySeekUsingNext(), since for sparse key spaces it is
 	// likely that the next key will also be contained in the current file.
 	if n := l.split(l.iterFile.LargestPointKey.UserKey); l.cmp(prefix, l.iterFile.LargestPointKey.UserKey[:n]) < 0 {
 		return nil, nil

--- a/level_iter.go
+++ b/level_iter.go
@@ -499,7 +499,7 @@ func (l *levelIter) SeekPrefixGE(
 	return l.verify(l.skipEmptyFileForward())
 }
 
-func (l *levelIter) SeekLT(key []byte) (*InternalKey, []byte) {
+func (l *levelIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, []byte) {
 	l.err = nil // clear cached iteration error
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
@@ -511,7 +511,7 @@ func (l *levelIter) SeekLT(key []byte) (*InternalKey, []byte) {
 	if l.loadFile(l.findFileLT(key), -1) == noFileLoaded {
 		return nil, nil
 	}
-	if key, val := l.iter.SeekLT(key); key != nil {
+	if key, val := l.iter.SeekLT(key, flags); key != nil {
 		return l.verify(key, val)
 	}
 	return l.verify(l.skipEmptyFileBackward())

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -392,8 +392,8 @@ func (i *levelIterTestIter) SeekPrefixGE(
 	return i.rangeDelSeek(key, ikey, val, 1)
 }
 
-func (i *levelIterTestIter) SeekLT(key []byte) (*InternalKey, []byte) {
-	ikey, val := i.levelIter.SeekLT(key)
+func (i *levelIterTestIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, []byte) {
+	ikey, val := i.levelIter.SeekLT(key, flags)
 	return i.rangeDelSeek(key, ikey, val, -1)
 }
 

--- a/mem_table.go
+++ b/mem_table.go
@@ -257,6 +257,10 @@ func (m *memTable) newRangeKeyIter(*IterOptions) keyspan.FragmentIterator {
 	return keyspan.NewIter(m.cmp, rangeKeys)
 }
 
+func (m *memTable) containsRangeKeys() bool {
+	return m.rangeKeys.count > 0
+}
+
 func (m *memTable) availBytes() uint32 {
 	a := m.skl.Arena()
 	if atomic.LoadInt32(&m.writerRefs) == 1 {

--- a/mem_table_test.go
+++ b/mem_table_test.go
@@ -28,7 +28,7 @@ import (
 // not contain the key.
 func (m *memTable) get(key []byte) (value []byte, err error) {
 	it := m.skl.NewIter(nil, nil)
-	ikey, val := it.SeekGE(key, false /* trySeekUsingNext */)
+	ikey, val := it.SeekGE(key, base.SeekGEFlagsNone)
 	if ikey == nil {
 		return nil, ErrNotFound
 	}
@@ -126,7 +126,7 @@ func TestMemTableBasic(t *testing.T) {
 	}
 	// Check an iterator.
 	s, x := "", newInternalIterAdapter(m.newIter(nil))
-	for valid := x.SeekGE([]byte("mango"), false); valid; valid = x.Next() {
+	for valid := x.SeekGE([]byte("mango"), base.SeekGEFlagsNone); valid; valid = x.Next() {
 		s += fmt.Sprintf("%s/%s.", x.Key().UserKey, x.Value())
 	}
 	if want := "peach/yellow.plum/purple."; s != want {
@@ -228,7 +228,7 @@ func TestMemTable1000Entries(t *testing.T) {
 		"507",
 	}
 	x := newInternalIterAdapter(m0.newIter(nil))
-	x.SeekGE([]byte(wants[0]), false)
+	x.SeekGE([]byte(wants[0]), base.SeekGEFlagsNone)
 	for _, want := range wants {
 		if !x.Valid() {
 			t.Fatalf("iter: next failed, want=%q", want)
@@ -411,7 +411,7 @@ func BenchmarkMemTableIterSeekGE(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		iter.SeekGE(keys[rng.Intn(len(keys))], false /* trySeekUsingNext */)
+		iter.SeekGE(keys[rng.Intn(len(keys))], base.SeekGEFlagsNone)
 	}
 }
 

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -370,7 +370,7 @@ func (m *mergingIter) initMaxRangeDelIters(oldTopLevel int) {
 func (m *mergingIter) switchToMinHeap() {
 	if m.heap.len() == 0 {
 		if m.lower != nil {
-			m.SeekGE(m.lower, false /* trySeekUsingNext */)
+			m.SeekGE(m.lower, base.SeekGEFlagsNone)
 		} else {
 			m.First()
 		}
@@ -423,7 +423,7 @@ func (m *mergingIter) switchToMinHeap() {
 			l.iterKey.IsExclusiveSentinel() &&
 			m.heap.cmp(l.iterKey.UserKey, m.lower) <= 0) {
 			if m.lower != nil {
-				l.iterKey, l.iterValue = l.iter.SeekGE(m.lower, false /* trySeekUsingNext */)
+				l.iterKey, l.iterValue = l.iter.SeekGE(m.lower, base.SeekGEFlagsNone)
 			} else {
 				l.iterKey, l.iterValue = l.iter.First()
 			}
@@ -444,7 +444,7 @@ func (m *mergingIter) switchToMinHeap() {
 	// levelIter's invariants. See the example in the for loop above.
 	if m.lower != nil && cur.isSyntheticIterBoundsKey && cur.iterKey.IsExclusiveSentinel() &&
 		m.heap.cmp(cur.iterKey.UserKey, m.lower) <= 0 {
-		cur.iterKey, cur.iterValue = cur.iter.SeekGE(m.lower, false /* trySeekUsingNext */)
+		cur.iterKey, cur.iterValue = cur.iter.SeekGE(m.lower, base.SeekGEFlagsNone)
 	} else {
 		cur.iterKey, cur.iterValue = cur.iter.Next()
 	}
@@ -644,8 +644,8 @@ func (m *mergingIter) isNextEntryDeleted(item *mergingIterItem) bool {
 				}
 				// This seek is not directly due to a SeekGE call, so we don't
 				// know enough about the underlying iterator positions, and so
-				// we set trySeekUsingNext=false.
-				m.seekGE(seekKey, item.index, false /* trySeekUsingNext */)
+				// we keep seek optiomizations disabled.
+				m.seekGE(seekKey, item.index, base.SeekGEFlagsNone)
 				return true
 			}
 			if l.tombstone.CoversAt(m.snapshot, item.key.SeqNum()) {
@@ -850,7 +850,7 @@ func (m *mergingIter) findPrevEntry() (*InternalKey, []byte) {
 }
 
 // Seeks levels >= level to >= key. Additionally uses range tombstones to extend the seeks.
-func (m *mergingIter) seekGE(key []byte, level int, trySeekUsingNext bool) {
+func (m *mergingIter) seekGE(key []byte, level int, flags base.SeekGEFlags) {
 	// When seeking, we can use tombstones to adjust the key we seek to on each
 	// level. Consider the series of range tombstones:
 	//
@@ -879,9 +879,9 @@ func (m *mergingIter) seekGE(key []byte, level int, trySeekUsingNext bool) {
 
 		l := &m.levels[level]
 		if m.prefix != nil {
-			l.iterKey, l.iterValue = l.iter.SeekPrefixGE(m.prefix, key, trySeekUsingNext)
+			l.iterKey, l.iterValue = l.iter.SeekPrefixGE(m.prefix, key, flags)
 		} else {
-			l.iterKey, l.iterValue = l.iter.SeekGE(key, trySeekUsingNext)
+			l.iterKey, l.iterValue = l.iter.SeekGE(key, flags)
 		}
 
 		if rangeDelIter := l.rangeDelIter; rangeDelIter != nil {
@@ -933,10 +933,10 @@ func (m *mergingIter) String() string {
 // SeekGE implements base.InternalIterator.SeekGE. Note that SeekGE only checks
 // the upper bound. It is up to the caller to ensure that key is greater than
 // or equal to the lower bound.
-func (m *mergingIter) SeekGE(key []byte, trySeekUsingNext bool) (*InternalKey, []byte) {
+func (m *mergingIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, []byte) {
 	m.err = nil // clear cached iteration error
 	m.prefix = nil
-	m.seekGE(key, 0 /* start level */, trySeekUsingNext)
+	m.seekGE(key, 0 /* start level */, flags)
 	return m.findNextEntry()
 }
 
@@ -944,11 +944,11 @@ func (m *mergingIter) SeekGE(key []byte, trySeekUsingNext bool) (*InternalKey, [
 // SeekPrefixGE only checks the upper bound. It is up to the caller to ensure
 // that key is greater than or equal to the lower bound.
 func (m *mergingIter) SeekPrefixGE(
-	prefix, key []byte, trySeekUsingNext bool,
+	prefix, key []byte, flags base.SeekGEFlags,
 ) (*base.InternalKey, []byte) {
 	m.err = nil // clear cached iteration error
 	m.prefix = prefix
-	m.seekGE(key, 0 /* start level */, trySeekUsingNext)
+	m.seekGE(key, 0 /* start level */, flags)
 	return m.findNextEntry()
 }
 

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -355,7 +355,7 @@ func BenchmarkMergingIterSeekGE(b *testing.B) {
 
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {
-								m.SeekGE(keys[rng.Intn(len(keys))], false /* trySeekUsingNext */)
+								m.SeekGE(keys[rng.Intn(len(keys))], base.SeekGEFlagsNone)
 							}
 							m.Close()
 						})
@@ -615,7 +615,7 @@ func BenchmarkMergingIterSeqSeekGEWithBounds(b *testing.B) {
 					pos := i % (keyCount - 1)
 					m.SetBounds(keys[pos], keys[pos+1])
 					// SeekGE will return keys[pos].
-					k, _ := m.SeekGE(keys[pos], false /* trySeekUsingNext */)
+					k, _ := m.SeekGE(keys[pos], base.SeekGEFlagsNone)
 					for k != nil {
 						k, _ = m.Next()
 					}
@@ -645,17 +645,20 @@ func BenchmarkMergingIterSeqSeekPrefixGE(b *testing.B) {
 					keyCount := len(keys)
 					pos := 0
 
-					m.SeekPrefixGE(keys[pos], keys[pos], false)
+					m.SeekPrefixGE(keys[pos], keys[pos], base.SeekGEFlagsNone)
 					b.ResetTimer()
 					for i := 0; i < b.N; i++ {
 						pos += skip
-						trySeekUsingNext := useNext
+						var flags base.SeekGEFlags
+						if useNext {
+							flags = flags.EnableTrySeekUsingNext()
+						}
 						if pos >= keyCount {
 							pos = 0
-							trySeekUsingNext = false
+							flags = flags.DisableTrySeekUsingNext()
 						}
 						// SeekPrefixGE will return keys[pos].
-						m.SeekPrefixGE(keys[pos], keys[pos], trySeekUsingNext)
+						m.SeekPrefixGE(keys[pos], keys[pos], flags)
 					}
 					b.StopTimer()
 					m.Close()

--- a/range_keys.go
+++ b/range_keys.go
@@ -5,45 +5,47 @@
 package pebble
 
 import (
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 )
 
-func (d *DB) newRangeKeyIter(
-	it *Iterator, seqNum, batchSeqNum uint64, batch *Batch, readState *readState,
-) keyspan.FragmentIterator {
-	it.rangeKey.rangeKeyIter = it.rangeKey.iterConfig.Init(d.cmp, seqNum)
+// constructRangeKeyIter constructs the range-key iterator stack, populating
+// i.rangeKey.rangeKeyIter with the resulting iterator.
+func (i *Iterator) constructRangeKeyIter() {
+	i.rangeKey.rangeKeyIter = i.rangeKey.iterConfig.Init(i.cmp, i.seqNum)
 
 	// If there's an indexed batch with range keys, include it.
-	if batch != nil {
-		if batch.index == nil {
-			it.rangeKey.iterConfig.AddLevel(newErrorKeyspanIter(ErrNotIndexed))
+	if i.batch != nil {
+		if i.batch.index == nil {
+			i.rangeKey.iterConfig.AddLevel(newErrorKeyspanIter(ErrNotIndexed))
 		} else {
 			// Only include the batch's range key iterator if it has any keys.
 			// NB: This can force reconstruction of the rangekey iterator stack
 			// in SetOptions if subsequently range keys are added. See
 			// SetOptions.
-			if batch.countRangeKeys > 0 {
-				batch.initRangeKeyIter(&it.opts, &it.batchRangeKeyIter, batchSeqNum)
-				it.rangeKey.iterConfig.AddLevel(&it.batchRangeKeyIter)
+			if i.batch.countRangeKeys > 0 {
+				i.batch.initRangeKeyIter(&i.opts, &i.batchRangeKeyIter, i.batchSeqNum)
+				i.rangeKey.iterConfig.AddLevel(&i.batchRangeKeyIter)
 			}
 		}
 	}
 
 	// Next are the flushables: memtables and large batches.
-	for i := len(readState.memtables) - 1; i >= 0; i-- {
-		mem := readState.memtables[i]
+	for j := len(i.readState.memtables) - 1; j >= 0; j-- {
+		mem := i.readState.memtables[j]
 		// We only need to read from memtables which contain sequence numbers older
 		// than seqNum.
-		if logSeqNum := mem.logSeqNum; logSeqNum >= seqNum {
+		if logSeqNum := mem.logSeqNum; logSeqNum >= i.seqNum {
 			continue
 		}
-		if rki := mem.newRangeKeyIter(&it.opts); rki != nil {
-			it.rangeKey.iterConfig.AddLevel(rki)
+		if rki := mem.newRangeKeyIter(&i.opts); rki != nil {
+			i.rangeKey.iterConfig.AddLevel(rki)
 		}
 	}
 
-	current := readState.current
+	current := i.readState.current
 	// Next are the file levels: L0 sub-levels followed by lower levels.
 	//
 	// Add file-specific iterators for L0 files containing range keys. This is less
@@ -53,13 +55,13 @@ func (d *DB) newRangeKeyIter(
 	// files and then using it here.
 	iter := current.RangeKeyLevels[0].Iter()
 	for f := iter.First(); f != nil; f = iter.Next() {
-		spanIterOpts := &keyspan.SpanIterOptions{RangeKeyFilters: it.opts.RangeKeyFilters}
-		spanIter, err := d.tableNewRangeKeyIter(f, spanIterOpts)
+		spanIterOpts := &keyspan.SpanIterOptions{RangeKeyFilters: i.opts.RangeKeyFilters}
+		spanIter, err := i.newIterRangeKey(f, spanIterOpts)
 		if err != nil {
-			it.rangeKey.iterConfig.AddLevel(&errorKeyspanIter{err: err})
+			i.rangeKey.iterConfig.AddLevel(&errorKeyspanIter{err: err})
 			continue
 		}
-		it.rangeKey.iterConfig.AddLevel(spanIter)
+		i.rangeKey.iterConfig.AddLevel(spanIter)
 	}
 
 	// Add level iterators for the non-empty non-L0 levels.
@@ -67,12 +69,279 @@ func (d *DB) newRangeKeyIter(
 		if current.RangeKeyLevels[level].Empty() {
 			continue
 		}
-		li := it.rangeKey.iterConfig.NewLevelIter()
-		spanIterOpts := keyspan.SpanIterOptions{RangeKeyFilters: it.opts.RangeKeyFilters}
-
-		li.Init(spanIterOpts, it.cmp, d.tableNewRangeKeyIter, current.RangeKeyLevels[level].Iter(),
-			manifest.Level(level), d.opts.Logger, manifest.KeyTypeRange)
-		it.rangeKey.iterConfig.AddLevel(li)
+		li := i.rangeKey.iterConfig.NewLevelIter()
+		spanIterOpts := keyspan.SpanIterOptions{RangeKeyFilters: i.opts.RangeKeyFilters}
+		li.Init(spanIterOpts, i.cmp, i.newIterRangeKey, current.RangeKeyLevels[level].Iter(),
+			manifest.Level(level), i.opts.logger, manifest.KeyTypeRange)
+		i.rangeKey.iterConfig.AddLevel(li)
 	}
-	return it.rangeKey.rangeKeyIter
+}
+
+// lazyCombinedIter implements the internalIterator interface, wrapping a
+// pointIter. It requires the pointIter's the levelIters be configured with
+// pointers to its combinedIterState. When the levelIter observes a file
+// containing a range key, the lazyCombinedIter constructs the combined
+// range+point key iterator stack and switches to it.
+type lazyCombinedIter struct {
+	// parent holds a pointer to the root *pebble.Iterator containing this
+	// iterator. It's used to mutate the internalIterator in use when switching
+	// to combined iteration.
+	parent            *Iterator
+	pointIter         internalIteratorWithStats
+	combinedIterState combinedIterState
+}
+
+// combinedIterState encapsulates the current state of combined iteration.
+// Various low-level iterators (mergingIter, leveliter) hold pointers to the
+// *pebble.Iterator's combinedIterState. This allows them to check whether or
+// not they must monitor for files containing range keys (!initialized), or not.
+//
+// When !initialized, low-level iterators watch for files containing range keys.
+// When one is discovered, they set triggered=true and key to the smallest
+// (forward direction) or largest (reverse direction) range key that's been
+// observed.
+type combinedIterState struct {
+	// key holds the smallest (forward direction) or largest (backward
+	// direction) user key from a range key bound discovered during the iterator
+	// operation that triggered the switch to combined iteration.
+	//
+	// Slices stored here must be stable. This is possible because callers pass
+	// a Smallest/Largest bound from a fileMetadata, which are immutable. A key
+	// slice's bytes must not be overwritten.
+	key         []byte
+	triggered   bool
+	initialized bool
+}
+
+// Assert that *lazyCombinedIter implements internalIterator.
+var _ internalIterator = (*lazyCombinedIter)(nil)
+
+// initCombinedIteration is invoked after a pointIter positioning operation
+// resulted in i.combinedIterState.triggered=true.
+//
+// The `dir` parameter is `+1` or `-1` indicating forward iteration or backward
+// iteration respectively.
+//
+// The `pointKey` and `pointValue` parameters provide the new point key-value
+// pair that the iterator was just positioned to. The combined iterator should
+// be seeded with this point key-value pair and return the smaller (forward
+// iteration) or largest (backward iteration) of the two.
+//
+// The `seekKey` parameter is non-nil only if the iterator operation that
+// triggered the switch to combined iteration was a SeekGE, SeekPrefixGE or
+// SeekLT. It provides the seek key supplied and is used to seek the range-key
+// iterator using the same key. This is necessary for SeekGE/SeekPrefixGE
+// operations that land in the middle of a range key and must truncate to the
+// user-provided seek key.
+func (i *lazyCombinedIter) initCombinedIteration(
+	dir int8, pointKey *InternalKey, pointValue []byte, seekKey []byte,
+) (*InternalKey, []byte) {
+	// Invariant: i.parent.rangeKey is nil.
+	// Invariant: !i.combinedIterState.initialized.
+	if invariants.Enabled {
+		if i.combinedIterState.initialized {
+			panic("pebble: combined iterator already initialized")
+		}
+		if i.parent.rangeKey != nil {
+			panic("pebble: iterator already has a range-key iterator stack")
+		}
+	}
+
+	// An operation on the point iterator observed a file containing range keys,
+	// so we must switch to combined interleaving iteration. First, construct
+	// the range key iterator stack. It must not exist, otherwise we'd already
+	// be performing combined iteration.
+	i.parent.rangeKey = iterRangeKeyStateAllocPool.Get().(*iteratorRangeKeyState)
+	i.parent.rangeKey.init(i.parent.cmp, i.parent.split, &i.parent.opts)
+	i.parent.constructRangeKeyIter()
+
+	// Initialize the Iterator's interleaving iterator.
+	i.parent.rangeKey.iiter.Init(
+		i.parent.cmp, i.parent.pointIter, i.parent.rangeKey.rangeKeyIter,
+		i.parent.rangeKey, i.parent.opts.LowerBound, i.parent.opts.UpperBound)
+
+	// We need to determine the key to seek the range key iterator to. If
+	// seekKey is not nil, the user-initiated operation that triggered the
+	// switch to combined iteration was itself a seek, and we can use that key.
+	// Otherwise, a First/Last or relative positioning operation triggered the
+	// switch to combined iteration.
+	//
+	// The levelIter that observed a file containing range keys populated
+	// combinedIterState.key with the smallest (forward) or largest (backward)
+	// range key it observed. If multiple levelIters observed files with range
+	// keys during the same operation on the mergingIter, combinedIterState.key
+	// is the smallest [during forward iteration; largest in reverse iteration]
+	// such key.
+	if seekKey == nil {
+		// Use the levelIter-populated key.
+		seekKey = i.combinedIterState.key
+
+		// We may need to adjust the levelIter-populated seek key to the
+		// surfaced point key. If the key observed is beyond [in the iteration
+		// direction] the current point key, there may still exist a range key
+		// at an earlier key. Consider the following example:
+		//
+		//   L5:  000003:[bar.DEL.5, foo.RANGEKEYSET.9]
+		//   L6:  000001:[bar.SET.2] 000002:[bax.RANGEKEYSET.8]
+		//
+		// A call to First() seeks the levels to files L5.000003 and L6.000001.
+		// The L5 levelIter observes that L5.000003 contains the range key with
+		// start key `foo`, and triggers a switch to combined iteration, setting
+		// `combinedIterState.key` = `foo`.
+		//
+		// The L6 levelIter did not observe the true first range key
+		// (bax.RANGEKEYSET.8), because it appears in a later sstable. When the
+		// combined iterator is initialized, the range key iterator must be
+		// seeked to a key that will find `bax`. To accomplish this, we seek the
+		// key instead to `bar`. It is guaranteed that no range key exists
+		// earlier than `bar`, otherwise a levelIter would've observed it and
+		// set `combinedIterState.key` to its start key.
+		if pointKey != nil {
+			if dir == +1 && i.parent.cmp(i.combinedIterState.key, pointKey.UserKey) > 0 {
+				seekKey = pointKey.UserKey
+			} else if dir == -1 && i.parent.cmp(seekKey, pointKey.UserKey) < 0 {
+				seekKey = pointKey.UserKey
+			}
+		}
+	}
+
+	// Set the parent's primary iterator to point to the combined, interleaving
+	// iterator that's now initialized with our current state.
+	i.parent.iter = &i.parent.rangeKey.iiter
+	i.combinedIterState.initialized = true
+	i.combinedIterState.key = nil
+
+	// All future iterator operations will go directly through the combined
+	// iterator.
+	//
+	// Initialize the interleaving iterator. We pass the point key-value pair so
+	// that the interleaving iterator knows where the point iterator is
+	// positioned. Additionally, we pass the seek key to which the range-key
+	// iterator should be seeked in order to initialize its position.
+	//
+	// In the forward direction (invert for backwards), the seek key is a key
+	// guaranteed to find the smallest range key that's greater than the last
+	// key the iterator returned. The range key may be less than pointKey, in
+	// which case the range key will be interleaved next instead of the point
+	// key.
+	if dir == +1 {
+		return i.parent.rangeKey.iiter.InitSeekGE(seekKey, pointKey, pointValue)
+	}
+	return i.parent.rangeKey.iiter.InitSeekLT(seekKey, pointKey, pointValue)
+}
+
+func (i *lazyCombinedIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, []byte) {
+	if i.combinedIterState.initialized {
+		return i.parent.rangeKey.iiter.SeekGE(key, flags)
+	}
+	k, v := i.pointIter.SeekGE(key, flags)
+	if i.combinedIterState.triggered {
+		return i.initCombinedIteration(+1, k, v, key)
+	}
+	return k, v
+}
+
+func (i *lazyCombinedIter) SeekPrefixGE(
+	prefix, key []byte, flags base.SeekGEFlags,
+) (*InternalKey, []byte) {
+	if i.combinedIterState.initialized {
+		return i.parent.rangeKey.iiter.SeekPrefixGE(prefix, key, flags)
+	}
+	k, v := i.pointIter.SeekPrefixGE(prefix, key, flags)
+	if i.combinedIterState.triggered {
+		return i.initCombinedIteration(+1, k, v, key)
+	}
+	return k, v
+}
+
+func (i *lazyCombinedIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, []byte) {
+	if i.combinedIterState.initialized {
+		return i.parent.rangeKey.iiter.SeekLT(key, flags)
+	}
+	k, v := i.pointIter.SeekLT(key, flags)
+	if i.combinedIterState.triggered {
+		return i.initCombinedIteration(-1, k, v, key)
+	}
+	return k, v
+}
+
+func (i *lazyCombinedIter) First() (*InternalKey, []byte) {
+	if i.combinedIterState.initialized {
+		return i.parent.rangeKey.iiter.First()
+	}
+	k, v := i.pointIter.First()
+	if i.combinedIterState.triggered {
+		return i.initCombinedIteration(+1, k, v, nil)
+	}
+	return k, v
+}
+
+func (i *lazyCombinedIter) Last() (*InternalKey, []byte) {
+	if i.combinedIterState.initialized {
+		return i.parent.rangeKey.iiter.Last()
+	}
+	k, v := i.pointIter.Last()
+	if i.combinedIterState.triggered {
+		return i.initCombinedIteration(-1, k, v, nil)
+	}
+	return k, v
+}
+
+func (i *lazyCombinedIter) Next() (*InternalKey, []byte) {
+	if i.combinedIterState.initialized {
+		return i.parent.rangeKey.iiter.Next()
+	}
+	k, v := i.pointIter.Next()
+	if i.combinedIterState.triggered {
+		return i.initCombinedIteration(+1, k, v, nil)
+	}
+	return k, v
+}
+
+func (i *lazyCombinedIter) Prev() (*InternalKey, []byte) {
+	if i.combinedIterState.initialized {
+		return i.parent.rangeKey.iiter.Prev()
+	}
+	k, v := i.pointIter.Prev()
+	if i.combinedIterState.triggered {
+		return i.initCombinedIteration(-1, k, v, nil)
+	}
+	return k, v
+}
+
+func (i *lazyCombinedIter) Error() error {
+	if i.combinedIterState.initialized {
+		return i.parent.rangeKey.iiter.Error()
+	}
+	return i.pointIter.Error()
+}
+
+func (i *lazyCombinedIter) Close() error {
+	if i.combinedIterState.initialized {
+		return i.parent.rangeKey.iiter.Close()
+	}
+	return i.pointIter.Close()
+}
+
+func (i *lazyCombinedIter) SetBounds(lower, upper []byte) {
+	if i.combinedIterState.initialized {
+		i.parent.rangeKey.iiter.SetBounds(lower, upper)
+		return
+	}
+	i.pointIter.SetBounds(lower, upper)
+}
+
+func (i *lazyCombinedIter) String() string {
+	if i.combinedIterState.initialized {
+		return i.parent.rangeKey.iiter.String()
+	}
+	return i.pointIter.String()
+}
+
+func (i *lazyCombinedIter) Stats() InternalIteratorStats {
+	return i.pointIter.Stats()
+}
+
+func (i *lazyCombinedIter) ResetStats() {
+	i.pointIter.ResetStats()
 }

--- a/range_keys_test.go
+++ b/range_keys_test.go
@@ -41,6 +41,7 @@ func TestRangeKeys(t *testing.T) {
 				Comparer:           testkeys.Comparer,
 				FormatMajorVersion: FormatRangeKeys,
 			}
+			opts.DisableAutomaticCompactions = true
 
 			for _, cmdArgs := range td.CmdArgs {
 				if cmdArgs.Key != "format-major-version" {
@@ -92,6 +93,8 @@ func TestRangeKeys(t *testing.T) {
 			require.NoError(t, runBatchDefineCmd(td, b))
 			count := b.Count()
 			return fmt.Sprintf("created indexed batch with %d keys\n", count)
+		case "lsm":
+			return runLSMCmd(td, d)
 		case "commit-batch":
 			if b == nil {
 				return "no pending batch"

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -534,7 +534,7 @@ func (i *blockIter) cacheEntry() {
 
 // SeekGE implements internalIterator.SeekGE, as documented in the pebble
 // package.
-func (i *blockIter) SeekGE(key []byte, trySeekUsingNext bool) (*InternalKey, []byte) {
+func (i *blockIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, []byte) {
 	i.clearCache()
 
 	ikey := base.MakeSearchKey(key)
@@ -639,7 +639,7 @@ func (i *blockIter) SeekGE(key []byte, trySeekUsingNext bool) (*InternalKey, []b
 // SeekPrefixGE implements internalIterator.SeekPrefixGE, as documented in the
 // pebble package.
 func (i *blockIter) SeekPrefixGE(
-	prefix, key []byte, trySeekUsingNext bool,
+	prefix, key []byte, flags base.SeekGEFlags,
 ) (*base.InternalKey, []byte) {
 	// This should never be called as prefix iteration is handled by sstable.Iterator.
 	panic("pebble: SeekPrefixGE unimplemented")
@@ -1210,7 +1210,7 @@ func (i *fragmentBlockIter) Prev() *keyspan.Span {
 // SeekGE implements (keyspan.FragmentIterator).SeekGE.
 func (i *fragmentBlockIter) SeekGE(k []byte) *keyspan.Span {
 	i.dir = +1
-	return i.gatherForward(i.blockIter.SeekGE(k, false))
+	return i.gatherForward(i.blockIter.SeekGE(k, base.SeekGEFlags(0)))
 }
 
 // SeekLT implements (keyspan.FragmentIterator).SeekLT.

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -647,7 +647,7 @@ func (i *blockIter) SeekPrefixGE(
 
 // SeekLT implements internalIterator.SeekLT, as documented in the pebble
 // package.
-func (i *blockIter) SeekLT(key []byte) (*InternalKey, []byte) {
+func (i *blockIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, []byte) {
 	i.clearCache()
 
 	ikey := base.MakeSearchKey(key)
@@ -1216,7 +1216,7 @@ func (i *fragmentBlockIter) SeekGE(k []byte) *keyspan.Span {
 // SeekLT implements (keyspan.FragmentIterator).SeekLT.
 func (i *fragmentBlockIter) SeekLT(k []byte) *keyspan.Span {
 	i.dir = -1
-	return i.gatherBackward(i.blockIter.SeekLT(k))
+	return i.gatherBackward(i.blockIter.SeekLT(k, base.SeekLTFlagsNone))
 }
 
 // String implements fmt.Stringer.

--- a/sstable/block_test.go
+++ b/sstable/block_test.go
@@ -205,7 +205,7 @@ func TestBlockIter2(t *testing.T) {
 							if len(parts) != 2 {
 								return "seek-ge <key>\n"
 							}
-							iter.SeekGE([]byte(strings.TrimSpace(parts[1])), false /* trySeekUsingNext */)
+							iter.SeekGE([]byte(strings.TrimSpace(parts[1])), base.SeekGEFlagsNone)
 						case "seek-lt":
 							if len(parts) != 2 {
 								return "seek-lt <key>\n"
@@ -271,7 +271,7 @@ func TestBlockIterKeyStability(t *testing.T) {
 	// restart-interval of 1 so that prefix compression was not performed.
 	for j := range expected {
 		keys := [][]byte{}
-		for key, _ := i.SeekGE(expected[j], false /* trySeekUsingNext */); key != nil; key, _ = i.Next() {
+		for key, _ := i.SeekGE(expected[j], base.SeekGEFlagsNone); key != nil; key, _ = i.Next() {
 			check(key.UserKey)
 			keys = append(keys, key.UserKey)
 		}
@@ -360,7 +360,7 @@ func BenchmarkBlockIterSeekGE(b *testing.B) {
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					k := keys[rng.Intn(len(keys))]
-					it.SeekGE(k, false /* trySeekUsingNext */)
+					it.SeekGE(k, base.SeekGEFlagsNone)
 					if testing.Verbose() {
 						if !it.valid() {
 							b.Fatal("expected to find key")

--- a/sstable/block_test.go
+++ b/sstable/block_test.go
@@ -210,7 +210,7 @@ func TestBlockIter2(t *testing.T) {
 							if len(parts) != 2 {
 								return "seek-lt <key>\n"
 							}
-							iter.SeekLT([]byte(strings.TrimSpace(parts[1])))
+							iter.SeekLT([]byte(strings.TrimSpace(parts[1])), base.SeekLTFlagsNone)
 						case "first":
 							iter.First()
 						case "last":
@@ -280,7 +280,7 @@ func TestBlockIterKeyStability(t *testing.T) {
 
 	for j := range expected {
 		keys := [][]byte{}
-		for key, _ := i.SeekLT(expected[j]); key != nil; key, _ = i.Prev() {
+		for key, _ := i.SeekLT(expected[j], base.SeekLTFlagsNone); key != nil; key, _ = i.Prev() {
 			check(key.UserKey)
 			keys = append(keys, key.UserKey)
 		}
@@ -315,7 +315,7 @@ func TestBlockIterReverseDirections(t *testing.T) {
 			require.NoError(t, err)
 
 			pos := 3
-			if key, _ := i.SeekLT([]byte("carrot")); !bytes.Equal(keys[pos], key.UserKey) {
+			if key, _ := i.SeekLT([]byte("carrot"), base.SeekLTFlagsNone); !bytes.Equal(keys[pos], key.UserKey) {
 				t.Fatalf("expected %s, but found %s", keys[pos], key.UserKey)
 			}
 			for pos > targetPos {
@@ -402,7 +402,7 @@ func BenchmarkBlockIterSeekLT(b *testing.B) {
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					j := rng.Intn(len(keys))
-					it.SeekLT(keys[j])
+					it.SeekLT(keys[j], base.SeekLTFlagsNone)
 					if testing.Verbose() {
 						if j == 0 {
 							if it.valid() {

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -304,7 +304,7 @@ func runIterCmd(td *datadriven.TestData, origIter Iterator, opt ...runIterCmdOpt
 				return "seek-lt <key>\n"
 			}
 			prefix = nil
-			iter.SeekLT([]byte(strings.TrimSpace(parts[1])))
+			iter.SeekLT([]byte(strings.TrimSpace(parts[1])), base.SeekLTFlagsNone)
 		case "first":
 			prefix = nil
 			iter.First()

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -276,29 +276,29 @@ func runIterCmd(td *datadriven.TestData, origIter Iterator, opt ...runIterCmdOpt
 				return "seek-ge <key> [<try-seek-using-next]\n"
 			}
 			prefix = nil
-			trySeekUsingNext := false
+			var flags base.SeekGEFlags
 			if len(parts) == 3 {
-				var err error
-				trySeekUsingNext, err = strconv.ParseBool(parts[2])
-				if err != nil {
+				if trySeekUsingNext, err := strconv.ParseBool(parts[2]); err != nil {
 					return err.Error()
+				} else if trySeekUsingNext {
+					flags = flags.EnableTrySeekUsingNext()
 				}
 			}
-			iter.SeekGE([]byte(strings.TrimSpace(parts[1])), trySeekUsingNext)
+			iter.SeekGE([]byte(strings.TrimSpace(parts[1])), flags)
 		case "seek-prefix-ge":
 			if len(parts) != 2 && len(parts) != 3 {
 				return "seek-prefix-ge <key> [<try-seek-using-next>]\n"
 			}
 			prefix = []byte(strings.TrimSpace(parts[1]))
-			trySeekUsingNext := false
+			var flags base.SeekGEFlags
 			if len(parts) == 3 {
-				var err error
-				trySeekUsingNext, err = strconv.ParseBool(parts[2])
-				if err != nil {
+				if trySeekUsingNext, err := strconv.ParseBool(parts[2]); err != nil {
 					return err.Error()
+				} else if trySeekUsingNext {
+					flags = flags.EnableTrySeekUsingNext()
 				}
 			}
-			iter.SeekPrefixGE(prefix, prefix /* key */, trySeekUsingNext)
+			iter.SeekPrefixGE(prefix, prefix /* key */, flags)
 		case "seek-lt":
 			if len(parts) != 2 {
 				return "seek-lt <key>\n"

--- a/sstable/internal.go
+++ b/sstable/internal.go
@@ -9,6 +9,12 @@ import "github.com/cockroachdb/pebble/internal/base"
 // InternalKeyKind exports the base.InternalKeyKind type.
 type InternalKeyKind = base.InternalKeyKind
 
+// SeekGEFlags exports base.SeekGEFlags.
+type SeekGEFlags = base.SeekGEFlags
+
+// SeekLTFlags exports base.SeekLTFlags.
+type SeekLTFlags = base.SeekLTFlags
+
 // These constants are part of the file format, and should not be changed.
 const (
 	InternalKeyKindDelete          = base.InternalKeyKindDelete

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -708,7 +708,7 @@ func (i *singleLevelIterator) seekPrefixGE(
 // SeekLT implements internalIterator.SeekLT, as documented in the pebble
 // package. Note that SeekLT only checks the lower bound. It is up to the
 // caller to ensure that key is less than the upper bound.
-func (i *singleLevelIterator) SeekLT(key []byte) (*InternalKey, []byte) {
+func (i *singleLevelIterator) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, []byte) {
 	i.exhaustedBounds = 0
 	i.err = nil // clear cached iteration error
 	boundsCmp := i.boundsCmp
@@ -780,7 +780,7 @@ func (i *singleLevelIterator) SeekLT(key []byte) (*InternalKey, []byte) {
 		}
 	}
 	if !dontSeekWithinBlock {
-		if ikey, val := i.data.SeekLT(key); ikey != nil {
+		if ikey, val := i.data.SeekLT(key, flags); ikey != nil {
 			if i.blockLower != nil && i.cmp(ikey.UserKey, i.blockLower) < 0 {
 				i.exhaustedBounds = -1
 				return nil, nil
@@ -1175,7 +1175,7 @@ func (i *compactionIterator) SeekPrefixGE(
 	panic("pebble: SeekPrefixGE unimplemented")
 }
 
-func (i *compactionIterator) SeekLT(key []byte) (*InternalKey, []byte) {
+func (i *compactionIterator) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, []byte) {
 	panic("pebble: SeekLT unimplemented")
 }
 
@@ -1526,7 +1526,7 @@ func (i *twoLevelIterator) SeekPrefixGE(
 // SeekLT implements internalIterator.SeekLT, as documented in the pebble
 // package. Note that SeekLT only checks the lower bound. It is up to the
 // caller to ensure that key is less than the upper bound.
-func (i *twoLevelIterator) SeekLT(key []byte) (*InternalKey, []byte) {
+func (i *twoLevelIterator) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, []byte) {
 	i.exhaustedBounds = 0
 	i.err = nil // clear cached iteration error
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
@@ -1565,7 +1565,7 @@ func (i *twoLevelIterator) SeekLT(key []byte) (*InternalKey, []byte) {
 			return nil, nil
 		}
 		if result == loadBlockOK {
-			if ikey, val := i.singleLevelIterator.SeekLT(key); ikey != nil {
+			if ikey, val := i.singleLevelIterator.SeekLT(key, flags); ikey != nil {
 				return ikey, val
 			}
 			// Fall through to skipBackward since the singleLevelIterator did
@@ -1834,7 +1834,9 @@ func (i *twoLevelCompactionIterator) SeekPrefixGE(
 	panic("pebble: SeekPrefixGE unimplemented")
 }
 
-func (i *twoLevelCompactionIterator) SeekLT(key []byte) (*InternalKey, []byte) {
+func (i *twoLevelCompactionIterator) SeekLT(
+	key []byte, flags base.SeekLTFlags,
+) (*InternalKey, []byte) {
 	panic("pebble: SeekLT unimplemented")
 }
 

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -59,7 +59,7 @@ func (r *Reader) get(key []byte) (value []byte, err error) {
 	if err != nil {
 		return nil, err
 	}
-	ikey, value := i.SeekGE(key, false /* trySeekUsingNext */)
+	ikey, value := i.SeekGE(key, base.SeekGEFlagsNone)
 
 	if ikey == nil || r.Compare(key, ikey.UserKey) != 0 {
 		err := i.Close()
@@ -104,12 +104,12 @@ func (i *iterAdapter) String() string {
 	return "iter-adapter"
 }
 
-func (i *iterAdapter) SeekGE(key []byte, trySeekUsingNext bool) bool {
-	return i.update(i.Iterator.SeekGE(key, trySeekUsingNext))
+func (i *iterAdapter) SeekGE(key []byte, flags base.SeekGEFlags) bool {
+	return i.update(i.Iterator.SeekGE(key, flags))
 }
 
-func (i *iterAdapter) SeekPrefixGE(prefix, key []byte, trySeekUsingNext bool) bool {
-	return i.update(i.Iterator.SeekPrefixGE(prefix, key, trySeekUsingNext))
+func (i *iterAdapter) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) bool {
+	return i.update(i.Iterator.SeekPrefixGE(prefix, key, flags))
 }
 
 func (i *iterAdapter) SeekLT(key []byte) bool {
@@ -1039,7 +1039,7 @@ func BenchmarkTableIterSeekGE(b *testing.B) {
 
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					it.SeekGE(keys[rng.Intn(len(keys))], false /* trySeekUsingNext */)
+					it.SeekGE(keys[rng.Intn(len(keys))], base.SeekGEFlagsNone)
 				}
 
 				b.StopTimer()

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -112,8 +112,8 @@ func (i *iterAdapter) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) b
 	return i.update(i.Iterator.SeekPrefixGE(prefix, key, flags))
 }
 
-func (i *iterAdapter) SeekLT(key []byte) bool {
-	return i.update(i.Iterator.SeekLT(key))
+func (i *iterAdapter) SeekLT(key []byte, flags base.SeekLTFlags) bool {
+	return i.update(i.Iterator.SeekLT(key, flags))
 }
 
 func (i *iterAdapter) First() bool {
@@ -1060,7 +1060,7 @@ func BenchmarkTableIterSeekLT(b *testing.B) {
 
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					it.SeekLT(keys[rng.Intn(len(keys))])
+					it.SeekLT(keys[rng.Intn(len(keys))], base.SeekLTFlagsNone)
 				}
 
 				b.StopTimer()

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -147,7 +147,7 @@ func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
 			return err
 		}
 		i := newIterAdapter(iter)
-		if !i.SeekGE([]byte(k), false /* trySeekUsingNext */) || string(i.Key().UserKey) != k {
+		if !i.SeekGE([]byte(k), base.SeekGEFlagsNone) || string(i.Key().UserKey) != k {
 			return errors.Errorf("Find %q: key was not in the table", k)
 		}
 		if k1 := i.Key().UserKey; len(k1) != cap(k1) {
@@ -197,7 +197,7 @@ func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
 			return err
 		}
 		i := newIterAdapter(iter)
-		if i.SeekGE([]byte(s), false /* trySeekUsingNext */) && s == string(i.Key().UserKey) {
+		if i.SeekGE([]byte(s), base.SeekGEFlagsNone) && s == string(i.Key().UserKey) {
 			return errors.Errorf("Find %q: unexpectedly found key in the table", s)
 		}
 		if err := i.Close(); err != nil {
@@ -227,7 +227,7 @@ func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
 			return err
 		}
 		n, i := 0, newIterAdapter(iter)
-		for valid := i.SeekGE([]byte(ct.start), false /* trySeekUsingNext */); valid; valid = i.Next() {
+		for valid := i.SeekGE([]byte(ct.start), base.SeekGEFlagsNone); valid; valid = i.Next() {
 			n++
 		}
 		if n != ct.count {
@@ -303,7 +303,7 @@ func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
 
 		if lower != nil {
 			n := 0
-			for valid := i.SeekGE(lower, false /* trySeekUsingNext */); valid; valid = i.Next() {
+			for valid := i.SeekGE(lower, base.SeekGEFlagsNone); valid; valid = i.Next() {
 				n++
 			}
 			if expected := upperIdx - lowerIdx; expected != n {

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -161,7 +161,7 @@ func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
 		}
 
 		// Check using SeekLT.
-		if !i.SeekLT([]byte(k)) {
+		if !i.SeekLT([]byte(k), base.SeekLTFlagsNone) {
 			i.First()
 		} else {
 			i.Next()
@@ -313,7 +313,7 @@ func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
 
 		if upper != nil {
 			n := 0
-			for valid := i.SeekLT(upper); valid; valid = i.Prev() {
+			for valid := i.SeekLT(upper, base.SeekLTFlagsNone); valid; valid = i.Prev() {
 				n++
 			}
 			if expected := upperIdx - lowerIdx; expected != n {

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -450,7 +450,7 @@ func testTableCacheRandomAccess(t *testing.T, concurrent bool) {
 				errc <- errors.Errorf("i=%d, fileNum=%d: find: %v", i, fileNum, err)
 				return
 			}
-			key, value := iter.SeekGE([]byte("k"), false /* trySeekUsingNext */)
+			key, value := iter.SeekGE([]byte("k"), base.SeekGEFlagsNone)
 			if concurrent {
 				time.Sleep(time.Duration(sleepTime) * time.Microsecond)
 			}

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -339,6 +339,9 @@ range-key-del   d e
 ----
 wrote 3 keys
 
+flush
+----
+
 combined-iter
 seek-ge az
 next
@@ -405,6 +408,9 @@ range-key-set   c z @1000 boop
 range-key-del   bat bus
 ----
 wrote 4 keys
+
+flush
+----
 
 scan-rangekeys
 ----
@@ -668,6 +674,9 @@ range-key-set b e @1 foo
 ----
 wrote 2 keys
 
+flush
+----
+
 combined-iter
 seek-ge b
 prev
@@ -691,6 +700,9 @@ del b
 range-key-set a d @1 foo
 ----
 wrote 2 keys
+
+flush
+----
 
 combined-iter
 seek-ge z
@@ -717,3 +729,152 @@ prev-limit c
 ----
 .
 . at-limit
+
+# Test a lazy-combined iteration edge. Consider the LSM:
+#
+#   L5:  000003:[bar.DEL.3, foo.RANGEKEYSET.4]
+#   L6:  000001:[bar.SET.1] 000002:[bax.RANGEKEYSET.2]
+#
+# A call to First() seeks the levels to files L5.000003 and L6.000001.
+# The L5 levelIter observes that L5.000003 contains the range key with
+# start key `foo`, and triggers a switch to combined iteration, setting
+# `combinedIterState.key` = `foo`. While switching to combined iteration, the
+# iterator must recognize that `foo` > `bar`, and there may yet exist range keys
+# that begin before `foo` (in this case `bax`).
+
+reset
+----
+
+batch
+set bar bar
+----
+wrote 1 keys
+
+flush
+----
+
+batch
+range-key-set bax zoo @1 foo
+----
+wrote 1 keys
+
+flush
+----
+
+batch
+del bar
+range-key-set foo zoo @2 bar
+----
+wrote 2 keys
+
+flush
+----
+
+lsm
+----
+0.1:
+  000009:[bar#3,DEL-zoo#72057594037927935,RANGEKEYSET]
+0.0:
+  000005:[bar#1,SET-bar#1,SET]
+  000007:[bax#2,RANGEKEYSET-zoo#72057594037927935,RANGEKEYSET]
+
+# Assert that First correctly finds [bax,zoo), despite the discovery of
+# [foo,zoo) triggering the switch to combined iteration.
+
+combined-iter
+first
+next
+----
+bax: (., [bax-foo) @1=foo)
+foo: (., [foo-zoo) @2=bar, @1=foo)
+
+# Test seeking into the middle of a range key during lazy-combined iteration.
+# The iterator should surface Key() = the seek key.
+
+combined-iter
+seek-ge bop
+----
+bop: (., [bax-foo) @1=foo)
+
+combined-iter
+last
+----
+foo: (., [foo-zoo) @2=bar, @1=foo)
+
+
+# Test a lazy combined iterator that must next/prev through fileMetdata when
+# skipping through a RANGEDEL.
+#
+# L5
+#     b-----------------------y RANGEDEL
+# L6
+#  [a]   [[d,e)@1]  [[l,m)@1]   [z]
+#
+# A SeekGE(k) must surface [l,m)@1 and a SeekLT(k) must surface [d,e)@1.
+
+reset
+----
+
+batch
+set a a
+----
+wrote 1 keys
+
+flush
+----
+
+batch
+set z z
+----
+wrote 1 keys
+
+flush
+----
+
+batch
+range-key-set d e @1 foo
+----
+wrote 1 keys
+
+flush
+----
+
+batch
+range-key-set l m @1 foo
+----
+wrote 1 keys
+
+flush
+----
+
+batch
+del-range b y
+----
+wrote 1 keys
+
+flush
+----
+
+lsm
+----
+0.1:
+  000013:[b#5,RANGEDEL-y#72057594037927935,RANGEDEL]
+0.0:
+  000005:[a#1,SET-a#1,SET]
+  000009:[d#3,RANGEKEYSET-e#72057594037927935,RANGEKEYSET]
+  000011:[l#4,RANGEKEYSET-m#72057594037927935,RANGEKEYSET]
+  000007:[z#2,SET-z#2,SET]
+
+combined-iter
+seek-ge k
+next
+----
+l: (., [l-m) @1=foo)
+z: (z, .)
+
+combined-iter
+seek-lt k
+prev
+----
+d: (., [d-e) @1=foo)
+a: (a, .)

--- a/tool/find.go
+++ b/tool/find.go
@@ -428,7 +428,7 @@ func (f *findT) searchTables(searchKey []byte, refs []findRef) []findRef {
 				return err
 			}
 			defer iter.Close()
-			key, value := iter.SeekGE(searchKey, false /* trySeekUsingNext */)
+			key, value := iter.SeekGE(searchKey, base.SeekGEFlagsNone)
 
 			// We configured sstable.Reader to return raw tombstones which requires a
 			// bit more work here to put them in a form that can be iterated in

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -205,7 +205,7 @@ func (s *sstableT) runCheck(cmd *cobra.Command, args []string) {
 			if prefixIter != nil {
 				n := r.Split(key.UserKey)
 				prefix := key.UserKey[:n]
-				key2, _ := prefixIter.SeekPrefixGE(prefix, key.UserKey, false)
+				key2, _ := prefixIter.SeekPrefixGE(prefix, key.UserKey, base.SeekGEFlagsNone)
 				if key2 == nil {
 					fmt.Fprintf(stdout, "WARNING: PREFIX ITERATION FAILURE!\n")
 					if s.fmtKey.spec != "null" {
@@ -385,7 +385,7 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 			return
 		}
 		defer iter.Close()
-		key, value := iter.SeekGE(s.start, false /* trySeekUsingNext */)
+		key, value := iter.SeekGE(s.start, base.SeekGEFlagsNone)
 
 		// We configured sstable.Reader to return raw tombstones which requires a
 		// bit more work here to put them in a form that can be iterated in


### PR DESCRIPTION
Combined range-key iteration adds overhead to Pebble iterators. Construction of
the range-key iterator stack adds a noticeable slowdown, even when the LSM
contains no range keys. Additionally, when the LSM contains range keys outside
of the span being iterated over, additional key comparisons are expected to add
an additional slowdown. In order to optimize these cases for the expected case
of rare range keys, this commit adds lazy combined iteration.

When an iterator is constructed with the IterKeyTypePointsAndRanges key type,
iterator construction examines the indexed batch (if any) and memtables to see
if they contain any range keys. If they don't, the iterator is initially
constructed with only a point iterator stack. A flag signals to lower-level
iterators that the user configured the iterator for combined iteration, but
combined iteration isn't yet being used.

When a levelIter observes a file containing range keys, the levelIter sets
state to signal that there might be range keys that need to be interleaved. An
interstitial internal iterator `lazyCombinedIter` observes the signal,
constructs the range-key iterator and reconfigures the iterator stack to use
combined iteration.

While this commit is nice performance win, it unfortunately introduces several
subtle complexities:
  1. When performing lazy combined iteration, the merging iterator must not
     alter seek keys according to range deletions until AFTER the level is
     already positioned according the seek key. This allows levelIters the
     opportunity to observe range keys between the user-provided seek key and
     the new modified seek key.
  2. When the merging iterator does seek a level to a tombstone's end key, it
     must set a new RelativeSeek seek flag, which causes the levelIter to scan
     all the fileMetadata between the original seek and the modified seek,
     rather than skipping straight to the fileMetadata matching the modified
     seek.
  3. Deciding how to seek the range-key iterator when switching to combined
     iteration is full of intricacies depending on the iterator operation
     and context.

The below benchmarks capture the performance improvement of avoiding the
range-key iterator construction when no range keys exist in the LSM. There
aren't yet suitable benchmarks for measuring the improvement in cases where
there exist range keys in the LSM, but the range keys are outside the keyspace
being iterated over.

```
name                                                    old time/op    new time/op    delta
MVCCScan_Pebble/rows=1/versions=1/valueSize=64-10         3.04µs ± 5%    2.62µs ± 5%  -13.69%  (p=0.000 n=9+10)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64-10       21.2µs ± 1%    20.7µs ± 1%   -2.74%  (p=0.000 n=9+10)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64-10     1.41ms ± 1%    1.36ms ± 1%   -3.10%  (p=0.000 n=9+10)
MVCCGet_Pebble/batch=false/versions=1/valueSize=8-10      3.02µs ± 2%    2.58µs ± 0%  -14.84%  (p=0.000 n=9+10)
MVCCGet_Pebble/batch=false/versions=10/valueSize=8-10     3.48µs ± 2%    3.06µs ± 4%  -12.08%  (p=0.000 n=9+9)
MVCCGet_Pebble/batch=false/versions=100/valueSize=8-10    7.29µs ± 2%    6.93µs ±11%   -4.88%  (p=0.028 n=9+10)
MVCCGet_Pebble/batch=true/versions=1/valueSize=8-10       1.59µs ± 1%    1.57µs ± 4%     ~     (p=0.128 n=9+10)
MVCCGet_Pebble/batch=true/versions=10/valueSize=8-10      2.18µs ± 3%    2.18µs ± 6%     ~     (p=0.593 n=10+10)
MVCCGet_Pebble/batch=true/versions=100/valueSize=8-10     5.55µs ± 9%    5.17µs ± 1%   -6.95%  (p=0.000 n=10+9)

name                                                    old speed      new speed      delta
MVCCScan_Pebble/rows=1/versions=1/valueSize=64-10       21.1MB/s ± 5%  24.4MB/s ± 5%  +15.90%  (p=0.000 n=9+10)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64-10      301MB/s ± 1%   310MB/s ± 1%   +2.82%  (p=0.000 n=9+10)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64-10    454MB/s ± 1%   469MB/s ± 1%   +3.20%  (p=0.000 n=9+10)
MVCCGet_Pebble/batch=false/versions=1/valueSize=8-10    2.65MB/s ± 2%  3.11MB/s ± 1%  +17.44%  (p=0.000 n=9+10)
MVCCGet_Pebble/batch=false/versions=10/valueSize=8-10   2.30MB/s ± 2%  2.62MB/s ± 4%  +13.86%  (p=0.000 n=9+9)
MVCCGet_Pebble/batch=false/versions=100/valueSize=8-10  1.10MB/s ± 1%  1.16MB/s ±10%   +5.66%  (p=0.031 n=8+10)
MVCCGet_Pebble/batch=true/versions=1/valueSize=8-10     5.04MB/s ± 1%  5.10MB/s ± 4%     ~     (p=0.127 n=9+10)
MVCCGet_Pebble/batch=true/versions=10/valueSize=8-10    3.68MB/s ± 3%  3.68MB/s ± 6%     ~     (p=0.589 n=10+10)
MVCCGet_Pebble/batch=true/versions=100/valueSize=8-10   1.44MB/s ± 9%  1.54MB/s ± 2%   +7.00%  (p=0.000 n=10+10)
```

Close https://github.com/cockroachdb/pebble/issues/1780.