### PR TITLE
internal/keyspan: don't buffer empty span in DefragmentingIter seeks

### DIFF
--- a/internal/keyspan/defragment.go
+++ b/internal/keyspan/defragment.go
@@ -176,6 +176,9 @@ func (i *DefragmentingIter) SeekGE(key []byte) *Span {
 	if i.iterSpan == nil {
 		i.iterPos = iterPosCurr
 		return nil
+	} else if i.iterSpan.Empty() {
+		i.iterPos = iterPosCurr
+		return i.iterSpan
 	}
 	// Save the current span and peek backwards.
 	i.saveCurrent()
@@ -206,6 +209,9 @@ func (i *DefragmentingIter) SeekLT(key []byte) *Span {
 	if i.iterSpan == nil {
 		i.iterPos = iterPosCurr
 		return nil
+	} else if i.iterSpan.Empty() {
+		i.iterPos = iterPosCurr
+		return i.iterSpan
 	}
 	// Defragment forward to find the end of the defragmented span.
 	i.defragmentForward()


### PR DESCRIPTION
The defragmenting iterator avoids defragmenting empty spans, because the empty
span fragments are not observable by the user. However on seeks, it would still
pay the cost of buffering the empty span and stepping the iterator both
directions.

This was a regression added in #1748, hidden among that change's own
performance wins. Previously, we used `Span.Empty()` in the defragmenting
iterator to detect both of the two cases: a span doesn't exist, or a span
exists but is empty. Now that nonexistent spans are surfaced as `nil`s, these
cases must be handled separately.

```
name                                    old time/op    new time/op    delta
IteratorSeekNoRangeKeys/batch=false-10    2.58µs ± 1%    2.49µs ± 1%   -3.49%  (p=0.000 n=10+10)
IteratorSeekNoRangeKeys/batch=true-10     4.87µs ± 1%    4.02µs ± 1%  -17.44%  (p=0.000 n=10+10)
```