### PR TITLE
ci: test against go1.19

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,9 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - "1.16"
           - "1.17"
           - "1.18"
+          - "1.19"
     steps:
     - uses: actions/checkout@v2
 
@@ -41,7 +41,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: "1.17"
+        go-version: "1.18"
 
     - run: make crossversion-meta
 
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: "1.17"
+        go-version: "1.18"
 
     - run: make testrace TAGS=
 
@@ -67,7 +67,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: "1.17"
+        go-version: "1.18"
 
     - run: make test TAGS=
 
@@ -80,7 +80,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: "1.17"
+        go-version: "1.18"
 
     - run: CGO_ENABLED=0 make test TAGS=
 
@@ -93,7 +93,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: "1.17"
+        go-version: "1.18"
 
     - run: make test
 
@@ -106,7 +106,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: "1.17"
+        go-version: "1.18"
 
     - run: go test -v ./...
 
@@ -119,7 +119,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: "1.17"
+        go-version: "1.18"
 
     - name: FreeBSD build
       env:
@@ -135,7 +135,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: "1.17"
+        go-version: "1.18"
 
     - name: mod-tidy-check
       run: make mod-tidy-check


### PR DESCRIPTION
Add Go version 1.19 to the test matrix.

Bump the Go version used to for the specific test runs (race, cgo,
crossversion) use Go 1.18.