### PR TITLE
crl-release-22.2: db: always return RangeKeyChanged()=false when range keys disabled

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -314,7 +314,7 @@ func printIterState(
 		fmt.Fprintf(b, "err=%v\n", err)
 	} else if validity == IterValid {
 		switch {
-		case iter.opts.rangeKeys() && iter.opts.pointKeys():
+		case iter.opts.pointKeys():
 			hasPoint, hasRange := iter.HasPointAndRange()
 			fmt.Fprintf(b, "%s:%s (", iter.Key(), validityStateStr)
 			if hasPoint {
@@ -333,7 +333,7 @@ func printIterState(
 				fmt.Fprint(b, " UPDATED")
 			}
 			fmt.Fprint(b, ")")
-		case iter.opts.rangeKeys():
+		default:
 			if iter.Valid() {
 				hasPoint, hasRange := iter.HasPointAndRange()
 				if hasPoint || !hasRange {
@@ -348,8 +348,6 @@ func printIterState(
 			if iter.RangeKeyChanged() {
 				fmt.Fprint(b, " UPDATED")
 			}
-		default:
-			fmt.Fprintf(b, "%s:%s%s", iter.Key(), iter.Value(), validityStateStr)
 		}
 		fmt.Fprintln(b)
 	} else {

--- a/iterator.go
+++ b/iterator.go
@@ -296,6 +296,9 @@ type iteratorRangeKeyState struct {
 	// `RangeKeyChanged` method. It's set to true during an Iterator positioning
 	// operation that changes the state of the current range key. Each Iterator
 	// positioning operation sets it back to false before executing.
+	//
+	// TODO(jackson): The lifecycle of {stale,updated,prevPosHadRangeKey} is
+	// intricate and confusing. Try to refactor to reduce complexity.
 	updated bool
 	// prevPosHadRangeKey records whether the previous Iterator position had a
 	// range key (HasPointAndRage() = (_, true)). It's updated at the beginning
@@ -1023,7 +1026,7 @@ func (i *Iterator) SeekGEWithLimit(key []byte, limit []byte) IterValidityState {
 		// The remainder of this function will only update i.rangeKey.updated if
 		// the iterator moves into a new range key, or out of the current range
 		// key.
-		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid()
+		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid() && i.opts.rangeKeys()
 	}
 	lastPositioningOp := i.lastPositioningOp
 	hasPrefix := i.hasPrefix
@@ -1183,7 +1186,7 @@ func (i *Iterator) SeekPrefixGE(key []byte) bool {
 		// The remainder of this function will only update i.rangeKey.updated if
 		// the iterator moves into a new range key, or out of the current range
 		// key.
-		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid()
+		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid() && i.opts.rangeKeys()
 	}
 	lastPositioningOp := i.lastPositioningOp
 	// Set it to unknown, since this operation may not succeed, in which case
@@ -1309,7 +1312,7 @@ func (i *Iterator) SeekLTWithLimit(key []byte, limit []byte) IterValidityState {
 		// The remainder of this function will only update i.rangeKey.updated if
 		// the iterator moves into a new range key, or out of the current range
 		// key.
-		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid()
+		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid() && i.opts.rangeKeys()
 	}
 	lastPositioningOp := i.lastPositioningOp
 	// Set it to unknown, since this operation may not succeed, in which case
@@ -1385,7 +1388,7 @@ func (i *Iterator) First() bool {
 		// The remainder of this function will only update i.rangeKey.updated if
 		// the iterator moves into a new range key, or out of the current range
 		// key.
-		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid()
+		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid() && i.opts.rangeKeys()
 	}
 	i.err = nil // clear cached iteration error
 	i.hasPrefix = false
@@ -1422,7 +1425,7 @@ func (i *Iterator) Last() bool {
 		// The remainder of this function will only update i.rangeKey.updated if
 		// the iterator moves into a new range key, or out of the current range
 		// key.
-		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid()
+		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid() && i.opts.rangeKeys()
 	}
 	i.err = nil // clear cached iteration error
 	i.hasPrefix = false
@@ -1492,7 +1495,7 @@ func (i *Iterator) NextWithLimit(limit []byte) IterValidityState {
 		// The remainder of this function will only update i.rangeKey.updated if
 		// the iterator moves into a new range key, or out of the current range
 		// key.
-		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid()
+		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid() && i.opts.rangeKeys()
 	}
 	i.lastPositioningOp = unknownLastPositionOp
 	i.requiresReposition = false
@@ -1592,7 +1595,7 @@ func (i *Iterator) PrevWithLimit(limit []byte) IterValidityState {
 		// The remainder of this function will only update i.rangeKey.updated if
 		// the iterator moves into a new range key, or out of the current range
 		// key.
-		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid()
+		i.rangeKey.updated = i.rangeKey.hasRangeKey && !i.Valid() && i.opts.rangeKeys()
 	}
 	i.lastPositioningOp = unknownLastPositionOp
 	i.requiresReposition = false

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -267,7 +267,7 @@ iter
 first
 next
 ----
-a:b
+a: (b, .)
 .
 
 # Closing the next snapshot should NOT trigger another compaction, as the
@@ -282,7 +282,7 @@ iter
 first
 next
 ----
-a:b
+a: (b, .)
 .
 
 # Construct a scenario with tables containing a mixture of range dels and range

--- a/testdata/external_iterator
+++ b/testdata/external_iterator
@@ -188,11 +188,11 @@ first
 next
 ----
 .
-a@4:v
-c@2:v
+a@4: (v, .)
+c@2: (v, .)
 .
-e@5:v
-k@3:v
+e@5: (v, .)
+k@3: (v, .)
 
 # Test the TrySeekUsingNext optimization that's enabled only for fwd-only
 # external iterators. Seed the database with keys like 'a', 'aa', 'aaa', etc so

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -58,8 +58,8 @@ seek-ge a
 next
 next
 ----
-a:1
-b:2
+a: (1, .)
+b: (2, .)
 .
 
 get
@@ -97,7 +97,7 @@ iter
 seek-ge a
 next
 ----
-a:3
+a: (3, .)
 .
 
 get
@@ -130,9 +130,9 @@ seek-ge a
 next
 next
 ----
-a:4
-b:5
-c:6
+a: (4, .)
+b: (5, .)
+c: (6, .)
 
 get
 a
@@ -167,8 +167,8 @@ seek-ge a
 next
 next
 ----
-a:4
-b:55
+a: (4, .)
+b: (55, .)
 .
 
 get
@@ -205,9 +205,9 @@ seek-lt y
 prev
 prev
 ----
-x:7
-b:55
-a:4
+x: (7, .)
+b: (55, .)
+a: (4, .)
 
 get
 x
@@ -249,8 +249,8 @@ iter
 seek-ge j
 next
 ----
-j:9
-k:11
+j: (9, .)
+k: (11, .)
 
 get
 j

--- a/testdata/iter_histories/clone
+++ b/testdata/iter_histories/clone
@@ -73,9 +73,9 @@ ap: (., [ap-c) @5=bar UPDATED)
 b: (b, [ap-c) @5=bar)
 c: (c, . UPDATED)
 .
-a:a
-b:b
-c:c
+a: (a, .)
+b: (b, .)
+c: (c, .)
 .
 
 # Test cloning an iterator that reads through an indexed batch.

--- a/testdata/iter_histories/range_key_changed
+++ b/testdata/iter_histories/range_key_changed
@@ -208,3 +208,68 @@ a: (., [a-d) @1=foo)
 .
 a: (., [a-d) @1=foo UPDATED)
 a: (., [a-d) @1=foo)
+
+# Regression test for #1980. An iterator with RangeKeyChanged()=true that is
+# then reconfigured to iterate over point keys should always return
+# RangeKeyChanged()=false.
+
+reset
+----
+
+batch commit
+range-key-set a b @1 foo
+set c c
+----
+committed 2 keys
+
+combined-iter
+seek-ge a
+set-options key-types=point
+seek-ge c
+----
+a: (., [a-b) @1=foo UPDATED)
+.
+c: (c, .)
+
+combined-iter
+seek-ge a
+set-options key-types=point
+seek-prefix-ge c
+----
+a: (., [a-b) @1=foo UPDATED)
+.
+c: (c, .)
+
+combined-iter
+seek-ge a
+set-options key-types=point
+seek-lt cat
+----
+a: (., [a-b) @1=foo UPDATED)
+.
+c: (c, .)
+
+combined-iter
+seek-ge a
+set-options key-types=point
+last
+----
+a: (., [a-b) @1=foo UPDATED)
+.
+c: (c, .)
+
+batch commit
+range-key-del a b
+range-key-set d e @1 foo
+----
+committed 2 keys
+
+combined-iter
+seek-ge d
+set-options key-types=point
+first
+----
+d: (., [d-e) @1=foo UPDATED)
+.
+c: (c, .)
+

--- a/testdata/iter_histories/set_options
+++ b/testdata/iter_histories/set_options
@@ -43,9 +43,9 @@ ap: (., [ap-c) @5=bar UPDATED)
 b: (b, [ap-c) @5=bar)
 c: (c, . UPDATED)
 .
-a:a
-b:b
-c:c
+a: (a, .)
+b: (b, .)
+c: (c, .)
 .
 
 flush

--- a/testdata/iterator
+++ b/testdata/iterator
@@ -7,9 +7,9 @@ seek-ge a
 next
 prev
 ----
-a:b
+a: (b, .)
 .
-a:b
+a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 1, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
 
@@ -36,9 +36,9 @@ seek-ge a
 next
 prev
 ----
-a:b
+a: (b, .)
 .
-a:b
+a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 1, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0))
 
@@ -47,9 +47,9 @@ seek-ge a
 next
 prev
 ----
-a:c
+a: (c, .)
 .
-a:c
+a: (c, .)
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 1, 2)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0))
 
@@ -59,7 +59,7 @@ next
 prev
 next
 ----
-a:b
+a: (b, .)
 .
 err=pebble: unsupported reverse prefix iteration
 err=pebble: unsupported reverse prefix iteration
@@ -70,7 +70,7 @@ iter seq=3
 seek-prefix-ge a
 next
 ----
-a:c
+a: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
@@ -92,7 +92,7 @@ iter seq=2
 seek-ge 1
 next
 ----
-a:b
+a: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned: 0))
@@ -109,9 +109,9 @@ seek-lt b
 prev
 next
 ----
