### PR TITLE
sstable: skip two known test flakes on windows

### DIFF
--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -626,6 +627,9 @@ func TestBytesIterated(t *testing.T) {
 		testBytesIteratedWithCompression(t, SnappyCompression, 1, blockSizes, []uint64{1e5, 1e5, 1e5, 1e5, 1e5})
 	})
 	t.Run("Uncompressed", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("See #1897.")
+		}
 		testBytesIteratedWithCompression(t, NoCompression, 0, blockSizes, []uint64{1e5, 1e5, 1e5, 1e5, 1e5})
 	})
 	t.Run("Zstd", func(t *testing.T) {

--- a/sstable/unsafe_test.go
+++ b/sstable/unsafe_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"runtime"
 	"testing"
 	"time"
 	"unsafe"
@@ -17,6 +18,9 @@ import (
 )
 
 func TestGetBytes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("See #1897.")
+	}
 	const size = (1 << 31) - 1
 	block := make([]byte, size)
 	data := getBytes(unsafe.Pointer(&block[0]), size)


### PR DESCRIPTION
Skip two tests that are known to be flakes when run on windows.

Touches #1897.