### PR TITLE
crl-release-23.1: vfs: include size of write in DiskSlowInfo

### DIFF
--- a/event.go
+++ b/event.go
@@ -119,24 +119,7 @@ func (i levelInfos) SafeFormat(w redact.SafePrinter, _ rune) {
 
 // DiskSlowInfo contains the info for a disk slowness event when writing to a
 // file.
-type DiskSlowInfo struct {
-	// Path of file being written to.
-	Path string
-	// Operation being performed on the file.
-	OpType vfs.OpType
-	// Duration that has elapsed since this disk operation started.
-	Duration time.Duration
-}
-
-func (i DiskSlowInfo) String() string {
-	return redact.StringWithoutMarkers(i)
-}
-
-// SafeFormat implements redact.SafeFormatter.
-func (i DiskSlowInfo) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Printf("disk slowness detected: %s on file %s has been ongoing for %0.1fs",
-		redact.Safe(i.OpType.String()), i.Path, redact.Safe(i.Duration.Seconds()))
-}
+type DiskSlowInfo = vfs.DiskSlowInfo
 
 // FlushInfo contains the info for a flush event.
 type FlushInfo struct {

--- a/options.go
+++ b/options.go
@@ -1038,12 +1038,8 @@ func (o *Options) WithFSDefaults() *Options {
 		o.FS = vfs.Default
 	}
 	o.FS, o.private.fsCloser = vfs.WithDiskHealthChecks(o.FS, 5*time.Second,
-		func(name string, op vfs.OpType, duration time.Duration) {
-			o.EventListener.DiskSlow(DiskSlowInfo{
-				Path:     name,
-				OpType:   op,
-				Duration: duration,
-			})
+		func(info vfs.DiskSlowInfo) {
+			o.EventListener.DiskSlow(info)
 		})
 	return o
 }

--- a/vfs/disk_health.go
+++ b/vfs/disk_health.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -375,7 +376,8 @@ func (i DiskSlowInfo) String() string {
 // SafeFormat implements redact.SafeFormatter.
 func (i DiskSlowInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.Printf("disk slowness detected: %s on file %s (%d bytes) has been ongoing for %0.1fs",
-		redact.Safe(i.OpType.String()), i.Path, i.WriteSize, redact.Safe(i.Duration.Seconds()))
+		redact.Safe(i.OpType.String()), redact.Safe(filepath.Base(i.Path)),
+		redact.Safe(i.WriteSize), redact.Safe(i.Duration.Seconds()))
 }
 
 // diskHealthCheckingFS adds disk-health checking facilities to a VFS.

--- a/vfs/fd_test.go
+++ b/vfs/fd_test.go
@@ -22,7 +22,7 @@ func TestFileWrappersHaveFd(t *testing.T) {
 
 	// File wrapper case 1: Check if diskHealthCheckingFile has Fd().
 	fs2, closer := WithDiskHealthChecks(Default, 10*time.Second,
-		func(s string, opType OpType, duration time.Duration) {})
+		func(info DiskSlowInfo) {})
 	defer closer.Close()
 	f2, err := fs2.Open(filename)
 	require.NoError(t, err)


### PR DESCRIPTION
This is a backport of #2281 and #2499 to 23.1.

---

**vfs: include size of write in DiskSlowInfo**

This commit adds the size of a write to DiskSlowInfo, in cases where a write is
sized. A small write stalling out points at file system / disk issues, while
a large write taking time to complete may indicate CRDB issues with a certain
workload, etc.

**vfs: mark file basename as safe to avoid log redaction**

When a disk stall is detected, the operation and path of the file are
logged. Currently, in Cockroach, the path is redacted as it is not
marked as safe.

As a path in a production environment could contain sensitive
information (we have no control over how a user configures the directory
in which they use for the Pebble store), we want to avoid leaking too
much information. Only take the basename of the file, and mark this as
safe. The filenames that Pebble uses are well-formed, and should not
contain sensitive information.