### PR TITLE
sstable: add TableFormatPebblev3 for writing value blocks

### DIFF
--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -56,6 +56,9 @@ func TestRatchetFormat(t *testing.T) {
 	require.Equal(t, FormatPrePebblev1Marked, d.FormatMajorVersion())
 	require.NoError(t, d.RatchetFormatMajorVersion(FormatPrePebblev1MarkedCompacted))
 	require.Equal(t, FormatPrePebblev1MarkedCompacted, d.FormatMajorVersion())
+	require.NoError(t, d.RatchetFormatMajorVersion(FormatSSTableValueBlocks))
+	require.Equal(t, FormatSSTableValueBlocks, d.FormatMajorVersion())
+
 	require.NoError(t, d.Close())
 
 	// If we Open the database again, leaving the default format, the
@@ -215,6 +218,7 @@ func TestFormatMajorVersions_TableFormat(t *testing.T) {
 		FormatMinTableFormatPebblev1:       {sstable.TableFormatPebblev1, sstable.TableFormatPebblev2},
 		FormatPrePebblev1Marked:            {sstable.TableFormatPebblev1, sstable.TableFormatPebblev2},
 		FormatPrePebblev1MarkedCompacted:   {sstable.TableFormatPebblev1, sstable.TableFormatPebblev2},
+		FormatSSTableValueBlocks:           {sstable.TableFormatPebblev1, sstable.TableFormatPebblev3},
 	}
 
 	// Valid versions.

--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -362,9 +362,14 @@ func (k *InternalKey) SetKind(kind InternalKeyKind) {
 	k.Trailer = (k.Trailer &^ 0xff) | uint64(kind)
 }
 
-// Kind returns the kind compoment of the key.
+// Kind returns the kind component of the key.
 func (k InternalKey) Kind() InternalKeyKind {
-	return InternalKeyKind(k.Trailer & 0xff)
+	return TrailerKind(k.Trailer)
+}
+
+// TrailerKind returns the key kind of the key trailer.
+func TrailerKind(trailer uint64) InternalKeyKind {
+	return InternalKeyKind(trailer & 0xff)
 }
 
 // Valid returns true if the key has a valid kind.

--- a/internal/base/lazy_value.go
+++ b/internal/base/lazy_value.go
@@ -16,12 +16,8 @@ import "github.com/cockroachdb/pebble/internal/invariants"
 // it can call the ShortAttributeExtractor to extract the attribute and store
 // it together with the key. This allows for cheap retrieval of
 // AttributeAndLen on the read-path, without doing a more expensive retrieval
-// of the value.
-//
-// In general, the extraction code may want to also look at the key to decide
-// how to treat the value. Our current needs can be satisfied by configuring a
-// keyspan for which the ShortAttributeExtractor should be used, so we do not
-// expose the key to the extractor.
+// of the value. In general, the extraction code may want to also look at the
+// key to decide how to treat the value, hence the key* parameters.
 //
 // Write path performance: The ShortAttributeExtractor func cannot be inlined,
 // so we will pay the cost of this function call. However, we will only pay
@@ -38,7 +34,8 @@ const MaxShortAttribute = 7
 
 // ShortAttributeExtractor is an extractor that given the value, will return
 // the ShortAttribute.
-type ShortAttributeExtractor func(value []byte) (ShortAttribute, error)
+type ShortAttributeExtractor func(
+	key []byte, keyPrefixLen int, value []byte) (ShortAttribute, error)
 
 // AttributeAndLen represents the pair of value length and the short
 // attribute.

--- a/open_test.go
+++ b/open_test.go
@@ -147,7 +147,7 @@ func TestNewDBFilenames(t *testing.T) {
 			"LOCK",
 			"MANIFEST-000001",
 			"OPTIONS-000003",
-			"marker.format-version.000010.011",
+			"marker.format-version.000011.012",
 			"marker.manifest.000001.MANIFEST-000001",
 		},
 	}

--- a/sstable/format.go
+++ b/sstable/format.go
@@ -23,8 +23,12 @@ const (
 	TableFormatRocksDBv2
 	TableFormatPebblev1 // Block properties.
 	TableFormatPebblev2 // Range keys.
+	// TableFormatPebblev3 is not currently intended to subsume v2, as
+	// supporting value blocks adds a 1 byte prefix to each value. After
+	// thorough experimentation and some production experience, this may change.
+	TableFormatPebblev3 // Value blocks.
 
-	TableFormatMax = TableFormatPebblev2
+	TableFormatMax = TableFormatPebblev3
 )
 
 // ParseTableFormat parses the given magic bytes and version into its
