### PR TITLE
db: remove levelIterBoundaryContext and rangeDelIter pointer shenanigans

### DIFF
--- a/external_iterator.go
+++ b/external_iterator.go
@@ -244,7 +244,7 @@ func createExternalPointIter(ctx context.Context, it *Iterator) (internalIterato
 			mlevels[len(mlevels)-1].initSimple(sli, nil /* rangeDelIter */)
 		}
 	}
-	if len(mlevels) == 1 && mlevels[0].rangeDelIter == nil {
+	if len(mlevels) == 1 && mlevels[0].rangeDelIter.get() == nil {
 		// Set closePointIterOnce to true. This is because we're bypassing the
 		// merging iter, which turns Close()s on it idempotent for any child
 		// iterators. The outer Iterator could call Close() on a point iter twice,

--- a/internal_iterator.go
+++ b/internal_iterator.go
@@ -122,9 +122,8 @@ func (i *scanInternalIterator) constructPointIter(memtables flushableList, buf *
 	// Next are the memtables.
 	for j := len(memtables) - 1; j >= 0; j-- {
 		mem := memtables[j]
-		mlevels = append(mlevels, mergingIterLevel{
-			iter: mem.newIter(&i.opts),
-		})
+		mlevels = append(mlevels, mergingIterLevel{})
+		mlevels[len(mlevels)-1].initSimple(mem.newIter(&i.opts), nil /* rangeDelIter */)
 		if rdi := mem.newRangeDelIter(&i.opts); rdi != nil {
 			rangeDelIters = append(rangeDelIters, rdi)
 		}
@@ -143,8 +142,7 @@ func (i *scanInternalIterator) constructPointIter(memtables flushableList, buf *
 		li.init(
 			context.Background(), i.opts, i.comparer.Compare, i.comparer.Split, i.newIters, files, level,
 			internalIterOpts{})
-		li.initBoundaryContext(&mlevels[mlevelsIndex].levelIterBoundaryContext)
-		mlevels[mlevelsIndex].iter = li
+		mlevels[mlevelsIndex].initSimple(li, nil /* rangeDelIter */)
 		rli.Init(keyspan.SpanIterOptions{RangeKeyFilters: i.opts.RangeKeyFilters},
 			i.comparer.Compare, tableNewRangeDelIter(context.Background(), i.newIters), files, level,
 			manifest.KeyTypePoint)

--- a/level_iter.go
+++ b/level_iter.go
@@ -148,10 +148,9 @@ type levelIter struct {
 	files            manifest.LevelIterator
 	err              error
 
-	// Pointer into this level's entry in `mergingIterLevel::levelIterBoundaryContext`.
-	// We populate it with the corresponding bounds for the currently opened file. It is used for
-	// two purposes (described for forward iteration. The explanation for backward iteration is
-	// similar.)
+	// We populate the levelIterBoundaryContext with the corresponding bounds for
+	// the currently opened file. It is used for two purposes (described for
+	// forward iteration. The explanation for backward iteration is similar.)
 	// - To limit the optimization that seeks lower-level iterators past keys shadowed by a range
 	//   tombstone. Limiting this seek to the file largestUserKey is necessary since
 	//   range tombstones are stored untruncated, while they only apply to keys within their
@@ -194,7 +193,7 @@ type levelIter struct {
 	// - `*Boundary` is only populated when the iterator is positioned exactly on the sentinel key.
 	// - `*Boundary` can hold either the lower- or upper-bound, depending on the iterator direction.
 	// - `*Boundary` is not exposed to the next higher-level iterator, i.e., `mergingIter`.
-	boundaryContext *levelIterBoundaryContext
+	boundaryContext levelIterBoundaryContext
 
 	// internalOpts holds the internal iterator options to pass to the table
 	// cache when constructing new table iterators.
@@ -227,6 +226,32 @@ type filteredIter interface {
 	// iterator is exhausted. It must never return false negatives when the
 	// iterator is exhausted.
 	MaybeFilteredKeys() bool
+}
+
+type levelIterBoundaryContext struct {
+	// smallestUserKey and largestUserKey are populated with the smallest and
+	// largest boundaries of the current file.
+	smallestUserKey, largestUserKey []byte
+	// isLargestUserKeyExclusive is set to true when a file's largest boundary
+	// is an exclusive key, (eg, a range deletion sentinel). If true, the file
+	// does not contain any keys with the provided user key, and the
+	// largestUserKey bound is exclusive.
+	isLargestUserKeyExclusive bool
+	// isSyntheticIterBoundsKey is set to true iff the key returned by the level
+	// iterator is a synthetic key derived from the iterator bounds. This is used
+	// to prevent the mergingIter from being stuck at such a synthetic key if it
+	// becomes the top element of the heap. When used with a user-facing Iterator,
+	// the only range deletions exposed by this mergingIter should be those with
+	// `isSyntheticIterBoundsKey || isIgnorableBoundaryKey`.
+	isSyntheticIterBoundsKey bool
+	// isIgnorableBoundaryKey is set to true iff the key returned by the level
+	// iterator is a file boundary key that should be ignored when returning to
+	// the parent iterator. File boundary keys are used by the level iter to
+	// keep a levelIter file's range deletion iterator open as long as other
+	// levels within the merging iterator require it. When used with a user-facing
+	// Iterator, the only range deletions exposed by this mergingIter should be
+	// those with `isSyntheticIterBoundsKey || isIgnorableBoundaryKey`.
+	isIgnorableBoundaryKey bool
 }
 
 // levelIter implements the base.InternalIterator interface.
@@ -279,10 +304,6 @@ func (l *levelIter) init(
 
 func (l *levelIter) initRangeDel(rangeDelIter *keyspan.FragmentIterator) {
 	l.rangeDelIterPtr = rangeDelIter
-}
-
-func (l *levelIter) initBoundaryContext(context *levelIterBoundaryContext) {
-	l.boundaryContext = context
 }
 
 func (l *levelIter) initCombinedIterState(state *combinedIterState) {
@@ -588,10 +609,8 @@ const (
 func (l *levelIter) loadFile(file *fileMetadata, dir int) loadFileReturnIndicator {
 	l.smallestBoundary = nil
 	l.largestBoundary = nil
-	if l.boundaryContext != nil {
-		l.boundaryContext.isSyntheticIterBoundsKey = false
-		l.boundaryContext.isIgnorableBoundaryKey = false
-	}
+	l.boundaryContext.isSyntheticIterBoundsKey = false
+	l.boundaryContext.isIgnorableBoundaryKey = false
 	if l.iterFile == file {
 		if l.err != nil {
 			return noFileLoaded
@@ -686,11 +705,9 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) loadFileReturnIndicato
 		} else if rangeDelIter != nil {
 			rangeDelIter.Close()
 		}
-		if l.boundaryContext != nil {
-			l.boundaryContext.smallestUserKey = file.Smallest.UserKey
-			l.boundaryContext.largestUserKey = file.Largest.UserKey
-			l.boundaryContext.isLargestUserKeyExclusive = file.Largest.IsExclusiveSentinel()
-		}
+		l.boundaryContext.smallestUserKey = file.Smallest.UserKey
+		l.boundaryContext.largestUserKey = file.Largest.UserKey
+		l.boundaryContext.isLargestUserKeyExclusive = file.Largest.IsExclusiveSentinel()
 		return newFileLoaded
 	}
 }
@@ -717,10 +734,8 @@ func (l *levelIter) verify(key *InternalKey, val base.LazyValue) (*InternalKey, 
 
 func (l *levelIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, base.LazyValue) {
 	l.err = nil // clear cached iteration error
-	if l.boundaryContext != nil {
-		l.boundaryContext.isSyntheticIterBoundsKey = false
-		l.boundaryContext.isIgnorableBoundaryKey = false
-	}
+	l.boundaryContext.isSyntheticIterBoundsKey = false
+	l.boundaryContext.isIgnorableBoundaryKey = false
 	// NB: the top-level Iterator has already adjusted key based on
 	// IterOptions.LowerBound.
 	loadFileIndicator := l.loadFile(l.findFileGE(key, flags), +1)
@@ -742,10 +757,8 @@ func (l *levelIter) SeekPrefixGE(
 	prefix, key []byte, flags base.SeekGEFlags,
 ) (*base.InternalKey, base.LazyValue) {
 	l.err = nil // clear cached iteration error
-	if l.boundaryContext != nil {
-		l.boundaryContext.isSyntheticIterBoundsKey = false
-		l.boundaryContext.isIgnorableBoundaryKey = false
-	}
+	l.boundaryContext.isSyntheticIterBoundsKey = false
+	l.boundaryContext.isIgnorableBoundaryKey = false
 
 	// NB: the top-level Iterator has already adjusted key based on
 	// IterOptions.LowerBound.
@@ -771,10 +784,8 @@ func (l *levelIter) SeekPrefixGE(
 			l.syntheticBoundary.UserKey = l.tableOpts.UpperBound
 			l.syntheticBoundary.Trailer = InternalKeyRangeDeleteSentinel
 			l.largestBoundary = &l.syntheticBoundary
-			if l.boundaryContext != nil {
-				l.boundaryContext.isSyntheticIterBoundsKey = true
-				l.boundaryContext.isIgnorableBoundaryKey = false
-			}
+			l.boundaryContext.isSyntheticIterBoundsKey = true
+			l.boundaryContext.isIgnorableBoundaryKey = false
 			return l.verify(l.largestBoundary, base.LazyValue{})
 		}
 		// Return the file's largest bound, ensuring this file stays open until
@@ -782,10 +793,8 @@ func (l *levelIter) SeekPrefixGE(
 		// isIgnorableBoundaryKey to signal that the actual key returned should
 		// be ignored, and does not represent a real key in the database.
 		l.largestBoundary = &l.iterFile.LargestPointKey
-		if l.boundaryContext != nil {
-			l.boundaryContext.isSyntheticIterBoundsKey = false
-			l.boundaryContext.isIgnorableBoundaryKey = true
-		}
+		l.boundaryContext.isSyntheticIterBoundsKey = false
+		l.boundaryContext.isIgnorableBoundaryKey = true
 		return l.verify(l.largestBoundary, base.LazyValue{})
 	}
 	// It is possible that we are here because bloom filter matching failed.  In
@@ -804,10 +813,8 @@ func (l *levelIter) SeekPrefixGE(
 
 func (l *levelIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, base.LazyValue) {
 	l.err = nil // clear cached iteration error
-	if l.boundaryContext != nil {
-		l.boundaryContext.isSyntheticIterBoundsKey = false
-		l.boundaryContext.isIgnorableBoundaryKey = false
-	}
+	l.boundaryContext.isSyntheticIterBoundsKey = false
+	l.boundaryContext.isIgnorableBoundaryKey = false
 
 	// NB: the top-level Iterator has already adjusted key based on
 	// IterOptions.UpperBound.
@@ -822,10 +829,8 @@ func (l *levelIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, ba
 
 func (l *levelIter) First() (*InternalKey, base.LazyValue) {
 	l.err = nil // clear cached iteration error
-	if l.boundaryContext != nil {
-		l.boundaryContext.isSyntheticIterBoundsKey = false
-		l.boundaryContext.isIgnorableBoundaryKey = false
-	}
+	l.boundaryContext.isSyntheticIterBoundsKey = false
+	l.boundaryContext.isIgnorableBoundaryKey = false
 
 	// NB: the top-level Iterator will call SeekGE if IterOptions.LowerBound is
 	// set.
@@ -840,10 +845,8 @@ func (l *levelIter) First() (*InternalKey, base.LazyValue) {
 
 func (l *levelIter) Last() (*InternalKey, base.LazyValue) {
 	l.err = nil // clear cached iteration error
-	if l.boundaryContext != nil {
-		l.boundaryContext.isSyntheticIterBoundsKey = false
-		l.boundaryContext.isIgnorableBoundaryKey = false
-	}
+	l.boundaryContext.isSyntheticIterBoundsKey = false
+	l.boundaryContext.isIgnorableBoundaryKey = false
 
 	// NB: the top-level Iterator will call SeekLT if IterOptions.UpperBound is
 	// set.
@@ -860,10 +863,8 @@ func (l *levelIter) Next() (*InternalKey, base.LazyValue) {
 	if l.err != nil || l.iter == nil {
 		return nil, base.LazyValue{}
 	}
-	if l.boundaryContext != nil {
-		l.boundaryContext.isSyntheticIterBoundsKey = false
-		l.boundaryContext.isIgnorableBoundaryKey = false
-	}
+	l.boundaryContext.isSyntheticIterBoundsKey = false
+	l.boundaryContext.isIgnorableBoundaryKey = false
 
 	switch {
 	case l.largestBoundary != nil:
@@ -901,10 +902,8 @@ func (l *levelIter) NextPrefix(succKey []byte) (*InternalKey, base.LazyValue) {
 	if l.err != nil || l.iter == nil {
 		return nil, base.LazyValue{}
 	}
-	if l.boundaryContext != nil {
-		l.boundaryContext.isSyntheticIterBoundsKey = false
-		l.boundaryContext.isIgnorableBoundaryKey = false
-	}
+	l.boundaryContext.isSyntheticIterBoundsKey = false
+	l.boundaryContext.isIgnorableBoundaryKey = false
 
 	switch {
 	case l.largestBoundary != nil:
@@ -951,10 +950,8 @@ func (l *levelIter) Prev() (*InternalKey, base.LazyValue) {
 	if l.err != nil || l.iter == nil {
 		return nil, base.LazyValue{}
 	}
-	if l.boundaryContext != nil {
-		l.boundaryContext.isSyntheticIterBoundsKey = false
-		l.boundaryContext.isIgnorableBoundaryKey = false
-	}
+	l.boundaryContext.isSyntheticIterBoundsKey = false
+	l.boundaryContext.isIgnorableBoundaryKey = false
 
 	switch {
 	case l.smallestBoundary != nil:
@@ -1024,9 +1021,7 @@ func (l *levelIter) skipEmptyFileForward() (*InternalKey, base.LazyValue) {
 					l.syntheticBoundary.UserKey = l.tableOpts.UpperBound
 					l.syntheticBoundary.Trailer = InternalKeyRangeDeleteSentinel
 					l.largestBoundary = &l.syntheticBoundary
-					if l.boundaryContext != nil {
-						l.boundaryContext.isSyntheticIterBoundsKey = true
-					}
+					l.boundaryContext.isSyntheticIterBoundsKey = true
 					return l.largestBoundary, base.LazyValue{}
 				}
 				// Else there are no range deletions in this sstable. This
@@ -1038,9 +1033,7 @@ func (l *levelIter) skipEmptyFileForward() (*InternalKey, base.LazyValue) {
 			// If the boundary is a range deletion tombstone, return that key.
 			if l.iterFile.LargestPointKey.Kind() == InternalKeyKindRangeDelete {
 				l.largestBoundary = &l.iterFile.LargestPointKey
-				if l.boundaryContext != nil {
-					l.boundaryContext.isIgnorableBoundaryKey = true
-				}
+				l.boundaryContext.isIgnorableBoundaryKey = true
 				return l.largestBoundary, base.LazyValue{}
 			}
 			// If the last point iterator positioning op might've skipped keys,
@@ -1114,9 +1107,7 @@ func (l *levelIter) skipEmptyFileBackward() (*InternalKey, base.LazyValue) {
 					l.syntheticBoundary.UserKey = l.tableOpts.LowerBound
 					l.syntheticBoundary.Trailer = InternalKeyRangeDeleteSentinel
 					l.smallestBoundary = &l.syntheticBoundary
-					if l.boundaryContext != nil {
-						l.boundaryContext.isSyntheticIterBoundsKey = true
-					}
+					l.boundaryContext.isSyntheticIterBoundsKey = true
 					return l.smallestBoundary, base.LazyValue{}
 				}
 				// Else there are no range deletions in this sstable. This
@@ -1128,9 +1119,7 @@ func (l *levelIter) skipEmptyFileBackward() (*InternalKey, base.LazyValue) {
 			// If the boundary is a range deletion tombstone, return that key.
 			if l.iterFile.SmallestPointKey.Kind() == InternalKeyKindRangeDelete {
 				l.smallestBoundary = &l.iterFile.SmallestPointKey
-				if l.boundaryContext != nil {
-					l.boundaryContext.isIgnorableBoundaryKey = true
-				}
+				l.boundaryContext.isIgnorableBoundaryKey = true
 				return l.smallestBoundary, base.LazyValue{}
 			}
 			// If the last point iterator positioning op skipped keys, it's

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -20,10 +20,9 @@ type mergingIterLevel struct {
 	index int
 	iter  internalIterator
 	// rangeDelIter is set to the range-deletion iterator for the level. When
-	// configured with a levelIter, this pointer changes as sstable boundaries
-	// are crossed. See levelIter.initRangeDel and the Range Deletions comment
-	// below.
-	rangeDelIter keyspan.FragmentIterator
+	// configured with a levelIter, this changes as sstable boundaries
+	// are crossed.
+	rangeDelIter rangeDelIterHolder
 	// iterKey and iterValue cache the current key and value iter are pointed at.
 	iterKey   *InternalKey
 	iterValue base.LazyValue
@@ -50,7 +49,7 @@ func (l *mergingIterLevel) initSimple(
 ) {
 	*l = mergingIterLevel{
 		iter:            iter,
-		rangeDelIter:    rangeDelIter,
+		rangeDelIter:    makeRangeDelIterHolderFixed(rangeDelIter),
 		boundaryContext: &emptyBoundaryContext,
 	}
 }
@@ -61,9 +60,9 @@ var emptyBoundaryContext = levelIterBoundaryContext{}
 func (l *mergingIterLevel) initWithLevelIter(iter *levelIter) {
 	*l = mergingIterLevel{
 		iter:            iter,
+		rangeDelIter:    makeRangeDelIterHolderLevel(iter),
 		boundaryContext: &iter.boundaryContext,
 	}
-	iter.initRangeDel(&l.rangeDelIter)
 }
 
 // mergingIter provides a merged view of multiple iterators from different
@@ -353,10 +352,9 @@ func (m *mergingIter) initMinRangeDelIters(oldTopLevel int) {
 	item := m.heap.items[0]
 	for level := oldTopLevel + 1; level <= item.index; level++ {
 		l := &m.levels[level]
-		if l.rangeDelIter == nil {
-			continue
+		if rangeDelIter := l.rangeDelIter.get(); rangeDelIter != nil {
+			l.tombstone = rangeDelIter.SeekGE(item.iterKey.UserKey)
 		}
-		l.tombstone = l.rangeDelIter.SeekGE(item.iterKey.UserKey)
 	}
 }
 
@@ -380,10 +378,9 @@ func (m *mergingIter) initMaxRangeDelIters(oldTopLevel int) {
 	item := m.heap.items[0]
 	for level := oldTopLevel + 1; level <= item.index; level++ {
 		l := &m.levels[level]
-		if l.rangeDelIter == nil {
-			continue
+		if rangeDelIter := l.rangeDelIter.get(); rangeDelIter != nil {
+			l.tombstone = keyspan.SeekLE(m.heap.cmp, rangeDelIter, item.iterKey.UserKey)
 		}
-		l.tombstone = keyspan.SeekLE(m.heap.cmp, l.rangeDelIter, item.iterKey.UserKey)
 	}
 }
 
@@ -608,7 +605,7 @@ func (m *mergingIter) nextEntry(l *mergingIterLevel, succKey []byte) {
 	}
 
 	oldTopLevel := l.index
-	oldRangeDelIter := l.rangeDelIter
+	oldRangeDelIter := l.rangeDelIter.get()
 
 	if succKey == nil {
 		l.iterKey, l.iterValue = l.iter.Next()
@@ -620,7 +617,7 @@ func (m *mergingIter) nextEntry(l *mergingIterLevel, succKey []byte) {
 		if m.heap.len() > 1 {
 			m.heap.fix(0)
 		}
-		if l.rangeDelIter != oldRangeDelIter {
+		if l.rangeDelIter.get() != oldRangeDelIter {
 			// The rangeDelIter changed which indicates that the l.iter moved to the
 			// next sstable. We have to update the tombstone for oldTopLevel as well.
 			oldTopLevel--
@@ -654,7 +651,8 @@ func (m *mergingIter) isNextEntryDeleted(item *mergingIterLevel) bool {
 	// entry.
 	for level := 0; level <= item.index; level++ {
 		l := &m.levels[level]
-		if l.rangeDelIter == nil || l.tombstone == nil {
+		rangeDelIter := l.rangeDelIter.get()
+		if rangeDelIter == nil || l.tombstone == nil {
 			// If l.tombstone is nil, there are no further tombstones
 			// in the current sstable in the current (forward) iteration
 			// direction.
@@ -663,13 +661,13 @@ func (m *mergingIter) isNextEntryDeleted(item *mergingIterLevel) bool {
 		if m.heap.cmp(l.tombstone.End, item.iterKey.UserKey) <= 0 {
 			// The current key is at or past the tombstone end key.
 			//
-			// NB: for the case that this l.rangeDelIter is provided by a levelIter we know that
+			// NB: for the case that this rangeDelIter is provided by a levelIter we know that
 			// the levelIter must be positioned at a key >= item.iterKey. So it is sufficient to seek the
-			// current l.rangeDelIter (since any range del iterators that will be provided by the
+			// current rangeDelIter (since any range del iterators that will be provided by the
 			// levelIter in the future cannot contain item.iterKey). Also, it is possible that we
 			// will encounter parts of the range delete that should be ignored -- we handle that
 			// below.
-			l.tombstone = l.rangeDelIter.SeekGE(item.iterKey.UserKey)
+			l.tombstone = rangeDelIter.SeekGE(item.iterKey.UserKey)
 		}
 		if l.tombstone == nil {
 			continue
@@ -832,12 +830,12 @@ func (m *mergingIter) findNextEntry() (*InternalKey, base.LazyValue) {
 // Steps to the prev entry. item is the current top item in the heap.
 func (m *mergingIter) prevEntry(l *mergingIterLevel) {
 	oldTopLevel := l.index
-	oldRangeDelIter := l.rangeDelIter
+	oldRangeDelIter := l.rangeDelIter.get()
 	if l.iterKey, l.iterValue = l.iter.Prev(); l.iterKey != nil {
 		if m.heap.len() > 1 {
 			m.heap.fix(0)
 		}
-		if l.rangeDelIter != oldRangeDelIter && l.rangeDelIter != nil {
+		if newRangeDelIter := l.rangeDelIter.get(); newRangeDelIter != oldRangeDelIter && newRangeDelIter != nil {
 			// The rangeDelIter changed which indicates that the l.iter moved to the
 			// previous sstable. We have to update the tombstone for oldTopLevel as
 			// well.
@@ -868,7 +866,8 @@ func (m *mergingIter) isPrevEntryDeleted(item *mergingIterLevel) bool {
 	// entry.
 	for level := 0; level <= item.index; level++ {
 		l := &m.levels[level]
-		if l.rangeDelIter == nil || l.tombstone == nil {
+		rangeDelIter := l.rangeDelIter.get()
+		if rangeDelIter == nil || l.tombstone == nil {
 			// If l.tombstone is nil, there are no further tombstones
 			// in the current sstable in the current (reverse) iteration
 			// direction.
@@ -877,13 +876,13 @@ func (m *mergingIter) isPrevEntryDeleted(item *mergingIterLevel) bool {
 		if m.heap.cmp(item.iterKey.UserKey, l.tombstone.Start) < 0 {
 			// The current key is before the tombstone start key.
 			//
-			// NB: for the case that this l.rangeDelIter is provided by a levelIter we know that
+			// NB: for the case that this rangeDelIter is provided by a levelIter we know that
 			// the levelIter must be positioned at a key < item.iterKey. So it is sufficient to seek the
-			// current l.rangeDelIter (since any range del iterators that will be provided by the
+			// current rangeDelIter (since any range del iterators that will be provided by the
 			// levelIter in the future cannot contain item.iterKey). Also, it is it is possible that we
 			// will encounter parts of the range delete that should be ignored -- we handle that
 			// below.
-			l.tombstone = keyspan.SeekLE(m.heap.cmp, l.rangeDelIter, item.iterKey.UserKey)
+			l.tombstone = keyspan.SeekLE(m.heap.cmp, rangeDelIter, item.iterKey.UserKey)
 		}
 		if l.tombstone == nil {
 			continue
@@ -1053,7 +1052,7 @@ func (m *mergingIter) seekGE(key []byte, level int, flags base.SeekGEFlags) {
 		// keys, and there might exist live range keys within the range
 		// tombstone's span that need to be observed to trigger a switch to
 		// combined iteration.
-		if rangeDelIter := l.rangeDelIter; rangeDelIter != nil &&
+		if rangeDelIter := l.rangeDelIter.get(); rangeDelIter != nil &&
 			(m.combinedIterState == nil || m.combinedIterState.initialized) {
 			// The level has a range-del iterator. Find the tombstone containing
 			// the search key.
@@ -1143,7 +1142,7 @@ func (m *mergingIter) seekLT(key []byte, level int, flags base.SeekLTFlags) {
 		// keys, and there might exist live range keys within the range
 		// tombstone's span that need to be observed to trigger a switch to
 		// combined iteration.
-		if rangeDelIter := l.rangeDelIter; rangeDelIter != nil &&
+		if rangeDelIter := l.rangeDelIter.get(); rangeDelIter != nil &&
 			(m.combinedIterState == nil || m.combinedIterState.initialized) {
 			// The level has a range-del iterator. Find the tombstone containing
 			// the search key.
@@ -1337,7 +1336,7 @@ func (m *mergingIter) Close() error {
 		if err := iter.Close(); err != nil && m.err == nil {
 			m.err = err
 		}
-		if rangeDelIter := m.levels[i].rangeDelIter; rangeDelIter != nil {
+		if rangeDelIter := m.levels[i].rangeDelIter.get(); rangeDelIter != nil {
 			if err := rangeDelIter.Close(); err != nil && m.err == nil {
 				m.err = err
 			}


### PR DESCRIPTION
#### db: remove levelIterBoundaryContext pointer shenanigans

The level iterator can optionally populate an *external*
levelIterBoundaryContext through a pointer; this is set to point to
the corresponding field in the merging iterators.

This subtlety of how this field is updated is unnecessary. We can make
the level iterator always keep track of this information internally;
in the merging iterator we initialize a pointer to this state in the
level iterator or to an empty struct if we are not using a level
iterator.

#### db: rework the mechanism to support a changing rangeDelIter

When using a `levelIter`, the `rangeDelIter` changes with each file.
The current mechanism for higher levels (in particular the merging
iterator) to obtain the current `rangeDelIter` is to configure the
`levelIter` with a pointer to a field. This is very subtle, as the
field seems to "magically" change from the perspective of the higher
level code.

This commit changes this mechanism: we define a `rangeDelIterHolder`
which can be configured either with a fixed `rangeDeliter` or with a
`levelIter` that is configured to expose the current `rangeDelIter`. A
`get()` method returns either the fixed `rangeDelIter` or the
`levelIter`'s current `rangeDelIter`.
