### PR TITLE
Add support for NetBSD

### DIFF
--- a/vfs/disk_usage_unix.go
+++ b/vfs/disk_usage_unix.go
@@ -2,16 +2,16 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-//go:build darwin || openbsd || dragonfly || freebsd
-// +build darwin openbsd dragonfly freebsd
+//go:build darwin || openbsd || dragonfly || freebsd || netbsd
+// +build darwin openbsd dragonfly freebsd netbsd
 
 package vfs
 
 import "golang.org/x/sys/unix"
 
 func (defaultFS) GetDiskUsage(path string) (DiskUsage, error) {
-	stat := unix.Statfs_t{}
-	if err := unix.Statfs(path, &stat); err != nil {
+	stat := unix.Statvfs_t{}
+	if err := unix.Statvfs(path, &stat); err != nil {
 		return DiskUsage{}, err
 	}
 

--- a/vfs/errors_unix.go
+++ b/vfs/errors_unix.go
@@ -2,8 +2,8 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-//go:build darwin || dragonfly || freebsd || linux || openbsd
-// +build darwin dragonfly freebsd linux openbsd
+//go:build darwin || dragonfly || freebsd || linux || openbsd || netbsd
+// +build darwin dragonfly freebsd linux openbsd netbsd
 
 package vfs
 

--- a/vfs/errors_unix_test.go
+++ b/vfs/errors_unix_test.go
@@ -2,8 +2,8 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-//go:build darwin || dragonfly || freebsd || linux || openbsd
-// +build darwin dragonfly freebsd linux openbsd
+//go:build darwin || dragonfly || freebsd || linux || openbsd || netbsd
+// +build darwin dragonfly freebsd linux openbsd netbsd
 
 package vfs
 


### PR DESCRIPTION
This PR mostly mechanically adds `netbsd` to the list of platform supported by pebble.

NetBSD do not have `statfs(2)` and is neither POSIX so it also switches most Unix-es to use `unix.Statvfs()` (instead of `unix.Statfs()`) that is also defined as part of POSIX.

With these commits all tests seems to pass too (on NetBSD/amd64 9.99.98):

```
$ gmake test
go test -tags 'invariants'  -run . ./...
ok      github.com/cockroachdb/pebble   67.269s
ok      github.com/cockroachdb/pebble/bloom     0.060s
ok      github.com/cockroachdb/pebble/cmd/pebble        0.020s
?       github.com/cockroachdb/pebble/internal/ackseq   [no test files]
ok      github.com/cockroachdb/pebble/internal/arenaskl 0.332s
ok      github.com/cockroachdb/pebble/internal/base     0.078s
ok      github.com/cockroachdb/pebble/internal/batchskl 0.209s
?       github.com/cockroachdb/pebble/internal/bytealloc        [no test files]
ok      github.com/cockroachdb/pebble/internal/cache    3.728s
?       github.com/cockroachdb/pebble/internal/crc      [no test files]
?       github.com/cockroachdb/pebble/internal/datatest [no test files]
?       github.com/cockroachdb/pebble/internal/errorfs  [no test files]
ok      github.com/cockroachdb/pebble/internal/fastrand 0.006s [no tests to run]
?       github.com/cockroachdb/pebble/internal/humanize [no test files]
ok      github.com/cockroachdb/pebble/internal/intern   0.006s
?       github.com/cockroachdb/pebble/internal/invariants       [no test files]
ok      github.com/cockroachdb/pebble/internal/keyspan  4.026s
ok      github.com/cockroachdb/pebble/internal/lint     124.575s
ok      github.com/cockroachdb/pebble/internal/manifest 115.133s
?       github.com/cockroachdb/pebble/internal/manual   [no test files]
ok      github.com/cockroachdb/pebble/internal/metamorphic      47.035s
ok      github.com/cockroachdb/pebble/internal/metamorphic/crossversion 0.024s
ok      github.com/cockroachdb/pebble/internal/mkbench  0.588s
?       github.com/cockroachdb/pebble/internal/pacertoy/pebble  [no test files]
?       github.com/cockroachdb/pebble/internal/pacertoy/rocksdb [no test files]
?       github.com/cockroachdb/pebble/internal/private  [no test files]
ok      github.com/cockroachdb/pebble/internal/randvar  5.895s
?       github.com/cockroachdb/pebble/internal/rangedel [no test files]
ok      github.com/cockroachdb/pebble/internal/rangekey 0.412s
ok      github.com/cockroachdb/pebble/internal/rate     0.324s
ok      github.com/cockroachdb/pebble/internal/rawalloc 0.005s [no tests to run]
ok      github.com/cockroachdb/pebble/internal/testkeys 0.901s
ok      github.com/cockroachdb/pebble/objstorage        0.013s
?       github.com/cockroachdb/pebble/objstorage/shared [no test files]
ok      github.com/cockroachdb/pebble/objstorage/sharedobjcat   2.991s
?       github.com/cockroachdb/pebble/rangekey  [no test files]
ok      github.com/cockroachdb/pebble/record    22.766s
ok      github.com/cockroachdb/pebble/replay    15.466s
ok      github.com/cockroachdb/pebble/sstable   42.445s
ok      github.com/cockroachdb/pebble/tool      0.539s
ok      github.com/cockroachdb/pebble/tool/logs 0.028s
ok      github.com/cockroachdb/pebble/vfs       6.717s
ok      github.com/cockroachdb/pebble/vfs/atomicfs      0.014s
```
