### PR TITLE
db: fix prefix iteration invariant violation

### DIFF
--- a/internal/keyspan/testdata/bounded_iter
+++ b/internal/keyspan/testdata/bounded_iter
@@ -232,3 +232,20 @@ next
 c@7-c@6:{(#1,RANGEKEYSET,@1)}
 c@6-c@5:{(#1,RANGEKEYSET,@1)}
 <nil>
+
+define
+a@7-a@5:{(#1,RANGEKEYSET,@1)}
+b-boo:{(#1,RANGEKEYSET,@1)}
+c@9-c@8:{(#1,RANGEKEYSET,@1)}
+----
+
+set-prefix b
+----
+set prefix to "b"
+
+iter
+seek-lt c@8
+seek-ge a@9
+----
+<nil>
+<nil>

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -1392,3 +1392,116 @@ seek-prefix-ge p
 p@5: (., [p-"p\x00") @1=foo UPDATED)
 .
 p: (., [p-"p\x00") @1=foo UPDATED)
+
+# Regression test for an invariant violation in the range key defragmenting
+# iterator during prefix iteration. [Related to #1893]. There is a lot of
+# subtlety here. Do not modify this test case without verifying that it still
+# exercises the right conditions.
+#
+# Normally during forward iteration, if a switch to lazy-combined iteration is
+# triggered, the lazy-combined iterator establishes a seek key for the range key
+# iterator such that the seek key is:
+#   1. greater than or equal to the key at previous iterator position.
+#   2. less than or equal to the first range key with a start key greater than
+#       or equal to the previous iterator position.
+# These invariants are important so that the range key iterator is positioned
+# appropriately after the switch to combined iteration and no range keys are
+# missed.
+#
+# Parts of the iterator stack depend on the above invariants. For example,
+# during forward iteration the BoundedIter only checks span start keys against
+# iterator bounds and the configured prefix, with the expectation that the seek
+# is always already greater than or equal to the lower bound. In turn, the
+# DefragmentingIter indirectly relies on the same invariant, because it requires
+# a consistent view of the fragments. If the BoundedIter returns a span in one
+# direction, but skips it when iterating back, the defragmenting iterator will
+# end up on a different fragment.
+#
+# This test exercises a case in which previously, during prefix iteration, it
+# was possible for the switch to lazy-combined iteration to trigger using a seek
+# key k, such that there exist range key fragments between the current iterator
+# position and k (violating the 2nd invariant up above).
+#
+# The sequence of events is:
+#   1. SeekPrefixGE("b@9") = 'b@4':
+#      a. This seek positions the two levels, L0 and L6. The L0 iterator seeks
+#         to file 000006. This file does not contain any keys with the prefix
+#         "b", and the bloom filter must succeed in excluding the file. Since the
+#         file contains a range deletion, SeekPrefixGE returns the level's
+#         largest point key (`d#inf,RANGEDEL`) to ensure the file stays open until
+#         the iterator advances past the range deletion.
+#      b. In L6, the level iterator seeks to 000004 which contains a key with
+#         the prefix, returning 'b@4'.
+#   2. Next():
+#      a. Next advances the the L6 iterator to file 000005. This file contains a
+#         range key [e,f)@1=bar, which updates the lazy-combined iterator's
+#         state, recording the earliest observed range key as 'e'. The L6 level
+#         iterator then returns the file single point key 'c'.
+#      b. The merging iterator checks whether point key 'c' is deleted by any
+#         range key deletions. It is. It's deleted by L0's [c,d) range deletion.
+#         The merging iterator then seeks the iterator to the tombstone's end
+#         key 'd'.
+#      c. After seeking, the range deletion sentinel d is at the top of the
+#         heap. At this point, the merging iterator checks whether the keyspace
+#         of the prefix has been exceeded, and it has. It returns nil.
+#   3. Switch to combined iteration:
+#      a. The Next has completed and triggered combined iteration. The only file
+#         containing range keys that was observed was 000005, containing the
+#         range key [e,f). The switch to combined iteration seeks the keyspan
+#         iterator to 'e'. Note that the iterator never observed L0's [d,e)
+#         range key that precedes [e,f) in the keyspace.
+#      b. Seeking the keyspan iterator calls DefragmentingIter.SeekLT('e'),
+#         which lands on the [d,e) fragment. This fragment does NOT check to see
+#         if the span starts at a prefix greater than the current prefix 'b',
+#         because only bounds in the direction of iteration are check.
+#      c. The DefragmentingIter observes disappearing range key fragments when
+#         it switches directions, as a result of (b).
+#
+
+# Use 100-bits per key to ensure the bloom filter provides total recall.
+reset bloom-bits-per-key=100
+----
+
+# Ingest L6 files:
+#
+# 000004: b@4
+# 000005: c, [e,f)@1=bar
+
+ingest ext1
+set b@4 b@4
+----
+
+ingest ext1
+set c c
+range-key-set e f @1 bar
+----
+
+# Ingest L0 files:
+#
+# 000006: a, del-range(c, d)
+# 000007: [d,e)@1=bar
+
+ingest ext2
+set a a
+del-range c d
+----
+
+ingest ext3
+range-key-set d e @1 bar
+----
+
+lsm
+----
+0.0:
+  000006:[a#3,SET-d#72057594037927935,RANGEDEL]
+  000007:[d#4,RANGEKEYSET-e#72057594037927935,RANGEKEYSET]
+6:
+  000004:[b@4#1,SET-b@4#1,SET]
+  000005:[c#2,SET-f#72057594037927935,RANGEKEYSET]
+
+combined-iter
+seek-prefix-ge b@9
+next
+----
+b@4: (b@4, .)
+.


### PR DESCRIPTION
In #1875, the range key iterator stack was modified to avoid defragmenting
beyond the bounds of a prefix. During the switch to lazy combined iteration,
this could induce an invariant violation under very particular circumstances.

See the extended comment added to the range keys datadriven test case.

This violation is fixed in two places in this commit. The lazy combined
iterator will avoid switching to combined iteration if encountered range keys
fall wholly outside the prefix's bounds. Additionally, the bounded keyspan
iterator will enforce prefix bounds on both start and end bounds, rather than
just the direction of iteration. This redundancy is performed out of an
abundance of caution, because prefix iterator bounds enforcement has
been a frequent source of range key bugs since it's been introduced.

Informs #1893.