### PR TITLE
Revert "sstable: skip two known test flakes on windows"

### DIFF
--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -638,9 +637,6 @@ func TestBytesIterated(t *testing.T) {
 		testBytesIteratedWithCompression(t, SnappyCompression, 1, blockSizes, []uint64{1e5, 1e5, 1e5, 1e5, 1e5})
 	})
 	t.Run("Uncompressed", func(t *testing.T) {
-		if runtime.GOOS == "windows" {
-			t.Skip("See #1897.")
-		}
 		testBytesIteratedWithCompression(t, NoCompression, 0, blockSizes, []uint64{1e5, 1e5, 1e5, 1e5, 1e5})
 	})
 	t.Run("Zstd", func(t *testing.T) {

--- a/sstable/unsafe_test.go
+++ b/sstable/unsafe_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"runtime"
 	"testing"
 	"time"
 	"unsafe"
@@ -18,9 +17,6 @@ import (
 )
 
 func TestGetBytes(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("See #1897.")
-	}
 	const size = (1 << 31) - 1
 	block := make([]byte, size)
 	data := getBytes(unsafe.Pointer(&block[0]), size)


### PR DESCRIPTION
This reverts commit 65ff304d3d7a5f7b7ed038bd175a7dd440637af4.

Touches #1897.