### PR TITLE
crl-release-22.2: db: don't require holding d.mu to read format major version

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -142,7 +142,7 @@ func (d *DB) Checkpoint(
 	// file number.
 	memQueue := d.mu.mem.queue
 	current := d.mu.versions.currentVersion()
-	formatVers := d.mu.formatVers.vers
+	formatVers := d.FormatMajorVersion()
 	manifestFileNum := d.mu.versions.manifestFileNum
 	manifestSize := d.mu.versions.manifest.Size()
 	optionsFileNum := d.optionsFileNum

--- a/compaction.go
+++ b/compaction.go
@@ -2302,7 +2302,7 @@ func (d *DB) runCompaction(
 	}()
 
 	snapshots := d.mu.snapshots.toSlice()
-	formatVers := d.mu.formatVers.vers
+	formatVers := d.FormatMajorVersion()
 	// The table is written at the maximum allowable format implied by the current
 	// format major version of the DB.
 	tableFormat := formatVers.MaxTableFormat()

--- a/db.go
+++ b/db.go
@@ -301,7 +301,12 @@ type DB struct {
 			// Backwards-incompatible features are gated behind new
 			// format major versions and not enabled until a database's
 			// version is ratcheted upwards.
-			vers FormatMajorVersion
+			//
+			// Although this is under the `mu` prefix, readers may read vers
+			// atomically without holding d.mu. Writers must only write to this
+			// value through finalizeFormatVersUpgrade which requires d.mu is
+			// held.
+			vers uint64
 			// marker is the atomic marker for the format major version.
 			// When a database's version is ratcheted upwards, the
 			// marker is moved in order to atomically record the new


### PR DESCRIPTION
22.2 backport of #2643.

----

Allow readers of the database's format major version to read the format major version through an atomic load, instead of acquiring the global d.mu. This is particularly important for batch application, which must read the format major version to determine if the batch holds keys any keys that cannot be applied. Mutex contention during batch application in DB.FormatMajorVersion has been observed in experiments.