-a:b
+a: (b, .)
 .
-a:b
+a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 2, tombstoned: 0))
 
@@ -139,7 +139,7 @@ iter seq=4
 seek-ge a
 next
 ----
-b:c
+b: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned: 0))
@@ -154,7 +154,7 @@ stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, 
 iter seq=2
 seek-ge a
 ----
-a:b
+a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned: 0))
 
@@ -175,7 +175,7 @@ stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, 
 iter seq=2
 seek-prefix-ge a
 ----
-a:b
+a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned: 0))
 
@@ -183,7 +183,7 @@ iter seq=2
 seek-prefix-ge a
 seek-prefix-ge b
 ----
-a:b
+a: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned: 0))
@@ -203,7 +203,7 @@ seek-prefix-ge c
 ----
 .
 .
-c:d
+c: (d, .)
 stats: (interface (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 3, 4), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 7, key-bytes 7, value-bytes 4, tombstoned: 0))
 
@@ -212,8 +212,8 @@ seek-prefix-ge a
 seek-prefix-ge b
 seek-prefix-ge c
 ----
-a:b
-b:c
+a: (b, .)
+b: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 3, tombstoned: 0))
@@ -223,8 +223,8 @@ seek-ge a
 seek-ge b
 seek-ge c
 ----
-a:b
-b:c
+a: (b, .)
+b: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 3, tombstoned: 0))
@@ -241,9 +241,9 @@ next
 next
 next
 ----
-a:a
-b:b
-c:c
+a: (a, .)
+b: (b, .)
+c: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned: 0))
@@ -252,15 +252,15 @@ iter seq=4
 seek-ge b
 next
 ----
-b:b
-c:c
+b: (b, .)
+c: (c, .)
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
 
 iter seq=4
 seek-ge c
 ----
-c:c
+c: (c, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
 
@@ -275,9 +275,9 @@ seek-lt b
 prev
 next
 ----
-a:a
+a: (a, .)
 .
-a:a
+a: (a, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
 
@@ -287,10 +287,10 @@ prev
 prev
 next
 ----
-b:b
-a:a
+b: (b, .)
+a: (a, .)
 .
-a:a
+a: (a, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 2)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 2)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned: 0))
 
@@ -302,11 +302,11 @@ prev
 prev
 next
 ----
-c:c
-b:b
-a:a
+c: (c, .)
+b: (b, .)
+a: (a, .)
 .
-a:a
+a: (a, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 3)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 3)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0))
 
@@ -314,7 +314,7 @@ iter seq=4
 seek-prefix-ge a
 next
 ----
-a:a
+a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
@@ -323,7 +323,7 @@ iter seq=4
 seek-prefix-ge b
 next
 ----
-b:b
+b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
@@ -333,7 +333,7 @@ iter seq=4
 seek-prefix-ge c
 next
 ----
-c:c
+c: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
@@ -350,9 +350,9 @@ seek-prefix-ge a
 seek-prefix-ge c
 seek-prefix-ge b
 ----
-a:a
-c:c
-b:b
+a: (a, .)
+c: (c, .)
+b: (b, .)
 stats: (interface (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned: 0))
 
@@ -366,9 +366,9 @@ seek-ge a
 next
 prev
 ----
-a:b
+a: (b, .)
 .
-a:b
+a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 1, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0))
 
@@ -390,9 +390,9 @@ seek-lt b
 prev
 next
 ----
-a:b
+a: (b, .)
 .
-a:b
+a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
 
@@ -401,9 +401,9 @@ seek-lt c
 prev
 next
 ----
-a:b
+a: (b, .)
 .
-a:b
+a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned: 0))
 
@@ -411,7 +411,7 @@ iter seq=2
 seek-prefix-ge a
 next
 ----
-a:b
+a: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
@@ -435,7 +435,7 @@ iter seq=5
 seek-prefix-ge a
 next
 ----
-a:a
+a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 3, value-bytes 3, tombstoned: 0))
@@ -444,7 +444,7 @@ iter seq=5
 seek-prefix-ge a
 next
 ----
-a:a
+a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 3, value-bytes 3, tombstoned: 0))
@@ -452,7 +452,7 @@ stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, 
 iter seq=5
 seek-prefix-ge aa
 ----
-aa:aa
+aa: (aa, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 2, value-bytes 2, tombstoned: 0))
 
@@ -460,7 +460,7 @@ iter seq=5
 seek-prefix-ge aa
 next
 ----
-aa:aa
+aa: (aa, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 5, value-bytes 5, tombstoned: 0))
@@ -469,7 +469,7 @@ iter seq=5
 seek-prefix-ge aa
 next
 ----
-aa:aa
+aa: (aa, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 5, value-bytes 5, tombstoned: 0))
@@ -478,7 +478,7 @@ iter seq=5
 seek-prefix-ge aaa
 next
 ----
-aaa:aaa
+aaa: (aaa, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 4, value-bytes 4, tombstoned: 0))
@@ -486,7 +486,7 @@ stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, 
 iter seq=5
 seek-prefix-ge aaa
 ----
-aaa:aaa
+aaa: (aaa, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 3, value-bytes 3, tombstoned: 0))
 
@@ -494,7 +494,7 @@ iter seq=5
 seek-prefix-ge b
 next
 ----
-b:b
+b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
@@ -507,11 +507,11 @@ prev
 prev
 prev
 ----
-aa:aa
-b:b
-aaa:aaa
-aa:aa
-a:a
+aa: (aa, .)
+b: (b, .)
+aaa: (aaa, .)
+aa: (aa, .)
+a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 1, 4)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 4)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 9, value-bytes 9, tombstoned: 0))
@@ -524,11 +524,11 @@ next
 next
 next
 ----
-aa:aa
-a:a
-aa:aa
-aaa:aaa
-b:b
+aa: (aa, .)
+a: (a, .)
+aa: (aa, .)
+aaa: (aaa, .)
+b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 4), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 4), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 9, value-bytes 9, tombstoned: 0))
@@ -540,10 +540,10 @@ next
 next
 next
 ----
-aaa:aaa
-aa:aa
-aaa:aaa
-b:b
+aaa: (aaa, .)
+aa: (aa, .)
+aaa: (aaa, .)
+b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 3), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 3), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 9, value-bytes 9, tombstoned: 0))
@@ -554,9 +554,9 @@ seek-ge aaa
 next
 next
 ----
-aaa:aaa
-aaa:aaa
-b:b
+aaa: (aaa, .)
+aaa: (aaa, .)
+b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 2), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 7, value-bytes 7, tombstoned: 0))
@@ -569,11 +569,11 @@ next
 next
 next
 ----
-aaa:aaa
-a:a
-aa:aa
-aaa:aaa
-b:b
+aaa: (aaa, .)
+a: (a, .)
+aa: (aa, .)
+aaa: (aaa, .)
+b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 4), (rev, 1, 0)), (internal (dir, seek, step): (fwd, 2, 4), (rev, 1, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 6, key-bytes 11, value-bytes 11, tombstoned: 0))
@@ -585,9 +585,9 @@ seek-lt b
 next
 next
 ----
-aaa:aaa
-aaa:aaa
-b:b
+aaa: (aaa, .)
+aaa: (aaa, .)
+b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 1, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 1, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 12, value-bytes 12, tombstoned: 0))
@@ -598,9 +598,9 @@ seek-prefix-ge aa
 seek-prefix-ge aaa
 seek-prefix-ge b
 ----
