### PR TITLE
sstable: don't fatal if file no longer exists during readahead

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -2897,12 +2897,6 @@ func (r *Reader) readBlock(
 						raState.sequentialFile = f
 						file = f
 					}
-
-					// If we tried to load a table that doesn't exist, panic
-					// immediately.  Something is seriously wrong if a table
-					// doesn't exist.
-					// See cockroachdb/cockroach#56490.
-					base.MustExist(r.fs, r.filename, panicFataler{}, err)
 				}
 			}
 			if raState.sequentialFile == nil {
@@ -3784,10 +3778,4 @@ func (l *Layout) Describe(
 
 	last := blocks[len(blocks)-1]
 	fmt.Fprintf(w, "%10d  EOF\n", last.Offset+last.Length)
-}
-
-type panicFataler struct{}
-
-func (panicFataler) Fatalf(format string, args ...interface{}) {
-	panic(errors.Errorf(format, args...))
 }


### PR DESCRIPTION
Previously, we had inconsistent handling of errors encountered while opening a new file for OS-level readahead. If the error indicated the file did not exist, we panicked. Otherwise, we continued unperturbed. This commit removes the unnecessary fataling of ENOTEXIST errors (cockroachdb/cockroach#79801), which isn't appropriate in this case which may happen when using a sstable.Reader outside the context of a running pebble.DB.

This panic site was particularly troublesome for Sentry reports because the error surfaced by the `panicFataler` would be redacted.

Fix cockroachdb/cockroach#79801.