### PR TITLE
crl-release-22.1: sstable: fix interaction between bpf and monotonic bounds optimization

### DIFF
--- a/internal/testkeys/blockprop/blockprop.go
+++ b/internal/testkeys/blockprop/blockprop.go
@@ -1,0 +1,87 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// Package blockprop implements interval block property collectors and filters
+// on the suffixes of keys in the format used by the testkeys package (eg,
+// 'key@5').
+package blockprop
+
+import (
+	"math"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/sstable"
+)
+
+const blockPropertyName = `pebble.internal.testkeys.suffixes`
+
+// NewBlockPropertyCollector constructs a sstable property collector over
+// testkey suffixes.
+func NewBlockPropertyCollector() sstable.BlockPropertyCollector {
+	return sstable.NewBlockIntervalCollector(
+		blockPropertyName,
+		&suffixIntervalCollector{},
+		nil)
+}
+
+// NewBlockPropertyFilter constructs a new block-property filter that excludes
+// blocks containing exclusively suffixed keys where all the suffixes fall
+// outside of the range [filterMin, filterMax).
+//
+// The filter only filters based on data derived from the key. The iteration
+// results of this block property filter are deterministic for unsuffixed keys
+// and keys with suffixes within the range [filterMin, filterMax). For keys with
+// suffixes outside the range, iteration is nondeterministic.
+func NewBlockPropertyFilter(filterMin, filterMax uint64) sstable.BlockPropertyFilter {
+	return sstable.NewBlockIntervalFilter(blockPropertyName, filterMin, filterMax)
+}
+
+var _ sstable.DataBlockIntervalCollector = (*suffixIntervalCollector)(nil)
+
+// suffixIntervalCollector maintains an interval over the timestamps in
+// MVCC-like suffixes for keys (e.g. foo@123).
+type suffixIntervalCollector struct {
+	initialized  bool
+	lower, upper uint64
+}
+
+// Add implements DataBlockIntervalCollector by adding the timestamp(s) in the
+// suffix(es) of this record to the current interval.
+//
+// Note that range sets and unsets may have multiple suffixes. Range key deletes
+// do not have a suffix. All other point keys have a single suffix.
+func (c *suffixIntervalCollector) Add(key base.InternalKey, value []byte) error {
+	i := testkeys.Comparer.Split(key.UserKey)
+	if i == len(key.UserKey) {
+		c.initialized = true
+		c.lower, c.upper = 0, math.MaxUint64
+		return nil
+	}
+	ts, err := testkeys.ParseSuffix(key.UserKey[i:])
+	if err != nil {
+		return err
+	}
+	uts := uint64(ts)
+	if !c.initialized {
+		c.lower, c.upper = uts, uts+1
+		c.initialized = true
+		return nil
+	}
+	if uts < c.lower {
+		c.lower = uts
+	}
+	if uts >= c.upper {
+		c.upper = uts + 1
+	}
+	return nil
+}
+
+// FinishDataBlock implements DataBlockIntervalCollector.
+func (c *suffixIntervalCollector) FinishDataBlock() (lower, upper uint64, err error) {
+	l, u := c.lower, c.upper
+	c.lower, c.upper = 0, 0
+	c.initialized = false
+	return l, u, nil
+}

