### PR TITLE
manifest: make `FileMetadata.Compacting` an enum

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1266,7 +1266,7 @@ func TestManualCompaction(t *testing.T) {
 		for _, cl := range ongoingCompaction.inputs {
 			iter := cl.files.Iter()
 			for f := iter.First(); f != nil; f = iter.Next() {
-				f.Compacting = true
+				f.CompactionState = manifest.CompactionStateCompacting
 			}
 		}
 		d.mu.compact.inProgress[ongoingCompaction] = struct{}{}
@@ -1279,7 +1279,7 @@ func TestManualCompaction(t *testing.T) {
 		for _, cl := range ongoingCompaction.inputs {
 			iter := cl.files.Iter()
 			for f := iter.First(); f != nil; f = iter.Next() {
-				f.Compacting = false
+				f.CompactionState = manifest.CompactionStateNotCompacting
 			}
 		}
 		delete(d.mu.compact.inProgress, ongoingCompaction)

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -79,7 +79,7 @@ func TestL0Sublevels_LargeImportL0(t *testing.T) {
 		var files []*FileMetadata
 		for i := range c.Files {
 			if c.FilesIncluded[i] {
-				c.Files[i].Compacting = true
+				c.Files[i].CompactionState = CompactionStateCompacting
 				files = append(files, c.Files[i])
 			}
 		}
@@ -98,7 +98,7 @@ func TestL0Sublevels_LargeImportL0(t *testing.T) {
 		var files []*FileMetadata
 		for i := range c.Files {
 			if c.FilesIncluded[i] {
-				c.Files[i].Compacting = true
+				c.Files[i].CompactionState = CompactionStateCompacting
 				c.Files[i].IsIntraL0Compacting = true
 				files = append(files, c.Files[i])
 			}
@@ -132,14 +132,14 @@ func visualizeSublevels(
 			if isL0 {
 				if compactionFiles[f.L0Index] {
 					middleChar = '+'
-				} else if f.Compacting {
+				} else if f.IsCompacting() {
 					if f.IsIntraL0Compacting {
 						middleChar = '^'
 					} else {
 						middleChar = 'v'
 					}
 				}
-			} else if f.Compacting {
+			} else if f.IsCompacting() {
 				middleChar = '='
 			}
 			if largestChar < f.Largest.UserKey[0] {
@@ -236,12 +236,12 @@ func TestL0Sublevels(t *testing.T) {
 				switch parts[0] {
 				case "base_compacting":
 					m.IsIntraL0Compacting = false
-					m.Compacting = true
+					m.CompactionState = CompactionStateCompacting
 				case "intra_l0_compacting":
 					m.IsIntraL0Compacting = true
-					m.Compacting = true
+					m.CompactionState = CompactionStateCompacting
 				case "compacting":
-					m.Compacting = true
+					m.CompactionState = CompactionStateCompacting
 				case "size":
 					sizeInt, err := strconv.Atoi(parts[1])
 					if err != nil {
@@ -522,7 +522,7 @@ func TestL0Sublevels(t *testing.T) {
 			for _, num := range fileNums {
 				for _, f := range fileMetas[0] {
 					if f.FileNum == num {
-						f.Compacting = true
+						f.CompactionState = CompactionStateCompacting
 						files = append(files, f)
 						break
 					}


### PR DESCRIPTION
Currently, the boolean field `FileMetadata.Compcting` tracks the
compaction status of a file. Given the boolean nature of the field, a
file is modeled as either compacting or not compacting.

The compaction state of a file can also be modeled as a state machine. A
file starts in a "not-compacting" state, and typically transitions into
a "compacting" state when selected by the compaction picker. Compacted
files typically transition into a terminal "compacted" state, after
which the file is removed from the LSM as it becomes obsolete. A notable
exception to the terminal state is for move-compactions, where a file
becomes eligible for subsequent compactions after it has been moved,
transitioning back into a "not-compacting" state. There also exists a
pre-compaction state, where a file has been marked for compaction, but
has not yet been selected by the compaction picker.

Replace the `Compacting` field with an enum, `CompactionState`. A file
starts in a `NotCompacting` state, and can transition immediately into a
`Compacting` state, or indirectly into `Compacting` by way of
`NeedsCompaction`, if the file has been marked. A file, once compacted,
will move into the terminal `Compacted` state, unless the file was
move-compacted, in which case it transitions back into the initial
`NeedsCompaction` state.

The enum, like its boolean predecessor, is not persisted to the
manifest. Instead, it is valid for the process lifetime, and is
re-hydrated when the DB is opened.

Set the `NeedsCompaction` state when scanning the LSM on DB open as part
of the `FormatSplitUserKeysMarked` migration. This simplifies the logic
and lowers the time taken to mark the files, as a file's compaction
state can be set directly while holding the `DB.mu`, rather than
searching the level again for the file. This also caters for case in
which a file has been moved-compacted to a lower level, as the
`*FileMetadata` pointer still provides a handle on the same file.