### PR TITLE
db: use pointer-receiver for range key sorts

### DIFF
--- a/internal/rangekey/coalesce.go
+++ b/internal/rangekey/coalesce.go
@@ -133,10 +133,10 @@ func (ui *UserIteratorConfig) ShouldDefragment(cmp base.Compare, a, b *keyspan.S
 	// both spans into buffers and sort them by suffix for comparison.
 	ui.defragBufA.cmp = cmp
 	ui.defragBufA.keys = append(ui.defragBufA.keys[:0], a.Keys...)
-	sort.Sort(ui.defragBufA)
+	sort.Sort(&ui.defragBufA)
 	ui.defragBufB.cmp = cmp
 	ui.defragBufB.keys = append(ui.defragBufB.keys[:0], b.Keys...)
-	sort.Sort(ui.defragBufB)
+	sort.Sort(&ui.defragBufB)
 
 	for i := range ui.defragBufA.keys {
 		if ui.defragBufA.keys[i].Kind() != base.InternalKeyKindRangeKeySet ||
@@ -215,7 +215,7 @@ func Coalesce(cmp base.Compare, keys []keyspan.Key, dst *[]keyspan.Key) error {
 				continue
 			}
 			keysBySuffix.keys = append(keysBySuffix.keys, k)
-			sort.Sort(keysBySuffix)
+			sort.Sort(&keysBySuffix)
 		case base.InternalKeyKindRangeKeyUnset:
 			n := len(keysBySuffix.keys)
 
@@ -225,7 +225,7 @@ func Coalesce(cmp base.Compare, keys []keyspan.Key, dst *[]keyspan.Key) error {
 				continue
 			}
 			keysBySuffix.keys = append(keysBySuffix.keys, k)
-			sort.Sort(keysBySuffix)
+			sort.Sort(&keysBySuffix)
 		case base.InternalKeyKindRangeKeyDelete:
 			// All remaining range keys in this span have been deleted by this
 			// RangeKeyDelete. There's no need to continue looping, because all
@@ -252,7 +252,7 @@ func SortBySuffix(cmp base.Compare, keys []keyspan.Key) {
 		cmp:  cmp,
 		keys: keys,
 	}
-	sort.Sort(bySuffix)
+	sort.Sort(&bySuffix)
 }
 
 type keysBySuffix struct {
@@ -263,7 +263,7 @@ type keysBySuffix struct {
 // get searches for suffix among the first n keys in keys. If the suffix is
 // found, it returns the index of the item with the suffix. If the suffix is not
 // found, it returns n.
-func (s keysBySuffix) get(n int, suffix []byte) (i int) {
+func (s *keysBySuffix) get(n int, suffix []byte) (i int) {
 	// Binary search for the suffix to see if there's an existing key with the
 	// suffix. Only binary search among the first n items. get is called while
 	// appending new keys with suffixes that may sort before existing keys.
@@ -279,6 +279,6 @@ func (s keysBySuffix) get(n int, suffix []byte) (i int) {
 	return n
 }
 
-func (s keysBySuffix) Len() int           { return len(s.keys) }
-func (s keysBySuffix) Less(i, j int) bool { return s.cmp(s.keys[i].Suffix, s.keys[j].Suffix) < 0 }
-func (s keysBySuffix) Swap(i, j int)      { s.keys[i], s.keys[j] = s.keys[j], s.keys[i] }
+func (s *keysBySuffix) Len() int           { return len(s.keys) }
+func (s *keysBySuffix) Less(i, j int) bool { return s.cmp(s.keys[i].Suffix, s.keys[j].Suffix) < 0 }
+func (s *keysBySuffix) Swap(i, j int)      { s.keys[i], s.keys[j] = s.keys[j], s.keys[i] }

--- a/iterator.go
+++ b/iterator.go
@@ -289,9 +289,9 @@ type bySuffix struct {
 	data []RangeKeyData
 }
 
-func (s bySuffix) Len() int           { return len(s.data) }
-func (s bySuffix) Less(i, j int) bool { return s.cmp(s.data[i].Suffix, s.data[j].Suffix) < 0 }
-func (s bySuffix) Swap(i, j int)      { s.data[i], s.data[j] = s.data[j], s.data[i] }
+func (s *bySuffix) Len() int           { return len(s.data) }
+func (s *bySuffix) Less(i, j int) bool { return s.cmp(s.data[i].Suffix, s.data[j].Suffix) < 0 }
+func (s *bySuffix) Swap(i, j int)      { s.data[i], s.data[j] = s.data[j], s.data[i] }
 
 // isEphemeralPosition returns true iff the current iterator position is
 // ephemeral, and won't be visited during subsequent relative positioning
@@ -1610,7 +1610,7 @@ func (i *Iterator) setRangeKey() {
 			})
 		}
 	}
-	sort.Sort(i.rangeKey.keys)
+	sort.Sort(&i.rangeKey.keys)
 }
 
 // saveRangeKey sets the current range key to the underlying iterator's current
@@ -1650,7 +1650,7 @@ func (i *Iterator) saveRangeKey() {
 			})
 		}
 	}
-	sort.Sort(i.rangeKey.keys)
+	sort.Sort(&i.rangeKey.keys)
 }
 
 // HasPointAndRange indicates whether there exists a point key, a range key or


### PR DESCRIPTION
Define the sort.Interface on a pointer receiver when sorting range keys. This
prevents an allocation. Benchmark results from running the benchmark in #1824:

```
name                                                  old time/op    new time/op    delta
Iterator_RangeKeyMasking/range-keys-suffixes=@10-10     2.52ms ± 1%    2.33ms ± 2%   -7.60%  (p=0.000 n=10+10)
Iterator_RangeKeyMasking/range-keys-suffixes=@50-10     2.36ms ± 1%    2.24ms ± 1%   -4.86%  (p=0.000 n=10+9)
Iterator_RangeKeyMasking/range-keys-suffixes=@75-10     2.23ms ± 2%    2.23ms ± 3%     ~     (p=0.905 n=9+10)
Iterator_RangeKeyMasking/range-keys-suffixes=@100-10    2.11ms ± 3%    2.10ms ± 1%     ~     (p=0.780 n=10+9)

name                                                  old alloc/op   new alloc/op   delta
Iterator_RangeKeyMasking/range-keys-suffixes=@10-10      372kB ± 0%     122kB ± 2%  -67.32%  (p=0.000 n=8+9)
Iterator_RangeKeyMasking/range-keys-suffixes=@50-10      257kB ± 1%     117kB ± 1%  -54.38%  (p=0.000 n=10+10)
Iterator_RangeKeyMasking/range-keys-suffixes=@75-10      182kB ± 2%     116kB ± 3%  -36.16%  (p=0.000 n=10+10)
Iterator_RangeKeyMasking/range-keys-suffixes=@100-10     110kB ± 1%     110kB ± 1%     ~     (p=0.190 n=10+10)

name                                                  old allocs/op  new allocs/op  delta
Iterator_RangeKeyMasking/range-keys-suffixes=@10-10      7.63k ± 0%     0.07k ± 0%  -99.10%  (p=0.000 n=9+9)
Iterator_RangeKeyMasking/range-keys-suffixes=@50-10      4.26k ± 0%     0.07k ± 0%  -98.40%  (p=0.000 n=10+8)
Iterator_RangeKeyMasking/range-keys-suffixes=@75-10      2.12k ± 0%     0.07k ± 2%  -96.78%  (p=0.000 n=8+10)
Iterator_RangeKeyMasking/range-keys-suffixes=@100-10      72.0 ± 0%      67.0 ± 0%   -6.94%  (p=0.000 n=10+10)
```