### PR TITLE
db: fix Close race with WAL rotation

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1520,11 +1520,11 @@ func (d *DB) maybeScheduleDelayedFlush(tbl *memTable, dur time.Duration) {
 			defer d.mu.Unlock()
 
 			// NB: The timer may fire concurrently with a call to Close.  If a
-			// Close call beat us to acquiring d.mu, d.closed is 1, and it's
-			// too late to flush anything. Otherwise, the Close call will
-			// block on locking d.mu until we've finished scheduling the flush
-			// and set `d.mu.compact.flushing` to true. Close will wait for
-			// the current flush to complete.
+			// Close call beat us to acquiring d.mu, d.closed holds ErrClosed,
+			// and it's too late to flush anything. Otherwise, the Close call
+			// will block on locking d.mu until we've finished scheduling the
+			// flush and set `d.mu.compact.flushing` to true. Close will wait
+			// for the current flush to complete.
 			if d.closed.Load() != nil {
 				return
 			}

--- a/db.go
+++ b/db.go
@@ -1211,6 +1211,18 @@ func (d *DB) NewSnapshot() *Snapshot {
 // or to call Close concurrently with any other DB method. It is not valid
 // to call any of a DB's methods after the DB has been closed.
 func (d *DB) Close() error {
+	// Lock the commit pipeline for the duration of Close. This prevents a race
+	// with makeRoomForWrite. Rotating the WAL in makeRoomForWrite requires
+	// dropping d.mu several times for I/O. If Close only holds d.mu, an
+	// in-progress WAL rotation may re-acquire d.mu only once the database is
+	// closed.
+	//
+	// Additionally, locking the commit pipeline makes it more likely that
+	// (illegal) concurrent writes will observe d.closed.Load() != nil, creating
+	// more understable panics if the database is improperly used concurrently
+	// during Close.
+	d.commit.mu.Lock()
+	defer d.commit.mu.Unlock()
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if err := d.closed.Load(); err != nil {


### PR DESCRIPTION
Fix a race between DB.Close and WAL rotation. WAL rotation drops the database
mutex several times. If the database was closed in one of these gaps, the WAL
rotation goroutine would not notice, instead panicking on an inconsistent
refcount for a memtable.

This change fixes the race by acquiring DB.commit.mu in Close. WAL rotation
requires both the commit pipeline and the global DB mutex to be held, and it
does not drop the commit pipeline mutex at any point. This provides
synchronization between Close and WAL rotation.

This race was surfaced by the metamorphic tests after #1867's inclusion of the
FlushDelayDeleteRange and FlushDelayRangeKey options as metamorphic parameters
made it more likely.

Close #1728.
Inform #1893.