### PR TITLE
ci: bump macOS version to 12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,7 @@ jobs:
 
   darwin:
     name: go-macos
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
Use the latest available runner image for macOS.