### PR TITLE
crl-release-22.2: db: fix SeekPrefixGE TrySeekUsingNext optimization with batch

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -1216,7 +1216,6 @@ func (i *Iterator) SeekPrefixGE(key []byte) bool {
 	// the SeekPrefixGE following this should not make any assumption about
 	// iterator position.
 	i.lastPositioningOp = unknownLastPositionOp
-	i.batchJustRefreshed = false
 	i.requiresReposition = false
 	i.err = nil // clear cached iteration error
 	i.stats.ForwardSeekCount[InterfaceCall]++
@@ -1229,6 +1228,10 @@ func (i *Iterator) SeekPrefixGE(key []byte) bool {
 	prefixLen := i.split(key)
 	keyPrefix := key[:prefixLen]
 	var flags base.SeekGEFlags
+	if i.batchJustRefreshed {
+		flags = flags.EnableBatchJustRefreshed()
+		i.batchJustRefreshed = false
+	}
 	if lastPositioningOp == seekPrefixGELastPositioningOp {
 		if !i.hasPrefix {
 			panic("lastPositioningOpsIsSeekPrefixGE is true, but hasPrefix is false")

--- a/testdata/iter_histories/iter_optimizations
+++ b/testdata/iter_histories/iter_optimizations
@@ -342,3 +342,34 @@ seek-ge b@7
 .
 lastPositioningOp="unknown"
 b@6: (b@6, .)
+
+reset
+----
+
+batch commit
+set b@2 b@2
+set c@3 c@3
+----
+committed 2 keys
+
+batch name=b1
+----
+wrote 0 keys to batch "b1"
+
+combined-iter name=i1 reader=b1
+seek-prefix-ge b@1
+----
+.
+
+mutate batch=b1
+set c@4 c@4
+----
+
+iter iter=i1
+set-options
+inspect lastPositioningOp
+seek-prefix-ge c@8
+----
+.
+lastPositioningOp="seekprefixge"
+c@4: (c@4, .)


### PR DESCRIPTION
In #1987 the existing TrySeekUsingNext optimization was expanded to apply to batch iterators as well. The logic to omit this optimization when the batch was just refreshed was accidentally omitted from SeekPrefixGE.