### PR TITLE
Revert "Revert "db: require validity check before calling HasPointAnd…

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -250,13 +250,11 @@ func runIterCmd(d *datadriven.TestData, iter *Iterator, closeIter bool) string {
 		if valid != iter.Valid() {
 			fmt.Fprintf(&b, "mismatched valid states: %t vs %t\n", valid, iter.Valid())
 		}
-		hasPoint, hasRange := iter.HasPointAndRange()
-		hasEither := hasPoint || hasRange
-		if hasEither != valid {
-			fmt.Fprintf(&b, "mismatched valid/HasPointAndRange states: valid=%t HasPointAndRange=(%t,%t)\n", valid, hasPoint, hasRange)
-		}
-
 		if valid {
+			hasPoint, hasRange := iter.HasPointAndRange()
+			if !hasPoint && !hasRange {
+				fmt.Fprintf(&b, "mismatched valid/HasPointAndRange states: valid=%t HasPointAndRange=(%t,%t)\n", valid, hasPoint, hasRange)
+			}
 			validityState = IterValid
 		}
 		printIterState(&b, iter, validityState, printValidityState)

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -871,6 +871,10 @@ type iterSeekGEOp struct {
 func iteratorPos(i *retryableIter) string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "%q", i.Key())
+	if !i.Valid() {
+		fmt.Fprintf(&buf, "<no point>,<no range>")
+		return buf.String()
+	}
 	hasPoint, hasRange := i.HasPointAndRange()
 	if hasPoint {
 		fmt.Fprintf(&buf, ",%q", i.Value())

--- a/iterator.go
+++ b/iterator.go
@@ -2063,23 +2063,29 @@ func (i *Iterator) saveRangeKey() {
 // If false, previously obtained range key bounds, suffix and value slices are
 // still valid and may continue to be read.
 //
+// RangeKeyChanged must only be called if the iterator is Valid().
+//
 // Invalid iterator positions are considered to not hold range keys, meaning
 // that if an iterator steps from an IterExhausted or IterAtLimit position onto
 // a position with a range key, RangeKeyChanged will yield true.
 func (i *Iterator) RangeKeyChanged() bool {
-	return i.iterValidityState == IterValid && i.rangeKey != nil && i.rangeKey.updated
+	if invariants.Enabled && !i.Valid() {
+		panic("pebble: Iterator.RangeKeyChanged called on invalid iterator")
+	}
+	return i.rangeKey != nil && i.rangeKey.updated
 }
 
 // HasPointAndRange indicates whether there exists a point key, a range key or
-// both at the current iterator position.
+// both at the current iterator position. HasPointAndRange must only be called
+// if the iterator is Valid().
 func (i *Iterator) HasPointAndRange() (hasPoint, hasRange bool) {
-	if i.iterValidityState != IterValid || i.requiresReposition {
-		return false, false
+	if invariants.Enabled && !i.Valid() {
+		panic("pebble: Iterator.HasPointAndRange called on invalid iterator")
 	}
-	if i.opts.KeyTypes == IterKeyTypePointsOnly {
+	if i.rangeKey == nil || i.opts.KeyTypes == IterKeyTypePointsOnly {
 		return true, false
 	}
-	return i.rangeKey == nil || !i.rangeKey.rangeKeyOnly, i.rangeKey != nil && i.rangeKey.hasRangeKey
+	return !i.rangeKey.rangeKeyOnly, i.rangeKey.hasRangeKey
 }
 
 // RangeBounds returns the start (inclusive) and end (exclusive) bounds of the


### PR DESCRIPTION
…Range, RangeKeyChanged""

This reverts commit 10bdef44ad7c711414317c00bdefd1a822013381.

The new pkg/storage/pebbleiter.AssertionIter type asserts this contract and all violations of the contract have been fixed. I don't plan on backporting this.