### PR TITLE
db: add IteratorStats.Merge

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -2348,6 +2348,18 @@ func (i *Iterator) Clone(opts CloneOptions) (*Iterator, error) {
 	return finishInitializingIter(buf), nil
 }
 
+// Merge adds all of the argument's statistics to the receiver. It may be used
+// to accumulate stats across multiple iterators.
+func (stats *IteratorStats) Merge(o IteratorStats) {
+	for i := InterfaceCall; i < NumStatsKind; i++ {
+		stats.ForwardSeekCount[i] += o.ForwardSeekCount[i]
+		stats.ReverseSeekCount[i] += o.ReverseSeekCount[i]
+		stats.ForwardStepCount[i] += o.ForwardStepCount[i]
+		stats.ReverseStepCount[i] += o.ReverseStepCount[i]
+	}
+	stats.InternalStats.Merge(o.InternalStats)
+}
+
 func (stats *IteratorStats) String() string {
 	return redact.StringWithoutMarkers(stats)
 }

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1671,6 +1671,51 @@ func TestIteratorBoundsLifetimes(t *testing.T) {
 	})
 }
 
+func TestIteratorStatsMerge(t *testing.T) {
+	s := IteratorStats{
+		ForwardSeekCount: [NumStatsKind]int{1, 2},
+		ReverseSeekCount: [NumStatsKind]int{3, 4},
+		ForwardStepCount: [NumStatsKind]int{5, 6},
+		ReverseStepCount: [NumStatsKind]int{7, 8},
+		InternalStats: InternalIteratorStats{
+			BlockBytes:                     9,
+			BlockBytesInCache:              10,
+			KeyBytes:                       11,
+			ValueBytes:                     12,
+			PointCount:                     13,
+			PointsCoveredByRangeTombstones: 14,
+		},
+	}
+	s.Merge(IteratorStats{
+		ForwardSeekCount: [NumStatsKind]int{1, 2},
+		ReverseSeekCount: [NumStatsKind]int{3, 4},
+		ForwardStepCount: [NumStatsKind]int{5, 6},
+		ReverseStepCount: [NumStatsKind]int{7, 8},
+		InternalStats: InternalIteratorStats{
+			BlockBytes:                     9,
+			BlockBytesInCache:              10,
+			KeyBytes:                       11,
+			ValueBytes:                     12,
+			PointCount:                     13,
+			PointsCoveredByRangeTombstones: 14,
+		},
+	})
+	require.Equal(t, IteratorStats{
+		ForwardSeekCount: [NumStatsKind]int{2, 4},
+		ReverseSeekCount: [NumStatsKind]int{6, 8},
+		ForwardStepCount: [NumStatsKind]int{10, 12},
+		ReverseStepCount: [NumStatsKind]int{14, 16},
+		InternalStats: InternalIteratorStats{
+			BlockBytes:                     18,
+			BlockBytesInCache:              20,
+			KeyBytes:                       22,
+			ValueBytes:                     24,
+			PointCount:                     26,
+			PointsCoveredByRangeTombstones: 28,
+		},
+	}, s)
+}
+
 // TestSetOptionsEquivalence tests equivalence between SetOptions to mutate an
 // iterator and constructing a new iterator with NewIter. The long-lived
 // iterator and the new iterator should surface identical iterator states.


### PR DESCRIPTION
Add a Merge method to IteratorStats. I intend to use this in benchmarks to aggregate statistics across iterators to report a custom benchmark metric.