### PR TITLE
*: use golang.org/x/sys package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/exp v0.0.0-20200513190911-00229845015e
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9
+	golang.org/x/sys v0.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -539,8 +539,9 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
+golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/vfs/errors_unix.go
+++ b/vfs/errors_unix.go
@@ -8,13 +8,11 @@
 package vfs
 
 import (
-	"syscall"
-
 	"github.com/cockroachdb/errors"
 	"golang.org/x/sys/unix"
 )
 
-var errNotEmpty = syscall.ENOTEMPTY
+var errNotEmpty = unix.ENOTEMPTY
 
 // IsNoSpaceError returns true if the given error indicates that the disk is
 // out of space.

--- a/vfs/file_lock_unix.go
+++ b/vfs/file_lock_unix.go
@@ -11,9 +11,9 @@ import (
 	"io"
 	"os"
 	"sync"
-	"syscall"
 
 	"github.com/cockroachdb/errors"
+	"golang.org/x/sys/unix"
 )
 
 var lockedFiles struct {
@@ -54,14 +54,14 @@ func (defaultFS) Lock(name string) (io.Closer, error) {
 	if err != nil {
 		return nil, err
 	}
-	spec := syscall.Flock_t{
-		Type:   syscall.F_WRLCK,
+	spec := unix.Flock_t{
+		Type:   unix.F_WRLCK,
 		Whence: io.SeekStart,
 		Start:  0,
 		Len:    0, // 0 means to lock the entire file.
 		Pid:    int32(os.Getpid()),
 	}
-	if err := syscall.FcntlFlock(f.Fd(), syscall.F_SETLK, &spec); err != nil {
+	if err := unix.FcntlFlock(f.Fd(), unix.F_SETLK, &spec); err != nil {
 		f.Close()
 		return nil, err
 	}

--- a/vfs/file_lock_windows.go
+++ b/vfs/file_lock_windows.go
@@ -9,29 +9,30 @@ package vfs
 
 import (
 	"io"
-	"syscall"
+
+	"golang.org/x/sys/windows"
 )
 
-// lockCloser hides all of an syscall.Handle's methods, except for Close.
+// lockCloser hides all of an windows.Handle's methods, except for Close.
 type lockCloser struct {
-	fd syscall.Handle
+	fd windows.Handle
 }
 
 func (l lockCloser) Close() error {
-	return syscall.Close(l.fd)
+	return windows.Close(l.fd)
 }
 
 // Lock locks the given file. On Windows, Locking will fail if the file is
 // already open by the current process.
 func (defaultFS) Lock(name string) (io.Closer, error) {
-	p, err := syscall.UTF16PtrFromString(name)
+	p, err := windows.UTF16PtrFromString(name)
 	if err != nil {
 		return nil, err
 	}
-	fd, err := syscall.CreateFile(p,
-		syscall.GENERIC_READ|syscall.GENERIC_WRITE,
-		0, nil, syscall.CREATE_ALWAYS,
-		syscall.FILE_ATTRIBUTE_NORMAL,
+	fd, err := windows.CreateFile(p,
+		windows.GENERIC_READ|windows.GENERIC_WRITE,
+		0, nil, windows.CREATE_ALWAYS,
+		windows.FILE_ATTRIBUTE_NORMAL,
 		0,
 	)
 	if err != nil {

--- a/vfs/preallocate_linux.go
+++ b/vfs/preallocate_linux.go
@@ -17,12 +17,8 @@
 
 package vfs
 
-import (
-	"syscall"
-
-	"golang.org/x/sys/unix"
-)
+import "golang.org/x/sys/unix"
 
 func preallocExtend(fd uintptr, offset, length int64) error {
-	return syscall.Fallocate(int(fd), unix.FALLOC_FL_KEEP_SIZE, offset, length)
+	return unix.Fallocate(int(fd), unix.FALLOC_FL_KEEP_SIZE, offset, length)
 }

--- a/vfs/prefetch_linux.go
+++ b/vfs/prefetch_linux.go
@@ -7,12 +7,12 @@
 
 package vfs
 
-import "syscall"
+import "golang.org/x/sys/unix"
 
 // Prefetch signals the OS (on supported platforms) to fetch the next size
 // bytes in file (as returned by os.File.Fd()) after offset into cache. Any
 // subsequent reads in that range will not issue disk IO.
 func Prefetch(file uintptr, offset uint64, size uint64) error {
-	_, _, err := syscall.Syscall(syscall.SYS_READAHEAD, uintptr(file), uintptr(offset), uintptr(size))
+	_, _, err := unix.Syscall(unix.SYS_READAHEAD, uintptr(file), uintptr(offset), uintptr(size))
 	return err
 }


### PR DESCRIPTION
Ever since Go 1.4 [1], the syscall package has been deprecated, replaced by golang.org/x/sys's platform-dependent packages. Update existing call sites to use these syscall entrypoints.

This commit should not have any functional changes.

[1] https://go.dev/doc/go1.4#major_library_changes