### PR TITLE
*: apply Go 1.19 gofmt

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -82,7 +82,7 @@ func (d DeferredBatchOp) Finish() error {
 // consumers should use a batch per goroutine or provide their own
 // synchronization.
 //
-// Indexing
+// # Indexing
 //
 // Batches can be optionally indexed (see DB.NewIndexedBatch). An indexed batch
 // allows iteration via an Iterator (see Batch.NewIter). The iterator provides
@@ -104,7 +104,7 @@ func (d DeferredBatchOp) Finish() error {
 // significantly slower than inserting into a non-indexed batch. Only use an
 // indexed batch if you require reading from it.
 //
-// Atomic commit
+// # Atomic commit
 //
 // The operations in a batch are persisted by calling Batch.Commit which is
 // equivalent to calling DB.Apply(batch). A batch is committed atomically by
@@ -115,7 +115,7 @@ func (d DeferredBatchOp) Finish() error {
 // Batch.Commit will guarantee that the batch is persisted to disk before
 // returning. See commitPipeline for more on the implementation details.
 //
-// Large batches
+// # Large batches
 //
 // The size of a batch is limited only by available memory (be aware that
 // indexed batches require considerably additional memory for the skiplist
@@ -140,34 +140,34 @@ func (d DeferredBatchOp) Finish() error {
 // memtable have the same big-O time, but the constant factor dominates
 // here. Sorting is significantly faster and uses significantly less memory.
 //
-// Internal representation
+// # Internal representation
 //
 // The internal batch representation is a contiguous byte buffer with a fixed
 // 12-byte header, followed by a series of records.
 //
-//   +-------------+------------+--- ... ---+
-//   | SeqNum (8B) | Count (4B) |  Entries  |
-//   +-------------+------------+--- ... ---+
+//	+-------------+------------+--- ... ---+
+//	| SeqNum (8B) | Count (4B) |  Entries  |
+//	+-------------+------------+--- ... ---+
 //
 // Each record has a 1-byte kind tag prefix, followed by 1 or 2 length prefixed
 // strings (varstring):
 //
-//   +-----------+-----------------+-------------------+
-//   | Kind (1B) | Key (varstring) | Value (varstring) |
-//   +-----------+-----------------+-------------------+
+//	+-----------+-----------------+-------------------+
+//	| Kind (1B) | Key (varstring) | Value (varstring) |
+//	+-----------+-----------------+-------------------+
 //
 // A varstring is a varint32 followed by N bytes of data. The Kind tags are
 // exactly those specified by InternalKeyKind. The following table shows the
 // format for records of each kind:
 //
-//   InternalKeyKindDelete         varstring
-//   InternalKeyKindLogData        varstring
-//   InternalKeyKindSet            varstring varstring
-//   InternalKeyKindMerge          varstring varstring
-//   InternalKeyKindRangeDelete    varstring varstring
-//   InternalKeyKindRangeKeySet    varstring varstring
-//   InternalKeyKindRangeKeyUnset  varstring varstring
-//   InternalKeyKindRangeKeyDelete varstring varstring
+//	InternalKeyKindDelete         varstring
+//	InternalKeyKindLogData        varstring
+//	InternalKeyKindSet            varstring varstring
+//	InternalKeyKindMerge          varstring varstring
+//	InternalKeyKindRangeDelete    varstring varstring
+//	InternalKeyKindRangeKeySet    varstring varstring
+//	InternalKeyKindRangeKeyUnset  varstring varstring
+//	InternalKeyKindRangeKeyDelete varstring varstring
 //
 // The intuitive understanding here are that the arguments to Delete, Set,
 // Merge, DeleteRange and RangeKeyDelete are encoded into the batch. The

--- a/cache.go
+++ b/cache.go
@@ -15,9 +15,9 @@ type Cache = cache.Cache
 // creator of the cache should usually release their reference after the DB is
 // created.
 //
-//   c := pebble.NewCache(...)
-//   defer c.Unref()
-//   d, err := pebble.Open(pebble.Options{Cache: c})
+//	c := pebble.NewCache(...)
+//	defer c.Unref()
+//	d, err := pebble.Open(pebble.Options{Cache: c})
 func NewCache(size int64) *cache.Cache {
 	return cache.New(size)
 }

--- a/commit.go
+++ b/commit.go
@@ -140,8 +140,8 @@ type commitEnv struct {
 // (contained in a single Batch) atomically to the DB. The steps are
 // conceptually:
 //
-//   1. Write the batch to the WAL and optionally sync the WAL
-//   2. Apply the mutations in the batch to the memtable
+//  1. Write the batch to the WAL and optionally sync the WAL
+//  2. Apply the mutations in the batch to the memtable
 //
 // These two simple steps are made complicated by the desire for high
 // performance. In the absence of concurrency, performance is limited by how
@@ -150,10 +150,10 @@ type commitEnv struct {
 // pipeline. Performance under concurrency is the primary concern of the commit
 // pipeline, though it also needs to maintain two invariants:
 //
-//   1. Batches need to be written to the WAL in sequence number order.
-//   2. Batches need to be made visible for reads in sequence number order. This
-//      invariant arises from the use of a single sequence number which
-//      indicates which mutations are visible.
+//  1. Batches need to be written to the WAL in sequence number order.
+//  2. Batches need to be made visible for reads in sequence number order. This
+//     invariant arises from the use of a single sequence number which
+//     indicates which mutations are visible.
 //
 // Taking these invariants into account, let's revisit the work the commit
 // pipeline needs to perform. Writing the batch to the WAL is necessarily
@@ -173,14 +173,14 @@ type commitEnv struct {
 //
 // The full outline of the commit pipeline operation is as follows:
 //
-//   with commitPipeline mutex locked:
-//     assign batch sequence number
-//     write batch to WAL
-//   (optionally) add batch to WAL sync list
-//   apply batch to memtable (concurrently)
-//   wait for earlier batches to apply
-//   ratchet read sequence number
-//   (optionally) wait for the WAL to sync
+//	with commitPipeline mutex locked:
+//	  assign batch sequence number
+//	  write batch to WAL
+//	(optionally) add batch to WAL sync list
+//	apply batch to memtable (concurrently)
+//	wait for earlier batches to apply
+//	ratchet read sequence number
+//	(optionally) wait for the WAL to sync
 //
 // As soon as a batch has been written to the WAL, the commitPipeline mutex is
 // released allowing another batch to write to the WAL. Each commit operation

--- a/compaction_iter.go
+++ b/compaction_iter.go
@@ -77,22 +77,22 @@ import (
 // is that snapshots define stripes and entries are collapsed within stripes,
 // but not across stripes. Consider the following scenario:
 //
-//   a.PUT.9
-//   a.DEL.8
-//   a.PUT.7
-//   a.DEL.6
-//   a.PUT.5
+//	a.PUT.9
+//	a.DEL.8
+//	a.PUT.7
+//	a.DEL.6
+//	a.PUT.5
 //
 // In the absence of snapshots these entries would be collapsed to
 // a.PUT.9. What if there is a snapshot at sequence number 7? The entries can
 // be divided into two stripes and collapsed within the stripes:
 //
-//   a.PUT.9        a.PUT.9
-//   a.DEL.8  --->
-//   a.PUT.7
-//   --             --
-//   a.DEL.6  --->  a.DEL.6
-//   a.PUT.5
+//	a.PUT.9        a.PUT.9
+//	a.DEL.8  --->
+//	a.PUT.7
+//	--             --
+//	a.DEL.6  --->  a.DEL.6
+//	a.PUT.5
 //
 // All of the rules described earlier still apply, but they are confined to
 // operate within a snapshot stripe. Snapshots only affect compaction when the
@@ -111,13 +111,13 @@ import (
 // subject to the rules for snapshots. For example, consider the two range
 // tombstones [a,e)#1 and [c,g)#2:
 //
-//   2:     c-------g
-//   1: a-------e
+//	2:     c-------g
+//	1: a-------e
 //
 // These tombstones will be fragmented into:
 //
-//   2:     c---e---g
-//   1: a---c---e
+//	2:     c---e---g
+//	1: a---c---e
 //
 // Do we output the fragment [c,e)#1? Since it is covered by [c-e]#2 the answer
 // depends on whether it is in a new snapshot stripe.

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -461,18 +461,18 @@ func (pc *pickedCompaction) initMultiLevelCompaction(
 // truncation of range tombstones to atomic compaction unit boundaries.
 // Consider the scenario:
 //
-//   L3:
-//     12:[a#2,15-b#1,1]
-//     13:[b#0,15-d#72057594037927935,15]
+//	L3:
+//	  12:[a#2,15-b#1,1]
+//	  13:[b#0,15-d#72057594037927935,15]
 //
 // These sstables contain a range tombstone [a-d)#2 which spans the two
 // sstables. The two sstables need to always be kept together. Compacting
 // sstable 13 independently of sstable 12 would result in:
 //
-//   L3:
-//     12:[a#2,15-b#1,1]
-//   L4:
-//     14:[b#0,15-d#72057594037927935,15]
+//	L3:
+//	  12:[a#2,15-b#1,1]
+//	L4:
+//	  14:[b#0,15-d#72057594037927935,15]
 //
 // This state is still ok, but when sstable 12 is next compacted, its range
 // tombstones will be truncated at "b" (the largest key in its atomic

--- a/data_test.go
+++ b/data_test.go
@@ -712,16 +712,16 @@ func runCompactCmd(td *datadriven.TestData, d *DB) error {
 // InternalKey's string representation, as understood by
 // ParseInternalKey, followed a colon and the corresponding value.
 //
-//     b.SET.50:foo
-//     c.DEL.20
+//	b.SET.50:foo
+//	c.DEL.20
 //
 // Range keys may be encoded by prefixing the line with `rangekey:`,
 // followed by the keyspan.Span string representation, as understood
 // by keyspan.ParseSpan.
 //
-//     rangekey:b-d:{(#5,RANGEKEYSET,@2,foo)}
+//	rangekey:b-d:{(#5,RANGEKEYSET,@2,foo)}
 //
-// Mechanics
+// # Mechanics
 //
 // runDBDefineCmd works by simulating a flush for every file written.
 // Keys are written to a memtable. When a file is complete, the table

--- a/db.go
+++ b/db.go
@@ -1691,14 +1691,14 @@ func (d *DB) SSTables(opts ...SSTablesOption) ([][]SSTableInfo, error) {
 // EstimateDiskUsage returns the estimated filesystem space used in bytes for
 // storing the range `[start, end]`. The estimation is computed as follows:
 //
-// - For sstables fully contained in the range the whole file size is included.
-// - For sstables partially contained in the range the overlapping data block sizes
-//   are included. Even if a data block partially overlaps, or we cannot determine
-//   overlap due to abbreviated index keys, the full data block size is included in
-//   the estimation. Note that unlike fully contained sstables, none of the
-//   meta-block space is counted for partially overlapped files.
-// - There may also exist WAL entries for unflushed keys in this range. This
-//   estimation currently excludes space used for the range in the WAL.
+//   - For sstables fully contained in the range the whole file size is included.
+//   - For sstables partially contained in the range the overlapping data block sizes
+//     are included. Even if a data block partially overlaps, or we cannot determine
+//     overlap due to abbreviated index keys, the full data block size is included in
+//     the estimation. Note that unlike fully contained sstables, none of the
+//     meta-block space is counted for partially overlapped files.
+//   - There may also exist WAL entries for unflushed keys in this range. This
+//     estimation currently excludes space used for the range in the WAL.
 func (d *DB) EstimateDiskUsage(start, end []byte) (uint64, error) {
 	if err := d.closed.Load(); err != nil {
 		panic(err)

--- a/ingest.go
+++ b/ingest.go
@@ -644,18 +644,18 @@ func ingestTargetLevel(
 //
 // The steps for ingestion are:
 //
-//   1. Allocate file numbers for every sstable being ingested.
-//   2. Load the metadata for all sstables being ingest.
-//   3. Sort the sstables by smallest key, verifying non overlap.
-//   4. Hard link (or copy) the sstables into the DB directory.
-//   5. Allocate a sequence number to use for all of the entries in the
-//      sstables. This is the step where overlap with memtables is
-//      determined. If there is overlap, we remember the most recent memtable
-//      that overlaps.
-//   6. Update the sequence number in the ingested sstables.
-//   7. Wait for the most recent memtable that overlaps to flush (if any).
-//   8. Add the ingested sstables to the version (DB.ingestApply).
-//   9. Publish the ingestion sequence number.
+//  1. Allocate file numbers for every sstable being ingested.
+//  2. Load the metadata for all sstables being ingest.
+//  3. Sort the sstables by smallest key, verifying non overlap.
+//  4. Hard link (or copy) the sstables into the DB directory.
+//  5. Allocate a sequence number to use for all of the entries in the
+//     sstables. This is the step where overlap with memtables is
+//     determined. If there is overlap, we remember the most recent memtable
+//     that overlaps.
+//  6. Update the sequence number in the ingested sstables.
+//  7. Wait for the most recent memtable that overlaps to flush (if any).
+//  8. Add the ingested sstables to the version (DB.ingestApply).
+//  9. Publish the ingestion sequence number.
 //
 // Note that if the mutable memtable overlaps with ingestion, a flush of the
 // memtable is forced equivalent to DB.Flush. Additionally, subsequent

--- a/internal/base/comparer.go
+++ b/internal/base/comparer.go
@@ -70,11 +70,11 @@ type Successor func(dst, a []byte) []byte
 // returns the smallest key that is larger than the given prefix a.
 // ImmediateSuccessor must return a prefix key k such that:
 //
-//   Split(k) == len(k) and Compare(k, a) > 0
+//	Split(k) == len(k) and Compare(k, a) > 0
 //
 // and there exists no representable k2 such that:
 //
-//   Split(k2) == len(k2) and Compare(k2, a) > 0 and Compare(k2, k) < 0
+//	Split(k2) == len(k2) and Compare(k2, a) > 0 and Compare(k2, k) < 0
 //
 // As an example, an implementation built on the natural byte ordering using
 // bytes.Compare could append a `\0` to `a`.
@@ -98,24 +98,23 @@ type ImmediateSuccessor func(dst, a []byte) []byte
 //
 // The returned prefix must have the following properties:
 //
-// 1) The prefix must be a byte prefix:
+//  1. The prefix must be a byte prefix:
 //
-//    bytes.HasPrefix(a, prefix(a))
+//     bytes.HasPrefix(a, prefix(a))
 //
-// 2) A key consisting of just a prefix must sort before all other keys with
-//    that prefix:
+//  2. A key consisting of just a prefix must sort before all other keys with
+//     that prefix:
 //
-//    Compare(prefix(a), a) < 0 if len(suffix(a)) > 0
+//     Compare(prefix(a), a) < 0 if len(suffix(a)) > 0
 //
-// 3) Prefixes must be used to order keys before suffixes:
+//  3. Prefixes must be used to order keys before suffixes:
 //
-//    If Compare(a, b) <= 0, then Compare(prefix(a), prefix(b)) <= 0
+//     If Compare(a, b) <= 0, then Compare(prefix(a), prefix(b)) <= 0
 //
-// 4) Suffixes themselves must be valid keys and comparable, respecting the same
-//    ordering as within a key.
+//  4. Suffixes themselves must be valid keys and comparable, respecting the same
+//     ordering as within a key.
 //
-//    If Compare(prefix(a), prefix(b)) == 0, then Compare(suffix(a), suffix(b)) == Compare(a, b)
-//
+//     If Compare(prefix(a), prefix(b)) == 0, then Compare(suffix(a), suffix(b)) == Compare(a, b)
 type Split func(a []byte) int
 
 // Comparer defines a total ordering over the space of []byte keys: a 'less

--- a/internal/base/merger.go
+++ b/internal/base/merger.go
@@ -23,7 +23,7 @@ type Merge func(key, value []byte) (ValueMerger, error)
 //
 // The merge operation must be associative. That is, for the values A, B, C:
 //
-//   Merge(A).MergeOlder(B).MergeOlder(C) == Merge(C).MergeNewer(B).MergeNewer(A)
+//	Merge(A).MergeOlder(B).MergeOlder(C) == Merge(C).MergeNewer(B).MergeNewer(A)
 //
 // Examples of merge operators are integer addition, list append, and string
 // concatenation.

--- a/internal/cache/clockpro.go
+++ b/internal/cache/clockpro.go
@@ -603,7 +603,7 @@ type Metrics struct {
 // efficient eviction of all of the blocks for a file which is used when an
 // sstable is deleted from disk.
 //
-// Memory Management
+// # Memory Management
 //
 // In order to reduce pressure on the Go GC, manual memory management is
 // performed for the data stored in the cache. Manual memory management is
@@ -639,9 +639,9 @@ type Cache struct {
 // creator of the cache should usually release their reference after the DB is
 // created.
 //
-//   c := cache.New(...)
-//   defer c.Unref()
-//   d, err := pebble.Open(pebble.Options{Cache: c})
+//	c := cache.New(...)
+//	defer c.Unref()
+//	d, err := pebble.Open(pebble.Options{Cache: c})
 func New(size int64) *Cache {
 	return newShards(size, 2*runtime.GOMAXPROCS(0))
 }

--- a/internal/cache/entry.go
+++ b/internal/cache/entry.go
@@ -30,7 +30,7 @@ func (p entryType) String() string {
 // Using manual memory management for entries is technically a volation of the
 // Cgo pointer rules:
 //
-//   https://golang.org/cmd/cgo/#hdr-Passing_pointers
+//	https://golang.org/cmd/cgo/#hdr-Passing_pointers
 //
 // Specifically, Go pointers should not be stored in C allocated memory. The
 // reason for this rule is that the Go GC will not look at C allocated memory

--- a/internal/cache/robin_hood.go
+++ b/internal/cache/robin_hood.go
@@ -95,11 +95,11 @@ func (e robinHoodEntries) free() {
 // table is 2, maxDist is computed as 4 and the actual size of the entry slice
 // is 6.
 //
-//   +---+---+---+---+---+---+
-//   | 0 | 1 | 2 | 3 | 4 | 5 |
-//   +---+---+---+---+---+---+
-//           ^
-//          size
+//	+---+---+---+---+---+---+
+//	| 0 | 1 | 2 | 3 | 4 | 5 |
+//	+---+---+---+---+---+---+
+//	        ^
+//	       size
 //
 // In this scenario, the target entry for a key will always be in the range
 // [0,1]. Valid entries may reside in the range [0,4] due to the linear probing

--- a/internal/crc/crc.go
+++ b/internal/crc/crc.go
@@ -10,7 +10,9 @@
 // look like a checksum.
 //
 // To calculate the uint32 checksum of some data:
+//
 //	var u uint32 = crc.New(data).Value()
+//
 // In pebble, the uint32 value is then stored in little-endian format.
 package crc // import "github.com/cockroachdb/pebble/internal/crc"
 

--- a/internal/fastrand/fastrand.go
+++ b/internal/fastrand/fastrand.go
@@ -7,9 +7,11 @@ package fastrand
 import _ "unsafe" // required by go:linkname
 
 // Uint32 returns a lock free uint32 value.
+//
 //go:linkname Uint32 runtime.fastrand
 func Uint32() uint32
 
 // Uint32n returns a lock free uint32 value in the interval [0, n).
+//
 //go:linkname Uint32n runtime.fastrandn
 func Uint32n(n uint32) uint32

--- a/internal/keyspan/fragmenter.go
+++ b/internal/keyspan/fragmenter.go
@@ -108,20 +108,20 @@ func (f *Fragmenter) checkInvariants(buf []Span) {
 // increasing start key order. That is, Add must be called with a series
 // of spans like:
 //
-//   a---e
-//     c---g
-//     c-----i
-//            j---n
-//            j-l
+//	a---e
+//	  c---g
+//	  c-----i
+//	         j---n
+//	         j-l
 //
 // We need to fragment the spans at overlap points. In the above
 // example, we'd create:
 //
-//   a-c-e
-//     c-e-g
-//     c-e-g-i
-//            j-l-n
-//            j-l
+//	a-c-e
+//	  c-e-g
+//	  c-e-g-i
+//	         j-l-n
+//	         j-l
 //
 // The fragments need to be output sorted by start key, and for equal start
 // keys, sorted by descending sequence number. This last part requires a mild
@@ -134,42 +134,42 @@ func (f *Fragmenter) checkInvariants(buf []Span) {
 //
 // Walking through the example above, we start with:
 //
-//   a---e
+//	a---e
 //
 // Next we add [c,g) resulting in:
 //
-//   a-c-e
-//     c---g
+//	a-c-e
+//	  c---g
 //
 // The fragment [a,c) is flushed leaving the pending spans as:
 //
-//   c-e
-//   c---g
+//	c-e
+//	c---g
 //
 // The next span is [c,i):
 //
-//   c-e
-//   c---g
-//   c-----i
+//	c-e
+//	c---g
+//	c-----i
 //
 // No fragments are flushed. The next span is [j,n):
 //
-//   c-e
-//   c---g
-//   c-----i
-//          j---n
+//	c-e
+//	c---g
+//	c-----i
+//	       j---n
 //
 // The fragments [c,e), [c,g) and [c,i) are flushed. We sort these fragments
 // by their end key, then split the fragments on the end keys:
 //
-//   c-e
-//   c-e-g
-//   c-e---i
+//	c-e
+//	c-e-g
+//	c-e---i
 //
 // The [c,e) fragments all get flushed leaving:
 //
-//   e-g
-//   e---i
+//	e-g
+//	e---i
 //
 // This process continues until there are no more fragments to flush.
 //
@@ -270,20 +270,21 @@ func (f *Fragmenter) Empty() bool {
 // emitting of spans which straddle an sstable boundary. Consider
 // the scenario:
 //
-//     a---------k#10
-//          f#8
-//          f#7
-///
+//	a---------k#10
+//	     f#8
+//	     f#7
+//
+// /
 // Let's say the next user key after f is g. Calling TruncateAndFlushTo(g) will
 // flush this span:
 //
-//    a-------g#10
-//         f#8
-//         f#7
+//	a-------g#10
+//	     f#8
+//	     f#7
 //
 // And leave this one in f.pending:
 //
-//            g----k#10
+//	g----k#10
 //
 // WARNING: The fragmenter could hold on to the specified end key. Ensure it's
 // a safe byte slice that could outlast the current sstable output, and one
@@ -374,8 +375,8 @@ func (f *Fragmenter) truncateAndFlush(key []byte) {
 // we want to flush (but not truncate) all range tombstones that start at or
 // before the first key in the next sstable. Consider:
 //
-//   a---e#10
-//   a------h#9
+//	a---e#10
+//	a------h#9
 //
 // If a compaction splits the sstables at key c we want the first sstable to
 // contain the tombstones [a,e)#10 and [a,e)#9. Fragmentation would naturally

--- a/internal/keyspan/interleaving_iter.go
+++ b/internal/keyspan/interleaving_iter.go
@@ -79,13 +79,13 @@ type SpanMask interface {
 // SeekGE or SeekPrefixGE search key. Consider, for example SetBounds('c', 'e'),
 // with an iterator containing the Span [a,z):
 //
-//     First()     = `c#72057594037927935,21`        Span() = [c,e)
-//     SeekGE('d') = `d#72057594037927935,21`        Span() = [c,e)
+//	First()     = `c#72057594037927935,21`        Span() = [c,e)
+//	SeekGE('d') = `d#72057594037927935,21`        Span() = [c,e)
 //
 // InterleavedIter does not interleave synthetic markers for spans that do not
 // contain any keys.
 //
-// SpanMask
+// # SpanMask
 //
 // InterelavingIter takes a SpanMask parameter that may be used to configure the
 // behavior of the iterator. See the documentation on the SpanMask type.

--- a/internal/keyspan/merging_iter.go
+++ b/internal/keyspan/merging_iter.go
@@ -76,34 +76,34 @@ func visibleTransform(snapshot uint64) Transformer {
 // trailer descending. If the MergingIter is configured with a Transformer, it's
 // permitted to modify the ordering of the spans' keys returned by MergingIter.
 //
-// Algorithm
+// # Algorithm
 //
 // The merging iterator wraps child iterators, merging and fragmenting spans
 // across levels. The high-level algorithm is:
 //
-//     1. Initialize the heap with bound keys from child iterators' spans.
-//     2. Find the next [or previous] two unique user keys' from bounds.
-//     3. Consider the span formed between the two unique user keys a candidate
-//        span.
-//     4. Determine if any of the child iterators' spans overlap the candidate
-//        span.
-//         4a. If any of the child iterator's current bounds are end keys
-//             (during forward iteration) or start keys (during reverse
-//             iteration), then all the spans with that bound overlap the
-//             candidate span.
-//         4b. Apply the configured transform, which may remove keys.
-//         4b. If no spans overlap, forget the smallest (forward iteration)
-//             or largest (reverse iteration) unique user key and advance
-//             the iterators to the next unique user key. Start again from 3.
+//  1. Initialize the heap with bound keys from child iterators' spans.
+//  2. Find the next [or previous] two unique user keys' from bounds.
+//  3. Consider the span formed between the two unique user keys a candidate
+//     span.
+//  4. Determine if any of the child iterators' spans overlap the candidate
+//     span.
+//     4a. If any of the child iterator's current bounds are end keys
+//     (during forward iteration) or start keys (during reverse
+//     iteration), then all the spans with that bound overlap the
+//     candidate span.
+//     4b. Apply the configured transform, which may remove keys.
+//     4c. If no spans overlap, forget the smallest (forward iteration)
+//     or largest (reverse iteration) unique user key and advance
+//     the iterators to the next unique user key. Start again from 3.
 //
-// Detailed algorithm
+// # Detailed algorithm
 //
 // Each level (i0, i1, ...) has a user-provided input FragmentIterator. The
 // merging iterator steps through individual boundaries of the underlying
 // spans separately. If the underlying FragmentIterator has fragments
 // [a,b){#2,#1} [b,c){#1} the mergingIterLevel.{next,prev} step through:
 //
-//     (a, start), (b, end), (b, start), (c, end)
+//	(a, start), (b, end), (b, start), (c, end)
 //
 // Note that (a, start) and (b, end) are observed ONCE each, despite two keys
 // sharing those bounds. Also note that (b, end) and (b, start) are two distinct
@@ -119,18 +119,18 @@ func visibleTransform(snapshot uint64) Transformer {
 // determine which span is next, but it's also responsible for fragmenting
 // overlapping spans. Consider the example:
 //
-//            i0:     b---d e-----h
-//            i1:   a---c         h-----k
-//            i2:   a------------------------------p
+//	       i0:     b---d e-----h
+//	       i1:   a---c         h-----k
+//	       i2:   a------------------------------p
 //
-//     fragments:   a-b-c-d-e-----h-----k----------p
+//	fragments:   a-b-c-d-e-----h-----k----------p
 //
 // None of the individual child iterators contain a span with the exact bounds
 // [c,d), but the merging iterator must produce a span [c,d). To accomplish
 // this, the merging iterator visits every span between unique boundary user
 // keys. In the above example, this is:
 //
-//     [a,b), [b,c), [c,d), [d,e), [e, h), [h, k), [k, p)
+//	[a,b), [b,c), [c,d), [d,e), [e, h), [h, k), [k, p)
 //
 // The merging iterator first initializes the heap to prepare for iteration.
 // The description below discusses the mechanics of forward iteration after a
@@ -141,9 +141,9 @@ func visibleTransform(snapshot uint64) Transformer {
 // mergingIterLevel to the first bound of the first fragment. In the above
 // example, this seeks the child iterators to:
 //
-//     i0: (b, boundKindFragmentStart, [ [b,d) ])
-//     i1: (a, boundKindFragmentStart, [ [a,c) ])
-//     i2: (a, boundKindFragmentStart, [ [a,p) ])
+//	i0: (b, boundKindFragmentStart, [ [b,d) ])
+//	i1: (a, boundKindFragmentStart, [ [a,c) ])
+//	i2: (a, boundKindFragmentStart, [ [a,p) ])
 //
 // After fixing up the heap, the root of the heap is a boundKey with the
 // smallest user key ('a' in the example). Once the heap is setup for iteration
@@ -160,9 +160,9 @@ func visibleTransform(snapshot uint64) Transformer {
 // In the above example, this results in m.start = 'a', m.end = 'b' and child
 // iterators in the following positions:
 //
-//     i0: (b, boundKindFragmentStart, [ [b,d) ])
-//     i1: (c, boundKindFragmentEnd,   [ [a,c) ])
-//     i2: (p, boundKindFragmentEnd,   [ [a,p) ])
+//	i0: (b, boundKindFragmentStart, [ [b,d) ])
+//	i1: (c, boundKindFragmentEnd,   [ [a,c) ])
+//	i2: (p, boundKindFragmentEnd,   [ [a,p) ])
 //
 // With the user key bounds of the next merged span established,
 // findNextFragmentSet must determine which, if any, fragments overlap the span.
@@ -191,7 +191,7 @@ func visibleTransform(snapshot uint64) Transformer {
 // findNextFragmentSet loops, repeating the above process again until it finds a
 // span that does contain keys.
 //
-// Memory safety
+// # Memory safety
 //
 // The FragmentIterator interface only guarantees stability of a Span and its
 // associated slices until the next positioning method is called. Adjacent Spans

--- a/internal/keyspan/span.go
+++ b/internal/keyspan/span.go
@@ -24,7 +24,8 @@ import (
 // Note that the start user key is inclusive and the end user key is exclusive.
 //
 // Currently the only supported key kinds are:
-//   RANGEDEL, RANGEKEYSET, RANGEKEYUNSET, RANGEKEYDEL.
+//
+//	RANGEDEL, RANGEKEYSET, RANGEKEYUNSET, RANGEKEYDEL.
 type Span struct {
 	// Start and End encode the user key range of all the contained items, with
 	// an inclusive start key and exclusive end key. Both Start and End must be

--- a/internal/manifest/btree.go
+++ b/internal/manifest/btree.go
@@ -338,23 +338,20 @@ func (n *node) find(cmp btreeCmp, item *FileMetadata) (index int, found bool) {
 // and this function returns the item that existed at that index and a new
 // node containing all items/children after it.
 //
-// Before:
+//			Before:
+//	 	      	+-----------+
+//	 	      	|   x y z   |
+//	 	      	+--/-/-\-\--+
 //
-//          +-----------+
-//          |   x y z   |
-//          +--/-/-\-\--+
-//
-// After:
-//
-//          +-----------+
-//          |     y     |
-//          +----/-\----+
-//              /   \
-//             v     v
-// +-----------+     +-----------+
-// |         x |     | z         |
-// +-----------+     +-----------+
-//
+//			After:
+//		       	+-----------+
+//		       	|     y     |
+//		       	+----/-\----+
+//		       	    /   \
+//		       	   v     v
+//		 +-----------+     +-----------+
+//		 |         x |     | z         |
+//		 +-----------+     +-----------+
 func (n *node) split(i int) (*FileMetadata, *node) {
 	out := n.items[i]
 	var next *node

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -112,13 +112,15 @@ func sortAndSweep(keys []intervalKeyTemp, cmp Compare) []intervalKeyTemp {
 	sorter := intervalKeySorter{keys: keys, cmp: cmp}
 	sort.Sort(sorter)
 
-	// intervalKeys are generated using the file bounds. Specifically, there are 2 intervalKeys
-	// for each file, and len(keys) = 2 * number of files. Each intervalKeyTemp stores information
-	// about which file it was generated from, and whether the key represents the end key of the file.
-	// So, as we're deduplicating the `keys` slice, we're guaranteed to iterate over the interval
-	// keys belonging to each of the files. Since the file.{min,max}IntervalIndex points to the position
-	// of the files bounds in the deduplicated `keys` slice, we can determine file.{min,max}IntervalIndex
-	// during the iteration.
+	// intervalKeys are generated using the file bounds. Specifically, there are
+	// 2 intervalKeys for each file, and len(keys) = 2 * number of files. Each
+	// `intervalKeyTemp` stores information about which file it was generated
+	// from, and whether the key represents the end key of the file. So, as
+	// we're deduplicating the `keys` slice, we're guaranteed to iterate over
+	// the interval keys belonging to each of the files. Since the
+	// file.{min,max}IntervalIndex points to the position of the files bounds in
+	// the deduplicated `keys` slice, we can determine
+	// file.{min,max}IntervalIndex during the iteration.
 	i := 0
 	j := 0
 	for i < len(keys) {
@@ -151,24 +153,24 @@ type fileInterval struct {
 	// cannot have any files participate in L0 -> Lbase compactions.
 	isBaseCompacting bool
 
-	// The min and max intervals index across all the files that overlap with this
-	// interval. Inclusive on both sides.
+	// The min and max intervals index across all the files that overlap with
+	// this interval. Inclusive on both sides.
 	filesMinIntervalIndex int
 	filesMaxIntervalIndex int
 
 	// True if another interval that has a file extending into this interval is
-	// undergoing a compaction into Lbase. In other words, this bool is true
-	// if any interval in [filesMinIntervalIndex,
-	// filesMaxIntervalIndex] has isBaseCompacting set to true. This
-	// lets the compaction picker de-prioritize this interval for picking
-	// compactions, since there's a high chance that a base compaction with a
-	// sufficient height of sublevels rooted at this interval could not be
-	// chosen due to the ongoing base compaction in the
-	// other interval. If the file straddling the two intervals is at a
-	// sufficiently high sublevel (with enough compactible files below it to
-	// satisfy minCompactionDepth), this is not an issue, but to optimize for
-	// quickly picking base compactions far away from other base compactions,
-	// this bool is used as a heuristic (but not as a complete disqualifier).
+	// undergoing a compaction into Lbase. In other words, this bool is true if
+	// any interval in [filesMinIntervalIndex, filesMaxIntervalIndex] has
+	// isBaseCompacting set to true. This lets the compaction picker
+	// de-prioritize this interval for picking compactions, since there's a high
+	// chance that a base compaction with a sufficient height of sublevels
+	// rooted at this interval could not be chosen due to the ongoing base
+	// compaction in the other interval. If the file straddling the two
+	// intervals is at a sufficiently high sublevel (with enough compactible
+	// files below it to satisfy minCompactionDepth), this is not an issue, but
+	// to optimize for quickly picking base compactions far away from other base
+	// compactions, this bool is used as a heuristic (but not as a complete
+	// disqualifier).
 	intervalRangeIsBaseCompacting bool
 
 	// All files in this interval, in increasing sublevel order.
@@ -178,9 +180,8 @@ type fileInterval struct {
 	// starting new compactions. This metric is not precise since the
 	// compactingFileCount can include files that are part of N (where N > 1)
 	// intra-L0 compactions, so the stack depth after those complete will be
-	// len(files) - compactingFileCount + N. We ignore this imprecision since
-	// we don't want to track which files are part of which intra-L0
-	// compaction.
+	// len(files) - compactingFileCount + N. We ignore this imprecision since we
+	// don't want to track which files are part of which intra-L0 compaction.
 	compactingFileCount int
 
 	// Interpolated from files in this interval. For files spanning multiple
@@ -339,10 +340,10 @@ func NewL0Sublevels(
 	return s, nil
 }
 
-// Helper function to merge new intervalKeys into an existing slice
-// of old fileIntervals, into result. Returns the new result and a slice of ints
-// mapping old interval indices to new ones. The added intervalKeys do not
-// need to be sorted; they get sorted and deduped in this function.
+// Helper function to merge new intervalKeys into an existing slice of old
+// fileIntervals, into result. Returns the new result and a slice of ints
+// mapping old interval indices to new ones. The added intervalKeys do not need
+// to be sorted; they get sorted and deduped in this function.
 func mergeIntervals(
 	old, result []fileInterval, added []intervalKeyTemp, compare Compare,
 ) ([]fileInterval, []int) {
@@ -413,35 +414,36 @@ func mergeIntervals(
 	return result, oldToNewMap
 }
 
-// AddL0Files incrementally builds a new L0Sublevels for when the only
-// change since the receiver L0Sublevels was an addition of the specified files,
-// with no L0 deletions. The common case of this is an ingestion or a flush.
-// These files can "sit on top" of existing sublevels, creating at most one
-// new sublevel for a flush (and possibly multiple for an ingestion), and at
-// most 2*len(files) additions to s.orderedIntervals. No files must have been
-// deleted from L0, and the added files must all be newer in sequence numbers
-// than existing files in L0Sublevels. The files parameter must be sorted in
-// seqnum order. The levelMetadata parameter corresponds to the new L0 post
-// addition of files. This method is meant to be significantly more performant
-// than NewL0Sublevels.
+// AddL0Files incrementally builds a new L0Sublevels for when the only change
+// since the receiver L0Sublevels was an addition of the specified files, with
+// no L0 deletions. The common case of this is an ingestion or a flush. These
+// files can "sit on top" of existing sublevels, creating at most one new
+// sublevel for a flush (and possibly multiple for an ingestion), and at most
+// 2*len(files) additions to s.orderedIntervals. No files must have been deleted
+// from L0, and the added files must all be newer in sequence numbers than
+// existing files in L0Sublevels. The files parameter must be sorted in seqnum
+// order. The levelMetadata parameter corresponds to the new L0 post addition of
+// files. This method is meant to be significantly more performant than
+// NewL0Sublevels.
 //
 // Note that this function can only be called once on a given receiver; it
 // appends to some slices in s which is only safe when done once. This is okay,
 // as the common case (generating a new L0Sublevels after a flush/ingestion) is
 // only going to necessitate one call of this method on a given receiver. The
-// returned value, if non-nil, can then have AddL0Files called on it again, and
-// so on. If errInvalidL0SublevelsOpt is returned as an error, it likely means
-// the optimization could not be applied (i.e. files added were older than files
-// already in the sublevels, which is possible around ingestions and in tests).
-// Eg. it can happen when an ingested file was ingested without queueing a flush
-// since it did not actually overlap with any keys in the memtable. Later on the
-// memtable was flushed, and the memtable had keys spanning around the ingested
-// file, producing a flushed file that overlapped with the ingested file in file
-// bounds but not in keys. It's possible for that flushed file to have a lower
-// LargestSeqNum than the ingested file if all the additions after the ingestion
-// were to another flushed file that was split into a separate sstable during
-// flush. Any other non-nil error means L0Sublevels generation failed in the same
-// way as NewL0Sublevels would likely fail.
+// returned value, if non-nil, can then have [*L0Sublevels.AddL0Files] called on
+// it again, and so on. If [errInvalidL0SublevelsOpt] is returned as an error,
+// it likely means the optimization could not be applied (i.e. files added were
+// older than files already in the sublevels, which is possible around
+// ingestions and in tests). Eg. it can happen when an ingested file was
+// ingested without queueing a flush since it did not actually overlap with any
+// keys in the memtable. Later on the memtable was flushed, and the memtable had
+// keys spanning around the ingested file, producing a flushed file that
+// overlapped with the ingested file in file bounds but not in keys. It's
+// possible for that flushed file to have a lower LargestSeqNum than the
+// ingested file if all the additions after the ingestion were to another
+// flushed file that was split into a separate sstable during flush. Any other
+// non-nil error means [L0Sublevels] generation failed in the same way as
+// [NewL0Sublevels] would likely fail.
 func (s *L0Sublevels) AddL0Files(
 	files []*FileMetadata, flushSplitMaxBytes int64, levelMetadata *LevelMetadata,
 ) (*L0Sublevels, error) {
@@ -485,8 +487,8 @@ func (s *L0Sublevels) AddL0Files(
 	keys := make([]fileInterval, 0, 2*levelMetadata.Len())
 	var oldToNewMap []int
 	// We can avoid the sortAndSweep step on the combined length of
-	// s.orderedIntervals and fileKeys by treating this as a merge of two
-	// sorted runs, fileKeys and s.orderedIntervals, into `keys` which will form
+	// s.orderedIntervals and fileKeys by treating this as a merge of two sorted
+	// runs, fileKeys and s.orderedIntervals, into `keys` which will form
 	// newVal.orderedIntervals.
 	keys, oldToNewMap = mergeIntervals(s.orderedIntervals, keys, fileKeys, s.cmp)
 	if invariants.Enabled {
@@ -502,20 +504,21 @@ func (s *L0Sublevels) AddL0Files(
 		newInterval := &keys[newIdx]
 		newInterval.index = newIdx
 		// This code, and related code in the for loop below, adjusts
-		// files{Min,Max}IntervalIndex just for interval indices shifting due to new
-		// intervals, and not for any of the new files being added to the same
-		// intervals. The goal is to produce a state of the system that's accurate
-		// for all existing files, and has all the new intervals to support new
-		// files. Once that's done, we can just call addFileToSublevel to adjust
-		// all relevant intervals for new files.
+		// files{Min,Max}IntervalIndex just for interval indices shifting due to
+		// new intervals, and not for any of the new files being added to the
+		// same intervals. The goal is to produce a state of the system that's
+		// accurate for all existing files, and has all the new intervals to
+		// support new files. Once that's done, we can just call
+		// addFileToSublevel to adjust all relevant intervals for new files.
 		newInterval.filesMinIntervalIndex = oldToNewMap[newInterval.filesMinIntervalIndex]
 		// maxIntervalIndexes are special. Since it's an inclusive end bound, we
 		// actually have to map it to the _next_ old interval's new previous
 		// interval. This logic is easier to understand if you see
 		// [f.minIntervalIndex, f.maxIntervalIndex] as [f.minIntervalIndex,
-		// f.maxIntervalIndex+1). The other case to remember is when the interval is
-		// completely empty (i.e. len(newInterval.files) == 0); in that case we want
-		// to refer back to ourselves regardless of additions to the right of us.
+		// f.maxIntervalIndex+1). The other case to remember is when the
+		// interval is completely empty (i.e. len(newInterval.files) == 0); in
+		// that case we want to refer back to ourselves regardless of additions
+		// to the right of us.
 		if newInterval.filesMaxIntervalIndex < len(oldToNewMap)-1 && len(newInterval.files) > 0 {
 			newInterval.filesMaxIntervalIndex = oldToNewMap[newInterval.filesMaxIntervalIndex+1] - 1
 		} else {
@@ -523,16 +526,16 @@ func (s *L0Sublevels) AddL0Files(
 			newInterval.filesMaxIntervalIndex = oldToNewMap[newInterval.filesMaxIntervalIndex]
 		}
 	}
-	// Loop through all instances of new intervals added between two old intervals
-	// and expand [filesMinIntervalIndex, filesMaxIntervalIndex] of new intervals
-	// to reflect that of adjacent old intervals.
+	// Loop through all instances of new intervals added between two old
+	// intervals and expand [filesMinIntervalIndex, filesMaxIntervalIndex] of
+	// new intervals to reflect that of adjacent old intervals.
 	{
 		// We can skip cases where new intervals were added to the left of all
 		// existing intervals (eg. if the first entry in oldToNewMap is
-		// oldToNewMap[0] >= 1). Those intervals will only contain newly added files
-		// and will have their parameters adjusted down in addFileToSublevels. The
-		// same can also be said about new intervals that are to the right of all
-		// existing intervals.
+		// oldToNewMap[0] >= 1). Those intervals will only contain newly added
+		// files and will have their parameters adjusted down in
+		// addFileToSublevels. The same can also be said about new intervals
+		// that are to the right of all existing intervals.
 		lastIdx := 0
 		for _, newIdx := range oldToNewMap {
 			for i := lastIdx + 1; i < newIdx; i++ {
@@ -555,28 +558,29 @@ func (s *L0Sublevels) AddL0Files(
 	// TODO(bilal): This is the only place in this method where we loop through
 	// all existing files, which could be much more in number than newly added
 	// files. See if we can avoid the need for this, either by getting rid of
-	// f.minIntervalIndex and f.maxIntervalIndex and calculating them on the
-	// fly with a binary search, or by only looping through files to the right
-	// of the first interval touched by this method.
+	// f.minIntervalIndex and f.maxIntervalIndex and calculating them on the fly
+	// with a binary search, or by only looping through files to the right of
+	// the first interval touched by this method.
 	for sublevel := range s.Levels {
 		s.Levels[sublevel].Each(func(f *FileMetadata) {
 			oldIntervalDelta := f.maxIntervalIndex - f.minIntervalIndex + 1
 			oldMinIntervalIndex := f.minIntervalIndex
 			f.minIntervalIndex = oldToNewMap[f.minIntervalIndex]
-			// maxIntervalIndex is special. Since it's an inclusive end bound, we
-			// actually have to map it to the _next_ old interval's new previous
-			// interval. This logic is easier to understand if you see
-			// [f.minIntervalIndex, f.maxIntervalIndex] as
-			// [f.minIntervalIndex, f.maxIntervalIndex+1).
+			// maxIntervalIndex is special. Since it's an inclusive end bound,
+			// we actually have to map it to the _next_ old interval's new
+			// previous interval. This logic is easier to understand if you see
+			// [f.minIntervalIndex, f.maxIntervalIndex] as [f.minIntervalIndex,
+			// f.maxIntervalIndex+1).
 			f.maxIntervalIndex = oldToNewMap[f.maxIntervalIndex+1] - 1
 			newIntervalDelta := f.maxIntervalIndex - f.minIntervalIndex + 1
-			// Recalculate estimatedBytes for all old files across new intervals, but
-			// only if new intervals were added in between.
+			// Recalculate estimatedBytes for all old files across new
+			// intervals, but only if new intervals were added in between.
 			if oldIntervalDelta != newIntervalDelta {
-				// j is incremented so that oldToNewMap[j] points to the next old
-				// interval. This is used to distinguish between old intervals (i.e.
-				// ones where we need to subtract f.Size/oldIntervalDelta) from new
-				// ones (where we don't need to subtract). In both cases we need to add
+				// j is incremented so that oldToNewMap[j] points to the next
+				// old interval. This is used to distinguish between old
+				// intervals (i.e. ones where we need to subtract
+				// f.Size/oldIntervalDelta) from new ones (where we don't need
+				// to subtract). In both cases we need to add
 				// f.Size/newIntervalDelta.
 				j := oldMinIntervalIndex
 				for i := f.minIntervalIndex; i <= f.maxIntervalIndex; i++ {
@@ -636,12 +640,12 @@ func (s *L0Sublevels) AddL0Files(
 	return newVal, nil
 }
 
-// addFileToSublevels is called during L0Sublevels generation, and adds f to
-// the correct sublevel's levelFiles, the relevant intervals' files slices, and
-// sets interval indices on f. This method, if called successively on multiple
-// files, _must_ be called on successively newer files (by seqnum). If
-// checkInvariant is true, it could check for this in some cases and return
-// errInvalidL0SublevelsOpt if that invariant isn't held.
+// addFileToSublevels is called during L0Sublevels generation, and adds f to the
+// correct sublevel's levelFiles, the relevant intervals' files slices, and sets
+// interval indices on f. This method, if called successively on multiple files,
+// _must_ be called on successively newer files (by seqnum). If checkInvariant
+// is true, it could check for this in some cases and return
+// [errInvalidL0SublevelsOpt] if that invariant isn't held.
 func (s *L0Sublevels) addFileToSublevels(f *FileMetadata, checkInvariant bool) error {
 	// This is a simple and not very accurate estimate of the number of
 	// bytes this SSTable contributes to the intervals it is a part of.
@@ -738,11 +742,10 @@ func (s *L0Sublevels) InitCompactingFileInfo(inProgress []L0Compaction) {
 		}
 	}
 
-	// Some intervals may be base compacting without the files contained
-	// within those intervals being marked as compacting. This is possible if
-	// the files were added after the compaction initiated, and the active
-	// compaction files straddle the input file. Mark these intervals as base
-	// compacting.
+	// Some intervals may be base compacting without the files contained within
+	// those intervals being marked as compacting. This is possible if the files
+	// were added after the compaction initiated, and the active compaction
+	// files straddle the input file. Mark these intervals as base compacting.
 	for _, c := range inProgress {
 		startIK := intervalKey{key: c.Smallest.UserKey, isLargest: false}
 		endIK := intervalKey{key: c.Largest.UserKey, isLargest: !c.Largest.IsExclusiveSentinel()}
@@ -924,35 +927,35 @@ func (s *L0Sublevels) InUseKeyRanges(smallest, largest []byte) []UserKeyRange {
 			curr = &keyRanges[len(keyRanges)-1]
 		}
 
-		// If the filesMaxIntervalIndex is not the current index, we can jump
-		// to the max index, knowing that all intermediary intervals are
-		// overlapped by some file.
+		// If the filesMaxIntervalIndex is not the current index, we can jump to
+		// the max index, knowing that all intermediary intervals are overlapped
+		// by some file.
 		if maxIdx := s.orderedIntervals[i].filesMaxIntervalIndex; maxIdx != i {
 			// Note that end may be less than or equal to maxIdx if we're
 			// concerned with a key range that ends before the interval at
-			// maxIdx starts. We must set curr.End now, before making that
-			// leap, because this iteration may be the last.
+			// maxIdx starts. We must set curr.End now, before making that leap,
+			// because this iteration may be the last.
 			i = maxIdx
 			curr.End = s.orderedIntervals[i+1].startKey.key
 			continue
 		}
 
 		// No files overlapping with this interval overlap with the next
-		// interval. Update the current end to be the next interval's start
-		// key. Note that curr is not necessarily finished, because there may
-		// be an abutting non-empty interval.
+		// interval. Update the current end to be the next interval's start key.
+		// Note that curr is not necessarily finished, because there may be an
+		// abutting non-empty interval.
 		curr.End = s.orderedIntervals[i+1].startKey.key
 		i++
 	}
 	return keyRanges
 }
 
-// FlushSplitKeys returns a slice of user keys to split flushes at.
-// Used by flushes to avoid writing sstables that straddle these split keys.
-// These should be interpreted as the keys to start the next sstable (not the
-// last key to include in the prev sstable). These are user keys so that
-// range tombstones can be properly truncated (untruncated range tombstones
-// are not permitted for L0 files).
+// FlushSplitKeys returns a slice of user keys to split flushes at. Used by
+// flushes to avoid writing sstables that straddle these split keys. These
+// should be interpreted as the keys to start the next sstable (not the last key
+// to include in the prev sstable). These are user keys so that range tombstones
+// can be properly truncated (untruncated range tombstones are not permitted for
+// L0 files).
 func (s *L0Sublevels) FlushSplitKeys() [][]byte {
 	return s.flushSplitUserKeys
 }
@@ -978,6 +981,7 @@ func (s *L0Sublevels) MaxDepthAfterOngoingCompactions() int {
 //
 // TODO(bilal): Simplify away the debugging statements in this method, and make
 // this a pure sanity checker.
+//
 //lint:ignore U1000 - useful for debugging
 func (s *L0Sublevels) checkCompaction(c *L0CompactionFiles) error {
 	includedFiles := newBitSet(s.levelMetadata.Len())
@@ -1074,7 +1078,7 @@ func (s *L0Sublevels) checkCompaction(c *L0CompactionFiles) error {
 // recently started compaction. isBase specifies if this is a base compaction;
 // if false, this is assumed to be an intra-L0 compaction. The specified
 // compaction must be involving L0 SSTables. It's assumed that the Compacting
-// and IsIntraL0Compacting fields are already set on all FileMetadatas passed
+// and IsIntraL0Compacting fields are already set on all [FileMetadata]s passed
 // in.
 func (s *L0Sublevels) UpdateStateForStartedCompaction(inputs []LevelSlice, isBase bool) error {
 	minIntervalIndex := -1
@@ -1106,11 +1110,10 @@ func (s *L0Sublevels) UpdateStateForStartedCompaction(inputs []LevelSlice, isBas
 	return nil
 }
 
-// L0CompactionFiles represents a candidate set of L0 files for compaction.
-// Also referred to as "lcf". Contains state information useful
-// for generating the compaction (such as Files), as well as for picking
-// between candidate compactions (eg. fileBytes and
-// seedIntervalStackDepthReduction).
+// L0CompactionFiles represents a candidate set of L0 files for compaction. Also
+// referred to as "lcf". Contains state information useful for generating the
+// compaction (such as Files), as well as for picking between candidate
+// compactions (eg. fileBytes and seedIntervalStackDepthReduction).
 type L0CompactionFiles struct {
 	Files []*FileMetadata
 
@@ -1180,12 +1183,11 @@ func (is intervalSorterByDecreasingScore) Swap(i, j int) {
 
 // Compactions:
 //
-// The sub-levels and intervals can be visualized in 2 dimensions as the X
-// axis containing intervals in increasing order and the Y axis containing
-// sub-levels (older to younger). The intervals can be sparse wrt sub-levels.
-// We observe that the system is typically under severe pressure in L0 during
-// large numbers of ingestions where most files added to L0 are narrow and
-// non-overlapping.
+// The sub-levels and intervals can be visualized in 2 dimensions as the X axis
+// containing intervals in increasing order and the Y axis containing sub-levels
+// (older to younger). The intervals can be sparse wrt sub-levels. We observe
+// that the system is typically under severe pressure in L0 during large numbers
+// of ingestions where most files added to L0 are narrow and non-overlapping.
 //
 //    L0.1    d---g
 //    L0.0  c--e  g--j o--s u--x
@@ -1203,23 +1205,23 @@ func (is intervalSorterByDecreasingScore) Swap(i, j int) {
 // it amenable to concurrent L0 -> Lbase compactions.
 //
 // L0 -> Lbase: The high-level goal of a L0 -> Lbase compaction is to reduce
-// stack depth, by compacting files in the intervals with the highest
-// (fileCount - compactingCount). Additionally, we would like compactions to
-// not involve a huge number of files, so that they finish quickly, and to
-// allow for concurrent L0 -> Lbase compactions when needed. In order to
-// achieve these goals we would like compactions to visualize as capturing
-// thin and tall rectangles. The approach below is to consider intervals in
-// some order and then try to construct a compaction using the interval. The
-// first interval we can construct a compaction for is the compaction that is
-// started. There can be multiple heuristics in choosing the ordering of the
-// intervals -- the code uses one heuristic that worked well for a large
-// ingestion stemming from a cockroachdb import, but additional experimentation
-// is necessary to pick a general heuristic. Additionally, the compaction that
-// gets picked may be not as desirable as one that could be constructed later
-// in terms of reducing stack depth (since adding more files to the compaction
-// can get blocked by needing to encompass files that are already being
-// compacted). So an alternative would be to try to construct more than one
-// compaction and pick the best one.
+// stack depth, by compacting files in the intervals with the highest (fileCount
+// - compactingCount). Additionally, we would like compactions to not involve a
+// huge number of files, so that they finish quickly, and to allow for
+// concurrent L0 -> Lbase compactions when needed. In order to achieve these
+// goals we would like compactions to visualize as capturing thin and tall
+// rectangles. The approach below is to consider intervals in some order and
+// then try to construct a compaction using the interval. The first interval we
+// can construct a compaction for is the compaction that is started. There can
+// be multiple heuristics in choosing the ordering of the intervals -- the code
+// uses one heuristic that worked well for a large ingestion stemming from a
+// cockroachdb import, but additional experimentation is necessary to pick a
+// general heuristic. Additionally, the compaction that gets picked may be not
+// as desirable as one that could be constructed later in terms of reducing
+// stack depth (since adding more files to the compaction can get blocked by
+// needing to encompass files that are already being compacted). So an
+// alternative would be to try to construct more than one compaction and pick
+// the best one.
 //
 // Here's a visualization of an ideal L0->LBase compaction selection:
 //
@@ -1243,9 +1245,9 @@ func (is intervalSorterByDecreasingScore) Swap(i, j int) {
 //    Lbase a--------i    m---------w
 //
 // Note that running this compaction will mark the a--i file in Lbase as
-// compacting, and when ExtendL0ForBaseCompactionTo is called with the bounds
-// of that base file, it'll expand the compaction to also include all L0 files
-// in the a-d interval. The resultant compaction would then be:
+// compacting, and when ExtendL0ForBaseCompactionTo is called with the bounds of
+// that base file, it'll expand the compaction to also include all L0 files in
+// the a-d interval. The resultant compaction would then be:
 //
 //         _____________
 //    L0.3 |a--d    g-j|
@@ -1255,11 +1257,10 @@ func (is intervalSorterByDecreasingScore) Swap(i, j int) {
 //
 //    Lbase a--------i    m---------w
 //
-// The next best interval for base compaction would therefore
-// be the one including r--t in L0.2 and p--x in L0.0, and both this compaction
-// and the one picked earlier can run in parallel. This is assuming
-// minCompactionDepth >= 2, otherwise the second compaction has too little
-// depth to pick.
+// The next best interval for base compaction would therefore be the one
+// including r--t in L0.2 and p--x in L0.0, and both this compaction and the one
+// picked earlier can run in parallel. This is assuming minCompactionDepth >= 2,
+// otherwise the second compaction has too little depth to pick.
 //
 //         _____________
 //    L0.3 |a--d    g-j|      _________
@@ -1292,24 +1293,23 @@ func (is intervalSorterByDecreasingScore) Swap(i, j int) {
 //
 //    Lbase a--------ij--lm---------w
 //
-// Intra-L0: If the L0 score is high, but PickBaseCompaction() is unable to
-// pick a compaction, PickIntraL0Compaction will be used to pick an intra-L0
-// compaction. Similar to L0 -> Lbase compactions, we want to allow for
-// multiple intra-L0 compactions and not generate wide output files that
-// hinder later concurrency of L0 -> Lbase compactions. Also compactions
-// that produce wide files don't reduce stack depth -- they represent wide
-// rectangles in our visualization, which means many intervals have their
-// depth reduced by a small amount. Typically, L0 files have non-overlapping
-// sequence numbers, and sticking to that invariant would require us to
-// consider intra-L0 compactions that proceed from youngest to oldest files,
-// which could result in the aforementioned undesirable wide rectangle
-// shape. But this non-overlapping sequence number is already relaxed in
-// RocksDB -- sstables are primarily ordered by their largest sequence
-// number. So we can arrange for intra-L0 compactions to capture thin and
-// tall rectangles starting with the top of the stack (youngest files).
-// Like the L0 -> Lbase case we order the intervals using a heuristic and
-// consider each in turn. The same comment about better L0 -> Lbase heuristics
-// and not being greedy applies here.
+// Intra-L0: If the L0 score is high, but PickBaseCompaction() is unable to pick
+// a compaction, PickIntraL0Compaction will be used to pick an intra-L0
+// compaction. Similar to L0 -> Lbase compactions, we want to allow for multiple
+// intra-L0 compactions and not generate wide output files that hinder later
+// concurrency of L0 -> Lbase compactions. Also compactions that produce wide
+// files don't reduce stack depth -- they represent wide rectangles in our
+// visualization, which means many intervals have their depth reduced by a small
+// amount. Typically, L0 files have non-overlapping sequence numbers, and
+// sticking to that invariant would require us to consider intra-L0 compactions
+// that proceed from youngest to oldest files, which could result in the
+// aforementioned undesirable wide rectangle shape. But this non-overlapping
+// sequence number is already relaxed in RocksDB -- sstables are primarily
+// ordered by their largest sequence number. So we can arrange for intra-L0
+// compactions to capture thin and tall rectangles starting with the top of the
+// stack (youngest files). Like the L0 -> Lbase case we order the intervals
+// using a heuristic and consider each in turn. The same comment about better L0
+// -> Lbase heuristics and not being greedy applies here.
 //
 // Going back to a modified version of our example from earlier, let's say these
 // are the base compactions in progress:
@@ -1387,10 +1387,9 @@ func (s *L0Sublevels) PickBaseCompaction(
 		// Pick the seed file for the interval as the file
 		// in the lowest sub-level.
 		f := interval.files[0]
-		// Don't bother considering the intervals that are
-		// covered by the seed file since they are likely
-		// nearby. Note that it is possible that those intervals
-		// have seed files at lower sub-levels so could be
+		// Don't bother considering the intervals that are covered by the seed
+		// file since they are likely nearby. Note that it is possible that
+		// those intervals have seed files at lower sub-levels so could be
 		// viable for compaction.
 		if f == nil {
 			return nil, errors.New("no seed file found in sublevel intervals")
@@ -1398,23 +1397,22 @@ func (s *L0Sublevels) PickBaseCompaction(
 		consideredIntervals.markBits(f.minIntervalIndex, f.maxIntervalIndex+1)
 		if f.IsCompacting() {
 			if f.IsIntraL0Compacting {
-				// If we're picking a base compaction and we came across a
-				// seed file candidate that's being intra-L0 compacted, skip
-				// the interval instead of erroring out.
+				// If we're picking a base compaction and we came across a seed
+				// file candidate that's being intra-L0 compacted, skip the
+				// interval instead of erroring out.
 				continue
 			}
-			// We chose a compaction seed file that should not be
-			// compacting. Usually means the score is not accurately
-			// accounting for files already compacting, or internal state is
-			// inconsistent.
+			// We chose a compaction seed file that should not be compacting.
+			// Usually means the score is not accurately accounting for files
+			// already compacting, or internal state is inconsistent.
 			return nil, errors.Errorf("file %s chosen as seed file for compaction should not be compacting", f.FileNum)
 		}
 
 		c := s.baseCompactionUsingSeed(f, interval.index, minCompactionDepth)
 		if c != nil {
-			// Check if the chosen compaction overlaps with any files
-			// in Lbase that have Compacting = true. If that's the case,
-			// this compaction cannot be chosen.
+			// Check if the chosen compaction overlaps with any files in Lbase
+			// that have Compacting = true. If that's the case, this compaction
+			// cannot be chosen.
 			baseIter := baseFiles.Iter()
 			// An interval starting at ImmediateSuccessor(key) can never be the
 			// first interval of a compaction since no file can start at that
@@ -1454,10 +1452,9 @@ func (s *L0Sublevels) baseCompactionUsingSeed(
 	c.addFile(f)
 
 	// The first iteration of this loop builds the compaction at the seed file's
-	// sublevel. Future iterations expand on this compaction by stacking
-	// more files from intervalIndex and repeating. This is an
-	// optional activity so when it fails we can fallback to the last
-	// successful candidate.
+	// sublevel. Future iterations expand on this compaction by stacking more
+	// files from intervalIndex and repeating. This is an optional activity so
+	// when it fails we can fallback to the last successful candidate.
 	var lastCandidate *L0CompactionFiles
 	interval := &s.orderedIntervals[intervalIndex]
 
@@ -1467,29 +1464,28 @@ func (s *L0Sublevels) baseCompactionUsingSeed(
 		c.seedIntervalStackDepthReduction++
 		c.seedIntervalMaxLevel = sl
 		c.addFile(f2)
-		// The seed file is in the lowest sublevel in the seed interval, but it may
-		// overlap with other files in even lower sublevels. For
-		// correctness we need to grow our interval to include those files, and
-		// capture all files in the next level that fall in this extended interval
-		// and so on. This can result in a triangular shape like the following
-		// where again the X axis is the key intervals and the Y axis
-		// is oldest to youngest. Note that it is not necessary for
-		// correctness to fill out the shape at the higher sub-levels
-		// to make it more rectangular since the invariant only requires
-		// that younger versions of a key not be moved to Lbase while
-		// leaving behind older versions.
+		// The seed file is in the lowest sublevel in the seed interval, but it
+		// may overlap with other files in even lower sublevels. For correctness
+		// we need to grow our interval to include those files, and capture all
+		// files in the next level that fall in this extended interval and so
+		// on. This can result in a triangular shape like the following where
+		// again the X axis is the key intervals and the Y axis is oldest to
+		// youngest. Note that it is not necessary for correctness to fill out
+		// the shape at the higher sub-levels to make it more rectangular since
+		// the invariant only requires that younger versions of a key not be
+		// moved to Lbase while leaving behind older versions.
 		//                     -
 		//                    ---
 		//                   -----
-		// It may be better for performance to have a more rectangular
-		// shape since the files being left behind will overlap with the
-		// same Lbase key range as that of this compaction. But there is
-		// also the danger that in trying to construct a more rectangular
-		// shape we will be forced to pull in a file that is already
-		// compacting. We expect extendCandidateToRectangle to eventually be called
-		// on this compaction if it's chosen, at which point we would iterate
-		// backward and choose those files. This logic is similar to compaction.grow
-		// for non-L0 compactions.
+		// It may be better for performance to have a more rectangular shape
+		// since the files being left behind will overlap with the same Lbase
+		// key range as that of this compaction. But there is also the danger
+		// that in trying to construct a more rectangular shape we will be
+		// forced to pull in a file that is already compacting. We expect
+		// extendCandidateToRectangle to eventually be called on this compaction
+		// if it's chosen, at which point we would iterate backward and choose
+		// those files. This logic is similar to compaction.grow for non-L0
+		// compactions.
 		done := false
 		for currLevel := sl - 1; currLevel >= 0; currLevel-- {
 			if !s.extendFiles(currLevel, math.MaxUint64, c) {
@@ -1509,8 +1505,8 @@ func (s *L0Sublevels) baseCompactionUsingSeed(
 		// depth, but long running compactions reduce flexibility in what can
 		// run concurrently in L0 and even Lbase -> Lbase+1. An increase more
 		// than 150% in bytes since the last candidate compaction (along with a
-		// total compaction size in excess of 100mb), or a total compaction
-		// size beyond a hard limit of 500mb, is criteria for rejecting this
+		// total compaction size in excess of 100mb), or a total compaction size
+		// beyond a hard limit of 500mb, is criteria for rejecting this
 		// candidate. This lets us prefer slow growths as we add files, while
 		// still having a hard limit. Note that if this is the first compaction
 		// candidate to reach a stack depth reduction of minCompactionDepth or
@@ -1568,7 +1564,7 @@ func (s *L0Sublevels) extendFiles(
 
 // PickIntraL0Compaction picks an intra-L0 compaction for files in this
 // sublevel. This method is only called when a base compaction cannot be chosen.
-// See comment above PickBaseCompaction for heuristics involved in this
+// See comment above [PickBaseCompaction] for heuristics involved in this
 // selection.
 func (s *L0Sublevels) PickIntraL0Compaction(
 	earliestUnflushedSeqNum uint64, minCompactionDepth int,
@@ -1584,9 +1580,8 @@ func (s *L0Sublevels) PickIntraL0Compaction(
 	}
 	sort.Sort(intervalSorterByDecreasingScore(scoredIntervals))
 
-	// Optimization to avoid considering different intervals that
-	// are likely to choose the same seed file. Again this is just
-	// to reduce wasted work.
+	// Optimization to avoid considering different intervals that are likely to
+	// choose the same seed file. Again this is just to reduce wasted work.
 	consideredIntervals := newBitSet(len(s.orderedIntervals))
 	for _, scoredInterval := range scoredIntervals {
 		interval := &s.orderedIntervals[scoredInterval.interval]
@@ -1595,8 +1590,8 @@ func (s *L0Sublevels) PickIntraL0Compaction(
 		}
 
 		var f *FileMetadata
-		// Pick the seed file for the interval as the file
-		// in the highest sub-level.
+		// Pick the seed file for the interval as the file in the highest
+		// sub-level.
 		stackDepthReduction := scoredInterval.score
 		for i := len(interval.files) - 1; i >= 0; i-- {
 			f = interval.files[i]
@@ -1604,9 +1599,8 @@ func (s *L0Sublevels) PickIntraL0Compaction(
 				break
 			}
 			consideredIntervals.markBits(f.minIntervalIndex, f.maxIntervalIndex+1)
-			// Can this be the seed file? Files with newer sequence
-			// numbers than earliestUnflushedSeqNum cannot be in
-			// the compaction.
+			// Can this be the seed file? Files with newer sequence numbers than
+			// earliestUnflushedSeqNum cannot be in the compaction.
 			if f.LargestSeqNum >= earliestUnflushedSeqNum {
 				stackDepthReduction--
 				if stackDepthReduction == 0 {
@@ -1669,10 +1663,10 @@ func (s *L0Sublevels) intraL0CompactionUsingSeed(
 	}
 	// The first iteration of this loop produces an intra-L0 compaction at the
 	// seed level. Iterations after that optionally add to the compaction by
-	// stacking more files from intervalIndex and repeating. This is an
-	// optional activity so when it fails we can fallback to the last
-	// successful candidate. The code stops adding when it can't add more, or
-	// when fileBytes grows too large.
+	// stacking more files from intervalIndex and repeating. This is an optional
+	// activity so when it fails we can fallback to the last successful
+	// candidate. The code stops adding when it can't add more, or when
+	// fileBytes grows too large.
 	for ; slIndex >= 0; slIndex-- {
 		f2 := interval.files[slIndex]
 		sl := f2.SubLevel
@@ -1684,23 +1678,24 @@ func (s *L0Sublevels) intraL0CompactionUsingSeed(
 		c.addFile(f2)
 		// The seed file captures all files in the higher level that fall in the
 		// range of intervals. That may extend the range of intervals so for
-		// correctness we need to capture all files in the next higher level that
-		// fall in this extended interval and so on. This can result in an
-		// inverted triangular shape like the following where again the X axis is the
-		// key intervals and the Y axis is oldest to youngest. Note that it is not
-		// necessary for correctness to fill out the shape at lower sub-levels to
-		// make it more rectangular since the invariant only requires that if we
-		// move an older seqnum for key k into a file that has a higher seqnum, we
-		// also move all younger seqnums for that key k into that file.
+		// correctness we need to capture all files in the next higher level
+		// that fall in this extended interval and so on. This can result in an
+		// inverted triangular shape like the following where again the X axis
+		// is the key intervals and the Y axis is oldest to youngest. Note that
+		// it is not necessary for correctness to fill out the shape at lower
+		// sub-levels to make it more rectangular since the invariant only
+		// requires that if we move an older seqnum for key k into a file that
+		// has a higher seqnum, we also move all younger seqnums for that key k
+		// into that file.
 		//                  -----
 		//                   ---
 		//                    -
-		//
-		// It may be better for performance to have a more rectangular shape since
-		// it will reduce the stack depth for more intervals. But there is also
-		// the danger that in explicitly trying to construct a more rectangular
-		// shape we will be forced to pull in a file that is already compacting.
-		// We assume that the performance concern is not a practical issue.
+		// It may be better for performance to have a more rectangular shape
+		// since it will reduce the stack depth for more intervals. But there is
+		// also the danger that in explicitly trying to construct a more
+		// rectangular shape we will be forced to pull in a file that is already
+		// compacting. We assume that the performance concern is not a practical
+		// issue.
 		done := false
 		for currLevel := sl + 1; currLevel < len(s.levelFiles); currLevel++ {
 			if !s.extendFiles(currLevel, earliestUnflushedSeqNum, c) {
@@ -1734,11 +1729,11 @@ func (s *L0Sublevels) intraL0CompactionUsingSeed(
 }
 
 // ExtendL0ForBaseCompactionTo extends the specified base compaction candidate
-// L0CompactionFiles to optionally cover more files in L0 without "touching"
-// any of the passed-in keys (i.e. the smallest/largest bounds are exclusive),
-// as including any user keys for those internal keys
-// could require choosing more files in LBase which is undesirable. Unbounded
-// start/end keys are indicated by passing in the InvalidInternalKey.
+// L0CompactionFiles to optionally cover more files in L0 without "touching" any
+// of the passed-in keys (i.e. the smallest/largest bounds are exclusive), as
+// including any user keys for those internal keys could require choosing more
+// files in LBase which is undesirable. Unbounded start/end keys are indicated
+// by passing in the InvalidInternalKey.
 func (s *L0Sublevels) ExtendL0ForBaseCompactionTo(
 	smallest, largest InternalKey, candidate *L0CompactionFiles,
 ) bool {
@@ -1794,65 +1789,66 @@ func (s *L0Sublevels) ExtendL0ForBaseCompactionTo(
 // Consider this scenario (original candidate is inside the rectangle), with
 // isBase = true and interval bounds a-j (from the union of base file bounds and
 // that of compaction candidate):
-//               _______
-//    L0.3  a--d |  g-j|
-//    L0.2       | f--j|         r-t
-//    L0.1   b-d |e---j|
-//    L0.0  a--d | f--j| l--o  p-----x
 //
-//    Lbase a--------i    m---------w
+//	           _______
+//	L0.3  a--d |  g-j|
+//	L0.2       | f--j|         r-t
+//	L0.1   b-d |e---j|
+//	L0.0  a--d | f--j| l--o  p-----x
+//
+//	Lbase a--------i    m---------w
 //
 // This method will iterate from the bottom up. At L0.0, it will add a--d since
 // it's in the bounds, then add b-d, then a--d, and so on, to produce this:
 //
-//         _____________
-//    L0.3 |a--d    g-j|
-//    L0.2 |       f--j|         r-t
-//    L0.1 | b-d  e---j|
-//    L0.0 |a--d   f--j| l--o  p-----x
+//	     _____________
+//	L0.3 |a--d    g-j|
+//	L0.2 |       f--j|         r-t
+//	L0.1 | b-d  e---j|
+//	L0.0 |a--d   f--j| l--o  p-----x
 //
-//    Lbase a-------i     m---------w
+//	Lbase a-------i     m---------w
 //
 // Let's assume that, instead of a--d in the top sublevel, we had 3 files, a-b,
 // bb-c, and cc-d, of which bb-c is compacting. Let's also add another sublevel
 // L0.4 with some files, all of which aren't compacting:
 //
-//    L0.4  a------c ca--d _______
-//    L0.3  a-b bb-c  cc-d |  g-j|
-//    L0.2                 | f--j|         r-t
-//    L0.1    b----------d |e---j|
-//    L0.0  a------------d | f--j| l--o  p-----x
+//	L0.4  a------c ca--d _______
+//	L0.3  a-b bb-c  cc-d |  g-j|
+//	L0.2                 | f--j|         r-t
+//	L0.1    b----------d |e---j|
+//	L0.0  a------------d | f--j| l--o  p-----x
 //
-//    Lbase a------------------i    m---------w
+//	Lbase a------------------i    m---------w
 //
-// This method then needs to choose between the left side of L0.3 bb-c
-// (i.e. a-b), or the right side (i.e. cc-d and g-j) for inclusion in this
-// compaction. Since the right side has more files as well as one file that has
-// already been picked, it gets chosen at that sublevel, resulting in this
-// intermediate compaction:
+// This method then needs to choose between the left side of L0.3 bb-c (i.e.
+// a-b), or the right side (i.e. cc-d and g-j) for inclusion in this compaction.
+// Since the right side has more files as well as one file that has already been
+// picked, it gets chosen at that sublevel, resulting in this intermediate
+// compaction:
 //
-//    L0.4  a------c ca--d
-//                  ______________
-//    L0.3  a-b bb-c| cc-d    g-j|
-//    L0.2 _________|        f--j|         r-t
-//    L0.1 |  b----------d  e---j|
-//    L0.0 |a------------d   f--j| l--o  p-----x
+//	L0.4  a------c ca--d
+//	              ______________
+//	L0.3  a-b bb-c| cc-d    g-j|
+//	L0.2 _________|        f--j|         r-t
+//	L0.1 |  b----------d  e---j|
+//	L0.0 |a------------d   f--j| l--o  p-----x
 //
-//    Lbase a------------------i    m---------w
+//	Lbase a------------------i    m---------w
 //
 // Since bb-c had to be excluded at L0.3, the interval bounds for L0.4 are
 // actually ca-j, since ca is the next interval start key after the end interval
 // of bb-c. This would result in only ca-d being chosen at that sublevel, even
 // though a--c is also not compacting. This is the final result:
 //
-//                  ______________
-//    L0.4  a------c|ca--d       |
-//    L0.3  a-b bb-c| cc-d    g-j|
-//    L0.2 _________|        f--j|         r-t
-//    L0.1 |  b----------d  e---j|
-//    L0.0 |a------------d   f--j| l--o  p-----x
+//	              ______________
+//	L0.4  a------c|ca--d       |
+//	L0.3  a-b bb-c| cc-d    g-j|
+//	L0.2 _________|        f--j|         r-t
+//	L0.1 |  b----------d  e---j|
+//	L0.0 |a------------d   f--j| l--o  p-----x
 //
-//    Lbase a------------------i    m---------w
+//	Lbase a------------------i    m---------w
 //
 // TODO(bilal): Add more targeted tests for this method, through
 // ExtendL0ForBaseCompactionTo and intraL0CompactionUsingSeed.
@@ -1883,19 +1879,19 @@ func (s *L0Sublevels) extendCandidateToRectangle(
 	}
 	// Stats for files.
 	addedCount := 0
-	// Iterate from the oldest sub-level for L0 -> Lbase and youngest
-	// sub-level for intra-L0. The idea here is that anything that can't
-	// be included from that level constrains what can be included from
-	// the next level. This change in constraint is directly incorporated
-	// into minIntervalIndex, maxIntervalIndex.
+	// Iterate from the oldest sub-level for L0 -> Lbase and youngest sub-level
+	// for intra-L0. The idea here is that anything that can't be included from
+	// that level constrains what can be included from the next level. This
+	// change in constraint is directly incorporated into minIntervalIndex,
+	// maxIntervalIndex.
 	for sl := startLevel; sl != endLevel; sl += increment {
 		files := s.levelFiles[sl]
 		// Find the first file that overlaps with minIntervalIndex.
 		index := sort.Search(len(files), func(i int) bool {
 			return minIntervalIndex <= files[i].maxIntervalIndex
 		})
-		// Track the files that are fully within the current constraint
-		// of [minIntervalIndex, maxIntervalIndex].
+		// Track the files that are fully within the current constraint of
+		// [minIntervalIndex, maxIntervalIndex].
 		firstIndex := -1
 		lastIndex := -1
 		for ; index < len(files); index++ {
@@ -1904,8 +1900,8 @@ func (s *L0Sublevels) extendCandidateToRectangle(
 				break
 			}
 			include := true
-			// Extends out on the left so can't be included. This narrows
-			// what we can included in the next level.
+			// Extends out on the left so can't be included. This narrows what
+			// we can included in the next level.
 			if f.minIntervalIndex < minIntervalIndex {
 				include = false
 				minIntervalIndex = f.maxIntervalIndex + 1
@@ -1932,13 +1928,13 @@ func (s *L0Sublevels) extendCandidateToRectangle(
 			continue
 		}
 		// We have the files in [firstIndex, lastIndex] as potential for
-		// inclusion. Some of these may already have been picked. Some
-		// of them may be already compacting. The latter is tricky since
-		// we have to decide whether to contract minIntervalIndex or
-		// maxIntervalIndex when we encounter an already compacting file.
-		// We pick the longest sequence between firstIndex
-		// and lastIndex of non-compacting files -- this is represented by
-		// [candidateNonCompactingFirst, candidateNonCompactingLast].
+		// inclusion. Some of these may already have been picked. Some of them
+		// may be already compacting. The latter is tricky since we have to
+		// decide whether to contract minIntervalIndex or maxIntervalIndex when
+		// we encounter an already compacting file. We pick the longest sequence
+		// between firstIndex and lastIndex of non-compacting files -- this is
+		// represented by [candidateNonCompactingFirst,
+		// candidateNonCompactingLast].
 		nonCompactingFirst := -1
 		currentRunHasAlreadyPickedFiles := false
 		candidateNonCompactingFirst := -1
@@ -1985,8 +1981,8 @@ func (s *L0Sublevels) extendCandidateToRectangle(
 			}
 		}
 		if candidateNonCompactingFirst == -1 {
-			// All files are compacting. There will be gaps that we could exploit
-			// to continue, but don't bother.
+			// All files are compacting. There will be gaps that we could
+			// exploit to continue, but don't bother.
 			break
 		}
 		// May need to shrink [minIntervalIndex, maxIntervalIndex] for the next level.

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -79,10 +79,10 @@ const (
 //
 // The following shows the valid state transitions:
 //
-//    NotCompacting --> Compacting --> Compacted
-//          ^               |
-//          |               |
-//          +-------<-------+
+//	NotCompacting --> Compacting --> Compacted
+//	      ^               |
+//	      |               |
+//	      +-------<-------+
 //
 // Input files to a compaction transition to Compacting when a compaction is
 // picked. A file that has finished compacting typically transitions into the

--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -278,7 +278,7 @@ func hashThread(objID objID, numThreads int) int {
 // subsequent invocation will overwrite that output. A test can be re-run by
 // using the `--run-dir` flag. For example:
 //
-//   go test -v -run TestMeta --run-dir _meta/standard-017
+//	go test -v -run TestMeta --run-dir _meta/standard-017
 //
 // This will reuse the existing operations present in _meta/ops, rather than
 // generating a new set.
@@ -287,7 +287,7 @@ func hashThread(objID objID, numThreads int) int {
 // pseudorandom number generator seed. If a failure occurs, the seed is
 // printed, and the full suite of tests may be re-run using the `--seed` flag:
 //
-//   go test -v -run TestMeta --seed 1594395154492165000
+//	go test -v -run TestMeta --seed 1594395154492165000
 //
 // This will generate a new `_meta/<test>` directory, with the same operations
 // and options. This must be run on the same commit SHA as the original

--- a/internal/mkbench/main.go
+++ b/internal/mkbench/main.go
@@ -6,12 +6,12 @@
 // data that can be visualized by docs/js/app.js. The raw data is expected to
 // be stored in dated directories underneath the "data/" directory:
 //
-//   data/YYYYMMDD/.../<file>
+//	data/YYYYMMDD/.../<file>
 //
 // The files are expected to be bzip2 compressed. Within each file mkbench
 // looks for Go-bench-style lines of the form:
 //
-//   Benchmark<name> %d %f ops/sec %d read %d write %f r-amp %f w-amp
+//	Benchmark<name> %d %f ops/sec %d read %d write %f r-amp %f w-amp
 //
 // The output is written to "data.js". In order to avoid reading all of the raw
 // data to regenerate "data.js" on every run, mkbench first reads "data.js",
@@ -24,7 +24,7 @@
 // The nightly Pebble benchmarks are orchestrated from the CockroachDB
 // repo:
 //
-//   https://github.com/cockroachdb/cockroach/blob/master/build/teamcity-nightly-pebble.sh
+//	https://github.com/cockroachdb/cockroach/blob/master/build/teamcity-nightly-pebble.sh
 package main
 
 import (

--- a/internal/mkbench/split.go
+++ b/internal/mkbench/split.go
@@ -11,12 +11,12 @@ const increment = 50 // ops/sec
 //
 // The following gives a visual representation of the problem:
 //
-//                        Optimal partition (=550) -----> |
-// Passes:   o          o        o              o o o oo  |
-// Fails:                         x             x         |x    x  x     x x        x
-// |---------|---------|---------|---------|---------|----|----|---------|---------|---------|---> x
-// 0        100       200       300       400       500   |   600       700       800       900
-//	                                                      |
+//		                     Optimal partition (=550) -----> |
+//	                                                         |
+//	  Passes:   o          o        o              o o o oo  |
+//	  Fails:                         x             x         |x    x  x     x x        x
+//	  |---------|---------|---------|---------|---------|----|----|---------|---------|---------|---> x
+//	  0        100       200       300       400       500   |   600       700       800       900
 //
 // The algorithm works by computing the error (i.e. mis-classifications) at
 // various points along the x-axis, starting from the origin and increasing by

--- a/internal/mkbench/write.go
+++ b/internal/mkbench/write.go
@@ -270,17 +270,18 @@ type cookedWriteRun struct {
 
 // formatSummaryJSON returns a JSON representation of the combined raw data from
 // all rawWriteRuns that comprise the writeRun. It has the form:
-//   {
-//     "original-raw-write-run-log-file-1.gz": {
-//       "opsSec": ...,
-//       "raw": ...,
-//     },
-//      ...
-//     "original-raw-write-run-log-file-N.gz": {
-//       "opsSec": ...,
-//       "raw": ...,
-//     },
-//   }
+//
+//	{
+//	  "original-raw-write-run-log-file-1.gz": {
+//	    "opsSec": ...,
+//	    "raw": ...,
+//	  },
+//	   ...
+//	  "original-raw-write-run-log-file-N.gz": {
+//	    "opsSec": ...,
+//	    "raw": ...,
+//	  },
+//	}
 func (r writeRun) formatSummaryJSON() ([]byte, error) {
 	m := make(map[string]cookedWriteRun)
 	for name, data := range r.rawRuns {

--- a/internal/rangekey/coalesce.go
+++ b/internal/rangekey/coalesce.go
@@ -209,8 +209,9 @@ func (ui *UserIteratorConfig) ShouldDefragment(equal base.Equal, a, b *keyspan.S
 //
 // Additionally, internal range keys at the same sequence number have subtle
 // mechanics:
-//   * RANGEKEYSETs shadow RANGEKEYUNSETs of the same suffix.
-//   * RANGEKEYDELs only apply to keys at lower sequence numbers.
+//   - RANGEKEYSETs shadow RANGEKEYUNSETs of the same suffix.
+//   - RANGEKEYDELs only apply to keys at lower sequence numbers.
+//
 // This is required for ingestion. Ingested sstables are assigned a single
 // sequence number for the file, at which all of the file's keys are visible.
 // The RANGEKEYSET, RANGEKEYUNSET and RANGEKEYDEL key kinds are ordered such

--- a/internal/rate/rate.go
+++ b/internal/rate/rate.go
@@ -196,13 +196,15 @@ func (lim *Limiter) Reserve() Reservation {
 // The Limiter takes this Reservation into account when allowing future events.
 // ReserveN returns false if n exceeds the Limiter's burst size.
 // Usage example:
-//   r := lim.ReserveN(time.Now(), 1)
-//   if !r.OK() {
-//     // Not allowed to act! Did you remember to set lim.burst to be > 0 ?
-//     return
-//   }
-//   time.Sleep(r.Delay())
-//   Act()
+//
+//	r := lim.ReserveN(time.Now(), 1)
+//	if !r.OK() {
+//	  // Not allowed to act! Did you remember to set lim.burst to be > 0 ?
+//	  return
+//	}
+//	time.Sleep(r.Delay())
+//	Act()
+//
 // Use this method if you wish to wait and slow down in accordance with the rate limit without dropping events.
 // If you need to respect a deadline or cancel the delay, use Wait instead.
 // To drop or skip events exceeding rate limit, use Allow instead.

--- a/level_checker.go
+++ b/level_checker.go
@@ -554,11 +554,11 @@ type CheckLevelsStats struct {
 }
 
 // CheckLevels checks:
-// - Every entry in the DB is consistent with the level invariant. See the
-//   comment at the top of the file.
-// - Point keys in sstables are ordered.
-// - Range delete tombstones in sstables are ordered and fragmented.
-// - Successful processing of all MERGE records.
+//   - Every entry in the DB is consistent with the level invariant. See the
+//     comment at the top of the file.
+//   - Point keys in sstables are ordered.
+//   - Range delete tombstones in sstables are ordered and fragmented.
+//   - Successful processing of all MERGE records.
 func (d *DB) CheckLevels(stats *CheckLevelsStats) error {
 	// Grab and reference the current readState.
 	readState := d.loadReadState()

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -80,7 +80,7 @@ type levelIterBoundaryContext struct {
 // property. When one of the child iterators is exhausted during Next/Prev
 // iteration, it is removed from the heap.
 //
-// Range Deletions
+// # Range Deletions
 //
 // A mergingIter can optionally be configured with a slice of range deletion
 // iterators. The range deletion iterator slice must exactly parallel the point
@@ -150,11 +150,11 @@ type levelIterBoundaryContext struct {
 // to skip processing entries in that shadow. For example, consider the
 // scenario:
 //
-//   r0: a---e
-//   r1:    d---h
-//   r2:       g---k
-//   r3:          j---n
-//   r4:             m---q
+//	r0: a---e
+//	r1:    d---h
+//	r2:       g---k
+//	r3:          j---n
+//	r4:             m---q
 //
 // This is showing 5 levels of range deletions. Consider what happens upon
 // SeekGE("b"). We first seek the point iterator for level 0 (the point values
@@ -196,17 +196,17 @@ type levelIterBoundaryContext struct {
 //
 // For a full example, consider the following setup:
 //
-//   p0:               o
-//   r0:             m---q
+//	p0:               o
+//	r0:             m---q
 //
-//   p1:              n p
-//   r1:       g---k
+//	p1:              n p
+//	r1:       g---k
 //
-//   p2:  b d    i
-//   r2: a---e           q----v
+//	p2:  b d    i
+//	r2: a---e           q----v
 //
-//   p3:     e
-//   r3:
+//	p3:     e
+//	r3:
 //
 // If we start iterating from the beginning, the first key we encounter is "b"
 // in p2. When the mergingIter is pointing at a valid entry, the range deletion

--- a/metrics.go
+++ b/metrics.go
@@ -329,27 +329,27 @@ func (m *Metrics) formatWAL(w redact.SafePrinter) {
 // String pretty-prints the metrics, showing a line for the WAL, a line per-level, and
 // a total:
 //
-//   __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___w-amp
-//       WAL         1    27 B       -    48 B       -       -       -       -   108 B       -       -     2.2
-//         0         2   1.6 K    0.50    81 B   825 B       1     0 B       0   2.4 K       3     0 B    30.6
-//         1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
-//         2         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
-//         3         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
-//         4         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
-//         5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
-//         6         1   825 B    0.00   1.6 K     0 B       0     0 B       0   825 B       1   1.6 K     0.5
-//     total         3   2.4 K       -   933 B   825 B       1     0 B       0   4.1 K       4   1.6 K     4.5
-//     flush         3
-//   compact         1   1.6 K     0 B       1          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
-//     ctype         0       0       0       0       0  (default, delete, elision, move, read)
-//    memtbl         1   4.0 M
-//   zmemtbl         0     0 B
-//      ztbl         0     0 B
-//    bcache         4   752 B    7.7%  (score == hit-rate)
-//    tcache         0     0 B    0.0%  (score == hit-rate)
-// snapshots         0               0  (score == earliest seq num)
-//    titers         0
-//    filter         -       -    0.0%  (score == utility)
+//		__level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___w-amp
+//		    WAL         1    27 B       -    48 B       -       -       -       -   108 B       -       -     2.2
+//		      0         2   1.6 K    0.50    81 B   825 B       1     0 B       0   2.4 K       3     0 B    30.6
+//		      1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+//		      2         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+//		      3         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+//		      4         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+//		      5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     0.0
+//		      6         1   825 B    0.00   1.6 K     0 B       0     0 B       0   825 B       1   1.6 K     0.5
+//		  total         3   2.4 K       -   933 B   825 B       1     0 B       0   4.1 K       4   1.6 K     4.5
+//		  flush         3
+//		compact         1   1.6 K     0 B       1          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
+//		  ctype         0       0       0       0       0  (default, delete, elision, move, read)
+//		 memtbl         1   4.0 M
+//		zmemtbl         0     0 B
+//		   ztbl         0     0 B
+//		 bcache         4   752 B    7.7%  (score == hit-rate)
+//		 tcache         0     0 B    0.0%  (score == hit-rate)
+//	snapshots         0               0  (score == earliest seq num)
+//		 titers         0
+//		 filter         -       -    0.0%  (score == utility)
 //
 // The WAL "in" metric is the size of the batches written to the WAL. The WAL
 // "write" metric is the size of the physical data written to the WAL which

--- a/open_test.go
+++ b/open_test.go
@@ -850,10 +850,11 @@ func TestCrashOpenCrashAfterWALCreation(t *testing.T) {
 }
 
 // TestOpenWALReplayReadOnlySeqNums tests opening a database:
-// * in read-only mode
-// * with multiple unflushed log files that must replayed
-// * a MANIFEST that sets the last sequence number to a number greater than
-//   the unflushed log files
+//   - in read-only mode
+//   - with multiple unflushed log files that must replayed
+//   - a MANIFEST that sets the last sequence number to a number greater than
+//     the unflushed log files
+//
 // See cockroachdb/cockroach#48660.
 func TestOpenWALReplayReadOnlySeqNums(t *testing.T) {
 	const root = ""
@@ -1062,9 +1063,9 @@ func TestOpen_ErrorIfUnknownFormatVersion(t *testing.T) {
 //
 // This function is intended to be used in tests with defer.
 //
-//     opts := &Options{FS: vfs.NewMem()}
-//     defer ensureFilesClosed(t, opts)()
-//     /* test code */
+//	opts := &Options{FS: vfs.NewMem()}
+//	defer ensureFilesClosed(t, opts)()
+//	/* test code */
 func ensureFilesClosed(t *testing.T, o *Options) func() {
 	fs := &closeTrackingFS{
 		FS:    o.FS,

--- a/options.go
+++ b/options.go
@@ -230,7 +230,7 @@ func (o *IterOptions) getLogger() Logger {
 // Specifically, when configured with a RangeKeyMasking.Suffix _s_, and there
 // exists a range key with suffix _r_ covering a point key with suffix _p_, and
 //
-//     _s_ ≤ _r_ < _p_
+//	_s_ ≤ _r_ < _p_
 //
 // then the point key is elided.
 //

--- a/range_keys.go
+++ b/range_keys.go
@@ -266,24 +266,24 @@ func (m *rangeKeyMasking) SpanChanged(s *keyspan.Span) {
 // _t_, and there exists a span with suffix _r_ covering a point key with suffix
 // _p_, and
 //
-//     _t_ ≤ _r_ < _p_
+//	_t_ ≤ _r_ < _p_
 //
 // then the point key is elided. Consider the following rendering, where using
 // integer suffixes with higher integers sort before suffixes with lower
 // integers, (for example @7 ≤ @6 < @5):
 //
-//          ^
-//       @9 |        •―――――――――――――――○ [e,m)@9
-//     s  8 |                      • l@8
-//     u  7 |------------------------------------ @7 RangeKeyMasking.Suffix
-//     f  6 |      [h,q)@6 •―――――――――――――――――○            (threshold)
-//     f  5 |              • h@5
-//     f  4 |                          • n@4
-//     i  3 |          •―――――――――――○ [f,l)@3
-//     x  2 |  • b@2
-//        1 |
-//        0 |___________________________________
-//           a b c d e f g h i j k l m n o p q
+//	     ^
+//	  @9 |        •―――――――――――――――○ [e,m)@9
+//	s  8 |                      • l@8
+//	u  7 |------------------------------------ @7 RangeKeyMasking.Suffix
+//	f  6 |      [h,q)@6 •―――――――――――――――――○            (threshold)
+//	f  5 |              • h@5
+//	f  4 |                          • n@4
+//	i  3 |          •―――――――――――○ [f,l)@3
+//	x  2 |  • b@2
+//	   1 |
+//	   0 |___________________________________
+//	      a b c d e f g h i j k l m n o p q
 //
 // An iterator scanning the entire keyspace with the masking threshold set to @7
 // will observe point keys b@2 and l@8. The span keys [h,q)@6 and [f,l)@3 serve
@@ -327,9 +327,9 @@ func (m *rangeKeyMasking) SkipPoint(userKey []byte) bool {
 // Consider the range key [a,m)@10, and an iterator positioned just before the
 // below block, bounded by index separators `c` and `z`:
 //
-//                 c                          z
-//          x      |  c@9 c@5 c@1 d@7 e@4 y@4 | ...
-//       iter pos
+//	          c                          z
+//	   x      |  c@9 c@5 c@1 d@7 e@4 y@4 | ...
+//	iter pos
 //
 // The next block cannot be skipped, despite the range key suffix @10 is greater
 // than all the block's keys' suffixes, because it contains a key (y@4) outside

--- a/record/record.go
+++ b/record/record.go
@@ -19,6 +19,7 @@
 // Neither Readers or Writers are safe to use concurrently.
 //
 // Example code:
+//
 //	func read(r io.Reader) ([]string, error) {
 //		var ss []string
 //		records := record.NewReader(r)
@@ -65,9 +66,9 @@
 // A record maps to one or more chunks. There are two chunk formats: legacy and
 // recyclable. The legacy chunk format:
 //
-//   +----------+-----------+-----------+--- ... ---+
-//   | CRC (4B) | Size (2B) | Type (1B) | Payload   |
-//   +----------+-----------+-----------+--- ... ---+
+//	+----------+-----------+-----------+--- ... ---+
+//	| CRC (4B) | Size (2B) | Type (1B) | Payload   |
+//	+----------+-----------+-----------+--- ... ---+
 //
 // CRC is computed over the type and payload
 // Size is the length of the payload in bytes
@@ -84,9 +85,9 @@
 // metadata. Additionally, recycling log files is a prequisite for using direct
 // IO with log writing. The recyclyable format is:
 //
-//   +----------+-----------+-----------+----------------+--- ... ---+
-//   | CRC (4B) | Size (2B) | Type (1B) | Log number (4B)| Payload   |
-//   +----------+-----------+-----------+----------------+--- ... ---+
+//	+----------+-----------+-----------+----------------+--- ... ---+
+//	| CRC (4B) | Size (2B) | Type (1B) | Log number (4B)| Payload   |
+//	+----------+-----------+-----------+----------------+--- ... ---+
 //
 // Recyclable chunks are distinguished from legacy chunks by the addition of 4
 // extra "recyclable" chunk types that map directly to the legacy chunk types

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -296,18 +296,20 @@ type blockEntry struct {
 // handling. But these also turned out too costly for mid-stack inlining since
 // simple calls like the following have a high cost that is barely under the
 // budget of 80
-//  k, v := i.data.SeekGE(key, flags)  // cost 74
-//  k, v := i.data.Next()              // cost 72
+//
+//	k, v := i.data.SeekGE(key, flags)  // cost 74
+//	k, v := i.data.Next()              // cost 72
 //
 // We have 2 options for minimizing performance regressions:
-// - Include the lazyValueHandling logic in the already non-inlineable
-//   blockIter functions: Since most of the time is spent in data block iters,
-//   it is acceptable to take the small hit of unnecessary branching (which
-//   hopefully branch prediction will predict correctly) for other kinds of
-//   blocks.
-// - Duplicate the logic of singleLevelIterator and twoLevelIterator for the
-//   v3 sstable and only use the aforementioned lazyValueDataBlockIter for a
-//   v3 sstable. We would want to manage these copies via code generation.
+//   - Include the lazyValueHandling logic in the already non-inlineable
+//     blockIter functions: Since most of the time is spent in data block iters,
+//     it is acceptable to take the small hit of unnecessary branching (which
+//     hopefully branch prediction will predict correctly) for other kinds of
+//     blocks.
+//   - Duplicate the logic of singleLevelIterator and twoLevelIterator for the
+//     v3 sstable and only use the aforementioned lazyValueDataBlockIter for a
+//     v3 sstable. We would want to manage these copies via code generation.
+//
 // We have picked the first option here.
 type blockIter struct {
 	cmp Compare
@@ -1424,7 +1426,7 @@ func (i *blockIter) valid() bool {
 // gathers all the fragments with identical bounds within a block and returns a
 // single keyspan.Span describing all the keys defined over the span.
 //
-// Memory lifetime
+// # Memory lifetime
 //
 // A Span returned by fragmentBlockIter is only guaranteed to be stable until
 // the next fragmentBlockIter iteration positioning method. A Span's Keys slice

--- a/sstable/block_property.go
+++ b/sstable/block_property.go
@@ -82,17 +82,18 @@ import (
 // properties must only apply to the key, and will be provided a nil value.
 
 // BlockPropertyCollector is used when writing a sstable.
-// - All calls to Add are included in the next FinishDataBlock, after which
-//   the next data block is expected to start.
 //
-// - The index entry generated for the data block, which contains the return
-//   value from FinishDataBlock, is not immediately included in the current
-//   index block. It is included when AddPrevDataBlockToIndexBlock is called.
-//   An alternative would be to return an opaque handle from FinishDataBlock
-//   and pass it to a new AddToIndexBlock method, which requires more
-//   plumbing, and passing of an interface{} results in a undesirable heap
-//   allocation. AddPrevDataBlockToIndexBlock must be called before keys are
-//   added to the new data block.
+//   - All calls to Add are included in the next FinishDataBlock, after which
+//     the next data block is expected to start.
+//
+//   - The index entry generated for the data block, which contains the return
+//     value from FinishDataBlock, is not immediately included in the current
+//     index block. It is included when AddPrevDataBlockToIndexBlock is called.
+//     An alternative would be to return an opaque handle from FinishDataBlock
+//     and pass it to a new AddToIndexBlock method, which requires more
+//     plumbing, and passing of an interface{} results in a undesirable heap
+//     allocation. AddPrevDataBlockToIndexBlock must be called before keys are
+//     added to the new data block.
 type BlockPropertyCollector interface {
 	// Name returns the name of the block property collector.
 	Name() string

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -27,44 +27,44 @@
 //
 // To return the value for a key:
 //
-// 	r := table.NewReader(file, options)
-// 	defer r.Close()
-// 	i := r.NewIter(nil, nil)
-// 	defer i.Close()
-// 	ikey, value := r.SeekGE(key)
-// 	if options.Comparer.Compare(ikey.UserKey, key) != 0 {
-// 	  // not found
-// 	} else {
-// 	  // value is the first record containing key
-// 	}
+//	r := table.NewReader(file, options)
+//	defer r.Close()
+//	i := r.NewIter(nil, nil)
+//	defer i.Close()
+//	ikey, value := r.SeekGE(key)
+//	if options.Comparer.Compare(ikey.UserKey, key) != 0 {
+//	  // not found
+//	} else {
+//	  // value is the first record containing key
+//	}
 //
 // To count the number of entries in a table:
 //
-// 	i, n := r.NewIter(nil, nil), 0
-// 	for key, value := i.First(); key != nil; key, value = i.Next() {
-// 		n++
-// 	}
-// 	if err := i.Close(); err != nil {
-// 		return 0, err
-// 	}
-// 	return n, nil
+//	i, n := r.NewIter(nil, nil), 0
+//	for key, value := i.First(); key != nil; key, value = i.Next() {
+//		n++
+//	}
+//	if err := i.Close(); err != nil {
+//		return 0, err
+//	}
+//	return n, nil
 //
 // To write a table with three entries:
 //
-// 	w := table.NewWriter(file, options)
-// 	if err := w.Set([]byte("apple"), []byte("red")); err != nil {
-// 		w.Close()
-// 		return err
-// 	}
-// 	if err := w.Set([]byte("banana"), []byte("yellow")); err != nil {
-// 		w.Close()
-// 		return err
-// 	}
-// 	if err := w.Set([]byte("cherry"), []byte("red")); err != nil {
-// 		w.Close()
-// 		return err
-// 	}
-// 	return w.Close()
+//	w := table.NewWriter(file, options)
+//	if err := w.Set([]byte("apple"), []byte("red")); err != nil {
+//		w.Close()
+//		return err
+//	}
+//	if err := w.Set([]byte("banana"), []byte("yellow")); err != nil {
+//		w.Close()
+//		return err
+//	}
+//	if err := w.Set([]byte("cherry"), []byte("red")); err != nil {
+//		w.Close()
+//		return err
+//	}
+//	return w.Close()
 package sstable // import "github.com/cockroachdb/pebble/sstable"
 
 import (
@@ -282,17 +282,20 @@ func (t blockType) String() string {
 }
 
 // legacy (LevelDB) footer format:
-//    metaindex handle (varint64 offset, varint64 size)
-//    index handle     (varint64 offset, varint64 size)
-//    <padding> to make the total size 2 * BlockHandle::kMaxEncodedLength
-//    table_magic_number (8 bytes)
+//
+//	metaindex handle (varint64 offset, varint64 size)
+//	index handle     (varint64 offset, varint64 size)
+//	<padding> to make the total size 2 * BlockHandle::kMaxEncodedLength
+//	table_magic_number (8 bytes)
+//
 // new (RocksDB) footer format:
-//    checksum type (char, 1 byte)
-//    metaindex handle (varint64 offset, varint64 size)
-//    index handle     (varint64 offset, varint64 size)
-//    <padding> to make the total size 2 * BlockHandle::kMaxEncodedLength + 1
-//    footer version (4 bytes)
-//    table_magic_number (8 bytes)
+//
+//	checksum type (char, 1 byte)
+//	metaindex handle (varint64 offset, varint64 size)
+//	index handle     (varint64 offset, varint64 size)
+//	<padding> to make the total size 2 * BlockHandle::kMaxEncodedLength + 1
+//	footer version (4 bytes)
+//	table_magic_number (8 bytes)
 type footer struct {
 	format      TableFormat
 	checksum    ChecksumType

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -256,35 +256,37 @@ func (c *coordinationState) init(parallelismEnabled bool, writer *Writer) {
 
 // sizeEstimate is a general purpose helper for estimating two kinds of sizes:
 // A. The compressed sstable size, which is useful for deciding when to start
-//    a new sstable during flushes or compactions. In practice, we use this in
-//    estimating the data size (excluding the index).
+//
+//	a new sstable during flushes or compactions. In practice, we use this in
+//	estimating the data size (excluding the index).
+//
 // B. The size of index blocks to decide when to start a new index block.
 //
 // There are some terminology peculiarities which are due to the origin of
 // sizeEstimate for use case A with parallel compression enabled (for which
 // the code has not been merged). Specifically this relates to the terms
 // "written" and "compressed".
-// - The notion of "written" for case A is sufficiently defined by saying that
-//   the data block is compressed. Waiting for the actual data block write to
-//   happen can result in unnecessary estimation, when we already know how big
-//   it will be in compressed form. Additionally, with the forthcoming value
-//   blocks containing older MVCC values, these compressed block will be held
-//   in-memory until late in the sstable writing, and we do want to accurately
-//   account for them without waiting for the actual write.
-//   For case B, "written" means that the index entry has been fully
-//   generated, and has been added to the uncompressed block buffer for that
-//   index block. It does not include actually writing a potentially
-//   compressed index block.
-// - The notion of "compressed" is to differentiate between a "inflight" size
-//   and the actual size, and is handled via computing a compression ratio
-//   observed so far (defaults to 1).
-//   For case A, this is actual data block compression, so the "inflight" size
-//   is uncompressed blocks (that are no longer being written to) and the
-//   "compressed" size is after they have been compressed.
-//   For case B the inflight size is for a key-value pair in the index for
-//   which the value size (the encoded size of the BlockHandleWithProperties)
-//   is not accurately known, while the compressed size is the size of that
-//   entry when it has been added to the (in-progress) index ssblock.
+//   - The notion of "written" for case A is sufficiently defined by saying that
+//     the data block is compressed. Waiting for the actual data block write to
+//     happen can result in unnecessary estimation, when we already know how big
+//     it will be in compressed form. Additionally, with the forthcoming value
+//     blocks containing older MVCC values, these compressed block will be held
+//     in-memory until late in the sstable writing, and we do want to accurately
+//     account for them without waiting for the actual write.
+//     For case B, "written" means that the index entry has been fully
+//     generated, and has been added to the uncompressed block buffer for that
+//     index block. It does not include actually writing a potentially
+//     compressed index block.
+//   - The notion of "compressed" is to differentiate between a "inflight" size
+//     and the actual size, and is handled via computing a compression ratio
+//     observed so far (defaults to 1).
+//     For case A, this is actual data block compression, so the "inflight" size
+//     is uncompressed blocks (that are no longer being written to) and the
+//     "compressed" size is after they have been compressed.
+//     For case B the inflight size is for a key-value pair in the index for
+//     which the value size (the encoded size of the BlockHandleWithProperties)
+//     is not accurately known, while the compressed size is the size of that
+//     entry when it has been added to the (in-progress) index ssblock.
 //
 // Usage: To update state, one can optionally provide an inflight write value
 // using addInflight (used for case B). When something is "written" the state
@@ -1419,11 +1421,11 @@ func (w *Writer) indexEntrySep(prevKey, key InternalKey, dataBlockBuf *dataBlock
 // they're used when the index block is finished.
 //
 // Invariant:
-// 1. addIndexEntry must not store references to the sep InternalKey, the tmp
-//    byte slice, bhp.Props. That is, these must be either deep copied or
-//    encoded.
-// 2. addIndexEntry must not hold references to the flushIndexBuf, and the writeTo
-//    indexBlockBufs.
+//  1. addIndexEntry must not store references to the sep InternalKey, the tmp
+//     byte slice, bhp.Props. That is, these must be either deep copied or
+//     encoded.
+//  2. addIndexEntry must not hold references to the flushIndexBuf, and the writeTo
+//     indexBlockBufs.
 func (w *Writer) addIndexEntry(
 	sep InternalKey,
 	bhp BlockHandleWithProperties,
@@ -1468,8 +1470,8 @@ func (w *Writer) addPrevDataBlockToIndexBlockProps() {
 // aren't being written asynchronously.
 //
 // Invariant:
-// 1. addIndexEntrySync must not store references to the prevKey, key InternalKey's,
-//    the tmp byte slice. That is, these must be either deep copied or encoded.
+//  1. addIndexEntrySync must not store references to the prevKey, key InternalKey's,
+//     the tmp byte slice. That is, these must be either deep copied or encoded.
 func (w *Writer) addIndexEntrySync(
 	prevKey, key InternalKey, bhp BlockHandleWithProperties, tmp []byte,
 ) error {
@@ -1547,11 +1549,13 @@ func cloneKeyWithBuf(k InternalKey, buf []byte) ([]byte, InternalKey) {
 }
 
 // Invariants: The byte slice returned by finishIndexBlockProps is heap-allocated
-//  and has its own lifetime, independent of the Writer and the blockPropsEncoder,
+//
+//	and has its own lifetime, independent of the Writer and the blockPropsEncoder,
+//
 // and it is safe to:
-// 1. Reuse w.blockPropsEncoder without first encoding the byte slice returned.
-// 2. Store the byte slice in the Writer since it is a copy and not supported by
-//    an underlying buffer.
+//  1. Reuse w.blockPropsEncoder without first encoding the byte slice returned.
+//  2. Store the byte slice in the Writer since it is a copy and not supported by
+//     an underlying buffer.
 func (w *Writer) finishIndexBlockProps() ([]byte, error) {
 	w.blockPropsEncoder.resetProps()
 	for i := range w.blockPropCollectors {
@@ -1571,11 +1575,11 @@ func (w *Writer) finishIndexBlockProps() ([]byte, error) {
 // level index block. This is only used when two level indexes are enabled.
 //
 // Invariants:
-// 1. The props slice passed into finishedIndexBlock must not be a
-//    owned by any other struct, since it will be stored in the Writer.indexPartitions
-//    slice.
-// 2. None of the buffers owned by indexBuf will be shallow copied and stored elsewhere.
-//    That is, it must be safe to reuse indexBuf after finishIndexBlock has been called.
+//  1. The props slice passed into finishedIndexBlock must not be a
+//     owned by any other struct, since it will be stored in the Writer.indexPartitions
+//     slice.
+//  2. None of the buffers owned by indexBuf will be shallow copied and stored elsewhere.
+//     That is, it must be safe to reuse indexBuf after finishIndexBlock has been called.
 func (w *Writer) finishIndexBlock(indexBuf *indexBlockBuf, props []byte) error {
 	part := indexBlockAndBlockProperties{
 		nEntries: indexBuf.block.nEntries, properties: props,

--- a/table_stats.go
+++ b/table_stats.go
@@ -611,20 +611,20 @@ func estimateEntrySizes(
 // As an example, consider the following set of spans from the range deletion
 // and range key blocks of a table:
 //
-//         |---------|     |---------|         |-------| RANGEKEYDELs
-//   |-----------|-------------|           |-----|       RANGEDELs
-// __________________________________________________________
-//   a b c d e f g h i j k l m n o p q r s t u v w x y z
+//		      |---------|     |---------|         |-------| RANGEKEYDELs
+//		|-----------|-------------|           |-----|       RANGEDELs
+//	  __________________________________________________________
+//		a b c d e f g h i j k l m n o p q r s t u v w x y z
 //
 // The tableRangedDeletionIter produces the following set of output spans, where
 // '1' indicates a span containing only range deletions, '2' is a span
 // containing only range key deletions, and '3' is a span containing a mixture
 // of both range deletions and range key deletions.
 //
-//      1       3       1    3    2          1  3   2
-//   |-----|---------|-----|---|-----|     |---|-|-----|
-// __________________________________________________________
-//   a b c d e f g h i j k l m n o p q r s t u v w x y z
+//		   1       3       1    3    2          1  3   2
+//		|-----|---------|-----|---|-----|     |---|-|-----|
+//	  __________________________________________________________
+//		a b c d e f g h i j k l m n o p q r s t u v w x y z
 //
 // Algorithm.
 //
@@ -639,11 +639,11 @@ func estimateEntrySizes(
 // have already been defragmented. To the left and right of any overlap, the
 // same reasoning applies. For example,
 //
-//            |--------|         |-------| RANGEKEYDEL
-//   |---------------------------|         RANGEDEL
-//   |----1---|----3---|----1----|---2---| Merged, fragmented spans.
-// __________________________________________________________
-//   a b c d e f g h i j k l m n o p q r s t u v w x y z
+//		         |--------|         |-------| RANGEKEYDEL
+//		|---------------------------|         RANGEDEL
+//		|----1---|----3---|----1----|---2---| Merged, fragmented spans.
+//	  __________________________________________________________
+//		a b c d e f g h i j k l m n o p q r s t u v w x y z
 //
 // Any fragmented abutting spans produced by the merging iter will be of
 // differing types (i.e. a transition from a span with homogenous key kinds to a

--- a/tool/testdata/mixed/main.go
+++ b/tool/testdata/mixed/main.go
@@ -3,19 +3,16 @@
 //
 // Upon running this command, the DB directory will contain:
 //
-// - A single SSTable (000005.sst), containing:
-//   - 26 point keys, a@1 through z@1.
-//   - Three range keys:
-//     - RANGEKEYSET [a, z)@1
-//     - RANGEKEYUNSET [a, z)@2
-//     - RANGEKEYDEL [a, b)
-//
-// - A WAL for an unflushed memtable containing:
-//   - A single point key a@2.
-//   - Three range keys:
-//     - RANGEKEYSET [a, z)@3
-//     - RANGEKEYUNSET [a, z)@4
-//     - RANGEKEYDEL [a, b)
+//  1. A single SSTable (000005.sst), containing:
+//     a. 26 point keys, a@1 through z@1.
+//     b. a RANGEKEYSET [a, z)@1
+//     c. a RANGEKEYUNSET [a, z)@2
+//     d. a RANGEKEYDEL [a, b)
+//  2. A WAL for an unflushed memtable containing:
+//     a. A single point key a@2.
+//     b. a RANGEKEYSET [a, z)@3
+//     c. a RANGEKEYUNSET [a, z)@4
+//     d. a RANGEKEYDEL [a, b)
 package main
 
 import (

--- a/vfs/disk_health.go
+++ b/vfs/disk_health.go
@@ -156,18 +156,18 @@ func (d *diskHealthCheckingFile) timeDiskOp(op func()) {
 // maximum concurrent filesystem operations. This is expected to be very few
 // for these reasons:
 //  1. Pebble has limited write concurrency. Flushes, compactions and WAL
-//  rotations are the primary sources of filesystem metadata operations. With
-//  the default max-compaction concurrency, these operations require at most 5
-//  concurrent slots if all 5 perform a filesystem metadata operation
-//  simultaneously.
+//     rotations are the primary sources of filesystem metadata operations. With
+//     the default max-compaction concurrency, these operations require at most 5
+//     concurrent slots if all 5 perform a filesystem metadata operation
+//     simultaneously.
 //  2. Pebble's limited concurrent I/O writers spend most of their time
-//  performing file I/O, not performing the filesystem metadata operations that
-//  require recording a slot on the diskHealthCheckingFS.
+//     performing file I/O, not performing the filesystem metadata operations that
+//     require recording a slot on the diskHealthCheckingFS.
 //  3. In CockroachDB, each additional store/Pebble instance has its own vfs.FS
-//  which provides a separate goroutine and set of slots.
+//     which provides a separate goroutine and set of slots.
 //  4. In CockroachDB, many of the additional sources of filesystem metadata
-//  operations (like encryption-at-rest) are sequential with respect to Pebble's
-//  threads.
+//     operations (like encryption-at-rest) are sequential with respect to Pebble's
+//     threads.
 type diskHealthCheckingFS struct {
 	tickInterval      time.Duration
 	diskSlowThreshold time.Duration

--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -36,22 +36,23 @@ func NewMem() *MemFS {
 // at which point they are discarded and no longer visible.
 //
 // Expected usage:
-//  strictFS := NewStrictMem()
-//  db := Open(..., &Options{FS: strictFS})
-//  // Do and commit various operations.
-//  ...
-//  // Prevent any more changes to finalized state.
-//  strictFS.SetIgnoreSyncs(true)
-//  // This will finish any ongoing background flushes, compactions but none of these writes will
-//  // be finalized since syncs are being ignored.
-//  db.Close()
-//  // Discard unsynced state.
-//  strictFS.ResetToSyncedState()
-//  // Allow changes to finalized state.
-//  strictFS.SetIgnoreSyncs(false)
-//  // Open the DB. This DB should have the same state as if the earlier strictFS operations and
-//  // db.Close() were not called.
-//  db := Open(..., &Options{FS: strictFS})
+//
+//	strictFS := NewStrictMem()
+//	db := Open(..., &Options{FS: strictFS})
+//	// Do and commit various operations.
+//	...
+//	// Prevent any more changes to finalized state.
+//	strictFS.SetIgnoreSyncs(true)
+//	// This will finish any ongoing background flushes, compactions but none of these writes will
+//	// be finalized since syncs are being ignored.
+//	db.Close()
+//	// Discard unsynced state.
+//	strictFS.ResetToSyncedState()
+//	// Allow changes to finalized state.
+//	strictFS.SetIgnoreSyncs(false)
+//	// Open the DB. This DB should have the same state as if the earlier strictFS operations and
+//	// db.Close() were not called.
+//	db := Open(..., &Options{FS: strictFS})
 func NewStrictMem() *MemFS {
 	return &MemFS{
 		root:   newRootMemNode(),
@@ -141,6 +142,7 @@ func (y *MemFS) ResetToSyncedState() {
 //   - "/", "foo", false
 //   - "/foo/", "bar", false
 //   - "/foo/bar/", "x", true
+//
 // Similarly, walking "/y/z/", with a trailing slash, will result in 3 calls to f:
 //   - "/", "y", false
 //   - "/y/", "z", false


### PR DESCRIPTION
Reformat the codebase using Go 1.19's gofmt. Go 1.19 introduced new doc comment formatting rules outlined at:
  https://tip.golang.org/doc/comment

This commit applies these rules to all doc comments across Pebble, plus some additional comment reshaping to preserve some ASCII formatting.