### PR TITLE
replay: add option to apply subset of a workload

### DIFF
--- a/cmd/pebble/replay.go
+++ b/cmd/pebble/replay.go
@@ -45,6 +45,8 @@ func initReplayCmd() *cobra.Command {
 		&c.name, "name", "", "the name of the workload being replayed")
 	cmd.Flags().VarPF(
 		&c.pacer, "pacer", "p", "the pacer to use: unpaced, reference-ramp, or fixed-ramp=N")
+	cmd.Flags().Uint64Var(
+		&c.maxWritesMB, "max-writes", 0, "the maximum volume of writes (MB) to apply, with 0 denoting unlimited")
 	cmd.Flags().StringVar(
 		&c.optionsString, "options", "", "Pebble options to override, in the OPTIONS ini format but with any whitespace as field delimiters instead of newlines")
 	cmd.Flags().StringVar(
@@ -61,6 +63,7 @@ type replayConfig struct {
 	pacer            pacerFlag
 	runDir           string
 	count            int
+	maxWritesMB      uint64
 	streamLogs       bool
 	ignoreCheckpoint bool
 	optionsString    string
@@ -92,6 +95,9 @@ func (c *replayConfig) runOnce(stdout io.Writer, workloadPath string) error {
 		WorkloadPath: workloadPath,
 		Pacer:        c.pacer,
 		Opts:         &pebble.Options{},
+	}
+	if c.maxWritesMB > 0 {
+		r.MaxWriteBytes = c.maxWritesMB * (1 << 20)
 	}
 	if err := c.initRunDir(r); err != nil {
 		return err

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -537,6 +537,10 @@ func (r *Runner) applyWorkloadSteps(ctx context.Context) error {
 			if err := step.flushBatch.Commit(&pebble.WriteOptions{Sync: false}); err != nil {
 				return err
 			}
+			_, err := r.d.AsyncFlush()
+			if err != nil {
+				return err
+			}
 			r.stepsApplied <- step
 		case ingestStepKind:
 			if err := r.d.Ingest(step.tablesToIngest); err != nil {

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/datatest"
+	"github.com/cockroachdb/pebble/internal/humanize"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/rangekey"
@@ -131,10 +132,11 @@ func runReplayTest(t *testing.T, path string) {
 			ct.WaitForInflightCompactionsToEqual(target)
 			return ""
 		case "wait":
-			if _, err := r.Wait(); err != nil {
+			m, err := r.Wait()
+			if err != nil {
 				return err.Error()
 			}
-			return ""
+			return fmt.Sprintf("replayed %s in writes", humanize.Uint64(m.WriteBytes))
 		case "close":
 			if err := r.Close(); err != nil {
 				return err.Error()

--- a/replay/testdata/replay
+++ b/replay/testdata/replay
@@ -85,6 +85,7 @@ replay simple unpaced
 
 wait
 ----
+replayed 42 B in writes
 
 # NB: The file sizes are non-deterministic after replay (because compactions are
 # nondeterministic). We don't `tree` here as a result.

--- a/replay/testdata/replay_paced
+++ b/replay/testdata/replay_paced
@@ -39,6 +39,7 @@ wait-for-compactions
 
 wait
 ----
+replayed 42 B in writes
 
 scan-keys
 ----


### PR DESCRIPTION
Add a `--max-writes` flag to the cmd/pebble replay command that limits the amount of a workload to replay by the configured MB. This allows us to collect large workloads and apply a smaller subset at replay time if the full workload is unnecessary.