### PR TITLE
cmd/pebble: fix ycsb/F read amp sampling

### DIFF
--- a/cmd/pebble/ycsb.go
+++ b/cmd/pebble/ycsb.go
@@ -406,9 +406,9 @@ func (y *ycsb) run(db DB, wg *sync.WaitGroup) {
 func (y *ycsb) sampleReadAmp(db DB, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	limiter := rate.NewLimiter(rate.Every(time.Second), 0)
-	for {
-		wait(limiter)
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for range ticker.C {
 		m := db.Metrics()
 		y.readAmpCount.Add(1)
 		y.readAmpSum.Add(uint64(m.ReadAmp()))

--- a/docs/index.html
+++ b/docs/index.html
@@ -67,6 +67,7 @@
             compaction splitting</div>
         <div class="annotation" data-date="20230516">Infrastructure
             change (#2578)</div>
+        <div class="annotation" data-date="20230607">ycsb/F sampling bug</div>
       </div>
       <div class="section rows">
         <div>


### PR DESCRIPTION
In c3bf955f I goofed and misused a rate.Limiter which caused continuous sampling of read amplification. Use an ordinary ticker instead.

<img width="1190" alt="Screenshot 2023-06-08 at 11 43 40 AM" src="https://github.com/cockroachdb/pebble/assets/867352/72ab03a1-0c0e-47dd-b42f-d0e85cf04b9c">