@@ -46,6 +50,8 @@ func ParseTableFormat(magic []byte, version uint32) (TableFormat, error) {
 			return TableFormatPebblev1, nil
 		case 2:
 			return TableFormatPebblev2, nil
+		case 3:
+			return TableFormatPebblev3, nil
 		default:
 			return TableFormatUnspecified, base.CorruptionErrorf(
 				"pebble/table: unsupported pebble format version %d", errors.Safe(version),
@@ -69,6 +75,8 @@ func (f TableFormat) AsTuple() (string, uint32) {
 		return pebbleDBMagic, 1
 	case TableFormatPebblev2:
 		return pebbleDBMagic, 2
+	case TableFormatPebblev3:
+		return pebbleDBMagic, 3
 	default:
 		panic("sstable: unknown table format version tuple")
 	}
@@ -85,6 +93,8 @@ func (f TableFormat) String() string {
 		return "(Pebble,v1)"
 	case TableFormatPebblev2:
 		return "(Pebble,v2)"
+	case TableFormatPebblev3:
+		return "(Pebble,v3)"
 	default:
 		panic("sstable: unknown table format version tuple")
 	}

--- a/sstable/format_test.go
+++ b/sstable/format_test.go
@@ -43,6 +43,12 @@ func TestTableFormat_RoundTrip(t *testing.T) {
 			version: 2,
 			want:    TableFormatPebblev2,
 		},
+		{
+			name:    "PebbleDBv3",
+			magic:   pebbleDBMagic,
+			version: 3,
+			want:    TableFormatPebblev3,
+		},
 		// Invalid cases.
 		{
 			name:    "Invalid RocksDB version",
@@ -53,8 +59,8 @@ func TestTableFormat_RoundTrip(t *testing.T) {
 		{
 			name:    "Invalid PebbleDB version",
 			magic:   pebbleDBMagic,
-			version: 3,
-			wantErr: "pebble/table: unsupported pebble format version 3",
+			version: 4,
+			wantErr: "pebble/table: unsupported pebble format version 4",
 		},
 		{
 			name:    "Unknown magic string",

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -221,6 +221,18 @@ type WriterOptions struct {
 	// compress data blocks and write datablocks to disk in parallel with the
 	// Writer client goroutine.
 	Parallelism bool
+
+	// EnableValueBlocks mirrors Options.Experimental.EnableValueBlocks. Must
+	// be false if the TableFormat is < TableFormatPebblev3.
+	EnableValueBlocks bool
+
+	// ShortAttributeExtractor mirrors
+	// Options.Experimental.ShortAttributeExtractor.
+	ShortAttributeExtractor base.ShortAttributeExtractor
+
+	// RequiredInPlaceValueBound mirrors
+	// Options.Experimental.RequiredInPlaceValueBound.
+	RequiredInPlaceValueBound UserKeyPrefixBound
 }
 
 func (o WriterOptions) ensureDefaults() WriterOptions {

--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -120,6 +120,10 @@ type Properties struct {
 	NumRangeKeySets uint64 `prop:"pebble.num.range-key-sets"`
 	// The number of RANGEKEYUNSETs in this table.
 	NumRangeKeyUnsets uint64 `prop:"pebble.num.range-key-unsets"`
+	// The number of value blocks in this table. Only serialized if > 0.
+	NumValueBlocks uint64 `prop:"pebble.num.value-blocks"`
+	// The number of values stored in value blocks. Only serialized if > 0.
+	NumValuesInValueBlocks uint64 `prop:"pebble.num.values.in.value-blocks"`
 	// Timestamp of the earliest key. 0 if unknown.
 	OldestKeyTime uint64 `prop:"rocksdb.oldest.key.time"`
 	// The name of the prefix extractor used in this table. Empty if no prefix
@@ -142,6 +146,8 @@ type Properties struct {
 	TopLevelIndexSize uint64 `prop:"rocksdb.top-level.index.size"`
 	// User collected properties.
 	UserProperties map[string]string
+	// Total size of value blocks and value index block. Only serialized if > 0.
+	ValueBlocksSize uint64 `prop:"pebble.value-blocks.size"`
 	// If filtering is enabled, was the filter created on the whole key.
 	WholeKeyFiltering bool `prop:"rocksdb.block.based.table.whole.key.filtering"`
 
@@ -340,6 +346,12 @@ func (p *Properties) save(w *rawBlockWriter) {
 		p.saveUvarint(m, unsafe.Offsetof(p.RawRangeKeyKeySize), p.RawRangeKeyKeySize)
 		p.saveUvarint(m, unsafe.Offsetof(p.RawRangeKeyValueSize), p.RawRangeKeyValueSize)
 	}
+	if p.NumValueBlocks > 0 {
+		p.saveUvarint(m, unsafe.Offsetof(p.NumValueBlocks), p.NumValueBlocks)
+	}
+	if p.NumValuesInValueBlocks > 0 {
+		p.saveUvarint(m, unsafe.Offsetof(p.NumValuesInValueBlocks), p.NumValuesInValueBlocks)
+	}
 	p.saveUvarint(m, unsafe.Offsetof(p.OldestKeyTime), p.OldestKeyTime)
 	if p.PrefixExtractorName != "" {
 		p.saveString(m, unsafe.Offsetof(p.PrefixExtractorName), p.PrefixExtractorName)
@@ -350,6 +362,9 @@ func (p *Properties) save(w *rawBlockWriter) {
 	}
 	p.saveUvarint(m, unsafe.Offsetof(p.RawKeySize), p.RawKeySize)
 	p.saveUvarint(m, unsafe.Offsetof(p.RawValueSize), p.RawValueSize)
+	if p.ValueBlocksSize > 0 {
+		p.saveUvarint(m, unsafe.Offsetof(p.ValueBlocksSize), p.ValueBlocksSize)
+	}
 	p.saveBool(m, unsafe.Offsetof(p.WholeKeyFiltering), p.WholeKeyFiltering)
 
 	keys := make([]string, 0, len(m))

--- a/sstable/properties_test.go
+++ b/sstable/properties_test.go
@@ -88,18 +88,21 @@ func TestPropertiesSave(t *testing.T) {
 		NumRangeKeyDels:          19,
 		NumRangeKeySets:          20,
 		NumRangeKeyUnsets:        21,
-		OldestKeyTime:            22,
+		NumValueBlocks:           22,
+		NumValuesInValueBlocks:   23,
+		OldestKeyTime:            24,
 		PrefixExtractorName:      "prefix extractor name",
 		PrefixFiltering:          true,
 		PropertyCollectorNames:   "prefix collector names",
-		RawKeySize:               23,
-		RawValueSize:             24,
-		TopLevelIndexSize:        25,
+		RawKeySize:               25,
+		RawValueSize:             26,
+		TopLevelIndexSize:        27,
 		WholeKeyFiltering:        true,
 		UserProperties: map[string]string{
 			"user-prop-a": "1",
 			"user-prop-b": "2",
 		},
+		ValueBlocksSize: 28,
 	}
 
 	check1 := func(expected *Properties) {

--- a/sstable/raw_block.go
+++ b/sstable/raw_block.go
@@ -26,7 +26,7 @@ func (w *rawBlockWriter) add(key InternalKey, value []byte) {
 	w.curKey = w.curKey[:size]
 	copy(w.curKey, key.UserKey)
 
-	w.store(size, value)
+	w.storeWithOptionalValuePrefix(size, value, false, 0, false)
 }
 
 // rawBlockIter is an iterator over a single block of data. Unlike blockIter,

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -39,6 +39,14 @@ func RewriteKeySuffixes(
 	if err != nil {
 		return nil, err
 	}
+	// TODO(sumeer): Add support for value blocks. The valueHandles do not need
+	// to change. We need to (a) copy the value blocks, (b) rewrite the meta
+	// value index block as the block offsets can change, (c) update the entry
+	// in the metaindex block entry for the meta value index block. Also handle
+	// the set-has-same-prefix bit in restarts.
+	if r.tableFormat > TableFormatPebblev2 {
+		return nil, errors.Errorf("efficient key suffix rewriting is unsupported with value blocks")
+	}
 	defer r.Close()
 	return rewriteKeySuffixesInBlocks(r, out, o, from, to, concurrency)
 }

--- a/sstable/testdata/writer_value_blocks
+++ b/sstable/testdata/writer_value_blocks
@@ -1,0 +1,85 @@
+# Size of value index is 3 bytes plus 5 + 5 = 10 bytes of trailer of the value
+# block and value index block. So size 18 - 13 = 5 size of the value in the
+# value block.
+build
+a@2.SET.1:a2
+b@5.SET.7:b5
+b@4.DEL.3:
+b@3.SET.2:bat3
+b@2.SET.1:vbat2
+----
+value-blocks: num-values 1, num-blocks: 1, size: 18
+
+scan-raw
+----
+a@2#1,1:in-place a2, same-pre false
+b@5#7,1:in-place b5, same-pre false
+b@4#3,0:
+b@3#2,1:in-place bat3, same-pre false
+b@2#1,1:value-handle len 5 block 0 offset 0, att 5, same-pre true
+
+# Size of value index is 3 bytes plus 5 + 5 = 10 bytes of trailer of the value
+# block and value index block. So size 33 - 13 = 20 is the total size of the
+# values in the value block.
+build
+blue@10.SET.20:blue10
+blue@8.SET.18:blue8
+blue@8.SET.16:blue8s
+blue@6.DEL.14:
+blue@4.SET.12:blue4
+blue@3.SET.10:blue3
+red@9.SET.18:red9
+red@7.SET.8:red7
+----
+value-blocks: num-values 4, num-blocks: 1, size: 33
+
+scan-raw
+----
+blue@10#20,1:in-place blue10, same-pre false
+blue@8#18,1:value-handle len 5 block 0 offset 0, att 5, same-pre true
+blue@8#16,1:value-handle len 6 block 0 offset 5, att 6, same-pre true
+blue@6#14,0:
+blue@4#12,1:in-place blue4, same-pre false
+blue@3#10,1:value-handle len 5 block 0 offset 11, att 5, same-pre true
+red@9#18,1:in-place red9, same-pre false
+red@7#8,1:value-handle len 4 block 0 offset 16, att 4, same-pre true
+
+# Multiple value blocks. Trailers of 5+5+5 for the two value blocks and the
+# value index block, totals to 15. The values are 5+6+11=22. The value index
+# block has to encode two tuples, each of 4 bytes (blockNumByteLength=1,
+# blockOffsetByteLength=2, blockLengthByteLength=1), so 2*4=8. The total is
+# 15+22+8=45 bytes, which corresponds to "size: 45" below.
+build block-size=8
+blue@10.SET.20:blue10
+blue@8.SET.18:blue8
+blue@8.SET.16:blue8s
+blue@6.SET.16:blue6islong
+----
+value-blocks: num-values 3, num-blocks: 2, size: 45
+
+scan-raw
+----
+blue@10#20,1:in-place blue10, same-pre false
+blue@8#18,1:value-handle len 5 block 0 offset 0, att 5, same-pre true
+blue@8#16,1:value-handle len 6 block 0 offset 5, att 6, same-pre true
+blue@6#16,1:value-handle len 11 block 1 offset 0, att 3, same-pre true
+
+# Require that [c,e) must be in-place.
+build in-place-bound=(c,e)
+blue@10.SET.20:blue10
+blue@8.SET.18:blue8
+c@10.SET.16:c10
+c@8.SET.14:c8
+e@20.SET.25:eat20
+e@18.SET.23:eat18
+----
+value-blocks: num-values 2, num-blocks: 1, size: 23
+
+scan-raw
+----
+blue@10#20,1:in-place blue10, same-pre false
+blue@8#18,1:value-handle len 5 block 0 offset 0, att 5, same-pre true
+c@10#16,1:in-place c10, same-pre false
+c@8#14,1:in-place c8, same-pre false
+e@20#25,1:in-place eat20, same-pre false
+e@18#23,1:value-handle len 5 block 0 offset 5, att 5, same-pre true

--- a/sstable/value_block.go
+++ b/sstable/value_block.go
@@ -1,0 +1,606 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"encoding/binary"
+	"io"
+	"sync"
+	"unsafe"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/invariants"
+	"golang.org/x/exp/rand"
+)
+
+// Value blocks are supported in TableFormatPebblev3.
+//
+// Value blocks are a mechanism designed for sstables storing MVCC data, where
+// there can be many versions of a key that need to be kept, but only the
+// latest value is typically read. See the documentation for Comparer.Split
+// regarding MVCC keys.
+//
+// Note that the notion of the latest value is local to the sstable. It is
+// possible that that latest value has been deleted by a sstable in a higher
+// level, and what is the latest value from the perspective of the whole LSM
+// is an older MVCC version. This only affects performance and not
+// correctness. This local knowledge is also why we continue to store these
+// older versions in the same sstable -- we need to be able to conveniently
+// read them. The code in this file is agnostic to the policy regarding what
+// should be stored in value blocks -- it allows even the latest MVCC version
+// to be stored in a value block. The policy decision in made in the
+// sstable.Writer. See Writer.makeAddPointDecision.
+//
+// Data blocks contain two kinds of SET keys: those with in-place values and
+// those with a value handle. To distinguish these two cases we use a single
+// byte prefix (valuePrefix). This single byte prefix is split into multiple
+// parts, where nb represents information that is encoded in n bits.
+//
+// +---------------+--------------------+-----------+--------------------+
+// | value-kind 2b | SET-same-prefix 1b | unused 2b | short-attribute 3b |
+// +---------------+--------------------+-----------+--------------------+
+//
+// The 2 bit value-kind specifies whether this is an in-place value or a value
+// handle pointing to a value block. We use 2 bits here for future
+// representation of values that are in separate files. The 1 bit
+// SET-same-prefix is true if this key is a SET and is immediately preceded by
+// a SET that shares the same prefix. The 3 bit short-attribute is described
+// in base.ShortAttribute -- it stores user-defined attributes about the
+// value. It is unused for in-place values.
+//
+// Value Handle and Value Blocks:
+// valueHandles refer to values in value blocks. Value blocks are simpler than
+// normal data blocks (that contain key-value pairs, and allow for binary
+// search), which makes them cheap for value retrieval purposes. A valueHandle
+// is a tuple (valueLen, blockNum, offsetInBlock), where blockNum is the 0
+// indexed value block number and offsetInBlock is the byte offset in that
+// block containing the value. The valueHandle.valueLen is included since
+// there are multiple use cases in CockroachDB that need the value length but
+// not the value, for which we can avoid reading the value in the value block
+// (see
+// https://github.com/cockroachdb/pebble/issues/1170#issuecomment-958203245).
+//
+// A value block has a checksum like other blocks, and is optionally
+// compressed. An uncompressed value block is a sequence of values with no
+// separator or length (we rely on the valueHandle to demarcate). The
+// valueHandle.offsetInBlock points to the value, of length
+// valueHandle.valueLen. While writing a sstable, all the (possibly
+// compressed) value blocks need to be held in-memory until they can be
+// written. Value blocks are placed after the "meta rangedel" and "meta range
+// key" blocks since value blocks are considered less likely to be read.
+//
+// Meta Value Index Block:
+// Since the (key, valueHandle) pair are written before there is any knowledge
+// of the byte offset of the value block in the file, or its compressed
+// length, we need another lookup to map the valueHandle.blockNum to the
+// information needed to read it from the file. This information is provided
+// by the "value index block". The "value index block" is referred to by the
+// metaindex block. The design intentionally avoids making the "value index
+// block" a general purpose key-value block, since each caller wants to lookup
+// the information for a particular blockNum (there is no need for SeekGE
+// etc.). Instead, this index block stores a sequence of (blockNum,
+// blockOffset, blockLength) tuples, where the blockNums are consecutive
+// integers, and the tuples are encoded with a fixed width encoding. This
+// allows a reader to find the tuple for block K by looking at the offset
+// K*fixed-width. The fixed width for each field is decided by looking at the
+// maximum value of each of these fields. As a concrete example of a large
+// sstable with many value blocks, we constructed a 100MB sstable with many
+// versions and had 2475 value blocks (~32KB each). This sstable had this
+// tuple encoded using 2+4+2=8 bytes, which means the uncompressed value index
+// block was 2475*8=~19KB, which is modest. Therefore, we don't support more
+// than one value index block. Consider the example of 2 byte blockNum, 4 byte
+// blockOffset and 2 byte blockLen. The value index block will look like:
+//
+//   +---------------+------------------+---------------+
+//   | blockNum (2B) | blockOffset (4B) | blockLen (2B) |
+//   +---------------+------------------+---------------+
+//   |       0       |    7,123,456     |  30,000       |
+//   +---------------+------------------+---------------+
+//   |       1       |    7,153,456     |  20,000       |
+//   +---------------+------------------+---------------+
+//   |       2       |    7,173,456     |  25,567       |
+//   +---------------+------------------+---------------+
+//   |     ....      |      ...         |    ...        |
+//
+//
+// The metaindex block contains the valueBlocksIndexHandle which in addition
+// to the BlockHandle also specifies the widths of these tuple fields. In the
+// above example, the
+// valueBlockIndexHandle.{blockNumByteLength,blockOffsetByteLength,blockLengthByteLength}
+// will be (2,4,2).
+
+// valueHandle is stored with a key when the value is in a value block. This
+// handle is the pointer to that value.
+type valueHandle struct {
+	valueLen      uint32
+	blockNum      uint32
+	offsetInBlock uint32
+}
+
+// valuePrefix is the single byte prefix for either the in-place value or the
+// encoded valueHandle. It encoded multiple kinds of information.
+type valuePrefix byte
+
+const (
+	// 2 most-significant bits of valuePrefix encodes the value-kind.
+	valueKindMask           valuePrefix = '\xC0'
+	valueKindIsValueHandle  valuePrefix = '\x80'
+	valueKindIsInPlaceValue valuePrefix = '\x00'
+
+	// 1 bit indicates SET has same key prefix as immediately preceding key that
+	// is also a SET. This is optional, in that if this bit is false, there is
+	// no information.
+	//
+	// Note that the current policy of only storing older MVCC versions in value
+	// blocks means that valueKindIsValueHandle => SET has same prefix. But no
+	// code should rely on this behavior.
+	setHasSameKeyPrefixMask valuePrefix = '\x20'
+
+	// 3 least-significant bits for the user-defined base.ShortAttribute.
+	// Undefined for valueKindIsInPlaceValue.
+	userDefinedShortAttributeMask valuePrefix = '\x07'
+)
+
+// valueHandle fields are varint encoded, so maximum 5 bytes each, plus 1 byte
+// for the valuePrefix. This could alternatively be group varint encoded, but
+// experiments were inconclusive
+// (https://github.com/cockroachdb/pebble/pull/1443#issuecomment-1270298802).
+const valueHandleMaxLen = 5*3 + 1
+
+// Assert blockHandleLikelyMaxLen >= valueHandleMaxLen.
+const _ = uint(blockHandleLikelyMaxLen - valueHandleMaxLen)
+
+func encodeValueHandle(dst []byte, v valueHandle) int {
+	n := 0
+	n += binary.PutUvarint(dst[n:], uint64(v.valueLen))
+	n += binary.PutUvarint(dst[n:], uint64(v.blockNum))
+	n += binary.PutUvarint(dst[n:], uint64(v.offsetInBlock))
+	return n
+}
+
+func makePrefixForValueHandle(setHasSameKeyPrefix bool, attribute base.ShortAttribute) valuePrefix {
+	prefix := valueKindIsValueHandle | valuePrefix(attribute)
+	if setHasSameKeyPrefix {
+		prefix = prefix | setHasSameKeyPrefixMask
+	}
+	return prefix
+}
+
+func makePrefixForInPlaceValue(setHasSameKeyPrefix bool) valuePrefix {
+	prefix := valueKindIsInPlaceValue
+	if setHasSameKeyPrefix {
+		prefix = prefix | setHasSameKeyPrefixMask
+	}
+	return prefix
+}
+
+func isValueHandle(b valuePrefix) bool {
+	return b&valueKindMask == valueKindIsValueHandle
+}
+
+// REQUIRES: isValueHandle(b)
+func getShortAttribute(b valuePrefix) base.ShortAttribute {
+	return base.ShortAttribute(b & userDefinedShortAttributeMask)
+}
+
+func setHasSamePrefix(b valuePrefix) bool {
+	return b&setHasSameKeyPrefixMask == setHasSameKeyPrefixMask
+}
+
+func decodeValueHandle(src []byte) (valueHandle, error) {
+	var vh valueHandle
+	ptr := unsafe.Pointer(&src[0])
+	for i := 0; i < 3; i++ {
+		// Manually inlined uvarint decoding. Saves ~25% in
+		// BenchmarkValueBlocks/valueSize=100/versions=10/needValue=true/hasCache=true.
+		// If needed we can also unroll the loop, as done in blockIter.readEntry.
+		var v uint32
+		if a := *((*uint8)(ptr)); a < 128 {
+			v = uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 1)
+		} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+			v = uint32(b)<<7 | uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 2)
+		} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+			v = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 3)
+		} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+			v = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 4)
+		} else {
+			d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+			v = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+			ptr = unsafe.Pointer(uintptr(ptr) + 5)
+		}
+		switch i {
+		case 0:
+			vh.valueLen = v
+		case 1:
+			vh.blockNum = v
+		case 2:
+			vh.offsetInBlock = v
+		}
+	}
+	return vh, nil
+}
+
+// valueBlocksIndexHandle is placed in the metaindex if there are any value
+// blocks. If there are no value blocks, there is no value blocks index, and
+// no entry in the metaindex. Note that the lack of entry in the metaindex
+// should not be used to ascertain whether the values are prefixed, since the
+// former is an emergent property of the data that was written and not known
+// until all the key-value pairs in the sstable are written.
+type valueBlocksIndexHandle struct {
+	h                     BlockHandle
+	blockNumByteLength    uint8
+	blockOffsetByteLength uint8
+	blockLengthByteLength uint8
+}
+
+const valueBlocksIndexHandleMaxLen = blockHandleMaxLenWithoutProperties + 3
+
+// Assert blockHandleLikelyMaxLen >= valueBlocksIndexHandleMaxLen.
+const _ = uint(blockHandleLikelyMaxLen - valueBlocksIndexHandleMaxLen)
+
+func encodeValueBlocksIndexHandle(dst []byte, v valueBlocksIndexHandle) int {
+	n := encodeBlockHandle(dst, v.h)
+	dst[n] = v.blockNumByteLength
+	n++
+	dst[n] = v.blockOffsetByteLength
+	n++
+	dst[n] = v.blockLengthByteLength
+	n++
+	return n
+}
+
+func decodeValueBlocksIndexHandle(src []byte) (valueBlocksIndexHandle, int, error) {
+	var vbih valueBlocksIndexHandle
+	var n int
+	vbih.h, n = decodeBlockHandle(src)
+	if n <= 0 {
+		return vbih, 0, errors.Errorf("bad BlockHandle %x", src)
+	}
+	if len(src) != n+3 {
+		return vbih, 0, errors.Errorf("bad BlockHandle %x", src)
+	}
+	vbih.blockNumByteLength = src[n]
+	vbih.blockOffsetByteLength = src[n+1]
+	vbih.blockLengthByteLength = src[n+2]
+	return vbih, n + 3, nil
+}
+
+// TODO(sumeer): Incorporate into Pebble metrics.
+type valueBlocksAndIndexStats struct {
+	numValueBlocks         uint64
+	numValuesInValueBlocks uint64
+	// Includes both value blocks and value index block.
+	valueBlocksAndIndexSize uint64
+}
+
+// valueBlockWriter writes a sequence of value blocks, and the value blocks
+// index, for a sstable.
+type valueBlockWriter struct {
+	// The configured uncompressed block size and size threshold
+	blockSize, blockSizeThreshold int
+	// Configured compression.
+	compression Compression
+	// checksummer with configured checksum type.
+	checksummer checksummer
+	// Block finished callback.
+	blockFinishedFunc func(compressedSize int)
+
+	// buf is the current block being written to (uncompressed).
+	buf *blockBuffer
+	// compressedBuf is used for compressing the block.
+	compressedBuf *blockBuffer
+	// Sequence of blocks that are finished.
+	blocks []blockAndHandle
+	// Cumulative value block bytes written so far.
+	totalBlockBytes uint64
+	numValues       uint64
+}
+
+type blockAndHandle struct {
+	block      *blockBuffer
+	handle     BlockHandle
+	compressed bool
+}
+
+type blockBuffer struct {
+	b []byte
+}
+
+// Pool of block buffers that should be roughly the blockSize.
+var uncompressedValueBlockBufPool = sync.Pool{
+	New: func() interface{} {
+		return &blockBuffer{}
+	},
+}
+
+// Pool of block buffers for compressed value blocks. These may widely vary in
+// size based on compression ratios.
+var compressedValueBlockBufPool = sync.Pool{
+	New: func() interface{} {
+		return &blockBuffer{}
+	},
+}
+
+func releaseToValueBlockBufPool(pool *sync.Pool, b *blockBuffer) {
+	// Don't pool buffers larger than 128KB, in case we had some rare large
+	// values.
+	if len(b.b) > 128*1024 {
+		return
+	}
+	if invariants.Enabled {
+		// Set the bytes to a random value.
+		b.b = b.b[:cap(b.b)]
+		rand.Read(b.b)
+	}
+	pool.Put(b)
+}
+
+var valueBlockWriterPool = sync.Pool{
+	New: func() interface{} {
+		return &valueBlockWriter{}
+	},
+}
+
+func newValueBlockWriter(
+	blockSize int,
+	blockSizeThreshold int,
+	compression Compression,
+	checksumType ChecksumType,
+	// compressedSize should exclude the block trailer.
+	blockFinishedFunc func(compressedSize int),
+) *valueBlockWriter {
+	w := valueBlockWriterPool.Get().(*valueBlockWriter)
+	*w = valueBlockWriter{
+		blockSize:          blockSize,
+		blockSizeThreshold: blockSizeThreshold,
+		compression:        compression,
+		checksummer: checksummer{
+			checksumType: checksumType,
+		},
+		blockFinishedFunc: blockFinishedFunc,
+		buf:               uncompressedValueBlockBufPool.Get().(*blockBuffer),
+		compressedBuf:     compressedValueBlockBufPool.Get().(*blockBuffer),
+		blocks:            w.blocks[:0],
+	}
+	w.buf.b = w.buf.b[:0]
+	w.compressedBuf.b = w.compressedBuf.b[:0]
+	return w
+}
+
+func releaseValueBlockWriter(w *valueBlockWriter) {
+	for i := range w.blocks {
+		if w.blocks[i].compressed {
+			releaseToValueBlockBufPool(&compressedValueBlockBufPool, w.blocks[i].block)
+		} else {
+			releaseToValueBlockBufPool(&uncompressedValueBlockBufPool, w.blocks[i].block)
+		}
+		w.blocks[i].block = nil
+	}
+	if w.buf != nil {
+		releaseToValueBlockBufPool(&uncompressedValueBlockBufPool, w.buf)
+	}
+	if w.compressedBuf != nil {
+		releaseToValueBlockBufPool(&compressedValueBlockBufPool, w.compressedBuf)
+	}
+	*w = valueBlockWriter{
+		blocks: w.blocks[:0],
+	}
+	valueBlockWriterPool.Put(w)
+}
+
+func (w *valueBlockWriter) addValue(v []byte) (valueHandle, error) {
+	w.numValues++
+	blockLen := len(w.buf.b)
+	valueLen := len(v)
+	if blockLen >= w.blockSize ||
+		(blockLen > w.blockSizeThreshold && blockLen+valueLen > w.blockSize) {
+		// Block is not currently empty and adding this value will become too big,
+		// so finish this block.
+		w.compressAndFlush()
+		blockLen = len(w.buf.b)
+		if invariants.Enabled && blockLen != 0 {
+			panic("blockLen of new block should be 0")
+		}
+	}
+	vh := valueHandle{
+		valueLen:      uint32(valueLen),
+		blockNum:      uint32(len(w.blocks)),
+		offsetInBlock: uint32(blockLen),
+	}
+	blockLen = int(vh.offsetInBlock + vh.valueLen)
+	if cap(w.buf.b) < blockLen {
+		size := w.blockSize + w.blockSize/2
+		if size < blockLen {
+			size = blockLen + blockLen/2
+		}
+		buf := make([]byte, blockLen, size)
+		_ = copy(buf, w.buf.b)
+		w.buf.b = buf
+	} else {
+		w.buf.b = w.buf.b[:blockLen]
+	}
+	buf := w.buf.b[vh.offsetInBlock:]
+	n := copy(buf, v)
+	if n != len(buf) {
+		panic("incorrect length computation")
+	}
+	return vh, nil
+}
+
+func (w *valueBlockWriter) compressAndFlush() {
+	// Compress the buffer, discarding the result if the improvement isn't at
+	// least 12.5%.
+	blockType := noCompressionBlockType
+	b := w.buf
+	if w.compression != NoCompression {
+		blockType, w.compressedBuf.b =
+			compressBlock(w.compression, w.buf.b, w.compressedBuf.b[:cap(w.compressedBuf.b)])
+		if len(w.compressedBuf.b) < len(w.buf.b)-len(w.buf.b)/8 {
+			b = w.compressedBuf
+		} else {
+			blockType = noCompressionBlockType
+		}
+	}
+	n := len(b.b)
+	allocated := false
+	if n+blockTrailerLen > cap(b.b) {
+		block := make([]byte, n+blockTrailerLen)
+		copy(block, b.b)
+		b.b = block
+		allocated = true
+	} else {
+		b.b = b.b[:n+blockTrailerLen]
+	}
+	b.b[n] = byte(blockType)
+	w.computeChecksum(b.b)
+	bh := BlockHandle{Offset: w.totalBlockBytes, Length: uint64(n)}
+	w.totalBlockBytes += uint64(len(b.b))
+	// blockFinishedFunc length excludes the block trailer.
+	w.blockFinishedFunc(n)
+	compressed := blockType != noCompressionBlockType
+	w.blocks = append(w.blocks, blockAndHandle{
+		block:      b,
+		handle:     bh,
+		compressed: compressed,
+	})
+	if !allocated {
+		// Handed off a buffer to w.blocks, so need get a new one.
+		if compressed {
+			w.compressedBuf = compressedValueBlockBufPool.Get().(*blockBuffer)
+		} else {
+			w.buf = uncompressedValueBlockBufPool.Get().(*blockBuffer)
+		}
+	}
+	w.buf.b = w.buf.b[:0]
+}
+
+func (w *valueBlockWriter) computeChecksum(block []byte) {
+	n := len(block) - blockTrailerLen
+	checksum := w.checksummer.checksum(block[:n], block[n:n+1])
+	binary.LittleEndian.PutUint32(block[n+1:], checksum)
+}
+
+func (w *valueBlockWriter) finish(
+	writer io.Writer, fileOffset uint64,
+) (valueBlocksIndexHandle, valueBlocksAndIndexStats, error) {
+	if len(w.buf.b) > 0 {
+		w.compressAndFlush()
+	}
+	n := len(w.blocks)
+	if n == 0 {
+		return valueBlocksIndexHandle{}, valueBlocksAndIndexStats{}, nil
+	}
+	largestOffset := uint64(0)
+	largestLength := uint64(0)
+	for i := range w.blocks {
+		_, err := writer.Write(w.blocks[i].block.b)
+		if err != nil {
+			return valueBlocksIndexHandle{}, valueBlocksAndIndexStats{}, err
+		}
+		w.blocks[i].handle.Offset += fileOffset
+		largestOffset = w.blocks[i].handle.Offset
+		if largestLength < w.blocks[i].handle.Length {
+			largestLength = w.blocks[i].handle.Length
+		}
+	}
+	vbihOffset := fileOffset + w.totalBlockBytes
+
+	vbih := valueBlocksIndexHandle{
+		h: BlockHandle{
+			Offset: vbihOffset,
+		},
+		blockNumByteLength:    uint8(lenLittleEndian(uint64(n - 1))),
+		blockOffsetByteLength: uint8(lenLittleEndian(largestOffset)),
+		blockLengthByteLength: uint8(lenLittleEndian(largestLength)),
+	}
+	var err error
+	if vbih, err = w.writeValueBlocksIndex(writer, vbih); err != nil {
+		return valueBlocksIndexHandle{}, valueBlocksAndIndexStats{}, err
+	}
+	stats := valueBlocksAndIndexStats{
+		numValueBlocks:          uint64(n),
+		numValuesInValueBlocks:  w.numValues,
+		valueBlocksAndIndexSize: w.totalBlockBytes + vbih.h.Length + blockTrailerLen,
+	}
+	return vbih, stats, err
+}
+
+func (w *valueBlockWriter) writeValueBlocksIndex(
+	writer io.Writer, h valueBlocksIndexHandle,
+) (valueBlocksIndexHandle, error) {
+	blockLen :=
+		int(h.blockNumByteLength+h.blockOffsetByteLength+h.blockLengthByteLength) * len(w.blocks)
+	h.h.Length = uint64(blockLen)
+	blockLen += blockTrailerLen
+	var buf []byte
+	if cap(w.buf.b) < blockLen {
+		buf = make([]byte, blockLen)
+		w.buf.b = buf
+	} else {
+		buf = w.buf.b[:blockLen]
+	}
+	b := buf
+	for i := range w.blocks {
+		littleEndianPut(uint64(i), b, int(h.blockNumByteLength))
+		b = b[int(h.blockNumByteLength):]
+		littleEndianPut(w.blocks[i].handle.Offset, b, int(h.blockOffsetByteLength))
+		b = b[int(h.blockOffsetByteLength):]
+		littleEndianPut(w.blocks[i].handle.Length, b, int(h.blockLengthByteLength))
+		b = b[int(h.blockLengthByteLength):]
+	}
+	if len(b) != blockTrailerLen {
+		panic("incorrect length calculation")
+	}
+	b[0] = byte(noCompressionBlockType)
+	w.computeChecksum(buf)
+	if _, err := writer.Write(buf); err != nil {
+		return valueBlocksIndexHandle{}, err
+	}
+	return h, nil
+}
+
+// littleEndianPut writes v to b using little endian encoding, under the
+// assumption that v can be represented using n bytes.
+func littleEndianPut(v uint64, b []byte, n int) {
+	_ = b[n-1] // bounds check
+	for i := 0; i < n; i++ {
+		b[i] = byte(v)
+		v = v >> 8
+	}
+}
+
+// lenLittleEndian returns the minimum number of bytes needed to encode v
+// using little endian encoding.
+func lenLittleEndian(v uint64) int {
+	n := 0
+	for i := 0; i < 8; i++ {
+		n++
+		v = v >> 8
+		if v == 0 {
+			break
+		}
+	}
+	return n
+}
+
+// UserKeyPrefixBound represents a [Lower,Upper) bound of user key prefixes.
+// If both are nil, there is no bound specified. Else, Compare(Lower,Upper)
+// must be < 0.
+type UserKeyPrefixBound struct {
+	// Lower is a lower bound user key prefix.
+	Lower []byte
+	// Upper is an upper bound user key prefix.
+	Upper []byte
+}
+
+// IsEmpty returns true iff the bound is empty.
+func (ukb *UserKeyPrefixBound) IsEmpty() bool {
+	return len(ukb.Lower) == 0 && len(ukb.Upper) == 0
+}

--- a/sstable/value_block_test.go
+++ b/sstable/value_block_test.go
@@ -1,0 +1,96 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValueHandleEncodeDecode(t *testing.T) {
+	testCases := []valueHandle{
+		{valueLen: 23, blockNum: 100003, offsetInBlock: 2300},
+		{valueLen: math.MaxUint32 - 1, blockNum: math.MaxUint32 / 2, offsetInBlock: math.MaxUint32 - 2},
+	}
+	var buf [valueHandleMaxLen]byte
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%+v", tc), func(t *testing.T) {
+			n := encodeValueHandle(buf[:], tc)
+			vh, err := decodeValueHandle(buf[:n])
+			require.NoError(t, err)
+			require.Equal(t, tc, vh)
+		})
+	}
+}
+
+func TestValuePrefix(t *testing.T) {
+	testCases := []struct {
+		isHandle         bool
+		setHasSamePrefix bool
+		attr             base.ShortAttribute
+	}{
+		{
+			isHandle:         false,
+			setHasSamePrefix: false,
+		},
+		{
+			isHandle:         false,
+			setHasSamePrefix: true,
+		},
+		{
+			isHandle:         true,
+			setHasSamePrefix: false,
+			attr:             5,
+		},
+		{
+			isHandle:         true,
+			setHasSamePrefix: true,
+			attr:             2,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%+v", tc), func(t *testing.T) {
+			var prefix valuePrefix
+			if tc.isHandle {
+				prefix = makePrefixForValueHandle(tc.setHasSamePrefix, tc.attr)
+			} else {
+				prefix = makePrefixForInPlaceValue(tc.setHasSamePrefix)
+			}
+			require.Equal(t, tc.isHandle, isValueHandle(prefix))
+			require.Equal(t, tc.setHasSamePrefix, setHasSamePrefix(prefix))
+			if tc.isHandle {
+				require.Equal(t, tc.attr, getShortAttribute(prefix))
+			}
+		})
+	}
+}
+
+func TestValueBlocksIndexHandleEncodeDecode(t *testing.T) {
+	testCases := []valueBlocksIndexHandle{
+		{
+			h: BlockHandle{
+				Offset: math.MaxUint64 / 2,
+				Length: math.MaxUint64 / 4,
+			},
+			blockNumByteLength:    53,
+			blockOffsetByteLength: math.MaxUint8,
+			blockLengthByteLength: math.MaxUint8 / 2,
+		},
+	}
+	var buf [valueBlocksIndexHandleMaxLen]byte
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%+v", tc), func(t *testing.T) {
+			n := encodeValueBlocksIndexHandle(buf[:], tc)
+			vbih, n2, err := decodeValueBlocksIndexHandle(buf[:n])
+			require.NoError(t, err)
+			require.Equal(t, n, n2)
+			require.Equal(t, tc, vbih)
+		})
+	}
+}

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -49,6 +49,9 @@ sync: db
 create: db/marker.format-version.000010.011
 close: db/marker.format-version.000010.011
 sync: db
