### PR TITLE
*: reserve sequence numbers for foreign keys

### DIFF
--- a/compaction_iter.go
+++ b/compaction_iter.go
@@ -957,7 +957,7 @@ func (i *compactionIter) maybeZeroSeqnum(snapshotIdx int) {
 		// This is not the last snapshot
 		return
 	}
-	i.key.SetSeqNum(0)
+	i.key.SetSeqNum(base.SeqNumZero)
 }
 
 // A frontier is used to monitor a compaction's progression across the user

--- a/db_test.go
+++ b/db_test.go
@@ -417,13 +417,13 @@ func TestLargeBatch(t *testing.T) {
 
 	// Verify this results in one L0 table being created.
 	require.NoError(t, try(100*time.Microsecond, 20*time.Second,
-		verifyLSM("0.0:\n  000005:[a#1,SET-a#1,SET]\n")))
+		verifyLSM("0.0:\n  000005:[a#10,SET-a#10,SET]\n")))
 
 	require.NoError(t, d.Set([]byte("b"), bytes.Repeat([]byte("b"), 512), nil))
 
 	// Verify this results in a second L0 table being created.
 	require.NoError(t, try(100*time.Microsecond, 20*time.Second,
-		verifyLSM("0.0:\n  000005:[a#1,SET-a#1,SET]\n  000007:[b#2,SET-b#2,SET]\n")))
+		verifyLSM("0.0:\n  000005:[a#10,SET-a#10,SET]\n  000007:[b#11,SET-b#11,SET]\n")))
 
 	// Allocate a bunch of batches to exhaust the batchPool. None of these
 	// batches should have a non-zero count.

