### PR TITLE
db: integrate elastic cpu granter with pebble

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2317,10 +2317,10 @@ func (d *DB) runCompaction(
 	// must be careful, because the byte slice returned by UnsafeKey
 	// points directly into the Writer's block buffer.
 	var prevPointKey sstable.PreviousPointKeyOpt
-	var additionalCPUProcs int
+	var cpuWorkHandle CPUWorkHandle
 	defer func() {
-		if additionalCPUProcs > 0 {
-			d.opts.Experimental.CPUWorkPermissionGranter.ReturnProcs(additionalCPUProcs)
+		if cpuWorkHandle != nil {
+			d.opts.Experimental.CPUWorkPermissionGranter.CPUWorkDone(cpuWorkHandle)
 		}
 	}()
 
@@ -2359,12 +2359,15 @@ func (d *DB) runCompaction(
 		filenames = append(filenames, filename)
 		cacheOpts := private.SSTableCacheOpts(d.cacheID, fileNum).(sstable.WriterOption)
 		internalTableOpt := private.SSTableInternalTableOpt.(sstable.WriterOption)
-		if d.opts.Experimental.CPUWorkPermissionGranter != nil {
-			additionalCPUProcs = d.opts.Experimental.CPUWorkPermissionGranter.TryGetProcs(1)
-		}
+
+		const MaxFileWriteAdditionalCPUTime = time.Millisecond * 100
+		cpuWorkHandle = d.opts.Experimental.CPUWorkPermissionGranter.GetPermission(
+			MaxFileWriteAdditionalCPUTime,
+		)
 		writerOpts.Parallelism =
 			d.opts.Experimental.MaxWriterConcurrency > 0 &&
-				(additionalCPUProcs > 0 || d.opts.Experimental.ForceWriterParallelism)
+				(cpuWorkHandle.Permitted() || d.opts.Experimental.ForceWriterParallelism)
+
 		tw = sstable.NewWriter(file, writerOpts, cacheOpts, internalTableOpt, &prevPointKey)
 
 		fileMeta.CreationTime = time.Now().Unix()
@@ -2469,10 +2472,8 @@ func (d *DB) runCompaction(
 			tw = nil
 			return err
 		}
-		if additionalCPUProcs > 0 {
-			d.opts.Experimental.CPUWorkPermissionGranter.ReturnProcs(additionalCPUProcs)
-			additionalCPUProcs = 0
-		}
+		d.opts.Experimental.CPUWorkPermissionGranter.CPUWorkDone(cpuWorkHandle)
+		cpuWorkHandle = nil
 		writerMeta, err := tw.Metadata()
 		if err != nil {
 			tw = nil

--- a/db.go
+++ b/db.go
@@ -168,17 +168,39 @@ type Writer interface {
 	RangeKeyDelete(start, end []byte, opts *WriteOptions) error
 }
 
-// CPUWorkPermissionGranter is used to request permission to opportunistically
-// use additional CPUs to speed up internal background work. Each granted "proc"
-// can be used to spin up a CPU bound goroutine, i.e, if scheduled each such
-// goroutine can consume one P in the goroutine scheduler. The calls to
-// ReturnProcs can be a bit delayed, since Pebble interacts with this interface
-// in a coarse manner. So one should assume that the total number of granted
-// procs is a non tight upper bound on the CPU that will get consumed.
-type CPUWorkPermissionGranter interface {
-	TryGetProcs(count int) int
-	ReturnProcs(count int)
+// CPUWorkHandle represents a handle used by the CPUWorkPermissionGranter API.
+type CPUWorkHandle interface {
+	// Permitted indicates whether Pebble can use additional CPU resources.
+	Permitted() bool
 }
+
+// CPUWorkPermissionGranter is used to request permission to opportunistically
+// use additional CPUs to speed up internal background work.
+type CPUWorkPermissionGranter interface {
+	// GetPermission returns a handle regardless of whether permission is granted
+	// or not. In the latter case, the handle is only useful for recording
+	// the CPU time actually spent on this calling goroutine.
+	GetPermission(time.Duration) CPUWorkHandle
+	// CPUWorkDone must be called regardless of whether CPUWorkHandle.Permitted
+	// returns true or false.
+	CPUWorkDone(CPUWorkHandle)
+}
+
+// Use a default implementation for the CPU work granter to avoid excessive nil
+// checks in the code.
+type defaultCPUWorkHandle struct{}
+
+func (d defaultCPUWorkHandle) Permitted() bool {
+	return false
+}
+
+type defaultCPUWorkGranter struct{}
+
+func (d defaultCPUWorkGranter) GetPermission(_ time.Duration) CPUWorkHandle {
+	return defaultCPUWorkHandle{}
+}
+
+func (d defaultCPUWorkGranter) CPUWorkDone(_ CPUWorkHandle) {}
 
 // DB provides a concurrent, persistent ordered key/value store.
 //

--- a/options.go
+++ b/options.go
@@ -928,6 +928,9 @@ func (o *Options) EnsureDefaults() *Options {
 	if o.Experimental.TableCacheShards <= 0 {
 		o.Experimental.TableCacheShards = runtime.GOMAXPROCS(0)
 	}
+	if o.Experimental.CPUWorkPermissionGranter == nil {
+		o.Experimental.CPUWorkPermissionGranter = defaultCPUWorkGranter{}
+	}
 
 	o.initMaps()
 	return o


### PR DESCRIPTION
This pr modifies the interface of the CPUWorkPermissionGranter to accommodate the change from cpu soft slots to the elastic cpu granter.

The CPUWorkPermissionGranter returns a handle which internally calculates the CPU time spent on the Writer client goroutine.