### PR TITLE
pebble: minor cleanup around obsolete tables

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1725,7 +1725,7 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 			info.Err = err
 			// TODO(peter): untested.
 			d.mu.versions.obsoleteTables = append(d.mu.versions.obsoleteTables, pendingOutputs...)
-			d.mu.versions.incrementObsoleteTablesLocked(pendingOutputs)
+			d.mu.versions.updateObsoleteTableMetricsLocked()
 		}
 	}
 
@@ -2208,7 +2208,7 @@ func (d *DB) compact1(c *compaction, errChannel chan error) (err error) {
 		if err != nil {
 			// TODO(peter): untested.
 			d.mu.versions.obsoleteTables = append(d.mu.versions.obsoleteTables, pendingOutputs...)
-			d.mu.versions.incrementObsoleteTablesLocked(pendingOutputs)
+			d.mu.versions.updateObsoleteTableMetricsLocked()
 		}
 	}
 
@@ -2950,9 +2950,9 @@ func (d *DB) scanObsoleteFiles(list []string) {
 	}
 
 	d.mu.log.queue = merge(d.mu.log.queue, obsoleteLogs)
-	d.mu.versions.metrics.WAL.Files += int64(len(obsoleteLogs))
+	d.mu.versions.metrics.WAL.Files = int64(len(d.mu.log.queue))
 	d.mu.versions.obsoleteTables = mergeFileMetas(d.mu.versions.obsoleteTables, obsoleteTables)
-	d.mu.versions.incrementObsoleteTablesLocked(obsoleteTables)
+	d.mu.versions.updateObsoleteTableMetricsLocked()
 	d.mu.versions.obsoleteManifests = merge(d.mu.versions.obsoleteManifests, obsoleteManifests)
 	d.mu.versions.obsoleteOptions = merge(d.mu.versions.obsoleteOptions, obsoleteOptions)
 }

--- a/version_set.go
+++ b/version_set.go
@@ -764,12 +764,12 @@ func (vs *versionSet) addObsoleteLocked(obsolete []*manifest.FileMetadata) {
 		}
 	}
 	vs.obsoleteTables = append(vs.obsoleteTables, obsolete...)
-	vs.incrementObsoleteTablesLocked(obsolete)
+	vs.updateObsoleteTableMetricsLocked()
 }
 
-func (vs *versionSet) incrementObsoleteTablesLocked(obsolete []*manifest.FileMetadata) {
-	for _, fileMeta := range obsolete {
-		vs.metrics.Table.ObsoleteCount++
+func (vs *versionSet) updateObsoleteTableMetricsLocked() {
+	vs.metrics.Table.ObsoleteCount = int64(len(vs.obsoleteTables))
+	for _, fileMeta := range vs.obsoleteTables {
 		vs.metrics.Table.ObsoleteSize += fileMeta.Size
 	}
 }


### PR DESCRIPTION
In `scanObsoleteFiles` we use `mergeFileMetas` on obsolete tables which deduplicates, but when we increment the obsolete table metrics we assume there were no duplicates.

This change makes updating the obsolete table metrics less fragile - we simply recalculate the metric from scratch each time.