### PR TITLE
metamorphic: prevent directory collisions

### DIFF
--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -314,9 +314,10 @@ func TestMeta(t *testing.T) {
 		seed = uint64(time.Now().UnixNano())
 	}
 
-	// Cleanup any previous state.
-	metaDir := filepath.Join(*dir, time.Now().Format("060102-150405.000"))
-	require.NoError(t, os.RemoveAll(metaDir))
+	// Create a directory for test state.
+	require.NoError(t, os.MkdirAll(*dir, 0755))
+	metaDir, err := os.MkdirTemp(*dir, time.Now().Format("060102-150405.000"))
+	require.NoError(t, err)
 	require.NoError(t, os.MkdirAll(metaDir, 0755))
 	defer func() {
 		if !t.Failed() && !*keep {


### PR DESCRIPTION
Previously, if two metamorphic tests were started simulatneously, they could use the same directory because test directories were a function only of time. Fix this by using os.MkdirTemp, which guarantees that concurrent callers will not choose the same directory.

Fix #2125.
Fix #2126.