### PR TITLE
db: delay memtable memory allocation until the first write

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1702,7 +1702,7 @@ func (b *flushableBatch) inuseBytes() uint64 {
 	return uint64(len(b.data) - batchHeaderLen)
 }
 
-func (b *flushableBatch) totalBytes() uint64 {
+func (b *flushableBatch) allocatedBytes() uint64 {
 	return uint64(cap(b.data))
 }
 

--- a/compaction.go
+++ b/compaction.go
@@ -1718,7 +1718,7 @@ func (d *DB) passedFlushThreshold() bool {
 			// size. See minFlushSize below.
 			size += uint64(d.opts.MemTableSize)
 		} else {
-			size += d.mu.mem.queue[n].totalBytes()
+			size += d.mu.mem.queue[n].allocatedBytes()
 		}
 	}
 	if n == 0 {

--- a/data_test.go
+++ b/data_test.go
@@ -944,6 +944,9 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 					d.updateReadStateLocked(nil)
 				}
 				mem = d.mu.mem.mutable
+				// We're writing using memTable.set, which bypasses
+				// memTable.prepare, so allocate manually.
+				mem.allocate()
 				start, end = nil, nil
 				fields = fields[1:]
 			case "L0", "L1", "L2", "L3", "L4", "L5", "L6":

