### PR TITLE
db: add Options.LoggerAndTracer for tracing

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -5,6 +5,7 @@
 package pebble
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -898,10 +899,16 @@ func (b *Batch) SetRepr(data []byte) error {
 // later mutations. Its view can be refreshed via RefreshBatchSnapshot or
 // SetOptions().
 func (b *Batch) NewIter(o *IterOptions) *Iterator {
+	return b.NewIterWithContext(context.Background(), o)
+}
+
+// NewIterWithContext is like NewIter, and additionally accepts a context for
+// tracing.
+func (b *Batch) NewIterWithContext(ctx context.Context, o *IterOptions) *Iterator {
 	if b.index == nil {
 		return &Iterator{err: ErrNotIndexed}
 	}
-	return b.db.newIter(b, nil /* snapshot */, o)
+	return b.db.newIter(ctx, b, nil /* snapshot */, o)
 }
 
 // newInternalIter creates a new internalIterator that iterates over the

--- a/compaction.go
+++ b/compaction.go
@@ -1317,8 +1317,8 @@ func (c *compaction) newInputIter(
 	newRangeDelIter := func(
 		f manifest.LevelFile, _ *IterOptions, bytesIterated *uint64,
 	) (keyspan.FragmentIterator, error) {
-		iter, rangeDelIter, err := newIters(f.FileMetadata, nil, /* iter options */
-			internalIterOpts{bytesIterated: &c.bytesIterated})
+		iter, rangeDelIter, err := newIters(context.Background(), f.FileMetadata,
+			nil /* iter options */, internalIterOpts{bytesIterated: &c.bytesIterated})
 		if err == nil {
 			// TODO(peter): It is mildly wasteful to open the point iterator only to
 			// immediately close it. One way to solve this would be to add new

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -6,6 +6,7 @@ package pebble
 
 import (
 	"bytes"
+	"context"
 	crand "crypto/rand"
 	"fmt"
 	"math"
@@ -3061,7 +3062,7 @@ func TestCompactionCheckOrdering(t *testing.T) {
 				}
 
 				newIters := func(
-					_ *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts,
+					_ context.Context, _ *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts,
 				) (internalIterator, keyspan.FragmentIterator, error) {
 					return &errorIter{}, nil, nil
 				}

--- a/data_test.go
+++ b/data_test.go
@@ -202,6 +202,8 @@ func runIterCmd(d *datadriven.TestData, iter *Iterator, closeIter bool) string {
 			valid = iter.Valid()
 		case "stats":
 			stats := iter.Stats()
+			// The timing is non-deterministic, so set to 0.
+			stats.InternalStats.BlockReadDuration = 0
 			fmt.Fprintf(&b, "stats: %s\n", stats.String())
 			continue
 		case "clone":
@@ -491,6 +493,8 @@ func runInternalIterCmd(
 			continue
 		case "stats":
 			if o.stats != nil {
+				// The timing is non-deterministic, so set to 0.
+				o.stats.BlockReadDuration = 0
 				fmt.Fprintf(&b, "%+v\n", *o.stats)
 			}
 			continue

--- a/db_test.go
+++ b/db_test.go
@@ -6,6 +6,7 @@ package pebble
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -19,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -1286,6 +1288,90 @@ func TestSSTables(t *testing.T) {
 			require.NotNil(t, info.Properties)
 		}
 	}
+}
+
+type testTracer struct {
+	enabledOnlyForNonBackgroundContext bool
+	buf                                strings.Builder
+}
+
+func (t *testTracer) Infof(format string, args ...interface{})  {}
+func (t *testTracer) Fatalf(format string, args ...interface{}) {}
+
+func (t *testTracer) Eventf(ctx context.Context, format string, args ...interface{}) {
+	if t.enabledOnlyForNonBackgroundContext && ctx == context.Background() {
+		return
+	}
+	fmt.Fprintf(&t.buf, format, args...)
+	fmt.Fprint(&t.buf, "\n")
+}
+
+func (t *testTracer) IsTracingEnabled(ctx context.Context) bool {
+	if t.enabledOnlyForNonBackgroundContext && ctx == context.Background() {
+		return false
+	}
+	return true
+}
+
+func TestTracing(t *testing.T) {
+	if !invariants.Enabled {
+		// The test relies on timing behavior injected when invariants.Enabled.
+		return
+	}
+	var tracer testTracer
+	c := NewCache(0)
+	defer c.Unref()
+	d, err := Open("", &Options{
+		FS:              vfs.NewMem(),
+		Cache:           c,
+		LoggerAndTracer: &tracer,
+	})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, d.Close())
+	}()
+
+	// Create a sstable.
+	require.NoError(t, d.Set([]byte("hello"), nil, nil))
+	require.NoError(t, d.Flush())
+	_, closer, err := d.Get([]byte("hello"))
+	require.NoError(t, err)
+	closer.Close()
+	readerInitTraceString := "reading 37 bytes took 5ms\nreading 628 bytes took 5ms\n"
+	iterTraceString := "reading 27 bytes took 5ms\nreading 29 bytes took 5ms\n"
+	require.Equal(t, readerInitTraceString+iterTraceString, tracer.buf.String())
+
+	// Get again, but since it currently uses context.Background(), no trace
+	// output is produced.
+	tracer.buf.Reset()
+	tracer.enabledOnlyForNonBackgroundContext = true
+	_, closer, err = d.Get([]byte("hello"))
+	require.NoError(t, err)
+	closer.Close()
+	require.Equal(t, "", tracer.buf.String())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	iter := d.NewIterWithContext(ctx, nil)
+	iter.SeekGE([]byte("hello"))
+	iter.Close()
+	require.Equal(t, iterTraceString, tracer.buf.String())
+
+	tracer.buf.Reset()
+	snap := d.NewSnapshot()
+	iter = snap.NewIterWithContext(ctx, nil)
+	iter.SeekGE([]byte("hello"))
+	iter.Close()
+	require.Equal(t, iterTraceString, tracer.buf.String())
+	snap.Close()
+
+	tracer.buf.Reset()
+	b := d.NewIndexedBatch()
+	iter = b.NewIterWithContext(ctx, nil)
+	iter.SeekGE([]byte("hello"))
+	iter.Close()
+	require.Equal(t, iterTraceString, tracer.buf.String())
+	b.Close()
 }
 
 func BenchmarkDelete(b *testing.B) {

--- a/flushable.go
+++ b/flushable.go
@@ -5,6 +5,7 @@
 package pebble
 
 import (
+	"context"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -155,6 +156,9 @@ func newIngestedFlushable(
 	return ret
 }
 
+// TODO(sumeer): ingestedFlushable iters also need to plumb context for
+// tracing.
+
 func (s *ingestedFlushable) newIter(o *IterOptions) internalIterator {
 	var opts IterOptions
 	if o != nil {
@@ -181,7 +185,7 @@ func (s *ingestedFlushable) constructRangeDelIter(
 ) (keyspan.FragmentIterator, error) {
 	// Note that the keyspan level iter expects a non-nil iterator to be
 	// returned even if there is an error. So, we return the emptyKeyspanIter.
-	iter, rangeDelIter, err := s.newIters(file, nil, internalIterOpts{})
+	iter, rangeDelIter, err := s.newIters(context.Background(), file, nil, internalIterOpts{})
 	if err != nil {
 		return emptyKeyspanIter, err
 	}

--- a/get_iter.go
+++ b/get_iter.go
@@ -5,6 +5,7 @@
 package pebble
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/cockroachdb/pebble/internal/base"
@@ -158,7 +159,7 @@ func (g *getIter) Next() (*InternalKey, base.LazyValue) {
 				files := g.l0[n-1].Iter()
 				g.l0 = g.l0[:n-1]
 				iterOpts := IterOptions{logger: g.logger}
-				g.levelIter.init(iterOpts, g.cmp, nil /* split */, g.newIters,
+				g.levelIter.init(context.Background(), iterOpts, g.cmp, nil /* split */, g.newIters,
 					files, manifest.L0Sublevel(n), internalIterOpts{})
 				g.levelIter.initRangeDel(&g.rangeDelIter)
 				g.iter = &g.levelIter
@@ -177,7 +178,7 @@ func (g *getIter) Next() (*InternalKey, base.LazyValue) {
 		}
 
 		iterOpts := IterOptions{logger: g.logger}
-		g.levelIter.init(iterOpts, g.cmp, nil /* split */, g.newIters,
+		g.levelIter.init(context.Background(), iterOpts, g.cmp, nil /* split */, g.newIters,
 			g.version.Levels[g.level].Iter(), manifest.Level(g.level), internalIterOpts{})
 		g.levelIter.initRangeDel(&g.rangeDelIter)
 		g.level++

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -5,6 +5,7 @@
 package pebble
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -472,7 +473,7 @@ func TestGetIter(t *testing.T) {
 		// m is a map from file numbers to DBs.
 		m := map[FileNum]*memTable{}
 		newIter := func(
-			file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts,
+			_ context.Context, file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts,
 		) (internalIterator, keyspan.FragmentIterator, error) {
 			d, ok := m[file.FileNum]
 			if !ok {

--- a/ingest.go
+++ b/ingest.go
@@ -5,6 +5,7 @@
 package pebble
 
 import (
+	"context"
 	"sort"
 	"sync/atomic"
 	"time"
@@ -514,7 +515,9 @@ func ingestTargetLevel(
 			continue
 		}
 
-		iter, rangeDelIter, err := newIters(meta0, nil, internalIterOpts{})
+		// TODO(sumeer): ingest is a user-facing operation, so we should accept a
+		// context and plumb it through, for tracing.
+		iter, rangeDelIter, err := newIters(context.Background(), meta0, nil, internalIterOpts{})
 		if err != nil {
 			return 0, err
 		}

--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -4,7 +4,10 @@
 
 package base
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // InternalIterator iterates over a DB's key/value pairs in key order. Unlike
 // the Iterator interface, the returned keys are InternalKeys composed of the
@@ -348,7 +351,11 @@ type InternalIteratorStats struct {
 	BlockBytes uint64
 	// Subset of BlockBytes that were in the block cache.
 	BlockBytesInCache uint64
-
+	// BlockReadDuration accumulates the duration spent fetching blocks
+	// due to block cache misses.
+	// TODO(sumeer): this currently excludes the time spent in Reader creation,
+	// and in reading the rangedel and rangekey blocks. Fix that.
+	BlockReadDuration time.Duration
 	// The following can repeatedly count the same points if they are iterated
 	// over multiple times. Additionally, they may count a point twice when
 	// switching directions. The latter could be improved if needed.
@@ -391,6 +398,7 @@ type InternalIteratorStats struct {
 func (s *InternalIteratorStats) Merge(from InternalIteratorStats) {
 	s.BlockBytes += from.BlockBytes
 	s.BlockBytesInCache += from.BlockBytesInCache
+	s.BlockReadDuration += from.BlockReadDuration
 	s.KeyBytes += from.KeyBytes
 	s.ValueBytes += from.ValueBytes
 	s.PointCount += from.PointCount

--- a/internal/base/logger.go
+++ b/internal/base/logger.go
@@ -6,11 +6,14 @@ package base
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"os"
 	"runtime"
 	"sync"
+
+	"github.com/cockroachdb/pebble/internal/invariants"
 )
 
 // Logger defines an interface for writing log messages.
@@ -76,4 +79,66 @@ func (b *InMemLogger) Infof(format string, args ...interface{}) {
 func (b *InMemLogger) Fatalf(format string, args ...interface{}) {
 	b.Infof(format, args...)
 	runtime.Goexit()
+}
+
+// LoggerAndTracer defines an interface for logging and tracing.
+type LoggerAndTracer interface {
+	Logger
+	// Eventf formats and emits a tracing log, if tracing is enabled in the
+	// current context.
+	Eventf(ctx context.Context, format string, args ...interface{})
+	// IsTracingEnabled returns true if tracing is enabled. It can be used as an
+	// optimization to avoid calling Eventf (which will be a noop when tracing
+	// is not enabled) to avoid the overhead of boxing the args.
+	IsTracingEnabled(ctx context.Context) bool
+}
+
+// LoggerWithNoopTracer wraps a logger and does no tracing.
+type LoggerWithNoopTracer struct {
+	Logger
+}
+
+var _ LoggerAndTracer = &LoggerWithNoopTracer{}
+
+// Eventf implements LoggerAndTracer.
+func (*LoggerWithNoopTracer) Eventf(ctx context.Context, format string, args ...interface{}) {
+	if invariants.Enabled && ctx == nil {
+		panic("Eventf context is nil")
+	}
+}
+
+// IsTracingEnabled implements LoggerAndTracer.
+func (*LoggerWithNoopTracer) IsTracingEnabled(ctx context.Context) bool {
+	if invariants.Enabled && ctx == nil {
+		panic("IsTracingEnabled ctx is nil")
+	}
+	return false
+}
+
+// NoopLoggerAndTracer does no logging and tracing. Remember that struct{} is
+// special cased in Go and does not incur an allocation when it backs the
+// interface LoggerAndTracer.
+type NoopLoggerAndTracer struct{}
+
+var _ LoggerAndTracer = NoopLoggerAndTracer{}
+
+// Infof implements LoggerAndTracer.
+func (l NoopLoggerAndTracer) Infof(format string, args ...interface{}) {}
+
+// Fatalf implements LoggerAndTracer.
+func (l NoopLoggerAndTracer) Fatalf(format string, args ...interface{}) {}
+
+// Eventf implements LoggerAndTracer.
+func (l NoopLoggerAndTracer) Eventf(ctx context.Context, format string, args ...interface{}) {
+	if invariants.Enabled && ctx == nil {
+		panic("Eventf context is nil")
+	}
+}
+
+// IsTracingEnabled implements LoggerAndTracer.
+func (l NoopLoggerAndTracer) IsTracingEnabled(ctx context.Context) bool {
+	if invariants.Enabled && ctx == nil {
+		panic("IsTracingEnabled ctx is nil")
+	}
+	return false
 }

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -6,6 +6,7 @@ package pebble
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -1065,8 +1066,10 @@ func TestIteratorSeekOpt(t *testing.T) {
 			s := d.mu.versions.currentVersion().String()
 			d.mu.Unlock()
 			oldNewIters := d.newIters
-			d.newIters = func(file *manifest.FileMetadata, opts *IterOptions, internalOpts internalIterOpts) (internalIterator, keyspan.FragmentIterator, error) {
-				iter, rangeIter, err := oldNewIters(file, opts, internalOpts)
+			d.newIters = func(
+				ctx context.Context, file *manifest.FileMetadata, opts *IterOptions,
+				internalOpts internalIterOpts) (internalIterator, keyspan.FragmentIterator, error) {
+				iter, rangeIter, err := oldNewIters(ctx, file, opts, internalOpts)
 				iterWrapped := &iterSeekOptWrapper{
 					internalIterator:      iter,
 					seekGEUsingNext:       &seekGEUsingNext,
@@ -1706,6 +1709,7 @@ func TestIteratorStatsMerge(t *testing.T) {
 		InternalStats: InternalIteratorStats{
 			BlockBytes:                     9,
 			BlockBytesInCache:              10,
+			BlockReadDuration:              3 * time.Millisecond,
 			KeyBytes:                       11,
 			ValueBytes:                     12,
 			PointCount:                     13,
@@ -1728,6 +1732,7 @@ func TestIteratorStatsMerge(t *testing.T) {
 		InternalStats: InternalIteratorStats{
 			BlockBytes:                     9,
 			BlockBytesInCache:              10,
+			BlockReadDuration:              4 * time.Millisecond,
 			KeyBytes:                       11,
 			ValueBytes:                     12,
 			PointCount:                     13,
@@ -1751,6 +1756,7 @@ func TestIteratorStatsMerge(t *testing.T) {
 		InternalStats: InternalIteratorStats{
 			BlockBytes:                     18,
 			BlockBytesInCache:              20,
+			BlockReadDuration:              7 * time.Millisecond,
 			KeyBytes:                       22,
 			ValueBytes:                     24,
 			PointCount:                     26,

--- a/level_checker.go
+++ b/level_checker.go
@@ -5,6 +5,7 @@
 package pebble
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"sort"
@@ -378,7 +379,8 @@ func checkRangeTombstones(c *checkConfig) error {
 			lf := files.Take()
 			atomicUnit, _ := expandToAtomicUnit(c.cmp, lf.Slice(), true /* disableIsCompacting */)
 			lower, upper := manifest.KeyRange(c.cmp, atomicUnit.Iter())
-			iterToClose, iter, err := c.newIters(lf.FileMetadata, nil, internalIterOpts{})
+			iterToClose, iter, err := c.newIters(
+				context.Background(), lf.FileMetadata, nil, internalIterOpts{})
 			if err != nil {
 				return err
 			}
@@ -638,7 +640,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 		manifestIter := current.L0SublevelFiles[sublevel].Iter()
 		iterOpts := IterOptions{logger: c.logger}
 		li := &levelIter{}
-		li.init(iterOpts, c.cmp, nil /* split */, c.newIters, manifestIter,
+		li.init(context.Background(), iterOpts, c.cmp, nil /* split */, c.newIters, manifestIter,
 			manifest.L0Sublevel(sublevel), internalIterOpts{})
 		li.initRangeDel(&mlevelAlloc[0].rangeDelIter)
 		li.initBoundaryContext(&mlevelAlloc[0].levelIterBoundaryContext)
@@ -652,7 +654,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 
 		iterOpts := IterOptions{logger: c.logger}
 		li := &levelIter{}
-		li.init(iterOpts, c.cmp, nil /* split */, c.newIters,
+		li.init(context.Background(), iterOpts, c.cmp, nil /* split */, c.newIters,
 			current.Levels[level].Iter(), manifest.Level(level), internalIterOpts{})
 		li.initRangeDel(&mlevelAlloc[0].rangeDelIter)
 		li.initBoundaryContext(&mlevelAlloc[0].levelIterBoundaryContext)

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -6,6 +6,7 @@ package pebble
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -95,7 +96,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 
 	var fileNum FileNum
 	newIters :=
-		func(file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts) (internalIterator, keyspan.FragmentIterator, error) {
+		func(_ context.Context, file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts) (internalIterator, keyspan.FragmentIterator, error) {
 			r := readers[file.FileNum]
 			rangeDelIter, err := r.NewRawRangeDelIter()
 			if err != nil {

--- a/level_iter.go
+++ b/level_iter.go
@@ -5,6 +5,7 @@
 package pebble
 
 import (
+	"context"
 	"fmt"
 	"runtime/debug"
 
@@ -19,6 +20,7 @@ import (
 // number. If bytesIterated is specified, it is incremented as the given file is
 // iterated through.
 type tableNewIters func(
+	ctx context.Context,
 	file *manifest.FileMetadata,
 	opts *IterOptions,
 	internalOpts internalIterOpts,
@@ -26,9 +28,10 @@ type tableNewIters func(
 
 // tableNewRangeDelIter takes a tableNewIters and returns a TableNewSpanIter
 // for the rangedel iterator returned by tableNewIters.
-func tableNewRangeDelIter(newIters tableNewIters) keyspan.TableNewSpanIter {
+func tableNewRangeDelIter(ctx context.Context, newIters tableNewIters) keyspan.TableNewSpanIter {
 	return func(file *manifest.FileMetadata, iterOptions *keyspan.SpanIterOptions) (keyspan.FragmentIterator, error) {
-		iter, rangeDelIter, err := newIters(file, &IterOptions{RangeKeyFilters: iterOptions.RangeKeyFilters}, internalIterOpts{})
+		iter, rangeDelIter, err := newIters(
+			ctx, file, &IterOptions{RangeKeyFilters: iterOptions.RangeKeyFilters}, internalIterOpts{})
 		if iter != nil {
 			_ = iter.Close()
 		}
@@ -68,6 +71,11 @@ type internalIterOpts struct {
 // kind InternalKeyKindRangeDeletion which will be used to pause the levelIter
 // at the sstable until the mergingIter is ready to advance past it.
 type levelIter struct {
+	// The context is stored here since (a) iterators are expected to be
+	// short-lived (since they pin sstables), (b) plumbing a context into every
+	// method is very painful, (c) they do not (yet) respect context
+	// cancellation and are only used for tracing.
+	ctx    context.Context
 	logger Logger
 	cmp    Compare
 	split  Split
@@ -229,11 +237,13 @@ func newLevelIter(
 	bytesIterated *uint64,
 ) *levelIter {
 	l := &levelIter{}
-	l.init(opts, cmp, split, newIters, files, level, internalIterOpts{bytesIterated: bytesIterated})
+	l.init(context.Background(), opts, cmp, split, newIters, files, level,
+		internalIterOpts{bytesIterated: bytesIterated})
 	return l
 }
 
 func (l *levelIter) init(
+	ctx context.Context,
 	opts IterOptions,
 	cmp Compare,
 	split Split,
@@ -242,6 +252,7 @@ func (l *levelIter) init(
 	level manifest.Level,
 	internalOpts internalIterOpts,
 ) {
+	l.ctx = ctx
 	l.err = nil
 	l.level = level
 	l.logger = opts.getLogger()
@@ -648,7 +659,7 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) loadFileReturnIndicato
 
 		var rangeDelIter keyspan.FragmentIterator
 		var iter internalIterator
-		iter, rangeDelIter, l.err = l.newIters(l.iterFile, &l.tableOpts, l.internalOpts)
+		iter, rangeDelIter, l.err = l.newIters(l.ctx, l.iterFile, &l.tableOpts, l.internalOpts)
 		l.iter = iter
 		if l.err != nil {
 			return noFileLoaded

--- a/logger.go
+++ b/logger.go
@@ -11,3 +11,6 @@ type Logger = base.Logger
 
 // DefaultLogger logs to the Go stdlib logs.
 var DefaultLogger = base.DefaultLogger
+
+// LoggerAndTracer defines an interface for logging and tracing.
+type LoggerAndTracer = base.LoggerAndTracer

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -5,6 +5,7 @@
 package pebble
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -152,7 +153,8 @@ func TestMergingIterCornerCases(t *testing.T) {
 
 	var fileNum base.FileNum
 	newIters :=
-		func(file *manifest.FileMetadata, opts *IterOptions, iio internalIterOpts) (internalIterator, keyspan.FragmentIterator, error) {
+		func(_ context.Context, file *manifest.FileMetadata, opts *IterOptions, iio internalIterOpts,
+		) (internalIterator, keyspan.FragmentIterator, error) {
 			r := readers[file.FileNum]
 			rangeDelIter, err := r.NewRawRangeDelIter()
 			if err != nil {
@@ -257,8 +259,8 @@ func TestMergingIterCornerCases(t *testing.T) {
 					continue
 				}
 				li := &levelIter{}
-				li.init(IterOptions{}, cmp, func(a []byte) int { return len(a) }, newIters,
-					slice.Iter(), manifest.Level(i), internalIterOpts{stats: &stats})
+				li.init(context.Background(), IterOptions{}, cmp, func(a []byte) int { return len(a) },
+					newIters, slice.Iter(), manifest.Level(i), internalIterOpts{stats: &stats})
 				i := len(levelIters)
 				levelIters = append(levelIters, mergingIterLevel{iter: li})
 				li.initRangeDel(&levelIters[i].rangeDelIter)
@@ -609,7 +611,7 @@ func buildMergingIter(readers [][]*sstable.Reader, levelSlices []manifest.LevelS
 		levelIndex := i
 		level := len(readers) - 1 - i
 		newIters := func(
-			file *manifest.FileMetadata, opts *IterOptions, _ internalIterOpts,
+			_ context.Context, file *manifest.FileMetadata, opts *IterOptions, _ internalIterOpts,
 		) (internalIterator, keyspan.FragmentIterator, error) {
 			iter, err := readers[levelIndex][file.FileNum].NewIter(
 				opts.LowerBound, opts.UpperBound)

--- a/open.go
+++ b/open.go
@@ -62,6 +62,11 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	if err := opts.Validate(); err != nil {
 		return nil, err
 	}
+	if opts.LoggerAndTracer == nil {
+		opts.LoggerAndTracer = &base.LoggerWithNoopTracer{Logger: opts.Logger}
+	} else {
+		opts.Logger = opts.LoggerAndTracer
+	}
 
 	// In all error cases, we return db = nil; this is used by various
 	// deferred cleanups.

--- a/options.go
+++ b/options.go
@@ -715,10 +715,15 @@ type Options struct {
 	// options for the last level are used for all subsequent levels.
 	Levels []LevelOptions
 
+	// LoggerAndTracer will be used, if non-nil, else Logger will be used and
+	// tracing will be a noop.
+
 	// Logger used to write log messages.
 	//
 	// The default logger uses the Go standard library log package.
 	Logger Logger
+	// LoggerAndTracer is used for writing log messages and traces.
+	LoggerAndTracer LoggerAndTracer
 
 	// MaxManifestFileSize is the maximum size the MANIFEST file is allowed to
 	// become. When the MANIFEST exceeds this size it is rolled over and a new
@@ -1586,6 +1591,7 @@ func (o *Options) MakeReaderOptions() sstable.ReaderOptions {
 		if o.Merger != nil {
 			readerOpts.MergerName = o.Merger.Name
 		}
+		readerOpts.LoggerAndTracer = o.LoggerAndTracer
 	}
 	return readerOpts
 }

--- a/snapshot.go
+++ b/snapshot.go
@@ -5,6 +5,7 @@
 package pebble
 
 import (
+	"context"
 	"io"
 	"math"
 
@@ -44,10 +45,16 @@ func (s *Snapshot) Get(key []byte) ([]byte, io.Closer, error) {
 // return false). The iterator can be positioned via a call to SeekGE,
 // SeekLT, First or Last.
 func (s *Snapshot) NewIter(o *IterOptions) *Iterator {
+	return s.NewIterWithContext(context.Background(), o)
+}
+
+// NewIterWithContext is like NewIter, and additionally accepts a context for
+// tracing.
+func (s *Snapshot) NewIterWithContext(ctx context.Context, o *IterOptions) *Iterator {
 	if s.db == nil {
 		panic(ErrClosed)
 	}
-	return s.db.newIter(nil /* batch */, s, o)
+	return s.db.newIter(ctx, nil /* batch */, s, o)
 }
 
 // ScanInternal scans all internal keys within the specified bounds, truncating

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -6,6 +6,7 @@ package sstable
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"math"
@@ -927,7 +928,7 @@ func TestBlockProperties(t *testing.T) {
 
 				// Enumerate point key data blocks encoded into the index.
 				if f != nil {
-					indexH, err := r.readIndex(nil /* stats */)
+					indexH, err := r.readIndex(context.Background(), nil)
 					if err != nil {
 						return err.Error()
 					}
@@ -1268,7 +1269,7 @@ func runBlockPropertiesBuildCmd(td *datadriven.TestData) (r *Reader, out string)
 }
 
 func runBlockPropsCmd(r *Reader, td *datadriven.TestData) string {
-	bh, err := r.readIndex(nil /* stats */)
+	bh, err := r.readIndex(context.Background(), nil)
 	if err != nil {
 		return err.Error()
 	}
@@ -1315,8 +1316,7 @@ func runBlockPropsCmd(r *Reader, td *datadriven.TestData) string {
 		// block that bhp points to, along with its block properties.
 		if twoLevelIndex {
 			subiter := &blockIter{}
-			subIndex, err := r.readBlock(
-				bhp.BlockHandle, nil /* transform */, nil /* readaheadState */, nil /* stats */)
+			subIndex, err := r.readBlock(context.Background(), bhp.BlockHandle, nil, nil, nil)
 			if err != nil {
 				return err.Error()
 			}

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -374,6 +374,8 @@ func runIterCmd(
 			}
 			iter.SetBounds(lower, upper)
 		case "stats":
+			// The timing is non-deterministic, so set to 0.
+			opts.stats.BlockReadDuration = 0
 			fmt.Fprintf(&b, "%+v\n", *opts.stats)
 			continue
 		case "reset-stats":

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -117,6 +117,9 @@ type ReaderOptions struct {
 	// written with {Batch,DB}.Merge. The MergerName is checked for consistency
 	// with the value stored in the sstable when it was written.
 	MergerName string
+
+	// Logger is an optional logger and tracer.
+	LoggerAndTracer base.LoggerAndTracer
 }
 
 func (o ReaderOptions) ensureDefaults() ReaderOptions {
@@ -125,6 +128,9 @@ func (o ReaderOptions) ensureDefaults() ReaderOptions {
 	}
 	if o.MergerName == "" {
 		o.MergerName = base.DefaultMerger.Name
+	}
+	if o.LoggerAndTracer == nil {
+		o.LoggerAndTracer = base.NoopLoggerAndTracer{}
 	}
 	return o
 }

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -7,6 +7,7 @@ package sstable
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -693,7 +694,7 @@ func TestMetaIndexEntriesSorted(t *testing.T) {
 	r, err := newReader(f, ReaderOptions{})
 	require.NoError(t, err)
 
-	b, err := r.readBlock(r.metaIndexBH, nil /* transform */, nil /* attrs */, nil /* stats */)
+	b, err := r.readBlock(context.Background(), r.metaIndexBH, nil, nil, nil)
 	require.NoError(t, err)
 	defer b.Release()
 

--- a/sstable/testdata/readerstats/iter
+++ b/sstable/testdata/readerstats/iter
@@ -35,25 +35,25 @@ first
 stats
 ----
 <a:1>
-{BlockBytes:74 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:74 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 <b:2>
-{BlockBytes:74 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:74 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 <c:3>
-{BlockBytes:108 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:108 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 <d:4>
-{BlockBytes:108 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:108 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 .
-{BlockBytes:108 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:108 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 <a:1>
-{BlockBytes:142 BlockBytesInCache:34 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:142 BlockBytesInCache:34 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 <b:2>
-{BlockBytes:142 BlockBytesInCache:34 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:142 BlockBytesInCache:34 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 <c:3>
-{BlockBytes:176 BlockBytesInCache:68 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:176 BlockBytesInCache:68 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 <d:4>
-{BlockBytes:176 BlockBytesInCache:68 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:176 BlockBytesInCache:68 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 .
-{BlockBytes:176 BlockBytesInCache:68 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
-{BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:176 BlockBytesInCache:68 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 <a:1>
-{BlockBytes:34 BlockBytesInCache:34 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:34 BlockBytesInCache:34 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}

--- a/sstable/testdata/readerstats_v3/iter
+++ b/sstable/testdata/readerstats_v3/iter
@@ -33,13 +33,13 @@ next
 stats
 ----
 <c@10:10>
-{BlockBytes:251 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:251 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 <c@9:9>
-{BlockBytes:328 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:1 ValueBytes:4 ValueBytesFetched:4}}
+{BlockBytes:328 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:1 ValueBytes:4 ValueBytesFetched:4}}
 <c@8:8>
-{BlockBytes:328 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:2 ValueBytes:8 ValueBytesFetched:8}}
+{BlockBytes:328 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:2 ValueBytes:8 ValueBytesFetched:8}}
 <d@7:9>
-{BlockBytes:328 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:2 ValueBytes:8 ValueBytesFetched:8}}
+{BlockBytes:328 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:2 ValueBytes:8 ValueBytesFetched:8}}
 
 # seek-ge e@37 starts at the restart point at the beginning of the block and
 # iterates over 3 irrelevant separated versions before getting to e@37
@@ -55,12 +55,12 @@ next
 stats
 ----
 <e@37:47>
-{BlockBytes:328 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:4 ValueBytes:18 ValueBytesFetched:5}}
+{BlockBytes:328 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:4 ValueBytes:18 ValueBytesFetched:5}}
 <e@36:46>
 <e@35:45>
 <e@34:44>
 <e@33:43>
-{BlockBytes:328 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:8 ValueBytes:38 ValueBytesFetched:25}}
+{BlockBytes:328 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:8 ValueBytes:38 ValueBytesFetched:25}}
 
 # seek-ge e@26 lands at the restart point e@26.
 iter
@@ -72,8 +72,8 @@ prev
 stats
 ----
 <e@26:36>
-{BlockBytes:328 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:1 ValueBytes:5 ValueBytesFetched:5}}
+{BlockBytes:328 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:1 ValueBytes:5 ValueBytesFetched:5}}
 <e@27:37>
-{BlockBytes:328 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:2 ValueBytes:10 ValueBytesFetched:10}}
+{BlockBytes:328 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:2 ValueBytes:10 ValueBytesFetched:10}}
 <e@28:38>
-{BlockBytes:328 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:3 ValueBytes:15 ValueBytesFetched:15}}
+{BlockBytes:328 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:3 ValueBytes:15 ValueBytesFetched:15}}

--- a/sstable/value_block.go
+++ b/sstable/value_block.go
@@ -5,6 +5,7 @@
 package sstable
 
 import (
+	"context"
 	"encoding/binary"
 	"io"
 	"sync"
@@ -658,7 +659,9 @@ func (ukb *UserKeyPrefixBound) IsEmpty() bool {
 }
 
 type blockProviderWhenOpen interface {
-	readBlockForVBR(h BlockHandle, stats *base.InternalIteratorStats) (cache.Handle, error)
+	readBlockForVBR(
+		ctx context.Context, h BlockHandle, stats *base.InternalIteratorStats,
+	) (cache.Handle, error)
 }
 
 type blockProviderWhenClosed struct {
@@ -678,9 +681,9 @@ func (bpwc *blockProviderWhenClosed) close() {
 }
 
 func (bpwc blockProviderWhenClosed) readBlockForVBR(
-	h BlockHandle, stats *base.InternalIteratorStats,
+	ctx context.Context, h BlockHandle, stats *base.InternalIteratorStats,
 ) (cache.Handle, error) {
-	return bpwc.r.readBlock(h, nil, nil, stats)
+	return bpwc.r.readBlock(ctx, h, nil, nil, stats)
 }
 
 // ReaderProvider supports the implementation of blockProviderWhenClosed.
@@ -710,6 +713,7 @@ func (trp TrivialReaderProvider) Close() {}
 // blocks. It is used when the sstable was written with
 // Properties.ValueBlocksAreEnabled.
 type valueBlockReader struct {
+	ctx    context.Context
 	bpOpen blockProviderWhenOpen
 	rp     ReaderProvider
 	vbih   valueBlocksIndexHandle
@@ -822,7 +826,7 @@ func (r *valueBlockReader) getValueInternal(handle []byte, valLen int32) (val []
 	vh := decodeRemainingValueHandle(handle)
 	vh.valueLen = uint32(valLen)
 	if r.vbiBlock == nil {
-		ch, err := r.bpOpen.readBlockForVBR(r.vbih.h, r.stats)
+		ch, err := r.bpOpen.readBlockForVBR(r.ctx, r.vbih.h, r.stats)
 		if err != nil {
 			return nil, err
 		}
@@ -834,7 +838,7 @@ func (r *valueBlockReader) getValueInternal(handle []byte, valLen int32) (val []
 		if err != nil {
 			return nil, err
 		}
-		vbCacheHandle, err := r.bpOpen.readBlockForVBR(vbh, r.stats)
+		vbCacheHandle, err := r.bpOpen.readBlockForVBR(r.ctx, vbh, r.stats)
 		if err != nil {
 			return nil, err
 		}

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -239,7 +239,7 @@ compact         1   2.3 K     0 B       0          (size == estimated-debt, scor
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.4 K   11.1%  (score == hit-rate)
- tcache         1   680 B   50.0%  (score == hit-rate)
+ tcache         1   696 B   50.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)

--- a/testdata/external_iterator
+++ b/testdata/external_iterator
@@ -254,7 +254,7 @@ aaaa@1: (aaaa@1, .)
 aaaaa@3: (aaaaa@3, .)
 aaaaa@1: (aaaaa@1, .)
 stats: (interface (dir, seek, step): (fwd, 5, 5), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 5, 5), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 475 B, cached 0 B)), (points: (count 10, key-bytes 50, value-bytes 50, tombstoned 0)))
+(internal-stats: (block-bytes: (total 475 B, cached 0 B, read-time 0s)), (points: (count 10, key-bytes 50, value-bytes 50, tombstoned 0)))
 
 # Note the inclusion of fwd-only. This iterator will use the TrySeekUsingNext
 # optimization and loads ~half the block-bytes as a result.
@@ -283,4 +283,4 @@ aaaa@1: (aaaa@1, .)
 aaaaa@3: (aaaaa@3, .)
 aaaaa@1: (aaaaa@1, .)
 stats: (interface (dir, seek, step): (fwd, 5, 5), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 5, 5), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 281 B, cached 0 B)), (points: (count 10, key-bytes 50, value-bytes 50, tombstoned 0)))
+(internal-stats: (block-bytes: (total 281 B, cached 0 B, read-time 0s)), (points: (count 10, key-bytes 50, value-bytes 50, tombstoned 0)))

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -48,7 +48,7 @@ compact         0     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.5 K   42.9%  (score == hit-rate)
- tcache         1   680 B   50.0%  (score == hit-rate)
+ tcache         1   696 B   50.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)

--- a/testdata/iter_histories/iter_optimizations
+++ b/testdata/iter_histories/iter_optimizations
@@ -200,7 +200,7 @@ stats
 lastPositioningOp="unknown"
 b@5: (b@5, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 119 B, cached 0 B)), (points: (count 1, key-bytes 3, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 119 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 3, value-bytes 3, tombstoned 0)))
 
 mutate batch=foo
 set h@2 h@2
@@ -216,7 +216,7 @@ stats
 lastPositioningOp="seekprefixge"
 c@3: (c@3, .)
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 119 B, cached 0 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned 0)))
+(internal-stats: (block-bytes: (total 119 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned 0)))
 
 mutate batch=foo
 set i@1 i@1
@@ -232,7 +232,7 @@ stats
 lastPositioningOp="seekprefixge"
 d@9: (d@9, .)
 stats: (interface (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 119 B, cached 0 B)), (points: (count 3, key-bytes 9, value-bytes 9, tombstoned 0)))
+(internal-stats: (block-bytes: (total 119 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 9, value-bytes 9, tombstoned 0)))
 
 mutate batch=foo
 set j@6 j@6
@@ -248,7 +248,7 @@ stats
 lastPositioningOp="seekprefixge"
 e@8: (e@8, .)
 stats: (interface (dir, seek, step): (fwd, 4, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 4, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 119 B, cached 0 B)), (points: (count 4, key-bytes 12, value-bytes 12, tombstoned 0)))
+(internal-stats: (block-bytes: (total 119 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 12, value-bytes 12, tombstoned 0)))
 
 # Ensure that a case eligible for TrySeekUsingNext across a SetOptions correctly
 # sees new batch mutations. The batch iterator should ignore the

--- a/testdata/iter_histories/range_key_masking
+++ b/testdata/iter_histories/range_key_masking
@@ -154,7 +154,7 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 1.1 K, cached 0 B)), (points: (count 25, key-bytes 75, value-bytes 75, tombstoned 0))),
+(internal-stats: (block-bytes: (total 1.1 K, cached 0 B, read-time 0s)), (points: (count 25, key-bytes 75, value-bytes 75, tombstoned 0))),
 (range-key-stats: (count 1), (contained points: (count 25, skipped 25)))
 
 # Repeat the above test, but with an iterator that uses a block-property filter
@@ -169,7 +169,7 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 514 B, cached 514 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned 0))),
+(internal-stats: (block-bytes: (total 514 B, cached 514 B, read-time 0s)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned 0))),
 (range-key-stats: (count 1), (contained points: (count 2, skipped 2)))
 
 # Perform a similar comparison in reverse.
@@ -182,7 +182,7 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 1.1 K, cached 1.1 K)), (points: (count 25, key-bytes 75, value-bytes 75, tombstoned 0))),
+(internal-stats: (block-bytes: (total 1.1 K, cached 1.1 K, read-time 0s)), (points: (count 25, key-bytes 75, value-bytes 75, tombstoned 0))),
 (range-key-stats: (count 1), (contained points: (count 25, skipped 25)))
 
 combined-iter mask-suffix=@9 mask-filter
@@ -193,7 +193,7 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 514 B, cached 514 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned 0))),
+(internal-stats: (block-bytes: (total 514 B, cached 514 B, read-time 0s)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned 0))),
 (range-key-stats: (count 1), (contained points: (count 2, skipped 2)))
 
 # Perform similar comparisons with seeks.
@@ -206,7 +206,7 @@ stats
 m: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 789 B, cached 789 B)), (points: (count 13, key-bytes 39, value-bytes 39, tombstoned 0))),
+(internal-stats: (block-bytes: (total 789 B, cached 789 B, read-time 0s)), (points: (count 13, key-bytes 39, value-bytes 39, tombstoned 0))),
 (range-key-stats: (count 1), (contained points: (count 13, skipped 13)))
 
 combined-iter mask-suffix=@9 mask-filter
@@ -217,7 +217,7 @@ stats
 m: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 514 B, cached 514 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned 0))),
+(internal-stats: (block-bytes: (total 514 B, cached 514 B, read-time 0s)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned 0))),
 (range-key-stats: (count 1), (contained points: (count 2, skipped 2)))
 
 combined-iter mask-suffix=@9
@@ -228,7 +228,7 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 789 B, cached 789 B)), (points: (count 12, key-bytes 36, value-bytes 36, tombstoned 0))),
+(internal-stats: (block-bytes: (total 789 B, cached 789 B, read-time 0s)), (points: (count 12, key-bytes 36, value-bytes 36, tombstoned 0))),
 (range-key-stats: (count 1), (contained points: (count 12, skipped 12)))
 
 combined-iter mask-suffix=@9 mask-filter
@@ -239,5 +239,5 @@ stats
 a: (., [a-z) @5=boop UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 539 B, cached 539 B)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned 0))),
+(internal-stats: (block-bytes: (total 539 B, cached 539 B, read-time 0s)), (points: (count 2, key-bytes 6, value-bytes 6, tombstoned 0))),
 (range-key-stats: (count 1), (contained points: (count 2, skipped 2)))

--- a/testdata/iter_histories/stats_no_invariants
+++ b/testdata/iter_histories/stats_no_invariants
@@ -34,14 +34,14 @@ stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 0, 0)), (internal (dir, 
 a: (a, .)
 b: (b, [b-c) @5=boop UPDATED)
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 89 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0))),
+(internal-stats: (block-bytes: (total 89 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0))),
 (range-key-stats: (count 1), (contained points: (count 1, skipped 0)))
 c: (c, . UPDATED)
 cat: (., [cat-dog) @3=beep UPDATED)
 d: (d, [cat-dog) @3=beep)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 5), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 6), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 89 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0))),
+(internal-stats: (block-bytes: (total 89 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0))),
 (range-key-stats: (count 2), (contained points: (count 2, skipped 0)))
 
 # Do the above forward iteration but with a mask suffix. The results should be
@@ -64,7 +64,7 @@ cat: (., [cat-dog) @3=beep UPDATED)
 d: (d, [cat-dog) @3=beep)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 5), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 6), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 89 B, cached 89 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0))),
+(internal-stats: (block-bytes: (total 89 B, cached 89 B, read-time 0s)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0))),
 (range-key-stats: (count 2), (contained points: (count 2, skipped 0)))
 
 # Scan backward
@@ -85,7 +85,7 @@ b: (b, [b-c) @5=boop UPDATED)
 a: (a, . UPDATED)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 5)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 6)),
-(internal-stats: (block-bytes: (total 89 B, cached 89 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0))),
+(internal-stats: (block-bytes: (total 89 B, cached 89 B, read-time 0s)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0))),
 (range-key-stats: (count 2), (contained points: (count 2, skipped 0)))
 
 combined-iter
@@ -108,7 +108,7 @@ d: (d, [cat-dog) @3=beep)
 day: (., [cat-dog) @3=beep)
 .
 stats: (interface (dir, seek, step): (fwd, 8, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 6, 4), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 89 B, cached 89 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0))),
