### PR TITLE
crl-release-22.2: db: restore TrySeekUsingNext across SetOptions batch refresh

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -124,6 +124,29 @@ func runIterCmd(d *datadriven.TestData, iter *Iterator, closeIter bool) string {
 			validityState = iter.SeekLTWithLimit(
 				[]byte(parts[1]), []byte(parts[2]))
 			printValidityState = true
+		case "inspect":
+			if len(parts) != 2 {
+				return "inspect <field>\n"
+			}
+			field := parts[1]
+			switch field {
+			case "lastPositioningOp":
+				op := "?"
+				switch iter.lastPositioningOp {
+				case unknownLastPositionOp:
+					op = "unknown"
+				case seekPrefixGELastPositioningOp:
+					op = "seekprefixge"
+				case seekGELastPositioningOp:
+					op = "seekge"
+				case seekLTLastPositioningOp:
+					op = "seeklt"
+				}
+				fmt.Fprintf(&b, "%s=%q\n", field, op)
+			default:
+				return fmt.Sprintf("unrecognized inspect field %q\n", field)
+			}
+			continue
 		case "next-limit":
 			if len(parts) != 2 {
 				return "next-limit <limit>\n"

--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -190,6 +190,7 @@ type SeekGEFlags uint8
 const (
 	seekGEFlagTrySeekUsingNext uint8 = iota
 	seekGEFlagRelativeSeek
+	seekGEFlagBatchJustRefreshed
 )
 
 // SeekGEFlagsNone is the default value of SeekGEFlags, with all flags disabled.
@@ -234,6 +235,13 @@ func (s SeekGEFlags) TrySeekUsingNext() bool { return (s & (1 << seekGEFlagTrySe
 // iterator position and the new seeked position.
 func (s SeekGEFlags) RelativeSeek() bool { return (s & (1 << seekGEFlagRelativeSeek)) != 0 }
 
+// BatchJustRefreshed is set by Seek[Prefix]GE when an iterator's view of an
+// indexed batch was just refreshed. It serves as a signal to the batch iterator
+// to ignore the TrySeekUsingNext optimization, because the external knowledge
+// imparted by the TrySeekUsingNext flag does not apply to the batch iterator's
+// position. See (pebble.Iterator).batchJustRefreshed.
+func (s SeekGEFlags) BatchJustRefreshed() bool { return (s & (1 << seekGEFlagBatchJustRefreshed)) != 0 }
+
 // EnableTrySeekUsingNext returns the provided flags with the
 // try-seek-using-next optimization enabled. See TrySeekUsingNext for an
 // explanation of this optimization.
@@ -257,6 +265,19 @@ func (s SeekGEFlags) EnableRelativeSeek() SeekGEFlags {
 // disabled.
 func (s SeekGEFlags) DisableRelativeSeek() SeekGEFlags {
 	return s &^ (1 << seekGEFlagRelativeSeek)
+}
+
+// EnableBatchJustRefreshed returns the provided flags with the
+// batch-just-refreshed bit set. See BatchJustRefreshed for an explanation of
+// this flag.
+func (s SeekGEFlags) EnableBatchJustRefreshed() SeekGEFlags {
+	return s | (1 << seekGEFlagBatchJustRefreshed)
+}
+
+// DisableBatchJustRefreshed returns the provided flags with the
+// batch-just-refreshed bit unset.
+func (s SeekGEFlags) DisableBatchJustRefreshed() SeekGEFlags {
+	return s &^ (1 << seekGEFlagBatchJustRefreshed)
 }
 
 // SeekLTFlags holds flags that may configure the behavior of a reverse seek.

--- a/internal/base/iterator_test.go
+++ b/internal/base/iterator_test.go
@@ -25,6 +25,12 @@ func TestFlags(t *testing.T) {
 				func() { f = f.EnableRelativeSeek() },
 				func() { f = f.DisableRelativeSeek() },
 			},
+			{
+				"BatchJustRefreshed",
+				func() bool { return f.BatchJustRefreshed() },
+				func() { f = f.EnableBatchJustRefreshed() },
+				func() { f = f.DisableBatchJustRefreshed() },
+			},
 		}
 		ref := make([]bool, len(flags))
 		checkCombination(t, 0, flags, ref)

--- a/internal/batchskl/skl_test.go
+++ b/internal/batchskl/skl_test.go
@@ -51,7 +51,7 @@ func (i *iterAdapter) verify(key *base.InternalKey) bool {
 }
 
 func (i *iterAdapter) SeekGE(key []byte) bool {
-	return i.verify(i.Iterator.SeekGE(key))
+	return i.verify(i.Iterator.SeekGE(key, base.SeekGEFlagsNone))
 }
 
 func (i *iterAdapter) SeekLT(key []byte) bool {
@@ -462,7 +462,7 @@ func BenchmarkReadWrite(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				key := randomKey(rng, buf[:])
 				if rng.Float32() < readFrac {
-					_ = it.SeekGE(key)
+					_ = it.SeekGE(key, base.SeekGEFlagsNone)
 				} else {
 					offset := d.addBytes(buf[:])
 					_ = l.Add(offset)

--- a/iterator.go
+++ b/iterator.go
@@ -237,6 +237,26 @@ type Iterator struct {
 	// Used for deriving the value of SeekPrefixGE(..., trySeekUsingNext),
 	// and SeekGE/SeekLT optimizations
 	lastPositioningOp lastPositioningOpKind
+	// Used for determining when it's safe to perform SeekGE optimizations that
+	// reuse the iterator state to avoid the cost of a full seek if the iterator
+	// is already positioned in the correct place. If the iterator's view of its
+	// indexed batch was just refreshed, some optimizations cannot be applied on
+	// the first seek after the refresh:
+	// - SeekGE has a no-op optimization that does not seek on the internal
+	//   iterator at all if the iterator is already in the correct place.
+	//   This optimization cannot be performed if the internal iterator was
+	//   last positioned when the iterator had a different view of an
+	//   underlying batch.
+	// - Seek[Prefix]GE set flags.TrySeekUsingNext()=true when the seek key is
+	//   greater than the previous operation's seek key, under the expectation
+	//   that the various internal iterators can use their current position to
+	//   avoid a full expensive re-seek. This applies to the batchIter as well.
+	//   However, if the view of the batch was just refreshed, the batchIter's
+	//   position is not useful because it may already be beyond new keys less
+	//   than the seek key. To prevent the use of this optimization in
+	//   batchIter, Seek[Prefix]GE set flags.BatchJustRefreshed()=true if this
+	//   bit is enabled.
+	batchJustRefreshed bool
 	// Used for an optimization in external iterators to reduce the number of
 	// merging levels.
 	forwardOnly bool
@@ -1044,20 +1064,23 @@ func (i *Iterator) SeekGEWithLimit(key []byte, limit []byte) IterValidityState {
 		key = upperBound
 	}
 	seekInternalIter := true
+
 	var flags base.SeekGEFlags
-	// The following noop optimization only applies when i.batch == nil, since
-	// an iterator over a batch is iterating over mutable data, that may have
-	// changed since the last seek.
-	if lastPositioningOp == seekGELastPositioningOp && i.batch == nil {
+	if i.batchJustRefreshed {
+		i.batchJustRefreshed = false
+		flags = flags.EnableBatchJustRefreshed()
+	}
+	if lastPositioningOp == seekGELastPositioningOp {
 		cmp := i.cmp(i.prefixOrFullSeekKey, key)
 		// If this seek is to the same or later key, and the iterator is
 		// already positioned there, this is a noop. This can be helpful for
 		// sparse key spaces that have many deleted keys, where one can avoid
 		// the overhead of iterating past them again and again.
 		if cmp <= 0 {
-			if i.iterValidityState == IterExhausted ||
-				(i.iterValidityState == IterValid && i.cmp(key, i.key) <= 0 &&
-					(limit == nil || i.cmp(i.key, limit) < 0)) {
+			if !flags.BatchJustRefreshed() &&
+				(i.iterValidityState == IterExhausted ||
+					(i.iterValidityState == IterValid && i.cmp(key, i.key) <= 0 &&
+						(limit == nil || i.cmp(i.key, limit) < 0))) {
 				// Noop
 				if !invariants.Enabled || !disableSeekOpt(key, uintptr(unsafe.Pointer(i))) || i.forceEnableSeekOpt {
 					i.lastPositioningOp = seekGELastPositioningOp
@@ -1083,7 +1106,7 @@ func (i *Iterator) SeekGEWithLimit(key []byte, limit []byte) IterValidityState {
 			if invariants.Enabled && flags.TrySeekUsingNext() && !i.forceEnableSeekOpt && disableSeekOpt(key, uintptr(unsafe.Pointer(i))) {
 				flags = flags.DisableTrySeekUsingNext()
 			}
-			if i.pos == iterPosCurForwardPaused && i.cmp(key, i.iterKey.UserKey) <= 0 {
+			if !flags.BatchJustRefreshed() && i.pos == iterPosCurForwardPaused && i.cmp(key, i.iterKey.UserKey) <= 0 {
 				// Have some work to do, but don't need to seek, and we can
 				// start doing findNextEntry from i.iterKey.
 				seekInternalIter = false
@@ -1114,7 +1137,7 @@ func (i *Iterator) SeekGEWithLimit(key []byte, limit []byte) IterValidityState {
 	}
 	i.findNextEntry(limit)
 	i.maybeSampleRead()
-	if i.Error() == nil && i.batch == nil {
+	if i.Error() == nil {
 		// Prepare state for a future noop optimization.
 		i.prefixOrFullSeekKey = append(i.prefixOrFullSeekKey[:0], key...)
 		i.lastPositioningOp = seekGELastPositioningOp
@@ -1193,6 +1216,7 @@ func (i *Iterator) SeekPrefixGE(key []byte) bool {
 	// the SeekPrefixGE following this should not make any assumption about
 	// iterator position.
 	i.lastPositioningOp = unknownLastPositionOp
+	i.batchJustRefreshed = false
 	i.requiresReposition = false
 	i.err = nil // clear cached iteration error
 	i.stats.ForwardSeekCount[InterfaceCall]++
@@ -1319,6 +1343,7 @@ func (i *Iterator) SeekLTWithLimit(key []byte, limit []byte) IterValidityState {
 	// the SeekLT following this should not make any assumption about iterator
 	// position.
 	i.lastPositioningOp = unknownLastPositionOp
+	i.batchJustRefreshed = false
 	i.requiresReposition = false
 	i.err = nil // clear cached iteration error
 	i.stats.ReverseSeekCount[InterfaceCall]++
@@ -1392,6 +1417,7 @@ func (i *Iterator) First() bool {
 	}
 	i.err = nil // clear cached iteration error
 	i.hasPrefix = false
+	i.batchJustRefreshed = false
 	i.lastPositioningOp = unknownLastPositionOp
 	i.requiresReposition = false
 	i.stats.ForwardSeekCount[InterfaceCall]++
@@ -1429,6 +1455,7 @@ func (i *Iterator) Last() bool {
 	}
 	i.err = nil // clear cached iteration error
 	i.hasPrefix = false
+	i.batchJustRefreshed = false
 	i.lastPositioningOp = unknownLastPositionOp
 	i.requiresReposition = false
 	i.stats.ReverseSeekCount[InterfaceCall]++
@@ -2102,31 +2129,31 @@ func (i *Iterator) SetOptions(o *IterOptions) {
 			if i.merging != nil {
 				i.merging.batchSnapshot = nextBatchSeqNum
 			}
-			if i.pointIter != nil {
-				if i.batch.countRangeDels == 0 {
-					// No range deletions exist in the batch. We only need to
-					// update the batchIter's snapshot.
-					i.invalidate()
-				} else if i.batchRangeDelIter.Count() == 0 {
+			// Prevent a no-op seek optimization on the next seek. We won't be
+			// able to reuse the top-level Iterator state, because it may be
+			// incorrect after the inclusion of new batch mutations.
+			i.batchJustRefreshed = true
+			if i.pointIter != nil && i.batch.countRangeDels > 0 {
+				if i.batchRangeDelIter.Count() == 0 {
 					// When we constructed this iterator, there were no
-					// rangedels in the batch. Iterator construction will have
-					// excluded the batch rangedel iterator from the point
-					// iterator stack. We need to reconstruct the point iterator
-					// to add i.batchRangeDelIter into the iterator stack.
+					// rangedels in the batch. Iterator construction will
+					// have excluded the batch rangedel iterator from the
+					// point iterator stack. We need to reconstruct the
+					// point iterator to add i.batchRangeDelIter into the
+					// iterator stack.
 					i.err = firstError(i.err, i.pointIter.Close())
 					i.pointIter = nil
 				} else {
 					// There are range deletions in the batch and we already
-					// have a batch rangedel iterator. We can update the batch
-					// rangedel iterator in place.
+					// have a batch rangedel iterator. We can update the
+					// batch rangedel iterator in place.
 					//
-					// NB: There may or may not be new range deletions. We can't
-					// tell based on i.batchRangeDelIter.Count(), which is the
-					// count of fragmented range deletions, NOT the number of
-					// range deletions written to the batch
+					// NB: There may or may not be new range deletions. We
+					// can't tell based on i.batchRangeDelIter.Count(),
+					// which is the count of fragmented range deletions, NOT
+					// the number of range deletions written to the batch
 					// [i.batch.countRangeDels].
 					i.batch.initRangeDelIter(&i.opts, &i.batchRangeDelIter, nextBatchSeqNum)
-					i.invalidate()
 				}
 			}
 			if i.rangeKey != nil && i.batch.countRangeKeys > 0 {

--- a/testdata/iter_histories/iter_optimizations
+++ b/testdata/iter_histories/iter_optimizations
@@ -159,3 +159,186 @@ a: (a, [a-b) @9=v UPDATED)
 .
 d@5: (., [d-"d\x00") @9=v UPDATED)
 b: (b, [b-e) @9=v UPDATED)
+
+# Test TrySeekUsingNext across no-op SetOptions when reading through an indexed
+# batch with modifications. The seek-prefix-ges after the first should make use
+# of the TrySeekUsingNext optimization.
+#
+# TODO(jackson): The iterator stats don't signal the use of try-seek-using-next,
+# so we inspect lastPositioningOp as a proxy since that's the
+# try-seek-using-next prerequisite that previously regressed. Is there a way to
+# adapt to this test so that the absence of the try-seek-using-next optimization
+# is visible in the iterator statistics?
+#
+# Regression test for cockroachdb/cockroach#88819.
+
+reset
+----
+
+batch commit
+set b@5 b@5
+set c@3 c@3
+set d@9 d@9
+set e@8 e@8
+set f@8 f@8
+----
+committed 5 keys
+
+flush
+----
+
+batch name=foo
+set g@4 g@4
+----
+wrote 1 keys to batch "foo"
+
+combined-iter reader=foo name=fooiter
+inspect lastPositioningOp
+seek-prefix-ge b@10
+stats
+----
+lastPositioningOp="unknown"
+b@5: (b@5, .)
+stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 120 B, cached 0 B)), (points: (count 1, key-bytes 3, value-bytes 3, tombstoned: 0))
+
+mutate batch=foo
+set h@2 h@2
+----
+
+iter iter=fooiter
+set-options
+inspect lastPositioningOp
+seek-prefix-ge c@10
+stats
+----
+.
+lastPositioningOp="seekprefixge"
+c@3: (c@3, .)
+stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 120 B, cached 0 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+
+mutate batch=foo
+set i@1 i@1
+----
+
+iter iter=fooiter
+set-options
+inspect lastPositioningOp
+seek-prefix-ge d@10
+stats
+----
+.
+lastPositioningOp="seekprefixge"
+d@9: (d@9, .)
+stats: (interface (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 120 B, cached 0 B)), (points: (count 3, key-bytes 9, value-bytes 9, tombstoned: 0))
+
+mutate batch=foo
+set j@6 j@6
+----
+
+iter iter=fooiter
+set-options
+inspect lastPositioningOp
+seek-prefix-ge e@10
+stats
+----
+.
+lastPositioningOp="seekprefixge"
+e@8: (e@8, .)
+stats: (interface (dir, seek, step): (fwd, 4, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 4, 0), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 120 B, cached 0 B)), (points: (count 4, key-bytes 12, value-bytes 12, tombstoned: 0))
+
+# Ensure that a case eligible for TrySeekUsingNext across a SetOptions correctly
+# sees new batch mutations. The batch iterator should ignore the
+# TrySeekUsingNext designation.
+
+reset
+----
+
+batch commit
+set b@3 b@3
+set c@3 c@3
+----
+committed 2 keys
+
+batch name=b1
+----
+wrote 0 keys to batch "b1"
+
+combined-iter name=i1 reader=b1
+seek-prefix-ge b@6
+----
+b@3: (b@3, .)
+
+mutate batch=b1
+set b@4 b@4
+----
+
+iter iter=i1
+set-options
+inspect lastPositioningOp
+seek-prefix-ge b@5
+----
+.
+lastPositioningOp="seekprefixge"
+b@4: (b@4, .)
+
+# Similar case with SeekGE.
+
+iter iter=i1
+seek-ge b@2
+----
+c@3: (c@3, .)
+
+mutate batch=b1
+set c@9 c@9
+----
+
+iter iter=i1
+set-options
+inspect lastPositioningOp
+seek-ge b@1
+----
+.
+lastPositioningOp="seekge"
+c@9: (c@9, .)
+
+# Test a case similar to the above, but with an intermediate switch to
+# range-key-only iteration, so that the batchIter is not re-seeked.
+
+reset
+----
+
+batch commit
+set b@5 b@5
+set c@3 c@3
+----
+committed 2 keys
+
+batch name=b1
+----
+wrote 0 keys to batch "b1"
+
+combined-iter name=i1 reader=b1
+seek-ge b@9
+----
+b@5: (b@5, .)
+
+mutate batch=b1
+set b@6 b@6
+----
+
+iter iter=i1
+set-options key-types=range
+seek-ge b@8
+set-options key-types=both
+inspect lastPositioningOp
+seek-ge b@7
+----
+.
+.
+.
+lastPositioningOp="unknown"
+b@6: (b@6, .)


### PR DESCRIPTION
The change to batch mutation visibility began invalidating the iterator in SetOptions if the iterator was configured to read through an indexed batch that had been modified. This prevented the TrySeekUsingNext optimization from triggering when the pebbleBatch's iterator was reused after a mutation.

This commit restores this optimization, and allows the batch iterator to perform TrySeekUsingNext optimizations when the batch view has not been just refreshed.

Relative to HEAD:
```
name                                                  old time/op    new time/op    delta
MVCCBatchPut_Pebble/valueSize=10/batchSize=1-24         7.52µs ± 4%    7.57µs ± 3%      ~     (p=0.690 n=5+5)
MVCCBatchPut_Pebble/valueSize=10/batchSize=100-24       3.81µs ± 9%    1.39µs ± 2%   -63.52%  (p=0.008 n=5+5)
MVCCBatchPut_Pebble/valueSize=10/batchSize=10000-24     2.83µs ± 6%    1.30µs ± 1%   -54.06%  (p=0.008 n=5+5)
MVCCBatchPut_Pebble/valueSize=10/batchSize=100000-24    2.01µs ± 2%    1.39µs ± 0%   -30.79%  (p=0.008 n=5+5)

name                                                  old speed      new speed      delta
MVCCBatchPut_Pebble/valueSize=10/batchSize=1-24       1.33MB/s ± 4%  1.32MB/s ± 3%      ~     (p=0.587 n=5+5)
MVCCBatchPut_Pebble/valueSize=10/batchSize=100-24     2.63MB/s ±10%  7.19MB/s ± 2%  +173.38%  (p=0.008 n=5+5)
MVCCBatchPut_Pebble/valueSize=10/batchSize=10000-24   3.54MB/s ± 6%  7.69MB/s ± 1%  +117.36%  (p=0.008 n=5+5)
MVCCBatchPut_Pebble/valueSize=10/batchSize=100000-24  4.97MB/s ± 2%  7.17MB/s ± 0%   +44.40%  (p=0.008 n=5+5)
```

Relative to 22.1:
```
name                                                  old time/op    new time/op    delta
MVCCBatchPut_Pebble/valueSize=10/batchSize=1-24         8.31µs ± 3%    7.57µs ± 3%  -8.93%  (p=0.008 n=5+5)
MVCCBatchPut_Pebble/valueSize=10/batchSize=100-24       1.42µs ± 1%    1.39µs ± 2%  -2.14%  (p=0.040 n=5+5)
MVCCBatchPut_Pebble/valueSize=10/batchSize=10000-24     1.35µs ± 1%    1.30µs ± 1%  -3.67%  (p=0.008 n=5+5)
MVCCBatchPut_Pebble/valueSize=10/batchSize=100000-24    1.46µs ± 1%    1.39µs ± 0%  -4.44%  (p=0.008 n=5+5)

name                                                  old speed      new speed      delta
MVCCBatchPut_Pebble/valueSize=10/batchSize=1-24       1.20MB/s ± 4%  1.32MB/s ± 3%  +9.63%  (p=0.008 n=5+5)
MVCCBatchPut_Pebble/valueSize=10/batchSize=100-24     7.04MB/s ± 1%  7.19MB/s ± 2%  +2.19%  (p=0.032 n=5+5)
MVCCBatchPut_Pebble/valueSize=10/batchSize=10000-24   7.41MB/s ± 1%  7.69MB/s ± 1%  +3.78%  (p=0.008 n=5+5)
MVCCBatchPut_Pebble/valueSize=10/batchSize=100000-24  6.86MB/s ± 1%  7.17MB/s ± 0%  +4.64%  (p=0.008 n=5+5)
```

Informs cockroachdb/cockroach#88723.
Informs cockroachdb/cockroach#88819.
Close #1946.