### PR TITLE
objstorage: rename ReadaheadHandle to ReadHandle

### DIFF
--- a/objstorage/noop_readahead.go
+++ b/objstorage/noop_readahead.go
@@ -6,24 +6,24 @@ package objstorage
 
 import "io"
 
-// NoopReadaheadHandle can be used by Readable implementations that don't
+// NoopReadHandle can be used by Readable implementations that don't
 // support read-ahead.
-type NoopReadaheadHandle struct {
+type NoopReadHandle struct {
 	io.ReaderAt
 }
 
-// MakeNoopReadaheadHandle initializes a NoopReadaheadHandle.
-func MakeNoopReadaheadHandle(r io.ReaderAt) NoopReadaheadHandle {
-	return NoopReadaheadHandle{ReaderAt: r}
+// MakeNoopReadHandle initializes a NoopReadHandle.
+func MakeNoopReadHandle(r io.ReaderAt) NoopReadHandle {
+	return NoopReadHandle{ReaderAt: r}
 }
 
-var _ ReadaheadHandle = (*NoopReadaheadHandle)(nil)
+var _ ReadHandle = (*NoopReadHandle)(nil)
 
-// Close is part of the ReadaheadHandle interface.
-func (*NoopReadaheadHandle) Close() error { return nil }
+// Close is part of the ReadHandle interface.
+func (*NoopReadHandle) Close() error { return nil }
 
-// MaxReadahead is part of the ReadaheadHandle interface.
-func (*NoopReadaheadHandle) MaxReadahead() {}
+// MaxReadahead is part of the ReadHandle interface.
+func (*NoopReadHandle) MaxReadahead() {}
 
-// RecordCacheHit is part of the ReadaheadHandle interface.
-func (*NoopReadaheadHandle) RecordCacheHit(offset, size int64) {}
+// RecordCacheHit is part of the ReadHandle interface.
+func (*NoopReadHandle) RecordCacheHit(offset, size int64) {}

--- a/objstorage/provider.go
+++ b/objstorage/provider.go
@@ -68,18 +68,18 @@ type Readable interface {
 	// Size returns the size of the object.
 	Size() int64
 
-	// NewReadaheadHandle creates a read-ahead handle which encapsulates
-	// read-ahead state. To benefit from read-ahead, ReadaheadHandle.ReadAt must
-	// be used (as opposed to Readable.ReadAt).
+	// NewReadHandle creates a read handle for ReadAt requests that are related
+	// and can benefit from optimizations like read-ahead.
 	//
-	// The ReadaheadHandle must be closed before the Readable is closed.
+	// The ReadHandle must be closed before the Readable is closed.
 	//
-	// Multiple separate ReadaheadHandles can be used.
-	NewReadaheadHandle() ReadaheadHandle
+	// Multiple separate ReadHandles can be used.
+	NewReadHandle() ReadHandle
 }
 
-// ReadaheadHandle is used to perform reads that might benefit from read-ahead.
-type ReadaheadHandle interface {
+// ReadHandle is used to perform reads that are related and might benefit from
+// optimizations like read-ahead.
+type ReadHandle interface {
 	io.ReaderAt
 	io.Closer
 

--- a/objstorage/vfs_readable.go
+++ b/objstorage/vfs_readable.go
@@ -19,7 +19,7 @@ type fileReadable struct {
 	size int64
 
 	// The following fields are used to possibly open the file again using the
-	// sequential reads option (see vfsReadaheadHandle).
+	// sequential reads option (see vfsReadHandle).
 	filename string
 	fs       vfs.FS
 }
@@ -62,14 +62,14 @@ func (r *fileReadable) Size() int64 {
 	return r.size
 }
 
-// NewReadaheadHandle is part of the objstorage.Readable interface.
-func (r *fileReadable) NewReadaheadHandle() ReadaheadHandle {
-	rh := readaheadHandlePool.Get().(*vfsReadaheadHandle)
+// NewReadHandle is part of the objstorage.Readable interface.
+func (r *fileReadable) NewReadHandle() ReadHandle {
+	rh := readHandlePool.Get().(*vfsReadHandle)
 	rh.r = r
 	return rh
 }
 
-type vfsReadaheadHandle struct {
+type vfsReadHandle struct {
 	r  *fileReadable
 	rs readaheadState
 
@@ -80,15 +80,15 @@ type vfsReadaheadHandle struct {
 	sequentialFile vfs.File
 }
 
-var _ ReadaheadHandle = (*vfsReadaheadHandle)(nil)
+var _ ReadHandle = (*vfsReadHandle)(nil)
 
-var readaheadHandlePool = sync.Pool{
+var readHandlePool = sync.Pool{
 	New: func() interface{} {
-		i := &vfsReadaheadHandle{}
+		i := &vfsReadHandle{}
 		// Note: this is a no-op if invariants are disabled or race is enabled.
 		invariants.SetFinalizer(i, func(obj interface{}) {
-			if obj.(*vfsReadaheadHandle).r != nil {
-				fmt.Fprintf(os.Stderr, "ReadaheadHandle was not closed")
+			if obj.(*vfsReadHandle).r != nil {
+				fmt.Fprintf(os.Stderr, "ReadHandle was not closed")
 				os.Exit(1)
 			}
 		})
@@ -96,19 +96,19 @@ var readaheadHandlePool = sync.Pool{
 	},
 }
 
-// Close is part of the objstorage.ReadaheadHandle interface.
-func (rh *vfsReadaheadHandle) Close() error {
+// Close is part of the objstorage.ReadHandle interface.
+func (rh *vfsReadHandle) Close() error {
 	var err error
 	if rh.sequentialFile != nil {
 		err = rh.sequentialFile.Close()
 	}
-	*rh = vfsReadaheadHandle{}
-	readaheadHandlePool.Put(rh)
+	*rh = vfsReadHandle{}
+	readHandlePool.Put(rh)
 	return err
 }
 
-// ReadAt is part of the objstorage.ReadaheadHandle interface.
-func (rh *vfsReadaheadHandle) ReadAt(p []byte, offset int64) (n int, err error) {
+// ReadAt is part of the objstorage.ReadHandle interface.
+func (rh *vfsReadHandle) ReadAt(p []byte, offset int64) (n int, err error) {
 	if rh.sequentialFile != nil {
 		// Use OS-level read-ahead.
 		return rh.sequentialFile.ReadAt(p, offset)
@@ -125,8 +125,8 @@ func (rh *vfsReadaheadHandle) ReadAt(p []byte, offset int64) (n int, err error) 
 	return rh.r.file.ReadAt(p, offset)
 }
 
-// MaxReadahead is part of the objstorage.ReadaheadHandle interface.
-func (rh *vfsReadaheadHandle) MaxReadahead() {
+// MaxReadahead is part of the objstorage.ReadHandle interface.
+func (rh *vfsReadHandle) MaxReadahead() {
 	if rh.sequentialFile != nil {
 		return
 	}
@@ -139,8 +139,8 @@ func (rh *vfsReadaheadHandle) MaxReadahead() {
 	}
 }
 
-// RecordCacheHit is part of the objstorage.ReadaheadHandle interface.
-func (rh *vfsReadaheadHandle) RecordCacheHit(offset, size int64) {
+// RecordCacheHit is part of the objstorage.ReadHandle interface.
+func (rh *vfsReadHandle) RecordCacheHit(offset, size int64) {
 	if rh.sequentialFile != nil {
 		// Using OS-level readahead, so do nothing.
 		return
@@ -154,7 +154,7 @@ type genericFileReadable struct {
 	file vfs.File
 	size int64
 
-	rh NoopReadaheadHandle
+	rh NoopReadHandle
 }
 
 var _ Readable = (*genericFileReadable)(nil)
@@ -167,7 +167,7 @@ func newGenericFileReadable(file vfs.File) (*genericFileReadable, error) {
 	r := &genericFileReadable{
 		file: file,
 		size: info.Size(),
-		rh:   MakeNoopReadaheadHandle(file),
+		rh:   MakeNoopReadHandle(file),
 	}
 	invariants.SetFinalizer(r, func(obj interface{}) {
 		if obj.(*genericFileReadable).file != nil {
@@ -194,13 +194,13 @@ func (r *genericFileReadable) Size() int64 {
 	return r.size
 }
 
-// NewReadaheadHandle is part of the objstorage.Readable interface.
-func (r *genericFileReadable) NewReadaheadHandle() ReadaheadHandle {
+// NewReadHandle is part of the objstorage.Readable interface.
+func (r *genericFileReadable) NewReadHandle() ReadHandle {
 	return &r.rh
 }
 
-// TestingCheckMaxReadahead returns true if the ReadaheadHandle has switched to
+// TestingCheckMaxReadahead returns true if the ReadHandle has switched to
 // OS-level read-ahead.
-func TestingCheckMaxReadahead(rh ReadaheadHandle) bool {
-	return rh.(*vfsReadaheadHandle).sequentialFile != nil
+func TestingCheckMaxReadahead(rh ReadHandle) bool {
+	return rh.(*vfsReadHandle).sequentialFile != nil
 }

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -473,7 +473,7 @@ func readBlockBuf(r *Reader, bh BlockHandle, buf []byte) ([]byte, []byte, error)
 type memReader struct {
 	b  []byte
 	r  *bytes.Reader
-	rh objstorage.NoopReadaheadHandle
+	rh objstorage.NoopReadHandle
 }
 
 var _ objstorage.Readable = (*memReader)(nil)
@@ -483,7 +483,7 @@ func newMemReader(b []byte) *memReader {
 		b: b,
 		r: bytes.NewReader(b),
 	}
-	r.rh = objstorage.MakeNoopReadaheadHandle(r)
+	r.rh = objstorage.MakeNoopReadHandle(r)
 	return r
 }
 
@@ -502,7 +502,7 @@ func (m *memReader) Size() int64 {
 	return int64(len(m.b))
 }
 
-// NewReadaheadHandle implements objstorage.Readable.
-func (m *memReader) NewReadaheadHandle() objstorage.ReadaheadHandle {
+// NewReadHandle implements objstorage.Readable.
+func (m *memReader) NewReadHandle() objstorage.ReadHandle {
 	return &m.rh
 }


### PR DESCRIPTION
This name is too specific - read-ahead is just one possible optimization. The idea as far as the API is concerned is that related operations should go through the same handle so they can benefit from internal optimizations.