### PR TITLE
crl-release-23.1: db,record: add BatchCommitStats to measure total and component durations for commit

### DIFF
--- a/commit_test.go
+++ b/commit_test.go
@@ -248,7 +248,7 @@ func TestCommitPipelineWALClose(t *testing.T) {
 			return nil
 		},
 		write: func(b *Batch, syncWG *sync.WaitGroup, syncErr *error) (*memTable, error) {
-			_, err := wal.SyncRecord(b.data, syncWG, syncErr)
+			_, _, err := wal.SyncRecord(b.data, syncWG, syncErr)
 			return nil, err
 		},
 	}
@@ -319,7 +319,7 @@ func BenchmarkCommitPipeline(b *testing.B) {
 								break
 							}
 
-							_, err := wal.SyncRecord(b.data, syncWG, syncErr)
+							_, _, err := wal.SyncRecord(b.data, syncWG, syncErr)
 							return mem, err
 						},
 					}

--- a/record/log_writer_test.go
+++ b/record/log_writer_test.go
@@ -148,7 +148,7 @@ func TestSyncError(t *testing.T) {
 		var syncErr error
 		var syncWG sync.WaitGroup
 		syncWG.Add(1)
-		_, err = w.SyncRecord([]byte("hello"), &syncWG, &syncErr)
+		_, _, err = w.SyncRecord([]byte("hello"), &syncWG, &syncErr)
 		require.NoError(t, err)
 		syncWG.Wait()
 		if injectedErr != syncErr {
@@ -186,7 +186,7 @@ func TestSyncRecord(t *testing.T) {
 	for i := 0; i < 100000; i++ {
 		var syncWG sync.WaitGroup
 		syncWG.Add(1)
-		offset, err := w.SyncRecord([]byte("hello"), &syncWG, &syncErr)
+		offset, _, err := w.SyncRecord([]byte("hello"), &syncWG, &syncErr)
 		require.NoError(t, err)
 		syncWG.Wait()
 		require.NoError(t, syncErr)
@@ -214,7 +214,7 @@ func TestSyncRecordWithSignalChan(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		var syncWG sync.WaitGroup
 		syncWG.Add(1)
-		_, err := w.SyncRecord([]byte("hello"), &syncWG, &syncErr)
+		_, _, err := w.SyncRecord([]byte("hello"), &syncWG, &syncErr)
 		require.NoError(t, err)
 		syncWG.Wait()
 		require.NoError(t, syncErr)
@@ -273,7 +273,7 @@ func TestMinSyncInterval(t *testing.T) {
 	syncRecord := func(n int) *sync.WaitGroup {
 		wg := &sync.WaitGroup{}
 		wg.Add(1)
-		_, err := w.SyncRecord(bytes.Repeat([]byte{'a'}, n), wg, new(error))
+		_, _, err := w.SyncRecord(bytes.Repeat([]byte{'a'}, n), wg, new(error))
 		require.NoError(t, err)
 		return wg
 	}
@@ -344,7 +344,7 @@ func TestMinSyncIntervalClose(t *testing.T) {
 	syncRecord := func(n int) *sync.WaitGroup {
 		wg := &sync.WaitGroup{}
 		wg.Add(1)
-		_, err := w.SyncRecord(bytes.Repeat([]byte{'a'}, n), wg, new(error))
+		_, _, err := w.SyncRecord(bytes.Repeat([]byte{'a'}, n), wg, new(error))
 		require.NoError(t, err)
 		return wg
 	}
@@ -379,7 +379,7 @@ func TestMetricsWithoutSync(t *testing.T) {
 	f := &syncFileWithWait{}
 	f.writeWG.Add(1)
 	w := NewLogWriter(f, 0, LogWriterConfig{WALFsyncLatency: prometheus.NewHistogram(prometheus.HistogramOpts{})})
-	offset, err := w.SyncRecord([]byte("hello"), nil, nil)
+	offset, _, err := w.SyncRecord([]byte("hello"), nil, nil)
 	require.NoError(t, err)
 	const recordSize = 16
 	require.EqualValues(t, recordSize, offset)
@@ -388,7 +388,7 @@ func TestMetricsWithoutSync(t *testing.T) {
 	// constitutes ~14 blocks (each 32KB).
 	const numRecords = 28 << 10
 	for i := 0; i < numRecords; i++ {
-		_, err = w.SyncRecord([]byte("hello"), nil, nil)
+		_, _, err = w.SyncRecord([]byte("hello"), nil, nil)
 		require.NoError(t, err)
 	}
 	// Unblock the flush loop. It will run once or twice to write these blocks,
@@ -430,7 +430,7 @@ func TestMetricsWithSync(t *testing.T) {
 	wg.Add(100)
 	for i := 0; i < 100; i++ {
 		var syncErr error
-		_, err := w.SyncRecord([]byte("hello"), &wg, &syncErr)
+		_, _, err := w.SyncRecord([]byte("hello"), &wg, &syncErr)
 		require.NoError(t, err)
 	}
 	// Unblock the flush loop. It may have run once or twice for these writes,


### PR DESCRIPTION
backport to 23.1
----

The component durations expose implementation detail and are only for expert diagnosis. We may choose to trace slow batch commits in CockroachDB, and aggregate these durations into histograms for metrics.

Informs #1943