### PR TITLE
db: add metrics for flushable ingests; improve logging

### DIFF
--- a/event.go
+++ b/event.go
@@ -5,10 +5,13 @@
 package pebble
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/humanize"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/redact"
@@ -152,8 +155,14 @@ type FlushInfo struct {
 	// TotalDuration is the total wall-time duration of the flush, including
 	// applying the flush to the database. TotalDuration is always ≥ Duration.
 	TotalDuration time.Duration
-	Done          bool
-	Err           error
+	// Ingest is set to true if the flush is handling tables that were added to
+	// the flushable queue via an ingestion operation.
+	Ingest bool
+	// IngestLevels are the output levels for each ingested table in the flush.
+	// This field is only populated when Ingest is true.
+	IngestLevels []int
+	Done         bool
+	Err          error
 }
 
 func (i FlushInfo) String() string {
@@ -172,20 +181,51 @@ func (i FlushInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 		plural = ""
 	}
 	if !i.Done {
-		w.Printf("[JOB %d] flushing %d memtable", redact.Safe(i.JobID), redact.Safe(i.Input))
-		w.SafeString(plural)
-		w.Printf(" to L0")
+		w.Printf("[JOB %d] ", redact.Safe(i.JobID))
+		if !i.Ingest {
+			w.Printf("flushing %d memtable", redact.Safe(i.Input))
+			w.SafeString(plural)
+			w.Printf(" to L0")
+		} else {
+			w.Printf("flushing ingested tables")
+		}
 		return
 	}
 
 	outputSize := tablesTotalSize(i.Output)
-	w.Printf("[JOB %d] flushed %d memtable%s to L0 [%s] (%s), in %.1fs (%.1fs total), output rate %s/s",
-		redact.Safe(i.JobID), redact.Safe(i.Input), plural,
-		redact.Safe(formatFileNums(i.Output)),
-		redact.Safe(humanize.Uint64(outputSize)),
-		redact.Safe(i.Duration.Seconds()),
-		redact.Safe(i.TotalDuration.Seconds()),
-		redact.Safe(humanize.Uint64(uint64(float64(outputSize)/i.Duration.Seconds()))))
+	if !i.Ingest {
+		if invariants.Enabled && len(i.IngestLevels) > 0 {
+			panic(errors.Newf("pebble: expected len(IngestedLevels) == 0"))
+		}
+		w.Printf("[JOB %d] flushed %d memtable%s to L0 [%s] (%s), in %.1fs (%.1fs total), output rate %s/s",
+			redact.Safe(i.JobID), redact.Safe(i.Input), plural,
+			redact.Safe(formatFileNums(i.Output)),
+			redact.Safe(humanize.Uint64(outputSize)),
+			redact.Safe(i.Duration.Seconds()),
+			redact.Safe(i.TotalDuration.Seconds()),
+			redact.Safe(humanize.Uint64(uint64(float64(outputSize)/i.Duration.Seconds()))))
+	} else {
+		if invariants.Enabled && len(i.IngestLevels) == 0 {
+			panic(errors.Newf("pebble: expected len(IngestedLevels) > 0"))
+		}
+		plural = "s"
+		if len(i.Output) == 1 {
+			plural = ""
+		}
+		w.Printf("[JOB %d] flushed %d ingested flushable%s",
+			redact.Safe(i.JobID), redact.Safe(len(i.Output)), plural)
+		for j, level := range i.IngestLevels {
+			file := i.Output[j]
+			if j > 0 {
+				w.Printf(" +")
+			}
+			w.Printf(" L%d:%s (%s)", level, file.FileNum, humanize.IEC.Uint64(file.Size))
+		}
+		w.Printf(" in %.1fs (%.1fs total), output rate %s/s",
+			redact.Safe(i.Duration.Seconds()),
+			redact.Safe(i.TotalDuration.Seconds()),
+			redact.Safe(humanize.Uint64(uint64(float64(outputSize)/i.Duration.Seconds()))))
+	}
 }
 
 // ManifestCreateInfo contains info about a manifest creation event.
