### PR TITLE
*: check L0 sublevel metadata when ingesting files

### DIFF
--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -1014,7 +1014,7 @@ type Version struct {
 	// usage.
 	//
 	// L0Sublevels.Levels contains L0 files ordered by sublevels. All the files
-	// in Files[0] are in L0Sublevels.Levels. L0SublevelFiles is also set to
+	// in Levels[0] are in L0Sublevels.Levels. L0SublevelFiles is also set to
 	// a reference to that slice, as that slice is necessary for iterator
 	// creation and needs to outlast L0Sublevels.
 	L0Sublevels     *L0Sublevels

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -239,7 +239,7 @@ compact         1   2.3 K     0 B       0                          (size == esti
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.4 K   11.1%  (score == hit-rate)
- tcache         1   720 B   50.0%  (score == hit-rate)
+ tcache         1   720 B   40.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)
@@ -318,7 +318,7 @@ compact         1   4.7 K     0 B       0                          (size == esti
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache        16   2.9 K   14.3%  (score == hit-rate)
- tcache         1   720 B   62.5%  (score == hit-rate)
+ tcache         1   720 B   50.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -369,7 +369,7 @@ compact         2   5.7 K     0 B       0                          (size == esti
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache        16   2.9 K   34.4%  (score == hit-rate)
- tcache         3   2.1 K   63.6%  (score == hit-rate)
+ tcache         3   2.1 K   57.9%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)


### PR DESCRIPTION
Previously, when determining the level in which to ingest a new file,
we would iterate over every file in L0 to check for overlap. With this change,
we instead iterate over every sublevel to check for overlap. This is more
efficient since the number of sublevels in L0 is <= the number of files in L0.

Closes: https://github.com/cockroachdb/pebble/issues/2329
Release note: None
Epic: None