### PR TITLE
db: fix TestCleaner flake

### DIFF
--- a/cleaner_test.go
+++ b/cleaner_test.go
@@ -107,6 +107,8 @@ func TestCleaner(t *testing.T) {
 					return "open <dir> [archive] [readonly]"
 				}
 			}
+			// Asynchronous table stats retrieval makes the output flaky.
+			opts.private.disableTableStats = true
 			d, err := Open(dir, opts)
 			if err != nil {
 				return err.Error()


### PR DESCRIPTION
TestCleaner flakes because of table stats are retrieved asynchronously. Disable table stats altogether.

Fixes #2560