### PR TITLE
db: avoid defragmenting beyond prefix bounds during prefix iteration

### DIFF
--- a/compaction_iter_test.go
+++ b/compaction_iter_test.go
@@ -100,7 +100,7 @@ func TestCompactionIter(t *testing.T) {
 		fi := &fakeIter{keys: keys, vals: vals}
 		interleavingIter = &keyspan.InterleavingIter{}
 		interleavingIter.Init(
-			base.DefaultComparer.Compare,
+			base.DefaultComparer,
 			base.WrapIterWithStats(fi),
 			keyspan.NewIter(base.DefaultComparer.Compare, rangeKeys),
 			nil, nil, nil)

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -666,6 +666,7 @@ func TestElideTombstone(t *testing.T) {
 	for _, tc := range testCases {
 		c := compaction{
 			cmp:      DefaultComparer.Compare,
+			comparer: DefaultComparer,
 			version:  tc.version,
 			inputs:   []compactionLevel{{level: tc.level}, {level: tc.level + 1}},
 			smallest: base.ParseInternalKey("a.SET.0"),
@@ -811,6 +812,7 @@ func TestElideRangeTombstone(t *testing.T) {
 	for _, tc := range testCases {
 		c := compaction{
 			cmp:      DefaultComparer.Compare,
+			comparer: DefaultComparer,
 			version:  tc.version,
 			inputs:   []compactionLevel{{level: tc.level}, {level: tc.level + 1}},
 			smallest: base.ParseInternalKey("a.SET.0"),
@@ -869,6 +871,7 @@ func TestCompactionTransform(t *testing.T) {
 			var outSpan keyspan.Span
 			c := compaction{
 				cmp:                base.DefaultComparer.Compare,
+				comparer:           base.DefaultComparer,
 				disableSpanElision: disableElision,
 				inuseKeyRanges:     keyRanges,
 			}
@@ -1574,6 +1577,7 @@ func TestCompactionFindGrandparentLimit(t *testing.T) {
 				c := &compaction{
 					cmp:          cmp,
 					equal:        DefaultComparer.Equal,
+					comparer:     DefaultComparer,
 					grandparents: manifest.NewLevelSliceKeySorted(cmp, grandparents),
 				}
 				if len(d.CmdArgs) != 1 {
@@ -1703,6 +1707,7 @@ func TestCompactionFindL0Limit(t *testing.T) {
 				c := &compaction{
 					cmp:      cmp,
 					equal:    DefaultComparer.Equal,
+					comparer: DefaultComparer,
 					version:  vers,
 					l0Limits: vers.L0Sublevels.FlushSplitKeys(),
 					inputs:   []compactionLevel{{level: -1}, {level: 0}},
@@ -1797,9 +1802,10 @@ func TestCompactionAtomicUnitBounds(t *testing.T) {
 
 			case "atomic-unit-bounds":
 				c := &compaction{
-					cmp:    cmp,
-					equal:  DefaultComparer.Equal,
-					inputs: []compactionLevel{{files: files}, {}},
+					cmp:      cmp,
+					equal:    DefaultComparer.Equal,
+					comparer: DefaultComparer,
+					inputs:   []compactionLevel{{files: files}, {}},
 				}
 				c.startLevel, c.outputLevel = &c.inputs[0], &c.inputs[1]
 				if len(d.CmdArgs) != 1 {
@@ -2415,6 +2421,7 @@ func TestCompactionInuseKeyRanges(t *testing.T) {
 			c = &compaction{
 				cmp:       DefaultComparer.Compare,
 				equal:     DefaultComparer.Equal,
+				comparer:  DefaultComparer,
 				formatKey: DefaultComparer.FormatKey,
 				inputs:    []compactionLevel{{}, {}},
 			}
@@ -2639,9 +2646,10 @@ func TestCompactionAllowZeroSeqNum(t *testing.T) {
 			case "allow-zero-seqnum":
 				d.mu.Lock()
 				c := &compaction{
-					cmp:     d.cmp,
-					version: d.mu.versions.currentVersion(),
-					inputs:  []compactionLevel{{}, {}},
+					cmp:      d.cmp,
+					comparer: d.opts.Comparer,
+					version:  d.mu.versions.currentVersion(),
+					inputs:   []compactionLevel{{}, {}},
 				}
 				c.startLevel, c.outputLevel = &c.inputs[0], &c.inputs[1]
 				d.mu.Unlock()
@@ -2725,6 +2733,7 @@ func TestCompactionErrorOnUserKeyOverlap(t *testing.T) {
 			case "error-on-user-key-overlap":
 				c := &compaction{
 					cmp:       DefaultComparer.Compare,
+					comparer:  DefaultComparer,
 					formatKey: DefaultComparer.FormatKey,
 				}
 				var files []manifest.NewFileEntry
@@ -2853,6 +2862,7 @@ func TestCompactionCheckOrdering(t *testing.T) {
 			case "check-ordering":
 				c := &compaction{
 					cmp:       DefaultComparer.Compare,
+					comparer:  DefaultComparer,
 					formatKey: DefaultComparer.FormatKey,
 					logger:    panicLogger{},
 					inputs:    []compactionLevel{{level: -1}, {level: -1}},

--- a/data_test.go
+++ b/data_test.go
@@ -313,7 +313,7 @@ func printIterState(
 			}
 			if hasRange {
 				start, end := iter.RangeBounds()
-				fmt.Fprintf(b, "[%s-%s)", start, end)
+				fmt.Fprintf(b, "[%s-%s)", formatASCIIKey(start), formatASCIIKey(end))
 				writeRangeKeys(b, iter)
 			} else {
 				fmt.Fprint(b, ".")
@@ -329,7 +329,7 @@ func printIterState(
 					panic(fmt.Sprintf("pebble: unexpected HasPointAndRange (%t, %t)", hasPoint, hasRange))
 				}
 				start, end := iter.RangeBounds()
-				fmt.Fprintf(b, "%s [%s-%s)", iter.Key(), start, end)
+				fmt.Fprintf(b, "%s [%s-%s)", iter.Key(), formatASCIIKey(start), formatASCIIKey(end))
 				writeRangeKeys(b, iter)
 			} else {
 				fmt.Fprint(b, ".")
@@ -344,6 +344,14 @@ func printIterState(
 	} else {
 		fmt.Fprintf(b, ".%s\n", validityStateStr)
 	}
+}
+
+func formatASCIIKey(b []byte) string {
+	if bytes.IndexFunc(b, func(r rune) bool { return r < 'A' || r > 'z' }) != -1 {
+		// This key is not just ASCII letters. Quote it.
+		return fmt.Sprintf("%q", b)
+	}
+	return string(b)
 }
 
 func writeRangeKeys(b io.Writer, iter *Iterator) {

--- a/db.go
+++ b/db.go
@@ -532,6 +532,7 @@ func (d *DB) getInternal(key []byte, b *Batch, s *Snapshot) ([]byte, io.Closer, 
 		pointIter:    pointIter,
 		merge:        d.merge,
 		split:        d.split,
+		comparer:     d.opts.Comparer,
 		readState:    readState,
 		keyBuf:       buf.keyBuf,
 	}
@@ -906,6 +907,7 @@ func (d *DB) newIterInternal(batch *Batch, s *Snapshot, o *IterOptions) *Iterato
 		equal:               d.equal,
 		merge:               d.merge,
 		split:               d.split,
+		comparer:            d.opts.Comparer,
 		readState:           readState,
 		keyBuf:              buf.keyBuf,
 		prefixOrFullSeekKey: buf.prefixOrFullSeekKey,
@@ -1013,7 +1015,7 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 			// NB: The interleaving iterator is always reinitialized, even if
 			// dbi already had an initialized range key iterator, in case the point
 			// iterator changed or the range key masking suffix changed.
-			dbi.rangeKey.iiter.Init(dbi.cmp, dbi.iter, dbi.rangeKey.rangeKeyIter,
+			dbi.rangeKey.iiter.Init(dbi.comparer, dbi.iter, dbi.rangeKey.rangeKeyIter,
 				&dbi.rangeKeyMasking, dbi.opts.LowerBound, dbi.opts.UpperBound)
 			dbi.iter = &dbi.rangeKey.iiter
 		}

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -59,6 +59,7 @@ func NewExternalIter(
 		equal:               o.equal(),
 		merge:               o.Merger.Merge,
 		split:               o.Comparer.Split,
+		comparer:            o.Comparer,
 		readState:           nil,
 		keyBuf:              buf.keyBuf,
 		prefixOrFullSeekKey: buf.prefixOrFullSeekKey,
@@ -148,9 +149,10 @@ func finishInitializingExternal(it *Iterator) {
 			it.rangeKey = iterRangeKeyStateAllocPool.Get().(*iteratorRangeKeyState)
 			it.rangeKey.init(it.cmp, it.split, &it.opts)
 			it.rangeKey.rangeKeyIter = it.rangeKey.iterConfig.Init(
-				it.cmp,
+				it.comparer,
 				base.InternalKeySeqNumMax,
 				it.opts.LowerBound, it.opts.UpperBound,
+				&it.hasPrefix, &it.prefixOrFullSeekKey,
 			)
 			for _, r := range it.externalReaders {
 				if rki, err := r.NewRawRangeKeyIter(); err != nil {
@@ -160,7 +162,7 @@ func finishInitializingExternal(it *Iterator) {
 				}
 			}
 		}
-		it.rangeKey.iiter.Init(it.cmp, it.iter, it.rangeKey.rangeKeyIter, &it.rangeKeyMasking,
+		it.rangeKey.iiter.Init(it.comparer, it.iter, it.rangeKey.rangeKeyIter, &it.rangeKeyMasking,
 			it.opts.LowerBound, it.opts.UpperBound)
 		it.iter = &it.rangeKey.iiter
 	}

--- a/internal/keyspan/interleaving_iter_test.go
+++ b/internal/keyspan/interleaving_iter_test.go
@@ -107,7 +107,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 			}
 			keyspanIter.Init(cmp, noopTransform, NewIter(cmp, spans))
 			hooks.maskSuffix = nil
-			iter.Init(cmp, base.WrapIterWithStats(&pointIter), &keyspanIter, &hooks, nil, nil)
+			iter.Init(testkeys.Comparer, base.WrapIterWithStats(&pointIter), &keyspanIter, &hooks, nil, nil)
 			return "OK"
 		case "define-pointkeys":
 			var points []base.InternalKey
@@ -117,7 +117,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 			}
 			pointIter = pointIterator{cmp: cmp, keys: points}
 			hooks.maskSuffix = nil
-			iter.Init(cmp, base.WrapIterWithStats(&pointIter), &keyspanIter, &hooks, nil, nil)
+			iter.Init(testkeys.Comparer, base.WrapIterWithStats(&pointIter), &keyspanIter, &hooks, nil, nil)
 			return "OK"
 		case "iter":
 			buf.Reset()
@@ -143,6 +143,10 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 					formatKey(iter.Prev())
 				case "seek-ge":
 					formatKey(iter.SeekGE([]byte(strings.TrimSpace(line[i:])), base.SeekGEFlagsNone))
+				case "seek-prefix-ge":
+					key := []byte(strings.TrimSpace(line[i:]))
+					prefix := key[:testkeys.Comparer.Split(key)]
+					formatKey(iter.SeekPrefixGE(prefix, key, base.SeekGEFlagsNone))
 				case "seek-lt":
 					formatKey(iter.SeekLT([]byte(strings.TrimSpace(line[i:])), base.SeekLTFlagsNone))
 				case "set-bounds":

--- a/internal/keyspan/testdata/bounded_iter
+++ b/internal/keyspan/testdata/bounded_iter
@@ -115,3 +115,120 @@ b-g:{(#4,RANGEKEYSET,@3)}
 <nil>
 b-g:{(#4,RANGEKEYSET,@3)}
 <nil>
+
+set-prefix bar
+----
+set prefix to "bar"
+
+# Test seeking to a portion of the keyspace that contains no range keys with
+# start bounds ≥ the seek key such that the range key also overlaps the current
+# prefix.
+
+iter lower=a upper=z
+seek-ge bar
+prev
+prev
+----
+<nil>
+b-g:{(#4,RANGEKEYSET,@3)}
+<nil>
+
+# Test seeking to a portion of the keyspace that contains a range key with a
+# start bound < the seek key, and the range key also overlaps the current
+# prefix.
+
+iter lower=a upper=z
+seek-lt bar
+next
+prev
+prev
+----
+b-g:{(#4,RANGEKEYSET,@3)}
+<nil>
+b-g:{(#4,RANGEKEYSET,@3)}
+<nil>
+
+# Test seeking with bounds narrower than the range of the seek prefix. This is
+# possible in practice because the bounded iterator iterates over fragments, not
+# pre-defragmented range keys.
+
+iter lower=bar@9 upper=bar@3
+seek-lt bar
+next
+prev
+prev
+----
+b-g:{(#4,RANGEKEYSET,@3)}
+<nil>
+b-g:{(#4,RANGEKEYSET,@3)}
+<nil>
+
+# Test a similar scenario but on the start prefix of a key.
+
+iter lower=b@9 upper=b@3
+seek-lt b
+next
+next
+prev
+prev
+----
+<nil>
+b-g:{(#4,RANGEKEYSET,@3)}
+<nil>
+b-g:{(#4,RANGEKEYSET,@3)}
+<nil>
+
+# Test a scenario where the prefix overlaps a span, but the bounds exclude it.
+
+iter lower=z@9 upper=z@3
+seek-lt z@3
+next
+----
+<nil>
+<nil>
+
+# Test many spans matching the prefix, due to fragmentation within a prefix.
+
+define
+b-boo:{(#1,RANGEKEYSET,@1)}
+c@9-c@8:{(#1,RANGEKEYSET,@1)}
+c@8-c@7:{(#1,RANGEKEYSET,@1)}
+c@7-c@6:{(#1,RANGEKEYSET,@1)}
+c@6-c@5:{(#1,RANGEKEYSET,@1)}
+c@5-c@4:{(#1,RANGEKEYSET,@1)}
+----
+
+set-prefix c
+----
+set prefix to "c"
+
+iter
+seek-lt c
+next
+next
+next
+next
+next
+next
+----
+<nil>
+c@9-c@8:{(#1,RANGEKEYSET,@1)}
+c@8-c@7:{(#1,RANGEKEYSET,@1)}
+c@7-c@6:{(#1,RANGEKEYSET,@1)}
+c@6-c@5:{(#1,RANGEKEYSET,@1)}
+c@5-c@4:{(#1,RANGEKEYSET,@1)}
+<nil>
+
+# Test the same scenario with bounds limiting iteration to a subset of the
+# keys.
+
+iter lower=c@7 upper=c@5
+seek-lt c@7
+next
+next
+next
+----
+<nil>
+c@7-c@6:{(#1,RANGEKEYSET,@1)}
+c@6-c@5:{(#1,RANGEKEYSET,@1)}
+<nil>

--- a/internal/keyspan/testdata/interleaving_iter
+++ b/internal/keyspan/testdata/interleaving_iter
@@ -88,11 +88,11 @@ next
 next
 ----
 -- SpanChanged(nil)
--- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
+-- SpanChanged(b-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
 PointKey: b#72057594037927935,21
 Span: b-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
--- SpanChanged(c-d:{(#4,RANGEKEYSET,@3,coconut)})
+-- SpanChanged(c-carrot:{(#4,RANGEKEYSET,@3,coconut)})
 PointKey: c#72057594037927935,21
 Span: c-carrot:{(#4,RANGEKEYSET,@3,coconut)}
 -
@@ -110,11 +110,11 @@ prev
 prev
 ----
 -- SpanChanged(nil)
--- SpanChanged(c-d:{(#4,RANGEKEYSET,@3,coconut)})
+-- SpanChanged(c-carrot:{(#4,RANGEKEYSET,@3,coconut)})
 PointKey: c#72057594037927935,21
 Span: c-carrot:{(#4,RANGEKEYSET,@3,coconut)}
 -
--- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
+-- SpanChanged(b-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
 PointKey: b#72057594037927935,21
 Span: b-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 -
@@ -719,7 +719,7 @@ prev
 prev
 ----
 -- SpanChanged(nil)
--- SpanChanged(a-z:{(#5,RANGEKEYSET,@1,v1)})
+-- SpanChanged(a-c:{(#5,RANGEKEYSET,@1,v1)})
 PointKey: a#72057594037927935,21
 Span: a-c:{(#5,RANGEKEYSET,@1,v1)}
 -
@@ -728,7 +728,7 @@ Span: a-c:{(#5,RANGEKEYSET,@1,v1)}
 PointKey: z#8,1
 Span: <invalid>
 -
--- SpanChanged(a-z:{(#5,RANGEKEYSET,@1,v1)})
+-- SpanChanged(c-z:{(#5,RANGEKEYSET,@1,v1)})
 PointKey: c#72057594037927935,21
 Span: c-z:{(#5,RANGEKEYSET,@1,v1)}
 -
@@ -887,3 +887,39 @@ seek-lt d
 -- SpanChanged(nil)
 -- SpanChanged(nil)
 .
+
+# Test seek-prefix-ge and its truncation of bounds to the prefix's bounds.
+
+define-rangekeys
+b-d:{(#5,RANGEKEYSET,@1,foo)}
+f-g:{(#6,RANGEKEYSET,@1,foo)}
+----
+OK
+
+define-pointkeys
+c.SET.8
+----
+OK
+
+iter
+seek-prefix-ge b
+next
+seek-prefix-ge c
+next
+----
+-- SpanChanged(nil)
+-- SpanChanged(b-b\x00:{(#5,RANGEKEYSET,@1,foo)})
+PointKey: b#72057594037927935,21
+Span: b-b\x00:{(#5,RANGEKEYSET,@1,foo)}
+-
+PointKey: c#8,1
+Span: b-b\x00:{(#5,RANGEKEYSET,@1,foo)}
+-
+-- SpanChanged(nil)
+-- SpanChanged(c-c\x00:{(#5,RANGEKEYSET,@1,foo)})
+PointKey: c#72057594037927935,21
+Span: c-c\x00:{(#5,RANGEKEYSET,@1,foo)}
+-
+PointKey: c#8,1
+Span: c-c\x00:{(#5,RANGEKEYSET,@1,foo)}
+-

--- a/internal/rangekey/coalesce.go
+++ b/internal/rangekey/coalesce.go
@@ -35,12 +35,17 @@ type UserIteratorConfig struct {
 // The snapshot sequence number parameter determines which keys are visible. Any
 // keys not visible at the provided snapshot are ignored.
 func (ui *UserIteratorConfig) Init(
-	cmp base.Compare, snapshot uint64, lower, upper []byte, iters ...keyspan.FragmentIterator,
+	comparer *base.Comparer,
+	snapshot uint64,
+	lower, upper []byte,
+	hasPrefix *bool,
+	prefix *[]byte,
+	iters ...keyspan.FragmentIterator,
 ) keyspan.FragmentIterator {
 	ui.snapshot = snapshot
-	ui.miter.Init(cmp, ui, iters...)
-	ui.biter.Init(cmp, &ui.miter, lower, upper)
-	ui.diter.Init(cmp, &ui.biter, ui, keyspan.StaticDefragmentReducer)
+	ui.miter.Init(comparer.Compare, ui, iters...)
+	ui.biter.Init(comparer.Compare, comparer.Split, &ui.miter, lower, upper, hasPrefix, prefix)
+	ui.diter.Init(comparer.Compare, &ui.biter, ui, keyspan.StaticDefragmentReducer)
 	ui.litersUsed = 0
 	return &ui.diter
 }

--- a/internal/testkeys/testkeys.go
+++ b/internal/testkeys/testkeys.go
@@ -76,6 +76,15 @@ var Comparer *base.Comparer = &base.Comparer{
 		// The successor is > a[:ai], so we only need to add the sentinel.
 		return append(dst, 0)
 	},
+	ImmediateSuccessor: func(dst, a []byte) []byte {
+		// TODO(jackson): Consider changing this Comparer to only support
+		// representable prefix keys containing characters a-z.
+		ai := split(a)
+		if ai != len(a) {
+			panic("pebble: ImmediateSuccessor invoked with a non-prefix key")
+		}
+		return append(append(dst, a...), 0x00)
+	},
 	Split: split,
 	Name:  "pebble.internal.testkeys",
 }

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -242,11 +242,13 @@ b: (b2, [ace-c) @3=beep)
 c: (c2, [c-d) @1=boop UPDATED)
 .
 
+# NB: seek-prefix-ge truncates bounds to the prefix.
+
 combined-iter
 seek-prefix-ge b
 next
 ----
-b: (b2, [ace-c) @3=beep UPDATED)
+b: (b2, [b-"b\x00") @3=beep UPDATED)
 .
 
 reset
@@ -255,7 +257,7 @@ reset
 batch
 range-key-set a d @8 boop
 set a@2 a@2
-set a@3 a#3
+set a@3 a@3
 set a@9 a@9
 set a@10 a@10
 set b b
@@ -270,12 +272,14 @@ next
 next
 next
 ----
-a: (., [a-d) @8=boop UPDATED)
-a@10: (a@10, [a-d) @8=boop)
-a@9: (a@9, [a-d) @8=boop)
-a@3: (a#3, [a-d) @8=boop)
-a@2: (a@2, [a-d) @8=boop)
+a: (., [a-"a\x00") @8=boop UPDATED)
+a@10: (a@10, [a-"a\x00") @8=boop)
+a@9: (a@9, [a-"a\x00") @8=boop)
+a@3: (a@3, [a-"a\x00") @8=boop)
+a@2: (a@2, [a-"a\x00") @8=boop)
 .
+
+
 
 # Perform the above iteration with range-key masking enabled at a suffix equal
 # to the range key's. The [a,d)@8 range key should serve as a masking, obscuring
@@ -287,9 +291,9 @@ next
 next
 next
 ----
-a: (., [a-d) @8=boop UPDATED)
-a@10: (a@10, [a-d) @8=boop)
-a@9: (a@9, [a-d) @8=boop)
+a: (., [a-"a\x00") @8=boop UPDATED)
+a@10: (a@10, [a-"a\x00") @8=boop)
+a@9: (a@9, [a-"a\x00") @8=boop)
 .
 
 # Perform the same thing but with a mask suffix below the range key's. All the
@@ -310,17 +314,29 @@ next
 next
 next
 ----
-a: (., [a-d) @8=boop UPDATED)
-a@10: (a@10, [a-d) @8=boop)
-a@9: (a@9, [a-d) @8=boop)
-a@3: (a#3, [a-d) @8=boop)
-a@2: (a@2, [a-d) @8=boop)
+a: (., [a-"a\x00") @8=boop UPDATED)
+a@10: (a@10, [a-"a\x00") @8=boop)
+a@9: (a@9, [a-"a\x00") @8=boop)
+a@3: (a@3, [a-"a\x00") @8=boop)
+a@2: (a@2, [a-"a\x00") @8=boop)
 .
 .
-a: (., [a-d) @8=boop UPDATED)
-a@10: (a@10, [a-d) @8=boop)
-a@9: (a@9, [a-d) @8=boop)
+a: (., [a-"a\x00") @8=boop UPDATED)
+a@10: (a@10, [a-"a\x00") @8=boop)
+a@9: (a@9, [a-"a\x00") @8=boop)
 .
+
+# Test that switching out of prefix iteration correctly expands the bounds
+# beyond the scope of the previous prefix.
+
+combined-iter
+seek-prefix-ge a
+next
+seek-ge a@3
+----
+a: (., [a-"a\x00") @8=boop UPDATED)
+a@10: (a@10, [a-"a\x00") @8=boop)
+a@3: (a@3, [a-d) @8=boop UPDATED)
 
 reset
 ----
@@ -428,9 +444,9 @@ seek-prefix-ge ca
 next
 seek-prefix-ge ca@100
 ----
-ca: (., [c-e) @1000=boop, @1=bop UPDATED)
-ca@100: (ca@100, [c-e) @1000=boop, @1=bop)
-ca@100: (ca@100, [c-e) @1000=boop, @1=bop)
+ca: (., [ca-"ca\x00") @1000=boop, @1=bop UPDATED)
+ca@100: (ca@100, [ca-"ca\x00") @1000=boop, @1=bop)
+ca@100: (ca@100, [ca-"ca\x00") @1000=boop, @1=bop)
 
 
 # Perform the same iteration as above, but with @1000 range-key masking. The
@@ -441,9 +457,9 @@ seek-prefix-ge ca
 next
 seek-prefix-ge ca@100
 ----
-ca: (., [c-e) @1000=boop, @1=bop UPDATED)
+ca: (., [ca-"ca\x00") @1000=boop, @1=bop UPDATED)
 .
-ca@100: (., [c-e) @1000=boop, @1=bop UPDATED)
+ca@100: (., [ca-"ca\x00") @1000=boop, @1=bop UPDATED)
 
 # Test masked, non-prefixed iteration. We should see the range keys, but all the
 # points should be masked except those beginning with z which were excluded by


### PR DESCRIPTION
During prefix iteration, avoid defragmenting range keys beyond the bounds of
the prefix. To preserve determinism, also truncated returned range keys to the
prefix bounds.

This requires the introduction of a new ImmediateSuccessor function on the
Comparer.

```
name                           old time/op    new time/op    delta
CombinedIteratorSeekPrefix-10    2.53ms ± 3%    0.10ms ± 2%  -96.19%  (p=0.000 n=10+10)

name                           old alloc/op   new alloc/op   delta
CombinedIteratorSeekPrefix-10    1.78MB ± 0%    0.05MB ± 0%  -96.92%  (p=0.000 n=9+9)

name                           old allocs/op  new allocs/op  delta
CombinedIteratorSeekPrefix-10     17.0k ± 0%      0.4k ± 0%  -97.93%  (p=0.000 n=10+10)
```

Fix #1874.