### PR TITLE
sstable: adjust sizeEstimate logic for forthcoming value blocks

### DIFF
--- a/sstable/testdata/size_estimate
+++ b/sstable/testdata/size_estimate
@@ -22,9 +22,16 @@ num_entries
 ----
 1
 
-# After compression, entry only had a size of 3. The total size is the 3, but the
-# max estimated size yet is 4.
-entry_written 3 4 3
+# Compression ratio defaults to 1, so the size of the inflight entry fully
+# counts towards size.
+size
+----
+4
+
+# After compression, entry only had a size of 3. The total size is therefore
+# 3, since this is the first entry. The max estimated size is 4 since we
+# ensure that it is monotonically non decreasing.
+entry_written 3 4
 ----
 4
 
@@ -38,7 +45,7 @@ num_inflight_entries
 0
 
 # Compression ratio is 0.75 at this point. The total size is 3, and the inflight
-# size is 4, so that returned size is uint64(6.75).
+# size is 5, so that returned size is uint64(3 + 0.75*5) = uint64(6.75).
 add_inflight 5
 ----
 6
@@ -71,7 +78,7 @@ num_inflight_entries
 
 # First inflight entry written. The entry didn't get compressed. The total size
 # now is less than 9, but the max estimated size should still be 9.
-entry_written 4 4 4
+entry_written 4 4
 ----
 9
 
@@ -94,16 +101,16 @@ num_written_entries
 ----
 1
 
-# The inflight entry had a size of 5, but the entry added had a size of 3 because
-# of compression/size estimation. The compression ratio is 0.77 at this point.
-# The inflightSize is 8. The true size is 13.16, but the maxEstimatedSize is
-# returned.
-entry_written 7 5 3 
+# The inflight entry had a size of 5, but the entry added had a size of 3
+# because of compression/size estimation. The compression ratio is (4+3)/(4+5)
+# = 0.77 at this point. The inflightSize is 8. The true size is 7+8*0.77 =
+# 13.22, but the maxEstimatedSize is returned.
+entry_written 7 5
 ----
 17
 
 # The inflight size is 0, and the total size is 11.
-entry_written 11 8 4
+entry_written 11 8
 ----
 17
 
@@ -111,8 +118,8 @@ num_written_entries
 ----
 3
 
-# The compression ratio is 0.64, and the inflight size is 20, 20*0.64 = 12.8,
-# so the total size is uint64(12.8 + 11)
+# The compression ratio is (4+3+4)/(4+5+8)=0.647, and the inflight size is 20,
+# 20*0.64 = 12.94, so the total size is uint64(12.94 + 11)
 add_inflight 20
 ----
 23
@@ -121,13 +128,17 @@ num_inflight_entries
 ----
 1
 
-# We can write an entry, but it might not have an inflightSize, because it
-# was never inflight. In such a case, the numInflightEntries, shouldn't be
-# decreased.
-entry_written 11 0 4
+# We can write an entry, which increases the written size from 11 to 19, but
+# it might not have an inflightSize, because it was never inflight. In such a
+# case, the numInflightEntries, shouldn't be decreased.
+entry_written 19 0
 ----
-28
+31
 
 num_inflight_entries
 ----
 1
+
+num_written_entries
+----
+4

--- a/sstable/write_queue.go
+++ b/sstable/write_queue.go
@@ -17,8 +17,6 @@ type writeTask struct {
 	// currIndexBlock is the index block on which indexBlock.add must be called.
 	currIndexBlock *indexBlockBuf
 	indexEntrySep  InternalKey
-	// inflightSize is used to decrement Writer.coordination.sizeEstimate.inflightSize.
-	inflightSize int
 	// inflightIndexEntrySize is used to decrement Writer.indexBlock.sizeEstimate.inflightSize.
 	indexInflightSize int
 	// If the index block is finished, then we set the finishedIndexProps here.
@@ -68,11 +66,6 @@ func (w *writeQueue) performWrite(task *writeTask) error {
 	if bh, err = w.writer.writeCompressedBlock(task.buf.compressed, task.buf.tmp[:]); err != nil {
 		return err
 	}
-
-	// Update the size estimates after writing the data block to disk.
-	w.writer.coordination.sizeEstimate.dataBlockWritten(
-		w.writer.meta.Size, task.inflightSize, int(bh.Length),
-	)
 
 	bhp = BlockHandleWithProperties{BlockHandle: bh, Props: task.buf.dataBlockProps}
 	if err = w.writer.addIndexEntry(


### PR DESCRIPTION
sizeEstimate is used for two purposes: estimating the total compressed size of the data blocks, and estimating the size of the index block. The commentary around sizeEstimate was incomplete in terms of how these use cases behave, which is now clarified (and the "written", "inflight" and "compressed" terms clarified, since they map to different concepts for the index block case).

Additionally, the size estimation of the total compressed data blocks can count a block as "written" once compression is complete, and does not need to wait until the write. This simplification is made now, so there is no need for the mutex to update sizeEstimate in the writeQueue. The mutex path is kept to allow for easy merging of the pending code for parallel compression. The interface is also simplified to not separately pass a finalEntrySize when we know the total size. This will fix the peculiarity with compression ratio 1 for the index block case -- the estimaton there has nothing to do with compression and has to do with the fact that we don't know the key-value size upfront, and we should be properly using the ratio in that case. The interface now has two methods writtenWithTotal and writtenWithDelta, and the caller can use whichever one is more convenient. The writtenWithTotal is more convenient for the index block writing case.

This cleanup is worthwhile in itself, and it also sets us up for the value blocks change where the compressed value blocks will be held in-memory until late in the sstable construction (since the value blocks are written after all the index blocks). We do want to accurately account for their compressed size. That code path will use the writtenWithDelta similar to how we use it now after compressing a data block.