### PR TITLE
db: fix RangeKeyChanged and -WithLimit interaction 

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -1011,11 +1011,21 @@ func (i *Iterator) SeekGE(key []byte) bool {
 func (i *Iterator) SeekGEWithLimit(key []byte, limit []byte) IterValidityState {
 	if i.rangeKey != nil {
 		// NB: Check Valid() before clearing requiresReposition.
-		i.rangeKey.updated = false
 		i.rangeKey.prevPosHadRangeKey = i.rangeKey.hasRangeKey && i.Valid()
+		// If we have a range key but did not expose it at the previous iterator
+		// position (because the iterator was not at a valid position), updated
+		// must be true. This ensures that after an iterator op sequence like:
+		//   - Next()             → (IterValid, RangeBounds() = [a,b))
+		//   - NextWithLimit(...) → (IterAtLimit, RangeBounds() = -)
+		//   - SeekGE(...)        → (IterValid, RangeBounds() = [a,b))
+		// the iterator returns RangeKeyChanged()=true.
+		//
+		// The remainder of this function will only update i.rangeKey.updated if
+		// the iterator moves into a new range key, or out of the current range
+		// key.
+		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid()
 	}
 	lastPositioningOp := i.lastPositioningOp
-	requiresReposition := i.requiresReposition
 	hasPrefix := i.hasPrefix
 	// Set it to unknown, since this operation may not succeed, in which case
 	// the SeekGE following this should not make any assumption about iterator
@@ -1048,19 +1058,6 @@ func (i *Iterator) SeekGEWithLimit(key []byte, limit []byte) IterValidityState {
 				// Noop
 				if !invariants.Enabled || !disableSeekOpt(key, uintptr(unsafe.Pointer(i))) || i.forceEnableSeekOpt {
 					i.lastPositioningOp = seekGELastPositioningOp
-
-					// If there's a range key iterator stack, we need to update
-					// whether or not the current current key has changed since
-					// the previous iterator position. This is surfaced in the
-					// public interface through Iterator.RangeKeyChanged(). In
-					// most cases, we're reusing the iterator position so if
-					// there's any range key, it hasn't changed. But if
-					// requiresReposition=true, the previous iterator position
-					// was a no-op SetOptions/SetBounds, and RangeKeyChanged()
-					// must return true if there is a range key at the position.
-					if i.rangeKey != nil {
-						i.rangeKey.updated = i.rangeKey.hasRangeKey && requiresReposition
-					}
 					return i.iterValidityState
 				}
 			}
@@ -1174,8 +1171,19 @@ func (i *Iterator) SeekGEWithLimit(key []byte, limit []byte) IterValidityState {
 func (i *Iterator) SeekPrefixGE(key []byte) bool {
 	if i.rangeKey != nil {
 		// NB: Check Valid() before clearing requiresReposition.
-		i.rangeKey.updated = false
 		i.rangeKey.prevPosHadRangeKey = i.rangeKey.hasRangeKey && i.Valid()
+		// If we have a range key but did not expose it at the previous iterator
+		// position (because the iterator was not at a valid position), updated
+		// must be true. This ensures that after an iterator op sequence like:
+		//   - Next()             → (IterValid, RangeBounds() = [a,b))
+		//   - NextWithLimit(...) → (IterAtLimit, RangeBounds() = -)
+		//   - SeekPrefixGE(...)  → (IterValid, RangeBounds() = [a,b))
+		// the iterator returns RangeKeyChanged()=true.
+		//
+		// The remainder of this function will only update i.rangeKey.updated if
+		// the iterator moves into a new range key, or out of the current range
+		// key.
+		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid()
 	}
 	lastPositioningOp := i.lastPositioningOp
 	// Set it to unknown, since this operation may not succeed, in which case
@@ -1289,11 +1297,21 @@ func (i *Iterator) SeekLT(key []byte) bool {
 func (i *Iterator) SeekLTWithLimit(key []byte, limit []byte) IterValidityState {
 	if i.rangeKey != nil {
 		// NB: Check Valid() before clearing requiresReposition.
-		i.rangeKey.updated = false
 		i.rangeKey.prevPosHadRangeKey = i.rangeKey.hasRangeKey && i.Valid()
+		// If we have a range key but did not expose it at the previous iterator
+		// position (because the iterator was not at a valid position), updated
+		// must be true. This ensures that after an iterator op sequence like:
+		//   - Next()               → (IterValid, RangeBounds() = [a,b))
+		//   - NextWithLimit(...)   → (IterAtLimit, RangeBounds() = -)
+		//   - SeekLTWithLimit(...) → (IterValid, RangeBounds() = [a,b))
+		// the iterator returns RangeKeyChanged()=true.
+		//
+		// The remainder of this function will only update i.rangeKey.updated if
+		// the iterator moves into a new range key, or out of the current range
+		// key.
+		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid()
 	}
 	lastPositioningOp := i.lastPositioningOp
-	requiresReposition := i.requiresReposition
 	// Set it to unknown, since this operation may not succeed, in which case
 	// the SeekLT following this should not make any assumption about iterator
 	// position.
@@ -1326,19 +1344,6 @@ func (i *Iterator) SeekLTWithLimit(key []byte, limit []byte) IterValidityState {
 					(limit == nil || i.cmp(limit, i.key) <= 0)) {
 				if !invariants.Enabled || !disableSeekOpt(key, uintptr(unsafe.Pointer(i))) {
 					i.lastPositioningOp = seekLTLastPositioningOp
-
-					// If there's a range key iterator stack, we need to update
-					// whether or not the current current key has changed since
-					// the previous iterator position. This is surfaced in the
-					// public interface through Iterator.RangeKeyChanged(). In
-					// most cases, we're reusing the iterator position so if
-					// there's any range key, it hasn't changed. But if
-					// requiresReposition=true, the previous iterator position
-					// was a no-op SetOptions/SetBounds, and RangeKeyChanged()
-					// must return true if there is a range key at the position.
-					if i.rangeKey != nil {
-						i.rangeKey.updated = i.rangeKey.hasRangeKey && requiresReposition
-					}
 					return i.iterValidityState
 				}
 			}
@@ -1368,8 +1373,19 @@ func (i *Iterator) SeekLTWithLimit(key []byte, limit []byte) IterValidityState {
 func (i *Iterator) First() bool {
 	if i.rangeKey != nil {
 		// NB: Check Valid() before clearing requiresReposition.
-		i.rangeKey.updated = false
 		i.rangeKey.prevPosHadRangeKey = i.rangeKey.hasRangeKey && i.Valid()
+		// If we have a range key but did not expose it at the previous iterator
+		// position (because the iterator was not at a valid position), updated
+		// must be true. This ensures that after an iterator op sequence like:
+		//   - Next()             → (IterValid, RangeBounds() = [a,b))
+		//   - NextWithLimit(...) → (IterAtLimit, RangeBounds() = -)
+		//   - First(...)         → (IterValid, RangeBounds() = [a,b))
+		// the iterator returns RangeKeyChanged()=true.
+		//
+		// The remainder of this function will only update i.rangeKey.updated if
+		// the iterator moves into a new range key, or out of the current range
+		// key.
+		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid()
 	}
 	i.err = nil // clear cached iteration error
 	i.hasPrefix = false
@@ -1394,8 +1410,19 @@ func (i *Iterator) First() bool {
 func (i *Iterator) Last() bool {
 	if i.rangeKey != nil {
 		// NB: Check Valid() before clearing requiresReposition.
-		i.rangeKey.updated = false
 		i.rangeKey.prevPosHadRangeKey = i.rangeKey.hasRangeKey && i.Valid()
+		// If we have a range key but did not expose it at the previous iterator
+		// position (because the iterator was not at a valid position), updated
+		// must be true. This ensures that after an iterator op sequence like:
+		//   - Next()             → (IterValid, RangeBounds() = [a,b))
+		//   - NextWithLimit(...) → (IterAtLimit, RangeBounds() = -)
+		//   - Last(...)          → (IterValid, RangeBounds() = [a,b))
+		// the iterator returns RangeKeyChanged()=true.
+		//
+		// The remainder of this function will only update i.rangeKey.updated if
+		// the iterator moves into a new range key, or out of the current range
+		// key.
+		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid()
 	}
 	i.err = nil // clear cached iteration error
 	i.hasPrefix = false
@@ -1453,8 +1480,19 @@ func (i *Iterator) NextWithLimit(limit []byte) IterValidityState {
 	}
 	if i.rangeKey != nil {
 		// NB: Check Valid() before clearing requiresReposition.
-		i.rangeKey.updated = false
 		i.rangeKey.prevPosHadRangeKey = i.rangeKey.hasRangeKey && i.Valid()
+		// If we have a range key but did not expose it at the previous iterator
+		// position (because the iterator was not at a valid position), updated
+		// must be true. This ensures that after an iterator op sequence like:
+		//   - Next()             → (IterValid, RangeBounds() = [a,b))
+		//   - NextWithLimit(...) → (IterAtLimit, RangeBounds() = -)
+		//   - NextWithLimit(...) → (IterValid, RangeBounds() = [a,b))
+		// the iterator returns RangeKeyChanged()=true.
+		//
+		// The remainder of this function will only update i.rangeKey.updated if
+		// the iterator moves into a new range key, or out of the current range
+		// key.
+		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid()
 	}
 	i.lastPositioningOp = unknownLastPositionOp
 	i.requiresReposition = false
@@ -1542,8 +1580,19 @@ func (i *Iterator) PrevWithLimit(limit []byte) IterValidityState {
 	}
 	if i.rangeKey != nil {
 		// NB: Check Valid() before clearing requiresReposition.
-		i.rangeKey.updated = false
 		i.rangeKey.prevPosHadRangeKey = i.rangeKey.hasRangeKey && i.Valid()
+		// If we have a range key but did not expose it at the previous iterator
+		// position (because the iterator was not at a valid position), updated
+		// must be true. This ensures that after an iterator op sequence like:
+		//   - Next()             → (IterValid, RangeBounds() = [a,b))
+		//   - NextWithLimit(...) → (IterAtLimit, RangeBounds() = -)
+		//   - PrevWithLimit(...) → (IterValid, RangeBounds() = [a,b))
+		// the iterator returns RangeKeyChanged()=true.
+		//
+		// The remainder of this function will only update i.rangeKey.updated if
+		// the iterator moves into a new range key, or out of the current range
+		// key.
+		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid()
 	}
 	i.lastPositioningOp = unknownLastPositionOp
 	i.requiresReposition = false

--- a/testdata/iter_histories/with_limit
+++ b/testdata/iter_histories/with_limit
@@ -100,3 +100,86 @@ prev-limit c
 ----
 .
 . at-limit
+
+# Test at-limit interactions with RangeKeyChanged().
+# Regression test for #1963.
+
+reset
+----
+
+# Construct a range key and points such that there are deleted keys that a
+# -WithLimit iterator operation may pause at both at the beginning and end of
+# the range key's bounds.
+#
+#                    * b.DEL             * cat.SET         * dog.DEL
+#   |-------------------------------------------------------------------) [a,e)@1→foo
+#   a                b                c                d                e
+
+batch commit
+del b
+set cat cat
+del dog
+range-key-set a e @1 foo
+----
+committed 4 keys
+
+combined-iter
+seek-ge-limit a bat
+seek-ge-limit a bat
+seek-ge-limit apple bat
+seek-ge-limit cow zoo
+----
+a: valid (., [a-e) @1=foo UPDATED)
+a: valid (., [a-e) @1=foo)
+apple: valid (., [a-e) @1=foo)
+cow: valid (., [a-e) @1=foo)
+
+combined-iter
+seek-ge a
+next-limit bat
+next-limit dog
+next-limit zoo
+----
+a: (., [a-e) @1=foo UPDATED)
+. at-limit
+cat: valid (cat, [a-e) @1=foo UPDATED)
+. exhausted
+
+combined-iter
+seek-lt-limit f e
+seek-lt-limit e d
+seek-lt-limit e d
+seek-lt-limit f e
+seek-lt-limit e d
+----
+. at-limit
+cat: valid (cat, [a-e) @1=foo UPDATED)
+cat: valid (cat, [a-e) @1=foo)
+. at-limit
+cat: valid (cat, [a-e) @1=foo UPDATED)
+
+# Add a new dz.SET key.
+#
+#                    * b.DEL             * cat.SET         * dog.DEL  * dz.SET
+#   |-------------------------------------------------------------------) [a,e)@1→foo
+#   a                b                c                d                e
+
+batch commit
+set dz dz
+----
+committed 1 keys
+
+combined-iter
+seek-ge dz
+prev-limit e
+prev-limit dy
+prev-limit c
+prev
+next
+----
+dz: (dz, [a-e) @1=foo UPDATED)
+. at-limit
+cat: valid (cat, [a-e) @1=foo UPDATED)
+a: valid (., [a-e) @1=foo)
+.
+a: (., [a-e) @1=foo UPDATED)


### PR DESCRIPTION
Fix a bug whereby RangeKeyChanged would sometimes return false for an
iterator position that held range keys immediately after an at-limit
position. The documented interface dictates that after any !Valid()
iterator position, an iterator position that holds range keys should
return RangeKeyChanged()=true:

> Invalid iterator positions are considered to not hold range keys,
> meaning that if an iterator steps from an IterExhausted or IterAtLimit
> position onto a position with a range key, RangeKeyChanged will yield
> true.

Previously every iterator positioning operation would reset
`i.rangeKey.updated=false` before executing. Now, it's initialized to
represent the current internal state of the range keys held in
`i.rangeKey`. If there exists a range key at the current internal
iterator position, `i.rangeKey.updated` is initialized to true if the
previous iterator position did not hold range keys.