+(internal-stats: (block-bytes: (total 89 B, cached 89 B, read-time 0s)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0))),
 (range-key-stats: (count 2), (contained points: (count 3, skipped 0)))
 
 combined-iter
@@ -135,7 +135,7 @@ d: (d, [cat-dog) @3=beep)
 d: (d, [cat-dog) @3=beep)
 d: (d, [cat-dog) @3=beep)
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 10, 0)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 10, 10)),
-(internal-stats: (block-bytes: (total 267 B, cached 267 B)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned 0))),
+(internal-stats: (block-bytes: (total 267 B, cached 267 B, read-time 0s)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned 0))),
 (range-key-stats: (count 2), (contained points: (count 6, skipped 0)))
 
 rangekey-iter

--- a/testdata/iterator
+++ b/testdata/iterator
@@ -11,7 +11,7 @@ a: (b, .)
 .
 a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 iter seq=2
 seek-ge b
@@ -40,7 +40,7 @@ a: (b, .)
 .
 a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0)))
 
 iter seq=3
 seek-ge a
@@ -51,7 +51,7 @@ a: (c, .)
 .
 a: (c, .)
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 1, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0)))
 
 iter seq=2
 seek-prefix-ge a
@@ -64,7 +64,7 @@ a: (b, .)
 err=pebble: unsupported reverse prefix iteration
 err=pebble: unsupported reverse prefix iteration
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 iter seq=3
 seek-prefix-ge a
