### PR TITLE
compaction: introduce multilevel compaction heuristic interface

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -82,6 +82,17 @@ type compactionLevel struct {
 	files manifest.LevelSlice
 }
 
+func (cl compactionLevel) Clone() compactionLevel {
+	newCL := compactionLevel{
+		level: cl.level,
+		files: cl.files.Reslice(func(start, end *manifest.LevelIterator) {}),
+	}
+	return newCL
+}
+func (cl compactionLevel) String() string {
+	return fmt.Sprintf(`Level %d, Files %s`, cl.level, cl.files)
+}
+
 // Return output from compactionOutputSplitters. See comment on
 // compactionOutputSplitter.shouldSplitBefore() on how this value is used.
 type compactionSplitSuggestion int

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/humanize"
@@ -96,6 +97,16 @@ func (s sortCompactionLevelsDecreasingScore) Swap(i, j int) {
 type sublevelInfo struct {
 	manifest.LevelSlice
 	sublevel manifest.Level
+}
+
+func (cl sublevelInfo) Clone() sublevelInfo {
+	return sublevelInfo{
+		sublevel:   cl.sublevel,
+		LevelSlice: cl.LevelSlice.Reslice(func(start, end *manifest.LevelIterator) {}),
+	}
+}
+func (cl sublevelInfo) String() string {
+	return fmt.Sprintf(`Sublevel %s; Levels %s`, cl.sublevel, cl.LevelSlice)
 }
 
 // generateSublevelInfo will generate the level slices for each of the sublevels
@@ -257,6 +268,69 @@ func newPickedCompactionFromL0(
 	return pc
 }
 
+func (pc *pickedCompaction) String() string {
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf(`Score=%f, `, pc.score))
+	builder.WriteString(fmt.Sprintf(`Kind=%s, `, pc.kind))
+	builder.WriteString(fmt.Sprintf(`AdjustedOutputLevel=%d, `, pc.adjustedOutputLevel))
+	builder.WriteString(fmt.Sprintf(`maxOutputFileSize=%d, `, pc.maxOutputFileSize))
+	builder.WriteString(fmt.Sprintf(`maxReadCompactionBytes=%d, `, pc.maxReadCompactionBytes))
+	builder.WriteString(fmt.Sprintf(`smallest=%s, `, pc.smallest))
+	builder.WriteString(fmt.Sprintf(`largest=%s, `, pc.largest))
+	builder.WriteString(fmt.Sprintf(`version=%s, `, pc.version))
+	builder.WriteString(fmt.Sprintf(`inputs=%s, `, pc.inputs))
+	builder.WriteString(fmt.Sprintf(`startlevel=%s, `, pc.startLevel))
+	builder.WriteString(fmt.Sprintf(`outputLevel=%s, `, pc.outputLevel))
+	builder.WriteString(fmt.Sprintf(`extraLevels=%s, `, pc.extraLevels))
+	builder.WriteString(fmt.Sprintf(`l0SublevelInfo=%s, `, pc.l0SublevelInfo))
+	builder.WriteString(fmt.Sprintf(`lcf=%s`, pc.lcf))
+	return builder.String()
+}
+
+// Clone creates a deep copy of the pickedCompaction
+func (pc *pickedCompaction) clone() *pickedCompaction {
+
+	// Quickly copy over fields that do not require special deep copy care, and
+	// set all fields that will require a deep copy to nil.
+	newPC := &pickedCompaction{
+		cmp:                    pc.cmp,
+		score:                  pc.score,
+		kind:                   pc.kind,
+		adjustedOutputLevel:    pc.adjustedOutputLevel,
+		maxOutputFileSize:      pc.maxOutputFileSize,
+		maxOverlapBytes:        pc.maxOverlapBytes,
+		maxReadCompactionBytes: pc.maxReadCompactionBytes,
+		smallest:               pc.smallest.Clone(),
+		largest:                pc.largest.Clone(),
+
+		// Both copies see the same manifest, therefore, it's ok for them to se
+		// share the same pc. version.
+		version: pc.version,
+	}
+
+	newPC.inputs = make([]compactionLevel, len(pc.inputs))
+	newPC.extraLevels = make([]*compactionLevel, 0, len(pc.extraLevels))
+	for i := range pc.inputs {
+		newPC.inputs[i] = pc.inputs[i].Clone()
+		if i == 0 {
+			newPC.startLevel = &newPC.inputs[i]
+		} else if i == len(pc.inputs)-1 {
+			newPC.outputLevel = &newPC.inputs[i]
+		} else {
+			newPC.extraLevels = append(newPC.extraLevels, &newPC.inputs[i])
+		}
+	}
+
+	newPC.l0SublevelInfo = make([]sublevelInfo, len(pc.l0SublevelInfo))
+	for i := range pc.l0SublevelInfo {
+		newPC.l0SublevelInfo[i] = pc.l0SublevelInfo[i].Clone()
+	}
+	if pc.lcf != nil {
+		newPC.lcf = pc.lcf.Clone()
+	}
+	return newPC
+}
+
 // maybeExpandedBounds is a helper function for setupInputs which ensures the
 // pickedCompaction's smallest and largest internal keys are updated iff
 // the candidate keys expand the key span. This avoids a bug for multi-level
