### PR TITLE
sstable: pool range key fragment iterators

### DIFF
--- a/sstable/block.go
+++ b/sstable/block.go
@@ -987,6 +987,10 @@ type fragmentBlockIter struct {
 	closeHook func(i keyspan.FragmentIterator) error
 }
 
+func (i *fragmentBlockIter) resetForReuse() fragmentBlockIter {
+	return fragmentBlockIter{blockIter: i.blockIter.resetForReuse()}
+}
+
 func (i *fragmentBlockIter) decodeSpanKeys(k *InternalKey, internalValue []byte) {
 	// TODO(jackson): The use of i.span.Keys to accumulate keys across multiple
 	// calls to Decode is too confusing and subtle. Refactor to make it


### PR DESCRIPTION
Pool range key fragment iterators to avoid allocations every time a table's
range keys are read. Ideally we'd pool all *fragmentBlockIters, but currently
some code paths call Close twice on rangedel fragmentBlockIters.

```
name                                                                    old time/op    new time/op    delta
MVCCGet_Pebble/batch=false/versions=1/valueSize=8/numRangeKeys=0-10       3.79µs ± 1%    3.85µs ± 3%     ~     (p=0.421 n=5+5)
MVCCGet_Pebble/batch=false/versions=1/valueSize=8/numRangeKeys=1-10       6.30µs ± 1%    6.11µs ± 1%   -2.96%  (p=0.008 n=5+5)
MVCCGet_Pebble/batch=false/versions=1/valueSize=8/numRangeKeys=100-10     56.3µs ± 0%    55.0µs ± 1%   -2.30%  (p=0.008 n=5+5)
MVCCGet_Pebble/batch=false/versions=10/valueSize=8/numRangeKeys=0-10      4.26µs ± 1%    4.27µs ± 1%     ~     (p=0.548 n=5+5)
MVCCGet_Pebble/batch=false/versions=10/valueSize=8/numRangeKeys=1-10      7.55µs ± 1%    7.18µs ± 2%   -4.90%  (p=0.008 n=5+5)
MVCCGet_Pebble/batch=false/versions=10/valueSize=8/numRangeKeys=100-10    57.4µs ± 0%    56.3µs ± 0%   -1.85%  (p=0.008 n=5+5)
MVCCGet_Pebble/batch=false/versions=100/valueSize=8/numRangeKeys=0-10     8.27µs ± 4%    8.20µs ± 2%     ~     (p=0.690 n=5+5)
MVCCGet_Pebble/batch=false/versions=100/valueSize=8/numRangeKeys=1-10     12.7µs ± 1%    11.7µs ± 1%   -8.28%  (p=0.008 n=5+5)

name                                                                    old alloc/op   new alloc/op   delta
MVCCGet_Pebble/batch=false/versions=1/valueSize=8/numRangeKeys=0-10         241B ± 0%      241B ± 0%     ~     (all equal)
MVCCGet_Pebble/batch=false/versions=1/valueSize=8/numRangeKeys=1-10       1.68kB ± 0%    0.68kB ± 0%  -59.42%  (p=0.029 n=4+4)
MVCCGet_Pebble/batch=false/versions=1/valueSize=8/numRangeKeys=100-10     36.5kB ± 1%    35.9kB ± 1%   -1.52%  (p=0.008 n=5+5)
MVCCGet_Pebble/batch=false/versions=10/valueSize=8/numRangeKeys=0-10        241B ± 0%      241B ± 0%     ~     (all equal)
MVCCGet_Pebble/batch=false/versions=10/valueSize=8/numRangeKeys=1-10      2.19kB ± 0%    0.74kB ± 0%  -66.08%  (p=0.000 n=5+4)
MVCCGet_Pebble/batch=false/versions=10/valueSize=8/numRangeKeys=100-10    36.6kB ± 0%    36.2kB ± 0%   -1.17%  (p=0.008 n=5+5)
MVCCGet_Pebble/batch=false/versions=100/valueSize=8/numRangeKeys=0-10       370B ± 0%      370B ± 0%     ~     (p=0.556 n=5+4)
MVCCGet_Pebble/batch=false/versions=100/valueSize=8/numRangeKeys=1-10     2.46kB ± 0%    0.91kB ± 0%  -62.79%  (p=0.008 n=5+5)
```