### PR TITLE
db: add IterOptions.DoNotFillCache option

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -976,7 +976,7 @@ func TestCompaction(t *testing.T) {
 					return "", "", errors.WithStack(err)
 				}
 				defer r.Close()
-				iter, err := r.NewIter(nil /* lower */, nil /* upper */)
+				iter, err := r.NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 				if err != nil {
 					return "", "", errors.WithStack(err)
 				}

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -193,9 +193,9 @@ func finishInitializingExternal(it *Iterator) {
 					pointIter    internalIterator
 					err          error
 				)
-				pointIter, err = r.NewIter(it.opts.LowerBound, it.opts.UpperBound)
+				pointIter, err = r.NewIter(it.opts.LowerBound, it.opts.UpperBound, it.opts.doNotFillCache())
 				if err == nil {
-					rangeDelIter, err = r.NewRawRangeDelIter()
+					rangeDelIter, err = r.NewRawRangeDelIter(it.opts.doNotFillCache())
 				}
 				if err != nil {
 					pointIter = &errorIter{err: err}
@@ -255,7 +255,7 @@ func finishInitializingExternal(it *Iterator) {
 			// this optimization.
 			for _, readers := range it.externalReaders {
 				for _, r := range readers {
-					if rki, err := r.NewRawRangeKeyIter(); err != nil {
+					if rki, err := r.NewRawRangeKeyIter(it.opts.doNotFillCache()); err != nil {
 						it.rangeKey.iterConfig.AddLevel(&errorKeyspanIter{err: err})
 					} else if rki != nil {
 						it.rangeKey.iterConfig.AddLevel(rki)

--- a/external_iterator_test.go
+++ b/external_iterator_test.go
@@ -111,7 +111,7 @@ func TestSimpleLevelIter(t *testing.T) {
 			}()
 			var internalIters []internalIterator
 			for i := range readers {
-				iter, err := readers[i].NewIter(nil, nil)
+				iter, err := readers[i].NewIter(nil, nil, false)
 				require.NoError(t, err)
 				internalIters = append(internalIters, iter)
 			}

--- a/ingest.go
+++ b/ingest.go
@@ -93,7 +93,7 @@ func ingestLoad1(
 	maybeSetStatsFromProperties(meta, &r.Properties)
 
 	{
-		iter, err := r.NewIter(nil /* lower */, nil /* upper */)
+		iter, err := r.NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 		if err != nil {
 			return nil, err
 		}
@@ -119,7 +119,7 @@ func ingestLoad1(
 		}
 	}
 
-	iter, err := r.NewRawRangeDelIter()
+	iter, err := r.NewRawRangeDelIter(false)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +148,7 @@ func ingestLoad1(
 
 	// Update the range-key bounds for the table.
 	{
-		iter, err := r.NewRawRangeKeyIter()
+		iter, err := r.NewRawRangeKeyIter(false /* doNotFillCache */)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cache/clockpro.go
+++ b/internal/cache/clockpro.go
@@ -59,6 +59,11 @@ type Handle struct {
 	value *Value
 }
 
+// HandleFrom creates a handle from value.
+func HandleFrom(value *Value) Handle {
+	return Handle{value: value}
+}
+
 // Get returns the value stored in handle.
 func (h Handle) Get() []byte {
 	if h.value != nil {

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -96,11 +96,11 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 	newIters :=
 		func(file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts) (internalIterator, keyspan.FragmentIterator, error) {
 			r := readers[file.FileNum]
-			rangeDelIter, err := r.NewRawRangeDelIter()
+			rangeDelIter, err := r.NewRawRangeDelIter(false /* doNotFillCache */)
 			if err != nil {
 				return nil, nil, err
 			}
-			iter, err := r.NewIter(nil /* lower */, nil /* upper */)
+			iter, err := r.NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -159,11 +159,11 @@ func (lt *levelIterTest) newIters(
 	file *manifest.FileMetadata, opts *IterOptions, _ internalIterOpts,
 ) (internalIterator, keyspan.FragmentIterator, error) {
 	lt.itersCreated++
-	iter, err := lt.readers[file.FileNum].NewIter(opts.LowerBound, opts.UpperBound)
+	iter, err := lt.readers[file.FileNum].NewIter(opts.LowerBound, opts.UpperBound, false /* doNotFillCache */)
 	if err != nil {
 		return nil, nil, err
 	}
-	rangeDelIter, err := lt.readers[file.FileNum].NewRawRangeDelIter()
+	rangeDelIter, err := lt.readers[file.FileNum].NewRawRangeDelIter(false /* doNotFillCache */)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -487,7 +487,7 @@ func buildLevelIterTables(
 
 	meta := make([]*fileMetadata, len(readers))
 	for i := range readers {
-		iter, err := readers[i].NewIter(nil /* lower */, nil /* upper */)
+		iter, err := readers[i].NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 		require.NoError(b, err)
 		smallest, _ := iter.First()
 		meta[i] = &fileMetadata{}
@@ -513,7 +513,7 @@ func BenchmarkLevelIterSeekGE(b *testing.B) {
 							newIters := func(
 								file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts,
 							) (internalIterator, keyspan.FragmentIterator, error) {
-								iter, err := readers[file.FileNum].NewIter(nil /* lower */, nil /* upper */)
+								iter, err := readers[file.FileNum].NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 								return iter, nil, err
 							}
 							l := newLevelIter(IterOptions{}, DefaultComparer.Compare, nil, newIters, metas.Iter(), manifest.Level(level), nil)
@@ -555,7 +555,7 @@ func BenchmarkLevelIterSeqSeekGEWithBounds(b *testing.B) {
 								file *manifest.FileMetadata, opts *IterOptions, _ internalIterOpts,
 							) (internalIterator, keyspan.FragmentIterator, error) {
 								iter, err := readers[file.FileNum].NewIter(
-									opts.LowerBound, opts.UpperBound)
+									opts.LowerBound, opts.UpperBound, false /* doNotFillCache */)
 								return iter, nil, err
 							}
 							l := newLevelIter(IterOptions{}, DefaultComparer.Compare, nil, newIters, metas.Iter(), manifest.Level(level), nil)
@@ -597,7 +597,7 @@ func BenchmarkLevelIterSeqSeekPrefixGE(b *testing.B) {
 		file *manifest.FileMetadata, opts *IterOptions, _ internalIterOpts,
 	) (internalIterator, keyspan.FragmentIterator, error) {
 		iter, err := readers[file.FileNum].NewIter(
-			opts.LowerBound, opts.UpperBound)
+			opts.LowerBound, opts.UpperBound, false /* doNotFillCache */)
 		return iter, nil, err
 	}
 
@@ -649,7 +649,7 @@ func BenchmarkLevelIterNext(b *testing.B) {
 							newIters := func(
 								file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts,
 							) (internalIterator, keyspan.FragmentIterator, error) {
-								iter, err := readers[file.FileNum].NewIter(nil /* lower */, nil /* upper */)
+								iter, err := readers[file.FileNum].NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 								return iter, nil, err
 							}
 							l := newLevelIter(IterOptions{}, DefaultComparer.Compare, nil, newIters, metas.Iter(), manifest.Level(level), nil)
@@ -683,7 +683,7 @@ func BenchmarkLevelIterPrev(b *testing.B) {
 							newIters := func(
 								file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts,
 							) (internalIterator, keyspan.FragmentIterator, error) {
-								iter, err := readers[file.FileNum].NewIter(nil /* lower */, nil /* upper */)
+								iter, err := readers[file.FileNum].NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 								return iter, nil, err
 							}
 							l := newLevelIter(IterOptions{}, DefaultComparer.Compare, nil, newIters, metas.Iter(), manifest.Level(level), nil)

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -150,11 +150,11 @@ func TestMergingIterCornerCases(t *testing.T) {
 	newIters :=
 		func(file *manifest.FileMetadata, opts *IterOptions, _ internalIterOpts) (internalIterator, keyspan.FragmentIterator, error) {
 			r := readers[file.FileNum]
-			rangeDelIter, err := r.NewRawRangeDelIter()
+			rangeDelIter, err := r.NewRawRangeDelIter(false /* doNotFillCache */)
 			if err != nil {
 				return nil, nil, err
 			}
-			iter, err := r.NewIter(opts.GetLowerBound(), opts.GetUpperBound())
+			iter, err := r.NewIter(opts.GetLowerBound(), opts.GetUpperBound(), false /* doNotFillCache */)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -346,7 +346,7 @@ func BenchmarkMergingIterSeekGE(b *testing.B) {
 							iters := make([]internalIterator, len(readers))
 							for i := range readers {
 								var err error
-								iters[i], err = readers[i].NewIter(nil /* lower */, nil /* upper */)
+								iters[i], err = readers[i].NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 								require.NoError(b, err)
 							}
 							m := newMergingIter(nil /* logger */, DefaultComparer.Compare,
@@ -378,7 +378,7 @@ func BenchmarkMergingIterNext(b *testing.B) {
 							iters := make([]internalIterator, len(readers))
 							for i := range readers {
 								var err error
-								iters[i], err = readers[i].NewIter(nil /* lower */, nil /* upper */)
+								iters[i], err = readers[i].NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 								require.NoError(b, err)
 							}
 							m := newMergingIter(nil /* logger */, DefaultComparer.Compare,
@@ -413,7 +413,7 @@ func BenchmarkMergingIterPrev(b *testing.B) {
 							iters := make([]internalIterator, len(readers))
 							for i := range readers {
 								var err error
-								iters[i], err = readers[i].NewIter(nil /* lower */, nil /* upper */)
+								iters[i], err = readers[i].NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 								require.NoError(b, err)
 							}
 							m := newMergingIter(nil /* logger */, DefaultComparer.Compare,
@@ -543,7 +543,7 @@ func buildLevelsForMergingIterSeqSeek(
 	for i := range readers {
 		meta := make([]*fileMetadata, len(readers[i]))
 		for j := range readers[i] {
-			iter, err := readers[i][j].NewIter(nil /* lower */, nil /* upper */)
+			iter, err := readers[i][j].NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 			require.NoError(b, err)
 			smallest, _ := iter.First()
 			meta[j] = &fileMetadata{}
@@ -568,11 +568,11 @@ func buildMergingIter(readers [][]*sstable.Reader, levelSlices []manifest.LevelS
 			file *manifest.FileMetadata, opts *IterOptions, _ internalIterOpts,
 		) (internalIterator, keyspan.FragmentIterator, error) {
 			iter, err := readers[levelIndex][file.FileNum].NewIter(
-				opts.LowerBound, opts.UpperBound)
+				opts.LowerBound, opts.UpperBound, false /* doNotFillCache */)
 			if err != nil {
 				return nil, nil, err
 			}
-			rdIter, err := readers[levelIndex][file.FileNum].NewRawRangeDelIter()
+			rdIter, err := readers[levelIndex][file.FileNum].NewRawRangeDelIter(false /* doNotFillCache */)
 			if err != nil {
 				iter.Close()
 				return nil, nil, err

--- a/options.go
+++ b/options.go
@@ -127,6 +127,8 @@ type IterOptions struct {
 	// and point key iteration mode (IterKeyTypePointsAndRanges).
 	RangeKeyMasking RangeKeyMasking
 
+	// DoNotFillCache does not put the missing blocks into the internal cache.
+	DoNotFillCache bool
 	// OnlyReadGuaranteedDurable is an advanced option that is only supported by
 	// the Reader implemented by DB. When set to true, only the guaranteed to be
 	// durable state is visible in the iterator.
@@ -187,6 +189,13 @@ func (o *IterOptions) GetUpperBound() []byte {
 		return nil
 	}
 	return o.UpperBound
+}
+
+func (o *IterOptions) doNotFillCache() bool {
+	if o == nil {
+		return false
+	}
+	return o.DoNotFillCache
 }
 
 func (o *IterOptions) pointKeys() bool {

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -926,7 +926,7 @@ func TestBlockProperties(t *testing.T) {
 
 				// Enumerate point key data blocks encoded into the index.
 				if f != nil {
-					indexH, err := r.readIndex()
+					indexH, err := r.readIndex(false /* doNotFillCache */)
 					if err != nil {
 						return err.Error()
 					}
@@ -1006,7 +1006,7 @@ func TestBlockProperties(t *testing.T) {
 			} else if !ok {
 				return "filter excludes entire table"
 			}
-			iter, err := r.NewIterWithBlockPropertyFilters(lower, upper, filterer, false /* use (bloom) filter */)
+			iter, err := r.NewIterWithBlockPropertyFilters(lower, upper, filterer, false /* use (bloom) filter */, false /* doNotFillCache */)
 			if err != nil {
 				return err.Error()
 			}
@@ -1083,7 +1083,7 @@ func TestBlockProperties_BoundLimited(t *testing.T) {
 			} else if !ok {
 				return "filter excludes entire table"
 			}
-			iter, err := r.NewIterWithBlockPropertyFilters(lower, upper, filterer, false /* use (bloom) filter */)
+			iter, err := r.NewIterWithBlockPropertyFilters(lower, upper, filterer, false /* use (bloom) filter */, false /* doNotFillCache */)
 			if err != nil {
 				return err.Error()
 			}
@@ -1262,7 +1262,7 @@ func runBlockPropertiesBuildCmd(td *datadriven.TestData) (r *Reader, out string)
 }
 
 func runBlockPropsCmd(r *Reader, td *datadriven.TestData) string {
-	bh, err := r.readIndex()
+	bh, err := r.readIndex(false /* doNotFillCache */)
 	if err != nil {
 		return err.Error()
 	}
@@ -1310,7 +1310,7 @@ func runBlockPropsCmd(r *Reader, td *datadriven.TestData) string {
 		if twoLevelIndex {
 			subiter := &blockIter{}
 			subIndex, _, err := r.readBlock(
-				bhp.BlockHandle, nil /* transform */, nil /* readaheadState */)
+				bhp.BlockHandle, nil /* transform */, nil /* readaheadState */, false /* doNotFillCache */)
 			if err != nil {
 				return err.Error()
 			}

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -38,7 +38,7 @@ func (r *Reader) get(key []byte) (value []byte, err error) {
 	}
 
 	if r.tableFilter != nil {
-		dataH, err := r.readFilter()
+		dataH, err := r.readFilter(false /* doNotFillCache */)
 		if err != nil {
 			return nil, err
 		}
@@ -55,7 +55,7 @@ func (r *Reader) get(key []byte) (value []byte, err error) {
 		}
 	}
 
-	i, err := r.NewIter(nil /* lower */, nil /* upper */)
+	i, err := r.NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +288,7 @@ func TestInjectedErrors(t *testing.T) {
 				return err
 			}
 
-			iter, err := r.NewIter(nil, nil)
+			iter, err := r.NewIter(nil, nil, false /* doNotFillCache */)
 			if err != nil {
 				return err
 			}
@@ -364,7 +364,7 @@ func runTestReader(t *testing.T, o WriterOptions, dir string, r *Reader, cacheSi
 					return err.Error()
 				}
 				r.Properties.GlobalSeqNum = seqNum
-				iter, err := r.NewIter(nil /* lower */, nil /* upper */)
+				iter, err := r.NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 				if err != nil {
 					return err.Error()
 				}
@@ -498,7 +498,7 @@ func testBytesIteratedWithCompression(
 			for _, numEntries := range []uint64{0, 1, maxNumEntries[i]} {
 				r := buildTestTable(t, numEntries, blockSize, indexBlockSize, compression)
 				var bytesIterated, prevIterated uint64
-				citer, err := r.NewCompactionIter(&bytesIterated)
+				citer, err := r.NewCompactionIter(&bytesIterated, false /* doNotFillCache */)
 				require.NoError(t, err)
 
 				for key, _ := citer.First(); key != nil; key, _ = citer.Next() {
@@ -548,7 +548,7 @@ func TestCompactionIteratorSetupForCompaction(t *testing.T) {
 			for _, numEntries := range []uint64{0, 1, 1e5} {
 				r := buildTestTable(t, numEntries, blockSize, indexBlockSize, DefaultCompression)
 				var bytesIterated uint64
-				citer, err := r.NewCompactionIter(&bytesIterated)
+				citer, err := r.NewCompactionIter(&bytesIterated, false /* doNotFillCache */)
 				require.NoError(t, err)
 				switch i := citer.(type) {
 				case *compactionIterator:
@@ -678,14 +678,14 @@ func TestReaderChecksumErrors(t *testing.T) {
 						r, err := NewReader(corrupted, ReaderOptions{})
 						require.NoError(t, err)
 
-						iter, err := r.NewIter(nil, nil)
+						iter, err := r.NewIter(nil, nil, false /* doNotFillCache */)
 						require.NoError(t, err)
 						for k, _ := iter.First(); k != nil; k, _ = iter.Next() {
 						}
 						require.Regexp(t, `checksum mismatch`, iter.Error())
 						require.Regexp(t, `checksum mismatch`, iter.Close())
 
-						iter, err = r.NewIter(nil, nil)
+						iter, err = r.NewIter(nil, nil, false /* doNotFillCache */)
 						require.NoError(t, err)
 						for k, _ := iter.Last(); k != nil; k, _ = iter.Prev() {
 						}
@@ -1033,7 +1033,7 @@ func BenchmarkTableIterSeekGE(b *testing.B) {
 		b.Run(bm.name,
 			func(b *testing.B) {
 				r, keys := buildBenchmarkTable(b, bm.options)
-				it, err := r.NewIter(nil /* lower */, nil /* upper */)
+				it, err := r.NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 				require.NoError(b, err)
 				rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 
@@ -1054,7 +1054,7 @@ func BenchmarkTableIterSeekLT(b *testing.B) {
 		b.Run(bm.name,
 			func(b *testing.B) {
 				r, keys := buildBenchmarkTable(b, bm.options)
-				it, err := r.NewIter(nil /* lower */, nil /* upper */)
+				it, err := r.NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 				require.NoError(b, err)
 				rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 
@@ -1075,7 +1075,7 @@ func BenchmarkTableIterNext(b *testing.B) {
 		b.Run(bm.name,
 			func(b *testing.B) {
 				r, _ := buildBenchmarkTable(b, bm.options)
-				it, err := r.NewIter(nil /* lower */, nil /* upper */)
+				it, err := r.NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 				require.NoError(b, err)
 
 				b.ResetTimer()
@@ -1104,7 +1104,7 @@ func BenchmarkTableIterPrev(b *testing.B) {
 		b.Run(bm.name,
 			func(b *testing.B) {
 				r, _ := buildBenchmarkTable(b, bm.options)
-				it, err := r.NewIter(nil /* lower */, nil /* upper */)
+				it, err := r.NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 				require.NoError(b, err)
 
 				b.ResetTimer()

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -328,7 +328,7 @@ func rewriteDataBlocksToWriter(
 }
 
 func rewriteRangeKeyBlockToWriter(r *Reader, w *Writer, from, to []byte) error {
-	iter, err := r.NewRawRangeKeyIter()
+	iter, err := r.NewRawRangeKeyIter(false /* doNotFillCache */)
 	if err != nil {
 		return err
 	}
@@ -390,7 +390,7 @@ func RewriteKeySuffixesViaWriter(
 	}
 
 	w := NewWriter(out, o)
-	i, err := r.NewIter(nil, nil)
+	i, err := r.NewIter(nil, nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -142,7 +142,7 @@ func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
 		}
 
 		// Check using SeekGE.
-		iter, err := r.NewIter(nil /* lower */, nil /* upper */)
+		iter, err := r.NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 		if err != nil {
 			return err
 		}
@@ -192,7 +192,7 @@ func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
 		}
 
 		// Check using Find.
-		iter, err := r.NewIter(nil /* lower */, nil /* upper */)
+		iter, err := r.NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 		if err != nil {
 			return err
 		}
@@ -222,7 +222,7 @@ func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
 		{0, "~"},
 	}
 	for _, ct := range countTests {
-		iter, err := r.NewIter(nil /* lower */, nil /* upper */)
+		iter, err := r.NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 		if err != nil {
 			return err
 		}
@@ -275,7 +275,7 @@ func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
 			upper = []byte(words[upperIdx])
 		}
 
-		iter, err := r.NewIter(lower, upper)
+		iter, err := r.NewIter(lower, upper, false /* doNotFillCache */)
 		if err != nil {
 			return err
 		}
@@ -637,7 +637,7 @@ func TestFinalBlockIsWritten(t *testing.T) {
 					if err != nil {
 						t.Errorf("nk=%d, vLen=%d: reader open: %v", nk, vLen, err)
 					}
-					iter, err := r.NewIter(nil /* lower */, nil /* upper */)
+					iter, err := r.NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 					require.NoError(t, err)
 					i := newIterAdapter(iter)
 					for valid := i.First(); valid; valid = i.Next() {
@@ -672,7 +672,7 @@ func TestReaderGlobalSeqNum(t *testing.T) {
 	const globalSeqNum = 42
 	r.Properties.GlobalSeqNum = globalSeqNum
 
-	iter, err := r.NewIter(nil /* lower */, nil /* upper */)
+	iter, err := r.NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 	require.NoError(t, err)
 	i := newIterAdapter(iter)
 	for valid := i.First(); valid; valid = i.Next() {
@@ -692,7 +692,7 @@ func TestMetaIndexEntriesSorted(t *testing.T) {
 	r, err := NewReader(f, ReaderOptions{})
 	require.NoError(t, err)
 
-	b, _, err := r.readBlock(r.metaIndexBH, nil /* transform */, nil /* attrs */)
+	b, _, err := r.readBlock(r.metaIndexBH, nil /* transform */, nil /* attrs */, false /* doNotFillCache */)
 	require.NoError(t, err)
 	defer b.Release()
 

--- a/sstable/writer_rangekey_test.go
+++ b/sstable/writer_rangekey_test.go
@@ -104,7 +104,7 @@ func TestWriter_RangeKeys(t *testing.T) {
 				return err.Error()
 			}
 
-			iter, err := r.NewRawRangeKeyIter()
+			iter, err := r.NewRawRangeKeyIter(false /* doNotFillCache */)
 			if err != nil {
 				return err.Error()
 			}

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -99,7 +99,7 @@ func runDataDriven(t *testing.T, file string, parallelism bool) {
 			return format(meta)
 
 		case "scan":
-			origIter, err := r.NewIter(nil /* lower */, nil /* upper */)
+			origIter, err := r.NewIter(nil /* lower */, nil /* upper */, false /* doNotFillCache */)
 			if err != nil {
 				return err.Error()
 			}
@@ -125,7 +125,7 @@ func runDataDriven(t *testing.T, file string, parallelism bool) {
 			return buf.String()
 
 		case "scan-range-del":
-			iter, err := r.NewRawRangeDelIter()
+			iter, err := r.NewRawRangeDelIter(false /* doNotFillCache */)
 			if err != nil {
 				return err.Error()
 			}
@@ -141,7 +141,7 @@ func runDataDriven(t *testing.T, file string, parallelism bool) {
 			return buf.String()
 
 		case "scan-range-key":
-			iter, err := r.NewRawRangeKeyIter()
+			iter, err := r.NewRawRangeKeyIter(false /* doNotFillCache */)
 			if err != nil {
 				return err.Error()
 			}
@@ -665,7 +665,7 @@ func TestWriterRace(t *testing.T) {
 			r, err := NewMemReader(f.Bytes(), readerOpts)
 			require.NoError(t, err)
 			defer r.Close()
-			it, err := r.NewIter(nil, nil)
+			it, err := r.NewIter(nil, nil, false /* doNotFillCache */)
 			require.NoError(t, err)
 			defer it.Close()
 			ki := 0

--- a/table_cache.go
+++ b/table_cache.go
@@ -383,7 +383,7 @@ func (c *tableCacheShard) newIters(
 
 	// NB: range-del iterator does not maintain a reference to the table, nor
 	// does it need to read from it after creation.
-	rangeDelIter, err := v.reader.NewRawRangeDelIter()
+	rangeDelIter, err := v.reader.NewRawRangeDelIter(opts.doNotFillCache())
 	if err != nil {
 		c.unrefValue(v)
 		return nil, nil, err
@@ -411,10 +411,10 @@ func (c *tableCacheShard) newIters(
 		useFilter = manifest.LevelToInt(opts.level) != 6 || opts.UseL6Filters
 	}
 	if internalOpts.bytesIterated != nil {
-		iter, err = v.reader.NewCompactionIter(internalOpts.bytesIterated)
+		iter, err = v.reader.NewCompactionIter(internalOpts.bytesIterated, opts.doNotFillCache())
 	} else {
 		iter, err = v.reader.NewIterWithBlockPropertyFilters(
-			opts.GetLowerBound(), opts.GetUpperBound(), filterer, useFilter)
+			opts.GetLowerBound(), opts.GetUpperBound(), filterer, useFilter, opts.doNotFillCache())
 	}
 	if err != nil {
 		if rangeDelIter != nil {
@@ -473,7 +473,7 @@ func (c *tableCacheShard) newRangeKeyIter(
 	}
 
 	var iter keyspan.FragmentIterator
-	iter, err = v.reader.NewRawRangeKeyIter()
+	iter, err = v.reader.NewRawRangeKeyIter(false /* doNotFillCache */) // FIXME
 	// iter is a block iter that holds the entire value of the block in memory.
 	// No need to hold onto a ref of the cache value.
 	c.unrefValue(v)

--- a/table_stats.go
+++ b/table_stats.go
@@ -717,7 +717,7 @@ func newCombinedDeletionKeyspanIter(
 	})
 	mIter.Init(cmp, transform)
 
-	iter, err := r.NewRawRangeDelIter()
+	iter, err := r.NewRawRangeDelIter(false /* doNotFillCache */)
 	if err != nil {
 		return nil, err
 	}
@@ -733,7 +733,7 @@ func newCombinedDeletionKeyspanIter(
 		mIter.AddLevel(iter)
 	}
 
-	iter, err = r.NewRawRangeKeyIter()
+	iter, err = r.NewRawRangeKeyIter(false /* doNotFillCache */)
 	if err != nil {
 		return nil, err
 	}

--- a/tool/find.go
+++ b/tool/find.go
@@ -423,7 +423,7 @@ func (f *findT) searchTables(searchKey []byte, refs []findRef) []findRef {
 				r.Properties.GlobalSeqNum = m.LargestSeqNum
 			}
 
-			iter, err := r.NewIter(nil, nil)
+			iter, err := r.NewIter(nil, nil, true /* doNotFillCache */)
 			if err != nil {
 				return err
 			}
@@ -434,7 +434,7 @@ func (f *findT) searchTables(searchKey []byte, refs []findRef) []findRef {
 			// bit more work here to put them in a form that can be iterated in
 			// parallel with the point records.
 			rangeDelIter, err := func() (keyspan.FragmentIterator, error) {
-				iter, err := r.NewRawRangeDelIter()
+				iter, err := r.NewRawRangeDelIter(true /* doNotFillCache */)
 				if err != nil {
 					return nil, err
 				}

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -172,7 +172,7 @@ func (s *sstableT) runCheck(cmd *cobra.Command, args []string) {
 		s.fmtKey.setForComparer(r.Properties.ComparerName, s.comparers)
 		s.fmtValue.setForComparer(r.Properties.ComparerName, s.comparers)
 
-		iter, err := r.NewIter(nil, nil)
+		iter, err := r.NewIter(nil, nil, true /* doNotFillCache */)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s\n", err)
 			return
@@ -183,7 +183,7 @@ func (s *sstableT) runCheck(cmd *cobra.Command, args []string) {
 		var prefixIter sstable.Iterator
 		if r.Split != nil {
 			var err error
-			prefixIter, err = r.NewIter(nil, nil)
+			prefixIter, err = r.NewIter(nil, nil, true /* doNotFillCache */)
 			if err != nil {
 				fmt.Fprintf(stderr, "%s\n", err)
 				return
@@ -382,7 +382,7 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 		s.fmtKey.setForComparer(r.Properties.ComparerName, s.comparers)
 		s.fmtValue.setForComparer(r.Properties.ComparerName, s.comparers)
 
-		iter, err := r.NewIter(nil, s.end)
+		iter, err := r.NewIter(nil, s.end, true /* doNotFillCache */)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s%s\n", prefix, err)
 			return
@@ -394,7 +394,7 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 		// bit more work here to put them in a form that can be iterated in
 		// parallel with the point records.
 		rangeDelIter, err := func() (keyspan.FragmentIterator, error) {
-			iter, err := r.NewRawRangeDelIter()
+			iter, err := r.NewRawRangeDelIter(false /* doNotFillCache */)
 			if err != nil {
 				return nil, err
 			}
@@ -478,7 +478,7 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 		}
 
 		// Handle range keys.
-		rkIter, err := r.NewRawRangeKeyIter()
+		rkIter, err := r.NewRawRangeKeyIter(false)
 		if err != nil {
 			fmt.Fprintf(stdout, "%s\n", err)
 			os.Exit(1)


### PR DESCRIPTION
DoNotFillCache does not put the missing blocks into the internal cache,
and it does not affect already cached blocks.
This enables users to manage the cache by themselves.

Ref: https://github.com/cockroachdb/pebble/issues/1208

The write/compaction path is using the cache, do not know what to do, so I am using hard-coded options in those places. 😅 