### PR TITLE
db: fix compaction file picking bounds checks

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1085,12 +1085,12 @@ func (p *compactionPickerByScore) pickFile(
 		var overlappingBytes uint64
 
 		// Trim any output-level files smaller than f.
-		for outputFile != nil && base.InternalCompare(cmp, outputFile.Largest, f.Smallest) < 0 {
+		for outputFile != nil && sstableKeyCompare(cmp, outputFile.Largest, f.Smallest) < 0 {
 			outputFile = outputIter.Next()
 		}
 
 		compacting := f.IsCompacting()
-		for outputFile != nil && base.InternalCompare(cmp, outputFile.Smallest, f.Largest) < 0 {
+		for outputFile != nil && sstableKeyCompare(cmp, outputFile.Smallest, f.Largest) <= 0 {
 			overlappingBytes += outputFile.Size
 			compacting = compacting || outputFile.IsCompacting()
 
@@ -1109,7 +1109,7 @@ func (p *compactionPickerByScore) pickFile(
 			// If the file in the next level extends beyond f's largest key,
 			// break out and don't advance outputIter because f's successor
 			// might also overlap.
-			if base.InternalCompare(cmp, outputFile.Largest, f.Largest) > 0 {
+			if sstableKeyCompare(cmp, outputFile.Largest, f.Largest) > 0 {
 				break
 			}
 			outputFile = outputIter.Next()

--- a/testdata/compaction_picker_pick_file
+++ b/testdata/compaction_picker_pick_file
@@ -1,0 +1,107 @@
+# Simple test with a single file per level.
+
+define
+L1
+  b.SET.11:foo
+  c.SET.11:foo
+L2
+  c.SET.0:foo
+  d.SET.0:foo
+----
+1:
+  000004:[b#11,SET-c#11,SET]
+2:
+  000005:[c#0,SET-d#0,SET]
+
+file-sizes
+----
+L1:
+  000004:[b#11,1-c#11,1]: 778 bytes (778 B)
+L2:
+  000005:[c#0,1-d#0,1]: 777 bytes (777 B)
+
+pick-file L1
+----
+000004:[b#11,1-c#11,1]
+
+pick-file L2
+----
+000005:[c#0,1-d#0,1]
+
+# Test a scenario where we should pick a file with a tiny file size over one
+# with a larger file size, because the tiny sized one overlaps zero data in the
+# output level.
+
+define
+L5
+  b.SET.11:<rand-bytes=65536>
+  c.SET.11:<rand-bytes=65536>
+L5
+  e.SET.11:<rand-bytes=2>
+L6
+  a.SET.0:foo
+  d.SET.0:foo
+----
+5:
+  000004:[b#11,SET-c#11,SET]
+  000005:[e#11,SET-e#11,SET]
+6:
+  000006:[a#0,SET-d#0,SET]
+
+pick-file L5
+----
+000005:[e#11,1-e#11,1]
+
+# Test the same scenario as above, but the larger file that overlaps the next
+# level only overlaps on its end boundary key ("c"). c.SET.11 sorts before
+# c.SET.0, but the files should still be considered overlapping.
+
+define
+L5
+  b.SET.11:<rand-bytes=65536>
+  c.SET.11:<rand-bytes=65536>
+L5
+  e.SET.11:<rand-bytes=2>
+L6
+  a.SET.0:foo
+  c.SET.0:foo
+----
+5:
+  000004:[b#11,SET-c#11,SET]
+  000005:[e#11,SET-e#11,SET]
+6:
+  000006:[a#0,SET-c#0,SET]
+
+pick-file L5
+----
+000005:[e#11,1-e#11,1]
+
+
+# Test a scenario where the file containing e.SET.11 overlaps an L6 file
+# containing e.SET.0. These files should be considered overlapping, despite the
+# fact that they don't overlap within the internal key keyspace. The overlap
+# should then cause the larger file (with a lower overlapping ratio) to be
+# picked.
+
+define
+L5
+  c.SET.11:<rand-bytes=65536>
+  d.SET.11:<rand-bytes=65536>
+L5
+  e.SET.11:<rand-bytes=2>
+L6
+  a.SET.0:foo
+  c.SET.0:foo
+L6
+  e.SET.0:foo
+----
+5:
+  000004:[c#11,SET-d#11,SET]
+  000005:[e#11,SET-e#11,SET]
+6:
+  000006:[a#0,SET-c#0,SET]
+  000007:[e#0,SET-e#0,SET]
+
+pick-file L5
+----
+000004:[c#11,1-d#11,1]

--- a/testdata/compaction_picker_target_level
+++ b/testdata/compaction_picker_target_level
@@ -195,7 +195,7 @@ L4->L5: 7.7
 
 pick ongoing=(5,6)
 ----
-no compaction
+L4->L5: 12.0
 
 pick ongoing=(0,4)
 ----
@@ -211,7 +211,7 @@ base: 4
 
 pick ongoing=(0,5)
 ----
-no compaction
+L4->L5: 8.6
 
 init 1
 0: 20


### PR DESCRIPTION
When picking a seed file within a level to build a compaction around, the compaction picker uses a 'min-overlapping ratio' heuristic to pick a file such that the sum of the overlapping output-level files have the least size relative to the input-level file's size. This requires the compaction picker to check for file overlap between levels as it walks across a level.

Previously, these overlap checks were performed in terms of internal key comparisons. However, internal key comparisons are not what ultimately determine whether or not a compaction overlaps. A table with a largest key b.SET.10 and a table with a smallest key b.SET.0 overlap (they both contain the key "b"), despite b.SET.10 sorting before b.SET.0 within the internal key keyspace. This bug did not break LSM invariants because compaction inputs setup would always separately calculate output-level overlaps, which would pull in the correct file. However, in these cases the compaction picker could pick a suboptimal file for compaction, mistakenly calculating an overlapping ratio that's lower than the file's true overlapping ratio.