### PR TITLE
crl-release-23.1: point tombstone bug fixes

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -672,11 +672,11 @@ type candidateLevelInfo struct {
 
 // compensatedSize returns f's file size, inflated according to compaction
 // priorities.
-func compensatedSize(f *fileMetadata, pointTombstoneWeight float64) uint64 {
+func compensatedSize(f *fileMetadata) uint64 {
 	sz := f.Size
 	// Add in the estimate of disk space that may be reclaimed by compacting
 	// the file's tombstones.
-	sz += uint64(float64(f.Stats.PointDeletionsBytesEstimate) * pointTombstoneWeight)
+	sz += uint64(f.Stats.PointDeletionsBytesEstimate)
 	sz += f.Stats.RangeDeletionsBytesEstimate
 	return sz
 }
@@ -687,7 +687,6 @@ func compensatedSize(f *fileMetadata, pointTombstoneWeight float64) uint64 {
 // asynchronously, so its values are marked as cacheable only if a file's
 // stats have been loaded.
 type compensatedSizeAnnotator struct {
-	pointTombstoneWeight float64
 }
 
 var _ manifest.Annotator = compensatedSizeAnnotator{}
@@ -705,7 +704,7 @@ func (a compensatedSizeAnnotator) Accumulate(
 	f *fileMetadata, dst interface{},
 ) (v interface{}, cacheOK bool) {
 	vptr := dst.(*uint64)
-	*vptr = *vptr + compensatedSize(f, a.pointTombstoneWeight)
+	*vptr = *vptr + compensatedSize(f)
 	return vptr, f.StatsValidLocked()
 }
 
@@ -720,10 +719,10 @@ func (a compensatedSizeAnnotator) Merge(src interface{}, dst interface{}) interf
 // iterator. Note that this function is linear in the files available to the
 // iterator. Use the compensatedSizeAnnotator if querying the total
 // compensated size of a level.
-func totalCompensatedSize(iter manifest.LevelIterator, pointTombstoneWeight float64) uint64 {
+func totalCompensatedSize(iter manifest.LevelIterator) uint64 {
 	var sz uint64
 	for f := iter.First(); f != nil; f = iter.Next() {
-		sz += compensatedSize(f, pointTombstoneWeight)
+		sz += compensatedSize(f)
 	}
 	return sz
 }
@@ -921,9 +920,7 @@ func (p *compactionPickerByScore) initLevelMaxBytes(inProgressCompactions []comp
 	}
 }
 
-func calculateSizeAdjust(
-	inProgressCompactions []compactionInfo, pointTombstoneWeight float64,
-) [numLevels]int64 {
+func calculateSizeAdjust(inProgressCompactions []compactionInfo) [numLevels]int64 {
 	// Compute a size adjustment for each level based on the in-progress
 	// compactions. We subtract the compensated size of start level inputs.
 	// Since compensated file sizes may be compensated because they reclaim
@@ -936,7 +933,7 @@ func calculateSizeAdjust(
 
 		for _, input := range c.inputs {
 			real := int64(input.files.SizeSum())
-			compensated := int64(totalCompensatedSize(input.files.Iter(), pointTombstoneWeight))
+			compensated := int64(totalCompensatedSize(input.files.Iter()))
 
 			if input.level != c.outputLevel {
 				sizeAdjust[input.level] -= compensated
@@ -963,10 +960,7 @@ func (p *compactionPickerByScore) calculateScores(
 	}
 	scores[0] = p.calculateL0Score(inProgressCompactions)
 
-	sizeAdjust := calculateSizeAdjust(
-		inProgressCompactions,
-		p.opts.Experimental.PointTombstoneWeight,
-	)
+	sizeAdjust := calculateSizeAdjust(inProgressCompactions)
 	for level := 1; level < numLevels; level++ {
 		levelSize := int64(levelCompensatedSize(p.vers.Levels[level])) + sizeAdjust[level]
 		scores[level].score = float64(levelSize) / float64(p.levelMaxBytes[level])
@@ -1123,7 +1117,7 @@ func (p *compactionPickerByScore) pickFile(
 			continue
 		}
 
-		compSz := compensatedSize(f, p.opts.Experimental.PointTombstoneWeight)
+		compSz := compensatedSize(f)
 		scaledRatio := overlappingBytes * 1024 / compSz
 		if scaledRatio < smallestRatio && !f.IsCompacting() {
 			smallestRatio = scaledRatio
@@ -1187,7 +1181,7 @@ func (p *compactionPickerByScore) pickAuto(env compactionEnv) (pc *pickedCompact
 			fmt.Fprintf(&buf, "  %sL%d: %5.1f  %5.1f  %8s  %8s",
 				marker, info.level, info.score, info.origScore,
 				humanize.Int64(int64(totalCompensatedSize(
-					p.vers.Levels[info.level].Iter(), p.opts.Experimental.PointTombstoneWeight,
+					p.vers.Levels[info.level].Iter(),
 				))),
 				humanize.Int64(p.levelMaxBytes[info.level]),
 			)

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -670,15 +670,16 @@ type candidateLevelInfo struct {
 	file manifest.LevelFile
 }
 
+func fileCompensation(f *fileMetadata) uint64 {
+	return uint64(f.Stats.PointDeletionsBytesEstimate) + f.Stats.RangeDeletionsBytesEstimate
+}
+
 // compensatedSize returns f's file size, inflated according to compaction
 // priorities.
 func compensatedSize(f *fileMetadata) uint64 {
-	sz := f.Size
-	// Add in the estimate of disk space that may be reclaimed by compacting
-	// the file's tombstones.
-	sz += uint64(f.Stats.PointDeletionsBytesEstimate)
-	sz += f.Stats.RangeDeletionsBytesEstimate
-	return sz
+	// Add in the estimate of disk space that may be reclaimed by compacting the
+	// file's tombstones.
+	return f.Size + fileCompensation(f)
 }
 
 // compensatedSizeAnnotator implements manifest.Annotator, annotating B-Tree

--- a/data_test.go
+++ b/data_test.go
@@ -777,6 +777,12 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 					return nil, errors.New("Snapshots must be in ascending order")
 				}
 			}
+		case "lbase-max-bytes":
+			lbaseMaxBytes, err := strconv.ParseInt(arg.Vals[0], 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			opts.LBaseMaxBytes = lbaseMaxBytes
 		case "level-max-bytes":
 			levelMaxBytes = map[int]int64{}
 			for i := range arg.Vals {
@@ -815,12 +821,12 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 			for _, levelOpts := range opts.Levels {
 				levelOpts.BlockSize = size
 			}
-		case "point-tombstone-weight":
-			w, err := strconv.ParseFloat(arg.Vals[0], 64)
+		case "format-major-version":
+			fmv, err := strconv.Atoi(arg.Vals[0])
 			if err != nil {
-				return nil, errors.Errorf("%s: could not parse %q as float: %s", td.Cmd, arg.Vals[0], err)
+				return nil, err
 			}
-			opts.Experimental.PointTombstoneWeight = w
+			opts.FormatMajorVersion = FormatMajorVersion(fmv)
 		}
 	}
 	d, err := Open("", opts)

--- a/internal/metamorphic/options.go
+++ b/internal/metamorphic/options.go
@@ -367,7 +367,6 @@ func randomOptions(rng *rand.Rand) *testOptions {
 		lopts.FilterPolicy = newTestingFilterPolicy(1 << rng.Intn(5))
 	}
 	opts.Levels = []pebble.LevelOptions{lopts}
-	opts.Experimental.PointTombstoneWeight = 1 + 10*rng.Float64() // 1 - 10
 
 	// Explicitly disable disk-backed FS's for the random configurations. The
 	// single standard test configuration that uses a disk-backed FS is

--- a/open.go
+++ b/open.go
@@ -510,7 +510,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	}
 	d.mu.tableStats.cond.L = &d.mu.Mutex
 	d.mu.tableValidation.cond.L = &d.mu.Mutex
-	if !d.opts.ReadOnly && !d.opts.private.disableTableStats {
+	if !d.opts.ReadOnly {
 		d.maybeCollectTableStatsLocked()
 	}
 	d.calculateDiskAvailableBytes()

--- a/options.go
+++ b/options.go
@@ -596,12 +596,6 @@ type Options struct {
 		// for CPUWorkPermissionGranter for more details.
 		CPUWorkPermissionGranter CPUWorkPermissionGranter
 
-		// PointTombstoneWeight is a float in the range [0, +inf) used to weight the
-		// point tombstone heuristics during compaction picking.
-		//
-		// The default value is 1, which results in no scaling of point tombstones.
-		PointTombstoneWeight float64
-
 		// EnableValueBlocks is used to decide whether to enable writing
 		// TableFormatPebblev3 sstables. WARNING: do not return true yet, since
 		// support for TableFormatPebblev3 is incomplete and not production ready.
@@ -1030,10 +1024,6 @@ func (o *Options) EnsureDefaults() *Options {
 	if o.Experimental.CPUWorkPermissionGranter == nil {
 		o.Experimental.CPUWorkPermissionGranter = defaultCPUWorkGranter{}
 	}
-	if o.Experimental.PointTombstoneWeight == 0 {
-		o.Experimental.PointTombstoneWeight = 1
-	}
-
 	if o.Experimental.MultiLevelCompactionHueristic == nil {
 		o.Experimental.MultiLevelCompactionHueristic = NoMultiLevel{}
 	}
@@ -1156,7 +1146,6 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  mem_table_stop_writes_threshold=%d\n", o.MemTableStopWritesThreshold)
 	fmt.Fprintf(&buf, "  min_deletion_rate=%d\n", o.Experimental.MinDeletionRate)
 	fmt.Fprintf(&buf, "  merger=%s\n", o.Merger.Name)
-	fmt.Fprintf(&buf, "  point_tombstone_weight=%f\n", o.Experimental.PointTombstoneWeight)
 	fmt.Fprintf(&buf, "  read_compaction_rate=%d\n", o.Experimental.ReadCompactionRate)
 	fmt.Fprintf(&buf, "  read_sampling_multiplier=%d\n", o.Experimental.ReadSamplingMultiplier)
 	fmt.Fprintf(&buf, "  strict_wal_tail=%t\n", o.private.strictWALTail)
@@ -1406,7 +1395,7 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				// Do nothing; option existed in older versions of pebble, and
 				// may be meaningful again eventually.
 			case "point_tombstone_weight":
-				o.Experimental.PointTombstoneWeight, err = strconv.ParseFloat(value, 64)
+				// Do nothing; deprecated.
 			case "strict_wal_tail":
 				o.private.strictWALTail, err = strconv.ParseBool(value)
 			case "merger":

--- a/options_test.go
+++ b/options_test.go
@@ -91,7 +91,6 @@ func TestOptionsString(t *testing.T) {
   mem_table_stop_writes_threshold=2
   min_deletion_rate=0
   merger=pebble.concatenate
-  point_tombstone_weight=1.000000
   read_compaction_rate=16000
   read_sampling_multiplier=16
   strict_wal_tail=true

--- a/replay/testdata/replay
+++ b/replay/testdata/replay
@@ -13,7 +13,7 @@ tree
        0      LOCK
       96      MANIFEST-000001
      122      MANIFEST-000008
-    1171      OPTIONS-000003
+    1137      OPTIONS-000003
        0      marker.format-version.000007.008
        0      marker.manifest.000002.MANIFEST-000008
             simple/
@@ -24,7 +24,7 @@ tree
       25        000004.log
      795        000005.sst
       96        MANIFEST-000001
-    1171        OPTIONS-000003
+    1137        OPTIONS-000003
        0        marker.format-version.000001.008
        0        marker.manifest.000001.MANIFEST-000001
 
@@ -57,7 +57,6 @@ cat build/OPTIONS-000003
   mem_table_stop_writes_threshold=2
   min_deletion_rate=0
   merger=pebble.concatenate
-  point_tombstone_weight=1.000000
   read_compaction_rate=16000
   read_sampling_multiplier=16
   strict_wal_tail=true

--- a/replay/testdata/replay_paced
+++ b/replay/testdata/replay_paced
@@ -15,7 +15,7 @@ tree
        0      LOCK
      122      MANIFEST-000008
      205      MANIFEST-000011
-    1171      OPTIONS-000003
+    1137      OPTIONS-000003
        0      marker.format-version.000007.008
        0      marker.manifest.000003.MANIFEST-000011
             high_read_amp/
@@ -27,7 +27,7 @@ tree
       39        000009.log
      769        000010.sst
      157        MANIFEST-000011
-    1171        OPTIONS-000003
+    1137        OPTIONS-000003
        0        marker.format-version.000001.008
        0        marker.manifest.000001.MANIFEST-000011
 

--- a/table_stats.go
+++ b/table_stats.go
@@ -126,7 +126,7 @@ func (d *DB) collectTableStats() bool {
 	maybeCompact := false
 	for _, c := range collected {
 		c.fileMetadata.Stats = c.TableStats
-		maybeCompact = maybeCompact || c.TableStats.RangeDeletionsBytesEstimate > 0
+		maybeCompact = maybeCompact || fileCompensation(c.fileMetadata) > 0
 		c.fileMetadata.StatsMarkValid()
 	}
 	d.mu.tableStats.cond.Broadcast()

--- a/testdata/compaction_picker_scores
+++ b/testdata/compaction_picker_scores
@@ -105,3 +105,61 @@ L3  	0 B    0.0
 L4  	0 B    0.0
 L5  	785 B  4.5
 L6  	321 K  -
+
+# Run a similar test as above, but this time the table containing the DELs is
+# ingested after the database is initialized, with table stats enabled and
+# automatic compactions enabled. When the ingested sstable's stats are loaded,
+# it should trigger an automatic compaction of the ingested sstable on account
+# of the high point-deletions-bytes-estimate value.
+#
+# This a regression test for an issue where the table stats collector wouldn't
+# attempt to schedule a compaction if a file only had compensation due to point
+# deletions and not range deletions.
+
+define lbase-max-bytes=65536  enable-table-stats=true auto-compactions=on
+L6
+  a.SET.1:<rand-bytes=65536>
+  b.SET.1:<rand-bytes=65536>
+  c.SET.1:<rand-bytes=65536>
+  d.SET.1:<rand-bytes=65536>
+  e.SET.1:<rand-bytes=65536>
+----
+6:
+  000004:[a#1,SET-e#1,SET]
+
+ingest ext1
+del a:
+del b:
+del c:
+del d:
+del e:
+----
+5:
+  000005:[a:#2,DEL-e:#2,DEL]
+6:
+  000004:[a#1,SET-e#1,SET]
+
+wait-pending-table-stats
+000005
+----
+num-entries: 5
+num-deletions: 5
+num-range-key-sets: 0
+point-deletions-bytes-estimate: 328660
+range-deletions-bytes-estimate: 0
+
+scores
+----
+L       Size   Score
+L0  	0 B    0.0
+L1  	0 B    0.0
+L2  	0 B    0.0
+L3  	0 B    0.0
+L4  	0 B    0.0
+L5  	0 B    0.0
+L6  	321 K  -
+
+lsm
+----
+6:
+  000006:[a#0,SET-e#0,SET]

--- a/testdata/compaction_picker_scores
+++ b/testdata/compaction_picker_scores
@@ -1,0 +1,107 @@
+# Ensure that a range deletion in a higher level results in a compensated level
+# size and a higher level score as a result.
+
+define lbase-max-bytes=65536 enable-table-stats=false
+L5
+  a.RANGEDEL.2:f
+L6
+  a.SET.1:<rand-bytes=65536>
+  b.SET.1:<rand-bytes=65536>
+  c.SET.1:<rand-bytes=65536>
+  d.SET.1:<rand-bytes=65536>
+  e.SET.1:<rand-bytes=65536>
+----
+5:
+  000004:[a#2,RANGEDEL-f#inf,RANGEDEL]
+6:
+  000005:[a#1,SET-e#1,SET]
+
+scores
+----
+L       Size   Score
+L0  	0 B    0.0
+L1  	0 B    0.0
+L2  	0 B    0.0
+L3  	0 B    0.0
+L4  	0 B    0.0
+L5  	834 B  0.0
+L6  	321 K  -
+
+enable-table-stats
+----
+
+wait-pending-table-stats
+000004
+----
+num-entries: 1
+num-deletions: 1
+num-range-key-sets: 0
+point-deletions-bytes-estimate: 0
+range-deletions-bytes-estimate: 328623
+
+scores
+----
+L       Size   Score
+L0  	0 B    0.0
+L1  	0 B    0.0
+L2  	0 B    0.0
+L3  	0 B    0.0
+L4  	0 B    0.0
+L5  	834 B  4.5
+L6  	321 K  -
+
+# Ensure that point deletions in a higher level result in a compensated level
+# size and higher level scores as a result.
+
+define lbase-max-bytes=65536  enable-table-stats=false
+L5
+  a.DEL.2:
+  b.DEL.2:
+  c.DEL.2:
+  d.DEL.2:
+  e.DEL.2:
+L6
+  a.SET.1:<rand-bytes=65536>
+  b.SET.1:<rand-bytes=65536>
+  c.SET.1:<rand-bytes=65536>
+  d.SET.1:<rand-bytes=65536>
+  e.SET.1:<rand-bytes=65536>
+----
+5:
+  000004:[a#2,DEL-e#2,DEL]
+6:
+  000005:[a#1,SET-e#1,SET]
+
+scores
+----
+L       Size   Score
+L0  	0 B    0.0
+L1  	0 B    0.0
+L2  	0 B    0.0
+L3  	0 B    0.0
+L4  	0 B    0.0
+L5  	785 B  0.0
+L6  	321 K  -
+
+enable-table-stats
+----
+
+wait-pending-table-stats
+000004
+----
+num-entries: 5
+num-deletions: 5
+num-range-key-sets: 0
+point-deletions-bytes-estimate: 328660
+range-deletions-bytes-estimate: 0
+
+scores
+----
+L       Size   Score
+L0  	0 B    0.0
+L1  	0 B    0.0
+L2  	0 B    0.0
+L3  	0 B    0.0
+L4  	0 B    0.0
+L5  	785 B  4.5
+L6  	321 K  -

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -416,4 +416,4 @@ range-deletions-bytes-estimate: 8244
 
 maybe-compact
 ----
-[JOB 100] compacted(default) L5 [000004] (782 B) + L6 [000006] (13 K) -> L6 [000008] (4.8 K), in 1.0s (2.0s total), output rate 4.8 K/s
+[JOB 100] compacted(default) L5 [000005] (849 B) + L6 [000007] (13 K) -> L6 [000008] (4.8 K), in 1.0s (2.0s total), output rate 4.8 K/s

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -152,7 +152,7 @@ zmemtbl         1   256 K
 
 disk-usage
 ----
-2.9 K
+2.8 K
 
 # Closing iter b will release the last zombie sstable and the last zombie memtable.
 


### PR DESCRIPTION
23.1 backport of #2550.

----

**db: remove experimental point tombstone weight option**

Remove the experimental point_tombstone_weight option. The introduction of this
option accidentally caused the loss of point tombstone compensation applied to
level scoring. It's been inconculsive whether setting this value >1.0 has ever
helped customers.

**db: consider scheduling compaction when adding point tombstone compensation**

Previously, when the asynchronous table stats collector calculated a positive
PointDeletionsBytesEstimate, it did not consider scheduling compactions unless
it also calculated a positive RangeDeletionsBytesEstimate. If the database was
otherwise quiet with few flushes and no in-progress compactions, this could
delay the scheduling of a compaction until the next flush or ingest, despite
levels having scores ≥ 1.0. This was illustrated with CockroachDB's point
tombstone roachtest, which at times ran no compactions despite levels having
scores as high as 50 due to high volumes of data dropped by point tombstones.

Note, an issue still remains whereby L0 files that delete large amounts of data
do not trigger compactions out of L0 on their own. This is a consequence of
L0's different scoring heuristics which do not consider compensated size. See
https://github.com/cockroachdb/pebble/issues/2549.