### PR TITLE
manifest: support ve encoding/decoding for virtual sstables

### DIFF
--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -38,6 +38,77 @@ func checkRoundTrip(e0 VersionEdit) error {
 	return nil
 }
 
+// Version edits with virtual sstables will not be the same after a round trip
+// as the Decode function will not set the FileBacking for a virtual sstable.
+// We test round trip + bve accumulation here, after which the virtual sstable
+// FileBacking should be set.
+func TestVERoundTripAndAccumulate(t *testing.T) {
+	cmp := base.DefaultComparer.Compare
+	m1 := (&FileMetadata{
+		FileNum:        810,
+		Size:           8090,
+		CreationTime:   809060,
+		SmallestSeqNum: 9,
+		LargestSeqNum:  11,
+	}).ExtendPointKeyBounds(
+		cmp,
+		base.MakeInternalKey([]byte("a"), 0, base.InternalKeyKindSet),
+		base.MakeInternalKey([]byte("m"), 0, base.InternalKeyKindSet),
+	).ExtendRangeKeyBounds(
+		cmp,
+		base.MakeInternalKey([]byte("l"), 0, base.InternalKeyKindRangeKeySet),
+		base.MakeExclusiveSentinelKey(base.InternalKeyKindRangeKeySet, []byte("z")),
+	)
+	m1.InitPhysicalBacking()
+
+	m2 := (&FileMetadata{
+		FileNum:        812,
+		Size:           8090,
+		CreationTime:   809060,
+		SmallestSeqNum: 9,
+		LargestSeqNum:  11,
+		Virtual:        true,
+		FileBacking:    m1.FileBacking,
+	}).ExtendPointKeyBounds(
+		cmp,
+		base.MakeInternalKey([]byte("a"), 0, base.InternalKeyKindSet),
+		base.MakeInternalKey([]byte("c"), 0, base.InternalKeyKindSet),
+	)
+
+	ve1 := VersionEdit{
+		ComparerName:         "11",
+		MinUnflushedLogNum:   22,
+		ObsoletePrevLogNum:   33,
+		NextFileNum:          44,
+		LastSeqNum:           55,
+		CreatedBackingTables: []*FileBacking{m1.FileBacking},
+		NewFiles: []NewFileEntry{
+			{
+				Level: 4,
+				Meta:  m2,
+				// Only set for the test.
+				BackingFileNum: m2.FileBacking.DiskFileNum,
+			},
+		},
+	}
+	var err error
+	buf := new(bytes.Buffer)
+	if err = ve1.Encode(buf); err != nil {
+		t.Error(err)
+	}
+	var ve2 VersionEdit
+	if err = ve2.Decode(buf); err != nil {
+		t.Error(err)
+	}
+	// Perform accumulation to set the FileBacking on the files in the Decoded
+	// version edit.
+	var bve BulkVersionEdit
+	require.NoError(t, bve.Accumulate(&ve2))
+	if diff := pretty.Diff(ve1, ve2); diff != nil {
+		t.Error(errors.Errorf("%s", strings.Join(diff, "\n")))
+	}
+}
+
 func TestVersionEditRoundTrip(t *testing.T) {
 	cmp := base.DefaultComparer.Compare
 	m1 := (&FileMetadata{
@@ -93,6 +164,40 @@ func TestVersionEditRoundTrip(t *testing.T) {
 	)
 	m4.InitPhysicalBacking()
 
+	m5 := (&FileMetadata{
+		FileNum:        810,
+		Size:           8090,
+		CreationTime:   809060,
+		SmallestSeqNum: 9,
+		LargestSeqNum:  11,
+	}).ExtendPointKeyBounds(
+		cmp,
+		base.MakeInternalKey([]byte("a"), 0, base.InternalKeyKindSet),
+		base.MakeInternalKey([]byte("m"), 0, base.InternalKeyKindSet),
+	).ExtendRangeKeyBounds(
+		cmp,
+		base.MakeInternalKey([]byte("l"), 0, base.InternalKeyKindRangeKeySet),
+		base.MakeExclusiveSentinelKey(base.InternalKeyKindRangeKeySet, []byte("z")),
+	)
+	m5.InitPhysicalBacking()
+
+	m6 := (&FileMetadata{
+		FileNum:        811,
+		Size:           8090,
+		CreationTime:   809060,
+		SmallestSeqNum: 9,
+		LargestSeqNum:  11,
+	}).ExtendPointKeyBounds(
+		cmp,
+		base.MakeInternalKey([]byte("a"), 0, base.InternalKeyKindSet),
+		base.MakeInternalKey([]byte("m"), 0, base.InternalKeyKindSet),
+	).ExtendRangeKeyBounds(
+		cmp,
+		base.MakeInternalKey([]byte("l"), 0, base.InternalKeyKindRangeKeySet),
+		base.MakeExclusiveSentinelKey(base.InternalKeyKindRangeKeySet, []byte("z")),
+	)
+	m6.InitPhysicalBacking()
+
 	testCases := []VersionEdit{
 		// An empty version edit.
 		{},
@@ -103,6 +208,10 @@ func TestVersionEditRoundTrip(t *testing.T) {
 			ObsoletePrevLogNum: 33,
 			NextFileNum:        44,
 			LastSeqNum:         55,
+			RemovedBackingTables: []base.DiskFileNum{
+				base.FileNum(10).DiskFileNum(), base.FileNum(11).DiskFileNum(),
+			},
+			CreatedBackingTables: []*FileBacking{m5.FileBacking, m6.FileBacking},
 			DeletedFiles: map[DeletedFileEntry]*FileMetadata{
 				{
 					Level:   3,

--- a/table_stats.go
+++ b/table_stats.go
@@ -217,6 +217,12 @@ func (d *DB) scanReadStateTableStats(
 	for l, levelMetadata := range rs.current.Levels {
 		iter := levelMetadata.Iter()
 		for f := iter.First(); f != nil; f = iter.Next() {
+			if f.Virtual {
+				// TODO(bananabrick): Support stats collection for virtual
+				// sstables.
+				continue
+			}
+
 			// NB: We're not holding d.mu which protects f.Stats, but only the
 			// active stats collection job updates f.Stats for active files,
 			// and we ensure only one goroutine runs it at a time through

--- a/tool/make_incorrect_manifests.go
+++ b/tool/make_incorrect_manifests.go
@@ -40,13 +40,13 @@ func makeManifest1() {
 	ve.NextFileNum = 5
 	ve.LastSeqNum = 20
 	ve.NewFiles = []manifest.NewFileEntry{
-		{6, &manifest.FileMetadata{
+		{Level: 6, Meta: &manifest.FileMetadata{
 			FileNum: 1, SmallestSeqNum: 2, LargestSeqNum: 5}}}
 	writeVE(writer, &ve)
 
 	ve.MinUnflushedLogNum = 3
 	ve.NewFiles = []manifest.NewFileEntry{
-		{6, &manifest.FileMetadata{
+		{Level: 6, Meta: &manifest.FileMetadata{
 			FileNum: 2, SmallestSeqNum: 1, LargestSeqNum: 4}}}
 	writeVE(writer, &ve)
 

--- a/version_set.go
+++ b/version_set.go
@@ -293,8 +293,8 @@ func (vs *versionSet) load(
 	}
 	vs.markFileNumUsed(vs.minUnflushedLogNum)
 
-	// Populate the fileBackingMap since we have finished version
-	// edit accumulation.
+	// Populate the fileBackingMap and the FileBacking for virtual sstables since
+	// we have finished version edit accumulation.
 	for _, s := range bve.AddedFileBacking {
 		vs.fileBackingMap[s.DiskFileNum] = s
 	}
@@ -688,7 +688,6 @@ func (vs *versionSet) createManifest(
 				Level: level,
 				Meta:  meta,
 			})
-			// TODO(bananabrick): Test snapshot changes.
 			if _, ok := dedup[meta.FileBacking.DiskFileNum]; meta.Virtual && !ok {
 				dedup[meta.FileBacking.DiskFileNum] = struct{}{}
 				snapshot.CreatedBackingTables = append(


### PR DESCRIPTION
We introduce three new tags for virtual sstable encoding/decoding.

tagCreatedBackingTable, tagRemovedBackingTable are used to encode
VersionEdit.CreatedBackingTables and VersionEdit.RemovedBackingTables.
For CreatedBackingTables, we just need to encode the DiskFileNum and
the Size, and for RemovedBackingTable, we just need to encode the
DiskFileNum.

We introduce a customTag customTagVirtual, to encode whether the
FileMetadata belongs to a virtual sstable. We only use this tag for
virtual sstables. If this tag is absent, then the FileMetadata belongs
to a physical sstable. This tag is also used to encode
FileMetadata.FileBacking.DiskFileNum for virtual sstables.

Note that virtual sstable construction depends on state which may
not exist in the version edit in which the virtual sstable is created.
For this reason, the we need to store some persistent state across calls
to Decode.