### PR TITLE
replay: unflake TestCollectCorpus

### DIFF
--- a/db.go
+++ b/db.go
@@ -480,6 +480,15 @@ type DB struct {
 var _ Reader = (*DB)(nil)
 var _ Writer = (*DB)(nil)
 
+// TestOnlyWaitForCleaning MUST only be used in tests.
+func (d *DB) TestOnlyWaitForCleaning() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for d.mu.cleaner.cleaning {
+		d.mu.cleaner.cond.Wait()
+	}
+}
+
 // Get gets the value for the given key. It returns ErrNotFound if the DB does
 // not contain the key.
 //

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -279,6 +279,9 @@ func collectCorpus(t *testing.T, fs *vfs.MemFS, name string) {
 			require.NoError(t, d.Flush())
 			return ""
 		case "list-files":
+			if d != nil {
+				d.TestOnlyWaitForCleaning()
+			}
 			return runListFiles(t, fs, td)
 		case "open":
 			wc = NewWorkloadCollector("build")


### PR DESCRIPTION
Files can be deleted asynchronously so it makes sense to wait for cleaning to complete before listing the files.