### PR TITLE
objstorage: don't use mutex in sharedReadable.ReadAt

### DIFF
--- a/objstorage/objstorageprovider/testdata/provider/shared_attach
+++ b/objstorage/objstorageprovider/testdata/provider/shared_attach
@@ -122,6 +122,7 @@ read 101
 <shared> size of object "00000000000000000001-000001.sst.ref.00000000000000000002.000101": 0
 <shared> size of object "00000000000000000001-000001.sst": 7
 <shared> read object "00000000000000000001-000001.sst" at 0: 7 bytes
+<shared> close reader for "00000000000000000001-000001.sst"
 data: obj-one
 
 read 102
@@ -129,6 +130,7 @@ read 102
 <shared> size of object "00000000000000000001-000002.sst.ref.00000000000000000002.000102": 0
 <shared> size of object "00000000000000000001-000002.sst": 7
 <shared> read object "00000000000000000001-000002.sst" at 0: 7 bytes
+<shared> close reader for "00000000000000000001-000002.sst"
 data: obj-two
 
 read 103
@@ -136,4 +138,5 @@ read 103
 <shared> size of object "00000000000000000001-000003.sst.ref.00000000000000000002.000103": 0
 <shared> size of object "00000000000000000001-000003.sst": 9
 <shared> read object "00000000000000000001-000003.sst" at 0: 9 bytes
+<shared> close reader for "00000000000000000001-000003.sst"
 data: obj-three

--- a/objstorage/objstorageprovider/testdata/provider/shared_basic
+++ b/objstorage/objstorageprovider/testdata/provider/shared_basic
@@ -37,6 +37,7 @@ read 2
 <shared> size of object "00000000000000000001-000002.sst.ref.00000000000000000001.000002": 0
 <shared> size of object "00000000000000000001-000002.sst": 7
 <shared> read object "00000000000000000001-000002.sst" at 0: 7 bytes
+<shared> close reader for "00000000000000000001-000002.sst"
 data: obj-two
 
 list
@@ -98,6 +99,7 @@ read 4
 <shared> size of object "00000000000000000001-000004.sst.ref.00000000000000000001.000004": 0
 <shared> size of object "00000000000000000001-000004.sst": 4
 <shared> read object "00000000000000000001-000004.sst" at 0: 4 bytes
+<shared> close reader for "00000000000000000001-000004.sst"
 data: four
 
 close

--- a/objstorage/objstorageprovider/testdata/provider/shared_no_ref
+++ b/objstorage/objstorageprovider/testdata/provider/shared_no_ref
@@ -23,6 +23,7 @@ read 1
 ----
 <shared> size of object "00000000000000000001-000001.sst": 7
 <shared> read object "00000000000000000001-000001.sst" at 0: 7 bytes
+<shared> close reader for "00000000000000000001-000001.sst"
 data: obj-one
 
 create 2 shared no-ref-tracking
@@ -35,6 +36,7 @@ read 2
 ----
 <shared> size of object "00000000000000000001-000002.sst": 7
 <shared> read object "00000000000000000001-000002.sst" at 0: 7 bytes
+<shared> close reader for "00000000000000000001-000002.sst"
 data: obj-two
 
 list
@@ -54,6 +56,7 @@ read 3
 ----
 <shared> size of object "00000000000000000001-000003.sst": 9
 <shared> read object "00000000000000000001-000003.sst" at 0: 9 bytes
+<shared> close reader for "00000000000000000001-000003.sst"
 data: obj-three
 
 close
@@ -78,18 +81,21 @@ read 1
 ----
 <shared> size of object "00000000000000000001-000001.sst": 7
 <shared> read object "00000000000000000001-000001.sst" at 0: 7 bytes
+<shared> close reader for "00000000000000000001-000001.sst"
 data: obj-one
 
 read 2
 ----
 <shared> size of object "00000000000000000001-000002.sst": 7
 <shared> read object "00000000000000000001-000002.sst" at 0: 7 bytes
+<shared> close reader for "00000000000000000001-000002.sst"
 data: obj-two
 
 read 3
 ----
 <shared> size of object "00000000000000000001-000003.sst": 9
 <shared> read object "00000000000000000001-000003.sst" at 0: 9 bytes
+<shared> close reader for "00000000000000000001-000003.sst"
 data: obj-three
 
 save-backing b1 1
@@ -127,12 +133,14 @@ read 101
 ----
 <shared> size of object "00000000000000000001-000001.sst": 7
 <shared> read object "00000000000000000001-000001.sst" at 0: 7 bytes
+<shared> close reader for "00000000000000000001-000001.sst"
 data: obj-one
 
 read 102
 ----
 <shared> size of object "00000000000000000001-000001.sst": 7
 <shared> read object "00000000000000000001-000001.sst" at 0: 7 bytes
+<shared> close reader for "00000000000000000001-000001.sst"
 data: obj-one
 
 # In this mode, all removes should be no-ops on the shared backend.


### PR DESCRIPTION
Instead of serializing all `ReadAt` calls against a `Readable`, use a temporary throw-away handle. The end result is similar (we don't expect to be able to reuse the underlying reader in the common case) but without serialization.

Reads without a ReadHandle happen for various sst metadata (like index or filter blocks).