### PR TITLE
db: zero mergingIter, levelIter structs before use

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -160,6 +160,10 @@ func runIterCmd(d *datadriven.TestData, iter *Iterator, closeIter bool) string {
 			}
 			iter.SetOptions(&opts)
 			valid = iter.Valid()
+		case "stats":
+			stats := iter.Stats()
+			fmt.Fprintf(&b, "stats: %s\n", stats.String())
+			continue
 		case "clone":
 			var opts CloneOptions
 			if len(parts) > 1 {

--- a/iterator.go
+++ b/iterator.go
@@ -1811,7 +1811,11 @@ func (i *Iterator) Close() error {
 				alloc.boundsBuf[j] = i.boundsBuf[j]
 			}
 		}
-		*i = Iterator{}
+		*alloc = iterAlloc{
+			keyBuf:              alloc.keyBuf,
+			boundsBuf:           alloc.boundsBuf,
+			prefixOrFullSeekKey: alloc.prefixOrFullSeekKey,
+		}
 		iterAllocPool.Put(alloc)
 	} else if alloc := i.getIterAlloc; alloc != nil {
 		if cap(i.keyBuf) >= maxKeyBufCacheSize {
@@ -1819,7 +1823,9 @@ func (i *Iterator) Close() error {
 		} else {
 			alloc.keyBuf = i.keyBuf
 		}
-		*i = Iterator{}
+		*alloc = getIterAlloc{
+			keyBuf: alloc.keyBuf,
+		}
 		getIterAllocPool.Put(alloc)
 	}
 	return err

--- a/testdata/iterator_stats
+++ b/testdata/iterator_stats
@@ -1,0 +1,36 @@
+build ext1
+merge a 1
+set c 2
+----
+
+ingest ext1
+----
+6:
+  000004:[a#1,MERGE-c#1,SET]
+
+iter
+first
+next
+next
+stats
+----
+a:1
+c:2
+.
+stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 34 B, cached 34 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+
+# Perform the same operation again with a new iterator. It should yield
+# identical statistics.
+
+iter
+first
+next
+next
+stats
+----
+a:1
+c:2
+.
+stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 34 B, cached 34 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))


### PR DESCRIPTION
Previously, if a mergingIter or levelIter was reused as part of a pooled
iterAlloc, only fields explicitly set were initialized. Other fields were left
with their previous values. This caused internal iterator stats to leak between
iterators.

This commit fixes this by zeroing the entire iterAlloc struct when returning it
to the pool.