@@ -73,7 +73,7 @@ next
 a: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 
 define
@@ -86,7 +86,7 @@ seek-ge a
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned 0)))
 
 iter seq=2
 seek-ge 1
@@ -95,14 +95,14 @@ next
 a: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned 0)))
 
 iter seq=3
 seek-lt b
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 0)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned 0)))
 
 iter seq=2
 seek-lt b
@@ -113,21 +113,21 @@ a: (b, .)
 .
 a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 4, value-bytes 2, tombstoned 0)))
 
 iter seq=3
 seek-prefix-ge a
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned 0)))
 
 iter seq=2
 seek-prefix-ge 1
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 0, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 1, value-bytes 0, tombstoned 0)))
 
 define
 a.DEL.2:
@@ -142,42 +142,42 @@ next
 b: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned 0)))
 
 iter seq=3
 seek-ge a
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned 0)))
 
 iter seq=2
 seek-ge a
 ----
 a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned 0)))
 
 iter seq=4
 seek-prefix-ge a
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned 0)))
 
 iter seq=3
 seek-prefix-ge a
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned 0)))
 
 iter seq=2
 seek-prefix-ge a
 ----
 a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned 0)))
 
 iter seq=2
 seek-prefix-ge a
@@ -186,7 +186,7 @@ seek-prefix-ge b
 a: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned 0)))
 
 define
 a.DEL.3:
