### PR TITLE
db: only switch to combined iteration on RangeKeySet keys

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -610,7 +610,7 @@ func (a compensatedSizeAnnotator) Accumulate(
 ) (v interface{}, cacheOK bool) {
 	vptr := dst.(*uint64)
 	*vptr = *vptr + compensatedSize(f)
-	return vptr, f.Stats.Valid
+	return vptr, f.StatsValidLocked()
 }
 
 func (a compensatedSizeAnnotator) Merge(src interface{}, dst interface{}) interface{} {
@@ -1228,7 +1228,7 @@ func (a elisionOnlyAnnotator) Accumulate(f *fileMetadata, dst interface{}) (inte
 	if f.Compacting {
 		return dst, true
 	}
-	if !f.Stats.Valid {
+	if !f.StatsValidLocked() {
 		return dst, false
 	}
 	// Bottommost files are large and not worthwhile to compact just

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -1171,9 +1171,9 @@ func TestCompactionOutputFileSize(t *testing.T) {
 				if err != nil {
 					return nil, err
 				}
-				m.Stats.Valid = true
 				m.Stats.RangeDeletionsBytesEstimate = uint64(v)
 				m.Stats.NumDeletions = 1 // At least one range del responsible for the deletion bytes.
+				m.StatsMarkValid()
 			}
 		}
 		m.SmallestSeqNum = m.Smallest.SeqNum()

--- a/db.go
+++ b/db.go
@@ -995,6 +995,9 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 			}
 			dbi.iter = &dbi.lazyCombinedIter
 		} else {
+			dbi.lazyCombinedIter.combinedIterState = combinedIterState{
+				initialized: true,
+			}
 			if dbi.rangeKey == nil {
 				dbi.rangeKey = iterRangeKeyStateAllocPool.Get().(*iteratorRangeKeyState)
 				dbi.rangeKey.init(dbi.cmp, dbi.split, &dbi.opts)

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/cockroachdb/pebble/internal/errorfs"
 	"github.com/cockroachdb/pebble/internal/keyspan"
-	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -126,10 +125,8 @@ func TestIngestLoadRand(t *testing.T) {
 		pending[i] = FileNum(rng.Int63())
 		expected[i] = &fileMetadata{
 			FileNum: pending[i],
-			Stats: manifest.TableStats{
-				Valid: true,
-			},
 		}
+		expected[i].StatsMarkValid()
 
 		func() {
 			f, err := mem.Create(paths[i])

--- a/range_keys_test.go
+++ b/range_keys_test.go
@@ -164,6 +164,11 @@ func TestRangeKeys(t *testing.T) {
 				fmt.Fprintln(&buf)
 			}
 			return buf.String()
+		case "wait-table-stats":
+			d.mu.Lock()
+			d.waitTableStats()
+			d.mu.Unlock()
+			return ""
 		default:
 			return fmt.Sprintf("unknown command %q", td.Cmd)
 		}

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -13,7 +13,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 2
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
@@ -35,7 +35,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 2
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
@@ -56,7 +56,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 26
 
@@ -79,7 +79,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
@@ -118,7 +118,7 @@ wait-pending-table-stats
 ----
 num-entries: 6
 num-deletions: 2
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 76
 
@@ -151,7 +151,7 @@ wait-pending-table-stats
 ----
 num-entries: 11
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 149
 range-deletions-bytes-estimate: 0
 
@@ -195,7 +195,7 @@ wait-pending-table-stats
 ----
 num-entries: 5
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 16488
 
@@ -232,7 +232,7 @@ wait-pending-table-stats
 ----
 num-entries: 3
 num-deletions: 3
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 13167
 range-deletions-bytes-estimate: 0
 
@@ -266,7 +266,7 @@ wait-pending-table-stats
 ----
 num-entries: 0
 num-deletions: 0
-num-range-keys: 1
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
@@ -275,7 +275,7 @@ wait-pending-table-stats
 ----
 num-entries: 0
 num-deletions: 0
-num-range-keys: 1
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
@@ -284,7 +284,7 @@ wait-pending-table-stats
 ----
 num-entries: 0
 num-deletions: 0
-num-range-keys: 1
+num-range-key-sets: 1
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -74,7 +74,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 0
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
@@ -347,7 +347,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 2
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 1666
 

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -86,7 +86,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 1552
 
@@ -104,7 +104,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 776
 

--- a/testdata/manual_compaction_set_with_del
+++ b/testdata/manual_compaction_set_with_del
@@ -86,7 +86,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 1552
 
@@ -104,7 +104,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 776
 

--- a/testdata/range_del
+++ b/testdata/range_del
@@ -1390,7 +1390,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
@@ -1399,7 +1399,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 836
 
@@ -1408,7 +1408,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 1672
 
@@ -1417,7 +1417,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 2
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 1672
 
@@ -1457,7 +1457,7 @@ wait-pending-table-stats
 ----
 num-entries: 4
 num-deletions: 0
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
@@ -1466,7 +1466,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 42
 
@@ -1475,7 +1475,7 @@ wait-pending-table-stats
 ----
 num-entries: 3
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 68
 
@@ -1484,7 +1484,7 @@ wait-pending-table-stats
 ----
 num-entries: 4
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 100
 
@@ -1520,7 +1520,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 782
 
@@ -1529,7 +1529,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 771
 
@@ -1538,6 +1538,6 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 2
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 1553

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -1048,3 +1048,79 @@ seek-ge b
 ----
 a: (., [a-c) @5=boop)
 b: (., [a-c) @5=boop)
+
+# Test a few cases around when a combined iterator should be lazy or not.
+
+reset
+----
+
+batch
+set a a
+set b b
+set c c
+set e e
+range-key-del a f
+range-key-unset a f @5
+----
+wrote 6 keys
+
+flush
+----
+
+wait-table-stats
+----
+
+# The lazy iterator shouldn't switch to combined iteration when it encounters a
+# file that is known to only contain RANGEKEYDELs and RANGEKEYUNSETs.
+
+combined-iter
+is-using-combined
+seek-ge a
+seek-ge b
+is-using-combined
+----
+using lazy iterator
+a: (a, .)
+b: (b, .)
+using lazy iterator
+
+# Write a range key to the memtable. The combined iterator should be forced to
+# use non-lazy iteration.
+
+batch
+range-key-set m z @5 foo
+set s s
+----
+wrote 2 keys
+
+combined-iter
+is-using-combined
+seek-ge a
+is-using-combined
+seek-ge n
+is-using-combined
+----
+using combined (non-lazy) iterator
+a: (a, .)
+using combined (non-lazy) iterator
+n: (., [m-z) @5=foo)
+using combined (non-lazy) iterator
+
+flush
+----
+
+# Now that the range key is flushed, a switch to combined iteration should only
+# happen once the sstable containing the set is encountered.
+
+combined-iter
+is-using-combined
+seek-ge a
+is-using-combined
+seek-ge n
+is-using-combined
+----
+using lazy iterator
+a: (a, .)
+using lazy iterator
+n: (., [m-z) @5=foo)
+using combined (non-lazy) iterator

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -14,7 +14,7 @@ wait-pending-table-stats
 ----
 num-entries: 3
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
@@ -39,7 +39,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 51
 
@@ -58,7 +58,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 51
 
@@ -96,7 +96,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 0
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
@@ -179,7 +179,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 769
 
@@ -188,7 +188,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 769
 
@@ -207,7 +207,7 @@ wait-pending-table-stats
 ----
 num-entries: 4
 num-deletions: 2
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 68
 
@@ -245,7 +245,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 33
 
@@ -256,7 +256,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 66
 
@@ -331,7 +331,7 @@ wait-pending-table-stats
 ----
 num-entries: 0
 num-deletions: 0
-num-range-keys: 1
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
@@ -344,7 +344,7 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 915
 
@@ -421,7 +421,7 @@ wait-pending-table-stats
 ----
 num-entries: 0
 num-deletions: 0
-num-range-keys: 1
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
@@ -451,7 +451,7 @@ wait-pending-table-stats
 ----
 num-entries: 2
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 0
 
@@ -462,6 +462,6 @@ wait-pending-table-stats
 ----
 num-entries: 1
 num-deletions: 1
-num-range-keys: 0
+num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
 range-deletions-bytes-estimate: 26


### PR DESCRIPTION
Previously, the lazy combined iterator always switched to combined iteration
when it observed a file for which `m.HasRangeKeys` was true. This change tweaks
the table stats to record the number of `RangeKeySets` within a file. Now, if
table stats have been calculated for a file and the lazy combined iterator
observes it has no `RangeKeySet`s, the lazy combined iterator will NOT trigger
a switch.

In Cockroach, this is expected to help with snapshot ingested RANGEKEYDELs.
Cockroach lays both a RANGEDEL and RANGEKEYDEL across a range's snapshot
sstable. Previously, iterating onto this sstable would unconditionally trigger
a switch to combined iteration.

Additionally, fix a bug where a combined iterator that was non-lazy due to
batch or memtable range keys was incorrectly recorded as lazy. This would cause
an unnecessary rebuild of the iterator stack on the first encounter of a range
key.

Close #1839.