### PR TITLE
metamorphic/crossversion: update reproduction command

### DIFF
--- a/internal/metamorphic/crossversion/crossversion_test.go
+++ b/internal/metamorphic/crossversion/crossversion_test.go
@@ -65,8 +65,10 @@ moved on failure. Defaults to the current working directory.`)
 }
 
 func reproductionCommand() string {
-	return fmt.Sprintf("go test -v -run 'TestMetaCrossVersion' --seed %d --factor %d %s\n",
-		seed, factor, versions.String())
+	return fmt.Sprintf(
+		"SEED=%d FACTOR=%d ./scripts/run-crossversion-meta.sh %s\n",
+		seed, factor, versions.String(),
+	)
 }
 
 // TestMetaCrossVersion performs cross-version metamorphic testing.
@@ -325,7 +327,7 @@ func (f *pebbleVersions) String() string {
 		if i > 0 {
 			fmt.Fprint(&buf, " ")
 		}
-		fmt.Fprintf(&buf, "--version %s", v.String())
+		fmt.Fprintf(&buf, v.SHA)
 	}
 	return buf.String()
 }

--- a/scripts/run-crossversion-meta.sh
+++ b/scripts/run-crossversion-meta.sh
@@ -26,9 +26,21 @@ done
 git checkout $BRANCH
 
 if [[ -z "${STRESS}" ]]; then
-    go test ./internal/metamorphic/crossversion -test.v -test.timeout "${TIMEOUT:-30m}" -test.run 'TestMetaCrossVersion$' $(echo $VERSIONS)
+    go test ./internal/metamorphic/crossversion \
+      -test.v \
+      -test.timeout "${TIMEOUT:-30m}" \
+      -test.run 'TestMetaCrossVersion$' \
+      -seed ${SEED:-0} \
+      -factor ${FACTOR:-10} \
+      $(echo $VERSIONS)
 else
-    stress -p 1 go test ./internal/metamorphic/crossversion -test.v -test.timeout "${TIMEOUT:-30m}" -test.run 'TestMetaCrossVersion$' $(echo $VERSIONS)
+    stress -p 1 go test ./internal/metamorphic/crossversion \
+      -test.v \
+      -test.timeout "${TIMEOUT:-30m}" \
+      -test.run 'TestMetaCrossVersion$' \
+      -seed ${SEED:-0} \
+      -factor ${FACTOR:-10} \
+      $(echo $VERSIONS)
 fi
 
 rm -rf $TEMPDIR


### PR DESCRIPTION
Update the reproduction command for the crossversion test to make use of the wrapper script. Previously the command would output the command with the paths to the test binaries, which may not exist on the machine where the reproduction is attempted.

Allow the seed and the branching factor to be passed through as environment variables.

As a result, the output should allow for a simple copy-paste to perform a reproduction. For example:

```bash
$ SEED=123 FACTOR=1 ./scripts/run-crossversion-meta.sh crl-release-21.2 crl-release-22.1 crl-release-22.2 master
...
    crossversion_test.go:83: Reproduction:
          SEED=123 FACTOR=1 ./scripts/run-crossversion-meta.sh 441910e2 03e49132 0fc8d9e0 f2a7c319
```

Touches #2099.