### PR TITLE
[crl-release-22.1] db: allow for tuning point tombstone weight

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -483,11 +483,11 @@ type candidateLevelInfo struct {
 
 // compensatedSize returns f's file size, inflated according to compaction
 // priorities.
-func compensatedSize(f *fileMetadata) uint64 {
+func compensatedSize(f *fileMetadata, pointTombstoneWeight float64) uint64 {
 	sz := f.Size
 	// Add in the estimate of disk space that may be reclaimed by compacting
 	// the file's tombstones.
-	sz += f.Stats.PointDeletionsBytesEstimate
+	sz += uint64(float64(f.Stats.PointDeletionsBytesEstimate) * pointTombstoneWeight)
 	sz += f.Stats.RangeDeletionsBytesEstimate
 	return sz
 }
@@ -497,7 +497,9 @@ func compensatedSize(f *fileMetadata) uint64 {
 // a *uint64. Compensated sizes may change once a table's stats are loaded
 // asynchronously, so its values are marked as cacheable only if a file's
 // stats have been loaded.
-type compensatedSizeAnnotator struct{}
+type compensatedSizeAnnotator struct {
+	pointTombstoneWeight float64
+}
 
 var _ manifest.Annotator = compensatedSizeAnnotator{}
 
@@ -514,7 +516,7 @@ func (a compensatedSizeAnnotator) Accumulate(
 	f *fileMetadata, dst interface{},
 ) (v interface{}, cacheOK bool) {
 	vptr := dst.(*uint64)
-	*vptr = *vptr + compensatedSize(f)
+	*vptr = *vptr + compensatedSize(f, a.pointTombstoneWeight)
 	return vptr, f.Stats.Valid
 }
 
@@ -529,10 +531,10 @@ func (a compensatedSizeAnnotator) Merge(src interface{}, dst interface{}) interf
 // iterator. Note that this function is linear in the files available to the
 // iterator. Use the compensatedSizeAnnotator if querying the total
 // compensated size of a level.
-func totalCompensatedSize(iter manifest.LevelIterator) uint64 {
+func totalCompensatedSize(iter manifest.LevelIterator, pointTombstoneWeight float64) uint64 {
 	var sz uint64
 	for f := iter.First(); f != nil; f = iter.Next() {
-		sz += compensatedSize(f)
+		sz += compensatedSize(f, pointTombstoneWeight)
 	}
 	return sz
 }
@@ -730,7 +732,9 @@ func (p *compactionPickerByScore) initLevelMaxBytes(inProgressCompactions []comp
 	}
 }
 
-func calculateSizeAdjust(inProgressCompactions []compactionInfo) [numLevels]int64 {
+func calculateSizeAdjust(
+	inProgressCompactions []compactionInfo, pointTombstoneWeight float64,
+) [numLevels]int64 {
 	// Compute a size adjustment for each level based on the in-progress
 	// compactions. We subtract the compensated size of start level inputs.
 	// Since compensated file sizes may be compensated because they reclaim
@@ -743,7 +747,7 @@ func calculateSizeAdjust(inProgressCompactions []compactionInfo) [numLevels]int6
 
 		for _, input := range c.inputs {
 			real := int64(input.files.SizeSum())
-			compensated := int64(totalCompensatedSize(input.files.Iter()))
+			compensated := int64(totalCompensatedSize(input.files.Iter(), pointTombstoneWeight))
 
 			if input.level != c.outputLevel {
 				sizeAdjust[input.level] -= compensated
@@ -770,7 +774,10 @@ func (p *compactionPickerByScore) calculateScores(
 	}
 	scores[0] = p.calculateL0Score(inProgressCompactions)
 
-	sizeAdjust := calculateSizeAdjust(inProgressCompactions)
+	sizeAdjust := calculateSizeAdjust(
+		inProgressCompactions,
+		p.opts.Experimental.PointTombstoneWeight,
+	)
 	for level := 1; level < numLevels; level++ {
 		levelSize := int64(levelCompensatedSize(p.vers.Levels[level])) + sizeAdjust[level]
 		scores[level].score = float64(levelSize) / float64(p.levelMaxBytes[level])
@@ -927,7 +934,8 @@ func (p *compactionPickerByScore) pickFile(
 			continue
 		}
 
-		scaledRatio := overlappingBytes * 1024 / compensatedSize(f)
+		compSz := compensatedSize(f, p.opts.Experimental.PointTombstoneWeight)
+		scaledRatio := overlappingBytes * 1024 / compSz
 		if scaledRatio < smallestRatio && !f.Compacting {
 			smallestRatio = scaledRatio
 			file = startIter.Take()
@@ -989,7 +997,9 @@ func (p *compactionPickerByScore) pickAuto(env compactionEnv) (pc *pickedCompact
 			}
 			fmt.Fprintf(&buf, "  %sL%d: %5.1f  %5.1f  %8s  %8s",
 				marker, info.level, info.score, info.origScore,
-				humanize.Int64(int64(totalCompensatedSize(p.vers.Levels[info.level].Iter()))),
+				humanize.Int64(int64(totalCompensatedSize(
+					p.vers.Levels[info.level].Iter(), p.opts.Experimental.PointTombstoneWeight,
+				))),
 				humanize.Int64(p.levelMaxBytes[info.level]),
 			)
 

--- a/data_test.go
+++ b/data_test.go
@@ -583,6 +583,12 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 				return nil, errors.Errorf("%s: could not parse %q as bool: %s", td.Cmd, arg.Vals[0], err)
 			}
 			opts.private.disableTableStats = !enable
+		case "point-tombstone-weight":
+			w, err := strconv.ParseFloat(arg.Vals[0], 64)
+			if err != nil {
+				return nil, errors.Errorf("%s: could not parse %q as float: %s", td.Cmd, arg.Vals[0], err)
+			}
+			opts.Experimental.PointTombstoneWeight = w
 		default:
 			return nil, errors.Errorf("%s: unknown arg: %s", td.Cmd, arg.Key)
 		}

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -278,6 +278,7 @@ func randomOptions(rng *rand.Rand) *testOptions {
 	lopts.IndexBlockSize = 1 << uint(rng.Intn(24)) // 1 - 16MB
 	lopts.TargetFileSize = 1 << uint(rng.Intn(28)) // 1 - 256MB
 	opts.Levels = []pebble.LevelOptions{lopts}
+	opts.Experimental.PointTombstoneWeight = 1 + 10*rng.Float64() // 1 - 10
 
 	// Explicitly disable disk-backed FS's for the random configurations. The
 	// single standard test configuration that uses a disk-backed FS is

--- a/options_test.go
+++ b/options_test.go
@@ -92,6 +92,7 @@ func TestOptionsString(t *testing.T) {
   min_deletion_rate=0
   min_flush_rate=1048576
   merger=pebble.concatenate
+  point_tombstone_weight=1.000000
   read_compaction_rate=16000
   read_sampling_multiplier=16
   strict_wal_tail=true

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -236,3 +236,88 @@ range-deletions-bytes-estimate: 0
 maybe-compact
 ----
 [JOB 100] compacted(default) L5 [000004] (794 B) + L6 [000006] (13 K) -> L6 [] (0 B), in 1.0s (2.0s total), output rate 0 B/s
+
+# Demonstration of point tombstone weighting.
+#
+# Construct an LSM with two tables in L6, with a table above each in L5. The
+# layout of the tables is such that the range deletion bytes estimate for table
+# 000005 is greater than the point deletion bytes estimate for table 000004.
+# Without weighting, table 000005 will be selected.
+
+define auto-compactions=off level-max-bytes=(L5 : 1000)
+L5
+a.DEL.101: b.SET.102:
+L5
+e.RANGEDEL.107:f f.SET.108:
+L6
+a.SET.001:<largeval> b.SET.002:<largeval> c.SET.003:<largeval>
+L6
+e.SET.007:<largeval> f.SET.008:<largeval> g.SET.009:<largeval>
+----
+5:
+  000004:[a#101,DEL-b#102,SET]
+  000005:[e#107,RANGEDEL-f#108,SET]
+6:
+  000006:[a#1,SET-c#3,SET]
+  000007:[e#7,SET-g#9,SET]
+
+wait-pending-table-stats
+000004
+----
+num-entries: 2
+num-deletions: 1
+point-deletions-bytes-estimate: 4389
+range-deletions-bytes-estimate: 0
+
+wait-pending-table-stats
+000005
+----
+num-entries: 2
+num-deletions: 1
+point-deletions-bytes-estimate: 0
+range-deletions-bytes-estimate: 8244
+
+maybe-compact
+----
+[JOB 100] compacted(default) L5 [000005] (849 B) + L6 [000007] (13 K) -> L6 [000008] (4.8 K), in 1.0s (2.0s total), output rate 4.8 K/s
+
+# The same LSM as above. However, this time, with point tombstone weighting at
+# 2x, the table with the point tombstone (000004) will be selected as the
+# compaction input.
+
+define auto-compactions=off level-max-bytes=(L5 : 1000) point-tombstone-weight=2
+L5
+a.DEL.101: b.SET.102:
+L5
+e.RANGEDEL.107:f f.SET.108:
+L6
+a.SET.001:<largeval> b.SET.002:<largeval> c.SET.003:<largeval>
+L6
+e.SET.007:<largeval> f.SET.008:<largeval> g.SET.009:<largeval>
+----
+5:
+  000004:[a#101,DEL-b#102,SET]
+  000005:[e#107,RANGEDEL-f#108,SET]
+6:
+  000006:[a#1,SET-c#3,SET]
+  000007:[e#7,SET-g#9,SET]
+
+wait-pending-table-stats
+000004
+----
+num-entries: 2
+num-deletions: 1
+point-deletions-bytes-estimate: 4389
+range-deletions-bytes-estimate: 0
+
+wait-pending-table-stats
+000005
+----
+num-entries: 2
+num-deletions: 1
+point-deletions-bytes-estimate: 0
+range-deletions-bytes-estimate: 8244
+
+maybe-compact
+----
+[JOB 100] compacted(default) L5 [000004] (782 B) + L6 [000006] (13 K) -> L6 [000008] (4.8 K), in 1.0s (2.0s total), output rate 4.8 K/s

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -41,7 +41,7 @@ zmemtbl         1   256 K
 
 disk-usage
 ----
-1.9 K
+2.0 K
 
 batch
 set b 2


### PR DESCRIPTION
This is a backport of #2052 to 22.1.

---

Add an experimental option `point_tombstone_weight` that can be used to tune how much a table's point deletion tombstones factor into the decision whether or not include it as an input to a compaction.

This experimental option can to encourage compaction of point tombstones that would otherwise be de-prioritized in favor of other compactions, which may have an adverse effect on iteration, which would have to skip over the tombstones.

Informs #1836.