### PR TITLE
sharedobjcat: add creator-id and object type

### DIFF
--- a/objstorage/sharedobjcat/catalog.go
+++ b/objstorage/sharedobjcat/catalog.go
@@ -58,6 +58,8 @@ type SharedObjectMetadata struct {
 	// FileNum is the identifier for the object within the context of a single DB
 	// instance.
 	FileNum base.FileNum
+	// FileType is the type of the object. Only certain FileTypes are possible.
+	FileType base.FileType
 	// CreatorID identifies the DB instance that originally created the object.
 	CreatorID CreatorID
 	// CreatorFileNum is the identifier for the object within the context of the

--- a/objstorage/sharedobjcat/catalog_test.go
+++ b/objstorage/sharedobjcat/catalog_test.go
@@ -44,7 +44,9 @@ func TestCatalog(t *testing.T) {
 			}
 			vals := toInt(args...)
 			return sharedobjcat.SharedObjectMetadata{
-				FileNum:        base.FileNum(vals[0]),
+				FileNum: base.FileNum(vals[0]),
+				// When we support other file types, we should let the test determine this.
+				FileType:       base.FileTypeTable,
 				CreatorID:      sharedobjcat.CreatorID(vals[1]),
 				CreatorFileNum: base.FileNum(vals[2]),
 			}
@@ -136,7 +138,9 @@ func TestCatalog(t *testing.T) {
 			for batchIdx := 0; batchIdx < n; batchIdx++ {
 				for i := 0; i < size; i++ {
 					b.AddObject(sharedobjcat.SharedObjectMetadata{
-						FileNum:        base.FileNum(rand.Uint64()),
+						FileNum: base.FileNum(rand.Uint64()),
+						// When we support other file types, we should let the test determine this.
+						FileType:       base.FileTypeTable,
 						CreatorID:      sharedobjcat.CreatorID(rand.Uint64()),
 						CreatorFileNum: base.FileNum(rand.Uint64()),
 					})

--- a/objstorage/sharedobjcat/testdata/catalog
+++ b/objstorage/sharedobjcat/testdata/catalog
@@ -35,6 +35,17 @@ list test
 SHARED-CATALOG-000001
 marker.shared-catalog.000001.SHARED-CATALOG-000001
 
+set-creator-id 5
+----
+sync: test/SHARED-CATALOG-000001
+
+set-creator-id 5
+----
+
+set-creator-id 6
+----
+error setting creator ID: attempt to change CreatorID from 00000000000000000005 to 00000000000000000006
+
 # Bad batches.
 batch
 add 3 1 1
@@ -52,8 +63,13 @@ close: test/SHARED-CATALOG-000001
 
 open test
 ----
+creator-id: 00000000000000000005
 000002: 20/000200
 000003: 30/000300
+
+set-creator-id 6
+----
+error setting creator ID: attempt to change CreatorID from 00000000000000000005 to 00000000000000000006
 
 batch
 add 4 40 40

--- a/objstorage/sharedobjcat/version_edit_test.go
+++ b/objstorage/sharedobjcat/version_edit_test.go
@@ -18,6 +18,9 @@ func TestVersionEditRoundTrip(t *testing.T) {
 	for _, ve := range []versionEdit{
 		{},
 		{
+			CreatorID: 12345,
+		},
+		{
 			NewObjects: []SharedObjectMetadata{
 				{
 					FileNum:        1,
@@ -30,6 +33,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 			DeletedObjects: []base.FileNum{1},
 		},
 		{
+			CreatorID: 12345,
 			NewObjects: []SharedObjectMetadata{
 				{
 					FileNum:        1,

--- a/objstorage/sharedobjcat/version_edit_test.go
+++ b/objstorage/sharedobjcat/version_edit_test.go
@@ -24,6 +24,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 			NewObjects: []SharedObjectMetadata{
 				{
 					FileNum:        1,
+					FileType:       base.FileTypeTable,
 					CreatorID:      12,
 					CreatorFileNum: 123,
 				},
@@ -37,16 +38,19 @@ func TestVersionEditRoundTrip(t *testing.T) {
 			NewObjects: []SharedObjectMetadata{
 				{
 					FileNum:        1,
+					FileType:       base.FileTypeTable,
 					CreatorID:      12,
 					CreatorFileNum: 123,
 				},
 				{
 					FileNum:        2,
+					FileType:       base.FileTypeTable,
 					CreatorID:      22,
 					CreatorFileNum: 223,
 				},
 				{
 					FileNum:        3,
+					FileType:       base.FileTypeTable,
 					CreatorID:      32,
 					CreatorFileNum: 323,
 				},


### PR DESCRIPTION
#### sharedobjcat: add creator-id

This commit adds support for storing the creator ID in the shared
object catalog. Once set, the ID cannot change.

#### sharedobjcat: store object type

Add object type to on-disk catalog and include FileType in
SharedObjectMetadata.