-a:a
-aa:aa
-aaa:aaa
+a: (a, .)
+aa: (aa, .)
+aaa: (aaa, .)
 .
 stats: (interface (dir, seek, step): (fwd, 4, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 4, 0), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 7, value-bytes 7, tombstoned: 0))
@@ -614,8 +614,8 @@ seek-prefix-ge aaa
 ----
 .
 .
-a:a
-aa:aa
+a: (a, .)
+aa: (aa, .)
 .
 stats: (interface (dir, seek, step): (fwd, 5, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 5, 0), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 7, key-bytes 12, value-bytes 12, tombstoned: 0))
@@ -654,10 +654,10 @@ next
 next
 prev
 ----
-a:bcd
-b:ab
+a: (bcd, .)
+b: (ab, .)
 .
-b:ab
+b: (ab, .)
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 5), (rev, 1, 2)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned: 0))
 
@@ -665,8 +665,8 @@ iter seq=3
 seek-ge a
 next
 ----
-a:bc
-b:ab
+a: (bc, .)
+b: (ab, .)
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 4), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 10, value-bytes 10, tombstoned: 0))
 
@@ -674,8 +674,8 @@ iter seq=2
 seek-ge a
 next
 ----
-a:b
-b:a
+a: (b, .)
+b: (a, .)
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 10, value-bytes 10, tombstoned: 0))
 
@@ -685,10 +685,10 @@ prev
 prev
 next
 ----
-b:ab
-a:bcd
+b: (ab, .)
+a: (bcd, .)
 .
-a:bcd
+a: (bcd, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 2)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 1, 5)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 16, key-bytes 16, value-bytes 16, tombstoned: 0))
 
@@ -696,8 +696,8 @@ iter seq=3
 seek-lt c
 prev
 ----
-b:ab
-a:bc
+b: (ab, .)
+a: (bc, .)
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 4)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 10, value-bytes 10, tombstoned: 0))
 
@@ -705,8 +705,8 @@ iter seq=2
 seek-lt c
 prev
 ----
-b:a
-a:b
+b: (a, .)
+a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 2)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 10, value-bytes 10, tombstoned: 0))
 
@@ -716,10 +716,10 @@ next
 prev
 next
 ----
-a:bcd
-b:ab
-a:bcd
-b:ab
+a: (bcd, .)
+b: (ab, .)
+a: (bcd, .)
+b: (ab, .)
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 10), (rev, 1, 5)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 30, key-bytes 30, value-bytes 30, tombstoned: 0))
 
@@ -729,10 +729,10 @@ next
 prev
 next
 ----
-a:bc
-b:ab
-a:bc
-b:ab
+a: (bc, .)
+b: (ab, .)
+a: (bc, .)
+b: (ab, .)
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 8), (rev, 1, 4)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 30, key-bytes 30, value-bytes 30, tombstoned: 0))
 
@@ -742,10 +742,10 @@ next
 prev
 next
 ----
-a:b
-b:a
-a:b
-b:a
+a: (b, .)
+b: (a, .)
+a: (b, .)
+b: (a, .)
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 4), (rev, 1, 2)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 30, key-bytes 30, value-bytes 30, tombstoned: 0))
 
@@ -755,10 +755,10 @@ prev
 next
 prev
 ----
-b:ab
-a:bcd
-b:ab
-a:bcd
+b: (ab, .)
+a: (bcd, .)
+b: (ab, .)
+a: (bcd, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 2)), (internal (dir, seek, step): (fwd, 1, 5), (rev, 2, 10)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 30, key-bytes 30, value-bytes 30, tombstoned: 0))
 
@@ -768,10 +768,10 @@ prev
 next
 prev
 ----
-b:ab
-a:bc
-b:ab
-a:bc
+b: (ab, .)
+a: (bc, .)
+b: (ab, .)
+a: (bc, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 2)), (internal (dir, seek, step): (fwd, 1, 4), (rev, 2, 8)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 30, key-bytes 30, value-bytes 30, tombstoned: 0))
 
@@ -781,10 +781,10 @@ prev
 next
 prev
 ----
-b:a
-a:b
-b:a
-a:b
+b: (a, .)
+a: (b, .)
+b: (a, .)
+a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 2)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 2, 4)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 30, key-bytes 30, value-bytes 30, tombstoned: 0))
 
@@ -792,7 +792,7 @@ iter seq=3
 seek-prefix-ge a
 next
 ----
-a:bc
+a: (bc, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 8, key-bytes 8, value-bytes 8, tombstoned: 0))
@@ -801,7 +801,7 @@ iter seq=2
 seek-prefix-ge a
 next
 ----
-a:b
+a: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 10, value-bytes 10, tombstoned: 0))
@@ -810,7 +810,7 @@ iter seq=4
 seek-prefix-ge a
 next
 ----
-a:bcd
+a: (bcd, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 8, key-bytes 8, value-bytes 8, tombstoned: 0))
@@ -819,7 +819,7 @@ iter seq=2
 seek-prefix-ge a
 next
 ----
-a:b
+a: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 10, value-bytes 10, tombstoned: 0))
@@ -828,7 +828,7 @@ iter seq=3
 seek-prefix-ge a
 next
 ----
-a:bc
+a: (bc, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 8, key-bytes 8, value-bytes 8, tombstoned: 0))
@@ -849,7 +849,7 @@ stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, 
 iter seq=3
 seek-prefix-ge a
 ----
-a:bc
+a: (bc, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 6, key-bytes 6, value-bytes 6, tombstoned: 0))
 
@@ -877,7 +877,7 @@ seek-prefix-ge a
 next
 next
 ----
-a:bc
+a: (bc, .)
 .
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
@@ -888,7 +888,7 @@ seek-prefix-ge a
 next
 next
 ----
-a:b
+a: (b, .)
 .
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
@@ -898,7 +898,7 @@ iter seq=4
 seek-prefix-ge a
 next
 ----
-a:bcd
+a: (bcd, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 8, key-bytes 10, value-bytes 8, tombstoned: 0))
@@ -907,7 +907,7 @@ iter seq=2
 seek-prefix-ge a
 next
 ----
-a:b
+a: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 14, value-bytes 10, tombstoned: 0))
@@ -916,7 +916,7 @@ iter seq=3
 seek-prefix-ge aa
 next
 ----
-aa:ab
+aa: (ab, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 6, key-bytes 10, value-bytes 6, tombstoned: 0))
@@ -924,7 +924,7 @@ stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, 
 iter seq=4
 seek-prefix-ge aa
 ----
-aa:ab
+aa: (ab, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 6, key-bytes 10, value-bytes 6, tombstoned: 0))
 
@@ -940,8 +940,8 @@ seek-ge a
 first
 prev
 ----
-a:a
-a:a
+a: (a, .)
+a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
@@ -951,8 +951,8 @@ seek-ge a
 first
 prev
 ----
-b:b
-b:b
+b: (b, .)
+b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
@@ -962,8 +962,8 @@ seek-ge a
 first
 prev
 ----
-c:c
-c:c
+c: (c, .)
+c: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
@@ -973,8 +973,8 @@ seek-ge a
 first
 prev
 ----
-d:d
-d:d
+d: (d, .)
+d: (d, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
@@ -992,8 +992,8 @@ seek-lt d
 last
 next
 ----
-c:c
-c:c
+c: (c, .)
+c: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 2, 0)), (internal (dir, seek, step): (fwd, 0, 2), (rev, 2, 2)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
@@ -1003,8 +1003,8 @@ seek-lt d
 last
 next
 ----
-b:b
-b:b
+b: (b, .)
+b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 2, 0)), (internal (dir, seek, step): (fwd, 0, 2), (rev, 2, 2)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
@@ -1014,8 +1014,8 @@ seek-lt d
 last
 next
 ----
-a:a
-a:a
+a: (a, .)
+a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 2, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 2, 2)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned: 0))
@@ -1032,7 +1032,7 @@ iter seq=2 lower=b upper=c
 seek-ge a
 next
 ----
-b:b
+b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
@@ -1044,8 +1044,8 @@ first
 prev
 ----
 .
-a:a
-a:a
+a: (a, .)
+a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
@@ -1057,8 +1057,8 @@ first
 prev
 ----
 .
-b:b
-b:b
+b: (b, .)
+b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
@@ -1070,8 +1070,8 @@ first
 prev
 ----
 .
-c:c
-c:c
+c: (c, .)
+c: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
@@ -1083,8 +1083,8 @@ first
 prev
 ----
 .
-d:d
-d:d
+d: (d, .)
+d: (d, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
@@ -1106,8 +1106,8 @@ last
 next
 ----
 .
-c:c
-c:c
+c: (c, .)
+c: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 2, 0)), (internal (dir, seek, step): (fwd, 0, 2), (rev, 2, 2)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
@@ -1119,8 +1119,8 @@ last
 next
 ----
 .
-b:b
-b:b
+b: (b, .)
+b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 2, 0)), (internal (dir, seek, step): (fwd, 0, 2), (rev, 2, 2)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
@@ -1132,8 +1132,8 @@ last
 next
 ----
 .
-a:a
-a:a
+a: (a, .)
+a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 2, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 2, 2)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned: 0))
@@ -1155,8 +1155,8 @@ next
 next
 ----
 .
