### PR TITLE
crl-release-22.2: db: fix FormatPrePebblev1Marked migration

### DIFF
--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -85,10 +85,10 @@ sync: wal/000002.log
 close: wal/000002.log
 create: wal/000005.log
 sync: wal
-[JOB 4] WAL created 000005
-[JOB 5] flushing 1 memtable to L0
+[JOB 6] WAL created 000005
+[JOB 7] flushing 1 memtable to L0
 create: db/000006.sst
-[JOB 5] flushing: sstable created 000006
+[JOB 7] flushing: sstable created 000006
 sync: db/000006.sst
 close: db/000006.sst
 sync: db
@@ -98,9 +98,9 @@ sync: db/MANIFEST-000007
 create: db/marker.manifest.000003.MANIFEST-000007
 close: db/marker.manifest.000003.MANIFEST-000007
 sync: db
-[JOB 5] MANIFEST created 000007
-[JOB 5] flushed 1 memtable to L0 [000006] (770 B), in 1.0s (2.0s total), output rate 770 B/s
-[JOB 5] MANIFEST deleted 000001
+[JOB 7] MANIFEST created 000007
+[JOB 7] flushed 1 memtable to L0 [000006] (770 B), in 1.0s (2.0s total), output rate 770 B/s
+[JOB 7] MANIFEST deleted 000001
 
 compact
 ----
@@ -109,10 +109,10 @@ sync: wal/000005.log
 close: wal/000005.log
 reuseForWrite: wal/000002.log -> wal/000008.log
 sync: wal
-[JOB 6] WAL created 000008 (recycled 000002)
-[JOB 7] flushing 1 memtable to L0
+[JOB 8] WAL created 000008 (recycled 000002)
+[JOB 9] flushing 1 memtable to L0
 create: db/000009.sst
-[JOB 7] flushing: sstable created 000009
+[JOB 9] flushing: sstable created 000009
 sync: db/000009.sst
 close: db/000009.sst
 sync: db
@@ -122,12 +122,12 @@ sync: db/MANIFEST-000010
 create: db/marker.manifest.000004.MANIFEST-000010
 close: db/marker.manifest.000004.MANIFEST-000010
 sync: db
-[JOB 7] MANIFEST created 000010
-[JOB 7] flushed 1 memtable to L0 [000009] (770 B), in 1.0s (2.0s total), output rate 770 B/s
-[JOB 7] MANIFEST deleted 000003
-[JOB 8] compacting(default) L0 [000006 000009] (1.5 K) + L6 [] (0 B)
+[JOB 9] MANIFEST created 000010
+[JOB 9] flushed 1 memtable to L0 [000009] (770 B), in 1.0s (2.0s total), output rate 770 B/s
+[JOB 9] MANIFEST deleted 000003
+[JOB 10] compacting(default) L0 [000006 000009] (1.5 K) + L6 [] (0 B)
 create: db/000011.sst
-[JOB 8] compacting: sstable created 000011
+[JOB 10] compacting: sstable created 000011
 sync: db/000011.sst
 close: db/000011.sst
 sync: db
@@ -137,11 +137,11 @@ sync: db/MANIFEST-000012
 create: db/marker.manifest.000005.MANIFEST-000012
 close: db/marker.manifest.000005.MANIFEST-000012
 sync: db
-[JOB 8] MANIFEST created 000012
-[JOB 8] compacted(default) L0 [000006 000009] (1.5 K) + L6 [] (0 B) -> L6 [000011] (770 B), in 1.0s (2.0s total), output rate 770 B/s
-[JOB 8] sstable deleted 000006
-[JOB 8] sstable deleted 000009
-[JOB 8] MANIFEST deleted 000007
+[JOB 10] MANIFEST created 000012
+[JOB 10] compacted(default) L0 [000006 000009] (1.5 K) + L6 [] (0 B) -> L6 [000011] (770 B), in 1.0s (2.0s total), output rate 770 B/s
+[JOB 10] sstable deleted 000006
+[JOB 10] sstable deleted 000009
+[JOB 10] MANIFEST deleted 000007
 
 disable-file-deletions
 ----
@@ -153,10 +153,10 @@ sync: wal/000008.log
 close: wal/000008.log
 reuseForWrite: wal/000005.log -> wal/000013.log
 sync: wal
-[JOB 9] WAL created 000013 (recycled 000005)
-[JOB 10] flushing 1 memtable to L0
+[JOB 11] WAL created 000013 (recycled 000005)
+[JOB 12] flushing 1 memtable to L0
 create: db/000014.sst
-[JOB 10] flushing: sstable created 000014
+[JOB 12] flushing: sstable created 000014
 sync: db/000014.sst
 close: db/000014.sst
 sync: db
@@ -166,17 +166,17 @@ sync: db/MANIFEST-000015
 create: db/marker.manifest.000006.MANIFEST-000015
 close: db/marker.manifest.000006.MANIFEST-000015
 sync: db
-[JOB 10] MANIFEST created 000015
-[JOB 10] flushed 1 memtable to L0 [000014] (770 B), in 1.0s (2.0s total), output rate 770 B/s
+[JOB 12] MANIFEST created 000015
+[JOB 12] flushed 1 memtable to L0 [000014] (770 B), in 1.0s (2.0s total), output rate 770 B/s
 
 enable-file-deletions
 ----
-[JOB 11] MANIFEST deleted 000010
+[JOB 13] MANIFEST deleted 000010
 
 ingest
 ----
 link: ext/0 -> db/000016.sst
-[JOB 12] ingesting: sstable created 000016
+[JOB 14] ingesting: sstable created 000016
 sync: db
 create: db/MANIFEST-000017
 close: db/MANIFEST-000015
@@ -184,9 +184,9 @@ sync: db/MANIFEST-000017
 create: db/marker.manifest.000007.MANIFEST-000017
 close: db/marker.manifest.000007.MANIFEST-000017
 sync: db
-[JOB 12] MANIFEST created 000017
-[JOB 12] MANIFEST deleted 000012
-[JOB 12] ingested L0:000016 (825 B)
+[JOB 14] MANIFEST created 000017
+[JOB 14] MANIFEST deleted 000012
+[JOB 14] ingested L0:000016 (825 B)
 
 metrics
 ----


### PR DESCRIPTION
Cockroach 22.2 backport of #2020.

----

Fix the FormatPrePebblev1Marked migration to tolerate concurrent file deletions by disabling physical deletion of files removed from the LSM until the migration completes.

Fix #2019.
Informs cockroachdb/cockroach#89755.
Informs cockroachdb/cockroach#83079.