### PR TITLE
[DNM] db: add API for computing summary stats between a start and end bound

### DIFF
--- a/debug_span.go
+++ b/debug_span.go
@@ -1,0 +1,142 @@
+package pebble
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/humanize"
+	"github.com/cockroachdb/pebble/internal/manifest"
+)
+
+// SpanLevelStats contains statistics for a span in a given level of the LSM.
+type SpanLevelStats struct {
+	NumFiles   int
+	TotalBytes uint64
+}
+
+// SpanStats contains statistics for a span in the LSM.
+type SpanStats struct {
+	// Levels contains aggregate statistics for each level in the LSM. Level 0 is
+	// aggregated across all the constituent sub-levels.
+	Levels [numLevels]SpanLevelStats
+	// L0SubLevels contains statistics for each sub-level in L0. The oldest
+	// sublevel is the first element of the slice.
+	L0Sublevels []SpanLevelStats
+}
+
+// TotalReadAmp returns the total read amplification for the span.
+func (s SpanStats) TotalReadAmp() int {
+	var rAmp int
+	for i, level := range s.Levels {
+		if level.NumFiles == 0 {
+			continue
+		}
+		if i == 0 {
+			rAmp += len(s.L0Sublevels)
+		} else {
+			rAmp++
+		}
+	}
+	return rAmp
+}
+
+// TotalFiles returns the total number of files that overlap the span.
+func (s SpanStats) TotalFiles() int {
+	var nFiles int
+	for _, level := range s.Levels {
+		nFiles += level.NumFiles
+	}
+	return nFiles
+}
+
+// TotalBytes returns the total number of bytes across all files that overlap
+// the span.
+func (s SpanStats) TotalBytes() uint64 {
+	var nBytes uint64
+	for _, level := range s.Levels {
+		nBytes += level.TotalBytes
+	}
+	return nBytes
+}
+
+// String implements fmt.Stringer, printing a summary of the span, one line for
+// each level (and sub-level).
+func (s SpanStats) String() string {
+	var b bytes.Buffer
+	_, _ = fmt.Fprintln(&b, "___level___files________size___r-amp")
+	printLevelStats := func(levelIdx string, l SpanLevelStats) {
+		var rAmp int
+		if l.NumFiles > 0 {
+			rAmp = 1
+		}
+		_, _ = fmt.Fprintf(
+			&b, "%8s %7d %11s %7d\n",
+			levelIdx, l.NumFiles, humanize.Uint64(l.TotalBytes), rAmp,
+		)
+	}
+	// Print L0 sublevel individually, in reverse order (youngest first).
+	for i := len(s.L0Sublevels) - 1; i >= 0; i-- {
+		printLevelStats(fmt.Sprintf("0.%d", i), s.L0Sublevels[i])
+	}
+	// Print remaining levels.
+	for i := 1; i < len(s.Levels); i++ {
+		printLevelStats(strconv.Itoa(i), s.Levels[i])
+	}
+	_, _ = fmt.Fprintf(
+		&b, "   total %7d %11s %7d\n",
+		s.TotalFiles(), humanize.Uint64(s.TotalBytes()), s.TotalReadAmp(),
+	)
+	return b.String()
+}
+
+// DebugSpan returns a SpanStats for a span between the given start and end
+// bounds (inclusive, and exclusive, respectively).
+//
+// Passing `nil` for a start and end bound will return a SpanStats covering the
+// entire LSM, whose output should match that of Metrics.
+//
+// If `start` is non-nil, then `end > start`.
+func (d *DB) DebugSpan(start, end []byte) (stats SpanStats, _ error) {
+	if start != nil && d.cmp(start, end) >= 0 {
+		return stats, errors.Errorf("debug span: end must be > start")
+	}
+
+	rs := d.loadReadState()
+	defer rs.unref()
+	v := rs.current
+
+	levelStats := func(iter manifest.LevelIterator) (lStats SpanLevelStats) {
+		iter.SeekGE(d.cmp, start)
+		for m := iter.Current(); m != nil; m = iter.Next() {
+			if end != nil && d.cmp(m.Smallest.UserKey, end) >= 0 /* exclusive end */ {
+				// We've iterated too far.
+				break
+			}
+			lStats.NumFiles++
+			lStats.TotalBytes += m.Size
+		}
+		return
+	}
+	// L0 has its files sorted by seqnum. Use the L0 sublevels to compute the span
+	// stats, as each sublevel has its files sorted by start key.
+	stats.L0Sublevels = make([]SpanLevelStats, len(v.L0Sublevels.Levels))
+	for i, subLevel := range v.L0Sublevels.Levels {
+		s := levelStats(subLevel.Iter())
+		if s.NumFiles == 0 {
+			continue
+		}
+		// Update per-sublevel stats.
+		stats.L0Sublevels[i].NumFiles += s.NumFiles
+		stats.L0Sublevels[i].TotalBytes += s.TotalBytes
+		// Update aggregate sublevel stats.
+		stats.Levels[0].NumFiles += s.NumFiles
+		stats.Levels[0].TotalBytes += s.TotalBytes
+	}
+	// Levels > 0 can use a regular level iterator.
+	for i := 1; i < numLevels; i++ {
+		stats.Levels[i] = levelStats(v.Levels[i].Iter())
+	}
+	return stats, nil
+}

