### PR TITLE
*: Set isIgnorableBoundaryKey=true for rangedel boundaries in levelIter

### DIFF
--- a/db.go
+++ b/db.go
@@ -1175,7 +1175,6 @@ func (i *Iterator) constructPointIter(memtables flushableList, buf *iterAlloc) {
 	buf.merging.init(&i.opts, &i.stats.InternalStats, i.comparer.Compare, i.comparer.Split, mlevels...)
 	buf.merging.snapshot = i.seqNum
 	buf.merging.batchSnapshot = i.batchSeqNum
-	buf.merging.elideRangeTombstones = true
 	buf.merging.combinedIterState = &i.lazyCombinedIter.combinedIterState
 	i.pointIter = &buf.merging
 	i.merging = &buf.merging

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -248,7 +248,6 @@ func createExternalPointIter(it *Iterator) (internalIterator, error) {
 
 	it.alloc.merging.init(&it.opts, &it.stats.InternalStats, it.comparer.Compare, it.comparer.Split, mlevels...)
 	it.alloc.merging.snapshot = base.InternalKeySeqNumMax
-	it.alloc.merging.elideRangeTombstones = true
 	return &it.alloc.merging, nil
 }
 

--- a/iterator_histories_test.go
+++ b/iterator_histories_test.go
@@ -299,6 +299,8 @@ func TestIterHistories(t *testing.T) {
 						o.PointKeyFilters = []sstable.BlockPropertyFilter{
 							sstable.NewTestKeysBlockPropertyFilter(min, max),
 						}
+					case "use-l6-filter":
+						o.UseL6Filters = true
 					}
 				}
 				var iter *Iterator

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -513,7 +513,6 @@ func TestIterator(t *testing.T) {
 			vals:  vals,
 		})
 		iter.snapshot = seqNum
-		iter.elideRangeTombstones = true
 		// NB: This Iterator cannot be cloned since it is not constructed
 		// with a readState. It suffices for this test.
 		it.iter = newInvalidatingIter(iter)

