### PR TITLE
objstorage: introduce shared object catalog

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -936,7 +936,7 @@ func TestRollManifest(t *testing.T) {
 	sizeRolloverState := func() (int64, int64) {
 		d.mu.Lock()
 		defer d.mu.Unlock()
-		return d.mu.versions.lastSnapshotFileCount, d.mu.versions.editsSinceLastSnapshotFileCount
+		return d.mu.versions.rotationHelper.DebugInfo()
 	}
 
 	current := func() string {

--- a/objstorage/sharedobjcat/catalog.go
+++ b/objstorage/sharedobjcat/catalog.go
@@ -1,0 +1,309 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sharedobjcat
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"sync"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/record"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/cockroachdb/pebble/vfs/atomicfs"
+)
+
+// Catalog is used to manage the on-disk shared object catalog.
+//
+// The catalog file is a log of records, where each record is an encoded
+// versionEdit.
+type Catalog struct {
+	fs      vfs.FS
+	dirname string
+	mu      struct {
+		sync.Mutex
+
+		objects map[base.FileNum]SharedObjectMetadata
+
+		marker *atomicfs.Marker
+
+		catalogFile      vfs.File
+		catalogRecWriter *record.Writer
+
+		rotationHelper record.RotationHelper
+
+		// catalogFilename is the filename of catalogFile when catalogFile != nil, otherwise
+		// it is the filename of the last catalog file.
+		catalogFilename string
+	}
+}
+
+// SharedObjectMetadata encapsulates the data stored in the catalog file for each object.
+type SharedObjectMetadata struct {
+	// FileNum is the identifier for the object within the context of a single DB
+	// instance.
+	FileNum base.FileNum
+	// CreatorID identifies the DB instance that originally created the object.
+	CreatorID uint64
+	// CreatorFileNum is the identifier for the object within the context of the
+	// DB instance that originally created the object.
+	CreatorFileNum base.FileNum
+}
+
+const (
+	catalogFilenameBase = "SHARED-CATALOG"
+	catalogMarkerName   = "shared-catalog"
+
+	// We create a new file when the size exceeds 1MB (and some other conditions
+	// hold; see record.RotationHelper).
+	rotateFileSize = 1024 * 1024 // 1MB
+)
+
+// CatalogContents contains the shared objects in the catalog.
+type CatalogContents = []SharedObjectMetadata
+
+// Open creates a Catalog and loads any existing catalog file, returning the contents.
+func Open(fs vfs.FS, dirname string) (*Catalog, CatalogContents, error) {
+	c := &Catalog{
+		fs:      fs,
+		dirname: dirname,
+	}
+	c.mu.objects = make(map[base.FileNum]SharedObjectMetadata)
+
+	var err error
+	c.mu.marker, c.mu.catalogFilename, err = atomicfs.LocateMarker(fs, dirname, catalogMarkerName)
+	if err != nil {
+		return nil, nil, err
+	}
+	// If the filename is empty, there is no existing catalog.
+	if c.mu.catalogFilename != "" {
+		if err := c.loadFromCatalogFile(c.mu.catalogFilename); err != nil {
+			return nil, nil, err
+		}
+		if err := c.mu.marker.RemoveObsolete(); err != nil {
+			return nil, nil, err
+		}
+		// TODO(radu): remove obsolete catalog files.
+	}
+	res := make(CatalogContents, 0, len(c.mu.objects))
+	for _, meta := range c.mu.objects {
+		res = append(res, meta)
+	}
+	// Sort the objects so the function is deterministic.
+	sort.Slice(res, func(i, j int) bool {
+		return res[i].FileNum < res[j].FileNum
+	})
+	return c, res, nil
+}
+
+// Close any open files.
+func (c *Catalog) Close() error {
+	return c.closeCatalogFile()
+}
+
+func (c *Catalog) closeCatalogFile() error {
+	if c.mu.catalogFile == nil {
+		return nil
+	}
+	err1 := c.mu.catalogRecWriter.Close()
+	err2 := c.mu.catalogFile.Close()
+	c.mu.catalogRecWriter = nil
+	c.mu.catalogFile = nil
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}
+
+// Batch is used to perform multiple object additions/deletions at once.
+type Batch struct {
+	ve versionEdit
+}
+
+// AddObject adds a new object to the batch.
+//
+// The given FileNum must be new - it must not match that of any object that was
+// ever in the catalog.
+func (b *Batch) AddObject(meta SharedObjectMetadata) {
+	b.ve.NewObjects = append(b.ve.NewObjects, meta)
+}
+
+// DeleteObject adds an object removal to the batch.
+func (b *Batch) DeleteObject(fileNum base.FileNum) {
+	b.ve.DeletedObjects = append(b.ve.DeletedObjects, fileNum)
+}
+
+// Reset clears the batch.
+func (b *Batch) Reset() {
+	b.ve.NewObjects = b.ve.NewObjects[:0]
+	b.ve.DeletedObjects = b.ve.DeletedObjects[:0]
+}
+
+// ApplyBatch applies a batch of updates; returns after the change is stably recorded on storage.
+// On success, the batch is cleared.
+func (c *Catalog) ApplyBatch(b *Batch) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, n := range b.ve.DeletedObjects {
+		if _, exists := c.mu.objects[n]; !exists {
+			return errors.AssertionFailedf("deleting non-existent object %s", n)
+		}
+	}
+	for _, meta := range b.ve.NewObjects {
+		if _, exists := c.mu.objects[meta.FileNum]; exists {
+			return errors.AssertionFailedf("adding existing object %s", meta.FileNum)
+		}
+	}
+
+	if err := c.writeToCatalogFileLocked(&b.ve); err != nil {
+		return errors.Wrapf(err, "pebble: could not write to shared object catalog: %v", err)
+	}
+
+	// Apply the batch to our current state.
+	for _, n := range b.ve.DeletedObjects {
+		delete(c.mu.objects, n)
+	}
+	for _, meta := range b.ve.NewObjects {
+		c.mu.objects[meta.FileNum] = meta
+	}
+	b.Reset()
+	return nil
+}
+
+func (c *Catalog) loadFromCatalogFile(filename string) error {
+	catalogPath := c.fs.PathJoin(c.dirname, filename)
+	f, err := c.fs.Open(catalogPath)
+	if err != nil {
+		return errors.Wrapf(
+			err, "pebble: could not open shared object catalog file %q for DB %q",
+			errors.Safe(filename), c.dirname,
+		)
+	}
+	defer f.Close()
+	rr := record.NewReader(f, 0 /* logNum */)
+	for {
+		r, err := rr.Next()
+		if err == io.EOF || record.IsInvalidRecord(err) {
+			break
+		}
+		if err != nil {
+			return errors.Wrapf(err, "pebble: error when loading shared object catalog file %q",
+				errors.Safe(filename))
+		}
+		var ve versionEdit
+		err = ve.Decode(r)
+		if err != nil {
+			return errors.Wrapf(err, "pebble: error when loading shared object catalog file %q",
+				errors.Safe(filename))
+		}
+		// Apply the version edit to the current state.
+		for _, fileNum := range ve.DeletedObjects {
+			delete(c.mu.objects, fileNum)
+		}
+		for _, meta := range ve.NewObjects {
+			c.mu.objects[meta.FileNum] = meta
+		}
+	}
+	return nil
+}
+
+// writeToCatalogFileLocked writes a versionEdit to the catalog file.
+// Creates a new file if this is the first write.
+func (c *Catalog) writeToCatalogFileLocked(ve *versionEdit) error {
+	c.mu.rotationHelper.AddRecord(int64(len(ve.NewObjects) + len(ve.DeletedObjects)))
+	snapshotSize := int64(len(c.mu.objects))
+
+	var shouldRotate bool
+	if c.mu.catalogFile == nil {
+		shouldRotate = true
+	} else if c.mu.catalogRecWriter.Size() >= rotateFileSize {
+		shouldRotate = c.mu.rotationHelper.ShouldRotate(snapshotSize)
+	}
+
+	if shouldRotate {
+		if c.mu.catalogFile != nil {
+			if err := c.closeCatalogFile(); err != nil {
+				return err
+			}
+		}
+		if err := c.createNewCatalogFileLocked(); err != nil {
+			return err
+		}
+		c.mu.rotationHelper.Rotate(snapshotSize)
+	}
+	return writeRecord(ve, c.mu.catalogFile, c.mu.catalogRecWriter)
+}
+
+func makeCatalogFilename(iter uint64) string {
+	return fmt.Sprintf("%s-%06d", catalogFilenameBase, iter)
+}
+
+// createNewCatalogFileLocked creates a new catalog file, populates it with the
+// current catalog and sets c.mu.catalogFile and c.mu.catalogRecWriter.
+func (c *Catalog) createNewCatalogFileLocked() (outErr error) {
+	if c.mu.catalogFile != nil {
+		return errors.AssertionFailedf("catalogFile already open")
+	}
+	filename := makeCatalogFilename(c.mu.marker.NextIter())
+	filepath := c.fs.PathJoin(c.dirname, filename)
+	file, err := c.fs.Create(filepath)
+	if err != nil {
+		return err
+	}
+	recWriter := record.NewWriter(file)
+	err = func() error {
+		// Create a versionEdit that gets us from an empty catalog to the current state.
+		var ve versionEdit
+		ve.NewObjects = make([]SharedObjectMetadata, 0, len(c.mu.objects))
+		for _, meta := range c.mu.objects {
+			ve.NewObjects = append(ve.NewObjects, meta)
+		}
+		if err := writeRecord(&ve, file, recWriter); err != nil {
+			return err
+		}
+
+		// Move the marker to the new filename. Move handles syncing the data
+		// directory as well.
+		if err := c.mu.marker.Move(filename); err != nil {
+			return errors.Wrap(err, "moving marker")
+		}
+
+		return nil
+	}()
+
+	if err != nil {
+		_ = recWriter.Close()
+		_ = file.Close()
+		_ = c.fs.Remove(filepath)
+		return err
+	}
+
+	// Remove any previous file (ignoring any error).
+	if c.mu.catalogFilename != "" {
+		_ = c.fs.Remove(c.fs.PathJoin(c.dirname, c.mu.catalogFilename))
+	}
+
+	c.mu.catalogFile = file
+	c.mu.catalogRecWriter = recWriter
+	c.mu.catalogFilename = filename
+	return nil
+}
+
+func writeRecord(ve *versionEdit, file vfs.File, recWriter *record.Writer) error {
+	w, err := recWriter.Next()
+	if err != nil {
+		return err
+	}
+	if err := ve.Encode(w); err != nil {
+		return err
+	}
+	if err := recWriter.Flush(); err != nil {
+		return err
+	}
+	return file.Sync()
+}