@@ -205,7 +205,7 @@ seek-prefix-ge c
 .
 c: (d, .)
 stats: (interface (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 3, 4), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 7, key-bytes 7, value-bytes 4, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 7, key-bytes 7, value-bytes 4, tombstoned 0)))
 
 iter seq=3
 seek-prefix-ge a
@@ -216,7 +216,7 @@ a: (b, .)
 b: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 5, key-bytes 5, value-bytes 3, tombstoned 0)))
 
 iter seq=3
 seek-ge a
@@ -227,7 +227,7 @@ a: (b, .)
 b: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 5, key-bytes 5, value-bytes 3, tombstoned 0)))
 
 define
 a.SET.1:a
@@ -246,7 +246,7 @@ b: (b, .)
 c: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned 0)))
 
 iter seq=4
 seek-ge b
@@ -255,14 +255,14 @@ next
 b: (b, .)
 c: (c, .)
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 iter seq=4
 seek-ge c
 ----
 c: (c, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
 
 iter seq=4
 seek-lt a
@@ -279,7 +279,7 @@ a: (a, .)
 .
 a: (a, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 iter seq=4
 seek-lt c
@@ -292,7 +292,7 @@ a: (a, .)
 .
 a: (a, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 2)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned 0)))
 
 
 iter seq=4
