### PR TITLE
objstorage: add Sync

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3152,7 +3152,7 @@ func (d *DB) runCompaction(
 		}
 	}
 
-	if err := d.dataDir.Sync(); err != nil {
+	if err := d.objProvider.Sync(); err != nil {
 		return nil, pendingOutputs, err
 	}
 

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -994,6 +994,7 @@ func TestCompaction(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
+		defer provider.Close()
 		for _, levelMetadata := range v.Levels {
 			iter := levelMetadata.Iter()
 			for meta := iter.First(); meta != nil; meta = iter.Next() {

--- a/db.go
+++ b/db.go
@@ -1391,6 +1391,8 @@ func (d *DB) Close() error {
 		err = firstError(err, errors.Errorf("non-zero zombie file count: %d", ztbls))
 	}
 
+	err = firstError(err, d.objProvider.Close())
+
 	// If the options include a closer to 'close' the filesystem, close it.
 	if d.opts.private.fsCloser != nil {
 		d.opts.private.fsCloser.Close()

--- a/ingest.go
+++ b/ingest.go
@@ -821,11 +821,10 @@ func (d *DB) ingest(
 	if err := ingestLink(jobID, d.opts, d.objProvider, paths, meta); err != nil {
 		return IngestOperationStats{}, err
 	}
-	// Fsync the directory we added the tables to. We need to do this at some
-	// point before we update the MANIFEST (via logAndApply), otherwise a crash
-	// can have the tables referenced in the MANIFEST, but not present in the
-	// directory.
-	if err := d.dataDir.Sync(); err != nil {
+	// Make the new tables durable. We need to do this at some point before we
+	// update the MANIFEST (via logAndApply), otherwise a crash can have the
+	// tables referenced in the MANIFEST, but not present in the provider.
+	if err := d.objProvider.Sync(); err != nil {
 		return IngestOperationStats{}, err
 	}
 

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -292,6 +292,7 @@ func TestIngestLink(t *testing.T) {
 			require.NoError(t, opts.FS.MkdirAll(dir, 0755))
 			objProvider, err := objstorage.Open(objstorage.DefaultSettings(opts.FS, dir))
 			require.NoError(t, err)
+			defer objProvider.Close()
 
 			paths := make([]string, 10)
 			meta := make([]*fileMetadata, len(paths))
@@ -371,13 +372,14 @@ func TestIngestLinkFallback(t *testing.T) {
 	src, err := mem.Create("source")
 	require.NoError(t, err)
 
-	opts := &Options{FS: errorfs.Wrap(mem, errorfs.OnIndex(0))}
+	opts := &Options{FS: errorfs.Wrap(mem, errorfs.OnIndex(1))}
 	opts.EnsureDefaults().WithFSDefaults()
 	objSettings := objstorage.DefaultSettings(opts.FS, "")
 	// Prevent the provider from listing the dir (where we may get an injected error).
 	objSettings.FSDirInitialListing = []string{}
 	objProvider, err := objstorage.Open(objSettings)
 	require.NoError(t, err)
+	defer objProvider.Close()
 
 	meta := []*fileMetadata{{FileNum: 1}}
 	err = ingestLink(0, opts, objProvider, []string{"source"}, meta)
@@ -1675,6 +1677,7 @@ func TestIngestCleanup(t *testing.T) {
 			mem.UseWindowsSemantics(true)
 			objProvider, err := objstorage.Open(objstorage.DefaultSettings(mem, ""))
 			require.NoError(t, err)
+			defer objProvider.Close()
 
 			// Create the files in the VFS.
 			metaMap := make(map[base.FileNum]objstorage.Writable)

--- a/open.go
+++ b/open.go
@@ -175,6 +175,9 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 					t.arenaBuf = nil
 				}
 			}
+			if d.objProvider != nil {
+				d.objProvider.Close()
+			}
 			if r != nil {
 				panic(r)
 			}

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -175,6 +175,7 @@ func runBuildRawCmd(
 	if err != nil {
 		return nil, nil, err
 	}
+	defer provider.Close()
 
 	f0, _, err := provider.Create(base.FileTypeTable, 0 /* fileNum */)
 	if err != nil {

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -660,6 +660,7 @@ func TestCompactionIteratorSetupForCompaction(t *testing.T) {
 	tmpDir := path.Join(t.TempDir())
 	provider, err := objstorage.Open(objstorage.DefaultSettings(vfs.Default, tmpDir))
 	require.NoError(t, err)
+	defer provider.Close()
 	blockSizes := []int{10, 100, 1000, 4096, math.MaxInt32}
 	for _, blockSize := range blockSizes {
 		for _, indexBlockSize := range blockSizes {
@@ -1003,6 +1004,7 @@ func buildTestTable(
 ) *Reader {
 	provider, err := objstorage.Open(objstorage.DefaultSettings(vfs.NewMem(), "" /* dirName */))
 	require.NoError(t, err)
+	defer provider.Close()
 	return buildTestTableWithProvider(t, provider, numEntries, blockSize, indexBlockSize, compression)
 }
 

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -165,6 +165,7 @@ func newTableCacheContainerTest(
 	if err != nil {
 		return nil, nil, err
 	}
+	defer objProvider.Close()
 
 	for i := 0; i < tableCacheTestNumTables; i++ {
 		w, _, err := objProvider.Create(fileTypeTable, FileNum(i))
@@ -872,6 +873,8 @@ func TestTableCacheClockPro(t *testing.T) {
 	mem := vfs.NewMem()
 	objProvider, err := objstorage.Open(objstorage.DefaultSettings(mem, ""))
 	require.NoError(t, err)
+	defer objProvider.Close()
+
 	makeTable := func(fileNum FileNum) {
 		require.NoError(t, err)
 		f, _, err := objProvider.Create(fileTypeTable, fileNum)

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -13,6 +13,7 @@ sync: db/temporary.000001.dbtmp
 close: db/temporary.000001.dbtmp
 rename: db/temporary.000001.dbtmp -> db/CURRENT
 sync: db
+open-dir: db
 sync: db/MANIFEST-000001
 create: db/000002.log
 sync: db
@@ -271,6 +272,7 @@ open-dir: checkpoints/checkpoint1
 lock: checkpoints/checkpoint1/LOCK
 open-dir: checkpoints/checkpoint1
 open-dir: checkpoints/checkpoint1
+open-dir: checkpoints/checkpoint1
 
 scan checkpoints/checkpoint1
 ----
@@ -311,6 +313,7 @@ open-dir: checkpoints/checkpoint2
 lock: checkpoints/checkpoint2/LOCK
 open-dir: checkpoints/checkpoint2
 open-dir: checkpoints/checkpoint2
+open-dir: checkpoints/checkpoint2
 
 scan checkpoints/checkpoint2
 ----
@@ -336,6 +339,7 @@ open checkpoints/checkpoint3 readonly
 ----
 open-dir: checkpoints/checkpoint3
 lock: checkpoints/checkpoint3/LOCK
+open-dir: checkpoints/checkpoint3
 open-dir: checkpoints/checkpoint3
 open-dir: checkpoints/checkpoint3
 

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -15,6 +15,7 @@ sync: db/temporary.000001.dbtmp
 close: db/temporary.000001.dbtmp
 rename: db/temporary.000001.dbtmp -> db/CURRENT
 sync: db
+open-dir: db
 sync: db/MANIFEST-000001
 create: wal/000002.log
 sync: wal

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -16,6 +16,7 @@ close: db/temporary.000001.dbtmp
 rename: db/temporary.000001.dbtmp -> db/CURRENT
 sync: db
 [JOB 1] MANIFEST created 000001
+open-dir: db
 sync: db/MANIFEST-000001
 create: wal/000002.log
 sync: wal
@@ -286,3 +287,4 @@ close: db/MANIFEST-000016
 close: db
 close: db
 close: wal
+close: db

--- a/tool/db.go
+++ b/tool/db.go
@@ -492,6 +492,7 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 		if err != nil {
 			return err
 		}
+		defer objProvider.Close()
 
 		// Load and aggregate sstable properties.
 		tw := tabwriter.NewWriter(stdout, 2, 1, 4, ' ', 0)


### PR DESCRIPTION
Add Sync method to the objstorage provider. Object creation or removal is only durable when Sync is called. Currently we just sync the local directory; soon we will also push an update to the shared object catalog (if needed).