### PR TITLE
Skip TestManualCompaction (flaky)

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1248,6 +1248,9 @@ func TestValidateVersionEdit(t *testing.T) {
 }
 
 func TestManualCompaction(t *testing.T) {
+	// skip flaky test until fixed (https://github.com/cockroachdb/pebble/issues/2613)
+	t.Skip()
+
 	var mem vfs.FS
 	var d *DB
 	defer func() {


### PR DESCRIPTION
Skip `TestManualCompaction` until a fix is found. 

Informs: #2613
Release note: None