### PR TITLE
vfs: mark file basename as safe to avoid log redaction

### DIFF
--- a/vfs/disk_health.go
+++ b/vfs/disk_health.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -375,7 +376,8 @@ func (i DiskSlowInfo) String() string {
 // SafeFormat implements redact.SafeFormatter.
 func (i DiskSlowInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.Printf("disk slowness detected: %s on file %s (%d bytes) has been ongoing for %0.1fs",
-		redact.Safe(i.OpType.String()), i.Path, i.WriteSize, redact.Safe(i.Duration.Seconds()))
+		redact.Safe(i.OpType.String()), redact.Safe(filepath.Base(i.Path)),
+		redact.Safe(i.WriteSize), redact.Safe(i.Duration.Seconds()))
 }
 
 // diskHealthCheckingFS adds disk-health checking facilities to a VFS.


### PR DESCRIPTION
When a disk stall is detected, the operation and path of the file are logged. Currently, in Cockroach, the path is redacted as it is not marked as safe.

As a path in a production environment could contain sensitive information (we have no control over how a user configures the directory in which they use for the Pebble store), we want to avoid leaking too much information. Only take the basename of the file, and mark this as safe. The filenames that Pebble uses are well-formed, and should not contain sensitive information.

Touches cockroachdb/cockroach#99756.