### PR TITLE
*: use Equal for more efficient equality comparisons

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1269,7 +1269,7 @@ func (c *compaction) newInputIter(
 		mi := &keyspan.MergingIter{}
 		mi.Init(c.cmp, rangeKeyCompactionTransform(snapshots, c.elideRangeKey), rangeKeyIters...)
 		di := &keyspan.DefragmentingIter{}
-		di.Init(c.cmp, mi, keyspan.DefragmentInternal, keyspan.StaticDefragmentReducer)
+		di.Init(c.comparer, mi, keyspan.DefragmentInternal, keyspan.StaticDefragmentReducer)
 		c.rangeKeyInterleaving.Init(c.comparer, pointKeyIter, di, nil /* hooks */, nil /* lowerBound */, nil /* upperBound */)
 		return &c.rangeKeyInterleaving, nil
 	}

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/internal/testkeys"
 )
 
 func TestGetIter(t *testing.T) {
@@ -463,8 +464,8 @@ func TestGetIter(t *testing.T) {
 		},
 	}
 
-	cmp := DefaultComparer.Compare
-	equal := DefaultComparer.Equal
+	cmp := testkeys.Comparer.Compare
+	equal := testkeys.Comparer.Equal
 	for _, tc := range testCases {
 		desc := tc.description[:strings.Index(tc.description, ":")]
 
@@ -538,8 +539,7 @@ func TestGetIter(t *testing.T) {
 			get.snapshot = ikey.SeqNum() + 1
 
 			i := &buf.dbi
-			i.cmp = cmp
-			i.equal = equal
+			i.comparer = *testkeys.Comparer
 			i.merge = DefaultMerger.Merge
 			i.iter = base.WrapIterWithStats(get)
 

--- a/internal/keyspan/defragment_test.go
+++ b/internal/keyspan/defragment_test.go
@@ -21,9 +21,10 @@ import (
 )
 
 func TestDefragmentingIter(t *testing.T) {
-	cmp := testkeys.Comparer.Compare
+	comparer := testkeys.Comparer
+	cmp := comparer.Compare
 	internalEqual := DefragmentInternal
-	alwaysEqual := DefragmentMethodFunc(func(_ base.Compare, _, _ *Span) bool { return true })
+	alwaysEqual := DefragmentMethodFunc(func(_ base.Equal, _, _ *Span) bool { return true })
 	staticReducer := StaticDefragmentReducer
 	collectReducer := func(cur, next []Key) []Key {
 		c := keysBySeqNumKind(append(cur, next...))
@@ -79,7 +80,7 @@ func TestDefragmentingIter(t *testing.T) {
 			var innerIter MergingIter
 			innerIter.Init(cmp, noopTransform, NewIter(cmp, spans))
 			var iter DefragmentingIter
-			iter.Init(cmp, &innerIter, equal, reducer)
+			iter.Init(comparer, &innerIter, equal, reducer)
 			for _, line := range strings.Split(td.Input, "\n") {
 				runIterOp(&buf, &iter, line)
 			}
@@ -103,8 +104,9 @@ func TestDefragmentingIter_RandomizedFixedSeed(t *testing.T) {
 }
 
 func testDefragmentingIteRandomizedOnce(t *testing.T, seed int64) {
-	cmp := testkeys.Comparer.Compare
-	formatKey := testkeys.Comparer.FormatKey
+	comparer := testkeys.Comparer
+	cmp := comparer.Compare
+	formatKey := comparer.FormatKey
 
 	rng := rand.New(rand.NewSource(seed))
 	t.Logf("seed = %d", seed)
@@ -163,8 +165,8 @@ func testDefragmentingIteRandomizedOnce(t *testing.T, seed int64) {
 	fragmentedInner.Init(cmp, noopTransform, NewIter(cmp, fragmented))
 
 	var referenceIter, fragmentedIter DefragmentingIter
-	referenceIter.Init(cmp, &originalInner, DefragmentInternal, StaticDefragmentReducer)
-	fragmentedIter.Init(cmp, &fragmentedInner, DefragmentInternal, StaticDefragmentReducer)
+	referenceIter.Init(comparer, &originalInner, DefragmentInternal, StaticDefragmentReducer)
+	fragmentedIter.Init(comparer, &fragmentedInner, DefragmentInternal, StaticDefragmentReducer)
 
 	// Generate 100 random operations and run them against both iterators.
 	const numIterOps = 100

--- a/internal/keyspan/interleaving_iter.go
+++ b/internal/keyspan/interleaving_iter.go
@@ -861,7 +861,7 @@ func (i *InterleavingIter) checkForwardBound(prefix []byte) {
 		}
 	}
 
-	if i.truncated && i.cmp(i.truncatedSpan.Start, i.truncatedSpan.End) == 0 {
+	if i.truncated && i.comparer.Equal(i.truncatedSpan.Start, i.truncatedSpan.End) {
 		i.span = nil
 	}
 }
@@ -898,7 +898,7 @@ func (i *InterleavingIter) checkBackwardBound() {
 		}
 		i.truncatedSpan.End = i.upper
 	}
-	if i.truncated && i.cmp(i.truncatedSpan.Start, i.truncatedSpan.End) == 0 {
+	if i.truncated && i.comparer.Equal(i.truncatedSpan.Start, i.truncatedSpan.End) {
 		i.span = nil
 	}
 }
@@ -932,7 +932,7 @@ func (i *InterleavingIter) yieldSyntheticSpanMarker(lowerBound []byte) (*base.In
 		// bound for truncating a span. The span a-z will be truncated to [k,
 		// z). If i.upper == k, we'd mistakenly try to return a span [k, k), an
 		// invariant violation.
-		if i.cmp(lowerBound, i.upper) == 0 {
+		if i.comparer.Equal(lowerBound, i.upper) {
 			return i.yieldNil()
 		}
 

--- a/internal/keyspan/span.go
+++ b/internal/keyspan/span.go
@@ -83,9 +83,9 @@ func (k Key) Kind() base.InternalKeyKind {
 // Equal returns true if this Key is equal to the given key. Two keys are said
 // to be equal if the two Keys have equal trailers, suffix and value. Suffix
 // comparison uses the provided base.Compare func. Value comparison is bytewise.
-func (k Key) Equal(cmp base.Compare, b Key) bool {
+func (k Key) Equal(equal base.Equal, b Key) bool {
 	return k.Trailer == b.Trailer &&
-		cmp(k.Suffix, b.Suffix) == 0 &&
+		equal(k.Suffix, b.Suffix) &&
 		bytes.Equal(k.Value, b.Value)
 }
 

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -204,7 +204,7 @@ func TestTableRangeDeletionIter(t *testing.T) {
 				return err.Error()
 			}
 			defer r.Close()
-			iter, err := newCombinedDeletionKeyspanIter(cmp, r, m)
+			iter, err := newCombinedDeletionKeyspanIter(base.DefaultComparer, r, m)
 			if err != nil {
 				return err.Error()
 			}


### PR DESCRIPTION
Use base.Equal for equality comparisons in more places. Equal(a,b) is faster
than Compare(a,b)==0. Additionally, embed the Comparer directly into the
Iterator struct for better cache locality and to avoid the additional pointer
indirection.

Informs #1819.
Informs cockroachdb/cockroach#82559.

```
name                                                                     old time/op    new time/op    delta
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=0-24           6.80µs ± 1%    6.72µs ± 2%    ~     (p=0.165 n=5+10)
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=1-24           14.1µs ± 1%    14.0µs ± 2%    ~     (p=0.107 n=5+10)
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=100-24          154µs ± 2%     152µs ± 2%    ~     (p=0.075 n=5+10)
MVCCScan_Pebble/rows=1/versions=2/valueSize=64/numRangeKeys=0-24           7.16µs ± 2%    7.10µs ± 1%    ~     (p=0.147 n=5+9)
MVCCScan_Pebble/rows=1/versions=2/valueSize=64/numRangeKeys=1-24           15.0µs ± 1%    14.9µs ± 1%  -0.94%  (p=0.007 n=5+9)
MVCCScan_Pebble/rows=1/versions=2/valueSize=64/numRangeKeys=100-24          155µs ± 1%     155µs ± 1%    ~     (p=0.513 n=5+10)
MVCCScan_Pebble/rows=1/versions=10/valueSize=64/numRangeKeys=0-24          9.15µs ± 2%    8.91µs ± 0%  -2.61%  (p=0.003 n=5+7)
MVCCScan_Pebble/rows=1/versions=10/valueSize=64/numRangeKeys=1-24          18.2µs ± 2%    18.1µs ± 1%    ~     (p=0.518 n=5+9)
MVCCScan_Pebble/rows=1/versions=10/valueSize=64/numRangeKeys=100-24         147µs ± 4%     145µs ± 2%    ~     (p=0.129 n=5+10)
MVCCScan_Pebble/rows=1/versions=100/valueSize=64/numRangeKeys=0-24         18.1µs ± 2%    17.7µs ± 1%  -1.98%  (p=0.013 n=5+10)
MVCCScan_Pebble/rows=1/versions=100/valueSize=64/numRangeKeys=1-24         27.5µs ± 1%    27.2µs ± 2%    ~     (p=0.206 n=5+10)
MVCCScan_Pebble/rows=1/versions=100/valueSize=64/numRangeKeys=100-24        112µs ± 4%     109µs ± 1%    ~     (p=0.075 n=5+10)
MVCCScan_Pebble/rows=10/versions=1/valueSize=64/numRangeKeys=0-24          12.1µs ± 2%    11.8µs ± 2%  -3.00%  (p=0.003 n=5+10)
MVCCScan_Pebble/rows=10/versions=1/valueSize=64/numRangeKeys=1-24          21.5µs ± 1%    20.8µs ± 1%  -3.02%  (p=0.001 n=5+9)
MVCCScan_Pebble/rows=10/versions=1/valueSize=64/numRangeKeys=100-24         105µs ± 3%     102µs ± 1%  -2.73%  (p=0.013 n=5+10)
MVCCScan_Pebble/rows=10/versions=2/valueSize=64/numRangeKeys=0-24          13.8µs ± 2%    13.4µs ± 4%  -2.89%  (p=0.013 n=5+10)
MVCCScan_Pebble/rows=10/versions=2/valueSize=64/numRangeKeys=1-24          24.3µs ± 2%    23.8µs ± 2%    ~     (p=0.075 n=5+10)
MVCCScan_Pebble/rows=10/versions=2/valueSize=64/numRangeKeys=100-24         109µs ± 2%     105µs ± 2%  -3.43%  (p=0.005 n=5+10)
MVCCScan_Pebble/rows=10/versions=10/valueSize=64/numRangeKeys=0-24         25.0µs ± 1%    24.2µs ± 3%  -3.27%  (p=0.001 n=5+10)
MVCCScan_Pebble/rows=10/versions=10/valueSize=64/numRangeKeys=1-24         42.6µs ± 2%    42.0µs ± 2%    ~     (p=0.055 n=5+10)
MVCCScan_Pebble/rows=10/versions=10/valueSize=64/numRangeKeys=100-24        129µs ± 3%     127µs ± 2%  -1.61%  (p=0.040 n=5+10)
MVCCScan_Pebble/rows=10/versions=100/valueSize=64/numRangeKeys=0-24        63.2µs ± 1%    61.7µs ± 1%  -2.30%  (p=0.001 n=5+10)
MVCCScan_Pebble/rows=10/versions=100/valueSize=64/numRangeKeys=1-24        83.4µs ± 1%    81.6µs ± 1%  -2.16%  (p=0.003 n=5+10)
MVCCScan_Pebble/rows=10/versions=100/valueSize=64/numRangeKeys=100-24       178µs ± 2%     173µs ± 1%  -2.46%  (p=0.001 n=5+10)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=0-24         47.4µs ± 2%    46.0µs ± 1%  -2.89%  (p=0.001 n=5+10)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=1-24         74.2µs ± 1%    71.2µs ± 2%  -4.06%  (p=0.001 n=5+10)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=100-24        173µs ± 1%     170µs ± 3%    ~     (p=0.055 n=5+10)
MVCCScan_Pebble/rows=100/versions=2/valueSize=64/numRangeKeys=0-24         60.8µs ± 2%    59.1µs ± 2%  -2.82%  (p=0.001 n=5+10)
MVCCScan_Pebble/rows=100/versions=2/valueSize=64/numRangeKeys=1-24         95.8µs ± 1%    94.2µs ± 2%  -1.75%  (p=0.019 n=5+10)
MVCCScan_Pebble/rows=100/versions=2/valueSize=64/numRangeKeys=100-24        197µs ± 2%     193µs ± 2%  -1.85%  (p=0.019 n=5+10)
MVCCScan_Pebble/rows=100/versions=10/valueSize=64/numRangeKeys=0-24         148µs ± 1%     145µs ± 1%  -1.66%  (p=0.003 n=5+10)
MVCCScan_Pebble/rows=100/versions=10/valueSize=64/numRangeKeys=1-24         247µs ± 1%     241µs ± 2%  -2.32%  (p=0.003 n=5+10)
MVCCScan_Pebble/rows=100/versions=10/valueSize=64/numRangeKeys=100-24       390µs ± 2%     382µs ± 2%  -1.95%  (p=0.028 n=5+10)
MVCCScan_Pebble/rows=100/versions=100/valueSize=64/numRangeKeys=0-24        441µs ± 2%     437µs ± 1%    ~     (p=0.222 n=5+8)
MVCCScan_Pebble/rows=100/versions=100/valueSize=64/numRangeKeys=1-24        558µs ± 1%     547µs ± 1%  -2.01%  (p=0.004 n=4+10)
MVCCScan_Pebble/rows=100/versions=100/valueSize=64/numRangeKeys=100-24      790µs ± 2%     774µs ± 2%  -1.93%  (p=0.008 n=5+10)
MVCCScan_Pebble/rows=1000/versions=1/valueSize=64/numRangeKeys=0-24         350µs ± 1%     346µs ± 1%    ~     (p=0.075 n=5+10)
MVCCScan_Pebble/rows=1000/versions=1/valueSize=64/numRangeKeys=1-24         539µs ± 1%     534µs ± 2%    ~     (p=0.206 n=5+10)
MVCCScan_Pebble/rows=1000/versions=1/valueSize=64/numRangeKeys=100-24       759µs ± 1%     747µs ± 1%  -1.61%  (p=0.008 n=5+10)
MVCCScan_Pebble/rows=1000/versions=2/valueSize=64/numRangeKeys=0-24         472µs ± 0%     466µs ± 0%  -1.12%  (p=0.003 n=4+9)
MVCCScan_Pebble/rows=1000/versions=2/valueSize=64/numRangeKeys=1-24         755µs ± 1%     740µs ± 1%  -2.03%  (p=0.001 n=5+10)
MVCCScan_Pebble/rows=1000/versions=2/valueSize=64/numRangeKeys=100-24      1.02ms ± 3%    0.96ms ± 2%  -5.05%  (p=0.001 n=5+10)
MVCCScan_Pebble/rows=1000/versions=10/valueSize=64/numRangeKeys=0-24       1.29ms ± 1%    1.28ms ± 1%  -1.42%  (p=0.005 n=5+10)
MVCCScan_Pebble/rows=1000/versions=10/valueSize=64/numRangeKeys=1-24       2.19ms ± 1%    2.13ms ± 1%  -2.64%  (p=0.001 n=5+10)
MVCCScan_Pebble/rows=1000/versions=10/valueSize=64/numRangeKeys=100-24     2.82ms ± 2%    2.77ms ± 2%    ~     (p=0.129 n=5+10)
MVCCScan_Pebble/rows=1000/versions=100/valueSize=64/numRangeKeys=0-24      4.11ms ± 1%    4.08ms ± 2%    ~     (p=0.859 n=5+10)
MVCCScan_Pebble/rows=1000/versions=100/valueSize=64/numRangeKeys=1-24      5.17ms ± 2%    5.08ms ± 2%    ~     (p=0.055 n=5+10)
MVCCScan_Pebble/rows=1000/versions=100/valueSize=64/numRangeKeys=100-24    6.69ms ± 2%    6.61ms ± 4%    ~     (p=0.206 n=5+10)
```