### PR TITLE
sstable: disallow identical point keys

### DIFF
--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1500,7 +1500,7 @@ func TestIngestValidation(t *testing.T) {
 	)
 	const (
 		nKeys     = 1_000
-		keySize   = 10
+		keySize   = 16
 		valSize   = 100
 		blockSize = 100
 
@@ -1651,11 +1651,11 @@ func TestIngestValidation(t *testing.T) {
 			// Construct a set of keys to ingest.
 			var keyVals []keyVal
 			for i := 0; i < nKeys; i++ {
-				key := make([]byte, 0, keySize)
+				key := make([]byte, keySize)
 				_, err = rng.Read(key)
 				require.NoError(t, err)
 
-				val := make([]byte, 0, valSize)
+				val := make([]byte, valSize)
 				_, err = rng.Read(val)
 				require.NoError(t, err)
 

--- a/sstable/testdata/writer
+++ b/sstable/testdata/writer
@@ -119,13 +119,13 @@ build
 a.SET.1:b
 a.SET.2:c
 ----
-pebble: keys must be added in order: a#1,SET, a#2,SET
+pebble: keys must be added in strictly increasing order: a#1,SET, a#2,SET
 
 build
 b.SET.1:a
 a.SET.2:b
 ----
-pebble: keys must be added in order: b#1,SET, a#2,SET
+pebble: keys must be added in strictly increasing order: b#1,SET, a#2,SET
 
 build
 b.RANGEDEL.1:c
@@ -143,7 +143,7 @@ build-raw
 a.RANGEDEL.1:c
 a.RANGEDEL.2:c
 ----
-pebble: keys must be added in order: a#1,RANGEDEL, a#2,RANGEDEL
+pebble: keys must be added in strictly increasing order: a#1,RANGEDEL, a#2,RANGEDEL
 
 build-raw
 a.RANGEDEL.1:c


### PR DESCRIPTION
Previously, the sstable's key-order checks allowed an InternalKey to be
added to an sstable twice. Among keys with with equal user keys, each
key must have a unique Trailer in be added in Trailer decreasing order.

Noticed in cockroachdb/cockroach#85468, which uncovered a unit test
that improperly added an identical key to an external sstable intended
for ingestion. 