--- a/iterator_histories_test.go
+++ b/iterator_histories_test.go
@@ -1,0 +1,337 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+package pebble
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/bloom"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/internal/testkeys/blockprop"
+	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+// TODO(jackson): Add a range keys test with concurrency: the logic to cache
+// fragmented spans is susceptible to races.
+
+func TestIterHistories(t *testing.T) {
+	datadriven.Walk(t, "testdata/iter_histories", func(t *testing.T, path string) {
+		var d *DB
+		iters := map[string]*Iterator{}
+		batches := map[string]*Batch{}
+		newIter := func(name string, reader Reader, o *IterOptions) *Iterator {
+			it := reader.NewIter(o)
+			iters[name] = it
+			return it
+		}
+		cleanup := func() (err error) {
+			for key, batch := range batches {
+				err = firstError(err, batch.Close())
+				delete(batches, key)
+			}
+			for key, iter := range iters {
+				err = firstError(err, iter.Close())
+				delete(iters, key)
+			}
+			if d != nil {
+				err = firstError(err, d.Close())
+				d = nil
+			}
+			return err
+		}
+		defer cleanup()
+
+		datadriven.RunTest(t, path, func(td *datadriven.TestData) string {
+			switch td.Cmd {
+			case "reset":
+				if err := cleanup(); err != nil {
+					return err.Error()
+				}
+				opts := &Options{
+					FS:                 vfs.NewMem(),
+					Comparer:           testkeys.Comparer,
+					FormatMajorVersion: FormatRangeKeys,
+					BlockPropertyCollectors: []func() BlockPropertyCollector{
+						blockprop.NewBlockPropertyCollector,
+					},
+				}
+				opts.Experimental.RangeKeys = new(RangeKeysArena)
+				opts.DisableAutomaticCompactions = true
+				opts.EnsureDefaults()
+
+				for _, cmdArg := range td.CmdArgs {
+					switch cmdArg.Key {
+					case "format-major-version":
+						v, err := strconv.Atoi(cmdArg.Vals[0])
+						if err != nil {
+							return err.Error()
+						}
+						// Override the DB version.
+						opts.FormatMajorVersion = FormatMajorVersion(v)
+					case "block-size":
+						v, err := strconv.Atoi(cmdArg.Vals[0])
+						if err != nil {
+							return err.Error()
+						}
+						for i := range opts.Levels {
+							opts.Levels[i].BlockSize = v
+						}
+					case "index-block-size":
+						v, err := strconv.Atoi(cmdArg.Vals[0])
+						if err != nil {
+							return err.Error()
+						}
+						for i := range opts.Levels {
+							opts.Levels[i].IndexBlockSize = v
+						}
+					case "target-file-size":
+						v, err := strconv.Atoi(cmdArg.Vals[0])
+						if err != nil {
+							return err.Error()
+						}
+						for i := range opts.Levels {
+							opts.Levels[i].TargetFileSize = int64(v)
+						}
+					case "bloom-bits-per-key":
+						v, err := strconv.Atoi(cmdArg.Vals[0])
+						if err != nil {
+							return err.Error()
+						}
+						fp := bloom.FilterPolicy(v)
+						opts.Filters = map[string]FilterPolicy{fp.Name(): fp}
+						for i := range opts.Levels {
+							opts.Levels[i].FilterPolicy = fp
+						}
+					case "merger":
+						switch cmdArg.Vals[0] {
+						case "appender":
+							opts.Merger = base.DefaultMerger
+						default:
+							return fmt.Sprintf("unrecognized Merger %q\n", cmdArg.Vals[0])
+						}
+					default:
+						return fmt.Sprintf("unknown command %s\n", cmdArg.Key)
+					}
+
+				}
+
+				var err error
+				d, err = Open("", opts)
+				require.NoError(t, err)
+				return ""
+			case "populate":
+				b := d.NewBatch()
+				runPopulateCmd(t, td, b)
+				count := b.Count()
+				require.NoError(t, b.Commit(nil))
+				return fmt.Sprintf("wrote %d keys\n", count)
+			case "batch":
+				var commit bool
+				var name string
+				for _, arg := range td.CmdArgs {
+					switch arg.Key {
+					case "name":
+						name = arg.Vals[0]
+					case "commit":
+						commit = true
+					default:
+						return fmt.Sprintf("unrecognized command argument %q\n", arg.Key)
+					}
+				}
+				b := d.NewIndexedBatch()
+				require.NoError(t, runBatchDefineCmd(td, b))
+				var err error
+				if commit {
+					func() {
+						defer func() {
+							if r := recover(); r != nil {
+								err = errors.New(r.(string))
+							}
+						}()
+						err = b.Commit(nil)
+					}()
+				} else if name != "" {
+					batches[name] = b
+				}
+				if err != nil {
+					return err.Error()
+				}
+				count := b.Count()
+				if commit {
+					return fmt.Sprintf("committed %d keys\n", count)
+				}
+				return fmt.Sprintf("wrote %d keys to batch %q\n", count, name)
+			case "flush":
+				err := d.Flush()
+				if err != nil {
+					return err.Error()
+				}
+				return ""
+			case "get":
+				var reader Reader = d
+				for _, cmd := range td.CmdArgs {
+					switch cmd.Key {
+					case "reader":
+						var ok bool
+						reader, ok = batches[cmd.Vals[0]]
+						if !ok {
+							return fmt.Sprintf("unknown reader %q", cmd.Vals[0])
+						}
+					default:
+						return fmt.Sprintf("unrecognized command %q", cmd.Key)
+					}
+				}
+				var buf bytes.Buffer
+				for _, l := range strings.Split(td.Input, "\n") {
+					v, closer, err := reader.Get([]byte(l))
+					if err != nil {
+						fmt.Fprintf(&buf, "%s: error: %s\n", l, err)
+					} else {
+						fmt.Fprintf(&buf, "%s: %s\n", l, v)
+					}
+					if err := closer.Close(); err != nil {
+						fmt.Fprintf(&buf, "close err: %s\n", err)
+					}
+				}
+				return buf.String()
+			case "ingest":
+				if err := runBuildCmd(td, d, d.opts.FS); err != nil {
+					return err.Error()
+				}
+				if err := runIngestCmd(td, d, d.opts.FS); err != nil {
+					return err.Error()
+				}
+				return ""
+			case "lsm":
+				return runLSMCmd(td, d)
+			case "mutate":
+				var batchName string
+				td.ScanArgs(t, "batch", &batchName)
+				mut := newBatch(d)
+				if err := runBatchDefineCmd(td, mut); err != nil {
+					return err.Error()
+				}
+				if err := batches[batchName].Apply(mut, nil); err != nil {
+					return err.Error()
+				}
+				return ""
+			case "commit":
+				name := pluckStringCmdArg(td, "batch")
+				b := batches[name]
+				defer b.Close()
+				count := b.Count()
+				require.NoError(t, d.Apply(b, nil))
+				delete(batches, name)
+				return fmt.Sprintf("committed %d keys\n", count)
+			case "combined-iter":
+				o := &IterOptions{KeyTypes: IterKeyTypePointsAndRanges}
+				var reader Reader = d
+				var name string
+				for _, arg := range td.CmdArgs {
+					switch arg.Key {
+					case "mask-suffix":
+						o.RangeKeyMasking.Suffix = []byte(arg.Vals[0])
+					case "lower":
+						o.LowerBound = []byte(arg.Vals[0])
+					case "upper":
+						o.UpperBound = []byte(arg.Vals[0])
+					case "name":
+						name = arg.Vals[0]
+					case "reader":
+						reader = batches[arg.Vals[0]]
+						if reader == nil {
+							return fmt.Sprintf("unknown reader %q", arg.Vals[0])
+						}
+					case "point-key-filter":
+						if len(arg.Vals) != 2 {
+							return fmt.Sprintf("blockprop-filter expects 2 arguments, received %d", len(arg.Vals))
+						}
+						min, err := strconv.ParseUint(arg.Vals[0], 10, 64)
+						if err != nil {
+							return err.Error()
+						}
+						max, err := strconv.ParseUint(arg.Vals[1], 10, 64)
+						if err != nil {
+							return err.Error()
+						}
+						o.PointKeyFilters = []sstable.BlockPropertyFilter{
+							blockprop.NewBlockPropertyFilter(min, max),
+						}
+					}
+				}
+				var iter *Iterator
+				var err error
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							switch v := r.(type) {
+							case string:
+								err = errors.New(v)
+							case error:
+								err = v
+							default:
+								panic(r)
+							}
+						}
+					}()
+					iter = newIter(name, reader, o)
+				}()
+				if err != nil {
+					return err.Error()
+				}
+				return runIterCmd(td, iter, name == "" /* close iter */)
+			case "rangekey-iter":
+				name := pluckStringCmdArg(td, "name")
+				iter := newIter(name, d, &IterOptions{KeyTypes: IterKeyTypeRangesOnly})
+				return runIterCmd(td, iter, name == "" /* close iter */)
+			case "scan-rangekeys":
+				var buf bytes.Buffer
+				iter := newIter(
+					pluckStringCmdArg(td, "name"),
+					d,
+					&IterOptions{KeyTypes: IterKeyTypeRangesOnly},
+				)
+				func() {
+					defer iter.Close()
+					for iter.First(); iter.Valid(); iter.Next() {
+						start, end := iter.RangeBounds()
+						fmt.Fprintf(&buf, "[%s, %s)\n", start, end)
+						writeRangeKeys(&buf, iter)
+						fmt.Fprintln(&buf)
+					}
+				}()
+				return buf.String()
+			case "iter":
+				var name string
+				td.ScanArgs(t, "iter", &name)
+				return runIterCmd(td, iters[name], false /* close iter */)
+			case "wait-table-stats":
+				d.mu.Lock()
+				d.waitTableStats()
+				d.mu.Unlock()
+				return ""
+			default:
+				return fmt.Sprintf("unknown command %q", td.Cmd)
+			}
+		})
+	})
+}
+
+func pluckStringCmdArg(td *datadriven.TestData, key string) string {
+	for i := range td.CmdArgs {
+		if td.CmdArgs[i].Key == key {
+			return td.CmdArgs[i].Vals[0]
+		}
+	}
+	return ""
+}

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -1271,6 +1271,7 @@ func (i *twoLevelIterator) SeekGE(key []byte, trySeekUsingNext bool) (*InternalK
 
 		result := i.loadIndex()
 		if result == loadBlockFailed {
+			i.boundsCmp = 0
 			return nil, nil
 		}
 		if result == loadBlockIrrelevant {
@@ -1285,6 +1286,12 @@ func (i *twoLevelIterator) SeekGE(key []byte, trySeekUsingNext bool) (*InternalK
 			}
 			// Fall through to skipForward.
 			dontSeekWithinSingleLevelIter = true
+			// Clear boundsCmp. Normally, singleLevelIterator.SeekGE will clear
+			// it, but if we're skipping an index block altogether, it's
+			// possible we'll return without ever seeking within the
+			// single-level iterator, in which case boundsCmp may be improperly
+			// left == 0.
+			i.boundsCmp = 0
 		}
 	}
 	// Else fast-path: There are two possible cases, from