-c:c
-d:d
+c: (c, .)
+d: (d, .)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 2), (rev, 1, 0)), (internal (dir, seek, step): (fwd, 0, 3), (rev, 1, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0))
@@ -1167,7 +1167,7 @@ seek-ge a
 next
 ----
 .
-b:b
+b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
@@ -1179,9 +1179,9 @@ set-bounds lower=b upper=z
 seek-ge a
 ----
 .
-b:b
+b: (b, .)
 .
-b:b
+b: (b, .)
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
 
@@ -1189,7 +1189,7 @@ iter seq=2
 seek-ge a
 set-bounds upper=e
 ----
-a:a
+a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
@@ -1200,7 +1200,7 @@ seek-ge a
 set-bounds upper=e
 ----
 .
-b:b
+b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
@@ -1210,7 +1210,7 @@ set-bounds lower=b
 first
 ----
 .
-b:b
+b: (b, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
 
@@ -1219,7 +1219,7 @@ set-bounds upper=b
 first
 ----
 .
-a:a
+a: (a, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
 
@@ -1228,7 +1228,7 @@ set-bounds lower=b
 last
 ----
 .
-d:d
+d: (d, .)
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 0)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
 
@@ -1237,7 +1237,7 @@ set-bounds upper=b
 last
 ----
 .
-a:a
+a: (a, .)
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 0)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
 
@@ -1250,10 +1250,10 @@ next
 set-bounds upper=c
 prev
 ----
-d:d
+d: (d, .)
 .
 .
-b:b
+b: (b, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 2), (rev, 2, 2)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
 
@@ -1266,10 +1266,10 @@ prev
 set-bounds lower=b
 next
 ----
-a:a
+a: (a, .)
 .
 .
-b:b
+b: (b, .)
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
 
@@ -1279,8 +1279,8 @@ seek-lt c
 next
 ----
 .
-b:b
-c:c
+b: (b, .)
+c: (c, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 1, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned: 0))
 
@@ -1290,8 +1290,8 @@ seek-ge c
 prev
 ----
 .
-c:c
-b:b
+c: (c, .)
+b: (b, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 2)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned: 0))
 
@@ -1307,8 +1307,8 @@ seek-prefix-ge a
 first
 prev
 ----
-a:a
-a:a
+a: (a, .)
+a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
@@ -1324,7 +1324,7 @@ iter seq=2 lower=a upper=aa
 seek-prefix-ge a
 next
 ----
-a:a
+a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
@@ -1333,7 +1333,7 @@ iter seq=2 lower=a upper=aaa
 seek-prefix-ge a
 next
 ----
-a:a
+a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 3, value-bytes 3, tombstoned: 0))
@@ -1342,7 +1342,7 @@ iter seq=2 lower=a upper=b
 seek-prefix-ge a
 next
 ----
-a:a
+a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 3, value-bytes 3, tombstoned: 0))
@@ -1351,7 +1351,7 @@ iter seq=2 lower=a upper=c
 seek-prefix-ge a
 next
 ----
-a:a
+a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 3, value-bytes 3, tombstoned: 0))
@@ -1359,7 +1359,7 @@ stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, 
 iter seq=2 lower=a upper=aaa
 seek-prefix-ge aa
 ----
-aa:aa
+aa: (aa, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 2, value-bytes 2, tombstoned: 0))
 
@@ -1367,7 +1367,7 @@ iter seq=2 lower=a upper=aaa
 seek-prefix-ge aa
 next
 ----
-aa:aa
+aa: (aa, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 2, value-bytes 2, tombstoned: 0))
@@ -1386,8 +1386,8 @@ first
 next
 next
 ----
-a:a
-b:b
+a: (a, .)
+b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
@@ -1460,7 +1460,7 @@ iter seq=3
 first
 next
 ----
-a:b
+a: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned: 0))
@@ -1475,7 +1475,7 @@ iter seq=4
 first
 next
 ----
-b:c
+b: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned: 0))
@@ -1586,21 +1586,21 @@ prev-limit a
 next-limit a
 next-limit b
 ----
-a:a valid
+a: valid (a, .)
 . at-limit
-a:a valid
-. at-limit
-. at-limit
+a: valid (a, .)
 . at-limit
 . at-limit
-d:d valid
 . at-limit
-c:c valid
-b:b valid
-a:a valid
+. at-limit
+d: valid (d, .)
+. at-limit
+c: valid (c, .)
+b: valid (b, .)
+a: valid (a, .)
 . exhausted
 . at-limit
-a:a valid
+a: valid (a, .)
 stats: (interface (dir, seek, step): (fwd, 1, 6), (rev, 1, 7)), (internal (dir, seek, step): (fwd, 3, 3), (rev, 1, 6)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 11, key-bytes 11, value-bytes 11, tombstoned: 0))
 
@@ -1633,21 +1633,21 @@ next-limit e
 prev-limit d
 next-limit e
 ----
-a:a valid
+a: valid (a, .)
 . at-limit
-a:a valid
+a: valid (a, .)
 . exhausted
-a:a valid
+a: valid (a, .)
 . at-limit
 . at-limit
-a:a valid
+a: valid (a, .)
 . at-limit
 . at-limit
 . at-limit
 . at-limit
-d:d valid
+d: valid (d, .)
 . exhausted
-d:d valid
+d: valid (d, .)
 . exhausted
 stats: (interface (dir, seek, step): (fwd, 1, 10), (rev, 0, 5)), (internal (dir, seek, step): (fwd, 3, 13), (rev, 1, 8)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 21, key-bytes 21, value-bytes 14, tombstoned: 0))
@@ -1661,7 +1661,7 @@ next-limit e
 . at-limit
 . at-limit
 . at-limit
-d:d valid
+d: valid (d, .)
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 9), (rev, 0, 5)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 15, key-bytes 15, value-bytes 9, tombstoned: 0))
 
@@ -1676,9 +1676,9 @@ next-limit b
 . at-limit
 . at-limit
 . at-limit
-a:a valid
+a: valid (a, .)
 . exhausted
-a:a valid
+a: valid (a, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 4)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 5)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 6, key-bytes 6, value-bytes 4, tombstoned: 0))
 
@@ -1716,10 +1716,10 @@ next
 prev
 prev
 ----
-a:2
-b:3
+a: (2, .)
+b: (3, .)
 .
-b:3
-a:2
+b: (3, .)
+a: (2, .)
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 2)), (internal (dir, seek, step): (fwd, 1, 6), (rev, 1, 6)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 16, key-bytes 16, value-bytes 24, tombstoned: 0))

--- a/testdata/iterator_block_interval_filter
+++ b/testdata/iterator_block_interval_filter
@@ -24,12 +24,12 @@ next
 next
 next
 ----
-a01:a
-b02:b
-c03:c
-d04:d
-e05:e
-f06:f
+a01: (a, .)
+b02: (b, .)
+c03: (c, .)
+d04: (d, .)
+e05: (e, .)
+f06: (f, .)
 .
 
 # Iterate with a filter interval [1,2) that selects a key at the beginning of
@@ -47,17 +47,17 @@ seek-ge a
 seek-ge b
 prev
 ----
-a01:a
+a01: (a, .)
 .
-a01:a
+a01: (a, .)
 .
-a01:a
+a01: (a, .)
 .
-a01:a
-a01:a
-a01:a
+a01: (a, .)
+a01: (a, .)
+a01: (a, .)
 .
-a01:a
+a01: (a, .)
 
 # Iterate with a filter interval [3,5) that selects keys in the middle of the
 # file.
@@ -81,23 +81,23 @@ prev
 prev
 prev
 ----
-c03:c
-d04:d
+c03: (c, .)
+d04: (d, .)
 .
-d04:d
-c03:c
+d04: (d, .)
+c03: (c, .)
 .
-d04:d
-c03:c
-d04:d
-c03:c
+d04: (d, .)
+c03: (c, .)
+d04: (d, .)
+c03: (c, .)
 .
-d04:d
-c03:c
-d04:d
+d04: (d, .)
+c03: (c, .)
+d04: (d, .)
 .
-d04:d
-c03:c
+d04: (d, .)
+c03: (c, .)
 .
 
 # Iterate with a filter interval [6,8) that selects a key at the end of the
@@ -113,15 +113,15 @@ prev
 seek-lt g
 seek-ge b
 ----
-f06:f
+f06: (f, .)
 .
-f06:f
+f06: (f, .)
 .
-f06:f
-f06:f
+f06: (f, .)
+f06: (f, .)
 .
-f06:f
-f06:f
+f06: (f, .)
+f06: (f, .)
 
 iter id_lower_upper=(2,2,2)
 first
@@ -170,12 +170,12 @@ next
 next
 next
 ----
