### PR TITLE
docs: add benchmark annotation for grandparent boundary splitting

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -63,6 +63,8 @@
         <div class="annotation" data-date="20220526">Data quality issue fixed (YCSB A only)</div>
         <div class="annotation" data-date="20220626">Began zeroing reused
             iterator structs (#1822)</div>
+        <div class="annotation" data-date="20230215">Grandparent boundary
+            compaction splitting</div>
       </div>
       <div class="section rows">
         <div>


### PR DESCRIPTION
Add an annotation to the nightly benchmarks displaying when we began splitting compaction outputs at grandparent boundaries.