### PR TITLE
crl-release-22.2: db: add RangeKeyIteratorStats

### DIFF
--- a/iterator_histories_test.go
+++ b/iterator_histories_test.go
@@ -6,6 +6,7 @@ package pebble
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/datadriven"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -25,6 +27,12 @@ import (
 
 func TestIterHistories(t *testing.T) {
 	datadriven.Walk(t, "testdata/iter_histories", func(t *testing.T, path string) {
+		filename := filepath.Base(path)
+		switch {
+		case invariants.Enabled && strings.Contains(filename, "no_invariants"):
+			t.Skip("disabled when run with -tags invariants due to nondeterminism")
+		}
+
 		var d *DB
 		iters := map[string]*Iterator{}
 		batches := map[string]*Batch{}

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1670,6 +1670,66 @@ func TestIteratorBoundsLifetimes(t *testing.T) {
 	})
 }
 
+func TestIteratorStatsMerge(t *testing.T) {
+	s := IteratorStats{
+		ForwardSeekCount: [NumStatsKind]int{1, 2},
+		ReverseSeekCount: [NumStatsKind]int{3, 4},
+		ForwardStepCount: [NumStatsKind]int{5, 6},
+		ReverseStepCount: [NumStatsKind]int{7, 8},
+		InternalStats: InternalIteratorStats{
+			BlockBytes:                     9,
+			BlockBytesInCache:              10,
+			KeyBytes:                       11,
+			ValueBytes:                     12,
+			PointCount:                     13,
+			PointsCoveredByRangeTombstones: 14,
+		},
+		RangeKeyStats: RangeKeyIteratorStats{
+			Count:           15,
+			ContainedPoints: 16,
+			SkippedPoints:   17,
+		},
+	}
+	s.Merge(IteratorStats{
+		ForwardSeekCount: [NumStatsKind]int{1, 2},
+		ReverseSeekCount: [NumStatsKind]int{3, 4},
+		ForwardStepCount: [NumStatsKind]int{5, 6},
+		ReverseStepCount: [NumStatsKind]int{7, 8},
+		InternalStats: InternalIteratorStats{
+			BlockBytes:                     9,
+			BlockBytesInCache:              10,
+			KeyBytes:                       11,
+			ValueBytes:                     12,
+			PointCount:                     13,
+			PointsCoveredByRangeTombstones: 14,
+		},
+		RangeKeyStats: RangeKeyIteratorStats{
+			Count:           15,
+			ContainedPoints: 16,
+			SkippedPoints:   17,
+		},
+	})
+	require.Equal(t, IteratorStats{
+		ForwardSeekCount: [NumStatsKind]int{2, 4},
+		ReverseSeekCount: [NumStatsKind]int{6, 8},
+		ForwardStepCount: [NumStatsKind]int{10, 12},
+		ReverseStepCount: [NumStatsKind]int{14, 16},
+		InternalStats: InternalIteratorStats{
+			BlockBytes:                     18,
+			BlockBytesInCache:              20,
+			KeyBytes:                       22,
+			ValueBytes:                     24,
+			PointCount:                     26,
+			PointsCoveredByRangeTombstones: 28,
+		},
+		RangeKeyStats: RangeKeyIteratorStats{
+			Count:           30,
+			ContainedPoints: 32,
+			SkippedPoints:   34,
+		},
+	}, s)
+}
+
 // TestSetOptionsEquivalence tests equivalence between SetOptions to mutate an
 // iterator and constructing a new iterator with NewIter. The long-lived
 // iterator and the new iterator should surface identical iterator states.

--- a/range_keys.go
+++ b/range_keys.go
@@ -297,6 +297,7 @@ func (m *rangeKeyMasking) SpanChanged(s *keyspan.Span) {
 // Invariant: The userKey is within the user key bounds of the span most
 // recently provided to `SpanChanged`.
 func (m *rangeKeyMasking) SkipPoint(userKey []byte) bool {
+	m.parent.stats.RangeKeyStats.ContainedPoints++
 	if m.maskSpan == nil {
 		// No range key is currently acting as a mask, so don't skip.
 		return false
@@ -309,7 +310,11 @@ func (m *rangeKeyMasking) SkipPoint(userKey []byte) bool {
 	// the InterleavingIter). Skip the point key if the range key's suffix is
 	// greater than the point key's suffix.
 	pointSuffix := userKey[m.split(userKey):]
-	return len(pointSuffix) > 0 && m.cmp(m.maskActiveSuffix, pointSuffix) < 0
+	if len(pointSuffix) > 0 && m.cmp(m.maskActiveSuffix, pointSuffix) < 0 {
+		m.parent.stats.RangeKeyStats.SkippedPoints++
+		return true
+	}
+	return false
 }
 
 // The iteratorRangeKeyState type implements the sstable package's

--- a/testdata/iter_histories/range_key_masking
+++ b/testdata/iter_histories/range_key_masking
@@ -154,7 +154,8 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 1.1 K, cached 0 B)), (points: (count 25, key-bytes 75, value-bytes 75, tombstoned: 0))
+(internal-stats: (block-bytes: (total 1.1 K, cached 0 B)), (points: (count 25, key-bytes 75, value-bytes 75, tombstoned: 0)),
+(range-key-stats: (count 1), (contained points: (count 25, skipped 25)))
 
 # Repeat the above test, but with an iterator that uses a block-property filter
 # mask. The internal stats should reflect fewer bytes read and fewer points
@@ -168,7 +169,8 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 514 B, cached 514 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+(internal-stats: (block-bytes: (total 514 B, cached 514 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0)),
+(range-key-stats: (count 1), (contained points: (count 2, skipped 2)))
 
 # Perform a similar comparison in reverse.
 
@@ -180,7 +182,8 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 1.1 K, cached 1.1 K)), (points: (count 25, key-bytes 75, value-bytes 75, tombstoned: 0))
+(internal-stats: (block-bytes: (total 1.1 K, cached 1.1 K)), (points: (count 25, key-bytes 75, value-bytes 75, tombstoned: 0)),
+(range-key-stats: (count 1), (contained points: (count 25, skipped 25)))
 
 combined-iter mask-suffix=@9 mask-filter
 last
@@ -190,7 +193,8 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 514 B, cached 514 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+(internal-stats: (block-bytes: (total 514 B, cached 514 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0)),
+(range-key-stats: (count 1), (contained points: (count 2, skipped 2)))
 
 # Perform similar comparisons with seeks.
 
@@ -202,7 +206,8 @@ stats
 m: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 789 B, cached 789 B)), (points: (count 13, key-bytes 39, value-bytes 39, tombstoned: 0))
+(internal-stats: (block-bytes: (total 789 B, cached 789 B)), (points: (count 13, key-bytes 39, value-bytes 39, tombstoned: 0)),
+(range-key-stats: (count 1), (contained points: (count 13, skipped 13)))
 
 combined-iter mask-suffix=@9 mask-filter
 seek-ge m
@@ -212,7 +217,8 @@ stats
 m: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 514 B, cached 514 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+(internal-stats: (block-bytes: (total 514 B, cached 514 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0)),
+(range-key-stats: (count 1), (contained points: (count 2, skipped 2)))
 
 combined-iter mask-suffix=@9
 seek-lt m
@@ -222,7 +228,8 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 789 B, cached 789 B)), (points: (count 12, key-bytes 36, value-bytes 36, tombstoned: 0))
+(internal-stats: (block-bytes: (total 789 B, cached 789 B)), (points: (count 12, key-bytes 36, value-bytes 36, tombstoned: 0)),
+(range-key-stats: (count 1), (contained points: (count 12, skipped 12)))
 
 combined-iter mask-suffix=@9 mask-filter
 seek-lt m
@@ -232,4 +239,5 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 539 B, cached 539 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0))
+(internal-stats: (block-bytes: (total 539 B, cached 539 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned: 0)),
+(range-key-stats: (count 1), (contained points: (count 2, skipped 2)))

--- a/testdata/iter_histories/stats_no_invariants
+++ b/testdata/iter_histories/stats_no_invariants
@@ -1,0 +1,160 @@
+reset
+----
+
+# Use the key string as the value so that it's easy to tell when we surface the
+# wrong value.
+
+batch commit
+set a a
+set b b
+set c c
+set d d
+range-key-set b   c   @5 boop
+range-key-set cat dog @3 beep
+----
+committed 6 keys
+
+flush
+----
+
+# Scan forward
+
+combined-iter
+stats
+seek-ge a
+next
+stats
+next
+next
+next
+next
+stats
+----
+stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 0, 0))
+a: (a, .)
+b: (b, [b-c) @5=boop UPDATED)
+stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 89 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned: 0)),
+(range-key-stats: (count 1), (contained points: (count 1, skipped 0)))
+c: (c, . UPDATED)
+cat: (., [cat-dog) @3=beep UPDATED)
+d: (d, [cat-dog) @3=beep)
+.
+stats: (interface (dir, seek, step): (fwd, 1, 5), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 6), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 89 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0)),
+(range-key-stats: (count 2), (contained points: (count 2, skipped 0)))
+
+# Do the above forward iteration but with a mask suffix. The results should be
+# identical despite range keys serving as masks, because none of the point keys
+# have suffixes.
+
+combined-iter mask-suffix=@9
+seek-ge a
+next
+next
+next
+next
+next
+stats
+----
+a: (a, .)
+b: (b, [b-c) @5=boop UPDATED)
+c: (c, . UPDATED)
+cat: (., [cat-dog) @3=beep UPDATED)
+d: (d, [cat-dog) @3=beep)
+.
+stats: (interface (dir, seek, step): (fwd, 1, 5), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 6), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 89 B, cached 89 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0)),
+(range-key-stats: (count 2), (contained points: (count 2, skipped 0)))
+
+# Scan backward
+
+combined-iter
+seek-lt z
+prev
+prev
+prev
+prev
+prev
+stats
+----
+d: (d, [cat-dog) @3=beep UPDATED)
+cat: (., [cat-dog) @3=beep)
+c: (c, . UPDATED)
+b: (b, [b-c) @5=boop UPDATED)
+a: (a, . UPDATED)
+.
+stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 5)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 6)),
+(internal-stats: (block-bytes: (total 89 B, cached 89 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0)),
+(range-key-stats: (count 2), (contained points: (count 2, skipped 0)))
+
+combined-iter
+seek-ge ace
+seek-ge b
+seek-ge c
+seek-ge cab
+seek-ge cat
+seek-ge d
+seek-ge day
+seek-ge dog
+stats
+----
+b: (b, [b-c) @5=boop UPDATED)
+b: (b, [b-c) @5=boop)
+c: (c, . UPDATED)
+cat: (., [cat-dog) @3=beep UPDATED)
+cat: (., [cat-dog) @3=beep)
+d: (d, [cat-dog) @3=beep)
+day: (., [cat-dog) @3=beep)
+.
+stats: (interface (dir, seek, step): (fwd, 8, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 6, 4), (rev, 0, 0)),
+(internal-stats: (block-bytes: (total 89 B, cached 89 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned: 0)),
+(range-key-stats: (count 2), (contained points: (count 3, skipped 0)))
+
+combined-iter
+seek-lt 1
+seek-lt ace
+seek-lt b
+seek-lt c
+seek-lt cab
+seek-lt cat
+seek-lt d
+seek-lt day
+seek-lt dog
+seek-lt zebra
+stats
+----
+.
+a: (a, .)
+a: (a, .)
+b: (b, [b-c) @5=boop UPDATED)
+c: (c, . UPDATED)
+c: (c, .)
+cat: (., [cat-dog) @3=beep UPDATED)
+d: (d, [cat-dog) @3=beep)
+d: (d, [cat-dog) @3=beep)
+d: (d, [cat-dog) @3=beep)
+stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 10, 0)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 10, 10)),
+(internal-stats: (block-bytes: (total 267 B, cached 267 B)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned: 0)),
+(range-key-stats: (count 2), (contained points: (count 6, skipped 0)))
+
+rangekey-iter
+first
+next
+next
+set-bounds lower=bat upper=catatonic
+first
+next
+next
+stats
+----
+b [b-c) @5=boop UPDATED
+cat [cat-dog) @3=beep UPDATED
+.
+.
+bat [bat-c) @5=boop UPDATED
+cat [cat-catatonic) @3=beep UPDATED
+.
+stats: (interface (dir, seek, step): (fwd, 2, 4), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 4), (rev, 0, 0)),
+(range-key-stats: (count 4), (contained points: (count 0, skipped 0)))
+


### PR DESCRIPTION
22.2 backport of #1871.

----

Expand the IteratorStats structure to include a few statistics about range key iteration.

Informs #1848.