### PR TITLE
deps: update github.com/klauspost/compress to v1.15.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cockroachdb/redact v1.0.8
 	github.com/ghemawat/stream v0.0.0-20171120220530-696b145b53b9
 	github.com/golang/snappy v0.0.4
-	github.com/klauspost/compress v1.11.13
+	github.com/klauspost/compress v1.15.15
 	github.com/kr/pretty v0.2.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.8.2/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.9.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
-github.com/klauspost/compress v1.11.13 h1:eSvu8Tmq6j2psUJqJrLcWH6K3w5Dwc+qipbaA6eVEN4=
-github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.15.15 h1:EF27CXIuDsYJ6mmvtBRlEuB2UVOqHG1tAXgZ7yIO+lw=
+github.com/klauspost/compress v1.15.15/go.mod h1:ZcK2JAFqKOpnBlxcLsJzYfrS9X1akm9fHZNnD9+Vo/4=
 github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=


### PR DESCRIPTION
Update to the latest available version of
`github.com/klauspost/compress`. This package is only used when using zstd compression with a non-CGo build of Pebble.

Benchmarks show more or less no change in the performance between the previous (`v1.11.13`) and latest versions:

```
name                                                                                old time/op    new time/op    delta
Writer/format=(Pebble,v2)/block=4.0_K/filter=true/compression=ZSTD-16                  239ms ± 2%     235ms ± 1%  -1.60%  (p=0.000 n=10+9)
Writer/format=(Pebble,v2)/block=4.0_K/filter=false/compression=ZSTD-16                 221ms ± 2%     220ms ± 2%    ~     (p=0.165 n=10+10)
Writer/format=(Pebble,v2)/block=32_K/filter=true/compression=ZSTD-16                   115ms ± 1%     114ms ± 2%    ~     (p=0.247 n=10+10)
Writer/format=(Pebble,v2)/block=32_K/filter=false/compression=ZSTD-16                 93.7ms ± 1%    92.9ms ± 1%  -0.79%  (p=0.029 n=10+10)
Writer/format=(Pebble,v3)/block=4.0_K/filter=true/compression=ZSTD-16                  252ms ± 1%     250ms ± 2%    ~     (p=0.146 n=8+10)
Writer/format=(Pebble,v3)/block=4.0_K/filter=false/compression=ZSTD-16                 232ms ± 3%     230ms ± 1%    ~     (p=0.133 n=10+9)
Writer/format=(Pebble,v3)/block=32_K/filter=true/compression=ZSTD-16                   120ms ± 1%     120ms ± 2%    ~     (p=1.000 n=10+10)
Writer/format=(Pebble,v3)/block=32_K/filter=false/compression=ZSTD-16                 97.3ms ± 2%    98.8ms ± 2%  +1.51%  (p=0.009 n=10+10)
WriterWithVersions/format=(Pebble,v2)/block=4.0_K/filter=true/compression=ZSTD-16      256ms ± 2%     254ms ± 1%    ~     (p=0.156 n=10+9)
WriterWithVersions/format=(Pebble,v2)/block=4.0_K/filter=false/compression=ZSTD-16     235ms ± 2%     236ms ± 1%    ~     (p=0.447 n=10+9)
WriterWithVersions/format=(Pebble,v2)/block=32_K/filter=true/compression=ZSTD-16       127ms ± 1%     127ms ± 1%    ~     (p=0.353 n=10+10)
WriterWithVersions/format=(Pebble,v2)/block=32_K/filter=false/compression=ZSTD-16      106ms ± 1%     107ms ± 2%    ~     (p=0.631 n=10+10)
WriterWithVersions/format=(Pebble,v3)/block=4.0_K/filter=true/compression=ZSTD-16      318ms ± 2%     320ms ± 1%    ~     (p=0.053 n=9+10)
WriterWithVersions/format=(Pebble,v3)/block=4.0_K/filter=false/compression=ZSTD-16     299ms ± 2%     300ms ± 1%    ~     (p=0.529 n=10+10)
WriterWithVersions/format=(Pebble,v3)/block=32_K/filter=true/compression=ZSTD-16       178ms ± 1%     179ms ± 3%    ~     (p=0.631 n=10+10)
WriterWithVersions/format=(Pebble,v3)/block=32_K/filter=false/compression=ZSTD-16      156ms ± 2%     157ms ± 2%    ~     (p=0.089 n=10+10)

name                                                                                old speed      new speed      delta
Writer/format=(Pebble,v2)/block=4.0_K/filter=true/compression=ZSTD-16               25.1MB/s ± 1%  25.5MB/s ± 1%  +1.82%  (p=0.000 n=9+9)
Writer/format=(Pebble,v2)/block=4.0_K/filter=false/compression=ZSTD-16              21.5MB/s ± 2%  21.6MB/s ± 2%    ~     (p=0.171 n=10+10)
Writer/format=(Pebble,v2)/block=32_K/filter=true/compression=ZSTD-16                29.7MB/s ± 1%  30.0MB/s ± 2%    ~     (p=0.239 n=10+10)
Writer/format=(Pebble,v2)/block=32_K/filter=false/compression=ZSTD-16               23.1MB/s ± 1%  23.3MB/s ± 1%  +0.80%  (p=0.024 n=10+10)
Writer/format=(Pebble,v3)/block=4.0_K/filter=true/compression=ZSTD-16               23.8MB/s ± 1%  23.9MB/s ± 2%    ~     (p=0.140 n=8+10)
Writer/format=(Pebble,v3)/block=4.0_K/filter=false/compression=ZSTD-16              20.4MB/s ± 3%  20.6MB/s ± 1%    ~     (p=0.127 n=10+9)
Writer/format=(Pebble,v3)/block=32_K/filter=true/compression=ZSTD-16                28.8MB/s ± 1%  28.8MB/s ± 2%    ~     (p=0.987 n=10+10)
Writer/format=(Pebble,v3)/block=32_K/filter=false/compression=ZSTD-16               22.7MB/s ± 2%  22.3MB/s ± 2%  -1.49%  (p=0.010 n=10+10)
WriterWithVersions/format=(Pebble,v2)/block=4.0_K/filter=true/compression=ZSTD-16   16.2MB/s ± 2%  16.3MB/s ± 1%    ~     (p=0.304 n=10+8)
WriterWithVersions/format=(Pebble,v2)/block=4.0_K/filter=false/compression=ZSTD-16  14.9MB/s ± 2%  14.9MB/s ± 1%    ~     (p=0.456 n=10+9)
WriterWithVersions/format=(Pebble,v2)/block=32_K/filter=true/compression=ZSTD-16    19.1MB/s ± 2%  19.2MB/s ± 1%    ~     (p=0.324 n=10+10)
WriterWithVersions/format=(Pebble,v2)/block=32_K/filter=false/compression=ZSTD-16   16.9MB/s ± 1%  16.9MB/s ± 2%    ~     (p=0.616 n=10+10)
WriterWithVersions/format=(Pebble,v3)/block=4.0_K/filter=true/compression=ZSTD-16   16.5MB/s ± 2%  16.4MB/s ± 1%    ~     (p=0.051 n=9+10)
WriterWithVersions/format=(Pebble,v3)/block=4.0_K/filter=false/compression=ZSTD-16  15.4MB/s ± 1%  15.4MB/s ± 1%    ~     (p=0.494 n=10+10)
WriterWithVersions/format=(Pebble,v3)/block=32_K/filter=true/compression=ZSTD-16    21.0MB/s ± 1%  20.9MB/s ± 3%    ~     (p=0.616 n=10+10)
WriterWithVersions/format=(Pebble,v3)/block=32_K/filter=false/compression=ZSTD-16   19.9MB/s ± 2%  19.7MB/s ± 2%    ~     (p=0.086 n=10+10)
```

Touches #1854.