### PR TITLE
Makefile: fix crlfmt version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,9 +96,11 @@ endif
 	@${GO} mod tidy
 	$(MAKE) git-clean-check
 
+# TODO(radu): switch back to @latest once bogus doc changes are
+# addressed; see https://github.com/cockroachdb/crlfmt/pull/44
 .PHONY: format
 format:
-	go install github.com/cockroachdb/crlfmt@latest && crlfmt -w -tab 2 .
+	go install github.com/cockroachdb/crlfmt@44a36ec7 && crlfmt -w -tab 2 .
 
 .PHONY: format-check
 format-check:


### PR DESCRIPTION
The latest crlfmt version tries to make a lot of (bad) comment changes. Until this is addressed, we fix the version used for `make format/format-check`.