### PR TITLE
db: add a ScanInternal to scan internal keys

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -901,7 +901,7 @@ func (b *Batch) NewIter(o *IterOptions) *Iterator {
 	if b.index == nil {
 		return &Iterator{err: ErrNotIndexed}
 	}
-	return b.db.newIterInternal(b, nil /* snapshot */, o)
+	return b.db.newIter(b, nil /* snapshot */, o)
 }
 
 // newInternalIter creates a new internalIterator that iterates over the

--- a/batch_test.go
+++ b/batch_test.go
@@ -1085,7 +1085,7 @@ func TestFlushableBatchDeleteRange(t *testing.T) {
 			} else {
 				ii := fb.newIter(nil)
 				defer ii.Close()
-				scanInternalIterator(&buf, ii)
+				scanInternalIter(&buf, ii)
 			}
 			return buf.String()
 
@@ -1095,7 +1095,7 @@ func TestFlushableBatchDeleteRange(t *testing.T) {
 	})
 }
 
-func scanInternalIterator(w io.Writer, ii internalIterator) {
+func scanInternalIter(w io.Writer, ii internalIterator) {
 	for k, v := ii.First(); k != nil; k, v = ii.Next() {
 		fmt.Fprintf(w, "%s:%s\n", k, v.InPlaceValue())
 	}

--- a/db.go
+++ b/db.go
@@ -932,9 +932,9 @@ var iterAllocPool = sync.Pool{
 	},
 }
 
-// newIterInternal constructs a new iterator, merging in batch iterators as an extra
+// newIter constructs a new iterator, merging in batch iterators as an extra
 // level.
-func (d *DB) newIterInternal(batch *Batch, s *Snapshot, o *IterOptions) *Iterator {
+func (d *DB) newIter(batch *Batch, s *Snapshot, o *IterOptions) *Iterator {
 	if err := d.closed.Load(); err != nil {
 		panic(err)
 	}
@@ -1103,6 +1103,110 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 	return dbi
 }
 
+// ScanInternal scans all internal keys within the specified bounds, truncating
+// any rangedels and rangekeys to those bounds if they span past them. For use
+// when an external user needs to be aware of all internal keys that make up a
+// key range.
+//
+// Keys deleted by range deletions must not be returned or exposed by this
+// method, while the range deletion deleting that key must be exposed using
+// visitRangeDel. Keys that would be masked by range key masking (if an
+// appropriate prefix were set) should be exposed, alongside the range key
+// that would have masked it.
+func (d *DB) ScanInternal(
+	lower, upper []byte,
+	visitPointKey func(key *InternalKey, value LazyValue) error,
+	visitRangeDel func(start, end []byte, seqNum uint64) error,
+	visitRangeKey func(start, end []byte, keys []keyspan.Key) error,
+) error {
+	iter := d.newInternalIter(nil /* snapshot */, &IterOptions{
+		KeyTypes:   IterKeyTypePointsAndRanges,
+		LowerBound: lower,
+		UpperBound: upper,
+	})
+	defer iter.close()
+	return scanInternalImpl(lower, iter, visitPointKey, visitRangeDel, visitRangeKey)
+}
+
+// NewInternalIter constructs and returns a new scanInternalIterator on this db.
+//
+// TODO(bilal): This method has a lot of similarities with db.newIter as well as
+// finishInitializingIter. Both pairs of methods should be refactored to reduce
+// this duplication.
+func (d *DB) newInternalIter(s *Snapshot, o *IterOptions) *scanInternalIterator {
+	if err := d.closed.Load(); err != nil {
+		panic(err)
+	}
+	// Grab and reference the current readState. This prevents the underlying
+	// files in the associated version from being deleted if there is a current
+	// compaction. The readState is unref'd by Iterator.Close().
+	readState := d.loadReadState()
+
+	// Determine the seqnum to read at after grabbing the read state (current and
+	// memtables) above.
+	var seqNum uint64
+	if s == nil {
+		seqNum = atomic.LoadUint64(&d.mu.versions.atomic.visibleSeqNum)
+	} else {
+		seqNum = s.seqNum
+	}
+
+	// Bundle various structures under a single umbrella in order to allocate
+	// them together.
+	buf := iterAllocPool.Get().(*iterAlloc)
+	dbi := &scanInternalIterator{
+		comparer:        d.opts.Comparer,
+		readState:       readState,
+		alloc:           buf,
+		newIters:        d.newIters,
+		newIterRangeKey: d.tableNewRangeKeyIter,
+		seqNum:          seqNum,
+	}
+	if o != nil {
+		dbi.opts = *o
+	}
+	dbi.opts.logger = d.opts.Logger
+	if d.opts.private.disableLazyCombinedIteration {
+		dbi.opts.disableLazyCombinedIteration = true
+	}
+	return finishInitializingInternalIter(buf, dbi)
+}
+
+func finishInitializingInternalIter(buf *iterAlloc, i *scanInternalIterator) *scanInternalIterator {
+	// Short-hand.
+	memtables := i.readState.memtables
+	// We only need to read from memtables which contain sequence numbers older
+	// than seqNum. Trim off newer memtables.
+	for j := len(memtables) - 1; j >= 0; j-- {
+		if logSeqNum := memtables[j].logSeqNum; logSeqNum < i.seqNum {
+			break
+		}
+		memtables = memtables[:j]
+	}
+	i.initializeBoundBufs(i.opts.LowerBound, i.opts.UpperBound)
+
+	i.constructPointIter(memtables, buf)
+
+	// For internal iterators, we skip the lazy combined iteration optimization
+	// entirely, and create the range key iterator stack directly.
+	if i.rangeKey == nil {
+		i.rangeKey = iterRangeKeyStateAllocPool.Get().(*iteratorRangeKeyState)
+		i.rangeKey.init(i.comparer.Compare, i.comparer.Split, &i.opts)
+		i.constructRangeKeyIter()
+	} else {
+		i.rangeKey.iterConfig.SetBounds(i.opts.LowerBound, i.opts.UpperBound)
+	}
+
+	// Wrap the point iterator (currently i.iter) with an interleaving
+	// iterator that interleaves range keys pulled from
+	// i.rangeKey.rangeKeyIter.
+	i.rangeKey.iiter.Init(i.comparer, i.iter, i.rangeKey.rangeKeyIter,
+		nil /* mask */, i.opts.LowerBound, i.opts.UpperBound)
+	i.iter = &i.rangeKey.iiter
+
+	return i
+}
+
 func (i *Iterator) constructPointIter(memtables flushableList, buf *iterAlloc) {
 	if i.pointIter != nil {
 		// Already have one.
@@ -1248,7 +1352,7 @@ func (d *DB) NewIndexedBatch() *Batch {
 // apparent memory and disk usage leak. Use snapshots (see NewSnapshot) for
 // point-in-time snapshots which avoids these problems.
 func (d *DB) NewIter(o *IterOptions) *Iterator {
-	return d.newIterInternal(nil /* batch */, nil /* snapshot */, o)
+	return d.newIter(nil /* batch */, nil /* snapshot */, o)
 }
 
 // NewSnapshot returns a point-in-time view of the current DB state. Iterators

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -294,7 +294,7 @@ func finishInitializingExternal(it *Iterator) {
 					base.InternalKeySeqNumMax,
 					it.opts.LowerBound, it.opts.UpperBound,
 					&it.hasPrefix, &it.prefixOrFullSeekKey,
-					&it.rangeKey.internal,
+					true /* onlySets */, &it.rangeKey.internal,
 				)
 				for i := range rangeKeyIters {
 					it.rangeKey.iterConfig.AddLevel(rangeKeyIters[i])

--- a/internal/keyspan/level_iter_test.go
+++ b/internal/keyspan/level_iter_test.go
@@ -313,8 +313,8 @@ func TestLevelIterEquivalence(t *testing.T) {
 			levelIters = append(levelIters, &levelIter)
 		}
 
-		iter1.Init(base.DefaultComparer.Compare, visibleTransform(base.InternalKeySeqNumMax), new(MergingBuffers), fileIters...)
-		iter2.Init(base.DefaultComparer.Compare, visibleTransform(base.InternalKeySeqNumMax), new(MergingBuffers), levelIters...)
+		iter1.Init(base.DefaultComparer.Compare, VisibleTransform(base.InternalKeySeqNumMax), new(MergingBuffers), fileIters...)
+		iter2.Init(base.DefaultComparer.Compare, VisibleTransform(base.InternalKeySeqNumMax), new(MergingBuffers), levelIters...)
 		// Check iter1 and iter2 for equivalence.
 
 		require.Equal(t, iter1.First(), iter2.First(), "failed on test case %q", tc.name)

--- a/internal/keyspan/merging_iter.go
+++ b/internal/keyspan/merging_iter.go
@@ -49,9 +49,9 @@ var noopTransform Transformer = TransformerFunc(func(_ base.Compare, s Span, dst
 	return nil
 })
 
-// visibleTransform filters keys that are invisible at the provided snapshot
+// VisibleTransform filters keys that are invisible at the provided snapshot
 // sequence number.
-func visibleTransform(snapshot uint64) Transformer {
+func VisibleTransform(snapshot uint64) Transformer {
 	return TransformerFunc(func(_ base.Compare, s Span, dst *Span) error {
 		dst.Start, dst.End = s.Start, s.End
 		dst.Keys = dst.Keys[:0]
@@ -1044,7 +1044,7 @@ func (m *MergingIter) synthesizeKeys(dir int8) (bool, *Span) {
 	// sorted by trailer descending for the range key iteration use case.
 	sort.Sort(&m.keys)
 
-	// Apply the configured transform. See visibleTransform.
+	// Apply the configured transform. See VisibleTransform.
 	m.span = Span{
 		Start:     m.start,
 		End:       m.end,

--- a/internal/keyspan/merging_iter_test.go
+++ b/internal/keyspan/merging_iter_test.go
@@ -55,7 +55,7 @@ func TestMergingIter(t *testing.T) {
 			if len(spans) > 0 {
 				iters = append(iters, &invalidatingIter{iter: NewIter(cmp, spans)})
 			}
-			iter.Init(cmp, visibleTransform(snapshot), new(MergingBuffers), iters...)
+			iter.Init(cmp, VisibleTransform(snapshot), new(MergingBuffers), iters...)
 			return fmt.Sprintf("%d levels", len(iters))
 		case "iter":
 			buf.Reset()
@@ -197,7 +197,7 @@ func testFragmenterEquivalenceOnce(t *testing.T, seed int64) {
 
 	fragmenterIter := NewIter(f.Cmp, allFragmented)
 	mergingIter := &MergingIter{}
-	mergingIter.Init(f.Cmp, visibleTransform(base.InternalKeySeqNumMax), new(MergingBuffers), iters...)
+	mergingIter.Init(f.Cmp, VisibleTransform(base.InternalKeySeqNumMax), new(MergingBuffers), iters...)
 
 	// Position both so that it's okay to perform relative positioning
 	// operations immediately.

--- a/internal/rangekey/coalesce_test.go
+++ b/internal/rangekey/coalesce_test.go
@@ -151,7 +151,7 @@ func TestDefragmenting(t *testing.T) {
 			var userIterCfg UserIteratorConfig
 			iter := userIterCfg.Init(testkeys.Comparer, base.InternalKeySeqNumMax,
 				nil /* lower */, nil, /* upper */
-				&hasPrefix, &prefix, new(Buffers),
+				&hasPrefix, &prefix, true /* onlySets */, new(Buffers),
 				keyspan.NewIter(cmp, spans))
 			for _, line := range strings.Split(td.Input, "\n") {
 				runIterOp(&buf, iter, line)
@@ -233,11 +233,11 @@ func testDefragmentingIteRandomizedOnce(t *testing.T, seed int64) {
 	var referenceCfg, fragmentedCfg UserIteratorConfig
 	referenceIter := referenceCfg.Init(testkeys.Comparer, base.InternalKeySeqNumMax,
 		nil /* lower */, nil, /* upper */
-		new(bool), new([]byte), new(Buffers),
+		new(bool), new([]byte), true /* ßonlySets */, new(Buffers),
 		keyspan.NewIter(cmp, original))
 	fragmentedIter := fragmentedCfg.Init(testkeys.Comparer, base.InternalKeySeqNumMax,
 		nil /* lower */, nil, /* upper */
-		new(bool), new([]byte), new(Buffers),
+		new(bool), new([]byte), true /* onlySets */, new(Buffers),
 		keyspan.NewIter(cmp, fragmented))
 
 	// Generate 100 random operations and run them against both iterators.
@@ -370,7 +370,7 @@ func BenchmarkTransform(b *testing.B) {
 	var ui UserIteratorConfig
 	reinit := func() {
 		bufs.PrepareForReuse()
-		_ = ui.Init(testkeys.Comparer, math.MaxUint64, nil, nil, new(bool), nil, &bufs)
+		_ = ui.Init(testkeys.Comparer, math.MaxUint64, nil, nil, new(bool), nil, false /* onlySets */, &bufs)
 	}
 
 	for _, shadowing := range []bool{false, true} {

--- a/internal_iterator.go
+++ b/internal_iterator.go
@@ -1,0 +1,323 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/keyspan"
+	"github.com/cockroachdb/pebble/internal/manifest"
+)
+
+// scanInternalIterator is an iterator that returns all internal keys instead of
+// collapsing them by user keys. For instance, an InternalKeyKindDelete would be
+// returned as an InternalKeyKindDelete instead of the iterator skipping over to
+// the next key. Useful if an external user of Pebble needs to observe and
+// rebuild Pebble's history of internal keys, such as in node-to-node
+// replication. For use with {db,snapshot}.ScanInternal().
+//
+// scanInternalIterator is allowed to ignorepoint keys deleted by range deletions,
+// and range keys shadowed by a range key unset or delete, however it *must*
+// return the range delete as well as the range key unset/delete that did the
+// shadowing.
+type scanInternalIterator struct {
+	opts            IterOptions
+	comparer        *base.Comparer
+	iter            internalIterator
+	readState       *readState
+	rangeKey        *iteratorRangeKeyState
+	pointKeyIter    keyspan.InterleavingIter
+	iterKey         *InternalKey
+	iterValue       LazyValue
+	alloc           *iterAlloc
+	newIters        tableNewIters
+	newIterRangeKey keyspan.TableNewSpanIter
+	seqNum          uint64
+
+	// boundsBuf holds two buffers used to store the lower and upper bounds.
+	// Whenever the InternalIterator's bounds change, the new bounds are copied
+	// into boundsBuf[boundsBufIdx]. The two bounds share a slice to reduce
+	// allocations. opts.LowerBound and opts.UpperBound point into this slice.
+	boundsBuf    [2][]byte
+	boundsBufIdx int
+}
+
+func scanInternalImpl(
+	lower []byte,
+	iter *scanInternalIterator,
+	visitPointKey func(key *InternalKey, value LazyValue) error,
+	visitRangeDel func(start, end []byte, seqNum uint64) error,
+	visitRangeKey func(start, end []byte, keys []keyspan.Key) error,
+) error {
+	for valid := iter.seekGE(lower); valid && iter.error() == nil; valid = iter.next() {
+		key := iter.unsafeKey()
+
+		switch key.Kind() {
+		case InternalKeyKindRangeKeyDelete, InternalKeyKindRangeKeyUnset, InternalKeyKindRangeKeySet:
+			span := iter.unsafeSpan()
+			if err := visitRangeKey(span.Start, span.End, span.Keys); err != nil {
+				return err
+			}
+		case InternalKeyKindRangeDelete:
+			rangeDel := iter.unsafeRangeDel()
+			if err := visitRangeDel(rangeDel.Start, rangeDel.End, rangeDel.LargestSeqNum()); err != nil {
+				return err
+			}
+		default:
+			val := iter.lazyValue()
+			if s := iter.pointKeyIter.Span(); s != nil && s.CoversAt(iter.seqNum, key.SeqNum()) {
+				// Key deleted by a range deletion. Skip it.
+				continue
+			}
+			if err := visitPointKey(key, val); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// constructPointIter constructs a merging iterator and sets i.iter to it.
+func (i *scanInternalIterator) constructPointIter(memtables flushableList, buf *iterAlloc) {
+	// Merging levels and levels from iterAlloc.
+	mlevels := buf.mlevels[:0]
+	levels := buf.levels[:0]
+
+	// We compute the number of levels needed ahead of time and reallocate a slice if
+	// the array from the iterAlloc isn't large enough. Doing this allocation once
+	// should improve the performance.
+	numMergingLevels := len(memtables)
+	numLevelIters := 0
+
+	current := i.readState.current
+	numMergingLevels += len(current.L0SublevelFiles)
+	numLevelIters += len(current.L0SublevelFiles)
+	for level := 1; level < len(current.Levels); level++ {
+		if current.Levels[level].Empty() {
+			continue
+		}
+		numMergingLevels++
+		numLevelIters++
+	}
+
+	if numMergingLevels > cap(mlevels) {
+		mlevels = make([]mergingIterLevel, 0, numMergingLevels)
+	}
+	if numLevelIters > cap(levels) {
+		levels = make([]levelIter, 0, numLevelIters)
+	}
+	// TODO(bilal): Push these into the iterAlloc buf.
+	var rangeDelMiter keyspan.MergingIter
+	rangeDelIters := make([]keyspan.FragmentIterator, 0, numMergingLevels)
+	rangeDelLevels := make([]keyspan.LevelIter, 0, numLevelIters)
+
+	// Next are the memtables.
+	for j := len(memtables) - 1; j >= 0; j-- {
+		mem := memtables[j]
+		mlevels = append(mlevels, mergingIterLevel{
+			iter: mem.newIter(&i.opts),
+		})
+		if rdi := mem.newRangeDelIter(&i.opts); rdi != nil {
+			rangeDelIters = append(rangeDelIters, rdi)
+		}
+	}
+
+	// Next are the file levels: L0 sub-levels followed by lower levels.
+	mlevelsIndex := len(mlevels)
+	levelsIndex := len(levels)
+	mlevels = mlevels[:numMergingLevels]
+	levels = levels[:numLevelIters]
+	rangeDelLevels = rangeDelLevels[:numLevelIters]
+	addLevelIterForFiles := func(files manifest.LevelIterator, level manifest.Level) {
+		li := &levels[levelsIndex]
+		rli := &rangeDelLevels[levelsIndex]
+
+		li.init(i.opts, i.comparer.Compare, i.comparer.Split, i.newIters, files, level, internalIterOpts{})
+		li.initBoundaryContext(&mlevels[mlevelsIndex].levelIterBoundaryContext)
+		mlevels[mlevelsIndex].iter = li
+		rli.Init(keyspan.SpanIterOptions{RangeKeyFilters: i.opts.RangeKeyFilters},
+			i.comparer.Compare, tableNewRangeDelIter(i.newIters), files, level, manifest.KeyTypePoint)
+		rangeDelIters = append(rangeDelIters, rli)
+
+		levelsIndex++
+		mlevelsIndex++
+	}
+
+	// Add level iterators for the L0 sublevels, iterating from newest to
+	// oldest.
+	for i := len(current.L0SublevelFiles) - 1; i >= 0; i-- {
+		addLevelIterForFiles(current.L0SublevelFiles[i].Iter(), manifest.L0Sublevel(i))
+	}
+
+	// Add level iterators for the non-empty non-L0 levels.
+	for level := 1; level < numLevels; level++ {
+		if current.Levels[level].Empty() {
+			continue
+		}
+		addLevelIterForFiles(current.Levels[level].Iter(), manifest.Level(level))
+	}
+	buf.merging.init(&i.opts, &InternalIteratorStats{}, i.comparer.Compare, i.comparer.Split, mlevels...)
+	buf.merging.snapshot = i.seqNum
+	rangeDelMiter.Init(i.comparer.Compare, keyspan.VisibleTransform(i.seqNum), new(keyspan.MergingBuffers), rangeDelIters...)
+	i.pointKeyIter.Init(i.comparer, &buf.merging, &rangeDelMiter, nil /* mask */, i.opts.LowerBound, i.opts.UpperBound)
+	i.iter = &i.pointKeyIter
+}
+
+// constructRangeKeyIter constructs the range-key iterator stack, populating
+// i.rangeKey.rangeKeyIter with the resulting iterator. This is similar to
+// Iterator.constructRangeKeyIter, except it doesn't handle batches and ensures
+// iterConfig does *not* elide unsets/deletes.
+func (i *scanInternalIterator) constructRangeKeyIter() {
+	// We want the bounded iter from iterConfig, but not the collapsing of
+	// RangeKeyUnsets and RangeKeyDels.
+	i.rangeKey.rangeKeyIter = i.rangeKey.iterConfig.Init(
+		i.comparer, i.seqNum, i.opts.LowerBound, i.opts.UpperBound,
+		nil /* hasPrefix */, nil /* prefix */, false, /* onlySets */
+		&i.rangeKey.rangeKeyBuffers.internal)
+
+	// Next are the flushables: memtables and large batches.
+	for j := len(i.readState.memtables) - 1; j >= 0; j-- {
+		mem := i.readState.memtables[j]
+		// We only need to read from memtables which contain sequence numbers older
+		// than seqNum.
+		if logSeqNum := mem.logSeqNum; logSeqNum >= i.seqNum {
+			continue
+		}
+		if rki := mem.newRangeKeyIter(&i.opts); rki != nil {
+			i.rangeKey.iterConfig.AddLevel(rki)
+		}
+	}
+
+	current := i.readState.current
+	// Next are the file levels: L0 sub-levels followed by lower levels.
+	//
+	// Add file-specific iterators for L0 files containing range keys. This is less
+	// efficient than using levelIters for sublevels of L0 files containing
+	// range keys, but range keys are expected to be sparse anyway, reducing the
+	// cost benefit of maintaining a separate L0Sublevels instance for range key
+	// files and then using it here.
+	//
+	// NB: We iterate L0's files in reverse order. They're sorted by
+	// LargestSeqNum ascending, and we need to add them to the merging iterator
+	// in LargestSeqNum descending to preserve the merging iterator's invariants
+	// around Key Trailer order.
+	iter := current.RangeKeyLevels[0].Iter()
+	for f := iter.Last(); f != nil; f = iter.Prev() {
+		spanIterOpts := &keyspan.SpanIterOptions{RangeKeyFilters: i.opts.RangeKeyFilters}
+		spanIter, err := i.newIterRangeKey(f, spanIterOpts)
+		if err != nil {
+			i.rangeKey.iterConfig.AddLevel(&errorKeyspanIter{err: err})
+			continue
+		}
+		i.rangeKey.iterConfig.AddLevel(spanIter)
+	}
+
+	// Add level iterators for the non-empty non-L0 levels.
+	for level := 1; level < len(current.RangeKeyLevels); level++ {
+		if current.RangeKeyLevels[level].Empty() {
+			continue
+		}
+		li := i.rangeKey.iterConfig.NewLevelIter()
+		spanIterOpts := keyspan.SpanIterOptions{RangeKeyFilters: i.opts.RangeKeyFilters}
+		li.Init(spanIterOpts, i.comparer.Compare, i.newIterRangeKey, current.RangeKeyLevels[level].Iter(),
+			manifest.Level(level), manifest.KeyTypeRange)
+		i.rangeKey.iterConfig.AddLevel(li)
+	}
+}
+
+// seekGE seeks this iterator to the first key that's greater than or equal
+// to the specified user key.
+func (i *scanInternalIterator) seekGE(key []byte) bool {
+	i.iterKey, i.iterValue = i.iter.SeekGE(key, base.SeekGEFlagsNone)
+	return i.iterKey != nil
+}
+
+// unsafeKey returns the unsafe InternalKey at the current position. The value
+// is nil if the iterator is invalid or exhausted.
+func (i *scanInternalIterator) unsafeKey() *InternalKey {
+	return i.iterKey
+}
+
+// lazyValue returns a value pointer to the value at the current iterator
+// position. Behaviour undefined if unsafeKey() returns a Range key or Rangedel
+// kind key.
+func (i *scanInternalIterator) lazyValue() LazyValue {
+	return i.iterValue
+}
+
+// unsafeRangeDel returns a range key span. Behaviour undefined if UnsafeKey returns
+// a non-rangedel kind.
+func (i *scanInternalIterator) unsafeRangeDel() *keyspan.Span {
+	return i.pointKeyIter.Span()
+}
+
+// unsafeSpan returns a range key span. Behaviour undefined if UnsafeKey returns
+// a non-rangekey type.
+func (i *scanInternalIterator) unsafeSpan() *keyspan.Span {
+	return i.rangeKey.iiter.Span()
+}
+
+// next advances the iterator in the forward direction, and returns the
+// iterator's new validity state.
+func (i *scanInternalIterator) next() bool {
+	i.iterKey, i.iterValue = i.iter.Next()
+	return i.iterKey != nil
+}
+
+// error returns an error from the internal iterator, if there's any.
+func (i *scanInternalIterator) error() error {
+	return i.iter.Error()
+}
+
+// close closes this iterator, and releases any pooled objects.
+func (i *scanInternalIterator) close() error {
+	if err := i.iter.Close(); err != nil {
+		return err
+	}
+	i.readState.unref()
+	if i.rangeKey != nil {
+		i.rangeKey.PrepareForReuse()
+		*i.rangeKey = iteratorRangeKeyState{
+			rangeKeyBuffers: i.rangeKey.rangeKeyBuffers,
+		}
+		iterRangeKeyStateAllocPool.Put(i.rangeKey)
+		i.rangeKey = nil
+	}
+	if alloc := i.alloc; alloc != nil {
+		for j := range i.boundsBuf {
+			if cap(i.boundsBuf[j]) >= maxKeyBufCacheSize {
+				alloc.boundsBuf[j] = nil
+			} else {
+				alloc.boundsBuf[j] = i.boundsBuf[j]
+			}
+		}
+		*alloc = iterAlloc{
+			keyBuf:              alloc.keyBuf[:0],
+			boundsBuf:           alloc.boundsBuf,
+			prefixOrFullSeekKey: alloc.prefixOrFullSeekKey[:0],
+		}
+		iterAllocPool.Put(alloc)
+		i.alloc = nil
+	}
+	return nil
+}
+
+func (i *scanInternalIterator) initializeBoundBufs(lower, upper []byte) {
+	buf := i.boundsBuf[i.boundsBufIdx][:0]
+	if lower != nil {
+		buf = append(buf, lower...)
+		i.opts.LowerBound = buf
+	} else {
+		i.opts.LowerBound = nil
+	}
+	if upper != nil {
+		buf = append(buf, upper...)
+		i.opts.UpperBound = buf[len(buf)-len(upper):]
+	} else {
+		i.opts.UpperBound = nil
+	}
+	i.boundsBuf[i.boundsBufIdx] = buf
+	i.boundsBufIdx = 1 - i.boundsBufIdx
+}

--- a/internal_iterator_test.go
+++ b/internal_iterator_test.go
@@ -1,0 +1,257 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/bloom"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/keyspan"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanInternal(t *testing.T) {
+	var d *DB
+	type scanInternalReader interface {
+		ScanInternal(
+			lower, upper []byte, visitPointKey func(key *InternalKey, value LazyValue) error,
+			visitRangeDel func(start, end []byte, seqNum uint64) error,
+			visitRangeKey func(start, end []byte, keys []keyspan.Key) error) error
+	}
+	batches := map[string]*Batch{}
+	snaps := map[string]*Snapshot{}
+	parseOpts := func(td *datadriven.TestData) (*Options, error) {
+		opts := &Options{
+			FS:                 vfs.NewMem(),
+			Comparer:           testkeys.Comparer,
+			FormatMajorVersion: FormatRangeKeys,
+			BlockPropertyCollectors: []func() BlockPropertyCollector{
+				sstable.NewTestKeysBlockPropertyCollector,
+			},
+		}
+		opts.DisableAutomaticCompactions = true
+		opts.EnsureDefaults()
+		opts.WithFSDefaults()
+
+		for _, cmdArg := range td.CmdArgs {
+			switch cmdArg.Key {
+			case "format-major-version":
+				v, err := strconv.Atoi(cmdArg.Vals[0])
+				if err != nil {
+					return nil, err
+				}
+				// Override the DB version.
+				opts.FormatMajorVersion = FormatMajorVersion(v)
+			case "block-size":
+				v, err := strconv.Atoi(cmdArg.Vals[0])
+				if err != nil {
+					return nil, err
+				}
+				for i := range opts.Levels {
+					opts.Levels[i].BlockSize = v
+				}
+			case "index-block-size":
+				v, err := strconv.Atoi(cmdArg.Vals[0])
+				if err != nil {
+					return nil, err
+				}
+				for i := range opts.Levels {
+					opts.Levels[i].IndexBlockSize = v
+				}
+			case "target-file-size":
+				v, err := strconv.Atoi(cmdArg.Vals[0])
+				if err != nil {
+					return nil, err
+				}
+				for i := range opts.Levels {
+					opts.Levels[i].TargetFileSize = int64(v)
+				}
+			case "bloom-bits-per-key":
+				v, err := strconv.Atoi(cmdArg.Vals[0])
+				if err != nil {
+					return nil, err
+				}
+				fp := bloom.FilterPolicy(v)
+				opts.Filters = map[string]FilterPolicy{fp.Name(): fp}
+				for i := range opts.Levels {
+					opts.Levels[i].FilterPolicy = fp
+				}
+			case "merger":
+				switch cmdArg.Vals[0] {
+				case "appender":
+					opts.Merger = base.DefaultMerger
+				default:
+					return nil, errors.Newf("unrecognized Merger %q\n", cmdArg.Vals[0])
+				}
+			}
+		}
+		return opts, nil
+	}
+	cleanup := func() (err error) {
+		for key, batch := range batches {
+			err = firstError(err, batch.Close())
+			delete(batches, key)
+		}
+		for key, snap := range snaps {
+			err = firstError(err, snap.Close())
+			delete(snaps, key)
+		}
+		if d != nil {
+			err = firstError(err, d.Close())
+			d = nil
+		}
+		return err
+	}
+	defer cleanup()
+
+	datadriven.RunTest(t, "testdata/scan_internal", func(t *testing.T, td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "define":
+			if err := cleanup(); err != nil {
+				return err.Error()
+			}
+			opts, err := parseOpts(td)
+			if err != nil {
+				return err.Error()
+			}
+			d, err = runDBDefineCmd(td, opts)
+			if err != nil {
+				return err.Error()
+			}
+			return runLSMCmd(td, d)
+
+		case "reset":
+			if err := cleanup(); err != nil {
+				t.Fatal(err)
+				return err.Error()
+			}
+			opts, err := parseOpts(td)
+			if err != nil {
+				t.Fatal(err)
+				return err.Error()
+			}
+
+			d, err = Open("", opts)
+			require.NoError(t, err)
+			return ""
+		case "snapshot":
+			s := d.NewSnapshot()
+			var name string
+			for _, arg := range td.CmdArgs {
+				switch arg.Key {
+				case "name":
+					name = arg.Vals[0]
+				default:
+					return fmt.Sprintf("unrecognized command argument %q\n", arg.Key)
+				}
+			}
+			snaps[name] = s
+			return ""
+		case "batch":
+			var commit bool
+			var name string
+			for _, arg := range td.CmdArgs {
+				switch arg.Key {
+				case "name":
+					name = arg.Vals[0]
+				case "commit":
+					commit = true
+				default:
+					return fmt.Sprintf("unrecognized command argument %q\n", arg.Key)
+				}
+			}
+			b := d.NewIndexedBatch()
+			require.NoError(t, runBatchDefineCmd(td, b))
+			var err error
+			if commit {
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							err = errors.New(r.(string))
+						}
+					}()
+					err = b.Commit(nil)
+				}()
+			} else if name != "" {
+				batches[name] = b
+			}
+			if err != nil {
+				return err.Error()
+			}
+			count := b.Count()
+			if commit {
+				return fmt.Sprintf("committed %d keys\n", count)
+			}
+			return fmt.Sprintf("wrote %d keys to batch %q\n", count, name)
+		case "compact":
+			if err := runCompactCmd(td, d); err != nil {
+				return err.Error()
+			}
+			return runLSMCmd(td, d)
+		case "flush":
+			err := d.Flush()
+			if err != nil {
+				return err.Error()
+			}
+			return ""
+		case "lsm":
+			return runLSMCmd(td, d)
+		case "commit":
+			name := pluckStringCmdArg(td, "batch")
+			b := batches[name]
+			defer b.Close()
+			count := b.Count()
+			require.NoError(t, d.Apply(b, nil))
+			delete(batches, name)
+			return fmt.Sprintf("committed %d keys\n", count)
+		case "scan-internal":
+			var lower, upper []byte
+			var reader scanInternalReader = d
+			for _, arg := range td.CmdArgs {
+				switch arg.Key {
+				case "lower":
+					lower = []byte(arg.Vals[0])
+				case "upper":
+					upper = []byte(arg.Vals[0])
+				case "snapshot":
+					name := arg.Vals[0]
+					snap, ok := snaps[name]
+					if !ok {
+						return fmt.Sprintf("no snapshot found for name %s", name)
+					}
+					reader = snap
+				}
+			}
+			var b strings.Builder
+			err := reader.ScanInternal(lower, upper, func(key *InternalKey, value LazyValue) error {
+				v := value.InPlaceValue()
+				fmt.Fprintf(&b, "%s (%s)\n", key, v)
+				return nil
+			}, func(start, end []byte, seqNum uint64) error {
+				fmt.Fprintf(&b, "%s-%s#%d,RANGEDEL\n", start, end, seqNum)
+				return nil
+			}, func(start, end []byte, keys []keyspan.Key) error {
+				s := keyspan.Span{Start: start, End: end, Keys: keys}
+				fmt.Fprintf(&b, "%s\n", s.String())
+				return nil
+			})
+			if err != nil {
+				return err.Error()
+			}
+			return b.String()
+		default:
+			return fmt.Sprintf("unknown command %q", td.Cmd)
+		}
+	})
+}

--- a/mem_table_test.go
+++ b/mem_table_test.go
@@ -336,7 +336,7 @@ func TestMemTableDeleteRange(t *testing.T) {
 			} else {
 				iter := mem.newIter(nil)
 				defer iter.Close()
-				scanInternalIterator(&buf, iter)
+				scanInternalIter(&buf, iter)
 			}
 			return buf.String()
 

--- a/range_keys.go
+++ b/range_keys.go
@@ -17,7 +17,7 @@ import (
 func (i *Iterator) constructRangeKeyIter() {
 	i.rangeKey.rangeKeyIter = i.rangeKey.iterConfig.Init(
 		&i.comparer, i.seqNum, i.opts.LowerBound, i.opts.UpperBound,
-		&i.hasPrefix, &i.prefixOrFullSeekKey, &i.rangeKey.rangeKeyBuffers.internal)
+		&i.hasPrefix, &i.prefixOrFullSeekKey, true /* onlySets */, &i.rangeKey.rangeKeyBuffers.internal)
 
 	// If there's an indexed batch with range keys, include it.
 	if i.batch != nil {

--- a/snapshot.go
+++ b/snapshot.go
@@ -7,6 +7,8 @@ package pebble
 import (
 	"io"
 	"math"
+
+	"github.com/cockroachdb/pebble/internal/keyspan"
 )
 
 // Snapshot provides a read-only point-in-time view of the DB state.
@@ -45,7 +47,32 @@ func (s *Snapshot) NewIter(o *IterOptions) *Iterator {
 	if s.db == nil {
 		panic(ErrClosed)
 	}
-	return s.db.newIterInternal(nil /* batch */, s, o)
+	return s.db.newIter(nil /* batch */, s, o)
+}
+
+// ScanInternal scans all internal keys within the specified bounds, truncating
+// any rangedels and rangekeys to those bounds. For use when an external user
+// needs to be aware of all internal keys that make up a key range.
+//
+// See comment on db.ScanInternal for the behaviour that can be expected of
+// point keys deleted by range dels and keys masked by range keys.
+func (s *Snapshot) ScanInternal(
+	lower, upper []byte,
+	visitPointKey func(key *InternalKey, value LazyValue) error,
+	visitRangeDel func(start, end []byte, seqNum uint64) error,
+	visitRangeKey func(start, end []byte, keys []keyspan.Key) error,
+) error {
+	if s.db == nil {
+		panic(ErrClosed)
+	}
+	iter := s.db.newInternalIter(s, &IterOptions{
+		KeyTypes:   IterKeyTypePointsAndRanges,
+		LowerBound: lower,
+		UpperBound: upper,
+	})
+	defer iter.close()
+
+	return scanInternalImpl(lower, iter, visitPointKey, visitRangeDel, visitRangeKey)
 }
 
 // Close closes the snapshot, releasing its resources. Close must be called.

--- a/testdata/scan_internal
+++ b/testdata/scan_internal
@@ -1,0 +1,154 @@
+
+reset
+----
+
+batch commit
+range-key-set a c @5 boop
+range-key-set c e @5 beep
+----
+committed 2 keys
+
+snapshot name=foo
+----
+
+batch commit
+set b d
+set e foo
+----
+committed 2 keys
+
+flush
+----
+
+scan-internal
+----
+a-c:{(#1,RANGEKEYSET,@5,boop)}
+b#3,1 (d)
+c-e:{(#2,RANGEKEYSET,@5,beep)}
+e#4,1 (foo)
+
+# Keys deleted by rangedels are elided.
+
+batch commit
+del-range b d
+----
+committed 1 keys
+
+scan-internal
+----
+a-c:{(#1,RANGEKEYSET,@5,boop)}
+b-d#5,RANGEDEL
+c-e:{(#2,RANGEKEYSET,@5,beep)}
+e#4,1 (foo)
+
+flush
+----
+
+scan-internal
+----
+a-c:{(#1,RANGEKEYSET,@5,boop)}
+b-d#5,RANGEDEL
+c-e:{(#2,RANGEKEYSET,@5,beep)}
+e#4,1 (foo)
+
+# Snapshots work with internal iters.
+
+scan-internal snapshot=foo
+----
+a-c:{(#1,RANGEKEYSET,@5,boop)}
+c-e:{(#2,RANGEKEYSET,@5,beep)}
+
+# Range keys and range dels are truncated to [lower,upper).
+
+scan-internal lower=bb upper=dd
+----
+bb-c:{(#1,RANGEKEYSET,@5,boop)}
+bb-d#5,RANGEDEL
+c-dd:{(#2,RANGEKEYSET,@5,beep)}
+
+scan-internal lower=b upper=cc
+----
+b-c:{(#1,RANGEKEYSET,@5,boop)}
+b-cc#5,RANGEDEL
+c-cc:{(#2,RANGEKEYSET,@5,beep)}
+
+reset
+----
+
+# Range key unsets and dels are allowed to delete keys they observe, however
+# the unset/del must also be returned to the user.
+
+batch commit
+range-key-set a c @8 foo
+range-key-set b e @6 bar
+----
+committed 2 keys
+
+flush
+----
+
+compact a-z
+----
+6:
+  000005:[a#1,RANGEKEYSET-e#inf,RANGEKEYSET]
+
+batch commit
+range-key-unset b d @6
+----
+committed 1 keys
+
+flush
+----
+
+batch commit
+range-key-del a b
+----
+committed 1 keys
+
+scan-internal
+----
+a-b:{(#4,RANGEKEYDEL)}
+b-c:{(#1,RANGEKEYSET,@8,foo) (#3,RANGEKEYUNSET,@6)}
+c-d:{(#3,RANGEKEYUNSET,@6)}
+d-e:{(#2,RANGEKEYSET,@6,bar)}
+
+flush
+----
+
+lsm
+----
+0.0:
+  000009:[a#4,RANGEKEYDEL-b#inf,RANGEKEYDEL]
+  000007:[b#3,RANGEKEYUNSET-d#inf,RANGEKEYUNSET]
+6:
+  000005:[a#1,RANGEKEYSET-e#inf,RANGEKEYSET]
+
+scan-internal
+----
+a-b:{(#4,RANGEKEYDEL)}
+b-c:{(#1,RANGEKEYSET,@8,foo) (#3,RANGEKEYUNSET,@6)}
+c-d:{(#3,RANGEKEYUNSET,@6)}
+d-e:{(#2,RANGEKEYSET,@6,bar)}
+
+# Range key masking is not exercised, with range keys that could mask point
+# keys being returned alongside point keys.
+
+reset
+----
+
+batch commit
+set b@3 bar
+----
+committed 1 keys
+
+batch commit
+range-key-set a c @5 boop
+range-key-set c e @5 beep
+----
+committed 2 keys
+
+scan-internal
+----
+a-c:{(#2,RANGEKEYSET,@5,boop)}
+b@3#1,1 (bar)
+c-e:{(#3,RANGEKEYSET,@5,beep)}


### PR DESCRIPTION
This change adds a new scanInternalIterator that exposes internal keys to external users through a ScanInternal(). This will be useful for when we start creating iterators on partial LSM states, and we'd need to observe all keys that could impact the part of the LSM that we do not observe, such as point tombstones, rangedels, etc.