### PR TITLE
metamorphic: vary bloom filter setting and UseL6Filters for iterators

### DIFF
--- a/internal/metamorphic/generator.go
+++ b/internal/metamorphic/generator.go
@@ -33,12 +33,15 @@ type iterOpts struct {
 	filterMin uint64
 	filterMax uint64
 
+	// see IterOptions.UseL6Filters.
+	useL6Filters bool
+
 	// NB: If adding or removing fields, ensure IsZero is in sync.
 }
 
 func (o iterOpts) IsZero() bool {
 	return o.lower == nil && o.upper == nil && o.keyTypes == 0 &&
-		o.maskSuffix == nil && o.filterMin == 0 && o.filterMax == 0
+		o.maskSuffix == nil && o.filterMin == 0 && o.filterMax == 0 && !o.useL6Filters
 }
 
 type generator struct {
@@ -528,11 +531,11 @@ func (g *generator) newIter() {
 	}
 	opts.keyTypes, opts.maskSuffix = g.randKeyTypesAndMask()
 
-	// With a low probability, enable automatic filtering of keys with suffixes
+	// With 10% probability, enable automatic filtering of keys with suffixes
 	// not in the provided range. This filtering occurs both through
 	// block-property filtering and explicitly within the iterator operations to
 	// ensure determinism.
-	if g.rng.Intn(10) == 1 {
+	if g.rng.Float64() <= 0.1 {
 		max := g.cfg.writeSuffixDist.Max()
 		opts.filterMin, opts.filterMax = g.rng.Uint64n(max)+1, g.rng.Uint64n(max)+1
 		if opts.filterMin > opts.filterMax {
@@ -540,6 +543,11 @@ func (g *generator) newIter() {
 		} else if opts.filterMin == opts.filterMax {
 			opts.filterMax = opts.filterMin + 1
 		}
+	}
+
+	// Enable L6 filters with a 10% probability.
+	if g.rng.Float64() <= 0.1 {
+		opts.useL6Filters = true
 	}
 
 	g.itersLastOpts[iterID] = opts
@@ -1228,6 +1236,10 @@ func (g *generator) maybeMutateOptions(opts *iterOpts) {
 			} else if opts.filterMin == opts.filterMax {
 				opts.filterMax = opts.filterMin + 1
 			}
+		}
+		// With 10% probability, flip enablement of L6 filters.
+		if g.rng.Float64() <= 0.1 {
+			opts.useL6Filters = !opts.useL6Filters
 		}
 	}
 }

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -661,8 +661,8 @@ func (o *newIterOp) run(t *test, h historyRecorder) {
 }
 
 func (o *newIterOp) String() string {
-	return fmt.Sprintf("%s = %s.NewIter(%q, %q, %d /* key types */, %d, %d, %q /* masking suffix */)",
-		o.iterID, o.readerID, o.lower, o.upper, o.keyTypes, o.filterMin, o.filterMax, o.maskSuffix)
+	return fmt.Sprintf("%s = %s.NewIter(%q, %q, %d /* key types */, %d, %d, %t /* use L6 filters */, %q /* masking suffix */)",
+		o.iterID, o.readerID, o.lower, o.upper, o.keyTypes, o.filterMin, o.filterMax, o.useL6Filters, o.maskSuffix)
 }
 
 func (o *newIterOp) receiver() objID { return o.readerID }
@@ -712,9 +712,9 @@ func (o *newIterUsingCloneOp) run(t *test, h historyRecorder) {
 }
 
 func (o *newIterUsingCloneOp) String() string {
-	return fmt.Sprintf("%s = %s.Clone(%t, %q, %q, %d /* key types */, %d, %d, %q /* masking suffix */)",
+	return fmt.Sprintf("%s = %s.Clone(%t, %q, %q, %d /* key types */, %d, %d, %t /* use L6 filters */, %q /* masking suffix */)",
 		o.iterID, o.existingIterID, o.refreshBatch, o.lower, o.upper,
-		o.keyTypes, o.filterMin, o.filterMax, o.maskSuffix)
+		o.keyTypes, o.filterMin, o.filterMax, o.useL6Filters, o.maskSuffix)
 }
 
 func (o *newIterUsingCloneOp) receiver() objID { return o.existingIterID }