@@ -308,7 +308,7 @@ a: (a, .)
 .
 a: (a, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 3)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 3)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0)))
 
 iter seq=4
 seek-prefix-ge a
@@ -317,7 +317,7 @@ next
 a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 iter seq=4
 seek-prefix-ge b
@@ -326,7 +326,7 @@ next
 b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 
 iter seq=4
@@ -336,7 +336,7 @@ next
 c: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
 
 
 iter seq=4
@@ -354,7 +354,7 @@ a: (a, .)
 c: (c, .)
 b: (b, .)
 stats: (interface (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 3, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned 0)))
 
 define
 a.SET.b2:b
@@ -370,14 +370,14 @@ a: (b, .)
 .
 a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0)))
 
 iter seq=2
 seek-ge b
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
 
 iter seq=2
 seek-lt a
@@ -394,7 +394,7 @@ a: (b, .)
 .
 a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 iter seq=2
 seek-lt c
@@ -405,7 +405,7 @@ a: (b, .)
 .
 a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned 0)))
 
 iter seq=2
 seek-prefix-ge a
@@ -414,14 +414,14 @@ next
 a: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 iter seq=2
 seek-prefix-ge b
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
 
 
 define
@@ -438,7 +438,7 @@ next
 a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 3, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 3, value-bytes 3, tombstoned 0)))
 
 iter seq=5
 seek-prefix-ge a
