### PR TITLE
db: refactor merging iterator's prefix handling for TrySeekUsingNext

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -779,8 +779,6 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 				return nil, errors.Errorf("%s: could not parse %q as float: %s", td.Cmd, arg.Vals[0], err)
 			}
 			opts.Experimental.PointTombstoneWeight = w
-		default:
-			return nil, errors.Errorf("%s: unknown arg: %s", td.Cmd, arg.Key)
 		}
 	}
 	d, err := Open("", opts)

--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -40,7 +40,9 @@ import "fmt"
 // context is not a strict byte prefix, but defined by byte equality for the
 // result of the Comparer.Split method. An InternalIterator is not required to
 // support prefix iteration mode, and can implement SeekPrefixGE by forwarding
-// to SeekGE.
+// to SeekGE. When the iteration prefix is exhausted, it is not valid to call
+// Next on an internal iterator that's already returned (nil,nilv) or a key
+// beyond the prefix.
 //
 // Bounds, [lower, upper), can be set on iterators, either using the SetBounds()
 // function in the interface, or in implementation specific ways during iterator

--- a/testdata/iter_histories/prefix_iteration
+++ b/testdata/iter_histories/prefix_iteration
@@ -296,3 +296,40 @@ next
 ----
 b@4: (b@4, .)
 .
+
+# Regression test for #2151.
+#
+# This test consists of two SeekPrefixGEs for ascending keys, which results in
+# TrySeekUsingNext()=true for the second seek. The entirety of both seeked
+# prefixes is deleted by the range deletion [b-d). The iterator being used is
+# created from a snapshot at sequence number #4. At that sequence number, the
+# iterator observes the range deletion and all of L6's point keys, but none of
+# the point keys in L5.
+#
+# Previously, a bug existed where the SeekPrefixGE("b@9") would cause the
+# iterator to next beyond the L5 sstable. The subsequent SeekPrefixGE with
+# TrySeekUsingNext would mistakenly miss the range deletion [b-d) because it had
+# already proceeded beyond the file.
+
+define snapshots=(4)
+L5
+  b.RANGEDEL.3:d
+  b@9.SET.9:v
+  c@9.SET.9:v
+  d@9.SET.9:v
+L6
+  b@2.SET.2:v
+  c@2.SET.2:v
+  d@2.SET.2:v
+----
+5:
+  000004:[b#3,RANGEDEL-d@9#9,SET]
+6:
+  000005:[b@2#2,SET-d@2#2,SET]
+
+combined-iter snapshot=4
+seek-prefix-ge b@9
+seek-prefix-ge c@9
+----
+.
+.

--- a/testdata/iterator
+++ b/testdata/iterator
@@ -127,7 +127,7 @@ seek-prefix-ge 1
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 0, tombstoned: 0))
 
 define
 a.DEL.2:
@@ -798,7 +798,7 @@ next
 a: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0))
 
 iter seq=4
 seek-prefix-ge a
@@ -816,7 +816,7 @@ next
 a: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0))
 
 iter seq=3
 seek-prefix-ge a
@@ -838,7 +838,7 @@ seek-prefix-ge 1
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned: 0))
 
 iter seq=3
 seek-prefix-ge a
@@ -878,7 +878,7 @@ a: (b, .)
 .
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 7, value-bytes 5, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 5, value-bytes 4, tombstoned: 0))
 
 iter seq=4
 seek-prefix-ge a
@@ -896,7 +896,7 @@ next
 a: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 7, value-bytes 5, tombstoned: 0))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 5, value-bytes 4, tombstoned: 0))
 
 iter seq=3
 seek-prefix-ge aa

--- a/testdata/merging_iter
+++ b/testdata/merging_iter
@@ -540,8 +540,8 @@ seek-prefix-ge c true
 seek-prefix-ge d true
 ----
 a#10,1:a10
-d#10,1:d10
-d#10,1:d10
+.
+.
 d#10,1:d10
 d#10,1:d10
 
@@ -553,8 +553,8 @@ seek-prefix-ge d true
 next
 ----
 a#10,1:a10
-d#10,1:d10
-d#10,1:d10
+.
+.
 d#10,1:d10
 .
 

