### PR TITLE
metrics: expose InternalIntervalMetrics as cumulative metrics

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -1311,4 +1312,84 @@ func verifyGetNotFound(t *testing.T, r Reader, key []byte) {
 	if err != base.ErrNotFound {
 		t.Fatalf("expected nil, but got %s", val)
 	}
+}
+
+func TestFlushIntervalMetrics(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test is flaky on windows")
+	}
+	sumIntervalMetrics := InternalIntervalMetrics{}
+	mem := vfs.NewMem()
+	d, err := Open("", testingRandomized(&Options{
+		FS: mem,
+	}))
+	require.NoError(t, err)
+	// Flush metrics are updated after and non-atomically with the memtable
+	// being removed from the queue.
+	waitAndAccumlateIntervalMetrics := func() {
+		begin := time.Now()
+		for {
+			metrics := d.InternalIntervalMetrics()
+			sumIntervalMetrics.Flush.WriteThroughput.Merge(metrics.Flush.WriteThroughput)
+			sumIntervalMetrics.LogWriter.WriteThroughput.Merge(metrics.LogWriter.WriteThroughput)
+			if sumIntervalMetrics.LogWriter.SyncLatencyMicros == nil {
+				sumIntervalMetrics.LogWriter.SyncLatencyMicros = metrics.LogWriter.SyncLatencyMicros
+			} else {
+				sumIntervalMetrics.LogWriter.SyncLatencyMicros.Merge(metrics.LogWriter.SyncLatencyMicros)
+			}
+
+			require.NotNil(t, metrics)
+			if int64(50<<10) < metrics.Flush.WriteThroughput.Bytes {
+				// The writes (during which the flush is idle) and the flush work
+				// should not be so fast as to be unrealistic. If these turn out to be
+				// flaky we could instead inject a clock.
+				tinyInterval := int64(50 * time.Microsecond)
+				require.Less(t, tinyInterval, int64(metrics.Flush.WriteThroughput.WorkDuration))
+				require.Less(t, tinyInterval, int64(metrics.Flush.WriteThroughput.IdleDuration))
+				return
+			}
+			if time.Since(begin) > 2*time.Second {
+				t.Fatal()
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	writeAndFlush := func() {
+		// Add the key "a" to the memtable, then fill up the memtable with the key
+		// prefix "b". The compaction will only overlap with the queued memtable,
+		// not the mutable memtable.
+		// NB: The initial memtable size is 256KB, which is filled up with random
+		// values which typically don't compress well. The test also appends the
+		// random value to the "b" key to limit overwriting of the same key, which
+		// would get collapsed at flush time since there are no open snapshots.
+		value := make([]byte, 50)
+		rand.Read(value)
+		require.NoError(t, d.Set([]byte("a"), value, nil))
+		for {
+			rand.Read(value)
+			require.NoError(t, d.Set(append([]byte("b"), value...), value, nil))
+			d.mu.Lock()
+			done := len(d.mu.mem.queue) == 2
+			d.mu.Unlock()
+			if done {
+				break
+			}
+		}
+
+		require.NoError(t, d.Compact([]byte("a"), []byte("a\x00"), false))
+		d.mu.Lock()
+		require.Equal(t, 1, len(d.mu.mem.queue))
+		d.mu.Unlock()
+	}
+
+	writeAndFlush()
+	waitAndAccumlateIntervalMetrics()
+	writeAndFlush()
+	waitAndAccumlateIntervalMetrics()
+
+	require.NoError(t, d.Close())
+	dbMetrics := d.Metrics()
+	require.Equal(t, dbMetrics.Flush.WriteThroughput.Bytes, sumIntervalMetrics.Flush.WriteThroughput.Bytes)
+	require.Equal(t, dbMetrics.LogWriter.SyncLatencyMicros.Export(), sumIntervalMetrics.LogWriter.SyncLatencyMicros.Export())
 }

--- a/internal/base/metrics.go
+++ b/internal/base/metrics.go
@@ -29,6 +29,13 @@ func (tm *ThroughputMetric) Merge(x ThroughputMetric) {
 	tm.IdleDuration += x.IdleDuration
 }
 
+// Subtract subtracts the information from another ThroughputMetric
+func (tm *ThroughputMetric) Subtract(x ThroughputMetric) {
+	tm.Bytes -= x.Bytes
+	tm.WorkDuration -= x.WorkDuration
+	tm.IdleDuration -= x.IdleDuration
+}
+
 // PeakRate returns the approximate peak rate if there was no idling.
 func (tm *ThroughputMetric) PeakRate() int64 {
 	if tm.Bytes == 0 {
@@ -65,6 +72,12 @@ func (gsm *GaugeSampleMetric) AddSample(sample int64) {
 func (gsm *GaugeSampleMetric) Merge(x GaugeSampleMetric) {
 	gsm.sampleSum += x.sampleSum
 	gsm.count += x.count
+}
+
+// Subtract subtracts the information from another gauge metric.
+func (gsm *GaugeSampleMetric) Subtract(x GaugeSampleMetric) {
+	gsm.sampleSum -= x.sampleSum
+	gsm.count -= x.count
 }
 
 // Mean returns the mean value.

--- a/internal/base/metrics_test.go
+++ b/internal/base/metrics_test.go
@@ -31,6 +31,24 @@ func TestThroughputMetric(t *testing.T) {
 	require.EqualValues(t, 10*1000, m1.PeakRate())
 }
 
+func TestThroughputMetric_Subtract(t *testing.T) {
+	m1 := ThroughputMetric{
+		Bytes:        10,
+		WorkDuration: time.Millisecond,
+		IdleDuration: 9 * time.Millisecond,
+	}
+	m2 := ThroughputMetric{
+		Bytes:        100,
+		WorkDuration: time.Millisecond,
+		IdleDuration: 90 * time.Millisecond,
+	}
+
+	m2.Subtract(m1)
+	require.Equal(t, int64(90), m2.Bytes)
+	require.Equal(t, 0*time.Millisecond, m2.WorkDuration)
+	require.Equal(t, 81*time.Millisecond, m2.IdleDuration)
+}
+
 func TestGaugeSampleMetric(t *testing.T) {
 	g1 := GaugeSampleMetric{}
 	g1.AddSample(10)
@@ -42,4 +60,20 @@ func TestGaugeSampleMetric(t *testing.T) {
 	require.EqualValues(t, 3, g2.count)
 	require.EqualValues(t, 15, g1.Mean())
 	require.EqualValues(t, 2, g1.count)
+}
+
+func TestGaugeSampleMetricSubtract(t *testing.T) {
+	g1 := GaugeSampleMetric{}
+	g2 := GaugeSampleMetric{}
+	g1.AddSample(10)
+	g1.AddSample(20)
+	g1.AddSample(0)
+
+	g2.AddSample(10)
+
+	g1.Subtract(g2)
+
+	require.Equal(t, int64(20), g1.sampleSum)
+	require.Equal(t, int64(2), g1.count)
+
 }

--- a/metrics.go
+++ b/metrics.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/humanize"
+	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/redact"
 )
@@ -158,7 +159,8 @@ type Metrics struct {
 
 	Flush struct {
 		// The total number of flushes.
-		Count int64
+		Count           int64
+		WriteThroughput ThroughputMetric
 	}
 
 	Filter FilterMetrics
@@ -226,6 +228,8 @@ type Metrics struct {
 		// Number of bytes written to the WAL.
 		BytesWritten uint64
 	}
+
+	LogWriter record.LogWriterMetrics
 
 	private struct {
 		optionsFileSize  uint64


### PR DESCRIPTION
Move the metrics stored on the `InternalIntervalMetrics` struct to the `Metrics` struct. Moving these metrics will enable multiple clients to get the metrics over an interval. Currently, if two clients interact with `GetInternalIntervalMetrics` one client will reset the other client’s interval. Ex: Client A calls every 5 seconds and Client B calls every 10 seconds. Client B will end up getting metrics at a 5-second interval since `GetInternalIntervalMetrics` resets the interval on each call.

Refactor `GetInternalIntervalMetrics` to use the
`InternalIntervalMetrics`  that have been moved over to `Metrics`. In order to facilitate the calculation of the delta between calls to `GetInternalIntervalMetrics`, `DB.mu.lastIntervalMetrics` has been added. Each call to  `GetInternalIntervalMetrics` will update this value and use it for subsequent interval calculation.

closes: #1954