### PR TITLE
tool: capture stdout / stderr

### DIFF
--- a/tool/data_test.go
+++ b/tool/data_test.go
@@ -69,15 +69,10 @@ func runTests(t *testing.T, path string) {
 				}
 
 				var buf bytes.Buffer
-				stdout = &buf
-				stderr = &buf
-
 				var secs int64
 				timeNow = func() time.Time { secs++; return time.Unix(secs, 0) }
 
 				defer func() {
-					stdout = os.Stdout
-					stderr = os.Stderr
 					timeNow = time.Now
 				}()
 
@@ -121,7 +116,8 @@ func runTests(t *testing.T, path string) {
 				c := &cobra.Command{}
 				c.AddCommand(tool.Commands...)
 				c.SetArgs(args)
-				c.SetOutput(&buf)
+				c.SetOut(&buf)
+				c.SetErr(&buf)
 				if err := c.Execute(); err != nil {
 					return err.Error()
 				}

--- a/tool/db.go
+++ b/tool/db.go
@@ -277,19 +277,20 @@ func (d *dbT) openDB(dir string, openOptions ...openOption) (*pebble.DB, error) 
 	return pebble.Open(dir, &opts)
 }
 
-func (d *dbT) closeDB(db *pebble.DB) {
+func (d *dbT) closeDB(stdout io.Writer, db *pebble.DB) {
 	if err := db.Close(); err != nil {
 		fmt.Fprintf(stdout, "%s\n", err)
 	}
 }
 
 func (d *dbT) runCheck(cmd *cobra.Command, args []string) {
+	stdout := cmd.OutOrStdout()
 	db, err := d.openDB(args[0])
 	if err != nil {
 		fmt.Fprintf(stdout, "%s\n", err)
 		return
 	}
-	defer d.closeDB(db)
+	defer d.closeDB(stdout, db)
 
 	var stats pebble.CheckLevelsStats
 	if err := db.CheckLevels(&stats); err != nil {
@@ -309,12 +310,13 @@ func (n nonReadOnly) apply(opts *pebble.Options) {
 }
 
 func (d *dbT) runCheckpoint(cmd *cobra.Command, args []string) {
+	stdout := cmd.OutOrStdout()
 	db, err := d.openDB(args[0], nonReadOnly{})
 	if err != nil {
 		fmt.Fprintf(stdout, "%s\n", err)
 		return
 	}
-	defer d.closeDB(db)
+	defer d.closeDB(stdout, db)
 	destDir := args[1]
 
 	if err := db.Checkpoint(destDir); err != nil {
@@ -323,12 +325,13 @@ func (d *dbT) runCheckpoint(cmd *cobra.Command, args []string) {
 }
 
 func (d *dbT) runGet(cmd *cobra.Command, args []string) {
+	stdout := cmd.OutOrStdout()
 	db, err := d.openDB(args[0])
 	if err != nil {
 		fmt.Fprintf(stdout, "%s\n", err)
 		return
 	}
-	defer d.closeDB(db)
+	defer d.closeDB(stdout, db)
 	var k key
 	if err := k.Set(args[1]); err != nil {
 		fmt.Fprintf(stdout, "%s\n", err)
@@ -351,23 +354,25 @@ func (d *dbT) runGet(cmd *cobra.Command, args []string) {
 }
 
 func (d *dbT) runLSM(cmd *cobra.Command, args []string) {
+	stdout := cmd.OutOrStdout()
 	db, err := d.openDB(args[0])
 	if err != nil {
 		fmt.Fprintf(stdout, "%s\n", err)
 		return
 	}
-	defer d.closeDB(db)
+	defer d.closeDB(stdout, db)
 
 	fmt.Fprintf(stdout, "%s", db.Metrics())
 }
 
 func (d *dbT) runScan(cmd *cobra.Command, args []string) {
+	stdout := cmd.OutOrStdout()
 	db, err := d.openDB(args[0])
 	if err != nil {
 		fmt.Fprintf(stdout, "%s\n", err)
 		return
 	}
-	defer d.closeDB(db)
+	defer d.closeDB(stdout, db)
 
 	// Update the internal formatter if this comparator has one specified.
 	if d.opts.Comparer != nil {
@@ -416,12 +421,13 @@ func (d *dbT) runScan(cmd *cobra.Command, args []string) {
 }
 
 func (d *dbT) runSpace(cmd *cobra.Command, args []string) {
+	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
 	db, err := d.openDB(args[0])
 	if err != nil {
 		fmt.Fprintf(stderr, "%s\n", err)
 		return
 	}
-	defer d.closeDB(db)
+	defer d.closeDB(stdout, db)
 
 	bytes, err := db.EstimateDiskUsage(d.start, d.end)
 	if err != nil {
@@ -432,6 +438,7 @@ func (d *dbT) runSpace(cmd *cobra.Command, args []string) {
 }
 
 func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
+	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
 	dirname := args[0]
 	err := func() error {
 		desc, err := pebble.Peek(dirname, d.opts.FS)
@@ -556,12 +563,13 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 }
 
 func (d *dbT) runSet(cmd *cobra.Command, args []string) {
+	stdout := cmd.OutOrStdout()
 	db, err := d.openDB(args[0], nonReadOnly{})
 	if err != nil {
 		fmt.Fprintf(stdout, "%s\n", err)
 		return
 	}
-	defer d.closeDB(db)
+	defer d.closeDB(stdout, db)
 	var k, v key
 	if err := k.Set(args[1]); err != nil {
 		fmt.Fprintf(stdout, "%s\n", err)

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -7,6 +7,7 @@ package tool
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -151,7 +152,8 @@ func (s *sstableT) newReader(f vfs.File) (*sstable.Reader, error) {
 }
 
 func (s *sstableT) runCheck(cmd *cobra.Command, args []string) {
-	s.foreachSstable(args, func(arg string) {
+	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
+	s.foreachSstable(stderr, args, func(arg string) {
 		f, err := s.opts.FS.Open(arg)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s\n", err)
@@ -227,7 +229,8 @@ func (s *sstableT) runCheck(cmd *cobra.Command, args []string) {
 }
 
 func (s *sstableT) runLayout(cmd *cobra.Command, args []string) {
-	s.foreachSstable(args, func(arg string) {
+	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
+	s.foreachSstable(stderr, args, func(arg string) {
 		f, err := s.opts.FS.Open(arg)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s\n", err)
@@ -263,7 +266,8 @@ func (s *sstableT) runLayout(cmd *cobra.Command, args []string) {
 }
 
 func (s *sstableT) runProperties(cmd *cobra.Command, args []string) {
-	s.foreachSstable(args, func(arg string) {
+	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
+	s.foreachSstable(stderr, args, func(arg string) {
 		f, err := s.opts.FS.Open(arg)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s\n", err)
@@ -355,7 +359,8 @@ func (s *sstableT) runProperties(cmd *cobra.Command, args []string) {
 }
 
 func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
-	s.foreachSstable(args, func(arg string) {
+	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
+	s.foreachSstable(stderr, args, func(arg string) {
 		f, err := s.opts.FS.Open(arg)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s\n", err)
@@ -512,7 +517,8 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 }
 
 func (s *sstableT) runSpace(cmd *cobra.Command, args []string) {
-	s.foreachSstable(args, func(arg string) {
+	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
+	s.foreachSstable(stderr, args, func(arg string) {
 		f, err := s.opts.FS.Open(arg)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s\n", err)
@@ -534,7 +540,7 @@ func (s *sstableT) runSpace(cmd *cobra.Command, args []string) {
 	})
 }
 
-func (s *sstableT) foreachSstable(args []string, fn func(arg string)) {
+func (s *sstableT) foreachSstable(stderr io.Writer, args []string, fn func(arg string)) {
 	// Loop over args, invoking fn for each file. Each directory is recursively
 	// listed and fn is invoked on any file with an .sst or .ldb suffix.
 	for _, arg := range args {
@@ -543,7 +549,7 @@ func (s *sstableT) foreachSstable(args []string, fn func(arg string)) {
 			fn(arg)
 			continue
 		}
-		walk(s.opts.FS, arg, func(path string) {
+		walk(stderr, s.opts.FS, arg, func(path string) {
 			switch filepath.Ext(path) {
 			case ".sst", ".ldb":
 				fn(path)

--- a/tool/util.go
+++ b/tool/util.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -20,8 +19,6 @@ import (
 	"github.com/cockroachdb/pebble/vfs"
 )
 
-var stdout = io.Writer(os.Stdout)
-var stderr = io.Writer(os.Stderr)
 var timeNow = time.Now
 
 type key []byte
@@ -305,7 +302,7 @@ func formatSpan(w io.Writer, fmtKey keyFormatter, fmtValue valueFormatter, s *ke
 	}
 }
 
-func walk(fs vfs.FS, dir string, fn func(path string)) {
+func walk(stderr io.Writer, fs vfs.FS, dir string, fn func(path string)) {
 	paths, err := fs.List(dir)
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", dir, err)
@@ -320,7 +317,7 @@ func walk(fs vfs.FS, dir string, fn func(path string)) {
 			continue
 		}
 		if info.IsDir() {
-			walk(fs, path, fn)
+			walk(stderr, fs, path, fn)
 		} else {
 			fn(path)
 		}

--- a/tool/wal.go
+++ b/tool/wal.go
@@ -65,6 +65,7 @@ Print the contents of the WAL files.
 }
 
 func (w *walT) runDump(cmd *cobra.Command, args []string) {
+	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
 	w.fmtKey.setForComparer(w.defaultComparer, w.comparers)
 	w.fmtValue.setForComparer(w.defaultComparer, w.comparers)
 


### PR DESCRIPTION
Currently, the tools write directly to `os.{Stdout,Stderr}`, which complicates testing in the case where the command is run from same process running the tests (i.e. from a `testing.T` func).

Adapt the tools to make use of the return values from `(*cobra.Command).{OutOrStdout,OutOrStderr}`. In testing scenarios, the tools can use `SetOut` and `SetErr` to pass in a writer that can intercept anything written to stdout / stderr. In productions scenarios, the tools will emit to the appropriate channel.

Touches cockroachdb/cockroach#89095.