### PR TITLE
db: fix lazy-combined iteration bug

### DIFF
--- a/range_keys.go
+++ b/range_keys.go
@@ -501,24 +501,6 @@ func (i *lazyCombinedIter) initCombinedIteration(
 		}
 	}
 
-	if i.parent.hasPrefix {
-		si := i.parent.comparer.Split(seekKey)
-		if i.parent.cmp(seekKey[:si], i.parent.prefixOrFullSeekKey) > 0 {
-			// The earliest possible range key has a start key with a prefix
-			// greater than the current iteration prefix. There's no need to
-			// switch to combined iteration, because there are not any range
-			// keys within the bounds of the prefix. Additionally, using a seek
-			// key that is outside the scope of the prefix can violate
-			// invariants within the range key iterator stack. Optimizations
-			// that exit early due to exhausting the prefix may result in
-			// `seekKey` being larger than the next range key's start key.
-			//
-			// See the testdata/rangekeys test case associated with #1893.
-			i.combinedIterState = combinedIterState{initialized: false}
-			return pointKey, pointValue
-		}
-	}
-
 	// An operation on the point iterator observed a file containing range keys,
 	// so we must switch to combined interleaving iteration. First, construct
 	// the range key iterator stack. It must not exist, otherwise we'd already

--- a/testdata/iter_histories/lazy_combined_iteration
+++ b/testdata/iter_histories/lazy_combined_iteration
@@ -220,3 +220,60 @@ a: (a, .)
 using lazy iterator
 n: (., [m-z) @5=foo UPDATED)
 using combined (non-lazy) iterator
+
+# Regression tests for #2210 metamorphic test failure.
+#
+# Lazy-combined iteration depends on individual point level iterators triggering
+# a switch to combined iteration when they observe a file containing relevant
+# range keys. Previously, this switch did not happen if the observed range
+# keys all lied outside the current iteration prefix.
+#
+# This made it possible for a level to become positioned beyond the file
+# containing range keys, without ever triggering the switch to combined
+# iteration. A subsequent seek that made use of the TrySeekUsingNext
+# optimization would never observe the file containing range keys, and omit the
+# range keys.
+
+define
+L6
+  bax.DEL.9:
+L6
+  rangekey:c-d:{(#0,RANGEKEYSET,@1,foo)}
+L6
+  d@2.SET.2:v
+----
+6:
+  000004:[bax#9,DEL-bax#9,DEL]
+  000005:[c#0,RANGEKEYSET-d#72057594037927935,RANGEKEYSET]
+  000006:[d@2#2,SET-d@2#2,SET]
+
+combined-iter
+seek-prefix-ge bax
+seek-prefix-ge cat
+----
+.
+cat: (., [cat-"cat\x00") @1=foo UPDATED)
+
+# Another regression test for the #2210 metamorphic test failure, this one using
+# a MERGE key to force the Iterator to step the internal iterator beyond the
+# range key file.
+
+define
+L6
+  bax.MERGE.9:v
+L6
+  rangekey:c-d:{(#0,RANGEKEYSET,@1,foo)}
+L6
+  d@2.SET.2:v
+----
+6:
+  000004:[bax#9,MERGE-bax#9,MERGE]
+  000005:[c#0,RANGEKEYSET-d#72057594037927935,RANGEKEYSET]
+  000006:[d@2#2,SET-d@2#2,SET]
+
+combined-iter
+seek-prefix-ge bax
+seek-prefix-ge cat
+----
+bax: (v, .)
+cat: (., [cat-"cat\x00") @1=foo UPDATED)


### PR DESCRIPTION
Lazy-combined iteration depends on individual point level iterators triggering a switch to combined iteration when they observe a file containing relevant range keys. Previously, this switch did not happen if the observed range keys all lied outside the current iteration prefix. This made it possible for a level to become positioned beyond the file containing range keys, without ever triggering the switch to combined iteration. A subsequent seek that made use of the TrySeekUsingNext optimization would never observe the file containing range keys, and omit the range keys.

This commit deletes the code preventing the switch to combined iteration when a key is observed outside the prefix. The commit that introduced this logic #1900 was fixing a range-key iterator invariant violation, but it fixed that issue in two distinct ways (one of which was this logic).

An alternative fix would prevent the level iterator from advancing to a file outside the current iteration prefix, but this would require the level iterator to gain knowledge of the current iteration prefix.

Fix #2210.