### PR TITLE
crl-release-22.1: db: zero mergingIter, levelIter structs before use

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -151,6 +151,10 @@ func runIterCmd(d *datadriven.TestData, iter *Iterator, closeIter bool) string {
 			}
 			iter.SetBounds(lower, upper)
 			valid = iter.Valid()
+		case "stats":
+			stats := iter.Stats()
+			fmt.Fprintf(&b, "stats: %s\n", stats.String())
+			continue
 		case "clone":
 			clonedIter, err := iter.Clone()
 			if err != nil {

--- a/iterator.go
+++ b/iterator.go
@@ -1540,7 +1540,10 @@ func (i *Iterator) Close() error {
 		} else {
 			alloc.prefixOrFullSeekKey = i.prefixOrFullSeekKey
 		}
-		*i = Iterator{}
+		*alloc = iterAlloc{
+			keyBuf:              alloc.keyBuf,
+			prefixOrFullSeekKey: alloc.prefixOrFullSeekKey,
+		}
 		iterAllocPool.Put(alloc)
 	} else if alloc := i.getIterAlloc; alloc != nil {
 		if cap(i.keyBuf) >= maxKeyBufCacheSize {
@@ -1548,7 +1551,9 @@ func (i *Iterator) Close() error {
 		} else {
 			alloc.keyBuf = i.keyBuf
 		}
-		*i = Iterator{}
+		*alloc = getIterAlloc{
+			keyBuf: alloc.keyBuf,
+		}
 		getIterAllocPool.Put(alloc)
 	}
 	return err

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -910,6 +910,78 @@ func TestIteratorNextPrev(t *testing.T) {
 	})
 }
 
+func TestIteratorStats(t *testing.T) {
+	var mem vfs.FS
+	var d *DB
+	defer func() {
+		require.NoError(t, d.Close())
+	}()
+
+	reset := func() {
+		if d != nil {
+			require.NoError(t, d.Close())
+		}
+
+		mem = vfs.NewMem()
+		require.NoError(t, mem.MkdirAll("ext", 0755))
+		opts := &Options{FS: mem}
+		// Automatic compactions may make some testcases non-deterministic.
+		opts.DisableAutomaticCompactions = true
+		var err error
+		d, err = Open("", opts)
+		require.NoError(t, err)
+	}
+	reset()
+
+	datadriven.RunTest(t, "testdata/iterator_stats", func(td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "reset":
+			reset()
+			return ""
+
+		case "build":
+			if err := runBuildCmd(td, d, mem); err != nil {
+				return err.Error()
+			}
+			return ""
+
+		case "ingest":
+			if err := runIngestCmd(td, d, mem); err != nil {
+				return err.Error()
+			}
+			return runLSMCmd(td, d)
+
+		case "iter":
+			seqNum := InternalKeySeqNumMax
+			for _, arg := range td.CmdArgs {
+				if len(arg.Vals) != 1 {
+					return fmt.Sprintf("%s: %s=<value>", td.Cmd, arg.Key)
+				}
+				switch arg.Key {
+				case "seq":
+					var err error
+					seqNum, err = strconv.ParseUint(arg.Vals[0], 10, 64)
+					if err != nil {
+						return err.Error()
+					}
+				default:
+					return fmt.Sprintf("%s: unknown arg: %s", td.Cmd, arg.Key)
+				}
+			}
+
+			snap := Snapshot{
+				db:     d,
+				seqNum: seqNum,
+			}
+			iter := snap.NewIter(nil)
+			return runIterCmd(td, iter, true)
+
+		default:
+			return fmt.Sprintf("unknown command: %s", td.Cmd)
+		}
+	})
+}
+
 type iterSeekOptWrapper struct {
 	internalIterator
 

--- a/testdata/iterator_stats
+++ b/testdata/iterator_stats
@@ -1,0 +1,36 @@
+build ext1
+merge a 1
+set c 2
+----
+
+ingest ext1
+----
+6:
+  000004:[a#1,MERGE-c#1,SET]
+
+iter
+first
+next
+next
+stats
+----
+a:1
+c:2
+.
+stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 34 B, cached 34 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+
+# Perform the same operation again with a new iterator. It should yield
+# identical statistics.
+
+iter
+first
+next
+next
+stats
+----
+a:1
+c:2
+.
+stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 34 B, cached 34 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))


### PR DESCRIPTION
Previously, if a mergingIter or levelIter was reused as part of a pooled
iterAlloc, only fields explicitly set were initialized. Other fields were left
with their previous values. This caused internal iterator stats to leak between
iterators.

This commit fixes this by zeroing the entire iterAlloc struct when returning it
to the pool.