+create: db/marker.format-version.000011.012
+close: db/marker.format-version.000011.012
+sync: db
 sync: db/MANIFEST-000001
 create: db/000002.log
 sync: db
@@ -114,9 +117,9 @@ close:
 open-dir: checkpoints/checkpoint1
 link: db/OPTIONS-000003 -> checkpoints/checkpoint1/OPTIONS-000003
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.011
-sync: checkpoints/checkpoint1/marker.format-version.000001.011
-close: checkpoints/checkpoint1/marker.format-version.000001.011
+create: checkpoints/checkpoint1/marker.format-version.000001.012
+sync: checkpoints/checkpoint1/marker.format-version.000001.012
+close: checkpoints/checkpoint1/marker.format-version.000001.012
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 create: checkpoints/checkpoint1/MANIFEST-000001
@@ -171,7 +174,7 @@ CURRENT
 LOCK
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000010.011
+marker.format-version.000011.012
 marker.manifest.000001.MANIFEST-000001
 
 list checkpoints/checkpoint1
@@ -181,7 +184,7 @@ list checkpoints/checkpoint1
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.011
+marker.format-version.000001.012
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint1 readonly

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -62,6 +62,10 @@ create: db/marker.format-version.000010.011
 close: db/marker.format-version.000010.011
 sync: db
 upgraded to format version: 011
