### PR TITLE
db: add Experimental.LevelMultiplier option

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -19,8 +19,6 @@ import (
 // heuristic.
 const minIntraL0Count = 4
 
-const levelMultiplier = 10
-
 type compactionEnv struct {
 	earliestUnflushedSeqNum uint64
 	earliestSnapshotSeqNum  uint64
@@ -786,11 +784,11 @@ func (p *compactionPickerByScore) initLevelMaxBytes(inProgressCompactions []comp
 	}
 
 	dbSize += p.levelSizes[0]
-	bottomLevelSize := dbSize - dbSize/levelMultiplier
+	bottomLevelSize := dbSize - dbSize/int64(p.opts.Experimental.LevelMultiplier)
 
 	curLevelSize := bottomLevelSize
 	for level := numLevels - 2; level >= firstNonEmptyLevel; level-- {
-		curLevelSize = int64(float64(curLevelSize) / levelMultiplier)
+		curLevelSize = int64(float64(curLevelSize) / float64(p.opts.Experimental.LevelMultiplier))
 	}
 
 	// Compute base level (where L0 data is compacted to).
@@ -798,7 +796,7 @@ func (p *compactionPickerByScore) initLevelMaxBytes(inProgressCompactions []comp
 	p.baseLevel = firstNonEmptyLevel
 	for p.baseLevel > 1 && curLevelSize > baseBytesMax {
 		p.baseLevel--
-		curLevelSize = int64(float64(curLevelSize) / levelMultiplier)
+		curLevelSize = int64(float64(curLevelSize) / float64(p.opts.Experimental.LevelMultiplier))
 	}
 
 	smoothedLevelMultiplier := 1.0

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -295,6 +295,7 @@ func randomOptions(rng *rand.Rand) *testOptions {
 		opts.FormatMajorVersion += pebble.FormatMajorVersion(rng.Intn(n))
 	}
 	opts.Experimental.L0CompactionConcurrency = 1 + rng.Intn(4)    // 1-4
+	opts.Experimental.LevelMultiplier = 5 << rng.Intn(7)           // 5 - 320
 	opts.Experimental.MinDeletionRate = 1 << uint(20+rng.Intn(10)) // 1MB - 1GB
 	opts.Experimental.ValidateOnIngest = rng.Intn(2) != 0
 	opts.L0CompactionThreshold = 1 + rng.Intn(100)     // 1 - 100

--- a/options.go
+++ b/options.go
@@ -23,7 +23,8 @@ import (
 )
 
 const (
-	cacheDefaultSize = 8 << 20 // 8 MB
+	cacheDefaultSize       = 8 << 20 // 8 MB
+	defaultLevelMultiplier = 10
 )
 
 // Compression exports the base.Compression type.
@@ -549,6 +550,10 @@ type Options struct {
 		// By default, this value is false.
 		ValidateOnIngest bool
 
+		// LevelMultiplier configures the size multiplier used to determine the
+		// desired size of each level of the LSM. Defaults to 10.
+		LevelMultiplier int
+
 		// MultiLevelCompaction allows the compaction of SSTs from more than two
 		// levels iff a conventional two level compaction will quickly trigger a
 		// compaction in the output level.
@@ -919,6 +924,9 @@ func (o *Options) EnsureDefaults() *Options {
 	if o.FlushSplitBytes <= 0 {
 		o.FlushSplitBytes = 2 * o.Levels[0].TargetFileSize
 	}
+	if o.Experimental.LevelMultiplier <= 0 {
+		o.Experimental.LevelMultiplier = defaultLevelMultiplier
+	}
 	if o.Experimental.ReadCompactionRate == 0 {
 		o.Experimental.ReadCompactionRate = 16000
 	}
@@ -1015,6 +1023,9 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  l0_compaction_threshold=%d\n", o.L0CompactionThreshold)
 	fmt.Fprintf(&buf, "  l0_stop_writes_threshold=%d\n", o.L0StopWritesThreshold)
 	fmt.Fprintf(&buf, "  lbase_max_bytes=%d\n", o.LBaseMaxBytes)
+	if o.Experimental.LevelMultiplier != defaultLevelMultiplier {
+		fmt.Fprintf(&buf, "  level_multiplier=%d\n", o.Experimental.LevelMultiplier)
+	}
 	fmt.Fprintf(&buf, "  max_concurrent_compactions=%d\n", o.MaxConcurrentCompactions())
 	fmt.Fprintf(&buf, "  max_manifest_file_size=%d\n", o.MaxManifestFileSize)
 	fmt.Fprintf(&buf, "  max_open_files=%d\n", o.MaxOpenFiles)
@@ -1226,6 +1237,8 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				// Do nothing; option existed in older versions of pebble.
 			case "lbase_max_bytes":
 				o.LBaseMaxBytes, err = strconv.ParseInt(value, 10, 64)
+			case "level_multiplier":
+				o.Experimental.LevelMultiplier, err = strconv.Atoi(value)
 			case "max_concurrent_compactions":
 				var concurrentCompactions int
 				concurrentCompactions, err = strconv.Atoi(value)

--- a/options_test.go
+++ b/options_test.go
@@ -226,6 +226,7 @@ func TestOptionsParse(t *testing.T) {
 			opts.Experimental.CompactionDebtConcurrency = 100
 			opts.FlushDelayDeleteRange = 10 * time.Second
 			opts.FlushDelayRangeKey = 11 * time.Second
+			opts.Experimental.LevelMultiplier = 5
 			opts.Experimental.MinDeletionRate = 200
 			opts.Experimental.ReadCompactionRate = 300
 			opts.Experimental.ReadSamplingMultiplier = 400


### PR DESCRIPTION
Add an Experimental.Option for configuring the level multiplier used to determine the relative target sizes of levels. Vary this level multiplier in metamorphic tests.

Varying the level multiplier can induce more automatic compactions which can be useful for scheduling more compactions than would otherwise be scheduled with the small store sizes produced by the metamorphic tests.