-a01:a
-b02:b
-c03:c
-d04:d
-e05:e
-f06:f
+a01: (a, .)
+b02: (b, .)
+c03: (c, .)
+d04: (d, .)
+e05: (e, .)
+f06: (f, .)
 .
 
 # Build a table with two interval collectors:
@@ -202,11 +202,11 @@ next
 next
 next
 ----
-a1001:a
-b0902:b
-c0803:c
-d0704:d
-e0605:e
+a1001: (a, .)
+b0902: (b, .)
+c0803: (c, .)
+d0704: (d, .)
+e0605: (e, .)
 .
 
 # Iterate with filter id=5, interval [7,9).
@@ -217,11 +217,11 @@ next
 prev
 prev
 ----
-c0803:c
-d0704:d
+c0803: (c, .)
+d0704: (d, .)
 .
-d0704:d
-c0803:c
+d0704: (d, .)
+c0803: (c, .)
 
 # Iterate with filter id=5, interval [7,9), and an unknown filter id. The
 # result should only be affected by the filter id=5.
@@ -232,11 +232,11 @@ next
 prev
 prev
 ----
-c0803:c
-d0704:d
+c0803: (c, .)
+d0704: (d, .)
 .
-d0704:d
-c0803:c
+d0704: (d, .)
+c0803: (c, .)
 
 # Iterate with filter id=3, interval [4,5) and filter id=5, interval [7,9).
 # The set of blocks admitted by these two filters are intersecting, but not
@@ -248,9 +248,9 @@ next
 prev
 prev
 ----
-d0704:d
+d0704: (d, .)
 .
-d0704:d
+d0704: (d, .)
 .
 
 # Repeat the above test, but calling set-options before iteration to set the
@@ -263,9 +263,9 @@ prev
 prev
 ----
 .
-d0704:d
+d0704: (d, .)
 .
-d0704:d
+d0704: (d, .)
 .
 
 # Repeat the above test, but calling set-options before iteration to remove the
@@ -278,9 +278,9 @@ prev
 prev
 ----
 .
-a1001:a
-b0902:b
-a1001:a
+a1001: (a, .)
+b0902: (b, .)
+a1001: (a, .)
 .
 
 

--- a/testdata/iterator_bounds_lifetimes
+++ b/testdata/iterator_bounds_lifetimes
@@ -6,8 +6,8 @@ iter label=first
 first
 next
 ----
-bb@29:bb@29
-bc@30:bc@30
+bb@29: (bb@29, .)
+bc@30: (bc@30, .)
 
 # Clone an iterator from the original iterator. The clone should have its own
 # copy of the bounds.
@@ -21,8 +21,8 @@ iter label=second
 last
 prev
 ----
-fo@150:fo@150
-fn@149:fn@149
+fo@150: (fo@150, .)
+fn@149: (fn@149, .)
 
 # Changing the bounds on the original should leave the clone's bounds unchanged.
 
@@ -34,12 +34,12 @@ second: ("bar", "foo") boundsBufIdx=1
 iter label=first
 seek-ge goop
 ----
-gp@178:gp@178
+gp@178: (gp@178, .)
 
 iter label=second
 prev
 ----
-fm@148:fm@148
+fm@148: (fm@148, .)
 
 set-bounds label=first lower=boop upper=bop
 ----

--- a/testdata/iterator_next_prev
+++ b/testdata/iterator_next_prev
@@ -43,7 +43,7 @@ iter
 first
 prev
 ----
-a:1
+a: (1, .)
 .
 
 reset
@@ -94,7 +94,7 @@ iter
 last
 next
 ----
-z:2
+z: (2, .)
 .
 
 # Verify that switching from reverse iteration to forward iteration
@@ -136,7 +136,7 @@ last
 next
 ----
 .
-e:e
+e: (e, .)
 .
 
 # Test that the cloned iterator sees all the keys.
@@ -151,12 +151,12 @@ next
 next
 ----
 .
-b:b
-e:e
+b: (b, .)
+e: (e, .)
 .
 .
-b:b
-e:e
+b: (b, .)
+e: (e, .)
 .
 
 # Test that the cloned iterator respects the original bounds.
@@ -169,10 +169,10 @@ seek-ge a
 next
 ----
 .
-b:b
+b: (b, .)
 .
 .
-b:b
+b: (b, .)
 .
 
 # Test that a cloned iterator set with new bounds, respects the new bounds and
@@ -186,7 +186,7 @@ seek-ge a
 next
 ----
 .
-b:b
+b: (b, .)
 .
 .
 b: (b, .)
@@ -202,10 +202,10 @@ last
 prev
 ----
 .
-e:e
+e: (e, .)
 .
 .
-e:e
+e: (e, .)
 .
 
 # Verify that switching from forward iteration to reverse iteration
@@ -241,7 +241,7 @@ first
 prev
 ----
 .
-a:a
+a: (a, .)
 .
 
 reset
@@ -274,5 +274,5 @@ iter
 first
 next
 ----
-a:1
+a: (1, .)
 .

--- a/testdata/iterator_read_sampling
+++ b/testdata/iterator_read_sampling
@@ -26,7 +26,7 @@ set allowed-seeks=2
 iter
 first
 ----
-a:4
+a: (4, .)
 
 iter-read-compactions
 ----
@@ -35,7 +35,7 @@ iter-read-compactions
 iter
 first
 ----
-a:4
+a: (4, .)
 
 iter-read-compactions
 ----
@@ -55,17 +55,17 @@ read-compactions
 iter
 seek-ge d
 ----
-d:2
+d: (2, .)
 
 iter
 prev
 ----
-a:4
+a: (4, .)
 
 iter
 next
 ----
-d:2
+d: (2, .)
 
 iter-read-compactions
 ----
@@ -112,7 +112,7 @@ set allowed-seeks=2
 iter
 last
 ----
-l:8
+l: (8, .)
 
 iter-read-compactions
 ----
@@ -121,7 +121,7 @@ iter-read-compactions
 iter
 last
 ----
-l:8
+l: (8, .)
 
 iter-read-compactions
 ----
@@ -141,17 +141,17 @@ read-compactions
 iter
 seek-lt d
 ----
-c:9
+c: (9, .)
 
 iter
 next
 ----
-d:2
+d: (2, .)
 
 iter
 prev
 ----
-c:9
+c: (9, .)
 
 iter-read-compactions
 ----
@@ -194,7 +194,7 @@ set allowed-seeks=2
 iter
 last
 ----
-d:2
+d: (2, .)
 
 iter-read-compactions
 ----
@@ -203,7 +203,7 @@ iter-read-compactions
 iter
 last
 ----
-d:2
+d: (2, .)
 
 iter-read-compactions
 ----
@@ -223,17 +223,17 @@ read-compactions
 iter
 seek-lt d
 ----
-a:4
+a: (4, .)
 
 iter
 next
 ----
-d:2
+d: (2, .)
 
 iter
 prev
 ----
-a:4
+a: (4, .)
 
 iter-read-compactions
 ----
@@ -275,17 +275,17 @@ set allowed-seeks=3
 iter
 first
 ----
-a:4
+a: (4, .)
 
 iter
 first
 ----
-a:4
+a: (4, .)
 
 iter
 first
 ----
-a:4
+a: (4, .)
 
 iter-read-compactions
 ----
@@ -329,7 +329,7 @@ set allowed-seeks=1
 iter
 last
 ----
-l:8
+l: (8, .)
 
 iter-read-compactions
 ----

--- a/testdata/iterator_seek_opt
+++ b/testdata/iterator_seek_opt
@@ -27,7 +27,7 @@ L3
 iter
 seek-ge a
 ----
-a:4
+a: (4, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0))
 SeekGEs with trySeekUsingNext: 0
 SeekPrefixGEs with trySeekUsingNext: 0
@@ -35,7 +35,7 @@ SeekPrefixGEs with trySeekUsingNext: 0
 iter
 seek-ge b
 ----
-b:1
+b: (1, .)
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 0))
 SeekGEs with trySeekUsingNext: 2
 SeekPrefixGEs with trySeekUsingNext: 0
@@ -43,7 +43,7 @@ SeekPrefixGEs with trySeekUsingNext: 0
 iter
 seek-ge c
 ----
-c:1
+c: (1, .)
 stats: (interface (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 3, 0), (rev, 0, 0))
 SeekGEs with trySeekUsingNext: 4
 SeekPrefixGEs with trySeekUsingNext: 0
@@ -53,7 +53,7 @@ SeekPrefixGEs with trySeekUsingNext: 0
 iter
 seek-ge bb
 ----
-c:1
+c: (1, .)
 stats: (interface (dir, seek, step): (fwd, 4, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 4, 0), (rev, 0, 0))
 SeekGEs with trySeekUsingNext: 4
 SeekPrefixGEs with trySeekUsingNext: 0
@@ -64,7 +64,7 @@ SeekPrefixGEs with trySeekUsingNext: 0
 iter
 seek-ge bbb
 ----
