### PR TITLE
sstable: optimize twoLevelIterator, when exhausted, for SeekGE & SeekPrefixGE

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -151,8 +151,10 @@ type Iterator interface {
 //   bound is exhausted (due to block property filters filtering out index and
 //   data blocks and going past the bound on the top level index block). Note
 //   that if we tried to separate out the BPF case from others we could
-//   develop more knowledge here. - !PLDE or !PGDE of course imply that
-//   data-exhausted is not true.
+//   develop more knowledge here.
+// - PGDE is true for twoLevelIterator. PLDE is true if it is a standalone
+//   singleLevelIterator. !PLDE or !PGDE of course imply that data-exhausted
+//   is not true.
 //
 // An implication of the above is that if we are going to somehow utilize
 // knowledge of data-exhausted in an optimization, we must not forget the
@@ -171,6 +173,21 @@ type Iterator interface {
 //   comments if trying to optimize this in the future.
 // - TrySeekUsingNext optimizations: these work regardless of exhaustion
 //   state.
+//
+// Implementation detail: In the code PLDE only checks that
+// i.data.isDataInvalidated(). This narrower check is safe, since this is a
+// subset of the set expressed by the OR expression. Also, it is not a
+// de-optimization since whenever we exhaust the iterator we explicitly call
+// i.data.invalidate(). PGDE checks i.index.isDataInvalidated() &&
+// i.data.isDataInvalidated(). Again, this narrower check is safe, and not a
+// de-optimization since whenever we exhaust the iterator we explicitly call
+// i.index.invalidate() and i.data.invalidate(). The && is questionable -- for
+// now this is a bit of defensive code. We should seriously consider removing
+// it, since defensive code suggests we are not confident about our invariants
+// (and if we are not confident, we need more invariant assertions, not
+// defensive code).
+//
+// TODO(sumeer): remove the aforementioned defensive code.
 
 // singleLevelIterator iterates over an entire table of data. To seek for a given
 // key, it first looks in the index for the block that contains that key, and then
@@ -1608,14 +1625,15 @@ func (i *twoLevelIterator) SeekGE(
 	err := i.err
 	i.err = nil // clear cached iteration error
 
-	// TODO(sumeer): we are not fully optimizing in the flags.TrySeekUsingNext()
-	// case when the twoLevelIterator is already exhausted. We will take the
-	// slow-path below, even though we could return now. We could do:
-	// if flags.TrySeekUsingNext() && (i.exhaustedBounds == +1 || (i.data.isDataInvalidated() &&
-	//	i.index.isDataInvalidated())) && i.err == nil {
-	//	// Already exhausted, so return nil.
-	//	return nil, nil
-	// }
+	// The twoLevelIterator could be already exhausted. Utilize that when
+	// trySeekUsingNext is true. See the comment about data-exhausted, PGDE, and
+	// bounds-exhausted near the top of the file.
+	if flags.TrySeekUsingNext() &&
+		(i.exhaustedBounds == +1 || (i.data.isDataInvalidated() && i.index.isDataInvalidated())) &&
+		err == nil {
+		// Already exhausted, so return nil.
+		return nil, base.LazyValue{}
+	}
 
 	// SeekGE performs various step-instead-of-seeking optimizations: eg enabled
 	// by trySeekUsingNext, or by monotonically increasing bounds (i.boundsCmp).
@@ -1749,16 +1767,17 @@ func (i *twoLevelIterator) SeekPrefixGE(
 	err := i.err
 	i.err = nil // clear cached iteration error
 
-	// TODO(sumeer): we are not fully optimizing in the flags.TrySeekUsingNext()
-	// case when the twoLevelIterator is already exhausted. We will take the
-	// slow-path below, even though we could return now. We could do:
-	// filterUsedAndDidNotMatch :=
-	//	i.reader.tableFilter != nil && i.useFilter && !i.lastBloomFilterMatched
-	// if flags.TrySeekUsingNext() && (i.exhaustedBounds == +1 || (i.data.isDataInvalidated() &&
-	//  i.index.isDataInvalidated())) && i.err == nil {
-	//	// Already exhausted, so return nil.
-	//	return nil, nil
-	//}
+	// The twoLevelIterator could be already exhausted. Utilize that when
+	// trySeekUsingNext is true. See the comment about data-exhausted, PGDE, and
+	// bounds-exhausted near the top of the file.
+	filterUsedAndDidNotMatch :=
+		i.reader.tableFilter != nil && i.useFilter && !i.lastBloomFilterMatched
+	if flags.TrySeekUsingNext() && !filterUsedAndDidNotMatch &&
+		(i.exhaustedBounds == +1 || (i.data.isDataInvalidated() && i.index.isDataInvalidated())) &&
+		err == nil {
+		// Already exhausted, so return nil.
+		return nil, base.LazyValue{}
+	}
 
 	// Check prefix bloom filter.
 	if i.reader.tableFilter != nil && i.useFilter {

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -1043,7 +1043,9 @@ func buildTestTable(
 	return r
 }
 
-func buildBenchmarkTable(b *testing.B, options WriterOptions) (*Reader, [][]byte) {
+func buildBenchmarkTable(
+	b *testing.B, options WriterOptions, confirmTwoLevelIndex bool, offset int,
+) (*Reader, [][]byte) {
 	mem := vfs.NewMem()
 	f0, err := mem.Create("bench")
 	if err != nil {
@@ -1056,7 +1058,7 @@ func buildBenchmarkTable(b *testing.B, options WriterOptions) (*Reader, [][]byte
 	var ikey InternalKey
 	for i := uint64(0); i < 1e6; i++ {
 		key := make([]byte, 8)
-		binary.BigEndian.PutUint64(key, i)
+		binary.BigEndian.PutUint64(key, i+uint64(offset))
 		keys = append(keys, key)
 		ikey.UserKey = key
 		w.Add(ikey, nil)
@@ -1078,6 +1080,9 @@ func buildBenchmarkTable(b *testing.B, options WriterOptions) (*Reader, [][]byte
 	})
 	if err != nil {
 		b.Fatal(err)
+	}
+	if confirmTwoLevelIndex && r.Properties.IndexPartitions == 0 {
+		b.Fatalf("should have constructed two level index")
 	}
 	return r, keys
 }
@@ -1110,7 +1115,7 @@ func BenchmarkTableIterSeekGE(b *testing.B) {
 	for _, bm := range basicBenchmarks {
 		b.Run(bm.name,
 			func(b *testing.B) {
-				r, keys := buildBenchmarkTable(b, bm.options)
+				r, keys := buildBenchmarkTable(b, bm.options, false, 0)
 				it, err := r.NewIter(nil /* lower */, nil /* upper */)
 				require.NoError(b, err)
 				rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
@@ -1131,7 +1136,7 @@ func BenchmarkTableIterSeekLT(b *testing.B) {
 	for _, bm := range basicBenchmarks {
 		b.Run(bm.name,
 			func(b *testing.B) {
-				r, keys := buildBenchmarkTable(b, bm.options)
+				r, keys := buildBenchmarkTable(b, bm.options, false, 0)
 				it, err := r.NewIter(nil /* lower */, nil /* upper */)
 				require.NoError(b, err)
 				rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
@@ -1152,7 +1157,7 @@ func BenchmarkTableIterNext(b *testing.B) {
 	for _, bm := range basicBenchmarks {
 		b.Run(bm.name,
 			func(b *testing.B) {
-				r, _ := buildBenchmarkTable(b, bm.options)
+				r, _ := buildBenchmarkTable(b, bm.options, false, 0)
 				it, err := r.NewIter(nil /* lower */, nil /* upper */)
 				require.NoError(b, err)
 
@@ -1181,7 +1186,7 @@ func BenchmarkTableIterPrev(b *testing.B) {
 	for _, bm := range basicBenchmarks {
 		b.Run(bm.name,
 			func(b *testing.B) {
-				r, _ := buildBenchmarkTable(b, bm.options)
+				r, _ := buildBenchmarkTable(b, bm.options, false, 0)
 				it, err := r.NewIter(nil /* lower */, nil /* upper */)
 				require.NoError(b, err)
 
@@ -1207,11 +1212,93 @@ func BenchmarkTableIterPrev(b *testing.B) {
 }
 
 func BenchmarkLayout(b *testing.B) {
-	r, _ := buildBenchmarkTable(b, WriterOptions{})
+	r, _ := buildBenchmarkTable(b, WriterOptions{}, false, 0)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r.Layout()
 	}
 	b.StopTimer()
 	r.Close()
+}
+
+func BenchmarkSeqSeekGEExhausted(b *testing.B) {
+	// Snappy with no bloom filter.
+	options := basicBenchmarks[0].options
+
+	for _, twoLevelIndex := range []bool{false, true} {
+		switch twoLevelIndex {
+		case false:
+			options.IndexBlockSize = 0
+		case true:
+			options.IndexBlockSize = 512
+		}
+		const offsetCount = 5000
+		reader, keys := buildBenchmarkTable(b, options, twoLevelIndex, offsetCount)
+		var preKeys [][]byte
+		for i := 0; i < offsetCount; i++ {
+			key := make([]byte, 8)
+			binary.BigEndian.PutUint64(key, uint64(i))
+			preKeys = append(preKeys, key)
+		}
+		var postKeys [][]byte
+		for i := 0; i < offsetCount; i++ {
+			key := make([]byte, 8)
+			binary.BigEndian.PutUint64(key, uint64(i+offsetCount+len(keys)))
+			postKeys = append(postKeys, key)
+		}
+		for _, exhaustedBounds := range []bool{false, true} {
+			for _, prefixSeek := range []bool{false, true} {
+				exhausted := "file"
+				if exhaustedBounds {
+					exhausted = "bounds"
+				}
+				seekKind := "ge"
+				if prefixSeek {
+					seekKind = "prefix-ge"
+				}
+				b.Run(fmt.Sprintf(
+					"two-level=%t/exhausted=%s/seek=%s", twoLevelIndex, exhausted, seekKind),
+					func(b *testing.B) {
+						var upper []byte
+						var seekKeys [][]byte
+						if exhaustedBounds {
+							seekKeys = preKeys
+							upper = keys[0]
+						} else {
+							seekKeys = postKeys
+						}
+						it, err := reader.NewIter(nil /* lower */, upper)
+						require.NoError(b, err)
+						b.ResetTimer()
+						pos := 0
+						var seekGEFlags SeekGEFlags
+						for i := 0; i < b.N; i++ {
+							seekKey := seekKeys[0]
+							var k *InternalKey
+							if prefixSeek {
+								k, _ = it.SeekPrefixGE(seekKey, seekKey, seekGEFlags)
+							} else {
+								k, _ = it.SeekGE(seekKey, seekGEFlags)
+							}
+							if k != nil {
+								b.Fatal("found a key")
+							}
+							if it.Error() != nil {
+								b.Fatalf("%s", it.Error().Error())
+							}
+							pos++
+							if pos == len(seekKeys) {
+								pos = 0
+								seekGEFlags = seekGEFlags.DisableTrySeekUsingNext()
+							} else {
+								seekGEFlags = seekGEFlags.EnableTrySeekUsingNext()
+							}
+						}
+						b.StopTimer()
+						it.Close()
+					})
+			}
+		}
+		reader.Close()
+	}
 }


### PR DESCRIPTION
This optimization is done when TrySeekUsingNext is set to true.
A new microbenchmark is added for this case and shows substantial
improvement. We expect this to be helpful when an sstable is not
part of a levelIter (since if the data is exhausted, the levelIter
will switch to a different sstable), or when only the bounds are
reached (even with a levelIter).

Note: two-level=true/exhausted=bounds does not show as much
improvement since the index block is loaded and a fast path will
be taken when twoLevelIterator calls into singleLevelIterator. If
the index block was not loaded, say because of block property
filter not matching, then the speedup should be similar to the
exhausted=file case.

```
name                                                                   old time/op    new time/op    delta
SeqSeekGEExhausted/two-level=false/exhausted=file/seek=ge-10             3.49ns ± 0%    3.46ns ± 0%   -0.72%  (p=0.008 n=5+5)
SeqSeekGEExhausted/two-level=false/exhausted=file/seek=prefix-ge-10      5.37ns ± 0%    5.34ns ± 1%   -0.67%  (p=0.032 n=5+5)
SeqSeekGEExhausted/two-level=false/exhausted=bounds/seek=ge-10           3.90ns ± 6%    3.76ns ± 0%   -3.72%  (p=0.008 n=5+5)
SeqSeekGEExhausted/two-level=false/exhausted=bounds/seek=prefix-ge-10    5.69ns ± 0%    5.61ns ± 0%   -1.40%  (p=0.008 n=5+5)
SeqSeekGEExhausted/two-level=true/exhausted=file/seek=ge-10               319ns ± 5%       4ns ± 0%  -98.72%  (p=0.008 n=5+5)
SeqSeekGEExhausted/two-level=true/exhausted=file/seek=prefix-ge-10        325ns ± 3%       5ns ± 3%  -98.53%  (p=0.008 n=5+5)
SeqSeekGEExhausted/two-level=true/exhausted=bounds/seek=ge-10            11.6ns ± 7%     4.1ns ± 0%  -64.67%  (p=0.016 n=5+4)
SeqSeekGEExhausted/two-level=true/exhausted=bounds/seek=prefix-ge-10     12.4ns ±12%     4.7ns ± 0%  -61.89%  (p=0.008 n=5+5)
```