### PR TITLE
vfs: use `Frsize` for computing total size on Linux

### DIFF
--- a/vfs/disk_usage_linux.go
+++ b/vfs/disk_usage_linux.go
@@ -35,7 +35,7 @@ func (defaultFS) GetDiskUsage(path string) (DiskUsage, error) {
 	// [2] https://man7.org/linux/man-pages/man3/statvfs.3.html
 	freeBytes := uint64(stat.Frsize) * uint64(stat.Bfree)
 	availBytes := uint64(stat.Frsize) * uint64(stat.Bavail)
-	totalBytes := uint64(stat.Bsize) * uint64(stat.Blocks)
+	totalBytes := uint64(stat.Frsize) * uint64(stat.Blocks)
 	return DiskUsage{
 		AvailBytes: availBytes,
 		TotalBytes: totalBytes,


### PR DESCRIPTION
Currently, when computing the total size of a volume in `(defaultFS).GetDiskUsage`, `Bsize` is used to multiply the number of filesystem blocks to arrive at a total size. On Linux, there also exists the `Frsize` parameter, returned from `statfs` / `statvfs`.

For the most part, `Bsize` and `Frsize` are interchangeable on Linux. However, when a Linux container is run with a macOS filesystem mounted into it (for example, when using Docker), a discrepancy in the values can result in an incorrect total size. This can result in issues such as cockroachdb/cockroach#90150, where the denominator of a "percent available" calculation is computed using a larger value of `Bsize`, which results in the overall fraction falling below the allowable threshold for certain operations.

This can be seen with the following example, run on macOS, inside of a Linux container:

```go
package main

import (
	"fmt"
	"os"

	"golang.org/x/sys/unix"
)

func main() {
	path := os.Args[1]
	stat := unix.Statfs_t{}
	if err := unix.Statfs(path, &stat); err != nil {
		panic(err)
	}

	freeBytes := uint64(stat.Frsize) * stat.Bfree
	availBytes := uint64(stat.Frsize) * stat.Bavail
	totalBytesBsize := uint64(stat.Bsize) * stat.Blocks
	totalBytesFrsize := uint64(stat.Frsize) * stat.Blocks

	fmt.Printf(
		"free:\t\t%d\navail:\t\t%d\ntotal(Bsize):\t%d\ntotal(Frsize):\t%d\n",
		freeBytes, availBytes, totalBytesBsize, totalBytesFrsize,
	)
}
```

```
$ docker run --rm -it -v $(mktemp -d):/data test
root@2d1ae8a4ce52:/# ./test /data/
free:           535343923200
avail:          535343923200
total(Bsize):   256061686677504
total(Frsize):  1000240963584
```

The same experiment on Linux demonstrates the values of `Bsize` and `Frsize` being the same:

```
$ docker run --rm -it -v $(mktemp -d):/data test
root@ca362068606a:/# ./test /data/
free:           755544031232
avail:          705578549248
total(Bsize):   982141468672
total(Frsize):  982141468672
```

Use `Frsize` on Linux for the calculation of total volume size.

Touches cockroachdb/cockroach#90150.