### PR TITLE
crl-release-22.2: makefile: pin latest release version for cross-version tests to 22.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOFLAGS :=
 STRESSFLAGS :=
 TAGS := invariants
 TESTS := .
-LATEST_RELEASE := $(shell git fetch origin && git branch -r --list '*/crl-release-*' | grep -o 'crl-release-.*$$' | sort | tail -1)
+LATEST_RELEASE := crl-release-22.1
 
 .PHONY: all
 all:


### PR DESCRIPTION
Currently, the cross-version makefile target infers the latest release version by querying git. While this is suitable for the master branch, on a release branch the latest version should be "capped" so as to avoid building against a later version.

Pin the latest release for the crl-release-22.2 branch.