-c:1
+c: (1, .)
 stats: (interface (dir, seek, step): (fwd, 5, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 4, 0), (rev, 0, 0))
 SeekGEs with trySeekUsingNext: 4
 SeekPrefixGEs with trySeekUsingNext: 0
@@ -75,8 +75,8 @@ iter
 next
 seek-ge e
 ----
-d:2
-e:1
+d: (2, .)
+e: (1, .)
 stats: (interface (dir, seek, step): (fwd, 6, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 5, 1), (rev, 0, 0))
 SeekGEs with trySeekUsingNext: 4
 SeekPrefixGEs with trySeekUsingNext: 0
@@ -85,8 +85,8 @@ iter
 prev
 seek-ge b
 ----
-d:2
-b:1
+d: (2, .)
+b: (1, .)
 stats: (interface (dir, seek, step): (fwd, 7, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 6, 1), (rev, 0, 3))
 SeekGEs with trySeekUsingNext: 4
 SeekPrefixGEs with trySeekUsingNext: 0
@@ -96,7 +96,7 @@ SeekPrefixGEs with trySeekUsingNext: 0
 iter
 seek-prefix-ge a
 ----
-a:4
+a: (4, .)
 stats: (interface (dir, seek, step): (fwd, 8, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 7, 1), (rev, 0, 3))
 SeekGEs with trySeekUsingNext: 4
 SeekPrefixGEs with trySeekUsingNext: 0
@@ -104,7 +104,7 @@ SeekPrefixGEs with trySeekUsingNext: 0
 iter
 seek-prefix-ge b
 ----
-b:1
+b: (1, .)
 stats: (interface (dir, seek, step): (fwd, 9, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 8, 1), (rev, 0, 3))
 SeekGEs with trySeekUsingNext: 4
 SeekPrefixGEs with trySeekUsingNext: 2
@@ -112,7 +112,7 @@ SeekPrefixGEs with trySeekUsingNext: 2
 iter
 seek-prefix-ge c
 ----
-c:1
+c: (1, .)
 stats: (interface (dir, seek, step): (fwd, 10, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 9, 1), (rev, 0, 3))
 SeekGEs with trySeekUsingNext: 4
 SeekPrefixGEs with trySeekUsingNext: 4
@@ -136,7 +136,7 @@ set-bounds lower=a upper=aa
 seek-ge a
 ----
 .
-a:4
+a: (4, .)
 stats: (interface (dir, seek, step): (fwd, 12, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 11, 1), (rev, 0, 3))
 SeekGEs with trySeekUsingNext: 4
 SeekPrefixGEs with trySeekUsingNext: 4
@@ -146,7 +146,7 @@ set-bounds lower=a upper=c
 seek-ge b
 ----
 .
-b:1
+b: (1, .)
 stats: (interface (dir, seek, step): (fwd, 13, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 12, 1), (rev, 0, 3))
 SeekGEs with trySeekUsingNext: 4
 SeekPrefixGEs with trySeekUsingNext: 4
@@ -164,7 +164,7 @@ set-bounds lower=a upper=d
 seek-ge bbb
 ----
 .
-c:1
+c: (1, .)
 stats: (interface (dir, seek, step): (fwd, 15, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 14, 1), (rev, 0, 3))
 SeekGEs with trySeekUsingNext: 5
 SeekPrefixGEs with trySeekUsingNext: 4
@@ -187,7 +187,7 @@ set-bounds lower=a upper=c
 seek-ge b
 ----
 .
-b:1
+b: (1, .)
 stats: (interface (dir, seek, step): (fwd, 17, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 16, 1), (rev, 0, 3))
 SeekGEs with trySeekUsingNext: 6
 SeekPrefixGEs with trySeekUsingNext: 4
@@ -197,7 +197,7 @@ set-bounds lower=c upper=e
 seek-ge c
 ----
 .
-c:1
+c: (1, .)
 stats: (interface (dir, seek, step): (fwd, 18, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 17, 1), (rev, 0, 3))
 SeekGEs with trySeekUsingNext: 6
 SeekPrefixGEs with trySeekUsingNext: 4
@@ -209,7 +209,7 @@ set-bounds lower=c upper=e
 seek-ge d
 ----
 .
-d:2
+d: (2, .)
 stats: (interface (dir, seek, step): (fwd, 19, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 18, 1), (rev, 0, 3))
 SeekGEs with trySeekUsingNext: 8
 SeekPrefixGEs with trySeekUsingNext: 4
@@ -219,7 +219,7 @@ set-bounds lower=a upper=c
 seek-prefix-ge b
 ----
 .
-b:1
+b: (1, .)
 stats: (interface (dir, seek, step): (fwd, 20, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 19, 1), (rev, 0, 3))
 SeekGEs with trySeekUsingNext: 8
 SeekPrefixGEs with trySeekUsingNext: 4
@@ -229,7 +229,7 @@ set-bounds lower=c upper=e
 seek-prefix-ge c
 ----
 .
-c:1
+c: (1, .)
 stats: (interface (dir, seek, step): (fwd, 21, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 20, 1), (rev, 0, 3))
 SeekGEs with trySeekUsingNext: 8
 SeekPrefixGEs with trySeekUsingNext: 4
@@ -241,7 +241,7 @@ set-bounds lower=c upper=e
 seek-prefix-ge d
 ----
 .
-d:2
+d: (2, .)
 stats: (interface (dir, seek, step): (fwd, 22, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 21, 1), (rev, 0, 3))
 SeekGEs with trySeekUsingNext: 8
 SeekPrefixGEs with trySeekUsingNext: 6
@@ -257,7 +257,7 @@ set-options lower=a upper=c
 seek-ge b
 ----
 .
-b:1
+b: (1, .)
 stats: (interface (dir, seek, step): (fwd, 23, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 22, 1), (rev, 0, 3))
 SeekGEs with trySeekUsingNext: 8
 SeekPrefixGEs with trySeekUsingNext: 6
@@ -267,7 +267,7 @@ set-options lower=c upper=e
 seek-ge c
 ----
 .
-c:1
+c: (1, .)
 stats: (interface (dir, seek, step): (fwd, 24, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 23, 1), (rev, 0, 3))
 SeekGEs with trySeekUsingNext: 8
 SeekPrefixGEs with trySeekUsingNext: 6
@@ -279,7 +279,7 @@ set-options lower=c upper=e
 seek-ge d
 ----
 .
-d:2
+d: (2, .)
 stats: (interface (dir, seek, step): (fwd, 25, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 24, 1), (rev, 0, 3))
 SeekGEs with trySeekUsingNext: 10
 SeekPrefixGEs with trySeekUsingNext: 6
@@ -289,7 +289,7 @@ set-options lower=a upper=c
 seek-prefix-ge b
 ----
 .
-b:1
+b: (1, .)
 stats: (interface (dir, seek, step): (fwd, 26, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 25, 1), (rev, 0, 3))
 SeekGEs with trySeekUsingNext: 10
 SeekPrefixGEs with trySeekUsingNext: 6
@@ -299,7 +299,7 @@ set-options lower=c upper=e
 seek-prefix-ge c
 ----
 .
-c:1
+c: (1, .)
 stats: (interface (dir, seek, step): (fwd, 27, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 26, 1), (rev, 0, 3))
 SeekGEs with trySeekUsingNext: 10
 SeekPrefixGEs with trySeekUsingNext: 6
@@ -311,7 +311,7 @@ set-options lower=c upper=e
 seek-prefix-ge d
 ----
 .
-d:2
+d: (2, .)
 stats: (interface (dir, seek, step): (fwd, 28, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 27, 1), (rev, 0, 3))
 SeekGEs with trySeekUsingNext: 10
 SeekPrefixGEs with trySeekUsingNext: 8

--- a/testdata/iterator_seek_opt_errors
+++ b/testdata/iterator_seek_opt_errors
@@ -14,11 +14,11 @@ seek-ge aaa
 seek-ge b
 seek-ge bb
 ----
-b:b
-b:b
-b:b
-b:b
-c:c
+b: (b, .)
+b: (b, .)
+b: (b, .)
+b: (b, .)
+c: (c, .)
 
 iter
 seek-lt ddd
@@ -27,11 +27,11 @@ seek-lt dd
 seek-lt d
 seek-lt c
 ----
-d:d
-d:d
-d:d
-c:c
-b:b
+d: (d, .)
+d: (d, .)
+d: (d, .)
+c: (c, .)
+b: (b, .)
 
 # Exercise errors which should prevent seek optimizations.
 
@@ -43,8 +43,8 @@ seek-ge d
 ----
 err=injecting error
 err=injecting error
-c:c
-d:d
+c: (c, .)
+d: (d, .)
 
 iter seek-error=(1)
 seek-ge d
@@ -52,10 +52,10 @@ seek-ge a
 seek-ge b
 seek-ge b
 ----
-d:d
+d: (d, .)
 err=injecting error
-b:b
-b:b
+b: (b, .)
+b: (b, .)
 
 iter seek-error=(0,1)
 seek-lt e
