### PR TITLE
objstorage: allow attaching of shared objects

### DIFF
--- a/objstorage/provider.go
+++ b/objstorage/provider.go
@@ -190,8 +190,8 @@ type ObjectMetadata struct {
 type CreatorID = sharedobjcat.CreatorID
 
 // IsShared returns true if the object is on shared storage.
-func (m *ObjectMetadata) IsShared() bool {
-	return m.Shared.CreatorID.IsSet()
+func (meta *ObjectMetadata) IsShared() bool {
+	return meta.Shared.CreatorID.IsSet()
 }
 
 // Open creates the Provider.

--- a/objstorage/shared.go
+++ b/objstorage/shared.go
@@ -75,7 +75,10 @@ func (p *Provider) sharedPath(meta ObjectMetadata) string {
 
 func sharedObjectName(meta ObjectMetadata) string {
 	// TODO(radu): prepend a "shard" value for better distribution within the bucket?
-	return fmt.Sprintf("%s-%s", meta.Shared.CreatorID, base.MakeFilename(meta.FileType, meta.FileNum))
+	return fmt.Sprintf(
+		"%s-%s",
+		meta.Shared.CreatorID, base.MakeFilename(meta.FileType, meta.Shared.CreatorFileNum),
+	)
 }
 
 func (p *Provider) sharedCreate(

--- a/objstorage/shared_backing.go
+++ b/objstorage/shared_backing.go
@@ -1,0 +1,145 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package objstorage
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage/sharedobjcat"
+)
+
+// SharedObjectBacking encodes the metadata necessary to incorporate a shared
+// object into a different Pebble instance.
+type SharedObjectBacking []byte
+
+const (
+	tagCreatorID      = 1
+	tagCreatorFileNum = 2
+
+	// Any new tags that don't have the tagNotSafeToIgnoreMask bit set must be
+	// followed by the length of the data (so they can be skipped).
+
+	// Any new tags that have the tagNotSafeToIgnoreMask bit set cause errors if
+	// they are encountered by earlier code that doesn't know the tag.
+	tagNotSafeToIgnoreMask = 64
+)
+
+// SharedObjectBacking encodes the shared object metadata.
+func (meta *ObjectMetadata) SharedObjectBacking() (SharedObjectBacking, error) {
+	if !meta.IsShared() {
+		return nil, errors.AssertionFailedf("object %s not on shared storage", meta.FileNum)
+	}
+
+	buf := make([]byte, 0, binary.MaxVarintLen64*4)
+	buf = binary.AppendUvarint(buf, tagCreatorID)
+	buf = binary.AppendUvarint(buf, uint64(meta.Shared.CreatorID))
+	buf = binary.AppendUvarint(buf, tagCreatorFileNum)
+	buf = binary.AppendUvarint(buf, uint64(meta.Shared.CreatorFileNum))
+	return buf, nil
+}
+
+// fromSharedObjectBacking decodes the shared object metadata.
+func fromSharedObjectBacking(
+	fileType base.FileType, fileNum base.FileNum, buf SharedObjectBacking,
+) (ObjectMetadata, error) {
+	var creatorID uint64
+	var creatorFileNum uint64
+	br := bytes.NewReader(buf)
+	for {
+		tag, err := binary.ReadUvarint(br)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return ObjectMetadata{}, err
+		}
+		switch tag {
+		case tagCreatorID:
+			creatorID, err = binary.ReadUvarint(br)
+
+		case tagCreatorFileNum:
+			creatorFileNum, err = binary.ReadUvarint(br)
+
+		// TODO(radu): encode file type as well?
+
+		default:
+			// Ignore unknown tags, unless they're not safe to ignore.
+			if tag&tagNotSafeToIgnoreMask != 0 {
+				return ObjectMetadata{}, errors.Newf("unknown tag %d", tag)
+			}
+			var dataLen uint64
+			dataLen, err = binary.ReadUvarint(br)
+			if err == nil {
+				_, err = br.Seek(int64(dataLen), io.SeekCurrent)
+			}
+		}
+		if err != nil {
+			return ObjectMetadata{}, err
+		}
+	}
+	if creatorID == 0 {
+		return ObjectMetadata{}, errors.Newf("shared object backing missing creator ID")
+	}
+	if creatorFileNum == 0 {
+		return ObjectMetadata{}, errors.Newf("shared object backing missing creator file num")
+	}
+	meta := ObjectMetadata{
+		FileNum:  fileNum,
+		FileType: fileType,
+	}
+	meta.Shared.CreatorID = CreatorID(creatorID)
+	meta.Shared.CreatorFileNum = base.FileNum(creatorFileNum)
+	return meta, nil
+}
+
+// SharedObjectToAttach contains the arguments needed to attach an existing shared object.
+type SharedObjectToAttach struct {
+	// FileNum is the file number that will be used to refer to this object (in
+	// the context of this instance).
+	FileNum  base.FileNum
+	FileType base.FileType
+	// Backing contains the metadata for the share dobject backing (normally
+	// generated from a different instance).
+	Backing SharedObjectBacking
+}
+
+// AttachSharedObjects registers existing shared objects with this provider.
+func (p *Provider) AttachSharedObjects(objs []SharedObjectToAttach) ([]ObjectMetadata, error) {
+	metas := make([]ObjectMetadata, len(objs))
+	for i, o := range objs {
+		meta, err := fromSharedObjectBacking(o.FileType, o.FileNum, o.Backing)
+		if err != nil {
+			return nil, err
+		}
+		metas[i] = meta
+	}
+
+	func() {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		for _, meta := range metas {
+			p.mu.shared.catalogBatch.AddObject(sharedobjcat.SharedObjectMetadata{
+				FileNum:        meta.FileNum,
+				FileType:       meta.FileType,
+				CreatorID:      meta.Shared.CreatorID,
+				CreatorFileNum: meta.Shared.CreatorFileNum,
+			})
+		}
+	}()
+	if err := p.sharedSync(); err != nil {
+		return nil, err
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, meta := range metas {
+		p.mu.knownObjects[meta.FileNum] = meta
+	}
+	return metas, nil
+}

--- a/objstorage/shared_backing_test.go
+++ b/objstorage/shared_backing_test.go
@@ -1,0 +1,47 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package objstorage
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSharedObjectBacking(t *testing.T) {
+	meta := ObjectMetadata{
+		FileNum:  1,
+		FileType: base.FileTypeTable,
+	}
+	meta.Shared.CreatorID = 100
+	meta.Shared.CreatorFileNum = 200
+
+	buf, err := meta.SharedObjectBacking()
+	require.NoError(t, err)
+
+	meta1, err := fromSharedObjectBacking(meta.FileType, meta.FileNum, buf)
+	require.NoError(t, err)
+	require.Equal(t, meta, meta1)
+
+	t.Run("unknown-tags", func(t *testing.T) {
+		// Append a tag that is safe to ignore.
+		buf2 := buf
+		buf2 = binary.AppendUvarint(buf2, 13)
+		buf2 = binary.AppendUvarint(buf2, 2)
+		buf2 = append(buf2, 1, 1)
+
+		meta2, err := fromSharedObjectBacking(meta.FileType, meta.FileNum, buf2)
+		require.NoError(t, err)
+		require.Equal(t, meta, meta2)
+
+		buf3 := buf2
+		buf3 = binary.AppendUvarint(buf3, tagNotSafeToIgnoreMask+5)
+		_, err = fromSharedObjectBacking(meta.FileType, meta.FileNum, buf3)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unknown tag")
+	})
+}

--- a/objstorage/testdata/provider
+++ b/objstorage/testdata/provider
@@ -36,8 +36,8 @@ data: obj-one
 
 list
 ----
-p1/000001.sst
-shared://00000000000000000001-000002.sst
+000001 -> p1/000001.sst
+000002 -> shared://00000000000000000001-000002.sst
 
 close
 ----
@@ -54,8 +54,8 @@ open p1 1
 
 list
 ----
-p1/000001.sst
-shared://00000000000000000001-000002.sst
+000001 -> p1/000001.sst
+000002 -> shared://00000000000000000001-000002.sst
 
 close
 ----
@@ -83,3 +83,121 @@ close
 ----
 <local fs> sync: p0
 <local fs> close: p0
+
+open p2 2
+----
+<local fs> mkdir-all: p2 0755
+<local fs> open-dir: p2
+<local fs> open-dir: p2
+<local fs> create: p2/SHARED-CATALOG-000001
+<local fs> sync: p2/SHARED-CATALOG-000001
+<local fs> create: p2/marker.shared-catalog.000001.SHARED-CATALOG-000001
+<local fs> close: p2/marker.shared-catalog.000001.SHARED-CATALOG-000001
+<local fs> sync: p2
+<local fs> sync: p2/SHARED-CATALOG-000001
+
+create 1 shared
+obj-ten
+----
+<shared> create object "00000000000000000002-000001.sst"
+<shared> close writer for "00000000000000000002-000001.sst" after 7 bytes
+
+create 2 shared
+obj-eleven
+----
+<shared> create object "00000000000000000002-000002.sst"
+<shared> close writer for "00000000000000000002-000002.sst" after 10 bytes
+
+create 3 shared
+obj-eleven
+----
+<shared> create object "00000000000000000002-000003.sst"
+<shared> close writer for "00000000000000000002-000003.sst" after 10 bytes
+
+create 100 local
+obj-one
+----
+<local fs> create: p2/000100.sst
+<local fs> sync-data: p2/000100.sst
+<local fs> close: p2/000100.sst
+
+
+list
+----
+000001 -> shared://00000000000000000002-000001.sst
+000002 -> shared://00000000000000000002-000002.sst
+000003 -> shared://00000000000000000002-000003.sst
+000100 -> p2/000100.sst
+
+# Can't get backing of local object.
+save-backing foo 100
+----
+object 000100 not on shared storage
+
+save-backing b1 1
+----
+
+save-backing b2 2
+----
+
+save-backing b3 3
+----
+
+close
+----
+<local fs> sync: p2
+<local fs> sync: p2/SHARED-CATALOG-000001
+<local fs> close: p2
+
+open p3 3
+----
+<local fs> mkdir-all: p3 0755
+<local fs> open-dir: p3
+<local fs> open-dir: p3
+<local fs> create: p3/SHARED-CATALOG-000001
+<local fs> sync: p3/SHARED-CATALOG-000001
+<local fs> create: p3/marker.shared-catalog.000001.SHARED-CATALOG-000001
+<local fs> close: p3/marker.shared-catalog.000001.SHARED-CATALOG-000001
+<local fs> sync: p3
+<local fs> sync: p3/SHARED-CATALOG-000001
+
+create 100 shared
+obj-one-hundred
+----
+<shared> create object "00000000000000000003-000100.sst"
+<shared> close writer for "00000000000000000003-000100.sst" after 15 bytes
+
+attach
+b1 101
+b2 102
+b3 103
+----
+<local fs> sync: p3/SHARED-CATALOG-000001
+000101 -> shared://00000000000000000002-000001.sst
+000102 -> shared://00000000000000000002-000002.sst
+000103 -> shared://00000000000000000002-000003.sst
+
+list
+----
+000100 -> shared://00000000000000000003-000100.sst
+000101 -> shared://00000000000000000002-000001.sst
+000102 -> shared://00000000000000000002-000002.sst
+000103 -> shared://00000000000000000002-000003.sst
+
+read 101
+----
+<shared> size of object "00000000000000000002-000001.sst": 7
+<shared> read object "00000000000000000002-000001.sst" at 0: 7 bytes
+data: obj-ten
+
+read 102
+----
+<shared> size of object "00000000000000000002-000002.sst": 10
+<shared> read object "00000000000000000002-000002.sst" at 0: 10 bytes
+data: obj-eleven
+
+read 103
+----
+<shared> size of object "00000000000000000002-000003.sst": 10
+<shared> read object "00000000000000000002-000003.sst" at 0: 10 bytes
+data: obj-eleven


### PR DESCRIPTION
This commit introduces the concept of a `SharedObjectBacking`. This is an opaque encoding of the metadata necessary to access a shared object (specifically creator ID and creator file num). The backing can be extracted for a shared object on an instance and then used to attach the object to another instance. This will be used for rebalancing.