@@ -447,14 +447,14 @@ next
 a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 3, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 3, value-bytes 3, tombstoned 0)))
 
 iter seq=5
 seek-prefix-ge aa
 ----
 aa: (aa, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 iter seq=5
 seek-prefix-ge aa
@@ -463,7 +463,7 @@ next
 aa: (aa, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 5, value-bytes 5, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 5, value-bytes 5, tombstoned 0)))
 
 iter seq=5
 seek-prefix-ge aa
@@ -472,7 +472,7 @@ next
 aa: (aa, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 5, value-bytes 5, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 5, value-bytes 5, tombstoned 0)))
 
 iter seq=5
 seek-prefix-ge aaa
@@ -481,14 +481,14 @@ next
 aaa: (aaa, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 4, value-bytes 4, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 4, value-bytes 4, tombstoned 0)))
 
 iter seq=5
 seek-prefix-ge aaa
 ----
 aaa: (aaa, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 3, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 3, value-bytes 3, tombstoned 0)))
 
 iter seq=5
 seek-prefix-ge b
@@ -497,7 +497,7 @@ next
 b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
 
 iter seq=5
 seek-prefix-ge aa
@@ -514,7 +514,7 @@ aa: (aa, .)
 a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 1, 4)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 4)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 9, value-bytes 9, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 5, key-bytes 9, value-bytes 9, tombstoned 0)))
 
 iter seq=5
 seek-prefix-ge aa
@@ -531,7 +531,7 @@ aaa: (aaa, .)
 b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 4), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 4), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 9, value-bytes 9, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 5, key-bytes 9, value-bytes 9, tombstoned 0)))
 
 iter seq=5
 seek-prefix-ge aaa
@@ -546,7 +546,7 @@ aaa: (aaa, .)
 b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 3), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 3), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 9, value-bytes 9, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 9, value-bytes 9, tombstoned 0)))
 
 iter seq=5
 seek-prefix-ge aaa
@@ -559,7 +559,7 @@ aaa: (aaa, .)
 b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 7, value-bytes 7, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 7, value-bytes 7, tombstoned 0)))
 
 iter seq=5
 seek-prefix-ge aaa
@@ -576,7 +576,7 @@ aaa: (aaa, .)
 b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 4), (rev, 1, 0)), (internal (dir, seek, step): (fwd, 2, 4), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 6, key-bytes 11, value-bytes 11, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 6, key-bytes 11, value-bytes 11, tombstoned 0)))
 
 
 iter seq=5
@@ -590,7 +590,7 @@ aaa: (aaa, .)
 b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 1, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 12, value-bytes 12, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 5, key-bytes 12, value-bytes 12, tombstoned 0)))
 
 iter seq=4
 seek-prefix-ge a
@@ -603,7 +603,7 @@ aa: (aa, .)
 aaa: (aaa, .)
 .
 stats: (interface (dir, seek, step): (fwd, 4, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 4, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 7, value-bytes 7, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 7, value-bytes 7, tombstoned 0)))
 
 iter seq=3
 seek-prefix-ge aaa
@@ -618,7 +618,7 @@ a: (a, .)
 aa: (aa, .)
 .
 stats: (interface (dir, seek, step): (fwd, 5, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 5, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 7, key-bytes 12, value-bytes 12, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 7, key-bytes 12, value-bytes 12, tombstoned 0)))
 
 define
 bb.DEL.2:
@@ -631,7 +631,7 @@ seek-prefix-ge bb
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 7, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 7, value-bytes 2, tombstoned 0)))
 
 
 define
@@ -653,7 +653,7 @@ b: (ab, .)
 .
 b: (ab, .)
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 5), (rev, 1, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 8, key-bytes 8, value-bytes 8, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 8, key-bytes 8, value-bytes 8, tombstoned 0)))
 
 iter seq=3
 seek-ge a
@@ -662,7 +662,7 @@ next
 a: (bc, .)
 b: (ab, .)
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 4), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned 0)))
 
 iter seq=2
 seek-ge a
@@ -671,7 +671,7 @@ next
 a: (b, .)
 b: (a, .)
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned 0)))
 
 iter seq=4
 seek-lt c
@@ -684,7 +684,7 @@ a: (bcd, .)
 .
 a: (bcd, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 2)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 1, 5)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 8, key-bytes 8, value-bytes 8, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 8, key-bytes 8, value-bytes 8, tombstoned 0)))
 
 iter seq=3
 seek-lt c
@@ -693,7 +693,7 @@ prev
 b: (ab, .)
 a: (bc, .)
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 4)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned 0)))
 
 iter seq=2
 seek-lt c
@@ -702,7 +702,7 @@ prev
 b: (a, .)
 a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned 0)))
 
 iter seq=4
 seek-ge a
@@ -715,7 +715,7 @@ b: (ab, .)
 a: (bcd, .)
 b: (ab, .)
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 10), (rev, 1, 5)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned 0)))
 
 iter seq=3
 seek-ge a
@@ -728,7 +728,7 @@ b: (ab, .)
 a: (bc, .)
 b: (ab, .)
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 8), (rev, 1, 4)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned 0)))
 
 iter seq=2
 seek-ge a
@@ -741,7 +741,7 @@ b: (a, .)
 a: (b, .)
 b: (a, .)
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 4), (rev, 1, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned 0)))
 
 iter seq=4
 seek-lt c
@@ -754,7 +754,7 @@ a: (bcd, .)
 b: (ab, .)
 a: (bcd, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 2)), (internal (dir, seek, step): (fwd, 1, 5), (rev, 2, 10)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned 0)))
 
 iter seq=3
 seek-lt c
@@ -767,7 +767,7 @@ a: (bc, .)
 b: (ab, .)
 a: (bc, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 2)), (internal (dir, seek, step): (fwd, 1, 4), (rev, 2, 8)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned 0)))
 
 iter seq=2
 seek-lt c
@@ -780,7 +780,7 @@ a: (b, .)
 b: (a, .)
 a: (b, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 2)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 2, 4)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 15, key-bytes 15, value-bytes 15, tombstoned 0)))
 
 iter seq=3
 seek-prefix-ge a
@@ -789,7 +789,7 @@ next
 a: (bc, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0)))
 
 iter seq=2
 seek-prefix-ge a
@@ -798,7 +798,7 @@ next
 a: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0)))
 
 iter seq=4
 seek-prefix-ge a
@@ -807,7 +807,7 @@ next
 a: (bcd, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0)))
 
 iter seq=2
 seek-prefix-ge a
@@ -816,7 +816,7 @@ next
 a: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0)))
 
 iter seq=3
 seek-prefix-ge a
