### PR TITLE
Butler metrics explore

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -662,13 +662,16 @@ type compaction struct {
 	allowedZeroSeqNum bool
 
 	metrics map[int]*LevelMetrics
+
+	pickerMetrics compactionPickerMetrics
 }
 
 func (c *compaction) makeInfo(jobID int) CompactionInfo {
 	info := CompactionInfo{
-		JobID:  jobID,
-		Reason: c.kind.String(),
-		Input:  make([]LevelInfo, 0, len(c.inputs)),
+		JobID:       jobID,
+		Reason:      c.kind.String(),
+		Input:       make([]LevelInfo, 0, len(c.inputs)),
+		Annotations: []string{},
 	}
 	for _, cl := range c.inputs {
 		inputInfo := LevelInfo{Level: cl.level, Tables: nil}
@@ -693,6 +696,16 @@ func (c *compaction) makeInfo(jobID int) CompactionInfo {
 		// semantic distinction.
 		info.Output.Level = numLevels - 1
 	}
+
+	for i, score := range c.pickerMetrics.scores {
+		info.Input[i].Score = score
+	}
+	info.SingleLevelOverlappingRatio = c.pickerMetrics.singleLevelOverlappingRatio
+	info.MultiLevelOverlappingRatio = c.pickerMetrics.multiLevelOverlappingRatio
+	if len(info.Input) > 2 {
+		info.Annotations = append(info.Annotations, "multilevel")
+		info.CounterOverlappingRatio = c.pickerMetrics.counterOverlappingRatio
+	}
 	return info
 }
 
@@ -713,6 +726,7 @@ func newCompaction(pc *pickedCompaction, opts *Options, beganAt time.Time) *comp
 		maxOutputFileSize: pc.maxOutputFileSize,
 		maxOverlapBytes:   pc.maxOverlapBytes,
 		l0SublevelInfo:    pc.l0SublevelInfo,
+		pickerMetrics:     pc.pickerMetrics,
 	}
 	c.startLevel = &c.inputs[0]
 	c.outputLevel = &c.inputs[1]
@@ -2099,7 +2113,7 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 	d.maybeUpdateDeleteCompactionHints(c)
 	d.clearCompactingState(c, err != nil)
 	delete(d.mu.compact.inProgress, c)
