### PR TITLE
sstable: tiny Reader sizeof optimization

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -2607,7 +2607,6 @@ type Reader struct {
 	filename          string
 	cacheID           uint64
 	fileNum           base.FileNum
-	rawTombstones     bool
 	err               error
 	indexBH           BlockHandle
 	filterBH          BlockHandle
@@ -2621,11 +2620,14 @@ type Reader struct {
 	Compare           Compare
 	FormatKey         base.FormatKey
 	Split             Split
+	tableFilter       *tableFilterReader
+	// Keep types that are not multiples of 8 bytes at the end and with
+	// decreasing size.
+	Properties        Properties
+	tableFormat       TableFormat
+	rawTombstones     bool
 	mergerOK          bool
 	checksumType      ChecksumType
-	tableFilter       *tableFilterReader
-	tableFormat       TableFormat
-	Properties        Properties
 }
 
 // Close implements DB.Close, as documented in the pebble package.

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -204,7 +204,7 @@ compact         1   2.3 K     0 B       0          (size == estimated-debt, scor
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.4 K   11.1%  (score == hit-rate)
- tcache         1   704 B   50.0%  (score == hit-rate)
+ tcache         1   688 B   50.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -48,7 +48,7 @@ compact         0     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.5 K   42.9%  (score == hit-rate)
- tcache         1   704 B   50.0%  (score == hit-rate)
+ tcache         1   688 B   50.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -34,7 +34,7 @@ compact         0     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         1   256 K
    ztbl         0     0 B
  bcache         4   698 B    0.0%  (score == hit-rate)
- tcache         1   704 B    0.0%  (score == hit-rate)
+ tcache         1   688 B    0.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         1
  filter         -       -    0.0%  (score == utility)
@@ -82,7 +82,7 @@ compact         1     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         2   512 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   42.9%  (score == hit-rate)
- tcache         2   1.4 K   66.7%  (score == hit-rate)
+ tcache         2   1.3 K   66.7%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         2
  filter         -       -    0.0%  (score == utility)
@@ -115,7 +115,7 @@ compact         1     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         1   256 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   42.9%  (score == hit-rate)
- tcache         2   1.4 K   66.7%  (score == hit-rate)
+ tcache         2   1.3 K   66.7%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         2
  filter         -       -    0.0%  (score == utility)
@@ -145,7 +145,7 @@ compact         1     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         1   256 K
    ztbl         1   771 B
  bcache         4   698 B   42.9%  (score == hit-rate)
- tcache         1   704 B   66.7%  (score == hit-rate)
+ tcache         1   688 B   66.7%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         1
  filter         -       -    0.0%  (score == utility)


### PR DESCRIPTION
Reduces Reader struct size from 704 to 688 bytes. The bulk of the bytes, 488 bytes, are in Properties, which has some legacy stuff from RocksDB that we may be able to remove in the future.