### PR TITLE
internal/keyspan: fix interleaving SeekGE optimization

### DIFF
--- a/internal/keyspan/interleaving_iter.go
+++ b/internal/keyspan/interleaving_iter.go
@@ -245,12 +245,7 @@ func (i *InterleavingIter) SeekGE(key []byte, flags base.SeekGEFlags) (*base.Int
 	// We need to seek the keyspan iterator too. If the keyspan iterator was
 	// already positioned at a span, we might be able to avoid the seek if the
 	// seek key falls within the existing span's bounds.
-	//
-	// If flags.TrySeekUsingNext()=true, it's externally known that we're
-	// seeking to a later key, so the start bound must be ≤ key. If possible, we
-	// use that fact to avoid the start-key comparison.
-	if i.span != nil && i.cmp(key, i.span.End) < 0 &&
-		(flags.TrySeekUsingNext() || i.cmp(key, i.span.Start) >= 0) {
+	if i.span != nil && i.cmp(key, i.span.End) < 0 && i.cmp(key, i.span.Start) >= 0 {
 		// We're seeking within the existing span's bounds. We still might need
 		// truncate the span to the iterator's bounds.
 		i.checkForwardBound()
@@ -283,12 +278,7 @@ func (i *InterleavingIter) SeekPrefixGE(
 	// We need to seek the keyspan iterator too. If the keyspan iterator was
 	// already positioned at a span, we might be able to avoid the seek if the
 	// seek key falls within the existing span's bounds.
-	//
-	// If flags.TrySeekUsingNext()=true, it's externally known that we're
-	// seeking to a later key, so the start bound must be ≤ key. If possible, we
-	// use that fact to avoid the start-key comparison.
-	if i.span != nil && i.cmp(key, i.span.End) < 0 &&
-		(flags.TrySeekUsingNext() || i.cmp(key, i.span.Start) >= 0) {
+	if i.span != nil && i.cmp(key, i.span.End) < 0 && i.cmp(key, i.span.Start) >= 0 {
 		// We're seeking within the existing span's bounds. We still might need
 		// truncate the span to the iterator's bounds.
 		i.checkForwardBound()

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -1029,3 +1029,22 @@ a: (., [a-z) @5=boop)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
 (internal-stats: (block-bytes: (total 75 B, cached 75 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+
+# Test repeated seeks into the same range key, while TrySeekUsingNext=true.
+# Test for regression fixed in #1849.
+
+reset
+----
+
+batch
+range-key-set a c @5 boop
+range-key-set c e @5 beep
+----
+wrote 2 keys
+
+combined-iter
+seek-ge a
+seek-ge b
+----
+a: (., [a-c) @5=boop)
+b: (., [a-c) @5=boop)


### PR DESCRIPTION
The interleaving iterator SeekGE optimization added in 04f9100 attempted to use
trySeekUsingNext=true to avoid a key comparison, but it was based on faulty
logic. The span previously stored in i.span might not be the one previously
returned to the user if the *pebble.Iterator had to step the interleaving
iterator to check for a coincident point key.

Fixes #1850.