### PR TITLE
db: change flushable ingest key to encode just the FileNum

### DIFF
--- a/flushable_test.go
+++ b/flushable_test.go
@@ -78,7 +78,7 @@ func TestIngestedSSTFlushableAPI(t *testing.T) {
 		// (e.g. because the files reside on a different filesystem), ingestLink will
 		// fall back to copying, and if that fails we undo our work and return an
 		// error.
-		if _, err := ingestLink(jobID, d.opts, d.objProvider, paths, meta); err != nil {
+		if err := ingestLink(jobID, d.opts, d.objProvider, paths, meta); err != nil {
 			panic("couldn't hard link sstables")
 		}
 

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -314,7 +314,7 @@ func TestIngestLink(t *testing.T) {
 				opts.FS.Remove(paths[i])
 			}
 
-			_, err := ingestLink(0 /* jobID */, opts, objProvider, paths, meta)
+			err := ingestLink(0 /* jobID */, opts, objProvider, paths, meta)
 			if i < count {
 				if err == nil {
 					t.Fatalf("expected error, but found success")
@@ -375,7 +375,7 @@ func TestIngestLinkFallback(t *testing.T) {
 	objProvider := objstorage.New(objstorage.DefaultSettings(opts.FS, ""))
 
 	meta := []*fileMetadata{{FileNum: 1}}
-	_, err = ingestLink(0, opts, objProvider, []string{"source"}, meta)
+	err = ingestLink(0, opts, objProvider, []string{"source"}, meta)
 	require.NoError(t, err)
 
 	dest, err := mem.Open("000001.sst")


### PR DESCRIPTION
The `InternalKeyKindIngestSST` key contains the file path of an SST object. We don't normally store paths in metadata, as it is fairly fragile (e.g. what if the store is moved).

Since this is always an SST object that we created (usually through hard-link), we can store just the FileNum.

This also opens up the door for this object to be potentially stored on shared storage (we'd need to support non-local SSTs as ingest inputs though).