### PR TITLE
compaction: add a couple microoptimizations

### DIFF
--- a/testdata/compaction_iter
+++ b/testdata/compaction_iter
@@ -1163,10 +1163,10 @@ b#1,2:1
 
 # NB: Zero values are skipped by deletable merger.
 define merger=deletable
-a.MERGE.1:1
-a.MERGE.2:2
-a.MERGE.3:-1
 a.MERGE.4:-2
+a.MERGE.3:-1
+a.MERGE.2:2
+a.MERGE.1:1
 b.MERGE.4:-3
 b.MERGE.3:3
 b.MERGE.2:2

--- a/testdata/compaction_read_triggered
+++ b/testdata/compaction_read_triggered
@@ -3,12 +3,12 @@ define
 L5
 a.SET.55:a b.SET.5:b
 L6
-a.SET.55:a b.SET.5:b
+a.SET.54:a b.SET.4:b
 ----
 5:
   000004:[a#55,SET-b#5,SET]
 6:
-  000005:[a#55,SET-b#5,SET]
+  000005:[a#54,SET-b#4,SET]
 
 add-read-compaction
 5: a-b 000004
@@ -42,12 +42,12 @@ define
 L5
 a.SET.55:a b.SET.5:b
 L6
-a.SET.55:a b.SET.5:b
+a.SET.54:a b.SET.4:b
 ----
 5:
   000004:[a#55,SET-b#5,SET]
 6:
-  000005:[a#55,SET-b#5,SET]
+  000005:[a#54,SET-b#4,SET]
 
 add-read-compaction flushing=true
 5: a-b 000004
@@ -70,7 +70,7 @@ version
 5:
   000004:[a#55,SET-b#5,SET]
 6:
-  000005:[a#55,SET-b#5,SET]
+  000005:[a#54,SET-b#4,SET]
 
 add-read-compaction flushing=false
 ----


### PR DESCRIPTION
**compaction: avoid compactionIter key comparison when possible**

The compaction iterator performs a key-equality check in order to determine the
active snapshot stripe. The compaction iterator reads keys in the order defined
over InternalKeys: ascending by user key, followed by descending by trailer.
Identical InternalKeys are prohibited.

This patch introduces an optimization to the compaction iterator that takes
advantage of the sorted nature of incoming keys. If a key has a trailer greater
than or equal to the previous key's trailer, it necessarily must have a new
user key. In this case the compaction iterator skips the key comparison and
begins the new snapshot stripe.

In a database receiving randomly distributed writes, this fast path should
trigger 50% of the time. However, keys at the bottom of the LSM have their
sequence numbers zeroed. This zeroing makes this optimization much more likely
to trigger for compactions into L6.

Informs #1815.

**compaction: avoid unnecessary inuse keyspan comparisons**

Compactions high in the LSM frequently have high overlap with lower-level
sstables. Boundary overlap with files lower in the LSM prohibits the elision of
tombstones, because the compaction does not know whether or not the tombstone
is needed to shadow keys in the overlapping sstables.

Previously, these compactions at higher levels frequently performed 2 key
comparisons per-tombstone in order to determine whether or not the tombstone
may be elided—always determining no. This patch adds an optimization to skip
these key comparions if the entire compaction's key range is in-use in lower
levels.

Informs #1815.

A 30-min 3-node tpcc run showed a 1.58% increase in tpmC, but that could easily be noise. We don't have any good compaction microbenchmarks to get more targeted numbers yet. The inuse-keyspan optimization won't show up in the pebble ycsb benchmarks, because we don't write tombstones in those benchmarks.