+create: db/marker.format-version.000011.012
+close: db/marker.format-version.000011.012
+sync: db
+upgraded to format version: 012
 sync: db/MANIFEST-000001
 create: wal/000002.log
 sync: wal
@@ -200,7 +204,7 @@ compact         1   2.3 K     0 B       0          (size == estimated-debt, scor
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.4 K   11.1%  (score == hit-rate)
- tcache         1   680 B   50.0%  (score == hit-rate)
+ tcache         1   704 B   50.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)
@@ -222,9 +226,9 @@ close:
 open-dir: checkpoint
 link: db/OPTIONS-000003 -> checkpoint/OPTIONS-000003
 open-dir: checkpoint
-create: checkpoint/marker.format-version.000001.011
-sync: checkpoint/marker.format-version.000001.011
-close: checkpoint/marker.format-version.000001.011
+create: checkpoint/marker.format-version.000001.012
+sync: checkpoint/marker.format-version.000001.012
+close: checkpoint/marker.format-version.000001.012
 sync: checkpoint
 close: checkpoint
 create: checkpoint/MANIFEST-000016

--- a/testdata/format_major_version_pebblev1_migration
+++ b/testdata/format_major_version_pebblev1_migration
@@ -69,6 +69,7 @@ tally-table-formats
 (RocksDB,v2): 1
 (Pebble,v1): 1
 (Pebble,v2): 2
