### PR TITLE
internal/keyspan: avoid unnecessarily re-seeking keyspan iter

### DIFF
--- a/iterator_test.go
+++ b/iterator_test.go
@@ -2299,44 +2299,52 @@ func BenchmarkIteratorScan(b *testing.B) {
 	}
 }
 
-func BenchmarkIteratorSeekNoRangeKeys(b *testing.B) {
-	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
-	ks := testkeys.Alpha(1)
-	opts := &Options{
-		FS:                 vfs.NewMem(),
-		FormatMajorVersion: FormatNewest,
-	}
-	d, err := Open("", opts)
-	require.NoError(b, err)
-	defer func() { require.NoError(b, d.Close()) }()
+func BenchmarkCombinedIteratorSeek(b *testing.B) {
+	for _, withRangeKey := range []bool{false, true} {
+		b.Run(fmt.Sprintf("range-key=%t", withRangeKey), func(b *testing.B) {
+			rng := rand.New(rand.NewSource(uint64(1658872515083979000)))
+			ks := testkeys.Alpha(1)
+			opts := &Options{
+				FS:                 vfs.NewMem(),
+				Comparer:           testkeys.Comparer,
+				FormatMajorVersion: FormatNewest,
+			}
+			d, err := Open("", opts)
+			require.NoError(b, err)
+			defer func() { require.NoError(b, d.Close()) }()
 
-	keys := make([][]byte, ks.Count())
-	for i := 0; i < ks.Count(); i++ {
-		keys[i] = testkeys.Key(ks, i)
-		var val [40]byte
-		rng.Read(val[:])
-		require.NoError(b, d.Set(keys[i], val[:], nil))
-	}
+			keys := make([][]byte, ks.Count())
+			for i := 0; i < ks.Count(); i++ {
+				keys[i] = testkeys.Key(ks, i)
+				var val [40]byte
+				rng.Read(val[:])
+				require.NoError(b, d.Set(keys[i], val[:], nil))
+			}
+			if withRangeKey {
+				require.NoError(b, d.RangeKeySet([]byte("a"), []byte{'z', 0x00}, []byte("@5"), nil, nil))
+			}
 
-	batch := d.NewIndexedBatch()
-	defer batch.Close()
+			batch := d.NewIndexedBatch()
+			defer batch.Close()
 
-	for _, useBatch := range []bool{false, true} {
-		b.Run(fmt.Sprintf("batch=%t", useBatch), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				iterOpts := IterOptions{KeyTypes: IterKeyTypePointsAndRanges}
-				var it *Iterator
-				if useBatch {
-					it = batch.NewIter(&iterOpts)
-				} else {
-					it = d.NewIter(&iterOpts)
-				}
-				for j := 0; j < len(keys); j++ {
-					if !it.SeekGE(keys[j]) {
-						b.Errorf("key %q missing", keys[j])
+			for _, useBatch := range []bool{false, true} {
+				b.Run(fmt.Sprintf("batch=%t", useBatch), func(b *testing.B) {
+					for i := 0; i < b.N; i++ {
+						iterOpts := IterOptions{KeyTypes: IterKeyTypePointsAndRanges}
+						var it *Iterator
+						if useBatch {
+							it = batch.NewIter(&iterOpts)
+						} else {
+							it = d.NewIter(&iterOpts)
+						}
+						for j := 0; j < len(keys); j++ {
+							if !it.SeekGE(keys[j]) {
+								b.Errorf("key %q missing", keys[j])
+							}
+						}
+						require.NoError(b, it.Close())
 					}
-				}
-				require.NoError(b, it.Close())
+				})
 			}
 		})
 	}


### PR DESCRIPTION
Avoid unnecessarily seeking the keyspan iterator in the InterleavingIter
when performing a seek on an already-positioned iterator with a current
span that encompasses the seek key.

```
name                                                 old time/op  new time/op  delta
CombinedIteratorSeek/range-key=false/batch=false-16  4.10µs ± 6%  3.81µs ± 2%   -6.94%  (p=0.000 n=10+10)
CombinedIteratorSeek/range-key=false/batch=true-16   6.72µs ± 4%  6.70µs ± 2%     ~     (p=0.796 n=9+9)
CombinedIteratorSeek/range-key=true/batch=false-16   29.7µs ± 6%   9.1µs ± 3%  -69.28%  (p=0.000 n=10+10)
CombinedIteratorSeek/range-key=true/batch=true-16    31.7µs ± 7%  12.2µs ± 1%  -61.57%  (p=0.000 n=10+9)
```

The benefit for CombinedIteratorSeek/range-key=false is noise: the
interleaving iterator is never invoked in that subbenchmark. We should
expect that there's noise in the other benchmarks as well, but the
benefits are large enough that there's a definite benefit.

Informs #1841.