### PR TITLE
db: Refactor compaction cancellation with concurrent excises

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -13,6 +13,7 @@ import (
 	"runtime/pprof"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -30,6 +31,7 @@ import (
 
 var errEmptyTable = errors.New("pebble: empty table")
 var errFlushInvariant = errors.New("pebble: flush next log number is unset")
+var errCancelledCompaction = errors.New("pebble: compaction cancelled by a concurrent operation, will retry compaction")
 
 var compactLabels = pprof.Labels("pebble", "compact")
 var flushLabels = pprof.Labels("pebble", "flush")
@@ -546,6 +548,11 @@ func rangeKeyCompactionTransform(
 // compaction is a table compaction from one level to the next, starting from a
 // given version.
 type compaction struct {
+	// cancel is a bool that can be used by other goroutines to signal a compaction
+	// to cancel, such as if a conflicting excise operation raced it to manifest
+	// application. Only holders of the manifest lock will write to this atomic.
+	cancel atomic.Bool
+
 	kind      compactionKind
 	cmp       Compare
 	equal     Equal
@@ -2569,14 +2576,12 @@ func (d *DB) compact1(c *compaction, errChannel chan error) (err error) {
 		err = func() error {
 			var err error
 			d.mu.versions.logLock()
-			// Confirm if any of this compaction's inputs were deleted while this
-			// compaction was ongoing.
-			for i := range c.inputs {
-				c.inputs[i].files.Each(func(m *manifest.FileMetadata) {
-					if m.Deleted {
-						err = firstError(err, errors.New("pebble: file deleted by a concurrent operation, will retry compaction"))
-					}
-				})
+			// Check if this compaction had a conflicting operation (eg. a d.excise())
+			// that necessitates it restarting from scratch. Note that since we hold
+			// the manifest lock, we don't expect this bool to change its value
+			// as only the holder of the manifest lock will ever write to it.
+			if c.cancel.Load() {
+				err = firstError(err, errCancelledCompaction)
 			}
 			if err != nil {
 				// logAndApply calls logUnlock. If we didn't call it, we need to call
@@ -2832,6 +2837,10 @@ func (d *DB) runCompaction(
 	}()
 
 	newOutput := func() error {
+		// Check if we've been cancelled by a concurrent operation.
+		if c.cancel.Load() {
+			return errCancelledCompaction
+		}
 		fileMeta := &fileMetadata{}
 		d.mu.Lock()
 		fileNum := d.mu.versions.getNextFileNum()

--- a/ingest.go
+++ b/ingest.go
@@ -50,13 +50,21 @@ func (k *KeyRange) Contains(cmp base.Compare, key InternalKey) bool {
 	return (v < 0 || (v == 0 && key.IsExclusiveSentinel())) && cmp(k.Start, key.UserKey) <= 0
 }
 
+// OverlapsInternalKeyRange checks if the specified internal key range has an
+// overlap with the KeyRange. Note that we aren't checking for full containment
+// of smallest-largest within k, rather just that there's some intersection
+// between the two ranges.
+func (k *KeyRange) OverlapsInternalKeyRange(cmp base.Compare, smallest, largest InternalKey) bool {
+	v := cmp(k.Start, largest.UserKey)
+	return v <= 0 && !(largest.IsExclusiveSentinel() && v == 0) &&
+		cmp(k.End, smallest.UserKey) > 0
+}
+
 // Overlaps checks if the specified file has an overlap with the KeyRange.
 // Note that we aren't checking for full containment of m within k, rather just
 // that there's some intersection between m and k's bounds.
 func (k *KeyRange) Overlaps(cmp base.Compare, m *fileMetadata) bool {
-	v := cmp(k.Start, m.Largest.UserKey)
-	return v <= 0 && !(m.Largest.IsExclusiveSentinel() && v == 0) &&
-		cmp(k.End, m.Smallest.UserKey) > 0
+	return k.OverlapsInternalKeyRange(cmp, m.Smallest, m.Largest)
 }
 
 func ingestValidateKey(opts *Options, key *InternalKey) error {
@@ -1711,6 +1719,21 @@ func (d *DB) ingestApply(
 					levelMetrics.Size += int64(excised[i].Meta.Size)
 				}
 			}
+		}
+	}
+	for c := range d.mu.compact.inProgress {
+		if c.versionEditApplied {
+			continue
+		}
+		// Check if this compaction overlaps with the excise span. Note that just
+		// checking if the inputs individually overlap with the excise span
+		// isn't sufficient; for instance, a compaction could have [a,b] and [e,f]
+		// as inputs and write it all out as [a,b,e,f] in one sstable. If we're
+		// doing a [c,d) excise at the same time as this compaction, we will have
+		// to error out the whole compaction as we can't guarantee it hasn't/won't
+		// write a file overlapping with the excise span.
+		if exciseSpan.OverlapsInternalKeyRange(d.cmp, c.smallest, c.largest) {
+			c.cancel.Store(true)
 		}
 	}
 	if err := d.mu.versions.logAndApply(jobID, ve, metrics, false /* forceRotation */, func() []compactionInfo {

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -227,10 +227,6 @@ type FileMetadata struct {
 	// we'd have to write virtual sstable stats to the version edit.
 	Stats TableStats
 
-	// Deleted is set to true if a VersionEdit gets installed that has deleted
-	// this file. Protected by the manifest lock (see versionSet.logLock()).
-	Deleted bool
-
 	// For L0 files only. Protected by DB.mu. Used to generate L0 sublevels and
 	// pick L0 compactions. Only accurate for the most recent Version.
 	SubLevel         int

--- a/version_set.go
+++ b/version_set.go
@@ -572,14 +572,6 @@ func (vs *versionSet) logAndApply(
 	for fileNum, size := range zombies {
 		vs.zombieTables[fileNum] = size
 	}
-	// Update the Deleted bools. We can't use the zombieTables struct for this
-	// as it works on FileBackings, not FileMetadatas.
-	for _, f := range ve.DeletedFiles {
-		f.Deleted = true
-	}
-	for i := range ve.NewFiles {
-		ve.NewFiles[i].Meta.Deleted = false
-	}
 
 	// Install the new version.
 	vs.append(newVersion)


### PR DESCRIPTION
This change reworks the logic to cancel concurrent compactions by moving to a per-compaction cancelled atomic boolean, instead of relying on a boolean in the input FileMetadatas. This is easier for the compaction to check during its execution, reducing the amount of wasted work. It's also more correct as it allows the excising goroutine to error out an entire compaction even if none of its inputs overlapped with the excised span, as there's no guarantee that there won't be an output that overlaps with the excise span even if no inputs overlapped with it.