### PR TITLE
.github: renable crossversion metamorphic CI action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,6 @@ jobs:
     - run: make test generate
 
   linux-crossversion:
-    if: ${{ false }} # disabled in PR 2018 until further investigation
     name: go-linux-crossversion
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This CI action was temporarily disabled while it was being fixed. It can now be reenabled.