### PR TITLE
objstorage: implement tracing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ testmsan: export CC=clang
 testmsan: testflags += -msan -timeout 20m
 testmsan: test
 
+.PHONY: testobjiotracing
+testobjiotracing:
+	${GO} test -tags '$(TAGS) pebble_obj_io_tracing' ${testflags} -run ${TESTS} ./objstorage/objstorageprovider/objiotracing
+
 .PHONY: lint
 lint:
 	${GO} test -tags '$(TAGS)' ${testflags} -run ${TESTS} ./internal/lint

--- a/compaction.go
+++ b/compaction.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/rangedel"
 	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -2748,7 +2749,19 @@ func (d *DB) runCompaction(
 		pendingOutputs = append(pendingOutputs, fileMeta)
 		d.mu.Unlock()
 
-		writable, objMeta, err := d.objProvider.Create(context.TODO(), fileTypeTable, fileNum, objstorage.CreateOptions{} /* TODO */)
+		ctx := context.TODO()
+		if objiotracing.Enabled {
+			ctx = objiotracing.WithLevel(ctx, c.outputLevel.level)
+			switch c.kind {
+			case compactionKindFlush:
+				ctx = objiotracing.WithReason(ctx, objiotracing.ForFlush)
+			case compactionKindIngestedFlushable:
+				ctx = objiotracing.WithReason(ctx, objiotracing.ForIngestion)
+			default:
+				ctx = objiotracing.WithReason(ctx, objiotracing.ForCompaction)
+			}
+		}
+		writable, objMeta, err := d.objProvider.Create(ctx, fileTypeTable, fileNum, objstorage.CreateOptions{} /* TODO */)
 		if err != nil {
 			return err
 		}

--- a/objstorage/objstorage.go
+++ b/objstorage/objstorage.go
@@ -71,7 +71,8 @@ type ReadHandle interface {
 	MaxReadahead()
 
 	// RecordCacheHit informs the implementation that we were able to retrieve a
-	// block from cache.
+	// block from cache. This is useful for example when the implementation is
+	// trying to detect a sequential reading pattern.
 	RecordCacheHit(ctx context.Context, offset, size int64)
 }
 

--- a/objstorage/objstorageprovider/objiotracing/obj_io_tracing.go
+++ b/objstorage/objstorageprovider/objiotracing/obj_io_tracing.go
@@ -1,0 +1,68 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package objiotracing
+
+import "github.com/cockroachdb/pebble/internal/base"
+
+// OpType indicates the type of operation.
+type OpType uint8
+
+// OpType values.
+const (
+	ReadOp OpType = iota
+	WriteOp
+	// RecordCacheHitOp happens when a read is satisfied from the block cache. See
+	// objstorage.ReadHandle.RecordCacheHit().
+	RecordCacheHitOp
+	// MaxReadaheadOp is a "meta operation" that configures a read handle for
+	// large sequential reads. See objstorage.ReadHandle.MaxReadahead().
+	MaxReadaheadOp
+)
+
+// Reason indicates the higher-level context of the operation.
+type Reason uint8
+
+// Reason values.
+const (
+	UnknownReason Reason = iota
+	ForFlush
+	ForCompaction
+	ForIngestion
+	// TODO(radu): add ForUserFacing.
+)
+
+// BlockType indicates the type of data block relevant to an operation.
+type BlockType uint8
+
+// BlockType values.
+const (
+	UnknownBlock BlockType = iota
+	DataBlock
+	ValueBlock
+	FilterBlock
+	MetadataBlock
+)
+
+// Event is the on-disk format of a tracing event. It is exported here so that
+// trace processing tools can use it by importing this package.
+type Event struct {
+	// Event start time as a Unix time (see time.Time.StartUnixNano()).
+	// Note that recorded events are not necessarily ordered by time - this is
+	// because separate event "streams" use local buffers (for performance).
+	StartUnixNano int64
+	Op            OpType
+	Reason        Reason
+	BlockType     BlockType
+	// LSM level plus one (with 0 indicating unknown level).
+	LevelPlusOne uint8
+	// Hardcoded padding so that struct layout doesn't depend on architecture.
+	_       uint32
+	FileNum base.FileNum
+	// HandleID is a unique identifier corresponding to an objstorage.ReadHandle;
+	// only set for read operations performed through a ReadHandle.
+	HandleID uint64
+	Offset   int64
+	Size     int64
+}

--- a/objstorage/objstorageprovider/objiotracing/obj_io_tracing_off.go
+++ b/objstorage/objstorageprovider/objiotracing/obj_io_tracing_off.go
@@ -1,0 +1,59 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+//go:build !pebble_obj_io_tracing
+// +build !pebble_obj_io_tracing
+
+package objiotracing
+
+import (
+	"context"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+// Enabled is used to short circuit tracing-related code in regular builds.
+const Enabled = false
+
+// Tracer manages the writing of object IO traces to files.
+type Tracer struct{}
+
+// Open creates a Tracer which generates trace files in the given directory.
+// Each trace file contains a series of Events (as they are in memory).
+func Open(fs vfs.FS, fsDir string) *Tracer {
+	return nil
+}
+
+// Close the tracer, flushing any remaining events.
+func (*Tracer) Close() {}
+
+// WrapReadable wraps an objstorage.Readable with one that generates tracing
+// events.
+func (*Tracer) WrapReadable(
+	ctx context.Context, r objstorage.Readable, fileNum base.FileNum,
+) objstorage.Readable {
+	return r
+}
+
+// WrapWritable wraps an objstorage.Writable with one that generates tracing
+// events.
+func (t *Tracer) WrapWritable(
+	ctx context.Context, w objstorage.Writable, fileNum base.FileNum,
+) objstorage.Writable {
+	return w
+}
+
+// WithReason creates a context that has an associated Reason (which ends up in
+// traces created under that context).
+func WithReason(ctx context.Context, reason Reason) context.Context { return ctx }
+
+// WithBlockType creates a context that has an associated BlockType (which ends up in
+// traces created under that context).
+func WithBlockType(ctx context.Context, blockType BlockType) context.Context { return ctx }
+
+// WithLevel creates a context that has an associated level (which ends up in
+// traces created under that context).
+func WithLevel(ctx context.Context, level int) context.Context { return ctx }

--- a/objstorage/objstorageprovider/objiotracing/obj_io_tracing_on.go
+++ b/objstorage/objstorageprovider/objiotracing/obj_io_tracing_on.go
@@ -1,0 +1,405 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+//go:build pebble_obj_io_tracing
+// +build pebble_obj_io_tracing
+
+package objiotracing
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+// Enabled is used to short circuit tracing-related code in regular builds.
+const Enabled = true
+
+// Tracer manages the writing of object IO traces to files.
+//
+// The tracer runs a background worker goroutine which receives trace event
+// buffers over a channel and dumps them to IOTRACES- files. Wrapper
+// implementations for Readable, ReadHandle, Writable are producers of traces;
+// they maintain internal buffers of events which get flushed to the buffered
+// channel when they get full. This allows for minimal synchronization per IO
+// (as for most of these structures, an instance only allows a single IO at a
+// time).
+type Tracer struct {
+	fs    vfs.FS
+	fsDir string
+
+	handleID atomic.Uint64
+
+	workerStopCh chan struct{}
+	workerDataCh chan eventBuf
+	workerWait   sync.WaitGroup
+}
+
+// Open creates a Tracer which generates trace files in the given directory.
+// Each trace file contains a series of Events (as they are in memory).
+func Open(fs vfs.FS, fsDir string) *Tracer {
+	t := &Tracer{
+		fs:           fs,
+		fsDir:        fsDir,
+		workerStopCh: make(chan struct{}),
+		workerDataCh: make(chan eventBuf, channelBufSize),
+	}
+
+	t.handleID.Store(uint64(rand.NewSource(time.Now().UnixNano()).Int63()))
+
+	t.workerWait.Add(1)
+	go t.workerLoop()
+	return t
+}
+
+// Close the tracer, flushing any remaining events.
+func (t *Tracer) Close() {
+	if t.workerStopCh == nil {
+		return
+	}
+	// Tell the worker to stop and wait for it to finish up.
+	close(t.workerStopCh)
+	t.workerWait.Wait()
+	t.workerStopCh = nil
+}
+
+// WrapWritable wraps an objstorage.Writable with one that generates tracing
+// events.
+func (t *Tracer) WrapWritable(
+	ctx context.Context, w objstorage.Writable, fileNum base.FileNum,
+) objstorage.Writable {
+	return &writable{
+		w:       w,
+		fileNum: fileNum,
+		g:       makeEventGenerator(ctx, t),
+	}
+}
+
+type writable struct {
+	w         objstorage.Writable
+	fileNum   base.FileNum
+	curOffset int64
+	g         eventGenerator
+}
+
+var _ objstorage.Writable = (*writable)(nil)
+
+// Write is part of the objstorage.Writable interface.
+func (w *writable) Write(p []byte) error {
+	w.g.add(context.Background(), Event{
+		Op:      WriteOp,
+		FileNum: w.fileNum,
+		Offset:  w.curOffset,
+		Size:    int64(len(p)),
+	})
+	return w.w.Write(p)
+}
+
+// Finish is part of the objstorage.Writable interface.
+func (w *writable) Finish() error {
+	w.g.flush()
+	return w.w.Finish()
+}
+
+// Abort is part of the objstorage.Writable interface.
+func (w *writable) Abort() {
+	w.g.flush()
+	w.w.Abort()
+}
+
+// WrapReadable wraps an objstorage.Readable with one that generates tracing
+// events.
+func (t *Tracer) WrapReadable(
+	ctx context.Context, r objstorage.Readable, fileNum base.FileNum,
+) objstorage.Readable {
+	res := &readable{
+		r:       r,
+		fileNum: fileNum,
+	}
+	res.mu.g = makeEventGenerator(ctx, t)
+	return res
+}
+
+type readable struct {
+	r       objstorage.Readable
+	fileNum base.FileNum
+	mu      struct {
+		sync.Mutex
+		g eventGenerator
+	}
+}
+
+var _ objstorage.Readable = (*readable)(nil)
+
+// ReadAt is part of the objstorage.Readable interface.
+func (r *readable) ReadAt(ctx context.Context, v []byte, off int64) (n int, err error) {
+	r.mu.Lock()
+	r.mu.g.add(ctx, Event{
+		Op:      ReadOp,
+		FileNum: r.fileNum,
+		Offset:  off,
+		Size:    int64(len(v)),
+	})
+	r.mu.Unlock()
+	return r.r.ReadAt(ctx, v, off)
+}
+
+// Close is part of the objstorage.Readable interface.
+func (r *readable) Close() error {
+	r.mu.g.flush()
+	return r.r.Close()
+}
+
+// Size is part of the objstorage.Readable interface.
+func (r *readable) Size() int64 {
+	return r.r.Size()
+}
+
+// NewReadHandle is part of the objstorage.Readable interface.
+func (r *readable) NewReadHandle(ctx context.Context) objstorage.ReadHandle {
+	// It's safe to get the tracer from the generator without the mutex since it never changes.
+	t := r.mu.g.t
+	return &readHandle{
+		rh:       r.r.NewReadHandle(ctx),
+		fileNum:  r.fileNum,
+		handleID: t.handleID.Add(1),
+		g:        makeEventGenerator(ctx, t),
+	}
+}
+
+type readHandle struct {
+	rh       objstorage.ReadHandle
+	fileNum  base.FileNum
+	handleID uint64
+	g        eventGenerator
+}
+
+var _ objstorage.ReadHandle = (*readHandle)(nil)
+
+// ReadAt is part of the objstorage.ReadHandle interface.
+func (rh *readHandle) ReadAt(ctx context.Context, p []byte, off int64) (n int, err error) {
+	rh.g.add(ctx, Event{
+		Op:       ReadOp,
+		FileNum:  rh.fileNum,
+		HandleID: rh.handleID,
+		Offset:   off,
+		Size:     int64(len(p)),
+	})
+	return rh.rh.ReadAt(ctx, p, off)
+}
+
+// Close is part of the objstorage.ReadHandle interface.
+func (rh *readHandle) Close() error {
+	rh.g.flush()
+	return rh.rh.Close()
+}
+
+// MaxReadahead is part of the objstorage.ReadHandle interface.
+func (rh *readHandle) MaxReadahead() {
+	rh.g.add(context.Background(), Event{
+		Op:       MaxReadaheadOp,
+		FileNum:  rh.fileNum,
+		HandleID: rh.handleID,
+	})
+	rh.rh.MaxReadahead()
+}
+
+// RecordCacheHit is part of the objstorage.ReadHandle interface.
+func (rh *readHandle) RecordCacheHit(ctx context.Context, offset, size int64) {
+	rh.g.add(ctx, Event{
+		Op:       RecordCacheHitOp,
+		FileNum:  rh.fileNum,
+		HandleID: rh.handleID,
+		Offset:   offset,
+		Size:     size,
+	})
+	rh.rh.RecordCacheHit(ctx, offset, size)
+}
+
+type ctxInfo struct {
+	reason       Reason
+	blockType    BlockType
+	levelPlusOne uint8
+}
+
+func mergeCtxInfo(base, other ctxInfo) ctxInfo {
+	res := other
+	if res.reason == 0 {
+		res.reason = base.reason
+	}
+	if res.blockType == 0 {
+		res.blockType = base.blockType
+	}
+	if res.levelPlusOne == 0 {
+		res.levelPlusOne = base.levelPlusOne
+	}
+	return res
+}
+
+type ctxInfoKey struct{}
+
+func withInfo(ctx context.Context, info ctxInfo) context.Context {
+	return context.WithValue(ctx, ctxInfoKey{}, info)
+}
+
+func infoFromCtx(ctx context.Context) ctxInfo {
+	res := ctx.Value(ctxInfoKey{})
+	if res == nil {
+		return ctxInfo{}
+	}
+	return res.(ctxInfo)
+}
+
+// WithReason creates a context that has an associated Reason (which ends up in
+// traces created under that context).
+func WithReason(ctx context.Context, reason Reason) context.Context {
+	info := infoFromCtx(ctx)
+	info.reason = reason
+	return withInfo(ctx, info)
+}
+
+// WithBlockType creates a context that has an associated BlockType (which ends up in
+// traces created under that context).
+func WithBlockType(ctx context.Context, blockType BlockType) context.Context {
+	info := infoFromCtx(ctx)
+	info.blockType = blockType
+	return withInfo(ctx, info)
+}
+
+// WithLevel creates a context that has an associated level (which ends up in
+// traces created under that context).
+func WithLevel(ctx context.Context, level int) context.Context {
+	info := infoFromCtx(ctx)
+	info.levelPlusOne = uint8(level) + 1
+	return withInfo(ctx, info)
+}
+
+const (
+	eventSize            = int(unsafe.Sizeof(Event{}))
+	targetEntriesPerFile = 256 * 1024 * 1024 / eventSize // 256MB files
+	eventsPerBuf         = 16
+	channelBufSize       = 512 * 1024 / eventsPerBuf // 512K events.
+	bytesPerFileSync     = 128 * 1024
+)
+
+type eventBuf struct {
+	events [eventsPerBuf]Event
+	num    int
+}
+
+type eventGenerator struct {
+	t           *Tracer
+	baseCtxInfo ctxInfo
+	buf         eventBuf
+}
+
+func makeEventGenerator(ctx context.Context, t *Tracer) eventGenerator {
+	return eventGenerator{
+		t:           t,
+		baseCtxInfo: infoFromCtx(ctx),
+	}
+}
+
+func (g *eventGenerator) flush() {
+	if g.buf.num > 0 {
+		g.t.workerDataCh <- g.buf
+		g.buf.num = 0
+	}
+}
+
+func (g *eventGenerator) add(ctx context.Context, e Event) {
+	e.StartUnixNano = time.Now().UnixNano()
+	info := infoFromCtx(ctx)
+	info = mergeCtxInfo(g.baseCtxInfo, info)
+	e.Reason = info.reason
+	e.BlockType = info.blockType
+	e.LevelPlusOne = info.levelPlusOne
+	if g.buf.num == eventsPerBuf {
+		g.flush()
+	}
+	g.buf.events[g.buf.num] = e
+	g.buf.num++
+}
+
+type workerState struct {
+	curFile          vfs.File
+	curBW            *bufio.Writer
+	numEntriesInFile int
+}
+
+func (t *Tracer) workerLoop() {
+	defer t.workerWait.Done()
+	stopCh := t.workerStopCh
+	dataCh := t.workerDataCh
+	var state workerState
+	t.workerNewFile(&state)
+	for {
+		select {
+		case <-stopCh:
+			close(dataCh)
+			// Flush any remaining traces.
+			for data := range dataCh {
+				t.workerWriteTraces(&state, data)
+			}
+			t.workerCloseFile(&state)
+			return
+
+		case data := <-dataCh:
+			t.workerWriteTraces(&state, data)
+		}
+	}
+}
+
+func (t *Tracer) workerWriteTraces(state *workerState, data eventBuf) {
+	if state.numEntriesInFile >= targetEntriesPerFile {
+		t.workerCloseFile(state)
+		t.workerNewFile(state)
+	}
+	state.numEntriesInFile += data.num
+	p := unsafe.Pointer(&data.events[0])
+	b := unsafe.Slice((*byte)(p), eventSize*data.num)
+	if _, err := state.curBW.Write(b); err != nil {
+		panic(err)
+	}
+}
+
+func (t *Tracer) workerNewFile(state *workerState) {
+	filename := fmt.Sprintf("IOTRACES-%s", time.Now().UTC().Format(time.RFC3339Nano))
+
+	file, err := t.fs.Create(t.fs.PathJoin(t.fsDir, filename))
+	if err != nil {
+		panic(err)
+	}
+	file = vfs.NewSyncingFile(file, vfs.SyncingFileOptions{
+		BytesPerSync: bytesPerFileSync,
+	})
+	state.curFile = file
+	state.curBW = bufio.NewWriter(file)
+	state.numEntriesInFile = 0
+}
+
+func (t *Tracer) workerCloseFile(state *workerState) {
+	if state.curFile != nil {
+		if err := state.curBW.Flush(); err != nil {
+			panic(err)
+		}
+		if err := state.curFile.Sync(); err != nil {
+			panic(err)
+		}
+		if err := state.curFile.Close(); err != nil {
+			panic(err)
+		}
+		state.curFile = nil
+		state.curBW = nil
+	}
+}

--- a/objstorage/objstorageprovider/objiotracing/obj_io_tracing_test.go
+++ b/objstorage/objstorageprovider/objiotracing/obj_io_tracing_test.go
@@ -1,0 +1,126 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package objiotracing_test
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+type Event = objiotracing.Event
+
+const eventSize = int(unsafe.Sizeof(Event{}))
+
+func TestTracing(t *testing.T) {
+	if !objiotracing.Enabled {
+		t.Skipf("test can only be run under pebble_obj_io_tracing build tag")
+	}
+	fs := vfs.NewMem()
+	d, err := pebble.Open("", &pebble.Options{FS: fs})
+	require.NoError(t, err)
+
+	require.NoError(t, d.Set([]byte("a"), []byte("aaa"), nil))
+	require.NoError(t, d.Set([]byte("b"), []byte("bbb"), nil))
+	require.NoError(t, d.Flush())
+	require.NoError(t, d.Set([]byte("c"), []byte("ccc"), nil))
+	require.NoError(t, d.Flush())
+	require.NoError(t, d.Compact([]byte("a"), []byte("z"), false /* parallelize */))
+	require.NoError(t, d.Set([]byte("b"), []byte("bbb2"), nil))
+	require.NoError(t, d.Set([]byte("c"), []byte("ccc2"), nil))
+	require.NoError(t, d.Set([]byte("d"), []byte("ddd"), nil))
+	require.NoError(t, d.Flush())
+	require.NoError(t, d.Compact([]byte("a"), []byte("z"), false /* parallelize */))
+	require.NoError(t, d.Close())
+
+	collectEvents := func() []Event {
+		t.Helper()
+
+		list, err := fs.List("")
+		require.NoError(t, err)
+
+		var events []Event
+		for _, f := range list {
+			if strings.HasPrefix(f, "IOTRACES-") {
+				file, err := fs.Open(f)
+				require.NoError(t, err)
+				data, err := io.ReadAll(file)
+				file.Close()
+				require.NoError(t, err)
+				// Remove the file so we don't read these events again later.
+				fs.Remove(f)
+				if len(data) == 0 {
+					continue
+				}
+				require.Equal(t, len(data)%eventSize, 0)
+				p := unsafe.Pointer(&data[0])
+				asEvents := unsafe.Slice((*Event)(p), len(data)/eventSize)
+				events = append(events, asEvents...)
+			}
+		}
+		if testing.Verbose() {
+			t.Logf("collected events:")
+			for _, e := range events {
+				t.Logf("  %#v", e)
+			}
+		}
+		return events
+	}
+	events := collectEvents()
+	num := func(check func(e Event) bool) int {
+		res := 0
+		for _, e := range events {
+			if check(e) {
+				res += 1
+			}
+		}
+		return res
+	}
+	// Check that we saw at least a few reads and writes.
+	// TODO(radu): check more fields when they are populated.
+	require.Greater(t, num(func(e Event) bool { return e.Op == objiotracing.ReadOp }), 5)
+	require.Greater(t, num(func(e Event) bool { return e.Op == objiotracing.WriteOp }), 5)
+
+	// We should see writes at L0 and L7.
+	require.Greater(t, num(func(e Event) bool { return e.Op == objiotracing.WriteOp && e.LevelPlusOne == 1 }), 0)
+	require.Greater(t, num(func(e Event) bool { return e.Op == objiotracing.WriteOp && e.LevelPlusOne == 7 }), 0)
+
+	// Check that we saw writes for flushing and for compaction.
+	require.Greater(t, num(func(e Event) bool { return e.Reason == objiotracing.ForFlush }), 0)
+	require.Greater(t, num(func(e Event) bool { return e.Reason == objiotracing.ForCompaction }), 0)
+
+	// Check that the FileNums are set and that we see at least two different files.
+	fileNums := make(map[base.FileNum]int)
+	for _, e := range events {
+		require.NotZero(t, e.FileNum)
+		fileNums[e.FileNum] += 1
+	}
+	require.GreaterOrEqual(t, len(fileNums), 2)
+
+	// Open again and do some reads.
+	d, err = pebble.Open("", &pebble.Options{FS: fs})
+	require.NoError(t, err)
+	for _, k := range []string{"0", "a", "d", "ccc", "b"} {
+		_, closer, err := d.Get([]byte(k))
+		if err == pebble.ErrNotFound {
+			continue
+		}
+		require.NoError(t, err)
+		closer.Close()
+	}
+	require.NoError(t, d.Close())
+	events = collectEvents()
+	// Expect L6 data block reads.
+	require.Greater(t, num(func(e Event) bool {
+		return e.Op == objiotracing.ReadOp && e.BlockType == objiotracing.DataBlock && e.LevelPlusOne == 7
+	}), 0)
+}

--- a/sstable/value_block.go
+++ b/sstable/value_block.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
 	"golang.org/x/exp/rand"
 )
 
@@ -683,6 +684,7 @@ func (bpwc *blockProviderWhenClosed) close() {
 func (bpwc blockProviderWhenClosed) readBlockForVBR(
 	ctx context.Context, h BlockHandle, stats *base.InternalIteratorStats,
 ) (cache.Handle, error) {
+	ctx = objiotracing.WithBlockType(ctx, objiotracing.ValueBlock)
 	return bpwc.r.readBlock(ctx, h, nil, nil, stats)
 }
 

--- a/table_cache.go
+++ b/table_cache.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/private"
 	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
 	"github.com/cockroachdb/pebble/sstable"
 )
 
@@ -416,6 +417,7 @@ func (c *tableCacheShard) newIters(
 	useFilter := true
 	if opts != nil {
 		useFilter = manifest.LevelToInt(opts.level) != 6 || opts.UseL6Filters
+		ctx = objiotracing.WithLevel(ctx, manifest.LevelToInt(opts.level))
 	}
 	tableFormat, err := v.reader.TableFormat()
 	if err != nil {


### PR DESCRIPTION
This commit adds an obj IO tracing subsystem. It works by wrapping `Readable` and `Writable` in implementations which generate tracing events. The events are dumped to `IOTRACE-<timestamp>` files in the store directory. Contexts are used to plumb various details, like LSM level or block type.

The tracing code is behind the `pebble_obj_io_tracing` build tag; this is to avoid causing any regressions to normal build.

The plumbing of details through contexts is not (nor it is intended to be) complete.

A new make target `testobjiotracing` runs the test (which requires the `pebble_obj_io_tracing` tag).