### PR TITLE
db: fix TestRangeKeyMaskingRandomized

### DIFF
--- a/iterator_test.go
+++ b/iterator_test.go
@@ -2248,7 +2248,8 @@ func TestRangeKeyMaskingRandomized(t *testing.T) {
 				continue
 			}
 
-			if bytes.Compare(pkey, rkeys[i].start) > 0 && bytes.Compare(pkey, rkeys[i].end) < 0 {
+			if testkeys.Comparer.Compare(pkey, rkeys[i].start) >= 0 &&
+				testkeys.Comparer.Compare(pkey, rkeys[i].end) < 0 {
 				pointKeyHidden[j] = true
 			}
 		}


### PR DESCRIPTION
The test was comparing keys suffixed with timestamps using bytes.Compare which lead to erroneous results.

Fixes: #1973