### PR TITLE
crl-release-22.2: .github: renable crossversion metamorphic CI action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,6 @@ jobs:
     - run: make test generate
 
   linux-crossversion:
-    if: ${{ false }} # disabled in PR 2018 until further investigation
     name: go-linux-crossversion
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Cockroach 22.2 backport of #2037.

----

This CI action was temporarily disabled while it was being fixed. It can now be reenabled.