### PR TITLE
lint: add linter for raw atomic operations

### DIFF
--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -155,6 +155,21 @@ func TestLint(t *testing.T) {
 		}
 	})
 
+	// Disallow "raw" atomics; wrappers like atomic.Int32 provide much better
+	// safety and alignment guarantees.
+	t.Run("TestRawAtomics", func(t *testing.T) {
+		t.Parallel()
+		if err := stream.ForEach(
+			stream.Sequence(
+				dirCmd(t, pkg.Dir, "git", "grep", `atomic\.\(Load\|Store\|Add\|Swap\|Compare\)`),
+				lintIgnore("lint:ignore RawAtomics"),
+			), func(s string) {
+				t.Errorf("\n%s <- please use atomic wrappers (like atomic.Int32) instead", s)
+			}); err != nil {
+			t.Error(err)
+		}
+	})
+
 	t.Run("TestForbiddenImports", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
#### db: use atomic.Pointer for keySpanFrags


#### lint: add linter for raw atomic operations

This commit adds a lint check for using atomic operations like
`atomic.LoadInt32` instead of using a wrapper like `atomic.Int32`. The
wrappers provide much better safety and alignment guarantees (e.g.
with a wrapper you can't accidentally use the value non-atomically).