+(Pebble,v3): 0
 
 # Upgrade the DB to FormatMinTableFormatPebblev1.
 
@@ -164,3 +165,4 @@ tally-table-formats
 (RocksDB,v2): 0
 (Pebble,v1): 1
 (Pebble,v2): 4
+(Pebble,v3): 0

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -48,7 +48,7 @@ compact         0     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.5 K   42.9%  (score == hit-rate)
- tcache         1   680 B   50.0%  (score == hit-rate)
+ tcache         1   704 B   50.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -34,7 +34,7 @@ compact         0     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         1   256 K
    ztbl         0     0 B
  bcache         4   698 B    0.0%  (score == hit-rate)
- tcache         1   680 B    0.0%  (score == hit-rate)
+ tcache         1   704 B    0.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         1
  filter         -       -    0.0%  (score == utility)
@@ -82,7 +82,7 @@ compact         1     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         2   512 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   42.9%  (score == hit-rate)
- tcache         2   1.3 K   66.7%  (score == hit-rate)
+ tcache         2   1.4 K   66.7%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         2
  filter         -       -    0.0%  (score == utility)
@@ -115,7 +115,7 @@ compact         1     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         1   256 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   42.9%  (score == hit-rate)
- tcache         2   1.3 K   66.7%  (score == hit-rate)
+ tcache         2   1.4 K   66.7%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         2
  filter         -       -    0.0%  (score == utility)
