### PR TITLE
tool: add --filter-{start,end} flags

### DIFF
--- a/tool/testdata/manifest_dump
+++ b/tool/testdata/manifest_dump
@@ -33,6 +33,57 @@ EOF
 --- L5 ---
 --- L6 ---
 
+manifest dump --filter-start=zoo
+../testdata/db-stage-4/MANIFEST-000005
+----
+MANIFEST-000005
+0/0
+  comparer:     leveldb.BytewiseComparator
+EOF
+--- L0.0 ---
+--- L1 ---
+--- L2 ---
+--- L3 ---
+--- L4 ---
+--- L5 ---
+--- L6 ---
+
+manifest dump --filter-end=a
+../testdata/db-stage-4/MANIFEST-000005
+----
+MANIFEST-000005
+0/0
+  comparer:     leveldb.BytewiseComparator
+EOF
+--- L0.0 ---
+--- L1 ---
+--- L2 ---
+--- L3 ---
+--- L4 ---
+--- L5 ---
+--- L6 ---
+
+manifest dump --filter-start=a --filter-end=d
+../testdata/db-stage-4/MANIFEST-000005
+----
+MANIFEST-000005
+0/0
+  comparer:     leveldb.BytewiseComparator
+44/1
+  log-num:       4
+  next-file-num: 6
+  last-seq-num:  5
+  added:         L0 000004:986<#3-#5>[bar#5,DEL-foo#4,SET]
+EOF
+--- L0.0 ---
+  000004:986<#3-#5>[bar#5,DEL-foo#4,SET]
+--- L1 ---
+--- L2 ---
+--- L3 ---
+--- L4 ---
+--- L5 ---
+--- L6 ---
+
 manifest dump
 ../testdata/db-stage-4/MANIFEST-000005
 --key=%x
@@ -235,6 +286,58 @@ MANIFEST-000001
   deleted:       L6 000008
   added:         L6 000011:898<#0-#10>[aaa#8,DEL-eee#72057594037927935,RANGEDEL] (2021-04-01T20:24:02Z)
 408/9
+  next-file-num: 12
+  last-seq-num:  10
+  deleted:       L6 000011
+EOF
+--- L0 ---
+--- L1 ---
+--- L2 ---
+--- L3 ---
+--- L4 ---
+--- L5 ---
+--- L6 ---
+
+manifest dump --filter-start=bat --filter-end=cat
+./testdata/find-db/MANIFEST-000001
+----
+MANIFEST-000001
+0/0
+  comparer:     alt-comparer
+  next-file-num: 2
+36/1
+  log-num:       4
+  next-file-num: 6
+  last-seq-num:  5
+  added:         L0 000005:784<#1-#5>[aaa#1,SET-ccc#5,MERGE] (2021-04-01T20:24:02Z)
+88/2
+  next-file-num: 6
+  last-seq-num:  5
+  deleted:       L0 000005
+  added:         L6 000005:784<#1-#5>[aaa#1,SET-ccc#5,MERGE] (2021-04-01T20:24:02Z)
+141/3
+  next-file-num: 7
+  last-seq-num:  6
+  added:         L0 000006:817<#6-#6>[bbb#6,SET-ccc#6,SET] (2021-04-01T20:24:02Z)
+241/4
+  next-file-num: 9
+  last-seq-num:  7
+  deleted:       L0 000006
+  deleted:       L6 000005
+  added:         L6 000008:791<#0-#6>[aaa#0,SET-ccc#0,MERGE] (2021-04-01T20:24:02Z)
+297/5
+  log-num:       9
+  next-file-num: 11
+  last-seq-num:  10
+  added:         L0 000010:834<#8-#10>[aaa#8,DEL-eee#72057594037927935,RANGEDEL] (2021-04-01T20:24:02Z)
+349/6
+  next-file-num: 12
+  last-seq-num:  10
+  deleted:       L0 000010
+  deleted:       L6 000007
+  deleted:       L6 000008
+  added:         L6 000011:898<#0-#10>[aaa#8,DEL-eee#72057594037927935,RANGEDEL] (2021-04-01T20:24:02Z)
+408/7
   next-file-num: 12
   last-seq-num:  10
   deleted:       L6 000011


### PR DESCRIPTION
Support accepting start and/or end bounds of a relevant keyspace in the manifest dump command. Dump skips any version edits that exclusively contain files that fall outside the provided key span.