### PR TITLE
.*: add maxLevel parameter to db.Compact

### DIFF
--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -68,7 +68,7 @@ func TestCheckpoint(t *testing.T) {
 			}
 			buf.Reset()
 			d := dbs[td.CmdArgs[0].String()]
-			if err := d.Compact(nil, []byte("\xff"), false); err != nil {
+			if err := d.Compact(nil, []byte("\xff"), false, 7 /* maxLevel */); err != nil {
 				return err.Error()
 			}
 			return buf.String()
@@ -163,7 +163,7 @@ func TestCheckpointCompaction(t *testing.T) {
 		defer cancel()
 		defer wg.Done()
 		for ctx.Err() == nil {
-			if err := d.Compact([]byte("key"), []byte("key999999"), false); err != nil {
+			if err := d.Compact([]byte("key"), []byte("key999999"), false, 7 /* maxLevel */); err != nil {
 				t.Error(err)
 				return
 			}

--- a/cleaner_test.go
+++ b/cleaner_test.go
@@ -54,7 +54,7 @@ func TestArchiveCleaner(t *testing.T) {
 			}
 			buf.Reset()
 			d := dbs[td.CmdArgs[0].String()]
-			if err := d.Compact(nil, []byte("\xff"), false); err != nil {
+			if err := d.Compact(nil, []byte("\xff"), false, 7 /* maxLevel */); err != nil {
 				return err.Error()
 			}
 			return buf.String()

--- a/cmd/pebble/compact.go
+++ b/cmd/pebble/compact.go
@@ -369,7 +369,7 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	if err := iter.Close(); err != nil {
 		return err
 	}
-	if err := d.Compact(first, last, false); err != nil {
+	if err := d.Compact(first, last, false, 7 /* maxLevel */); err != nil {
 		return err
 	}
 	afterSize := totalSize(d.Metrics())

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -914,7 +914,7 @@ func TestCompactionSlots(t *testing.T) {
 	defer d.Close()
 
 	d.Set([]byte{'a'}, []byte{'a'}, nil)
-	err = d.Compact([]byte{'a'}, []byte{'b'}, true)
+	err = d.Compact([]byte{'a'}, []byte{'b'}, true, 7 /* maxLevel */)
 	if err != nil {
 		t.Fatalf("Compact: %v", err)
 	}
@@ -2812,7 +2812,7 @@ func TestCompactionErrorCleanup(t *testing.T) {
 	d.mu.Lock()
 	initialSetupDone = true
 	d.mu.Unlock()
-	err = d.Compact([]byte("a"), []byte("d"), false)
+	err = d.Compact([]byte("a"), []byte("d"), false, 7 /* maxLevel */)
 	require.Error(t, err, "injected error")
 
 	d.mu.Lock()
@@ -3142,7 +3142,7 @@ func TestCompactFlushQueuedMemTableAndFlushMetrics(t *testing.T) {
 		}
 	}
 
-	require.NoError(t, d.Compact([]byte("a"), []byte("a\x00"), false))
+	require.NoError(t, d.Compact([]byte("a"), []byte("a\x00"), false, 7 /* maxLevel */))
 	d.mu.Lock()
 	require.Equal(t, 1, len(d.mu.mem.queue))
 	d.mu.Unlock()
@@ -3197,7 +3197,7 @@ func TestCompactFlushQueuedLargeBatch(t *testing.T) {
 	require.Greater(t, len(d.mu.mem.queue), 1)
 	d.mu.Unlock()
 
-	require.NoError(t, d.Compact([]byte("a"), []byte("a\x00"), false))
+	require.NoError(t, d.Compact([]byte("a"), []byte("a\x00"), false, 7 /* maxLevel */))
 	d.mu.Lock()
 	require.Equal(t, 1, len(d.mu.mem.queue))
 	d.mu.Unlock()
@@ -3319,9 +3319,9 @@ func TestCompactionInvalidBounds(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	defer db.Close()
-	require.NoError(t, db.Compact([]byte("a"), []byte("b"), false))
-	require.Error(t, db.Compact([]byte("a"), []byte("a"), false))
-	require.Error(t, db.Compact([]byte("b"), []byte("a"), false))
+	require.NoError(t, db.Compact([]byte("a"), []byte("b"), false, 7 /* maxLevel */))
+	require.Error(t, db.Compact([]byte("a"), []byte("a"), false, 7 /* maxLevel */))
+	require.Error(t, db.Compact([]byte("b"), []byte("a"), false, 7 /* maxLevel */))
 }
 
 func Test_calculateInuseKeyRanges(t *testing.T) {

--- a/data_test.go
+++ b/data_test.go
@@ -628,7 +628,7 @@ func runCompactCmd(td *datadriven.TestData, d *DB) error {
 		}
 		return d.manualCompact(iStart.UserKey, iEnd.UserKey, level, parallelize)
 	}
-	return d.Compact([]byte(parts[0]), []byte(parts[1]), parallelize)
+	return d.Compact([]byte(parts[0]), []byte(parts[1]), parallelize, 7 /* maxLevel */)
 }
 
 func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {

--- a/db_test.go
+++ b/db_test.go
@@ -891,7 +891,7 @@ func TestCacheEvict(t *testing.T) {
 		require.NoError(t, d.Delete(key, nil))
 	}
 
-	require.NoError(t, d.Compact([]byte("0"), []byte("1"), false))
+	require.NoError(t, d.Compact([]byte("0"), []byte("1"), false, 7 /* maxLevel */))
 
 	require.NoError(t, d.Close())
 
@@ -1004,7 +1004,7 @@ func TestDBClosed(t *testing.T) {
 
 	require.True(t, errors.Is(catch(func() { _ = d.Close() }), ErrClosed))
 
-	require.True(t, errors.Is(catch(func() { _ = d.Compact(nil, nil, false) }), ErrClosed))
+	require.True(t, errors.Is(catch(func() { _ = d.Compact(nil, nil, false, 7 /* maxLevel */) }), ErrClosed))
 	require.True(t, errors.Is(catch(func() { _ = d.Flush() }), ErrClosed))
 	require.True(t, errors.Is(catch(func() { _, _ = d.AsyncFlush() }), ErrClosed))
 
@@ -1043,7 +1043,7 @@ func TestDBConcurrentCommitCompactFlush(t *testing.T) {
 			var err error
 			switch i % 3 {
 			case 0:
-				err = d.Compact(nil, []byte("\xff"), false)
+				err = d.Compact(nil, []byte("\xff"), false, 7 /* maxLevel */)
 			case 1:
 				err = d.Flush()
 			case 2:
@@ -1147,7 +1147,7 @@ func TestCloseCleanerRace(t *testing.T) {
 		it := db.NewIter(nil)
 		require.NotNil(t, it)
 		require.NoError(t, db.DeleteRange([]byte("a"), []byte("b"), Sync))
-		require.NoError(t, db.Compact([]byte("a"), []byte("b"), false))
+		require.NoError(t, db.Compact([]byte("a"), []byte("b"), false, 7 /* maxLevel */))
 		// Only the iterator is keeping the sstables alive.
 		files, err := mem.List("/")
 		require.NoError(t, err)

--- a/error_test.go
+++ b/error_test.go
@@ -113,7 +113,7 @@ func TestErrors(t *testing.T) {
 		if err := d.Flush(); err != nil {
 			return err
 		}
-		if err := d.Compact(nil, []byte("\xff"), false); err != nil {
+		if err := d.Compact(nil, []byte("\xff"), false, 7 /* maxLevel */); err != nil {
 			return err
 		}
 
@@ -181,7 +181,7 @@ func TestRequireReadError(t *testing.T) {
 		require.NoError(t, d.Set(key1, value, nil))
 		require.NoError(t, d.Set(key2, value, nil))
 		require.NoError(t, d.Flush())
-		require.NoError(t, d.Compact(key1, key2, false))
+		require.NoError(t, d.Compact(key1, key2, false, 7 /* maxLevel */))
 		require.NoError(t, d.DeleteRange(key1, key2, nil))
 		require.NoError(t, d.Set(key1, value, nil))
 		require.NoError(t, d.Flush())
@@ -283,7 +283,7 @@ func TestCorruptReadError(t *testing.T) {
 		require.NoError(t, d.Set(key1, value, nil))
 		require.NoError(t, d.Set(key2, value, nil))
 		require.NoError(t, d.Flush())
-		require.NoError(t, d.Compact(key1, key2, false))
+		require.NoError(t, d.Compact(key1, key2, false, 7 /* maxLevel */))
 		require.NoError(t, d.DeleteRange(key1, key2, nil))
 		require.NoError(t, d.Set(key1, value, nil))
 		require.NoError(t, d.Flush())

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -189,7 +189,7 @@ func TestEventListener(t *testing.T) {
 			if err := d.Set([]byte("a"), nil, nil); err != nil {
 				return err.Error()
 			}
-			if err := d.Compact([]byte("a"), []byte("b"), false); err != nil {
+			if err := d.Compact([]byte("a"), []byte("b"), false, 7 /* maxLevel */); err != nil {
 				return err.Error()
 			}
 			return buf.String()

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -77,7 +77,7 @@ func testBasicDB(d *DB) error {
 	if err := d.Flush(); err != nil {
 		return err
 	}
-	if err := d.Compact(nil, []byte("\xff"), false); err != nil {
+	if err := d.Compact(nil, []byte("\xff"), false, 7 /* maxLevel */); err != nil {
 		return err
 	}
 

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -884,7 +884,7 @@ func TestConcurrentIngestCompact(t *testing.T) {
 
 			compact := func(start, end string) {
 				t.Helper()
-				require.NoError(t, d.Compact([]byte(start), []byte(end), false))
+				require.NoError(t, d.Compact([]byte(start), []byte(end), false, 7 /* maxLevel */))
 			}
 
 			lsm := func() string {

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -111,7 +111,7 @@ type compactOp struct {
 
 func (o *compactOp) run(t *test, h *history) {
 	err := withRetries(func() error {
-		return t.db.Compact(o.start, o.end, o.parallelize)
+		return t.db.Compact(o.start, o.end, o.parallelize, 7 /* maxLevel */)
 	})
 	h.Recordf("%s // %v", o, err)
 }

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -2094,7 +2094,7 @@ func BenchmarkBlockPropertyFilter(b *testing.B) {
 			}
 			require.NoError(b, batch.Commit(nil))
 			require.NoError(b, d.Flush())
-			require.NoError(b, d.Compact(nil, []byte{0xFF}, false))
+			require.NoError(b, d.Compact(nil, []byte{0xFF}, false, 7 /* maxLevel */))
 
 			for _, filter := range []bool{false, true} {
 				b.Run(fmt.Sprintf("filter=%t", filter), func(b *testing.B) {

--- a/open_test.go
+++ b/open_test.go
@@ -427,7 +427,7 @@ func TestOpenReadOnly(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify various write operations fail in read-only mode.
-		require.EqualValues(t, ErrReadOnly, d.Compact(nil, []byte("\xff"), false))
+		require.EqualValues(t, ErrReadOnly, d.Compact(nil, []byte("\xff"), false, 7 /* maxLevel */))
 		require.EqualValues(t, ErrReadOnly, d.Flush())
 		require.EqualValues(t, ErrReadOnly, func() error { _, err := d.AsyncFlush(); return err }())
 
@@ -892,7 +892,7 @@ func TestOpenWALReplayReadOnlySeqNums(t *testing.T) {
 	// written to the MANIFEST. This produces a MANIFEST where the `logSeqNum`
 	// is greater than the sequence numbers contained in the
 	// `minUnflushedLogNum` log file
-	require.NoError(t, d.Compact([]byte("a"), []byte("a\x00"), false))
+	require.NoError(t, d.Compact([]byte("a"), []byte("a\x00"), false, 7 /* maxLevel */))
 	d.mu.Lock()
 	for d.mu.compact.compactingCount > 0 {
 		d.mu.compact.cond.Wait()

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -204,7 +204,7 @@ func TestRangeDelCompactionTruncation(t *testing.T) {
 		require.NoError(t, d.DeleteRange([]byte("a"), []byte("d"), nil))
 
 		// Compact to produce the L1 tables.
-		require.NoError(t, d.Compact([]byte("c"), []byte("c\x00"), false))
+		require.NoError(t, d.Compact([]byte("c"), []byte("c\x00"), false, 7 /* maxLevel */))
 		expectLSM(`
 1:
   000008:[a#3,RANGEDEL-b#72057594037927935,RANGEDEL]
@@ -212,7 +212,7 @@ func TestRangeDelCompactionTruncation(t *testing.T) {
 `)
 
 		// Compact again to move one of the tables to L2.
-		require.NoError(t, d.Compact([]byte("c"), []byte("c\x00"), false))
+		require.NoError(t, d.Compact([]byte("c"), []byte("c\x00"), false, 7 /* maxLevel */))
 		expectLSM(`
 1:
   000008:[a#3,RANGEDEL-b#72057594037927935,RANGEDEL]
@@ -261,7 +261,7 @@ func TestRangeDelCompactionTruncation(t *testing.T) {
 		// containing "c" will be compacted again with the L2 table creating two
 		// tables in L2. Lastly, the L2 table containing "c" will be compacted
 		// creating the L3 table.
-		require.NoError(t, d.Compact([]byte("c"), []byte("c\x00"), false))
+		require.NoError(t, d.Compact([]byte("c"), []byte("c\x00"), false, 7 /* maxLevel */))
 		if formatVersion < FormatSetWithDelete {
 			expectLSM(`
 1:
@@ -354,14 +354,14 @@ func TestRangeDelCompactionTruncation2(t *testing.T) {
 	require.NoError(t, d.DeleteRange([]byte("a"), []byte("d"), nil))
 
 	// Compact to produce the L1 tables.
-	require.NoError(t, d.Compact([]byte("b"), []byte("b\x00"), false))
+	require.NoError(t, d.Compact([]byte("b"), []byte("b\x00"), false, 7 /* maxLevel */))
 	expectLSM(`
 6:
   000009:[a#3,RANGEDEL-d#72057594037927935,RANGEDEL]
 `)
 
 	require.NoError(t, d.Set([]byte("c"), bytes.Repeat([]byte("d"), 100), nil))
-	require.NoError(t, d.Compact([]byte("c"), []byte("c\x00"), false))
+	require.NoError(t, d.Compact([]byte("c"), []byte("c\x00"), false, 7 /* maxLevel */))
 	expectLSM(`
 6:
   000012:[a#3,RANGEDEL-c#72057594037927935,RANGEDEL]
@@ -427,7 +427,7 @@ func TestRangeDelCompactionTruncation3(t *testing.T) {
 
 	// Compact a few times to move the tables down to L3.
 	for i := 0; i < 3; i++ {
-		require.NoError(t, d.Compact([]byte("b"), []byte("b\x00"), false))
+		require.NoError(t, d.Compact([]byte("b"), []byte("b\x00"), false, 7 /* maxLevel */))
 	}
 	expectLSM(`
 3:
@@ -436,7 +436,7 @@ func TestRangeDelCompactionTruncation3(t *testing.T) {
 
 	require.NoError(t, d.Set([]byte("c"), bytes.Repeat([]byte("d"), 100), nil))
 
-	require.NoError(t, d.Compact([]byte("c"), []byte("c\x00"), false))
+	require.NoError(t, d.Compact([]byte("c"), []byte("c\x00"), false, 7 /* maxLevel */))
 	expectLSM(`
 3:
   000013:[a#3,RANGEDEL-c#72057594037927935,RANGEDEL]
@@ -444,7 +444,7 @@ func TestRangeDelCompactionTruncation3(t *testing.T) {
   000014:[c#4,SET-d#72057594037927935,RANGEDEL]
 `)
 
-	require.NoError(t, d.Compact([]byte("c"), []byte("c\x00"), false))
+	require.NoError(t, d.Compact([]byte("c"), []byte("c\x00"), false, 7 /* maxLevel */))
 	expectLSM(`
 3:
   000013:[a#3,RANGEDEL-c#72057594037927935,RANGEDEL]
@@ -456,7 +456,7 @@ func TestRangeDelCompactionTruncation3(t *testing.T) {
 		t.Fatalf("expected not found, but found %v", err)
 	}
 
-	require.NoError(t, d.Compact([]byte("a"), []byte("a\x00"), false))
+	require.NoError(t, d.Compact([]byte("a"), []byte("a\x00"), false, 7 /* maxLevel */))
 	expectLSM(`
 4:
   000013:[a#3,RANGEDEL-c#72057594037927935,RANGEDEL]
@@ -542,7 +542,7 @@ func benchmarkRangeDelIterate(b *testing.B, entries, deleted int, snapshotCompac
 	}
 
 	if snapshotCompact {
-		require.NoError(b, d.Compact(makeKey(0), makeKey(entries), false))
+		require.NoError(b, d.Compact(makeKey(0), makeKey(entries), false, 7 /* maxLevel */))
 	}
 
 	b.ResetTimer()

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -109,7 +109,7 @@ func TestSnapshot(t *testing.T) {
 					if len(keys) != 2 {
 						return fmt.Sprintf("malformed key range: %s", parts[1])
 					}
-					err = d.Compact([]byte(keys[0]), []byte(keys[1]), false)
+					err = d.Compact([]byte(keys[0]), []byte(keys[1]), false, 7 /* maxLevel */)
 				default:
 					return fmt.Sprintf("unknown op: %s", parts[0])
 				}

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -327,7 +327,7 @@ func TestSharedTableCacheUseAfterOneFree(t *testing.T) {
 	require.NoError(t, db2.Set(start, nil, nil))
 	require.NoError(t, db2.Flush())
 	require.NoError(t, db2.DeleteRange(start, end, nil))
-	require.NoError(t, db2.Compact(start, end, false))
+	require.NoError(t, db2.Compact(start, end, false, 7 /* maxLevel */))
 }
 
 // A basic test which makes sure that a shared table cache is usable
@@ -365,7 +365,7 @@ func TestSharedTableCacheUsable(t *testing.T) {
 	require.NoError(t, db1.Set(start, nil, nil))
 	require.NoError(t, db1.Flush())
 	require.NoError(t, db1.DeleteRange(start, end, nil))
-	require.NoError(t, db1.Compact(start, end, false))
+	require.NoError(t, db1.Compact(start, end, false, 7 /* maxLevel */))
 
 	start = []byte("x")
 	end = []byte("y")
@@ -374,7 +374,7 @@ func TestSharedTableCacheUsable(t *testing.T) {
 	require.NoError(t, db2.Set(start, []byte{'a'}, nil))
 	require.NoError(t, db2.Flush())
 	require.NoError(t, db2.DeleteRange(start, end, nil))
-	require.NoError(t, db2.Compact(start, end, false))
+	require.NoError(t, db2.Compact(start, end, false, 7 /* maxLevel */))
 }
 
 func TestSharedTableConcurrent(t *testing.T) {
@@ -417,7 +417,7 @@ func TestSharedTableConcurrent(t *testing.T) {
 			require.NoError(t, db.Set(start, nil, nil))
 			require.NoError(t, db.Flush())
 			require.NoError(t, db.DeleteRange(start, end, nil))
-			require.NoError(t, db.Compact(start, end, false))
+			require.NoError(t, db.Compact(start, end, false, 7 /* maxLevel */))
 		}
 		wg.Done()
 	}
@@ -843,7 +843,7 @@ func TestTableCacheEvictClose(t *testing.T) {
 	require.NoError(t, db.Set(start, nil, nil))
 	require.NoError(t, db.Flush())
 	require.NoError(t, db.DeleteRange(start, end, nil))
-	require.NoError(t, db.Compact(start, end, false))
+	require.NoError(t, db.Compact(start, end, false, 7 /* maxLevel */))
 	require.NoError(t, db.Close())
 	close(errs)
 

--- a/tool/make_test_find_db.go
+++ b/tool/make_test_find_db.go
@@ -124,7 +124,7 @@ func (d *db) flush() {
 }
 
 func (d *db) compact(start, end string) {
-	if err := d.db.Compact([]byte(start), []byte(end), false); err != nil {
+	if err := d.db.Compact([]byte(start), []byte(end), false, 7 /* maxLevel */); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
We want to be able to configure the depth of manual compactions.
This pr adds a maxLevel paramter to db.Compact. This will allow
manual compactions through cockroach to configure the level
upto which we want these compactions to occur.