### PR TITLE
metamorphic: Batch close operation to `g.BatchClose` and rename function to `removeBatchFromGenerator`

### DIFF
--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -85,7 +85,6 @@ func (o *applyOp) run(t *test, h historyRecorder) {
 	}
 	h.Recordf("%s // %v", o, err)
 	_ = b.Close()
-	t.clearObj(o.batchID)
 }
 
 func (o *applyOp) String() string  { return fmt.Sprintf("%s.Apply(%s)", o.writerID, o.batchID) }
@@ -423,7 +422,6 @@ type batchCommitOp struct {
 
 func (o *batchCommitOp) run(t *test, h historyRecorder) {
 	b := t.getBatch(o.batchID)
-	t.clearObj(o.batchID)
 	err := b.Commit(t.writeOpts)
 	h.Recordf("%s // %v", o, err)
 }


### PR DESCRIPTION
Added a batch close operation when closing a batch to avoid metamorphic test leaks. Additionally, `g.batchClose` has been renamed to `g.removeBatchFromGenerator`. 

Fixes: #2579
Release note: None