### PR TITLE
crl-release-21.2: metamorphic: prevent directory collisions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - "1.15"
           - "1.16"
           - "1.17"
     steps:

--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -178,9 +178,10 @@ func TestMeta(t *testing.T) {
 		seed = uint64(time.Now().UnixNano())
 	}
 
-	// Cleanup any previous state.
-	metaDir := filepath.Join(*dir, time.Now().Format("060102-150405.000"))
-	require.NoError(t, os.RemoveAll(metaDir))
+	// Create a directory for test state.
+	require.NoError(t, os.MkdirAll(*dir, 0755))
+	metaDir, err := os.MkdirTemp(*dir, time.Now().Format("060102-150405.000"))
+	require.NoError(t, err)
 	require.NoError(t, os.MkdirAll(metaDir, 0755))
 	defer func() {
 		if !t.Failed() && !*keep {


### PR DESCRIPTION
Backport of #2135.

----

Previously, if two metamorphic tests were started simultaneously, they could use the same directory because test directories were a function only of time. Fix this by using os.MkdirTemp, which guarantees that concurrent callers will not choose the same directory.