### PR TITLE
db: add option to force memtable flush of range keys

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1468,7 +1468,7 @@ func (d *DB) passedFlushThreshold() bool {
 	return size >= minFlushSize
 }
 
-func (d *DB) maybeScheduleDelayedFlush(tbl *memTable) {
+func (d *DB) maybeScheduleDelayedFlush(tbl *memTable, dur time.Duration) {
 	var mem *flushableEntry
 	for _, m := range d.mu.mem.queue {
 		if m.flushable == tbl {
@@ -1476,12 +1476,17 @@ func (d *DB) maybeScheduleDelayedFlush(tbl *memTable) {
 			break
 		}
 	}
-	if mem == nil || mem.flushForced || mem.delayedFlushForced {
+	if mem == nil || mem.flushForced {
 		return
 	}
-	mem.delayedFlushForced = true
+	deadline := d.timeNow().Add(dur)
+	if !mem.delayedFlushForcedAt.IsZero() && deadline.After(mem.delayedFlushForcedAt) {
+		// Already scheduled to flush sooner than within `dur`.
+		return
+	}
+	mem.delayedFlushForcedAt = deadline
 	go func() {
-		timer := time.NewTimer(d.opts.Experimental.DeleteRangeFlushDelay)
+		timer := time.NewTimer(dur)
 		defer timer.Stop()
 
 		select {

--- a/flushable.go
+++ b/flushable.go
@@ -7,6 +7,7 @@ package pebble
 import (
 	"fmt"
 	"sync/atomic"
+	"time"
 
 	"github.com/cockroachdb/pebble/internal/keyspan"
 )
@@ -37,9 +38,10 @@ type flushableEntry struct {
 	// flushForced indicates whether a flush was forced on this memtable (either
 	// manual, or due to ingestion). Protected by DB.mu.
 	flushForced bool
-	// delayedFlushForced indicates whether a timer has been set to force a flush
-	// on this memtable at some point in the future. Protected by DB.mu
-	delayedFlushForced bool
+	// delayedFlushForcedAt indicates whether a timer has been set to force a
+	// flush on this memtable at some point in the future. Protected by DB.mu.
+	// Holds the timestamp of when the flush will be issued.
+	delayedFlushForcedAt time.Time
 	// logNum corresponds to the WAL that contains the records present in the
 	// receiver.
 	logNum FileNum

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/bloom"
@@ -253,7 +254,9 @@ func randomOptions(rng *rand.Rand) *testOptions {
 	opts.BytesPerSync = 1 << uint(rng.Intn(28))     // 1B - 256MB
 	opts.Cache = cache.New(1 << uint(rng.Intn(30))) // 1B - 1GB
 	opts.DisableWAL = rng.Intn(2) == 0
-	opts.FlushSplitBytes = 1 << rng.Intn(20) // 1B - 1MB
+	opts.FlushDelayDeleteRange = time.Millisecond * time.Duration(5*rng.Intn(245)) // 5-250ms
+	opts.FlushDelayRangeKey = time.Millisecond * time.Duration(5*rng.Intn(245))    // 5-250ms
+	opts.FlushSplitBytes = 1 << rng.Intn(20)                                       // 1B - 1MB
 	// The metamorphic test exercise range keys, so we cannot use an older
 	// FormatMajorVersion than pebble.FormatRangeKeys.
 	opts.FormatMajorVersion = pebble.FormatRangeKeys

--- a/options_test.go
+++ b/options_test.go
@@ -74,8 +74,9 @@ func TestOptionsString(t *testing.T) {
   cleaner=delete
   compaction_debt_concurrency=1073741824
   comparer=leveldb.BytewiseComparator
-  delete_range_flush_delay=0s
   disable_wal=false
+  flush_delay_delete_range=0s
+  flush_delay_range_key=0s
   flush_split_bytes=4194304
   format_major_version=1
   l0_compaction_concurrency=10
@@ -223,7 +224,8 @@ func TestOptionsParse(t *testing.T) {
 			opts.Levels[1].BlockSize = 2048
 			opts.Levels[2].BlockSize = 4096
 			opts.Experimental.CompactionDebtConcurrency = 100
-			opts.Experimental.DeleteRangeFlushDelay = 10 * time.Second
+			opts.FlushDelayDeleteRange = 10 * time.Second
+			opts.FlushDelayRangeKey = 11 * time.Second
 			opts.Experimental.MinDeletionRate = 200
 			opts.Experimental.ReadCompactionRate = 300
 			opts.Experimental.ReadSamplingMultiplier = 400

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -41,7 +41,7 @@ zmemtbl         1   256 K
 
 disk-usage
 ----
-1.9 K
+2.0 K
 
 batch
 set b 2


### PR DESCRIPTION
Add a new FlushDelayRangeKey option to force the flush of a memtable with range
keys within some duration. Range keys within the memtable can slow iteration,
especially when range keys are sparse, because they prevent lazy-combined
iteration.

Also, rename the existing Experimental.DeleteRangeFlushDelay option to
FlushDelayDeleteRange. It's been used in production for two years and is no longer
experimental. Also renaming it keeps the related FlushDelayRangeKey and FlushDelayDeleteRange options adjacent.

Close #1857.