--- a/objstorage/sharedobjcat/catalog_test.go
+++ b/objstorage/sharedobjcat/catalog_test.go
@@ -1,0 +1,163 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sharedobjcat_test
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage/sharedobjcat"
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+func TestCatalog(t *testing.T) {
+	mem := vfs.NewMem()
+	var memLog base.InMemLogger
+
+	var cat *sharedobjcat.Catalog
+	datadriven.RunTest(t, "testdata/catalog", func(t *testing.T, td *datadriven.TestData) string {
+		toInt := func(args ...string) []int {
+			t.Helper()
+			var res []int
+			for _, arg := range args {
+				n, err := strconv.Atoi(arg)
+				if err != nil {
+					td.Fatalf(t, "error parsing arg %s as integer: %v", arg, err)
+				}
+				res = append(res, int(n))
+			}
+			return res
+		}
+
+		parseAdd := func(args []string) sharedobjcat.SharedObjectMetadata {
+			t.Helper()
+			if len(args) != 3 {
+				td.Fatalf(t, "add <file-num> <creator-id> <creator-file-num>")
+			}
+			vals := toInt(args...)
+			return sharedobjcat.SharedObjectMetadata{
+				FileNum:        base.FileNum(vals[0]),
+				CreatorID:      uint64(vals[1]),
+				CreatorFileNum: base.FileNum(vals[2]),
+			}
+		}
+
+		parseDel := func(args []string) base.FileNum {
+			t.Helper()
+			if len(args) != 1 {
+				td.Fatalf(t, "delete <file-num>")
+			}
+			return base.FileNum(toInt(args[0])[0])
+		}
+
+		memLog.Reset()
+		switch td.Cmd {
+		case "open":
+			if len(td.CmdArgs) != 1 {
+				td.Fatalf(t, "open <dir>")
+			}
+			dirname := td.CmdArgs[0].String()
+			err := mem.MkdirAll(dirname, 0755)
+			if err != nil {
+				td.Fatalf(t, "%v", err)
+			}
+			var contents sharedobjcat.CatalogContents
+			cat, contents, err = sharedobjcat.Open(vfs.WithLogging(mem, memLog.Infof), dirname)
+			if err != nil {
+				return err.Error()
+			}
+			var buf strings.Builder
+			for _, meta := range contents {
+				fmt.Fprintf(&buf, "%s: %d/%s\n", meta.FileNum, meta.CreatorID, meta.CreatorFileNum)
+			}
+
+			return buf.String()
+
+		case "batch":
+			var b sharedobjcat.Batch
+			for _, cmd := range strings.Split(td.Input, "\n") {
+				tokens := strings.Split(cmd, " ")
+				if len(tokens) == 0 {
+					td.Fatalf(t, "empty batch line")
+				}
+				switch tokens[0] {
+				case "add":
+					b.AddObject(parseAdd(tokens[1:]))
+				case "delete":
+					b.DeleteObject(parseDel(tokens[1:]))
+				default:
+					td.Fatalf(t, "unknown batch command: %s", tokens[0])
+				}
+			}
+			if err := cat.ApplyBatch(&b); err != nil {
+				return fmt.Sprintf("error applying batch: %v", err)
+			}
+			return memLog.String()
+
+		case "random-batches":
+			n := 1
+			size := 1000
+			for _, arg := range td.CmdArgs {
+				if len(arg.Vals) != 1 {
+					td.Fatalf(t, "random-batches n=<val> size=<val>")
+				}
+				val := toInt(arg.Vals[0])[0]
+				switch arg.Key {
+				case "n":
+					n = val
+				case "size":
+					size = val
+				default:
+					td.Fatalf(t, "random-batches n=<val> size=<val>")
+				}
+			}
+			var b sharedobjcat.Batch
+			for batchIdx := 0; batchIdx < n; batchIdx++ {
+				for i := 0; i < size; i++ {
+					b.AddObject(sharedobjcat.SharedObjectMetadata{
+						FileNum:        base.FileNum(rand.Uint64()),
+						CreatorID:      rand.Uint64(),
+						CreatorFileNum: base.FileNum(rand.Uint64()),
+					})
+				}
+				if err := cat.ApplyBatch(&b); err != nil {
+					td.Fatalf(t, "error applying batch: %v", err)
+				}
+			}
+			return memLog.String()
+
+		case "close":
+			if cat == nil {
+				return "nil catalog"
+			}
+			err := cat.Close()
+			cat = nil
+			if err != nil {
+				return fmt.Sprintf("%v", err)
+			}
+			return memLog.String()
+
+		case "list":
+			if len(td.CmdArgs) != 1 {
+				td.Fatalf(t, "open <dir>")
+			}
+			paths, err := mem.List(td.CmdArgs[0].String())
+			if err != nil {
+				return err.Error()
+			}
+			sort.Strings(paths)
+			return strings.Join(paths, "\n")
+
+		default:
+			return fmt.Sprintf("unknown command: %s", td.Cmd)
+		}
+	})
+}

