### PR TITLE
db: add Iterator.RangeKeyChanged

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -318,6 +318,9 @@ func printIterState(
 			} else {
 				fmt.Fprint(b, ".")
 			}
+			if iter.RangeKeyChanged() {
+				fmt.Fprint(b, " UPDATED")
+			}
 			fmt.Fprint(b, ")")
 		case iter.opts.rangeKeys():
 			if iter.Valid() {
@@ -330,6 +333,9 @@ func printIterState(
 				writeRangeKeys(b, iter)
 			} else {
 				fmt.Fprint(b, ".")
+			}
+			if iter.RangeKeyChanged() {
+				fmt.Fprint(b, " UPDATED")
 			}
 		default:
 			fmt.Fprintf(b, "%s:%s%s", iter.Key(), iter.Value(), validityStateStr)

--- a/db.go
+++ b/db.go
@@ -959,7 +959,7 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 	}
 
 	if dbi.opts.rangeKeys() {
-		dbi.rangeKeyMasking.init(dbi.cmp, dbi.split, &dbi.opts)
+		dbi.rangeKeyMasking.init(dbi, dbi.cmp, dbi.split)
 
 		// When iterating over both point and range keys, don't create the
 		// range-key iterator stack immediately if we can avoid it. This
@@ -1011,8 +1011,8 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 			// NB: The interleaving iterator is always reinitialized, even if
 			// dbi already had an initialized range key iterator, in case the point
 			// iterator changed or the range key masking suffix changed.
-			dbi.rangeKey.iiter.Init(dbi.cmp, dbi.iter, dbi.rangeKey.rangeKeyIter, &dbi.rangeKeyMasking,
-				dbi.opts.LowerBound, dbi.opts.UpperBound)
+			dbi.rangeKey.iiter.Init(dbi.cmp, dbi.iter, dbi.rangeKey.rangeKeyIter,
+				&dbi.rangeKeyMasking, dbi.opts.LowerBound, dbi.opts.UpperBound)
 			dbi.iter = &dbi.rangeKey.iiter
 		}
 	} else {

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -143,7 +143,7 @@ func finishInitializingExternal(it *Iterator) {
 	it.iter = it.pointIter
 
 	if it.opts.rangeKeys() {
-		it.rangeKeyMasking.init(it.cmp, it.split, &it.opts)
+		it.rangeKeyMasking.init(it, it.cmp, it.split)
 		if it.rangeKey == nil {
 			it.rangeKey = iterRangeKeyStateAllocPool.Get().(*iteratorRangeKeyState)
 			it.rangeKey.init(it.cmp, it.split, &it.opts)

--- a/internal/keyspan/interleaving_iter_test.go
+++ b/internal/keyspan/interleaving_iter_test.go
@@ -84,11 +84,13 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 			fmt.Fprint(&buf, ".")
 			return
 		}
-		var s Span
-		if s2 := iter.Span(); s2 != nil {
-			s = *s2
+		s := iter.Span()
+		fmt.Fprintf(&buf, "PointKey: %s\n", k.String())
+		if s != nil {
+			fmt.Fprintf(&buf, "Span: %s\n-", s)
+		} else {
+			fmt.Fprintf(&buf, "Span: %s\n-", Span{})
 		}
-		fmt.Fprintf(&buf, "PointKey: %s\nSpan: %s\n-", k.String(), s)
 	}
 
 	datadriven.RunTest(t, filename, func(td *datadriven.TestData) string {

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -774,6 +774,9 @@ func iteratorPos(i *retryableIter) string {
 	} else {
 		fmt.Fprint(&buf, ",<no range>")
 	}
+	if i.RangeKeyChanged() {
+		fmt.Fprint(&buf, "*")
+	}
 	return buf.String()
 }
 

--- a/internal/metamorphic/retryable.go
+++ b/internal/metamorphic/retryable.go
@@ -96,6 +96,17 @@ func (i *retryableIter) Key() []byte {
 	return i.iter.Key()
 }
 
+func (i *retryableIter) RangeKeyChanged() bool {
+	// A single operation on the retryableIter may result in many operations on
+	// i.iter if we need to skip filtered keys. To provide determinism, we
+	// return RangeKeyChanged()=false for all iterators configured with filters.
+	//
+	// TODO(jackson): We should be able to provide more test coverage here by
+	// returning true if i.iter.RangeKeyChanged()=true after any of the
+	// individual repositioning methods.
+	return i.filterMax == 0 && i.iter.RangeKeyChanged()
+}
+
 func (i *retryableIter) HasPointAndRange() (bool, bool) {
 	return i.iter.HasPointAndRange()
 }

--- a/testdata/external_iterator
+++ b/testdata/external_iterator
@@ -56,10 +56,10 @@ next
 next
 next
 ----
-a: (a, [a-b) @2=foo)
-b: (b, .)
-d: (., [d-e) @3=bar)
-f: (f, .)
+a: (a, [a-b) @2=foo UPDATED)
+b: (b, . UPDATED)
+d: (., [d-e) @3=bar UPDATED)
+f: (f, . UPDATED)
 .
 
 # Test including range keys with empty spans and a merge in between. At no point
@@ -78,7 +78,7 @@ next
 bb: (ac, .)
 b: (b, .)
 bb: (ac, .)
-d: (., [d-e) @3=bar)
+d: (., [d-e) @3=bar UPDATED)
 
 iter files=(6, 5, 4, 3, 2, 1)
 seek-ge b
@@ -92,10 +92,10 @@ next
 b: (b, .)
 bb: (ac, .)
 b: (b, .)
-a: (a, [a-b) @2=foo)
-b: (b, .)
+a: (a, [a-b) @2=foo UPDATED)
+b: (b, . UPDATED)
 bb: (ac, .)
-d: (., [d-e) @3=bar)
+d: (., [d-e) @3=bar UPDATED)
 
 # Test range keys that overlap each other with identical state. These
 # should be defragmented and exposed as a single range key.
@@ -115,7 +115,7 @@ iter files=(ag, ek)
 first
 next
 ----
-a: (., [a-k) @5=foo)
+a: (., [a-k) @5=foo UPDATED)
 .
 
 # Test range-key masking by creating points, some with suffixes above
@@ -139,10 +139,10 @@ next
 next
 next
 ----
-a: (., [a-k) @5=foo)
+a: (., [a-k) @5=foo UPDATED)
 d@9: (v, [a-k) @5=foo)
 e@5: (v, [a-k) @5=foo)
-k@3: (v, .)
+k@3: (v, . UPDATED)
 p@4: (v, .)
 .
 
@@ -158,7 +158,7 @@ iter files=(points, ag, ek, stacked)
 first
 next
 ----
-a: (., [a-k) @5=foo, @4=bar, @1=bax)
+a: (., [a-k) @5=foo, @4=bar, @1=bax UPDATED)
 a@4: (v, [a-k) @5=foo, @4=bar, @1=bax)
 
 # Test mutating the external iterator's options through SetOptions.

--- a/testdata/indexed_batch_mutation
+++ b/testdata/indexed_batch_mutation
@@ -97,7 +97,7 @@ next
 next
 ----
 .
-a: (., [a-c) @1=boop)
+a: (., [a-c) @1=boop UPDATED)
 b: (b, [a-c) @1=boop)
 bar: (bar, [a-c) @1=boop)
 
@@ -115,7 +115,7 @@ prev
 prev
 ----
 .
-bar: (bar, [a-c) @1=boop)
+bar: (bar, [a-c) @1=boop UPDATED)
 b: (b, [a-c) @1=boop)
 a: (., [a-c) @1=boop)
 .
@@ -128,8 +128,8 @@ next
 next
 ----
 .
-a: (., [a-ace) @1=boop)
-arc: (., [arc-c) @1=boop)
+a: (., [a-ace) @1=boop UPDATED)
+arc: (., [arc-c) @1=boop UPDATED)
 b: (b, [arc-c) @1=boop)
 bar: (bar, [arc-c) @1=boop)
 
@@ -193,7 +193,7 @@ next
 foo: (foo, .)
 .
 .
-a: (., [a-z) @1=boop)
+a: (., [a-z) @1=boop UPDATED)
 bar: (bar, [a-z) @1=boop)
 .
 
@@ -206,7 +206,7 @@ iter iter=i3
 first
 next
 ----
-a: (., [a-z) @1=boop)
+a: (., [a-z) @1=boop UPDATED)
 bar: (bar, [a-z) @1=boop)
 
 # i1 should still have the old, stale view of the batch.
@@ -239,7 +239,7 @@ next
 foo: (foo, .)
 .
 .
-a: (., [a-z) @2=bax, @1=boop)
+a: (., [a-z) @2=bax, @1=boop UPDATED)
 foo: (foo, [a-z) @2=bax, @1=boop)
 .
 
@@ -252,11 +252,11 @@ first
 next
 next
 ----
-a: (., [a-z) @1=boop)
+a: (., [a-z) @1=boop UPDATED)
 bar: (bar, [a-z) @1=boop)
 .
 .
-a: (., [a-z) @2=bax, @1=boop)
+a: (., [a-z) @2=bax, @1=boop UPDATED)
 foo: (foo, [a-z) @2=bax, @1=boop)
 .
 
@@ -273,7 +273,7 @@ first
 next
 next
 ----
-a: (., [a-z) @2=bax, @1=boop)
+a: (., [a-z) @2=bax, @1=boop UPDATED)
 foo: (foo, [a-z) @2=bax, @1=boop)
 .
 
@@ -287,7 +287,7 @@ first
 next
 next
 ----
-a: (., [a-z) @2=bax, @1=boop)
+a: (., [a-z) @2=bax, @1=boop UPDATED)
 foo: (foo, [a-z) @2=bax, @1=boop)
 .
 
@@ -301,7 +301,7 @@ next
 next
 ----
 .
-a: (., [a-z) @2=bax, @1=boop)
+a: (., [a-z) @2=bax, @1=boop UPDATED)
 foo: (foo, [a-z) @2=bax, @1=boop)
 .
 
@@ -317,7 +317,7 @@ next
 next
 next
 ----
-a: (., [a-z) @5=poi, @2=bax, @1=boop)
+a: (., [a-z) @5=poi, @2=bax, @1=boop UPDATED)
 apple: (apple, [a-z) @5=poi, @2=bax, @1=boop)
 foo: (foo, [a-z) @5=poi, @2=bax, @1=boop)
 .
@@ -337,7 +337,7 @@ first
 next
 next
 ----
-a: (., [a-z) @2=bax, @1=boop)
+a: (., [a-z) @2=bax, @1=boop UPDATED)
 foo: (foo, [a-z) @2=bax, @1=boop)
 .
 
@@ -350,11 +350,11 @@ first
 next
 next
 ----
-a: (., [a-z) @2=bax, @1=boop)
+a: (., [a-z) @2=bax, @1=boop UPDATED)
 foo: (foo, [a-z) @2=bax, @1=boop)
 .
 .
-a: (., [a-z) @6=yaya, @2=bax, @1=boop)
+a: (., [a-z) @6=yaya, @2=bax, @1=boop UPDATED)
 c: (c, [a-z) @6=yaya, @2=bax, @1=boop)
 foo: (foo, [a-z) @6=yaya, @2=bax, @1=boop)
 
@@ -399,7 +399,7 @@ iter iter=i2
 first
 next
 ----
-a: (., [a-z) @1=foo)
+a: (., [a-z) @1=foo UPDATED)
 .
 
 # Clone the original iterator from before the delete range and the range key
@@ -435,9 +435,9 @@ first
 next
 next
 ----
-a: (., [a-b) @1=poi)
-b: (., [b-c) @2=yaya, @1=poi)
-c: (., [c-d) @2=yaya)
+a: (., [a-b) @1=poi UPDATED)
+b: (., [b-c) @2=yaya, @1=poi UPDATED)
+c: (., [c-d) @2=yaya UPDATED)
 
 # Add a new range key to the batch. The batch contains 3 internal range keys,
 # and the skiplist of fragmented range keys contains 3 elements.
@@ -462,15 +462,15 @@ next
 next
 seek-ge bat
 ----
-a: (., [a-b) @1=poi)
-b: (., [b-c) @2=yaya, @1=poi)
-c: (., [c-d) @2=yaya)
+a: (., [a-b) @1=poi UPDATED)
+b: (., [b-c) @2=yaya, @1=poi UPDATED)
+c: (., [c-d) @2=yaya UPDATED)
 .
-a: (., [a-b) @1=poi)
-b: (., [b-c) @2=yaya, @1=poi)
-c: (., [c-d) @2=yaya)
-e: (., [e-f) @3=foo)
-bat: (., [b-c) @2=yaya, @1=poi)
+a: (., [a-b) @1=poi UPDATED)
+b: (., [b-c) @2=yaya, @1=poi UPDATED)
+c: (., [c-d) @2=yaya UPDATED)
+e: (., [e-f) @3=foo UPDATED)
+bat: (., [b-c) @2=yaya, @1=poi UPDATED)
 
 # Mutate the range key under the interleaving iterator's current position in the
 # indexed batch.
@@ -501,4 +501,4 @@ set-options
 seek-ge cat
 ----
 .
-e: (., [e-f) @3=foo)
+e: (., [e-f) @3=foo UPDATED)

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -25,9 +25,9 @@ next
 next
 ----
 a: (a, .)
-b: (b, [b-c) @5=boop)
-c: (c, .)
-cat: (., [cat-dog) @3=beep)
+b: (b, [b-c) @5=boop UPDATED)
+c: (c, . UPDATED)
+cat: (., [cat-dog) @3=beep UPDATED)
 d: (d, [cat-dog) @3=beep)
 .
 
@@ -44,9 +44,9 @@ next
 next
 ----
 a: (a, .)
-b: (b, [b-c) @5=boop)
-c: (c, .)
-cat: (., [cat-dog) @3=beep)
+b: (b, [b-c) @5=boop UPDATED)
+c: (c, . UPDATED)
+cat: (., [cat-dog) @3=beep UPDATED)
 d: (d, [cat-dog) @3=beep)
 .
 
@@ -60,11 +60,11 @@ prev
 prev
 prev
 ----
-d: (d, [cat-dog) @3=beep)
+d: (d, [cat-dog) @3=beep UPDATED)
 cat: (., [cat-dog) @3=beep)
-c: (c, .)
-b: (b, [b-c) @5=boop)
-a: (a, .)
+c: (c, . UPDATED)
+b: (b, [b-c) @5=boop UPDATED)
+a: (a, . UPDATED)
 .
 
 combined-iter
@@ -77,10 +77,10 @@ seek-ge d
 seek-ge day
 seek-ge dog
 ----
+b: (b, [b-c) @5=boop UPDATED)
 b: (b, [b-c) @5=boop)
-b: (b, [b-c) @5=boop)
-c: (c, .)
-cat: (., [cat-dog) @3=beep)
+c: (c, . UPDATED)
+cat: (., [cat-dog) @3=beep UPDATED)
 cat: (., [cat-dog) @3=beep)
 d: (d, [cat-dog) @3=beep)
 day: (., [cat-dog) @3=beep)
@@ -101,10 +101,10 @@ seek-lt zebra
 .
 a: (a, .)
 a: (a, .)
-b: (b, [b-c) @5=boop)
+b: (b, [b-c) @5=boop UPDATED)
+c: (c, . UPDATED)
 c: (c, .)
-c: (c, .)
-cat: (., [cat-dog) @3=beep)
+cat: (., [cat-dog) @3=beep UPDATED)
 d: (d, [cat-dog) @3=beep)
 d: (d, [cat-dog) @3=beep)
 d: (d, [cat-dog) @3=beep)
@@ -118,18 +118,18 @@ first
 next
 next
 ----
-b [b-c) @5=boop
-cat [cat-dog) @3=beep
+b [b-c) @5=boop UPDATED
+cat [cat-dog) @3=beep UPDATED
 .
 .
-bat [bat-c) @5=boop
-cat [cat-catatonic) @3=beep
+bat [bat-c) @5=boop UPDATED
+cat [cat-catatonic) @3=beep UPDATED
 .
 
 rangekey-iter
 seek-ge bat
 ----
-bat [b-c) @5=boop
+bat [b-c) @5=boop UPDATED
 
 # Delete 'b': The Iterator should still stop at b because of the range key
 # with a start boundary at b.
@@ -143,14 +143,14 @@ combined-iter
 seek-ge b
 seek-ge ace
 ----
-b: (., [b-c) @5=boop)
+b: (., [b-c) @5=boop UPDATED)
 b: (., [b-c) @5=boop)
 
 rangekey-iter
 seek-ge b
 seek-ge ace
 ----
-b [b-c) @5=boop
+b [b-c) @5=boop UPDATED
 b [b-c) @5=boop
 
 # Delete the b-c range key and the beginning of the cat-dog range key,
@@ -169,7 +169,7 @@ seek-ge b
 next
 ----
 c: (c, .)
-d: (d, [d-dog) @3=beep)
+d: (d, [d-dog) @3=beep UPDATED)
 
 commit-batch
 ----
@@ -183,7 +183,7 @@ seek-ge b
 next
 ----
 c: (c, .)
-d: (d, [d-dog) @3=beep)
+d: (d, [d-dog) @3=beep UPDATED)
 
 # Reading through the database after flushing, we should still see the
 # beginning of the cat-dog range key now beginning at 'd'.
@@ -196,7 +196,7 @@ seek-ge b
 next
 ----
 c: (c, .)
-d: (d, [d-dog) @3=beep)
+d: (d, [d-dog) @3=beep UPDATED)
 
 reset
 ----
@@ -223,8 +223,8 @@ prev
 prev
 prev
 ----
-c: (c2, [c-d) @1=boop)
-b: (b2, [ace-c) @3=beep)
+c: (c2, [c-d) @1=boop UPDATED)
+b: (b2, [ace-c) @3=beep UPDATED)
 ace: (., [ace-c) @3=beep)
 .
 
@@ -237,16 +237,16 @@ next
 next
 next
 ----
-ace: (., [ace-c) @3=beep)
+ace: (., [ace-c) @3=beep UPDATED)
 b: (b2, [ace-c) @3=beep)
-c: (c2, [c-d) @1=boop)
+c: (c2, [c-d) @1=boop UPDATED)
 .
 
 combined-iter
 seek-prefix-ge b
 next
 ----
-b: (b2, [ace-c) @3=beep)
+b: (b2, [ace-c) @3=beep UPDATED)
 .
 
 reset
@@ -270,7 +270,7 @@ next
 next
 next
 ----
-a: (., [a-d) @8=boop)
+a: (., [a-d) @8=boop UPDATED)
 a@10: (a@10, [a-d) @8=boop)
 a@9: (a@9, [a-d) @8=boop)
 a@3: (a#3, [a-d) @8=boop)
@@ -287,7 +287,7 @@ next
 next
 next
 ----
-a: (., [a-d) @8=boop)
+a: (., [a-d) @8=boop UPDATED)
 a@10: (a@10, [a-d) @8=boop)
 a@9: (a@9, [a-d) @8=boop)
 .
@@ -310,14 +310,14 @@ next
 next
 next
 ----
-a: (., [a-d) @8=boop)
+a: (., [a-d) @8=boop UPDATED)
 a@10: (a@10, [a-d) @8=boop)
 a@9: (a@9, [a-d) @8=boop)
 a@3: (a#3, [a-d) @8=boop)
 a@2: (a@2, [a-d) @8=boop)
 .
 .
-a: (., [a-d) @8=boop)
+a: (., [a-d) @8=boop UPDATED)
 a@10: (a@10, [a-d) @8=boop)
 a@9: (a@9, [a-d) @8=boop)
 .
@@ -356,12 +356,12 @@ next
 az@100: (az@100, .)
 az@10: (az@10, .)
 az@1: (az@1, .)
-b: (., [b-c) @5=beep)
+b: (., [b-c) @5=beep UPDATED)
 b@100: (b@100, [b-c) @5=beep)
 b@10: (b@10, [b-c) @5=beep)
 bz@10: (bz@10, [b-c) @5=beep)
 bz@1: (bz@1, [b-c) @5=beep)
-c@100: (c@100, .)
+c@100: (c@100, . UPDATED)
 
 # Perform the same iteration with all range keys serving as masks. The bz@1
 # point key should be elided.
@@ -380,11 +380,11 @@ next
 az@100: (az@100, .)
 az@10: (az@10, .)
 az@1: (az@1, .)
-b: (., [b-c) @5=beep)
+b: (., [b-c) @5=beep UPDATED)
 b@100: (b@100, [b-c) @5=beep)
 b@10: (b@10, [b-c) @5=beep)
 bz@10: (bz@10, [b-c) @5=beep)
-c@100: (c@100, .)
+c@100: (c@100, . UPDATED)
 c@10: (c@10, .)
 
 # Ensure that a cloned iterator includes range keys.
@@ -394,9 +394,9 @@ seek-ge bz@10
 clone
 seek-ge bz@10
 ----
-bz@10: (bz@10, [b-c) @5=beep)
+bz@10: (bz@10, [b-c) @5=beep UPDATED)
 .
-bz@10: (bz@10, [b-c) @5=beep)
+bz@10: (bz@10, [b-c) @5=beep UPDATED)
 
 # Within a batch, later writes overwrite earlier writes. Here, the range-key-del
 # of [bat, bus) overwrites the earlier writes of [b,c) and [b,e).
@@ -428,7 +428,7 @@ seek-prefix-ge ca
 next
 seek-prefix-ge ca@100
 ----
-ca: (., [c-e) @1000=boop, @1=bop)
+ca: (., [c-e) @1000=boop, @1=bop UPDATED)
 ca@100: (ca@100, [c-e) @1000=boop, @1=bop)
 ca@100: (ca@100, [c-e) @1000=boop, @1=bop)
 
@@ -441,9 +441,9 @@ seek-prefix-ge ca
 next
 seek-prefix-ge ca@100
 ----
-ca: (., [c-e) @1000=boop, @1=bop)
+ca: (., [c-e) @1000=boop, @1=bop UPDATED)
 .
-ca@100: (., [c-e) @1000=boop, @1=bop)
+ca@100: (., [c-e) @1000=boop, @1=bop UPDATED)
 
 # Test masked, non-prefixed iteration. We should see the range keys, but all the
 # points should be masked except those beginning with z which were excluded by
@@ -457,9 +457,9 @@ next
 next
 next
 ----
-ca: (., [c-e) @1000=boop, @1=bop)
-e: (., [e-z) @1000=boop)
-z@100: (z@100, .)
+ca: (., [c-e) @1000=boop, @1=bop UPDATED)
+e: (., [e-z) @1000=boop UPDATED)
+z@100: (z@100, . UPDATED)
 z@10: (z@10, .)
 z@1: (z@1, .)
 za@100: (za@100, .)
@@ -477,9 +477,9 @@ last
 next
 prev
 ----
-x: (., [x-z) @5=boop)
+x: (., [x-z) @5=boop UPDATED)
 .
-x: (., [x-z) @5=boop)
+x: (., [x-z) @5=boop UPDATED)
 
 # Test limited reverse iteration. The seek-lt-limit z y must see the [x-z) range
 # key because it covers a key within the range [y, z). The range key start
@@ -490,9 +490,9 @@ seek-lt-limit z y
 next
 prev-limit y
 ----
-x: valid (., [x-z) @5=boop)
+x: valid (., [x-z) @5=boop UPDATED)
 .
-x: valid (., [x-z) @5=boop)
+x: valid (., [x-z) @5=boop UPDATED)
 
 # Test limited forward iteration. Since range keys are interleaved at the start
 # boundaries, the iterator is guaranteed to encounter covering range keys
@@ -503,9 +503,9 @@ seek-ge-limit w y
 prev
 next-limit y
 ----
-x: valid (., [x-z) @5=boop)
+x: valid (., [x-z) @5=boop UPDATED)
 .
-x: valid (., [x-z) @5=boop)
+x: valid (., [x-z) @5=boop UPDATED)
 
 # Test another limited backward iteration case where there exists a deleted
 # point key and the underlying internalIterator is Prev'd to a key beyond the
@@ -521,9 +521,9 @@ seek-lt-limit z y
 next
 prev-limit y
 ----
-x: valid (., [x-z) @5=boop)
+x: valid (., [x-z) @5=boop UPDATED)
 .
-x: valid (., [x-z) @5=boop)
+x: valid (., [x-z) @5=boop UPDATED)
 
 # Applying range keys to a DB running with a version that doesn't support them
 # results in an error. Range keys were added in version 7.
@@ -578,15 +578,15 @@ next
 next
 next
 ----
-b: (b, [b-c) @5=bar)
-c: (c, .)
-cat: (., [cat-e) @3=bax)
+b: (b, [b-c) @5=bar UPDATED)
+c: (c, . UPDATED)
+cat: (., [cat-e) @3=bax UPDATED)
 d: (d, [cat-e) @3=bax)
 .
 .
-b: (b, [b-c) @5=bar)
-c: (c, .)
-cat: (., [cat-e) @3=bax)
+b: (b, [b-c) @5=bar UPDATED)
+c: (c, . UPDATED)
+cat: (., [cat-e) @3=bax UPDATED)
 d: (d, [cat-e) @3=bax)
 .
 
@@ -609,16 +609,16 @@ next
 next
 next
 ----
-b: (b, [b-c) @5=bar)
-c: (c, .)
-cat: (., [cat-e) @3=bax)
+b: (b, [b-c) @5=bar UPDATED)
+c: (c, . UPDATED)
+cat: (., [cat-e) @3=bax UPDATED)
 d: (d, [cat-e) @3=bax)
 .
 .
-a: (a, [a-ap) @6=foo)
-ap: (., [ap-c) @5=bar)
+a: (a, [a-ap) @6=foo UPDATED)
+ap: (., [ap-c) @5=bar UPDATED)
 b: (b, [ap-c) @5=bar)
-c: (c, .)
+c: (c, . UPDATED)
 .
 a:a
 b:b
@@ -644,16 +644,16 @@ next
 next
 next
 ----
-b: (b, [b-c) @5=bar)
-c: (c, .)
-cat: (., [cat-e) @3=bax)
+b: (b, [b-c) @5=bar UPDATED)
+c: (c, . UPDATED)
+cat: (., [cat-e) @3=bax UPDATED)
 d: (d, [cat-e) @3=bax)
 .
 .
-a: (a, [a-ap) @6=foo)
-ap: (., [ap-c) @5=bar)
+a: (a, [a-ap) @6=foo UPDATED)
+ap: (., [ap-c) @5=bar UPDATED)
 b: (b, [ap-c) @5=bar)
-c: (c, .)
+c: (c, . UPDATED)
 .
 a:a
 b:b
@@ -683,9 +683,9 @@ prev
 seek-ge c
 prev
 ----
-b: (., [b-e) @1=foo)
-a: (a, .)
-c: (., [b-e) @1=foo)
+b: (., [b-e) @1=foo UPDATED)
+a: (a, . UPDATED)
+c: (., [b-e) @1=foo UPDATED)
 b: (., [b-e) @1=foo)
 
 # Test a case during limited reverse iteration where a range key covers a
@@ -709,7 +709,7 @@ seek-ge z
 prev-limit c
 ----
 .
-a: valid (., [a-d) @1=foo)
+a: valid (., [a-d) @1=foo UPDATED)
 
 # Test a case during limited reverse iteration where there exists a range key
 # but it ends before the limit. The iterator should pause.
@@ -785,8 +785,8 @@ combined-iter
 first
 next
 ----
-bax: (., [bax-foo) @1=foo)
-foo: (., [foo-zoo) @2=bar, @1=foo)
+bax: (., [bax-foo) @1=foo UPDATED)
+foo: (., [foo-zoo) @2=bar, @1=foo UPDATED)
 
 # Test seeking into the middle of a range key during lazy-combined iteration.
 # The iterator should surface Key() = the seek key.
@@ -794,12 +794,12 @@ foo: (., [foo-zoo) @2=bar, @1=foo)
 combined-iter
 seek-ge bop
 ----
-bop: (., [bax-foo) @1=foo)
+bop: (., [bax-foo) @1=foo UPDATED)
 
 combined-iter
 last
 ----
-foo: (., [foo-zoo) @2=bar, @1=foo)
+foo: (., [foo-zoo) @2=bar, @1=foo UPDATED)
 
 
 # Test a lazy combined iterator that must next/prev through fileMetdata when
@@ -869,15 +869,15 @@ combined-iter
 seek-ge k
 next
 ----
-l: (., [l-m) @1=foo)
-z: (z, .)
+l: (., [l-m) @1=foo UPDATED)
+z: (z, . UPDATED)
 
 combined-iter
 seek-lt k
 prev
 ----
-d: (., [d-e) @1=foo)
-a: (a, .)
+d: (., [d-e) @1=foo UPDATED)
+a: (a, . UPDATED)
 
 # Test a range key masking case where the range key is not immediately
 # masking point keys, but masks point keys once positioned beneath it.
@@ -901,7 +901,7 @@ next
 ----
 a@1: (a1, .)
 b@3: (b3, .)
-d: (., [d-e) @5=boop)
+d: (., [d-e) @5=boop UPDATED)
 .
 
 # Try a broad range key that masks all the point keys.
@@ -947,7 +947,7 @@ first
 next
 stats
 ----
-a: (., [a-z) @5=boop)
+a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 625 B, cached 0 B)), (points: (count 25, key-bytes 75, value-bytes 75, tombstoned: 0))
@@ -961,7 +961,7 @@ first
 next
 stats
 ----
-a: (., [a-z) @5=boop)
+a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 50 B, cached 50 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
@@ -973,7 +973,7 @@ last
 prev
 stats
 ----
-a: (., [a-z) @5=boop)
+a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
 (internal-stats: (block-bytes: (total 625 B, cached 625 B)), (points: (count 25, key-bytes 75, value-bytes 75, tombstoned: 0))
@@ -983,7 +983,7 @@ last
 prev
 stats
 ----
-a: (., [a-z) @5=boop)
+a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
 (internal-stats: (block-bytes: (total 50 B, cached 50 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
@@ -995,7 +995,7 @@ seek-ge m
 next
 stats
 ----
-m: (., [a-z) @5=boop)
+m: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 325 B, cached 325 B)), (points: (count 13, key-bytes 39, value-bytes 39, tombstoned: 0))
@@ -1005,7 +1005,7 @@ seek-ge m
 next
 stats
 ----
-m: (., [a-z) @5=boop)
+m: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 50 B, cached 50 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
@@ -1015,7 +1015,7 @@ seek-lt m
 prev
 stats
 ----
-a: (., [a-z) @5=boop)
+a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
 (internal-stats: (block-bytes: (total 325 B, cached 325 B)), (points: (count 12, key-bytes 36, value-bytes 36, tombstoned: 0))
@@ -1025,7 +1025,7 @@ seek-lt m
 prev
 stats
 ----
-a: (., [a-z) @5=boop)
+a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
 (internal-stats: (block-bytes: (total 75 B, cached 75 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
@@ -1046,7 +1046,7 @@ combined-iter
 seek-ge a
 seek-ge b
 ----
-a: (., [a-c) @5=boop)
+a: (., [a-c) @5=boop UPDATED)
 b: (., [a-c) @5=boop)
 
 # Test a few cases around when a combined iterator should be lazy or not.
@@ -1103,7 +1103,7 @@ is-using-combined
 using combined (non-lazy) iterator
 a: (a, .)
 using combined (non-lazy) iterator
-n: (., [m-z) @5=foo)
+n: (., [m-z) @5=foo UPDATED)
 using combined (non-lazy) iterator
 
 flush
@@ -1122,5 +1122,5 @@ is-using-combined
 using lazy iterator
 a: (a, .)
 using lazy iterator
-n: (., [m-z) @5=foo)
+n: (., [m-z) @5=foo UPDATED)
 using combined (non-lazy) iterator


### PR DESCRIPTION
Add a new Iterator method RangeKeyChanged() that indicates whether the state
of range keys changed in the most recent iterator positioning operation. If
this new method returns false, the user is guaranteed that the
previously-returned range key buffers returned from RangeBounds and RangeKeys
are still valid.

Additionally, use the SpanChanged hook to flip a flag on the range iterator
range key state, indicating that a new span was encountered. This allows the
iterator to avoid copying the range key state if the current range key has not
changed. This commit removes setRangeKey and always copies range key buffers to
Iterator-owned buffers in order to provide the guarantee that the buffers
returned by RangeKeyBounds and RangeKeys will be stable until the iterator's
range key changes.

Most of this commit's direct performance gains are during reverse iteration,
which no longer must copy the range key on every step. It's expected that this
change will allow additional performance optimizations higher up and in both
directions, because users will no longer need to copy and compare range keys in
order to determine if they changed.

```
name                                                           old time/op    new time/op    delta
Iterator_RangeKeyMasking/range-keys-suffixes=@10/forward-10      2.37ms ±11%    2.30ms ±11%    ~     (p=0.142 n=20+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@10/backward-10     3.28ms ± 4%    3.11ms ± 8%  -5.17%  (p=0.000 n=17+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/forward-10      2.10ms ± 8%    2.03ms ± 8%  -3.29%  (p=0.001 n=20+18)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/backward-10     2.78ms ± 3%    2.64ms ± 3%  -5.22%  (p=0.000 n=18+19)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/forward-10       963µs ± 1%     951µs ± 1%  -1.32%  (p=0.000 n=17+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/backward-10     1.43ms ±16%    1.32ms ± 5%  -7.72%  (p=0.000 n=19+20)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/forward-10      151µs ± 1%     149µs ± 1%  -0.95%  (p=0.000 n=19+19)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/backward-10     301µs ± 1%     308µs ± 2%  +2.11%  (p=0.000 n=19+18)
CombinedIteratorSeek/range-key=false/batch=false-10              2.83µs ± 1%    2.81µs ± 1%  -0.90%  (p=0.007 n=9+10)
CombinedIteratorSeek/range-key=false/batch=true-10               4.85µs ± 1%    4.58µs ± 0%  -5.60%  (p=0.000 n=9+10)
CombinedIteratorSeek/range-key=true/batch=false-10               6.43µs ± 0%    6.01µs ± 1%  -6.49%  (p=0.000 n=10+10)
CombinedIteratorSeek/range-key=true/batch=true-10                8.47µs ± 0%    8.10µs ± 0%  -4.44%  (p=0.000 n=10+10)
```

Close #1775.