--- a/debug_span_test.go
+++ b/debug_span_test.go
@@ -1,0 +1,67 @@
+package pebble
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDebugSpan(t *testing.T) {
+	var d *DB
+	defer func() {
+		if d != nil {
+			require.NoError(t, d.Close())
+		}
+	}()
+
+	datadriven.RunTest(t, "testdata/debug_span", func(td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "define":
+			if d != nil {
+				if err := d.Close(); err != nil {
+					return err.Error()
+				}
+			}
+			opts := &Options{
+				FS:         vfs.NewMem(),
+				DebugCheck: DebugCheckLevels,
+			}
+			var err error
+			d, err = runDBDefineCmd(td, opts)
+			if err != nil {
+				return err.Error()
+			}
+			d.mu.Lock()
+			s := d.mu.versions.currentVersion().String()
+			d.mu.Unlock()
+			return s
+
+		case "debug-span":
+			var start, end []byte
+			for _, cmdArg := range td.CmdArgs {
+				switch cmdArg.Key {
+				case "start":
+					start = []byte(cmdArg.Vals[0])
+				case "end":
+					end = []byte(cmdArg.Vals[0])
+				default:
+					return fmt.Sprintf("unknown arg %q", cmdArg.Key)
+				}
+			}
+			s, err := d.DebugSpan(start, end)
+			if err != nil {
+				return err.Error()
+			}
+			return s.String()
+
+		case "metrics":
+			return d.Metrics().String()
+
+		default:
+			return fmt.Sprintf("unknown command %q", td.Cmd)
+		}
+	})
+}

