### PR TITLE
record: fix TestSyncRecordWithSignalChan flake

### DIFF
--- a/record/log_writer_test.go
+++ b/record/log_writer_test.go
@@ -218,7 +218,11 @@ func TestSyncRecordWithSignalChan(t *testing.T) {
 		require.NoError(t, err)
 		syncWG.Wait()
 		require.NoError(t, syncErr)
-		require.Equal(t, cap(semChan)-(i+1), len(semChan))
+		// The waitgroup is released before the channel is read, so wait if
+		// necessary.
+		require.Eventually(t, func() bool {
+			return cap(semChan)-(i+1) == len(semChan)
+		}, 10*time.Second, time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
SyncRecord first releases the waitgroup, then reads from the channel. To avoid this race, we retry for a while in the test.

Fixes #2324