### PR TITLE
db: apply TrySeekUsingNext to level metadata

### DIFF
--- a/testdata/level_iter_seek
+++ b/testdata/level_iter_seek
@@ -306,11 +306,11 @@ j.SET.7:j
 
 # Seeks to immediately following keys.
 iter
-seek-prefix-ge a true
+seek-prefix-ge a false
 seek-prefix-ge a true
 seek-prefix-ge b true
 next
-seek-prefix-ge c true
+seek-prefix-ge c false
 seek-prefix-ge d true
 seek-prefix-ge f true
 seek-prefix-ge g true
@@ -332,7 +332,7 @@ j/<invalid>#7,1:j
 
 # Seeks to keys that are in the next file, so cannot use Next.
 iter
-seek-prefix-ge a true
+seek-prefix-ge a false
 seek-prefix-ge e true
 seek-prefix-ge i true
 seek-prefix-ge j true


### PR DESCRIPTION
When TrySeekUsingNext=true, the iterator knows the current seek key must
be greater than or equal to the key at the current iterator position.
This knowledge can be used by level iterators to avoid re-seeking within
the level metadata, under the expectation that the seek key is proximate
and Next-ing will require fewer key comparisons.

Like other TrySeekUsingNext optimizations, this optimization falls back to
seeking if several Nexts does not appropriately position the iterator.  The
fallback seek is expected to be rare in real-world use cases that typically
seek within a limited area of the keyspace (eg, within a single Cockroach KV
range).

The MVCCScan microbenchmarks show an improvement of 1-19% with 64-byte value
sizes. I expect the true benefit to be higher with large, realistic LSMs that
have more files.

