### PR TITLE
ci: only use latest version of Go

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,22 +13,15 @@ on:
 jobs:
 
   linux:
-    name: go${{ matrix.go }}-linux
+    name: go-linux
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        go:
-          - "1.17"
-          - "1.18"
-          - "1.19"
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up go${{ matrix.go }}
+    - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: ${{ matrix.go }}
+        go-version: "1.19"
 
     - run: make test generate
 


### PR DESCRIPTION
Drop the Go version matrix and test against a single version of Go.