### PR TITLE
objstorage: keep track of objects in the Provider

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -990,7 +990,10 @@ func TestCompaction(t *testing.T) {
 		}
 		ss := []string(nil)
 		v := d.mu.versions.currentVersion()
-		provider := objstorage.New(objstorage.DefaultSettings(mem, "" /* dirName */))
+		provider, err := objstorage.Open(objstorage.DefaultSettings(mem, "" /* dirName */))
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 		for _, levelMetadata := range v.Levels {
 			iter := levelMetadata.Iter()
 			for meta := iter.First(); meta != nil; meta = iter.Next() {

--- a/ingest.go
+++ b/ingest.go
@@ -269,7 +269,7 @@ func ingestLink(
 	jobID int, opts *Options, objProvider *objstorage.Provider, paths []string, meta []*fileMetadata,
 ) error {
 	for i := range paths {
-		err := objProvider.LinkOrCopyFromLocal(opts.FS, paths[i], fileTypeTable, meta[i].FileNum)
+		objMeta, err := objProvider.LinkOrCopyFromLocal(opts.FS, paths[i], fileTypeTable, meta[i].FileNum)
 		if err != nil {
 			if err2 := ingestCleanup(objProvider, meta[:i]); err2 != nil {
 				opts.Logger.Infof("ingest cleanup failed: %v", err2)
@@ -280,7 +280,7 @@ func ingestLink(
 			opts.EventListener.TableCreated(TableCreateInfo{
 				JobID:   jobID,
 				Reason:  "ingesting",
-				Path:    objProvider.Path(fileTypeTable, meta[i].FileNum),
+				Path:    objProvider.Path(objMeta),
 				FileNum: meta[i].FileNum,
 			})
 		}

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -290,7 +290,8 @@ func TestIngestLink(t *testing.T) {
 			opts := &Options{FS: vfs.NewMem()}
 			opts.EnsureDefaults().WithFSDefaults()
 			require.NoError(t, opts.FS.MkdirAll(dir, 0755))
-			objProvider := objstorage.New(objstorage.DefaultSettings(opts.FS, dir))
+			objProvider, err := objstorage.Open(objstorage.DefaultSettings(opts.FS, dir))
+			require.NoError(t, err)
 
 			paths := make([]string, 10)
 			meta := make([]*fileMetadata, len(paths))
@@ -314,7 +315,7 @@ func TestIngestLink(t *testing.T) {
 				opts.FS.Remove(paths[i])
 			}
 
-			err := ingestLink(0 /* jobID */, opts, objProvider, paths, meta)
+			err = ingestLink(0 /* jobID */, opts, objProvider, paths, meta)
 			if i < count {
 				if err == nil {
 					t.Fatalf("expected error, but found success")
@@ -372,7 +373,11 @@ func TestIngestLinkFallback(t *testing.T) {
 
 	opts := &Options{FS: errorfs.Wrap(mem, errorfs.OnIndex(0))}
 	opts.EnsureDefaults().WithFSDefaults()
-	objProvider := objstorage.New(objstorage.DefaultSettings(opts.FS, ""))
+	objSettings := objstorage.DefaultSettings(opts.FS, "")
+	// Prevent the provider from listing the dir (where we may get an injected error).
+	objSettings.FSDirInitialListing = []string{}
+	objProvider, err := objstorage.Open(objSettings)
+	require.NoError(t, err)
 
 	meta := []*fileMetadata{{FileNum: 1}}
 	err = ingestLink(0, opts, objProvider, []string{"source"}, meta)
@@ -1637,7 +1642,7 @@ func TestIngestCleanup(t *testing.T) {
 	testCases := []struct {
 		closeFiles   []base.FileNum
 		cleanupFiles []base.FileNum
-		wantErr      error
+		wantErr      string
 	}{
 		// Close and remove all files.
 		{
@@ -1648,19 +1653,19 @@ func TestIngestCleanup(t *testing.T) {
 		{
 			closeFiles:   fns,
 			cleanupFiles: []base.FileNum{3},
-			wantErr:      oserror.ErrNotExist,
+			wantErr:      "unknown to the provider",
 		},
 		// Remove a file that has not been closed.
 		{
 			closeFiles:   []base.FileNum{0, 2},
 			cleanupFiles: fns,
-			wantErr:      oserror.ErrInvalid,
+			wantErr:      oserror.ErrInvalid.Error(),
 		},
 		// Remove all files, one of which is still open, plus a file that does not exist.
 		{
 			closeFiles:   []base.FileNum{0, 2},
 			cleanupFiles: []base.FileNum{0, 1, 2, 3},
-			wantErr:      oserror.ErrInvalid, // The first error encountered is due to the open file.
+			wantErr:      oserror.ErrInvalid.Error(), // The first error encountered is due to the open file.
 		},
 	}
 
@@ -1668,24 +1673,25 @@ func TestIngestCleanup(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			mem := vfs.NewMem()
 			mem.UseWindowsSemantics(true)
-			objProvider := objstorage.New(objstorage.DefaultSettings(mem, ""))
+			objProvider, err := objstorage.Open(objstorage.DefaultSettings(mem, ""))
+			require.NoError(t, err)
 
 			// Create the files in the VFS.
-			metaMap := make(map[base.FileNum]vfs.File)
+			metaMap := make(map[base.FileNum]objstorage.Writable)
 			for _, fn := range fns {
-				path := base.MakeFilepath(mem, "", base.FileTypeTable, fn)
-				f, err := mem.Create(path)
-				metaMap[fn] = f
+				w, _, err := objProvider.Create(base.FileTypeTable, fn)
 				require.NoError(t, err)
+
+				metaMap[fn] = w
 			}
 
 			// Close a select number of files.
 			for _, m := range tc.closeFiles {
-				f, ok := metaMap[m]
+				w, ok := metaMap[m]
 				if !ok {
 					continue
 				}
-				require.NoError(t, f.Close())
+				require.NoError(t, w.Close())
 			}
 
 			// Cleanup the set of files in the FS.
@@ -1694,9 +1700,10 @@ func TestIngestCleanup(t *testing.T) {
 				toRemove = append(toRemove, &fileMetadata{FileNum: fn})
 			}
 
-			err := ingestCleanup(objProvider, toRemove)
-			if tc.wantErr != nil {
-				require.Equal(t, tc.wantErr, err)
+			err = ingestCleanup(objProvider, toRemove)
+			if tc.wantErr != "" {
+				require.Error(t, err, "got no error, expected %s", tc.wantErr)
+				require.Contains(t, err.Error(), tc.wantErr)
 			} else {
 				require.NoError(t, err)
 			}

--- a/objstorage/provider.go
+++ b/objstorage/provider.go
@@ -6,7 +6,9 @@ package objstorage
 
 import (
 	"io"
+	"sync"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/vfs"
@@ -18,14 +20,21 @@ import (
 // objects is for storing sstables; in the future it could also be used for blob
 // storage.
 //
+// The Provider can only manage objects that it knows about - either objects
+// created by the provider, or existing objects the Provider was informed about
+// via AddObjects.
+//
 // Objects are currently backed by a vfs.File.
 type Provider struct {
 	st Settings
 
-	// TODO(radu): when we support shared storage as well, this object will need to
-	// maintain a FileNum to backend type mapping.
+	mu struct {
+		sync.RWMutex
 
-	// TODO(radu): add more functionality around listing, copying, linking, etc.
+		// knownObjects maintains information about objects that are known to the provider.
+		// It is initialized with the list of files in the manifest when we open a DB.
+		knownObjects map[base.FileNum]ObjectMetadata
+	}
 }
 
 // Readable is the handle for an object that is open for reading.
@@ -78,6 +87,14 @@ type Settings struct {
 	// Local filesystem configuration.
 	FS        vfs.FS
 	FSDirName string
+
+	// FSDirInitialListing is a listing of FSDirName at the time of calling Open.
+	//
+	// This is an optional optimization to avoid double listing on Open when the
+	// higher layer already has a listing. When nil, we obtain the listing on
+	// Open.
+	FSDirInitialListing []string
+
 	// Cleaner cleans obsolete files from the local filesystem.
 	//
 	// The default cleaner uses the DeleteCleaner.
@@ -108,33 +125,55 @@ func DefaultSettings(fs vfs.FS, dirName string) Settings {
 	}
 }
 
-// New creates the Provider.
-func New(settings Settings) *Provider {
-	return &Provider{
-		st: settings,
-	}
+// ObjectMetadata contains the metadata required to be able to access an object.
+type ObjectMetadata struct {
+	FileNum  base.FileNum
+	FileType base.FileType
+	// TODO(radu): this will also contain shared object metadata.
 }
 
-// Path returns an internal path for an object. It is used for informative
-// purposes (e.g. logging).
-func (p *Provider) Path(fileType base.FileType, fileNum base.FileNum) string {
-	return base.MakeFilepath(p.st.FS, p.st.FSDirName, fileType, fileNum)
+// IsShared returns true if the object is on shared storage.
+func (m *ObjectMetadata) IsShared() bool {
+	// TODO(radu)
+	return false
+}
+
+// Open creates the Provider.
+func Open(settings Settings) (*Provider, error) {
+	p := &Provider{
+		st: settings,
+	}
+	p.mu.knownObjects = make(map[base.FileNum]ObjectMetadata)
+
+	// Add local FS objects.
+	listing := settings.FSDirInitialListing
+	if listing == nil {
+		var err error
+		listing, err = p.st.FS.List(p.st.FSDirName)
+		if err != nil {
+			return nil, errors.Wrapf(err, "pebble: could not list store directory")
+		}
+	}
+	objects := p.vfsFindExisting(listing)
+	for _, o := range objects {
+		p.mu.knownObjects[o.FileNum] = o
+	}
+
+	return p, nil
 }
 
 // OpenForReading opens an existing object.
 func (p *Provider) OpenForReading(fileType base.FileType, fileNum base.FileNum) (Readable, error) {
-	filename := p.Path(fileType, fileNum)
-	file, err := p.st.FS.Open(filename, vfs.RandomReadsOption)
+	meta, err := p.Lookup(fileType, fileNum)
 	if err != nil {
 		return nil, err
 	}
-	// TODO(radu): we use the existence of the file descriptor as an indication
-	// that the File might support Prefetch and SequentialReadsOption. We should
-	// replace this with a cleaner way to obtain the capabilities of the FS / File.
-	if fd := file.Fd(); fd != vfs.InvalidFd {
-		return newFileReadable(file, p.st.FS, filename)
+
+	if !meta.IsShared() {
+		return p.vfsOpenForReading(fileType, fileNum, false /* mustExist */)
 	}
-	return newGenericFileReadable(file)
+
+	panic("unimplemented")
 }
 
 // OpenForReadingMustExist is a variant of OpenForReading which causes a fatal
@@ -143,30 +182,56 @@ func (p *Provider) OpenForReading(fileType base.FileType, fileNum base.FileNum) 
 func (p *Provider) OpenForReadingMustExist(
 	fileType base.FileType, fileNum base.FileNum,
 ) (Readable, error) {
-	r, err := p.OpenForReading(fileType, fileNum)
+	meta, err := p.Lookup(fileType, fileNum)
 	if err != nil {
-		filename := p.Path(fileType, fileNum)
-		base.MustExist(p.st.FS, filename, p.st.Logger, err)
+		p.st.Logger.Fatalf("%v", err)
+		return nil, err
 	}
-	return r, err
+
+	if !meta.IsShared() {
+		return p.vfsOpenForReading(fileType, fileNum, true /* mustExist */)
+	}
+
+	panic("unimplemented")
 }
 
 // Create creates a new object and opens it for writing.
-func (p *Provider) Create(fileType base.FileType, fileNum base.FileNum) (Writable, error) {
-	file, err := p.st.FS.Create(p.Path(fileType, fileNum))
+func (p *Provider) Create(
+	fileType base.FileType, fileNum base.FileNum,
+) (Writable, ObjectMetadata, error) {
+	w, err := p.vfsCreate(fileType, fileNum)
 	if err != nil {
-		return nil, err
+		return nil, ObjectMetadata{}, err
 	}
-	file = vfs.NewSyncingFile(file, vfs.SyncingFileOptions{
-		NoSyncOnClose: p.st.NoSyncOnClose,
-		BytesPerSync:  p.st.BytesPerSync,
-	})
-	return newFileBufferedWritable(file), nil
+	meta := ObjectMetadata{
+		FileNum:  fileNum,
+		FileType: fileType,
+	}
+
+	p.addMetadata(meta)
+	return w, meta, nil
 }
 
 // Remove removes an object.
 func (p *Provider) Remove(fileType base.FileType, fileNum base.FileNum) error {
-	return p.st.FSCleaner.Clean(p.st.FS, fileType, p.Path(fileType, fileNum))
+	meta, err := p.Lookup(fileType, fileNum)
+	if err != nil {
+		return err
+	}
+
+	if !meta.IsShared() {
+		err = p.vfsRemove(fileType, fileNum)
+	} else {
+		panic("unimplemented")
+	}
+	if err != nil {
+		// We want to be able to retry a Remove, so we keep the object in our list.
+		// TODO(radu): we should mark the object as "zombie" and not allow any other
+		// operations.
+		return err
+	}
+	p.removeMetadata(fileNum)
+	return nil
 }
 
 // IsNotExistError indicates whether the error is known to report that a file or
@@ -180,7 +245,7 @@ func IsNotExistError(err error) bool {
 // if the FS supports it).
 func (p *Provider) LinkOrCopyFromLocal(
 	srcFS vfs.FS, srcFilePath string, dstFileType base.FileType, dstFileNum base.FileNum,
-) error {
+) (ObjectMetadata, error) {
 	if srcFS == p.st.FS {
 		// Wrap the normal filesystem with one which wraps newly created files with
 		// vfs.NewSyncingFile.
@@ -188,8 +253,60 @@ func (p *Provider) LinkOrCopyFromLocal(
 			NoSyncOnClose: p.st.NoSyncOnClose,
 			BytesPerSync:  p.st.BytesPerSync,
 		})
-		return vfs.LinkOrCopy(fs, srcFilePath, p.Path(dstFileType, dstFileNum))
+		dstPath := p.vfsPath(dstFileType, dstFileNum)
+		if err := vfs.LinkOrCopy(fs, srcFilePath, dstPath); err != nil {
+			return ObjectMetadata{}, err
+		}
+
+		meta := ObjectMetadata{
+			FileNum:  dstFileNum,
+			FileType: dstFileType,
+		}
+		p.addMetadata(meta)
+		return meta, nil
 	}
 	// TODO(radu): for the copy case, we should use `p.Create` and do the copy ourselves.
 	panic("unimplemented")
+}
+
+// Path returns an internal, implementation-dependent path for the object. It is
+// meant to be used for informational purposes (like logging).
+func (p *Provider) Path(meta ObjectMetadata) string {
+	if !meta.IsShared() {
+		return p.vfsPath(meta.FileType, meta.FileNum)
+	}
+	panic("unimplemented")
+}
+
+// Lookup returns the metadata of an object that is already known to the Provider.
+// Does not perform any I/O.
+func (p *Provider) Lookup(fileType base.FileType, fileNum base.FileNum) (ObjectMetadata, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	meta, ok := p.mu.knownObjects[fileNum]
+	if !ok {
+		return ObjectMetadata{}, errors.Newf(
+			"file %s (type %d) unknown to the provider",
+			errors.Safe(fileNum), errors.Safe(fileType),
+		)
+	}
+	if meta.FileType != fileType {
+		return ObjectMetadata{}, errors.AssertionFailedf(
+			"file %s type mismatch (known type %d, expected type %d)",
+			errors.Safe(fileNum), errors.Safe(meta.FileType), errors.Safe(fileType),
+		)
+	}
+	return meta, nil
+}
+
+func (p *Provider) addMetadata(meta ObjectMetadata) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.mu.knownObjects[meta.FileNum] = meta
+}
+
+func (p *Provider) removeMetadata(fileNum base.FileNum) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.mu.knownObjects, fileNum)
 }

--- a/objstorage/vfs.go
+++ b/objstorage/vfs.go
@@ -1,0 +1,65 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package objstorage
+
+import (
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+func (p *Provider) vfsPath(fileType base.FileType, fileNum base.FileNum) string {
+	return base.MakeFilepath(p.st.FS, p.st.FSDirName, fileType, fileNum)
+}
+
+func (p *Provider) vfsOpenForReading(
+	fileType base.FileType, fileNum base.FileNum, mustExist bool,
+) (Readable, error) {
+	filename := p.vfsPath(fileType, fileNum)
+	file, err := p.st.FS.Open(filename, vfs.RandomReadsOption)
+	if err != nil {
+		if mustExist {
+			base.MustExist(p.st.FS, filename, p.st.Logger, err)
+		}
+		return nil, err
+	}
+	// TODO(radu): we use the existence of the file descriptor as an indication
+	// that the File might support Prefetch and SequentialReadsOption. We should
+	// replace this with a cleaner way to obtain the capabilities of the FS / File.
+	if fd := file.Fd(); fd != vfs.InvalidFd {
+		return newFileReadable(file, p.st.FS, filename)
+	}
+	return newGenericFileReadable(file)
+}
+
+func (p *Provider) vfsCreate(fileType base.FileType, fileNum base.FileNum) (Writable, error) {
+	filename := p.vfsPath(fileType, fileNum)
+	file, err := p.st.FS.Create(filename)
+	if err != nil {
+		return nil, err
+	}
+	file = vfs.NewSyncingFile(file, vfs.SyncingFileOptions{
+		NoSyncOnClose: p.st.NoSyncOnClose,
+		BytesPerSync:  p.st.BytesPerSync,
+	})
+	return newFileBufferedWritable(file), nil
+}
+
+func (p *Provider) vfsRemove(fileType base.FileType, fileNum base.FileNum) error {
+	return p.st.FSCleaner.Clean(p.st.FS, fileType, p.vfsPath(fileType, fileNum))
+}
+
+func (p *Provider) vfsFindExisting(ls []string) []ObjectMetadata {
+	var res []ObjectMetadata
+	for _, filename := range ls {
+		fileType, fileNum, ok := base.ParseFilename(p.st.FS, filename)
+		if ok && fileType == base.FileTypeTable {
+			res = append(res, ObjectMetadata{
+				FileType: fileType,
+				FileNum:  fileNum,
+			})
+		}
+	}
+	return res
+}

--- a/open.go
+++ b/open.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/pebble/internal/arenaskl"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
@@ -62,25 +63,77 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		return nil, err
 	}
 
+	// In all error cases, we return db = nil; this is used by various
+	// deferred cleanups.
+
+	// Open the database and WAL directories first.
+	walDirname, dataDir, walDir, err := prepareAndOpenDirs(dirname, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if db == nil {
+			if walDir != dataDir {
+				walDir.Close()
+			}
+			dataDir.Close()
+		}
+	}()
+
+	// Lock the database directory.
+	fileLock, err := opts.FS.Lock(base.MakeFilepath(opts.FS, dirname, fileTypeLock, 0))
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if db == nil {
+			fileLock.Close()
+		}
+	}()
+
+	// Establish the format major version.
+	formatVersion, formatVersionMarker, err := lookupFormatMajorVersion(opts.FS, dirname)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if db == nil {
+			formatVersionMarker.Close()
+		}
+	}()
+
+	// Find the currently active manifest, if there is one.
+	manifestMarker, manifestFileNum, manifestExists, err := findCurrentManifest(formatVersion, opts.FS, dirname)
+	if err != nil {
+		return nil, errors.Wrapf(err, "pebble: database %q", dirname)
+	}
+	defer func() {
+		if db == nil {
+			manifestMarker.Close()
+		}
+	}()
+
+	// Atomic markers may leave behind obsolete files if there's a crash
+	// mid-update. Clean these up if we're not in read-only mode.
+	if !opts.ReadOnly {
+		if err := formatVersionMarker.RemoveObsolete(); err != nil {
+			return nil, err
+		}
+		if err := manifestMarker.RemoveObsolete(); err != nil {
+			return nil, err
+		}
+	}
+
 	if opts.Cache == nil {
 		opts.Cache = cache.New(cacheDefaultSize)
 	} else {
 		opts.Cache.Ref()
 	}
 
-	objProvider := objstorage.New(objstorage.Settings{
-		Logger:        opts.Logger,
-		FS:            opts.FS,
-		FSDirName:     dirname,
-		FSCleaner:     opts.Cleaner,
-		NoSyncOnClose: opts.NoSyncOnClose,
-		BytesPerSync:  opts.BytesPerSync,
-	})
-
 	d := &DB{
 		cacheID:             opts.Cache.NewID(),
 		dirname:             dirname,
-		walDirname:          opts.WALDir,
+		walDirname:          walDirname,
 		opts:                opts,
 		cmp:                 opts.Comparer.Compare,
 		equal:               opts.equal(),
@@ -88,7 +141,9 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		split:               opts.Comparer.Split,
 		abbreviatedKey:      opts.Comparer.AbbreviatedKey,
 		largeBatchThreshold: (opts.MemTableSize - int(memTableEmptySize)) / 2,
-		objProvider:         objProvider,
+		fileLock:            fileLock,
+		dataDir:             dataDir,
+		walDir:              walDir,
 		logRecycler:         logRecycler{limit: opts.MemTableStopWritesThreshold + 1},
 		closed:              new(atomic.Value),
 		closedCh:            make(chan struct{}),
@@ -126,11 +181,6 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		}
 	}()
 
-	tableCacheSize := TableCacheSize(opts.MaxOpenFiles)
-	d.tableCache = newTableCacheContainer(opts.TableCache, d.cacheID, objProvider, d.opts, tableCacheSize)
-	d.newIters = d.tableCache.newIters
-	d.tableNewRangeKeyIter = d.tableCache.newRangeKeyIter
-
 	d.commit = newCommitPipeline(commitEnv{
 		logSeqNum:     &d.mu.versions.atomic.logSeqNum,
 		visibleSeqNum: &d.mu.versions.atomic.visibleSeqNum,
@@ -154,109 +204,20 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	// logSeqNum is the next sequence number that will be assigned. Start
 	// assigning sequence numbers from 1 to match rocksdb.
 	d.mu.versions.atomic.logSeqNum = 1
+	d.mu.formatVers.vers = formatVersion
+	d.mu.formatVers.marker = formatVersionMarker
 
 	d.timeNow = time.Now
 
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	if !d.opts.ReadOnly {
-		err := opts.FS.MkdirAll(dirname, 0755)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// Ensure we close resources if we error out early. If the database is
-	// successfully opened, the named return value `db` will be set to `d`.
-	defer func() {
-		if db != nil {
-			// The database was successfully opened.
-			return
-		}
-		if d.dataDir != nil {
-			d.dataDir.Close()
-		}
-		if d.walDirname != d.dirname && d.walDir != nil {
-			d.walDir.Close()
-		}
-		if d.mu.formatVers.marker != nil {
-			d.mu.formatVers.marker.Close()
-		}
-	}()
-
-	// Open the database and WAL directories first in order to check for their
-	// existence.
-	var err error
-	d.dataDir, err = opts.FS.OpenDir(dirname)
-	if err != nil {
-		return nil, err
-	}
-	if d.walDirname == "" {
-		d.walDirname = d.dirname
-	}
-	if d.walDirname == d.dirname {
-		d.walDir = d.dataDir
-	} else {
-		if !d.opts.ReadOnly {
-			err := opts.FS.MkdirAll(d.walDirname, 0755)
-			if err != nil {
-				return nil, err
-			}
-		}
-		d.walDir, err = opts.FS.OpenDir(d.walDirname)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// Lock the database directory.
-	fileLock, err := opts.FS.Lock(base.MakeFilepath(opts.FS, dirname, fileTypeLock, 0))
-	if err != nil {
-		d.dataDir.Close()
-		if d.dataDir != d.walDir {
-			d.walDir.Close()
-		}
-		return nil, err
-	}
-	defer func() {
-		if fileLock != nil {
-			fileLock.Close()
-		}
-	}()
-
-	// Establish the format major version.
-	d.mu.formatVers.vers, d.mu.formatVers.marker, err = lookupFormatMajorVersion(opts.FS, dirname)
-	if err != nil {
-		return nil, err
-	}
-	if !d.opts.ReadOnly {
-		if err := d.mu.formatVers.marker.RemoveObsolete(); err != nil {
-			return nil, err
-		}
-	}
-
 	jobID := d.mu.nextJobID
 	d.mu.nextJobID++
 
-	// Find the currently active manifest, if there is one.
-	manifestMarker, manifestFileNum, exists, err := findCurrentManifest(d.mu.formatVers.vers, opts.FS, dirname)
-	defer func() {
-		// Ensure we close the manifest marker if we error out for any reason.
-		// If the database is successfully opened, the *versionSet will take
-		// ownership over the manifest marker, ensuring it's closed when the DB
-		// is closed.
-		if db == nil {
-			manifestMarker.Close()
-		}
-	}()
-	if err != nil {
-		return nil, errors.Wrapf(err, "pebble: database %q", dirname)
-	}
-
 	setCurrent := setCurrentFunc(d.mu.formatVers.vers, manifestMarker, opts.FS, dirname, d.dataDir)
 
-	if !exists {
+	if !manifestExists {
 		// DB does not exist.
 		if d.opts.ErrorIfNotExists || d.opts.ReadOnly {
 			return nil, errors.Errorf("pebble: database %q does not exist", dirname)
@@ -274,16 +235,8 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		if err := d.mu.versions.load(dirname, opts, manifestFileNum, manifestMarker, setCurrent, &d.mu.Mutex); err != nil {
 			return nil, err
 		}
-		if err := d.mu.versions.currentVersion().CheckConsistency(dirname, opts.FS); err != nil {
-			return nil, err
-		}
-	}
-
-	// Atomic markers like the one used for the MANIFEST may leave
-	// behind obsolete files if there's a crash mid-update. Clean these
-	// up if we're not in read-only mode.
-	if !d.opts.ReadOnly {
-		if err := manifestMarker.RemoveObsolete(); err != nil {
+		curVersion := d.mu.versions.currentVersion()
+		if err := curVersion.CheckConsistency(dirname, opts.FS); err != nil {
 			return nil, err
 		}
 	}
@@ -297,6 +250,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		d.mu.mem.queue = append(d.mu.mem.queue, entry)
 	}
 
+	// List the objects
 	ls, err := opts.FS.List(d.walDirname)
 	if err != nil {
 		return nil, err
@@ -308,6 +262,24 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		}
 		ls = append(ls, ls2...)
 	}
+
+	d.objProvider, err = objstorage.Open(objstorage.Settings{
+		Logger:              opts.Logger,
+		FS:                  opts.FS,
+		FSDirName:           dirname,
+		FSDirInitialListing: ls,
+		FSCleaner:           opts.Cleaner,
+		NoSyncOnClose:       opts.NoSyncOnClose,
+		BytesPerSync:        opts.BytesPerSync,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	tableCacheSize := TableCacheSize(opts.MaxOpenFiles)
+	d.tableCache = newTableCacheContainer(opts.TableCache, d.cacheID, d.objProvider, d.opts, tableCacheSize)
+	d.newIters = d.tableCache.newIters
+	d.tableNewRangeKeyIter = d.tableCache.newRangeKeyIter
 
 	// Replay any newer log files than the ones named in the manifest.
 	type fileNumAndName struct {
@@ -538,8 +510,51 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		}
 	})
 
-	d.fileLock, fileLock = fileLock, nil
 	return d, nil
+}
+
+// prepareAndOpenDirs opens the directories for the store (and creates them if
+// necessary).
+//
+// Returns an error if ReadOnly is set and the directories don't exist.
+func prepareAndOpenDirs(
+	dirname string, opts *Options,
+) (walDirname string, dataDir vfs.File, walDir vfs.File, err error) {
+	walDirname = opts.WALDir
+	if opts.WALDir == "" {
+		walDirname = dirname
+	}
+
+	// Create directories if needed.
+	if !opts.ReadOnly {
+		if err := opts.FS.MkdirAll(dirname, 0755); err != nil {
+			return "", nil, nil, err
+		}
+		if walDirname != dirname {
+			if err := opts.FS.MkdirAll(walDirname, 0755); err != nil {
+				return "", nil, nil, err
+			}
+		}
+	}
+
+	dataDir, err = opts.FS.OpenDir(dirname)
+	if err != nil {
+		if opts.ReadOnly && oserror.IsNotExist(err) {
+			return "", nil, nil, errors.Errorf("pebble: database %q does not exist", dirname)
+		}
+		return "", nil, nil, err
+	}
+
+	if walDirname == dirname {
+		walDir = dataDir
+	} else {
+		walDir, err = opts.FS.OpenDir(walDirname)
+		if err != nil {
+			dataDir.Close()
+			return "", nil, nil, err
+		}
+	}
+	return walDirname, dataDir, walDir, nil
 }
 
 // GetVersion returns the engine version string from the latest options

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -171,9 +171,12 @@ func runBuildRawCmd(
 	td *datadriven.TestData, opts *WriterOptions,
 ) (*WriterMetadata, *Reader, error) {
 	mem := vfs.NewMem()
-	provider := objstorage.New(objstorage.DefaultSettings(mem, "" /* dirName */))
+	provider, err := objstorage.Open(objstorage.DefaultSettings(mem, "" /* dirName */))
+	if err != nil {
+		return nil, nil, err
+	}
 
-	f0, err := provider.Create(base.FileTypeTable, 0 /* fileNum */)
+	f0, _, err := provider.Create(base.FileTypeTable, 0 /* fileNum */)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -658,7 +658,8 @@ func TestBytesIterated(t *testing.T) {
 
 func TestCompactionIteratorSetupForCompaction(t *testing.T) {
 	tmpDir := path.Join(t.TempDir())
-	provider := objstorage.New(objstorage.DefaultSettings(vfs.Default, tmpDir))
+	provider, err := objstorage.Open(objstorage.DefaultSettings(vfs.Default, tmpDir))
+	require.NoError(t, err)
 	blockSizes := []int{10, 100, 1000, 4096, math.MaxInt32}
 	for _, blockSize := range blockSizes {
 		for _, indexBlockSize := range blockSizes {
@@ -1000,7 +1001,8 @@ func TestReader_TableFormat(t *testing.T) {
 func buildTestTable(
 	t *testing.T, numEntries uint64, blockSize, indexBlockSize int, compression Compression,
 ) *Reader {
-	provider := objstorage.New(objstorage.DefaultSettings(vfs.NewMem(), "" /* dirName */))
+	provider, err := objstorage.Open(objstorage.DefaultSettings(vfs.NewMem(), "" /* dirName */))
+	require.NoError(t, err)
 	return buildTestTableWithProvider(t, provider, numEntries, blockSize, indexBlockSize, compression)
 }
 
@@ -1011,7 +1013,7 @@ func buildTestTableWithProvider(
 	blockSize, indexBlockSize int,
 	compression Compression,
 ) *Reader {
-	f0, err := provider.Create(base.FileTypeTable, 0 /* fileNum */)
+	f0, _, err := provider.Create(base.FileTypeTable, 0 /* fileNum */)
 	require.NoError(t, err)
 
 	w := NewWriter(f0, WriterOptions{

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -1,8 +1,8 @@
 open db
 ----
 mkdir-all: db 0755
-open-dir: db
 mkdir-all: wal 0755
+open-dir: db
 open-dir: wal
 lock: db/LOCK
 open-dir: db

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -1,8 +1,8 @@
 open
 ----
 mkdir-all: db 0755
-open-dir: db
 mkdir-all: wal 0755
+open-dir: db
 open-dir: wal
 lock: db/LOCK
 open-dir: db

--- a/tool/testdata/db_check
+++ b/tool/testdata/db_check
@@ -5,7 +5,7 @@ accepts 1 arg(s), received 0
 db check
 non-existent
 ----
-open non-existent: file does not exist
+pebble: database "non-existent" does not exist
 
 db check
 ../testdata/db-stage-4

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -5,7 +5,7 @@ accepts 1 arg(s), received 0
 db lsm
 non-existent
 ----
-open non-existent: file does not exist
+pebble: database "non-existent" does not exist
 
 db lsm
 ../testdata/db-stage-4

--- a/tool/testdata/db_scan
+++ b/tool/testdata/db_scan
@@ -5,7 +5,7 @@ accepts 1 arg(s), received 0
 db scan
 non-existent
 ----
-open non-existent: file does not exist
+pebble: database "non-existent" does not exist
 
 db scan
 ../testdata/db-stage-4


### PR DESCRIPTION
This change modifies the objstorage API and restructures some of its
code to allow for adding support for shared objects.

The main change is that the Provider maintains its own list of known
objects. We populate the initial list from the local FS listing; for
shared objects the information will come from the shared object
catalog.

This change includes some cleanup in db.Open. We now open the
directories first and move more code up before the `Db` object
initialization (after which cleanup becomes more complicated).