### PR TITLE
metamorphic: fix NextPrefix integration

### DIFF
--- a/internal/metamorphic/retryable.go
+++ b/internal/metamorphic/retryable.go
@@ -261,8 +261,10 @@ func (i *retryableIter) NextPrefix() bool {
 	var valid bool
 	i.withRetry(func() {
 		valid = i.iter.NextPrefix()
+		i.updateRangeKeyChangedGuess()
 		for valid && i.shouldFilter() {
 			valid = i.iter.Next()
+			i.updateRangeKeyChangedGuess()
 		}
 	})
 	return valid


### PR DESCRIPTION
The metamorphic test uses a retryable iterator to manage nondeterminism within the `RangeKeyChanged` output when block-property filters are in use. The integration of NextPrefix into the metamorphic tests forgot to update the state on the `retryableIter`.

Fix #2188.