### PR TITLE
db: disallow NextPrefix if the upper-bound is a versioned key

### DIFF
--- a/db.go
+++ b/db.go
@@ -982,7 +982,7 @@ func (d *DB) newIterInternal(batch *Batch, s *Snapshot, o *IterOptions) *Iterato
 	}
 	if o != nil {
 		dbi.opts = *o
-		dbi.saveBounds(o.LowerBound, o.UpperBound)
+		dbi.processBounds(o.LowerBound, o.UpperBound)
 	}
 	dbi.opts.logger = d.opts.Logger
 	if d.opts.private.disableLazyCombinedIteration {

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -143,7 +143,7 @@ func NewExternalIter(
 	}
 	if iterOpts != nil {
 		dbi.opts = *iterOpts
-		dbi.saveBounds(iterOpts.LowerBound, iterOpts.UpperBound)
+		dbi.processBounds(iterOpts.LowerBound, iterOpts.UpperBound)
 	}
 	for i := range extraOpts {
 		extraOpts[i].iterApply(dbi)

--- a/testdata/iter_histories/next_prefix
+++ b/testdata/iter_histories/next_prefix
@@ -234,3 +234,59 @@ next-prefix
 a@10: (a@10, .)
 a@100: (a@100, .)
 b@100: (b@100, .)
+
+reset
+----
+
+populate keylen=1 timestamps=(1, 10, 100)
+----
+wrote 78 keys
+
+flush
+----
+
+lsm
+----
+0.0:
+  000005:[a@100#3,SET-z@1#76,SET]
+
+# Test for https://github.com/cockroachdb/pebble/issues/2260. Triggered the
+# bug. The second call to first would return c@100 instead of the correct key,
+# b@1.
+combined-iter upper=b@1
+first
+next-prefix
+next-prefix
+set-bounds lower=b@1 upper=d
+first
+next
+first
+----
+a@100: (a@100, .)
+err=NextPrefix not permitted with upper bound b@1
+err=NextPrefix not permitted with upper bound b@1
+.
+b@1: (b@1, .)
+c@100: (c@100, .)
+b@1: (b@1, .)
+
+# Did not trigger https://github.com/cockroachdb/pebble/issues/2260 since
+# Iterator.NextPrefix first does a Next. So the second call to NextPrefix
+# returned after the Next, since the upper bound was reached, which left the
+# Iterator positioned at b@1.
+combined-iter upper=b@10
+first
+next-prefix
+next-prefix
+set-bounds lower=b@1 upper=d
+first
+next
+first
+----
+a@100: (a@100, .)
+err=NextPrefix not permitted with upper bound b@10
+err=NextPrefix not permitted with upper bound b@10
+.
+b@1: (b@1, .)
+c@100: (c@100, .)
+b@1: (b@1, .)


### PR DESCRIPTION
See https://github.com/cockroachdb/pebble/issues/2260#issuecomment-1406803934 for the reason behind this choice. Note that CockroachDB never uses versioned keys in the bounds by construction, since bounds are always of type roachpb.Key. Completely disallowing versioned bounds in Pebble would also be an option, but was considered too strict, and switching the behavior based on the upper-bound is simple and cheap (well designed implementations of Comparer.Split should be O(1)).

Fixes #2260