### PR TITLE
internal/lint: remove support for Go 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/cockroachdb/redact v1.0.8
 	github.com/ghemawat/stream v0.0.0-20171120220530-696b145b53b9
 	github.com/golang/snappy v0.0.3
-	github.com/hashicorp/go-version v1.6.0
 	github.com/klauspost/compress v1.11.7
 	github.com/kr/pretty v0.1.0
 	github.com/pmezard/go-difflib v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,6 @@ github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
-github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:qEIFzExnS6016fRpRfxrExeVn2gbClQA99gQhnIcdhE=

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/ghemawat/stream"
-	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/require"
 )
 
@@ -67,12 +66,6 @@ func TestLint(t *testing.T) {
 	}
 
 	t.Run("TestGolint", func(t *testing.T) {
-		// Go versions less than 1.17 do not support the `go run path@version`
-		// syntax.
-		// TODO(travers): This can be removed when support for go1.16 is dropped.
-		if goVersionMatches("< 1.17") {
-			t.Skip("go run path@version unsupported in versions < go1.17")
-		}
 		t.Parallel()
 
 		args := []string{"run", golint}
@@ -92,12 +85,6 @@ func TestLint(t *testing.T) {
 	})
 
 	t.Run("TestStaticcheck", func(t *testing.T) {
-		// Go versions less than 1.17 do not support the `go run path@version`
-		// syntax.
-		// TODO(travers): This can be removed when support for go1.16 is dropped.
-		if goVersionMatches("< 1.17") {
-			t.Skip("go run path@version unsupported in versions < go1.17")
-		}
 		t.Parallel()
 
 		args := []string{"run", staticcheck}
@@ -233,12 +220,6 @@ func TestLint(t *testing.T) {
 	})
 
 	t.Run("TestCrlfmt", func(t *testing.T) {
-		// Go versions less than 1.17 do not support the `go run path@version`
-		// syntax.
-		// TODO(travers): This can be removed when support for go1.16 is dropped.
-		if goVersionMatches("< 1.17") {
-			t.Skip("go run path@version unsupported in versions < go1.17")
-		}
 		t.Parallel()
 
 		args := []string{"run", crlfmt, "-fast", "-tab", "2", "."}
@@ -297,17 +278,4 @@ func lintIgnore(ignore string) stream.FilterFunc {
 		}
 		return nil
 	}
-}
-
-// goVersionMatches returns true if the Go runtime versions matches the given
-// semver constraint. If the runtime version does not contain a semver string
-// (i.e. it is a SHA), this function returns false.
-func goVersionMatches(constraint string) bool {
-	runtimeVersion := strings.TrimPrefix(runtime.Version(), "go")
-	goV, err := version.NewSemver(runtimeVersion)
-	if err != nil {
-		return false // Fail open.
-	}
-	c := version.MustConstraints(version.NewConstraint(constraint))
-	return c.Check(goV)
 }


### PR DESCRIPTION
We no longer run 1.16 in CI.