### PR TITLE
docs: add benchmark annotation for #1822

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -61,6 +61,8 @@
           runtime to 90 minutes</div>
         <div class="annotation" data-date="20220330">Data quality issue introduced (YCSB A only)</div>
         <div class="annotation" data-date="20220526">Data quality issue fixed (YCSB A only)</div>
+        <div class="annotation" data-date="20200626">Began zeroing reused
+            iterator structs (#1822)</div>
       </div>
       <div class="section rows">
         <div>


### PR DESCRIPTION
In #1822 we began zeroing the entirety of the iterAlloc structure to avoid
accidental reuse bugs. This had a noticeable impact on read-heavy YCSB
workloads. Add an annotation to the benchmarks explaining this change.