### PR TITLE
.*: virtual sstable FileMetadata changes

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -135,6 +135,9 @@ func mkdirAllAndSyncParents(fs vfs.FS, destDir string) (vfs.File, error) {
 // space overhead for a checkpoint if hard links are disabled. Also beware that
 // even if hard links are used, the space overhead for the checkpoint will
 // increase over time as the DB performs compactions.
+//
+// TODO(bananabrick): Test checkpointing of virtual sstables once virtual
+// sstables is running e2e.
 func (d *DB) Checkpoint(
 	destDir string, opts ...CheckpointOption,
 ) (
@@ -188,7 +191,10 @@ func (d *DB) Checkpoint(
 	manifestFileNum := d.mu.versions.manifestFileNum
 	manifestSize := d.mu.versions.manifest.Size()
 	optionsFileNum := d.optionsFileNum
-
+	virtualBackingFiles := make(map[base.FileNum]struct{})
+	for fileNum := range d.mu.versions.fileBackingMap {
+		virtualBackingFiles[fileNum] = struct{}{}
+	}
 	// Release the manifest and DB.mu so we don't block other operations on
 	// the database.
 	d.mu.versions.logUnlock()
@@ -254,7 +260,9 @@ func (d *DB) Checkpoint(
 	}
 
 	var excludedFiles map[deletedFileEntry]*fileMetadata
-
+	// Set of FileBacking.FileNum which will be required by virtual sstables in
+	// the checkpoint.
+	requiredVirtualBackingFiles := make(map[base.FileNum]struct{})
 	// Link or copy the sstables.
 	for l := range current.Levels {
 		iter := current.Levels[l].Iter()
@@ -270,7 +278,15 @@ func (d *DB) Checkpoint(
 				continue
 			}
 
-			srcPath := base.MakeFilepath(fs, d.dirname, fileTypeTable, f.FileNum)
+			fileBacking := f.FileBacking
+			if f.Virtual {
+				if _, ok := requiredVirtualBackingFiles[fileBacking.FileNum]; ok {
+					continue
+				}
+				requiredVirtualBackingFiles[fileBacking.FileNum] = struct{}{}
+			}
+
+			srcPath := base.MakeFilepath(fs, d.dirname, fileTypeTable, fileBacking.FileNum)
 			destPath := fs.PathJoin(destDir, fs.PathBase(srcPath))
 			ckErr = vfs.LinkOrCopy(fs, srcPath, destPath)
 			if ckErr != nil {
@@ -279,7 +295,19 @@ func (d *DB) Checkpoint(
 		}
 	}
 
-	ckErr = d.writeCheckpointManifest(fs, formatVers, destDir, dir, manifestFileNum, manifestSize, excludedFiles)
+	var removeBackingTables []base.FileNum
+	for fileNum := range virtualBackingFiles {
+		if _, ok := requiredVirtualBackingFiles[fileNum]; !ok {
+			// The backing sstable associated with fileNum is no longer
+			// required.
+			removeBackingTables = append(removeBackingTables, fileNum)
+		}
+	}
+
+	ckErr = d.writeCheckpointManifest(
+		fs, formatVers, destDir, dir, manifestFileNum, manifestSize,
+		excludedFiles, removeBackingTables,
+	)
 	if ckErr != nil {
 		return ckErr
 	}
@@ -318,6 +346,7 @@ func (d *DB) writeCheckpointManifest(
 	manifestFileNum FileNum,
 	manifestSize int64,
 	excludedFiles map[deletedFileEntry]*fileMetadata,
+	removeBackingTables []base.FileNum,
 ) error {
 	// Copy the MANIFEST, and create a pointer to it. We copy rather
 	// than link because additional version edits added to the
@@ -349,8 +378,10 @@ func (d *DB) writeCheckpointManifest(
 		if len(excludedFiles) > 0 {
 			// Write out an additional VersionEdit that deletes the excluded SST files.
 			ve := versionEdit{
-				DeletedFiles: excludedFiles,
+				DeletedFiles:         excludedFiles,
+				RemovedBackingTables: removeBackingTables,
 			}
+
 			rw := record.NewWriter(dst)
 			w, err := rw.Next()
 			if err != nil {

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -66,6 +66,7 @@ func loadVersion(d *datadriven.TestData) (*version, *Options, [numLevels]int64, 
 					LargestSeqNum:  key.SeqNum(),
 					Size:           1,
 				}).ExtendPointKeyBounds(opts.Comparer.Compare, key, key)
+				m.InitPhysicalBacking()
 				if size >= 100 {
 					// If the requested size of the level is very large only add a single
 					// file in order to avoid massive blow-up in the number of files in
@@ -364,6 +365,7 @@ func TestCompactionPickerL0(t *testing.T) {
 		)
 		m.SmallestSeqNum = m.Smallest.SeqNum()
 		m.LargestSeqNum = m.Largest.SeqNum()
+		m.InitPhysicalBacking()
 		return m, nil
 	}
 
@@ -595,6 +597,7 @@ func TestCompactionPickerConcurrency(t *testing.T) {
 			base.ParseInternalKey(strings.TrimSpace(parts[0])),
 			base.ParseInternalKey(strings.TrimSpace(parts[1])),
 		)
+		m.InitPhysicalBacking()
 		for _, p := range fields[1:] {
 			if strings.HasPrefix(p, "size=") {
 				v, err := strconv.Atoi(strings.TrimPrefix(p, "size="))
@@ -812,6 +815,7 @@ func TestCompactionPickerPickReadTriggered(t *testing.T) {
 			base.ParseInternalKey(strings.TrimSpace(parts[0])),
 			base.ParseInternalKey(strings.TrimSpace(parts[1])),
 		)
+		m.InitPhysicalBacking()
 		for _, p := range fields[1:] {
 			if strings.HasPrefix(p, "size=") {
 				v, err := strconv.Atoi(strings.TrimPrefix(p, "size="))
@@ -984,6 +988,7 @@ func TestPickedCompactionSetupInputs(t *testing.T) {
 		)
 		m.SmallestSeqNum = m.Smallest.SeqNum()
 		m.LargestSeqNum = m.Largest.SeqNum()
+		m.InitPhysicalBacking()
 		return m
 	}
 
@@ -1120,6 +1125,7 @@ func TestPickedCompactionExpandInputs(t *testing.T) {
 			base.ParseInternalKey(parts[0]),
 			base.ParseInternalKey(parts[1]),
 		)
+		m.InitPhysicalBacking()
 		return m
 	}
 
@@ -1203,6 +1209,7 @@ func TestCompactionOutputFileSize(t *testing.T) {
 			base.ParseInternalKey(strings.TrimSpace(parts[0])),
 			base.ParseInternalKey(strings.TrimSpace(parts[1])),
 		)
+		m.InitPhysicalBacking()
 		for _, p := range fields[1:] {
 			if strings.HasPrefix(p, "size=") {
 				v, err := strconv.Atoi(strings.TrimPrefix(p, "size="))
@@ -1342,6 +1349,7 @@ func TestCompactionPickerCompensatedSize(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
 			f := &fileMetadata{Size: tc.size}
+			f.InitPhysicalBacking()
 			f.Stats.PointDeletionsBytesEstimate = tc.pointDelEstimateBytes
 			f.Stats.RangeDeletionsBytesEstimate = tc.rangeDelEstimateBytes
 			gotBytes := compensatedSize(f, tc.pointTombstoneWeight)

--- a/data_test.go
+++ b/data_test.go
@@ -909,6 +909,7 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 			InternalKey{UserKey: []byte(parts[0])},
 			InternalKey{UserKey: []byte(parts[1])},
 		)
+		m.InitPhysicalBacking()
 		return m, nil
 	}
 

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -439,14 +439,15 @@ func TestPebblev1Migration(t *testing.T) {
 				for _, l := range v.Levels {
 					iter := l.Iter()
 					for m := iter.First(); m != nil; m = iter.Next() {
-						err := d.tableCache.withReader(m, func(r *sstable.Reader) error {
-							f, err := r.TableFormat()
-							if err != nil {
-								return err
-							}
-							tally[f]++
-							return nil
-						})
+						err := d.tableCache.withReader(m,
+							func(r *sstable.Reader) error {
+								f, err := r.TableFormat()
+								if err != nil {
+									return err
+								}
+								tally[f]++
+								return nil
+							})
 						if err != nil {
 							return err.Error()
 						}

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -490,6 +490,7 @@ func TestGetIter(t *testing.T) {
 			meta := &fileMetadata{
 				FileNum: tt.fileNum,
 			}
+			meta.InitPhysicalBacking()
 			for i, datum := range tt.data {
 				s := strings.Split(datum, " ")
 				ikey := base.ParseInternalKey(s[0])

--- a/ingest.go
+++ b/ingest.go
@@ -7,7 +7,6 @@ package pebble
 import (
 	"context"
 	"sort"
-	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -82,6 +81,7 @@ func ingestLoad1(
 	meta.FileNum = fileNum
 	meta.Size = uint64(readable.Size())
 	meta.CreationTime = time.Now().Unix()
+	meta.InitPhysicalBacking()
 
 	// Avoid loading into the table cache for collecting stats if we
 	// don't need to. If there are no range deletions, we have all the
@@ -92,7 +92,7 @@ func ingestLoad1(
 	// disallowing removal of an open file. Under MemFS, if we don't populate
 	// meta.Stats here, the file will be loaded into the table cache for
 	// calculating stats before we can remove the original link.
-	maybeSetStatsFromProperties(meta, &r.Properties)
+	maybeSetStatsFromProperties(meta.PhysicalMeta(), &r.Properties)
 
 	{
 		iter, err := r.NewIter(nil /* lower */, nil /* upper */)
@@ -703,13 +703,13 @@ func (d *DB) newIngestedFlushableEntry(
 	// The flushable entry starts off with a single reader ref, so increment
 	// the FileMetadata.Refs.
 	for _, file := range f.files {
-		atomic.AddInt32(&file.Refs, 1)
+		file.Ref()
 	}
-	entry.unrefFiles = func() []*fileMetadata {
-		var obsolete []*fileMetadata
+	entry.unrefFiles = func() []*fileBacking {
+		var obsolete []*fileBacking
 		for _, file := range f.files {
-			if val := atomic.AddInt32(&file.Refs, -1); val == 0 {
-				obsolete = append(obsolete, file)
+			if file.Unref() == 0 {
+				obsolete = append(obsolete, file.FileMetadata.FileBacking)
 			}
 		}
 		return obsolete
@@ -1021,10 +1021,19 @@ func (d *DB) ingestApply(
 // maybeValidateSSTablesLocked adds the slice of newFileEntrys to the pending
 // queue of files to be validated, when the feature is enabled.
 // DB.mu must be locked when calling.
+//
+// TODO(bananabrick): Make sure that the ingestion step only passes in the
+// physical sstables for validation here.
 func (d *DB) maybeValidateSSTablesLocked(newFiles []newFileEntry) {
 	// Only add to the validation queue when the feature is enabled.
 	if !d.opts.Experimental.ValidateOnIngest {
 		return
+	}
+
+	for _, f := range newFiles {
+		if f.Meta.Virtual {
+			panic("pebble: invalid call to maybeValidateSSTablesLocked")
+		}
 	}
 
 	d.mu.tableValidation.pending = append(d.mu.tableValidation.pending, newFiles...)
@@ -1086,9 +1095,10 @@ func (d *DB) validateSSTables() {
 			}
 		}
 
-		err := d.tableCache.withReader(f.Meta, func(r *sstable.Reader) error {
-			return r.ValidateBlockChecksums()
-		})
+		err := d.tableCache.withReader(
+			f.Meta, func(r *sstable.Reader) error {
+				return r.ValidateBlockChecksums()
+			})
 		if err != nil {
 			// TODO(travers): Hook into the corruption reporting pipeline, once
 			// available. See pebble#1192.

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -199,6 +199,7 @@ func TestIngestLoadRand(t *testing.T) {
 			require.NoError(t, err)
 
 			expected[i].Size = meta.Size
+			expected[i].InitPhysicalBacking()
 		}()
 	}
 
@@ -264,6 +265,7 @@ func TestIngestSortAndVerify(t *testing.T) {
 						return fmt.Sprintf("range %v-%v is not valid", smallest, largest)
 					}
 					m := (&fileMetadata{}).ExtendPointKeyBounds(cmp, smallest, largest)
+					m.InitPhysicalBacking()
 					meta = append(meta, m)
 					paths = append(paths, strconv.Itoa(i))
 				}
@@ -305,6 +307,7 @@ func TestIngestLink(t *testing.T) {
 				paths[j] = fmt.Sprintf("external%d", j)
 				meta[j] = &fileMetadata{}
 				meta[j].FileNum = FileNum(j)
+				meta[j].InitPhysicalBacking()
 				f, err := opts.FS.Create(paths[j])
 				require.NoError(t, err)
 
@@ -609,6 +612,7 @@ func TestIngestMemtableOverlaps(t *testing.T) {
 					smallest, largest = largest, smallest
 				}
 				meta.ExtendPointKeyBounds(comparer.Compare, smallest, largest)
+				meta.InitPhysicalBacking()
 				return meta
 			}
 
@@ -736,6 +740,7 @@ func TestIngestTargetLevel(t *testing.T) {
 				InternalKey{UserKey: []byte(parts[1])},
 			)
 		}
+		m.InitPhysicalBacking()
 		return m
 	}
 
@@ -1608,6 +1613,7 @@ func TestIngest_UpdateSequenceNumber(t *testing.T) {
 					maybeUpdateUpperBound(wm.LargestRangeKey),
 				)
 			}
+			m.InitPhysicalBacking()
 			if err := m.Validate(cmp, base.DefaultFormatter); err != nil {
 				return err.Error()
 			}

--- a/internal/keyspan/level_iter_test.go
+++ b/internal/keyspan/level_iter_test.go
@@ -294,6 +294,7 @@ func TestLevelIterEquivalence(t *testing.T) {
 					HasPointKeys:     false,
 					HasRangeKeys:     true,
 				}
+				meta.InitPhysicalBacking()
 				meta.ExtendRangeKeyBounds(base.DefaultComparer.Compare, meta.SmallestRangeKey, meta.LargestRangeKey)
 				metas = append(metas, meta)
 			}
@@ -376,6 +377,7 @@ func TestLevelIter(t *testing.T) {
 						if len(pointKeys) != 0 {
 							meta.ExtendPointKeyBounds(base.DefaultComparer.Compare, pointKeys[0], pointKeys[len(pointKeys)-1])
 						}
+						meta.InitPhysicalBacking()
 						level = append(level, currentFile)
 						metas = append(metas, meta)
 						rangedels = append(rangedels, currentRangeDels)
@@ -403,6 +405,7 @@ func TestLevelIter(t *testing.T) {
 			meta := &manifest.FileMetadata{
 				FileNum: base.FileNum(len(level) + 1),
 			}
+			meta.InitPhysicalBacking()
 			level = append(level, currentFile)
 			rangedels = append(rangedels, currentRangeDels)
 			if len(currentFile) > 0 {

--- a/internal/manifest/btree_test.go
+++ b/internal/manifest/btree_test.go
@@ -22,6 +22,7 @@ func newItem(k InternalKey) *FileMetadata {
 	m := (&FileMetadata{}).ExtendPointKeyBounds(
 		base.DefaultComparer.Compare, k, k,
 	)
+	m.InitPhysicalBacking()
 	return m
 }
 
@@ -596,6 +597,7 @@ func TestRandomizedBTree(t *testing.T) {
 	var metadataAlloc [maxFileNum]FileMetadata
 	for i := 0; i < len(metadataAlloc); i++ {
 		metadataAlloc[i].FileNum = base.FileNum(i)
+		metadataAlloc[i].InitPhysicalBacking()
 	}
 
 	// Use a btree comparator that sorts by file number to make it easier to

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -229,7 +229,7 @@ func TestL0Sublevels(t *testing.T) {
 		}
 		m.FileNum = base.FileNum(fileNum)
 		m.Size = uint64(256)
-
+		m.InitPhysicalBacking()
 		if len(fields) > 1 {
 			for _, field := range fields[1:] {
 				parts := strings.Split(field, "=")
@@ -592,6 +592,7 @@ func TestAddL0FilesEquivalence(t *testing.T) {
 				base.MakeInternalKey(startKey, uint64(2*i+1), base.InternalKeyKindSet),
 				base.MakeRangeDeleteSentinelKey(endKey),
 			)
+			meta.InitPhysicalBacking()
 			fileMetas = append(fileMetas, meta)
 			filesToAdd = append(filesToAdd, meta)
 		}

--- a/internal/manifest/level_metadata_test.go
+++ b/internal/manifest/level_metadata_test.go
@@ -47,6 +47,7 @@ func TestLevelIterator(t *testing.T) {
 						)
 						m.SmallestSeqNum = m.Smallest.SeqNum()
 						m.LargestSeqNum = m.Largest.SeqNum()
+						m.InitPhysicalBacking()
 						files = append(files, m)
 					}
 				}

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -119,7 +119,33 @@ func (s CompactionState) String() string {
 	}
 }
 
-// FileMetadata holds the metadata for an on-disk table.
+// FileMetadata is maintained for leveled-ssts, i.e., they belong to a level of
+// some version. FileMetadata does not contain the actual level of the sst,
+// since such leveled-ssts can move across levels in different versions, while
+// sharing the same FileMetadata. There are two kinds of leveled-ssts, physical
+// and virtual. Underlying both leveled-ssts is a backing-sst, for which the
+// only state is FileBacking. A backing-sst is level-less. It is possible for a
+// backing-sst to be referred to by a physical sst in one version and by one or
+// more virtual ssts in one or more versions. A backing-sst becomes obsolete
+// and can be deleted once it is no longer required by any physical or virtual
+// sst in any version.
+//
+// We maintain some invariants:
+//
+//  1. Each physical and virtual sst will have a unique FileMetadata.FileNum,
+//     and there will be exactly one FileMetadata associated with the FileNum.
+//
+//  2. Within a version, a backing-sst is either only referred to by one
+//     physical sst or one or more virtual ssts.
+//
+//  3. Once a backing-sst is referred to by a virtual sst in the latest version,
+//     it cannot go back to being referred to by a physical sst in any future
+//     version.
+//
+// Once a physical sst is no longer needed by any version, we will no longer
+// maintain the file metadata associated with it. We will still maintain the
+// FileBacking associated with the physical sst if the backing sst is required
+// by any virtual ssts in any version.
 type FileMetadata struct {
 	// Atomic contains fields which are accessed atomically. Go allocations
 	// are guaranteed to be 64-bit aligned which we take advantage of by
@@ -138,24 +164,43 @@ type FileMetadata struct {
 		statsValid uint32
 	}
 
+	// FileBacking is the state which backs either a physical or virtual
+	// sstables.
+	FileBacking *FileBacking
+
 	// InitAllowedSeeks is the inital value of allowed seeks. This is used
 	// to re-set allowed seeks on a file once it hits 0.
 	InitAllowedSeeks int64
-
-	// Reference count for the file: incremented when a file is added to a
-	// version and decremented when the version is unreferenced. The file is
-	// obsolete when the reference count falls to zero.
-	Refs int32
 	// FileNum is the file number.
+	//
+	// INVARIANT: when !FileMetadata.Virtual, FileNum == FileBacking.FileNum.
+	//
+	// TODO(bananabrick): Consider creating separate types for
+	// FileMetadata.FileNum and FileBacking.FileNum. FileNum is used both as
+	// an indentifier for the FileMetadata in Pebble, and also as a handle to
+	// perform reads and writes. We should ensure through types that
+	// FileMetadata.FileNum isn't used to perform reads, and that
+	// FileBacking.FileNum isn't used as an identifier for the FileMetadata.
 	FileNum base.FileNum
-	// Size is the size of the file, in bytes.
+	// Size is the size of the file, in bytes. Size is an approximate value for
+	// virtual sstables.
+	//
+	// INVARIANT: when !FileMetadata.Virtual, Size == FileBacking.Size.
+	//
+	// TODO(bananabrick): Size is currently used in metrics, and for many key
+	// Pebble level heuristics. Make sure that the heuristics will still work
+	// appropriately with an approximate value of size.
 	Size uint64
 	// File creation time in seconds since the epoch (1970-01-01 00:00:00
 	// UTC). For ingested sstables, this corresponds to the time the file was
-	// ingested.
+	// ingested. For virtual sstables, this corresponds to the wall clock time
+	// when the FileMetadata for the virtual sstable was first created.
 	CreationTime int64
-	// Smallest and largest sequence numbers in the table, across both point and
-	// range keys.
+	// Lower and upper bounds for the smallest and largest sequence numbers in
+	// the table, across both point and range keys. For physical sstables, these
+	// values are tight bounds. For virtual sstables, there is no guarantee that
+	// there will be keys with SmallestSeqNum or LargestSeqNum within virtual
+	// sstable bounds.
 	SmallestSeqNum uint64
 	LargestSeqNum  uint64
 	// SmallestPointKey and LargestPointKey are the inclusive bounds for the
@@ -178,6 +223,13 @@ type FileMetadata struct {
 	Smallest InternalKey
 	Largest  InternalKey
 	// Stats describe table statistics. Protected by DB.mu.
+	//
+	// For virtual sstables, set stats upon virtual sstable creation as
+	// asynchronous computation of stats is not currently supported.
+	//
+	// TODO(bananabrick): To support manifest replay for virtual sstables, we
+	// probably need to compute virtual sstable stats asynchronously. Otherwise,
+	// we'd have to write virtual sstable stats to the version edit.
 	Stats TableStats
 
 	SubLevel         int
@@ -226,6 +278,171 @@ type FileMetadata struct {
 	// key type (point or range) corresponds to the smallest and largest overall
 	// table bounds.
 	boundTypeSmallest, boundTypeLargest boundType
+	// Virtual is true if the FileMetadata belongs to a virtual sstable.
+	Virtual bool
+}
+
+// PhysicalFileMeta is used by functions which want a guarantee that their input
+// belongs to a physical sst and not a virtual sst.
+//
+// NB: This type should only be constructed by calling
+// FileMetadata.PhysicalMeta.
+type PhysicalFileMeta struct {
+	*FileMetadata
+}
+
+// VirtualFileMeta is used by functions which want a guarantee that their input
+// belongs to a virtual sst and not a physical sst.
+//
+// NB: This type should only be constructed by calling FileMetadata.VirtualMeta.
+type VirtualFileMeta struct {
+	*FileMetadata
+}
+
+// PhysicalMeta should be the only source of creating the PhysicalFileMeta
+// wrapper type.
+func (m *FileMetadata) PhysicalMeta() PhysicalFileMeta {
+	if m.Virtual {
+		panic("pebble: file metadata does not belong to a physical sstable")
+	}
+	return PhysicalFileMeta{
+		m,
+	}
+}
+
+// VirtualMeta should be the only source of creating the VirtualFileMeta wrapper
+// type.
+func (m *FileMetadata) VirtualMeta() VirtualFileMeta {
+	if !m.Virtual {
+		panic("pebble: file metadata does not belong to a virtual sstable")
+	}
+	return VirtualFileMeta{
+		m,
+	}
+}
+
+// FileBacking either backs a single physical sstable, or one or more virtual
+// sstables.
+//
+// See the comment above the FileMetadata type for sstable terminology.
+type FileBacking struct {
+	Atomic struct {
+		// Reference count for the backing file on disk: incremented when a
+		// physical or virtual sstable which is backed by the FileBacking is
+		// added to a version and decremented when the version is unreferenced.
+		// We ref count in order to determine when it is safe to delete a
+		// backing sst file from disk. The backing file is obsolete when the
+		// reference count falls to zero.
+		refs atomic.Int32
+		// latestVersionRefs are the references to the FileBacking in the
+		// latest version. This reference can be through a single physical
+		// sstable in the latest version, or one or more virtual sstables in the
+		// latest version.
+		//
+		// INVARIANT: latestVersionRefs <= refs.
+		latestVersionRefs atomic.Int32
+		// VirtualizedSize is set iff the backing sst is only referred to by
+		// virtual ssts in the latest version. VirtualizedSize is the sum of the
+		// virtual sstable sizes of all of the virtual sstables in the latest
+		// version which are backed by the physical sstable. When a virtual
+		// sstable is removed from the latest version, we will decrement the
+		// VirtualizedSize. During compaction picking, we'll compensate a
+		// virtual sstable file size by
+		// (FileBacking.Size - FileBacking.VirtualizedSize) / latestVersionRefs.
+		// The intuition is that if FileBacking.Size - FileBacking.VirtualizedSize
+		// is high, then the space amplification due to virtual sstables is
+		// high, and we should pick the virtual sstable with a higher priority.
+		//
+		// TODO(bananabrick): Compensate the virtual sstable file size using
+		// the VirtualizedSize during compaction picking and test.
+		VirtualizedSize atomic.Uint64
+	}
+	FileNum base.FileNum
+	Size    uint64
+}
+
+// InitPhysicalBacking allocates and sets the FileBacking which is required by a
+// physical sstable FileMetadata.
+//
+// Ensure that the state required by FileBacking, such as the FileNum, is
+// already set on the FileMetadata before InitPhysicalBacking is called.
+// Calling InitPhysicalBacking only after the relevant state has been set in the
+// FileMetadata is not necessary in tests which don't rely on FileBacking.
+func (m *FileMetadata) InitPhysicalBacking() {
+	if m.Virtual {
+		panic("pebble: virtual sstables should use a pre-existing FileBacking")
+	}
+	if m.FileBacking == nil {
+		m.FileBacking = &FileBacking{Size: m.Size, FileNum: m.FileNum}
+	}
+}
+
+// ValidateVirtual should be called once the FileMetadata for a virtual sstable
+// is created to verify that the fields of the virtual sstable are sound.
+func (m *FileMetadata) ValidateVirtual(createdFrom *FileMetadata) {
+	if !m.Virtual {
+		panic("pebble: invalid virtual sstable")
+	}
+
+	if createdFrom.SmallestSeqNum != m.SmallestSeqNum {
+		panic("pebble: invalid smallest sequence number for virtual sstable")
+	}
+
+	if createdFrom.LargestSeqNum != m.LargestSeqNum {
+		panic("pebble: invalid largest sequence number for virtual sstable")
+	}
+
+	if createdFrom.FileBacking != nil && createdFrom.FileBacking != m.FileBacking {
+		panic("pebble: invalid physical sstable state for virtual sstable")
+	}
+}
+
+// Refs returns the refcount of backing sstable.
+func (m *FileMetadata) Refs() int32 {
+	return m.FileBacking.Atomic.refs.Load()
+}
+
+// Ref increments the ref count associated with the backing sstable.
+func (m *FileMetadata) Ref() {
+	m.FileBacking.Atomic.refs.Add(1)
+}
+
+// Unref decrements the ref count associated with the backing sstable.
+func (m *FileMetadata) Unref() int32 {
+	v := m.FileBacking.Atomic.refs.Add(-1)
+	if invariants.Enabled && v < 0 {
+		panic("pebble: invalid FileMetadata refcounting")
+	}
+	return v
+}
+
+// LatestRef increments the latest ref count associated with the backing
+// sstable.
+func (m *FileMetadata) LatestRef() {
+	m.FileBacking.Atomic.latestVersionRefs.Add(1)
+
+	if m.Virtual {
+		m.FileBacking.Atomic.VirtualizedSize.Add(m.Size)
+	}
+}
+
+// LatestUnref decrements the latest ref count associated with the backing
+// sstable.
+func (m *FileMetadata) LatestUnref() int32 {
+	if m.Virtual {
+		m.FileBacking.Atomic.VirtualizedSize.Add(-m.Size)
+	}
+
+	v := m.FileBacking.Atomic.latestVersionRefs.Add(-1)
+	if invariants.Enabled && v < 0 {
+		panic("pebble: invalid FileMetadata latest refcounting")
+	}
+	return v
+}
+
+// LatestRefs returns the latest ref count associated with the backing sstable.
+func (m *FileMetadata) LatestRefs() int32 {
+	return m.FileBacking.Atomic.latestVersionRefs.Load()
 }
 
 // SetCompactionState transitions this file's compaction state to the given
@@ -522,6 +739,7 @@ func ParseFileMetadataDebug(s string) (m FileMetadata, err error) {
 		m.SmallestPointKey, m.LargestPointKey = m.Smallest, m.Largest
 		m.HasPointKeys = true
 	}
+	m.InitPhysicalBacking()
 	return
 }
 
@@ -582,6 +800,11 @@ func (m *FileMetadata) Validate(cmp Compare, formatKey base.FormatKey) error {
 				m.SmallestRangeKey.Pretty(formatKey), m.LargestRangeKey.Pretty(formatKey),
 			)
 		}
+	}
+
+	// Ensure that FileMetadata.Init was called.
+	if m.FileBacking == nil {
+		return base.CorruptionErrorf("file metadata FileBacking not set")
 	}
 
 	return nil
@@ -820,7 +1043,7 @@ type Version struct {
 
 	// The callback to invoke when the last reference to a version is
 	// removed. Will be called with list.mu held.
-	Deleted func(obsolete []*FileMetadata)
+	Deleted func(obsolete []*FileBacking)
 
 	// Stats holds aggregated stats about the version maintained from
 	// version to version.
@@ -926,11 +1149,15 @@ func (v *Version) Ref() {
 // locked.
 func (v *Version) Unref() {
 	if atomic.AddInt32(&v.refs, -1) == 0 {
-		obsolete := v.unrefFiles()
 		l := v.list
 		l.mu.Lock()
 		l.Remove(v)
-		v.Deleted(obsolete)
+		obsolete := v.unrefFiles()
+		fileBacking := make([]*FileBacking, len(obsolete))
+		for i, f := range obsolete {
+			fileBacking[i] = f.FileBacking
+		}
+		v.Deleted(fileBacking)
 		l.mu.Unlock()
 	}
 }
@@ -942,7 +1169,12 @@ func (v *Version) Unref() {
 func (v *Version) UnrefLocked() {
 	if atomic.AddInt32(&v.refs, -1) == 0 {
 		v.list.Remove(v)
-		v.Deleted(v.unrefFiles())
+		obsolete := v.unrefFiles()
+		fileBacking := make([]*FileBacking, len(obsolete))
+		for i, f := range obsolete {
+			fileBacking[i] = f.FileBacking
+		}
+		v.Deleted(fileBacking)
 	}
 }
 

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -49,6 +49,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 		base.DecodeInternalKey([]byte("abc\x00\x01\x02\x03\x04\x05\x06\x07")),
 		base.DecodeInternalKey([]byte("xyz\x01\xff\xfe\xfd\xfc\xfb\xfa\xf9")),
 	)
+	m1.InitPhysicalBacking()
 
 	m2 := (&FileMetadata{
 		FileNum:             806,
@@ -62,6 +63,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 		base.DecodeInternalKey([]byte("A\x00\x01\x02\x03\x04\x05\x06\x07")),
 		base.DecodeInternalKey([]byte("Z\x01\xff\xfe\xfd\xfc\xfb\xfa\xf9")),
 	)
+	m2.InitPhysicalBacking()
 
 	m3 := (&FileMetadata{
 		FileNum:      807,
@@ -72,6 +74,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 		base.MakeInternalKey([]byte("aaa"), 0, base.InternalKeyKindRangeKeySet),
 		base.MakeExclusiveSentinelKey(base.InternalKeyKindRangeKeySet, []byte("zzz")),
 	)
+	m3.InitPhysicalBacking()
 
 	m4 := (&FileMetadata{
 		FileNum:        809,
@@ -88,6 +91,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 		base.MakeInternalKey([]byte("l"), 0, base.InternalKeyKindRangeKeySet),
 		base.MakeExclusiveSentinelKey(base.InternalKeyKindRangeKeySet, []byte("z")),
 	)
+	m4.InitPhysicalBacking()
 
 	testCases := []VersionEdit{
 		// An empty version edit.
@@ -148,6 +152,7 @@ func TestVersionEditDecode(t *testing.T) {
 		base.MakeInternalKey([]byte("bar"), 5, base.InternalKeyKindDelete),
 		base.MakeInternalKey([]byte("foo"), 4, base.InternalKeyKindSet),
 	)
+	m.InitPhysicalBacking()
 
 	testCases := []struct {
 		filename     string
@@ -312,6 +317,7 @@ func TestVersionEditApply(t *testing.T) {
 		if m.SmallestSeqNum > m.LargestSeqNum {
 			m.SmallestSeqNum, m.LargestSeqNum = m.LargestSeqNum, m.SmallestSeqNum
 		}
+		m.InitPhysicalBacking()
 		return m, nil
 	}
 
@@ -366,6 +372,7 @@ func TestVersionEditApply(t *testing.T) {
 								}
 								versionFiles[meta.FileNum] = &meta
 								v.Levels[level].tree.Insert(&meta)
+								meta.LatestRef()
 							} else {
 								ve.NewFiles =
 									append(ve.NewFiles, NewFileEntry{Level: level, Meta: &meta})

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -74,6 +74,7 @@ func TestIkeyRange(t *testing.T) {
 				m := (&FileMetadata{
 					FileNum: base.FileNum(i),
 				}).ExtendPointKeyBounds(cmp, ikey(s[0:1]), ikey(s[2:3]))
+				m.InitPhysicalBacking()
 				f = append(f, m)
 			}
 		}
@@ -128,6 +129,7 @@ func TestContains(t *testing.T) {
 			FileNum: fileNum,
 			Size:    size,
 		}).ExtendPointKeyBounds(cmp, smallest, largest)
+		m.InitPhysicalBacking()
 		return m
 	}
 	m00 := newFileMeta(
@@ -272,7 +274,7 @@ func TestContains(t *testing.T) {
 func TestVersionUnref(t *testing.T) {
 	list := &VersionList{}
 	list.Init(&sync.Mutex{})
-	v := &Version{Deleted: func([]*FileMetadata) {}}
+	v := &Version{Deleted: func([]*FileBacking) {}}
 	v.Ref()
 	list.PushBack(v)
 	v.Unref()

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -141,6 +141,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 				m := (&fileMetadata{
 					FileNum: fileNum,
 				}).ExtendPointKeyBounds(cmp, smallestKey, largestKey)
+				m.InitPhysicalBacking()
 				*li = append(*li, m)
 
 				i++

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -63,6 +63,7 @@ func TestLevelIter(t *testing.T) {
 					f.keys[0],
 					f.keys[len(f.keys)-1],
 				)
+				meta.InitPhysicalBacking()
 				metas = append(metas, meta)
 			}
 			files = manifest.NewLevelSliceKeySorted(base.DefaultComparer.Compare, metas)
@@ -277,6 +278,7 @@ func (lt *levelIterTest) runBuild(d *datadriven.TestData) string {
 	if meta.HasRangeKeys {
 		m.ExtendRangeKeyBounds(lt.cmp.Compare, meta.SmallestRangeKey, meta.LargestRangeKey)
 	}
+	m.InitPhysicalBacking()
 	lt.metas = append(lt.metas, m)
 
 	var buf bytes.Buffer
@@ -511,6 +513,7 @@ func buildLevelIterTables(
 		meta[i].FileNum = FileNum(i)
 		largest, _ := iter.Last()
 		meta[i].ExtendPointKeyBounds(opts.Comparer.Compare, (*smallest).Clone(), (*largest).Clone())
+		meta[i].InitPhysicalBacking()
 	}
 	slice := manifest.NewLevelSliceKeySorted(base.DefaultComparer.Compare, meta)
 	return readers, slice, keys, cleanup

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -190,6 +190,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 				m := (&fileMetadata{
 					FileNum: fileNum,
 				}).ExtendPointKeyBounds(cmp, smallestKey, largestKey)
+				m.InitPhysicalBacking()
 				files[level] = append(files[level], m)
 
 				i++
@@ -599,6 +600,7 @@ func buildLevelsForMergingIterSeqSeek(
 			meta[j].FileNum = FileNum(j)
 			largest, _ := iter.Last()
 			meta[j].ExtendPointKeyBounds(opts.Comparer.Compare, smallest.Clone(), largest.Clone())
+			meta[j].InitPhysicalBacking()
 		}
 		levelSlices[i] = manifest.NewLevelSliceSpecificOrder(meta)
 	}

--- a/open_test.go
+++ b/open_test.go
@@ -1224,10 +1224,12 @@ func TestCheckConsistency(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
-		return &manifest.FileMetadata{
+		m := &manifest.FileMetadata{
 			FileNum: base.FileNum(fileNum),
 			Size:    uint64(size),
-		}, nil
+		}
+		m.InitPhysicalBacking()
+		return m, nil
 	}
 
 	datadriven.RunTest(t, "testdata/version_check_consistency",

--- a/table_cache.go
+++ b/table_cache.go
@@ -145,8 +145,8 @@ func (c *tableCacheContainer) newRangeKeyIter(
 	return c.tableCache.getShard(file.FileNum).newRangeKeyIter(file, opts, &c.dbOpts)
 }
 
-func (c *tableCacheContainer) getTableProperties(file *fileMetadata) (*sstable.Properties, error) {
-	return c.tableCache.getShard(file.FileNum).getTableProperties(file, &c.dbOpts)
+func (c *tableCacheContainer) getTableProperties(file physicalMeta) (*sstable.Properties, error) {
+	return c.tableCache.getShard(file.FileNum).getTableProperties(file.FileMetadata, &c.dbOpts)
 }
 
 func (c *tableCacheContainer) evict(fileNum FileNum) {

--- a/table_stats.go
+++ b/table_stats.go
@@ -186,7 +186,10 @@ func (d *DB) loadNewFileStats(
 			continue
 		}
 
-		stats, newHints, err := d.loadTableStats(rs.current, nf.Level, nf.Meta)
+		stats, newHints, err := d.loadTableStats(
+			rs.current, nf.Level,
+			nf.Meta.PhysicalMeta(),
+		)
 		if err != nil {
 			d.opts.EventListener.BackgroundError(err)
 			continue
@@ -233,7 +236,9 @@ func (d *DB) scanReadStateTableStats(
 				return fill, hints, moreRemain
 			}
 
-			stats, newHints, err := d.loadTableStats(rs.current, l, f)
+			stats, newHints, err := d.loadTableStats(
+				rs.current, l, f.PhysicalMeta(),
+			)
 			if err != nil {
 				// Set `moreRemain` so we'll try again.
 				moreRemain = true
@@ -250,31 +255,38 @@ func (d *DB) scanReadStateTableStats(
 	return fill, hints, moreRemain
 }
 
+// loadTableStats currently only supports stats collection for physical
+// sstables.
+//
+// TODO(bananabrick): Support stats collection for virtual sstables.
 func (d *DB) loadTableStats(
-	v *version, level int, meta *fileMetadata,
+	v *version, level int, meta physicalMeta,
 ) (manifest.TableStats, []deleteCompactionHint, error) {
 	var stats manifest.TableStats
 	var compactionHints []deleteCompactionHint
-	err := d.tableCache.withReader(meta, func(r *sstable.Reader) (err error) {
-		stats.NumEntries = r.Properties.NumEntries
-		stats.NumDeletions = r.Properties.NumDeletions
-		if r.Properties.NumPointDeletions() > 0 {
-			if err = d.loadTablePointKeyStats(r, v, level, meta, &stats); err != nil {
-				return
+	err := d.tableCache.withReader(
+		meta.FileMetadata, func(r *sstable.Reader) (err error) {
+			stats.NumEntries = r.Properties.NumEntries
+			stats.NumDeletions = r.Properties.NumDeletions
+			if r.Properties.NumPointDeletions() > 0 {
+				if err = d.loadTablePointKeyStats(r, v, level, meta, &stats); err != nil {
+					return
+				}
 			}
-		}
-		if r.Properties.NumRangeDeletions > 0 || r.Properties.NumRangeKeyDels > 0 {
-			if compactionHints, err = d.loadTableRangeDelStats(r, v, level, meta, &stats); err != nil {
-				return
+			if r.Properties.NumRangeDeletions > 0 || r.Properties.NumRangeKeyDels > 0 {
+				if compactionHints, err = d.loadTableRangeDelStats(
+					r, v, level, meta, &stats,
+				); err != nil {
+					return
+				}
 			}
-		}
-		// TODO(travers): Once we have real-world data, consider collecting
-		// additional stats that may provide improved heuristics for compaction
-		// picking.
-		stats.NumRangeKeySets = r.Properties.NumRangeKeySets
-		stats.ValueBlocksSize = r.Properties.ValueBlocksSize
-		return
-	})
+			// TODO(travers): Once we have real-world data, consider collecting
+			// additional stats that may provide improved heuristics for compaction
+			// picking.
+			stats.NumRangeKeySets = r.Properties.NumRangeKeySets
+			stats.ValueBlocksSize = r.Properties.ValueBlocksSize
+			return
+		})
 	if err != nil {
 		return stats, nil, err
 	}
@@ -284,7 +296,7 @@ func (d *DB) loadTableStats(
 // loadTablePointKeyStats calculates the point key statistics for the given
 // table. The provided manifest.TableStats are updated.
 func (d *DB) loadTablePointKeyStats(
-	r *sstable.Reader, v *version, level int, meta *fileMetadata, stats *manifest.TableStats,
+	r *sstable.Reader, v *version, level int, meta physicalMeta, stats *manifest.TableStats,
 ) error {
 	// TODO(jackson): If the file has a wide keyspace, the average
 	// value size beneath the entire file might not be representative
@@ -304,9 +316,9 @@ func (d *DB) loadTablePointKeyStats(
 // loadTableRangeDelStats calculates the range deletion and range key deletion
 // statistics for the given table.
 func (d *DB) loadTableRangeDelStats(
-	r *sstable.Reader, v *version, level int, meta *fileMetadata, stats *manifest.TableStats,
+	r *sstable.Reader, v *version, level int, meta physicalMeta, stats *manifest.TableStats,
 ) ([]deleteCompactionHint, error) {
-	iter, err := newCombinedDeletionKeyspanIter(d.opts.Comparer, r, meta)
+	iter, err := newCombinedDeletionKeyspanIter(d.opts.Comparer, r, meta.FileMetadata)
 	if err != nil {
 		return nil, err
 	}
@@ -370,7 +382,7 @@ func (d *DB) loadTableRangeDelStats(
 			hintType:                hintType,
 			start:                   make([]byte, len(start)),
 			end:                     make([]byte, len(end)),
-			tombstoneFile:           meta,
+			tombstoneFile:           meta.FileMetadata,
 			tombstoneLevel:          level,
 			tombstoneLargestSeqNum:  s.LargestSeqNum(),
 			tombstoneSmallestSeqNum: s.SmallestSeqNum(),
@@ -384,7 +396,7 @@ func (d *DB) loadTableRangeDelStats(
 }
 
 func (d *DB) averageEntrySizeBeneath(
-	v *version, level int, meta *fileMetadata,
+	v *version, level int, meta physicalMeta,
 ) (avgKeySize, avgValueSize uint64, err error) {
 	// Find all files in lower levels that overlap with meta,
 	// summing their value sizes and entry counts.
@@ -394,13 +406,23 @@ func (d *DB) averageEntrySizeBeneath(
 			meta.Largest.UserKey, meta.Largest.IsExclusiveSentinel())
 		iter := overlaps.Iter()
 		for file := iter.First(); file != nil; file = iter.Next() {
-			err := d.tableCache.withReader(file, func(r *sstable.Reader) (err error) {
-				fileSum += file.Size
-				entryCount += r.Properties.NumEntries
-				keySum += r.Properties.RawKeySize
-				valSum += r.Properties.RawValueSize
-				return nil
-			})
+			var err error
+			if file.Virtual {
+				// TODO(bananabrick): Once we have Properties for the virtual
+				// sstables, use those here.
+				panic("pebble: not implemented")
+			} else {
+				err = d.tableCache.withReader(
+					file,
+					func(r *sstable.Reader) (err error) {
+						fileSum += file.Size
+						entryCount += r.Properties.NumEntries
+						keySum += r.Properties.RawKeySize
+						valSum += r.Properties.RawValueSize
+						return nil
+					})
+			}
+
 			if err != nil {
 				return 0, 0, err
 			}
@@ -446,6 +468,11 @@ func (d *DB) estimateReclaimedSizeBeneath(
 		overlaps := v.Overlaps(l, d.cmp, start, end, true /* exclusiveEnd */)
 		iter := overlaps.Iter()
 		for file := iter.First(); file != nil; file = iter.Next() {
+			if file.Virtual {
+				// TODO(bananabrick): Remove this check once
+				// Reader.EstimatedDiskUsage works for virtual sstables.
+				panic("pebble: unimplemented")
+			}
 			startCmp := d.cmp(start, file.Smallest.UserKey)
 			endCmp := d.cmp(file.Largest.UserKey, end)
 			if startCmp <= 0 && (endCmp < 0 || endCmp == 0 && file.Largest.IsExclusiveSentinel()) {
@@ -502,10 +529,11 @@ func (d *DB) estimateReclaimedSizeBeneath(
 					continue
 				}
 				var size uint64
-				err := d.tableCache.withReader(file, func(r *sstable.Reader) (err error) {
-					size, err = r.EstimateDiskUsage(start, end)
-					return err
-				})
+				err := d.tableCache.withReader(
+					file, func(r *sstable.Reader) (err error) {
+						size, err = r.EstimateDiskUsage(start, end)
+						return err
+					})
 				if err != nil {
 					return 0, hintSeqNum, err
 				}
@@ -516,7 +544,7 @@ func (d *DB) estimateReclaimedSizeBeneath(
 	return estimate, hintSeqNum, nil
 }
 
-func maybeSetStatsFromProperties(meta *fileMetadata, props *sstable.Properties) bool {
+func maybeSetStatsFromProperties(meta physicalMeta, props *sstable.Properties) bool {
 	// If a table contains range deletions or range key deletions, we defer the
 	// stats collection. There are two main reasons for this:
 	//
@@ -730,7 +758,8 @@ func newCombinedDeletionKeyspanIter(
 		// Truncate tombstones to the containing file's bounds if necessary.
 		// See docs/range_deletions.md for why this is necessary.
 		iter = keyspan.Truncate(
-			comparer.Compare, iter, m.Smallest.UserKey, m.Largest.UserKey, nil, nil,
+			comparer.Compare, iter, m.Smallest.UserKey, m.Largest.UserKey,
+			nil, nil,
 		)
 		mIter.AddLevel(iter)
 	}

--- a/tool/find.go
+++ b/tool/find.go
@@ -28,6 +28,14 @@ type findRef struct {
 }
 
 // findT implements the find tool.
+//
+// TODO(bananabrick): Add support for virtual sstables in this tool. Currently,
+// the tool will work because we're parsing files from disk, so virtual sstables
+// will never be added to findT.tables. The manifest could contain information
+// about virtual sstables. This is fine because the manifest is only used to
+// compute the findT.editRefs, and editRefs is only used if a file in
+// findT.tables contains a key. Of course, the tool won't be completely
+// accurate without dealing with virtual sstable case.
 type findT struct {
 	Root *cobra.Command
 

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -234,7 +234,11 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 			}
 
 			if cmp != nil {
-				v, err := bve.Apply(nil /* version */, cmp.Compare, m.fmtKey.fn, 0, m.opts.Experimental.ReadCompactionRate, nil /* zombies */)
+				v, err := bve.Apply(
+					nil /* version */, cmp.Compare, m.fmtKey.fn, 0,
+					m.opts.Experimental.ReadCompactionRate,
+					nil, /* zombies */
+				)
 				if err != nil {
 					fmt.Fprintf(stdout, "%s\n", err)
 					return

--- a/version_set.go
+++ b/version_set.go
@@ -30,6 +30,8 @@ const manifestMarkerName = `manifest`
 type bulkVersionEdit = manifest.BulkVersionEdit
 type deletedFileEntry = manifest.DeletedFileEntry
 type fileMetadata = manifest.FileMetadata
+type physicalMeta = manifest.PhysicalFileMeta
+type fileBacking = manifest.FileBacking
 type newFileEntry = manifest.NewFileEntry
 type version = manifest.Version
 type versionEdit = manifest.VersionEdit
@@ -83,14 +85,26 @@ type versionSet struct {
 
 	// A pointer to versionSet.addObsoleteLocked. Avoids allocating a new closure
 	// on the creation of every version.
-	obsoleteFn        func(obsolete []*manifest.FileMetadata)
-	obsoleteTables    []*manifest.FileMetadata
+	obsoleteFn        func(obsolete []*fileBacking)
+	obsoleteTables    []fileInfo
 	obsoleteManifests []fileInfo
 	obsoleteOptions   []fileInfo
 
 	// Zombie tables which have been removed from the current version but are
 	// still referenced by an inuse iterator.
 	zombieTables map[FileNum]uint64 // filenum -> size
+
+	// fileBackingMap is a map for the FileBacking which is supporting virtual
+	// sstables in the latest version. Once the file backing is backing no
+	// virtual sstables in the latest version, it is removed from this map and
+	// the corresponding state is added to the zombieTables map. Note that we
+	// don't keep track of file backing which supports a virtual sstable
+	// which is not in the latest version.
+	//
+	// fileBackingMap is protected by the versionSet.logLock. It's populated
+	// during Open in versionSet.load, but it's not used concurrently during
+	// load.
+	fileBackingMap map[FileNum]*fileBacking
 
 	// minUnflushedLogNum is the smallest WAL log file number corresponding to
 	// mutations that have not been flushed to an sstable.
@@ -132,6 +146,7 @@ func (vs *versionSet) init(
 	vs.versions.Init(mu)
 	vs.obsoleteFn = vs.addObsoleteLocked
 	vs.zombieTables = make(map[FileNum]uint64)
+	vs.fileBackingMap = make(map[FileNum]*fileBacking)
 	vs.nextFileNum = 1
 	vs.manifestMarker = marker
 	vs.setCurrent = setCurrent
@@ -276,6 +291,16 @@ func (vs *versionSet) load(
 		}
 	}
 	vs.markFileNumUsed(vs.minUnflushedLogNum)
+
+	// Populate the fileBackingMap since we have finished version
+	// edit accumulation.
+	for _, s := range bve.AddedFileBacking {
+		vs.fileBackingMap[s.FileNum] = s
+	}
+
+	for _, fileNum := range bve.RemovedFileBacking {
+		delete(vs.fileBackingMap, fileNum)
+	}
 
 	newVersion, err := bve.Apply(
 		nil, vs.cmp, opts.Comparer.FormatKey, opts.FlushSplitBytes,
@@ -464,9 +489,10 @@ func (vs *versionSet) logAndApply(
 		defer vs.mu.Lock()
 
 		var err error
-		newVersion, zombies, err = manifest.AccumulateAndApplySingleVE(
+		newVersion, zombies, err = manifest.AccumulateIncompleteAndApplySingleVE(
 			ve, currentVersion, vs.cmp, vs.opts.Comparer.FormatKey,
 			vs.opts.FlushSplitBytes, vs.opts.Experimental.ReadCompactionRate,
+			vs.fileBackingMap,
 		)
 		if err != nil {
 			return errors.Wrap(err, "MANIFEST apply failed")
@@ -488,6 +514,7 @@ func (vs *versionSet) logAndApply(
 		if err != nil {
 			return errors.Wrap(err, "MANIFEST next record write failed")
 		}
+
 		// NB: Any error from this point on is considered fatal as we don't now if
 		// the MANIFEST write occurred or not. Trying to determine that is
 		// fraught. Instead we rely on the standard recovery mechanism run when a
@@ -652,6 +679,7 @@ func (vs *versionSet) createManifest(
 	snapshot := versionEdit{
 		ComparerName: vs.cmpName,
 	}
+	dedup := make(map[base.FileNum]struct{})
 	for level, levelMetadata := range vs.currentVersion().Levels {
 		iter := levelMetadata.Iter()
 		for meta := iter.First(); meta != nil; meta = iter.Next() {
@@ -659,6 +687,14 @@ func (vs *versionSet) createManifest(
 				Level: level,
 				Meta:  meta,
 			})
+			// TODO(bananabrick): Test snapshot changes.
+			if _, ok := dedup[meta.FileBacking.FileNum]; meta.Virtual && !ok {
+				dedup[meta.FileBacking.FileNum] = struct{}{}
+				snapshot.CreatedBackingTables = append(
+					snapshot.CreatedBackingTables,
+					meta.FileBacking,
+				)
+			}
 		}
 	}
 
@@ -729,7 +765,7 @@ func (vs *versionSet) addLiveFileNums(m map[FileNum]struct{}) {
 		for _, lm := range v.Levels {
 			iter := lm.Iter()
 			for f := iter.First(); f != nil; f = iter.Next() {
-				m[f.FileNum] = struct{}{}
+				m[f.FileBacking.FileNum] = struct{}{}
 			}
 		}
 		if v == current {
@@ -738,27 +774,49 @@ func (vs *versionSet) addLiveFileNums(m map[FileNum]struct{}) {
 	}
 }
 
+// addObsoleteLocked will add the fileInfo associated with obsolete backing
+// sstables to the obsolete tables list.
+//
+// The file backings in the obsolete list must not appear more than once.
+//
 // DB.mu must be held when addObsoleteLocked is called.
-func (vs *versionSet) addObsoleteLocked(obsolete []*manifest.FileMetadata) {
+func (vs *versionSet) addObsoleteLocked(obsolete []*fileBacking) {
 	if len(obsolete) == 0 {
 		return
 	}
 
-	for _, fileMeta := range obsolete {
+	obsoleteFileInfo := make([]fileInfo, len(obsolete))
+	for i, bs := range obsolete {
+		obsoleteFileInfo[i].fileNum = bs.FileNum
+		obsoleteFileInfo[i].fileSize = bs.Size
+	}
+
+	if invariants.Enabled {
+		dedup := make(map[base.FileNum]struct{})
+		for _, fi := range obsoleteFileInfo {
+			dedup[fi.fileNum] = struct{}{}
+		}
+		if len(dedup) != len(obsoleteFileInfo) {
+			panic("pebble: duplicate FileBacking present in obsolete list")
+		}
+	}
+
+	for _, fi := range obsoleteFileInfo {
 		// Note that the obsolete tables are no longer zombie by the definition of
 		// zombie, but we leave them in the zombie tables map until they are
 		// deleted from disk.
-		if _, ok := vs.zombieTables[fileMeta.FileNum]; !ok {
-			vs.opts.Logger.Fatalf("MANIFEST obsolete table %s not marked as zombie", fileMeta.FileNum)
+		if _, ok := vs.zombieTables[fi.fileNum]; !ok {
+			vs.opts.Logger.Fatalf("MANIFEST obsolete table %s not marked as zombie", fi.fileNum)
 		}
 	}
-	vs.obsoleteTables = append(vs.obsoleteTables, obsolete...)
+
+	vs.obsoleteTables = append(vs.obsoleteTables, obsoleteFileInfo...)
 	vs.updateObsoleteTableMetricsLocked()
 }
 
 // addObsolete will acquire DB.mu, so DB.mu must not be held when this is
 // called.
-func (vs *versionSet) addObsolete(obsolete []*manifest.FileMetadata) {
+func (vs *versionSet) addObsolete(obsolete []*fileBacking) {
 	vs.mu.Lock()
 	defer vs.mu.Unlock()
 	vs.addObsoleteLocked(obsolete)
@@ -767,8 +825,8 @@ func (vs *versionSet) addObsolete(obsolete []*manifest.FileMetadata) {
 func (vs *versionSet) updateObsoleteTableMetricsLocked() {
 	vs.metrics.Table.ObsoleteCount = int64(len(vs.obsoleteTables))
 	vs.metrics.Table.ObsoleteSize = 0
-	for _, fileMeta := range vs.obsoleteTables {
-		vs.metrics.Table.ObsoleteSize += fileMeta.Size
+	for _, fi := range vs.obsoleteTables {
+		vs.metrics.Table.ObsoleteSize += fi.fileSize
 	}
 }
 

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -7,8 +7,10 @@ package pebble
 import (
 	"io"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/sstable"
@@ -24,6 +26,188 @@ func writeAndIngest(t *testing.T, mem vfs.FS, d *DB, k InternalKey, v []byte, fi
 	require.NoError(t, w.Add(k, v))
 	require.NoError(t, w.Close())
 	require.NoError(t, d.Ingest([]string{path}))
+}
+
+// TestLatestRefCounting sanity checks the ref counting implementation for
+// FileMetadata.latestRefs, and makes sure that the zombie table implementation
+// works when the version edit contains virtual sstables. It also checks that
+// we're adding the physical sstable to the obsolete tables list iff the file is
+// truly obsolete.
+func TestLatestRefCounting(t *testing.T) {
+	mem := vfs.NewMem()
+	require.NoError(t, mem.MkdirAll("ext", 0755))
+
+	opts := &Options{
+		FS:                          mem,
+		MaxManifestFileSize:         1,
+		DisableAutomaticCompactions: true,
+	}
+	d, err := Open("", opts)
+	require.NoError(t, err)
+
+	err = d.Set([]byte{'a'}, []byte{'a'}, nil)
+	require.NoError(t, err)
+	err = d.Set([]byte{'b'}, []byte{'b'}, nil)
+	require.NoError(t, err)
+
+	err = d.Flush()
+	require.NoError(t, err)
+
+	iter := d.mu.versions.currentVersion().Levels[0].Iter()
+	var f *fileMetadata = iter.First()
+	require.NotNil(t, f)
+	require.Equal(t, 1, int(f.LatestRefs()))
+	require.Equal(t, 0, len(d.mu.versions.obsoleteTables))
+
+	// Grab some new file nums.
+	d.mu.Lock()
+	f1 := d.mu.versions.nextFileNum
+	f2 := f1 + 1
+	d.mu.versions.nextFileNum += 2
+	d.mu.Unlock()
+
+	m1 := &manifest.FileMetadata{
+		FileBacking:    f.FileBacking,
+		FileNum:        f1,
+		CreationTime:   time.Now().Unix(),
+		Size:           f.Size / 2,
+		SmallestSeqNum: f.SmallestSeqNum,
+		LargestSeqNum:  f.LargestSeqNum,
+		Smallest:       base.MakeInternalKey([]byte{'a'}, f.Smallest.SeqNum(), InternalKeyKindSet),
+		Largest:        base.MakeInternalKey([]byte{'a'}, f.Smallest.SeqNum(), InternalKeyKindSet),
+		HasPointKeys:   true,
+		Virtual:        true,
+	}
+
+	m2 := &manifest.FileMetadata{
+		FileBacking:    f.FileBacking,
+		FileNum:        f2,
+		CreationTime:   time.Now().Unix(),
+		Size:           f.Size / 2,
+		SmallestSeqNum: f.SmallestSeqNum,
+		LargestSeqNum:  f.LargestSeqNum,
+		Smallest:       base.MakeInternalKey([]byte{'b'}, f.Largest.SeqNum(), InternalKeyKindSet),
+		Largest:        base.MakeInternalKey([]byte{'b'}, f.Largest.SeqNum(), InternalKeyKindSet),
+		HasPointKeys:   true,
+		Virtual:        true,
+	}
+
+	m1.LargestPointKey = m1.Largest
+	m1.SmallestPointKey = m1.Smallest
+
+	m2.LargestPointKey = m2.Largest
+	m2.SmallestPointKey = m2.Smallest
+
+	m1.ValidateVirtual(f)
+	m2.ValidateVirtual(f)
+
+	fileMetrics := func(ve *versionEdit) map[int]*LevelMetrics {
+		metrics := newFileMetrics(ve.NewFiles)
+		for de, f := range ve.DeletedFiles {
+			lm := metrics[de.Level]
+			if lm == nil {
+				lm = &LevelMetrics{}
+				metrics[de.Level] = lm
+			}
+			metrics[de.Level].NumFiles--
+			metrics[de.Level].Size -= int64(f.Size)
+		}
+		return metrics
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	applyVE := func(ve *versionEdit) error {
+		d.mu.versions.logLock()
+		jobID := d.mu.nextJobID
+		d.mu.nextJobID++
+
+		err := d.mu.versions.logAndApply(jobID, ve, fileMetrics(ve), false, func() []compactionInfo {
+			return d.getInProgressCompactionInfoLocked(nil)
+		})
+		d.updateReadStateLocked(nil)
+		return err
+	}
+
+	// Virtualize f.
+	ve := manifest.VersionEdit{}
+	d1 := manifest.DeletedFileEntry{Level: 0, FileNum: f.FileNum}
+	n1 := manifest.NewFileEntry{Level: 0, Meta: m1}
+	n2 := manifest.NewFileEntry{Level: 0, Meta: m2}
+
+	ve.DeletedFiles = make(map[manifest.DeletedFileEntry]*manifest.FileMetadata)
+	ve.DeletedFiles[d1] = f
+	ve.NewFiles = append(ve.NewFiles, n1)
+	ve.NewFiles = append(ve.NewFiles, n2)
+	ve.CreatedBackingTables = append(ve.CreatedBackingTables, f.FileBacking)
+
+	require.NoError(t, applyVE(&ve))
+	// 2 latestRefs from 2 virtual sstables in the latest version which refer
+	// to the physical sstable.
+	require.Equal(t, 2, int(m1.LatestRefs()))
+	require.Equal(t, 0, len(d.mu.versions.obsoleteTables))
+	require.Equal(t, 1, len(d.mu.versions.fileBackingMap))
+	_, ok := d.mu.versions.fileBackingMap[f.FileNum]
+	require.True(t, ok)
+	require.Equal(t, f.Size, m2.FileBacking.Atomic.VirtualizedSize.Load())
+
+	// Make sure that f is not present in zombie list, because it is not yet a
+	// zombie.
+	require.Equal(t, 0, len(d.mu.versions.zombieTables))
+
+	// Delete the virtual sstable m1.
+	ve = manifest.VersionEdit{}
+	d1 = manifest.DeletedFileEntry{Level: 0, FileNum: m1.FileNum}
+	ve.DeletedFiles = make(map[manifest.DeletedFileEntry]*manifest.FileMetadata)
+	ve.DeletedFiles[d1] = m1
+	require.NoError(t, applyVE(&ve))
+
+	// Only one virtual sstable in the latest version, confirm that the latest
+	// version ref counting is correct.
+	require.Equal(t, 1, int(m2.LatestRefs()))
+	require.Equal(t, 0, len(d.mu.versions.zombieTables))
+	require.Equal(t, 0, len(d.mu.versions.obsoleteTables))
+	require.Equal(t, 1, len(d.mu.versions.fileBackingMap))
+	_, ok = d.mu.versions.fileBackingMap[f.FileNum]
+	require.True(t, ok)
+	require.Equal(t, m2.Size, m2.FileBacking.Atomic.VirtualizedSize.Load())
+
+	// Move m2 from L0 to L6 to test the move compaction case.
+	ve = manifest.VersionEdit{}
+	d1 = manifest.DeletedFileEntry{Level: 0, FileNum: m2.FileNum}
+	n1 = manifest.NewFileEntry{Level: 6, Meta: m2}
+	ve.DeletedFiles = make(map[manifest.DeletedFileEntry]*manifest.FileMetadata)
+	ve.DeletedFiles[d1] = m2
+	ve.NewFiles = append(ve.NewFiles, n1)
+	require.NoError(t, applyVE(&ve))
+
+	require.Equal(t, 1, int(m2.LatestRefs()))
+	require.Equal(t, 0, len(d.mu.versions.zombieTables))
+	require.Equal(t, 0, len(d.mu.versions.obsoleteTables))
+	require.Equal(t, 1, len(d.mu.versions.fileBackingMap))
+	_, ok = d.mu.versions.fileBackingMap[f.FileNum]
+	require.True(t, ok)
+	require.Equal(t, m2.Size, m2.FileBacking.Atomic.VirtualizedSize.Load())
+
+	// Delete m2 from L6.
+	ve = manifest.VersionEdit{}
+	d1 = manifest.DeletedFileEntry{Level: 6, FileNum: m2.FileNum}
+	ve.DeletedFiles = make(map[manifest.DeletedFileEntry]*manifest.FileMetadata)
+	ve.DeletedFiles[d1] = m2
+	require.NoError(t, applyVE(&ve))
+
+	// All virtual sstables are gone.
+	require.Equal(t, 0, int(m2.LatestRefs()))
+	require.Equal(t, 1, len(d.mu.versions.zombieTables))
+	require.Equal(t, f.Size, d.mu.versions.zombieTables[f.FileNum])
+	require.Equal(t, 0, len(d.mu.versions.fileBackingMap))
+	_, ok = d.mu.versions.fileBackingMap[f.FileNum]
+	require.False(t, ok)
+	require.Equal(t, 0, int(m2.FileBacking.Atomic.VirtualizedSize.Load()))
+
+	// Make sure that the backing file is added to the obsolete tables list.
+	require.Equal(t, 1, len(d.mu.versions.obsoleteTables))
+
 }
 
 func TestVersionSetCheckpoint(t *testing.T) {


### PR DESCRIPTION
This pr introduces the FileMetadata changes which will be required to make further virtual sstable changes.

This pr doesn't deal with persisting of the FileMetadata to disk through the version edits.

RFC: https://github.com/cockroachdb/pebble/blob/master/docs/RFCS/20221122_virtual_sstable.md