### PR TITLE
db: fix keyspan SeekGE optimization with indexed batch

### DIFF
--- a/internal/keyspan/interleaving_iter.go
+++ b/internal/keyspan/interleaving_iter.go
@@ -983,6 +983,15 @@ func (i *InterleavingIter) SetBounds(lower, upper []byte) {
 	i.pointIter.SetBounds(lower, upper)
 }
 
+// Invalidate invalidates the interleaving iterator's current position, clearing
+// its state. This prevents optimizations such as reusing the current span on
+// seek.
+func (i *InterleavingIter) Invalidate() {
+	i.span = nil
+	i.pointKey = nil
+	i.pointVal = nil
+}
+
 // Error implements (base.InternalIterator).Error.
 func (i *InterleavingIter) Error() error {
 	return firstError(i.pointIter.Error(), i.keyspanIter.Error())

--- a/iterator.go
+++ b/iterator.go
@@ -2024,6 +2024,9 @@ func (i *Iterator) invalidate() {
 		i.pos = iterPosCurReverse
 	}
 	i.iterValidityState = IterExhausted
+	if i.rangeKey != nil {
+		i.rangeKey.iiter.Invalidate()
+	}
 }
 
 // Metrics returns per-iterator metrics.

--- a/testdata/indexed_batch_mutation
+++ b/testdata/indexed_batch_mutation
@@ -460,6 +460,7 @@ first
 next
 next
 next
+seek-ge bat
 ----
 a: (., [a-b) @1=poi)
 b: (., [b-c) @2=yaya, @1=poi)
@@ -468,4 +469,36 @@ c: (., [c-d) @2=yaya)
 a: (., [a-b) @1=poi)
 b: (., [b-c) @2=yaya, @1=poi)
 c: (., [c-d) @2=yaya)
+e: (., [e-f) @3=foo)
+bat: (., [b-c) @2=yaya, @1=poi)
+
+# Mutate the range key under the interleaving iterator's current position in the
+# indexed batch.
+#
+# The last `seek-ge` operation landed on the range key [b-c). The top-level
+# *pebble.Iterator needs to step the iterator again to see if there's a
+# coincident point key at (`bat`), which would've advanced the interleaving
+# iterator to the range key with bounds [c,d), so the underlying interleaving
+# iterator is positioned ahead at:
+#
+#     c: (., [c-d) @2=yaya)
+#
+# If we call set-options to refresh the iterator's view of the indexed batch,
+# the range-key-unset [c,d)@2 becomes visible, and the range key that the
+# underlying interleaving iterator is positioned over should not be visible.
+#
+# A bug previously allowed this range key to be visible when seeking into this
+# span's bounds (see the optimization in InterleavingIter.SeekGE). Now, the call
+# to SetOptions clears the interleaving iterator's positional state to avoid the
+# SeekGE optimization.
+
+mutate
+range-key-unset b d @2
+----
+
+iter iter=i1
+set-options
+seek-ge cat
+----
+.
 e: (., [e-f) @3=foo)


### PR DESCRIPTION
The interleaving iterator SeekGE optimization added in 04f9100 had a bug in its
interaction with SetOptions calls on an indexed batch iterator. When SetOptions
is called on an iterator over an indexed batch, it refreshes its view of the
batch. The refresh of the batch's view may change the state of range keys,
including the span that the interleaving iterator is positioned over.
Previously, the SeekGE optimization would improperly return this existing,
possibly-outdated span.

Now, SetOptions invalidates the interleaving iterator position to disable the
SeekGE optimization, just like it does for other seek optimizations.

Informs cockroachdb/cockroach#85660.