### PR TITLE
replay: collect tables and manifests from workloads

### DIFF
--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -90,7 +90,8 @@ func newPebbleDB(dir string) DB {
 	opts.EnsureDefaults()
 
 	if verbose {
-		opts.EventListener = pebble.MakeLoggingEventListener(nil)
+		lel := pebble.MakeLoggingEventListener(nil)
+		opts.EventListener = &lel
 		opts.EventListener.TableDeleted = nil
 		opts.EventListener.TableIngested = nil
 		opts.EventListener.WALCreated = nil

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1906,7 +1906,7 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 		opts := &Options{
 			FS:         vfs.NewMem(),
 			DebugCheck: DebugCheckLevels,
-			EventListener: EventListener{
+			EventListener: &EventListener{
 				CompactionEnd: func(info CompactionInfo) {
 					if compactInfo != nil {
 						return
@@ -2176,7 +2176,7 @@ func TestCompactionTombstones(t *testing.T) {
 				opts := &Options{
 					FS:         vfs.NewMem(),
 					DebugCheck: DebugCheckLevels,
-					EventListener: EventListener{
+					EventListener: &EventListener{
 						CompactionEnd: func(info CompactionInfo) {
 							compactInfo = &info
 						},
@@ -2384,7 +2384,7 @@ func TestCompactionReadTriggered(t *testing.T) {
 				opts := &Options{
 					FS:         vfs.NewMem(),
 					DebugCheck: DebugCheckLevels,
-					EventListener: EventListener{
+					EventListener: &EventListener{
 						CompactionEnd: func(info CompactionInfo) {
 							compactInfo = &info
 						},
@@ -2854,7 +2854,7 @@ func TestCompactionErrorCleanup(t *testing.T) {
 	opts := &Options{
 		FS:     errorfs.Wrap(mem, ii),
 		Levels: make([]LevelOptions, numLevels),
-		EventListener: EventListener{
+		EventListener: &EventListener{
 			TableCreated: func(info TableCreateInfo) {
 				t.Log(info)
 
@@ -3146,7 +3146,7 @@ func TestFlushInvariant(t *testing.T) {
 					d, err := Open("", testingRandomized(&Options{
 						DisableWAL: disableWAL,
 						FS:         vfs.NewMem(),
-						EventListener: EventListener{
+						EventListener: &EventListener{
 							BackgroundError: func(err error) {
 								select {
 								case errCh <- err:
@@ -3352,7 +3352,7 @@ func TestFlushError(t *testing.T) {
 	}))
 	d, err := Open("", testingRandomized(&Options{
 		FS: fs,
-		EventListener: EventListener{
+		EventListener: &EventListener{
 			BackgroundError: func(err error) {
 				t.Log(err)
 			},
@@ -3657,7 +3657,7 @@ func TestMarkedForCompaction(t *testing.T) {
 		DebugCheck:                  DebugCheckLevels,
 		DisableAutomaticCompactions: true,
 		FormatMajorVersion:          FormatNewest,
-		EventListener: EventListener{
+		EventListener: &EventListener{
 			CompactionEnd: func(info CompactionInfo) {
 				// Fix the job ID and durations for determinism.
 				info.JobID = 100
@@ -3840,7 +3840,7 @@ func TestCompaction_LogAndApplyFails(t *testing.T) {
 			// file creation, into which errors can be injected.
 			MaxManifestFileSize: 1,
 			Logger:              logger,
-			EventListener: EventListener{
+			EventListener: &EventListener{
 				BackgroundError: func(err error) {
 					if bgFn != nil {
 						bgFn(db, err)

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -142,10 +142,11 @@ func TestEventListener(t *testing.T) {
 		switch td.Cmd {
 		case "open":
 			buf.Reset()
+			lel := MakeLoggingEventListener(&buf)
 			opts := &Options{
 				FS:                    loggingFS{mem, &buf},
 				FormatMajorVersion:    FormatNewest,
-				EventListener:         MakeLoggingEventListener(&buf),
+				EventListener:         &lel,
 				MaxManifestFileSize:   1,
 				L0CompactionThreshold: 10,
 				WALDir:                "wal",
@@ -290,7 +291,7 @@ func TestWriteStallEvents(t *testing.T) {
 			createReleased := make(chan struct{}, flushCount)
 			var buf syncedBuffer
 			var delayOnce sync.Once
-			listener := EventListener{
+			listener := &EventListener{
 				TableCreated: func(info TableCreateInfo) {
 					if c.delayFlush == (info.Reason == "flushing") {
 						delayOnce.Do(func() {

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -257,7 +257,7 @@ func TestSplitUserKeyMigration(t *testing.T) {
 				}
 				opts = &Options{
 					FormatMajorVersion: FormatBlockPropertyCollector,
-					EventListener: EventListener{
+					EventListener: &EventListener{
 						CompactionEnd: func(info CompactionInfo) {
 							// Fix the job ID and durations for determinism.
 							info.JobID = 100

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -638,7 +638,7 @@ func TestIngest(t *testing.T) {
 			L0CompactionThreshold: 100,
 			L0StopWritesThreshold: 100,
 			DebugCheck:            DebugCheckLevels,
-			EventListener: EventListener{FlushEnd: func(info FlushInfo) {
+			EventListener: &EventListener{FlushEnd: func(info FlushInfo) {
 				flushed = true
 			}},
 			FormatMajorVersion: FormatNewest,
@@ -826,8 +826,9 @@ func TestIngestIdempotence(t *testing.T) {
 func TestIngestCompact(t *testing.T) {
 	var buf syncedBuffer
 	mem := vfs.NewMem()
+	lel := MakeLoggingEventListener(&buf)
 	d, err := Open("", &Options{
-		EventListener:         MakeLoggingEventListener(&buf),
+		EventListener:         &lel,
 		FS:                    mem,
 		L0CompactionThreshold: 1,
 		L0StopWritesThreshold: 1,
@@ -921,7 +922,7 @@ func TestConcurrentIngestCompact(t *testing.T) {
 			compactionBegin := make(chan struct{})
 			d, err := Open("", &Options{
 				FS: mem,
-				EventListener: EventListener{
+				EventListener: &EventListener{
 					TableCreated: func(info TableCreateInfo) {
 						if info.Reason == "compacting" {
 							close(compactionReady)
@@ -1609,7 +1610,7 @@ func TestIngestValidation(t *testing.T) {
 			opts := &Options{
 				FS:     fs,
 				Logger: logger,
-				EventListener: EventListener{
+				EventListener: &EventListener{
 					TableValidated: func(i TableValidatedInfo) {
 						wg.Done()
 					},

--- a/internal/metamorphic/test.go
+++ b/internal/metamorphic/test.go
@@ -53,7 +53,8 @@ func (t *test) init(h *history, dir string, testOpts *testOptions) error {
 	}
 	t.opts = testOpts.opts.EnsureDefaults()
 	t.opts.Logger = h
-	t.opts.EventListener = pebble.MakeLoggingEventListener(t.opts.Logger)
+	lel := pebble.MakeLoggingEventListener(t.opts.Logger)
+	t.opts.EventListener = &lel
 	t.opts.DebugCheck = func(db *pebble.DB) error {
 		// Wrap the ordinary DebugCheckLevels with retrying
 		// of injected errors.

--- a/options.go
+++ b/options.go
@@ -467,7 +467,7 @@ type Options struct {
 
 	// EventListener provides hooks to listening to significant DB events such as
 	// flushes, compactions, and table deletion.
-	EventListener EventListener
+	EventListener *EventListener
 
 	// Experimental contains experimental options which are off by default.
 	// These options are temporary and will eventually either be deleted, moved
@@ -935,6 +935,9 @@ func (o *Options) EnsureDefaults() *Options {
 	}
 	if o.Logger == nil {
 		o.Logger = DefaultLogger
+	}
+	if o.EventListener == nil {
+		o.EventListener = &EventListener{}
 	}
 	o.EventListener.EnsureDefaults(o.Logger)
 	if o.MaxManifestFileSize == 0 {

--- a/replay/workload_capture.go
+++ b/replay/workload_capture.go
@@ -1,0 +1,380 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package replay
+
+import (
+	"io"
+	"sync"
+	"sync/atomic"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+type workloadCaptureState uint8
+
+const (
+	obsolete = workloadCaptureState(1) << iota
+	readyForProcessing
+	capturedSuccessfully
+)
+
+func (wcs workloadCaptureState) is(flag workloadCaptureState) bool { return wcs&flag != 0 }
+
+type manifestDetails struct {
+	sourceFilepath string
+	sourceFile     vfs.File
+
+	destFile vfs.File
+}
+
+// WorkloadCollector is designed to capture workloads by handling manifest
+// files, flushed SSTs and ingested SSTs. The collector hooks into the
+// pebble.EventListener and pebble.Cleaner in order keep track of file states.
+type WorkloadCollector struct {
+	mu struct {
+		sync.Mutex
+
+		fileState         map[string]workloadCaptureState
+		sstablesToProcess []string
+
+		manifestIndex int
+
+		// appending to manifests requires holding mu however reading data does not.
+		manifests []*manifestDetails
+	}
+
+	// Stores the current manifest that is being used by the database. Updated
+	// atomically.
+	curManifest uint64
+
+	// A boolean represented as an atomic uint32 that stores whether the workload
+	// collector is enabled.
+	enabled uint32
+
+	buffer []byte
+
+	// configuration contains information that is only set on the creation of the
+	// WorkloadCollector.
+	configuration struct {
+		// srcFS and srcDir represent the location from which the workload collector
+		// collects the files from.
+		srcFS  vfs.FS
+		srcDir string
+
+		// destFS and destDir represent the location to which the workload collector
+		// sends the files to.
+		destFS  vfs.FS
+		destDir string
+
+		// cleaner stores the cleaner to use when files become obsolete and need to
+		// be cleaned.
+		cleaner base.Cleaner
+	}
+
+	fileListener struct {
+		sync.Cond
+		stopFileListener bool
+	}
+}
+
+// NewWorkloadCollector is used externally to create a New WorkloadCollector.
+func NewWorkloadCollector(srcDir string) *WorkloadCollector {
+	wc := &WorkloadCollector{}
+	wc.buffer = make([]byte, 1<<10 /* 1KB */)
+
+	wc.configuration.srcDir = srcDir
+
+	wc.mu.fileState = make(map[string]workloadCaptureState)
+	wc.fileListener.Cond.L = &wc.mu.Mutex
+	return wc
+}
+
+// Attach is used to set up the WorkloadCollector by attaching itself to
+// pebble.Options EventListener and Cleaner.
+func (w *WorkloadCollector) Attach(opts *pebble.Options) {
+	l := pebble.EventListener{
+		FlushEnd:        w.onFlushEnd,
+		ManifestCreated: w.onManifestCreated,
+		TableIngested:   w.onTableIngest,
+	}
+
+	if !opts.EventListener.IsConfigured() {
+		opts.EventListener = l
+	} else {
+		opts.EventListener = pebble.TeeEventListener(opts.EventListener, l)
+	}
+
+	opts.EnsureDefaults()
+	// Replace the original Cleaner with the workload collector's implementation,
+	// which will invoke the original Cleaner, but only once the collector's copied
+	// what it needs.
+	w.configuration.cleaner, opts.Cleaner = opts.Cleaner, w
+	w.configuration.srcFS = opts.FS
+}
+
+// setSSTableAsReadyForProcessing marks a SST as ready for processing and adds
+// it to the list of files to process. Must be called while holding a write
+// lock.
+func (w *WorkloadCollector) setSSTableAsReadyForProcessing(fileNum base.FileNum) {
+	fileName := base.MakeFilename(base.FileTypeTable, fileNum)
+	filePath := makeFilepathWithName(w.configuration.srcFS, w.configuration.srcDir, fileName)
+	w.mu.fileState[fileName] |= readyForProcessing
+	w.mu.sstablesToProcess = append(w.mu.sstablesToProcess, filePath)
+}
+
+// cleanFile calls the cleaner on the specified path and removes the path from
+// the fileState map.
+func (w *WorkloadCollector) cleanFile(fileType base.FileType, path string) error {
+	err := w.configuration.cleaner.Clean(w.configuration.srcFS, fileType, path)
+	if err == nil {
+		w.mu.Lock()
+		delete(w.mu.fileState, w.configuration.srcFS.PathBase(path))
+		w.mu.Unlock()
+	}
+	return err
+}
+
+// Clean deletes files only after they have been processed or are not required
+// for the workload collection.
+func (w *WorkloadCollector) Clean(fs vfs.FS, fileType base.FileType, path string) error {
+	w.mu.Lock()
+	fileName := fs.PathBase(path)
+	if fileState, ok := w.mu.fileState[fileName]; !ok || fileState.is(capturedSuccessfully) {
+		// Delete the file if it has been captured or the file is not important to
+		// capture which means it can be deleted.
+		w.mu.Unlock()
+		return w.cleanFile(fileType, path)
+	}
+	w.mu.fileState[fileName] |= obsolete
+	w.mu.Unlock()
+	return nil
+}
+
+// onTableIngest is a handler that is to be setup on an EventListener and
+// triggered by EventListener.TableIngested calls. It runs through the tables
+// and processes them by calling setSSTableAsReadyForProcessing.
+func (w *WorkloadCollector) onTableIngest(info pebble.TableIngestInfo) {
+	if atomic.LoadUint32(&w.enabled) == 0 {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, table := range info.Tables {
+		w.setSSTableAsReadyForProcessing(table.FileNum)
+	}
+	w.fileListener.Signal()
+}
+
+// onFlushEnd is a handler that is to be setup on an EventListener and triggered
+// by EventListener.FlushEnd calls. It runs through the tables and processes
+// them by calling setSSTableAsReadyForProcessing.
+func (w *WorkloadCollector) onFlushEnd(info pebble.FlushInfo) {
+	if atomic.LoadUint32(&w.enabled) == 0 {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, table := range info.Output {
+		w.setSSTableAsReadyForProcessing(table.FileNum)
+	}
+	w.fileListener.Signal()
+}
+
+// onManifestCreated is a handler that is to be setup on an EventListener and
+// triggered by EventListener.ManifestCreated calls. It sets the state of the
+// newly created manifests file and appends it to a list of manifests files to
+// process.
+func (w *WorkloadCollector) onManifestCreated(info pebble.ManifestCreateInfo) {
+	atomic.StoreUint64(&w.curManifest, uint64(info.FileNum))
+	if atomic.LoadUint32(&w.enabled) == 0 {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// mark the manifest file as ready for processing to prevent it from being
+	// cleaned before we process it.
+	fileName := base.MakeFilename(base.FileTypeManifest, info.FileNum)
+	w.mu.fileState[fileName] |= readyForProcessing
+	w.mu.manifests = append(w.mu.manifests, &manifestDetails{
+		sourceFilepath: info.Path,
+	})
+}
+
+// filesToProcessWatcher runs and performs the collection of the files of
+// interest.
+func (w *WorkloadCollector) filesToProcessWatcher() {
+	w.mu.Lock() // lock [1]
+	for !w.fileListener.stopFileListener {
+		// The following performs the workload capture. It waits on a condition
+		// variable (fileListener) to let it know when new files are available to be
+		// collected.
+		if len(w.mu.sstablesToProcess) == 0 {
+			w.fileListener.Wait()
+		}
+		// Copied details for manifests
+		index := w.mu.manifestIndex
+		manifestsToProcess := w.mu.manifests[index:]
+		w.mu.Unlock() // lock [1]
+
+		// Process the manifests files.
+		w.processManifests(index, manifestsToProcess)
+
+		w.mu.Lock()
+		// Copied details for SSTs
+		sstablesToProcess := w.mu.sstablesToProcess
+		w.mu.sstablesToProcess = nil
+		w.mu.Unlock()
+
+		// Process the SSTables provided in sstablesToProcess. sstablesToProcess
+		// will be rewritten and cannot be used following this call.
+		w.processSSTables(sstablesToProcess)
+
+		w.mu.Lock() // reset lock for loop [1]
+	}
+	w.mu.Unlock() // unlock for end of loop [1]
+}
+
+// processManifests iterates over the manifests and copies data that has been
+// added to the source.
+func (w *WorkloadCollector) processManifests(startAtIndex int, manifests []*manifestDetails) {
+	destFS := w.configuration.destFS
+	totalManifests := len(manifests)
+
+	for index, manifest := range manifests {
+		if manifest.destFile == nil && manifest.sourceFile == nil {
+			// srcFile and destFile are not opened / created as this is the first time
+			// this manifest is being processed. This method will be updating the
+			// source and destination files as a result it is safe to do so without
+			// holding a lock.
+			var err error
+			manifest.destFile, err = destFS.Create(
+				makeFilepathWithName(destFS, w.configuration.destDir, destFS.PathBase(manifest.sourceFilepath)))
+
+			if err != nil {
+				panic(err)
+			}
+			manifest.sourceFile, err = w.configuration.srcFS.Open(manifest.sourceFilepath)
+			if err != nil {
+				panic(err)
+			}
+		}
+
+		numBytesRead, err := io.CopyBuffer(manifest.destFile, manifest.sourceFile, w.buffer)
+		if err != nil {
+			panic(err)
+		}
+
+		// Read 0 bytes from the current manifest and this is not the latest/newest
+		// manifest which means we have read all the data no new data will be
+		// written to it since it's not the latest one. Close the current source and
+		// destination files and move the manifest to start at the next index in
+		// w.mu.manifests.
+		if numBytesRead == 0 && index != totalManifests-1 {
+			// Rotating the manifests so we can close the files
+			err := w.mu.manifests[index].sourceFile.Close()
+			if err != nil {
+				panic(err)
+			}
+			err = w.mu.manifests[index].destFile.Close()
+			if err != nil {
+				panic(err)
+			}
+			w.mu.Lock()
+			w.mu.manifestIndex = startAtIndex + index + 1
+			w.mu.Unlock()
+		}
+	}
+}
+
+// processSSTables goes through the sstablesToProcess and copies them between
+// srcFS and the destFS. Additionally, each table has its file state updated. If
+// a file has already been marked as obsolete, then file will be cleaned by the
+// w.configuration.cleaner. The sstablesToProcess will be rewritten and should
+// not be used following the call to this function.
+func (w *WorkloadCollector) processSSTables(sstablesToProcess []string) {
+	for _, filePath := range sstablesToProcess {
+		err := vfs.CopyAcrossFS(w.configuration.srcFS,
+			filePath,
+			w.configuration.destFS,
+			makeFilepathWithName(w.configuration.destFS, w.configuration.destDir, w.configuration.srcFS.PathBase(filePath)))
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	// reuse the slice
+	filesToDelete := sstablesToProcess[:0]
+	w.mu.Lock()
+	for _, filePath := range sstablesToProcess {
+		fileName := w.configuration.srcFS.PathBase(filePath)
+		if w.mu.fileState[fileName].is(obsolete) {
+			filesToDelete = append(filesToDelete, fileName)
+		} else {
+			w.mu.fileState[fileName] |= capturedSuccessfully
+		}
+	}
+	w.mu.Unlock()
+
+	for _, filePath := range filesToDelete {
+		err := w.cleanFile(base.FileTypeTable, filePath)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+// Start starts a go routine that listens for new files that
+// need to be collected.
+func (w *WorkloadCollector) Start(destFS vfs.FS, destPath string) {
+	// If the collector not is running then that means w.enabled == 0 so swap it
+	// to 1 and continue else return since it is not running.
+	if !atomic.CompareAndSwapUint32(&w.enabled, 0, 1) {
+		return
+	}
+	w.configuration.destFS = destFS
+	w.configuration.destDir = destPath
+
+	// Take the current manifest and append it to the current slice (empty) of
+	// manifests since it needs to be collected but was created before collection
+	// started.
+	fileNum := base.FileNum(atomic.LoadUint64(&w.curManifest))
+
+	fileName := base.MakeFilename(base.FileTypeManifest, fileNum)
+	filePath := makeFilepathWithName(w.configuration.srcFS, w.configuration.srcDir, fileName)
+	w.mu.manifests = append(w.mu.manifests,
+		&manifestDetails{
+			sourceFilepath: filePath,
+		})
+	w.mu.fileState[fileName] |= readyForProcessing
+
+	go w.filesToProcessWatcher()
+}
+
+// Stop stops the go routine that listens for new files
+// that need to be collected.
+func (w *WorkloadCollector) Stop() {
+	// If the collector is running then that means w.enabled == 1 so swap it to 0
+	// and continue else return since it is not running.
+	if !atomic.CompareAndSwapUint32(&w.enabled, 1, 0) {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.fileListener.stopFileListener = true
+	w.fileListener.Signal()
+}
+
+// IsRunning returns whether the WorkloadCollector is currently running.
+func (w *WorkloadCollector) IsRunning() bool {
+	return atomic.LoadUint32(&w.enabled) == 1
+}
+
+// makeFilepathWithName creates a file path given the file name
+func makeFilepathWithName(fs vfs.FS, dirName, fileName string) string {
+	return fs.PathJoin(dirName, fileName)
+}

--- a/replay/workload_capture.go
+++ b/replay/workload_capture.go
@@ -102,10 +102,11 @@ func (w *WorkloadCollector) Attach(opts *pebble.Options) {
 		TableIngested:   w.onTableIngest,
 	}
 
-	if !opts.EventListener.IsConfigured() {
-		opts.EventListener = l
+	if opts.EventListener == nil {
+		opts.EventListener = &l
 	} else {
-		opts.EventListener = pebble.TeeEventListener(opts.EventListener, l)
+		t := pebble.TeeEventListener(*opts.EventListener, l)
+		opts.EventListener = &t
 	}
 
 	opts.EnsureDefaults()

--- a/replay/workload_capture_test.go
+++ b/replay/workload_capture_test.go
@@ -1,0 +1,505 @@
+package replay
+
+import (
+	"math/rand"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+func newWorkloadCollectorForTest(
+	fs vfs.FS, srcDir string, cleaner base.Cleaner,
+) *WorkloadCollector {
+	collector := NewWorkloadCollector(srcDir)
+	collector.configuration.srcFS = fs
+	collector.configuration.destFS = fs
+	collector.configuration.destDir = "captured"
+	collector.configuration.cleaner = cleaner
+
+	return collector
+}
+
+func createCaptureDir(fs vfs.FS, destDir string) {
+	if err := fs.MkdirAll(destDir, 0755); err != nil {
+		panic(err)
+	}
+}
+
+func TestWorkloadCaptureCleanerNotReadyToClean(t *testing.T) {
+	imfs := vfs.NewMem()
+	filePath := base.MakeFilepath(imfs, "", base.FileTypeTable, 1)
+	f, err := imfs.Create(filePath)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	createCaptureDir(imfs, "captured")
+	collector := newWorkloadCollectorForTest(imfs, "", base.DeleteCleaner{})
+	atomic.StoreUint32(&collector.enabled, 1)
+	collector.onFlushEnd(pebble.FlushInfo{Output: []pebble.TableInfo{{
+		FileNum: 1,
+		Size:    10,
+	}}})
+	err = collector.Clean(imfs, base.FileTypeTable, filePath)
+	require.NoError(t, err)
+	_, err = imfs.Stat(filePath)
+	require.NoError(t, err)
+}
+
+func TestWorkloadCaptureCleanerMarkForClean(t *testing.T) {
+	imfs := vfs.NewMem()
+	filePath := base.MakeFilepath(imfs, "", base.FileTypeTable, 1)
+	f, err := imfs.Create(filePath)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	createCaptureDir(imfs, "captured")
+	collector := newWorkloadCollectorForTest(imfs, "", base.DeleteCleaner{})
+
+	atomic.StoreUint32(&collector.enabled, 1)
+	ch := make(chan struct{})
+	go func() {
+		collector.filesToProcessWatcher()
+		ch <- struct{}{}
+	}()
+
+	collector.onFlushEnd(pebble.FlushInfo{Output: []pebble.TableInfo{{
+		FileNum: 1,
+		Size:    10,
+	}}})
+	collector.mu.Lock()
+	for len(collector.mu.sstablesToProcess) != 0 {
+		collector.mu.Unlock()
+		time.Sleep(time.Microsecond)
+		collector.mu.Lock()
+	}
+	collector.mu.Unlock()
+	collector.Stop()
+	<-ch
+	err = collector.Clean(imfs, base.FileTypeTable, filePath)
+	require.NoError(t, err)
+	_, err = imfs.Stat(filePath)
+	require.Errorf(t, err, "stat 000001.sst: file does not exist")
+}
+
+func TestWorkloadCaptureWatcherDeleteWhenObsolete(t *testing.T) {
+	imfs := vfs.NewMem()
+	filePath := base.MakeFilepath(imfs, "", base.FileTypeTable, 1)
+	f, err := imfs.Create(filePath)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	createCaptureDir(imfs, "captured")
+	collector := newWorkloadCollectorForTest(imfs, "", base.DeleteCleaner{})
+
+	collector.mu.fileState[imfs.PathBase(filePath)] |= readyForProcessing
+	err = collector.Clean(imfs, base.FileTypeTable, filePath)
+	require.NoError(t, err)
+
+	atomic.StoreUint32(&collector.enabled, 1)
+	ch := make(chan struct{})
+	go func() {
+		collector.filesToProcessWatcher()
+		ch <- struct{}{}
+	}()
+
+	collector.onFlushEnd(pebble.FlushInfo{Output: []pebble.TableInfo{{
+		FileNum: 1,
+		Size:    10,
+	}}})
+	collector.mu.Lock()
+	for len(collector.mu.sstablesToProcess) != 0 {
+		collector.mu.Unlock()
+		time.Sleep(time.Microsecond)
+		collector.mu.Lock()
+	}
+	collector.mu.Unlock()
+	collector.Stop()
+	<-ch
+	_, err = imfs.Stat(filePath)
+	require.Errorf(t, err, "stat 000001.sst: file does not exist")
+}
+
+func TestManifestCollection(t *testing.T) {
+	imfs := vfs.NewMem()
+	manifestFilePath := base.MakeFilepath(imfs, "", base.FileTypeManifest, 1)
+	manifestFile, err := imfs.Create(manifestFilePath)
+	require.NoError(t, err)
+
+	const numberOfBytesToWrite = 1024
+	dataToWrite := make([]byte, numberOfBytesToWrite)
+	copyOfFileInputData := make([]byte, numberOfBytesToWrite)
+	rand.Read(dataToWrite)
+	copy(copyOfFileInputData, dataToWrite)
+
+	_, err = manifestFile.Write(dataToWrite)
+	require.NoError(t, err)
+	require.NoError(t, manifestFile.Close())
+
+	tableFilePath := base.MakeFilepath(imfs, "", base.FileTypeTable, 1)
+	tableFile, err := imfs.Create(tableFilePath)
+	require.NoError(t, err)
+	require.NoError(t, tableFile.Close())
+
+	createCaptureDir(imfs, "captured")
+	collector := newWorkloadCollectorForTest(imfs, "", base.DeleteCleaner{})
+
+	ch := make(chan struct{})
+	atomic.StoreUint32(&collector.enabled, 1)
+	go func() {
+		collector.filesToProcessWatcher()
+		ch <- struct{}{}
+	}()
+
+	collector.onManifestCreated(pebble.ManifestCreateInfo{
+		Path:    manifestFilePath,
+		FileNum: 1,
+	})
+	collector.onFlushEnd(pebble.FlushInfo{Output: []pebble.TableInfo{{
+		FileNum: 1,
+		Size:    10,
+	}}})
+	collector.mu.Lock()
+
+	for len(collector.mu.sstablesToProcess) != 0 {
+		collector.mu.Unlock()
+		time.Sleep(time.Microsecond)
+		collector.mu.Lock()
+	}
+	collector.mu.Unlock()
+	collector.Stop()
+	<-ch
+	destFilepath := imfs.PathJoin("captured", imfs.PathBase(collector.mu.manifests[0].sourceFilepath))
+	stat, err := imfs.Stat(destFilepath)
+	require.NoError(t, err)
+	require.Equal(t, int64(numberOfBytesToWrite), stat.Size())
+	f, err := imfs.Open(destFilepath)
+	require.NoError(t, err)
+	fromOutputFile := make([]byte, numberOfBytesToWrite)
+	_, err = f.Read(fromOutputFile)
+	require.NoError(t, err)
+	require.Equal(t, fromOutputFile, copyOfFileInputData)
+}
+
+func TestManifestNumberCollectionBeforeEnable(t *testing.T) {
+	imfs := vfs.NewMem()
+	collector := newWorkloadCollectorForTest(imfs, "", base.DeleteCleaner{})
+	require.Equal(t, uint64(0), collector.curManifest)
+	collector.onManifestCreated(pebble.ManifestCreateInfo{
+		Path:    "",
+		FileNum: 1,
+	})
+	require.Equal(t, uint64(1), collector.curManifest)
+}
+
+func TestManifestCopyingWithChunks(t *testing.T) {
+	imfs := vfs.NewMem()
+	manifestFilePath := base.MakeFilepath(imfs, "", base.FileTypeManifest, 1)
+	manifestFile, err := imfs.Create(manifestFilePath)
+	require.NoError(t, err)
+
+	const numberOfBytesToWrite = 9 << 9
+	dataToWrite := make([]byte, numberOfBytesToWrite)
+	copyOfDataToWrite := make([]byte, numberOfBytesToWrite)
+	rand.Read(dataToWrite)
+	copy(copyOfDataToWrite, dataToWrite)
+
+	_, err = manifestFile.Write(dataToWrite)
+	require.NoError(t, err)
+	require.NoError(t, manifestFile.Close())
+
+	tableFilePath := base.MakeFilepath(imfs, "", base.FileTypeTable, 1)
+	tableFile, err := imfs.Create(tableFilePath)
+	require.NoError(t, err)
+	require.NoError(t, tableFile.Close())
+
+	createCaptureDir(imfs, "captured")
+	collector := newWorkloadCollectorForTest(imfs, "", base.DeleteCleaner{})
+
+	ch := make(chan struct{})
+	atomic.StoreUint32(&collector.enabled, 1)
+	go func() {
+		collector.filesToProcessWatcher()
+		ch <- struct{}{}
+	}()
+
+	collector.onManifestCreated(pebble.ManifestCreateInfo{
+		Path:    manifestFilePath,
+		FileNum: 1,
+	})
+	collector.onFlushEnd(pebble.FlushInfo{Output: []pebble.TableInfo{{
+		FileNum: 1,
+		Size:    10,
+	}}})
+	collector.mu.Lock()
+
+	for len(collector.mu.sstablesToProcess) != 0 {
+		collector.mu.Unlock()
+		time.Sleep(time.Microsecond)
+		collector.mu.Lock()
+	}
+	collector.mu.Unlock()
+	collector.Stop()
+	<-ch
+	destFilepath := imfs.PathJoin("captured", imfs.PathBase(collector.mu.manifests[0].sourceFilepath))
+	stat, err := imfs.Stat(destFilepath)
+	require.NoError(t, err)
+	require.Equal(t, int64(numberOfBytesToWrite), stat.Size())
+	f, err := imfs.Open(destFilepath)
+	require.NoError(t, err)
+	fromOutputFile := make([]byte, numberOfBytesToWrite)
+	_, err = f.Read(fromOutputFile)
+	require.NoError(t, err)
+	require.Equal(t, fromOutputFile, copyOfDataToWrite)
+}
+
+func TestManifestCopyingWithRotation(t *testing.T) {
+	imfs := vfs.NewMem()
+
+	// Manifest 1
+	manifestFilePath1 := base.MakeFilepath(imfs, "", base.FileTypeManifest, 1)
+	manifestFile1, err := imfs.Create(manifestFilePath1)
+	require.NoError(t, err)
+
+	// Manifest 2
+	manifestFilePath2 := base.MakeFilepath(imfs, "", base.FileTypeManifest, 2)
+	manifestFile2, err := imfs.Create(manifestFilePath2)
+	require.NoError(t, err)
+
+	// Manifest 3
+	manifestFilePath3 := base.MakeFilepath(imfs, "", base.FileTypeManifest, 3)
+	manifestFile3, err := imfs.Create(manifestFilePath3)
+	require.NoError(t, err)
+
+	// Write HALF the data to Manifest 1
+	manifest1DataSize := 8338
+	fileInputData1 := make([]byte, manifest1DataSize)
+	copyOfFileInputData1 := make([]byte, manifest1DataSize)
+	rand.Read(fileInputData1)
+	copy(copyOfFileInputData1, fileInputData1)
+	_, err = manifestFile1.Write(fileInputData1[:manifest1DataSize/2])
+	require.NoError(t, err)
+
+	// Write all the data to Manifest 2
+	manifest2DataSize := 6746
+	fileInputData2 := make([]byte, manifest2DataSize)
+	copyOfFileInputData2 := make([]byte, manifest2DataSize)
+	rand.Read(fileInputData2)
+	copy(copyOfFileInputData2, fileInputData2)
+	_, err = manifestFile2.Write(fileInputData2)
+	require.NoError(t, err)
+
+	// Write all the data to Manifest 3
+	manifest3DataSize := 4378
+	fileInputData3 := make([]byte, manifest3DataSize)
+	copyOfFileInputData3 := make([]byte, manifest3DataSize)
+	rand.Read(fileInputData3)
+	copy(copyOfFileInputData3, fileInputData3)
+	_, err = manifestFile3.Write(fileInputData3)
+	require.NoError(t, err)
+
+	// Create table path to trigger the FileHandler
+	tableFilePath := base.MakeFilepath(imfs, "", base.FileTypeTable, 1)
+	tableFile, err := imfs.Create(tableFilePath)
+	require.NoError(t, err)
+	require.NoError(t, tableFile.Close())
+
+	// Create the collector and file handler
+	createCaptureDir(imfs, "captured")
+	collector := newWorkloadCollectorForTest(imfs, "", base.DeleteCleaner{})
+
+	ch := make(chan struct{})
+	atomic.StoreUint32(&collector.enabled, 1)
+	go func() {
+		collector.filesToProcessWatcher()
+		ch <- struct{}{}
+	}()
+
+	// Create the first manifests
+	collector.onManifestCreated(pebble.ManifestCreateInfo{
+		Path:    manifestFilePath1,
+		FileNum: 1,
+	})
+
+	collector.onManifestCreated(pebble.ManifestCreateInfo{
+		Path:    manifestFilePath2,
+		FileNum: 2,
+	})
+
+	// Trigger the Manifest Handler
+	collector.onFlushEnd(pebble.FlushInfo{Output: []pebble.TableInfo{{
+		FileNum: 1,
+		Size:    10,
+	}}})
+
+	collector.mu.Lock()
+	for len(collector.mu.sstablesToProcess) != 0 {
+		collector.mu.Unlock()
+		time.Sleep(time.Microsecond)
+		collector.mu.Lock()
+	}
+	collector.mu.Unlock()
+
+	_, err = manifestFile1.Write(fileInputData1[manifest1DataSize/2:])
+	require.NoError(t, err)
+
+	collector.onManifestCreated(pebble.ManifestCreateInfo{
+		Path:    manifestFilePath3,
+		FileNum: 3,
+	})
+
+	collector.onFlushEnd(pebble.FlushInfo{Output: []pebble.TableInfo{{
+		FileNum: 1,
+		Size:    10,
+	}}})
+
+	collector.mu.Lock()
+	for len(collector.mu.sstablesToProcess) != 0 {
+		collector.mu.Unlock()
+		time.Sleep(time.Microsecond)
+		collector.mu.Lock()
+	}
+	collector.mu.Unlock()
+
+	collector.onFlushEnd(pebble.FlushInfo{Output: []pebble.TableInfo{{
+		FileNum: 1,
+		Size:    10,
+	}}})
+
+	collector.mu.Lock()
+	for len(collector.mu.sstablesToProcess) != 0 {
+		collector.mu.Unlock()
+		time.Sleep(time.Microsecond)
+		collector.mu.Lock()
+	}
+	collector.mu.Unlock()
+
+	collector.Stop()
+	<-ch
+	expectedManifestSize := []int{manifest1DataSize, manifest2DataSize, manifest3DataSize}
+	expectedFileData := [][]byte{copyOfFileInputData1, copyOfFileInputData2, copyOfFileInputData3}
+	require.Len(t, collector.mu.manifests, 3)
+	require.Equal(t, collector.mu.manifestIndex, 2)
+	for i, manifest := range collector.mu.manifests {
+		destFilepath := imfs.PathJoin("captured", imfs.PathBase(manifest.sourceFilepath))
+		manifestStats, err := imfs.Stat(destFilepath)
+		require.NoError(t, err)
+		require.Equal(t, int64(expectedManifestSize[i]), manifestStats.Size())
+		f, err := imfs.Open(destFilepath)
+		require.NoError(t, err)
+		fromOutputFile := make([]byte, expectedManifestSize[i])
+		_, err = f.Read(fromOutputFile)
+		require.NoError(t, err)
+		require.Equal(
+			t,
+			fromOutputFile,
+			expectedFileData[i],
+			"File contents do not match between %s and %s",
+			destFilepath,
+			manifest.sourceFilepath,
+		)
+	}
+}
+
+func TestManifestNotCleanedBeforeOpen(t *testing.T) {
+	imfs := vfs.NewMem()
+	filePath := base.MakeFilepath(imfs, "", base.FileTypeManifest, 1)
+	f, err := imfs.Create(filePath)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	createCaptureDir(imfs, "captured")
+	collector := newWorkloadCollectorForTest(imfs, "", base.DeleteCleaner{})
+	atomic.StoreUint32(&collector.enabled, 1)
+	collector.onManifestCreated(pebble.ManifestCreateInfo{
+		Path:    filePath,
+		FileNum: 1,
+	})
+	err = collector.Clean(imfs, base.FileTypeManifest, filePath)
+	require.NoError(t, err)
+	_, err = imfs.Stat(filePath)
+	require.NoError(t, err)
+}
+
+func TestAttachCollectorToPebble(t *testing.T) {
+	imfs := vfs.NewMem()
+	manifestFilePath := base.MakeFilepath(imfs, "", base.FileTypeManifest, 1)
+	manifestFile, err := imfs.Create(manifestFilePath)
+	require.NoError(t, err)
+	require.NoError(t, manifestFile.Close())
+
+	tableFilePath := base.MakeFilepath(imfs, "", base.FileTypeTable, 1)
+	tableFile, err := imfs.Create(tableFilePath)
+	require.NoError(t, err)
+	require.NoError(t, tableFile.Close())
+
+	collector := newWorkloadCollectorForTest(imfs, "", base.DeleteCleaner{})
+	atomic.StoreUint32(&collector.enabled, 1)
+
+	opts := &pebble.Options{FS: imfs}
+	collector.Attach(opts)
+
+	require.Equal(t, collector, opts.Cleaner)
+	require.NotNil(t, opts.EventListener.TableIngested)
+	require.NotNil(t, opts.EventListener.ManifestCreated)
+	require.NotNil(t, opts.EventListener.FlushEnd)
+}
+
+func TestEnableDisable(t *testing.T) {
+	imfs := vfs.NewMem()
+	createCaptureDir(imfs, "captured")
+	collector := newWorkloadCollectorForTest(imfs, "", base.DeleteCleaner{})
+	type testCase struct{ onFlushEndLength, onTableIngestLength, onManifestLength int }
+	testCases := []testCase{
+		{
+			onFlushEndLength:    0,
+			onTableIngestLength: 0,
+			onManifestLength:    0,
+		},
+		{
+			onFlushEndLength:    1,
+			onTableIngestLength: 2,
+			onManifestLength:    1,
+		},
+	}
+	for _, currentTestCase := range testCases {
+		collector.onFlushEnd(pebble.FlushInfo{Output: []pebble.TableInfo{{
+			FileNum: 1,
+			Size:    10,
+		}}})
+		require.Len(t, collector.mu.sstablesToProcess, currentTestCase.onFlushEndLength)
+		collector.onTableIngest(pebble.TableIngestInfo{
+			Tables: []struct {
+				pebble.TableInfo
+				Level int
+			}{
+				{TableInfo: pebble.TableInfo{
+					FileNum: 1,
+					Size:    10,
+				}, Level: 0},
+			},
+		})
+		require.Len(t, collector.mu.sstablesToProcess, currentTestCase.onTableIngestLength)
+		collector.onManifestCreated(pebble.ManifestCreateInfo{
+			FileNum: 1,
+		})
+		require.Len(t, collector.mu.manifests, currentTestCase.onManifestLength)
+
+		// Enable the WorkloadCollector for the second iteration
+		atomic.StoreUint32(&collector.enabled, 1)
+	}
+}
+
+func TestAtomicStartStop(t *testing.T) {
+	imfs := vfs.NewMem()
+	collector := NewWorkloadCollector("")
+	collector.Stop()
+	require.Equal(t, collector.fileListener.stopFileListener, false)
+	atomic.StoreUint32(&collector.enabled, 1)
+	collector.Start(imfs, "captured")
+	require.NotEqual(t, imfs, collector.configuration.destFS)
+}

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -834,7 +834,7 @@ func TestTableCacheEvictClose(t *testing.T) {
 	db, err := Open("test",
 		&Options{
 			FS: vfs.NewMem(),
-			EventListener: EventListener{
+			EventListener: &EventListener{
 				TableDeleted: func(info TableDeleteInfo) {
 					errs <- info.Err
 				},

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -26,7 +26,7 @@ func TestTableStats(t *testing.T) {
 	var loadedInfo *TableStatsInfo
 	opts := &Options{
 		FS: fs,
-		EventListener: EventListener{
+		EventListener: &EventListener{
 			TableStatsLoaded: func(info TableStatsInfo) {
 				loadedInfo = &info
 			},

--- a/tool/make_test_find_db.go
+++ b/tool/make_test_find_db.go
@@ -30,10 +30,11 @@ func open(fs vfs.FS, dir string) *db {
 	m := *base.DefaultMerger
 	m.Name = "test-merger"
 
+	lel := pebble.MakeLoggingEventListener(pebble.DefaultLogger)
 	d, err := pebble.Open(dir, &pebble.Options{
 		Cleaner:       pebble.ArchiveCleaner{},
 		Comparer:      &c,
-		EventListener: pebble.MakeLoggingEventListener(pebble.DefaultLogger),
+		EventListener: &lel,
 		FS:            fs,
 		Merger:        &m,
 	})

--- a/tool/testdata/mixed/main.go
+++ b/tool/testdata/mixed/main.go
@@ -43,12 +43,13 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	lel := pebble.MakeLoggingEventListener(pebble.DefaultLogger)
 
 	opts := &pebble.Options{
 		FS:                          vfs.Default,
 		Comparer:                    testkeys.Comparer,
 		FormatMajorVersion:          pebble.FormatNewest,
-		EventListener:               pebble.MakeLoggingEventListener(pebble.DefaultLogger),
+		EventListener:               &lel,
 		DisableAutomaticCompactions: true,
 	}
 	db, err := pebble.Open(outDir, opts)

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -268,13 +268,19 @@ func (sequentialReadsOption) Apply(f File) {
 // Copy copies the contents of oldname to newname. If newname exists, it will
 // be overwritten.
 func Copy(fs FS, oldname, newname string) error {
-	src, err := fs.Open(oldname)
+	return CopyAcrossFS(fs, oldname, fs, newname)
+}
+
+// CopyAcrossFS copies the contents of oldname on srcFS to newname dstFS. If
+// newname exists, it will be overwritten.
+func CopyAcrossFS(srcFS FS, oldname string, dstFS FS, newname string) error {
+	src, err := srcFS.Open(oldname)
 	if err != nil {
 		return err
 	}
 	defer src.Close()
 
-	dst, err := fs.Create(newname)
+	dst, err := dstFS.Create(newname)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## replay: collect tables and manifests from workloads

Develop a workload collector that captures tables and manifests from a
workload. The workload collector learns about the tables and manifests
from the `EventListener`. The workload collector exposes an `Attach`
method that  attaches to the pebble `Options`. It also reads and
saves information from the already configured options.

The workload collector replaces the cleaner of a pebble database in
order to ensure that the files that are ready for cleaning do not get
cleaned before the workload collector has a chance to process them.
During the `Attach` call the workload collector will save the originally
provided cleaner. This saved cleaner will be used to perform the final
cleaning once the files the are obsolete for the collector.

When a manifest is created the event listener will be fired which will
trigger the `onManifestCreated` method that will mark the manifest file
as `readyForProcessing`. Additionally this event handler will update the
workload collectors current manifest file number which will be used in
the start method to ensure that the current manifest is copied once
workload collection starts. This is required as workload collection can
be started at any point in time and to collect the workload requires
having the manifest file saved.

Similarly when a table is ingested or flushed the `onTableIngest` and
`onFlushEnd` methods will run that also mark the tables as
`readyForProcessing`.  After the files are marked as
`readyForProcessing` they won’t be cleaned until they are marked as
`obsolete`.

After the files’ states are set the table handlers mentioned above will
signal a go routine that will perform the processing. Note that only the
`onTableIngest` and `onFlushEnd` signal the go routine.

The processing go routine performs the task of copying the tables from
the source `VFS` to a destination `VFS`. It also copies the manifest
files in chunks to the destination `VFS`. The `VFS` interface was chosen
to allow clients flexibility in the location to copy the files to. Once
a table file has been processed it will be marked as `obsolete` and
cleaned by the cleaner.

The processing go routine mentioned above is started by a call to
`Start` which does several key things:

1. It enables the collection handlers by setting the `enabled` atomic as
   `1` (true)  which allows the aforementioned `EventListener` methods
   to update the table/manifest states.
2. Takes the current manifest and adds it to the list of manifests to
   process
3. It starts the processing go routine

Closes: #2050 