### PR TITLE
crl-release-23.1: db: populate return statistics for flushable ingests

### DIFF
--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1212,44 +1212,54 @@ func TestConcurrentIngestCompact(t *testing.T) {
 func TestIngestFlushQueuedMemTable(t *testing.T) {
 	// Verify that ingestion forces a flush of a queued memtable.
 
-	mem := vfs.NewMem()
-	d, err := Open("", &Options{
-		FS: mem,
-	})
-	require.NoError(t, err)
+	// Test with a format major version prior to FormatFlushableIngest and one
+	// after. Both should result in the same statistic calculations.
+	for _, fmv := range []FormatMajorVersion{FormatFlushableIngest - 1, FormatNewest} {
+		func(fmv FormatMajorVersion) {
+			mem := vfs.NewMem()
+			d, err := Open("", &Options{
+				FS:                 mem,
+				FormatMajorVersion: fmv,
+			})
+			require.NoError(t, err)
 
-	// Add the key "a" to the memtable, then fill up the memtable with the key
-	// "b". The ingested sstable will only overlap with the queued memtable.
-	require.NoError(t, d.Set([]byte("a"), nil, nil))
-	for {
-		require.NoError(t, d.Set([]byte("b"), nil, nil))
-		d.mu.Lock()
-		done := len(d.mu.mem.queue) == 2
-		d.mu.Unlock()
-		if done {
-			break
-		}
+			// Add the key "a" to the memtable, then fill up the memtable with the key
+			// "b". The ingested sstable will only overlap with the queued memtable.
+			require.NoError(t, d.Set([]byte("a"), nil, nil))
+			for {
+				require.NoError(t, d.Set([]byte("b"), nil, nil))
+				d.mu.Lock()
+				done := len(d.mu.mem.queue) == 2
+				d.mu.Unlock()
+				if done {
+					break
+				}
+			}
+
+			ingest := func(keys ...string) {
+				t.Helper()
+				f, err := mem.Create("ext")
+				require.NoError(t, err)
+
+				w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{
+					TableFormat: fmv.MinTableFormat(),
+				})
+				for _, k := range keys {
+					require.NoError(t, w.Set([]byte(k), nil))
+				}
+				require.NoError(t, w.Close())
+				stats, err := d.IngestWithStats([]string{"ext"})
+				require.NoError(t, err)
+				require.Equal(t, stats.ApproxIngestedIntoL0Bytes, stats.Bytes)
+				require.Equal(t, stats.MemtableOverlappingFiles, 1)
+				require.Less(t, uint64(0), stats.Bytes)
+			}
+
+			ingest("a")
+
+			require.NoError(t, d.Close())
+		}(fmv)
 	}
-
-	ingest := func(keys ...string) {
-		t.Helper()
-		f, err := mem.Create("ext")
-		require.NoError(t, err)
-
-		w := sstable.NewWriter(objstorage.NewFileWritable(f), sstable.WriterOptions{})
-		for _, k := range keys {
-			require.NoError(t, w.Set([]byte(k), nil))
-		}
-		require.NoError(t, w.Close())
-		stats, err := d.IngestWithStats([]string{"ext"})
-		require.NoError(t, err)
-		require.Equal(t, stats.ApproxIngestedIntoL0Bytes, stats.Bytes)
-		require.Less(t, uint64(0), stats.Bytes)
-	}
-
-	ingest("a")
-
-	require.NoError(t, d.Close())
 }
 
 func TestIngestStats(t *testing.T) {


### PR DESCRIPTION
23.1 backport of #2425.

----

The IngestWithStats ingestion entrypoint returnrs statistics about the ingest. Cockroach uses these statistics to inform admission control. During a flushable ingest, at commit time the number of bytes that will be ingested into L0 is unknown. This commit adds an approximation based on which tables overlapped the flushable queue. This required adjusting the memtable overlap logic to avoid short circuiting as soon as overlap is found.

This approximation is rough and may be improved with future work, such as #2112.

Informs #2421.
Informs #2112.
Informs cockroachdb/cockroach#100149.