### PR TITLE
db: enable TrySeekUsingNext after Next in external iters

### DIFF
--- a/external_iterator.go
+++ b/external_iterator.go
@@ -193,7 +193,13 @@ func createExternalPointIter(it *Iterator) (internalIterator, error) {
 				pointIter    internalIterator
 				err          error
 			)
-			pointIter, err = r.NewIter(it.opts.LowerBound, it.opts.UpperBound)
+			pointIter, err = r.NewIterWithBlockPropertyFilters(
+				it.opts.LowerBound,
+				it.opts.UpperBound,
+				nil,   /* BlockPropertiesFilterer */
+				false, /* useFilterBlock */
+				&it.stats.InternalStats,
+			)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -301,8 +301,8 @@ func (s SeekLTFlags) DisableRelativeSeek() SeekLTFlags {
 // are aggregated as one goes up the InternalIterator tree.
 type InternalIteratorStats struct {
 	// Bytes in the loaded blocks. If the block was compressed, this is the
-	// compressed bytes. Currently, only the second-level index and data blocks
-	// containing points are included.
+	// compressed bytes. Currently, only the index blocks, data blocks
+	// containing points, and filter blocks are included.
 	BlockBytes uint64
 	// Subset of BlockBytes that were in the block cache.
 	BlockBytesInCache uint64

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -927,7 +927,7 @@ func TestBlockProperties(t *testing.T) {
 
 				// Enumerate point key data blocks encoded into the index.
 				if f != nil {
-					indexH, err := r.readIndex()
+					indexH, err := r.readIndex(nil /* stats */)
 					if err != nil {
 						return err.Error()
 					}
@@ -1264,7 +1264,7 @@ func runBlockPropertiesBuildCmd(td *datadriven.TestData) (r *Reader, out string)
 }
 
 func runBlockPropsCmd(r *Reader, td *datadriven.TestData) string {
-	bh, err := r.readIndex()
+	bh, err := r.readIndex(nil /* stats */)
 	if err != nil {
 		return err.Error()
 	}
@@ -1311,8 +1311,8 @@ func runBlockPropsCmd(r *Reader, td *datadriven.TestData) string {
 		// block that bhp points to, along with its block properties.
 		if twoLevelIndex {
 			subiter := &blockIter{}
-			subIndex, _, err := r.readBlock(
-				bhp.BlockHandle, nil /* transform */, nil /* readaheadState */)
+			subIndex, err := r.readBlock(
+				bhp.BlockHandle, nil /* transform */, nil /* readaheadState */, nil /* stats */)
 			if err != nil {
 				return err.Error()
 			}

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -304,7 +304,7 @@ func (i *singleLevelIterator) init(
 	if r.err != nil {
 		return r.err
 	}
-	indexH, err := r.readIndex()
+	indexH, err := r.readIndex(stats)
 	if err != nil {
 		return err
 	}
@@ -509,15 +509,7 @@ func (i *singleLevelIterator) resolveMaybeExcluded(dir int8) intersectsResult {
 func (i *singleLevelIterator) readBlockWithStats(
 	bh BlockHandle, raState *readaheadState,
 ) (cache.Handle, error) {
-	block, cacheHit, err := i.reader.readBlock(bh, nil /* transform */, raState)
-	if err == nil && i.stats != nil {
-		n := bh.Length
-		i.stats.BlockBytes += n
-		if cacheHit {
-			i.stats.BlockBytesInCache += n
-		}
-	}
-	return block, err
+	return i.reader.readBlock(bh, nil /* transform */, raState, i.stats)
 }
 
 func (i *singleLevelIterator) initBoundsForAlreadyLoadedBlock() {
@@ -765,7 +757,7 @@ func (i *singleLevelIterator) seekPrefixGE(
 		i.lastBloomFilterMatched = false
 		// Check prefix bloom filter.
 		var dataH cache.Handle
-		dataH, i.err = i.reader.readFilter()
+		dataH, i.err = i.reader.readFilter(i.stats)
 		if i.err != nil {
 			i.data.invalidate()
 			return nil, nil
@@ -1458,7 +1450,7 @@ func (i *twoLevelIterator) init(
 	if r.err != nil {
 		return r.err
 	}
-	topLevelIndexH, err := r.readIndex()
+	topLevelIndexH, err := r.readIndex(stats)
 	if err != nil {
 		return err
 	}
@@ -1592,7 +1584,7 @@ func (i *twoLevelIterator) SeekPrefixGE(
 		}
 		i.lastBloomFilterMatched = false
 		var dataH cache.Handle
-		dataH, i.err = i.reader.readFilter()
+		dataH, i.err = i.reader.readFilter(i.stats)
 		if i.err != nil {
 			i.data.invalidate()
 			return nil, nil
@@ -2486,7 +2478,7 @@ func (r *Reader) NewRawRangeDelIter() (keyspan.FragmentIterator, error) {
 	if r.rangeDelBH.Length == 0 {
 		return nil, nil
 	}
-	h, err := r.readRangeDel()
+	h, err := r.readRangeDel(nil /* stats */)
 	if err != nil {
 		return nil, err
 	}
@@ -2504,7 +2496,7 @@ func (r *Reader) NewRawRangeKeyIter() (keyspan.FragmentIterator, error) {
 	if r.rangeKeyBH.Length == 0 {
 		return nil, nil
 	}
-	h, err := r.readRangeKey()
+	h, err := r.readRangeKey(nil /* stats */)
 	if err != nil {
 		return nil, err
 	}
@@ -2526,28 +2518,20 @@ func (i *rangeKeyFragmentBlockIter) Close() error {
 	return err
 }
 
-func (r *Reader) readIndex() (cache.Handle, error) {
-	h, _, err :=
-		r.readBlock(r.indexBH, nil /* transform */, nil /* readaheadState */)
-	return h, err
+func (r *Reader) readIndex(stats *base.InternalIteratorStats) (cache.Handle, error) {
+	return r.readBlock(r.indexBH, nil /* transform */, nil /* readaheadState */, stats)
 }
 
-func (r *Reader) readFilter() (cache.Handle, error) {
-	h, _, err :=
-		r.readBlock(r.filterBH, nil /* transform */, nil /* readaheadState */)
-	return h, err
+func (r *Reader) readFilter(stats *base.InternalIteratorStats) (cache.Handle, error) {
+	return r.readBlock(r.filterBH, nil /* transform */, nil /* readaheadState */, stats)
 }
 
-func (r *Reader) readRangeDel() (cache.Handle, error) {
-	h, _, err :=
-		r.readBlock(r.rangeDelBH, r.rangeDelTransform, nil /* readaheadState */)
-	return h, err
+func (r *Reader) readRangeDel(stats *base.InternalIteratorStats) (cache.Handle, error) {
+	return r.readBlock(r.rangeDelBH, r.rangeDelTransform, nil /* readaheadState */, stats)
 }
 
-func (r *Reader) readRangeKey() (cache.Handle, error) {
-	h, _, err :=
-		r.readBlock(r.rangeKeyBH, nil /* transform */, nil /* readaheadState */)
-	return h, err
+func (r *Reader) readRangeKey(stats *base.InternalIteratorStats) (cache.Handle, error) {
+	return r.readBlock(r.rangeKeyBH, nil /* transform */, nil /* readaheadState */, stats)
 }
 
 func checkChecksum(
@@ -2574,13 +2558,20 @@ func checkChecksum(
 
 // readBlock reads and decompresses a block from disk into memory.
 func (r *Reader) readBlock(
-	bh BlockHandle, transform blockTransform, raState *readaheadState,
-) (_ cache.Handle, cacheHit bool, _ error) {
+	bh BlockHandle,
+	transform blockTransform,
+	raState *readaheadState,
+	stats *base.InternalIteratorStats,
+) (_ cache.Handle, _ error) {
 	if h := r.opts.Cache.Get(r.cacheID, r.fileNum, bh.Offset); h.Get() != nil {
 		if raState != nil {
 			raState.recordCacheHit(int64(bh.Offset), int64(bh.Length+blockTrailerLen))
 		}
-		return h, true, nil
+		if stats != nil {
+			stats.BlockBytes += bh.Length
+			stats.BlockBytesInCache += bh.Length
+		}
+		return h, nil
 	}
 	file := r.file
 
@@ -2625,12 +2616,12 @@ func (r *Reader) readBlock(
 	b := v.Buf()
 	if _, err := file.ReadAt(b, int64(bh.Offset)); err != nil {
 		r.opts.Cache.Free(v)
-		return cache.Handle{}, false, err
+		return cache.Handle{}, err
 	}
 
 	if err := checkChecksum(r.checksumType, b, bh, r.fileNum); err != nil {
 		r.opts.Cache.Free(v)
-		return cache.Handle{}, false, err
+		return cache.Handle{}, err
 	}
 
 	typ := blockType(b[bh.Length])
@@ -2644,7 +2635,7 @@ func (r *Reader) readBlock(
 		b = v.Buf()
 	} else if err != nil {
 		r.opts.Cache.Free(v)
-		return cache.Handle{}, false, err
+		return cache.Handle{}, err
 	}
 
 	if transform != nil {
@@ -2654,7 +2645,7 @@ func (r *Reader) readBlock(
 		b, err = transform(b)
 		if err != nil {
 			r.opts.Cache.Free(v)
-			return cache.Handle{}, false, err
+			return cache.Handle{}, err
 		}
 		newV := r.opts.Cache.Alloc(len(b))
 		copy(newV.Buf(), b)
@@ -2662,8 +2653,12 @@ func (r *Reader) readBlock(
 		v = newV
 	}
 
+	if stats != nil {
+		stats.BlockBytes += bh.Length
+	}
+
 	h := r.opts.Cache.Set(r.cacheID, r.fileNum, bh.Offset, v)
-	return h, false, nil
+	return h, nil
 }
 
 func (r *Reader) transformRangeDelV1(b []byte) ([]byte, error) {
@@ -2710,7 +2705,7 @@ func (r *Reader) transformRangeDelV1(b []byte) ([]byte, error) {
 }
 
 func (r *Reader) readMetaindex(metaindexBH BlockHandle) error {
-	b, _, err := r.readBlock(metaindexBH, nil /* transform */, nil /* readaheadState */)
+	b, err := r.readBlock(metaindexBH, nil /* transform */, nil /* readaheadState */, nil /* stats */)
 	if err != nil {
 		return err
 	}
@@ -2740,7 +2735,7 @@ func (r *Reader) readMetaindex(metaindexBH BlockHandle) error {
 	}
 
 	if bh, ok := meta[metaPropertiesName]; ok {
-		b, _, err = r.readBlock(bh, nil /* transform */, nil /* readaheadState */)
+		b, err = r.readBlock(bh, nil /* transform */, nil /* readaheadState */, nil /* stats */)
 		if err != nil {
 			return err
 		}
@@ -2811,7 +2806,7 @@ func (r *Reader) Layout() (*Layout, error) {
 		Footer:     r.footerBH,
 	}
 
-	indexH, err := r.readIndex()
+	indexH, err := r.readIndex(nil /* stats */)
 	if err != nil {
 		return nil, err
 	}
@@ -2848,8 +2843,8 @@ func (r *Reader) Layout() (*Layout, error) {
 			}
 			l.Index = append(l.Index, indexBH.BlockHandle)
 
-			subIndex, _, err := r.readBlock(
-				indexBH.BlockHandle, nil /* transform */, nil /* readaheadState */)
+			subIndex, err := r.readBlock(
+				indexBH.BlockHandle, nil /* transform */, nil /* readaheadState */, nil /* stats */)
 			if err != nil {
 				return nil, err
 			}
@@ -2914,7 +2909,7 @@ func (r *Reader) ValidateBlockChecksums() error {
 		}
 
 		// Read the block, which validates the checksum.
-		h, _, err := r.readBlock(bh, nil /* transform */, blockRS)
+		h, err := r.readBlock(bh, nil /* transform */, blockRS, nil /* stats */)
 		if err != nil {
 			return err
 		}
@@ -2944,7 +2939,7 @@ func (r *Reader) EstimateDiskUsage(start, end []byte) (uint64, error) {
 		return 0, r.err
 	}
 
-	indexH, err := r.readIndex()
+	indexH, err := r.readIndex(nil /* stats */)
 	if err != nil {
 		return 0, err
 	}
@@ -2976,8 +2971,8 @@ func (r *Reader) EstimateDiskUsage(start, end []byte) (uint64, error) {
 		if err != nil {
 			return 0, errCorruptIndexEntry
 		}
-		startIdxBlock, _, err := r.readBlock(
-			startIdxBH.BlockHandle, nil /* transform */, nil /* readaheadState */)
+		startIdxBlock, err := r.readBlock(
+			startIdxBH.BlockHandle, nil /* transform */, nil /* readaheadState */, nil /* stats */)
 		if err != nil {
 			return 0, err
 		}
@@ -2997,8 +2992,8 @@ func (r *Reader) EstimateDiskUsage(start, end []byte) (uint64, error) {
 			if err != nil {
 				return 0, errCorruptIndexEntry
 			}
-			endIdxBlock, _, err := r.readBlock(
-				endIdxBH.BlockHandle, nil /* transform */, nil /* readaheadState */)
+			endIdxBlock, err := r.readBlock(
+				endIdxBH.BlockHandle, nil /* transform */, nil /* readaheadState */, nil /* stats */)
 			if err != nil {
 				return 0, err
 			}
@@ -3255,7 +3250,7 @@ func (l *Layout) Describe(
 			continue
 		}
 
-		h, _, err := r.readBlock(b.BlockHandle, nil /* transform */, nil /* readaheadState */)
+		h, err := r.readBlock(b.BlockHandle, nil /* transform */, nil /* readaheadState */, nil /* stats */)
 		if err != nil {
 			fmt.Fprintf(w, "  [err: %s]\n", err)
 			continue

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -38,7 +38,7 @@ func (r *Reader) get(key []byte) (value []byte, err error) {
 	}
 
 	if r.tableFilter != nil {
-		dataH, err := r.readFilter()
+		dataH, err := r.readFilter(nil /* stats */)
 		if err != nil {
 			return nil, err
 		}

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -692,7 +692,7 @@ func TestMetaIndexEntriesSorted(t *testing.T) {
 	r, err := NewReader(f, ReaderOptions{})
 	require.NoError(t, err)
 
-	b, _, err := r.readBlock(r.metaIndexBH, nil /* transform */, nil /* attrs */)
+	b, err := r.readBlock(r.metaIndexBH, nil /* transform */, nil /* attrs */, nil /* stats */)
 	require.NoError(t, err)
 	defer b.Release()
 

--- a/sstable/testdata/readerstats/iter
+++ b/sstable/testdata/readerstats/iter
@@ -35,25 +35,25 @@ first
 stats
 ----
 <a:1>
-{BlockBytes:34 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{BlockBytes:74 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 <b:2>
-{BlockBytes:34 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{BlockBytes:74 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 <c:3>
-{BlockBytes:68 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{BlockBytes:108 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 <d:4>
-{BlockBytes:68 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{BlockBytes:108 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 .
-{BlockBytes:68 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{BlockBytes:108 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 <a:1>
-{BlockBytes:102 BlockBytesInCache:34 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{BlockBytes:142 BlockBytesInCache:34 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 <b:2>
-{BlockBytes:102 BlockBytesInCache:34 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{BlockBytes:142 BlockBytesInCache:34 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 <c:3>
-{BlockBytes:136 BlockBytesInCache:68 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{BlockBytes:176 BlockBytesInCache:68 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 <d:4>
-{BlockBytes:136 BlockBytesInCache:68 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{BlockBytes:176 BlockBytesInCache:68 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 .
-{BlockBytes:136 BlockBytesInCache:68 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{BlockBytes:176 BlockBytesInCache:68 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 {BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 <a:1>
 {BlockBytes:34 BlockBytesInCache:34 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}

--- a/testdata/external_iterator
+++ b/testdata/external_iterator
@@ -193,3 +193,94 @@ c@2:v
 .
 e@5:v
 k@3:v
+
+# Test the TrySeekUsingNext optimization that's enabled only for fwd-only
+# external iterators. Seed the database with keys like 'a', 'aa', 'aaa', etc so
+# that the index block uses a final separator that's beyond all the other live
+# keys.
+
+reset
+----
+
+build a
+set a@3 a@3
+set a@1 a@1
+----
+
+build aa
+set aa@3 aa@3
+set aa@1 aa@1
+----
+
+build aaa
+set aaa@3 aaa@3
+set aaa@1 aaa@1
+----
+
+build aaaa
+set aaaa@3 aaaa@3
+set aaaa@1 aaaa@1
+----
+
+build aaaaa
+set aaaaa@3 aaaaa@3
+set aaaaa@1 aaaaa@1
+----
+
+# Note the absence of fwd-only. This iterator will not use the TrySeekUsingNext
+# optimization.
+
+iter files=(a, aa, aaa, aaaa, aaaaa)
+seek-ge a
+next
+seek-ge aa
+next
+seek-ge aaa
+next
+seek-ge aaaa
+next
+seek-ge aaaaa
+next
+stats
+----
+a@3: (a@3, .)
+a@1: (a@1, .)
+aa@3: (aa@3, .)
+aa@1: (aa@1, .)
+aaa@3: (aaa@3, .)
+aaa@1: (aaa@1, .)
+aaaa@3: (aaaa@3, .)
+aaaa@1: (aaaa@1, .)
+aaaaa@3: (aaaaa@3, .)
+aaaaa@1: (aaaaa@1, .)
+stats: (interface (dir, seek, step): (fwd, 5, 5), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 5, 5), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 480 B, cached 0 B)), (points: (count 10, key-bytes 50, value-bytes 50, tombstoned: 0))
+
+# Note the inclusion of fwd-only. This iterator will use the TrySeekUsingNext
+# optimization and loads ~half the block-bytes as a result.
+
+iter files=(a, aa, aaa, aaaa, aaaaa) fwd-only
+seek-ge a
+next
+seek-ge aa
+next
+seek-ge aaa
+next
+seek-ge aaaa
+next
+seek-ge aaaaa
+next
+stats
+----
+a@3: (a@3, .)
+a@1: (a@1, .)
+aa@3: (aa@3, .)
+aa@1: (aa@1, .)
+aaa@3: (aaa@3, .)
+aaa@1: (aaa@1, .)
+aaaa@3: (aaaa@3, .)
+aaaa@1: (aaaa@1, .)
+aaaaa@3: (aaaaa@3, .)
+aaaaa@1: (aaaaa@1, .)
+stats: (interface (dir, seek, step): (fwd, 5, 5), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 5, 5), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 286 B, cached 0 B)), (points: (count 10, key-bytes 50, value-bytes 50, tombstoned: 0))

--- a/testdata/iterator_stats
+++ b/testdata/iterator_stats
@@ -18,7 +18,7 @@ a:1
 c:2
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 34 B, cached 34 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (block-bytes: (total 56 B, cached 56 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
 
 # Perform the same operation again with a new iterator. It should yield
 # identical statistics.
@@ -33,4 +33,4 @@ a:1
 c:2
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 34 B, cached 34 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (block-bytes: (total 56 B, cached 56 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))

--- a/testdata/level_iter_seek
+++ b/testdata/level_iter_seek
@@ -109,20 +109,20 @@ reset-stats
 stats
 ----
 a/<invalid>#9,1:a
-{BlockBytes:34 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{BlockBytes:56 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 {BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 b#8,1:b
 {BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 c#7,1:c
-{BlockBytes:34 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{BlockBytes:56 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 f#5,1:f
-{BlockBytes:34 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{BlockBytes:56 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 g#4,1:g
-{BlockBytes:68 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{BlockBytes:112 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 h#3,1:h
-{BlockBytes:68 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{BlockBytes:112 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 .
-{BlockBytes:68 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
+{BlockBytes:112 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 {BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 
 iter

--- a/testdata/merging_iter
+++ b/testdata/merging_iter
@@ -40,7 +40,7 @@ c#27,1:27
 e#72057594037927935,15:
 e#10,1:10
 g#20,1:20
-{BlockBytes:72 BlockBytesInCache:0 KeyBytes:5 ValueBytes:8 PointCount:5 PointsCoveredByRangeTombstones:0}
+{BlockBytes:116 BlockBytesInCache:0 KeyBytes:5 ValueBytes:8 PointCount:5 PointsCoveredByRangeTombstones:0}
 {BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 
 # seekGE() should not allow the rangedel to act on points in the lower sstable that are after it.
@@ -582,7 +582,7 @@ next
 stats
 ----
 a#30,1:30
-{BlockBytes:75 BlockBytesInCache:0 KeyBytes:1 ValueBytes:2 PointCount:1 PointsCoveredByRangeTombstones:0}
+{BlockBytes:97 BlockBytesInCache:0 KeyBytes:1 ValueBytes:2 PointCount:1 PointsCoveredByRangeTombstones:0}
 {BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 f#21,1:21
 {BlockBytes:0 BlockBytesInCache:0 KeyBytes:5 ValueBytes:10 PointCount:5 PointsCoveredByRangeTombstones:4}

--- a/testdata/rangekeys
+++ b/testdata/rangekeys
@@ -993,7 +993,7 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 625 B, cached 0 B)), (points: (count 25, key-bytes 75, value-bytes 75, tombstoned: 0))
+(internal-stats: (block-bytes: (total 1.1 K, cached 0 B)), (points: (count 25, key-bytes 75, value-bytes 75, tombstoned: 0))
 
 # Repeat the above test, but with an iterator that uses a block-property filter
 # mask. The internal stats should reflect fewer bytes read and fewer points
@@ -1007,7 +1007,7 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 50 B, cached 50 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+(internal-stats: (block-bytes: (total 515 B, cached 515 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
 
 # Perform a similar comparison in reverse.
 
@@ -1019,7 +1019,7 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 625 B, cached 625 B)), (points: (count 25, key-bytes 75, value-bytes 75, tombstoned: 0))
+(internal-stats: (block-bytes: (total 1.1 K, cached 1.1 K)), (points: (count 25, key-bytes 75, value-bytes 75, tombstoned: 0))
 
 combined-iter mask-suffix=@9 mask-filter
 last
@@ -1029,7 +1029,7 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 50 B, cached 50 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+(internal-stats: (block-bytes: (total 515 B, cached 515 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
 
 # Perform similar comparisons with seeks.
 
@@ -1041,7 +1041,7 @@ stats
 m: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 325 B, cached 325 B)), (points: (count 13, key-bytes 39, value-bytes 39, tombstoned: 0))
+(internal-stats: (block-bytes: (total 790 B, cached 790 B)), (points: (count 13, key-bytes 39, value-bytes 39, tombstoned: 0))
 
 combined-iter mask-suffix=@9 mask-filter
 seek-ge m
@@ -1051,7 +1051,7 @@ stats
 m: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 50 B, cached 50 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+(internal-stats: (block-bytes: (total 515 B, cached 515 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
 
 combined-iter mask-suffix=@9
 seek-lt m
@@ -1061,7 +1061,7 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 325 B, cached 325 B)), (points: (count 12, key-bytes 36, value-bytes 36, tombstoned: 0))
+(internal-stats: (block-bytes: (total 790 B, cached 790 B)), (points: (count 12, key-bytes 36, value-bytes 36, tombstoned: 0))
 
 combined-iter mask-suffix=@9 mask-filter
 seek-lt m
@@ -1071,7 +1071,7 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 75 B, cached 75 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+(internal-stats: (block-bytes: (total 540 B, cached 540 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
 
 # Test repeated seeks into the same range key, while TrySeekUsingNext=true.
 # Test for regression fixed in #1849.


### PR DESCRIPTION
**sstable: include more blocks' stats in BlockBytes**

Previously, BlockBytes and BlockBytesInCache only included data blocks
and sometimes the top-level index block. Now it always includes the
top-level index block, the first-level index block and the filter block.

This is motivated by a latter commit that needs the inclusion of index
blocks for a test case that illustrates the effectiveness of an
optimization.

**db: add ExternalIter_NonOverlapping_SeekNextScan benchmark**

Add a new benchmark that illustrates the pathological behavior of an external
iterator that must repeatedly seek into exhausted sstables.

**db: enable TrySeekUsingNext after Next in external iters**

Enable the TrySeekUsingNext optimization in another case, specifically
for external iterators. Previously this optimization only applied if the
previous positioning operation was also a seek.

This commit also enables it during forward iteration of external
iterators if the seek key is strictly greater than the current iterator
position's user key. This allows the optimization to trigger during
workloads that perform SeekGEs with monotonically increasing keys,
interspersed with Nexts. This is the case for CockroachDB scans.

This optimization is not enabled for non-external iterators because it
is unclear whether there is a performance benefit in these case. This
optimization is particularly beneficial with external iterators, because
it avoids the pathological behavior of re-seeking exhausted sstable
iterators.

Informs cockroachdb/cockroach#88329.

```
name                                                                                  old time/op    new time/op    delta
ExternalIter_NonOverlapping_SeekNextScan/keys=100/files=1/forward-only=false-16         45.8µs ± 1%    46.4µs ± 3%     ~     (p=0.222 n=5+5)
ExternalIter_NonOverlapping_SeekNextScan/keys=100/files=1/forward-only=true-16          46.0µs ± 1%    35.4µs ± 2%  -23.02%  (p=0.008 n=5+5)
ExternalIter_NonOverlapping_SeekNextScan/keys=100/files=10/forward-only=false-16         532µs ± 1%     545µs ± 2%   +2.40%  (p=0.016 n=5+5)
ExternalIter_NonOverlapping_SeekNextScan/keys=100/files=10/forward-only=true-16          533µs ± 1%     300µs ± 0%  -43.67%  (p=0.008 n=5+5)
ExternalIter_NonOverlapping_SeekNextScan/keys=100/files=100/forward-only=false-16       6.27ms ± 4%    6.09ms ± 1%     ~     (p=0.151 n=5+5)
ExternalIter_NonOverlapping_SeekNextScan/keys=100/files=100/forward-only=true-16        5.93ms ± 1%    4.66ms ± 1%  -21.53%  (p=0.008 n=5+5)
ExternalIter_NonOverlapping_SeekNextScan/keys=10000/files=1/forward-only=false-16       2.06ms ± 1%    2.15ms ± 1%   +4.12%  (p=0.008 n=5+5)
ExternalIter_NonOverlapping_SeekNextScan/keys=10000/files=1/forward-only=true-16        2.10ms ± 2%    0.64ms ± 0%  -69.68%  (p=0.008 n=5+5)
ExternalIter_NonOverlapping_SeekNextScan/keys=10000/files=10/forward-only=false-16      48.2ms ± 1%    48.9ms ± 2%     ~     (p=0.095 n=5+5)
ExternalIter_NonOverlapping_SeekNextScan/keys=10000/files=10/forward-only=true-16       48.5ms ± 3%     2.1ms ± 1%  -95.64%  (p=0.008 n=5+5)
ExternalIter_NonOverlapping_SeekNextScan/keys=10000/files=100/forward-only=false-16      461ms ± 1%     470ms ± 3%     ~     (p=0.095 n=5+5)
ExternalIter_NonOverlapping_SeekNextScan/keys=10000/files=100/forward-only=true-16       461ms ± 2%      15ms ± 1%  -96.67%  (p=0.008 n=5+5)
ExternalIter_NonOverlapping_SeekNextScan/keys=100000/files=1/forward-only=false-16       256ms ± 1%     257ms ± 2%     ~     (p=0.421 n=5+5)
ExternalIter_NonOverlapping_SeekNextScan/keys=100000/files=1/forward-only=true-16        255ms ± 2%       7ms ± 1%  -97.38%  (p=0.008 n=5+5)
ExternalIter_NonOverlapping_SeekNextScan/keys=100000/files=10/forward-only=false-16      438ms ± 2%     446ms ± 2%     ~     (p=0.095 n=5+5)
ExternalIter_NonOverlapping_SeekNextScan/keys=100000/files=10/forward-only=true-16       444ms ± 3%      19ms ± 1%  -95.81%  (p=0.008 n=5+5)
ExternalIter_NonOverlapping_SeekNextScan/keys=100000/files=100/forward-only=false-16     5.26s ± 1%     5.37s ± 1%   +2.16%  (p=0.008 n=5+5)
ExternalIter_NonOverlapping_SeekNextScan/keys=100000/files=100/forward-only=true-16      5.26s ± 1%     0.11s ± 1%  -97.92%  (p=0.008 n=5+5)
```
