### PR TITLE
metamorphic: increase probability of valid SeekPrefixGE calls

### DIFF
--- a/internal/metamorphic/key_manager_test.go
+++ b/internal/metamorphic/key_manager_test.go
@@ -112,6 +112,9 @@ func TestKeyMeta_MergeInto(t *testing.T) {
 				sets:      1,
 				merges:    0,
 				singleDel: true,
+				updateOps: []keyUpdate{
+					{deleted: true, metaTimestamp: 0},
+				},
 			},
 		},
 		{
@@ -131,6 +134,9 @@ func TestKeyMeta_MergeInto(t *testing.T) {
 				merges: 3,
 				dels:   15,
 				del:    true,
+				updateOps: []keyUpdate{
+					{deleted: true, metaTimestamp: 1},
+				},
 			},
 		},
 		{
@@ -151,13 +157,17 @@ func TestKeyMeta_MergeInto(t *testing.T) {
 				merges: 1,
 				dels:   15,
 				del:    false,
+				updateOps: []keyUpdate{
+					{deleted: false, metaTimestamp: 2},
+				},
 			},
 		},
 	}
 
+	keyManager := newKeyManager()
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
-			tc.toMerge.mergeInto(&tc.existing)
+			tc.toMerge.mergeInto(keyManager, &tc.existing)
 			require.Equal(t, tc.expected, tc.existing)
 		})
 	}


### PR DESCRIPTION
This pr increases the probablity of SeekPrefixGE calls which are in
range, and also makes it likely that the key passed to the
SeekPrefixGE function is readable by the iterator.

Currently, we only increase the probablity of valid SeekPrefixGE
calls for iterators created on the DB.