@@ -145,7 +145,7 @@ compact         1     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         1   256 K
    ztbl         1   771 B
  bcache         4   698 B   42.9%  (score == hit-rate)
- tcache         1   680 B   66.7%  (score == hit-rate)
+ tcache         1   704 B   66.7%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         1
  filter         -       -    0.0%  (score == utility)


### PR DESCRIPTION
Value blocks are a mechanism designed for sstables storing MVCC data, where
there can be many versions of a key that need to be kept, but only the
latest value is typically read.

TableFormatPebblev3 is accompanied with DB format-major-version
FormatSSTableValueBlocks. The support for this format is incomplete
and is noted as such. It is introduced at this stage to allow code
in this new format-major-version to configurably write either v2
or v3 sstables.

The writing of sstable v3 is enabled via Options, specifically
EnableValueBlocks, ShortAttributeExtractor (optional), and
RequiredInPlaceValueBound. The RequiredInPlaceValueBound configures an
exclusion prefix key span that can have non-empty suffixes but should
not use value blocks. It is for use in CockroachDB's lock table key
space, which has suffixed keys but are not MVCC.

The sstable format includes an optional sequence of value blocks,
positioned after the meta range key block. The value blocks are
followed by a meta value index block. Some details about the format
are included below.

Data blocks contain two kinds of SET keys: those with in-place values and
those with a value handle. To distinguish these two cases we use a single
byte prefix (valuePrefix). This single byte prefix is split into multiple
parts, where nb represents information that is encoded in n bits.
```
+---------------+--------------------+-----------+--------------------+
| value-kind 2b | SET-same-prefix 1b | unused 2b | short-attribute 3b |
+---------------+--------------------+-----------+--------------------+
```
The 2 bit value-kind specifies whether this is an in-place value or a value
handle pointing to a value block. We use 2 bits here for future
representation of values that are in separate files. The 1 bit
SET-same-prefix is true if this key is a SET and is immediately preceded by
a SET that shares the same prefix. The 3 bit short-attribute is described
in base.ShortAttribute -- it stores user-defined attributes about the
value. It is unused for in-place values. Additionally a sequence of
SET-same-prefix=true values between adjacent restart points in a datablock
is encoded into the most significant bit in the little endian encoded 32
bit restart. This is to allow skipping over 1 or more restart keys in the
same block when trying to get to the next prefix, without doing any key
decoding (which requires decoding 3 varints).

