### PR TITLE
ci: re-enable linux race

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,21 +45,18 @@ jobs:
 
     - run: make crossversion-meta
 
-  # This job currently (reliably) fails in GitHub actions. Temporarily skip
-  # while the failures are investigated.
-  # See: https://github.com/cockroachdb/pebble/issues/2159
-  #linux-race:
-  #  name: go-linux-race
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #  - uses: actions/checkout@v2
-  #
-  #  - name: Set up Go
-  #    uses: actions/setup-go@v2
-  #    with:
-  #      go-version: "1.18"
-  #
-  #  - run: make testrace TAGS=
+  linux-race:
+    name: go-linux-race
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: "1.19"
+
+    - run: make testrace TAGS=
 
   linux-no-invariants:
     name: go-linux-no-invariants


### PR DESCRIPTION
Follow-on from https://github.com/cockroachdb/pebble/pull/2236.