### PR TITLE
github: add action runner for automating issue labeling

### DIFF
--- a/.github/workflows/new-issue.yml
+++ b/.github/workflows/new-issue.yml
@@ -1,0 +1,18 @@
+name: Triage new issue
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  label-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Apply storage labels
+        uses: andymckay/labeler@1.0.2
+        with:
+          add-labels: 'T-storage,A-storage'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As Pebble lives in a repo separate from Cockroach, it misses out on a
number of the automation goodies - issue labeling, project management,
etc.

In anticipation of the eventual wiring of the Pebble repo and our
internal project management tool, apply the `T-storage` and `A-storage`
labels to incoming issues by way of a GitHub Action runner (as outlined
[here][1]).

Note that issue labeling is separate to project automation, which
requires a separate step in the pipeline. This will be added in a
subsequent patch, when the requisite credentials are available in the
repo.

[1]: https://docs.github.com/en/actions/managing-issues-and-pull-requests/adding-labels-to-issues