### PR TITLE
db: export ErrCorruption

### DIFF
--- a/internal.go
+++ b/internal.go
@@ -34,3 +34,7 @@ type InternalKey = base.InternalKey
 type internalIterator = base.InternalIterator
 
 type internalIteratorWithStats = base.InternalIteratorWithStats
+
+// ErrCorruption is a marker to indicate that data in a file (WAL, MANIFEST,
+// sstable) isn't in the expected format.
+var ErrCorruption = base.ErrCorruption


### PR DESCRIPTION
Export the ErrCorruption error from the public pebble package. This allows
users, including CockroachDB, to test specifically for errors marked as
corruption.

Informs cockroachdb/cockroach#84479.