### PR TITLE
db: rename isLargestUserKeyRangeDelSentinel

### DIFF
--- a/level_iter.go
+++ b/level_iter.go
@@ -655,7 +655,7 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) loadFileReturnIndicato
 		if l.boundaryContext != nil {
 			l.boundaryContext.smallestUserKey = file.Smallest.UserKey
 			l.boundaryContext.largestUserKey = file.Largest.UserKey
-			l.boundaryContext.isLargestUserKeyRangeDelSentinel = file.Largest.IsExclusiveSentinel()
+			l.boundaryContext.isLargestUserKeyExclusive = file.Largest.IsExclusiveSentinel()
 		}
 		return newFileLoaded
 	}

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -44,11 +44,11 @@ type levelIterBoundaryContext struct {
 	// smallestUserKey and largestUserKey are populated with the smallest and
 	// largest boundaries of the current file.
 	smallestUserKey, largestUserKey []byte
-	// isLargestUserKeyRangeDelSentinel is set to true when a file's largest
-	// boundary is an exclusive range deletion sentinel. If true, the file does
-	// not contain any keys with the provided user key, and the largestUserKey
-	// bound is exclusive.
-	isLargestUserKeyRangeDelSentinel bool
+	// isLargestUserKeyExclusive is set to true when a file's largest boundary
+	// is an exclusive key, (eg, a range deletion sentinel). If true, the file
+	// does not contain any keys with the provided user key, and the
+	// largestUserKey bound is exclusive.
+	isLargestUserKeyExclusive bool
 	// isSyntheticIterBoundsKey is set to true iff the key returned by the level
 	// iterator is a synthetic key derived from the iterator bounds. This is
 	// used to prevent the mergingIter from being stuck at such a synthetic key
@@ -823,7 +823,7 @@ func (m *mergingIter) isPrevEntryDeleted(item *mergingIterItem) bool {
 		// Example 3:
 		// sstable bounds [c#8, g#RangeDelSentinel] containing [b, i)#7 and the key is g#10.
 		// This key is not deleted by this tombstone. We need to look at
-		// isLargestUserKeyRangeDelSentinel.
+		// isLargestUserKeyExclusive.
 		//
 		// For a tombstone at the same level as the key, the file bounds are trivially satisfied.
 
@@ -831,7 +831,7 @@ func (m *mergingIter) isPrevEntryDeleted(item *mergingIterItem) bool {
 		withinLargestSSTableBound := true
 		if l.largestUserKey != nil {
 			cmpResult := m.heap.cmp(l.largestUserKey, item.key.UserKey)
-			withinLargestSSTableBound = cmpResult > 0 || (cmpResult == 0 && !l.isLargestUserKeyRangeDelSentinel)
+			withinLargestSSTableBound = cmpResult > 0 || (cmpResult == 0 && !l.isLargestUserKeyExclusive)
 		}
 		if withinLargestSSTableBound && l.tombstone.Contains(m.heap.cmp, item.key.UserKey) && l.tombstone.VisibleAt(m.snapshot) {
 			if level < item.index {
@@ -1040,7 +1040,7 @@ func (m *mergingIter) seekLT(key []byte, level int, flags base.SeekLTFlags) {
 			withinLargestSSTableBound := true
 			if l.largestUserKey != nil {
 				cmpResult := m.heap.cmp(l.largestUserKey, key)
-				withinLargestSSTableBound = cmpResult > 0 || (cmpResult == 0 && !l.isLargestUserKeyRangeDelSentinel)
+				withinLargestSSTableBound = cmpResult > 0 || (cmpResult == 0 && !l.isLargestUserKeyExclusive)
 			}
 
 			l.tombstone = keyspan.SeekLE(m.heap.cmp, rangeDelIter, key)


### PR DESCRIPTION
The isLargestUserKeyRangeDelSentinel flag on the levelIterBoundaryContext—used to propagate information to the merging iterator about a level's current file's boundaries—had an outdated, misleading name. Range deletion sentinels are no longer the only source of exclusive end boundaries. If a file's largest key is a range key sentinel, this flag was also marked as true. Rename it to specifically describe whether the largest key is exclusive.