### PR TITLE
db: fix mergingIter TrySeekUsingNext disablement

### DIFF
--- a/iterator_histories_test.go
+++ b/iterator_histories_test.go
@@ -169,6 +169,11 @@ func TestIterHistories(t *testing.T) {
 					return fmt.Sprintf("committed %d keys\n", count)
 				}
 				return fmt.Sprintf("wrote %d keys to batch %q\n", count, name)
+			case "compact":
+				if err := runCompactCmd(td, d); err != nil {
+					return err.Error()
+				}
+				return runLSMCmd(td, d)
 			case "flush":
 				err := d.Flush()
 				if err != nil {

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1080,6 +1080,7 @@ func TestIteratorSeekOpt(t *testing.T) {
 				iter.readSampling.forceReadSampling = true
 				iter.comparer.Split = func(a []byte) int { return len(a) }
 				iter.forceEnableSeekOpt = true
+				iter.merging.forceEnableSeekOpt = true
 			}
 			iterOutput := runIterCmd(td, iter, false)
 			stats := iter.Stats()

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -260,6 +260,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 			miter := &mergingIter{}
 			miter.init(nil /* opts */, &stats, cmp, func(a []byte) int { return len(a) }, levelIters...)
 			defer miter.Close()
+			miter.forceEnableSeekOpt = true
 			return runInternalIterCmd(t, d, miter, iterCmdVerboseKey, iterCmdStats(&stats))
 		default:
 			return fmt.Sprintf("unknown command: %s", d.Cmd)

--- a/testdata/iter_histories/iter_optimizations
+++ b/testdata/iter_histories/iter_optimizations
@@ -463,3 +463,75 @@ seek-prefix-ge d@1
 b@3: (b@3, .)
 .
 d@1: (d@1, .)
+
+
+# Test an instance where unequal application of TrySeekUsingNext optimizations
+# among a merging iterator's levels can result in surfacing deleted keys.
+# Regression test for #2101.
+
+reset
+----
+
+batch commit
+set b b
+----
+committed 1 keys
+
+flush
+----
+
+compact a-h
+----
+6:
+  000005:[b#1,SET-b#1,SET]
+
+batch commit
+set g g
+----
+committed 1 keys
+
+flush
+----
+
+compact a-h
+----
+6:
+  000005:[b#1,SET-b#1,SET]
+  000007:[g#2,SET-g#2,SET]
+
+batch commit
+del-range b d
+----
+committed 1 keys
+
+flush
+----
+
+batch commit
+set e e
+----
+committed 1 keys
+
+flush
+----
+
+lsm
+----
+0.0:
+  000009:[b#3,RANGEDEL-d#72057594037927935,RANGEDEL]
+  000011:[e#4,SET-e#4,SET]
+6:
+  000005:[b#1,SET-b#1,SET]
+  000007:[g#2,SET-g#2,SET]
+
+# The `seek-ge b` could incorrectly return `b` if the level 0.0 levelIter obeys
+# the TrySeekUsingNext optimization but the level 6 levelIter does not. The
+# TrySeekUsingNext optimization must be applied equally across all the levels of
+# a merging iterator.
+
+combined-iter
+seek-ge a
+seek-ge b
+----
+e: (e, .)
+e: (e, .)


### PR DESCRIPTION
In #2087, the levelIter began disabling the TrySeekUsingNext optimization deterministically in order to improve test coverage. Disabling the TrySeekUsingNext optimization on some but not all levels of a merging iterator can violate merging iterator invariants. Disabling the TrySeekUsingNext optimization can cause a child iterator to seek backwards to an earlier deleted key that is ≥ the seek key, but less than the key at the previous child iterator position.

This commit fixes this bug by disabling the TrySeekUsingNext optimization for all or none of the merging iterator's level iterators.

Fix #2101.