### PR TITLE
crl-release-21.2: metamorphic: use testkeys comparer

### DIFF
--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -18,6 +18,8 @@ var comparer = func() pebble.Comparer {
 	c.Split = func(a []byte) int {
 		return len(a)
 	}
+	// Use the comparer name used by later release branch's comparer.
+	c.Name = "pebble.internal.testkeys"
 	return c
 }()
 


### PR DESCRIPTION
Use the testkeys comparer name so that opening a metamorphic test database with a later version of Pebble does not mistakenly think the comparers are incompatible.

Informs #2018.