### PR TITLE
objstorageprovider: use cache in ReadAt

### DIFF
--- a/objstorage/objstorageprovider/shared.go
+++ b/objstorage/objstorageprovider/shared.go
@@ -240,7 +240,7 @@ func (p *provider) sharedOpenForReading(
 		}
 		return nil, err
 	}
-	return newSharedReadable(reader, size), nil
+	return p.newSharedReadable(reader, size, meta.DiskFileNum), nil
 }
 
 func (p *provider) sharedSize(meta objstorage.ObjectMetadata) (int64, error) {

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/compaction_reads
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/compaction_reads
@@ -1,0 +1,22 @@
+write 200000
+----
+
+read 10000 1024
+----
+misses=1
+
+# This should be in the cache.
+read-for-compaction 2000 4096
+----
+misses=0
+
+# This should miss the cache.
+read-for-compaction 100000 4096
+----
+misses=1
+
+# This should miss the cache again - we don't populate the cache when doing
+# compaction reads.
+read-for-compaction 100000 4096
+----
+misses=1

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/read_larger_than_two_cache_shards
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/read_larger_than_two_cache_shards
@@ -9,4 +9,4 @@ misses=1
 
 read 3145671 57
 ----
-misses=1
+misses=0

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_blocks
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_blocks
@@ -9,8 +9,8 @@ misses=1
 
 read 32773 0
 ----
-misses=1
+misses=0
 
 read 32716 57
 ----
-misses=1
+misses=0

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_blocks_with_first_read_at_big_offset
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_blocks_with_first_read_at_big_offset
@@ -9,4 +9,4 @@ misses=1
 
 read 5 32768
 ----
-misses=1
+misses=0

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_blocks_with_first_read_at_offset
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_blocks_with_first_read_at_offset
@@ -9,4 +9,4 @@ misses=1
 
 read 32716 57
 ----
-misses=1
+misses=0

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_shards
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_shards
@@ -9,8 +9,8 @@ misses=1
 
 read 1048776 0
 ----
-misses=1
+misses=0
 
 read 1048719 57
 ----
-misses=1
+misses=0

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_shards_with_first_read_at_offset
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_shards_with_first_read_at_offset
@@ -9,4 +9,4 @@ misses=1
 
 read 1048719 57
 ----
-misses=1
+misses=0

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/small_read
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/small_read
@@ -9,8 +9,8 @@ misses=1
 
 read 10 0
 ----
-misses=1
+misses=0
 
 read 6 4
 ----
-misses=1
+misses=0

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/small_read_with_first_read_at_offset
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/small_read_with_first_read_at_offset
@@ -9,8 +9,8 @@ misses=1
 
 read 6 4
 ----
-misses=1
+misses=0
 
 read 10 0
 ----
-misses=1
+misses=0


### PR DESCRIPTION
This commit adds code to optionally use the shared cache when reading from an object.

When the read is for a compaction, we don't want to populate the cache (but we do want to read from it if the data is already there).