### PR TITLE
sharedcache: fix two bugs, add testing & assertions, esp. a randomized test

### DIFF
--- a/objstorage/objstorageprovider/shared_cache.go
+++ b/objstorage/objstorageprovider/shared_cache.go
@@ -76,7 +76,7 @@ func (sc *sharedCache) ReadAt(
 	// that all shards have the same block size.
 	blockSize := sc.shards[0].blockSize
 	adjustedOfs := ((ofs + int64(n)) / int64(blockSize)) * int64(blockSize)
-	adjustedP := make([]byte, (((len(p[n:]) + int(ofs-adjustedOfs))+(blockSize-1))/blockSize)*blockSize)
+	adjustedP := make([]byte, (((len(p[n:])+int(ofs-adjustedOfs))+(blockSize-1))/blockSize)*blockSize)
 
 	// Read the rest from the object.
 	sc.misses.Add(1)
@@ -112,7 +112,7 @@ func (sc *sharedCache) Get(fileNum base.FileNum, p []byte, ofs int64) (n int, _ 
 	for {
 		shard := sc.getShard(fileNum, ofs+int64(n))
 		cappedLen := len(p[n:])
-		if toBoundary := int(shardingBlockSize - ((ofs+int64(n)) % shardingBlockSize)); cappedLen > toBoundary {
+		if toBoundary := int(shardingBlockSize - ((ofs + int64(n)) % shardingBlockSize)); cappedLen > toBoundary {
 			cappedLen = toBoundary
 		}
 		numRead, err := shard.Get(fileNum, p[n:n+cappedLen], ofs+int64(n))
@@ -138,7 +138,7 @@ func (sc *sharedCache) Get(fileNum base.FileNum, p []byte, ofs int64) (n int, _ 
 // If all of p is not written to the shard, Set returns a non-nil error.
 func (sc *sharedCache) Set(fileNum base.FileNum, p []byte, ofs int64) error {
 	if invariants.Enabled {
-		if ofs % int64(sc.shards[0].blockSize) != 0 || len(p) % sc.shards[0].blockSize != 0 {
+		if ofs%int64(sc.shards[0].blockSize) != 0 || len(p)%sc.shards[0].blockSize != 0 {
 			panic(fmt.Sprintf("Set with ofs & len not multiples of block size: %v %v", ofs, len(p)))
 		}
 	}
@@ -150,7 +150,7 @@ func (sc *sharedCache) Set(fileNum base.FileNum, p []byte, ofs int64) error {
 	for {
 		shard := sc.getShard(fileNum, ofs+int64(n))
 		cappedLen := len(p[n:])
-		if toBoundary := int(shardingBlockSize - ((ofs+int64(n)) % shardingBlockSize)); cappedLen > toBoundary {
+		if toBoundary := int(shardingBlockSize - ((ofs + int64(n)) % shardingBlockSize)); cappedLen > toBoundary {
 			cappedLen = toBoundary
 		}
 		err := shard.Set(fileNum, p[n:n+cappedLen], ofs+int64(n))
@@ -301,7 +301,7 @@ func (s *sharedCacheShard) Set(fileNum base.FileNum, p []byte, ofs int64) error 
 		if ofs/shardingBlockSize != (ofs+int64(len(p))-1)/shardingBlockSize {
 			panic(fmt.Sprintf("Set crosses shard boundary: %v %v", ofs, len(p)))
 		}
-		if ofs % int64(s.blockSize) != 0 || len(p) % s.blockSize != 0 {
+		if ofs%int64(s.blockSize) != 0 || len(p)%s.blockSize != 0 {
 			panic(fmt.Sprintf("Set with ofs & len not multiples of block size: %v %v", ofs, len(p)))
 		}
 	}

--- a/objstorage/objstorageprovider/shared_cache_test.go
+++ b/objstorage/objstorageprovider/shared_cache_test.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/rand"
 )
 
-// TODO(josh): Write a randomized version.
 func TestSharedCache(t *testing.T) {
 	ctx := context.Background()
 
@@ -96,4 +97,63 @@ func TestSharedCache(t *testing.T) {
 			}
 		})
 	})
+}
+
+func TestSharedCacheRandomized(t *testing.T) {
+	ctx := context.Background()
+
+	var log base.InMemLogger
+	fs := vfs.WithLogging(vfs.NewMem(), func(fmt string, args ...interface{}) {
+		log.Infof("<local fs> "+fmt, args...)
+	})
+
+	seed := uint64(time.Now().UnixNano())
+	fmt.Printf("seed: %v\n", seed)
+	rand.Seed(seed)
+
+	blockSize := 32 * 1024 // 32 KB
+	if rand.Intn(2) == 0 {
+		blockSize = 1024 * 1024 // 1 MB
+	}
+	numShards := rand.Intn(64) + 1
+	cacheSize := int64(shardingBlockSize * numShards) // minimum allowed cache size
+
+	cache, err := openSharedCache(fs, "", blockSize, cacheSize, numShards)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	file, err := fs.Create("test")
+	require.NoError(t, err)
+
+	size := rand.Int63n(cacheSize)
+
+	// With invariants on, Write will modify its input buffer.
+	toWrite := make([]byte, size)
+	wrote := make([]byte, size)
+	for i := 0; i < int(size); i++ {
+		toWrite[i] = byte(i)
+		wrote[i] = byte(i)
+	}
+
+	n, err := file.Write(wrote)
+	require.NoError(t, err)
+	require.Equal(t, size, int64(n))
+
+	readable, err := newFileReadable(file, fs, "test")
+	require.NoError(t, err)
+	defer readable.Close()
+
+	offset := rand.Int63n(size)
+
+	// Cache miss.
+	got := make([]byte, size-offset)
+	err = cache.ReadAt(ctx, 1, got, offset, readable)
+	require.NoError(t, err)
+	require.Equal(t, toWrite[int(offset):], got)
+
+	// Cache hit.
+	got = make([]byte, size-offset)
+	err = cache.ReadAt(ctx, 1, got, offset, readable)
+	require.NoError(t, err)
+	require.Equal(t, toWrite[int(offset):], got)
 }

--- a/objstorage/objstorageprovider/testdata/cache/read_larger_than_two_cache_shards
+++ b/objstorage/objstorageprovider/testdata/cache/read_larger_than_two_cache_shards
@@ -1,0 +1,12 @@
+# Read larger than two cache shards.
+
+write 3145728
+----
+
+read 3145671 57
+----
+misses=1
+
+read 3145671 57
+----
+misses=1

--- a/vfs/logging_fs.go
+++ b/vfs/logging_fs.go
@@ -46,6 +46,15 @@ func (fs *loggingFS) Open(name string, opts ...OpenOption) (File, error) {
 	return newLoggingFile(f, name, fs.logFn), nil
 }
 
+func (fs *loggingFS) OpenReadWrite(name string, opts ...OpenOption) (File, error) {
+	fs.logFn("openreadwrite: %s", name)
+	f, err := fs.FS.OpenReadWrite(name, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return newLoggingFile(f, name, fs.logFn), nil
+}
+
 func (fs *loggingFS) Link(oldname, newname string) error {
 	fs.logFn("link: %s -> %s", oldname, newname)
 	return fs.FS.Link(oldname, newname)
@@ -135,6 +144,11 @@ func (f *loggingFile) SyncTo(length int64) (fullSync bool, err error) {
 func (f *loggingFile) ReadAt(p []byte, offset int64) (int, error) {
 	f.logFn("read-at(%d, %d): %s", offset, len(p), f.name)
 	return f.File.ReadAt(p, offset)
+}
+
+func (f *loggingFile) WriteAt(p []byte, offset int64) (int, error) {
+	f.logFn("write-at(%d, %d): %s", offset, len(p), f.name)
+	return f.File.WriteAt(p, offset)
 }
 
 func (f *loggingFile) Prefetch(offset int64, length int64) error {

--- a/vfs/logging_fs.go
+++ b/vfs/logging_fs.go
@@ -47,7 +47,7 @@ func (fs *loggingFS) Open(name string, opts ...OpenOption) (File, error) {
 }
 
 func (fs *loggingFS) OpenReadWrite(name string, opts ...OpenOption) (File, error) {
-	fs.logFn("openreadwrite: %s", name)
+	fs.logFn("open-read-write: %s", name)
 	f, err := fs.FS.OpenReadWrite(name, opts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
```
$ go test . -tags=invariants -run='TestSharedCacheRandomized' --count=1000
ok  	github.com/cockroachdb/pebble/objstorage/objstorageprovider	50.720s
```

**vfs: add logging for OpenReadWrite & WriteAt**

This commit adds logging for OpenReadWrite & WriteAt to the logging vfs.

**sharedcache: fix two bugs, add assertions & test case**

This commit fixes two bugs which were uncovered initially by the randomized
test that is added in the next commit. This commit adds assertions & a
non-randomized test case also.

The first bug was an incorrect computation of the length of the adjusted buffer
with the desired length being a multiple of the block size. The necessary
adjustment by ofs-adjustedOfs happened in the wrong place in the mathematical
expression computing the desired length of the adjusted buffer.

The second bug was an error in bounding calls to shard.Get and shard.Set so
that the reads & writes don't cross a shard boundary. The computation did not
take into account n, so it did not take into account previous calls to
shard.Get & shard.Set made in the loop in cache.Get & cache.Set.

**sharedcache: implement a randomized test**

This commit implements a randomized test of the shared cache. The main goal is
to find correctness bugs. The test found two bugs fixed in the previous commit.