### PR TITLE
sstable: optimize SeekPrefixGE for two-level indices to use trySeekUs…

### DIFF
--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1991,6 +1991,51 @@ func BenchmarkIteratorPrev(b *testing.B) {
 	}
 }
 
+type twoLevelBloomTombstoneState struct {
+	keys        [][]byte
+	readers     [8][][]*sstable.Reader
+	levelSlices [8][]manifest.LevelSlice
+	indexFunc   func(twoLevelIndex bool, bloom bool, withTombstone bool) int
+}
+
+func setupForTwoLevelBloomTombstone(b *testing.B, keyOffset int) twoLevelBloomTombstoneState {
+	const blockSize = 32 << 10
+	const restartInterval = 16
+	const levelCount = 5
+
+	var readers [8][][]*sstable.Reader
+	var levelSlices [8][]manifest.LevelSlice
+	var keys [][]byte
+	indexFunc := func(twoLevelIndex bool, bloom bool, withTombstone bool) int {
+		index := 0
+		if twoLevelIndex {
+			index = 4
+		}
+		if bloom {
+			index += 2
+		}
+		if withTombstone {
+			index++
+		}
+		return index
+	}
+	for _, twoLevelIndex := range []bool{false, true} {
+		for _, bloom := range []bool{false, true} {
+			for _, withTombstone := range []bool{false, true} {
+				index := indexFunc(twoLevelIndex, bloom, withTombstone)
+				levels := levelCount
+				if withTombstone {
+					levels = 1
+				}
+				readers[index], levelSlices[index], keys = buildLevelsForMergingIterSeqSeek(
+					b, blockSize, restartInterval, levels, keyOffset, withTombstone, bloom, twoLevelIndex)
+			}
+		}
+	}
+	return twoLevelBloomTombstoneState{
+		keys: keys, readers: readers, levelSlices: levelSlices, indexFunc: indexFunc}
+}
+
 // BenchmarkIteratorSeqSeekPrefixGENotFound exercises the case of SeekPrefixGE
 // specifying monotonic keys all of which precede actual keys present in L6 of
 // the DB. Moreover, with-tombstone=true exercises the sub-case where those
