### PR TITLE
*: Enable linux-crossversion test in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,6 @@ jobs:
     - run: make test generate
 
   linux-crossversion:
-    if: ${{ false }} # disabled in PR 2018 until further investigation
     name: go-linux-crossversion
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This change re-enables the crossversion test in github actions CI after it was disabled in #2018. This test seems to generally pass now, after a bunch of recent changes to iron out kinks.