### PR TITLE
internal/metamorphic: improve SetOptions coverage

### DIFF
--- a/internal/metamorphic/parser.go
+++ b/internal/metamorphic/parser.go
@@ -77,7 +77,7 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	case *newIndexedBatchOp:
 		return nil, &t.batchID, nil
 	case *newIterOp:
-		return &t.readerID, &t.iterID, []interface{}{&t.lower, &t.upper, &t.keyTypes, &t.filterMin, &t.filterMax, &t.rangeKeyMaskSuffix}
+		return &t.readerID, &t.iterID, []interface{}{&t.lower, &t.upper, &t.keyTypes, &t.filterMin, &t.filterMax, &t.maskSuffix}
 	case *newIterUsingCloneOp:
 		return &t.existingIterID, &t.iterID, []interface{}{&t.refreshBatch}
 	case *newSnapshotOp:
@@ -97,7 +97,7 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	case *iterSetBoundsOp:
 		return &t.iterID, nil, []interface{}{&t.lower, &t.upper}
 	case *iterSetOptionsOp:
-		return &t.iterID, nil, []interface{}{&t.lower, &t.upper, &t.keyTypes, &t.filterMin, &t.filterMax, &t.rangeKeyMaskSuffix}
+		return &t.iterID, nil, []interface{}{&t.lower, &t.upper, &t.keyTypes, &t.filterMin, &t.filterMax, &t.maskSuffix}
 	case *singleDeleteOp:
 		return &t.writerID, nil, []interface{}{&t.key, &t.maybeReplaceDelete}
 	case *rangeKeyDeleteOp:

--- a/internal/metamorphic/parser_test.go
+++ b/internal/metamorphic/parser_test.go
@@ -49,8 +49,7 @@ func TestParserNilBounds(t *testing.T) {
 		&newIterOp{
 			readerID: makeObjID(dbTag, 0),
 			iterID:   makeObjID(iterTag, 1),
-			lower:    nil,
-			upper:    nil,
+			iterOpts: iterOpts{},
 		},
 	})
 	parsedOps, err := parse([]byte(formatted))

--- a/internal/metamorphic/retryable.go
+++ b/internal/metamorphic/retryable.go
@@ -38,6 +38,9 @@ type retryableIter struct {
 }
 
 func (i *retryableIter) shouldFilter() bool {
+	if i.filterMax == 0 {
+		return false
+	}
 	k := i.iter.Key()
 	n := testkeys.Comparer.Split(k)
 	if n == len(k) {


### PR DESCRIPTION
Improve the test coverage of the metamorphic tests around SetOptions by
allowing SetOptions to modify block-property filters, and by improving the
probability of its fast paths.

Informs #1885.