### PR TITLE
*: use atomic types

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -285,7 +285,7 @@ type Batch struct {
 	commitStats BatchCommitStats
 
 	commitErr error
-	applied   uint32 // updated atomically
+	applied   atomic.Bool
 }
 
 // BatchCommitStats exposes stats related to committing a batch.
@@ -1198,7 +1198,7 @@ func (b *Batch) Reset() {
 	b.fsyncWait = sync.WaitGroup{}
 	b.commitStats = BatchCommitStats{}
 	b.commitErr = nil
-	atomic.StoreUint32(&b.applied, 0)
+	b.applied.Store(false)
 	if b.data != nil {
 		if cap(b.data) > batchMaxRetainedSize {
 			// If the capacity of the buffer is larger than our maximum

--- a/batch_test.go
+++ b/batch_test.go
@@ -297,7 +297,7 @@ func TestBatchReset(t *testing.T) {
 	require.NoError(t, b.RangeKeySet([]byte(key), []byte(value), []byte(value), []byte(value), nil))
 
 	b.setSeqNum(100)
-	b.applied = 1
+	b.applied.Store(true)
 	b.commitErr = errors.New("test-error")
 	b.commit.Add(1)
 	b.fsyncWait.Add(1)
@@ -326,7 +326,7 @@ func TestBatchReset(t *testing.T) {
 
 	b.Reset()
 	require.Equal(t, db, b.db)
-	require.Equal(t, uint32(0), b.applied)
+	require.Equal(t, false, b.applied.Load())
 	require.Nil(t, b.commitErr)
 	require.Equal(t, uint32(0), b.Count())
 	require.Equal(t, uint64(0), b.countRangeDels)

--- a/cmd/pebble/fsbench.go
+++ b/cmd/pebble/fsbench.go
@@ -208,10 +208,10 @@ func createBench(benchName string, benchDescription string) fsBenchmark {
 		// setup the operation to benchmark, and the cleanup functions.
 		pref := "temp_"
 		var numFiles int
-		var done int32
+		var done atomic.Bool
 
 		bench.run = func(hist *namedHistogram) bool {
-			if atomic.LoadInt32(&done) == 1 {
+			if done.Load() {
 				return false
 			}
 
@@ -226,7 +226,7 @@ func createBench(benchName string, benchDescription string) fsBenchmark {
 		}
 
 		bench.stop = func() {
-			atomic.StoreInt32(&done, 1)
+			done.Store(true)
 		}
 
 		bench.clean = func() {
@@ -274,9 +274,9 @@ func deleteBench(
 		}
 		syncFile(bench.dir)
 
-		var done int32
+		var done atomic.Bool
 		bench.run = func(hist *namedHistogram) bool {
-			if atomic.LoadInt32(&done) == 1 {
+			if done.Load() {
 				return false
 			}
 
@@ -293,7 +293,7 @@ func deleteBench(
 		}
 
 		bench.stop = func() {
-			atomic.StoreInt32(&done, 1)
+			done.Store(true)
 		}
 
 		bench.clean = func() {
@@ -341,9 +341,9 @@ func deleteUniformBench(
 		}
 		syncFile(bench.dir)
 
-		var done int32
+		var done atomic.Bool
 		bench.run = func(hist *namedHistogram) bool {
-			if atomic.LoadInt32(&done) == 1 {
+			if done.Load() {
 				return false
 			}
 
@@ -360,7 +360,7 @@ func deleteUniformBench(
 		}
 
 		bench.stop = func() {
-			atomic.StoreInt32(&done, 1)
+			done.Store(true)
 		}
 
 		bench.clean = func() {
@@ -403,7 +403,7 @@ func writeSyncBench(
 
 		pref := "temp_"
 		var benchData struct {
-			done         int32
+			done         atomic.Bool
 			fh           vfs.File
 			fileNum      int
 			bytesWritten int
@@ -411,7 +411,7 @@ func writeSyncBench(
 		benchData.fh = createFile(path.Join(dirpath, fmt.Sprintf("%s%d", pref, benchData.fileNum)))
 
 		bench.run = func(hist *namedHistogram) bool {
-			if atomic.LoadInt32(&benchData.done) == 1 {
+			if benchData.done.Load() {
 				return false
 			}
 
@@ -433,7 +433,7 @@ func writeSyncBench(
 		}
 
 		bench.stop = func() {
-			atomic.StoreInt32(&benchData.done, 1)
+			benchData.done.Store(true)
 		}
 
 		bench.clean = func() {
@@ -476,7 +476,7 @@ func diskUsageBench(
 
 		pref := "temp_"
 		var benchData struct {
-			done         int32
+			done         atomic.Bool
 			fh           vfs.File
 			fileNum      int
 			bytesWritten int
@@ -484,7 +484,7 @@ func diskUsageBench(
 		benchData.fh = createFile(path.Join(dirpath, fmt.Sprintf("%s%d", pref, benchData.fileNum)))
 
 		bench.run = func(hist *namedHistogram) bool {
-			if atomic.LoadInt32(&benchData.done) == 1 {
+			if benchData.done.Load() {
 				return false
 			}
 
@@ -507,7 +507,7 @@ func diskUsageBench(
 		}
 
 		bench.stop = func() {
-			atomic.StoreInt32(&benchData.done, 1)
+			benchData.done.Store(true)
 		}
 
 		bench.clean = func() {

--- a/cmd/pebble/queue.go
+++ b/cmd/pebble/queue.go
@@ -32,8 +32,8 @@ func initQueue(cmd *cobra.Command) {
 		"queue value size distribution [{zipf,uniform}:]min[-max][/<target-compression>]")
 }
 
-func queueTest() (test, *int64) {
-	ops := new(int64) // atomic
+func queueTest() (test, *atomic.Int64) {
+	ops := new(atomic.Int64) // atomic
 	var (
 		lastOps     int64
 		lastElapsed time.Duration
@@ -87,7 +87,7 @@ func queueTest() (test, *int64) {
 					}
 					_ = b.Close()
 					wait(limiter)
-					atomic.AddInt64(ops, 1)
+					ops.Add(1)
 				}
 			}()
 		},
@@ -96,7 +96,7 @@ func queueTest() (test, *int64) {
 				fmt.Println("Queue___elapsed_______ops/sec")
 			}
 
-			curOps := atomic.LoadInt64(ops)
+			curOps := ops.Load()
 			dur := elapsed - lastElapsed
 			fmt.Printf("%15s %13.1f\n",
 				time.Duration(elapsed.Seconds()+0.5)*time.Second,
@@ -106,7 +106,7 @@ func queueTest() (test, *int64) {
 			lastElapsed = elapsed
 		},
 		done: func(elapsed time.Duration) {
-			curOps := atomic.LoadInt64(ops)
+			curOps := ops.Load()
 			fmt.Println("\nQueue___elapsed___ops/sec(cum)")
 			fmt.Printf("%13.1fs %14.1f\n\n",
 				elapsed.Seconds(),

--- a/cmd/pebble/scan.go
+++ b/cmd/pebble/scan.go
@@ -46,8 +46,8 @@ func init() {
 
 func runScan(cmd *cobra.Command, args []string) {
 	var (
-		bytes       int64
-		scanned     int64
+		bytes       atomic.Int64
+		scanned     atomic.Int64
 		lastBytes   int64
 		lastScanned int64
 		lastElapsed time.Duration
@@ -119,8 +119,8 @@ func runScan(cmd *cobra.Command, args []string) {
 							log.Fatalf("scanned %d, expected %d\n", count, rows)
 						}
 
-						atomic.AddInt64(&bytes, nbytes)
-						atomic.AddInt64(&scanned, int64(count))
+						bytes.Add(nbytes)
+						scanned.Add(int64(count))
 					}
 				}(i)
 			}
@@ -131,8 +131,8 @@ func runScan(cmd *cobra.Command, args []string) {
 				fmt.Println("_elapsed_______rows/sec_______MB/sec_______ns/row")
 			}
 
-			curBytes := atomic.LoadInt64(&bytes)
-			curScanned := atomic.LoadInt64(&scanned)
+			curBytes := bytes.Load()
+			curScanned := scanned.Load()
 			dur := elapsed - lastElapsed
 			fmt.Printf("%8s %14.1f %12.1f %12.1f\n",
 				time.Duration(elapsed.Seconds()+0.5)*time.Second,
@@ -146,8 +146,8 @@ func runScan(cmd *cobra.Command, args []string) {
 		},
 
 		done: func(elapsed time.Duration) {
-			curBytes := atomic.LoadInt64(&bytes)
-			curScanned := atomic.LoadInt64(&scanned)
+			curBytes := bytes.Load()
+			curScanned := scanned.Load()
 			fmt.Println("\n_elapsed___ops/sec(cum)__MB/sec(cum)__ns/row(avg)")
 			fmt.Printf("%7.1fs %14.1f %12.1f %12.1f\n\n",
 				elapsed.Seconds(),

--- a/cmd/pebble/tombstone.go
+++ b/cmd/pebble/tombstone.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -95,7 +94,7 @@ func runTombstoneCmd(cmd *cobra.Command, args []string) error {
 				fmt.Println("________elapsed______queue_size__ops/sec(inst)___ops/sec(cum)__ops/sec(inst)___ops/sec(cum)")
 			}
 
-			curQueueOps := atomic.LoadInt64(queueOps)
+			curQueueOps := queueOps.Load()
 			dur := elapsed - lastElapsed
 			queueOpsPerSec := float64(curQueueOps-lastQueueOps) / dur.Seconds()
 			queueCumOpsPerSec := float64(curQueueOps) / elapsed.Seconds()

--- a/commit_test.go
+++ b/commit_test.go
@@ -70,12 +70,12 @@ func TestCommitQueue(t *testing.T) {
 	if b := q.dequeue(); b != nil {
 		t.Fatalf("unexpectedly dequeued batch: %p", b)
 	}
-	atomic.StoreUint32(&batches[1].applied, 1)
+	batches[1].applied.Store(true)
 	if b := q.dequeue(); b != nil {
 		t.Fatalf("unexpectedly dequeued batch: %p", b)
 	}
 	for i := range batches {
-		atomic.StoreUint32(&batches[i].applied, 1)
+		batches[i].applied.Store(true)
 		if b := q.dequeue(); b != &batches[i] {
 			t.Fatalf("%d: expected batch %p, but found %p", i, &batches[i], b)
 		}

--- a/compaction.go
+++ b/compaction.go
@@ -13,7 +13,6 @@ import (
 	"runtime/pprof"
 	"sort"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -1669,16 +1668,16 @@ func (d *DB) removeInProgressCompaction(c *compaction, rollback bool) {
 
 func (d *DB) calculateDiskAvailableBytes() uint64 {
 	if space, err := d.opts.FS.GetDiskUsage(d.dirname); err == nil {
-		atomic.StoreUint64(&d.atomic.diskAvailBytes, space.AvailBytes)
+		d.diskAvailBytes.Store(space.AvailBytes)
 		return space.AvailBytes
 	} else if !errors.Is(err, vfs.ErrUnsupported) {
 		d.opts.EventListener.BackgroundError(err)
 	}
-	return atomic.LoadUint64(&d.atomic.diskAvailBytes)
+	return d.diskAvailBytes.Load()
 }
 
 func (d *DB) getDiskAvailableBytesCached() uint64 {
-	return atomic.LoadUint64(&d.atomic.diskAvailBytes)
+	return d.diskAvailBytes.Load()
 }
 
 func (d *DB) getDeletionPacerInfo() deletionPacerInfo {

--- a/db.go
+++ b/db.go
@@ -772,7 +772,7 @@ func (d *DB) applyInternal(batch *Batch, opts *WriteOptions, noSyncWait bool) er
 	if err := d.closed.Load(); err != nil {
 		panic(err)
 	}
-	if atomic.LoadUint32(&batch.applied) != 0 {
+	if batch.applied.Load() {
 		panic("pebble: batch already applied")
 	}
 	if d.opts.ReadOnly {

--- a/db.go
+++ b/db.go
@@ -232,25 +232,17 @@ func (d defaultCPUWorkGranter) CPUWorkDone(_ CPUWorkHandle) {}
 //		Comparer: myComparer,
 //	})
 type DB struct {
-	// WARNING: The following struct `atomic` contains fields which are accessed
-	// atomically.
-	//
-	// Go allocations are guaranteed to be 64-bit aligned which we take advantage
-	// of by placing the 64-bit fields which we access atomically at the beginning
-	// of the DB struct. For more information, see https://golang.org/pkg/sync/atomic/#pkg-note-BUG.
-	atomic struct {
-		// The count and size of referenced memtables. This includes memtables
-		// present in DB.mu.mem.queue, as well as memtables that have been flushed
-		// but are still referenced by an inuse readState.
-		memTableCount    int64
-		memTableReserved int64 // number of bytes reserved in the cache for memtables
+	// The count and size of referenced memtables. This includes memtables
+	// present in DB.mu.mem.queue, as well as memtables that have been flushed
+	// but are still referenced by an inuse readState.
+	memTableCount    atomic.Int64
+	memTableReserved atomic.Int64 // number of bytes reserved in the cache for memtables
 
-		// The size of the current log file (i.e. db.mu.log.queue[len(queue)-1].
-		logSize uint64
+	// The size of the current log file (i.e. db.mu.log.queue[len(queue)-1].
+	logSize atomic.Uint64
 
-		// The number of bytes available on disk.
-		diskAvailBytes uint64
-	}
+	// The number of bytes available on disk.
+	diskAvailBytes atomic.Uint64
 
 	cacheID        uint64
 	dirname        string
@@ -922,7 +914,7 @@ func (d *DB) commitWrite(b *Batch, syncWG *sync.WaitGroup, syncErr *error) (*mem
 		}
 	}
 
-	atomic.StoreUint64(&d.atomic.logSize, uint64(size))
+	d.logSize.Store(uint64(size))
 	return mem, err
 }
 
@@ -1490,7 +1482,7 @@ func (d *DB) Close() error {
 		// replay.
 		mem.readerUnrefLocked(false)
 	}
-	if reserved := atomic.LoadInt64(&d.atomic.memTableReserved); reserved != 0 {
+	if reserved := d.memTableReserved.Load(); reserved != 0 {
 		err = firstError(err, errors.Errorf("leaked memtable reservation: %d", errors.Safe(reserved)))
 	}
 
@@ -1733,11 +1725,11 @@ func (d *DB) Metrics() *Metrics {
 	metrics.Snapshots.PinnedKeys = d.mu.snapshots.cumulativePinnedCount
 	metrics.Snapshots.PinnedSize = d.mu.snapshots.cumulativePinnedSize
 	metrics.MemTable.Count = int64(len(d.mu.mem.queue))
-	metrics.MemTable.ZombieCount = atomic.LoadInt64(&d.atomic.memTableCount) - metrics.MemTable.Count
-	metrics.MemTable.ZombieSize = uint64(atomic.LoadInt64(&d.atomic.memTableReserved)) - metrics.MemTable.Size
+	metrics.MemTable.ZombieCount = d.memTableCount.Load() - metrics.MemTable.Count
+	metrics.MemTable.ZombieSize = uint64(d.memTableReserved.Load()) - metrics.MemTable.Size
 	metrics.WAL.ObsoleteFiles = int64(recycledLogsCount)
 	metrics.WAL.ObsoletePhysicalSize = recycledLogSize
-	metrics.WAL.Size = atomic.LoadUint64(&d.atomic.logSize)
+	metrics.WAL.Size = d.logSize.Load()
 	// The current WAL size (d.atomic.logSize) is the current logical size,
 	// which may be less than the WAL's physical size if it was recycled.
 	// The file sizes in d.mu.log.queue are updated to the physical size
@@ -1964,8 +1956,8 @@ func (d *DB) newMemTable(logNum FileNum, logSeqNum uint64) (*memTable, *flushabl
 		}
 	}
 
-	atomic.AddInt64(&d.atomic.memTableCount, 1)
-	atomic.AddInt64(&d.atomic.memTableReserved, int64(size))
+	d.memTableCount.Add(1)
+	d.memTableReserved.Add(int64(size))
 	releaseAccountingReservation := d.opts.Cache.Reserve(size)
 
 	mem := newMemTable(memTableOptions{
@@ -1981,8 +1973,8 @@ func (d *DB) newMemTable(logNum FileNum, logSeqNum uint64) (*memTable, *flushabl
 	entry.releaseMemAccounting = func() {
 		manual.Free(mem.arenaBuf)
 		mem.arenaBuf = nil
-		atomic.AddInt64(&d.atomic.memTableCount, -1)
-		atomic.AddInt64(&d.atomic.memTableReserved, -int64(size))
+		d.memTableCount.Add(-1)
+		d.memTableReserved.Add(-int64(size))
 		releaseAccountingReservation()
 	}
 	return mem, entry

--- a/db_test.go
+++ b/db_test.go
@@ -815,7 +815,7 @@ func TestMemTableReservation(t *testing.T) {
 
 	checkReserved := func(expected int64) {
 		t.Helper()
-		if reserved := atomic.LoadInt64(&d.atomic.memTableReserved); expected != reserved {
+		if reserved := d.memTableReserved.Load(); expected != reserved {
 			t.Fatalf("expected %d reserved, but found %d", expected, reserved)
 		}
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -390,7 +390,7 @@ func TestLargeBatch(t *testing.T) {
 
 	startLogNum := logNum()
 	startLogStartSize := fileSize(startLogNum)
-	startSeqNum := atomic.LoadUint64(&d.mu.versions.atomic.logSeqNum)
+	startSeqNum := d.mu.versions.logSeqNum.Load()
 
 	// Write a key with a value larger than the memtable size.
 	require.NoError(t, d.Set([]byte("a"), bytes.Repeat([]byte("a"), 512), nil))

--- a/level_checker.go
+++ b/level_checker.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"sort"
-	"sync/atomic"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -568,7 +567,7 @@ func (d *DB) CheckLevels(stats *CheckLevelsStats) error {
 
 	// Determine the seqnum to read at after grabbing the read state (current and
 	// memtables) above.
-	seqNum := atomic.LoadUint64(&d.mu.versions.atomic.visibleSeqNum)
+	seqNum := d.mu.versions.visibleSeqNum.Load()
 
 	checkConfig := &checkConfig{
 		logger:    d.opts.Logger,

--- a/open.go
+++ b/open.go
@@ -191,8 +191,8 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	}()
 
 	d.commit = newCommitPipeline(commitEnv{
-		logSeqNum:     &d.mu.versions.atomic.logSeqNum,
-		visibleSeqNum: &d.mu.versions.atomic.visibleSeqNum,
+		logSeqNum:     &d.mu.versions.logSeqNum,
+		visibleSeqNum: &d.mu.versions.visibleSeqNum,
 		apply:         d.commitApply,
 		write:         d.commitWrite,
 	})
@@ -212,7 +212,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	d.mu.snapshots.init()
 	// logSeqNum is the next sequence number that will be assigned. Start
 	// assigning sequence numbers from 1 to match rocksdb.
-	d.mu.versions.atomic.logSeqNum = 1
+	d.mu.versions.logSeqNum.Store(1)
 	d.mu.formatVers.vers = formatVersion
 	d.mu.formatVers.marker = formatVersionMarker
 
@@ -258,7 +258,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	// sequence number of the first batch that will be inserted.
 	if !d.opts.ReadOnly {
 		var entry *flushableEntry
-		d.mu.mem.mutable, entry = d.newMemTable(0 /* logNum */, d.mu.versions.atomic.logSeqNum)
+		d.mu.mem.mutable, entry = d.newMemTable(0 /* logNum */, d.mu.versions.logSeqNum.Load())
 		d.mu.mem.queue = append(d.mu.mem.queue, entry)
 	}
 
@@ -374,11 +374,11 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		}
 		toFlush = append(toFlush, flush...)
 		d.mu.versions.markFileNumUsed(lf.num)
-		if d.mu.versions.atomic.logSeqNum < maxSeqNum {
-			d.mu.versions.atomic.logSeqNum = maxSeqNum
+		if d.mu.versions.logSeqNum.Load() < maxSeqNum {
+			d.mu.versions.logSeqNum.Store(maxSeqNum)
 		}
 	}
-	d.mu.versions.atomic.visibleSeqNum = d.mu.versions.atomic.logSeqNum
+	d.mu.versions.visibleSeqNum.Store(d.mu.versions.logSeqNum.Load())
 
 	if !d.opts.ReadOnly {
 		// Create an empty .log file.

--- a/open.go
+++ b/open.go
@@ -155,7 +155,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		closedCh:            make(chan struct{}),
 	}
 	d.mu.versions = &versionSet{}
-	d.atomic.diskAvailBytes = math.MaxUint64
+	d.diskAvailBytes.Store(math.MaxUint64)
 	d.mu.versions.diskAvailBytes = d.getDiskAvailableBytesCached
 
 	defer func() {

--- a/record/log_writer_test.go
+++ b/record/log_writer_test.go
@@ -31,14 +31,14 @@ func (f syncErrorFile) Sync() error {
 
 func TestSyncQueue(t *testing.T) {
 	var q syncQueue
-	var closed int32
+	var closed atomic.Bool
 
 	var flusherWG sync.WaitGroup
 	flusherWG.Add(1)
 	go func() {
 		defer flusherWG.Done()
 		for {
-			if atomic.LoadInt32(&closed) == 1 {
+			if closed.Load() {
 				return
 			}
 			head, tail, _ := q.load()
@@ -66,7 +66,7 @@ func TestSyncQueue(t *testing.T) {
 	}
 	doneWG.Wait()
 
-	atomic.StoreInt32(&closed, 1)
+	closed.Store(true)
 	flusherWG.Wait()
 }
 

--- a/sstable/filter.go
+++ b/sstable/filter.go
@@ -7,6 +7,9 @@ package sstable
 import "sync/atomic"
 
 // FilterMetrics holds metrics for the filter policy.
+// TODO(radu): in some contexts, the fields inside are used as atomics; in
+// others they are not (in particular, the struct gets copied around). Split the
+// type into two and use atomic.Int64.
 type FilterMetrics struct {
 	// The number of hits for the filter policy. This is the
 	// number of times the filter policy was successfully used to avoid access

--- a/table_cache.go
+++ b/table_cache.go
@@ -187,14 +187,7 @@ func (c *tableCacheContainer) iterCount() int64 {
 
 // TableCache is a shareable cache for open sstables.
 type TableCache struct {
-	// atomic contains fields which are accessed atomically. Go allocations
-	// are guaranteed to be 64-bit aligned which we take advantage of by
-	// placing the 64-bit fields which we access atomically at the beginning
-	// of the TableCache struct. For more information, see
-	// https://golang.org/pkg/sync/atomic/#pkg-note-BUG.
-	atomic struct {
-		refs int64
-	}
+	refs atomic.Int64
 
 	cache  *Cache
 	shards []*tableCacheShard
@@ -204,7 +197,7 @@ type TableCache struct {
 // the table cache only remains valid if there is at least one reference
 // to it.
 func (c *TableCache) Ref() {
-	v := atomic.AddInt64(&c.atomic.refs, 1)
+	v := c.refs.Add(1)
 	// We don't want the reference count to ever go from 0 -> 1,
 	// cause a reference count of 0 implies that we've closed the cache.
 	if v <= 1 {
@@ -214,7 +207,7 @@ func (c *TableCache) Ref() {
 
 // Unref removes a reference to the table cache.
 func (c *TableCache) Unref() error {
-	v := atomic.AddInt64(&c.atomic.refs, -1)
+	v := c.refs.Add(-1)
 	switch {
 	case v < 0:
 		panic(fmt.Sprintf("pebble: inconsistent reference count: %d", v))
@@ -256,7 +249,7 @@ func NewTableCache(cache *Cache, numShards int, size int) *TableCache {
 	}
 
 	// Hold a ref to the cache here.
-	c.atomic.refs = 1
+	c.refs.Store(1)
 
 	return c
 }

--- a/table_cache.go
+++ b/table_cache.go
@@ -58,12 +58,9 @@ var tableCacheLabels = pprof.Labels("pebble", "table-cache")
 // are updated, we could have unnecessary evictions of those
 // fields, and the surrounding fields from the CPU caches.
 type tableCacheOpts struct {
-	atomic struct {
-		// iterCount in the tableCacheOpts keeps track of iterators
-		// opened or closed by a DB. It's used to keep track of
-		// leaked iterators on a per-db level.
-		iterCount *int32
-	}
+	// iterCount keeps track of how many iterators are open. It is used to keep
+	// track of leaked iterators on a per-db level.
+	iterCount *atomic.Int32
 
 	loggerAndTracer LoggerAndTracer
 	cacheID         uint64
@@ -106,7 +103,7 @@ func newTableCacheContainer(
 	t.dbOpts.objProvider = objProvider
 	t.dbOpts.opts = opts.MakeReaderOptions()
 	t.dbOpts.filterMetrics = &FilterMetrics{}
-	t.dbOpts.atomic.iterCount = new(int32)
+	t.dbOpts.iterCount = new(atomic.Int32)
 	return t
 }
 
@@ -117,7 +114,7 @@ func (c *tableCacheContainer) close() error {
 	// by the DB using this container. Note that we'll still perform cleanup
 	// below in the case that there are leaked iterators.
 	var err error
-	if v := atomic.LoadInt32(c.dbOpts.atomic.iterCount); v > 0 {
+	if v := c.dbOpts.iterCount.Load(); v > 0 {
 		err = errors.Errorf("leaked iterators: %d", errors.Safe(v))
 	}
 
@@ -182,7 +179,7 @@ func (c *tableCacheContainer) withReader(meta *fileMetadata, fn func(*sstable.Re
 }
 
 func (c *tableCacheContainer) iterCount() int64 {
-	return int64(atomic.LoadInt32(c.dbOpts.atomic.iterCount))
+	return int64(c.dbOpts.iterCount.Load())
 }
 
 // TableCache is a shareable cache for open sstables.
@@ -436,7 +433,7 @@ func (c *tableCacheShard) newIters(
 	iter.SetCloseHook(v.closeHook)
 
 	atomic.AddInt32(&c.atomic.iterCount, 1)
-	atomic.AddInt32(dbOpts.atomic.iterCount, 1)
+	dbOpts.iterCount.Add(1)
 	if invariants.RaceEnabled {
 		c.mu.Lock()
 		c.mu.iters[iter] = debug.Stack()
@@ -686,7 +683,7 @@ func (c *tableCacheShard) findNode(meta *fileMetadata, dbOpts *tableCacheOpts) *
 		}
 		c.unrefValue(v)
 		atomic.AddInt32(&c.atomic.iterCount, -1)
-		atomic.AddInt32(dbOpts.atomic.iterCount, -1)
+		dbOpts.iterCount.Add(-1)
 		return nil
 	}
 	n.value = v

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -15,7 +15,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -885,11 +884,11 @@ func TestTableCacheClockPro(t *testing.T) {
 			tables[key] = true
 		}
 
-		oldHits := atomic.LoadInt64(&cache.atomic.hits)
+		oldHits := cache.hits.Load()
 		v := cache.findNode(&fileMetadata{FileNum: FileNum(key)}, dbOpts)
 		cache.unrefValue(v)
 
-		hit := atomic.LoadInt64(&cache.atomic.hits) != oldHits
+		hit := cache.hits.Load() != oldHits
 		wantHit := fields[1][0] == 'h'
 		if hit != wantHit {
 			t.Errorf("%d: cache hit mismatch: got %v, want %v\n", line, hit, wantHit)

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -209,25 +209,25 @@ func newTableCacheContainerTest(
 func TestTableCacheRefs(t *testing.T) {
 	tc := newTableCacheTest(8<<20, 10, 2)
 
-	v := atomic.LoadInt64(&tc.atomic.refs)
+	v := tc.refs.Load()
 	if v != 1 {
 		require.Equal(t, 1, v)
 	}
 
 	tc.Ref()
-	v = atomic.LoadInt64(&tc.atomic.refs)
+	v = tc.refs.Load()
 	if v != 2 {
 		require.Equal(t, 2, v)
 	}
 
 	tc.Unref()
-	v = atomic.LoadInt64(&tc.atomic.refs)
+	v = tc.refs.Load()
 	if v != 1 {
 		require.Equal(t, 1, v)
 	}
 
 	tc.Unref()
-	v = atomic.LoadInt64(&tc.atomic.refs)
+	v = tc.refs.Load()
 	if v != 0 {
 		require.Equal(t, 0, v)
 	}
@@ -269,7 +269,7 @@ func TestSharedTableCacheUseAfterAllFree(t *testing.T) {
 	require.NoError(t, db1.Close())
 	require.NoError(t, db2.Close())
 
-	v := atomic.LoadInt64(&tc.atomic.refs)
+	v := tc.refs.Load()
 	if v != 0 {
 		t.Fatalf("expected reference count %d, got %d", 0, v)
 	}
@@ -326,7 +326,7 @@ func TestSharedTableCacheUseAfterOneFree(t *testing.T) {
 	// Make db1 release a reference to the cache. It should
 	// still be usable by db2.
 	require.NoError(t, db1.Close())
-	v := atomic.LoadInt64(&tc.atomic.refs)
+	v := tc.refs.Load()
 	if v != 1 {
 		t.Fatalf("expected reference count %d, got %d", 1, v)
 	}

--- a/version_set.go
+++ b/version_set.go
@@ -43,26 +43,19 @@ type versionList = manifest.VersionList
 // like it sounds: a delta from the previous version. Version edits are logged
 // to the MANIFEST file, which is replayed at startup.
 type versionSet struct {
-	// WARNING: The following struct `atomic` contains fields are accessed atomically.
-	//
-	// Go allocations are guaranteed to be 64-bit aligned which we take advantage
-	// of by placing the 64-bit fields which we access atomically at the beginning
-	// of the versionSet struct.
-	// For more information, see https://golang.org/pkg/sync/atomic/#pkg-note-BUG.
-	atomic struct {
-		logSeqNum uint64 // next seqNum to use for WAL writes
+	// Next seqNum to use for WAL writes.
+	logSeqNum atomic.Uint64
 
-		// The upper bound on sequence numbers that have been assigned so far.
-		// A suffix of these sequence numbers may not have been written to a
-		// WAL. Both logSeqNum and visibleSeqNum are atomically updated by the
-		// commitPipeline.
-		visibleSeqNum uint64 // visible seqNum (<= logSeqNum)
+	// The upper bound on sequence numbers that have been assigned so far. A
+	// suffix of these sequence numbers may not have been written to a WAL. Both
+	// logSeqNum and visibleSeqNum are atomically updated by the commitPipeline.
+	// visibleSeqNum is <= logSeqNum.
+	visibleSeqNum atomic.Uint64
 
-		// Number of bytes present in sstables being written by in-progress
-		// compactions. This value will be zero if there are no in-progress
-		// compactions. Updated and read atomically.
-		atomicInProgressBytes int64
-	}
+	// Number of bytes present in sstables being written by in-progress
+	// compactions. This value will be zero if there are no in-progress
+	// compactions. Updated and read atomically.
+	atomicInProgressBytes atomic.Int64
 
 	// Immutable fields.
 	dirname string
@@ -272,7 +265,7 @@ func (vs *versionSet) load(
 			// (assuming no WALs contain higher sequence numbers than the
 			// manifest's LastSeqNum). Increment LastSeqNum by 1 to get the
 			// next sequence number that will be assigned.
-			vs.atomic.logSeqNum = ve.LastSeqNum + 1
+			vs.logSeqNum.Store(ve.LastSeqNum + 1)
 		}
 	}
 	// We have already set vs.nextFileNum = 2 at the beginning of the
@@ -410,7 +403,7 @@ func (vs *versionSet) logAndApply(
 	// in an unflushed memtable. logSeqNum is the _next_ sequence number that
 	// will be assigned, so subtract that by 1 to get the upper bound on the
 	// last assigned sequence number.
-	logSeqNum := atomic.LoadUint64(&vs.atomic.logSeqNum)
+	logSeqNum := vs.logSeqNum.Load()
 	ve.LastSeqNum = logSeqNum - 1
 	if logSeqNum == 0 {
 		// logSeqNum is initialized to 1 in Open() if there are no previous WAL
@@ -647,7 +640,7 @@ func (vs *versionSet) incrementCompactions(kind compactionKind, extraLevels []*c
 }
 
 func (vs *versionSet) incrementCompactionBytes(numBytes int64) {
-	atomic.AddInt64(&vs.atomic.atomicInProgressBytes, numBytes)
+	vs.atomicInProgressBytes.Add(numBytes)
 }
 
 // createManifest creates a manifest file that contains a snapshot of vs.

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -295,5 +295,5 @@ func TestVersionSetSeqNums(t *testing.T) {
 	// 2 ingestions happened, so LastSeqNum should equal 2.
 	require.Equal(t, uint64(2), lastSeqNum)
 	// logSeqNum is always one greater than the last assigned sequence number.
-	require.Equal(t, d.mu.versions.atomic.logSeqNum, lastSeqNum+1)
+	require.Equal(t, d.mu.versions.logSeqNum.Load(), lastSeqNum+1)
 }

--- a/vfs/disk_full_test.go
+++ b/vfs/disk_full_test.go
@@ -114,9 +114,9 @@ func TestOnDiskFull_Concurrent(t *testing.T) {
 		opDelay: 10 * time.Millisecond,
 	}
 	innerFS.atomic.enospcs = 10
-	var callbackInvocations int32
+	var callbackInvocations atomic.Int32
 	fs := OnDiskFull(innerFS, func() {
-		atomic.AddInt32(&callbackInvocations, 1)
+		callbackInvocations.Add(1)
 	})
 
 	var wg sync.WaitGroup
@@ -132,7 +132,7 @@ func TestOnDiskFull_Concurrent(t *testing.T) {
 	wg.Wait()
 	// Since all operations should start before the first one returns an
 	// ENOSPC, the callback should only be invoked once.
-	require.Equal(t, int32(1), atomic.LoadInt32(&callbackInvocations))
+	require.Equal(t, int32(1), callbackInvocations.Load())
 	require.Equal(t, uint32(20), atomic.LoadUint32(&innerFS.atomic.invocations))
 }
 


### PR DESCRIPTION
This set of commits changes most usages of atomics to types like `atomic.Uint64`, `atomic.Bool` etc. Note that `atomic.Uint64 / atomic.Int64` are guaranteed to be 64-bit aligned on all platforms (unlike `int64/uint64`).

There are some usages remaining, mostly because of structs that get copied around.