### PR TITLE
db: wait for compactions in scan step

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3207,7 +3207,7 @@ func (d *DB) scanObsoleteFiles(list []string) {
 	d.opts.DisableAutomaticCompactions = true
 
 	// Wait for any ongoing compaction to complete before continuing.
-	if d.mu.compact.compactingCount > 0 || d.mu.compact.flushing {
+	for d.mu.compact.compactingCount > 0 || d.mu.compact.flushing {
 		d.mu.compact.cond.Wait()
 	}
 


### PR DESCRIPTION
If we're waiting on a condition variable, then we must check that the condition is met after reacquiring the mutex.