### PR TITLE
db: invalidate iterator in SetOptions if range keys are present

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -1942,10 +1942,11 @@ func (i *Iterator) SetOptions(o *IterOptions) {
 			i.err = firstError(i.err, i.rangeKey.rangeKeyIter.Close())
 			i.rangeKey = nil
 		} else {
-			// If there's still a range key iterator stack, wipe its state so
-			// that a seek that finds the same range key returns
-			// RangeKeyChanged()=true.
-			i.clearSavedRangeKey()
+			// If there's still a range key iterator stack, invalidate the
+			// iterator. This ensures RangeKeyChanged() returns true if a
+			// subsequent positioning operation discovers a range key. It also
+			// prevents seek no-op optimizations.
+			i.invalidate()
 		}
 	}
 
@@ -2100,15 +2101,8 @@ func (i *Iterator) invalidate() {
 	}
 	i.iterValidityState = IterExhausted
 	if i.rangeKey != nil {
-		i.clearSavedRangeKey()
 		i.rangeKey.iiter.Invalidate()
 	}
-}
-
-func (i *Iterator) clearSavedRangeKey() {
-	i.rangeKey.prevPosHadRangeKey = false
-	i.rangeKey.start = nil
-	i.rangeKey.end = nil
 }
 
 // Metrics returns per-iterator metrics.

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -1353,3 +1353,42 @@ seek-prefix-ge c@10
 y@1: (., [y-"y\x00") @1=foo UPDATED)
 a@1: (., [a-"a\x00") @1=bar UPDATED)
 c@10: (., [c-"c\x00") @1=bar UPDATED)
+
+# Ensure that no-op optimizations do not reuse range key iterator state across
+# SetOptions calls. No-op optimizations have the potential to fail to update
+# RangeKeyChanged().
+
+reset
+----
+
+batch
+range-key-set p s @1 foo
+----
+wrote 1 keys
+
+combined-iter lower=n@9 upper=x@5
+seek-lt y@3
+set-options lower=n@9 upper=x@5
+seek-lt-limit t o
+----
+p: (., [p-s) @1=foo UPDATED)
+.
+p: valid (., [p-s) @1=foo UPDATED)
+
+combined-iter lower=n@9 upper=x@5
+seek-ge o
+set-options lower=n@9 upper=x@5
+seek-ge oat
+----
+p: (., [p-s) @1=foo UPDATED)
+.
+p: (., [p-s) @1=foo UPDATED)
+
+combined-iter lower=n@9 upper=x@5
+seek-prefix-ge p@5
+set-options lower=n@9 upper=x@5
+seek-prefix-ge p
+----
+p@5: (., [p-"p\x00") @1=foo UPDATED)
+.
+p: (., [p-"p\x00") @1=foo UPDATED)


### PR DESCRIPTION
The change in #1888 was an incomplete fix for preventing range key state from
leaking across a SetOptions call. Specifically, it still permitted the use of
no-op seek optimizations. Take a more conservative stance of invalidating the
iterator in SetOptions calls with initialized range key iterator stacks.

It's possible this could be optimized to preserve the optimization in some
cases, but given the bugs in this area and stability, we should take the more
conservative approach.

Fix #1890.