### PR TITLE
db: tweak to BenchmarkIteratorScanNextPrefix and performance commentary

### DIFF
--- a/internal/base/lazy_value.go
+++ b/internal/base/lazy_value.go
@@ -156,15 +156,18 @@ type LazyValue struct {
 }
 
 // LazyFetcher supports fetching a lazy value.
+//
+// Fetcher and Attribute are to be initialized at creation time. The fields
+// are arranged to reduce the sizeof this struct.
 type LazyFetcher struct {
 	// Fetcher, given a handle, returns the value.
 	Fetcher ValueFetcher
+	err     error
+	value   []byte
 	// Attribute includes the short attribute and value length.
 	Attribute   AttributeAndLen
 	fetched     bool
-	value       []byte
 	callerOwned bool
-	err         error
 }
 
 // ValueFetcher is an interface for fetching a value.

--- a/iterator.go
+++ b/iterator.go
@@ -1713,6 +1713,10 @@ func (i *Iterator) internalNextPrefix(currKeyPrefixLen int) {
 	if i.iterKey == nil {
 		return
 	}
+	// The Next "fast-path" is not really a fast-path when there is more than
+	// one version. However, even with TableFormatPebblev3, there is a small
+	// slowdown (~10%) for one version if we remove it and only call NextPrefix.
+	// When there are two versions, only calling NextPrefix is ~30% faster.
 	i.stats.ForwardStepCount[InternalIterCall]++
 	if i.iterKey, i.iterValue = i.iter.Next(); i.iterKey == nil {
 		return

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -419,6 +419,15 @@ func (i *singleLevelIterator) init(
 	i.dataRS.size = initialReadaheadSize
 	if r.tableFormat == TableFormatPebblev3 {
 		if r.Properties.NumValueBlocks > 0 {
+			// NB: we cannot avoid this ~248 byte allocation, since valueBlockReader
+			// can outlive the singleLevelIterator due to be being embedded in a
+			// LazyValue. This consumes ~2% in microbenchmark CPU profiles, but we
+			// should only optimize this if it shows up as significant in end-to-end
+			// CockroachDB benchmarks, since it is tricky to do so. One possibility
+			// is that if many sstable iterators only get positioned at latest
+			// versions of keys, and therefore never expose a LazyValue that is
+			// separated to their callers, they can put this valueBlockReader into a
+			// sync.Pool.
 			i.vbReader = &valueBlockReader{
 				bpOpen: i,
 				rp:     rp,


### PR DESCRIPTION
BenchmarkIteratorScanNextPrefix now exercises value blocks. Also, the benchmark now does an iterator step per benchmark iteration instead of a full scan -- this makes the benchmark faster and allows us to compare performance metrics across benchmark parameters (since the metrics do not vary based on the total number of different key prefixes in the LSM).

There is a tiny tweak to the field ordering in LazyFetcher and additional code comments about performance and future optimization.

Informs #1170