### PR TITLE
ci: add build for OpenBSD

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,6 +150,11 @@ jobs:
         GOOS: netbsd
       run: go build -v ./...
 
+    - name: OpenBSD build
+      env:
+        GOOS: openbsd
+      run: go build -v ./...
+
   go-lint-checks:
     name: go-lint-checks
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a new target for build on OpenBSD : duplicate of FreeBSD/NetBSD build with `GOOS: openbsd`