### PR TITLE
metamorphic: set iters last bounds on iter creation

### DIFF
--- a/internal/metamorphic/generator.go
+++ b/internal/metamorphic/generator.go
@@ -496,6 +496,10 @@ func (g *generator) newIter() {
 	if g.cmp(lower, upper) > 0 {
 		lower, upper = upper, lower
 	}
+	g.itersLastBounds[iterID] = iterBounds{
+		lower: lower,
+		upper: upper,
+	}
 	keyTypes, maskSuffix := g.randKeyTypesAndMask()
 
 	// With a low probability, enable automatic filtering of keys with suffixes
@@ -562,6 +566,7 @@ func (g *generator) newIterUsingClone() {
 
 	// TODO(jackson): Exercise changing iterator options as a part of Clone.
 
+	g.itersLastBounds[iterID] = g.itersLastBounds[existingIterID]
 	g.add(&newIterUsingCloneOp{
 		existingIterID: existingIterID,
 		iterID:         iterID,


### PR DESCRIPTION
The set bounds operation relies on the iters previous bounds being set
to determine if the new bounds should overlap with the previous. Not
having the bounds set may generate overlap even when the generator
is trying to create bounds with no overlap.