### PR TITLE
metamorphic: disable {delete,elision}-only compactions randomly

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1814,7 +1814,8 @@ func (d *DB) maybeScheduleCompactionPicker(
 
 	// Check for delete-only compactions first, because they're expected to be
 	// cheap and reduce future compaction work.
-	if len(d.mu.compact.deletionHints) > 0 &&
+	if !d.opts.private.disableDeleteOnlyCompactions &&
+		len(d.mu.compact.deletionHints) > 0 &&
 		d.mu.compact.compactingCount < maxConcurrentCompactions &&
 		!d.opts.DisableAutomaticCompactions {
 		v := d.mu.versions.currentVersion()

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1328,6 +1328,9 @@ func markedMergeHelper(f *fileMetadata, dst interface{}) (interface{}, bool) {
 func (p *compactionPickerByScore) pickElisionOnlyCompaction(
 	env compactionEnv,
 ) (pc *pickedCompaction) {
+	if p.opts.private.disableElisionOnlyCompactions {
+		return nil
+	}
 	v := p.vers.Levels[numLevels-1].Annotation(elisionOnlyAnnotator{})
 	if v == nil {
 		return nil

--- a/table_stats.go
+++ b/table_stats.go
@@ -131,7 +131,7 @@ func (d *DB) collectTableStats() bool {
 	}
 	d.mu.tableStats.cond.Broadcast()
 	d.maybeCollectTableStatsLocked()
-	if len(hints) > 0 {
+	if len(hints) > 0 && !d.opts.private.disableDeleteOnlyCompactions {
 		// Verify that all of the hint tombstones' files still exist in the
 		// current version. Otherwise, the tombstone itself may have been
 		// compacted into L6 and more recent keys may have had their sequence


### PR DESCRIPTION
In random runs, randomly disable delete-only and elision-only compactions. This can improve test coverage of snapshot-pinned data and range tombstones. Users should not disable these compaction types, so these new knobs are hidden within the private Options struct.

Informs #2042.