### PR TITLE
bloom: reduce memory allocations in table bloom filter

### DIFF
--- a/bloom/bloom.go
+++ b/bloom/bloom.go
@@ -8,6 +8,7 @@ package bloom // import "github.com/cockroachdb/pebble/bloom"
 import (
 	"encoding/binary"
 	"fmt"
+	"sync"
 
 	"github.com/cockroachdb/pebble/internal/base"
 )
@@ -122,6 +123,29 @@ type tableFilterWriter struct {
 	hashes     []uint32
 }
 
+var tableFilterWriterPool = sync.Pool{
+	New: func() interface{} {
+		return &tableFilterWriter{}
+	},
+}
+
+func newTableFilterWriter(bitsPerKey int) *tableFilterWriter {
+	w := tableFilterWriterPool.Get().(*tableFilterWriter)
+	w.bitsPerKey = bitsPerKey
+	w.hashes = w.hashes[:0]
+	return w
+}
+
+const maxReusableHashes = 4 * 1024 * 1024
+
+func dropTableFilterWriter(w *tableFilterWriter) {
+	if cap(w.hashes) > maxReusableHashes {
+		// Avoid holding on to a very large buffer.
+		w.hashes = nil
+	}
+	tableFilterWriterPool.Put(w)
+}
+
 // AddKey implements the base.FilterWriter interface.
 func (w *tableFilterWriter) AddKey(key []byte) {
 	h := hash(key)
@@ -173,10 +197,9 @@ func (w *tableFilterWriter) Finish(buf []byte) []byte {
 //
 // The integer value is the approximate number of bits used per key. A good
 // value is 10, which yields a filter with ~ 1% false positive rate.
-//
-// It is valid to use the other API in this package (pebble/bloom) without
-// using this type or the pebble package.
 type FilterPolicy int
+
+var _ base.FilterPolicy = FilterPolicy(0)
 
 // Name implements the pebble.FilterPolicy interface.
 func (p FilterPolicy) Name() string {
@@ -200,10 +223,15 @@ func (p FilterPolicy) MayContain(ftype base.FilterType, f, key []byte) bool {
 func (p FilterPolicy) NewWriter(ftype base.FilterType) base.FilterWriter {
 	switch ftype {
 	case base.TableFilter:
-		return &tableFilterWriter{
-			bitsPerKey: int(p),
-		}
+		return newTableFilterWriter(int(p))
 	default:
 		panic(fmt.Sprintf("unknown filter type: %v", ftype))
+	}
+}
+
+// DropWriter implements the pebble.FilterPolicy interface.
+func (p FilterPolicy) DropWriter(w base.FilterWriter) {
+	if w, ok := w.(*tableFilterWriter); ok {
+		dropTableFilterWriter(w)
 	}
 }

--- a/bloom/bloom_test.go
+++ b/bloom/bloom_test.go
@@ -5,6 +5,7 @@
 package bloom
 
 import (
+	"math/rand"
 	"strings"
 	"testing"
 
@@ -195,5 +196,24 @@ func TestHash(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			require.EqualValues(t, tc.expected, hash([]byte(tc.s)))
 		})
+	}
+}
+
+func BenchmarkBloomFilter(b *testing.B) {
+	const keyLen = 128
+	const numKeys = 1024
+	keys := make([][]byte, numKeys)
+	for i := range keys {
+		keys[i] = make([]byte, keyLen)
+		_, _ = rand.Read(keys[i])
+	}
+	b.ResetTimer()
+	policy := FilterPolicy(10)
+	for i := 0; i < b.N; i++ {
+		w := policy.NewWriter(base.TableFilter)
+		for _, key := range keys {
+			w.AddKey(key)
+		}
+		w.Finish(nil)
 	}
 }

--- a/bloom/bloom_test.go
+++ b/bloom/bloom_test.go
@@ -215,5 +215,6 @@ func BenchmarkBloomFilter(b *testing.B) {
 			w.AddKey(key)
 		}
 		w.Finish(nil)
+		policy.DropWriter(w)
 	}
 }

--- a/internal/base/options.go
+++ b/internal/base/options.go
@@ -62,6 +62,11 @@ type FilterPolicy interface {
 
 	// NewWriter creates a new FilterWriter.
 	NewWriter(ftype FilterType) FilterWriter
+
+	// DropWriter takes ownership of a writer object so that it can be potentially
+	// reused by a future NewWriter call. The object must not be used anymore by
+	// the caller. The use of this method is optional.
+	DropWriter(w FilterWriter)
 }
 
 // BlockPropertyFilter is used in an Iterator to filter sstables and blocks

--- a/sstable/filter.go
+++ b/sstable/filter.go
@@ -87,6 +87,10 @@ func (f *tableFilterWriter) addKey(key []byte) {
 }
 
 func (f *tableFilterWriter) finish() ([]byte, error) {
+	defer func() {
+		f.policy.DropWriter(f.writer)
+		f.writer = nil
+	}()
 	if f.count == 0 {
 		return nil, nil
 	}

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -1800,6 +1800,8 @@ func (w *Writer) Close() (err error) {
 	var metaindex rawBlockWriter
 	metaindex.restartInterval = 1
 	if w.filter != nil {
+		metaName := w.filter.metaName()
+		policyName := w.filter.policyName()
 		b, err := w.filter.finish()
 		if err != nil {
 			w.err = err
@@ -1811,8 +1813,8 @@ func (w *Writer) Close() (err error) {
 			return w.err
 		}
 		n := encodeBlockHandle(w.blockBuf.tmp[:], bh)
-		metaindex.add(InternalKey{UserKey: []byte(w.filter.metaName())}, w.blockBuf.tmp[:n])
-		w.props.FilterPolicyName = w.filter.policyName()
+		metaindex.add(InternalKey{UserKey: []byte(metaName)}, w.blockBuf.tmp[:n])
+		w.props.FilterPolicyName = policyName
 		w.props.FilterSize = bh.Length
 	}
 


### PR DESCRIPTION
#### bloom: add a table bloom filter benchmark


#### bloom: reduce memory allocations in table bloom filter

A minor performance improvement to avoid many allocations of the
`hashes` buffer in `tableFilterWriter`.

We extend `FilterPolicy` with a `DropWriter` method which allows reuse
of writers. The implementation uses a `sync.Pool`.

```
name            old time/op    new time/op    delta
BloomFilter-16    45.4µs ± 0%    43.8µs ± 1%   -3.50%  (p=0.000 n=10+10)

name            old alloc/op   new alloc/op   delta
BloomFilter-16    10.0kB ± 0%     1.8kB ± 0%  -82.03%  (p=0.000 n=10+10)

name            old allocs/op  new allocs/op  delta
BloomFilter-16      11.0 ± 0%       1.0 ± 0%  -90.91%  (p=0.000 n=10+10)
```

Fixes #1999
