### PR TITLE
Makefile: separate target for generating test data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ all:
 	@echo "  make stressmeta"
 	@echo "  make crossversion-meta"
 	@echo "  make mod-update"
+	@echo "  make generate"
+	@echo "  make generate-test-data"
 	@echo "  make clean"
 
 override testflags :=
@@ -68,6 +70,16 @@ stress-crossversion:
 .PHONY: generate
 generate:
 	${GO} generate ${PKG}
+
+generate:
+
+# Note that the output of generate-test-data is not deterministic. This should
+# only be run manually as needed.
+.PHONY: generate-test-data
+generate-test-data:
+	${GO} run -tags make_incorrect_manifests ./tool/make_incorrect_manifests.go
+	${GO} run -tags make_test_find_db ./tool/make_test_find_db.go
+	${GO} run -tags make_test_sstables ./tool/make_test_sstables.go
 
 mod-update:
 	${GO} get -u

--- a/tool/make_incorrect_manifests.go
+++ b/tool/make_incorrect_manifests.go
@@ -5,7 +5,7 @@
 //go:build make_incorrect_manifests
 // +build make_incorrect_manifests
 
-// Run using: go run -tags make_incorrect_manifests make_incorrect_manifests.go
+// Run using: go run -tags make_incorrect_manifests ./tool/make_incorrect_manifests.go
 package main
 
 import (
@@ -29,7 +29,7 @@ func writeVE(writer *record.Writer, ve *manifest.VersionEdit) {
 
 func makeManifest1() {
 	fs := vfs.Default
-	f, err := fs.Create("testdata/MANIFEST-invalid")
+	f, err := fs.Create("tool/testdata/MANIFEST-invalid")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/tool/make_test_find_db.go
+++ b/tool/make_test_find_db.go
@@ -5,7 +5,7 @@
 //go:build make_test_find_db
 // +build make_test_find_db
 
-// Run using: go run -tags make_test_find_db make_test_find_db.go
+// Run using: go run -tags make_test_find_db ./tool/make_test_find_db.go
 package main
 
 import (
@@ -86,7 +86,7 @@ func (d *db) deleteRange(start, end string) {
 }
 
 func (d *db) ingest(keyVals ...string) {
-	const path = "testdata/ingest.tmp"
+	const path = "tool/testdata/ingest.tmp"
 
 	if len(keyVals)%2 != 0 {
 		log.Fatalf("even number of key/values required")
@@ -136,7 +136,7 @@ func (d *db) snapshot() *pebble.Snapshot {
 }
 
 func main() {
-	const dir = "testdata/find-db"
+	const dir = "tool/testdata/find-db"
 
 	fs := vfs.Default
 	if err := fs.RemoveAll(dir); err != nil {

--- a/tool/make_test_sstables.go
+++ b/tool/make_test_sstables.go
@@ -5,7 +5,7 @@
 //go:build make_test_sstables
 // +build make_test_sstables
 
-// Run using: go run -tags make_test_sstables make_test_sstables.go
+// Run using: go run -tags make_test_sstables ./tool/make_test_sstables.go
 package main
 
 import (
@@ -19,7 +19,7 @@ import (
 
 func makeOutOfOrder() {
 	fs := vfs.Default
-	f, err := fs.Create("testdata/out-of-order.sst")
+	f, err := fs.Create("tool/testdata/out-of-order.sst")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -14,10 +14,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate go run -tags make_incorrect_manifests make_incorrect_manifests.go
-//go:generate go run -tags make_test_find_db make_test_find_db.go
-//go:generate go run -tags make_test_sstables make_test_sstables.go
-
 // Comparer exports the base.Comparer type.
 type Comparer = base.Comparer
 


### PR DESCRIPTION
We use `go:generate` to invoke programs that generate tool test data. This test data is non-deterministic (and tests don't generally pass when data is regenerated). This is not appropriate for the `make generate` target which is supposed to be a no-op on a "clean" branch.

This change separates these into a new `generate-test-data` target.

Fixes #2383.