### PR TITLE
ingest: Call Extend{Point,Range}KeyBounds in excise

### DIFF
--- a/testdata/ingest_shared
+++ b/testdata/ingest_shared
@@ -497,3 +497,75 @@ c@9: (foobar, .)
 e: (baz, .)
 .
 .
+
+# Test for cases where an excise produces a range key on one side and point keys
+# on the other.
+
+reset
+----
+
+switch 1
+----
+ok
+
+batch
+range-key-set a aaa @3 foo
+set d foobar
+set e barbaz
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+lsm
+----
+6:
+  000005:[a#10,RANGEKEYSET-e#12,SET]
+
+switch 2
+----
+ok
+
+batch
+set b bcd
+set c cde
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+replicate 2 1 b cc
+----
+replicated 1 shared SSTs
+
+switch 1
+----
+ok
+
+lsm
+----
+6:
+  000008:[a#10,RANGEKEYSET-aaa#inf,RANGEKEYSET]
+  000007:[b#1,SET-c#1,SET]
+  000009:[d#11,SET-e#12,SET]
+
+iter
+first
+next
+next
+next
+next
+----
+a: (., [a-aaa) @3=foo UPDATED)
+b: (bcd, . UPDATED)
+c: (cde, .)
+d: (foobar, .)
+e: (barbaz, .)


### PR DESCRIPTION
Previously when we called `excise()`, we created new FileMetadata objects without calling ExtendPointKeyBounds and ExtendRangeKeyBounds. During testing we quickly realized that we would result in some instances of us not having the `boundType` set correctly, resulting in panics when we tried to install a file that had a modified boundType.