### PR TITLE
metamorphic: compare and assert logical DB state across test variants

### DIFF
--- a/internal/metamorphic/generator.go
+++ b/internal/metamorphic/generator.go
@@ -415,6 +415,14 @@ func (g *generator) batchCommit() {
 }
 
 func (g *generator) dbClose() {
+	// Flush memtables. While this is not strictly required in practice (i.e. the
+	// WAL will preserve any un-flushed operations), in the case where a
+	// metamorphic test variant is running _without_ a WAL, un-flushed operations
+	// will not be preserved at the end of the test. Flushing ensures that the
+	// logical state of a DB running without a WAL matches that of a DB running
+	// with a WAL, given the same sequence of operations.
+	g.add(&flushOp{})
+
 	// Close any live iterators and snapshots, so that we can close the DB
 	// cleanly.
 	for len(g.liveIters) > 0 {

--- a/internal/metamorphic/history.go
+++ b/internal/metamorphic/history.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"os"
 	"regexp"
 	"strings"
 	"sync/atomic"
@@ -130,4 +131,10 @@ func readHistory(t *testing.T, historyPath string) []string {
 		newLines = append(newLines, line)
 	}
 	return newLines
+}
+
+func readLogicalState(t *testing.T, path string) []string {
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return difflib.SplitLines(string(data))
 }


### PR DESCRIPTION
Currently, the metamorphic test harness asserts that the result of each
individual operation applied to each DB variant matches. However, the
harness does not currently assert that the logical state (i.e. live KV
pairs) of a DB matches across variants.

Enhance the test harness by re-opening the DB in read-only mode at the
end of each test variant and iterating over all records that are visible
in the DB. The visible KV pairs are printed to a log file for each
variant. Each variant's log file is then compared to the base case's log
file. Any difference in logical state of the DB results in a test
failure and prints the resultant diff of operations, for debugging.

This patch required a small change to the way the final generated
`dbClose` operation works. This operation now flushes any memtables
before calling `(*DB).Close()`. This ensures that variants running
_without_ a WAL have the same logical state at the end of a test as a
those running _with_ a WAL.