### PR TITLE
db: don't require holding d.mu to read format major version

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -187,7 +187,7 @@ func (d *DB) Checkpoint(
 	// file number.
 	memQueue := d.mu.mem.queue
 	current := d.mu.versions.currentVersion()
-	formatVers := d.mu.formatVers.vers
+	formatVers := d.FormatMajorVersion()
 	manifestFileNum := d.mu.versions.manifestFileNum
 	manifestSize := d.mu.versions.manifest.Size()
 	optionsFileNum := d.optionsFileNum

--- a/compaction.go
+++ b/compaction.go
@@ -2724,7 +2724,7 @@ func (d *DB) runCompaction(
 	}()
 
 	snapshots := d.mu.snapshots.toSlice()
-	formatVers := d.mu.formatVers.vers
+	formatVers := d.FormatMajorVersion()
 
 	// Release the d.mu lock while doing I/O.
 	// Note the unusual order: Unlock and then Lock.

--- a/db.go
+++ b/db.go
@@ -340,7 +340,12 @@ type DB struct {
 			// Backwards-incompatible features are gated behind new
 			// format major versions and not enabled until a database's
 			// version is ratcheted upwards.
-			vers FormatMajorVersion
+			//
+			// Although this is under the `mu` prefix, readers may read vers
+			// atomically without holding d.mu. Writers must only write to this
+			// value through finalizeFormatVersUpgrade which requires d.mu is
+			// held.
+			vers atomic.Uint64
 			// marker is the atomic marker for the format major version.
 			// When a database's version is ratcheted upwards, the
 			// marker is moved in order to atomically record the new

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -382,9 +382,7 @@ func lookupFormatMajorVersion(
 // provided in Options when the database was opened if the existing
 // database was written with a higher format version.
 func (d *DB) FormatMajorVersion() FormatMajorVersion {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	return d.mu.formatVers.vers
+	return FormatMajorVersion(d.mu.formatVers.vers.Load())
 }
 
 // RatchetFormatMajorVersion ratchets the opened database's format major
@@ -411,9 +409,9 @@ func (d *DB) ratchetFormatMajorVersionLocked(formatVers FormatMajorVersion) erro
 		// Guard against accidentally forgetting to update internalFormatNewest.
 		return errors.Errorf("pebble: unknown format version %d", formatVers)
 	}
-	if d.mu.formatVers.vers > formatVers {
+	if currentVers := d.FormatMajorVersion(); currentVers > formatVers {
 		return errors.Newf("pebble: database already at format major version %d; cannot reduce to %d",
-			d.mu.formatVers.vers, formatVers)
+			currentVers, formatVers)
 	}
 	if d.mu.formatVers.ratcheting {
 		return errors.Newf("pebble: database format major version upgrade is in-progress")
@@ -421,7 +419,7 @@ func (d *DB) ratchetFormatMajorVersionLocked(formatVers FormatMajorVersion) erro
 	d.mu.formatVers.ratcheting = true
 	defer func() { d.mu.formatVers.ratcheting = false }()
 
-	for nextVers := d.mu.formatVers.vers + 1; nextVers <= formatVers; nextVers++ {
+	for nextVers := d.FormatMajorVersion() + 1; nextVers <= formatVers; nextVers++ {
 		if err := formatMajorVersionMigrations[nextVers](d); err != nil {
 			return errors.Wrapf(err, "migrating to version %d", nextVers)
 		}
@@ -432,7 +430,7 @@ func (d *DB) ratchetFormatMajorVersionLocked(formatVers FormatMajorVersion) erro
 		// update in-memory state (without ever dropping locks) after
 		// the upgrade is finalized. Here we assert that the upgrade
 		// did occur.
-		if d.mu.formatVers.vers != nextVers {
+		if d.FormatMajorVersion() != nextVers {
 			d.opts.Logger.Fatalf("pebble: successful migration to format version %d never finalized the upgrade", nextVers)
 		}
 	}
@@ -451,7 +449,7 @@ func (d *DB) finalizeFormatVersUpgrade(formatVers FormatMajorVersion) error {
 	if err := d.mu.formatVers.marker.Move(formatVers.String()); err != nil {
 		return err
 	}
-	d.mu.formatVers.vers = formatVers
+	d.mu.formatVers.vers.Store(uint64(formatVers))
 	d.opts.EventListener.FormatUpgrade(formatVers)
 	return nil
 }

--- a/ingest.go
+++ b/ingest.go
@@ -1160,7 +1160,7 @@ func (d *DB) ingest(
 			return
 		}
 		// The ingestion overlaps with some entry in the flushable queue.
-		if d.mu.formatVers.vers < FormatFlushableIngest ||
+		if d.FormatMajorVersion() < FormatFlushableIngest ||
 			d.opts.Experimental.DisableIngestAsFlushable() ||
 			len(shared) > 0 || overlapWithExciseSpan ||
 			(len(d.mu.mem.queue) > d.opts.MemTableStopWritesThreshold-1) {


### PR DESCRIPTION
Allow readers of the database's format major version to read the format major version through an atomic load, instead of acquiring the global d.mu. This is particularly important for batch application, which must read the format major version to determine if the batch holds any keys that cannot be applied. Mutex contention during batch application in DB.FormatMajorVersion has been observed in experiments.

<img width="467" alt="Screenshot 2023-06-16 at 11 16 59 AM" src="https://github.com/cockroachdb/pebble/assets/867352/b9a0f1da-5cdf-46b0-be8c-164402050d86">
