### PR TITLE
crl-release-22.2: sstable: don't fatal if file no longer exists during readahead

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -2794,12 +2794,6 @@ func (r *Reader) readBlock(
 						raState.sequentialFile = f
 						file = f
 					}
-
-					// If we tried to load a table that doesn't exist, panic
-					// immediately.  Something is seriously wrong if a table
-					// doesn't exist.
-					// See cockroachdb/cockroach#56490.
-					base.MustExist(r.fs, r.filename, panicFataler{}, err)
 				}
 			}
 			if raState.sequentialFile == nil {
@@ -3574,10 +3568,4 @@ func (l *Layout) Describe(
 
 	last := blocks[len(blocks)-1]
 	fmt.Fprintf(w, "%10d  EOF\n", last.Offset+last.Length)
-}
-
-type panicFataler struct{}
-
-func (panicFataler) Fatalf(format string, args ...interface{}) {
-	panic(errors.Errorf(format, args...))
 }


### PR DESCRIPTION
22.2 backport of #2168. Backporting to try to stem the flow of unproductive Sentry reports.

----

Previously, we had inconsistent handling of errors encountered while opening a new file for OS-level readahead. If the error indicated the file did not exist, we panicked. Otherwise, we continued unperturbed. This commit removes the unnecessary fataling of ENOTEXIST errors (cockroachdb/cockroach#79801), which isn't appropriate in this case which may happen when using a sstable.Reader outside the context of a running pebble.DB.