### PR TITLE
db: Call maybeScheduleFlush before waiting on cond lock

### DIFF
--- a/db.go
+++ b/db.go
@@ -2136,6 +2136,7 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 					})
 				}
 				now := time.Now()
+				d.maybeScheduleFlush()
 				d.mu.compact.cond.Wait()
 				if b != nil {
 					b.commitStats.MemTableWriteStallDuration += time.Since(now)


### PR DESCRIPTION
After #2486 went in, it became more likely for past calls to `maybeScheduleFlush` to not do anything as the mutable memtable during an ingestion would no longer count towards a flush's bytes as it has a nonzero writerRef. If this is followed by the mutable memtable filling up and hitting the write stall threshold, we could end up in a situation where we (an ingesting goroutine) is holding the commit mutex and there is no remaining goroutine to call maybeScheduleFlush. There could possibly be calls to maybeScheduleDelayedFlush, but those would wait for the commit mutex and so wouldn't do anything.

This change calls maybeScheduledFlush before waiting on the compaction cond lock just to ensure a flush is happening.

Fixes #2597.