### PR TITLE
sstable: include SINGLEDELs within NumDeletions table property

### DIFF
--- a/sstable/internal.go
+++ b/sstable/internal.go
@@ -21,6 +21,7 @@ const (
 	InternalKeyKindSet             = base.InternalKeyKindSet
 	InternalKeyKindMerge           = base.InternalKeyKindMerge
 	InternalKeyKindLogData         = base.InternalKeyKindLogData
+	InternalKeyKindSingleDelete    = base.InternalKeyKindSingleDelete
 	InternalKeyKindRangeDelete     = base.InternalKeyKindRangeDelete
 	InternalKeyKindMax             = base.InternalKeyKindMax
 	InternalKeyKindInvalid         = base.InternalKeyKindInvalid

--- a/sstable/testdata/writer
+++ b/sstable/testdata/writer
@@ -14,7 +14,7 @@ scan-range-del
 scan-range-key
 ----
 
-build
+build props=(deletions,deleted)
 a.SET.1:a
 b.DEL.2:
 c.MERGE.3:c
@@ -31,6 +31,33 @@ point:    [a#1,1-h#7,2]
 rangedel: [d#4,15-j#72057594037927935,15]
 rangekey: [j#9,19-m#72057594037927935,21]
 seqnums:  [1-11]
+props "deletions":
+  rocksdb.num.range-deletions: 2
+props "deleted":
+  rocksdb.deleted.keys: 4
+
+
+build props=(deletions,deleted)
+a.SET.1:a
+b.DEL.2:
+c.MERGE.3:c
+d.SINGLEDEL.4:
+e.SINGLEDEL.5:
+f.SET.6:f
+g.DEL.7:
+h.SINGLEDEL.8:
+rangekey: j-k:{(#9,RANGEKEYDEL)}
+rangekey: k-l:{(#10,RANGEKEYUNSET,@t5)}
+rangekey: l-m:{(#11,RANGEKEYSET,@t10,foo)}
+----
+point:    [a#1,1-h#8,7]
+rangekey: [j#9,19-m#72057594037927935,21]
+seqnums:  [1-11]
+props "deletions":
+  rocksdb.num.range-deletions: 0
+props "deleted":
+  rocksdb.deleted.keys: 5
+
 
 build
 a.SET.1:a

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -930,7 +930,7 @@ func (w *Writer) addPoint(key InternalKey, value []byte) error {
 
 	w.props.NumEntries++
 	switch key.Kind() {
-	case InternalKeyKindDelete:
+	case InternalKeyKindDelete, InternalKeyKindSingleDelete:
 		w.props.NumDeletions++
 	case InternalKeyKindMerge:
 		w.props.NumMergeOperands++

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -70,7 +70,15 @@ func runDataDriven(t *testing.T, file string, tableFormat TableFormat, paralleli
 		}
 	}()
 
-	format := func(m *WriterMetadata) string {
+	format := func(td *datadriven.TestData, m *WriterMetadata) string {
+		var requestedProps []string
+		for _, cmdArg := range td.CmdArgs {
+			switch cmdArg.Key {
+			case "props":
+				requestedProps = cmdArg.Vals
+			}
+		}
+
 		var b bytes.Buffer
 		if m.HasPointKeys {
 			fmt.Fprintf(&b, "point:    [%s-%s]\n", m.SmallestPoint, m.LargestPoint)
@@ -82,6 +90,19 @@ func runDataDriven(t *testing.T, file string, tableFormat TableFormat, paralleli
 			fmt.Fprintf(&b, "rangekey: [%s-%s]\n", m.SmallestRangeKey, m.LargestRangeKey)
 		}
 		fmt.Fprintf(&b, "seqnums:  [%d-%d]\n", m.SmallestSeqNum, m.LargestSeqNum)
+
+		if len(requestedProps) > 0 {
+			props := strings.Split(r.Properties.String(), "\n")
+			for _, requestedProp := range requestedProps {
+				fmt.Fprintf(&b, "props %q:\n", requestedProp)
+				for _, prop := range props {
+					if strings.Contains(prop, requestedProp) {
+						fmt.Fprintf(&b, "  %s\n", prop)
+					}
+				}
+			}
+		}
+
 		return b.String()
 	}
 
@@ -101,7 +122,7 @@ func runDataDriven(t *testing.T, file string, tableFormat TableFormat, paralleli
 			if err != nil {
 				return err.Error()
 			}
-			return format(meta)
+			return format(td, meta)
 
 		case "build-raw":
 			if r != nil {
@@ -116,7 +137,7 @@ func runDataDriven(t *testing.T, file string, tableFormat TableFormat, paralleli
 			if err != nil {
 				return err.Error()
 			}
-			return format(meta)
+			return format(td, meta)
 
 		case "scan":
 			origIter, err := r.NewIter(nil /* lower */, nil /* upper */)
@@ -205,7 +226,7 @@ func runDataDriven(t *testing.T, file string, tableFormat TableFormat, paralleli
 			if err != nil {
 				return err.Error()
 			}
-			return format(meta)
+			return format(td, meta)
 
 		default:
 			return fmt.Sprintf("unknown command: %s", td.Cmd)


### PR DESCRIPTION
Previously, the sstable property recording the number of deletion tombstones within a file included DELs and RANGEDELs but not SINGLEDELs. This caused SINGLEDELs to be excluded from point tombstone compaction heuristics that use these properties to estimate the amount of disk space that may be reclaimed by compacting a file.