### PR TITLE
build: add make targets for asan and msan; add ci jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,6 +77,32 @@ jobs:
 
     - run: CGO_ENABLED=0 make test TAGS=
 
+  linux-asan:
+    name: go-linux-asan
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: "1.20.1"
+
+    - run: make testasan
+
+  linux-msan:
+    name: go-linux-msan
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: "1.20.1"
+
+    - run: make testmsan
+
   darwin:
     name: go-macos
     runs-on: macos-11

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,13 @@ test:
 testrace: testflags += -race -timeout 20m
 testrace: test
 
+testasan: testflags += -asan -timeout 20m
+testasan: test
+
+testmsan: export CC=clang
+testmsan: testflags += -msan -timeout 20m
+testmsan: test
+
 .PHONY: lint
 lint:
 	${GO} test -tags '$(TAGS)' ${testflags} -run ${TESTS} ./internal/lint


### PR DESCRIPTION
Add two test targets for address and memory sanitization. This is intended to improve Pebble coverage to aid in detection of subtle memory errors.

Add two new CI targets. The two types of sanitization must can not be run together.

Touches #2320.