### PR TITLE
crl-release-22.2: db: scan a readState during format major version upgrades

### DIFF
--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -12,6 +12,9 @@ sync: db/temporary.000001.dbtmp
 close: db/temporary.000001.dbtmp
 rename: db/temporary.000001.dbtmp -> db/CURRENT
 sync: db
+sync: db/MANIFEST-000001
+create: db/000002.log
+sync: db
 create: db/marker.manifest.000001.MANIFEST-000001
 close: db/marker.manifest.000001.MANIFEST-000001
 sync: db
@@ -48,9 +51,6 @@ close: db/marker.format-version.000009.010
 sync: db
 create: db/marker.format-version.000010.011
 close: db/marker.format-version.000010.011
-sync: db
-sync: db/MANIFEST-000001
-create: db/000002.log
 sync: db
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -15,6 +15,10 @@ close: db/temporary.000001.dbtmp
 rename: db/temporary.000001.dbtmp -> db/CURRENT
 sync: db
 [JOB 1] MANIFEST created 000001
+sync: db/MANIFEST-000001
+create: wal/000002.log
+sync: wal
+[JOB 1] WAL created 000002
 create: db/marker.manifest.000001.MANIFEST-000001
 close: db/marker.manifest.000001.MANIFEST-000001
 sync: db
@@ -62,10 +66,6 @@ create: db/marker.format-version.000010.011
 close: db/marker.format-version.000010.011
 sync: db
 upgraded to format version: 011
-sync: db/MANIFEST-000001
-create: wal/000002.log
-sync: wal
-[JOB 1] WAL created 000002
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -79,10 +79,10 @@ sync: wal/000002.log
 close: wal/000002.log
 create: wal/000004.log
 sync: wal
-[JOB 6] WAL created 000004
-[JOB 7] flushing 1 memtable to L0
+[JOB 4] WAL created 000004
+[JOB 5] flushing 1 memtable to L0
 create: db/000005.sst
-[JOB 7] flushing: sstable created 000005
+[JOB 5] flushing: sstable created 000005
 sync: db/000005.sst
 close: db/000005.sst
 sync: db
@@ -92,8 +92,8 @@ sync: db/MANIFEST-000006
 create: db/marker.manifest.000002.MANIFEST-000006
 close: db/marker.manifest.000002.MANIFEST-000006
 sync: db
-[JOB 7] MANIFEST created 000006
-[JOB 7] flushed 1 memtable to L0 [000005] (770 B), in 1.0s (2.0s total), output rate 770 B/s
+[JOB 5] MANIFEST created 000006
+[JOB 5] flushed 1 memtable to L0 [000005] (770 B), in 1.0s (2.0s total), output rate 770 B/s
 
 compact
 ----
@@ -102,10 +102,10 @@ sync: wal/000004.log
 close: wal/000004.log
 reuseForWrite: wal/000002.log -> wal/000007.log
 sync: wal
-[JOB 8] WAL created 000007 (recycled 000002)
-[JOB 9] flushing 1 memtable to L0
+[JOB 6] WAL created 000007 (recycled 000002)
+[JOB 7] flushing 1 memtable to L0
 create: db/000008.sst
-[JOB 9] flushing: sstable created 000008
+[JOB 7] flushing: sstable created 000008
 sync: db/000008.sst
 close: db/000008.sst
 sync: db
@@ -115,12 +115,12 @@ sync: db/MANIFEST-000009
 create: db/marker.manifest.000003.MANIFEST-000009
 close: db/marker.manifest.000003.MANIFEST-000009
 sync: db
-[JOB 9] MANIFEST created 000009
-[JOB 9] flushed 1 memtable to L0 [000008] (770 B), in 1.0s (2.0s total), output rate 770 B/s
-[JOB 9] MANIFEST deleted 000001
-[JOB 10] compacting(default) L0 [000005 000008] (1.5 K) + L6 [] (0 B)
+[JOB 7] MANIFEST created 000009
+[JOB 7] flushed 1 memtable to L0 [000008] (770 B), in 1.0s (2.0s total), output rate 770 B/s
+[JOB 7] MANIFEST deleted 000001
+[JOB 8] compacting(default) L0 [000005 000008] (1.5 K) + L6 [] (0 B)
 create: db/000010.sst
