### PR TITLE
db: log events to testing.T in unit tests

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1408,7 +1408,7 @@ func TestMemtableIngestInversion(t *testing.T) {
 	var blockedCompactionsMu sync.Mutex // protects the above two variables.
 	nextSem := make(chan chan struct{}, 1)
 	var el EventListener
-	el.EnsureDefaults(DefaultLogger)
+	el.EnsureDefaults(testLogger{t: t})
 	el.FlushBegin = func(info FlushInfo) {
 		blockedCompactionsMu.Lock()
 		defer blockedCompactionsMu.Unlock()
@@ -1444,7 +1444,7 @@ func TestMemtableIngestInversion(t *testing.T) {
 		nextSem <- sem
 		<-sem
 	}
-	tel := TeeEventListener(MakeLoggingEventListener(DefaultLogger), el)
+	tel := TeeEventListener(MakeLoggingEventListener(testLogger{t: t}), el)
 	opts.EventListener = &tel
 	opts.Experimental.L0CompactionConcurrency = 1
 	d, err := Open("", opts)

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1422,6 +1422,18 @@ func TestIngestMemtablePendingOverlap(t *testing.T) {
 	require.NoError(t, d.Close())
 }
 
+type testLogger struct {
+	t testing.TB
+}
+
+func (l testLogger) Infof(format string, args ...interface{}) {
+	l.t.Logf(format, args...)
+}
+
+func (l testLogger) Fatalf(format string, args ...interface{}) {
+	l.t.Fatalf(format, args...)
+}
+
 // TestIngestMemtableOverlapRace is a regression test for the race described in
 // #2196. If an ingest that checks for overlap with the mutable memtable and
 // finds no overlap, it must not allow overlapping keys with later sequence
@@ -1438,7 +1450,7 @@ func TestIngestMemtablePendingOverlap(t *testing.T) {
 // numbers, since every flush and every ingest conflicts with one another.
 func TestIngestMemtableOverlapRace(t *testing.T) {
 	mem := vfs.NewMem()
-	el := MakeLoggingEventListener(DefaultLogger)
+	el := MakeLoggingEventListener(testLogger{t: t})
 	d, err := Open("", &Options{
 		FS: mem,
 		// Disable automatic compactions to keep the manifest clean; only


### PR DESCRIPTION
A few unit tests in the top-level pebble package recently started logging database events (eg, MakeLoggingEventListener) to the DefaultLogger which outputs directly to stdout. This makes `go test` noisy. This commit updates these unit tests to use a logger that logs to the `*testing.T` type, so that the logs are only printed when verbosity is enabled.