### PR TITLE
db: use objstorage to find obsolete objects

### DIFF
--- a/objstorage/vfs.go
+++ b/objstorage/vfs.go
@@ -63,3 +63,12 @@ func (p *Provider) vfsFindExisting(ls []string) []ObjectMetadata {
 	}
 	return res
 }
+
+func (p *Provider) vfsSize(fileType base.FileType, fileNum base.FileNum) (int64, error) {
+	filename := p.vfsPath(fileType, fileNum)
+	stat, err := p.st.FS.Stat(filename)
+	if err != nil {
+		return 0, err
+	}
+	return stat.Size(), nil
+}

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -1,9 +1,10 @@
-open db
+# Test archive cleaner.
+open db archive
 ----
 mkdir-all: db 0755
-mkdir-all: wal 0755
+mkdir-all: db_wal 0755
 open-dir: db
-open-dir: wal
+open-dir: db_wal
 lock: db/LOCK
 open-dir: db
 open-dir: db
@@ -17,8 +18,8 @@ rename: db/temporary.000001.dbtmp -> db/CURRENT
 sync: db
 open-dir: db
 sync: db/MANIFEST-000001
-create: wal/000002.log
-sync: wal
+create: db_wal/000002.log
+sync: db_wal
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -30,40 +31,40 @@ set a 1
 set b 2
 set c 3
 ----
-sync-data: wal/000002.log
+sync-data: db_wal/000002.log
 
 flush db
 ----
-sync-data: wal/000002.log
-close: wal/000002.log
-create: wal/000004.log
-sync: wal
+sync-data: db_wal/000002.log
+close: db_wal/000002.log
+create: db_wal/000004.log
+sync: db_wal
 create: db/000005.sst
 sync-data: db/000005.sst
 close: db/000005.sst
 sync: db
 sync: db/MANIFEST-000001
-mkdir-all: wal/archive 0755
-rename: wal/000002.log -> wal/archive/000002.log
+mkdir-all: db_wal/archive 0755
+rename: db_wal/000002.log -> db_wal/archive/000002.log
 
 batch db
 set d 4
 ----
-sync-data: wal/000004.log
+sync-data: db_wal/000004.log
 
 compact db
 ----
-sync-data: wal/000004.log
-close: wal/000004.log
-create: wal/000006.log
-sync: wal
+sync-data: db_wal/000004.log
+close: db_wal/000004.log
+create: db_wal/000006.log
+sync: db_wal
 create: db/000007.sst
 sync-data: db/000007.sst
 close: db/000007.sst
 sync: db
 sync: db/MANIFEST-000001
-mkdir-all: wal/archive 0755
-rename: wal/000004.log -> wal/archive/000004.log
+mkdir-all: db_wal/archive 0755
+rename: db_wal/000004.log -> db_wal/archive/000004.log
 create: db/000008.sst
 sync-data: db/000008.sst
 close: db/000008.sst
@@ -83,7 +84,7 @@ MANIFEST-000001
 OPTIONS-000003
 archive
 
-list wal
+list db_wal
 ----
 000006.log
 archive
@@ -93,7 +94,118 @@ list db/archive
 000005.sst
 000007.sst
 
-list wal/archive
+list db_wal/archive
 ----
 000002.log
 000004.log
+
+# Test cleanup of extra sstables on open.
+open db1
+----
+mkdir-all: db1 0755
+mkdir-all: db1_wal 0755
+open-dir: db1
+open-dir: db1_wal
+lock: db1/LOCK
+open-dir: db1
+open-dir: db1
+create: db1/MANIFEST-000001
+sync: db1/MANIFEST-000001
+remove: db1/temporary.000001.dbtmp
+create: db1/temporary.000001.dbtmp
+sync: db1/temporary.000001.dbtmp
+close: db1/temporary.000001.dbtmp
+rename: db1/temporary.000001.dbtmp -> db1/CURRENT
+sync: db1
+open-dir: db1
+sync: db1/MANIFEST-000001
+create: db1_wal/000002.log
+sync: db1_wal
+create: db1/temporary.000003.dbtmp
+sync: db1/temporary.000003.dbtmp
+close: db1/temporary.000003.dbtmp
+rename: db1/temporary.000003.dbtmp -> db1/OPTIONS-000003
+sync: db1
+
+batch db1
+set a 1
+set b 2
+set c 3
+----
+sync-data: db1_wal/000002.log
+
+flush db1
+----
+sync-data: db1_wal/000002.log
+close: db1_wal/000002.log
+create: db1_wal/000004.log
+sync: db1_wal
+create: db1/000005.sst
+sync-data: db1/000005.sst
+close: db1/000005.sst
+sync: db1
+sync: db1/MANIFEST-000001
+
+close db1
+----
+close: db1
+sync-data: db1_wal/000004.log
+close: db1_wal/000004.log
+close: db1/MANIFEST-000001
+close: db1
+close: db1
+close: db1_wal
+close: db1
+
+create-bogus-file db1/000123.sst
+----
+create: db1/000123.sst
+sync: db1/000123.sst
+close: db1/000123.sst
+
+create-bogus-file db1/000456.sst
+----
+create: db1/000456.sst
+sync: db1/000456.sst
+close: db1/000456.sst
+
+open db1
+----
+mkdir-all: db1 0755
+mkdir-all: db1_wal 0755
+open-dir: db1
+open-dir: db1_wal
+lock: db1/LOCK
+open-dir: db1
+open-dir: db1
+open-dir: db1
+sync: db1
+create: db1/MANIFEST-000458
+sync: db1/MANIFEST-000458
+remove: db1/temporary.000458.dbtmp
+create: db1/temporary.000458.dbtmp
+sync: db1/temporary.000458.dbtmp
+close: db1/temporary.000458.dbtmp
+rename: db1/temporary.000458.dbtmp -> db1/CURRENT
+sync: db1
+create: db1_wal/000457.log
+sync: db1_wal
+create: db1/temporary.000459.dbtmp
+sync: db1/temporary.000459.dbtmp
+close: db1/temporary.000459.dbtmp
+rename: db1/temporary.000459.dbtmp -> db1/OPTIONS-000459
+sync: db1
+remove: db1_wal/000002.log
+remove: db1_wal/000004.log
+remove: db1/000123.sst
+remove: db1/000456.sst
+remove: db1/OPTIONS-000003
+
+list db1
+----
+000005.sst
+CURRENT
+LOCK
+MANIFEST-000001
+MANIFEST-000458
+OPTIONS-000459


### PR DESCRIPTION
Ignore SST files in the listing and instead get the list of objects from the objstorage provider.