### PR TITLE
sstable: fix RewriteKeySuffixes to disallow format changes

### DIFF
--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -425,7 +425,7 @@ func runRewriteCmd(
 	}
 
 	f := &memFile{}
-	meta, err := rewriteKeySuffixesInBlocks(r, f, opts, from, to, 2)
+	meta, _, err := rewriteKeySuffixesInBlocks(r, f, opts, from, to, 2)
 	if err != nil {
 		return nil, r, errors.Wrap(err, "rewrite failed")
 	}

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -9,24 +9,14 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/bytealloc"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/objstorage"
 )
 
-// RewriteKeySuffixes copies the content of the passed SSTable bytes to a new
-// sstable, written to `out`, in which the suffix `from` has is replaced with
-// `to` in every key. The input sstable must consist of only Sets or RangeKeySets
-// and every key must have `from` as its suffix as determined by the Split
-// function of the Comparer in the passed WriterOptions. Range deletes must not
-// exist in this sstable, as they will be ignored.
+// RewriteKeySuffixes is deprecated.
 //
-// Data blocks are rewritten in parallel by `concurrency` workers and then
-// assembled into a final SST. Filters are copied from the original SST without
-// modification as they are not affected by the suffix, while block and table
-// properties are only minimally recomputed.
-//
-// Any block and table property collectors configured in the WriterOptions must
-// implement SuffixReplaceableTableCollector/SuffixReplaceableBlockCollector.
+// TODO(sumeer): remove after switching CockroachDB to RewriteKeySuffixesAndReturnFormat.
 func RewriteKeySuffixes(
 	sst []byte,
 	rOpts ReaderOptions,
@@ -35,9 +25,41 @@ func RewriteKeySuffixes(
 	from, to []byte,
 	concurrency int,
 ) (*WriterMetadata, error) {
+	meta, _, err := RewriteKeySuffixesAndReturnFormat(sst, rOpts, out, o, from, to, concurrency)
+	return meta, err
+}
+
+// RewriteKeySuffixesAndReturnFormat copies the content of the passed SSTable
+// bytes to a new sstable, written to `out`, in which the suffix `from` has is
+// replaced with `to` in every key. The input sstable must consist of only
+// Sets or RangeKeySets and every key must have `from` as its suffix as
+// determined by the Split function of the Comparer in the passed
+// WriterOptions. Range deletes must not exist in this sstable, as they will
+// be ignored.
+//
+// Data blocks are rewritten in parallel by `concurrency` workers and then
+// assembled into a final SST. Filters are copied from the original SST without
+// modification as they are not affected by the suffix, while block and table
+// properties are only minimally recomputed.
+//
+// Any block and table property collectors configured in the WriterOptions must
+// implement SuffixReplaceableTableCollector/SuffixReplaceableBlockCollector.
+//
+// The WriterOptions.TableFormat is ignored, and the output sstable has the
+// same TableFormat as the input, which is returned in case the caller wants
+// to do some error checking. Suffix rewriting is meant to be efficient, and
+// allowing changes in the TableFormat detracts from that efficiency.
+func RewriteKeySuffixesAndReturnFormat(
+	sst []byte,
+	rOpts ReaderOptions,
+	out objstorage.Writable,
+	o WriterOptions,
+	from, to []byte,
+	concurrency int,
+) (*WriterMetadata, TableFormat, error) {
 	r, err := NewMemReader(sst, rOpts)
 	if err != nil {
-		return nil, err
+		return nil, TableFormatUnspecified, err
 	}
 	defer r.Close()
 	return rewriteKeySuffixesInBlocks(r, out, o, from, to, concurrency)
@@ -45,17 +67,23 @@ func RewriteKeySuffixes(
 
 func rewriteKeySuffixesInBlocks(
 	r *Reader, out objstorage.Writable, o WriterOptions, from, to []byte, concurrency int,
-) (*WriterMetadata, error) {
+) (*WriterMetadata, TableFormat, error) {
 	if o.Comparer == nil || o.Comparer.Split == nil {
-		return nil, errors.New("a valid splitter is required to define suffix to replace replace suffix")
+		return nil, TableFormatUnspecified,
+			errors.New("a valid splitter is required to rewrite suffixes")
 	}
 	if concurrency < 1 {
-		return nil, errors.New("concurrency must be >= 1")
+		return nil, TableFormatUnspecified, errors.New("concurrency must be >= 1")
 	}
-	if r.Properties.NumValueBlocks > 0 {
-		return nil, errors.New("sstable with a single suffix should not have value blocks")
+	// Even though NumValueBlocks = 0 => NumValuesInValueBlocks = 0, check both
+	// as a defensive measure.
+	if r.Properties.NumValueBlocks > 0 || r.Properties.NumValuesInValueBlocks > 0 {
+		return nil, TableFormatUnspecified,
+			errors.New("sstable with a single suffix should not have value blocks")
 	}
 
+	tableFormat := r.tableFormat
+	o.TableFormat = tableFormat
 	w := NewWriter(out, o)
 	defer func() {
 		if w != nil {
@@ -65,27 +93,29 @@ func rewriteKeySuffixesInBlocks(
 
 	for _, c := range w.propCollectors {
 		if _, ok := c.(SuffixReplaceableTableCollector); !ok {
-			return nil, errors.Errorf("property collector %s does not support suffix replacement", c.Name())
+			return nil, TableFormatUnspecified,
+				errors.Errorf("property collector %s does not support suffix replacement", c.Name())
 		}
 	}
 	for _, c := range w.blockPropCollectors {
 		if _, ok := c.(SuffixReplaceableBlockCollector); !ok {
-			return nil, errors.Errorf("block property collector %s does not support suffix replacement", c.Name())
+			return nil, TableFormatUnspecified,
+				errors.Errorf("block property collector %s does not support suffix replacement", c.Name())
 		}
 	}
 
 	l, err := r.Layout()
 	if err != nil {
-		return nil, errors.Wrap(err, "reading layout")
+		return nil, TableFormatUnspecified, errors.Wrap(err, "reading layout")
 	}
 
 	if err := rewriteDataBlocksToWriter(r, w, l.Data, from, to, w.split, concurrency); err != nil {
-		return nil, errors.Wrap(err, "rewriting data blocks")
+		return nil, TableFormatUnspecified, errors.Wrap(err, "rewriting data blocks")
 	}
 
 	// Copy over the range key block and replace suffixes in it if it exists.
 	if err := rewriteRangeKeyBlockToWriter(r, w, from, to); err != nil {
-		return nil, errors.Wrap(err, "rewriting range key blocks")
+		return nil, TableFormatUnspecified, errors.Wrap(err, "rewriting range key blocks")
 	}
 
 	// Copy over the filter block if it exists (rewriteDataBlocksToWriter will
@@ -93,7 +123,7 @@ func rewriteKeySuffixesInBlocks(
 	if w.filter != nil && l.Filter.Length > 0 {
 		filterBlock, _, err := readBlockBuf(r, l.Filter, nil)
 		if err != nil {
-			return nil, errors.Wrap(err, "reading filter")
+			return nil, TableFormatUnspecified, errors.Wrap(err, "reading filter")
 		}
 		w.filter = copyFilterWriter{
 			origPolicyName: w.filter.policyName(), origMetaName: w.filter.metaName(), data: filterBlock,
@@ -102,11 +132,11 @@ func rewriteKeySuffixesInBlocks(
 
 	if err := w.Close(); err != nil {
 		w = nil
-		return nil, err
+		return nil, TableFormatUnspecified, err
 	}
 	writerMeta, err := w.Metadata()
 	w = nil
-	return writerMeta, err
+	return writerMeta, tableFormat, err
 }
 
 var errBadKind = errors.New("key does not have expected kind (set)")
@@ -187,7 +217,24 @@ func rewriteBlocks(
 			copy(scratch.UserKey, key.UserKey[:si])
 			copy(scratch.UserKey[si:], to)
 
+			// NB: for TableFormatPebblev3, since
+			// !iter.lazyValueHandling.hasValuePrefix, it will return the raw value
+			// in the block, which includes the 1-byte prefix. This is fine since bw
+			// also does not know about the prefix and will preserve it in bw.add.
 			v := val.InPlaceValue()
+			if invariants.Enabled && r.tableFormat == TableFormatPebblev3 &&
+				key.Kind() == InternalKeyKindSet {
+				if len(v) < 1 {
+					return errors.Errorf("value has no prefix")
+				}
+				prefix := valuePrefix(v[0])
+				if isValueHandle(prefix) {
+					return errors.Errorf("value prefix is incorrect")
+				}
+				if setHasSamePrefix(prefix) {
+					return errors.Errorf("multiple keys with same key prefix")
+				}
+			}
 			bw.add(scratch, v)
 			if output[i].start.UserKey == nil {
 				keyAlloc, output[i].start = cloneKeyWithBuf(scratch, keyAlloc)
@@ -391,7 +438,7 @@ func RewriteKeySuffixesViaWriter(
 	r *Reader, out objstorage.Writable, o WriterOptions, from, to []byte,
 ) (*WriterMetadata, error) {
 	if o.Comparer == nil || o.Comparer.Split == nil {
-		return nil, errors.New("a valid splitter is required to define suffix to replace replace suffix")
+		return nil, errors.New("a valid splitter is required to rewrite suffixes")
 	}
 
 	w := NewWriter(out, o)

--- a/sstable/testdata/rewriter
+++ b/sstable/testdata/rewriter
@@ -8,7 +8,7 @@ seqnums:  [1-1]
 
 rewrite from=xyz to=123 block-size=1 index-block-size=1 filter
 ----
-rewrite failed: a valid splitter is required to define suffix to replace replace suffix
+rewrite failed: a valid splitter is required to rewrite suffixes
 
 rewrite from=xyz to=123 block-size=1 index-block-size=1 filter comparer-split-4b-suffix
 ----

--- a/sstable/testdata/rewriter_v3
+++ b/sstable/testdata/rewriter_v3
@@ -8,7 +8,7 @@ seqnums:  [1-1]
 
 rewrite from=xyz to=123 block-size=1 index-block-size=1 filter
 ----
-rewrite failed: a valid splitter is required to define suffix to replace replace suffix
+rewrite failed: a valid splitter is required to rewrite suffixes
 
 rewrite from=xyz to=123 block-size=1 index-block-size=1 filter comparer-split-4b-suffix
 ----


### PR DESCRIPTION
The code was broken both for v2=>v3 and v3=>v2 transitions. The modified test would catch both bugs. The test now also verifies that the vanilla rewrite and this optimized rewrite produce the same output.

Informs https://github.com/cockroachdb/cockroach/issues/97076