### PR TITLE
db: create new type for file numbers on disk

### DIFF
--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -215,7 +215,10 @@ func TestCheckpointCompaction(t *testing.T) {
 			tableInfos, _ := d2.SSTables()
 			for _, tables := range tableInfos {
 				for _, tbl := range tables {
-					if _, err := fs.Stat(base.MakeFilepath(fs, dir, base.FileTypeTable, tbl.FileNum)); err != nil {
+					if tbl.Virtual {
+						continue
+					}
+					if _, err := fs.Stat(base.MakeFilepath(fs, dir, base.FileTypeTable, tbl.FileNum.DiskFileNum())); err != nil {
 						t.Error(err)
 						return
 					}

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1004,7 +1004,10 @@ func TestCompaction(t *testing.T) {
 		for _, levelMetadata := range v.Levels {
 			iter := levelMetadata.Iter()
 			for meta := iter.First(); meta != nil; meta = iter.Next() {
-				f, err := provider.OpenForReading(context.Background(), base.FileTypeTable, meta.FileNum, objstorage.OpenOptions{})
+				if meta.Virtual {
+					continue
+				}
+				f, err := provider.OpenForReading(context.Background(), base.FileTypeTable, meta.FileBacking.DiskFileNum, objstorage.OpenOptions{})
 				if err != nil {
 					return "", "", errors.WithStack(err)
 				}

--- a/db_test.go
+++ b/db_test.go
@@ -372,12 +372,12 @@ func TestLargeBatch(t *testing.T) {
 		}
 	}
 
-	logNum := func() FileNum {
+	logNum := func() base.DiskFileNum {
 		d.mu.Lock()
 		defer d.mu.Unlock()
 		return d.mu.log.queue[len(d.mu.log.queue)-1].fileNum
 	}
-	fileSize := func(fileNum FileNum) int64 {
+	fileSize := func(fileNum base.DiskFileNum) int64 {
 		info, err := d.opts.FS.Stat(base.MakeFilepath(d.opts.FS, "", fileTypeLog, fileNum))
 		require.NoError(t, err)
 		return info.Size()
@@ -808,7 +808,7 @@ func TestMemTableReservation(t *testing.T) {
 	helloWorld := []byte("hello world")
 	value := opts.Cache.Alloc(len(helloWorld))
 	copy(value.Buf(), helloWorld)
-	opts.Cache.Set(tmpID, 0, 0, value).Release()
+	opts.Cache.Set(tmpID, base.FileNum(0).DiskFileNum(), 0, value).Release()
 
 	d, err := Open("", opts)
 	require.NoError(t, err)
@@ -825,7 +825,7 @@ func TestMemTableReservation(t *testing.T) {
 		t.Fatalf("expected 2 refs, but found %d", refs)
 	}
 	// Verify the memtable reservation has caused our test block to be evicted.
-	if h := opts.Cache.Get(tmpID, 0, 0); h.Get() != nil {
+	if h := opts.Cache.Get(tmpID, base.FileNum(0).DiskFileNum(), 0); h.Get() != nil {
 		t.Fatalf("expected failure, but found success: %s", h.Get())
 	}
 

--- a/filenames.go
+++ b/filenames.go
@@ -33,7 +33,7 @@ const (
 // NB: This is a low-level routine and typically not what you want to
 // use. Newer versions of Pebble running newer format major versions do
 // not use the CURRENT file. See setCurrentFunc in version_set.go.
-func setCurrentFile(dirname string, fs vfs.FS, fileNum FileNum) error {
+func setCurrentFile(dirname string, fs vfs.FS, fileNum base.DiskFileNum) error {
 	newFilename := base.MakeFilepath(fs, dirname, fileTypeCurrent, fileNum)
 	oldFilename := base.MakeFilepath(fs, dirname, fileTypeTemp, fileNum)
 	fs.Remove(oldFilename)

--- a/flushable_test.go
+++ b/flushable_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
@@ -47,9 +48,9 @@ func TestIngestedSSTFlushableAPI(t *testing.T) {
 
 	loadFileMeta := func(paths []string) []*fileMetadata {
 		d.mu.Lock()
-		pendingOutputs := make([]FileNum, len(paths))
+		pendingOutputs := make([]base.DiskFileNum, len(paths))
 		for i := range paths {
-			pendingOutputs[i] = d.mu.versions.getNextFileNum()
+			pendingOutputs[i] = d.mu.versions.getNextFileNum().DiskFileNum()
 		}
 		jobID := d.mu.nextJobID
 		d.mu.nextJobID++

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -219,7 +219,7 @@ var formatMajorVersionMigrations = map[FormatMajorVersion]func(*DB) error{
 		// guaranteed to exist, because we unconditionally locate it
 		// during Open.
 		manifestFileNum := d.mu.versions.manifestFileNum
-		filename := base.MakeFilename(fileTypeManifest, manifestFileNum)
+		filename := base.MakeFilename(fileTypeManifest, manifestFileNum.DiskFileNum())
 		if err := d.mu.versions.manifestMarker.Move(filename); err != nil {
 			return errors.Wrap(err, "moving manifest marker")
 		}
@@ -257,7 +257,7 @@ var formatMajorVersionMigrations = map[FormatMajorVersion]func(*DB) error{
 		// version that does not know about format major versions
 		// attempts to open the database, it will error avoiding
 		// accidental corruption.
-		if err := setCurrentFile(d.mu.versions.dirname, d.mu.versions.fs, 0); err != nil {
+		if err := setCurrentFile(d.mu.versions.dirname, d.mu.versions.fs, base.FileNum(0).DiskFileNum()); err != nil {
 			return err
 		}
 		return d.finalizeFormatVersUpgrade(FormatVersioned)

--- a/ingest.go
+++ b/ingest.go
@@ -46,7 +46,7 @@ func ingestValidateKey(opts *Options, key *InternalKey) error {
 }
 
 func ingestLoad1(
-	opts *Options, fmv FormatMajorVersion, path string, cacheID uint64, fileNum FileNum,
+	opts *Options, fmv FormatMajorVersion, path string, cacheID uint64, fileNum base.DiskFileNum,
 ) (*fileMetadata, error) {
 	f, err := opts.FS.Open(path)
 	if err != nil {
@@ -78,7 +78,7 @@ func ingestLoad1(
 	}
 
 	meta := &fileMetadata{}
-	meta.FileNum = fileNum
+	meta.FileNum = fileNum.FileNum()
 	meta.Size = uint64(readable.Size())
 	meta.CreationTime = time.Now().Unix()
 	meta.InitPhysicalBacking()
@@ -196,7 +196,7 @@ func ingestLoad1(
 }
 
 func ingestLoad(
-	opts *Options, fmv FormatMajorVersion, paths []string, cacheID uint64, pending []FileNum,
+	opts *Options, fmv FormatMajorVersion, paths []string, cacheID uint64, pending []base.DiskFileNum,
 ) ([]*fileMetadata, []string, error) {
 	meta := make([]*fileMetadata, 0, len(paths))
 	newPaths := make([]string, 0, len(paths))
@@ -257,7 +257,7 @@ func ingestSortAndVerify(cmp Compare, meta []*fileMetadata, paths []string) erro
 func ingestCleanup(objProvider objstorage.Provider, meta []*fileMetadata) error {
 	var firstErr error
 	for i := range meta {
-		if err := objProvider.Remove(fileTypeTable, meta[i].FileNum); err != nil {
+		if err := objProvider.Remove(fileTypeTable, meta[i].FileBacking.DiskFileNum); err != nil {
 			firstErr = firstError(firstErr, err)
 		}
 	}
@@ -270,7 +270,7 @@ func ingestLink(
 	jobID int, opts *Options, objProvider objstorage.Provider, paths []string, meta []*fileMetadata,
 ) error {
 	for i := range paths {
-		objMeta, err := objProvider.LinkOrCopyFromLocal(opts.FS, paths[i], fileTypeTable, meta[i].FileNum)
+		objMeta, err := objProvider.LinkOrCopyFromLocal(opts.FS, paths[i], fileTypeTable, meta[i].FileBacking.DiskFileNum)
 		if err != nil {
 			if err2 := ingestCleanup(objProvider, meta[:i]); err2 != nil {
 				opts.Logger.Infof("ingest cleanup failed: %v", err2)
@@ -803,9 +803,9 @@ func (d *DB) ingest(
 	// ordering. The sorting of L0 tables by sequence number avoids relying on
 	// that (busted) invariant.
 	d.mu.Lock()
-	pendingOutputs := make([]FileNum, len(paths))
+	pendingOutputs := make([]base.DiskFileNum, len(paths))
 	for i := range paths {
-		pendingOutputs[i] = d.mu.versions.getNextFileNum()
+		pendingOutputs[i] = d.mu.versions.getNextFileNum().DiskFileNum()
 	}
 	jobID := d.mu.nextJobID
 	d.mu.nextJobID++

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -120,7 +120,7 @@ func TestIngestLoad(t *testing.T) {
 				Comparer: DefaultComparer,
 				FS:       mem,
 			}).WithFSDefaults()
-			meta, _, err := ingestLoad(opts, dbVersion, []string{"ext"}, 0, []FileNum{1})
+			meta, _, err := ingestLoad(opts, dbVersion, []string{"ext"}, 0, []base.DiskFileNum{base.FileNum(1).DiskFileNum()})
 			if err != nil {
 				return err.Error()
 			}
@@ -153,13 +153,13 @@ func TestIngestLoadRand(t *testing.T) {
 	}
 
 	paths := make([]string, 1+rng.Intn(10))
-	pending := make([]FileNum, len(paths))
+	pending := make([]base.DiskFileNum, len(paths))
 	expected := make([]*fileMetadata, len(paths))
 	for i := range paths {
 		paths[i] = fmt.Sprint(i)
-		pending[i] = FileNum(rng.Int63())
+		pending[i] = base.FileNum(rng.Uint64()).DiskFileNum()
 		expected[i] = &fileMetadata{
-			FileNum: pending[i],
+			FileNum: pending[i].FileNum(),
 		}
 		expected[i].StatsMarkValid()
 
@@ -228,7 +228,7 @@ func TestIngestLoadInvalid(t *testing.T) {
 		Comparer: DefaultComparer,
 		FS:       mem,
 	}).WithFSDefaults()
-	if _, _, err := ingestLoad(opts, FormatNewest, []string{"invalid"}, 0, []FileNum{1}); err == nil {
+	if _, _, err := ingestLoad(opts, FormatNewest, []string{"invalid"}, 0, []base.DiskFileNum{base.FileNum(1).DiskFileNum()}); err == nil {
 		t.Fatalf("expected error, but found success")
 	}
 }
@@ -354,7 +354,7 @@ func TestIngestLink(t *testing.T) {
 					if fileTypeTable != ftype {
 						t.Fatalf("expected table, but found %d", ftype)
 					}
-					if FileNum(j) != fileNum {
+					if j != int(fileNum.FileNum()) {
 						t.Fatalf("expected table %d, but found %d", j, fileNum)
 					}
 					f, err := opts.FS.Open(opts.FS.PathJoin(dir, files[j]))
@@ -389,6 +389,7 @@ func TestIngestLinkFallback(t *testing.T) {
 	defer objProvider.Close()
 
 	meta := []*fileMetadata{{FileNum: 1}}
+	meta[0].InitPhysicalBacking()
 	err = ingestLink(0, opts, objProvider, []string{"source"}, meta)
 	require.NoError(t, err)
 
@@ -1700,7 +1701,7 @@ func TestIngestCleanup(t *testing.T) {
 			// Create the files in the VFS.
 			metaMap := make(map[base.FileNum]objstorage.Writable)
 			for _, fn := range fns {
-				w, _, err := objProvider.Create(context.Background(), base.FileTypeTable, fn, objstorage.CreateOptions{})
+				w, _, err := objProvider.Create(context.Background(), base.FileTypeTable, fn.DiskFileNum(), objstorage.CreateOptions{})
 				require.NoError(t, err)
 
 				metaMap[fn] = w
@@ -1718,7 +1719,9 @@ func TestIngestCleanup(t *testing.T) {
 			// Cleanup the set of files in the FS.
 			var toRemove []*fileMetadata
 			for _, fn := range tc.cleanupFiles {
-				toRemove = append(toRemove, &fileMetadata{FileNum: fn})
+				m := &fileMetadata{FileNum: fn}
+				m.InitPhysicalBacking()
+				toRemove = append(toRemove, m)
 			}
 
 			err = ingestCleanup(objProvider, toRemove)

--- a/internal/base/filenames.go
+++ b/internal/base/filenames.go
@@ -20,6 +20,31 @@ type FileNum uint64
 // String returns a string representation of the file number.
 func (fn FileNum) String() string { return fmt.Sprintf("%06d", fn) }
 
+// DiskFileNum converts a FileNum to a DiskFileNum. DiskFileNum should only be
+// called if the caller can ensure that the FileNum belongs to a physical file
+// on disk. These could be manifests, log files, physical sstables on disk, the
+// options file, but not virtual sstables.
+func (fn FileNum) DiskFileNum() DiskFileNum {
+	return DiskFileNum{fn}
+}
+
+// A DiskFileNum is just a FileNum belonging to a file which exists on disk.
+// Note that a FileNum is an internal DB identifier and it could belong to files
+// which don't exist on disk. An example would be virtual sstable FileNums.
+// Converting a DiskFileNum to a FileNum is always valid, whereas converting a
+// FileNum to DiskFileNum may not be valid and care should be taken to prove
+// that the FileNum actually exists on disk.
+type DiskFileNum struct {
+	fn FileNum
+}
+
+func (dfn DiskFileNum) String() string { return dfn.fn.String() }
+
+// FileNum converts a DiskFileNum to a FileNum. This conversion is always valid.
+func (dfn DiskFileNum) FileNum() FileNum {
+	return dfn.fn
+}
+
 // FileType enumerates the types of files found in a DB.
 type FileType int
 
@@ -36,92 +61,92 @@ const (
 )
 
 // MakeFilename builds a filename from components.
-func MakeFilename(fileType FileType, fileNum FileNum) string {
+func MakeFilename(fileType FileType, dfn DiskFileNum) string {
 	switch fileType {
 	case FileTypeLog:
-		return fmt.Sprintf("%s.log", fileNum)
+		return fmt.Sprintf("%s.log", dfn)
 	case FileTypeLock:
 		return "LOCK"
 	case FileTypeTable:
-		return fmt.Sprintf("%s.sst", fileNum)
+		return fmt.Sprintf("%s.sst", dfn)
 	case FileTypeManifest:
-		return fmt.Sprintf("MANIFEST-%s", fileNum)
+		return fmt.Sprintf("MANIFEST-%s", dfn)
 	case FileTypeCurrent:
 		return "CURRENT"
 	case FileTypeOptions:
-		return fmt.Sprintf("OPTIONS-%s", fileNum)
+		return fmt.Sprintf("OPTIONS-%s", dfn)
 	case FileTypeOldTemp:
-		return fmt.Sprintf("CURRENT.%s.dbtmp", fileNum)
+		return fmt.Sprintf("CURRENT.%s.dbtmp", dfn)
 	case FileTypeTemp:
-		return fmt.Sprintf("temporary.%s.dbtmp", fileNum)
+		return fmt.Sprintf("temporary.%s.dbtmp", dfn)
 	}
 	panic("unreachable")
 }
 
 // MakeFilepath builds a filepath from components.
-func MakeFilepath(fs vfs.FS, dirname string, fileType FileType, fileNum FileNum) string {
-	return fs.PathJoin(dirname, MakeFilename(fileType, fileNum))
+func MakeFilepath(fs vfs.FS, dirname string, fileType FileType, dfn DiskFileNum) string {
+	return fs.PathJoin(dirname, MakeFilename(fileType, dfn))
 }
 
 // ParseFilename parses the components from a filename.
-func ParseFilename(fs vfs.FS, filename string) (fileType FileType, fileNum FileNum, ok bool) {
+func ParseFilename(fs vfs.FS, filename string) (fileType FileType, dfn DiskFileNum, ok bool) {
 	filename = fs.PathBase(filename)
 	switch {
 	case filename == "CURRENT":
-		return FileTypeCurrent, 0, true
+		return FileTypeCurrent, DiskFileNum{0}, true
 	case filename == "LOCK":
-		return FileTypeLock, 0, true
+		return FileTypeLock, DiskFileNum{0}, true
 	case strings.HasPrefix(filename, "MANIFEST-"):
-		fileNum, ok = parseFileNum(filename[len("MANIFEST-"):])
+		dfn, ok = parseDiskFileNum(filename[len("MANIFEST-"):])
 		if !ok {
 			break
 		}
-		return FileTypeManifest, fileNum, true
+		return FileTypeManifest, dfn, true
 	case strings.HasPrefix(filename, "OPTIONS-"):
-		fileNum, ok = parseFileNum(filename[len("OPTIONS-"):])
+		dfn, ok = parseDiskFileNum(filename[len("OPTIONS-"):])
 		if !ok {
 			break
 		}
-		return FileTypeOptions, fileNum, ok
+		return FileTypeOptions, dfn, ok
 	case strings.HasPrefix(filename, "CURRENT.") && strings.HasSuffix(filename, ".dbtmp"):
 		s := strings.TrimSuffix(filename[len("CURRENT."):], ".dbtmp")
-		fileNum, ok = parseFileNum(s)
+		dfn, ok = parseDiskFileNum(s)
 		if !ok {
 			break
 		}
-		return FileTypeOldTemp, fileNum, ok
+		return FileTypeOldTemp, dfn, ok
 	case strings.HasPrefix(filename, "temporary.") && strings.HasSuffix(filename, ".dbtmp"):
 		s := strings.TrimSuffix(filename[len("temporary."):], ".dbtmp")
-		fileNum, ok = parseFileNum(s)
+		dfn, ok = parseDiskFileNum(s)
 		if !ok {
 			break
 		}
-		return FileTypeTemp, fileNum, ok
+		return FileTypeTemp, dfn, ok
 	default:
 		i := strings.IndexByte(filename, '.')
 		if i < 0 {
 			break
 		}
-		fileNum, ok = parseFileNum(filename[:i])
+		dfn, ok = parseDiskFileNum(filename[:i])
 		if !ok {
 			break
 		}
 		switch filename[i+1:] {
 		case "sst":
-			return FileTypeTable, fileNum, true
+			return FileTypeTable, dfn, true
 		case "log":
-			return FileTypeLog, fileNum, true
+			return FileTypeLog, dfn, true
 		}
 	}
-	return 0, fileNum, false
+	return 0, dfn, false
 }
 
-func parseFileNum(s string) (fileNum FileNum, ok bool) {
+func parseDiskFileNum(s string) (dfn DiskFileNum, ok bool) {
 	u, err := strconv.ParseUint(s, 10, 64)
 	if err != nil {
-		return fileNum, false
+		return dfn, false
 	}
-	return FileNum(u), true
+	return DiskFileNum{FileNum(u)}, true
 }
 
 // A Fataler fatals a process with a message when called.

--- a/internal/base/filenames_test.go
+++ b/internal/base/filenames_test.go
@@ -72,13 +72,13 @@ func TestFilenameRoundTrip(t *testing.T) {
 			fileNums = []FileNum{0, 1, 2, 3, 10, 42, 99, 1001}
 		}
 		for _, fileNum := range fileNums {
-			filename := MakeFilepath(fs, "foo", fileType, fileNum)
+			filename := MakeFilepath(fs, "foo", fileType, fileNum.DiskFileNum())
 			gotFT, gotFN, gotOK := ParseFilename(fs, filename)
 			if !gotOK {
 				t.Errorf("could not parse %q", filename)
 				continue
 			}
-			if gotFT != fileType || gotFN != fileNum {
+			if gotFT != fileType || gotFN.FileNum() != fileNum {
 				t.Errorf("filename=%q: got %v, %v, want %v, %v", filename, gotFT, gotFN, fileType, fileNum)
 				continue
 			}

--- a/internal/cache/clockpro_test.go
+++ b/internal/cache/clockpro_test.go
@@ -39,11 +39,11 @@ func TestCache(t *testing.T) {
 		wantHit := fields[1][0] == 'h'
 
 		var hit bool
-		h := cache.Get(1, base.FileNum(key), 0)
+		h := cache.Get(1, base.FileNum(uint64(key)).DiskFileNum(), 0)
 		if v := h.Get(); v == nil {
 			value := cache.Alloc(1)
 			value.Buf()[0] = fields[0][0]
-			cache.Set(1, base.FileNum(key), 0, value).Release()
+			cache.Set(1, base.FileNum(uint64(key)).DiskFileNum(), 0, value).Release()
 		} else {
 			hit = true
 			if !bytes.Equal(v, fields[0][:1]) {
@@ -69,28 +69,28 @@ func TestCacheDelete(t *testing.T) {
 	cache := newShards(100, 1)
 	defer cache.Unref()
 
-	cache.Set(1, 0, 0, testValue(cache, "a", 5)).Release()
-	cache.Set(1, 1, 0, testValue(cache, "a", 5)).Release()
-	cache.Set(1, 2, 0, testValue(cache, "a", 5)).Release()
+	cache.Set(1, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 5)).Release()
+	cache.Set(1, base.FileNum(1).DiskFileNum(), 0, testValue(cache, "a", 5)).Release()
+	cache.Set(1, base.FileNum(2).DiskFileNum(), 0, testValue(cache, "a", 5)).Release()
 	if expected, size := int64(15), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	cache.Delete(1, 1, 0)
+	cache.Delete(1, base.FileNum(1).DiskFileNum(), 0)
 	if expected, size := int64(10), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	if h := cache.Get(1, 0, 0); h.Get() == nil {
+	if h := cache.Get(1, base.FileNum(0).DiskFileNum(), 0); h.Get() == nil {
 		t.Fatalf("expected to find block 0/0")
 	} else {
 		h.Release()
 	}
-	if h := cache.Get(1, 1, 0); h.Get() != nil {
+	if h := cache.Get(1, base.FileNum(1).DiskFileNum(), 0); h.Get() != nil {
 		t.Fatalf("expected to not find block 1/0")
 	} else {
 		h.Release()
 	}
 	// Deleting a non-existing block does nothing.
-	cache.Delete(1, 1, 0)
+	cache.Delete(1, base.FileNum(1).DiskFileNum(), 0)
 	if expected, size := int64(10), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
@@ -100,23 +100,23 @@ func TestEvictFile(t *testing.T) {
 	cache := newShards(100, 1)
 	defer cache.Unref()
 
-	cache.Set(1, 0, 0, testValue(cache, "a", 5)).Release()
-	cache.Set(1, 1, 0, testValue(cache, "a", 5)).Release()
-	cache.Set(1, 2, 0, testValue(cache, "a", 5)).Release()
-	cache.Set(1, 2, 1, testValue(cache, "a", 5)).Release()
-	cache.Set(1, 2, 2, testValue(cache, "a", 5)).Release()
+	cache.Set(1, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 5)).Release()
+	cache.Set(1, base.FileNum(1).DiskFileNum(), 0, testValue(cache, "a", 5)).Release()
+	cache.Set(1, base.FileNum(2).DiskFileNum(), 0, testValue(cache, "a", 5)).Release()
+	cache.Set(1, base.FileNum(2).DiskFileNum(), 1, testValue(cache, "a", 5)).Release()
+	cache.Set(1, base.FileNum(2).DiskFileNum(), 2, testValue(cache, "a", 5)).Release()
 	if expected, size := int64(25), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	cache.EvictFile(1, 0)
+	cache.EvictFile(1, base.FileNum(0).DiskFileNum())
 	if expected, size := int64(20), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	cache.EvictFile(1, 1)
+	cache.EvictFile(1, base.FileNum(1).DiskFileNum())
 	if expected, size := int64(15), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	cache.EvictFile(1, 2)
+	cache.EvictFile(1, base.FileNum(2).DiskFileNum())
 	if expected, size := int64(0), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
@@ -128,28 +128,28 @@ func TestEvictAll(t *testing.T) {
 	cache := newShards(100, 1)
 	defer cache.Unref()
 
-	cache.Set(1, 0, 0, testValue(cache, "a", 101)).Release()
-	cache.Set(1, 1, 0, testValue(cache, "a", 101)).Release()
+	cache.Set(1, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 101)).Release()
+	cache.Set(1, base.FileNum(1).DiskFileNum(), 0, testValue(cache, "a", 101)).Release()
 }
 
 func TestMultipleDBs(t *testing.T) {
 	cache := newShards(100, 1)
 	defer cache.Unref()
 
-	cache.Set(1, 0, 0, testValue(cache, "a", 5)).Release()
-	cache.Set(2, 0, 0, testValue(cache, "b", 5)).Release()
+	cache.Set(1, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 5)).Release()
+	cache.Set(2, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "b", 5)).Release()
 	if expected, size := int64(10), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	cache.EvictFile(1, 0)
+	cache.EvictFile(1, base.FileNum(0).DiskFileNum())
 	if expected, size := int64(5), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	h := cache.Get(1, 0, 0)
+	h := cache.Get(1, base.FileNum(0).DiskFileNum(), 0)
 	if v := h.Get(); v != nil {
 		t.Fatalf("expected not present, but found %s", v)
 	}
-	h = cache.Get(2, 0, 0)
+	h = cache.Get(2, base.FileNum(0).DiskFileNum(), 0)
 	if v := h.Get(); string(v) != "bbbbb" {
 		t.Fatalf("expected bbbbb, but found %s", v)
 	} else {
@@ -161,27 +161,27 @@ func TestZeroSize(t *testing.T) {
 	cache := newShards(0, 1)
 	defer cache.Unref()
 
-	cache.Set(1, 0, 0, testValue(cache, "a", 5)).Release()
+	cache.Set(1, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 5)).Release()
 }
 
 func TestReserve(t *testing.T) {
 	cache := newShards(4, 2)
 	defer cache.Unref()
 
-	cache.Set(1, 0, 0, testValue(cache, "a", 1)).Release()
-	cache.Set(2, 0, 0, testValue(cache, "a", 1)).Release()
+	cache.Set(1, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 1)).Release()
+	cache.Set(2, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 1)).Release()
 	require.EqualValues(t, 2, cache.Size())
 	r := cache.Reserve(1)
 	require.EqualValues(t, 0, cache.Size())
-	cache.Set(1, 0, 0, testValue(cache, "a", 1)).Release()
-	cache.Set(2, 0, 0, testValue(cache, "a", 1)).Release()
-	cache.Set(3, 0, 0, testValue(cache, "a", 1)).Release()
-	cache.Set(4, 0, 0, testValue(cache, "a", 1)).Release()
+	cache.Set(1, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 1)).Release()
+	cache.Set(2, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 1)).Release()
+	cache.Set(3, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 1)).Release()
+	cache.Set(4, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 1)).Release()
 	require.EqualValues(t, 2, cache.Size())
 	r()
 	require.EqualValues(t, 2, cache.Size())
-	cache.Set(1, 0, 0, testValue(cache, "a", 1)).Release()
-	cache.Set(2, 0, 0, testValue(cache, "a", 1)).Release()
+	cache.Set(1, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 1)).Release()
+	cache.Set(2, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 1)).Release()
 	require.EqualValues(t, 4, cache.Size())
 }
 
@@ -217,7 +217,7 @@ func TestCacheStressSetExisting(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			for j := 0; j < 10000; j++ {
-				cache.Set(1, 0, uint64(i), testValue(cache, "a", 1)).Release()
+				cache.Set(1, base.FileNum(0).DiskFileNum(), uint64(i), testValue(cache, "a", 1)).Release()
 				runtime.Gosched()
 			}
 		}(i)
@@ -233,7 +233,7 @@ func BenchmarkCacheGet(b *testing.B) {
 
 	for i := 0; i < size; i++ {
 		v := testValue(cache, "a", 1)
-		cache.Set(1, 0, uint64(i), v).Release()
+		cache.Set(1, base.FileNum(0).DiskFileNum(), uint64(i), v).Release()
 	}
 
 	b.ResetTimer()
@@ -241,7 +241,7 @@ func BenchmarkCacheGet(b *testing.B) {
 		rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 
 		for pb.Next() {
-			h := cache.Get(1, 0, uint64(rng.Intn(size)))
+			h := cache.Get(1, base.FileNum(0).DiskFileNum(), uint64(rng.Intn(size)))
 			if h.Get() == nil {
 				b.Fatal("failed to lookup value")
 			}
@@ -259,7 +259,7 @@ func TestReserveColdTarget(t *testing.T) {
 	defer cache.Unref()
 
 	for i := 0; i < 50; i++ {
-		cache.Set(uint64(i+1), 0, 0, testValue(cache, "a", 1)).Release()
+		cache.Set(uint64(i+1), base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 1)).Release()
 	}
 
 	if cache.Size() != 50 {

--- a/internal/cache/robin_hood.go
+++ b/internal/cache/robin_hood.go
@@ -24,7 +24,7 @@ func robinHoodHash(k key, shift uint32) uint32 {
 	const m = 11400714819323198485
 	h := hashSeed
 	h ^= k.id * m
-	h ^= uint64(k.fileNum) * m
+	h ^= uint64(k.fileNum.FileNum()) * m
 	h ^= k.offset * m
 	return uint32(h >> shift)
 }

--- a/internal/cache/robin_hood_test.go
+++ b/internal/cache/robin_hood_test.go
@@ -45,7 +45,7 @@ func TestRobinHoodMap(t *testing.T) {
 			// 40% insert.
 			var k key
 			k.id = rng.Uint64()
-			k.fileNum = base.FileNum(rng.Uint64())
+			k.fileNum = base.FileNum(rng.Uint64()).DiskFileNum()
 			k.offset = rng.Uint64()
 			e := &entry{}
 			goMap[k] = e
@@ -93,7 +93,7 @@ func BenchmarkGoMapInsert(b *testing.B) {
 	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 	keys := make([]key, benchSize)
 	for i := range keys {
-		keys[i].fileNum = base.FileNum(rng.Intn(1 << 20))
+		keys[i].fileNum = base.FileNum(rng.Uint64n(1 << 20)).DiskFileNum()
 		keys[i].offset = uint64(rng.Intn(1 << 20))
 	}
 	b.ResetTimer()
@@ -114,7 +114,7 @@ func BenchmarkRobinHoodInsert(b *testing.B) {
 	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 	keys := make([]key, benchSize)
 	for i := range keys {
-		keys[i].fileNum = base.FileNum(rng.Intn(1 << 20))
+		keys[i].fileNum = base.FileNum(rng.Uint64n(1 << 20)).DiskFileNum()
 		keys[i].offset = uint64(rng.Intn(1 << 20))
 	}
 	e := &entry{}
@@ -140,7 +140,7 @@ func BenchmarkGoMapLookupHit(b *testing.B) {
 	m := make(map[key]*entry, len(keys))
 	e := &entry{}
 	for i := range keys {
-		keys[i].fileNum = base.FileNum(rng.Intn(1 << 20))
+		keys[i].fileNum = base.FileNum(rng.Uint64n(1 << 20)).DiskFileNum()
 		keys[i].offset = uint64(rng.Intn(1 << 20))
 		m[keys[i]] = e
 	}
@@ -165,7 +165,7 @@ func BenchmarkRobinHoodLookupHit(b *testing.B) {
 	m := newRobinHoodMap(len(keys))
 	e := &entry{}
 	for i := range keys {
-		keys[i].fileNum = base.FileNum(rng.Intn(1 << 20))
+		keys[i].fileNum = base.FileNum(rng.Uint64n(1 << 20)).DiskFileNum()
 		keys[i].offset = uint64(rng.Intn(1 << 20))
 		m.Put(keys[i], e)
 	}
@@ -192,7 +192,7 @@ func BenchmarkGoMapLookupMiss(b *testing.B) {
 	e := &entry{}
 	for i := range keys {
 		keys[i].id = 1
-		keys[i].fileNum = base.FileNum(rng.Intn(1 << 20))
+		keys[i].fileNum = base.FileNum(rng.Uint64n(1 << 20)).DiskFileNum()
 		keys[i].offset = uint64(rng.Intn(1 << 20))
 		m[keys[i]] = e
 		keys[i].id = 2
@@ -219,7 +219,7 @@ func BenchmarkRobinHoodLookupMiss(b *testing.B) {
 	e := &entry{}
 	for i := range keys {
 		keys[i].id = 1
-		keys[i].fileNum = base.FileNum(rng.Intn(1 << 20))
+		keys[i].fileNum = base.FileNum(rng.Uint64n(1 << 20)).DiskFileNum()
 		keys[i].offset = uint64(rng.Intn(1 << 20))
 		m.Put(keys[i], e)
 		keys[i].id = 2

--- a/internal/manifest/testdata/version_edit_apply
+++ b/internal/manifest/testdata/version_edit_apply
@@ -125,7 +125,7 @@ edit
   000005:[h#3,SET-j#4,SET]
   000010:[j#3,SET-m#2,SET]
   000002:[n#5,SET-q#3,SET]
-zombies [1 4]
+zombies [{1} {4}]
 
 apply
 edit
@@ -153,7 +153,7 @@ edit
   L1
    2
 ----
-zombies [1 2]
+zombies [{1} {2}]
 
 # Deletion of a non-existent table results in an error.
 

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -168,7 +168,7 @@ type FileMetadata struct {
 	InitAllowedSeeks int64
 	// FileNum is the file number.
 	//
-	// INVARIANT: when !FileMetadata.Virtual, FileNum == FileBacking.FileNum.
+	// INVARIANT: when !FileMetadata.Virtual, FileNum == FileBacking.DiskFileNum.
 	//
 	// TODO(bananabrick): Consider creating separate types for
 	// FileMetadata.FileNum and FileBacking.FileNum. FileNum is used both as
@@ -350,7 +350,7 @@ type FileBacking struct {
 	// TODO(bananabrick): Compensate the virtual sstable file size using
 	// the VirtualizedSize during compaction picking and test.
 	VirtualizedSize atomic.Uint64
-	FileNum         base.FileNum
+	DiskFileNum     base.DiskFileNum
 	Size            uint64
 }
 
@@ -366,7 +366,7 @@ func (m *FileMetadata) InitPhysicalBacking() {
 		panic("pebble: virtual sstables should use a pre-existing FileBacking")
 	}
 	if m.FileBacking == nil {
-		m.FileBacking = &FileBacking{Size: m.Size, FileNum: m.FileNum}
+		m.FileBacking = &FileBacking{Size: m.Size, DiskFileNum: m.FileNum.DiskFileNum()}
 	}
 }
 

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -404,13 +404,13 @@ func TestVersionEditApply(t *testing.T) {
 						return err.Error()
 					}
 				}
-				zombies := make(map[base.FileNum]uint64)
+				zombies := make(map[base.DiskFileNum]uint64)
 				newv, err := bve.Apply(v, base.DefaultComparer.Compare, base.DefaultFormatter, 10<<20, 32000, zombies)
 				if err != nil {
 					return err.Error()
 				}
 
-				zombieFileNums := make([]base.FileNum, 0, len(zombies))
+				zombieFileNums := make([]base.DiskFileNum, 0, len(zombies))
 				if len(veList) == 1 {
 					// Only care about zombies if a single version edit was
 					// being applied.
@@ -418,7 +418,7 @@ func TestVersionEditApply(t *testing.T) {
 						zombieFileNums = append(zombieFileNums, fileNum)
 					}
 					sort.Slice(zombieFileNums, func(i, j int) bool {
-						return zombieFileNums[i] < zombieFileNums[j]
+						return zombieFileNums[i].FileNum() < zombieFileNums[j].FileNum()
 					})
 				}
 

--- a/internal/private/sstable.go
+++ b/internal/private/sstable.go
@@ -8,7 +8,7 @@ import "github.com/cockroachdb/pebble/internal/base"
 
 // SSTableCacheOpts is a hook for specifying cache options to
 // sstable.NewReader.
-var SSTableCacheOpts func(cacheID uint64, fileNum base.FileNum) interface{}
+var SSTableCacheOpts func(cacheID uint64, fileNum base.DiskFileNum) interface{}
 
 // SSTableRawTombstonesOpt is a sstable.Reader option for disabling
 // fragmentation of the range tombstones returned by

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -210,7 +210,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 				if err != nil {
 					return err.Error()
 				}
-				cacheOpts := private.SSTableCacheOpts(0, fileNum-1).(sstable.ReaderOption)
+				cacheOpts := private.SSTableCacheOpts(0, base.FileNum(uint64(fileNum)-1).DiskFileNum()).(sstable.ReaderOption)
 				r, err := sstable.NewReader(readable, sstable.ReaderOptions{}, cacheOpts)
 				if err != nil {
 					return err.Error()

--- a/objstorage/objstorage.go
+++ b/objstorage/objstorage.go
@@ -99,8 +99,8 @@ type Writable interface {
 
 // ObjectMetadata contains the metadata required to be able to access an object.
 type ObjectMetadata struct {
-	FileNum  base.FileNum
-	FileType base.FileType
+	DiskFileNum base.DiskFileNum
+	FileType    base.FileType
 
 	// The fields below are only set if the object is on shared storage.
 	Shared struct {
@@ -108,7 +108,7 @@ type ObjectMetadata struct {
 		CreatorID CreatorID
 		// CreatorFileNum is the identifier for the object within the context of the
 		// DB instance that originally created the object.
-		CreatorFileNum base.FileNum
+		CreatorFileNum base.DiskFileNum
 
 		CleanupMethod SharedCleanupMethod
 	}
@@ -174,7 +174,7 @@ type CreateOptions struct {
 type Provider interface {
 	// OpenForReading opens an existing object.
 	OpenForReading(
-		ctx context.Context, fileType base.FileType, fileNum base.FileNum, opts OpenOptions,
+		ctx context.Context, fileType base.FileType, FileNum base.DiskFileNum, opts OpenOptions,
 	) (Readable, error)
 
 	// Create creates a new object and opens it for writing.
@@ -182,13 +182,13 @@ type Provider interface {
 	// The object is not guaranteed to be durable (accessible in case of crashes)
 	// until Sync is called.
 	Create(
-		ctx context.Context, fileType base.FileType, fileNum base.FileNum, opts CreateOptions,
+		ctx context.Context, fileType base.FileType, FileNum base.DiskFileNum, opts CreateOptions,
 	) (w Writable, meta ObjectMetadata, err error)
 
 	// Remove removes an object.
 	//
 	// The object is not guaranteed to be durably removed until Sync is called.
-	Remove(fileType base.FileType, fileNum base.FileNum) error
+	Remove(fileType base.FileType, FileNum base.DiskFileNum) error
 
 	// Sync flushes the metadata from creation or removal of objects since the last Sync.
 	// This includes objects that have been Created but for which
@@ -202,12 +202,12 @@ type Provider interface {
 	// The object is not guaranteed to be durable (accessible in case of crashes)
 	// until Sync is called.
 	LinkOrCopyFromLocal(
-		srcFS vfs.FS, srcFilePath string, dstFileType base.FileType, dstFileNum base.FileNum,
+		srcFS vfs.FS, srcFilePath string, dstFileType base.FileType, dstFileNum base.DiskFileNum,
 	) (ObjectMetadata, error)
 
 	// Lookup returns the metadata of an object that is already known to the Provider.
 	// Does not perform any I/O.
-	Lookup(fileType base.FileType, fileNum base.FileNum) (ObjectMetadata, error)
+	Lookup(fileType base.FileType, FileNum base.DiskFileNum) (ObjectMetadata, error)
 
 	// Path returns an internal, implementation-dependent path for the object. It is
 	// meant to be used for informational purposes (like logging).
@@ -260,7 +260,7 @@ type SharedObjectBackingHandle interface {
 type SharedObjectToAttach struct {
 	// FileNum is the file number that will be used to refer to this object (in
 	// the context of this instance).
-	FileNum  base.FileNum
+	FileNum  base.DiskFileNum
 	FileType base.FileType
 	// Backing contains the metadata for the shared object backing (normally
 	// generated from a different instance, but using the same Provider

--- a/objstorage/objstorageprovider/objiotracing/obj_io_tracing_off.go
+++ b/objstorage/objstorageprovider/objiotracing/obj_io_tracing_off.go
@@ -33,7 +33,7 @@ func (*Tracer) Close() {}
 // WrapReadable wraps an objstorage.Readable with one that generates tracing
 // events.
 func (*Tracer) WrapReadable(
-	ctx context.Context, r objstorage.Readable, fileNum base.FileNum,
+	ctx context.Context, r objstorage.Readable, fileNum base.DiskFileNum,
 ) objstorage.Readable {
 	return r
 }
@@ -41,7 +41,7 @@ func (*Tracer) WrapReadable(
 // WrapWritable wraps an objstorage.Writable with one that generates tracing
 // events.
 func (t *Tracer) WrapWritable(
-	ctx context.Context, w objstorage.Writable, fileNum base.FileNum,
+	ctx context.Context, w objstorage.Writable, fileNum base.DiskFileNum,
 ) objstorage.Writable {
 	return w
 }

--- a/objstorage/objstorageprovider/shared.go
+++ b/objstorage/objstorageprovider/shared.go
@@ -68,13 +68,13 @@ func (p *provider) sharedInit() error {
 
 	for _, meta := range contents.Objects {
 		o := objstorage.ObjectMetadata{
-			FileNum:  meta.FileNum,
-			FileType: meta.FileType,
+			DiskFileNum: meta.FileNum,
+			FileType:    meta.FileType,
 		}
 		o.Shared.CreatorID = meta.CreatorID
 		o.Shared.CreatorFileNum = meta.CreatorFileNum
 		o.Shared.CleanupMethod = meta.CleanupMethod
-		p.mu.knownObjects[o.FileNum] = o
+		p.mu.knownObjects[o.DiskFileNum] = o
 	}
 	return nil
 }
@@ -157,11 +157,11 @@ func (p *provider) sharedObjectRefName(meta objstorage.ObjectMetadata) string {
 	if meta.Shared.CleanupMethod != objstorage.SharedRefTracking {
 		panic("ref object used when ref tracking disabled")
 	}
-	return sharedObjectRefName(meta, p.shared.creatorID, meta.FileNum)
+	return sharedObjectRefName(meta, p.shared.creatorID, meta.DiskFileNum)
 }
 
 func sharedObjectRefName(
-	meta objstorage.ObjectMetadata, refCreatorID objstorage.CreatorID, refFileNum base.FileNum,
+	meta objstorage.ObjectMetadata, refCreatorID objstorage.CreatorID, refFileNum base.DiskFileNum,
 ) string {
 	if meta.Shared.CleanupMethod != objstorage.SharedRefTracking {
 		panic("ref object used when ref tracking disabled")
@@ -198,14 +198,17 @@ func (p *provider) sharedCreateRef(meta objstorage.ObjectMetadata) error {
 }
 
 func (p *provider) sharedCreate(
-	_ context.Context, fileType base.FileType, fileNum base.FileNum, opts objstorage.CreateOptions,
+	_ context.Context,
+	fileType base.FileType,
+	fileNum base.DiskFileNum,
+	opts objstorage.CreateOptions,
 ) (objstorage.Writable, objstorage.ObjectMetadata, error) {
 	if err := p.sharedCheckInitialized(); err != nil {
 		return nil, objstorage.ObjectMetadata{}, err
 	}
 	meta := objstorage.ObjectMetadata{
-		FileNum:  fileNum,
-		FileType: fileType,
+		DiskFileNum: fileNum,
+		FileType:    fileType,
 	}
 	meta.Shared.CreatorID = p.shared.creatorID
 	meta.Shared.CreatorFileNum = fileNum
@@ -272,7 +275,7 @@ func (p *provider) sharedUnref(meta objstorage.ObjectMetadata) error {
 		// Never delete objects in this mode.
 		return nil
 	}
-	if p.isProtected(meta.FileNum) {
+	if p.isProtected(meta.DiskFileNum) {
 		// TODO(radu): we need a mechanism to unref the object when it becomes
 		// unprotected.
 		return nil

--- a/objstorage/objstorageprovider/shared_backing_test.go
+++ b/objstorage/objstorageprovider/shared_backing_test.go
@@ -23,11 +23,11 @@ func TestSharedObjectBacking(t *testing.T) {
 		}
 		t.Run(name, func(t *testing.T) {
 			meta := objstorage.ObjectMetadata{
-				FileNum:  1,
-				FileType: base.FileTypeTable,
+				DiskFileNum: base.FileNum(1).DiskFileNum(),
+				FileType:    base.FileTypeTable,
 			}
 			meta.Shared.CreatorID = 100
-			meta.Shared.CreatorFileNum = 200
+			meta.Shared.CreatorFileNum = base.FileNum(200).DiskFileNum()
 			meta.Shared.CleanupMethod = cleanup
 
 			st := DefaultSettings(vfs.NewMem(), "")
@@ -47,17 +47,17 @@ func TestSharedObjectBacking(t *testing.T) {
 			_, err = h.Get()
 			require.Error(t, err)
 
-			d1, err := decodeSharedObjectBacking(base.FileTypeTable, 100, buf)
+			d1, err := decodeSharedObjectBacking(base.FileTypeTable, base.FileNum(100).DiskFileNum(), buf)
 			require.NoError(t, err)
-			require.Equal(t, base.FileNum(100), d1.meta.FileNum)
+			require.Equal(t, uint64(100), uint64(d1.meta.DiskFileNum.FileNum()))
 			require.Equal(t, base.FileTypeTable, d1.meta.FileType)
 			require.Equal(t, meta.Shared, d1.meta.Shared)
 			if cleanup == objstorage.SharedRefTracking {
 				require.Equal(t, creatorID, d1.refToCheck.creatorID)
-				require.Equal(t, base.FileNum(1), d1.refToCheck.fileNum)
+				require.Equal(t, base.FileNum(1).DiskFileNum(), d1.refToCheck.fileNum)
 			} else {
 				require.Equal(t, objstorage.CreatorID(0), d1.refToCheck.creatorID)
-				require.Equal(t, base.FileNum(0), d1.refToCheck.fileNum)
+				require.Equal(t, base.FileNum(0).DiskFileNum(), d1.refToCheck.fileNum)
 			}
 
 			t.Run("unknown-tags", func(t *testing.T) {
@@ -67,22 +67,22 @@ func TestSharedObjectBacking(t *testing.T) {
 				buf2 = binary.AppendUvarint(buf2, 2)
 				buf2 = append(buf2, 1, 1)
 
-				d2, err := decodeSharedObjectBacking(base.FileTypeTable, 100, buf2)
+				d2, err := decodeSharedObjectBacking(base.FileTypeTable, base.FileNum(100).DiskFileNum(), buf2)
 				require.NoError(t, err)
-				require.Equal(t, base.FileNum(100), d2.meta.FileNum)
+				require.Equal(t, uint64(100), uint64(d2.meta.DiskFileNum.FileNum()))
 				require.Equal(t, base.FileTypeTable, d2.meta.FileType)
 				require.Equal(t, meta.Shared, d2.meta.Shared)
 				if cleanup == objstorage.SharedRefTracking {
 					require.Equal(t, creatorID, d2.refToCheck.creatorID)
-					require.Equal(t, base.FileNum(1), d2.refToCheck.fileNum)
+					require.Equal(t, base.FileNum(1).DiskFileNum(), d2.refToCheck.fileNum)
 				} else {
 					require.Equal(t, objstorage.CreatorID(0), d2.refToCheck.creatorID)
-					require.Equal(t, base.FileNum(0), d2.refToCheck.fileNum)
+					require.Equal(t, base.FileNum(0).DiskFileNum(), d2.refToCheck.fileNum)
 				}
 
 				buf3 := buf2
 				buf3 = binary.AppendUvarint(buf3, tagNotSafeToIgnoreMask+5)
-				_, err = decodeSharedObjectBacking(meta.FileType, meta.FileNum, buf3)
+				_, err = decodeSharedObjectBacking(meta.FileType, meta.DiskFileNum, buf3)
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "unknown tag")
 			})

--- a/objstorage/objstorageprovider/shared_writable.go
+++ b/objstorage/objstorageprovider/shared_writable.go
@@ -49,6 +49,6 @@ func (w *sharedWritable) Abort() {
 		_ = w.storageWriter.Close()
 		w.storageWriter = nil
 	}
-	w.p.removeMetadata(w.meta.FileNum)
+	w.p.removeMetadata(w.meta.DiskFileNum)
 	// TODO(radu): delete the object if it was created.
 }

--- a/objstorage/objstorageprovider/sharedobjcat/catalog_test.go
+++ b/objstorage/objstorageprovider/sharedobjcat/catalog_test.go
@@ -25,15 +25,15 @@ func TestCatalog(t *testing.T) {
 
 	var cat *sharedobjcat.Catalog
 	datadriven.RunTest(t, "testdata/catalog", func(t *testing.T, td *datadriven.TestData) string {
-		toInt := func(args ...string) []int {
+		toUInt64 := func(args ...string) []uint64 {
 			t.Helper()
-			var res []int
+			var res []uint64
 			for _, arg := range args {
 				n, err := strconv.Atoi(arg)
 				if err != nil {
 					td.Fatalf(t, "error parsing arg %s as integer: %v", arg, err)
 				}
-				res = append(res, int(n))
+				res = append(res, uint64(n))
 			}
 			return res
 		}
@@ -43,22 +43,22 @@ func TestCatalog(t *testing.T) {
 			if len(args) != 3 {
 				td.Fatalf(t, "add <file-num> <creator-id> <creator-file-num>")
 			}
-			vals := toInt(args...)
+			vals := toUInt64(args...)
 			return sharedobjcat.SharedObjectMetadata{
-				FileNum: base.FileNum(vals[0]),
+				FileNum: base.FileNum(vals[0]).DiskFileNum(),
 				// When we support other file types, we should let the test determine this.
 				FileType:       base.FileTypeTable,
 				CreatorID:      objstorage.CreatorID(vals[1]),
-				CreatorFileNum: base.FileNum(vals[2]),
+				CreatorFileNum: base.FileNum(vals[2]).DiskFileNum(),
 			}
 		}
 
-		parseDel := func(args []string) base.FileNum {
+		parseDel := func(args []string) base.DiskFileNum {
 			t.Helper()
 			if len(args) != 1 {
 				td.Fatalf(t, "delete <file-num>")
 			}
-			return base.FileNum(toInt(args[0])[0])
+			return base.FileNum(toUInt64(args[0])[0]).DiskFileNum()
 		}
 
 		memLog.Reset()
@@ -91,7 +91,7 @@ func TestCatalog(t *testing.T) {
 			if len(td.CmdArgs) != 1 {
 				td.Fatalf(t, "set-creator-id <id>")
 			}
-			id := objstorage.CreatorID(toInt(td.CmdArgs[0].String())[0])
+			id := objstorage.CreatorID(toUInt64(td.CmdArgs[0].String())[0])
 			if err := cat.SetCreatorID(id); err != nil {
 				return fmt.Sprintf("error setting creator ID: %v", err)
 			}
@@ -126,12 +126,12 @@ func TestCatalog(t *testing.T) {
 				if len(arg.Vals) != 1 {
 					td.Fatalf(t, "random-batches n=<val> size=<val>")
 				}
-				val := toInt(arg.Vals[0])[0]
+				val := toUInt64(arg.Vals[0])[0]
 				switch arg.Key {
 				case "n":
-					n = val
+					n = int(val)
 				case "size":
-					size = val
+					size = int(val)
 				default:
 					td.Fatalf(t, "random-batches n=<val> size=<val>")
 				}
@@ -140,11 +140,11 @@ func TestCatalog(t *testing.T) {
 			for batchIdx := 0; batchIdx < n; batchIdx++ {
 				for i := 0; i < size; i++ {
 					b.AddObject(sharedobjcat.SharedObjectMetadata{
-						FileNum: base.FileNum(rand.Uint64()),
+						FileNum: base.FileNum(rand.Uint64()).DiskFileNum(),
 						// When we support other file types, we should let the test determine this.
 						FileType:       base.FileTypeTable,
 						CreatorID:      objstorage.CreatorID(rand.Uint64()),
-						CreatorFileNum: base.FileNum(rand.Uint64()),
+						CreatorFileNum: base.FileNum(rand.Uint64()).DiskFileNum(),
 					})
 				}
 				if err := cat.ApplyBatch(b); err != nil {

--- a/objstorage/objstorageprovider/sharedobjcat/version_edit_test.go
+++ b/objstorage/objstorageprovider/sharedobjcat/version_edit_test.go
@@ -24,42 +24,42 @@ func TestVersionEditRoundTrip(t *testing.T) {
 		{
 			NewObjects: []SharedObjectMetadata{
 				{
-					FileNum:        1,
+					FileNum:        base.FileNum(1).DiskFileNum(),
 					FileType:       base.FileTypeTable,
 					CreatorID:      12,
-					CreatorFileNum: 123,
+					CreatorFileNum: base.FileNum(123).DiskFileNum(),
 					CleanupMethod:  objstorage.SharedNoCleanup,
 				},
 			},
 		},
 		{
-			DeletedObjects: []base.FileNum{1},
+			DeletedObjects: []base.DiskFileNum{base.FileNum(1).DiskFileNum()},
 		},
 		{
 			CreatorID: 12345,
 			NewObjects: []SharedObjectMetadata{
 				{
-					FileNum:        1,
+					FileNum:        base.FileNum(1).DiskFileNum(),
 					FileType:       base.FileTypeTable,
 					CreatorID:      12,
-					CreatorFileNum: 123,
+					CreatorFileNum: base.FileNum(123).DiskFileNum(),
 					CleanupMethod:  objstorage.SharedRefTracking,
 				},
 				{
-					FileNum:        2,
+					FileNum:        base.FileNum(2).DiskFileNum(),
 					FileType:       base.FileTypeTable,
 					CreatorID:      22,
-					CreatorFileNum: 223,
+					CreatorFileNum: base.FileNum(223).DiskFileNum(),
 				},
 				{
-					FileNum:        3,
+					FileNum:        base.FileNum(3).DiskFileNum(),
 					FileType:       base.FileTypeTable,
 					CreatorID:      32,
-					CreatorFileNum: 323,
+					CreatorFileNum: base.FileNum(323).DiskFileNum(),
 					CleanupMethod:  objstorage.SharedRefTracking,
 				},
 			},
-			DeletedObjects: []base.FileNum{4, 5},
+			DeletedObjects: []base.DiskFileNum{base.FileNum(4).DiskFileNum(), base.FileNum(5).DiskFileNum()},
 		},
 	} {
 		if err := checkRoundTrip(ve); err != nil {

--- a/open_test.go
+++ b/open_test.go
@@ -1050,8 +1050,8 @@ func TestGetVersion(t *testing.T) {
 		}
 		switch ft {
 		case fileTypeOptions:
-			if fn > highestOptionsNum {
-				highestOptionsNum = fn
+			if fn.FileNum() > highestOptionsNum {
+				highestOptionsNum = fn.FileNum()
 			}
 		}
 	}
@@ -1286,7 +1286,7 @@ func TestCheckConsistency(t *testing.T) {
 					if err != nil {
 						return err.Error()
 					}
-					path := base.MakeFilepath(mem, dir, base.FileTypeTable, m.FileNum)
+					path := base.MakeFilepath(mem, dir, base.FileTypeTable, m.FileBacking.DiskFileNum)
 					_ = mem.Remove(path)
 					f, err := mem.Create(path)
 					if err != nil {

--- a/replay/workload_capture_test.go
+++ b/replay/workload_capture_test.go
@@ -66,7 +66,7 @@ func TestWorkloadCollector(t *testing.T) {
 				var fileNum uint64
 				var err error
 				td.ScanArgs(t, "filenum", &fileNum)
-				path := base.MakeFilepath(fs, srcDir, base.FileTypeManifest, base.FileNum(fileNum))
+				path := base.MakeFilepath(fs, srcDir, base.FileTypeManifest, base.FileNum(fileNum).DiskFileNum())
 				currentManifest, err = fs.Create(path)
 				require.NoError(t, err)
 				_, err = currentManifest.Write(randData(100))
@@ -95,7 +95,7 @@ func TestWorkloadCollector(t *testing.T) {
 					require.NoError(t, err)
 					tableInfo.FileNum = base.FileNum(fileNum)
 
-					p := writeFile(t, fs, srcDir, base.FileTypeTable, tableInfo.FileNum, randData(int(tableInfo.Size)))
+					p := writeFile(t, fs, srcDir, base.FileTypeTable, tableInfo.FileNum.DiskFileNum(), randData(int(tableInfo.Size)))
 					fmt.Fprintf(&buf, "created %s\n", p)
 					flushInfo.Output = append(flushInfo.Output, tableInfo)
 
@@ -119,7 +119,7 @@ func TestWorkloadCollector(t *testing.T) {
 					require.NoError(t, err)
 					tableInfo.FileNum = base.FileNum(fileNum)
 
-					p := writeFile(t, fs, srcDir, base.FileTypeTable, tableInfo.FileNum, randData(int(tableInfo.Size)))
+					p := writeFile(t, fs, srcDir, base.FileTypeTable, tableInfo.FileNum.DiskFileNum(), randData(int(tableInfo.Size)))
 					fmt.Fprintf(&buf, "created %s\n", p)
 					ingestInfo.Tables = append(ingestInfo.Tables, struct {
 						pebble.TableInfo
@@ -178,9 +178,9 @@ func randData(byteCount int) []byte {
 }
 
 func writeFile(
-	t *testing.T, fs vfs.FS, dir string, typ base.FileType, num base.FileNum, data []byte,
+	t *testing.T, fs vfs.FS, dir string, typ base.FileType, fileNum base.DiskFileNum, data []byte,
 ) string {
-	path := base.MakeFilepath(fs, dir, typ, num)
+	path := base.MakeFilepath(fs, dir, typ, fileNum)
 	f, err := fs.Create(path)
 	require.NoError(t, err)
 	_, err = f.Write(data)

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -179,7 +179,7 @@ func runBuildRawCmd(
 	}
 	defer provider.Close()
 
-	f0, _, err := provider.Create(context.Background(), base.FileTypeTable, 0 /* fileNum */, objstorage.CreateOptions{})
+	f0, _, err := provider.Create(context.Background(), base.FileTypeTable, base.FileNum(0).DiskFileNum(), objstorage.CreateOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -226,7 +226,7 @@ func runBuildRawCmd(
 		return nil, nil, err
 	}
 
-	f1, err := provider.OpenForReading(context.Background(), base.FileTypeTable, 0 /* fileNum */, objstorage.OpenOptions{})
+	f1, err := provider.OpenForReading(context.Background(), base.FileTypeTable, base.FileNum(0).DiskFileNum(), objstorage.OpenOptions{})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -2522,7 +2522,7 @@ func (m Mergers) readerApply(r *Reader) {
 // number. If not specified, a unique cache ID will be used.
 type cacheOpts struct {
 	cacheID uint64
-	fileNum base.FileNum
+	fileNum base.DiskFileNum
 }
 
 // Marker function to indicate the option should be applied before reading the
@@ -2534,7 +2534,7 @@ func (c *cacheOpts) readerApply(r *Reader) {
 	if r.cacheID == 0 {
 		r.cacheID = c.cacheID
 	}
-	if r.fileNum == 0 {
+	if r.fileNum.FileNum() == 0 {
 		r.fileNum = c.fileNum
 	}
 }
@@ -2543,7 +2543,7 @@ func (c *cacheOpts) writerApply(w *Writer) {
 	if w.cacheID == 0 {
 		w.cacheID = c.cacheID
 	}
-	if w.fileNum == 0 {
+	if w.fileNum.FileNum() == 0 {
 		w.fileNum = c.fileNum
 	}
 }
@@ -2561,7 +2561,7 @@ func (rawTombstonesOpt) readerApply(r *Reader) {
 }
 
 func init() {
-	private.SSTableCacheOpts = func(cacheID uint64, fileNum base.FileNum) interface{} {
+	private.SSTableCacheOpts = func(cacheID uint64, fileNum base.DiskFileNum) interface{} {
 		return &cacheOpts{cacheID, fileNum}
 	}
 	private.SSTableRawTombstonesOpt = rawTombstonesOpt{}
@@ -2571,7 +2571,7 @@ func init() {
 type Reader struct {
 	readable          objstorage.Readable
 	cacheID           uint64
-	fileNum           base.FileNum
+	fileNum           base.DiskFileNum
 	err               error
 	indexBH           BlockHandle
 	filterBH          BlockHandle
@@ -2847,7 +2847,7 @@ func (r *Reader) readBlock(
 		return cache.Handle{}, err
 	}
 
-	if err := checkChecksum(r.checksumType, b, bh, r.fileNum); err != nil {
+	if err := checkChecksum(r.checksumType, b, bh, r.fileNum.FileNum()); err != nil {
 		r.opts.Cache.Free(v)
 		return cache.Handle{}, err
 	}

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -698,7 +698,7 @@ func TestReadaheadSetupForV3TablesWithMultipleVersions(t *testing.T) {
 	provider, err := objstorageprovider.Open(objstorageprovider.DefaultSettings(vfs.Default, tmpDir))
 	require.NoError(t, err)
 	defer provider.Close()
-	f0, _, err := provider.Create(context.Background(), base.FileTypeTable, 0 /* fileNum */, objstorage.CreateOptions{})
+	f0, _, err := provider.Create(context.Background(), base.FileTypeTable, base.FileNum(0).DiskFileNum(), objstorage.CreateOptions{})
 	require.NoError(t, err)
 
 	w := NewWriter(f0, WriterOptions{
@@ -716,7 +716,7 @@ func TestReadaheadSetupForV3TablesWithMultipleVersions(t *testing.T) {
 		}
 	}
 	require.NoError(t, w.Close())
-	f1, err := provider.OpenForReading(context.Background(), base.FileTypeTable, 0 /* fileNum */, objstorage.OpenOptions{})
+	f1, err := provider.OpenForReading(context.Background(), base.FileTypeTable, base.FileNum(0).DiskFileNum(), objstorage.OpenOptions{})
 	require.NoError(t, err)
 	r, err := NewReader(f1, ReaderOptions{Comparer: testkeys.Comparer})
 	require.NoError(t, err)
@@ -1070,7 +1070,7 @@ func buildTestTableWithProvider(
 	blockSize, indexBlockSize int,
 	compression Compression,
 ) *Reader {
-	f0, _, err := provider.Create(context.Background(), base.FileTypeTable, 0 /* fileNum */, objstorage.CreateOptions{})
+	f0, _, err := provider.Create(context.Background(), base.FileTypeTable, base.FileNum(0).DiskFileNum(), objstorage.CreateOptions{})
 	require.NoError(t, err)
 
 	w := NewWriter(f0, WriterOptions{
@@ -1092,7 +1092,7 @@ func buildTestTableWithProvider(
 	require.NoError(t, w.Close())
 
 	// Re-open that filename for reading.
-	f1, err := provider.OpenForReading(context.Background(), base.FileTypeTable, 0 /* fileNum */, objstorage.OpenOptions{})
+	f1, err := provider.OpenForReading(context.Background(), base.FileTypeTable, base.FileNum(0).DiskFileNum(), objstorage.OpenOptions{})
 	require.NoError(t, err)
 
 	c := cache.New(128 << 20)

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -119,7 +119,7 @@ type Writer struct {
 	// the cache, providing a defense in depth against bugs which cause cache
 	// collisions.
 	cacheID uint64
-	fileNum base.FileNum
+	fileNum base.DiskFileNum
 	// The following fields are copied from Options.
 	blockSize               int
 	blockSizeThreshold      int
@@ -1660,7 +1660,7 @@ func compressAndChecksum(b []byte, compression Compression, blockBuf *blockBuf) 
 func (w *Writer) writeCompressedBlock(block []byte, blockTrailerBuf []byte) (BlockHandle, error) {
 	bh := BlockHandle{Offset: w.meta.Size, Length: uint64(len(block))}
 
-	if w.cacheID != 0 && w.fileNum != 0 {
+	if w.cacheID != 0 && w.fileNum.FileNum() != 0 {
 		// Remove the block being written from the cache. This provides defense in
 		// depth against bugs which cause cache collisions.
 		//
@@ -1687,7 +1687,7 @@ func (w *Writer) writeCompressedBlock(block []byte, blockTrailerBuf []byte) (Blo
 // return a BlockHandle.
 func (w *Writer) Write(blockWithTrailer []byte) (n int, err error) {
 	offset := w.meta.Size
-	if w.cacheID != 0 && w.fileNum != 0 {
+	if w.cacheID != 0 && w.fileNum.FileNum() != 0 {
 		// Remove the block being written from the cache. This provides defense in
 		// depth against bugs which cause cache collisions.
 		//

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -556,7 +556,7 @@ func TestWriterClearCache(t *testing.T) {
 		Comparer:    testkeys.Comparer,
 		TableFormat: TableFormatPebblev3,
 	}
-	cacheOpts := &cacheOpts{cacheID: 1, fileNum: 1}
+	cacheOpts := &cacheOpts{cacheID: 1, fileNum: base.FileNum(1).DiskFileNum()}
 	invalidData := func() *cache.Value {
 		invalid := []byte("invalid data")
 		v := opts.Cache.Alloc(len(invalid))

--- a/table_cache.go
+++ b/table_cache.go
@@ -134,20 +134,20 @@ func (c *tableCacheContainer) newIters(
 	opts *IterOptions,
 	internalOpts internalIterOpts,
 ) (internalIterator, keyspan.FragmentIterator, error) {
-	return c.tableCache.getShard(file.FileNum).newIters(ctx, file, opts, internalOpts, &c.dbOpts)
+	return c.tableCache.getShard(file.FileBacking.DiskFileNum).newIters(ctx, file, opts, internalOpts, &c.dbOpts)
 }
 
 func (c *tableCacheContainer) newRangeKeyIter(
 	file *manifest.FileMetadata, opts *keyspan.SpanIterOptions,
 ) (keyspan.FragmentIterator, error) {
-	return c.tableCache.getShard(file.FileNum).newRangeKeyIter(file, opts, &c.dbOpts)
+	return c.tableCache.getShard(file.FileBacking.DiskFileNum).newRangeKeyIter(file, opts, &c.dbOpts)
 }
 
 func (c *tableCacheContainer) getTableProperties(file physicalMeta) (*sstable.Properties, error) {
-	return c.tableCache.getShard(file.FileNum).getTableProperties(file.FileMetadata, &c.dbOpts)
+	return c.tableCache.getShard(file.FileBacking.DiskFileNum).getTableProperties(file.FileMetadata, &c.dbOpts)
 }
 
-func (c *tableCacheContainer) evict(fileNum FileNum) {
+func (c *tableCacheContainer) evict(fileNum base.DiskFileNum) {
 	c.tableCache.getShard(fileNum).evict(fileNum, &c.dbOpts, false)
 }
 
@@ -167,7 +167,7 @@ func (c *tableCacheContainer) metrics() (CacheMetrics, FilterMetrics) {
 }
 
 func (c *tableCacheContainer) withReader(meta *fileMetadata, fn func(*sstable.Reader) error) error {
-	s := c.tableCache.getShard(meta.FileNum)
+	s := c.tableCache.getShard(meta.FileBacking.DiskFileNum)
 	v := s.findNode(meta, &c.dbOpts)
 	defer s.unrefValue(v)
 	if v.err != nil {
@@ -249,13 +249,13 @@ func NewTableCache(cache *Cache, numShards int, size int) *TableCache {
 	return c
 }
 
-func (c *TableCache) getShard(fileNum FileNum) *tableCacheShard {
-	return c.shards[uint64(fileNum)%uint64(len(c.shards))]
+func (c *TableCache) getShard(fileNum base.DiskFileNum) *tableCacheShard {
+	return c.shards[uint64(fileNum.FileNum())%uint64(len(c.shards))]
 }
 
 type tableCacheKey struct {
 	cacheID uint64
-	fileNum FileNum
+	fileNum base.DiskFileNum
 }
 
 type tableCacheShard struct {
@@ -548,7 +548,7 @@ func (c *tableCacheShard) releaseNode(n *tableCacheNode) {
 //
 // c.mu must be held when calling this.
 func (c *tableCacheShard) unlinkNode(n *tableCacheNode) {
-	key := tableCacheKey{n.cacheID, n.meta.FileNum}
+	key := tableCacheKey{n.cacheID, n.meta.FileBacking.DiskFileNum}
 	delete(c.mu.nodes, key)
 
 	switch n.ptype {
@@ -605,7 +605,7 @@ func (c *tableCacheShard) unrefValue(v *tableCacheValue) {
 func (c *tableCacheShard) findNode(meta *fileMetadata, dbOpts *tableCacheOpts) *tableCacheValue {
 	// Fast-path for a hit in the cache.
 	c.mu.RLock()
-	key := tableCacheKey{dbOpts.cacheID, meta.FileNum}
+	key := tableCacheKey{dbOpts.cacheID, meta.FileBacking.DiskFileNum}
 	if n := c.mu.nodes[key]; n != nil && n.value != nil {
 		// Fast-path hit.
 		//
@@ -693,7 +693,7 @@ func (c *tableCacheShard) findNode(meta *fileMetadata, dbOpts *tableCacheOpts) *
 func (c *tableCacheShard) addNode(n *tableCacheNode, dbOpts *tableCacheOpts) {
 	c.evictNodes()
 	n.cacheID = dbOpts.cacheID
-	key := tableCacheKey{n.cacheID, n.meta.FileNum}
+	key := tableCacheKey{n.cacheID, n.meta.FileBacking.DiskFileNum}
 	c.mu.nodes[key] = n
 
 	n.links.next = n
@@ -787,7 +787,7 @@ func (c *tableCacheShard) runHandTest() {
 	c.mu.handTest = c.mu.handTest.next()
 }
 
-func (c *tableCacheShard) evict(fileNum FileNum, dbOpts *tableCacheOpts, allowLeak bool) {
+func (c *tableCacheShard) evict(fileNum base.DiskFileNum, dbOpts *tableCacheOpts, allowLeak bool) {
 	c.mu.Lock()
 	key := tableCacheKey{dbOpts.cacheID, fileNum}
 	n := c.mu.nodes[key]
@@ -823,7 +823,7 @@ func (c *tableCacheShard) evict(fileNum FileNum, dbOpts *tableCacheOpts, allowLe
 // associated with dbOpts.cacheID. Make sure that there will
 // be no more accesses to the files associated with the DB.
 func (c *tableCacheShard) removeDB(dbOpts *tableCacheOpts) {
-	var fileNums []base.FileNum
+	var fileNums []base.DiskFileNum
 
 	c.mu.RLock()
 	// Collect the fileNums which need to be cleaned.
@@ -835,7 +835,7 @@ func (c *tableCacheShard) removeDB(dbOpts *tableCacheOpts) {
 		}
 
 		if node.cacheID == dbOpts.cacheID {
-			fileNums = append(fileNums, node.meta.FileNum)
+			fileNums = append(fileNums, node.meta.FileBacking.DiskFileNum)
 		}
 		node = node.next()
 	}
@@ -844,8 +844,8 @@ func (c *tableCacheShard) removeDB(dbOpts *tableCacheOpts) {
 	// Evict all the nodes associated with the DB.
 	// This should synchronously close all the files
 	// associated with the DB.
-	for _, fNum := range fileNums {
-		c.evict(fNum, dbOpts, true)
+	for _, fileNum := range fileNums {
+		c.evict(fileNum, dbOpts, true)
 	}
 }
 
@@ -914,10 +914,10 @@ func (v *tableCacheValue) load(meta *fileMetadata, c *tableCacheShard, dbOpts *t
 	// Try opening the file first.
 	var f objstorage.Readable
 	f, v.err = dbOpts.objProvider.OpenForReading(
-		context.TODO(), fileTypeTable, meta.FileNum, objstorage.OpenOptions{MustExist: true},
+		context.TODO(), fileTypeTable, meta.FileBacking.DiskFileNum, objstorage.OpenOptions{MustExist: true},
 	)
 	if v.err == nil {
-		cacheOpts := private.SSTableCacheOpts(dbOpts.cacheID, meta.FileNum).(sstable.ReaderOption)
+		cacheOpts := private.SSTableCacheOpts(dbOpts.cacheID, meta.FileBacking.DiskFileNum).(sstable.ReaderOption)
 		v.reader, v.err = sstable.NewReader(f, dbOpts.opts, cacheOpts, dbOpts.filterMetrics)
 	}
 	if v.err == nil {
@@ -930,7 +930,7 @@ func (v *tableCacheValue) load(meta *fileMetadata, c *tableCacheShard, dbOpts *t
 		defer c.mu.Unlock()
 		// Lookup the node in the cache again as it might have already been
 		// removed.
-		key := tableCacheKey{dbOpts.cacheID, meta.FileNum}
+		key := tableCacheKey{dbOpts.cacheID, meta.FileBacking.DiskFileNum}
 		n := c.mu.nodes[key]
 		if n != nil && n.value == v {
 			c.releaseNode(n)

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -102,7 +102,7 @@ func (fs *tableCacheTestFS) validateOpenTables(f func(i, gotO, gotC int) error) 
 
 		numStillOpen := 0
 		for i := 0; i < tableCacheTestNumTables; i++ {
-			filename := base.MakeFilepath(fs, "", fileTypeTable, FileNum(i))
+			filename := base.MakeFilepath(fs, "", fileTypeTable, base.FileNum(uint64(i)).DiskFileNum())
 			gotO, gotC := fs.openCounts[filename], fs.closeCounts[filename]
 			if gotO > gotC {
 				numStillOpen++
@@ -132,7 +132,7 @@ func (fs *tableCacheTestFS) validateNoneStillOpen() error {
 		defer fs.mu.Unlock()
 
 		for i := 0; i < tableCacheTestNumTables; i++ {
-			filename := base.MakeFilepath(fs, "", fileTypeTable, FileNum(i))
+			filename := base.MakeFilepath(fs, "", fileTypeTable, base.FileNum(uint64(i)).DiskFileNum())
 			gotO, gotC := fs.openCounts[filename], fs.closeCounts[filename]
 			if gotO != gotC {
 				return errors.Errorf("i=%d: opened %d times, closed %d times", i, gotO, gotC)
@@ -169,7 +169,7 @@ func newTableCacheContainerTest(
 	defer objProvider.Close()
 
 	for i := 0; i < tableCacheTestNumTables; i++ {
-		w, _, err := objProvider.Create(context.Background(), fileTypeTable, FileNum(i), objstorage.CreateOptions{})
+		w, _, err := objProvider.Create(context.Background(), fileTypeTable, base.FileNum(uint64(i)).DiskFileNum(), objstorage.CreateOptions{})
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "fs.Create")
 		}
@@ -451,7 +451,9 @@ func testTableCacheRandomAccess(t *testing.T, concurrent bool) {
 			rngMu.Lock()
 			fileNum, sleepTime := rng.Intn(tableCacheTestNumTables), rng.Intn(1000)
 			rngMu.Unlock()
-			iter, _, err := c.newIters(context.Background(), &fileMetadata{FileNum: FileNum(fileNum)}, nil, internalIterOpts{})
+			m := &fileMetadata{FileNum: FileNum(fileNum)}
+			m.InitPhysicalBacking()
+			iter, _, err := c.newIters(context.Background(), m, nil, internalIterOpts{})
 			if err != nil {
 				errc <- errors.Errorf("i=%d, fileNum=%d: find: %v", i, fileNum, err)
 				return
@@ -510,12 +512,12 @@ func testTableCacheFrequentlyUsedInternal(t *testing.T, rangeIter bool) {
 		for _, j := range [...]int{pinned0, i % tableCacheTestNumTables, pinned1} {
 			var iter io.Closer
 			var err error
+			m := &fileMetadata{FileNum: FileNum(j)}
+			m.InitPhysicalBacking()
 			if rangeIter {
-				iter, err = c.newRangeKeyIter(
-					&fileMetadata{FileNum: FileNum(j)},
-					nil /* iter options */)
+				iter, err = c.newRangeKeyIter(m, nil /* iter options */)
 			} else {
-				iter, _, err = c.newIters(context.Background(), &fileMetadata{FileNum: FileNum(j)}, nil, internalIterOpts{})
+				iter, _, err = c.newIters(context.Background(), m, nil, internalIterOpts{})
 			}
 			if err != nil {
 				t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
@@ -559,11 +561,13 @@ func TestSharedTableCacheFrequentlyUsed(t *testing.T) {
 
 	for i := 0; i < N; i++ {
 		for _, j := range [...]int{pinned0, i % tableCacheTestNumTables, pinned1} {
-			iter1, _, err := c1.newIters(context.Background(), &fileMetadata{FileNum: FileNum(j)}, nil, internalIterOpts{})
+			m := &fileMetadata{FileNum: FileNum(j)}
+			m.InitPhysicalBacking()
+			iter1, _, err := c1.newIters(context.Background(), m, nil, internalIterOpts{})
 			if err != nil {
 				t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
 			}
-			iter2, _, err := c2.newIters(context.Background(), &fileMetadata{FileNum: FileNum(j)}, nil, internalIterOpts{})
+			iter2, _, err := c2.newIters(context.Background(), m, nil, internalIterOpts{})
 			if err != nil {
 				t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
 			}
@@ -609,12 +613,12 @@ func testTableCacheEvictionsInternal(t *testing.T, rangeIter bool) {
 		j := rng.Intn(tableCacheTestNumTables)
 		var iter io.Closer
 		var err error
+		m := &fileMetadata{FileNum: FileNum(j)}
+		m.InitPhysicalBacking()
 		if rangeIter {
-			iter, err = c.newRangeKeyIter(
-				&fileMetadata{FileNum: FileNum(j)},
-				nil /* iter options */)
+			iter, err = c.newRangeKeyIter(m, nil /* iter options */)
 		} else {
-			iter, _, err = c.newIters(context.Background(), &fileMetadata{FileNum: FileNum(j)}, nil, internalIterOpts{})
+			iter, _, err = c.newIters(context.Background(), m, nil, internalIterOpts{})
 		}
 		if err != nil {
 			t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
@@ -623,7 +627,7 @@ func testTableCacheEvictionsInternal(t *testing.T, rangeIter bool) {
 			t.Fatalf("i=%d, j=%d: close: %v", i, j, err)
 		}
 
-		c.evict(FileNum(lo + rng.Intn(hi-lo)))
+		c.evict(base.FileNum(lo + rng.Uint64n(hi-lo)).DiskFileNum())
 	}
 
 	sumEvicted, nEvicted := 0, 0
@@ -673,12 +677,14 @@ func TestSharedTableCacheEvictions(t *testing.T) {
 	rng := rand.New(rand.NewSource(2))
 	for i := 0; i < N; i++ {
 		j := rng.Intn(tableCacheTestNumTables)
-		iter1, _, err := c1.newIters(context.Background(), &fileMetadata{FileNum: FileNum(j)}, nil, internalIterOpts{})
+		m := &fileMetadata{FileNum: FileNum(j)}
+		m.InitPhysicalBacking()
+		iter1, _, err := c1.newIters(context.Background(), m, nil, internalIterOpts{})
 		if err != nil {
 			t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
 		}
 
-		iter2, _, err := c2.newIters(context.Background(), &fileMetadata{FileNum: FileNum(j)}, nil, internalIterOpts{})
+		iter2, _, err := c2.newIters(context.Background(), m, nil, internalIterOpts{})
 		if err != nil {
 			t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
 		}
@@ -691,8 +697,8 @@ func TestSharedTableCacheEvictions(t *testing.T) {
 			t.Fatalf("i=%d, j=%d: close: %v", i, j, err)
 		}
 
-		c1.evict(FileNum(lo + rng.Intn(hi-lo)))
-		c2.evict(FileNum(lo + rng.Intn(hi-lo)))
+		c1.evict(base.FileNum(lo + rng.Uint64n(hi-lo)).DiskFileNum())
+		c2.evict(base.FileNum(lo + rng.Uint64n(hi-lo)).DiskFileNum())
 	}
 
 	check := func(fs *tableCacheTestFS, c *tableCacheContainer) (float64, float64, float64) {
@@ -737,7 +743,9 @@ func TestTableCacheIterLeak(t *testing.T) {
 	c, _, err := newTableCacheContainerTest(nil, "")
 	require.NoError(t, err)
 
-	iter, _, err := c.newIters(context.Background(), &fileMetadata{FileNum: 0}, nil, internalIterOpts{})
+	m := &fileMetadata{FileNum: 0}
+	m.InitPhysicalBacking()
+	iter, _, err := c.newIters(context.Background(), m, nil, internalIterOpts{})
 	require.NoError(t, err)
 
 	if err := c.close(); err == nil {
@@ -760,7 +768,9 @@ func TestSharedTableCacheIterLeak(t *testing.T) {
 	require.NoError(t, err)
 	tc.Unref()
 
-	iter, _, err := c1.newIters(context.Background(), &fileMetadata{FileNum: 0}, nil, internalIterOpts{})
+	m := &fileMetadata{FileNum: 0}
+	m.InitPhysicalBacking()
+	iter, _, err := c1.newIters(context.Background(), m, nil, internalIterOpts{})
 	require.NoError(t, err)
 
 	if err := c1.close(); err == nil {
@@ -794,12 +804,14 @@ func TestTableCacheRetryAfterFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	fs.setOpenError(true /* enabled */)
-	if _, _, err := c.newIters(context.Background(), &fileMetadata{FileNum: 0}, nil, internalIterOpts{}); err == nil {
+	m := &fileMetadata{FileNum: 0}
+	m.InitPhysicalBacking()
+	if _, _, err := c.newIters(context.Background(), m, nil, internalIterOpts{}); err == nil {
 		t.Fatalf("expected failure, but found success")
 	}
 	fs.setOpenError(false /* enabled */)
 	var iter internalIterator
-	iter, _, err = c.newIters(context.Background(), &fileMetadata{FileNum: 0}, nil, internalIterOpts{})
+	iter, _, err = c.newIters(context.Background(), m, nil, internalIterOpts{})
 	require.NoError(t, err)
 	require.NoError(t, iter.Close())
 	fs.validate(t, c, nil)
@@ -843,9 +855,9 @@ func TestTableCacheClockPro(t *testing.T) {
 	require.NoError(t, err)
 	defer objProvider.Close()
 
-	makeTable := func(fileNum FileNum) {
+	makeTable := func(dfn base.DiskFileNum) {
 		require.NoError(t, err)
-		f, _, err := objProvider.Create(context.Background(), fileTypeTable, fileNum, objstorage.CreateOptions{})
+		f, _, err := objProvider.Create(context.Background(), fileTypeTable, dfn, objstorage.CreateOptions{})
 		require.NoError(t, err)
 		w := sstable.NewWriter(f, sstable.WriterOptions{})
 		require.NoError(t, w.Set([]byte("a"), nil))
@@ -880,12 +892,14 @@ func TestTableCacheClockPro(t *testing.T) {
 		// Ensure that underlying sstables exist on disk, creating each table the
 		// first time it is seen.
 		if !tables[key] {
-			makeTable(FileNum(key))
+			makeTable(base.FileNum(uint64(key)).DiskFileNum())
 			tables[key] = true
 		}
 
 		oldHits := cache.hits.Load()
-		v := cache.findNode(&fileMetadata{FileNum: FileNum(key)}, dbOpts)
+		m := &fileMetadata{FileNum: FileNum(key)}
+		m.InitPhysicalBacking()
+		v := cache.findNode(m, dbOpts)
 		cache.unrefValue(v)
 
 		hit := cache.hits.Load() != oldHits

--- a/tool/db.go
+++ b/tool/db.go
@@ -675,7 +675,7 @@ func (d *dbT) addProps(
 	objProvider objstorage.Provider, m manifest.PhysicalFileMeta, p *props,
 ) error {
 	ctx := context.Background()
-	f, err := objProvider.OpenForReading(ctx, base.FileTypeTable, m.FileNum, objstorage.OpenOptions{})
+	f, err := objProvider.OpenForReading(ctx, base.FileTypeTable, m.FileBacking.DiskFileNum, objstorage.OpenOptions{})
 	if err != nil {
 		return err
 	}

--- a/tool/find.go
+++ b/tool/find.go
@@ -168,15 +168,15 @@ func (f *findT) findFiles(stdout, stderr io.Writer, dir string) error {
 		}
 		switch ft {
 		case base.FileTypeLog:
-			f.logs = append(f.logs, fileNum)
+			f.logs = append(f.logs, fileNum.FileNum())
 		case base.FileTypeManifest:
-			f.manifests = append(f.manifests, fileNum)
+			f.manifests = append(f.manifests, fileNum.FileNum())
 		case base.FileTypeTable:
-			f.tables = append(f.tables, fileNum)
+			f.tables = append(f.tables, fileNum.FileNum())
 		default:
 			return
 		}
-		f.files[fileNum] = path
+		f.files[fileNum.FileNum()] = path
 	})
 
 	sort.Slice(f.logs, func(i, j int) bool {

--- a/tool/wal.go
+++ b/tool/wal.go
@@ -77,7 +77,7 @@ func (w *walT) runDump(cmd *cobra.Command, args []string) {
 			// anyways (which will likely fail when we try to read the file).
 			_, fileNum, ok := base.ParseFilename(w.opts.FS, arg)
 			if !ok {
-				fileNum = 0
+				fileNum = base.FileNum(0).DiskFileNum()
 			}
 
 			f, err := w.opts.FS.Open(arg)
@@ -91,7 +91,7 @@ func (w *walT) runDump(cmd *cobra.Command, args []string) {
 
 			var b pebble.Batch
 			var buf bytes.Buffer
-			rr := record.NewReader(f, fileNum)
+			rr := record.NewReader(f, fileNum.FileNum())
 			for {
 				offset := rr.Offset()
 				r, err := rr.Next()

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -147,7 +147,7 @@ func TestLatestRefCounting(t *testing.T) {
 	require.Equal(t, 2, int(m1.LatestRefs()))
 	require.Equal(t, 0, len(d.mu.versions.obsoleteTables))
 	require.Equal(t, 1, len(d.mu.versions.fileBackingMap))
-	_, ok := d.mu.versions.fileBackingMap[f.FileNum]
+	_, ok := d.mu.versions.fileBackingMap[f.FileBacking.DiskFileNum]
 	require.True(t, ok)
 	require.Equal(t, f.Size, m2.FileBacking.VirtualizedSize.Load())
 
@@ -168,7 +168,7 @@ func TestLatestRefCounting(t *testing.T) {
 	require.Equal(t, 0, len(d.mu.versions.zombieTables))
 	require.Equal(t, 0, len(d.mu.versions.obsoleteTables))
 	require.Equal(t, 1, len(d.mu.versions.fileBackingMap))
-	_, ok = d.mu.versions.fileBackingMap[f.FileNum]
+	_, ok = d.mu.versions.fileBackingMap[f.FileBacking.DiskFileNum]
 	require.True(t, ok)
 	require.Equal(t, m2.Size, m2.FileBacking.VirtualizedSize.Load())
 
@@ -185,7 +185,7 @@ func TestLatestRefCounting(t *testing.T) {
 	require.Equal(t, 0, len(d.mu.versions.zombieTables))
 	require.Equal(t, 0, len(d.mu.versions.obsoleteTables))
 	require.Equal(t, 1, len(d.mu.versions.fileBackingMap))
-	_, ok = d.mu.versions.fileBackingMap[f.FileNum]
+	_, ok = d.mu.versions.fileBackingMap[f.FileBacking.DiskFileNum]
 	require.True(t, ok)
 	require.Equal(t, m2.Size, m2.FileBacking.VirtualizedSize.Load())
 
@@ -199,9 +199,9 @@ func TestLatestRefCounting(t *testing.T) {
 	// All virtual sstables are gone.
 	require.Equal(t, 0, int(m2.LatestRefs()))
 	require.Equal(t, 1, len(d.mu.versions.zombieTables))
-	require.Equal(t, f.Size, d.mu.versions.zombieTables[f.FileNum])
+	require.Equal(t, f.Size, d.mu.versions.zombieTables[f.FileBacking.DiskFileNum])
 	require.Equal(t, 0, len(d.mu.versions.fileBackingMap))
-	_, ok = d.mu.versions.fileBackingMap[f.FileNum]
+	_, ok = d.mu.versions.fileBackingMap[f.FileBacking.DiskFileNum]
 	require.False(t, ok)
 	require.Equal(t, 0, int(m2.FileBacking.VirtualizedSize.Load()))
 


### PR DESCRIPTION
Create a DiskFileNum type for file numbers which actually exist
on disk. This helps ensure that we don't perform reads on virtual
sstable file numbers.