### PR TITLE
docs: fix date for struct zeroing annotation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -61,7 +61,7 @@
           runtime to 90 minutes</div>
         <div class="annotation" data-date="20220330">Data quality issue introduced (YCSB A only)</div>
         <div class="annotation" data-date="20220526">Data quality issue fixed (YCSB A only)</div>
-        <div class="annotation" data-date="20200626">Began zeroing reused
+        <div class="annotation" data-date="20220626">Began zeroing reused
             iterator structs (#1822)</div>
       </div>
       <div class="section rows">


### PR DESCRIPTION
The previous date was off by 2 years.