### PR TITLE
db: improve documentation of tableNewIters

### DIFF
--- a/level_iter.go
+++ b/level_iter.go
@@ -17,8 +17,15 @@ import (
 )
 
 // tableNewIters creates a new point and range-del iterator for the given file
-// number. If bytesIterated is specified, it is incremented as the given file is
-// iterated through.
+// number.
+//
+// On success, the internalIterator is not-nil and must be closed; the
+// FragmentIterator can be nil.
+// TODO(radu): always return a non-nil FragmentIterator.
+//
+// On error, the iterators are nil.
+//
+// The only (non-test) implementation of tableNewIters is tableCacheContainer.newIters().
 type tableNewIters func(
 	ctx context.Context,
 	file *manifest.FileMetadata,


### PR DESCRIPTION
It's much easier to navigate code when using interfaces instead of passing around `func`s (e.g. you can easily find all implementations).

Change `tableNewIters` to a new `tableIterFactory` interface. We also improve the documentation and clean up the main implementation (adding some missing error path cleanup).