### PR TITLE
db: add Metric.Keys.MissizedTombstoneCount

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2072,6 +2072,7 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 	bytesFlushed = c.bytesIterated
 	d.mu.snapshots.cumulativePinnedCount += stats.cumulativePinnedKeys
 	d.mu.snapshots.cumulativePinnedSize += stats.cumulativePinnedSize
+	d.mu.versions.metrics.Keys.MissizedTombstonesCount += stats.countMissizedDels
 
 	d.maybeUpdateDeleteCompactionHints(c)
 	d.clearCompactingState(c, err != nil)
@@ -2622,6 +2623,7 @@ func (d *DB) compact1(c *compaction, errChannel chan error) (err error) {
 type compactStats struct {
 	cumulativePinnedKeys uint64
 	cumulativePinnedSize uint64
+	countMissizedDels    uint64
 }
 
 // runCompactions runs a compaction that produces new on-disk tables from
@@ -3294,6 +3296,11 @@ func (d *DB) runCompaction(
 			}] = f
 		}
 	}
+
+	// The compaction iterator keeps track of a count of the number of DELSIZED
+	// keys that encoded an incorrect size. Propagate it up as a part of
+	// compactStats.
+	stats.countMissizedDels = iter.stats.countMissizedDels
 
 	if err := d.objProvider.Sync(); err != nil {
 		return nil, pendingOutputs, stats, err

--- a/compaction_iter.go
+++ b/compaction_iter.go
@@ -256,6 +256,10 @@ type compactionIter struct {
 	// The on-disk format major version. This informs the types of keys that
 	// may be written to disk during a compaction.
 	formatVersion FormatMajorVersion
+	stats         struct {
+		// count of DELSIZED keys that were missized.
+		countMissizedDels uint64
+	}
 }
 
 func newCompactionIter(
@@ -953,6 +957,7 @@ func (i *compactionIter) deleteSizedNext() (*base.InternalKey, []byte) {
 	// user-provided size for accuracy, so ordinary DEL heuristics are safer.
 	i.value = i.valueBuf[:0]
 	if elidedSize != v {
+		i.stats.countMissizedDels++
 		i.key.SetKind(InternalKeyKindDelete)
 	}
 	return &i.key, i.value

--- a/metrics.go
+++ b/metrics.go
@@ -230,6 +230,9 @@ type Metrics struct {
 		// The approximate count of internal tombstones (DEL, SINGLEDEL and
 		// RANGEDEL key kinds) within the database.
 		TombstoneCount uint64
+		// A cumulative total number of missized DELSIZED keys encountered by
+		// compactions since the database was opened.
+		MissizedTombstonesCount uint64
 	}
 
 	Snapshots struct {

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -114,6 +114,21 @@ func TestTableStats(t *testing.T) {
 			d.mu.Unlock()
 			return s
 
+		case "metric":
+			m := d.Metrics()
+			// TODO(jackson): Make a generalized command that uses reflection to
+			// pull out arbitrary Metrics fields.
+			var buf bytes.Buffer
+			for _, arg := range td.CmdArgs {
+				switch arg.String() {
+				case "keys.missized-tombstones-count":
+					fmt.Fprintf(&buf, "%s: %d", arg.String(), m.Keys.MissizedTombstonesCount)
+				default:
+					return fmt.Sprintf("unrecognized metric %s", arg)
+				}
+			}
+			return buf.String()
+
 		case "wait-pending-table-stats":
 			return runTableStatsCmd(td, d)
 

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -516,6 +516,10 @@ flush
 6:
   000004:[bar#0,SET-moo#0,SET]
 
+metric keys.missized-tombstones-count
+----
+keys.missized-tombstones-count: 0
+
 # The foo DELSIZED tombstone should cause the
 # `pebble.raw.point-tombstone.value.size` property to be 100000 + len(foo) =
 # 100003.
@@ -544,3 +548,24 @@ num-deletions: 2
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 112732
 range-deletions-bytes-estimate: 0
+
+# Try a missized point tombstone. It should appear in the Metrics after the
+# flush that will elide the a.SET.
+
+batch
+set a boop
+del-sized a 10000
+----
+
+flush
+----
+0.1:
+  000008:[a#16,DEL-a#16,DEL]
+0.0:
+  000006:[a#10,SET-moo#14,DEL]
+6:
+  000004:[bar#0,SET-moo#0,SET]
+
+metric keys.missized-tombstones-count
+----
+keys.missized-tombstones-count: 1


### PR DESCRIPTION
Add a new metric that exposes the count of DELSIZED tombstones that are missized when they drop data from the LSM. This is useful within unit tests in client code to ensure that we're appropriately sizing tombstones.