### PR TITLE
db: implement relaxed target file size splitting heuristic

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -134,26 +134,179 @@ type compactionOutputSplitter interface {
 	onNewOutput(key []byte) []byte
 }
 
-// fileSizeSplitter is a compactionOutputSplitter that makes a determination
-// to split outputs based on the estimated file size of the current output.
-// Note that, unlike most other splitters, this splitter does not guarantee
-// that it will advise splits only at user key change boundaries.
+// fileSizeSplitter is a compactionOutputSplitter that enforces target file
+// sizes. This splitter splits to a new output file when the estimated file size
+// is 0.5x-2x the target file size. If there are overlapping grandparent files,
+// this splitter will attempt to split at a grandparent boundary. For example,
+// consider the example where a compaction wrote 'd' to the current output file,
+// and the next key has a user key 'g':
+//
+//	                              previous key   next key
+//		                                 |           |
+//		                                 |           |
+//		                 +---------------|----+   +--|----------+
+//		  grandparents:  |       000006  |    |   |  | 000007   |
+//		                 +---------------|----+   +--|----------+
+//		                 a    b          d    e   f  g       i
+//
+// Splitting the output file F before 'g' will ensure that the current output
+// file F does not overlap the grandparent file 000007. Aligning sstable
+// boundaries like this can significantly reduce write amplification, since a
+// subsequent compaction of F into the grandparent level will avoid needlessly
+// rewriting any keys within 000007 that do not overlap F's bounds. Consider the
+// following compaction:
+//
+//	                       +----------------------+
+//		  input            |                      |
+//		  level            +----------------------+
+//		                              \/
+//		           +---------------+       +---------------+
+//		  output   |XXXXXXX|       |       |      |XXXXXXXX|
+//		  level    +---------------+       +---------------+
+//
+// The input-level file overlaps two files in the output level, but only
+// partially. The beginning of the first output-level file and the end of the
+// second output-level file will be rewritten verbatim. This write I/O is
+// "wasted" in the sense that no merging is being performed.
+//
+// To prevent the above waste, this splitter attempts to split output files
+// before the start key of grandparent files. It still strives to write output
+// files of approximately the target file size, by constraining this splitting
+// at grandparent points to apply only if the current output's file size is
+// about the right order of magnitude.
+//
+// Note that, unlike most other splitters, this splitter does not guarantee that
+// it will advise splits only at user key change boundaries.
 type fileSizeSplitter struct {
-	maxFileSize uint64
+	frontier              frontier
+	targetFileSize        uint64
+	atGrandparentBoundary bool
+	boundariesObserved    uint64
+	nextGrandparent       *fileMetadata
+	grandparents          manifest.LevelIterator
+}
+
+func newFileSizeSplitter(
+	f *frontiers, targetFileSize uint64, grandparents manifest.LevelIterator,
+) *fileSizeSplitter {
+	s := &fileSizeSplitter{targetFileSize: targetFileSize}
+	s.nextGrandparent = grandparents.First()
+	s.grandparents = grandparents
+	if s.nextGrandparent != nil {
+		s.frontier.Init(f, s.nextGrandparent.Smallest.UserKey, s.reached)
+	}
+	return s
+}
+
+func (f *fileSizeSplitter) reached(nextKey []byte) []byte {
+	f.atGrandparentBoundary = true
+	f.boundariesObserved++
+	// NB: f.grandparents is a bounded iterator, constrained to the compaction
+	// key range.
+	f.nextGrandparent = f.grandparents.Next()
+	if f.nextGrandparent == nil {
+		return nil
+	}
+	// TODO(jackson): Should we also split before or immediately after
+	// grandparents' largest keys? Splitting before the start boundary prevents
+	// overlap with the grandparent. Also splitting after the end boundary may
+	// increase the probability of move compactions.
+	return f.nextGrandparent.Smallest.UserKey
 }
 
 func (f *fileSizeSplitter) shouldSplitBefore(key *InternalKey, tw *sstable.Writer) maybeSplit {
-	// The Kind != RangeDelete part exists because EstimatedSize doesn't grow
-	// rightaway when a range tombstone is added to the fragmenter. It's always
-	// better to make a sequence of range tombstones visible to the fragmenter.
-	if key.Kind() != InternalKeyKindRangeDelete && tw != nil &&
-		tw.EstimatedSize() >= f.maxFileSize {
+	atGrandparentBoundary := f.atGrandparentBoundary
+
+	// Clear f.atGrandparentBoundary unconditionally.
+	//
+	// This is a bit subtle. Even if do decide to split, it's possible that a
+	// higher-level splitter will ignore our request (eg, because we're between
+	// two internal keys with the same user key). In this case, the next call to
+	// shouldSplitBefore will find atGrandparentBoundary=false. This is
+	// desirable, because in this case we would've already written the earlier
+	// key with the same user key to the output file. The current output file is
+	// already doomed to overlap the grandparent whose bound triggered
+	// atGrandparentBoundary=true. We should continue on, waiting for the next
+	// grandparent boundary.
+	f.atGrandparentBoundary = false
+
+	// If the key is a range tombstone, the EstimatedSize may not grow right
+	// away when a range tombstone is added to the fragmenter: It's dependent on
+	// whether or not the this new range deletion will start a new fragment.
+	// Range deletions are rare, so we choose to simply not split yet.
+	// TODO(jackson): Reconsider this, and consider range keys too as a part of
+	// #2321.
+	if key.Kind() == InternalKeyKindRangeDelete || tw == nil {
+		return noSplit
+	}
+
+	estSize := tw.EstimatedSize()
+	switch {
+	case estSize < f.targetFileSize/2:
+		// The estimated file size is less than half the target file size. Don't
+		// split it, even if currently aligned with a grandparent file because
+		// it's too small.
+		return noSplit
+	case estSize >= 2*f.targetFileSize:
+		// The estimated file size is double the target file size. Split it even
+		// if we were not aligned with a grandparent file boundary to avoid
+		// excessively exceeding the target file size.
+		return splitNow
+	case !atGrandparentBoundary:
+		// Don't split if we're not at a grandparent, except if we've exhausted
+		// all the grandparents overlapping this compaction's key range. Then we
+		// may want to split purely based on file size.
+		if f.nextGrandparent == nil {
+			// There are no more grandparents. Optimize for the target file size
+			// and split as soon as we hit the target file size.
+			if estSize >= f.targetFileSize {
+				return splitNow
+			}
+		}
+		return noSplit
+	default:
+		// INVARIANT: atGrandparentBoundary
+		// INVARIANT: targetSize/2 < estSize < 2*targetSize
+		//
+		// The estimated file size is close enough to the target file size that
+		// we should consider splitting.
+		//
+		// Determine whether to split now based on how many grandparent
+		// boundaries we have already observed while building this output file.
+		// The intuition here is that if the grandparent level is dense in this
+		// part of the keyspace, we're likely to continue to have more
+		// opportunities to split this file aligned with a grandparent. If this
+		// is the first grandparent boundary observed, we split immediately
+		// (we're already at ≥50% the target file size). Otherwise, each
+		// overlapping grandparent we've observed increases the minimum file
+		// size by 5% of the target file size, up to at most 90% of the target
+		// file size.
+		//
+		// TODO(jackson): The particular thresholds are somewhat unprincipled.
+		// This is the same heuristic as RocksDB implements. Is there are more
+		// principled formulation that can, further reduce w-amp, produce files
+		// closer to the target file size, or is more understandable?
+
+		// NB: Subtract 1 from `boundariesObserved` to account for the current
+		// boundary we're considering splitting at. `reached` will have
+		// incremented it at the same time it set `atGrandparentBoundary`.
+		minimumPctOfTargetSize := 50 + 5*minUint64(f.boundariesObserved-1, 8)
+		if estSize < (minimumPctOfTargetSize*f.targetFileSize)/100 {
+			return noSplit
+		}
 		return splitNow
 	}
-	return noSplit
+}
+
+func minUint64(a, b uint64) uint64 {
+	if b < a {
+		a = b
+	}
+	return a
 }
 
 func (f *fileSizeSplitter) onNewOutput(key []byte) []byte {
+	f.boundariesObserved = 0
 	return nil
 }
 
@@ -2822,30 +2975,32 @@ func (d *DB) runCompaction(
 		return nil
 	}
 
-	// compactionOutputSplitters contain all logic to determine whether the
-	// compaction loop should stop writing to one output sstable and switch to
-	// a new one. Some splitters can wrap other splitters, and
-	// the splitterGroup can be composed of multiple splitters. In this case,
-	// we start off with splitters for file sizes, grandparent limits, and (for
-	// L0 splits) L0 limits, before wrapping them in an splitterGroup.
+	// Build a compactionOutputSplitter that contains all logic to determine
+	// whether the compaction loop should stop writing to one output sstable and
+	// switch to a new one. Some splitters can wrap other splitters, and the
+	// splitterGroup can be composed of multiple splitters. In this case, we
+	// start off with splitters for file sizes, grandparent limits, and (for L0
+	// splits) L0 limits, before wrapping them in an splitterGroup.
+	sizeSplitter := newFileSizeSplitter(&iter.frontiers, c.maxOutputFileSize, c.grandparents.Iter())
+	unsafePrevUserKey := func() []byte {
+		// Return the largest point key written to tw or the start of
+		// the current range deletion in the fragmenter, whichever is
+		// greater.
+		prevPoint := prevPointKey.UnsafeKey()
+		if c.cmp(prevPoint.UserKey, c.rangeDelFrag.Start()) > 0 {
+			return prevPoint.UserKey
+		}
+		return c.rangeDelFrag.Start()
+	}
 	outputSplitters := []compactionOutputSplitter{
 		// We do not split the same user key across different sstables within
 		// one flush or compaction. The fileSizeSplitter may request a split in
 		// the middle of a user key, so the userKeyChangeSplitter ensures we are
 		// at a user key change boundary when doing a split.
 		&userKeyChangeSplitter{
-			cmp:      c.cmp,
-			splitter: &fileSizeSplitter{maxFileSize: c.maxOutputFileSize},
-			unsafePrevUserKey: func() []byte {
-				// Return the largest point key written to tw or the start of
-				// the current range deletion in the fragmenter, whichever is
-				// greater.
-				prevPoint := prevPointKey.UnsafeKey()
-				if c.cmp(prevPoint.UserKey, c.rangeDelFrag.Start()) > 0 {
-					return prevPoint.UserKey
-				}
-				return c.rangeDelFrag.Start()
-			},
+			cmp:               c.cmp,
+			splitter:          sizeSplitter,
+			unsafePrevUserKey: unsafePrevUserKey,
 		},
 		newLimitFuncSplitter(&iter.frontiers, c.findGrandparentLimit),
 	}

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1265,7 +1265,18 @@ func TestManualCompaction(t *testing.T) {
 		return FormatMajorVersion(int(min) + rng.Intn(int(max)-int(min)+1))
 	}
 
+	var compactionLog bytes.Buffer
+	compactionLogEventListener := &EventListener{
+		CompactionEnd: func(info CompactionInfo) {
+			// Ensure determinism.
+			info.JobID = 1
+			info.Duration = time.Second
+			info.TotalDuration = time.Second
+			fmt.Fprintln(&compactionLog, info.String())
+		},
+	}
 	reset := func(minVersion, maxVersion FormatMajorVersion) {
+		compactionLog.Reset()
 		if d != nil {
 			require.NoError(t, closeAllSnapshots(d))
 			require.NoError(t, d.Close())
@@ -1274,11 +1285,12 @@ func TestManualCompaction(t *testing.T) {
 		require.NoError(t, mem.MkdirAll("ext", 0755))
 
 		opts := (&Options{
-			FS:                 mem,
-			DebugCheck:         DebugCheckLevels,
-			FormatMajorVersion: randVersion(minVersion, maxVersion),
+			FS:                          mem,
+			DebugCheck:                  DebugCheckLevels,
+			DisableAutomaticCompactions: true,
+			EventListener:               compactionLogEventListener,
+			FormatMajorVersion:          randVersion(minVersion, maxVersion),
 		}).WithFSDefaults()
-		opts.DisableAutomaticCompactions = true
 
 		var err error
 		d, err = Open("", opts)
@@ -1374,6 +1386,7 @@ func TestManualCompaction(t *testing.T) {
 				opts := (&Options{
 					FS:                          mem,
 					DebugCheck:                  DebugCheckLevels,
+					EventListener:               compactionLogEventListener,
 					FormatMajorVersion:          randVersion(minVersion, maxVersion),
 					DisableAutomaticCompactions: true,
 				}).WithFSDefaults()
@@ -1388,6 +1401,9 @@ func TestManualCompaction(t *testing.T) {
 					s = d.mu.versions.currentVersion().DebugString(base.DefaultFormatter)
 				}
 				return s
+
+			case "file-sizes":
+				return runTableFileSizesCmd(td, d)
 
 			case "flush":
 				if err := d.Flush(); err != nil {
@@ -1423,6 +1439,16 @@ func TestManualCompaction(t *testing.T) {
 				}
 				iter := snap.NewIter(nil)
 				return runIterCmd(td, iter, true)
+
+			case "lsm":
+				return runLSMCmd(td, d)
+
+			case "populate":
+				b := d.NewBatch()
+				runPopulateCmd(t, td, b)
+				count := b.Count()
+				require.NoError(t, b.Commit(nil))
+				return fmt.Sprintf("wrote %d keys\n", count)
 
 			case "async-compact":
 				var s string
@@ -1528,6 +1554,11 @@ func TestManualCompaction(t *testing.T) {
 					}
 				}
 				return ""
+
+			case "compaction-log":
+				defer compactionLog.Reset()
+				return compactionLog.String()
+
 			default:
 				return fmt.Sprintf("unknown command: %s", td.Cmd)
 			}
@@ -1565,6 +1596,11 @@ func TestManualCompaction(t *testing.T) {
 			minVersion: FormatRangeKeys,
 			maxVersion: FormatNewest,
 			verbose:    true,
+		},
+		{
+			testData:   "testdata/manual_compaction_file_boundaries",
+			minVersion: FormatMostCompatible,
+			maxVersion: FormatNewest,
 		},
 	}
 

--- a/data_test.go
+++ b/data_test.go
@@ -997,8 +997,9 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 			key := base.ParseInternalKey(data[:i])
 			valueStr := data[i+1:]
 			value := []byte(valueStr)
-			if valueStr == "<largeval>" {
-				value = make([]byte, 4096)
+			var randBytes int
+			if n, err := fmt.Sscanf(valueStr, "<rand-bytes=%d>", &randBytes); err == nil && n == 1 {
+				value = make([]byte, randBytes)
 				rnd := rand.New(rand.NewSource(int64(key.SeqNum())))
 				if _, err := rnd.Read(value[:]); err != nil {
 					return nil, err

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -167,15 +167,15 @@ close-snapshot
 # automatic compaction compacts before we've closen the snapshot.
 define snapshots=(103) level-max-bytes=(L5 : 1000) auto-compactions=off
 L5
-b.SET.200:<largeval> bb.SET.203:<largeval> cc.SET.204:<largeval>
+b.SET.200:<rand-bytes=4096> bb.SET.203:<rand-bytes=4096> cc.SET.204:<rand-bytes=4096>
 L5
-d.SET.302:<largeval> dd.SET.303:<largeval> de.SET.303:<largeval>
+d.SET.302:<rand-bytes=4096> dd.SET.303:<rand-bytes=4096> de.SET.303:<rand-bytes=4096>
 L5
-m.SET.320:<largeval> n.SET.330:<largeval> o.SET.340:<largeval>
+m.SET.320:<rand-bytes=4096> n.SET.330:<rand-bytes=4096> o.SET.340:<rand-bytes=4096>
 L6
-a.SET.55:<largeval> b.SET.100:<largeval> c.SET.101:<largeval> d.SET.102:<largeval> a.RANGEDEL.103:e
+a.SET.55:<rand-bytes=4096> b.SET.100:<rand-bytes=4096> c.SET.101:<rand-bytes=4096> d.SET.102:<rand-bytes=4096> a.RANGEDEL.103:e
 L6
-f.SET.30:<largeval> z.SET.31:<largeval>
+f.SET.30:<rand-bytes=4096> z.SET.31:<rand-bytes=4096>
 ----
 5:
   000004:[b#200,SET-cc#204,SET]
@@ -214,11 +214,11 @@ define level-max-bytes=(L5 : 1000) auto-compactions=off
 L5
 a.DEL.101: b.DEL.102: c.DEL.103:
 L5
-m.SET.107:<largeval>
+m.SET.107:<rand-bytes=4096>
 L6
-a.SET.001:<largeval> b.SET.002:<largeval> c.SET.003:<largeval>
+a.SET.001:<rand-bytes=4096> b.SET.002:<rand-bytes=4096> c.SET.003:<rand-bytes=4096>
 L6
-f.SET.007:<largeval> x.SET.008:<largeval> z.SET.009:<largeval>
+f.SET.007:<rand-bytes=4096> x.SET.008:<rand-bytes=4096> z.SET.009:<rand-bytes=4096>
 ----
 5:
   000004:[a#101,DEL-c#103,DEL]
@@ -342,9 +342,9 @@ a.DEL.101: b.SET.102:
 L5
 e.RANGEDEL.107:f f.SET.108:
 L6
-a.SET.001:<largeval> b.SET.002:<largeval> c.SET.003:<largeval>
+a.SET.001:<rand-bytes=4096> b.SET.002:<rand-bytes=4096> c.SET.003:<rand-bytes=4096>
 L6
-e.SET.007:<largeval> f.SET.008:<largeval> g.SET.009:<largeval>
+e.SET.007:<rand-bytes=4096> f.SET.008:<rand-bytes=4096> g.SET.009:<rand-bytes=4096>
 ----
 5:
   000004:[a#101,DEL-b#102,SET]
@@ -385,9 +385,9 @@ a.DEL.101: b.SET.102:
 L5
 e.RANGEDEL.107:f f.SET.108:
 L6
-a.SET.001:<largeval> b.SET.002:<largeval> c.SET.003:<largeval>
+a.SET.001:<rand-bytes=4096> b.SET.002:<rand-bytes=4096> c.SET.003:<rand-bytes=4096>
 L6
-e.SET.007:<largeval> f.SET.008:<largeval> g.SET.009:<largeval>
+e.SET.007:<rand-bytes=4096> f.SET.008:<rand-bytes=4096> g.SET.009:<rand-bytes=4096>
 ----
 5:
   000004:[a#101,DEL-b#102,SET]

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -1125,8 +1125,8 @@ compact g-z
   000009:[b#2,SET-b#2,SET]
 6:
   000006:[a#1,SET-g#inf,RANGEDEL]
-  000049:[h#0,SET-k#0,SET]
-  000050:[m#0,SET-y#0,SET]
+  000048:[h#0,SET-k#0,SET]
+  000049:[m#0,SET-y#0,SET]
 
 batch
 set t t
@@ -1136,11 +1136,11 @@ flush
 ----
 0.0:
   000009:[b#2,SET-b#2,SET]
-  000052:[t#10,SET-t#10,SET]
+  000051:[t#10,SET-t#10,SET]
 6:
   000006:[a#1,SET-g#inf,RANGEDEL]
-  000049:[h#0,SET-k#0,SET]
-  000050:[m#0,SET-y#0,SET]
+  000048:[h#0,SET-k#0,SET]
+  000049:[m#0,SET-y#0,SET]
 
 # Compact everything. The batch-committed keys with zeroed sequence numbers (eg,
 # h, i, j, k, m, q, y) should all still exist because the a-z tombstone in
@@ -1149,9 +1149,9 @@ flush
 compact a-z
 ----
 6:
-  000063:[a#0,SET-i#0,SET]
-  000064:[j#0,SET-q#0,SET]
-  000065:[t#0,SET-y#0,SET]
+  000062:[a#0,SET-i#0,SET]
+  000063:[j#0,SET-q#0,SET]
+  000064:[t#0,SET-y#0,SET]
 
 iter
 first

--- a/testdata/manual_compaction_file_boundaries
+++ b/testdata/manual_compaction_file_boundaries
@@ -1,0 +1,518 @@
+# Test the file-size grandparent boundary alignment heuristic. This test sets up
+# L3 with a file at each of 'a', 'b', ..., 'z'. It also creates a single file in
+# L2 spanning a-z. Then, it commits, flushes and compacts into L1 keys 'a@1',
+# 'aa@1', 'ab@1', ..., 'zz@1'. Finally, it tests compacting L1 into L2.
+#
+# With L3 as the grandparent level, the alignment heuristic should attempt to
+# align the output files with grandparent's boundaries. Each output file should
+# have a key range formed by the prefix of a single letter.
+
+define target-file-sizes=(5000, 5000, 5000, 5000)
+L2
+  a.SET.101:<rand-bytes=1000>
+  z.SET.102:<rand-bytes=1000>
+L3
+  a.SET.001:<rand-bytes=10000>
+L3
+  b.SET.002:<rand-bytes=10000>
+L3
+  c.SET.003:<rand-bytes=10000>
+L3
+  d.SET.004:<rand-bytes=10000>
+L3
+  e.SET.005:<rand-bytes=10000>
+L3
+  f.SET.006:<rand-bytes=10000>
+L3
+  g.SET.007:<rand-bytes=10000>
+L3
+  h.SET.008:<rand-bytes=10000>
+L3
+  i.SET.009:<rand-bytes=10000>
+L3
+  j.SET.010:<rand-bytes=10000>
+L3
+  k.SET.011:<rand-bytes=10000>
+L3
+  l.SET.012:<rand-bytes=10000>
+L3
+  m.SET.013:<rand-bytes=10000>
+L3
+  n.SET.014:<rand-bytes=10000>
+L3
+  o.SET.015:<rand-bytes=10000>
+L3
+  p.SET.016:<rand-bytes=10000>
+L3
+  q.SET.017:<rand-bytes=10000>
+L3
+  r.SET.018:<rand-bytes=10000>
+L3
+  s.SET.019:<rand-bytes=10000>
+L3
+  t.SET.020:<rand-bytes=10000>
+L3
+  u.SET.021:<rand-bytes=10000>
+L3
+  v.SET.022:<rand-bytes=10000>
+L3
+  w.SET.023:<rand-bytes=10000>
+L3
+  x.SET.024:<rand-bytes=10000>
+L3
+  y.SET.025:<rand-bytes=10000>
+L3
+  z.SET.026:<rand-bytes=10000>
+----
+2:
+  000004:[a#101,SET-z#102,SET]
+3:
+  000005:[a#1,SET-a#1,SET]
+  000006:[b#2,SET-b#2,SET]
+  000007:[c#3,SET-c#3,SET]
+  000008:[d#4,SET-d#4,SET]
+  000009:[e#5,SET-e#5,SET]
+  000010:[f#6,SET-f#6,SET]
+  000011:[g#7,SET-g#7,SET]
+  000012:[h#8,SET-h#8,SET]
+  000013:[i#9,SET-i#9,SET]
+  000014:[j#10,SET-j#10,SET]
+  000015:[k#11,SET-k#11,SET]
+  000016:[l#12,SET-l#12,SET]
+  000017:[m#13,SET-m#13,SET]
+  000018:[n#14,SET-n#14,SET]
+  000019:[o#15,SET-o#15,SET]
+  000020:[p#16,SET-p#16,SET]
+  000021:[q#17,SET-q#17,SET]
+  000022:[r#18,SET-r#18,SET]
+  000023:[s#19,SET-s#19,SET]
+  000024:[t#20,SET-t#20,SET]
+  000025:[u#21,SET-u#21,SET]
+  000026:[v#22,SET-v#22,SET]
+  000027:[w#23,SET-w#23,SET]
+  000028:[x#24,SET-x#24,SET]
+  000029:[y#25,SET-y#25,SET]
+  000030:[z#26,SET-z#26,SET]
+
+populate keylen=2 vallen=200 timestamps=(1)
+----
+wrote 702 keys
+
+flush
+----
+0.0:
+  000033:[a@1#103,SET-aw@1#126,SET]
+  000034:[ax@1#127,SET-bt@1#150,SET]
+  000035:[bu@1#151,SET-cq@1#174,SET]
+  000036:[cr@1#175,SET-dn@1#198,SET]
+  000037:[do@1#199,SET-ek@1#222,SET]
+  000038:[el@1#223,SET-fh@1#246,SET]
+  000039:[fi@1#247,SET-ge@1#270,SET]
+  000040:[gf@1#271,SET-hb@1#294,SET]
+  000041:[hc@1#295,SET-hz@1#318,SET]
+  000042:[i@1#319,SET-iw@1#342,SET]
+  000043:[ix@1#343,SET-jt@1#366,SET]
+  000044:[ju@1#367,SET-kq@1#390,SET]
+  000045:[kr@1#391,SET-ln@1#414,SET]
+  000046:[lo@1#415,SET-mk@1#438,SET]
+  000047:[ml@1#439,SET-nh@1#462,SET]
+  000048:[ni@1#463,SET-oe@1#486,SET]
+  000049:[of@1#487,SET-pb@1#510,SET]
+  000050:[pc@1#511,SET-pz@1#534,SET]
+  000051:[q@1#535,SET-qw@1#558,SET]
+  000052:[qx@1#559,SET-rt@1#582,SET]
+  000053:[ru@1#583,SET-sq@1#606,SET]
+  000054:[sr@1#607,SET-tn@1#630,SET]
+  000055:[to@1#631,SET-uk@1#654,SET]
+  000056:[ul@1#655,SET-vh@1#678,SET]
+  000057:[vi@1#679,SET-we@1#702,SET]
+  000058:[wf@1#703,SET-xb@1#726,SET]
+  000059:[xc@1#727,SET-xz@1#750,SET]
+  000060:[y@1#751,SET-yw@1#774,SET]
+  000061:[yx@1#775,SET-zt@1#798,SET]
+  000062:[zu@1#799,SET-zz@1#804,SET]
+2:
+  000004:[a#101,SET-z#102,SET]
+3:
+  000005:[a#1,SET-a#1,SET]
+  000006:[b#2,SET-b#2,SET]
+  000007:[c#3,SET-c#3,SET]
+  000008:[d#4,SET-d#4,SET]
+  000009:[e#5,SET-e#5,SET]
+  000010:[f#6,SET-f#6,SET]
+  000011:[g#7,SET-g#7,SET]
+  000012:[h#8,SET-h#8,SET]
+  000013:[i#9,SET-i#9,SET]
+  000014:[j#10,SET-j#10,SET]
+  000015:[k#11,SET-k#11,SET]
+  000016:[l#12,SET-l#12,SET]
+  000017:[m#13,SET-m#13,SET]
+  000018:[n#14,SET-n#14,SET]
+  000019:[o#15,SET-o#15,SET]
+  000020:[p#16,SET-p#16,SET]
+  000021:[q#17,SET-q#17,SET]
+  000022:[r#18,SET-r#18,SET]
+  000023:[s#19,SET-s#19,SET]
+  000024:[t#20,SET-t#20,SET]
+  000025:[u#21,SET-u#21,SET]
+  000026:[v#22,SET-v#22,SET]
+  000027:[w#23,SET-w#23,SET]
+  000028:[x#24,SET-x#24,SET]
+  000029:[y#25,SET-y#25,SET]
+  000030:[z#26,SET-z#26,SET]
+
+compact a-zz L0
+----
+1:
+  000063:[a@1#103,SET-aw@1#126,SET]
+  000064:[ax@1#127,SET-bt@1#150,SET]
+  000065:[bu@1#151,SET-cq@1#174,SET]
+  000066:[cr@1#175,SET-dn@1#198,SET]
+  000067:[do@1#199,SET-ek@1#222,SET]
+  000068:[el@1#223,SET-fh@1#246,SET]
+  000069:[fi@1#247,SET-ge@1#270,SET]
+  000070:[gf@1#271,SET-hb@1#294,SET]
+  000071:[hc@1#295,SET-hz@1#318,SET]
+  000072:[i@1#319,SET-iw@1#342,SET]
+  000073:[ix@1#343,SET-jt@1#366,SET]
+  000074:[ju@1#367,SET-kq@1#390,SET]
+  000075:[kr@1#391,SET-ln@1#414,SET]
+  000076:[lo@1#415,SET-mk@1#438,SET]
+  000077:[ml@1#439,SET-nh@1#462,SET]
+  000078:[ni@1#463,SET-oe@1#486,SET]
+  000079:[of@1#487,SET-pb@1#510,SET]
+  000080:[pc@1#511,SET-pz@1#534,SET]
+  000081:[q@1#535,SET-qw@1#558,SET]
+  000082:[qx@1#559,SET-rt@1#582,SET]
+  000083:[ru@1#583,SET-sq@1#606,SET]
+  000084:[sr@1#607,SET-tn@1#630,SET]
+  000085:[to@1#631,SET-uk@1#654,SET]
+  000086:[ul@1#655,SET-vh@1#678,SET]
+  000087:[vi@1#679,SET-we@1#702,SET]
+  000088:[wf@1#703,SET-xb@1#726,SET]
+  000089:[xc@1#727,SET-xz@1#750,SET]
+  000090:[y@1#751,SET-yw@1#774,SET]
+  000091:[yx@1#775,SET-zt@1#798,SET]
+  000092:[zu@1#799,SET-zz@1#804,SET]
+2:
+  000004:[a#101,SET-z#102,SET]
+3:
+  000005:[a#1,SET-a#1,SET]
+  000006:[b#2,SET-b#2,SET]
+  000007:[c#3,SET-c#3,SET]
+  000008:[d#4,SET-d#4,SET]
+  000009:[e#5,SET-e#5,SET]
+  000010:[f#6,SET-f#6,SET]
+  000011:[g#7,SET-g#7,SET]
+  000012:[h#8,SET-h#8,SET]
+  000013:[i#9,SET-i#9,SET]
+  000014:[j#10,SET-j#10,SET]
+  000015:[k#11,SET-k#11,SET]
+  000016:[l#12,SET-l#12,SET]
+  000017:[m#13,SET-m#13,SET]
+  000018:[n#14,SET-n#14,SET]
+  000019:[o#15,SET-o#15,SET]
+  000020:[p#16,SET-p#16,SET]
+  000021:[q#17,SET-q#17,SET]
+  000022:[r#18,SET-r#18,SET]
+  000023:[s#19,SET-s#19,SET]
+  000024:[t#20,SET-t#20,SET]
+  000025:[u#21,SET-u#21,SET]
+  000026:[v#22,SET-v#22,SET]
+  000027:[w#23,SET-w#23,SET]
+  000028:[x#24,SET-x#24,SET]
+  000029:[y#25,SET-y#25,SET]
+  000030:[z#26,SET-z#26,SET]
+
+# Perform the actual test. Compacting L1 into L2 should use L3's boundaries to
+# inform compaction output splitting.
+#
+compact a-zz L1
+----
+2:
+  000093:[a#101,SET-az@1#129,SET]
+  000094:[b@1#130,SET-bz@1#156,SET]
+  000095:[c@1#157,SET-cz@1#183,SET]
+  000096:[d@1#184,SET-dz@1#210,SET]
+  000097:[e@1#211,SET-ez@1#237,SET]
+  000098:[f@1#238,SET-fz@1#264,SET]
+  000099:[g@1#265,SET-gz@1#291,SET]
+  000100:[h@1#292,SET-hz@1#318,SET]
+  000101:[i@1#319,SET-iz@1#345,SET]
+  000102:[j@1#346,SET-jz@1#372,SET]
+  000103:[k@1#373,SET-kz@1#399,SET]
+  000104:[l@1#400,SET-lz@1#426,SET]
+  000105:[m@1#427,SET-mz@1#453,SET]
+  000106:[n@1#454,SET-nz@1#480,SET]
+  000107:[o@1#481,SET-oz@1#507,SET]
+  000108:[p@1#508,SET-pz@1#534,SET]
+  000109:[q@1#535,SET-qz@1#561,SET]
+  000110:[r@1#562,SET-rz@1#588,SET]
+  000111:[s@1#589,SET-sz@1#615,SET]
+  000112:[t@1#616,SET-tz@1#642,SET]
+  000113:[u@1#643,SET-uz@1#669,SET]
+  000114:[v@1#670,SET-vz@1#696,SET]
+  000115:[w@1#697,SET-wz@1#723,SET]
+  000116:[x@1#724,SET-xz@1#750,SET]
+  000117:[y@1#751,SET-yz@1#777,SET]
+  000118:[z#102,SET-zr@1#796,SET]
+  000119:[zs@1#797,SET-zz@1#804,SET]
+3:
+  000005:[a#1,SET-a#1,SET]
+  000006:[b#2,SET-b#2,SET]
+  000007:[c#3,SET-c#3,SET]
+  000008:[d#4,SET-d#4,SET]
+  000009:[e#5,SET-e#5,SET]
+  000010:[f#6,SET-f#6,SET]
+  000011:[g#7,SET-g#7,SET]
+  000012:[h#8,SET-h#8,SET]
+  000013:[i#9,SET-i#9,SET]
+  000014:[j#10,SET-j#10,SET]
+  000015:[k#11,SET-k#11,SET]
+  000016:[l#12,SET-l#12,SET]
+  000017:[m#13,SET-m#13,SET]
+  000018:[n#14,SET-n#14,SET]
+  000019:[o#15,SET-o#15,SET]
+  000020:[p#16,SET-p#16,SET]
+  000021:[q#17,SET-q#17,SET]
+  000022:[r#18,SET-r#18,SET]
+  000023:[s#19,SET-s#19,SET]
+  000024:[t#20,SET-t#20,SET]
+  000025:[u#21,SET-u#21,SET]
+  000026:[v#22,SET-v#22,SET]
+  000027:[w#23,SET-w#23,SET]
+  000028:[x#24,SET-x#24,SET]
+  000029:[y#25,SET-y#25,SET]
+  000030:[z#26,SET-z#26,SET]
+
+file-sizes
+----
+L2:
+  000093:[a#101,1-az@1#129,1]: 7609 bytes (7.4 K)
+  000094:[b@1#130,1-bz@1#156,1]: 6602 bytes (6.4 K)
+  000095:[c@1#157,1-cz@1#183,1]: 6602 bytes (6.4 K)
+  000096:[d@1#184,1-dz@1#210,1]: 6602 bytes (6.4 K)
+  000097:[e@1#211,1-ez@1#237,1]: 6602 bytes (6.4 K)
+  000098:[f@1#238,1-fz@1#264,1]: 6602 bytes (6.4 K)
+  000099:[g@1#265,1-gz@1#291,1]: 6602 bytes (6.4 K)
+  000100:[h@1#292,1-hz@1#318,1]: 6602 bytes (6.4 K)
+  000101:[i@1#319,1-iz@1#345,1]: 6602 bytes (6.4 K)
+  000102:[j@1#346,1-jz@1#372,1]: 6602 bytes (6.4 K)
+  000103:[k@1#373,1-kz@1#399,1]: 6602 bytes (6.4 K)
+  000104:[l@1#400,1-lz@1#426,1]: 6602 bytes (6.4 K)
+  000105:[m@1#427,1-mz@1#453,1]: 6602 bytes (6.4 K)
+  000106:[n@1#454,1-nz@1#480,1]: 6602 bytes (6.4 K)
+  000107:[o@1#481,1-oz@1#507,1]: 6602 bytes (6.4 K)
+  000108:[p@1#508,1-pz@1#534,1]: 6602 bytes (6.4 K)
+  000109:[q@1#535,1-qz@1#561,1]: 6601 bytes (6.4 K)
+  000110:[r@1#562,1-rz@1#588,1]: 6602 bytes (6.4 K)
+  000111:[s@1#589,1-sz@1#615,1]: 6602 bytes (6.4 K)
+  000112:[t@1#616,1-tz@1#642,1]: 6602 bytes (6.4 K)
+  000113:[u@1#643,1-uz@1#669,1]: 6602 bytes (6.4 K)
+  000114:[v@1#670,1-vz@1#696,1]: 6602 bytes (6.4 K)
+  000115:[w@1#697,1-wz@1#723,1]: 6602 bytes (6.4 K)
+  000116:[x@1#724,1-xz@1#750,1]: 6602 bytes (6.4 K)
+  000117:[y@1#751,1-yz@1#777,1]: 6602 bytes (6.4 K)
+  000118:[z#102,1-zr@1#796,1]: 5889 bytes (5.8 K)
+  000119:[zs@1#797,1-zz@1#804,1]: 2483 bytes (2.4 K)
+L3:
+  000005:[a#1,1-a#1,1]: 10775 bytes (10 K)
+  000006:[b#2,1-b#2,1]: 10775 bytes (10 K)
+  000007:[c#3,1-c#3,1]: 10775 bytes (10 K)
+  000008:[d#4,1-d#4,1]: 10775 bytes (10 K)
+  000009:[e#5,1-e#5,1]: 10775 bytes (10 K)
+  000010:[f#6,1-f#6,1]: 10775 bytes (10 K)
+  000011:[g#7,1-g#7,1]: 10775 bytes (10 K)
+  000012:[h#8,1-h#8,1]: 10775 bytes (10 K)
+  000013:[i#9,1-i#9,1]: 10775 bytes (10 K)
+  000014:[j#10,1-j#10,1]: 10775 bytes (10 K)
+  000015:[k#11,1-k#11,1]: 10775 bytes (10 K)
+  000016:[l#12,1-l#12,1]: 10775 bytes (10 K)
+  000017:[m#13,1-m#13,1]: 10775 bytes (10 K)
+  000018:[n#14,1-n#14,1]: 10775 bytes (10 K)
+  000019:[o#15,1-o#15,1]: 10775 bytes (10 K)
+  000020:[p#16,1-p#16,1]: 10775 bytes (10 K)
+  000021:[q#17,1-q#17,1]: 10775 bytes (10 K)
+  000022:[r#18,1-r#18,1]: 10775 bytes (10 K)
+  000023:[s#19,1-s#19,1]: 10775 bytes (10 K)
+  000024:[t#20,1-t#20,1]: 10775 bytes (10 K)
+  000025:[u#21,1-u#21,1]: 10775 bytes (10 K)
+  000026:[v#22,1-v#22,1]: 10775 bytes (10 K)
+  000027:[w#23,1-w#23,1]: 10775 bytes (10 K)
+  000028:[x#24,1-x#24,1]: 10775 bytes (10 K)
+  000029:[y#25,1-y#25,1]: 10775 bytes (10 K)
+  000030:[z#26,1-z#26,1]: 10775 bytes (10 K)
+
+# Test a scenario where there exists a grandparent file (in L3), but the L1->L2
+# compaction doesn't reach it until late in the compaction. The output file
+# should be split at 2x the target file size (~10K), despite not being aligned
+# with a grandparent.
+#
+# Additionally, when the compaction does reach the grandparent's start bound,
+# the compaction should NOT split the output if the current output is less than
+# 0.5x the target file size (~2.5K).
+#
+# Lastly, once past the final grandparent, the compaction should optimize for
+# cutting as close to file size as possible, resulting in an output file ~5K.
+
+define target-file-sizes=(5000, 5000, 5000, 5000)
+L1
+  a.SET.201:<rand-bytes=1000>
+  b.SET.202:<rand-bytes=1000>
+  c.SET.203:<rand-bytes=1000>
+  d.SET.204:<rand-bytes=1000>
+  e.SET.205:<rand-bytes=1000>
+  f.SET.206:<rand-bytes=1000>
+  g.SET.207:<rand-bytes=1000>
+  h.SET.208:<rand-bytes=1000>
+  i.SET.209:<rand-bytes=1000>
+  j.SET.210:<rand-bytes=1000>
+  k.SET.211:<rand-bytes=1000>
+  l.SET.212:<rand-bytes=1000>
+  m.SET.213:<rand-bytes=1000>
+  n.SET.214:<rand-bytes=1000>
+  o.SET.215:<rand-bytes=1000>
+L2
+  a.SET.101:<rand-bytes=10>
+  z.SET.102:<rand-bytes=10>
+L3
+  m.SET.001:<rand-bytes=10000>
+----
+1:
+  000004:[a#201,SET-o#215,SET]
+2:
+  000005:[a#101,SET-z#102,SET]
+3:
+  000006:[m#1,SET-m#1,SET]
+
+compact a-zz L1
+----
+2:
+  000007:[a#201,SET-j#210,SET]
+  000008:[k#211,SET-o#215,SET]
+  000009:[z#102,SET-z#102,SET]
+3:
+  000006:[m#1,SET-m#1,SET]
+
+file-sizes
+----
+L2:
+  000007:[a#201,1-j#210,1]: 10948 bytes (11 K)
+  000008:[k#211,1-o#215,1]: 5860 bytes (5.7 K)
+  000009:[z#102,1-z#102,1]: 780 bytes (780 B)
+L3:
+  000006:[m#1,1-m#1,1]: 10775 bytes (10 K)
+
+# Test the file-size splitter's adaptive tolerance for early-splitting at a
+# grandparent boundary. The L1->L2 compaction has many opportunities to split at
+# a grandparent boundary at file sizes ≥ 2.5K. Because it's seen more than 8
+# grandparent boundaries, waits until file size is ≥ 90% of the target file size
+# (eg, ~4.5K).
+
+define target-file-sizes=(5000, 5000, 5000, 5000)
+L1
+  a.SET.201:<rand-bytes=1000>
+  b.SET.202:<rand-bytes=1000>
+  c.SET.203:<rand-bytes=1000>
+  d.SET.204:<rand-bytes=1000>
+  e.SET.205:<rand-bytes=1000>
+  f.SET.206:<rand-bytes=1000>
+  g.SET.207:<rand-bytes=1000>
+  h.SET.208:<rand-bytes=1000>
+  i.SET.209:<rand-bytes=1000>
+  j.SET.210:<rand-bytes=1000>
+  k.SET.211:<rand-bytes=1000>
+  l.SET.212:<rand-bytes=1000>
+  m.SET.213:<rand-bytes=1000>
+  n.SET.214:<rand-bytes=1000>
+  o.SET.215:<rand-bytes=1000>
+L2
+  a.SET.101:<rand-bytes=10>
+  z.SET.102:<rand-bytes=10>
+L3
+  a.SET.001:<rand-bytes=1000>
+L3
+  ab.SET.002:<rand-bytes=1000>
+L3
+  ac.SET.003:<rand-bytes=1000>
+L3
+  ad.SET.004:<rand-bytes=1000>
+L3
+  ad.SET.005:<rand-bytes=1000>
+L3
+  ad.SET.006:<rand-bytes=1000>
+L3
+  ad.SET.007:<rand-bytes=1000>
+L3
+  ad.SET.008:<rand-bytes=1000>
+L3
+  c.SET.009:<rand-bytes=1000>
+L3
+  d.SET.010:<rand-bytes=1000>
+L3
+  e.SET.011:<rand-bytes=1000>
+L3
+  f.SET.012:<rand-bytes=1000>
+L3
+  m.SET.013:<rand-bytes=1000>
+----
+1:
+  000004:[a#201,SET-o#215,SET]
+2:
+  000005:[a#101,SET-z#102,SET]
+3:
+  000006:[a#1,SET-a#1,SET]
+  000007:[ab#2,SET-ab#2,SET]
+  000008:[ac#3,SET-ac#3,SET]
+  000013:[ad#8,SET-ad#8,SET]
+  000012:[ad#7,SET-ad#7,SET]
+  000011:[ad#6,SET-ad#6,SET]
+  000010:[ad#5,SET-ad#5,SET]
+  000009:[ad#4,SET-ad#4,SET]
+  000014:[c#9,SET-c#9,SET]
+  000015:[d#10,SET-d#10,SET]
+  000016:[e#11,SET-e#11,SET]
+  000017:[f#12,SET-f#12,SET]
+  000018:[m#13,SET-m#13,SET]
+
+compact a-zz L1
+----
+2:
+  000019:[a#201,SET-e#205,SET]
+  000020:[f#206,SET-l#212,SET]
+  000021:[m#213,SET-z#102,SET]
+3:
+  000006:[a#1,SET-a#1,SET]
+  000007:[ab#2,SET-ab#2,SET]
+  000008:[ac#3,SET-ac#3,SET]
+  000013:[ad#8,SET-ad#8,SET]
+  000012:[ad#7,SET-ad#7,SET]
+  000011:[ad#6,SET-ad#6,SET]
+  000010:[ad#5,SET-ad#5,SET]
+  000009:[ad#4,SET-ad#4,SET]
+  000014:[c#9,SET-c#9,SET]
+  000015:[d#10,SET-d#10,SET]
+  000016:[e#11,SET-e#11,SET]
+  000017:[f#12,SET-f#12,SET]
+  000018:[m#13,SET-m#13,SET]
+
+file-sizes
+----
+L2:
+  000019:[a#201,1-e#205,1]: 5860 bytes (5.7 K)
+  000020:[f#206,1-l#212,1]: 7886 bytes (7.7 K)
+  000021:[m#213,1-z#102,1]: 3823 bytes (3.7 K)
+L3:
+  000006:[a#1,1-a#1,1]: 1775 bytes (1.7 K)
+  000007:[ab#2,1-ab#2,1]: 1776 bytes (1.7 K)
+  000008:[ac#3,1-ac#3,1]: 1776 bytes (1.7 K)
+  000013:[ad#8,1-ad#8,1]: 1776 bytes (1.7 K)
+  000012:[ad#7,1-ad#7,1]: 1776 bytes (1.7 K)
+  000011:[ad#6,1-ad#6,1]: 1776 bytes (1.7 K)
+  000010:[ad#5,1-ad#5,1]: 1776 bytes (1.7 K)
+  000009:[ad#4,1-ad#4,1]: 1776 bytes (1.7 K)
+  000014:[c#9,1-c#9,1]: 1775 bytes (1.7 K)
+  000015:[d#10,1-d#10,1]: 1775 bytes (1.7 K)
+  000016:[e#11,1-e#11,1]: 1775 bytes (1.7 K)
+  000017:[f#12,1-f#12,1]: 1775 bytes (1.7 K)
+  000018:[m#13,1-m#13,1]: 1775 bytes (1.7 K)


### PR DESCRIPTION
This commit implements a compaction-splitting heuristic as implemented by
RocksDB and described within the blog post "Reduce Write Amplification by
Aligning Compaction Output File Boundaries." [1]

Aligning sstable boundaries can significantly reduce write amplification.
Consider the following compaction:

                                   +----------------------+
                  input            |                      |
                  level            +----------------------+
                                              \/
                           +---------------+       +---------------+
                  output   |XXXXXXX|       |       |      |XXXXXXXX|
                  level    +---------------+       +---------------+
                  
The input-level file overlaps two files in the output level, but only
partially. The beginning of the first output-level file and the end of the
second output-level file will be rewritten verbatim. This write IO is "wasted"
in the sense that no merging is being performed.

To prevent the above waste, this commit adapts the file-size splitter to
attempt to split output files at the boundaries of overlapping grandparent
files. The file-size spliiter still strives to write output files of
approximately the target file size, by constraining this splitting at
grandparent points to apply only if the current output's file size is about the
right order of magnitude.

The tolerance for how much an output file may deviate from its target file size
is adaptive, based on the number of grandparent files that are observed while
constructing the file. The particulars of this heuristic are currently
implemented as they are within RocksDB. Future work may adjust the heuristic to
improve write-amp savings, reduce the deviation from target file sizes or
produce a more understandable heuristic.

As implemented, a kv0 (random writes) compaction workload that writes 40gb of
data starting from an empty database with compaction concurrency 5 observes a
~12% reduction in write-amplification. The mean of read-amplification samples
is also ~39% reduced.:

```
                                  │ https://github.com/jbowens/pebble/commit/5d8daed0ac88647ca81fe2c288648a1c02741507-40gb-reframp.txt │    https://github.com/jbowens/pebble/commit/739646eb1b6c53921718b27750faab707ff2c03b-40gb-reframp.txt    │
                                  │            wamp             │    wamp     vs base               │
BenchmarkReplay/kv0/40gb/WriteAmp                   10.274 ± 1%   9.063 ± 6%  -11.78% (p=0.002 n=6)

                                      │ https://github.com/jbowens/pebble/commit/5d8daed0ac88647ca81fe2c288648a1c02741507-40gb-reframp.txt │    https://github.com/jbowens/pebble/commit/739646eb1b6c53921718b27750faab707ff2c03b-40gb-reframp.txt     │
                                      │            files            │    files     vs base               │
BenchmarkReplay/kv0/40gb/ReadAmp/mean                  10.403 ±  4%   6.368 ± 14%  -38.79% (p=0.002 n=6)
BenchmarkReplay/kv0/40gb/ReadAmp/max                   18.500 ± 19%   9.000 ± 22%  -51.35% (p=0.002 n=6)
```

[1] http://rocksdb.org/blog/2022/10/31/align-compaction-output-file.html

Close #2156.