### PR TITLE
db: add NextPrefix to Iterator

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -166,6 +166,8 @@ func runIterCmd(d *datadriven.TestData, iter *Iterator, closeIter bool) string {
 			valid = iter.Last()
 		case "next":
 			valid = iter.Next()
+		case "next-prefix":
+			valid = iter.NextPrefix()
 		case "prev":
 			valid = iter.Prev()
 		case "set-bounds":

--- a/db.go
+++ b/db.go
@@ -883,6 +883,7 @@ type iterAlloc struct {
 	merging             mergingIter
 	mlevels             [3 + numLevels]mergingIterLevel
 	levels              [3 + numLevels]levelIter
+	levelsPositioned    [3 + numLevels]bool
 }
 
 var iterAllocPool = sync.Pool{
@@ -1173,6 +1174,9 @@ func (i *Iterator) constructPointIter(memtables flushableList, buf *iterAlloc) {
 		addLevelIterForFiles(current.Levels[level].Iter(), manifest.Level(level))
 	}
 	buf.merging.init(&i.opts, &i.stats.InternalStats, i.comparer.Compare, i.comparer.Split, mlevels...)
+	if len(mlevels) <= cap(buf.levelsPositioned) {
+		buf.merging.levelsPositioned = buf.levelsPositioned[:len(mlevels)]
+	}
 	buf.merging.snapshot = i.seqNum
 	buf.merging.batchSnapshot = i.batchSeqNum
 	buf.merging.combinedIterState = &i.lazyCombinedIter.combinedIterState

--- a/error_iter.go
+++ b/error_iter.go
@@ -50,6 +50,10 @@ func (c *errorIter) Prev() (*InternalKey, base.LazyValue) {
 	return nil, base.LazyValue{}
 }
 
+func (c *errorIter) NextPrefix([]byte) (*InternalKey, base.LazyValue) {
+	return nil, base.LazyValue{}
+}
+
 func (c *errorIter) Error() error {
 	return c.err
 }

--- a/get_iter.go
+++ b/get_iter.go
@@ -190,6 +190,10 @@ func (g *getIter) Prev() (*InternalKey, base.LazyValue) {
 	panic("pebble: Prev unimplemented")
 }
 
+func (g *getIter) NextPrefix([]byte) (*InternalKey, base.LazyValue) {
+	panic("pebble: NextPrefix unimplemented")
+}
+
 func (g *getIter) Valid() bool {
 	return g.iterKey != nil && g.err == nil
 }

--- a/internal/arenaskl/flush_iterator.go
+++ b/internal/arenaskl/flush_iterator.go
@@ -79,6 +79,10 @@ func (it *flushIterator) Next() (*base.InternalKey, base.LazyValue) {
 	return &it.key, base.MakeInPlaceValue(it.value())
 }
 
+func (it *flushIterator) NextPrefix(succKey []byte) (*base.InternalKey, base.LazyValue) {
+	panic("pebble: NextPrefix unimplemented")
+}
+
 func (it *flushIterator) Prev() (*base.InternalKey, base.LazyValue) {
 	panic("pebble: Prev unimplemented")
 }

--- a/internal/arenaskl/iterator.go
+++ b/internal/arenaskl/iterator.go
@@ -194,6 +194,13 @@ func (it *Iterator) Next() (*base.InternalKey, base.LazyValue) {
 	return &it.key, base.MakeInPlaceValue(it.value())
 }
 
+// NextPrefix advances to the next position with a new prefix. Returns the key
+// and value if the iterator is pointing at a valid entry, and (nil, nil)
+// otherwise.
+func (it *Iterator) NextPrefix(succKey []byte) (*base.InternalKey, base.LazyValue) {
+	return it.SeekGE(succKey, base.SeekGEFlagsNone.EnableTrySeekUsingNext())
+}
+
 // Prev moves to the previous position. Returns the key and value if the
 // iterator is pointing at a valid entry, and (nil, nil) otherwise.
 func (it *Iterator) Prev() (*base.InternalKey, base.LazyValue) {

--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -154,6 +154,22 @@ type InternalIterator interface {
 	// SeekPrefixGE or Next returned (nil, nilv).
 	Next() (*InternalKey, LazyValue)
 
+	// NextPrefix moves the iterator to the next key/value pair with a different
+	// prefix than the key at the current iterator position. Returns the key and
+	// value if the iterator is pointing at a valid entry, and (nil, nil)
+	// otherwise. Note that NextPrefix only checks the upper bound. It is up to
+	// the caller to ensure that key is greater than or equal to the lower
+	// bound.
+	//
+	// NextPrefix is passed the immediate successor to the current prefix key. A
+	// valid implementation of NextPrefix is to call SeekGE with succKey.
+	//
+	// It is not allowed to call NextPrefix when the previous call was a reverse
+	// positioning operation or a call to a forward positioning method that
+	// returned (nil, nilv). It is also not allowed to call NextPrefix when the
+	// iterator is in prefix iteration mode.
+	NextPrefix(succKey []byte) (*InternalKey, LazyValue)
+
 	// Prev moves the iterator to the previous key/value pair. Returns the key
 	// and value if the iterator is pointing at a valid entry, and (nil, nilv)
 	// otherwise. Note that Prev only checks the lower bound. It is up to the

--- a/internal/keyspan/interleaving_iter.go
+++ b/internal/keyspan/interleaving_iter.go
@@ -29,9 +29,9 @@ type SpanMask interface {
 	SpanChanged(*Span)
 	// SkipPoint is invoked by the interleaving iterator whenever the iterator
 	// encounters a point key covered by a Span. If SkipPoint returns true, the
-	// interleaving iterator skips the point key without returning it. This is
-	// used during range key iteration to skip over point keys 'masked' by range
-	// keys.
+	// interleaving iterator skips the point key and all larger keys with the
+	// same prefix. This is used during range key iteration to skip over point
+	// keys 'masked' by range keys.
 	SkipPoint(userKey []byte) bool
 }
 
@@ -479,6 +479,30 @@ func (i *InterleavingIter) Next() (*base.InternalKey, base.LazyValue) {
 	return i.interleaveForward(i.lower, nil /* prefix */)
 }
 
+// NextPrefix implements (base.InternalIterator).NextPrefix.
+func (i *InterleavingIter) NextPrefix(succKey []byte) (*base.InternalKey, base.LazyValue) {
+	if i.dir == -1 {
+		panic("pebble: cannot switch directions with NextPrefix")
+	}
+
+	// Refresh the point key if the current point key has already been
+	// interleaved, OR if the next uninterleaved point key has the old suffix
+	// (it's less than succKey).
+	if i.pointKeyInterleaved || (i.pointKey != nil && i.cmp(i.pointKey.UserKey, succKey) < 0) {
+		i.pointKey, i.pointVal = i.pointIter.NextPrefix(succKey)
+		i.pointKeyInterleaved = false
+	}
+	// If we already interleaved the current span start key, and the point key
+	// is ≥ the span's end key, move to the next span.
+	if i.keyspanInterleaved && i.pointKey != nil && i.span != nil &&
+		i.cmp(i.pointKey.UserKey, i.span.End) >= 0 {
+		i.span = i.keyspanIter.Next()
+		i.checkForwardBound(nil)
+		i.savedKeyspan()
+	}
+	return i.interleaveForward(i.lower, nil)
+}
+
 // Prev implements (base.InternalIterator).Prev.
 func (i *InterleavingIter) Prev() (*base.InternalKey, base.LazyValue) {
 	if i.dir == +1 {
@@ -677,7 +701,7 @@ func (i *InterleavingIter) interleaveForward(
 				// if we have stepped outside of the span last saved as a mask,
 				// so that the decision to skip is made with the correct
 				// knowledge of the covering span.
-				i.maybeUpdateMask(true /*covered */)
+				i.maybeUpdateMask(true /* covered */)
 
 				if i.mask != nil && i.mask.SkipPoint(i.pointKey.UserKey) {
 					if i.prefix {
@@ -694,6 +718,11 @@ func (i *InterleavingIter) interleaveForward(
 						// point is already beyond the prefix.
 						return i.yieldNil()
 					}
+					// TODO(jackson): If we thread a base.Comparer through to
+					// InterleavingIter so that we have access to
+					// ImmediateSuccessor, we could use NextPrefix. We'd need to
+					// tweak the SpanMask interface slightly, but it's probably
+					// worthwhile.
 
 					i.pointKey, i.pointVal = i.pointIter.Next()
 					// We may have just invalidated the invariant that

--- a/internal/keyspan/interleaving_iter_test.go
+++ b/internal/keyspan/interleaving_iter_test.go
@@ -257,6 +257,10 @@ func (i *pointIterator) Next() (*base.InternalKey, base.LazyValue) {
 	return &i.keys[i.index], base.LazyValue{}
 }
 
+func (i *pointIterator) NextPrefix(succKey []byte) (*base.InternalKey, base.LazyValue) {
+	return i.SeekGE(succKey, base.SeekGEFlagsNone)
+}
+
 func (i *pointIterator) Prev() (*base.InternalKey, base.LazyValue) {
 	i.index--
 	if i.index < 0 || i.index >= len(i.keys) {

--- a/internal/keyspan/internal_iter_shim.go
+++ b/internal/keyspan/internal_iter_shim.go
@@ -88,6 +88,11 @@ func (i *InternalIteratorShim) Next() (*base.InternalKey, base.LazyValue) {
 	return &i.iterKey, base.MakeInPlaceValue(i.span.End)
 }
 
+// NextPrefix implements (base.InternalIterator).NextPrefix.
+func (i *InternalIteratorShim) NextPrefix([]byte) (*base.InternalKey, base.LazyValue) {
+	panic("unimplemented")
+}
+
 // Prev implements (base.InternalIterator).Prev.
 func (i *InternalIteratorShim) Prev() (*base.InternalKey, base.LazyValue) {
 	panic("unimplemented")

--- a/internal/metamorphic/config.go
+++ b/internal/metamorphic/config.go
@@ -21,6 +21,7 @@ const (
 	iterLast
 	iterNext
 	iterNextWithLimit
+	iterNextPrefix
 	iterPrev
 	iterPrevWithLimit
 	iterSeekGE
@@ -87,6 +88,7 @@ func defaultConfig() config {
 			iterLast:             100,
 			iterNext:             100,
 			iterNextWithLimit:    20,
+			iterNextPrefix:       20,
 			iterPrev:             100,
 			iterPrevWithLimit:    20,
 			iterSeekGE:           100,

--- a/internal/metamorphic/generator.go
+++ b/internal/metamorphic/generator.go
@@ -126,6 +126,7 @@ func generate(rng *rand.Rand, count uint64, cfg config, km *keyManager) []op {
 		iterLast:             g.randIter(g.iterLast),
 		iterNext:             g.randIter(g.iterNext),
 		iterNextWithLimit:    g.randIter(g.iterNextWithLimit),
+		iterNextPrefix:       g.randIter(g.iterNextPrefix),
 		iterPrev:             g.randIter(g.iterPrev),
 		iterPrevWithLimit:    g.randIter(g.iterPrevWithLimit),
 		iterSeekGE:           g.randIter(g.iterSeekGE),
@@ -911,6 +912,13 @@ func (g *generator) iterNextWithLimit(iterID objID) {
 	g.add(&iterNextOp{
 		iterID:          iterID,
 		limit:           g.randKeyToRead(0.001), // 0.1% new keys
+		derivedReaderID: g.iterReaderID[iterID],
+	})
+}
+
+func (g *generator) iterNextPrefix(iterID objID) {
+	g.add(&iterNextPrefixOp{
+		iterID:          iterID,
 		derivedReaderID: g.iterReaderID[iterID],
 	})
 }

--- a/internal/metamorphic/key_manager.go
+++ b/internal/metamorphic/key_manager.go
@@ -512,6 +512,7 @@ func opWrittenKeys(untypedOp op) [][]byte {
 	case *iterFirstOp:
 	case *iterLastOp:
 	case *iterNextOp:
+	case *iterNextPrefixOp:
 	case *iterPrevOp:
 	case *iterSeekGEOp:
 	case *iterSeekLTOp:

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -1061,6 +1061,28 @@ func (o *iterNextOp) String() string       { return fmt.Sprintf("%s.Next(%q)", o
 func (o *iterNextOp) receiver() objID      { return o.iterID }
 func (o *iterNextOp) syncObjs() objIDSlice { return onlyBatchIDs(o.derivedReaderID) }
 
+// iterNextPrefixOp models an Iterator.NextPrefix operation.
+type iterNextPrefixOp struct {
+	iterID objID
+
+	derivedReaderID objID
+}
+
+func (o *iterNextPrefixOp) run(t *test, h historyRecorder) {
+	i := t.getIter(o.iterID)
+	valid := i.NextPrefix()
+	validStr := validBoolToStr(valid)
+	if valid {
+		h.Recordf("%s // [%s,%s] %v", o, validStr, iteratorPos(i), i.Error())
+	} else {
+		h.Recordf("%s // [%s] %v", o, validStr, i.Error())
+	}
+}
+
+func (o *iterNextPrefixOp) String() string       { return fmt.Sprintf("%s.NextPrefix()", o.iterID) }
+func (o *iterNextPrefixOp) receiver() objID      { return o.iterID }
+func (o *iterNextPrefixOp) syncObjs() objIDSlice { return onlyBatchIDs(o.derivedReaderID) }
+
 // iterPrevOp models an Iterator.Prev[WithLimit] operation.
 type iterPrevOp struct {
 	iterID objID

--- a/internal/metamorphic/parser.go
+++ b/internal/metamorphic/parser.go
@@ -84,6 +84,8 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 		return nil, &t.snapID, nil
 	case *iterNextOp:
 		return &t.iterID, nil, []interface{}{&t.limit}
+	case *iterNextPrefixOp:
+		return &t.iterID, nil, nil
 	case *iterPrevOp:
 		return &t.iterID, nil, []interface{}{&t.limit}
 	case *iterSeekLTOp:
@@ -131,6 +133,7 @@ var methods = map[string]*methodInfo{
 	"NewIter":         makeMethod(newIterOp{}, dbTag, batchTag, snapTag),
 	"NewSnapshot":     makeMethod(newSnapshotOp{}, dbTag),
 	"Next":            makeMethod(iterNextOp{}, iterTag),
+	"NextPrefix":      makeMethod(iterNextPrefixOp{}, iterTag),
 	"Prev":            makeMethod(iterPrevOp{}, iterTag),
 	"RangeKeyDelete":  makeMethod(rangeKeyDeleteOp{}, dbTag, batchTag),
 	"RangeKeySet":     makeMethod(rangeKeySetOp{}, dbTag, batchTag),
@@ -417,6 +420,8 @@ func computeDerivedFields(ops []op) {
 		case *iterSeekLTOp:
 			v.derivedReaderID = iterToReader[v.iterID]
 		case *iterNextOp:
+			v.derivedReaderID = iterToReader[v.iterID]
+		case *iterNextPrefixOp:
 			v.derivedReaderID = iterToReader[v.iterID]
 		case *iterPrevOp:
 			v.derivedReaderID = iterToReader[v.iterID]

--- a/internal/metamorphic/retryable.go
+++ b/internal/metamorphic/retryable.go
@@ -257,6 +257,17 @@ func (i *retryableIter) NextWithLimit(limit []byte) pebble.IterValidityState {
 
 }
 
+func (i *retryableIter) NextPrefix() bool {
+	var valid bool
+	i.withRetry(func() {
+		valid = i.iter.NextPrefix()
+		for valid && i.shouldFilter() {
+			valid = i.iter.Next()
+		}
+	})
+	return valid
+}
+
 func (i *retryableIter) Prev() bool {
 	var valid bool
 	i.withPosition(func() {

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -174,6 +174,10 @@ func (f *fakeIter) Prev() (*InternalKey, base.LazyValue) {
 	return f.Key(), f.Value()
 }
 
+func (f *fakeIter) NextPrefix(succKey []byte) (*InternalKey, base.LazyValue) {
+	return f.SeekGE(succKey, base.SeekGEFlagsNone)
+}
+
 // key returns the current Key the iterator is positioned at regardless of the
 // value of f.valid.
 func (f *fakeIter) key() *InternalKey {
@@ -311,6 +315,10 @@ func (i *invalidatingIter) Next() (*InternalKey, base.LazyValue) {
 
 func (i *invalidatingIter) Prev() (*InternalKey, base.LazyValue) {
 	return i.update(i.iter.Prev())
+}
+
+func (i *invalidatingIter) NextPrefix(succKey []byte) (*InternalKey, base.LazyValue) {
+	return i.update(i.iter.NextPrefix(succKey))
 }
 
 func (i *invalidatingIter) Error() error {
@@ -2786,6 +2794,83 @@ func BenchmarkIteratorScan(b *testing.B) {
 				}
 			}()
 		}
+	}
+}
+
+func BenchmarkIteratorScanNextPrefix(b *testing.B) {
+	setupBench := func(b *testing.B, maxKeysPerLevel, versCount, readAmp int) *DB {
+		keyBuf := make([]byte, readAmp+testkeys.MaxSuffixLen)
+		opts := &Options{
+			FS:                 vfs.NewMem(),
+			Comparer:           testkeys.Comparer,
+			FormatMajorVersion: FormatNewest,
+		}
+		opts.DisableAutomaticCompactions = true
+		d, err := Open("", opts)
+		require.NoError(b, err)
+
+		// Create `readAmp` levels. Prefixes in the top of the LSM are length 1.
+		// Prefixes in the bottom of the LSM are length `readAmp`. Eg,:
+		//
+		//    a  b c...
+		//    aa ab ac...
+		//    aaa aab aac...
+		//
+		for l := readAmp; l > 0; l-- {
+			ks := testkeys.Alpha(l)
+			if step := ks.Count() / maxKeysPerLevel; step > 1 {
+				ks = ks.EveryN(step)
+			}
+			if ks.Count() > maxKeysPerLevel {
+				ks = ks.Slice(0, maxKeysPerLevel)
+			}
+
+			batch := d.NewBatch()
+			for i := 0; i < ks.Count(); i++ {
+				for v := 0; v < versCount; v++ {
+					n := testkeys.WriteKeyAt(keyBuf[:], ks, i, versCount-v+1)
+					batch.Set(keyBuf[:n], keyBuf[:n], nil)
+				}
+			}
+			require.NoError(b, batch.Commit(nil))
+			require.NoError(b, d.Flush())
+		}
+
+		// Each level is a sublevel.
+		m := d.Metrics()
+		require.Equal(b, readAmp, m.ReadAmp())
+		return d
+	}
+
+	for _, keysPerLevel := range []int{10, 100, 1000} {
+		b.Run(fmt.Sprintf("keysPerLevel=%d", keysPerLevel), func(b *testing.B) {
+			for _, versionCount := range []int{1, 2, 10, 100} {
+				b.Run(fmt.Sprintf("versions=%d", versionCount), func(b *testing.B) {
+					for _, readAmp := range []int{1, 3, 7, 10} {
+						b.Run(fmt.Sprintf("ramp=%d", readAmp), func(b *testing.B) {
+							d := setupBench(b, keysPerLevel, versionCount, readAmp)
+							defer func() { require.NoError(b, d.Close()) }()
+							for _, keyTypes := range []IterKeyType{IterKeyTypePointsOnly, IterKeyTypePointsAndRanges} {
+								b.Run(fmt.Sprintf("key-types=%s", keyTypes), func(b *testing.B) {
+									b.ResetTimer()
+									iterOpts := IterOptions{KeyTypes: keyTypes}
+									for i := 0; i < b.N; i++ {
+										b.StartTimer()
+										iter := d.NewIter(&iterOpts)
+										valid := iter.First()
+										for valid {
+											valid = iter.NextPrefix()
+										}
+										b.StopTimer()
+										require.NoError(b, iter.Close())
+									}
+								})
+							}
+						})
+					}
+				})
+			}
+		})
 	}
 }
 

--- a/range_keys.go
+++ b/range_keys.go
@@ -633,6 +633,17 @@ func (i *lazyCombinedIter) Next() (*InternalKey, base.LazyValue) {
 	return k, v
 }
 
+func (i *lazyCombinedIter) NextPrefix(succKey []byte) (*InternalKey, base.LazyValue) {
+	if i.combinedIterState.initialized {
+		return i.parent.rangeKey.iiter.NextPrefix(succKey)
+	}
+	k, v := i.pointIter.NextPrefix(succKey)
+	if i.combinedIterState.triggered {
+		return i.initCombinedIteration(+1, k, v, nil)
+	}
+	return k, v
+}
+
 func (i *lazyCombinedIter) Prev() (*InternalKey, base.LazyValue) {
 	if i.combinedIterState.initialized {
 		return i.parent.rangeKey.iiter.Prev()

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -994,6 +994,19 @@ func (i *blockIter) Next() (*InternalKey, base.LazyValue) {
 	return &i.ikey, i.lazyValue
 }
 
+// NextPrefix implements (base.InternalIterator).NextPrefix
+func (i *blockIter) NextPrefix(succKey []byte) (*InternalKey, base.LazyValue) {
+	const nextsBeforeSeek = 3
+	k, v := i.Next()
+	for j := 1; k != nil && i.cmp(k.UserKey, succKey) < 0; j++ {
+		if j >= nextsBeforeSeek {
+			return i.SeekGE(succKey, base.SeekGEFlagsNone)
+		}
+		k, v = i.Next()
+	}
+	return k, v
+}
+
 // Prev implements internalIterator.Prev, as documented in the pebble
 // package.
 func (i *blockIter) Prev() (*InternalKey, base.LazyValue) {

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -1180,6 +1180,29 @@ func (i *singleLevelIterator) Next() (*InternalKey, base.LazyValue) {
 	return i.skipForward()
 }
 
+// NextPrefix implements (base.InternalIterator).NextPrefix.
+func (i *singleLevelIterator) NextPrefix(succKey []byte) (*InternalKey, base.LazyValue) {
+	if i.exhaustedBounds == +1 {
+		panic("NextPrefix called even though exhausted upper bound")
+	}
+	i.exhaustedBounds = 0
+	i.maybeFilteredKeysSingleLevel = false
+	// Seek optimization only applies until iterator is first positioned after SetBounds.
+	i.boundsCmp = 0
+
+	if i.err != nil {
+		return nil, base.LazyValue{}
+	}
+	if key, val := i.data.NextPrefix(succKey); key != nil {
+		if i.blockUpper != nil && i.cmp(key.UserKey, i.blockUpper) >= 0 {
+			i.exhaustedBounds = +1
+			return nil, base.LazyValue{}
+		}
+		return key, val
+	}
+	return i.SeekGE(succKey, base.SeekGEFlagsNone)
+}
+
 // Prev implements internalIterator.Prev, as documented in the pebble
 // package.
 func (i *singleLevelIterator) Prev() (*InternalKey, base.LazyValue) {
@@ -2133,6 +2156,20 @@ func (i *twoLevelIterator) Next() (*InternalKey, base.LazyValue) {
 		return key, val
 	}
 	return i.skipForward()
+}
+
+// NextPrefix implements (base.InternalIterator).NextPrefix.
+func (i *twoLevelIterator) NextPrefix(succKey []byte) (*InternalKey, base.LazyValue) {
+	// Seek optimization only applies until iterator is first positioned after SetBounds.
+	i.boundsCmp = 0
+	i.maybeFilteredKeysTwoLevel = false
+	if i.err != nil {
+		return nil, base.LazyValue{}
+	}
+	if key, val := i.singleLevelIterator.NextPrefix(succKey); key != nil {
+		return key, val
+	}
+	return i.SeekGE(succKey, base.SeekGEFlagsNone)
 }
 
 // Prev implements internalIterator.Prev, as documented in the pebble

--- a/testdata/iter_histories/next_prefix
+++ b/testdata/iter_histories/next_prefix
@@ -1,0 +1,224 @@
+reset
+----
+
+# For all prefixes a-z, write 3 keys at timestamps @1, @10, @100.
+# This populates a total of 26 * 3 = 78 keys.
+
+populate keylen=1 timestamps=(1, 10, 100)
+----
+wrote 78 keys
+
+combined-iter
+first
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+----
+a@100: (a@100, .)
+b@100: (b@100, .)
+c@100: (c@100, .)
+d@100: (d@100, .)
+e@100: (e@100, .)
+f@100: (f@100, .)
+g@100: (g@100, .)
+h@100: (h@100, .)
+i@100: (i@100, .)
+j@100: (j@100, .)
+k@100: (k@100, .)
+l@100: (l@100, .)
+m@100: (m@100, .)
+n@100: (n@100, .)
+o@100: (o@100, .)
+p@100: (p@100, .)
+
+combined-iter
+seek-ge n@30
+next-prefix
+next
+next
+next-prefix
+----
+n@10: (n@10, .)
+o@100: (o@100, .)
+o@10: (o@10, .)
+o@1: (o@1, .)
+p@100: (p@100, .)
+
+combined-iter
+seek-prefix-ge p@210
+next-prefix
+----
+p@100: (p@100, .)
+err=cannot use NextPrefix with prefix iteration
+
+combined-iter
+seek-ge p@210
+next-prefix
+seek-ge p@210
+next
+next-prefix
+seek-ge p@210
+next
+next
+next-prefix
+----
+p@100: (p@100, .)
+q@100: (q@100, .)
+p@100: (p@100, .)
+p@10: (p@10, .)
+q@100: (q@100, .)
+p@100: (p@100, .)
+p@10: (p@10, .)
+p@1: (p@1, .)
+q@100: (q@100, .)
+
+reset target-file-size=1
+----
+
+populate keylen=1 timestamps=(1, 10, 100)
+----
+wrote 78 keys
+
+flush
+----
+
+combined-iter
+first
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+next-prefix
+----
+a@100: (a@100, .)
+b@100: (b@100, .)
+c@100: (c@100, .)
+d@100: (d@100, .)
+e@100: (e@100, .)
+f@100: (f@100, .)
+g@100: (g@100, .)
+h@100: (h@100, .)
+i@100: (i@100, .)
+j@100: (j@100, .)
+k@100: (k@100, .)
+l@100: (l@100, .)
+m@100: (m@100, .)
+n@100: (n@100, .)
+o@100: (o@100, .)
+p@100: (p@100, .)
+
+combined-iter
+seek-ge n@30
+next-prefix
+next
+next
+next-prefix
+----
+n@10: (n@10, .)
+o@100: (o@100, .)
+o@10: (o@10, .)
+o@1: (o@1, .)
+p@100: (p@100, .)
+
+combined-iter
+seek-prefix-ge p@210
+next-prefix
+----
+p@100: (p@100, .)
+err=cannot use NextPrefix with prefix iteration
+
+combined-iter
+seek-ge p@210
+next-prefix
+seek-ge p@210
+next
+next-prefix
+seek-ge p@210
+next
+next
+next-prefix
+----
+p@100: (p@100, .)
+q@100: (q@100, .)
+p@100: (p@100, .)
+p@10: (p@10, .)
+q@100: (q@100, .)
+p@100: (p@100, .)
+p@10: (p@10, .)
+p@1: (p@1, .)
+q@100: (q@100, .)
+
+batch commit
+range-key-set p r @1 foo
+----
+committed 1 keys
+
+combined-iter
+seek-ge p@210
+next-prefix
+----
+p@210: (., [p-r) @1=foo UPDATED)
+q@100: (q@100, [p-r) @1=foo)
+
+combined-iter
+seek-ge p@210
+next-prefix
+seek-ge p@210
+next
+next-prefix
+seek-ge p@210
+next
+next
+next-prefix
+----
+p@210: (., [p-r) @1=foo UPDATED)
+q@100: (q@100, [p-r) @1=foo)
+p@210: (., [p-r) @1=foo)
+p@100: (p@100, [p-r) @1=foo)
+q@100: (q@100, [p-r) @1=foo)
+p@210: (., [p-r) @1=foo)
+p@100: (p@100, [p-r) @1=foo)
+p@10: (p@10, [p-r) @1=foo)
+q@100: (q@100, [p-r) @1=foo)
+
+# Test an iterator that is positioned on a range key start of a prefix, and the
+# next key is a point key with that same prefix. The interleaving iterator must
+# correctly handle this case and advance the point key iterator.
+combined-iter
+seek-ge p
+next-prefix
+----
+p: (., [p-r) @1=foo UPDATED)
+q@100: (q@100, [p-r) @1=foo)
+
+# Test that switching directions via NextPrefix is disallowed.
+combined-iter
+seek-ge p@100
+prev
+next-prefix
+----
+p@100: (p@100, [p-r) @1=foo UPDATED)
+p: (., [p-r) @1=foo)
+p@100: (p@100, [p-r) @1=foo)


### PR DESCRIPTION
Expose a NextPrefix method on *pebble.Iterator that may be called when
the user wishes to move to the next key prefix (as determined by
Comparer.Split). NextPrefix guarantees that it will move to the next
key prefix.

When there are many keys per-prefix, the performance benefit of a new
NextPrefix is substantial. Previously, callers would need to SeekGE past
the previous key.  This would force repositioning all the levels of the
iterator. Now the dedicated NextPrefix method is able to use the current
iterator position to avoid a seek from scratch, and avoid repositioning
any levels that are already positioned at the next prefix. Additionally,
during combined iteration over a keyspace covered by a range key,
NextPrefix does not need to interleave range keys at the seek key and
instead will only interleave range keys if the iterator steps onto a new
one.

```
name                                                                      old speed      new speed       delta
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=0-24          6.20MB/s ± 2%   6.24MB/s ± 1%     ~     (p=0.524 n=5+5)
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=1-24          3.71MB/s ± 1%   3.90MB/s ± 1%   +5.01%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=100-24         376kB/s ± 2%    670kB/s ± 0%  +78.19%  (p=0.016 n=5+4)
MVCCScan_Pebble/rows=1/versions=2/valueSize=64/numRangeKeys=0-24          4.87MB/s ± 0%   5.00MB/s ± 2%   +2.71%  (p=0.032 n=5+5)
MVCCScan_Pebble/rows=1/versions=2/valueSize=64/numRangeKeys=1-24          3.08MB/s ± 1%   3.18MB/s ± 1%   +3.38%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1/versions=2/valueSize=64/numRangeKeys=100-24         420kB/s ± 0%    758kB/s ± 2%  +80.48%  (p=0.016 n=4+5)
MVCCScan_Pebble/rows=1/versions=10/valueSize=64/numRangeKeys=0-24         3.21MB/s ± 1%   3.27MB/s ± 2%   +1.99%  (p=0.024 n=5+5)
MVCCScan_Pebble/rows=1/versions=10/valueSize=64/numRangeKeys=1-24         2.11MB/s ± 2%   2.23MB/s ± 2%   +5.89%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1/versions=10/valueSize=64/numRangeKeys=100-24        410kB/s ± 2%    688kB/s ± 2%  +67.80%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1/versions=100/valueSize=64/numRangeKeys=0-24        1.55MB/s ± 1%   1.65MB/s ± 2%   +6.19%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1/versions=100/valueSize=64/numRangeKeys=1-24        1.26MB/s ± 2%   1.33MB/s ± 3%   +5.87%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1/versions=100/valueSize=64/numRangeKeys=100-24       460kB/s ± 0%    536kB/s ± 3%  +16.52%  (p=0.016 n=4+5)
MVCCScan_Pebble/rows=10/versions=1/valueSize=64/numRangeKeys=0-24         41.4MB/s ± 2%   41.2MB/s ± 2%     ~     (p=0.516 n=5+5)
MVCCScan_Pebble/rows=10/versions=1/valueSize=64/numRangeKeys=1-24         26.5MB/s ± 2%   27.1MB/s ± 1%   +2.42%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10/versions=1/valueSize=64/numRangeKeys=100-24       5.37MB/s ± 2%   6.17MB/s ± 1%  +14.74%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10/versions=2/valueSize=64/numRangeKeys=0-24         32.7MB/s ± 2%   31.5MB/s ± 3%   -3.51%  (p=0.032 n=5+5)
MVCCScan_Pebble/rows=10/versions=2/valueSize=64/numRangeKeys=1-24         21.4MB/s ± 0%   21.6MB/s ± 1%   +1.18%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10/versions=2/valueSize=64/numRangeKeys=100-24       5.88MB/s ± 1%   6.74MB/s ± 0%  +14.51%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10/versions=10/valueSize=64/numRangeKeys=0-24        17.2MB/s ± 2%   18.5MB/s ± 1%   +7.73%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10/versions=10/valueSize=64/numRangeKeys=1-24        11.6MB/s ± 2%   13.2MB/s ± 2%  +13.93%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10/versions=10/valueSize=64/numRangeKeys=100-24      4.56MB/s ± 1%   5.58MB/s ± 1%  +22.36%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10/versions=100/valueSize=64/numRangeKeys=0-24       6.79MB/s ± 3%   7.50MB/s ± 2%  +10.45%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10/versions=100/valueSize=64/numRangeKeys=1-24       5.53MB/s ± 2%   6.31MB/s ± 2%  +13.95%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10/versions=100/valueSize=64/numRangeKeys=100-24     2.94MB/s ± 1%   3.54MB/s ± 1%  +20.27%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=0-24         125MB/s ± 1%    124MB/s ± 1%     ~     (p=0.548 n=5+5)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=1-24        84.2MB/s ± 3%   86.1MB/s ± 2%     ~     (p=0.222 n=5+5)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=100-24      33.7MB/s ± 3%   38.0MB/s ± 1%  +12.83%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=100/versions=2/valueSize=64/numRangeKeys=0-24        92.7MB/s ± 1%   94.5MB/s ± 1%   +1.90%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=100/versions=2/valueSize=64/numRangeKeys=1-24        62.5MB/s ± 1%   65.4MB/s ± 1%   +4.75%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=100/versions=2/valueSize=64/numRangeKeys=100-24      32.0MB/s ± 1%   36.4MB/s ± 1%  +13.51%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=100/versions=10/valueSize=64/numRangeKeys=0-24       36.5MB/s ± 3%   41.3MB/s ± 4%  +13.05%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=100/versions=10/valueSize=64/numRangeKeys=1-24       23.7MB/s ± 2%   30.8MB/s ± 2%  +29.93%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=100/versions=10/valueSize=64/numRangeKeys=100-24     15.8MB/s ± 1%   21.3MB/s ± 2%  +34.67%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=100/versions=100/valueSize=64/numRangeKeys=0-24      11.1MB/s ± 1%   12.6MB/s ± 2%  +13.08%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=100/versions=100/valueSize=64/numRangeKeys=1-24      9.06MB/s ± 2%  11.08MB/s ± 2%  +22.29%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=100/versions=100/valueSize=64/numRangeKeys=100-24    6.65MB/s ± 1%   8.91MB/s ± 2%  +33.95%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1000/versions=1/valueSize=64/numRangeKeys=0-24        175MB/s ± 2%    176MB/s ± 2%     ~     (p=0.421 n=5+5)
MVCCScan_Pebble/rows=1000/versions=1/valueSize=64/numRangeKeys=1-24        120MB/s ± 1%    124MB/s ± 1%   +3.59%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1000/versions=1/valueSize=64/numRangeKeys=100-24     81.3MB/s ± 2%   87.5MB/s ± 1%   +7.62%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1000/versions=2/valueSize=64/numRangeKeys=0-24        122MB/s ± 1%    132MB/s ± 2%   +7.88%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1000/versions=2/valueSize=64/numRangeKeys=1-24       82.5MB/s ± 2%   90.5MB/s ± 2%   +9.70%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1000/versions=2/valueSize=64/numRangeKeys=100-24     65.2MB/s ± 1%   72.0MB/s ± 1%  +10.41%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1000/versions=10/valueSize=64/numRangeKeys=0-24      42.9MB/s ± 1%   50.2MB/s ± 2%  +17.02%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1000/versions=10/valueSize=64/numRangeKeys=1-24      27.3MB/s ± 1%   36.7MB/s ± 1%  +34.49%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1000/versions=10/valueSize=64/numRangeKeys=100-24    21.4MB/s ± 3%   31.4MB/s ± 4%  +46.71%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1000/versions=100/valueSize=64/numRangeKeys=0-24     12.5MB/s ± 3%   14.6MB/s ± 5%  +16.55%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1000/versions=100/valueSize=64/numRangeKeys=1-24     10.3MB/s ± 4%   13.2MB/s ± 2%  +28.04%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1000/versions=100/valueSize=64/numRangeKeys=100-24   8.00MB/s ± 4%  11.47MB/s ± 4%  +43.25%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=0-24       193MB/s ± 2%    197MB/s ± 1%   +2.33%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=1-24       130MB/s ± 2%    133MB/s ± 1%   +2.05%  (p=0.032 n=5+5)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=100-24     104MB/s ± 2%    108MB/s ± 1%   +3.41%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10000/versions=2/valueSize=64/numRangeKeys=0-24       137MB/s ± 1%    143MB/s ± 2%   +4.14%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10000/versions=2/valueSize=64/numRangeKeys=1-24      89.4MB/s ± 2%   95.8MB/s ± 0%   +7.10%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10000/versions=2/valueSize=64/numRangeKeys=100-24    77.3MB/s ± 2%   82.3MB/s ± 2%   +6.47%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10000/versions=10/valueSize=64/numRangeKeys=0-24     44.9MB/s ± 1%   52.7MB/s ± 3%  +17.30%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10000/versions=10/valueSize=64/numRangeKeys=1-24     28.6MB/s ± 2%   39.0MB/s ± 5%  +36.19%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10000/versions=10/valueSize=64/numRangeKeys=100-24   22.6MB/s ± 7%   34.5MB/s ± 5%  +52.68%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10000/versions=100/valueSize=64/numRangeKeys=0-24    13.2MB/s ± 3%   15.2MB/s ± 4%  +15.51%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10000/versions=100/valueSize=64/numRangeKeys=1-24    10.5MB/s ± 4%   13.4MB/s ± 2%  +27.11%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10000/versions=100/valueSize=64/numRangeKeys=100-24  8.13MB/s ± 6%  11.87MB/s ± 3%  +45.98%  (p=0.008 n=5+5)
```

Informs cockroachdb/cockroach#83049.