### PR TITLE
db: use block properties for efficient range-key masking

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1114,7 +1114,8 @@ func (c *compaction) newInputIter(
 	newRangeDelIter := func(
 		f *manifest.FileMetadata, slice manifest.LevelSlice, _ *IterOptions, bytesIterated *uint64,
 	) (keyspan.FragmentIterator, error) {
-		iter, rangeDelIter, err := newIters(f, nil /* iter options */, &c.bytesIterated)
+		iter, rangeDelIter, err := newIters(f, nil, /* iter options */
+			internalIterOpts{bytesIterated: &c.bytesIterated})
 		if err == nil {
 			// TODO(peter): It is mildly wasteful to open the point iterator only to
 			// immediately close it. One way to solve this would be to add new

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2929,7 +2929,7 @@ func TestCompactionCheckOrdering(t *testing.T) {
 				}
 
 				newIters := func(
-					_ *manifest.FileMetadata, _ *IterOptions, _ *uint64,
+					_ *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts,
 				) (internalIterator, keyspan.FragmentIterator, error) {
 					return &errorIter{}, nil, nil
 				}

--- a/data_test.go
+++ b/data_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/rangedel"
 	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/internal/testkeys/blockprop"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -250,6 +251,8 @@ func parseIterOptions(
 			}
 		case "mask-suffix":
 			opts.RangeKeyMasking.Suffix = []byte(arg[1])
+		case "mask-filter":
+			opts.RangeKeyMasking.Filter = blockprop.NewMaskingFilter()
 		case "table-filter":
 			switch arg[1] {
 			case "reuse":

--- a/get_iter.go
+++ b/get_iter.go
@@ -154,7 +154,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 				g.l0 = g.l0[:n-1]
 				iterOpts := IterOptions{logger: g.logger}
 				g.levelIter.init(iterOpts, g.cmp, nil /* split */, g.newIters,
-					files, manifest.L0Sublevel(n), nil)
+					files, manifest.L0Sublevel(n), internalIterOpts{})
 				g.levelIter.initRangeDel(&g.rangeDelIter)
 				g.iter = &g.levelIter
 				g.iterKey, g.iterValue = g.iter.SeekGE(g.key, base.SeekGEFlagsNone)
@@ -173,7 +173,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 
 		iterOpts := IterOptions{logger: g.logger}
 		g.levelIter.init(iterOpts, g.cmp, nil /* split */, g.newIters,
-			g.version.Levels[g.level].Iter(), manifest.Level(g.level), nil)
+			g.version.Levels[g.level].Iter(), manifest.Level(g.level), internalIterOpts{})
 		g.levelIter.initRangeDel(&g.rangeDelIter)
 		g.level++
 		g.iter = &g.levelIter

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -471,7 +471,7 @@ func TestGetIter(t *testing.T) {
 		// m is a map from file numbers to DBs.
 		m := map[FileNum]*memTable{}
 		newIter := func(
-			file *manifest.FileMetadata, _ *IterOptions, _ *uint64,
+			file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts,
 		) (internalIterator, keyspan.FragmentIterator, error) {
 			d, ok := m[file.FileNum]
 			if !ok {

--- a/ingest.go
+++ b/ingest.go
@@ -511,7 +511,7 @@ func ingestTargetLevel(
 			continue
 		}
 
-		iter, rangeDelIter, err := newIters(iter.Current(), nil, nil)
+		iter, rangeDelIter, err := newIters(iter.Current(), nil, internalIterOpts{})
 		if err != nil {
 			return 0, err
 		}

--- a/internal/keyspan/testdata/interleaving_iter
+++ b/internal/keyspan/testdata/interleaving_iter
@@ -109,6 +109,7 @@ seek-lt carrot
 prev
 prev
 ----
+-- SpanChanged(nil)
 -- SpanChanged(c-d:{(#4,RANGEKEYSET,@3,coconut)})
 PointKey: c#72057594037927935,21
 Span: c-carrot:{(#4,RANGEKEYSET,@3,coconut)}
@@ -130,6 +131,7 @@ seek-ge p
 seek-ge yyy
 seek-ge z
 ----
+-- SpanChanged(nil)
 -- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
 PointKey: a#72057594037927935,21
 Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
@@ -139,14 +141,17 @@ Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (
 PointKey: a#72057594037927935,21
 Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(nil)
 PointKey: parsnip#3,1
 Span: <invalid>
 -
+-- SpanChanged(nil)
 -- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
 PointKey: yyy#72057594037927935,21
 Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(nil)
 PointKey: zucchini#12,2
 Span: <invalid>
@@ -163,6 +168,8 @@ next
 next
 next
 ----
+-- SpanChanged(nil)
+-- SpanChanged(nil)
 PointKey: zucchini#12,2
 Span: <invalid>
 -
@@ -181,6 +188,7 @@ Span: <invalid>
 PointKey: l#72057594037927935,20
 Span: l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(nil)
 PointKey: parsnip#3,1
 Span: <invalid>
@@ -204,6 +212,7 @@ seek-ge q
 seek-ge parsnip
 next
 ----
+-- SpanChanged(nil)
 -- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
 PointKey: tomato#72057594037927935,21
 Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
@@ -216,6 +225,7 @@ Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 PointKey: q#72057594037927935,21
 Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(nil)
 PointKey: parsnip#3,1
 Span: <invalid>
@@ -239,6 +249,8 @@ Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 PointKey: parsnip#3,1
 Span: <invalid>
 -
+-- SpanChanged(nil)
+-- SpanChanged(nil)
 .
 
 define-rangekeys
@@ -286,6 +298,7 @@ iter
 seek-lt a
 ----
 -- SpanChanged(nil)
+-- SpanChanged(nil)
 .
 
 iter
@@ -298,6 +311,7 @@ next
 next
 next
 ----
+-- SpanChanged(nil)
 -- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
 PointKey: ab#72057594037927935,21
 Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
@@ -384,6 +398,7 @@ prev
 PointKey: b#72057594037927935,21
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
 PointKey: a#8,1
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
@@ -408,6 +423,7 @@ Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 PointKey: b#13,1
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
 PointKey: a#8,1
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
@@ -430,6 +446,8 @@ next
 PointKey: b#13,1
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
+-- SpanChanged(nil)
+-- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
 PointKey: c#9,0
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
@@ -447,6 +465,8 @@ Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 PointKey: a#8,1
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
+-- SpanChanged(nil)
+-- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
 PointKey: b#13,1
 Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 -
@@ -481,6 +501,7 @@ next
 next
 ----
 -- SpanChanged(nil)
+-- SpanChanged(nil)
 PointKey: a#9,1
 Span: <invalid>
 -
@@ -491,10 +512,13 @@ Span: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
 PointKey: b#13,1
 Span: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(ace-bat:{(#5,RANGEKEYSET,@5,v5)})
 PointKey: ace#72057594037927935,21
 Span: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
 -
+-- SpanChanged(nil)
+-- SpanChanged(ace-bat:{(#5,RANGEKEYSET,@5,v5)})
 PointKey: b#13,1
 Span: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
 -
@@ -507,9 +531,13 @@ iter
 seek-lt ace
 seek-lt zoo
 ----
+-- SpanChanged(nil)
+-- SpanChanged(nil)
 PointKey: a#9,1
 Span: <invalid>
 -
+-- SpanChanged(nil)
+-- SpanChanged(nil)
 PointKey: z#3,1
 Span: <invalid>
 -
@@ -520,6 +548,8 @@ prev
 next
 next
 ----
+-- SpanChanged(nil)
+-- SpanChanged(nil)
 PointKey: z#3,1
 Span: <invalid>
 -
@@ -528,9 +558,11 @@ PointKey: y#3,1
 Span: x-z:{(#6,RANGEKEYSET,@6,v5)}
 -
 -- SpanChanged(nil)
+-- SpanChanged(nil)
 PointKey: z#3,1
 Span: <invalid>
 -
+-- SpanChanged(nil)
 .
 
 iter
@@ -539,15 +571,23 @@ next
 seek-ge m
 prev
 ----
+-- SpanChanged(nil)
+-- SpanChanged(nil)
 PointKey: d#18,1
 Span: <invalid>
 -
+-- SpanChanged(nil)
+-- SpanChanged(nil)
 PointKey: m#4,1
 Span: <invalid>
 -
+-- SpanChanged(nil)
+-- SpanChanged(nil)
 PointKey: m#4,1
 Span: <invalid>
 -
+-- SpanChanged(nil)
+-- SpanChanged(nil)
 PointKey: d#18,1
 Span: <invalid>
 -
@@ -636,6 +676,7 @@ PointKey: w#72057594037927935,21
 Span: w-y:{(#5,RANGEKEYSET,@1,v1)}
 -
 -- SpanChanged(nil)
+-- SpanChanged(nil)
 .
 
 define-rangekeys
@@ -658,10 +699,12 @@ next
 PointKey: c#72057594037927935,21
 Span: a-z:{(#5,RANGEKEYSET,@1,v1)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(a-z:{(#5,RANGEKEYSET,@1,v1)})
 PointKey: a#72057594037927935,21
 Span: a-z:{(#5,RANGEKEYSET,@1,v1)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(nil)
 PointKey: z#8,1
 Span: <invalid>
@@ -675,10 +718,12 @@ last
 prev
 prev
 ----
+-- SpanChanged(nil)
 -- SpanChanged(a-z:{(#5,RANGEKEYSET,@1,v1)})
 PointKey: a#72057594037927935,21
 Span: a-c:{(#5,RANGEKEYSET,@1,v1)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(nil)
 PointKey: z#8,1
 Span: <invalid>
@@ -717,15 +762,19 @@ prev
 next
 ----
 -- SpanChanged(nil)
+-- SpanChanged(nil)
 PointKey: z#1,1
 Span: <invalid>
 -
+-- SpanChanged(nil)
 PointKey: v#1,1
 Span: <invalid>
 -
+-- SpanChanged(nil)
 PointKey: v#2,1
 Span: <invalid>
 -
+-- SpanChanged(nil)
 PointKey: s#1,1
 Span: <invalid>
 -
@@ -737,6 +786,7 @@ Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
 PointKey: g#1,1
 Span: <invalid>
 -
+-- SpanChanged(nil)
 -- SpanChanged(j-l:{(#3,RANGEKEYSET,@1,v0)})
 PointKey: j#72057594037927935,21
 Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
@@ -765,6 +815,7 @@ next
 prev
 ----
 -- SpanChanged(nil)
+-- SpanChanged(nil)
 PointKey: a#1,1
 Span: <invalid>
 -
@@ -779,6 +830,7 @@ Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
 PointKey: m#1,1
 Span: <invalid>
 -
+-- SpanChanged(nil)
 -- SpanChanged(j-l:{(#3,RANGEKEYSET,@1,v0)})
 PointKey: k#1,1
 Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
@@ -802,12 +854,15 @@ set-bounds a c
 seek-ge c
 ----
 -- SpanChanged(nil)
+-- SpanChanged(nil)
 .
 
 iter
 set-bounds a c
 seek-lt a
 ----
+-- SpanChanged(nil)
+-- SpanChanged(nil)
 .
 
 # Test a SeekLT that searches a keyspace exclusive with the iterator's bounds.
@@ -829,5 +884,6 @@ iter
 set-bounds d e
 seek-lt d
 ----
+-- SpanChanged(nil)
 -- SpanChanged(nil)
 .

--- a/internal/keyspan/testdata/interleaving_iter_masking
+++ b/internal/keyspan/testdata/interleaving_iter_masking
@@ -47,6 +47,7 @@ next
 next
 ----
 -- SpanChanged(nil)
+-- SpanChanged(nil)
 PointKey: b@2#1,1
 Span: <invalid>
 -
@@ -86,6 +87,7 @@ prev
 prev
 prev
 ----
+-- SpanChanged(nil)
 -- SpanChanged(m-q:{(#1,RANGEKEYSET,@6,bax)})
 PointKey: m#72057594037927935,21
 Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
@@ -113,6 +115,7 @@ Span: e-f:{(#1,RANGEKEYSET,@9,foo)}
 PointKey: b@2#1,1
 Span: <invalid>
 -
+-- SpanChanged(nil)
 .
 
 iter
@@ -125,9 +128,12 @@ next
 seek-ge m
 seek-ge r
 ----
+-- SpanChanged(nil)
+-- SpanChanged(nil)
 PointKey: b@2#1,1
 Span: <invalid>
 -
+-- SpanChanged(nil)
 -- SpanChanged(e-f:{(#1,RANGEKEYSET,@9,foo)})
 PointKey: e#72057594037927935,21
 Span: e-f:{(#1,RANGEKEYSET,@9,foo)}
@@ -156,6 +162,7 @@ PointKey: m#72057594037927935,21
 Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
 -
 -- SpanChanged(nil)
+-- SpanChanged(nil)
 .
 
 # Setting the masking threshold to @9 should result in l@8 being masked by
@@ -173,6 +180,7 @@ seek-lt l
 seek-lt ll
 prev
 ----
+-- SpanChanged(nil)
 -- SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
 PointKey: l#72057594037927935,21
 Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
@@ -258,6 +266,7 @@ prev
 prev
 prev
 ----
+-- SpanChanged(nil)
 -- SpanChanged(a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)})
 PointKey: a@12#1,1
 Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
@@ -315,6 +324,7 @@ prev
 prev
 prev
 ----
+-- SpanChanged(nil)
 -- SpanChanged(a-c:{(#2,RANGEKEYSET,@20,apples)})
 PointKey: b@2#1,1
 Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
@@ -363,6 +373,7 @@ Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 -
 -- SpanChanged(nil)
 .
+-- SpanChanged(nil)
 .
 
 iter
@@ -372,6 +383,7 @@ prev
 prev
 prev
 ----
+-- SpanChanged(nil)
 -- SpanChanged(a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)})
 PointKey: a@12#1,1
 Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
@@ -384,6 +396,7 @@ Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 -
 -- SpanChanged(nil)
 .
+-- SpanChanged(nil)
 .
 
 # Test a scenario where a point key is masked in the forward direction, which in
@@ -476,6 +489,7 @@ next
 PointKey: a#72057594037927935,21
 Span: a-c:{(#1,RANGEKEYSET,@10,apples)}
 -
+-- SpanChanged(nil)
 -- SpanChanged(nil)
 PointKey: d@9#3,1
 Span: <invalid>

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/errorfs"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/private"
+	"github.com/cockroachdb/pebble/internal/testkeys/blockprop"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -592,9 +593,12 @@ func (o *newIterOp) run(t *test, h *history) {
 			Suffix: o.rangeKeyMaskSuffix,
 		},
 	}
+	if opts.RangeKeyMasking.Suffix != nil {
+		opts.RangeKeyMasking.Filter = blockprop.NewMaskingFilter()
+	}
 	if o.filterMax > 0 {
 		opts.PointKeyFilters = []pebble.BlockPropertyFilter{
-			newBlockPropertyFilter(o.filterMin, o.filterMax),
+			blockprop.NewBlockPropertyFilter(o.filterMin, o.filterMax),
 		}
 	}
 
@@ -714,9 +718,12 @@ func (o *iterSetOptionsOp) run(t *test, h *history) {
 			Suffix: o.rangeKeyMaskSuffix,
 		},
 	}
+	if opts.RangeKeyMasking.Suffix != nil {
+		opts.RangeKeyMasking.Filter = blockprop.NewMaskingFilter()
+	}
 	if o.filterMax > 0 {
 		opts.PointKeyFilters = []pebble.BlockPropertyFilter{
-			newBlockPropertyFilter(o.filterMin, o.filterMax),
+			blockprop.NewBlockPropertyFilter(o.filterMin, o.filterMax),
 		}
 	}
 

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -7,16 +7,14 @@ package metamorphic
 import (
 	"bytes"
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/bloom"
-	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/testkeys"
-	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/internal/testkeys/blockprop"
 	"github.com/cockroachdb/pebble/vfs"
 	"golang.org/x/exp/rand"
 )
@@ -52,7 +50,7 @@ func parseOptions(opts *testOptions, data string) error {
 			case "TestOptions.initial_state_path":
 				opts.initialStatePath = value
 				return true
-			case "TestOptions.use_block_property_filter":
+			case "TestOptions.use_block_property_collector":
 				opts.useBlockPropertyCollector = true
 				opts.opts.BlockPropertyCollectors = blockPropertyCollectorConstructors
 				return true
@@ -86,7 +84,7 @@ func optionsToString(opts *testOptions) string {
 		fmt.Fprintf(&buf, "  initial_state_desc=%s\n", opts.initialStateDesc)
 	}
 	if opts.useBlockPropertyCollector {
-		fmt.Fprintf(&buf, "  use_block_property_filter=%t\n", opts.useBlockPropertyCollector)
+		fmt.Fprintf(&buf, "  use_block_property_collector=%t\n", opts.useBlockPropertyCollector)
 	}
 
 	s := opts.opts.String()
@@ -94,6 +92,13 @@ func optionsToString(opts *testOptions) string {
 		return s
 	}
 	return s + "\n[TestOptions]\n" + buf.String()
+}
+
+func defaultTestOptions() *testOptions {
+	return &testOptions{
+		opts:                      defaultOptions(),
+		useBlockPropertyCollector: true,
+	}
 }
 
 func defaultOptions() *pebble.Options {
@@ -228,13 +233,13 @@ func standardOptions() []*testOptions {
 `,
 		23: `
 [TestOptions]
-  use_block_property_filter=true
+  use_block_property_collector=false
 `,
 	}
 
 	opts := make([]*testOptions, len(stdOpts))
 	for i := range opts {
-		opts[i] = &testOptions{opts: defaultOptions()}
+		opts[i] = defaultTestOptions()
 		if err := parseOptions(opts[i], stdOpts[i]); err != nil {
 			panic(err)
 		}
@@ -362,75 +367,6 @@ func moveLogs(fs vfs.FS, srcDir, dstDir string) error {
 	return nil
 }
 
-const blockPropertyCollectorName = `pebble.internal.metamorphic.suffixes`
-
 var blockPropertyCollectorConstructors = []func() pebble.BlockPropertyCollector{
-	func() pebble.BlockPropertyCollector {
-		return sstable.NewBlockIntervalCollector(
-			blockPropertyCollectorName,
-			&suffixIntervalCollector{},
-			nil)
-	},
-}
-
-// newBlockPropertyFilter constructs a new block-property filter that ignores
-// blocks containing exclusively suffixed keys where all the suffixes fall
-// outside of the range [filterMin, filterMax).
-//
-// The filter only filters based on data derived from the key. The iteration
-// results of this block property filter are deterministic for unsuffixed keys
-// and keys with suffixes within the range [filterMin, filterMax). For keys with
-// suffixes outside the range, iteration is nondeterministic. To accommodate
-// this, the metamorphic test iterators automatically skip keys outside the
-// configured filter span.
-func newBlockPropertyFilter(filterMin, filterMax uint64) pebble.BlockPropertyFilter {
-	return sstable.NewBlockIntervalFilter(blockPropertyCollectorName, filterMin, filterMax)
-}
-
-var _ sstable.DataBlockIntervalCollector = (*suffixIntervalCollector)(nil)
-
-// suffixIntervalCollector maintains an interval over the timestamps in
-// MVCC-like suffixes for keys (e.g. foo@123).
-type suffixIntervalCollector struct {
-	initialized  bool
-	lower, upper uint64
-}
-
-// Add implements DataBlockIntervalCollector by adding the timestamp(s) in the
-// suffix(es) of this record to the current interval.
-//
-// Note that range sets and unsets may have multiple suffixes. Range key deletes
-// do not have a suffix. All other point keys have a single suffix.
-func (c *suffixIntervalCollector) Add(key base.InternalKey, value []byte) error {
-	i := testkeys.Comparer.Split(key.UserKey)
-	if i == len(key.UserKey) {
-		c.initialized = true
-		c.lower, c.upper = 0, math.MaxUint64
-		return nil
-	}
-	ts, err := testkeys.ParseSuffix(key.UserKey[i:])
-	if err != nil {
-		return err
-	}
-	uts := uint64(ts)
-	if !c.initialized {
-		c.lower, c.upper = uts, uts+1
-		c.initialized = true
-		return nil
-	}
-	if uts < c.lower {
-		c.lower = uts
-	}
-	if uts >= c.upper {
-		c.upper = uts + 1
-	}
-	return nil
-}
-
-// FinishDataBlock implements DataBlockIntervalCollector.
-func (c *suffixIntervalCollector) FinishDataBlock() (lower, upper uint64, err error) {
-	l, u := c.lower, c.upper
-	c.lower, c.upper = 0, 0
-	c.initialized = false
-	return l, u, nil
+	blockprop.NewBlockPropertyCollector,
 }

--- a/internal/testkeys/blockprop/blockprop.go
+++ b/internal/testkeys/blockprop/blockprop.go
@@ -1,0 +1,117 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// Package blockprop implements interval block property collectors and filters
+// on the suffixes of keys in the format used by the testkeys package (eg,
+// 'key@5').
+package blockprop
+
+import (
+	"math"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/sstable"
+)
+
+const blockPropertyName = `pebble.internal.testkeys.suffixes`
+
+// NewBlockPropertyCollector constructs a sstable property collector over
+// testkey suffixes.
+func NewBlockPropertyCollector() sstable.BlockPropertyCollector {
+	return sstable.NewBlockIntervalCollector(
+		blockPropertyName,
+		&suffixIntervalCollector{},
+		nil)
+}
+
+// NewBlockPropertyFilter constructs a new block-property filter that excludes
+// blocks containing exclusively suffixed keys where all the suffixes fall
+// outside of the range [filterMin, filterMax).
+//
+// The filter only filters based on data derived from the key. The iteration
+// results of this block property filter are deterministic for unsuffixed keys
+// and keys with suffixes within the range [filterMin, filterMax). For keys with
+// suffixes outside the range, iteration is nondeterministic.
+func NewBlockPropertyFilter(filterMin, filterMax uint64) *sstable.BlockIntervalFilter {
+	return sstable.NewBlockIntervalFilter(blockPropertyName, filterMin, filterMax)
+}
+
+// NewMaskingFilter constructs a MaskingFilter that implements
+// pebble.BlockPropertyFilterMask for efficient range-key masking using the
+// testkeys block property filter. The masking filter wraps a block interval
+// filter, and modifies the configured interval when Pebble requests it.
+func NewMaskingFilter() MaskingFilter {
+	return MaskingFilter{BlockIntervalFilter: NewBlockPropertyFilter(0, math.MaxUint64)}
+}
+
+// MaskingFilter implements BlockPropertyFilterMask and may be used to mask
+// point keys with the testkeys-style suffixes (eg, @4) that are masked by range
+// keys with testkeys-style suffixes.
+type MaskingFilter struct {
+	*sstable.BlockIntervalFilter
+}
+
+// SetSuffix implements pebble.BlockPropertyFilterMask.
+func (f MaskingFilter) SetSuffix(suffix []byte) error {
+	ts, err := testkeys.ParseSuffix(suffix)
+	if err != nil {
+		return err
+	}
+	f.BlockIntervalFilter.SetInterval(uint64(ts), math.MaxUint64)
+	return nil
+}
+
+// Intersects implements the BlockPropertyFilter interface.
+func (f MaskingFilter) Intersects(prop []byte) (bool, error) {
+	return f.BlockIntervalFilter.Intersects(prop)
+}
+
+var _ sstable.DataBlockIntervalCollector = (*suffixIntervalCollector)(nil)
+
+// suffixIntervalCollector maintains an interval over the timestamps in
+// MVCC-like suffixes for keys (e.g. foo@123).
+type suffixIntervalCollector struct {
+	initialized  bool
+	lower, upper uint64
+}
+
+// Add implements DataBlockIntervalCollector by adding the timestamp(s) in the
+// suffix(es) of this record to the current interval.
+//
+// Note that range sets and unsets may have multiple suffixes. Range key deletes
+// do not have a suffix. All other point keys have a single suffix.
+func (c *suffixIntervalCollector) Add(key base.InternalKey, value []byte) error {
+	i := testkeys.Comparer.Split(key.UserKey)
+	if i == len(key.UserKey) {
+		c.initialized = true
+		c.lower, c.upper = 0, math.MaxUint64
+		return nil
+	}
+	ts, err := testkeys.ParseSuffix(key.UserKey[i:])
+	if err != nil {
+		return err
+	}
+	uts := uint64(ts)
+	if !c.initialized {
+		c.lower, c.upper = uts, uts+1
+		c.initialized = true
+		return nil
+	}
+	if uts < c.lower {
+		c.lower = uts
+	}
+	if uts >= c.upper {
+		c.upper = uts + 1
+	}
+	return nil
+}
+
+// FinishDataBlock implements DataBlockIntervalCollector.
+func (c *suffixIntervalCollector) FinishDataBlock() (lower, upper uint64, err error) {
+	l, u := c.lower, c.upper
+	c.lower, c.upper = 0, 0
+	c.initialized = false
+	return l, u, nil
+}

--- a/level_checker.go
+++ b/level_checker.go
@@ -373,7 +373,7 @@ func checkRangeTombstones(c *checkConfig) error {
 			lf := files.Take()
 			atomicUnit, _ := expandToAtomicUnit(c.cmp, lf.Slice(), true /* disableIsCompacting */)
 			lower, upper := manifest.KeyRange(c.cmp, atomicUnit.Iter())
-			iterToClose, iter, err := c.newIters(lf.FileMetadata, nil, nil)
+			iterToClose, iter, err := c.newIters(lf.FileMetadata, nil, internalIterOpts{})
 			if err != nil {
 				return err
 			}
@@ -634,7 +634,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 		iterOpts := IterOptions{logger: c.logger}
 		li := &levelIter{}
 		li.init(iterOpts, c.cmp, nil /* split */, c.newIters, manifestIter,
-			manifest.L0Sublevel(sublevel), nil)
+			manifest.L0Sublevel(sublevel), internalIterOpts{})
 		li.initRangeDel(&mlevelAlloc[0].rangeDelIter)
 		li.initBoundaryContext(&mlevelAlloc[0].levelIterBoundaryContext)
 		mlevelAlloc[0].iter = li
@@ -648,7 +648,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 		iterOpts := IterOptions{logger: c.logger}
 		li := &levelIter{}
 		li.init(iterOpts, c.cmp, nil /* split */, c.newIters,
-			current.Levels[level].Iter(), manifest.Level(level), nil)
+			current.Levels[level].Iter(), manifest.Level(level), internalIterOpts{})
 		li.initRangeDel(&mlevelAlloc[0].rangeDelIter)
 		li.initBoundaryContext(&mlevelAlloc[0].levelIterBoundaryContext)
 		mlevelAlloc[0].iter = li

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -94,7 +94,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 
 	var fileNum FileNum
 	newIters :=
-		func(file *manifest.FileMetadata, opts *IterOptions, bytesIterated *uint64) (internalIterator, keyspan.FragmentIterator, error) {
+		func(file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts) (internalIterator, keyspan.FragmentIterator, error) {
 			r := readers[file.FileNum]
 			rangeDelIter, err := r.NewRawRangeDelIter()
 			if err != nil {

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -32,7 +32,7 @@ func TestLevelIter(t *testing.T) {
 	var files manifest.LevelSlice
 
 	newIters := func(
-		file *manifest.FileMetadata, opts *IterOptions, bytesIterated *uint64,
+		file *manifest.FileMetadata, opts *IterOptions, _ internalIterOpts,
 	) (internalIterator, keyspan.FragmentIterator, error) {
 		f := *iters[file.FileNum]
 		f.lower = opts.GetLowerBound()
@@ -119,10 +119,10 @@ func TestLevelIter(t *testing.T) {
 
 			var tableOpts *IterOptions
 			newIters2 := func(
-				file *manifest.FileMetadata, opts *IterOptions, bytesIterated *uint64,
+				file *manifest.FileMetadata, opts *IterOptions, internalOpts internalIterOpts,
 			) (internalIterator, keyspan.FragmentIterator, error) {
 				tableOpts = opts
-				return newIters(file, opts, nil)
+				return newIters(file, opts, internalOpts)
 			}
 
 			iter := newLevelIter(opts, DefaultComparer.Compare,
@@ -156,7 +156,7 @@ func newLevelIterTest() *levelIterTest {
 }
 
 func (lt *levelIterTest) newIters(
-	file *manifest.FileMetadata, opts *IterOptions, _ *uint64,
+	file *manifest.FileMetadata, opts *IterOptions, _ internalIterOpts,
 ) (internalIterator, keyspan.FragmentIterator, error) {
 	lt.itersCreated++
 	iter, err := lt.readers[file.FileNum].NewIter(opts.LowerBound, opts.UpperBound)
@@ -511,7 +511,7 @@ func BenchmarkLevelIterSeekGE(b *testing.B) {
 							readers, metas, keys, cleanup := buildLevelIterTables(b, blockSize, restartInterval, count)
 							defer cleanup()
 							newIters := func(
-								file *manifest.FileMetadata, _ *IterOptions, _ *uint64,
+								file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts,
 							) (internalIterator, keyspan.FragmentIterator, error) {
 								iter, err := readers[file.FileNum].NewIter(nil /* lower */, nil /* upper */)
 								return iter, nil, err
@@ -552,7 +552,7 @@ func BenchmarkLevelIterSeqSeekGEWithBounds(b *testing.B) {
 							// This newIters is cheaper than in practice since it does not do
 							// tableCacheShard.findNode.
 							newIters := func(
-								file *manifest.FileMetadata, opts *IterOptions, _ *uint64,
+								file *manifest.FileMetadata, opts *IterOptions, _ internalIterOpts,
 							) (internalIterator, keyspan.FragmentIterator, error) {
 								iter, err := readers[file.FileNum].NewIter(
 									opts.LowerBound, opts.UpperBound)
@@ -594,7 +594,7 @@ func BenchmarkLevelIterSeqSeekPrefixGE(b *testing.B) {
 	// This newIters is cheaper than in practice since it does not do
 	// tableCacheShard.findNode.
 	newIters := func(
-		file *manifest.FileMetadata, opts *IterOptions, _ *uint64,
+		file *manifest.FileMetadata, opts *IterOptions, _ internalIterOpts,
 	) (internalIterator, keyspan.FragmentIterator, error) {
 		iter, err := readers[file.FileNum].NewIter(
 			opts.LowerBound, opts.UpperBound)
@@ -647,7 +647,7 @@ func BenchmarkLevelIterNext(b *testing.B) {
 							readers, metas, _, cleanup := buildLevelIterTables(b, blockSize, restartInterval, count)
 							defer cleanup()
 							newIters := func(
-								file *manifest.FileMetadata, _ *IterOptions, _ *uint64,
+								file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts,
 							) (internalIterator, keyspan.FragmentIterator, error) {
 								iter, err := readers[file.FileNum].NewIter(nil /* lower */, nil /* upper */)
 								return iter, nil, err
@@ -681,7 +681,7 @@ func BenchmarkLevelIterPrev(b *testing.B) {
 							readers, metas, _, cleanup := buildLevelIterTables(b, blockSize, restartInterval, count)
 							defer cleanup()
 							newIters := func(
-								file *manifest.FileMetadata, _ *IterOptions, _ *uint64,
+								file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts,
 							) (internalIterator, keyspan.FragmentIterator, error) {
 								iter, err := readers[file.FileNum].NewIter(nil /* lower */, nil /* upper */)
 								return iter, nil, err

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -148,7 +148,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 
 	var fileNum base.FileNum
 	newIters :=
-		func(file *manifest.FileMetadata, opts *IterOptions, bytesIterated *uint64) (internalIterator, keyspan.FragmentIterator, error) {
+		func(file *manifest.FileMetadata, opts *IterOptions, _ internalIterOpts) (internalIterator, keyspan.FragmentIterator, error) {
 			r := readers[file.FileNum]
 			rangeDelIter, err := r.NewRawRangeDelIter()
 			if err != nil {
@@ -247,7 +247,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 				}
 				li := &levelIter{}
 				li.init(IterOptions{}, cmp, func(a []byte) int { return len(a) }, newIters,
-					slice.Iter(), manifest.Level(i), nil)
+					slice.Iter(), manifest.Level(i), internalIterOpts{})
 				i := len(levelIters)
 				levelIters = append(levelIters, mergingIterLevel{iter: li})
 				li.initRangeDel(&levelIters[i].rangeDelIter)
@@ -565,7 +565,7 @@ func buildMergingIter(readers [][]*sstable.Reader, levelSlices []manifest.LevelS
 		levelIndex := i
 		level := len(readers) - 1 - i
 		newIters := func(
-			file *manifest.FileMetadata, opts *IterOptions, _ *uint64,
+			file *manifest.FileMetadata, opts *IterOptions, _ internalIterOpts,
 		) (internalIterator, keyspan.FragmentIterator, error) {
 			iter, err := readers[levelIndex][file.FileNum].NewIter(
 				opts.LowerBound, opts.UpperBound)

--- a/sstable/block_property.go
+++ b/sstable/block_property.go
@@ -140,6 +140,54 @@ type SuffixReplaceableBlockCollector interface {
 // be thread-safe.
 type BlockPropertyFilter = base.BlockPropertyFilter
 
+// BoundLimitedBlockPropertyFilter implements the block-property filter but
+// imposes an additional constraint on its usage, requiring that only blocks
+// containing exclusively keys between its lower and upper bounds may be
+// filtered. The bounds may be change during iteration, so the filter doesn't
+// expose the bounds, instead implementing KeyIsWithin[Lower,Upper]Bound methods
+// for performing bound comparisons.
+//
+// To be used, a BoundLimitedBlockPropertyFilter must be supplied directly
+// through NewBlockPropertiesFilterer's dedicated parameter. If supplied through
+// the ordinary slice of block property filters, this filter's bounds will be
+// ignored.
+//
+// The current [lower,upper) bounds of the filter are unknown, because they may
+// be changing. During forward iteration the lower bound is externally
+// guaranteed, meaning Intersects only returns false if the sstable iterator is
+// already known to be positioned at a key ≥ lower. The sstable iterator is then
+// only responsible for ensuring filtered blocks also meet the upper bound, and
+// should only allow a block to be filtered if all its keys are < upper. The
+// sstable iterator may invoke KeyIsWithinUpperBound(key) to perform this check,
+// where key is an inclusive upper bound on the block's keys.
+//
+// During backward iteration the upper bound is externally guaranteed, and
+// Intersects only returns false if the sstable iterator is already known to be
+// positioned at a key < upper. The sstable iterator is responsible for ensuring
+// filtered blocks also meet the lower bound, enforcing that a block is only
+// filtered if all its keys are ≥ lower. This check is made through passing the
+// block's inclusive lower bound to KeyIsWithinLowerBound.
+//
+// Usage of BoundLimitedBlockPropertyFilter is subtle, and Pebble consumers
+// should not implement this interface directly. This interface is an internal
+// detail in the implementation of block-property range-key masking.
+type BoundLimitedBlockPropertyFilter interface {
+	BlockPropertyFilter
+
+	// KeyIsWithinLowerBound tests whether the provided internal key falls
+	// within the current lower bound of the filter. A true return value
+	// indicates that the filter may be used to filter blocks that exclusively
+	// contain keys ≥ `key`, so long as the blocks' keys also satisfy the upper
+	// bound.
+	KeyIsWithinLowerBound(key *InternalKey) bool
+	// KeyIsWithinUpperBound tests whether the provided internal key falls
+	// within the current upper bound of the filter. A true return value
+	// indicates that the filter may be used to filter blocks that exclusively
+	// contain keys ≤ `key`, so long as the blocks' keys also satisfy the lower
+	// bound.
+	KeyIsWithinUpperBound(key *InternalKey) bool
+}
+
 // BlockIntervalCollector is a helper implementation of BlockPropertyCollector
 // for users who want to represent a set of the form [lower,upper) where both
 // lower and upper are uint64, and lower <= upper.
@@ -354,37 +402,47 @@ func (w *suffixReplacementBlockCollectorWrapper) UpdateKeySuffixes(
 	return w.BlockIntervalCollector.points.(SuffixReplaceableBlockCollector).UpdateKeySuffixes(oldProp, from, to)
 }
 
-// blockIntervalFilter is an implementation of BlockPropertyFilter when the
+// BlockIntervalFilter is an implementation of BlockPropertyFilter when the
 // corresponding collector is a BlockIntervalCollector. That is, the set is of
 // the form [lower, upper).
-type blockIntervalFilter struct {
+type BlockIntervalFilter struct {
 	name           string
 	filterInterval interval
 }
+
+var _ BlockPropertyFilter = (*BlockIntervalFilter)(nil)
 
 // NewBlockIntervalFilter constructs a BlockPropertyFilter that filters blocks
 // based on an interval property collected by BlockIntervalCollector and the
 // given [lower, upper) bounds. The given name specifies the
 // BlockIntervalCollector's properties to read.
-func NewBlockIntervalFilter(name string, lower uint64, upper uint64) BlockPropertyFilter {
-	return &blockIntervalFilter{
+func NewBlockIntervalFilter(name string, lower uint64, upper uint64) *BlockIntervalFilter {
+	return &BlockIntervalFilter{
 		name:           name,
 		filterInterval: interval{lower: lower, upper: upper},
 	}
 }
 
 // Name implements the BlockPropertyFilter interface.
-func (b *blockIntervalFilter) Name() string {
+func (b *BlockIntervalFilter) Name() string {
 	return b.name
 }
 
 // Intersects implements the BlockPropertyFilter interface.
-func (b *blockIntervalFilter) Intersects(prop []byte) (bool, error) {
+func (b *BlockIntervalFilter) Intersects(prop []byte) (bool, error) {
 	var i interval
 	if err := i.decode(prop); err != nil {
 		return false, err
 	}
 	return i.intersects(b.filterInterval), nil
+}
+
+// SetInterval adjusts the [lower, upper) bounds used by the filter. It is not
+// generally safe to alter the filter while it's in use, except as part of the
+// implementation of BlockPropertyFilterMask.SetSuffix used for range-key
+// masking.
+func (b *BlockIntervalFilter) SetInterval(lower, upper uint64) {
+	b.filterInterval = interval{lower: lower, upper: upper}
 }
 
 // When encoding block properties for each block, we cannot afford to encode
@@ -482,6 +540,25 @@ type BlockPropertiesFilterer struct {
 	// has two filters, corresponding to shortIDs 2, 0, this would be:
 	// len(shortIDToFiltersIndex)==3, 0=>1, 1=>-1, 2=>0.
 	shortIDToFiltersIndex []int
+
+	// boundLimitedFilter, if non-nil, holds a single block-property filter with
+	// additional constraints on its filtering. A boundLimitedFilter may only
+	// filter blocks that are wholly contained within its bounds. During forward
+	// iteration the lower bound (and during backward iteration the upper bound)
+	// must be externally guaranteed, with Intersects only returning false if
+	// that bound is met. The opposite bound is verified during iteration by the
+	// sstable iterator.
+	//
+	// boundLimitedFilter is permitted to be defined on a property (`Name()`)
+	// for which another filter exists in filters. In this case both filters
+	// will be consulted, and either filter may exclude block(s). Only a single
+	// bound-limited block-property filter may be set.
+	//
+	// The boundLimitedShortID field contains the shortID of the filter's
+	// property within the sstable. It's set to -1 if the property was not
+	// collected when the table was built.
+	boundLimitedFilter  BoundLimitedBlockPropertyFilter
+	boundLimitedShortID int
 }
 
 var blockPropertiesFiltererPool = sync.Pool{
@@ -492,9 +569,16 @@ var blockPropertiesFiltererPool = sync.Pool{
 
 // NewBlockPropertiesFilterer returns a partially initialized filterer. To complete
 // initialization, call IntersectsUserPropsAndFinishInit.
-func NewBlockPropertiesFilterer(filters []BlockPropertyFilter) *BlockPropertiesFilterer {
+func NewBlockPropertiesFilterer(
+	filters []BlockPropertyFilter, limited BoundLimitedBlockPropertyFilter,
+) *BlockPropertiesFilterer {
 	filterer := blockPropertiesFiltererPool.Get().(*BlockPropertiesFilterer)
-	*filterer = BlockPropertiesFilterer{filters: filters}
+	*filterer = BlockPropertiesFilterer{
+		filters:               filters,
+		shortIDToFiltersIndex: filterer.shortIDToFiltersIndex[:0],
+		boundLimitedFilter:    limited,
+		boundLimitedShortID:   -1,
+	}
 	return filterer
 }
 
@@ -546,12 +630,73 @@ func (f *BlockPropertiesFilterer) IntersectsUserPropsAndFinishInit(
 		}
 		f.shortIDToFiltersIndex[shortID] = i
 	}
+	if f.boundLimitedFilter == nil {
+		return true, nil
+	}
+
+	// There's a bound-limited filter. Find its shortID. It's possible that
+	// there's an existing filter in f.filters on the same property. That's
+	// okay. Both filters will be consulted whenever a relevant prop is decoded.
+	props, ok := userProperties[f.boundLimitedFilter.Name()]
+	if !ok {
+		// The collector was not used when writing this file, so it's
+		// intersecting. We leave f.boundLimitedShortID=-1, so the filter will
+		// be unused within this file.
+		return true, nil
+	}
+	byteProps := []byte(props)
+	if len(byteProps) < 1 {
+		return false, base.CorruptionErrorf(
+			"block properties for %s is corrupted", f.boundLimitedFilter.Name())
+	}
+	f.boundLimitedShortID = int(byteProps[0])
+
+	// We don't check for table-level intersection for the bound-limited filter.
+	// If a filter is bound-limited and only applicable to a limited span of
+	// keyspace, then it's treated as vacuously intersecting.
+	//
+	// TODO(jackson): We could filter at the table-level by threading the table
+	// smallest and largest bounds here.
+
+	// The bound-limited filter isn't included in shortIDToFiltersIndex.
+	//
+	// When determining intersection, we decode props only up to the shortID
+	// len(shortIDToFiltersIndex). If f.limitedShortID is greater than any of
+	// the existing filters' shortIDs, we need to grow shortIDToFiltersIndex.
+	// Growing the index with -1s ensures we're able to consult the index
+	// without length checks.
+	if n := len(f.shortIDToFiltersIndex); n <= f.boundLimitedShortID {
+		if cap(f.shortIDToFiltersIndex) <= f.boundLimitedShortID {
+			index := make([]int, f.boundLimitedShortID+1)
+			copy(index, f.shortIDToFiltersIndex)
+			f.shortIDToFiltersIndex = index
+		} else {
+			f.shortIDToFiltersIndex = f.shortIDToFiltersIndex[:f.boundLimitedShortID+1]
+		}
+		for j := n; j <= f.boundLimitedShortID; j++ {
+			f.shortIDToFiltersIndex[j] = -1
+		}
+	}
 	return true, nil
 }
 
-func (f *BlockPropertiesFilterer) intersects(props []byte) (bool, error) {
+type intersectsResult int8
+
+const (
+	blockIntersects intersectsResult = iota
+	blockExcluded
+	// blockMaybeExcluded is returned by BlockPropertiesFilterer.intersects when
+	// no filters unconditionally exclude the block, but the bound-limited block
+	// property filter will exclude it if the block's bounds fall within the
+	// filter's current bounds. See the reader's
+	// {single,two}LevelIterator.resolveMaybeExcluded methods.
+	blockMaybeExcluded
+)
+
+func (f *BlockPropertiesFilterer) intersects(props []byte) (ret intersectsResult, err error) {
 	i := 0
 	decoder := blockPropertiesDecoder{props: props}
+	ret = blockIntersects
 	for i < len(f.shortIDToFiltersIndex) {
 		var id int
 		var prop []byte
@@ -560,43 +705,68 @@ func (f *BlockPropertiesFilterer) intersects(props []byte) (bool, error) {
 			var err error
 			shortID, prop, err = decoder.next()
 			if err != nil {
-				return false, err
+				return ret, err
 			}
 			id = int(shortID)
 		} else {
 			id = math.MaxUint8 + 1
 		}
 		for i < len(f.shortIDToFiltersIndex) && id > i {
-			if f.shortIDToFiltersIndex[i] >= 0 {
-				// There is a filter for this id, but the property for this id
-				// is not encoded for this block.
-				intersects, err := f.filters[f.shortIDToFiltersIndex[i]].Intersects(nil)
-				if err != nil {
-					return false, err
-				}
-				if !intersects {
-					return false, nil
-				}
+			// The property for this id is not encoded for this block, but there
+			// may still be a filter for this id.
+			if intersects, err := f.intersectsFilter(i, nil); err != nil {
+				return ret, err
+			} else if intersects == blockExcluded {
+				return blockExcluded, nil
+			} else if intersects == blockMaybeExcluded {
+				ret = blockMaybeExcluded
 			}
 			i++
 		}
 		if i >= len(f.shortIDToFiltersIndex) {
-			return true, nil
+			return ret, nil
 		}
 		// INVARIANT: id <= i. And since i is always incremented by 1, id==i.
 		if id != i {
 			panic(fmt.Sprintf("%d != %d", id, i))
 		}
-		if f.shortIDToFiltersIndex[i] >= 0 {
-			intersects, err := f.filters[f.shortIDToFiltersIndex[i]].Intersects(prop)
-			if err != nil {
-				return false, err
-			}
-			if !intersects {
-				return false, nil
-			}
+		if intersects, err := f.intersectsFilter(i, prop); err != nil {
+			return ret, err
+		} else if intersects == blockExcluded {
+			return blockExcluded, nil
+		} else if intersects == blockMaybeExcluded {
+			ret = blockMaybeExcluded
 		}
 		i++
 	}
-	return true, nil
+	// ret == blockIntersects || ret == blockMaybeExcluded
+	return ret, nil
+}
+
+func (f *BlockPropertiesFilterer) intersectsFilter(i int, prop []byte) (intersectsResult, error) {
+	if f.shortIDToFiltersIndex[i] >= 0 {
+		intersects, err := f.filters[f.shortIDToFiltersIndex[i]].Intersects(prop)
+		if err != nil {
+			return blockIntersects, err
+		}
+		if !intersects {
+			return blockExcluded, nil
+		}
+	}
+	if i == f.boundLimitedShortID {
+		// The bound-limited filter uses this id.
+		//
+		// The bound-limited filter only applies within a keyspan interval. We
+		// expect the Intersects call to be cheaper than bounds checks. If
+		// Intersects determines that there is no intersection, we return
+		// `blockMaybeExcluded` if no other bpf unconditionally excludes the
+		// block.
+		intersects, err := f.boundLimitedFilter.Intersects(prop)
+		if err != nil {
+			return blockIntersects, err
+		} else if !intersects {
+			return blockMaybeExcluded, nil
+		}
+	}
+	return blockIntersects, nil
 }

--- a/sstable/testdata/block_properties_boundlimited
+++ b/sstable/testdata/block_properties_boundlimited
@@ -1,0 +1,167 @@
+build block-size=28 collectors=(suffix)
+a@5.SET.1:15
+b@2.SET.2:86
+c@9.SET.3:72
+d@3.SET.4:21
+e@2.SET.5:47
+f@0.SET.6:54
+g@8.SET.7:63
+h@3.SET.8:38
+----
+point:    [a@5#1,1,h@3#8,1]
+rangedel: [#0,0,#0,0]
+rangekey: [#0,0,#0,0]
+seqnums:  [1,8]
+
+collectors
+----
+0: suffix
+
+table-props
+----
+0: [0, 10)
+
+block-props
+----
+c#72057594037927935,17:
+  0: [2, 6)
+e#72057594037927935,17:
+  0: [3, 10)
+g#72057594037927935,17:
+  0: [0, 3)
+i#72057594037927935,17:
+  0: [3, 9)
+
+# Test an interator with a bound-limited filter that has a filtering criteria
+# too narrow to exclude any blocks.
+
+iter filter=(suffix,1,20)
+first
+next
+next
+next
+next
+next
+next
+next
+next
+----
+    filter.Intersects([2, 6)) = (true, <nil>)
+<a@5:1> MaybeFilteredKeys()=false
+<b@2:2> MaybeFilteredKeys()=false
+    filter.Intersects([3, 10)) = (true, <nil>)
+<c@9:3> MaybeFilteredKeys()=false
+<d@3:4> MaybeFilteredKeys()=false
+    filter.Intersects([0, 3)) = (true, <nil>)
+<e@2:5> MaybeFilteredKeys()=false
+<f@0:6> MaybeFilteredKeys()=false
+    filter.Intersects([3, 9)) = (true, <nil>)
+<g@8:7> MaybeFilteredKeys()=false
+<h@3:8> MaybeFilteredKeys()=false
+. MaybeFilteredKeys()=false
+
+# Test an interator with a bound-limited filter that excludes one block, the
+# third block.
+
+iter filter=(suffix,3,20)
+first
+next
+next
+next
+next
+next
+next
+----
+    filter.Intersects([2, 6)) = (true, <nil>)
+<a@5:1> MaybeFilteredKeys()=false
+<b@2:2> MaybeFilteredKeys()=false
+    filter.Intersects([3, 10)) = (true, <nil>)
+<c@9:3> MaybeFilteredKeys()=false
+<d@3:4> MaybeFilteredKeys()=false
+    filter.Intersects([0, 3)) = (false, <nil>)
+    filter.KeyIsWithinUpperBound(g#72057594037927935,17) = true
+    filter.Intersects([3, 9)) = (true, <nil>)
+<g@8:7> MaybeFilteredKeys()=true
+<h@3:8> MaybeFilteredKeys()=false
+. MaybeFilteredKeys()=false
+
+# Test the same case but with an upper bound set that prevents skipping the
+# block.
+
+iter filter=(suffix,3,20) filter-upper=f@9
+first
+next
+next
+next
+next
+next
+next
+next
+next
+----
+    filter.Intersects([2, 6)) = (true, <nil>)
+<a@5:1> MaybeFilteredKeys()=false
+<b@2:2> MaybeFilteredKeys()=false
+    filter.Intersects([3, 10)) = (true, <nil>)
+<c@9:3> MaybeFilteredKeys()=false
+<d@3:4> MaybeFilteredKeys()=false
+    filter.Intersects([0, 3)) = (false, <nil>)
+    filter.KeyIsWithinUpperBound(g#72057594037927935,17) = false
+<e@2:5> MaybeFilteredKeys()=false
+<f@0:6> MaybeFilteredKeys()=false
+    filter.Intersects([3, 9)) = (true, <nil>)
+<g@8:7> MaybeFilteredKeys()=false
+<h@3:8> MaybeFilteredKeys()=false
+. MaybeFilteredKeys()=false
+
+# Test a case that filters the first two blocks. The third block is not filtered
+# due to block-property intersection. The fourth block is not filtered due to
+# the upper bound.
+
+iter filter=(suffix,0,1) filter-upper=h@6
+first
+next
+next
+next
+next
+----
+    filter.Intersects([2, 6)) = (false, <nil>)
+    filter.KeyIsWithinUpperBound(c#72057594037927935,17) = true
+    filter.Intersects([3, 10)) = (false, <nil>)
+    filter.KeyIsWithinUpperBound(e#72057594037927935,17) = true
+    filter.Intersects([0, 3)) = (true, <nil>)
+<e@2:5> MaybeFilteredKeys()=true
+<f@0:6> MaybeFilteredKeys()=false
+    filter.Intersects([3, 9)) = (false, <nil>)
+    filter.KeyIsWithinUpperBound(i#72057594037927935,17) = false
+<g@8:7> MaybeFilteredKeys()=false
+<h@3:8> MaybeFilteredKeys()=false
+. MaybeFilteredKeys()=false
+
+# Test a similar case in reverse. In reverse if the very first block is reached,
+# we do not know whether or not it's actually within the bounds because we don't
+# have another index separator to bound the block. As such, there's no call to
+# KeyIsWithinLowerBound for the first block of the sstable [ie, the last one
+# visited by the iterator].
+
+iter filter=(suffix,9,10) filter-lower=a@0
+last
+prev
+prev
+prev
+prev
+----
+    filter.Intersects([3, 9)) = (false, <nil>)
+    filter.KeyIsWithinLowerBound(g#72057594037927935,17) = true
+    filter.Intersects([0, 3)) = (false, <nil>)
+    filter.KeyIsWithinLowerBound(e#72057594037927935,17) = true
+    filter.Intersects([3, 10)) = (true, <nil>)
+<d@3:4> MaybeFilteredKeys()=true
+<c@9:3> MaybeFilteredKeys()=false
+    filter.Intersects([2, 6)) = (false, <nil>)
+<b@2:2> MaybeFilteredKeys()=false
+<a@5:1> MaybeFilteredKeys()=false
+. MaybeFilteredKeys()=false
+
+# Add tests with other non-limited filters set, including one with the same
+# Name.

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -445,7 +445,7 @@ func testTableCacheRandomAccess(t *testing.T, concurrent bool) {
 			iter, _, err := c.newIters(
 				&fileMetadata{FileNum: FileNum(fileNum)},
 				nil, /* iter options */
-				nil /* bytes iterated */)
+				internalIterOpts{})
 			if err != nil {
 				errc <- errors.Errorf("i=%d, fileNum=%d: find: %v", i, fileNum, err)
 				return
@@ -508,7 +508,7 @@ func testTableCacheFrequentlyUsedInternal(t *testing.T, rangeIter bool) {
 				iter, _, err = c.newIters(
 					&fileMetadata{FileNum: FileNum(j)},
 					nil, /* iter options */
-					nil /* bytes iterated */)
+					internalIterOpts{})
 			}
 			if err != nil {
 				t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
@@ -555,14 +555,14 @@ func TestSharedTableCacheFrequentlyUsed(t *testing.T) {
 			iter1, _, err := c1.newIters(
 				&fileMetadata{FileNum: FileNum(j)},
 				nil, /* iter options */
-				nil /* bytes iterated */)
+				internalIterOpts{})
 			if err != nil {
 				t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
 			}
 			iter2, _, err := c2.newIters(
 				&fileMetadata{FileNum: FileNum(j)},
 				nil, /* iter options */
-				nil /* bytes iterated */)
+				internalIterOpts{})
 			if err != nil {
 				t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
 			}
@@ -616,7 +616,7 @@ func testTableCacheEvictionsInternal(t *testing.T, rangeIter bool) {
 			iter, _, err = c.newIters(
 				&fileMetadata{FileNum: FileNum(j)},
 				nil, /* iter options */
-				nil /* bytes iterated */)
+				internalIterOpts{})
 		}
 		if err != nil {
 			t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
@@ -678,7 +678,7 @@ func TestSharedTableCacheEvictions(t *testing.T) {
 		iter1, _, err := c1.newIters(
 			&fileMetadata{FileNum: FileNum(j)},
 			nil, /* iter options */
-			nil /* bytes iterated */)
+			internalIterOpts{})
 		if err != nil {
 			t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
 		}
@@ -686,7 +686,7 @@ func TestSharedTableCacheEvictions(t *testing.T) {
 		iter2, _, err := c2.newIters(
 			&fileMetadata{FileNum: FileNum(j)},
 			nil, /* iter options */
-			nil /* bytes iterated */)
+			internalIterOpts{})
 		if err != nil {
 			t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
 		}
@@ -748,7 +748,7 @@ func TestTableCacheIterLeak(t *testing.T) {
 	iter, _, err := c.newIters(
 		&fileMetadata{FileNum: 0},
 		nil, /* iter options */
-		nil /* bytes iterated */)
+		internalIterOpts{})
 	require.NoError(t, err)
 
 	if err := c.close(); err == nil {
@@ -774,7 +774,7 @@ func TestSharedTableCacheIterLeak(t *testing.T) {
 	iter, _, err := c1.newIters(
 		&fileMetadata{FileNum: 0},
 		nil, /* iter options */
-		nil /* bytes iterated */)
+		internalIterOpts{})
 	require.NoError(t, err)
 
 	if err := c1.close(); err == nil {
@@ -811,7 +811,7 @@ func TestTableCacheRetryAfterFailure(t *testing.T) {
 	if _, _, err := c.newIters(
 		&fileMetadata{FileNum: 0},
 		nil, /* iter options */
-		nil /* bytes iterated */); err == nil {
+		internalIterOpts{}); err == nil {
 		t.Fatalf("expected failure, but found success")
 	}
 	fs.setOpenError(false /* enabled */)
@@ -819,7 +819,7 @@ func TestTableCacheRetryAfterFailure(t *testing.T) {
 	iter, _, err = c.newIters(
 		&fileMetadata{FileNum: 0},
 		nil, /* iter options */
-		nil /* bytes iterated */)
+		internalIterOpts{})
 	require.NoError(t, err)
 	require.NoError(t, iter.Close())
 	fs.validate(t, c, nil)

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -903,3 +903,129 @@ a@1: (a1, .)
 b@3: (b3, .)
 d: (., [d-e) @5=boop)
 .
+
+# Try a broad range key that masks all the point keys.
+
+reset block-size=20
+----
+
+batch
+range-key-set a z @5 boop
+set a@1 foo
+set b@3 foo
+set c@3 foo
+set d@1 foo
+set e@3 foo
+set f@3 foo
+set g@2 foo
+set h@2 foo
+set i@2 foo
+set j@2 foo
+set k@0 foo
+set l@2 foo
+set m@1 foo
+set n@3 foo
+set o@4 foo
+set p@2 foo
+set q@2 foo
+set r@1 foo
+set s@2 foo
+set t@3 foo
+set u@2 foo
+set v@0 foo
+set w@0 foo
+set x@2 foo
+set y@4 foo
+----
+wrote 26 keys
+
+flush
+----
+
+combined-iter mask-suffix=@9
+first
+next
+stats
+----
+a: (., [a-z) @5=boop)
+.
+stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 625 B, cached 0 B)), (points: (count 25, key-bytes 75, value-bytes 75, tombstoned: 0))
+
+# Repeat the above test, but with an iterator that uses a block-property filter
+# mask. The internal stats should reflect fewer bytes read and fewer points
+# visited by the internal iterators.
+
+combined-iter mask-suffix=@9 mask-filter
+first
+next
+stats
+----
+a: (., [a-z) @5=boop)
+.
+stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 50 B, cached 50 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+
+# Perform a similar comparison in reverse.
+
+combined-iter mask-suffix=@9
+last
+prev
+stats
+----
+a: (., [a-z) @5=boop)
+.
+stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
+(internal-stats: (block-bytes: (total 625 B, cached 625 B)), (points: (count 25, key-bytes 75, value-bytes 75, tombstoned: 0))
+
+combined-iter mask-suffix=@9 mask-filter
+last
+prev
+stats
+----
+a: (., [a-z) @5=boop)
+.
+stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
+(internal-stats: (block-bytes: (total 50 B, cached 50 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+
+# Perform similar comparisons with seeks.
+
+combined-iter mask-suffix=@9
+seek-ge m
+next
+stats
+----
+m: (., [a-z) @5=boop)
+.
+stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 325 B, cached 325 B)), (points: (count 13, key-bytes 39, value-bytes 39, tombstoned: 0))
+
+combined-iter mask-suffix=@9 mask-filter
+seek-ge m
+next
+stats
+----
+m: (., [a-z) @5=boop)
+.
+stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 50 B, cached 50 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+
+combined-iter mask-suffix=@9
+seek-lt m
+prev
+stats
+----
+a: (., [a-z) @5=boop)
+.
+stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
+(internal-stats: (block-bytes: (total 325 B, cached 325 B)), (points: (count 12, key-bytes 36, value-bytes 36, tombstoned: 0))
+
+combined-iter mask-suffix=@9 mask-filter
+seek-lt m
+prev
+stats
+----
+a: (., [a-z) @5=boop)
+.
+stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
+(internal-stats: (block-bytes: (total 75 B, cached 75 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))


### PR DESCRIPTION
Add a new `IterOptions.RangeKeyMasking.Filter` option that allows skipping of
sstable blocks that contain exclusively keys masked by range keys. The user
configures a block-property collector to record the maximal suffix within a
block and a block-property filter to filter on the property. The filter must
implement an additional `SetSuffix` method that dynamically changes the
filtering criteria.

Close #1713.

```
name                                                           old time/op    new time/op    delta
Iterator_RangeKeyMasking/range-keys-suffixes=@10/forward-10      2.34ms ± 7%    2.38ms ±11%     ~     (p=0.428 n=20+19)
Iterator_RangeKeyMasking/range-keys-suffixes=@10/backward-10     3.30ms ± 6%    3.31ms ± 2%     ~     (p=0.223 n=19+19)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/forward-10      2.24ms ± 6%    2.08ms ± 4%   -7.16%  (p=0.000 n=19+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/backward-10     2.95ms ± 4%    2.79ms ± 4%   -5.72%  (p=0.000 n=19+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/forward-10      2.17ms ± 7%    0.97ms ± 1%  -55.21%  (p=0.000 n=19+18)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/backward-10     2.74ms ±14%    1.39ms ± 8%  -49.14%  (p=0.000 n=20+19)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/forward-10     2.07ms ±17%    0.15ms ± 1%  -92.80%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/backward-10    2.62ms ±12%    0.30ms ± 1%  -88.46%  (p=0.000 n=20+20)

name                                                           old alloc/op   new alloc/op   delta
Iterator_RangeKeyMasking/range-keys-suffixes=@10/forward-10      3.07kB ± 1%    3.10kB ± 1%   +0.87%  (p=0.007 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@10/backward-10     4.82kB ± 1%    4.84kB ± 1%   +0.36%  (p=0.008 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/forward-10      3.07kB ± 1%    3.11kB ± 0%   +1.22%  (p=0.000 n=20+16)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/backward-10     4.83kB ± 0%    4.83kB ± 1%     ~     (p=0.325 n=15+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/forward-10      3.08kB ± 0%    3.08kB ± 0%   -0.18%  (p=0.013 n=17+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/backward-10     4.83kB ± 0%    4.81kB ± 0%   -0.43%  (p=0.000 n=19+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/forward-10     3.07kB ± 1%    3.06kB ± 0%   -0.17%  (p=0.027 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/backward-10    4.84kB ± 0%    4.81kB ± 0%   -0.54%  (p=0.000 n=17+20)

name                                                           old allocs/op  new allocs/op  delta
Iterator_RangeKeyMasking/range-keys-suffixes=@10/forward-10        47.0 ± 0%      50.0 ± 0%   +6.38%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@10/backward-10       58.0 ± 0%      61.0 ± 0%   +5.17%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/forward-10        47.0 ± 0%      50.0 ± 0%   +6.38%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/backward-10       58.0 ± 0%      61.0 ± 0%   +5.17%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/forward-10        47.0 ± 0%      50.0 ± 0%   +6.38%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/backward-10       58.0 ± 0%      61.0 ± 0%   +5.17%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/forward-10       47.0 ± 0%      50.0 ± 0%   +6.38%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/backward-10      59.0 ± 0%      62.0 ± 0%   +5.08%  (p=0.000 n=20+20)
```

The allocations come from sorting saved range keys at each surfaced point, and will be addressed separately.