### PR TITLE
db: Add Option to Filter SSTables

### DIFF
--- a/db.go
+++ b/db.go
@@ -1876,6 +1876,10 @@ func (d *DB) Metrics() *Metrics {
 type sstablesOptions struct {
 	// set to true will return the sstable properties in TableInfo
 	withProperties bool
+
+	// if set, return sstables that overlap the key range (end-exclusive)
+	start []byte
+	end   []byte
 }
 
 // SSTablesOption set optional parameter used by `DB.SSTables`.
@@ -1888,6 +1892,15 @@ type SSTablesOption func(*sstablesOptions)
 func WithProperties() SSTablesOption {
 	return func(opt *sstablesOptions) {
 		opt.withProperties = true
+	}
+}
+
+// WithKeyRangeFilter ensures returned sstables overlap start and end (end-exclusive)
+// if start and end are both nil these properties have no effect
+func WithKeyRangeFilter(start, end []byte) SSTablesOption {
+	return func(opt *sstablesOptions) {
+		opt.end = end
+		opt.start = start
 	}
 }
 
@@ -1936,6 +1949,9 @@ func (d *DB) SSTables(opts ...SSTablesOption) ([][]SSTableInfo, error) {
 		iter := srcLevels[i].Iter()
 		j := 0
 		for m := iter.First(); m != nil; m = iter.Next() {
+			if opt.start != nil && opt.end != nil && !m.Overlaps(d.opts.Comparer.Compare, opt.start, opt.end, true /* exclusive end */) {
+				continue
+			}
 			destTables[j] = SSTableInfo{TableInfo: m.TableInfo()}
 			if opt.withProperties {
 				p, err := d.tableCache.getTableProperties(
@@ -1953,6 +1969,7 @@ func (d *DB) SSTables(opts ...SSTablesOption) ([][]SSTableInfo, error) {
 		destLevels[i] = destTables[:j]
 		destTables = destTables[j:]
 	}
+
 	return destLevels, nil
 }
 

--- a/db_test.go
+++ b/db_test.go
@@ -1254,6 +1254,46 @@ func TestCloseCleanerRace(t *testing.T) {
 	}
 }
 
+func TestFilterSSTablesWithOption(t *testing.T) {
+	d, err := Open("", &Options{
+		FS: vfs.NewMem(),
+	})
+	require.NoError(t, err)
+	defer func() {
+		if d != nil {
+			require.NoError(t, d.Close())
+		}
+	}()
+
+	// Create two sstables.
+	require.NoError(t, d.Set([]byte("/Table/5"), nil, nil))
+	require.NoError(t, d.Flush())
+	require.NoError(t, d.Set([]byte("/Table/10"), nil, nil))
+	require.NoError(t, d.Flush())
+
+	tableInfos, err := d.SSTables(WithKeyRangeFilter([]byte("/Table/5"), []byte("/Table/6")))
+	require.NoError(t, err)
+
+	totalTables := 0
+	for _, levelTables := range tableInfos {
+		totalTables += len(levelTables)
+	}
+
+	// with filter second sstable should not be returned
+	require.EqualValues(t, 1, totalTables)
+
+	tableInfos, err = d.SSTables()
+	require.NoError(t, err)
+
+	totalTables = 0
+	for _, levelTables := range tableInfos {
+		totalTables += len(levelTables)
+	}
+
+	// without filter
+	require.EqualValues(t, 2, totalTables)
+}
+
 func TestSSTables(t *testing.T) {
 	d, err := Open("", &Options{
 		FS: vfs.NewMem(),


### PR DESCRIPTION
This change allows users to pass in a `start` and `end` bound option to filter sstables. This will be useful when trying to obtain metrics only for those sstables that intersect this key range.

Informs: https://github.com/cockroachdb/cockroach/issues/102604
Release note: None