### PR TITLE
.*: make MaxConcurrentCompactions dynamically changeable

### DIFF
--- a/cmd/pebble/compact.go
+++ b/cmd/pebble/compact.go
@@ -99,7 +99,6 @@ func open(dir string, listener pebble.EventListener) (*replay.DB, error) {
 		Comparer:                    mvccComparer,
 		MemTableSize:                64 << 20,
 		MemTableStopWritesThreshold: 4,
-		MaxConcurrentCompactions:    2,
 		L0CompactionThreshold:       2,
 		L0StopWritesThreshold:       400,
 		LBaseMaxBytes:               64 << 20, // 64 MB
@@ -107,6 +106,9 @@ func open(dir string, listener pebble.EventListener) (*replay.DB, error) {
 			BlockSize: 32 << 10,
 		}},
 		Merger: fauxMVCCMerger,
+		MaxConcurrentCompactions: func() int {
+			return 2
+		},
 	}
 	opts.EnsureDefaults()
 

--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -62,12 +62,14 @@ func newPebbleDB(dir string) DB {
 		L0StopWritesThreshold:       1000,
 		LBaseMaxBytes:               64 << 20, // 64 MB
 		Levels:                      make([]pebble.LevelOptions, 7),
-		MaxConcurrentCompactions:    3,
 		MaxOpenFiles:                16384,
 		MemTableSize:                64 << 20,
 		MemTableStopWritesThreshold: 4,
 		Merger: &pebble.Merger{
 			Name: "cockroach_merge_operator",
+		},
+		MaxConcurrentCompactions: func() int {
+			return 3
 		},
 	}
 

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -294,7 +294,9 @@ func (pc *pickedCompaction) setupInputs(
 	// maxExpandedBytes is the maximum size of an expanded compaction. If
 	// growing a compaction results in a larger size, the original compaction
 	// is used instead.
-	maxExpandedBytes := expandedCompactionByteSizeLimit(opts, pc.adjustedOutputLevel, diskAvailBytes)
+	maxExpandedBytes := expandedCompactionByteSizeLimit(
+		opts, pc.adjustedOutputLevel, diskAvailBytes,
+	)
 
 	// Expand the initial inputs to a clean cut.
 	var isCompacting bool

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1454,7 +1454,11 @@ func TestManualCompaction(t *testing.T) {
 				return ""
 
 			case "set-concurrent-compactions":
-				td.ScanArgs(t, "num", &d.opts.MaxConcurrentCompactions)
+				var concurrentCompactions int
+				td.ScanArgs(t, "num", &concurrentCompactions)
+				d.opts.MaxConcurrentCompactions = func() int {
+					return concurrentCompactions
+				}
 				return ""
 
 			case "wait-pending-table-stats":

--- a/db_test.go
+++ b/db_test.go
@@ -1062,10 +1062,13 @@ func TestDBConcurrentCompactClose(t *testing.T) {
 	// detects the close and finishes cleanly.
 	mem := vfs.NewMem()
 	for i := 0; i < 100; i++ {
-		d, err := Open("", testingRandomized(&Options{
-			FS:                       mem,
-			MaxConcurrentCompactions: 2,
-		}))
+		opts := &Options{
+			FS: mem,
+			MaxConcurrentCompactions: func() int {
+				return 2
+			},
+		}
+		d, err := Open("", testingRandomized(opts))
 		require.NoError(t, err)
 
 		// Ingest a series of files containing a single key each. As the outer

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -270,8 +270,11 @@ func randomOptions(rng *rand.Rand) *testOptions {
 	if opts.L0StopWritesThreshold < opts.L0CompactionThreshold {
 		opts.L0StopWritesThreshold = opts.L0CompactionThreshold
 	}
-	opts.LBaseMaxBytes = 1 << uint(rng.Intn(30))       // 1B - 1GB
-	opts.MaxConcurrentCompactions = rng.Intn(4)        // 0-3
+	opts.LBaseMaxBytes = 1 << uint(rng.Intn(30)) // 1B - 1GB
+	maxConcurrentCompactions := rng.Intn(3) + 1  // 1-3
+	opts.MaxConcurrentCompactions = func() int {
+		return maxConcurrentCompactions
+	}
 	opts.MaxManifestFileSize = 1 << uint(rng.Intn(30)) // 1B  - 1GB
 	opts.MemTableSize = 2 << (10 + uint(rng.Intn(16))) // 2KB - 256MB
 	opts.MemTableStopWritesThreshold = 2 + rng.Intn(5) // 2 - 5

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -2139,11 +2139,12 @@ func BenchmarkIterator_RangeKeyMasking(b *testing.B) {
 	valBuf := make([]byte, valueSize)
 
 	mem := vfs.NewStrictMem()
+	maxProcs := runtime.GOMAXPROCS(0)
 	opts := &Options{
 		FS:                       mem,
 		Comparer:                 testkeys.Comparer,
 		FormatMajorVersion:       FormatNewest,
-		MaxConcurrentCompactions: runtime.GOMAXPROCS(0)/2 + 1,
+		MaxConcurrentCompactions: func() int { return maxProcs/2 + 1 },
 		BlockPropertyCollectors: []func() BlockPropertyCollector{
 			blockprop.NewBlockPropertyCollector,
 		},


### PR DESCRIPTION
We turn MaxConcurrentCompactions into a function so that Cockroach
has the ability to change MaxConcurrentCompactions on the fly.