### PR TITLE
options: move MinDeletionRate out of Experimental, rename to TargetDe…

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3623,7 +3623,7 @@ func (d *DB) doDeleteObsoleteFiles(jobID int) {
 	if len(filesToDelete) > 0 {
 		d.deleters.Add(1)
 		// Delete asynchronously if that could get held up in the pacer.
-		if d.opts.Experimental.MinDeletionRate > 0 {
+		if d.opts.TargetByteDeletionRate > 0 {
 			go d.paceAndDeleteObsoleteFiles(jobID, filesToDelete)
 		} else {
 			d.paceAndDeleteObsoleteFiles(jobID, filesToDelete)
@@ -3636,7 +3636,7 @@ func (d *DB) doDeleteObsoleteFiles(jobID int) {
 func (d *DB) paceAndDeleteObsoleteFiles(jobID int, files []obsoleteFile) {
 	defer d.deleters.Done()
 	pacer := (pacer)(nilPacer)
-	if d.opts.Experimental.MinDeletionRate > 0 {
+	if d.opts.TargetByteDeletionRate > 0 {
 		pacer = newDeletionPacer(d.deletionLimiter, d.getDeletionPacerInfo)
 	}
 

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -390,9 +390,9 @@ func randomOptions(
 	opts.FormatMajorVersion = minimumFormatMajorVersion
 	n := int(pebble.FormatNewest - opts.FormatMajorVersion)
 	opts.FormatMajorVersion += pebble.FormatMajorVersion(rng.Intn(n + 1))
-	opts.Experimental.L0CompactionConcurrency = 1 + rng.Intn(4)    // 1-4
-	opts.Experimental.LevelMultiplier = 5 << rng.Intn(7)           // 5 - 320
-	opts.Experimental.MinDeletionRate = 1 << uint(20+rng.Intn(10)) // 1MB - 1GB
+	opts.Experimental.L0CompactionConcurrency = 1 + rng.Intn(4) // 1-4
+	opts.Experimental.LevelMultiplier = 5 << rng.Intn(7)        // 5 - 320
+	opts.TargetByteDeletionRate = 1 << uint(20+rng.Intn(10))    // 1MB - 1GB
 	opts.Experimental.ValidateOnIngest = rng.Intn(2) != 0
 	opts.L0CompactionThreshold = 1 + rng.Intn(100)     // 1 - 100
 	opts.L0CompactionFileThreshold = 1 << rng.Intn(11) // 1 - 1024

--- a/open.go
+++ b/open.go
@@ -210,8 +210,8 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		write:         d.commitWrite,
 	})
 	d.deletionLimiter = rate.NewLimiter(
-		rate.Limit(d.opts.Experimental.MinDeletionRate),
-		d.opts.Experimental.MinDeletionRate)
+		rate.Limit(d.opts.TargetByteDeletionRate),
+		d.opts.TargetByteDeletionRate)
 	d.mu.nextJobID = 1
 	d.mu.mem.nextSize = opts.MemTableSize
 	if d.mu.mem.nextSize > initialMemTableSize {

--- a/options_test.go
+++ b/options_test.go
@@ -232,7 +232,7 @@ func TestOptionsParse(t *testing.T) {
 			opts.FlushDelayDeleteRange = 10 * time.Second
 			opts.FlushDelayRangeKey = 11 * time.Second
 			opts.Experimental.LevelMultiplier = 5
-			opts.Experimental.MinDeletionRate = 200
+			opts.TargetByteDeletionRate = 200
 			opts.Experimental.ReadCompactionRate = 300
 			opts.Experimental.ReadSamplingMultiplier = 400
 			opts.Experimental.TableCacheShards = 500

--- a/pacer.go
+++ b/pacer.go
@@ -106,7 +106,7 @@ func (p *deletionPacer) limit(amount uint64, info deletionPacerInfo) error {
 }
 
 // maybeThrottle slows down a deletion of this file if it's faster than
-// opts.Experimental.MinDeletionRate.
+// opts.TargetByteDeletionRate.
 func (p *deletionPacer) maybeThrottle(bytesToDelete uint64) error {
 	return p.limit(bytesToDelete, p.getInfo())
 }


### PR DESCRIPTION
…letionRate

This setting has been used in production for many releases; moving out of Experimental.

Also renaming to `TargetDeletionRate` - the "minimum" part is very confusing. The key is kept as `min_deletion_rate` for backward compatibility.