### PR TITLE
crl-release-22.2: db: fix interaction between no-op optimizations and RangeKeyChanged

### DIFF
--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -1547,3 +1547,40 @@ a: (., [a-d) @1=foo UPDATED)
 a: (., [a-"a\x00") @1=foo UPDATED)
 .
 a: (., [a-"a\x00") @1=foo UPDATED)
+
+# Regression test for #1950 — Test a no-op call to SeekGE/SeekLT after a
+# SetBounds/SetOptions noop. The SetBounds/SetOptions noop made the iterator
+# appear to be invalidated, but the internal iterator state was preserved.
+# However, if the previous iterator state had a range key, this range key must
+# be considered changed for the purpose of calculating RangeKeyChanged().
+
+combined-iter lower=a upper=z
+seek-lt z
+set-bounds lower=a upper=z
+seek-lt y
+seek-ge 1
+set-bounds lower=a upper=z
+seek-ge a
+----
+a: (., [a-d) @1=foo UPDATED)
+.
+a: (., [a-d) @1=foo UPDATED)
+a: (., [a-d) @1=foo)
+.
+a: (., [a-d) @1=foo UPDATED)
+
+# Similar to the above regression, test that a no-op correctly returns
+# RangeKeyChanged()=false if there's no intervening SetOptions/SetBounds call.
+
+combined-iter lower=a upper=z
+seek-lt z
+seek-lt y
+set-bounds lower=a upper=z
+seek-ge 1
+seek-ge a
+----
+a: (., [a-d) @1=foo UPDATED)
+a: (., [a-d) @1=foo)
+.
+a: (., [a-d) @1=foo UPDATED)
+a: (., [a-d) @1=foo)


### PR DESCRIPTION
22.2 backport of #1953.

----

Previously, RangeKeyChanged could report a false negative when an iterator hit a no-op seek optimization. These seek optimizations avoid repositioning the iterator in cases of repeated, monotonically shifting seek keys. These optimizations reuse the current iterator state for the next position.

If the previous iterator operation was a no-op SetOptions or SetBounds call and the last seek operation resulted in RangeKeyChanged()=false the iterator could falsely preserve the RangeKeyChanged()=false state after the no-op seek operation. The first seek call to return a range key after a SetOptions or SetBounds call must return RangeKeyChanged()=true.

Close #1950.
Close #1952.