### PR TITLE
objstorage: basic shared object functionality 

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2728,7 +2728,7 @@ func (d *DB) runCompaction(
 		pendingOutputs = append(pendingOutputs, fileMeta)
 		d.mu.Unlock()
 
-		writable, objMeta, err := d.objProvider.Create(fileTypeTable, fileNum)
+		writable, objMeta, err := d.objProvider.Create(fileTypeTable, fileNum, objstorage.CreateOptions{} /* TODO */)
 		if err != nil {
 			return err
 		}

--- a/error_test.go
+++ b/error_test.go
@@ -222,6 +222,7 @@ func TestRequireReadError(t *testing.T) {
 			return err
 		}
 		if err := d.Close(); err != nil {
+			d = nil
 			return err
 		}
 		d = nil

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1682,7 +1682,7 @@ func TestIngestCleanup(t *testing.T) {
 			// Create the files in the VFS.
 			metaMap := make(map[base.FileNum]objstorage.Writable)
 			for _, fn := range fns {
-				w, _, err := objProvider.Create(base.FileTypeTable, fn)
+				w, _, err := objProvider.Create(base.FileTypeTable, fn, objstorage.CreateOptions{})
 				require.NoError(t, err)
 
 				metaMap[fn] = w

--- a/objstorage/provider.go
+++ b/objstorage/provider.go
@@ -13,6 +13,8 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage/shared"
+	"github.com/cockroachdb/pebble/objstorage/sharedobjcat"
 	"github.com/cockroachdb/pebble/vfs"
 )
 
@@ -32,8 +34,25 @@ type Provider struct {
 
 	fsDir vfs.File
 
+	// shared fields are only initialized if st.SharedBackend is not nil.
+	shared struct {
+		creatorID CreatorID
+
+		catalog *sharedobjcat.Catalog
+	}
+
 	mu struct {
 		sync.RWMutex
+
+		shared struct {
+			// catalogBatch accumulates shared object creations and deletions until
+			// Sync is called.
+			catalogBatch sharedobjcat.Batch
+		}
+
+		// localObjectsChanged is set if non-shared objects were created or deleted
+		// but Sync was not yet called.
+		localObjectsChanged bool
 
 		// knownObjects maintains information about objects that are known to the provider.
 		// It is initialized with the list of files in the manifest when we open a DB.
@@ -81,6 +100,11 @@ type Writable interface {
 	io.Writer
 	io.Closer
 
+	// Sync makes the data durable and must be called unless we are giving up on
+	// using this object. Sync may be called at most once (before Close); Write
+	// can no longer be called after Sync.
+	// TODO(radu): clean this API up; maybe Close should internally Sync (but we
+	// have to be careful about tests that are using vfs.File as a Writable).
 	Sync() error
 }
 
@@ -115,9 +139,25 @@ type Settings struct {
 	// is used to avoid latency spikes if the OS automatically decides to write
 	// out a large chunk of dirty filesystem buffers.
 	BytesPerSync int
+
+	// Fields here are set only if the provider is to support shared objects
+	// (experimental).
+	Shared struct {
+		Storage shared.Storage
+
+		// CreatorID is persisted in the shared object catalog, if set.
+		//
+		// Ideally it should be set the first time we are opening the provider
+		// (i.e. when creating a new database).
+		//
+		// Until the database is opened with the Creator ID set at least once,
+		// shared objects cannot be created. The Creator ID cannot change.
+		CreatorID CreatorID
+	}
 }
 
-// DefaultSettings initializes default settings, suitable for tests and tools.
+// DefaultSettings initializes default settings (with no shared storage),
+// suitable for tests and tools.
 func DefaultSettings(fs vfs.FS, dirName string) Settings {
 	return Settings{
 		Logger:        base.DefaultLogger,
@@ -133,13 +173,25 @@ func DefaultSettings(fs vfs.FS, dirName string) Settings {
 type ObjectMetadata struct {
 	FileNum  base.FileNum
 	FileType base.FileType
-	// TODO(radu): this will also contain shared object metadata.
+
+	// The fields below are only set if the object is on shared storage.
+	Shared struct {
+		// CreatorID identifies the DB instance that originally created the object.
+		CreatorID CreatorID
+		// CreatorFileNum is the identifier for the object within the context of the
+		// DB instance that originally created the object.
+		CreatorFileNum base.FileNum
+	}
 }
+
+// CreatorID identifies the DB instance that originally created a shared object.
+// This ID is incorporated in backing object names.
+// Must be non-zero.
+type CreatorID = sharedobjcat.CreatorID
 
 // IsShared returns true if the object is on shared storage.
 func (m *ObjectMetadata) IsShared() bool {
-	// TODO(radu)
-	return false
+	return m.Shared.CreatorID.IsSet()
 }
 
 // Open creates the Provider.
@@ -162,17 +214,15 @@ func Open(settings Settings) (p *Provider, _ error) {
 	p.mu.knownObjects = make(map[base.FileNum]ObjectMetadata)
 
 	// Add local FS objects.
-	listing := settings.FSDirInitialListing
-	if listing == nil {
-		var err error
-		listing, err = p.st.FS.List(p.st.FSDirName)
-		if err != nil {
-			return nil, errors.Wrapf(err, "pebble: could not list store directory")
-		}
+	if err := p.vfsInit(); err != nil {
+		return nil, err
 	}
-	objects := p.vfsFindExisting(listing)
-	for _, o := range objects {
-		p.mu.knownObjects[o.FileNum] = o
+
+	// Add shared objects.
+	if p.supportsSharedStorage() {
+		if err := p.sharedInit(); err != nil {
+			return nil, err
+		}
 	}
 
 	return p, nil
@@ -180,11 +230,12 @@ func Open(settings Settings) (p *Provider, _ error) {
 
 // Close the provider.
 func (p *Provider) Close() error {
+	var err error
 	if p.fsDir != nil {
-		return p.fsDir.Close()
+		err = p.fsDir.Close()
+		p.fsDir = nil
 	}
-	p.fsDir = nil
-	return nil
+	return err
 }
 
 // OpenForReading opens an existing object.
@@ -197,8 +248,10 @@ func (p *Provider) OpenForReading(fileType base.FileType, fileNum base.FileNum) 
 	if !meta.IsShared() {
 		return p.vfsOpenForReading(fileType, fileNum, false /* mustExist */)
 	}
-
-	panic("unimplemented")
+	if !p.supportsSharedStorage() {
+		return nil, errors.Errorf("shared storage not enabled but object is shared")
+	}
+	return p.sharedOpenForReading(meta)
 }
 
 // OpenForReadingMustExist is a variant of OpenForReading which causes a fatal
@@ -216,8 +269,19 @@ func (p *Provider) OpenForReadingMustExist(
 	if !meta.IsShared() {
 		return p.vfsOpenForReading(fileType, fileNum, true /* mustExist */)
 	}
+	if !p.supportsSharedStorage() {
+		return nil, errors.Errorf("shared storage not enabled but object is shared")
+	}
 
-	panic("unimplemented")
+	// TODO(radu): implement "must exist" behavior.
+	return p.sharedOpenForReading(meta)
+}
+
+// CreateOptions contains optional arguments for Create.
+type CreateOptions struct {
+	// PreferSharedStorage causes the object to be created on shared storage if
+	// the provider has shared storage configured.
+	PreferSharedStorage bool
 }
 
 // Create creates a new object and opens it for writing.
@@ -225,17 +289,17 @@ func (p *Provider) OpenForReadingMustExist(
 // The object is not guaranteed to be durable (accessible in case of crashes)
 // until Sync is called.
 func (p *Provider) Create(
-	fileType base.FileType, fileNum base.FileNum,
-) (Writable, ObjectMetadata, error) {
-	w, err := p.vfsCreate(fileType, fileNum)
+	fileType base.FileType, fileNum base.FileNum, opts CreateOptions,
+) (w Writable, meta ObjectMetadata, err error) {
+	if opts.PreferSharedStorage && p.supportsSharedStorage() {
+		w, meta, err = p.sharedCreate(fileType, fileNum)
+	} else {
+		w, meta, err = p.vfsCreate(fileType, fileNum)
+	}
 	if err != nil {
+		err = errors.Wrapf(err, "creating object %s", errors.Safe(fileNum))
 		return nil, ObjectMetadata{}, err
 	}
-	meta := ObjectMetadata{
-		FileNum:  fileNum,
-		FileType: fileType,
-	}
-
 	p.addMetadata(meta)
 	return w, meta, nil
 }
@@ -251,14 +315,14 @@ func (p *Provider) Remove(fileType base.FileType, fileNum base.FileNum) error {
 
 	if !meta.IsShared() {
 		err = p.vfsRemove(fileType, fileNum)
-	} else {
-		panic("unimplemented")
 	}
+	// TODO(radu): implement shared object removal (i.e. deref).
+
 	if err != nil && !IsNotExistError(err) {
 		// We want to be able to retry a Remove, so we keep the object in our list.
 		// TODO(radu): we should mark the object as "zombie" and not allow any other
 		// operations.
-		return err
+		return errors.Wrapf(err, "removing object %s", errors.Safe(fileNum))
 	}
 	p.removeMetadata(fileNum)
 	return err
@@ -272,7 +336,13 @@ func IsNotExistError(err error) bool {
 
 // Sync flushes the metadata from creation or removal of objects since the last Sync.
 func (p *Provider) Sync() error {
-	return p.fsDir.Sync()
+	if err := p.vfsSync(); err != nil {
+		return err
+	}
+	if err := p.sharedSync(); err != nil {
+		return err
+	}
+	return nil
 }
 
 // LinkOrCopyFromLocal creates a new object that is either a copy of a given
@@ -335,7 +405,7 @@ func (p *Provider) Path(meta ObjectMetadata) string {
 	if !meta.IsShared() {
 		return p.vfsPath(meta.FileType, meta.FileNum)
 	}
-	panic("unimplemented")
+	return p.sharedPath(meta)
 }
 
 // Size returns the size of the object.
@@ -343,14 +413,14 @@ func (p *Provider) Size(meta ObjectMetadata) (int64, error) {
 	if !meta.IsShared() {
 		return p.vfsSize(meta.FileType, meta.FileNum)
 	}
-	panic("unimplemented")
+	return p.sharedSize(meta)
 }
 
 // List returns the objects currently known to the provider. Does not perform any I/O.
 func (p *Provider) List() []ObjectMetadata {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	res := make([]ObjectMetadata, len(p.mu.knownObjects))
+	res := make([]ObjectMetadata, 0, len(p.mu.knownObjects))
 	for _, meta := range p.mu.knownObjects {
 		res = append(res, meta)
 	}
@@ -364,10 +434,34 @@ func (p *Provider) addMetadata(meta ObjectMetadata) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.mu.knownObjects[meta.FileNum] = meta
+	if meta.IsShared() {
+		p.mu.shared.catalogBatch.AddObject(sharedobjcat.SharedObjectMetadata{
+			FileNum:        meta.FileNum,
+			FileType:       meta.FileType,
+			CreatorID:      meta.Shared.CreatorID,
+			CreatorFileNum: meta.Shared.CreatorFileNum,
+		})
+	} else {
+		p.mu.localObjectsChanged = true
+	}
 }
 
 func (p *Provider) removeMetadata(fileNum base.FileNum) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+
+	meta, ok := p.mu.knownObjects[fileNum]
+	if !ok {
+		return
+	}
 	delete(p.mu.knownObjects, fileNum)
+	if meta.IsShared() {
+		p.mu.shared.catalogBatch.DeleteObject(fileNum)
+	} else {
+		p.mu.localObjectsChanged = true
+	}
+}
+
+func (p *Provider) supportsSharedStorage() bool {
+	return p.st.Shared.Storage != nil
 }

--- a/objstorage/provider_test.go
+++ b/objstorage/provider_test.go
@@ -5,12 +5,117 @@
 package objstorage
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage/shared"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
+
+func TestProvider(t *testing.T) {
+	var log base.InMemLogger
+	fs := vfs.WithLogging(vfs.NewMem(), func(fmt string, args ...interface{}) {
+		log.Infof("<local fs> "+fmt, args...)
+	})
+	sharedStore := shared.WithLogging(shared.NewInMem(), func(fmt string, args ...interface{}) {
+		log.Infof("<shared> "+fmt, args...)
+	})
+
+	providers := make(map[string]*Provider)
+	var curProvider *Provider
+	datadriven.RunTest(t, "testdata/provider", func(t *testing.T, d *datadriven.TestData) string {
+		scanArgs := func(desc string, args ...interface{}) {
+			t.Helper()
+			if len(d.CmdArgs) != len(args) {
+				d.Fatalf(t, "usage: %s %s", d.Cmd, desc)
+			}
+			for i := range args {
+				_, err := fmt.Sscan(d.CmdArgs[i].String(), args[i])
+				if err != nil {
+					d.Fatalf(t, "%s: error parsing argument '%s'", d.Cmd, d.CmdArgs[i])
+				}
+			}
+		}
+
+		log.Reset()
+		switch d.Cmd {
+		case "open":
+			var fsDir string
+			var creatorID CreatorID
+			scanArgs("<fs-dir> <shared-creator-id>", &fsDir, &creatorID)
+
+			st := DefaultSettings(fs, fsDir)
+			if creatorID != 0 {
+				st.Shared.Storage = sharedStore
+				st.Shared.CreatorID = creatorID
+			}
+			require.NoError(t, fs.MkdirAll(fsDir, 0755))
+			provider, err := Open(st)
+			require.NoError(t, err)
+			providers[fsDir] = provider
+			curProvider = provider
+
+			return log.String()
+
+		case "close":
+			require.NoError(t, curProvider.Sync())
+			require.NoError(t, curProvider.Close())
+			delete(providers, curProvider.st.FSDirName)
+			curProvider = nil
+
+			return log.String()
+
+		case "create":
+			var fileNum base.FileNum
+			var typ string
+			scanArgs("<file-num> <local|shared>", &fileNum, &typ)
+			var opts CreateOptions
+			switch typ {
+			case "local":
+			case "shared":
+				opts.PreferSharedStorage = true
+			default:
+				d.Fatalf(t, "'%s' should be 'local' or 'shared'", typ)
+			}
+			w, _, err := curProvider.Create(base.FileTypeTable, fileNum, opts)
+			if err != nil {
+				return err.Error()
+			}
+			_, err = w.Write([]byte(d.Input))
+			require.NoError(t, err)
+			require.NoError(t, w.Sync())
+			require.NoError(t, w.Close())
+
+			return log.String()
+
+		case "read":
+			var fileNum base.FileNum
+			scanArgs("<file-num>", &fileNum)
+			r, err := curProvider.OpenForReading(base.FileTypeTable, fileNum)
+			if err != nil {
+				return err.Error()
+			}
+			data := make([]byte, int(r.Size()))
+			n, err := r.ReadAt(data, 0)
+			require.NoError(t, err)
+			require.Equal(t, n, len(data))
+			return log.String() + fmt.Sprintf("data: %s\n", string(data))
+
+		case "list":
+			for _, meta := range curProvider.List() {
+				log.Infof("%s", curProvider.Path(meta))
+			}
+			return log.String()
+
+		default:
+			d.Fatalf(t, "unknown command %s", d.Cmd)
+			return ""
+		}
+	})
+}
 
 func TestNotExistError(t *testing.T) {
 	// TODO(radu): test with shared objects.
@@ -23,7 +128,7 @@ func TestNotExistError(t *testing.T) {
 	_, err = provider.OpenForReading(base.FileTypeTable, 1)
 	require.True(t, IsNotExistError(err))
 
-	w, _, err := provider.Create(base.FileTypeTable, 1)
+	w, _, err := provider.Create(base.FileTypeTable, 1, CreateOptions{})
 	require.NoError(t, err)
 	_, err = w.Write([]byte("foo"))
 	require.NoError(t, err)

--- a/objstorage/shared.go
+++ b/objstorage/shared.go
@@ -1,0 +1,116 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package objstorage
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage/sharedobjcat"
+)
+
+// sharedInit initializes the shared object subsystem and finds any shared
+// objects.
+func (p *Provider) sharedInit() error {
+	catalog, contents, err := sharedobjcat.Open(p.st.FS, p.st.FSDirName)
+	if err != nil {
+		return errors.Wrapf(err, "pebble: could not open shared object catalog")
+	}
+	p.shared.catalog = catalog
+	// The creator ID may or may not be initialized yet.
+	p.shared.creatorID = contents.CreatorID
+
+	if p.st.Shared.CreatorID.IsSet() {
+		if err := catalog.SetCreatorID(p.st.Shared.CreatorID); err != nil {
+			catalog.Close()
+			return err
+		}
+		p.shared.creatorID = p.st.Shared.CreatorID
+	}
+
+	for _, meta := range contents.Objects {
+		o := ObjectMetadata{
+			FileNum:  meta.FileNum,
+			FileType: meta.FileType,
+		}
+		o.Shared.CreatorID = meta.CreatorID
+		o.Shared.CreatorFileNum = meta.CreatorFileNum
+		p.mu.knownObjects[o.FileNum] = o
+	}
+	return nil
+}
+
+func (p *Provider) sharedSync() error {
+	batch := func() sharedobjcat.Batch {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		res := p.mu.shared.catalogBatch.Copy()
+		p.mu.shared.catalogBatch.Reset()
+		return res
+	}()
+
+	if batch.IsEmpty() {
+		return nil
+	}
+
+	err := p.shared.catalog.ApplyBatch(batch)
+	if err != nil {
+		// We have to put back the batch (for the next Sync).
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		batch.Append(p.mu.shared.catalogBatch)
+		p.mu.shared.catalogBatch = batch
+		return err
+	}
+
+	return nil
+}
+
+func (p *Provider) sharedPath(meta ObjectMetadata) string {
+	return "shared://" + sharedObjectName(meta)
+}
+
+func sharedObjectName(meta ObjectMetadata) string {
+	// TODO(radu): prepend a "shard" value for better distribution within the bucket?
+	return fmt.Sprintf("%s-%s", meta.Shared.CreatorID, base.MakeFilename(meta.FileType, meta.FileNum))
+}
+
+func (p *Provider) sharedCreate(
+	fileType base.FileType, fileNum base.FileNum,
+) (Writable, ObjectMetadata, error) {
+	if !p.shared.creatorID.IsSet() {
+		return nil, ObjectMetadata{}, errors.Errorf("creator ID not set; shared object creation not possible")
+	}
+	meta := ObjectMetadata{
+		FileNum:  fileNum,
+		FileType: fileType,
+	}
+	meta.Shared.CreatorID = p.shared.creatorID
+	meta.Shared.CreatorFileNum = fileNum
+
+	objName := sharedObjectName(meta)
+	writer, err := p.st.Shared.Storage.CreateObject(objName)
+	if err != nil {
+		return nil, ObjectMetadata{}, err
+	}
+	return &sharedWritable{
+		storageWriter: writer,
+	}, meta, nil
+}
+
+func (p *Provider) sharedOpenForReading(meta ObjectMetadata) (Readable, error) {
+	objName := sharedObjectName(meta)
+	size, err := p.st.Shared.Storage.Size(objName)
+	if err != nil {
+		return nil, err
+	}
+	return newSharedReadable(p.st.Shared.Storage, objName, size), nil
+}
+
+func (p *Provider) sharedSize(meta ObjectMetadata) (int64, error) {
+	objName := sharedObjectName(meta)
+	return p.st.Shared.Storage.Size(objName)
+}

--- a/objstorage/shared/logging.go
+++ b/objstorage/shared/logging.go
@@ -1,0 +1,105 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package shared
+
+import (
+	"fmt"
+	"io"
+	"sort"
+)
+
+// loggingStore wraps a shared.Storage implementation and emits logs of the
+// operations.
+type loggingStore struct {
+	logf    func(fmt string, args ...interface{})
+	wrapped Storage
+}
+
+var _ Storage = (*loggingStore)(nil)
+
+func (l *loggingStore) Close() error {
+	l.logf("close")
+	return l.wrapped.Close()
+}
+
+func (l *loggingStore) ReadObjectAt(
+	basename string, offset int64,
+) (_ io.ReadCloser, totalSize int64, _ error) {
+	r, totalSize, err := l.wrapped.ReadObjectAt(basename, offset)
+	l.logf("read object %q at %d: %s", basename, offset, errOrPrintf(err, "%d bytes", totalSize))
+	if err != nil {
+		return nil, 0, err
+	}
+	return &loggingReader{
+		l:          l,
+		name:       basename,
+		ReadCloser: r,
+	}, totalSize, nil
+}
+
+type loggingReader struct {
+	l    *loggingStore
+	name string
+	io.ReadCloser
+}
+
+func (l *loggingReader) Close() error {
+	l.l.logf("close reader for %q", l.name)
+	return l.ReadCloser.Close()
+}
+
+func (l *loggingStore) CreateObject(basename string) (io.WriteCloser, error) {
+	l.logf("create object %q", basename)
+	return l.wrapped.CreateObject(basename)
+}
+
+type loggingWriter struct {
+	l     *loggingStore
+	name  string
+	bytes int64
+	io.WriteCloser
+}
+
+func (l *loggingWriter) Write(p []byte) (n int, err error) {
+	n, err = l.WriteCloser.Write(p)
+	l.bytes += int64(n)
+	return n, err
+}
+func (l *loggingWriter) Close() error {
+	l.l.logf("close writer for %q after %d bytes", l.name, l.bytes)
+	return l.WriteCloser.Close()
+}
+
+func (l *loggingStore) List(prefix, delimiter string) ([]string, error) {
+	l.logf("list (prefix=%q, delimiter=%q)", prefix, delimiter)
+	res, err := l.wrapped.List(prefix, delimiter)
+	if err != nil {
+		return nil, err
+	}
+	sorted := append([]string(nil), res...)
+	sort.Strings(sorted)
+	for _, s := range sorted {
+		l.logf(" - %s", s)
+	}
+	return res, nil
+}
+
+func (l *loggingStore) Delete(basename string) error {
+	l.logf("delete object %q", basename)
+	return l.wrapped.Delete(basename)
+}
+
+func (l *loggingStore) Size(basename string) (int64, error) {
+	size, err := l.wrapped.Size(basename)
+	l.logf("size of object %q: %s", basename, errOrPrintf(err, "%d", size))
+	return size, err
+}
+
+func errOrPrintf(err error, format string, args ...interface{}) string {
+	if err != nil {
+		return fmt.Sprintf("error: %v", err)
+	}
+	return fmt.Sprintf(format, args...)
+}

--- a/objstorage/shared/mem.go
+++ b/objstorage/shared/mem.go
@@ -1,0 +1,154 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package shared
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"sync"
+)
+
+// InMemStore is an in-memory implementation of the shared.Storage interface
+// (for testing).
+type InMemStore struct {
+	mu struct {
+		sync.Mutex
+		objects map[string]*inMemObj
+	}
+}
+
+var _ Storage = (*InMemStore)(nil)
+
+type inMemObj struct {
+	name string
+	data []byte
+}
+
+func NewInMemStore() *InMemStore {
+	store := &InMemStore{}
+	store.mu.objects = make(map[string]*inMemObj)
+	return store
+}
+
+func (s *InMemStore) Close() error {
+	*s = InMemStore{}
+	return nil
+}
+
+func (s *InMemStore) ReadObjectAt(basename string, offset int64) (io.ReadCloser, int64, error) {
+	obj, err := s.getObj(basename)
+	if err != nil {
+		return nil, 0, err
+	}
+	remaining := int64(len(obj.data)) - offset
+	if remaining < 0 {
+		return nil, 0, io.EOF
+	}
+	return newInMemReader(obj.data[int(offset):]), remaining, nil
+}
+
+type inMemReader struct {
+	bytes.Reader
+}
+
+func newInMemReader(b []byte) *inMemReader {
+	r := &inMemReader{}
+	r.Reset(b)
+	return r
+}
+
+var _ io.ReadCloser = (*inMemReader)(nil)
+
+func (r *inMemReader) Close() error {
+	r.Reset(nil)
+	return nil
+}
+
+func (s *InMemStore) CreateObject(basename string) (io.WriteCloser, error) {
+	return &inMemWriter{
+		store: s,
+		name:  basename,
+	}, nil
+}
+
+type inMemWriter struct {
+	store *InMemStore
+	name  string
+	buf   bytes.Buffer
+}
+
+var _ io.WriteCloser = (*inMemWriter)(nil)
+
+func (o *inMemWriter) Write(p []byte) (n int, err error) {
+	if o.store == nil {
+		panic("Write after Close")
+	}
+	return o.buf.Write(p)
+}
+
+func (o *inMemWriter) Close() error {
+	if o.store != nil {
+		o.store.addObj(&inMemObj{
+			name: o.name,
+			data: o.buf.Bytes(),
+		})
+		o.store = nil
+	}
+	return nil
+}
+
+func (s *InMemStore) List(prefix, delimiter string) ([]string, error) {
+	if delimiter != "" {
+		panic("delimiter unimplemented")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	res := make([]string, 0, len(s.mu.objects))
+	for name := range s.mu.objects {
+		if strings.HasPrefix(name, prefix) {
+			res = append(res, name)
+		}
+	}
+	return res, nil
+}
+
+func (s *InMemStore) Delete(basename string) error {
+	s.rmObj(basename)
+	return nil
+}
+
+// Size returns the length of the named object in bytes.
+func (s *InMemStore) Size(basename string) (int64, error) {
+	obj, err := s.getObj(basename)
+	if err != nil {
+		return 0, err
+	}
+	return int64(len(obj.data)), nil
+}
+
+func (s *InMemStore) getObj(name string) (*inMemObj, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	obj, ok := s.mu.objects[name]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return obj, nil
+}
+
+func (s *InMemStore) addObj(o *inMemObj) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mu.objects[o.name] = o
+}
+
+func (s *InMemStore) rmObj(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.mu.objects, name)
+}

--- a/objstorage/shared/storage.go
+++ b/objstorage/shared/storage.go
@@ -16,8 +16,8 @@ type Storage interface {
 	io.Closer
 
 	// ReadObjectAt returns a Reader for reading the object at the requested name
-	// and offset.
-	ReadObjectAt(basename string, offset int64) (io.ReadCloser, int64, error)
+	// and offset, along with the total size of the object.
+	ReadObjectAt(basename string, offset int64) (_ io.ReadCloser, totalSize int64, _ error)
 
 	// CreateObject returns a writer for the object at the request name. A new
 	// empty object is created if CreateObject is called on an existing object.

--- a/objstorage/shared/storage.go
+++ b/objstorage/shared/storage.go
@@ -27,6 +27,10 @@ type Storage interface {
 	// implementation may buffer written data until Close and only then return
 	// an error, or Write may return an opaque io.EOF with the underlying cause
 	// returned by the subsequent Close().
+	//
+	// TODO(radu): if we encounter some unrelated error while writing to the
+	// WriteCloser, we'd want to abort the whole thing rather than letting Close
+	// finalize the upload.
 	CreateObject(basename string) (io.WriteCloser, error)
 
 	// List enumerates files within the supplied prefix, returning a list of
@@ -45,8 +49,13 @@ type Storage interface {
 	List(prefix, delimiter string) ([]string, error)
 
 	// Delete removes the named object from the store.
+	//
+	// TODO(radu): do we get an error when the object isn't there? How can we
+	// check for that error?
 	Delete(basename string) error
 
-	// Size returns the length of the named object in bytes.
+	// Size returns the length of the named object in bytesWritten.
+	//
+	// TODO(radu): same as above - how can we tell if it's a "no such object" error?
 	Size(basename string) (int64, error)
 }

--- a/objstorage/shared_readable.go
+++ b/objstorage/shared_readable.go
@@ -1,0 +1,97 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package objstorage
+
+import (
+	"io"
+
+	"github.com/cockroachdb/pebble/objstorage/shared"
+)
+
+// sharedReadable is a very simple implementation of Readable on top of the
+// ReadCloser returned by shared.Storage.CreateObject.
+type sharedReadable struct {
+	storage shared.Storage
+	objName string
+	size    int64
+
+	// rh is used for direct ReadAt calls without a readahead handle.
+	rh sharedReadaheadHandle
+}
+
+var _ Readable = (*sharedReadable)(nil)
+
+func newSharedReadable(storage shared.Storage, objName string, size int64) *sharedReadable {
+	r := &sharedReadable{
+		storage: storage,
+		objName: objName,
+		size:    size,
+	}
+	r.rh.readable = r
+	return r
+}
+
+func (r *sharedReadable) ReadAt(p []byte, offset int64) (n int, err error) {
+	return r.rh.ReadAt(p, offset)
+}
+
+func (r *sharedReadable) Close() error {
+	err := r.rh.Close()
+	r.storage = nil
+	return err
+}
+
+func (r *sharedReadable) Size() int64 {
+	return r.size
+}
+
+func (r *sharedReadable) NewReadaheadHandle() ReadaheadHandle {
+	// TODO(radu): use a pool.
+	return &sharedReadaheadHandle{readable: r}
+}
+
+type sharedReadaheadHandle struct {
+	readable   *sharedReadable
+	lastReader io.ReadCloser
+	lastOffset int64
+}
+
+var _ ReadaheadHandle = (*sharedReadaheadHandle)(nil)
+
+func (r *sharedReadaheadHandle) ReadAt(p []byte, offset int64) (n int, err error) {
+	// See if this continues the previous read so that we can reuse the last reader.
+	if r.lastReader == nil || r.lastOffset != offset {
+		// We need to create a new reader.
+		if r.lastReader != nil {
+			if err := r.lastReader.Close(); err != nil {
+				return 0, err
+			}
+			r.lastReader = nil
+		}
+		reader, _, err := r.readable.storage.ReadObjectAt(r.readable.objName, offset)
+		if err != nil {
+			return 0, err
+		}
+		r.lastReader = reader
+		r.lastOffset = offset
+	}
+	n, err = io.ReadFull(r.lastReader, p)
+	r.lastOffset += int64(n)
+	return n, err
+}
+
+func (r *sharedReadaheadHandle) Close() error {
+	var err error
+	if r.lastReader != nil {
+		err = r.lastReader.Close()
+		r.lastReader = nil
+	}
+	r.readable = nil
+	return err
+}
+
+func (r *sharedReadaheadHandle) MaxReadahead() {}
+
+func (r *sharedReadaheadHandle) RecordCacheHit(offset, size int64) {}

--- a/objstorage/shared_writable.go
+++ b/objstorage/shared_writable.go
@@ -1,0 +1,42 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package objstorage
+
+import (
+	"io"
+
+	"github.com/cockroachdb/errors"
+)
+
+// sharedWritable is a very simple implementation of Writable on top of the
+// WriteCloser returned by shared.Storage.CreateObject.
+type sharedWritable struct {
+	storageWriter io.WriteCloser
+}
+
+var _ Writable = (*sharedWritable)(nil)
+
+func (w *sharedWritable) Write(p []byte) (n int, err error) {
+	if w.storageWriter == nil {
+		return 0, errors.AssertionFailedf("Write after Sync or Close")
+	}
+	return w.storageWriter.Write(p)
+}
+
+func (w *sharedWritable) Close() error {
+	if w.storageWriter == nil {
+		return nil
+	}
+	err := w.storageWriter.Close()
+	w.storageWriter = nil
+	return err
+}
+
+func (w *sharedWritable) Sync() error {
+	if w.storageWriter == nil {
+		return errors.AssertionFailedf("Sync after Sync or Close")
+	}
+	return w.Close()
+}

--- a/objstorage/sharedobjcat/catalog_test.go
+++ b/objstorage/sharedobjcat/catalog_test.go
@@ -112,9 +112,10 @@ func TestCatalog(t *testing.T) {
 					td.Fatalf(t, "unknown batch command: %s", tokens[0])
 				}
 			}
-			if err := cat.ApplyBatch(&b); err != nil {
+			if err := cat.ApplyBatch(b); err != nil {
 				return fmt.Sprintf("error applying batch: %v", err)
 			}
+			b.Reset()
 			return memLog.String()
 
 		case "random-batches":
@@ -145,9 +146,10 @@ func TestCatalog(t *testing.T) {
 						CreatorFileNum: base.FileNum(rand.Uint64()),
 					})
 				}
-				if err := cat.ApplyBatch(&b); err != nil {
+				if err := cat.ApplyBatch(b); err != nil {
 					td.Fatalf(t, "error applying batch: %v", err)
 				}
+				b.Reset()
 			}
 			return memLog.String()
 

--- a/objstorage/testdata/provider
+++ b/objstorage/testdata/provider
@@ -1,0 +1,85 @@
+# open <fs-dir> <creator-id>
+open p1 1
+----
+<local fs> mkdir-all: p1 0755
+<local fs> open-dir: p1
+<local fs> open-dir: p1
+<local fs> create: p1/SHARED-CATALOG-000001
+<local fs> sync: p1/SHARED-CATALOG-000001
+<local fs> create: p1/marker.shared-catalog.000001.SHARED-CATALOG-000001
+<local fs> close: p1/marker.shared-catalog.000001.SHARED-CATALOG-000001
+<local fs> sync: p1
+<local fs> sync: p1/SHARED-CATALOG-000001
+
+create 1 local
+obj-one
+----
+<local fs> create: p1/000001.sst
+<local fs> sync-data: p1/000001.sst
+<local fs> close: p1/000001.sst
+
+read 1
+----
+data: obj-one
+
+create 2 shared
+obj-one
+----
+<shared> create object "00000000000000000001-000002.sst"
+<shared> close writer for "00000000000000000001-000002.sst" after 7 bytes
+
+read 2
+----
+<shared> size of object "00000000000000000001-000002.sst": 7
+<shared> read object "00000000000000000001-000002.sst" at 0: 7 bytes
+data: obj-one
+
+list
+----
+p1/000001.sst
+shared://00000000000000000001-000002.sst
+
+close
+----
+<local fs> sync: p1
+<local fs> sync: p1/SHARED-CATALOG-000001
+<local fs> close: p1
+
+# Test that the objects are there on re-open.
+open p1 1
+----
+<local fs> mkdir-all: p1 0755
+<local fs> open-dir: p1
+<local fs> open-dir: p1
+
+list
+----
+p1/000001.sst
+shared://00000000000000000001-000002.sst
+
+close
+----
+<local fs> close: p1
+
+# A provider without shared storage creates object with shared preference
+# locally.
+open p0 0
+----
+<local fs> mkdir-all: p0 0755
+<local fs> open-dir: p0
+
+create 1 shared
+foo
+----
+<local fs> create: p0/000001.sst
+<local fs> sync-data: p0/000001.sst
+<local fs> close: p0/000001.sst
+
+read 1
+----
+data: foo
+
+close
+----
+<local fs> sync: p0
+<local fs> close: p0

--- a/open.go
+++ b/open.go
@@ -707,7 +707,7 @@ func (d *DB) replayWAL(
 			1 /* base level */, toFlush)
 		newVE, _, err := d.runCompaction(jobID, c)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "running compaction during WAL replay")
 		}
 		ve.NewFiles = append(ve.NewFiles, newVE.NewFiles...)
 		return nil

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -177,7 +177,7 @@ func runBuildRawCmd(
 	}
 	defer provider.Close()
 
-	f0, _, err := provider.Create(base.FileTypeTable, 0 /* fileNum */)
+	f0, _, err := provider.Create(base.FileTypeTable, 0 /* fileNum */, objstorage.CreateOptions{})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -695,7 +695,7 @@ func TestReadaheadSetupForV3TablesWithMultipleVersions(t *testing.T) {
 	provider, err := objstorage.Open(objstorage.DefaultSettings(vfs.Default, tmpDir))
 	require.NoError(t, err)
 	defer provider.Close()
-	f0, _, err := provider.Create(base.FileTypeTable, 0 /* fileNum */)
+	f0, _, err := provider.Create(base.FileTypeTable, 0 /* fileNum */, objstorage.CreateOptions{})
 	require.NoError(t, err)
 
 	w := NewWriter(f0, WriterOptions{
@@ -1067,7 +1067,7 @@ func buildTestTableWithProvider(
 	blockSize, indexBlockSize int,
 	compression Compression,
 ) *Reader {
-	f0, _, err := provider.Create(base.FileTypeTable, 0 /* fileNum */)
+	f0, _, err := provider.Create(base.FileTypeTable, 0 /* fileNum */, objstorage.CreateOptions{})
 	require.NoError(t, err)
 
 	w := NewWriter(f0, WriterOptions{

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -168,7 +168,7 @@ func newTableCacheContainerTest(
 	defer objProvider.Close()
 
 	for i := 0; i < tableCacheTestNumTables; i++ {
-		w, _, err := objProvider.Create(fileTypeTable, FileNum(i))
+		w, _, err := objProvider.Create(fileTypeTable, FileNum(i), objstorage.CreateOptions{})
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "fs.Create")
 		}
@@ -877,7 +877,7 @@ func TestTableCacheClockPro(t *testing.T) {
 
 	makeTable := func(fileNum FileNum) {
 		require.NoError(t, err)
-		f, _, err := objProvider.Create(fileTypeTable, fileNum)
+		f, _, err := objProvider.Create(fileTypeTable, fileNum, objstorage.CreateOptions{})
 		require.NoError(t, err)
 		w := sstable.NewWriter(f, sstable.WriterOptions{})
 		require.NoError(t, w.Set([]byte("a"), nil))

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -179,7 +179,6 @@ lock: db1/LOCK
 open-dir: db1
 open-dir: db1
 open-dir: db1
-sync: db1
 create: db1/MANIFEST-000458
 sync: db1/MANIFEST-000458
 remove: db1/temporary.000458.dbtmp


### PR DESCRIPTION
#### objstorage: add in-memory and logging implementations of shared.Storage

This commit adds in-memory and with-logging implementations of
shared.Storage.

#### objstorage: basic shared object functionality

This commit adds basic shared object functionality to the provider.

We do not implement any refcounting or removal of shared objects.
