### PR TITLE
base: remove vfs dependency

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -9,7 +9,6 @@ import (
 	"os"
 
 	"github.com/cockroachdb/errors/oserror"
-	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/atomicfs"
@@ -223,7 +222,7 @@ func (d *DB) Checkpoint(
 
 	{
 		// Link or copy the OPTIONS.
-		srcPath := base.MakeFilepath(fs, d.dirname, fileTypeOptions, optionsFileNum)
+		srcPath := vfs.MakeFilepath(fs, d.dirname, fileTypeOptions, optionsFileNum)
 		destPath := fs.PathJoin(destDir, fs.PathBase(srcPath))
 		ckErr = vfs.LinkOrCopy(fs, srcPath, destPath)
 		if ckErr != nil {
@@ -270,7 +269,7 @@ func (d *DB) Checkpoint(
 				continue
 			}
 
-			srcPath := base.MakeFilepath(fs, d.dirname, fileTypeTable, f.FileNum)
+			srcPath := vfs.MakeFilepath(fs, d.dirname, fileTypeTable, f.FileNum)
 			destPath := fs.PathJoin(destDir, fs.PathBase(srcPath))
 			ckErr = vfs.LinkOrCopy(fs, srcPath, destPath)
 			if ckErr != nil {
@@ -292,7 +291,7 @@ func (d *DB) Checkpoint(
 		if logNum == 0 {
 			continue
 		}
-		srcPath := base.MakeFilepath(fs, d.walDirname, fileTypeLog, logNum)
+		srcPath := vfs.MakeFilepath(fs, d.walDirname, fileTypeLog, logNum)
 		destPath := fs.PathJoin(destDir, fs.PathBase(srcPath))
 		ckErr = vfs.Copy(fs, srcPath, destPath)
 		if ckErr != nil {
@@ -328,7 +327,7 @@ func (d *DB) writeCheckpointManifest(
 	// If some files are excluded from the checkpoint, also append a block that
 	// records those files as deleted.
 	if err := func() error {
-		srcPath := base.MakeFilepath(fs, d.dirname, fileTypeManifest, manifestFileNum)
+		srcPath := vfs.MakeFilepath(fs, d.dirname, fileTypeManifest, manifestFileNum)
 		destPath := fs.PathJoin(destDirPath, fs.PathBase(srcPath))
 		src, err := fs.Open(srcPath, vfs.SequentialReadsOption)
 		if err != nil {

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -217,7 +217,7 @@ func TestCheckpointCompaction(t *testing.T) {
 			tableInfos, _ := d2.SSTables()
 			for _, tables := range tableInfos {
 				for _, tbl := range tables {
-					if _, err := fs.Stat(base.MakeFilepath(fs, dir, base.FileTypeTable, tbl.FileNum)); err != nil {
+					if _, err := fs.Stat(vfs.MakeFilepath(fs, dir, base.FileTypeTable, tbl.FileNum)); err != nil {
 						t.Error(err)
 						return
 					}

--- a/cleaner.go
+++ b/cleaner.go
@@ -4,13 +4,13 @@
 
 package pebble
 
-import "github.com/cockroachdb/pebble/internal/base"
+import "github.com/cockroachdb/pebble/vfs"
 
-// Cleaner exports the base.Cleaner type.
-type Cleaner = base.Cleaner
+// Cleaner aliases the vfs.Cleaner type.
+type Cleaner = vfs.Cleaner
 
-// DeleteCleaner exports the base.DeleteCleaner type.
-type DeleteCleaner = base.DeleteCleaner
+// DeleteCleaner aliases the vfs.DeleteCleaner type.
+type DeleteCleaner = vfs.DeleteCleaner
 
-// ArchiveCleaner exports the base.ArchiveCleaner type.
-type ArchiveCleaner = base.ArchiveCleaner
+// ArchiveCleaner aliases the vfs.ArchiveCleaner type.
+type ArchiveCleaner = vfs.ArchiveCleaner

--- a/cmd/pebble/replay.go
+++ b/cmd/pebble/replay.go
@@ -174,7 +174,7 @@ func (c *replayConfig) initOptions(r *replay.Runner) error {
 		var optionsFilepath string
 		for _, l := range ls {
 			path := r.WorkloadFS.PathJoin(r.WorkloadPath, "checkpoint", l)
-			typ, _, ok := base.ParseFilename(r.WorkloadFS, path)
+			typ, _, ok := vfs.ParseFilepath(r.WorkloadFS, path)
 			if ok && typ == base.FileTypeOptions {
 				optionsFilepath = path
 			}

--- a/compaction.go
+++ b/compaction.go
@@ -3061,7 +3061,7 @@ func (d *DB) scanObsoleteFiles(list []string) {
 	var obsoleteOptions []fileInfo
 
 	for _, filename := range list {
-		fileType, fileNum, ok := base.ParseFilename(d.opts.FS, filename)
+		fileType, fileNum, ok := vfs.ParseFilepath(d.opts.FS, filename)
 		if !ok {
 			continue
 		}
@@ -3270,7 +3270,7 @@ func (d *DB) doDeleteObsoleteFiles(jobID int) {
 		{fileTypeManifest, obsoleteManifests},
 		{fileTypeOptions, obsoleteOptions},
 	}
-	_, noRecycle := d.opts.Cleaner.(base.NeedsFileContents)
+	_, noRecycle := d.opts.Cleaner.(vfs.NeedsFileContents)
 	filesToDelete := make([]obsoleteFile, 0, len(files))
 	for _, f := range files {
 		// We sort to make the order of deletions deterministic, which is nice for
@@ -3319,7 +3319,7 @@ func (d *DB) paceAndDeleteObsoleteFiles(jobID int, files []obsoleteFile) {
 	}
 
 	for _, of := range files {
-		path := base.MakeFilepath(d.opts.FS, of.dir, of.fileType, of.fileNum)
+		path := vfs.MakeFilepath(d.opts.FS, of.dir, of.fileType, of.fileNum)
 		if of.fileType == fileTypeTable {
 			_ = pacer.maybeThrottle(of.fileSize)
 			d.mu.Lock()

--- a/db.go
+++ b/db.go
@@ -2028,7 +2028,7 @@ func (d *DB) recycleWAL() (newLogNum FileNum, prevLogSize uint64) {
 	}
 	d.mu.Unlock()
 
-	newLogName := base.MakeFilepath(d.opts.FS, d.walDirname, fileTypeLog, newLogNum)
+	newLogName := vfs.MakeFilepath(d.opts.FS, d.walDirname, fileTypeLog, newLogNum)
 
 	// Try to use a recycled log file. Recycling log files is an important
 	// performance optimization as it is faster to sync a file that has
@@ -2042,12 +2042,12 @@ func (d *DB) recycleWAL() (newLogNum FileNum, prevLogSize uint64) {
 	if err == nil {
 		recycleLog, recycleOK = d.logRecycler.peek()
 		if recycleOK {
-			recycleLogName := base.MakeFilepath(d.opts.FS, d.walDirname, fileTypeLog, recycleLog.fileNum)
+			recycleLogName := vfs.MakeFilepath(d.opts.FS, d.walDirname, fileTypeLog, recycleLog.fileNum)
 			newLogFile, err = d.opts.FS.ReuseForWrite(recycleLogName, newLogName)
-			base.MustExist(d.opts.FS, newLogName, d.opts.Logger, err)
+			vfs.MustExist(d.opts.FS, newLogName, d.opts.Logger, err)
 		} else {
 			newLogFile, err = d.opts.FS.Create(newLogName)
-			base.MustExist(d.opts.FS, newLogName, d.opts.Logger, err)
+			vfs.MustExist(d.opts.FS, newLogName, d.opts.Logger, err)
 		}
 	}
 

--- a/db_test.go
+++ b/db_test.go
@@ -375,7 +375,7 @@ func TestLargeBatch(t *testing.T) {
 		return d.mu.log.queue[len(d.mu.log.queue)-1].fileNum
 	}
 	fileSize := func(fileNum FileNum) int64 {
-		info, err := d.opts.FS.Stat(base.MakeFilepath(d.opts.FS, "", fileTypeLog, fileNum))
+		info, err := d.opts.FS.Stat(vfs.MakeFilepath(d.opts.FS, "", fileTypeLog, fileNum))
 		require.NoError(t, err)
 		return info.Size()
 	}
@@ -1007,7 +1007,7 @@ func TestRollManifest(t *testing.T) {
 
 	var manifests []string
 	for _, filename := range files {
-		fileType, _, ok := base.ParseFilename(d.opts.FS, filename)
+		fileType, _, ok := vfs.ParseFilepath(d.opts.FS, filename)
 		if !ok {
 			continue
 		}

--- a/filenames.go
+++ b/filenames.go
@@ -34,8 +34,8 @@ const (
 // use. Newer versions of Pebble running newer format major versions do
 // not use the CURRENT file. See setCurrentFunc in version_set.go.
 func setCurrentFile(dirname string, fs vfs.FS, fileNum FileNum) error {
-	newFilename := base.MakeFilepath(fs, dirname, fileTypeCurrent, fileNum)
-	oldFilename := base.MakeFilepath(fs, dirname, fileTypeTemp, fileNum)
+	newFilename := vfs.MakeFilepath(fs, dirname, fileTypeCurrent, fileNum)
+	oldFilename := vfs.MakeFilepath(fs, dirname, fileTypeTemp, fileNum)
 	fs.Remove(oldFilename)
 	f, err := fs.Create(oldFilename)
 	if err != nil {

--- a/filenames_test.go
+++ b/filenames_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
@@ -73,7 +72,7 @@ func allTempFiles(t *testing.T, fs vfs.FS) []string {
 	ls, err := fs.List("")
 	require.NoError(t, err)
 	for _, f := range ls {
-		ft, _, ok := base.ParseFilename(fs, f)
+		ft, _, ok := vfs.ParseFilepath(fs, f)
 		if ok && ft == fileTypeTemp {
 			files = append(files, f)
 		}

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -338,7 +338,7 @@ func TestIngestLink(t *testing.T) {
 					t.Fatalf("expected %d files, but found:\n%s", count, strings.Join(files, "\n"))
 				}
 				for j := range files {
-					ftype, fileNum, ok := base.ParseFilename(opts.FS, files[j])
+					ftype, fileNum, ok := vfs.ParseFilepath(opts.FS, files[j])
 					if !ok {
 						t.Fatalf("unable to parse filename: %s", files[j])
 					}
@@ -1674,7 +1674,7 @@ func TestIngestCleanup(t *testing.T) {
 			// Create the files in the VFS.
 			metaMap := make(map[base.FileNum]vfs.File)
 			for _, fn := range fns {
-				path := base.MakeFilepath(mem, "", base.FileTypeTable, fn)
+				path := vfs.MakeFilepath(mem, "", base.FileTypeTable, fn)
 				f, err := mem.Create(path)
 				metaMap[fn] = f
 				require.NoError(t, err)

--- a/internal/base/filenames.go
+++ b/internal/base/filenames.go
@@ -1,17 +1,9 @@
-// Copyright 2012 The LevelDB-Go and Pebble Authors. All rights reserved. Use
-// of this source code is governed by a BSD-style license that can be found in
-// the LICENSE file.
-
 package base
 
 import (
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/cockroachdb/errors/oserror"
-	"github.com/cockroachdb/pebble/vfs"
-	"github.com/cockroachdb/redact"
 )
 
 // FileNum is an internal DB identifier for a file.
@@ -58,14 +50,8 @@ func MakeFilename(fileType FileType, fileNum FileNum) string {
 	panic("unreachable")
 }
 
-// MakeFilepath builds a filepath from components.
-func MakeFilepath(fs vfs.FS, dirname string, fileType FileType, fileNum FileNum) string {
-	return fs.PathJoin(dirname, MakeFilename(fileType, fileNum))
-}
-
 // ParseFilename parses the components from a filename.
-func ParseFilename(fs vfs.FS, filename string) (fileType FileType, fileNum FileNum, ok bool) {
-	filename = fs.PathBase(filename)
+func ParseFilename(filename string) (fileType FileType, fileNum FileNum, ok bool) {
 	switch {
 	case filename == "CURRENT":
 		return FileTypeCurrent, 0, true
@@ -122,48 +108,4 @@ func parseFileNum(s string) (fileNum FileNum, ok bool) {
 		return fileNum, false
 	}
 	return FileNum(u), true
-}
-
-// A Fataler fatals a process with a message when called.
-type Fataler interface {
-	Fatalf(format string, args ...interface{})
-}
-
-// MustExist checks if err is an error indicating a file does not exist.
-// If it is, it lists the containing directory's files to annotate the error
-// with counts of the various types of files and invokes the provided fataler.
-// See cockroachdb/cockroach#56490.
-func MustExist(fs vfs.FS, filename string, fataler Fataler, err error) {
-	if err == nil || !oserror.IsNotExist(err) {
-		return
-	}
-
-	ls, lsErr := fs.List(fs.PathDir(filename))
-	if lsErr != nil {
-		// TODO(jackson): if oserror.IsNotExist(lsErr), the the data directory
-		// doesn't exist anymore. Another process likely deleted it before
-		// killing the process. We want to fatal the process, but without
-		// triggering error reporting like Sentry.
-		fataler.Fatalf("%s:\norig err: %s\nlist err: %s", redact.Safe(fs.PathBase(filename)), err, lsErr)
-	}
-	var total, unknown, tables, logs, manifests int
-	total = len(ls)
-	for _, f := range ls {
-		typ, _, ok := ParseFilename(fs, f)
-		if !ok {
-			unknown++
-			continue
-		}
-		switch typ {
-		case FileTypeTable:
-			tables++
-		case FileTypeLog:
-			logs++
-		case FileTypeManifest:
-			manifests++
-		}
-	}
-
-	fataler.Fatalf("%s:\n%s\ndirectory contains %d files, %d unknown, %d tables, %d logs, %d manifests",
-		fs.PathBase(filename), err, total, unknown, tables, logs, manifests)
 }

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -1102,7 +1102,7 @@ func (v *Version) CheckConsistency(dirname string, fs vfs.FS) error {
 	for level, files := range v.Levels {
 		iter := files.Iter()
 		for f := iter.First(); f != nil; f = iter.Next() {
-			path := base.MakeFilepath(fs, dirname, base.FileTypeTable, f.FileNum)
+			path := vfs.MakeFilepath(fs, dirname, base.FileTypeTable, f.FileNum)
 			info, err := fs.Stat(path)
 			if err != nil {
 				buf.WriteString("L%d: %s: %v\n")

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -396,7 +396,7 @@ func TestCheckConsistency(t *testing.T) {
 					if err != nil {
 						return err.Error()
 					}
-					path := base.MakeFilepath(mem, dir, base.FileTypeTable, m.FileNum)
+					path := vfs.MakeFilepath(mem, dir, base.FileTypeTable, m.FileNum)
 					_ = mem.Remove(path)
 					f, err := mem.Create(path)
 					if err != nil {

--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble"
-	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/errorfs"
 	"github.com/cockroachdb/pebble/internal/randvar"
 	"github.com/cockroachdb/pebble/internal/testkeys"
@@ -148,7 +147,7 @@ func testMetaRun(t *testing.T, runDir string, seed uint64, historyPath string) {
 	// keys at the trailing '@'.
 	opts.Comparer = testkeys.Comparer
 	// Use an archive cleaner to ease post-mortem debugging.
-	opts.Cleaner = base.ArchiveCleaner{}
+	opts.Cleaner = vfs.ArchiveCleaner{}
 
 	// Set up the filesystem to use for the test. Note that by default we use an
 	// in-memory FS.
@@ -156,7 +155,7 @@ func testMetaRun(t *testing.T, runDir string, seed uint64, historyPath string) {
 		opts.FS = vfs.Default
 		require.NoError(t, os.RemoveAll(opts.FS.PathJoin(runDir, "data")))
 	} else {
-		opts.Cleaner = base.ArchiveCleaner{}
+		opts.Cleaner = vfs.ArchiveCleaner{}
 		if testOpts.strictFS {
 			opts.FS = vfs.NewStrictMem()
 		} else {

--- a/objstorage/provider.go
+++ b/objstorage/provider.go
@@ -81,7 +81,7 @@ type Settings struct {
 	// Cleaner cleans obsolete files from the local filesystem.
 	//
 	// The default cleaner uses the DeleteCleaner.
-	FSCleaner base.Cleaner
+	FSCleaner vfs.Cleaner
 
 	// NoSyncOnClose decides whether the implementation will enforce a
 	// close-time synchronization (e.g., fdatasync() or sync_file_range())
@@ -102,7 +102,7 @@ func DefaultSettings(fs vfs.FS, dirName string) Settings {
 		Logger:        base.DefaultLogger,
 		FS:            fs,
 		FSDirName:     dirName,
-		FSCleaner:     base.DeleteCleaner{},
+		FSCleaner:     vfs.DeleteCleaner{},
 		NoSyncOnClose: false,
 		BytesPerSync:  512 * 1024, // 512KB
 	}
@@ -118,7 +118,7 @@ func New(settings Settings) *Provider {
 // Path returns an internal path for an object. It is used for informative
 // purposes (e.g. logging).
 func (p *Provider) Path(fileType base.FileType, fileNum base.FileNum) string {
-	return base.MakeFilepath(p.st.FS, p.st.FSDirName, fileType, fileNum)
+	return vfs.MakeFilepath(p.st.FS, p.st.FSDirName, fileType, fileNum)
 }
 
 // OpenForReading opens an existing object.
@@ -146,7 +146,7 @@ func (p *Provider) OpenForReadingMustExist(
 	r, err := p.OpenForReading(fileType, fileNum)
 	if err != nil {
 		filename := p.Path(fileType, fileNum)
-		base.MustExist(p.st.FS, filename, p.st.Logger, err)
+		vfs.MustExist(p.st.FS, filename, p.st.Logger, err)
 	}
 	return r, err
 }

--- a/open.go
+++ b/open.go
@@ -213,7 +213,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	}
 
 	// Lock the database directory.
-	fileLock, err := opts.FS.Lock(base.MakeFilepath(opts.FS, dirname, fileTypeLock, 0))
+	fileLock, err := opts.FS.Lock(vfs.MakeFilepath(opts.FS, dirname, fileTypeLock, 0))
 	if err != nil {
 		d.dataDir.Close()
 		if d.dataDir != d.walDir {
@@ -320,7 +320,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	var previousOptionsFileNum FileNum
 	var previousOptionsFilename string
 	for _, filename := range ls {
-		ft, fn, ok := base.ParseFilename(opts.FS, filename)
+		ft, fn, ok := vfs.ParseFilepath(opts.FS, filename)
 		if !ok {
 			continue
 		}
@@ -413,7 +413,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 			entry.readerUnrefLocked(true)
 		}
 
-		newLogName := base.MakeFilepath(opts.FS, d.walDirname, fileTypeLog, newLogNum)
+		newLogName := vfs.MakeFilepath(opts.FS, d.walDirname, fileTypeLog, newLogNum)
 		d.mu.log.queue = append(d.mu.log.queue, fileInfo{fileNum: newLogNum, fileSize: 0})
 		logFile, err := opts.FS.Create(newLogName)
 		if err != nil {
@@ -466,8 +466,8 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	if !d.opts.ReadOnly {
 		// Write the current options to disk.
 		d.optionsFileNum = d.mu.versions.getNextFileNum()
-		tmpPath := base.MakeFilepath(opts.FS, dirname, fileTypeTemp, d.optionsFileNum)
-		optionsPath := base.MakeFilepath(opts.FS, dirname, fileTypeOptions, d.optionsFileNum)
+		tmpPath := vfs.MakeFilepath(opts.FS, dirname, fileTypeTemp, d.optionsFileNum)
+		optionsPath := vfs.MakeFilepath(opts.FS, dirname, fileTypeOptions, d.optionsFileNum)
 
 		// Write them to a temporary file first, in case we crash before
 		// we're done. A corrupt options file prevents opening the
@@ -556,7 +556,7 @@ func GetVersion(dir string, fs vfs.FS) (string, error) {
 	var version string
 	lastOptionsSeen := FileNum(0)
 	for _, filename := range ls {
-		ft, fn, ok := base.ParseFilename(fs, filename)
+		ft, fn, ok := vfs.ParseFilepath(fs, filename)
 		if !ok {
 			continue
 		}
@@ -920,7 +920,7 @@ func Peek(dirname string, fs vfs.FS) (*DBDesc, error) {
 		FormatMajorVersion: vers,
 	}
 	if exists {
-		desc.ManifestFilename = base.MakeFilepath(fs, dirname, fileTypeManifest, manifestFileNum)
+		desc.ManifestFilename = vfs.MakeFilepath(fs, dirname, fileTypeManifest, manifestFileNum)
 	}
 	return desc, nil
 }

--- a/open_test.go
+++ b/open_test.go
@@ -19,7 +19,6 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/errorfs"
 	"github.com/cockroachdb/pebble/vfs"
@@ -257,7 +256,7 @@ func testOpenCloseOpenClose(t *testing.T, fs vfs.FS, root string) {
 					}
 					var optionsCount int
 					for _, s := range got {
-						if t, _, ok := base.ParseFilename(opts.FS, s); ok && t == fileTypeOptions {
+						if t, _, ok := vfs.ParseFilepath(opts.FS, s); ok && t == fileTypeOptions {
 							optionsCount++
 						}
 					}
@@ -971,7 +970,7 @@ func TestGetVersion(t *testing.T) {
 	ls, err := mem.List("")
 	require.NoError(t, err)
 	for _, filename := range ls {
-		ft, fn, ok := base.ParseFilename(mem, filename)
+		ft, fn, ok := vfs.ParseFilepath(mem, filename)
 		if !ok {
 			continue
 		}

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -700,8 +700,8 @@ func (r *Runner) prepareWorkloadSteps(ctx context.Context) error {
 					//     ahead of time ensures that we're able to Link the
 					//     file like the original workload did.
 					for _, fileNum := range newFiles {
-						src := base.MakeFilepath(r.WorkloadFS, r.WorkloadPath, base.FileTypeTable, fileNum)
-						dst := base.MakeFilepath(r.Opts.FS, r.stagingDir, base.FileTypeTable, fileNum)
+						src := vfs.MakeFilepath(r.WorkloadFS, r.WorkloadPath, base.FileTypeTable, fileNum)
+						dst := vfs.MakeFilepath(r.Opts.FS, r.stagingDir, base.FileTypeTable, fileNum)
 						if err := vfs.CopyAcrossFS(r.WorkloadFS, src, r.Opts.FS, dst); err != nil {
 							return errors.Wrapf(err, "ingest in %q at offset %d", manifestName, rr.Offset())
 						}
@@ -736,7 +736,7 @@ func findWorkloadFiles(
 	}
 	sstables = make(map[base.FileNum]struct{})
 	for _, dirent := range dirents {
-		typ, fileNum, ok := base.ParseFilename(fs, dirent)
+		typ, fileNum, ok := vfs.ParseFilepath(fs, dirent)
 		if !ok {
 			continue
 		}
@@ -819,7 +819,7 @@ func loadFlushedSSTableKeys(
 	// Load all the keys across all the sstables.
 	for _, fileNum := range fileNums {
 		if err := func() error {
-			filePath := base.MakeFilepath(fs, path, base.FileTypeTable, fileNum)
+			filePath := vfs.MakeFilepath(fs, path, base.FileTypeTable, fileNum)
 			f, err := fs.Open(filePath)
 			if err != nil {
 				return err

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -331,11 +331,11 @@ func collectCorpus(t *testing.T, fs *vfs.MemFS, name string) {
 				fileNum := base.FileNum(fileNumInt)
 				switch fT {
 				case "table":
-					filePath = base.MakeFilepath(fs, dir, base.FileTypeTable, fileNum)
+					filePath = vfs.MakeFilepath(fs, dir, base.FileTypeTable, fileNum)
 				case "log":
-					filePath = base.MakeFilepath(fs, dir, base.FileTypeLog, fileNum)
+					filePath = vfs.MakeFilepath(fs, dir, base.FileTypeLog, fileNum)
 				case "manifest":
-					filePath = base.MakeFilepath(fs, dir, base.FileTypeManifest, fileNum)
+					filePath = vfs.MakeFilepath(fs, dir, base.FileTypeManifest, fileNum)
 				}
 			}
 			f, err := fs.Create(filePath)

--- a/replay/workload_capture.go
+++ b/replay/workload_capture.go
@@ -80,7 +80,7 @@ type WorkloadCollector struct {
 		destDir string
 		// cleaner stores the cleaner to use when files become obsolete and need to
 		// be cleaned.
-		cleaner base.Cleaner
+		cleaner vfs.Cleaner
 	}
 	copier struct {
 		sync.Cond

--- a/replay/workload_capture_test.go
+++ b/replay/workload_capture_test.go
@@ -53,7 +53,7 @@ func TestWorkloadCollector(t *testing.T) {
 				return "equal"
 			case "clean":
 				for _, path := range strings.Fields(td.Input) {
-					typ, _, ok := base.ParseFilename(fs, path)
+					typ, _, ok := vfs.ParseFilepath(fs, path)
 					require.True(t, ok)
 					require.NoError(t, o.Cleaner.Clean(fs, typ, path))
 				}
@@ -66,7 +66,7 @@ func TestWorkloadCollector(t *testing.T) {
 				var fileNum uint64
 				var err error
 				td.ScanArgs(t, "filenum", &fileNum)
-				path := base.MakeFilepath(fs, srcDir, base.FileTypeManifest, base.FileNum(fileNum))
+				path := vfs.MakeFilepath(fs, srcDir, base.FileTypeManifest, base.FileNum(fileNum))
 				currentManifest, err = fs.Create(path)
 				require.NoError(t, err)
 				_, err = currentManifest.Write(randData(100))
@@ -180,7 +180,7 @@ func randData(byteCount int) []byte {
 func writeFile(
 	t *testing.T, fs vfs.FS, dir string, typ base.FileType, num base.FileNum, data []byte,
 ) string {
-	path := base.MakeFilepath(fs, dir, typ, num)
+	path := vfs.MakeFilepath(fs, dir, typ, num)
 	f, err := fs.Create(path)
 	require.NoError(t, err)
 	_, err = f.Write(data)

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -101,7 +101,7 @@ func (fs *tableCacheTestFS) validateOpenTables(f func(i, gotO, gotC int) error) 
 
 		numStillOpen := 0
 		for i := 0; i < tableCacheTestNumTables; i++ {
-			filename := base.MakeFilepath(fs, "", fileTypeTable, FileNum(i))
+			filename := vfs.MakeFilepath(fs, "", fileTypeTable, FileNum(i))
 			gotO, gotC := fs.openCounts[filename], fs.closeCounts[filename]
 			if gotO > gotC {
 				numStillOpen++
@@ -131,7 +131,7 @@ func (fs *tableCacheTestFS) validateNoneStillOpen() error {
 		defer fs.mu.Unlock()
 
 		for i := 0; i < tableCacheTestNumTables; i++ {
-			filename := base.MakeFilepath(fs, "", fileTypeTable, FileNum(i))
+			filename := vfs.MakeFilepath(fs, "", fileTypeTable, FileNum(i))
 			gotO, gotC := fs.openCounts[filename], fs.closeCounts[filename]
 			if gotO != gotC {
 				return errors.Errorf("i=%d: opened %d times, closed %d times", i, gotO, gotC)
@@ -162,7 +162,7 @@ func newTableCacheContainerTest(
 		FS: vfs.NewMem(),
 	}
 	for i := 0; i < tableCacheTestNumTables; i++ {
-		f, err := fs.Create(base.MakeFilepath(fs, dirname, fileTypeTable, FileNum(i)))
+		f, err := fs.Create(vfs.MakeFilepath(fs, dirname, fileTypeTable, FileNum(i)))
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "fs.Create")
 		}
@@ -868,7 +868,7 @@ func TestTableCacheClockPro(t *testing.T) {
 	mem := vfs.NewMem()
 	makeTable := func(fileNum FileNum) {
 		require.NoError(t, err)
-		f, err := mem.Create(base.MakeFilepath(mem, "", fileTypeTable, fileNum))
+		f, err := mem.Create(vfs.MakeFilepath(mem, "", fileTypeTable, fileNum))
 		require.NoError(t, err)
 		w := sstable.NewWriter(f, sstable.WriterOptions{})
 		require.NoError(t, w.Set([]byte("a"), nil))

--- a/tool/db.go
+++ b/tool/db.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/tool/logs"
+	"github.com/cockroachdb/pebble/vfs"
 	"github.com/spf13/cobra"
 )
 
@@ -211,7 +212,7 @@ func (d *dbT) loadOptions(dir string) error {
 	// matters.
 	var dbOpts pebble.Options
 	for _, filename := range ls {
-		ft, _, ok := base.ParseFilename(d.opts.FS, filename)
+		ft, _, ok := vfs.ParseFilepath(d.opts.FS, filename)
 		if !ok {
 			continue
 		}

--- a/tool/find.go
+++ b/tool/find.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/rangedel"
 	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/vfs"
 	"github.com/spf13/cobra"
 )
 
@@ -154,7 +155,7 @@ func (f *findT) findFiles(stdout, stderr io.Writer, dir string) error {
 	}
 
 	walk(stderr, f.opts.FS, dir, func(path string) {
-		ft, fileNum, ok := base.ParseFilename(f.opts.FS, path)
+		ft, fileNum, ok := vfs.ParseFilepath(f.opts.FS, path)
 		if !ok {
 			return
 		}

--- a/tool/wal.go
+++ b/tool/wal.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/vfs"
 	"github.com/spf13/cobra"
 )
 
@@ -75,7 +76,7 @@ func (w *walT) runDump(cmd *cobra.Command, args []string) {
 			// necessary in case WAL recycling was used (which it is usually is). If
 			// we can't parse the filename or it isn't a log file, we'll plow ahead
 			// anyways (which will likely fail when we try to read the file).
-			_, fileNum, ok := base.ParseFilename(w.opts.FS, arg)
+			_, fileNum, ok := vfs.ParseFilepath(w.opts.FS, arg)
 			if !ok {
 				fileNum = 0
 			}

--- a/version_set.go
+++ b/version_set.go
@@ -180,7 +180,7 @@ func (vs *versionSet) create(
 
 	vs.opts.EventListener.ManifestCreated(ManifestCreateInfo{
 		JobID:   jobID,
-		Path:    base.MakeFilepath(vs.fs, vs.dirname, fileTypeManifest, vs.manifestFileNum),
+		Path:    vfs.MakeFilepath(vs.fs, vs.dirname, fileTypeManifest, vs.manifestFileNum),
 		FileNum: vs.manifestFileNum,
 		Err:     err,
 	})
@@ -202,7 +202,7 @@ func (vs *versionSet) load(
 	vs.init(dirname, opts, marker, setCurrent, mu)
 
 	vs.manifestFileNum = manifestFileNum
-	manifestPath := base.MakeFilepath(opts.FS, dirname, fileTypeManifest, vs.manifestFileNum)
+	manifestPath := vfs.MakeFilepath(opts.FS, dirname, fileTypeManifest, vs.manifestFileNum)
 	manifestFilename := opts.FS.PathBase(manifestPath)
 
 	// Read the versionEdits in the manifest file.
@@ -491,7 +491,7 @@ func (vs *versionSet) logAndApply(
 			if err := vs.createManifest(vs.dirname, newManifestFileNum, minUnflushedLogNum, nextFileNum); err != nil {
 				vs.opts.EventListener.ManifestCreated(ManifestCreateInfo{
 					JobID:   jobID,
-					Path:    base.MakeFilepath(vs.fs, vs.dirname, fileTypeManifest, newManifestFileNum),
+					Path:    vfs.MakeFilepath(vs.fs, vs.dirname, fileTypeManifest, newManifestFileNum),
 					FileNum: newManifestFileNum,
 					Err:     err,
 				})
@@ -524,7 +524,7 @@ func (vs *versionSet) logAndApply(
 			}
 			vs.opts.EventListener.ManifestCreated(ManifestCreateInfo{
 				JobID:   jobID,
-				Path:    base.MakeFilepath(vs.fs, vs.dirname, fileTypeManifest, newManifestFileNum),
+				Path:    vfs.MakeFilepath(vs.fs, vs.dirname, fileTypeManifest, newManifestFileNum),
 				FileNum: newManifestFileNum,
 			})
 		}
@@ -644,7 +644,7 @@ func (vs *versionSet) createManifest(
 	dirname string, fileNum, minUnflushedLogNum, nextFileNum FileNum,
 ) (err error) {
 	var (
-		filename     = base.MakeFilepath(vs.fs, dirname, fileTypeManifest, fileNum)
+		filename     = vfs.MakeFilepath(vs.fs, dirname, fileTypeManifest, fileNum)
 		manifestFile vfs.File
 		manifest     *record.Writer
 	)
@@ -854,7 +854,7 @@ func findCurrentManifest(
 	}
 
 	var ok bool
-	_, manifestNum, ok = base.ParseFilename(fs, filename)
+	_, manifestNum, ok = vfs.ParseFilepath(fs, filename)
 	if !ok {
 		return marker, 0, false, base.CorruptionErrorf("pebble: MANIFEST name %q is malformed", errors.Safe(filename))
 	}
@@ -863,7 +863,7 @@ func findCurrentManifest(
 
 func readCurrentFile(fs vfs.FS, dirname string) (FileNum, error) {
 	// Read the CURRENT file to find the current manifest file.
-	current, err := fs.Open(base.MakeFilepath(fs, dirname, fileTypeCurrent, 0))
+	current, err := fs.Open(vfs.MakeFilepath(fs, dirname, fileTypeCurrent, 0))
 	if err != nil {
 		return 0, errors.Wrapf(err, "pebble: could not open CURRENT file for DB %q", dirname)
 	}
@@ -889,7 +889,7 @@ func readCurrentFile(fs vfs.FS, dirname string) (FileNum, error) {
 	}
 	b = bytes.TrimSpace(b)
 
-	_, manifestFileNum, ok := base.ParseFilename(fs, string(b))
+	_, manifestFileNum, ok := vfs.ParseFilepath(fs, string(b))
 	if !ok {
 		return 0, base.CorruptionErrorf("pebble: MANIFEST name %q is malformed", errors.Safe(b))
 	}

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -84,7 +84,7 @@ func TestVersionSetSeqNums(t *testing.T) {
 	require.NoError(t, err)
 	var manifest vfs.File
 	for _, filename := range filenames {
-		fileType, _, ok := base.ParseFilename(mem, filename)
+		fileType, _, ok := vfs.ParseFilepath(mem, filename)
 		if ok && fileType == fileTypeManifest {
 			manifest, err = mem.Open(filename)
 			require.NoError(t, err)

--- a/vfs/cleaner.go
+++ b/vfs/cleaner.go
@@ -2,13 +2,13 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package base
+package vfs
 
-import "github.com/cockroachdb/pebble/vfs"
+import "github.com/cockroachdb/pebble/internal/base"
 
 // Cleaner cleans obsolete files.
 type Cleaner interface {
-	Clean(fs vfs.FS, fileType FileType, path string) error
+	Clean(fs FS, fileType base.FileType, path string) error
 }
 
 // NeedsFileContents is implemented by a cleaner that needs the contents of the
@@ -21,7 +21,7 @@ type NeedsFileContents interface {
 type DeleteCleaner struct{}
 
 // Clean removes file.
-func (DeleteCleaner) Clean(fs vfs.FS, fileType FileType, path string) error {
+func (DeleteCleaner) Clean(fs FS, fileType base.FileType, path string) error {
 	return fs.Remove(path)
 }
 
@@ -35,9 +35,9 @@ type ArchiveCleaner struct{}
 var _ NeedsFileContents = ArchiveCleaner{}
 
 // Clean archives file.
-func (ArchiveCleaner) Clean(fs vfs.FS, fileType FileType, path string) error {
+func (ArchiveCleaner) Clean(fs FS, fileType base.FileType, path string) error {
 	switch fileType {
-	case FileTypeLog, FileTypeManifest, FileTypeTable:
+	case base.FileTypeLog, base.FileTypeManifest, base.FileTypeTable:
 		destDir := fs.PathJoin(fs.PathDir(path), "archive")
 
 		if err := fs.MkdirAll(destDir, 0755); err != nil {

--- a/vfs/filenames.go
+++ b/vfs/filenames.go
@@ -1,0 +1,65 @@
+// Copyright 2012 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package vfs
+
+import (
+	"github.com/cockroachdb/errors/oserror"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/redact"
+)
+
+// MakeFilepath builds a filepath from components.
+func MakeFilepath(fs FS, dirname string, fileType base.FileType, fileNum base.FileNum) string {
+	return fs.PathJoin(dirname, base.MakeFilename(fileType, fileNum))
+}
+
+// ParseFilepath parses the components from a filepath.
+func ParseFilepath(fs FS, filename string) (fileType base.FileType, fileNum base.FileNum, ok bool) {
+	return base.ParseFilename(fs.PathBase(filename))
+}
+
+// A Fataler fatals a process with a message when called.
+type Fataler interface {
+	Fatalf(format string, args ...interface{})
+}
+
+// MustExist checks if err is an error indicating a file does not exist.
+// If it is, it lists the containing directory's files to annotate the error
+// with counts of the various types of files and invokes the provided fataler.
+// See cockroachdb/cockroach#56490.
+func MustExist(fs FS, filename string, fataler Fataler, err error) {
+	if err == nil || !oserror.IsNotExist(err) {
+		return
+	}
+
+	ls, lsErr := fs.List(fs.PathDir(filename))
+	if lsErr != nil {
+		// TODO(jackson): if oserror.IsNotExist(lsErr), the the data directory
+		// doesn't exist anymore. Another process likely deleted it before
+		// killing the process. We want to fatal the process, but without
+		// triggering error reporting like Sentry.
+		fataler.Fatalf("%s:\norig err: %s\nlist err: %s", redact.Safe(fs.PathBase(filename)), err, lsErr)
+	}
+	var total, unknown, tables, logs, manifests int
+	total = len(ls)
+	for _, f := range ls {
+		typ, _, ok := ParseFilepath(fs, f)
+		if !ok {
+			unknown++
+			continue
+		}
+		switch typ {
+		case base.FileTypeTable:
+			tables++
+		case base.FileTypeLog:
+			logs++
+		case base.FileTypeManifest:
+			manifests++
+		}
+	}
+
+	fataler.Fatalf("%s:\n%s\ndirectory contains %d files, %d unknown, %d tables, %d logs, %d manifests",
+		fs.PathBase(filename), err, total, unknown, tables, logs, manifests)
+}


### PR DESCRIPTION
The `internal/base` package depends on `vfs` which is unexpected (and prevents adding code in vfs that e.g. uses a `base.Logger`). This change moves the vfs-related functionality to `vfs`.

We rename the `ParseFilename` function into `vfs.ParseFilepath` (which is consistent with `vfs.MakeFilepath`) and extract most of its implementation into `base.ParseFilename` (which is consistent with `base.MakeFielname`).

The change is mechanical, no functional changes.