--- a/testdata/merging_iter_seek
+++ b/testdata/merging_iter_seek
@@ -183,7 +183,7 @@ aaa.SET.2:2
 iter
 seek-prefix-ge a
 next
-next
+seek-prefix-ge aaa
 next
 ----
 a:0


### PR DESCRIPTION
Builds off of #2151. This commit refactors the merging iterator's
handling of prefix-related invariants for enabling TrySeekUsingNext
optimizations when using SeekPrefixGE.

The TrySeekUsingNext optimization notes successively larger seek keys,
and attempts to use next to find the appropriate key in the later seeks,
avoiding seeking from scratch. In a level's file metadata, we now use
the presence of the TrySeekUsingNext flag to signal that we can Next
through the file metadata. This saves key comparisons, especially in
larger LSMs with many files within a level.

Ever since the introduction of #2048, we've encountered a slew of
metamorphic test failures due to interactions between this optimization
and prefix iteration. We've made various fixes in #2087, #2111, #2123
and #2151.

Most of these failures revolve around the progression of a level
iterator beyond the iterator's current iteration prefix. This is
problematic, because the incomplete view of the LSM during prefix
iteration can result in inconsistent positioning outside of the current
iterator prefix. The internal iterators do not guarantee that keys or
range deletions outside the prefix are observed.

This commit fixes the latest instance of this (#2174), and attempts to
restructure the code to clarify the required invariants. Now, any method
that may advance the iterator during prefix iteration (eg, nextEntry or
isNextEntryDeleted) check that the iteration prefix has not already been
exceeded. This check is only performed when the merging iterator is
advancing internal iterators of its own volition (eg, due to non-visible
keys or keys deleted by range tombstones). It does NOT perform this
check when the top-level Iterator Nexts the merging iterator because
of a user Next, a point-delete, etc. This means these prefix checks are
only redundant with the top-level Iterator Nexts in two cases:

  a) the heap root is deleted by a range tombstone
  b) the heap root is not visible at the iterator's sequence number

Both of these cases are expected to be rare, and the redundant prefix
check is expected to be insignificant.

Additionally, to obey these new stricter invariants, the interleaving
iterator is adjusted to exhaust the iterator when the remainder of a
prefix is masked by a range key. Besides ensuring invariants are
respected, this change provides a large benefit to prefix iteration
within a large swath of masked point keys.

```
name                                                                     old time/op  new time/op  delta
Iterator_RangeKeyMasking/range-keys-suffixes=@10/forward/seekprefix-24   59.8ms ± 2%  60.3ms ± 2%   +0.92%  (p=0.013 n=25+25)
Iterator_RangeKeyMasking/range-keys-suffixes=@10/forward/next-24         4.50ms ± 6%  4.52ms ± 3%     ~     (p=0.388 n=25+24)
Iterator_RangeKeyMasking/range-keys-suffixes=@10/backward-24             5.64ms ± 7%  5.51ms ± 3%   -2.26%  (p=0.001 n=25+25)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/forward/seekprefix-24   64.0ms ± 5%  60.2ms ± 4%   -5.89%  (p=0.000 n=25+25)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/forward/next-24         4.11ms ± 3%  4.16ms ± 5%   +1.06%  (p=0.040 n=25+24)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/backward-24             4.94ms ± 3%  4.89ms ± 3%   -0.97%  (p=0.011 n=25+24)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/forward/seekprefix-24   69.0ms ± 2%  60.1ms ± 2%  -12.88%  (p=0.000 n=22+24)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/forward/next-24         2.55ms ± 2%  2.59ms ± 3%   +1.90%  (p=0.000 n=25+25)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/backward-24             3.20ms ± 2%  3.21ms ± 3%     ~     (p=0.418 n=25+25)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/forward/seekprefix-24   2.19s ± 3%   0.06s ± 2%  -97.27%  (p=0.000 n=24+25)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/forward/next-24         346µs ± 2%   346µs ± 2%     ~     (p=0.898 n=24+25)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/backward-24             687µs ± 3%   696µs ± 2%   +1.31%  (p=0.000 n=25+25)
```

Fix #2174.