### PR TITLE
*: propagate pointer to InternalIteratorStats

### DIFF
--- a/compaction_iter_test.go
+++ b/compaction_iter_test.go
@@ -101,7 +101,7 @@ func TestCompactionIter(t *testing.T) {
 		interleavingIter = &keyspan.InterleavingIter{}
 		interleavingIter.Init(
 			base.DefaultComparer,
-			base.WrapIterWithStats(fi),
+			fi,
 			keyspan.NewIter(base.DefaultComparer.Compare, rangeKeys),
 			nil, nil, nil)
 		iter := newInvalidatingIter(interleavingIter)

--- a/error_iter.go
+++ b/error_iter.go
@@ -14,7 +14,7 @@ type errorIter struct {
 }
 
 // errorIter implements the base.InternalIterator interface.
-var _ internalIteratorWithStats = (*errorIter)(nil)
+var _ internalIterator = (*errorIter)(nil)
 
 func newErrorIter(err error) *errorIter {
 	return &errorIter{err: err}
@@ -63,8 +63,6 @@ func (c *errorIter) String() string {
 }
 
 func (c *errorIter) SetBounds(lower, upper []byte) {}
-func (c *errorIter) Stats() InternalIteratorStats  { return InternalIteratorStats{} }
-func (c *errorIter) ResetStats()                   {}
 
 type errorKeyspanIter struct {
 	err error

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -207,7 +207,7 @@ func finishInitializingExternal(it *Iterator) {
 					continue
 				}
 				mlevels = append(mlevels, mergingIterLevel{
-					iter:         base.WrapIterWithStats(pointIter),
+					iter:         pointIter,
 					rangeDelIter: rangeDelIter,
 				})
 			}
@@ -218,12 +218,12 @@ func finishInitializingExternal(it *Iterator) {
 				}
 				sli.init(it.opts)
 				mlevels = append(mlevels, mergingIterLevel{
-					iter:         base.WrapIterWithStats(sli),
+					iter:         sli,
 					rangeDelIter: nil,
 				})
 			}
 		}
