### PR TITLE
manifest: refactor BulkVersionEdit for consistency

### DIFF
--- a/internal/keyspan/level_iter_test.go
+++ b/internal/keyspan/level_iter_test.go
@@ -303,8 +303,12 @@ func TestLevelIterEquivalence(t *testing.T) {
 			}
 			// Add all the fileMetadatas to L6.
 			b := &manifest.BulkVersionEdit{}
-			b.Added[6] = metas
-			v, _, err := b.Apply(nil, base.DefaultComparer.Compare, base.DefaultFormatter, 0, 0)
+			amap := make(map[base.FileNum]*manifest.FileMetadata)
+			for i := range metas {
+				amap[metas[i].FileNum] = metas[i]
+			}
+			b.Added[6] = amap
+			v, err := b.Apply(nil, base.DefaultComparer.Compare, base.DefaultFormatter, 0, 0, nil)
 			require.NoError(t, err)
 			levelIter.Init(
 				SpanIterOptions{}, base.DefaultComparer.Compare, tableNewIters,
@@ -436,8 +440,12 @@ func TestLevelIter(t *testing.T) {
 					return NewIter(base.DefaultComparer.Compare, spans), nil
 				}
 				b := &manifest.BulkVersionEdit{}
-				b.Added[6] = metas
-				v, _, err := b.Apply(nil, base.DefaultComparer.Compare, base.DefaultFormatter, 0, 0)
+				amap := make(map[base.FileNum]*manifest.FileMetadata)
+				for i := range metas {
+					amap[metas[i].FileNum] = metas[i]
+				}
+				b.Added[6] = amap
+				v, err := b.Apply(nil, base.DefaultComparer.Compare, base.DefaultFormatter, 0, 0, nil)
 				require.NoError(t, err)
 				iter = NewLevelIter(
 					SpanIterOptions{}, base.DefaultComparer.Compare,

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -50,7 +50,7 @@ func readManifest(filename string) (*Version, error) {
 		if err := bve.Accumulate(&ve); err != nil {
 			return nil, err
 		}
-		if v, _, err = bve.Apply(v, base.DefaultComparer.Compare, base.DefaultFormatter, 10<<20, 32000); err != nil {
+		if v, err = bve.Apply(v, base.DefaultComparer.Compare, base.DefaultFormatter, 10<<20, 32000, nil); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/manifest/testdata/version_edit_apply
+++ b/internal/manifest/testdata/version_edit_apply
@@ -166,3 +166,26 @@ edit
    2
 ----
 pebble: file deleted L0.000002 before it was inserted
+
+apply
+ L0
+  1:[a#1,SET-b#2,SET]
+edit
+ delete
+  L0
+   1
+ add
+  L2
+  1:[a#1,SET-b#2,SET]
+  4:[c#3,SET-d#4,SET]
+  5:[s#3,SET-z#4,SET]
+edit
+  delete
+    L2
+     1
+    L2
+     4
+----
+2:
+  000005:[s#3,SET-z#4,SET]
+zombies []

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -315,6 +315,7 @@ func TestVersionEditApply(t *testing.T) {
 		return m, nil
 	}
 
+	// TODO(bananabrick): Improve the parsing logic in this test.
 	datadriven.RunTest(t, "testdata/version_edit_apply",
 		func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
@@ -323,7 +324,7 @@ func TestVersionEditApply(t *testing.T) {
 				// avoid repeating it, and make it the inverse of
 				// Version.DebugString().
 				var v *Version
-				ve := &VersionEdit{}
+				var veList []*VersionEdit
 				isVersion := true
 				isDelete := true
 				var level int
@@ -334,6 +335,7 @@ func TestVersionEditApply(t *testing.T) {
 					switch data {
 					case "edit":
 						isVersion = false
+						veList = append(veList, &VersionEdit{})
 					case "delete":
 						isVersion = false
 						isDelete = true
@@ -346,6 +348,10 @@ func TestVersionEditApply(t *testing.T) {
 							return err.Error()
 						}
 					default:
+						var ve *VersionEdit
+						if len(veList) > 0 {
+							ve = veList[len(veList)-1]
+						}
 						if isVersion || !isDelete {
 							meta, err := parseMeta(data)
 							if err != nil {
@@ -386,21 +392,28 @@ func TestVersionEditApply(t *testing.T) {
 
 				bve := BulkVersionEdit{}
 				bve.AddedByFileNum = make(map[base.FileNum]*FileMetadata)
-				if err := bve.Accumulate(ve); err != nil {
-					return err.Error()
+				for _, ve := range veList {
+					if err := bve.Accumulate(ve); err != nil {
+						return err.Error()
+					}
 				}
-				newv, zombies, err := bve.Apply(v, base.DefaultComparer.Compare, base.DefaultFormatter, 10<<20, 32000)
+				zombies := make(map[base.FileNum]uint64)
+				newv, err := bve.Apply(v, base.DefaultComparer.Compare, base.DefaultFormatter, 10<<20, 32000, zombies)
 				if err != nil {
 					return err.Error()
 				}
 
 				zombieFileNums := make([]base.FileNum, 0, len(zombies))
-				for fileNum := range zombies {
-					zombieFileNums = append(zombieFileNums, fileNum)
+				if len(veList) == 1 {
+					// Only care about zombies if a single version edit was
+					// being applied.
+					for fileNum := range zombies {
+						zombieFileNums = append(zombieFileNums, fileNum)
+					}
+					sort.Slice(zombieFileNums, func(i, j int) bool {
+						return zombieFileNums[i] < zombieFileNums[j]
+					})
 				}
-				sort.Slice(zombieFileNums, func(i, j int) bool {
-					return zombieFileNums[i] < zombieFileNums[j]
-				})
 
 				return fmt.Sprintf("%szombies %d\n", newv, zombieFileNums)
 

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -665,11 +665,12 @@ func (r *Runner) prepareWorkloadSteps(ctx context.Context) error {
 	}
 	currentVersion := func() (*manifest.Version, error) {
 		var err error
-		v, _, err = bve.Apply(v,
+		v, err = bve.Apply(v,
 			r.Opts.Comparer.Compare,
 			r.Opts.Comparer.FormatKey,
 			r.Opts.FlushSplitBytes,
-			r.Opts.Experimental.ReadCompactionRate)
+			r.Opts.Experimental.ReadCompactionRate,
+			nil /* zombies */)
 		bve = manifest.BulkVersionEdit{AddedByFileNum: bve.AddedByFileNum}
 		return v, err
 	}

--- a/tool/db.go
+++ b/tool/db.go
@@ -483,7 +483,7 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 				d.fmtValue.setForComparer(ve.ComparerName, d.comparers)
 			}
 		}
-		v, _, err := bve.Apply(nil /* version */, cmp.Compare, d.fmtKey.fn, d.opts.FlushSplitBytes, d.opts.Experimental.ReadCompactionRate)
+		v, err := bve.Apply(nil /* version */, cmp.Compare, d.fmtKey.fn, d.opts.FlushSplitBytes, d.opts.Experimental.ReadCompactionRate, nil /* zombies */)
 		if err != nil {
 			return err
 		}

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -234,7 +234,7 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 			}
 
 			if cmp != nil {
-				v, _, err := bve.Apply(nil /* version */, cmp.Compare, m.fmtKey.fn, 0, m.opts.Experimental.ReadCompactionRate)
+				v, err := bve.Apply(nil /* version */, cmp.Compare, m.fmtKey.fn, 0, m.opts.Experimental.ReadCompactionRate, nil /* zombies */)
 				if err != nil {
 					fmt.Fprintf(stdout, "%s\n", err)
 					return
@@ -541,7 +541,7 @@ func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
 				}
 				// TODO(sbhola): add option to Apply that reports all errors instead of
 				// one error.
-				newv, _, err := bve.Apply(v, cmp.Compare, m.fmtKey.fn, 0, m.opts.Experimental.ReadCompactionRate)
+				newv, err := bve.Apply(v, cmp.Compare, m.fmtKey.fn, 0, m.opts.Experimental.ReadCompactionRate, nil /* zombies */)
 				if err != nil {
 					fmt.Fprintf(stdout, "%s: offset: %d err: %s\n",
 						arg, offset, err)


### PR DESCRIPTION
Makes bulk version edit accumulation consistent with respect
to files being added and removed from a level; a file added
and deleted from the same level in the same bulk version edit
is no longer tracked in BulkVersionEdit.Added/Deleted.

We also explicitly write down the invariants which aid in proving
the correctness of the new approach.

We also separate out `BulkVersionEdit.Apply` into
`BulkVersionEdit.Apply` and `AccumulateAndApplySingleVE`. It's
easier to reason about accumulation/apply/zombie tables if we
have stricter invariants about when these functions are called.