@@ -65,23 +65,23 @@ seek-lt b
 ----
 err=injecting error
 err=injecting error
-b:b
-a:a
+b: (b, .)
+a: (a, .)
 
 iter seek-error=(1)
 seek-lt b
 seek-lt e
 seek-lt e
 ----
-a:a
+a: (a, .)
 err=injecting error
-d:d
+d: (d, .)
 
 iter seek-error=(1)
 seek-prefix-ge d
 seek-prefix-ge a
 seek-prefix-ge b
 ----
-d:d
+d: (d, .)
 err=injecting error
-b:b
+b: (b, .)

--- a/testdata/iterator_stats
+++ b/testdata/iterator_stats
@@ -14,8 +14,8 @@ next
 next
 stats
 ----
-a:1
-c:2
+a: (1, .)
+c: (2, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 56 B, cached 56 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
@@ -29,8 +29,8 @@ next
 next
 stats
 ----
-a:1
-c:2
+a: (1, .)
+c: (2, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 56 B, cached 56 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))

--- a/testdata/iterator_table_filter
+++ b/testdata/iterator_table_filter
@@ -20,29 +20,29 @@ L3
 iter
 first
 ----
-a:4
+a: (4, .)
 
 # Only scan tables with min-seq-num < filter.
 
 iter filter=5
 first
 ----
-a:4
+a: (4, .)
 
 iter filter=4
 first
 ----
-a:3
+a: (3, .)
 
 iter filter=3
 first
 ----
-a:2
+a: (2, .)
 
 iter filter=2
 first
 ----
-a:1
+a: (1, .)
 
 iter filter=1
 first
@@ -59,8 +59,8 @@ first
 set-options table-filter=none
 first
 ----
-a:3
+a: (3, .)
 .
-a:3
+a: (3, .)
 .
-a:4
+a: (4, .)

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -338,9 +338,9 @@ next
 next
 next
 ----
-a:2
-b:2
-z:1
+a: (2, .)
+b: (2, .)
+z: (1, .)
 .
 
 compact a-z
@@ -354,9 +354,9 @@ next
 next
 next
 ----
-a:2
-b:2
-z:1
+a: (2, .)
+b: (2, .)
+z: (1, .)
 .
 
 # Regresion test for a bug in sstable smallest boundary generation
@@ -402,8 +402,8 @@ first
 next
 next
 ----
-a:3
-c:4
+a: (3, .)
+c: (4, .)
 .
 
 # The bug allowed seeing b:1 during reverse iteration.
@@ -413,8 +413,8 @@ last
 prev
 prev
 ----
-c:4
-a:3
+c: (4, .)
+a: (3, .)
 .
 
 # This is a similar scenario to the one above. In older versions of Pebble this
@@ -454,9 +454,9 @@ next
 last
 prev
 ----
-a:4
+a: (4, .)
 .
-a:4
+a: (4, .)
 .
 
 # Similar to the preceding scenario, except the range tombstone has
@@ -493,11 +493,11 @@ last
 prev
 prev
 ----
-a:4
-b:3
+a: (4, .)
+b: (3, .)
 .
-b:3
-a:4
+b: (3, .)
+a: (4, .)
 .
 
 # Similar to the preceding scenario, except the range tombstone has
@@ -534,11 +534,11 @@ last
 prev
 prev
 ----
-a:4
-b:4
+a: (4, .)
+b: (4, .)
 .
-b:4
-a:4
+b: (4, .)
+a: (4, .)
 .
 
 # Test a scenario where the last point key in an sstable has a seqnum
@@ -565,7 +565,7 @@ iter
 last
 prev
 ----
-a:3
+a: (3, .)
 .
 
 compact a-e L1
@@ -581,7 +581,7 @@ iter
 last
 prev
 ----
-a:3
+a: (3, .)
 .
 
 # Test a scenario where the last point key in an sstable before the
@@ -1011,6 +1011,6 @@ first
 next
 next
 ----
-tmgc:barfoo
+tmgc: (barfoo, .)
 .
 .

--- a/testdata/manual_compaction_set_with_del
+++ b/testdata/manual_compaction_set_with_del
@@ -338,9 +338,9 @@ next
 next
 next
 ----
-a:2
-b:2
-z:1
+a: (2, .)
+b: (2, .)
+z: (1, .)
 .
 
 compact a-z
@@ -354,9 +354,9 @@ next
 next
 next
 ----
-a:2
-b:2
-z:1
+a: (2, .)
+b: (2, .)
+z: (1, .)
 .
 
 # Regresion test for a bug in sstable smallest boundary generation
@@ -402,8 +402,8 @@ first
 next
 next
 ----
-a:3
-c:4
+a: (3, .)
+c: (4, .)
 .
 
 # The bug allowed seeing b:1 during reverse iteration.
@@ -413,8 +413,8 @@ last
 prev
 prev
 ----
-c:4
-a:3
+c: (4, .)
+a: (3, .)
 .
 
 # This is a similar scenario to the one above. In older versions of Pebble this
@@ -454,9 +454,9 @@ next
 last
 prev
 ----
-a:4
+a: (4, .)
 .
-a:4
+a: (4, .)
 .
 
 # Similar to the preceding scenario, except the range tombstone has
@@ -493,11 +493,11 @@ last
 prev
 prev
 ----
-a:4
-b:3
+a: (4, .)
+b: (3, .)
 .
-b:3
-a:4
+b: (3, .)
+a: (4, .)
 .
 
 # Similar to the preceding scenario, except the range tombstone has
@@ -534,11 +534,11 @@ last
 prev
 prev
 ----
-a:4
-b:4
+a: (4, .)
+b: (4, .)
 .
-b:4
-a:4
+b: (4, .)
+a: (4, .)
 .
 
 # Test a scenario where the last point key in an sstable has a seqnum
@@ -565,7 +565,7 @@ iter
 last
 prev
 ----
-a:3
+a: (3, .)
 .
 
 compact a-e L1
@@ -581,7 +581,7 @@ iter
 last
 prev
 ----
-a:3
+a: (3, .)
 .
 
 # Test a scenario where the last point key in an sstable before the

--- a/testdata/range_del
+++ b/testdata/range_del
@@ -88,22 +88,22 @@ seek-lt b
 seek-lt c
 seek-lt d
 ----
-a:d
-b:bcd
-c:d
+a: (d, .)
+b: (bcd, .)
+c: (d, .)
 .
-a:d
-b:bcd
-c:d
+a: (d, .)
+b: (bcd, .)
+c: (d, .)
 .
-c:d
-b:bcd
-a:d
+c: (d, .)
+b: (bcd, .)
+a: (d, .)
 .
 .
-a:d
-b:bcd
-c:d
+a: (d, .)
+b: (bcd, .)
+c: (d, .)
 
 iter seq=7
 first
@@ -121,20 +121,20 @@ seek-lt b
 seek-lt c
 seek-lt d
 ----
-a:d
-c:d
+a: (d, .)
+c: (d, .)
 .
-a:d
-c:d
-c:d
+a: (d, .)
+c: (d, .)
+c: (d, .)
 .
-c:d
-a:d
+c: (d, .)
+a: (d, .)
 .
 .
-a:d
-a:d
-c:d
+a: (d, .)
+a: (d, .)
+c: (d, .)
 
 # Multiple memtables.
 
@@ -230,22 +230,22 @@ seek-lt b
 seek-lt c
 seek-lt d
 ----
-a:d
-b:bcd
-c:d
+a: (d, .)
+b: (bcd, .)
+c: (d, .)
 .
-a:d
-b:bcd
-c:d
+a: (d, .)
+b: (bcd, .)
+c: (d, .)
 .
-c:d
-b:bcd
-a:d
+c: (d, .)
+b: (bcd, .)
+a: (d, .)
 .
 .
-a:d
-b:bcd
-c:d
+a: (d, .)
+b: (bcd, .)
+c: (d, .)
 
 iter seq=7
 first
@@ -263,20 +263,20 @@ seek-lt b
 seek-lt c
 seek-lt d
 ----
-a:d
-c:d
+a: (d, .)
+c: (d, .)
 .
-a:d
-c:d
-c:d
+a: (d, .)
+c: (d, .)
+c: (d, .)
 .
-c:d
-a:d
+c: (d, .)
+a: (d, .)
 .
 .
-a:d
-a:d
-c:d
+a: (d, .)
+a: (d, .)
+c: (d, .)
 
 # Overlapping range deletions in the same memtable.
 
@@ -374,15 +374,15 @@ prev
 prev
 prev
 ----
-a:1
-b:1
-c:1
-d:1
+a: (1, .)
+b: (1, .)
+c: (1, .)
+d: (1, .)
 .
-d:1
-c:1
-b:1
-a:1
+d: (1, .)
+c: (1, .)
+b: (1, .)
+a: (1, .)
 .
 
 iter seq=3
@@ -391,9 +391,9 @@ next
 last
 prev
 ----
-d:1
+d: (1, .)
 .
