### PR TITLE
internal/keyspan: tighten masking guarantees

### DIFF
--- a/internal/keyspan/testdata/interleaving_iter
+++ b/internal/keyspan/testdata/interleaving_iter
@@ -33,6 +33,7 @@ next
 next
 next
 ----
+-- SpanChanged(nil)
 -- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
 PointKey: a#72057594037927935,21
 Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
@@ -65,10 +66,11 @@ Span: h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,st
 PointKey: l#72057594037927935,20
 Span: l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
 -
--- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
+-- SpanChanged(nil)
 PointKey: parsnip#3,1
 Span: <invalid>
 -
+-- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
 PointKey: q#72057594037927935,21
 Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
@@ -85,6 +87,7 @@ seek-ge b
 next
 next
 ----
+-- SpanChanged(nil)
 -- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
 PointKey: b#72057594037927935,21
 Span: b-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
@@ -131,11 +134,12 @@ seek-ge z
 PointKey: a#72057594037927935,21
 Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
 PointKey: a#72057594037927935,21
 Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
--- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
+-- SpanChanged(nil)
 PointKey: parsnip#3,1
 Span: <invalid>
 -
@@ -159,27 +163,29 @@ next
 next
 next
 ----
--- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
 PointKey: zucchini#12,2
 Span: <invalid>
 -
+-- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
 PointKey: tomato#2,1
 Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
 PointKey: q#72057594037927935,21
 Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
--- SpanChanged(l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)})
+-- SpanChanged(nil)
 PointKey: parsnip#3,1
 Span: <invalid>
 -
+-- SpanChanged(l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)})
 PointKey: l#72057594037927935,20
 Span: l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
 -
--- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
+-- SpanChanged(nil)
 PointKey: parsnip#3,1
 Span: <invalid>
 -
+-- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
 PointKey: q#72057594037927935,21
 Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
@@ -205,14 +211,16 @@ Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 PointKey: tomato#2,1
 Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
 PointKey: q#72057594037927935,21
 Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
--- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
+-- SpanChanged(nil)
 PointKey: parsnip#3,1
 Span: <invalid>
 -
+-- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
 PointKey: q#72057594037927935,21
 Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
@@ -222,15 +230,15 @@ seek-lt tomato
 prev
 seek-lt a
 ----
+-- SpanChanged(nil)
 -- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
 PointKey: q#72057594037927935,21
 Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
--- SpanChanged(l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)})
+-- SpanChanged(nil)
 PointKey: parsnip#3,1
 Span: <invalid>
 -
--- SpanChanged(nil)
 .
 
 define-rangekeys
@@ -259,6 +267,7 @@ next
 next
 next
 ----
+-- SpanChanged(nil)
 -- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
 PointKey: a#72057594037927935,21
 Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
@@ -303,10 +312,11 @@ Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
 PointKey: c#9,0
 Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
 -
--- SpanChanged(e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)})
+-- SpanChanged(nil)
 PointKey: d#3,1
 Span: <invalid>
 -
+-- SpanChanged(e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)})
 PointKey: e#72057594037927935,21
 Span: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
 -
@@ -341,6 +351,7 @@ next
 next
 next
 ----
+-- SpanChanged(nil)
 -- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
 PointKey: a#72057594037927935,21
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
@@ -368,6 +379,7 @@ iter
 seek-ge b
 prev
 ----
+-- SpanChanged(nil)
 -- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
 PointKey: b#72057594037927935,21
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
@@ -388,6 +400,7 @@ prev
 prev
 prev
 ----
+-- SpanChanged(nil)
 -- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
 PointKey: b#72057594037927935,21
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
@@ -412,6 +425,7 @@ iter
 seek-lt c
 next
 ----
+-- SpanChanged(nil)
 -- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
 PointKey: b#13,1
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
@@ -425,6 +439,7 @@ seek-lt c
 prev
 next
 ----
+-- SpanChanged(nil)
 -- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
 PointKey: b#13,1
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
@@ -465,10 +480,11 @@ prev
 next
 next
 ----
