### PR TITLE
metamorphic/crossversion: if verbose, print metamorphic output

### DIFF
--- a/internal/metamorphic/crossversion/crossversion_test.go
+++ b/internal/metamorphic/crossversion/crossversion_test.go
@@ -169,6 +169,9 @@ func runCrossVersion(
 			if err != nil {
 				fatalf(t, rootDir, "Metamorphic test failed: %s\nOutput:%s\n", err, buf.String())
 			}
+			if testing.Verbose() {
+				t.Log(buf.String())
+			}
 
 			// dir is a directory containing the ops file and subdirectories for
 			// each run with a particular set of OPTIONS. For example:


### PR DESCRIPTION
If `-test.v` is provided to go test, print the output of each metamorphic test run.

Informs cockroachdb/cockroach#82544.