### PR TITLE
db: intialize memTable.reserve when creating memTable

### DIFF
--- a/mem_table.go
+++ b/mem_table.go
@@ -143,6 +143,7 @@ func newMemTable(opts memTableOptions) *memTable {
 	m.skl.Reset(arena, m.cmp)
 	m.rangeDelSkl.Reset(arena, m.cmp)
 	m.rangeKeySkl.Reset(arena, m.cmp)
+	m.reserved = arena.Size()
 	return m
 }
 

--- a/mem_table_test.go
+++ b/mem_table_test.go
@@ -389,6 +389,21 @@ func TestMemTableConcurrentDeleteRange(t *testing.T) {
 	}
 }
 
+func TestMemTableReserved(t *testing.T) {
+	m := newMemTable(memTableOptions{size: 5000})
+	// Increase to 2 references.
+	m.writerRef()
+	// The initial reservation accounts for the already allocated bytes from the
+	// arena.
+	require.Equal(t, m.reserved, m.skl.Arena().Size())
+	b := newBatch(nil)
+	b.Set([]byte("blueberry"), []byte("pie"), nil)
+	require.NotEqual(t, 0, int(b.memTableSize))
+	prevReserved := m.reserved
+	m.prepare(b)
+	require.Equal(t, int(m.reserved), int(b.memTableSize)+int(prevReserved))
+}
+
 func buildMemTable(b *testing.B) (*memTable, [][]byte) {
 	m := newMemTable(memTableOptions{})
 	var keys [][]byte


### PR DESCRIPTION
(backport)

Informs https://github.com/cockroachdb/cockroach/issues/102945

Fixes #2516