### PR TITLE
crl-release-22.2: sstable: propagate error if decompression fails

### DIFF
--- a/sstable/compression_test.go
+++ b/sstable/compression_test.go
@@ -1,0 +1,64 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble/internal/cache"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompressionRoundtrip(t *testing.T) {
+	seed := time.Now().UnixNano()
+	t.Logf("seed %d", seed)
+	rng := rand.New(rand.NewSource(seed))
+	c := cache.New(128 << 10 /* 128 KiB */)
+	defer c.Unref()
+
+	for compression := DefaultCompression + 1; compression < NCompression; compression++ {
+		t.Run(compression.String(), func(t *testing.T) {
+			payload := make([]byte, rng.Intn(10<<10 /* 10 KiB */))
+			rng.Read(payload)
+			// Create a randomly-sized buffer to house the compressed output. If it's
+			// not sufficient, compressBlock should allocate one that is.
+			compressedBuf := make([]byte, rng.Intn(1<<10 /* 1 KiB */))
+
+			btyp, compressed := compressBlock(compression, payload, compressedBuf)
+			v, err := decompressBlock(c, btyp, compressed)
+			require.NoError(t, err)
+			got := payload
+			if v != nil {
+				got = v.Buf()
+				require.Equal(t, payload, got)
+				c.Free(v)
+			}
+		})
+	}
+}
+
+// TestDecompressionError tests that a decompressing a value that does not
+// decompress returns an error.
+func TestDecompressionError(t *testing.T) {
+	c := cache.New(128 << 10 /* 128 KiB */)
+	defer c.Unref()
+	rng := rand.New(rand.NewSource(1 /* fixed seed */))
+
+	// Create a buffer to represent a faux zstd compressed block. It's prefixed
+	// with a uvarint of the appropriate length, followed by garabge.
+	fauxCompressed := make([]byte, rng.Intn(10<<10 /* 10 KiB */))
+	compressedPayloadLen := len(fauxCompressed) - binary.MaxVarintLen64
+	n := binary.PutUvarint(fauxCompressed, uint64(compressedPayloadLen))
+	fauxCompressed = fauxCompressed[:n+compressedPayloadLen]
+	rng.Read(fauxCompressed[n:])
+
+	v, err := decompressBlock(c, zstdCompressionBlockType, fauxCompressed)
+	t.Log(err)
+	require.Error(t, err)
+	require.Nil(t, v)
+}


### PR DESCRIPTION
22.2 backport of https://github.com/cockroachdb/pebble/pull/2647.

----

Previously, if decompression failed decompressBlock would discard the error and return a cache.Value that had already been freed. This possibly explains some of the occurrences of cockroachdb/cockroach#84971.