--- a/level_iter.go
+++ b/level_iter.go
@@ -955,6 +955,9 @@ func (l *levelIter) skipEmptyFileForward() (*InternalKey, base.LazyValue) {
 			// If the boundary is a range deletion tombstone, return that key.
 			if l.iterFile.LargestPointKey.Kind() == InternalKeyKindRangeDelete {
 				l.largestBoundary = &l.iterFile.LargestPointKey
+				if l.boundaryContext != nil {
+					l.boundaryContext.isIgnorableBoundaryKey = true
+				}
 				return l.largestBoundary, base.LazyValue{}
 			}
 			// If the last point iterator positioning op might've skipped keys,

--- a/level_iter.go
+++ b/level_iter.go
@@ -1045,6 +1045,9 @@ func (l *levelIter) skipEmptyFileBackward() (*InternalKey, base.LazyValue) {
 			// If the boundary is a range deletion tombstone, return that key.
 			if l.iterFile.SmallestPointKey.Kind() == InternalKeyKindRangeDelete {
 				l.smallestBoundary = &l.iterFile.SmallestPointKey
+				if l.boundaryContext != nil {
+					l.boundaryContext.isIgnorableBoundaryKey = true
+				}
 				return l.smallestBoundary, base.LazyValue{}
 			}
 			// If the last point iterator positioning op skipped keys, it's

--- a/testdata/iter_histories/iter_optimizations
+++ b/testdata/iter_histories/iter_optimizations
@@ -535,3 +535,93 @@ seek-ge b
 ----
 e: (e, .)
 e: (e, .)
+
+# Regression test for #2118, where a MERGE pushes child iterators to the next
+# key, and possibly past a file that contained a range tombstone that we
+# should have paused at in a SeekPrefixGE, affecting future TrySeekUsingNexts.
+# This test constructs this example (suffixes ignored), where square brackets
+# consist of one SST:
+#
+# L0: [(b, MERGE)  (c-d, RANGEDEL)] [(m, DEL)]
+# L6: [(c, SET) (c-e, RANGEKEYSET)] [(j, SET)]
+#
+# We create an iterator with L6 filters enabled and create relatively large
+# bloom filter blocks to reduce the false positive rate. Then we SeekPrefixGE(b)
+# and end up with the L0 levelIter landing on the (b, MERGE), and the L6 iterator
+# is exhausted as no SST filter blocks match the prefix. The top-level iterator
+# then Next()s to find the next internal key at b if there is any, we land
+# on the pause key at (d, RANGEDELSENTINEL). Crucially since there are no
+# more items in the mergingIter heap and the merging iter is set to elide
+# range tombstones, we Next() the level iter again as part of the same top-level
+# iterator Next(), and land on (m, DEL). The type of the key here doesn't really
+# matter.
+#
+# We then do a SeekPrefixGE(c), and since c > b, in the buggy scenario we
+# TrySeekUsingNext. The bottom levelIter correctly finds the sstable containing
+# the set, but the upper levelIter is already past the sstable containing the
+# rangedel, so it just returns (m, DEL) again, and we surface the (c, SET) that
+# should have been deleted.
+
+reset bloom-bits-per-key=100
+----
+
+batch commit
+set c@2 foo
+range-key-set c e @5 bar
+----
+committed 2 keys
+
+flush
+----
+
+compact a-z
+----
+6:
+  000005:[c#2,RANGEKEYSET-e#72057594037927935,RANGEKEYSET]
+
+batch commit
+set j k
+----
+committed 1 keys
+
+flush
+----
+
+compact a-z
+----
+6:
+  000005:[c#2,RANGEKEYSET-e#72057594037927935,RANGEKEYSET]
+  000007:[j#3,SET-j#3,SET]
+
+batch commit
+del-range c@2 d
+merge b@2 g
+----
+committed 2 keys
+
+flush
+----
+
+batch commit
+del m
+----
+committed 1 keys
+
+flush
+----
+
+lsm
+----
+0.0:
+  000009:[b@2#5,MERGE-d#72057594037927935,RANGEDEL]
+  000011:[m#6,DEL-m#6,DEL]
+6:
+  000005:[c#2,RANGEKEYSET-e#72057594037927935,RANGEKEYSET]
+  000007:[j#3,SET-j#3,SET]
+
+combined-iter upper=z@3 mask-suffix=@3 mask-filter use-l6-filter
+seek-prefix-ge b@2
+seek-prefix-ge c@2
+----
+b@2: (g, .)
+c@2: (., [c-"c\x00") @5=bar UPDATED)

--- a/testdata/iterator
+++ b/testdata/iterator
@@ -634,17 +634,11 @@ stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, 
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 7, value-bytes 2, tombstoned: 0))
 
 
-# NB: RANGEDEL entries are ignored.
 define
-a.RANGEDEL.4:c
 a.MERGE.3:d
-a.RANGEDEL.2:c
 a.MERGE.2:c
-a.RANGEDEL.1:c
 a.SET.1:b
-b.RANGEDEL.3:c
 b.MERGE.2:b
-b.RANGEDEL.1:c
 b.MERGE.1:a
 ----
 
@@ -659,7 +653,7 @@ b: (ab, .)
 .
 b: (ab, .)
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 5), (rev, 1, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 8, key-bytes 8, value-bytes 8, tombstoned: 0))
 
 iter seq=3
 seek-ge a
@@ -668,7 +662,7 @@ next
 a: (bc, .)
 b: (ab, .)
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 4), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 10, value-bytes 10, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
 
 iter seq=2
 seek-ge a
@@ -677,7 +671,7 @@ next
 a: (b, .)
 b: (a, .)
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 10, value-bytes 10, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
 
 iter seq=4
 seek-lt c
@@ -690,7 +684,7 @@ a: (bcd, .)
 .
 a: (bcd, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 2)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 1, 5)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 16, key-bytes 16, value-bytes 16, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 8, key-bytes 8, value-bytes 8, tombstoned: 0))
 
 iter seq=3
 seek-lt c
@@ -699,7 +693,7 @@ prev
 b: (ab, .)
 a: (bc, .)
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 4)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 10, value-bytes 10, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
 
 iter seq=2
 seek-lt c
@@ -708,7 +702,7 @@ prev
 b: (a, .)
 a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 10, value-bytes 10, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
 
 iter seq=4
 seek-ge a
@@ -721,7 +715,7 @@ b: (ab, .)
 a: (bcd, .)
 b: (ab, .)
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 10), (rev, 1, 5)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 30, key-bytes 30, value-bytes 30, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned: 0))
 
 iter seq=3
 seek-ge a
