### PR TITLE
db: fix memtable.containsRangeKeys race

### DIFF
--- a/range_keys_test.go
+++ b/range_keys_test.go
@@ -16,6 +16,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TODO(jackson): Add a range keys test with concurrency: the logic to cache
+// fragmented spans is susceptible to races.
+
 func TestRangeKeys(t *testing.T) {
 	var d *DB
 	var b *Batch


### PR DESCRIPTION
The memtable.containsRangeKeys method read an atomic value without using an
atomic intrinsic.

Informs cockroachdb/cockroach#84950.