### PR TITLE
internal/keyspan: remove unnecessary allocations

### DIFF
--- a/internal/keyspan/merging_iter.go
+++ b/internal/keyspan/merging_iter.go
@@ -826,7 +826,9 @@ func (m *MergingIter) synthesizeKeys(dir int8) (bool, *Span) {
 		Keys:      m.keys,
 		KeysOrder: ByTrailerDesc,
 	}
-	if err := m.transformer.Transform(m.cmp, s, &m.span); err != nil {
+	// NB: m.heap.cmp is a base.Compare, whereas m.cmp is a method on
+	// MergingIter.
+	if err := m.transformer.Transform(m.heap.cmp, s, &m.span); err != nil {
 		m.err = err
 		return false, nil
 	}


### PR DESCRIPTION
This bug crept in during a refactor. `m.cmp` is a convenience method defined on
the MergingIter which calls through to `m.heap.cmp`. Passing `m.cmp`, the
method on the merging iterator, was forcing an allocation during Transform calls.

```
name                           old time/op    new time/op    delta
CombinedIteratorSeekPrefix-10    91.1µs ± 0%    89.1µs ± 1%   -2.16%  (p=0.016 n=4+5)

name                           old alloc/op   new alloc/op   delta
CombinedIteratorSeekPrefix-10    2.25kB ± 0%    0.57kB ± 0%  -74.82%  (p=0.008 n=5+5)

name                           old allocs/op  new allocs/op  delta
CombinedIteratorSeekPrefix-10       140 ± 0%        35 ± 0%  -75.00%  (p=0.008 n=5+5)
```