--- SpanChanged(ace-bat:{(#5,RANGEKEYSET,@5,v5)})
+-- SpanChanged(nil)
 PointKey: a#9,1
 Span: <invalid>
 -
+-- SpanChanged(ace-bat:{(#5,RANGEKEYSET,@5,v5)})
 PointKey: ace#72057594037927935,21
 Span: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
 -
@@ -482,7 +498,7 @@ Span: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
 PointKey: b#13,1
 Span: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
 -
--- SpanChanged(x-z:{(#6,RANGEKEYSET,@6,v5)})
+-- SpanChanged(nil)
 PointKey: c#9,0
 Span: <invalid>
 -
@@ -491,11 +507,9 @@ iter
 seek-lt ace
 seek-lt zoo
 ----
--- SpanChanged(nil)
 PointKey: a#9,1
 Span: <invalid>
 -
--- SpanChanged(x-z:{(#6,RANGEKEYSET,@6,v5)})
 PointKey: z#3,1
 Span: <invalid>
 -
@@ -506,10 +520,10 @@ prev
 next
 next
 ----
--- SpanChanged(x-z:{(#6,RANGEKEYSET,@6,v5)})
 PointKey: z#3,1
 Span: <invalid>
 -
+-- SpanChanged(x-z:{(#6,RANGEKEYSET,@6,v5)})
 PointKey: y#3,1
 Span: x-z:{(#6,RANGEKEYSET,@6,v5)}
 -
@@ -525,19 +539,15 @@ next
 seek-ge m
 prev
 ----
--- SpanChanged(ace-bat:{(#5,RANGEKEYSET,@5,v5)})
 PointKey: d#18,1
 Span: <invalid>
 -
--- SpanChanged(x-z:{(#6,RANGEKEYSET,@6,v5)})
 PointKey: m#4,1
 Span: <invalid>
 -
--- SpanChanged(x-z:{(#6,RANGEKEYSET,@6,v5)})
 PointKey: m#4,1
 Span: <invalid>
 -
--- SpanChanged(ace-bat:{(#5,RANGEKEYSET,@5,v5)})
 PointKey: d#18,1
 Span: <invalid>
 -
@@ -561,18 +571,22 @@ last
 seek-ge a
 seek-lt d
 ----
+-- SpanChanged(nil)
 -- SpanChanged(b-d:{(#5,RANGEKEYDEL)})
 PointKey: b#72057594037927935,19
 Span: b-d:{(#5,RANGEKEYDEL)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(f-g:{(#6,RANGEKEYDEL)})
 PointKey: f#72057594037927935,19
 Span: f-g:{(#6,RANGEKEYDEL)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(b-d:{(#5,RANGEKEYDEL)})
 PointKey: b#72057594037927935,19
 Span: b-d:{(#5,RANGEKEYDEL)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(b-d:{(#5,RANGEKEYDEL)})
 PointKey: c#8,1
 Span: b-d:{(#5,RANGEKEYDEL)}
@@ -597,6 +611,7 @@ first
 next
 next
 ----
+-- SpanChanged(nil)
 -- SpanChanged(w-y:{(#5,RANGEKEYSET,@1,v1)})
 PointKey: w#72057594037927935,21
 Span: w-y:{(#5,RANGEKEYSET,@1,v1)}
@@ -615,6 +630,7 @@ iter
 first
 prev
 ----
+-- SpanChanged(nil)
 -- SpanChanged(w-y:{(#5,RANGEKEYSET,@1,v1)})
 PointKey: w#72057594037927935,21
 Span: w-y:{(#5,RANGEKEYSET,@1,v1)}
@@ -637,6 +653,7 @@ seek-ge c
 prev
 next
 ----
+-- SpanChanged(nil)
 -- SpanChanged(a-z:{(#5,RANGEKEYSET,@1,v1)})
 PointKey: c#72057594037927935,21
 Span: a-z:{(#5,RANGEKEYSET,@1,v1)}
@@ -662,10 +679,11 @@ prev
 PointKey: a#72057594037927935,21
 Span: a-c:{(#5,RANGEKEYSET,@1,v1)}
 -
--- SpanChanged(a-z:{(#5,RANGEKEYSET,@1,v1)})
+-- SpanChanged(nil)
 PointKey: z#8,1
 Span: <invalid>
 -
+-- SpanChanged(a-z:{(#5,RANGEKEYSET,@1,v1)})
 PointKey: c#72057594037927935,21
 Span: c-z:{(#5,RANGEKEYSET,@1,v1)}
 -
@@ -698,7 +716,7 @@ prev
 prev
 next
 ----
--- SpanChanged(j-l:{(#3,RANGEKEYSET,@1,v0)})
+-- SpanChanged(nil)
 PointKey: z#1,1
 Span: <invalid>
 -
@@ -711,6 +729,7 @@ Span: <invalid>
 PointKey: s#1,1
 Span: <invalid>
 -
+-- SpanChanged(j-l:{(#3,RANGEKEYSET,@1,v0)})
 PointKey: j#72057594037927935,21
 Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
 -
@@ -745,10 +764,11 @@ next
 next
 prev
 ----
--- SpanChanged(j-l:{(#3,RANGEKEYSET,@1,v0)})
+-- SpanChanged(nil)
 PointKey: a#1,1
 Span: <invalid>
 -
+-- SpanChanged(j-l:{(#3,RANGEKEYSET,@1,v0)})
 PointKey: j#72057594037927935,21
 Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
 -
@@ -781,14 +801,13 @@ iter
 set-bounds a c
 seek-ge c
 ----
--- SpanChanged(a-d:{(#10,RANGEKEYSET,@5,apples)})
+-- SpanChanged(nil)
 .
 
 iter
 set-bounds a c
 seek-lt a
 ----
--- SpanChanged(nil)
 .
 
 # Test a SeekLT that searches a keyspace exclusive with the iterator's bounds.

--- a/internal/keyspan/testdata/interleaving_iter
+++ b/internal/keyspan/testdata/interleaving_iter
@@ -33,6 +33,7 @@ next
 next
 next
 ----
+-- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
 PointKey: a#72057594037927935,21
 Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
@@ -42,6 +43,7 @@ Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (
 PointKey: artichoke#8,1
 Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
+-- SpanChanged(c-d:{(#4,RANGEKEYSET,@3,coconut)})
 PointKey: c#72057594037927935,21
 Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
 -
@@ -51,15 +53,19 @@ Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
 PointKey: cauliflower#9,0
 Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
 -
+-- SpanChanged(e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)})
 PointKey: e#72057594037927935,21
 Span: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
 -
+-- SpanChanged(h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)})
 PointKey: h#72057594037927935,19
 Span: h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)}
 -
+-- SpanChanged(l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)})
 PointKey: l#72057594037927935,20
 Span: l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
 -
+-- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
 PointKey: parsnip#3,1
 Span: <invalid>
 -
@@ -79,12 +85,15 @@ seek-ge b
 next
 next
 ----
+-- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
 PointKey: b#72057594037927935,21
 Span: b-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
+-- SpanChanged(c-d:{(#4,RANGEKEYSET,@3,coconut)})
 PointKey: c#72057594037927935,21
 Span: c-carrot:{(#4,RANGEKEYSET,@3,coconut)}
 -
+-- SpanChanged(nil)
 .
 
 
@@ -97,12 +106,15 @@ seek-lt carrot
 prev
 prev
 ----
+-- SpanChanged(c-d:{(#4,RANGEKEYSET,@3,coconut)})
 PointKey: c#72057594037927935,21
 Span: c-carrot:{(#4,RANGEKEYSET,@3,coconut)}
 -
+-- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
 PointKey: b#72057594037927935,21
 Span: b-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
+-- SpanChanged(nil)
 .
 
 # Test seek-ge.
@@ -115,18 +127,23 @@ seek-ge p
 seek-ge yyy
 seek-ge z
 ----
+-- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
 PointKey: a#72057594037927935,21
 Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
+-- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
 PointKey: a#72057594037927935,21
 Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
+-- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
 PointKey: parsnip#3,1
 Span: <invalid>
 -
+-- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
 PointKey: yyy#72057594037927935,21
 Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
+-- SpanChanged(nil)
 PointKey: zucchini#12,2
 Span: <invalid>
 -
@@ -142,6 +159,7 @@ next
 next
 next
 ----
+-- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
 PointKey: zucchini#12,2
 Span: <invalid>
 -
@@ -151,12 +169,14 @@ Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 PointKey: q#72057594037927935,21
 Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
+-- SpanChanged(l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)})
 PointKey: parsnip#3,1
 Span: <invalid>
 -
 PointKey: l#72057594037927935,20
 Span: l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
 -
+-- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
 PointKey: parsnip#3,1
 Span: <invalid>
 -
@@ -166,6 +186,7 @@ Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 PointKey: tomato#2,1
 Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
+-- SpanChanged(nil)
 PointKey: zucchini#12,2
 Span: <invalid>
 -
@@ -177,15 +198,18 @@ seek-ge q
 seek-ge parsnip
 next
 ----
+-- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
 PointKey: tomato#72057594037927935,21
 Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
 PointKey: tomato#2,1
 Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
+-- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
 PointKey: q#72057594037927935,21
 Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
+-- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
 PointKey: parsnip#3,1
 Span: <invalid>
 -
@@ -198,12 +222,15 @@ seek-lt tomato
 prev
 seek-lt a
 ----
+-- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
 PointKey: q#72057594037927935,21
 Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
+-- SpanChanged(l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)})
 PointKey: parsnip#3,1
 Span: <invalid>
 -
+-- SpanChanged(nil)
 .
 
 define-rangekeys
@@ -232,6 +259,7 @@ next
 next
 next
 ----
+-- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
 PointKey: a#72057594037927935,21
 Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
@@ -248,6 +276,7 @@ Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (
 iter
 seek-lt a
 ----
+-- SpanChanged(nil)
 .
 
 iter
@@ -260,18 +289,21 @@ next
 next
 next
 ----
+-- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
 PointKey: ab#72057594037927935,21
 Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
 PointKey: b#13,1
 Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
+-- SpanChanged(c-d:{(#4,RANGEKEYSET,@3,coconut)})
 PointKey: c#72057594037927935,21
 Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
 -
 PointKey: c#9,0
 Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
 -
+-- SpanChanged(e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)})
 PointKey: d#3,1
 Span: <invalid>
 -
@@ -281,6 +313,7 @@ Span: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
 PointKey: e#2,1
 Span: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
 -
+-- SpanChanged(h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)})
 PointKey: h#72057594037927935,19
 Span: h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)}
 -
@@ -308,6 +341,7 @@ next
 next
 next
 ----
+-- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
 PointKey: a#72057594037927935,21
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
@@ -334,9 +368,11 @@ iter
 seek-ge b
 prev
 ----
+-- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
 PointKey: b#72057594037927935,21
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
+-- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
 PointKey: a#8,1
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
@@ -352,12 +388,14 @@ prev
 prev
 prev
 ----
+-- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
 PointKey: b#72057594037927935,21
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
 PointKey: b#13,1
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
+-- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
 PointKey: a#8,1
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
@@ -374,6 +412,7 @@ iter
 seek-lt c
 next
 ----
+-- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
 PointKey: b#13,1
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
@@ -386,6 +425,7 @@ seek-lt c
 prev
 next
 ----
+-- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
 PointKey: b#13,1
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
@@ -425,6 +465,7 @@ prev
 next
 next
 ----
+-- SpanChanged(ace-bat:{(#5,RANGEKEYSET,@5,v5)})
 PointKey: a#9,1
 Span: <invalid>
 -
@@ -434,12 +475,14 @@ Span: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
 PointKey: b#13,1
 Span: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
 -
+-- SpanChanged(ace-bat:{(#5,RANGEKEYSET,@5,v5)})
 PointKey: ace#72057594037927935,21
 Span: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
 -
 PointKey: b#13,1
 Span: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
 -
+-- SpanChanged(x-z:{(#6,RANGEKEYSET,@6,v5)})
 PointKey: c#9,0
 Span: <invalid>
 -
@@ -448,9 +491,11 @@ iter
 seek-lt ace
 seek-lt zoo
 ----
+-- SpanChanged(nil)
 PointKey: a#9,1
 Span: <invalid>
 -
+-- SpanChanged(x-z:{(#6,RANGEKEYSET,@6,v5)})
 PointKey: z#3,1
 Span: <invalid>
 -
@@ -461,12 +506,14 @@ prev
 next
 next
 ----
+-- SpanChanged(x-z:{(#6,RANGEKEYSET,@6,v5)})
 PointKey: z#3,1
 Span: <invalid>
 -
 PointKey: y#3,1
 Span: x-z:{(#6,RANGEKEYSET,@6,v5)}
 -
+-- SpanChanged(nil)
 PointKey: z#3,1
 Span: <invalid>
 -
@@ -478,15 +525,19 @@ next
 seek-ge m
 prev
 ----
+-- SpanChanged(ace-bat:{(#5,RANGEKEYSET,@5,v5)})
 PointKey: d#18,1
 Span: <invalid>
 -
+-- SpanChanged(x-z:{(#6,RANGEKEYSET,@6,v5)})
 PointKey: m#4,1
 Span: <invalid>
 -
+-- SpanChanged(x-z:{(#6,RANGEKEYSET,@6,v5)})
 PointKey: m#4,1
 Span: <invalid>
 -
+-- SpanChanged(ace-bat:{(#5,RANGEKEYSET,@5,v5)})
 PointKey: d#18,1
 Span: <invalid>
 -
@@ -510,15 +561,19 @@ last
 seek-ge a
 seek-lt d
 ----
+-- SpanChanged(b-d:{(#5,RANGEKEYDEL)})
 PointKey: b#72057594037927935,19
 Span: b-d:{(#5,RANGEKEYDEL)}
 -
+-- SpanChanged(f-g:{(#6,RANGEKEYDEL)})
 PointKey: f#72057594037927935,19
 Span: f-g:{(#6,RANGEKEYDEL)}
 -
+-- SpanChanged(b-d:{(#5,RANGEKEYDEL)})
 PointKey: b#72057594037927935,19
 Span: b-d:{(#5,RANGEKEYDEL)}
 -
+-- SpanChanged(b-d:{(#5,RANGEKEYDEL)})
 PointKey: c#8,1
 Span: b-d:{(#5,RANGEKEYDEL)}
 -
@@ -542,12 +597,14 @@ first
 next
 next
 ----
+-- SpanChanged(w-y:{(#5,RANGEKEYSET,@1,v1)})
 PointKey: w#72057594037927935,21
 Span: w-y:{(#5,RANGEKEYSET,@1,v1)}
 -
 PointKey: x#8,1
 Span: w-y:{(#5,RANGEKEYSET,@1,v1)}
 -
+-- SpanChanged(y-z:{(#5,RANGEKEYDEL)})
 PointKey: y#72057594037927935,19
 Span: y-z:{(#5,RANGEKEYDEL)}
 -
@@ -558,9 +615,11 @@ iter
 first
 prev
 ----
+-- SpanChanged(w-y:{(#5,RANGEKEYSET,@1,v1)})
 PointKey: w#72057594037927935,21
 Span: w-y:{(#5,RANGEKEYSET,@1,v1)}
 -
+-- SpanChanged(nil)
 .
 
 define-rangekeys
@@ -578,12 +637,15 @@ seek-ge c
 prev
 next
 ----
+-- SpanChanged(a-z:{(#5,RANGEKEYSET,@1,v1)})
 PointKey: c#72057594037927935,21
 Span: a-z:{(#5,RANGEKEYSET,@1,v1)}
 -
+-- SpanChanged(a-z:{(#5,RANGEKEYSET,@1,v1)})
 PointKey: a#72057594037927935,21
 Span: a-z:{(#5,RANGEKEYSET,@1,v1)}
 -
+-- SpanChanged(nil)
 PointKey: z#8,1
 Span: <invalid>
 -
@@ -596,15 +658,18 @@ last
 prev
 prev
 ----
+-- SpanChanged(a-z:{(#5,RANGEKEYSET,@1,v1)})
 PointKey: a#72057594037927935,21
 Span: a-c:{(#5,RANGEKEYSET,@1,v1)}
 -
+-- SpanChanged(a-z:{(#5,RANGEKEYSET,@1,v1)})
 PointKey: z#8,1
 Span: <invalid>
 -
 PointKey: c#72057594037927935,21
 Span: c-z:{(#5,RANGEKEYSET,@1,v1)}
 -
+-- SpanChanged(nil)
 .
 
 # Test switching directions after exhausting a range key iterator.
@@ -633,6 +698,7 @@ prev
 prev
 next
 ----
+-- SpanChanged(j-l:{(#3,RANGEKEYSET,@1,v0)})
 PointKey: z#1,1
 Span: <invalid>
 -
@@ -648,9 +714,11 @@ Span: <invalid>
 PointKey: j#72057594037927935,21
 Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
 -
+-- SpanChanged(nil)
 PointKey: g#1,1
 Span: <invalid>
 -
+-- SpanChanged(j-l:{(#3,RANGEKEYSET,@1,v0)})
 PointKey: j#72057594037927935,21
 Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
 -
@@ -677,6 +745,7 @@ next
 next
 prev
 ----
+-- SpanChanged(j-l:{(#3,RANGEKEYSET,@1,v0)})
 PointKey: a#1,1
 Span: <invalid>
 -
@@ -686,9 +755,11 @@ Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
 PointKey: k#1,1
 Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
 -
+-- SpanChanged(nil)
 PointKey: m#1,1
 Span: <invalid>
 -
+-- SpanChanged(j-l:{(#3,RANGEKEYSET,@1,v0)})
 PointKey: k#1,1
 Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
 -
@@ -710,12 +781,14 @@ iter
 set-bounds a c
 seek-ge c
 ----
+-- SpanChanged(a-d:{(#10,RANGEKEYSET,@5,apples)})
 .
 
 iter
 set-bounds a c
 seek-lt a
 ----
+-- SpanChanged(nil)
 .
 
 # Test a SeekLT that searches a keyspace exclusive with the iterator's bounds.
@@ -737,4 +810,5 @@ iter
 set-bounds d e
 seek-lt d
 ----
+-- SpanChanged(nil)
 .

--- a/internal/keyspan/testdata/interleaving_iter_masking
+++ b/internal/keyspan/testdata/interleaving_iter_masking
@@ -46,27 +46,33 @@ next
 next
 next
 ----
+-- SpanChanged(e-f:{(#1,RANGEKEYSET,@9,foo)})
 PointKey: b@2#1,1
 Span: <invalid>
 -
 PointKey: e#72057594037927935,21
 Span: e-f:{(#1,RANGEKEYSET,@9,foo)}
 -
+-- SpanChanged(f-h:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@3,bar)})
 PointKey: f#72057594037927935,21
 Span: f-h:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@3,bar)}
 -
+-- SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
 PointKey: h#72057594037927935,21
 Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
 -
+-- SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
 PointKey: l#72057594037927935,21
 Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 -
 PointKey: l@8#1,1
 Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 -
+-- SpanChanged(m-q:{(#1,RANGEKEYSET,@6,bax)})
 PointKey: m#72057594037927935,21
 Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
 -
+-- SpanChanged(nil)
 .
 
 iter
@@ -79,24 +85,30 @@ prev
 prev
 prev
 ----
+-- SpanChanged(m-q:{(#1,RANGEKEYSET,@6,bax)})
 PointKey: m#72057594037927935,21
 Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
 -
+-- SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
 PointKey: l@8#1,1
 Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 -
 PointKey: l#72057594037927935,21
 Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 -
+-- SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
 PointKey: h#72057594037927935,21
 Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
 -
+-- SpanChanged(f-h:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@3,bar)})
 PointKey: f#72057594037927935,21
 Span: f-h:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@3,bar)}
 -
+-- SpanChanged(e-f:{(#1,RANGEKEYSET,@9,foo)})
 PointKey: e#72057594037927935,21
 Span: e-f:{(#1,RANGEKEYSET,@9,foo)}
 -
+-- SpanChanged(nil)
 PointKey: b@2#1,1
 Span: <invalid>
 -
@@ -112,27 +124,34 @@ next
 seek-ge m
 seek-ge r
 ----
+-- SpanChanged(e-f:{(#1,RANGEKEYSET,@9,foo)})
 PointKey: b@2#1,1
 Span: <invalid>
 -
+-- SpanChanged(e-f:{(#1,RANGEKEYSET,@9,foo)})
 PointKey: e#72057594037927935,21
 Span: e-f:{(#1,RANGEKEYSET,@9,foo)}
 -
+-- SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
 PointKey: h#72057594037927935,21
 Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
 -
+-- SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
 PointKey: i#72057594037927935,21
 Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
 -
+-- SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
 PointKey: l#72057594037927935,21
 Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 -
 PointKey: l@8#1,1
 Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 -
+-- SpanChanged(m-q:{(#1,RANGEKEYSET,@6,bax)})
 PointKey: m#72057594037927935,21
 Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
 -
+-- SpanChanged(nil)
 .
 
 # Setting the masking threshold to @9 should result in l@8 being masked by
@@ -150,18 +169,23 @@ seek-lt l
 seek-lt ll
 prev
 ----
+-- SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
 PointKey: l#72057594037927935,21
 Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 -
+-- SpanChanged(m-q:{(#1,RANGEKEYSET,@6,bax)})
 PointKey: m#72057594037927935,21
 Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
 -
+-- SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
 PointKey: h#72057594037927935,21
 Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
 -
+-- SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
 PointKey: l#72057594037927935,21
 Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 -
+-- SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
 PointKey: h#72057594037927935,21
 Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
 -
@@ -170,9 +194,11 @@ iter
 seek-ge l
 next
 ----
+-- SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
 PointKey: l#72057594037927935,21
 Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 -
+-- SpanChanged(m-q:{(#1,RANGEKEYSET,@6,bax)})
 PointKey: m#72057594037927935,21
 Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
 -
@@ -205,6 +231,7 @@ next
 next
 next
 ----
+-- SpanChanged(a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)})
 PointKey: a#72057594037927935,21
 Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
 -
@@ -214,6 +241,7 @@ Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
 PointKey: a@12#1,1
 Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
 -
+-- SpanChanged(nil)
 .
 
 iter
@@ -222,6 +250,7 @@ prev
 prev
 prev
 ----
+-- SpanChanged(a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)})
 PointKey: a@12#1,1
 Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
 -
@@ -231,6 +260,7 @@ Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
 PointKey: a#72057594037927935,21
 Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
 -
+-- SpanChanged(nil)
 .
 
 # Try the same test, but with a range key that sorts before the masking
@@ -249,6 +279,7 @@ next
 next
 next
 ----
+-- SpanChanged(a-c:{(#2,RANGEKEYSET,@20,apples)})
 PointKey: a#72057594037927935,21
 Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
 -
@@ -264,6 +295,7 @@ Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
 PointKey: b@2#1,1
 Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
 -
+-- SpanChanged(nil)
 .
 
 iter
@@ -274,6 +306,7 @@ prev
 prev
 prev
 ----
+-- SpanChanged(a-c:{(#2,RANGEKEYSET,@20,apples)})
 PointKey: b@2#1,1
 Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
 -
@@ -289,6 +322,7 @@ Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
 PointKey: a#72057594037927935,21
 Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
 -
+-- SpanChanged(nil)
 .
 
 # Try the original test, but with an internal range key containing just an
@@ -307,6 +341,7 @@ next
 next
 next
 ----
+-- SpanChanged(a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)})
 PointKey: a#72057594037927935,20
 Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 -
@@ -316,6 +351,7 @@ Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 PointKey: a@12#1,1
 Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 -
+-- SpanChanged(nil)
 .
 .
 
@@ -326,6 +362,7 @@ prev
 prev
 prev
 ----
+-- SpanChanged(a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)})
 PointKey: a@12#1,1
 Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 -
@@ -335,6 +372,7 @@ Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 PointKey: a#72057594037927935,20
 Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 -
+-- SpanChanged(nil)
 .
 .
 
@@ -364,9 +402,11 @@ first
 next
 next
 ----
+-- SpanChanged(a-c:{(#1,RANGEKEYSET,@5,apples)})
 PointKey: a#72057594037927935,21
 Span: a-c:{(#1,RANGEKEYSET,@5,apples)}
 -
+-- SpanChanged(c-z:{(#1,RANGEKEYSET,@10,bananas)})
 PointKey: c#72057594037927935,21
 Span: c-z:{(#1,RANGEKEYSET,@10,bananas)}
 -
@@ -379,12 +419,14 @@ last
 prev
 prev
 ----
+-- SpanChanged(c-z:{(#1,RANGEKEYSET,@10,bananas)})
 PointKey: j@11#3,1
 Span: c-z:{(#1,RANGEKEYSET,@10,bananas)}
 -
 PointKey: c#72057594037927935,21
 Span: c-z:{(#1,RANGEKEYSET,@10,bananas)}
 -
+-- SpanChanged(a-c:{(#1,RANGEKEYSET,@5,apples)})
 PointKey: a#72057594037927935,21
 Span: a-c:{(#1,RANGEKEYSET,@5,apples)}
 -

--- a/internal/keyspan/testdata/interleaving_iter_masking
+++ b/internal/keyspan/testdata/interleaving_iter_masking
@@ -46,10 +46,11 @@ next
 next
 next
 ----
--- SpanChanged(e-f:{(#1,RANGEKEYSET,@9,foo)})
+-- SpanChanged(nil)
 PointKey: b@2#1,1
 Span: <invalid>
 -
+-- SpanChanged(e-f:{(#1,RANGEKEYSET,@9,foo)})
 PointKey: e#72057594037927935,21
 Span: e-f:{(#1,RANGEKEYSET,@9,foo)}
 -
@@ -124,7 +125,6 @@ next
 seek-ge m
 seek-ge r
 ----
--- SpanChanged(e-f:{(#1,RANGEKEYSET,@9,foo)})
 PointKey: b@2#1,1
 Span: <invalid>
 -
@@ -132,14 +132,17 @@ Span: <invalid>
 PointKey: e#72057594037927935,21
 Span: e-f:{(#1,RANGEKEYSET,@9,foo)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
 PointKey: h#72057594037927935,21
 Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
 PointKey: i#72057594037927935,21
 Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
 PointKey: l#72057594037927935,21
 Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
@@ -147,6 +150,7 @@ Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 PointKey: l@8#1,1
 Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(m-q:{(#1,RANGEKEYSET,@6,bax)})
 PointKey: m#72057594037927935,21
 Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
@@ -177,10 +181,12 @@ Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
 PointKey: m#72057594037927935,21
 Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
 PointKey: h#72057594037927935,21
 Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
 PointKey: l#72057594037927935,21
 Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
@@ -194,6 +200,7 @@ iter
 seek-ge l
 next
 ----
+-- SpanChanged(nil)
 -- SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
 PointKey: l#72057594037927935,21
 Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
@@ -231,6 +238,7 @@ next
 next
 next
 ----
+-- SpanChanged(nil)
 -- SpanChanged(a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)})
 PointKey: a#72057594037927935,21
 Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
@@ -279,6 +287,7 @@ next
 next
 next
 ----
+-- SpanChanged(nil)
 -- SpanChanged(a-c:{(#2,RANGEKEYSET,@20,apples)})
 PointKey: a#72057594037927935,21
 Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
@@ -341,6 +350,7 @@ next
 next
 next
 ----
+-- SpanChanged(nil)
 -- SpanChanged(a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)})
 PointKey: a#72057594037927935,20
 Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
@@ -402,6 +412,7 @@ first
 next
 next
 ----
+-- SpanChanged(nil)
 -- SpanChanged(a-c:{(#1,RANGEKEYSET,@5,apples)})
 PointKey: a#72057594037927935,21
 Span: a-c:{(#1,RANGEKEYSET,@5,apples)}
@@ -419,6 +430,7 @@ last
 prev
 prev
 ----
+-- SpanChanged(nil)
 -- SpanChanged(c-z:{(#1,RANGEKEYSET,@10,bananas)})
 PointKey: j@11#3,1
 Span: c-z:{(#1,RANGEKEYSET,@10,bananas)}
@@ -430,3 +442,47 @@ Span: c-z:{(#1,RANGEKEYSET,@10,bananas)}
 PointKey: a#72057594037927935,21
 Span: a-c:{(#1,RANGEKEYSET,@5,apples)}
 -
+
+# Test a scenario where a there's an empty range key, requiring the interleaving
+# iter to call SpanChanged(nil) which should clear the previous mask.
+
+define-rangekeys
+a-c:{(#1,RANGEKEYSET,@10,apples)}
+c-e:{}
+e-f:{(#1,RANGEKEYSET,@5,bananas)}
+----
+OK
+
+define-pointkeys
+a@2.SET.4
+b@9.SET.2
+d@9.SET.3
+----
+OK
+
+set-masking-threshold
+@20
+----
+OK
+
+iter
+seek-ge a
+next
+next
+next
+----
+-- SpanChanged(nil)
+-- SpanChanged(a-c:{(#1,RANGEKEYSET,@10,apples)})
+PointKey: a#72057594037927935,21
+Span: a-c:{(#1,RANGEKEYSET,@10,apples)}
+-
+-- SpanChanged(nil)
+PointKey: d@9#3,1
+Span: <invalid>
+-
+-- SpanChanged(e-f:{(#1,RANGEKEYSET,@5,bananas)})
+PointKey: e#72057594037927935,21
+Span: e-f:{(#1,RANGEKEYSET,@5,bananas)}
+-
+-- SpanChanged(nil)
+.

--- a/iterator.go
+++ b/iterator.go
@@ -1494,6 +1494,8 @@ func (i *Iterator) rangeKeyWithinLimit(limit []byte) bool {
 	return true
 }
 
+// SpanChanged implements the keyspan.SpanMask interface, used during range key
+// iteration.
 func (i *iteratorRangeKeyState) SpanChanged(s *keyspan.Span) {
 	i.activeMaskSuffix = i.activeMaskSuffix[:0]
 
@@ -1515,10 +1517,10 @@ func (i *iteratorRangeKeyState) SpanChanged(s *keyspan.Span) {
 	}
 }
 
-// SkipPoint is installed as a keyspan.InterleavingIter's SkipPoint hook during
-// range key iteration. Whenever a point key is covered by a non-empty Span, the
-// interleaving iterator invokes the SkipPoint hook. This function is
-// responsible for performing range key masking.
+// SkipPoint implements the keyspan.SpanMask interface, used during range key
+// iteration. Whenever a point key is covered by a non-empty Span, the
+// interleaving iterator invokes SkipPoint. This function is responsible for
+// performing range key masking.
 //
 // If a non-nil IterOptions.RangeKeyMasking.Suffix is set, range key masking is
 // enabled. Masking hides point keys, transparently skipping over the keys.
@@ -1555,7 +1557,8 @@ func (i *iteratorRangeKeyState) SpanChanged(s *keyspan.Span) {
 // non-masking due to its suffix. The point key l@8 also falls within the user
 // key bounds of [h,q)@6, but since cmp(@6,@8) ≥ 0, l@8 is unmasked.
 //
-// Invariant: userKey is within the user key bounds of i.rangeKey.iter.Span().
+// Invariant: The userKey is within the user key bounds of the span most
+// recently provided to `SpanChanged`.
 func (i *iteratorRangeKeyState) SkipPoint(userKey []byte) bool {
 	if len(i.activeMaskSuffix) == 0 {
 		// No range key is currently acting as a mask, so don't skip.

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -878,3 +878,28 @@ prev
 ----
 d: (., [d-e) @1=foo)
 a: (a, .)
+
+# Test a range key masking case where the range key is not immediately
+# masking point keys, but masks point keys once positioned beneath it.
+
+reset
+----
+
+batch
+range-key-set d e @5 boop
+set a@1 a1
+set b@3 b3
+set d@3 d3
+----
+wrote 4 keys
+
+combined-iter mask-suffix=@9
+first
+next
+next
+next
+----
+a@1: (a1, .)
+b@3: (b3, .)
+d: (., [d-e) @5=boop)
+.


### PR DESCRIPTION
Refactor the InterleavingIter's Hooks to be masking-specific, and tighten its
contract of guarantees.

The InterleavingIter's SpanChanged hook is intended to notify a caller when the
span covering the current iterator position changes. This is used during
range-key masking to configure the suffix used to filter points. The
InterleavingIter previously called SpanChanged eagerly, whenever it positioned
the key span iterator. Range-key masking correctness relied on the SkipPoint
hook only being invoked when a point key is covered by the current span.

The previous guarantees were sufficient for filtering points in SkipPoint but
are not strong enough for block-property masking.

Filtering masked keys using block-property filters (#1713) requires bounds
checking. We intend to only activate block-property filters once the point
iterator is already stepped into the first range key bound. Filtering cannot be
enabled via the SpanChanged hook until the InterleavingIter guarantees the
point key iterator is positioned within or beyond the current span.