### PR TITLE
[crl-release-22.1] metamorphic: Flush before close if DisableWAL is true

### DIFF
--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -88,6 +88,12 @@ type closeOp struct {
 
 func (o *closeOp) run(t *test, h *history) {
 	c := t.getCloser(o.objID)
+	if o.objID.tag() == dbTag && t.opts.DisableWAL {
+		// Special case: If WAL is disabled, do a flush right before DB Close. This
+		// allows us to reuse this run's data directory as initial state for
+		// future runs without losing any mutations.
+		_ = t.db.Flush()
+	}
 	t.clearObj(o.objID)
 	err := c.Close()
 	h.Recordf("%s // %v", o, err)


### PR DESCRIPTION
Backport of #2028

Now that we're using the state of one metamorphic test run as initial state for future metamorphic test runs with the crossversion test, we've noticed an incompatibility if the initial state belonged to a DB with WAL disabled. We'd drop the mutations since the last flush, as those would not be written to a WAL or sstable.

Explicitly do a pre-Close Flush() of the db if DisableWAL is true.