-	d.mu.versions.incrementCompactions(c.kind, c.extraLevels)
+	d.mu.versions.incrementCompactions(c.kind, c.extraLevels,c.pickerMetrics)
 
 	var flushed flushableList
 	if err == nil {
@@ -2634,7 +2648,7 @@ func (d *DB) compact1(c *compaction, errChannel chan error) (err error) {
 	// NB: clearing compacting state must occur before updating the read state;
 	// L0Sublevels initialization depends on it.
 	d.clearCompactingState(c, err != nil)
-	d.mu.versions.incrementCompactions(c.kind, c.extraLevels)
+	d.mu.versions.incrementCompactions(c.kind, c.extraLevels, c.pickerMetrics)
 	d.mu.versions.incrementCompactionBytes(-c.bytesWritten)
 
 	info.TotalDuration = d.timeNow().Sub(c.beganAt)
@@ -2816,8 +2830,9 @@ func (d *DB) runCompaction(
 		DeletedFiles: map[deletedFileEntry]*fileMetadata{},
 	}
 
+	startLevelBytes := c.startLevel.files.SizeSum()
 	outputMetrics := &LevelMetrics{
-		BytesIn:   c.startLevel.files.SizeSum(),
+		BytesIn:   startLevelBytes,
 		BytesRead: c.outputLevel.files.SizeSum(),
 	}
 	if len(c.extraLevels) > 0 {
@@ -2833,6 +2848,9 @@ func (d *DB) runCompaction(
 	}
 	if len(c.extraLevels) > 0 {
 		c.metrics[c.extraLevels[0].level] = &LevelMetrics{}
+		outputMetrics.BytesInTopML = startLevelBytes
+		outputMetrics.BytesInML = outputMetrics.BytesIn
+		outputMetrics.BytesReadML = outputMetrics.BytesRead
 	}
 
 	// The table is typically written at the maximum allowable format implied by

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1806,7 +1806,7 @@ func pickL0(
 		if pc.startLevel.files.Empty() {
 			opts.Logger.Fatalf("empty compaction chosen")
 		}
-		return pc
+		return pc.maybeAddLevel(opts, diskAvailBytes())
 	}
 
 	// Couldn't choose a base compaction. Try choosing an intra-L0

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -1102,6 +1102,11 @@ func TestPickedCompactionSetupInputs(t *testing.T) {
 	opts.Experimental.MultiLevelCompactionHueristic = alwaysMultiLevel{}
 	datadriven.RunTest(t, "testdata/compaction_setup_inputs_multilevel_dummy",
 		setupInputTest)
+
+	t.Logf("Try Write-Amp Heuristic")
+	opts.Experimental.MultiLevelCompactionHueristic = WriteAmpHeuristic{addPropensity: 0}
+	datadriven.RunTest(t, "testdata/compaction_setup_inputs_multilevel_write_amp",
+		setupInputTest)
 }
 
 func TestPickedCompactionExpandInputs(t *testing.T) {

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -92,7 +92,7 @@ func (p *compactionPickerForTesting) pickAuto(env compactionEnv) (pc *pickedComp
 	if cInfo.level == 0 {
 		return pickL0(env, p.opts, p.vers, p.baseLevel, diskAvailBytesInf)
 	}
-	return pickAutoLPositive(env, p.opts, p.vers, cInfo, p.baseLevel, diskAvailBytesInf, p.maxLevelBytes)
+	return pickAutoLPositive(env, p.opts, p.vers, cInfo, p.baseLevel, diskAvailBytesInf)
 }
 
 func (p *compactionPickerForTesting) pickElisionOnlyCompaction(

--- a/event.go
+++ b/event.go
@@ -39,10 +39,11 @@ func formatFileNums(tables []TableInfo) string {
 	return buf.String()
 }
 
-// LevelInfo contains info pertaining to a partificular level.
+// LevelInfo contains info pertaining to a particular level.
 type LevelInfo struct {
-	Level  int
-	Tables []TableInfo
+	Level           int
+	Tables          []TableInfo
+	Score           float64
 }
 
 func (i LevelInfo) String() string {
@@ -51,8 +52,11 @@ func (i LevelInfo) String() string {
 
 // SafeFormat implements redact.SafeFormatter.
 func (i LevelInfo) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Printf("L%d [%s] (%s)", redact.Safe(i.Level), redact.Safe(formatFileNums(i.Tables)),
-		redact.Safe(humanize.Bytes.Uint64(tablesTotalSize(i.Tables))))
+	w.Printf("L%d [%s] (%s) Score=%.2f",
+		redact.Safe(i.Level),
+		redact.Safe(formatFileNums(i.Tables)),
+		redact.Safe(humanize.Bytes.Uint64(tablesTotalSize(i.Tables))),
+		redact.Safe(i.Score))
 }
 
 // CompactionInfo contains the info for a compaction event.
@@ -75,6 +79,13 @@ type CompactionInfo struct {
 	TotalDuration time.Duration
 	Done          bool
 	Err           error
+
+	SingleLevelOverlappingRatio float64
+	MultiLevelOverlappingRatio  float64
+	CounterOverlappingRatio     float64
+
+	// Annotations specifies additional info to appear in a compaction's event log line
+	Annotations []string
 }
 
 func (i CompactionInfo) String() string {
@@ -90,8 +101,16 @@ func (i CompactionInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 	}
 
 	if !i.Done {
-		w.Printf("[JOB %d] compacting(%s) ", redact.Safe(i.JobID), redact.SafeString(i.Reason))
-		w.Print(levelInfos(i.Input))
+		w.Printf("[JOB %d] compacting(%s) %s ",
+			redact.Safe(i.JobID),
+			redact.SafeString(i.Reason),
+			redact.Safe(i.Annotations))
+		w.Printf("%s; ", levelInfos(i.Input))
+		w.Printf("SingleOverlappingRatio %.2f; ", i.SingleLevelOverlappingRatio)
+		w.Printf("MultiOverlappingRatio %.2f; ", i.MultiLevelOverlappingRatio)
+		if i.CounterOverlappingRatio != 0 {
+			w.Printf("CounterOverlappingRatio %.2f; ", i.CounterOverlappingRatio)
+		}
 		return
 	}
 	outputSize := tablesTotalSize(i.Output.Tables)

--- a/options.go
+++ b/options.go
@@ -1080,7 +1080,7 @@ func (o *Options) EnsureDefaults() *Options {
 		o.Experimental.CPUWorkPermissionGranter = defaultCPUWorkGranter{}
 	}
 	if o.Experimental.MultiLevelCompactionHueristic == nil {
-		o.Experimental.MultiLevelCompactionHueristic = NoMultiLevel{}
+		o.Experimental.MultiLevelCompactionHueristic = WriteAmpHeuristic{}
 	}
 
 	o.initMaps()

--- a/options.go
+++ b/options.go
@@ -596,6 +596,11 @@ type Options struct {
 		// compaction will never get triggered.
 		MultiLevelCompactionHueristic MultiLevelHeuristic
 
+		// ExtraMultiLevelStatCollectionProbability is the probability (from 0,100)
+		// that pebble will compute and log compaction extra metrics after a
+		// multilevel compaction has been picked.
+		ExtraMultiLevelStatCollectionProbability int32
+
 		// MaxWriterConcurrency is used to indicate the maximum number of
 		// compression workers the compression queue is allowed to use. If
 		// MaxWriterConcurrency > 0, then the Writer will use parallelism, to

--- a/testdata/compaction_setup_inputs_multilevel_write_amp
+++ b/testdata/compaction_setup_inputs_multilevel_write_amp
@@ -1,0 +1,302 @@
+# init a multi-level compaction, because multi level write amp is lower
+setup-inputs a a
+L1
+  a.SET.1-b.SET.2 size=1
+L2
+  a.SET.3-c.SET.4 size=1
+L3
+  c.SET.3-d.SET.2 size=1
+----
+L1
+  000001:[a#1,1-b#2,1]
+L2
+  000002:[a#3,1-c#4,1]
+L3
+  000003:[c#3,1-d#2,1]
+init-multi-level(1,2,3)
+
+# Verify that an input level should not affect the decision to conduct a multi
+# level compaction, so long as the moreLevels constant is 0.
+setup-inputs a a
+L1
+  a.SET.1-b.SET.2 size=1000
+L2
+  a.SET.3-c.SET.4 size=1
+L3
+  c.SET.3-d.SET.2 size=1
+----
+L1
+  000001:[a#1,1-b#2,1]
+L2
+  000002:[a#3,1-c#4,1]
+L3
+  000003:[c#3,1-d#2,1]
+init-multi-level(1,2,3)
+
+# don't init a multi-level compaction bc write amp from multi level compaction is larger
+setup-inputs a a
+L1
+  a.SET.1-b.SET.2 size=1
+L2
+  a.SET.3-c.SET.4 size=1
+L3
+  c.SET.3-d.SET.2 size=3
+----
+L1
+  000001:[a#1,1-b#2,1]
+L2
+  000002:[a#3,1-c#4,1]
+
+# init a multi-level compaction, note that the second files in L2 and L3 do not get
+# chosen, as it doesn't overlap with the original compaction.
+setup-inputs a a
+L1
+  a.SET.1-b.SET.2 size=6
+L2
+  a.SET.3-c.SET.4 size=5
+  e.SET.1-h.SET.4 size=4
+L3
+  c.SET.3-d.SET.2 size=6
+  e.SET.2-h.SET.4 size=4
+----
+L1
+  000001:[a#1,1-b#2,1]
+L2
+  000002:[a#3,1-c#4,1]
+L3
+  000004:[c#3,1-d#2,1]
+init-multi-level(1,2,3)
+
+# init multi-level compaction, without an overlapping file in the lowest level
+setup-inputs a a
+L1
+  a.SET.1-b.SET.2 size=6
+L2 max-size=5
+  a.SET.3-c.SET.4 size=5
+L3
+  e.SET.3-f.SET.2 size=100
+----
+L1
+  000001:[a#1,1-b#2,1]
+L2
+  000002:[a#3,1-c#4,1]
+init-multi-level(1,2,3)
+
+# init multi-level compaction, with no file in the lowest level
+setup-inputs a a
+L1
+  a.SET.1-b.SET.2 size=6
+L2
+  a.SET.3-c.SET.4 size=5
+----
+L1
+  000001:[a#1,1-b#2,1]
+L2
+  000002:[a#3,1-c#4,1]
+init-multi-level(1,2,3)
+
+# Don't init a multi-level compaction, as Write Amp to L2 is 1, and Write Amp to L2 is >1
+setup-inputs a a
+L1
+  a.SET.1-b.SET.2 size=6
+L2
+  e.SET.3-f.SET.2 size=100
+L3
+  a.SET.3-c.SET.4 size=5
+----
+L1
+  000001:[a#1,1-b#2,1]
+
+# Init a multi-level compaction, without an overlapping file in the
+# intermediate and output levels
+setup-inputs a a
+L1
+  a.SET.1-b.SET.2 size=6
+L2
+  e.SET.3-f.SET.2 size=1
+L3
+  e.SET.4-f.SET.5 size=5
+----
+L1
+  000001:[a#1,1-b#2,1]
+init-multi-level(1,2,3)
+
+
+# init a multi-level compaction which expands the intermediate level with a file that only
+# overlaps with the lowest level. (gets included during second setupInputs call)
+setup-inputs a a
+L1
+  a.SET.1-b.SET.2 size=3
+L2
+  a.SET.2-b.SET.3 size=5
+  c.SET.2-d.SET.3 size=3
+L3
+  a.SET.3-c.SET.4 size=3
+----
+L1
+  000001:[a#1,1-b#2,1]
+L2
+  000002:[a#2,1-b#3,1]
+  000003:[c#2,1-d#3,1]
+L3
+  000004:[a#3,1-c#4,1]
+init-multi-level(1,2,3)
+
+# Init a multi-level compaction which DOES NOT expand the input level with a file that
+# only overlaps with the lowest level, even if it doesn't expand the output level keyspan.
+# TODO(msbutler): include this file in the compaction
+setup-inputs a a
+L1
+  a.SET.1-b.SET.2 size=1
+  c.SET.2-d.SET.3 size=10
+L2
+  a.SET.2-b.SET.3 size=1
+L3
+  a.SET.3-c.SET.4 size=1
+----
+L1
+  000001:[a#1,1-b#2,1]
+L2
+  000003:[a#2,1-b#3,1]
+L3
+  000004:[a#3,1-c#4,1]
+init-multi-level(1,2,3)
+
+# Verify an expansion of the output level in the initial setupInputs will init a multi-level
+# compaction. i.e. without the initial expansion, the multil level compaction would not have
+# occurred.
+setup-inputs a a
+L1
+  a.SET.5-b.SET.6 size=1
+L2
+  a.SET.3-c.SET.4 size=1
+  c.SET.3-d.SET.2 size=1
+L3
+  c.SET.4-d.SET.4 size=3
+----
+L1
+  000001:[a#5,1-b#6,1]
+L2
+  000002:[a#3,1-c#4,1]
+  000003:[c#3,1-d#2,1]
+L3
+  000004:[c#4,1-d#4,1]
+init-multi-level(1,2,3)
+
+setup-inputs a a
+L1
+  a.SET.5-b.SET.6 size=1
+L2
+  a.SET.3-c.SET.4 size=1
+L3
+  c.SET.4-d.SET.4 size=3
+----
+L1
+  000001:[a#5,1-b#6,1]
+L2
+  000002:[a#3,1-c#4,1]
+
+
+# Verify the second setupInputs call does not add an intermediate file if doing so would expand the
+# output level (i.e. the pc.grow logic)
+setup-inputs a a
+L1
+  a.SET.1-b.SET.2 size=1
+L2
+  a.SET.2-b.SET.3 size=1
+  d.SET.2-f.SET.2 size=1
+L3
+  b.SET.1-d.SET.1 size=1
+  e.SET.4-f.SET.5 size=1
+----
+L1
+  000001:[a#1,1-b#2,1]
+L2
+  000002:[a#2,1-b#3,1]
+L3
+  000004:[b#1,1-d#1,1]
+init-multi-level(1,2,3)
+
+
+# Verify the max number of input levels equals 2
+setup-inputs a a
+L1
+  a.SET.1-b.SET.2 size=6
+L2
+  a.SET.3-c.SET.4 size=5
+L3
+  c.SET.3-d.SET.2 size=2
+L4
+  c.SET.4-d.SET.3 size=1
+----
+L1
+  000001:[a#1,1-b#2,1]
+L2
+  000002:[a#3,1-c#4,1]
+L3
+  000003:[c#3,1-d#2,1]
+init-multi-level(1,2,3)
+
+# Don't init multi-level compaction if max size limit exceeded by initial setupInputs
+setup-inputs avail-bytes=10 a a
+L1
+  a.SET.1-b.SET.2 size=6
+L2
+  a.SET.5-b.SET.6 size=5
+L3
+  a.SET.3-d.SET.4 size=3
+----
+L1
+  000001:[a#1,1-b#2,1]
+L2
+  000002:[a#5,1-b#6,1]
+
+# During second setupInputs call, allow output level expansion even if max size
+# limit is exceeded, but not the intermediate level expansion
+#
+# TODO(msbutler): If second setup inputs exceeds maxSize limits, should the first compaction get
+# returned?
+setup-inputs avail-bytes=20 a a
+L1
+  a.SET.1-b.SET.2 size=4
+L2
+  a.SET.5-b.SET.6 size=5
+  c.SET.4-e.SET.3 size=8
+L3
+  a.SET.3-d.SET.4 size=2
+  d.SET.2-e.SET.2 size=2
+----
+L1
+  000001:[a#1,1-b#2,1]
+L2
+  000002:[a#5,1-b#6,1]
+L3
+  000004:[a#3,1-d#4,1]
+  000005:[d#2,1-e#2,1]
+init-multi-level(1,2,3)
+
+# Don't init a multi-level compaction if the start level is L5
+setup-inputs a a
+L5
+  a.SET.1-b.SET.2 size=6
+L6
+  a.SET.3-c.SET.4 size=5
+----
+L5
+  000001:[a#1,1-b#2,1]
+L6
+  000002:[a#3,1-c#4,1]
+
+# Verify a multi level compaction will not init on a compacting file
+setup-inputs a a
+L1
+  a.SET.1-b.SET.2 size=1
+L2
+  a.SET.3-c.SET.4 size=1
+L3
+  c.SET.3-d.SET.2 size=1 compacting
+----
+L1
+  000001:[a#1,1-b#2,1]
+L2
+  000002:[a#3,1-c#4,1]


### PR DESCRIPTION
This draft PR is used to benchmark multilevel compaction on the kv0 replay workload, described [here](https://cockroachlabs.atlassian.net/wiki/spaces/STOR/pages/2861105466/Compaction+benchmarking#Precollected-workloads). 

My gce worker attatched [this snapshot ](https://console.cloud.google.com/compute/disksDetail/zones/us-east1-b/disks/michaelbutler-kv0short?project=cockroach-workers&supportedpurview=project), and its source snapshot is `kv0-from-empty-120gb-of-writes` (note that my snapshot copy is incorrectly named kv0short, but its source is correct).

I benchmark 3 flavors of pebble:
- multilevel compaction enabled, allowing l0 as input
- multilevel compaction enabled, disallowing l0 as input
- control

I use [this script](https://github.com/msbutler/crl-scripts/blob/master/pebble_replay/build.sh) to build these binaries, and [this script](https://github.com/msbutler/crl-scripts/blob/master/pebble_replay/orch.sh) to run the benchmarks (takes about 4 hours). 


