### PR TITLE
metamorphic: fix NextPrefix integration

### DIFF
--- a/internal/metamorphic/retryable.go
+++ b/internal/metamorphic/retryable.go
@@ -259,13 +259,15 @@ func (i *retryableIter) NextWithLimit(limit []byte) pebble.IterValidityState {
 
 func (i *retryableIter) NextPrefix() bool {
 	var valid bool
-	i.withRetry(func() {
-		valid = i.iter.NextPrefix()
-		i.updateRangeKeyChangedGuess()
-		for valid && i.shouldFilter() {
-			valid = i.iter.Next()
+	i.withPosition(func() {
+		i.withRetry(func() {
+			valid = i.iter.NextPrefix()
 			i.updateRangeKeyChangedGuess()
-		}
+			for valid && i.shouldFilter() {
+				valid = i.iter.Next()
+				i.updateRangeKeyChangedGuess()
+			}
+		})
 	})
 	return valid
 }


### PR DESCRIPTION
Fix the NextPrefix integration into the metamorphic test. The prior attempt (33377d59) accidentally omitted the initialization of the retryableIter's RangeKeyChanged tracking state through i.withPosition.

Fix #2190.