### PR TITLE
metamorphic: add unit test for Options propagation

### DIFF
--- a/internal/metamorphic/options_test.go
+++ b/internal/metamorphic/options_test.go
@@ -5,12 +5,17 @@
 package metamorphic
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/rand"
 )
 
 func TestSetupInitialState(t *testing.T) {
@@ -46,4 +51,78 @@ func TestSetupInitialState(t *testing.T) {
 	copied, err := opts.opts.FS.List("")
 	require.NoError(t, err)
 	require.ElementsMatch(t, ls, copied)
+}
+
+func TestOptionsRoundtrip(t *testing.T) {
+	// Some fields mut be ignored to avoid spurious diffs.
+	ignorePrefixes := []string{
+		// Pointers
+		"Cache:",
+		"Cache.",
+		"FS:",
+		"TableCache:",
+		// Function pointers
+		"EventListener:",
+		"MaxConcurrentCompactions:",
+		"Experimental.EnableValueBlocks:",
+		// Floating points
+		"Experimental.PointTombstoneWeight:",
+	}
+
+	// Ensure that we unref any caches created, so invariants builds don't
+	// complain about the leaked ref counts.
+	maybeUnref := func(o *testOptions) {
+		if o.opts.Cache != nil {
+			o.opts.Cache.Unref()
+		}
+	}
+
+	checkOptions := func(t *testing.T, o *testOptions) {
+		s := optionsToString(o)
+		parsed := defaultTestOptions()
+		require.NoError(t, parseOptions(parsed, s))
+		maybeUnref(parsed)
+		got := optionsToString(parsed)
+		require.Equal(t, s, got)
+
+		// In some options, the closure obscures the underlying value. Check
+		// that the return values are equal.
+		require.Equal(t, o.opts.Experimental.EnableValueBlocks == nil, parsed.opts.Experimental.EnableValueBlocks == nil)
+		if o.opts.Experimental.EnableValueBlocks != nil {
+			require.Equal(t, o.opts.Experimental.EnableValueBlocks(), parsed.opts.Experimental.EnableValueBlocks())
+		}
+		require.Equal(t, o.opts.MaxConcurrentCompactions(), parsed.opts.MaxConcurrentCompactions())
+
+		diff := pretty.Diff(o.opts, parsed.opts)
+		cleaned := diff[:0]
+		for _, d := range diff {
+			var ignored bool
+			for _, prefix := range ignorePrefixes {
+				if strings.HasPrefix(d, prefix) {
+					ignored = true
+					break
+				}
+			}
+			if !ignored {
+				cleaned = append(cleaned, d)
+			}
+		}
+		require.Equal(t, diff[:0], cleaned)
+	}
+
+	standard := standardOptions()
+	for i := range standard {
+		t.Run(fmt.Sprintf("standard-%03d", i), func(t *testing.T) {
+			checkOptions(t, standard[i])
+			maybeUnref(standard[i])
+		})
+	}
+	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
+	for i := 0; i < 100; i++ {
+		t.Run(fmt.Sprintf("random-%03d", i), func(t *testing.T) {
+			o := randomOptions(rng)
+			checkOptions(t, o)
+			maybeUnref(o)
+		})
+	}
 }

--- a/options.go
+++ b/options.go
@@ -1184,6 +1184,7 @@ func (o *Options) String() string {
 		fmt.Fprintf(&buf, "[Level \"%d\"]\n", i)
 		fmt.Fprintf(&buf, "  block_restart_interval=%d\n", l.BlockRestartInterval)
 		fmt.Fprintf(&buf, "  block_size=%d\n", l.BlockSize)
+		fmt.Fprintf(&buf, "  block_size_threshold=%d\n", l.BlockSizeThreshold)
 		fmt.Fprintf(&buf, "  compression=%s\n", l.Compression)
 		fmt.Fprintf(&buf, "  filter_policy=%s\n", filterPolicyName(l.FilterPolicy))
 		fmt.Fprintf(&buf, "  filter_type=%s\n", l.FilterType)
@@ -1458,6 +1459,8 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				l.BlockRestartInterval, err = strconv.Atoi(value)
 			case "block_size":
 				l.BlockSize, err = strconv.Atoi(value)
+			case "block_size_threshold":
+				l.BlockSizeThreshold, err = strconv.Atoi(value)
 			case "compression":
 				switch value {
 				case "Default":

--- a/options_test.go
+++ b/options_test.go
@@ -106,6 +106,7 @@ func TestOptionsString(t *testing.T) {
 [Level "0"]
   block_restart_interval=16
   block_size=4096
+  block_size_threshold=90
   compression=Snappy
   filter_policy=none
   filter_type=table

--- a/replay/testdata/replay
+++ b/replay/testdata/replay
@@ -13,7 +13,7 @@ tree
        0      LOCK
       96      MANIFEST-000001
      122      MANIFEST-000008
-    1145      OPTIONS-000003
+    1171      OPTIONS-000003
        0      marker.format-version.000007.008
        0      marker.manifest.000002.MANIFEST-000008
             simple/
@@ -24,7 +24,7 @@ tree
       25        000004.log
      795        000005.sst
       96        MANIFEST-000001
-    1145        OPTIONS-000003
+    1171        OPTIONS-000003
        0        marker.format-version.000001.008
        0        marker.manifest.000001.MANIFEST-000001
 
@@ -72,6 +72,7 @@ cat build/OPTIONS-000003
 [Level "0"]
   block_restart_interval=16
   block_size=4096
+  block_size_threshold=90
   compression=Snappy
   filter_policy=none
   filter_type=table

--- a/replay/testdata/replay_paced
+++ b/replay/testdata/replay_paced
@@ -15,7 +15,7 @@ tree
        0      LOCK
      122      MANIFEST-000008
      205      MANIFEST-000011
-    1145      OPTIONS-000003
+    1171      OPTIONS-000003
        0      marker.format-version.000007.008
        0      marker.manifest.000003.MANIFEST-000011
             high_read_amp/
@@ -27,7 +27,7 @@ tree
       39        000009.log
      769        000010.sst
      157        MANIFEST-000011
-    1145        OPTIONS-000003
+    1171        OPTIONS-000003
        0        marker.format-version.000001.008
        0        marker.manifest.000001.MANIFEST-000011
 


### PR DESCRIPTION
Add a unit test that ensures that Options set by the metamorphic tests survive a serialization and deserialization roundtrip. The top-level metamorphic test propagates the options to sub-runs through a serialized OPTIONS file, so varying OPTIONS must be serialized to be tested.

Fix the LevelOptions.BlockSizeThreshold field that was not serialized, and wasn't effectively tested within the metamorphic tests.

This change also inverts the `useBlockPropertyCollector` option to be `disableBlockPropertyCollector` to play a little better with the default of using the collector.