### PR TITLE
db: avoid logging to stdout in unit tests

### DIFF
--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -24,9 +24,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func loadVersion(d *datadriven.TestData) (*version, *Options, [numLevels]int64, string) {
+func loadVersion(
+	t *testing.T, d *datadriven.TestData,
+) (*version, *Options, [numLevels]int64, string) {
 	var sizes [numLevels]int64
 	opts := &Options{}
+	opts.testingRandomized(t)
 	opts.EnsureDefaults()
 
 	if len(d.CmdArgs) != 1 {
@@ -100,7 +103,7 @@ func TestCompactionPickerByScoreLevelMaxBytes(t *testing.T) {
 		func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "init":
-				vers, opts, sizes, errMsg := loadVersion(d)
+				vers, opts, sizes, errMsg := loadVersion(t, d)
 				if errMsg != "" {
 					return errMsg
 				}
@@ -163,7 +166,7 @@ func TestCompactionPickerTargetLevel(t *testing.T) {
 			switch d.Cmd {
 			case "init":
 				var errMsg string
-				vers, opts, sizes, errMsg = loadVersion(d)
+				vers, opts, sizes, errMsg = loadVersion(t, d)
 				if errMsg != "" {
 					return errMsg
 				}
@@ -309,7 +312,7 @@ func TestCompactionPickerEstimatedCompactionDebt(t *testing.T) {
 		func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "init":
-				vers, opts, sizes, errMsg := loadVersion(d)
+				vers, opts, sizes, errMsg := loadVersion(t, d)
 				if errMsg != "" {
 					return errMsg
 				}

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -959,7 +959,7 @@ func TestCompaction(t *testing.T) {
 		DebugCheck:            DebugCheckLevels,
 		L0CompactionThreshold: 8,
 	}
-	opts.testingRandomized().WithFSDefaults()
+	opts.testingRandomized(t).WithFSDefaults()
 	d, err := Open("", opts)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
@@ -2911,7 +2911,7 @@ func TestCompactionErrorCleanup(t *testing.T) {
 	for i := range opts.Levels {
 		opts.Levels[i].TargetFileSize = 1
 	}
-	opts.testingRandomized()
+	opts.testingRandomized(t)
 	d, err := Open("", opts)
 	require.NoError(t, err)
 
@@ -3180,7 +3180,7 @@ func TestFlushInvariant(t *testing.T) {
 				t.Run("", func(t *testing.T) {
 					errCh := make(chan error, 1)
 					defer close(errCh)
-					d, err := Open("", testingRandomized(&Options{
+					d, err := Open("", testingRandomized(t, &Options{
 						DisableWAL: disableWAL,
 						FS:         vfs.NewMem(),
 						EventListener: &EventListener{
@@ -3241,7 +3241,7 @@ func TestCompactFlushQueuedMemTableAndFlushMetrics(t *testing.T) {
 	// Verify that manual compaction forces a flush of a queued memtable.
 
 	mem := vfs.NewMem()
-	d, err := Open("", testingRandomized(&Options{
+	d, err := Open("", testingRandomized(t, &Options{
 		FS: mem,
 	}).WithFSDefaults())
 	require.NoError(t, err)
@@ -3302,7 +3302,7 @@ func TestCompactFlushQueuedLargeBatch(t *testing.T) {
 	// Verify that compaction forces a flush of a queued large batch.
 
 	mem := vfs.NewMem()
-	d, err := Open("", testingRandomized(&Options{
+	d, err := Open("", testingRandomized(t, &Options{
 		FS: mem,
 	}).WithFSDefaults())
 	require.NoError(t, err)
@@ -3336,7 +3336,7 @@ func TestCompactFlushQueuedLargeBatch(t *testing.T) {
 // that could previously lead to DB.disableFileDeletions blocking forever even
 // though no cleaning was in progress.
 func TestCleanerCond(t *testing.T) {
-	d, err := Open("", testingRandomized(&Options{
+	d, err := Open("", testingRandomized(t, &Options{
 		FS: vfs.NewMem(),
 	}).WithFSDefaults())
 	require.NoError(t, err)
@@ -3389,7 +3389,7 @@ func TestFlushError(t *testing.T) {
 		}
 		return nil
 	}))
-	d, err := Open("", testingRandomized(&Options{
+	d, err := Open("", testingRandomized(t, &Options{
 		FS: fs,
 		EventListener: &EventListener{
 			BackgroundError: func(err error) {
@@ -3443,7 +3443,7 @@ func TestAdjustGrandparentOverlapBytesForFlush(t *testing.T) {
 }
 
 func TestCompactionInvalidBounds(t *testing.T) {
-	db, err := Open("", testingRandomized(&Options{
+	db, err := Open("", testingRandomized(t, &Options{
 		FS: vfs.NewMem(),
 	}).WithFSDefaults())
 	require.NoError(t, err)
@@ -3882,7 +3882,7 @@ func TestCompaction_LogAndApplyFails(t *testing.T) {
 	runTest := func(t *testing.T, addFn func(db *DB) error, bgFn func(*DB, error)) {
 		var db *DB
 		inj := &createManifestErrorInjector{}
-		logger := &fatalCapturingLogger{}
+		logger := &fatalCapturingLogger{t: t}
 		opts := (&Options{
 			FS: errorfs.Wrap(vfs.NewMem(), inj),
 			// Rotate the manifest after each write. This is required to trigger a

--- a/db_test.go
+++ b/db_test.go
@@ -132,7 +132,7 @@ func TestBasicReads(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s: cloneFileSystem failed: %v", tc.dirname, err)
 			}
-			d, err := Open(tc.dirname, testingRandomized(&Options{
+			d, err := Open(tc.dirname, testingRandomized(t, &Options{
 				FS: fs,
 			}))
 			if err != nil {
@@ -159,7 +159,7 @@ func TestBasicReads(t *testing.T) {
 }
 
 func TestBasicWrites(t *testing.T) {
-	d, err := Open("", testingRandomized(&Options{
+	d, err := Open("", testingRandomized(t, &Options{
 		FS: vfs.NewMem(),
 	}))
 	require.NoError(t, err)
@@ -297,7 +297,7 @@ func TestBasicWrites(t *testing.T) {
 }
 
 func TestRandomWrites(t *testing.T) {
-	d, err := Open("", testingRandomized(&Options{
+	d, err := Open("", testingRandomized(t, &Options{
 		FS:           vfs.NewMem(),
 		MemTableSize: 8 * 1024,
 	}))
@@ -350,7 +350,7 @@ func TestRandomWrites(t *testing.T) {
 }
 
 func TestLargeBatch(t *testing.T) {
-	d, err := Open("", testingRandomized(&Options{
+	d, err := Open("", testingRandomized(t, &Options{
 		FS:                          vfs.NewMem(),
 		MemTableSize:                1400,
 		MemTableStopWritesThreshold: 100,
@@ -439,7 +439,7 @@ func TestGetNoCache(t *testing.T) {
 	cache := NewCache(0)
 	defer cache.Unref()
 
-	d, err := Open("", testingRandomized(&Options{
+	d, err := Open("", testingRandomized(t, &Options{
 		Cache: cache,
 		FS:    vfs.NewMem(),
 	}))
@@ -453,7 +453,7 @@ func TestGetNoCache(t *testing.T) {
 }
 
 func TestGetMerge(t *testing.T) {
-	d, err := Open("", testingRandomized(&Options{
+	d, err := Open("", testingRandomized(t, &Options{
 		FS: vfs.NewMem(),
 	}))
 	require.NoError(t, err)
@@ -486,7 +486,7 @@ func TestGetMerge(t *testing.T) {
 func TestMergeOrderSameAfterFlush(t *testing.T) {
 	// Ensure compaction iterator (used by flush) and user iterator process merge
 	// operands in the same order
-	d, err := Open("", testingRandomized(&Options{
+	d, err := Open("", testingRandomized(t, &Options{
 		FS: vfs.NewMem(),
 	}))
 	require.NoError(t, err)
@@ -546,7 +546,7 @@ func (m *closableMerger) Close() error {
 func TestMergerClosing(t *testing.T) {
 	m := &closableMerger{}
 
-	d, err := Open("", testingRandomized(&Options{
+	d, err := Open("", testingRandomized(t, &Options{
 		FS: vfs.NewMem(),
 		Merger: &Merger{
 			Merge: func(key, value []byte) (base.ValueMerger, error) {
@@ -574,7 +574,7 @@ func TestMergerClosing(t *testing.T) {
 }
 
 func TestLogData(t *testing.T) {
-	d, err := Open("", testingRandomized(&Options{
+	d, err := Open("", testingRandomized(t, &Options{
 		FS: vfs.NewMem(),
 	}))
 	require.NoError(t, err)
@@ -590,7 +590,7 @@ func TestLogData(t *testing.T) {
 }
 
 func TestSingleDeleteGet(t *testing.T) {
-	d, err := Open("", testingRandomized(&Options{
+	d, err := Open("", testingRandomized(t, &Options{
 		FS: vfs.NewMem(),
 	}))
 	require.NoError(t, err)
@@ -615,7 +615,7 @@ func TestSingleDeleteGet(t *testing.T) {
 }
 
 func TestSingleDeleteFlush(t *testing.T) {
-	d, err := Open("", testingRandomized(&Options{
+	d, err := Open("", testingRandomized(t, &Options{
 		FS: vfs.NewMem(),
 	}))
 	require.NoError(t, err)
@@ -648,7 +648,7 @@ func TestSingleDeleteFlush(t *testing.T) {
 }
 
 func TestUnremovableSingleDelete(t *testing.T) {
-	d, err := Open("", testingRandomized(&Options{
+	d, err := Open("", testingRandomized(t, &Options{
 		FS:                    vfs.NewMem(),
 		L0CompactionThreshold: 8,
 	}))
@@ -687,7 +687,7 @@ func TestIterLeak(t *testing.T) {
 		t.Run(fmt.Sprintf("leak=%t", leak), func(t *testing.T) {
 			for _, flush := range []bool{true, false} {
 				t.Run(fmt.Sprintf("flush=%t", flush), func(t *testing.T) {
-					d, err := Open("", testingRandomized(&Options{
+					d, err := Open("", testingRandomized(t, &Options{
 						FS: vfs.NewMem(),
 					}))
 					require.NoError(t, err)
@@ -796,7 +796,7 @@ func TestMemTableReservation(t *testing.T) {
 		MemTableSize: initialMemTableSize,
 		FS:           vfs.NewMem(),
 	}
-	opts.testingRandomized()
+	opts.testingRandomized(t)
 	opts.EnsureDefaults()
 	// We're going to be looking at and asserting the global memtable reservation
 	// amount below so we don't want to race with any triggered stats collections.
@@ -907,7 +907,7 @@ func TestCacheEvict(t *testing.T) {
 }
 
 func TestFlushEmpty(t *testing.T) {
-	d, err := Open("", testingRandomized(&Options{
+	d, err := Open("", testingRandomized(t, &Options{
 		FS: vfs.NewMem(),
 	}))
 	require.NoError(t, err)
@@ -927,7 +927,7 @@ func TestRollManifest(t *testing.T) {
 		NumPrevManifest:       int(toPreserve),
 	}
 	opts.DisableAutomaticCompactions = true
-	opts.testingRandomized()
+	opts.testingRandomized(t)
 	d, err := Open("", opts)
 	require.NoError(t, err)
 
@@ -1107,7 +1107,7 @@ func TestDBClosed(t *testing.T) {
 }
 
 func TestDBConcurrentCommitCompactFlush(t *testing.T) {
-	d, err := Open("", testingRandomized(&Options{
+	d, err := Open("", testingRandomized(t, &Options{
 		FS: vfs.NewMem(),
 	}))
 	require.NoError(t, err)
@@ -1149,7 +1149,7 @@ func TestDBConcurrentCompactClose(t *testing.T) {
 				return 2
 			},
 		}
-		d, err := Open("", testingRandomized(opts))
+		d, err := Open("", testingRandomized(t, opts))
 		require.NoError(t, err)
 
 		// Ingest a series of files containing a single key each. As the outer
@@ -1220,7 +1220,7 @@ func TestDBApplyBatchMismatch(t *testing.T) {
 func TestCloseCleanerRace(t *testing.T) {
 	mem := vfs.NewMem()
 	for i := 0; i < 20; i++ {
-		db, err := Open("", testingRandomized(&Options{FS: mem}))
+		db, err := Open("", testingRandomized(t, &Options{FS: mem}))
 		require.NoError(t, err)
 		require.NoError(t, db.Set([]byte("a"), []byte("something"), Sync))
 		require.NoError(t, db.Flush())

--- a/external_iterator_test.go
+++ b/external_iterator_test.go
@@ -148,7 +148,7 @@ func TestIterRandomizedMaybeFilteredKeys(t *testing.T) {
 	seed := *seed
 	if seed == 0 {
 		seed = uint64(time.Now().UnixNano())
-		fmt.Printf("seed: %d\n", seed)
+		t.Logf("seed: %d", seed)
 	}
 	rng := rand.New(rand.NewSource(seed))
 	numKeys := 100 + rng.Intn(5000)

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1878,12 +1878,13 @@ func TestIngestCleanup(t *testing.T) {
 
 // fatalCapturingLogger captures a fatal error instead of panicking.
 type fatalCapturingLogger struct {
+	t   testing.TB
 	err error
 }
 
 // Infof implements the Logger interface.
 func (l *fatalCapturingLogger) Infof(fmt string, args ...interface{}) {
-	base.DefaultLogger.Infof(fmt, args...)
+	l.t.Logf(fmt, args...)
 }
 
 // Fatalf implements the Logger interface.
@@ -1954,7 +1955,7 @@ func TestIngestValidation(t *testing.T) {
 			wg.Add(1)
 
 			fs := vfs.NewMem()
-			logger := &fatalCapturingLogger{}
+			logger := &fatalCapturingLogger{t: t}
 			opts := &Options{
 				FS:     fs,
 				Logger: logger,

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1391,7 +1391,7 @@ func TestIteratorRandomizedBlockIntervalFilter(t *testing.T) {
 	seed := *seed
 	if seed == 0 {
 		seed = uint64(time.Now().UnixNano())
-		fmt.Printf("seed: %d\n", seed)
+		t.Logf("seed: %d", seed)
 	}
 	rng := rand.New(rand.NewSource(seed))
 	opts.FlushSplitBytes = 1 << rng.Intn(8)            // 1B - 256B
@@ -1446,7 +1446,7 @@ func TestIteratorRandomizedBlockIntervalFilter(t *testing.T) {
 			delete(matchingKeyValues, key)
 		}
 	}
-	fmt.Printf("generated %d keys: %d matching, %d found\n", n, matchingCount, found)
+	t.Logf("generated %d keys: %d matching, %d found", n, matchingCount, found)
 	require.Equal(t, 0, len(matchingKeyValues))
 }
 
@@ -2321,7 +2321,7 @@ func TestRangeKeyMaskingRandomized(t *testing.T) {
 	seed := *seed
 	if seed == 0 {
 		seed = uint64(time.Now().UnixNano())
-		fmt.Printf("seed: %d\n", seed)
+		t.Logf("seed: %d", seed)
 	}
 	rng := rand.New(rand.NewSource(seed))
 

--- a/open_test.go
+++ b/open_test.go
@@ -39,7 +39,7 @@ func TestOpenSharedTableCache(t *testing.T) {
 	defer tc.Unref()
 	defer c.Unref()
 
-	d0, err := Open("", testingRandomized(&Options{
+	d0, err := Open("", testingRandomized(t, &Options{
 		FS:         vfs.NewMem(),
 		Cache:      c,
 		TableCache: tc,
@@ -49,7 +49,7 @@ func TestOpenSharedTableCache(t *testing.T) {
 	}
 	defer d0.Close()
 
-	d1, err := Open("", testingRandomized(&Options{
+	d1, err := Open("", testingRandomized(t, &Options{
 		FS:         vfs.NewMem(),
 		Cache:      c,
 		TableCache: tc,
@@ -68,7 +68,7 @@ func TestOpenSharedTableCache(t *testing.T) {
 }
 
 func TestErrorIfExists(t *testing.T) {
-	opts := testingRandomized(&Options{
+	opts := testingRandomized(t, &Options{
 		FS:            vfs.NewMem(),
 		ErrorIfExists: true,
 	})
@@ -89,7 +89,7 @@ func TestErrorIfExists(t *testing.T) {
 }
 
 func TestErrorIfNotExists(t *testing.T) {
-	opts := testingRandomized(&Options{
+	opts := testingRandomized(t, &Options{
 		FS:               vfs.NewMem(),
 		ErrorIfNotExists: true,
 	})
@@ -113,7 +113,7 @@ func TestErrorIfNotExists(t *testing.T) {
 }
 
 func TestErrorIfNotPristine(t *testing.T) {
-	opts := testingRandomized(&Options{
+	opts := testingRandomized(t, &Options{
 		FS:                 vfs.NewMem(),
 		ErrorIfNotPristine: true,
 	})
@@ -148,7 +148,7 @@ func TestErrorIfNotPristine(t *testing.T) {
 
 func TestOpenAlreadyLocked(t *testing.T) {
 	runTest := func(t *testing.T, dirname string, fs vfs.FS) {
-		opts := testingRandomized(&Options{FS: fs})
+		opts := testingRandomized(t, &Options{FS: fs})
 		var err error
 		opts.Lock, err = LockDirectory(dirname, fs)
 		require.NoError(t, err)
@@ -229,7 +229,7 @@ func TestNewDBFilenames(t *testing.T) {
 }
 
 func testOpenCloseOpenClose(t *testing.T, fs vfs.FS, root string) {
-	opts := testingRandomized(&Options{FS: fs})
+	opts := testingRandomized(t, &Options{FS: fs})
 
 	for _, startFromEmpty := range []bool{false, true} {
 		for _, walDirname := range []string{"", "wal"} {
@@ -421,7 +421,7 @@ func TestOpenReadOnly(t *testing.T) {
 		// Opening a non-existent DB in read-only mode should result in no mutable
 		// filesystem operations.
 		var memLog base.InMemLogger
-		_, err := Open("non-existent", testingRandomized(&Options{
+		_, err := Open("non-existent", testingRandomized(t, &Options{
 			FS:       vfs.WithLogging(mem, memLog.Infof),
 			ReadOnly: true,
 			WALDir:   "non-existent-waldir",
@@ -439,7 +439,7 @@ func TestOpenReadOnly(t *testing.T) {
 		// Opening a DB with a non-existent WAL dir in read-only mode should result
 		// in no mutable filesystem operations other than the LOCK.
 		var memLog base.InMemLogger
-		_, err := Open("", testingRandomized(&Options{
+		_, err := Open("", testingRandomized(t, &Options{
 			FS:       vfs.WithLogging(mem, memLog.Infof),
 			ReadOnly: true,
 			WALDir:   "non-existent-waldir",
@@ -456,7 +456,7 @@ func TestOpenReadOnly(t *testing.T) {
 	var contents []string
 	{
 		// Create a new DB and populate it with a small amount of data.
-		d, err := Open("", testingRandomized(&Options{
+		d, err := Open("", testingRandomized(t, &Options{
 			FS: mem,
 		}))
 		require.NoError(t, err)
@@ -469,7 +469,7 @@ func TestOpenReadOnly(t *testing.T) {
 
 	{
 		// Re-open the DB read-only. The directory contents should be unchanged.
-		d, err := Open("", testingRandomized(&Options{
+		d, err := Open("", testingRandomized(t, &Options{
 			FS:       mem,
 			ReadOnly: true,
 		}))
@@ -555,7 +555,7 @@ func TestOpenWALReplay(t *testing.T) {
 			// Create a new DB and populate it with some data.
 			const dir = ""
 			mem := vfs.NewMem()
-			d, err := Open(dir, testingRandomized(&Options{
+			d, err := Open(dir, testingRandomized(t, &Options{
 				FS:           mem,
 				MemTableSize: 32 << 20,
 			}))
@@ -590,7 +590,7 @@ func TestOpenWALReplay(t *testing.T) {
 			// value for 3 will go in the next memtable; value for 4 will be in a flushable batch
 			// which will cause the previous memtable to be flushed; value for 5 will go in the next
 			// memtable
-			d, err = Open(dir, testingRandomized(&Options{
+			d, err = Open(dir, testingRandomized(t, &Options{
 				FS:           mem,
 				MemTableSize: 300 << 10,
 				ReadOnly:     readOnly,
@@ -613,7 +613,7 @@ func TestOpenWALReplay(t *testing.T) {
 // Reproduction for https://github.com/cockroachdb/pebble/issues/2234.
 func TestWALReplaySequenceNumBug(t *testing.T) {
 	mem := vfs.NewMem()
-	d, err := Open("", testingRandomized(&Options{
+	d, err := Open("", testingRandomized(t, &Options{
 		FS: mem,
 	}))
 	require.NoError(t, err)
@@ -677,7 +677,7 @@ func TestOpenWALReplay2(t *testing.T) {
 			for _, reason := range []string{"forced", "size", "large-batch"} {
 				t.Run(reason, func(t *testing.T) {
 					mem := vfs.NewMem()
-					d, err := Open("", testingRandomized(&Options{
+					d, err := Open("", testingRandomized(t, &Options{
 						FS:           mem,
 						MemTableSize: 256 << 10,
 					}))
@@ -716,7 +716,7 @@ func TestOpenWALReplay2(t *testing.T) {
 					// value for 3 will go in the next memtable; value for 4 will be in a flushable batch
 					// which will cause the previous memtable to be flushed; value for 5 will go in the next
 					// memtable
-					d, err = Open("", testingRandomized(&Options{
+					d, err = Open("", testingRandomized(t, &Options{
 						FS:           mem,
 						MemTableSize: 300 << 10,
 						ReadOnly:     readOnly,
@@ -740,7 +740,7 @@ func TestTwoWALReplayCorrupt(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	d, err := Open(dir, testingRandomized(&Options{
+	d, err := Open(dir, testingRandomized(t, &Options{
 		MemTableStopWritesThreshold: 4,
 		MemTableSize:                2048,
 	}))
@@ -800,7 +800,7 @@ func TestTwoWALReplayPermissive(t *testing.T) {
 		MemTableStopWritesThreshold: 4,
 		MemTableSize:                2048,
 	}
-	opts.testingRandomized()
+	opts.testingRandomized(t)
 	opts.EnsureDefaults()
 	d, err := Open(dir, opts)
 	require.NoError(t, err)
@@ -875,7 +875,7 @@ func TestCrashOpenCrashAfterWALCreation(t *testing.T) {
 	}
 
 	{
-		d, err := Open("", testingRandomized(&Options{FS: fs}))
+		d, err := Open("", testingRandomized(t, &Options{FS: fs}))
 		require.NoError(t, err)
 		require.NoError(t, d.Set([]byte("abc"), nil, Sync))
 
@@ -952,7 +952,7 @@ func TestCrashOpenCrashAfterWALCreation(t *testing.T) {
 	}
 
 	// Finally, open the database with syncs enabled.
-	d, err := Open("", testingRandomized(&Options{FS: fs}))
+	d, err := Open("", testingRandomized(t, &Options{FS: fs}))
 	require.NoError(t, err)
 	require.NoError(t, d.Close())
 }
@@ -978,7 +978,7 @@ func TestOpenWALReplayReadOnlySeqNums(t *testing.T) {
 
 	// Create a new database under `/original` with a couple sstables.
 	dir := mem.PathJoin(root, "original")
-	d, err := Open(dir, testingRandomized(&Options{FS: mem}))
+	d, err := Open(dir, testingRandomized(t, &Options{FS: mem}))
 	require.NoError(t, err)
 	require.NoError(t, d.Set([]byte("a"), nil, nil))
 	require.NoError(t, d.Flush())
@@ -1023,7 +1023,7 @@ func TestOpenWALReplayReadOnlySeqNums(t *testing.T) {
 	// multiple unflushed log files that need to replay. Since the manual
 	// compaction completed, the `logSeqNum` read from the manifest should be
 	// greater than the unflushed log files' sequence numbers.
-	d, err = Open(replayDir, testingRandomized(&Options{
+	d, err = Open(replayDir, testingRandomized(t, &Options{
 		FS:       mem,
 		ReadOnly: true,
 	}))
@@ -1038,7 +1038,7 @@ func TestOpenWALReplayMemtableGrowth(t *testing.T) {
 		MemTableSize: memTableSize,
 		FS:           mem,
 	}
-	opts.testingRandomized()
+	opts.testingRandomized(t)
 	func() {
 		db, err := Open("", opts)
 		require.NoError(t, err)
@@ -1060,7 +1060,7 @@ func TestGetVersion(t *testing.T) {
 	opts := &Options{
 		FS: mem,
 	}
-	opts.testingRandomized()
+	opts.testingRandomized(t)
 
 	// Case 1: No options file.
 	version, err := GetVersion("", mem)

--- a/options_test.go
+++ b/options_test.go
@@ -19,20 +19,24 @@ import (
 
 // testingRandomized randomizes some default options. Currently, it's
 // used for testing under a random format major version in some tests.
-func (o *Options) testingRandomized() *Options {
+func (o *Options) testingRandomized(t testing.TB) *Options {
 	if o == nil {
 		o = &Options{}
+	}
+	if o.Logger == nil {
+		o.Logger = testLogger{t: t}
 	}
 	if o.FormatMajorVersion == FormatDefault {
 		// Pick a random format major version from the range
 		// [MostCompatible, FormatNewest].
 		o.FormatMajorVersion = FormatMajorVersion(rand.Intn(int(internalFormatNewest)) + 1)
+		t.Logf("Running %s with format major version %s", t.Name(), o.FormatMajorVersion.String())
 	}
 	return o
 }
 
-func testingRandomized(o *Options) *Options {
-	o.testingRandomized()
+func testingRandomized(t testing.TB, o *Options) *Options {
+	o.testingRandomized(t)
 	return o
 }
 

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -39,6 +39,7 @@ func TestScanInternal(t *testing.T) {
 	parseOpts := func(td *datadriven.TestData) (*Options, error) {
 		opts := &Options{
 			FS:                 vfs.NewMem(),
+			Logger:             testLogger{t: t},
 			Comparer:           testkeys.Comparer,
 			FormatMajorVersion: FormatRangeKeys,
 			BlockPropertyCollectors: []func() BlockPropertyCollector{


### PR DESCRIPTION
This removes the remaining output written to stdout from the main `pebble` package's unit tests. Running `go test` now prints just the output:

```
PASS
ok  	github.com/cockroachdb/pebble	11.011s
```