### PR TITLE
internal/manifest: fix out-of-bounds b-tree access

### DIFF
--- a/internal/manifest/btree.go
+++ b/internal/manifest/btree.go
@@ -12,6 +12,7 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/invariants"
 )
 
 // The Annotator type defined below is used by other packages to lazily
@@ -1150,5 +1151,8 @@ func (i *iterator) valid() bool {
 // cur returns the item at the iterator's current position. It is illegal
 // to call cur if the iterator is not valid.
 func (i *iterator) cur() *FileMetadata {
+	if invariants.Enabled && !i.valid() {
+		panic("btree iterator.cur invoked on invalid iterator")
+	}
 	return i.n.items[i.pos]
 }

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -606,7 +606,6 @@ func (i *LevelIterator) seek(fn func(*FileMetadata) bool) *FileMetadata {
 		return nil
 	} else if i.start != nil && cmpIter(i.iter, *i.start) < 0 {
 		i.iter = i.start.clone()
-		return i.iter.cur()
 	}
 	if !i.iter.valid() {
 		return nil

--- a/internal/manifest/testdata/level_iterator
+++ b/internal/manifest/testdata/level_iterator
@@ -111,3 +111,18 @@ seek-lt z
 .
 000002:[c#3,1-d#4,1]
 000003:[e#5,1-f#6,1]
+
+define
+a.SET.1-b.SET.2 c.SET.3-d.SET.4 e.SET.5-f.SET.6 g.SET.7-h.SET.8 [ ]
+----
+
+iter
+seek-ge cat
+seek-lt cat
+first
+last
+----
+.
+.
+.
+.


### PR DESCRIPTION
In #2187, the LevelIterator seeking methods were refactored to no longer early exit when a LevelIterator's bounds indicate that the iterator is empty. This change was necessary for new invariant checking around the exhausted iterator positions at the beginning and end of iteration.

This inadvertently allowed a seek on an empty, bounded iterator to improperly access the underlying b-tree iterator's current position, despite it being invalid.

Informs #2210.