### PR TITLE
[crl-release-22.2] *: Set isIgnorableBoundaryKey=true for rangedel boundaries in levelIter

### DIFF
--- a/iterator_histories_test.go
+++ b/iterator_histories_test.go
@@ -169,6 +169,11 @@ func TestIterHistories(t *testing.T) {
 					return fmt.Sprintf("committed %d keys\n", count)
 				}
 				return fmt.Sprintf("wrote %d keys to batch %q\n", count, name)
+			case "compact":
+				if err := runCompactCmd(td, d); err != nil {
+					return err.Error()
+				}
+				return runLSMCmd(td, d)
 			case "flush":
 				err := d.Flush()
 				if err != nil {
@@ -294,6 +299,8 @@ func TestIterHistories(t *testing.T) {
 						o.PointKeyFilters = []sstable.BlockPropertyFilter{
 							sstable.NewTestKeysBlockPropertyFilter(min, max),
 						}
+					case "use-l6-filter":
+						o.UseL6Filters = true
 					}
 				}
 				var iter *Iterator

--- a/level_iter.go
+++ b/level_iter.go
@@ -901,6 +901,9 @@ func (l *levelIter) skipEmptyFileForward() (*InternalKey, []byte) {
 			// If the boundary is a range deletion tombstone, return that key.
 			if l.iterFile.LargestPointKey.Kind() == InternalKeyKindRangeDelete {
 				l.largestBoundary = &l.iterFile.LargestPointKey
+				if l.boundaryContext != nil {
+					l.boundaryContext.isIgnorableBoundaryKey = true
+				}
 				return l.largestBoundary, nil
 			}
 			// If the last point iterator positioning op might've skipped keys,

--- a/testdata/iter_histories/iter_optimizations
+++ b/testdata/iter_histories/iter_optimizations
@@ -373,3 +373,93 @@ seek-prefix-ge c@8
 .
 lastPositioningOp="seekprefixge"
 c@4: (c@4, .)
+
+# Regression test for #2118, where a MERGE pushes child iterators to the next
+# key, and possibly past a file that contained a range tombstone that we
+# should have paused at in a SeekPrefixGE, affecting future TrySeekUsingNexts.
+# This test constructs this example (suffixes ignored), where square brackets
+# consist of one SST:
+#
+# L0: [(b, MERGE)  (c-d, RANGEDEL)] [(m, DEL)]
+# L6: [(c, SET) (c-e, RANGEKEYSET)] [(j, SET)]
+#
+# We create an iterator with L6 filters enabled and create relatively large
+# bloom filter blocks to reduce the false positive rate. Then we SeekPrefixGE(b)
+# and end up with the L0 levelIter landing on the (b, MERGE), and the L6 iterator
+# is exhausted as no SST filter blocks match the prefix. The top-level iterator
+# then Next()s to find the next internal key at b if there is any, we land
+# on the pause key at (d, RANGEDELSENTINEL). Crucially since there are no
+# more items in the mergingIter heap and the merging iter is set to elide
+# range tombstones, we Next() the level iter again as part of the same top-level
+# iterator Next(), and land on (m, DEL). The type of the key here doesn't really
+# matter.
+#
+# We then do a SeekPrefixGE(c), and since c > b, in the buggy scenario we
+# TrySeekUsingNext. The bottom levelIter correctly finds the sstable containing
+# the set, but the upper levelIter is already past the sstable containing the
+# rangedel, so it just returns (m, DEL) again, and we surface the (c, SET) that
+# should have been deleted.
+
+reset bloom-bits-per-key=100
+----
+
+batch commit
+set c@2 foo
+range-key-set c e @5 bar
+----
+committed 2 keys
+
+flush
+----
+
+compact a-z
+----
+6:
+  000005:[c#2,RANGEKEYSET-e#72057594037927935,RANGEKEYSET]
+
+batch commit
+set j k
+----
+committed 1 keys
+
+flush
+----
+
+compact a-z
+----
+6:
+  000005:[c#2,RANGEKEYSET-e#72057594037927935,RANGEKEYSET]
+  000007:[j#3,SET-j#3,SET]
+
+batch commit
+del-range c@2 d
+merge b@2 g
+----
+committed 2 keys
+
+flush
+----
+
+batch commit
+del m
+----
+committed 1 keys
+
+flush
+----
+
+lsm
+----
+0.0:
+  000009:[b@2#5,MERGE-d#72057594037927935,RANGEDEL]
+  000011:[m#6,DEL-m#6,DEL]
+6:
+  000005:[c#2,RANGEKEYSET-e#72057594037927935,RANGEKEYSET]
+  000007:[j#3,SET-j#3,SET]
+
+combined-iter upper=z@3 mask-suffix=@3 mask-filter use-l6-filter
+seek-prefix-ge b@2
+seek-prefix-ge c@2
+----
+b@2: (g, .)
+c@2: (., [c-"c\x00") @5=bar UPDATED)

--- a/testdata/merging_iter
+++ b/testdata/merging_iter
@@ -37,9 +37,9 @@ stats
 ----
 a#30,1:30
 c#27,1:27
-e#72057594037927935,15:
 e#10,1:10
 g#20,1:20
+.
 {BlockBytes:116 BlockBytesInCache:0 KeyBytes:5 ValueBytes:8 PointCount:5 PointsCoveredByRangeTombstones:0}
 {BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 
@@ -49,9 +49,9 @@ seek-ge d
 next
 next
 ----
-e#72057594037927935,15:
 e#10,1:10
 g#20,1:20
+.
 
 # isPrevEntryDeleted() should not allow the rangedel to act on the points in the lower sstable
 # that are after it.
@@ -273,9 +273,9 @@ next
 ----
 a#30,1:30
 c#27,1:27
-e#72057594037927935,15:
 e#10,1:10
 g#20,1:20
+.
 
 # Verify that switching directions respects lower/upper bound.
 
@@ -425,10 +425,10 @@ next
 a#2,1:2
 a#0,1:1
 b#0,1:1
-e#72057594037927935,15:
 e#0,1:1
 f#3,1:3
 f#0,1:1
+.
 .
 
 iter
@@ -586,7 +586,7 @@ a#30,1:30
 {BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0}
 f#21,1:21
 {BlockBytes:0 BlockBytesInCache:0 KeyBytes:5 ValueBytes:10 PointCount:5 PointsCoveredByRangeTombstones:4}
-g#72057594037927935,15:
+.
 {BlockBytes:0 BlockBytesInCache:0 KeyBytes:6 ValueBytes:10 PointCount:6 PointsCoveredByRangeTombstones:4}
 .
 {BlockBytes:0 BlockBytesInCache:0 KeyBytes:6 ValueBytes:10 PointCount:6 PointsCoveredByRangeTombstones:4}


### PR DESCRIPTION
Backport of #2123

----

Merge keys put the top level Iterator's position to `iterPosNext`, and in the process of Next()ing to the next user key, one of the child levelIters could have advanced past the sstable that contained the Merge that is being returned.

If that sstable contained a range delete covering a key in an sstable in a lower level, and the lower level's key was not exposed to the mergingIter due to a bloom filter mismatch, and we do two consecutive SeekPrefixGEs where the second one gets TrySeekUsingNext, we could end up surfacing the deleted key in the lower sstable as the higher level's levelIter has already moved past the sstable containing the range deletion.

This change sets isIgnorableBoundaryKey = true when returning largestBoundary in the levelIter to prevent the mergingIter from next()ing past it in the first SeekPrefixGE.

Fixes #2118.