@@ -734,7 +728,7 @@ b: (ab, .)
 a: (bc, .)
 b: (ab, .)
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 8), (rev, 1, 4)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 30, key-bytes 30, value-bytes 30, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned: 0))
 
 iter seq=2
 seek-ge a
@@ -747,7 +741,7 @@ b: (a, .)
 a: (b, .)
 b: (a, .)
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 4), (rev, 1, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 30, key-bytes 30, value-bytes 30, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned: 0))
 
 iter seq=4
 seek-lt c
@@ -760,7 +754,7 @@ a: (bcd, .)
 b: (ab, .)
 a: (bcd, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 2)), (internal (dir, seek, step): (fwd, 1, 5), (rev, 2, 10)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 30, key-bytes 30, value-bytes 30, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned: 0))
 
 iter seq=3
 seek-lt c
@@ -773,7 +767,7 @@ a: (bc, .)
 b: (ab, .)
 a: (bc, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 2)), (internal (dir, seek, step): (fwd, 1, 4), (rev, 2, 8)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 30, key-bytes 30, value-bytes 30, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned: 0))
 
 iter seq=2
 seek-lt c
@@ -786,7 +780,7 @@ a: (b, .)
 b: (a, .)
 a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 2)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 2, 4)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 30, key-bytes 30, value-bytes 30, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned: 0))
 
 iter seq=3
 seek-prefix-ge a
@@ -795,7 +789,7 @@ next
 a: (bc, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 8, key-bytes 8, value-bytes 8, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0))
 
 iter seq=2
 seek-prefix-ge a
@@ -804,7 +798,7 @@ next
 a: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 10, value-bytes 10, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
 
 iter seq=4
 seek-prefix-ge a
@@ -813,7 +807,7 @@ next
 a: (bcd, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 8, key-bytes 8, value-bytes 8, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0))
 
 iter seq=2
 seek-prefix-ge a
@@ -822,7 +816,7 @@ next
 a: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 10, value-bytes 10, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
 
 iter seq=3
 seek-prefix-ge a
@@ -831,7 +825,7 @@ next
 a: (bc, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 8, key-bytes 8, value-bytes 8, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0))
 
 iter seq=3
 seek-prefix-ge c
@@ -844,31 +838,23 @@ seek-prefix-ge 1
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
 
 iter seq=3
 seek-prefix-ge a
 ----
 a: (bc, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 6, key-bytes 6, value-bytes 6, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned: 0))
 
 
-# NB: RANGEDEL entries are ignored.
 define
-a.RANGEDEL.4:c
 a.MERGE.3:d
-a.RANGEDEL.2:c
 a.MERGE.2:c
-a.RANGEDEL.1:c
 a.MERGE.1:b
-aa.RANGEDEL.3:c
 aa.MERGE.2:b
-aa.RANGEDEL.1:c
 aa.MERGE.1:a
-b.RANGEDEL.3:c
 b.MERGE.2:b
-b.RANGEDEL.1:c
 b.MERGE.1:a
 ----
 
@@ -881,7 +867,7 @@ a: (bc, .)
 .
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 8, key-bytes 10, value-bytes 8, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 5, value-bytes 4, tombstoned: 0))
 
 iter seq=2
 seek-prefix-ge a
@@ -892,7 +878,7 @@ a: (b, .)
 .
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 14, value-bytes 10, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 7, value-bytes 5, tombstoned: 0))
 
 iter seq=4
 seek-prefix-ge a
@@ -901,7 +887,7 @@ next
 a: (bcd, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 8, key-bytes 10, value-bytes 8, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 5, value-bytes 4, tombstoned: 0))
 
 iter seq=2
 seek-prefix-ge a
@@ -910,7 +896,7 @@ next
 a: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 10, key-bytes 14, value-bytes 10, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 7, value-bytes 5, tombstoned: 0))
 
 iter seq=3
 seek-prefix-ge aa
@@ -919,14 +905,14 @@ next
 aa: (ab, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 6, key-bytes 10, value-bytes 6, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 5, value-bytes 3, tombstoned: 0))
 
 iter seq=4
 seek-prefix-ge aa
 ----
 aa: (ab, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 6, key-bytes 10, value-bytes 6, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 5, value-bytes 3, tombstoned: 0))
 
 define
 a.SET.1:a
