### PR TITLE
db: require validity check before calling HasPointAndRange, RangeKeyChanged

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -246,13 +246,11 @@ func runIterCmd(d *datadriven.TestData, iter *Iterator, closeIter bool) string {
 		if valid != iter.Valid() {
 			fmt.Fprintf(&b, "mismatched valid states: %t vs %t\n", valid, iter.Valid())
 		}
-		hasPoint, hasRange := iter.HasPointAndRange()
-		hasEither := hasPoint || hasRange
-		if hasEither != valid {
-			fmt.Fprintf(&b, "mismatched valid/HasPointAndRange states: valid=%t HasPointAndRange=(%t,%t)\n", valid, hasPoint, hasRange)
-		}
-
 		if valid {
+			hasPoint, hasRange := iter.HasPointAndRange()
+			if !hasPoint && !hasRange {
+				fmt.Fprintf(&b, "mismatched valid/HasPointAndRange states: valid=%t HasPointAndRange=(%t,%t)\n", valid, hasPoint, hasRange)
+			}
 			validityState = IterValid
 		}
 		printIterState(&b, iter, validityState, printValidityState)

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -858,6 +858,10 @@ type iterSeekGEOp struct {
 func iteratorPos(i *retryableIter) string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "%q", i.Key())
+	if !i.Valid() {
+		fmt.Fprintf(&buf, "<no point>,<no range>")
+		return buf.String()
+	}
 	hasPoint, hasRange := i.HasPointAndRange()
 	if hasPoint {
 		fmt.Fprintf(&buf, ",%q", i.Value())


### PR DESCRIPTION
Document that both HasPointAndRange and RangeKeyChanged require that the iterator already be known to be valid before being called. This is already true of CockroachDB's use of these methods:

* https://github.com/cockroachdb/cockroach/blob/75e145f4d4a7c4fec6d3daaee236ecca08f021ac/pkg/storage/engine.go#L189-L193
* cockroachdb/cockroach#94220

These methods are called in the hot path every KV, so eliding unnecessary
validity checks does slightly move the MVCCScan benchmarks.

```
    name                                                                   old time/op    new time/op    delta
    MVCCScan_Pebble/rows=1/versions=1/valueSize=8/numRangeKeys=0-24          6.54µs ± 1%    6.47µs ± 1%  -1.13%  (p=0.001 n=9+10)
    MVCCScan_Pebble/rows=1/versions=2/valueSize=8/numRangeKeys=0-24          7.74µs ± 1%    7.65µs ± 2%  -1.25%  (p=0.004 n=9+10)
    MVCCScan_Pebble/rows=1/versions=10/valueSize=8/numRangeKeys=0-24         25.8µs ± 2%    25.0µs ± 1%  -3.06%  (p=0.000 n=10+9)
    MVCCScan_Pebble/rows=1/versions=100/valueSize=8/numRangeKeys=0-24        93.2µs ± 2%    90.2µs ± 1%  -3.21%  (p=0.000 n=10+10)
    MVCCScan_Pebble/rows=10/versions=1/valueSize=8/numRangeKeys=0-24         10.9µs ± 1%    10.7µs ± 1%  -1.69%  (p=0.000 n=10+10)
    MVCCScan_Pebble/rows=10/versions=2/valueSize=8/numRangeKeys=0-24         13.3µs ± 1%    13.1µs ± 1%  -1.52%  (p=0.000 n=10+10)
    MVCCScan_Pebble/rows=10/versions=10/valueSize=8/numRangeKeys=0-24        41.6µs ± 2%    40.9µs ± 2%  -1.83%  (p=0.001 n=10+10)
    MVCCScan_Pebble/rows=10/versions=100/valueSize=8/numRangeKeys=0-24        149µs ± 2%     146µs ± 2%  -1.99%  (p=0.000 n=10+10)
    MVCCScan_Pebble/rows=100/versions=1/valueSize=8/numRangeKeys=0-24        44.1µs ± 2%    42.8µs ± 1%  -2.82%  (p=0.000 n=10+10)
    MVCCScan_Pebble/rows=100/versions=2/valueSize=8/numRangeKeys=0-24        58.1µs ± 1%    57.2µs ± 1%  -1.59%  (p=0.000 n=10+10)
    MVCCScan_Pebble/rows=100/versions=10/valueSize=8/numRangeKeys=0-24        170µs ± 0%     169µs ± 1%  -0.98%  (p=0.000 n=8+8)
    MVCCScan_Pebble/rows=100/versions=100/valueSize=8/numRangeKeys=0-24       636µs ± 1%     629µs ± 1%  -1.09%  (p=0.002 n=10+10)
    MVCCScan_Pebble/rows=1000/versions=1/valueSize=8/numRangeKeys=0-24        348µs ± 2%     339µs ± 1%  -2.72%  (p=0.000 n=10+10)
    MVCCScan_Pebble/rows=1000/versions=2/valueSize=8/numRangeKeys=0-24        469µs ± 0%     464µs ± 1%  -1.08%  (p=0.000 n=9+9)
    MVCCScan_Pebble/rows=1000/versions=10/valueSize=8/numRangeKeys=0-24      1.37ms ± 1%    1.36ms ± 1%    ~     (p=0.077 n=9+9)
    MVCCScan_Pebble/rows=1000/versions=100/valueSize=8/numRangeKeys=0-24     5.41ms ± 2%    5.33ms ± 1%  -1.50%  (p=0.003 n=10+10)
    MVCCScan_Pebble/rows=10000/versions=1/valueSize=8/numRangeKeys=0-24      3.16ms ± 2%    3.09ms ± 2%  -2.10%  (p=0.002 n=10+10)
    MVCCScan_Pebble/rows=10000/versions=2/valueSize=8/numRangeKeys=0-24      4.37ms ± 2%    4.31ms ± 1%  -1.21%  (p=0.001 n=10+9)
    MVCCScan_Pebble/rows=10000/versions=10/valueSize=8/numRangeKeys=0-24     13.4ms ± 3%    13.2ms ± 1%    ~     (p=0.075 n=10+10)
    MVCCScan_Pebble/rows=10000/versions=100/valueSize=8/numRangeKeys=0-24    53.6ms ± 4%    52.1ms ± 4%    ~     (p=0.053 n=9+10)
    MVCCScan_Pebble/rows=50000/versions=1/valueSize=8/numRangeKeys=0-24      16.7ms ± 1%    16.5ms ± 1%  -1.62%  (p=0.000 n=9+9)
    MVCCScan_Pebble/rows=50000/versions=2/valueSize=8/numRangeKeys=0-24      22.9ms ± 3%    22.6ms ± 2%  -1.33%  (p=0.035 n=10+9)
    MVCCScan_Pebble/rows=50000/versions=10/valueSize=8/numRangeKeys=0-24     67.5ms ± 3%    67.0ms ± 2%    ~     (p=0.280 n=10+10)
    MVCCScan_Pebble/rows=50000/versions=100/valueSize=8/numRangeKeys=0-24     270ms ± 5%     259ms ± 7%  -4.09%  (p=0.004 n=10+9)
```
