### PR TITLE
db: unflake TestArchiveCleaner

### DIFF
--- a/cleaner_test.go
+++ b/cleaner_test.go
@@ -30,6 +30,7 @@ func TestArchiveCleaner(t *testing.T) {
 		FS:      loggingFS{mem, &buf},
 		WALDir:  "wal",
 	}
+	opts.private.waitForCleaningAfterFlush = true
 
 	datadriven.RunTest(t, "testdata/cleaner", func(t *testing.T, td *datadriven.TestData) string {
 		switch td.Cmd {
@@ -68,6 +69,7 @@ func TestArchiveCleaner(t *testing.T) {
 			if err := d.Flush(); err != nil {
 				return err.Error()
 			}
+			d.TestOnlyWaitForCleaning()
 			return buf.String()
 
 		case "list":

--- a/compaction.go
+++ b/compaction.go
@@ -1748,7 +1748,7 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 	info.TotalDuration = d.timeNow().Sub(startTime)
 	d.opts.EventListener.FlushEnd(info)
 
-	d.deleteObsoleteFiles(jobID, false /* waitForOngoing */)
+	d.deleteObsoleteFiles(jobID, d.opts.private.waitForCleaningAfterFlush)
 
 	// Mark all the memtables we flushed as flushed. Note that we do this last so
 	// that a synchronous call to DB.Flush() will not return until the deletion

--- a/options.go
+++ b/options.go
@@ -845,6 +845,11 @@ type Options struct {
 		// against the FS are made after the DB is closed, the FS may leak a
 		// goroutine indefinitely.
 		fsCloser io.Closer
+
+		// waitForCleaningAfterFlush is used to ensure that the we wait
+		// synchronously for obsolete file deletion after a flush. This setting
+		// is useful for tests which force a flush.
+		waitForCleaningAfterFlush bool
 	}
 }
 


### PR DESCRIPTION
Forces test archive cleaner to wait for cleaning after a flush by calling TestOnlyWaitForCleaning to ensure that the expected file removals in the test are observed.

But waiting for cleaning after the flush command in the test isn't sufficient, as the compact command in the test can itself schedule a flush and if the files after a flush test are deleted asynchronously, then the output of the compact command in the test will differ. So, we add an option to force flushes to wait for file deletions