### PR TITLE
*: avoid various range key iteration allocations

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1033,7 +1033,7 @@ func (c *compaction) newInputIter(
 			}
 			if rangeKeyIter := f.newRangeKeyIter(nil); rangeKeyIter != nil {
 				mi := &keyspan.MergingIter{}
-				mi.Init(c.cmp, rangeKeyCompactionTransform(snapshots, c.elideRangeKey), rangeKeyIter)
+				mi.Init(c.cmp, rangeKeyCompactionTransform(snapshots, c.elideRangeKey), new(keyspan.MergingBuffers), rangeKeyIter)
 				c.rangeKeyInterleaving.Init(c.comparer, iter, mi, nil /* hooks */, nil /* lowerBound */, nil /* upperBound */)
 				iter = &c.rangeKeyInterleaving
 			}
@@ -1060,7 +1060,7 @@ func (c *compaction) newInputIter(
 		var iter internalIterator = newMergingIter(c.logger, &c.stats, c.cmp, nil, iters...)
 		if len(rangeKeyIters) > 0 {
 			mi := &keyspan.MergingIter{}
-			mi.Init(c.cmp, rangeKeyCompactionTransform(snapshots, c.elideRangeKey), rangeKeyIters...)
+			mi.Init(c.cmp, rangeKeyCompactionTransform(snapshots, c.elideRangeKey), new(keyspan.MergingBuffers), rangeKeyIters...)
 			c.rangeKeyInterleaving.Init(c.comparer, iter, mi, nil /* hooks */, nil /* lowerBound */, nil /* upperBound */)
 			iter = &c.rangeKeyInterleaving
 		}
@@ -1330,7 +1330,7 @@ func (c *compaction) newInputIter(
 	pointKeyIter := newMergingIter(c.logger, &c.stats, c.cmp, nil, iters...)
 	if len(rangeKeyIters) > 0 {
 		mi := &keyspan.MergingIter{}
-		mi.Init(c.cmp, rangeKeyCompactionTransform(snapshots, c.elideRangeKey), rangeKeyIters...)
+		mi.Init(c.cmp, rangeKeyCompactionTransform(snapshots, c.elideRangeKey), new(keyspan.MergingBuffers), rangeKeyIters...)
 		di := &keyspan.DefragmentingIter{}
 		di.Init(c.comparer, mi, keyspan.DefragmentInternal, keyspan.StaticDefragmentReducer, new(keyspan.DefragmentingBuffers))
 		c.rangeKeyInterleaving.Init(c.comparer, pointKeyIter, di, nil /* hooks */, nil /* lowerBound */, nil /* upperBound */)

--- a/compaction.go
+++ b/compaction.go
@@ -1332,7 +1332,7 @@ func (c *compaction) newInputIter(
 		mi := &keyspan.MergingIter{}
 		mi.Init(c.cmp, rangeKeyCompactionTransform(snapshots, c.elideRangeKey), rangeKeyIters...)
 		di := &keyspan.DefragmentingIter{}
-		di.Init(c.comparer, mi, keyspan.DefragmentInternal, keyspan.StaticDefragmentReducer)
+		di.Init(c.comparer, mi, keyspan.DefragmentInternal, keyspan.StaticDefragmentReducer, new(keyspan.DefragmentingBuffers))
 		c.rangeKeyInterleaving.Init(c.comparer, pointKeyIter, di, nil /* hooks */, nil /* lowerBound */, nil /* upperBound */)
 		return &c.rangeKeyInterleaving, nil
 	}

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -290,6 +290,7 @@ func finishInitializingExternal(it *Iterator) {
 					base.InternalKeySeqNumMax,
 					it.opts.LowerBound, it.opts.UpperBound,
 					&it.hasPrefix, &it.prefixOrFullSeekKey,
+					&it.rangeKey.internal,
 				)
 				for i := range rangeKeyIters {
 					it.rangeKey.iterConfig.AddLevel(rangeKeyIters[i])

--- a/internal/bytealloc/bytealloc.go
+++ b/internal/bytealloc/bytealloc.go
@@ -59,3 +59,11 @@ func (a A) Copy(src []byte) (A, []byte) {
 	copy(alloc, src)
 	return a, alloc
 }
+
+// Reset returns the current chunk, resetting allocated memory back to none.
+// Future allocations will use memory previously allocated by previous calls to
+// Alloc or Copy, so the caller must know know that none of the previously
+// allocated byte slices are still in use.
+func (a A) Reset() A {
+	return a[:0]
+}

--- a/internal/keyspan/defragment.go
+++ b/internal/keyspan/defragment.go
@@ -12,9 +12,14 @@ import (
 )
 
 // bufferReuseMaxCapacity is the maximum capacity of a DefragmentingIter buffer
-// that DefragmentingIter will reuse. Buffers greater than this will be
+// that DefragmentingIter will reuse. Buffers larger than this will be
 // discarded and reallocated as necessary.
 const bufferReuseMaxCapacity = 10 << 10 // 10 KB
+
+// keysReuseMaxCapacity is the maximum capacity of a []keyspan.Key buffer that
+// DefragmentingIter will reuse. Buffers larger than this will be discarded and
+// reallocated as necessary.
+const keysReuseMaxCapacity = 100
 
 // DefragmentMethod configures the defragmentation performed by the
 // DefragmentingIter.
@@ -118,25 +123,16 @@ const (
 // defragments in the iteration direction, ensuring it's found a whole
 // defragmented span.
 type DefragmentingIter struct {
+	// DefragmentingBuffers holds buffers used for copying iterator state.
+	*DefragmentingBuffers
 	comparer *base.Comparer
 	equal    base.Equal
 	iter     FragmentIterator
 	iterSpan *Span
 	iterPos  iterPos
 
-	// curr holds the span at the current iterator position. currBuf is a buffer
-	// for use when copying user keys for curr. keysBuf is a buffer for use when
-	// copying Keys for curr. currBuf is cleared between positioning methods.
-	//
-	// keyBuf is a buffer specifically for the defragmented start key when
-	// defragmenting backwards or the defragmented end key when defragmenting
-	// forwards. These bounds are overwritten repeatedly during defragmentation,
-	// and the defragmentation routines overwrite keyBuf repeatedly to store
-	// these extended bounds.
-	curr    Span
-	currBuf []byte
-	keysBuf []Key
-	keyBuf  []byte
+	// curr holds the span at the current iterator position.
+	curr Span
 
 	// method is a comparison function for two spans. method is called when two
 	// spans are abutting to determine whether they may be defragmented.
@@ -148,20 +144,53 @@ type DefragmentingIter struct {
 	reduce DefragmentReducer
 }
 
+// DefragmentingBuffers holds buffers used for copying iterator state.
+type DefragmentingBuffers struct {
+	// currBuf is a buffer for use when copying user keys for curr. currBuf is
+	// cleared between positioning methods.
+	currBuf []byte
+	// keysBuf is a buffer for use when copying Keys for DefragmentingIter.curr.
+	keysBuf []Key
+	// keyBuf is a buffer specifically for the defragmented start key when
+	// defragmenting backwards or the defragmented end key when defragmenting
+	// forwards. These bounds are overwritten repeatedly during defragmentation,
+	// and the defragmentation routines overwrite keyBuf repeatedly to store
+	// these extended bounds.
+	keyBuf []byte
+}
+
+// PrepareForReuse discards any excessively large buffers.
+func (bufs *DefragmentingBuffers) PrepareForReuse() {
+	if cap(bufs.currBuf) > bufferReuseMaxCapacity {
+		bufs.currBuf = nil
+	}
+	if cap(bufs.keyBuf) > bufferReuseMaxCapacity {
+		bufs.keyBuf = nil
+	}
+	if cap(bufs.keysBuf) > keysReuseMaxCapacity {
+		bufs.keysBuf = nil
+	}
+}
+
 // Assert that *DefragmentingIter implements the FragmentIterator interface.
 var _ FragmentIterator = (*DefragmentingIter)(nil)
 
 // Init initializes the defragmenting iter using the provided defragment
 // method.
 func (i *DefragmentingIter) Init(
-	comparer *base.Comparer, iter FragmentIterator, equal DefragmentMethod, reducer DefragmentReducer,
+	comparer *base.Comparer,
+	iter FragmentIterator,
+	equal DefragmentMethod,
+	reducer DefragmentReducer,
+	bufs *DefragmentingBuffers,
 ) {
 	*i = DefragmentingIter{
-		comparer: comparer,
-		equal:    comparer.Equal,
-		iter:     iter,
-		method:   equal,
-		reduce:   reducer,
+		DefragmentingBuffers: bufs,
+		comparer:             comparer,
+		equal:                comparer.Equal,
+		iter:                 iter,
+		method:               equal,
+		reduce:               reducer,
 	}
 }
 
@@ -440,12 +469,6 @@ func (i *DefragmentingIter) saveCurrent() {
 	i.currBuf = i.currBuf[:0]
 	i.keysBuf = i.keysBuf[:0]
 	i.keyBuf = i.keyBuf[:0]
-	if cap(i.currBuf) > bufferReuseMaxCapacity {
-		i.currBuf = nil
-	}
-	if cap(i.keyBuf) > bufferReuseMaxCapacity {
-		i.keyBuf = nil
-	}
 	if i.iterSpan == nil {
 		return
 	}

--- a/internal/keyspan/defragment_test.go
+++ b/internal/keyspan/defragment_test.go
@@ -78,7 +78,7 @@ func TestDefragmentingIter(t *testing.T) {
 				}
 			}
 			var innerIter MergingIter
-			innerIter.Init(cmp, noopTransform, NewIter(cmp, spans))
+			innerIter.Init(cmp, noopTransform, new(MergingBuffers), NewIter(cmp, spans))
 			var iter DefragmentingIter
 			iter.Init(comparer, &innerIter, equal, reducer, new(DefragmentingBuffers))
 			for _, line := range strings.Split(td.Input, "\n") {
@@ -160,9 +160,9 @@ func testDefragmentingIteRandomizedOnce(t *testing.T, seed int64) {
 	fragmented = fragment(cmp, formatKey, fragmented)
 
 	var originalInner MergingIter
-	originalInner.Init(cmp, noopTransform, NewIter(cmp, original))
+	originalInner.Init(cmp, noopTransform, new(MergingBuffers), NewIter(cmp, original))
 	var fragmentedInner MergingIter
-	fragmentedInner.Init(cmp, noopTransform, NewIter(cmp, fragmented))
+	fragmentedInner.Init(cmp, noopTransform, new(MergingBuffers), NewIter(cmp, fragmented))
 
 	var referenceIter, fragmentedIter DefragmentingIter
 	referenceIter.Init(comparer, &originalInner, DefragmentInternal, StaticDefragmentReducer, new(DefragmentingBuffers))

--- a/internal/keyspan/defragment_test.go
+++ b/internal/keyspan/defragment_test.go
@@ -80,7 +80,7 @@ func TestDefragmentingIter(t *testing.T) {
 			var innerIter MergingIter
 			innerIter.Init(cmp, noopTransform, NewIter(cmp, spans))
 			var iter DefragmentingIter
-			iter.Init(comparer, &innerIter, equal, reducer)
+			iter.Init(comparer, &innerIter, equal, reducer, new(DefragmentingBuffers))
 			for _, line := range strings.Split(td.Input, "\n") {
 				runIterOp(&buf, &iter, line)
 			}
@@ -165,8 +165,8 @@ func testDefragmentingIteRandomizedOnce(t *testing.T, seed int64) {
 	fragmentedInner.Init(cmp, noopTransform, NewIter(cmp, fragmented))
 
 	var referenceIter, fragmentedIter DefragmentingIter
-	referenceIter.Init(comparer, &originalInner, DefragmentInternal, StaticDefragmentReducer)
-	fragmentedIter.Init(comparer, &fragmentedInner, DefragmentInternal, StaticDefragmentReducer)
+	referenceIter.Init(comparer, &originalInner, DefragmentInternal, StaticDefragmentReducer, new(DefragmentingBuffers))
+	fragmentedIter.Init(comparer, &fragmentedInner, DefragmentInternal, StaticDefragmentReducer, new(DefragmentingBuffers))
 
 	// Generate 100 random operations and run them against both iterators.
 	const numIterOps = 100

--- a/internal/keyspan/interleaving_iter_test.go
+++ b/internal/keyspan/interleaving_iter_test.go
@@ -105,7 +105,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 			for _, line := range lines {
 				spans = append(spans, ParseSpan(line))
 			}
-			keyspanIter.Init(cmp, noopTransform, NewIter(cmp, spans))
+			keyspanIter.Init(cmp, noopTransform, new(MergingBuffers), NewIter(cmp, spans))
 			hooks.maskSuffix = nil
 			iter.Init(testkeys.Comparer, &pointIter, &keyspanIter, &hooks, nil, nil)
 			return "OK"

--- a/internal/keyspan/internal_iter_shim.go
+++ b/internal/keyspan/internal_iter_shim.go
@@ -16,6 +16,7 @@ import "github.com/cockroachdb/pebble/internal/base"
 // keyspan.FragmentIterator with point keys.
 type InternalIteratorShim struct {
 	miter   MergingIter
+	mbufs   MergingBuffers
 	span    *Span
 	iterKey base.InternalKey
 }
@@ -26,7 +27,7 @@ var _ base.InternalIterator = &InternalIteratorShim{}
 // Init initializes the internal iterator shim to merge the provided fragment
 // iterators.
 func (i *InternalIteratorShim) Init(cmp base.Compare, iters ...FragmentIterator) {
-	i.miter.Init(cmp, noopTransform, iters...)
+	i.miter.Init(cmp, noopTransform, &i.mbufs, iters...)
 }
 
 // Span returns the span containing the full set of keys over the key span at

--- a/internal/keyspan/level_iter_test.go
+++ b/internal/keyspan/level_iter_test.go
@@ -310,8 +310,8 @@ func TestLevelIterEquivalence(t *testing.T) {
 			levelIters = append(levelIters, &levelIter)
 		}
 
-		iter1.Init(base.DefaultComparer.Compare, visibleTransform(base.InternalKeySeqNumMax), fileIters...)
-		iter2.Init(base.DefaultComparer.Compare, visibleTransform(base.InternalKeySeqNumMax), levelIters...)
+		iter1.Init(base.DefaultComparer.Compare, visibleTransform(base.InternalKeySeqNumMax), new(MergingBuffers), fileIters...)
+		iter2.Init(base.DefaultComparer.Compare, visibleTransform(base.InternalKeySeqNumMax), new(MergingBuffers), levelIters...)
 		// Check iter1 and iter2 for equivalence.
 
 		require.Equal(t, iter1.First(), iter2.First(), "failed on test case %q", tc.name)

--- a/internal/keyspan/merging_iter.go
+++ b/internal/keyspan/merging_iter.go
@@ -844,7 +844,7 @@ func (m *MergingIter) synthesizeKeys(dir int8) (bool, *Span) {
 	sort.Sort(&m.keys)
 
 	// Apply the configured transform. See visibleTransform.
-	s := Span{
+	m.span = Span{
 		Start:     m.start,
 		End:       m.end,
 		Keys:      m.keys,
@@ -852,7 +852,7 @@ func (m *MergingIter) synthesizeKeys(dir int8) (bool, *Span) {
 	}
 	// NB: m.heap.cmp is a base.Compare, whereas m.cmp is a method on
 	// MergingIter.
-	if err := m.transformer.Transform(m.heap.cmp, s, &m.span); err != nil {
+	if err := m.transformer.Transform(m.heap.cmp, m.span, &m.span); err != nil {
 		m.err = err
 		return false, nil
 	}

--- a/internal/keyspan/merging_iter_test.go
+++ b/internal/keyspan/merging_iter_test.go
@@ -55,7 +55,7 @@ func TestMergingIter(t *testing.T) {
 			if len(spans) > 0 {
 				iters = append(iters, &invalidatingIter{iter: NewIter(cmp, spans)})
 			}
-			iter.Init(cmp, visibleTransform(snapshot), iters...)
+			iter.Init(cmp, visibleTransform(snapshot), new(MergingBuffers), iters...)
 			return fmt.Sprintf("%d levels", len(iters))
 		case "iter":
 			buf.Reset()
@@ -197,7 +197,7 @@ func testFragmenterEquivalenceOnce(t *testing.T, seed int64) {
 
 	fragmenterIter := NewIter(f.Cmp, allFragmented)
 	mergingIter := &MergingIter{}
-	mergingIter.Init(f.Cmp, visibleTransform(base.InternalKeySeqNumMax), iters...)
+	mergingIter.Init(f.Cmp, visibleTransform(base.InternalKeySeqNumMax), new(MergingBuffers), iters...)
 
 	// Position both so that it's okay to perform relative positioning
 	// operations immediately.

--- a/internal/rangekey/coalesce.go
+++ b/internal/rangekey/coalesce.go
@@ -24,7 +24,7 @@ type UserIteratorConfig struct {
 	diter      keyspan.DefragmentingIter
 	liters     [manifest.NumLevels]keyspan.LevelIter
 	litersUsed int
-	sortBuf    keysBySuffix
+	bufs       *Buffers
 }
 
 // Buffers holds various buffers used for range key iteration. They're exposed
@@ -32,6 +32,7 @@ type UserIteratorConfig struct {
 type Buffers struct {
 	merging       keyspan.MergingBuffers
 	defragmenting keyspan.DefragmentingBuffers
+	sortBuf       keysBySuffix
 }
 
 // PrepareForReuse discards any excessively large buffers.
@@ -63,6 +64,7 @@ func (ui *UserIteratorConfig) Init(
 	ui.biter.Init(comparer.Compare, comparer.Split, &ui.miter, lower, upper, hasPrefix, prefix)
 	ui.diter.Init(comparer, &ui.biter, ui, keyspan.StaticDefragmentReducer, &bufs.defragmenting)
 	ui.litersUsed = 0
+	ui.bufs = bufs
 	return &ui.diter
 }
 
@@ -101,17 +103,17 @@ func (ui *UserIteratorConfig) Transform(cmp base.Compare, s keyspan.Span, dst *k
 	// Apply shadowing of keys.
 	dst.Start = s.Start
 	dst.End = s.End
-	ui.sortBuf = keysBySuffix{
+	ui.bufs.sortBuf = keysBySuffix{
 		cmp:  cmp,
-		keys: dst.Keys[:0],
+		keys: ui.bufs.sortBuf.keys[:0],
 	}
-	if err := coalesce(&ui.sortBuf, s.Visible(ui.snapshot).Keys, &dst.Keys); err != nil {
+	if err := coalesce(&ui.bufs.sortBuf, s.Visible(ui.snapshot).Keys); err != nil {
 		return err
 	}
 	// During user iteration over range keys, unsets and deletes don't
 	// matter. Remove them. This step helps logical defragmentation during
 	// iteration.
-	keys := dst.Keys
+	keys := ui.bufs.sortBuf.keys
 	dst.Keys = dst.Keys[:0]
 	for i := range keys {
 		switch keys[i].Kind() {
@@ -225,15 +227,17 @@ func Coalesce(cmp base.Compare, keys []keyspan.Key, dst *[]keyspan.Key) error {
 		cmp:  cmp,
 		keys: (*dst)[:0],
 	}
-	if err := coalesce(&keysBySuffix, keys, dst); err != nil {
+	if err := coalesce(&keysBySuffix, keys); err != nil {
 		return err
 	}
-	// coalesce left the keys in *dst sorted by suffix. Re-sort them by trailer.
+	// Update the span with the (potentially reduced) keys slice.  coalesce left
+	// the keys in *dst sorted by suffix. Re-sort them by trailer.
+	*dst = keysBySuffix.keys
 	keyspan.SortKeysByTrailer(dst)
 	return nil
 }
 
-func coalesce(keysBySuffix *keysBySuffix, keys []keyspan.Key, dst *[]keyspan.Key) error {
+func coalesce(keysBySuffix *keysBySuffix, keys []keyspan.Key) error {
 	var deleted bool
 	for i := 0; i < len(keys) && !deleted; i++ {
 		k := keys[i]
@@ -278,11 +282,6 @@ func coalesce(keysBySuffix *keysBySuffix, keys []keyspan.Key, dst *[]keyspan.Key
 			return base.CorruptionErrorf("pebble: unexpected range key kind %s", k.Kind())
 		}
 	}
-
-	// Update the span with the (potentially reduced) keys slice.
-	// NB: We don't re-sort by Trailer. The exported Coalesce function however
-	// will.
-	*dst = keysBySuffix.keys
 	return nil
 }
 

--- a/internal/rangekey/coalesce.go
+++ b/internal/rangekey/coalesce.go
@@ -30,11 +30,13 @@ type UserIteratorConfig struct {
 // Buffers holds various buffers used for range key iteration. They're exposed
 // so that they may be pooled and reused between iterators.
 type Buffers struct {
+	merging       keyspan.MergingBuffers
 	defragmenting keyspan.DefragmentingBuffers
 }
 
 // PrepareForReuse discards any excessively large buffers.
 func (bufs *Buffers) PrepareForReuse() {
+	bufs.merging.PrepareForReuse()
 	bufs.defragmenting.PrepareForReuse()
 }
 
@@ -57,7 +59,7 @@ func (ui *UserIteratorConfig) Init(
 ) keyspan.FragmentIterator {
 	ui.snapshot = snapshot
 	ui.comparer = comparer
-	ui.miter.Init(comparer.Compare, ui, iters...)
+	ui.miter.Init(comparer.Compare, ui, &bufs.merging, iters...)
 	ui.biter.Init(comparer.Compare, comparer.Split, &ui.miter, lower, upper, hasPrefix, prefix)
 	ui.diter.Init(comparer, &ui.biter, ui, keyspan.StaticDefragmentReducer, &bufs.defragmenting)
 	ui.litersUsed = 0

--- a/internal/rangekey/coalesce_test.go
+++ b/internal/rangekey/coalesce_test.go
@@ -138,7 +138,7 @@ func TestDefragmenting(t *testing.T) {
 			var userIterCfg UserIteratorConfig
 			iter := userIterCfg.Init(testkeys.Comparer, base.InternalKeySeqNumMax,
 				nil /* lower */, nil, /* upper */
-				&hasPrefix, &prefix,
+				&hasPrefix, &prefix, new(Buffers),
 				keyspan.NewIter(cmp, spans))
 			for _, line := range strings.Split(td.Input, "\n") {
 				runIterOp(&buf, iter, line)
@@ -220,11 +220,11 @@ func testDefragmentingIteRandomizedOnce(t *testing.T, seed int64) {
 	var referenceCfg, fragmentedCfg UserIteratorConfig
 	referenceIter := referenceCfg.Init(testkeys.Comparer, base.InternalKeySeqNumMax,
 		nil /* lower */, nil, /* upper */
-		new(bool), new([]byte),
+		new(bool), new([]byte), new(Buffers),
 		keyspan.NewIter(cmp, original))
 	fragmentedIter := fragmentedCfg.Init(testkeys.Comparer, base.InternalKeySeqNumMax,
 		nil /* lower */, nil, /* upper */
-		new(bool), new([]byte),
+		new(bool), new([]byte), new(Buffers),
 		keyspan.NewIter(cmp, fragmented))
 
 	// Generate 100 random operations and run them against both iterators.

--- a/internal/rangekey/coalesce_test.go
+++ b/internal/rangekey/coalesce_test.go
@@ -75,7 +75,7 @@ func TestIter(t *testing.T) {
 				dst.End = s.End
 				return Coalesce(cmp, s.Keys, &dst.Keys)
 			})
-			iter.Init(cmp, transform, keyspan.NewIter(cmp, spans))
+			iter.Init(cmp, transform, new(keyspan.MergingBuffers), keyspan.NewIter(cmp, spans))
 			return "OK"
 		case "iter":
 			buf.Reset()

--- a/iterator.go
+++ b/iterator.go
@@ -2031,7 +2031,10 @@ func (i *Iterator) Close() error {
 		if cap(i.rangeKey.buf) >= maxKeyBufCacheSize {
 			i.rangeKey.buf = nil
 		}
-		*i.rangeKey = iteratorRangeKeyState{buf: i.rangeKey.buf}
+		*i.rangeKey = iteratorRangeKeyState{
+			buf:  i.rangeKey.buf,
+			keys: i.rangeKey.keys[:0],
+		}
 		iterRangeKeyStateAllocPool.Put(i.rangeKey)
 		i.rangeKey = nil
 	}

--- a/range_keys.go
+++ b/range_keys.go
@@ -17,7 +17,7 @@ import (
 func (i *Iterator) constructRangeKeyIter() {
 	i.rangeKey.rangeKeyIter = i.rangeKey.iterConfig.Init(
 		&i.comparer, i.seqNum, i.opts.LowerBound, i.opts.UpperBound,
-		&i.hasPrefix, &i.prefixOrFullSeekKey)
+		&i.hasPrefix, &i.prefixOrFullSeekKey, &i.rangeKey.rangeKeyBuffers.internal)
 
 	// If there's an indexed batch with range keys, include it.
 	if i.batch != nil {

--- a/table_stats.go
+++ b/table_stats.go
@@ -723,7 +723,7 @@ func newCombinedDeletionKeyspanIter(
 	}
 	if iter != nil {
 		dIter := &keyspan.DefragmentingIter{}
-		dIter.Init(comparer, iter, equal, reducer)
+		dIter.Init(comparer, iter, equal, reducer, new(keyspan.DefragmentingBuffers))
 		iter = dIter
 		// Truncate tombstones to the containing file's bounds if necessary.
 		// See docs/range_deletions.md for why this is necessary.
@@ -752,7 +752,7 @@ func newCombinedDeletionKeyspanIter(
 			return len(out.Keys) > 0
 		})
 		dIter := &keyspan.DefragmentingIter{}
-		dIter.Init(comparer, iter, equal, reducer)
+		dIter.Init(comparer, iter, equal, reducer, new(keyspan.DefragmentingBuffers))
 		iter = dIter
 		mIter.AddLevel(iter)
 	}

--- a/table_stats.go
+++ b/table_stats.go
@@ -715,7 +715,7 @@ func newCombinedDeletionKeyspanIter(
 		keyspan.SortKeysByTrailer(&out.Keys)
 		return nil
 	})
-	mIter.Init(comparer.Compare, transform)
+	mIter.Init(comparer.Compare, transform, new(keyspan.MergingBuffers))
 
 	iter, err := r.NewRawRangeDelIter()
 	if err != nil {


### PR DESCRIPTION
Avoid various allocations during range key iteration by including additional buffers and slices on the pooled `iteratorRangeKeyState` type.

```
name                                                                      old speed      new speed      delta
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=0-24          6.61MB/s ± 3%  6.76MB/s ± 3%   +2.29%  (p=0.005 n=9+10)
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=1-24          4.00MB/s ± 2%  4.09MB/s ± 3%   +2.22%  (p=0.014 n=9+9)
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=100-24         420kB/s ± 0%   452kB/s ± 3%   +7.62%  (p=0.000 n=6+10)
MVCCScan_Pebble/rows=1/versions=2/valueSize=64/numRangeKeys=0-24          5.49MB/s ± 2%  5.52MB/s ± 4%     ~     (p=0.540 n=10+10)
MVCCScan_Pebble/rows=1/versions=2/valueSize=64/numRangeKeys=1-24          3.34MB/s ± 3%  3.43MB/s ± 3%   +2.64%  (p=0.008 n=10+10)
MVCCScan_Pebble/rows=1/versions=2/valueSize=64/numRangeKeys=100-24         454kB/s ± 1%   484kB/s ± 1%   +6.61%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=1/versions=10/valueSize=64/numRangeKeys=0-24         3.48MB/s ± 3%  3.46MB/s ± 3%     ~     (p=0.364 n=10+10)
MVCCScan_Pebble/rows=1/versions=10/valueSize=64/numRangeKeys=1-24         2.33MB/s ± 1%  2.34MB/s ± 3%     ~     (p=0.562 n=9+10)
MVCCScan_Pebble/rows=1/versions=10/valueSize=64/numRangeKeys=100-24        448kB/s ± 3%   482kB/s ± 3%   +7.64%  (p=0.000 n=10+9)
MVCCScan_Pebble/rows=1/versions=100/valueSize=64/numRangeKeys=0-24        1.69MB/s ± 3%  1.67MB/s ± 2%     ~     (p=0.159 n=10+9)
MVCCScan_Pebble/rows=1/versions=100/valueSize=64/numRangeKeys=1-24        1.35MB/s ± 2%  1.36MB/s ± 3%     ~     (p=0.700 n=10+10)
MVCCScan_Pebble/rows=1/versions=100/valueSize=64/numRangeKeys=100-24       506kB/s ± 3%   549kB/s ± 2%   +8.48%  (p=0.000 n=10+9)
MVCCScan_Pebble/rows=10/versions=1/valueSize=64/numRangeKeys=0-24         44.6MB/s ± 2%  45.1MB/s ± 3%     ~     (p=0.256 n=10+10)
MVCCScan_Pebble/rows=10/versions=1/valueSize=64/numRangeKeys=1-24         29.2MB/s ± 2%  29.4MB/s ± 2%     ~     (p=0.356 n=9+10)
MVCCScan_Pebble/rows=10/versions=1/valueSize=64/numRangeKeys=100-24       5.88MB/s ± 2%  6.55MB/s ± 2%  +11.38%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=10/versions=2/valueSize=64/numRangeKeys=0-24         34.5MB/s ± 2%  35.0MB/s ± 4%     ~     (p=0.055 n=8+10)
MVCCScan_Pebble/rows=10/versions=2/valueSize=64/numRangeKeys=1-24         23.2MB/s ± 4%  23.5MB/s ± 2%   +1.28%  (p=0.033 n=10+9)
MVCCScan_Pebble/rows=10/versions=2/valueSize=64/numRangeKeys=100-24       6.46MB/s ± 4%  7.21MB/s ± 1%  +11.71%  (p=0.000 n=10+9)
MVCCScan_Pebble/rows=10/versions=10/valueSize=64/numRangeKeys=0-24        18.3MB/s ± 3%  18.5MB/s ± 2%     ~     (p=0.353 n=10+10)
MVCCScan_Pebble/rows=10/versions=10/valueSize=64/numRangeKeys=1-24        12.7MB/s ± 2%  12.7MB/s ± 2%     ~     (p=0.826 n=9+10)
MVCCScan_Pebble/rows=10/versions=10/valueSize=64/numRangeKeys=100-24      5.02MB/s ± 3%  5.41MB/s ± 4%   +7.87%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=10/versions=100/valueSize=64/numRangeKeys=0-24       7.28MB/s ± 3%  7.31MB/s ± 3%     ~     (p=0.643 n=10+10)
MVCCScan_Pebble/rows=10/versions=100/valueSize=64/numRangeKeys=1-24       6.03MB/s ± 2%  5.97MB/s ± 3%     ~     (p=0.283 n=8+10)
MVCCScan_Pebble/rows=10/versions=100/valueSize=64/numRangeKeys=100-24     3.19MB/s ± 4%  3.45MB/s ± 2%   +8.22%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=0-24         135MB/s ± 3%   136MB/s ± 1%     ~     (p=0.720 n=10+9)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=1-24        94.0MB/s ± 1%  94.4MB/s ± 2%     ~     (p=0.211 n=9+10)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=100-24      38.2MB/s ± 3%  40.4MB/s ± 1%   +5.63%  (p=0.000 n=10+9)
MVCCScan_Pebble/rows=100/versions=2/valueSize=64/numRangeKeys=0-24         101MB/s ± 2%   102MB/s ± 1%     ~     (p=0.123 n=10+10)
MVCCScan_Pebble/rows=100/versions=2/valueSize=64/numRangeKeys=1-24        68.3MB/s ± 1%  68.9MB/s ± 4%     ~     (p=0.082 n=9+10)
MVCCScan_Pebble/rows=100/versions=2/valueSize=64/numRangeKeys=100-24      35.9MB/s ± 2%  37.6MB/s ± 1%   +4.70%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=100/versions=10/valueSize=64/numRangeKeys=0-24       39.8MB/s ± 2%  39.3MB/s ± 3%     ~     (p=0.255 n=10+10)
MVCCScan_Pebble/rows=100/versions=10/valueSize=64/numRangeKeys=1-24       26.0MB/s ± 2%  25.9MB/s ± 2%     ~     (p=0.496 n=10+9)
MVCCScan_Pebble/rows=100/versions=10/valueSize=64/numRangeKeys=100-24     17.2MB/s ± 3%  17.6MB/s ± 3%   +2.58%  (p=0.002 n=10+9)
MVCCScan_Pebble/rows=100/versions=100/valueSize=64/numRangeKeys=0-24      12.2MB/s ± 4%  12.0MB/s ± 2%   -1.52%  (p=0.030 n=10+10)
MVCCScan_Pebble/rows=100/versions=100/valueSize=64/numRangeKeys=1-24      9.90MB/s ± 3%  9.76MB/s ± 4%     ~     (p=0.085 n=10+10)
MVCCScan_Pebble/rows=100/versions=100/valueSize=64/numRangeKeys=100-24    7.21MB/s ± 3%  7.18MB/s ± 3%     ~     (p=0.697 n=10+10)
MVCCScan_Pebble/rows=1000/versions=1/valueSize=64/numRangeKeys=0-24        189MB/s ± 2%   189MB/s ± 2%     ~     (p=0.912 n=10+10)
MVCCScan_Pebble/rows=1000/versions=1/valueSize=64/numRangeKeys=1-24        129MB/s ± 2%   131MB/s ± 2%   +1.73%  (p=0.004 n=10+9)
MVCCScan_Pebble/rows=1000/versions=1/valueSize=64/numRangeKeys=100-24     91.3MB/s ± 0%  93.3MB/s ± 2%   +2.20%  (p=0.000 n=8+10)
MVCCScan_Pebble/rows=1000/versions=2/valueSize=64/numRangeKeys=0-24        137MB/s ± 2%   138MB/s ± 2%     ~     (p=0.127 n=10+10)
MVCCScan_Pebble/rows=1000/versions=2/valueSize=64/numRangeKeys=1-24       91.2MB/s ± 2%  91.1MB/s ± 3%     ~     (p=0.912 n=10+10)
MVCCScan_Pebble/rows=1000/versions=2/valueSize=64/numRangeKeys=100-24     71.6MB/s ± 3%  73.4MB/s ± 3%   +2.50%  (p=0.006 n=9+10)
MVCCScan_Pebble/rows=1000/versions=10/valueSize=64/numRangeKeys=0-24      46.6MB/s ± 2%  47.4MB/s ± 2%   +1.66%  (p=0.008 n=10+10)
MVCCScan_Pebble/rows=1000/versions=10/valueSize=64/numRangeKeys=1-24      29.9MB/s ± 2%  30.1MB/s ± 2%     ~     (p=0.128 n=10+10)
MVCCScan_Pebble/rows=1000/versions=10/valueSize=64/numRangeKeys=100-24    23.2MB/s ± 5%  23.8MB/s ± 4%   +2.60%  (p=0.022 n=10+10)
MVCCScan_Pebble/rows=1000/versions=100/valueSize=64/numRangeKeys=0-24     13.9MB/s ± 3%  13.8MB/s ± 2%     ~     (p=0.078 n=10+8)
MVCCScan_Pebble/rows=1000/versions=100/valueSize=64/numRangeKeys=1-24     11.3MB/s ± 2%  11.0MB/s ± 3%   -2.29%  (p=0.003 n=10+10)
MVCCScan_Pebble/rows=1000/versions=100/valueSize=64/numRangeKeys=100-24   8.86MB/s ± 3%  8.72MB/s ± 3%   -1.52%  (p=0.045 n=10+10)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=0-24       206MB/s ± 2%   209MB/s ± 1%   +1.77%  (p=0.001 n=10+10)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=1-24       139MB/s ± 2%   142MB/s ± 2%   +2.73%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=100-24     114MB/s ± 3%   116MB/s ± 1%   +1.25%  (p=0.032 n=10+8)
MVCCScan_Pebble/rows=10000/versions=2/valueSize=64/numRangeKeys=0-24       148MB/s ± 2%   148MB/s ± 2%     ~     (p=1.000 n=9+10)
MVCCScan_Pebble/rows=10000/versions=2/valueSize=64/numRangeKeys=1-24      96.7MB/s ± 2%  98.2MB/s ± 3%   +1.56%  (p=0.029 n=10+10)
```