### PR TITLE
*: Add shared.Storage to Options.

### DIFF
--- a/objstorage/shared/storage.go
+++ b/objstorage/shared/storage.go
@@ -42,7 +42,7 @@ type Storage interface {
 	//   List("", "/") -> ["a", "b"]
 	//   List("b", "/") -> ["4", "5", "6"]
 	//   List("b", "") -> ["/4", "/5", "/6"]
-	List(prefix, delimiter string) []string
+	List(prefix, delimiter string) ([]string, error)
 
 	// Delete removes the named object from the store.
 	Delete(basename string) error

--- a/options.go
+++ b/options.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/humanize"
 	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/objstorage/shared"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -633,9 +634,7 @@ type Options struct {
 		// wrote a file should not delete it if other Pebble instances are known to
 		// be reading this file. This FS is expected to have slower read/write
 		// performance than the default FS above.
-		//
-		// TODO(bilal): Uncomment this once it's in use.
-		// SharedStorage shared.Storage
+		SharedStorage shared.Storage
 	}
 
 	// Filters is a map from filter policy name to filter policy. It is used for


### PR DESCRIPTION
This change adds an option to specify shared.Storage in pebble Options and also adds a missing error return value to the List() method in that interface.