### PR TITLE
db: add RangeKeyIteratorStats

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -119,6 +119,7 @@ type IteratorStats struct {
 	// ReverseStepCount includes Prev.
 	ReverseStepCount [NumStatsKind]int
 	InternalStats    InternalIteratorStats
+	RangeKeyStats    RangeKeyIteratorStats
 }
 
 var _ redact.SafeFormatter = &IteratorStats{}
@@ -126,6 +127,32 @@ var _ redact.SafeFormatter = &IteratorStats{}
 // InternalIteratorStats contains miscellaneous stats produced by internal
 // iterators.
 type InternalIteratorStats = base.InternalIteratorStats
+
+// RangeKeyIteratorStats contains miscellaneous stats about range keys
+// encountered by the iterator.
+type RangeKeyIteratorStats struct {
+	// Count records the number of range keys encountered during
+	// iteration. Range keys may be counted multiple times if the iterator
+	// leaves a range key's bounds and then returns.
+	Count int
+	// ContainedPoints records the number of point keys encountered within the
+	// bounds of a range key. Note that this includes point keys with suffixes
+	// that sort both above and below the covering range key's suffix.
+	ContainedPoints int
+	// SkippedPoints records the count of the subset of ContainedPoints point
+	// keys that were skipped during iteration due to range-key masking. It does
+	// not include point keys that were never loaded because a
+	// RangeKeyMasking.Filter excluded the entire containing block.
+	SkippedPoints int
+}
+
+// Merge adds all of the argument's statistics to the receiver. It may be used
+// to accumulate stats across multiple iterators.
+func (s *RangeKeyIteratorStats) Merge(o RangeKeyIteratorStats) {
+	s.Count += o.Count
+	s.ContainedPoints += o.ContainedPoints
+	s.SkippedPoints += o.SkippedPoints
+}
 
 // LazyValue is a lazy value. See the long comment in base.LazyValue.
 type LazyValue = base.LazyValue
@@ -1851,6 +1878,7 @@ func (i *Iterator) saveRangeKey() {
 		i.rangeKey.hasRangeKey = true
 		return
 	}
+	i.stats.RangeKeyStats.Count += len(s.Keys)
 	i.rangeKey.buf.Reset()
 	i.rangeKey.hasRangeKey = true
 	i.rangeKey.updated = true
@@ -2488,6 +2516,7 @@ func (stats *IteratorStats) Merge(o IteratorStats) {
 		stats.ReverseStepCount[i] += o.ReverseStepCount[i]
 	}
 	stats.InternalStats.Merge(o.InternalStats)
+	stats.RangeKeyStats.Merge(o.RangeKeyStats)
 }
 
 func (stats *IteratorStats) String() string {
@@ -2518,5 +2547,12 @@ func (stats *IteratorStats) SafeFormat(s redact.SafePrinter, verb rune) {
 			humanize.SI.Uint64(stats.InternalStats.ValueBytes),
 			humanize.SI.Uint64(stats.InternalStats.PointsCoveredByRangeTombstones),
 		)
+	}
+	if stats.RangeKeyStats != (RangeKeyIteratorStats{}) {
+		s.SafeString(",\n(range-key-stats: ")
+		s.Printf("(count %d), (contained points: (count %d, skipped %d)))",
+			stats.RangeKeyStats.Count,
+			stats.RangeKeyStats.ContainedPoints,
+			stats.RangeKeyStats.SkippedPoints)
 	}
 }

