### PR TITLE
db: adaptive size-based rollover logic for manifest

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -916,6 +916,7 @@ func TestRollManifest(t *testing.T) {
 	opts := &Options{
 		MaxManifestFileSize:   1,
 		L0CompactionThreshold: 10,
+		L0StopWritesThreshold: 1000,
 		FS:                    vfs.NewMem(),
 		NumPrevManifest:       int(toPreserve),
 	}
@@ -929,6 +930,11 @@ func TestRollManifest(t *testing.T) {
 		defer d.mu.Unlock()
 		return d.mu.versions.manifestFileNum
 	}
+	sizeRolloverState := func() (int64, int64) {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+		return d.mu.versions.lastSnapshotFileCount, d.mu.versions.editsSinceLastSnapshotFileCount
+	}
 
 	current := func() string {
 		desc, err := Peek(d.dirname, d.opts.FS)
@@ -939,11 +945,46 @@ func TestRollManifest(t *testing.T) {
 	lastManifestNum := manifestFileNumber()
 	manifestNums := []base.FileNum{lastManifestNum}
 	for i := 0; i < 5; i++ {
-		require.NoError(t, d.Set([]byte("a"), nil, nil))
-		require.NoError(t, d.Flush())
+		// MaxManifestFileSize is 1, but the rollover logic also counts edits
+		// since the last snapshot to decide on rollover, so do as many flushes as
+		// it demands.
+		lastSnapshotCount, editsSinceSnapshotCount := sizeRolloverState()
+		var expectedLastSnapshotCount, expectedEditsSinceSnapshotCount int64
+		switch i {
+		case 0:
+			// DB is empty.
+			expectedLastSnapshotCount, expectedEditsSinceSnapshotCount = 0, 0
+		case 1:
+			// First edit that caused rollover is not in the snapshot.
+			expectedLastSnapshotCount, expectedEditsSinceSnapshotCount = 0, 1
+		case 2:
+			// One flush is in the snapshot. One flush in the edit.
+			expectedLastSnapshotCount, expectedEditsSinceSnapshotCount = 1, 1
+		case 3:
+			// Two flushes in the snapshot. One flush in the edit. Will need to do
+			// two more flushes, the first of which will be in the next snapshot.
+			expectedLastSnapshotCount, expectedEditsSinceSnapshotCount = 2, 1
+		case 4:
+			// Four flushes in the snapshot. One flush in the edit. Will need to do
+			// four more flushes, three of which will be in the snapshot.
+			expectedLastSnapshotCount, expectedEditsSinceSnapshotCount = 4, 1
+		}
+		require.Equal(t, expectedLastSnapshotCount, lastSnapshotCount)
+		require.Equal(t, expectedEditsSinceSnapshotCount, editsSinceSnapshotCount)
+		// Number of flushes to do to trigger the rollover.
+		steps := int(lastSnapshotCount - editsSinceSnapshotCount + 1)
+		// Steps can be <= 0, but we need to do at least one edit to trigger the
+		// rollover logic.
+		if steps <= 0 {
+			steps = 1
+		}
+		for j := 0; j < steps; j++ {
+			require.NoError(t, d.Set([]byte("a"), nil, nil))
+			require.NoError(t, d.Flush())
+		}
 		num := manifestFileNumber()
 		if lastManifestNum == num {
-			t.Fatalf("manifest failed to roll: %d == %d", lastManifestNum, num)
+			t.Fatalf("manifest failed to roll %d: %d == %d", i, lastManifestNum, num)
 		}
 
 		manifestNums = append(manifestNums, num)
@@ -954,6 +995,9 @@ func TestRollManifest(t *testing.T) {
 			t.Fatalf("expected %s, but found %s", expectedCurrent, v)
 		}
 	}
+	lastSnapshotCount, editsSinceSnapshotCount := sizeRolloverState()
+	require.EqualValues(t, 8, lastSnapshotCount)
+	require.EqualValues(t, 1, editsSinceSnapshotCount)
 
 	files, err := d.opts.FS.List("")
 	require.NoError(t, err)
@@ -981,6 +1025,37 @@ func TestRollManifest(t *testing.T) {
 		)
 	}
 	require.EqualValues(t, expected, manifests)
+
+	// Test the logic that uses the future snapshot size to rollover.
+	// Reminder: we have a snapshot with 8 files and the manifest has 1 edit
+	// (flush) with 1 file.
+	// Add 8 more files with a different key.
+	lastManifestNum = manifestFileNumber()
+	for j := 0; j < 8; j++ {
+		require.NoError(t, d.Set([]byte("c"), nil, nil))
+		require.NoError(t, d.Flush())
+	}
+	lastSnapshotCount, editsSinceSnapshotCount = sizeRolloverState()
+	// Need 16 more files in edits to trigger a rollover.
+	require.EqualValues(t, 16, lastSnapshotCount)
+	require.EqualValues(t, 1, editsSinceSnapshotCount)
+	require.NotEqual(t, manifestFileNumber(), lastManifestNum)
+	lastManifestNum = manifestFileNumber()
+	// Do a compaction that moves 8 of the files from L0 to 1 file in L6. This
+	// adds 9 files in edits. We still need 6 more files in edits based on the
+	// last snapshot. But the current version has only 9 L0 files and 1 L6 file,
+	// for a total of 10 files. So 1 flush should push us over that threshold.
+	d.Compact([]byte("c"), []byte("d"), false)
+	lastSnapshotCount, editsSinceSnapshotCount = sizeRolloverState()
+	require.EqualValues(t, 16, lastSnapshotCount)
+	require.EqualValues(t, 10, editsSinceSnapshotCount)
+	require.Equal(t, manifestFileNumber(), lastManifestNum)
+	require.NoError(t, d.Set([]byte("c"), nil, nil))
+	require.NoError(t, d.Flush())
+	lastSnapshotCount, editsSinceSnapshotCount = sizeRolloverState()
+	require.EqualValues(t, 10, lastSnapshotCount)
+	require.EqualValues(t, 1, editsSinceSnapshotCount)
+	require.NotEqual(t, manifestFileNumber(), lastManifestNum)
 
 	require.NoError(t, d.Close())
 }

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -50,20 +50,14 @@ create: db/marker.format-version.000007.008
 close: db/marker.format-version.000007.008
 sync: db
 upgraded to format version: 008
-create: db/MANIFEST-000003
-close: db/MANIFEST-000001
-sync: db/MANIFEST-000003
-create: db/marker.manifest.000002.MANIFEST-000003
-close: db/marker.manifest.000002.MANIFEST-000003
-sync: db
-[JOB 1] MANIFEST created 000003
+sync: db/MANIFEST-000001
 create: wal/000002.log
 sync: wal
 [JOB 1] WAL created 000002
-create: db/temporary.000004.dbtmp
-sync: db/temporary.000004.dbtmp
-close: db/temporary.000004.dbtmp
-rename: db/temporary.000004.dbtmp -> db/OPTIONS-000004
+create: db/temporary.000003.dbtmp
+sync: db/temporary.000003.dbtmp
+close: db/temporary.000003.dbtmp
+rename: db/temporary.000003.dbtmp -> db/OPTIONS-000003
 sync: db
 
 flush
@@ -71,110 +65,109 @@ flush
 sync: wal/000002.log
 sync: wal/000002.log
 close: wal/000002.log
-create: wal/000005.log
+create: wal/000004.log
 sync: wal
-[JOB 3] WAL created 000005
+[JOB 3] WAL created 000004
 [JOB 4] flushing 1 memtable to L0
-create: db/000006.sst
-[JOB 4] flushing: sstable created 000006
-sync: db/000006.sst
-close: db/000006.sst
+create: db/000005.sst
+[JOB 4] flushing: sstable created 000005
+sync: db/000005.sst
+close: db/000005.sst
 sync: db
-create: db/MANIFEST-000007
-close: db/MANIFEST-000003
-sync: db/MANIFEST-000007
-create: db/marker.manifest.000003.MANIFEST-000007
-close: db/marker.manifest.000003.MANIFEST-000007
+create: db/MANIFEST-000006
+close: db/MANIFEST-000001
+sync: db/MANIFEST-000006
+create: db/marker.manifest.000002.MANIFEST-000006
+close: db/marker.manifest.000002.MANIFEST-000006
 sync: db
-[JOB 4] MANIFEST created 000007
-[JOB 4] flushed 1 memtable to L0 [000006] (770 B), in 1.0s (2.0s total), output rate 770 B/s
-[JOB 4] MANIFEST deleted 000001
+[JOB 4] MANIFEST created 000006
+[JOB 4] flushed 1 memtable to L0 [000005] (770 B), in 1.0s (2.0s total), output rate 770 B/s
 
 compact
 ----
-sync: wal/000005.log
-sync: wal/000005.log
-close: wal/000005.log
-reuseForWrite: wal/000002.log -> wal/000008.log
+sync: wal/000004.log
+sync: wal/000004.log
+close: wal/000004.log
+reuseForWrite: wal/000002.log -> wal/000007.log
 sync: wal
-[JOB 5] WAL created 000008 (recycled 000002)
+[JOB 5] WAL created 000007 (recycled 000002)
 [JOB 6] flushing 1 memtable to L0
-create: db/000009.sst
-[JOB 6] flushing: sstable created 000009
-sync: db/000009.sst
-close: db/000009.sst
+create: db/000008.sst
+[JOB 6] flushing: sstable created 000008
+sync: db/000008.sst
+close: db/000008.sst
 sync: db
-create: db/MANIFEST-000010
-close: db/MANIFEST-000007
-sync: db/MANIFEST-000010
-create: db/marker.manifest.000004.MANIFEST-000010
-close: db/marker.manifest.000004.MANIFEST-000010
+create: db/MANIFEST-000009
+close: db/MANIFEST-000006
+sync: db/MANIFEST-000009
+create: db/marker.manifest.000003.MANIFEST-000009
+close: db/marker.manifest.000003.MANIFEST-000009
 sync: db
-[JOB 6] MANIFEST created 000010
-[JOB 6] flushed 1 memtable to L0 [000009] (770 B), in 1.0s (2.0s total), output rate 770 B/s
-[JOB 6] MANIFEST deleted 000003
-[JOB 7] compacting(default) L0 [000006 000009] (1.5 K) + L6 [] (0 B)
-create: db/000011.sst
-[JOB 7] compacting: sstable created 000011
-sync: db/000011.sst
-close: db/000011.sst
+[JOB 6] MANIFEST created 000009
+[JOB 6] flushed 1 memtable to L0 [000008] (770 B), in 1.0s (2.0s total), output rate 770 B/s
+[JOB 6] MANIFEST deleted 000001
+[JOB 7] compacting(default) L0 [000005 000008] (1.5 K) + L6 [] (0 B)
+create: db/000010.sst
+[JOB 7] compacting: sstable created 000010
+sync: db/000010.sst
+close: db/000010.sst
 sync: db
-create: db/MANIFEST-000012
-close: db/MANIFEST-000010
-sync: db/MANIFEST-000012
-create: db/marker.manifest.000005.MANIFEST-000012
-close: db/marker.manifest.000005.MANIFEST-000012
+create: db/MANIFEST-000011
+close: db/MANIFEST-000009
+sync: db/MANIFEST-000011
+create: db/marker.manifest.000004.MANIFEST-000011
+close: db/marker.manifest.000004.MANIFEST-000011
 sync: db
-[JOB 7] MANIFEST created 000012
-[JOB 7] compacted(default) L0 [000006 000009] (1.5 K) + L6 [] (0 B) -> L6 [000011] (770 B), in 1.0s (2.0s total), output rate 770 B/s
-[JOB 7] sstable deleted 000006
-[JOB 7] sstable deleted 000009
-[JOB 7] MANIFEST deleted 000007
+[JOB 7] MANIFEST created 000011
+[JOB 7] compacted(default) L0 [000005 000008] (1.5 K) + L6 [] (0 B) -> L6 [000010] (770 B), in 1.0s (2.0s total), output rate 770 B/s
+[JOB 7] sstable deleted 000005
+[JOB 7] sstable deleted 000008
+[JOB 7] MANIFEST deleted 000006
 
 disable-file-deletions
 ----
 
 flush
 ----
-sync: wal/000008.log
-sync: wal/000008.log
-close: wal/000008.log
-reuseForWrite: wal/000005.log -> wal/000013.log
+sync: wal/000007.log
+sync: wal/000007.log
+close: wal/000007.log
+reuseForWrite: wal/000004.log -> wal/000012.log
 sync: wal
-[JOB 8] WAL created 000013 (recycled 000005)
+[JOB 8] WAL created 000012 (recycled 000004)
 [JOB 9] flushing 1 memtable to L0
-create: db/000014.sst
-[JOB 9] flushing: sstable created 000014
-sync: db/000014.sst
-close: db/000014.sst
+create: db/000013.sst
+[JOB 9] flushing: sstable created 000013
+sync: db/000013.sst
+close: db/000013.sst
 sync: db
-create: db/MANIFEST-000015
-close: db/MANIFEST-000012
-sync: db/MANIFEST-000015
-create: db/marker.manifest.000006.MANIFEST-000015
-close: db/marker.manifest.000006.MANIFEST-000015
+create: db/MANIFEST-000014
+close: db/MANIFEST-000011
+sync: db/MANIFEST-000014
+create: db/marker.manifest.000005.MANIFEST-000014
+close: db/marker.manifest.000005.MANIFEST-000014
 sync: db
-[JOB 9] MANIFEST created 000015
-[JOB 9] flushed 1 memtable to L0 [000014] (770 B), in 1.0s (2.0s total), output rate 770 B/s
+[JOB 9] MANIFEST created 000014
+[JOB 9] flushed 1 memtable to L0 [000013] (770 B), in 1.0s (2.0s total), output rate 770 B/s
 
 enable-file-deletions
 ----
-[JOB 10] MANIFEST deleted 000010
+[JOB 10] MANIFEST deleted 000009
 
 ingest
 ----
-link: ext/0 -> db/000016.sst
-[JOB 11] ingesting: sstable created 000016
+link: ext/0 -> db/000015.sst
+[JOB 11] ingesting: sstable created 000015
 sync: db
-create: db/MANIFEST-000017
-close: db/MANIFEST-000015
-sync: db/MANIFEST-000017
-create: db/marker.manifest.000007.MANIFEST-000017
-close: db/marker.manifest.000007.MANIFEST-000017
+create: db/MANIFEST-000016
+close: db/MANIFEST-000014
+sync: db/MANIFEST-000016
+create: db/marker.manifest.000006.MANIFEST-000016
+close: db/marker.manifest.000006.MANIFEST-000016
 sync: db
-[JOB 11] MANIFEST created 000017
-[JOB 11] MANIFEST deleted 000012
-[JOB 11] ingested L0:000016 (825 B)
+[JOB 11] MANIFEST created 000016
+[JOB 11] MANIFEST deleted 000011
+[JOB 11] ingested L0:000015 (825 B)
 
 metrics
 ----
@@ -203,10 +196,10 @@ zmemtbl         0     0 B
 sstables
 ----
 0:
-  14:[a-a]
-  16:[a-a]
+  13:[a-a]
+  15:[a-a]
 6:
-  11:[a-a]
+  10:[a-a]
 
 checkpoint
 ----
@@ -215,28 +208,28 @@ open-dir:
 sync: 
 close: 
 open-dir: checkpoint
-link: db/OPTIONS-000004 -> checkpoint/OPTIONS-000004
+link: db/OPTIONS-000003 -> checkpoint/OPTIONS-000003
 open-dir: checkpoint
 create: checkpoint/marker.format-version.000001.008
 sync: checkpoint/marker.format-version.000001.008
 close: checkpoint/marker.format-version.000001.008
 sync: checkpoint
 close: checkpoint
-create: checkpoint/MANIFEST-000017
-sync: checkpoint/MANIFEST-000017
-close: checkpoint/MANIFEST-000017
+create: checkpoint/MANIFEST-000016
+sync: checkpoint/MANIFEST-000016
+close: checkpoint/MANIFEST-000016
 open-dir: checkpoint
-create: checkpoint/marker.manifest.000001.MANIFEST-000017
-sync: checkpoint/marker.manifest.000001.MANIFEST-000017
-close: checkpoint/marker.manifest.000001.MANIFEST-000017
+create: checkpoint/marker.manifest.000001.MANIFEST-000016
+sync: checkpoint/marker.manifest.000001.MANIFEST-000016
+close: checkpoint/marker.manifest.000001.MANIFEST-000016
 sync: checkpoint
 close: checkpoint
-link: db/000014.sst -> checkpoint/000014.sst
-link: db/000016.sst -> checkpoint/000016.sst
-link: db/000011.sst -> checkpoint/000011.sst
-create: checkpoint/000013.log
-sync: checkpoint/000013.log
-close: checkpoint/000013.log
+link: db/000013.sst -> checkpoint/000013.sst
+link: db/000015.sst -> checkpoint/000015.sst
+link: db/000010.sst -> checkpoint/000010.sst
+create: checkpoint/000012.log
+sync: checkpoint/000012.log
+close: checkpoint/000012.log
 sync: checkpoint
 close: checkpoint
 
@@ -247,9 +240,9 @@ pebble: file deletion disablement invariant violated
 close
 ----
 close: db
-sync: wal/000013.log
-close: wal/000013.log
-close: db/MANIFEST-000017
+sync: wal/000012.log
+close: wal/000012.log
+close: db/MANIFEST-000016
 close: db
 close: db
 close: wal

--- a/version_set.go
+++ b/version_set.go
@@ -110,6 +110,9 @@ type versionSet struct {
 
 	writing    bool
 	writerCond sync.Cond
+	// State for deciding when to write a snapshot. Protected by mu.
+	lastSnapshotFileCount           int64
+	editsSinceLastSnapshotFileCount int64
 }
 
 func (vs *versionSet) init(
@@ -391,13 +394,76 @@ func (vs *versionSet) logAndApply(
 	currentVersion := vs.currentVersion()
 	var newVersion *version
 
-	// Generate a new manifest if we don't currently have one, or the current one
-	// is too large.
+	// Generate a new manifest if we don't currently have one, or forceRotation
+	// is true, or the current one is too large.
+	//
+	// For largeness, we do not exclusively use MaxManifestFileSize size
+	// threshold since we have had incidents where due to either large keys or
+	// large numbers of files, each edit results in a snapshot + write of the
+	// edit. This slows the system down since each flush or compaction is
+	// writing a new manifest snapshot. The primary goal of the size-based
+	// rollover logic is to ensure that when reopening a DB, the number of edits
+	// that need to be replayed on top of the snapshot is "sane". Rolling over
+	// to a new manifest after each edit is not relevant to that goal.
+	//
+	// Consider the following cases:
+	// - The number of live files F in the DB is roughly stable: after writing
+	//   the snapshot (with F files), say we require that there be enough edits
+	//   such that the cumulative number of files in those edits, E, be greater
+	//   than F. This will ensure that the total amount of time in logAndApply
+	//   that is spent in snapshot writing is ~50%.
+	//
+	// - The number of live files F in the DB is shrinking drastically, say from
+	//   F to F/10: This can happen for various reasons, like wide range
+	//   tombstones, or large numbers of smaller than usual files that are being
+	//   merged together into larger files. And say the new files generated
+	//   during this shrinkage is insignificant compared to F/10, and so for
+	//   this example we will assume it is effectively 0. After this shrinking,
+	//   E = 0.9F, and so if we used the previous snapshot file count, F, as the
+	//   threshold that needs to be exceeded, we will further delay the snapshot
+	//   writing. Which means on DB reopen we will need to replay 0.9F edits to
+	//   get to a version with 0.1F files. It would be better to create a new
+	//   snapshot when E exceeds the number of files in the current version.
+	//
+	// - The number of live files F in the DB is growing via perfect ingests
+	//   into L6: Say we wrote the snapshot when there were F files and now we
+	//   have 10F files, so E = 9F. We will further delay writing a new
+	//   snapshot. This case can be critiqued as contrived, but we consider it
+	//   nonetheless.
+	//
+	// The logic below uses the min of the last snapshot file count and the file
+	// count in the current version.
+	editCount := int64(len(ve.DeletedFiles) + len(ve.NewFiles))
+	vs.editsSinceLastSnapshotFileCount += editCount
+	sizeExceeded := vs.manifest.Size() >= vs.opts.MaxManifestFileSize
+	requireRotation := forceRotation || vs.manifest == nil
+	computeNextSnapshotFileCount := func() int64 {
+		var count int64
+		for i := range vs.metrics.Levels {
+			count += vs.metrics.Levels[i].NumFiles
+		}
+		return count
+	}
+	var nextSnapshotFileCount int64
+	if sizeExceeded && !requireRotation {
+		if vs.editsSinceLastSnapshotFileCount > vs.lastSnapshotFileCount {
+			requireRotation = true
+		} else {
+			nextSnapshotFileCount = computeNextSnapshotFileCount()
+			if vs.editsSinceLastSnapshotFileCount > nextSnapshotFileCount {
+				requireRotation = true
+			}
+		}
+	}
 	var newManifestFileNum FileNum
 	var prevManifestFileSize uint64
-	if forceRotation || vs.manifest == nil || vs.manifest.Size() >= vs.opts.MaxManifestFileSize {
+	if requireRotation {
 		newManifestFileNum = vs.getNextFileNum()
 		prevManifestFileSize = uint64(vs.manifest.Size())
+		if nextSnapshotFileCount == 0 {
+			// Haven't computed it, or happens to be 0.
+			nextSnapshotFileCount = computeNextSnapshotFileCount()
+		}
 	}
 
 	// Grab certain values before releasing vs.mu, in case createManifest() needs
@@ -474,6 +540,11 @@ func (vs *versionSet) logAndApply(
 		return err
 	}
 
+	if requireRotation {
+		// Successfully rotated.
+		vs.lastSnapshotFileCount = nextSnapshotFileCount
+		vs.editsSinceLastSnapshotFileCount = editCount
+	}
 	// Now that DB.mu is held again, initialize compacting file info in
 	// L0Sublevels.
 	inProgress := inProgressCompactions()

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -38,7 +38,10 @@ func TestVersionSetCheckpoint(t *testing.T) {
 
 	// Multiple manifest files are created such that the latest one must have a correct snapshot
 	// of the preceding state for the DB to be opened correctly and see the written data.
+	// Snapshot has no files, so first edit will cause manifest rotation.
 	writeAndIngest(t, mem, d, base.MakeInternalKey([]byte("a"), 0, InternalKeyKindSet), []byte("b"), "a")
+	// Snapshot has no files, and manifest has an edit from the previous ingest,
+	// so this second ingest will cause manifest rotation.
 	writeAndIngest(t, mem, d, base.MakeInternalKey([]byte("c"), 0, InternalKeyKindSet), []byte("d"), "c")
 	require.NoError(t, d.Close())
 	d, err = Open("", opts)
@@ -65,7 +68,10 @@ func TestVersionSetSeqNums(t *testing.T) {
 	d, err := Open("", opts)
 	require.NoError(t, err)
 
+	// Snapshot has no files, so first edit will cause manifest rotation.
 	writeAndIngest(t, mem, d, base.MakeInternalKey([]byte("a"), 0, InternalKeyKindSet), []byte("b"), "a")
+	// Snapshot has no files, and manifest has an edit from the previous ingest,
+	// so this second ingest will cause manifest rotation.
 	writeAndIngest(t, mem, d, base.MakeInternalKey([]byte("c"), 0, InternalKeyKindSet), []byte("d"), "c")
 	require.NoError(t, d.Close())
 	d, err = Open("", opts)


### PR DESCRIPTION
(cherrypick of https://github.com/cockroachdb/pebble/commit/28e54a5a2383b2eb3e0ac844b3050080a3bc944d)

In addition to the manifest file size, the logic now waits until the number of files in subsequent edits exceeds the minimim of the number of files in the last snapshot and the prospective next snapshot. This should prevent pathological situations where a large manifest snapshot exceeds the size threshold, due to which we would rollover after each edit, resulting in slow flushes and compactions.

Some justification for this change: The primary goal of the size-based rollover logic is to ensure that when reopening a DB, the number of edits that need to be replayed on top of the snapshot is "sane". Rolling over to a new manifest after each edit is not relevant to that goal. A secondary goal is to keep limited size amplification of the manifest by reducing how much file metadata we track for deleted files.

Consider the following cases:
- The number of live files F in the DB is roughly stable: after writing the snapshot (with F files), say we require that there be enough edits such that the cumulative number of files in those edits, E, be greater than F. This will ensure that the total amount of time in logAndApply that is spent in snapshot writing is ~50%.

- The number of live files F in the DB is shrinking drastically, say from F to F/10: This can happen for various reasons, like wide range tombstones, or large numbers of smaller than usual files that are being merged together into larger files. And say the new files generated during this shrinkage is insignificant compared to F/10, and so for this example we will assume it is effectively 0. After this shrinking, E = 0.9F, and so if we used the previous snapshot file count, F, as the threshold that needs to be exceeded, we will further delay the snapshot writing. So on DB reopen we will need to replay 0.9F edits to get to a version with 0.1F files. It would be better to create a new snapshot when E exceeds the number of files in the current version.

- The number of live files F in the DB is growing via perfect ingests into L6: Say we wrote the snapshot when there were F files and now we have 10F files, so E = 9F. We will further delay writing a new snapshot. This case can be critiqued as contrived, but we consider it nonetheless.

So the logic here uses the min of the last snapshot file count and the file count in the current version.

Informs #1741