### PR TITLE
replay: add utility to construct batch from flushed sstables

### DIFF
--- a/internal/bytealloc/bytealloc.go
+++ b/internal/bytealloc/bytealloc.go
@@ -26,7 +26,7 @@ import "github.com/cockroachdb/pebble/internal/rawalloc"
 type A []byte
 
 const chunkAllocMinSize = 512
-const chunkAllocMaxSize = 16384
+const chunkAllocMaxSize = 256 << 10 // 256 KB
 
 func (a A) reserve(n int) A {
 	allocSize := cap(a) * 2

--- a/internal/datatest/datatest.go
+++ b/internal/datatest/datatest.go
@@ -1,0 +1,93 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// Package datatest provides common datadriven test commands for use outside of
+// the root Pebble package.
+package datatest
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/pkg/errors"
+)
+
+// TODO(jackson): Consider a refactoring that can consolidate this package and
+// the datadriven commands defined in pebble/data_test.go.
+
+// DefineBatch interprets the provided datadriven command as a sequence of write
+// operations, one-per-line, to apply to the provided batch.
+func DefineBatch(d *datadriven.TestData, b *pebble.Batch) error {
+	for _, line := range strings.Split(d.Input, "\n") {
+		parts := strings.Fields(line)
+		if len(parts) == 0 {
+			continue
+		}
+		if parts[1] == `<nil>` {
+			parts[1] = ""
+		}
+		var err error
+		switch parts[0] {
+		case "set":
+			if len(parts) != 3 {
+				return errors.Errorf("%s expects 2 arguments", parts[0])
+			}
+			err = b.Set([]byte(parts[1]), []byte(parts[2]), nil)
+		case "del":
+			if len(parts) != 2 {
+				return errors.Errorf("%s expects 1 argument", parts[0])
+			}
+			err = b.Delete([]byte(parts[1]), nil)
+		case "singledel":
+			if len(parts) != 2 {
+				return errors.Errorf("%s expects 1 argument", parts[0])
+			}
+			err = b.SingleDelete([]byte(parts[1]), nil)
+		case "del-range":
+			if len(parts) != 3 {
+				return errors.Errorf("%s expects 2 arguments", parts[0])
+			}
+			err = b.DeleteRange([]byte(parts[1]), []byte(parts[2]), nil)
+		case "merge":
+			if len(parts) != 3 {
+				return errors.Errorf("%s expects 2 arguments", parts[0])
+			}
+			err = b.Merge([]byte(parts[1]), []byte(parts[2]), nil)
+		case "range-key-set":
+			if len(parts) != 5 {
+				return errors.Errorf("%s expects 4 arguments", parts[0])
+			}
+			err = b.RangeKeySet(
+				[]byte(parts[1]),
+				[]byte(parts[2]),
+				[]byte(parts[3]),
+				[]byte(parts[4]),
+				nil)
+		case "range-key-unset":
+			if len(parts) != 4 {
+				return errors.Errorf("%s expects 3 arguments", parts[0])
+			}
+			err = b.RangeKeyUnset(
+				[]byte(parts[1]),
+				[]byte(parts[2]),
+				[]byte(parts[3]),
+				nil)
+		case "range-key-del":
+			if len(parts) != 3 {
+				return errors.Errorf("%s expects 2 arguments", parts[0])
+			}
+			err = b.RangeKeyDelete(
+				[]byte(parts[1]),
+				[]byte(parts[2]),
+				nil)
+		default:
+			return errors.Errorf("unknown op: %s", parts[0])
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -1,0 +1,164 @@
+// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package replay
+
+import (
+	"sort"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/bytealloc"
+	"github.com/cockroachdb/pebble/internal/rangedel"
+	"github.com/cockroachdb/pebble/internal/rangekey"
+	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+// loadFlushedSSTableKeys copies keys from the sstables specified by `fileNums`
+// in the directory specified by `path` into the provided the batch. Keys are
+// applied to the batch in the order dictated by their sequence numbers within
+// the sstables, ensuring the relative relationship between sequence numbers is
+// maintained.
+func loadFlushedSSTableKeys(
+	b *pebble.Batch, fs vfs.FS, path string, fileNums []base.FileNum, readOpts sstable.ReaderOptions,
+) error {
+	// Load all the keys across all the sstables.
+	var alloc bytealloc.A
+	var keys flushedKeys
+	for _, fileNum := range fileNums {
+		if err := func() error {
+			filePath := base.MakeFilepath(fs, path, base.FileTypeTable, fileNum)
+			f, err := fs.Open(filePath)
+			if err != nil {
+				return err
+			}
+			r, err := sstable.NewReader(f, readOpts)
+			if err != nil {
+				return err
+			}
+			defer r.Close()
+
+			// Load all the point keys.
+			if iter, err := r.NewIter(nil, nil); err != nil {
+				return err
+			} else {
+				defer iter.Close()
+				for k, lv := iter.First(); k != nil; k, lv = iter.Next() {
+					var key flushedKey
+					key.Trailer = k.Trailer
+					alloc, key.UserKey = alloc.Copy(k.UserKey)
+					if v, callerOwned, err := lv.Value(nil); err != nil {
+						return err
+					} else if callerOwned {
+						key.value = v
+					} else {
+						alloc, key.value = alloc.Copy(v)
+					}
+					keys = append(keys, key)
+				}
+			}
+
+			// Load all the range tombstones.
+			if iter, err := r.NewRawRangeDelIter(); err != nil {
+				return err
+			} else if iter != nil {
+				defer iter.Close()
+				for s := iter.First(); s != nil; s = iter.Next() {
+					if err := rangedel.Encode(s, func(k base.InternalKey, v []byte) error {
+						var key flushedKey
+						key.Trailer = k.Trailer
+						alloc, key.UserKey = alloc.Copy(k.UserKey)
+						alloc, key.value = alloc.Copy(v)
+						keys = append(keys, key)
+						return nil
+					}); err != nil {
+						return err
+					}
+				}
+			}
+
+			// Load all the range keys.
+			if iter, err := r.NewRawRangeKeyIter(); err != nil {
+				return err
+			} else if iter != nil {
+				defer iter.Close()
+				for s := iter.First(); s != nil; s = iter.Next() {
+					if err := rangekey.Encode(s, func(k base.InternalKey, v []byte) error {
+						var key flushedKey
+						key.Trailer = k.Trailer
+						alloc, key.UserKey = alloc.Copy(k.UserKey)
+						alloc, key.value = alloc.Copy(v)
+						keys = append(keys, key)
+						return nil
+					}); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		}(); err != nil {
+			return err
+		}
+	}
+
+	// Sort the flushed keys by their sequence numbers so that we can apply them
+	// to the batch in the same order, maintaining the relative relationship
+	// between keys.
+	sort.Sort(keys)
+
+	// Add the keys to the batch in the order they were committed when the
+	// workload was captured.
+	for i := 0; i < len(keys); i++ {
+		var err error
+		switch keys[i].Kind() {
+		case base.InternalKeyKindDelete:
+			err = b.Delete(keys[i].UserKey, nil)
+		case base.InternalKeyKindSet, base.InternalKeyKindSetWithDelete:
+			err = b.Set(keys[i].UserKey, keys[i].value, nil)
+		case base.InternalKeyKindMerge:
+			err = b.Merge(keys[i].UserKey, keys[i].value, nil)
+		case base.InternalKeyKindSingleDelete:
+			err = b.SingleDelete(keys[i].UserKey, nil)
+		case base.InternalKeyKindRangeDelete:
+			err = b.DeleteRange(keys[i].UserKey, keys[i].value, nil)
+		case base.InternalKeyKindRangeKeySet, base.InternalKeyKindRangeKeyUnset, base.InternalKeyKindRangeKeyDelete:
+			s, err := rangekey.Decode(keys[i].InternalKey, keys[i].value, nil)
+			if err != nil {
+				return err
+			}
+			if len(s.Keys) != 1 {
+				return errors.Newf("range key span unexpectedly contains %d keys", len(s.Keys))
+			}
+			switch keys[i].Kind() {
+			case base.InternalKeyKindRangeKeySet:
+				err = b.RangeKeySet(s.Start, s.End, s.Keys[0].Suffix, s.Keys[0].Value, nil)
+			case base.InternalKeyKindRangeKeyUnset:
+				err = b.RangeKeyUnset(s.Start, s.End, s.Keys[0].Suffix, nil)
+			case base.InternalKeyKindRangeKeyDelete:
+				err = b.RangeKeyDelete(s.Start, s.End, nil)
+			default:
+				err = errors.Newf("unexpected key kind %q", keys[i].Kind())
+			}
+		default:
+			err = errors.Newf("unexpected key kind %q", keys[i].Kind())
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type flushedKeys []flushedKey
+
+func (s flushedKeys) Len() int           { return len(s) }
+func (s flushedKeys) Less(i, j int) bool { return s[i].Trailer < s[j].Trailer }
+func (s flushedKeys) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+type flushedKey struct {
+	base.InternalKey
+	value []byte
+}

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -1,0 +1,116 @@
+package replay
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/cockroachdb/pebble/internal/datatest"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/rangekey"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadFlushedSSTableKeys(t *testing.T) {
+	var buf bytes.Buffer
+	var fileNums []base.FileNum
+	opts := &pebble.Options{
+		EventListener: pebble.EventListener{
+			FlushEnd: func(info pebble.FlushInfo) {
+				// Fix the durations to 1s for determinism.
+				info.Duration, info.TotalDuration = time.Second, time.Second
+				for _, tbl := range info.Output {
+					fileNums = append(fileNums, tbl.FileNum)
+				}
+				fmt.Fprintln(&buf, info.String())
+			},
+		},
+		FS:                 vfs.NewMem(),
+		Comparer:           testkeys.Comparer,
+		FormatMajorVersion: pebble.FormatRangeKeys,
+	}
+	d, err := pebble.Open("", opts)
+	require.NoError(t, err)
+	defer d.Close()
+
+	datadriven.RunTest(t, "testdata/flushed_sstable_keys", func(td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "commit":
+			b := d.NewIndexedBatch()
+			if err := datatest.DefineBatch(td, b); err != nil {
+				return err.Error()
+			}
+			if err := b.Commit(nil); err != nil {
+				return err.Error()
+			}
+			return ""
+		case "flush":
+			if err := d.Flush(); err != nil {
+				return err.Error()
+			}
+
+			b := d.NewBatch()
+			err := loadFlushedSSTableKeys(b, opts.FS, "", fileNums, opts.MakeReaderOptions())
+			if err != nil {
+				b.Close()
+				return err.Error()
+			}
+
+			br, _ := pebble.ReadBatch(b.Repr())
+			for kind, ukey, v, ok := br.Next(); ok; kind, ukey, v, ok = br.Next() {
+				fmt.Fprintf(&buf, "%s.%s", ukey, kind)
+				switch kind {
+				case base.InternalKeyKindRangeDelete,
+					base.InternalKeyKindRangeKeyDelete:
+					fmt.Fprintf(&buf, "-%s", v)
+				case base.InternalKeyKindSet,
+					base.InternalKeyKindMerge:
+					fmt.Fprintf(&buf, ": %s", v)
+				case base.InternalKeyKindRangeKeySet, base.InternalKeyKindRangeKeyUnset:
+					s, err := rangekey.Decode(base.MakeInternalKey(ukey, 0, kind), v, nil)
+					if err != nil {
+						return err.Error()
+					}
+					if kind == base.InternalKeyKindRangeKeySet {
+						fmt.Fprintf(&buf, "-%s: %s → %s", s.End, s.Keys[0].Suffix, s.Keys[0].Value)
+					} else {
+						fmt.Fprintf(&buf, "-%s: %s", s.End, s.Keys[0].Suffix)
+					}
+				case base.InternalKeyKindDelete, base.InternalKeyKindSingleDelete:
+				default:
+					fmt.Fprintf(&buf, ": %x", v)
+				}
+				fmt.Fprintln(&buf)
+			}
+
+			s := buf.String()
+			buf.Reset()
+			require.NoError(t, b.Close())
+
+			fileNums = fileNums[:0]
+			return s
+		default:
+			return fmt.Sprintf("unrecognized command %q", td.Cmd)
+		}
+		return ""
+	})
+}
+
+type bufferLogger struct {
+	bytes.Buffer
+}
+
+func (l *bufferLogger) Infof(format string, args ...interface{}) {
+	fmt.Fprintf(&l.Buffer, format, args...)
+	fmt.Fprintln(&l.Buffer)
+}
+
+func (l *bufferLogger) Fatalf(format string, args ...interface{}) {
+	fmt.Fprintf(&l.Buffer, format, args...)
+	fmt.Fprintln(&l.Buffer)
+}

--- a/replay/testdata/flushed_sstable_keys
+++ b/replay/testdata/flushed_sstable_keys
@@ -1,0 +1,69 @@
+commit
+set a a
+set b b
+set c c
+----
+
+flush
+----
+[JOB 6] flushed 1 memtable to L0 [000005] (795 B), in 1.0s (1.0s total), output rate 795 B/s
+a.SET: a
+b.SET: b
+c.SET: c
+
+# Test that the keys in the batch are in the same order they were originally
+# committed, not sorted by user key.
+
+commit
+set c c
+set b b
+set a a
+----
+
+flush
+----
+[JOB 8] flushed 1 memtable to L0 [000007] (795 B), in 1.0s (1.0s total), output rate 795 B/s
+c.SET: c
+b.SET: b
+a.SET: a
+
+# Test that the keys in the batch are in the same order they were originally
+# committed, not sorted by user key.
+
+commit
+set c c
+del b
+del-range d f
+singledel a
+----
+
+flush
+----
+[JOB 11] flushed 1 memtable to L0 [000010] (872 B), in 1.0s (1.0s total), output rate 872 B/s
+c.SET: c
+b.DEL
+d.RANGEDEL-f
+a.SINGLEDEL
+
+commit
+set x foo
+range-key-del a z
+range-key-unset g h @3
+range-key-set l m @1 foo
+set a bar
+del y
+----
+
+flush
+----
+[JOB 14] flushed 1 memtable to L0 [000012] (1.0 K), in 1.0s (1.0s total), output rate 1.0 K/s
+x.SET: foo
+a.RANGEKEYDEL-g
+g.RANGEKEYDEL-h
+h.RANGEKEYDEL-l
+l.RANGEKEYDEL-m
+m.RANGEKEYDEL-z
+g.RANGEKEYUNSET-h: @3
+l.RANGEKEYSET-m: @1 → foo
+a.SET: bar
+y.DEL


### PR DESCRIPTION
Add a utility function to construct a batch from the contents of sstables created by a flush. This will be used in #1865 to replay flushes by applying a batch containing the contents of the flush, and then manually flushing the memtable.

This function handles reordering the keys according to sequence number, so that the relative sequence number distribution matches that of the original workload.

This batch-commit approach is favored over the previously implemented FlushExternalTble approach (eg, see private.FlushExternalTable) in order to exercise flush-splitting logic.