### PR TITLE
internal/rangekey: enforce iterator bounds beneath defragmentation

### DIFF
--- a/db.go
+++ b/db.go
@@ -1002,6 +1002,8 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 				dbi.rangeKey = iterRangeKeyStateAllocPool.Get().(*iteratorRangeKeyState)
 				dbi.rangeKey.init(dbi.cmp, dbi.split, &dbi.opts)
 				dbi.constructRangeKeyIter()
+			} else {
+				dbi.rangeKey.iterConfig.SetBounds(dbi.opts.LowerBound, dbi.opts.UpperBound)
 			}
 
 			// Wrap the point iterator (currently dbi.iter) with an interleaving

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -150,6 +150,7 @@ func finishInitializingExternal(it *Iterator) {
 			it.rangeKey.rangeKeyIter = it.rangeKey.iterConfig.Init(
 				it.cmp,
 				base.InternalKeySeqNumMax,
+				it.opts.LowerBound, it.opts.UpperBound,
 			)
 			for _, r := range it.externalReaders {
 				if rki, err := r.NewRawRangeKeyIter(); err != nil {

--- a/internal/keyspan/bounded.go
+++ b/internal/keyspan/bounded.go
@@ -1,0 +1,171 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package keyspan
+
+import "github.com/cockroachdb/pebble/internal/base"
+
+// TODO(jackson): Consider removing this type and adding bounds enforcement
+// directly to the MergingIter. This type is probably too lightweight to warrant
+// its own type, but for now we implement it separately for expediency.
+
+// boundedIterPos records the position of the BoundedIter relative to the
+// underlying iterator's position. It's used to avoid Next/Prev-ing the iterator
+// if there can't possibly be another span within bounds, because the current
+// span overlaps the bound.
+//
+// Imagine bounds [a,c) and an iterator that seeks to a span [b,d). The span
+// [b,d) overlaps some portion of the iterator bounds, so the iterator must
+// return it. If the iterator is subsequently Nexted, Next can tell that the
+// iterator is exhausted without advancing the underlying iterator because the
+// current span's end bound of d is ≥ the upper bound of c. In this case, the
+// bounded iterator returns nil and records i.pos as posAtUpperLimit to remember
+// that the underlying iterator position does not match the current BoundedIter
+// position.
+type boundedIterPos int8
+
+const (
+	posAtLowerLimit boundedIterPos = -1
+	posAtIterSpan   boundedIterPos = 0
+	posAtUpperLimit boundedIterPos = +1
+)
+
+// BoundedIter implements FragmentIterator and enforces bounds.
+type BoundedIter struct {
+	iter     FragmentIterator
+	iterSpan *Span
+	cmp      base.Compare
+	lower    []byte
+	upper    []byte
+	pos      boundedIterPos
+}
+
+// Init initializes the bounded iterator.
+func (i *BoundedIter) Init(cmp base.Compare, iter FragmentIterator, lower, upper []byte) {
+	*i = BoundedIter{
+		iter:  iter,
+		cmp:   cmp,
+		lower: lower,
+		upper: upper,
+	}
+}
+
+var _ FragmentIterator = (*BoundedIter)(nil)
+
+// SeekGE implements FragmentIterator.
+func (i *BoundedIter) SeekGE(key []byte) *Span {
+	return i.checkForwardBound(i.iter.SeekGE(key))
+}
+
+// SeekLT implements FragmentIterator.
+func (i *BoundedIter) SeekLT(key []byte) *Span {
+	return i.checkBackwardBound(i.iter.SeekLT(key))
+}
+
+// First implements FragmentIterator.
+func (i *BoundedIter) First() *Span {
+	return i.checkForwardBound(i.iter.First())
+}
+
+// Last implements FragmentIterator.
+func (i *BoundedIter) Last() *Span {
+	return i.checkBackwardBound(i.iter.Last())
+}
+
+// Next implements FragmentIterator.
+func (i *BoundedIter) Next() *Span {
+	switch i.pos {
+	case posAtLowerLimit:
+		// The BoundedIter had previously returned nil, because it knew from
+		// i.iterSpan's bounds that there was no previous span. To Next, we only
+		// need to return the current iter span and reset i.pos to reflect that
+		// we're no longer positioned at the limit.
+		i.pos = posAtIterSpan
+		return i.iterSpan
+	case posAtIterSpan:
+		// If the span at the underlying iterator position extends to or beyond the
+		// upper bound, we can avoid advancing because the next span is necessarily
+		// out of bounds.
+		if i.iterSpan != nil && i.upper != nil && i.cmp(i.iterSpan.End, i.upper) >= 0 {
+			i.pos = posAtUpperLimit
+			return nil
+		}
+		return i.checkForwardBound(i.iter.Next())
+	case posAtUpperLimit:
+		// Already exhausted.
+		return nil
+	default:
+		panic("unreachable")
+	}
+}
+
+// Prev implements FragmentIterator.
+func (i *BoundedIter) Prev() *Span {
+	switch i.pos {
+	case posAtLowerLimit:
+		// Already exhausted.
+		return nil
+	case posAtIterSpan:
+		// If the span at the underlying iterator position extends to or beyond
+		// the lower bound, we can avoid advancing because the previous span is
+		// necessarily out of bounds.
+		if i.iterSpan != nil && i.lower != nil && i.cmp(i.iterSpan.Start, i.lower) <= 0 {
+			i.pos = posAtLowerLimit
+			return nil
+		}
+		return i.checkBackwardBound(i.iter.Prev())
+	case posAtUpperLimit:
+		// The BoundedIter had previously returned nil, because it knew from
+		// i.iterSpan's bounds that there was no next span. To Prev, we only
+		// need to return the current iter span and reset i.pos to reflect that
+		// we're no longer positioned at the limit.
+		i.pos = posAtIterSpan
+		return i.iterSpan
+	default:
+		panic("unreachable")
+	}
+}
+
+// Error implements FragmentIterator.
+func (i *BoundedIter) Error() error {
+	return i.iter.Error()
+}
+
+// Close implements FragmentIterator.
+func (i *BoundedIter) Close() error {
+	return i.iter.Close()
+}
+
+// SetBounds modifies the FragmentIterator's bounds.
+func (i *BoundedIter) SetBounds(lower, upper []byte) {
+	i.lower, i.upper = lower, upper
+}
+
+// checkForwardBound enforces the upper bound, returning nil if the provided
+// span is wholly outside the upper bound. It also updates i.pos and i.iterSpan
+// to reflect the new iterator position.
+func (i *BoundedIter) checkForwardBound(span *Span) *Span {
+	if span != nil && i.upper != nil && i.cmp(span.Start, i.upper) >= 0 {
+		span = nil
+	}
+	i.iterSpan = span
+	if i.pos != posAtIterSpan {
+		i.pos = posAtIterSpan
+	}
+	return span
+}
+
+// checkBackward enforces the lower bound, returning nil if the provided span is
+// wholly outside the lower bound.  It also updates i.pos and i.iterSpan to
+// reflect the new iterator position.
+func (i *BoundedIter) checkBackwardBound(span *Span) *Span {
+	if span != nil && i.lower != nil && i.cmp(span.End, i.lower) <= 0 {
+		span = nil
+	}
+	i.iterSpan = span
+	if i.pos != posAtIterSpan {
+		i.pos = posAtIterSpan
+	}
+	return span
+}

--- a/internal/keyspan/bounded_test.go
+++ b/internal/keyspan/bounded_test.go
@@ -1,0 +1,89 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package keyspan
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoundedIter(t *testing.T) {
+	getBounds := func(td *datadriven.TestData) (lower, upper []byte, ok bool) {
+		for _, cmdArg := range td.CmdArgs {
+			switch cmdArg.Key {
+			case "lower":
+				if len(cmdArg.Vals[0]) > 0 {
+					lower = []byte(cmdArg.Vals[0])
+				}
+				ok = true
+			case "upper":
+				if len(cmdArg.Vals[0]) > 0 {
+					upper = []byte(cmdArg.Vals[0])
+				}
+				ok = true
+			}
+		}
+		return lower, upper, ok
+	}
+
+	cmp := testkeys.Comparer.Compare
+	var buf bytes.Buffer
+	var iter BoundedIter
+	datadriven.RunTest(t, "testdata/bounded_iter", func(td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "define":
+			var spans []Span
+			lines := strings.Split(strings.TrimSpace(td.Input), "\n")
+			for _, line := range lines {
+				spans = append(spans, ParseSpan(line))
+			}
+			inner := &invalidatingIter{iter: NewIter(cmp, spans)}
+			lower, upper, _ := getBounds(td)
+			iter.Init(cmp, inner, lower, upper)
+			return ""
+		case "iter":
+			buf.Reset()
+			if lower, upper, ok := getBounds(td); ok {
+				iter.SetBounds(lower, upper)
+			}
+
+			lines := strings.Split(strings.TrimSpace(td.Input), "\n")
+			for _, line := range lines {
+				line = strings.TrimSpace(line)
+				i := strings.IndexByte(line, ' ')
+				iterCmd := line
+				if i > 0 {
+					iterCmd = string(line[:i])
+				}
+				switch iterCmd {
+				case "first":
+					fmt.Fprintln(&buf, iter.First())
+				case "last":
+					fmt.Fprintln(&buf, iter.Last())
+				case "next":
+					fmt.Fprintln(&buf, iter.Next())
+				case "prev":
+					fmt.Fprintln(&buf, iter.Prev())
+				case "seek-ge":
+					fmt.Fprintln(&buf, iter.SeekGE([]byte(strings.TrimSpace(line[i:]))))
+				case "seek-lt":
+					fmt.Fprintln(&buf, iter.SeekLT([]byte(strings.TrimSpace(line[i:]))))
+				default:
+					return fmt.Sprintf("unrecognized iter command %q", iterCmd)
+				}
+				require.NoError(t, iter.Error())
+			}
+			return strings.TrimSpace(buf.String())
+		default:
+			return fmt.Sprintf("unrecognized command %q", td.Cmd)
+		}
+	})
+}

--- a/internal/keyspan/interleaving_iter.go
+++ b/internal/keyspan/interleaving_iter.go
@@ -981,6 +981,7 @@ func (i *InterleavingIter) Span() *Span {
 func (i *InterleavingIter) SetBounds(lower, upper []byte) {
 	i.lower, i.upper = lower, upper
 	i.pointIter.SetBounds(lower, upper)
+	i.Invalidate()
 }
 
 // Invalidate invalidates the interleaving iterator's current position, clearing

--- a/internal/keyspan/testdata/bounded_iter
+++ b/internal/keyspan/testdata/bounded_iter
@@ -1,0 +1,117 @@
+define
+a-b:{(#10,RANGEKEYSET,@5,apples)}
+d-e:{(#4,RANGEKEYSET,@3,coconut)}
+g-h:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
+----
+
+# Nothing out of bounds.
+
+iter lower=a upper=z
+first
+next
+next
+next
+last
+prev
+prev
+prev
+----
+a-b:{(#10,RANGEKEYSET,@5,apples)}
+d-e:{(#4,RANGEKEYSET,@3,coconut)}
+g-h:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
+<nil>
+g-h:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
+d-e:{(#4,RANGEKEYSET,@3,coconut)}
+a-b:{(#10,RANGEKEYSET,@5,apples)}
+<nil>
+
+# Test out of upper bound, but undiscovered until we Next.
+
+iter lower=a upper=f
+first
+next
+next
+prev
+----
+a-b:{(#10,RANGEKEYSET,@5,apples)}
+d-e:{(#4,RANGEKEYSET,@3,coconut)}
+<nil>
+d-e:{(#4,RANGEKEYSET,@3,coconut)}
+
+# Test out of upper bound, but discovered before we Next.
+
+iter lower=a upper=dog
+first
+next
+next
+prev
+----
+a-b:{(#10,RANGEKEYSET,@5,apples)}
+d-e:{(#4,RANGEKEYSET,@3,coconut)}
+<nil>
+d-e:{(#4,RANGEKEYSET,@3,coconut)}
+
+# Test out of lower bound, but undiscovered until we Prev.
+
+iter lower=c upper=z
+last
+prev
+prev
+next
+----
+g-h:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
+d-e:{(#4,RANGEKEYSET,@3,coconut)}
+<nil>
+d-e:{(#4,RANGEKEYSET,@3,coconut)}
+
+# Test out of lower bound, but discovered before we Prev.
+
+iter lower=d upper=z
+last
+prev
+prev
+next
+----
+g-h:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
+d-e:{(#4,RANGEKEYSET,@3,coconut)}
+<nil>
+d-e:{(#4,RANGEKEYSET,@3,coconut)}
+
+# Test a single span ([b-g)) within the bounds, overlapping on both ends.
+
+define
+a-b:{(#10,RANGEKEYSET,@5)}
+b-g:{(#4,RANGEKEYSET,@3)}
+g-h:{(#20,RANGEKEYSET,@5)}
+----
+
+iter lower=c upper=f
+seek-ge b
+next
+next
+seek-ge b
+prev
+prev
+seek-lt f
+prev
+prev
+seek-lt f
+next
+next
+prev
+prev
+----
+b-g:{(#4,RANGEKEYSET,@3)}
+<nil>
+<nil>
+b-g:{(#4,RANGEKEYSET,@3)}
+<nil>
+<nil>
+b-g:{(#4,RANGEKEYSET,@3)}
+<nil>
+<nil>
+b-g:{(#4,RANGEKEYSET,@3)}
+<nil>
+<nil>
+b-g:{(#4,RANGEKEYSET,@3)}
+<nil>

--- a/internal/rangekey/coalesce_test.go
+++ b/internal/rangekey/coalesce_test.go
@@ -134,7 +134,8 @@ func TestDefragmenting(t *testing.T) {
 			return ""
 		case "iter":
 			var userIterCfg UserIteratorConfig
-			iter := userIterCfg.Init(cmp, base.InternalKeySeqNumMax, keyspan.NewIter(cmp, spans))
+			iter := userIterCfg.Init(cmp, base.InternalKeySeqNumMax,
+				nil /* lower */, nil /* upper */, keyspan.NewIter(cmp, spans))
 			for _, line := range strings.Split(td.Input, "\n") {
 				runIterOp(&buf, iter, line)
 			}
@@ -213,8 +214,10 @@ func testDefragmentingIteRandomizedOnce(t *testing.T, seed int64) {
 	fragmented = fragment(cmp, formatKey, fragmented)
 
 	var referenceCfg, fragmentedCfg UserIteratorConfig
-	referenceIter := referenceCfg.Init(cmp, base.InternalKeySeqNumMax, keyspan.NewIter(cmp, original))
-	fragmentedIter := fragmentedCfg.Init(cmp, base.InternalKeySeqNumMax, keyspan.NewIter(cmp, fragmented))
+	referenceIter := referenceCfg.Init(cmp, base.InternalKeySeqNumMax,
+		nil /* lower */, nil /* upper */, keyspan.NewIter(cmp, original))
+	fragmentedIter := fragmentedCfg.Init(cmp, base.InternalKeySeqNumMax,
+		nil /* lower */, nil /* upper */, keyspan.NewIter(cmp, fragmented))
 
 	// Generate 100 random operations and run them against both iterators.
 	const numIterOps = 100

--- a/iterator.go
+++ b/iterator.go
@@ -1828,6 +1828,14 @@ func (i *Iterator) SetBounds(lower, upper []byte) {
 	if i.pointIter != nil && !i.opts.pointKeys() {
 		i.pointIter.SetBounds(i.opts.LowerBound, i.opts.UpperBound)
 	}
+	// If the iterator has a range key iterator, propagate bounds to it. The
+	// top-level SetBounds on the interleaving iterator (i.iter) won't propagate
+	// bounds to the range key iterator stack, because the FragmentIterator
+	// interface doesn't define a SetBounds method. We need to directly inform
+	// the iterConfig stack.
+	if i.rangeKey != nil {
+		i.rangeKey.iterConfig.SetBounds(i.opts.LowerBound, i.opts.UpperBound)
+	}
 
 	// Even though this is not a positioning operation, the alteration of the
 	// bounds means we cannot optimize Seeks by using Next.
@@ -2030,6 +2038,9 @@ func (i *Iterator) SetOptions(o *IterOptions) {
 		// because i.opts now point to buffers owned by Pebble.
 		if i.pointIter != nil {
 			i.pointIter.SetBounds(i.opts.LowerBound, i.opts.UpperBound)
+		}
+		if i.rangeKey != nil {
+			i.rangeKey.iterConfig.SetBounds(i.opts.LowerBound, i.opts.UpperBound)
 		}
 	}
 

--- a/range_keys.go
+++ b/range_keys.go
@@ -15,7 +15,7 @@ import (
 // constructRangeKeyIter constructs the range-key iterator stack, populating
 // i.rangeKey.rangeKeyIter with the resulting iterator.
 func (i *Iterator) constructRangeKeyIter() {
-	i.rangeKey.rangeKeyIter = i.rangeKey.iterConfig.Init(i.cmp, i.seqNum)
+	i.rangeKey.rangeKeyIter = i.rangeKey.iterConfig.Init(i.cmp, i.seqNum, i.opts.LowerBound, i.opts.UpperBound)
 
 	// If there's an indexed batch with range keys, include it.
 	if i.batch != nil {


### PR DESCRIPTION
Enforce iterator bounds beneath defragmentation to avoid unnecessary range-key
block loads.

```
name                             old time/op    new time/op    delta
CombinedIteratorSeek_Bounded-10    2.77ms ± 1%    0.05ms ± 2%  -98.23%  (p=0.000 n=10+20)

name                             old alloc/op   new alloc/op   delta
CombinedIteratorSeek_Bounded-10    1.79MB ± 0%    0.02MB ± 0%  -98.89%  (p=0.000 n=10+19)

name                             old allocs/op  new allocs/op  delta
CombinedIteratorSeek_Bounded-10     17.0k ± 0%      0.1k ± 0%  -99.28%  (p=0.000 n=10+20)
```

Close #1861.