### PR TITLE
tool: implement 04efab2 in proper place to avoid generate staleness

### DIFF
--- a/tool/data/lsm.js
+++ b/tool/data/lsm.js
@@ -610,7 +610,6 @@ let version = {
             }
         }
 
-        // TODO(peter): display smallest/largest key.
         reason.text(
             "[" +
                 this.levelsInfo[i].levelString +
@@ -620,6 +619,11 @@ let version = {
                 humanize(data.Files[fileNum].Size) +
                 ")" +
                 overlapInfo +
+                " <" +
+                data.Keys[data.Files[fileNum].Smallest].Pretty +
+                ", " +
+                data.Keys[data.Files[fileNum].Largest].Pretty +
+                ">" +
                 "]"
         );
 


### PR DESCRIPTION
https://github.com/cockroachdb/pebble/issues/2383

**tool: implement 04efab2 in proper place to avoid generate staleness**

04efab2 added pretty-printed keys to the LSM visualization tool. It did this by updating a generated file. This commit updates the file that generates that file instead.

Release note: None.

To test, I did the following:

```
~/g/s/g/c/p/tool [fix_generate] $ bash make_lsm_data.sh
~/g/s/g/c/p/tool [fix_generate] $ git status
On branch fix_generate
nothing to commit, working tree clean
```