### PR TITLE
sstable: clean up suffix rewriter comment, test

### DIFF
--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -218,7 +218,7 @@ func rewriteBlocks(
 			copy(scratch.UserKey, key.UserKey[:si])
 			copy(scratch.UserKey[si:], to)
 
-			// NB: for TableFormatPebblev3, since
+			// NB: for TableFormatPebblev3 and higher, since
 			// !iter.lazyValueHandling.hasValuePrefix, it will return the raw value
 			// in the block, which includes the 1-byte prefix. This is fine since bw
 			// also does not know about the prefix and will preserve it in bw.add.


### PR DESCRIPTION
Clean up a comment in the sstable suffix rewriter code, and update the test to run subtests across all table formats.

This is response to feedback on #2528 that I forgot to push.