### PR TITLE
*: don't close pointIter twice if bypassing merging iter

### DIFF
--- a/external_iterator.go
+++ b/external_iterator.go
@@ -231,6 +231,12 @@ func createExternalPointIter(it *Iterator) (internalIterator, error) {
 		}
 	}
 	if len(mlevels) == 1 && mlevels[0].rangeDelIter == nil {
+		// Set closePointIterOnce to true. This is because we're bypassing the
+		// merging iter, which turns Close()s on it idempotent for any child
+		// iterators. The outer Iterator could call Close() on a point iter twice,
+		// which sstable iterators do not support (as they release themselves to
+		// a pool).
+		it.closePointIterOnce = true
 		return mlevels[0].iter, nil
 	}
 

--- a/iterator.go
+++ b/iterator.go
@@ -235,6 +235,12 @@ type Iterator struct {
 	// Used for an optimization in external iterators to reduce the number of
 	// merging levels.
 	forwardOnly bool
+	// closePointIterOnce is set to true if this point iter can only be Close()d
+	// once, _and_ closing i.iter and then i.pointIter would close i.pointIter
+	// twice. This is necessary to track if the point iter is an internal iterator
+	// that could release its resources to a pool on Close(), making it harder for
+	// that iterator to make its own closes idempotent.
+	closePointIterOnce bool
 	// Used in some tests to disable the random disabling of seek optimizations.
 	forceEnableSeekOpt bool
 }
@@ -1739,7 +1745,7 @@ func (i *Iterator) Close() error {
 		// NB: If the iterators were still connected to i.iter, they may be
 		// closed, but calling Close on a closed internal iterator or fragment
 		// iterator is allowed.
-		if i.pointIter != nil {
+		if i.pointIter != nil && !i.closePointIterOnce {
 			i.err = firstError(i.err, i.pointIter.Close())
 		}
 		if i.rangeKey != nil && i.rangeKey.rangeKeyIter != nil {

--- a/testdata/external_iterator
+++ b/testdata/external_iterator
@@ -10,6 +10,22 @@ del-range c z
 # Test that a delete range in a more recent file shadows keys in an
 # earlier file.
 
+iter files=(1)
+first
+next
+next
+----
+b: (b, .)
+c: (c, .)
+.
+
+iter files=(1)
+seek-ge bb
+next
+----
+c: (c, .)
+.
+
 iter files=(2, 1) fwd-only
 first
 next


### PR DESCRIPTION
Currently, if the pointIter is an sstable iterator under an `Iterator`,
it could get Close()d twice. This is not an issue if the pointIter
is a merging iter as merging iters are idempotent for closes, but
sstable iterators release themselves into a pool on close so
making their closes idempotent is harder, and double-closes lead
to double iterator reuse.

This change adds a `closePointIterOnce bool` to track if the
point iter should only be closed once, _and_ that closing i.iter
would close it too.