### PR TITLE
internal/manifest: fix Version.Overlaps length bug

### DIFF
--- a/internal/manifest/btree.go
+++ b/internal/manifest/btree.go
@@ -111,7 +111,16 @@ type leafNode struct {
 	ref   int32
 	count int16
 	leaf  bool
-	items [maxItems]*FileMetadata
+	// subtreeCount holds the count of files in the entire subtree formed by
+	// this node. For leaf nodes, subtreeCount is always equal to count. For
+	// non-leaf nodes, it's the sum of count plus all the children's
+	// subtreeCounts.
+	//
+	// NB: We could move this field to the end of the node struct, since leaf =>
+	// count=subtreeCount, however the unsafe casting [leafToNode] performs make
+	// it risky and cumbersome.
+	subtreeCount int
+	items        [maxItems]*FileMetadata
 	// annot contains one annotation per annotator, merged over the entire
 	// node's files (and all descendants for non-leaf nodes).
 	annot []annotation
@@ -168,7 +177,7 @@ func mut(n **node) *node {
 	// reference count to be greater than 1, we might be racing
 	// with another call to decRef on this node.
 	c := (*n).clone()
-	(*n).decRef(true /* recursive */, nil)
+	(*n).decRef(true /* contentsToo */, nil)
 	*n = c
 	// NB: We don't need to clear annotations, because (*node).clone does not
 	// copy them.
@@ -180,17 +189,23 @@ func (n *node) incRef() {
 	atomic.AddInt32(&n.ref, 1)
 }
 
-// decRef releases a reference to the node. If requested, the method
-// will recurse into child nodes and decrease their refcounts as well.
+// decRef releases a reference to the node. If requested, the method will unref
+// its items and recurse into child nodes and decrease their refcounts as well.
+// Some internal codepaths that manually copy the node's items or children to
+// new nodes pass contentsToo=false to preserve existing reference counts during
+// operations that should yield a net-zero change to descendant refcounts.
 // When a node is released, its contained files are dereferenced.
-func (n *node) decRef(recursive bool, obsolete *[]*FileMetadata) {
+func (n *node) decRef(contentsToo bool, obsolete *[]*FileMetadata) {
 	if atomic.AddInt32(&n.ref, -1) > 0 {
 		// Other references remain. Can't free.
 		return
 	}
 
-	// Dereference the node's metadata and release child references.
-	if recursive {
+	// Dereference the node's metadata and release child references if
+	// requested. Some internal callers may not want to propagate the deref
+	// because they're manually copying the filemetadata and children to other
+	// nodes, and they want to preserve the existing reference count.
+	if contentsToo {
 		for _, f := range n.items[:n.count] {
 			if atomic.AddInt32(&f.refs, -1) == 0 {
 				// There are two sources of node dereferences: tree mutations
@@ -205,7 +220,7 @@ func (n *node) decRef(recursive bool, obsolete *[]*FileMetadata) {
 		}
 		if !n.leaf {
 			for i := int16(0); i <= n.count; i++ {
-				n.children[i].decRef(true /* recursive */, obsolete)
+				n.children[i].decRef(true /* contentsToo */, obsolete)
 			}
 		}
 	}
@@ -223,6 +238,7 @@ func (n *node) clone() *node {
 	// triggering the race detector and looking like a data race.
 	c.count = n.count
 	c.items = n.items
+	c.subtreeCount = n.subtreeCount
 	// Increase the refcount of each contained item.
 	for _, f := range n.items[:n.count] {
 		atomic.AddInt32(&f.refs, 1)
@@ -237,6 +253,9 @@ func (n *node) clone() *node {
 	return c
 }
 
+// insertAt inserts the provided file and node at the provided index. This
+// function is for use only as a helper function for internal B-Tree code.
+// Clients should not invoke it directly.
 func (n *node) insertAt(index int, item *FileMetadata, nd *node) {
 	if index < int(n.count) {
 		copy(n.items[index+1:n.count+1], n.items[index:n.count])
@@ -251,6 +270,9 @@ func (n *node) insertAt(index int, item *FileMetadata, nd *node) {
 	n.count++
 }
 
+// pushBack inserts the provided file and node at the tail of the node's items.
+// This function is for use only as a helper function for internal B-Tree code.
+// Clients should not invoke it directly.
 func (n *node) pushBack(item *FileMetadata, nd *node) {
 	n.items[n.count] = item
 	if !n.leaf {
@@ -259,6 +281,9 @@ func (n *node) pushBack(item *FileMetadata, nd *node) {
 	n.count++
 }
 
+// pushFront inserts the provided file and node at the head of the
+// node's items. This function is for use only as a helper function for internal B-Tree
+// code. Clients should not invoke it directly.
 func (n *node) pushFront(item *FileMetadata, nd *node) {
 	if !n.leaf {
 		copy(n.children[1:n.count+2], n.children[:n.count+1])
@@ -270,7 +295,8 @@ func (n *node) pushFront(item *FileMetadata, nd *node) {
 }
 
 // removeAt removes a value at a given index, pulling all subsequent values
-// back.
+// back. This function is for use only as a helper function for internal B-Tree
+// code. Clients should not invoke it directly.
 func (n *node) removeAt(index int) (*FileMetadata, *node) {
 	var child *node
 	if !n.leaf {
@@ -285,7 +311,9 @@ func (n *node) removeAt(index int) (*FileMetadata, *node) {
 	return out, child
 }
 
-// popBack removes and returns the last element in the list.
+// popBack removes and returns the last element in the list. This function is
+// for use only as a helper function for internal B-Tree code. Clients should
+// not invoke it directly.
 func (n *node) popBack() (*FileMetadata, *node) {
 	n.count--
 	out := n.items[n.count]
@@ -298,7 +326,9 @@ func (n *node) popBack() (*FileMetadata, *node) {
 	return out, child
 }
 
-// popFront removes and returns the first element in the list.
+// popFront removes and returns the first element in the list. This function is
+// for use only as a helper function for internal B-Tree code. Clients should
+// not invoke it directly.
 func (n *node) popFront() (*FileMetadata, *node) {
 	n.count--
 	var child *node
@@ -316,6 +346,9 @@ func (n *node) popFront() (*FileMetadata, *node) {
 // find returns the index where the given item should be inserted into this
 // list. 'found' is true if the item already exists in the list at the given
 // index.
+//
+// This function is for use only as a helper function for internal B-Tree code.
+// Clients should not invoke it directly.
 func (n *node) find(cmp btreeCmp, item *FileMetadata) (index int, found bool) {
 	// Logic copied from sort.Search. Inlining this gave
 	// an 11% speedup on BenchmarkBTreeDeleteInsert.
@@ -339,20 +372,34 @@ func (n *node) find(cmp btreeCmp, item *FileMetadata) (index int, found bool) {
 // and this function returns the item that existed at that index and a new
 // node containing all items/children after it.
 //
+// split is called when we want to perform a transformation like the one
+// depicted in the following diagram.
+//
 //	Before:
-//	 	      	+-----------+
-//	 	      	|   x y z   |
-//	 	      	+--/-/-\-\--+
+//	                       +-----------+
+//	             n *node   |   x y z   |
+//	                       +--/-/-\-\--+
 //
 //	After:
-//		       	+-----------+
-//		       	|     y     |
-//		       	+----/-\----+
-//		       	    /   \
-//		       	   v     v
-//		 +-----------+     +-----------+
-//		 |         x |     | z         |
-//		 +-----------+     +-----------+
+//	                       +-----------+
+//	                       |     y     |  n's parent
+//	                       +----/-\----+
+//	                           /   \
+//	                          v     v
+//	              +-----------+     +-----------+
+//	      n *node |         x |     | z         | next *node
+//	              +-----------+     +-----------+
+//
+// split does not perform the complete transformation; the caller is responsible
+// for updating the parent appropriately. split splits `n` into two nodes, `n`
+// and `next`, returning `next` and the file that separates them. In the diagram
+// above, `n.split` removes y and z from `n`, returning y in the first return
+// value and `next` in the second return value. The caller is responsible for
+// updating n's parent to now contain `y` as the separator between nodes `n` and
+// `next`.
+//
+// This function is for use only as a helper function for internal B-Tree code.
+// Clients should not invoke it directly.
 func (n *node) split(i int) (*FileMetadata, *node) {
 	out := n.items[i]
 	var next *node
@@ -368,17 +415,27 @@ func (n *node) split(i int) (*FileMetadata, *node) {
 	}
 	if !n.leaf {
 		copy(next.children[:], n.children[i+1:n.count+1])
+		descendantsMoved := 0
 		for j := int16(i + 1); j <= n.count; j++ {
+			descendantsMoved += n.children[j].subtreeCount
 			n.children[j] = nil
 		}
+		n.subtreeCount -= descendantsMoved
+		next.subtreeCount += descendantsMoved
 	}
 	n.count = int16(i)
+	// NB: We subtract one more than `next.count` from n's subtreeCount because
+	// the item at index `i` was removed from `n.items`. We'll return the item
+	// at index `i`, and the caller is responsible for updating the subtree
+	// count of whichever node adopts it.
+	n.subtreeCount -= int(next.count) + 1
+	next.subtreeCount += int(next.count)
 	return out, next
 }
 
-// insert inserts a item into the subtree rooted at this node, making sure no
+// Insert inserts a item into the subtree rooted at this node, making sure no
 // nodes in the subtree exceed maxItems items.
-func (n *node) insert(cmp btreeCmp, item *FileMetadata) error {
+func (n *node) Insert(cmp btreeCmp, item *FileMetadata) error {
 	i, found := n.find(cmp, item)
 	if found {
 		// cmp provides a total ordering of the files within a level.
@@ -389,6 +446,7 @@ func (n *node) insert(cmp btreeCmp, item *FileMetadata) error {
 	}
 	if n.leaf {
 		n.insertAt(i, item, nil)
+		n.subtreeCount++
 		return nil
 	}
 	if n.children[i].count >= maxItems {
@@ -408,14 +466,21 @@ func (n *node) insert(cmp btreeCmp, item *FileMetadata) error {
 				errors.Safe(item.FileNum), errors.Safe(n.items[i].FileNum))
 		}
 	}
-	return mut(&n.children[i]).insert(cmp, item)
+
+	err := mut(&n.children[i]).Insert(cmp, item)
+	if err == nil {
+		n.subtreeCount++
+	}
+	return err
 }
 
-// removeMax removes and returns the maximum item from the subtree rooted
-// at this node.
+// removeMax removes and returns the maximum item from the subtree rooted at
+// this node. This function is for use only as a helper function for internal
+// B-Tree code. Clients should not invoke it directly.
 func (n *node) removeMax() *FileMetadata {
 	if n.leaf {
 		n.count--
+		n.subtreeCount--
 		out := n.items[n.count]
 		n.items[n.count] = nil
 		return out
@@ -425,16 +490,18 @@ func (n *node) removeMax() *FileMetadata {
 		n.rebalanceOrMerge(int(n.count))
 		return n.removeMax()
 	}
+	n.subtreeCount--
 	return child.removeMax()
 }
 
-// remove removes a item from the subtree rooted at this node. Returns
+// Remove removes a item from the subtree rooted at this node. Returns
 // the item that was removed or nil if no matching item was found.
-func (n *node) remove(cmp btreeCmp, item *FileMetadata) (out *FileMetadata) {
+func (n *node) Remove(cmp btreeCmp, item *FileMetadata) (out *FileMetadata) {
 	i, found := n.find(cmp, item)
 	if n.leaf {
 		if found {
 			out, _ = n.removeAt(i)
+			n.subtreeCount--
 			return out
 		}
 		return nil
@@ -442,22 +509,28 @@ func (n *node) remove(cmp btreeCmp, item *FileMetadata) (out *FileMetadata) {
 	if n.children[i].count <= minItems {
 		// Child not large enough to remove from.
 		n.rebalanceOrMerge(i)
-		return n.remove(cmp, item)
+		return n.Remove(cmp, item)
 	}
 	child := mut(&n.children[i])
 	if found {
 		// Replace the item being removed with the max item in our left child.
 		out = n.items[i]
 		n.items[i] = child.removeMax()
+		n.subtreeCount--
 		return out
 	}
-	// Latch is not in this node and child is large enough to remove from.
-	out = child.remove(cmp, item)
+	// File is not in this node and child is large enough to remove from.
+	out = child.Remove(cmp, item)
+	if out != nil {
+		n.subtreeCount--
+	}
 	return out
 }
 
-// rebalanceOrMerge grows child 'i' to ensure it has sufficient room to remove
-// a item from it while keeping it at or above minItems.
+// rebalanceOrMerge grows child 'i' to ensure it has sufficient room to remove a
+// item from it while keeping it at or above minItems. This function is for use
+// only as a helper function for internal B-Tree code. Clients should not invoke
+// it directly.
 func (n *node) rebalanceOrMerge(i int) {
 	switch {
 	case i > 0 && n.children[i-1].count > minItems:
@@ -495,6 +568,12 @@ func (n *node) rebalanceOrMerge(i int) {
 		yLa := n.items[i-1]
 		child.pushFront(yLa, grandChild)
 		n.items[i-1] = xLa
+		child.subtreeCount++
+		left.subtreeCount--
+		if grandChild != nil {
+			child.subtreeCount += grandChild.subtreeCount
+			left.subtreeCount -= grandChild.subtreeCount
+		}
 
 	case i < int(n.count) && n.children[i+1].count > minItems:
 		// Rebalance from right sibling.
@@ -530,6 +609,12 @@ func (n *node) rebalanceOrMerge(i int) {
 		xLa, grandChild := right.popFront()
 		yLa := n.items[i]
 		child.pushBack(yLa, grandChild)
+		child.subtreeCount++
+		right.subtreeCount--
+		if grandChild != nil {
+			child.subtreeCount += grandChild.subtreeCount
+			right.subtreeCount -= grandChild.subtreeCount
+		}
 		n.items[i] = xLa
 
 	default:
@@ -568,12 +653,15 @@ func (n *node) rebalanceOrMerge(i int) {
 			copy(child.children[child.count+1:], mergeChild.children[:mergeChild.count+1])
 		}
 		child.count += mergeChild.count + 1
+		child.subtreeCount += mergeChild.subtreeCount + 1
 
-		mergeChild.decRef(false /* recursive */, nil)
+		mergeChild.decRef(false /* contentsToo */, nil)
 	}
 }
 
-func (n *node) invalidateAnnotation(a Annotator) {
+// InvalidateAnnotation removes any existing cached annotations for the provided
+// annotator from this node's subtree.
+func (n *node) InvalidateAnnotation(a Annotator) {
 	// Find this annotator's annotation on this node.
 	var annot *annotation
 	for i := range n.annot {
@@ -588,12 +676,17 @@ func (n *node) invalidateAnnotation(a Annotator) {
 	}
 	if !n.leaf {
 		for i := int16(0); i <= n.count; i++ {
-			n.children[i].invalidateAnnotation(a)
+			n.children[i].InvalidateAnnotation(a)
 		}
 	}
 }
 
-func (n *node) annotation(a Annotator) (interface{}, bool) {
+// Annotation retrieves, computing if not already computed, the provided
+// annotator's annotation of this node. The second return value indicates
+// whether the future reads of this annotation may use the first return value
+// as-is. If false, the annotation is not stable and may change on a subsequent
+// computation.
+func (n *node) Annotation(a Annotator) (interface{}, bool) {
 	// Find this annotator's annotation on this node.
 	var annot *annotation
 	for i := range n.annot {
@@ -625,7 +718,7 @@ func (n *node) annotation(a Annotator) (interface{}, bool) {
 	annot.valid = true
 	for i := int16(0); i <= n.count; i++ {
 		if !n.leaf {
-			v, ok := n.children[i].annotation(a)
+			v, ok := n.children[i].Annotation(a)
 			annot.v = a.Merge(v, annot.v)
 			annot.valid = annot.valid && ok
 		}
@@ -638,6 +731,20 @@ func (n *node) annotation(a Annotator) (interface{}, bool) {
 	return annot.v, annot.valid
 }
 
+func (n *node) verifyInvariants() {
+	recomputedSubtreeCount := int(n.count)
+	if !n.leaf {
+		for i := int16(0); i <= n.count; i++ {
+			n.children[i].verifyInvariants()
+			recomputedSubtreeCount += n.children[i].subtreeCount
+		}
+	}
+	if recomputedSubtreeCount != n.subtreeCount {
+		panic(fmt.Sprintf("recomputed subtree count (%d) ≠ n.subtreeCount (%d)",
+			recomputedSubtreeCount, n.subtreeCount))
+	}
+}
+
 // btree is an implementation of a B-Tree.
 //
 // btree stores FileMetadata in an ordered structure, allowing easy insertion,
@@ -648,25 +755,23 @@ func (n *node) annotation(a Annotator) (interface{}, bool) {
 // Write operations are not safe for concurrent mutation by multiple
 // goroutines, but Read operations are.
 type btree struct {
-	root   *node
-	length int
-	cmp    btreeCmp
+	root *node
+	cmp  btreeCmp
 }
 
-// release dereferences and clears the root node of the btree, removing all
+// Release dereferences and clears the root node of the btree, removing all
 // items from the btree. In doing so, it decrements contained file counts.
 // It returns a slice of newly obsolete files, if any.
-func (t *btree) release() (obsolete []*FileMetadata) {
+func (t *btree) Release() (obsolete []*FileMetadata) {
 	if t.root != nil {
-		t.root.decRef(true /* recursive */, &obsolete)
+		t.root.decRef(true /* contentsToo */, &obsolete)
 		t.root = nil
 	}
-	t.length = 0
 	return obsolete
 }
 
-// clone clones the btree, lazily. It does so in constant time.
-func (t *btree) clone() btree {
+// Clone clones the btree, lazily. It does so in constant time.
+func (t *btree) Clone() btree {
 	c := *t
 	if c.root != nil {
 		// Incrementing the reference count on the root node is sufficient to
@@ -688,15 +793,17 @@ func (t *btree) clone() btree {
 	return c
 }
 
-// delete removes the provided file from the tree.
+// Delete removes the provided file from the tree.
 // It returns true if the file now has a zero reference count.
-func (t *btree) delete(item *FileMetadata) (obsolete bool) {
+func (t *btree) Delete(item *FileMetadata) (obsolete bool) {
 	if t.root == nil || t.root.count == 0 {
 		return false
 	}
-	if out := mut(&t.root).remove(t.cmp, item); out != nil {
-		t.length--
+	if out := mut(&t.root).Remove(t.cmp, item); out != nil {
 		obsolete = atomic.AddInt32(&out.refs, -1) == 0
+	}
+	if invariants.Enabled {
+		t.root.verifyInvariants()
 	}
 	if t.root.count == 0 {
 		old := t.root
@@ -705,14 +812,14 @@ func (t *btree) delete(item *FileMetadata) (obsolete bool) {
 		} else {
 			t.root = t.root.children[0]
 		}
-		old.decRef(false /* recursive */, nil)
+		old.decRef(false /* contentsToo */, nil)
 	}
 	return obsolete
 }
 
-// insert adds the given item to the tree. If a item in the tree already
-// equals the given one, insert panics.
-func (t *btree) insert(item *FileMetadata) error {
+// Insert adds the given item to the tree. If a item in the tree already
+// equals the given one, Insert panics.
+func (t *btree) Insert(item *FileMetadata) error {
 	if t.root == nil {
 		t.root = newLeafNode()
 	} else if t.root.count >= maxItems {
@@ -722,39 +829,36 @@ func (t *btree) insert(item *FileMetadata) error {
 		newRoot.items[0] = splitLa
 		newRoot.children[0] = t.root
 		newRoot.children[1] = splitNode
+		newRoot.subtreeCount = t.root.subtreeCount + splitNode.subtreeCount + 1
 		t.root = newRoot
 	}
 	atomic.AddInt32(&item.refs, 1)
-	err := mut(&t.root).insert(t.cmp, item)
-	t.length++
+	err := mut(&t.root).Insert(t.cmp, item)
+	if invariants.Enabled {
+		t.root.verifyInvariants()
+	}
 	return err
 }
 
-// iter returns a new iterator object. It is not safe to continue using an
+// Iter returns a new iterator object. It is not safe to continue using an
 // iterator after modifications are made to the tree. If modifications are made,
 // create a new iterator.
-func (t *btree) iter() iterator {
+func (t *btree) Iter() iterator {
 	return iterator{r: t.root, pos: -1, cmp: t.cmp}
 }
 
-// height returns the height of the tree.
-func (t *btree) height() int {
+// Count returns the number of files contained within the B-Tree.
+func (t *btree) Count() int {
 	if t.root == nil {
 		return 0
 	}
-	h := 1
-	n := t.root
-	for !n.leaf {
-		n = n.children[0]
-		h++
-	}
-	return h
+	return t.root.subtreeCount
 }
 
 // String returns a string description of the tree. The format is
 // similar to the https://en.wikipedia.org/wiki/Newick_format.
 func (t *btree) String() string {
-	if t.length == 0 {
+	if t.Count() == 0 {
 		return ";"
 	}
 	var b strings.Builder
@@ -881,6 +985,59 @@ type iterator struct {
 	// taken to arrive at n. If non-empty, the bottommost frame of the stack
 	// will always contain the B-Tree root.
 	s iterStack
+}
+
+// countLeft returns the count of files that are to the left of the current
+// iterator position.
+func (i *iterator) countLeft() int {
+	if i.r == nil {
+		return 0
+	}
+
+	// Each iterator has a stack of frames marking the path from the root node
+	// to the current iterator position. All files (n.items) and all subtrees
+	// (n.children) with indexes less than [pos] are to the left of the current
+	// iterator position.
+	//
+	//     +------------------------+  -
+	//     |  Root            pos:5 |   |
+	//     +------------------------+   | stack
+	//     |  Root/5          pos:3 |   | frames
+	//     +------------------------+   | [i.s]
+	//     |  Root/5/3        pos:9 |   |
+	//     +========================+  -
+	//     |                        |
+	//     | i.n: Root/5/3/9 i.pos:2|
+	//     +------------------------+
+	//
+	var count int
+	// Walk all the ancestors in the iterator stack [i.s], tallying up all the
+	// files and subtrees to the left of the stack frame's position.
+	f, ok := i.s.nth(0)
+	for fi := 0; ok; fi++ {
+		// There are [f.pos] files contained within [f.n.items] that sort to the
+		// left of the subtree the iterator has descended.
+		count += int(f.pos)
+		// Any subtrees that fall before the stack frame's position are entirely
+		// to the left of the iterator's current position.
+		for j := int16(0); j < f.pos; j++ {
+			count += f.n.children[j].subtreeCount
+		}
+		f, ok = i.s.nth(fi + 1)
+	}
+
+	// The bottommost stack frame is inlined within the iterator struct. Again,
+	// [i.pos] files fall to the left of the current iterator position.
+	count += int(i.pos)
+	if !i.n.leaf {
+		// NB: Unlike above, we use a `<= i.pos` comparison. The iterator is
+		// positioned at item `i.n.items[i.pos]`, which sorts after everything
+		// in the subtree at `i.n.children[i.pos]`.
+		for j := int16(0); j <= i.pos; j++ {
+			count += i.n.children[j].subtreeCount
+		}
+	}
+	return count
 }
 
 func (i *iterator) clone() iterator {

--- a/internal/manifest/btree_test.go
+++ b/internal/manifest/btree_test.go
@@ -39,13 +39,14 @@ func cmpKey(a, b InternalKey) int {
 
 // Verify asserts that the tree's structural invariants all hold.
 func (t *btree) Verify(tt *testing.T) {
-	if t.length == 0 {
+	if t.Count() == 0 {
 		require.Nil(tt, t.root)
 		return
 	}
 	t.verifyLeafSameDepth(tt)
 	t.verifyCountAllowed(tt)
 	t.isSorted(tt)
+	t.root.verifyInvariants()
 }
 
 func (t *btree) verifyLeafSameDepth(tt *testing.T) {
@@ -64,6 +65,20 @@ func (n *node) verifyDepthEqualToHeight(t *testing.T, depth, height int) {
 
 func (t *btree) verifyCountAllowed(tt *testing.T) {
 	t.root.verifyCountAllowed(tt, true)
+}
+
+// height returns the height of the tree.
+func (t *btree) height() int {
+	if t.root == nil {
+		return 0
+	}
+	h := 1
+	n := t.root
+	for !n.leaf {
+		n = n.children[0]
+		h++
+	}
+	return h
 }
 
 func (n *node) verifyCountAllowed(t *testing.T, root bool) {
@@ -167,6 +182,7 @@ func checkIter(t *testing.T, it iterator, start, end int, keyMemo map[int]Intern
 		if cmpKey(expected, item.Smallest) != 0 {
 			t.Fatalf("expected %s, but found %s", expected, item.Smallest)
 		}
+		require.Equal(t, i-start, it.countLeft())
 		i++
 	}
 	if i != end {
@@ -180,6 +196,7 @@ func checkIter(t *testing.T, it iterator, start, end int, keyMemo map[int]Intern
 		if cmpKey(expected, item.Smallest) != 0 {
 			t.Fatalf("expected %s, but found %s", expected, item.Smallest)
 		}
+		require.Equal(t, i-start, it.countLeft())
 	}
 	if i != start {
 		t.Fatalf("expected %d, but at %d: %+v", start, i, it)
@@ -200,48 +217,48 @@ func TestBTree(t *testing.T) {
 
 	// Add keys in sorted order.
 	for i := 0; i < count; i++ {
-		require.NoError(t, tr.insert(items[i]))
+		require.NoError(t, tr.Insert(items[i]))
 		tr.Verify(t)
-		if e := i + 1; e != tr.length {
-			t.Fatalf("expected length %d, but found %d", e, tr.length)
+		if e := i + 1; e != tr.Count() {
+			t.Fatalf("expected length %d, but found %d", e, tr.Count())
 		}
-		checkIter(t, tr.iter(), 0, i+1, keyMemo)
+		checkIter(t, tr.Iter(), 0, i+1, keyMemo)
 	}
 
 	// delete keys in sorted order.
 	for i := 0; i < count; i++ {
-		obsolete := tr.delete(items[i])
+		obsolete := tr.Delete(items[i])
 		if !obsolete {
 			t.Fatalf("expected item %d to be obsolete", i)
 		}
 		tr.Verify(t)
-		if e := count - (i + 1); e != tr.length {
-			t.Fatalf("expected length %d, but found %d", e, tr.length)
+		if e := count - (i + 1); e != tr.Count() {
+			t.Fatalf("expected length %d, but found %d", e, tr.Count())
 		}
-		checkIter(t, tr.iter(), i+1, count, keyMemo)
+		checkIter(t, tr.Iter(), i+1, count, keyMemo)
 	}
 
 	// Add keys in reverse sorted order.
 	for i := 1; i <= count; i++ {
-		require.NoError(t, tr.insert(items[count-i]))
+		require.NoError(t, tr.Insert(items[count-i]))
 		tr.Verify(t)
-		if i != tr.length {
-			t.Fatalf("expected length %d, but found %d", i, tr.length)
+		if i != tr.Count() {
+			t.Fatalf("expected length %d, but found %d", i, tr.Count())
 		}
-		checkIter(t, tr.iter(), count-i, count, keyMemo)
+		checkIter(t, tr.Iter(), count-i, count, keyMemo)
 	}
 
 	// delete keys in reverse sorted order.
 	for i := 1; i <= count; i++ {
-		obsolete := tr.delete(items[count-i])
+		obsolete := tr.Delete(items[count-i])
 		if !obsolete {
 			t.Fatalf("expected item %d to be obsolete", i)
 		}
 		tr.Verify(t)
-		if e := count - i; e != tr.length {
-			t.Fatalf("expected length %d, but found %d", e, tr.length)
+		if e := count - i; e != tr.Count() {
+			t.Fatalf("expected length %d, but found %d", e, tr.Count())
 		}
-		checkIter(t, tr.iter(), 0, count-i, keyMemo)
+		checkIter(t, tr.Iter(), 0, count-i, keyMemo)
 	}
 }
 
@@ -253,10 +270,10 @@ func TestIterClone(t *testing.T) {
 	keyMemo := make(map[int]InternalKey)
 
 	for i := 0; i < count; i++ {
-		require.NoError(t, tr.insert(newItem(key(i))))
+		require.NoError(t, tr.Insert(newItem(key(i))))
 	}
 
-	it := tr.iter()
+	it := tr.Iter()
 	i := 0
 	for it.first(); it.valid(); it.next() {
 		if i%500 == 0 {
@@ -277,14 +294,14 @@ func TestIterCmpEdgeCases(t *testing.T) {
 	var tr btree
 	tr.cmp = cmp
 	t.Run("empty", func(t *testing.T) {
-		a := tr.iter()
-		b := tr.iter()
+		a := tr.Iter()
+		b := tr.Iter()
 		require.Equal(t, 0, cmpIter(a, b))
 	})
-	require.NoError(t, tr.insert(newItem(key(5))))
+	require.NoError(t, tr.Insert(newItem(key(5))))
 	t.Run("exhausted_next", func(t *testing.T) {
-		a := tr.iter()
-		b := tr.iter()
+		a := tr.Iter()
+		b := tr.Iter()
 		a.first()
 		b.first()
 		require.Equal(t, 0, cmpIter(a, b))
@@ -293,8 +310,8 @@ func TestIterCmpEdgeCases(t *testing.T) {
 		require.Equal(t, -1, cmpIter(a, b))
 	})
 	t.Run("exhausted_prev", func(t *testing.T) {
-		a := tr.iter()
-		b := tr.iter()
+		a := tr.Iter()
+		b := tr.Iter()
 		a.first()
 		b.first()
 		b.prev()
@@ -312,7 +329,7 @@ func TestIterCmpRand(t *testing.T) {
 	var tr btree
 	tr.cmp = cmp
 	for i := 0; i < itemCount; i++ {
-		require.NoError(t, tr.insert(newItem(key(i))))
+		require.NoError(t, tr.Insert(newItem(key(i))))
 	}
 
 	seed := time.Now().UnixNano()
@@ -321,7 +338,7 @@ func TestIterCmpRand(t *testing.T) {
 	iters2 := make([]*LevelIterator, iterCount)
 	for i := 0; i < iterCount; i++ {
 		k := rng.Intn(itemCount)
-		iter := LevelIterator{iter: tr.iter()}
+		iter := LevelIterator{iter: tr.Iter()}
 		iter.SeekGE(base.DefaultComparer.Compare, key(k).UserKey)
 		iters1[i] = &iter
 		iters2[i] = &iter
@@ -347,10 +364,10 @@ func TestBTreeSeek(t *testing.T) {
 	var tr btree
 	tr.cmp = cmp
 	for i := 0; i < count; i++ {
-		require.NoError(t, tr.insert(newItem(key(i*2))))
+		require.NoError(t, tr.Insert(newItem(key(i*2))))
 	}
 
-	it := LevelIterator{iter: tr.iter()}
+	it := LevelIterator{iter: tr.Iter()}
 	for i := 0; i < 2*count-1; i++ {
 		item := it.SeekGE(base.DefaultComparer.Compare, key(i).UserKey)
 		if item == nil {
@@ -385,12 +402,12 @@ func TestBTreeSeek(t *testing.T) {
 func TestBTreeInsertDuplicateError(t *testing.T) {
 	var tr btree
 	tr.cmp = cmp
-	require.NoError(t, tr.insert(newItem(key(1))))
-	require.NoError(t, tr.insert(newItem(key(2))))
-	require.NoError(t, tr.insert(newItem(key(3))))
+	require.NoError(t, tr.Insert(newItem(key(1))))
+	require.NoError(t, tr.Insert(newItem(key(2))))
+	require.NoError(t, tr.Insert(newItem(key(3))))
 	wantErr := errors.Errorf("files %s and %s collided on sort keys",
 		errors.Safe(base.FileNum(000000)), errors.Safe(base.FileNum(000000)))
-	require.Error(t, wantErr, tr.insert(newItem(key(2))))
+	require.Error(t, wantErr, tr.Insert(newItem(key(2))))
 }
 
 // TestBTreeCloneConcurrentOperations tests that cloning a btree returns a new
@@ -415,10 +432,10 @@ func TestBTreeCloneConcurrentOperations(t *testing.T) {
 		t.Logf("Starting new clone at %v", start)
 		treeC <- tr
 		for i := start; i < cloneTestSize; i++ {
-			require.NoError(t, tr.insert(p[i]))
+			require.NoError(t, tr.Insert(p[i]))
 			if i%(cloneTestSize/5) == 0 {
 				wg.Add(1)
-				c := tr.clone()
+				c := tr.Clone()
 				go populate(&c, i+1)
 			}
 		}
@@ -448,7 +465,7 @@ func TestBTreeCloneConcurrentOperations(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			for _, item := range toRemove {
-				tree.delete(item)
+				tree.Delete(item)
 			}
 			wg.Done()
 		}()
@@ -470,7 +487,7 @@ func TestBTreeCloneConcurrentOperations(t *testing.T) {
 
 	var obsolete []*FileMetadata
 	for i := range trees {
-		obsolete = append(obsolete, trees[i].release()...)
+		obsolete = append(obsolete, trees[i].Release()...)
 	}
 	if len(obsolete) != len(p) {
 		t.Errorf("got %d obsolete trees, expected %d", len(obsolete), len(p))
@@ -497,10 +514,10 @@ func TestIterStack(t *testing.T) {
 func TestIterEndSentinel(t *testing.T) {
 	var tr btree
 	tr.cmp = cmp
-	require.NoError(t, tr.insert(newItem(key(1))))
-	require.NoError(t, tr.insert(newItem(key(2))))
-	require.NoError(t, tr.insert(newItem(key(3))))
-	iter := LevelIterator{iter: tr.iter()}
+	require.NoError(t, tr.Insert(newItem(key(1))))
+	require.NoError(t, tr.Insert(newItem(key(2))))
+	require.NoError(t, tr.Insert(newItem(key(3))))
+	iter := LevelIterator{iter: tr.Iter()}
 	iter.SeekGE(base.DefaultComparer.Compare, key(3).UserKey)
 	require.True(t, iter.iter.valid())
 	iter.Next()
@@ -545,23 +562,120 @@ func TestAnnotationOrderStatistic(t *testing.T) {
 	var tr btree
 	tr.cmp = cmp
 	for i := 1; i <= count; i++ {
-		require.NoError(t, tr.insert(newItem(key(i))))
+		require.NoError(t, tr.Insert(newItem(key(i))))
 
-		v, ok := tr.root.annotation(ann)
+		v, ok := tr.root.Annotation(ann)
 		require.True(t, ok)
 		vtyped := v.(*int)
 		require.Equal(t, i, *vtyped)
 	}
 
-	v, ok := tr.root.annotation(ann)
+	v, ok := tr.root.Annotation(ann)
 	require.True(t, ok)
 	vtyped := v.(*int)
 	require.Equal(t, count, *vtyped)
 
-	v, ok = tr.root.annotation(ann)
+	v, ok = tr.root.Annotation(ann)
 	vtyped = v.(*int)
 	require.True(t, ok)
 	require.Equal(t, count, *vtyped)
+}
+
+// TestRandomizedBTree tests a random set of Insert, Delete and iteration
+// operations, checking for equivalence with a map of filenums.
+func TestRandomizedBTree(t *testing.T) {
+	const maxFileNum = 50_000
+	const maxNumOps = 50_000
+
+	seed := time.Now().UnixNano()
+	t.Log("seed", seed)
+	rng := rand.New(rand.NewSource(seed))
+
+	numOps := 10_000 + rng.Intn(maxNumOps-10_000)
+
+	var metadataAlloc [maxFileNum]FileMetadata
+	for i := 0; i < len(metadataAlloc); i++ {
+		metadataAlloc[i].FileNum = base.FileNum(i)
+	}
+
+	// Use a btree comparator that sorts by file number to make it easier to
+	// prevent duplicates or overlaps.
+	tree := btree{
+		cmp: func(a *FileMetadata, b *FileMetadata) int {
+			switch {
+			case a.FileNum < b.FileNum:
+				return -1
+			case a.FileNum > b.FileNum:
+				return +1
+			default:
+				return 0
+			}
+		},
+	}
+
+	type opDecl struct {
+		fn     func()
+		weight int
+	}
+	ref := map[base.FileNum]bool{}
+	ops := []opDecl{
+		{
+			// Insert
+			fn: func() {
+				f := &metadataAlloc[rng.Intn(maxFileNum)]
+				err := tree.Insert(f)
+				if ref[f.FileNum] {
+					require.Error(t, err, "btree.Insert should error if file already exists")
+				} else {
+					ref[f.FileNum] = true
+					require.NoError(t, err)
+				}
+			},
+			weight: 20,
+		},
+		{
+			// Delete
+			fn: func() {
+				f := &metadataAlloc[rng.Intn(maxFileNum)]
+				tree.Delete(f)
+				delete(ref, f.FileNum)
+			},
+			weight: 10,
+		},
+		{
+			// Iterate
+			fn: func() {
+				iter := tree.Iter()
+				count := 0
+				var prev base.FileNum
+				for iter.first(); iter.valid(); iter.next() {
+					fn := iter.cur().FileNum
+					require.True(t, ref[fn])
+					if count > 0 {
+						require.Less(t, prev, fn)
+					}
+					count++
+				}
+				require.Equal(t, count, len(ref))
+			},
+			weight: 1,
+		},
+	}
+	weightSum := 0
+	for i := range ops {
+		weightSum += ops[i].weight
+	}
+
+	for i := 0; i < numOps; i++ {
+		w := rng.Intn(weightSum)
+		for j := range ops {
+			w -= ops[j].weight
+			if w < 0 {
+				ops[j].fn()
+				break
+			}
+		}
+	}
 }
 
 //////////////////////////////////////////
@@ -594,7 +708,7 @@ func strReprs(items []*FileMetadata) []string {
 
 // all extracts all items from a tree in order as a slice.
 func all(tr *btree) (out []*FileMetadata) {
-	it := tr.iter()
+	it := tr.Iter()
 	it.first()
 	for it.valid() {
 		out = append(out, it.cur())
@@ -620,7 +734,7 @@ func BenchmarkBTreeInsert(b *testing.B) {
 			var tr btree
 			tr.cmp = cmp
 			for _, item := range insertP {
-				if err := tr.insert(item); err != nil {
+				if err := tr.Insert(item); err != nil {
 					b.Fatal(err)
 				}
 				i++
@@ -642,19 +756,19 @@ func BenchmarkBTreeDelete(b *testing.B) {
 			var tr btree
 			tr.cmp = cmp
 			for _, item := range insertP {
-				if err := tr.insert(item); err != nil {
+				if err := tr.Insert(item); err != nil {
 					b.Fatal(err)
 				}
 			}
 			b.StartTimer()
 			for _, item := range removeP {
-				tr.delete(item)
+				tr.Delete(item)
 				i++
 				if i >= b.N {
 					return
 				}
 			}
-			if tr.length > 0 {
+			if tr.Count() > 0 {
 				b.Fatalf("tree not empty: %s", &tr)
 			}
 		}
@@ -668,15 +782,15 @@ func BenchmarkBTreeDeleteInsert(b *testing.B) {
 		var tr btree
 		tr.cmp = cmp
 		for _, item := range insertP {
-			if err := tr.insert(item); err != nil {
+			if err := tr.Insert(item); err != nil {
 				b.Fatal(err)
 			}
 		}
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			item := insertP[i%count]
-			tr.delete(item)
-			if err := tr.insert(item); err != nil {
+			tr.Delete(item)
+			if err := tr.Insert(item); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -691,16 +805,16 @@ func BenchmarkBTreeDeleteInsertCloneOnce(b *testing.B) {
 		var tr btree
 		tr.cmp = cmp
 		for _, item := range insertP {
-			if err := tr.insert(item); err != nil {
+			if err := tr.Insert(item); err != nil {
 				b.Fatal(err)
 			}
 		}
-		tr = tr.clone()
+		tr = tr.Clone()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			item := insertP[i%count]
-			tr.delete(item)
-			if err := tr.insert(item); err != nil {
+			tr.Delete(item)
+			if err := tr.Insert(item); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -718,7 +832,7 @@ func BenchmarkBTreeDeleteInsertCloneEachTime(b *testing.B) {
 				tr.cmp = cmp
 				trRelease.cmp = cmp
 				for _, item := range insertP {
-					if err := tr.insert(item); err != nil {
+					if err := tr.Insert(item); err != nil {
 						b.Fatal(err)
 					}
 				}
@@ -726,12 +840,12 @@ func BenchmarkBTreeDeleteInsertCloneEachTime(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					item := insertP[i%count]
 					if release {
-						trRelease.release()
+						trRelease.Release()
 						trRelease = tr
 					}
-					tr = tr.clone()
-					tr.delete(item)
-					if err := tr.insert(item); err != nil {
+					tr = tr.Clone()
+					tr.Delete(item)
+					if err := tr.Insert(item); err != nil {
 						b.Fatal(err)
 					}
 				}
@@ -745,7 +859,7 @@ func BenchmarkBTreeIter(b *testing.B) {
 	var tr btree
 	tr.cmp = cmp
 	for i := 0; i < b.N; i++ {
-		it := tr.iter()
+		it := tr.Iter()
 		it.first()
 	}
 }
@@ -762,7 +876,7 @@ func BenchmarkBTreeIterSeekGE(b *testing.B) {
 		for i := 0; i < count; i++ {
 			s := key(i)
 			keys = append(keys, s)
-			if err := tr.insert(newItem(s)); err != nil {
+			if err := tr.Insert(newItem(s)); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -770,7 +884,7 @@ func BenchmarkBTreeIterSeekGE(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			k := keys[rng.Intn(len(keys))]
-			it := LevelIterator{iter: tr.iter()}
+			it := LevelIterator{iter: tr.Iter()}
 			f := it.SeekGE(base.DefaultComparer.Compare, k.UserKey)
 			if testing.Verbose() {
 				if f == nil {
@@ -796,7 +910,7 @@ func BenchmarkBTreeIterSeekLT(b *testing.B) {
 		for i := 0; i < count; i++ {
 			k := key(i)
 			keys = append(keys, k)
-			if err := tr.insert(newItem(k)); err != nil {
+			if err := tr.Insert(newItem(k)); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -805,7 +919,7 @@ func BenchmarkBTreeIterSeekLT(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			j := rng.Intn(len(keys))
 			k := keys[j]
-			it := LevelIterator{iter: tr.iter()}
+			it := LevelIterator{iter: tr.Iter()}
 			f := it.SeekLT(base.DefaultComparer.Compare, k.UserKey)
 			if testing.Verbose() {
 				if j == 0 {
@@ -835,12 +949,12 @@ func BenchmarkBTreeIterNext(b *testing.B) {
 	const count = 8 << 10
 	for i := 0; i < count; i++ {
 		item := newItem(key(i))
-		if err := tr.insert(item); err != nil {
+		if err := tr.Insert(item); err != nil {
 			b.Fatal(err)
 		}
 	}
 
-	it := tr.iter()
+	it := tr.Iter()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if !it.valid() {
@@ -859,12 +973,12 @@ func BenchmarkBTreeIterPrev(b *testing.B) {
 	const count = 8 << 10
 	for i := 0; i < count; i++ {
 		item := newItem(key(i))
-		if err := tr.insert(item); err != nil {
+		if err := tr.Insert(item); err != nil {
 			b.Fatal(err)
 		}
 	}
 
-	it := tr.iter()
+	it := tr.Iter()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if !it.valid() {

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -333,7 +333,7 @@ func NewL0Sublevels(
 	for _, sublevelFiles := range s.levelFiles {
 		tr, ls := makeBTree(btreeCmpSmallestKey(cmp), sublevelFiles)
 		s.Levels = append(s.Levels, ls)
-		tr.release()
+		tr.Release()
 	}
 
 	s.calculateFlushSplitKeys(flushSplitMaxBytes)
@@ -632,7 +632,7 @@ func (s *L0Sublevels) AddL0Files(
 			// populated correctly.
 			newVal.Levels[sublevel] = ls
 		}
-		tr.release()
+		tr.Release()
 	}
 
 	newVal.flushSplitUserKeys = nil

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -24,12 +24,12 @@ type LevelMetadata struct {
 func (lm *LevelMetadata) clone() LevelMetadata {
 	return LevelMetadata{
 		level: lm.level,
-		tree:  lm.tree.clone(),
+		tree:  lm.tree.Clone(),
 	}
 }
 
 func (lm *LevelMetadata) release() (obsolete []*FileMetadata) {
-	return lm.tree.release()
+	return lm.tree.Release()
 }
 
 func makeLevelMetadata(cmp Compare, level int, files []*FileMetadata) LevelMetadata {
@@ -47,29 +47,29 @@ func makeBTree(cmp btreeCmp, files []*FileMetadata) (btree, LevelSlice) {
 	var t btree
 	t.cmp = cmp
 	for _, f := range files {
-		t.insert(f)
+		t.Insert(f)
 	}
-	return t, LevelSlice{iter: t.iter(), length: t.length}
+	return t, newLevelSlice(t.Iter())
 }
 
 // Empty indicates whether there are any files in the level.
 func (lm *LevelMetadata) Empty() bool {
-	return lm.tree.length == 0
+	return lm.tree.Count() == 0
 }
 
 // Len returns the number of files within the level.
 func (lm *LevelMetadata) Len() int {
-	return lm.tree.length
+	return lm.tree.Count()
 }
 
 // Iter constructs a LevelIterator over the entire level.
 func (lm *LevelMetadata) Iter() LevelIterator {
-	return LevelIterator{iter: lm.tree.iter()}
+	return LevelIterator{iter: lm.tree.Iter()}
 }
 
 // Slice constructs a slice containing the entire level.
 func (lm *LevelMetadata) Slice() LevelSlice {
-	return LevelSlice{iter: lm.tree.iter(), length: lm.tree.length}
+	return newLevelSlice(lm.tree.Iter())
 }
 
 // Find finds the provided file in the level if it exists.
@@ -100,7 +100,7 @@ func (lm *LevelMetadata) Annotation(annotator Annotator) interface{} {
 	if lm.Empty() {
 		return annotator.Zero(nil)
 	}
-	v, _ := lm.tree.root.annotation(annotator)
+	v, _ := lm.tree.root.Annotation(annotator)
 	return v
 }
 
@@ -113,7 +113,7 @@ func (lm *LevelMetadata) InvalidateAnnotation(annotator Annotator) {
 	if lm.Empty() {
 		return
 	}
-	lm.tree.root.invalidateAnnotation(annotator)
+	lm.tree.root.InvalidateAnnotation(annotator)
 }
 
 // LevelFile holds a file's metadata along with its position
@@ -134,7 +134,8 @@ func (lf LevelFile) Slice() LevelSlice {
 // a slice constructor like this?
 func NewLevelSliceSeqSorted(files []*FileMetadata) LevelSlice {
 	tr, slice := makeBTree(btreeCmpSeqNum, files)
-	tr.release()
+	tr.Release()
+	slice.verifyInvariants()
 	return slice
 }
 
@@ -144,7 +145,8 @@ func NewLevelSliceSeqSorted(files []*FileMetadata) LevelSlice {
 // a slice constructor like this?
 func NewLevelSliceKeySorted(cmp base.Compare, files []*FileMetadata) LevelSlice {
 	tr, slice := makeBTree(btreeCmpSmallestKey(cmp), files)
-	tr.release()
+	tr.Release()
+	slice.verifyInvariants()
 	return slice
 }
 
@@ -154,13 +156,56 @@ func NewLevelSliceKeySorted(cmp base.Compare, files []*FileMetadata) LevelSlice 
 // TODO(jackson): Update tests to avoid requiring this and remove it.
 func NewLevelSliceSpecificOrder(files []*FileMetadata) LevelSlice {
 	tr, slice := makeBTree(btreeCmpSpecificOrder(files), files)
-	tr.release()
+	tr.Release()
+	slice.verifyInvariants()
 	return slice
+}
+
+// newLevelSlice constructs a new LevelSlice backed by iter.
+func newLevelSlice(iter iterator) LevelSlice {
+	s := LevelSlice{iter: iter}
+	if iter.r != nil {
+		s.length = iter.r.subtreeCount
+	}
+	s.verifyInvariants()
+	return s
+}
+
+// newBoundedLevelSlice constructs a new LevelSlice backed by iter and bounded
+// by the provided start and end bounds. The provided startBound and endBound
+// iterators must be iterators over the same B-Tree. Both start and end bounds
+// are inclusive.
+func newBoundedLevelSlice(iter iterator, startBound, endBound *iterator) LevelSlice {
+	s := LevelSlice{
+		iter:  iter,
+		start: startBound,
+		end:   endBound,
+	}
+	if iter.valid() {
+		s.length = endBound.countLeft() - startBound.countLeft()
+		// NB: The +1 is a consequence of the end bound being inclusive.
+		if endBound.valid() {
+			s.length++
+		}
+		// NB: A slice that's empty due to its bounds may have an endBound
+		// positioned before the startBound due to the inclusive bounds.
+		// TODO(jackson): Consider refactoring the end boundary to be exclusive;
+		// it would simplify some areas (eg, here) and complicate others (eg,
+		// Reslice-ing to grow compactions).
+		if s.length < 0 {
+			s.length = 0
+		}
+	}
+	s.verifyInvariants()
+	return s
 }
 
 // LevelSlice contains a slice of the files within a level of the LSM.
 // A LevelSlice is immutable once created, but may be used to construct a
 // mutable LevelIterator over the slice's files.
+//
+// LevelSlices should be constructed through one of the existing constructors,
+// not manually initialized.
 type LevelSlice struct {
 	iter   iterator
 	length int
@@ -169,6 +214,19 @@ type LevelSlice struct {
 	// accessible.
 	start *iterator
 	end   *iterator
+}
+
+func (ls LevelSlice) verifyInvariants() {
+	if invariants.Enabled {
+		i := ls.Iter()
+		var length int
+		for f := i.First(); f != nil; f = i.Next() {
+			length++
+		}
+		if ls.length != length {
+			panic(fmt.Sprintf("LevelSlice %s has length %d value; actual length is %d", ls, ls.length, length))
+		}
+	}
 }
 
 // Each invokes fn for each element in the slice.
@@ -182,6 +240,7 @@ func (ls LevelSlice) Each(fn func(*FileMetadata)) {
 // String implements fmt.Stringer.
 func (ls LevelSlice) String() string {
 	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d files: ", ls.length)
 	ls.Each(func(f *FileMetadata) {
 		if buf.Len() > 0 {
 			fmt.Fprintf(&buf, " ")
@@ -247,18 +306,7 @@ func (ls LevelSlice) Reslice(resliceFunc func(start, end *LevelIterator)) LevelS
 		end.iter = ls.end.clone()
 	}
 	resliceFunc(&start, &end)
-
-	s := LevelSlice{
-		iter:  start.iter.clone(),
-		start: &start.iter,
-		end:   &end.iter,
-	}
-	// Calculate the new slice's length.
-	iter := s.Iter()
-	for f := iter.First(); f != nil; f = iter.Next() {
-		s.length++
-	}
-	return s
+	return newBoundedLevelSlice(start.iter.clone(), &start.iter, &end.iter)
 }
 
 // KeyType is used to specify the type of keys we're looking for in
@@ -625,13 +673,9 @@ func (i *LevelIterator) Take() LevelFile {
 	// the same position for a LevelFile because they're inclusive, so we can
 	// share one iterator stack between the two bounds.
 	boundsIter := i.iter.clone()
+	s := newBoundedLevelSlice(i.iter.clone(), &boundsIter, &boundsIter)
 	return LevelFile{
 		FileMetadata: m,
-		slice: LevelSlice{
-			iter:   i.iter.clone(),
-			start:  &boundsIter,
-			end:    &boundsIter,
-			length: 1,
-		},
+		slice:        s,
 	}
 }

--- a/internal/manifest/testdata/overlaps
+++ b/internal/manifest/testdata/overlaps
@@ -40,33 +40,39 @@ define
 
 overlaps level=0 start=a end=a exclusive-end=false
 ----
+0 files:
 
 overlaps level=0 start=a end=b exclusive-end=false
 ----
+3 files:
 000700:[b#7008,SET-e#7009,SET]
 000701:[c#7018,SET-f#7019,SET]
 000702:[f#7028,SET-g#7029,SET]
 
 overlaps level=0 start=a end=d exclusive-end=false
 ----
+3 files:
 000700:[b#7008,SET-e#7009,SET]
 000701:[c#7018,SET-f#7019,SET]
 000702:[f#7028,SET-g#7029,SET]
 
 overlaps level=0 start=a end=e exclusive-end=false
 ----
+3 files:
 000700:[b#7008,SET-e#7009,SET]
 000701:[c#7018,SET-f#7019,SET]
 000702:[f#7028,SET-g#7029,SET]
 
 overlaps level=0 start=a end=g exclusive-end=false
 ----
+3 files:
 000700:[b#7008,SET-e#7009,SET]
 000701:[c#7018,SET-f#7019,SET]
 000702:[f#7028,SET-g#7029,SET]
 
 overlaps level=0 start=a end=z exclusive-end=false
 ----
+8 files:
 000700:[b#7008,SET-e#7009,SET]
 000701:[c#7018,SET-f#7019,SET]
 000702:[f#7028,SET-g#7029,SET]
@@ -78,12 +84,14 @@ overlaps level=0 start=a end=z exclusive-end=false
 
 overlaps level=0 start=c end=e exclusive-end=false
 ----
+3 files:
 000700:[b#7008,SET-e#7009,SET]
 000701:[c#7018,SET-f#7019,SET]
 000702:[f#7028,SET-g#7029,SET]
 
 overlaps level=0 start=d end=d exclusive-end=false
 ----
+3 files:
 000700:[b#7008,SET-e#7009,SET]
 000701:[c#7018,SET-f#7019,SET]
 000702:[f#7028,SET-g#7029,SET]
@@ -92,12 +100,14 @@ overlaps level=0 start=d end=d exclusive-end=false
 
 overlaps level=0 start=b end=f exclusive-end=true
 ----
+3 files:
 000700:[b#7008,SET-e#7009,SET]
 000701:[c#7018,SET-f#7019,SET]
 000702:[f#7028,SET-g#7029,SET]
 
 overlaps level=0 start=g end=n exclusive-end=false
 ----
+7 files:
 000700:[b#7008,SET-e#7009,SET]
 000701:[c#7018,SET-f#7019,SET]
 000702:[f#7028,SET-g#7029,SET]
@@ -108,9 +118,11 @@ overlaps level=0 start=g end=n exclusive-end=false
 
 overlaps level=0 start=h end=i exclusive-end=false
 ----
+0 files:
 
 overlaps level=0 start=h end=o exclusive-end=false
 ----
+4 files:
 000704:[n#7048,SET-p#7049,SET]
 000705:[p#7058,SET-p#7059,SET]
 000706:[p#7068,SET-u#7069,SET]
@@ -118,6 +130,7 @@ overlaps level=0 start=h end=o exclusive-end=false
 
 overlaps level=0 start=h end=u exclusive-end=false
 ----
+4 files:
 000704:[n#7048,SET-p#7049,SET]
 000705:[p#7058,SET-p#7059,SET]
 000706:[p#7068,SET-u#7069,SET]
@@ -125,9 +138,11 @@ overlaps level=0 start=h end=u exclusive-end=false
 
 overlaps level=0 start=k end=l exclusive-end=false
 ----
+0 files:
 
 overlaps level=0 start=k end=o exclusive-end=false
 ----
+4 files:
 000704:[n#7048,SET-p#7049,SET]
 000705:[p#7058,SET-p#7059,SET]
 000706:[p#7068,SET-u#7069,SET]
@@ -135,6 +150,7 @@ overlaps level=0 start=k end=o exclusive-end=false
 
 overlaps level=0 start=k end=p exclusive-end=false
 ----
+4 files:
 000704:[n#7048,SET-p#7049,SET]
 000705:[p#7058,SET-p#7059,SET]
 000706:[p#7068,SET-u#7069,SET]
@@ -142,6 +158,7 @@ overlaps level=0 start=k end=p exclusive-end=false
 
 overlaps level=0 start=n end=o exclusive-end=false
 ----
+4 files:
 000704:[n#7048,SET-p#7049,SET]
 000705:[p#7058,SET-p#7059,SET]
 000706:[p#7068,SET-u#7069,SET]
@@ -149,6 +166,7 @@ overlaps level=0 start=n end=o exclusive-end=false
 
 overlaps level=0 start=n end=z exclusive-end=false
 ----
+5 files:
 000703:[x#7038,SET-y#7039,SET]
 000704:[n#7048,SET-p#7049,SET]
 000705:[p#7058,SET-p#7059,SET]
@@ -157,6 +175,7 @@ overlaps level=0 start=n end=z exclusive-end=false
 
 overlaps level=0 start=o end=z exclusive-end=false
 ----
+5 files:
 000703:[x#7038,SET-y#7039,SET]
 000704:[n#7048,SET-p#7049,SET]
 000705:[p#7058,SET-p#7059,SET]
@@ -165,6 +184,7 @@ overlaps level=0 start=o end=z exclusive-end=false
 
 overlaps level=0 start=p end=z exclusive-end=false
 ----
+5 files:
 000703:[x#7038,SET-y#7039,SET]
 000704:[n#7048,SET-p#7049,SET]
 000705:[p#7058,SET-p#7059,SET]
@@ -173,6 +193,7 @@ overlaps level=0 start=p end=z exclusive-end=false
 
 overlaps level=0 start=q end=z exclusive-end=false
 ----
+5 files:
 000703:[x#7038,SET-y#7039,SET]
 000704:[n#7048,SET-p#7049,SET]
 000705:[p#7058,SET-p#7059,SET]
@@ -181,6 +202,7 @@ overlaps level=0 start=q end=z exclusive-end=false
 
 overlaps level=0 start=r end=s exclusive-end=false
 ----
+4 files:
 000704:[n#7048,SET-p#7049,SET]
 000705:[p#7058,SET-p#7059,SET]
 000706:[p#7068,SET-u#7069,SET]
@@ -188,6 +210,7 @@ overlaps level=0 start=r end=s exclusive-end=false
 
 overlaps level=0 start=r end=z exclusive-end=false
 ----
+5 files:
 000703:[x#7038,SET-y#7039,SET]
 000704:[n#7048,SET-p#7049,SET]
 000705:[p#7058,SET-p#7059,SET]
@@ -196,6 +219,7 @@ overlaps level=0 start=r end=z exclusive-end=false
 
 overlaps level=0 start=s end=z exclusive-end=false
 ----
+5 files:
 000703:[x#7038,SET-y#7039,SET]
 000704:[n#7048,SET-p#7049,SET]
 000705:[p#7058,SET-p#7059,SET]
@@ -204,6 +228,7 @@ overlaps level=0 start=s end=z exclusive-end=false
 
 overlaps level=0 start=u end=z exclusive-end=false
 ----
+5 files:
 000703:[x#7038,SET-y#7039,SET]
 000704:[n#7048,SET-p#7049,SET]
 000705:[p#7058,SET-p#7059,SET]
@@ -212,44 +237,53 @@ overlaps level=0 start=u end=z exclusive-end=false
 
 overlaps level=0 start=y end=z exclusive-end=false
 ----
+1 files:
 000703:[x#7038,SET-y#7039,SET]
 
 overlaps level=0 start=z end=z exclusive-end=false
 ----
+0 files:
 
 # Level 1
 
 overlaps level=1 start=a end=a exclusive-end=false
 ----
+1 files:
 000710:[a#7140,SET-d#inf,RANGEDEL]
 
 overlaps level=1 start=a end=b exclusive-end=false
 ----
+1 files:
 000710:[a#7140,SET-d#inf,RANGEDEL]
 
 overlaps level=1 start=a end=d exclusive-end=false
 ----
+2 files:
 000710:[a#7140,SET-d#inf,RANGEDEL]
 000711:[d#7108,SET-g#7109,SET]
 
 overlaps level=1 start=a end=e exclusive-end=false
 ----
+2 files:
 000710:[a#7140,SET-d#inf,RANGEDEL]
 000711:[d#7108,SET-g#7109,SET]
 
 overlaps level=1 start=a end=g exclusive-end=false
 ----
+3 files:
 000710:[a#7140,SET-d#inf,RANGEDEL]
 000711:[d#7108,SET-g#7109,SET]
 000712:[g#7118,SET-j#7119,SET]
 
 overlaps level=1 start=a end=g exclusive-end=true
 ----
+2 files:
 000710:[a#7140,SET-d#inf,RANGEDEL]
 000711:[d#7108,SET-g#7109,SET]
 
 overlaps level=1 start=a end=z exclusive-end=false
 ----
+6 files:
 000710:[a#7140,SET-d#inf,RANGEDEL]
 000711:[d#7108,SET-g#7109,SET]
 000712:[g#7118,SET-j#7119,SET]
@@ -259,6 +293,7 @@ overlaps level=1 start=a end=z exclusive-end=false
 
 overlaps level=1 start=a end=z exclusive-end=true
 ----
+6 files:
 000710:[a#7140,SET-d#inf,RANGEDEL]
 000711:[d#7108,SET-g#7109,SET]
 000712:[g#7118,SET-j#7119,SET]
@@ -268,39 +303,47 @@ overlaps level=1 start=a end=z exclusive-end=true
 
 overlaps level=1 start=c end=e exclusive-end=false
 ----
+2 files:
 000710:[a#7140,SET-d#inf,RANGEDEL]
 000711:[d#7108,SET-g#7109,SET]
 
 overlaps level=1 start=d end=d exclusive-end=false
 ----
+1 files:
 000711:[d#7108,SET-g#7109,SET]
 
 overlaps level=1 start=g end=n exclusive-end=false
 ----
+3 files:
 000711:[d#7108,SET-g#7109,SET]
 000712:[g#7118,SET-j#7119,SET]
 000713:[n#7128,SET-p#7129,SET]
 
 overlaps level=1 start=h end=i exclusive-end=false
 ----
+1 files:
 000712:[g#7118,SET-j#7119,SET]
 
 overlaps level=1 start=h end=n exclusive-end=true
 ----
+1 files:
 000712:[g#7118,SET-j#7119,SET]
 
 overlaps level=1 start=h end=n exclusive-end=false
 ----
+2 files:
 000712:[g#7118,SET-j#7119,SET]
 000713:[n#7128,SET-p#7129,SET]
 
 overlaps level=1 start=h end=o exclusive-end=false
 ----
+2 files:
 000712:[g#7118,SET-j#7119,SET]
 000713:[n#7128,SET-p#7129,SET]
 
 overlaps level=1 start=h end=u exclusive-end=false
 ----
+4 files:
 000712:[g#7118,SET-j#7119,SET]
 000713:[n#7128,SET-p#7129,SET]
 000714:[p#7148,SET-p#7149,SET]
@@ -308,73 +351,89 @@ overlaps level=1 start=h end=u exclusive-end=false
 
 overlaps level=1 start=k end=l exclusive-end=false
 ----
+0 files:
 
 overlaps level=1 start=k end=o exclusive-end=false
 ----
+1 files:
 000713:[n#7128,SET-p#7129,SET]
 
 overlaps level=1 start=k end=p exclusive-end=false
 ----
+3 files:
 000713:[n#7128,SET-p#7129,SET]
 000714:[p#7148,SET-p#7149,SET]
 000715:[p#7138,SET-u#7139,SET]
 
 overlaps level=1 start=k end=p exclusive-end=true
 ----
+1 files:
 000713:[n#7128,SET-p#7129,SET]
 
 overlaps level=1 start=n end=o exclusive-end=false
 ----
+1 files:
 000713:[n#7128,SET-p#7129,SET]
 
 overlaps level=1 start=n end=z exclusive-end=false
 ----
+3 files:
 000713:[n#7128,SET-p#7129,SET]
 000714:[p#7148,SET-p#7149,SET]
 000715:[p#7138,SET-u#7139,SET]
 
 overlaps level=1 start=o end=z exclusive-end=false
 ----
+3 files:
 000713:[n#7128,SET-p#7129,SET]
 000714:[p#7148,SET-p#7149,SET]
 000715:[p#7138,SET-u#7139,SET]
 
 overlaps level=1 start=p end=z exclusive-end=false
 ----
+3 files:
 000713:[n#7128,SET-p#7129,SET]
 000714:[p#7148,SET-p#7149,SET]
 000715:[p#7138,SET-u#7139,SET]
 
 overlaps level=1 start=q end=z exclusive-end=false
 ----
+1 files:
 000715:[p#7138,SET-u#7139,SET]
 
 overlaps level=1 start=r end=s exclusive-end=false
 ----
+1 files:
 000715:[p#7138,SET-u#7139,SET]
 
 overlaps level=1 start=r end=z exclusive-end=false
 ----
+1 files:
 000715:[p#7138,SET-u#7139,SET]
 
 overlaps level=1 start=s end=z exclusive-end=false
 ----
+1 files:
 000715:[p#7138,SET-u#7139,SET]
 
 overlaps level=1 start=u end=z exclusive-end=false
 ----
+1 files:
 000715:[p#7138,SET-u#7139,SET]
 
 overlaps level=1 start=y end=z exclusive-end=false
 ----
+0 files:
 
 overlaps level=1 start=z end=z exclusive-end=false
 ----
+0 files:
 
 # Level 2 is empty.
 
 overlaps level=2 start=a end=z exclusive-end=false
 ----
+0 files:
 
 # Test a scenario where an originally exclusive-end must be promoted to
 # inclusive during the iterative expansion of L0 overlaps.
@@ -396,6 +455,7 @@ define
 
 overlaps level=0 start=a end=b exclusive-end=true
 ----
+3 files:
 000001:[a#1,SET-d#2,SET]
 000002:[c#3,SET-f#4,SET]
 000003:[f#5,SET-f#5,SET]
@@ -468,6 +528,7 @@ define
 
 overlaps level=0 start=heacptnep@12 end=kiicbzwtpe@16 exclusive-end=false
 ----
+13 files:
 000973:[ewqqtp@15#4591,RANGEDEL-zaygjmy@1#inf,RANGEDEL]
 000975:[ajoqjxr@16#4578,MERGE-zjyqka@1#4544,DEL]
 000977:[mgksrvk@15#4598,DEL-mgksrvk@15#4598,DEL]
@@ -484,6 +545,7 @@ overlaps level=0 start=heacptnep@12 end=kiicbzwtpe@16 exclusive-end=false
 
 overlaps level=0 start=acutc@6 end=zzhra@12 exclusive-end=true
 ----
+18 files:
 000535:[zzqwavxgrec@12#2657,SINGLEDEL-zzqwavxgrec@12#2526,SET]
 000605:[zzqwavxgrec@12#2894,SET-zzqwavxgrec@12#2894,SET]
 000828:[zzqwavxgrec@12#4092,SINGLEDEL-zzqwavxgrec@12#4092,SINGLEDEL]

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -729,13 +729,7 @@ func overlaps(iter LevelIterator, cmp Compare, start, end []byte, exclusiveEnd b
 		}
 		_ = endIterFile // Ignore unused assignment.
 	}
-
-	iter = startIter.Clone()
-	return LevelSlice{
-		iter:  iter.iter,
-		start: &startIter.iter,
-		end:   &endIter.iter,
-	}
+	return newBoundedLevelSlice(startIter.Clone().iter, &startIter.iter, &endIter.iter)
 }
 
 // NumLevels is the number of levels a Version contains.
@@ -1059,17 +1053,17 @@ func (v *Version) Overlaps(
 				tr.cmp = v.Levels[level].tree.cmp
 				for i, meta := 0, l0Iter.First(); meta != nil; i, meta = i+1, l0Iter.Next() {
 					if selectedIndices[i] {
-						err := tr.insert(meta)
+						err := tr.Insert(meta)
 						if err != nil {
 							panic(err)
 						}
 					}
 				}
-				slice = LevelSlice{iter: tr.iter(), length: tr.length}
+				slice = newLevelSlice(tr.Iter())
 				// TODO(jackson): Avoid the oddity of constructing and
 				// immediately releasing a B-Tree. Make LevelSlice an
 				// interface?
-				tr.release()
+				tr.Release()
 				break
 			}
 			// Continue looping to retry the files that were not selected.

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -686,7 +686,7 @@ func (b *BulkVersionEdit) Apply(
 
 		for _, f := range deletedMap {
 			addZombie(f.FileNum, f.Size)
-			if obsolete := v.Levels[level].tree.delete(f); obsolete {
+			if obsolete := v.Levels[level].tree.Delete(f); obsolete {
 				// Deleting a file from the B-Tree may decrement its
 				// reference count. However, because we cloned the
 				// previous level's B-Tree, this should never result in a
@@ -695,7 +695,7 @@ func (b *BulkVersionEdit) Apply(
 				return nil, nil, err
 			}
 			if f.HasRangeKeys {
-				if obsolete := v.RangeKeyLevels[level].tree.delete(f); obsolete {
+				if obsolete := v.RangeKeyLevels[level].tree.Delete(f); obsolete {
 					// Deleting a file from the B-Tree may decrement its
 					// reference count. However, because we cloned the
 					// previous level's B-Tree, this should never result in a
@@ -726,12 +726,12 @@ func (b *BulkVersionEdit) Apply(
 			atomic.StoreInt64(&f.Atomic.AllowedSeeks, allowedSeeks)
 			f.InitAllowedSeeks = allowedSeeks
 
-			err := lm.tree.insert(f)
+			err := lm.tree.Insert(f)
 			if err != nil {
 				return nil, nil, errors.Wrap(err, "pebble")
 			}
 			if f.HasRangeKeys {
-				err = lmRange.tree.insert(f)
+				err = lmRange.tree.Insert(f)
 				if err != nil {
 					return nil, nil, errors.Wrap(err, "pebble")
 				}

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -359,7 +359,7 @@ func TestVersionEditApply(t *testing.T) {
 									}
 								}
 								versionFiles[meta.FileNum] = &meta
-								v.Levels[level].tree.insert(&meta)
+								v.Levels[level].tree.Insert(&meta)
 							} else {
 								ve.NewFiles =
 									append(ve.NewFiles, NewFileEntry{Level: level, Meta: &meta})

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -112,8 +112,10 @@ func TestOverlaps(t *testing.T) {
 			d.ScanArgs(t, "start", &start)
 			d.ScanArgs(t, "end", &end)
 			d.ScanArgs(t, "exclusive-end", &exclusiveEnd)
+			overlaps := v.Overlaps(level, testkeys.Comparer.Compare, []byte(start), []byte(end), exclusiveEnd)
 			var buf bytes.Buffer
-			v.Overlaps(level, testkeys.Comparer.Compare, []byte(start), []byte(end), exclusiveEnd).Each(func(f *FileMetadata) {
+			fmt.Fprintf(&buf, "%d files:\n", overlaps.Len())
+			overlaps.Each(func(f *FileMetadata) {
 				fmt.Fprintf(&buf, "%s\n", f.DebugString(base.DefaultFormatter, false))
 			})
 			return buf.String()


### PR DESCRIPTION
Previously, calling `Version.Overlaps` for a level lower than L0 would return a LevelSlice containing the correct files but a `length` field of zero. Thankfully, it appears there were no call sites that accessed such a LevelSlice's `Len()`. Compaction picking came close, but the `Reslice` calls to expand to the atomic compaction unit would compute the length on the adjusted slice before the first call to Len.

This commit fixes this bug by:

1. introducing a [subtreeCount] into the level metadata b-tree nodes, which is incrementally updated with the total number of files within the node's subtree.
2. adding a countLeft method to the B-Tree iterator, which returns the number of files to the left of the iterator's current position within a level. This method takes advantage of the incrementally-computed [subtreeCount] to compute a total in log(N) time.
3. adjusting Overlaps to compute the number of files it's returning in a LevelSlice by subtracting the countLeft values for the end and start bound iterator positions.