### PR TITLE
objstorage: simplify ReadAt for objects

### DIFF
--- a/objstorage/noop_readahead.go
+++ b/objstorage/noop_readahead.go
@@ -20,7 +20,7 @@ func MakeNoopReadHandle(r Readable) NoopReadHandle {
 var _ ReadHandle = (*NoopReadHandle)(nil)
 
 // ReadAt is part of the ReadHandle interface.
-func (h *NoopReadHandle) ReadAt(ctx context.Context, p []byte, off int64) (n int, err error) {
+func (h *NoopReadHandle) ReadAt(ctx context.Context, p []byte, off int64) error {
 	return h.readable.ReadAt(ctx, p, off)
 }
 

--- a/objstorage/objstorage.go
+++ b/objstorage/objstorage.go
@@ -14,22 +14,11 @@ import (
 
 // Readable is the handle for an object that is open for reading.
 type Readable interface {
-	// ReadAt reads len(p) bytes into p starting at offset off. It returns the
-	// number of bytes read (0 <= n <= len(p)) and any error encountered.
-	//
-	// When ReadAt returns n < len(p), it returns a non-nil error explaining why
-	// more bytes were not returned.
-	//
-	// Even if ReadAt returns n < len(p), it may use all of p as scratch space
-	// during the call. If some data is available but not len(p) bytes, ReadAt
-	// blocks until either all the data is available or an error occurs.
-	//
-	// If the n = len(p) bytes returned by ReadAt are at the end of the input
-	// source, ReadAt may return either err == EOF or err == nil.
+	// ReadAt reads len(p) bytes into p starting at offset off.
 	//
 	// Clients of ReadAt can execute parallel ReadAt calls on the
 	// same Readable.
-	ReadAt(ctx context.Context, p []byte, off int64) (n int, err error)
+	ReadAt(ctx context.Context, p []byte, off int64) error
 
 	Close() error
 
@@ -48,21 +37,10 @@ type Readable interface {
 // ReadHandle is used to perform reads that are related and might benefit from
 // optimizations like read-ahead.
 type ReadHandle interface {
-	// ReadAt reads len(p) bytes into p starting at offset off. It returns the
-	// number of bytes read (0 <= n <= len(p)) and any error encountered.
-	//
-	// When ReadAt returns n < len(p), it returns a non-nil error explaining why
-	// more bytes were not returned.
-	//
-	// Even if ReadAt returns n < len(p), it may use all of p as scratch space
-	// during the call. If some data is available but not len(p) bytes, ReadAt
-	// blocks until either all the data is available or an error occurs.
-	//
-	// If the n = len(p) bytes returned by ReadAt are at the end of the input
-	// source, ReadAt may return either err == EOF or err == nil.
+	// ReadAt reads len(p) bytes into p starting at offset off.
 	//
 	// Parallel ReadAt calls on the same ReadHandle are not allowed.
-	ReadAt(ctx context.Context, p []byte, off int64) (n int, err error)
+	ReadAt(ctx context.Context, p []byte, off int64) error
 
 	Close() error
 

--- a/objstorage/objstorageprovider/provider_test.go
+++ b/objstorage/objstorageprovider/provider_test.go
@@ -128,9 +128,8 @@ func TestProvider(t *testing.T) {
 					return err.Error()
 				}
 				data := make([]byte, int(r.Size()))
-				n, err := r.ReadAt(ctx, data, 0)
+				err = r.ReadAt(ctx, data, 0)
 				require.NoError(t, err)
-				require.Equal(t, n, len(data))
 				return log.String() + fmt.Sprintf("data: %s\n", string(data))
 
 			case "remove":

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -536,8 +536,12 @@ func newMemReader(b []byte) *memReader {
 }
 
 // ReadAt is part of objstorage.Readable.
-func (m *memReader) ReadAt(_ context.Context, p []byte, off int64) (n int, err error) {
-	return m.r.ReadAt(p, off)
+func (m *memReader) ReadAt(_ context.Context, p []byte, off int64) error {
+	n, err := m.r.ReadAt(p, off)
+	if invariants.Enabled && err == nil && n != len(p) {
+		panic("short read")
+	}
+	return err
 }
 
 // Close is part of objstorage.Readable.

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -70,7 +70,6 @@ package sstable // import "github.com/cockroachdb/pebble/sstable"
 import (
 	"context"
 	"encoding/binary"
-	"io"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -317,12 +316,11 @@ func readFooter(f objstorage.Readable) (footer, error) {
 	off := size - maxFooterLen
 	if off < 0 {
 		off = 0
+		buf = buf[:size]
 	}
-	n, err := f.ReadAt(context.TODO(), buf, off)
-	if err != nil && err != io.EOF {
+	if _, err := f.ReadAt(context.TODO(), buf, off); err != nil {
 		return footer, errors.Wrap(err, "pebble/table: invalid table (could not read footer)")
 	}
-	buf = buf[:n]
 
 	switch magic := buf[len(buf)-len(rocksDBMagic):]; string(magic) {
 	case levelDBMagic:

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -318,7 +318,7 @@ func readFooter(f objstorage.Readable) (footer, error) {
 		off = 0
 		buf = buf[:size]
 	}
-	if _, err := f.ReadAt(context.TODO(), buf, off); err != nil {
+	if err := f.ReadAt(context.TODO(), buf, off); err != nil {
 		return footer, errors.Wrap(err, "pebble/table: invalid table (could not read footer)")
 	}
 

--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -665,7 +665,11 @@ func (f *memFile) ReadAt(p []byte, off int64) (int, error) {
 	if off >= int64(len(f.n.mu.data)) {
 		return 0, io.EOF
 	}
-	return copy(p, f.n.mu.data[off:]), nil
+	n := copy(p, f.n.mu.data[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
 }
 
 func (f *memFile) Write(p []byte) (int, error) {


### PR DESCRIPTION
#### vfs: fix MemFS ReadAt EOF behavior

The MemFS implementation of `ReadAt` does not conform to the spec: an
error must be returned if `n < len(p)`. If we are at the end of the
file, we need to return `io.EOF`.

#### sstable: don't try to read past end of object

Minor change to the `readFooter` code to never try to read past
object EOF.

#### objstorage: simplify ReadAt for objects

Simplify `ReadAt` to only return an error; the `n` return value is no
longer used.

#### objstorage: add mutex in sharedReadable

Unlike `ReadHandle.ReadAt`, `Readable.ReadAt` must support concurrent
calls.

Note that most of the performance sensitive paths use `ReadHandle`.

This fixes an occasional race failure in CI.
