### PR TITLE
*: treat manifest-related errors during logAndApply as fatal

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1651,15 +1651,6 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 			// TODO(peter): untested.
 			d.mu.versions.obsoleteTables = append(d.mu.versions.obsoleteTables, pendingOutputs...)
 			d.mu.versions.incrementObsoleteTablesLocked(pendingOutputs)
-
-			// If logAndApply fails, there is a chance that we ran NewL0Sublevels
-			// successfully, or at least ran it for long enough to mutate
-			// f.{min,max}IntervalIndex on many files. Since that NewL0Sublevels was
-			// on a Version that was not installed, regenerate the current version's
-			// NewL0Sublevels to ensure that all interval indices on FileMetadatas
-			// are correct again. This is necessary to avoid future panics in
-			// InitCompactingFileInfo as well as to aid in correct compaction picking.
-			_ = d.mu.versions.currentVersion().InitL0Sublevels(c.cmp, c.formatKey, d.opts.FlushSplitBytes)
 		}
 	}
 
@@ -2152,14 +2143,9 @@ func (d *DB) compact1(c *compaction, errChannel chan error) (err error) {
 			return d.getInProgressCompactionInfoLocked(c)
 		})
 		if err != nil {
-			info.Err = err
 			// TODO(peter): untested.
 			d.mu.versions.obsoleteTables = append(d.mu.versions.obsoleteTables, pendingOutputs...)
 			d.mu.versions.incrementObsoleteTablesLocked(pendingOutputs)
-
-			// See comment in the similar invocation of InitL0Sublevels in flush1()
-			// above, on why this is necessary.
-			_ = d.mu.versions.currentVersion().InitL0Sublevels(c.cmp, c.formatKey, d.opts.FlushSplitBytes)
 		}
 	}
 

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -3661,8 +3661,8 @@ func TestMarkedForCompaction(t *testing.T) {
 	})
 }
 
-// createManifestErrorInjector injects errors (when enabled) it vfs.FS calls to
-// create MANIFEST files.
+// createManifestErrorInjector injects errors (when enabled) into vfs.FS calls
+// to create MANIFEST files.
 type createManifestErrorInjector struct {
 	enabled uint32 // atomic
 }
@@ -3692,115 +3692,99 @@ func (i *createManifestErrorInjector) MaybeError(op errorfs.Op, path string) err
 
 var _ errorfs.Injector = &createManifestErrorInjector{}
 
-// TestCompaction_LogAndApplyFails is a regression test for #1669.
+// TestCompaction_LogAndApplyFails exercises a flush or ingest encountering an
+// unrecoverable error during logAndApply.
 //
