### PR TITLE
crl-release-23.1: internal/lint: bump crlfmt version used

### DIFF
--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -23,7 +23,7 @@ const (
 	cmdGo       = "go"
 	golint      = "golang.org/x/lint/golint@6edffad5e6160f5949cdefc81710b2706fbcd4f6"
 	staticcheck = "honnef.co/go/tools/cmd/staticcheck@2023.1"
-	crlfmt      = "github.com/cockroachdb/crlfmt@b3eff0b"
+	crlfmt      = "github.com/cockroachdb/crlfmt@44a36ec7"
 )
 
 func dirCmd(t *testing.T, dir string, name string, args ...string) stream.Filter {


### PR DESCRIPTION
This is a backport of #2397 to 23.1.

---

Bump crlfmt to pick up a change that ignores files/directories removed while walking the filesystem tree.