### PR TITLE
db: change LazyFetcher.ValueFetcher to an interface

### DIFF
--- a/sstable/value_block.go
+++ b/sstable/value_block.go
@@ -733,7 +733,7 @@ func (r *valueBlockReader) getLazyValueForPrefixAndValueHandle(handle []byte) ba
 	fetcher := &r.lazyFetcher
 	valLen, h := decodeLenFromValueHandle(handle[1:])
 	*fetcher = base.LazyFetcher{
-		ValueFetcher: r.getValue,
+		Fetcher: r,
 		Attribute: base.AttributeAndLen{
 			ValueLen:       int32(valLen),
 			ShortAttribute: getShortAttribute(valuePrefix(handle[0])),
@@ -764,7 +764,8 @@ func (r *valueBlockReader) close() {
 	// implemented.
 }
 
-func (r *valueBlockReader) getValue(
+// Fetch implements base.ValueFetcher.
+func (r *valueBlockReader) Fetch(
 	handle []byte, valLen int32, buf []byte,
 ) (val []byte, callerOwned bool, err error) {
 	if !r.closed {


### PR DESCRIPTION
It used to be a func, which meant that every assignment that used valueBlockReader.getValue caused an allocation for the closure. By changing to an interface, the two words needed for the interface representation are included in the LazyFetcher struct. And since valueBlockReader is already on the heap, there are no allocations.

The IteratorScanManyVersions benchmark is added and shows a significant improvement for v3 (old is master). Additionally, for a cache-size that results in poor cache hit rate for the whole sstable (20M), the new time for v3 (18.1ns) is significantly better than v2 (27.4ns), since the former has very little data in the data blocks. In contrast, the v2 iteration needs to repeatedly do block memory allocations and checksum checking (there is no real IO due to the use of MemFS, and the random value results in no compression, hence no decompression overhead). With the 150M cache, v2 (12.7ns) is better than v3 (15.7ns) -- the difference is due to the need to construct a LazyValue by calling
valueBlockReader.getLazyValueForPrefixAndValueHandle.

```
name                                                             old time/op    new time/op    delta
IteratorScanManyVersions/format=(Pebble,v2)/cache-size=20_M-10     27.5ns ± 0%    27.4ns ± 0%      ~     (p=0.079 n=5+5)
IteratorScanManyVersions/format=(Pebble,v2)/cache-size=150_M-10    12.7ns ± 1%    12.7ns ± 1%      ~     (p=0.460 n=5+5)
IteratorScanManyVersions/format=(Pebble,v3)/cache-size=20_M-10     33.6ns ± 1%    18.1ns ± 0%   -46.31%  (p=0.008 n=5+5)
IteratorScanManyVersions/format=(Pebble,v3)/cache-size=150_M-10    31.3ns ± 1%    15.7ns ± 0%   -49.80%  (p=0.008 n=5+5)

name                                                             old alloc/op   new alloc/op   delta
IteratorScanManyVersions/format=(Pebble,v2)/cache-size=20_M-10      0.00B          0.00B           ~     (all equal)
IteratorScanManyVersions/format=(Pebble,v2)/cache-size=150_M-10     0.00B          0.00B           ~     (all equal)
IteratorScanManyVersions/format=(Pebble,v3)/cache-size=20_M-10      15.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
IteratorScanManyVersions/format=(Pebble,v3)/cache-size=150_M-10     15.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
```

Informs #1170