### PR TITLE
crl-release-23.1: tool: improve `wal dump` output

### DIFF
--- a/internal/keyspan/span.go
+++ b/internal/keyspan/span.go
@@ -368,6 +368,7 @@ func (s Span) String() string {
 
 // Pretty returns a formatter for the span.
 func (s Span) Pretty(f base.FormatKey) fmt.Formatter {
+	// TODO(jackson): Take a base.FormatValue to format Key.Value too.
 	return prettySpan{s, f}
 }
 

--- a/tool/testdata/wal_dump
+++ b/tool/testdata/wal_dump
@@ -112,7 +112,7 @@ wal dump
 000004.log
 0(42) seq=30 count=4
     SET(test formatter: a@2,test value formatter: )
-    RANGEKEYSET()
-    RANGEKEYUNSET()
-    RANGEKEYDEL()
+    RANGEKEYSET(test formatter: a-test formatter: z:{(#31,RANGEKEYSET,@3)})
+    RANGEKEYUNSET(test formatter: a-test formatter: z:{(#32,RANGEKEYUNSET,@4)})
+    RANGEKEYDEL(test formatter: a-test formatter: b:{(#33,RANGEKEYDEL)})
 EOF


### PR DESCRIPTION
Backport of #2552.

----

Improve the debug tool's output for dumping WALs. Previously, the contents of range keys (start key, end key, suffix and value) were never printed. Additionally, the file number associated with an INGESTSST (encoded within the userkey as a varint) was not printed.