### PR TITLE
scripts: add script for running the crossversion metamorphic tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 cpu.*.prof
 heap.prof
 mutex.prof
+# Testing artifacts
+meta.*.test

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ crossversion-meta:
 		${GO} test -c ./internal/metamorphic -o './internal/metamorphic/crossversion/head.test'; \
 		${GO} test -tags '$(TAGS)' ${testflags} -v -run 'TestMetaCrossVersion' ./internal/metamorphic/crossversion --version '${LATEST_RELEASE},${LATEST_RELEASE},${LATEST_RELEASE}.test' --version 'HEAD,HEAD,./head.test'
 
+.PHONY: stress-crossversion
+stress-crossversion:
+	STRESS=1 ./scripts/run-crossversion-meta.sh crl-release-21.2 crl-release-22.1 crl-release-22.2 master
+
 .PHONY: generate
 generate:
 	${GO} generate ${PKG}

--- a/scripts/run-crossversion-meta.sh
+++ b/scripts/run-crossversion-meta.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -ex
+
+VERSIONS=""
+for branch in "$@"
+do
+    git checkout "$branch"
+    sha=`git rev-parse --short HEAD`
+
+    # If the branch name has a "-<suffix>", pull off the suffix. With the
+    # crl-release-{XX.X} release branch naming scheme, this will extract the
+    # {XX.X}.
+    version=`cut -d- -f3 <<< "$branch"`
+
+    echo "Building $version ($sha)"
+    go test -c -o "meta.$version.test" ./internal/metamorphic
+    VERSIONS="$VERSIONS -version $version,$sha,$PWD/meta.$version.test"
+done
+
+# Always use master's crossversion package.
+git checkout master
+
+if [[ -z "${STRESS}" ]]; then
+    go test ./internal/metamorphic/crossversion -test.v -test.run 'TestMetaCrossVersion$' $(echo $VERSIONS)
+else
+    stress -p 1 go test ./internal/metamorphic/crossversion -test.v -test.timeout "${TIMEOUT:-30m}" -test.run 'TestMetaCrossVersion$' $(echo $VERSIONS)
+fi


### PR DESCRIPTION
Add a simple script that takes a series of branch names as arguments, and then runs the cross-version metamorphic tests across the branch's builds.

Informs cockroachdb/cockroach#82544.