### PR TITLE
internal/rangekey: optimize Coalesce 

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -875,7 +875,7 @@ func TestCompactionTransform(t *testing.T) {
 				disableSpanElision: disableElision,
 				inuseKeyRanges:     keyRanges,
 			}
-			transformer := rangeKeyCompactionTransform(snapshots, c.elideRangeTombstone)
+			transformer := rangeKeyCompactionTransform(base.DefaultComparer.Equal, snapshots, c.elideRangeTombstone)
 			if err := transformer.Transform(base.DefaultComparer.Compare, span, &outSpan); err != nil {
 				return fmt.Sprintf("error: %s", err)
 			}

--- a/internal/keyspan/span.go
+++ b/internal/keyspan/span.go
@@ -76,6 +76,15 @@ func (k Key) SeqNum() uint64 {
 	return k.Trailer >> 8
 }
 
+// VisibleAt returns true if the provided key is visible at the provided
+// snapshot sequence number. It interprets batch sequence numbers as always
+// visible, because non-visible batch span keys are filtered when they're
+// fragmented.
+func (k Key) VisibleAt(snapshot uint64) bool {
+	seq := k.SeqNum()
+	return seq < snapshot || seq&base.InternalKeySeqNumBatch != 0
+}
+
 // Kind returns the kind component of the key.
 func (k Key) Kind() base.InternalKeyKind {
 	return base.InternalKeyKind(k.Trailer & 0xff)

--- a/sstable/testdata/writer
+++ b/sstable/testdata/writer
@@ -169,7 +169,7 @@ rangekey: a-b:{(#1,RANGEKEYSET,@t10,foo)}
 rangekey: a-b:{(#2,RANGEKEYSET,@t10,foo)}
 ----
 rangekey: [a#2,21-b#72057594037927935,21]
-seqnums:  [2-2]
+seqnums:  [1-2]
 
 build-raw
 rangekey: b-c:{(#2,RANGEKEYSET,@t10,foo)}

--- a/sstable/testdata/writer_range_keys
+++ b/sstable/testdata/writer_range_keys
@@ -44,7 +44,7 @@ SET a-c @2=foo
 SET a-c @1=bar
 SET a-c @3=baz
 ----
-a-c:{(#0,RANGEKEYSET,@3,baz) (#0,RANGEKEYSET,@2,foo) (#0,RANGEKEYSET,@1,bar)}
+a-c:{(#0,RANGEKEYSET,@2,foo) (#0,RANGEKEYSET,@1,bar) (#0,RANGEKEYSET,@3,baz)}
 
 # Aligned spans, mixed range key kinds.
 #
@@ -81,9 +81,9 @@ SET f-i @9=v9
 DEL f-i
 ----
 a-c:{(#0,RANGEKEYSET,@1,v1) (#0,RANGEKEYUNSET,@5)}
-c-d:{(#0,RANGEKEYSET,@5,v5) (#0,RANGEKEYSET,@2,v2)}
+c-d:{(#0,RANGEKEYSET,@2,v2) (#0,RANGEKEYSET,@5,v5)}
 d-e:{(#0,RANGEKEYSET,@9,v9) (#0,RANGEKEYDEL)}
-f-i:{(#0,RANGEKEYSET,@9,v9) (#0,RANGEKEYSET,@8,v8) (#0,RANGEKEYSET,@7,v7) (#0,RANGEKEYSET,@5,v5) (#0,RANGEKEYSET,@4,v4) (#0,RANGEKEYUNSET,@6) (#0,RANGEKEYDEL)}
+f-i:{(#0,RANGEKEYSET,@4,v4) (#0,RANGEKEYSET,@5,v5) (#0,RANGEKEYSET,@7,v7) (#0,RANGEKEYSET,@8,v8) (#0,RANGEKEYSET,@9,v9) (#0,RANGEKEYUNSET,@6) (#0,RANGEKEYDEL)}
 
 # Merge overlapping RANGEKEYSETs.
 #
@@ -100,7 +100,7 @@ SET b-f @2=bar
 SET c-d @3=baz
 ----
 a-b:{(#0,RANGEKEYSET,@1,foo)}
-b-c:{(#0,RANGEKEYSET,@2,bar) (#0,RANGEKEYSET,@1,foo)}
+b-c:{(#0,RANGEKEYSET,@1,foo) (#0,RANGEKEYSET,@2,bar)}
 c-d:{(#0,RANGEKEYSET,@3,baz) (#0,RANGEKEYSET,@2,bar)}
 d-f:{(#0,RANGEKEYSET,@2,bar)}
 
@@ -108,8 +108,8 @@ d-f:{(#0,RANGEKEYSET,@2,bar)}
 #
 #  ^
 #  |                      •―――――○     [l,o) DEL
-#  |        •―――――――――――――――――――――――○ [e,q) SET   @4=baz
-#  |    •―○                           [c,d) DEL
+#  |        •―――――――――――――○           [e,l) SET   @4=baz
+#  |                              •―○ [p,q) DEL
 #  |    •―――――――――○                   [c,h) UNSET @3
 #  |  •―○                             [b,c) SET   @2=bar
 #  |•―――――――――――――――○                 [a,i) SET   @1=foo
@@ -125,41 +125,11 @@ SET e-q @4=baz
 DEL l-o
 ----
 a-b:{(#0,RANGEKEYSET,@1,foo)}
-b-c:{(#0,RANGEKEYSET,@2,bar) (#0,RANGEKEYSET,@1,foo)}
+b-c:{(#0,RANGEKEYSET,@1,foo) (#0,RANGEKEYSET,@2,bar)}
 c-d:{(#0,RANGEKEYSET,@1,foo) (#0,RANGEKEYUNSET,@3) (#0,RANGEKEYDEL)}
 d-e:{(#0,RANGEKEYSET,@1,foo) (#0,RANGEKEYUNSET,@3)}
-e-h:{(#0,RANGEKEYSET,@4,baz) (#0,RANGEKEYSET,@1,foo) (#0,RANGEKEYUNSET,@3)}
-h-i:{(#0,RANGEKEYSET,@4,baz) (#0,RANGEKEYSET,@1,foo)}
+e-h:{(#0,RANGEKEYSET,@1,foo) (#0,RANGEKEYSET,@4,baz) (#0,RANGEKEYUNSET,@3)}
+h-i:{(#0,RANGEKEYSET,@1,foo) (#0,RANGEKEYSET,@4,baz)}
 i-l:{(#0,RANGEKEYSET,@4,baz)}
 l-o:{(#0,RANGEKEYSET,@4,baz) (#0,RANGEKEYDEL)}
 o-q:{(#0,RANGEKEYSET,@4,baz)}
-
-build
-UNSET a-b @1
-SET a-b @1=foo
-----
-a-b:{(#0,RANGEKEYSET,@1,foo)}
-
-# Within the same fragmented span, key kinds do not affect one another. SETs and
-# DELs will have their own records. A SET will eliminate an UNSET as the former
-# sorts before the latter in a fragmented and coalesced span with the same
-# sequence number.
-#
-#  ^
-#  |        •―――――――○        [c,e) SET   @2=bar
-#  |    •―――――――○            [b,d) UNSET @2
-#  |    •―――――――○            [b,d) UNSET @1
-#  |•―――――――○                [a,c) SET   @1=foo
-#  |___________________________________
-#   a   b   c   d   e   f   g   h   i
-
-build
-SET a-c @1=foo
-UNSET b-d @1
-UNSET b-d @2
-SET c-e @2=bar
-----
-a-b:{(#0,RANGEKEYSET,@1,foo)}
-b-c:{(#0,RANGEKEYSET,@1,foo) (#0,RANGEKEYUNSET,@2)}
-c-d:{(#0,RANGEKEYSET,@2,bar) (#0,RANGEKEYUNSET,@1)}
-d-e:{(#0,RANGEKEYSET,@2,bar)}

--- a/sstable/testdata/writer_v3
+++ b/sstable/testdata/writer_v3
@@ -169,7 +169,7 @@ rangekey: a-b:{(#1,RANGEKEYSET,@t10,foo)}
 rangekey: a-b:{(#2,RANGEKEYSET,@t10,foo)}
 ----
 rangekey: [a#2,21-b#72057594037927935,21]
-seqnums:  [2-2]
+seqnums:  [1-2]
 
 build-raw
 rangekey: b-c:{(#2,RANGEKEYSET,@t10,foo)}


### PR DESCRIPTION
Optimize rangekey.Coalesce by sorting range keys altogether once, and then
deduplicating in a second pass.

```
name                                   old time/op  new time/op  delta
Transform/shadowing=false/keys=1-10    46.5ns ± 0%  35.7ns ± 0%  -23.19%  (p=0.016 n=5+4)
Transform/shadowing=false/keys=2-10     116ns ± 0%    96ns ± 0%  -17.50%  (p=0.008 n=5+5)
Transform/shadowing=false/keys=4-10     436ns ± 0%   256ns ± 0%  -41.30%  (p=0.008 n=5+5)
Transform/shadowing=false/keys=8-10    1.77µs ± 0%  0.95µs ± 0%  -46.67%  (p=0.008 n=5+5)
Transform/shadowing=false/keys=16-10   8.85µs ± 0%  3.24µs ± 0%  -63.42%  (p=0.008 n=5+5)
Transform/shadowing=false/keys=32-10   48.7µs ± 0%   7.2µs ± 0%  -85.19%  (p=0.008 n=5+5)
Transform/shadowing=false/keys=64-10    170µs ± 0%    19µs ± 0%  -88.85%  (p=0.008 n=5+5)
Transform/shadowing=false/keys=128-10   432µs ± 0%    47µs ± 0%  -89.05%  (p=0.008 n=5+5)
Transform/shadowing=true/keys=1-10     46.6ns ± 0%  36.0ns ± 2%  -22.83%  (p=0.008 n=5+5)
Transform/shadowing=true/keys=2-10     95.6ns ± 1%  85.3ns ± 0%  -10.79%  (p=0.008 n=5+5)
Transform/shadowing=true/keys=4-10      227ns ± 0%   201ns ± 0%  -11.68%  (p=0.008 n=5+5)
Transform/shadowing=true/keys=8-10      774ns ± 0%   830ns ± 0%   +7.34%  (p=0.008 n=5+5)
Transform/shadowing=true/keys=16-10    3.29µs ± 0%  2.79µs ± 0%  -15.23%  (p=0.008 n=5+5)
Transform/shadowing=true/keys=32-10    16.3µs ± 0%   6.7µs ± 0%  -58.72%  (p=0.008 n=5+5)
Transform/shadowing=true/keys=64-10    83.5µs ± 0%  18.9µs ± 0%  -77.42%  (p=0.008 n=5+5)
Transform/shadowing=true/keys=128-10    243µs ± 0%    48µs ± 0%  -80.14%  (p=0.008 n=5+5)
```

Close #2175.