### PR TITLE
deps: replace github.com/kr/pretty with github.com/r3labs/diff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/ghemawat/stream v0.0.0-20171120220530-696b145b53b9
 	github.com/golang/snappy v0.0.4
 	github.com/klauspost/compress v1.15.15
-	github.com/kr/pretty v0.2.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.12.0
 	github.com/prometheus/client_model v0.2.1-0.20210607210712-147c58e9608a
+	github.com/r3labs/diff/v3 v3.0.1
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/exp v0.0.0-20200513190911-00229845015e
@@ -30,12 +30,15 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/kr/pretty v0.2.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -332,6 +332,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/r3labs/diff/v3 v3.0.1 h1:CBKqf3XmNRHXKmdU7mZP1w7TV0pDyVCis1AUHtA4Xtg=
+github.com/r3labs/diff/v3 v3.0.1/go.mod h1:f1S9bourRbiM66NskseyUdo0fTmEE0qKrikYJX63dgo=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
@@ -363,6 +365,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -373,6 +376,10 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasthttp v1.6.0/go.mod h1:FstJa9V+Pj9vQ7OJie2qMHdwemEDaDiSdBnvPM1Su9w=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
+github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
+github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
-	"github.com/kr/pretty"
+	"github.com/r3labs/diff/v3"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
 )
@@ -208,9 +208,9 @@ func TestIngestLoadRand(t *testing.T) {
 	for _, m := range meta {
 		m.CreationTime = 0
 	}
-	if diff := pretty.Diff(expected, meta); diff != nil {
-		t.Fatalf("%s", strings.Join(diff, "\n"))
-	}
+	c, err := diff.Diff(expected, meta)
+	require.NoError(t, err)
+	require.Empty(t, c)
 }
 
 func TestIngestLoadInvalid(t *testing.T) {

--- a/internal/metamorphic/parser_test.go
+++ b/internal/metamorphic/parser_test.go
@@ -6,12 +6,11 @@ package metamorphic
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/randvar"
-	"github.com/kr/pretty"
+	"github.com/r3labs/diff/v3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,9 +38,9 @@ func TestParserRandom(t *testing.T) {
 		t.Fatalf("%s\n%s", err, src)
 	}
 
-	if diff := pretty.Diff(ops, parsedOps); diff != nil {
-		t.Fatalf("%s\n%s", strings.Join(diff, "\n"), src)
-	}
+	d, err := diff.Diff(ops, parsedOps)
+	require.NoError(t, err)
+	require.Empty(t, d)
 }
 
 func TestParserNilBounds(t *testing.T) {

--- a/open_test.go
+++ b/open_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/errorfs"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/atomicfs"
-	"github.com/kr/pretty"
+	"github.com/r3labs/diff/v3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -454,9 +454,9 @@ func TestOpenReadOnly(t *testing.T) {
 			}
 			require.NoError(t, iter.Close())
 			expectedKeys := []string{"test"}
-			if diff := pretty.Diff(keys, expectedKeys); diff != nil {
-				t.Fatalf("%s\n%s", strings.Join(diff, "\n"), keys)
-			}
+			c, err := diff.Diff(keys, expectedKeys)
+			require.NoError(t, err)
+			require.Empty(t, c)
 		}
 
 		checkIter(d.NewIter(nil))
@@ -476,9 +476,9 @@ func TestOpenReadOnly(t *testing.T) {
 		require.NoError(t, err)
 
 		sort.Strings(newContents)
-		if diff := pretty.Diff(contents, newContents); diff != nil {
-			t.Fatalf("%s", strings.Join(diff, "\n"))
-		}
+		c, err := diff.Diff(contents, newContents)
+		require.NoError(t, err)
+		require.Empty(t, c)
 	}
 }
 
@@ -494,9 +494,9 @@ func TestOpenWALReplay(t *testing.T) {
 		}
 		require.NoError(t, iter.Close())
 		expectedKeys := []string{"1", "2", "3", "4", "5"}
-		if diff := pretty.Diff(keys, expectedKeys); diff != nil {
-			t.Fatalf("%s\n%s", strings.Join(diff, "\n"), keys)
-		}
+		c, err := diff.Diff(keys, expectedKeys)
+		require.NoError(t, err)
+		require.Empty(t, c)
 	}
 
 	for _, readOnly := range []bool{false, true} {

--- a/sstable/properties_test.go
+++ b/sstable/properties_test.go
@@ -10,12 +10,11 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"strings"
 	"testing"
 	"testing/quick"
 	"time"
 
-	"github.com/kr/pretty"
+	"github.com/r3labs/diff/v3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -53,9 +52,9 @@ func TestPropertiesLoad(t *testing.T) {
 		defer r.Close()
 
 		r.Properties.Loaded = nil
-		if diff := pretty.Diff(expected, r.Properties); diff != nil {
-			t.Fatalf("%s", strings.Join(diff, "\n"))
-		}
+		c, err := diff.Diff(expected, r.Properties)
+		require.NoError(t, err)
+		require.Empty(t, c)
 	}
 }
 
@@ -113,9 +112,9 @@ func TestPropertiesSave(t *testing.T) {
 		var props Properties
 		require.NoError(t, props.load(w.finish(), 0))
 		props.Loaded = nil
-		if diff := pretty.Diff(*expected, props); diff != nil {
-			t.Fatalf("%s", strings.Join(diff, "\n"))
-		}
+		c, err := diff.Diff(*expected, props)
+		require.NoError(t, err)
+		require.Empty(t, c)
 	}
 
 	check1(expected)

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/vfs"
-	"github.com/kr/pretty"
+	"github.com/r3labs/diff/v3"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
 )
@@ -754,10 +754,9 @@ func TestFooterRoundTrip(t *testing.T) {
 							require.NoError(t, err)
 							require.NoError(t, readable.Close())
 
-							if diff := pretty.Diff(footer, result); diff != nil {
-								t.Fatalf("expected %+v, but found %+v\n%s",
-									footer, result, strings.Join(diff, "\n"))
-							}
+							c, err := diff.Diff(footer, result)
+							require.NoError(t, err)
+							require.Empty(t, c)
 						})
 					}
 				})


### PR DESCRIPTION
When using more recent versions of github.com/kr/pretty, errant diffs are detected in the cases where structs contained members that are shared between other structs (e.g. shared byte slices). Such diffs are of the form:

```
[7877].key[5]: uint8(0x6a) (previously visited) != uint8(0x6a)
```

Despite the byte values being identical, a diff is detected due to the re-used values. For more context see [this commit][1].

Replace the library used for diffing, to one that is agnostic of re-used fields.

One alternative to this approach would be to audit all usages structs that contain fields that may be shared. This is common, say, in our metamorphic test suite, where byte slices are tracked by a key manager, and re-used, rather than copied.

Touches #1854.

[1]: https://github.com/kr/pretty/commit/44035784bff0f01338f57bad55b2d91364b5b537