### PR TITLE
objstorage: better Writable API

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -430,15 +430,14 @@ type compactionWritable struct {
 }
 
 // Write is part of the objstorage.Writable interface.
-func (c *compactionWritable) Write(p []byte) (n int, err error) {
-	n, err = c.Writable.Write(p)
-	if err != nil {
-		return n, err
+func (c *compactionWritable) Write(p []byte) error {
+	if err := c.Writable.Write(p); err != nil {
+		return err
 	}
 
-	*c.written += int64(n)
-	c.versions.incrementCompactionBytes(int64(n))
-	return n, err
+	*c.written += int64(len(p))
+	c.versions.incrementCompactionBytes(int64(len(p)))
+	return nil
 }
 
 type compactionKind int

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2920,7 +2920,7 @@ func TestCompactionErrorCleanup(t *testing.T) {
 		f, err := mem.Create("ext")
 		require.NoError(t, err)
 
-		w := sstable.NewWriter(f, sstable.WriterOptions{
+		w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{
 			TableFormat: d.FormatMajorVersion().MaxTableFormat(),
 		})
 		for _, k := range keys {
@@ -3835,7 +3835,7 @@ func TestCompaction_LogAndApplyFails(t *testing.T) {
 		const fName = "ext"
 		f, err := db.opts.FS.Create(fName)
 		require.NoError(t, err)
-		w := sstable.NewWriter(f, sstable.WriterOptions{})
+		w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{})
 		require.NoError(t, w.Set(key, nil))
 		require.NoError(t, w.Close())
 		// Ingest the SST.

--- a/data_test.go
+++ b/data_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/rangedel"
 	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -628,7 +629,7 @@ func runBuildCmd(td *datadriven.TestData, d *DB, fs vfs.FS) error {
 	if err != nil {
 		return err
 	}
-	w := sstable.NewWriter(f, writeOpts)
+	w := sstable.NewWriter(objstorage.NewFileWritable(f), writeOpts)
 	iter := b.newInternalIter(nil)
 	for key, val := iter.First(); key != nil; key, val = iter.Next() {
 		tmp := *key

--- a/db_test.go
+++ b/db_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -1156,7 +1157,7 @@ func TestDBConcurrentCompactClose(t *testing.T) {
 			path := fmt.Sprintf("ext%d", j)
 			f, err := mem.Create(path)
 			require.NoError(t, err)
-			w := sstable.NewWriter(f, sstable.WriterOptions{
+			w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{
 				TableFormat: d.FormatMajorVersion().MaxTableFormat(),
 			})
 			require.NoError(t, w.Set([]byte(fmt.Sprint(j)), nil))

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/redact"
@@ -120,7 +121,7 @@ func TestEventListener(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			w := sstable.NewWriter(f, sstable.WriterOptions{
+			w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{
 				TableFormat: d.FormatMajorVersion().MaxTableFormat(),
 			})
 			if err := w.Add(base.MakeInternalKey([]byte("a"), 0, InternalKeyKindSet), nil); err != nil {

--- a/external_iterator_test.go
+++ b/external_iterator_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -185,7 +186,7 @@ func TestIterRandomizedMaybeFilteredKeys(t *testing.T) {
 			if twoLevelIndex {
 				indexBlockSize = 1
 			}
-			w := sstable.NewWriter(f0, sstable.WriterOptions{
+			w := sstable.NewWriter(objstorage.NewFileWritable(f0), sstable.WriterOptions{
 				BlockSize:      blockSize,
 				Comparer:       testkeys.Comparer,
 				IndexBlockSize: indexBlockSize,
@@ -330,7 +331,7 @@ func BenchmarkExternalIter_NonOverlapping_SeekNextScan(b *testing.B) {
 						filename := fmt.Sprintf("%03d.sst", i)
 						wf, err := fs.Create(filename)
 						require.NoError(b, err)
-						w := sstable.NewWriter(wf, writeOpts)
+						w := sstable.NewWriter(objstorage.NewFileWritable(wf), writeOpts)
 						for j := 0; j < keyCount/fileCount; j++ {
 							key := testkeys.Key(ks, len(keys))
 							keys = append(keys, key)

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -110,7 +110,9 @@ func TestIngestLoad(t *testing.T) {
 					return err.Error()
 				}
 			}
-			w.Close()
+			if err := w.Close(); err != nil {
+				return err.Error()
+			}
 
 			opts := (&Options{
 				Comparer: DefaultComparer,

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -88,7 +88,7 @@ func TestIngestLoad(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			w := sstable.NewWriter(f, writerOpts)
+			w := sstable.NewWriter(objstorage.NewFileWritable(f), writerOpts)
 			for _, data := range strings.Split(td.Input, "\n") {
 				if strings.HasPrefix(data, "rangekey: ") {
 					data = strings.TrimPrefix(data, "rangekey: ")
@@ -178,7 +178,7 @@ func TestIngestLoadRand(t *testing.T) {
 
 			expected[i].ExtendPointKeyBounds(cmp, keys[0], keys[len(keys)-1])
 
-			w := sstable.NewWriter(f, sstable.WriterOptions{
+			w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{
 				TableFormat: version.MaxTableFormat(),
 			})
 			var count uint64
@@ -689,7 +689,7 @@ func BenchmarkIngestOverlappingMemtable(b *testing.B) {
 				// Create the overlapping sstable that will force a flush when ingested.
 				f, err := mem.Create("ext")
 				assertNoError(err)
-				w := sstable.NewWriter(f, sstable.WriterOptions{})
+				w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{})
 				assertNoError(w.Set([]byte("a"), nil))
 				assertNoError(w.Close())
 
@@ -916,12 +916,12 @@ func TestIngestError(t *testing.T) {
 
 		f0, err := mem.Create("ext0")
 		require.NoError(t, err)
-		w := sstable.NewWriter(f0, sstable.WriterOptions{})
+		w := sstable.NewWriter(objstorage.NewFileWritable(f0), sstable.WriterOptions{})
 		require.NoError(t, w.Set([]byte("d"), nil))
 		require.NoError(t, w.Close())
 		f1, err := mem.Create("ext1")
 		require.NoError(t, err)
-		w = sstable.NewWriter(f1, sstable.WriterOptions{})
+		w = sstable.NewWriter(objstorage.NewFileWritable(f1), sstable.WriterOptions{})
 		require.NoError(t, w.Set([]byte("d"), nil))
 		require.NoError(t, w.Close())
 
@@ -985,7 +985,7 @@ func TestIngestIdempotence(t *testing.T) {
 	path := fs.PathJoin(dir, "ext")
 	f, err := fs.Create(fs.PathJoin(dir, "ext"))
 	require.NoError(t, err)
-	w := sstable.NewWriter(f, sstable.WriterOptions{})
+	w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{})
 	require.NoError(t, w.Set([]byte("d"), nil))
 	require.NoError(t, w.Close())
 
@@ -1019,7 +1019,7 @@ func TestIngestCompact(t *testing.T) {
 	f, err := mem.Create(src(0))
 	require.NoError(t, err)
 
-	w := sstable.NewWriter(f, sstable.WriterOptions{})
+	w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{})
 	key := []byte("a")
 	require.NoError(t, w.Add(base.MakeInternalKey(key, 0, InternalKeyKindSet), nil))
 	require.NoError(t, w.Close())
@@ -1062,7 +1062,7 @@ func TestConcurrentIngest(t *testing.T) {
 	f, err := mem.Create(src(0))
 	require.NoError(t, err)
 
-	w := sstable.NewWriter(f, sstable.WriterOptions{})
+	w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{})
 	require.NoError(t, w.Set([]byte("a"), nil))
 	require.NoError(t, w.Set([]byte("b"), nil))
 	require.NoError(t, w.Close())
@@ -1116,7 +1116,7 @@ func TestConcurrentIngestCompact(t *testing.T) {
 				f, err := mem.Create("ext")
 				require.NoError(t, err)
 
-				w := sstable.NewWriter(f, sstable.WriterOptions{})
+				w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{})
 				for _, k := range keys {
 					require.NoError(t, w.Set([]byte(k), nil))
 				}
@@ -1236,7 +1236,7 @@ func TestIngestFlushQueuedMemTable(t *testing.T) {
 		f, err := mem.Create("ext")
 		require.NoError(t, err)
 
-		w := sstable.NewWriter(f, sstable.WriterOptions{})
+		w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{})
 		for _, k := range keys {
 			require.NoError(t, w.Set([]byte(k), nil))
 		}
@@ -1264,7 +1264,7 @@ func TestIngestStats(t *testing.T) {
 		f, err := mem.Create("ext")
 		require.NoError(t, err)
 
-		w := sstable.NewWriter(f, sstable.WriterOptions{})
+		w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{})
 		for _, k := range keys {
 			require.NoError(t, w.Set([]byte(k), nil))
 		}
@@ -1312,7 +1312,7 @@ func TestIngestFlushQueuedLargeBatch(t *testing.T) {
 		f, err := mem.Create("ext")
 		require.NoError(t, err)
 
-		w := sstable.NewWriter(f, sstable.WriterOptions{})
+		w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{})
 		for _, k := range keys {
 			require.NoError(t, w.Set([]byte(k), nil))
 		}
@@ -1350,7 +1350,7 @@ func TestIngestMemtablePendingOverlap(t *testing.T) {
 		f, err := mem.Create("ext")
 		require.NoError(t, err)
 
-		w := sstable.NewWriter(f, sstable.WriterOptions{})
+		w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{})
 		for _, k := range keys {
 			require.NoError(t, w.Set([]byte(k), nil))
 		}
@@ -1450,7 +1450,7 @@ func TestIngestFileNumReuseCrash(t *testing.T) {
 		name := fmt.Sprintf("ext%d", i)
 		f, err := fs.Create(fs.PathJoin(dir, name))
 		require.NoError(t, err)
-		w := sstable.NewWriter(f, sstable.WriterOptions{})
+		w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{})
 		require.NoError(t, w.Set([]byte(fmt.Sprintf("foo%d", i)), nil))
 		require.NoError(t, w.Close())
 		files = append(files, name)
@@ -1512,7 +1512,7 @@ func TestIngest_UpdateSequenceNumber(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
-		w := sstable.NewWriter(f, sstable.WriterOptions{
+		w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{
 			TableFormat: sstable.TableFormatMax,
 		})
 		for _, data := range strings.Split(input, "\n") {
@@ -1694,7 +1694,7 @@ func TestIngestCleanup(t *testing.T) {
 				if !ok {
 					continue
 				}
-				require.NoError(t, w.Close())
+				require.NoError(t, w.Finish())
 			}
 
 			// Cleanup the set of files in the FS.
@@ -1858,7 +1858,7 @@ func TestIngestValidation(t *testing.T) {
 				require.NoError(t, err)
 				defer func() { _ = tmpFS.Remove(ingestTableName) }()
 
-				w := sstable.NewWriter(f, sstable.WriterOptions{
+				w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{
 					BlockSize:   blockSize,     // Create many smaller blocks.
 					Compression: NoCompression, // For simpler debugging.
 				})
@@ -1960,7 +1960,7 @@ func BenchmarkManySSTables(b *testing.B) {
 						n := fmt.Sprintf("%07d", i)
 						f, err := mem.Create(n)
 						require.NoError(b, err)
-						w := sstable.NewWriter(f, sstable.WriterOptions{})
+						w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{})
 						require.NoError(b, w.Set([]byte(n), nil))
 						require.NoError(b, w.Close())
 						paths = append(paths, n)
@@ -1971,7 +1971,7 @@ func BenchmarkManySSTables(b *testing.B) {
 						const broadIngest = "broad.sst"
 						f, err := mem.Create(broadIngest)
 						require.NoError(b, err)
-						w := sstable.NewWriter(f, sstable.WriterOptions{})
+						w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{})
 						require.NoError(b, w.Set([]byte("0"), nil))
 						require.NoError(b, w.Set([]byte("Z"), nil))
 						require.NoError(b, w.Close())
@@ -1997,7 +1997,7 @@ func runBenchmarkManySSTablesIngest(b *testing.B, d *DB, fs vfs.FS, count int) {
 		n := fmt.Sprintf("%07d", count+i)
 		f, err := fs.Create(n)
 		require.NoError(b, err)
-		w := sstable.NewWriter(f, sstable.WriterOptions{})
+		w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{})
 		require.NoError(b, w.Set([]byte(n), nil))
 		require.NoError(b, w.Close())
 		require.NoError(b, d.Ingest([]string{n}))

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/errorfs"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/private"
+	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -462,7 +463,10 @@ func (o *ingestOp) build(t *test, h historyRecorder, b *pebble.Batch, i int) (st
 
 	equal := t.opts.Comparer.Equal
 	tableFormat := t.db.FormatMajorVersion().MaxTableFormat()
-	w := sstable.NewWriter(f, t.opts.MakeWriterOptions(0, tableFormat))
+	w := sstable.NewWriter(
+		objstorage.NewFileWritable(f),
+		t.opts.MakeWriterOptions(0, tableFormat),
+	)
 
 	var lastUserKey []byte
 	for key, value := iter.First(); key != nil; key, value = iter.Next() {

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -3068,7 +3069,7 @@ func BenchmarkSeekPrefixTombstones(b *testing.B) {
 			filename := fmt.Sprintf("ext%2d", i)
 			f, err := o.FS.Create(filename)
 			require.NoError(b, err)
-			w := sstable.NewWriter(f, wOpts)
+			w := sstable.NewWriter(objstorage.NewFileWritable(f), wOpts)
 			require.NoError(b, w.DeleteRange(testkeys.Key(ks, i), testkeys.Key(ks, i+1)))
 			require.NoError(b, w.Close())
 			require.NoError(b, d.Ingest([]string{filename}))

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/private"
 	"github.com/cockroachdb/pebble/internal/rangedel"
+	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -151,7 +152,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 					return err.Error()
 				}
 				writeUnfragmented := false
-				w := sstable.NewWriter(f, sstable.WriterOptions{})
+				w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{})
 				for _, arg := range d.CmdArgs {
 					switch arg.Key {
 					case "disable-key-order-checks":

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/rangedel"
+	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -203,7 +204,7 @@ func (lt *levelIterTest) runBuild(d *datadriven.TestData) string {
 		}
 	}
 	fp := bloom.FilterPolicy(10)
-	w := sstable.NewWriter(f0, sstable.WriterOptions{
+	w := sstable.NewWriter(objstorage.NewFileWritable(f0), sstable.WriterOptions{
 		Comparer:     &lt.cmp,
 		FilterPolicy: fp,
 		TableFormat:  tableFormat,
@@ -453,7 +454,7 @@ func buildLevelIterTables(
 
 	writers := make([]*sstable.Writer, len(files))
 	for i := range files {
-		writers[i] = sstable.NewWriter(files[i], sstable.WriterOptions{
+		writers[i] = sstable.NewWriter(objstorage.NewFileWritable(files[i]), sstable.WriterOptions{
 			BlockRestartInterval: restartInterval,
 			BlockSize:            blockSize,
 			Compression:          NoCompression,

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/rangedel"
+	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -198,7 +199,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 				if err != nil {
 					return err.Error()
 				}
-				w := sstable.NewWriter(f, sstable.WriterOptions{})
+				w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{})
 				var tombstones []keyspan.Span
 				frag := keyspan.Fragmenter{
 					Cmp:    cmp,
@@ -289,7 +290,7 @@ func buildMergingIterTables(
 
 	writers := make([]*sstable.Writer, len(files))
 	for i := range files {
-		writers[i] = sstable.NewWriter(files[i], sstable.WriterOptions{
+		writers[i] = sstable.NewWriter(objstorage.NewFileWritable(files[i]), sstable.WriterOptions{
 			BlockRestartInterval: restartInterval,
 			BlockSize:            blockSize,
 			Compression:          NoCompression,
@@ -516,7 +517,7 @@ func buildLevelsForMergingIterSeqSeek(
 					writerOptions.IndexBlockSize = 1
 				}
 			}
-			writers[i] = append(writers[i], sstable.NewWriter(files[i][j], writerOptions))
+			writers[i] = append(writers[i], sstable.NewWriter(objstorage.NewFileWritable(files[i][j]), writerOptions))
 		}
 	}
 

--- a/objstorage/provider_test.go
+++ b/objstorage/provider_test.go
@@ -88,10 +88,8 @@ func TestProvider(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			_, err = w.Write([]byte(d.Input))
-			require.NoError(t, err)
-			require.NoError(t, w.Sync())
-			require.NoError(t, w.Close())
+			require.NoError(t, w.Write([]byte(d.Input)))
+			require.NoError(t, w.Finish())
 
 			return log.String()
 
@@ -175,10 +173,8 @@ func TestNotExistError(t *testing.T) {
 
 	w, _, err := provider.Create(base.FileTypeTable, 1, CreateOptions{})
 	require.NoError(t, err)
-	_, err = w.Write([]byte("foo"))
-	require.NoError(t, err)
-	require.NoError(t, w.Sync())
-	require.NoError(t, w.Close())
+	require.NoError(t, w.Write([]byte("foo")))
+	require.NoError(t, w.Finish())
 
 	// Remove the underlying file.
 	require.NoError(t, fs.Remove(base.MakeFilename(base.FileTypeTable, 1)))

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -616,7 +617,7 @@ func benchmarkRangeDelIterate(b *testing.B, entries, deleted int, snapshotCompac
 	if err != nil {
 		b.Fatal(err)
 	}
-	w := sstable.NewWriter(f, sstable.WriterOptions{
+	w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{
 		BlockSize: 32 << 10, // 32 KB
 	})
 	for i := 0; i < entries; i++ {

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -525,7 +525,7 @@ func TestReaderCheckComparerMerger(t *testing.T) {
 	f0, err := mem.Create(testTable)
 	require.NoError(t, err)
 
-	w := NewWriter(f0, writerOpts)
+	w := NewWriter(objstorage.NewFileWritable(f0), writerOpts)
 	require.NoError(t, w.Set([]byte("test"), nil))
 	require.NoError(t, w.Close())
 
@@ -754,7 +754,7 @@ func TestReaderChecksumErrors(t *testing.T) {
 							indexBlockSize = 1
 						}
 
-						w := NewWriter(f, WriterOptions{
+						w := NewWriter(objstorage.NewFileWritable(f), WriterOptions{
 							BlockSize:      blockSize,
 							IndexBlockSize: indexBlockSize,
 							Checksum:       checksumType,
@@ -1029,7 +1029,7 @@ func TestReader_TableFormat(t *testing.T) {
 		require.NoError(t, err)
 
 		opts := WriterOptions{TableFormat: want}
-		w := NewWriter(f, opts)
+		w := NewWriter(objstorage.NewFileWritable(f), opts)
 		err = w.Close()
 		require.NoError(t, err)
 
@@ -1110,7 +1110,7 @@ func buildBenchmarkTable(
 		b.Fatal(err)
 	}
 
-	w := NewWriter(f0, options)
+	w := NewWriter(objstorage.NewFileWritable(f0), options)
 
 	var keys [][]byte
 	var ikey InternalKey
@@ -1396,7 +1396,7 @@ func BenchmarkIteratorScanManyVersions(b *testing.B) {
 		f0, err := mem.Create("bench")
 		require.NoError(b, err)
 		options.TableFormat = tableFormat
-		w := NewWriter(f0, options)
+		w := NewWriter(objstorage.NewFileWritable(f0), options)
 		val := make([]byte, 100)
 		rng := rand.New(rand.NewSource(100))
 		for i := 0; i < keys.Count(); i++ {
@@ -1496,7 +1496,7 @@ func BenchmarkIteratorScanNextPrefix(b *testing.B) {
 		mem := vfs.NewMem()
 		f0, err := mem.Create("bench")
 		require.NoError(b, err)
-		w := NewWriter(f0, options)
+		w := NewWriter(objstorage.NewFileWritable(f0), options)
 		for i := 0; i < keys.Count(); i++ {
 			for v := 0; v < versCount; v++ {
 				n := testkeys.WriteKeyAt(keyBuf[sharedPrefixLen:], keys, i, versCount-v+1)

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -282,11 +282,11 @@ func rewriteDataBlocksToWriter(
 
 	for i := range blocks {
 		// Write the rewritten block to the file.
-		n, err := w.writable.Write(blocks[i].data)
-		if err != nil {
+		if err := w.writable.Write(blocks[i].data); err != nil {
 			return err
 		}
 
+		n := len(blocks[i].data)
 		bh := BlockHandle{Offset: w.meta.Size, Length: uint64(n) - blockTrailerLen}
 		// Update the overall size.
 		w.meta.Size += uint64(n)
@@ -310,8 +310,8 @@ func rewriteDataBlocksToWriter(
 			}
 		}
 
-		var bhp BlockHandleWithProperties
-		if bhp, err = w.maybeAddBlockPropertiesToBlockHandle(bh); err != nil {
+		bhp, err := w.maybeAddBlockPropertiesToBlockHandle(bh)
+		if err != nil {
 			return err
 		}
 		var nextKey InternalKey

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
@@ -373,7 +374,7 @@ func build(
 		writerOpts.TablePropertyCollectors = append(writerOpts.TablePropertyCollectors, propCollector)
 	}
 
-	w := NewWriter(f0, writerOpts)
+	w := NewWriter(objstorage.NewFileWritable(f0), writerOpts)
 	// Use rangeDelV1Format for testing byte equality with RocksDB.
 	w.rangeDelV1Format = true
 	var rangeDelLength int
@@ -613,7 +614,7 @@ func TestFinalBlockIsWritten(t *testing.T) {
 						t.Errorf("nk=%d, vLen=%d: memFS create: %v", nk, vLen, err)
 						continue
 					}
-					w := NewWriter(wf, WriterOptions{
+					w := NewWriter(objstorage.NewFileWritable(wf), WriterOptions{
 						BlockSize:      blockSize,
 						IndexBlockSize: indexBlockSize,
 					})
@@ -857,7 +858,7 @@ func TestTablePropertyCollectorErrors(t *testing.T) {
 				return errorPropCollector{}
 			})
 
-		w := NewWriter(f, opts)
+		w := NewWriter(objstorage.NewFileWritable(f), opts)
 
 		require.Regexp(t, e, fun(w))
 	}

--- a/sstable/writer_rangekey_test.go
+++ b/sstable/writer_rangekey_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
@@ -32,7 +33,7 @@ func TestWriter_RangeKeys(t *testing.T) {
 		// Use a "suffix-aware" Comparer, that will sort suffix-values in
 		// descending order of timestamp, rather than in lexical order.
 		cmp := testkeys.Comparer
-		w := NewWriter(f, WriterOptions{
+		w := NewWriter(objstorage.NewFileWritable(f), WriterOptions{
 			Comparer:    cmp,
 			TableFormat: TableFormatPebblev2,
 		})

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -153,7 +154,7 @@ func TestTableRangeDeletionIter(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			w := sstable.NewWriter(f, sstable.WriterOptions{
+			w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{
 				TableFormat: sstable.TableFormatMax,
 			})
 			m = &fileMetadata{}

--- a/testdata/ingest_load
+++ b/testdata/ingest_load
@@ -97,7 +97,7 @@ pebble: table format (Pebble,v2) is not within range supported at DB format majo
 
 # Tables with range keys only.
 
-load
+load writer-version=10 db-version=10
 rangekey: a-z:{(#0,RANGEKEYSET,@1,foo)}
 ----
 1: a#0,21-z#72057594037927935,21
@@ -106,7 +106,7 @@ rangekey: a-z:{(#0,RANGEKEYSET,@1,foo)}
 
 # Tables with a mixture of point and range keys.
 
-load
+load writer-version=10 db-version=10
 a.SET.0:
 b.SET.0:
 c.SET.0:
@@ -118,7 +118,7 @@ rangekey: y-z:{(#0,RANGEKEYSET,@3,baz)}
   points: a#0,1-c#0,1
   ranges: w#0,21-z#72057594037927935,21
 
-load
+load writer-version=10 db-version=10
 c.SET.0:d
 rangekey: a-z:{(#0,RANGEKEYSET,@1,foo)}
 ----
@@ -126,7 +126,7 @@ rangekey: a-z:{(#0,RANGEKEYSET,@1,foo)}
   points: c#0,1-c#0,1
   ranges: a#0,21-z#72057594037927935,21
 
-load
+load writer-version=10 db-version=10
 a.SET.0:z
 rangekey: c-d:{(#0,RANGEKEYSET,@1,foo)}
 ----
@@ -136,7 +136,7 @@ rangekey: c-d:{(#0,RANGEKEYSET,@1,foo)}
 
 # NB: range dels sort before range keys
 
-load
+load writer-version=10 db-version=10
 a.RANGEDEL.0:z
 rangekey: a-z:{(#0,RANGEKEYSET,@1,foo)}
 ----

--- a/tool/make_test_find_db.go
+++ b/tool/make_test_find_db.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -96,7 +97,7 @@ func (d *db) ingest(keyVals ...string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	w := sstable.NewWriter(f, sstable.WriterOptions{
+	w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{
 		Comparer:   d.comparer,
 		MergerName: d.merger.Name,
 	})

--- a/tool/make_test_sstables.go
+++ b/tool/make_test_sstables.go
@@ -12,6 +12,7 @@ import (
 	"log"
 
 	"github.com/cockroachdb/pebble/internal/private"
+	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -22,7 +23,7 @@ func makeOutOfOrder() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	w := sstable.NewWriter(f, sstable.WriterOptions{})
+	w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{})
 	private.SSTableWriterDisableKeyOrderChecks(w)
 
 	set := func(key string) {

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -19,7 +20,7 @@ func writeAndIngest(t *testing.T, mem vfs.FS, d *DB, k InternalKey, v []byte, fi
 	path := mem.PathJoin("ext", filename)
 	f, err := mem.Create(path)
 	require.NoError(t, err)
-	w := sstable.NewWriter(f, sstable.WriterOptions{})
+	w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{})
 	require.NoError(t, w.Add(k, v))
 	require.NoError(t, w.Close())
 	require.NoError(t, d.Ingest([]string{path}))


### PR DESCRIPTION
#### db: add missing error check in TestIngestLoad

We weren't checking the error returned from `Close`. It turns out that
some testcases were hitting the error but passing anyway; updating
the directives to set the necessary table version.

#### objstorage: better Writable API

Improve the writable API to more closely match its actual usage.
Simplify `Write` to not return a length, and replace `Sync` and
`Close` with `Finish` and `Abort`.

`vfs.File` can no longer be used as a `Writable`; we provide access to
the objstorage file implementation for tests.
