### PR TITLE
metrics: remove deprecated InternalIntervalMetrics method

### DIFF
--- a/commit_test.go
+++ b/commit_test.go
@@ -184,7 +184,7 @@ func TestCommitPipelineWALClose(t *testing.T) {
 	}
 
 	// A basic commitEnv which writes to a WAL.
-	wal := record.NewLogWriter(sf, 0 /* logNum */)
+	wal := record.NewLogWriter(sf, 0 /* logNum */, record.LogWriterConfig{})
 	var walDone sync.WaitGroup
 	testEnv := commitEnv{
 		logSeqNum:     new(uint64),
@@ -235,7 +235,7 @@ func BenchmarkCommitPipeline(b *testing.B) {
 		b.Run(fmt.Sprintf("parallel=%d", parallelism), func(b *testing.B) {
 			b.SetParallelism(parallelism)
 			mem := newMemTable(memTableOptions{})
-			wal := record.NewLogWriter(io.Discard, 0 /* logNum */)
+			wal := record.NewLogWriter(io.Discard, 0 /* logNum */, record.LogWriterConfig{})
 
 			nullCommitEnv := commitEnv{
 				logSeqNum:     new(uint64),

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -3190,7 +3190,7 @@ func TestCompactFlushQueuedMemTableAndFlushMetrics(t *testing.T) {
 	func() {
 		begin := time.Now()
 		for {
-			metrics := d.InternalIntervalMetrics()
+			metrics := d.Metrics()
 			require.NotNil(t, metrics)
 			if int64(50<<10) < metrics.Flush.WriteThroughput.Bytes {
 				// The writes (during which the flush is idle) and the flush work

--- a/db.go
+++ b/db.go
@@ -1949,8 +1949,10 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 
 		if !d.opts.DisableWAL {
 			d.mu.log.queue = append(d.mu.log.queue, fileInfo{fileNum: newLogNum, fileSize: newLogSize})
-			d.mu.log.LogWriter = record.NewLogWriter(newLogFile, newLogNum)
-			d.mu.log.LogWriter.SetMinSyncInterval(d.opts.WALMinSyncInterval)
+			d.mu.log.LogWriter = record.NewLogWriter(newLogFile, newLogNum, record.LogWriterConfig{
+				LogWriterFsyncLatencyCallback: d.opts.OnMetrics.LogWriterFsyncLatency,
+				WALMinSyncIntervalCallback:    d.opts.WALMinSyncInterval,
+			})
 		}
 
 		immMem := d.mu.mem.mutable

--- a/metrics.go
+++ b/metrics.go
@@ -7,7 +7,6 @@ package pebble
 import (
 	"fmt"
 
-	"github.com/HdrHistogram/hdrhistogram-go"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/humanize"
@@ -432,42 +431,4 @@ func hitRate(hits, misses int64) float64 {
 		return 0
 	}
 	return 100 * float64(hits) / float64(sum)
-}
-
-// InternalIntervalMetrics exposes metrics about internal subsystems, that can
-// be useful for deep observability purposes, and for higher-level admission
-// control systems that are trying to estimate the capacity of the DB. These
-// are experimental and subject to change, since they expose internal
-// implementation details, so do not rely on these without discussion with the
-// Pebble team.
-// These represent the metrics over the interval of time from the last call to
-// retrieve these metrics. These are not cumulative, unlike Metrics. The main
-// challenge in making these cumulative is the hdrhistogram.Histogram, which
-// does not have the ability to subtract a histogram from a preceding metric
-// retrieval.
-type InternalIntervalMetrics struct {
-	// LogWriter metrics.
-	LogWriter struct {
-		// WriteThroughput is the WAL throughput.
-		WriteThroughput ThroughputMetric
-		// PendingBufferUtilization is the utilization of the WAL writer's
-		// finite-sized pending blocks buffer. It provides an additional signal
-		// regarding how close to "full" the WAL writer is. The value is in the
-		// interval [0,1].
-		PendingBufferUtilization float64
-		// SyncQueueUtilization is the utilization of the WAL writer's
-		// finite-sized queue of work that is waiting to sync. The value is in the
-		// interval [0,1].
-		SyncQueueUtilization float64
-		// SyncLatencyMicros is a distribution of the fsync latency observed by
-		// the WAL writer. It can be nil if there were no fsyncs.
-		SyncLatencyMicros *hdrhistogram.Histogram
-	}
-	// Flush loop metrics.
-	Flush struct {
-		// WriteThroughput is the flushing throughput.
-		WriteThroughput ThroughputMetric
-	}
-	// NB: the LogWriter throughput and the Flush throughput are not directly
-	// comparable because the former does not compress, unlike the latter.
 }

--- a/open.go
+++ b/open.go
@@ -418,8 +418,11 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 			BytesPerSync:    d.opts.WALBytesPerSync,
 			PreallocateSize: d.walPreallocateSize(),
 		})
-		d.mu.log.LogWriter = record.NewLogWriter(logFile, newLogNum)
-		d.mu.log.LogWriter.SetMinSyncInterval(d.opts.WALMinSyncInterval)
+		logWriterConfig := record.LogWriterConfig{
+			WALMinSyncIntervalCallback:    d.opts.WALMinSyncInterval,
+			LogWriterFsyncLatencyCallback: d.opts.OnMetrics.LogWriterFsyncLatency,
+		}
+		d.mu.log.LogWriter = record.NewLogWriter(logFile, newLogNum, logWriterConfig)
 		d.mu.versions.metrics.WAL.Files++
 	}
 	d.updateReadStateLocked(d.opts.DebugCheck)

--- a/options.go
+++ b/options.go
@@ -759,6 +759,8 @@ type Options struct {
 	// changing options dynamically?
 	WALMinSyncInterval func() time.Duration
 
+	OnMetrics MetricCallbacks
+
 	// private options are only used by internal tests or are used internally
 	// for facilitating upgrade paths of unconfigurable functionality.
 	private struct {
@@ -792,6 +794,12 @@ type Options struct {
 		// do not want to allow users to actually configure.
 		disableLazyCombinedIteration bool
 	}
+}
+
+// MetricCallbacks is a struct that contains the callbacks that pebble will call
+// in order to update clients.
+type MetricCallbacks struct {
+	LogWriterFsyncLatency func(duration int64)
 }
 
 // DebugCheckLevels calls CheckLevels on the provided database.

--- a/record/log_writer.go
+++ b/record/log_writer.go
@@ -13,11 +13,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/HdrHistogram/hdrhistogram-go"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/crc"
-	"github.com/cockroachdb/pebble/internal/invariants"
 )
 
 var walSyncLabels = pprof.Labels("pebble", "wal-sync")
@@ -229,6 +227,7 @@ func (c *flusherCond) Unlock() {
 }
 
 type durationFunc func() time.Duration
+type recordValueFunc func(value int64)
 
 // syncTimer is an interface for timers, modeled on the closure callback mode
 // of time.Timer. See time.AfterFunc and LogWriter.afterFunc. syncTimer is used
@@ -281,10 +280,11 @@ type LogWriter struct {
 		// Accumulated flush error.
 		err error
 		// minSyncInterval is the minimum duration between syncs.
-		minSyncInterval durationFunc
-		pending         []*block
-		syncQ           syncQueue
-		metrics         *LogWriterMetrics
+		minSyncInterval      durationFunc
+		onFsyncLatencyMetric recordValueFunc
+		pending              []*block
+		syncQ                syncQueue
+		metrics              *LogWriterMetrics
 	}
 
 	// afterFunc is a hook to allow tests to mock out the timer functionality
@@ -293,12 +293,18 @@ type LogWriter struct {
 	afterFunc func(d time.Duration, f func()) syncTimer
 }
 
+// LogWriterConfig is a struct used for configuring new LogWriters
+type LogWriterConfig struct {
+	WALMinSyncIntervalCallback    durationFunc
+	LogWriterFsyncLatencyCallback recordValueFunc
+}
+
 // CapAllocatedBlocks is the maximum number of blocks allocated by the
 // LogWriter.
 const CapAllocatedBlocks = 16
 
 // NewLogWriter returns a new LogWriter.
-func NewLogWriter(w io.Writer, logNum base.FileNum) *LogWriter {
+func NewLogWriter(w io.Writer, logNum base.FileNum, logWriterConfig LogWriterConfig) *LogWriter {
 	c, _ := w.(io.Closer)
 	s, _ := w.(syncer)
 	r := &LogWriter{
@@ -322,23 +328,15 @@ func NewLogWriter(w io.Writer, logNum base.FileNum) *LogWriter {
 	r.flusher.closed = make(chan struct{})
 	r.flusher.pending = make([]*block, 0, cap(r.free.blocks))
 	r.flusher.metrics = &LogWriterMetrics{}
-	// Histogram with max value of 30s. We are not trying to detect anomalies
-	// with this, and normally latencies range from 0.5ms to 25ms.
-	r.flusher.metrics.SyncLatencyMicros = hdrhistogram.New(
-		0, (time.Second * 30).Microseconds(), 2)
+
+	f := &r.flusher
+	f.minSyncInterval = logWriterConfig.WALMinSyncIntervalCallback
+	f.onFsyncLatencyMetric = logWriterConfig.LogWriterFsyncLatencyCallback
+
 	go func() {
 		pprof.Do(context.Background(), walSyncLabels, r.flushLoop)
 	}()
 	return r
-}
-
-// SetMinSyncInterval sets the closure to invoke for retrieving the minimum
-// sync duration between syncs.
-func (w *LogWriter) SetMinSyncInterval(minSyncInterval durationFunc) {
-	f := &w.flusher
-	f.Lock()
-	f.minSyncInterval = minSyncInterval
-	f.Unlock()
 }
 
 func (w *LogWriter) flushLoop(context.Context) {
@@ -453,8 +451,8 @@ func (w *LogWriter) flushLoop(context.Context) {
 		f.Unlock()
 		synced, syncLatency, bytesWritten, err := w.flushPending(data, pending, head, tail)
 		f.Lock()
-		if synced {
-			f.metrics.SyncLatencyMicros.RecordValue(syncLatency.Microseconds())
+		if synced && f.onFsyncLatencyMetric != nil {
+			f.onFsyncLatencyMetric(syncLatency.Microseconds())
 		}
 		f.err = err
 		if f.err != nil {
@@ -608,7 +606,9 @@ func (w *LogWriter) Close() error {
 		syncLatency, err = w.syncWithLatency()
 	}
 	f.Lock()
-	f.metrics.SyncLatencyMicros.RecordValue(syncLatency.Microseconds())
+	if f.onFsyncLatencyMetric != nil {
+		f.onFsyncLatencyMetric(syncLatency.Microseconds())
+	}
 	f.Unlock()
 
 	if w.c != nil {
@@ -731,10 +731,9 @@ func (w *LogWriter) Metrics() *LogWriterMetrics {
 
 // LogWriterMetrics contains misc metrics for the log writer.
 type LogWriterMetrics struct {
-	WriteThroughput   base.ThroughputMetric
-	PendingBufferLen  base.GaugeSampleMetric
-	SyncQueueLen      base.GaugeSampleMetric
-	SyncLatencyMicros *hdrhistogram.Histogram
+	WriteThroughput  base.ThroughputMetric
+	PendingBufferLen base.GaugeSampleMetric
+	SyncQueueLen     base.GaugeSampleMetric
 }
 
 // Merge merges metrics from x. Requires that x is non-nil.
@@ -742,41 +741,5 @@ func (m *LogWriterMetrics) Merge(x *LogWriterMetrics) error {
 	m.WriteThroughput.Merge(x.WriteThroughput)
 	m.PendingBufferLen.Merge(x.PendingBufferLen)
 	m.SyncQueueLen.Merge(x.SyncQueueLen)
-	if x.SyncLatencyMicros == nil {
-		return nil
-	} else if m.SyncLatencyMicros == nil {
-		m.SyncLatencyMicros = hdrhistogram.Import(x.SyncLatencyMicros.Export())
-	} else {
-		dropped := m.SyncLatencyMicros.Merge(x.SyncLatencyMicros)
-		if dropped > 0 {
-			// This should never happen since we use a consistent min, max when
-			// creating these histograms, and out-of-range is the only reason for the
-			// merge to drop samples.
-			return errors.Errorf("sync latency histogram merge dropped %d samples", dropped)
-		}
-	}
 	return nil
-}
-
-// Subtract merges metrics from x. Requires that x is non-nil.
-func (m *LogWriterMetrics) Subtract(x *LogWriterMetrics) {
-	m.WriteThroughput.Subtract(x.WriteThroughput)
-	m.PendingBufferLen.Subtract(x.PendingBufferLen)
-	m.SyncQueueLen.Subtract(x.SyncQueueLen)
-	if x.SyncLatencyMicros != nil {
-		m.SyncLatencyMicros = subtract(m.SyncLatencyMicros, x.SyncLatencyMicros)
-	}
-}
-
-// subtract returns a hdrhistogram.Histogram produce from subtracting two histograms
-func subtract(h *hdrhistogram.Histogram, g *hdrhistogram.Histogram) *hdrhistogram.Histogram {
-	snapg, snaph := g.Export(), h.Export()
-	for i := range snapg.Counts {
-		difference := snaph.Counts[i] - snapg.Counts[i]
-		if invariants.Enabled && difference < 0 {
-			panic("histogram subtraction lead to unexpected negative counts in buckets")
-		}
-		snaph.Counts[i] = difference
-	}
-	return hdrhistogram.Import(snaph)
 }

--- a/record/log_writer_test.go
+++ b/record/log_writer_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/HdrHistogram/hdrhistogram-go"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
@@ -138,7 +137,7 @@ func TestSyncError(t *testing.T) {
 	require.NoError(t, err)
 
 	injectedErr := errors.New("injected error")
-	w := NewLogWriter(syncErrorFile{f, injectedErr}, 0)
+	w := NewLogWriter(syncErrorFile{f, injectedErr}, 0, LogWriterConfig{})
 
 	syncRecord := func() {
 		var syncErr error
@@ -176,7 +175,7 @@ func (f *syncFile) Sync() error {
 
 func TestSyncRecord(t *testing.T) {
 	f := &syncFile{}
-	w := NewLogWriter(f, 0)
+	w := NewLogWriter(f, 0, LogWriterConfig{})
 
 	var syncErr error
 	for i := 0; i < 100000; i++ {
@@ -222,9 +221,11 @@ func TestMinSyncInterval(t *testing.T) {
 	const minSyncInterval = 100 * time.Millisecond
 
 	f := &syncFile{}
-	w := NewLogWriter(f, 0)
-	w.SetMinSyncInterval(func() time.Duration {
-		return minSyncInterval
+	w := NewLogWriter(f, 0, LogWriterConfig{
+		WALMinSyncIntervalCallback: func() time.Duration {
+			return minSyncInterval
+		},
+		LogWriterFsyncLatencyCallback: nil,
 	})
 
 	var timer fakeTimer
@@ -291,9 +292,11 @@ func TestMinSyncIntervalClose(t *testing.T) {
 	const minSyncInterval = 100 * time.Millisecond
 
 	f := &syncFile{}
-	w := NewLogWriter(f, 0)
-	w.SetMinSyncInterval(func() time.Duration {
-		return minSyncInterval
+	w := NewLogWriter(f, 0, LogWriterConfig{
+		WALMinSyncIntervalCallback: func() time.Duration {
+			return minSyncInterval
+		},
+		LogWriterFsyncLatencyCallback: nil,
 	})
 
 	var timer fakeTimer
@@ -343,7 +346,7 @@ func (f *syncFileWithWait) Sync() error {
 func TestMetricsWithoutSync(t *testing.T) {
 	f := &syncFileWithWait{}
 	f.writeWG.Add(1)
-	w := NewLogWriter(f, 0)
+	w := NewLogWriter(f, 0, LogWriterConfig{})
 	offset, err := w.SyncRecord([]byte("hello"), nil, nil)
 	require.NoError(t, err)
 	const recordSize = 16
@@ -372,7 +375,16 @@ func TestMetricsWithoutSync(t *testing.T) {
 func TestMetricsWithSync(t *testing.T) {
 	f := &syncFileWithWait{}
 	f.syncWG.Add(1)
-	w := NewLogWriter(f, 0)
+	syncLatencyMicros := hdrhistogram.New(0, (time.Second * 30).Microseconds(), 2)
+	w := NewLogWriter(f, 0, LogWriterConfig{
+		WALMinSyncIntervalCallback: nil,
+		LogWriterFsyncLatencyCallback: func(duration int64) {
+			err := syncLatencyMicros.RecordValue(duration)
+			if err != nil {
+				t.Fatal("Ran into error when recording values to histogram")
+			}
+		},
+	})
 	var wg sync.WaitGroup
 	wg.Add(100)
 	for i := 0; i < 100; i++ {
@@ -392,90 +404,6 @@ func TestMetricsWithSync(t *testing.T) {
 	// Allow for some inaccuracy in sleep and for two syncs, one of which was
 	// fast.
 	require.LessOrEqual(t, int64(syncLatency/(2*time.Microsecond)),
-		m.SyncLatencyMicros.ValueAtQuantile(90))
+		syncLatencyMicros.ValueAtQuantile(90))
 	require.LessOrEqual(t, int64(syncLatency/2), int64(m.WriteThroughput.WorkDuration))
-}
-
-func TestLogWriterMetricsMergeWithNilSyncLatency(t *testing.T) {
-	lm1 := LogWriterMetrics{}
-	lm2 := LogWriterMetrics{
-		SyncLatencyMicros: hdrhistogram.New(1, 1, 1),
-	}
-	err := lm1.Merge(&lm2)
-	if err != nil {
-		require.Errorf(t, err, "Unexpected error when merging two LogWriterMetrics")
-	}
-	require.Equal(t, lm2.SyncLatencyMicros, lm1.SyncLatencyMicros)
-}
-
-const significantValueDigits = 3
-const lowestDiscernibleValue = 1
-const highestTrackableValue = 1000
-
-func TestSubtractToZeroCounts(t *testing.T) {
-	h1 := hdrhistogram.New(lowestDiscernibleValue, highestTrackableValue, significantValueDigits)
-	for i := 0; i < 100; i++ {
-		handleRecordValue(t, h1, i)
-	}
-
-	h1 = subtract(h1, h1)
-
-	if v, want := h1.ValueAtQuantile(50), int64(0); v != want {
-		t.Errorf("Median was %v, but expected %v", v, want)
-	}
-}
-
-func TestSubtractAfterAdd(t *testing.T) {
-	h1 := hdrhistogram.New(lowestDiscernibleValue, 5, significantValueDigits)
-	handleRecordValues(t, h1, 1, 1)
-	handleRecordValues(t, h1, 2, 2)
-	handleRecordValues(t, h1, 3, 3)
-	handleRecordValues(t, h1, 4, 2)
-	handleRecordValues(t, h1, 5, 1)
-
-	h2 := hdrhistogram.New(lowestDiscernibleValue, 10, significantValueDigits)
-	handleRecordValues(t, h2, 5, 1)
-	handleRecordValues(t, h2, 6, 2)
-	handleRecordValues(t, h2, 7, 3)
-	handleRecordValues(t, h2, 8, 10)
-	handleRecordValues(t, h2, 9, 1)
-
-	h1Original := hdrhistogram.Import(h1.Export())
-	h1.Merge(h2)
-
-	if v, want := h1.ValueAtQuantile(50), int64(7); v != want {
-		t.Errorf("Median was %v, but expected %v", v, want)
-	}
-
-	h3 := subtract(h1, h2)
-	if !h1Original.Equals(h3) {
-		t.Errorf("Expected Histograms to be equal")
-	}
-}
-
-func TestLogWriterSubtractInvalidHistograms(t *testing.T) {
-	lwm := LogWriterMetrics{
-		WriteThroughput: base.ThroughputMetric{
-			Bytes:        0,
-			WorkDuration: 0,
-			IdleDuration: 0,
-		},
-		PendingBufferLen:  base.GaugeSampleMetric{},
-		SyncQueueLen:      base.GaugeSampleMetric{},
-		SyncLatencyMicros: nil,
-	}
-	lwm.Subtract(&lwm)
-	require.Nil(t, lwm.SyncLatencyMicros)
-
-}
-
-func handleRecordValues(t *testing.T, h *hdrhistogram.Histogram, valueToRecord int, n int) {
-	err := h.RecordValues(int64(valueToRecord), int64(n))
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func handleRecordValue(t *testing.T, h *hdrhistogram.Histogram, valueToRecord int) {
-	handleRecordValues(t, h, valueToRecord, 1)
 }


### PR DESCRIPTION
The fsync latency was computed using an HDR histogram however this
histogram generates too many buckets of various widths.  In order to
allow clients to store the fsync latency in their preferred format,  a
callback was introduced. This callback is defined on the
`pebble.Options` which enables clients to provide a callback function
which will be triggered each time pebble produces the fsync latency
metrics.

Additionally the `record.NewLogWriter` method was updated to take in a
configuration struct which configures the `LogWriter` with the specified
callbacks.