### PR TITLE
db: adjust range-del bytes estimate for L6 files

### DIFF
--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -60,9 +60,11 @@ type TableStats struct {
 	// overlapping data in L0 and ignores L0 sublevels, but the error that
 	// introduces is expected to be small.
 	//
-	// Tables in the bottommost level of the LSM may have a nonzero estimate
-	// if snapshots or move compactions prevented the elision of their range
-	// tombstones.
+	// Tables in the bottommost level of the LSM may have a nonzero estimate if
+	// snapshots or move compactions prevented the elision of their range
+	// tombstones. A table in the bottommost level that was ingested into L6
+	// will have a zero estimate, because the file's sequence numbers indicate
+	// that the tombstone cannot drop any data contained within the file itself.
 	RangeDeletionsBytesEstimate uint64
 	// Total size of value blocks and value index block.
 	ValueBlocksSize uint64

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -58,7 +58,7 @@ num-entries: 2
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 26
+range-deletions-bytes-estimate: 0
 
 maybe-compact
 ----

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -367,6 +367,29 @@ range-key-del a z
 compact a-z
 ----
 
+# Ingest another sstable with range tombstones again, but this time into an
+# empty LSM. The table should ingest into L6. Its table stats should reflect
+# that its range tombstones cannot delete any of the data contained within the
+# file itself.
+ingest ext1
+del-range a z
+range-key-del a z
+set d d
+set e e
+set f f
+----
+6:
+  000015:[a#8,RANGEKEYDEL-z#inf,RANGEDEL]
+
+wait-pending-table-stats
+000015
+----
+num-entries: 4
+num-deletions: 1
+num-range-key-sets: 0
+point-deletions-bytes-estimate: 0
+range-deletions-bytes-estimate: 0
+
 # A hint for exclusively range key deletions that covers a table with point keys
 # should not contain an estimate for point keys.
 


### PR DESCRIPTION
Previously, a file in L6 that contained range deletion(s) was assumed to contain range deletions due to open snapshots at the time it was written. Table stats, and in particular the RangeDeletionBytesEstimate value, was calculated assuming the range deletion dropped all keys within the sstable that fall within the range deletion's bounds. This is a decent heuristic for when snapshots were indeed open, preventing the elision of the range deletion.

However, Cockroach KV snapshot reception writes range deletions to each of the ingested sstables (see cockroachdb/cockroach#44048). These range deletions delete nothing within the tables themselves. They exist only to clear out existing state below the table in the LSM. In these cases, the RangeDeletionBytesEstimate value would be a gross overestimate. Compacting these tables would only drop the tombstones themselves and none of the actual range data contained in point blocks.

This commit adjusts the logic for calculating RangeDeletionBytesEstimate to take the range deletion sequence number into account. This small change will prevent sstables ingested through Cockroach snapshot reception from having a RangeDeletionBytesEstimate that incorrectly sums all data blocks. This has two consequences:

a) In times of low compaction pressure, we will no longer rewrite the ingested sstables through elision-only compactions simply to remove the tombstones. b) When compacting from L5 into L6, we will no longer artificially deflate these sstable's size when calculating the min-overlapping ratio heuristic.

Together, these effects should reduce write amplification/bandwidth, especially in the presence of significant rebalancing.