### PR TITLE
crl-release-23.1: db: fix bug with restricted checkpoints

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -342,8 +342,28 @@ func (d *DB) writeCheckpointManifest(
 		}
 		defer dst.Close()
 
-		if _, err := io.Copy(dst, &io.LimitedReader{R: src, N: manifestSize}); err != nil {
-			return err
+		// Copy all existing records. We need to copy at the record level in case we
+		// need to append another record with the excluded files (we cannot simply
+		// append a record after a raw data copy; see
+		// https://github.com/cockroachdb/cockroach/issues/100935).
+		r := record.NewReader(&io.LimitedReader{R: src, N: manifestSize}, manifestFileNum)
+		w := record.NewWriter(dst)
+		for {
+			rr, err := r.Next()
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				return err
+			}
+
+			rw, err := w.Next()
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(rw, rr); err != nil {
+				return err
+			}
 		}
 
 		if len(excludedFiles) > 0 {
@@ -351,17 +371,16 @@ func (d *DB) writeCheckpointManifest(
 			ve := versionEdit{
 				DeletedFiles: excludedFiles,
 			}
-			rw := record.NewWriter(dst)
-			w, err := rw.Next()
+			rw, err := w.Next()
 			if err != nil {
 				return err
 			}
-			if err := ve.Encode(w); err != nil {
+			if err := ve.Encode(rw); err != nil {
 				return err
 			}
-			if err := rw.Close(); err != nil {
-				return err
-			}
+		}
+		if err := w.Close(); err != nil {
+			return err
 		}
 		return dst.Sync()
 	}(); err != nil {

--- a/record/record.go
+++ b/record/record.go
@@ -248,6 +248,7 @@ func (r *Reader) nextChunk(wantFirst bool) error {
 			r.begin = r.end + headerSize
 			r.end = r.begin + int(length)
 			if r.end > r.n {
+				// The chunk straddles a 32KB boundary (or the end of file).
 				if r.recovering {
 					r.recover()
 					continue


### PR DESCRIPTION
Backport of #2460 for 23.1.x

----

When a checkpoint is restricted to a set of spans, we append a record to the checkpoint's manifest removing all the excluded ssts.

We append the record after copying the raw data from the existing manifest. This is not quite ok: the `record` library works by breaking up records in chunks and packing chunks into 32KB blocks. Chunks cannot straddle a 32KB boundary, but this invariant is violated by our append method. In practice, this only happens if the record we are appending is big and/or we are very unlucky and the existing manifest is close to a 32KB boundary.

To fix this: instead of doing a raw data copy of the existing manifest, we copy at the record level (using a record reader and a record writer). Then we can add a new record using the same writer.

Informs https://github.com/cockroachdb/cockroach/issues/100935