Value Handle and Value Blocks:
valueHandles refer to values in value blocks. Value blocks are simpler than
normal data blocks (that contain key-value pairs, and allow for binary
search), which makes them cheap for value retrieval purposes. A valueHandle
is a tuple (valueLen, blockNum, offsetInBlock), where blockNum is the 0
indexed value block number and offsetInBlock is the byte offset in that
block containing the value. The valueHandle.valueLen is included since
there are multiple use cases in CockroachDB that need the value length but
not the value, for which we can avoid reading the value in the value block.

A value block has a checksum like other blocks, and is optionally
compressed. An uncompressed value block is a sequence of values with no
separator or length (we rely on the valueHandle to demarcate). The
valueHandle.offsetInBlock points to the value, of length
valueHandle.valueLen. While writing a sstable, all the (possibly
compressed) value blocks need to be held in-memory until they can be
written. Value blocks are placed after the "meta rangedel" and "meta range
key" blocks since value blocks are considered less likely to be read.

Meta Value Index Block:
Since the (key, valueHandle) pair are written before there is any knowledge
of the byte offset of the value block in the file, or its compressed
length, we need another lookup to map the valueHandle.blockNum to the
information needed to read it from the file. This information is provided
by the "value index block". The "value index block" is referred to by the
metaindex block. The design intentionally avoids making the "value index
block" a general purpose key-value block, since each caller wants to lookup
the information for a particular blockNum (there is no need for SeekGE
etc.). Instead, this index block stores a sequence of (blockNum,
blockOffset, blockLength) tuples, where the blockNums are consecutive
integers, and the tuples are encoded with a fixed width encoding. This
allows a reader to find the tuple for block K by looking at the offset
K*fixed-width. The fixed width for each field is decided by looking at the
maximum value of each of these fields: an extreme case of a 100MB sstable
with 2475 value blocks (~32KB each), has this tuple encoded using 2+4+2=8
bytes, which means the uncompressed value index block is 2475*8=~19KB,
which is modest. Therefore, we don't support more than one value index
block. Consider the example of 2 byte blockNum, 4 byte blockOffset and 2
byte blockLen. The value index block will look like:
```
  +---------------+------------------+---------------+
  | blockNum (2B) | blockOffset (4B) | blockLen (2B) |
  +---------------+------------------+---------------+
  |       0       |    7,123,456     |  30,000       |
  +---------------+------------------+---------------+
  |       1       |    7,153,456     |  20,000       |
  +---------------+------------------+---------------+
  |       2       |    7,173,456     |  25,567       |
  +---------------+------------------+---------------+
  |     ....      |      ...         |    ...        |
```
The metaindex block contains the valueBlocksIndexHandle which in addition
to the BlockHandle also specifies the widths of these tuple fields.

The benchmark results for BenchmarkWriter and BenchmarkWriterWithVersion
show some slowdown, but it is not conclusive and is unlikely to matter in
practice (since these are writing in-memory). The first two sets of results
here are comparisons between sstable v2 on master (old) and v2 with this
PR (new). The first one shows a slowdown and the second a speedup (both on
gceworker). Based on some other measurements there is some slowdown with
no clear cause based on looking at cpu profiles: some extra cost in
makeAddPointDecisionV2 and some in blockWriter. The last set of results is
v2 (old) and v3 (new), both with this PR, for which the throughput is
comparable.

