### PR TITLE
db: min table format; add FormatMinTableFormatPebblev1

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2791,7 +2791,9 @@ func TestCompactionErrorCleanup(t *testing.T) {
 		f, err := mem.Create("ext")
 		require.NoError(t, err)
 
-		w := sstable.NewWriter(f, sstable.WriterOptions{})
+		w := sstable.NewWriter(f, sstable.WriterOptions{
+			TableFormat: d.FormatMajorVersion().MaxTableFormat(),
+		})
 		for _, k := range keys {
 			require.NoError(t, w.Set([]byte(k), nil))
 		}

--- a/db_test.go
+++ b/db_test.go
@@ -1075,7 +1075,9 @@ func TestDBConcurrentCompactClose(t *testing.T) {
 			path := fmt.Sprintf("ext%d", j)
 			f, err := mem.Create(path)
 			require.NoError(t, err)
-			w := sstable.NewWriter(f, sstable.WriterOptions{})
+			w := sstable.NewWriter(f, sstable.WriterOptions{
+				TableFormat: d.FormatMajorVersion().MaxTableFormat(),
+			})
 			require.NoError(t, w.Set([]byte(fmt.Sprint(j)), nil))
 			require.NoError(t, w.Close())
 			require.NoError(t, d.Ingest([]string{path}))

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -228,7 +228,9 @@ func TestEventListener(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			w := sstable.NewWriter(f, sstable.WriterOptions{})
+			w := sstable.NewWriter(f, sstable.WriterOptions{
+				TableFormat: d.FormatMajorVersion().MaxTableFormat(),
+			})
 			if err := w.Add(base.MakeInternalKey([]byte("a"), 0, InternalKeyKindSet), nil); err != nil {
 				return err.Error()
 			}

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -110,6 +110,19 @@ func (v FormatMajorVersion) MaxTableFormat() sstable.TableFormat {
 	}
 }
 
+// MinTableFormat returns the minimum sstable.TableFormat that can be used at
+// this FormatMajorVersion.
+func (v FormatMajorVersion) MinTableFormat() sstable.TableFormat {
+	switch v {
+	case FormatDefault, FormatMostCompatible, formatVersionedManifestMarker,
+		FormatVersioned, FormatSetWithDelete, FormatBlockPropertyCollector,
+		FormatSplitUserKeysMarked, FormatMarkedCompacted, FormatRangeKeys:
+		return sstable.TableFormatLevelDB
+	default:
+		panic(fmt.Sprintf("pebble: unsupported format major version: %s", v))
+	}
+}
+
 // formatMajorVersionMigrations defines the migrations from one format
 // major version to the next. Each migration is defined as a closure
 // which will be invoked on the database before the new format major

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -189,27 +189,29 @@ func TestFormatMajorVersions_TableFormat(t *testing.T) {
 	// sanity check that new versions have a corresponding mapping. The test
 	// fixture is intentionally verbose.
 
-	m := map[FormatMajorVersion]sstable.TableFormat{
-		FormatDefault:                 sstable.TableFormatRocksDBv2,
-		FormatMostCompatible:          sstable.TableFormatRocksDBv2,
-		formatVersionedManifestMarker: sstable.TableFormatRocksDBv2,
-		FormatVersioned:               sstable.TableFormatRocksDBv2,
-		FormatSetWithDelete:           sstable.TableFormatRocksDBv2,
-		FormatBlockPropertyCollector:  sstable.TableFormatPebblev1,
-		FormatSplitUserKeysMarked:     sstable.TableFormatPebblev1,
-		FormatMarkedCompacted:         sstable.TableFormatPebblev1,
-		FormatRangeKeys:               sstable.TableFormatPebblev2,
+	m := map[FormatMajorVersion][2]sstable.TableFormat{
+		FormatDefault:                 {sstable.TableFormatLevelDB, sstable.TableFormatRocksDBv2},
+		FormatMostCompatible:          {sstable.TableFormatLevelDB, sstable.TableFormatRocksDBv2},
+		formatVersionedManifestMarker: {sstable.TableFormatLevelDB, sstable.TableFormatRocksDBv2},
+		FormatVersioned:               {sstable.TableFormatLevelDB, sstable.TableFormatRocksDBv2},
+		FormatSetWithDelete:           {sstable.TableFormatLevelDB, sstable.TableFormatRocksDBv2},
+		FormatBlockPropertyCollector:  {sstable.TableFormatLevelDB, sstable.TableFormatPebblev1},
+		FormatSplitUserKeysMarked:     {sstable.TableFormatLevelDB, sstable.TableFormatPebblev1},
+		FormatMarkedCompacted:         {sstable.TableFormatLevelDB, sstable.TableFormatPebblev1},
+		FormatRangeKeys:               {sstable.TableFormatLevelDB, sstable.TableFormatPebblev2},
 	}
 
 	// Valid versions.
 	for fmv := FormatMostCompatible; fmv <= FormatNewest; fmv++ {
-		f := fmv.MaxTableFormat()
-		require.Equalf(t, m[fmv], f, "got %s; want %s", f, m[fmv])
+		got := [2]sstable.TableFormat{fmv.MinTableFormat(), fmv.MaxTableFormat()}
+		require.Equalf(t, m[fmv], got, "got %s; want %s", got, m[fmv])
+		require.True(t, got[0] <= got[1] /* min <= max */)
 	}
 
 	// Invalid versions.
 	fmv := FormatNewest + 1
 	require.Panics(t, func() { _ = fmv.MaxTableFormat() })
+	require.Panics(t, func() { _ = fmv.MinTableFormat() })
 }
 
 func TestSplitUserKeyMigration(t *testing.T) {

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -43,6 +43,8 @@ func TestRatchetFormat(t *testing.T) {
 	require.Equal(t, FormatBlockPropertyCollector, d.FormatMajorVersion())
 	require.NoError(t, d.RatchetFormatMajorVersion(FormatRangeKeys))
 	require.Equal(t, FormatRangeKeys, d.FormatMajorVersion())
+	require.NoError(t, d.RatchetFormatMajorVersion(FormatMinTableFormatPebblev1))
+	require.Equal(t, FormatMinTableFormatPebblev1, d.FormatMajorVersion())
 	require.NoError(t, d.Close())
 
 	// If we Open the database again, leaving the default format, the
@@ -199,6 +201,7 @@ func TestFormatMajorVersions_TableFormat(t *testing.T) {
 		FormatSplitUserKeysMarked:     {sstable.TableFormatLevelDB, sstable.TableFormatPebblev1},
 		FormatMarkedCompacted:         {sstable.TableFormatLevelDB, sstable.TableFormatPebblev1},
 		FormatRangeKeys:               {sstable.TableFormatLevelDB, sstable.TableFormatPebblev2},
+		FormatMinTableFormatPebblev1:  {sstable.TableFormatPebblev1, sstable.TableFormatPebblev2},
 	}
 
 	// Valid versions.

--- a/ingest.go
+++ b/ingest.go
@@ -69,10 +69,10 @@ func ingestLoad1(
 	if err != nil {
 		return nil, err
 	}
-	if tf > fmv.MaxTableFormat() {
+	if tf < fmv.MinTableFormat() || tf > fmv.MaxTableFormat() {
 		return nil, errors.Newf(
-			"pebble: table with format %s unsupported at DB format major version %d, %s",
-			tf, fmv, fmv.MaxTableFormat(),
+			"pebble: table format %s is not within range supported at DB format major version %d, (%s,%s)",
+			tf, fmv, fmv.MinTableFormat(), fmv.MaxTableFormat(),
 		)
 	}
 

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -108,6 +108,7 @@ func TestIngestLoadRand(t *testing.T) {
 	mem := vfs.NewMem()
 	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 	cmp := DefaultComparer.Compare
+	version := FormatNewest
 
 	randBytes := func(size int) []byte {
 		data := make([]byte, size)
@@ -147,7 +148,9 @@ func TestIngestLoadRand(t *testing.T) {
 
 			expected[i].ExtendPointKeyBounds(cmp, keys[0], keys[len(keys)-1])
 
-			w := sstable.NewWriter(f, sstable.WriterOptions{})
+			w := sstable.NewWriter(f, sstable.WriterOptions{
+				TableFormat: version.MaxTableFormat(),
+			})
 			var count uint64
 			for i := range keys {
 				if i > 0 && base.InternalCompare(cmp, keys[i-1], keys[i]) == 0 {
@@ -171,7 +174,7 @@ func TestIngestLoadRand(t *testing.T) {
 		Comparer: DefaultComparer,
 		FS:       mem,
 	}
-	meta, _, err := ingestLoad(opts, FormatNewest, paths, 0, pending)
+	meta, _, err := ingestLoad(opts, version, paths, 0, pending)
 	require.NoError(t, err)
 
 	for _, m := range meta {

--- a/open_test.go
+++ b/open_test.go
@@ -148,7 +148,7 @@ func TestNewDBFilenames(t *testing.T) {
 			"LOCK",
 			"MANIFEST-000001",
 			"OPTIONS-000003",
-			"marker.format-version.000007.008",
+			"marker.format-version.000008.009",
 			"marker.manifest.000001.MANIFEST-000001",
 		},
 	}

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -40,6 +40,9 @@ sync: db
 create: db/marker.format-version.000007.008
 close: db/marker.format-version.000007.008
 sync: db
+create: db/marker.format-version.000008.009
+close: db/marker.format-version.000008.009
+sync: db
 sync: db/MANIFEST-000001
 create: db/000002.log
 sync: db
@@ -105,9 +108,9 @@ close:
 open-dir: checkpoints/checkpoint1
 link: db/OPTIONS-000003 -> checkpoints/checkpoint1/OPTIONS-000003
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.008
-sync: checkpoints/checkpoint1/marker.format-version.000001.008
-close: checkpoints/checkpoint1/marker.format-version.000001.008
+create: checkpoints/checkpoint1/marker.format-version.000001.009
+sync: checkpoints/checkpoint1/marker.format-version.000001.009
+close: checkpoints/checkpoint1/marker.format-version.000001.009
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 create: checkpoints/checkpoint1/MANIFEST-000001
@@ -162,7 +165,7 @@ CURRENT
 LOCK
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000007.008
+marker.format-version.000008.009
 marker.manifest.000001.MANIFEST-000001
 
 list checkpoints/checkpoint1
@@ -172,7 +175,7 @@ list checkpoints/checkpoint1
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.008
+marker.format-version.000001.009
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint1 readonly

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -50,6 +50,10 @@ create: db/marker.format-version.000007.008
 close: db/marker.format-version.000007.008
 sync: db
 upgraded to format version: 008
+create: db/marker.format-version.000008.009
+close: db/marker.format-version.000008.009
+sync: db
+upgraded to format version: 009
 create: db/MANIFEST-000003
 close: db/MANIFEST-000001
 sync: db/MANIFEST-000003
@@ -217,9 +221,9 @@ close:
 open-dir: checkpoint
 link: db/OPTIONS-000004 -> checkpoint/OPTIONS-000004
 open-dir: checkpoint
-create: checkpoint/marker.format-version.000001.008
-sync: checkpoint/marker.format-version.000001.008
-close: checkpoint/marker.format-version.000001.008
+create: checkpoint/marker.format-version.000001.009
+sync: checkpoint/marker.format-version.000001.009
+close: checkpoint/marker.format-version.000001.009
 sync: checkpoint
 close: checkpoint
 create: checkpoint/MANIFEST-000017

--- a/testdata/ingest_load
+++ b/testdata/ingest_load
@@ -93,7 +93,7 @@ a.RANGEDEL.0:b
 load writer-version=8 db-version=7
 a.SET.1:
 ----
-pebble: table with format (Pebble,v2) unsupported at DB format major version 7, (Pebble,v1)
+pebble: table format (Pebble,v2) is not within range supported at DB format major version 7, ((LevelDB),(Pebble,v1))
 
 # Tables with range keys only.
 


### PR DESCRIPTION
**db: introduce a minimum table format for each format major version**

Currently, a Pebble format major version has a corresponding maximum
supported SSTable format version. This ensures that a DB is running at a
given version before it can support reading and writing tables with a
certain features - i.e. range keys or block properties.

In addition to supporting an upper bound on the table format supported
by a DB, there are plans to support dropping support for certain
features (i.e. table properties). Dropping support for features relies
on being able to enforce that tables in the LSM (either created by the
DB, or external tables that are ingested) are compatible with the DB,
with table formats falling within a range of supported versions.

Add the `(FormatMajorVersion).MinTableFormat` method, returning the
minimum supported table format version for a given format major version.
Initially, all existing format major versions support reading the
earliest supported table format (i.e. the LevelDB table format).

Add a lower bound check when ingesting tables.

Touches https://github.com/cockroachdb/cockroach/issues/82678.

**db: add FormatMinTableFormatPebblev1 format major version**

In preparation for dropping support for table properties, add a format
major version (`FormatMinTableFormatPebblev1`) that acts as a gate for
new and ingested SSTables being created with a table format of _at
least_ `Pebblev1` (block properites).

With a DB at version `FormatMinTableFormatPebblev1`, subsequent format
major version migrations (e.g. a mark / sweep of all tables in the LSM
looking for tables with an "old" format version) can rely on the fact
that no _new_ SSTables can be introduced with a table format _older_
than `Pebblev1`.

Touches https://github.com/cockroachdb/cockroach/issues/82678.