### PR TITLE
vfs: Add support for OpenBSD

### DIFF
--- a/vfs/disk_usage_openbsd.go
+++ b/vfs/disk_usage_openbsd.go
@@ -1,9 +1,9 @@
-// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-//go:build darwin || dragonfly || freebsd
-// +build darwin dragonfly freebsd
+//go:build openbsd
+// +build openbsd
 
 package vfs
 
@@ -15,9 +15,9 @@ func (defaultFS) GetDiskUsage(path string) (DiskUsage, error) {
 		return DiskUsage{}, err
 	}
 
-	freeBytes := uint64(stat.Bsize) * uint64(stat.Bfree)
-	availBytes := uint64(stat.Bsize) * uint64(stat.Bavail)
-	totalBytes := uint64(stat.Bsize) * uint64(stat.Blocks)
+	freeBytes := uint64(stat.F_bsize) * uint64(stat.F_bfree)
+	availBytes := uint64(stat.F_bsize) * uint64(stat.F_bavail)
+	totalBytes := uint64(stat.F_bsize) * uint64(stat.F_blocks)
 	return DiskUsage{
 		AvailBytes: availBytes,
 		TotalBytes: totalBytes,


### PR DESCRIPTION
  - Add `vfs/disk_usage_openbsd.go` to use `unix.Statfs` with specific fields for OpenBSD => see https://cs.opensource.google/go/x/sys/+/master:unix/ztypes_openbsd_amd64.go
  - Fix bug #2341

Tests are OK with `make test`