```
name                                                                           old speed      new speed      delta
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=0-24               6.73MB/s ± 2%  7.01MB/s ± 3%   +4.23%  (p=0.000 n=10+9)
MVCCScan_Pebble/rows=1/versions=2/valueSize=64/numRangeKeys=0-24               5.33MB/s ± 2%  5.68MB/s ± 2%   +6.56%  (p=0.000 n=9+10)
MVCCScan_Pebble/rows=1/versions=10/valueSize=64/numRangeKeys=0-24              3.20MB/s ± 4%  3.55MB/s ± 1%  +10.94%  (p=0.000 n=10+9)
MVCCScan_Pebble/rows=1/versions=100/valueSize=64/numRangeKeys=0-24             1.47MB/s ± 3%  1.65MB/s ± 2%  +12.59%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=10/versions=1/valueSize=64/numRangeKeys=0-24              44.2MB/s ± 3%  46.2MB/s ± 3%   +4.70%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=10/versions=2/valueSize=64/numRangeKeys=0-24              34.4MB/s ± 1%  35.4MB/s ± 5%   +2.85%  (p=0.002 n=9+10)
MVCCScan_Pebble/rows=10/versions=10/valueSize=64/numRangeKeys=0-24             17.3MB/s ± 4%  18.5MB/s ± 2%   +6.91%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=10/versions=100/valueSize=64/numRangeKeys=0-24            6.51MB/s ± 2%  7.29MB/s ± 3%  +11.92%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=0-24              139MB/s ± 2%   132MB/s ± 6%   -4.93%  (p=0.001 n=9+10)
MVCCScan_Pebble/rows=100/versions=2/valueSize=64/numRangeKeys=0-24              103MB/s ± 2%   104MB/s ± 3%   +1.47%  (p=0.014 n=9+9)
MVCCScan_Pebble/rows=100/versions=10/valueSize=64/numRangeKeys=0-24            39.8MB/s ± 3%  41.2MB/s ± 2%   +3.58%  (p=0.000 n=10+9)
MVCCScan_Pebble/rows=100/versions=100/valueSize=64/numRangeKeys=0-24           10.7MB/s ± 2%  12.1MB/s ± 3%  +13.88%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=1000/versions=1/valueSize=64/numRangeKeys=0-24             200MB/s ± 3%   202MB/s ± 2%   +1.26%  (p=0.004 n=9+10)
MVCCScan_Pebble/rows=1000/versions=2/valueSize=64/numRangeKeys=0-24             143MB/s ± 1%   147MB/s ± 1%   +2.93%  (p=0.000 n=9+10)
MVCCScan_Pebble/rows=1000/versions=10/valueSize=64/numRangeKeys=0-24           47.0MB/s ± 2%  48.5MB/s ± 2%   +3.26%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=1000/versions=100/valueSize=64/numRangeKeys=0-24          12.2MB/s ± 2%  13.9MB/s ± 3%  +14.01%  (p=0.000 n=9+10)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=0-24            211MB/s ± 2%   217MB/s ± 4%   +2.98%  (p=0.003 n=10+10)
MVCCScan_Pebble/rows=10000/versions=2/valueSize=64/numRangeKeys=0-24            150MB/s ± 2%   155MB/s ± 3%   +3.13%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=10000/versions=10/valueSize=64/numRangeKeys=0-24          48.4MB/s ± 5%  50.9MB/s ± 2%   +5.15%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=10000/versions=100/valueSize=64/numRangeKeys=0-24         12.1MB/s ± 5%  14.3MB/s ± 3%  +18.56%  (p=0.000 n=10+9)
MVCCScan_Pebble/rows=50000/versions=1/valueSize=64/numRangeKeys=0-24            209MB/s ± 3%   214MB/s ± 2%   +2.47%  (p=0.003 n=10+10)
MVCCScan_Pebble/rows=50000/versions=2/valueSize=64/numRangeKeys=0-24            149MB/s ± 3%   151MB/s ± 3%     ~     (p=0.123 n=10+10)
MVCCScan_Pebble/rows=50000/versions=10/valueSize=64/numRangeKeys=0-24          48.6MB/s ± 5%  51.0MB/s ± 6%   +4.82%  (p=0.003 n=10+10)
MVCCScan_Pebble/rows=50000/versions=100/valueSize=64/numRangeKeys=0-24         12.2MB/s ± 7%  14.5MB/s ± 9%  +18.99%  (p=0.000 n=10+10)

name                                                                            old time/op    new time/op    delta
CheckSSTConflicts/keys=1000/sstKeys=10/overlap=false/prefixSeek=false-24          95.1µs ± 1%    95.6µs ± 2%     ~     (p=0.101 n=8+10)
CheckSSTConflicts/keys=1000/sstKeys=10/overlap=false/prefixSeek=true-24           2.78µs ± 1%    2.76µs ± 2%     ~     (p=0.324 n=10+10)
CheckSSTConflicts/keys=1000/sstKeys=10/overlap=true/prefixSeek=false-24            119µs ± 3%     121µs ± 2%     ~     (p=0.063 n=10+10)
CheckSSTConflicts/keys=1000/sstKeys=10/overlap=true/prefixSeek=true-24             105µs ± 1%     107µs ± 1%   +1.83%  (p=0.000 n=9+9)
CheckSSTConflicts/keys=1000/sstKeys=100/overlap=false/prefixSeek=false-24         98.1µs ± 1%   100.6µs ± 2%   +2.58%  (p=0.000 n=9+10)
CheckSSTConflicts/keys=1000/sstKeys=100/overlap=false/prefixSeek=true-24          2.76µs ± 1%    2.80µs ± 2%   +1.63%  (p=0.001 n=10+10)
CheckSSTConflicts/keys=1000/sstKeys=100/overlap=true/prefixSeek=false-24           339µs ± 2%     350µs ± 2%   +3.31%  (p=0.000 n=9+10)
CheckSSTConflicts/keys=1000/sstKeys=100/overlap=true/prefixSeek=true-24            159µs ± 2%     156µs ± 1%   -1.62%  (p=0.002 n=10+8)
CheckSSTConflicts/keys=1000/sstKeys=1000/overlap=false/prefixSeek=false-24         103µs ± 0%     104µs ± 2%   +0.92%  (p=0.010 n=7+10)
CheckSSTConflicts/keys=1000/sstKeys=1000/overlap=false/prefixSeek=true-24         2.79µs ± 2%    2.79µs ± 3%     ~     (p=0.481 n=10+10)
CheckSSTConflicts/keys=1000/sstKeys=1000/overlap=true/prefixSeek=false-24          693µs ± 1%     691µs ± 1%     ~     (p=0.393 n=10+10)
CheckSSTConflicts/keys=1000/sstKeys=1000/overlap=true/prefixSeek=true-24           682µs ± 1%     655µs ± 1%   -3.94%  (p=0.000 n=10+10)
CheckSSTConflicts/keys=1000/sstKeys=10000/overlap=false/prefixSeek=false-24        104µs ± 2%     105µs ± 3%     ~     (p=0.065 n=9+10)
CheckSSTConflicts/keys=1000/sstKeys=10000/overlap=false/prefixSeek=true-24        2.76µs ± 4%    2.77µs ± 1%     ~     (p=0.114 n=9+7)
CheckSSTConflicts/keys=1000/sstKeys=10000/overlap=true/prefixSeek=false-24        1.74ms ± 1%    1.76ms ± 1%     ~     (p=0.095 n=9+10)
CheckSSTConflicts/keys=1000/sstKeys=10000/overlap=true/prefixSeek=true-24         5.85ms ± 3%    5.47ms ± 1%   -6.43%  (p=0.000 n=9+9)
CheckSSTConflicts/keys=1000/sstKeys=100000/overlap=false/prefixSeek=false-24       110µs ± 5%     107µs ± 2%   -2.08%  (p=0.010 n=10+9)
CheckSSTConflicts/keys=1000/sstKeys=100000/overlap=false/prefixSeek=true-24       2.76µs ± 2%    2.72µs ± 2%   -1.36%  (p=0.034 n=10+10)
CheckSSTConflicts/keys=1000/sstKeys=100000/overlap=true/prefixSeek=false-24       6.07ms ± 2%    6.05ms ± 1%     ~     (p=0.529 n=10+10)
CheckSSTConflicts/keys=1000/sstKeys=100000/overlap=true/prefixSeek=true-24        59.4ms ± 6%    54.1ms ± 2%   -8.87%  (p=0.000 n=10+10)
CheckSSTConflicts/keys=10000/sstKeys=10/overlap=false/prefixSeek=false-24         95.8µs ± 2%    91.6µs ± 2%   -4.32%  (p=0.000 n=10+9)
CheckSSTConflicts/keys=10000/sstKeys=10/overlap=false/prefixSeek=true-24          2.79µs ± 1%    2.74µs ± 3%   -1.72%  (p=0.006 n=9+10)
CheckSSTConflicts/keys=10000/sstKeys=10/overlap=true/prefixSeek=false-24           119µs ± 1%     116µs ± 1%   -1.73%  (p=0.000 n=10+9)
CheckSSTConflicts/keys=10000/sstKeys=10/overlap=true/prefixSeek=true-24            103µs ± 1%     101µs ± 1%   -2.23%  (p=0.000 n=9+10)
CheckSSTConflicts/keys=10000/sstKeys=100/overlap=false/prefixSeek=false-24        97.3µs ± 3%    96.5µs ± 3%     ~     (p=0.218 n=10+10)
CheckSSTConflicts/keys=10000/sstKeys=100/overlap=false/prefixSeek=true-24         2.80µs ± 3%    2.73µs ± 3%   -2.53%  (p=0.004 n=10+9)
CheckSSTConflicts/keys=10000/sstKeys=100/overlap=true/prefixSeek=false-24          359µs ± 0%     352µs ± 1%   -1.79%  (p=0.000 n=8+9)
CheckSSTConflicts/keys=10000/sstKeys=100/overlap=true/prefixSeek=true-24           160µs ± 1%     153µs ± 1%   -4.57%  (p=0.000 n=10+9)
CheckSSTConflicts/keys=10000/sstKeys=1000/overlap=false/prefixSeek=false-24        102µs ± 1%     100µs ± 2%   -1.74%  (p=0.001 n=8+10)
CheckSSTConflicts/keys=10000/sstKeys=1000/overlap=false/prefixSeek=true-24        2.77µs ± 2%    2.75µs ± 4%     ~     (p=0.073 n=9+9)
CheckSSTConflicts/keys=10000/sstKeys=1000/overlap=true/prefixSeek=false-24        2.64ms ± 2%    2.59ms ± 1%   -1.94%  (p=0.005 n=10+10)
CheckSSTConflicts/keys=10000/sstKeys=1000/overlap=true/prefixSeek=true-24          688µs ± 1%     646µs ± 1%   -6.15%  (p=0.000 n=8+9)
CheckSSTConflicts/keys=10000/sstKeys=10000/overlap=false/prefixSeek=false-24       102µs ± 2%     101µs ± 1%     ~     (p=0.063 n=10+10)
CheckSSTConflicts/keys=10000/sstKeys=10000/overlap=false/prefixSeek=true-24       2.79µs ± 1%    2.75µs ± 2%   -1.29%  (p=0.025 n=10+10)
CheckSSTConflicts/keys=10000/sstKeys=10000/overlap=true/prefixSeek=false-24       5.92ms ± 1%    5.87ms ± 3%     ~     (p=0.089 n=10+10)
CheckSSTConflicts/keys=10000/sstKeys=10000/overlap=true/prefixSeek=true-24        5.99ms ± 2%    5.63ms ± 2%   -5.93%  (p=0.000 n=10+10)
CheckSSTConflicts/keys=10000/sstKeys=100000/overlap=false/prefixSeek=false-24      108µs ± 1%     108µs ± 3%     ~     (p=0.549 n=9+10)
CheckSSTConflicts/keys=10000/sstKeys=100000/overlap=false/prefixSeek=true-24      2.74µs ± 2%    2.72µs ± 2%     ~     (p=0.305 n=10+10)
CheckSSTConflicts/keys=10000/sstKeys=100000/overlap=true/prefixSeek=false-24      16.8ms ± 1%    16.9ms ± 1%     ~     (p=0.113 n=9+10)
CheckSSTConflicts/keys=10000/sstKeys=100000/overlap=true/prefixSeek=true-24       57.4ms ± 4%    54.1ms ± 2%   -5.69%  (p=0.000 n=10+10)
CheckSSTConflicts/keys=100000/sstKeys=10/overlap=false/prefixSeek=false-24        90.6µs ± 3%    91.0µs ± 2%     ~     (p=0.447 n=10+9)
CheckSSTConflicts/keys=100000/sstKeys=10/overlap=false/prefixSeek=true-24         2.65µs ± 3%    2.66µs ± 3%     ~     (p=0.985 n=10+10)
CheckSSTConflicts/keys=100000/sstKeys=10/overlap=true/prefixSeek=false-24          114µs ± 2%     116µs ± 2%   +1.24%  (p=0.022 n=9+10)
CheckSSTConflicts/keys=100000/sstKeys=10/overlap=true/prefixSeek=true-24           101µs ± 2%     102µs ± 2%   +1.07%  (p=0.043 n=10+10)
CheckSSTConflicts/keys=100000/sstKeys=100/overlap=false/prefixSeek=false-24       94.9µs ± 3%    94.6µs ± 2%     ~     (p=0.720 n=9+10)
CheckSSTConflicts/keys=100000/sstKeys=100/overlap=false/prefixSeek=true-24        2.65µs ± 2%    2.67µs ± 4%     ~     (p=0.436 n=10+10)
CheckSSTConflicts/keys=100000/sstKeys=100/overlap=true/prefixSeek=false-24         372µs ± 3%     371µs ± 1%     ~     (p=0.971 n=10+10)
CheckSSTConflicts/keys=100000/sstKeys=100/overlap=true/prefixSeek=true-24          155µs ± 1%     154µs ± 2%     ~     (p=0.079 n=10+9)
CheckSSTConflicts/keys=100000/sstKeys=1000/overlap=false/prefixSeek=false-24      99.3µs ± 4%    99.7µs ± 4%     ~     (p=0.684 n=10+10)
CheckSSTConflicts/keys=100000/sstKeys=1000/overlap=false/prefixSeek=true-24       2.68µs ± 3%    2.66µs ± 2%     ~     (p=0.353 n=10+10)
CheckSSTConflicts/keys=100000/sstKeys=1000/overlap=true/prefixSeek=false-24       2.97ms ± 2%    2.93ms ± 2%   -1.23%  (p=0.011 n=10+10)
CheckSSTConflicts/keys=100000/sstKeys=1000/overlap=true/prefixSeek=true-24         682µs ± 2%     665µs ± 2%   -2.61%  (p=0.000 n=9+10)
CheckSSTConflicts/keys=100000/sstKeys=10000/overlap=false/prefixSeek=false-24      101µs ± 2%     102µs ± 1%     ~     (p=0.165 n=10+10)
CheckSSTConflicts/keys=100000/sstKeys=10000/overlap=false/prefixSeek=true-24      2.69µs ± 2%    2.69µs ± 3%     ~     (p=0.726 n=10+10)
CheckSSTConflicts/keys=100000/sstKeys=10000/overlap=true/prefixSeek=false-24      26.1ms ± 1%    26.1ms ± 2%     ~     (p=1.000 n=8+10)
CheckSSTConflicts/keys=100000/sstKeys=10000/overlap=true/prefixSeek=true-24       5.99ms ± 3%    5.77ms ± 5%   -3.77%  (p=0.001 n=10+9)
CheckSSTConflicts/keys=100000/sstKeys=100000/overlap=false/prefixSeek=false-24     108µs ± 2%     109µs ± 4%     ~     (p=0.353 n=10+10)
CheckSSTConflicts/keys=100000/sstKeys=100000/overlap=false/prefixSeek=true-24     2.67µs ± 2%    2.63µs ± 1%   -1.65%  (p=0.002 n=10+9)
CheckSSTConflicts/keys=100000/sstKeys=100000/overlap=true/prefixSeek=false-24     58.2ms ± 3%    58.1ms ± 2%     ~     (p=0.971 n=10+10)
CheckSSTConflicts/keys=100000/sstKeys=100000/overlap=true/prefixSeek=true-24      60.5ms ± 4%    55.9ms ± 3%   -7.62%  (p=0.000 n=10+10)
```

Close #2048.
Informs #2078.