### PR TITLE
sstable: prevent duplicate put of valueBlockWriter to sync.Pool

### DIFF
--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -1739,6 +1739,9 @@ func (w *Writer) Close() (err error) {
 	defer func() {
 		if w.valueBlockWriter != nil {
 			releaseValueBlockWriter(w.valueBlockWriter)
+			// Defensive code in case Close gets called again. We don't want to put
+			// the same object to a sync.Pool.
+			w.valueBlockWriter = nil
 		}
 		if w.syncer == nil {
 			return


### PR DESCRIPTION
This could happen if Writer.Close was called more than once. It is
tripping up some CockroachDB tests, which are panicking because a field
of the valueBlockWriter that should never be nil is nil. A concurrent
goroutine using the same valueBlockWriter would set that field to nil
before returning the valueBlockWriter to the sync.Pool. Even worse,
multiple goroutines using the same valueBlockWriter can cause data
corruption. Adding this defensive code fixes the test failure.

Additionally, the cause of the multiple calls to Writer.Close in
suffix_rewriter.go is fixed. There was also a missing call to Writer.Close
which is fixed.

Informs https://github.com/cockroachdb/pebble/issues/1170

Epic: [CRDB-20378](https://cockroachlabs.atlassian.net/browse/CRDB-20378)
