### PR TITLE
deps: update github.com/cespare/xxhash to v2.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cockroachdb/pebble
 require (
 	github.com/DataDog/zstd v1.4.5
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2
-	github.com/cespare/xxhash/v2 v2.1.2
+	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/cockroachdb/datadriven v1.0.2
 	github.com/cockroachdb/errors v1.8.1
 	github.com/cockroachdb/redact v1.0.8

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,9 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=


### PR DESCRIPTION
Pull in the latest version of xxhash.

Benchmarks show a slight performance improvement for Pebblev2 tables. A very slight regression is observed for v3 tables when using larger block sizes.

```
 name                                                                                                           old time/op    new time/op    delta
Writer/format=(Pebble,v2)/block=4.0_K/filter=true/compression=NoCompression/checksum=xxhash64-16                 67.7ms ± 3%    64.8ms ± 2%  -4.28%  (p=0.000 n=10+9)
Writer/format=(Pebble,v2)/block=4.0_K/filter=true/compression=Snappy/checksum=xxhash64-16                        81.5ms ± 2%    78.1ms ± 1%  -4.19%  (p=0.000 n=10+10)
Writer/format=(Pebble,v2)/block=4.0_K/filter=true/compression=ZSTD/checksum=xxhash64-16                           239ms ± 1%     234ms ± 1%  -2.11%  (p=0.000 n=10+10)
Writer/format=(Pebble,v2)/block=4.0_K/filter=false/compression=NoCompression/checksum=xxhash64-16                48.6ms ± 2%    47.6ms ± 3%  -2.17%  (p=0.015 n=10+10)
Writer/format=(Pebble,v2)/block=4.0_K/filter=false/compression=Snappy/checksum=xxhash64-16                       62.6ms ± 2%    61.6ms ± 3%    ~     (p=0.063 n=10+10)
Writer/format=(Pebble,v2)/block=4.0_K/filter=false/compression=ZSTD/checksum=xxhash64-16                          223ms ± 1%     217ms ± 2%  -2.46%  (p=0.000 n=9+10)
Writer/format=(Pebble,v2)/block=32_K/filter=true/compression=NoCompression/checksum=xxhash64-16                  67.1ms ± 0%    66.2ms ± 1%  -1.26%  (p=0.002 n=9+9)
Writer/format=(Pebble,v2)/block=32_K/filter=true/compression=Snappy/checksum=xxhash64-16                         77.3ms ± 1%    76.7ms ± 2%    ~     (p=0.237 n=8+10)
Writer/format=(Pebble,v2)/block=32_K/filter=true/compression=ZSTD/checksum=xxhash64-16                            115ms ± 2%     113ms ± 2%  -1.65%  (p=0.004 n=10+10)
Writer/format=(Pebble,v2)/block=32_K/filter=false/compression=NoCompression/checksum=xxhash64-16                 47.0ms ± 2%    45.8ms ± 2%  -2.64%  (p=0.000 n=9+10)
Writer/format=(Pebble,v2)/block=32_K/filter=false/compression=Snappy/checksum=xxhash64-16                        56.4ms ± 1%    55.3ms ± 1%  -2.03%  (p=0.000 n=10+9)
Writer/format=(Pebble,v2)/block=32_K/filter=false/compression=ZSTD/checksum=xxhash64-16                          93.3ms ± 2%    92.4ms ± 2%    ~     (p=0.052 n=10+10)
Writer/format=(Pebble,v3)/block=4.0_K/filter=true/compression=NoCompression/checksum=xxhash64-16                 75.1ms ± 2%    74.6ms ± 1%    ~     (p=0.353 n=10+10)
Writer/format=(Pebble,v3)/block=4.0_K/filter=true/compression=Snappy/checksum=xxhash64-16                        87.8ms ± 3%    87.5ms ± 3%    ~     (p=0.579 n=10+10)
Writer/format=(Pebble,v3)/block=4.0_K/filter=true/compression=ZSTD/checksum=xxhash64-16                           252ms ± 2%     248ms ± 1%  -1.57%  (p=0.001 n=10+9)
Writer/format=(Pebble,v3)/block=4.0_K/filter=false/compression=NoCompression/checksum=xxhash64-16                52.8ms ± 2%    52.7ms ± 3%    ~     (p=0.720 n=9+10)
Writer/format=(Pebble,v3)/block=4.0_K/filter=false/compression=Snappy/checksum=xxhash64-16                       67.0ms ± 2%    66.3ms ± 2%    ~     (p=0.123 n=10+10)
Writer/format=(Pebble,v3)/block=4.0_K/filter=false/compression=ZSTD/checksum=xxhash64-16                          229ms ± 2%     228ms ± 1%    ~     (p=0.089 n=10+10)
Writer/format=(Pebble,v3)/block=32_K/filter=true/compression=NoCompression/checksum=xxhash64-16                  70.9ms ± 1%    71.3ms ± 3%    ~     (p=0.447 n=9+10)
Writer/format=(Pebble,v3)/block=32_K/filter=true/compression=Snappy/checksum=xxhash64-16                         80.9ms ± 3%    82.1ms ± 3%  +1.51%  (p=0.023 n=10+10)
Writer/format=(Pebble,v3)/block=32_K/filter=true/compression=ZSTD/checksum=xxhash64-16                            119ms ± 2%     119ms ± 2%    ~     (p=0.218 n=10+10)
Writer/format=(Pebble,v3)/block=32_K/filter=false/compression=NoCompression/checksum=xxhash64-16                 49.6ms ± 2%    49.2ms ± 3%    ~     (p=0.095 n=10+9)
Writer/format=(Pebble,v3)/block=32_K/filter=false/compression=Snappy/checksum=xxhash64-16                        58.5ms ± 2%    59.3ms ± 1%  +1.45%  (p=0.001 n=10+8)
Writer/format=(Pebble,v3)/block=32_K/filter=false/compression=ZSTD/checksum=xxhash64-16                          97.0ms ± 3%    96.8ms ± 2%    ~     (p=0.968 n=9+10)
WriterWithVersions/format=(Pebble,v2)/block=4.0_K/filter=true/compression=NoCompression/checksum=xxhash64-16     83.2ms ± 2%    80.7ms ± 3%  -2.98%  (p=0.001 n=10+10)
WriterWithVersions/format=(Pebble,v2)/block=4.0_K/filter=true/compression=Snappy/checksum=xxhash64-16            94.7ms ± 2%    94.2ms ± 3%    ~     (p=0.278 n=9+10)
WriterWithVersions/format=(Pebble,v2)/block=4.0_K/filter=true/compression=ZSTD/checksum=xxhash64-16               255ms ± 2%     252ms ± 1%    ~     (p=0.173 n=10+8)
WriterWithVersions/format=(Pebble,v2)/block=4.0_K/filter=false/compression=NoCompression/checksum=xxhash64-16    62.5ms ± 2%    62.0ms ± 2%    ~     (p=0.315 n=9+10)
WriterWithVersions/format=(Pebble,v2)/block=4.0_K/filter=false/compression=Snappy/checksum=xxhash64-16           74.9ms ± 2%    75.0ms ± 0%    ~     (p=0.211 n=10+9)
WriterWithVersions/format=(Pebble,v2)/block=4.0_K/filter=false/compression=ZSTD/checksum=xxhash64-16              236ms ± 2%     234ms ± 1%    ~     (p=0.113 n=10+9)
WriterWithVersions/format=(Pebble,v2)/block=32_K/filter=true/compression=NoCompression/checksum=xxhash64-16      77.6ms ± 1%    77.0ms ± 1%  -0.76%  (p=0.027 n=10+8)
WriterWithVersions/format=(Pebble,v2)/block=32_K/filter=true/compression=Snappy/checksum=xxhash64-16             90.9ms ± 1%    89.6ms ± 2%  -1.46%  (p=0.001 n=9+10)
WriterWithVersions/format=(Pebble,v2)/block=32_K/filter=true/compression=ZSTD/checksum=xxhash64-16                126ms ± 1%     125ms ± 2%    ~     (p=0.095 n=9+10)
WriterWithVersions/format=(Pebble,v2)/block=32_K/filter=false/compression=NoCompression/checksum=xxhash64-16     58.2ms ± 0%    58.1ms ± 2%    ~     (p=0.356 n=9+10)
WriterWithVersions/format=(Pebble,v2)/block=32_K/filter=false/compression=Snappy/checksum=xxhash64-16            71.7ms ± 1%    71.0ms ± 2%  -0.94%  (p=0.006 n=8+9)
WriterWithVersions/format=(Pebble,v2)/block=32_K/filter=false/compression=ZSTD/checksum=xxhash64-16               106ms ± 2%     107ms ± 2%  +0.87%  (p=0.043 n=10+9)
WriterWithVersions/format=(Pebble,v3)/block=4.0_K/filter=true/compression=NoCompression/checksum=xxhash64-16      112ms ± 4%     113ms ± 1%    ~     (p=0.156 n=10+9)
WriterWithVersions/format=(Pebble,v3)/block=4.0_K/filter=true/compression=Snappy/checksum=xxhash64-16             129ms ± 1%     131ms ± 1%  +1.34%  (p=0.001 n=10+9)
WriterWithVersions/format=(Pebble,v3)/block=4.0_K/filter=true/compression=ZSTD/checksum=xxhash64-16               315ms ± 1%     314ms ± 1%    ~     (p=0.053 n=10+9)
WriterWithVersions/format=(Pebble,v3)/block=4.0_K/filter=false/compression=NoCompression/checksum=xxhash64-16    92.8ms ± 3%    93.3ms ± 2%    ~     (p=0.315 n=10+10)
WriterWithVersions/format=(Pebble,v3)/block=4.0_K/filter=false/compression=Snappy/checksum=xxhash64-16            110ms ± 2%     111ms ± 1%    ~     (p=0.133 n=10+9)
WriterWithVersions/format=(Pebble,v3)/block=4.0_K/filter=false/compression=ZSTD/checksum=xxhash64-16              294ms ± 1%     293ms ± 1%    ~     (p=0.218 n=10+10)
WriterWithVersions/format=(Pebble,v3)/block=32_K/filter=true/compression=NoCompression/checksum=xxhash64-16       108ms ± 3%     107ms ± 2%    ~     (p=0.762 n=10+8)
WriterWithVersions/format=(Pebble,v3)/block=32_K/filter=true/compression=Snappy/checksum=xxhash64-16              128ms ± 1%     128ms ± 3%    ~     (p=1.000 n=10+10)
WriterWithVersions/format=(Pebble,v3)/block=32_K/filter=true/compression=ZSTD/checksum=xxhash64-16                174ms ± 1%     172ms ± 2%    ~     (p=0.075 n=10+10)
WriterWithVersions/format=(Pebble,v3)/block=32_K/filter=false/compression=NoCompression/checksum=xxhash64-16     87.6ms ± 3%    87.9ms ± 1%    ~     (p=0.315 n=10+8)
WriterWithVersions/format=(Pebble,v3)/block=32_K/filter=false/compression=Snappy/checksum=xxhash64-16             107ms ± 1%     108ms ± 2%  +0.88%  (p=0.043 n=10+8)
WriterWithVersions/format=(Pebble,v3)/block=32_K/filter=false/compression=ZSTD/checksum=xxhash64-16               152ms ± 1%     153ms ± 1%    ~     (p=0.436 n=9+9)

name                                                                                                           old speed      new speed      delta
Writer/format=(Pebble,v2)/block=4.0_K/filter=true/compression=NoCompression/checksum=xxhash64-16                584MB/s ± 3%   610MB/s ± 1%  +4.44%  (p=0.000 n=10+9)
Writer/format=(Pebble,v2)/block=4.0_K/filter=true/compression=Snappy/checksum=xxhash64-16                       135MB/s ± 2%   141MB/s ± 1%  +4.36%  (p=0.000 n=10+10)
Writer/format=(Pebble,v2)/block=4.0_K/filter=true/compression=ZSTD/checksum=xxhash64-16                        25.1MB/s ± 1%  25.7MB/s ± 1%  +2.16%  (p=0.000 n=10+10)
Writer/format=(Pebble,v2)/block=4.0_K/filter=false/compression=NoCompression/checksum=xxhash64-16               787MB/s ± 2%   805MB/s ± 3%  +2.25%  (p=0.015 n=10+10)
Writer/format=(Pebble,v2)/block=4.0_K/filter=false/compression=Snappy/checksum=xxhash64-16                      156MB/s ± 2%   159MB/s ± 3%    ~     (p=0.063 n=10+10)
Writer/format=(Pebble,v2)/block=4.0_K/filter=false/compression=ZSTD/checksum=xxhash64-16                       21.3MB/s ± 1%  21.9MB/s ± 2%  +2.54%  (p=0.000 n=9+10)
Writer/format=(Pebble,v2)/block=32_K/filter=true/compression=NoCompression/checksum=xxhash64-16                 582MB/s ± 0%   589MB/s ± 1%  +1.28%  (p=0.002 n=9+9)
Writer/format=(Pebble,v2)/block=32_K/filter=true/compression=Snappy/checksum=xxhash64-16                        104MB/s ± 1%   105MB/s ± 2%    ~     (p=0.237 n=8+10)
Writer/format=(Pebble,v2)/block=32_K/filter=true/compression=ZSTD/checksum=xxhash64-16                         29.8MB/s ± 2%  30.3MB/s ± 2%  +1.67%  (p=0.005 n=10+10)
Writer/format=(Pebble,v2)/block=32_K/filter=false/compression=NoCompression/checksum=xxhash64-16                803MB/s ± 2%   825MB/s ± 2%  +2.72%  (p=0.000 n=9+10)
Writer/format=(Pebble,v2)/block=32_K/filter=false/compression=Snappy/checksum=xxhash64-16                       120MB/s ± 1%   123MB/s ± 1%  +2.08%  (p=0.000 n=10+9)
Writer/format=(Pebble,v2)/block=32_K/filter=false/compression=ZSTD/checksum=xxhash64-16                        23.3MB/s ± 2%  23.5MB/s ± 2%  +0.90%  (p=0.045 n=10+10)
Writer/format=(Pebble,v3)/block=4.0_K/filter=true/compression=NoCompression/checksum=xxhash64-16                541MB/s ± 2%   544MB/s ± 2%    ~     (p=0.353 n=10+10)
Writer/format=(Pebble,v3)/block=4.0_K/filter=true/compression=Snappy/checksum=xxhash64-16                       126MB/s ± 3%   126MB/s ± 3%    ~     (p=0.579 n=10+10)
Writer/format=(Pebble,v3)/block=4.0_K/filter=true/compression=ZSTD/checksum=xxhash64-16                        23.8MB/s ± 2%  24.2MB/s ± 1%  +1.59%  (p=0.001 n=10+9)
Writer/format=(Pebble,v3)/block=4.0_K/filter=false/compression=NoCompression/checksum=xxhash64-16               746MB/s ± 2%   747MB/s ± 3%    ~     (p=0.720 n=9+10)
Writer/format=(Pebble,v3)/block=4.0_K/filter=false/compression=Snappy/checksum=xxhash64-16                      146MB/s ± 2%   148MB/s ± 2%    ~     (p=0.123 n=10+10)
Writer/format=(Pebble,v3)/block=4.0_K/filter=false/compression=ZSTD/checksum=xxhash64-16                       20.6MB/s ± 2%  20.8MB/s ± 1%    ~     (p=0.093 n=10+10)
Writer/format=(Pebble,v3)/block=32_K/filter=true/compression=NoCompression/checksum=xxhash64-16                 564MB/s ± 1%   561MB/s ± 3%    ~     (p=0.447 n=9+10)
Writer/format=(Pebble,v3)/block=32_K/filter=true/compression=Snappy/checksum=xxhash64-16                        100MB/s ± 3%    98MB/s ± 3%  -1.49%  (p=0.023 n=10+10)
Writer/format=(Pebble,v3)/block=32_K/filter=true/compression=ZSTD/checksum=xxhash64-16                         29.1MB/s ± 2%  28.9MB/s ± 2%    ~     (p=0.225 n=10+10)
Writer/format=(Pebble,v3)/block=32_K/filter=false/compression=NoCompression/checksum=xxhash64-16                781MB/s ± 2%   787MB/s ± 2%    ~     (p=0.095 n=10+9)
Writer/format=(Pebble,v3)/block=32_K/filter=false/compression=Snappy/checksum=xxhash64-16                       116MB/s ± 2%   115MB/s ± 1%  -1.43%  (p=0.001 n=10+8)
Writer/format=(Pebble,v3)/block=32_K/filter=false/compression=ZSTD/checksum=xxhash64-16                        22.7MB/s ± 3%  22.8MB/s ± 2%    ~     (p=0.951 n=9+10)
WriterWithVersions/format=(Pebble,v2)/block=4.0_K/filter=true/compression=NoCompression/checksum=xxhash64-16    509MB/s ± 2%   524MB/s ± 3%  +3.07%  (p=0.001 n=10+10)
WriterWithVersions/format=(Pebble,v2)/block=4.0_K/filter=true/compression=Snappy/checksum=xxhash64-16          83.4MB/s ± 2%  83.9MB/s ± 3%    ~     (p=0.268 n=9+10)
WriterWithVersions/format=(Pebble,v2)/block=4.0_K/filter=true/compression=ZSTD/checksum=xxhash64-16            16.3MB/s ± 2%  16.4MB/s ± 1%    ~     (p=0.166 n=10+8)
WriterWithVersions/format=(Pebble,v2)/block=4.0_K/filter=false/compression=NoCompression/checksum=xxhash64-16   667MB/s ± 2%   672MB/s ± 2%    ~     (p=0.315 n=9+10)
WriterWithVersions/format=(Pebble,v2)/block=4.0_K/filter=false/compression=Snappy/checksum=xxhash64-16         97.1MB/s ± 2%  97.0MB/s ± 0%    ~     (p=0.219 n=10+9)
WriterWithVersions/format=(Pebble,v2)/block=4.0_K/filter=false/compression=ZSTD/checksum=xxhash64-16           14.9MB/s ± 2%  15.0MB/s ± 1%    ~     (p=0.117 n=10+9)
WriterWithVersions/format=(Pebble,v2)/block=32_K/filter=true/compression=NoCompression/checksum=xxhash64-16     535MB/s ± 1%   539MB/s ± 1%  +0.76%  (p=0.027 n=10+8)
WriterWithVersions/format=(Pebble,v2)/block=32_K/filter=true/compression=Snappy/checksum=xxhash64-16           73.2MB/s ± 1%  74.3MB/s ± 2%  +1.50%  (p=0.001 n=9+10)
WriterWithVersions/format=(Pebble,v2)/block=32_K/filter=true/compression=ZSTD/checksum=xxhash64-16             19.2MB/s ± 1%  19.4MB/s ± 2%    ~     (p=0.082 n=9+10)
WriterWithVersions/format=(Pebble,v2)/block=32_K/filter=false/compression=NoCompression/checksum=xxhash64-16    702MB/s ± 0%   704MB/s ± 2%    ~     (p=0.356 n=9+10)
WriterWithVersions/format=(Pebble,v2)/block=32_K/filter=false/compression=Snappy/checksum=xxhash64-16          84.2MB/s ± 1%  85.0MB/s ± 2%  +0.96%  (p=0.006 n=8+9)
WriterWithVersions/format=(Pebble,v2)/block=32_K/filter=false/compression=ZSTD/checksum=xxhash64-16            17.0MB/s ± 2%  16.8MB/s ± 2%  -0.85%  (p=0.046 n=10+9)
WriterWithVersions/format=(Pebble,v3)/block=4.0_K/filter=true/compression=NoCompression/checksum=xxhash64-16    409MB/s ± 4%   407MB/s ± 1%    ~     (p=0.156 n=10+9)
WriterWithVersions/format=(Pebble,v3)/block=4.0_K/filter=true/compression=Snappy/checksum=xxhash64-16          82.2MB/s ± 1%  81.1MB/s ± 1%  -1.32%  (p=0.001 n=10+9)
WriterWithVersions/format=(Pebble,v3)/block=4.0_K/filter=true/compression=ZSTD/checksum=xxhash64-16            16.7MB/s ± 1%  16.7MB/s ± 1%    ~     (p=0.054 n=10+9)
WriterWithVersions/format=(Pebble,v3)/block=4.0_K/filter=false/compression=NoCompression/checksum=xxhash64-16   487MB/s ± 3%   484MB/s ± 3%    ~     (p=0.315 n=10+10)
WriterWithVersions/format=(Pebble,v3)/block=4.0_K/filter=false/compression=Snappy/checksum=xxhash64-16         90.6MB/s ± 2%  90.1MB/s ± 1%    ~     (p=0.118 n=10+9)
WriterWithVersions/format=(Pebble,v3)/block=4.0_K/filter=false/compression=ZSTD/checksum=xxhash64-16           15.7MB/s ± 1%  15.8MB/s ± 1%    ~     (p=0.197 n=10+10)
WriterWithVersions/format=(Pebble,v3)/block=32_K/filter=true/compression=NoCompression/checksum=xxhash64-16     424MB/s ± 3%   424MB/s ± 2%    ~     (p=0.762 n=10+8)
WriterWithVersions/format=(Pebble,v3)/block=32_K/filter=true/compression=Snappy/checksum=xxhash64-16           75.2MB/s ± 1%  74.8MB/s ± 3%    ~     (p=1.000 n=10+10)
WriterWithVersions/format=(Pebble,v3)/block=32_K/filter=true/compression=ZSTD/checksum=xxhash64-16             21.5MB/s ± 1%  21.7MB/s ± 2%    ~     (p=0.072 n=10+10)
WriterWithVersions/format=(Pebble,v3)/block=32_K/filter=false/compression=NoCompression/checksum=xxhash64-16    513MB/s ± 3%   511MB/s ± 1%    ~     (p=0.315 n=10+8)
WriterWithVersions/format=(Pebble,v3)/block=32_K/filter=false/compression=Snappy/checksum=xxhash64-16          84.2MB/s ± 1%  83.4MB/s ± 2%  -0.88%  (p=0.043 n=10+8)
WriterWithVersions/format=(Pebble,v3)/block=32_K/filter=false/compression=ZSTD/checksum=xxhash64-16            20.4MB/s ± 1%  20.3MB/s ± 1%    ~     (p=0.436 n=9+9)
```

Touches #1854.