### PR TITLE
Revert "db: require validity check before calling HasPointAndRange, R…

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -246,11 +246,13 @@ func runIterCmd(d *datadriven.TestData, iter *Iterator, closeIter bool) string {
 		if valid != iter.Valid() {
 			fmt.Fprintf(&b, "mismatched valid states: %t vs %t\n", valid, iter.Valid())
 		}
+		hasPoint, hasRange := iter.HasPointAndRange()
+		hasEither := hasPoint || hasRange
+		if hasEither != valid {
+			fmt.Fprintf(&b, "mismatched valid/HasPointAndRange states: valid=%t HasPointAndRange=(%t,%t)\n", valid, hasPoint, hasRange)
+		}
+
 		if valid {
-			hasPoint, hasRange := iter.HasPointAndRange()
-			if !hasPoint && !hasRange {
-				fmt.Fprintf(&b, "mismatched valid/HasPointAndRange states: valid=%t HasPointAndRange=(%t,%t)\n", valid, hasPoint, hasRange)
-			}
 			validityState = IterValid
 		}
 		printIterState(&b, iter, validityState, printValidityState)

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -858,10 +858,6 @@ type iterSeekGEOp struct {
 func iteratorPos(i *retryableIter) string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "%q", i.Key())
-	if !i.Valid() {
-		fmt.Fprintf(&buf, "<no point>,<no range>")
-		return buf.String()
-	}
 	hasPoint, hasRange := i.HasPointAndRange()
 	if hasPoint {
 		fmt.Fprintf(&buf, ",%q", i.Value())

--- a/internal/metamorphic/retryable.go
+++ b/internal/metamorphic/retryable.go
@@ -140,15 +140,13 @@ func (i *retryableIter) withPosition(fn func()) {
 	if !intermediate {
 		// Clear out the previous value stored in the buff.
 		i.rkeyBuff = i.rkeyBuff[:0]
-		if i.iter.Valid() {
-			if _, hasRange := i.iter.HasPointAndRange(); hasRange {
-				// This is a top level positioning op. We should determine if the iter
-				// is positioned over a range key to later determine if the range key
-				// changed.
-				startTmp, _ := i.iter.RangeBounds()
-				i.rkeyBuff = append(i.rkeyBuff, startTmp...)
+		if _, hasRange := i.iter.HasPointAndRange(); hasRange {
+			// This is a top level positioning op. We should determine if the iter
+			// is positioned over a range key to later determine if the range key
+			// changed.
+			startTmp, _ := i.iter.RangeBounds()
+			i.rkeyBuff = append(i.rkeyBuff, startTmp...)
 
-			}
 		}
 		// Set this to false. Any positioning op can set this to true.
 		i.rangeKeyChangeGuess = false
@@ -159,10 +157,8 @@ func (i *retryableIter) withPosition(fn func()) {
 	if !intermediate {
 		// Check if the range key changed.
 		var newStartKey []byte
-		if i.iter.Valid() {
-			if _, hasRange := i.iter.HasPointAndRange(); hasRange {
-				newStartKey, _ = i.iter.RangeBounds()
-			}
+		if _, hasRange := i.iter.HasPointAndRange(); hasRange {
+			newStartKey, _ = i.iter.RangeBounds()
 		}
 
 		i.rangeKeyChanged = !bytes.Equal(newStartKey, i.rkeyBuff)
@@ -170,7 +166,7 @@ func (i *retryableIter) withPosition(fn func()) {
 }
 
 func (i *retryableIter) updateRangeKeyChangedGuess() {
-	i.rangeKeyChangeGuess = i.rangeKeyChangeGuess || (i.iter.Valid() && i.iter.RangeKeyChanged())
+	i.rangeKeyChangeGuess = i.rangeKeyChangeGuess || i.iter.RangeKeyChanged()
 }
 
 func (i *retryableIter) First() bool {

--- a/iterator.go
+++ b/iterator.go
@@ -2038,29 +2038,23 @@ func (i *Iterator) saveRangeKey() {
 // If false, previously obtained range key bounds, suffix and value slices are
 // still valid and may continue to be read.
 //
-// RangeKeyChanged must only be called if the iterator is Valid().
-//
 // Invalid iterator positions are considered to not hold range keys, meaning
 // that if an iterator steps from an IterExhausted or IterAtLimit position onto
 // a position with a range key, RangeKeyChanged will yield true.
 func (i *Iterator) RangeKeyChanged() bool {
-	if invariants.Enabled && !i.Valid() {
-		panic("pebble: Iterator.RangeKeyChanged called on invalid iterator")
-	}
-	return i.rangeKey != nil && i.rangeKey.updated
+	return i.iterValidityState == IterValid && i.rangeKey != nil && i.rangeKey.updated
 }
 
 // HasPointAndRange indicates whether there exists a point key, a range key or
-// both at the current iterator position. HasPointAndRange must only be called
-// if the iterator is Valid().
+// both at the current iterator position.
 func (i *Iterator) HasPointAndRange() (hasPoint, hasRange bool) {
-	if invariants.Enabled && !i.Valid() {
-		panic("pebble: Iterator.HasPointAndRange called on invalid iterator")
+	if i.iterValidityState != IterValid || i.requiresReposition {
+		return false, false
 	}
-	if i.rangeKey == nil || i.opts.KeyTypes == IterKeyTypePointsOnly {
+	if i.opts.KeyTypes == IterKeyTypePointsOnly {
 		return true, false
 	}
-	return !i.rangeKey.rangeKeyOnly, i.rangeKey.hasRangeKey
+	return i.rangeKey == nil || !i.rangeKey.rangeKeyOnly, i.rangeKey != nil && i.rangeKey.hasRangeKey
 }
 
 // RangeBounds returns the start (inclusive) and end (exclusive) bounds of the


### PR DESCRIPTION
…angeKeyChanged"

Temporarily revert this commit. The vendor bump cockroachdb/cockroach#94712 revealed test failures that need more investigation. I believe the problem lies in the Cockroach iterator stack, but I don't want to block Pebble bumps until I've figured it out.

This reverts commit 1a5e233546af8807354e342096193d148478bd28.