### PR TITLE
crl-release-23.1: sstable: optimize NewReadHandle allocations

### DIFF
--- a/objstorage/vfs_readable.go
+++ b/objstorage/vfs_readable.go
@@ -13,7 +13,8 @@ import (
 	"github.com/cockroachdb/pebble/vfs"
 )
 
-// fileReadable implements objstorage.Readable on top of vfs.File.
+// fileReadable implements objstorage.Readable on top of a vfs.File that
+// supports Prefetch and/or on an FS that supports SequentialReadsOption.
 type fileReadable struct {
 	file vfs.File
 	size int64
@@ -202,5 +203,41 @@ func (r *genericFileReadable) NewReadHandle() ReadHandle {
 // TestingCheckMaxReadahead returns true if the ReadHandle has switched to
 // OS-level read-ahead.
 func TestingCheckMaxReadahead(rh ReadHandle) bool {
-	return rh.(*vfsReadHandle).sequentialFile != nil
+	switch rh := rh.(type) {
+	case *vfsReadHandle:
+		return rh.sequentialFile != nil
+	case *PreallocatedReadHandle:
+		return rh.sequentialFile != nil
+	default:
+		panic("unknown ReadHandle type")
+	}
+}
+
+// PreallocatedReadHandle is used to avoid an allocation in NewReadHandle; see
+// UsePreallocatedReadHandle.
+type PreallocatedReadHandle struct {
+	vfsReadHandle
+}
+
+// Close is part of the objstorage.ReadHandle interface.
+func (rh *PreallocatedReadHandle) Close() error {
+	var err error
+	if rh.sequentialFile != nil {
+		err = rh.sequentialFile.Close()
+	}
+	rh.vfsReadHandle = vfsReadHandle{}
+	return err
+}
+
+// UsePreallocatedReadHandle is equivalent to calling readable.NewReadHandle()
+// but uses the existing storage of a PreallocatedReadHandle when possible
+// (currently this happens if we are reading from a local file).
+// The returned handle still needs to be closed.
+func UsePreallocatedReadHandle(readable Readable, rh *PreallocatedReadHandle) ReadHandle {
+	if r, ok := readable.(*fileReadable); ok {
+		// See fileReadable.NewReadHandle.
+		rh.vfsReadHandle = vfsReadHandle{r: r}
+		return rh
+	}
+	return readable.NewReadHandle()
 }


### PR DESCRIPTION
Backport of #2481.

----
This commit adds a "shortcut" through objstorage which allows using a preallocated read handle. This avoids two sync.Pool-backed allocations in `singleLeveliter.init`.

Informs https://github.com/cockroachdb/cockroach/issues/101299.