### PR TITLE
db: use exact accounting of point tombstone key sizes

### DIFF
--- a/sstable/properties_test.go
+++ b/sstable/properties_test.go
@@ -109,7 +109,7 @@ func TestPropertiesSave(t *testing.T) {
 		// Check that we can save properties and read them back.
 		var w rawBlockWriter
 		w.restartInterval = propertiesBlockRestartInterval
-		expected.save(&w)
+		expected.save(TableFormatPebblev2, &w)
 		var props Properties
 		require.NoError(t, props.load(w.finish(), 0))
 		props.Loaded = nil

--- a/sstable/testdata/writer_value_blocks
+++ b/sstable/testdata/writer_value_blocks
@@ -296,46 +296,47 @@ layout
         71    block:0/66 [restart]
         85    [restart 71]
         93    [trailer compression=none checksum=0xf80f5bcf]
-        98  properties (676)
-        98    rocksdb.block.based.table.index.type (43) [restart]
-       141    rocksdb.block.based.table.prefix.filtering (20)
-       161    rocksdb.block.based.table.whole.key.filtering (23)
-       184    rocksdb.column.family.id (24)
-       208    rocksdb.comparator (35)
-       243    rocksdb.compression (16)
-       259    rocksdb.compression_options (106)
-       365    rocksdb.creation.time (16)
-       381    rocksdb.data.size (13)
-       394    rocksdb.deleted.keys (15)
-       409    rocksdb.external_sst_file.global_seqno (41)
-       450    rocksdb.external_sst_file.version (14)
-       464    rocksdb.filter.size (15)
-       479    rocksdb.fixed.key.length (18)
-       497    rocksdb.format.version (17)
-       514    rocksdb.index.key.is.user.key (25)
-       539    rocksdb.index.size (8)
-       547    rocksdb.index.value.is.delta.encoded (26)
-       573    rocksdb.merge.operands (18)
-       591    rocksdb.merge.operator (24)
-       615    rocksdb.num.data.blocks (19)
-       634    rocksdb.num.entries (11)
-       645    rocksdb.num.range-deletions (19)
-       664    rocksdb.oldest.key.time (19)
-       683    rocksdb.prefix.extractor.name (31)
-       714    rocksdb.property.collectors (22)
-       736    rocksdb.raw.key.size (16)
-       752    rocksdb.raw.value.size (14)
-       766    [restart 98]
-       774    [trailer compression=none checksum=0x9367b10c]
-       779  meta-index (32)
-       779    rocksdb.properties block:98/676 [restart]
-       803    [restart 779]
-       811    [trailer compression=none checksum=0xca0f17d]
-       816  footer (53)
-       816    checksum type: crc32c
-       817    meta: offset=779, length=32
-       820    index: offset=71, length=22
-       822    [padding]
-       857    version: 3
-       861    magic number: 0xf09faab3f09faab3
-       869  EOF
+        98  properties (715)
+        98    pebble.raw.point-tombstone.key.size (39) [restart]
+       137    rocksdb.block.based.table.index.type (43)
+       180    rocksdb.block.based.table.prefix.filtering (20)
+       200    rocksdb.block.based.table.whole.key.filtering (23)
+       223    rocksdb.column.family.id (24)
+       247    rocksdb.comparator (35)
+       282    rocksdb.compression (16)
+       298    rocksdb.compression_options (106)
+       404    rocksdb.creation.time (16)
+       420    rocksdb.data.size (13)
+       433    rocksdb.deleted.keys (15)
+       448    rocksdb.external_sst_file.global_seqno (41)
+       489    rocksdb.external_sst_file.version (14)
+       503    rocksdb.filter.size (15)
+       518    rocksdb.fixed.key.length (18)
+       536    rocksdb.format.version (17)
+       553    rocksdb.index.key.is.user.key (25)
+       578    rocksdb.index.size (8)
+       586    rocksdb.index.value.is.delta.encoded (26)
+       612    rocksdb.merge.operands (18)
+       630    rocksdb.merge.operator (24)
+       654    rocksdb.num.data.blocks (19)
+       673    rocksdb.num.entries (11)
+       684    rocksdb.num.range-deletions (19)
+       703    rocksdb.oldest.key.time (19)
+       722    rocksdb.prefix.extractor.name (31)
+       753    rocksdb.property.collectors (22)
+       775    rocksdb.raw.key.size (16)
+       791    rocksdb.raw.value.size (14)
+       805    [restart 98]
+       813    [trailer compression=none checksum=0x89a91fa9]
+       818  meta-index (32)
+       818    rocksdb.properties block:98/715 [restart]
+       842    [restart 818]
+       850    [trailer compression=none checksum=0x8ca405dc]
+       855  footer (53)
+       855    checksum type: crc32c
+       856    meta: offset=818, length=32
+       859    index: offset=71, length=22
+       861    [padding]
+       896    version: 3
+       900    magic number: 0xf09faab3f09faab3
+       908  EOF

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -932,6 +932,7 @@ func (w *Writer) addPoint(key InternalKey, value []byte) error {
 	switch key.Kind() {
 	case InternalKeyKindDelete, InternalKeyKindSingleDelete:
 		w.props.NumDeletions++
+		w.props.RawPointTombstoneKeySize += uint64(key.Size())
 	case InternalKeyKindMerge:
 		w.props.NumMergeOperands++
 	}
@@ -1948,7 +1949,7 @@ func (w *Writer) Close() (err error) {
 		// reduces table size without a significant impact on performance.
 		raw.restartInterval = propertiesBlockRestartInterval
 		w.props.CompressionOptions = rocksDBCompressionOptions
-		w.props.save(&raw)
+		w.props.save(w.tableFormat, &raw)
 		bh, err := w.writeBlock(raw.finish(), NoCompression, &w.blockBuf)
 		if err != nil {
 			return err

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -80,12 +80,12 @@ wait-pending-table-stats
 num-entries: 2
 num-deletions: 1
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 0
+point-deletions-bytes-estimate: 778
 range-deletions-bytes-estimate: 0
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (783 B) + L6 [] (0 B) -> L6 [000005] (771 B), in 1.0s (2.0s total), output rate 771 B/s
+[JOB 100] compacted(elision-only) L6 [000004] (822 B) + L6 [] (0 B) -> L6 [000005] (771 B), in 1.0s (2.0s total), output rate 771 B/s
 
 version
 ----
@@ -119,7 +119,7 @@ wait-pending-table-stats
 num-entries: 6
 num-deletions: 2
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 0
+point-deletions-bytes-estimate: 308
 range-deletions-bytes-estimate: 76
 
 maybe-compact
@@ -134,7 +134,7 @@ close-snapshot
 close-snapshot
 103
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (984 B) + L6 [] (0 B) -> L6 [] (0 B), in 1.0s (2.0s total), output rate 0 B/s
+[JOB 100] compacted(elision-only) L6 [000004] (1012 B) + L6 [] (0 B) -> L6 [] (0 B), in 1.0s (2.0s total), output rate 0 B/s
 
 # Test a table that contains both deletions and non-deletions, but whose
 # non-deletions well outnumber its deletions. The table should not be
@@ -152,7 +152,7 @@ wait-pending-table-stats
 num-entries: 11
 num-deletions: 1
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 165
+point-deletions-bytes-estimate: 170
 range-deletions-bytes-estimate: 0
 
 close-snapshot
@@ -233,7 +233,7 @@ wait-pending-table-stats
 num-entries: 3
 num-deletions: 3
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 13167
+point-deletions-bytes-estimate: 14782
 range-deletions-bytes-estimate: 0
 
 # By plain file size, 000005 should be picked because it is larger and
@@ -243,7 +243,7 @@ range-deletions-bytes-estimate: 0
 
 maybe-compact
 ----
-[JOB 100] compacted(default) L5 [000004] (794 B) + L6 [000006] (13 K) -> L6 [] (0 B), in 1.0s (2.0s total), output rate 0 B/s
+[JOB 100] compacted(default) L5 [000004] (833 B) + L6 [000006] (13 K) -> L6 [] (0 B), in 1.0s (2.0s total), output rate 0 B/s
 
 # A table containing only range keys is not eligible for elision.
 # RANGEKEYDEL or RANGEKEYUNSET.
@@ -359,7 +359,7 @@ wait-pending-table-stats
 num-entries: 2
 num-deletions: 1
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 4389
+point-deletions-bytes-estimate: 5193
 range-deletions-bytes-estimate: 0
 
 wait-pending-table-stats
@@ -402,7 +402,7 @@ wait-pending-table-stats
 num-entries: 2
 num-deletions: 1
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 4389
+point-deletions-bytes-estimate: 5193
 range-deletions-bytes-estimate: 0
 
 wait-pending-table-stats
@@ -416,4 +416,4 @@ range-deletions-bytes-estimate: 8244
 
 maybe-compact
 ----
-[JOB 100] compacted(default) L5 [000004] (782 B) + L6 [000006] (13 K) -> L6 [000008] (4.8 K), in 1.0s (2.0s total), output rate 4.8 K/s
+[JOB 100] compacted(default) L5 [000004] (821 B) + L6 [000006] (13 K) -> L6 [000008] (4.8 K), in 1.0s (2.0s total), output rate 4.8 K/s

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -239,7 +239,7 @@ compact         1   2.3 K     0 B       0                          (size == esti
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.4 K   11.1%  (score == hit-rate)
- tcache         1   720 B   40.0%  (score == hit-rate)
+ tcache         1   728 B   40.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)
@@ -318,7 +318,7 @@ compact         1   4.7 K     0 B       0                          (size == esti
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache        16   2.9 K   14.3%  (score == hit-rate)
- tcache         1   720 B   50.0%  (score == hit-rate)
+ tcache         1   728 B   50.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -48,7 +48,7 @@ compact         0     0 B     0 B       0                          (size == esti
 zmemtbl         0     0 B
    ztbl         0     0 B
  bcache         8   1.5 K   42.9%  (score == hit-rate)
- tcache         1   720 B   50.0%  (score == hit-rate)
+ tcache         1   728 B   50.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         0
  filter         -       -    0.0%  (score == utility)

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -34,7 +34,7 @@ compact         0     0 B     0 B       0                          (size == esti
 zmemtbl         1   256 K
    ztbl         0     0 B
  bcache         4   697 B    0.0%  (score == hit-rate)
- tcache         1   720 B    0.0%  (score == hit-rate)
+ tcache         1   728 B    0.0%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         1
  filter         -       -    0.0%  (score == utility)
@@ -145,7 +145,7 @@ compact         1     0 B     0 B       0                          (size == esti
 zmemtbl         1   256 K
    ztbl         1   770 B
  bcache         4   697 B   42.9%  (score == hit-rate)
- tcache         1   720 B   66.7%  (score == hit-rate)
+ tcache         1   728 B   66.7%  (score == hit-rate)
   snaps         0       -       0  (score == earliest seq num)
  titers         1
  filter         -       -    0.0%  (score == utility)

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -15,7 +15,7 @@ wait-pending-table-stats
 num-entries: 3
 num-deletions: 1
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 0
+point-deletions-bytes-estimate: 517
 range-deletions-bytes-estimate: 0
 
 compact a-c


### PR DESCRIPTION
Pebble's compaction heuristics estimate the amount of disk space that will be reclaimed by compacting a file due to point tombstones contained within a file. This estimate is used to increase the priority of compacting these files by inflating the file size during level scoring and file picking.

Previously, these heuristics relied on average key sizes to estimate the space reclaimed by tombstones. Depending on the density of point tombstones, this average was computed over the table's own keys or over all overlapping tables in lower levels.

This commit updates this estimation to instead use a new sstable property that totals all point tombstones' key sizes within a file. This exact sum of the logical bytes that will be reclaimed through compaction, removing all error from uneven distributions of key sizes. This logical estimate must then be scaled to physical sizes to account for compression, metadata, etc. This source of error remains, since different keys may be unequally compressible.

This commit does not alter the logic for estimating the amount of disk space that will be reclaimed through removing deleted entries' values, which continues to rely exclusively on averages. Future work (#2340) will seek to remove the error introduced by value sizes when a user knows the size of the value they're removing.