-[JOB 10] compacting: sstable created 000010
+[JOB 8] compacting: sstable created 000010
 sync: db/000010.sst
 close: db/000010.sst
 sync: db
@@ -130,11 +130,11 @@ sync: db/MANIFEST-000011
 create: db/marker.manifest.000004.MANIFEST-000011
 close: db/marker.manifest.000004.MANIFEST-000011
 sync: db
-[JOB 10] MANIFEST created 000011
-[JOB 10] compacted(default) L0 [000005 000008] (1.5 K) + L6 [] (0 B) -> L6 [000010] (770 B), in 1.0s (2.0s total), output rate 770 B/s
-[JOB 10] sstable deleted 000005
-[JOB 10] sstable deleted 000008
-[JOB 10] MANIFEST deleted 000006
+[JOB 8] MANIFEST created 000011
+[JOB 8] compacted(default) L0 [000005 000008] (1.5 K) + L6 [] (0 B) -> L6 [000010] (770 B), in 1.0s (2.0s total), output rate 770 B/s
+[JOB 8] sstable deleted 000005
+[JOB 8] sstable deleted 000008
+[JOB 8] MANIFEST deleted 000006
 
 disable-file-deletions
 ----
@@ -146,10 +146,10 @@ sync: wal/000007.log
 close: wal/000007.log
 reuseForWrite: wal/000004.log -> wal/000012.log
 sync: wal
-[JOB 11] WAL created 000012 (recycled 000004)
-[JOB 12] flushing 1 memtable to L0
+[JOB 9] WAL created 000012 (recycled 000004)
+[JOB 10] flushing 1 memtable to L0
 create: db/000013.sst
-[JOB 12] flushing: sstable created 000013
+[JOB 10] flushing: sstable created 000013
 sync: db/000013.sst
 close: db/000013.sst
 sync: db
@@ -159,17 +159,17 @@ sync: db/MANIFEST-000014
 create: db/marker.manifest.000005.MANIFEST-000014
 close: db/marker.manifest.000005.MANIFEST-000014
 sync: db
-[JOB 12] MANIFEST created 000014
-[JOB 12] flushed 1 memtable to L0 [000013] (770 B), in 1.0s (2.0s total), output rate 770 B/s
+[JOB 10] MANIFEST created 000014
+[JOB 10] flushed 1 memtable to L0 [000013] (770 B), in 1.0s (2.0s total), output rate 770 B/s
 
 enable-file-deletions
 ----
-[JOB 13] MANIFEST deleted 000009
+[JOB 11] MANIFEST deleted 000009
 
 ingest
 ----
 link: ext/0 -> db/000015.sst
-[JOB 14] ingesting: sstable created 000015
+[JOB 12] ingesting: sstable created 000015
 sync: db
 create: db/MANIFEST-000016
 close: db/MANIFEST-000014
@@ -177,9 +177,9 @@ sync: db/MANIFEST-000016
 create: db/marker.manifest.000006.MANIFEST-000016
 close: db/marker.manifest.000006.MANIFEST-000016
 sync: db
-[JOB 14] MANIFEST created 000016
-[JOB 14] MANIFEST deleted 000011
-[JOB 14] ingested L0:000015 (825 B)
+[JOB 12] MANIFEST created 000016
+[JOB 12] MANIFEST deleted 000011
+[JOB 12] ingested L0:000015 (825 B)
 
 metrics
 ----


### PR DESCRIPTION
22.2 backport of #2186.

----

During a format major version, some version migrations must scan the LSM. These migrations require that the files they examine are not deleted before or while they're reading them. A previous attempt (#2020) at avoiding these unexpected deletions accidentally left an opening for the acquired versions' files to be deleted while waiting for file deletions to be disabled (sleeping on a condition variable).

A different fix with less subtlety is applied here. The format major version upgrade path acquires a readState, which refs the versions it acquires, preventing deletion of the referenced files. This requires the format major version upgrade in Open to be moved later within the Open routine, after the current read state is initialized.

Fix #2143.