### PR TITLE
sstable: sort user-added range keys by suffix descending

### DIFF
--- a/internal/keyspan/span.go
+++ b/internal/keyspan/span.go
@@ -406,6 +406,17 @@ func SortKeysByTrailer(keys *[]Key) {
 	sort.Sort(sorted)
 }
 
+// KeysBySuffix implements sort.Interface, sorting its member Keys slice to by
+// Suffix in the order dictated by Cmp.
+type KeysBySuffix struct {
+	Cmp  base.Compare
+	Keys []Key
+}
+
+func (s *KeysBySuffix) Len() int           { return len(s.Keys) }
+func (s *KeysBySuffix) Less(i, j int) bool { return s.Cmp(s.Keys[i].Suffix, s.Keys[j].Suffix) < 0 }
+func (s *KeysBySuffix) Swap(i, j int)      { s.Keys[i], s.Keys[j] = s.Keys[j], s.Keys[i] }
+
 // ParseSpan parses the string representation of a Span. It's intended for
 // tests. ParseSpan panics if passed a malformed span representation.
 func ParseSpan(input string) Span {

--- a/internal/rangekey/coalesce_test.go
+++ b/internal/rangekey/coalesce_test.go
@@ -73,16 +73,16 @@ func TestIter(t *testing.T) {
 				spans = append(spans, keyspan.ParseSpan(line))
 			}
 			transform := keyspan.TransformerFunc(func(cmp base.Compare, s keyspan.Span, dst *keyspan.Span) error {
-				keysBySuffix := keysBySuffix{
-					cmp:  cmp,
-					keys: dst.Keys[:0],
+				keysBySuffix := keyspan.KeysBySuffix{
+					Cmp:  cmp,
+					Keys: dst.Keys[:0],
 				}
 				if err := coalesce(eq, &keysBySuffix, visibleSeqNum, s.Keys); err != nil {
 					return err
 				}
 				// Update the span with the (potentially reduced) keys slice.  coalesce left
 				// the keys in *dst sorted by suffix. Re-sort them by trailer.
-				dst.Keys = keysBySuffix.keys
+				dst.Keys = keysBySuffix.Keys
 				keyspan.SortKeysByTrailer(&dst.Keys)
 				dst.Start = s.Start
 				dst.End = s.End

--- a/sstable/testdata/writer_range_keys
+++ b/sstable/testdata/writer_range_keys
@@ -44,7 +44,7 @@ SET a-c @2=foo
 SET a-c @1=bar
 SET a-c @3=baz
 ----
-a-c:{(#0,RANGEKEYSET,@2,foo) (#0,RANGEKEYSET,@1,bar) (#0,RANGEKEYSET,@3,baz)}
+a-c:{(#0,RANGEKEYSET,@3,baz) (#0,RANGEKEYSET,@2,foo) (#0,RANGEKEYSET,@1,bar)}
 
 # Aligned spans, mixed range key kinds.
 #
@@ -81,9 +81,9 @@ SET f-i @9=v9
 DEL f-i
 ----
 a-c:{(#0,RANGEKEYSET,@1,v1) (#0,RANGEKEYUNSET,@5)}
-c-d:{(#0,RANGEKEYSET,@2,v2) (#0,RANGEKEYSET,@5,v5)}
+c-d:{(#0,RANGEKEYSET,@5,v5) (#0,RANGEKEYSET,@2,v2)}
 d-e:{(#0,RANGEKEYSET,@9,v9) (#0,RANGEKEYDEL)}
-f-i:{(#0,RANGEKEYSET,@4,v4) (#0,RANGEKEYSET,@5,v5) (#0,RANGEKEYSET,@7,v7) (#0,RANGEKEYSET,@8,v8) (#0,RANGEKEYSET,@9,v9) (#0,RANGEKEYUNSET,@6) (#0,RANGEKEYDEL)}
+f-i:{(#0,RANGEKEYSET,@9,v9) (#0,RANGEKEYSET,@8,v8) (#0,RANGEKEYSET,@7,v7) (#0,RANGEKEYSET,@5,v5) (#0,RANGEKEYSET,@4,v4) (#0,RANGEKEYUNSET,@6) (#0,RANGEKEYDEL)}
 
 # Merge overlapping RANGEKEYSETs.
 #
@@ -100,7 +100,7 @@ SET b-f @2=bar
 SET c-d @3=baz
 ----
 a-b:{(#0,RANGEKEYSET,@1,foo)}
-b-c:{(#0,RANGEKEYSET,@1,foo) (#0,RANGEKEYSET,@2,bar)}
+b-c:{(#0,RANGEKEYSET,@2,bar) (#0,RANGEKEYSET,@1,foo)}
 c-d:{(#0,RANGEKEYSET,@3,baz) (#0,RANGEKEYSET,@2,bar)}
 d-f:{(#0,RANGEKEYSET,@2,bar)}
 
@@ -125,11 +125,11 @@ SET e-q @4=baz
 DEL l-o
 ----
 a-b:{(#0,RANGEKEYSET,@1,foo)}
-b-c:{(#0,RANGEKEYSET,@1,foo) (#0,RANGEKEYSET,@2,bar)}
+b-c:{(#0,RANGEKEYSET,@2,bar) (#0,RANGEKEYSET,@1,foo)}
 c-d:{(#0,RANGEKEYSET,@1,foo) (#0,RANGEKEYUNSET,@3) (#0,RANGEKEYDEL)}
 d-e:{(#0,RANGEKEYSET,@1,foo) (#0,RANGEKEYUNSET,@3)}
-e-h:{(#0,RANGEKEYSET,@1,foo) (#0,RANGEKEYSET,@4,baz) (#0,RANGEKEYUNSET,@3)}
-h-i:{(#0,RANGEKEYSET,@1,foo) (#0,RANGEKEYSET,@4,baz)}
+e-h:{(#0,RANGEKEYSET,@4,baz) (#0,RANGEKEYSET,@1,foo) (#0,RANGEKEYUNSET,@3)}
+h-i:{(#0,RANGEKEYSET,@4,baz) (#0,RANGEKEYSET,@1,foo)}
 i-l:{(#0,RANGEKEYSET,@4,baz)}
 l-o:{(#0,RANGEKEYSET,@4,baz) (#0,RANGEKEYDEL)}
 o-q:{(#0,RANGEKEYSET,@4,baz)}


### PR DESCRIPTION
When a user adds a range key to a sstable that they're building (eg, for ingest or backups), sort the range keys before writing them. This was a bug introduced recently in #2197. Although we don't need to coalesce the keys, we should write them in disk descending by suffix. Note that this ordering of sstable keys isn't a property we rely upon or use in any way in practice, but we may want to make use of it sometime in the future.