### PR TITLE
objstorage: fix ReadAt EOF behavior for shared objects and add test

### DIFF
--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -665,7 +665,11 @@ func (f *memFile) ReadAt(p []byte, off int64) (int, error) {
 	if off >= int64(len(f.n.mu.data)) {
 		return 0, io.EOF
 	}
-	return copy(p, f.n.mu.data[off:]), nil
+	n := copy(p, f.n.mu.data[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
 }
 
 func (f *memFile) Write(p []byte) (int, error) {


### PR DESCRIPTION
#### vfs: fix MemFS ReadAt EOF behavior

The MemFS implementation of `ReadAt` does not conform to the spec: an
error must be returned if `n < len(p)`. If we are at the end of the
file, we need to return `io.EOF`.

#### objstorage: fix shared object ReadAt EOF behavior

The current ReadAt implementation for shared objects uses
`io.ReadFull` which converts an `EOF` error into an `UnexpectedEOF`
error. We don't want this conversion so we implement the read loop
ourselves.

We also add a mutex around the internal read handle - unlike
`ReadHandle.ReadAt`, `Readable.ReadAt` must support concurrent calls.

#### objstorage: add test for EOF behavior of ReadAt