--- a/db.go
+++ b/db.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
-	"github.com/cockroachdb/pebble/internal/manual"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/sstable"
@@ -1715,7 +1714,7 @@ func (d *DB) Metrics() *Metrics {
 	metrics.Compact.NumInProgress = int64(d.mu.compact.compactingCount)
 	metrics.Compact.MarkedFiles = vers.Stats.MarkedForCompaction
 	for _, m := range d.mu.mem.queue {
-		metrics.MemTable.Size += m.totalBytes()
+		metrics.MemTable.Size += m.allocatedBytes()
 	}
 	metrics.Snapshots.Count = d.mu.snapshots.count()
 	if metrics.Snapshots.Count > 0 {
@@ -1940,13 +1939,18 @@ func (d *DB) newMemTable(logNum FileNum, logSeqNum uint64) (*memTable, *flushabl
 	}
 
 	atomic.AddInt64(&d.atomic.memTableCount, 1)
-	atomic.AddInt64(&d.atomic.memTableReserved, int64(size))
-	releaseAccountingReservation := d.opts.Cache.Reserve(size)
 
 	mem := newMemTable(memTableOptions{
-		Options:   d.opts,
-		arenaBuf:  manual.New(int(size)),
-		logSeqNum: logSeqNum,
+		Options:          d.opts,
+		size:             size,
+		logSeqNum:        logSeqNum,
+		allocateManually: true,
+		cacheReserve: func(size int) func() {
+			atomic.AddInt64(&d.atomic.memTableReserved, int64(size))
+			freeInCache := d.opts.Cache.Reserve(size)
+			return freeInCache
+		},
+		delayAllocation: true,
 	})
 
 	// Note: this is a no-op if invariants are disabled or race is enabled.
@@ -1954,11 +1958,9 @@ func (d *DB) newMemTable(logNum FileNum, logSeqNum uint64) (*memTable, *flushabl
 
 	entry := d.newFlushableEntry(mem, logNum, logSeqNum)
 	entry.releaseMemAccounting = func() {
-		manual.Free(mem.arenaBuf)
-		mem.arenaBuf = nil
+		allocatedSize := mem.releaseMemAccounting()
 		atomic.AddInt64(&d.atomic.memTableCount, -1)
-		atomic.AddInt64(&d.atomic.memTableReserved, -int64(size))
-		releaseAccountingReservation()
+		atomic.AddInt64(&d.atomic.memTableReserved, -int64(allocatedSize))
 	}
 	return mem, entry
 }
@@ -2010,7 +2012,7 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 		{
 			var size uint64
 			for i := range d.mu.mem.queue {
-				size += d.mu.mem.queue[i].totalBytes()
+				size += d.mu.mem.queue[i].allocatedBytes()
 			}
 			if size >= uint64(d.opts.MemTableStopWritesThreshold)*uint64(d.opts.MemTableSize) {
 				// We have filled up the current memtable, but already queued memtables
@@ -2053,8 +2055,8 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 		// the memtable, don't increase the size for the next memtable. This
 		// reduces memtable memory pressure when an application is frequently
 		// manually flushing.
-		if (b == nil) && uint64(immMem.availBytes()) > immMem.totalBytes()/2 {
-			d.mu.mem.nextSize = int(immMem.totalBytes())
+		if (b == nil) && int(immMem.availBytes()) > immMem.maxCapacity()/2 {
+			d.mu.mem.nextSize = int(immMem.maxCapacity())
 		}
 
 		if b != nil && b.flushable != nil {
@@ -2072,7 +2074,7 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 			entry := d.newFlushableEntry(b.flushable, imm.logNum, b.SeqNum())
 			// The large batch is by definition large. Reserve space from the cache
 			// for it until it is flushed.
-			entry.releaseMemAccounting = d.opts.Cache.Reserve(int(b.flushable.totalBytes()))
+			entry.releaseMemAccounting = d.opts.Cache.Reserve(int(b.flushable.allocatedBytes()))
 			d.mu.mem.queue = append(d.mu.mem.queue, entry)
 		}
 

--- a/db_test.go
+++ b/db_test.go
@@ -815,6 +815,8 @@ func TestMemTableReservation(t *testing.T) {
 
 	checkReserved := func(expected int64) {
 		t.Helper()
+		// Perform a tiny write to the memtable to force allocation.
+		require.NoError(t, d.Set([]byte{'a'}, nil, nil))
 		if reserved := atomic.LoadInt64(&d.atomic.memTableReserved); expected != reserved {
 			t.Fatalf("expected %d reserved, but found %d", expected, reserved)
 		}
@@ -850,6 +852,7 @@ func TestMemTableReservation(t *testing.T) {
 func TestMemTableReservationLeak(t *testing.T) {
 	d, err := Open("", &Options{FS: vfs.NewMem()})
 	require.NoError(t, err)
+	require.NoError(t, d.Set([]byte{'a'}, nil, nil))
 
 	d.mu.Lock()
 	last := d.mu.mem.queue[len(d.mu.mem.queue)-1]

--- a/docs/RFCS/20220311_pebble_flushable_ingested_sstable.md
+++ b/docs/RFCS/20220311_pebble_flushable_ingested_sstable.md
@@ -169,7 +169,7 @@ The special-cased flush process for this flushable is described in [Section
 
 Will wait on range key support in `levelIter` to land before implementing.
 
-#### 5. `inuseBytes() uint64` and `totalBytes() uint64`
+#### 5. `inuseBytes() uint64` and `allocatedBytes() uint64`
 
 For both functions, we return 0.
 
@@ -183,7 +183,7 @@ memtable when determining whether or not to stall writes
 instead (`L0StopWritesThreshold`). Thus, we'll have to special case for ingested
 SSTs in `d.makeRoomForWrite()` to address this detail.
 
-`totalBytes()` represents the number of bytes allocated by the flushable, which
+`allocatedBytes()` represents the number of bytes allocated by the flushable, which
 in our case is 0. A consequence for this is that the size of the SSTs do not
 count towards the flush threshold calculation. However, by setting
 `flushableEntry.flushForced` we can achieve the same behaviour.

--- a/flushable.go
+++ b/flushable.go
@@ -23,8 +23,8 @@ type flushable interface {
 	containsRangeKeys() bool
 	// inuseBytes returns the number of inuse bytes by the flushable.
 	inuseBytes() uint64
-	// totalBytes returns the total number of bytes allocated by the flushable.
-	totalBytes() uint64
+	// allocatedBytes returns the total number of bytes allocated by the flushable.
+	allocatedBytes() uint64
 	// readyForFlush returns true when the flushable is ready for flushing. See
 	// memTable.readyForFlush for one implementation which needs to check whether
 	// there are any outstanding write references.
@@ -61,7 +61,8 @@ type flushableEntry struct {
 	// refs will already be zero because the memtable will have been flushed and
 	// that only occurs once the writer refs drops to zero.
 	readerRefs int32
-	// Closure to invoke to release memory accounting.
+	// Closure to invoke to release memory accounting. Note that this closure
+	// can be nil, if no memory has been allocated for the memTable yet.
 	releaseMemAccounting func()
 	// unrefFiles, if not nil, should be invoked to decrease the ref count of
 	// files which are backing the flushable.
@@ -226,7 +227,7 @@ func (s *ingestedFlushable) inuseBytes() uint64 {
 	panic("pebble: not implemented")
 }
 
-func (s *ingestedFlushable) totalBytes() uint64 {
+func (s *ingestedFlushable) allocatedBytes() uint64 {
 	// We don't allocate additional bytes for the ingestedFlushable.
 	return 0
 }

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -634,6 +634,9 @@ func TestIngestMemtableOverlaps(t *testing.T) {
 					}
 
 					mem = newMemTable(memTableOptions{Options: opts})
+					if err := mem.prepare(b); err != nil {
+						return err.Error()
+					}
 					if err := mem.apply(b, 0); err != nil {
 						return err.Error()
 					}

--- a/mem_table.go
+++ b/mem_table.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/arenaskl"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/keyspan"
+	"github.com/cockroachdb/pebble/internal/manual"
 	"github.com/cockroachdb/pebble/internal/rangedel"
 	"github.com/cockroachdb/pebble/internal/rangekey"
 )
@@ -86,6 +87,11 @@ type memTable struct {
 	// The current logSeqNum at the time the memtable was created. This is
 	// guaranteed to be less than or equal to any seqnum stored in the memtable.
 	logSeqNum uint64
+	// Since memtable allocation is delayed, we store the size to allocate here.
+	capacity            int
+	allocateManually    bool
+	cacheReserve        func(n int) func()
+	releaseCacheReserve func()
 }
 
 // memTableOptions holds configuration used when creating a memTable. All of
@@ -93,9 +99,11 @@ type memTable struct {
 // which is used by tests.
 type memTableOptions struct {
 	*Options
-	arenaBuf  []byte
-	size      int
-	logSeqNum uint64
+	size             int
+	logSeqNum        uint64
+	allocateManually bool
+	cacheReserve     func(n int) func()
+	delayAllocation  bool
 }
 
 func checkMemTable(obj interface{}) {
@@ -107,7 +115,9 @@ func checkMemTable(obj interface{}) {
 }
 
 // newMemTable returns a new MemTable of the specified size. If size is zero,
-// Options.MemTableSize is used instead.
+// Options.MemTableSize is used instead. Note that the actual memory allocation
+// required by the memtable only takes place right before the first write to the
+// memtable.
 func newMemTable(opts memTableOptions) *memTable {
 	opts.Options = opts.Options.EnsureDefaults()
 	if opts.size == 0 {
@@ -115,12 +125,14 @@ func newMemTable(opts memTableOptions) *memTable {
 	}
 
 	m := &memTable{
-		cmp:        opts.Comparer.Compare,
-		formatKey:  opts.Comparer.FormatKey,
-		equal:      opts.Comparer.Equal,
-		arenaBuf:   opts.arenaBuf,
-		writerRefs: 1,
-		logSeqNum:  opts.logSeqNum,
+		cmp:              opts.Comparer.Compare,
+		formatKey:        opts.Comparer.FormatKey,
+		equal:            opts.Comparer.Equal,
+		writerRefs:       1,
+		logSeqNum:        opts.logSeqNum,
+		allocateManually: opts.allocateManually,
+		capacity:         opts.size,
+		cacheReserve:     opts.cacheReserve,
 	}
 	m.tombstones = keySpanCache{
 		cmp:           m.cmp,
@@ -134,16 +146,40 @@ func newMemTable(opts memTableOptions) *memTable {
 		skl:           &m.rangeKeySkl,
 		constructSpan: rangekey.Decode,
 	}
+	if !opts.delayAllocation {
+		m.allocate()
+	}
+	return m
+}
 
-	if m.arenaBuf == nil {
-		m.arenaBuf = make([]byte, opts.size)
+func (m *memTable) allocate() {
+	if m.cacheReserve != nil {
+		m.releaseCacheReserve = m.cacheReserve(m.capacity)
 	}
 
+	if m.allocateManually {
+		m.arenaBuf = manual.New(m.capacity)
+	} else {
+		m.arenaBuf = make([]byte, m.capacity)
+	}
 	arena := arenaskl.NewArena(m.arenaBuf)
 	m.skl.Reset(arena, m.cmp)
 	m.rangeDelSkl.Reset(arena, m.cmp)
 	m.rangeKeySkl.Reset(arena, m.cmp)
-	return m
+}
+
+func (m *memTable) releaseMemAccounting() (allocatedSize int) {
+	if m.arenaBuf != nil {
+		allocatedSize = m.capacity
+		if m.releaseCacheReserve != nil {
+			m.releaseCacheReserve()
+		}
+	}
+	if m.arenaBuf != nil && m.allocateManually {
+		manual.Free(m.arenaBuf)
+		m.arenaBuf = nil
+	}
+	return allocatedSize
 }
 
 func (m *memTable) writerRef() {
@@ -173,6 +209,10 @@ func (m *memTable) readyForFlush() bool {
 // that prepare is not thread-safe, while apply is. The caller must call
 // writerUnref() after the batch has been applied.
 func (m *memTable) prepare(batch *Batch) error {
+	if m.arenaBuf == nil {
+		m.allocate()
+	}
+
 	avail := m.availBytes()
 	if batch.memTableSize > uint64(avail) {
 		return arenaskl.ErrArenaFull
@@ -183,6 +223,8 @@ func (m *memTable) prepare(batch *Batch) error {
 	return nil
 }
 
+// prepare must be called for a given batch before calling apply. Tests can
+// choose to call apply directly if they call memTable.allocate first.
 func (m *memTable) apply(batch *Batch, seqNum uint64) error {
 	if seqNum < m.logSeqNum {
 		return base.CorruptionErrorf("pebble: batch seqnum %d is less than memtable creation seqnum %d",
@@ -236,14 +278,26 @@ func (m *memTable) apply(batch *Batch, seqNum uint64) error {
 // return false). The iterator can be positioned via a call to SeekGE,
 // SeekLT, First or Last.
 func (m *memTable) newIter(o *IterOptions) internalIterator {
+	if m.arenaBuf == nil {
+		return emptyIter
+	}
+
 	return m.skl.NewIter(o.GetLowerBound(), o.GetUpperBound())
 }
 
 func (m *memTable) newFlushIter(o *IterOptions, bytesFlushed *uint64) internalIterator {
+	if m.arenaBuf == nil {
+		return emptyIter
+	}
+
 	return m.skl.NewFlushIter(bytesFlushed)
 }
 
 func (m *memTable) newRangeDelIter(*IterOptions) keyspan.FragmentIterator {
+	if m.arenaBuf == nil {
+		return emptyKeyspanIter
+	}
+
 	tombstones := m.tombstones.get()
 	if tombstones == nil {
 		return nil
@@ -252,6 +306,10 @@ func (m *memTable) newRangeDelIter(*IterOptions) keyspan.FragmentIterator {
 }
 
 func (m *memTable) newRangeKeyIter(*IterOptions) keyspan.FragmentIterator {
+	if m.arenaBuf == nil {
+		return emptyKeyspanIter
+	}
+
 	rangeKeys := m.rangeKeys.get()
 	if rangeKeys == nil {
 		return nil
@@ -260,10 +318,18 @@ func (m *memTable) newRangeKeyIter(*IterOptions) keyspan.FragmentIterator {
 }
 
 func (m *memTable) containsRangeKeys() bool {
+	if m.arenaBuf == nil {
+		return false
+	}
+
 	return atomic.LoadUint32(&m.rangeKeys.atomicCount) > 0
 }
 
 func (m *memTable) availBytes() uint32 {
+	if m.arenaBuf == nil {
+		return uint32(m.capacity)
+	}
+
 	a := m.skl.Arena()
 	if atomic.LoadInt32(&m.writerRefs) == 1 {
 		// If there are no other concurrent apply operations, we can update the
@@ -275,16 +341,30 @@ func (m *memTable) availBytes() uint32 {
 }
 
 func (m *memTable) inuseBytes() uint64 {
+	if m.arenaBuf == nil {
+		return 0
+	}
+
 	return uint64(m.skl.Size() - memTableEmptySize)
 }
 
-func (m *memTable) totalBytes() uint64 {
+func (m *memTable) allocatedBytes() uint64 {
+	if m.arenaBuf == nil {
+		// No space allocated yet since the memtable is empty and has seen no
+		// writes. This will prevent empty memtables from contributing to
+		// memtable write stalls.
+		return 0
+	}
 	return uint64(m.skl.Arena().Capacity())
+}
+
+func (m *memTable) maxCapacity() int {
+	return m.capacity
 }
 
 // empty returns whether the MemTable has no key/value pairs.
 func (m *memTable) empty() bool {
-	return m.skl.Size() == memTableEmptySize
+	return m.arenaBuf == nil || m.skl.Size() == memTableEmptySize
 }
 
 // A keySpanFrags holds a set of fragmented keyspan.Spans with a particular key

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -235,7 +235,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   flush         3                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         1   2.3 K     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
- memtbl         1   256 K
+ memtbl         1     0 B
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.4 K   11.1%  (score == hit-rate)
@@ -314,7 +314,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   flush         6                           1.6 K       2       1  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         1   4.7 K     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
- memtbl         1   512 K
+ memtbl         1     0 B
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache        16   2.9 K   14.3%  (score == hit-rate)

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -44,7 +44,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   flush         0                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         0     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         0       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
- memtbl         1   256 K
+ memtbl         1     0 B
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.5 K   42.9%  (score == hit-rate)

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -5,6 +5,30 @@ set a 1
 iter-new a
 ----
 
+metrics
+----
+__level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___r-amp___w-amp
+    WAL         1    28 B       -    17 B       -       -       -       -    28 B       -       -       -     1.6
+      0         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      2         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      3         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      4         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      5         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+      6         0     0 B       -     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
+  total         0     0 B       -    28 B     0 B       0     0 B       0    28 B       0     0 B       0     1.0
+  flush         0                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
+compact         0     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
+  ctype         0       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
+ memtbl         1   256 K
+zmemtbl         0     0 B
+   ztbl         0     0 B
+ bcache         0     0 B    0.0%  (score == hit-rate)
+ tcache         0     0 B    0.0%  (score == hit-rate)
+  snaps         0       -       0  (score == earliest seq num)
+ titers         0
+ filter         -       -    0.0%  (score == utility)
+
 flush
 ----
 0.0:
@@ -30,7 +54,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   flush         1                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         0     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         0       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
- memtbl         1   256 K
+ memtbl         1     0 B
 zmemtbl         1   256 K
    ztbl         0     0 B
  bcache         4   697 B    0.0%  (score == hit-rate)
@@ -78,7 +102,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   flush         2                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         1     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
- memtbl         1   256 K
+ memtbl         1     0 B
 zmemtbl         2   512 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   42.9%  (score == hit-rate)
@@ -111,7 +135,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   flush         2                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         1     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
- memtbl         1   256 K
+ memtbl         1     0 B
 zmemtbl         1   256 K
    ztbl         2   1.5 K
  bcache         8   1.4 K   42.9%  (score == hit-rate)
@@ -141,7 +165,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   flush         2                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         1     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
- memtbl         1   256 K
+ memtbl         1     0 B
 zmemtbl         1   256 K
    ztbl         1   770 B
  bcache         4   697 B   42.9%  (score == hit-rate)
@@ -174,7 +198,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   flush         2                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         1     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
- memtbl         1   256 K
+ memtbl         1     0 B
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         0     0 B   42.9%  (score == hit-rate)
@@ -233,7 +257,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   flush         3                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         1   3.3 K     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         1       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
- memtbl         1   256 K
+ memtbl         1     0 B
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         0     0 B   42.9%  (score == hit-rate)
@@ -276,7 +300,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   flush         3                             0 B       0       0  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         2     0 B     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         2       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
- memtbl         1   256 K
+ memtbl         1     0 B
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         0     0 B   27.3%  (score == hit-rate)
@@ -365,7 +389,7 @@ __level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___writ
   flush         8                           2.4 K       3       2  (ingest = tables-ingested, move = ingested-as-flushable)
 compact         2   5.7 K     0 B       0                          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
   ctype         2       0       0       0       0       0       0  (default, delete, elision, move, read, rewrite, multi-level)
- memtbl         1   1.0 M
+ memtbl         1     0 B
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache        16   2.9 K   34.4%  (score == hit-rate)


### PR DESCRIPTION
Flushable ingestions, and flushable batches can lead to the rotation
of empty memtables. Empty memtables still have memory allocated for
them, and thus can contribute to memtable write stalls. By delaying
memory allocation for memtables until the first write happens, we
can ensure that empty memtables don't contribute to write stalls.