### PR TITLE
internal/rangekey: sort keys by suffix once during iteration

### DIFF
--- a/internal/keyspan/fragmenter.go
+++ b/internal/keyspan/fragmenter.go
@@ -183,9 +183,13 @@ func (f *Fragmenter) checkInvariants(buf []Span) {
 // deletion and range key blocks, so these keys are stable. Because of this key
 // stability, typically callers only need to perform a shallow clone of the Span
 // before Add-ing it to the fragmenter.
+//
+// Add requires the provided span's keys are sorted in Trailer descending order.
 func (f *Fragmenter) Add(s Span) {
 	if f.finished {
 		panic("pebble: span fragmenter already finished")
+	} else if s.KeysOrder != ByTrailerDesc {
+		panic("pebble: span keys unexpectedly not in trailer descending order")
 	}
 	if f.flushedKey != nil {
 		switch c := f.Cmp(s.Start, f.flushedKey); {

--- a/internal/keyspan/merging_iter.go
+++ b/internal/keyspan/merging_iter.go
@@ -68,6 +68,10 @@ func visibleTransform(snapshot uint64) Transformer {
 // overlapping keys are surfaced in a single Span. Key spans from one child
 // iterator may overlap key spans from another child iterator arbitrarily.
 //
+// The spans combined by MergingIter will return spans with keys sorted by
+// trailer descending. If the MergingIter is configured with a Transformer, it's
+// permitted to modify the ordering of the spans' keys returned by MergingIter.
+//
 // Algorithm
 //
 // The merging iterator wraps child iterators, merging and fragmenting spans
@@ -210,9 +214,9 @@ type MergingIter struct {
 	// buf is a buffer used to save [start, end) boundary keys.
 	buf []byte
 	// keys holds all of the keys across all levels that overlap the key span
-	// [start, end), sorted by sequence number and kind descending. This slice
-	// is reconstituted in synthesizeKeys from each mergingIterLevel's keys
-	// every time the [start, end) bounds change.
+	// [start, end), sorted by Trailer descending. This slice is reconstituted
+	// in synthesizeKeys from each mergingIterLevel's keys every time the
+	// [start, end) bounds change.
 	//
 	// Each element points into a child iterator's memory, so the keys may not
 	// be directly modified.
@@ -809,13 +813,18 @@ func (m *MergingIter) synthesizeKeys(dir int8) (bool, *Span) {
 			found = true
 		}
 	}
+	// TODO(jackson): We should be able to remove this sort and instead
+	// guarantee that we'll return keys in the order of the levels they're from.
+	// With careful iterator construction, this would  guarantee that they're
+	// sorted by trailer descending for the range key iteration use case.
 	sort.Sort(&m.keys)
 
 	// Apply the configured transform. See visibleTransform.
 	s := Span{
-		Start: m.start,
-		End:   m.end,
-		Keys:  m.keys,
+		Start:     m.start,
+		End:       m.end,
+		Keys:      m.keys,
+		KeysOrder: ByTrailerDesc,
 	}
 	if err := m.transformer.Transform(m.cmp, s, &m.span); err != nil {
 		m.err = err

--- a/internal/keyspan/span.go
+++ b/internal/keyspan/span.go
@@ -31,15 +31,29 @@ type Span struct {
 	// non-nil, or both nil if representing an invalid Span.
 	Start, End []byte
 	// Keys holds the set of keys applied over the [Start, End) user key range.
-	// Keys is sorted by (SeqNum, Kind) descending. If SeqNum and Kind are
-	// equal, the order of Keys is undefined. Keys may be empty, even if Start
-	// and End are non-nil.
+	// Keys is sorted by (SeqNum, Kind) descending, unless otherwise specified
+	// by the context. If SeqNum and Kind are equal, the order of Keys is
+	// undefined. Keys may be empty, even if Start and End are non-nil.
 	//
 	// Keys are a decoded representation of the internal keys stored in batches
 	// or sstable blocks. A single internal key in a range key block may produce
 	// several decoded Keys.
-	Keys []Key
+	Keys      []Key
+	KeysOrder KeysOrder
 }
+
+// KeysOrder describes the ordering of Keys within a Span.
+type KeysOrder int8
+
+const (
+	// ByTrailerDesc indicates a Span's keys are sorted by Trailer descending.
+	// This is the default ordering, and the ordering used during physical
+	// storage.
+	ByTrailerDesc KeysOrder = iota
+	// BySuffixAsc indicates a Span's keys are sorted by Suffix ascending. This
+	// ordering is used during user iteration of range keys.
+	BySuffixAsc
+)
 
 // Key represents a single key applied over a span of user keys. A Key is
 // contained by a Span which specifies the span of user keys over which the Key
@@ -90,10 +104,13 @@ func (s *Span) Empty() bool {
 }
 
 // SmallestKey returns the smallest internal key defined by the span's keys.
-// It panics if the span contains no keys.
+// It requires the Span's keys be in ByTrailerDesc order. It panics if the span
+// contains no keys or its keys are sorted in a different order.
 func (s *Span) SmallestKey() base.InternalKey {
 	if len(s.Keys) == 0 {
 		panic("pebble: Span contains no keys")
+	} else if s.KeysOrder != ByTrailerDesc {
+		panic("pebble: span's keys unexpectedly not in trailer order")
 	}
 	// The first key has the highest (sequence number,kind) tuple.
 	return base.InternalKey{
@@ -108,10 +125,13 @@ func (s *Span) SmallestKey() base.InternalKey {
 // with the maximal sequence number, ensuring all InternalKeys with the same
 // user key sort after the sentinel key.
 //
-// It panics if the span contains no keys.
+// It requires the Span's keys be in ByTrailerDesc order. It panics if the span
+// contains no keys or its keys are sorted in a different order.
 func (s *Span) LargestKey() base.InternalKey {
 	if len(s.Keys) == 0 {
 		panic("pebble: Span contains no keys")
+	} else if s.KeysOrder != ByTrailerDesc {
+		panic("pebble: span's keys unexpectedly not in trailer order")
 	}
 	// The last key has the lowest (sequence number,kind) tuple.
 	kind := s.Keys[len(s.Keys)-1].Kind()
@@ -119,16 +139,21 @@ func (s *Span) LargestKey() base.InternalKey {
 }
 
 // SmallestSeqNum returns the smallest sequence number of a key contained within
-// the span. It panics if the span contains no keys.
+// the span. It requires the Span's keys be in ByTrailerDesc order. It panics if
+// the span contains no keys or its keys are sorted in a different order.
 func (s *Span) SmallestSeqNum() uint64 {
 	if len(s.Keys) == 0 {
 		panic("pebble: Span contains no keys")
+	} else if s.KeysOrder != ByTrailerDesc {
+		panic("pebble: span's keys unexpectedly not in trailer order")
 	}
+
 	return s.Keys[len(s.Keys)-1].SeqNum()
 }
 
 // LargestSeqNum returns the largest sequence number of a key contained within
-// the span. It panics if the span contains no keys.
+// the span. It requires the Span's keys be in ByTrailerDesc order. It panics if
+// the span contains no keys or its keys are sorted in a different order.
 func (s *Span) LargestSeqNum() uint64 {
 	if len(s.Keys) == 0 {
 		panic("pebble: Span contains no keys")
@@ -140,11 +165,16 @@ func (s *Span) LargestSeqNum() uint64 {
 // that avoid the need to construct a new Span.
 
 // Visible returns a span with the subset of keys visible at the provided
-// sequence number.
+// sequence number. It requires the Span's keys be in ByTrailerDesc order. It
+// panics if the span's keys are sorted in a different order.
 //
 // Visible may incur an allocation, so callers should prefer targeted,
 // non-allocating methods when possible.
 func (s Span) Visible(snapshot uint64) Span {
+	if s.KeysOrder != ByTrailerDesc {
+		panic("pebble: span's keys unexpectedly not in trailer order")
+	}
+
 	ret := Span{Start: s.Start, End: s.End}
 	if len(s.Keys) == 0 {
 		return ret
@@ -214,7 +244,13 @@ func (s Span) Visible(snapshot uint64) Span {
 // VisibleAt returns true if the span contains a key visible at the provided
 // snapshot. Keys with sequence numbers with the batch bit set are treated as
 // always visible.
+//
+// VisibleAt requires the Span's keys be in ByTrailerDesc order. It panics if
+// the span's keys are sorted in a different order.
 func (s *Span) VisibleAt(snapshot uint64) bool {
+	if s.KeysOrder != ByTrailerDesc {
+		panic("pebble: span's keys unexpectedly not in trailer order")
+	}
 	if len(s.Keys) == 0 {
 		return false
 	} else if first := s.Keys[0].SeqNum(); first&base.InternalKeySeqNumBatch != 0 {
@@ -235,9 +271,10 @@ func (s *Span) VisibleAt(snapshot uint64) bool {
 // None of the key byte slices are cloned (see Span.DeepClone).
 func (s *Span) ShallowClone() Span {
 	c := Span{
-		Start: s.Start,
-		End:   s.End,
-		Keys:  make([]Key, len(s.Keys)),
+		Start:     s.Start,
+		End:       s.End,
+		Keys:      make([]Key, len(s.Keys)),
+		KeysOrder: s.KeysOrder,
 	}
 	copy(c.Keys, s.Keys)
 	return c
@@ -248,9 +285,10 @@ func (s *Span) ShallowClone() Span {
 // because it is allocation heavy.
 func (s *Span) DeepClone() Span {
 	c := Span{
-		Start: make([]byte, len(s.Start)),
-		End:   make([]byte, len(s.End)),
-		Keys:  make([]Key, len(s.Keys)),
+		Start:     make([]byte, len(s.Start)),
+		End:       make([]byte, len(s.End)),
+		Keys:      make([]Key, len(s.Keys)),
+		KeysOrder: s.KeysOrder,
 	}
 	copy(c.Start, s.Start)
 	copy(c.End, s.End)
@@ -274,7 +312,13 @@ func (s *Span) Contains(cmp base.Compare, key []byte) bool {
 }
 
 // Covers returns true if the span covers keys at seqNum.
+//
+// Covers requires the Span's keys be in ByTrailerDesc order. It panics if the
+// span's keys are sorted in a different order.
 func (s Span) Covers(seqNum uint64) bool {
+	if s.KeysOrder != ByTrailerDesc {
+		panic("pebble: span's keys unexpectedly not in trailer order")
+	}
 	return !s.Empty() && s.Keys[0].SeqNum() > seqNum
 }
 
@@ -284,7 +328,13 @@ func (s Span) Covers(seqNum uint64) bool {
 //
 // Keys with sequence numbers with the batch bit set are treated as always
 // visible.
+//
+// CoversAt requires the Span's keys be in ByTrailerDesc order. It panics if the
+// span's keys are sorted in a different order.
 func (s *Span) CoversAt(snapshot, seqNum uint64) bool {
+	if s.KeysOrder != ByTrailerDesc {
+		panic("pebble: span's keys unexpectedly not in trailer order")
+	}
 	// NB: A key is visible at `snapshot` if its sequence number is strictly
 	// less than `snapshot`. See base.Visible.
 	for i := range s.Keys {
@@ -336,8 +386,8 @@ func (s prettySpan) Format(fs fmt.State, c rune) {
 	fmt.Fprintf(fs, "}")
 }
 
-// SortKeys sorts a keys slice by trailer.
-func SortKeys(keys *[]Key) {
+// SortKeysByTrailer sorts a keys slice by trailer.
+func SortKeysByTrailer(keys *[]Key) {
 	// NB: keys is a pointer to a slice instead of a slice to avoid `sorted`
 	// escaping to the heap.
 	sorted := (*keysBySeqNumKind)(keys)

--- a/range_keys.go
+++ b/range_keys.go
@@ -54,8 +54,13 @@ func (i *Iterator) constructRangeKeyIter() {
 	// range keys, but range keys are expected to be sparse anyway, reducing the
 	// cost benefit of maintaining a separate L0Sublevels instance for range key
 	// files and then using it here.
+	//
+	// NB: We iterate L0's files in reverse order. They're sorted by
+	// LargestSeqNum ascending, and we need to add them to the merging iterator
+	// in LargestSeqNum descending to preserve the merging iterator's invariants
+	// around Key Trailer order.
 	iter := current.RangeKeyLevels[0].Iter()
-	for f := iter.First(); f != nil; f = iter.Next() {
+	for f := iter.Last(); f != nil; f = iter.Prev() {
 		spanIterOpts := &keyspan.SpanIterOptions{RangeKeyFilters: i.opts.RangeKeyFilters}
 		spanIter, err := i.newIterRangeKey(f, spanIterOpts)
 		if err != nil {

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -1109,7 +1109,7 @@ func (i *fragmentBlockIter) gatherBackward(k *InternalKey, internalValue []byte)
 	// span.
 
 	// Backwards iteration encounters internal keys in the wrong order.
-	keyspan.SortKeys(&i.span.Keys)
+	keyspan.SortKeysByTrailer(&i.span.Keys)
 
 	return &i.span
 }

--- a/table_stats.go
+++ b/table_stats.go
@@ -703,8 +703,18 @@ func newCombinedDeletionKeyspanIter(
 	// iters are only added if the particular key kind is present.
 	mIter := &keyspan.MergingIter{}
 	var transform = keyspan.TransformerFunc(func(cmp base.Compare, in keyspan.Span, out *keyspan.Span) error {
+		if in.KeysOrder != keyspan.ByTrailerDesc {
+			panic("pebble: combined deletion iter encountered keys in non-trailer descending order")
+		}
 		out.Start, out.End = in.Start, in.End
 		out.Keys = append(out.Keys[:0], in.Keys...)
+		out.KeysOrder = keyspan.ByTrailerDesc
+		// NB: The order of by-trailer descending may have been violated,
+		// because we've layered rangekey and rangedel iterators from the same
+		// sstable into the same keyspan.MergingIter. The MergingIter will
+		// return the keys in the order that the child iterators were provided.
+		// Sort the keys to ensure they're sorted by trailer descending.
+		keyspan.SortKeysByTrailer(&out.Keys)
 		return nil
 	})
 	mIter.Init(cmp, transform)


### PR DESCRIPTION
During iteration over range keys, a stack of keyspan.FragmentIterators handle
various parts of range-key iteration: fragmenting, shadowing and defragmenting.
Previously, the keyspan.Span and keyspan.FragmentIterator strictly specified
the order of keys within a Span: always by Trailer, descending.

This created some unfortunate gymnastics during range-key iteration:
- To resolve shadowing (or "coalesce" range keys), the keyspan.Transform
  invoked by the keyspan.MergingIter) would sort the keys by suffix, and
  re-sort by Trailer.
- To determine whether or not two range key spans should be defragmented into a
  single Span, the range-key iterator would copy the keys into a buffer to sort
  by suffix.
- Lastly, when the range keys were surfaced to the *pebble.Iterator, they'd
  once again be sorted by suffix to present to the client.

This commit relaxes the keyspan.Span contract, allowing the Transform that
resolves shadowing to leave range keys in sorted order. This allows the
defragmenting iterator and the pebble.Iterator to avoid any additional sorting.

Benchmark results when rebased over #1824:
```
name                                                           old time/op    new time/op    delta
Iterator_RangeKeyMasking/range-keys-suffixes=@10/forward-10      2.31ms ± 6%    2.20ms ± 6%   -4.89%  (p=0.000 n=20+18)
Iterator_RangeKeyMasking/range-keys-suffixes=@10/backward-10     3.45ms ±14%    3.17ms ± 3%   -8.22%  (p=0.000 n=20+19)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/forward-10      2.20ms ±14%    1.97ms ± 3%  -10.48%  (p=0.000 n=19+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/backward-10     2.83ms ± 4%    2.64ms ± 1%   -6.79%  (p=0.000 n=19+17)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/forward-10       978µs ± 1%     957µs ± 2%   -2.10%  (p=0.000 n=19+18)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/backward-10     1.37ms ± 3%    1.38ms ± 5%     ~     (p=0.134 n=18+19)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/forward-10      151µs ± 1%     150µs ± 1%   -0.78%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/backward-10     304µs ± 1%     311µs ± 1%   +2.31%  (p=0.000 n=20+19)

name                                                           old alloc/op   new alloc/op   delta
Iterator_RangeKeyMasking/range-keys-suffixes=@10/forward-10      2.88kB ± 1%    2.62kB ± 1%   -9.03%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@10/backward-10     4.50kB ± 0%    4.22kB ± 1%   -6.38%  (p=0.000 n=16+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/forward-10      2.89kB ± 0%    2.62kB ± 1%   -9.42%  (p=0.000 n=14+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/backward-10     4.47kB ± 1%    4.22kB ± 1%   -5.74%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/forward-10      2.86kB ± 0%    2.61kB ± 0%   -8.94%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/backward-10     4.45kB ± 0%    4.19kB ± 0%   -5.72%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/forward-10     2.85kB ± 0%    2.59kB ± 0%   -8.98%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/backward-10    4.45kB ± 0%    4.20kB ± 0%   -5.74%  (p=0.000 n=20+20)

name                                                           old allocs/op  new allocs/op  delta
Iterator_RangeKeyMasking/range-keys-suffixes=@10/forward-10        41.0 ± 0%      33.0 ± 0%  -19.51%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@10/backward-10       46.0 ± 0%      38.0 ± 0%  -17.39%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/forward-10        41.0 ± 0%      33.0 ± 0%  -19.51%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/backward-10       46.0 ± 0%      38.0 ± 0%  -17.39%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/forward-10        41.0 ± 0%      33.0 ± 0%  -19.51%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/backward-10       46.0 ± 0%      38.0 ± 0%  -17.39%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/forward-10       41.0 ± 0%      33.0 ± 0%  -19.51%  (p=0.000 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/backward-10      47.0 ± 0%      39.0 ± 0%  -17.02%  (p=0.000 n=20+20)
```