### PR TITLE
db: remove unused condition variable

### DIFF
--- a/db.go
+++ b/db.go
@@ -369,9 +369,6 @@ type DB struct {
 		}
 
 		mem struct {
-			// Condition variable used to serialize memtable switching. See
-			// DB.makeRoomForWrite().
-			cond sync.Cond
 			// The current mutable memTable.
 			mutable *memTable
 			// Queue of flushables (the mutable memtable is at end). Elements are
@@ -2265,7 +2262,6 @@ func (d *DB) recycleWAL() (newLogNum FileNum, prevLogSize uint64) {
 	})
 
 	d.mu.Lock()
-	d.mu.mem.cond.Broadcast()
 
 	d.mu.versions.metrics.WAL.Files++
 

--- a/open.go
+++ b/open.go
@@ -204,7 +204,6 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	if d.mu.mem.nextSize > initialMemTableSize {
 		d.mu.mem.nextSize = initialMemTableSize
 	}
-	d.mu.mem.cond.L = &d.mu.Mutex
 	d.mu.cleaner.cond.L = &d.mu.Mutex
 	d.mu.compact.cond.L = &d.mu.Mutex
 	d.mu.compact.inProgress = make(map[*compaction]struct{})


### PR DESCRIPTION
The DB.mu.mem.cond condition variable is no longer used. It previously was intended to synchronize concurrent callers of makeRoomForWrite during a memtable rotation, but that function requires that the commit pipeline's mutex be held throughout the entirety of the function, providing mutual exclusion.

This condition variable is now only broadcasted, without any waiters.