### PR TITLE
vfs: update DiskSlowInfo Stringer implementation

### DIFF
--- a/vfs/disk_health.go
+++ b/vfs/disk_health.go
@@ -383,9 +383,17 @@ func (i DiskSlowInfo) String() string {
 
 // SafeFormat implements redact.SafeFormatter.
 func (i DiskSlowInfo) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Printf("disk slowness detected: %s on file %s (%d bytes) has been ongoing for %0.1fs",
-		redact.Safe(i.OpType.String()), redact.Safe(filepath.Base(i.Path)),
-		redact.Safe(i.WriteSize), redact.Safe(i.Duration.Seconds()))
+	switch i.OpType {
+	// Operations for which i.WriteSize is meaningful.
+	case OpTypeWrite, OpTypeSyncTo, OpTypePreallocate:
+		w.Printf("disk slowness detected: %s on file %s (%d bytes) has been ongoing for %0.1fs",
+			redact.Safe(i.OpType.String()), redact.Safe(filepath.Base(i.Path)),
+			redact.Safe(i.WriteSize), redact.Safe(i.Duration.Seconds()))
+	default:
+		w.Printf("disk slowness detected: %s on file %s has been ongoing for %0.1fs",
+			redact.Safe(i.OpType.String()), redact.Safe(filepath.Base(i.Path)),
+			redact.Safe(i.Duration.Seconds()))
+	}
 }
 
 // diskHealthCheckingFS adds disk-health checking facilities to a VFS.


### PR DESCRIPTION
Some write operations do not have sizing information (eg, Sync/SyncData) and including `(0 bytes)` in the log message is likely to confuse.