### PR TITLE
sstable: fix twoLevelIterator SeekGE optimization

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/rangedel"
 	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/internal/testkeys"
-	"github.com/cockroachdb/pebble/internal/testkeys/blockprop"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -141,6 +140,8 @@ func runIterCmd(d *datadriven.TestData, iter *Iterator, closeIter bool) string {
 					op = "seekge"
 				case seekLTLastPositioningOp:
 					op = "seeklt"
+				case invalidatedLastPositionOp:
+					op = "invalidate"
 				}
 				fmt.Fprintf(&b, "%s=%q\n", field, op)
 			default:
@@ -294,7 +295,7 @@ func parseIterOptions(
 			opts.RangeKeyMasking.Suffix = []byte(arg[1])
 		case "mask-filter":
 			opts.RangeKeyMasking.Filter = func() BlockPropertyFilterMask {
-				return blockprop.NewMaskingFilter()
+				return sstable.NewTestKeysMaskingFilter()
 			}
 		case "table-filter":
 			switch arg[1] {

--- a/external_iterator_test.go
+++ b/external_iterator_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/cockroachdb/pebble/internal/testkeys"
-	"github.com/cockroachdb/pebble/internal/testkeys/blockprop"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -193,7 +192,7 @@ func TestIterRandomizedMaybeFilteredKeys(t *testing.T) {
 				TableFormat:    sstable.TableFormatPebblev2,
 				BlockPropertyCollectors: []func() BlockPropertyCollector{
 					func() BlockPropertyCollector {
-						return blockprop.NewBlockPropertyCollector()
+						return sstable.NewTestKeysBlockPropertyCollector()
 					},
 				},
 			})
@@ -235,7 +234,7 @@ func TestIterRandomizedMaybeFilteredKeys(t *testing.T) {
 			require.NoError(t, err)
 			defer r.Close()
 
-			filter := blockprop.NewBlockPropertyFilter(uint64(tsSeparator), math.MaxUint64)
+			filter := sstable.NewTestKeysBlockPropertyFilter(uint64(tsSeparator), math.MaxUint64)
 			filterer := sstable.NewBlockPropertiesFilterer([]BlockPropertyFilter{filter}, nil)
 			ok, err := filterer.IntersectsUserPropsAndFinishInit(r.Properties.UserProperties)
 			require.True(t, ok)

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/errorfs"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/private"
-	"github.com/cockroachdb/pebble/internal/testkeys/blockprop"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -821,12 +820,12 @@ func iterOptions(o iterOpts) *pebble.IterOptions {
 	}
 	if opts.RangeKeyMasking.Suffix != nil {
 		opts.RangeKeyMasking.Filter = func() pebble.BlockPropertyFilterMask {
-			return blockprop.NewMaskingFilter()
+			return sstable.NewTestKeysMaskingFilter()
 		}
 	}
 	if o.filterMax > 0 {
 		opts.PointKeyFilters = []pebble.BlockPropertyFilter{
-			blockprop.NewBlockPropertyFilter(o.filterMin, o.filterMax),
+			sstable.NewTestKeysBlockPropertyFilter(o.filterMin, o.filterMax),
 		}
 	}
 	return opts

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/testkeys"
-	"github.com/cockroachdb/pebble/internal/testkeys/blockprop"
+	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"golang.org/x/exp/rand"
 )
@@ -404,5 +404,5 @@ func moveLogs(fs vfs.FS, srcDir, dstDir string) error {
 }
 
 var blockPropertyCollectorConstructors = []func() pebble.BlockPropertyCollector{
-	blockprop.NewBlockPropertyCollector,
+	sstable.NewTestKeysBlockPropertyCollector,
 }

--- a/internal/testkeys/testkeys.go
+++ b/internal/testkeys/testkeys.go
@@ -58,8 +58,8 @@ var Comparer *base.Comparer = &base.Comparer{
 		if bytes.Equal(a[:ai], buf) {
 			return append(dst[:n], a...)
 		}
-		// The separator is > a[:ai], so we only need to add the sentinel.
-		return append(dst, 0)
+		// The separator is > a[:ai], so return it
+		return dst
 	},
 	Successor: func(dst, a []byte) []byte {
 		ai := split(a)
@@ -73,8 +73,8 @@ var Comparer *base.Comparer = &base.Comparer{
 		if bytes.Equal(a[:ai], buf) {
 			return append(dst[:n], a...)
 		}
-		// The successor is > a[:ai], so we only need to add the sentinel.
-		return append(dst, 0)
+		// The successor is > a[:ai], so return it.
+		return dst
 	},
 	ImmediateSuccessor: func(dst, a []byte) []byte {
 		// TODO(jackson): Consider changing this Comparer to only support

--- a/iterator_histories_test.go
+++ b/iterator_histories_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/cockroachdb/pebble/internal/testkeys"
-	"github.com/cockroachdb/pebble/internal/testkeys/blockprop"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -62,7 +61,7 @@ func TestIterHistories(t *testing.T) {
 					Comparer:           testkeys.Comparer,
 					FormatMajorVersion: FormatRangeKeys,
 					BlockPropertyCollectors: []func() BlockPropertyCollector{
-						blockprop.NewBlockPropertyCollector,
+						sstable.NewTestKeysBlockPropertyCollector,
 					},
 				}
 				opts.DisableAutomaticCompactions = true
@@ -267,7 +266,7 @@ func TestIterHistories(t *testing.T) {
 						o.RangeKeyMasking.Suffix = []byte(arg.Vals[0])
 					case "mask-filter":
 						o.RangeKeyMasking.Filter = func() BlockPropertyFilterMask {
-							return blockprop.NewMaskingFilter()
+							return sstable.NewTestKeysMaskingFilter()
 						}
 					case "lower":
 						o.LowerBound = []byte(arg.Vals[0])
@@ -293,7 +292,7 @@ func TestIterHistories(t *testing.T) {
 							return err.Error()
 						}
 						o.PointKeyFilters = []sstable.BlockPropertyFilter{
-							blockprop.NewBlockPropertyFilter(min, max),
+							sstable.NewTestKeysBlockPropertyFilter(min, max),
 						}
 					}
 				}

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/testkeys"
-	"github.com/cockroachdb/pebble/internal/testkeys/blockprop"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -1685,7 +1684,6 @@ func testSetOptionsEquivalence(t *testing.T, seed uint64) {
 	rng := rand.New(rand.NewSource(seed))
 	ks := testkeys.Alpha(2)
 	d := newTestkeysDatabase(t, ks, rng)
-	d.opts.Logger = panicLogger{}
 	defer func() { require.NoError(t, d.Close()) }()
 
 	var o IterOptions
@@ -1836,6 +1834,7 @@ func newTestkeysDatabase(t *testing.T, ks testkeys.Keyspace, rng *rand.Rand) *DB
 		Comparer:           testkeys.Comparer,
 		FS:                 vfs.NewMem(),
 		FormatMajorVersion: FormatRangeKeys,
+		Logger:             panicLogger{},
 	}
 	d, err := Open("", dbOpts)
 	require.NoError(t, err)
@@ -2185,6 +2184,228 @@ func BenchmarkBlockPropertyFilter(b *testing.B) {
 	}
 }
 
+func TestRangeKeyMaskingRandomized(t *testing.T) {
+	seed := *seed
+	if seed == 0 {
+		seed = uint64(time.Now().UnixNano())
+		fmt.Printf("seed: %d\n", seed)
+	}
+	rng := rand.New(rand.NewSource(seed))
+
+	// Generate keyspace with point keys, and range keys which will
+	// mask the point keys.
+	var timestamps []int
+	for i := 0; i <= 100; i++ {
+		timestamps = append(timestamps, rng.Intn(1000))
+	}
+
+	ks := testkeys.Alpha(5)
+	numKeys := 1000 + rng.Intn(9000)
+	keys := make([][]byte, numKeys)
+	keyTimeStamps := make([]int, numKeys) // ts associated with the keys.
+	for i := 0; i < numKeys; i++ {
+		keys[i] = make([]byte, 5+testkeys.MaxSuffixLen)
+		keyTimeStamps[i] = timestamps[rng.Intn(len(timestamps))]
+		n := testkeys.WriteKeyAt(keys[i], ks, rng.Intn(ks.Count()), keyTimeStamps[i])
+		keys[i] = keys[i][:n]
+	}
+
+	numRangeKeys := rng.Intn(20)
+	type rkey struct {
+		start  []byte
+		end    []byte
+		suffix []byte
+	}
+	rkeys := make([]rkey, numRangeKeys)
+	pointKeyHidden := make([]bool, numKeys)
+	for i := 0; i < numRangeKeys; i++ {
+		rkeys[i].start = make([]byte, 5)
+		rkeys[i].end = make([]byte, 5)
+
+		testkeys.WriteKey(rkeys[i].start[:5], ks, rng.Intn(ks.Count()))
+		testkeys.WriteKey(rkeys[i].end[:5], ks, rng.Intn(ks.Count()))
+
+		for bytes.Equal(rkeys[i].start[:5], rkeys[i].end[:5]) {
+			testkeys.WriteKey(rkeys[i].end[:5], ks, rng.Intn(ks.Count()))
+		}
+
+		if bytes.Compare(rkeys[i].start[:5], rkeys[i].end[:5]) > 0 {
+			rkeys[i].start, rkeys[i].end = rkeys[i].end, rkeys[i].start
+		}
+
+		rkeyTimestamp := timestamps[rng.Intn(len(timestamps))]
+		rkeys[i].suffix = []byte("@" + strconv.Itoa(rkeyTimestamp))
+
+		// Each time we create a range key, check if the range key masks any
+		// point keys.
+		for j, pkey := range keys {
+			if pointKeyHidden[j] {
+				continue
+			}
+
+			if keyTimeStamps[j] >= rkeyTimestamp {
+				continue
+			}
+
+			if testkeys.Comparer.Compare(pkey, rkeys[i].start) >= 0 &&
+				testkeys.Comparer.Compare(pkey, rkeys[i].end) < 0 {
+				pointKeyHidden[j] = true
+			}
+		}
+	}
+
+	// Define a simple base testOpts, and a randomized testOpts. The results
+	// of iteration will be compared.
+	type testOpts struct {
+		levelOpts []LevelOptions
+		filter    func() BlockPropertyFilterMask
+	}
+
+	baseOpts := testOpts{
+		levelOpts: make([]LevelOptions, 7),
+	}
+	for i := 0; i < len(baseOpts.levelOpts); i++ {
+		baseOpts.levelOpts[i].TargetFileSize = 1
+		baseOpts.levelOpts[i].BlockSize = 1
+	}
+
+	randomOpts := testOpts{
+		levelOpts: []LevelOptions{
+			{
+				TargetFileSize: int64(1 + rng.Intn(2<<20)), // Vary the L0 file size.
+				BlockSize:      1 + rng.Intn(32<<10),
+			},
+		},
+	}
+	if rng.Intn(2) == 0 {
+		randomOpts.filter = func() BlockPropertyFilterMask {
+			return sstable.NewTestKeysMaskingFilter()
+		}
+	}
+
+	maxProcs := runtime.GOMAXPROCS(0)
+
+	opts1 := &Options{
+		FS:                       vfs.NewStrictMem(),
+		Comparer:                 testkeys.Comparer,
+		FormatMajorVersion:       FormatNewest,
+		MaxConcurrentCompactions: func() int { return maxProcs/2 + 1 },
+		BlockPropertyCollectors: []func() BlockPropertyCollector{
+			sstable.NewTestKeysBlockPropertyCollector,
+		},
+	}
+	opts1.Levels = baseOpts.levelOpts
+	d1, err := Open("", opts1)
+	require.NoError(t, err)
+
+	opts2 := &Options{
+		FS:                       vfs.NewStrictMem(),
+		Comparer:                 testkeys.Comparer,
+		FormatMajorVersion:       FormatNewest,
+		MaxConcurrentCompactions: func() int { return maxProcs/2 + 1 },
+		BlockPropertyCollectors: []func() BlockPropertyCollector{
+			sstable.NewTestKeysBlockPropertyCollector,
+		},
+	}
+	opts2.Levels = randomOpts.levelOpts
+	d2, err := Open("", opts2)
+	require.NoError(t, err)
+
+	defer func() {
+		if err := d1.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := d2.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Run test
+	var batch1 *Batch
+	var batch2 *Batch
+	const keysPerBatch = 50
+	for i := 0; i < numKeys; i++ {
+		if i%keysPerBatch == 0 {
+			if batch1 != nil {
+				require.NoError(t, batch1.Commit(nil))
+				require.NoError(t, batch2.Commit(nil))
+			}
+			batch1 = d1.NewBatch()
+			batch2 = d2.NewBatch()
+		}
+		require.NoError(t, batch1.Set(keys[i], []byte{1}, nil))
+		require.NoError(t, batch2.Set(keys[i], []byte{1}, nil))
+	}
+
+	for _, rkey := range rkeys {
+		require.NoError(t, d1.RangeKeySet(rkey.start, rkey.end, rkey.suffix, nil, nil))
+		require.NoError(t, d2.RangeKeySet(rkey.start, rkey.end, rkey.suffix, nil, nil))
+	}
+
+	// Scan the keyspace
+	iter1Opts := IterOptions{
+		KeyTypes: IterKeyTypePointsAndRanges,
+		RangeKeyMasking: RangeKeyMasking{
+			Suffix: []byte("@1000"),
+			Filter: baseOpts.filter,
+		},
+	}
+
+	iter2Opts := IterOptions{
+		KeyTypes: IterKeyTypePointsAndRanges,
+		RangeKeyMasking: RangeKeyMasking{
+			Suffix: []byte("@1000"),
+			Filter: randomOpts.filter,
+		},
+	}
+
+	iter1 := d1.NewIter(&iter1Opts)
+	iter2 := d2.NewIter(&iter2Opts)
+	defer func() {
+		if err := iter1.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := iter2.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	for valid1, valid2 := iter1.First(), iter2.First(); valid1 || valid2; valid1, valid2 = iter1.Next(), iter2.Next() {
+		if valid1 != valid2 {
+			t.Fatalf("iteration didn't produce identical results")
+		}
+
+		// Confirm exposed range key state is identical.
+		hasP1, hasR1 := iter1.HasPointAndRange()
+		hasP2, hasR2 := iter2.HasPointAndRange()
+		if hasP1 != hasP2 || hasR1 != hasR2 {
+			t.Fatalf("iteration didn't produce identical results")
+		}
+		if hasP1 && !bytes.Equal(iter1.Key(), iter2.Key()) {
+			t.Fatalf(fmt.Sprintf("iteration didn't produce identical point keys: %s, %s", iter1.Key(), iter2.Key()))
+		}
+		if hasR1 {
+			// Confirm that the range key is the same.
+			b1, e1 := iter1.RangeBounds()
+			b2, e2 := iter2.RangeBounds()
+			if !bytes.Equal(b1, b2) || !bytes.Equal(e1, e2) {
+				t.Fatalf(fmt.Sprintf(
+					"iteration didn't produce identical range keys: [%s, %s], [%s, %s]",
+					b1, e1, b2, e2,
+				))
+			}
+
+		}
+
+		// Confirm that the returned point key wasn't hidden.
+		for j, pkey := range keys {
+			if bytes.Equal(iter1.Key(), pkey) && pointKeyHidden[j] {
+				t.Fatalf(fmt.Sprintf("hidden point key was exposed %s %d", pkey, keyTimeStamps[j]))
+			}
+		}
+	}
+}
+
 // BenchmarkIterator_RangeKeyMasking benchmarks a scan through a keyspace with
 // 10,000 random suffixed point keys, and three range keys covering most of the
 // keyspace. It varies the suffix of the range keys in subbenchmarks to exercise
@@ -2210,7 +2431,7 @@ func BenchmarkIterator_RangeKeyMasking(b *testing.B) {
 		FormatMajorVersion:       FormatNewest,
 		MaxConcurrentCompactions: func() int { return maxProcs/2 + 1 },
 		BlockPropertyCollectors: []func() BlockPropertyCollector{
-			blockprop.NewBlockPropertyCollector,
+			sstable.NewTestKeysBlockPropertyCollector,
 		},
 	}
 	d, err := Open("", opts)
@@ -2260,7 +2481,7 @@ func BenchmarkIterator_RangeKeyMasking(b *testing.B) {
 				RangeKeyMasking: RangeKeyMasking{
 					Suffix: []byte("@100"),
 					Filter: func() BlockPropertyFilterMask {
-						return blockprop.NewMaskingFilter()
+						return sstable.NewTestKeysMaskingFilter()
 					},
 				},
 			}

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -801,7 +801,7 @@ func (c *valueCharBlockIntervalCollector) FinishDataBlock() (lower, upper uint64
 	return l, u, nil
 }
 
-// suffixIntervalCollector maintains an interval over the timestamps in
+// testKeysSuffixIntervalCollector maintains an interval over the timestamps in
 // MVCC-like suffixes for keys (e.g. foo@123).
 type suffixIntervalCollector struct {
 	initialized  bool

--- a/sstable/block_property_test_utils.go
+++ b/sstable/block_property_test_utils.go
@@ -2,31 +2,31 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-// Package blockprop implements interval block property collectors and filters
-// on the suffixes of keys in the format used by the testkeys package (eg,
-// 'key@5').
-package blockprop
+package sstable
 
 import (
 	"math"
 
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/testkeys"
-	"github.com/cockroachdb/pebble/sstable"
 )
 
-const blockPropertyName = `pebble.internal.testkeys.suffixes`
+// Code in this file contains utils for testing. It implements interval block
+// property collectors and filters on the suffixes of keys in the format used
+// by the testkeys package (eg, 'key@5').
 
-// NewBlockPropertyCollector constructs a sstable property collector over
-// testkey suffixes.
-func NewBlockPropertyCollector() sstable.BlockPropertyCollector {
-	return sstable.NewBlockIntervalCollector(
-		blockPropertyName,
-		&suffixIntervalCollector{},
+const testKeysBlockPropertyName = `pebble.internal.testkeys.suffixes`
+
+// NewTestKeysBlockPropertyCollector constructs a sstable property collector
+// over testkey suffixes.
+func NewTestKeysBlockPropertyCollector() BlockPropertyCollector {
+	return NewBlockIntervalCollector(
+		testKeysBlockPropertyName,
+		&testKeysSuffixIntervalCollector{},
 		nil)
 }
 
-// NewBlockPropertyFilter constructs a new block-property filter that excludes
+// NewTestKeysBlockPropertyFilter constructs a new block-property filter that excludes
 // blocks containing exclusively suffixed keys where all the suffixes fall
 // outside of the range [filterMin, filterMax).
 //
@@ -34,27 +34,27 @@ func NewBlockPropertyCollector() sstable.BlockPropertyCollector {
 // results of this block property filter are deterministic for unsuffixed keys
 // and keys with suffixes within the range [filterMin, filterMax). For keys with
 // suffixes outside the range, iteration is nondeterministic.
-func NewBlockPropertyFilter(filterMin, filterMax uint64) *sstable.BlockIntervalFilter {
-	return sstable.NewBlockIntervalFilter(blockPropertyName, filterMin, filterMax)
+func NewTestKeysBlockPropertyFilter(filterMin, filterMax uint64) *BlockIntervalFilter {
+	return NewBlockIntervalFilter(testKeysBlockPropertyName, filterMin, filterMax)
 }
 
-// NewMaskingFilter constructs a MaskingFilter that implements
+// NewTestKeysMaskingFilter constructs a TestKeysMaskingFilter that implements
 // pebble.BlockPropertyFilterMask for efficient range-key masking using the
 // testkeys block property filter. The masking filter wraps a block interval
 // filter, and modifies the configured interval when Pebble requests it.
-func NewMaskingFilter() MaskingFilter {
-	return MaskingFilter{BlockIntervalFilter: NewBlockPropertyFilter(0, math.MaxUint64)}
+func NewTestKeysMaskingFilter() TestKeysMaskingFilter {
+	return TestKeysMaskingFilter{BlockIntervalFilter: NewTestKeysBlockPropertyFilter(0, math.MaxUint64)}
 }
 
-// MaskingFilter implements BlockPropertyFilterMask and may be used to mask
+// TestKeysMaskingFilter implements BlockPropertyFilterMask and may be used to mask
 // point keys with the testkeys-style suffixes (eg, @4) that are masked by range
 // keys with testkeys-style suffixes.
-type MaskingFilter struct {
-	*sstable.BlockIntervalFilter
+type TestKeysMaskingFilter struct {
+	*BlockIntervalFilter
 }
 
 // SetSuffix implements pebble.BlockPropertyFilterMask.
-func (f MaskingFilter) SetSuffix(suffix []byte) error {
+func (f TestKeysMaskingFilter) SetSuffix(suffix []byte) error {
 	ts, err := testkeys.ParseSuffix(suffix)
 	if err != nil {
 		return err
@@ -64,15 +64,15 @@ func (f MaskingFilter) SetSuffix(suffix []byte) error {
 }
 
 // Intersects implements the BlockPropertyFilter interface.
-func (f MaskingFilter) Intersects(prop []byte) (bool, error) {
+func (f TestKeysMaskingFilter) Intersects(prop []byte) (bool, error) {
 	return f.BlockIntervalFilter.Intersects(prop)
 }
 
-var _ sstable.DataBlockIntervalCollector = (*suffixIntervalCollector)(nil)
+var _ DataBlockIntervalCollector = (*testKeysSuffixIntervalCollector)(nil)
 
-// suffixIntervalCollector maintains an interval over the timestamps in
+// testKeysSuffixIntervalCollector maintains an interval over the timestamps in
 // MVCC-like suffixes for keys (e.g. foo@123).
-type suffixIntervalCollector struct {
+type testKeysSuffixIntervalCollector struct {
 	initialized  bool
 	lower, upper uint64
 }
@@ -82,7 +82,7 @@ type suffixIntervalCollector struct {
 //
 // Note that range sets and unsets may have multiple suffixes. Range key deletes
 // do not have a suffix. All other point keys have a single suffix.
-func (c *suffixIntervalCollector) Add(key base.InternalKey, value []byte) error {
+func (c *testKeysSuffixIntervalCollector) Add(key base.InternalKey, value []byte) error {
 	i := testkeys.Comparer.Split(key.UserKey)
 	if i == len(key.UserKey) {
 		c.initialized = true
@@ -109,7 +109,7 @@ func (c *suffixIntervalCollector) Add(key base.InternalKey, value []byte) error 
 }
 
 // FinishDataBlock implements DataBlockIntervalCollector.
-func (c *suffixIntervalCollector) FinishDataBlock() (lower, upper uint64, err error) {
+func (c *testKeysSuffixIntervalCollector) FinishDataBlock() (lower, upper uint64, err error) {
 	l, u := c.lower, c.upper
 	c.lower, c.upper = 0, 0
 	c.initialized = false

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -104,6 +104,75 @@ type Iterator interface {
 	SetCloseHook(fn func(i Iterator) error)
 }
 
+
+// Iterator positioning optimizations and singleLevelIterator and
+// twoLevelIterator:
+//
+// An iterator is absolute positioned using one of the Seek or First or Last
+// calls. After absolute positioning, there can be relative positioning done
+// by stepping using Prev or Next.
+//
+// We implement optimizations below where an absolute positioning call can in
+// some cases use the current position to do less work. To understand these,
+// we first define some terms. An iterator is bounds-exhausted if the bounds
+// (upper of lower) have been reached. An iterator is data-exhausted if it has
+// the reached the end of the data (forward or reverse) in the sstable. A
+// singleLevelIterator only knows a local-data-exhausted property since when
+// it is used as part of a twoLevelIterator, the twoLevelIterator can step to
+// the next lower-level index block.
+//
+// The bounds-exhausted property is tracked by
+// singleLevelIterator.exhaustedBounds being +1 (upper bound reached) or -1
+// (lower bound reached). The same field is reused by twoLevelIterator. Either
+// may notice the exhaustion of the bound and set it. Note that if
+// singleLevelIterator sets this property, it is not a local property (since
+// the bound has been reached regardless of whether this is in the context of
+// the twoLevelIterator or not).
+//
+// The data-exhausted property is tracked in a more subtle manner. We define
+// two predicates:
+// - partial-local-data-exhausted (PLDE):
+//   i.data.isDataInvalidated() || !i.data.valid()
+// - partial-global-data-exhausted (PGDE):
+//   i.index.isDataInvalidated() || !i.index.valid() || i.data.isDataInvalidated() ||
+//   !i.data.valid()
+//
+// PLDE is defined for a singleLevelIterator. PGDE is defined for a
+// twoLevelIterator. Oddly, in our code below the singleLevelIterator does not
+// know when it is part of a twoLevelIterator so it does not know when its
+// property is local or global.
+//
+// Now to define data-exhausted:
+// - Prerequisite: we must know that the iterator has been positioned and
+//   i.err is nil.
+// - bounds-exhausted must not be true:
+//   If bounds-exhausted is true, we have incomplete knowledge of
+//   data-exhausted since PLDE or PGDE could be true because we could have
+//   chosen not to load index block or data block and figured out that the
+//   bound is exhausted (due to block property filters filtering out index and
+//   data blocks and going past the bound on the top level index block). Note
+//   that if we tried to separate out the BPF case from others we could
+//   develop more knowledge here. - !PLDE or !PGDE of course imply that
+//   data-exhausted is not true.
+//
+// An implication of the above is that if we are going to somehow utilize
+// knowledge of data-exhausted in an optimization, we must not forget the
+// existing value of bounds-exhausted since by forgetting the latter we can
+// erroneously think that data-exhausted is true. Bug #2036 was due to this
+// forgetting.
+//
+// Now to the two categories of optimizations we currently have:
+// - Monotonic bounds optimization that reuse prior iterator position when
+//   doing seek: These only work with !data-exhausted. We could choose to make
+//   these work with data-exhausted but have not bothered because in the
+//   context of a DB if data-exhausted were true, the DB would move to the
+//   next file in the level. Note that this behavior of moving to the next
+//   file is not necessarily true for L0 files, so there could be some benefit
+//   in the future in this optimization. See the WARNING-data-exhausted
+//   comments if trying to optimize this in the future.
+// - TrySeekUsingNext optimizations: these work regardless of exhaustion
+//   state.
+
 // singleLevelIterator iterates over an entire table of data. To seek for a given
 // key, it first looks in the index for the block that contains that key, and then
 // looks inside that block.
@@ -209,7 +278,10 @@ type singleLevelIterator struct {
 	// exhaustedBounds represents whether the iterator is exhausted for
 	// iteration by reaching the upper or lower bound. +1 when exhausted
 	// the upper bound, -1 when exhausted the lower bound, and 0 when
-	// neither. It is used for invariant checking.
+	// neither. exhaustedBounds is also used for the TrySeekUsingNext
+	// optimization in twoLevelIterator and singleLevelIterator. Care should be
+	// taken in setting this in twoLevelIterator before calling into
+	// singleLevelIterator, given that these two iterators share this field.
 	exhaustedBounds int8
 
 	// maybeFilteredKeysSingleLevel indicates whether the last iterator
@@ -603,12 +675,23 @@ func (i *singleLevelIterator) recordOffset() uint64 {
 // package. Note that SeekGE only checks the upper bound. It is up to the
 // caller to ensure that key is greater than or equal to the lower bound.
 func (i *singleLevelIterator) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, []byte) {
-	// The i.exhaustedBounds comparison indicates that the upper bound was
-	// reached. The i.data.isDataInvalidated() indicates that the sstable was
-	// exhausted.
-	if flags.TrySeekUsingNext() && (i.exhaustedBounds == +1 || i.data.isDataInvalidated()) {
-		// Already exhausted, so return nil.
-		return nil, nil
+	if flags.TrySeekUsingNext() {
+		// The i.exhaustedBounds comparison indicates that the upper bound was
+		// reached. The i.data.isDataInvalidated() indicates that the sstable was
+		// exhausted.
+		if (i.exhaustedBounds == +1 || i.data.isDataInvalidated()) && i.err == nil {
+			// Already exhausted, so return nil.
+			return nil, nil
+		}
+		if i.err != nil {
+			// The current iterator position cannot be used.
+			flags = flags.DisableTrySeekUsingNext()
+		}
+		// INVARIANT: flags.TrySeekUsingNext() => i.err == nil &&
+		// !i.exhaustedBounds==+1 && !i.data.isDataInvalidated(). That is,
+		// data-exhausted and bounds-exhausted, as defined earlier, are both
+		// false. Ths makes it safe to clear out i.exhaustedBounds and i.err
+		// before calling into seekGEHelper.
 	}
 
 	i.exhaustedBounds = 0
@@ -748,6 +831,11 @@ func (i *singleLevelIterator) SeekPrefixGE(
 func (i *singleLevelIterator) seekPrefixGE(
 	prefix, key []byte, flags base.SeekGEFlags, checkFilter bool,
 ) (k *InternalKey, value []byte) {
+	// NOTE: prefix is only used for bloom filter checking and not later work in
+	// this method. Hence, we can use the existing iterator position if the last
+	// SeekPrefixGE did not fail bloom filter matching.
+
+	err := i.err
 	i.err = nil // clear cached iteration error
 	if checkFilter && i.reader.tableFilter != nil {
 		if !i.lastBloomFilterMatched {
@@ -775,12 +863,23 @@ func (i *singleLevelIterator) seekPrefixGE(
 		}
 		i.lastBloomFilterMatched = true
 	}
-	// The i.exhaustedBounds comparison indicates that the upper bound was
-	// reached. The i.data.isDataInvalidated() indicates that the sstable was
-	// exhausted.
-	if flags.TrySeekUsingNext() && (i.exhaustedBounds == +1 || i.data.isDataInvalidated()) {
-		// Already exhausted, so return nil.
-		return nil, nil
+	if flags.TrySeekUsingNext() {
+		// The i.exhaustedBounds comparison indicates that the upper bound was
+		// reached. The i.data.isDataInvalidated() indicates that the sstable was
+		// exhausted.
+		if (i.exhaustedBounds == +1 || i.data.isDataInvalidated()) && err == nil {
+			// Already exhausted, so return nil.
+			return nil, nil
+		}
+		if err != nil {
+			// The current iterator position cannot be used.
+			flags = flags.DisableTrySeekUsingNext()
+		}
+		// INVARIANT: flags.TrySeekUsingNext() => err == nil &&
+		// !i.exhaustedBounds==+1 && !i.data.isDataInvalidated(). That is,
+		// data-exhausted and bounds-exhausted, as defined earlier, are both
+		// false. Ths makes it safe to clear out i.exhaustedBounds and i.err
+		// before calling into seekGEHelper.
 	}
 	// Bloom filter matches, or skipped, so this method will position the
 	// iterator.
@@ -1494,8 +1593,17 @@ func (i *twoLevelIterator) MaybeFilteredKeys() bool {
 // package. Note that SeekGE only checks the upper bound. It is up to the
 // caller to ensure that key is greater than or equal to the lower bound.
 func (i *twoLevelIterator) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, []byte) {
-	i.exhaustedBounds = 0
+	err := i.err
 	i.err = nil // clear cached iteration error
+
+	// TODO(sumeer): we are not fully optimizing in the flags.TrySeekUsingNext()
+	// case when the twoLevelIterator is already exhausted. We will take the
+	// slow-path below, even though we could return now. We could do:
+	// if flags.TrySeekUsingNext() && (i.exhaustedBounds == +1 || (i.data.isDataInvalidated() &&
+	//	i.index.isDataInvalidated())) && i.err == nil {
+	//	// Already exhausted, so return nil.
+	//	return nil, nil
+	// }
 
 	// SeekGE performs various step-instead-of-seeking optimizations: eg enabled
 	// by trySeekUsingNext, or by monotonically increasing bounds (i.boundsCmp).
@@ -1511,9 +1619,13 @@ func (i *twoLevelIterator) SeekGE(key []byte, flags base.SeekGEFlags) (*Internal
 	// previous value of maybeFilteredKeys.
 
 	var dontSeekWithinSingleLevelIter bool
-	if i.topLevelIndex.isDataInvalidated() || !i.topLevelIndex.valid() ||
+	if i.topLevelIndex.isDataInvalidated() || !i.topLevelIndex.valid() || err != nil ||
 		(i.boundsCmp <= 0 && !flags.TrySeekUsingNext()) || i.cmp(key, i.topLevelIndex.Key().UserKey) > 0 {
 		// Slow-path: need to position the topLevelIndex.
+
+		// The previous exhausted state of singleLevelIterator is no longer
+		// relevant, since we may be moving to a different index block.
+		i.exhaustedBounds = 0
 		i.maybeFilteredKeysTwoLevel = false
 		flags = flags.DisableTrySeekUsingNext()
 		var ikey *InternalKey
@@ -1547,23 +1659,57 @@ func (i *twoLevelIterator) SeekGE(key []byte, flags base.SeekGEFlags) (*Internal
 			// left == 0.
 			i.boundsCmp = 0
 		}
+	} else {
+		// INVARIANT: err == nil.
+		//
+		// Else fast-path: There are two possible cases, from
+		// (i.boundsCmp > 0 || flags.TrySeekUsingNext()):
+		//
+		// 1) The bounds have moved forward (i.boundsCmp > 0) and this SeekGE is
+		// respecting the lower bound (guaranteed by Iterator). We know that the
+		// iterator must already be positioned within or just outside the previous
+		// bounds. Therefore, the topLevelIndex iter cannot be positioned at an
+		// entry ahead of the seek position (though it can be positioned behind).
+		// The !i.cmp(key, i.topLevelIndex.Key().UserKey) > 0 confirms that it is
+		// not behind. Since it is not ahead and not behind it must be at the
+		// right position.
+		//
+		// 2) This SeekGE will land on a key that is greater than the key we are
+		// currently at (guaranteed by trySeekUsingNext), but since i.cmp(key,
+		// i.topLevelIndex.Key().UserKey) <= 0, we are at the correct lower level
+		// index block. No need to reset the state of singleLevelIterator.
+		//
+		// Note that cases 1 and 2 never overlap, and one of them must be true,
+		// but we have some test code (TestIterRandomizedMaybeFilteredKeys) that
+		// sets both to true, so we fix things here and then do an invariant
+		// check.
+		//
+		// This invariant checking is important enough that we do not gate it
+		// behind invariants.Enabled.
+		if i.boundsCmp > 0 {
+			// TODO(sumeer): fix TestIterRandomizedMaybeFilteredKeys so as to not
+			// need this behavior.
+			flags = flags.DisableTrySeekUsingNext()
+		}
+		if i.boundsCmp > 0 == flags.TrySeekUsingNext() {
+			panic(fmt.Sprintf("inconsistency in optimization case 1 %t and case 2 %t",
+				i.boundsCmp > 0, flags.TrySeekUsingNext()))
+		}
+
+		if !flags.TrySeekUsingNext() {
+			// Case 1. Bounds have changed so the previous exhausted bounds state is
+			// irrelevant.
+			// WARNING-data-exhausted: this is safe to do only because the monotonic
+			// bounds optimizations only work when !data-exhausted. If they also
+			// worked with data-exhausted, we have made it unclear whether
+			// data-exhausted is actually true. See the comment at the top of the
+			// file.
+			i.exhaustedBounds = 0
+		}
+		// Else flags.TrySeekUsingNext(). The i.exhaustedBounds is important to
+		// preserve for singleLevelIterator, and twoLevelIterator.skipForward. See
+		// bug https://github.com/cockroachdb/pebble/issues/2036.
 	}
-	// Else fast-path: There are two possible cases, from
-	// (i.boundsCmp > 0 || flags.TrySeekUsingNext()):
-	//
-	// 1) The bounds have moved forward (i.boundsCmp > 0) and this SeekGE is
-	// respecting the lower bound (guaranteed by Iterator). We know that
-	// the iterator must already be positioned within or just outside the
-	// previous bounds. Therefore the topLevelIndex iter cannot be
-	// positioned at an entry ahead of the seek position (though it can be
-	// positioned behind). The !i.cmp(key, i.topLevelIndex.Key().UserKey) > 0
-	// confirms that it is not behind. Since it is not ahead and not behind
-	// it must be at the right position.
-	//
-	// 2) This SeekGE will land on a key that is greater than the key we are
-	// currently at (guaranteed by trySeekUsingNext), but since
-	// i.cmp(key, i.topLevelIndex.Key().UserKey) <= 0, we are at the correct
-	// lower level index block. No need to reset the state of singleLevelIterator.
 
 	if !dontSeekWithinSingleLevelIter {
 		// Note that while trySeekUsingNext could be false here, singleLevelIterator
@@ -1581,7 +1727,23 @@ func (i *twoLevelIterator) SeekGE(key []byte, flags base.SeekGEFlags) (*Internal
 func (i *twoLevelIterator) SeekPrefixGE(
 	prefix, key []byte, flags base.SeekGEFlags,
 ) (*base.InternalKey, []byte) {
+	// NOTE: prefix is only used for bloom filter checking and not later work in
+	// this method. Hence, we can use the existing iterator position if the last
+	// SeekPrefixGE did not fail bloom filter matching.
+
+	err := i.err
 	i.err = nil // clear cached iteration error
+
+	// TODO(sumeer): we are not fully optimizing in the flags.TrySeekUsingNext()
+	// case when the twoLevelIterator is already exhausted. We will take the
+	// slow-path below, even though we could return now. We could do:
+	// filterUsedAndDidNotMatch :=
+	//	i.reader.tableFilter != nil && i.useFilter && !i.lastBloomFilterMatched
+	// if flags.TrySeekUsingNext() && (i.exhaustedBounds == +1 || (i.data.isDataInvalidated() &&
+	//  i.index.isDataInvalidated())) && i.err == nil {
+	//	// Already exhausted, so return nil.
+	//	return nil, nil
+	//}
 
 	// Check prefix bloom filter.
 	if i.reader.tableFilter != nil && i.useFilter {
@@ -1611,7 +1773,6 @@ func (i *twoLevelIterator) SeekPrefixGE(
 	}
 
 	// Bloom filter matches.
-	i.exhaustedBounds = 0
 
 	// SeekPrefixGE performs various step-instead-of-seeking optimizations: eg
 	// enabled by trySeekUsingNext, or by monotonically increasing bounds
@@ -1628,7 +1789,7 @@ func (i *twoLevelIterator) SeekPrefixGE(
 	// remembering the previous value of maybeFilteredKeysTwoLevel.
 
 	var dontSeekWithinSingleLevelIter bool
-	if i.topLevelIndex.isDataInvalidated() || !i.topLevelIndex.valid() ||
+	if i.topLevelIndex.isDataInvalidated() || !i.topLevelIndex.valid() || err != nil ||
 		i.boundsCmp <= 0 || i.cmp(key, i.topLevelIndex.Key().UserKey) > 0 {
 		// Slow-path: need to position the topLevelIndex.
 		//
@@ -1638,7 +1799,13 @@ func (i *twoLevelIterator) SeekPrefixGE(
 		// monotonic bounds). To apply it here, we would need to confirm that
 		// the topLevelIndex can continue using the same second level index
 		// block, and in that case we don't need to invalidate and reload the
-		// singleLevelIterator state.
+		// singleLevelIterator state. Do this after release blocker bug is fixed
+		// since don't want to backport this optimization.
+
+		// The previous exhausted state of singleLevelIterator is no longer
+		// relevant, since we may be moving to a different index block.
+		i.exhaustedBounds = 0
+
 		i.maybeFilteredKeysTwoLevel = false
 		flags = flags.DisableTrySeekUsingNext()
 		var ikey *InternalKey
@@ -1672,15 +1839,36 @@ func (i *twoLevelIterator) SeekPrefixGE(
 			// left == 0.
 			i.boundsCmp = 0
 		}
+	} else {
+		// INVARIANT: err == nil.
+		//
+		// Else fast-path: The bounds have moved forward and this SeekGE is
+		// respecting the lower bound (guaranteed by Iterator). We know that
+		// the iterator must already be positioned within or just outside the
+		// previous bounds. Therefore the topLevelIndex iter cannot be
+		// positioned at an entry ahead of the seek position (though it can be
+		// positioned behind). The !i.cmp(key, i.topLevelIndex.Key().UserKey) > 0
+		// confirms that it is not behind. Since it is not ahead and not behind
+		// it must be at the right position.
+		//
+		// This invariant checking is important enough that we do not gate it
+		// behind invariants.Enabled.
+		if i.boundsCmp <= 0 {
+			panic(fmt.Sprintf("boundsCmp %d is invalid for optimization", i.boundsCmp))
+		}
+		if flags.TrySeekUsingNext() {
+			panic("TrySeekUsingNext must not be true")
+		}
+
+		// Bounds have changed so the previous exhausted bounds state is
+		// irrelevant.
+		// WARNING-data-exhausted: this is safe to do only because the monotonic
+		// bounds optimizations only work when !data-exhausted. If they also
+		// worked with data-exhausted, we have made it unclear whether
+		// data-exhausted is actually true. See the comment at the top of the
+		// file.
+		i.exhaustedBounds = 0
 	}
-	// Else fast-path: The bounds have moved forward and this SeekGE is
-	// respecting the lower bound (guaranteed by Iterator). We know that
-	// the iterator must already be positioned within or just outside the
-	// previous bounds. Therefore the topLevelIndex iter cannot be
-	// positioned at an entry ahead of the seek position (though it can be
-	// positioned behind). The !i.cmp(key, i.topLevelIndex.Key().UserKey) > 0
-	// confirms that it is not behind. Since it is not ahead and not behind
-	// it must be at the right position.
 
 	if !dontSeekWithinSingleLevelIter {
 		if ikey, val := i.singleLevelIterator.seekPrefixGE(

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/cockroachdb/pebble/internal/errorfs"
+	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
@@ -206,7 +207,7 @@ func TestReader(t *testing.T) {
 							oName, lName, dName, iName),
 						func(t *testing.T) {
 							runTestReader(
-								t, tableOpt, testDirs[oName], nil /* Reader */, 0)
+								t, tableOpt, testDirs[oName], nil /* Reader */, 0, false)
 						})
 				}
 			}
@@ -234,7 +235,9 @@ func TestHamletReader(t *testing.T) {
 
 		t.Run(
 			fmt.Sprintf("sst=%s", prebuiltSST),
-			func(t *testing.T) { runTestReader(t, WriterOptions{}, "testdata/hamletreader", r, 0) },
+			func(t *testing.T) {
+				runTestReader(t, WriterOptions{}, "testdata/hamletreader", r, 0, false)
+			},
 		)
 	}
 }
@@ -244,7 +247,19 @@ func TestReaderStats(t *testing.T) {
 		BlockSize:      30,
 		IndexBlockSize: 30,
 	}
-	runTestReader(t, tableOpt, "testdata/readerstats", nil, 10000)
+	runTestReader(t, tableOpt, "testdata/readerstats", nil, 10000, false)
+}
+
+func TestReaderWithBlockPropertyFilter(t *testing.T) {
+	writerOpt := WriterOptions{
+		BlockSize: 1,
+		IndexBlockSize: 40,
+		Comparer: testkeys.Comparer,
+		TableFormat: TableFormatMax,
+		BlockPropertyCollectors: []func() BlockPropertyCollector{NewTestKeysBlockPropertyCollector},
+	}
+	runTestReader(
+		t, writerOpt, "testdata/reader_bpf", nil /* Reader */,0, true)
 }
 
 func TestInjectedErrors(t *testing.T) {
@@ -320,7 +335,44 @@ func TestInvalidReader(t *testing.T) {
 	}
 }
 
-func runTestReader(t *testing.T, o WriterOptions, dir string, r *Reader, cacheSize int) {
+func indexLayoutString(t *testing.T, r *Reader) string {
+	indexH, err := r.readIndex(nil /* stats */)
+	require.NoError(t, err)
+	defer indexH.Release()
+	var buf strings.Builder
+	twoLevelIndex := r.Properties.IndexType == twoLevelIndex
+	buf.WriteString("index entries:\n")
+	iter, err := newBlockIter(r.Compare, indexH.Get())
+	defer func() {
+		require.NoError(t, iter.Close())
+	}()
+	require.NoError(t, err)
+	for key, value := iter.First(); key != nil; key, value = iter.Next() {
+		bh, err := decodeBlockHandleWithProperties(value)
+		require.NoError(t, err)
+		fmt.Fprintf(&buf, " %s: size %d\n", string(key.UserKey), bh.Length)
+		if twoLevelIndex {
+			b, err := r.readBlock(bh.BlockHandle, nil, nil, nil)
+			require.NoError(t, err)
+			defer b.Release()
+			iter2, err := newBlockIter(r.Compare, b.Get())
+			defer func() {
+				require.NoError(t, iter2.Close())
+			}()
+			require.NoError(t, err)
+			for key, value := iter2.First(); key != nil; key, value = iter2.Next() {
+				bh, err := decodeBlockHandleWithProperties(value)
+				require.NoError(t, err)
+				fmt.Fprintf(&buf, "   %s: size %d\n", string(key.UserKey), bh.Length)
+			}
+		}
+	}
+	return buf.String()
+}
+
+func runTestReader(
+	t *testing.T, o WriterOptions, dir string, r *Reader, cacheSize int, printLayout bool,
+) {
 	datadriven.Walk(t, dir, func(t *testing.T, path string) {
 		defer func() {
 			if r != nil {
@@ -341,6 +393,9 @@ func runTestReader(t *testing.T, o WriterOptions, dir string, r *Reader, cacheSi
 				if err != nil {
 					return err.Error()
 				}
+				if printLayout {
+					return indexLayoutString(t, r)
+				}
 				return ""
 
 			case "iter":
@@ -350,10 +405,25 @@ func runTestReader(t *testing.T, o WriterOptions, dir string, r *Reader, cacheSi
 				}
 				var stats base.InternalIteratorStats
 				r.Properties.GlobalSeqNum = seqNum
+				var filterer *BlockPropertiesFilterer
+				if d.HasArg("block-property-filter") {
+					var filterMin, filterMax uint64
+					d.ScanArgs(t, "block-property-filter", &filterMin, &filterMax)
+					bpf := NewTestKeysBlockPropertyFilter(filterMin, filterMax)
+					filterer = NewBlockPropertiesFilterer([]BlockPropertyFilter{bpf}, nil)
+					intersects, err :=
+						filterer.IntersectsUserPropsAndFinishInit(r.Properties.UserProperties)
+					if err != nil {
+						return err.Error()
+					}
+					if !intersects {
+						return "table does not intersect BlockPropertyFilter"
+					}
+				}
 				iter, err := r.NewIterWithBlockPropertyFilters(
 					nil,  /* lower */
 					nil,  /* upper */
-					nil,  /* filterer */
+					filterer,
 					true, /* use filter block */
 					&stats,
 				)

--- a/sstable/testdata/reader_bpf/iter
+++ b/sstable/testdata/reader_bpf/iter
@@ -1,0 +1,56 @@
+# Test case for bug https://github.com/cockroachdb/pebble/issues/2036 Build
+# sstable with two-level index, with two data blocks in each lower-level index
+# block.
+build
+c@10.SET.10:cAT10
+d@7.SET.9:dAT7
+e@15.SET.8:eAT15
+f@7.SET.5:fAT7
+----
+index entries:
+ d@7: size 53
+   c@10: size 28
+   d@7: size 26
+ g: size 51
+   e@15: size 28
+   g: size 26
+
+iter
+first
+next
+next
+next
+----
+<c@10:10>
+<d@7:9>
+<e@15:8>
+<f@7:5>
+
+
+# The block property filter matches data block 2 and 4.
+iter block-property-filter=(7,8)
+first
+next
+----
+<d@7:9>
+<f@7:5>
+
+# Use the same block property filter, but use seeks to find these entries.
+# With the bug the second seek-ge below would step to the second lower-level
+# index block and only see the entry in the data block 4.
+iter block-property-filter=(7,8)
+set-bounds lower=a upper=c
+seek-ge a
+seek-ge b true
+set-bounds lower=c upper=g
+seek-ge c
+next
+next
+----
+.
+.
+.
+.
+<d@7:9>
+<f@7:5>
+.

--- a/testdata/external_iterator
+++ b/testdata/external_iterator
@@ -254,7 +254,7 @@ aaaa@1: (aaaa@1, .)
 aaaaa@3: (aaaaa@3, .)
 aaaaa@1: (aaaaa@1, .)
 stats: (interface (dir, seek, step): (fwd, 5, 5), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 5, 5), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 480 B, cached 0 B)), (points: (count 10, key-bytes 50, value-bytes 50, tombstoned: 0))
+(internal-stats: (block-bytes: (total 475 B, cached 0 B)), (points: (count 10, key-bytes 50, value-bytes 50, tombstoned: 0))
 
 # Note the inclusion of fwd-only. This iterator will use the TrySeekUsingNext
 # optimization and loads ~half the block-bytes as a result.
@@ -283,4 +283,4 @@ aaaa@1: (aaaa@1, .)
 aaaaa@3: (aaaaa@3, .)
 aaaaa@1: (aaaaa@1, .)
 stats: (interface (dir, seek, step): (fwd, 5, 5), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 5, 5), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 286 B, cached 0 B)), (points: (count 10, key-bytes 50, value-bytes 50, tombstoned: 0))
+(internal-stats: (block-bytes: (total 281 B, cached 0 B)), (points: (count 10, key-bytes 50, value-bytes 50, tombstoned: 0))

--- a/testdata/iter_histories/iter_optimizations
+++ b/testdata/iter_histories/iter_optimizations
@@ -200,7 +200,7 @@ stats
 lastPositioningOp="unknown"
 b@5: (b@5, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 120 B, cached 0 B)), (points: (count 1, key-bytes 3, value-bytes 3, tombstoned: 0))
+(internal-stats: (block-bytes: (total 119 B, cached 0 B)), (points: (count 1, key-bytes 3, value-bytes 3, tombstoned: 0))
 
 mutate batch=foo
 set h@2 h@2
@@ -216,7 +216,7 @@ stats
 lastPositioningOp="seekprefixge"
 c@3: (c@3, .)
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 120 B, cached 0 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+(internal-stats: (block-bytes: (total 119 B, cached 0 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
 
 mutate batch=foo
 set i@1 i@1
@@ -232,7 +232,7 @@ stats
 lastPositioningOp="seekprefixge"
 d@9: (d@9, .)
 stats: (interface (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 120 B, cached 0 B)), (points: (count 3, key-bytes 9, value-bytes 9, tombstoned: 0))
+(internal-stats: (block-bytes: (total 119 B, cached 0 B)), (points: (count 3, key-bytes 9, value-bytes 9, tombstoned: 0))
 
 mutate batch=foo
 set j@6 j@6
@@ -248,7 +248,7 @@ stats
 lastPositioningOp="seekprefixge"
 e@8: (e@8, .)
 stats: (interface (dir, seek, step): (fwd, 4, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 4, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 120 B, cached 0 B)), (points: (count 4, key-bytes 12, value-bytes 12, tombstoned: 0))
+(internal-stats: (block-bytes: (total 119 B, cached 0 B)), (points: (count 4, key-bytes 12, value-bytes 12, tombstoned: 0))
 
 # Ensure that a case eligible for TrySeekUsingNext across a SetOptions correctly
 # sees new batch mutations. The batch iterator should ignore the
@@ -340,7 +340,7 @@ seek-ge b@7
 .
 .
 .
-lastPositioningOp="unknown"
+lastPositioningOp="invalidate"
 b@6: (b@6, .)
 
 reset

--- a/testdata/iter_histories/range_key_changed
+++ b/testdata/iter_histories/range_key_changed
@@ -272,4 +272,3 @@ first
 d: (., [d-e) @1=foo UPDATED)
 .
 c: (c, .)
-

--- a/testdata/iter_histories/range_key_masking
+++ b/testdata/iter_histories/range_key_masking
@@ -168,7 +168,7 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 515 B, cached 515 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+(internal-stats: (block-bytes: (total 514 B, cached 514 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
 
 # Perform a similar comparison in reverse.
 
@@ -190,7 +190,7 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 515 B, cached 515 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+(internal-stats: (block-bytes: (total 514 B, cached 514 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
 
 # Perform similar comparisons with seeks.
 
@@ -202,7 +202,7 @@ stats
 m: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 790 B, cached 790 B)), (points: (count 13, key-bytes 39, value-bytes 39, tombstoned: 0))
+(internal-stats: (block-bytes: (total 789 B, cached 789 B)), (points: (count 13, key-bytes 39, value-bytes 39, tombstoned: 0))
 
 combined-iter mask-suffix=@9 mask-filter
 seek-ge m
@@ -212,7 +212,7 @@ stats
 m: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 515 B, cached 515 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+(internal-stats: (block-bytes: (total 514 B, cached 514 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
 
 combined-iter mask-suffix=@9
 seek-lt m
@@ -222,7 +222,7 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 790 B, cached 790 B)), (points: (count 12, key-bytes 36, value-bytes 36, tombstoned: 0))
+(internal-stats: (block-bytes: (total 789 B, cached 789 B)), (points: (count 12, key-bytes 36, value-bytes 36, tombstoned: 0))
 
 combined-iter mask-suffix=@9 mask-filter
 seek-lt m
@@ -232,4 +232,4 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 540 B, cached 540 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+(internal-stats: (block-bytes: (total 539 B, cached 539 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))


### PR DESCRIPTION
(backport, cherrypicked from commit fc37e522eff27f4a214c3669137ec27d88893daf)

The current TrySeekUsingNext optimization had a bug where a first SeekGE could set exhaustedBounds=+1, and the next
monotonic twoLevelIterator.SeekGE (without changing bounds) would set exhaustedBounds back to 0, call singleLevelIterator.SeekGE which would immediately return because of i.data.isDataInvalidated() (and TrySeekUsingNext), which would cause the twoLevelIterator to step the top-level index iterator.
This woud break a subsequent optimization when the bounds were monotonically advanced, since the top-level index iterator had been advanced too far. See https://github.com/cockroachdb/pebble/issues/2036#issuecomment-1287290559 for an example of the bug.

Given that both singleLevelIterator and twoLevelIterator use the exhaustedBounds value from the previous SeekGE call for the TrySeekUsingNext optimization, the twoLevelIterator should be selective on when it resets exhaustedBounds to 0. The logic behind when this can be done is not complex, so should be maintainable.

This bug should only occur when using block property filters with the monotonic bound optimization: the second SeekGE in the above, which moves the top-level index too far forward would not happen if the singleLevelIterator was actually loading data blocks, since the singleLevelIterator would do some work and set exhaustedBound back to +1.

The PR also constrains this TrySeekUsingNext fast path to the case where i.err == nil. This was an oversight, though very unlikely to happen in practice.

There are todos added to make further changes after we backport this change:
- The twoLevelIterator.SeekPrefixGE code does not currently utilize TrySeekUsingNext. There is no reason to hold back on this optimization.
- The cases where the twoLevelIterator is already exhausted are not optimized. We will wastefully reseek the top level index.

Fixes #2036