### PR TITLE
sstable: shrink buffer in readFooter before calling Readable

### DIFF
--- a/sstable/table.go
+++ b/sstable/table.go
@@ -337,6 +337,7 @@ func readFooter(f objstorage.Readable) (footer, error) {
 		off = 0
 		buf = buf[:size]
 	}
+	buf = buf[:size-off]
 	if err := f.ReadAt(context.TODO(), buf, off); err != nil {
 		return footer, errors.Wrap(err, "pebble/table: invalid table (could not read footer)")
 	}


### PR DESCRIPTION
The objstorage.Readable interface specifically disallows partial reads, as an EOF error could be returned if a buffer larger than the size of the remaining part of the file is passed in. This change shrinks the buffer before calling ReadAt to avoid an EOF error from being erroneously returned.