### PR TITLE
metamorphic: fix iterSeekLTWithlimit

### DIFF
--- a/internal/metamorphic/generator.go
+++ b/internal/metamorphic/generator.go
@@ -808,7 +808,7 @@ func (g *generator) iterSeekLTWithLimit(iterID objID) {
 		key, limit = limit, key
 	}
 	g.add(&iterSeekLTOp{
-		iterID: g.liveIters.rand(g.rng),
+		iterID: iterID,
 		key:    key,
 		limit:  limit,
 	})


### PR DESCRIPTION
In #1912, I forgot to update iterSeekLTWithLimit to actually use the iterID
parameter, rather than generating a random iterID.

Fix #1919.