### PR TITLE
docs: add nightly benchmark annotation for infra change

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -65,6 +65,8 @@
             iterator structs (#1822)</div>
         <div class="annotation" data-date="20230215">Grandparent boundary
             compaction splitting</div>
+        <div class="annotation" data-date="20230516">Infrastructure
+            change (#2578)</div>
       </div>
       <div class="section rows">
         <div>


### PR DESCRIPTION
A yet unidentified change to Cockroach's roachprod or roachtest tooling resulted in a significant change to the ycsb/F/values=1024 benchmark. Compactions started to be less effective, resulting in a larger build-up of read amplification and less back pressure on the workload.

Close #2578.