### PR TITLE
crl-release-22.2: db: prevent ingestions from breaking seq num invariants

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1291,7 +1291,7 @@ func (c *compaction) newInputIter(
 				}
 				return iter, err
 			}
-			li.Init(keyspan.SpanIterOptions{}, c.cmp, newRangeKeyIterWrapper, level.files.Iter(), l, c.logger, manifest.KeyTypeRange)
+			li.Init(keyspan.SpanIterOptions{}, c.cmp, newRangeKeyIterWrapper, level.files.Iter(), l, manifest.KeyTypeRange)
 			rangeKeyIters = append(rangeKeyIters, li)
 		}
 		return nil

--- a/data_test.go
+++ b/data_test.go
@@ -1059,6 +1059,7 @@ func runForceIngestCmd(td *datadriven.TestData, d *DB) error {
 	}
 	_, err := d.ingest(paths, func(
 		tableNewIters,
+		keyspan.TableNewSpanIter,
 		IterOptions,
 		Compare,
 		*version,

--- a/internal/keyspan/level_iter.go
+++ b/internal/keyspan/level_iter.go
@@ -11,18 +11,11 @@ import (
 	"github.com/cockroachdb/pebble/internal/manifest"
 )
 
-// Logger defines an interface for writing log messages.
-type Logger interface {
-	Infof(format string, args ...interface{})
-	Fatalf(format string, args ...interface{})
-}
-
 // LevelIter provides a merged view of spans from sstables in a level.
 // It takes advantage of level invariants to only have one sstable span block
 // open at one time, opened using the newIter function passed in.
 type LevelIter struct {
-	logger Logger
-	cmp    base.Compare
+	cmp base.Compare
 	// Denotes if this level iter should read point key spans (i.e. rangedels,
 	// or range keys. If key type is Point, no straddle spans are emitted between
 	// files, and point key bounds are used to find files instead of range key
@@ -79,11 +72,10 @@ func newLevelIter(
 	newIter TableNewSpanIter,
 	files manifest.LevelIterator,
 	level manifest.Level,
-	logger Logger,
 	keyType manifest.KeyType,
 ) *LevelIter {
 	l := &LevelIter{}
-	l.Init(opts, cmp, newIter, files, level, logger, keyType)
+	l.Init(opts, cmp, newIter, files, level, keyType)
 	return l
 }
 
@@ -94,12 +86,10 @@ func (l *LevelIter) Init(
 	newIter TableNewSpanIter,
 	files manifest.LevelIterator,
 	level manifest.Level,
-	logger Logger,
 	keyType manifest.KeyType,
 ) {
 	l.err = nil
 	l.level = level
-	l.logger = logger
 	l.tableOpts.RangeKeyFilters = opts.RangeKeyFilters
 	l.cmp = cmp
 	l.iterFile = nil

--- a/internal/keyspan/level_iter_test.go
+++ b/internal/keyspan/level_iter_test.go
@@ -6,7 +6,6 @@ package keyspan
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"testing"
 
@@ -307,7 +306,7 @@ func TestLevelIterEquivalence(t *testing.T) {
 			b.Added[6] = metas
 			v, _, err := b.Apply(nil, base.DefaultComparer.Compare, base.DefaultFormatter, 0, 0)
 			require.NoError(t, err)
-			levelIter.Init(SpanIterOptions{}, base.DefaultComparer.Compare, tableNewIters, v.Levels[6].Iter(), 0, nil, manifest.KeyTypeRange)
+			levelIter.Init(SpanIterOptions{}, base.DefaultComparer.Compare, tableNewIters, v.Levels[6].Iter(), 0, manifest.KeyTypeRange)
 			levelIters = append(levelIters, &levelIter)
 		}
 
@@ -333,21 +332,6 @@ func TestLevelIterEquivalence(t *testing.T) {
 			valid = f1 != nil && f2 != nil
 		}
 	}
-}
-
-type testLogger struct {
-	t *testing.T
-}
-
-// Infof implements the Logger.Infof interface.
-func (t *testLogger) Infof(format string, args ...interface{}) {
-	_ = log.Output(2, fmt.Sprintf(format, args...))
-}
-
-// Fatalf implements the Logger.Fatalf interface.
-func (t *testLogger) Fatalf(format string, args ...interface{}) {
-	_ = log.Output(2, fmt.Sprintf(format, args...))
-	t.t.Fail()
 }
 
 func TestLevelIter(t *testing.T) {
@@ -452,7 +436,7 @@ func TestLevelIter(t *testing.T) {
 				b.Added[6] = metas
 				v, _, err := b.Apply(nil, base.DefaultComparer.Compare, base.DefaultFormatter, 0, 0)
 				require.NoError(t, err)
-				iter = newLevelIter(SpanIterOptions{}, base.DefaultComparer.Compare, tableNewIters, v.Levels[6].Iter(), 6, &testLogger{t}, keyType)
+				iter = newLevelIter(SpanIterOptions{}, base.DefaultComparer.Compare, tableNewIters, v.Levels[6].Iter(), 6, keyType)
 				extraInfo = func() string {
 					return fmt.Sprintf("file = %s.sst", lastFileNum)
 				}

--- a/range_keys.go
+++ b/range_keys.go
@@ -80,7 +80,7 @@ func (i *Iterator) constructRangeKeyIter() {
 		li := i.rangeKey.iterConfig.NewLevelIter()
 		spanIterOpts := keyspan.SpanIterOptions{RangeKeyFilters: i.opts.RangeKeyFilters}
 		li.Init(spanIterOpts, i.cmp, i.newIterRangeKey, current.RangeKeyLevels[level].Iter(),
-			manifest.Level(level), i.opts.logger, manifest.KeyTypeRange)
+			manifest.Level(level), manifest.KeyTypeRange)
 		i.rangeKey.iterConfig.AddLevel(li)
 	}
 }

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -200,7 +200,7 @@ compact         1   2.3 K     0 B       0          (size == estimated-debt, scor
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.4 K   11.1%  (score == hit-rate)
- tcache         1   680 B   40.0%  (score == hit-rate)
+ tcache         1   680 B   50.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -695,3 +695,210 @@ lsm
   000005:[a#2,RANGEDEL-b#72057594037927935,RANGEDEL]
 6:
   000004:[a#1,RANGEDEL-b#72057594037927935,RANGEDEL]
+
+# Check for range key ingestion bug fix in
+# https://github.com/cockroachdb/pebble/pull/2082. Without the fix, we expect
+# the range key associated with the table ext3 to get elided. This test checks
+# that the elision does not happen.
+reset
+----
+
+build ext1
+range-key-set d g 1 val1
+----
+
+ingest ext1
+----
+
+lsm
+----
+6:
+  000004:[d#1,RANGEKEYSET-g#72057594037927935,RANGEKEYSET]
+
+build ext2
+range-key-set b e 1 val2
+----
+
+ingest ext2
+----
+
+lsm
+----
+0.0:
+  000005:[b#2,RANGEKEYSET-e#72057594037927935,RANGEKEYSET]
+6:
+  000004:[d#1,RANGEKEYSET-g#72057594037927935,RANGEKEYSET]
+
+build ext3
+range-key-del a c
+----
+
+ingest ext3
+----
+
+# Without the fix in #2082 we would expect ext3 file to be ingested into L6.
+lsm
+----
+0.1:
+  000006:[a#3,RANGEKEYDEL-c#72057594037927935,RANGEKEYDEL]
+0.0:
+  000005:[b#2,RANGEKEYSET-e#72057594037927935,RANGEKEYSET]
+6:
+  000004:[d#1,RANGEKEYSET-g#72057594037927935,RANGEKEYSET]
+
+build ext4
+set a a
+----
+
+ingest ext4
+----
+
+lsm
+----
+0.2:
+  000007:[a#4,SET-a#4,SET]
+0.1:
+  000006:[a#3,RANGEKEYDEL-c#72057594037927935,RANGEKEYDEL]
+0.0:
+  000005:[b#2,RANGEKEYSET-e#72057594037927935,RANGEKEYSET]
+6:
+  000004:[d#1,RANGEKEYSET-g#72057594037927935,RANGEKEYSET]
+
+compact a aa
+----
+
+# Without the fix in #2082, we would expect the range key delete a-c to
+# get elided as it would be in L6 beneath the b-e range key in L0.
+lsm
+----
+6:
+  000008:[a#0,SET-g#72057594037927935,RANGEKEYSET]
+
+# Shouldn't show results for the b-c range as it must be deleted.
+iter
+first
+next
+next
+next
+----
+a: (a, .)
+c: (., [c-e) 1=val2 UPDATED)
+e: (., [e-g) 1=val1 UPDATED)
+.
+
+# Keys can have exclusive sentinels. Check that files boundaries which contain
+# such keys are ingested ingested into the lowest level possible.
+reset
+----
+
+build ext1
+set c c
+set e e
+----
+
+ingest ext1
+----
+
+lsm
+----
+6:
+  000004:[c#1,SET-e#1,SET]
+
+
+build ext2
+range-key-set a c 1 val1
+----
+
+ingest ext2
+----
+
+lsm
+----
+6:
+  000005:[a#2,RANGEKEYSET-c#72057594037927935,RANGEKEYSET]
+  000004:[c#1,SET-e#1,SET]
+
+# The following test cases will test that files where the end bound is an
+# exclusive sentinel due to range keys are ingested into the correct levels.
+build ext3
+set f f
+set h h
+----
+
+ingest ext3
+----
+
+lsm
+----
+6:
+  000005:[a#2,RANGEKEYSET-c#72057594037927935,RANGEKEYSET]
+  000004:[c#1,SET-e#1,SET]
+  000006:[f#3,SET-h#3,SET]
+
+
+build ext4
+range-key-unset eee f 1
+----
+
+ingest ext4
+----
+
+lsm
+----
+6:
+  000005:[a#2,RANGEKEYSET-c#72057594037927935,RANGEKEYSET]
+  000004:[c#1,SET-e#1,SET]
+  000007:[eee#4,RANGEKEYUNSET-f#72057594037927935,RANGEKEYUNSET]
+  000006:[f#3,SET-h#3,SET]
+
+build ext5
+range-key-set ee eee 1 val3
+----
+
+ingest ext5
+----
+
+lsm
+----
+6:
+  000005:[a#2,RANGEKEYSET-c#72057594037927935,RANGEKEYSET]
+  000004:[c#1,SET-e#1,SET]
+  000008:[ee#5,RANGEKEYSET-eee#72057594037927935,RANGEKEYSET]
+  000007:[eee#4,RANGEKEYUNSET-f#72057594037927935,RANGEKEYUNSET]
+  000006:[f#3,SET-h#3,SET]
+
+build ext6
+set x x
+set y y
+----
+
+ingest ext6
+----
+
+lsm
+----
+6:
+  000005:[a#2,RANGEKEYSET-c#72057594037927935,RANGEKEYSET]
+  000004:[c#1,SET-e#1,SET]
+  000008:[ee#5,RANGEKEYSET-eee#72057594037927935,RANGEKEYSET]
+  000007:[eee#4,RANGEKEYUNSET-f#72057594037927935,RANGEKEYUNSET]
+  000006:[f#3,SET-h#3,SET]
+  000009:[x#6,SET-y#6,SET]
+
+build ext7
+range-key-del s x
+----
+
+ingest ext7
+----
+
+lsm
+----
+6:
+  000005:[a#2,RANGEKEYSET-c#72057594037927935,RANGEKEYSET]
+  000004:[c#1,SET-e#1,SET]
+  000008:[ee#5,RANGEKEYSET-eee#72057594037927935,RANGEKEYSET]
+  000007:[eee#4,RANGEKEYUNSET-f#72057594037927935,RANGEKEYUNSET]
+  000006:[f#3,SET-h#3,SET]
+  000010:[s#7,RANGEKEYDEL-x#72057594037927935,RANGEKEYDEL]
+  000009:[x#6,SET-y#6,SET]

--- a/testdata/ingest_memtable_overlaps
+++ b/testdata/ingest_memtable_overlaps
@@ -138,3 +138,38 @@ overlaps
 a.RANGEDEL.2-b.RANGEDEL.72057594037927935
 ----
 false
+
+define default
+del-range a f
+del-range b c
+----
+
+overlaps
+d.RANGEDEL.2-e.RANGEDEL.72057594037927935
+----
+true
+
+define default
+range-key-set a f 1 val1
+range-key-set b c 2 val2
+----
+
+overlaps
+d-e
+----
+true
+
+define default
+range-key-set a c 1 val1
+----
+
+overlaps
+a-c
+b-c
+a.RANGEDEL.2-b.RANGEDEL.72057594037927935
+d-e
+----
+true
+true
+true
+false

--- a/testdata/ingest_target_level
+++ b/testdata/ingest_target_level
@@ -203,3 +203,46 @@ ee-ff
 ----
 6
 6
+
+# Range key-point key data overlap will always correctly identify overlap because
+# we seek using the combined point and range key bounds of the ingested file
+# to determine overlap and don't check the data within the ingested file.
+define
+L5
+  a.SET.0:a
+  b.SET.0:b
+  c.SET.0:c
+----
+5:
+  000004:[a#0,SET-c#0,SET]
+
+target
+rkey:a-c
+----
+4
+
+# Point key-range key overlap
+define
+L5
+  rangekey:a-c:{(#1,RANGEKEYSET,@t10,foo)}
+----
+5:
+  000004:[a#1,RANGEKEYSET-c#72057594037927935,RANGEKEYSET]
+
+target
+a-c
+----
+4
+
+# Range key-range key overlap.
+define
+L5
+  rangekey:a-c:{(#1,RANGEKEYSET,@t10,foo)}
+----
+5:
+  000004:[a#1,RANGEKEYSET-c#72057594037927935,RANGEKEYSET]
+
+target
+rkey:a-c
+----
+4


### PR DESCRIPTION
Prior to this pr, it was  possible for an ingested file 'a' to be placed beneath another file 'b' which the ingested file has data overlap with if the file 'b' contains range keys.

This pr uses the range key iters to compute data overlap in the overlapWithIterator function. The pr also adds a test which shows data corruption if the overlapWithIterator funciton wasn't fixed.

(cherry picked from commit 76b2a8e78634e4acb089e3e88055f462d98cf796)