### PR TITLE
crl-release-23.1: db: don't require holding d.mu to read format major version

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -184,7 +184,7 @@ func (d *DB) Checkpoint(
 	// file number.
 	memQueue := d.mu.mem.queue
 	current := d.mu.versions.currentVersion()
-	formatVers := d.mu.formatVers.vers
+	formatVers := d.FormatMajorVersion()
 	manifestFileNum := d.mu.versions.manifestFileNum
 	manifestSize := d.mu.versions.manifest.Size()
 	optionsFileNum := d.optionsFileNum

--- a/compaction.go
+++ b/compaction.go
@@ -2661,7 +2661,7 @@ func (d *DB) runCompaction(
 	}()
 
 	snapshots := d.mu.snapshots.toSlice()
-	formatVers := d.mu.formatVers.vers
+	formatVers := d.FormatMajorVersion()
 
 	// Release the d.mu lock while doing I/O.
 	// Note the unusual order: Unlock and then Lock.

--- a/db.go
+++ b/db.go
@@ -329,7 +329,12 @@ type DB struct {
 			// Backwards-incompatible features are gated behind new
 			// format major versions and not enabled until a database's
 			// version is ratcheted upwards.
-			vers FormatMajorVersion
+			//
+			// Although this is under the `mu` prefix, readers may read vers
+			// atomically without holding d.mu. Writers must only write to this
+			// value through finalizeFormatVersUpgrade which requires d.mu is
+			// held.
+			vers atomic.Uint64
 			// marker is the atomic marker for the format major version.
 			// When a database's version is ratcheted upwards, the
 			// marker is moved in order to atomically record the new

--- a/ingest.go
+++ b/ingest.go
@@ -909,7 +909,7 @@ func (d *DB) ingest(
 			return
 		}
 		// The ingestion overlaps with some entry in the flushable queue.
-		if d.mu.formatVers.vers < FormatFlushableIngest ||
+		if d.FormatMajorVersion() < FormatFlushableIngest ||
 			d.opts.Experimental.DisableIngestAsFlushable() ||
 			(len(d.mu.mem.queue) > d.opts.MemTableStopWritesThreshold-1) {
 			// We're not able to ingest as a flushable,


### PR DESCRIPTION
23.1 backport of #2643.

----

Allow readers of the database's format major version to read the format major version through an atomic load, instead of acquiring the global d.mu. This is particularly important for batch application, which must read the format major version to determine if the batch holds keys any keys that cannot be applied. Mutex contention during batch application in DB.FormatMajorVersion has been observed in experiments.