@@ -825,7 +825,7 @@ next
 a: (bc, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0)))
 
 iter seq=3
 seek-prefix-ge c
@@ -838,14 +838,14 @@ seek-prefix-ge 1
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
 
 iter seq=3
 seek-prefix-ge a
 ----
 a: (bc, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned 0)))
 
 
 define
@@ -867,7 +867,7 @@ a: (bc, .)
 .
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 5, value-bytes 4, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 5, value-bytes 4, tombstoned 0)))
 
 iter seq=2
 seek-prefix-ge a
@@ -878,7 +878,7 @@ a: (b, .)
 .
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 5, value-bytes 4, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 5, value-bytes 4, tombstoned 0)))
 
 iter seq=4
 seek-prefix-ge a
@@ -887,7 +887,7 @@ next
 a: (bcd, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 5, value-bytes 4, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 5, value-bytes 4, tombstoned 0)))
 
 iter seq=2
 seek-prefix-ge a
@@ -896,7 +896,7 @@ next
 a: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 5, value-bytes 4, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 5, value-bytes 4, tombstoned 0)))
 
 iter seq=3
 seek-prefix-ge aa
@@ -905,14 +905,14 @@ next
 aa: (ab, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 5, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 5, value-bytes 3, tombstoned 0)))
 
 iter seq=4
 seek-prefix-ge aa
 ----
 aa: (ab, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 5, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 5, value-bytes 3, tombstoned 0)))
 
 define
 a.SET.1:a
@@ -930,7 +930,7 @@ a: (a, .)
 a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 iter seq=2 lower=b
 seek-ge a
@@ -941,7 +941,7 @@ b: (b, .)
 b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 iter seq=2 lower=c
 seek-ge a
@@ -952,7 +952,7 @@ c: (c, .)
 c: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 iter seq=2 lower=d
 seek-ge a
@@ -963,7 +963,7 @@ d: (d, .)
 d: (d, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 iter seq=2 lower=e
 seek-ge a
@@ -982,7 +982,7 @@ c: (c, .)
 c: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 2, 0)), (internal (dir, seek, step): (fwd, 0, 2), (rev, 2, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned 0)))
 
 iter seq=2 upper=c
 seek-lt d
@@ -993,7 +993,7 @@ b: (b, .)
 b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 2, 0)), (internal (dir, seek, step): (fwd, 0, 2), (rev, 2, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned 0)))
 
 iter seq=2 upper=b
 seek-lt d
@@ -1004,7 +1004,7 @@ a: (a, .)
 a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 2, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 2, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned 0)))
 
 iter seq=2 upper=a
 seek-lt d
@@ -1021,7 +1021,7 @@ next
 b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
 
 iter seq=2
 set-bounds lower=a
@@ -1034,7 +1034,7 @@ a: (a, .)
 a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 iter seq=2
 set-bounds lower=b
@@ -1047,7 +1047,7 @@ b: (b, .)
 b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 iter seq=2
 set-bounds lower=c
@@ -1060,7 +1060,7 @@ c: (c, .)
 c: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 iter seq=2
 set-bounds lower=d
@@ -1073,7 +1073,7 @@ d: (d, .)
 d: (d, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 iter seq=2
 set-bounds lower=e
@@ -1096,7 +1096,7 @@ c: (c, .)
 c: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 2, 0)), (internal (dir, seek, step): (fwd, 0, 2), (rev, 2, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned 0)))
 
 iter seq=2
 set-bounds upper=c
@@ -1109,7 +1109,7 @@ b: (b, .)
 b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 2, 0)), (internal (dir, seek, step): (fwd, 0, 2), (rev, 2, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned 0)))
 
 iter seq=2
 set-bounds upper=b
@@ -1122,7 +1122,7 @@ a: (a, .)
 a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 2, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 2, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned 0)))
 
 iter seq=2
 set-bounds upper=a
@@ -1145,7 +1145,7 @@ c: (c, .)
 d: (d, .)
 .
 stats: (interface (dir, seek, step): (fwd, 0, 2), (rev, 1, 0)), (internal (dir, seek, step): (fwd, 0, 3), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 4, value-bytes 4, tombstoned 0)))
 
 iter seq=2
 set-bounds lower=b upper=c
@@ -1156,7 +1156,7 @@ next
 b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
 
 iter seq=2
 set-bounds lower=b
@@ -1169,7 +1169,7 @@ b: (b, .)
 .
 b: (b, .)
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 iter seq=2
 seek-ge a
@@ -1178,7 +1178,7 @@ set-bounds upper=e
 a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
 
 iter seq=2
 set-bounds lower=b
@@ -1189,7 +1189,7 @@ set-bounds upper=e
 b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
 
 iter seq=2
 set-bounds lower=b
@@ -1198,7 +1198,7 @@ first
 .
 b: (b, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
 
 iter seq=2
 set-bounds upper=b
@@ -1207,7 +1207,7 @@ first
 .
 a: (a, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
 
 iter seq=2
 set-bounds lower=b
@@ -1216,7 +1216,7 @@ last
 .
 d: (d, .)
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 0)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 iter seq=2
 set-bounds upper=b
@@ -1225,7 +1225,7 @@ last
 .
 a: (a, .)
 stats: (interface (dir, seek, step): (fwd, 0, 0), (rev, 1, 0)), (internal (dir, seek, step): (fwd, 0, 0), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
 
 # The prev call after "set-bounds upper=c" will assume that the iterator
 # is exhausted due to having stepped up to c. Which means prev should step
@@ -1241,7 +1241,7 @@ d: (d, .)
 .
 b: (b, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 1)), (internal (dir, seek, step): (fwd, 0, 2), (rev, 2, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 5, key-bytes 5, value-bytes 5, tombstoned 0)))
 
 # The next call after "set-bounds lower=b" will assume that the iterator
 # is exhausted due to having stepped below b. Which means next should step
@@ -1257,7 +1257,7 @@ a: (a, .)
 .
 b: (b, .)
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 iter seq=2
 set-bounds lower=b
@@ -1268,7 +1268,7 @@ next
 b: (b, .)
 c: (c, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 1, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned 0)))
 
 iter seq=2
 set-bounds upper=d
@@ -1279,7 +1279,7 @@ prev
 c: (c, .)
 b: (b, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 2)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 3, value-bytes 3, tombstoned 0)))
 
 define
 a.SET.1:a
@@ -1297,7 +1297,7 @@ a: (a, .)
 a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 2, 0), (rev, 0, 1)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 
 iter seq=2 lower=aa
@@ -1313,7 +1313,7 @@ next
 a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
 
 iter seq=2 lower=a upper=aaa
 seek-prefix-ge a
@@ -1322,7 +1322,7 @@ next
 a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 3, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 3, value-bytes 3, tombstoned 0)))
 
 iter seq=2 lower=a upper=b
 seek-prefix-ge a
@@ -1331,7 +1331,7 @@ next
 a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 3, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 3, value-bytes 3, tombstoned 0)))
 
 iter seq=2 lower=a upper=c
 seek-prefix-ge a
@@ -1340,14 +1340,14 @@ next
 a: (a, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 3, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 3, value-bytes 3, tombstoned 0)))
 
 iter seq=2 lower=a upper=aaa
 seek-prefix-ge aa
 ----
 aa: (aa, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 iter seq=2 lower=a upper=aaa
 seek-prefix-ge aa
@@ -1356,7 +1356,7 @@ next
 aa: (aa, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 define
 a.SET.1:a
@@ -1372,7 +1372,7 @@ a: (a, .)
 b: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 define
 a.SINGLEDEL.1:
@@ -1383,7 +1383,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 1, key-bytes 1, value-bytes 0, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 1, key-bytes 1, value-bytes 0, tombstoned 0)))
 
 define
 a.SINGLEDEL.2:
@@ -1395,7 +1395,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 0, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 0, tombstoned 0)))
 
 define
 a.SINGLEDEL.2:
@@ -1407,7 +1407,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 0, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 0, tombstoned 0)))
 
 define
 a.SINGLEDEL.2:
@@ -1419,7 +1419,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 0, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 0, tombstoned 0)))
 
 define
 a.SINGLEDEL.2:
@@ -1431,7 +1431,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned 0)))
 
 define
 a.SET.2:b
@@ -1445,7 +1445,7 @@ next
 a: (b, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 1, tombstoned 0)))
 
 define
 a.SINGLEDEL.2:
@@ -1460,7 +1460,7 @@ next
 b: (c, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 1), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned 0)))
 
 define
 a.SINGLEDEL.3:
@@ -1473,7 +1473,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned 0)))
 
 define
 a.SINGLEDEL.3:
@@ -1486,7 +1486,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 3, key-bytes 3, value-bytes 2, tombstoned 0)))
 
 define
 a.SINGLEDEL.4:
@@ -1500,7 +1500,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 4), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 6, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 4, value-bytes 6, tombstoned 0)))
 
 define
 a.SINGLEDEL.4:
@@ -1514,7 +1514,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 4), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 6, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 4, value-bytes 6, tombstoned 0)))
 
 define
 a.SINGLEDEL.4:
@@ -1528,7 +1528,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 4), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 4, key-bytes 4, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 4, key-bytes 4, value-bytes 3, tombstoned 0)))
 
 define
 a.SINGLEDEL.3:
@@ -1540,7 +1540,7 @@ first
 ----
 .
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 2, key-bytes 2, value-bytes 3, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 3, tombstoned 0)))
 
 # Exercise iteration with limits, when there are no deletes.
 define
