### PR TITLE
sstable: add AtomicFilterMetrics

### DIFF
--- a/sstable/filter.go
+++ b/sstable/filter.go
@@ -7,9 +7,6 @@ package sstable
 import "sync/atomic"
 
 // FilterMetrics holds metrics for the filter policy.
-// TODO(radu): in some contexts, the fields inside are used as atomics; in
-// others they are not (in particular, the struct gets copied around). Split the
-// type into two and use atomic.Int64.
 type FilterMetrics struct {
 	// The number of hits for the filter policy. This is the
 	// number of times the filter policy was successfully used to avoid access
@@ -21,11 +18,29 @@ type FilterMetrics struct {
 	Misses int64
 }
 
-var dummyFilterMetrics FilterMetrics
+// FilterMetricsTracker is used to keep track of filter metrics. It contains the
+// same metrics as FilterMetrics, but they can be updated atomically. An
+// instance of FilterMetricsTracker can be passed to a Reader as a ReaderOption.
+type FilterMetricsTracker struct {
+	// See FilterMetrics.Hits.
+	hits atomic.Int64
+	// See FilterMetrics.Misses.
+	misses atomic.Int64
+}
 
-func (m *FilterMetrics) readerApply(r *Reader) {
+var _ ReaderOption = (*FilterMetricsTracker)(nil)
+
+func (m *FilterMetricsTracker) readerApply(r *Reader) {
 	if r.tableFilter != nil {
 		r.tableFilter.metrics = m
+	}
+}
+
+// Load returns the current values as FilterMetrics.
+func (m *FilterMetricsTracker) Load() FilterMetrics {
+	return FilterMetrics{
+		Hits:   m.hits.Load(),
+		Misses: m.misses.Load(),
 	}
 }
 
@@ -50,22 +65,24 @@ type filterWriter interface {
 
 type tableFilterReader struct {
 	policy  FilterPolicy
-	metrics *FilterMetrics
+	metrics *FilterMetricsTracker
 }
 
 func newTableFilterReader(policy FilterPolicy) *tableFilterReader {
 	return &tableFilterReader{
 		policy:  policy,
-		metrics: &dummyFilterMetrics,
+		metrics: nil,
 	}
 }
 
 func (f *tableFilterReader) mayContain(data, key []byte) bool {
 	mayContain := f.policy.MayContain(TableFilter, data, key)
-	if mayContain {
-		atomic.AddInt64(&f.metrics.Misses, 1)
-	} else {
-		atomic.AddInt64(&f.metrics.Hits, 1)
+	if f.metrics != nil {
+		if mayContain {
+			f.metrics.misses.Add(1)
+		} else {
+			f.metrics.hits.Add(1)
+		}
 	}
 	return mayContain
 }

--- a/table_cache.go
+++ b/table_cache.go
@@ -67,7 +67,7 @@ type tableCacheOpts struct {
 	cacheID         uint64
 	objProvider     objstorage.Provider
 	opts            sstable.ReaderOptions
-	filterMetrics   *FilterMetrics
+	filterMetrics   *sstable.FilterMetricsTracker
 }
 
 // tableCacheContainer contains the table cache and
@@ -103,7 +103,7 @@ func newTableCacheContainer(
 	t.dbOpts.cacheID = cacheID
 	t.dbOpts.objProvider = objProvider
 	t.dbOpts.opts = opts.MakeReaderOptions()
-	t.dbOpts.filterMetrics = &FilterMetrics{}
+	t.dbOpts.filterMetrics = &sstable.FilterMetricsTracker{}
 	t.dbOpts.iterCount = new(atomic.Int32)
 	return t
 }
@@ -162,10 +162,7 @@ func (c *tableCacheContainer) metrics() (CacheMetrics, FilterMetrics) {
 		m.Misses += s.misses.Load()
 	}
 	m.Size = m.Count * int64(unsafe.Sizeof(sstable.Reader{}))
-	f := FilterMetrics{
-		Hits:   atomic.LoadInt64(&c.dbOpts.filterMetrics.Hits),
-		Misses: atomic.LoadInt64(&c.dbOpts.filterMetrics.Misses),
-	}
+	f := c.dbOpts.filterMetrics.Load()
 	return m, f
 }
 


### PR DESCRIPTION
FilterMetrics is used both to pass around the current values of the metrics and to maintain them internally. In the latter case, the accesses are atomic.

This commit adds `AtomicFilterMetrics` for internal use, which clarifies the code and allows use of `atomic.Int64`.