### PR TITLE
crl-release-22.1: vfs: handle concurrent directory Syncs in disk-health checking

### DIFF
--- a/cleaner_test.go
+++ b/cleaner_test.go
@@ -25,11 +25,11 @@ func TestArchiveCleaner(t *testing.T) {
 
 	var buf syncedBuffer
 	mem := vfs.NewMem()
-	opts := &Options{
+	opts := (&Options{
 		Cleaner: ArchiveCleaner{},
 		FS:      loggingFS{mem, &buf},
 		WALDir:  "wal",
-	}
+	}).WithFSDefaults()
 
 	datadriven.RunTest(t, "testdata/cleaner", func(td *datadriven.TestData) string {
 		switch td.Cmd {

--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -171,6 +171,7 @@ func testMetaRun(t *testing.T, runDir string, seed uint64, historyPath string) {
 			opts.FS = vfs.NewMem()
 		}
 	}
+	opts.WithFSDefaults()
 
 	dir := opts.FS.PathJoin(runDir, "data")
 	// Set up the initial database state if configured to start from a non-empty
@@ -238,7 +239,7 @@ func readHistory(t *testing.T, historyPath string) []string {
 // subsequent invocation will overwrite that output. A test can be re-run by
 // using the `--run-dir` flag. For example:
 //
-//   go test -v -run TestMeta --run-dir _meta/standard-017
+//	go test -v -run TestMeta --run-dir _meta/standard-017
 //
 // This will reuse the existing operations present in _meta/ops, rather than
 // generating a new set.
@@ -247,7 +248,7 @@ func readHistory(t *testing.T, historyPath string) []string {
 // pseudorandom number generator seed. If a failure occurs, the seed is
 // printed, and the full suite of tests may be re-run using the `--seed` flag:
 //
-//   go test -v -run TestMeta --seed 1594395154492165000
+//	go test -v -run TestMeta --seed 1594395154492165000
 //
 // This will generate a new `_meta/<test>` directory, with the same operations
 // and options. This must be run on the same commit SHA as the original


### PR DESCRIPTION
22.1 backport of #2298.

----

**db: add Options.WithFSDefaults**

Add a facility for easily layering in the default VFS middleware—currently the
disk-health checking FS. Options.EnsureDefaults by default uses the disk-health
checking FS, but most of our tests explicitly set a VFS, and in particular a
*vfs.MemFS. These tests have always run without the disk-health checking
filesystem layer. Use the new WithFSDefaults method across many Pebble unit
tests and the Pebble metamorphic tests.

This is sufficient to surface the concurrent `Sync` operations observed in
https://github.com/cockroachdb/cockroach/issues/96422 and https://github.com/cockroachdb/cockroach/issues/96414. See https://github.com/cockroachdb/pebble/pull/2282 for
context on where this panic is originating.

**vfs: handle concurrent directory Syncs in disk-health checking**

The file-level disk-health checker requires that a file not be used
concurrently, because it only supports timing a single in-flight operation at a
time. Pebble did not adhere to this contract for the data directory, which it
synced concurrently. This had the potential to leave a data directory Sync
untimed if an in-flight Syncs' timestamp was overwritten by the completion of
another Sync.

In https://github.com/cockroachdb/pebble/pull/2282 we began checking for serialized writes in `invariants` builds. This
revealed these concurrent syncs in CockroachDB test failures under `-race`:
https://github.com/cockroachdb/cockroach/issues/96414 and https://github.com/cockroachdb/cockroach/issues/96422.