### PR TITLE
db: handle Next on exhausted prefix iterator

### DIFF
--- a/internal/keyspan/bounded.go
+++ b/internal/keyspan/bounded.go
@@ -32,6 +32,22 @@ const (
 )
 
 // BoundedIter implements FragmentIterator and enforces bounds.
+//
+// Like the point InternalIterator interface, the bounded iterator's forward
+// positioning routines (SeekGE, First, and Next) only check the upper bound.
+// The reverse positioning routines (SeekLT, Last, and Prev) only check the
+// lower bound. It is up to the caller to ensure that the forward positioning
+// routines respect the lower bound and the reverse positioning routines respect
+// the upper bound (i.e. calling SeekGE instead of First if there is a lower
+// bound, and SeekLT instead of Last if there is an upper bound).
+//
+// When the hasPrefix parameter indicates that the iterator is in prefix
+// iteration mode, BoundedIter elides any spans that do not overlap with the
+// prefix's keyspace. In prefix iteration mode, reverse iteration is disallowed,
+// except for an initial SeekLT with a seek key greater than or equal to the
+// prefix. In prefix iteration mode, the first seek must position the iterator
+// at or immediately before the first fragment covering a key greater than or
+// equal to the prefix.
 type BoundedIter struct {
 	iter      FragmentIterator
 	iterSpan  *Span

--- a/testdata/iterator
+++ b/testdata/iterator
@@ -880,8 +880,8 @@ next
 a:bc
 .
 .
-stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 4), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 12, key-bytes 16, value-bytes 12, tombstoned: 0))
+stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 8, key-bytes 10, value-bytes 8, tombstoned: 0))
 
 iter seq=2
 seek-prefix-ge a
@@ -891,8 +891,8 @@ next
 a:b
 .
 .
-stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 14, key-bytes 18, value-bytes 14, tombstoned: 0))
+stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 14, value-bytes 10, tombstoned: 0))
 
 iter seq=4
 seek-prefix-ge a


### PR DESCRIPTION
Previously, when Next was called on an already exhausted prefix iterator, the
iterator stack would still step the internal iterator. If a level was removed
from the merging iterator because the matching file returned nil due to bloom
filter exclusion, the iterator could miss a range key and trigger a switch to
combined iteration using a later key.

This would provide an inconsistent view of the range keys when seeking the
range key iterator. The SeekGE(k) would unexpectedly discover range keys with
start keys <k. This is an issue during prefix iteration, because the bounded
keyspan iterator only guarantees a consistent view of prefix iteration for
forward iteration.

Fix #1881.