### PR TITLE
crl-release-23.1: sstable: print magic number when encountering corruption

### DIFF
--- a/sstable/format.go
+++ b/sstable/format.go
@@ -59,7 +59,7 @@ func ParseTableFormat(magic []byte, version uint32) (TableFormat, error) {
 		}
 	default:
 		return TableFormatUnspecified, base.CorruptionErrorf(
-			"pebble/table: invalid table (bad magic number)",
+			"pebble/table: invalid table (bad magic number: 0x%x)", magic,
 		)
 	}
 }

--- a/sstable/format_test.go
+++ b/sstable/format_test.go
@@ -65,7 +65,7 @@ func TestTableFormat_RoundTrip(t *testing.T) {
 		{
 			name:    "Unknown magic string",
 			magic:   "foo",
-			wantErr: "pebble/table: invalid table (bad magic number)",
+			wantErr: "pebble/table: invalid table (bad magic number: 0x666f6f)",
 		},
 	}
 

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -363,7 +363,7 @@ func readFooter(f objstorage.Readable) (footer, error) {
 		buf = buf[1:]
 
 	default:
-		return footer, base.CorruptionErrorf("pebble/table: invalid table (bad magic number)")
+		return footer, base.CorruptionErrorf("pebble/table: invalid table (bad magic number: 0x%x)", magic)
 	}
 
 	{

--- a/tool/testdata/sstable_check
+++ b/tool/testdata/sstable_check
@@ -51,7 +51,7 @@ sstable check
 testdata/bad-magic.sst
 ----
 bad-magic.sst
-pebble/table: invalid table (bad magic number)
+pebble/table: invalid table (bad magic number: 0xf6cff485b741e288)
 
 sstable check
 ./testdata/mixed/000005.sst

--- a/tool/testdata/sstable_properties
+++ b/tool/testdata/sstable_properties
@@ -200,7 +200,7 @@ sstable properties
 testdata/bad-magic.sst
 ----
 bad-magic.sst
-pebble/table: invalid table (bad magic number)
+pebble/table: invalid table (bad magic number: 0xf6cff485b741e288)
 
 sstable properties
 testdata/mixed/000005.sst


### PR DESCRIPTION
This is a backport of #2492 to 23.1.

---

Currently, if the magic number in an SSTable footer is invalid, an error is printed indicating as such. However, it would be useful to know what the magic number was for the SSTable. This allows for potentially faster issue triaging.

Print the magic number bytes when encountering an invalid table magic number.