--- a/testdata/debug_span
+++ b/testdata/debug_span
@@ -1,0 +1,167 @@
+#       a b c d e f g h i j k l m n o p q r s t u v w x y z
+# L0.1              x---------------------------x
+# L0.0    x-----x     x---------x         x---------x
+# L1
+# L2
+# L3                                      x---------x
+# L4
+# L5            x---------x         x-----------------x
+# L6    x-----------x x---------x x-------------x x-------x
+#       a b c d e f g h i j k l m n o p q r s t u v w x y z
+
+define
+L6
+  a.SET.1: g.SET.1:
+L6
+  h.SET.2: m.SET.2:
+L6
+  n.SET.3: u.SET.3:
+L6
+  v.SET.4: z.SET.4:
+L5
+  e.SET.5: j.SET.5:
+L5
+  o.SET.6: x.SET.6:
+L3
+  r.SET.7: w.SET.7:
+L0
+  b.SET.8: e.SET.8:
+L0
+  h.SET.9: m.SET.9:
+L0
+  r.SET.10: w.SET.10:
+L0
+  g.SET.11: u.SET.11:
+----
+0.1:
+  000014:[g#11,SET-u#11,SET]
+0.0:
+  000011:[b#8,SET-e#8,SET]
+  000012:[h#9,SET-m#9,SET]
+  000013:[r#10,SET-w#10,SET]
+3:
+  000010:[r#7,SET-w#7,SET]
+5:
+  000008:[e#5,SET-j#5,SET]
+  000009:[o#6,SET-x#6,SET]
+6:
+  000004:[a#1,SET-g#1,SET]
+  000005:[h#2,SET-m#2,SET]
+  000006:[n#3,SET-u#3,SET]
+  000007:[v#4,SET-z#4,SET]
+
+# Invalid inputs.
+
+debug-span start=a end=a
+----
+debug span: end must be > start
+
+debug-span start=b end=a
+----
+debug span: end must be > start
+
+# Valid inputs.
+
+debug-span
+----
+___level___files________size___r-amp
+     0.1       1       775 B       1
+     0.0       3       2.3 K       1
+       1       0         0 B       0
+       2       0         0 B       0
+       3       1       775 B       1
+       4       0         0 B       0
+       5       2       1.5 K       1
+       6       4       3.0 K       1
+   total      11       8.3 K       5
+
+# Print the metrics for the entire LSM here, for which the level information
+# should match.
+metrics
+----
+__level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___r-amp___w-amp
+    WAL         1     0 B       -     0 B       -       -       -       -     0 B       -       -       -     0.0
+      0         4   3.0 K  100.00     0 B     0 B       0     0 B       0     0 B       0     0 B       2     0.0
+      1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      2         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      3         1   775 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       1     0.0
+      4         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      5         2   1.5 K    0.01     0 B     0 B       0     0 B       0     0 B       0     0 B       1     0.0
+      6         4   3.0 K       -     0 B     0 B       0     0 B       0     0 B       0     0 B       1     0.0
+  total        11   8.3 K       -     0 B     0 B       0     0 B       0     0 B       0     0 B       5     0.0
+  flush         0
+compact         0     0 B   8.3 K       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
+  ctype         0       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
+ memtbl         1   256 K
+zmemtbl         0     0 B
+   ztbl         0     0 B
+ bcache         0     0 B    0.0%  (score == hit-rate)
+ tcache         0     0 B    0.0%  (score == hit-rate)
+  snaps         0       -       0  (score == earliest seq num)
+ titers         0
+ filter         -       -    0.0%  (score == utility)
+
+debug-span start=a end=b
+----
+___level___files________size___r-amp
+     0.1       0         0 B       0
+     0.0       0         0 B       0
+       1       0         0 B       0
+       2       0         0 B       0
+       3       0         0 B       0
+       4       0         0 B       0
+       5       0         0 B       0
+       6       1       775 B       1
+   total       1       775 B       1
+
+debug-span start=b end=f
+----
+___level___files________size___r-amp
+     0.1       0         0 B       0
+     0.0       1       775 B       1
+       1       0         0 B       0
+       2       0         0 B       0
+       3       0         0 B       0
+       4       0         0 B       0
+       5       1       775 B       1
+       6       1       775 B       1
+   total       3       2.3 K       4
+
+debug-span start=gg end=h
+----
+___level___files________size___r-amp
+     0.1       1       775 B       1
+     0.0       0         0 B       0
+       1       0         0 B       0
+       2       0         0 B       0
+       3       0         0 B       0
+       4       0         0 B       0
+       5       1       775 B       1
+       6       0         0 B       0
+   total       2       1.5 K       3
+
+debug-span start=i end=s
+----
+___level___files________size___r-amp
+     0.1       1       775 B       1
+     0.0       2       1.5 K       1
+       1       0         0 B       0
+       2       0         0 B       0
+       3       1       775 B       1
+       4       0         0 B       0
+       5       2       1.5 K       1
+       6       2       1.5 K       1
+   total       8       6.1 K       5
+
+debug-span start=s end=z
+----
+___level___files________size___r-amp
+     0.1       1       775 B       1
+     0.0       1       775 B       1
+       1       0         0 B       0
+       2       0         0 B       0
+       3       1       775 B       1
+       4       0         0 B       0
+       5       1       775 B       1
+       6       2       1.5 K       1
+   total       6       4.5 K       5


### PR DESCRIPTION
To aid in better understanding how a particular table, index, or more
generally, an arbitrary span between some start and end bounds resides
in a DB, introduce the `(*DB).DebugSpan` API. This method takes an
inclusive start and exclusive end bound, and returns a `SpanStats`
struct.

Within a `SpanStats`, simple statistics for each level are computed.
Initially these stats consist of the file count and total file size for
each level. L0 sublevels are broken out separately.

The output of a call to `DebugSpan` is envisioned to be used in a
similar fashion to the `Metrics` API, returning a string representation
of the state of the LSM. For example, given an LSM with files in various
levels L0, L3, L5 and L6, the ouput of a call `DebugSpan(start, end)` is
as follows:

```
___level___files_______bytes___r-amp
     0.1       1         775       1
     0.0       3        2325       1
       1       0           0       0
       2       0           0       0
       3       1         775       1
       4       0           0       0
       5       2        1550       1
       6       4        3107       1
   total      11        8532       5
```

The implementation of this debug API uses the current read state of the
DB at the time the method was called, and iterates over the files in
each level (and sublevel) to find files that overlap the given start and
end bounds. This provides a fast and relatively inexpensive means of
computing the state of the LSM between arbitrary bounds.

It is envisioned that this API will be used in Cockroach for computing
statistics on spans that represent entire tables, indexes, etc., i.e.
something akin to `DebugSpan('/table/1', '/table/2')`. This is intended
to help answer questions that often arise when troubleshooting
performance issues, commonly along the lines of "what is contributing to
read amp and/or LSM inverted LSM", or "how is table 'foo' sitting in the
LSM", etc.

Touches cockroachdb/cockroach#83942.

Informs cockroachdb/cockroach#79101.