### PR TITLE
sharedcache: move to fine-grained locking

### DIFF
--- a/objstorage/objstorageprovider/shared.go
+++ b/objstorage/objstorageprovider/shared.go
@@ -80,7 +80,7 @@ func (p *provider) sharedInit() error {
 			numShards = 2 * runtime.GOMAXPROCS(0)
 		}
 
-		p.shared.cache, err = sharedcache.Open(p.st.FS, p.st.FSDirName, blockSize, p.st.Shared.CacheSizeBytes, numShards)
+		p.shared.cache, err = sharedcache.Open(p.st.FS, p.st.Logger, p.st.FSDirName, blockSize, p.st.Shared.CacheSizeBytes, numShards)
 		if err != nil {
 			return errors.Wrapf(err, "pebble: could not open shared object cache")
 		}

--- a/objstorage/objstorageprovider/sharedcache/shared_cache.go
+++ b/objstorage/objstorageprovider/sharedcache/shared_cache.go
@@ -39,13 +39,14 @@ type Cache struct {
 
 // Open opens a cache. If there is no existing cache at fsDir, a new one
 // is created.
-func Open(fs vfs.FS, fsDir string, blockSize int, sizeBytes int64, numShards int) (*Cache, error) {
+func Open(fs vfs.FS, logger base.Logger, fsDir string, blockSize int, sizeBytes int64, numShards int) (*Cache, error) {
 	min := ShardingBlockSize * int64(numShards)
 	if sizeBytes < min {
 		return nil, errors.Errorf("cache size %d lower than min %d", sizeBytes, min)
 	}
 
 	sc := &Cache{
+		logger: logger,
 		blockSize: blockSize,
 	}
 	sc.shards = make([]shard, numShards)
@@ -295,6 +296,7 @@ func (s *shard) get(fileNum base.DiskFileNum, p []byte, ofs int64) (n int, _ err
 		if ofs/ShardingBlockSize != (ofs+int64(len(p))-1)/ShardingBlockSize {
 			panic(fmt.Sprintf("get crosses shard boundary: %v %v", ofs, len(p)))
 		}
+		s.assertShardStateIsConsistent()
 	}
 
 	// TODO(josh): Make the locking more fine-grained. Do not hold locks during calls
@@ -351,6 +353,7 @@ func (s *shard) set(fileNum base.DiskFileNum, p []byte, ofs int64) error {
 		if ofs%int64(s.blockSize) != 0 || len(p)%s.blockSize != 0 {
 			panic(fmt.Sprintf("set with ofs & len not multiples of block size: %v %v", ofs, len(p)))
 		}
+		s.assertShardStateIsConsistent()
 	}
 
 	// TODO(josh): Make the locking more fine-grained. Do not hold locks during calls
@@ -363,6 +366,25 @@ func (s *shard) set(fileNum base.DiskFileNum, p []byte, ofs int64) error {
 	// in units of sstable block size.
 	n := 0
 	for {
+		if n == len(p) {
+			return nil
+		}
+		if invariants.Enabled {
+			if n > len(p) {
+				panic(fmt.Sprintf("set with n greater than len(p): %v %v", n, len(p)))
+			}
+		}
+
+		// If the logical block is already in the cache, we should skip doing a set.
+		k := metadataKey{
+			filenum:    fileNum,
+			blockIndex: (ofs + int64(n)) / int64(s.blockSize),
+		}
+		if _, ok := s.mu.where[k]; ok {
+			n += s.blockSize
+			continue
+		}
+
 		var cacheBlockInd int64
 		if len(s.mu.free) == 0 {
 			// TODO(josh): Right now, we do random eviction. Eventually, we will do something
@@ -385,14 +407,12 @@ func (s *shard) set(fileNum base.DiskFileNum, p []byte, ofs int64) error {
 		}] = cacheBlockInd
 
 		writeAt := cacheBlockInd * int64(s.blockSize)
-		writeSize := s.blockSize
 
+		writeSize := s.blockSize
 		if len(p[n:]) <= writeSize {
-			// Ignore num written ret value, since if partial write, an error
-			// is returned.
-			_, err := s.file.WriteAt(p[n:], writeAt)
-			return err
+			writeSize = len(p[n:])
 		}
+
 		numWritten, err := s.file.WriteAt(p[n:n+writeSize], writeAt)
 		if err != nil {
 			return err
@@ -400,5 +420,29 @@ func (s *shard) set(fileNum base.DiskFileNum, p []byte, ofs int64) error {
 
 		// Note that numWritten == writeSize, since we checked for an error above.
 		n += numWritten
+	}
+}
+
+func (s *shard) assertShardStateIsConsistent() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cacheBlockInds := make(map[int64]bool)
+	for _, v := range s.mu.where {
+		if cacheBlockInds[v] {
+			panic(fmt.Sprintf("repeated cache block index: %v %v %v %v", v, cacheBlockInds, s.mu.where, s.mu.free))
+		}
+		cacheBlockInds[v] = true
+	}
+	for _, v := range s.mu.free {
+		if cacheBlockInds[v] {
+			panic(fmt.Sprintf("repeated cache block index: %v %v %v %v", v, cacheBlockInds, s.mu.where, s.mu.free))
+		}
+		cacheBlockInds[v] = true
+	}
+	for i := int64(0); i < s.sizeInBlocks; i++ {
+		if !cacheBlockInds[i] {
+			panic(fmt.Sprintf("missing cache block index: %v %v %v %v", i, cacheBlockInds, s.mu.where, s.mu.free))
+		}
 	}
 }

--- a/objstorage/objstorageprovider/sharedcache/shared_cache_helpers_test.go
+++ b/objstorage/objstorageprovider/sharedcache/shared_cache_helpers_test.go
@@ -1,0 +1,13 @@
+package sharedcache
+
+func ShardingBlockSize() int {
+	return shardingBlockSize
+}
+
+func (c *Cache) Misses() int32 {
+	return c.misses.Load()
+}
+
+func (c *Cache) WaitForWritesToComplete() {
+	c.writeBackWaitGroup.Wait()
+}

--- a/objstorage/objstorageprovider/sharedcache/shared_cache_test.go
+++ b/objstorage/objstorageprovider/sharedcache/shared_cache_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,7 +30,7 @@ func TestSharedCache(t *testing.T) {
 			log.Infof("<local fs> "+fmt, args...)
 		})
 
-		cache, err := sharedcache.Open(fs, "", 32*1024, size, 32)
+		cache, err := sharedcache.Open(fs, base.DefaultLogger, "", 32*1024, size, 32)
 		require.NoError(t, err)
 		defer cache.Close()
 
@@ -123,12 +124,14 @@ func TestSharedCacheRandomized(t *testing.T) {
 	fmt.Printf("seed: %v\n", seed)
 	rand.Seed(seed)
 
-	helper := func(blockSize int) func(t *testing.T) {
+	helper := func(
+		blockSize int,
+		concurrentReads bool) func(t *testing.T) {
 		return func(t *testing.T) {
 			numShards := rand.Intn(64) + 1
 			cacheSize := int64(sharedcache.ShardingBlockSize * numShards) // minimum allowed cache size
 
-			cache, err := sharedcache.Open(fs, "", blockSize, cacheSize, numShards)
+			cache, err := sharedcache.Open(fs, base.DefaultLogger, "", blockSize, cacheSize, numShards)
 			require.NoError(t, err)
 			defer cache.Close()
 
@@ -153,21 +156,36 @@ func TestSharedCacheRandomized(t *testing.T) {
 			defer readable.Close()
 
 			const numDistinctReads = 100
+			wg := sync.WaitGroup{}
 			for i := 0; i < numDistinctReads; i++ {
-				offset := rand.Int63n(size)
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					offset := rand.Int63n(size)
 
-				got := make([]byte, size-offset)
-				err = cache.ReadAt(ctx, base.FileNum(1).DiskFileNum(), got, offset, readable, sharedcache.ReadFlags{})
-				require.NoError(t, err)
-				require.Equal(t, objData[int(offset):], got)
+					got := make([]byte, size-offset)
+					err = cache.ReadAt(ctx, base.FileNum(1).DiskFileNum(), got, offset, readable, sharedcache.ReadFlags{})
+					require.NoError(t, err)
+					require.Equal(t, objData[int(offset):], got)
 
-				got = make([]byte, size-offset)
-				err = cache.ReadAt(ctx, base.FileNum(1).DiskFileNum(), got, offset, readable, sharedcache.ReadFlags{})
-				require.NoError(t, err)
-				require.Equal(t, objData[int(offset):], got)
+					got = make([]byte, size-offset)
+					err = cache.ReadAt(ctx, base.FileNum(1).DiskFileNum(), got, offset, readable, sharedcache.ReadFlags{})
+					require.NoError(t, err)
+					require.Equal(t, objData[int(offset):], got)
+				}()
+				// If concurrent reads, only wait 50% of loop iterations on average.
+				if concurrentReads && rand.Intn(2) == 0 {
+					wg.Wait()
+				}
+				if !concurrentReads {
+					wg.Wait()
+				}
 			}
+			wg.Wait()
 		}
 	}
-	t.Run("32 KB", helper(32*1024))
-	t.Run("1 MB", helper(1024*1024))
+	t.Run("32 KB with serial reads", helper(32*1024, false))
+	t.Run("1 MB with serial reads", helper(1024*1024, false))
+	t.Run("32 KB with concurrent reads", helper(32*1024, true))
+	t.Run("1 MB with concurrent reads", helper(1024*1024, true))
 }


### PR DESCRIPTION
Part of https://github.com/cockroachdb/pebble/issues/2541.

**sharedcache: fix bug that "leaks" cache block indexes**

This commit introduces assertions regarding in-memory shard state such as
s.mu.where & s.mu.free that caught an existing bug in the cache. The bug is:
If concurrent calls to ReadAt are made, then shard.set might be called for
a logical block that is already in the cache. Before this commit, such a
situation would "leak" a cache block, meaning the cache block index would
be removed from s.mu.where, implying the cache block could never be used
again. As of this commit, the bug is fixed.

**sharedcache: move to fine-grained locking**

Before this commit, s.mu was held when s.get & s.set were reading and
writing to s.file. This was done to simplify merging an initial implementation
with the necessary correctness properties. This commit moves to fine-grained
locking, to improve the performance of the cache. A table mapping each cache
block index to its "lock state" is introduced. During the reading and writing
to s.file, only the specific cache block being updated is locked. Both read and
write locks are supported, so that multiple reads of some cache block can be
done concurrently. Also, writing back to the cache is now done asynchronously
with respect to the call to ReadAt.

With this commit merged, I think we can run some production experiments
measuring the efficiency of the cache.