### PR TITLE
shared: add IsNotExistError method to shared.Storage

### DIFF
--- a/objstorage/objstorageprovider/provider.go
+++ b/objstorage/objstorageprovider/provider.go
@@ -181,7 +181,7 @@ func (p *provider) OpenForReading(
 	if !meta.IsShared() {
 		r, err = p.vfsOpenForReading(ctx, fileType, fileNum, opts)
 	} else {
-		r, err = p.sharedOpenForReading(ctx, meta)
+		r, err = p.sharedOpenForReading(ctx, meta, opts)
 	}
 	if err != nil {
 		return nil, err

--- a/objstorage/objstorageprovider/shared_backing.go
+++ b/objstorage/objstorageprovider/shared_backing.go
@@ -197,13 +197,16 @@ func (p *provider) AttachSharedObjects(
 			// TODO(radu): clean up references previously created in this loop.
 			return nil, err
 		}
-		// Check the "originator's" reference.
+		// Check the "origin"'s reference.
 		refName := sharedObjectRefName(d.meta, d.refToCheck.creatorID, d.refToCheck.fileNum)
-		if _, err := p.st.Shared.Storage.Size(refName); err != nil {
-			// TODO(radu): better error message if it doesn't exist.
+		if _, err := p.sharedStorage().Size(refName); err != nil {
 			_ = p.sharedUnref(d.meta)
 			// TODO(radu): clean up references previously created in this loop.
-			return nil, errors.Wrapf(err, "checking originator's marker object %s", refName)
+			if p.sharedStorage().IsNotExistError(err) {
+				return nil, errors.Errorf("origin marker object %q does not exist;"+
+					" object probably removed from the provider which created the backing", refName)
+			}
+			return nil, errors.Wrapf(err, "checking origin's marker object %s", refName)
 		}
 	}
 

--- a/objstorage/objstorageprovider/testdata/provider/shared_attach_after_unref
+++ b/objstorage/objstorageprovider/testdata/provider/shared_attach_after_unref
@@ -90,4 +90,4 @@ p5b2 102
 <shared> delete object "00000000000000000005-000002.sst.ref.00000000000000000006.000102"
 <shared> list (prefix="00000000000000000005-000002.sst.ref.", delimiter="")
 <shared> delete object "00000000000000000005-000002.sst"
-error: checking originator's marker object 00000000000000000005-000002.sst.ref.00000000000000000005.000002: file does not exist
+error: origin marker object "00000000000000000005-000002.sst.ref.00000000000000000005.000002" does not exist; object probably removed from the provider which created the backing

--- a/objstorage/shared/logging.go
+++ b/objstorage/shared/logging.go
@@ -121,3 +121,7 @@ func errOrPrintf(err error, format string, args ...interface{}) string {
 	}
 	return fmt.Sprintf(format, args...)
 }
+
+func (l *loggingStore) IsNotExistError(err error) bool {
+	return l.wrapped.IsNotExistError(err)
+}

--- a/objstorage/shared/mem.go
+++ b/objstorage/shared/mem.go
@@ -133,6 +133,10 @@ func (s *inMemStore) Size(basename string) (int64, error) {
 	return int64(len(obj.data)), nil
 }
 
+func (s *inMemStore) IsNotExistError(err error) bool {
+	return err == os.ErrNotExist
+}
+
 func (s *inMemStore) getObj(name string) (*inMemObj, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/objstorage/shared/storage.go
+++ b/objstorage/shared/storage.go
@@ -49,13 +49,12 @@ type Storage interface {
 	List(prefix, delimiter string) ([]string, error)
 
 	// Delete removes the named object from the store.
-	//
-	// TODO(radu): do we get an error when the object isn't there? How can we
-	// check for that error?
 	Delete(basename string) error
 
 	// Size returns the length of the named object in bytesWritten.
-	//
-	// TODO(radu): same as above - how can we tell if it's a "no such object" error?
 	Size(basename string) (int64, error)
+
+	// IsNotExistError returns true if the given error (returned by a method in
+	// this interface) indicates that the object does not exist.
+	IsNotExistError(err error) bool
 }


### PR DESCRIPTION
This commit adds a IsNotExist error to shared.Storage and addresses some relevant TODOs.

Note that the CockroachDB implementation of `cloud.ExternalStorage` already uses a special error for this, so this should be easy to wire up.