### PR TITLE
merging_iter: don't relative-seek past prefix in isNextEntryDeleted

### DIFF
--- a/testdata/iter_histories/iter_optimizations
+++ b/testdata/iter_histories/iter_optimizations
@@ -625,3 +625,99 @@ seek-prefix-ge c@2
 ----
 b@2: (g, .)
 c@2: (., [c-"c\x00") @5=bar UPDATED)
+
+# Regression test for Cockroachdb#92205. This test constructs this scenario:
+#
+# A DEL in a middle level (L0.0) that we SeekPrefixGE directly for. Note that
+# this DEL is not deleted by any range deletes; it gets exposed to the
+# Iterator. There's a key after this DEL in the L0.0 levelIter, and there's a
+# level above it (L0.1) that has a rangedel deleting that key, but not the DEL
+# we SeekPrefixGE for. In the lowest level, there's a SET at L6 that is to the
+# right of the DEL in L0.0, but is also not deleted by the RANGEDEL in L0.1.
+# Our second SeekPrefixGE will be for this SET. Visualization, where square
+# brackets are files:
+#
+# L0.1                 [dd-ee#RANGEDEL]
+# L0.0    [b#DEL          e#SET]
+# L6            [d#SET]       [f#SET g#SET]
+#
+# When the Iterator encounters the above DEL internal key in the SeekPrefixGE, it
+# calls Iterator.nextUserKey in the Iterator.findNextEntry call that was part of the
+# SeekPrefixGE call. While Iterator.findNextEntry has a conditional to exit
+# out of the loop if we're in prefix iteration and have gone past the prefix,
+# this break only happens _after_ nextUserKey() has run. As a result we Next()
+# the levelIter in L0.0, land on e#SET, and the mergingIter realizes that it
+# is deleted by the rangedel in a higher level (L0.1). The mergingIter does not
+# see d#SET because that sstable was excluded by the bloom filter. We then do a relative
+# seek of all levels below L0.1 to ee (the end key of the rangedel), and in that
+# process we advance the L6 levelIter to the second file.
+#
+# When we do the second SeekPrefixGE for d, the outer Iterator thinks d > b and
+# so TrySeekUsingNext can work. However, the L6 levelIter has already advanced
+# past the file containing d#SET, so we don't surface it even though we should
+# have.
+
+reset bloom-bits-per-key=100
+----
+
+batch commit
+set d@4 foo
+----
+committed 1 keys
+
+flush
+----
+
+compact a-f
+----
+6:
+  000005:[d@4#1,SET-d@4#1,SET]
+
+batch commit
+set f@5 bar
+set g@5 baz
+----
+committed 2 keys
+
+flush
+----
+
+compact e-k
+----
+6:
+  000005:[d@4#1,SET-d@4#1,SET]
+  000007:[f@5#2,SET-g@5#3,SET]
+
+batch commit
+del b@5
+set e@4 foobar
+----
+committed 2 keys
+
+flush
+----
+
+batch commit
+del-range dd ee
+----
+committed 1 keys
+
+flush
+----
+
+lsm
+----
+0.1:
+  000011:[dd#6,RANGEDEL-ee#72057594037927935,RANGEDEL]
+0.0:
+  000009:[b@5#4,DEL-e@4#5,SET]
+6:
+  000005:[d@4#1,SET-d@4#1,SET]
+  000007:[f@5#2,SET-g@5#3,SET]
+
+combined-iter upper=z@3 use-l6-filter
+seek-prefix-ge b@6
+seek-prefix-ge d@5
+----
+.
+d@4: (foo, .)

--- a/testdata/merging_iter
+++ b/testdata/merging_iter
@@ -540,8 +540,8 @@ seek-prefix-ge c true
 seek-prefix-ge d true
 ----
 a#10,1:a10
-.
-.
+d#10,1:d10
+d#10,1:d10
 d#10,1:d10
 d#10,1:d10
 
@@ -553,8 +553,8 @@ seek-prefix-ge d true
 next
 ----
 a#10,1:a10
-.
-.
+d#10,1:d10
+d#10,1:d10
 d#10,1:d10
 .
 


### PR DESCRIPTION
Doing a TrySeekUsingNext during a SeekPrefixGE is incorrect if the
last SeekPrefixGE did a relative seek to the end of a rangedel tombstone
in the merging iter as part of the process of finding a visible user key.
This is because there could have been a visible key in between
our seek prefix and the start of the rangedel, that was not visible to us
due to a bloom filter mismatch, but will become visible on the second
SeekPrefixGE.

This change avoids this bug by removing any merging iter levels below a
range tombstone if the end of the range tombstone is past the prefix.

Fixes https://github.com/cockroachdb/cockroach/issues/92205. Fixes https://github.com/cockroachdb/pebble/issues/2150.