--- a/error_test.go
+++ b/error_test.go
@@ -188,16 +188,16 @@ func TestRequireReadError(t *testing.T) {
 		if formatVersion < FormatSetWithDelete {
 			expectLSM(`
 0.0:
-  000007:[a1#4,SET-a2#inf,RANGEDEL]
+  000007:[a1#13,SET-a2#inf,RANGEDEL]
 6:
-  000005:[a1#1,SET-a2#2,SET]
+  000005:[a1#10,SET-a2#11,SET]
 `, d, t)
 		} else {
 			expectLSM(`
 0.0:
-  000007:[a1#4,SETWITHDEL-a2#inf,RANGEDEL]
+  000007:[a1#13,SETWITHDEL-a2#inf,RANGEDEL]
 6:
-  000005:[a1#1,SET-a2#2,SET]
+  000005:[a1#10,SET-a2#11,SET]
 `, d, t)
 		}
 
@@ -291,17 +291,17 @@ func TestCorruptReadError(t *testing.T) {
 		if formatVersion < FormatSetWithDelete {
 			expectLSM(`
 0.0:
-  000007:[a1#4,SET-a2#inf,RANGEDEL]
+  000007:[a1#13,SET-a2#inf,RANGEDEL]
 6:
-  000005:[a1#1,SET-a2#2,SET]
+  000005:[a1#10,SET-a2#11,SET]
 `, d, t)
 
 		} else {
 			expectLSM(`
 0.0:
-  000007:[a1#4,SETWITHDEL-a2#inf,RANGEDEL]
+  000007:[a1#13,SETWITHDEL-a2#inf,RANGEDEL]
 6:
-  000005:[a1#1,SET-a2#2,SET]
+  000005:[a1#10,SET-a2#11,SET]
 `, d, t)
 		}
 

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1159,11 +1159,11 @@ func TestConcurrentIngestCompact(t *testing.T) {
 
 			expectLSM(`
 0.0:
-  000005:[a#2,SET-a#2,SET]
-  000007:[c#4,SET-c#4,SET]
+  000005:[a#11,SET-a#11,SET]
+  000007:[c#13,SET-c#13,SET]
 6:
-  000004:[a#1,SET-a#1,SET]
-  000006:[c#3,SET-c#3,SET]
+  000004:[a#10,SET-a#10,SET]
+  000006:[c#12,SET-c#12,SET]
 `)
 
 			// At this point ingestion of an sstable containing only key "b" will be
@@ -1186,7 +1186,7 @@ func TestConcurrentIngestCompact(t *testing.T) {
 
 				expectLSM(`
 0.0:
-  000009:[b#5,SET-b#5,SET]
+  000009:[b#14,SET-b#14,SET]
 6:
   000008:[a#0,SET-c#0,SET]
 `)

--- a/internal/base/seqnums.go
+++ b/internal/base/seqnums.go
@@ -1,0 +1,54 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package base
+
+// This file defines sequence numbers that are reserved for foreign keys i.e.
+// internal keys coming from other Pebble instances and existing in shared
+// storage, as those will "slot below" any internal keys added by our own Pebble
+// instance. Any keys created by this Pebble instance need to be greater than
+// all reserved sequence numbers (i.e. >= SeqNumStart).
+const (
+	// SeqNumZero is the zero sequence number, set by compactions if they can
+	// guarantee there are no keys underneath an internal key.
+	SeqNumZero = uint64(0)
+
+	// SeqNumL6Point is the sequence number reserved for foreign point keys in L6.
+	// This sequence number must be lower than SeqNumL6RangeKey for range key
+	// masking to work correctly.
+	SeqNumL6Point = uint64(1)
+
+	// SeqNumL6RangeKey is the sequence number reserved for foreign range keys in
+	// L6. Only RangeKeySets are expected at this level.
+	SeqNumL6RangeKey = uint64(2)
+
+	// SeqNumL5RangeDel is the sequence number reserved for foreign range deletes
+	// in L5. These keys could delete L6 points.
+	SeqNumL5RangeDel = uint64(3)
+
+	// SeqNumL5Point is the sequence number reserved for foreign point keys in L5.
+	// Any sst-local range deletions would have already been applied to these keys,
+	// so they can safely get a sequence number higher than SeqNumL5RangeDel.
+	// However they must have a sequence number lower than SeqNumL5RangeKey* for
+	// range key masking to work correctly.
+	SeqNumL5Point = uint64(4)
+
+	// SeqNumL5RangeKeyUnsetDel is the sequence number reserved for foreign
+	// range key unsets/deletes in L5. These operations could apply to L6
+	// RangeKeySets, so this sequence number must be > SeqNumL6RangeKey.
+	SeqNumL5RangeKeyUnsetDel = uint64(5)
+
+	// SeqNumL5RangeKeySet is the sequence number reserved for foreign range key
+	// Sets in L5. These operations could apply to L6 RangeKeySets, so this
+	// sequence number must be > SeqNumL6RangeKey. Any SST-local rangekey
+	// unsets/dels have already been applied to them, so their sequence number must
+	// be > SeqNumL5RangeKeyUnsetDel.
+	SeqNumL5RangeKeySet = uint64(6)
+
+	// Sequence numbers 7-9 are reserved for future use.
+
+	// SeqNumStart is the first sequence number assigned to a key written by
+	// ourselves.
+	SeqNumStart = uint64(10)
+)

--- a/internal/metamorphic/ops.go
+++ b/internal/metamorphic/ops.go
@@ -478,7 +478,7 @@ func (o *ingestOp) build(t *test, h historyRecorder, b *pebble.Batch, i int) (st
 		// batch which doesn't do prefix compression.
 		lastUserKey = key.UserKey
 
-		key.SetSeqNum(0)
+		key.SetSeqNum(base.SeqNumZero)
 		if err := w.Add(*key, value.InPlaceValue()); err != nil {
 			return "", err
 		}

--- a/open.go
+++ b/open.go
@@ -211,8 +211,9 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	d.mu.compact.noOngoingFlushStartTime = time.Now()
 	d.mu.snapshots.init()
 	// logSeqNum is the next sequence number that will be assigned. Start
-	// assigning sequence numbers from 1 to match rocksdb.
-	d.mu.versions.logSeqNum.Store(1)
+	// assigning sequence numbers from base.SeqNumStart to leave room for reserved
+	// sequence numbers (see comments around SeqNumStart).
+	d.mu.versions.logSeqNum.Store(base.SeqNumStart)
 	d.mu.formatVers.vers = formatVersion
 	d.mu.formatVers.marker = formatVersionMarker
 

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -314,17 +314,17 @@ func TestRangeDelCompactionTruncation(t *testing.T) {
 		require.NoError(t, d.Compact([]byte("c"), []byte("c\x00"), false))
 		expectLSM(`
 1:
-  000008:[a#3,RANGEDEL-b#inf,RANGEDEL]
-  000009:[b#3,RANGEDEL-d#inf,RANGEDEL]
+  000008:[a#12,RANGEDEL-b#inf,RANGEDEL]
+  000009:[b#12,RANGEDEL-d#inf,RANGEDEL]
 `)
 
 		// Compact again to move one of the tables to L2.
 		require.NoError(t, d.Compact([]byte("c"), []byte("c\x00"), false))
 		expectLSM(`
 1:
-  000008:[a#3,RANGEDEL-b#inf,RANGEDEL]
+  000008:[a#12,RANGEDEL-b#inf,RANGEDEL]
 2:
-  000009:[b#3,RANGEDEL-d#inf,RANGEDEL]
+  000009:[b#12,RANGEDEL-d#inf,RANGEDEL]
 `)
 
 		// Write "b" and "c" to a new table.
@@ -333,11 +333,11 @@ func TestRangeDelCompactionTruncation(t *testing.T) {
 		require.NoError(t, d.Flush())
 		expectLSM(`
 0.0:
-  000011:[b#4,SET-c#5,SET]
+  000011:[b#13,SET-c#14,SET]
 1:
-  000008:[a#3,RANGEDEL-b#inf,RANGEDEL]
+  000008:[a#12,RANGEDEL-b#inf,RANGEDEL]
 2:
-  000009:[b#3,RANGEDEL-d#inf,RANGEDEL]
+  000009:[b#12,RANGEDEL-d#inf,RANGEDEL]
 `)
 
 		// "b" is still visible at this point as it should be.
@@ -372,20 +372,20 @@ func TestRangeDelCompactionTruncation(t *testing.T) {
 		if formatVersion < FormatSetWithDelete {
 			expectLSM(`
 1:
-  000008:[a#3,RANGEDEL-b#inf,RANGEDEL]
+  000008:[a#12,RANGEDEL-b#inf,RANGEDEL]
 2:
-  000012:[b#4,SET-c#inf,RANGEDEL]
+  000012:[b#13,SET-c#inf,RANGEDEL]
 3:
-  000013:[c#5,SET-d#inf,RANGEDEL]
+  000013:[c#14,SET-d#inf,RANGEDEL]
 `)
 		} else {
 			expectLSM(`
 1:
-  000008:[a#3,RANGEDEL-b#inf,RANGEDEL]
+  000008:[a#12,RANGEDEL-b#inf,RANGEDEL]
 2:
-  000012:[b#4,SETWITHDEL-c#inf,RANGEDEL]
+  000012:[b#13,SETWITHDEL-c#inf,RANGEDEL]
 3:
-  000013:[c#5,SET-d#inf,RANGEDEL]
+  000013:[c#14,SET-d#inf,RANGEDEL]
 `)
 		}
 
@@ -464,15 +464,15 @@ func TestRangeDelCompactionTruncation2(t *testing.T) {
 	require.NoError(t, d.Compact([]byte("b"), []byte("b\x00"), false))
 	expectLSM(`
 6:
-  000009:[a#3,RANGEDEL-d#inf,RANGEDEL]
+  000009:[a#12,RANGEDEL-d#inf,RANGEDEL]
 `)
 
 	require.NoError(t, d.Set([]byte("c"), bytes.Repeat([]byte("d"), 100), nil))
 	require.NoError(t, d.Compact([]byte("c"), []byte("c\x00"), false))
 	expectLSM(`
 6:
-  000012:[a#3,RANGEDEL-c#inf,RANGEDEL]
-  000013:[c#4,SET-d#inf,RANGEDEL]
+  000012:[a#12,RANGEDEL-c#inf,RANGEDEL]
+  000013:[c#13,SET-d#inf,RANGEDEL]
 `)
 }
 
@@ -538,7 +538,7 @@ func TestRangeDelCompactionTruncation3(t *testing.T) {
 	}
 	expectLSM(`
 3:
-  000009:[a#3,RANGEDEL-d#inf,RANGEDEL]
+  000009:[a#12,RANGEDEL-d#inf,RANGEDEL]
 `)
 
 	require.NoError(t, d.Set([]byte("c"), bytes.Repeat([]byte("d"), 100), nil))
@@ -546,17 +546,17 @@ func TestRangeDelCompactionTruncation3(t *testing.T) {
 	require.NoError(t, d.Compact([]byte("c"), []byte("c\x00"), false))
 	expectLSM(`
 3:
-  000013:[a#3,RANGEDEL-c#inf,RANGEDEL]
+  000013:[a#12,RANGEDEL-c#inf,RANGEDEL]
 4:
-  000014:[c#4,SET-d#inf,RANGEDEL]
+  000014:[c#13,SET-d#inf,RANGEDEL]
 `)
 
 	require.NoError(t, d.Compact([]byte("c"), []byte("c\x00"), false))
 	expectLSM(`
 3:
-  000013:[a#3,RANGEDEL-c#inf,RANGEDEL]
+  000013:[a#12,RANGEDEL-c#inf,RANGEDEL]
 5:
-  000014:[c#4,SET-d#inf,RANGEDEL]
+  000014:[c#13,SET-d#inf,RANGEDEL]
 `)
 
 	if _, _, err := d.Get([]byte("b")); err != ErrNotFound {
@@ -566,9 +566,9 @@ func TestRangeDelCompactionTruncation3(t *testing.T) {
 	require.NoError(t, d.Compact([]byte("a"), []byte("a\x00"), false))
 	expectLSM(`
 4:
-  000013:[a#3,RANGEDEL-c#inf,RANGEDEL]
+  000013:[a#12,RANGEDEL-c#inf,RANGEDEL]
 5:
-  000014:[c#4,SET-d#inf,RANGEDEL]
+  000014:[c#13,SET-d#inf,RANGEDEL]
 `)
 
 	if v, _, err := d.Get([]byte("b")); err != ErrNotFound {

--- a/replay/testdata/corpus/simple
+++ b/replay/testdata/corpus/simple
@@ -80,7 +80,7 @@ simple:
 stat simple/MANIFEST-000001 simple/MANIFEST-000008 simple/000007.sst
 ----
 simple/MANIFEST-000001:
-  size: 96
+  size: 98
 simple/MANIFEST-000008:
   size: 122
 simple/000007.sst:

--- a/replay/testdata/replay
+++ b/replay/testdata/replay
@@ -11,19 +11,19 @@ tree
      823      000007.sst
       16      CURRENT
        0      LOCK
-      96      MANIFEST-000001
+      98      MANIFEST-000001
      122      MANIFEST-000008
     1171      OPTIONS-000003
        0      marker.format-version.000007.008
        0      marker.manifest.000002.MANIFEST-000008
             simple/
      823      000007.sst
-      96      MANIFEST-000001
+      98      MANIFEST-000001
      122      MANIFEST-000008
               checkpoint/
       25        000004.log
      795        000005.sst
-      96        MANIFEST-000001
+      98        MANIFEST-000001
     1171        OPTIONS-000003
        0        marker.format-version.000001.008
        0        marker.manifest.000001.MANIFEST-000001

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -391,23 +391,23 @@ OK
 describe-lsm
 ----
 0.0:
-  000013:[a#10,RANGEDEL-z#inf,RANGEKEYDEL]
+  000013:[a#19,RANGEDEL-z#inf,RANGEKEYDEL]
 6:
-  000004:[a#1,RANGEKEYSET-c#1,SET]
-  000005:[d#2,RANGEKEYSET-f#inf,RANGEKEYSET]
-  000006:[g#3,SET-h#3,SET]
-  000007:[i#4,RANGEKEYSET-k#4,SET]
-  000008:[l#5,RANGEKEYSET-n#inf,RANGEKEYSET]
-  000009:[o#6,SET-q#6,SET]
-  000010:[r#7,RANGEKEYSET-t#7,SET]
-  000011:[u#8,RANGEKEYSET-w#inf,RANGEKEYSET]
-  000012:[x#9,SET-z#9,SET]
+  000004:[a#10,RANGEKEYSET-c#10,SET]
+  000005:[d#11,RANGEKEYSET-f#inf,RANGEKEYSET]
+  000006:[g#12,SET-h#12,SET]
+  000007:[i#13,RANGEKEYSET-k#13,SET]
+  000008:[l#14,RANGEKEYSET-n#inf,RANGEKEYSET]
+  000009:[o#15,SET-q#15,SET]
+  000010:[r#16,RANGEKEYSET-t#16,SET]
+  000011:[u#17,RANGEKEYSET-w#inf,RANGEKEYSET]
+  000012:[x#18,SET-z#18,SET]
 
 get-hints
 ----
-L0.000013 a-i seqnums(tombstone=10-10, file-smallest=3, type=point-key-only)
-L0.000013 i-r seqnums(tombstone=10-10, file-smallest=4, type=point-and-range-key)
-L0.000013 r-z seqnums(tombstone=10-10, file-smallest=8, type=range-key-only)
+L0.000013 a-i seqnums(tombstone=19-19, file-smallest=12, type=point-key-only)
+L0.000013 i-r seqnums(tombstone=19-19, file-smallest=13, type=point-and-range-key)
+L0.000013 r-z seqnums(tombstone=19-19, file-smallest=17, type=range-key-only)
 
 maybe-compact
 ----

--- a/testdata/flushable_ingest
+++ b/testdata/flushable_ingest
@@ -93,11 +93,11 @@ open
 lsm
 ----
 0.1:
-  000004:[a#2,SET-a#2,SET]
+  000004:[a#11,SET-a#11,SET]
 0.0:
-  000009:[a#1,SET-a#1,SET]
-  000005:[b#3,SET-b#3,SET]
-  000006:[d#4,SET-d#4,SET]
+  000009:[a#10,SET-a#10,SET]
+  000005:[b#12,SET-b#12,SET]
+  000006:[d#13,SET-d#13,SET]
 
 get
 a
@@ -135,12 +135,12 @@ ingest ext1 ext2 ext3
 lsm
 ----
 0.1:
-  000004:[a#2,SET-a#2,SET]
+  000004:[a#11,SET-a#11,SET]
 0.0:
-  000009:[a#1,SET-a#1,SET]
+  000009:[a#10,SET-a#10,SET]
 6:
-  000005:[b#3,SET-b#3,SET]
-  000006:[d#4,SET-d#4,SET]
+  000005:[b#12,SET-b#12,SET]
+  000006:[d#13,SET-d#13,SET]
 
 reset
 ----
@@ -210,12 +210,12 @@ flush
 lsm
 ----
 0.2:
-  000007:[a#4,SET-a#4,SET]
+  000007:[a#13,SET-a#13,SET]
 0.1:
-  000004:[a#2,SET-a#2,SET]
+  000004:[a#11,SET-a#11,SET]
 0.0:
-  000010:[a#1,SET-a#1,SET]
-  000011:[b#3,SET-b#3,SET]
+  000010:[a#10,SET-a#10,SET]
+  000011:[b#12,SET-b#12,SET]
 
 # Value of a should be the value of a in the second ingested SST.
 get
@@ -249,8 +249,8 @@ ingest ext1 ext2
 lsm
 ----
 6:
-  000004:[b#2,SET-b#2,SET]
-  000005:[d#3,SET-d#3,SET]
+  000004:[b#11,SET-b#11,SET]
+  000005:[d#12,SET-d#12,SET]
 
 
 # Verify target level of ingestedFlushable.
@@ -279,12 +279,12 @@ ingest ext1 ext2 ext3
 lsm
 ----
 0.1:
-  000004:[a#2,SET-a#2,SET]
+  000004:[a#11,SET-a#11,SET]
 0.0:
-  000009:[a#1,SET-a#1,SET]
+  000009:[a#10,SET-a#10,SET]
 6:
-  000005:[b#3,SET-b#3,SET]
-  000006:[d#4,SET-d#4,SET]
+  000005:[b#12,SET-b#12,SET]
+  000006:[d#13,SET-d#13,SET]
 
 
 batch
@@ -308,17 +308,17 @@ ingest ext4 ext5
 lsm
 ----
 0.3:
-  000010:[a#6,SET-a#6,SET]
+  000010:[a#15,SET-a#15,SET]
 0.2:
-  000014:[a#5,SET-a#5,SET]
+  000014:[a#14,SET-a#14,SET]
 0.1:
-  000004:[a#2,SET-a#2,SET]
+  000004:[a#11,SET-a#11,SET]
 0.0:
-  000009:[a#1,SET-a#1,SET]
-  000011:[b#7,SET-b#7,SET]
+  000009:[a#10,SET-a#10,SET]
+  000011:[b#16,SET-b#16,SET]
 6:
-  000005:[b#3,SET-b#3,SET]
-  000006:[d#4,SET-d#4,SET]
+  000005:[b#12,SET-b#12,SET]
+  000006:[d#13,SET-d#13,SET]
 
 # Testing whether the new mutable memtable with data is flushed correctly during
 # WAL replay.
@@ -423,12 +423,12 @@ open
 lsm
 ----
 0.1:
-  000004:[a#2,SET-a#2,SET]
+  000004:[a#11,SET-a#11,SET]
 0.0:
-  000009:[a#1,SET-a#1,SET]
-  000005:[b#3,SET-b#3,SET]
-  000006:[d#4,SET-d#4,SET]
-  000010:[f#5,SET-f#5,SET]
+  000009:[a#10,SET-a#10,SET]
+  000005:[b#12,SET-b#12,SET]
+  000006:[d#13,SET-d#13,SET]
+  000010:[f#14,SET-f#14,SET]
 
 # Check if the new mutable memtable is using a new log file, and that the
 # previous log files have been deleted appropriately after the flush.
@@ -574,9 +574,9 @@ flush
 lsm
 ----
 0.1:
-  000004:[a#3,SET-b#3,SET]
+  000004:[a#12,SET-b#12,SET]
 0.0:
-  000007:[a#1,SET-b#2,SET]
+  000007:[a#10,SET-b#11,SET]
 
 ls
 ----
@@ -622,6 +622,6 @@ open
 lsm
 ----
 0.1:
-  000004:[a#3,SET-b#3,SET]
+  000004:[a#12,SET-b#12,SET]
 0.0:
-  000007:[a#1,SET-b#2,SET]
+  000007:[a#10,SET-b#11,SET]

--- a/testdata/format_major_version_pebblev1_migration
+++ b/testdata/format_major_version_pebblev1_migration
@@ -56,12 +56,12 @@ set leveldb leveldb
 lsm
 ----
 0.0:
-  000005:[a#1,SET-a#1,SET]
+  000005:[a#10,SET-a#10,SET]
 6:
-  000009:[leveldb#5,SET-leveldb#5,SET]
-  000007:[pebblev1#3,SET-pebblev1#3,SET]
-  000006:[pebblev2#2,SET-pebblev2#2,SET]
-  000008:[rocksdbv2#4,SET-rocksdbv2#4,SET]
+  000009:[leveldb#14,SET-leveldb#14,SET]
+  000007:[pebblev1#12,SET-pebblev1#12,SET]
+  000006:[pebblev2#11,SET-pebblev2#11,SET]
+  000008:[rocksdbv2#13,SET-rocksdbv2#13,SET]
 
 tally-table-formats
 ----
@@ -150,11 +150,11 @@ marked-file-count
 lsm
 ----
 0.0:
-  000005:[a#1,SET-a#1,SET]
+  000005:[a#10,SET-a#10,SET]
 6:
   000013:[leveldb#0,SET-leveldb#0,SET]
-  000007:[pebblev1#3,SET-pebblev1#3,SET]
-  000006:[pebblev2#2,SET-pebblev2#2,SET]
+  000007:[pebblev1#12,SET-pebblev1#12,SET]
+  000006:[pebblev2#11,SET-pebblev2#11,SET]
   000012:[rocksdbv2#0,SET-rocksdbv2#0,SET]
 
 # Confirm all tables are at least the minimum supported table format version.

--- a/testdata/format_major_version_split_user_key_migration
+++ b/testdata/format_major_version_split_user_key_migration
@@ -107,10 +107,10 @@ set x x
 force-ingest paths=(ab, wx) level=1
 ----
 1:
-  000007:[a#6,SET-b#6,SET] points:[a#6,SET-b#6,SET]
+  000007:[a#10,SET-b#10,SET] points:[a#10,SET-b#10,SET]
   000004:[b#0,SET-c#5,SET] points:[b#0,SET-c#5,SET]
   000005:[l#5,SET-m#0,SET] points:[l#5,SET-m#0,SET]
-  000008:[w#7,SET-x#7,SET] points:[w#7,SET-x#7,SET]
+  000008:[w#11,SET-x#11,SET] points:[w#11,SET-x#11,SET]
   000006:[x#0,SET-y#5,SET] points:[x#0,SET-y#5,SET]
 
 format-major-version

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -27,7 +27,7 @@ ingest ext0
 lsm
 ----
 6:
-  000006:[a#1,SET-b#1,SET]
+  000006:[a#10,SET-b#10,SET]
 
 metrics
 ----
@@ -89,9 +89,9 @@ ingest ext1
 lsm
 ----
 0.0:
-  000007:[a#2,SET-b#2,DEL]
+  000007:[a#11,SET-b#11,DEL]
 6:
-  000006:[a#1,SET-b#1,SET]
+  000006:[a#10,SET-b#10,SET]
 
 iter
 seek-ge a
@@ -119,11 +119,11 @@ ingest ext2
 lsm
 ----
 0.1:
-  000008:[a#3,SET-c#3,SET]
+  000008:[a#12,SET-c#12,SET]
 0.0:
-  000007:[a#2,SET-b#2,DEL]
+  000007:[a#11,SET-b#11,DEL]
 6:
-  000006:[a#1,SET-b#1,SET]
+  000006:[a#10,SET-b#10,SET]
 
 iter
 seek-ge a
@@ -154,13 +154,13 @@ ingest ext3
 lsm
 ----
 0.2:
-  000009:[b#4,MERGE-c#4,DEL]
+  000009:[b#13,MERGE-c#13,DEL]
 0.1:
-  000008:[a#3,SET-c#3,SET]
+  000008:[a#12,SET-c#12,SET]
 0.0:
-  000007:[a#2,SET-b#2,DEL]
+  000007:[a#11,SET-b#11,DEL]
 6:
-  000006:[a#1,SET-b#1,SET]
+  000006:[a#10,SET-b#10,SET]
 
 iter
 seek-ge a
@@ -191,14 +191,14 @@ ingest ext4
 lsm
 ----
 0.2:
-  000009:[b#4,MERGE-c#4,DEL]
+  000009:[b#13,MERGE-c#13,DEL]
 0.1:
-  000008:[a#3,SET-c#3,SET]
+  000008:[a#12,SET-c#12,SET]
 0.0:
-  000007:[a#2,SET-b#2,DEL]
+  000007:[a#11,SET-b#11,DEL]
 6:
-  000006:[a#1,SET-b#1,SET]
-  000010:[x#5,SET-y#5,SET]
+  000006:[a#10,SET-b#10,SET]
+  000010:[x#14,SET-y#14,SET]
 
 iter
 seek-lt y
@@ -234,16 +234,16 @@ memtable flushed
 lsm
 ----
 0.2:
-  000009:[b#4,MERGE-c#4,DEL]
+  000009:[b#13,MERGE-c#13,DEL]
 0.1:
-  000008:[a#3,SET-c#3,SET]
-  000011:[k#8,SET-k#8,SET]
+  000008:[a#12,SET-c#12,SET]
+  000011:[k#17,SET-k#17,SET]
 0.0:
-  000007:[a#2,SET-b#2,DEL]
-  000014:[j#6,SET-k#7,SET]
+  000007:[a#11,SET-b#11,DEL]
+  000014:[j#15,SET-k#16,SET]
 6:
-  000006:[a#1,SET-b#1,SET]
-  000010:[x#5,SET-y#5,SET]
+  000006:[a#10,SET-b#10,SET]
+  000010:[x#14,SET-y#14,SET]
 
 iter
 seek-ge j
@@ -275,17 +275,17 @@ ingest ext6
 lsm
 ----
 0.2:
-  000009:[b#4,MERGE-c#4,DEL]
+  000009:[b#13,MERGE-c#13,DEL]
 0.1:
-  000008:[a#3,SET-c#3,SET]
-  000011:[k#8,SET-k#8,SET]
+  000008:[a#12,SET-c#12,SET]
+  000011:[k#17,SET-k#17,SET]
 0.0:
-  000007:[a#2,SET-b#2,DEL]
-  000014:[j#6,SET-k#7,SET]
+  000007:[a#11,SET-b#11,DEL]
+  000014:[j#15,SET-k#16,SET]
 6:
-  000006:[a#1,SET-b#1,SET]
-  000015:[n#10,SET-n#10,SET]
-  000010:[x#5,SET-y#5,SET]
+  000006:[a#10,SET-b#10,SET]
+  000015:[n#19,SET-n#19,SET]
+  000010:[x#14,SET-y#14,SET]
 
 get
 m
@@ -306,20 +306,20 @@ memtable flushed
 lsm
 ----
 0.3:
-  000016:[a#11,RANGEDEL-z#inf,RANGEDEL]
+  000016:[a#20,RANGEDEL-z#inf,RANGEDEL]
 0.2:
-  000009:[b#4,MERGE-c#4,DEL]
+  000009:[b#13,MERGE-c#13,DEL]
 0.1:
-  000008:[a#3,SET-c#3,SET]
-  000011:[k#8,SET-k#8,SET]
+  000008:[a#12,SET-c#12,SET]
+  000011:[k#17,SET-k#17,SET]
 0.0:
-  000007:[a#2,SET-b#2,DEL]
-  000014:[j#6,SET-k#7,SET]
-  000019:[m#9,SET-m#9,SET]
+  000007:[a#11,SET-b#11,DEL]
+  000014:[j#15,SET-k#16,SET]
+  000019:[m#18,SET-m#18,SET]
 6:
-  000006:[a#1,SET-b#1,SET]
-  000015:[n#10,SET-n#10,SET]
-  000010:[x#5,SET-y#5,SET]
+  000006:[a#10,SET-b#10,SET]
+  000015:[n#19,SET-n#19,SET]
+  000010:[x#14,SET-y#14,SET]
 
 get
 a
@@ -384,23 +384,23 @@ ingest ext9
 lsm
 ----
 0.4:
-  000021:[a#13,SET-g#13,SET]
-  000020:[j#12,RANGEDEL-m#12,SET]
+  000021:[a#22,SET-g#22,SET]
+  000020:[j#21,RANGEDEL-m#21,SET]
 0.3:
-  000016:[a#11,RANGEDEL-z#inf,RANGEDEL]
+  000016:[a#20,RANGEDEL-z#inf,RANGEDEL]
 0.2:
-  000009:[b#4,MERGE-c#4,DEL]
+  000009:[b#13,MERGE-c#13,DEL]
 0.1:
-  000008:[a#3,SET-c#3,SET]
-  000011:[k#8,SET-k#8,SET]
+  000008:[a#12,SET-c#12,SET]
+  000011:[k#17,SET-k#17,SET]
 0.0:
-  000007:[a#2,SET-b#2,DEL]
-  000014:[j#6,SET-k#7,SET]
-  000019:[m#9,SET-m#9,SET]
+  000007:[a#11,SET-b#11,DEL]
+  000014:[j#15,SET-k#16,SET]
+  000019:[m#18,SET-m#18,SET]
 6:
-  000006:[a#1,SET-b#1,SET]
-  000015:[n#10,SET-n#10,SET]
-  000010:[x#5,SET-y#5,SET]
+  000006:[a#10,SET-b#10,SET]
+  000015:[n#19,SET-n#19,SET]
+  000010:[x#14,SET-y#14,SET]
 
 # Overlap with sst boundary containing range del sentinel (fileNum 000015) is not considered an overlap since
 # range del's end key is exclusive. Hence ext9 gets ingested into L6.
@@ -437,26 +437,26 @@ d:40
 lsm
 ----
 0.4:
-  000021:[a#13,SET-g#13,SET]
-  000020:[j#12,RANGEDEL-m#12,SET]
+  000021:[a#22,SET-g#22,SET]
+  000020:[j#21,RANGEDEL-m#21,SET]
 0.3:
-  000016:[a#11,RANGEDEL-z#inf,RANGEDEL]
+  000016:[a#20,RANGEDEL-z#inf,RANGEDEL]
 0.2:
-  000009:[b#4,MERGE-c#4,DEL]
+  000009:[b#13,MERGE-c#13,DEL]
 0.1:
-  000008:[a#3,SET-c#3,SET]
-  000011:[k#8,SET-k#8,SET]
+  000008:[a#12,SET-c#12,SET]
+  000011:[k#17,SET-k#17,SET]
 0.0:
-  000007:[a#2,SET-b#2,DEL]
-  000014:[j#6,SET-k#7,SET]
-  000019:[m#9,SET-m#9,SET]
+  000007:[a#11,SET-b#11,DEL]
+  000014:[j#15,SET-k#16,SET]
+  000019:[m#18,SET-m#18,SET]
 6:
-  000006:[a#1,SET-b#1,SET]
-  000023:[d#14,SET-d#14,SET]
-  000024:[i#15,RANGEDEL-j#inf,RANGEDEL]
-  000015:[n#10,SET-n#10,SET]
-  000010:[x#5,SET-y#5,SET]
-  000022:[z#16,SET-z#16,SET]
+  000006:[a#10,SET-b#10,SET]
+  000023:[d#23,SET-d#23,SET]
+  000024:[i#24,RANGEDEL-j#inf,RANGEDEL]
+  000015:[n#19,SET-n#19,SET]
+  000010:[x#14,SET-y#14,SET]
+  000022:[z#25,SET-z#25,SET]
 
 # No overlap between fileNum 000019 that contains point key f, since f is ingested file's range del sentinel.
 
@@ -470,27 +470,27 @@ ingest ext13
 lsm
 ----
 0.4:
-  000021:[a#13,SET-g#13,SET]
-  000020:[j#12,RANGEDEL-m#12,SET]
+  000021:[a#22,SET-g#22,SET]
+  000020:[j#21,RANGEDEL-m#21,SET]
 0.3:
-  000016:[a#11,RANGEDEL-z#inf,RANGEDEL]
+  000016:[a#20,RANGEDEL-z#inf,RANGEDEL]
 0.2:
-  000009:[b#4,MERGE-c#4,DEL]
+  000009:[b#13,MERGE-c#13,DEL]
 0.1:
-  000008:[a#3,SET-c#3,SET]
-  000011:[k#8,SET-k#8,SET]
+  000008:[a#12,SET-c#12,SET]
+  000011:[k#17,SET-k#17,SET]
 0.0:
-  000007:[a#2,SET-b#2,DEL]
-  000014:[j#6,SET-k#7,SET]
-  000019:[m#9,SET-m#9,SET]
+  000007:[a#11,SET-b#11,DEL]
+  000014:[j#15,SET-k#16,SET]
+  000019:[m#18,SET-m#18,SET]
 6:
-  000006:[a#1,SET-b#1,SET]
-  000023:[d#14,SET-d#14,SET]
-  000025:[e#17,RANGEDEL-f#inf,RANGEDEL]
-  000024:[i#15,RANGEDEL-j#inf,RANGEDEL]
-  000015:[n#10,SET-n#10,SET]
-  000010:[x#5,SET-y#5,SET]
-  000022:[z#16,SET-z#16,SET]
+  000006:[a#10,SET-b#10,SET]
+  000023:[d#23,SET-d#23,SET]
+  000025:[e#26,RANGEDEL-f#inf,RANGEDEL]
+  000024:[i#24,RANGEDEL-j#inf,RANGEDEL]
+  000015:[n#19,SET-n#19,SET]
+  000010:[x#14,SET-y#14,SET]
+  000022:[z#25,SET-z#25,SET]
 
 # Overlap with range delete keys in memtable, hence memtable will be flushed.
 
@@ -509,31 +509,31 @@ memtable flushed
 lsm
 ----
 0.6:
-  000026:[b#19,SET-b#19,SET]
+  000026:[b#28,SET-b#28,SET]
 0.5:
-  000029:[a#18,RANGEDEL-d#inf,RANGEDEL]
+  000029:[a#27,RANGEDEL-d#inf,RANGEDEL]
 0.4:
-  000021:[a#13,SET-g#13,SET]
-  000020:[j#12,RANGEDEL-m#12,SET]
+  000021:[a#22,SET-g#22,SET]
+  000020:[j#21,RANGEDEL-m#21,SET]
 0.3:
-  000016:[a#11,RANGEDEL-z#inf,RANGEDEL]
+  000016:[a#20,RANGEDEL-z#inf,RANGEDEL]
 0.2:
-  000009:[b#4,MERGE-c#4,DEL]
+  000009:[b#13,MERGE-c#13,DEL]
 0.1:
-  000008:[a#3,SET-c#3,SET]
-  000011:[k#8,SET-k#8,SET]
+  000008:[a#12,SET-c#12,SET]
+  000011:[k#17,SET-k#17,SET]
 0.0:
-  000007:[a#2,SET-b#2,DEL]
-  000014:[j#6,SET-k#7,SET]
-  000019:[m#9,SET-m#9,SET]
+  000007:[a#11,SET-b#11,DEL]
+  000014:[j#15,SET-k#16,SET]
+  000019:[m#18,SET-m#18,SET]
 6:
-  000006:[a#1,SET-b#1,SET]
-  000023:[d#14,SET-d#14,SET]
-  000025:[e#17,RANGEDEL-f#inf,RANGEDEL]
-  000024:[i#15,RANGEDEL-j#inf,RANGEDEL]
-  000015:[n#10,SET-n#10,SET]
-  000010:[x#5,SET-y#5,SET]
-  000022:[z#16,SET-z#16,SET]
+  000006:[a#10,SET-b#10,SET]
+  000023:[d#23,SET-d#23,SET]
+  000025:[e#26,RANGEDEL-f#inf,RANGEDEL]
+  000024:[i#24,RANGEDEL-j#inf,RANGEDEL]
+  000015:[n#19,SET-n#19,SET]
+  000010:[x#14,SET-y#14,SET]
+  000022:[z#25,SET-z#25,SET]
 
 reset
 ----
@@ -554,7 +554,7 @@ ingest ext15
 lsm
 ----
 6:
-  000004:[a#2,RANGEDEL-b#inf,RANGEDEL]
+  000004:[a#11,RANGEDEL-b#inf,RANGEDEL]
 
 reset
 ----
@@ -573,7 +573,7 @@ ingest ext16
 lsm
 ----
 6:
-  000004:[a#2,RANGEDEL-b#inf,RANGEDEL]
+  000004:[a#11,RANGEDEL-b#inf,RANGEDEL]
 
 reset
 ----
@@ -602,9 +602,9 @@ ingest ext18
 lsm
 ----
 0.0:
-  000005:[a#2,SET-c#2,SET]
+  000005:[a#11,SET-c#11,SET]
 6:
-  000004:[a#1,RANGEDEL-b#inf,RANGEDEL]
+  000004:[a#10,RANGEDEL-b#inf,RANGEDEL]
 
 reset
 ----
@@ -636,10 +636,10 @@ ingest ext21
 lsm
 ----
 0.0:
-  000006:[c#3,SET-c#3,SET]
+  000006:[c#12,SET-c#12,SET]
 6:
-  000005:[a#2,SET-b#2,SET]
-  000004:[c#1,RANGEDEL-d#inf,RANGEDEL]
+  000005:[a#11,SET-b#11,SET]
+  000004:[c#10,RANGEDEL-d#inf,RANGEDEL]
 
 reset
 ----
@@ -665,9 +665,9 @@ ingest ext23
 lsm
 ----
 0.0:
-  000005:[a#2,SET-b#2,SET]
+  000005:[a#11,SET-b#11,SET]
 6:
-  000004:[a#1,RANGEDEL-b#inf,RANGEDEL]
+  000004:[a#10,RANGEDEL-b#inf,RANGEDEL]
 
 reset
 ----
@@ -692,9 +692,9 @@ ingest ext25
 lsm
 ----
 0.0:
-  000005:[a#2,RANGEDEL-b#inf,RANGEDEL]
+  000005:[a#11,RANGEDEL-b#inf,RANGEDEL]
 6:
-  000004:[a#1,RANGEDEL-b#inf,RANGEDEL]
+  000004:[a#10,RANGEDEL-b#inf,RANGEDEL]
 
 # Check for range key ingestion bug fix in
 # https://github.com/cockroachdb/pebble/pull/2082. Without the fix, we expect
@@ -713,7 +713,7 @@ ingest ext1
 lsm
 ----
 6:
-  000004:[d#1,RANGEKEYSET-g#inf,RANGEKEYSET]
+  000004:[d#10,RANGEKEYSET-g#inf,RANGEKEYSET]
 
 build ext2
 range-key-set b e 1 val2
@@ -725,9 +725,9 @@ ingest ext2
 lsm
 ----
 0.0:
-  000005:[b#2,RANGEKEYSET-e#inf,RANGEKEYSET]
+  000005:[b#11,RANGEKEYSET-e#inf,RANGEKEYSET]
 6:
-  000004:[d#1,RANGEKEYSET-g#inf,RANGEKEYSET]
+  000004:[d#10,RANGEKEYSET-g#inf,RANGEKEYSET]
 
 build ext3
 range-key-del a c
@@ -740,11 +740,11 @@ ingest ext3
 lsm
 ----
 0.1:
-  000006:[a#3,RANGEKEYDEL-c#inf,RANGEKEYDEL]
+  000006:[a#12,RANGEKEYDEL-c#inf,RANGEKEYDEL]
 0.0:
-  000005:[b#2,RANGEKEYSET-e#inf,RANGEKEYSET]
+  000005:[b#11,RANGEKEYSET-e#inf,RANGEKEYSET]
 6:
-  000004:[d#1,RANGEKEYSET-g#inf,RANGEKEYSET]
+  000004:[d#10,RANGEKEYSET-g#inf,RANGEKEYSET]
 
 build ext4
 set a a
@@ -756,13 +756,13 @@ ingest ext4
 lsm
 ----
 0.2:
-  000007:[a#4,SET-a#4,SET]
+  000007:[a#13,SET-a#13,SET]
 0.1:
-  000006:[a#3,RANGEKEYDEL-c#inf,RANGEKEYDEL]
+  000006:[a#12,RANGEKEYDEL-c#inf,RANGEKEYDEL]
 0.0:
-  000005:[b#2,RANGEKEYSET-e#inf,RANGEKEYSET]
+  000005:[b#11,RANGEKEYSET-e#inf,RANGEKEYSET]
 6:
-  000004:[d#1,RANGEKEYSET-g#inf,RANGEKEYSET]
+  000004:[d#10,RANGEKEYSET-g#inf,RANGEKEYSET]
 
 compact a aa
 ----
@@ -802,7 +802,7 @@ ingest ext1
 lsm
 ----
 6:
-  000004:[c#1,SET-e#1,SET]
+  000004:[c#10,SET-e#10,SET]
 
 
 build ext2
@@ -815,8 +815,8 @@ ingest ext2
 lsm
 ----
 6:
-  000005:[a#2,RANGEKEYSET-c#inf,RANGEKEYSET]
-  000004:[c#1,SET-e#1,SET]
+  000005:[a#11,RANGEKEYSET-c#inf,RANGEKEYSET]
+  000004:[c#10,SET-e#10,SET]
 
 # The following test cases will test that files where the end bound is an
 # exclusive sentinel due to range keys are ingested into the correct levels.
@@ -831,9 +831,9 @@ ingest ext3
 lsm
 ----
 6:
-  000005:[a#2,RANGEKEYSET-c#inf,RANGEKEYSET]
-  000004:[c#1,SET-e#1,SET]
-  000006:[f#3,SET-h#3,SET]
+  000005:[a#11,RANGEKEYSET-c#inf,RANGEKEYSET]
+  000004:[c#10,SET-e#10,SET]
+  000006:[f#12,SET-h#12,SET]
 
 
 build ext4
@@ -846,10 +846,10 @@ ingest ext4
 lsm
 ----
 6:
-  000005:[a#2,RANGEKEYSET-c#inf,RANGEKEYSET]
-  000004:[c#1,SET-e#1,SET]
-  000007:[eee#4,RANGEKEYUNSET-f#inf,RANGEKEYUNSET]
-  000006:[f#3,SET-h#3,SET]
+  000005:[a#11,RANGEKEYSET-c#inf,RANGEKEYSET]
+  000004:[c#10,SET-e#10,SET]
+  000007:[eee#13,RANGEKEYUNSET-f#inf,RANGEKEYUNSET]
+  000006:[f#12,SET-h#12,SET]
 
 build ext5
 range-key-set ee eee 1 val3
@@ -861,11 +861,11 @@ ingest ext5
 lsm
 ----
 6:
-  000005:[a#2,RANGEKEYSET-c#inf,RANGEKEYSET]
-  000004:[c#1,SET-e#1,SET]
-  000008:[ee#5,RANGEKEYSET-eee#inf,RANGEKEYSET]
-  000007:[eee#4,RANGEKEYUNSET-f#inf,RANGEKEYUNSET]
-  000006:[f#3,SET-h#3,SET]
+  000005:[a#11,RANGEKEYSET-c#inf,RANGEKEYSET]
+  000004:[c#10,SET-e#10,SET]
+  000008:[ee#14,RANGEKEYSET-eee#inf,RANGEKEYSET]
+  000007:[eee#13,RANGEKEYUNSET-f#inf,RANGEKEYUNSET]
+  000006:[f#12,SET-h#12,SET]
 
 build ext6
 set x x
@@ -878,12 +878,12 @@ ingest ext6
 lsm
 ----
 6:
-  000005:[a#2,RANGEKEYSET-c#inf,RANGEKEYSET]
-  000004:[c#1,SET-e#1,SET]
-  000008:[ee#5,RANGEKEYSET-eee#inf,RANGEKEYSET]
-  000007:[eee#4,RANGEKEYUNSET-f#inf,RANGEKEYUNSET]
-  000006:[f#3,SET-h#3,SET]
-  000009:[x#6,SET-y#6,SET]
+  000005:[a#11,RANGEKEYSET-c#inf,RANGEKEYSET]
+  000004:[c#10,SET-e#10,SET]
+  000008:[ee#14,RANGEKEYSET-eee#inf,RANGEKEYSET]
+  000007:[eee#13,RANGEKEYUNSET-f#inf,RANGEKEYUNSET]
+  000006:[f#12,SET-h#12,SET]
+  000009:[x#15,SET-y#15,SET]
 
 build ext7
 range-key-del s x
@@ -895,10 +895,10 @@ ingest ext7
 lsm
 ----
 6:
-  000005:[a#2,RANGEKEYSET-c#inf,RANGEKEYSET]
-  000004:[c#1,SET-e#1,SET]
-  000008:[ee#5,RANGEKEYSET-eee#inf,RANGEKEYSET]
-  000007:[eee#4,RANGEKEYUNSET-f#inf,RANGEKEYUNSET]
-  000006:[f#3,SET-h#3,SET]
-  000010:[s#7,RANGEKEYDEL-x#inf,RANGEKEYDEL]
-  000009:[x#6,SET-y#6,SET]
+  000005:[a#11,RANGEKEYSET-c#inf,RANGEKEYSET]
+  000004:[c#10,SET-e#10,SET]
+  000008:[ee#14,RANGEKEYSET-eee#inf,RANGEKEYSET]
+  000007:[eee#13,RANGEKEYUNSET-f#inf,RANGEKEYUNSET]
+  000006:[f#12,SET-h#12,SET]
+  000010:[s#16,RANGEKEYDEL-x#inf,RANGEKEYDEL]
+  000009:[x#15,SET-y#15,SET]

--- a/testdata/iter_histories/iter_optimizations
+++ b/testdata/iter_histories/iter_optimizations
@@ -434,9 +434,9 @@ flush
 lsm
 ----
 0.1:
-  000007:[c@0#4,DEL-e@0#5,SET]
+  000007:[c@0#13,DEL-e@0#14,SET]
 0.0:
-  000005:[a#1,RANGEDEL-d@1#3,SET]
+  000005:[a#10,RANGEDEL-d@1#12,SET]
 
 # The first SeekPrefixGE(b@3) positions each level iterator over their
 # respective files and correctly finds b@3.
@@ -483,7 +483,7 @@ flush
 compact a-h
 ----
 6:
-  000005:[b#1,SET-b#1,SET]
+  000005:[b#10,SET-b#10,SET]
 
 batch commit
 set g g
@@ -496,8 +496,8 @@ flush
 compact a-h
 ----
 6:
-  000005:[b#1,SET-b#1,SET]
-  000007:[g#2,SET-g#2,SET]
+  000005:[b#10,SET-b#10,SET]
+  000007:[g#11,SET-g#11,SET]
 
 batch commit
 del-range b d
@@ -518,11 +518,11 @@ flush
 lsm
 ----
 0.0:
-  000009:[b#3,RANGEDEL-d#inf,RANGEDEL]
-  000011:[e#4,SET-e#4,SET]
+  000009:[b#12,RANGEDEL-d#inf,RANGEDEL]
+  000011:[e#13,SET-e#13,SET]
 6:
-  000005:[b#1,SET-b#1,SET]
-  000007:[g#2,SET-g#2,SET]
+  000005:[b#10,SET-b#10,SET]
+  000007:[g#11,SET-g#11,SET]
 
 # The `seek-ge b` could incorrectly return `b` if the level 0.0 levelIter obeys
 # the TrySeekUsingNext optimization but the level 6 levelIter does not. The
@@ -577,7 +577,7 @@ flush
 compact a-z
 ----
 6:
-  000005:[c#2,RANGEKEYSET-e#inf,RANGEKEYSET]
+  000005:[c#11,RANGEKEYSET-e#inf,RANGEKEYSET]
 
 batch commit
 set j k
@@ -590,8 +590,8 @@ flush
 compact a-z
 ----
 6:
-  000005:[c#2,RANGEKEYSET-e#inf,RANGEKEYSET]
-  000007:[j#3,SET-j#3,SET]
+  000005:[c#11,RANGEKEYSET-e#inf,RANGEKEYSET]
+  000007:[j#12,SET-j#12,SET]
 
 batch commit
 del-range c@2 d
@@ -613,11 +613,11 @@ flush
 lsm
 ----
 0.0:
-  000009:[b@2#5,MERGE-d#inf,RANGEDEL]
-  000011:[m#6,DEL-m#6,DEL]
+  000009:[b@2#14,MERGE-d#inf,RANGEDEL]
+  000011:[m#15,DEL-m#15,DEL]
 6:
-  000005:[c#2,RANGEKEYSET-e#inf,RANGEKEYSET]
-  000007:[j#3,SET-j#3,SET]
+  000005:[c#11,RANGEKEYSET-e#inf,RANGEKEYSET]
+  000007:[j#12,SET-j#12,SET]
 
 combined-iter upper=z@3 mask-suffix=@3 mask-filter use-l6-filter
 seek-prefix-ge b@2
@@ -671,7 +671,7 @@ flush
 compact a-f
 ----
 6:
-  000005:[d@4#1,SET-d@4#1,SET]
+  000005:[d@4#10,SET-d@4#10,SET]
 
 batch commit
 set f@5 bar
@@ -685,8 +685,8 @@ flush
 compact e-k
 ----
 6:
-  000005:[d@4#1,SET-d@4#1,SET]
-  000007:[f@5#2,SET-g@5#3,SET]
+  000005:[d@4#10,SET-d@4#10,SET]
+  000007:[f@5#11,SET-g@5#12,SET]
 
 batch commit
 del b@5
@@ -708,12 +708,12 @@ flush
 lsm
 ----
 0.1:
-  000011:[dd#6,RANGEDEL-ee#inf,RANGEDEL]
+  000011:[dd#15,RANGEDEL-ee#inf,RANGEDEL]
 0.0:
-  000009:[b@5#4,DEL-e@4#5,SET]
+  000009:[b@5#13,DEL-e@4#14,SET]
 6:
-  000005:[d@4#1,SET-d@4#1,SET]
-  000007:[f@5#2,SET-g@5#3,SET]
+  000005:[d@4#10,SET-d@4#10,SET]
+  000007:[f@5#11,SET-g@5#12,SET]
 
 combined-iter upper=z@3 use-l6-filter
 seek-prefix-ge b@6

--- a/testdata/iter_histories/lazy_combined_iteration
+++ b/testdata/iter_histories/lazy_combined_iteration
@@ -41,10 +41,10 @@ flush
 lsm
 ----
 0.1:
-  000009:[bar#3,DEL-zoo#inf,RANGEKEYSET]
+  000009:[bar#12,DEL-zoo#inf,RANGEKEYSET]
 0.0:
-  000005:[bar#1,SET-bar#1,SET]
-  000007:[bax#2,RANGEKEYSET-zoo#inf,RANGEKEYSET]
+  000005:[bar#10,SET-bar#10,SET]
+  000007:[bax#11,RANGEKEYSET-zoo#inf,RANGEKEYSET]
 
 # Assert that First correctly finds [bax,zoo), despite the discovery of
 # [foo,zoo) triggering the switch to combined iteration.
@@ -125,12 +125,12 @@ flush
 lsm
 ----
 0.1:
-  000013:[b#5,RANGEDEL-y#inf,RANGEDEL]
+  000013:[b#14,RANGEDEL-y#inf,RANGEDEL]
 0.0:
-  000005:[a#1,SET-a#1,SET]
-  000009:[d#3,RANGEKEYSET-e#inf,RANGEKEYSET]
-  000011:[l#4,RANGEKEYSET-m#inf,RANGEKEYSET]
-  000007:[z#2,SET-z#2,SET]
+  000005:[a#10,SET-a#10,SET]
+  000009:[d#12,RANGEKEYSET-e#inf,RANGEKEYSET]
+  000011:[l#13,RANGEKEYSET-m#inf,RANGEKEYSET]
+  000007:[z#11,SET-z#11,SET]
 
 combined-iter
 seek-ge k

--- a/testdata/iter_histories/next_prefix
+++ b/testdata/iter_histories/next_prefix
@@ -248,7 +248,7 @@ flush
 lsm
 ----
 0.0:
-  000005:[a@100#3,SET-z@1#76,SET]
+  000005:[a@100#12,SET-z@1#85,SET]
 
 # Test for https://github.com/cockroachdb/pebble/issues/2260. Triggered the
 # bug. The second call to first would return c@100 instead of the correct key,

--- a/testdata/iter_histories/prefix_iteration
+++ b/testdata/iter_histories/prefix_iteration
@@ -40,9 +40,9 @@ flush
 lsm
 ----
 0.0:
-  000005:[a#1,RANGEKEYSET-c#inf,RANGEKEYSET]
-  000007:[c#2,RANGEKEYSET-f#inf,RANGEKEYSET]
-  000009:[f#3,RANGEKEYSET-m#inf,RANGEKEYSET]
+  000005:[a#10,RANGEKEYSET-c#inf,RANGEKEYSET]
+  000007:[c#11,RANGEKEYSET-f#inf,RANGEKEYSET]
+  000009:[f#12,RANGEKEYSET-m#inf,RANGEKEYSET]
 
 combined-iter
 seek-prefix-ge d@5
@@ -94,16 +94,16 @@ flush
 lsm
 ----
 0.0:
-  000005:[a#1,RANGEKEYSET-c@8#inf,RANGEKEYSET]
-  000006:[c@8#4,SET-c@7#inf,RANGEKEYSET]
-  000007:[c@7#5,SET-c@6#inf,RANGEKEYSET]
-  000008:[c@6#6,SET-c@5#inf,RANGEKEYSET]
-  000009:[c@5#7,SET-c@4#inf,RANGEKEYSET]
-  000010:[c@4#8,SET-c@3#inf,RANGEKEYSET]
-  000011:[c@3#9,SET-c@2#inf,RANGEKEYSET]
-  000012:[c@2#10,SET-d@0#inf,RANGEKEYSET]
-  000013:[d@0#11,SET-e#inf,RANGEKEYSET]
-  000014:[y#12,RANGEKEYSET-z#13,SET]
+  000005:[a#10,RANGEKEYSET-c@8#inf,RANGEKEYSET]
+  000006:[c@8#13,SET-c@7#inf,RANGEKEYSET]
+  000007:[c@7#14,SET-c@6#inf,RANGEKEYSET]
+  000008:[c@6#15,SET-c@5#inf,RANGEKEYSET]
+  000009:[c@5#16,SET-c@4#inf,RANGEKEYSET]
+  000010:[c@4#17,SET-c@3#inf,RANGEKEYSET]
+  000011:[c@3#18,SET-c@2#inf,RANGEKEYSET]
+  000012:[c@2#19,SET-d@0#inf,RANGEKEYSET]
+  000013:[d@0#20,SET-e#inf,RANGEKEYSET]
+  000014:[y#21,RANGEKEYSET-z#22,SET]
 
 # The first seek-prefix-ge y@1 converts the iterator from lazy combined iterator
 # to combined iteration.
@@ -157,9 +157,9 @@ set z z
 lsm
 ----
 6:
-  000004:[a#1,RANGEKEYSET-c@8#inf,RANGEKEYSET]
-  000005:[c@8#2,RANGEKEYSET-e#inf,RANGEKEYSET]
-  000006:[y#3,RANGEKEYSET-z#3,SET]
+  000004:[a#10,RANGEKEYSET-c@8#inf,RANGEKEYSET]
+  000005:[c@8#11,RANGEKEYSET-e#inf,RANGEKEYSET]
+  000006:[y#12,RANGEKEYSET-z#12,SET]
 
 
 # The first seek-prefix-ge y@1 converts the iterator from lazy combined iterator
@@ -284,11 +284,11 @@ range-key-set d e @1 bar
 lsm
 ----
 0.0:
-  000006:[a#3,SET-d#inf,RANGEDEL]
-  000007:[d#4,RANGEKEYSET-e#inf,RANGEKEYSET]
+  000006:[a#12,SET-d#inf,RANGEDEL]
+  000007:[d#13,RANGEKEYSET-e#inf,RANGEKEYSET]
 6:
-  000004:[b@4#1,SET-b@4#1,SET]
-  000005:[c#2,SET-f#inf,RANGEKEYSET]
+  000004:[b@4#10,SET-b@4#10,SET]
+  000005:[c#11,SET-f#inf,RANGEKEYSET]
 
 combined-iter
 seek-prefix-ge b@9

--- a/testdata/iter_histories/range_keys_simple
+++ b/testdata/iter_histories/range_keys_simple
@@ -349,9 +349,9 @@ flush
 lsm
 ----
 0.1:
-  000008:[b#2111,RANGEKEYSET-z#inf,RANGEKEYSET]
+  000008:[b#2120,RANGEKEYSET-z#inf,RANGEKEYSET]
 0.0:
-  000006:[a@100#3,SET-zz@1#2104,SET]
+  000006:[a@100#12,SET-zz@1#2113,SET]
 
 scan-rangekeys
 ----

--- a/testdata/iterator_block_interval_filter
+++ b/testdata/iterator_block_interval_filter
@@ -12,7 +12,7 @@ set e05 e
 set f06 f
 ----
 0.0:
-  000005:[a01#1,SET-f06#6,SET]
+  000005:[a01#10,SET-f06#15,SET]
 
 # Iterate without a filter.
 iter
@@ -191,7 +191,7 @@ set d0704 d
 set e0605 e
 ----
 0.0:
-  000005:[a1001#1,SET-e0605#5,SET]
+  000005:[a1001#10,SET-e0605#14,SET]
 
 # Iterate without a filter.
 iter

--- a/testdata/iterator_next_prev
+++ b/testdata/iterator_next_prev
@@ -6,7 +6,7 @@ set c 2
 ingest ext1
 ----
 6:
-  000004:[a#1,MERGE-c#1,SET]
+  000004:[a#10,MERGE-c#10,SET]
 
 build ext2
 del-range b c
@@ -15,9 +15,9 @@ del-range b c
 ingest ext2
 ----
 0.0:
-  000005:[b#2,RANGEDEL-c#inf,RANGEDEL]
+  000005:[b#11,RANGEDEL-c#inf,RANGEDEL]
 6:
-  000004:[a#1,MERGE-c#1,SET]
+  000004:[a#10,MERGE-c#10,SET]
 
 # Regression test for a bug where range tombstones were not properly
 # ignored by Iterator.prevUserKey when switching from forward to
@@ -57,7 +57,7 @@ merge z 2
 ingest ext1
 ----
 6:
-  000004:[t#1,SET-z#1,MERGE]
+  000004:[t#10,SET-z#10,MERGE]
 
 build ext2
 del-range x y
@@ -66,9 +66,9 @@ del-range x y
 ingest ext2
 ----
 0.0:
-  000005:[x#2,RANGEDEL-y#inf,RANGEDEL]
+  000005:[x#11,RANGEDEL-y#inf,RANGEDEL]
 6:
-  000004:[t#1,SET-z#1,MERGE]
+  000004:[t#10,SET-z#10,MERGE]
 
 # Regression test for a bug where range tombstones were not properly
 # ignored by Iterator.nextUserKey when switching from reverse to
@@ -111,7 +111,7 @@ set e e
 ingest ext1
 ----
 6:
-  000004:[e#1,SET-e#1,SET]
+  000004:[e#10,SET-e#10,SET]
 
 build ext2
 set b b
@@ -121,8 +121,8 @@ del-range c d
 ingest ext2
 ----
 6:
-  000005:[b#2,SET-d#inf,RANGEDEL]
-  000004:[e#1,SET-e#1,SET]
+  000005:[b#11,SET-d#inf,RANGEDEL]
+  000004:[e#10,SET-e#10,SET]
 
 # The scenario requires iteration at a snapshot. The "last" operation
 # will exhaust the mergingIter looking backwards for visible
@@ -130,7 +130,7 @@ ingest ext2
 # over the "b" record and find the boundary key due to the range
 # deletion sentinel.
 
-iter seq=2
+iter seq=11
 set-bounds lower=c upper=f
 last
 next
@@ -193,7 +193,7 @@ b: (b, .)
 e: (e, .)
 
 # Test that the cloned iterator respects the seq num.
-iter seq=2
+iter seq=11
 set-bounds lower=a upper=f
 first
 next
@@ -222,7 +222,7 @@ merge a a
 ingest ext1
 ----
 6:
-  000004:[a#1,MERGE-a#1,MERGE]
+  000004:[a#10,MERGE-a#10,MERGE]
 
 build ext2
 set e e
@@ -232,10 +232,10 @@ del-range c d
 ingest ext2
 ----
 6:
-  000004:[a#1,MERGE-a#1,MERGE]
-  000005:[c#2,RANGEDEL-e#2,SET]
+  000004:[a#10,MERGE-a#10,MERGE]
+  000005:[c#11,RANGEDEL-e#11,SET]
 
-iter seq=2
+iter seq=11
 set-bounds lower=a upper=e
 first
 prev
@@ -268,7 +268,7 @@ singledel b
 ingest ext1
 ----
 6:
-  000004:[a#1,SET-b#1,SET]
+  000004:[a#10,SET-b#10,SET]
 
 iter
 first

--- a/testdata/iterator_stats
+++ b/testdata/iterator_stats
@@ -6,7 +6,7 @@ set c 2
 ingest ext1
 ----
 6:
-  000004:[a#1,MERGE-c#1,SET]
+  000004:[a#10,MERGE-c#10,SET]
 
 iter
 first
@@ -46,8 +46,8 @@ set e@18 e18
 ingest ext2
 ----
 6:
-  000004:[a#1,MERGE-c#1,SET]
-  000005:[d@10#2,SET-e@18#2,SET]
+  000004:[a#10,MERGE-c#10,SET]
+  000005:[d@10#11,SET-e@18#11,SET]
 
 iter
 seek-ge c

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -6,7 +6,7 @@ set b 2
 compact a-b
 ----
 6:
-  000005:[a#1,SET-b#2,SET]
+  000005:[a#10,SET-b#11,SET]
 
 batch
 set c 3
@@ -16,8 +16,8 @@ set d 4
 compact c-d
 ----
 6:
-  000005:[a#1,SET-b#2,SET]
-  000007:[c#3,SET-d#4,SET]
+  000005:[a#10,SET-b#11,SET]
+  000007:[c#12,SET-d#13,SET]
 
 batch
 set b 5
@@ -313,7 +313,7 @@ set z 1
 compact a-z
 ----
 6:
-  000005:[a#1,SET-z#5,SET]
+  000005:[a#10,SET-z#14,SET]
 
 build ext1
 set a 2
@@ -327,10 +327,10 @@ del-range c z
 ingest ext1 ext2
 ----
 0.0:
-  000006:[a#6,SET-a#6,SET]
-  000007:[b#7,SET-z#inf,RANGEDEL]
+  000006:[a#15,SET-a#15,SET]
+  000007:[b#16,SET-z#inf,RANGEDEL]
 6:
-  000005:[a#1,SET-z#5,SET]
+  000005:[a#10,SET-z#14,SET]
 
 iter
 first
@@ -1133,14 +1133,14 @@ set y y
 flush
 ----
 0.0:
-  000009:[b#2,SET-b#2,SET]
-  000010:[h#3,SET-h#3,SET]
-  000011:[i#4,SET-i#4,SET]
-  000012:[j#5,SET-j#5,SET]
-  000013:[k#6,SET-k#6,SET]
-  000014:[m#7,SET-m#7,SET]
-  000015:[q#8,SET-q#8,SET]
-  000016:[y#9,SET-y#9,SET]
+  000009:[b#10,SET-b#10,SET]
+  000010:[h#11,SET-h#11,SET]
+  000011:[i#12,SET-i#12,SET]
+  000012:[j#13,SET-j#13,SET]
+  000013:[k#14,SET-k#14,SET]
+  000014:[m#15,SET-m#15,SET]
+  000015:[q#16,SET-q#16,SET]
+  000016:[y#17,SET-y#17,SET]
 6:
   000006:[a#1,SET-g#inf,RANGEDEL]
   000007:[m#0,SET-m#0,SET]
@@ -1150,7 +1150,7 @@ flush
 compact g-z
 ----
 0.0:
-  000009:[b#2,SET-b#2,SET]
+  000009:[b#10,SET-b#10,SET]
 6:
   000006:[a#1,SET-g#inf,RANGEDEL]
   000048:[h#0,SET-k#0,SET]
@@ -1163,8 +1163,8 @@ set t t
 flush
 ----
 0.0:
-  000009:[b#2,SET-b#2,SET]
-  000051:[t#10,SET-t#10,SET]
+  000009:[b#10,SET-b#10,SET]
+  000051:[t#18,SET-t#18,SET]
 6:
   000006:[a#1,SET-g#inf,RANGEDEL]
   000048:[h#0,SET-k#0,SET]

--- a/testdata/manual_compaction_set_with_del
+++ b/testdata/manual_compaction_set_with_del
@@ -6,7 +6,7 @@ set b 2
 compact a-b
 ----
 6:
-  000005:[a#1,SET-b#2,SET]
+  000005:[a#10,SET-b#11,SET]
 
 batch
 set c 3
@@ -16,8 +16,8 @@ set d 4
 compact c-d
 ----
 6:
-  000005:[a#1,SET-b#2,SET]
-  000007:[c#3,SET-d#4,SET]
+  000005:[a#10,SET-b#11,SET]
+  000007:[c#12,SET-d#13,SET]
 
 batch
 set b 5
@@ -313,7 +313,7 @@ set z 1
 compact a-z
 ----
 6:
-  000005:[a#1,SET-z#5,SET]
+  000005:[a#10,SET-z#14,SET]
 
 build ext1
 set a 2
@@ -327,10 +327,10 @@ del-range c z
 ingest ext1 ext2
 ----
 0.0:
-  000006:[a#6,SET-a#6,SET]
-  000007:[b#7,SET-z#inf,RANGEDEL]
+  000006:[a#15,SET-a#15,SET]
+  000007:[b#16,SET-z#inf,RANGEDEL]
 6:
-  000005:[a#1,SET-z#5,SET]
+  000005:[a#10,SET-z#14,SET]
 
 iter
 first

--- a/testdata/manual_flush
+++ b/testdata/manual_flush
@@ -7,7 +7,7 @@ set b 2
 flush
 ----
 0.0:
-  000005:[a#1,SET-b#2,SET]
+  000005:[a#10,SET-b#11,SET]
 
 reset
 ----
@@ -22,7 +22,7 @@ del b
 flush
 ----
 0.0:
-  000005:[a#3,DEL-b#4,DEL]
+  000005:[a#12,DEL-b#13,DEL]
 
 batch
 set a 3
@@ -32,9 +32,9 @@ set a 3
 flush
 ----
 0.1:
-  000007:[a#5,SET-a#5,SET]
+  000007:[a#14,SET-a#14,SET]
 0.0:
-  000005:[a#3,DEL-b#4,DEL]
+  000005:[a#12,DEL-b#13,DEL]
 
 batch
 set c 4
@@ -44,10 +44,10 @@ set c 4
 flush
 ----
 0.1:
-  000007:[a#5,SET-a#5,SET]
+  000007:[a#14,SET-a#14,SET]
 0.0:
-  000005:[a#3,DEL-b#4,DEL]
-  000009:[c#6,SET-c#6,SET]
+  000005:[a#12,DEL-b#13,DEL]
+  000009:[c#15,SET-c#15,SET]
 
 reset
 ----
@@ -61,7 +61,7 @@ del-range a c
 flush
 ----
 0.0:
-  000005:[a#3,RANGEDEL-c#inf,RANGEDEL]
+  000005:[a#12,RANGEDEL-c#inf,RANGEDEL]
 
 reset
 ----
@@ -74,7 +74,7 @@ set b 2
 async-flush
 ----
 0.0:
-  000005:[a#1,SET-b#2,SET]
+  000005:[a#10,SET-b#11,SET]
 
 # Test that synchronous flushes can happen even when a cleaning turn is held.
 reset
@@ -91,7 +91,7 @@ set b 2
 flush
 ----
 0.0:
-  000005:[a#1,SET-b#2,SET]
+  000005:[a#10,SET-b#11,SET]
 
 release-cleaning-turn
 ----

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -8,7 +8,7 @@ iter-new a
 flush
 ----
 0.0:
-  000005:[a#1,SET-a#1,SET]
+  000005:[a#10,SET-a#10,SET]
 
 # iter b references both a memtable and sstable 5.
 
@@ -50,8 +50,8 @@ set b 2
 flush
 ----
 0.0:
-  000005:[a#1,SET-a#1,SET]
-  000007:[b#2,SET-b#2,SET]
+  000005:[a#10,SET-a#10,SET]
+  000007:[b#11,SET-b#11,SET]
 
 # iter c references both a memtable and sstables 5 and 7.
 
@@ -212,9 +212,9 @@ set c@14 c14
 flush
 ----
 0.0:
-  000010:[c@20#3,SET-c@18#5,SET]
-  000011:[c@17#6,SET-c@15#8,SET]
-  000012:[c@14#9,SET-c@14#9,SET]
+  000010:[c@20#12,SET-c@18#14,SET]
+  000011:[c@17#15,SET-c@15#17,SET]
+  000012:[c@14#18,SET-c@14#18,SET]
 6:
   000008:[a#0,SET-b#0,SET]
 
@@ -338,11 +338,11 @@ disable
 flush
 ----
 0.1:
-  000015:[d#13,SET-d#13,SET]
-  000016:[e#14,SET-e#14,SET]
-  000019:[f#15,SET-f#15,SET]
+  000015:[d#22,SET-d#22,SET]
+  000016:[e#23,SET-e#23,SET]
+  000019:[f#24,SET-f#24,SET]
 0.0:
-  000023:[d#10,SET-f#12,SET]
+  000023:[d#19,SET-f#21,SET]
 6:
   000008:[a#0,SET-b#0,SET]
   000013:[c@20#0,SET-c@16#0,SET]

--- a/testdata/range_del
+++ b/testdata/range_del
@@ -2,21 +2,21 @@
 
 define
 mem
-  a.SET.1:b
-  a.SET.3:c
-  a.SET.5:d
-  b.MERGE.1:b
-  b.MERGE.3:c
-  b.MERGE.5:d
-  b.RANGEDEL.6:c
-  b.MERGE.7:e
-  c.SET.1:b
-  c.SET.3:c
-  c.SET.5:d
+  a.SET.10:b
+  a.SET.12:c
+  a.SET.14:d
+  b.MERGE.10:b
+  b.MERGE.12:c
+  b.MERGE.14:d
+  b.RANGEDEL.15:c
+  b.MERGE.16:e
+  c.SET.10:b
+  c.SET.12:c
+  c.SET.14:d
 ----
 mem: 1
 
-get seq=2
+get seq=11
 a
 b
 c
@@ -25,7 +25,7 @@ a:b
 b:b
 c:b
 
-get seq=4
+get seq=13
 a
 b
 c
@@ -34,7 +34,7 @@ a:c
 b:bc
 c:c
 
-get seq=6
+get seq=15
 a
 b
 c
@@ -43,7 +43,7 @@ a:d
 b:bcd
 c:d
 
-get seq=7
+get seq=16
 a
 b
 c
@@ -52,7 +52,7 @@ a:d
 b: pebble: not found
 c:d
 
-get seq=8
+get seq=17
 a
 b
 c
@@ -61,7 +61,7 @@ a:d
 b:e
 c:d
 
-get seq=6
+get seq=15
 a
 b
 c
@@ -70,7 +70,7 @@ a:d
 b:bcd
 c:d
 
-iter seq=6
+iter seq=15
 first
 next
 next
@@ -105,7 +105,7 @@ a: (d, .)
 b: (bcd, .)
 c: (d, .)
 
-iter seq=7
+iter seq=16
 first
 next
 next
@@ -140,25 +140,25 @@ c: (d, .)
 
 define
 mem
-  a.SET.1:b
-  b.MERGE.1:b
-  c.SET.1:b
+  a.SET.10:b
+  b.MERGE.10:b
+  c.SET.10:b
 mem
-  a.SET.3:c
-  b.MERGE.3:c
-  c.SET.3:c
+  a.SET.12:c
+  b.MERGE.12:c
+  c.SET.12:c
 mem
-  a.SET.5:d
-  b.MERGE.5:d
-  c.SET.5:d
+  a.SET.14:d
+  b.MERGE.14:d
+  c.SET.14:d
 mem
-  b.RANGEDEL.6:c
+  b.RANGEDEL.15:c
 mem
-  b.MERGE.7:e
+  b.MERGE.16:e
 ----
 mem: 5
 
-get seq=2
+get seq=11
 a
 b
 c
@@ -167,7 +167,7 @@ a:b
 b:b
 c:b
 
-get seq=4
+get seq=13
 a
 b
 c
@@ -176,7 +176,7 @@ a:c
 b:bc
 c:c
 
-get seq=6
+get seq=15
 a
 b
 c
@@ -185,7 +185,7 @@ a:d
 b:bcd
 c:d
 
-get seq=7
+get seq=16
 a
 b
 c
@@ -194,7 +194,7 @@ a:d
 b: pebble: not found
 c:d
 
-get seq=8
+get seq=17
 a
 b
 c
@@ -203,7 +203,7 @@ a:d
 b:e
 c:d
 
-get seq=6
+get seq=15
 a
 b
 c
@@ -212,7 +212,7 @@ a:d
 b:bcd
 c:d
 
-iter seq=6
+iter seq=15
 first
 next
 next
@@ -247,7 +247,7 @@ a: (d, .)
 b: (bcd, .)
 c: (d, .)
 
-iter seq=7
+iter seq=16
 first
 next
 next
@@ -282,32 +282,32 @@ c: (d, .)
 
 define
 mem
-  a.SET.1:1
-  a.SET.3:2
-  a.SET.5:3
-  a.SET.7:4
-  b.SET.1:1
-  b.SET.3:2
-  b.SET.5:3
-  b.SET.7:4
-  c.SET.1:1
-  c.SET.3:2
-  c.SET.5:3
-  c.SET.7:4
-  d.SET.1:1
-  d.SET.3:2
-  d.SET.5:3
-  d.SET.7:4
-  a.RANGEDEL.2:b
-  b.RANGEDEL.4:c
-  b.RANGEDEL.2:c
-  c.RANGEDEL.6:d
-  c.RANGEDEL.4:d
-  c.RANGEDEL.2:d
+  a.SET.10:1
+  a.SET.12:2
+  a.SET.14:3
+  a.SET.16:4
+  b.SET.10:1
+  b.SET.12:2
+  b.SET.14:3
+  b.SET.16:4
+  c.SET.10:1
+  c.SET.12:2
+  c.SET.14:3
+  c.SET.16:4
+  d.SET.10:1
+  d.SET.12:2
+  d.SET.14:3
+  d.SET.16:4
+  a.RANGEDEL.11:b
+  b.RANGEDEL.13:c
+  b.RANGEDEL.11:c
+  c.RANGEDEL.15:d
+  c.RANGEDEL.13:d
+  c.RANGEDEL.11:d
 ----
 mem: 1
 
-get seq=2
+get seq=11
 a
 b
 c
@@ -318,7 +318,7 @@ b:1
 c:1
 d:1
 
-get seq=3
+get seq=12
 a
 b
 c
@@ -329,7 +329,7 @@ b: pebble: not found
 c: pebble: not found
 d:1
 
-get seq=5
+get seq=14
 a
 b
 c
@@ -340,7 +340,7 @@ b: pebble: not found
 c: pebble: not found
 d:2
 
-get seq=7
+get seq=16
 a
 b
 c
@@ -351,7 +351,7 @@ b:3
 c: pebble: not found
 d:3
 
-get seq=9
+get seq=18
 a
 b
 c
@@ -362,7 +362,7 @@ b:4
 c:4
 d:4
 
-iter seq=2
+iter seq=11
 first
 next
 next
@@ -385,7 +385,7 @@ b: (1, .)
 a: (1, .)
 .
 
-iter seq=3
+iter seq=12
 first
 next
 last
@@ -396,7 +396,7 @@ d: (1, .)
 d: (1, .)
 .
 
-iter seq=5
+iter seq=14
 first
 next
 next
@@ -411,7 +411,7 @@ d: (2, .)
 a: (2, .)
 .
 
-iter seq=7
+iter seq=16
 first
 next
 next
@@ -430,7 +430,7 @@ b: (3, .)
 a: (3, .)
 .
 
-iter seq=9
+iter seq=18
 first
 next
 next
@@ -458,32 +458,32 @@ a: (4, .)
 
 define
 mem
-  a.SET.1:1
-  b.SET.1:1
-  c.SET.1:1
-  d.SET.1:1
+  a.SET.10:1
+  b.SET.10:1
+  c.SET.10:1
+  d.SET.10:1
 mem
-  a.SET.3:2
-  b.SET.3:2
-  c.SET.3:2
-  d.SET.3:2
-  a.RANGEDEL.2:d
+  a.SET.12:2
+  b.SET.12:2
+  c.SET.12:2
+  d.SET.12:2
+  a.RANGEDEL.11:d
 mem
-  a.SET.5:3
-  b.SET.5:3
-  c.SET.5:3
-  d.SET.5:3
-  b.RANGEDEL.4:d
+  a.SET.14:3
+  b.SET.14:3
+  c.SET.14:3
+  d.SET.14:3
+  b.RANGEDEL.13:d
 mem
-  a.SET.7:4
-  b.SET.7:4
-  c.SET.7:4
-  d.SET.7:4
-  c.RANGEDEL.4:d
+  a.SET.16:4
+  b.SET.16:4
+  c.SET.16:4
+  d.SET.16:4
+  c.RANGEDEL.13:d
 ----
 mem: 4
 
-get seq=2
+get seq=11
 a
 b
 c
@@ -494,7 +494,7 @@ b:1
 c:1
 d:1
 
-get seq=3
+get seq=12
 a
 b
 c
@@ -505,7 +505,7 @@ b: pebble: not found
 c: pebble: not found
 d:1
 
-get seq=5
+get seq=14
 a
 b
 c
@@ -516,7 +516,7 @@ b: pebble: not found
 c: pebble: not found
 d:2
 
-get seq=7
+get seq=16
 a
 b
 c
@@ -527,7 +527,7 @@ b:3
 c: pebble: not found
 d:3
 
-get seq=9
+get seq=18
 a
 b
 c
@@ -538,7 +538,7 @@ b:4
 c:4
 d:4
 
-iter seq=2
+iter seq=11
 first
 next
 next
@@ -561,7 +561,7 @@ b: (1, .)
 a: (1, .)
 .
 
-iter seq=3
+iter seq=12
 first
 next
 last
@@ -572,7 +572,7 @@ d: (1, .)
 d: (1, .)
 .
 
-iter seq=5
+iter seq=14
 first
 next
 next
@@ -587,7 +587,7 @@ d: (2, .)
 a: (2, .)
 .
 
-iter seq=7
+iter seq=16
 first
 next
 next
@@ -606,7 +606,7 @@ b: (3, .)
 a: (3, .)
 .
 
-iter seq=9
+iter seq=18
 first
 next
 next
@@ -633,39 +633,39 @@ a: (4, .)
 
 define
 L1
-  a.SET.3:3
+  a.SET.12:3
 L1
-  a.SET.2:2
+  a.SET.11:2
 L1
-  a.SET.1:1
+  a.SET.10:1
 ----
 mem: 1
 1:
-  000004:[a#3,SET-a#3,SET]
-  000005:[a#2,SET-a#2,SET]
-  000006:[a#1,SET-a#1,SET]
+  000004:[a#12,SET-a#12,SET]
+  000005:[a#11,SET-a#11,SET]
+  000006:[a#10,SET-a#10,SET]
 
-get seq=1
+get seq=10
 a
 ----
 a: pebble: not found
 
-get seq=2
+get seq=11
 a
 ----
 a:1
 
-get seq=3
+get seq=12
 a
 ----
 a:2
 
-get seq=4
+get seq=13
 a
 ----
 a:3
 
-iter seq=2
+iter seq=11
 first
 seek-ge a
 seek-ge b
@@ -680,7 +680,7 @@ a: (1, .)
 .
 a: (1, .)
 
-iter seq=3
+iter seq=12
 first
 seek-ge a
 seek-ge b
@@ -695,7 +695,7 @@ a: (2, .)
 .
 a: (2, .)
 
-iter seq=4
+iter seq=13
 first
 seek-ge a
 seek-ge b
@@ -712,39 +712,39 @@ a: (3, .)
 
 define
 L1
-  a.MERGE.3:3
+  a.MERGE.12:3
 L1
-  a.MERGE.2:2
+  a.MERGE.11:2
 L1
-  a.MERGE.1:1
+  a.MERGE.10:1
 ----
 mem: 1
 1:
-  000004:[a#3,MERGE-a#3,MERGE]
-  000005:[a#2,MERGE-a#2,MERGE]
-  000006:[a#1,MERGE-a#1,MERGE]
+  000004:[a#12,MERGE-a#12,MERGE]
+  000005:[a#11,MERGE-a#11,MERGE]
+  000006:[a#10,MERGE-a#10,MERGE]
 
-get seq=1
+get seq=10
 a
 ----
 a: pebble: not found
 
-get seq=2
+get seq=11
 a
 ----
 a:1
 
-get seq=3
+get seq=12
 a
 ----
 a:12
 
-get seq=4
+get seq=13
 a
 ----
 a:123
 
-iter seq=2
+iter seq=11
 first
 seek-ge a
 seek-ge b
@@ -759,7 +759,7 @@ a: (1, .)
 .
 a: (1, .)
 
-iter seq=3
+iter seq=12
 first
 seek-ge a
 seek-ge b
@@ -774,7 +774,7 @@ a: (12, .)
 .
 a: (12, .)
 
-iter seq=4
+iter seq=13
 first
 seek-ge a
 seek-ge b
@@ -793,48 +793,48 @@ a: (123, .)
 
 define
 mem
-  a.MERGE.4:4
+  a.MERGE.13:4
 L1
-  a.MERGE.3:3
+  a.MERGE.12:3
 L2
-  a.MERGE.2:2
+  a.MERGE.11:2
 L3
-  a.MERGE.1:1
+  a.MERGE.10:1
 ----
 mem: 1
 1:
-  000004:[a#3,MERGE-a#3,MERGE]
+  000004:[a#12,MERGE-a#12,MERGE]
 2:
-  000005:[a#2,MERGE-a#2,MERGE]
+  000005:[a#11,MERGE-a#11,MERGE]
 3:
-  000006:[a#1,MERGE-a#1,MERGE]
+  000006:[a#10,MERGE-a#10,MERGE]
 
-get seq=1
+get seq=10
 a
 ----
 a: pebble: not found
 
-get seq=2
+get seq=11
 a
 ----
 a:1
 
-get seq=3
+get seq=12
 a
 ----
 a:12
 
-get seq=4
+get seq=13
 a
 ----
 a:123
 
-get seq=5
+get seq=14
 a
 ----
 a:1234
 
-iter seq=2
+iter seq=11
 first
 seek-ge a
 seek-ge b
@@ -849,7 +849,7 @@ a: (1, .)
 .
 a: (1, .)
 
-iter seq=3
+iter seq=12
 first
 seek-ge a
 seek-ge b
@@ -864,7 +864,7 @@ a: (12, .)
 .
 a: (12, .)
 
-iter seq=4
+iter seq=13
 first
 seek-ge a
 seek-ge b
@@ -879,7 +879,7 @@ a: (123, .)
 .
 a: (123, .)
 
-iter seq=5
+iter seq=14
 first
 seek-ge a
 seek-ge b
@@ -897,34 +897,34 @@ a: (1234, .)
 # Range deletions on multiple levels.
 define
 L0
-  a.SET.4:4
-  b.SET.4:4
-  d.SET.4:4
-  c.RANGEDEL.4:d
+  a.SET.13:4
+  b.SET.13:4
+  d.SET.13:4
+  c.RANGEDEL.13:d
 L1
-  a.SET.3:3
-  d.SET.3:3
-  b.RANGEDEL.3:d
+  a.SET.12:3
+  d.SET.12:3
+  b.RANGEDEL.12:d
 L2
-  d.SET.2:2
-  a.RANGEDEL.2:d
+  d.SET.11:2
+  a.RANGEDEL.11:d
 L3
-  a.SET.1:1
-  b.SET.1:1
-  c.SET.1:1
-  d.SET.1:1
+  a.SET.10:1
+  b.SET.10:1
+  c.SET.10:1
+  d.SET.10:1
 ----
 mem: 1
 0.0:
-  000004:[a#4,SET-d#4,SET]
+  000004:[a#13,SET-d#13,SET]
 1:
-  000005:[a#3,SET-d#3,SET]
+  000005:[a#12,SET-d#12,SET]
 2:
-  000006:[a#2,RANGEDEL-d#2,SET]
+  000006:[a#11,RANGEDEL-d#11,SET]
 3:
-  000007:[a#1,SET-d#1,SET]
+  000007:[a#10,SET-d#10,SET]
 
-get seq=2
+get seq=11
 a
 b
 c
@@ -935,7 +935,7 @@ b:1
 c:1
 d:1
 
-get seq=3
+get seq=12
 a
 b
 c
@@ -946,7 +946,7 @@ b: pebble: not found
 c: pebble: not found
 d:2
 
-get seq=4
+get seq=13
 a
 b
 c
@@ -957,7 +957,7 @@ b: pebble: not found
 c: pebble: not found
 d:3
 
-get seq=5
+get seq=14
 a
 b
 c
@@ -968,7 +968,7 @@ b:4
 c: pebble: not found
 d:4
 
-iter seq=2
+iter seq=11
 first
 next
 next
@@ -987,14 +987,14 @@ c: (1, .)
 b: (1, .)
 a: (1, .)
 
-iter seq=3
+iter seq=12
 first
 last
 ----
 d: (2, .)
 d: (2, .)
 
-iter seq=4
+iter seq=13
 first
 next
 last
@@ -1005,7 +1005,7 @@ d: (3, .)
 d: (3, .)
 a: (3, .)
 
-iter seq=5
+iter seq=14
 first
 next
 next
@@ -1024,31 +1024,31 @@ a: (4, .)
 
 define
 mem
-  a.SET.3:3
-  b.SET.3:3
-  c.SET.3:3
-  d.SET.3:3
+  a.SET.12:3
+  b.SET.12:3
+  c.SET.12:3
+  d.SET.12:3
 L1
-  a.RANGEDEL.2:b
+  a.RANGEDEL.11:b
 L1
-  b.RANGEDEL.2:c
+  b.RANGEDEL.11:c
 L1
-  c.RANGEDEL.2:d
+  c.RANGEDEL.11:d
 L2
-  a.SET.1:1
-  b.SET.1:1
-  c.SET.1:1
-  d.SET.1:1
+  a.SET.10:1
+  b.SET.10:1
+  c.SET.10:1
+  d.SET.10:1
 ----
 mem: 1
 1:
-  000004:[a#2,RANGEDEL-b#inf,RANGEDEL]
-  000005:[b#2,RANGEDEL-c#inf,RANGEDEL]
-  000006:[c#2,RANGEDEL-d#inf,RANGEDEL]
+  000004:[a#11,RANGEDEL-b#inf,RANGEDEL]
+  000005:[b#11,RANGEDEL-c#inf,RANGEDEL]
+  000006:[c#11,RANGEDEL-d#inf,RANGEDEL]
 2:
-  000007:[a#1,SET-d#1,SET]
+  000007:[a#10,SET-d#10,SET]
 
-get seq=2
+get seq=11
 a
 b
 c
@@ -1059,7 +1059,7 @@ b:1
 c:1
 d:1
 
-get seq=3
+get seq=12
 a
 b
 c
@@ -1070,7 +1070,7 @@ b: pebble: not found
 c: pebble: not found
 d:1
 
-get seq=4
+get seq=13
 a
 b
 c
@@ -1081,7 +1081,7 @@ b:3
 c:3
 d:3
 
-iter seq=2
+iter seq=11
 first
 next
 next
@@ -1100,14 +1100,14 @@ c: (1, .)
 b: (1, .)
 a: (1, .)
 
-iter seq=3
+iter seq=12
 first
 last
 ----
 d: (1, .)
 d: (1, .)
 
-iter seq=4
+iter seq=13
 first
 next
 next
@@ -1132,17 +1132,17 @@ a: (3, .)
 
 define
 L1
-  a.RANGEDEL.1:b
+  a.RANGEDEL.10:b
 L2
-  a.SET.2:2
+  a.SET.11:2
 ----
 mem: 1
 1:
-  000004:[a#1,RANGEDEL-b#inf,RANGEDEL]
+  000004:[a#10,RANGEDEL-b#inf,RANGEDEL]
 2:
-  000005:[a#2,SET-a#2,SET]
+  000005:[a#11,SET-a#11,SET]
 
-get seq=3
+get seq=12
 a
 ----
 a: pebble: not found
@@ -1155,33 +1155,33 @@ a: pebble: not found
 
 define target-file-sizes=(100, 1) snapshots=(1)
 L0
-  a.RANGEDEL.1:e
+  a.RANGEDEL.10:e
 L0
-  a.SET.2:v
+  a.SET.11:v
 L0
-  c.SET.3:v
+  c.SET.12:v
 ----
 mem: 1
 0.1:
-  000005:[a#2,SET-a#2,SET]
-  000006:[c#3,SET-c#3,SET]
+  000005:[a#11,SET-a#11,SET]
+  000006:[c#12,SET-c#12,SET]
 0.0:
-  000004:[a#1,RANGEDEL-e#inf,RANGEDEL]
+  000004:[a#10,RANGEDEL-e#inf,RANGEDEL]
 
 compact a-e
 ----
 1:
-  000007:[a#2,SET-c#inf,RANGEDEL]
-  000008:[c#3,SET-e#inf,RANGEDEL]
+  000007:[a#11,SET-c#inf,RANGEDEL]
+  000008:[c#12,SET-e#inf,RANGEDEL]
 
 compact d-e
 ----
 1:
-  000007:[a#2,SET-c#inf,RANGEDEL]
+  000007:[a#11,SET-c#inf,RANGEDEL]
 2:
-  000008:[c#3,SET-e#inf,RANGEDEL]
+  000008:[c#12,SET-e#inf,RANGEDEL]
 
-iter seq=4
+iter seq=13
 seek-ge b
 next
 ----
@@ -1193,33 +1193,33 @@ c: (v, .)
 
 define target-file-sizes=(100, 1) snapshots=(1)
 L0
-  a.RANGEDEL.1:e
+  a.RANGEDEL.10:e
 L0
-  a.SET.2:v
+  a.SET.11:v
 L0
-  c.SET.3:v
+  c.SET.12:v
 ----
 mem: 1
 0.1:
-  000005:[a#2,SET-a#2,SET]
-  000006:[c#3,SET-c#3,SET]
+  000005:[a#11,SET-a#11,SET]
+  000006:[c#12,SET-c#12,SET]
 0.0:
-  000004:[a#1,RANGEDEL-e#inf,RANGEDEL]
+  000004:[a#10,RANGEDEL-e#inf,RANGEDEL]
 
 compact a-e
 ----
 1:
-  000007:[a#2,SET-c#inf,RANGEDEL]
-  000008:[c#3,SET-e#inf,RANGEDEL]
+  000007:[a#11,SET-c#inf,RANGEDEL]
+  000008:[c#12,SET-e#inf,RANGEDEL]
 
 compact a-b
 ----
 1:
-  000008:[c#3,SET-e#inf,RANGEDEL]
+  000008:[c#12,SET-e#inf,RANGEDEL]
 2:
-  000007:[a#2,SET-c#inf,RANGEDEL]
+  000007:[a#11,SET-c#inf,RANGEDEL]
 
-iter seq=4
+iter seq=13
 seek-lt d
 prev
 prev
@@ -1237,41 +1237,41 @@ a: (v, .)
 
 define target-file-sizes=(100, 1) snapshots=(1)
 L0
-  a.RANGEDEL.1:e
+  a.RANGEDEL.10:e
 L0
-  a.SET.2:v
+  a.SET.11:v
 L0
-  c.SET.3:v
+  c.SET.12:v
 L2
   d.SET.0:v
 ----
 mem: 1
 0.1:
-  000005:[a#2,SET-a#2,SET]
-  000006:[c#3,SET-c#3,SET]
+  000005:[a#11,SET-a#11,SET]
+  000006:[c#12,SET-c#12,SET]
 0.0:
-  000004:[a#1,RANGEDEL-e#inf,RANGEDEL]
+  000004:[a#10,RANGEDEL-e#inf,RANGEDEL]
 2:
   000007:[d#0,SET-d#0,SET]
 
 compact a-b
 ----
 1:
-  000008:[a#2,SET-c#inf,RANGEDEL]
-  000009:[c#3,SET-d#inf,RANGEDEL]
-  000010:[d#1,RANGEDEL-e#inf,RANGEDEL]
+  000008:[a#11,SET-c#inf,RANGEDEL]
+  000009:[c#12,SET-d#inf,RANGEDEL]
+  000010:[d#10,RANGEDEL-e#inf,RANGEDEL]
 2:
   000007:[d#0,SET-d#0,SET]
 
 compact d-e
 ----
 1:
-  000008:[a#2,SET-c#inf,RANGEDEL]
-  000009:[c#3,SET-d#inf,RANGEDEL]
+  000008:[a#11,SET-c#inf,RANGEDEL]
+  000009:[c#12,SET-d#inf,RANGEDEL]
 3:
-  000011:[d#1,RANGEDEL-e#inf,RANGEDEL]
+  000011:[d#10,RANGEDEL-e#inf,RANGEDEL]
 
-get seq=4
+get seq=13
 c
 ----
 c:v
@@ -1279,13 +1279,13 @@ c:v
 compact a-b L1
 ----
 1:
-  000009:[c#3,SET-d#inf,RANGEDEL]
+  000009:[c#12,SET-d#inf,RANGEDEL]
 2:
-  000008:[a#2,SET-c#inf,RANGEDEL]
+  000008:[a#11,SET-c#inf,RANGEDEL]
 3:
-  000011:[d#1,RANGEDEL-e#inf,RANGEDEL]
+  000011:[d#10,RANGEDEL-e#inf,RANGEDEL]
 
-get seq=4
+get seq=13
 c
 ----
 c:v
@@ -1295,48 +1295,48 @@ c:v
 
 define target-file-sizes=(100, 1) snapshots=(1)
 L0
-  a.RANGEDEL.1:e
+  a.RANGEDEL.10:e
 L0
-  a.SET.2:v
+  a.SET.11:v
 L0
-  c.SET.3:v
+  c.SET.12:v
 L0
-  f.SET.4:v
+  f.SET.13:v
 L2
   d.SET.0:v
 ----
 mem: 1
 0.1:
-  000005:[a#2,SET-a#2,SET]
-  000006:[c#3,SET-c#3,SET]
+  000005:[a#11,SET-a#11,SET]
+  000006:[c#12,SET-c#12,SET]
 0.0:
-  000004:[a#1,RANGEDEL-e#inf,RANGEDEL]
-  000007:[f#4,SET-f#4,SET]
+  000004:[a#10,RANGEDEL-e#inf,RANGEDEL]
+  000007:[f#13,SET-f#13,SET]
 2:
   000008:[d#0,SET-d#0,SET]
 
 compact a-b
 ----
 0.0:
-  000007:[f#4,SET-f#4,SET]
+  000007:[f#13,SET-f#13,SET]
 1:
-  000009:[a#2,SET-c#inf,RANGEDEL]
-  000010:[c#3,SET-d#inf,RANGEDEL]
-  000011:[d#1,RANGEDEL-e#inf,RANGEDEL]
+  000009:[a#11,SET-c#inf,RANGEDEL]
+  000010:[c#12,SET-d#inf,RANGEDEL]
+  000011:[d#10,RANGEDEL-e#inf,RANGEDEL]
 2:
   000008:[d#0,SET-d#0,SET]
 
 compact d-e
 ----
 0.0:
-  000007:[f#4,SET-f#4,SET]
+  000007:[f#13,SET-f#13,SET]
 1:
-  000009:[a#2,SET-c#inf,RANGEDEL]
-  000010:[c#3,SET-d#inf,RANGEDEL]
+  000009:[a#11,SET-c#inf,RANGEDEL]
+  000010:[c#12,SET-d#inf,RANGEDEL]
 3:
-  000012:[d#1,RANGEDEL-e#inf,RANGEDEL]
+  000012:[d#10,RANGEDEL-e#inf,RANGEDEL]
 
-get seq=4
+get seq=13
 c
 ----
 c:v
@@ -1344,46 +1344,46 @@ c:v
 compact f-f L0
 ----
 1:
-  000009:[a#2,SET-c#inf,RANGEDEL]
-  000010:[c#3,SET-d#inf,RANGEDEL]
-  000007:[f#4,SET-f#4,SET]
+  000009:[a#11,SET-c#inf,RANGEDEL]
+  000010:[c#12,SET-d#inf,RANGEDEL]
+  000007:[f#13,SET-f#13,SET]
 3:
-  000012:[d#1,RANGEDEL-e#inf,RANGEDEL]
+  000012:[d#10,RANGEDEL-e#inf,RANGEDEL]
 
 compact a-f L1
 ----
 2:
-  000013:[a#2,SET-c#inf,RANGEDEL]
-  000014:[c#3,SET-d#inf,RANGEDEL]
-  000015:[f#4,SET-f#4,SET]
+  000013:[a#11,SET-c#inf,RANGEDEL]
+  000014:[c#12,SET-d#inf,RANGEDEL]
+  000015:[f#13,SET-f#13,SET]
 3:
-  000012:[d#1,RANGEDEL-e#inf,RANGEDEL]
+  000012:[d#10,RANGEDEL-e#inf,RANGEDEL]
 
-get seq=4
+get seq=13
 c
 ----
 c:v
 
 define
 L0
-  a.RANGEDEL.3:f
+  a.RANGEDEL.12:f
 L0
-  a.RANGEDEL.4:c
-  c.RANGEDEL.4:f
+  a.RANGEDEL.13:c
+  c.RANGEDEL.13:f
 L1
-  b.RANGEDEL.2:e
+  b.RANGEDEL.11:e
 L2
-  c.RANGEDEL.1:d
+  c.RANGEDEL.10:d
 ----
 mem: 1
 0.1:
-  000005:[a#4,RANGEDEL-f#inf,RANGEDEL]
+  000005:[a#13,RANGEDEL-f#inf,RANGEDEL]
 0.0:
-  000004:[a#3,RANGEDEL-f#inf,RANGEDEL]
+  000004:[a#12,RANGEDEL-f#inf,RANGEDEL]
 1:
-  000006:[b#2,RANGEDEL-e#inf,RANGEDEL]
+  000006:[b#11,RANGEDEL-e#inf,RANGEDEL]
 2:
-  000007:[c#1,RANGEDEL-d#inf,RANGEDEL]
+  000007:[c#10,RANGEDEL-d#inf,RANGEDEL]
 
 wait-pending-table-stats
 000007
@@ -1425,32 +1425,32 @@ range-deletions-bytes-estimate: 1672
 # Range deletions with varying overlap.
 define
 L0
-  a.SET.4:4
-  b.SET.4:4
-  d.SET.4:4
-  c.RANGEDEL.4:d
+  a.SET.13:4
+  b.SET.13:4
+  d.SET.13:4
+  c.RANGEDEL.13:d
 L1
-  a.SET.3:3
-  d.SET.3:3
-  b.RANGEDEL.3:d
+  a.SET.12:3
+  d.SET.12:3
+  b.RANGEDEL.12:d
 L2
-  d.SET.2:2
-  a.RANGEDEL.2:d
+  d.SET.11:2
+  a.RANGEDEL.11:d
 L3
-  a.SET.1:1
-  b.SET.1:1
-  c.SET.1:1
-  d.SET.1:1
+  a.SET.10:1
+  b.SET.10:1
+  c.SET.10:1
+  d.SET.10:1
 ----
 mem: 1
 0.0:
-  000004:[a#4,SET-d#4,SET]
+  000004:[a#13,SET-d#13,SET]
 1:
-  000005:[a#3,SET-d#3,SET]
+  000005:[a#12,SET-d#12,SET]
 2:
-  000006:[a#2,RANGEDEL-d#2,SET]
+  000006:[a#11,RANGEDEL-d#11,SET]
 3:
-  000007:[a#1,SET-d#1,SET]
+  000007:[a#10,SET-d#10,SET]
 
 wait-pending-table-stats
 000007
@@ -1491,29 +1491,29 @@ range-deletions-bytes-estimate: 100
 # Multiple Range deletions in a table.
 define
 L0
-  a.RANGEDEL.6:d
-  e.RANGEDEL.6:z
+  a.RANGEDEL.15:d
+  e.RANGEDEL.15:z
 L0
-  a.RANGEDEL.5:d
+  a.RANGEDEL.14:d
 L0
-  e.RANGEDEL.4:z
+  e.RANGEDEL.13:z
 L1
-  a.SET.2:1
-  b.SET.2:1
-  c.SET.2:1
+  a.SET.11:1
+  b.SET.11:1
+  c.SET.11:1
 L2
-  x.SET.1:2
+  x.SET.10:2
 ----
 mem: 1
 0.1:
-  000004:[a#6,RANGEDEL-z#inf,RANGEDEL]
+  000004:[a#15,RANGEDEL-z#inf,RANGEDEL]
 0.0:
-  000005:[a#5,RANGEDEL-d#inf,RANGEDEL]
-  000006:[e#4,RANGEDEL-z#inf,RANGEDEL]
+  000005:[a#14,RANGEDEL-d#inf,RANGEDEL]
+  000006:[e#13,RANGEDEL-z#inf,RANGEDEL]
 1:
-  000007:[a#2,SET-c#2,SET]
+  000007:[a#11,SET-c#11,SET]
 2:
-  000008:[x#1,SET-x#1,SET]
+  000008:[x#10,SET-x#10,SET]
 
 wait-pending-table-stats
 000005

--- a/testdata/scan_internal
+++ b/testdata/scan_internal
@@ -22,10 +22,10 @@ flush
 
 scan-internal
 ----
-a-c:{(#1,RANGEKEYSET,@5,boop)}
-b#3,1 (d)
-c-e:{(#2,RANGEKEYSET,@5,beep)}
-e#4,1 (foo)
+a-c:{(#10,RANGEKEYSET,@5,boop)}
+b#12,1 (d)
+c-e:{(#11,RANGEKEYSET,@5,beep)}
+e#13,1 (foo)
 
 # Keys deleted by rangedels are elided.
 
@@ -36,41 +36,41 @@ committed 1 keys
 
 scan-internal
 ----
-a-c:{(#1,RANGEKEYSET,@5,boop)}
-b-d#5,RANGEDEL
-c-e:{(#2,RANGEKEYSET,@5,beep)}
-e#4,1 (foo)
+a-c:{(#10,RANGEKEYSET,@5,boop)}
+b-d#14,RANGEDEL
+c-e:{(#11,RANGEKEYSET,@5,beep)}
+e#13,1 (foo)
 
 flush
 ----
 
 scan-internal
 ----
-a-c:{(#1,RANGEKEYSET,@5,boop)}
-b-d#5,RANGEDEL
-c-e:{(#2,RANGEKEYSET,@5,beep)}
-e#4,1 (foo)
+a-c:{(#10,RANGEKEYSET,@5,boop)}
+b-d#14,RANGEDEL
+c-e:{(#11,RANGEKEYSET,@5,beep)}
+e#13,1 (foo)
 
 # Snapshots work with internal iters.
 
 scan-internal snapshot=foo
 ----
-a-c:{(#1,RANGEKEYSET,@5,boop)}
-c-e:{(#2,RANGEKEYSET,@5,beep)}
+a-c:{(#10,RANGEKEYSET,@5,boop)}
+c-e:{(#11,RANGEKEYSET,@5,beep)}
 
 # Range keys and range dels are truncated to [lower,upper).
 
 scan-internal lower=bb upper=dd
 ----
-bb-c:{(#1,RANGEKEYSET,@5,boop)}
-bb-d#5,RANGEDEL
-c-dd:{(#2,RANGEKEYSET,@5,beep)}
+bb-c:{(#10,RANGEKEYSET,@5,boop)}
+bb-d#14,RANGEDEL
+c-dd:{(#11,RANGEKEYSET,@5,beep)}
 
 scan-internal lower=b upper=cc
 ----
-b-c:{(#1,RANGEKEYSET,@5,boop)}
-b-cc#5,RANGEDEL
-c-cc:{(#2,RANGEKEYSET,@5,beep)}
+b-c:{(#10,RANGEKEYSET,@5,boop)}
+b-cc#14,RANGEDEL
+c-cc:{(#11,RANGEKEYSET,@5,beep)}
 
 reset
 ----
@@ -90,7 +90,7 @@ flush
 compact a-z
 ----
 6:
-  000005:[a#1,RANGEKEYSET-e#inf,RANGEKEYSET]
+  000005:[a#10,RANGEKEYSET-e#inf,RANGEKEYSET]
 
 batch commit
 range-key-unset b d @6
@@ -107,10 +107,10 @@ committed 1 keys
 
 scan-internal
 ----
-a-b:{(#4,RANGEKEYDEL)}
-b-c:{(#1,RANGEKEYSET,@8,foo) (#3,RANGEKEYUNSET,@6)}
-c-d:{(#3,RANGEKEYUNSET,@6)}
-d-e:{(#2,RANGEKEYSET,@6,bar)}
+a-b:{(#13,RANGEKEYDEL)}
+b-c:{(#10,RANGEKEYSET,@8,foo) (#12,RANGEKEYUNSET,@6)}
+c-d:{(#12,RANGEKEYUNSET,@6)}
+d-e:{(#11,RANGEKEYSET,@6,bar)}
 
 flush
 ----
@@ -118,17 +118,17 @@ flush
 lsm
 ----
 0.0:
-  000009:[a#4,RANGEKEYDEL-b#inf,RANGEKEYDEL]
-  000007:[b#3,RANGEKEYUNSET-d#inf,RANGEKEYUNSET]
+  000009:[a#13,RANGEKEYDEL-b#inf,RANGEKEYDEL]
+  000007:[b#12,RANGEKEYUNSET-d#inf,RANGEKEYUNSET]
 6:
-  000005:[a#1,RANGEKEYSET-e#inf,RANGEKEYSET]
+  000005:[a#10,RANGEKEYSET-e#inf,RANGEKEYSET]
 
 scan-internal
 ----
-a-b:{(#4,RANGEKEYDEL)}
-b-c:{(#1,RANGEKEYSET,@8,foo) (#3,RANGEKEYUNSET,@6)}
-c-d:{(#3,RANGEKEYUNSET,@6)}
-d-e:{(#2,RANGEKEYSET,@6,bar)}
+a-b:{(#13,RANGEKEYDEL)}
+b-c:{(#10,RANGEKEYSET,@8,foo) (#12,RANGEKEYUNSET,@6)}
+c-d:{(#12,RANGEKEYUNSET,@6)}
+d-e:{(#11,RANGEKEYSET,@6,bar)}
 
 # Range key masking is not exercised, with range keys that could mask point
 # keys being returned alongside point keys.
@@ -149,6 +149,6 @@ committed 2 keys
 
 scan-internal
 ----
-a-c:{(#2,RANGEKEYSET,@5,boop)}
-b@3#1,1 (bar)
-c-e:{(#3,RANGEKEYSET,@5,beep)}
+a-c:{(#11,RANGEKEYSET,@5,boop)}
+b@3#10,1 (bar)
+c-e:{(#12,RANGEKEYSET,@5,beep)}

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -7,7 +7,7 @@ del c
 flush
 ----
 0.0:
-  000005:[a#1,SET-c#3,DEL]
+  000005:[a#10,SET-c#12,DEL]
 
 wait-pending-table-stats
 000005
@@ -21,7 +21,7 @@ range-deletions-bytes-estimate: 0
 compact a-c
 ----
 6:
-  000005:[a#1,SET-c#3,DEL]
+  000005:[a#10,SET-c#12,DEL]
 
 batch
 del-range a c
@@ -30,9 +30,9 @@ del-range a c
 flush
 ----
 0.0:
-  000007:[a#4,RANGEDEL-c#inf,RANGEDEL]
+  000007:[a#13,RANGEDEL-c#inf,RANGEDEL]
 6:
-  000005:[a#1,SET-c#3,DEL]
+  000005:[a#10,SET-c#12,DEL]
 
 wait-pending-table-stats
 000007
@@ -81,12 +81,12 @@ set b 2
 flush
 ----
 0.0:
-  000012:[a#5,SET-b#6,SET]
+  000012:[a#14,SET-b#15,SET]
 
 compact a-c
 ----
 6:
-  000012:[a#5,SET-b#6,SET]
+  000012:[a#14,SET-b#15,SET]
 
 enable
 ----
@@ -113,9 +113,9 @@ del-range a c
 flush
 ----
 0.0:
-  000014:[a#7,RANGEDEL-c#inf,RANGEDEL]
+  000014:[a#16,RANGEDEL-c#inf,RANGEDEL]
 6:
-  000012:[a#5,SET-b#6,SET]
+  000012:[a#14,SET-b#15,SET]
 
 compact a-c
 ----
@@ -276,7 +276,7 @@ range-key-unset a b @2
 flush
 ----
 0.0:
-  000005:[a#3,RANGEKEYUNSET-b#inf,RANGEKEYSET]
+  000005:[a#12,RANGEKEYUNSET-b#inf,RANGEKEYSET]
 
 # Add a table that contains only point keys, to the right of the existing table.
 batch
@@ -286,13 +286,13 @@ set c c
 flush
 ----
 0.0:
-  000005:[a#3,RANGEKEYUNSET-b#inf,RANGEKEYSET]
-  000007:[c#4,SET-c#4,SET]
+  000005:[a#12,RANGEKEYUNSET-b#inf,RANGEKEYSET]
+  000007:[c#13,SET-c#13,SET]
 
 compact a-c
 ----
 6:
-  000008:[a#2,RANGEKEYSET-b#inf,RANGEKEYSET]
+  000008:[a#11,RANGEKEYSET-b#inf,RANGEKEYSET]
   000009:[c#0,SET-c#0,SET]
 
 # Add a table that contains a RANGEKEYDEL covering the first table in L6.
@@ -303,9 +303,9 @@ range-key-del a b
 flush
 ----
 0.0:
-  000011:[a#5,RANGEKEYDEL-b#inf,RANGEKEYDEL]
+  000011:[a#14,RANGEKEYDEL-b#inf,RANGEKEYDEL]
 6:
-  000008:[a#2,RANGEKEYSET-b#inf,RANGEKEYSET]
+  000008:[a#11,RANGEKEYSET-b#inf,RANGEKEYSET]
   000009:[c#0,SET-c#0,SET]
 
 # Add one more table containing a RANGEDEL.
@@ -316,11 +316,11 @@ del-range a c
 flush
 ----
 0.1:
-  000013:[a#6,RANGEDEL-c#inf,RANGEDEL]
+  000013:[a#15,RANGEDEL-c#inf,RANGEDEL]
 0.0:
-  000011:[a#5,RANGEKEYDEL-b#inf,RANGEKEYDEL]
+  000011:[a#14,RANGEKEYDEL-b#inf,RANGEKEYDEL]
 6:
-  000008:[a#2,RANGEKEYSET-b#inf,RANGEKEYSET]
+  000008:[a#11,RANGEKEYSET-b#inf,RANGEKEYSET]
   000009:[c#0,SET-c#0,SET]
 
 # Compute stats on the table containing range key del. It should not show an
@@ -355,13 +355,13 @@ del-range a z
 range-key-del a z
 ----
 0.2:
-  000014:[a#7,RANGEKEYDEL-z#inf,RANGEDEL]
+  000014:[a#16,RANGEKEYDEL-z#inf,RANGEDEL]
 0.1:
-  000013:[a#6,RANGEDEL-c#inf,RANGEDEL]
+  000013:[a#15,RANGEDEL-c#inf,RANGEDEL]
 0.0:
-  000011:[a#5,RANGEKEYDEL-b#inf,RANGEKEYDEL]
+  000011:[a#14,RANGEKEYDEL-b#inf,RANGEKEYDEL]
 6:
-  000008:[a#2,RANGEKEYSET-b#inf,RANGEKEYSET]
+  000008:[a#11,RANGEKEYSET-b#inf,RANGEKEYSET]
   000009:[c#0,SET-c#0,SET]
 
 compact a-z
@@ -379,7 +379,7 @@ set e e
 set f f
 ----
 6:
-  000015:[a#8,RANGEKEYDEL-z#inf,RANGEDEL]
+  000015:[a#17,RANGEKEYDEL-z#inf,RANGEDEL]
 
 wait-pending-table-stats
 000015
@@ -404,7 +404,7 @@ set b b
 flush
 ----
 0.0:
-  000005:[b#1,SET-b#1,SET]
+  000005:[b#10,SET-b#10,SET]
 
 # A table with a mixture of point and range keys.
 batch
@@ -415,8 +415,8 @@ range-key-set d d @1 foo
 flush
 ----
 0.0:
-  000005:[b#1,SET-b#1,SET]
-  000007:[c#2,SET-c#2,SET]
+  000005:[b#10,SET-b#10,SET]
+  000007:[c#11,SET-c#11,SET]
 
 compact a-z
 ----
@@ -432,7 +432,7 @@ range-key-del a z
 flush
 ----
 0.0:
-  000011:[a#4,RANGEKEYDEL-z#inf,RANGEKEYDEL]
+  000011:[a#13,RANGEKEYDEL-z#inf,RANGEKEYDEL]
 6:
   000008:[b#0,SET-b#0,SET]
   000009:[c#0,SET-c#0,SET]

--- a/version_set.go
+++ b/version_set.go
@@ -265,7 +265,14 @@ func (vs *versionSet) load(
 			// (assuming no WALs contain higher sequence numbers than the
 			// manifest's LastSeqNum). Increment LastSeqNum by 1 to get the
 			// next sequence number that will be assigned.
-			vs.logSeqNum.Store(ve.LastSeqNum + 1)
+			//
+			// If LastSeqNum is less than SeqNumStart, increase it to at least
+			// SeqNumStart to leave ample room for reserved sequence numbers.
+			if ve.LastSeqNum+1 < base.SeqNumStart {
+				vs.logSeqNum.Store(base.SeqNumStart)
+			} else {
+				vs.logSeqNum.Store(ve.LastSeqNum + 1)
+			}
 		}
 	}
 	// We have already set vs.nextFileNum = 2 at the beginning of the

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -292,8 +292,8 @@ func TestVersionSetSeqNums(t *testing.T) {
 			lastSeqNum = ve.LastSeqNum
 		}
 	}
-	// 2 ingestions happened, so LastSeqNum should equal 2.
-	require.Equal(t, uint64(2), lastSeqNum)
+	// 2 ingestions happened, so LastSeqNum should equal base.SeqNumStart + 1.
+	require.Equal(t, uint64(11), lastSeqNum)
 	// logSeqNum is always one greater than the last assigned sequence number.
 	require.Equal(t, d.mu.versions.logSeqNum.Load(), lastSeqNum+1)
 }


### PR DESCRIPTION
This change ratchets the start sequence number for all new keys forward to SeqNumStart (= 10). This reserves 1-9 for special use, of which 1-6 are going to be used for foreign sstable (i.e. shared sstables created by a different node) ingestions in a future change.

Really the only relevant code changes are in open.go and internal/base/seqnums.go. The rest are test changes.

Note that we don't need a Format major version change here; the only guarantee that needs to be held with these sequence numbers is that a foreign sstable ingestion and associated excise cannot be followed with a key being written to with a sequence number below 10. Since that ingestion will only be supported in future releases, as long as this change goes in before foreign sstable ingestions are supported, we're safe.