### PR TITLE
crl-release-22.2: deflake TestCompactionTombstones

### DIFF
--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -301,7 +301,7 @@ maybe-compact
 # should be deleted. In #90149, the table still had a reference count, and
 # therefore could not be deleted from the filesystem.
 
-define
+define auto-compactions=off
 L6
   rangekey:a-b:{(#1,RANGEKEYDEL)}
   a.SET.2:a


### PR DESCRIPTION
This is a backport of #2239 to 22.2.

---

Fixing flaky test case caused by an automatic compaction.

Fixes #2033