### PR TITLE
replay: various compaction benchmarking tweaks

### DIFF
--- a/cmd/pebble/replay.go
+++ b/cmd/pebble/replay.go
@@ -25,7 +25,7 @@ import (
 
 func initReplayCmd() *cobra.Command {
 	c := replayConfig{
-		pacer:            pacerFlag{Pacer: replay.Unpaced{}},
+		pacer:            pacerFlag{Pacer: replay.PaceByFixedReadAmp(10)},
 		runDir:           "",
 		count:            1,
 		streamLogs:       false,

--- a/cmd/pebble/replay_test.go
+++ b/cmd/pebble/replay_test.go
@@ -1,0 +1,58 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseOptionsStr(t *testing.T) {
+	type testCase struct {
+		optionsStr string
+		options    *pebble.Options
+	}
+
+	testCases := []testCase{
+		{
+			optionsStr: `[Options] max_concurrent_compactions=9`,
+			options:    &pebble.Options{MaxConcurrentCompactions: func() int { return 9 }},
+		},
+		{
+			optionsStr: `[Options] bytes_per_sync=90000`,
+			options:    &pebble.Options{BytesPerSync: 90000},
+		},
+		{
+			optionsStr: `[Options] [Level "0"] target_file_size=222`,
+			options: &pebble.Options{Levels: []pebble.LevelOptions{
+				{TargetFileSize: 222},
+			}},
+		},
+		{
+			optionsStr: `[Options] lbase_max_bytes=10  max_open_files=20  [Level "0"] target_file_size=30 [Level "1"] index_block_size=40`,
+			options: &pebble.Options{
+				LBaseMaxBytes: 10,
+				MaxOpenFiles:  20,
+				Levels: []pebble.LevelOptions{
+					{TargetFileSize: 30},
+					{IndexBlockSize: 40},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		o := new(pebble.Options)
+		require.NoError(t, parseCustomOptions(tc.optionsStr, o))
+		o.EnsureDefaults()
+		got := o.String()
+
+		tc.options.EnsureDefaults()
+		want := tc.options.String()
+		require.Equal(t, want, got)
+	}
+}

--- a/db.go
+++ b/db.go
@@ -1630,6 +1630,9 @@ func (d *DB) Metrics() *Metrics {
 		d.opts.Logger.Infof("metrics error: %s", err)
 	}
 	metrics.Flush.WriteThroughput = d.mu.compact.flushWriteThroughput
+	if d.mu.compact.flushing {
+		metrics.Flush.NumInProgress = 1
+	}
 
 	d.mu.Unlock()
 

--- a/metrics.go
+++ b/metrics.go
@@ -184,6 +184,9 @@ type Metrics struct {
 		// The total number of flushes.
 		Count           int64
 		WriteThroughput ThroughputMetric
+		// Number of flushes that are in-progress. In the current implementation
+		// this will always be zero or one.
+		NumInProgress int64
 	}
 
 	Filter FilterMetrics

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -411,11 +411,9 @@ func (r *Runner) Wait() (Metrics, error) {
 		err = storedErr.(error)
 	}
 	pm := r.d.Metrics()
-	var total pebble.LevelMetrics
+	total := pm.Total()
 	var ingestBytesWeighted uint64
 	for l := 0; l < len(pm.Levels); l++ {
-		total.Add(&pm.Levels[l])
-		total.Sublevels += pm.Levels[l].Sublevels
 		ingestBytesWeighted += pm.Levels[l].BytesIngested * uint64(len(pm.Levels)-l-1)
 	}
 

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -6,11 +6,14 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,6 +21,7 @@ import (
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/datatest"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/rangekey"
 	"github.com/cockroachdb/pebble/vfs"
@@ -448,4 +452,112 @@ func listFiles(t *testing.T, fs vfs.FS, w io.Writer, name string) {
 	for _, dirent := range ls {
 		fmt.Fprintf(w, "  %s\n", dirent)
 	}
+}
+
+// TestCompactionsQuiesce replays a workload that produces a nontrivial number of
+// compactions several times. It's intended to exercise Waits termination, which
+// is dependent on compactions quiescing.
+func TestCompactionsQuiesce(t *testing.T) {
+	const replayCount = 1
+	workloadFS := getHeavyWorkload(t)
+	fs := vfs.NewMem()
+	var atomicDone [replayCount]uint32
+	for i := 0; i < replayCount; i++ {
+		func(i int) {
+			runDir := fmt.Sprintf("run%d", i)
+			require.NoError(t, fs.MkdirAll(runDir, os.ModePerm))
+			r := Runner{
+				RunDir:       runDir,
+				WorkloadFS:   workloadFS,
+				WorkloadPath: "workload",
+				Pacer:        Unpaced{},
+				Opts: &pebble.Options{
+					Comparer:           testkeys.Comparer,
+					FS:                 fs,
+					FormatMajorVersion: pebble.FormatNewest,
+					LBaseMaxBytes:      1,
+				},
+			}
+			r.Opts.Experimental.LevelMultiplier = 2
+			require.NoError(t, r.Run(context.Background()))
+			defer r.Close()
+
+			var m Metrics
+			var err error
+			go func() {
+				m, err = r.Wait()
+				atomic.StoreUint32(&atomicDone[i], 1)
+			}()
+
+			wait := 30 * time.Second
+			if invariants.Enabled {
+				wait = time.Minute
+			}
+
+			// The above call to [Wait] should eventually return. [Wait] blocks
+			// until the workload has replayed AND compactions have quiesced. A
+			// bug in either could prevent [Wait] from ever returning.
+			require.Eventually(t, func() bool { return atomic.LoadUint32(&atomicDone[i]) == 1 },
+				wait, time.Millisecond, "(*replay.Runner).Wait didn't terminate")
+			require.NoError(t, err)
+			// Require at least 5 compactions.
+			require.Greater(t, m.Final.Compact.Count, int64(5))
+			require.Equal(t, int64(0), m.Final.Compact.NumInProgress)
+			for l := 0; l < len(m.Final.Levels)-1; l++ {
+				require.Less(t, m.Final.Levels[l].Score, 1.0)
+			}
+		}(i)
+	}
+}
+
+// getHeavyWorkload returns a FS containing a workload in the `workload`
+// directory that flushes enough randomly generated keys that replaying it
+// should generate a non-trivial number of compactions.
+func getHeavyWorkload(t *testing.T) vfs.FS {
+	heavyWorkload.Once.Do(func() {
+		t.Run("buildHeavyWorkload", func(t *testing.T) {
+			heavyWorkload.fs = buildHeavyWorkload(t)
+		})
+	})
+	return heavyWorkload.fs
+}
+
+var heavyWorkload struct {
+	sync.Once
+	fs vfs.FS
+}
+
+func buildHeavyWorkload(t *testing.T) vfs.FS {
+	o := &pebble.Options{
+		Comparer:           testkeys.Comparer,
+		FS:                 vfs.NewMem(),
+		FormatMajorVersion: pebble.FormatNewest,
+	}
+	wc := NewWorkloadCollector("")
+	wc.Attach(o)
+	d, err := pebble.Open("", o)
+	require.NoError(t, err)
+
+	destFS := vfs.NewMem()
+	require.NoError(t, destFS.MkdirAll("workload", os.ModePerm))
+	wc.Start(destFS, "workload")
+
+	ks := testkeys.Alpha(5)
+	var bufKey = make([]byte, ks.MaxLen())
+	var bufVal [512]byte
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		b := d.NewBatch()
+		for j := 0; j < 1000; j++ {
+			rng.Read(bufVal[:])
+			n := testkeys.WriteKey(bufKey[:], ks, rng.Intn(ks.Count()))
+			require.NoError(t, b.Set(bufKey[:n], bufVal[:], pebble.NoSync))
+		}
+		require.NoError(t, b.Commit(pebble.NoSync))
+		require.NoError(t, d.Flush())
+	}
+	wc.Stop()
+
+	defer d.Close()
+	return destFS
 }


### PR DESCRIPTION
**cmd/pebble: add -count to replay command**

Add a -count flag to the replay command to replay a workload multiple times,
useful for building up a statistically significant number of runs.

**replay: refactor compaction tracking**

Refactor the compaction tracking for readability and eliminating an extra
goroutine. Also, add a unit test that ensures the replayer correctly
detects when compactions quiesce.

**cmd/pebble: remove temporary run directories before exit**

**replay: fix TotalWAmp calculation**

Fix TotalWAmp calculation to use Metrics.Total and maintain consistency with
the w-amp reported by Metrics.String(). The Metrics.Total method handles
adjusting BytesIn and BytesFlushed.

**cmd/pebble: allow setting custom Pebble Options through a CLI flag**