### PR TITLE
sstable: allow rewriting suffixes of tables that contain only range keys

### DIFF
--- a/sstable/testdata/rewriter
+++ b/sstable/testdata/rewriter
@@ -208,3 +208,30 @@ c_123
 b
 get f_123: pebble: not found
 c
+
+# Rewrite a table that contain only range keys.
+
+build block-size=1 index-block-size=1 filter comparer-split-4b-suffix
+rangekey: a-b:{(#1,RANGEKEYSET,_xyz)}
+rangekey: b-c:{(#1,RANGEKEYSET,_xyz)}
+rangekey: c-d:{(#1,RANGEKEYSET,_xyz)}
+----
+rangekey: [a#1,21-d#72057594037927935,21]
+seqnums:  [1-1]
+
+scan-range-key
+----
+a-b:{(#1,RANGEKEYSET,_xyz)}
+b-c:{(#1,RANGEKEYSET,_xyz)}
+c-d:{(#1,RANGEKEYSET,_xyz)}
+
+rewrite from=_xyz to=_123 block-size=1 index-block-size=1 filter comparer-split-4b-suffix
+----
+rangekey: [a#1,21-d#72057594037927935,21]
+seqnums:  [1-1]
+
+scan-range-key
+----
+a-b:{(#1,RANGEKEYSET,_123)}
+b-c:{(#1,RANGEKEYSET,_123)}
+c-d:{(#1,RANGEKEYSET,_123)}

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -48,6 +48,7 @@ func runDataDriven(t *testing.T, file string, parallelism bool) {
 			require.NoError(t, r.Close())
 		}
 	}()
+	formatVersion := TableFormatMax
 
 	format := func(m *WriterMetadata) string {
 		var b bytes.Buffer
@@ -74,7 +75,7 @@ func runDataDriven(t *testing.T, file string, parallelism bool) {
 			var meta *WriterMetadata
 			var err error
 			meta, r, err = runBuildCmd(td, &WriterOptions{
-				TableFormat: TableFormatMax,
+				TableFormat: formatVersion,
 				Parallelism: parallelism,
 			}, 0)
 			if err != nil {
@@ -90,7 +91,7 @@ func runDataDriven(t *testing.T, file string, parallelism bool) {
 			var meta *WriterMetadata
 			var err error
 			meta, r, err = runBuildRawCmd(td, &WriterOptions{
-				TableFormat: TableFormatMax,
+				TableFormat: formatVersion,
 			})
 			if err != nil {
 				return err.Error()
@@ -175,7 +176,9 @@ func runDataDriven(t *testing.T, file string, parallelism bool) {
 		case "rewrite":
 			var meta *WriterMetadata
 			var err error
-			meta, r, err = runRewriteCmd(td, r, WriterOptions{})
+			meta, r, err = runRewriteCmd(td, r, WriterOptions{
+				TableFormat: formatVersion,
+			})
 			if err != nil {
 				return err.Error()
 			}


### PR DESCRIPTION
Currently, when rewriting suffixes for a table that contains only range
keys (i.e. no point keys), the rewrite fails, as the rewriter expects to
see a filter block. However, a table will only contain a filter block if
the table contains point keys (range keys are not included in the
filter).

Allow a rewrite to continue if it does not encounter a filter block.

Fix cockroachdb/cockroach#85175.