### PR TITLE
db: annotate table number when tables cannot be loaded

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1457,6 +1457,8 @@ func (c *compaction) newInputIter(
 		for f := iter.First(); f != nil; f = iter.Next() {
 			rangeDelIter, err := newRangeDelIter(iter.Take(), nil, &c.bytesIterated)
 			if err != nil {
+				// The error will already be annotated with the BackingFileNum, so
+				// we annotate it with the FileNum.
 				return errors.Wrapf(err, "pebble: could not open table %s", errors.Safe(f.FileNum))
 			}
 			if rangeDelIter != emptyKeyspanIter {


### PR DESCRIPTION
We recently saw a corruption error in a customer issue: https://github.com/cockroachlabs/support/issues/2340.

We couldn't figure out the sstable which was corrupted because the `bad magic number` error encountered by an sstable reader is currently only annotated with the sstable number for compaction reads.

This pr wraps all errors when we try to create a reader on an sstable with an error message which includes the sstable number.