### PR TITLE
[crl-release-22.1] metamorphic: Copy data/wal dirs from initial state

### DIFF
--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -273,13 +273,13 @@ func randomOptions(rng *rand.Rand) *testOptions {
 	return testOpts
 }
 
-func setupInitialState(dir string, testOpts *testOptions) error {
-	// Copy (vfs.Default,<initialStatePath>) to (testOpts.opts.FS,<dir>).
+func setupInitialState(dataDir string, testOpts *testOptions) error {
+	// Copy (vfs.Default,<initialStatePath>/data) to (testOpts.opts.FS,<dataDir>).
 	ok, err := vfs.Clone(
 		vfs.Default,
 		testOpts.opts.FS,
-		testOpts.initialStatePath,
-		dir,
+		vfs.Default.PathJoin(testOpts.initialStatePath, "data"),
+		dataDir,
 		vfs.CloneSync,
 		vfs.CloneSkip(func(filename string) bool {
 			// Skip the archive of historical files, any checkpoints created by
@@ -297,15 +297,15 @@ func setupInitialState(dir string, testOpts *testOptions) error {
 	// database (initialStatePath) could've had wal_dir set, or the current test
 	// options (testOpts) could have wal_dir set, or both.
 	fs := testOpts.opts.FS
-	walDir := fs.PathJoin(dir, "wal")
+	walDir := fs.PathJoin(dataDir, "wal")
 	if err := fs.MkdirAll(walDir, os.ModePerm); err != nil {
 		return err
 	}
 
-	// Copy <dir>/wal/*.log -> <dir>.
-	src, dst := walDir, dir
+	// Copy <dataDir>/wal/*.log -> <dataDir>.
+	src, dst := walDir, dataDir
 	if testOpts.opts.WALDir != "" {
-		// Copy <dir>/*.log -> <dir>/wal.
+		// Copy <dataDir>/*.log -> <dataDir>/wal.
 		src, dst = dst, src
 	}
 	return moveLogs(fs, src, dst)

--- a/internal/metamorphic/options_test.go
+++ b/internal/metamorphic/options_test.go
@@ -5,8 +5,6 @@
 package metamorphic
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/cockroachdb/pebble"
@@ -18,8 +16,9 @@ import (
 func TestSetupInitialState(t *testing.T) {
 	// Construct a small database in the test's TempDir.
 	initialStatePath := t.TempDir()
+	initialDataPath := vfs.Default.PathJoin(initialStatePath, "data")
 	{
-		d, err := pebble.Open(initialStatePath, &pebble.Options{})
+		d, err := pebble.Open(initialDataPath, &pebble.Options{})
 		require.NoError(t, err)
 		const maxKeyLen = 2
 		ks := testkeys.Alpha(maxKeyLen)
@@ -33,7 +32,6 @@ func TestSetupInitialState(t *testing.T) {
 		}
 		require.NoError(t, d.Close())
 	}
-	require.NoError(t, vfs.Default.MkdirAll(filepath.Join(initialStatePath, "wal"), os.ModePerm))
 	ls, err := vfs.Default.List(initialStatePath)
 	require.NoError(t, err)
 
@@ -44,7 +42,7 @@ func TestSetupInitialState(t *testing.T) {
 		initialStatePath: initialStatePath,
 		initialStateDesc: "test",
 	}
-	require.NoError(t, setupInitialState("", opts))
+	require.NoError(t, setupInitialState("data", opts))
 	copied, err := opts.opts.FS.List("")
 	require.NoError(t, err)
 	require.ElementsMatch(t, ls, copied)


### PR DESCRIPTION
Backport of #2018 

Previously, the logic to copy over data and WAL directories from initial state was subtly broken, resulting in the data directory containing the entirety of the "initial state directory" which has the _OPTIONS, history files and WAL directories. Then we'd copy the WAL logs out of the WAL directory into that directory if it existed. This meant we were always starting from a clean initial state, except if the previous state had a WAL directory and in that case we were starting with just the WALs (and no other initial files).

This change corrects that to copy over the initial data directory to the new data directory, and the initial WAL directory to the new data directory if necessary. If the new test options have a WAL directory, the WALs must be moved from the new data directory to the new WAL directory.

Fixes #2011.