### PR TITLE
db: add ingest-time splitting of ssts into virtual ones

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -1356,8 +1356,9 @@ func runForceIngestCmd(td *datadriven.TestData, d *DB) error {
 		int,
 		map[*compaction]struct{},
 		*fileMetadata,
-	) (int, error) {
-		return level, nil
+		bool,
+	) (int, *fileMetadata, error) {
+		return level, nil, nil
 	}, nil /* shared */, KeyRange{}, nil /* external */)
 	return err
 }

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1956,16 +1956,28 @@ func TestIngestTargetLevel(t *testing.T) {
 
 		case "target":
 			var buf bytes.Buffer
+			suggestSplit := false
+			for _, cmd := range td.CmdArgs {
+				switch cmd.Key {
+				case "suggest-split":
+					suggestSplit = true
+				}
+			}
 			for _, target := range strings.Split(td.Input, "\n") {
 				meta := parseMeta(target)
-				level, err := ingestTargetLevel(
+				level, overlapFile, err := ingestTargetLevel(
 					d.newIters, d.tableNewRangeKeyIter, IterOptions{logger: d.opts.Logger},
 					d.cmp, d.mu.versions.currentVersion(), 1, d.mu.compact.inProgress, meta,
+					suggestSplit,
 				)
 				if err != nil {
 					return err.Error()
 				}
-				fmt.Fprintf(&buf, "%d\n", level)
+				if overlapFile != nil {
+					fmt.Fprintf(&buf, "%d (split file: %s)\n", level, overlapFile.FileNum)
+				} else {
+					fmt.Fprintf(&buf, "%d\n", level)
+				}
 			}
 			return buf.String()
 
@@ -1983,7 +1995,7 @@ func TestIngest(t *testing.T) {
 		require.NoError(t, d.Close())
 	}()
 
-	reset := func() {
+	reset := func(split bool) {
 		if d != nil {
 			require.NoError(t, d.Close())
 		}
@@ -2000,6 +2012,9 @@ func TestIngest(t *testing.T) {
 			}},
 			FormatMajorVersion: internalFormatNewest,
 		}
+		opts.Experimental.IngestSplit = func() bool {
+			return split
+		}
 		// Disable automatic compactions because otherwise we'll race with
 		// delete-only compactions triggered by ingesting range tombstones.
 		opts.DisableAutomaticCompactions = true
@@ -2008,12 +2023,21 @@ func TestIngest(t *testing.T) {
 		d, err = Open("", opts)
 		require.NoError(t, err)
 	}
-	reset()
+	reset(false /* split */)
 
 	datadriven.RunTest(t, "testdata/ingest", func(t *testing.T, td *datadriven.TestData) string {
 		switch td.Cmd {
 		case "reset":
-			reset()
+			split := false
+			for _, cmd := range td.CmdArgs {
+				switch cmd.Key {
+				case "enable-split":
+					split = true
+				default:
+					return fmt.Sprintf("unexpected key: %s", cmd.Key)
+				}
+			}
+			reset(split)
 			return ""
 		case "batch":
 			b := d.NewIndexedBatch()

--- a/options.go
+++ b/options.go
@@ -550,6 +550,11 @@ type Options struct {
 		// concurrency slots as determined by the two options is chosen.
 		CompactionDebtConcurrency uint64
 
+		// IngestSplit, if it returns true, allows for ingest-time splitting of
+		// existing sstables into two virtual sstables to allow ingestion sstables to
+		// slot into a lower level than they otherwise would have.
+		IngestSplit func() bool
+
 		// ReadCompactionRate controls the frequency of read triggered
 		// compactions by adjusting `AllowedSeeks` in manifest.FileMetadata:
 		//

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -907,3 +907,272 @@ lsm
   000006:[f#12,SET-h#12,SET]
   000010:[s#16,RANGEKEYDEL-x#inf,RANGEKEYDEL]
   000009:[x#15,SET-y#15,SET]
+
+reset enable-split
+----
+
+build ext10
+set a foo
+set e bar
+----
+
+ingest ext10
+----
+
+lsm
+----
+6:
+  000004:[a#10,SET-e#10,SET]
+
+# The below ingestion should split one existing file.
+
+build ext11
+set b foobar
+set d foobar
+----
+
+ingest ext11
+----
+
+lsm
+----
+6:
+  000006:[a#10,SET-a#10,SET]
+  000005:[b#11,SET-d#11,SET]
+  000007:[e#10,SET-e#10,SET]
+
+iter
+first
+next
+next
+next
+----
+a: (foo, .)
+b: (foobar, .)
+d: (foobar, .)
+e: (bar, .)
+
+# This ingestion should not split any files due to data overlap.
+
+build ext12
+set c foobar
+set e baz
+----
+
+ingest ext12
+----
+
+lsm
+----
+0.0:
+  000008:[c#12,SET-e#12,SET]
+6:
+  000006:[a#10,SET-a#10,SET]
+  000005:[b#11,SET-d#11,SET]
+  000007:[e#10,SET-e#10,SET]
+
+# The below ingestion should fall through one existing file and split another
+# file.
+
+build ext13
+set cc foo
+set ccc foooo
+----
+
+ingest ext13
+----
+
+lsm
+----
+0.0:
+  000008:[c#12,SET-e#12,SET]
+6:
+  000006:[a#10,SET-a#10,SET]
+  000010:[b#11,SET-b#11,SET]
+  000009:[cc#13,SET-ccc#13,SET]
+  000011:[d#11,SET-d#11,SET]
+  000007:[e#10,SET-e#10,SET]
+
+iter
+seek-ge c
+next
+next
+next
+next
+----
+c: (foobar, .)
+cc: (foo, .)
+ccc: (foooo, .)
+d: (foobar, .)
+e: (baz, .)
+
+# Ingestion splitting doesn't kick in at L0.
+
+build ext14
+set d updated
+set dd new
+----
+
+ingest ext14
+----
+
+lsm
+----
+0.1:
+  000012:[d#14,SET-dd#14,SET]
+0.0:
+  000008:[c#12,SET-e#12,SET]
+6:
+  000006:[a#10,SET-a#10,SET]
+  000010:[b#11,SET-b#11,SET]
+  000009:[cc#13,SET-ccc#13,SET]
+  000011:[d#11,SET-d#11,SET]
+  000007:[e#10,SET-e#10,SET]
+
+iter
+seek-lt d
+next
+next
+next
+next
+----
+ccc: (foooo, .)
+d: (updated, .)
+dd: (new, .)
+e: (baz, .)
+.
+
+# Multi-sstable ingestion batches. This exercises logic to find the appropriate
+# file to split for each newly ingested file, as we will be repeatedly splitting
+# files into smaller virtual files.
+
+reset enable-split
+----
+
+build ext10
+set a foo
+set e bar
+set g baz
+----
+
+ingest ext10
+----
+
+lsm
+----
+6:
+  000004:[a#10,SET-g#10,SET]
+
+build ext11
+set b foobar
+set c foobar
+----
+
+build ext12
+set cc foobar
+set d foobar
+----
+
+# This ingestion should slide in the same gap between keys in ext10.
+
+ingest ext11 ext12
+----
+
+lsm
+----
+6:
+  000007:[a#10,SET-a#10,SET]
+  000005:[b#11,SET-c#11,SET]
+  000006:[cc#12,SET-d#12,SET]
+  000008:[e#10,SET-g#10,SET]
+
+# A virtual sstable produced from an ingest split can be ingest split again.
+
+build ext13
+set ee foooo
+set f bar
+----
+
+ingest ext13
+----
+
+lsm
+----
+6:
+  000007:[a#10,SET-a#10,SET]
+  000005:[b#11,SET-c#11,SET]
+  000006:[cc#12,SET-d#12,SET]
+  000010:[e#10,SET-e#10,SET]
+  000009:[ee#13,SET-f#13,SET]
+  000011:[g#10,SET-g#10,SET]
+
+reset enable-split
+----
+
+build ext10
+set a foo
+set e bar
+set g baz
+----
+
+ingest ext10
+----
+
+lsm
+----
+6:
+  000004:[a#10,SET-g#10,SET]
+
+build ext11
+set b foobar
+set c foobar
+----
+
+build ext12
+set cc foobar
+set d foobar
+----
+
+build ext13
+set ee foooo
+set f bar
+----
+
+# This ingestion should split ext10 twice, and land two files on one side
+# of a key in it, and another file on another side of it.
+
+ingest ext11 ext12 ext13
+----
+
+lsm
+----
+6:
+  000008:[a#10,SET-a#10,SET]
+  000005:[b#11,SET-c#11,SET]
+  000006:[cc#12,SET-d#12,SET]
+  000010:[e#10,SET-e#10,SET]
+  000007:[ee#13,SET-f#13,SET]
+  000011:[g#10,SET-g#10,SET]
+
+iter
+first
+next
+next
+next
+next
+next
+next
+next
+next
+next
+----
+a: (foo, .)
+b: (foobar, .)
+c: (foobar, .)
+cc: (foobar, .)
+d: (foobar, .)
+e: (bar, .)
+ee: (foooo, .)
+f: (bar, .)
+g: (baz, .)
+.

--- a/testdata/ingest_target_level
+++ b/testdata/ingest_target_level
@@ -246,3 +246,79 @@ target
 rkey:a-c
 ----
 4
+
+# Cases with boundary overlap and no data overlap. With suggest-split off
+# we get a target level of L0, but with suggest-split on, we get suggested
+# a file split.
+
+define
+L6
+  a.SET.2:2
+  d.SET.3:3
+L6
+  f.SET.4:4
+  k.SET.6:6
+----
+6:
+  000004:[a#2,SET-d#3,SET]
+  000005:[f#4,SET-k#6,SET]
+
+target
+b-c
+e-g
+----
+5
+5
+
+target suggest-split
+b-c
+e-g
+----
+6 (split file: 000004)
+5
+
+target suggest-split
+g-i
+----
+6 (split file: 000005)
+
+# suggest-split recognizes and avoids in-progress compactions.
+
+define
+L6
+  a.SET.2:2
+  d.SET.3:3
+L6
+  f.SET.4:4
+  k.SET.6:6
+  compact:f-k
+----
+6:
+  000004:[a#2,SET-d#3,SET]
+  000005:[f#4,SET-k#6,SET]
+
+target suggest-split
+g-i
+----
+5
+
+# Ingestion splitting correctly recognizes data overlap in L6, and suggests
+# split in L5.
+
+define
+L5
+  a.SET.2:2
+  e.SET.3:3
+L6
+  c.SET.1:1
+  k.SET.1:1
+----
+5:
+  000004:[a#2,SET-e#3,SET]
+6:
+  000005:[c#1,SET-k#1,SET]
+
+target suggest-split
+b-c
+----
+5 (split file: 000004)


### PR DESCRIPTION
Currently, if we identify boundary overlap in a level
during ingest target level calculation, but no data overlap,
we are forced to find a target level above the file we saw
the overlap with (if we can't fall below it, such as if the
existing file is in L6, which happens commonly).

This change takes advantage of virtual sstables to split
existing sstables into two virtual sstables when an ingested
sstable would be able to go into the same level had the sstables
been split that way to begin with. Doing this split reduces a
lot of write-amp as it avoids us from having to compact the
newly-ingested sstable with the sstable it boundary-overlapped with.

Biggest part of https://github.com/cockroachdb/pebble/issues/1683. First commit is https://github.com/cockroachdb/pebble/pull/2538, which this shares
a lot of logic with (mostly just the excise function).