### PR TITLE
sstable: inline keyOutOfBounds

### DIFF
--- a/table_cache.go
+++ b/table_cache.go
@@ -401,6 +401,7 @@ func (c *tableCacheShard) newIters(
 		) (sstable.Iterator, error)
 	}
 
+	// TODO(bananabrick): We suffer an allocation if file is a virtual sstable.
 	var ic iterCreator = v.reader
 	if file.Virtual {
 		virtualReader := sstable.MakeVirtualReader(


### PR DESCRIPTION
keyOutOfBounds is called deep in the iterator function call stack and should be inlined.