### PR TITLE
objiotracing: set curOffset when doing writes

### DIFF
--- a/objstorage/objstorageprovider/objiotracing/obj_io_tracing_on.go
+++ b/objstorage/objstorageprovider/objiotracing/obj_io_tracing_on.go
@@ -102,6 +102,11 @@ func (w *writable) Write(p []byte) error {
 		Offset:  w.curOffset,
 		Size:    int64(len(p)),
 	})
+	// If w.w.Write(p) returns an error, a new writable
+	// will be used, so even tho all of p may not have
+	// been written to the underlying "file", it is okay
+	// to add len(p) to curOffset.
+	w.curOffset += int64(len(p))
 	return w.w.Write(p)
 }
 

--- a/objstorage/objstorageprovider/objiotracing/obj_io_tracing_test.go
+++ b/objstorage/objstorageprovider/objiotracing/obj_io_tracing_test.go
@@ -98,6 +98,10 @@ func TestTracing(t *testing.T) {
 	require.Greater(t, num(func(e Event) bool { return e.Reason == objiotracing.ForFlush }), 0)
 	require.Greater(t, num(func(e Event) bool { return e.Reason == objiotracing.ForCompaction }), 0)
 
+	// Check that offset is set on reads & writes as expected.
+	require.Greater(t, num(func(e Event) bool { return e.Op == objiotracing.ReadOp && e.Offset > 0 }), 0)
+	require.Greater(t, num(func(e Event) bool { return e.Op == objiotracing.WriteOp && e.Offset > 0 }), 0)
+
 	// Check that the FileNums are set and that we see at least two different files.
 	fileNums := make(map[base.FileNum]int)
 	for _, e := range events {


### PR DESCRIPTION
**objiotracing: set curOffset when doing writes**

This commit fixes a buglet that led to IO traces with a zero offset set on all write events.

Release note: None.

```
$ go test . -count=1 -tags=pebble_obj_io_tracing
# github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing.test
ld: warning: -no_pie is deprecated when targeting new OS versions
ld: warning: non-standard -pagezero_size is deprecated when targeting macOS 13.0 or later
ok  	github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing	0.235s
```