### PR TITLE
Makefile: update `stress-crossversion` to exercise 23.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ crossversion-meta:
 
 .PHONY: stress-crossversion
 stress-crossversion:
-	STRESS=1 ./scripts/run-crossversion-meta.sh crl-release-21.2 crl-release-22.1 crl-release-22.2 master
+	STRESS=1 ./scripts/run-crossversion-meta.sh crl-release-21.2 crl-release-22.1 crl-release-22.2 crl-release-23.1 master
 
 .PHONY: generate
 generate:


### PR DESCRIPTION
Now that a Pebble branch for 23.1 has been created, update runs of `make stress-crossversion` on master to test 23.1 separately from master. I've left testing of 21.2 for now.

The Nightly Pebble Metamorphic Crossversion teamcity configuration has also been updated to add `crl-release-23.1` to the command arguments.