### PR TITLE
crossversion: allow run dir to not exist

### DIFF
--- a/internal/metamorphic/crossversion/crossversion_test.go
+++ b/internal/metamorphic/crossversion/crossversion_test.go
@@ -25,6 +25,7 @@ import (
 	"unicode"
 
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/pebble/internal/metamorphic"
 	"github.com/stretchr/testify/require"
 )
@@ -265,7 +266,12 @@ func fatalf(t testing.TB, dir string, msg string, args ...interface{}) {
 	}
 	dst := filepath.Join(artifactsDir, filepath.Base(dir))
 	t.Logf("Moving test dir %q to %q.", dir, dst)
-	require.NoError(t, os.Rename(dir, dst))
+	err := os.Rename(dir, dst)
+	// If the run of the metamorphic test panics or otherwise exits uncleanly,
+	// the source directory may not exist.
+	if !oserror.IsNotExist(err) {
+		t.Error(err)
+	}
 	t.Fatalf(msg, args...)
 }
 


### PR DESCRIPTION
The crossversion metamorphic tests run the individual metamorphic tests with the `--keep` flag, to preserve the data directory after the test runs. When a test fails and fatalf is invoked, the corssversion tests copy the relevant directory into the artifacts. However, if a metamorphic test fails before it's able to write the run data directory, this directory won't exist.

This bug is not the reason for the recent crossversion metamorphic test failures (#2143, #2144), but it's made the issue more difficult to diagnose.