### PR TITLE
metamorphic: add limited concurrency

### DIFF
--- a/internal/metamorphic/testdata/reorder_history
+++ b/internal/metamorphic/testdata/reorder_history
@@ -1,0 +1,33 @@
+reorder
+Init(49 /* batches */, 66 /* iters */, 46 /* snapshots */) #0
+db.Set("ynnjczfq", "rvfk") // <nil> #1
+db.Get("ynnjczfq") // ["rvfk"] <nil> #2
+db.DeleteRange("ynnjczfq", "ynnjczfq") // <nil> #3
+db.SingleDelete("ynnjczfq", false /* maybeReplaceDelete */) // <nil> #4
+db.Restart() #5
+db.DeleteRange("ynnjczfq", "ynnjczfq") // <nil> #6
+----
+Init(49 /* batches */, 66 /* iters */, 46 /* snapshots */) #0
+db.Set("ynnjczfq", "rvfk") // <nil> #1
+db.Get("ynnjczfq") // ["rvfk"] <nil> #2
+db.DeleteRange("ynnjczfq", "ynnjczfq") // <nil> #3
+db.SingleDelete("ynnjczfq", false /* maybeReplaceDelete */) // <nil> #4
+db.Restart() #5
+db.DeleteRange("ynnjczfq", "ynnjczfq") // <nil> #6
+
+reorder
+db.DeleteRange("ynnjczfq", "ynnjczfq") // <nil> #6
+db.Restart() #5
+db.SingleDelete("ynnjczfq", false /* maybeReplaceDelete */) // <nil> #4
+db.DeleteRange("ynnjczfq", "ynnjczfq") // <nil> #3
+db.Get("ynnjczfq") // ["rvfk"] <nil> #2
+db.Set("ynnjczfq", "rvfk") // <nil> #1
+Init(49 /* batches */, 66 /* iters */, 46 /* snapshots */) #0
+----
+Init(49 /* batches */, 66 /* iters */, 46 /* snapshots */) #0
+db.Set("ynnjczfq", "rvfk") // <nil> #1
+db.Get("ynnjczfq") // ["rvfk"] <nil> #2
+db.DeleteRange("ynnjczfq", "ynnjczfq") // <nil> #3
+db.SingleDelete("ynnjczfq", false /* maybeReplaceDelete */) // <nil> #4
+db.Restart() #5
+db.DeleteRange("ynnjczfq", "ynnjczfq") // <nil> #6


### PR DESCRIPTION
Add a new test option that controls the number of concurrent execution
threads to use for running operations. To maintain determinism,
synchronization points are added at the level of objects: Each operation
defines the set of objects that it must synchronize on. Before
executing, operations block on completion of all operations with earlier
operation indexes that synchronize on any of the same objects.

The synchronization described above creates a strict partial order to
the operations, allowing operations on independent iterators and
independent batches to run concurrently. Notably this level of
synchronization does /not/ permit concurrent commits to the database,
since all operations that mutate the database state synchronize on the
database object. Future work may relax this restriction by synchronizing
on certain classes of operations per object (eg, database commits don't
need to synchronize on other database commits, but do need to
synchronize on database reads).

In order to make the concurrency a little more understandable, all
operations with the same receiver are performed by the same thread. This
also mimics real-world usages (eg, a single goroutine building a batch
and then commiting it). Objects are crudely hashed by ID to a thread,
and different concurrency values exercise different mappings of objects
to threads.

Synchronization ensures all operations produce identical results in all
histories, however the operations themselves may appear in different
orders. When comparing histories to detect divergences, the lines of
operations are sorted according to operation index before diffing.

All of the existing default standard options now run with a default max
concurrency of 16. A new standard option is added for entirely
sequential execution.

Close #1910.