@@ -1374,6 +1381,7 @@ func (i *twoLevelIterator) SeekPrefixGE(
 
 		result := i.loadIndex()
 		if result == loadBlockFailed {
+			i.boundsCmp = 0
 			return nil, nil
 		}
 		if result == loadBlockIrrelevant {
@@ -1388,6 +1396,12 @@ func (i *twoLevelIterator) SeekPrefixGE(
 			}
 			// Fall through to skipForward.
 			dontSeekWithinSingleLevelIter = true
+			// Clear boundsCmp. Normally, singleLevelIterator.SeekPrefixGE will
+			// clear it, but if we're skipping this index block altogether, it's
+			// possible we'll return without ever seeking within the
+			// single-level iterator, in which case boundsCmp may be improperly
+			// left == 0.
+			i.boundsCmp = 0
 		}
 	}
 	// Else fast-path: The bounds have moved forward and this SeekGE is

--- a/testdata/iter_histories/iter_optimizations
+++ b/testdata/iter_histories/iter_optimizations
@@ -1,0 +1,74 @@
+# Regression test for #1963 / cockroachdb/cockroach#88296.
+#
+# The iterators in this test move their bounds monotonically forward
+# [a,b)→[b,e). This enables the sstable iterator optimization for monotonically
+# moving bounds (see boundsCmp in sstable/reader.go). With this optimization,
+# the first seek after the SetBounds may use the fact that the bounds moved
+# forward monotonically to avoid re-seeking within the index.
+#
+# The test cases below exercise a seek to a key, followed by a seek to a smaller
+# key. The second seek should not make use of the bounds optimization because
+# doing so may incorrectly skip all keys between the lower bound and the first
+# seek key. Previously, the code paths that handled block-property filtering on
+# a two-level iterator could leave the iterator in a state such that the second
+# seek would improperly also exercise the monotonic bounds optimization. In the
+# test cases below, this would result in the key 'b' not being found. Each test
+# case exercises a different combination of seek-ge and seek-prefix-ge.
+
+reset block-size=1 index-block-size=1
+----
+
+batch commit
+set a a
+set b b
+set b@4 b@4
+set z@6 z@6
+----
+committed 4 keys
+
+flush
+----
+
+combined-iter lower=a upper=b point-key-filter=(1,4)
+seek-ge a
+set-bounds lower=b upper=e
+seek-prefix-ge d@5
+seek-prefix-ge b
+----
+a: (a, .)
+.
+.
+b: (b, .)
+
+combined-iter lower=a upper=b point-key-filter=(1,4)
+seek-ge a
+set-bounds lower=b upper=e
+seek-ge d@5
+seek-prefix-ge b
+----
+a: (a, .)
+.
+.
+b: (b, .)
+
+combined-iter lower=a upper=b point-key-filter=(1,4)
+seek-ge a
+set-bounds lower=b upper=e
+seek-ge d@5
+seek-ge b
+----
+a: (a, .)
+.
+.
+b: (b, .)
+
+combined-iter lower=a upper=b point-key-filter=(1,4)
+seek-ge a
+set-bounds lower=b upper=e
+seek-prefix-ge d@5
+seek-ge b
+----
+a: (a, .)
+.
+.
+b: (b, .)


### PR DESCRIPTION
Cockroach 22.1 backport of #1970. In order to carry over the tests, I brought over the `internal/testkeys/blockprop` package and the new `TestIterHistories` datadriven test.

----

The sstable iterator has an optimization for when iterator bounds are moved monotonically forward or backward. The first seek after the bounds adjustment can reuse the existing iterator position to avoid a more expensive full seek.

In iterators over sstables with two-level indexes, this optimization could interact with block-property filters, improperly allowing the second seek after the bounds adjustment to also reuse the existing iterator position. If the second seek key was smaller than the first seek key, the iterator would skip keys.

Informs #1963.
Informs cockroachdb/cockroach#88296.