### PR TITLE
metamorphic: reposition iterator after SetOptions

### DIFF
--- a/internal/metamorphic/generator_test.go
+++ b/internal/metamorphic/generator_test.go
@@ -52,9 +52,9 @@ func TestGenerator(t *testing.T) {
 	require.EqualValues(t, 0, len(g.snapshots))
 	require.EqualValues(t, 1, len(g.liveWriters))
 
-	g.iterClose()
-	g.iterClose()
-	g.iterClose()
+	g.randIter(g.iterClose)()
+	g.randIter(g.iterClose)()
+	g.randIter(g.iterClose)()
 	require.EqualValues(t, 0, len(g.liveIters))
 
 	if testing.Verbose() {
@@ -85,9 +85,9 @@ func TestGenerator(t *testing.T) {
 	require.EqualValues(t, 0, len(g.snapshots))
 	require.EqualValues(t, 1, len(g.liveWriters))
 
-	g.iterClose()
-	g.iterClose()
-	g.iterClose()
+	g.randIter(g.iterClose)()
+	g.randIter(g.iterClose)()
+	g.randIter(g.iterClose)()
 	require.EqualValues(t, 0, len(g.liveIters))
 
 	if testing.Verbose() {
@@ -105,9 +105,9 @@ func TestGenerator(t *testing.T) {
 	g.writerApply()
 	g.writerApply()
 	g.writerApply()
-	g.iterClose()
-	g.iterClose()
-	g.iterClose()
+	g.randIter(g.iterClose)()
+	g.randIter(g.iterClose)()
+	g.randIter(g.iterClose)()
 
 	require.EqualValues(t, 0, len(g.liveBatches))
 	require.EqualValues(t, 0, len(g.batches))


### PR DESCRIPTION
A call to Iterator.SetOptions leaves an iterator in an undefined position. The
Iterator contract requires that the caller reposition the iterator using an
absolute positioning method (eg, SeekGE, SeekLT, etc). The logic to perform
this repositioning in the metamorphic tests was faulty. It performed a random
absolute positioning operation on a random iterator rather than the iterator
that was just configured with SetOptions.

Fix #1911.