### PR TITLE
shared: improve interface for more efficient reading

### DIFF
--- a/objstorage/objstorageprovider/shared.go
+++ b/objstorage/objstorageprovider/shared.go
@@ -203,7 +203,7 @@ func (p *provider) sharedOpenForReading(
 		}
 	}
 	objName := sharedObjectName(meta)
-	size, err := p.sharedStorage().Size(objName)
+	reader, size, err := p.sharedStorage().ReadObject(ctx, objName)
 	if err != nil {
 		if opts.MustExist && p.sharedStorage().IsNotExistError(err) {
 			p.st.Logger.Fatalf("object %q does not exist", objName)
@@ -211,7 +211,7 @@ func (p *provider) sharedOpenForReading(
 		}
 		return nil, err
 	}
-	return newSharedReadable(p.sharedStorage(), objName, size), nil
+	return newSharedReadable(reader, size), nil
 }
 
 func (p *provider) sharedSize(meta objstorage.ObjectMetadata) (int64, error) {

--- a/objstorage/objstorageprovider/testdata/provider/shared_attach
+++ b/objstorage/objstorageprovider/testdata/provider/shared_attach
@@ -117,12 +117,11 @@ read 101
 15 10
 ----
 <shared> size of object "61a6-1-000001.sst.ref.2.000101": 0
-<shared> size of object "61a6-1-000001.sst": 100
+<shared> create reader for object "61a6-1-000001.sst": 100 bytes
 size: 100
-<shared> read object "61a6-1-000001.sst" at 0: 100 bytes
+<shared> read object "61a6-1-000001.sst" at 0 (length 100)
 0 100: ok (salt 1)
-<shared> close reader for "61a6-1-000001.sst"
-<shared> read object "61a6-1-000001.sst" at 15: 85 bytes
+<shared> read object "61a6-1-000001.sst" at 15 (length 10)
 15 10: ok (salt 1)
 <shared> close reader for "61a6-1-000001.sst"
 
@@ -131,12 +130,11 @@ read 102
 90 100
 ----
 <shared> size of object "a629-1-000002.sst.ref.2.000102": 0
-<shared> size of object "a629-1-000002.sst": 200
+<shared> create reader for object "a629-1-000002.sst": 200 bytes
 size: 200
-<shared> read object "a629-1-000002.sst" at 0: 200 bytes
+<shared> read object "a629-1-000002.sst" at 0 (length 200)
 0 200: ok (salt 2)
-<shared> close reader for "a629-1-000002.sst"
-<shared> read object "a629-1-000002.sst" at 90: 110 bytes
+<shared> read object "a629-1-000002.sst" at 90 (length 100)
 90 100: ok (salt 2)
 <shared> close reader for "a629-1-000002.sst"
 
@@ -144,8 +142,8 @@ read 103
 0 300
 ----
 <shared> size of object "eaac-1-000003.sst.ref.2.000103": 0
-<shared> size of object "eaac-1-000003.sst": 300
+<shared> create reader for object "eaac-1-000003.sst": 300 bytes
 size: 300
-<shared> read object "eaac-1-000003.sst" at 0: 300 bytes
+<shared> read object "eaac-1-000003.sst" at 0 (length 300)
 0 300: ok (salt 3)
 <shared> close reader for "eaac-1-000003.sst"

--- a/objstorage/objstorageprovider/testdata/provider/shared_basic
+++ b/objstorage/objstorageprovider/testdata/provider/shared_basic
@@ -39,9 +39,9 @@ read 2
 0 100
 ----
 <shared> size of object "a629-1-000002.sst.ref.1.000002": 0
-<shared> size of object "a629-1-000002.sst": 100
+<shared> create reader for object "a629-1-000002.sst": 100 bytes
 size: 100
-<shared> read object "a629-1-000002.sst" at 0: 100 bytes
+<shared> read object "a629-1-000002.sst" at 0 (length 100)
 0 100: ok (salt 2)
 <shared> close reader for "a629-1-000002.sst"
 
@@ -110,9 +110,9 @@ read 4
 0 100
 ----
 <shared> size of object "2f2f-1-000004.sst.ref.1.000004": 0
-<shared> size of object "2f2f-1-000004.sst": 100
+<shared> create reader for object "2f2f-1-000004.sst": 100 bytes
 size: 100
-<shared> read object "2f2f-1-000004.sst" at 0: 100 bytes
+<shared> read object "2f2f-1-000004.sst" at 0 (length 100)
 0 100: ok (salt 4)
 <shared> close reader for "2f2f-1-000004.sst"
 

--- a/objstorage/objstorageprovider/testdata/provider/shared_no_ref
+++ b/objstorage/objstorageprovider/testdata/provider/shared_no_ref
@@ -21,9 +21,9 @@ create 1 shared 1 100 no-ref-tracking
 read 1
 0 100
 ----
-<shared> size of object "61a6-1-000001.sst": 100
+<shared> create reader for object "61a6-1-000001.sst": 100 bytes
 size: 100
-<shared> read object "61a6-1-000001.sst" at 0: 100 bytes
+<shared> read object "61a6-1-000001.sst" at 0 (length 100)
 0 100: ok (salt 1)
 <shared> close reader for "61a6-1-000001.sst"
 
@@ -35,9 +35,9 @@ create 2 shared 2 100 no-ref-tracking
 read 2
 0 100
 ----
-<shared> size of object "a629-1-000002.sst": 100
+<shared> create reader for object "a629-1-000002.sst": 100 bytes
 size: 100
-<shared> read object "a629-1-000002.sst" at 0: 100 bytes
+<shared> read object "a629-1-000002.sst" at 0 (length 100)
 0 100: ok (salt 2)
 <shared> close reader for "a629-1-000002.sst"
 
@@ -58,9 +58,9 @@ link-or-copy 3 shared 3 100 no-ref-tracking
 read 3
 0 100
 ----
-<shared> size of object "eaac-1-000003.sst": 100
+<shared> create reader for object "eaac-1-000003.sst": 100 bytes
 size: 100
-<shared> read object "eaac-1-000003.sst" at 0: 100 bytes
+<shared> read object "eaac-1-000003.sst" at 0 (length 100)
 0 100: ok (salt 3)
 <shared> close reader for "eaac-1-000003.sst"
 
@@ -87,27 +87,27 @@ list
 read 1
 0 100
 ----
-<shared> size of object "61a6-1-000001.sst": 100
+<shared> create reader for object "61a6-1-000001.sst": 100 bytes
 size: 100
-<shared> read object "61a6-1-000001.sst" at 0: 100 bytes
+<shared> read object "61a6-1-000001.sst" at 0 (length 100)
 0 100: ok (salt 1)
 <shared> close reader for "61a6-1-000001.sst"
 
 read 2
 0 100
 ----
-<shared> size of object "a629-1-000002.sst": 100
+<shared> create reader for object "a629-1-000002.sst": 100 bytes
 size: 100
-<shared> read object "a629-1-000002.sst" at 0: 100 bytes
+<shared> read object "a629-1-000002.sst" at 0 (length 100)
 0 100: ok (salt 2)
 <shared> close reader for "a629-1-000002.sst"
 
 read 3
 0 100
 ----
-<shared> size of object "eaac-1-000003.sst": 100
+<shared> create reader for object "eaac-1-000003.sst": 100 bytes
 size: 100
-<shared> read object "eaac-1-000003.sst" at 0: 100 bytes
+<shared> read object "eaac-1-000003.sst" at 0 (length 100)
 0 100: ok (salt 3)
 <shared> close reader for "eaac-1-000003.sst"
 
@@ -145,18 +145,18 @@ list
 read 101
 0 100
 ----
-<shared> size of object "61a6-1-000001.sst": 100
+<shared> create reader for object "61a6-1-000001.sst": 100 bytes
 size: 100
-<shared> read object "61a6-1-000001.sst" at 0: 100 bytes
+<shared> read object "61a6-1-000001.sst" at 0 (length 100)
 0 100: ok (salt 1)
 <shared> close reader for "61a6-1-000001.sst"
 
 read 102
 0 100
 ----
-<shared> size of object "61a6-1-000001.sst": 100
+<shared> create reader for object "61a6-1-000001.sst": 100 bytes
 size: 100
-<shared> read object "61a6-1-000001.sst" at 0: 100 bytes
+<shared> read object "61a6-1-000001.sst" at 0 (length 100)
 0 100: ok (salt 1)
 <shared> close reader for "61a6-1-000001.sst"
 


### PR DESCRIPTION
The current `shared.Storage` interface forces the implementation to perform a metadata operation to look up the object on each read. Some experimental backends have a separate internal open step that doesn't need to be performed every time.

This commit improves the interface to allow opening the object once and then performing many reads.