### PR TITLE
manifest: use atomic types in FileMetadata

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -706,7 +706,7 @@ func (a compensatedSizeAnnotator) Accumulate(
 ) (v interface{}, cacheOK bool) {
 	vptr := dst.(*uint64)
 	*vptr = *vptr + compensatedSize(f, a.pointTombstoneWeight)
-	return vptr, f.StatsValidLocked()
+	return vptr, f.StatsValid()
 }
 
 func (a compensatedSizeAnnotator) Merge(src interface{}, dst interface{}) interface{} {
@@ -1332,7 +1332,7 @@ func (a elisionOnlyAnnotator) Accumulate(f *fileMetadata, dst interface{}) (inte
 	if f.IsCompacting() {
 		return dst, true
 	}
-	if !f.StatsValidLocked() {
+	if !f.StatsValid() {
 		return dst, false
 	}
 	// Bottommost files are large and not worthwhile to compact just

--- a/data_test.go
+++ b/data_test.go
@@ -1059,7 +1059,7 @@ func runTableStatsCmd(td *datadriven.TestData, d *DB) string {
 				continue
 			}
 
-			if !f.StatsValidLocked() {
+			if !f.StatsValid() {
 				d.waitTableStats()
 			}
 

--- a/internal/manifest/level_metadata_test.go
+++ b/internal/manifest/level_metadata_test.go
@@ -81,7 +81,7 @@ func TestLevelIteratorFiltered(t *testing.T) {
 				for _, metaStr := range strings.Split(d.Input, "\n") {
 					m, err := ParseFileMetadataDebug(metaStr)
 					require.NoError(t, err)
-					files = append(files, &m)
+					files = append(files, m)
 				}
 				level = NewLevelSliceKeySorted(base.DefaultComparer.Compare, files)
 				return ""

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -698,7 +698,7 @@ func (m *FileMetadata) DebugString(format base.FormatKey, verbose bool) string {
 
 // ParseFileMetadataDebug parses a FileMetadata from its DebugString
 // representation.
-func ParseFileMetadataDebug(s string) (m FileMetadata, err error) {
+func ParseFileMetadataDebug(s string) (*FileMetadata, error) {
 	// Split lines of the form:
 	//  000000:[a#0,SET-z#0,SET] points:[...] ranges:[...]
 	fields := strings.FieldsFunc(s, func(c rune) bool {
@@ -710,8 +710,9 @@ func ParseFileMetadataDebug(s string) (m FileMetadata, err error) {
 		}
 	})
 	if len(fields)%3 != 0 {
-		return m, errors.Newf("malformed input: %s", s)
+		return nil, errors.Newf("malformed input: %s", s)
 	}
+	m := &FileMetadata{}
 	for len(fields) > 0 {
 		prefix := fields[0]
 		smallest := base.ParsePrettyInternalKey(fields[1])
@@ -742,7 +743,7 @@ func ParseFileMetadataDebug(s string) (m FileMetadata, err error) {
 		m.HasPointKeys = true
 	}
 	m.InitPhysicalBacking()
-	return
+	return m, nil
 }
 
 // Validate validates the metadata for consistency with itself, returning an
@@ -1123,7 +1124,7 @@ func ParseVersionDebug(
 				m.SmallestPointKey, m.LargestPointKey = m.Smallest, m.Largest
 				m.HasPointKeys = true
 			}
-			files[level] = append(files[level], &m)
+			files[level] = append(files[level], m)
 		}
 	}
 	// Reverse the order of L0 files. This ensures we construct the same

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -10,7 +10,6 @@ import (
 	"encoding/binary"
 	"io"
 	"sort"
-	"sync/atomic"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -885,7 +884,7 @@ func (b *BulkVersionEdit) Apply(
 			if allowedSeeks < 100 {
 				allowedSeeks = 100
 			}
-			atomic.StoreInt64(&f.Atomic.AllowedSeeks, allowedSeeks)
+			f.AllowedSeeks.Store(allowedSeeks)
 			f.InitAllowedSeeks = allowedSeeks
 
 			err := lm.tree.Insert(f)

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -307,10 +307,10 @@ func TestVersionEditEncodeLastSeqNum(t *testing.T) {
 }
 
 func TestVersionEditApply(t *testing.T) {
-	parseMeta := func(s string) (FileMetadata, error) {
+	parseMeta := func(s string) (*FileMetadata, error) {
 		m, err := ParseFileMetadataDebug(s)
 		if err != nil {
-			return FileMetadata{}, err
+			return nil, err
 		}
 		m.SmallestSeqNum = m.Smallest.SeqNum()
 		m.LargestSeqNum = m.Largest.SeqNum()
@@ -370,12 +370,12 @@ func TestVersionEditApply(t *testing.T) {
 										v.Levels[l] = makeLevelMetadata(base.DefaultComparer.Compare, l, nil /* files */)
 									}
 								}
-								versionFiles[meta.FileNum] = &meta
-								v.Levels[level].tree.Insert(&meta)
+								versionFiles[meta.FileNum] = meta
+								v.Levels[level].tree.Insert(meta)
 								meta.LatestRef()
 							} else {
 								ve.NewFiles =
-									append(ve.NewFiles, NewFileEntry{Level: level, Meta: &meta})
+									append(ve.NewFiles, NewFileEntry{Level: level, Meta: meta})
 							}
 						} else {
 							fileNum, err := strconv.Atoi(data)

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -14,7 +14,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -673,7 +672,7 @@ func TestReadSampling(t *testing.T) {
 			d.mu.Lock()
 			for _, l := range d.mu.versions.currentVersion().Levels {
 				l.Slice().Each(func(f *fileMetadata) {
-					atomic.StoreInt64(&f.Atomic.AllowedSeeks, allowedSeeks)
+					f.AllowedSeeks.Store(allowedSeeks)
 				})
 			}
 			d.mu.Unlock()
@@ -704,7 +703,7 @@ func TestReadSampling(t *testing.T) {
 			for _, l := range d.mu.versions.currentVersion().Levels {
 				l.Slice().Each(func(f *fileMetadata) {
 					if f.FileNum == base.FileNum(fileNum) {
-						actualAllowedSeeks := atomic.LoadInt64(&f.Atomic.AllowedSeeks)
+						actualAllowedSeeks := f.AllowedSeeks.Load()
 						foundAllowedSeeks = actualAllowedSeeks
 					}
 				})

--- a/table_stats.go
+++ b/table_stats.go
@@ -53,7 +53,7 @@ func (d *DB) maybeCollectTableStatsLocked() {
 func (d *DB) updateTableStatsLocked(newFiles []manifest.NewFileEntry) {
 	var needStats bool
 	for _, nf := range newFiles {
-		if !nf.Meta.StatsValidLocked() {
+		if !nf.Meta.StatsValid() {
 			needStats = true
 			break
 		}
@@ -175,7 +175,7 @@ func (d *DB) loadNewFileStats(
 		// collectTableStats updates f.Stats for active files, and we
 		// ensure only one goroutine runs it at a time through
 		// d.mu.tableStats.loading.
-		if nf.Meta.StatsValidLocked() {
+		if nf.Meta.StatsValid() {
 			continue
 		}
 
@@ -222,7 +222,7 @@ func (d *DB) scanReadStateTableStats(
 			// and we ensure only one goroutine runs it at a time through
 			// d.mu.tableStats.loading. This makes it safe to read validity
 			// through f.Stats.ValidLocked despite not holding d.mu.
-			if f.StatsValidLocked() {
+			if f.StatsValid() {
 				continue
 			}
 
@@ -839,7 +839,7 @@ func (a rangeKeySetsAnnotator) Accumulate(
 ) (v interface{}, cacheOK bool) {
 	vptr := dst.(*uint64)
 	*vptr = *vptr + f.Stats.NumRangeKeySets
-	return vptr, f.StatsValidLocked()
+	return vptr, f.StatsValid()
 }
 
 func (a rangeKeySetsAnnotator) Merge(src interface{}, dst interface{}) interface{} {
@@ -886,7 +886,7 @@ func (a tombstonesAnnotator) Accumulate(
 ) (v interface{}, cacheOK bool) {
 	vptr := dst.(*uint64)
 	*vptr = *vptr + f.Stats.NumDeletions
-	return vptr, f.StatsValidLocked()
+	return vptr, f.StatsValid()
 }
 
 func (a tombstonesAnnotator) Merge(src interface{}, dst interface{}) interface{} {
@@ -933,7 +933,7 @@ func (a valueBlocksSizeAnnotator) Accumulate(
 ) (v interface{}, cacheOK bool) {
 	vptr := dst.(*uint64)
 	*vptr = *vptr + f.Stats.ValueBlocksSize
-	return vptr, f.StatsValidLocked()
+	return vptr, f.StatsValid()
 }
 
 func (a valueBlocksSizeAnnotator) Merge(src interface{}, dst interface{}) interface{} {

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -149,7 +149,7 @@ func TestLatestRefCounting(t *testing.T) {
 	require.Equal(t, 1, len(d.mu.versions.fileBackingMap))
 	_, ok := d.mu.versions.fileBackingMap[f.FileNum]
 	require.True(t, ok)
-	require.Equal(t, f.Size, m2.FileBacking.Atomic.VirtualizedSize.Load())
+	require.Equal(t, f.Size, m2.FileBacking.VirtualizedSize.Load())
 
 	// Make sure that f is not present in zombie list, because it is not yet a
 	// zombie.
@@ -170,7 +170,7 @@ func TestLatestRefCounting(t *testing.T) {
 	require.Equal(t, 1, len(d.mu.versions.fileBackingMap))
 	_, ok = d.mu.versions.fileBackingMap[f.FileNum]
 	require.True(t, ok)
-	require.Equal(t, m2.Size, m2.FileBacking.Atomic.VirtualizedSize.Load())
+	require.Equal(t, m2.Size, m2.FileBacking.VirtualizedSize.Load())
 
 	// Move m2 from L0 to L6 to test the move compaction case.
 	ve = manifest.VersionEdit{}
@@ -187,7 +187,7 @@ func TestLatestRefCounting(t *testing.T) {
 	require.Equal(t, 1, len(d.mu.versions.fileBackingMap))
 	_, ok = d.mu.versions.fileBackingMap[f.FileNum]
 	require.True(t, ok)
-	require.Equal(t, m2.Size, m2.FileBacking.Atomic.VirtualizedSize.Load())
+	require.Equal(t, m2.Size, m2.FileBacking.VirtualizedSize.Load())
 
 	// Delete m2 from L6.
 	ve = manifest.VersionEdit{}
@@ -203,7 +203,7 @@ func TestLatestRefCounting(t *testing.T) {
 	require.Equal(t, 0, len(d.mu.versions.fileBackingMap))
 	_, ok = d.mu.versions.fileBackingMap[f.FileNum]
 	require.False(t, ok)
-	require.Equal(t, 0, int(m2.FileBacking.Atomic.VirtualizedSize.Load()))
+	require.Equal(t, 0, int(m2.FileBacking.VirtualizedSize.Load()))
 
 	// Make sure that the backing file is added to the obsolete tables list.
 	require.Equal(t, 1, len(d.mu.versions.obsoleteTables))


### PR DESCRIPTION
#### manifest: don't copy FileMetadata by value


#### manifest: use atomic types in FileMetadata

This commit changes the atomic fields in FileMetadata to use atomic
types.

The `StatsValidLocked` function is removed; this was not much of an
optimization - on x86 an atomic load is just a regular load
(https://github.com/golang/go/blob/master/src/runtime/internal/atomic/atomic_amd64.go#L29).