--- a/objstorage/sharedobjcat/testdata/catalog
+++ b/objstorage/sharedobjcat/testdata/catalog
@@ -1,0 +1,249 @@
+open test
+----
+
+list test
+----
+
+batch
+add 1 10 100
+----
+create: test/SHARED-CATALOG-000001
+sync: test/SHARED-CATALOG-000001
+create: test/marker.shared-catalog.000001.SHARED-CATALOG-000001
+close: test/marker.shared-catalog.000001.SHARED-CATALOG-000001
+sync: test
+sync: test/SHARED-CATALOG-000001
+
+list test
+----
+SHARED-CATALOG-000001
+marker.shared-catalog.000001.SHARED-CATALOG-000001
+
+batch
+add 2 20 200
+add 3 30 300
+----
+sync: test/SHARED-CATALOG-000001
+
+batch
+delete 1
+----
+sync: test/SHARED-CATALOG-000001
+
+list test
+----
+SHARED-CATALOG-000001
+marker.shared-catalog.000001.SHARED-CATALOG-000001
+
+# Bad batches.
+batch
+add 3 1 1
+----
+error applying batch: adding existing object 000003
+
+batch
+delete 1000
+----
+error applying batch: deleting non-existent object 001000
+
+close
+----
+close: test/SHARED-CATALOG-000001
+
+open test
+----
+000002: 20/000200
+000003: 30/000300
+
+batch
+add 4 40 40
+delete 3
+add 8 80 80
+----
+create: test/SHARED-CATALOG-000002
+sync: test/SHARED-CATALOG-000002
+create: test/marker.shared-catalog.000002.SHARED-CATALOG-000002
+close: test/marker.shared-catalog.000002.SHARED-CATALOG-000002
+remove: test/marker.shared-catalog.000001.SHARED-CATALOG-000001
+sync: test
+remove: test/SHARED-CATALOG-000001
+sync: test/SHARED-CATALOG-000002
+
+list test
+----
+SHARED-CATALOG-000002
+marker.shared-catalog.000002.SHARED-CATALOG-000002
+
+close
+----
+close: test/SHARED-CATALOG-000002
+
+open test
+----
+000002: 20/000200
+000004: 40/000040
+000008: 80/000080
+
+close
+----
+
+open other-path
+----
+
+batch
+add 5 50 500
+----
+create: other-path/SHARED-CATALOG-000001
+sync: other-path/SHARED-CATALOG-000001
+create: other-path/marker.shared-catalog.000001.SHARED-CATALOG-000001
+close: other-path/marker.shared-catalog.000001.SHARED-CATALOG-000001
+sync: other-path
+sync: other-path/SHARED-CATALOG-000001
+
+list other-path
+----
+SHARED-CATALOG-000001
+marker.shared-catalog.000001.SHARED-CATALOG-000001
+
+list test
+----
+SHARED-CATALOG-000002
+marker.shared-catalog.000002.SHARED-CATALOG-000002
+
+close
+----
+close: other-path/SHARED-CATALOG-000001
+
+open test
+----
+000002: 20/000200
+000004: 40/000040
+000008: 80/000080
+
+# Test rotation.
+list test
+----
+SHARED-CATALOG-000002
+marker.shared-catalog.000002.SHARED-CATALOG-000002
+
+random-batches n=20 size=2000
+----
+create: test/SHARED-CATALOG-000003
+sync: test/SHARED-CATALOG-000003
+create: test/marker.shared-catalog.000003.SHARED-CATALOG-000003
+close: test/marker.shared-catalog.000003.SHARED-CATALOG-000003
+remove: test/marker.shared-catalog.000002.SHARED-CATALOG-000002
+sync: test
+remove: test/SHARED-CATALOG-000002
+sync: test/SHARED-CATALOG-000003
+sync: test/SHARED-CATALOG-000003
+sync: test/SHARED-CATALOG-000003
+sync: test/SHARED-CATALOG-000003
+sync: test/SHARED-CATALOG-000003
+sync: test/SHARED-CATALOG-000003
+sync: test/SHARED-CATALOG-000003
+sync: test/SHARED-CATALOG-000003
+sync: test/SHARED-CATALOG-000003
+sync: test/SHARED-CATALOG-000003
+sync: test/SHARED-CATALOG-000003
+sync: test/SHARED-CATALOG-000003
+sync: test/SHARED-CATALOG-000003
+sync: test/SHARED-CATALOG-000003
+sync: test/SHARED-CATALOG-000003
+sync: test/SHARED-CATALOG-000003
+sync: test/SHARED-CATALOG-000003
+sync: test/SHARED-CATALOG-000003
+close: test/SHARED-CATALOG-000003
+create: test/SHARED-CATALOG-000004
+sync: test/SHARED-CATALOG-000004
+create: test/marker.shared-catalog.000004.SHARED-CATALOG-000004
+close: test/marker.shared-catalog.000004.SHARED-CATALOG-000004
+remove: test/marker.shared-catalog.000003.SHARED-CATALOG-000003
+sync: test
+remove: test/SHARED-CATALOG-000003
+sync: test/SHARED-CATALOG-000004
+sync: test/SHARED-CATALOG-000004
+
+list test
+----
+SHARED-CATALOG-000004
+marker.shared-catalog.000004.SHARED-CATALOG-000004
+
+random-batches n=20 size=2000
+----
+sync: test/SHARED-CATALOG-000004
+sync: test/SHARED-CATALOG-000004
+sync: test/SHARED-CATALOG-000004
+sync: test/SHARED-CATALOG-000004
+sync: test/SHARED-CATALOG-000004
+sync: test/SHARED-CATALOG-000004
+sync: test/SHARED-CATALOG-000004
+sync: test/SHARED-CATALOG-000004
+sync: test/SHARED-CATALOG-000004
+sync: test/SHARED-CATALOG-000004
+sync: test/SHARED-CATALOG-000004
+sync: test/SHARED-CATALOG-000004
+sync: test/SHARED-CATALOG-000004
+sync: test/SHARED-CATALOG-000004
+sync: test/SHARED-CATALOG-000004
+sync: test/SHARED-CATALOG-000004
+close: test/SHARED-CATALOG-000004
+create: test/SHARED-CATALOG-000005
+sync: test/SHARED-CATALOG-000005
+create: test/marker.shared-catalog.000005.SHARED-CATALOG-000005
+close: test/marker.shared-catalog.000005.SHARED-CATALOG-000005
+remove: test/marker.shared-catalog.000004.SHARED-CATALOG-000004
+sync: test
+remove: test/SHARED-CATALOG-000004
+sync: test/SHARED-CATALOG-000005
+sync: test/SHARED-CATALOG-000005
+sync: test/SHARED-CATALOG-000005
+sync: test/SHARED-CATALOG-000005
+
+list test
+----
+SHARED-CATALOG-000005
+marker.shared-catalog.000005.SHARED-CATALOG-000005
+
+# Even with huge batches, we don't rotate on each batch.
+random-batches n=10 size=50000
+----
+sync: test/SHARED-CATALOG-000005
+close: test/SHARED-CATALOG-000005
+create: test/SHARED-CATALOG-000006
+sync: test/SHARED-CATALOG-000006
+create: test/marker.shared-catalog.000006.SHARED-CATALOG-000006
+close: test/marker.shared-catalog.000006.SHARED-CATALOG-000006
+remove: test/marker.shared-catalog.000005.SHARED-CATALOG-000005
+sync: test
+remove: test/SHARED-CATALOG-000005
+sync: test/SHARED-CATALOG-000006
+sync: test/SHARED-CATALOG-000006
+close: test/SHARED-CATALOG-000006
+create: test/SHARED-CATALOG-000007
+sync: test/SHARED-CATALOG-000007
+create: test/marker.shared-catalog.000007.SHARED-CATALOG-000007
+close: test/marker.shared-catalog.000007.SHARED-CATALOG-000007
+remove: test/marker.shared-catalog.000006.SHARED-CATALOG-000006
+sync: test
+remove: test/SHARED-CATALOG-000006
+sync: test/SHARED-CATALOG-000007
+sync: test/SHARED-CATALOG-000007
+sync: test/SHARED-CATALOG-000007
+sync: test/SHARED-CATALOG-000007
+close: test/SHARED-CATALOG-000007
+create: test/SHARED-CATALOG-000008
+sync: test/SHARED-CATALOG-000008
+create: test/marker.shared-catalog.000008.SHARED-CATALOG-000008
+close: test/marker.shared-catalog.000008.SHARED-CATALOG-000008
+remove: test/marker.shared-catalog.000007.SHARED-CATALOG-000007
+sync: test
+remove: test/SHARED-CATALOG-000007
+sync: test/SHARED-CATALOG-000008
+sync: test/SHARED-CATALOG-000008
+sync: test/SHARED-CATALOG-000008
+
+list test
+----
+SHARED-CATALOG-000008
+marker.shared-catalog.000008.SHARED-CATALOG-000008

