### PR TITLE
db: add SetCreatorID

### DIFF
--- a/db.go
+++ b/db.go
@@ -2287,3 +2287,16 @@ func firstError(err0, err1 error) error {
 	}
 	return err1
 }
+
+// SetCreatorID sets the CreatorID which is needed in order to use shared objects.
+// Shared object usage is disabled until this method is called the first time.
+// Once set, the Creator ID is persisted and cannot change.
+//
+// Does nothing if SharedStorage was not set in the options when the DB was
+// opened or if the DB is in read-only mode.
+func (d *DB) SetCreatorID(creatorID uint64) error {
+	if d.opts.Experimental.SharedStorage == nil || d.opts.ReadOnly {
+		return nil
+	}
+	return d.objProvider.SetCreatorID(objstorage.CreatorID(creatorID))
+}

--- a/objstorage/provider_test.go
+++ b/objstorage/provider_test.go
@@ -52,11 +52,13 @@ func TestProvider(t *testing.T) {
 			st := DefaultSettings(fs, fsDir)
 			if creatorID != 0 {
 				st.Shared.Storage = sharedStore
-				st.Shared.CreatorID = creatorID
 			}
 			require.NoError(t, fs.MkdirAll(fsDir, 0755))
 			provider, err := Open(st)
 			require.NoError(t, err)
+			if creatorID != 0 {
+				require.NoError(t, provider.SetCreatorID(creatorID))
+			}
 			providers[fsDir] = provider
 			curProvider = provider
 

--- a/objstorage/shared.go
+++ b/objstorage/shared.go
@@ -6,29 +6,49 @@ package objstorage
 
 import (
 	"fmt"
+	"sync"
+	"sync/atomic"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/objstorage/sharedobjcat"
 )
 
-// sharedInit initializes the shared object subsystem and finds any shared
-// objects.
+// sharedSubsystem contains the provider fields related to shared storage.
+// All fields remain unset if shared storage is not configured.
+type sharedSubsystem struct {
+	catalog *sharedobjcat.Catalog
+	// initialized guards access to the creatorID field.
+	initialized atomic.Bool
+	creatorID   CreatorID
+	initOnce    sync.Once
+}
+
+func (ss *sharedSubsystem) init(creatorID CreatorID) {
+	ss.initOnce.Do(func() {
+		ss.creatorID = creatorID
+		ss.initialized.Store(true)
+	})
+}
+
+// sharedInit initializes the shared object subsystem (if configured) and finds
+// any shared objects.
 func (p *Provider) sharedInit() error {
+	if p.st.Shared.Storage == nil {
+		return nil
+	}
 	catalog, contents, err := sharedobjcat.Open(p.st.FS, p.st.FSDirName)
 	if err != nil {
 		return errors.Wrapf(err, "pebble: could not open shared object catalog")
 	}
 	p.shared.catalog = catalog
-	// The creator ID may or may not be initialized yet.
-	p.shared.creatorID = contents.CreatorID
 
-	if p.st.Shared.CreatorID.IsSet() {
-		if err := catalog.SetCreatorID(p.st.Shared.CreatorID); err != nil {
-			catalog.Close()
-			return err
-		}
-		p.shared.creatorID = p.st.Shared.CreatorID
+	// The creator ID may or may not be initialized yet.
+	if contents.CreatorID.IsSet() {
+		p.shared.init(contents.CreatorID)
+		p.st.Logger.Infof("shared storage configured; creatorID = %s", contents.CreatorID)
+	} else {
+		p.st.Logger.Infof("shared storage configured; no creatorID yet")
 	}
 
 	for _, meta := range contents.Objects {
@@ -39,6 +59,37 @@ func (p *Provider) sharedInit() error {
 		o.Shared.CreatorID = meta.CreatorID
 		o.Shared.CreatorFileNum = meta.CreatorFileNum
 		p.mu.knownObjects[o.FileNum] = o
+	}
+	return nil
+}
+
+// SetCreatorID sets the CreatorID which is needed in order to use shared
+// objects. Shared object usage is disabled until this method is called the
+// first time. Once set, the Creator ID is persisted and cannot change.
+//
+// Cannot be called if shared storage is not configured for the provider.
+func (p *Provider) SetCreatorID(creatorID CreatorID) error {
+	if p.st.Shared.Storage == nil {
+		return errors.AssertionFailedf("attempt to set CreatorID but shared storage not enabled")
+	}
+	// Note: this call is a cheap no-op if the creator ID was already set. This
+	// call also checks if we are trying to change the ID.
+	if err := p.shared.catalog.SetCreatorID(creatorID); err != nil {
+		return err
+	}
+	if !p.shared.initialized.Load() {
+		p.st.Logger.Infof("shared storage creatorID set to %s", creatorID)
+		p.shared.init(creatorID)
+	}
+	return nil
+}
+
+func (p *Provider) sharedCheckInitialized() error {
+	if p.st.Shared.Storage == nil {
+		return errors.Errorf("shared object support not configured")
+	}
+	if !p.shared.initialized.Load() {
+		return errors.Errorf("shared object support not available: shared creator ID not yet set")
 	}
 	return nil
 }
@@ -84,8 +135,8 @@ func sharedObjectName(meta ObjectMetadata) string {
 func (p *Provider) sharedCreate(
 	fileType base.FileType, fileNum base.FileNum,
 ) (Writable, ObjectMetadata, error) {
-	if !p.shared.creatorID.IsSet() {
-		return nil, ObjectMetadata{}, errors.Errorf("creator ID not set; shared object creation not possible")
+	if err := p.sharedCheckInitialized(); err != nil {
+		return nil, ObjectMetadata{}, err
 	}
 	meta := ObjectMetadata{
 		FileNum:  fileNum,
@@ -105,6 +156,9 @@ func (p *Provider) sharedCreate(
 }
 
 func (p *Provider) sharedOpenForReading(meta ObjectMetadata) (Readable, error) {
+	if err := p.sharedCheckInitialized(); err != nil {
+		return nil, err
+	}
 	objName := sharedObjectName(meta)
 	size, err := p.st.Shared.Storage.Size(objName)
 	if err != nil {
@@ -114,6 +168,9 @@ func (p *Provider) sharedOpenForReading(meta ObjectMetadata) (Readable, error) {
 }
 
 func (p *Provider) sharedSize(meta ObjectMetadata) (int64, error) {
+	if err := p.sharedCheckInitialized(); err != nil {
+		return 0, err
+	}
 	objName := sharedObjectName(meta)
 	return p.st.Shared.Storage.Size(objName)
 }

--- a/open.go
+++ b/open.go
@@ -268,8 +268,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		}
 		ls = append(ls, ls2...)
 	}
-
-	d.objProvider, err = objstorage.Open(objstorage.Settings{
+	providerSettings := objstorage.Settings{
 		Logger:              opts.Logger,
 		FS:                  opts.FS,
 		FSDirName:           dirname,
@@ -277,7 +276,10 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		FSCleaner:           opts.Cleaner,
 		NoSyncOnClose:       opts.NoSyncOnClose,
 		BytesPerSync:        opts.BytesPerSync,
-	})
+	}
+	providerSettings.Shared.Storage = opts.Experimental.SharedStorage
+
+	d.objProvider, err = objstorage.Open(providerSettings)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add SetCreatorID method to initialize the shared object creator ID. Update the provider code to tolerate asynchronous initialization of the shared subsystem.