### PR TITLE
replay: implement Stringer on workload collector's Cleaner

### DIFF
--- a/replay/testdata/replay
+++ b/replay/testdata/replay
@@ -13,7 +13,7 @@ tree
        0      LOCK
       96      MANIFEST-000001
      122      MANIFEST-000008
-    2511      OPTIONS-000003
+    1145      OPTIONS-000003
        0      marker.format-version.000007.008
        0      marker.manifest.000002.MANIFEST-000008
             simple/
@@ -24,9 +24,61 @@ tree
       25        000004.log
      795        000005.sst
       96        MANIFEST-000001
-    2511        OPTIONS-000003
+    1145        OPTIONS-000003
        0        marker.format-version.000001.008
        0        marker.manifest.000001.MANIFEST-000001
+
+cat build/OPTIONS-000003
+----
+----
+[Version]
+  pebble_version=0.1
+
+[Options]
+  bytes_per_sync=524288
+  cache_size=8388608
+  cleaner=replay.WorkloadCollector("delete")
+  compaction_debt_concurrency=1073741824
+  comparer=pebble.internal.testkeys
+  disable_wal=false
+  flush_delay_delete_range=0s
+  flush_delay_range_key=0s
+  flush_split_bytes=4194304
+  format_major_version=8
+  l0_compaction_concurrency=10
+  l0_compaction_file_threshold=500
+  l0_compaction_threshold=4
+  l0_stop_writes_threshold=12
+  lbase_max_bytes=67108864
+  max_concurrent_compactions=1
+  max_manifest_file_size=96
+  max_open_files=1000
+  mem_table_size=4194304
+  mem_table_stop_writes_threshold=2
+  min_deletion_rate=0
+  merger=pebble.concatenate
+  point_tombstone_weight=1.000000
+  read_compaction_rate=16000
+  read_sampling_multiplier=16
+  strict_wal_tail=true
+  table_cache_shards=2
+  table_property_collectors=[]
+  validate_on_ingest=false
+  wal_dir=
+  wal_bytes_per_sync=0
+  max_writer_concurrency=0
+  force_writer_parallelism=false
+
+[Level "0"]
+  block_restart_interval=16
+  block_size=4096
+  compression=Snappy
+  filter_policy=none
+  filter_type=table
+  index_block_size=4096
+  target_file_size=2097152
+----
+----
 
 replay simple unpaced
 ----
@@ -34,42 +86,8 @@ replay simple unpaced
 wait
 ----
 
-tree
-----
-          /
-            build/
-      89      000004.log
-     795      000005.sst
-      49      000006.log
-     823      000007.sst
-      16      CURRENT
-       0      LOCK
-      96      MANIFEST-000001
-     122      MANIFEST-000008
-    2511      OPTIONS-000003
-       0      marker.format-version.000007.008
-       0      marker.manifest.000002.MANIFEST-000008
-            run-31/
-     795      000005.sst
-       0      000006.log
-       0      LOCK
-      96      MANIFEST-000001
-     136      MANIFEST-000007
-    1121      OPTIONS-000008
-       0      marker.format-version.000001.008
-       0      marker.manifest.000002.MANIFEST-000007
-              staging/
-            simple/
-     823      000007.sst
-      96      MANIFEST-000001
-     122      MANIFEST-000008
-              checkpoint/
-      25        000004.log
-     795        000005.sst
-      96        MANIFEST-000001
-    2511        OPTIONS-000003
-       0        marker.format-version.000001.008
-       0        marker.manifest.000001.MANIFEST-000001
+# NB: The file sizes are non-deterministic after replay (because compactions are
+# nondeterministic). We don't `tree` here as a result.
 
 scan-keys
 ----

--- a/replay/testdata/replay_paced
+++ b/replay/testdata/replay_paced
@@ -15,7 +15,7 @@ tree
        0      LOCK
      122      MANIFEST-000008
      205      MANIFEST-000011
-    2511      OPTIONS-000003
+    1145      OPTIONS-000003
        0      marker.format-version.000007.008
        0      marker.manifest.000003.MANIFEST-000011
             high_read_amp/
@@ -27,7 +27,7 @@ tree
       39        000009.log
      769        000010.sst
      157        MANIFEST-000011
-    2511        OPTIONS-000003
+    1145        OPTIONS-000003
        0        marker.format-version.000001.008
        0        marker.manifest.000001.MANIFEST-000011
 


### PR DESCRIPTION
Pebble encodes the Options.Cleaner used within the OPTIONS file. During workload collection, a custom cleaner is installed to defer the deletion of files until they've been collected. Previously, the `*pebble.WorkloadCollector` itself implemented the Cleaner interface, resulting in the `%s` serialization of the entire WorkloadCollector structure being recorded within the OPTIONS file. This commit adjusts the collector to pass a Cleaner that implements fmt.Stringer, so that a consistent, stable string representation is encoded in the OPTIONS file.