@@ -1372,13 +1358,9 @@ aa: (aa, .)
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
 (internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 2, value-bytes 2, tombstoned: 0))
 
-# NB: RANGEDEL entries are ignored.
 define
-a.RANGEDEL.2:c
 a.SET.1:a
-b.RANGEDEL.3:d
 b.SET.2:b
-b.RANGEDEL.1:d
 ----
 
 iter seq=4
@@ -1390,7 +1372,7 @@ a: (a, .)
 b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
 
 define
 a.SINGLEDEL.1:
@@ -1550,7 +1532,6 @@ stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, 
 
 define
 a.SINGLEDEL.3:
-a.RANGEDEL.2:c
 a.SET.1:val
 ----
 
@@ -1559,7 +1540,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 4, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 3, tombstoned: 0))
 
 # Exercise iteration with limits, when there are no deletes.
 define

--- a/testdata/merging_iter
+++ b/testdata/merging_iter
@@ -444,10 +444,10 @@ prev
 f#0,1:1
 f#3,1:3
 e#0,1:1
-c#4,15:
 b#0,1:1
 a#0,1:1
 a#2,1:2
+.
 .
 
 # Verify the upper bound is respected when switching directions at a RANGEDEL
@@ -477,7 +477,7 @@ seek-ge krgywquurww
 prev
 ----
 .
-kq#100,15:
+koujdlp#37,2:37
 
 # Verify the lower bound is respected when switching directions at a RANGEDEL
 # boundary.

--- a/testdata/merging_iter
+++ b/testdata/merging_iter
@@ -37,9 +37,9 @@ stats
 ----
 a#30,1:30
 c#27,1:27
-e#72057594037927935,15:
 e#10,1:10
 g#20,1:20
+.
 {BlockBytes:116 BlockBytesInCache:0 KeyBytes:5 ValueBytes:8 PointCount:5 PointsCoveredByRangeTombstones:0}
 {BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 
@@ -49,9 +49,9 @@ seek-ge d
 next
 next
 ----
-e#72057594037927935,15:
 e#10,1:10
 g#20,1:20
+.
 
 # isPrevEntryDeleted() should not allow the rangedel to act on the points in the lower sstable
 # that are after it.
@@ -273,9 +273,9 @@ next
 ----
 a#30,1:30
 c#27,1:27
-e#72057594037927935,15:
 e#10,1:10
 g#20,1:20
+.
 
 # Verify that switching directions respects lower/upper bound.
 
@@ -425,10 +425,10 @@ next
 a#2,1:2
 a#0,1:1
 b#0,1:1
-e#72057594037927935,15:
 e#0,1:1
 f#3,1:3
 f#0,1:1
+.
 .
 
 iter
@@ -586,7 +586,7 @@ a#30,1:30
 {BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 f#21,1:21
 {BlockBytes:0 BlockBytesInCache:0 KeyBytes:5 ValueBytes:10 PointCount:5 PointsCoveredByRangeTombstones:4}
-g#72057594037927935,15:
+.
 {BlockBytes:0 BlockBytesInCache:0 KeyBytes:6 ValueBytes:10 PointCount:6 PointsCoveredByRangeTombstones:4}
 .
 {BlockBytes:0 BlockBytesInCache:0 KeyBytes:6 ValueBytes:10 PointCount:6 PointsCoveredByRangeTombstones:4}


### PR DESCRIPTION
Merge keys put the top level Iterator's position to `iterPosNext`, and
    in the process of Next()ing to the next user key, one of the child
    levelIters could have advanced past the sstable that contained the
    Merge that is being returned.

  If that sstable contained a range delete covering a key in an sstable
  in a lower level, and the lower level's key was not exposed to the
  mergingIter due to a bloom filter mismatch, and we do two consecutive
  SeekPrefixGEs where the second one gets TrySeekUsingNext, we could
  end up surfacing the deleted key in the lower sstable as the
  higher level's levelIter has already moved past the sstable
  containing the range deletion.

  This change sets isIgnorableBoundaryKey = true when returning
  largestBoundary in the levelIter to prevent the mergingIter from
  next()ing past it in the first SeekPrefixGE.

Fixes https://github.com/cockroachdb/pebble/issues/2118.