-		it.alloc.merging.init(&it.opts, it.comparer.Compare, it.comparer.Split, mlevels...)
+		it.alloc.merging.init(&it.opts, &it.stats.InternalStats, it.comparer.Compare, it.comparer.Split, mlevels...)
 		it.alloc.merging.snapshot = base.InternalKeySeqNumMax
 		it.alloc.merging.elideRangeTombstones = true
 		it.pointIter = &it.alloc.merging

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -541,7 +541,7 @@ func TestGetIter(t *testing.T) {
 			i := &buf.dbi
 			i.comparer = *testkeys.Comparer
 			i.merge = DefaultMerger.Merge
-			i.iter = base.WrapIterWithStats(get)
+			i.iter = get
 
 			defer i.Close()
 			if !i.First() {

--- a/internal.go
+++ b/internal.go
@@ -33,8 +33,6 @@ type InternalKey = base.InternalKey
 
 type internalIterator = base.InternalIterator
 
-type internalIteratorWithStats = base.InternalIteratorWithStats
-
 // ErrCorruption is a marker to indicate that data in a file (WAL, MANIFEST,
 // sstable) isn't in the expected format.
 var ErrCorruption = base.ErrCorruption

--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -295,13 +295,6 @@ func (s SeekLTFlags) DisableRelativeSeek() SeekLTFlags {
 	return s &^ (1 << seekLTFlagRelativeSeek)
 }
 
-// InternalIteratorWithStats extends InternalIterator to expose stats.
-type InternalIteratorWithStats interface {
-	InternalIterator
-	Stats() InternalIteratorStats
-	ResetStats()
-}
-
 // InternalIteratorStats contains miscellaneous stats produced by
 // InternalIterators that are part of the InternalIterator tree. Not every
 // field is relevant for an InternalIterator implementation. The field values
@@ -340,31 +333,4 @@ func (s *InternalIteratorStats) Merge(from InternalIteratorStats) {
 	s.ValueBytes += from.ValueBytes
 	s.PointCount += from.PointCount
 	s.PointsCoveredByRangeTombstones += from.PointsCoveredByRangeTombstones
-}
-
-type internalIteratorWithEmptyStats struct {
-	InternalIterator
-}
-
-var _ InternalIteratorWithStats = internalIteratorWithEmptyStats{}
-
-// Stats implements InternalIteratorWithStats.
-func (i internalIteratorWithEmptyStats) Stats() InternalIteratorStats {
-	return InternalIteratorStats{}
-}
-
-// ResetStats implements InternalIteratorWithStats.
-func (i internalIteratorWithEmptyStats) ResetStats() {}
-
-// WrapIterWithStats ensures that either iter implements the stats methods or
-// wraps it, such that the return value implements InternalIteratorWithStats.
-func WrapIterWithStats(iter InternalIterator) InternalIteratorWithStats {
-	if iter == nil {
-		return nil
-	}
-	i, ok := iter.(InternalIteratorWithStats)
-	if ok {
-		return i
-	}
-	return internalIteratorWithEmptyStats{InternalIterator: iter}
 }

--- a/internal/base/iterator_test.go
+++ b/internal/base/iterator_test.go
@@ -6,35 +6,8 @@ package base
 
 import (
 	"fmt"
-	"math/rand"
-	"reflect"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
-
-func setRandUint64(v reflect.Value) uint64 {
-	val := rand.Uint64()
-	v.SetUint(val)
-	return val
-}
-
-func TestInternalIteratorStatsMerge(t *testing.T) {
-	var from, to, expected InternalIteratorStats
-	n := reflect.ValueOf(from).NumField()
-	for i := 0; i < n; i++ {
-		switch reflect.ValueOf(from).Type().Field(i).Type.Kind() {
-		case reflect.Uint64:
-			v1 := setRandUint64(reflect.ValueOf(&from).Elem().Field(i))
-			v2 := setRandUint64(reflect.ValueOf(&to).Elem().Field(i))
-			reflect.ValueOf(&expected).Elem().Field(i).SetUint(v1 + v2)
-		default:
-			t.Fatalf("unknown kind %v", reflect.ValueOf(from).Type().Field(i).Type.Kind())
-		}
-	}
-	to.Merge(from)
-	require.Equal(t, expected, to)
-}
 
 func TestFlags(t *testing.T) {
 	t.Run("SeekGEFlags", func(t *testing.T) {

--- a/internal/keyspan/interleaving_iter.go
+++ b/internal/keyspan/interleaving_iter.go
@@ -94,7 +94,7 @@ type SpanMask interface {
 type InterleavingIter struct {
 	cmp         base.Compare
 	comparer    *base.Comparer
-	pointIter   base.InternalIteratorWithStats
+	pointIter   base.InternalIterator
 	keyspanIter FragmentIterator
 	mask        SpanMask
 
@@ -178,7 +178,7 @@ var _ base.InternalIterator = &InterleavingIter{}
 // propagate the bounds down the iterator stack.
 func (i *InterleavingIter) Init(
 	comparer *base.Comparer,
-	pointIter base.InternalIteratorWithStats,
+	pointIter base.InternalIterator,
 	keyspanIter FragmentIterator,
 	mask SpanMask,
 	lowerBound, upperBound []byte,
@@ -1081,18 +1081,6 @@ func (i *InterleavingIter) Close() error {
 // String implements (base.InternalIterator).String.
 func (i *InterleavingIter) String() string {
 	return fmt.Sprintf("keyspan-interleaving(%q)", i.pointIter.String())
-}
-
-var _ base.InternalIteratorWithStats = &InterleavingIter{}
-
-// Stats implements InternalIteratorWithStats.
-func (i *InterleavingIter) Stats() base.InternalIteratorStats {
-	return i.pointIter.Stats()
-}
-
-// ResetStats implements InternalIteratorWithStats.
-func (i *InterleavingIter) ResetStats() {
-	i.pointIter.ResetStats()
 }
 
 func firstError(err0, err1 error) error {

--- a/internal/keyspan/interleaving_iter_test.go
+++ b/internal/keyspan/interleaving_iter_test.go
@@ -107,7 +107,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 			}
 			keyspanIter.Init(cmp, noopTransform, NewIter(cmp, spans))
 			hooks.maskSuffix = nil
-			iter.Init(testkeys.Comparer, base.WrapIterWithStats(&pointIter), &keyspanIter, &hooks, nil, nil)
+			iter.Init(testkeys.Comparer, &pointIter, &keyspanIter, &hooks, nil, nil)
 			return "OK"
 		case "define-pointkeys":
 			var points []base.InternalKey
@@ -117,7 +117,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 			}
 			pointIter = pointIterator{cmp: cmp, keys: points}
 			hooks.maskSuffix = nil
-			iter.Init(testkeys.Comparer, base.WrapIterWithStats(&pointIter), &keyspanIter, &hooks, nil, nil)
+			iter.Init(testkeys.Comparer, &pointIter, &keyspanIter, &hooks, nil, nil)
 			return "OK"
 		case "iter":
 			buf.Reset()

--- a/iterator.go
+++ b/iterator.go
@@ -149,8 +149,8 @@ type Iterator struct {
 	opts      IterOptions
 	merge     Merge
 	comparer  base.Comparer
-	iter      internalIteratorWithStats
-	pointIter internalIteratorWithStats
+	iter      internalIterator
+	pointIter internalIterator
 	readState *readState
 	// rangeKey holds iteration state specific to iteration over range keys.
 	// The range key field may be nil if the Iterator has never been configured
@@ -2138,14 +2138,11 @@ func (i *Iterator) Metrics() IteratorMetrics {
 // ResetStats resets the stats to 0.
 func (i *Iterator) ResetStats() {
 	i.stats = IteratorStats{}
-	i.iter.ResetStats()
 }
 
 // Stats returns the current stats.
 func (i *Iterator) Stats() IteratorStats {
-	stats := i.stats
-	stats.InternalStats = i.iter.Stats()
-	return stats
+	return i.stats
 }
 
 // CloneOptions configures an iterator constructed through Iterator.Clone.

--- a/range_keys.go
+++ b/range_keys.go
@@ -391,7 +391,7 @@ type lazyCombinedIter struct {
 	// iterator. It's used to mutate the internalIterator in use when switching
 	// to combined iteration.
 	parent            *Iterator
-	pointIter         internalIteratorWithStats
+	pointIter         internalIterator
 	combinedIterState combinedIterState
 }
 
@@ -662,12 +662,4 @@ func (i *lazyCombinedIter) String() string {
 		return i.parent.rangeKey.iiter.String()
 	}
 	return i.pointIter.String()
-}
-
-func (i *lazyCombinedIter) Stats() InternalIteratorStats {
-	return i.pointIter.Stats()
-}
-
-func (i *lazyCombinedIter) ResetStats() {
-	i.pointIter.ResetStats()
 }

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -872,6 +872,7 @@ func TestBlockProperties(t *testing.T) {
 		}
 	}()
 
+	var stats base.InternalIteratorStats
 	datadriven.RunTest(t, "testdata/block_properties", func(td *datadriven.TestData) string {
 		switch td.Cmd {
 		case "build":
@@ -1006,7 +1007,7 @@ func TestBlockProperties(t *testing.T) {
 			} else if !ok {
 				return "filter excludes entire table"
 			}
-			iter, err := r.NewIterWithBlockPropertyFilters(lower, upper, filterer, false /* use (bloom) filter */)
+			iter, err := r.NewIterWithBlockPropertyFilters(lower, upper, filterer, false /* use (bloom) filter */, &stats)
 			if err != nil {
 				return err.Error()
 			}
@@ -1029,6 +1030,7 @@ func TestBlockProperties_BoundLimited(t *testing.T) {
 		}
 	}()
 
+	var stats base.InternalIteratorStats
 	datadriven.RunTest(t, "testdata/block_properties_boundlimited", func(td *datadriven.TestData) string {
 		switch td.Cmd {
 		case "build":
@@ -1083,7 +1085,7 @@ func TestBlockProperties_BoundLimited(t *testing.T) {
 			} else if !ok {
 				return "filter excludes entire table"
 			}
-			iter, err := r.NewIterWithBlockPropertyFilters(lower, upper, filterer, false /* use (bloom) filter */)
+			iter, err := r.NewIterWithBlockPropertyFilters(lower, upper, filterer, false /* use (bloom) filter */, &stats)
 			if err != nil {
 				return err.Error()
 			}

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -249,6 +249,7 @@ type runIterCmdOption func(*runIterCmdOptions)
 type runIterCmdOptions struct {
 	everyOp      func(io.Writer)
 	everyOpAfter func(io.Writer)
+	stats        *base.InternalIteratorStats
 }
 
 func runIterCmdEveryOp(everyOp func(io.Writer)) runIterCmdOption {
@@ -257,6 +258,10 @@ func runIterCmdEveryOp(everyOp func(io.Writer)) runIterCmdOption {
 
 func runIterCmdEveryOpAfter(everyOp func(io.Writer)) runIterCmdOption {
 	return func(opts *runIterCmdOptions) { opts.everyOpAfter = everyOp }
+}
+
+func runIterCmdStats(stats *base.InternalIteratorStats) runIterCmdOption {
+	return func(opts *runIterCmdOptions) { opts.stats = stats }
 }
 
 func runIterCmd(td *datadriven.TestData, origIter Iterator, opt ...runIterCmdOption) string {
@@ -347,10 +352,10 @@ func runIterCmd(td *datadriven.TestData, origIter Iterator, opt ...runIterCmdOpt
 			}
 			iter.SetBounds(lower, upper)
 		case "stats":
-			fmt.Fprintf(&b, "%+v\n", iter.Stats())
+			fmt.Fprintf(&b, "%+v\n", *opts.stats)
 			continue
 		case "reset-stats":
-			iter.ResetStats()
+			*opts.stats = base.InternalIteratorStats{}
 			continue
 		}
 		if opts.everyOp != nil {

--- a/table_cache.go
+++ b/table_cache.go
@@ -414,7 +414,7 @@ func (c *tableCacheShard) newIters(
 		iter, err = v.reader.NewCompactionIter(internalOpts.bytesIterated)
 	} else {
 		iter, err = v.reader.NewIterWithBlockPropertyFilters(
-			opts.GetLowerBound(), opts.GetUpperBound(), filterer, useFilter)
+			opts.GetLowerBound(), opts.GetUpperBound(), filterer, useFilter, internalOpts.stats)
 	}
 	if err != nil {
 		if rangeDelIter != nil {


### PR DESCRIPTION
Replace the base.InternalIteratorWithStats interface with logic to propagate a
pointer to a shared *InternalIteratorStats down the iterator tree during
iterator construction. This reduces the cost of collecting stats, which no
longer needs to descend the iterator tree summing stats as it goes.

Informs cockroachdb/cockroach#86083.
Informs cockroachdb/cockroach#82559.

Edit: Eh, I think these benchmark results are somewhat fake because they're not consistently reproducing. There seems to be a lot of variance in these benchmarks.

```
name                                                                     old time/op    new time/op    delta
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=0-24           6.80µs ± 1%    6.58µs ± 1%  -3.16%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=1-24           14.1µs ± 1%    13.4µs ± 2%  -4.65%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=100-24          154µs ± 2%     155µs ± 1%    ~     (p=1.000 n=5+5)
MVCCScan_Pebble/rows=1/versions=2/valueSize=64/numRangeKeys=0-24           7.16µs ± 2%    7.05µs ± 1%    ~     (p=0.095 n=5+5)
MVCCScan_Pebble/rows=1/versions=2/valueSize=64/numRangeKeys=1-24           15.0µs ± 1%    14.4µs ± 2%  -3.90%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1/versions=2/valueSize=64/numRangeKeys=100-24          155µs ± 1%     156µs ± 2%    ~     (p=0.690 n=5+5)
MVCCScan_Pebble/rows=1/versions=10/valueSize=64/numRangeKeys=0-24          9.15µs ± 2%    8.72µs ± 3%  -4.71%  (p=0.032 n=5+5)
MVCCScan_Pebble/rows=1/versions=10/valueSize=64/numRangeKeys=1-24          18.2µs ± 2%    17.7µs ± 1%  -3.01%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1/versions=10/valueSize=64/numRangeKeys=100-24         147µs ± 4%     144µs ± 4%    ~     (p=0.151 n=5+5)
MVCCScan_Pebble/rows=1/versions=100/valueSize=64/numRangeKeys=0-24         18.1µs ± 2%    17.6µs ± 2%  -2.52%  (p=0.032 n=5+5)
MVCCScan_Pebble/rows=1/versions=100/valueSize=64/numRangeKeys=1-24         27.5µs ± 1%    26.9µs ± 1%  -2.18%  (p=0.032 n=5+5)
MVCCScan_Pebble/rows=1/versions=100/valueSize=64/numRangeKeys=100-24        112µs ± 4%     111µs ± 1%    ~     (p=0.151 n=5+5)
MVCCScan_Pebble/rows=10/versions=1/valueSize=64/numRangeKeys=0-24          12.1µs ± 2%    11.7µs ± 4%    ~     (p=0.056 n=5+5)
MVCCScan_Pebble/rows=10/versions=1/valueSize=64/numRangeKeys=1-24          21.5µs ± 1%    20.8µs ± 3%  -3.26%  (p=0.016 n=5+5)
MVCCScan_Pebble/rows=10/versions=1/valueSize=64/numRangeKeys=100-24         105µs ± 3%     105µs ± 1%    ~     (p=0.310 n=5+5)
MVCCScan_Pebble/rows=10/versions=2/valueSize=64/numRangeKeys=0-24          13.8µs ± 2%    13.4µs ± 1%  -3.07%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10/versions=2/valueSize=64/numRangeKeys=1-24          24.3µs ± 2%    23.5µs ± 2%  -2.98%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10/versions=2/valueSize=64/numRangeKeys=100-24         109µs ± 2%     108µs ± 2%    ~     (p=0.690 n=5+5)
MVCCScan_Pebble/rows=10/versions=10/valueSize=64/numRangeKeys=0-24         25.0µs ± 1%    24.4µs ± 2%  -2.37%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10/versions=10/valueSize=64/numRangeKeys=1-24         42.6µs ± 2%    41.0µs ± 1%  -3.83%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10/versions=10/valueSize=64/numRangeKeys=100-24        129µs ± 3%     127µs ± 1%    ~     (p=0.095 n=5+5)
MVCCScan_Pebble/rows=10/versions=100/valueSize=64/numRangeKeys=0-24        63.2µs ± 1%    61.6µs ± 1%  -2.48%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10/versions=100/valueSize=64/numRangeKeys=1-24        83.4µs ± 1%    81.1µs ± 1%  -2.71%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10/versions=100/valueSize=64/numRangeKeys=100-24       178µs ± 2%     175µs ± 2%    ~     (p=0.056 n=5+5)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=0-24         47.4µs ± 2%    47.5µs ± 3%    ~     (p=1.000 n=5+5)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=1-24         74.2µs ± 1%    72.1µs ± 2%  -2.74%  (p=0.032 n=5+5)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=100-24        173µs ± 1%     174µs ± 2%    ~     (p=0.690 n=5+5)
MVCCScan_Pebble/rows=100/versions=2/valueSize=64/numRangeKeys=0-24         60.8µs ± 2%    60.5µs ± 3%    ~     (p=0.421 n=5+5)
MVCCScan_Pebble/rows=100/versions=2/valueSize=64/numRangeKeys=1-24         95.8µs ± 1%    93.4µs ± 1%  -2.55%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=100/versions=2/valueSize=64/numRangeKeys=100-24        197µs ± 2%     195µs ± 3%    ~     (p=0.421 n=5+5)
MVCCScan_Pebble/rows=100/versions=10/valueSize=64/numRangeKeys=0-24         148µs ± 1%     146µs ± 2%    ~     (p=0.310 n=5+5)
MVCCScan_Pebble/rows=100/versions=10/valueSize=64/numRangeKeys=1-24         247µs ± 1%     240µs ± 1%  -2.89%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=100/versions=10/valueSize=64/numRangeKeys=100-24       390µs ± 2%     385µs ± 1%    ~     (p=0.421 n=5+5)
MVCCScan_Pebble/rows=100/versions=100/valueSize=64/numRangeKeys=0-24        441µs ± 2%     443µs ± 2%    ~     (p=0.690 n=5+5)
MVCCScan_Pebble/rows=100/versions=100/valueSize=64/numRangeKeys=1-24        558µs ± 1%     540µs ± 2%  -3.22%  (p=0.016 n=4+5)
MVCCScan_Pebble/rows=100/versions=100/valueSize=64/numRangeKeys=100-24      790µs ± 2%     771µs ± 1%  -2.36%  (p=0.016 n=5+5)
MVCCScan_Pebble/rows=1000/versions=1/valueSize=64/numRangeKeys=0-24         350µs ± 1%     352µs ± 1%    ~     (p=0.548 n=5+5)
MVCCScan_Pebble/rows=1000/versions=1/valueSize=64/numRangeKeys=1-24         539µs ± 1%     531µs ± 1%  -1.42%  (p=0.016 n=5+5)
MVCCScan_Pebble/rows=1000/versions=1/valueSize=64/numRangeKeys=100-24       759µs ± 1%     752µs ± 2%    ~     (p=0.222 n=5+5)
MVCCScan_Pebble/rows=1000/versions=2/valueSize=64/numRangeKeys=0-24         472µs ± 0%     474µs ± 1%    ~     (p=0.556 n=4+5)
MVCCScan_Pebble/rows=1000/versions=2/valueSize=64/numRangeKeys=1-24         755µs ± 1%     752µs ± 1%    ~     (p=0.548 n=5+5)
MVCCScan_Pebble/rows=1000/versions=2/valueSize=64/numRangeKeys=100-24      1.02ms ± 3%    0.97ms ± 1%  -4.30%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1000/versions=10/valueSize=64/numRangeKeys=0-24       1.29ms ± 1%    1.27ms ± 2%    ~     (p=0.056 n=5+5)
MVCCScan_Pebble/rows=1000/versions=10/valueSize=64/numRangeKeys=1-24       2.19ms ± 1%    2.11ms ± 1%  -3.80%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1000/versions=10/valueSize=64/numRangeKeys=100-24     2.82ms ± 2%    2.75ms ± 3%    ~     (p=0.056 n=5+5)
MVCCScan_Pebble/rows=1000/versions=100/valueSize=64/numRangeKeys=0-24      4.11ms ± 1%    4.03ms ± 1%  -1.86%  (p=0.032 n=5+5)
MVCCScan_Pebble/rows=1000/versions=100/valueSize=64/numRangeKeys=1-24      5.17ms ± 2%    4.96ms ± 2%  -4.07%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1000/versions=100/valueSize=64/numRangeKeys=100-24    6.69ms ± 2%    6.51ms ± 2%    ~     (p=0.056 n=5+5)
```