### PR TITLE
*: decouple iterators when determining ingest target level 

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -5,6 +5,7 @@
 package pebble
 
 import (
+	"context"
 	"sort"
 	"time"
 
@@ -522,20 +523,22 @@ func ingestTargetLevel(
 		iter := newLevelIter(iterOps, cmp, nil /* split */, newIters,
 			v.L0Sublevels.Levels[subLevel].Iter(), manifest.Level(0), nil)
 
-		var rangeDelIter keyspan.FragmentIterator
-		// Pass in a non-nil pointer to rangeDelIter so that levelIter.findFileGE
-		// sets it up for the target file.
-		iter.initRangeDel(&rangeDelIter)
+		rangeDelIter := keyspan.LevelIter{}
+		rangeDelIter.Init(keyspan.SpanIterOptions{RangeKeyFilters: iterOps.RangeKeyFilters}, cmp,
+			tableNewRangeDelIter(context.Background(), newIters), v.L0Sublevels.Levels[subLevel].Iter(),
+			manifest.Level(0), manifest.KeyTypePoint)
+		fragmentRangeDelIter := keyspan.FragmentIterator(&rangeDelIter)
 
-		levelIter := keyspan.LevelIter{}
-		levelIter.Init(
+		rangeKeyIter := keyspan.LevelIter{}
+		rangeKeyIter.Init(
 			keyspan.SpanIterOptions{}, cmp, newRangeKeyIter,
 			v.L0Sublevels.Levels[subLevel].Iter(), manifest.Level(0), manifest.KeyTypeRange,
 		)
 
-		overlap := overlapWithIterator(iter, &rangeDelIter, &levelIter, meta, cmp)
-		err := iter.Close() // Closes range del iter as well.
-		err = firstError(err, levelIter.Close())
+		overlap := overlapWithIterator(iter, &fragmentRangeDelIter, &rangeKeyIter, meta, cmp)
+		err := iter.Close()
+		err = firstError(err, fragmentRangeDelIter.Close())
+		err = firstError(err, rangeKeyIter.Close())
 		if err != nil {
 			return 0, err
 		}
@@ -548,10 +551,12 @@ func ingestTargetLevel(
 	for ; level < numLevels; level++ {
 		levelIter := newLevelIter(iterOps, cmp, nil /* split */, newIters,
 			v.Levels[level].Iter(), manifest.Level(level), nil)
-		var rangeDelIter keyspan.FragmentIterator
-		// Pass in a non-nil pointer to rangeDelIter so that levelIter.findFileGE
-		// sets it up for the target file.
-		levelIter.initRangeDel(&rangeDelIter)
+
+		rangeDelIter := keyspan.LevelIter{}
+		rangeDelIter.Init(keyspan.SpanIterOptions{RangeKeyFilters: iterOps.RangeKeyFilters}, cmp,
+			tableNewRangeDelIter(context.Background(), newIters), v.Levels[level].Iter(),
+			manifest.Level(level), manifest.KeyTypePoint)
+		fragmentRangeDelIter := keyspan.FragmentIterator(&rangeDelIter)
 
 		rkeyLevelIter := &keyspan.LevelIter{}
 		rkeyLevelIter.Init(
@@ -559,8 +564,9 @@ func ingestTargetLevel(
 			v.Levels[level].Iter(), manifest.Level(level), manifest.KeyTypeRange,
 		)
 
-		overlap := overlapWithIterator(levelIter, &rangeDelIter, rkeyLevelIter, meta, cmp)
-		err := levelIter.Close() // Closes range del iter as well.
+		overlap := overlapWithIterator(levelIter, &fragmentRangeDelIter, rkeyLevelIter, meta, cmp)
+		err := levelIter.Close()
+		err = firstError(err, fragmentRangeDelIter.Close())
 		err = firstError(err, rkeyLevelIter.Close())
 		if err != nil {
 			return 0, err

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -317,8 +317,8 @@ compact         1   4.7 K     0 B       0                          (size == esti
  memtbl         1   512 K
 zmemtbl         0     0 B
    ztbl         0     0 B
- bcache        16   2.9 K   14.3%  (score == hit-rate)
- tcache         1   720 B   50.0%  (score == hit-rate)
+ bcache        22   4.2 K   28.6%  (score == hit-rate)
+ tcache         4   2.8 K   57.1%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)


### PR DESCRIPTION
Previously, when determining the level at which to ingest an SST,
we would call `overlapWithIterator` with a level iterator
and range deletion interator for each level. The range deletion
iterator was taken from a field of the level iterator. This behavior
is incorrect because the state of the range deletion iterator will depend
on the state of the level iterator, which is is unexpected by
`overlapWithIterator`. This change makes is so that the range deletion
iterator is created independently from the level iterator.

Release note: None
Epic: None