--- a/objstorage/sharedobjcat/version_edit.go
+++ b/objstorage/sharedobjcat/version_edit.go
@@ -1,0 +1,103 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sharedobjcat
+
+import (
+	"bufio"
+	"encoding/binary"
+	"io"
+
+	"github.com/cockroachdb/pebble/internal/base"
+)
+
+// versionEdit is a modification to the shared object state which can be encoded
+// into a record.
+//
+// TODO(radu): consider adding creation and deletion time for debugging purposes.
+type versionEdit struct {
+	NewObjects     []SharedObjectMetadata
+	DeletedObjects []base.FileNum
+}
+
+const (
+	// tagNewObject is followed by the FileNum, creator ID and creator FileNum.
+	tagNewObject = 1
+	// tagDeletedObject is followed by the FileNum.
+	tagDeletedObject = 2
+)
+
+// Encode encodes an edit to the specified writer.
+func (v *versionEdit) Encode(w io.Writer) error {
+	buf := make([]byte, 0, binary.MaxVarintLen64*(len(v.NewObjects)*4+len(v.DeletedObjects)*2))
+	for _, meta := range v.NewObjects {
+		buf = binary.AppendUvarint(buf, uint64(tagNewObject))
+		buf = binary.AppendUvarint(buf, uint64(meta.FileNum))
+		buf = binary.AppendUvarint(buf, meta.CreatorID)
+		buf = binary.AppendUvarint(buf, uint64(meta.CreatorFileNum))
+	}
+
+	for _, fileNum := range v.DeletedObjects {
+		buf = binary.AppendUvarint(buf, uint64(tagDeletedObject))
+		buf = binary.AppendUvarint(buf, uint64(fileNum))
+	}
+	_, err := w.Write(buf)
+	return err
+}
+
+// Decode decodes an edit from the specified reader.
+func (v *versionEdit) Decode(r io.Reader) error {
+	br, ok := r.(io.ByteReader)
+	if !ok {
+		br = bufio.NewReader(r)
+	}
+	for {
+		tag, err := binary.ReadUvarint(br)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		err = nil
+		switch tag {
+		case tagNewObject:
+			var fileNum, creatorID, creatorFileNum uint64
+			fileNum, err = binary.ReadUvarint(br)
+			if err == nil {
+				creatorID, err = binary.ReadUvarint(br)
+			}
+			if err == nil {
+				creatorFileNum, err = binary.ReadUvarint(br)
+			}
+			if err == nil {
+				v.NewObjects = append(v.NewObjects, SharedObjectMetadata{
+					FileNum:        base.FileNum(fileNum),
+					CreatorID:      creatorID,
+					CreatorFileNum: base.FileNum(creatorFileNum),
+				})
+			}
+
+		case tagDeletedObject:
+			var fileNum uint64
+			fileNum, err = binary.ReadUvarint(br)
+			if err == nil {
+				v.DeletedObjects = append(v.DeletedObjects, base.FileNum(fileNum))
+			}
+
+		default:
+			// Ignore unknown tags.
+		}
+		if err != nil {
+			if err == io.EOF {
+				return errCorruptCatalog
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+var errCorruptCatalog = base.CorruptionErrorf("pebble: corrupt shared object catalog")

--- a/objstorage/sharedobjcat/version_edit_test.go
+++ b/objstorage/sharedobjcat/version_edit_test.go
@@ -1,0 +1,72 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sharedobjcat
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/kr/pretty"
+)
+
+func TestVersionEditRoundTrip(t *testing.T) {
+	for _, ve := range []versionEdit{
+		{},
+		{
+			NewObjects: []SharedObjectMetadata{
+				{
+					FileNum:        1,
+					CreatorID:      12,
+					CreatorFileNum: 123,
+				},
+			},
+		},
+		{
+			DeletedObjects: []base.FileNum{1},
+		},
+		{
+			NewObjects: []SharedObjectMetadata{
+				{
+					FileNum:        1,
+					CreatorID:      12,
+					CreatorFileNum: 123,
+				},
+				{
+					FileNum:        2,
+					CreatorID:      22,
+					CreatorFileNum: 223,
+				},
+				{
+					FileNum:        3,
+					CreatorID:      32,
+					CreatorFileNum: 323,
+				},
+			},
+			DeletedObjects: []base.FileNum{4, 5},
+		},
+	} {
+		if err := checkRoundTrip(ve); err != nil {
+			t.Fatalf("%+v did not roundtrip: %v", ve, err)
+		}
+	}
+}
+
+func checkRoundTrip(e0 versionEdit) error {
+	var e1 versionEdit
+	buf := new(bytes.Buffer)
+	if err := e0.Encode(buf); err != nil {
+		return errors.Wrap(err, "encode")
+	}
+	if err := e1.Decode(buf); err != nil {
+		return errors.Wrap(err, "decode")
+	}
+	if diff := pretty.Diff(e0, e1); diff != nil {
+		return errors.Errorf("%s", strings.Join(diff, "\n"))
+	}
+	return nil
+}

--- a/record/rotation.go
+++ b/record/rotation.go
@@ -51,7 +51,7 @@ func (rh *RotationHelper) ShouldRotate(nextSnapshotSize int64) bool {
 	//   will ensure that at most 50% of data written out is due to rotation.
 	//
 	// - The number of live entries K in the DB is shrinking drastically, say from
-	//   S to S/10: After this shrinking, E = 0.9F, and so if we used the previous
+	//   S to S/10: After this shrinking, E = 0.9S, and so if we used the previous
 	//   snapshot entry count, S, as the threshold that needs to be exceeded, we
 	//   will further delay the snapshot writing. Which means on reopen we will
 	//   need to replay 0.9S edits to get to a version with 0.1S entries. It would
@@ -59,8 +59,9 @@ func (rh *RotationHelper) ShouldRotate(nextSnapshotSize int64) bool {
 	//   the current version.
 	//
 	// - The number of live entries L in the DB is growing; say the last snapshot
-	//   had S entries, and now we have 10S entries, so E = 9S. We will further
-	//   delay writing a new snapshot.
+	//   had S entries, and now we have 10S entries, so E = 9S. If we required
+	//   that E is at least the current number of entries, we would further delay
+	//   writing a new snapshot (which is not desirable).
 	//
 	// The logic below uses the min of the last snapshot size count and the size
 	// count in the current version.

--- a/record/rotation.go
+++ b/record/rotation.go
@@ -1,0 +1,81 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package record
+
+// RotationHelper is a type used to inform the decision of rotating a record log
+// file.
+//
+// The assumption is that multiple records can be coalesced into a single record
+// (called a snapshot). Starting a new file, where the first record is a
+// snapshot of the current state is referred to as "rotating" the log.
+//
+// Normally we rotate files when a certain file size is reached. But in certain
+// cases (e.g. contents become very large), this can result in too frequent
+// rotation. This helper contains logic to impose extra conditions on the
+// rotation.
+//
+// The rotation helper uses "size" as a unit-less estimation that is correlated
+// with the on-disk size of a record or snapshot.
+type RotationHelper struct {
+	// lastSnapshotSize is the size of the last snapshot.
+	lastSnapshotSize int64
+	// sizeSinceLastSnapshot is the sum of sizes of records applied since the last
+	// snapshot.
+	sizeSinceLastSnapshot int64
+	lastRecordSize        int64
+}
+
+// AddRecord makes the rotation helper aware of a new record.
+func (rh *RotationHelper) AddRecord(recordSize int64) {
+	rh.sizeSinceLastSnapshot += recordSize
+	rh.lastRecordSize = recordSize
+}
+
+// ShouldRotate returns whether we should start a new log file (with a snapshot).
+// Does not need to be called if other rotation factors (log file size) are not
+// satisfied.
+func (rh *RotationHelper) ShouldRotate(nextSnapshotSize int64) bool {
+	// The primary goal is to ensure that when reopening a log file, the number of
+	// edits that need to be replayed on top of the snapshot is "sane" while
+	// keeping the rotation frequency as low as possible.
+	//
+	// For the purposes of this description, we assume that the log is mainly
+	// storing a collection of "entries", with edits adding or removing entries.
+	// Consider the following cases:
+	//
+	// - The number of live entries is roughly stable: after writing the snapshot
+	//   (with S entries), we require that there be enough edits such that the
+	//   cumulative number of entries in those edits, E, be greater than S. This
+	//   will ensure that at most 50% of data written out is due to rotation.
+	//
+	// - The number of live entries K in the DB is shrinking drastically, say from
+	//   S to S/10: After this shrinking, E = 0.9F, and so if we used the previous
+	//   snapshot entry count, S, as the threshold that needs to be exceeded, we
+	//   will further delay the snapshot writing. Which means on reopen we will
+	//   need to replay 0.9S edits to get to a version with 0.1S entries. It would
+	//   be better to create a new snapshot when E exceeds the number of entries in
+	//   the current version.
+	//
+	// - The number of live entries L in the DB is growing; say the last snapshot
+	//   had S entries, and now we have 10S entries, so E = 9S. We will further
+	//   delay writing a new snapshot.
+	//
+	// The logic below uses the min of the last snapshot size count and the size
+	// count in the current version.
+	return rh.sizeSinceLastSnapshot > rh.lastSnapshotSize || rh.sizeSinceLastSnapshot > nextSnapshotSize
+}
+
+// Rotate makes the rotation helper aware that we are rotating to a new snapshot
+// (to which we will apply the latest edit).
+func (rh *RotationHelper) Rotate(snapshotSize int64) {
+	rh.lastSnapshotSize = snapshotSize
+	rh.sizeSinceLastSnapshot = rh.lastRecordSize
+}
+
+// DebugInfo returns the last snapshot size and size of the edits since the last
+// snapshot; used for testing and debugging.
+func (rh *RotationHelper) DebugInfo() (lastSnapshotSize int64, sizeSinceLastSnapshot int64) {
+	return rh.lastSnapshotSize, rh.sizeSinceLastSnapshot
+}

--- a/record/rotation_test.go
+++ b/record/rotation_test.go
@@ -1,0 +1,49 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package record
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+)
+
+func TestRotation(t *testing.T) {
+	var rh RotationHelper
+	datadriven.RunTest(t, "testdata/rotation", func(t *testing.T, td *datadriven.TestData) string {
+		oneIntArg := func() int64 {
+			if len(td.CmdArgs) != 1 {
+				td.Fatalf(t, "expected one integer argument")
+			}
+			n, err := strconv.Atoi(td.CmdArgs[0].String())
+			if err != nil {
+				td.Fatalf(t, "expected one integer argument")
+			}
+			return int64(n)
+		}
+		switch td.Cmd {
+		case "add":
+			size := oneIntArg()
+			rh.AddRecord(size)
+
+		case "should-rotate":
+			nextSnapshotSize := oneIntArg()
+			return fmt.Sprint(rh.ShouldRotate(nextSnapshotSize))
+
+		case "rotate":
+			snapshotSize := oneIntArg()
+			rh.Rotate(snapshotSize)
+
+		default:
+			td.Fatalf(t, "unknown command %s", td.Cmd)
+		}
+
+		// For commands with no output, show the debug info.
+		a, b := rh.DebugInfo()
+		return fmt.Sprintf("last-snapshot-size: %d\nsize-since-last-snapshot: %d", a, b)
+	})
+}

--- a/record/testdata/rotation
+++ b/record/testdata/rotation
@@ -1,0 +1,65 @@
+rotate 100
+----
+last-snapshot-size: 100
+size-since-last-snapshot: 0
+
+add 10
+----
+last-snapshot-size: 100
+size-since-last-snapshot: 10
+
+# We should only rotate if the next snapshot is much smaller.
+should-rotate 100
+----
+false
+
+should-rotate 5
+----
+true
+
+add 50
+----
+last-snapshot-size: 100
+size-since-last-snapshot: 60
+
+add 50
+----
+last-snapshot-size: 100
+size-since-last-snapshot: 110
+
+add 50
+----
+last-snapshot-size: 100
+size-since-last-snapshot: 160
+
+# We exceeded the last snapshot size, we should rotate regardless.
+should-rotate 1
+----
+true
+
+should-rotate 1000
+----
+true
+
+add 1
+----
+last-snapshot-size: 100
+size-since-last-snapshot: 161
+
+rotate 10
+----
+last-snapshot-size: 10
+size-since-last-snapshot: 1
+
+add 5
+----
+last-snapshot-size: 10
+size-since-last-snapshot: 6
+
+should-rotate 5
+----
+true
+
+should-rotate 100
+----
+false

--- a/version_set.go
+++ b/version_set.go
@@ -111,8 +111,7 @@ type versionSet struct {
 	writing    bool
 	writerCond sync.Cond
 	// State for deciding when to write a snapshot. Protected by mu.
-	lastSnapshotFileCount           int64
-	editsSinceLastSnapshotFileCount int64
+	rotationHelper record.RotationHelper
 }
 
 func (vs *versionSet) init(
@@ -433,37 +432,22 @@ func (vs *versionSet) logAndApply(
 	//
 	// The logic below uses the min of the last snapshot file count and the file
 	// count in the current version.
-	editCount := int64(len(ve.DeletedFiles) + len(ve.NewFiles))
-	vs.editsSinceLastSnapshotFileCount += editCount
+	vs.rotationHelper.AddRecord(int64(len(ve.DeletedFiles) + len(ve.NewFiles)))
 	sizeExceeded := vs.manifest.Size() >= vs.opts.MaxManifestFileSize
 	requireRotation := forceRotation || vs.manifest == nil
-	computeNextSnapshotFileCount := func() int64 {
-		var count int64
-		for i := range vs.metrics.Levels {
-			count += vs.metrics.Levels[i].NumFiles
-		}
-		return count
+
+	var nextSnapshotFilecount int64
+	for i := range vs.metrics.Levels {
+		nextSnapshotFilecount += vs.metrics.Levels[i].NumFiles
 	}
-	var nextSnapshotFileCount int64
 	if sizeExceeded && !requireRotation {
-		if vs.editsSinceLastSnapshotFileCount > vs.lastSnapshotFileCount {
-			requireRotation = true
-		} else {
-			nextSnapshotFileCount = computeNextSnapshotFileCount()
-			if vs.editsSinceLastSnapshotFileCount > nextSnapshotFileCount {
-				requireRotation = true
-			}
-		}
+		requireRotation = vs.rotationHelper.ShouldRotate(nextSnapshotFilecount)
 	}
 	var newManifestFileNum FileNum
 	var prevManifestFileSize uint64
 	if requireRotation {
 		newManifestFileNum = vs.getNextFileNum()
 		prevManifestFileSize = uint64(vs.manifest.Size())
-		if nextSnapshotFileCount == 0 {
-			// Haven't computed it, or happens to be 0.
-			nextSnapshotFileCount = computeNextSnapshotFileCount()
-		}
 	}
 
 	// Grab certain values before releasing vs.mu, in case createManifest() needs
@@ -542,8 +526,7 @@ func (vs *versionSet) logAndApply(
 
 	if requireRotation {
 		// Successfully rotated.
-		vs.lastSnapshotFileCount = nextSnapshotFileCount
-		vs.editsSinceLastSnapshotFileCount = editCount
+		vs.rotationHelper.Rotate(nextSnapshotFilecount)
 	}
 	// Now that DB.mu is held again, initialize compacting file info in
 	// L0Sublevels.


### PR DESCRIPTION
This commit adds code for a shared object catalog. It is implemented very similarly to the manifest: the catalog file contains multiple records, where each record is an encoded version edit. A marker file is used to keep track of the latest file.

The new code is not yet used.