### PR TITLE
db: ingest-as-flushable metric and logging tweaks

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2045,9 +2045,10 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 		d.updateReadStateLocked(d.opts.DebugCheck)
 		d.updateTableStatsLocked(ve.NewFiles)
 		if ingest {
+			d.mu.versions.metrics.Flush.AsIngestCount++
 			for _, l := range c.metrics {
 				d.mu.versions.metrics.Flush.AsIngestBytes += l.BytesIngested
-				d.mu.versions.metrics.Flush.AsIngestCount += l.TablesIngested
+				d.mu.versions.metrics.Flush.AsIngestTableCount += l.TablesIngested
 			}
 		}
 	}

--- a/event.go
+++ b/event.go
@@ -198,7 +198,7 @@ func (i FlushInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 			if j > 0 {
 				w.Printf(" +")
 			}
-			w.Printf(" L%d:%s (%s)", level, file.FileNum, humanize.IEC.Uint64(file.Size))
+			w.Printf(" L%d:%s (%s)", level, redact.Safe(file.FileNum), humanize.IEC.Uint64(file.Size))
 		}
 		w.Printf(" in %.1fs (%.1fs total), output rate %s/s",
 			redact.Safe(i.Duration.Seconds()),

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -36,8 +36,9 @@ func TestMetricsFormat(t *testing.T) {
 	m.Compact.InProgressBytes = 7
 	m.Compact.NumInProgress = 2
 	m.Flush.Count = 8
-	m.Flush.AsIngestCount = 34
-	m.Flush.AsIngestBytes = 35
+	m.Flush.AsIngestBytes = 34
+	m.Flush.AsIngestTableCount = 35
+	m.Flush.AsIngestCount = 36
 	m.Filter.Hits = 9
 	m.Filter.Misses = 10
 	m.MemTable.Size = 11
@@ -89,7 +90,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5       601   602 B  603.00   604 B   604 B     612   606 B     613   1.2 K   1.2 K   607 B       6     2.0
       6       701   702 B       -   704 B   704 B     712   706 B     713   1.4 K   1.4 K   707 B       7     2.0
   total      2807   2.7 K       -   2.8 K   2.8 K   2.9 K   2.8 K   2.9 K   8.4 K   5.7 K   2.8 K      28     3.0
-  flush         8                            35 B      34          (ingest = ingested-as-flushable)
+  flush         8                            34 B      35      36  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         5     6 B     7 B       2                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype        27      28      29      30      31      32      33  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl        12    11 B
@@ -284,7 +285,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       6         0     0 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
   total         0     0 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
-  flush         0                             0 B       0          (ingest = ingested-as-flushable)
+  flush         0                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         0     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         0       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         0     0 B

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -232,7 +232,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       6         1   770 B       -   1.5 K     0 B       0     0 B       0   770 B       1   1.5 K       1     0.5
   total         3   2.3 K       -   934 B   826 B       1     0 B       0   3.9 K       4   1.5 K       3     4.3
-  flush         3                             0 B       0          (ingest = ingested-as-flushable)
+  flush         3                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         1   2.3 K     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   256 K
@@ -311,7 +311,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       6         2   1.6 K       -   1.5 K   826 B       1     0 B       0   770 B       1   1.5 K       1     0.5
   total         6   4.7 K       -   2.5 K   2.4 K       3     0 B       0   6.3 K       5   1.5 K       5     2.5
-  flush         6                           1.6 K       2          (ingest = ingested-as-flushable)
+  flush         6                           1.6 K       2       1  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         1   4.7 K     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   512 K

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -41,7 +41,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       6         1   833 B       -     0 B   833 B       1     0 B       0     0 B       0     0 B       1     0.0
   total         1   833 B       -   833 B   833 B       1     0 B       0   833 B       0     0 B       1     1.0
-  flush         0                             0 B       0          (ingest = ingested-as-flushable)
+  flush         0                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         0     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         0       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   256 K

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -27,7 +27,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       6         0     0 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
   total         1   770 B       -    56 B     0 B       0     0 B       0   826 B       1     0 B       1    14.8
-  flush         1                             0 B       0          (ingest = ingested-as-flushable)
+  flush         1                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         0     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         0       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   256 K
@@ -75,7 +75,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       6         1   776 B       -   1.5 K     0 B       0     0 B       0   776 B       1   1.5 K       1     0.5
   total         1   776 B       -    84 B     0 B       0     0 B       0   2.3 K       3   1.5 K       1    28.6
-  flush         2                             0 B       0          (ingest = ingested-as-flushable)
+  flush         2                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         1     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   256 K
@@ -108,7 +108,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       6         1   776 B       -   1.5 K     0 B       0     0 B       0   776 B       1   1.5 K       1     0.5
   total         1   776 B       -    84 B     0 B       0     0 B       0   2.3 K       3   1.5 K       1    28.6
-  flush         2                             0 B       0          (ingest = ingested-as-flushable)
+  flush         2                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         1     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   256 K
@@ -138,7 +138,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       6         1   776 B       -   1.5 K     0 B       0     0 B       0   776 B       1   1.5 K       1     0.5
   total         1   776 B       -    84 B     0 B       0     0 B       0   2.3 K       3   1.5 K       1    28.6
-  flush         2                             0 B       0          (ingest = ingested-as-flushable)
+  flush         2                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         1     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   256 K
@@ -171,7 +171,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       6         1   776 B       -   1.5 K     0 B       0     0 B       0   776 B       1   1.5 K       1     0.5
   total         1   776 B       -    84 B     0 B       0     0 B       0   2.3 K       3   1.5 K       1    28.6
-  flush         2                             0 B       0          (ingest = ingested-as-flushable)
+  flush         2                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         1     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   256 K
@@ -230,7 +230,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0     0 B
       6         1   776 B       -   1.5 K     0 B       0     0 B       0   776 B       1   1.5 K       1     0.5     0 B
   total         4   3.3 K       -   242 B     0 B       0     0 B       0   5.0 K       6   1.5 K       2    21.4    38 B
-  flush         3                             0 B       0          (ingest = ingested-as-flushable)
+  flush         3                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         1   3.3 K     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   256 K
@@ -273,7 +273,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0     0 B
       6         3   2.5 K       -   4.1 K     0 B       0     0 B       0   2.5 K       3   4.1 K       1     0.6    41 B
   total         3   2.5 K       -   242 B     0 B       0     0 B       0   6.8 K       8   4.1 K       1    28.9    41 B
-  flush         3                             0 B       0          (ingest = ingested-as-flushable)
+  flush         3                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         2     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         2       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   256 K
@@ -362,7 +362,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0     0 B
       6         3   2.5 K       -   4.1 K     0 B       0     0 B       0   2.5 K       3   4.1 K       1     0.6    41 B
   total         7   5.7 K       -   2.6 K   2.4 K       3     0 B       0    10 K       9   4.1 K       3     3.8    41 B
-  flush         8                           2.4 K       3          (ingest = ingested-as-flushable)
+  flush         8                           2.4 K       3       2  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         2   5.7 K     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         2       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   1.0 M

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -20,7 +20,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
       5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
       6         0     0 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
   total         1   986 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
-  flush         0                             0 B       0          (ingest = ingested-as-flushable)
+  flush         0                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         0     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         0       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
  memtbl         1   256 K


### PR DESCRIPTION
**db: tweak ingest-as-flushable metrics**

Currently, the metric for ingest-as-flushable counts the number of
tables ingested, rather than the number of flushes that are handling
ingested tables. This can be confusing to the operator.

Switch the existing metric to count the flushes handling ingested
tables.

Introduce a separate metric tracking the count of tables ingested as
flushables.

---

**db: fix redaction of ingest-as-flushable filenum**

The filenum is currently not marked as safe for redaction, which results
in the field being delimited with redaction markers in Cockroach log
files.

As the file number is not sensitive, mark the field as safe.