### PR TITLE
sstable: assert invariant when range key is added to Writer

### DIFF
--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -970,6 +970,11 @@ func (w *Writer) AddRangeKey(key InternalKey, value []byte) error {
 }
 
 func (w *Writer) addRangeKeySpan(span keyspan.Span) error {
+	if w.compare(span.Start, span.End) >= 0 {
+		return errors.Errorf(
+			"pebble: start key must be strictly less than end key",
+		)
+	}
 	if w.fragmenter.Start() != nil && w.compare(w.fragmenter.Start(), span.Start) > 0 {
 		return errors.Errorf("pebble: spans must be added in order: %s > %s",
 			w.formatKey(w.fragmenter.Start()), w.formatKey(span.Start))


### PR DESCRIPTION
This pr adds an invariant check behing the invariants.Enabled flag to confirm that the start/end bounds of the range keys added to the Writer are not the same.