### PR TITLE
crl-release-22.2: sstable: print magic number when encountering corruption

### DIFF
--- a/sstable/format.go
+++ b/sstable/format.go
@@ -53,7 +53,7 @@ func ParseTableFormat(magic []byte, version uint32) (TableFormat, error) {
 		}
 	default:
 		return TableFormatUnspecified, base.CorruptionErrorf(
-			"pebble/table: invalid table (bad magic number)",
+			"pebble/table: invalid table (bad magic number: 0x%x)", magic,
 		)
 	}
 }

--- a/sstable/format_test.go
+++ b/sstable/format_test.go
@@ -59,7 +59,7 @@ func TestTableFormat_RoundTrip(t *testing.T) {
 		{
 			name:    "Unknown magic string",
 			magic:   "foo",
-			wantErr: "pebble/table: invalid table (bad magic number)",
+			wantErr: "pebble/table: invalid table (bad magic number: 0x666f6f)",
 		},
 	}
 

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -354,7 +354,7 @@ func readFooter(f ReadableFile) (footer, error) {
 		buf = buf[1:]
 
 	default:
-		return footer, base.CorruptionErrorf("pebble/table: invalid table (bad magic number)")
+		return footer, base.CorruptionErrorf("pebble/table: invalid table (bad magic number: 0x%x)", magic)
 	}
 
 	{

--- a/tool/testdata/sstable_check
+++ b/tool/testdata/sstable_check
@@ -51,7 +51,7 @@ sstable check
 testdata/bad-magic.sst
 ----
 bad-magic.sst
-pebble/table: invalid table (bad magic number)
+pebble/table: invalid table (bad magic number: 0xf6cff485b741e288)
 
 sstable check
 ./testdata/mixed/000005.sst

--- a/tool/testdata/sstable_properties
+++ b/tool/testdata/sstable_properties
@@ -191,7 +191,7 @@ sstable properties
 testdata/bad-magic.sst
 ----
 bad-magic.sst
-pebble/table: invalid table (bad magic number)
+pebble/table: invalid table (bad magic number: 0xf6cff485b741e288)
 
 sstable properties
 testdata/mixed/000005.sst


### PR DESCRIPTION
This is a backport of #2492 to 22.2.

---

Currently, if the magic number in an SSTable footer is invalid, an error is printed indicating as such. However, it would be useful to know what the magic number was for the SSTable. This allows for potentially faster issue triaging.

Print the magic number bytes when encountering an invalid table magic number.