### PR TITLE
[DNM] db: use uncompensated scores to smoothe compaction picking scores

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -396,6 +396,7 @@ type compaction struct {
 	//    - if startLevel is 0, the output level equals compactionPicker.baseLevel().
 	//    - in multilevel compaction, the output level is the lowest level involved in
 	//      the compaction
+	// A compaction's outputLevel is nil for delete-only compactions.
 	outputLevel *compactionLevel
 
 	// extraLevels point to additional levels in between the input and output

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -565,10 +565,16 @@ func newCompactionPicker(
 // Information about a candidate compaction level that has been identified by
 // the compaction picker.
 type candidateLevelInfo struct {
-	// The score of the level to be compacted.
-	score     float64
+	// The score of the level to be compacted, with compensated file sizes and
+	// adjustments.
+	score float64
+	// The original score of the level to be compacted, before adjusting
+	// according to other levels' sizes.
 	origScore float64
-	level     int
+	// The raw score of the level to be compacted, calculated using
+	// uncompensated file sizes and without any adjustments.
+	rawScore float64
+	level    int
 	// The level to compact to.
 	outputLevel int
 	// The file in level that will be compacted. Additional files may be
@@ -826,25 +832,50 @@ func (p *compactionPickerByScore) initLevelMaxBytes(inProgressCompactions []comp
 	}
 }
 
-func calculateSizeAdjust(inProgressCompactions []compactionInfo) [numLevels]int64 {
-	// Compute a size adjustment for each level based on the in-progress
-	// compactions. We subtract the compensated size of start level inputs.
+type levelSizeAdjust struct {
+	incomingActualBytes      int64
+	outgoingActualBytes      int64
+	outgoingCompensatedBytes int64
+}
+
+func (a levelSizeAdjust) compensated() int64 {
+	return a.incomingActualBytes - a.outgoingCompensatedBytes
+}
+
+func (a levelSizeAdjust) actual() int64 {
+	return a.incomingActualBytes - a.outgoingActualBytes
+}
+
+func calculateSizeAdjust(inProgressCompactions []compactionInfo) [numLevels]levelSizeAdjust {
+	// Compute size adjustments for each level based on the in-progress
+	// compactions. We sum the file sizes of all files leaving and entering each
+	// level in in-progress compactions. For outgoing files, we also sum a
+	// separate sum of 'compensated file sizes', which are inflated according
+	// to deletion estimates.
+	//
+	// When we adjust a level's size according to these values during score
+	// calculation, we subtract the compensated size of start level inputs to
+	// account for the fact that score calculation uses compensated sizes.
+	//
 	// Since compensated file sizes may be compensated because they reclaim
-	// space from the output level's files, we add the real file size to the
-	// output level. This is slightly different from RocksDB's behavior, which
-	// simply elides compacting files from the level size calculation.
-	var sizeAdjust [numLevels]int64
+	// space from the output level's files, we only add the real file size to
+	// the output level.
+	//
+	// This is slightly different from RocksDB's behavior, which simply elides
+	// compacting files from the level size calculation.
+	var sizeAdjust [numLevels]levelSizeAdjust
 	for i := range inProgressCompactions {
 		c := &inProgressCompactions[i]
 
 		for _, input := range c.inputs {
-			real := int64(input.files.SizeSum())
-			compensated := int64(totalCompensatedSize(input.files.Iter()))
+			actualSize := int64(input.files.SizeSum())
+			compensatedSize := int64(totalCompensatedSize(input.files.Iter()))
 
 			if input.level != c.outputLevel {
-				sizeAdjust[input.level] -= compensated
+				sizeAdjust[input.level].outgoingCompensatedBytes += compensatedSize
+				sizeAdjust[input.level].outgoingActualBytes += actualSize
 				if c.outputLevel != -1 {
-					sizeAdjust[c.outputLevel] += real
+					sizeAdjust[c.outputLevel].incomingActualBytes += actualSize
 				}
 			}
 		}
@@ -868,9 +899,15 @@ func (p *compactionPickerByScore) calculateScores(
 
 	sizeAdjust := calculateSizeAdjust(inProgressCompactions)
 	for level := 1; level < numLevels; level++ {
-		levelSize := int64(levelCompensatedSize(p.vers.Levels[level])) + sizeAdjust[level]
-		scores[level].score = float64(levelSize) / float64(p.levelMaxBytes[level])
+		compensatedLevelSize := int64(levelCompensatedSize(p.vers.Levels[level])) + sizeAdjust[level].compensated()
+		scores[level].score = float64(compensatedLevelSize) / float64(p.levelMaxBytes[level])
 		scores[level].origScore = scores[level].score
+
+		// In addition to the compensated score, we calculate a separate score
+		// that uses actual file sizes, not compensated sizes. This is used
+		// during score smoothing down below to prevent excessive
+		// prioritization of reclaiming disk space.
+		scores[level].rawScore = float64(p.levelSizes[level]+sizeAdjust[level].actual()) / float64(p.levelMaxBytes[level])
 	}
 
 	// Adjust each level's score by the score of the next level. If the next
@@ -901,7 +938,7 @@ func (p *compactionPickerByScore) calculateScores(
 			// adjust a level by. The value of 0.01 was chosen somewhat arbitrarily
 			const minScore = 0.01
 			if scores[level].score >= minScore {
-				scores[prevLevel].score /= scores[level].score
+				scores[prevLevel].score /= scores[level].rawScore
 			} else {
 				scores[prevLevel].score /= minScore
 			}

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -36,6 +36,14 @@ func loadVersion(d *datadriven.TestData) (*version, *Options, [numLevels]int64, 
 
 	var files [numLevels][]*fileMetadata
 	if len(d.Input) > 0 {
+		// Parse each line as
+		//
+		// <level>: <size> [compensation]
+		//
+		// Creating sstables within the level whose file sizes total to `size`
+		// and whose compensated file sizes total to `size`+`compensation`. If
+		// size is sufficiently large, only one single file is created. See
+		// the TODO below.
 		for _, data := range strings.Split(d.Input, "\n") {
 			parts := strings.Split(data, " ")
 			parts[0] = strings.TrimSuffix(strings.TrimSpace(parts[0]), ":")
@@ -53,6 +61,15 @@ func loadVersion(d *datadriven.TestData) (*version, *Options, [numLevels]int64, 
 			if err != nil {
 				return nil, nil, sizes, err.Error()
 			}
+			var compensation uint64
+			if len(parts) == 3 {
+				compensation, err = strconv.ParseUint(strings.TrimSpace(parts[2]), 10, 64)
+				if err != nil {
+					return nil, nil, sizes, err.Error()
+				}
+			}
+
+			var lastFile *fileMetadata
 			for i := uint64(1); sizes[level] < int64(size); i++ {
 				var key InternalKey
 				if level == 0 {
@@ -65,7 +82,12 @@ func loadVersion(d *datadriven.TestData) (*version, *Options, [numLevels]int64, 
 					SmallestSeqNum: key.SeqNum(),
 					LargestSeqNum:  key.SeqNum(),
 					Size:           1,
+					Stats: manifest.TableStats{
+						RangeDeletionsBytesEstimate: 0,
+					},
 				}).ExtendPointKeyBounds(opts.Comparer.Compare, key, key)
+				m.StatsMarkValid()
+				lastFile = m
 				if size >= 100 {
 					// If the requested size of the level is very large only add a single
 					// file in order to avoid massive blow-up in the number of files in
@@ -75,9 +97,17 @@ func loadVersion(d *datadriven.TestData) (*version, *Options, [numLevels]int64, 
 					// TestCompactionPickerLevelMaxBytes and
 					// TestCompactionPickerTargetLevel. Clean this up somehow.
 					m.Size = size
+					m.Stats.RangeDeletionsBytesEstimate = compensation
+				} else if compensation > 0 {
+					m.Stats.RangeDeletionsBytesEstimate = compensation / (uint64(sizes[level]) - size)
+					compensation -= m.Stats.RangeDeletionsBytesEstimate
 				}
 				files[level] = append(files[level], m)
 				sizes[level] += int64(m.Size)
+			}
+			// If there's any remainder compensation, add it to the last file.
+			if lastFile != nil && compensation > 0 {
+				lastFile.Stats.RangeDeletionsBytesEstimate += compensation
 			}
 		}
 	}
@@ -157,6 +187,15 @@ func TestCompactionPickerTargetLevel(t *testing.T) {
 		func(d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "init":
+				// loadVersion expects a single datadriven argument that it
+				// sets as Options.LBaseMaxBytes. It parses the input as
+				// newline-separated levels, specifying the level's file size
+				// and optionally additional compensation to be added during
+				// compensated file size calculations. Eg:
+				//
+				// init <LBaseMaxBytes>
+				// <level>: <size> [compensation]
+				// <level>: <size> [compensation]
 				var errMsg string
 				vers, opts, sizes, errMsg = loadVersion(d)
 				if errMsg != "" {

--- a/testdata/compaction_picker_target_level
+++ b/testdata/compaction_picker_target_level
@@ -118,6 +118,20 @@ queue
 L5->L6: 1.1
 
 init 1
+4: 1
+5: 11 50
+6: 100
+----
+
+init_cp
+----
+base: 4
+
+queue
+----
+L5->L6: 6.2
+
+init 1
 4: 2
 5: 11
 6: 100
@@ -282,6 +296,38 @@ L5->L6: 5.2
 pick ongoing=(5,6)
 ----
 no compaction
+
+# Verify that L0 score doesn't change with respect to L5's compensation.
+
+init 5
+0: 10
+5: 5 1
+6: 5
+----
+
+init_cp
+----
+base: 5
+
+queue
+----
+L0->L5: 5.0
+L5->L6: 11.5
+
+init 5
+0: 10
+5: 5 0
+6: 5
+----
+
+init_cp
+----
+base: 5
+
+queue
+----
+L0->L5: 5.0
+L5->L6: 10.8
 
 # Verify that successive manual compactions interleaved with an automatic
 # compaction does not trigger an error.


### PR DESCRIPTION
When adjusting scores by smoothing scores, use a parallel uncompensated score as the divisor for the smoothing adjustment. This helps avoid range deletions in lower levels from starving compactions in higher levels through excessive prioritization of lower-level disk space reclamation.