### PR TITLE
secondarycache: implement a minimal functional secondary cache

### DIFF
--- a/objstorage/objstorageprovider/provider.go
+++ b/objstorage/objstorageprovider/provider.go
@@ -93,6 +93,16 @@ type Settings struct {
 	// (experimental).
 	Shared struct {
 		Storage shared.Storage
+
+		// CacheSizeBytes is the size of the on-disk block cache for objects
+		// on shared storage. If it is 0, no cache is used.
+		CacheSizeBytes int64
+
+		// CacheBlockSize is the block size of the cache; if 0, the default of 32KB is used.
+		CacheBlockSize int
+
+		// TODO(radu): allow the cache to live on another FS/location (e.g. to use
+		// instance-local SSD).
 	}
 }
 

--- a/objstorage/objstorageprovider/provider.go
+++ b/objstorage/objstorageprovider/provider.go
@@ -101,6 +101,11 @@ type Settings struct {
 		// CacheBlockSize is the block size of the cache; if 0, the default of 32KB is used.
 		CacheBlockSize int
 
+		// The number of independent shards the cache leverages. Each shard is the same size,
+		// and a hash of filenum & offset map a read to a certain shard. If set to 0,
+		// 2*runtime.GOMAXPROCS is used as the shard count.
+		CacheShardCount int
+
 		// TODO(radu): allow the cache to live on another FS/location (e.g. to use
 		// instance-local SSD).
 	}