@@ -2000,35 +2045,12 @@ func BenchmarkIteratorPrev(b *testing.B) {
 // over all those deleted keys, including repeated iteration, (b) using the
 // next optimization, since the seeks are monotonic.
 func BenchmarkIteratorSeqSeekPrefixGENotFound(b *testing.B) {
-	const blockSize = 32 << 10
-	const restartInterval = 16
-	const levelCount = 5
 	const keyOffset = 100000
+	state := setupForTwoLevelBloomTombstone(b, keyOffset)
+	readers := state.readers
+	levelSlices := state.levelSlices
+	indexFunc := state.indexFunc
 
-	var readers [4][][]*sstable.Reader
-	var levelSlices [4][]manifest.LevelSlice
-	indexFunc := func(bloom bool, withTombstone bool) int {
-		index := 0
-		if bloom {
-			index = 2
-		}
-		if withTombstone {
-			index++
-		}
-		return index
-	}
-	for _, bloom := range []bool{false, true} {
-		for _, withTombstone := range []bool{false, true} {
-			index := indexFunc(bloom, withTombstone)
-			levels := levelCount
-			if withTombstone {
-				levels = 1
-			}
-			readers[index], levelSlices[index], _ = buildLevelsForMergingIterSeqSeek(
-				b, blockSize, restartInterval, levels, keyOffset, withTombstone, bloom)
-
-		}
-	}
 	// We will not be seeking to the keys that were written but instead to
 	// keys before the written keys. This is to validate that the optimization
 	// to use Next still functions when mergingIter checks for the prefix
@@ -2040,46 +2062,117 @@ func BenchmarkIteratorSeqSeekPrefixGENotFound(b *testing.B) {
 		keys = append(keys, []byte(fmt.Sprintf("%08d", i)))
 	}
 	for _, skip := range []int{1, 2, 4} {
-		for _, bloom := range []bool{false, true} {
-			for _, withTombstone := range []bool{false, true} {
-				b.Run(fmt.Sprintf("skip=%d/bloom=%t/with-tombstone=%t", skip, bloom, withTombstone),
-					func(b *testing.B) {
-						index := indexFunc(bloom, withTombstone)
-						readers := readers[index]
-						levelSlices := levelSlices[index]
-						m := buildMergingIter(readers, levelSlices)
-						iter := Iterator{
-							comparer: *testkeys.Comparer,
-							merge:    DefaultMerger.Merge,
-							iter:     m,
-						}
-						pos := 0
-						b.ResetTimer()
-						for i := 0; i < b.N; i++ {
-							// When withTombstone=true, and prior to the
-							// optimization to stop early due to a range
-							// tombstone, the iteration would continue into the
-							// next file, and not be able to use Next at the lower
-							// level in the next SeekPrefixGE call. So we would
-							// incur the cost of iterating over all the deleted
-							// keys for every seek. Note that it is not possible
-							// to do a noop optimization in Iterator for the
-							// prefix case, unlike SeekGE/SeekLT, since we don't
-							// know if the iterators inside mergingIter are all
-							// appropriately positioned -- some may not be due to
-							// bloom filters not matching.
-							valid := iter.SeekPrefixGE(keys[pos])
-							if valid {
-								b.Fatalf("key should not be found")
+		for _, twoLevelIndex := range []bool{false, true} {
+			for _, bloom := range []bool{false, true} {
+				for _, withTombstone := range []bool{false, true} {
+					b.Run(fmt.Sprintf("skip=%d/two-level=%t/bloom=%t/with-tombstone=%t",
+						skip, twoLevelIndex, bloom, withTombstone),
+						func(b *testing.B) {
+							index := indexFunc(twoLevelIndex, bloom, withTombstone)
+							readers := readers[index]
+							levelSlices := levelSlices[index]
+							m := buildMergingIter(readers, levelSlices)
+							iter := Iterator{
+								comparer: *testkeys.Comparer,
+								merge:    DefaultMerger.Merge,
+								iter:     m,
 							}
-							pos += skip
-							if pos >= keyOffset {
-								pos = 0
+							pos := 0
+							b.ResetTimer()
+							for i := 0; i < b.N; i++ {
+								// When withTombstone=true, and prior to the
+								// optimization to stop early due to a range
+								// tombstone, the iteration would continue into the
+								// next file, and not be able to use Next at the lower
+								// level in the next SeekPrefixGE call. So we would
+								// incur the cost of iterating over all the deleted
+								// keys for every seek. Note that it is not possible
+								// to do a noop optimization in Iterator for the
+								// prefix case, unlike SeekGE/SeekLT, since we don't
+								// know if the iterators inside mergingIter are all
+								// appropriately positioned -- some may not be due to
+								// bloom filters not matching.
+								valid := iter.SeekPrefixGE(keys[pos])
+								if valid {
+									b.Fatalf("key should not be found")
+								}
+								pos += skip
+								if pos >= keyOffset {
+									pos = 0
+								}
 							}
-						}
-						b.StopTimer()
-						iter.Close()
-					})
+							b.StopTimer()
+							iter.Close()
+						})
+				}
+			}
+		}
+	}
+	for _, r := range readers {
+		for i := range r {
+			for j := range r[i] {
+				r[i][j].Close()
+			}
+		}
+	}
+}
+
+// BenchmarkIteratorSeqSeekPrefixGEFound exercises the case of SeekPrefixGE
+// specifying monotonic keys that are present in L6 of the DB. Moreover,
+// with-tombstone=true exercises the sub-case where those actual keys are
+// deleted using a range tombstone that has not physically deleted those keys
+// due to the presence of a snapshot that needs to see those keys. This
+// sub-case needs to be efficient in (a) avoiding iteration over all those
+// deleted keys, including repeated iteration, (b) using the next
+// optimization, since the seeks are monotonic.
+func BenchmarkIteratorSeqSeekPrefixGEFound(b *testing.B) {
+	state := setupForTwoLevelBloomTombstone(b, 0)
+	keys := state.keys
+	readers := state.readers
+	levelSlices := state.levelSlices
+	indexFunc := state.indexFunc
+
+	for _, skip := range []int{1, 2, 4} {
+		for _, twoLevelIndex := range []bool{false, true} {
+			for _, bloom := range []bool{false, true} {
+				for _, withTombstone := range []bool{false, true} {
+					b.Run(fmt.Sprintf("skip=%d/two-level=%t/bloom=%t/with-tombstone=%t",
+						skip, twoLevelIndex, bloom, withTombstone),
+						func(b *testing.B) {
+							index := indexFunc(twoLevelIndex, bloom, withTombstone)
+							readers := readers[index]
+							levelSlices := levelSlices[index]
+							m := buildMergingIter(readers, levelSlices)
+							iter := Iterator{
+								comparer: *testkeys.Comparer,
+								merge:    DefaultMerger.Merge,
+								iter:     m,
+							}
+							pos := 0
+							b.ResetTimer()
+							for i := 0; i < b.N; i++ {
+								// When withTombstone=true, and prior to the
+								// optimization to stop early due to a range
+								// tombstone, the iteration would continue into the
+								// next file, and not be able to use Next at the lower
+								// level in the next SeekPrefixGE call. So we would
+								// incur the cost of iterating over all the deleted
+								// keys for every seek. Note that it is not possible
+								// to do a noop optimization in Iterator for the
+								// prefix case, unlike SeekGE/SeekLT, since we don't
+								// know if the iterators inside mergingIter are all
+								// appropriately positioned -- some may not be due to
+								// bloom filters not matching.
+								_ = iter.SeekPrefixGE(keys[pos])
+								pos += skip
+								if pos >= len(keys) {
+									pos = 0
+								}
+							}
+							b.StopTimer()
+							iter.Close()
+						})
+				}
 			}
 		}
 	}
@@ -2099,33 +2192,39 @@ func BenchmarkIteratorSeqSeekGEWithBounds(b *testing.B) {
 	const blockSize = 32 << 10
 	const restartInterval = 16
 	const levelCount = 5
-	readers, levelSlices, keys := buildLevelsForMergingIterSeqSeek(
-		b, blockSize, restartInterval, levelCount, 0 /* keyOffset */, false, false)
-	m := buildMergingIter(readers, levelSlices)
-	iter := Iterator{
-		comparer: *testkeys.Comparer,
-		merge:    DefaultMerger.Merge,
-		iter:     m,
-	}
-	keyCount := len(keys)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		pos := i % (keyCount - 1)
-		iter.SetBounds(keys[pos], keys[pos+1])
-		// SeekGE will return keys[pos].
-		valid := iter.SeekGE(keys[pos])
-		for valid {
-			valid = iter.Next()
-		}
-		if iter.Error() != nil {
-			b.Fatalf(iter.Error().Error())
-		}
-	}
-	iter.Close()
-	for i := range readers {
-		for j := range readers[i] {
-			readers[i][j].Close()
-		}
+	for _, twoLevelIndex := range []bool{false, true} {
+		b.Run(fmt.Sprintf("two-level=%t", twoLevelIndex),
+			func(b *testing.B) {
+				readers, levelSlices, keys := buildLevelsForMergingIterSeqSeek(
+					b, blockSize, restartInterval, levelCount, 0, /* keyOffset */
+					false, false, twoLevelIndex)
+				m := buildMergingIter(readers, levelSlices)
+				iter := Iterator{
+					comparer: *testkeys.Comparer,
+					merge:    DefaultMerger.Merge,
+					iter:     m,
+				}
+				keyCount := len(keys)
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					pos := i % (keyCount - 1)
+					iter.SetBounds(keys[pos], keys[pos+1])
+					// SeekGE will return keys[pos].
+					valid := iter.SeekGE(keys[pos])
+					for valid {
+						valid = iter.Next()
+					}
+					if iter.Error() != nil {
+						b.Fatalf(iter.Error().Error())
+					}
+				}
+				iter.Close()
+				for i := range readers {
+					for j := range readers[i] {
+						readers[i][j].Close()
+					}
+				}
+			})
 	}
 }
 
@@ -2135,7 +2234,7 @@ func BenchmarkIteratorSeekGENoop(b *testing.B) {
 	const levelCount = 5
 	const keyOffset = 10000
 	readers, levelSlices, _ := buildLevelsForMergingIterSeqSeek(
-		b, blockSize, restartInterval, levelCount, keyOffset, false, false)
+		b, blockSize, restartInterval, levelCount, keyOffset, false, false, false)
 	var keys [][]byte
 	for i := 0; i < keyOffset; i++ {
 		keys = append(keys, []byte(fmt.Sprintf("%08d", i)))

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -457,7 +457,8 @@ func buildLevelsForMergingIterSeqSeek(
 	keyOffset int,
 	writeRangeTombstoneToLowestLevel bool,
 	writeBloomFilters bool,
-) ([][]*sstable.Reader, []manifest.LevelSlice, [][]byte) {
+	forceTwoLevelIndex bool,
+) (readers [][]*sstable.Reader, levelSlices []manifest.LevelSlice, keys [][]byte) {
 	mem := vfs.NewMem()
 	if writeRangeTombstoneToLowestLevel && levelCount != 1 {
 		panic("expect to write only 1 level")
@@ -473,6 +474,7 @@ func buildLevelsForMergingIterSeqSeek(
 		}
 	}
 
+	const targetL6FirstFileSize = 2 << 20
 	writers := make([][]*sstable.Writer, levelCount)
 	// A policy unlikely to have false positives.
 	filterPolicy := bloom.FilterPolicy(100)
@@ -487,15 +489,29 @@ func buildLevelsForMergingIterSeqSeek(
 				writerOptions.FilterPolicy = filterPolicy
 				writerOptions.FilterType = base.TableFilter
 			}
+			if forceTwoLevelIndex {
+				if i == 0 && j == 0 {
+					// Ignoring compression, approximate number of blocks
+					numDataBlocks := targetL6FirstFileSize / blockSize
+					if numDataBlocks < 4 {
+						b.Fatalf("cannot produce two level index")
+					}
+					// Produce ~2 lower-level index blocks.
+					writerOptions.IndexBlockSize = (numDataBlocks / 2) * 8
+				} else if j == 0 {
+					// Only 2 keys in these files, so to produce two level indexes we
+					// set the block sizes to 1.
+					writerOptions.BlockSize = 1
+					writerOptions.IndexBlockSize = 1
+				}
+			}
 			writers[i] = append(writers[i], sstable.NewWriter(files[i][j], writerOptions))
 		}
 	}
 
-	var keys [][]byte
 	i := keyOffset
-	const targetSize = 2 << 20
 	w := writers[0][0]
-	for ; w.EstimatedSize() < targetSize; i++ {
+	for ; w.EstimatedSize() < targetL6FirstFileSize; i++ {
 		key := []byte(fmt.Sprintf("%08d", i))
 		keys = append(keys, key)
 		ikey := base.MakeInternalKey(key, 0, InternalKeyKindSet)
@@ -518,21 +534,26 @@ func buildLevelsForMergingIterSeqSeek(
 		writers[j][1].Add(lastIKey, nil)
 	}
 	for _, levelWriters := range writers {
-		for _, w := range levelWriters {
+		for j, w := range levelWriters {
 			if err := w.Close(); err != nil {
 				b.Fatal(err)
+			}
+			meta, err := w.Metadata()
+			require.NoError(b, err)
+			if forceTwoLevelIndex && j == 0 && meta.Properties.IndexType != 2 {
+				b.Fatalf("did not produce two level index")
 			}
 		}
 	}
 
-	opts := sstable.ReaderOptions{Cache: NewCache(128 << 20)}
+	opts := sstable.ReaderOptions{Cache: NewCache(128 << 20), Comparer: DefaultComparer}
 	if writeBloomFilters {
 		opts.Filters = make(map[string]FilterPolicy)
 		opts.Filters[filterPolicy.Name()] = filterPolicy
 	}
 	defer opts.Cache.Unref()
 
-	readers := make([][]*sstable.Reader, levelCount)
+	readers = make([][]*sstable.Reader, levelCount)
 	for i := range files {
 		for j := range files[i] {
 			f, err := mem.Open(fmt.Sprintf("bench%d_%d", i, j))
@@ -546,7 +567,7 @@ func buildLevelsForMergingIterSeqSeek(
 			readers[i] = append(readers[i], r)
 		}
 	}
-	levelSlices := make([]manifest.LevelSlice, levelCount)
+	levelSlices = make([]manifest.LevelSlice, levelCount)
 	for i := range readers {
 		meta := make([]*fileMetadata, len(readers[i]))
 		for j := range readers[i] {
@@ -615,7 +636,7 @@ func BenchmarkMergingIterSeqSeekGEWithBounds(b *testing.B) {
 		b.Run(fmt.Sprintf("levelCount=%d", levelCount),
 			func(b *testing.B) {
 				readers, levelSlices, keys := buildLevelsForMergingIterSeqSeek(
-					b, blockSize, restartInterval, levelCount, 0 /* keyOffset */, false, false)
+					b, blockSize, restartInterval, levelCount, 0 /* keyOffset */, false, false, false)
 				m := buildMergingIter(readers, levelSlices)
 				keyCount := len(keys)
 				b.ResetTimer()
@@ -643,7 +664,7 @@ func BenchmarkMergingIterSeqSeekPrefixGE(b *testing.B) {
 	const restartInterval = 16
 	const levelCount = 5
 	readers, levelSlices, keys := buildLevelsForMergingIterSeqSeek(
-		b, blockSize, restartInterval, levelCount, 0 /* keyOffset */, false, false)
+		b, blockSize, restartInterval, levelCount, 0 /* keyOffset */, false, false, false)
 
 	for _, skip := range []int{1, 2, 4, 8, 16} {
 		for _, useNext := range []bool{false, true} {

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -1792,22 +1792,12 @@ func (i *twoLevelIterator) SeekPrefixGE(
 
 	var dontSeekWithinSingleLevelIter bool
 	if i.topLevelIndex.isDataInvalidated() || !i.topLevelIndex.valid() || err != nil ||
-		i.boundsCmp <= 0 || i.cmp(key, i.topLevelIndex.Key().UserKey) > 0 {
+		(i.boundsCmp <= 0 && !flags.TrySeekUsingNext()) || i.cmp(key, i.topLevelIndex.Key().UserKey) > 0 {
 		// Slow-path: need to position the topLevelIndex.
-		//
-		// TODO(sumeer): improve this slow-path to be able to use Next, when
-		// flags.TrySeekUsingNext() is true, since the fast path never applies
-		// for practical uses of SeekPrefixGE in CockroachDB (they never set
-		// monotonic bounds). To apply it here, we would need to confirm that
-		// the topLevelIndex can continue using the same second level index
-		// block, and in that case we don't need to invalidate and reload the
-		// singleLevelIterator state. Do this after release blocker bug is fixed
-		// since don't want to backport this optimization.
 
 		// The previous exhausted state of singleLevelIterator is no longer
 		// relevant, since we may be moving to a different index block.
 		i.exhaustedBounds = 0
-
 		i.maybeFilteredKeysTwoLevel = false
 		flags = flags.DisableTrySeekUsingNext()
 		var ikey *InternalKey
@@ -1847,32 +1837,44 @@ func (i *twoLevelIterator) SeekPrefixGE(
 	} else {
 		// INVARIANT: err == nil.
 		//
-		// Else fast-path: The bounds have moved forward and this SeekGE is
-		// respecting the lower bound (guaranteed by Iterator). We know that
-		// the iterator must already be positioned within or just outside the
-		// previous bounds. Therefore the topLevelIndex iter cannot be
-		// positioned at an entry ahead of the seek position (though it can be
-		// positioned behind). The !i.cmp(key, i.topLevelIndex.Key().UserKey) > 0
-		// confirms that it is not behind. Since it is not ahead and not behind
-		// it must be at the right position.
+		// Else fast-path: There are two possible cases, from
+		// (i.boundsCmp > 0 || flags.TrySeekUsingNext()):
 		//
+		// 1) The bounds have moved forward (i.boundsCmp > 0) and this
+		// SeekPrefixGE is respecting the lower bound (guaranteed by Iterator). We
+		// know that the iterator must already be positioned within or just
+		// outside the previous bounds. Therefore, the topLevelIndex iter cannot
+		// be positioned at an entry ahead of the seek position (though it can be
+		// positioned behind). The !i.cmp(key, i.topLevelIndex.Key().UserKey) > 0
+		// confirms that it is not behind. Since it is not ahead and not behind it
+		// must be at the right position.
+		//
+		// 2) This SeekPrefixGE will land on a key that is greater than the key we
+		// are currently at (guaranteed by trySeekUsingNext), but since i.cmp(key,
+		// i.topLevelIndex.Key().UserKey) <= 0, we are at the correct lower level
+		// index block. No need to reset the state of singleLevelIterator.
+		//
+		// Note that cases 1 and 2 never overlap, and one of them must be true.
 		// This invariant checking is important enough that we do not gate it
 		// behind invariants.Enabled.
-		if i.boundsCmp <= 0 {
-			panic(fmt.Sprintf("boundsCmp %d is invalid for optimization", i.boundsCmp))
-		}
-		if flags.TrySeekUsingNext() {
-			panic("TrySeekUsingNext must not be true")
+		if i.boundsCmp > 0 == flags.TrySeekUsingNext() {
+			panic(fmt.Sprintf("inconsistency in optimization case 1 %t and case 2 %t",
+				i.boundsCmp > 0, flags.TrySeekUsingNext()))
 		}
 
-		// Bounds have changed so the previous exhausted bounds state is
-		// irrelevant.
-		// WARNING-data-exhausted: this is safe to do only because the monotonic
-		// bounds optimizations only work when !data-exhausted. If they also
-		// worked with data-exhausted, we have made it unclear whether
-		// data-exhausted is actually true. See the comment at the top of the
-		// file.
-		i.exhaustedBounds = 0
+		if !flags.TrySeekUsingNext() {
+			// Case 1. Bounds have changed so the previous exhausted bounds state is
+			// irrelevant.
+			// WARNING-data-exhausted: this is safe to do only because the monotonic
+			// bounds optimizations only work when !data-exhausted. If they also
+			// worked with data-exhausted, we have made it unclear whether
+			// data-exhausted is actually true. See the comment at the top of the
+			// file.
+			i.exhaustedBounds = 0
+		}
+		// Else flags.TrySeekUsingNext(). The i.exhaustedBounds is important to
+		// preserve for singleLevelIterator, and twoLevelIterator.skipForward. See
+		// bug https://github.com/cockroachdb/pebble/issues/2036.
 	}
 
 	if !dontSeekWithinSingleLevelIter {


### PR DESCRIPTION
…ingNext

The optimization added here is only applicable when the sstable is not exhausted. The existing IteratorSeqSeekPrefixGENotFound benchmark only improves for the case where bloom=false, since bloom=true will fail in the bloom filter match.

```
name                                                                                     old time/op    new time/op    delta
IteratorSeqSeekPrefixGEFound/skip=1/two-level=false/bloom=false/with-tombstone=false-10     262ns ± 1%     263ns ± 1%     ~     (p=0.151 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=1/two-level=false/bloom=false/with-tombstone=true-10      205ns ± 1%     207ns ± 0%   +0.86%  (p=0.016 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=1/two-level=false/bloom=true/with-tombstone=false-10      511ns ± 1%     537ns ± 2%   +5.12%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=1/two-level=false/bloom=true/with-tombstone=true-10       295ns ± 2%     304ns ± 2%   +3.12%  (p=0.016 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=1/two-level=true/bloom=false/with-tombstone=false-10     1.89µs ± 0%    0.30µs ± 1%  -84.41%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=1/two-level=true/bloom=false/with-tombstone=true-10       575ns ± 0%     213ns ± 1%  -62.92%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=1/two-level=true/bloom=true/with-tombstone=false-10       878ns ± 0%     540ns ± 3%  -38.55%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=1/two-level=true/bloom=true/with-tombstone=true-10        660ns ± 0%     308ns ± 5%  -53.32%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=2/two-level=false/bloom=false/with-tombstone=false-10     272ns ± 0%     275ns ± 1%   +1.11%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=2/two-level=false/bloom=false/with-tombstone=true-10      217ns ± 0%     220ns ± 1%   +1.60%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=2/two-level=false/bloom=true/with-tombstone=false-10      522ns ± 3%     562ns ± 6%   +7.65%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=2/two-level=false/bloom=true/with-tombstone=true-10       310ns ± 1%     311ns ± 1%     ~     (p=0.556 n=4+5)
IteratorSeqSeekPrefixGEFound/skip=2/two-level=true/bloom=false/with-tombstone=false-10     1.89µs ± 1%    0.31µs ± 1%  -83.77%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=2/two-level=true/bloom=false/with-tombstone=true-10       581ns ± 1%     226ns ± 1%  -61.17%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=2/two-level=true/bloom=true/with-tombstone=false-10       888ns ± 0%     545ns ± 6%  -38.68%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=2/two-level=true/bloom=true/with-tombstone=true-10        677ns ± 1%     312ns ± 1%  -53.98%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=4/two-level=false/bloom=false/with-tombstone=false-10     299ns ± 0%     296ns ± 1%   -1.11%  (p=0.032 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=4/two-level=false/bloom=false/with-tombstone=true-10      244ns ± 0%     242ns ± 0%   -1.15%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=4/two-level=false/bloom=true/with-tombstone=false-10      568ns ± 5%     560ns ± 0%     ~     (p=0.690 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=4/two-level=false/bloom=true/with-tombstone=true-10       346ns ± 3%     333ns ± 0%   -3.68%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=4/two-level=true/bloom=false/with-tombstone=false-10     1.93µs ± 1%    0.33µs ± 0%  -83.14%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=4/two-level=true/bloom=false/with-tombstone=true-10       607ns ± 0%     248ns ± 1%  -59.21%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=4/two-level=true/bloom=true/with-tombstone=false-10       951ns ± 6%     558ns ± 0%  -41.32%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGEFound/skip=4/two-level=true/bloom=true/with-tombstone=true-10        717ns ± 8%     339ns ± 2%  -52.76%  (p=0.008 n=5+5)

name                                                                                        old time/op  new time/op  delta
IteratorSeqSeekPrefixGENotFound/skip=1/two-level=false/bloom=false/with-tombstone=false-10   216ns ± 0%   217ns ± 0%     ~     (p=0.151 n=5+5)
IteratorSeqSeekPrefixGENotFound/skip=1/two-level=false/bloom=false/with-tombstone=true-10    178ns ± 1%   175ns ± 0%   -1.43%  (p=0.016 n=5+5)
IteratorSeqSeekPrefixGENotFound/skip=1/two-level=false/bloom=true/with-tombstone=false-10    430ns ± 5%   437ns ± 2%     ~     (p=0.135 n=5+5)
IteratorSeqSeekPrefixGENotFound/skip=1/two-level=false/bloom=true/with-tombstone=true-10     106ns ± 1%   105ns ± 1%     ~     (p=0.373 n=5+5)
IteratorSeqSeekPrefixGENotFound/skip=1/two-level=true/bloom=false/with-tombstone=false-10   1.20µs ± 0%  0.24µs ± 0%  -79.90%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGENotFound/skip=1/two-level=true/bloom=false/with-tombstone=true-10     424ns ± 0%   179ns ± 0%  -57.89%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGENotFound/skip=1/two-level=true/bloom=true/with-tombstone=false-10     432ns ± 1%   441ns ± 0%   +2.23%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGENotFound/skip=1/two-level=true/bloom=true/with-tombstone=true-10      107ns ± 0%   105ns ± 0%   -1.52%  (p=0.029 n=4+4)
IteratorSeqSeekPrefixGENotFound/skip=2/two-level=false/bloom=false/with-tombstone=false-10   218ns ± 1%   215ns ± 1%   -1.63%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGENotFound/skip=2/two-level=false/bloom=false/with-tombstone=true-10    176ns ± 0%   174ns ± 0%   -1.03%  (p=0.016 n=4+5)
IteratorSeqSeekPrefixGENotFound/skip=2/two-level=false/bloom=true/with-tombstone=false-10    416ns ± 2%   428ns ± 1%   +2.79%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGENotFound/skip=2/two-level=false/bloom=true/with-tombstone=true-10     107ns ± 1%   107ns ± 1%     ~     (p=0.952 n=5+5)
IteratorSeqSeekPrefixGENotFound/skip=2/two-level=true/bloom=false/with-tombstone=false-10   1.20µs ± 0%  0.24µs ± 0%  -79.63%  (p=0.016 n=4+5)
IteratorSeqSeekPrefixGENotFound/skip=2/two-level=true/bloom=false/with-tombstone=true-10     433ns ± 5%   181ns ± 0%  -58.27%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGENotFound/skip=2/two-level=true/bloom=true/with-tombstone=false-10     437ns ± 4%   451ns ± 3%     ~     (p=0.056 n=5+5)
IteratorSeqSeekPrefixGENotFound/skip=2/two-level=true/bloom=true/with-tombstone=true-10      106ns ± 0%   106ns ± 0%   -0.55%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGENotFound/skip=4/two-level=false/bloom=false/with-tombstone=false-10   215ns ± 0%   217ns ± 1%     ~     (p=0.135 n=5+5)
IteratorSeqSeekPrefixGENotFound/skip=4/two-level=false/bloom=false/with-tombstone=true-10    176ns ± 0%   176ns ± 1%     ~     (p=0.516 n=5+5)
IteratorSeqSeekPrefixGENotFound/skip=4/two-level=false/bloom=true/with-tombstone=false-10    418ns ± 1%   442ns ± 2%   +5.72%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGENotFound/skip=4/two-level=false/bloom=true/with-tombstone=true-10     107ns ± 1%   107ns ± 0%     ~     (p=0.357 n=5+5)
IteratorSeqSeekPrefixGENotFound/skip=4/two-level=true/bloom=false/with-tombstone=false-10   1.20µs ± 0%  0.24µs ± 0%  -79.64%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGENotFound/skip=4/two-level=true/bloom=false/with-tombstone=true-10     425ns ± 0%   181ns ± 1%  -57.38%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGENotFound/skip=4/two-level=true/bloom=true/with-tombstone=false-10     433ns ± 0%   457ns ± 6%   +5.41%  (p=0.008 n=5+5)
IteratorSeqSeekPrefixGENotFound/skip=4/two-level=true/bloom=true/with-tombstone=true-10      107ns ± 2%   106ns ± 1%     ~     (p=0.159 n=5+5)

name                                            old time/op  new time/op  delta
IteratorSeqSeekGEWithBounds/two-level=false-10   314ns ± 3%   308ns ± 0%  -1.97%  (p=0.008 n=5+5)
IteratorSeqSeekGEWithBounds/two-level=true-10    309ns ± 1%   308ns ± 0%    ~     (p=0.151 n=5+5)
```