### PR TITLE
internal: Allow building on riscv64 architecture

### DIFF
--- a/internal/manual/manual_64bit.go
+++ b/internal/manual/manual_64bit.go
@@ -2,8 +2,8 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-//go:build amd64 || arm64 || arm64be || ppc64 || ppc64le || mips64 || mips64le || s390x || sparc64
-// +build amd64 arm64 arm64be ppc64 ppc64le mips64 mips64le s390x sparc64
+//go:build amd64 || arm64 || arm64be || ppc64 || ppc64le || mips64 || mips64le || s390x || sparc64 || riscv64
+// +build amd64 arm64 arm64be ppc64 ppc64le mips64 mips64le s390x sparc64 riscv64
 
 package manual
 

--- a/internal/rawalloc/rawalloc_64bit.go
+++ b/internal/rawalloc/rawalloc_64bit.go
@@ -12,8 +12,8 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-//go:build amd64 || arm64 || arm64be || ppc64 || ppc64le || mips64 || mips64le || s390x || sparc64
-// +build amd64 arm64 arm64be ppc64 ppc64le mips64 mips64le s390x sparc64
+//go:build amd64 || arm64 || arm64be || ppc64 || ppc64le || mips64 || mips64le || s390x || sparc64 || riscv64
+// +build amd64 arm64 arm64be ppc64 ppc64le mips64 mips64le s390x sparc64 riscv64
 
 package rawalloc
 


### PR DESCRIPTION
This PR adds `riscv64` to the 64bit build tags, in order to allow building Pebble on 64-bit RISC-V CPUs. All tests are passing on riscv64:

```
ok  	github.com/cockroachdb/pebble	93.903s
ok  	github.com/cockroachdb/pebble/bloom	0.245s
?   	github.com/cockroachdb/pebble/cmd/pebble	[no test files]
?   	github.com/cockroachdb/pebble/internal/ackseq	[no test files]
ok  	github.com/cockroachdb/pebble/internal/arenaskl	0.435s
ok  	github.com/cockroachdb/pebble/internal/base	0.211s
ok  	github.com/cockroachdb/pebble/internal/batchskl	0.335s
?   	github.com/cockroachdb/pebble/internal/bytealloc	[no test files]
ok  	github.com/cockroachdb/pebble/internal/cache	1.502s
?   	github.com/cockroachdb/pebble/internal/crc	[no test files]
ok  	github.com/cockroachdb/pebble/internal/datadriven	0.151s
?   	github.com/cockroachdb/pebble/internal/errorfs	[no test files]
ok  	github.com/cockroachdb/pebble/internal/fastrand	0.081s [no tests to run]
?   	github.com/cockroachdb/pebble/internal/humanize	[no test files]
ok  	github.com/cockroachdb/pebble/internal/intern	0.101s
?   	github.com/cockroachdb/pebble/internal/invariants	[no test files]
ok  	github.com/cockroachdb/pebble/internal/keyspan	1.517s
ok  	github.com/cockroachdb/pebble/internal/lint	35.749s
ok  	github.com/cockroachdb/pebble/internal/manifest	23.583s
?   	github.com/cockroachdb/pebble/internal/manual	[no test files]
ok  	github.com/cockroachdb/pebble/internal/metamorphic	38.040s
ok  	github.com/cockroachdb/pebble/internal/metamorphic/crossversion	0.140s
ok  	github.com/cockroachdb/pebble/internal/mkbench	1.676s
?   	github.com/cockroachdb/pebble/internal/pacertoy/pebble	[no test files]
?   	github.com/cockroachdb/pebble/internal/pacertoy/rocksdb	[no test files]
?   	github.com/cockroachdb/pebble/internal/private	[no test files]
ok  	github.com/cockroachdb/pebble/internal/randvar	21.615s
?   	github.com/cockroachdb/pebble/internal/rangedel	[no test files]
ok  	github.com/cockroachdb/pebble/internal/rangekey	1.627s
ok  	github.com/cockroachdb/pebble/internal/rate	0.469s
ok  	github.com/cockroachdb/pebble/internal/rawalloc	0.078s [no tests to run]
ok  	github.com/cockroachdb/pebble/internal/testkeys	1.177s
?   	github.com/cockroachdb/pebble/rangekey	[no test files]
ok  	github.com/cockroachdb/pebble/record	15.577s
ok  	github.com/cockroachdb/pebble/replay	0.200s
ok  	github.com/cockroachdb/pebble/sstable	184.118s
ok  	github.com/cockroachdb/pebble/tool	0.891s
ok  	github.com/cockroachdb/pebble/tool/logs	0.230s
ok  	github.com/cockroachdb/pebble/vfs	3.998s
ok  	github.com/cockroachdb/pebble/vfs/atomicfs	0.170s
```