### PR TITLE
db: use function for Experimental.DisableIngestAsFlushable

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -849,7 +849,7 @@ func (d *DB) ingest(
 			if ingestMemtableOverlaps(d.cmp, m, meta) {
 				if (len(d.mu.mem.queue) > d.opts.MemTableStopWritesThreshold-1) ||
 					d.mu.formatVers.vers < FormatFlushableIngest ||
-					d.opts.Experimental.DisableIngestAsFlushable {
+					d.opts.Experimental.DisableIngestAsFlushable() {
 					mem = m
 					if mem.flushable == d.mu.mem.mutable {
 						err = d.makeRoomForWrite(nil)

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -359,7 +359,9 @@ func randomOptions(rng *rand.Rand) *testOptions {
 		opts.Experimental.MaxWriterConcurrency = 2
 		opts.Experimental.ForceWriterParallelism = true
 	}
-	opts.Experimental.DisableIngestAsFlushable = rng.Intn(2) == 0
+	if rng.Intn(2) == 0 {
+		opts.Experimental.DisableIngestAsFlushable = func() bool { return true }
+	}
 	var lopts pebble.LevelOptions
 	lopts.BlockRestartInterval = 1 + rng.Intn(64)  // 1 - 64
 	lopts.BlockSize = 1 << uint(rng.Intn(24))      // 1 - 16MB

--- a/internal/metamorphic/options_test.go
+++ b/internal/metamorphic/options_test.go
@@ -65,6 +65,7 @@ func TestOptionsRoundtrip(t *testing.T) {
 		"EventListener:",
 		"MaxConcurrentCompactions:",
 		"Experimental.EnableValueBlocks:",
+		"Experimental.DisableIngestAsFlushable:",
 		// Floating points
 		"Experimental.PointTombstoneWeight:",
 	}
@@ -90,6 +91,10 @@ func TestOptionsRoundtrip(t *testing.T) {
 		require.Equal(t, o.opts.Experimental.EnableValueBlocks == nil, parsed.opts.Experimental.EnableValueBlocks == nil)
 		if o.opts.Experimental.EnableValueBlocks != nil {
 			require.Equal(t, o.opts.Experimental.EnableValueBlocks(), parsed.opts.Experimental.EnableValueBlocks())
+		}
+		require.Equal(t, o.opts.Experimental.DisableIngestAsFlushable == nil, parsed.opts.Experimental.DisableIngestAsFlushable == nil)
+		if o.opts.Experimental.DisableIngestAsFlushable != nil {
+			require.Equal(t, o.opts.Experimental.DisableIngestAsFlushable(), parsed.opts.Experimental.DisableIngestAsFlushable())
 		}
 		require.Equal(t, o.opts.MaxConcurrentCompactions(), parsed.opts.MaxConcurrentCompactions())
 


### PR DESCRIPTION
Convert the Experimental.DisableIngestAsFlushable setting to a function, allowing the client to disable ingesting sstables as flushable at runtime. This will be used to tie the setting to a cluster setting in CockroachDB.

This will be backported to 23.1.

Informs cockroachdb/cockroach#97194.