### PR TITLE
db: add LazyValue for a value that may not be stored in-place with th…

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -762,7 +762,7 @@ func TestBatchIter(t *testing.T) {
 						}
 						iter := b.newInternalIter(&options)
 						defer iter.Close()
-						return runInternalIterCmd(d, iter)
+						return runInternalIterCmd(t, d, iter)
 
 					default:
 						return fmt.Sprintf("unknown command: %s", d.Cmd)
@@ -840,7 +840,7 @@ func TestBatchRangeOps(t *testing.T) {
 			} else {
 				for k, v := internalIter.First(); k != nil; k, v = internalIter.Next() {
 					k.SetSeqNum(k.SeqNum() &^ InternalKeySeqNumBatch)
-					fmt.Fprintf(&buf, "%s:%s\n", k, v)
+					fmt.Fprintf(&buf, "%s:%s\n", k, v.InPlaceValue())
 				}
 			}
 			return buf.String()
@@ -883,7 +883,7 @@ func TestFlushableBatchIter(t *testing.T) {
 		case "iter":
 			iter := b.newIter(nil)
 			defer iter.Close()
-			return runInternalIterCmd(d, iter)
+			return runInternalIterCmd(t, d, iter)
 
 		default:
 			return fmt.Sprintf("unknown command: %s", d.Cmd)
@@ -939,7 +939,7 @@ func TestFlushableBatch(t *testing.T) {
 
 			iter := b.newIter(&opts)
 			defer iter.Close()
-			return runInternalIterCmd(d, iter)
+			return runInternalIterCmd(t, d, iter)
 
 		case "dump":
 			if len(d.CmdArgs) != 1 || len(d.CmdArgs[0].Vals) != 1 || d.CmdArgs[0].Key != "seq" {
@@ -1026,7 +1026,7 @@ func TestFlushableBatchDeleteRange(t *testing.T) {
 
 func scanInternalIterator(w io.Writer, ii internalIterator) {
 	for k, v := ii.First(); k != nil; k, v = ii.Next() {
-		fmt.Fprintf(w, "%s:%s\n", k, v)
+		fmt.Fprintf(w, "%s:%s\n", k, v.InPlaceValue())
 	}
 }
 

--- a/compaction_iter.go
+++ b/compaction_iter.go
@@ -258,7 +258,12 @@ func (i *compactionIter) First() (*InternalKey, []byte) {
 	if i.err != nil {
 		return nil, nil
 	}
-	i.iterKey, i.iterValue = i.iter.First()
+	var iterValue LazyValue
+	i.iterKey, iterValue = i.iter.First()
+	i.iterValue, _, i.err = iterValue.Value(nil)
+	if i.err != nil {
+		return nil, nil
+	}
 	if i.iterKey != nil {
 		i.curSnapshotIdx, i.curSnapshotSeqNum = snapshotIndex(i.iterKey.SeqNum(), i.snapshots)
 	}
@@ -470,7 +475,12 @@ func (i *compactionIter) skipInStripe() {
 }
 
 func (i *compactionIter) iterNext() bool {
-	i.iterKey, i.iterValue = i.iter.Next()
+	var iterValue LazyValue
+	i.iterKey, iterValue = i.iter.Next()
+	i.iterValue, _, i.err = iterValue.Value(nil)
+	if i.err != nil {
+		i.iterKey = nil
+	}
 	return i.iterKey != nil
 }
 

--- a/error_iter.go
+++ b/error_iter.go
@@ -20,34 +20,34 @@ func newErrorIter(err error) *errorIter {
 	return &errorIter{err: err}
 }
 
-func (c *errorIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, []byte) {
-	return nil, nil
+func (c *errorIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, base.LazyValue) {
+	return nil, base.LazyValue{}
 }
 
 func (c *errorIter) SeekPrefixGE(
 	prefix, key []byte, flags base.SeekGEFlags,
-) (*base.InternalKey, []byte) {
-	return nil, nil
+) (*base.InternalKey, base.LazyValue) {
+	return nil, base.LazyValue{}
 }
 
-func (c *errorIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, []byte) {
-	return nil, nil
+func (c *errorIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, base.LazyValue) {
+	return nil, base.LazyValue{}
 }
 
-func (c *errorIter) First() (*InternalKey, []byte) {
-	return nil, nil
+func (c *errorIter) First() (*InternalKey, base.LazyValue) {
+	return nil, base.LazyValue{}
 }
 
-func (c *errorIter) Last() (*InternalKey, []byte) {
-	return nil, nil
+func (c *errorIter) Last() (*InternalKey, base.LazyValue) {
+	return nil, base.LazyValue{}
 }
 
-func (c *errorIter) Next() (*InternalKey, []byte) {
-	return nil, nil
+func (c *errorIter) Next() (*InternalKey, base.LazyValue) {
+	return nil, base.LazyValue{}
 }
 
-func (c *errorIter) Prev() (*InternalKey, []byte) {
-	return nil, nil
+func (c *errorIter) Prev() (*InternalKey, base.LazyValue) {
+	return nil, base.LazyValue{}
 }
 
 func (c *errorIter) Error() error {

--- a/external_iterator_test.go
+++ b/external_iterator_test.go
@@ -125,7 +125,7 @@ func TestSimpleLevelIter(t *testing.T) {
 			it := &simpleLevelIter{cmp: o.Comparer.Compare, iters: internalIters}
 			it.init(IterOptions{})
 
-			response := runInternalIterCmd(td, it)
+			response := runInternalIterCmd(t, td, it)
 			require.NoError(t, it.Close())
 			return response
 		default:

--- a/get_iter.go
+++ b/get_iter.go
@@ -33,7 +33,7 @@ type getIter struct {
 	l0           []manifest.LevelSlice
 	version      *version
 	iterKey      *InternalKey
-	iterValue    []byte
+	iterValue    base.LazyValue
 	err          error
 }
 
@@ -47,29 +47,29 @@ func (g *getIter) String() string {
 	return fmt.Sprintf("len(l0)=%d, len(mem)=%d, level=%d", len(g.l0), len(g.mem), g.level)
 }
 
-func (g *getIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, []byte) {
+func (g *getIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, base.LazyValue) {
 	panic("pebble: SeekGE unimplemented")
 }
 
 func (g *getIter) SeekPrefixGE(
 	prefix, key []byte, flags base.SeekGEFlags,
-) (*base.InternalKey, []byte) {
+) (*base.InternalKey, base.LazyValue) {
 	panic("pebble: SeekPrefixGE unimplemented")
 }
 
-func (g *getIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, []byte) {
+func (g *getIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, base.LazyValue) {
 	panic("pebble: SeekLT unimplemented")
 }
 
-func (g *getIter) First() (*InternalKey, []byte) {
+func (g *getIter) First() (*InternalKey, base.LazyValue) {
 	return g.Next()
 }
 
-func (g *getIter) Last() (*InternalKey, []byte) {
+func (g *getIter) Last() (*InternalKey, base.LazyValue) {
 	panic("pebble: Last unimplemented")
 }
 
-func (g *getIter) Next() (*InternalKey, []byte) {
+func (g *getIter) Next() (*InternalKey, base.LazyValue) {
 	if g.iter != nil {
 		g.iterKey, g.iterValue = g.iter.Next()
 	}
@@ -84,7 +84,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 			if g.rangeDelIter != nil {
 				g.tombstone = keyspan.Get(g.cmp, g.rangeDelIter, g.key)
 				if g.err = g.rangeDelIter.Close(); g.err != nil {
-					return nil, nil
+					return nil, base.LazyValue{}
 				}
 				g.rangeDelIter = nil
 			}
@@ -98,7 +98,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 					// effectively stopping iteration.
 					g.err = g.iter.Close()
 					g.iter = nil
-					return nil, nil
+					return nil, base.LazyValue{}
 				}
 				if g.equal(g.key, key.UserKey) {
 					if !key.Visible(g.snapshot, base.InternalKeySeqNumMax) {
@@ -113,7 +113,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 			g.err = g.iter.Close()
 			g.iter = nil
 			if g.err != nil {
-				return nil, nil
+				return nil, base.LazyValue{}
 			}
 		}
 
@@ -121,8 +121,8 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 		if g.batch != nil {
 			if g.batch.index == nil {
 				g.err = ErrNotIndexed
-				g.iterKey, g.iterValue = nil, nil
-				return nil, nil
+				g.iterKey, g.iterValue = nil, base.LazyValue{}
+				return nil, base.LazyValue{}
 			}
 			g.iter = g.batch.newInternalIter(nil)
 			g.rangeDelIter = g.batch.newRangeDelIter(
@@ -139,7 +139,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 		// If we have a tombstone from a previous level it is guaranteed to delete
 		// keys in lower levels.
 		if g.tombstone != nil && g.tombstone.VisibleAt(g.snapshot) {
-			return nil, nil
+			return nil, base.LazyValue{}
 		}
 
 		// Create iterators from memtables from newest to oldest.
@@ -169,7 +169,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 		}
 
 		if g.level >= numLevels {
-			return nil, nil
+			return nil, base.LazyValue{}
 		}
 		if g.version.Levels[g.level].Empty() {
 			g.level++
@@ -186,16 +186,8 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 	}
 }
 
-func (g *getIter) Prev() (*InternalKey, []byte) {
+func (g *getIter) Prev() (*InternalKey, base.LazyValue) {
 	panic("pebble: Prev unimplemented")
-}
-
-func (g *getIter) Key() *InternalKey {
-	return g.iterKey
-}
-
-func (g *getIter) Value() []byte {
-	return g.iterValue
 }
 
 func (g *getIter) Valid() bool {

--- a/internal/arenaskl/flush_iterator.go
+++ b/internal/arenaskl/flush_iterator.go
@@ -34,17 +34,21 @@ func (it *flushIterator) String() string {
 	return "memtable"
 }
 
-func (it *flushIterator) SeekGE(key []byte, flags base.SeekGEFlags) (*base.InternalKey, []byte) {
+func (it *flushIterator) SeekGE(
+	key []byte, flags base.SeekGEFlags,
+) (*base.InternalKey, base.LazyValue) {
 	panic("pebble: SeekGE unimplemented")
 }
 
 func (it *flushIterator) SeekPrefixGE(
 	prefix, key []byte, flags base.SeekGEFlags,
-) (*base.InternalKey, []byte) {
+) (*base.InternalKey, base.LazyValue) {
 	panic("pebble: SeekPrefixGE unimplemented")
 }
 
-func (it *flushIterator) SeekLT(key []byte, flags base.SeekLTFlags) (*base.InternalKey, []byte) {
+func (it *flushIterator) SeekLT(
+	key []byte, flags base.SeekLTFlags,
+) (*base.InternalKey, base.LazyValue) {
 	panic("pebble: SeekLT unimplemented")
 }
 
@@ -52,10 +56,10 @@ func (it *flushIterator) SeekLT(key []byte, flags base.SeekLTFlags) (*base.Inter
 // if the iterator is pointing at a valid entry, and (nil, nil) otherwise. Note
 // that First only checks the upper bound. It is up to the caller to ensure
 // that key is greater than or equal to the lower bound.
-func (it *flushIterator) First() (*base.InternalKey, []byte) {
+func (it *flushIterator) First() (*base.InternalKey, base.LazyValue) {
 	key, val := it.Iterator.First()
 	if key == nil {
-		return nil, nil
+		return nil, base.LazyValue{}
 	}
 	*it.bytesIterated += uint64(it.nd.allocSize)
 	return key, val
@@ -65,16 +69,16 @@ func (it *flushIterator) First() (*base.InternalKey, []byte) {
 // iterator is pointing at a valid entry, and (nil, nil) otherwise.
 // Note: flushIterator.Next mirrors the implementation of Iterator.Next
 // due to performance. Keep the two in sync.
-func (it *flushIterator) Next() (*base.InternalKey, []byte) {
+func (it *flushIterator) Next() (*base.InternalKey, base.LazyValue) {
 	it.nd = it.list.getNext(it.nd, 0)
 	if it.nd == it.list.tail {
-		return nil, nil
+		return nil, base.LazyValue{}
 	}
 	it.decodeKey()
 	*it.bytesIterated += uint64(it.nd.allocSize)
-	return &it.key, it.value()
+	return &it.key, base.MakeInPlaceValue(it.value())
 }
 
-func (it *flushIterator) Prev() (*base.InternalKey, []byte) {
+func (it *flushIterator) Prev() (*base.InternalKey, base.LazyValue) {
 	panic("pebble: Prev unimplemented")
 }

--- a/internal/arenaskl/skl_test.go
+++ b/internal/arenaskl/skl_test.go
@@ -49,9 +49,9 @@ func newIterAdapter(iter *Iterator) *iterAdapter {
 	}
 }
 
-func (i *iterAdapter) update(key *base.InternalKey, val []byte) bool {
+func (i *iterAdapter) update(key *base.InternalKey, val base.LazyValue) bool {
 	i.key = key
-	i.val = val
+	i.val = val.InPlaceValue()
 	return i.key != nil
 }
 

--- a/internal/base/lazy_value.go
+++ b/internal/base/lazy_value.go
@@ -1,0 +1,256 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package base
+
+import "github.com/cockroachdb/pebble/internal/invariants"
+
+// A value can have user-defined attributes that are a function of the value
+// byte slice. For now, we only support "short attributes", which can be
+// encoded in 3 bits. We will likely extend this to "long attributes" later
+// for values that are even more expensive to access than those in value
+// blocks in the same sstable.
+//
+// When a sstable writer chooses not to store a value together with the key,
+// it can call the ShortAttributeExtractor to extract the attribute and store
+// it together with the key. This allows for cheap retrieval of
+// AttributeAndLen on the read-path, without doing a more expensive retrieval
+// of the value.
+//
+// In general, the extraction code may want to also look at the key to decide
+// how to treat the value. Our current needs can be satisfied by configuring a
+// keyspan for which the ShortAttributeExtractor should be used, so we do not
+// expose the key to the extractor.
+//
+// Write path performance: The ShortAttributeExtractor func cannot be inlined,
+// so we will pay the cost of this function call. However, we will only pay
+// this when (a) the value is not being stored together with the key, and (b)
+// the key-value pair is being initially written to the DB, or a compaction is
+// transitioning the key-value pair from being stored together to being stored
+// separately.
+
+// ShortAttribute encodes a user-specified attribute of the value.
+type ShortAttribute uint8
+
+// MaxShortAttribute is the maximum value of the short attribute (3 bits).
+const MaxShortAttribute = 7
+
+// ShortAttributeExtractor is an extractor that given the value, will return
+// the ShortAttribute.
+type ShortAttributeExtractor func(value []byte) (ShortAttribute, error)
+
+// AttributeAndLen represents the pair of value length and the short
+// attribute.
+type AttributeAndLen struct {
+	ValueLen       int32
+	ShortAttribute ShortAttribute
+}
+
+// LazyValue represents a value that may not already have been extracted.
+// Currently, it can represent either an in-place value (stored with the key)
+// or a value stored in the value section. However, the interface is general
+// enough to support values that are stored in separate files.
+//
+// LazyValue is used in the InternalIterator interface, such that all
+// positioning calls return (*InternalKey, LazyValue). It is also exposed via
+// the public Iterator for callers that need to remember a recent but not
+// necessarily latest LazyValue, in case they need the actual value in the
+// future. An example is a caller that is iterating in reverse and looking for
+// the latest MVCC version for a key -- it cannot identify the latest MVCC
+// version without stepping to the previous key-value pair e.g.
+// storage.pebbleMVCCScanner in CockroachDB.
+//
+// Performance note: It is important for this struct to not exceed a sizeof 32
+// bytes, for optimizing the common case of the in-place value. Prior to
+// introducing LazyValue, we were passing around a []byte which is 24 bytes.
+// Passing a 40 byte or larger struct causes performance to drop by 75% on
+// some benchmarks that do tight iteration loops.
+//
+// Memory management:
+// This is subtle, but important for performance.
+//
+// - A LazyValue returned by an InternalIterator or Iterator is unstable in
+//   that repositioning the iterator will invalidate the memory inside it. A
+//   caller wishing to maintain that LazyValue needs to call
+//   LazyValue.Clone(). Note that this does not fetch the value if it is not
+//   in-place. Additionally, Clone() *must* only be called if
+//   LazyValue.Value() has *not* been called, since (a) it only makes a
+//   promise about stability of LazyValue and not the underlying value, (b) if
+//   LazyValue.Value() has been called already, the caller has the value
+//   []byte slice so it is unnecessary to fiddle around with LazyValue.
+//
+// - A user of an iterator that calls LazyValue.Value() wants as much as
+//   possible for the returned value []byte to point to iterator owned memory.
+//   - [P1] The underlying iterator that owns that memory also needs a promise
+//     from that user that at any time there is at most one value []byte slice
+//     that the caller is expecting it to maintain. Otherwise, the underlying
+//     iterator has to maintain multiple such []byte slices which results in
+//     more complicated and inefficient code.
+//   - [P2] The underlying iterator, in order to make the promise that it is
+//     maintaining the one value []byte slice, also needs a way to know when
+//     it is relieved of that promise. One way it is relieved of that promise
+//     is by being told that it is being repositioned. Typically, the owner of
+//     the value []byte slice is a sstable iterator, and it will know that it
+//     is relieved of the promise when it is repositioned. However, consider
+//     the case where the caller has used LazyValue.Clone() and repositioned
+//     the iterator (which is actually a tree of iterators). In this case the
+//     underlying sstable iterator may not even be open. LazyValue.Value()
+//     will still work (at a higher cost), but since the sstable iterator is
+//     not open, it does not have a mechanism to know when the retrieved value
+//     is no longer in use. We refer to this situation as "not satisfying P2".
+//     To handle this situation, the LazyValue.Value() method accepts a caller
+//     owned buffer, that the callee will use if needed. The callee explicitly
+//     tells the caller whether the []byte slice for the value is now owned by
+//     the caller. This will be true if the callee attempted to use buf and
+//     either successfully used it or allocated a new []byte slice.
+//
+//  To ground the above in reality, we consider three examples of callers of
+//  LazyValue.Value():
+//  - Iterator: it calls LazyValue.Value for its own use when merging values.
+//    When merging during reverse iteration, it may have cloned the LazyValue.
+//    In this case it calls LazyValue.Value() on the cloned value, merges it,
+//    and then calls LazyValue.Value() on the current iterator position and
+//    merges it. So it is honoring P1.
+//  - Iterator on behalf of Iterator clients: The Iterator.Value() method
+//    needs to call LazyValue.Value(). The client of Iterator is satisfying P1
+//    because of the inherent Iterator interface constraint, i.e., it is calling
+//    Iterator.Value() on the current Iterator position. It is possible that
+//    the Iterator has cloned this LazyValue (for the reverse iteration case),
+//    which the client is unaware of, so the underlying sstable iterator may
+//    not be able to satisfy P2. This is ok because Iterator will call
+//    LazyValue.Value with its (reusable) owned buffer.
+//  - CockroachDB's pebbleMVCCScanner: This will use LazyValues from Iterator
+//    since during reverse iteration in order to find the highest version that
+//    satisfies a read it needs to clone the LazyValue, step back the iterator
+//    and then decide whether it needs the value from the previously cloned
+//    LazyValue. The pebbleMVCCScanner will satisfy P1. The P2 story is
+//    similar to the previous case in that it will call LazyValue.Value with
+//    its (reusable) owned buffer.
+//
+// Corollary: callers that directly use InternalIterator can know that they
+// have done nothing to interfere with promise P2 can pass in a nil buf and be
+// sure that it will not trigger an allocation.
+//
+// Repeated calling of LazyValue.Value:
+// This is ok as long as the caller continues to satisfy P1. The previously
+// fetched value will be remembered inside LazyValue to avoid fetching again.
+// So if the caller's buffer is used the first time the value was fetched, it
+// is still in use.
+//
+// LazyValue fields are visible outside the package for use in
+// InternalIterator implementations and in Iterator, but not meant for direct
+// use by users of Pebble.
+type LazyValue struct {
+	// ValueOrHandle represents a value, or a handle to be passed to ValueFetcher.
+	// - Fetcher == nil: ValueOrHandle is a value.
+	// - Fetcher != nil: ValueOrHandle is a handle and Fetcher.Attribute is
+	//   initialized.
+	// The ValueOrHandle exposed by InternalIterator or Iterator may not be stable
+	// if the iterator is stepped. To make it stable, make a copy using Clone.
+	ValueOrHandle []byte
+	// Fetcher provides support for fetching an actually lazy value.
+	Fetcher *LazyFetcher
+}
+
+// LazyFetcher supports fetching a lazy value.
+type LazyFetcher struct {
+	// ValueFetcher, given a handle, returns the value. It is acceptable to call
+	// the ValueFetcher as long as the DB is open. However, one should assume
+	// there is a fast-path when the iterator tree has not moved off the sstable
+	// iterator that initially provided this LazyValue. Hence, to utilize this
+	// fast-path the caller should try to decide whether it needs the value or
+	// not as soon as possible, with minimal possible stepping of the iterator.
+	//
+	// buf will be used if the fetcher cannot satisfy P2 (see earlier comment).
+	// If the fetcher attempted to use buf *and* len(buf) was insufficient, it
+	// will allocate a new slice for the value. In either case it will set
+	// callerOwned to true.
+	ValueFetcher func(handle []byte, buf []byte) (val []byte, callerOwned bool, err error)
+	// Attribute includes the short attribute and value length.
+	Attribute   AttributeAndLen
+	fetched     bool
+	value       []byte
+	callerOwned bool
+	err         error
+}
+
+// Value returns the underlying value.
+func (lv *LazyValue) Value(buf []byte) (val []byte, callerOwned bool, err error) {
+	if lv.Fetcher == nil {
+		return lv.ValueOrHandle, false, nil
+	}
+	// Do the rest of the work in a separate method to attempt mid-stack
+	// inlining of Value(). Unfortunately, this still does not inline since the
+	// cost of 85 exceeds the budget of 80.
+	//
+	// TODO(sumeer): Packing the return values into a struct{[]byte error bool}
+	// causes it to be below the budget. Consider this if we need to recover
+	// more performance. I suspect that inlining this only matters in
+	// micro-benchmarks, and in actual use cases in CockroachDB it will not
+	// matter because there is substantial work done with a fetched value.
+	return lv.fetchValue(buf)
+}
+
+// INVARIANT: lv.Fetcher != nil
+func (lv *LazyValue) fetchValue(buf []byte) (val []byte, callerOwned bool, err error) {
+	f := lv.Fetcher
+	if !f.fetched {
+		f.fetched = true
+		f.value, f.callerOwned, f.err = lv.Fetcher.ValueFetcher(lv.ValueOrHandle, buf)
+	}
+	return f.value, f.callerOwned, f.err
+}
+
+// InPlaceValue returns the value under the assumption that it is in-place.
+// This is for Pebble-internal code.
+func (lv *LazyValue) InPlaceValue() []byte {
+	if invariants.Enabled && lv.Fetcher != nil {
+		panic("value must be in-place")
+	}
+	return lv.ValueOrHandle
+}
+
+// Len returns the length of the value.
+func (lv *LazyValue) Len() int {
+	if lv.Fetcher == nil {
+		return len(lv.ValueOrHandle)
+	}
+	return int(lv.Fetcher.Attribute.ValueLen)
+}
+
+// Clone creates a stable copy of the LazyValue, by appending bytes to buf.
+// REQUIRES: LazyValue.Value() has not been called.
+// Ensure that this is only called before LazyValue.Value is called. We don't
+// actually care if it was in-place but we don't want confusing things about whether
+// we need to clone the value inside the fetcher.
+func (lv *LazyValue) Clone(buf []byte) (LazyValue, []byte) {
+	if invariants.Enabled && lv.Fetcher != nil && lv.Fetcher.fetched {
+		panic("value has already been fetched")
+	}
+	// INVARIANT: LazyFetcher.value is nil, so there is nothing to copy there.
+	vLen := len(lv.ValueOrHandle)
+	lvCopy := LazyValue{Fetcher: lv.Fetcher}
+	if vLen == 0 {
+		return lvCopy, buf
+	}
+	bufLen := len(buf)
+	buf = append(buf, lv.ValueOrHandle...)
+	lvCopy.ValueOrHandle = buf[bufLen : bufLen+vLen]
+	return lvCopy, buf
+}
+
+// MakeInPlaceValue constructs an in-place value.
+func MakeInPlaceValue(val []byte) LazyValue {
+	return LazyValue{ValueOrHandle: val}
+}
+
+// TODO(sumeer): test that callers are adhering to promise P1. In the sstable
+// iterators, when invariants are enabled, create a testingFetcher struct that
+// contains the sstable name and the []byte backing for the last fetched
+// value. The sstable iterator, instead of returning an in-place value, will
+// return a copy of the key in ValueOrHandle, and a ValueFetcher implemented
+// by testingFetcher.valueFetcher. Each time this method is called, it will
+// mangle the last fetched value []byte slice, allocate a new one, open the
+// sstable, seek to the key, and copy the value into this new byte slice and
+// return.

--- a/internal/base/lazy_value_test.go
+++ b/internal/base/lazy_value_test.go
@@ -1,0 +1,56 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package base
+
+import (
+	"bytes"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLazyValue(t *testing.T) {
+	// Both 40 and 48 bytes makes iteration benchmarks like
+	// BenchmarkIteratorScan/keys=1000,r-amp=1,key-types=points-only 75%
+	// slower.
+	require.Equal(t, 32, int(unsafe.Sizeof(LazyValue{})))
+
+	fooBytes1 := []byte("foo")
+	fooLV1 := MakeInPlaceValue(fooBytes1)
+	require.Equal(t, 3, fooLV1.Len())
+	fooLV2, fooBytes2 := fooLV1.Clone(nil)
+	require.Equal(t, 3, fooLV2.Len())
+	require.Equal(t, fooLV1.InPlaceValue(), fooLV2.InPlaceValue())
+	getValue := func(lv LazyValue, expectedCallerOwned bool) []byte {
+		v, callerOwned, err := lv.Value(nil)
+		require.NoError(t, err)
+		require.Equal(t, expectedCallerOwned, callerOwned)
+		return v
+	}
+	require.Equal(t, getValue(fooLV1, false), getValue(fooLV2, false))
+	fooBytes2[0] = 'b'
+	require.False(t, bytes.Equal(fooLV1.InPlaceValue(), fooLV2.InPlaceValue()))
+
+	for _, callerOwned := range []bool{false, true} {
+		numCalls := 0
+		fooLV3 := LazyValue{
+			ValueOrHandle: []byte("foo-handle"),
+			Fetcher: &LazyFetcher{
+				ValueFetcher: func(handle []byte, buf []byte) ([]byte, bool, error) {
+					numCalls++
+					require.Equal(t, []byte("foo-handle"), handle)
+					return fooBytes1, callerOwned, nil
+				},
+				Attribute: AttributeAndLen{ValueLen: 3, ShortAttribute: 7},
+			},
+		}
+		require.Equal(t, []byte("foo"), getValue(fooLV3, callerOwned))
+		require.Equal(t, 1, numCalls)
+		require.Equal(t, []byte("foo"), getValue(fooLV3, callerOwned))
+		require.Equal(t, 1, numCalls)
+		require.Equal(t, 3, fooLV3.Len())
+	}
+}

--- a/internal/keyspan/interleaving_iter_test.go
+++ b/internal/keyspan/interleaving_iter_test.go
@@ -79,7 +79,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 		split: testkeys.Comparer.Split,
 	}
 
-	formatKey := func(k *base.InternalKey, v []byte) {
+	formatKey := func(k *base.InternalKey, _ base.LazyValue) {
 		if k == nil {
 			fmt.Fprint(&buf, ".")
 			return
@@ -187,81 +187,85 @@ type pointIterator struct {
 
 var _ base.InternalIterator = &pointIterator{}
 
-func (i *pointIterator) SeekGE(key []byte, flags base.SeekGEFlags) (*base.InternalKey, []byte) {
+func (i *pointIterator) SeekGE(
+	key []byte, flags base.SeekGEFlags,
+) (*base.InternalKey, base.LazyValue) {
 	i.index = sort.Search(len(i.keys), func(j int) bool {
 		return i.cmp(i.keys[j].UserKey, key) >= 0
 	})
 	if i.index < 0 || i.index >= len(i.keys) {
-		return nil, nil
+		return nil, base.LazyValue{}
 	}
 	if i.upper != nil && i.cmp(i.keys[i.index].UserKey, i.upper) >= 0 {
-		return nil, nil
+		return nil, base.LazyValue{}
 	}
-	return &i.keys[i.index], nil
+	return &i.keys[i.index], base.LazyValue{}
 }
 
 func (i *pointIterator) SeekPrefixGE(
 	prefix, key []byte, flags base.SeekGEFlags,
-) (*base.InternalKey, []byte) {
+) (*base.InternalKey, base.LazyValue) {
 	return i.SeekGE(key, flags)
 }
 
-func (i *pointIterator) SeekLT(key []byte, flags base.SeekLTFlags) (*base.InternalKey, []byte) {
+func (i *pointIterator) SeekLT(
+	key []byte, flags base.SeekLTFlags,
+) (*base.InternalKey, base.LazyValue) {
 	i.index = sort.Search(len(i.keys), func(j int) bool {
 		return i.cmp(i.keys[j].UserKey, key) >= 0
 	})
 	i.index--
 	if i.index < 0 || i.index >= len(i.keys) {
-		return nil, nil
+		return nil, base.LazyValue{}
 	}
 	if i.lower != nil && i.cmp(i.keys[i.index].UserKey, i.lower) < 0 {
-		return nil, nil
+		return nil, base.LazyValue{}
 	}
-	return &i.keys[i.index], nil
+	return &i.keys[i.index], base.LazyValue{}
 }
 
-func (i *pointIterator) First() (*base.InternalKey, []byte) {
+func (i *pointIterator) First() (*base.InternalKey, base.LazyValue) {
 	i.index = 0
 	if i.index < 0 || i.index >= len(i.keys) {
-		return nil, nil
+		return nil, base.LazyValue{}
 	}
 	if i.upper != nil && i.cmp(i.keys[i.index].UserKey, i.upper) >= 0 {
-		return nil, nil
+		return nil, base.LazyValue{}
 	}
-	return &i.keys[i.index], nil
+	return &i.keys[i.index], base.LazyValue{}
 }
 
-func (i *pointIterator) Last() (*base.InternalKey, []byte) {
+func (i *pointIterator) Last() (*base.InternalKey, base.LazyValue) {
 	i.index = len(i.keys) - 1
 	if i.index < 0 || i.index >= len(i.keys) {
-		return nil, nil
+		return nil, base.LazyValue{}
 	}
 	if i.lower != nil && i.cmp(i.keys[i.index].UserKey, i.lower) < 0 {
-		return nil, nil
+		return nil, base.LazyValue{}
 	}
-	return &i.keys[i.index], nil
+	return &i.keys[i.index], base.LazyValue{}
 }
 
-func (i *pointIterator) Next() (*base.InternalKey, []byte) {
+func (i *pointIterator) Next() (*base.InternalKey, base.LazyValue) {
 	i.index++
 	if i.index < 0 || i.index >= len(i.keys) {
-		return nil, nil
+		return nil, base.LazyValue{}
 	}
 	if i.upper != nil && i.cmp(i.keys[i.index].UserKey, i.upper) >= 0 {
-		return nil, nil
+		return nil, base.LazyValue{}
 	}
-	return &i.keys[i.index], nil
+	return &i.keys[i.index], base.LazyValue{}
 }
 
-func (i *pointIterator) Prev() (*base.InternalKey, []byte) {
+func (i *pointIterator) Prev() (*base.InternalKey, base.LazyValue) {
 	i.index--
 	if i.index < 0 || i.index >= len(i.keys) {
-		return nil, nil
+		return nil, base.LazyValue{}
 	}
 	if i.lower != nil && i.cmp(i.keys[i.index].UserKey, i.lower) < 0 {
-		return nil, nil
+		return nil, base.LazyValue{}
 	}
-	return &i.keys[i.index], nil
+	return &i.keys[i.index], base.LazyValue{}
 }
 
 func (i *pointIterator) Close() error   { return nil }

--- a/internal/keyspan/internal_iter_shim.go
+++ b/internal/keyspan/internal_iter_shim.go
@@ -38,57 +38,57 @@ func (i *InternalIteratorShim) Span() *Span {
 // SeekGE implements (base.InternalIterator).SeekGE.
 func (i *InternalIteratorShim) SeekGE(
 	key []byte, flags base.SeekGEFlags,
-) (*base.InternalKey, []byte) {
+) (*base.InternalKey, base.LazyValue) {
 	panic("unimplemented")
 }
 
 // SeekPrefixGE implements (base.InternalIterator).SeekPrefixGE.
 func (i *InternalIteratorShim) SeekPrefixGE(
 	prefix, key []byte, flags base.SeekGEFlags,
-) (*base.InternalKey, []byte) {
+) (*base.InternalKey, base.LazyValue) {
 	panic("unimplemented")
 }
 
 // SeekLT implements (base.InternalIterator).SeekLT.
 func (i *InternalIteratorShim) SeekLT(
 	key []byte, flags base.SeekLTFlags,
-) (*base.InternalKey, []byte) {
+) (*base.InternalKey, base.LazyValue) {
 	panic("unimplemented")
 }
 
 // First implements (base.InternalIterator).First.
-func (i *InternalIteratorShim) First() (*base.InternalKey, []byte) {
+func (i *InternalIteratorShim) First() (*base.InternalKey, base.LazyValue) {
 	i.span = i.miter.First()
 	for i.span != nil && i.span.Empty() {
 		i.span = i.miter.Next()
 	}
 	if i.span == nil {
-		return nil, nil
+		return nil, base.LazyValue{}
 	}
 	i.iterKey = base.InternalKey{UserKey: i.span.Start, Trailer: i.span.Keys[0].Trailer}
-	return &i.iterKey, i.span.End
+	return &i.iterKey, base.MakeInPlaceValue(i.span.End)
 }
 
 // Last implements (base.InternalIterator).Last.
-func (i *InternalIteratorShim) Last() (*base.InternalKey, []byte) {
+func (i *InternalIteratorShim) Last() (*base.InternalKey, base.LazyValue) {
 	panic("unimplemented")
 }
 
 // Next implements (base.InternalIterator).Next.
-func (i *InternalIteratorShim) Next() (*base.InternalKey, []byte) {
+func (i *InternalIteratorShim) Next() (*base.InternalKey, base.LazyValue) {
 	i.span = i.miter.Next()
 	for i.span != nil && i.span.Empty() {
 		i.span = i.miter.Next()
 	}
 	if i.span == nil {
-		return nil, nil
+		return nil, base.LazyValue{}
 	}
 	i.iterKey = base.InternalKey{UserKey: i.span.Start, Trailer: i.span.Keys[0].Trailer}
-	return &i.iterKey, i.span.End
+	return &i.iterKey, base.MakeInPlaceValue(i.span.End)
 }
 
 // Prev implements (base.InternalIterator).Prev.
-func (i *InternalIteratorShim) Prev() (*base.InternalKey, []byte) {
+func (i *InternalIteratorShim) Prev() (*base.InternalKey, base.LazyValue) {
 	panic("unimplemented")
 }
 

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -467,7 +467,7 @@ func (o *ingestOp) build(t *test, h historyRecorder, b *pebble.Batch, i int) (st
 		lastUserKey = key.UserKey
 
 		key.SetSeqNum(0)
-		if err := w.Add(*key, value); err != nil {
+		if err := w.Add(*key, value.InPlaceValue()); err != nil {
 			return "", err
 		}
 	}
@@ -565,9 +565,9 @@ func (o *ingestOp) collapseBatch(
 			case pebble.InternalKeyKindSingleDelete:
 				err = collapsed.SingleDelete(key.UserKey, nil)
 			case pebble.InternalKeyKindSet:
-				err = collapsed.Set(key.UserKey, value, nil)
+				err = collapsed.Set(key.UserKey, value.InPlaceValue(), nil)
 			case pebble.InternalKeyKindMerge:
-				err = collapsed.Merge(key.UserKey, value, nil)
+				err = collapsed.Merge(key.UserKey, value.InPlaceValue(), nil)
 			case pebble.InternalKeyKindLogData:
 				err = collapsed.LogData(key.UserKey, nil)
 			default:

--- a/mem_table.go
+++ b/mem_table.go
@@ -336,7 +336,7 @@ func (f *keySpanFrags) get(
 		it := skl.NewIter(nil, nil)
 		var keysDst []keyspan.Key
 		for key, val := it.First(); key != nil; key, val = it.Next() {
-			s, err := constructSpan(*key, val, keysDst)
+			s, err := constructSpan(*key, val.InPlaceValue(), keysDst)
 			if err != nil {
 				panic(err)
 			}

--- a/mem_table_test.go
+++ b/mem_table_test.go
@@ -39,7 +39,7 @@ func (m *memTable) get(key []byte) (value []byte, err error) {
 	case InternalKeyKindDelete, InternalKeyKindSingleDelete:
 		return nil, ErrNotFound
 	default:
-		return val, nil
+		return val.InPlaceValue(), nil
 	}
 }
 
@@ -287,7 +287,7 @@ func TestMemTableIter(t *testing.T) {
 				}
 				iter := mem.newIter(&options)
 				defer iter.Close()
-				return runInternalIterCmd(d, iter)
+				return runInternalIterCmd(t, d, iter)
 
 			default:
 				return fmt.Sprintf("unknown command: %s", d.Cmd)

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -24,7 +24,7 @@ type mergingIterLevel struct {
 	rangeDelIter keyspan.FragmentIterator
 	// iterKey and iterValue cache the current key and value iter are pointed at.
 	iterKey   *InternalKey
-	iterValue []byte
+	iterValue base.LazyValue
 
 	// levelIterBoundaryContext's fields are set when using levelIter, in order
 	// to surface sstable boundary keys and file-level context. See levelIter
@@ -677,7 +677,7 @@ func (m *mergingIter) isNextEntryDeleted(item *mergingIterItem) bool {
 }
 
 // Starting from the current entry, finds the first (next) entry that can be returned.
-func (m *mergingIter) findNextEntry() (*InternalKey, []byte) {
+func (m *mergingIter) findNextEntry() (*InternalKey, base.LazyValue) {
 	var reseeked bool
 	for m.heap.len() > 0 && m.err == nil {
 		item := &m.heap.items[0]
@@ -699,7 +699,7 @@ func (m *mergingIter) findNextEntry() (*InternalKey, []byte) {
 		// the iterator is now exhausted, item.key may be garbage.
 		if m.prefix != nil && reseeked {
 			if n := m.split(item.key.UserKey); !bytes.Equal(m.prefix, item.key.UserKey[:n]) {
-				return nil, nil
+				return nil, base.LazyValue{}
 			}
 		}
 
@@ -716,7 +716,7 @@ func (m *mergingIter) findNextEntry() (*InternalKey, []byte) {
 		}
 		m.nextEntry(item)
 	}
-	return nil, nil
+	return nil, base.LazyValue{}
 }
 
 // Steps to the prev entry. item is the current top item in the heap.
@@ -852,7 +852,7 @@ func (m *mergingIter) isPrevEntryDeleted(item *mergingIterItem) bool {
 }
 
 // Starting from the current entry, finds the first (prev) entry that can be returned.
-func (m *mergingIter) findPrevEntry() (*InternalKey, []byte) {
+func (m *mergingIter) findPrevEntry() (*InternalKey, base.LazyValue) {
 	for m.heap.len() > 0 && m.err == nil {
 		item := &m.heap.items[0]
 		if m.levels[item.index].isSyntheticIterBoundsKey {
@@ -870,7 +870,7 @@ func (m *mergingIter) findPrevEntry() (*InternalKey, []byte) {
 		}
 		m.prevEntry(item)
 	}
-	return nil, nil
+	return nil, base.LazyValue{}
 }
 
 // Seeks levels >= level to >= key. Additionally uses range tombstones to extend the seeks.
@@ -964,7 +964,7 @@ func (m *mergingIter) String() string {
 // SeekGE implements base.InternalIterator.SeekGE. Note that SeekGE only checks
 // the upper bound. It is up to the caller to ensure that key is greater than
 // or equal to the lower bound.
-func (m *mergingIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, []byte) {
+func (m *mergingIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, base.LazyValue) {
 	m.err = nil // clear cached iteration error
 	m.prefix = nil
 	m.seekGE(key, 0 /* start level */, flags)
@@ -976,7 +976,7 @@ func (m *mergingIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, 
 // that key is greater than or equal to the lower bound.
 func (m *mergingIter) SeekPrefixGE(
 	prefix, key []byte, flags base.SeekGEFlags,
-) (*base.InternalKey, []byte) {
+) (*base.InternalKey, base.LazyValue) {
 	m.err = nil // clear cached iteration error
 	m.prefix = prefix
 	m.seekGE(key, 0 /* start level */, flags)
@@ -1054,7 +1054,7 @@ func (m *mergingIter) seekLT(key []byte, level int, flags base.SeekLTFlags) {
 // SeekLT implements base.InternalIterator.SeekLT. Note that SeekLT only checks
 // the lower bound. It is up to the caller to ensure that key is less than the
 // upper bound.
-func (m *mergingIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, []byte) {
+func (m *mergingIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, base.LazyValue) {
 	m.err = nil // clear cached iteration error
 	m.prefix = nil
 	m.seekLT(key, 0 /* start level */, flags)
@@ -1064,7 +1064,7 @@ func (m *mergingIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, 
 // First implements base.InternalIterator.First. Note that First only checks
 // the upper bound. It is up to the caller to ensure that key is greater than
 // or equal to the lower bound (e.g. via a call to SeekGE(lower)).
-func (m *mergingIter) First() (*InternalKey, []byte) {
+func (m *mergingIter) First() (*InternalKey, base.LazyValue) {
 	m.err = nil // clear cached iteration error
 	m.prefix = nil
 	m.heap.items = m.heap.items[:0]
@@ -1079,7 +1079,7 @@ func (m *mergingIter) First() (*InternalKey, []byte) {
 // Last implements base.InternalIterator.Last. Note that Last only checks the
 // lower bound. It is up to the caller to ensure that key is less than the
 // upper bound (e.g. via a call to SeekLT(upper))
-func (m *mergingIter) Last() (*InternalKey, []byte) {
+func (m *mergingIter) Last() (*InternalKey, base.LazyValue) {
 	m.err = nil // clear cached iteration error
 	m.prefix = nil
 	for i := range m.levels {
@@ -1090,9 +1090,9 @@ func (m *mergingIter) Last() (*InternalKey, []byte) {
 	return m.findPrevEntry()
 }
 
-func (m *mergingIter) Next() (*InternalKey, []byte) {
+func (m *mergingIter) Next() (*InternalKey, base.LazyValue) {
 	if m.err != nil {
-		return nil, nil
+		return nil, base.LazyValue{}
 	}
 
 	if m.dir != 1 {
@@ -1101,29 +1101,29 @@ func (m *mergingIter) Next() (*InternalKey, []byte) {
 	}
 
 	if m.heap.len() == 0 {
-		return nil, nil
+		return nil, base.LazyValue{}
 	}
 
 	m.nextEntry(&m.heap.items[0])
 	return m.findNextEntry()
 }
 
-func (m *mergingIter) Prev() (*InternalKey, []byte) {
+func (m *mergingIter) Prev() (*InternalKey, base.LazyValue) {
 	if m.err != nil {
-		return nil, nil
+		return nil, base.LazyValue{}
 	}
 
 	if m.dir != -1 {
 		if m.prefix != nil {
 			m.err = errors.New("pebble: unsupported reverse prefix iteration")
-			return nil, nil
+			return nil, base.LazyValue{}
 		}
 		m.switchToMaxHeap()
 		return m.findPrevEntry()
 	}
 
 	if m.heap.len() == 0 {
-		return nil, nil
+		return nil, base.LazyValue{}
 	}
 
 	m.prevEntry(&m.heap.items[0])
@@ -1193,7 +1193,7 @@ func (m *mergingIter) ForEachLevelIter(fn func(li *levelIter) bool) {
 func (m *mergingIter) addItemStats(item *mergingIterItem) {
 	m.stats.PointCount++
 	m.stats.KeyBytes += uint64(len(item.key.UserKey))
-	m.stats.ValueBytes += uint64(len(item.value))
+	m.stats.ValueBytes += uint64(len(item.value.ValueOrHandle))
 }
 
 var _ internalIterator = &mergingIter{}

--- a/merging_iter_heap.go
+++ b/merging_iter_heap.go
@@ -4,10 +4,12 @@
 
 package pebble
 
+import "github.com/cockroachdb/pebble/internal/base"
+
 type mergingIterItem struct {
 	index int
 	key   InternalKey
-	value []byte
+	value base.LazyValue
 }
 
 type mergingIterHeap struct {

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -65,7 +65,7 @@ func TestMergingIterSeek(t *testing.T) {
 			iter := newMergingIter(nil /* logger */, &stats, DefaultComparer.Compare,
 				func(a []byte) int { return len(a) }, iters...)
 			defer iter.Close()
-			return runInternalIterCmd(d, iter)
+			return runInternalIterCmd(t, d, iter)
 
 		default:
 			return fmt.Sprintf("unknown command: %s", d.Cmd)
@@ -124,7 +124,7 @@ func TestMergingIterNextPrev(t *testing.T) {
 					iter := newMergingIter(nil /* logger */, &stats, DefaultComparer.Compare,
 						func(a []byte) int { return len(a) }, iters...)
 					defer iter.Close()
-					return runInternalIterCmd(d, iter)
+					return runInternalIterCmd(t, d, iter)
 
 				default:
 					return fmt.Sprintf("unknown command: %s", d.Cmd)
@@ -260,7 +260,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 			miter := &mergingIter{}
 			miter.init(nil /* opts */, &stats, cmp, func(a []byte) int { return len(a) }, levelIters...)
 			defer miter.Close()
-			return runInternalIterCmd(d, miter, iterCmdVerboseKey, iterCmdStats(&stats))
+			return runInternalIterCmd(t, d, miter, iterCmdVerboseKey, iterCmdStats(&stats))
 		default:
 			return fmt.Sprintf("unknown command: %s", d.Cmd)
 		}
@@ -525,7 +525,7 @@ func buildLevelsForMergingIterSeqSeek(
 		}
 	}
 
-	opts := sstable.ReaderOptions{Cache: NewCache(128 << 20)}
+	opts := sstable.ReaderOptions{Cache: NewCache(128 << 20), Comparer: DefaultComparer}
 	if writeBloomFilters {
 		opts.Filters = make(map[string]FilterPolicy)
 		opts.Filters[filterPolicy.Name()] = filterPolicy

--- a/range_keys.go
+++ b/range_keys.go
@@ -438,8 +438,8 @@ var _ internalIterator = (*lazyCombinedIter)(nil)
 // operations that land in the middle of a range key and must truncate to the
 // user-provided seek key.
 func (i *lazyCombinedIter) initCombinedIteration(
-	dir int8, pointKey *InternalKey, pointValue []byte, seekKey []byte,
-) (*InternalKey, []byte) {
+	dir int8, pointKey *InternalKey, pointValue base.LazyValue, seekKey []byte,
+) (*InternalKey, base.LazyValue) {
 	// Invariant: i.parent.rangeKey is nil.
 	// Invariant: !i.combinedIterState.initialized.
 	if invariants.Enabled {
@@ -556,7 +556,9 @@ func (i *lazyCombinedIter) initCombinedIteration(
 	return i.parent.rangeKey.iiter.InitSeekLT(seekKey, pointKey, pointValue)
 }
 
-func (i *lazyCombinedIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, []byte) {
+func (i *lazyCombinedIter) SeekGE(
+	key []byte, flags base.SeekGEFlags,
+) (*InternalKey, base.LazyValue) {
 	if i.combinedIterState.initialized {
 		return i.parent.rangeKey.iiter.SeekGE(key, flags)
 	}
@@ -569,7 +571,7 @@ func (i *lazyCombinedIter) SeekGE(key []byte, flags base.SeekGEFlags) (*Internal
 
 func (i *lazyCombinedIter) SeekPrefixGE(
 	prefix, key []byte, flags base.SeekGEFlags,
-) (*InternalKey, []byte) {
+) (*InternalKey, base.LazyValue) {
 	if i.combinedIterState.initialized {
 		return i.parent.rangeKey.iiter.SeekPrefixGE(prefix, key, flags)
 	}
@@ -580,7 +582,9 @@ func (i *lazyCombinedIter) SeekPrefixGE(
 	return k, v
 }
 
-func (i *lazyCombinedIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, []byte) {
+func (i *lazyCombinedIter) SeekLT(
+	key []byte, flags base.SeekLTFlags,
+) (*InternalKey, base.LazyValue) {
 	if i.combinedIterState.initialized {
 		return i.parent.rangeKey.iiter.SeekLT(key, flags)
 	}
@@ -591,7 +595,7 @@ func (i *lazyCombinedIter) SeekLT(key []byte, flags base.SeekLTFlags) (*Internal
 	return k, v
 }
 
-func (i *lazyCombinedIter) First() (*InternalKey, []byte) {
+func (i *lazyCombinedIter) First() (*InternalKey, base.LazyValue) {
 	if i.combinedIterState.initialized {
 		return i.parent.rangeKey.iiter.First()
 	}
@@ -602,7 +606,7 @@ func (i *lazyCombinedIter) First() (*InternalKey, []byte) {
 	return k, v
 }
 
-func (i *lazyCombinedIter) Last() (*InternalKey, []byte) {
+func (i *lazyCombinedIter) Last() (*InternalKey, base.LazyValue) {
 	if i.combinedIterState.initialized {
 		return i.parent.rangeKey.iiter.Last()
 	}
@@ -613,7 +617,7 @@ func (i *lazyCombinedIter) Last() (*InternalKey, []byte) {
 	return k, v
 }
 
-func (i *lazyCombinedIter) Next() (*InternalKey, []byte) {
+func (i *lazyCombinedIter) Next() (*InternalKey, base.LazyValue) {
 	if i.combinedIterState.initialized {
 		return i.parent.rangeKey.iiter.Next()
 	}
@@ -624,7 +628,7 @@ func (i *lazyCombinedIter) Next() (*InternalKey, []byte) {
 	return k, v
 }
 
-func (i *lazyCombinedIter) Prev() (*InternalKey, []byte) {
+func (i *lazyCombinedIter) Prev() (*InternalKey, base.LazyValue) {
 	if i.combinedIterState.initialized {
 		return i.parent.rangeKey.iiter.Prev()
 	}

--- a/sstable/block_property.go
+++ b/sstable/block_property.go
@@ -61,19 +61,25 @@ import (
 //      re-applying the kv filter while reading results back from Pebble.
 //
 //   b) Block property filtering may surface deleted key-value pairs if the
-//      the kv filter is not a strict function of the key's user key. A block
+//      kv filter is not a strict function of the key's user key. A block
 //      containing k.DEL may be filtered, while a block containing the deleted
 //      key k.SET may not be filtered, if the kv filter applies to one but not
 //      the other.
 //
 //      This error may be avoided trivially by using a kv filter that is a pure
-//      function of the the user key. A filter that examines values or key kinds
+//      function of the user key. A filter that examines values or key kinds
 //      requires care to ensure F(k.SET, <value>) = F(k.DEL) = F(k.SINGLEDEL).
 //
 // The combination of range deletions and filtering by table-level properties
 // add another opportunity for deleted point keys to be surfaced. The pebble
 // Iterator stack takes care to correctly apply filtered tables' range deletions
 // to lower tables, preventing this form of nondeterministic error.
+//
+// In addition to the non-determinism discussed in (b), which limits the use
+// of properties over values, we now have support for values that are not
+// stored together with the key, and may not even be retrieved during
+// compactions. If Pebble is configured with such value separation, block
+// properties must only apply to the key, and will be provided a nil value.
 
 // BlockPropertyCollector is used when writing a sstable.
 // - All calls to Add are included in the next FinishDataBlock, after which

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -939,7 +939,7 @@ func TestBlockProperties(t *testing.T) {
 					var i int
 					iter, _ := newBlockIter(r.Compare, indexH.Get())
 					for key, value := iter.First(); key != nil; key, value = iter.Next() {
-						bh, err := decodeBlockHandleWithProperties(value)
+						bh, err := decodeBlockHandleWithProperties(value.InPlaceValue())
 						if err != nil {
 							return err.Error()
 						}
@@ -1299,7 +1299,7 @@ func runBlockPropsCmd(r *Reader, td *datadriven.TestData) string {
 
 	for key, val := i.First(); key != nil; key, val = i.Next() {
 		sb.WriteString(fmt.Sprintf("%s:\n", key))
-		bhp, err := decodeBlockHandleWithProperties(val)
+		bhp, err := decodeBlockHandleWithProperties(val.InPlaceValue())
 		if err != nil {
 			return err.Error()
 		}
@@ -1321,7 +1321,7 @@ func runBlockPropsCmd(r *Reader, td *datadriven.TestData) string {
 			}
 			for key, value := subiter.First(); key != nil; key, value = subiter.Next() {
 				sb.WriteString(fmt.Sprintf("  %s:\n", key))
-				dataBH, err := decodeBlockHandleWithProperties(value)
+				dataBH, err := decodeBlockHandleWithProperties(value.InPlaceValue())
 				if err != nil {
 					return err.Error()
 				}

--- a/sstable/raw_block.go
+++ b/sstable/raw_block.go
@@ -33,7 +33,8 @@ func (w *rawBlockWriter) add(key InternalKey, value []byte) {
 // keys are stored in "raw" format (i.e. not as internal keys). Note that there
 // is significant similarity between this code and the code in blockIter. Yet
 // reducing duplication is difficult due to the blockIter being performance
-// critical.
+// critical. rawBlockIter must only be used for blocks where the value is
+// stored together with the key.
 type rawBlockIter struct {
 	cmp         Compare
 	offset      int32
@@ -146,19 +147,6 @@ func (i *rawBlockIter) SeekGE(key []byte) bool {
 		}
 	}
 	return i.Valid()
-}
-
-// SeekPrefixGE implements internalIterator.SeekPrefixGE, as documented in the
-// pebble package.
-func (i *rawBlockIter) SeekPrefixGE(key []byte) bool {
-	// This should never be called as prefix iteration is never used with raw blocks.
-	panic("pebble: SeekPrefixGE unimplemented")
-}
-
-// SeekLT implements internalIterator.SeekLT, as documented in the pebble
-// package.
-func (i *rawBlockIter) SeekLT(key []byte) bool {
-	panic("pebble/table: SeekLT unimplemented")
 }
 
 // First implements internalIterator.First, as documented in the pebble

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -178,7 +178,8 @@ func rewriteBlocks(
 			copy(scratch.UserKey, key.UserKey[:si])
 			copy(scratch.UserKey[si:], to)
 
-			bw.add(scratch, val)
+			v := val.InPlaceValue()
+			bw.add(scratch, v)
 			if output[i].start.UserKey == nil {
 				keyAlloc, output[i].start = cloneKeyWithBuf(scratch, keyAlloc)
 			}
@@ -410,7 +411,11 @@ func RewriteKeySuffixesViaWriter(
 		scratch.UserKey = append(scratch.UserKey, to...)
 		scratch.Trailer = k.Trailer
 
-		if w.addPoint(scratch, v); err != nil {
+		val, _, err := v.Value(nil)
+		if err != nil {
+			return nil, err
+		}
+		if w.addPoint(scratch, val); err != nil {
 			return nil, err
 		}
 		k, v = i.Next()

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -665,7 +665,9 @@ func TestWriterRace(t *testing.T) {
 			ki := 0
 			for k, v := it.First(); k != nil; k, v = it.Next() {
 				require.Equal(t, k.UserKey, keys[ki])
-				require.Equal(t, v, val)
+				vBytes, _, err := v.Value(nil)
+				require.NoError(t, err)
+				require.Equal(t, vBytes, val)
 				ki++
 			}
 		}()

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -458,7 +458,11 @@ func testTableCacheRandomAccess(t *testing.T, concurrent bool) {
 				errc <- errors.Errorf("i=%d, fileNum=%d: valid.0: got false, want true", i, fileNum)
 				return
 			}
-			if got := len(value); got != fileNum {
+			v, _, err := value.Value(nil)
+			if err != nil {
+				errc <- errors.Errorf("i=%d, fileNum=%d: err extracting value: %v", err)
+			}
+			if got := len(v); got != fileNum {
 				errc <- errors.Errorf("i=%d, fileNum=%d: value: got %d bytes, want %d", i, fileNum, got, fileNum)
 				return
 			}

--- a/tool/find.go
+++ b/tool/find.go
@@ -469,13 +469,16 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 				if key != nil &&
 					(rangeDel == nil || r.Compare(key.UserKey, rangeDel.Start) < 0) {
 					if r.Compare(searchKey, key.UserKey) != 0 {
-						key, value = nil, nil
+						key, value = nil, base.LazyValue{}
 						continue
 					}
-
+					v, _, err := value.Value(nil)
+					if err != nil {
+						return err
+					}
 					refs = append(refs, findRef{
 						key:     key.Clone(),
-						value:   append([]byte(nil), value...),
+						value:   append([]byte(nil), v...),
 						fileNum: fileNum,
 					})
 					key, value = iter.Next()

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -445,7 +445,13 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 				// Pebble default and CockroachDB's comparer.
 				if s.filter == nil || bytes.HasPrefix(key.UserKey, s.filter) {
 					fmt.Fprint(stdout, prefix)
-					formatKeyValue(stdout, s.fmtKey, s.fmtValue, key, value)
+					v, _, err := value.Value(nil)
+					if err != nil {
+						fmt.Fprintf(stdout, "%s%s\n", prefix, err)
+						return
+					}
+					formatKeyValue(stdout, s.fmtKey, s.fmtValue, key, v)
+
 				}
 				if base.InternalCompare(r.Compare, lastKey, *key) >= 0 {
 					fmt.Fprintf(stdout, "%s    WARNING: OUT OF ORDER KEYS!\n", prefix)


### PR DESCRIPTION
…e key

The changes here are plumbing for the read path. The actual write and read path for values stored in value blocks will happen in future PRs.

A ShortAttribute (3 bits) is also introduced, for user-defined attributes about a value. These will be included in the 1 byte prefix of the value in the key-value pairs in the sstable (the other 5 bits are for internal use). In CockroachDB, the ShortAttribute will initially be used for marking MVCC tombstones (for which 1 bit is sufficient).

LazyValue can represent either an in-place value (stored with the key) or a value stored in the value section. The interface is general enough for the future where values may be stored in separate files.

LazyValue is used in the InternalIterator interface, such that all positioning calls return (*InternalKey, LazyValue). It is also exposed via the public Iterator for callers that need to remember a recent but not necessarily latest LazyValue, in case they need the actual value in the future. An example is a caller that is iterating in reverse and looking for the latest MVCC version for a key -- it cannot identify the latest MVCC version without stepping to the previous key-value pair e.g. storage.pebbleMVCCScanner in CockroachDB.

There is subtlety in memory management:
- A LazyValue returned by an InternalIterator or Iterator is unstable in that repositioning the iterator will invalidate the memory inside it. A caller wishing to maintain that LazyValue needs to call LazyValue.Clone. Note that this does not fetch the value if it is not in-place.

- A user of an iterator that calls LazyValue.Value wants as much as possible for the returned value byte-slice to point to iterator owned memory.
  - [P1] The underlying iterator that owns that memory also needs a promise from that user that at any time there is at most one value byte-slice that the caller is expecting it to maintain. Otherwise, the underlying iterator has to maintain multiple such byte-slices which results in more complicated and inefficient code. Note that pre-LazyValue this promise was trivially provided by only asking for the value at the current iterator position (so it could certainly point inside the underlying ssblock). For other cases, the user would make a copy of the byte-slice. We are generalizing this promise which allows for more memory allocation optimization.
  - [P2] The underlying iterator, in order to make the promise that it is maintaining the one value byte-slice, also needs a way to know when it is relieved of that promise. It is relieved of that promise by being told that it is being repositioned (this behavior is unchanged by this PR). Specifically, the owner of the value byte-slice is a sstable iterator. Consider the case where the caller has used LazyValue.Clone and repositioned the iterator. In this case the sstable iterator may not even be open. LazyValue.Value will still work (at a higher cost), but since the sstable iterator is not open, it cannot satisfy P2. For this reason, the LazyValue.Value method accepts a caller owned buffer, that the callee will use if needed.