### PR TITLE
sstable: minor cleanup of flushable interface

### DIFF
--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -721,8 +721,7 @@ func (f *memFile) Sync() error {
 	return nil
 }
 
-// Flush is a no-op and present only to prevent buffering at higher levels
-// (e.g. it prevents sstable.Writer from using a bufio.Writer).
-func (f *memFile) Flush() error {
-	return nil
-}
+// NoWriteBufferingMarker is a marker method used to prevent unnecessary write
+// buffering at higher levels (it prevents sstable.Writer from using a
+// bufio.Writer).
+func (f *memFile) NoWriteBufferingMarker() {}


### PR DESCRIPTION
I found the logic around the `flushable` interface very confusing - if we have a `Flush()` method we disable our own buffering, but we don't actually ever call `Flush()`.

This commit renames the method to make it clear it is just a marker.