### PR TITLE
db: add Metrics.Keys.TombstoneCount

### DIFF
--- a/db.go
+++ b/db.go
@@ -1639,7 +1639,9 @@ func (d *DB) Metrics() *Metrics {
 	}
 	metrics.private.optionsFileSize = d.optionsFileSize
 
+	// TODO(jackson): Consider making these metrics optional.
 	metrics.Keys.RangeKeySetsCount = countRangeKeySetFragments(vers)
+	metrics.Keys.TombstoneCount = countTombstones(vers)
 
 	d.mu.versions.logLock()
 	metrics.private.manifestFileSize = uint64(d.mu.versions.manifest.Size())

--- a/metrics.go
+++ b/metrics.go
@@ -209,6 +209,9 @@ type Metrics struct {
 	Keys struct {
 		// The approximate count of internal range key set keys in the database.
 		RangeKeySetsCount uint64
+		// The approximate count of internal tombstones (DEL, SINGLEDEL and
+		// RANGEDEL key kinds) within the database.
+		TombstoneCount uint64
 	}
 
 	Snapshots struct {

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -418,6 +418,7 @@ func TestBenchmarkString(t *testing.T) {
 		EstimatedDebt:       SampledMetric{samples: []sample{{value: 5 << 25}}},
 		QuiesceDuration:     time.Second / 2,
 		ReadAmp:             SampledMetric{samples: []sample{{value: 10}}},
+		TombstoneCount:      SampledMetric{samples: []sample{{value: 295}}},
 		TotalSize:           SampledMetric{samples: []sample{{value: 5 << 30}}},
 		TotalWriteAmp:       5.6,
 		WorkloadDuration:    time.Second,
@@ -442,6 +443,8 @@ BenchmarkBenchmarkReplay/tpcc/IngestedIntoL0 1 5.24288e+06 bytes
 BenchmarkBenchmarkReplay/tpcc/IngestWeightedByLevel 1 9.437184e+06 bytes
 BenchmarkBenchmarkReplay/tpcc/ReadAmp/mean 1 10 files
 BenchmarkBenchmarkReplay/tpcc/ReadAmp/max 1 10 files
+BenchmarkBenchmarkReplay/tpcc/TombstoneCount/mean 1 295 tombstones
+BenchmarkBenchmarkReplay/tpcc/TombstoneCount/max 1 295 tombstones
 BenchmarkBenchmarkReplay/tpcc/Throughput 1 2.097152e+07 B/s
 BenchmarkBenchmarkReplay/tpcc/WriteAmp 1 5.6 wamp
 BenchmarkBenchmarkReplay/tpcc/WriteStalls 1 105 stalls 60 stallsec/op`),

--- a/replay/sampled_metric.go
+++ b/replay/sampled_metric.go
@@ -67,6 +67,9 @@ func (m *SampledMetric) PlotIncreasingPerSec(width, height int, scale float64) s
 // Mean calculates the mean value of the metric.
 func (m *SampledMetric) Mean() float64 {
 	var sum float64
+	if len(m.samples) == 0 {
+		return 0.0
+	}
 	for _, s := range m.samples {
 		sum += float64(s.value)
 	}


### PR DESCRIPTION
Add a metric to expose the approximate count of tombstones within the LSM. Sample this metric within compaction benchmarking replay to help in evaluating changes to tombstone compaction heuristics.