-// The test exercises a failing flush into L0 triggering a rebuild of the
-// in-memory L0 sublevels metadata. Without a rebuild, a future compaction or
-// flush may see an inconsistent state, which can result in erroneous compacting
-// picking or runtime panics.
+// Regression test for #1669.
 func TestCompaction_LogAndApplyFails(t *testing.T) {
-	var db *DB
-
-	// numSubLevelIntervals returns the number of L0 sublevel intervals.
-	numSubLevelIntervals := func(v *version) int {
-		// Find the max L0 interval index across all files in L0.
-		iter := v.Levels[0].Iter()
-		var max int
-		for f := iter.First(); f != nil; f = iter.Next() {
-			if f.L0Index > max {
-				max = f.L0Index
-			}
-		}
-		// The number of intervals is one plus the max index.
-		return max + 1
+	// flushKeys writes the given keys to the DB, flushing the resulting memtable.
+	var key = []byte("foo")
+	flushErrC := make(chan error)
+	flushKeys := func(db *DB) error {
+		b := db.NewBatch()
+		err := b.Set(key, nil, nil)
+		require.NoError(t, err)
+		err = b.Commit(nil)
+		require.NoError(t, err)
+		// An error from a failing flush is returned asynchronously.
+		go func() { _ = db.Flush() }()
+		return <-flushErrC
 	}
 
-	inj := &createManifestErrorInjector{}
-	type postApplyState struct {
-		numIntervals int
-		err          error
+	// ingestKeys adds the given keys to the DB via an ingestion.
+	ingestKeys := func(db *DB) error {
+		// Create an SST for ingestion.
+		const fName = "ext"
+		f, err := db.opts.FS.Create(fName)
+		require.NoError(t, err)
+		w := sstable.NewWriter(f, sstable.WriterOptions{})
+		require.NoError(t, w.Set(key, nil))
+		require.NoError(t, w.Close())
+		// Ingest the SST.
+		return db.Ingest([]string{fName})
 	}
-	flushed := make(chan postApplyState)
-	opts := &Options{
-		FS: errorfs.Wrap(vfs.NewMem(), inj),
-		// Rotate the manifest after each write. This is required to trigger a file
-		// creation, into which errors can be injected.
-		MaxManifestFileSize: 1,
-		EventListener: EventListener{
-			BackgroundError: func(err error) {
-				// Swallow errors to reduce noise.
+
+	testCases := []struct {
+		name              string
+		addFn             func(db *DB) error
+		backgroundErrorFn func(*DB, error)
+	}{
+		{
+			name:  "flush",
+			addFn: flushKeys,
+			backgroundErrorFn: func(db *DB, err error) {
+				require.True(t, errors.Is(err, errorfs.ErrInjected))
+				flushErrC <- err
+				// A flush will attempt to retry in the background. For the purposes of
+				// testing this particular scenario, where we would have crashed anyway,
+				// drop the memtable on the floor to short circuit the retry loop.
+				// NB: we hold db.mu here.
+				var cur *flushableEntry
+				cur, db.mu.mem.queue = db.mu.mem.queue[0], db.mu.mem.queue[1:]
+				cur.readerUnref()
 			},
-			FlushEnd: func(info FlushInfo) {
-				// NB: db.mu is held when this is called.
-				flushed <- postApplyState{
-					numIntervals: numSubLevelIntervals(db.mu.versions.currentVersion()),
-					err:          info.Err,
-				}
-			},
+		},
+		{
+			name:  "ingest",
+			addFn: ingestKeys,
 		},
 	}
 
-	var err error
-	db, err = Open("", opts)
-	require.NoError(t, err)
-	defer db.Close()
-
-	// flushKeys writes the given keys to the DB, flushing the resulting memtable.
-	flushKeys := func(keys ...byte) {
-		b := db.NewBatch()
-		for _, k := range keys {
-			err = b.Set([]byte{k}, nil, nil)
-			require.NoError(t, err)
+	runTest := func(t *testing.T, addFn func(db *DB) error, bgFn func(*DB, error)) {
+		var db *DB
+		inj := &createManifestErrorInjector{}
+		logger := &fatalCapturingLogger{}
+		opts := &Options{
+			FS: errorfs.Wrap(vfs.NewMem(), inj),
+			// Rotate the manifest after each write. This is required to trigger a
+			// file creation, into which errors can be injected.
+			MaxManifestFileSize: 1,
+			Logger:              logger,
+			EventListener: EventListener{
+				BackgroundError: func(err error) {
+					if bgFn != nil {
+						bgFn(db, err)
+					}
+				},
+			},
+			DisableAutomaticCompactions: true,
 		}
-		err = b.Commit(nil)
+
+		db, err := Open("", opts)
 		require.NoError(t, err)
-		go func() { _ = db.Flush() }()
+		defer func() { _ = db.Close() }()
+
+		inj.enable()
+		err = addFn(db)
+		require.True(t, errors.Is(err, errorfs.ErrInjected))
+
+		// Under normal circumstances, such an error in logAndApply would panic and
+		// cause the DB to terminate here. Assert that we captured the fatal error.
+		require.True(t, errors.Is(logger.err, errorfs.ErrInjected))
 	}
-
-	// Flush a single file into L0, resulting in a single L0 interval:
-	//
-	// L0.0  |-----------|
-	//       a  b  c  d  e
-	flushKeys('a', 'e')
-	state := <-flushed
-	require.NoError(t, state.err)
-	require.Equal(t, 1, state.numIntervals)
-
-	// Flush a second memtable into L0 that would under normal circumstances
-	// increase the number of intervals in L0 from one to two. i.e. L0 would
-	// resemble the following, with two intervals, [a, c) and [c, e]:
-	//
-	// L0.1  |-----|-----|
-	// L0.0  |-----------|
-	//       a  b  c  d  e
-	//
-	// However, the flush does not succeed as the FS prevents applying the
-	// MANIFEST update in the commit pipeline.
-	inj.enable()
-	flushKeys('a', 'c')
-
-	// Wait for the flush to fail at least once.
-	state = <-flushed
-	require.True(t, errors.Is(state.err, errorfs.ErrInjected))
-
-	// The flush will continue to retry and fail in the background. Allow it to
-	// proceed by disabling the FS errors.
-	inj.disable()
-
-	// The flush was retried in the background and should have completed. As the
-	// flush was possibly retried multiple times, consume from the channel until
-	// we see a successful flush.
-	for state = range flushed {
-		if state.err == nil {
-			close(flushed)
-			break
-		}
-		// While the flushes are failing, the interval indices for each file in L0
-		// should NOT change (i.e. it should have "rolled back" after each flush
-		// failure). The interval count stays at one.
-		require.Equal(t, 1, state.numIntervals)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			runTest(t, tc.addFn, tc.backgroundErrorFn)
+		})
 	}
-
-	// The interval is two, only after the flush succeeds.
-	require.Equal(t, 2, state.numIntervals)
 }


### PR DESCRIPTION
As certain manifest-related errors encountered during `logAndApply`
could leave file and b-tree reference counts inconsistent (as mentioned
in #1792), and / or L0 sublevel metadata incorrect (as identified in #1669),
remove the L0 sublevel regeneration logic added in #1784 in favor of
treating all manifest related errors encountered during `logAndApply` as
fatal.

Adapt the existing test case to cover ingestions, which are also
susceptible to the original issue identified in #1669. Specifically, an
ingestion requires application of a version edit, which may fail and
leave the metadata for the L0 sublevels in an inconsistent state.