### PR TITLE
crl-release-22.2: tool: capture stdout / stderr

### DIFF
--- a/tool/data_test.go
+++ b/tool/data_test.go
@@ -69,15 +69,10 @@ func runTests(t *testing.T, path string) {
 				}
 
 				var buf bytes.Buffer
-				stdout = &buf
-				stderr = &buf
-
 				var secs int64
 				timeNow = func() time.Time { secs++; return time.Unix(secs, 0) }
 
 				defer func() {
-					stdout = os.Stdout
-					stderr = os.Stderr
 					timeNow = time.Now
 				}()
 
@@ -121,7 +116,8 @@ func runTests(t *testing.T, path string) {
 				c := &cobra.Command{}
 				c.AddCommand(tool.Commands...)
 				c.SetArgs(args)
-				c.SetOutput(&buf)
+				c.SetOut(&buf)
+				c.SetErr(&buf)
 				if err := c.Execute(); err != nil {
 					return err.Error()
 				}

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -7,6 +7,7 @@ package tool
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -151,7 +152,8 @@ func (s *sstableT) newReader(f vfs.File) (*sstable.Reader, error) {
 }
 
 func (s *sstableT) runCheck(cmd *cobra.Command, args []string) {
-	s.foreachSstable(args, func(arg string) {
+	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
+	s.foreachSstable(stderr, args, func(arg string) {
 		f, err := s.opts.FS.Open(arg)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s\n", err)
@@ -227,7 +229,8 @@ func (s *sstableT) runCheck(cmd *cobra.Command, args []string) {
 }
 
 func (s *sstableT) runLayout(cmd *cobra.Command, args []string) {
-	s.foreachSstable(args, func(arg string) {
+	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
+	s.foreachSstable(stderr, args, func(arg string) {
 		f, err := s.opts.FS.Open(arg)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s\n", err)
@@ -263,7 +266,8 @@ func (s *sstableT) runLayout(cmd *cobra.Command, args []string) {
 }
 
 func (s *sstableT) runProperties(cmd *cobra.Command, args []string) {
-	s.foreachSstable(args, func(arg string) {
+	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
+	s.foreachSstable(stderr, args, func(arg string) {
 		f, err := s.opts.FS.Open(arg)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s\n", err)
@@ -355,7 +359,8 @@ func (s *sstableT) runProperties(cmd *cobra.Command, args []string) {
 }
 
 func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
-	s.foreachSstable(args, func(arg string) {
+	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
+	s.foreachSstable(stderr, args, func(arg string) {
 		f, err := s.opts.FS.Open(arg)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s\n", err)
@@ -512,7 +517,8 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 }
 
 func (s *sstableT) runSpace(cmd *cobra.Command, args []string) {
-	s.foreachSstable(args, func(arg string) {
+	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
+	s.foreachSstable(stderr, args, func(arg string) {
 		f, err := s.opts.FS.Open(arg)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s\n", err)
@@ -534,7 +540,7 @@ func (s *sstableT) runSpace(cmd *cobra.Command, args []string) {
 	})
 }
 
-func (s *sstableT) foreachSstable(args []string, fn func(arg string)) {
+func (s *sstableT) foreachSstable(stderr io.Writer, args []string, fn func(arg string)) {
 	// Loop over args, invoking fn for each file. Each directory is recursively
 	// listed and fn is invoked on any file with an .sst or .ldb suffix.
 	for _, arg := range args {
@@ -543,7 +549,7 @@ func (s *sstableT) foreachSstable(args []string, fn func(arg string)) {
 			fn(arg)
 			continue
 		}
-		walk(s.opts.FS, arg, func(path string) {
+		walk(stderr, s.opts.FS, arg, func(path string) {
 			switch filepath.Ext(path) {
 			case ".sst", ".ldb":
 				fn(path)

--- a/tool/util.go
+++ b/tool/util.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -20,8 +19,6 @@ import (
 	"github.com/cockroachdb/pebble/vfs"
 )
 
-var stdout = io.Writer(os.Stdout)
-var stderr = io.Writer(os.Stderr)
 var timeNow = time.Now
 
 type key []byte
@@ -305,7 +302,7 @@ func formatSpan(w io.Writer, fmtKey keyFormatter, fmtValue valueFormatter, s *ke
 	}
 }
 
-func walk(fs vfs.FS, dir string, fn func(path string)) {
+func walk(stderr io.Writer, fs vfs.FS, dir string, fn func(path string)) {
 	paths, err := fs.List(dir)
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", dir, err)
@@ -320,7 +317,7 @@ func walk(fs vfs.FS, dir string, fn func(path string)) {
 			continue
 		}
 		if info.IsDir() {
-			walk(fs, path, fn)
+			walk(stderr, fs, path, fn)
 		} else {
 			fn(path)
 		}

--- a/tool/wal.go
+++ b/tool/wal.go
@@ -65,6 +65,7 @@ Print the contents of the WAL files.
 }
 
 func (w *walT) runDump(cmd *cobra.Command, args []string) {
+	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
 	w.fmtKey.setForComparer(w.defaultComparer, w.comparers)
 	w.fmtValue.setForComparer(w.defaultComparer, w.comparers)
 


### PR DESCRIPTION
This is a backport of #1998 for 22.2.

---

Currently, the tools write directly to `os.{Stdout,Stderr}`, which complicates testing in the case where the command is run from same process running the tests (i.e. from a `testing.T` func).

Adapt the tools to make use of the return values from `(*cobra.Command).{OutOrStdout,OutOrStderr}`. In testing scenarios, the tools can use `SetOut` and `SetErr` to pass in a writer that can intercept anything written to stdout / stderr. In productions scenarios, the tools will emit to the appropriate channel.

Touches cockroachdb/cockroach#89095.