### PR TITLE
sstable: reuse block property filterers in all cases

### DIFF
--- a/external_iterator_test.go
+++ b/external_iterator_test.go
@@ -239,10 +239,9 @@ func TestIterRandomizedMaybeFilteredKeys(t *testing.T) {
 			defer r.Close()
 
 			filter := sstable.NewTestKeysBlockPropertyFilter(uint64(tsSeparator), math.MaxUint64)
-			filterer := sstable.NewBlockPropertiesFilterer([]BlockPropertyFilter{filter}, nil)
-			ok, err := filterer.IntersectsUserPropsAndFinishInit(r.Properties.UserProperties)
-			require.True(t, ok)
+			filterer, err := sstable.IntersectsTable([]BlockPropertyFilter{filter}, nil, r.Properties.UserProperties)
 			require.NoError(t, err)
+			require.NotNil(t, filterer)
 
 			var iter sstable.Iterator
 			iter, err = r.NewIterWithBlockPropertyFilters(

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -478,8 +478,8 @@ func TestBlockPropertiesFilterer_IntersectsUserPropsAndFinishInit(t *testing.T) 
 				filter := NewBlockIntervalFilter(f.name, f.i.lower, f.i.upper)
 				filters = append(filters, filter)
 			}
-			filterer := NewBlockPropertiesFilterer(filters, nil)
-			intersects, err := filterer.IntersectsUserPropsAndFinishInit(tc.userProps)
+			filterer := newBlockPropertiesFilterer(filters, nil)
+			intersects, err := filterer.intersectsUserPropsAndFinishInit(tc.userProps)
 			require.NoError(t, err)
 			require.Equal(t, tc.intersects, intersects)
 			require.Equal(t, tc.shortIDToFiltersIndex, filterer.shortIDToFiltersIndex)
@@ -916,8 +916,8 @@ func TestBlockProperties(t *testing.T) {
 			var f *BlockPropertiesFilterer
 			buf.WriteString("points: ")
 			if len(points) > 0 {
-				f = NewBlockPropertiesFilterer(points, nil)
-				ok, err := f.IntersectsUserPropsAndFinishInit(r.Properties.UserProperties)
+				f = newBlockPropertiesFilterer(points, nil)
+				ok, err := f.intersectsUserPropsAndFinishInit(r.Properties.UserProperties)
 				if err != nil {
 					return err.Error()
 				}
@@ -970,8 +970,8 @@ func TestBlockProperties(t *testing.T) {
 			// Range key filter matches.
 			buf.WriteString("ranges: ")
 			if len(ranges) > 0 {
-				f := NewBlockPropertiesFilterer(ranges, nil)
-				ok, err := f.IntersectsUserPropsAndFinishInit(r.Properties.UserProperties)
+				f := newBlockPropertiesFilterer(ranges, nil)
+				ok, err := f.intersectsUserPropsAndFinishInit(r.Properties.UserProperties)
 				if err != nil {
 					return err.Error()
 				}
@@ -1001,8 +1001,8 @@ func TestBlockProperties(t *testing.T) {
 					filters = append(filters, f)
 				}
 			}
-			filterer := NewBlockPropertiesFilterer(filters, nil)
-			ok, err := filterer.IntersectsUserPropsAndFinishInit(r.Properties.UserProperties)
+			filterer := newBlockPropertiesFilterer(filters, nil)
+			ok, err := filterer.intersectsUserPropsAndFinishInit(r.Properties.UserProperties)
 			if err != nil {
 				return err.Error()
 			} else if !ok {
@@ -1081,8 +1081,8 @@ func TestBlockProperties_BoundLimited(t *testing.T) {
 				return "missing block property filter"
 			}
 
-			filterer := NewBlockPropertiesFilterer(nil, &filter)
-			ok, err := filterer.IntersectsUserPropsAndFinishInit(r.Properties.UserProperties)
+			filterer := newBlockPropertiesFilterer(nil, &filter)
+			ok, err := filterer.intersectsUserPropsAndFinishInit(r.Properties.UserProperties)
 			if err != nil {
 				return err.Error()
 			} else if !ok {

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -464,9 +464,9 @@ func runTestReader(
 					var filterMin, filterMax uint64
 					d.ScanArgs(t, "block-property-filter", &filterMin, &filterMax)
 					bpf := NewTestKeysBlockPropertyFilter(filterMin, filterMax)
-					filterer = NewBlockPropertiesFilterer([]BlockPropertyFilter{bpf}, nil)
+					filterer = newBlockPropertiesFilterer([]BlockPropertyFilter{bpf}, nil)
 					intersects, err :=
-						filterer.IntersectsUserPropsAndFinishInit(r.Properties.UserProperties)
+						filterer.intersectsUserPropsAndFinishInit(r.Properties.UserProperties)
 					if err != nil {
 						return err.Error()
 					}

--- a/table_cache.go
+++ b/table_cache.go
@@ -323,14 +323,15 @@ func (c *tableCacheShard) checkAndIntersectFilters(
 	}
 
 	if boundLimitedFilter != nil || len(blockPropertyFilters) > 0 {
-		filterer = sstable.NewBlockPropertiesFilterer(blockPropertyFilters, boundLimitedFilter)
-		intersects, err :=
-			filterer.IntersectsUserPropsAndFinishInit(v.reader.Properties.UserProperties)
-		if err != nil {
+		filterer, err = sstable.IntersectsTable(
+			blockPropertyFilters,
+			boundLimitedFilter,
+			v.reader.Properties.UserProperties,
+		)
+		// NB: IntersectsTable will return a nil filterer if the table-level
+		// properties indicate there's no intersection with the provided filters.
+		if filterer == nil || err != nil {
 			return false, nil, err
-		}
-		if !intersects {
-			return false, nil, nil
 		}
 	}
 	return true, filterer, nil


### PR DESCRIPTION
Previously, if block-property filters were in use and a sstable was found to NOT intersect the filters, the allocated BlockPropertiesFilterer was dropped instead of being returned to the pool.

This commit refactors the sstable package's interface to hide the IntersectsUserPropsAndFinishInit function's subtle semantics behind a new IntersectsTable function that returns a new filterer if the table intersects the provided filters. If the table does not intersect the provided filters, the obtained filterer is automatically returned to the sync pool.

This was discovered while looking at the RefreshRange regression in cockroachdb/cockroach#98881, although I believe the logic was the same in 22.2, and this is not the source of the regression.

```
RefreshRange/linear-keys/refresh_window=[0.00,0.00]-24     189.5µ ± ∞ ¹   174.7µ ± ∞ ¹   -7.79% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[0.00,50.00]-24    21.64µ ± ∞ ¹   17.50µ ± ∞ ¹  -19.14% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[0.00,75.00]-24    15.02µ ± ∞ ¹   15.29µ ± ∞ ¹   +1.78% (p=0.016 n=5)
RefreshRange/linear-keys/refresh_window=[0.00,95.00]-24    14.89µ ± ∞ ¹   15.22µ ± ∞ ¹   +2.20% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[0.00,99.00]-24    14.95µ ± ∞ ¹   15.19µ ± ∞ ¹   +1.58% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[50.00,50.00]-24   189.3µ ± ∞ ¹   173.1µ ± ∞ ¹   -8.55% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[50.00,75.00]-24   31.03µ ± ∞ ¹   22.46µ ± ∞ ¹  -27.60% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[50.00,95.00]-24   31.15µ ± ∞ ¹   22.43µ ± ∞ ¹  -28.00% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[50.00,99.00]-24   31.03µ ± ∞ ¹   22.76µ ± ∞ ¹  -26.63% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[75.00,75.00]-24   178.0µ ± ∞ ¹   161.5µ ± ∞ ¹   -9.30% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[75.00,95.00]-24   36.50µ ± ∞ ¹   23.90µ ± ∞ ¹  -34.51% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[75.00,99.00]-24   36.36µ ± ∞ ¹   23.92µ ± ∞ ¹  -34.23% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[95.00,95.00]-24   177.4µ ± ∞ ¹   161.3µ ± ∞ ¹   -9.03% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[95.00,99.00]-24   42.60µ ± ∞ ¹   26.67µ ± ∞ ¹  -37.39% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[99.00,99.00]-24   179.9µ ± ∞ ¹   162.9µ ± ∞ ¹   -9.44% (p=0.008 n=5)
RefreshRange/random-keys/refresh_window=[0.00,0.00]-24     398.2µ ± ∞ ¹   383.2µ ± ∞ ¹   -3.77% (p=0.008 n=5)
RefreshRange/random-keys/refresh_window=[0.00,50.00]-24    21.99µ ± ∞ ¹   17.39µ ± ∞ ¹  -20.94% (p=0.008 n=5)
RefreshRange/random-keys/refresh_window=[0.00,75.00]-24    19.95µ ± ∞ ¹   19.01µ ± ∞ ¹   -4.71% (p=0.008 n=5)
RefreshRange/random-keys/refresh_window=[0.00,95.00]-24    14.36µ ± ∞ ¹   14.71µ ± ∞ ¹   +2.44% (p=0.008 n=5)
RefreshRange/random-keys/refresh_window=[0.00,99.00]-24    14.37µ ± ∞ ¹   14.69µ ± ∞ ¹   +2.20% (p=0.008 n=5)
RefreshRange/random-keys/refresh_window=[50.00,50.00]-24   857.8m ± ∞ ¹   858.5m ± ∞ ¹        ~ (p=0.841 n=5)
RefreshRange/random-keys/refresh_window=[50.00,75.00]-24   25.54µ ± ∞ ¹   24.86µ ± ∞ ¹   -2.64% (p=0.008 n=5)
RefreshRange/random-keys/refresh_window=[50.00,95.00]-24   14.85µ ± ∞ ¹   15.26µ ± ∞ ¹   +2.77% (p=0.008 n=5)
RefreshRange/random-keys/refresh_window=[50.00,99.00]-24   14.96µ ± ∞ ¹   15.23µ ± ∞ ¹   +1.83% (p=0.008 n=5)
RefreshRange/random-keys/refresh_window=[75.00,75.00]-24   484.1m ± ∞ ¹   482.6m ± ∞ ¹        ~ (p=0.841 n=5)
RefreshRange/random-keys/refresh_window=[75.00,95.00]-24   27.63µ ± ∞ ¹   20.21µ ± ∞ ¹  -26.86% (p=0.008 n=5)
RefreshRange/random-keys/refresh_window=[75.00,99.00]-24   27.46µ ± ∞ ¹   20.34µ ± ∞ ¹  -25.94% (p=0.008 n=5)
RefreshRange/random-keys/refresh_window=[95.00,95.00]-24   668.4m ± ∞ ¹   671.1m ± ∞ ¹        ~ (p=0.151 n=5)
RefreshRange/random-keys/refresh_window=[95.00,99.00]-24   30.33µ ± ∞ ¹   23.20µ ± ∞ ¹  -23.51% (p=0.008 n=5)
RefreshRange/random-keys/refresh_window=[99.00,99.00]-24   665.9m ± ∞ ¹   669.9m ± ∞ ¹        ~ (p=0.310 n=5)
RefreshRange/mixed-case/refresh_window=[0.00,0.00]-24      519.7µ ± ∞ ¹   519.9µ ± ∞ ¹        ~ (p=1.000 n=5)
RefreshRange/mixed-case/refresh_window=[0.00,50.00]-24     19.92µ ± ∞ ¹   18.42µ ± ∞ ¹   -7.53% (p=0.008 n=5)
RefreshRange/mixed-case/refresh_window=[0.00,75.00]-24     19.89µ ± ∞ ¹   18.32µ ± ∞ ¹   -7.88% (p=0.008 n=5)
RefreshRange/mixed-case/refresh_window=[0.00,95.00]-24     22.86µ ± ∞ ¹   22.82µ ± ∞ ¹        ~ (p=0.310 n=5)
RefreshRange/mixed-case/refresh_window=[0.00,99.00]-24     21.32µ ± ∞ ¹   21.60µ ± ∞ ¹   +1.31% (p=0.008 n=5)
RefreshRange/mixed-case/refresh_window=[50.00,50.00]-24    842.4m ± ∞ ¹   846.1m ± ∞ ¹        ~ (p=0.421 n=5)
RefreshRange/mixed-case/refresh_window=[50.00,75.00]-24    28.05µ ± ∞ ¹   26.66µ ± ∞ ¹   -4.96% (p=0.008 n=5)
RefreshRange/mixed-case/refresh_window=[50.00,95.00]-24    23.31µ ± ∞ ¹   23.22µ ± ∞ ¹        ~ (p=0.222 n=5)
RefreshRange/mixed-case/refresh_window=[50.00,99.00]-24    21.74µ ± ∞ ¹   22.07µ ± ∞ ¹   +1.49% (p=0.008 n=5)
RefreshRange/mixed-case/refresh_window=[75.00,75.00]-24    840.9m ± ∞ ¹   843.3m ± ∞ ¹        ~ (p=0.690 n=5)
RefreshRange/mixed-case/refresh_window=[75.00,95.00]-24    23.22µ ± ∞ ¹   23.19µ ± ∞ ¹        ~ (p=1.000 n=5)
RefreshRange/mixed-case/refresh_window=[75.00,99.00]-24    21.69µ ± ∞ ¹   22.07µ ± ∞ ¹   +1.77% (p=0.008 n=5)
RefreshRange/mixed-case/refresh_window=[95.00,95.00]-24    1.376m ± ∞ ¹   1.379m ± ∞ ¹        ~ (p=0.310 n=5)
RefreshRange/mixed-case/refresh_window=[95.00,99.00]-24    19.05µ ± ∞ ¹   18.09µ ± ∞ ¹   -5.04% (p=0.008 n=5)
RefreshRange/mixed-case/refresh_window=[99.00,99.00]-24    298.7m ± ∞ ¹   303.4m ± ∞ ¹   +1.57% (p=0.008 n=5)

RefreshRange/linear-keys/refresh_window=[0.00,0.00]-24      98.00 ± ∞ ¹    58.00 ± ∞ ¹  -40.82% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[0.00,50.00]-24     42.00 ± ∞ ¹    31.00 ± ∞ ¹  -26.19% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[0.00,75.00]-24     22.00 ± ∞ ¹    22.00 ± ∞ ¹        ~ (p=1.000 n=5) ²
RefreshRange/linear-keys/refresh_window=[0.00,95.00]-24     22.00 ± ∞ ¹    22.00 ± ∞ ¹        ~ (p=1.000 n=5) ²
RefreshRange/linear-keys/refresh_window=[0.00,99.00]-24     22.00 ± ∞ ¹    22.00 ± ∞ ¹        ~ (p=1.000 n=5) ²
RefreshRange/linear-keys/refresh_window=[50.00,50.00]-24    99.00 ± ∞ ¹    59.00 ± ∞ ¹  -40.40% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[50.00,75.00]-24    64.00 ± ∞ ¹    43.00 ± ∞ ¹  -32.81% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[50.00,95.00]-24    64.00 ± ∞ ¹    43.00 ± ∞ ¹  -32.81% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[50.00,99.00]-24    64.00 ± ∞ ¹    43.00 ± ∞ ¹  -32.81% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[75.00,75.00]-24    99.00 ± ∞ ¹    59.00 ± ∞ ¹  -40.40% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[75.00,95.00]-24    82.00 ± ∞ ¹    52.00 ± ∞ ¹  -36.59% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[75.00,99.00]-24    82.00 ± ∞ ¹    52.00 ± ∞ ¹  -36.59% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[95.00,95.00]-24    99.00 ± ∞ ¹    59.00 ± ∞ ¹  -40.40% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[95.00,99.00]-24    99.00 ± ∞ ¹    60.00 ± ∞ ¹  -39.39% (p=0.008 n=5)
RefreshRange/linear-keys/refresh_window=[99.00,99.00]-24    99.00 ± ∞ ¹    59.00 ± ∞ ¹  -40.40% (p=0.008 n=5)
RefreshRange/random-keys/refresh_window=[0.00,0.00]-24      78.00 ± ∞ ¹    49.00 ± ∞ ¹  -37.18% (p=0.008 n=5)
RefreshRange/random-keys/refresh_window=[0.00,50.00]-24     44.00 ± ∞ ¹    32.00 ± ∞ ¹  -27.27% (p=0.008 n=5)
RefreshRange/random-keys/refresh_window=[0.00,75.00]-24     28.00 ± ∞ ¹    24.00 ± ∞ ¹  -14.29% (p=0.008 n=5)
RefreshRange/random-keys/refresh_window=[0.00,95.00]-24     22.00 ± ∞ ¹    22.00 ± ∞ ¹        ~ (p=1.000 n=5) ²
RefreshRange/random-keys/refresh_window=[0.00,99.00]-24     22.00 ± ∞ ¹    22.00 ± ∞ ¹        ~ (p=1.000 n=5) ²
RefreshRange/random-keys/refresh_window=[50.00,50.00]-24   1064.0 ± ∞ ¹    945.0 ± ∞ ¹        ~ (p=0.548 n=5)
RefreshRange/random-keys/refresh_window=[50.00,75.00]-24    28.00 ± ∞ ¹    24.00 ± ∞ ¹  -14.29% (p=0.008 n=5)
RefreshRange/random-keys/refresh_window=[50.00,95.00]-24    22.00 ± ∞ ¹    22.00 ± ∞ ¹        ~ (p=1.000 n=5) ²
RefreshRange/random-keys/refresh_window=[50.00,99.00]-24    22.00 ± ∞ ¹    22.00 ± ∞ ¹        ~ (p=1.000 n=5) ²
RefreshRange/random-keys/refresh_window=[75.00,75.00]-24    739.0 ± ∞ ¹    738.0 ± ∞ ¹        ~ (p=0.690 n=5)
RefreshRange/random-keys/refresh_window=[75.00,95.00]-24    58.00 ± ∞ ¹    40.00 ± ∞ ¹  -31.03% (p=0.008 n=5)
RefreshRange/random-keys/refresh_window=[75.00,99.00]-24    58.00 ± ∞ ¹    40.00 ± ∞ ¹  -31.03% (p=0.008 n=5)
RefreshRange/random-keys/refresh_window=[95.00,95.00]-24   1.289k ± ∞ ¹   1.270k ± ∞ ¹        ~ (p=0.548 n=5)
RefreshRange/random-keys/refresh_window=[95.00,99.00]-24    58.00 ± ∞ ¹    40.00 ± ∞ ¹  -31.03% (p=0.008 n=5)
RefreshRange/random-keys/refresh_window=[99.00,99.00]-24   1.314k ± ∞ ¹   1.264k ± ∞ ¹        ~ (p=0.175 n=5)
RefreshRange/mixed-case/refresh_window=[0.00,0.00]-24       29.00 ± ∞ ¹    24.00 ± ∞ ¹  -17.24% (p=0.008 n=5)
RefreshRange/mixed-case/refresh_window=[0.00,50.00]-24      30.00 ± ∞ ¹    25.00 ± ∞ ¹  -16.67% (p=0.008 n=5)
RefreshRange/mixed-case/refresh_window=[0.00,75.00]-24      30.00 ± ∞ ¹    25.00 ± ∞ ¹  -16.67% (p=0.008 n=5)
RefreshRange/mixed-case/refresh_window=[0.00,95.00]-24      27.00 ± ∞ ¹    25.00 ± ∞ ¹   -7.41% (p=0.008 n=5)
RefreshRange/mixed-case/refresh_window=[0.00,99.00]-24      24.00 ± ∞ ¹    24.00 ± ∞ ¹        ~ (p=1.000 n=5) ²
RefreshRange/mixed-case/refresh_window=[50.00,50.00]-24     349.0 ± ∞ ¹    342.0 ± ∞ ¹        ~ (p=0.087 n=5)
RefreshRange/mixed-case/refresh_window=[50.00,75.00]-24     30.00 ± ∞ ¹    25.00 ± ∞ ¹  -16.67% (p=0.008 n=5)
RefreshRange/mixed-case/refresh_window=[50.00,95.00]-24     27.00 ± ∞ ¹    25.00 ± ∞ ¹   -7.41% (p=0.008 n=5)
RefreshRange/mixed-case/refresh_window=[50.00,99.00]-24     24.00 ± ∞ ¹    24.00 ± ∞ ¹        ~ (p=1.000 n=5) ²
RefreshRange/mixed-case/refresh_window=[75.00,75.00]-24     344.0 ± ∞ ¹    343.0 ± ∞ ¹        ~ (p=0.571 n=5)
RefreshRange/mixed-case/refresh_window=[75.00,95.00]-24     27.00 ± ∞ ¹    25.00 ± ∞ ¹   -7.41% (p=0.008 n=5)
RefreshRange/mixed-case/refresh_window=[75.00,99.00]-24     24.00 ± ∞ ¹    24.00 ± ∞ ¹        ~ (p=1.000 n=5) ²
RefreshRange/mixed-case/refresh_window=[95.00,95.00]-24     30.00 ± ∞ ¹    25.00 ± ∞ ¹  -16.67% (p=0.008 n=5)
RefreshRange/mixed-case/refresh_window=[95.00,99.00]-24     28.00 ± ∞ ¹    25.00 ± ∞ ¹  -10.71% (p=0.008 n=5)
RefreshRange/mixed-case/refresh_window=[99.00,99.00]-24     176.0 ± ∞ ¹    177.0 ± ∞ ¹        ~ (p=0.548 n=5)
```