### PR TITLE
sstable: use bytealloc.A in reader, writer, suffix rewriter

### DIFF
--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cespare/xxhash/v2"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/bytealloc"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/crc"
 	"github.com/cockroachdb/pebble/internal/invariants"
@@ -186,9 +187,9 @@ type Writer struct {
 	// indexBlockAlloc is used to bulk-allocate byte slices used to store index
 	// blocks in indexPartitions. These live until the index finishes.
 	indexBlockAlloc []byte
-	// indexSepAlloc is used to bulk-allocate index block seperator slices stored
+	// indexSepAlloc is used to bulk-allocate index block separator slices stored
 	// in indexPartitions. These live until the index finishes.
-	indexSepAlloc []byte
+	indexSepAlloc bytealloc.A
 
 	// To allow potentially overlapping (i.e. un-fragmented) range keys spans to
 	// be added to the Writer, a keyspan.Fragmenter is used to retain the keys
@@ -1533,17 +1534,12 @@ func shouldFlush(
 	return newSize > targetBlockSize
 }
 
-const keyAllocSize = 256 << 10
-
-func cloneKeyWithBuf(k InternalKey, buf []byte) ([]byte, InternalKey) {
+func cloneKeyWithBuf(k InternalKey, a bytealloc.A) (bytealloc.A, InternalKey) {
 	if len(k.UserKey) == 0 {
-		return buf, k
+		return a, k
 	}
-	if len(buf) < len(k.UserKey) {
-		buf = make([]byte, len(k.UserKey)+keyAllocSize)
-	}
-	n := copy(buf, k.UserKey)
-	return buf[n:], InternalKey{UserKey: buf[:n:n], Trailer: k.Trailer}
+	a, keyCopy := a.Copy(k.UserKey)
+	return a, InternalKey{UserKey: keyCopy, Trailer: k.Trailer}
 }
 
 // Invariants: The byte slice returned by finishIndexBlockProps is heap-allocated


### PR DESCRIPTION
We replace fairly large buffered allocations with bytealloc.A which is cleaner and more efficient when buffers are small.

Fixes #2000

UpdateSSTTimestamps benchmark changes:
```
name                                              old time/op    new time/op     delta
UpdateSSTTimestamps/numKeys=1/concurrency=0         41.6µs ± 0%     41.7µs ± 1%      ~     (p=0.690 n=5+5)
UpdateSSTTimestamps/numKeys=1/concurrency=1          149µs ± 5%       33µs ± 1%   -78.00%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1/concurrency=2          148µs ± 1%       34µs ± 0%   -77.10%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1/concurrency=4          151µs ± 1%       36µs ± 1%   -75.95%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1/concurrency=8          155µs ± 1%       41µs ± 1%   -73.64%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10/concurrency=0        43.9µs ± 1%     44.4µs ± 1%      ~     (p=0.056 n=5+5)
UpdateSSTTimestamps/numKeys=10/concurrency=1         158µs ± 1%       35µs ± 2%   -77.72%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10/concurrency=2         161µs ± 0%       37µs ± 1%   -77.25%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10/concurrency=4         164µs ± 0%       39µs ± 1%   -76.05%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10/concurrency=8         169µs ± 0%       44µs ± 0%   -74.09%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100/concurrency=0       66.2µs ± 0%     68.7µs ± 1%    +3.83%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100/concurrency=1        224µs ± 1%       55µs ± 3%   -75.45%  (p=0.016 n=4+5)
UpdateSSTTimestamps/numKeys=100/concurrency=2        226µs ± 1%       56µs ± 2%   -75.17%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100/concurrency=4        228µs ± 1%       58µs ± 1%   -74.53%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100/concurrency=8        235µs ± 2%       63µs ± 3%   -73.30%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1000/concurrency=0       266µs ± 1%      275µs ± 1%    +3.59%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1000/concurrency=1       629µs ± 0%      224µs ± 1%   -64.46%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1000/concurrency=2       807µs ± 6%      235µs ± 1%   -70.83%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1000/concurrency=4       850µs ± 5%      237µs ± 1%   -72.08%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1000/concurrency=8       834µs ± 3%      241µs ± 2%   -71.10%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10000/concurrency=0     2.25ms ± 2%     2.36ms ± 1%    +5.26%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10000/concurrency=1     1.93ms ± 1%     1.46ms ± 0%   -24.68%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10000/concurrency=2     2.34ms ± 2%     1.53ms ± 1%   -34.43%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10000/concurrency=4     2.50ms ± 3%     1.59ms ± 1%   -36.63%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10000/concurrency=8     3.37ms ± 7%     1.77ms ± 2%   -47.61%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100000/concurrency=0    22.7ms ± 1%     23.6ms ± 1%    +3.75%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100000/concurrency=1    12.8ms ± 1%     12.0ms ± 2%    -6.82%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100000/concurrency=2    10.4ms ± 3%     12.2ms ± 2%   +16.67%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100000/concurrency=4    12.8ms ± 1%     11.7ms ± 1%    -8.83%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100000/concurrency=8    13.7ms ± 3%     11.4ms ± 1%   -16.82%  (p=0.008 n=5+5)

name                                              old speed      new speed       delta
UpdateSSTTimestamps/numKeys=1/concurrency=0        380kB/s ± 0%    386kB/s ± 2%      ~     (p=0.238 n=4+5)
UpdateSSTTimestamps/numKeys=1/concurrency=1        106kB/s ± 6%    484kB/s ± 1%  +356.60%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1/concurrency=2        110kB/s ± 0%    470kB/s ± 0%  +327.27%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1/concurrency=4        110kB/s ± 0%    440kB/s ± 0%  +300.00%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1/concurrency=8        100kB/s ± 0%    390kB/s ± 0%  +290.00%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10/concurrency=0      3.65MB/s ± 1%   3.60MB/s ± 1%    -1.37%  (p=0.040 n=5+5)
UpdateSSTTimestamps/numKeys=10/concurrency=1      1.01MB/s ± 1%   4.55MB/s ± 2%  +349.11%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10/concurrency=2       990kB/s ± 0%   4364kB/s ± 1%  +340.81%  (p=0.016 n=4+5)
UpdateSSTTimestamps/numKeys=10/concurrency=4       970kB/s ± 0%   4064kB/s ± 1%  +318.97%  (p=0.016 n=4+5)
UpdateSSTTimestamps/numKeys=10/concurrency=8       950kB/s ± 0%   3652kB/s ± 1%  +284.42%  (p=0.016 n=4+5)
UpdateSSTTimestamps/numKeys=100/concurrency=0     24.2MB/s ± 0%   23.3MB/s ± 1%    -3.67%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100/concurrency=1     7.15MB/s ± 1%  29.12MB/s ± 3%  +307.13%  (p=0.016 n=4+5)
UpdateSSTTimestamps/numKeys=100/concurrency=2     7.09MB/s ± 1%  28.55MB/s ± 2%  +302.79%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100/concurrency=4     7.01MB/s ± 1%  27.52MB/s ± 1%  +292.52%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100/concurrency=8     6.80MB/s ± 2%  25.49MB/s ± 2%  +274.68%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1000/concurrency=0    60.2MB/s ± 1%   58.2MB/s ± 1%    -3.47%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1000/concurrency=1    25.4MB/s ± 0%   71.6MB/s ± 1%  +181.37%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1000/concurrency=2    19.9MB/s ± 6%   68.0MB/s ± 1%  +242.22%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1000/concurrency=4    18.9MB/s ± 5%   67.5MB/s ± 1%  +257.69%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1000/concurrency=8    19.2MB/s ± 3%   66.4MB/s ± 2%  +245.99%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10000/concurrency=0   71.2MB/s ± 2%   67.7MB/s ± 1%    -5.01%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10000/concurrency=1   82.8MB/s ± 1%  109.9MB/s ± 0%   +32.77%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10000/concurrency=2   68.5MB/s ± 2%  104.5MB/s ± 1%   +52.51%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10000/concurrency=4   63.9MB/s ± 3%  100.8MB/s ± 1%   +57.78%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10000/concurrency=8   47.5MB/s ± 7%   90.5MB/s ± 2%   +90.55%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100000/concurrency=0  70.5MB/s ± 1%   67.9MB/s ± 1%    -3.61%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100000/concurrency=1   125MB/s ± 1%    134MB/s ± 2%    +7.32%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100000/concurrency=2   153MB/s ± 3%    131MB/s ± 2%   -14.35%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100000/concurrency=4   125MB/s ± 1%    137MB/s ± 1%    +9.67%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100000/concurrency=8   117MB/s ± 3%    141MB/s ± 1%   +20.19%  (p=0.008 n=5+5)

name                                              old alloc/op   new alloc/op    delta
UpdateSSTTimestamps/numKeys=1/concurrency=0         27.7kB ± 0%     27.7kB ± 0%      ~     (p=0.421 n=5+5)
UpdateSSTTimestamps/numKeys=1/concurrency=1          562kB ± 0%       24kB ± 0%   -95.67%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1/concurrency=2          562kB ± 0%       25kB ± 0%   -95.61%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1/concurrency=4          563kB ± 0%       25kB ± 0%   -95.50%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1/concurrency=8          564kB ± 0%       27kB ± 0%   -95.27%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10/concurrency=0        27.9kB ± 0%     27.9kB ± 0%      ~     (p=0.889 n=5+5)
UpdateSSTTimestamps/numKeys=10/concurrency=1         592kB ± 0%       28kB ± 0%   -95.26%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10/concurrency=2         592kB ± 0%       28kB ± 0%   -95.21%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10/concurrency=4         593kB ± 0%       29kB ± 0%   -95.10%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10/concurrency=8         594kB ± 0%       30kB ± 0%   -94.89%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100/concurrency=0       31.7kB ± 0%     31.7kB ± 0%      ~     (p=0.190 n=5+5)
UpdateSSTTimestamps/numKeys=100/concurrency=1        866kB ± 0%       58kB ± 0%   -93.30%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100/concurrency=2        866kB ± 0%       58kB ± 0%   -93.26%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100/concurrency=4        867kB ± 0%       59kB ± 0%   -93.19%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100/concurrency=8        868kB ± 0%       60kB ± 0%   -93.04%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1000/concurrency=0      64.9kB ± 0%     64.9kB ± 0%      ~     (p=0.690 n=5+5)
UpdateSSTTimestamps/numKeys=1000/concurrency=1      2.91MB ± 0%     0.33MB ± 0%   -88.51%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1000/concurrency=2      3.71MB ± 0%     0.36MB ± 0%   -90.32%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1000/concurrency=4      3.71MB ± 0%     0.36MB ± 0%   -90.30%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1000/concurrency=8      3.71MB ± 0%     0.36MB ± 0%   -90.27%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10000/concurrency=0      413kB ± 0%      413kB ± 0%      ~     (p=0.841 n=5+5)
UpdateSSTTimestamps/numKeys=10000/concurrency=1     3.57MB ± 0%     1.20MB ± 0%   -66.48%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10000/concurrency=2     6.17MB ± 0%     1.55MB ± 0%   -74.88%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10000/concurrency=4     11.2MB ± 0%      1.9MB ± 0%   -83.39%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10000/concurrency=8     21.6MB ± 0%      2.7MB ± 0%   -87.43%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100000/concurrency=0    4.37MB ± 0%     4.37MB ± 0%      ~     (p=0.167 n=5+5)
UpdateSSTTimestamps/numKeys=100000/concurrency=1    5.59MB ± 0%     5.06MB ± 0%    -9.52%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100000/concurrency=2    8.44MB ± 0%     6.58MB ± 0%   -22.03%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100000/concurrency=4    14.0MB ± 0%      8.4MB ± 0%   -39.94%  (p=0.016 n=4+5)
UpdateSSTTimestamps/numKeys=100000/concurrency=8    25.1MB ± 0%     10.0MB ± 0%   -60.06%  (p=0.008 n=5+5)

name                                              old allocs/op  new allocs/op   delta
UpdateSSTTimestamps/numKeys=1/concurrency=0            168 ± 0%        168 ± 0%      ~     (all equal)
UpdateSSTTimestamps/numKeys=1/concurrency=1            149 ± 0%        148 ± 0%    -0.67%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1/concurrency=2            151 ± 0%        150 ± 0%    -0.66%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1/concurrency=4            155 ± 0%        154 ± 0%    -0.65%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1/concurrency=8            163 ± 0%        162 ± 0%    -0.61%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10/concurrency=0           171 ± 0%        171 ± 0%      ~     (all equal)
UpdateSSTTimestamps/numKeys=10/concurrency=1           150 ± 0%        149 ± 0%    -0.67%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10/concurrency=2           152 ± 0%        151 ± 0%    -0.66%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10/concurrency=4           156 ± 0%        155 ± 0%    -0.64%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10/concurrency=8           164 ± 0%        163 ± 0%    -0.61%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100/concurrency=0          174 ± 0%        174 ± 0%      ~     (all equal)
UpdateSSTTimestamps/numKeys=100/concurrency=1          149 ± 0%        148 ± 0%    -0.94%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100/concurrency=2          151 ± 0%        150 ± 0%    -0.66%  (p=0.000 n=5+4)
UpdateSSTTimestamps/numKeys=100/concurrency=4          155 ± 0%        154 ± 0%    -0.65%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100/concurrency=8          163 ± 0%        162 ± 0%    -0.61%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1000/concurrency=0         178 ± 0%        178 ± 0%      ~     (p=0.444 n=5+5)
UpdateSSTTimestamps/numKeys=1000/concurrency=1         152 ± 0%        150 ± 0%    -1.32%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1000/concurrency=2         164 ± 0%        161 ± 0%      ~     (p=0.079 n=4+5)
UpdateSSTTimestamps/numKeys=1000/concurrency=4         169 ± 0%        165 ± 0%    -2.37%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1000/concurrency=8         177 ± 0%        173 ± 0%      ~     (p=0.079 n=4+5)
UpdateSSTTimestamps/numKeys=10000/concurrency=0        186 ± 0%        186 ± 0%      ~     (all equal)
UpdateSSTTimestamps/numKeys=10000/concurrency=1        162 ± 0%        161 ± 0%    -0.86%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10000/concurrency=2        175 ± 0%        175 ± 0%      ~     (p=0.444 n=5+5)
UpdateSSTTimestamps/numKeys=10000/concurrency=4        196 ± 0%        198 ± 0%    +1.23%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10000/concurrency=8        247 ± 1%        245 ± 0%      ~     (p=0.167 n=5+5)
UpdateSSTTimestamps/numKeys=100000/concurrency=0       204 ± 1%        204 ± 0%      ~     (p=1.000 n=5+5)
UpdateSSTTimestamps/numKeys=100000/concurrency=1       159 ± 0%        170 ± 0%    +6.92%  (p=0.029 n=4+4)
UpdateSSTTimestamps/numKeys=100000/concurrency=2       179 ± 0%        193 ± 0%    +7.60%  (p=0.016 n=4+5)
UpdateSSTTimestamps/numKeys=100000/concurrency=4       213 ± 1%        234 ± 1%    +9.94%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100000/concurrency=8       283 ± 2%        314 ± 1%   +10.80%  (p=0.008 n=5+5)
```