### PR TITLE
db: don't recycle tiny log files

### DIFF
--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -33,6 +33,7 @@ func TestCheckpoint(t *testing.T) {
 		FormatMajorVersion:    FormatNewest,
 		L0CompactionThreshold: 10,
 	}
+	opts.private.minLogSizeRecycler = 1
 
 	datadriven.RunTest(t, "testdata/checkpoint", func(t *testing.T, td *datadriven.TestData) string {
 		switch td.Cmd {

--- a/cleaner_test.go
+++ b/cleaner_test.go
@@ -96,6 +96,7 @@ func TestCleaner(t *testing.T) {
 				FS:     fs,
 				WALDir: dir + "_wal",
 			}).WithFSDefaults()
+			opts.private.minLogSizeRecycler = 1
 
 			for i := 1; i < len(td.CmdArgs); i++ {
 				switch td.CmdArgs[i].String() {

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -47,6 +47,7 @@ func TestEventListener(t *testing.T) {
 			// can make these tests flaky. The TableStatsLoaded event is
 			// tested separately in TestTableStats.
 			opts.private.disableTableStats = true
+			opts.private.minLogSizeRecycler = 1
 			var err error
 			d, err = Open("db", opts)
 			if err != nil {

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -438,6 +438,7 @@ func TestOverlappingIngestedSSTs(t *testing.T) {
 		// delete-only compactions triggered by ingesting range tombstones.
 		opts.DisableAutomaticCompactions = true
 		opts.Experimental.IngestSSTablesAsFlushable = true
+		opts.private.minLogSizeRecycler = 1
 
 		var err error
 		d, err = Open(dir, opts)

--- a/log_recycler.go
+++ b/log_recycler.go
@@ -13,6 +13,8 @@ import (
 type logRecycler struct {
 	// The maximum number of log files to maintain for recycling.
 	limit int
+	// The minimum size of a log which can be recycled.
+	minLogSize int
 
 	// The minimum log number that is allowed to be recycled. Log numbers smaller
 	// than this will be subject to immediate deletion. This is used to prevent
@@ -32,7 +34,8 @@ type logRecycler struct {
 // the log file should not be deleted (i.e. the log is being recycled), and
 // false otherwise.
 func (r *logRecycler) add(logInfo fileInfo) bool {
-	if logInfo.fileNum < r.minRecycleLogNum {
+	if logInfo.fileNum < r.minRecycleLogNum ||
+		logInfo.fileSize < uint64(r.minLogSize) {
 		return false
 	}
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -113,6 +113,7 @@ func TestMetrics(t *testing.T) {
 	}
 	opts.Experimental.EnableValueBlocks = func() bool { return true }
 	opts.Levels = append(opts.Levels, LevelOptions{TargetFileSize: 50})
+	opts.private.minLogSizeRecycler = 1
 
 	// Prevent foreground flushes and compactions from triggering asynchronous
 	// follow-up compactions. This avoids asynchronously-scheduled work from

--- a/open.go
+++ b/open.go
@@ -144,9 +144,12 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		fileLock:            fileLock,
 		dataDir:             dataDir,
 		walDir:              walDir,
-		logRecycler:         logRecycler{limit: opts.MemTableStopWritesThreshold + 1},
-		closed:              new(atomic.Value),
-		closedCh:            make(chan struct{}),
+		logRecycler: logRecycler{
+			limit:      opts.MemTableStopWritesThreshold + 1,
+			minLogSize: opts.private.minLogSizeRecycler,
+		},
+		closed:   new(atomic.Value),
+		closedCh: make(chan struct{}),
 	}
 	d.mu.versions = &versionSet{}
 	d.atomic.diskAvailBytes = math.MaxUint64

--- a/replay/testdata/corpus/findManifestStart
+++ b/replay/testdata/corpus/findManifestStart
@@ -57,7 +57,6 @@ flush
 list-files build
 ----
 build:
-  000002.log
   000004.log
   000005.sst
   CURRENT

--- a/replay/testdata/corpus/high_read_amp
+++ b/replay/testdata/corpus/high_read_amp
@@ -69,7 +69,6 @@ list-files build
 ----
 build:
   000005.sst
-  000006.log
   000007.sst
   000009.log
   000010.sst

--- a/replay/testdata/corpus/simple
+++ b/replay/testdata/corpus/simple
@@ -24,7 +24,6 @@ flush
 list-files build
 ----
 build:
-  000002.log
   000004.log
   000005.sst
   CURRENT

--- a/replay/testdata/replay
+++ b/replay/testdata/replay
@@ -5,9 +5,8 @@ tree
 ----
           /
             build/
-      89      000004.log
      795      000005.sst
-      49      000006.log
+      11      000006.log
      823      000007.sst
       16      CURRENT
        0      LOCK

--- a/replay/testdata/replay_paced
+++ b/replay/testdata/replay_paced
@@ -7,9 +7,8 @@ tree
             build/
     1073      000005.sst
      769      000007.sst
-      89      000009.log
      769      000010.sst
-     200      000012.log
+      11      000012.log
      823      000013.sst
       16      CURRENT
        0      LOCK
@@ -24,7 +23,7 @@ tree
               checkpoint/
     1073        000005.sst
      769        000007.sst
-      39        000009.log
+      25        000009.log
      769        000010.sst
      157        MANIFEST-000011
     1145        OPTIONS-000003

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -936,10 +936,12 @@ func TestTableCacheNoSuchFileError(t *testing.T) {
 	mem := vfs.NewMem()
 	logger := &catchFatalLogger{}
 
-	d, err := Open(dirname, &Options{
+	opts := &Options{
 		FS:     mem,
 		Logger: logger,
-	})
+	}
+	opts.private.minLogSizeRecycler = 1
+	d, err := Open(dirname, opts)
 	require.NoError(t, err)
 	defer func() { _ = d.Close() }()
 	require.NoError(t, d.Set([]byte("a"), []byte("val_a"), nil))


### PR DESCRIPTION
Flushable ingests can produce tiny log files and we shouldn't try and recycle these as there's a limit on the number of log files which are recycled and we want the limit to be used for larger log files.