### PR TITLE
Makefile: add crossversion-meta

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,19 @@ jobs:
 
     - run: make test generate
 
+  linux-crossversion:
+    name: go-linux-crossversion
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: "1.17"
+
+    - run: make crossversion-meta
+
   linux-race:
     name: go-linux-race
     runs-on: ubuntu-latest

--- a/internal/metamorphic/.gitignore
+++ b/internal/metamorphic/.gitignore
@@ -1,1 +1,2 @@
 _meta/
+*.test


### PR DESCRIPTION
Add a Makefile target for running crossversion metamorphic tests between the
current SHA and the most recent crl-release branch. Add a new CI job to run the
target. It's slow (~3-5 minutes), so run it in its own job and only on linux w/
invariants.