### PR TITLE
db: introduce interface for sstable readers

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1011,7 +1011,7 @@ func TestCompaction(t *testing.T) {
 				if err != nil {
 					return "", "", errors.WithStack(err)
 				}
-				r, err := sstable.NewReader(f, sstable.ReaderOptions{})
+				r, err := sstable.NewPhysicalReader(f, sstable.ReaderOptions{})
 				if err != nil {
 					return "", "", errors.WithStack(err)
 				}

--- a/data_test.go
+++ b/data_test.go
@@ -1104,7 +1104,7 @@ func runSSTablePropertiesCmd(t *testing.T, td *datadriven.TestData, d *DB) strin
 	if err != nil {
 		return err.Error()
 	}
-	r, err := sstable.NewReader(readable, d.opts.MakeReaderOptions())
+	r, err := sstable.NewPhysicalReader(readable, d.opts.MakeReaderOptions())
 	if err != nil {
 		return err.Error()
 	}

--- a/db.go
+++ b/db.go
@@ -1918,7 +1918,7 @@ func (d *DB) EstimateDiskUsage(start, end []byte) (uint64, error) {
 				var size uint64
 				err := d.tableCache.withReader(
 					file,
-					func(r *sstable.Reader) (err error) {
+					func(r sstable.Reader) (err error) {
 						size, err = r.EstimateDiskUsage(start, end)
 						return err
 					},

--- a/external_iterator_test.go
+++ b/external_iterator_test.go
@@ -231,7 +231,7 @@ func TestIterRandomizedMaybeFilteredKeys(t *testing.T) {
 			readable, err := sstable.NewSimpleReadable(f1)
 			require.NoError(t, err)
 
-			r, err := sstable.NewReader(readable, sstable.ReaderOptions{
+			r, err := sstable.NewPhysicalReader(readable, sstable.ReaderOptions{
 				Cache:    c,
 				Comparer: testkeys.Comparer,
 			})
@@ -246,7 +246,7 @@ func TestIterRandomizedMaybeFilteredKeys(t *testing.T) {
 			var iter sstable.Iterator
 			iter, err = r.NewIterWithBlockPropertyFilters(
 				nil, nil, filterer, false /* useFilterBlock */, nil, /* stats */
-				sstable.TrivialReaderProvider{Reader: r})
+				sstable.TrivialReaderProvider{PhysicalReader: r})
 			require.NoError(t, err)
 			defer iter.Close()
 			var lastSeekKey, lowerBound, upperBound []byte

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -521,7 +521,7 @@ var markFilesPrePebblev1 = func(tc *tableCacheContainer) findFilesFunc {
 		for l := numLevels - 1; l > 0; l-- {
 			iter := v.Levels[l].Iter()
 			for f := iter.First(); f != nil; f = iter.Next() {
-				err = tc.withReader(f, func(r *sstable.Reader) error {
+				err = tc.withReader(f, func(r sstable.Reader) error {
 					tf, err := r.TableFormat()
 					if err != nil {
 						return err

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -440,7 +440,7 @@ func TestPebblev1Migration(t *testing.T) {
 					iter := l.Iter()
 					for m := iter.First(); m != nil; m = iter.Next() {
 						err := d.tableCache.withReader(m,
-							func(r *sstable.Reader) error {
+							func(r sstable.Reader) error {
 								f, err := r.TableFormat()
 								if err != nil {
 									return err

--- a/ingest.go
+++ b/ingest.go
@@ -58,7 +58,7 @@ func ingestLoad1(
 	}
 
 	cacheOpts := private.SSTableCacheOpts(cacheID, fileNum).(sstable.ReaderOption)
-	r, err := sstable.NewReader(readable, opts.MakeReaderOptions(), cacheOpts)
+	r, err := sstable.NewPhysicalReader(readable, opts.MakeReaderOptions(), cacheOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -1152,7 +1152,7 @@ func (d *DB) validateSSTables() {
 		}
 
 		err := d.tableCache.withReader(
-			f.Meta, func(r *sstable.Reader) error {
+			f.Meta, func(r sstable.Reader) error {
 				return r.ValidateBlockChecksums()
 			})
 		if err != nil {

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1833,7 +1833,7 @@ func TestIngestValidation(t *testing.T) {
 				require.NoError(t, err)
 				// Compute the layout of the sstable in order to find the
 				// appropriate block locations to corrupt.
-				r, err := sstable.NewReader(readable, sstable.ReaderOptions{})
+				r, err := sstable.NewPhysicalReader(readable, sstable.ReaderOptions{})
 				require.NoError(t, err)
 				l, err := r.Layout()
 				require.NoError(t, err)

--- a/iterator.go
+++ b/iterator.go
@@ -224,7 +224,7 @@ type Iterator struct {
 	prefixOrFullSeekKey []byte
 	readSampling        readSampling
 	stats               IteratorStats
-	externalReaders     [][]*sstable.Reader
+	externalReaders     [][]*sstable.PhysicalReader
 
 	// Following fields used when constructing an iterator stack, eg, in Clone
 	// and SetOptions or when re-fragmenting a batch's range keys/range dels.

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -2051,7 +2051,7 @@ func BenchmarkIteratorPrev(b *testing.B) {
 
 type twoLevelBloomTombstoneState struct {
 	keys        [][]byte
-	readers     [8][][]*sstable.Reader
+	readers     [8][][]*sstable.PhysicalReader
 	levelSlices [8][]manifest.LevelSlice
 	indexFunc   func(twoLevelIndex bool, bloom bool, withTombstone bool) int
 }
@@ -2061,7 +2061,7 @@ func setupForTwoLevelBloomTombstone(b *testing.B, keyOffset int) twoLevelBloomTo
 	const restartInterval = 16
 	const levelCount = 5
 
-	var readers [8][][]*sstable.Reader
+	var readers [8][][]*sstable.PhysicalReader
 	var levelSlices [8][]manifest.LevelSlice
 	var keys [][]byte
 	indexFunc := func(twoLevelIndex bool, bloom bool, withTombstone bool) int {

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -87,7 +87,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 	var levels [][]*fileMetadata
 	formatKey := DefaultComparer.FormatKey
 	// Indexed by fileNum
-	var readers []*sstable.Reader
+	var readers []*sstable.PhysicalReader
 	defer func() {
 		for _, r := range readers {
 			r.Close()
@@ -211,7 +211,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 					return err.Error()
 				}
 				cacheOpts := private.SSTableCacheOpts(0, base.FileNum(uint64(fileNum)-1).DiskFileNum()).(sstable.ReaderOption)
-				r, err := sstable.NewReader(readable, sstable.ReaderOptions{}, cacheOpts)
+				r, err := sstable.NewPhysicalReader(readable, sstable.ReaderOptions{}, cacheOpts)
 				if err != nil {
 					return err.Error()
 				}

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -952,7 +952,7 @@ func loadFlushedSSTableKeys(
 				f.Close()
 				return err
 			}
-			r, err := sstable.NewReader(readable, readOpts)
+			r, err := sstable.NewPhysicalReader(readable, readOpts)
 			if err != nil {
 				return err
 			}

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -866,7 +866,7 @@ func (c *suffixIntervalCollector) FinishDataBlock() (lower, upper uint64, err er
 }
 
 func TestBlockProperties(t *testing.T) {
-	var r *Reader
+	var r *PhysicalReader
 	defer func() {
 		if r != nil {
 			require.NoError(t, r.Close())
@@ -1010,7 +1010,7 @@ func TestBlockProperties(t *testing.T) {
 			}
 			iter, err := r.NewIterWithBlockPropertyFilters(
 				lower, upper, filterer, false /* use (bloom) filter */, &stats,
-				TrivialReaderProvider{Reader: r})
+				TrivialReaderProvider{PhysicalReader: r})
 			if err != nil {
 				return err.Error()
 			}
@@ -1026,7 +1026,7 @@ func TestBlockProperties(t *testing.T) {
 }
 
 func TestBlockProperties_BoundLimited(t *testing.T) {
-	var r *Reader
+	var r *PhysicalReader
 	defer func() {
 		if r != nil {
 			require.NoError(t, r.Close())
@@ -1090,7 +1090,7 @@ func TestBlockProperties_BoundLimited(t *testing.T) {
 			}
 			iter, err := r.NewIterWithBlockPropertyFilters(
 				lower, upper, filterer, false /* use (bloom) filter */, &stats,
-				TrivialReaderProvider{Reader: r})
+				TrivialReaderProvider{PhysicalReader: r})
 			if err != nil {
 				return err.Error()
 			}
@@ -1173,7 +1173,7 @@ func parseIntervalFilter(cmd datadriven.CmdArg) (BlockPropertyFilter, error) {
 	return NewBlockIntervalFilter(name, min, max), nil
 }
 
-func runCollectorsCmd(r *Reader, td *datadriven.TestData) string {
+func runCollectorsCmd(r *PhysicalReader, td *datadriven.TestData) string {
 	var lines []string
 	for k, v := range r.Properties.UserProperties {
 		lines = append(lines, fmt.Sprintf("%d: %s", v[0], k))
@@ -1183,7 +1183,7 @@ func runCollectorsCmd(r *Reader, td *datadriven.TestData) string {
 	return strings.Join(lines, "\n")
 }
 
-func runTablePropsCmd(r *Reader, td *datadriven.TestData) string {
+func runTablePropsCmd(r *PhysicalReader, td *datadriven.TestData) string {
 	var lines []string
 	for _, val := range r.Properties.UserProperties {
 		id := shortID(val[0])
@@ -1198,7 +1198,7 @@ func runTablePropsCmd(r *Reader, td *datadriven.TestData) string {
 	return strings.Join(lines, "\n")
 }
 
-func runBlockPropertiesBuildCmd(td *datadriven.TestData) (r *Reader, out string) {
+func runBlockPropertiesBuildCmd(td *datadriven.TestData) (r *PhysicalReader, out string) {
 	opts := WriterOptions{
 		TableFormat:    TableFormatPebblev2,
 		IndexBlockSize: math.MaxInt32, // Default to a single level index for simplicity.
@@ -1268,7 +1268,7 @@ func runBlockPropertiesBuildCmd(td *datadriven.TestData) (r *Reader, out string)
 		meta.SmallestSeqNum, meta.LargestSeqNum)
 }
 
-func runBlockPropsCmd(r *Reader, td *datadriven.TestData) string {
+func runBlockPropsCmd(r *PhysicalReader, td *datadriven.TestData) string {
 	bh, err := r.readIndex(context.Background(), nil)
 	if err != nil {
 		return err.Error()

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -61,7 +61,7 @@ func optsFromArgs(td *datadriven.TestData, writerOpts *WriterOptions) error {
 
 func runBuildCmd(
 	td *datadriven.TestData, writerOpts *WriterOptions, cacheSize int,
-) (*WriterMetadata, *Reader, error) {
+) (*WriterMetadata, *PhysicalReader, error) {
 
 	f0 := &memFile{}
 	if err := optsFromArgs(td, writerOpts); err != nil {
@@ -171,7 +171,7 @@ func runBuildCmd(
 
 func runBuildRawCmd(
 	td *datadriven.TestData, opts *WriterOptions,
-) (*WriterMetadata, *Reader, error) {
+) (*WriterMetadata, *PhysicalReader, error) {
 	mem := vfs.NewMem()
 	provider, err := objstorageprovider.Open(objstorageprovider.DefaultSettings(mem, "" /* dirName */))
 	if err != nil {
@@ -230,7 +230,7 @@ func runBuildRawCmd(
 	if err != nil {
 		return nil, nil, err
 	}
-	r, err := NewReader(f1, ReaderOptions{})
+	r, err := NewPhysicalReader(f1, ReaderOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -406,8 +406,8 @@ func runIterCmd(
 }
 
 func runRewriteCmd(
-	td *datadriven.TestData, r *Reader, writerOpts WriterOptions,
-) (*WriterMetadata, *Reader, error) {
+	td *datadriven.TestData, r *PhysicalReader, writerOpts WriterOptions,
+) (*WriterMetadata, *PhysicalReader, error) {
 	var from, to []byte
 	for _, arg := range td.CmdArgs {
 		switch arg.Key {

--- a/sstable/filter.go
+++ b/sstable/filter.go
@@ -30,7 +30,7 @@ type FilterMetricsTracker struct {
 
 var _ ReaderOption = (*FilterMetricsTracker)(nil)
 
-func (m *FilterMetricsTracker) readerApply(r *Reader) {
+func (m *FilterMetricsTracker) readerApply(r *PhysicalReader) {
 	if r.tableFilter != nil {
 		r.tableFilter.metrics = m
 	}

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -199,7 +199,7 @@ type singleLevelIterator struct {
 	// because we determined the block lies completely within the bound.
 	blockLower []byte
 	blockUpper []byte
-	reader     *Reader
+	reader     *PhysicalReader
 	index      blockIter
 	data       blockIter
 	dataRH     objstorage.ReadHandle
@@ -385,7 +385,7 @@ func checkRangeKeyFragmentBlockIterator(obj interface{}) {
 // between different Readers.
 func (i *singleLevelIterator) init(
 	ctx context.Context,
-	r *Reader,
+	r *PhysicalReader,
 	lower, upper []byte,
 	filterer *BlockPropertiesFilterer,
 	useFilter bool,
@@ -1671,7 +1671,7 @@ func (i *twoLevelIterator) resolveMaybeExcluded(dir int8) intersectsResult {
 
 func (i *twoLevelIterator) init(
 	ctx context.Context,
-	r *Reader,
+	r *PhysicalReader,
 	lower, upper []byte,
 	filterer *BlockPropertiesFilterer,
 	useFilter bool,
@@ -2485,7 +2485,7 @@ type blockTransform func([]byte) ([]byte, error)
 type ReaderOption interface {
 	// readerApply is called on the reader during opening in order to set internal
 	// parameters.
-	readerApply(*Reader)
+	readerApply(*PhysicalReader)
 }
 
 // Comparers is a map from comparer name to comparer. It is used for debugging
@@ -2494,7 +2494,7 @@ type ReaderOption interface {
 // as a parameter to NewReader.
 type Comparers map[string]*Comparer
 
-func (c Comparers) readerApply(r *Reader) {
+func (c Comparers) readerApply(r *PhysicalReader) {
 	if r.Compare != nil || r.Properties.ComparerName == "" {
 		return
 	}
@@ -2511,7 +2511,7 @@ func (c Comparers) readerApply(r *Reader) {
 // a parameter to NewReader.
 type Mergers map[string]*Merger
 
-func (m Mergers) readerApply(r *Reader) {
+func (m Mergers) readerApply(r *PhysicalReader) {
 	if r.mergerOK || r.Properties.MergerName == "" {
 		return
 	}
@@ -2530,7 +2530,7 @@ type cacheOpts struct {
 // sstable properties.
 func (c *cacheOpts) preApply() {}
 
-func (c *cacheOpts) readerApply(r *Reader) {
+func (c *cacheOpts) readerApply(r *PhysicalReader) {
 	if r.cacheID == 0 {
 		r.cacheID = c.cacheID
 	}
@@ -2556,7 +2556,7 @@ type rawTombstonesOpt struct{}
 
 func (rawTombstonesOpt) preApply() {}
 
-func (rawTombstonesOpt) readerApply(r *Reader) {
+func (rawTombstonesOpt) readerApply(r *PhysicalReader) {
 	r.rawTombstones = true
 }
 
@@ -2567,8 +2567,66 @@ func init() {
 	private.SSTableRawTombstonesOpt = rawTombstonesOpt{}
 }
 
-// Reader is a table reader.
-type Reader struct {
+// Reader is an interface used by both physical and virtual sstable readers.
+type Reader interface {
+	// NewIterWithBlockPropertyFilters returns an iterator for the contents of the
+	// table. If an error occurs, NewIterWithBlockPropertyFilters cleans up after
+	// itself and returns a nil iterator.
+	NewIterWithBlockPropertyFilters(
+		lower, upper []byte,
+		filterer *BlockPropertiesFilterer,
+		useFilterBlock bool,
+		stats *base.InternalIteratorStats,
+		rp ReaderProvider,
+	) (Iterator, error)
+	// NewIterWithBlockPropertyFiltersAndContext is similar to
+	// NewIterWithBlockPropertyFilters and additionally accepts a context for
+	// tracing.
+	NewIterWithBlockPropertyFiltersAndContext(
+		ctx context.Context,
+		lower, upper []byte,
+		filterer *BlockPropertiesFilterer,
+		useFilterBlock bool,
+		stats *base.InternalIteratorStats,
+		rp ReaderProvider,
+	) (Iterator, error)
+	// NewIter returns an iterator for the contents of the table. If an error
+	// occurs, NewIter cleans up after itself and returns a nil iterator. NewIter
+	// must only be used when the Reader is guaranteed to outlive any LazyValues
+	// returned from the iter.
+	NewIter(lower, upper []byte) (Iterator, error)
+	// NewCompactionIter returns an iterator similar to NewIter but it also increments
+	// the number of bytes iterated. If an error occurs, NewCompactionIter cleans up
+	// after itself and returns a nil iterator.
+	NewCompactionIter(bytesIterated *uint64, rp ReaderProvider) (Iterator, error)
+	// NewRawRangeDelIter returns an internal iterator for the contents of the
+	// range-del block for the table. Returns nil if the table does not contain
+	// any range deletions.
+	//
+	// TODO(sumeer): plumb context.Context since this path is relevant in the user-facing
+	// iterator. Add WithContext methods since the existing ones are public.
+	NewRawRangeDelIter() (keyspan.FragmentIterator, error)
+	// NewRawRangeKeyIter returns an internal iterator for the contents of the
+	// range-key block for the table. Returns nil if the table does not contain any
+	// range keys.
+	//
+	// TODO(sumeer): plumb context.Context since this path is relevant in the user-facing
+	// iterator. Add WithContext methods since the existing ones are public.
+	NewRawRangeKeyIter() (keyspan.FragmentIterator, error)
+	// ValidateBlockChecksums validates all of the block checksums in the sstable.
+	ValidateBlockChecksums() error
+	// EstimateDiskUsage can be used to estimate the disk usage by the sstable.
+	EstimateDiskUsage(start, end []byte) (uint64, error)
+	// TableFormat returns the format version for the table.
+	TableFormat() (TableFormat, error)
+	// Props returns the sstable Properties.
+	Props() *Properties
+}
+
+var _ Reader = (*PhysicalReader)(nil)
+
+// PhysicalReader is a table reader for a physical sstable.
+type PhysicalReader struct {
 	readable          objstorage.Readable
 	cacheID           uint64
 	fileNum           base.DiskFileNum
@@ -2596,8 +2654,13 @@ type Reader struct {
 	checksumType  ChecksumType
 }
 
+// Props implements the Reader interface.
+func (r *PhysicalReader) Props() *Properties {
+	return &r.Properties
+}
+
 // Close implements DB.Close, as documented in the pebble package.
-func (r *Reader) Close() error {
+func (r *PhysicalReader) Close() error {
 	r.opts.Cache.Unref()
 
 	if r.readable != nil {
@@ -2613,10 +2676,8 @@ func (r *Reader) Close() error {
 	return nil
 }
 
-// NewIterWithBlockPropertyFilters returns an iterator for the contents of the
-// table. If an error occurs, NewIterWithBlockPropertyFilters cleans up after
-// itself and returns a nil iterator.
-func (r *Reader) NewIterWithBlockPropertyFilters(
+// NewIterWithBlockPropertyFilters implements the Reader interface.
+func (r *PhysicalReader) NewIterWithBlockPropertyFilters(
 	lower, upper []byte,
 	filterer *BlockPropertiesFilterer,
 	useFilterBlock bool,
@@ -2627,10 +2688,8 @@ func (r *Reader) NewIterWithBlockPropertyFilters(
 		useFilterBlock, stats, rp)
 }
 
-// NewIterWithBlockPropertyFiltersAndContext is similar to
-// NewIterWithBlockPropertyFilters and additionally accepts a context for
-// tracing.
-func (r *Reader) NewIterWithBlockPropertyFiltersAndContext(
+// NewIterWithBlockPropertyFiltersAndContext implements the Reader interface.
+func (r *PhysicalReader) NewIterWithBlockPropertyFiltersAndContext(
 	ctx context.Context,
 	lower, upper []byte,
 	filterer *BlockPropertiesFilterer,
@@ -2659,20 +2718,17 @@ func (r *Reader) NewIterWithBlockPropertyFiltersAndContext(
 	return i, nil
 }
 
-// NewIter returns an iterator for the contents of the table. If an error
-// occurs, NewIter cleans up after itself and returns a nil iterator. NewIter
-// must only be used when the Reader is guaranteed to outlive any LazyValues
-// returned from the iter.
-func (r *Reader) NewIter(lower, upper []byte) (Iterator, error) {
+// NewIter implements the Reader interface.
+func (r *PhysicalReader) NewIter(lower, upper []byte) (Iterator, error) {
 	return r.NewIterWithBlockPropertyFilters(
 		lower, upper, nil, true /* useFilterBlock */, nil, /* stats */
-		TrivialReaderProvider{Reader: r})
+		TrivialReaderProvider{PhysicalReader: r})
 }
 
-// NewCompactionIter returns an iterator similar to NewIter but it also increments
-// the number of bytes iterated. If an error occurs, NewCompactionIter cleans up
-// after itself and returns a nil iterator.
-func (r *Reader) NewCompactionIter(bytesIterated *uint64, rp ReaderProvider) (Iterator, error) {
+// NewCompactionIter implements the Reader interface.
+func (r *PhysicalReader) NewCompactionIter(
+	bytesIterated *uint64, rp ReaderProvider,
+) (Iterator, error) {
 	if r.Properties.IndexType == twoLevelIndex {
 		i := twoLevelIterPool.Get().(*twoLevelIterator)
 		err := i.init(context.Background(), r, nil /* lower */, nil, /* upper */
@@ -2699,13 +2755,8 @@ func (r *Reader) NewCompactionIter(bytesIterated *uint64, rp ReaderProvider) (It
 	}, nil
 }
 
-// NewRawRangeDelIter returns an internal iterator for the contents of the
-// range-del block for the table. Returns nil if the table does not contain
-// any range deletions.
-//
-// TODO(sumeer): plumb context.Context since this path is relevant in the user-facing
-// iterator. Add WithContext methods since the existing ones are public.
-func (r *Reader) NewRawRangeDelIter() (keyspan.FragmentIterator, error) {
+// NewRawRangeDelIter implements the Reader interface.
+func (r *PhysicalReader) NewRawRangeDelIter() (keyspan.FragmentIterator, error) {
 	if r.rangeDelBH.Length == 0 {
 		return nil, nil
 	}
@@ -2720,13 +2771,8 @@ func (r *Reader) NewRawRangeDelIter() (keyspan.FragmentIterator, error) {
 	return i, nil
 }
 
-// NewRawRangeKeyIter returns an internal iterator for the contents of the
-// range-key block for the table. Returns nil if the table does not contain any
-// range keys.
-//
-// TODO(sumeer): plumb context.Context since this path is relevant in the user-facing
-// iterator. Add WithContext methods since the existing ones are public.
-func (r *Reader) NewRawRangeKeyIter() (keyspan.FragmentIterator, error) {
+// NewRawRangeKeyIter implements the Reader interface.
+func (r *PhysicalReader) NewRawRangeKeyIter() (keyspan.FragmentIterator, error) {
 	if r.rangeKeyBH.Length == 0 {
 		return nil, nil
 	}
@@ -2752,26 +2798,26 @@ func (i *rangeKeyFragmentBlockIter) Close() error {
 	return err
 }
 
-func (r *Reader) readIndex(
+func (r *PhysicalReader) readIndex(
 	ctx context.Context, stats *base.InternalIteratorStats,
 ) (cache.Handle, error) {
 	ctx = objiotracing.WithBlockType(ctx, objiotracing.MetadataBlock)
 	return r.readBlock(ctx, r.indexBH, nil, nil, stats)
 }
 
-func (r *Reader) readFilter(
+func (r *PhysicalReader) readFilter(
 	ctx context.Context, stats *base.InternalIteratorStats,
 ) (cache.Handle, error) {
 	ctx = objiotracing.WithBlockType(ctx, objiotracing.FilterBlock)
 	return r.readBlock(ctx, r.filterBH, nil /* transform */, nil /* readHandle */, stats)
 }
 
-func (r *Reader) readRangeDel(stats *base.InternalIteratorStats) (cache.Handle, error) {
+func (r *PhysicalReader) readRangeDel(stats *base.InternalIteratorStats) (cache.Handle, error) {
 	ctx := objiotracing.WithBlockType(context.Background(), objiotracing.MetadataBlock)
 	return r.readBlock(ctx, r.rangeDelBH, r.rangeDelTransform, nil /* readHandle */, stats)
 }
 
-func (r *Reader) readRangeKey(stats *base.InternalIteratorStats) (cache.Handle, error) {
+func (r *PhysicalReader) readRangeKey(stats *base.InternalIteratorStats) (cache.Handle, error) {
 	ctx := objiotracing.WithBlockType(context.Background(), objiotracing.MetadataBlock)
 	return r.readBlock(ctx, r.rangeKeyBH, nil /* transform */, nil /* readHandle */, stats)
 }
@@ -2799,7 +2845,7 @@ func checkChecksum(
 }
 
 // readBlock reads and decompresses a block from disk into memory.
-func (r *Reader) readBlock(
+func (r *PhysicalReader) readBlock(
 	ctx context.Context,
 	bh BlockHandle,
 	transform blockTransform,
@@ -2889,7 +2935,7 @@ func (r *Reader) readBlock(
 	return h, nil
 }
 
-func (r *Reader) transformRangeDelV1(b []byte) ([]byte, error) {
+func (r *PhysicalReader) transformRangeDelV1(b []byte) ([]byte, error) {
 	// Convert v1 (RocksDB format) range-del blocks to v2 blocks on the fly. The
 	// v1 format range-del blocks have unfragmented and unsorted range
 	// tombstones. We need properly fragmented and sorted range tombstones in
@@ -2932,7 +2978,7 @@ func (r *Reader) transformRangeDelV1(b []byte) ([]byte, error) {
 	return rangeDelBlock.finish(), nil
 }
 
-func (r *Reader) readMetaindex(metaindexBH BlockHandle) error {
+func (r *PhysicalReader) readMetaindex(metaindexBH BlockHandle) error {
 	b, err := r.readBlock(
 		context.Background(), metaindexBH, nil /* transform */, nil /* readHandle */, nil /* stats */)
 	if err != nil {
@@ -3033,7 +3079,7 @@ func (r *Reader) readMetaindex(metaindexBH BlockHandle) error {
 }
 
 // Layout returns the layout (block organization) for an sstable.
-func (r *Reader) Layout() (*Layout, error) {
+func (r *PhysicalReader) Layout() (*Layout, error) {
 	if r.err != nil {
 		return nil, r.err
 	}
@@ -3142,7 +3188,7 @@ func (r *Reader) Layout() (*Layout, error) {
 }
 
 // ValidateBlockChecksums validates the checksums for each block in the SSTable.
-func (r *Reader) ValidateBlockChecksums() error {
+func (r *PhysicalReader) ValidateBlockChecksums() error {
 	// Pre-compute the BlockHandles for the underlying file.
 	l, err := r.Layout()
 	if err != nil {
@@ -3201,7 +3247,7 @@ func (r *Reader) ValidateBlockChecksums() error {
 // TODO(ajkr): account for metablock space usage. Perhaps look at the fraction of
 // data blocks overlapped and add that same fraction of the metadata blocks to the
 // estimate.
-func (r *Reader) EstimateDiskUsage(start, end []byte) (uint64, error) {
+func (r *PhysicalReader) EstimateDiskUsage(start, end []byte) (uint64, error) {
 	if r.err != nil {
 		return 0, r.err
 	}
@@ -3318,19 +3364,21 @@ func (r *Reader) EstimateDiskUsage(start, end []byte) (uint64, error) {
 		endBH.Offset + endBH.Length + blockTrailerLen - startBH.Offset), nil
 }
 
-// TableFormat returns the format version for the table.
-func (r *Reader) TableFormat() (TableFormat, error) {
+// TableFormat implements the Reader interface.
+func (r *PhysicalReader) TableFormat() (TableFormat, error) {
 	if r.err != nil {
 		return TableFormatUnspecified, r.err
 	}
 	return r.tableFormat, nil
 }
 
-// NewReader returns a new table reader for the file. Closing the reader will
+// NewPhysicalReader returns a new table reader for the file. Closing the reader will
 // close the file.
-func NewReader(f objstorage.Readable, o ReaderOptions, extraOpts ...ReaderOption) (*Reader, error) {
+func NewPhysicalReader(
+	f objstorage.Readable, o ReaderOptions, extraOpts ...ReaderOption,
+) (*PhysicalReader, error) {
 	o = o.ensureDefaults()
-	r := &Reader{
+	r := &PhysicalReader{
 		readable: f,
 		opts:     o,
 	}
@@ -3431,7 +3479,7 @@ type Layout struct {
 // Describe returns a description of the layout. If the verbose parameter is
 // true, details of the structure of each block are returned as well.
 func (l *Layout) Describe(
-	w io.Writer, verbose bool, r *Reader, fmtRecord func(key *base.InternalKey, value []byte),
+	w io.Writer, verbose bool, r *PhysicalReader, fmtRecord func(key *base.InternalKey, value []byte),
 ) {
 	ctx := context.TODO()
 	type block struct {

--- a/sstable/suffix_rewriter_test.go
+++ b/sstable/suffix_rewriter_test.go
@@ -212,10 +212,10 @@ func BenchmarkRewriteSST(b *testing.B) {
 	sizes := []int{100, 10000, 1e6}
 	compressions := []Compression{NoCompression, SnappyCompression}
 
-	files := make([][]*Reader, len(compressions))
+	files := make([][]*PhysicalReader, len(compressions))
 
 	for comp := range compressions {
-		files[comp] = make([]*Reader, len(sizes))
+		files[comp] = make([]*PhysicalReader, len(sizes))
 
 		for size := range sizes {
 			writerOpts.Compression = compressions[comp]

--- a/sstable/value_block.go
+++ b/sstable/value_block.go
@@ -667,7 +667,7 @@ type blockProviderWhenOpen interface {
 
 type blockProviderWhenClosed struct {
 	rp ReaderProvider
-	r  *Reader
+	r  *PhysicalReader
 }
 
 func (bpwc *blockProviderWhenClosed) open() error {
@@ -691,21 +691,21 @@ func (bpwc blockProviderWhenClosed) readBlockForVBR(
 // ReaderProvider supports the implementation of blockProviderWhenClosed.
 // GetReader and Close can be called multiple times in pairs.
 type ReaderProvider interface {
-	GetReader() (r *Reader, err error)
+	GetReader() (r *PhysicalReader, err error)
 	Close()
 }
 
 // TrivialReaderProvider implements ReaderProvider for a Reader that will
 // outlive the top-level iterator in the iterator tree.
 type TrivialReaderProvider struct {
-	*Reader
+	*PhysicalReader
 }
 
 var _ ReaderProvider = TrivialReaderProvider{}
 
 // GetReader implements ReaderProvider.
-func (trp TrivialReaderProvider) GetReader() (*Reader, error) {
-	return trp.Reader, nil
+func (trp TrivialReaderProvider) GetReader() (*PhysicalReader, error) {
+	return trp.PhysicalReader, nil
 }
 
 // Close implements ReaderProvider.

--- a/sstable/writer_rangekey_test.go
+++ b/sstable/writer_rangekey_test.go
@@ -16,14 +16,14 @@ import (
 )
 
 func TestWriter_RangeKeys(t *testing.T) {
-	var r *Reader
+	var r *PhysicalReader
 	defer func() {
 		if r != nil {
 			require.NoError(t, r.Close())
 		}
 	}()
 
-	buildFn := func(td *datadriven.TestData) (*Reader, error) {
+	buildFn := func(td *datadriven.TestData) (*PhysicalReader, error) {
 		mem := vfs.NewMem()
 		f, err := mem.Create("test")
 		if err != nil {

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -63,7 +63,7 @@ func TestRewriterParallel(t *testing.T) {
 }
 
 func runDataDriven(t *testing.T, file string, tableFormat TableFormat, parallelism bool) {
-	var r *Reader
+	var r *PhysicalReader
 	defer func() {
 		if r != nil {
 			require.NoError(t, r.Close())
@@ -235,7 +235,7 @@ func runDataDriven(t *testing.T, file string, tableFormat TableFormat, paralleli
 }
 
 func TestWriterWithValueBlocks(t *testing.T) {
-	var r *Reader
+	var r *PhysicalReader
 	defer func() {
 		if r != nil {
 			require.NoError(t, r.Close())

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -201,12 +201,12 @@ func TestTableRangeDeletionIter(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			var r *sstable.Reader
+			var r *sstable.PhysicalReader
 			readable, err := sstable.NewSimpleReadable(f)
 			if err != nil {
 				return err.Error()
 			}
-			r, err = sstable.NewReader(readable, sstable.ReaderOptions{})
+			r, err = sstable.NewPhysicalReader(readable, sstable.ReaderOptions{})
 			if err != nil {
 				return err.Error()
 			}

--- a/tool/db.go
+++ b/tool/db.go
@@ -679,7 +679,7 @@ func (d *dbT) addProps(
 	if err != nil {
 		return err
 	}
-	r, err := sstable.NewReader(f, sstable.ReaderOptions{}, d.mergers, d.comparers)
+	r, err := sstable.NewPhysicalReader(f, sstable.ReaderOptions{}, d.mergers, d.comparers)
 	if err != nil {
 		_ = f.Close()
 		return err

--- a/tool/find.go
+++ b/tool/find.go
@@ -425,7 +425,7 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 			if err != nil {
 				return err
 			}
-			r, err := sstable.NewReader(readable, opts, f.comparers, f.mergers,
+			r, err := sstable.NewPhysicalReader(readable, opts, f.comparers, f.mergers,
 				private.SSTableRawTombstonesOpt.(sstable.ReaderOption))
 			if err != nil {
 				return err
@@ -443,9 +443,9 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 			defer iter.Close()
 			key, value := iter.SeekGE(searchKey, base.SeekGEFlagsNone)
 
-			// We configured sstable.Reader to return raw tombstones which requires a
-			// bit more work here to put them in a form that can be iterated in
-			// parallel with the point records.
+			// We configured sstable.Physicaleader to return raw tombstones
+			// which requires a bit more work here to put them in a form that
+			// can be iterated in parallel with the point records.
 			rangeDelIter, err := func() (keyspan.FragmentIterator, error) {
 				iter, err := r.NewRawRangeDelIter()
 				if err != nil {

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -140,7 +140,7 @@ inclusive-inclusive range specified by --start and --end.
 	return s
 }
 
-func (s *sstableT) newReader(f vfs.File) (*sstable.Reader, error) {
+func (s *sstableT) newReader(f vfs.File) (*sstable.PhysicalReader, error) {
 	readable, err := sstable.NewSimpleReadable(f)
 	if err != nil {
 		return nil, err
@@ -151,7 +151,7 @@ func (s *sstableT) newReader(f vfs.File) (*sstable.Reader, error) {
 		Filters:  s.opts.Filters,
 	}
 	defer o.Cache.Unref()
-	return sstable.NewReader(readable, o, s.comparers, s.mergers,
+	return sstable.NewPhysicalReader(readable, o, s.comparers, s.mergers,
 		private.SSTableRawTombstonesOpt.(sstable.ReaderOption))
 }
 
@@ -402,9 +402,9 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 		defer iter.Close()
 		key, value := iter.SeekGE(s.start, base.SeekGEFlagsNone)
 
-		// We configured sstable.Reader to return raw tombstones which requires a
-		// bit more work here to put them in a form that can be iterated in
-		// parallel with the point records.
+		// We configured sstable.PhysicalReader to return raw tombstones which
+		// requires a bit more work here to put them in a form that can be
+		// iterated in parallel with the point records.
 		rangeDelIter, err := func() (keyspan.FragmentIterator, error) {
 			iter, err := r.NewRawRangeDelIter()
 			if err != nil {


### PR DESCRIPTION
This pr introduces an interface for sstable readers which will be shared by both virtual sstables and physical sstables for code where we don't need special casing for virtual or physical sstables.

Physical readers can still be created and used directly depending on the usecase.