### PR TITLE
vfs: capture operation type affected by disk slowness

### DIFF
--- a/event.go
+++ b/event.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/pebble/internal/humanize"
 	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/redact"
 )
 
@@ -118,6 +119,8 @@ func (i levelInfos) SafeFormat(w redact.SafePrinter, _ rune) {
 type DiskSlowInfo struct {
 	// Path of file being written to.
 	Path string
+	// Operation being performed on the file.
+	OpType vfs.OpType
 	// Duration that has elapsed since this disk operation started.
 	Duration time.Duration
 }
@@ -128,8 +131,8 @@ func (i DiskSlowInfo) String() string {
 
 // SafeFormat implements redact.SafeFormatter.
 func (i DiskSlowInfo) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Printf("disk slowness detected: write to file %s has been ongoing for %0.1fs",
-		i.Path, redact.Safe(i.Duration.Seconds()))
+	w.Printf("disk slowness detected: %s on file %s has been ongoing for %0.1fs",
+		redact.Safe(i.OpType.String()), i.Path, redact.Safe(i.Duration.Seconds()))
 }
 
 // FlushInfo contains the info for a flush event.

--- a/options.go
+++ b/options.go
@@ -966,9 +966,10 @@ func (o *Options) EnsureDefaults() *Options {
 
 	if o.FS == nil {
 		o.FS, o.private.fsCloser = vfs.WithDiskHealthChecks(vfs.Default, 5*time.Second,
-			func(name string, duration time.Duration) {
+			func(name string, op vfs.OpType, duration time.Duration) {
 				o.EventListener.DiskSlow(DiskSlowInfo{
 					Path:     name,
+					OpType:   op,
 					Duration: duration,
 				})
 			})

--- a/vfs/disk_health_test.go
+++ b/vfs/disk_health_test.go
@@ -6,6 +6,7 @@ package vfs
 
 import (
 	"io"
+	"math"
 	"os"
 	"sync/atomic"
 	"testing"
@@ -16,7 +17,7 @@ import (
 )
 
 type mockFile struct {
-	syncDuration time.Duration
+	syncAndWriteDuration time.Duration
 }
 
 func (m mockFile) Close() error {
@@ -32,7 +33,7 @@ func (m mockFile) ReadAt(p []byte, off int64) (n int, err error) {
 }
 
 func (m mockFile) Write(p []byte) (n int, err error) {
-	time.Sleep(m.syncDuration)
+	time.Sleep(m.syncAndWriteDuration)
 	return len(p), nil
 }
 
@@ -41,7 +42,7 @@ func (m mockFile) Stat() (os.FileInfo, error) {
 }
 
 func (m mockFile) Sync() error {
-	time.Sleep(m.syncDuration)
+	time.Sleep(m.syncAndWriteDuration)
 	return nil
 }
 
@@ -180,30 +181,88 @@ func (m mockFS) GetDiskUsage(path string) (DiskUsage, error) {
 
 var _ FS = &mockFS{}
 
-func TestDiskHealthChecking_Sync(t *testing.T) {
-	diskSlow := make(chan time.Duration, 100)
-	slowThreshold := 1 * time.Second
-	mockFS := &mockFS{create: func(name string) (File, error) {
-		return mockFile{syncDuration: 3 * time.Second}, nil
-	}}
-	fs, closer := WithDiskHealthChecks(mockFS, slowThreshold,
-		func(s string, duration time.Duration) {
-			diskSlow <- duration
-		})
-	defer closer.Close()
-	dhFile, _ := fs.Create("test")
-	defer dhFile.Close()
-
-	dhFile.Sync()
-
-	select {
-	case d := <-diskSlow:
-		if d.Seconds() < slowThreshold.Seconds() {
-			t.Fatalf("expected %0.1f to be greater than threshold %0.1f", d.Seconds(), slowThreshold.Seconds())
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("disk stall detector did not detect slow disk operation")
+func TestDiskHealthChecking_File(t *testing.T) {
+	const (
+		slowThreshold = 1 * time.Second
+		syncDuration  = 3 * time.Second
+	)
+	testCases := []struct {
+		op OpType
+		fn func(f File)
+	}{
+		{
+			OpTypeWrite,
+			func(f File) { f.Write([]byte("uh oh")) },
+		},
+		{
+			OpTypeSync,
+			func(f File) { f.Sync() },
+		},
 	}
+	for _, tc := range testCases {
+		t.Run(tc.op.String(), func(t *testing.T) {
+			type info struct {
+				opType   OpType
+				duration time.Duration
+			}
+			diskSlow := make(chan info, 1)
+			mockFS := &mockFS{create: func(name string) (File, error) {
+				return mockFile{syncAndWriteDuration: syncDuration}, nil
+			}}
+			fs, closer := WithDiskHealthChecks(mockFS, slowThreshold,
+				func(s string, opType OpType, duration time.Duration) {
+					diskSlow <- info{
+						opType:   opType,
+						duration: duration,
+					}
+				})
+			defer closer.Close()
+			dhFile, _ := fs.Create("test")
+			defer dhFile.Close()
+
+			tc.fn(dhFile)
+			select {
+			case i := <-diskSlow:
+				d := i.duration
+				if d.Seconds() < slowThreshold.Seconds() {
+					t.Fatalf("expected %0.1f to be greater than threshold %0.1f", d.Seconds(), slowThreshold.Seconds())
+				}
+				require.Equal(t, tc.op, i.opType)
+			case <-time.After(5 * time.Second):
+				t.Fatal("disk stall detector did not detect slow disk operation")
+			}
+		})
+	}
+}
+
+func TestDiskHealthChecking_NotTooManyOps(t *testing.T) {
+	numBitsForOpType := 64 - nOffsetBits
+	numOpTypesAllowed := int(math.Pow(2, float64(numBitsForOpType)))
+	numOpTypes := int(opTypeMax)
+	require.LessOrEqual(t, numOpTypes, numOpTypesAllowed)
+}
+
+func TestDiskHealthChecking_File_Underflow(t *testing.T) {
+	f := &mockFile{}
+	hcFile := newDiskHealthCheckingFile(f, 1*time.Second, func(opType OpType, duration time.Duration) {
+		// We expect to panic before sending the event.
+		t.Fatalf("unexpected slow disk event")
+	})
+	defer hcFile.Close()
+
+	// Set the file creation to the UNIX epoch, which is earlier than the max
+	// offset of the health check.
+	tEpoch := time.Unix(0, 0)
+	hcFile.createTime = tEpoch
+
+	// Assert that the time since the epoch (in nanoseconds) is indeed greater
+	// than the max offset.
+	require.True(t, time.Since(tEpoch).Nanoseconds() > 1<<nOffsetBits-1)
+
+	// Attempting to start the clock for a new operation on the file should
+	// trigger a panic, as the calculated offset from the file creation time would
+	// result in integer overflow.
+	require.Panics(t, func() { _, _ = hcFile.Write([]byte("uh oh")) })
 }
 
 var (
@@ -243,35 +302,58 @@ func filesystemOpsMockFS(sleepDur time.Duration) *mockFS {
 	}
 }
 
-func stallFilesystemOperations(fs FS) map[string]func() {
-	return map[string]func(){
-		"create":          func() { _, _ = fs.Create("foo") },
-		"link":            func() { _ = fs.Link("foo", "bar") },
-		"mkdir-all":       func() { _ = fs.MkdirAll("foo", os.ModePerm) },
-		"remove":          func() { _ = fs.Remove("foo") },
-		"remove-all":      func() { _ = fs.RemoveAll("foo") },
-		"rename":          func() { _ = fs.Rename("foo", "bar") },
-		"reuse-for-write": func() { _, _ = fs.ReuseForWrite("foo", "bar") },
+func stallFilesystemOperations(fs FS) []filesystemOperation {
+	return []filesystemOperation{
+		{
+			"create", OpTypeCreate, func() { _, _ = fs.Create("foo") },
+		},
+		{
+			"link", OpTypeLink, func() { _ = fs.Link("foo", "bar") },
+		},
+		{
+			"mkdirall", OpTypeMkdirAll, func() { _ = fs.MkdirAll("foo", os.ModePerm) },
+		},
+		{
+			"remove", OpTypeRemove, func() { _ = fs.Remove("foo") },
+		},
+		{
+			"removeall", OpTypeRemoveAll, func() { _ = fs.RemoveAll("foo") },
+		},
+		{
+			"rename", OpTypeRename, func() { _ = fs.Rename("foo", "bar") },
+		},
+		{
+			"reuseforwrite", OpTypeReuseForWrite, func() { _, _ = fs.ReuseForWrite("foo", "bar") },
+		},
 	}
+}
+
+type filesystemOperation struct {
+	name   string
+	opType OpType
+	f      func()
 }
 
 func TestDiskHealthChecking_Filesystem(t *testing.T) {
 	const sleepDur = 50 * time.Millisecond
 	const stallThreshold = 10 * time.Millisecond
 
-	// Wrap with disk-health checking, counting each stall on stallCount.
+	// Wrap with disk-health checking, counting each stall via stallCount.
+	var expectedOpType OpType
 	var stallCount uint64
 	fs, closer := WithDiskHealthChecks(filesystemOpsMockFS(sleepDur), stallThreshold,
-		func(name string, dur time.Duration) {
+		func(name string, opType OpType, dur time.Duration) {
+			require.Equal(t, expectedOpType, opType)
 			atomic.AddUint64(&stallCount, 1)
 		})
 	defer closer.Close()
 	fs.(*diskHealthCheckingFS).tickInterval = 5 * time.Millisecond
 	ops := stallFilesystemOperations(fs)
-	for name, op := range ops {
-		t.Run(name, func(t *testing.T) {
+	for _, o := range ops {
+		t.Run(o.name, func(t *testing.T) {
+			expectedOpType = o.opType
 			before := atomic.LoadUint64(&stallCount)
-			op()
+			o.f()
 			after := atomic.LoadUint64(&stallCount)
 			require.Greater(t, int(after-before), 0)
 		})
@@ -295,7 +377,7 @@ func TestDiskHealthChecking_Filesystem_Close(t *testing.T) {
 
 	stalled := map[string]time.Duration{}
 	fs, closer := WithDiskHealthChecks(mockFS, stallThreshold,
-		func(name string, dur time.Duration) { stalled[name] = dur })
+		func(name string, opType OpType, dur time.Duration) { stalled[name] = dur })
 	fs.(*diskHealthCheckingFS).tickInterval = 5 * time.Millisecond
 
 	files := []string{"foo", "bar", "bax"}

--- a/vfs/fd_test.go
+++ b/vfs/fd_test.go
@@ -22,7 +22,7 @@ func TestFileWrappersHaveFd(t *testing.T) {
 
 	// File wrapper case 1: Check if diskHealthCheckingFile has Fd().
 	fs2, closer := WithDiskHealthChecks(Default, 10*time.Second,
-		func(s string, duration time.Duration) {})
+		func(s string, opType OpType, duration time.Duration) {})
 	defer closer.Close()
 	f2, err := fs2.Open(filename)
 	require.NoError(t, err)

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -329,3 +329,13 @@ func TestVFSRootDirName(t *testing.T) {
 		require.Equal(t, exp, fi.Name())
 	}
 }
+
+// TestOpType is intended to catch operations that have been added without an
+// associated string, which could result in a runtime panic.
+func TestOpType(t *testing.T) {
+	for i := 0; i < int(opTypeMax); i++ {
+		require.NotPanics(t, func() {
+			_ = OpType(i).String()
+		})
+	}
+}


### PR DESCRIPTION
Part of https://github.com/cockroachdb/cockroach/issues/67856. 

This is https://github.com/cockroachdb/pebble/pull/1672 from @nicktrav, rebased on top of https://github.com/cockroachdb/pebble/pull/1677 and extended so that the op type of filesystem metadata operations is also captured. I also addressed @sumeerbhola's last comments over at https://github.com/cockroachdb/pebble/pull/1672.

With this one merged, I still have more thing to do. I will extend `DiskSlowInfo` to track write size in case a sized write (e.g. a call to `Write`).

As an aside, some discussion was had at https://cockroachlabs.slack.com/archives/CAC6K3SLU/p1674138778490679 about moving from a single long-lived monitor goroutine per file to a shorter-lived monitor goroutine per file op. Would mean no shared mutable state and no packed int64. We prefer the existing long-lived monitor goroutine per file, as the perf impacts of the suggested change may be problematic (it may also be hard to observe these bad impacts via `pebble workload`, etc.).

**vfs: capture operation type affected by disk slowness**

Currently, if a Pebble DB is backed by `vfs.FS` that is wrapped with a `vfs.diskHealthCheckingFS`, the DB can be made aware of operations that are taking longer than some threshold. The current implementation does not make any distinction between the operation type (write, sync, etc.) that was observed as slow.

Capture the type of operation being performed when emitting a disk slowness event.