### PR TITLE
db: don't validate version edits during a panic

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2234,7 +2234,10 @@ func (d *DB) runCompaction(
 	// deleted files in the new versionEdit pass a validation function before
 	// returning the edit.
 	defer func() {
-		if ve != nil {
+		// If we're handling a panic, don't expect the version edit to validate.
+		if r := recover(); r != nil {
+			panic(r)
+		} else if ve != nil {
 			err := validateVersionEdit(ve, d.opts.Experimental.KeyValidationFunc, d.opts.Comparer.FormatKey)
 			if err != nil {
 				d.opts.Logger.Fatalf("pebble: version edit validation failed: %s", err)


### PR DESCRIPTION
At the end of every flush and compaction, we sanity-check the version edit and associated file metadata. If during the defer, we're handling an existing panic, don't validate the version edit.

In 22.2.0, Pebble would panic if a sstable.Reader found that a readahead file no longer existed. This was new behavior relative to previous releases, which would `os.Exit` directly. More recent releases (22.2.x) avoid treating these no-longer-existant files as fatal at all.

Informs cockroachdb/cockroach#93851.