### PR TITLE
tool: provide a post-checkpoint function option

### DIFF
--- a/tool/data_test.go
+++ b/tool/data_test.go
@@ -111,6 +111,10 @@ func runTests(t *testing.T, path string) {
 					Comparers(altComparer, testkeys.Comparer),
 					Mergers(merger),
 					FS(fs),
+					PostCheckpoint(func(cmd *cobra.Command, fs vfs.FS, destDir string) error {
+						cmd.Printf("post checkpoint fn called (destDir=%q)\n", destDir)
+						return nil
+					}),
 				)
 
 				c := &cobra.Command{}

--- a/tool/testdata/db_checkpoint
+++ b/tool/testdata/db_checkpoint
@@ -11,6 +11,7 @@ db checkpoint
 ../testdata/db-stage-4
 ../testdata/db-checkpoint1
 ----
+post checkpoint fn called (destDir="../testdata/db-checkpoint1")
 
 db check
 ../testdata/db-checkpoint1


### PR DESCRIPTION
This commit implements a new tool option to provide an opaque post-checkpoint function. This will be used by CRDB to output the min version file along with the checkpoint.