### PR TITLE
db: expose new metrics for compaction concurrency

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -555,6 +555,11 @@ type compaction struct {
 	logger    Logger
 	version   *version
 	stats     base.InternalIteratorStats
+	beganAt   time.Time
+	// versionEditApplied is set to true when a compaction has completed and the
+	// resulting version has been installed (if successful), but the compaction
+	// goroutine is still cleaning up (eg, deleting obsolete files).
+	versionEditApplied bool
 
 	score float64
 
@@ -683,7 +688,7 @@ func (c *compaction) makeInfo(jobID int) CompactionInfo {
 	return info
 }
 
-func newCompaction(pc *pickedCompaction, opts *Options) *compaction {
+func newCompaction(pc *pickedCompaction, opts *Options, beganAt time.Time) *compaction {
 	c := &compaction{
 		kind:              compactionKindDefault,
 		cmp:               pc.cmp,
@@ -696,6 +701,7 @@ func newCompaction(pc *pickedCompaction, opts *Options) *compaction {
 		largest:           pc.largest,
 		logger:            opts.Logger,
 		version:           pc.version,
+		beganAt:           beganAt,
 		maxOutputFileSize: pc.maxOutputFileSize,
 		maxOverlapBytes:   pc.maxOverlapBytes,
 		l0SublevelInfo:    pc.l0SublevelInfo,
@@ -727,7 +733,9 @@ func newCompaction(pc *pickedCompaction, opts *Options) *compaction {
 	return c
 }
 
-func newDeleteOnlyCompaction(opts *Options, cur *version, inputs []compactionLevel) *compaction {
+func newDeleteOnlyCompaction(
+	opts *Options, cur *version, inputs []compactionLevel, beganAt time.Time,
+) *compaction {
 	c := &compaction{
 		kind:      compactionKindDeleteOnly,
 		cmp:       opts.Comparer.Compare,
@@ -736,6 +744,7 @@ func newDeleteOnlyCompaction(opts *Options, cur *version, inputs []compactionLev
 		formatKey: opts.Comparer.FormatKey,
 		logger:    opts.Logger,
 		version:   cur,
+		beganAt:   beganAt,
 		inputs:    inputs,
 	}
 
@@ -815,7 +824,9 @@ func adjustGrandparentOverlapBytesForFlush(c *compaction, flushingBytes uint64) 
 	}
 }
 
-func newFlush(opts *Options, cur *version, baseLevel int, flushing flushableList) *compaction {
+func newFlush(
+	opts *Options, cur *version, baseLevel int, flushing flushableList, beganAt time.Time,
+) *compaction {
 	c := &compaction{
 		kind:              compactionKindFlush,
 		cmp:               opts.Comparer.Compare,
@@ -824,6 +835,7 @@ func newFlush(opts *Options, cur *version, baseLevel int, flushing flushableList
 		formatKey:         opts.Comparer.FormatKey,
 		logger:            opts.Logger,
 		version:           cur,
+		beganAt:           beganAt,
 		inputs:            []compactionLevel{{level: -1}, {level: 0}},
 		maxOutputFileSize: math.MaxUint64,
 		maxOverlapBytes:   math.MaxUint64,
@@ -1637,7 +1649,8 @@ func (d *DB) addInProgressCompaction(c *compaction) {
 //
 // DB.mu must be held when calling this method. All writes to the manifest for
 // this compaction should have completed by this point.
-func (d *DB) removeInProgressCompaction(c *compaction, rollback bool) {
+func (d *DB) clearCompactingState(c *compaction, rollback bool) {
+	c.versionEditApplied = true
 	for _, cl := range c.inputs {
 		iter := cl.files.Iter()
 		for f := iter.First(); f != nil; f = iter.Next() {
@@ -1661,8 +1674,6 @@ func (d *DB) removeInProgressCompaction(c *compaction, rollback bool) {
 			f.IsIntraL0Compacting = false
 		}
 	}
-	delete(d.mu.compact.inProgress, c)
-
 	l0InProgress := inProgressL0Compactions(d.getInProgressCompactionInfoLocked(c))
 	d.mu.versions.currentVersion().L0Sublevels.InitCompactingFileInfo(l0InProgress)
 }
@@ -1953,7 +1964,7 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 	}
 
 	c := newFlush(d.opts, d.mu.versions.currentVersion(),
-		d.mu.versions.picker.getBaseLevel(), d.mu.mem.queue[:n])
+		d.mu.versions.picker.getBaseLevel(), d.mu.mem.queue[:n], d.timeNow())
 	d.addInProgressCompaction(c)
 
 	jobID := d.mu.nextJobID
@@ -2057,7 +2068,8 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 	d.mu.snapshots.cumulativePinnedSize += stats.cumulativePinnedSize
 
 	d.maybeUpdateDeleteCompactionHints(c)
-	d.removeInProgressCompaction(c, err != nil)
+	d.clearCompactingState(c, err != nil)
+	delete(d.mu.compact.inProgress, c)
 	d.mu.versions.incrementCompactions(c.kind, c.extraLevels)
 	d.mu.versions.incrementCompactionBytes(-c.bytesWritten)
 
@@ -2182,7 +2194,7 @@ func (d *DB) maybeScheduleCompactionPicker(
 		d.mu.compact.deletionHints = unresolvedHints
 
 		if len(inputs) > 0 {
-			c := newDeleteOnlyCompaction(d.opts, v, inputs)
+			c := newDeleteOnlyCompaction(d.opts, v, inputs, d.timeNow())
 			d.mu.compact.compactingCount++
 			d.addInProgressCompaction(c)
 			go d.compact(c, nil)
@@ -2194,7 +2206,7 @@ func (d *DB) maybeScheduleCompactionPicker(
 		env.inProgressCompactions = d.getInProgressCompactionInfoLocked(nil)
 		pc, retryLater := d.mu.versions.picker.pickManual(env, manual)
 		if pc != nil {
-			c := newCompaction(pc, d.opts)
+			c := newCompaction(pc, d.opts, d.timeNow())
 			d.mu.compact.manual = d.mu.compact.manual[1:]
 			d.mu.compact.compactingCount++
 			d.addInProgressCompaction(c)
@@ -2221,7 +2233,7 @@ func (d *DB) maybeScheduleCompactionPicker(
 		if pc == nil {
 			break
 		}
-		c := newCompaction(pc, d.opts)
+		c := newCompaction(pc, d.opts, d.timeNow())
 		d.mu.compact.compactingCount++
 		d.addInProgressCompaction(c)
 		go d.compact(c, nil)
@@ -2511,6 +2523,13 @@ func (d *DB) compact(c *compaction, errChannel chan error) {
 			d.opts.EventListener.BackgroundError(err)
 		}
 		d.mu.compact.compactingCount--
+		delete(d.mu.compact.inProgress, c)
+		// Add this compaction's duration to the cumulative duration. NB: This
+		// must be atomic with the above removal of c from
+		// d.mu.compact.InProgress to ensure Metrics.Compact.Duration does not
+		// miss or double count a completing compaction's duration.
+		d.mu.compact.duration += d.timeNow().Sub(c.beganAt)
+
 		// The previous compaction may have produced too many files in a
 		// level, so reschedule another compaction if needed.
 		d.maybeScheduleCompaction()
@@ -2572,13 +2591,14 @@ func (d *DB) compact1(c *compaction, errChannel chan error) (err error) {
 
 	d.mu.snapshots.cumulativePinnedCount += stats.cumulativePinnedKeys
 	d.mu.snapshots.cumulativePinnedSize += stats.cumulativePinnedSize
-
 	d.maybeUpdateDeleteCompactionHints(c)
-	d.removeInProgressCompaction(c, err != nil)
+	// NB: clearing compacting state must occur before updating the read state;
+	// L0Sublevels initialization depends on it.
+	d.clearCompactingState(c, err != nil)
 	d.mu.versions.incrementCompactions(c.kind, c.extraLevels)
 	d.mu.versions.incrementCompactionBytes(-c.bytesWritten)
 
-	info.TotalDuration = d.timeNow().Sub(startTime)
+	info.TotalDuration = d.timeNow().Sub(c.beganAt)
 	d.opts.EventListener.CompactionEnd(info)
 
 	// Update the read state before deleting obsolete files because the

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -47,13 +47,17 @@ type readCompactionEnv struct {
 	flushing                 bool
 }
 
-// Information about in-progress compactions provided to the compaction picker. These are used to
-// constrain the new compactions that will be picked.
+// Information about in-progress compactions provided to the compaction picker.
+// These are used to constrain the new compactions that will be picked.
 type compactionInfo struct {
-	inputs      []compactionLevel
-	outputLevel int
-	smallest    InternalKey
-	largest     InternalKey
+	// versionEditApplied is true if this compaction's version edit has already
+	// been committed. The compaction may still be in-progress deleting newly
+	// obsolete files.
+	versionEditApplied bool
+	inputs             []compactionLevel
+	outputLevel        int
+	smallest           InternalKey
+	largest            InternalKey
 }
 
 func (info compactionInfo) String() string {

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
@@ -496,7 +497,7 @@ func TestCompactionPickerL0(t *testing.T) {
 			var result strings.Builder
 			if pc != nil {
 				checkClone(t, pc)
-				c := newCompaction(pc, opts)
+				c := newCompaction(pc, opts, time.Now())
 				fmt.Fprintf(&result, "L%d -> L%d\n", pc.startLevel.level, pc.outputLevel.level)
 				fmt.Fprintf(&result, "L%d: %s\n", pc.startLevel.level, fileNums(pc.startLevel.files))
 				if !pc.outputLevel.files.Empty() {
@@ -721,7 +722,7 @@ func TestCompactionPickerConcurrency(t *testing.T) {
 			})
 			var result strings.Builder
 			if pc != nil {
-				c := newCompaction(pc, opts)
+				c := newCompaction(pc, opts, time.Now())
 				fmt.Fprintf(&result, "L%d -> L%d\n", pc.startLevel.level, pc.outputLevel.level)
 				fmt.Fprintf(&result, "L%d: %s\n", pc.startLevel.level, fileNums(pc.startLevel.files))
 				if !pc.outputLevel.files.Empty() {

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -525,7 +525,7 @@ func TestPickCompaction(t *testing.T) {
 		vs.picker = &tc.picker
 		pc, got := vs.picker.pickAuto(compactionEnv{}), ""
 		if pc != nil {
-			c := newCompaction(pc, opts)
+			c := newCompaction(pc, opts, time.Now())
 			got0 := fileNums(c.startLevel.files)
 			got1 := fileNums(c.outputLevel.files)
 			got2 := fileNums(c.grandparents)
@@ -1836,7 +1836,7 @@ func TestCompactionOutputLevel(t *testing.T) {
 				d.ScanArgs(t, "start", &start)
 				d.ScanArgs(t, "base", &base)
 				pc := newPickedCompaction(opts, version, start, defaultOutputLevel(start, base), base)
-				c := newCompaction(pc, opts)
+				c := newCompaction(pc, opts, time.Now())
 				return fmt.Sprintf("output=%d\nmax-output-file-size=%d\n",
 					c.outputLevel.level, c.maxOutputFileSize)
 

--- a/data_test.go
+++ b/data_test.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
@@ -835,7 +836,7 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 			flushed:   make(chan struct{}),
 		}}
 		c := newFlush(d.opts, d.mu.versions.currentVersion(),
-			d.mu.versions.picker.getBaseLevel(), toFlush)
+			d.mu.versions.picker.getBaseLevel(), toFlush, time.Now())
 		c.disableSpanElision = true
 		// NB: define allows the test to exactly specify which keys go
 		// into which sstables. If the test has a small target file

--- a/db.go
+++ b/db.go
@@ -475,6 +475,9 @@ type DB struct {
 
 	// Normally equal to time.Now() but may be overridden in tests.
 	timeNow func() time.Time
+	// the time at database Open; may be used to compute metrics like effective
+	// compaction concurrency
+	openedAt time.Time
 }
 
 var _ Reader = (*DB)(nil)
@@ -1798,6 +1801,7 @@ func (d *DB) Metrics() *Metrics {
 	metrics.BlockCache = d.opts.Cache.Metrics()
 	metrics.TableCache, metrics.Filter = d.tableCache.metrics()
 	metrics.TableIters = int64(d.tableCache.iterCount())
+	metrics.Uptime = d.timeNow().Sub(d.openedAt)
 	return metrics
 }
 

--- a/db.go
+++ b/db.go
@@ -400,6 +400,10 @@ type DB struct {
 			// is at the start of the list. New entries are added to the end.
 			manual []*manualCompaction
 			// inProgress is the set of in-progress flushes and compactions.
+			// It's used in the calculation of some metrics and to initialize L0
+			// sublevels' state. Some of the compactions contained within this
+			// map may have already committed an edit to the version but are
+			// lingering performing cleanup, like deleting obsolete files.
 			inProgress map[*compaction]struct{}
 
 			// rescheduleReadCompaction indicates to an iterator that a read compaction
@@ -410,6 +414,9 @@ type DB struct {
 			// compactions which we might have to perform.
 			readCompactions readCompactionQueue
 
+			// The cumulative duration of all completed compactions since Open.
+			// Does not include flushes.
+			duration time.Duration
 			// Flush throughput metric.
 			flushWriteThroughput ThroughputMetric
 			// The idle start time for the flush "loop", i.e., when the flushing
@@ -1731,6 +1738,13 @@ func (d *DB) Metrics() *Metrics {
 	metrics.Compact.InProgressBytes = d.mu.versions.atomicInProgressBytes.Load()
 	metrics.Compact.NumInProgress = int64(d.mu.compact.compactingCount)
 	metrics.Compact.MarkedFiles = vers.Stats.MarkedForCompaction
+	metrics.Compact.Duration = d.mu.compact.duration
+	for c := range d.mu.compact.inProgress {
+		if c.kind != compactionKindFlush {
+			metrics.Compact.Duration += d.timeNow().Sub(c.beganAt)
+		}
+	}
+
 	for _, m := range d.mu.mem.queue {
 		metrics.MemTable.Size += m.totalBytes()
 	}
@@ -2319,10 +2333,11 @@ func (d *DB) getInProgressCompactionInfoLocked(finishing *compaction) (rv []comp
 	for c := range d.mu.compact.inProgress {
 		if len(c.flushing) == 0 && (finishing == nil || c != finishing) {
 			info := compactionInfo{
-				inputs:      c.inputs,
-				smallest:    c.smallest,
-				largest:     c.largest,
-				outputLevel: -1,
+				versionEditApplied: c.versionEditApplied,
+				inputs:             c.inputs,
+				smallest:           c.smallest,
+				largest:            c.largest,
+				outputLevel:        -1,
 			}
 			if c.outputLevel != nil {
 				info.outputLevel = c.outputLevel.level
@@ -2336,6 +2351,14 @@ func (d *DB) getInProgressCompactionInfoLocked(finishing *compaction) (rv []comp
 func inProgressL0Compactions(inProgress []compactionInfo) []manifest.L0Compaction {
 	var compactions []manifest.L0Compaction
 	for _, info := range inProgress {
+		// Skip in-progress compactions that have already committed; the L0
+		// sublevels initialization code requires the set of in-progress
+		// compactions to be consistent with the current version. Compactions
+		// with versionEditApplied=true are already applied to the current
+		// version and but are performing cleanup without the database mutex.
+		if info.versionEditApplied {
+			continue
+		}
 		l0 := false
 		for _, cl := range info.inputs {
 			l0 = l0 || cl.level == 0

--- a/metrics.go
+++ b/metrics.go
@@ -256,6 +256,8 @@ type Metrics struct {
 
 	// Count of the number of open sstable iterators.
 	TableIters int64
+	// Uptime is the total time since this DB was opened.
+	Uptime time.Duration
 
 	WAL struct {
 		// Number of live WAL files.

--- a/metrics.go
+++ b/metrics.go
@@ -179,6 +179,9 @@ type Metrics struct {
 		// compaction. Such files are compacted in a rewrite compaction
 		// when no other compactions are picked.
 		MarkedFiles int
+		// Duration records the cumulative duration of all compactions since the
+		// database was opened.
+		Duration time.Duration
 	}
 
 	Flush struct {

--- a/open.go
+++ b/open.go
@@ -230,6 +230,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	d.mu.formatVers.marker = formatVersionMarker
 
 	d.timeNow = time.Now
+	d.openedAt = d.timeNow()
 
 	d.mu.Lock()
 	defer d.mu.Unlock()

--- a/open.go
+++ b/open.go
@@ -726,7 +726,7 @@ func (d *DB) replayWAL(
 		// TODO(bananabrick): See if we can use the actual base level here,
 		// instead of using 1.
 		c := newFlush(d.opts, d.mu.versions.currentVersion(),
-			1 /* base level */, toFlush)
+			1 /* base level */, toFlush, d.timeNow())
 		newVE, _, _, err := d.runCompaction(jobID, c)
 		if err != nil {
 			return errors.Wrapf(err, "running compaction during WAL replay")
@@ -855,6 +855,7 @@ func (d *DB) replayWAL(
 						d.opts, d.mu.versions.currentVersion(),
 						1, /* base level */
 						[]*flushableEntry{entry},
+						d.timeNow(),
 					)
 					for _, file := range c.flushing[0].flushable.(*ingestedFlushable).files {
 						ve.NewFiles = append(ve.NewFiles, newFileEntry{Level: 0, Meta: file.FileMetadata})

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -162,7 +162,7 @@ close: db/marker.manifest.000004.MANIFEST-000011
 remove: db/marker.manifest.000003.MANIFEST-000009
 sync: db
 [JOB 8] MANIFEST created 000011
-[JOB 8] compacted(default) L0 [000005 000008] (1.5 K) + L6 [] (0 B) -> L6 [000010] (770 B), in 1.0s (2.0s total), output rate 770 B/s
+[JOB 8] compacted(default) L0 [000005 000008] (1.5 K) + L6 [] (0 B) -> L6 [000010] (770 B), in 1.0s (3.0s total), output rate 770 B/s
 remove: db/000005.sst
 [JOB 8] sstable deleted 000005
 remove: db/000008.sst


### PR DESCRIPTION
Compute and calculate two new metrics, `Uptime` and `Compact.Duration` which together may be used to compute the effective compaction concurrency over an interval.

**db: add Uptime metric**

Add a new Metric recording the database's uptime since Open. This can be used
in combination with other metrics to integrate over time.

**db: add Compact.Duration metric**

Add a new Compact.Duration metric that measures the cumulative time spent in
compactions since Open. This may be used in combination with Metrics.Uptime to
compute the effective compaction concurrency (https://github.com/cockroachdb/pebble/issues/1934). Callers may compute
effective compaction concurrency over an interval by measuring both Uptime and
Compact.Duration at the beginning and end of the interval and subtracting.

Close #1934.