### PR TITLE
internal/keyspan: avoid allocation in SortKeys

### DIFF
--- a/internal/keyspan/span.go
+++ b/internal/keyspan/span.go
@@ -337,9 +337,11 @@ func (s prettySpan) Format(fs fmt.State, c rune) {
 }
 
 // SortKeys sorts a keys slice by trailer.
-func SortKeys(keys []Key) {
-	sorted := keysBySeqNumKind(keys)
-	sort.Sort(&sorted)
+func SortKeys(keys *[]Key) {
+	// NB: keys is a pointer to a slice instead of a slice to avoid `sorted`
+	// escaping to the heap.
+	sorted := (*keysBySeqNumKind)(keys)
+	sort.Sort(sorted)
 }
 
 // ParseSpan parses the string representation of a Span. It's intended for

--- a/internal/rangekey/coalesce.go
+++ b/internal/rangekey/coalesce.go
@@ -242,7 +242,7 @@ func Coalesce(cmp base.Compare, keys []keyspan.Key, dst *[]keyspan.Key) error {
 	// Update the span with the (potentially reduced) keys slice, and re-sort it
 	// by Trailer.
 	*dst = keysBySuffix.keys
-	keyspan.SortKeys(*dst)
+	keyspan.SortKeys(dst)
 	return nil
 }
 

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -1109,7 +1109,7 @@ func (i *fragmentBlockIter) gatherBackward(k *InternalKey, internalValue []byte)
 	// span.
 
 	// Backwards iteration encounters internal keys in the wrong order.
-	keyspan.SortKeys(i.span.Keys)
+	keyspan.SortKeys(&i.span.Keys)
 
 	return &i.span
 }


### PR DESCRIPTION
```
name                                                           old time/op    new time/op    delta
Iterator_RangeKeyMasking/range-keys-suffixes=@10/forward-10      2.34ms ± 7%    2.32ms ± 5%     ~     (p=0.667 n=20+19)
Iterator_RangeKeyMasking/range-keys-suffixes=@10/backward-10     3.30ms ± 6%    3.20ms ± 2%   -2.98%  (p=0.000 n=19+19)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/forward-10      2.24ms ± 6%    2.19ms ± 5%   -2.49%  (p=0.006 n=19+19)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/backward-10     2.95ms ± 4%    3.06ms ±10%   +3.50%  (p=0.006 n=19+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/forward-10      2.17ms ± 7%    2.22ms ± 7%   +2.21%  (p=0.030 n=19+19)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/backward-10     2.74ms ±14%    2.77ms ± 8%     ~     (p=0.327 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/forward-10     2.07ms ±17%    2.14ms ±10%   +3.42%  (p=0.015 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/backward-10    2.62ms ±12%    2.40ms ±13%   -8.15%  (p=0.000 n=20+20)

name                                                           old alloc/op   new alloc/op   delta
Iterator_RangeKeyMasking/range-keys-suffixes=@10/forward-10      3.07kB ± 1%    2.86kB ± 1%   -6.85%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@10/backward-10     4.82kB ± 1%    4.46kB ± 1%   -7.59%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/forward-10      3.07kB ± 1%    2.86kB ± 1%   -6.94%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/backward-10     4.83kB ± 0%    4.46kB ± 1%   -7.76%  (p=0.000 n=15+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/forward-10      3.08kB ± 0%    2.86kB ± 1%   -7.28%  (p=0.000 n=17+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/backward-10     4.83kB ± 0%    4.46kB ± 1%   -7.75%  (p=0.000 n=19+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/forward-10     3.07kB ± 1%    2.85kB ± 1%   -7.22%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/backward-10    4.84kB ± 0%    4.46kB ± 1%   -7.86%  (p=0.000 n=17+20)

name                                                           old allocs/op  new allocs/op  delta
Iterator_RangeKeyMasking/range-keys-suffixes=@10/forward-10        47.0 ± 0%      38.0 ± 0%  -19.15%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@10/backward-10       58.0 ± 0%      43.0 ± 0%  -25.86%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/forward-10        47.0 ± 0%      38.0 ± 0%  -19.15%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/backward-10       58.0 ± 0%      43.0 ± 0%  -25.86%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/forward-10        47.0 ± 0%      38.0 ± 0%  -19.15%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/backward-10       58.0 ± 0%      43.0 ± 0%  -25.86%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/forward-10       47.0 ± 0%      38.0 ± 0%  -19.15%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/backward-10      59.0 ± 0%      44.0 ± 0%  -25.42%  (p=0.000 n=20+20)
```