### PR TITLE
internal/keyspan: fix prefixed InterleavingIter.InitSeekGE

### DIFF
--- a/internal/keyspan/interleaving_iter.go
+++ b/internal/keyspan/interleaving_iter.go
@@ -209,6 +209,7 @@ func (i *InterleavingIter) InitSeekGE(
 ) (*base.InternalKey, []byte) {
 	i.dir = +1
 	i.clearMask()
+	i.prefix = prefix != nil
 	i.pointKey, i.pointVal = pointKey, pointValue
 	i.pointKeyInterleaved = false
 	// NB: This keyspanSeekGE call will truncate the span to the seek key if

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -1167,3 +1167,56 @@ a: (a, .)
 using lazy iterator
 n: (., [m-z) @5=foo UPDATED)
 using combined (non-lazy) iterator
+
+# Regression test for a bug discovered in #1878.
+# A lazy-combined iterator triggers combined iteration during an initial
+# seek-prefix-ge call. The initial seek-prefix-ge call avoids defragmenting
+# fragments beyond the initial fragment [c,f). A subsequent seek-ge that seeks
+# within the bounds of the initial fragment [c,f) must not fall into the
+# optimization that reuses the span without reseeking the keypsan iterator,
+# because the span is not defragmented.
+#
+# In the bug surfaced by #1878, the initial seek-prefix-ge that switched to
+# combined iteration failed to record that the iterator was now in prefix mode,
+# allowing the subsequent seek-ge to incorrectly reuse the existing span.
+
+reset
+----
+
+batch
+range-key-set a c @5 foo
+----
+wrote 1 keys
+
+flush
+----
+
+batch
+range-key-set c f @5 foo
+----
+wrote 1 keys
+
+flush
+----
+
+batch
+range-key-set f m @5 foo
+----
+wrote 1 keys
+
+flush
+----
+
+lsm
+----
+0.0:
+  000005:[a#1,RANGEKEYSET-c#72057594037927935,RANGEKEYSET]
+  000007:[c#2,RANGEKEYSET-f#72057594037927935,RANGEKEYSET]
+  000009:[f#3,RANGEKEYSET-m#72057594037927935,RANGEKEYSET]
+
+combined-iter
+seek-prefix-ge d@5
+seek-ge d
+----
+d@5: (., [d-"d\x00") @5=foo UPDATED)
+d: (., [a-m) @5=foo UPDATED)


### PR DESCRIPTION
Fix a bug where an InitSeekGE with a prefix failed to record that the
interleaving iterator was in prefix mode, allowing incorrect use of the
existing, potentially fragmented span stored on the iterator.

Fix #1878.