### PR TITLE
db: Qualify fatal commit error message

### DIFF
--- a/db.go
+++ b/db.go
@@ -765,7 +765,7 @@ func (d *DB) Apply(batch *Batch, opts *WriteOptions) error {
 	if err := d.commit.Commit(batch, sync); err != nil {
 		// There isn't much we can do on an error here. The commit pipeline will be
 		// horked at this point.
-		d.opts.Logger.Fatalf("%v", err)
+		d.opts.Logger.Fatalf("pebble: fatal commit error: %v", err)
 	}
 	// If this is a large batch, we need to clear the batch contents as the
 	// flushable batch may still be present in the flushables queue.


### PR DESCRIPTION
This is a trivial change to add some additional context in the fatal log line when a commit fails.

I've been diagnosing a PebbleDB crash with `sync: negative WaitGroup counter` originating from this callsite (at the top of the stack). Since [panics are recovered](https://github.com/search?q=repo%3Acockroachdb%2Fpebble+recover%28%29&type=code) and the error is reproduced literally here, it was difficult to narrow down the source of this crash. This additional qualification in the message should make it easier to trace down in the future.

(I may open a separate issue for the commit failure crash once I am able to create a reliably reproducible test case)