### PR TITLE
objstorage: support LinkOrCopyFromLocal to shared storage

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -5,6 +5,7 @@
 package pebble
 
 import (
+	"context"
 	"sort"
 	"time"
 
@@ -269,7 +270,10 @@ func ingestLink(
 	jobID int, opts *Options, objProvider objstorage.Provider, paths []string, meta []*fileMetadata,
 ) error {
 	for i := range paths {
-		objMeta, err := objProvider.LinkOrCopyFromLocal(opts.FS, paths[i], fileTypeTable, meta[i].FileBacking.DiskFileNum)
+		objMeta, err := objProvider.LinkOrCopyFromLocal(
+			context.TODO(), opts.FS, paths[i], fileTypeTable, meta[i].FileBacking.DiskFileNum,
+			objstorage.CreateOptions{PreferSharedStorage: true},
+		)
 		if err != nil {
 			if err2 := ingestCleanup(objProvider, meta[:i]); err2 != nil {
 				opts.Logger.Infof("ingest cleanup failed: %v", err2)

--- a/objstorage/objstorage.go
+++ b/objstorage/objstorage.go
@@ -180,7 +180,12 @@ type Provider interface {
 	// The object is not guaranteed to be durable (accessible in case of crashes)
 	// until Sync is called.
 	LinkOrCopyFromLocal(
-		srcFS vfs.FS, srcFilePath string, dstFileType base.FileType, dstFileNum base.DiskFileNum,
+		ctx context.Context,
+		srcFS vfs.FS,
+		srcFilePath string,
+		dstFileType base.FileType,
+		dstFileNum base.DiskFileNum,
+		opts CreateOptions,
 	) (ObjectMetadata, error)
 
 	// Lookup returns the metadata of an object that is already known to the Provider.

--- a/objstorage/objstorageprovider/testdata/provider/local
+++ b/objstorage/objstorageprovider/testdata/provider/local
@@ -41,6 +41,28 @@ read 1
 ----
 file 000001 (type 2) unknown to the objstorage provider: file does not exist
 
+link-or-copy 3 local
+three
+----
+<local fs> create: temp-file-1
+<local fs> close: temp-file-1
+<local fs> link: temp-file-1 -> p0/000003.sst
+
+read 3
+----
+data: three
+
+link-or-copy 4 shared
+four
+----
+<local fs> create: temp-file-2
+<local fs> close: temp-file-2
+<local fs> link: temp-file-2 -> p0/000004.sst
+
+read 4
+----
+data: four
+
 close
 ----
 <local fs> sync: p0

--- a/objstorage/objstorageprovider/testdata/provider/shared_basic
+++ b/objstorage/objstorageprovider/testdata/provider/shared_basic
@@ -72,6 +72,34 @@ remove 2
 <shared> list (prefix="00000000000000000001-000002.sst.ref.", delimiter="")
 <shared> delete object "00000000000000000001-000002.sst"
 
+link-or-copy 3 local
+three
+----
+<local fs> create: temp-file-1
+<local fs> close: temp-file-1
+<local fs> link: temp-file-1 -> p1/000003.sst
+
+read 3
+----
+data: three
+
+link-or-copy 4 shared
+four
+----
+<local fs> create: temp-file-2
+<local fs> close: temp-file-2
+<shared> create object "00000000000000000001-000004.sst"
+<shared> close writer for "00000000000000000001-000004.sst" after 4 bytes
+<shared> create object "00000000000000000001-000004.sst.ref.00000000000000000001.000004"
+<shared> close writer for "00000000000000000001-000004.sst.ref.00000000000000000001.000004" after 0 bytes
+
+read 4
+----
+<shared> size of object "00000000000000000001-000004.sst.ref.00000000000000000001.000004": 0
+<shared> size of object "00000000000000000001-000004.sst": 4
+<shared> read object "00000000000000000001-000004.sst" at 0: 4 bytes
+data: four
+
 close
 ----
 <local fs> sync: p1

--- a/objstorage/objstorageprovider/testdata/provider/shared_no_ref
+++ b/objstorage/objstorageprovider/testdata/provider/shared_no_ref
@@ -42,6 +42,20 @@ list
 000001 -> shared://00000000000000000001-000001.sst
 000002 -> shared://00000000000000000001-000002.sst
 
+link-or-copy 3 shared no-ref-tracking
+obj-three
+----
+<local fs> create: temp-file-1
+<local fs> close: temp-file-1
+<shared> create object "00000000000000000001-000003.sst"
+<shared> close writer for "00000000000000000001-000003.sst" after 9 bytes
+
+read 3
+----
+<shared> size of object "00000000000000000001-000003.sst": 9
+<shared> read object "00000000000000000001-000003.sst" at 0: 9 bytes
+data: obj-three
+
 close
 ----
 <local fs> sync: p1/SHARED-CATALOG-000001
@@ -58,6 +72,25 @@ list
 ----
 000001 -> shared://00000000000000000001-000001.sst
 000002 -> shared://00000000000000000001-000002.sst
+000003 -> shared://00000000000000000001-000003.sst
+
+read 1
+----
+<shared> size of object "00000000000000000001-000001.sst": 7
+<shared> read object "00000000000000000001-000001.sst" at 0: 7 bytes
+data: obj-one
+
+read 2
+----
+<shared> size of object "00000000000000000001-000002.sst": 7
+<shared> read object "00000000000000000001-000002.sst" at 0: 7 bytes
+data: obj-two
+
+read 3
+----
+<shared> size of object "00000000000000000001-000003.sst": 9
+<shared> read object "00000000000000000001-000003.sst" at 0: 9 bytes
+data: obj-three
 
 save-backing b1 1
 ----


### PR DESCRIPTION
Implement missing functionality in LinkOrCopyFromLocal: we now pass `CreateOptions` and the destination object can be on shared storage.