### PR TITLE
objstorage: add Context to some operations

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2727,7 +2727,7 @@ func (d *DB) runCompaction(
 		pendingOutputs = append(pendingOutputs, fileMeta)
 		d.mu.Unlock()
 
-		writable, objMeta, err := d.objProvider.Create(fileTypeTable, fileNum, objstorage.CreateOptions{} /* TODO */)
+		writable, objMeta, err := d.objProvider.Create(context.TODO(), fileTypeTable, fileNum, objstorage.CreateOptions{} /* TODO */)
 		if err != nil {
 			return err
 		}

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1000,7 +1000,7 @@ func TestCompaction(t *testing.T) {
 		for _, levelMetadata := range v.Levels {
 			iter := levelMetadata.Iter()
 			for meta := iter.First(); meta != nil; meta = iter.Next() {
-				f, err := provider.OpenForReading(base.FileTypeTable, meta.FileNum)
+				f, err := provider.OpenForReading(context.Background(), base.FileTypeTable, meta.FileNum)
 				if err != nil {
 					return "", "", errors.WithStack(err)
 				}

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -6,6 +6,7 @@ package pebble
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -1682,7 +1683,7 @@ func TestIngestCleanup(t *testing.T) {
 			// Create the files in the VFS.
 			metaMap := make(map[base.FileNum]objstorage.Writable)
 			for _, fn := range fns {
-				w, _, err := objProvider.Create(base.FileTypeTable, fn, objstorage.CreateOptions{})
+				w, _, err := objProvider.Create(context.Background(), base.FileTypeTable, fn, objstorage.CreateOptions{})
 				require.NoError(t, err)
 
 				metaMap[fn] = w

--- a/objstorage/noop_readahead.go
+++ b/objstorage/noop_readahead.go
@@ -4,20 +4,25 @@
 
 package objstorage
 
-import "io"
+import "context"
 
 // NoopReadHandle can be used by Readable implementations that don't
 // support read-ahead.
 type NoopReadHandle struct {
-	io.ReaderAt
+	readable Readable
 }
 
 // MakeNoopReadHandle initializes a NoopReadHandle.
-func MakeNoopReadHandle(r io.ReaderAt) NoopReadHandle {
-	return NoopReadHandle{ReaderAt: r}
+func MakeNoopReadHandle(r Readable) NoopReadHandle {
+	return NoopReadHandle{readable: r}
 }
 
 var _ ReadHandle = (*NoopReadHandle)(nil)
+
+// ReadAt is part of the ReadHandle interface.
+func (h *NoopReadHandle) ReadAt(ctx context.Context, p []byte, off int64) (n int, err error) {
+	return h.readable.ReadAt(ctx, p, off)
+}
 
 // Close is part of the ReadHandle interface.
 func (*NoopReadHandle) Close() error { return nil }

--- a/objstorage/noop_readahead.go
+++ b/objstorage/noop_readahead.go
@@ -31,4 +31,4 @@ func (*NoopReadHandle) Close() error { return nil }
 func (*NoopReadHandle) MaxReadahead() {}
 
 // RecordCacheHit is part of the ReadHandle interface.
-func (*NoopReadHandle) RecordCacheHit(offset, size int64) {}
+func (*NoopReadHandle) RecordCacheHit(_ context.Context, offset, size int64) {}

--- a/objstorage/provider.go
+++ b/objstorage/provider.go
@@ -5,7 +5,7 @@
 package objstorage
 
 import (
-	"io"
+	"context"
 	"os"
 	"sort"
 	"sync"
@@ -57,8 +57,24 @@ type Provider struct {
 
 // Readable is the handle for an object that is open for reading.
 type Readable interface {
-	io.ReaderAt
-	io.Closer
+	// ReadAt reads len(p) bytes into p starting at offset off. It returns the
+	// number of bytes read (0 <= n <= len(p)) and any error encountered.
+	//
+	// When ReadAt returns n < len(p), it returns a non-nil error explaining why
+	// more bytes were not returned.
+	//
+	// Even if ReadAt returns n < len(p), it may use all of p as scratch space
+	// during the call. If some data is available but not len(p) bytes, ReadAt
+	// blocks until either all the data is available or an error occurs.
+	//
+	// If the n = len(p) bytes returned by ReadAt are at the end of the input
+	// source, ReadAt may return either err == EOF or err == nil.
+	//
+	// Clients of ReadAt can execute parallel ReadAt calls on the
+	// same input source.
+	ReadAt(ctx context.Context, p []byte, off int64) (n int, err error)
+
+	Close() error
 
 	// Size returns the size of the object.
 	Size() int64
@@ -75,8 +91,24 @@ type Readable interface {
 // ReadHandle is used to perform reads that are related and might benefit from
 // optimizations like read-ahead.
 type ReadHandle interface {
-	io.ReaderAt
-	io.Closer
+	// ReadAt reads len(p) bytes into p starting at offset off. It returns the
+	// number of bytes read (0 <= n <= len(p)) and any error encountered.
+	//
+	// When ReadAt returns n < len(p), it returns a non-nil error explaining why
+	// more bytes were not returned.
+	//
+	// Even if ReadAt returns n < len(p), it may use all of p as scratch space
+	// during the call. If some data is available but not len(p) bytes, ReadAt
+	// blocks until either all the data is available or an error occurs.
+	//
+	// If the n = len(p) bytes returned by ReadAt are at the end of the input
+	// source, ReadAt may return either err == EOF or err == nil.
+	//
+	// Clients of ReadAt can execute parallel ReadAt calls on the
+	// same input source.
+	ReadAt(ctx context.Context, p []byte, off int64) (n int, err error)
+
+	Close() error
 
 	// MaxReadahead configures the implementation to expect large sequential
 	// reads. Used to skip any initial read-ahead ramp-up.

--- a/objstorage/provider.go
+++ b/objstorage/provider.go
@@ -85,7 +85,7 @@ type Readable interface {
 	// The ReadHandle must be closed before the Readable is closed.
 	//
 	// Multiple separate ReadHandles can be used.
-	NewReadHandle() ReadHandle
+	NewReadHandle(ctx context.Context) ReadHandle
 }
 
 // ReadHandle is used to perform reads that are related and might benefit from

--- a/objstorage/provider.go
+++ b/objstorage/provider.go
@@ -260,23 +260,25 @@ func (p *Provider) Close() error {
 }
 
 // OpenForReading opens an existing object.
-func (p *Provider) OpenForReading(fileType base.FileType, fileNum base.FileNum) (Readable, error) {
+func (p *Provider) OpenForReading(
+	ctx context.Context, fileType base.FileType, fileNum base.FileNum,
+) (Readable, error) {
 	meta, err := p.Lookup(fileType, fileNum)
 	if err != nil {
 		return nil, err
 	}
 
 	if !meta.IsShared() {
-		return p.vfsOpenForReading(fileType, fileNum, false /* mustExist */)
+		return p.vfsOpenForReading(ctx, fileType, fileNum, false /* mustExist */)
 	}
-	return p.sharedOpenForReading(meta)
+	return p.sharedOpenForReading(ctx, meta)
 }
 
 // OpenForReadingMustExist is a variant of OpenForReading which causes a fatal
 // error if the file does not exist. The fatal error message contains
 // information helpful for debugging.
 func (p *Provider) OpenForReadingMustExist(
-	fileType base.FileType, fileNum base.FileNum,
+	ctx context.Context, fileType base.FileType, fileNum base.FileNum,
 ) (Readable, error) {
 	meta, err := p.Lookup(fileType, fileNum)
 	if err != nil {
@@ -285,11 +287,11 @@ func (p *Provider) OpenForReadingMustExist(
 	}
 
 	if !meta.IsShared() {
-		return p.vfsOpenForReading(fileType, fileNum, true /* mustExist */)
+		return p.vfsOpenForReading(ctx, fileType, fileNum, true /* mustExist */)
 	}
 
 	// TODO(radu): implement "must exist" behavior.
-	return p.sharedOpenForReading(meta)
+	return p.sharedOpenForReading(ctx, meta)
 }
 
 // CreateOptions contains optional arguments for Create.

--- a/objstorage/provider.go
+++ b/objstorage/provider.go
@@ -116,7 +116,7 @@ type ReadHandle interface {
 
 	// RecordCacheHit informs the implementation that we were able to retrieve a
 	// block from cache.
-	RecordCacheHit(offset, size int64)
+	RecordCacheHit(ctx context.Context, offset, size int64)
 }
 
 // Writable is the handle for an object that is open for writing.

--- a/objstorage/provider.go
+++ b/objstorage/provider.go
@@ -306,12 +306,12 @@ type CreateOptions struct {
 // The object is not guaranteed to be durable (accessible in case of crashes)
 // until Sync is called.
 func (p *Provider) Create(
-	fileType base.FileType, fileNum base.FileNum, opts CreateOptions,
+	ctx context.Context, fileType base.FileType, fileNum base.FileNum, opts CreateOptions,
 ) (w Writable, meta ObjectMetadata, err error) {
 	if opts.PreferSharedStorage && p.st.Shared.Storage != nil {
-		w, meta, err = p.sharedCreate(fileType, fileNum)
+		w, meta, err = p.sharedCreate(ctx, fileType, fileNum)
 	} else {
-		w, meta, err = p.vfsCreate(fileType, fileNum)
+		w, meta, err = p.vfsCreate(ctx, fileType, fileNum)
 	}
 	if err != nil {
 		err = errors.Wrapf(err, "creating object %s", errors.Safe(fileNum))

--- a/objstorage/provider_test.go
+++ b/objstorage/provider_test.go
@@ -87,7 +87,7 @@ func TestProvider(t *testing.T) {
 				default:
 					d.Fatalf(t, "'%s' should be 'local' or 'shared'", typ)
 				}
-				w, _, err := curProvider.Create(base.FileTypeTable, fileNum, opts)
+				w, _, err := curProvider.Create(ctx, base.FileTypeTable, fileNum, opts)
 				if err != nil {
 					return err.Error()
 				}
@@ -175,7 +175,7 @@ func TestNotExistError(t *testing.T) {
 	_, err = provider.OpenForReading(context.Background(), base.FileTypeTable, 1)
 	require.True(t, IsNotExistError(err))
 
-	w, _, err := provider.Create(base.FileTypeTable, 1, CreateOptions{})
+	w, _, err := provider.Create(context.Background(), base.FileTypeTable, 1, CreateOptions{})
 	require.NoError(t, err)
 	require.NoError(t, w.Write([]byte("foo")))
 	require.NoError(t, w.Finish())

--- a/objstorage/provider_test.go
+++ b/objstorage/provider_test.go
@@ -43,6 +43,7 @@ func TestProvider(t *testing.T) {
 					}
 				}
 			}
+			ctx := context.Background()
 
 			log.Reset()
 			switch d.Cmd {
@@ -98,12 +99,12 @@ func TestProvider(t *testing.T) {
 			case "read":
 				var fileNum base.FileNum
 				scanArgs("<file-num>", &fileNum)
-				r, err := curProvider.OpenForReading(base.FileTypeTable, fileNum)
+				r, err := curProvider.OpenForReading(ctx, base.FileTypeTable, fileNum)
 				if err != nil {
 					return err.Error()
 				}
 				data := make([]byte, int(r.Size()))
-				n, err := r.ReadAt(context.Background(), data, 0)
+				n, err := r.ReadAt(ctx, data, 0)
 				require.NoError(t, err)
 				require.Equal(t, n, len(data))
 				return log.String() + fmt.Sprintf("data: %s\n", string(data))
@@ -171,7 +172,7 @@ func TestNotExistError(t *testing.T) {
 	require.NoError(t, err)
 
 	require.True(t, IsNotExistError(provider.Remove(base.FileTypeTable, 1)))
-	_, err = provider.OpenForReading(base.FileTypeTable, 1)
+	_, err = provider.OpenForReading(context.Background(), base.FileTypeTable, 1)
 	require.True(t, IsNotExistError(err))
 
 	w, _, err := provider.Create(base.FileTypeTable, 1, CreateOptions{})

--- a/objstorage/provider_test.go
+++ b/objstorage/provider_test.go
@@ -5,6 +5,7 @@
 package objstorage
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -102,7 +103,7 @@ func TestProvider(t *testing.T) {
 					return err.Error()
 				}
 				data := make([]byte, int(r.Size()))
-				n, err := r.ReadAt(data, 0)
+				n, err := r.ReadAt(context.Background(), data, 0)
 				require.NoError(t, err)
 				require.Equal(t, n, len(data))
 				return log.String() + fmt.Sprintf("data: %s\n", string(data))

--- a/objstorage/shared.go
+++ b/objstorage/shared.go
@@ -134,7 +134,7 @@ func sharedObjectName(meta ObjectMetadata) string {
 }
 
 func (p *Provider) sharedCreate(
-	fileType base.FileType, fileNum base.FileNum,
+	_ context.Context, fileType base.FileType, fileNum base.FileNum,
 ) (Writable, ObjectMetadata, error) {
 	if err := p.sharedCheckInitialized(); err != nil {
 		return nil, ObjectMetadata{}, err

--- a/objstorage/shared.go
+++ b/objstorage/shared.go
@@ -5,6 +5,7 @@
 package objstorage
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -155,7 +156,9 @@ func (p *Provider) sharedCreate(
 	}, meta, nil
 }
 
-func (p *Provider) sharedOpenForReading(meta ObjectMetadata) (Readable, error) {
+func (p *Provider) sharedOpenForReading(
+	ctx context.Context, meta ObjectMetadata,
+) (Readable, error) {
 	if err := p.sharedCheckInitialized(); err != nil {
 		return nil, err
 	}

--- a/objstorage/shared_readable.go
+++ b/objstorage/shared_readable.go
@@ -95,4 +95,4 @@ func (r *sharedReadHandle) Close() error {
 
 func (r *sharedReadHandle) MaxReadahead() {}
 
-func (r *sharedReadHandle) RecordCacheHit(offset, size int64) {}
+func (r *sharedReadHandle) RecordCacheHit(_ context.Context, offset, size int64) {}

--- a/objstorage/shared_readable.go
+++ b/objstorage/shared_readable.go
@@ -48,7 +48,7 @@ func (r *sharedReadable) Size() int64 {
 	return r.size
 }
 
-func (r *sharedReadable) NewReadHandle() ReadHandle {
+func (r *sharedReadable) NewReadHandle(_ context.Context) ReadHandle {
 	// TODO(radu): use a pool.
 	return &sharedReadHandle{readable: r}
 }

--- a/objstorage/shared_readable.go
+++ b/objstorage/shared_readable.go
@@ -5,6 +5,7 @@
 package objstorage
 
 import (
+	"context"
 	"io"
 
 	"github.com/cockroachdb/pebble/objstorage/shared"
@@ -33,8 +34,8 @@ func newSharedReadable(storage shared.Storage, objName string, size int64) *shar
 	return r
 }
 
-func (r *sharedReadable) ReadAt(p []byte, offset int64) (n int, err error) {
-	return r.rh.ReadAt(p, offset)
+func (r *sharedReadable) ReadAt(ctx context.Context, p []byte, offset int64) (n int, err error) {
+	return r.rh.ReadAt(ctx, p, offset)
 }
 
 func (r *sharedReadable) Close() error {
@@ -60,7 +61,7 @@ type sharedReadHandle struct {
 
 var _ ReadHandle = (*sharedReadHandle)(nil)
 
-func (r *sharedReadHandle) ReadAt(p []byte, offset int64) (n int, err error) {
+func (r *sharedReadHandle) ReadAt(_ context.Context, p []byte, offset int64) (n int, err error) {
 	// See if this continues the previous read so that we can reuse the last reader.
 	if r.lastReader == nil || r.lastOffset != offset {
 		// We need to create a new reader.

--- a/objstorage/vfs.go
+++ b/objstorage/vfs.go
@@ -37,7 +37,7 @@ func (p *Provider) vfsOpenForReading(
 }
 
 func (p *Provider) vfsCreate(
-	fileType base.FileType, fileNum base.FileNum,
+	_ context.Context, fileType base.FileType, fileNum base.FileNum,
 ) (Writable, ObjectMetadata, error) {
 	filename := p.vfsPath(fileType, fileNum)
 	file, err := p.st.FS.Create(filename)

--- a/objstorage/vfs.go
+++ b/objstorage/vfs.go
@@ -5,6 +5,8 @@
 package objstorage
 
 import (
+	"context"
+
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/vfs"
@@ -15,7 +17,7 @@ func (p *Provider) vfsPath(fileType base.FileType, fileNum base.FileNum) string 
 }
 
 func (p *Provider) vfsOpenForReading(
-	fileType base.FileType, fileNum base.FileNum, mustExist bool,
+	ctx context.Context, fileType base.FileType, fileNum base.FileNum, mustExist bool,
 ) (Readable, error) {
 	filename := p.vfsPath(fileType, fileNum)
 	file, err := p.st.FS.Open(filename, vfs.RandomReadsOption)

--- a/objstorage/vfs_readable.go
+++ b/objstorage/vfs_readable.go
@@ -5,6 +5,7 @@
 package objstorage
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sync"
@@ -47,7 +48,7 @@ func newFileReadable(file vfs.File, fs vfs.FS, filename string) (*fileReadable, 
 }
 
 // ReadAt is part of the objstorage.Readable interface.
-func (r *fileReadable) ReadAt(p []byte, off int64) (n int, err error) {
+func (r *fileReadable) ReadAt(_ context.Context, p []byte, off int64) (n int, err error) {
 	return r.file.ReadAt(p, off)
 }
 
@@ -108,7 +109,7 @@ func (rh *vfsReadHandle) Close() error {
 }
 
 // ReadAt is part of the objstorage.ReadHandle interface.
-func (rh *vfsReadHandle) ReadAt(p []byte, offset int64) (n int, err error) {
+func (rh *vfsReadHandle) ReadAt(_ context.Context, p []byte, offset int64) (n int, err error) {
 	if rh.sequentialFile != nil {
 		// Use OS-level read-ahead.
 		return rh.sequentialFile.ReadAt(p, offset)
@@ -167,8 +168,8 @@ func newGenericFileReadable(file vfs.File) (*genericFileReadable, error) {
 	r := &genericFileReadable{
 		file: file,
 		size: info.Size(),
-		rh:   MakeNoopReadHandle(file),
 	}
+	r.rh = MakeNoopReadHandle(r)
 	invariants.SetFinalizer(r, func(obj interface{}) {
 		if obj.(*genericFileReadable).file != nil {
 			fmt.Fprintf(os.Stderr, "Readable was not closed")
@@ -179,7 +180,7 @@ func newGenericFileReadable(file vfs.File) (*genericFileReadable, error) {
 }
 
 // ReadAt is part of the objstorage.Readable interface.
-func (r *genericFileReadable) ReadAt(p []byte, off int64) (n int, err error) {
+func (r *genericFileReadable) ReadAt(_ context.Context, p []byte, off int64) (n int, err error) {
 	return r.file.ReadAt(p, off)
 }
 

--- a/objstorage/vfs_readable.go
+++ b/objstorage/vfs_readable.go
@@ -64,7 +64,7 @@ func (r *fileReadable) Size() int64 {
 }
 
 // NewReadHandle is part of the objstorage.Readable interface.
-func (r *fileReadable) NewReadHandle() ReadHandle {
+func (r *fileReadable) NewReadHandle(_ context.Context) ReadHandle {
 	rh := readHandlePool.Get().(*vfsReadHandle)
 	rh.r = r
 	return rh
@@ -196,7 +196,7 @@ func (r *genericFileReadable) Size() int64 {
 }
 
 // NewReadHandle is part of the objstorage.Readable interface.
-func (r *genericFileReadable) NewReadHandle() ReadHandle {
+func (r *genericFileReadable) NewReadHandle(_ context.Context) ReadHandle {
 	return &r.rh
 }
 

--- a/objstorage/vfs_readable.go
+++ b/objstorage/vfs_readable.go
@@ -141,7 +141,7 @@ func (rh *vfsReadHandle) MaxReadahead() {
 }
 
 // RecordCacheHit is part of the objstorage.ReadHandle interface.
-func (rh *vfsReadHandle) RecordCacheHit(offset, size int64) {
+func (rh *vfsReadHandle) RecordCacheHit(_ context.Context, offset, size int64) {
 	if rh.sequentialFile != nil {
 		// Using OS-level readahead, so do nothing.
 		return

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -6,6 +6,7 @@ package sstable
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"strconv"
@@ -224,7 +225,7 @@ func runBuildRawCmd(
 		return nil, nil, err
 	}
 
-	f1, err := provider.OpenForReading(base.FileTypeTable, 0 /* fileNum */)
+	f1, err := provider.OpenForReading(context.Background(), base.FileTypeTable, 0 /* fileNum */)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -178,7 +178,7 @@ func runBuildRawCmd(
 	}
 	defer provider.Close()
 
-	f0, _, err := provider.Create(base.FileTypeTable, 0 /* fileNum */, objstorage.CreateOptions{})
+	f0, _, err := provider.Create(context.Background(), base.FileTypeTable, 0 /* fileNum */, objstorage.CreateOptions{})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -2808,7 +2808,7 @@ func (r *Reader) readBlock(
 ) (handle cache.Handle, _ error) {
 	if h := r.opts.Cache.Get(r.cacheID, r.fileNum, bh.Offset); h.Get() != nil {
 		if readHandle != nil {
-			readHandle.RecordCacheHit(int64(bh.Offset), int64(bh.Length+blockTrailerLen))
+			readHandle.RecordCacheHit(ctx, int64(bh.Offset), int64(bh.Length+blockTrailerLen))
 		}
 		if stats != nil {
 			stats.BlockBytes += bh.Length

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -2822,9 +2822,9 @@ func (r *Reader) readBlock(
 	readStartTime := time.Now()
 	var err error
 	if readHandle != nil {
-		_, err = readHandle.ReadAt(b, int64(bh.Offset))
+		_, err = readHandle.ReadAt(ctx, b, int64(bh.Offset))
 	} else {
-		_, err = r.readable.ReadAt(b, int64(bh.Offset))
+		_, err = r.readable.ReadAt(ctx, b, int64(bh.Offset))
 	}
 	readDuration := time.Since(readStartTime)
 	// TODO(sumeer): should the threshold be configurable.
@@ -3433,6 +3433,7 @@ type Layout struct {
 func (l *Layout) Describe(
 	w io.Writer, verbose bool, r *Reader, fmtRecord func(key *base.InternalKey, value []byte),
 ) {
+	ctx := context.TODO()
 	type block struct {
 		BlockHandle
 		name string
@@ -3494,7 +3495,7 @@ func (l *Layout) Describe(
 
 		if b.name == "footer" || b.name == "leveldb-footer" {
 			trailer, offset := make([]byte, b.Length), b.Offset
-			_, _ = r.readable.ReadAt(trailer, int64(offset))
+			_, _ = r.readable.ReadAt(ctx, trailer, int64(offset))
 
 			if b.name == "footer" {
 				checksumType := ChecksumType(trailer[0])
@@ -3567,7 +3568,7 @@ func (l *Layout) Describe(
 		formatTrailer := func() {
 			trailer := make([]byte, blockTrailerLen)
 			offset := int64(b.Offset + b.Length)
-			_, _ = r.readable.ReadAt(trailer, offset)
+			_, _ = r.readable.ReadAt(ctx, trailer, offset)
 			bt := blockType(trailer[0])
 			checksum := binary.LittleEndian.Uint32(trailer[1:])
 			fmt.Fprintf(w, "%10d    [trailer compression=%s checksum=0x%04x]\n", offset, bt, checksum)
@@ -3696,8 +3697,8 @@ func (l *Layout) Describe(
 	fmt.Fprintf(w, "%10d  EOF\n", last.Offset+last.Length)
 }
 
-// ReadableFile describes the smallest subset of objstorage.Readable that is
-// required for reading SSTs.
+// ReadableFile describes the smallest subset of vfs.File that is required for
+// reading SSTs.
 type ReadableFile interface {
 	io.ReaderAt
 	io.Closer
@@ -3711,21 +3712,32 @@ func NewSimpleReadable(r ReadableFile) (objstorage.Readable, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &simpleReadable{
-		ReadableFile: r,
-		size:         info.Size(),
-		rh:           objstorage.MakeNoopReadHandle(r),
-	}, nil
+	res := &simpleReadable{
+		f:    r,
+		size: info.Size(),
+	}
+	res.rh = objstorage.MakeNoopReadHandle(res)
+	return res, nil
 }
 
 // simpleReadable wraps a ReadableFile to implement objstorage.Readable.
 type simpleReadable struct {
-	ReadableFile
+	f    ReadableFile
 	size int64
 	rh   objstorage.NoopReadHandle
 }
 
 var _ objstorage.Readable = (*simpleReadable)(nil)
+
+// ReadAt is part of the objstorage.Readable interface.
+func (s *simpleReadable) ReadAt(_ context.Context, p []byte, off int64) (n int, err error) {
+	return s.f.ReadAt(p, off)
+}
+
+// Close is part of the objstorage.Readable interface.
+func (s *simpleReadable) Close() error {
+	return s.f.Close()
+}
 
 // Size is part of the objstorage.Readable interface.
 func (s *simpleReadable) Size() int64 {

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -413,7 +413,7 @@ func (i *singleLevelIterator) init(
 		_ = i.index.Close()
 		return err
 	}
-	i.dataRH = r.readable.NewReadHandle()
+	i.dataRH = r.readable.NewReadHandle(ctx)
 	if r.tableFormat == TableFormatPebblev3 {
 		if r.Properties.NumValueBlocks > 0 {
 			// NB: we cannot avoid this ~248 byte allocation, since valueBlockReader
@@ -433,7 +433,7 @@ func (i *singleLevelIterator) init(
 				stats:  stats,
 			}
 			i.data.lazyValueHandling.vbr = i.vbReader
-			i.vbRH = r.readable.NewReadHandle()
+			i.vbRH = r.readable.NewReadHandle(ctx)
 		}
 		i.data.lazyValueHandling.hasValuePrefix = true
 	}
@@ -1702,7 +1702,7 @@ func (i *twoLevelIterator) init(
 		_ = i.topLevelIndex.Close()
 		return err
 	}
-	i.dataRH = r.readable.NewReadHandle()
+	i.dataRH = r.readable.NewReadHandle(ctx)
 	if r.tableFormat == TableFormatPebblev3 {
 		if r.Properties.NumValueBlocks > 0 {
 			i.vbReader = &valueBlockReader{
@@ -1713,7 +1713,7 @@ func (i *twoLevelIterator) init(
 				stats:  stats,
 			}
 			i.data.lazyValueHandling.vbr = i.vbReader
-			i.vbRH = r.readable.NewReadHandle()
+			i.vbRH = r.readable.NewReadHandle(ctx)
 		}
 		i.data.lazyValueHandling.hasValuePrefix = true
 	}
@@ -3166,7 +3166,7 @@ func (r *Reader) ValidateBlockChecksums() error {
 
 	// Check all blocks sequentially. Make use of read-ahead, given we are
 	// scanning the entire file from start to end.
-	rh := r.readable.NewReadHandle()
+	rh := r.readable.NewReadHandle(context.TODO())
 	defer rh.Close()
 
 	for _, bh := range blocks {
@@ -3745,6 +3745,6 @@ func (s *simpleReadable) Size() int64 {
 }
 
 // NewReaddHandle is part of the objstorage.Readable interface.
-func (s *simpleReadable) NewReadHandle() objstorage.ReadHandle {
+func (s *simpleReadable) NewReadHandle(_ context.Context) objstorage.ReadHandle {
 	return &s.rh
 }

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -715,7 +715,7 @@ func TestReadaheadSetupForV3TablesWithMultipleVersions(t *testing.T) {
 		}
 	}
 	require.NoError(t, w.Close())
-	f1, err := provider.OpenForReading(base.FileTypeTable, 0 /* fileNum */)
+	f1, err := provider.OpenForReading(context.Background(), base.FileTypeTable, 0 /* fileNum */)
 	require.NoError(t, err)
 	r, err := NewReader(f1, ReaderOptions{Comparer: testkeys.Comparer})
 	require.NoError(t, err)
@@ -1091,7 +1091,7 @@ func buildTestTableWithProvider(
 	require.NoError(t, w.Close())
 
 	// Re-open that filename for reading.
-	f1, err := provider.OpenForReading(base.FileTypeTable, 0 /* fileNum */)
+	f1, err := provider.OpenForReading(context.Background(), base.FileTypeTable, 0 /* fileNum */)
 	require.NoError(t, err)
 
 	c := cache.New(128 << 20)

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -697,7 +697,7 @@ func TestReadaheadSetupForV3TablesWithMultipleVersions(t *testing.T) {
 	provider, err := objstorage.Open(objstorage.DefaultSettings(vfs.Default, tmpDir))
 	require.NoError(t, err)
 	defer provider.Close()
-	f0, _, err := provider.Create(base.FileTypeTable, 0 /* fileNum */, objstorage.CreateOptions{})
+	f0, _, err := provider.Create(context.Background(), base.FileTypeTable, 0 /* fileNum */, objstorage.CreateOptions{})
 	require.NoError(t, err)
 
 	w := NewWriter(f0, WriterOptions{
@@ -1069,7 +1069,7 @@ func buildTestTableWithProvider(
 	blockSize, indexBlockSize int,
 	compression Compression,
 ) *Reader {
-	f0, _, err := provider.Create(base.FileTypeTable, 0 /* fileNum */, objstorage.CreateOptions{})
+	f0, _, err := provider.Create(context.Background(), base.FileTypeTable, 0 /* fileNum */, objstorage.CreateOptions{})
 	require.NoError(t, err)
 
 	w := NewWriter(f0, WriterOptions{

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -488,22 +488,22 @@ func newMemReader(b []byte) *memReader {
 	return r
 }
 
-// ReadAt implements io.ReaderAt.
+// ReadAt is part of objstorage.Readable.
 func (m *memReader) ReadAt(_ context.Context, p []byte, off int64) (n int, err error) {
 	return m.r.ReadAt(p, off)
 }
 
-// Close implements io.Closer.
+// Close is part of objstorage.Readable.
 func (*memReader) Close() error {
 	return nil
 }
 
-// Stat implements objstorage.Readable.
+// Stat is part of objstorage.Readable.
 func (m *memReader) Size() int64 {
 	return int64(len(m.b))
 }
 
-// NewReadHandle implements objstorage.Readable.
-func (m *memReader) NewReadHandle() objstorage.ReadHandle {
+// NewReadHandle is part of objstorage.Readable.
+func (m *memReader) NewReadHandle(_ context.Context) objstorage.ReadHandle {
 	return &m.rh
 }

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -2,6 +2,7 @@ package sstable
 
 import (
 	"bytes"
+	"context"
 	"math"
 	"sync"
 
@@ -467,7 +468,7 @@ func readBlockBuf(r *Reader, bh BlockHandle, buf []byte) ([]byte, []byte, error)
 	return res, buf, err
 }
 
-// memReader is a thin wrapper around a []byte such that it can be passed to an
+// memReader is a thin wrapper around a []byte such that it can be passed to
 // sstable.Reader. It supports concurrent use, and does so without locking in
 // contrast to the heavier read/write vfs.MemFile.
 type memReader struct {
@@ -488,7 +489,7 @@ func newMemReader(b []byte) *memReader {
 }
 
 // ReadAt implements io.ReaderAt.
-func (m *memReader) ReadAt(p []byte, off int64) (n int, err error) {
+func (m *memReader) ReadAt(_ context.Context, p []byte, off int64) (n int, err error) {
 	return m.r.ReadAt(p, off)
 }
 

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -68,6 +68,7 @@
 package sstable // import "github.com/cockroachdb/pebble/sstable"
 
 import (
+	"context"
 	"encoding/binary"
 	"io"
 
@@ -317,7 +318,7 @@ func readFooter(f objstorage.Readable) (footer, error) {
 	if off < 0 {
 		off = 0
 	}
-	n, err := f.ReadAt(buf, off)
+	n, err := f.ReadAt(context.TODO(), buf, off)
 	if err != nil && err != io.EOF {
 		return footer, errors.Wrap(err, "pebble/table: invalid table (could not read footer)")
 	}

--- a/table_cache.go
+++ b/table_cache.go
@@ -931,7 +931,7 @@ type tableCacheValue struct {
 func (v *tableCacheValue) load(meta *fileMetadata, c *tableCacheShard, dbOpts *tableCacheOpts) {
 	// Try opening the file first.
 	var f objstorage.Readable
-	f, v.err = dbOpts.objProvider.OpenForReadingMustExist(fileTypeTable, meta.FileNum)
+	f, v.err = dbOpts.objProvider.OpenForReadingMustExist(context.TODO(), fileTypeTable, meta.FileNum)
 	if v.err == nil {
 		cacheOpts := private.SSTableCacheOpts(dbOpts.cacheID, meta.FileNum).(sstable.ReaderOption)
 		v.reader, v.err = sstable.NewReader(f, dbOpts.opts, cacheOpts, dbOpts.filterMetrics)

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -169,7 +169,7 @@ func newTableCacheContainerTest(
 	defer objProvider.Close()
 
 	for i := 0; i < tableCacheTestNumTables; i++ {
-		w, _, err := objProvider.Create(fileTypeTable, FileNum(i), objstorage.CreateOptions{})
+		w, _, err := objProvider.Create(context.Background(), fileTypeTable, FileNum(i), objstorage.CreateOptions{})
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "fs.Create")
 		}
@@ -845,7 +845,7 @@ func TestTableCacheClockPro(t *testing.T) {
 
 	makeTable := func(fileNum FileNum) {
 		require.NoError(t, err)
-		f, _, err := objProvider.Create(fileTypeTable, fileNum, objstorage.CreateOptions{})
+		f, _, err := objProvider.Create(context.Background(), fileTypeTable, fileNum, objstorage.CreateOptions{})
 		require.NoError(t, err)
 		w := sstable.NewWriter(f, sstable.WriterOptions{})
 		require.NoError(t, w.Set([]byte("a"), nil))

--- a/tool/db.go
+++ b/tool/db.go
@@ -5,6 +5,7 @@
 package tool
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"text/tabwriter"
@@ -647,7 +648,8 @@ func (p *props) update(o props) {
 }
 
 func (d *dbT) addProps(objProvider *objstorage.Provider, m *manifest.FileMetadata, p *props) error {
-	f, err := objProvider.OpenForReading(base.FileTypeTable, m.FileNum)
+	ctx := context.Background()
+	f, err := objProvider.OpenForReading(ctx, base.FileTypeTable, m.FileNum)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
These commits add a `context.Context` to various calls in the objstorage API. These contexts will be used to plumb information for objstorage IO tracing (like LSM level, block type).