### PR TITLE
sstable: avoid allocating up to maximum block size in valueBlockWriter

### DIFF
--- a/sstable/value_block.go
+++ b/sstable/value_block.go
@@ -460,9 +460,12 @@ func (w *valueBlockWriter) addValue(v []byte) (valueHandle, error) {
 	}
 	blockLen = int(vh.offsetInBlock + vh.valueLen)
 	if cap(w.buf.b) < blockLen {
-		size := w.blockSize + w.blockSize/2
-		if size < blockLen {
-			size = blockLen + blockLen/2
+		size := 2 * cap(w.buf.b)
+		if size < 1024 {
+			size = 1024
+		}
+		for size < blockLen {
+			size *= 2
 		}
 		buf := make([]byte, blockLen, size)
 		_ = copy(buf, w.buf.b)


### PR DESCRIPTION
Tests can set a high maximum block size e.g. TestReader sets the block size to 2GB. This resulted in a 3GB byte slice being allocated. The new logic is similar to the behavior in blockWriter.

Fixes #2159