### PR TITLE
db: set sequence numbers in datadriven DB define commands

### DIFF
--- a/testdata/format_major_version_split_user_key_migration
+++ b/testdata/format_major_version_split_user_key_migration
@@ -13,16 +13,16 @@ OK
 # atomic compaction unit, so use the force-ingest command to force an ingestion
 # into L1.
 
-build ef
-set e e
-set f f
+build cd
+set c c
+set d d
 ----
 
-force-ingest paths=(ef) level=1
+force-ingest paths=(cd) level=1
 ----
 1:
+  000008:[c#141,SET-d#141,SET] points:[c#141,SET-d#141,SET]
   000004:[d#110,SET-e#140,SET] points:[d#110,SET-e#140,SET]
-  000008:[e#1,SET-f#1,SET] points:[e#1,SET-f#1,SET]
 
 format-major-version
 ----
@@ -68,7 +68,7 @@ disable-automatic-compactions false
 
 ratchet-format-major-version 007
 ----
-[JOB 100] compacted(rewrite) L1 [000004 000008] (1.6 K) + L1 [] (0 B) -> L1 [000013] (786 B), in 1.0s (2.0s total), output rate 786 B/s
+[JOB 100] compacted(rewrite) L1 [000008 000004] (1.6 K) + L1 [] (0 B) -> L1 [000013] (786 B), in 1.0s (2.0s total), output rate 786 B/s
 
 format-major-version
 ----
@@ -77,7 +77,7 @@ format-major-version
 lsm
 ----
 1:
-  000013:[d#0,SET-f#0,SET]
+  000013:[c#0,SET-e#0,SET]
 
 # Reset to a new LSM.
 
@@ -99,24 +99,18 @@ set a a
 set b b
 ----
 
-build cd
-set c c
-set d d
-----
-
 build wx
 set w w
 set x x
 ----
 
-force-ingest paths=(ab, cd, wx) level=1
+force-ingest paths=(ab, wx) level=1
 ----
 1:
-  000007:[a#1,SET-b#1,SET] points:[a#1,SET-b#1,SET]
+  000007:[a#6,SET-b#6,SET] points:[a#6,SET-b#6,SET]
   000004:[b#0,SET-c#5,SET] points:[b#0,SET-c#5,SET]
-  000008:[c#2,SET-d#2,SET] points:[c#2,SET-d#2,SET]
   000005:[l#5,SET-m#0,SET] points:[l#5,SET-m#0,SET]
-  000009:[w#3,SET-x#3,SET] points:[w#3,SET-x#3,SET]
+  000008:[w#7,SET-x#7,SET] points:[w#7,SET-x#7,SET]
   000006:[x#0,SET-y#5,SET] points:[x#0,SET-y#5,SET]
 
 format-major-version
@@ -132,22 +126,22 @@ format-major-version
 
 marked-file-count
 ----
-5 files marked for compaction
+4 files marked for compaction
 
 disable-automatic-compactions false
 ----
 
 ratchet-format-major-version 007
 ----
-[JOB 100] compacted(rewrite) L1 [000007 000004 000008] (2.4 K) + L1 [] (0 B) -> L1 [000011] (794 B), in 1.0s (2.0s total), output rate 794 B/s
-[JOB 100] compacted(rewrite) L1 [000009 000006] (1.6 K) + L1 [] (0 B) -> L1 [000012] (786 B), in 1.0s (2.0s total), output rate 786 B/s
+[JOB 100] compacted(rewrite) L1 [000007 000004] (1.6 K) + L1 [] (0 B) -> L1 [000010] (786 B), in 1.0s (2.0s total), output rate 786 B/s
+[JOB 100] compacted(rewrite) L1 [000008 000006] (1.6 K) + L1 [] (0 B) -> L1 [000011] (786 B), in 1.0s (2.0s total), output rate 786 B/s
 
 lsm
 ----
 1:
-  000011:[a#0,SET-d#0,SET]
+  000010:[a#0,SET-c#0,SET]
   000005:[l#5,SET-m#0,SET]
-  000012:[w#0,SET-y#0,SET]
+  000011:[w#0,SET-y#0,SET]
 
 format-major-version
 ----

--- a/testdata/iter_histories/range_keys_simple
+++ b/testdata/iter_histories/range_keys_simple
@@ -461,3 +461,16 @@ b: (., [b-e) @1=foo UPDATED)
 a: (a, . UPDATED)
 c: (., [b-e) @1=foo UPDATED)
 b: (., [b-e) @1=foo)
+
+define
+L6
+a.RANGEDEL.3:z
+rangekey:b-d:{(#5,RANGEKEYSET,@2,foo)}
+----
+6:
+  000004:[a#3,RANGEDEL-z#72057594037927935,RANGEDEL]
+
+combined-iter
+seek-ge apple
+----
+b: (., [b-d) @2=foo UPDATED)

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -594,7 +594,7 @@ L1
   a.SET.3:3
   b.RANGEDEL.3:e
   b.SET.0:0
-  c.SET.1:1
+  c.SET.3:1
   d.SET.1:1
 L3
   c.RANGEDEL.2:d
@@ -1105,14 +1105,14 @@ set y y
 flush
 ----
 0.0:
-  000009:[b#1,SET-b#1,SET]
-  000010:[h#2,SET-h#2,SET]
-  000011:[i#3,SET-i#3,SET]
-  000012:[j#4,SET-j#4,SET]
-  000013:[k#5,SET-k#5,SET]
-  000014:[m#6,SET-m#6,SET]
-  000015:[q#7,SET-q#7,SET]
-  000016:[y#8,SET-y#8,SET]
+  000009:[b#2,SET-b#2,SET]
+  000010:[h#3,SET-h#3,SET]
+  000011:[i#4,SET-i#4,SET]
+  000012:[j#5,SET-j#5,SET]
+  000013:[k#6,SET-k#6,SET]
+  000014:[m#7,SET-m#7,SET]
+  000015:[q#8,SET-q#8,SET]
+  000016:[y#9,SET-y#9,SET]
 6:
   000006:[a#1,SET-g#72057594037927935,RANGEDEL]
   000007:[m#0,SET-m#0,SET]
@@ -1122,7 +1122,7 @@ flush
 compact g-z
 ----
 0.0:
-  000009:[b#1,SET-b#1,SET]
+  000009:[b#2,SET-b#2,SET]
 6:
   000006:[a#1,SET-g#72057594037927935,RANGEDEL]
   000049:[h#0,SET-k#0,SET]
@@ -1135,8 +1135,8 @@ set t t
 flush
 ----
 0.0:
-  000009:[b#1,SET-b#1,SET]
-  000052:[t#9,SET-t#9,SET]
+  000009:[b#2,SET-b#2,SET]
+  000052:[t#10,SET-t#10,SET]
 6:
   000006:[a#1,SET-g#72057594037927935,RANGEDEL]
   000049:[h#0,SET-k#0,SET]

--- a/testdata/manual_compaction_set_with_del
+++ b/testdata/manual_compaction_set_with_del
@@ -594,7 +594,7 @@ L1
   a.SET.3:3
   b.RANGEDEL.3:e
   b.SET.0:0
-  c.SET.1:1
+  c.SET.3:1
   d.SET.1:1
 L3
   c.RANGEDEL.2:d


### PR DESCRIPTION
The `runDBDefineCmd` function is used in many datadriven tests to define a database state. This command would populate the LSM, but it never ratcheted the log or visible sequence numbers. This meant that an iterator constructed over the defined state would not observe the keys, because it would obtain a snapshot sequence number of zero.

Fix the runDBDefineCmd to ratchet both of these sequence numbers beyond the largest sequence number provided to runDBDefineCmd. This revealed a few tests that defined invalid state—now caught by the level checker, which only now reads at a non-zero snapshot sequence number.