### PR TITLE
db: add Metrics.Keys.RangeKeySetsCount

### DIFF
--- a/db.go
+++ b/db.go
@@ -1501,11 +1501,12 @@ func (d *DB) Metrics() *Metrics {
 	recycledLogsCount, recycledLogSize := d.logRecycler.stats()
 
 	d.mu.Lock()
+	vers := d.mu.versions.currentVersion()
 	*metrics = d.mu.versions.metrics
 	metrics.Compact.EstimatedDebt = d.mu.versions.picker.estimatedCompactionDebt(0)
 	metrics.Compact.InProgressBytes = atomic.LoadInt64(&d.mu.versions.atomic.atomicInProgressBytes)
 	metrics.Compact.NumInProgress = int64(d.mu.compact.compactingCount)
-	metrics.Compact.MarkedFiles = d.mu.versions.currentVersion().Stats.MarkedForCompaction
+	metrics.Compact.MarkedFiles = vers.Stats.MarkedForCompaction
 	for _, m := range d.mu.mem.queue {
 		metrics.MemTable.Size += m.totalBytes()
 	}
@@ -1548,6 +1549,8 @@ func (d *DB) Metrics() *Metrics {
 		metrics.Table.ZombieSize += size
 	}
 	metrics.private.optionsFileSize = d.optionsFileSize
+
+	metrics.Keys.RangeKeySetsCount = countRangeKeySetFragments(vers)
 
 	d.mu.versions.logLock()
 	metrics.private.manifestFileSize = uint64(d.mu.versions.manifest.Size())

--- a/metrics.go
+++ b/metrics.go
@@ -178,6 +178,11 @@ type Metrics struct {
 		ZombieCount int64
 	}
 
+	Keys struct {
+		// The approximate count of internal range key set keys in the database.
+		RangeKeySetsCount uint64
+	}
+
 	Snapshots struct {
 		// The number of currently open snapshots.
 		Count int

--- a/range_keys_test.go
+++ b/range_keys_test.go
@@ -114,6 +114,12 @@ func TestRangeKeys(t *testing.T) {
 			return fmt.Sprintf("created indexed batch with %d keys\n", count)
 		case "lsm":
 			return runLSMCmd(td, d)
+		case "metrics":
+			d.mu.Lock()
+			d.waitTableStats()
+			d.mu.Unlock()
+			m := d.Metrics()
+			return fmt.Sprintf("Metrics.Keys.RangeKeySetsCount = %d\n", m.Keys.RangeKeySetsCount)
 		case "commit-batch":
 			if b == nil {
 				return "no pending batch"

--- a/table_stats.go
+++ b/table_stats.go
@@ -759,3 +759,50 @@ func newCombinedDeletionKeyspanIter(
 
 	return mIter, nil
 }
+
+// rangeKeySetsAnnotator implements manifest.Annotator, annotating B-Tree nodes
+// with the sum of the files' counts of range key fragments. Its annotation type
+// is a *uint64. The count of range key sets may change once a table's stats are
+// loaded asynchronously, so its values are marked as cacheable only if a file's
+// stats have been loaded.
+type rangeKeySetsAnnotator struct{}
+
+var _ manifest.Annotator = rangeKeySetsAnnotator{}
+
+func (a rangeKeySetsAnnotator) Zero(dst interface{}) interface{} {
+	if dst == nil {
+		return new(uint64)
+	}
+	v := dst.(*uint64)
+	*v = 0
+	return v
+}
+
+func (a rangeKeySetsAnnotator) Accumulate(
+	f *fileMetadata, dst interface{},
+) (v interface{}, cacheOK bool) {
+	vptr := dst.(*uint64)
+	*vptr = *vptr + f.Stats.NumRangeKeySets
+	return vptr, f.StatsValidLocked()
+}
+
+func (a rangeKeySetsAnnotator) Merge(src interface{}, dst interface{}) interface{} {
+	srcV := src.(*uint64)
+	dstV := dst.(*uint64)
+	*dstV = *dstV + *srcV
+	return dstV
+}
+
+// countRangeKeySetFragments counts the number of RANGEKEYSET keys across all
+// files of the LSM. It only counts keys in files for which table stats have
+// been loaded. It uses a b-tree annotator to cache intermediate values between
+// calculations when possible.
+func countRangeKeySetFragments(v *version) (count uint64) {
+	for l := 0; l < numLevels; l++ {
+		if v.RangeKeyLevels[l].Empty() {
+			continue
+		}
+		count += *v.RangeKeyLevels[l].Annotation(rangeKeySetsAnnotator{}).(*uint64)
+	}
+	return count
+}

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -342,6 +342,10 @@ wrote 3 keys
 flush
 ----
 
+metrics
+----
+Metrics.Keys.RangeKeySetsCount = 1
+
 combined-iter
 seek-ge az
 next
@@ -412,6 +416,13 @@ wrote 4 keys
 flush
 ----
 
+lsm
+----
+0.1:
+  000008:[b#2111,RANGEKEYSET-z#72057594037927935,RANGEKEYSET]
+0.0:
+  000006:[a@100#3,SET-zz@1#2104,SET]
+
 scan-rangekeys
 ----
 [b, bat)
@@ -422,6 +433,15 @@ scan-rangekeys
  @1000=boop, @1=bop
 [e, z)
  @1000=boop
+
+# NB: There are now 8 range key sets in the database. See the 7 range keys in
+# the above scan-rangekeys. Additionally, the sstable flushed earlier up above
+# included a rangekeyset [b,c) @5=beep.
+
+metrics
+----
+Metrics.Keys.RangeKeySetsCount = 8
+
 
 combined-iter
 seek-prefix-ge ca
@@ -659,6 +679,13 @@ a:a
 b:b
 c:c
 .
+
+flush
+----
+
+metrics
+----
+Metrics.Keys.RangeKeySetsCount = 3
 
 # Test Prev-ing back over a synthetic range key marker. Synthetic range-key
 # markers (the keys interleaved at 'c' during a SeekGE(c) when there's a


### PR DESCRIPTION
Add a metric recording the approximate number of internal range key sets that
exist within the database. It's calculated through an annotation on the
range-key only level metadata b-trees. It's approximate since it excludes
memtable range key sets and any tables for which table stats have not yet been
loaded. I intend to export this as a time-series metric.

Informs #1848.