@@ -798,8 +798,8 @@ func (o *iterSetOptionsOp) run(t *test, h historyRecorder) {
 }
 
 func (o *iterSetOptionsOp) String() string {
-	return fmt.Sprintf("%s.SetOptions(%q, %q, %d /* key types */, %d, %d, %q /* masking suffix */)",
-		o.iterID, o.lower, o.upper, o.keyTypes, o.filterMin, o.filterMax, o.maskSuffix)
+	return fmt.Sprintf("%s.SetOptions(%q, %q, %d /* key types */, %d, %d, %t /* use L6 filters */, %q /* masking suffix */)",
+		o.iterID, o.lower, o.upper, o.keyTypes, o.filterMin, o.filterMax, o.useL6Filters, o.maskSuffix)
 }
 
 func iterOptions(o iterOpts) *pebble.IterOptions {
@@ -820,6 +820,7 @@ func iterOptions(o iterOpts) *pebble.IterOptions {
 		RangeKeyMasking: pebble.RangeKeyMasking{
 			Suffix: o.maskSuffix,
 		},
+		UseL6Filters: o.useL6Filters,
 	}
 	if opts.RangeKeyMasking.Suffix != nil {
 		opts.RangeKeyMasking.Filter = func() pebble.BlockPropertyFilterMask {

--- a/internal/metamorphic/parser.go
+++ b/internal/metamorphic/parser.go
@@ -77,9 +77,9 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	case *newIndexedBatchOp:
 		return nil, &t.batchID, nil
 	case *newIterOp:
-		return &t.readerID, &t.iterID, []interface{}{&t.lower, &t.upper, &t.keyTypes, &t.filterMin, &t.filterMax, &t.maskSuffix}
+		return &t.readerID, &t.iterID, []interface{}{&t.lower, &t.upper, &t.keyTypes, &t.filterMin, &t.filterMax, &t.useL6Filters, &t.maskSuffix}
 	case *newIterUsingCloneOp:
-		return &t.existingIterID, &t.iterID, []interface{}{&t.refreshBatch, &t.lower, &t.upper, &t.keyTypes, &t.filterMin, &t.filterMax, &t.maskSuffix}
+		return &t.existingIterID, &t.iterID, []interface{}{&t.refreshBatch, &t.lower, &t.upper, &t.keyTypes, &t.filterMin, &t.filterMax, &t.useL6Filters, &t.maskSuffix}
 	case *newSnapshotOp:
 		return nil, &t.snapID, nil
 	case *iterNextOp:
@@ -99,7 +99,7 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	case *iterSetBoundsOp:
 		return &t.iterID, nil, []interface{}{&t.lower, &t.upper}
 	case *iterSetOptionsOp:
-		return &t.iterID, nil, []interface{}{&t.lower, &t.upper, &t.keyTypes, &t.filterMin, &t.filterMax, &t.maskSuffix}
+		return &t.iterID, nil, []interface{}{&t.lower, &t.upper, &t.keyTypes, &t.filterMin, &t.filterMax, &t.useL6Filters, &t.maskSuffix}
 	case *singleDeleteOp:
 		return &t.writerID, nil, []interface{}{&t.key, &t.maybeReplaceDelete}
 	case *rangeKeyDeleteOp:


### PR DESCRIPTION
#### metamorphic: randomize bloom filter setting

Add support for randomizing the bloom filter bits-per-key setting in
metamorphic tests.

Informs #2127

#### metamorphic: vary UseL6Filters for iterators

Fixes #2127.