@@ -286,6 +360,8 @@ func (pc *pickedCompaction) maybeExpandBounds(smallest InternalKey, largest Inte
 	}
 }
 
+// setupInputs returns true if a compaction has been set up. It returns false if
+// a concurrent compaction is occurring on the start or output level files.
 func (pc *pickedCompaction) setupInputs(
 	opts *Options, diskAvailBytes uint64, startLevel *compactionLevel,
 ) bool {
@@ -362,8 +438,7 @@ func (pc *pickedCompaction) setupInputs(
 				}
 			})
 		}
-
-		oldLcf := *pc.lcf
+		oldLcf := pc.lcf.Clone()
 		if pc.version.L0Sublevels.ExtendL0ForBaseCompactionTo(smallestBaseKey, largestBaseKey, pc.lcf) {
 			var newStartLevelFiles []*fileMetadata
 			iter := pc.version.Levels[0].Iter()
@@ -379,7 +454,7 @@ func (pc *pickedCompaction) setupInputs(
 				pc.smallest, pc.largest = manifest.KeyRange(pc.cmp,
 					startLevel.files.Iter(), pc.outputLevel.files.Iter())
 			} else {
-				*pc.lcf = oldLcf
+				*pc.lcf = *oldLcf
 			}
 		}
 	} else if pc.grow(pc.smallest, pc.largest, maxExpandedBytes, startLevel) {
@@ -433,12 +508,28 @@ func (pc *pickedCompaction) grow(
 	return true
 }
 
-// initMultiLevelCompaction returns true if it initiated a multilevel input
-// compaction. This currently never inits a multiLevel compaction.
-func (pc *pickedCompaction) initMultiLevelCompaction(
-	opts *Options, vers *version, levelMaxBytes [7]int64, diskAvailBytes uint64,
-) bool {
-	return false
+func (pc *pickedCompaction) compactionSize() uint64 {
+	var bytesToCompact uint64
+	for i := range pc.inputs {
+		bytesToCompact += pc.inputs[i].files.SizeSum()
+	}
+	return bytesToCompact
+}
+
+// setupMultiLevelCandidated returns true if it successfully added another level
+// to the compaction.
+func (pc *pickedCompaction) setupMultiLevelCandidate(opts *Options, diskAvailBytes uint64) bool {
+	pc.inputs = append(pc.inputs, compactionLevel{level: pc.outputLevel.level + 1})
+
+	// Recalibrate startLevel and outputLevel:
+	//  - startLevel and outputLevel pointers may be obsolete after appending to pc.inputs.
+	//  - push outputLevel to extraLevels and move the new level to outputLevel
+	pc.startLevel = &pc.inputs[0]
+	pc.extraLevels = []*compactionLevel{&pc.inputs[1]}
+	pc.outputLevel = &pc.inputs[2]
+
+	pc.adjustedOutputLevel++
+	return pc.setupInputs(opts, diskAvailBytes, pc.extraLevels[len(pc.extraLevels)-1])
 }
 
 // expandToAtomicUnit expands the provided level slice within its level both
@@ -1463,12 +1554,35 @@ func pickAutoLPositive(
 	if !pc.setupInputs(opts, diskAvailBytes(), pc.startLevel) {
 		return nil
 	}
-	if opts.Experimental.MultiLevelCompaction &&
-		pc.initMultiLevelCompaction(opts, vers, levelMaxBytes, diskAvailBytes()) {
-		if !pc.setupInputs(opts, diskAvailBytes(), pc.extraLevels[len(pc.extraLevels)-1]) {
-			return nil
-		}
+	return pc.maybeAddLevel(opts, diskAvailBytes())
+}
+
+// maybeAddLevel maybe adds a level to the picked compaction.
+func (pc *pickedCompaction) maybeAddLevel(opts *Options, diskAvailBytes uint64) *pickedCompaction {
+	if pc.outputLevel.level == numLevels-1 {
+		// Don't add a level if the current output level is in L6
+		return pc
 	}
+	if pc.compactionSize() > expandedCompactionByteSizeLimit(
+		opts, pc.adjustedOutputLevel, diskAvailBytes) {
+		// Don't add a level if the current compaction exceeds the compaction size limit
+		return pc
+	}
+	return opts.Experimental.MultiLevelCompactionHueristic.pick(pc, opts, diskAvailBytes)
+}
+
+// MultiLevelHeuristic evaluates whether to add files from the next level into the compaction.
+type MultiLevelHeuristic interface {
+	// evaluate returns the preferred compaction.
+	pick(pc *pickedCompaction, opts *Options, diskAvailBytes uint64) *pickedCompaction
+}
+
+// NoMultiLevel will never add an additional level to the compaction.
+type NoMultiLevel struct{}
+
+func (nml NoMultiLevel) pick(
+	pc *pickedCompaction, opts *Options, diskAvailBytes uint64,
+) *pickedCompaction {
 	return pc
 }
 
@@ -1592,13 +1706,7 @@ func pickManualHelper(
 	if !pc.setupInputs(opts, diskAvailBytes(), pc.startLevel) {
 		return nil
 	}
-	if opts.Experimental.MultiLevelCompaction && pc.startLevel.level > 0 &&
-		pc.initMultiLevelCompaction(opts, vers, levelMaxBytes, diskAvailBytes()) {
-		if !pc.setupInputs(opts, diskAvailBytes(), pc.extraLevels[len(pc.extraLevels)-1]) {
-			return nil
-		}
-	}
-	return pc
+	return pc.maybeAddLevel(opts, diskAvailBytes())
 }
 
 func (p *compactionPickerByScore) pickReadTriggeredCompaction(

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -527,6 +527,7 @@ func TestCompactionPickerL0(t *testing.T) {
 			})
 			var result strings.Builder
 			if pc != nil {
+				checkClone(t, pc)
 				c := newCompaction(pc, opts)
 				fmt.Fprintf(&result, "L%d -> L%d\n", pc.startLevel.level, pc.outputLevel.level)
 				fmt.Fprintf(&result, "L%d: %s\n", pc.startLevel.level, fileNums(pc.startLevel.files))
@@ -935,9 +936,22 @@ func TestCompactionPickerPickReadTriggered(t *testing.T) {
 	})
 }
 
+type alwaysMultiLevel struct{}
+
+func (d alwaysMultiLevel) pick(
+	pcOrig *pickedCompaction, opts *Options, diskAvailBytes uint64,
+) *pickedCompaction {
+	pcMulti := pcOrig.clone()
+	if !pcMulti.setupMultiLevelCandidate(opts, diskAvailBytes) {
+		return pcOrig
+	}
+	return pcMulti
+}
+
 func TestPickedCompactionSetupInputs(t *testing.T) {
 	opts := &Options{}
 	opts.EnsureDefaults()
+
 	parseMeta := func(s string) *fileMetadata {
 		parts := strings.Split(strings.TrimSpace(s), " ")
 		var fileSize uint64
@@ -973,94 +987,121 @@ func TestPickedCompactionSetupInputs(t *testing.T) {
 		return m
 	}
 
-	datadriven.RunTest(t, "testdata/compaction_setup_inputs",
-		func(t *testing.T, d *datadriven.TestData) string {
-			switch d.Cmd {
-			case "setup-inputs":
-				var availBytes uint64 = math.MaxUint64
-				args := d.CmdArgs
+	setupInputTest := func(t *testing.T, d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "setup-inputs":
+			var availBytes uint64 = math.MaxUint64
+			var maxLevelBytes [7]int64
+			args := d.CmdArgs
 
-				if len(args) > 0 && args[0].Key == "avail-bytes" {
-					require.Equal(t, 1, len(args[0].Vals))
-					var err error
-					availBytes, err = strconv.ParseUint(args[0].Vals[0], 10, 64)
-					require.NoError(t, err)
-					args = args[1:]
-				}
+			if len(args) > 0 && args[0].Key == "avail-bytes" {
+				require.Equal(t, 1, len(args[0].Vals))
+				var err error
+				availBytes, err = strconv.ParseUint(args[0].Vals[0], 10, 64)
+				require.NoError(t, err)
+				args = args[1:]
+			}
 
-				if len(args) != 2 {
-					return "setup-inputs [avail-bytes=XXX] <start> <end>"
-				}
+			if len(args) != 2 {
+				return "setup-inputs [avail-bytes=XXX] <start> <end>"
+			}
 
-				pc := &pickedCompaction{
-					cmp:    DefaultComparer.Compare,
-					inputs: []compactionLevel{{level: -1}, {level: -1}},
-				}
-				pc.startLevel, pc.outputLevel = &pc.inputs[0], &pc.inputs[1]
-				var currentLevel int
-				var files [numLevels][]*fileMetadata
-				fileNum := FileNum(1)
+			pc := &pickedCompaction{
+				cmp:    DefaultComparer.Compare,
+				inputs: []compactionLevel{{level: -1}, {level: -1}},
+			}
+			pc.startLevel, pc.outputLevel = &pc.inputs[0], &pc.inputs[1]
+			var currentLevel int
+			var files [numLevels][]*fileMetadata
+			fileNum := FileNum(1)
 
-				for _, data := range strings.Split(d.Input, "\n") {
-					switch data {
-					case "L0", "L1", "L2", "L3", "L4", "L5", "L6":
-						level, err := strconv.Atoi(data[1:])
+			for _, data := range strings.Split(d.Input, "\n") {
+				switch data[:2] {
+				case "L0", "L1", "L2", "L3", "L4", "L5", "L6":
+					levelArgs := strings.Fields(data)
+					level, err := strconv.Atoi(levelArgs[0][1:])
+					if err != nil {
+						return err.Error()
+					}
+					currentLevel = level
+					if len(levelArgs) > 1 {
+						maxSizeArg := strings.Replace(levelArgs[1], "max-size=", "", 1)
+						maxSize, err := strconv.ParseInt(maxSizeArg, 10, 64)
 						if err != nil {
 							return err.Error()
 						}
-						if pc.startLevel.level == -1 {
-							pc.startLevel.level = level
-							currentLevel = level
-						} else if pc.outputLevel.level == -1 {
-							if pc.startLevel.level >= level {
-								return fmt.Sprintf("startLevel=%d >= outputLevel=%d\n", pc.startLevel.level, level)
-							}
-							pc.outputLevel.level = level
-							currentLevel = level
-						} else {
-							return "outputLevel already set\n"
+						maxLevelBytes[level] = maxSize
+					} else {
+						maxLevelBytes[level] = math.MaxInt64
+					}
+					if pc.startLevel.level == -1 {
+						pc.startLevel.level = level
+
+					} else if pc.outputLevel.level == -1 {
+						if pc.startLevel.level >= level {
+							return fmt.Sprintf("startLevel=%d >= outputLevel=%d\n", pc.startLevel.level, level)
 						}
-
-					default:
-						meta := parseMeta(data)
-						meta.FileNum = fileNum
-						fileNum++
-						files[currentLevel] = append(files[currentLevel], meta)
+						pc.outputLevel.level = level
 					}
+				default:
+					meta := parseMeta(data)
+					meta.FileNum = fileNum
+					fileNum++
+					files[currentLevel] = append(files[currentLevel], meta)
 				}
-
-				if pc.outputLevel.level == -1 {
-					pc.outputLevel.level = pc.startLevel.level + 1
-				}
-				pc.version = newVersion(opts, files)
-				pc.startLevel.files = pc.version.Overlaps(pc.startLevel.level, pc.cmp,
-					[]byte(args[0].String()), []byte(args[1].String()), false /* exclusiveEnd */)
-
-				var isCompacting bool
-				if !pc.setupInputs(opts, availBytes, pc.startLevel) {
-					isCompacting = true
-				}
-
-				var buf bytes.Buffer
-				for _, cl := range pc.inputs {
-					if cl.files.Empty() {
-						continue
-					}
-
-					fmt.Fprintf(&buf, "L%d\n", cl.level)
-					cl.files.Each(func(f *fileMetadata) {
-						fmt.Fprintf(&buf, "  %s\n", f)
-					})
-				}
-				if isCompacting {
-					fmt.Fprintf(&buf, "is-compacting")
-				}
-				return buf.String()
-
-			default:
-				return fmt.Sprintf("unknown command: %s", d.Cmd)
 			}
-		})
+
+			if pc.outputLevel.level == -1 {
+				pc.outputLevel.level = pc.startLevel.level + 1
+			}
+			pc.version = newVersion(opts, files)
+			pc.startLevel.files = pc.version.Overlaps(pc.startLevel.level, pc.cmp,
+				[]byte(args[0].String()), []byte(args[1].String()), false /* exclusiveEnd */)
+
+			var isCompacting bool
+			if !pc.setupInputs(opts, availBytes, pc.startLevel) {
+				isCompacting = true
+			}
+			origPC := pc
+			pc = pc.maybeAddLevel(opts, availBytes)
+			// If pc points to a new pickedCompaction, a new multi level compaction
+			// was initialized.
+			initMultiLevel := pc != origPC
+			checkClone(t, pc)
+			var buf bytes.Buffer
+			for _, cl := range pc.inputs {
+				if cl.files.Empty() {
+					continue
+				}
+
+				fmt.Fprintf(&buf, "L%d\n", cl.level)
+				cl.files.Each(func(f *fileMetadata) {
+					fmt.Fprintf(&buf, "  %s\n", f)
+				})
+			}
+			if isCompacting {
+				fmt.Fprintf(&buf, "is-compacting\n")
+			}
+
+			if initMultiLevel {
+				extraLevel := pc.extraLevels[0].level
+				fmt.Fprintf(&buf, "init-multi-level(%d,%d,%d)\n", pc.startLevel.level, extraLevel,
+					pc.outputLevel.level)
+			}
+			return buf.String()
+
+		default:
+			return fmt.Sprintf("unknown command: %s", d.Cmd)
+		}
+	}
+
+	datadriven.RunTest(t, "testdata/compaction_setup_inputs",
+		setupInputTest)
+
+	t.Logf("Turning multi level compaction on")
+	opts.Experimental.MultiLevelCompactionHueristic = alwaysMultiLevel{}
+	datadriven.RunTest(t, "testdata/compaction_setup_inputs_multilevel_dummy",
+		setupInputTest)
 }
 
 func TestPickedCompactionExpandInputs(t *testing.T) {
@@ -1316,4 +1357,22 @@ func fileNums(files manifest.LevelSlice) string {
 	})
 	sort.Strings(ss)
 	return strings.Join(ss, ",")
+}
+
+func checkClone(t *testing.T, pc *pickedCompaction) {
+	pcClone := pc.clone()
+	require.Equal(t, pc.String(), pcClone.String())
+
+	// ensure all input files are in new address
+	for i := range pc.inputs {
+		// Len could be zero if setup inputs rejected a level
+		if pc.inputs[i].files.Len() > 0 {
+			require.NotEqual(t, &pc.inputs[i], &pcClone.inputs[i])
+		}
+	}
+	for i := range pc.l0SublevelInfo {
+		if pc.l0SublevelInfo[i].Len() > 0 {
+			require.NotEqual(t, &pc.l0SublevelInfo[i], &pcClone.l0SublevelInfo[i])
+		}
+	}
 }

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -1149,6 +1149,23 @@ type L0CompactionFiles struct {
 	filesAdded              []*FileMetadata
 }
 
+// Clone allocates a new L0CompactionFiles, with the same underlying data. Note
+// that the two fileMetadata slices contain values that point to the same
+// underlying fileMetadata object. This is safe because these objects are read
+// only.
+func (l *L0CompactionFiles) Clone() *L0CompactionFiles {
+	oldLcf := *l
+	return &oldLcf
+}
+
+// String merely prints the starting address of the first file, if it exists.
+func (l *L0CompactionFiles) String() string {
+	if len(l.Files) > 0 {
+		return fmt.Sprintf("First File Address: %p", &l.Files[0])
+	}
+	return ""
+}
+
 // addFile adds the specified file to the LCF.
 func (l *L0CompactionFiles) addFile(f *FileMetadata) {
 	if l.FilesIncluded[f.L0Index] {

--- a/options.go
+++ b/options.go
@@ -562,10 +562,10 @@ type Options struct {
 		// desired size of each level of the LSM. Defaults to 10.
 		LevelMultiplier int
 
-		// MultiLevelCompaction allows the compaction of SSTs from more than two
-		// levels iff a conventional two level compaction will quickly trigger a
-		// compaction in the output level.
-		MultiLevelCompaction bool
+		// MultiLevelCompactionHueristic determines whether to add an additional
+		// level to a conventional two level compaction. If nil, a multilevel
+		// compaction will never get triggered.
+		MultiLevelCompactionHueristic MultiLevelHeuristic
 
 		// MaxWriterConcurrency is used to indicate the maximum number of
 		// compression workers the compression queue is allowed to use. If
@@ -993,6 +993,10 @@ func (o *Options) EnsureDefaults() *Options {
 	}
 	if o.Experimental.PointTombstoneWeight == 0 {
 		o.Experimental.PointTombstoneWeight = 1
+	}
+
+	if o.Experimental.MultiLevelCompactionHueristic == nil {
+		o.Experimental.MultiLevelCompactionHueristic = NoMultiLevel{}
 	}
 
 	o.initMaps()

--- a/testdata/compaction_setup_inputs_multilevel_dummy
+++ b/testdata/compaction_setup_inputs_multilevel_dummy
@@ -1,0 +1,16 @@
+# init a multi-level compaction with dummy hueristic
+setup-inputs a a
+L1
+  a.SET.1-b.SET.2 size=1
+L2
+  a.SET.3-c.SET.4 size=1
+L3
+  c.SET.3-d.SET.2 size=1
+----
+L1
+  000001:[a#1,1-b#2,1]
+L2
+  000002:[a#3,1-c#4,1]
+L3
+  000003:[c#3,1-d#2,1]
+init-multi-level(1,2,3)


### PR DESCRIPTION
This patch introduces the multiLevelHueristic interface, whose implementations
can evaluate whether to add an additional level to a conventional 2 level
compaction.

If the option.experimental.multiLevelHeuristic knob is set, the compaction
picker will create a deep copy of the original compaction, call setupInputs on
the newly allocated object, adding a new level to the new compaction
candidate. Then, the heuristic decides to compact with the original picked
compaction or the new multilevel candidate.

Informs #2053