@@ -314,7 +354,11 @@ func (i TableIngestInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 		if j > 0 {
 			w.Printf(",")
 		}
-		w.Printf(" L%d:%s (%s)", redact.Safe(t.Level), redact.Safe(t.FileNum),
+		levelStr := ""
+		if !i.flushable {
+			levelStr = fmt.Sprintf("L%d:", t.Level)
+		}
+		w.Printf(" %s%s (%s)", redact.Safe(levelStr), redact.Safe(t.FileNum),
 			redact.Safe(humanize.Uint64(t.Size)))
 	}
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -36,6 +36,8 @@ func TestMetricsFormat(t *testing.T) {
 	m.Compact.InProgressBytes = 7
 	m.Compact.NumInProgress = 2
 	m.Flush.Count = 8
+	m.Flush.AsIngestCount = 34
+	m.Flush.AsIngestBytes = 35
 	m.Filter.Hits = 9
 	m.Filter.Misses = 10
 	m.MemTable.Size = 11
@@ -87,8 +89,8 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5       601   602 B  603.00   604 B   604 B     612   606 B     613   1.2 K   1.2 K   607 B       6     2.0
       6       701   702 B       -   704 B   704 B     712   706 B     713   1.4 K   1.4 K   707 B       7     2.0
   total      2807   2.7 K       -   2.8 K   2.8 K   2.9 K   2.8 K   2.9 K   8.4 K   5.7 K   2.8 K      28     3.0
-  flush         8
-compact         5     6 B     7 B       2          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
+  flush         8                            35 B      34          (ingest = ingested-as-flushable)
+compact         5     6 B     7 B       2                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype        27      28      29      30      31      32      33  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl        12    11 B
 zmemtbl        14    13 B
@@ -119,6 +121,10 @@ func TestMetrics(t *testing.T) {
 	// interfering with the expected metrics output and reduces test flakiness.
 	opts.DisableAutomaticCompactions = true
 
+	// Increase the threshold for memtable stalls to allow for more flushable
+	// ingests.
+	opts.MemTableStopWritesThreshold = 4
+
 	d, err := Open("", opts)
 	require.NoError(t, err)
 	defer func() {
@@ -142,6 +148,12 @@ func TestMetrics(t *testing.T) {
 			b.Commit(nil)
 			return ""
 
+		case "build":
+			if err := runBuildCmd(td, d, d.opts.FS); err != nil {
+				return err.Error()
+			}
+			return ""
+
 		case "compact":
 			if err := runCompactCmd(td, d); err != nil {
 				return err.Error()
@@ -152,6 +164,19 @@ func TestMetrics(t *testing.T) {
 			d.mu.Unlock()
 			return s
 
+		case "delay-flush":
+			d.mu.Lock()
+			defer d.mu.Unlock()
+			switch td.Input {
+			case "enable":
+				d.mu.compact.flushing = true
+			case "disable":
+				d.mu.compact.flushing = false
+			default:
+				return fmt.Sprintf("unknown directive %q (expected 'enable'/'disable')", td.Input)
+			}
+			return ""
+
 		case "flush":
 			if err := d.Flush(); err != nil {
 				return err.Error()
@@ -161,6 +186,12 @@ func TestMetrics(t *testing.T) {
 			s := d.mu.versions.currentVersion().String()
 			d.mu.Unlock()
 			return s
+
+		case "ingest":
+			if err := runIngestCmd(td, d, d.opts.FS); err != nil {
+				return err.Error()
+			}
+			return ""
 
 		case "iter-close":
 			if len(td.CmdArgs) != 1 {
@@ -253,8 +284,8 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       6         0     0 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
   total         0     0 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
-  flush         0
-compact         0     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
+  flush         0                             0 B       0          (ingest = ingested-as-flushable)
+compact         0     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         0       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         0     0 B
 zmemtbl         0     0 B

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -232,8 +232,8 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       6         1   770 B       -   1.5 K     0 B       0     0 B       0   770 B       1   1.5 K       1     0.5
   total         3   2.3 K       -   934 B   826 B       1     0 B       0   3.9 K       4   1.5 K       3     4.3
-  flush         3
-compact         1   2.3 K     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
+  flush         3                             0 B       0          (ingest = ingested-as-flushable)
+compact         1   2.3 K     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   256 K
 zmemtbl         0     0 B
@@ -244,11 +244,89 @@ zmemtbl         0     0 B
  titers         0
  filter         -       -    0.0%  (score == utility)
 
+# Set up a scenario where the table to be ingested overlaps with the memtable.
+# The table is ingested as a flushable. The flush metrics refect the flushed
+# ingestion.
+
+ingest-flushable
+----
+sync-data: wal/000012.log
+link: ext/1 -> db/000017.sst
+[JOB 13] ingesting: sstable created 000017
+sync: db
+sync-data: wal/000012.log
+close: wal/000012.log
+reuseForWrite: wal/000007.log -> wal/000018.log
+sync: wal
+[JOB 14] WAL created 000018 (recycled 000007)
+sync-data: wal/000018.log
+sync-data: wal/000018.log
+close: wal/000018.log
+create: wal/000019.log
+sync: wal
+[JOB 15] WAL created 000019
+remove: ext/1
+[JOB 13] ingested as flushable 000017 (826 B)
+sync-data: wal/000019.log
+close: wal/000019.log
+create: wal/000020.log
+sync: wal
+[JOB 16] WAL created 000020
+[JOB 17] flushing 1 memtable to L0
+create: db/000021.sst
+[JOB 17] flushing: sstable created 000021
+sync-data: db/000021.sst
+close: db/000021.sst
+sync: db
+sync: db/MANIFEST-000016
+[JOB 17] flushed 1 memtable to L0 [000021] (770 B), in 1.0s (2.0s total), output rate 770 B/s
+[JOB 18] flushing ingested tables
+create: db/MANIFEST-000022
+close: db/MANIFEST-000016
+sync: db/MANIFEST-000022
+create: db/marker.manifest.000007.MANIFEST-000022
+close: db/marker.manifest.000007.MANIFEST-000022
+remove: db/marker.manifest.000006.MANIFEST-000016
+sync: db
+[JOB 18] MANIFEST created 000022
+[JOB 18] flushed 1 ingested flushable L0:000017 (826 B) in 1.0s (2.0s total), output rate 826 B/s
+remove: db/MANIFEST-000014
+[JOB 18] MANIFEST deleted 000014
+[JOB 19] flushing 1 memtable to L0
+sync: db/MANIFEST-000022
+[JOB 19] flush error: pebble: empty table
+
+metrics
+----
+__level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___r-amp___w-amp
+    WAL         1    26 B       -    79 B       -       -       -       -   107 B       -       -       -     1.4
+      0         4   3.1 K    0.80    81 B   1.6 K       2     0 B       0   3.0 K       4     0 B       4    38.0
+      1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      2         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      3         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      4         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      6         1   770 B       -   1.5 K     0 B       0     0 B       0   770 B       1   1.5 K       1     0.5
+  total         5   3.9 K       -   1.7 K   1.6 K       2     0 B       0   5.5 K       5   1.5 K       5     3.2
+  flush         6                           826 B       1          (ingest = ingested-as-flushable)
+compact         1   3.9 K     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
+  ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
+ memtbl         1   512 K
+zmemtbl         0     0 B
+   ztbl         0     0 B
+ bcache        12   2.2 K   16.7%  (score == hit-rate)
+ tcache         1   696 B   62.5%  (score == hit-rate)
+  snaps         0       -       0  (score == earliest seq num)
+ titers         0
+ filter         -       -    0.0%  (score == utility)
+
 sstables
 ----
 0:
   13:[a-a]
   15:[a-a]
+  21:[a-a]
+  17:[a-a]
 6:
   10:[a-a]
 
@@ -268,19 +346,21 @@ sync: checkpoint
 close: checkpoint
 link: db/000013.sst -> checkpoint/000013.sst
 link: db/000015.sst -> checkpoint/000015.sst
+link: db/000021.sst -> checkpoint/000021.sst
+link: db/000017.sst -> checkpoint/000017.sst
 link: db/000010.sst -> checkpoint/000010.sst
-create: checkpoint/MANIFEST-000016
-sync-data: checkpoint/MANIFEST-000016
-close: checkpoint/MANIFEST-000016
+create: checkpoint/MANIFEST-000022
+sync-data: checkpoint/MANIFEST-000022
+close: checkpoint/MANIFEST-000022
 open-dir: checkpoint
-create: checkpoint/marker.manifest.000001.MANIFEST-000016
-sync-data: checkpoint/marker.manifest.000001.MANIFEST-000016
-close: checkpoint/marker.manifest.000001.MANIFEST-000016
+create: checkpoint/marker.manifest.000001.MANIFEST-000022
+sync-data: checkpoint/marker.manifest.000001.MANIFEST-000022
+close: checkpoint/marker.manifest.000001.MANIFEST-000022
 sync: checkpoint
 close: checkpoint
-create: checkpoint/000012.log
-sync-data: checkpoint/000012.log
-close: checkpoint/000012.log
+create: checkpoint/000020.log
+sync-data: checkpoint/000020.log
+close: checkpoint/000020.log
 sync: checkpoint
 close: checkpoint
 
@@ -291,9 +371,9 @@ pebble: file deletion disablement invariant violated
 close
 ----
 close: db
-sync-data: wal/000012.log
-close: wal/000012.log
-close: db/MANIFEST-000016
+sync-data: wal/000020.log
+close: wal/000020.log
+close: db/MANIFEST-000022
 close: db
 close: db
 close: wal

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -41,8 +41,8 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       6         1   833 B       -     0 B   833 B       1     0 B       0     0 B       0     0 B       1     0.0
   total         1   833 B       -   833 B   833 B       1     0 B       0   833 B       0     0 B       1     1.0
-  flush         0
-compact         0     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
+  flush         0                             0 B       0          (ingest = ingested-as-flushable)
+compact         0     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         0       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   256 K
 zmemtbl         0     0 B

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -27,8 +27,8 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       6         0     0 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
   total         1   770 B       -    56 B     0 B       0     0 B       0   826 B       1     0 B       1    14.8
-  flush         1
-compact         0     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
+  flush         1                             0 B       0          (ingest = ingested-as-flushable)
+compact         0     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         0       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   256 K
 zmemtbl         1   256 K
@@ -75,8 +75,8 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       6         1   776 B       -   1.5 K     0 B       0     0 B       0   776 B       1   1.5 K       1     0.5
   total         1   776 B       -    84 B     0 B       0     0 B       0   2.3 K       3   1.5 K       1    28.6
-  flush         2
-compact         1     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
+  flush         2                             0 B       0          (ingest = ingested-as-flushable)
+compact         1     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   256 K
 zmemtbl         2   512 K
@@ -108,8 +108,8 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       6         1   776 B       -   1.5 K     0 B       0     0 B       0   776 B       1   1.5 K       1     0.5
   total         1   776 B       -    84 B     0 B       0     0 B       0   2.3 K       3   1.5 K       1    28.6
-  flush         2
-compact         1     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
+  flush         2                             0 B       0          (ingest = ingested-as-flushable)
+compact         1     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   256 K
 zmemtbl         1   256 K
@@ -138,8 +138,8 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       6         1   776 B       -   1.5 K     0 B       0     0 B       0   776 B       1   1.5 K       1     0.5
   total         1   776 B       -    84 B     0 B       0     0 B       0   2.3 K       3   1.5 K       1    28.6
-  flush         2
-compact         1     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
+  flush         2                             0 B       0          (ingest = ingested-as-flushable)
+compact         1     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   256 K
 zmemtbl         1   256 K
@@ -171,8 +171,8 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       6         1   776 B       -   1.5 K     0 B       0     0 B       0   776 B       1   1.5 K       1     0.5
   total         1   776 B       -    84 B     0 B       0     0 B       0   2.3 K       3   1.5 K       1    28.6
-  flush         2
-compact         1     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
+  flush         2                             0 B       0          (ingest = ingested-as-flushable)
+compact         1     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   256 K
 zmemtbl         0     0 B
@@ -230,8 +230,8 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0     0 B
       6         1   776 B       -   1.5 K     0 B       0     0 B       0   776 B       1   1.5 K       1     0.5     0 B
   total         4   3.3 K       -   242 B     0 B       0     0 B       0   5.0 K       6   1.5 K       2    21.4    38 B
-  flush         3
-compact         1   3.3 K     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
+  flush         3                             0 B       0          (ingest = ingested-as-flushable)
+compact         1   3.3 K     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   256 K
 zmemtbl         0     0 B
@@ -273,8 +273,8 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0     0 B
       6         3   2.5 K       -   4.1 K     0 B       0     0 B       0   2.5 K       3   4.1 K       1     0.6    41 B
   total         3   2.5 K       -   242 B     0 B       0     0 B       0   6.8 K       8   4.1 K       1    28.9    41 B
-  flush         3
-compact         2     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
+  flush         3                             0 B       0          (ingest = ingested-as-flushable)
+compact         2     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         2       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   256 K
 zmemtbl         0     0 B
@@ -296,3 +296,80 @@ block bytes written:
       4          0 B          0 B
       5          0 B          0 B
       6        143 B         41 B
+
+# Flushable ingestion metrics. This requires there be data in a memtable that
+# would overlap with the ingested table(s). Delayed flushes are disabled here to
+# prevent the ingestion from immediately triggering a flush of the memtable.
+# Instead, we wish to flush manually _after_ the ingestion of the two tables has
+# completed, linking the two tables into the flushable queue.
+
+delay-flush
+enable
+----
+
+batch
+set d d
+set e e
+set f f
+----
+
+build ext1.sst
+set d d
+----
+
+build ext2.sst
+set e e
+----
+
+ingest ext1.sst ext2.sst
+----
+
+build ext3.sst
+set f f
+----
+
+ingest ext3.sst
+----
+
+delay-flush
+disable
+----
+
+flush
+----
+0.1:
+  000015:[d#13,SET-d#13,SET]
+  000016:[e#14,SET-e#14,SET]
+  000019:[f#15,SET-f#15,SET]
+0.0:
+  000023:[d#10,SET-f#12,SET]
+6:
+  000008:[a#0,SET-b#0,SET]
+  000013:[c@20#0,SET-c@16#0,SET]
+  000014:[c@15#0,SET-c@14#0,SET]
+
+# We expect the ingested-as-flushable count to be three (one for each ingested
+# table).
+metrics
+----
+__level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___r-amp___w-amp__val-bl
+    WAL         1    26 B       -   176 B       -       -       -       -   175 B       -       -       -     1.0
+      0         4   3.2 K    0.50   149 B   2.4 K       3     0 B       0   4.8 K       6     0 B       2    33.1     0 B
+      1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0     0 B
+      2         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0     0 B
+      3         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0     0 B
+      4         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0     0 B
+      5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0     0 B
+      6         3   2.5 K       -   4.1 K     0 B       0     0 B       0   2.5 K       3   4.1 K       1     0.6    41 B
+  total         7   5.7 K       -   2.6 K   2.4 K       3     0 B       0    10 K       9   4.1 K       3     3.8    41 B
+  flush         8                           2.4 K       3          (ingest = ingested-as-flushable)
+compact         2   5.7 K     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
+  ctype         2       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
+ memtbl         1   1.0 M
+zmemtbl         0     0 B
+   ztbl         0     0 B
+ bcache        16   2.9 K   34.4%  (score == hit-rate)
+ tcache         3   2.0 K   63.6%  (score == hit-rate)
+  snaps         0       -       0  (score == earliest seq num)
+ titers         0
+ filter         -       -    0.0%  (score == utility)

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -20,8 +20,8 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       6         0     0 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
   total         1   986 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
-  flush         0
-compact         0     0 B     0 B       0          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
+  flush         0                             0 B       0          (ingest = ingested-as-flushable)
+compact         0     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         0       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   256 K
 zmemtbl         0     0 B


### PR DESCRIPTION
The new flushable ingest is designed to allow tables to be lazily ingested in the case where there is overlap with the memtable. To provide visibility into how the feature is being used, add two new flush metrics - a counter for each flushable ingest, and a counter for the number of bytes ingested as flushables.

Add the two new counts to the `Metrics` output. The formatting was altered slightly to improve the alignment.

Enhance the event logging for flushable ingests by printing the level into which the table is ingested.