### PR TITLE
db: tweak NextPrefix semantics in prefix-iteration mode

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -1610,14 +1610,14 @@ func (i *Iterator) NextWithLimit(limit []byte) IterValidityState {
 
 // NextPrefix moves the iterator to the next key/value pair with a key
 // containing a different prefix than the current key. Prefixes are determined
-// by Comparer.Split. Errors if invoked while in prefix-iteration mode.
+// by Comparer.Split. Exhausts the iterator if invoked while in prefix-iteration
+// mode.
 //
 // It is not permitted to invoke NextPrefix while at a IterAtLimit position or
 // to switch directions. When called in these conditions, NextPrefix has
 // non-deterministic behavior.
 func (i *Iterator) NextPrefix() bool {
 	if i.hasPrefix {
-		i.err = errors.New("cannot use NextPrefix with prefix iteration")
 		i.iterValidityState = IterExhausted
 		return false
 	}

--- a/testdata/iter_histories/next_prefix
+++ b/testdata/iter_histories/next_prefix
@@ -61,7 +61,7 @@ seek-prefix-ge p@210
 next-prefix
 ----
 p@100: (p@100, .)
-err=cannot use NextPrefix with prefix iteration
+.
 
 combined-iter
 seek-ge p@210
@@ -147,7 +147,7 @@ seek-prefix-ge p@210
 next-prefix
 ----
 p@100: (p@100, .)
-err=cannot use NextPrefix with prefix iteration
+.
 
 combined-iter
 seek-ge p@210


### PR DESCRIPTION
Previously, when an iterator was in prefix-iteration mode calling NextPrefix would error. This commit modifies NextPrefix to instead exhaust the iterator without any error. This allows for simpler code in CockroachDB's MVCC scanner.