### PR TITLE
db: make RangeKeyMasking.Filter a constructor function

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -227,7 +227,7 @@ func runIterCmd(d *datadriven.TestData, iter *Iterator, closeIter bool) string {
 func parseIterOptions(
 	opts *IterOptions, ref *IterOptions, parts []string,
 ) (foundAny bool, err error) {
-	const usageString = "[lower=<lower>] [upper=<upper>] [key-types=point|range|both] [mask-suffix=<suffix>] [only-durable=<bool>] [table-filter=reuse|none] [point-filters=reuse|none]\n"
+	const usageString = "[lower=<lower>] [upper=<upper>] [key-types=point|range|both] [mask-suffix=<suffix>] [mask-filter=<bool>] [only-durable=<bool>] [table-filter=reuse|none] [point-filters=reuse|none]\n"
 	for _, part := range parts {
 		arg := strings.SplitN(part, "=", 2)
 		if len(arg) != 2 {
@@ -261,7 +261,9 @@ func parseIterOptions(
 		case "mask-suffix":
 			opts.RangeKeyMasking.Suffix = []byte(arg[1])
 		case "mask-filter":
-			opts.RangeKeyMasking.Filter = blockprop.NewMaskingFilter()
+			opts.RangeKeyMasking.Filter = func() BlockPropertyFilterMask {
+				return blockprop.NewMaskingFilter()
+			}
 		case "table-filter":
 			switch arg[1] {
 			case "reuse":

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -577,7 +577,9 @@ func (o *newIterOp) run(t *test, h *history) {
 		},
 	}
 	if opts.RangeKeyMasking.Suffix != nil {
-		opts.RangeKeyMasking.Filter = blockprop.NewMaskingFilter()
+		opts.RangeKeyMasking.Filter = func() pebble.BlockPropertyFilterMask {
+			return blockprop.NewMaskingFilter()
+		}
 	}
 	if o.filterMax > 0 {
 		opts.PointKeyFilters = []pebble.BlockPropertyFilter{
@@ -685,7 +687,9 @@ func (o *iterSetOptionsOp) run(t *test, h *history) {
 		},
 	}
 	if opts.RangeKeyMasking.Suffix != nil {
-		opts.RangeKeyMasking.Filter = blockprop.NewMaskingFilter()
+		opts.RangeKeyMasking.Filter = func() pebble.BlockPropertyFilterMask {
+			return blockprop.NewMaskingFilter()
+		}
 	}
 	if o.filterMax > 0 {
 		opts.PointKeyFilters = []pebble.BlockPropertyFilter{

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -2269,7 +2269,6 @@ func BenchmarkIterator_RangeKeyMasking(b *testing.B) {
 	// Set ignore syncs to true so that each subbenchmark may mutate state and
 	// then revert back to the original state.
 	mem.SetIgnoreSyncs(true)
-	maskingFilter := blockprop.NewMaskingFilter()
 
 	// TODO(jackson): Benchmark lazy-combined iteration versus not.
 	// TODO(jackson): Benchmark seeks.
@@ -2289,7 +2288,9 @@ func BenchmarkIterator_RangeKeyMasking(b *testing.B) {
 				KeyTypes: IterKeyTypePointsAndRanges,
 				RangeKeyMasking: RangeKeyMasking{
 					Suffix: []byte("@100"),
-					Filter: maskingFilter,
+					Filter: func() BlockPropertyFilterMask {
+						return blockprop.NewMaskingFilter()
+					},
 				},
 			}
 			b.Run("forward", func(b *testing.B) {

--- a/options.go
+++ b/options.go
@@ -232,15 +232,17 @@ type RangeKeyMasking struct {
 	Suffix []byte
 	// Filter is an optional field that may be used to improve performance of
 	// range-key masking through a block-property filter defined over key
-	// suffixes. Filter allows Pebble to skip whole point-key blocks containing
-	// point keys with suffixes greater than a covering range-key's suffix.
+	// suffixes. If non-nil, Filter is called by Pebble to construct a
+	// block-property filter mask at iterator creation. The filter is used to
+	// skip whole point-key blocks containing point keys with suffixes greater
+	// than a covering range-key's suffix.
 	//
 	// To use this functionality, the caller must create and configure (through
 	// Options.BlockPropertyCollectors) a block-property collector that records
 	// the maxmimum suffix contained within a block. The caller then must write
 	// and provide a BlockPropertyFilterMask implementation on that same
 	// property. See the BlockPropertyFilterMask type for more information.
-	Filter BlockPropertyFilterMask
+	Filter func() BlockPropertyFilterMask
 }
 
 // BlockPropertyFilterMask extends the BlockPropertyFilter interface for use

--- a/range_keys_test.go
+++ b/range_keys_test.go
@@ -163,7 +163,9 @@ func TestRangeKeys(t *testing.T) {
 				case "mask-suffix":
 					o.RangeKeyMasking.Suffix = []byte(arg.Vals[0])
 				case "mask-filter":
-					o.RangeKeyMasking.Filter = blockprop.NewMaskingFilter()
+					o.RangeKeyMasking.Filter = func() BlockPropertyFilterMask {
+						return blockprop.NewMaskingFilter()
+					}
 				case "lower":
 					o.LowerBound = []byte(arg.Vals[0])
 				case "upper":

--- a/testdata/indexed_batch_mutation
+++ b/testdata/indexed_batch_mutation
@@ -576,3 +576,53 @@ seek-prefix-ge d@2
 d@2: (., [d-"d\x00") @1=foo)
 .
 d@2: (., [d-"d\x00") @2=foo, @1=foo UPDATED)
+
+# Test cloning an iterator with a range-key mask block property filter
+# configured. If the cloned and the clonee iterators have different suffixes
+# configured, their suffixes should be respected. Previously, the
+# RangeKeyMasking.Filter option was a footgun, because it was a single mutable
+# instance. Cloning the iterator without supplying new iterator options would
+# result in two iterators using the same filter.
+
+reset
+----
+
+batch
+range-key-set a e @5 foo
+set b@4 b@4
+----
+
+new-db-iter iter-a
+----
+
+iter iter=iter-a
+set-options mask-suffix=@3 mask-filter=true
+seek-ge a
+next
+next
+----
+.
+a: (., [a-e) @5=foo UPDATED)
+b@4: (b@4, [a-e) @5=foo)
+.
+
+clone from=iter-a to=iter-b refresh-batch=false
+----
+
+iter iter=iter-b
+set-options mask-suffix=@6
+seek-ge a
+next
+----
+.
+a: (., [a-e) @5=foo UPDATED)
+.
+
+iter iter=iter-a
+seek-ge a
+next
+next
+----
+a: (., [a-e) @5=foo UPDATED)
+b@4: (b@4, [a-e) @5=foo)
+.


### PR DESCRIPTION
The RangeKeyMasking.Filter option previously took a BlockPropertyFilterMask
implementation directly. Because BlockPropertyFilterMasks are mutable types,
this was easy to misuse when combined with Clone. If the Clone operation didn't
provide its own IterOptions, the cloned iterator would adopt the clonee's
BlockPropertyFilterMask. The two iterators would interfere with each other as
they iterate.

This was surfaced by the metamorphic tests, which currently never supplies
IterOptions to Clone (#1904). Cockroach already supplies IterOptions to Clone
and is unaffected.

Informs #1904.
Closes #1893.