### PR TITLE
objstorage: implement read-ahead for shared objects

### DIFF
--- a/objstorage/noop_readahead.go
+++ b/objstorage/noop_readahead.go
@@ -27,8 +27,8 @@ func (h *NoopReadHandle) ReadAt(ctx context.Context, p []byte, off int64) error 
 // Close is part of the ReadHandle interface.
 func (*NoopReadHandle) Close() error { return nil }
 
-// MaxReadahead is part of the ReadHandle interface.
-func (*NoopReadHandle) MaxReadahead() {}
+// SetupForCompaction is part of the ReadHandle interface.
+func (*NoopReadHandle) SetupForCompaction() {}
 
 // RecordCacheHit is part of the ReadHandle interface.
 func (*NoopReadHandle) RecordCacheHit(_ context.Context, offset, size int64) {}

--- a/objstorage/objstorage.go
+++ b/objstorage/objstorage.go
@@ -16,6 +16,9 @@ import (
 type Readable interface {
 	// ReadAt reads len(p) bytes into p starting at offset off.
 	//
+	// Does not return partial results; if off + len(p) is past the end of the
+	// object, an error is returned.
+	//
 	// Clients of ReadAt can execute parallel ReadAt calls on the
 	// same Readable.
 	ReadAt(ctx context.Context, p []byte, off int64) error
@@ -38,6 +41,9 @@ type Readable interface {
 // optimizations like read-ahead.
 type ReadHandle interface {
 	// ReadAt reads len(p) bytes into p starting at offset off.
+	//
+	// Does not return partial results; if off + len(p) is past the end of the
+	// object, an error is returned.
 	//
 	// Parallel ReadAt calls on the same ReadHandle are not allowed.
 	ReadAt(ctx context.Context, p []byte, off int64) error

--- a/objstorage/objstorage.go
+++ b/objstorage/objstorage.go
@@ -44,9 +44,10 @@ type ReadHandle interface {
 
 	Close() error
 
-	// MaxReadahead configures the implementation to expect large sequential
-	// reads. Used to skip any initial read-ahead ramp-up.
-	MaxReadahead()
+	// SetupForCompaction informs the implementation that the read handle will
+	// be used to read data blocks for a compaction. The implementation can expect
+	// sequential reads, and can decide to not retain data in any caches.
+	SetupForCompaction()
 
 	// RecordCacheHit informs the implementation that we were able to retrieve a
 	// block from cache. This is useful for example when the implementation is

--- a/objstorage/objstorageprovider/objiotracing/obj_io_tracing.go
+++ b/objstorage/objstorageprovider/objiotracing/obj_io_tracing.go
@@ -16,9 +16,9 @@ const (
 	// RecordCacheHitOp happens when a read is satisfied from the block cache. See
 	// objstorage.ReadHandle.RecordCacheHit().
 	RecordCacheHitOp
-	// MaxReadaheadOp is a "meta operation" that configures a read handle for
-	// large sequential reads. See objstorage.ReadHandle.MaxReadahead().
-	MaxReadaheadOp
+	// SetupForCompactionOp is a "meta operation" that configures a read handle
+	// for large sequential reads. See objstorage.ReadHandle.SetupForCompaction().
+	SetupForCompactionOp
 )
 
 // Reason indicates the higher-level context of the operation.

--- a/objstorage/objstorageprovider/objiotracing/obj_io_tracing_on.go
+++ b/objstorage/objstorageprovider/objiotracing/obj_io_tracing_on.go
@@ -209,14 +209,14 @@ func (rh *readHandle) Close() error {
 	return rh.rh.Close()
 }
 
-// MaxReadahead is part of the objstorage.ReadHandle interface.
-func (rh *readHandle) MaxReadahead() {
+// SetupForCompaction is part of the objstorage.ReadHandle interface.
+func (rh *readHandle) SetupForCompaction() {
 	rh.g.add(context.Background(), Event{
-		Op:       MaxReadaheadOp,
+		Op:       SetupForCompactionOp,
 		FileNum:  rh.fileNum,
 		HandleID: rh.handleID,
 	})
-	rh.rh.MaxReadahead()
+	rh.rh.SetupForCompaction()
 }
 
 // RecordCacheHit is part of the objstorage.ReadHandle interface.

--- a/objstorage/objstorageprovider/provider_test.go
+++ b/objstorage/objstorageprovider/provider_test.go
@@ -163,13 +163,21 @@ func TestProvider(t *testing.T) {
 				return log.String()
 
 			case "read":
+				forCompaction := false
+				if len(d.CmdArgs) == 2 && d.CmdArgs[1].Key == "for-compaction" {
+					d.CmdArgs = d.CmdArgs[:1]
+					forCompaction = true
+				}
 				var fileNum base.FileNum
-				scanArgs("<file-num>", &fileNum)
+				scanArgs("<file-num> [for-compaction]", &fileNum)
 				r, err := curProvider.OpenForReading(ctx, base.FileTypeTable, fileNum.DiskFileNum(), objstorage.OpenOptions{})
 				if err != nil {
 					return err.Error()
 				}
 				rh := r.NewReadHandle(ctx)
+				if forCompaction {
+					rh.SetupForCompaction()
+				}
 				log.Infof("size: %d", r.Size())
 				for _, l := range strings.Split(d.Input, "\n") {
 					var offset, size int

--- a/objstorage/objstorageprovider/shared_readable.go
+++ b/objstorage/objstorageprovider/shared_readable.go
@@ -60,6 +60,6 @@ func (r *sharedReadHandle) Close() error {
 	return nil
 }
 
-func (r *sharedReadHandle) MaxReadahead() {}
+func (r *sharedReadHandle) SetupForCompaction() {}
 
 func (r *sharedReadHandle) RecordCacheHit(_ context.Context, offset, size int64) {}

--- a/objstorage/objstorageprovider/shared_readable.go
+++ b/objstorage/objstorageprovider/shared_readable.go
@@ -42,24 +42,81 @@ func (r *sharedReadable) Size() int64 {
 
 func (r *sharedReadable) NewReadHandle(_ context.Context) objstorage.ReadHandle {
 	// TODO(radu): use a pool.
-	return &sharedReadHandle{readable: r}
+	rh := &sharedReadHandle{readable: r}
+	rh.readahead.state = makeReadaheadState()
+	return rh
 }
 
 type sharedReadHandle struct {
-	readable *sharedReadable
+	readable  *sharedReadable
+	readahead struct {
+		state  readaheadState
+		data   []byte
+		offset int64
+	}
+	forCompaction bool
 }
 
 var _ objstorage.ReadHandle = (*sharedReadHandle)(nil)
 
 func (r *sharedReadHandle) ReadAt(ctx context.Context, p []byte, offset int64) error {
+	readaheadSize := r.maybeReadahead(offset, len(p))
+
+	// Check if we already have the data from a previous read-ahead.
+	if rhSize := int64(len(r.readahead.data)); rhSize > 0 {
+		if r.readahead.offset <= offset && r.readahead.offset+rhSize > offset {
+			n := copy(p, r.readahead.data[offset-r.readahead.offset:])
+			if n == len(p) {
+				// All data was available.
+				return nil
+			}
+			// Use the data that we had and do a shorter read.
+			offset += int64(n)
+			p = p[n:]
+			readaheadSize -= n
+		}
+	}
+
+	if readaheadSize > len(p) {
+		r.readahead.offset = offset
+		// TODO(radu): we need to somehow account for this memory.
+		if cap(r.readahead.data) >= readaheadSize {
+			r.readahead.data = r.readahead.data[:readaheadSize]
+		} else {
+			r.readahead.data = make([]byte, readaheadSize)
+		}
+		if err := r.readable.ReadAt(ctx, r.readahead.data, offset); err != nil {
+			// Make sure we don't treat the data as valid next time.
+			r.readahead.data = r.readahead.data[:0]
+			return err
+		}
+		copy(p, r.readahead.data)
+		return nil
+	}
+
 	return r.readable.ReadAt(ctx, p, offset)
+}
+
+func (r *sharedReadHandle) maybeReadahead(offset int64, len int) int {
+	// TODO(radu): maxReadaheadSize is only 256KB, we probably want 1MB+.
+	if r.forCompaction {
+		return maxReadaheadSize
+	}
+	return int(r.readahead.state.maybeReadahead(offset, int64(len)))
 }
 
 func (r *sharedReadHandle) Close() error {
 	r.readable = nil
+	r.readahead.data = nil
 	return nil
 }
 
-func (r *sharedReadHandle) SetupForCompaction() {}
+func (r *sharedReadHandle) SetupForCompaction() {
+	r.forCompaction = true
+}
 
-func (r *sharedReadHandle) RecordCacheHit(_ context.Context, offset, size int64) {}
+func (r *sharedReadHandle) RecordCacheHit(_ context.Context, offset, size int64) {
+	if !r.forCompaction {
+		r.readahead.state.recordCacheHit(offset, size)
+	}
+}

--- a/objstorage/objstorageprovider/testdata/provider/shared_readahead
+++ b/objstorage/objstorageprovider/testdata/provider/shared_readahead
@@ -1,0 +1,76 @@
+open p1 1
+----
+<local fs> mkdir-all: p1 0755
+<local fs> open-dir: p1
+<local fs> open-dir: p1
+<local fs> create: p1/SHARED-CATALOG-000001
+<local fs> sync: p1/SHARED-CATALOG-000001
+<local fs> create: p1/marker.shared-catalog.000001.SHARED-CATALOG-000001
+<local fs> close: p1/marker.shared-catalog.000001.SHARED-CATALOG-000001
+<local fs> sync: p1
+<local fs> sync: p1/SHARED-CATALOG-000001
+
+create 1 shared 1 2000000
+----
+<shared> create object "61a6-1-000001.sst"
+<shared> close writer for "61a6-1-000001.sst" after 2000000 bytes
+<shared> create object "61a6-1-000001.sst.ref.1.000001"
+<shared> close writer for "61a6-1-000001.sst.ref.1.000001" after 0 bytes
+
+# We should be seeing larger and larger reads.
+read 1
+0 1000
+1000 15000
+16000 30000
+46000 10000
+56000 50000
+106000 30000
+150000 20000
+180000 10000
+210000 30000
+----
+<shared> size of object "61a6-1-000001.sst.ref.1.000001": 0
+<shared> create reader for object "61a6-1-000001.sst": 2000000 bytes
+size: 2000000
+<shared> read object "61a6-1-000001.sst" at 0 (length 1000)
+0 1000: ok (salt 1)
+<shared> read object "61a6-1-000001.sst" at 1000 (length 15000)
+1000 15000: ok (salt 1)
+<shared> read object "61a6-1-000001.sst" at 16000 (length 65536)
+16000 30000: ok (salt 1)
+46000 10000: ok (salt 1)
+<shared> read object "61a6-1-000001.sst" at 81536 (length 105536)
+56000 50000: ok (salt 1)
+106000 30000: ok (salt 1)
+150000 20000: ok (salt 1)
+<shared> read object "61a6-1-000001.sst" at 187072 (length 255072)
+180000 10000: ok (salt 1)
+210000 30000: ok (salt 1)
+<shared> close reader for "61a6-1-000001.sst"
+
+# When reading for a compaction, we should be doing large reads from the start.
+read 1 for-compaction
+0 1000
+1000 15000
+16000 30000
+46000 10000
+56000 50000
+106000 30000
+150000 20000
+180000 10000
+210000 30000
+----
+<shared> size of object "61a6-1-000001.sst.ref.1.000001": 0
+<shared> create reader for object "61a6-1-000001.sst": 2000000 bytes
+size: 2000000
+<shared> read object "61a6-1-000001.sst" at 0 (length 262144)
+0 1000: ok (salt 1)
+1000 15000: ok (salt 1)
+16000 30000: ok (salt 1)
+46000 10000: ok (salt 1)
+56000 50000: ok (salt 1)
+106000 30000: ok (salt 1)
+150000 20000: ok (salt 1)
+180000 10000: ok (salt 1)
+210000 30000: ok (salt 1)
+<shared> close reader for "61a6-1-000001.sst"

--- a/objstorage/objstorageprovider/vfs_readable.go
+++ b/objstorage/objstorageprovider/vfs_readable.go
@@ -129,7 +129,7 @@ func (rh *vfsReadHandle) ReadAt(_ context.Context, p []byte, offset int64) error
 			if readaheadSize >= maxReadaheadSize {
 				// We've reached the maximum readahead size. Beyond this point, rely on
 				// OS-level readahead.
-				rh.MaxReadahead()
+				rh.SetupForCompaction()
 			} else {
 				_ = rh.r.file.Prefetch(offset, readaheadSize)
 			}
@@ -142,8 +142,8 @@ func (rh *vfsReadHandle) ReadAt(_ context.Context, p []byte, offset int64) error
 	return err
 }
 
-// MaxReadahead is part of the objstorage.ReadHandle interface.
-func (rh *vfsReadHandle) MaxReadahead() {
+// SetupForCompaction is part of the objstorage.ReadHandle interface.
+func (rh *vfsReadHandle) SetupForCompaction() {
 	if rh.sequentialFile != nil {
 		return
 	}

--- a/objstorage/objstorageprovider/vfs_readable.go
+++ b/objstorage/objstorageprovider/vfs_readable.go
@@ -129,7 +129,7 @@ func (rh *vfsReadHandle) ReadAt(_ context.Context, p []byte, offset int64) error
 			if readaheadSize >= maxReadaheadSize {
 				// We've reached the maximum readahead size. Beyond this point, rely on
 				// OS-level readahead.
-				rh.SetupForCompaction()
+				rh.switchToOSReadahead()
 			} else {
 				_ = rh.r.file.Prefetch(offset, readaheadSize)
 			}
@@ -144,6 +144,10 @@ func (rh *vfsReadHandle) ReadAt(_ context.Context, p []byte, offset int64) error
 
 // SetupForCompaction is part of the objstorage.ReadHandle interface.
 func (rh *vfsReadHandle) SetupForCompaction() {
+	rh.switchToOSReadahead()
+}
+
+func (rh *vfsReadHandle) switchToOSReadahead() {
 	if rh.sequentialFile != nil {
 		return
 	}

--- a/objstorage/shared/storage.go
+++ b/objstorage/shared/storage.go
@@ -66,8 +66,11 @@ type Storage interface {
 type ObjectReader interface {
 	// ReadAt reads len(p) bytes into p starting at offset off.
 	//
-	// Clients of ReadAt can execute parallel ReadAt calls on the
-	// same ObjectReader.
+	// Does not return partial results; if offset + len(p) is past the end of the
+	// object, an error is returned.
+	//
+	// Clients of ReadAt can execute parallel ReadAt calls on the same
+	// ObjectReader.
 	ReadAt(ctx context.Context, p []byte, offset int64) error
 
 	Close() error

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -464,9 +464,9 @@ func (i *singleLevelIterator) init(
 // setupForCompaction sets up the singleLevelIterator for use with compactionIter.
 // Currently, it skips readahead ramp-up. It should be called after init is called.
 func (i *singleLevelIterator) setupForCompaction() {
-	i.dataRH.MaxReadahead()
+	i.dataRH.SetupForCompaction()
 	if i.vbRH != nil {
-		i.vbRH.MaxReadahead()
+		i.vbRH.SetupForCompaction()
 	}
 }
 


### PR DESCRIPTION
#### objstorage: rename MaxReadahead to SetupForCompaction

Renaming the primitive to be more specific. For compaction reads, we
may want to skip populating caches with the data since it's unlikely
to be used again.

#### objstorage: implement read-ahead for shared objects

We Reuse the existing ramp-up logic. For now, the max readahead is
256KB but we will probably want to make it configurable and increase
it for shared objects.
