### PR TITLE
scripts: default to a 30m timeout in non-stress run-crossversion-meta.sh

### DIFF
--- a/scripts/run-crossversion-meta.sh
+++ b/scripts/run-crossversion-meta.sh
@@ -22,7 +22,7 @@ done
 git checkout master
 
 if [[ -z "${STRESS}" ]]; then
-    go test ./internal/metamorphic/crossversion -test.v -test.run 'TestMetaCrossVersion$' $(echo $VERSIONS)
+    go test ./internal/metamorphic/crossversion -test.v -test.timeout "${TIMEOUT:-30m}" -test.run 'TestMetaCrossVersion$' $(echo $VERSIONS)
 else
     stress -p 1 go test ./internal/metamorphic/crossversion -test.v -test.timeout "${TIMEOUT:-30m}" -test.run 'TestMetaCrossVersion$' $(echo $VERSIONS)
 fi


### PR DESCRIPTION
When I added the script, I seem to have accidentally only added the explicit test timeout to the STRESS=1 command.