--- a/objstorage/objstorageprovider/shared.go
+++ b/objstorage/objstorageprovider/shared.go
@@ -6,6 +6,7 @@ package objstorageprovider
 
 import (
 	"context"
+	"runtime"
 	"sync"
 	"sync/atomic"
 
@@ -72,7 +73,8 @@ func (p *provider) sharedInit() error {
 		if blockSize == 0 {
 			blockSize = defaultBlockSize
 		}
-		p.shared.cache, err = openSharedCache(p.st.FS, p.st.FSDirName, blockSize, p.st.Shared.CacheSizeBytes)
+		numShards := 2 * runtime.GOMAXPROCS(0)
+		p.shared.cache, err = openSharedCache(p.st.FS, p.st.FSDirName, blockSize, p.st.Shared.CacheSizeBytes, numShards)
 		if err != nil {
 			return errors.Wrapf(err, "pebble: could not open shared object cache")
 		}

--- a/objstorage/objstorageprovider/shared.go
+++ b/objstorage/objstorageprovider/shared.go
@@ -73,7 +73,12 @@ func (p *provider) sharedInit() error {
 		if blockSize == 0 {
 			blockSize = defaultBlockSize
 		}
-		numShards := 2 * runtime.GOMAXPROCS(0)
+
+		numShards := p.st.Shared.CacheShardCount
+		if numShards == 0 {
+			numShards = 2 * runtime.GOMAXPROCS(0)
+		}
+
 		p.shared.cache, err = openSharedCache(p.st.FS, p.st.FSDirName, blockSize, p.st.Shared.CacheSizeBytes, numShards)
 		if err != nil {
 			return errors.Wrapf(err, "pebble: could not open shared object cache")

--- a/objstorage/objstorageprovider/shared.go
+++ b/objstorage/objstorageprovider/shared.go
@@ -21,6 +21,7 @@ import (
 // All fields remain unset if shared storage is not configured.
 type sharedSubsystem struct {
 	catalog *sharedobjcat.Catalog
+	cache   *sharedCache
 
 	// checkRefsOnOpen controls whether we check the ref marker file when opening
 	// an object. Normally this is true when invariants are enabled (but the provider
@@ -63,6 +64,18 @@ func (p *provider) sharedInit() error {
 		p.st.Logger.Infof("shared storage configured; creatorID = %s", contents.CreatorID)
 	} else {
 		p.st.Logger.Infof("shared storage configured; no creatorID yet")
+	}
+
+	if p.st.Shared.CacheSizeBytes > 0 {
+		const defaultBlockSize = 32 * 1024
+		blockSize := p.st.Shared.CacheBlockSize
+		if blockSize == 0 {
+			blockSize = defaultBlockSize
+		}
+		p.shared.cache, err = openSharedCache(p.st.FS, p.st.FSDirName, blockSize, p.st.Shared.CacheSizeBytes)
+		if err != nil {
+			return errors.Wrapf(err, "pebble: could not open shared object cache")
+		}
 	}
 
 	for _, meta := range contents.Objects {

--- a/objstorage/objstorageprovider/shared_cache.go
+++ b/objstorage/objstorageprovider/shared_cache.go
@@ -7,9 +7,9 @@ package objstorageprovider
 import (
 	"context"
 	"fmt"
-	"math/bits"
-	"runtime"
+	"io"
 	"sync"
+	"sync/atomic"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -20,15 +20,21 @@ import (
 
 type sharedCache struct {
 	shards []sharedCacheShard
+	logger base.Logger
+
+	// TODO(josh): Have a dedicated metrics struct. Right now, this
+	// is just for testing.
+	misses atomic.Int32
 }
 
 func openSharedCache(
-	fs vfs.FS, fsDir string, blockSize int, sizeBytes int64,
+	fs vfs.FS, fsDir string, blockSize int, sizeBytes int64, numShards int,
 ) (*sharedCache, error) {
-	numShards := 2 * runtime.GOMAXPROCS(0)
-	if sizeBytes < shardingBlockSize*int64(numShards) {
-		return nil, errors.Errorf("cache size %d too low", sizeBytes)
+	min := shardingBlockSize * int64(numShards)
+	if sizeBytes < min {
+		return nil, errors.Errorf("cache size %d lower than min %d", sizeBytes, min)
 	}
+
 	sc := &sharedCache{}
 	sc.shards = make([]sharedCacheShard, numShards)
 	blocksPerShard := sizeBytes / int64(numShards) / int64(blockSize)
@@ -51,7 +57,7 @@ func (sc *sharedCache) Close() error {
 	return retErr
 }
 
-// ReadAt peforms a read form an object, attempting to use cached data when
+// ReadAt performs a read form an object, attempting to use cached data when
 // possible.
 func (sc *sharedCache) ReadAt(
 	ctx context.Context, fileNum base.FileNum, p []byte, ofs int64, readable objstorage.Readable,
@@ -64,9 +70,33 @@ func (sc *sharedCache) ReadAt(
 		// Everything was in cache!
 		return nil
 	}
+
+	// We must do reads with offset & size that are multiples of the block size. Else
+	// later cache hits may return incorrect zeroed results from the cache. We assume
+	// that all shards have the same block size.
+	blockSize := sc.shards[0].blockSize
+	adjustedOfs := ((ofs+int64(n)) / int64(blockSize)) * int64(blockSize)
+	adjustedP := make([]byte, ((len(p[n:]) + (blockSize - 1)) / blockSize) * blockSize + int(ofs - adjustedOfs))
+
 	// Read the rest from the object.
-	// TODO(radu, josh): write back to cache.
-	return readable.ReadAt(ctx, p[n:], ofs+int64(n))
+	sc.misses.Add(1)
+	// TODO(josh): To have proper EOF handling, we will need readable.ReadAt to return
+	// the number of bytes read successfully. As is, we cannot tell if the readable.ReadAt
+	// should be returned from sharedCache.ReadAt. For now, the cache just swallows all
+	// io.EOF errors.
+	if err := readable.ReadAt(ctx, adjustedP, adjustedOfs); err != nil && err != io.EOF {
+		return err
+	}
+	copy(p[n:], adjustedP[ofs%int64(blockSize):])
+
+	// TODO(josh): Writing back to the cache should be async with respect to the
+	// call to ReadAt.
+	if err := sc.Set(fileNum, adjustedP, adjustedOfs); err != nil {
+		// TODO(josh): Would like to log at error severity, but base.Logger doesn't
+		// have error severity.
+		sc.logger.Infof("writing back to cache after miss failed: %v", err)
+	}
+	return nil
 }
 
 // Get attempts to read the requested data from the cache.
@@ -77,10 +107,11 @@ func (sc *sharedCache) ReadAt(
 // and no error. If no prefix is available, returns n = 0 and no error.
 func (sc *sharedCache) Get(fileNum base.FileNum, p []byte, ofs int64) (n int, _ error) {
 	// The data extent might cross shard boundaries, hence the loop. In the hot
-	// path, only one iteration of the loop will be executed.
+	// path, max two iterations of this loop will be executed, since reads are sized
+	// in units of sstable block size.
 	for {
-		shard := sc.getShard(fileNum, ofs)
-		cappedLen := len(p)
+		shard := sc.getShard(fileNum, ofs+int64(n))
+		cappedLen := len(p[n:])
 		if toBoundary := int(shardingBlockSize - (ofs % shardingBlockSize)); cappedLen > toBoundary {
 			cappedLen = toBoundary
 		}
@@ -101,23 +132,62 @@ func (sc *sharedCache) Get(fileNum base.FileNum, p []byte, ofs int64) (n int, _ 
 	}
 }
 
+// Set attempts to write the requested data to the cache.
+//
+// If all of p is not written to the shard, Set returns a non-nil error.
+func (sc *sharedCache) Set(fileNum base.FileNum, p []byte, ofs int64) error {
+	// The data extent might cross shard boundaries, hence the loop. In the hot
+	// path, max two iterations of this loop will be executed, since reads are sized
+	// in units of sstable block size.
+	n := 0
+	for {
+		shard := sc.getShard(fileNum, ofs+int64(n))
+		cappedLen := len(p[n:])
+		if toBoundary := int(shardingBlockSize - (ofs % shardingBlockSize)); cappedLen > toBoundary {
+			cappedLen = toBoundary
+		}
+		err := shard.Set(fileNum, p[n:n+cappedLen], ofs+int64(n))
+		if err != nil {
+			return err
+		}
+		// Set returns an error if cappedLen bytes aren't written the the shard.
+		n += cappedLen
+		if n == len(p) {
+			// We are done.
+			return nil
+		}
+		// Data extent crosses shard boundary, continue with next shard.
+	}
+}
+
 const shardingBlockSize = 1024 * 1024
 
 func (sc *sharedCache) getShard(fileNum base.FileNum, ofs int64) *sharedCacheShard {
 	const prime64 = 1099511628211
 	hash := uint64(fileNum)*prime64 + uint64(ofs)/shardingBlockSize
+	// TODO(josh): Instance change ops are often run in production. Such an operation
+	// updates len(sc.shards); see openSharedCache. As a result, the behavior of this
+	// function changes, and the cache empties out at restart time. We may want a better
+	// story here eventually.
 	return &sc.shards[hash%uint64(len(sc.shards))]
 }
 
 type sharedCacheShard struct {
 	file         vfs.File
 	sizeInBlocks int64
-	// blockSizeExp is log2(BlockSize).
-	blockSizeExp int
+	blockSize    int
 	mu           struct {
 		sync.Mutex
-		// TODO: map from fileNum / offset to block metadata.
+		// TODO(josh): Neither of these datastructures are space-efficient.
+		// Focusing on correctness to start.
+		where map[metadataKey]int64
+		free  []int64
 	}
+}
+
+type metadataKey struct {
+	filenum    base.FileNum
+	blockIndex int64
 }
 
 func (s *sharedCacheShard) init(
@@ -129,7 +199,7 @@ func (s *sharedCacheShard) init(
 	if blockSize < 1024 || shardingBlockSize%blockSize != 0 {
 		return errors.Newf("invalid block size %d (must divide %d)", blockSize, shardingBlockSize)
 	}
-	s.blockSizeExp = bits.Len64(uint64(blockSize)) - 1
+	s.blockSize = blockSize
 	file, err := fs.OpenReadWrite(fs.PathJoin(fsDir, fmt.Sprintf("SHARED-CACHE-%03d", shardIdx)))
 	if err != nil {
 		return err
@@ -139,6 +209,16 @@ func (s *sharedCacheShard) init(
 	if err := file.Preallocate(0, int64(blockSize)*sizeInBlocks); err != nil {
 		return err
 	}
+	s.file = file
+
+	// TODO(josh): Right now, the secondary cache is not persistent. All existing
+	// cache contents will be over-written, since all metadata is only stored in
+	// memory.
+	s.mu.where = make(map[metadataKey]int64)
+	for i := int64(0); i < sizeInBlocks; i++ {
+		s.mu.free = append(s.mu.free, i)
+	}
+
 	return nil
 }
 
@@ -162,6 +242,107 @@ func (s *sharedCacheShard) Get(fileNum base.FileNum, p []byte, ofs int64) (n int
 			panic("Get crosses shard boundary")
 		}
 	}
-	// TODO
-	return 0, nil
+
+	// TODO(josh): Make the locking more fine-grained. Do not hold locks during calls
+	// to ReadAt.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// The data extent might cross cache block boundaries, hence the loop. In the hot
+	// path, max two iterations of this loop will be executed, since reads are sized
+	// in units of sstable block size.
+	for {
+		cacheBlockInd, ok := s.mu.where[metadataKey{
+			filenum:    fileNum,
+			blockIndex: (ofs + int64(n)) / int64(s.blockSize),
+		}]
+		if !ok {
+			return n, nil
+		}
+
+		readAt := cacheBlockInd * int64(s.blockSize)
+		if n == 0 { // if first read
+			readAt += ofs % int64(s.blockSize)
+		}
+		readSize := s.blockSize
+		if n == 0 { // if first read
+			// Cast to int safe since ofs is modded by block size.
+			readSize -= int(ofs % int64(s.blockSize))
+		}
+
+		if len(p[n:]) <= readSize {
+			numRead, err := s.file.ReadAt(p[n:], readAt)
+			return n + numRead, err
+		}
+		numRead, err := s.file.ReadAt(p[n:n+readSize], readAt)
+		if err != nil {
+			return 0, err
+		}
+
+		// Note that numRead == readSize, since we checked for an error above.
+		n += numRead
+	}
+}
+
+// Set attempts to write the requested data to the shard. The data must not
+// cross a shard boundary, and both ofs & len(p) must be multiples of the
+// block size.
+//
+// If all of p is not written to the shard, Set returns a non-nil error.
+func (s *sharedCacheShard) Set(fileNum base.FileNum, p []byte, ofs int64) error {
+	if invariants.Enabled {
+		if ofs/shardingBlockSize != (ofs+int64(len(p))-1)/shardingBlockSize {
+			panic("Set crosses shard boundary")
+		}
+		// TODO(josh): Assert that ofs & len(p) are multiples of the block size.
+	}
+
+	// TODO(josh): Make the locking more fine-grained. Do not hold locks during calls
+	// to WriteAt.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// The data extent might cross cache block boundaries, hence the loop. In the hot
+	// path, max two iterations of this loop will be executed, since reads are sized
+	// in units of sstable block size.
+	n := 0
+	for {
+		var cacheBlockInd int64
+		if len(s.mu.free) == 0 {
+			// TODO(josh): Right now, we do random eviction. Eventually, we will do something
+			// more sophisticated, e.g. leverage ClockPro.
+			var k metadataKey
+			for k1, v := range s.mu.where {
+				cacheBlockInd = v
+				k = k1
+				break
+			}
+			delete(s.mu.where, k)
+		} else {
+			cacheBlockInd = s.mu.free[len(s.mu.free)-1]
+			s.mu.free = s.mu.free[:len(s.mu.free)-1]
+		}
+
+		s.mu.where[metadataKey{
+			filenum:    fileNum,
+			blockIndex: (ofs + int64(n)) / int64(s.blockSize),
+		}] = cacheBlockInd
+
+		writeAt := cacheBlockInd * int64(s.blockSize)
+		writeSize := s.blockSize
+
+		if len(p[n:]) <= writeSize {
+			// Ignore num written ret value, since if partial write, an error
+			// is returned.
+			_, err := s.file.WriteAt(p[n:], writeAt)
+			return err
+		}
+		numWritten, err := s.file.WriteAt(p[n:n+writeSize], writeAt)
+		if err != nil {
+			return err
+		}
+
+		// Note that numWritten == writeSize, since we checked for an error above.
+		n += numWritten
+	}
 }

--- a/objstorage/objstorageprovider/shared_cache.go
+++ b/objstorage/objstorageprovider/shared_cache.go
@@ -1,0 +1,167 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package objstorageprovider
+
+import (
+	"context"
+	"fmt"
+	"math/bits"
+	"runtime"
+	"sync"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+type sharedCache struct {
+	shards []sharedCacheShard
+}
+
+func openSharedCache(
+	fs vfs.FS, fsDir string, blockSize int, sizeBytes int64,
+) (*sharedCache, error) {
+	numShards := 2 * runtime.GOMAXPROCS(0)
+	if sizeBytes < shardingBlockSize*int64(numShards) {
+		return nil, errors.Errorf("cache size %d too low", sizeBytes)
+	}
+	sc := &sharedCache{}
+	sc.shards = make([]sharedCacheShard, numShards)
+	blocksPerShard := sizeBytes / int64(numShards) / int64(blockSize)
+	for i := range sc.shards {
+		if err := sc.shards[i].init(fs, fsDir, i, blocksPerShard, blockSize); err != nil {
+			return nil, err
+		}
+	}
+	return sc, nil
+}
+
+func (sc *sharedCache) Close() error {
+	var retErr error
+	for i := range sc.shards {
+		if err := sc.shards[i].Close(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}
+	sc.shards = nil
+	return retErr
+}
+
+// ReadAt peforms a read form an object, attempting to use cached data when
+// possible.
+func (sc *sharedCache) ReadAt(
+	ctx context.Context, fileNum base.FileNum, p []byte, ofs int64, readable objstorage.Readable,
+) error {
+	n, err := sc.Get(fileNum, p, ofs)
+	if err != nil {
+		return err
+	}
+	if n == len(p) {
+		// Everything was in cache!
+		return nil
+	}
+	// Read the rest from the object.
+	// TODO(radu, josh): write back to cache.
+	return readable.ReadAt(ctx, p[n:], ofs+int64(n))
+}
+
+// Get attempts to read the requested data from the cache.
+//
+// If all data is available, returns n = len(p).
+//
+// If data is partially available, a prefix of the data is read; returns n < len(p)
+// and no error. If no prefix is available, returns n = 0 and no error.
+func (sc *sharedCache) Get(fileNum base.FileNum, p []byte, ofs int64) (n int, _ error) {
+	// The data extent might cross shard boundaries, hence the loop. In the hot
+	// path, only one iteration of the loop will be executed.
+	for {
+		shard := sc.getShard(fileNum, ofs)
+		cappedLen := len(p)
+		if toBoundary := int(shardingBlockSize - (ofs % shardingBlockSize)); cappedLen > toBoundary {
+			cappedLen = toBoundary
+		}
+		numRead, err := shard.Get(fileNum, p[n:n+cappedLen], ofs+int64(n))
+		if err != nil {
+			return n, err
+		}
+		n += numRead
+		if numRead < cappedLen {
+			// We only read a prefix from this shard.
+			return n, nil
+		}
+		if n == len(p) {
+			// We are done.
+			return n, nil
+		}
+		// Data extent crosses shard boundary, continue with next shard.
+	}
+}
+
+const shardingBlockSize = 1024 * 1024
+
+func (sc *sharedCache) getShard(fileNum base.FileNum, ofs int64) *sharedCacheShard {
+	const prime64 = 1099511628211
+	hash := uint64(fileNum)*prime64 + uint64(ofs)/shardingBlockSize
+	return &sc.shards[hash%uint64(len(sc.shards))]
+}
+
+type sharedCacheShard struct {
+	file         vfs.File
+	sizeInBlocks int64
+	// blockSizeExp is log2(BlockSize).
+	blockSizeExp int
+	mu           struct {
+		sync.Mutex
+		// TODO: map from fileNum / offset to block metadata.
+	}
+}
+
+func (s *sharedCacheShard) init(
+	fs vfs.FS, fsDir string, shardIdx int, sizeInBlocks int64, blockSize int,
+) error {
+	*s = sharedCacheShard{
+		sizeInBlocks: sizeInBlocks,
+	}
+	if blockSize < 1024 || shardingBlockSize%blockSize != 0 {
+		return errors.Newf("invalid block size %d (must divide %d)", blockSize, shardingBlockSize)
+	}
+	s.blockSizeExp = bits.Len64(uint64(blockSize)) - 1
+	file, err := fs.OpenReadWrite(fs.PathJoin(fsDir, fmt.Sprintf("SHARED-CACHE-%03d", shardIdx)))
+	if err != nil {
+		return err
+	}
+	// TODO(radu): truncate file if necessary (especially important if we restart
+	// with more shards).
+	if err := file.Preallocate(0, int64(blockSize)*sizeInBlocks); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *sharedCacheShard) Close() error {
+	defer func() {
+		s.file = nil
+	}()
+	return s.file.Close()
+}
+
+// Get attempts to read the requested data from the shard. The data must not
+// cross a shard boundary.
+//
+// If all data is available, returns n = len(p).
+//
+// If data is partially available, a prefix of the data is read; returns n < len(p)
+// and no error. If no prefix is available, returns n = 0 and no error.
+func (s *sharedCacheShard) Get(fileNum base.FileNum, p []byte, ofs int64) (n int, _ error) {
+	if invariants.Enabled {
+		if ofs/shardingBlockSize != (ofs+int64(len(p))-1)/shardingBlockSize {
+			panic("Get crosses shard boundary")
+		}
+	}
+	// TODO
+	return 0, nil
+}

--- a/objstorage/objstorageprovider/shared_cache.go
+++ b/objstorage/objstorageprovider/shared_cache.go
@@ -75,8 +75,8 @@ func (sc *sharedCache) ReadAt(
 	// later cache hits may return incorrect zeroed results from the cache. We assume
 	// that all shards have the same block size.
 	blockSize := sc.shards[0].blockSize
-	adjustedOfs := ((ofs+int64(n)) / int64(blockSize)) * int64(blockSize)
-	adjustedP := make([]byte, ((len(p[n:]) + (blockSize - 1)) / blockSize) * blockSize + int(ofs - adjustedOfs))
+	adjustedOfs := ((ofs + int64(n)) / int64(blockSize)) * int64(blockSize)
+	adjustedP := make([]byte, ((len(p[n:])+(blockSize-1))/blockSize)*blockSize+int(ofs-adjustedOfs))
 
 	// Read the rest from the object.
 	sc.misses.Add(1)

--- a/objstorage/objstorageprovider/shared_cache_test.go
+++ b/objstorage/objstorageprovider/shared_cache_test.go
@@ -1,0 +1,92 @@
+package objstorageprovider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+// TODO(josh): Write a randomized version.
+func TestSharedCache(t *testing.T) {
+	ctx := context.Background()
+
+	numShards := 32
+	size := shardingBlockSize * int64(numShards)
+
+	datadriven.Walk(t, "testdata/cache", func(t *testing.T, path string) {
+		var log base.InMemLogger
+		fs := vfs.WithLogging(vfs.NewMem(), func(fmt string, args ...interface{}) {
+			log.Infof("<local fs> "+fmt, args...)
+		})
+
+		cache, err := openSharedCache(fs, "", 32*1024, size, 32)
+		require.NoError(t, err)
+
+		file, err := fs.Create("test")
+		require.NoError(t, err)
+
+		var readable *fileReadable
+		var wrote []byte
+
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+			scanArgs := func(desc string, args ...interface{}) {
+				t.Helper()
+				if len(d.CmdArgs) != len(args) {
+					d.Fatalf(t, "usage: %s %s", d.Cmd, desc)
+				}
+				for i := range args {
+					_, err := fmt.Sscan(d.CmdArgs[i].String(), args[i])
+					if err != nil {
+						d.Fatalf(t, "%s: error parsing argument '%s'", d.Cmd, d.CmdArgs[i])
+					}
+				}
+			}
+
+			log.Reset()
+			switch d.Cmd {
+			case "write":
+				var size int
+				scanArgs("<size>", &size)
+
+				wrote = make([]byte, size)
+				for i := 0; i < size; i++ {
+					wrote[i] = byte(i)
+				}
+				n, err := file.Write(wrote)
+				// Writing a file is test setup, and it always is expected to succeed, so we assert
+				// within the test, rather than returning n and/or err here. Ditto below.
+				require.NoError(t, err)
+				require.Equal(t, size, n)
+
+				readable, err = newFileReadable(file, fs, "test")
+				require.NoError(t, err)
+
+				return ""
+			case "read":
+				var size int
+				var offset int64
+				scanArgs("<size> <offset>", &size, &offset)
+
+				got := make([]byte, size)
+				err = cache.ReadAt(ctx, 1, got, offset, readable)
+				// We always expect cache.ReadAt to succeed.
+				require.NoError(t, err)
+				// It is easier to assert this condition programmatically, rather than returning
+				// got, which may be very large.
+				require.Equal(t, wrote[int(offset):], got)
+
+				// TODO(josh): Not tracing out filesystem activity here, since logging_fs.go
+				// doesn't trace calls to ReadAt or WriteAt. We should consider changing this.
+				return fmt.Sprintf("misses=%d", cache.misses.Load())
+			default:
+				d.Fatalf(t, "unknown command %s", d.Cmd)
+				return ""
+			}
+		})
+	})
+}

--- a/objstorage/objstorageprovider/testdata/cache/read_that_hits_two_cache_blocks
+++ b/objstorage/objstorageprovider/testdata/cache/read_that_hits_two_cache_blocks
@@ -1,0 +1,16 @@
+# Large read that hits two cache blocks.
+
+write 32773
+----
+
+read 32773 0
+----
+misses=1
+
+read 32773 0
+----
+misses=1
+
+read 32716 57
+----
+misses=1

--- a/objstorage/objstorageprovider/testdata/cache/read_that_hits_two_cache_blocks_with_first_read_at_big_offset
+++ b/objstorage/objstorageprovider/testdata/cache/read_that_hits_two_cache_blocks_with_first_read_at_big_offset
@@ -1,0 +1,12 @@
+# Large read that hits two cache blocks, with first read at big offset.
+
+write 32773
+----
+
+read 5 32768
+----
+misses=1
+
+read 5 32768
+----
+misses=1

--- a/objstorage/objstorageprovider/testdata/cache/read_that_hits_two_cache_blocks_with_first_read_at_offset
+++ b/objstorage/objstorageprovider/testdata/cache/read_that_hits_two_cache_blocks_with_first_read_at_offset
@@ -1,0 +1,12 @@
+# Large read that hits two cache blocks, with first read at offset.
+
+write 32773
+----
+
+read 32716 57
+----
+misses=1
+
+read 32716 57
+----
+misses=1

--- a/objstorage/objstorageprovider/testdata/cache/read_that_hits_two_cache_shards
+++ b/objstorage/objstorageprovider/testdata/cache/read_that_hits_two_cache_shards
@@ -1,0 +1,16 @@
+# Large read that hits two cache shards.
+
+write 1048776
+----
+
+read 1048776 0
+----
+misses=1
+
+read 1048776 0
+----
+misses=1
+
+read 1048719 57
+----
+misses=1

--- a/objstorage/objstorageprovider/testdata/cache/read_that_hits_two_cache_shards_with_first_read_at_offset
+++ b/objstorage/objstorageprovider/testdata/cache/read_that_hits_two_cache_shards_with_first_read_at_offset
@@ -1,0 +1,12 @@
+# Large read that hits two cache shards, with first read at offset.
+
+write 1048776
+----
+
+read 1048719 57
+----
+misses=1
+
+read 1048719 57
+----
+misses=1

--- a/objstorage/objstorageprovider/testdata/cache/small_read
+++ b/objstorage/objstorageprovider/testdata/cache/small_read
@@ -1,0 +1,16 @@
+# Small read, with one miss then two hits.
+
+write 10
+----
+
+read 10 0
+----
+misses=1
+
+read 10 0
+----
+misses=1
+
+read 6 4
+----
+misses=1

--- a/objstorage/objstorageprovider/testdata/cache/small_read_with_first_read_at_offset
+++ b/objstorage/objstorageprovider/testdata/cache/small_read_with_first_read_at_offset
@@ -1,0 +1,16 @@
+# Small read, with first read at offset.
+
+write 10
+----
+
+read 6 4
+----
+misses=1
+
+read 6 4
+----
+misses=1
+
+read 10 0
+----
+misses=1

--- a/vfs/disk_health.go
+++ b/vfs/disk_health.go
@@ -219,6 +219,14 @@ func (d *diskHealthCheckingFile) Write(p []byte) (n int, err error) {
 	return n, err
 }
 
+// Write implements the io.WriterAt interface.
+func (d *diskHealthCheckingFile) WriteAt(p []byte, ofs int64) (n int, err error) {
+	d.timeDiskOp(OpTypeWrite, int64(len(p)), func() {
+		n, err = d.file.WriteAt(p, ofs)
+	})
+	return n, err
+}
+
 // Close implements the io.Closer interface.
 func (d *diskHealthCheckingFile) Close() error {
 	d.stopTicker()
@@ -677,6 +685,11 @@ func (d *diskHealthCheckingFS) MkdirAll(dir string, perm os.FileMode) error {
 
 // Open implements the FS interface.
 func (d *diskHealthCheckingFS) Open(name string, opts ...OpenOption) (File, error) {
+	return d.fs.Open(name, opts...)
+}
+
+// OpenReadWrite implements the FS interface.
+func (d *diskHealthCheckingFS) OpenReadWrite(name string, opts ...OpenOption) (File, error) {
 	return d.fs.Open(name, opts...)
 }
 

--- a/vfs/disk_health_test.go
+++ b/vfs/disk_health_test.go
@@ -37,6 +37,11 @@ func (m mockFile) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
+func (m mockFile) WriteAt(p []byte, ofs int64) (n int, err error) {
+	time.Sleep(m.syncAndWriteDuration)
+	return len(p), nil
+}
+
 func (m mockFile) Prefetch(offset, length int64) error {
 	panic("unimplemented")
 }
@@ -109,6 +114,10 @@ func (m mockFS) Open(name string, opts ...OpenOption) (File, error) {
 		panic("unimplemented")
 	}
 	return m.open(name, opts...)
+}
+
+func (m mockFS) OpenReadWrite(name string, opts ...OpenOption) (File, error) {
+	panic("unimplemented")
 }
 
 func (m mockFS) OpenDir(name string) (File, error) {

--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -302,6 +302,11 @@ func (y *MemFS) Open(fullname string, opts ...OpenOption) (File, error) {
 	return y.open(fullname)
 }
 
+// OpenReadWrite implements FS.OpenReadWrite.
+func (y *MemFS) OpenReadWrite(fullname string, opts ...OpenOption) (File, error) {
+	return y.open(fullname)
+}
+
 // OpenDir implements FS.OpenDir.
 func (y *MemFS) OpenDir(fullname string) (File, error) {
 	return y.open(fullname)
@@ -699,6 +704,29 @@ func (f *memFile) Write(p []byte) (int, error) {
 			p[i] ^= 0xff
 		}
 	}
+	return len(p), nil
+}
+
+func (f *memFile) WriteAt(p []byte, ofs int64) (int, error) {
+	if !f.write {
+		return 0, errors.New("pebble/vfs: file was not created for writing")
+	}
+	if f.n.isDir {
+		return 0, errors.New("pebble/vfs: cannot write a directory")
+	}
+	f.n.mu.Lock()
+	defer f.n.mu.Unlock()
+	f.n.mu.modTime = time.Now()
+
+	for len(f.n.mu.data) < int(ofs)+len(p) {
+		f.n.mu.data = append(f.n.mu.data, 0)
+	}
+
+	n := copy(f.n.mu.data[int(ofs):int(ofs)+len(p)], p)
+	if n != len(p) {
+		panic("stuff")
+	}
+
 	return len(p), nil
 }
 


### PR DESCRIPTION
Part of https://github.com/cockroachdb/pebble/issues/2541.

First two commit are authored by @RaduBerinde.

**vfs: support WriteAt**

Add support for opening files in read/write mode and writing at
arbitrary offsets.

**secondarycache: implement a minimal skeleton**

This commit implements a minimal skeleton for the secondary cache. As of this
commit, it is non-functional.

**secondarycache: implement a minimal functional secondary cache**

This commit expands the skeleton added in the last commit to be functional.
This commit also adds basic tests. Concretely, as of this commit, the secondary
cache implements storing cached data on disk, sharding, configurable cache
block sizes, a random eviction scheme, and in-memory metadata (implying the
overall secondary cache empties at restart time).

**vfs: make in-mem vfs satisfy the vfs contract**

This commit updates the in-memory vfs to satisy the vfs contract. Concretely,
OpenReadWrite now opens a file for reading & writing, creating the file if it
does not yet exist, and Create creates a file that can be read, not just
written to.