### PR TITLE
db: apply trySeekUsingNext optimization to file metadata iterator

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -617,7 +617,7 @@ func (i *Iterator) sampleRead() {
 		if len(mi.levels) > 1 {
 			mi.ForEachLevelIter(func(li *levelIter) bool {
 				l := manifest.LevelToInt(li.level)
-				if file := li.files.Current(); file != nil {
+				if file := li.files.iterFile; file != nil {
 					var containsKey bool
 					if i.pos == iterPosNext || i.pos == iterPosCurForward ||
 						i.pos == iterPosCurForwardPaused {

--- a/level_checker.go
+++ b/level_checker.go
@@ -630,10 +630,10 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 		if current.L0SublevelFiles[sublevel].Empty() {
 			continue
 		}
-		manifestIter := current.L0SublevelFiles[sublevel].Iter()
+		files := current.L0SublevelFiles[sublevel].Iter()
 		iterOpts := IterOptions{logger: c.logger}
 		li := &levelIter{}
-		li.init(iterOpts, c.cmp, nil /* split */, c.newIters, manifestIter,
+		li.init(iterOpts, c.cmp, nil /* split */, c.newIters, files,
 			manifest.L0Sublevel(sublevel), nil)
 		li.initRangeDel(&mlevelAlloc[0].rangeDelIter)
 		li.initSmallestLargestUserKey(&mlevelAlloc[0].smallestUserKey, nil, nil)

--- a/testdata/level_iter_seek
+++ b/testdata/level_iter_seek
@@ -306,7 +306,7 @@ j.SET.7:j
 
 # Seeks to immediately following keys.
 iter
-seek-prefix-ge a true
+seek-prefix-ge a false
 seek-prefix-ge a true
 seek-prefix-ge b true
 next
@@ -332,7 +332,7 @@ j/<invalid>#7,1:j
 
 # Seeks to keys that are in the next file, so cannot use Next.
 iter
-seek-prefix-ge a true
+seek-prefix-ge a false
 seek-prefix-ge e true
 seek-prefix-ge i true
 seek-prefix-ge j true


### PR DESCRIPTION
When seeking with the trySeekUsingNext flag set, step the level iterator's
manifest.LevelIterator rather than seeking. This is expected to incur fewer key
comparisons.

This provides some performance benefit on its own, but it's primarily intended
to prepare for #1780, lazy construction of the combined iterator stack. The
switch to combined iteration sometimess requires using relative positioning
methods to reposition the manifest.LevelIterator in some cases, in order to
ensure no files containing range keys are skipped.

```
name                                                                           old time/op    new time/op    delta
KVAndStorageUsingSQL/versions=2-10                                               1.71ms ± 4%    1.66ms ± 5%  -2.76%  (p=0.042 n=5+9)
KVAndStorageUsingSQL/versions=4-10                                               1.75ms ±12%    1.69ms ± 3%    ~     (p=0.768 n=5+10)
KVAndStorageUsingSQL/versions=8-10                                               1.76ms ± 4%    1.68ms ± 3%  -4.52%  (p=0.012 n=5+9)
CheckSSTConflicts/keys=1000/sstKeys=10/overlap=false/prefixSeek=false-10         35.7µs ± 1%    36.1µs ± 0%  +1.32%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10/overlap=false/prefixSeek=true-10          20.1µs ± 1%    20.2µs ± 1%    ~     (p=0.421 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10/overlap=true/prefixSeek=false-10          43.7µs ± 1%    43.9µs ± 0%    ~     (p=0.841 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10/overlap=true/prefixSeek=true-10           41.1µs ± 1%    41.1µs ± 0%    ~     (p=0.548 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=100/overlap=false/prefixSeek=false-10        37.9µs ± 1%    38.5µs ± 0%  +1.46%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=100/overlap=false/prefixSeek=true-10         20.9µs ± 1%    20.8µs ± 0%    ~     (p=0.198 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=100/overlap=true/prefixSeek=false-10          103µs ± 1%     102µs ± 0%  -0.95%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=100/overlap=true/prefixSeek=true-10          63.1µs ± 0%    61.0µs ± 0%  -3.44%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=1000/overlap=false/prefixSeek=false-10       40.9µs ± 1%    41.0µs ± 0%    ~     (p=0.198 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=1000/overlap=false/prefixSeek=true-10        20.9µs ± 0%    20.7µs ± 0%  -1.08%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=1000/overlap=true/prefixSeek=false-10         365µs ± 0%     350µs ± 0%  -4.04%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=1000/overlap=true/prefixSeek=true-10          274µs ± 0%     255µs ± 0%  -6.82%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10000/overlap=false/prefixSeek=false-10      41.1µs ± 1%    42.1µs ± 4%  +2.35%  (p=0.016 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10000/overlap=false/prefixSeek=true-10       20.7µs ± 1%    20.9µs ± 1%    ~     (p=0.310 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10000/overlap=true/prefixSeek=false-10        893µs ± 0%     901µs ± 4%    ~     (p=0.690 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10000/overlap=true/prefixSeek=true-10        2.41ms ± 1%    2.23ms ± 0%  -7.61%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=100000/overlap=false/prefixSeek=false-10     44.0µs ± 0%    44.5µs ± 0%  +1.14%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=100000/overlap=false/prefixSeek=true-10      20.1µs ± 0%    20.1µs ± 1%    ~     (p=0.841 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=100000/overlap=true/prefixSeek=false-10      3.42ms ± 2%    3.47ms ± 0%  +1.62%  (p=0.032 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=100000/overlap=true/prefixSeek=true-10       24.3ms ± 1%    22.3ms ± 1%  -8.27%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10/overlap=false/prefixSeek=false-10        34.3µs ± 2%    34.6µs ± 0%    ~     (p=0.222 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10/overlap=false/prefixSeek=true-10         19.5µs ± 1%    19.7µs ± 1%    ~     (p=0.151 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10/overlap=true/prefixSeek=false-10         42.5µs ± 0%    43.0µs ± 1%  +1.13%  (p=0.016 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10/overlap=true/prefixSeek=true-10          38.9µs ± 0%    39.1µs ± 0%  +0.54%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=100/overlap=false/prefixSeek=false-10       36.3µs ± 1%    36.5µs ± 1%    ~     (p=0.310 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=100/overlap=false/prefixSeek=true-10        19.7µs ± 1%    19.6µs ± 1%    ~     (p=0.841 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=100/overlap=true/prefixSeek=false-10         111µs ± 1%     109µs ± 1%  -1.75%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=100/overlap=true/prefixSeek=true-10         61.9µs ± 0%    60.1µs ± 1%  -2.96%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=1000/overlap=false/prefixSeek=false-10      38.8µs ± 1%    39.4µs ± 2%    ~     (p=0.310 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=1000/overlap=false/prefixSeek=true-10       19.7µs ± 1%    19.7µs ± 1%    ~     (p=1.000 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=1000/overlap=true/prefixSeek=false-10        729µs ± 1%     715µs ± 0%  -1.90%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=1000/overlap=true/prefixSeek=true-10         278µs ± 2%     256µs ± 1%  -7.94%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10000/overlap=false/prefixSeek=false-10     39.4µs ± 1%    39.5µs ± 1%    ~     (p=0.690 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10000/overlap=false/prefixSeek=true-10      19.6µs ± 1%    19.7µs ± 1%    ~     (p=0.222 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10000/overlap=true/prefixSeek=false-10      3.21ms ± 1%    3.10ms ± 6%    ~     (p=0.151 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10000/overlap=true/prefixSeek=true-10       2.44ms ± 0%    2.25ms ± 0%  -7.61%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=100000/overlap=false/prefixSeek=false-10    42.6µs ± 1%    42.8µs ± 0%  +0.56%  (p=0.032 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=100000/overlap=false/prefixSeek=true-10     18.9µs ± 1%    18.9µs ± 1%    ~     (p=1.000 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=100000/overlap=true/prefixSeek=false-10     9.04ms ± 1%    8.89ms ± 0%  -1.69%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=100000/overlap=true/prefixSeek=true-10      24.2ms ± 1%    22.0ms ± 1%  -8.97%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=100000/sstKeys=10/overlap=false/prefixSeek=false-10       31.8µs ± 1%    31.7µs ± 1%    ~     (p=0.548 n=5+5)
CheckSSTConflicts/keys=100000/sstKeys=10/overlap=false/prefixSeek=true-10        17.9µs ± 0%    17.8µs ± 3%    ~     (p=0.690 n=5+5)
CheckSSTConflicts/keys=100000/sstKeys=10/overlap=true/prefixSeek=false-10        39.6µs ± 2%    38.6µs ± 1%  -2.74%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=100000/sstKeys=10/overlap=true/prefixSeek=true-10         36.6µs ± 1%    35.9µs ± 0%  -1.88%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=100000/sstKeys=100/overlap=false/prefixSeek=false-10      33.6µs ± 0%    33.5µs ± 0%    ~     (p=0.700 n=3+3)
```