### PR TITLE
db: return error from Close if open snapshots remain

### DIFF
--- a/db.go
+++ b/db.go
@@ -1321,6 +1321,12 @@ func (d *DB) Close() error {
 	if d.opts.private.fsCloser != nil {
 		d.opts.private.fsCloser.Close()
 	}
+
+	// Return an error if the user failed to close all open snapshots.
+	if v := d.mu.snapshots.count(); v > 0 {
+		err = firstError(err, errors.Errorf("leaked snapshots: %d open snapshots on DB %p", v, d))
+	}
+
 	return err
 }
 

--- a/db_test.go
+++ b/db_test.go
@@ -661,6 +661,7 @@ func TestUnremovableSingleDelete(t *testing.T) {
 
 	require.NoError(t, d.Set(key, valFirst, nil))
 	ss := d.NewSnapshot()
+	defer ss.Close()
 	require.NoError(t, d.SingleDelete(key, nil))
 	require.NoError(t, d.Set(key, valSecond, nil))
 	require.NoError(t, d.Flush())

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -27,6 +27,7 @@ func TestRangeDel(t *testing.T) {
 	var d *DB
 	defer func() {
 		if d != nil {
+			require.NoError(t, closeAllSnapshots(d))
 			require.NoError(t, d.Close())
 		}
 	}()
@@ -37,6 +38,9 @@ func TestRangeDel(t *testing.T) {
 		switch td.Cmd {
 		case "define":
 			if d != nil {
+				if err := closeAllSnapshots(d); err != nil {
+					return err.Error()
+				}
 				if err := d.Close(); err != nil {
 					return err.Error()
 				}

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -40,6 +40,7 @@ func TestTableStats(t *testing.T) {
 	require.NoError(t, err)
 	defer func() {
 		if d != nil {
+			require.NoError(t, closeAllSnapshots(d))
 			require.NoError(t, d.Close())
 		}
 	}()
@@ -60,6 +61,7 @@ func TestTableStats(t *testing.T) {
 			return ""
 
 		case "define":
+			require.NoError(t, closeAllSnapshots(d))
 			require.NoError(t, d.Close())
 			loadedInfo = nil
 


### PR DESCRIPTION
Return an error from DB.Close if the database has open snapshots. This helps ensure clients don't accidentally leak snapshots, which during normal operation prevents dropping any keys older than the snapshot.

Fix #1986.