--- a/iterator_histories_test.go
+++ b/iterator_histories_test.go
@@ -6,6 +6,7 @@ package pebble
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -25,6 +27,12 @@ import (
 
 func TestIterHistories(t *testing.T) {
 	datadriven.Walk(t, "testdata/iter_histories", func(t *testing.T, path string) {
+		filename := filepath.Base(path)
+		switch {
+		case invariants.Enabled && strings.Contains(filename, "no_invariants"):
+			t.Skip("disabled when run with -tags invariants due to nondeterminism")
+		}
+
 		var d *DB
 		iters := map[string]*Iterator{}
 		batches := map[string]*Batch{}

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1701,6 +1701,11 @@ func TestIteratorStatsMerge(t *testing.T) {
 			PointCount:                     13,
 			PointsCoveredByRangeTombstones: 14,
 		},
+		RangeKeyStats: RangeKeyIteratorStats{
+			Count:           15,
+			ContainedPoints: 16,
+			SkippedPoints:   17,
+		},
 	}
 	s.Merge(IteratorStats{
 		ForwardSeekCount: [NumStatsKind]int{1, 2},
@@ -1715,6 +1720,11 @@ func TestIteratorStatsMerge(t *testing.T) {
 			PointCount:                     13,
 			PointsCoveredByRangeTombstones: 14,
 		},
+		RangeKeyStats: RangeKeyIteratorStats{
+			Count:           15,
+			ContainedPoints: 16,
+			SkippedPoints:   17,
+		},
 	})
 	require.Equal(t, IteratorStats{
 		ForwardSeekCount: [NumStatsKind]int{2, 4},
@@ -1728,6 +1738,11 @@ func TestIteratorStatsMerge(t *testing.T) {
 			ValueBytes:                     24,
 			PointCount:                     26,
 			PointsCoveredByRangeTombstones: 28,
+		},
+		RangeKeyStats: RangeKeyIteratorStats{
+			Count:           30,
+			ContainedPoints: 32,
+			SkippedPoints:   34,
 		},
 	}, s)
 }

--- a/range_keys.go
+++ b/range_keys.go
@@ -297,6 +297,7 @@ func (m *rangeKeyMasking) SpanChanged(s *keyspan.Span) {
 // Invariant: The userKey is within the user key bounds of the span most
 // recently provided to `SpanChanged`.
 func (m *rangeKeyMasking) SkipPoint(userKey []byte) bool {
+	m.parent.stats.RangeKeyStats.ContainedPoints++
 	if m.maskSpan == nil {
 		// No range key is currently acting as a mask, so don't skip.
 		return false
@@ -309,7 +310,11 @@ func (m *rangeKeyMasking) SkipPoint(userKey []byte) bool {
 	// the InterleavingIter). Skip the point key if the range key's suffix is
 	// greater than the point key's suffix.
 	pointSuffix := userKey[m.split(userKey):]
-	return len(pointSuffix) > 0 && m.cmp(m.maskActiveSuffix, pointSuffix) < 0
+	if len(pointSuffix) > 0 && m.cmp(m.maskActiveSuffix, pointSuffix) < 0 {
+		m.parent.stats.RangeKeyStats.SkippedPoints++
+		return true
+	}
+	return false
 }
 
 // The iteratorRangeKeyState type implements the sstable package's

--- a/testdata/iter_histories/range_key_masking
+++ b/testdata/iter_histories/range_key_masking
@@ -154,7 +154,8 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 1.1 K, cached 0 B)), (points: (count 25, key-bytes 75, value-bytes 75, tombstoned: 0))
+(internal-stats: (block-bytes: (total 1.1 K, cached 0 B)), (points: (count 25, key-bytes 75, value-bytes 75, tombstoned: 0)),
+(range-key-stats: (count 1), (contained points: (count 25, skipped 25)))
 
 # Repeat the above test, but with an iterator that uses a block-property filter
 # mask. The internal stats should reflect fewer bytes read and fewer points
@@ -168,7 +169,8 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 514 B, cached 514 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+(internal-stats: (block-bytes: (total 514 B, cached 514 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0)),
+(range-key-stats: (count 1), (contained points: (count 2, skipped 2)))
 
 # Perform a similar comparison in reverse.
 
@@ -180,7 +182,8 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 1.1 K, cached 1.1 K)), (points: (count 25, key-bytes 75, value-bytes 75, tombstoned: 0))
+(internal-stats: (block-bytes: (total 1.1 K, cached 1.1 K)), (points: (count 25, key-bytes 75, value-bytes 75, tombstoned: 0)),
+(range-key-stats: (count 1), (contained points: (count 25, skipped 25)))
 
 combined-iter mask-suffix=@9 mask-filter
 last
@@ -190,7 +193,8 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 514 B, cached 514 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+(internal-stats: (block-bytes: (total 514 B, cached 514 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0)),
+(range-key-stats: (count 1), (contained points: (count 2, skipped 2)))
 
 # Perform similar comparisons with seeks.
 
@@ -202,7 +206,8 @@ stats
 m: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 789 B, cached 789 B)), (points: (count 13, key-bytes 39, value-bytes 39, tombstoned: 0))
+(internal-stats: (block-bytes: (total 789 B, cached 789 B)), (points: (count 13, key-bytes 39, value-bytes 39, tombstoned: 0)),
+(range-key-stats: (count 1), (contained points: (count 13, skipped 13)))
 
 combined-iter mask-suffix=@9 mask-filter
 seek-ge m
@@ -212,7 +217,8 @@ stats
 m: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 514 B, cached 514 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+(internal-stats: (block-bytes: (total 514 B, cached 514 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0)),
+(range-key-stats: (count 1), (contained points: (count 2, skipped 2)))
 
 combined-iter mask-suffix=@9
 seek-lt m
@@ -222,7 +228,8 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 789 B, cached 789 B)), (points: (count 12, key-bytes 36, value-bytes 36, tombstoned: 0))
+(internal-stats: (block-bytes: (total 789 B, cached 789 B)), (points: (count 12, key-bytes 36, value-bytes 36, tombstoned: 0)),
+(range-key-stats: (count 1), (contained points: (count 12, skipped 12)))
 
 combined-iter mask-suffix=@9 mask-filter
 seek-lt m
@@ -232,4 +239,5 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 539 B, cached 539 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+(internal-stats: (block-bytes: (total 539 B, cached 539 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0)),
+(range-key-stats: (count 1), (contained points: (count 2, skipped 2)))

--- a/testdata/iter_histories/stats_no_invariants
+++ b/testdata/iter_histories/stats_no_invariants
@@ -1,0 +1,160 @@
+reset
+----
+
+# Use the key string as the value so that it's easy to tell when we surface the
+# wrong value.
+
+batch commit
+set a a
+set b b
+set c c
+set d d
+range-key-set b   c   @5 boop
+range-key-set cat dog @3 beep
+----
+committed 6 keys
+
+flush
+----
+
+# Scan forward
+
+combined-iter
+stats
+seek-ge a
+next
+stats
+next
+next
+next
+next
+stats
+----
+stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 0, 0))
+a: (a, .)
+b: (b, [b-c) @5=boop UPDATED)
+stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 89 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0)),
+(range-key-stats: (count 1), (contained points: (count 1, skipped 0)))
+c: (c, . UPDATED)
+cat: (., [cat-dog) @3=beep UPDATED)
+d: (d, [cat-dog) @3=beep)
+.
+stats: (interface (dir, seek, step): (fwd, 1, 5), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 6), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 89 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0)),
+(range-key-stats: (count 2), (contained points: (count 2, skipped 0)))
+
+# Do the above forward iteration but with a mask suffix. The results should be
+# identical despite range keys serving as masks, because none of the point keys
+# have suffixes.
+
+combined-iter mask-suffix=@9
+seek-ge a
+next
+next
+next
+next
+next
+stats
+----
+a: (a, .)
+b: (b, [b-c) @5=boop UPDATED)
+c: (c, . UPDATED)
+cat: (., [cat-dog) @3=beep UPDATED)
+d: (d, [cat-dog) @3=beep)
+.
+stats: (interface (dir, seek, step): (fwd, 1, 5), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 6), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 89 B, cached 89 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0)),
+(range-key-stats: (count 2), (contained points: (count 2, skipped 0)))
+
+# Scan backward
+
+combined-iter
+seek-lt z
+prev
+prev
+prev
+prev
+prev
+stats
+----
+d: (d, [cat-dog) @3=beep UPDATED)
+cat: (., [cat-dog) @3=beep)
+c: (c, . UPDATED)
+b: (b, [b-c) @5=boop UPDATED)
+a: (a, . UPDATED)
+.
+stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 5)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 6)),
+(internal-stats: (block-bytes: (total 89 B, cached 89 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0)),
+(range-key-stats: (count 2), (contained points: (count 2, skipped 0)))
+
+combined-iter
+seek-ge ace
+seek-ge b
+seek-ge c
+seek-ge cab
+seek-ge cat
+seek-ge d
+seek-ge day
+seek-ge dog
+stats
+----
+b: (b, [b-c) @5=boop UPDATED)
+b: (b, [b-c) @5=boop)
+c: (c, . UPDATED)
+cat: (., [cat-dog) @3=beep UPDATED)
+cat: (., [cat-dog) @3=beep)
+d: (d, [cat-dog) @3=beep)
+day: (., [cat-dog) @3=beep)
+.
+stats: (interface (dir, seek, step): (fwd, 8, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 6, 4), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 89 B, cached 89 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0)),
+(range-key-stats: (count 2), (contained points: (count 3, skipped 0)))
+
+combined-iter
+seek-lt 1
+seek-lt ace
+seek-lt b
+seek-lt c
+seek-lt cab
+seek-lt cat
+seek-lt d
+seek-lt day
+seek-lt dog
+seek-lt zebra
+stats
+----
+.
+a: (a, .)
+a: (a, .)
+b: (b, [b-c) @5=boop UPDATED)
+c: (c, . UPDATED)
+c: (c, .)
+cat: (., [cat-dog) @3=beep UPDATED)
+d: (d, [cat-dog) @3=beep)
+d: (d, [cat-dog) @3=beep)
+d: (d, [cat-dog) @3=beep)
+stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 10, 0)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 10, 10)),
+(internal-stats: (block-bytes: (total 267 B, cached 267 B)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned: 0)),
+(range-key-stats: (count 2), (contained points: (count 6, skipped 0)))
+
+rangekey-iter
+first
+next
+next
+set-bounds lower=bat upper=catatonic
+first
+next
+next
+stats
+----
+b [b-c) @5=boop UPDATED
+cat [cat-dog) @3=beep UPDATED
+.
+.
+bat [bat-c) @5=boop UPDATED
+cat [cat-catatonic) @3=beep UPDATED
+.
+stats: (interface (dir, seek, step): (fwd, 2, 4), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 4), (rev, 0, 0)),
+(range-key-stats: (count 4), (contained points: (count 0, skipped 0)))
+


### PR DESCRIPTION
Expand the IteratorStats structure to include a few statistics about range
key iteration.

Close #1848.