### PR TITLE
db: calculate w-amp when DisableWAL is enabled

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1694,8 +1694,16 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 		// oldest unflushed memtable.
 		ve.MinUnflushedLogNum = minUnflushedLogNum
 		metrics := c.metrics[0]
-		for i := 0; i < n; i++ {
-			metrics.BytesIn += d.mu.mem.queue[i].logSize
+		if d.opts.DisableWAL {
+			// If the WAL is disabled, every flushable has a zero [logSize],
+			// resulting in zero bytes in. Instead, use the number of bytes we
+			// flushed as the BytesIn. This ensures we get a reasonable w-amp
+			// calculation even when the WAL is disabled.
+			metrics.BytesIn = metrics.BytesFlushed
+		} else {
+			for i := 0; i < n; i++ {
+				metrics.BytesIn += d.mu.mem.queue[i].logSize
+			}
 		}
 
 		d.mu.versions.logLock()


### PR DESCRIPTION
Previously, when DisableWAL was enabled, L0's [BytesIn] field was always zero, because the logSizes were always zero. This commit adjusts the flush metrics accounting to consider all the L0 flushed bytes as [BytesIn] when the WAL is disabled. This allows Metrics to compute a total write amplification value, whereas previously the zero BytesIn quantity prevented it.