-d:1
+d: (1, .)
 .
 
 iter seq=5
@@ -404,11 +404,11 @@ last
 prev
 prev
 ----
-a:2
-d:2
+a: (2, .)
+d: (2, .)
 .
-d:2
-a:2
+d: (2, .)
+a: (2, .)
 .
 
 iter seq=7
@@ -421,13 +421,13 @@ prev
 prev
 prev
 ----
-a:3
-b:3
-d:3
+a: (3, .)
+b: (3, .)
+d: (3, .)
 .
-d:3
-b:3
-a:3
+d: (3, .)
+b: (3, .)
+a: (3, .)
 .
 
 iter seq=9
@@ -442,15 +442,15 @@ prev
 prev
 prev
 ----
-a:4
-b:4
-c:4
-d:4
+a: (4, .)
+b: (4, .)
+c: (4, .)
+d: (4, .)
 .
-d:4
-c:4
-b:4
-a:4
+d: (4, .)
+c: (4, .)
+b: (4, .)
+a: (4, .)
 .
 
 # Overlapping range deletions in different memtables. Note that the
@@ -550,15 +550,15 @@ prev
 prev
 prev
 ----
-a:1
-b:1
-c:1
-d:1
+a: (1, .)
+b: (1, .)
+c: (1, .)
+d: (1, .)
 .
-d:1
-c:1
-b:1
-a:1
+d: (1, .)
+c: (1, .)
+b: (1, .)
+a: (1, .)
 .
 
 iter seq=3
@@ -567,9 +567,9 @@ next
 last
 prev
 ----
-d:1
+d: (1, .)
 .
-d:1
+d: (1, .)
 .
 
 iter seq=5
@@ -580,11 +580,11 @@ last
 prev
 prev
 ----
-a:2
-d:2
+a: (2, .)
+d: (2, .)
 .
-d:2
-a:2
+d: (2, .)
+a: (2, .)
 .
 
 iter seq=7
@@ -597,13 +597,13 @@ prev
 prev
 prev
 ----
-a:3
-b:3
-d:3
+a: (3, .)
+b: (3, .)
+d: (3, .)
 .
-d:3
-b:3
-a:3
+d: (3, .)
+b: (3, .)
+a: (3, .)
 .
 
 iter seq=9
@@ -618,15 +618,15 @@ prev
 prev
 prev
 ----
-a:4
-b:4
-c:4
-d:4
+a: (4, .)
+b: (4, .)
+c: (4, .)
+d: (4, .)
 .
-d:4
-c:4
-b:4
-a:4
+d: (4, .)
+c: (4, .)
+b: (4, .)
+a: (4, .)
 .
 
 # User-key that spans tables in a level.
@@ -673,12 +673,12 @@ last
 seek-lt a
 seek-lt b
 ----
-a:1
-a:1
+a: (1, .)
+a: (1, .)
 .
-a:1
+a: (1, .)
 .
-a:1
+a: (1, .)
 
 iter seq=3
 first
@@ -688,12 +688,12 @@ last
 seek-lt a
 seek-lt b
 ----
-a:2
-a:2
+a: (2, .)
+a: (2, .)
 .
-a:2
+a: (2, .)
 .
-a:2
+a: (2, .)
 
 iter seq=4
 first
@@ -703,12 +703,12 @@ last
 seek-lt a
 seek-lt b
 ----
-a:3
-a:3
+a: (3, .)
+a: (3, .)
 .
-a:3
+a: (3, .)
 .
-a:3
+a: (3, .)
 
 define
 L1
@@ -752,12 +752,12 @@ last
 seek-lt a
 seek-lt b
 ----
-a:1
-a:1
+a: (1, .)
+a: (1, .)
 .
-a:1
+a: (1, .)
 .
-a:1
+a: (1, .)
 
 iter seq=3
 first
@@ -767,12 +767,12 @@ last
 seek-lt a
 seek-lt b
 ----
-a:12
-a:12
+a: (12, .)
+a: (12, .)
 .
-a:12
+a: (12, .)
 .
-a:12
+a: (12, .)
 
 iter seq=4
 first
@@ -782,12 +782,12 @@ last
 seek-lt a
 seek-lt b
 ----
-a:123
-a:123
+a: (123, .)
+a: (123, .)
 .
-a:123
+a: (123, .)
 .
-a:123
+a: (123, .)
 
 # User-key spread across multiple levels.
 
@@ -842,12 +842,12 @@ last
 seek-lt a
 seek-lt b
 ----
-a:1
-a:1
+a: (1, .)
+a: (1, .)
 .
-a:1
+a: (1, .)
 .
-a:1
+a: (1, .)
 
 iter seq=3
 first
@@ -857,12 +857,12 @@ last
 seek-lt a
 seek-lt b
 ----
-a:12
-a:12
+a: (12, .)
+a: (12, .)
 .
-a:12
+a: (12, .)
 .
-a:12
+a: (12, .)
 
 iter seq=4
 first
@@ -872,12 +872,12 @@ last
 seek-lt a
 seek-lt b
 ----
-a:123
-a:123
+a: (123, .)
+a: (123, .)
 .
-a:123
+a: (123, .)
 .
-a:123
+a: (123, .)
 
 iter seq=5
 first
@@ -887,12 +887,12 @@ last
 seek-lt a
 seek-lt b
 ----
-a:1234
-a:1234
+a: (1234, .)
+a: (1234, .)
 .
-a:1234
+a: (1234, .)
 .
-a:1234
+a: (1234, .)
 
 # Range deletions on multiple levels.
 define
@@ -978,21 +978,21 @@ prev
 prev
 prev
 ----
-a:1
-b:1
-c:1
-d:1
-d:1
-c:1
-b:1
-a:1
+a: (1, .)
+b: (1, .)
+c: (1, .)
+d: (1, .)
+d: (1, .)
+c: (1, .)
+b: (1, .)
+a: (1, .)
 
 iter seq=3
 first
 last
 ----
-d:2
-d:2
+d: (2, .)
+d: (2, .)
 
 iter seq=4
 first
@@ -1000,10 +1000,10 @@ next
 last
 prev
 ----
-a:3
-d:3
-d:3
-a:3
+a: (3, .)
+d: (3, .)
+d: (3, .)
+a: (3, .)
 
 iter seq=5
 first
@@ -1013,12 +1013,12 @@ last
 prev
 prev
 ----
-a:4
-b:4
-d:4
-d:4
-b:4
-a:4
+a: (4, .)
+b: (4, .)
+d: (4, .)
+d: (4, .)
+b: (4, .)
+a: (4, .)
 
 # Range deletions spanning tables within a level.
 
@@ -1091,21 +1091,21 @@ prev
 prev
 prev
 ----
-a:1
-b:1
-c:1
-d:1
-d:1
-c:1
-b:1
-a:1
+a: (1, .)
+b: (1, .)
+c: (1, .)
+d: (1, .)
+d: (1, .)
+c: (1, .)
+b: (1, .)
+a: (1, .)
 
 iter seq=3
 first
 last
 ----
-d:1
-d:1
+d: (1, .)
+d: (1, .)
 
 iter seq=4
 first
@@ -1117,14 +1117,14 @@ prev
 prev
 prev
 ----
-a:3
-b:3
-c:3
-d:3
-d:3
-c:3
-b:3
-a:3
+a: (3, .)
+b: (3, .)
+c: (3, .)
+d: (3, .)
+d: (3, .)
+c: (3, .)
+b: (3, .)
+a: (3, .)
 
 # Invalid LSM structure (range deletion at newer level covers newer
 # write at an older level). This LSM structure is not generated
@@ -1185,7 +1185,7 @@ iter seq=4
 seek-ge b
 next
 ----
-c:v
+c: (v, .)
 .
 
 # Reverse the above test: compact the left file containing the split range
@@ -1224,8 +1224,8 @@ seek-lt d
 prev
 prev
 ----
-c:v
-a:v
+c: (v, .)
+a: (v, .)
 .
 
 # A range tombstone straddles two sstables. One is compacted two

--- a/testdata/read_compaction_queue
+++ b/testdata/read_compaction_queue
@@ -275,7 +275,7 @@ L5: n-w 4
 add-compaction
 L5: x-z 5
 ----
- 
+
 print-size
 ----
 5

--- a/testdata/singledel_manual_compaction
+++ b/testdata/singledel_manual_compaction
@@ -74,4 +74,4 @@ compact a-b L2
 iter
 first
 ----
-a:v2
+a: (v2, .)


### PR DESCRIPTION
Cockroach 22.2 backport of #1981.

----

The recent bug fix in https://github.com/cockroachdb/pebble/pull/1967 introduced a new bug when switching from iteration over range keys to iteration over only point keys. If the iterator was positioned over a range key before the swtich to point-only iteration, the first seek after SetOptions would improperly return RangeKeyChanged()=true, when the contract dictates that such a position must return RangeKeyChanged()=false.

Fix https://github.com/cockroachdb/pebble/issues/1980.