@@ -1583,7 +1583,7 @@ a: valid (a, .)
 . at-limit
 a: valid (a, .)
 stats: (interface (dir, seek, step): (fwd, 1, 6), (rev, 1, 7)), (internal (dir, seek, step): (fwd, 3, 3), (rev, 1, 6)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 11, key-bytes 11, value-bytes 11, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 11, key-bytes 11, value-bytes 11, tombstoned 0)))
 
 # Exercise iteration with limits when we have deletes.
 
@@ -1631,7 +1631,7 @@ d: valid (d, .)
 d: valid (d, .)
 . exhausted
 stats: (interface (dir, seek, step): (fwd, 1, 10), (rev, 0, 5)), (internal (dir, seek, step): (fwd, 3, 13), (rev, 1, 8)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 21, key-bytes 21, value-bytes 14, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 21, key-bytes 21, value-bytes 14, tombstoned 0)))
 
 iter seq=4
 seek-ge-limit b d
@@ -1644,7 +1644,7 @@ next-limit e
 . at-limit
 d: valid (d, .)
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 1)), (internal (dir, seek, step): (fwd, 1, 9), (rev, 0, 5)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 15, key-bytes 15, value-bytes 9, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 15, key-bytes 15, value-bytes 9, tombstoned 0)))
 
 iter seq=4
 seek-lt-limit d c
@@ -1661,7 +1661,7 @@ a: valid (a, .)
 . exhausted
 a: valid (a, .)
 stats: (interface (dir, seek, step): (fwd, 0, 1), (rev, 1, 4)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 5)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 6, key-bytes 6, value-bytes 4, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 6, key-bytes 6, value-bytes 4, tombstoned 0)))
 
 # NB: Zero values are skipped by deletable merger.
 define merger=deletable
@@ -1688,7 +1688,7 @@ prev
 .
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 2)), (internal (dir, seek, step): (fwd, 1, 8), (rev, 1, 8)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 16, key-bytes 16, value-bytes 24, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 16, key-bytes 16, value-bytes 24, tombstoned 0)))
 
 iter seq=4
 seek-ge a
@@ -1703,4 +1703,4 @@ b: (3, .)
 b: (3, .)
 a: (2, .)
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 2)), (internal (dir, seek, step): (fwd, 1, 6), (rev, 1, 6)),
-(internal-stats: (block-bytes: (total 0 B, cached 0 B)), (points: (count 16, key-bytes 16, value-bytes 24, tombstoned 0)))
+(internal-stats: (block-bytes: (total 0 B, cached 0 B, read-time 0s)), (points: (count 16, key-bytes 16, value-bytes 24, tombstoned 0)))

--- a/testdata/iterator_stats
+++ b/testdata/iterator_stats
@@ -18,7 +18,7 @@ a: (1, .)
 c: (2, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 57 B, cached 57 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 57 B, cached 57 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 # Perform the same operation again with a new iterator. It should yield
 # identical statistics.
@@ -33,7 +33,7 @@ a: (1, .)
 c: (2, .)
 .
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 57 B, cached 57 B)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
+(internal-stats: (block-bytes: (total 57 B, cached 57 B, read-time 0s)), (points: (count 2, key-bytes 2, value-bytes 2, tombstoned 0)))
 
 build ext2
 set d@10 d10
@@ -64,17 +64,17 @@ stats
 ----
 c: (2, .)
 stats: (interface (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 0), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 57 B, cached 57 B)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
+(internal-stats: (block-bytes: (total 57 B, cached 57 B, read-time 0s)), (points: (count 1, key-bytes 1, value-bytes 1, tombstoned 0)))
 d@10: (d10, .)
 d@9: (d9, .)
 stats: (interface (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 2), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 157 B, cached 147 B)), (points: (count 3, key-bytes 8, value-bytes 6, tombstoned 0)), (separated: (count 1, bytes 2 B, fetched 2 B)))
+(internal-stats: (block-bytes: (total 157 B, cached 147 B, read-time 0s)), (points: (count 3, key-bytes 8, value-bytes 6, tombstoned 0)), (separated: (count 1, bytes 2 B, fetched 2 B)))
 d@8: (d8, .)
 stats: (interface (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 3), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 157 B, cached 147 B)), (points: (count 4, key-bytes 11, value-bytes 8, tombstoned 0)), (separated: (count 2, bytes 4 B, fetched 4 B)))
+(internal-stats: (block-bytes: (total 157 B, cached 147 B, read-time 0s)), (points: (count 4, key-bytes 11, value-bytes 8, tombstoned 0)), (separated: (count 2, bytes 4 B, fetched 4 B)))
 e@20: (e20, .)
 stats: (interface (dir, seek, step): (fwd, 1, 4), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 4), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 157 B, cached 147 B)), (points: (count 5, key-bytes 15, value-bytes 11, tombstoned 0)), (separated: (count 2, bytes 4 B, fetched 4 B)))
+(internal-stats: (block-bytes: (total 157 B, cached 147 B, read-time 0s)), (points: (count 5, key-bytes 15, value-bytes 11, tombstoned 0)), (separated: (count 2, bytes 4 B, fetched 4 B)))
 e@18: (e18, .)
 stats: (interface (dir, seek, step): (fwd, 1, 5), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 1, 5), (rev, 0, 0)),
-(internal-stats: (block-bytes: (total 157 B, cached 147 B)), (points: (count 6, key-bytes 19, value-bytes 13, tombstoned 0)), (separated: (count 3, bytes 7 B, fetched 7 B)))
+(internal-stats: (block-bytes: (total 157 B, cached 147 B, read-time 0s)), (points: (count 6, key-bytes 19, value-bytes 13, tombstoned 0)), (separated: (count 3, bytes 7 B, fetched 7 B)))

--- a/testdata/level_iter_seek
+++ b/testdata/level_iter_seek
@@ -109,21 +109,21 @@ reset-stats
 stats
 ----
 a/<invalid>#9,1:a
-{BlockBytes:56 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
-{BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:56 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 b#8,1:b
-{BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 c#7,1:c
-{BlockBytes:56 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:56 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 f#5,1:f
-{BlockBytes:56 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:56 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 g#4,1:g
-{BlockBytes:112 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 h#3,1:h
-{BlockBytes:112 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 .
-{BlockBytes:112 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
-{BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 
 iter
 set-bounds lower=d

--- a/testdata/merging_iter
+++ b/testdata/merging_iter
@@ -40,8 +40,8 @@ c#27,1:27
 e#10,1:10
 g#20,1:20
 .
-{BlockBytes:116 BlockBytesInCache:0 KeyBytes:5 ValueBytes:8 PointCount:5 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
-{BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:116 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:5 ValueBytes:8 PointCount:5 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 
 # seekGE() should not allow the rangedel to act on points in the lower sstable that are after it.
 iter
@@ -582,11 +582,11 @@ next
 stats
 ----
 a#30,1:30
-{BlockBytes:97 BlockBytesInCache:0 KeyBytes:1 ValueBytes:2 PointCount:1 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
-{BlockBytes:0 BlockBytesInCache:0 KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:97 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:1 ValueBytes:2 PointCount:1 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 f#21,1:21
-{BlockBytes:0 BlockBytesInCache:0 KeyBytes:5 ValueBytes:10 PointCount:5 PointsCoveredByRangeTombstones:4 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:5 ValueBytes:10 PointCount:5 PointsCoveredByRangeTombstones:4 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 .
-{BlockBytes:0 BlockBytesInCache:0 KeyBytes:6 ValueBytes:10 PointCount:6 PointsCoveredByRangeTombstones:4 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:6 ValueBytes:10 PointCount:6 PointsCoveredByRangeTombstones:4 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 .
-{BlockBytes:0 BlockBytesInCache:0 KeyBytes:6 ValueBytes:10 PointCount:6 PointsCoveredByRangeTombstones:4 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:6 ValueBytes:10 PointCount:6 PointsCoveredByRangeTombstones:4 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -34,7 +34,7 @@ compact         0     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         1   256 K
    ztbl         0     0 B
  bcache         4   697 B    0.0%  (score == hit-rate)
- tcache         1   680 B    0.0%  (score == hit-rate)
+ tcache         1   696 B    0.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         1
  filter         -       -    0.0%  (score == utility)
@@ -82,7 +82,7 @@ compact         1     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         2   512 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   42.9%  (score == hit-rate)
- tcache         2   1.3 K   66.7%  (score == hit-rate)
+ tcache         2   1.4 K   66.7%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         2
  filter         -       -    0.0%  (score == utility)
@@ -115,7 +115,7 @@ compact         1     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         1   256 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   42.9%  (score == hit-rate)
- tcache         2   1.3 K   66.7%  (score == hit-rate)
+ tcache         2   1.4 K   66.7%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         2
  filter         -       -    0.0%  (score == utility)
@@ -145,7 +145,7 @@ compact         1     0 B     0 B       0          (size == estimated-debt, scor
 zmemtbl         1   256 K
    ztbl         1   770 B
  bcache         4   697 B   42.9%  (score == hit-rate)
- tcache         1   680 B   66.7%  (score == hit-rate)
+ tcache         1   696 B   66.7%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         1
  filter         -       -    0.0%  (score == utility)


### PR DESCRIPTION
A context is accepted when constructing an Iterator by the new
{DB,Batch,Snapshot}.NewIteratorWithContext methods and
Iterator.CloneWithContext. The context is plumbed to optionally
trace some block reads.

Informs #2055