### PR TITLE
bench: add --max-size flag

### DIFF
--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -19,6 +19,7 @@ var (
 	concurrency     int
 	disableWAL      bool
 	duration        time.Duration
+	maxSize         uint64
 	maxOpsPerSec    = newRateFlag("")
 	verbose         bool
 	waitCompactions bool
@@ -76,6 +77,8 @@ func main() {
 			"wait for background compactions to complete after load stops")
 		cmd.Flags().BoolVarP(
 			&wipe, "wipe", "w", false, "wipe the database before starting")
+		cmd.Flags().Uint64Var(
+			&maxSize, "max-size", 0, "maximum disk size, in MB (0, run forever)")
 	}
 
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/pebble/test.go
+++ b/cmd/pebble/test.go
@@ -329,6 +329,17 @@ func runTest(dir string, t test) {
 		close(workersDone)
 	}()
 
+	if maxSize > 0 {
+		go func() {
+			for {
+				time.Sleep(10 * time.Second)
+				if db.Metrics().DiskSpaceUsage() > maxSize*1e6 {
+					fmt.Println("max size reached")
+					done <- syscall.Signal(0)
+				}
+			}
+		}()
+	}
 	if duration > 0 {
 		go func() {
 			time.Sleep(duration)


### PR DESCRIPTION
This patch allows the bench user to specify a max disk size they'd like the benchmark to run until. If the --duration flag is also set, either the duration or max size can terminate the test.

Release note: None