v2 on master (old) vs v2 with this PR (new):
```
name                                                                      old speed      new speed      delta
Writer/block=4.0_K/filter=true/compression=NoCompression-16                284MB/s ± 3%   265MB/s ± 1%   -6.71%  (p=0.008 n=5+5)
Writer/block=4.0_K/filter=true/compression=Snappy-16                      67.7MB/s ± 2%  63.3MB/s ± 0%   -6.49%  (p=0.008 n=5+5)
Writer/block=4.0_K/filter=true/compression=ZSTD-16                        12.0MB/s ± 1%  11.9MB/s ± 1%     ~     (p=0.714 n=5+5)
Writer/block=4.0_K/filter=false/compression=NoCompression-16               424MB/s ± 0%   387MB/s ± 1%   -8.80%  (p=0.008 n=5+5)
Writer/block=4.0_K/filter=false/compression=Snappy-16                     84.8MB/s ± 1%  79.2MB/s ± 0%   -6.60%  (p=0.008 n=5+5)
Writer/block=4.0_K/filter=false/compression=ZSTD-16                       10.7MB/s ± 2%  10.4MB/s ± 2%   -2.89%  (p=0.008 n=5+5)
Writer/block=32_K/filter=true/compression=NoCompression-16                 293MB/s ± 1%   273MB/s ± 1%   -6.59%  (p=0.008 n=5+5)
Writer/block=32_K/filter=true/compression=Snappy-16                       52.2MB/s ± 2%  49.5MB/s ± 1%   -5.24%  (p=0.008 n=5+5)
Writer/block=32_K/filter=true/compression=ZSTD-16                         14.4MB/s ± 1%  13.9MB/s ± 1%   -3.60%  (p=0.008 n=5+5)
Writer/block=32_K/filter=false/compression=NoCompression-16                444MB/s ± 1%   403MB/s ± 1%   -9.25%  (p=0.008 n=5+5)
Writer/block=32_K/filter=false/compression=Snappy-16                      65.3MB/s ± 1%  60.3MB/s ± 0%   -7.56%  (p=0.008 n=5+5)
Writer/block=32_K/filter=false/compression=ZSTD-16                        11.7MB/s ± 1%  11.0MB/s ± 2%   -5.56%  (p=0.008 n=5+5)
WriterWithVersions/block=4.0_K/filter=true/compression=NoCompression-16    261MB/s ± 1%   242MB/s ± 1%   -7.08%  (p=0.008 n=5+5)
WriterWithVersions/block=4.0_K/filter=true/compression=Snappy-16          46.8MB/s ± 1%  43.7MB/s ± 1%   -6.69%  (p=0.008 n=5+5)
WriterWithVersions/block=4.0_K/filter=true/compression=ZSTD-16            7.66MB/s ± 2%  7.55MB/s ± 2%     ~     (p=0.151 n=5+5)
WriterWithVersions/block=4.0_K/filter=false/compression=NoCompression-16   341MB/s ± 2%   301MB/s ± 2%  -11.60%  (p=0.008 n=5+5)
WriterWithVersions/block=4.0_K/filter=false/compression=Snappy-16         54.7MB/s ± 1%  50.0MB/s ± 0%   -8.66%  (p=0.008 n=5+5)
WriterWithVersions/block=4.0_K/filter=false/compression=ZSTD-16           7.03MB/s ± 2%  6.72MB/s ± 2%   -4.46%  (p=0.008 n=5+5)
WriterWithVersions/block=32_K/filter=true/compression=NoCompression-16     271MB/s ± 1%   250MB/s ± 1%   -7.76%  (p=0.008 n=5+5)
WriterWithVersions/block=32_K/filter=true/compression=Snappy-16           42.2MB/s ± 2%  39.3MB/s ± 1%   -6.99%  (p=0.008 n=5+5)
WriterWithVersions/block=32_K/filter=true/compression=ZSTD-16             11.4MB/s ± 0%  10.9MB/s ± 2%   -4.45%  (p=0.008 n=5+5)
WriterWithVersions/block=32_K/filter=false/compression=NoCompression-16    354MB/s ± 1%   317MB/s ± 1%  -10.46%  (p=0.008 n=5+5)
WriterWithVersions/block=32_K/filter=false/compression=Snappy-16          49.6MB/s ± 1%  45.5MB/s ± 1%   -8.26%  (p=0.008 n=5+5)
WriterWithVersions/block=32_K/filter=false/compression=ZSTD-16            10.4MB/s ± 1%  10.0MB/s ± 1%   -4.38%  (p=0.008 n=5+5)
```
Same, but run at a different time:
```
name                                                                      old speed      new speed       delta
Writer/block=4.0_K/filter=true/compression=NoCompression-16                253MB/s ± 4%    265MB/s ± 1%   +4.63%  (p=0.016 n=5+5)
Writer/block=4.0_K/filter=true/compression=Snappy-16                      60.0MB/s ± 3%   63.3MB/s ± 0%   +5.57%  (p=0.008 n=5+5)
Writer/block=4.0_K/filter=true/compression=ZSTD-16                        10.8MB/s ± 4%   11.9MB/s ± 1%  +10.41%  (p=0.008 n=5+5)
Writer/block=4.0_K/filter=false/compression=NoCompression-16               377MB/s ± 1%    387MB/s ± 1%   +2.68%  (p=0.016 n=4+5)
Writer/block=4.0_K/filter=false/compression=Snappy-16                     76.1MB/s ± 4%   79.2MB/s ± 0%   +4.00%  (p=0.008 n=5+5)
Writer/block=4.0_K/filter=false/compression=ZSTD-16                       9.19MB/s ± 1%  10.43MB/s ± 2%  +13.49%  (p=0.008 n=5+5)
Writer/block=32_K/filter=true/compression=NoCompression-16                 252MB/s ± 1%    273MB/s ± 1%   +8.43%  (p=0.008 n=5+5)
Writer/block=32_K/filter=true/compression=Snappy-16                       47.7MB/s ± 2%   49.5MB/s ± 1%   +3.70%  (p=0.008 n=5+5)
Writer/block=32_K/filter=true/compression=ZSTD-16                         12.6MB/s ± 2%   13.9MB/s ± 1%  +10.10%  (p=0.008 n=5+5)
Writer/block=32_K/filter=false/compression=NoCompression-16                396MB/s ± 4%    403MB/s ± 1%     ~     (p=0.222 n=5+5)
Writer/block=32_K/filter=false/compression=Snappy-16                      58.6MB/s ± 2%   60.3MB/s ± 0%   +2.95%  (p=0.008 n=5+5)
Writer/block=32_K/filter=false/compression=ZSTD-16                        10.2MB/s ± 5%   11.0MB/s ± 2%   +7.86%  (p=0.008 n=5+5)
WriterWithVersions/block=4.0_K/filter=true/compression=NoCompression-16    236MB/s ± 4%    242MB/s ± 1%     ~     (p=0.095 n=5+5)
WriterWithVersions/block=4.0_K/filter=true/compression=Snappy-16          41.5MB/s ± 2%   43.7MB/s ± 1%   +5.17%  (p=0.008 n=5+5)
WriterWithVersions/block=4.0_K/filter=true/compression=ZSTD-16            6.77MB/s ± 3%   7.55MB/s ± 2%  +11.43%  (p=0.008 n=5+5)
WriterWithVersions/block=4.0_K/filter=false/compression=NoCompression-16   299MB/s ± 5%    301MB/s ± 2%     ~     (p=1.000 n=5+5)
WriterWithVersions/block=4.0_K/filter=false/compression=Snappy-16         49.3MB/s ± 3%   50.0MB/s ± 0%     ~     (p=0.548 n=5+5)
WriterWithVersions/block=4.0_K/filter=false/compression=ZSTD-16           6.26MB/s ± 5%   6.72MB/s ± 2%   +7.31%  (p=0.008 n=5+5)
WriterWithVersions/block=32_K/filter=true/compression=NoCompression-16     246MB/s ± 7%    250MB/s ± 1%     ~     (p=0.841 n=5+5)
WriterWithVersions/block=32_K/filter=true/compression=Snappy-16           37.8MB/s ± 3%   39.3MB/s ± 1%   +3.87%  (p=0.008 n=5+5)
WriterWithVersions/block=32_K/filter=true/compression=ZSTD-16             10.0MB/s ± 2%   10.9MB/s ± 2%   +8.17%  (p=0.008 n=5+5)
WriterWithVersions/block=32_K/filter=false/compression=NoCompression-16    319MB/s ± 2%    317MB/s ± 1%     ~     (p=0.548 n=5+5)
WriterWithVersions/block=32_K/filter=false/compression=Snappy-16          45.4MB/s ± 2%   45.5MB/s ± 1%     ~     (p=1.000 n=5+5)
WriterWithVersions/block=32_K/filter=false/compression=ZSTD-16            9.27MB/s ± 1%   9.97MB/s ± 1%   +7.51%  (p=0.008 n=5+5)
```
v2 (old) vs v3 (new), both with this PR:
```
name                                                                      old speed      new speed      delta
Writer/block=4.0_K/filter=true/compression=NoCompression-16                265MB/s ± 1%   265MB/s ± 1%    ~     (p=0.841 n=5+5)
Writer/block=4.0_K/filter=true/compression=Snappy-16                      63.3MB/s ± 0%  62.9MB/s ± 1%    ~     (p=0.095 n=5+5)
Writer/block=4.0_K/filter=true/compression=ZSTD-16                        11.9MB/s ± 1%  11.8MB/s ± 2%    ~     (p=0.095 n=5+5)
Writer/block=4.0_K/filter=false/compression=NoCompression-16               387MB/s ± 1%   389MB/s ± 2%    ~     (p=0.222 n=5+5)
Writer/block=4.0_K/filter=false/compression=Snappy-16                     79.2MB/s ± 0%  79.6MB/s ± 1%    ~     (p=0.095 n=5+5)
Writer/block=4.0_K/filter=false/compression=ZSTD-16                       10.4MB/s ± 2%  10.4MB/s ± 2%    ~     (p=0.730 n=5+5)
Writer/block=32_K/filter=true/compression=NoCompression-16                 273MB/s ± 1%   276MB/s ± 1%    ~     (p=0.151 n=5+5)
Writer/block=32_K/filter=true/compression=Snappy-16                       49.5MB/s ± 1%  49.7MB/s ± 1%    ~     (p=0.548 n=5+5)
Writer/block=32_K/filter=true/compression=ZSTD-16                         13.9MB/s ± 1%  13.9MB/s ± 1%    ~     (p=0.841 n=5+5)
Writer/block=32_K/filter=false/compression=NoCompression-16                403MB/s ± 1%   402MB/s ± 1%    ~     (p=1.000 n=5+5)
Writer/block=32_K/filter=false/compression=Snappy-16                      60.3MB/s ± 0%  59.9MB/s ± 1%    ~     (p=0.111 n=5+5)
Writer/block=32_K/filter=false/compression=ZSTD-16                        11.0MB/s ± 2%  11.0MB/s ± 2%    ~     (p=0.794 n=5+5)
WriterWithVersions/block=4.0_K/filter=true/compression=NoCompression-16    242MB/s ± 1%   240MB/s ± 1%    ~     (p=0.095 n=5+5)
WriterWithVersions/block=4.0_K/filter=true/compression=Snappy-16          43.7MB/s ± 1%  43.7MB/s ± 1%    ~     (p=1.000 n=5+5)
WriterWithVersions/block=4.0_K/filter=true/compression=ZSTD-16            7.55MB/s ± 2%  7.47MB/s ± 1%    ~     (p=0.143 n=5+5)
WriterWithVersions/block=4.0_K/filter=false/compression=NoCompression-16   301MB/s ± 2%   300MB/s ± 2%    ~     (p=0.548 n=5+5)
WriterWithVersions/block=4.0_K/filter=false/compression=Snappy-16         50.0MB/s ± 0%  50.4MB/s ± 1%    ~     (p=0.095 n=5+5)
WriterWithVersions/block=4.0_K/filter=false/compression=ZSTD-16           6.72MB/s ± 2%  6.72MB/s ± 2%    ~     (p=0.889 n=5+5)
WriterWithVersions/block=32_K/filter=true/compression=NoCompression-16     250MB/s ± 1%   250MB/s ± 1%    ~     (p=1.000 n=5+5)
WriterWithVersions/block=32_K/filter=true/compression=Snappy-16           39.3MB/s ± 1%  39.3MB/s ± 0%    ~     (p=0.333 n=5+5)
WriterWithVersions/block=32_K/filter=true/compression=ZSTD-16             10.9MB/s ± 2%  10.8MB/s ± 2%    ~     (p=0.841 n=5+5)
WriterWithVersions/block=32_K/filter=false/compression=NoCompression-16    317MB/s ± 1%   316MB/s ± 2%    ~     (p=0.690 n=5+5)
WriterWithVersions/block=32_K/filter=false/compression=Snappy-16          45.5MB/s ± 1%  45.2MB/s ± 1%    ~     (p=0.151 n=5+5)
WriterWithVersions/block=32_K/filter=false/compression=ZSTD-16            10.0MB/s ± 1%   9.8MB/s ± 2%    ~     (p=0.135 n=5+5)
```

Informs https://github.com/cockroachdb/pebble/issues/1170