### PR TITLE
ingest: Set {Smallest,Largest}SeqNum in Excise

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -1367,6 +1367,10 @@ func (d *DB) excise(
 			Virtual:     true,
 			FileBacking: m.FileBacking,
 			FileNum:     d.mu.versions.getNextFileNum(),
+			// Note that these are loose bounds for smallest/largest seqnums, but they're
+			// sufficient for maintaining correctness.
+			SmallestSeqNum: m.SmallestSeqNum,
+			LargestSeqNum:  m.LargestSeqNum,
 		}
 		if m.HasPointKeys && !exciseSpan.Contains(d.cmp, m.SmallestPointKey) {
 			// This file will contain point keys
@@ -1458,6 +1462,10 @@ func (d *DB) excise(
 		Virtual:     true,
 		FileBacking: m.FileBacking,
 		FileNum:     d.mu.versions.getNextFileNum(),
+		// Note that these are loose bounds for smallest/largest seqnums, but they're
+		// sufficient for maintaining correctness.
+		SmallestSeqNum: m.SmallestSeqNum,
+		LargestSeqNum:  m.LargestSeqNum,
 	}
 	if m.HasPointKeys && !exciseSpan.Contains(d.cmp, m.LargestPointKey) {
 		// This file will contain point keys

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -722,7 +722,7 @@ func TestExcise(t *testing.T) {
 			d.mu.Lock()
 			d.mu.versions.logUnlock()
 			d.mu.Unlock()
-			return fmt.Sprintf("would excise %d files, use ingest-and-excise to excise.\n%s", len(ve.DeletedFiles), ve.String())
+			return fmt.Sprintf("would excise %d files, use ingest-and-excise to excise.\n%s", len(ve.DeletedFiles), ve.DebugString(base.DefaultFormatter))
 
 		case "compact":
 			if len(td.CmdArgs) != 2 {

--- a/internal/manifest/testdata/file_metadata_bounds
+++ b/internal/manifest/testdata/file_metadata_bounds
@@ -3,7 +3,7 @@
 extend-point-key-bounds
 a.SET.0 - z.DEL.42
 ----
-000000:[a#0,SET-z#42,DEL] points:[a#0,SET-z#42,DEL]
+000000:[a#0,SET-z#42,DEL] seqnums:[0-0] points:[a#0,SET-z#42,DEL]
   bounds: (smallest=point,largest=point) (0x00000111)
 
 # Rangedels only (single update).
@@ -14,7 +14,7 @@ reset
 extend-point-key-bounds
 a.RANGEDEL.0:z
 ----
-000000:[a#0,RANGEDEL-z#inf,RANGEDEL] points:[a#0,RANGEDEL-z#inf,RANGEDEL]
+000000:[a#0,RANGEDEL-z#inf,RANGEDEL] seqnums:[0-0] points:[a#0,RANGEDEL-z#inf,RANGEDEL]
   bounds: (smallest=point,largest=point) (0x00000111)
 
 # Range keys only (single update).
@@ -25,7 +25,7 @@ reset
 extend-range-key-bounds
 a.RANGEKEYSET.0:z
 ----
-000000:[a#0,RANGEKEYSET-z#inf,RANGEKEYSET] ranges:[a#0,RANGEKEYSET-z#inf,RANGEKEYSET]
+000000:[a#0,RANGEKEYSET-z#inf,RANGEKEYSET] seqnums:[0-0] ranges:[a#0,RANGEKEYSET-z#inf,RANGEKEYSET]
   bounds: (smallest=range,largest=range) (0x00000000)
 
 # Multiple updates with various key kinds.
@@ -36,7 +36,7 @@ reset
 extend-point-key-bounds
 m.SET.0 - n.SET.0
 ----
-000000:[m#0,SET-n#0,SET] points:[m#0,SET-n#0,SET]
+000000:[m#0,SET-n#0,SET] seqnums:[0-0] points:[m#0,SET-n#0,SET]
   bounds: (smallest=point,largest=point) (0x00000111)
 
 # Extend the lower point key bound.
@@ -44,7 +44,7 @@ m.SET.0 - n.SET.0
 extend-point-key-bounds
 j.SET.0 - k.SET.0
 ----
-000000:[j#0,SET-n#0,SET] points:[j#0,SET-n#0,SET]
+000000:[j#0,SET-n#0,SET] seqnums:[0-0] points:[j#0,SET-n#0,SET]
   bounds: (smallest=point,largest=point) (0x00000111)
 
 # Extend the upper point key bound with a rangedel.
@@ -52,7 +52,7 @@ j.SET.0 - k.SET.0
 extend-point-key-bounds
 k.RANGEDEL.0:o
 ----
-000000:[j#0,SET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL]
+000000:[j#0,SET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL]
   bounds: (smallest=point,largest=point) (0x00000111)
 
 # Extend the lower bounds bound with a range key.
@@ -60,7 +60,7 @@ k.RANGEDEL.0:o
 extend-range-key-bounds
 a.RANGEKEYSET.42:m
 ----
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
   bounds: (smallest=range,largest=point) (0x00000101)
 
 # Extend again with a wide range key (equal keys tiebreak on seqnums descending,
@@ -69,7 +69,7 @@ a.RANGEKEYSET.42:m
 extend-range-key-bounds
 a.RANGEKEYSET.0:z
 ----
-000000:[a#42,RANGEKEYSET-z#inf,RANGEKEYSET] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-z#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-z#inf,RANGEKEYSET] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-z#inf,RANGEKEYSET]
   bounds: (smallest=range,largest=range) (0x00000001)
 
 # Extend again with a wide rangedel over the same range.
@@ -77,5 +77,5 @@ a.RANGEKEYSET.0:z
 extend-point-key-bounds
 A.RANGEDEL.0:y
 ----
-000000:[A#0,RANGEDEL-z#inf,RANGEKEYSET] points:[A#0,RANGEDEL-y#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-z#inf,RANGEKEYSET]
+000000:[A#0,RANGEDEL-z#inf,RANGEKEYSET] seqnums:[0-0] points:[A#0,RANGEDEL-y#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-z#inf,RANGEKEYSET]
   bounds: (smallest=point,largest=range) (0x00000011)

--- a/internal/manifest/testdata/level_iterator_filtered
+++ b/internal/manifest/testdata/level_iterator_filtered
@@ -9,9 +9,9 @@ seek-ge n
 seek-ge o
 seek-ge p
 ----
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
 .
 .
 
@@ -22,7 +22,7 @@ seek-ge n
 seek-ge o
 seek-ge p
 ----
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
 .
 .
 .
@@ -44,12 +44,12 @@ seek-lt p
 .
 .
 .
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
 
 iter key-type=ranges
 seek-lt a
@@ -64,15 +64,15 @@ seek-lt o
 seek-lt p
 ----
 .
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
 
 iter key-type=points
 seek-lt a
@@ -83,10 +83,10 @@ prev
 prev
 ----
 .
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
 .
 .
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
 .
 
 iter key-type=ranges
@@ -98,10 +98,10 @@ prev
 prev
 ----
 .
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
 .
 .
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
 .
 
 define
@@ -123,14 +123,14 @@ seek-ge cantalope
 seek-ge d
 seek-ge dragonfruit
 ----
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000001:[c#9,SET-d#2,DEL] points:[c#9,SET-d#2,DEL]
-000001:[c#9,SET-d#2,DEL] points:[c#9,SET-d#2,DEL]
-000001:[c#9,SET-d#2,DEL] points:[c#9,SET-d#2,DEL]
-000001:[c#9,SET-d#2,DEL] points:[c#9,SET-d#2,DEL]
-000002:[e#9,SET-f#2,DEL] points:[e#9,SET-f#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
+000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
+000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
+000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
+000002:[e#9,SET-f#2,DEL] seqnums:[0-0] points:[e#9,SET-f#2,DEL]
 
 iter key-type=points
 seek-lt a
@@ -143,13 +143,13 @@ seek-lt d
 seek-lt dragonfruit
 ----
 .
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000001:[c#9,SET-d#2,DEL] points:[c#9,SET-d#2,DEL]
-000001:[c#9,SET-d#2,DEL] points:[c#9,SET-d#2,DEL]
-000001:[c#9,SET-d#2,DEL] points:[c#9,SET-d#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
+000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
+000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
 
 iter key-type=ranges
 seek-ge a
@@ -223,27 +223,27 @@ seek-ge k
 seek-ge kiwi
 seek-ge l
 ----
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000003:[g#9,SET-g#2,DEL] points:[g#9,SET-g#2,DEL]
-000003:[g#9,SET-g#2,DEL] points:[g#9,SET-g#2,DEL]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000005:[k#9,SET-k#2,DEL] points:[k#9,SET-k#2,DEL]
-000005:[k#9,SET-k#2,DEL] points:[k#9,SET-k#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
+000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
 .
 .
 
@@ -273,28 +273,28 @@ seek-lt kiwi
 seek-lt l
 ----
 .
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000003:[g#9,SET-g#2,DEL] points:[g#9,SET-g#2,DEL]
-000003:[g#9,SET-g#2,DEL] points:[g#9,SET-g#2,DEL]
-000003:[g#9,SET-g#2,DEL] points:[g#9,SET-g#2,DEL]
-000003:[g#9,SET-g#2,DEL] points:[g#9,SET-g#2,DEL]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000005:[k#9,SET-k#2,DEL] points:[k#9,SET-k#2,DEL]
-000005:[k#9,SET-k#2,DEL] points:[k#9,SET-k#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
+000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
 
 
 iter key-type=points
@@ -322,27 +322,27 @@ seek-ge k
 seek-ge kiwi
 seek-ge l
 ----
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000003:[g#9,SET-g#2,DEL] points:[g#9,SET-g#2,DEL]
-000003:[g#9,SET-g#2,DEL] points:[g#9,SET-g#2,DEL]
-000003:[g#9,SET-g#2,DEL] points:[g#9,SET-g#2,DEL]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000005:[k#9,SET-k#2,DEL] points:[k#9,SET-k#2,DEL]
-000005:[k#9,SET-k#2,DEL] points:[k#9,SET-k#2,DEL]
-000005:[k#9,SET-k#2,DEL] points:[k#9,SET-k#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
+000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
+000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
 .
 .
 
@@ -372,28 +372,28 @@ seek-lt kiwi
 seek-lt l
 ----
 .
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000003:[g#9,SET-g#2,DEL] points:[g#9,SET-g#2,DEL]
-000003:[g#9,SET-g#2,DEL] points:[g#9,SET-g#2,DEL]
-000003:[g#9,SET-g#2,DEL] points:[g#9,SET-g#2,DEL]
-000003:[g#9,SET-g#2,DEL] points:[g#9,SET-g#2,DEL]
-000003:[g#9,SET-g#2,DEL] points:[g#9,SET-g#2,DEL]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000005:[k#9,SET-k#2,DEL] points:[k#9,SET-k#2,DEL]
-000005:[k#9,SET-k#2,DEL] points:[k#9,SET-k#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
+000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
 
 iter key-type=ranges
 seek-ge a
@@ -420,25 +420,25 @@ seek-ge k
 seek-ge kiwi
 seek-ge l
 ----
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
 .
 .
 .
@@ -474,24 +474,24 @@ seek-lt l
 .
 .
 .
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
 
 iter key-type=both
 first
@@ -502,12 +502,12 @@ next
 next
 next
 ----
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000003:[g#9,SET-g#2,DEL] points:[g#9,SET-g#2,DEL]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000005:[k#9,SET-k#2,DEL] points:[k#9,SET-k#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
 .
 
 iter key-type=points
@@ -518,11 +518,11 @@ next
 next
 next
 ----
-000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000003:[g#9,SET-g#2,DEL] points:[g#9,SET-g#2,DEL]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000005:[k#9,SET-k#2,DEL] points:[k#9,SET-k#2,DEL]
+000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
 .
 
 iter key-type=ranges
@@ -531,7 +531,7 @@ next
 next
 next
 ----
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
 .

--- a/internal/manifest/testdata/version_check_ordering
+++ b/internal/manifest/testdata/version_check_ordering
@@ -22,8 +22,8 @@ check-ordering
 ----
 L0 files 000001 and 000002 are not properly ordered: <#3-#4> vs <#1-#2>
 0.0:
-  000002:[a#1,SET-b#2,SET] points:[a#1,SET-b#2,SET]
-  000001:[c#3,SET-d#4,SET] points:[c#3,SET-d#4,SET]
+  000002:[a#1,SET-b#2,SET] seqnums:[1-2] points:[a#1,SET-b#2,SET]
+  000001:[c#3,SET-d#4,SET] seqnums:[3-4] points:[c#3,SET-d#4,SET]
 
 check-ordering
 0:
@@ -79,9 +79,9 @@ check-ordering
 ----
 L0 files 000001 and 000002 are not properly ordered: <#3-#3> vs <#1-#2>
 0.1:
-  000002:[a#1,SET-b#2,SET] points:[a#1,SET-b#2,SET]
+  000002:[a#1,SET-b#2,SET] seqnums:[1-2] points:[a#1,SET-b#2,SET]
 0.0:
-  000001:[a#3,SET-d#3,SET] points:[a#3,SET-d#3,SET]
+  000001:[a#3,SET-d#3,SET] seqnums:[3-3] points:[a#3,SET-d#3,SET]
 
 check-ordering
 0:
@@ -90,9 +90,9 @@ check-ordering
 ----
 L0 files 000001 and 000002 are not properly ordered: <#2-#4> vs <#3-#3>
 0.1:
-  000002:[a#3,SET-b#3,SET] points:[a#3,SET-b#3,SET]
+  000002:[a#3,SET-b#3,SET] seqnums:[3-3] points:[a#3,SET-b#3,SET]
 0.0:
-  000001:[a#2,SET-d#4,SET] points:[a#2,SET-d#4,SET]
+  000001:[a#2,SET-d#4,SET] seqnums:[2-4] points:[a#2,SET-d#4,SET]
 
 check-ordering
 0:
@@ -150,7 +150,7 @@ check-ordering
 ----
 L1 : file 000001 has inconsistent bounds: b#1,SET vs a#2,SET
 1:
-  000001:[b#1,SET-a#2,SET] points:[b#1,SET-a#2,SET]
+  000001:[b#1,SET-a#2,SET] seqnums:[0-0] points:[b#1,SET-a#2,SET]
 
 check-ordering
 1:
@@ -166,8 +166,8 @@ check-ordering
 ----
 L1 : file 000002 has inconsistent bounds: d#3,SET vs c#4,SET
 1:
-  000001:[a#1,SET-b#2,SET] points:[a#1,SET-b#2,SET]
-  000002:[d#3,SET-c#4,SET] points:[d#3,SET-c#4,SET]
+  000001:[a#1,SET-b#2,SET] seqnums:[0-0] points:[a#1,SET-b#2,SET]
+  000002:[d#3,SET-c#4,SET] seqnums:[0-0] points:[d#3,SET-c#4,SET]
 
 check-ordering
 1:
@@ -183,8 +183,8 @@ check-ordering
 ----
 L1 files 000001 and 000002 have overlapping ranges: [a#1,SET-b#2,SET] vs [b#2,SET-d#4,SET]
 1:
-  000001:[a#1,SET-b#2,SET] points:[a#1,SET-b#2,SET]
-  000002:[b#2,SET-d#4,SET] points:[b#2,SET-d#4,SET]
+  000001:[a#1,SET-b#2,SET] seqnums:[0-0] points:[a#1,SET-b#2,SET]
+  000002:[b#2,SET-d#4,SET] seqnums:[0-0] points:[b#2,SET-d#4,SET]
 
 check-ordering
 1:
@@ -193,8 +193,8 @@ check-ordering
 ----
 L1 files 000001 and 000002 have overlapping ranges: [a#1,SET-c#2,SET] vs [b#3,SET-d#4,SET]
 1:
-  000001:[a#1,SET-c#2,SET] points:[a#1,SET-c#2,SET]
-  000002:[b#3,SET-d#4,SET] points:[b#3,SET-d#4,SET]
+  000001:[a#1,SET-c#2,SET] seqnums:[0-0] points:[a#1,SET-c#2,SET]
+  000002:[b#3,SET-d#4,SET] seqnums:[0-0] points:[b#3,SET-d#4,SET]
 
 check-ordering
 1:
@@ -213,10 +213,10 @@ check-ordering
 ----
 L2 files 000002 and 000003 have overlapping ranges: [b#3,SET-d#4,SET] vs [c#5,SET-e#6,SET]
 1:
-  000001:[a#1,SET-c#2,SET] points:[a#1,SET-c#2,SET]
+  000001:[a#1,SET-c#2,SET] seqnums:[0-0] points:[a#1,SET-c#2,SET]
 2:
-  000002:[b#3,SET-d#4,SET] points:[b#3,SET-d#4,SET]
-  000003:[c#5,SET-e#6,SET] points:[c#5,SET-e#6,SET]
+  000002:[b#3,SET-d#4,SET] seqnums:[0-0] points:[b#3,SET-d#4,SET]
+  000003:[c#5,SET-e#6,SET] seqnums:[0-0] points:[c#5,SET-e#6,SET]
 
 # Ordering considers tables with just range keys.
 
@@ -234,8 +234,8 @@ check-ordering
 ----
 L0 files 000001 and 000002 are not properly ordered: <#3-#72057594037927935> vs <#1-#72057594037927935>
 0.0:
-  000001:[a#3,RANGEKEYSET-b#inf,RANGEKEYSET] ranges:[a#3,RANGEKEYSET-b#inf,RANGEKEYSET]
-  000002:[c#1,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#1,RANGEKEYSET-d#inf,RANGEKEYSET]
+  000001:[a#3,RANGEKEYSET-b#inf,RANGEKEYSET] seqnums:[3-72057594037927935] ranges:[a#3,RANGEKEYSET-b#inf,RANGEKEYSET]
+  000002:[c#1,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[1-72057594037927935] ranges:[c#1,RANGEKEYSET-d#inf,RANGEKEYSET]
 
 check-ordering
 1:
@@ -251,8 +251,8 @@ check-ordering
 ----
 L1 files 000001 and 000002 are not properly ordered: [c#3,RANGEKEYSET-d#inf,RANGEKEYSET] vs [a#1,RANGEKEYSET-b#inf,RANGEKEYSET]
 1:
-  000001:[c#3,RANGEKEYSET-d#inf,RANGEKEYSET] ranges:[c#3,RANGEKEYSET-d#inf,RANGEKEYSET]
-  000002:[a#1,RANGEKEYSET-b#inf,RANGEKEYSET] ranges:[a#1,RANGEKEYSET-b#inf,RANGEKEYSET]
+  000001:[c#3,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#3,RANGEKEYSET-d#inf,RANGEKEYSET]
+  000002:[a#1,RANGEKEYSET-b#inf,RANGEKEYSET] seqnums:[0-0] ranges:[a#1,RANGEKEYSET-b#inf,RANGEKEYSET]
 
 # Ordering considers tables with both point and range keys.
 
@@ -270,9 +270,9 @@ check-ordering
 ----
 L0 files 000001 and 000002 are not properly ordered: <#1-#4> vs <#1-#2>
 0.1:
-  000002:[c#1,RANGEKEYSET-e#2,SET] points:[d#3,SET-e#2,SET] ranges:[c#1,RANGEKEYSET-d#inf,RANGEKEYSET]
+  000002:[c#1,RANGEKEYSET-e#2,SET] seqnums:[1-2] points:[d#3,SET-e#2,SET] ranges:[c#1,RANGEKEYSET-d#inf,RANGEKEYSET]
 0.0:
-  000001:[a#1,RANGEKEYSET-c#4,SET] points:[b#1,SET-c#4,SET] ranges:[a#1,RANGEKEYSET-b#inf,RANGEKEYSET]
+  000001:[a#1,RANGEKEYSET-c#4,SET] seqnums:[1-4] points:[b#1,SET-c#4,SET] ranges:[a#1,RANGEKEYSET-b#inf,RANGEKEYSET]
 
 check-ordering
 1:
@@ -288,5 +288,5 @@ check-ordering
 ----
 L1 files 000001 and 000002 have overlapping ranges: [a#1,RANGEKEYSET-c#2,SET] vs [c#3,RANGEKEYSET-f#4,SET]
 1:
-  000001:[a#1,RANGEKEYSET-c#2,SET] points:[b#1,SET-c#2,SET] ranges:[a#1,RANGEKEYSET-b#inf,RANGEKEYSET]
-  000002:[c#3,RANGEKEYSET-f#4,SET] points:[e#3,SET-f#4,SET] ranges:[c#3,RANGEKEYSET-e#inf,RANGEKEYSET]
+  000001:[a#1,RANGEKEYSET-c#2,SET] seqnums:[0-0] points:[b#1,SET-c#2,SET] ranges:[a#1,RANGEKEYSET-b#inf,RANGEKEYSET]
+  000002:[c#3,RANGEKEYSET-f#4,SET] seqnums:[0-0] points:[e#3,SET-f#4,SET] ranges:[c#3,RANGEKEYSET-e#inf,RANGEKEYSET]

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -450,8 +450,7 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 	return nil
 }
 
-// String implements fmt.Stringer for a VersionEdit.
-func (v *VersionEdit) String() string {
+func (v *VersionEdit) string(verbose bool, fmtKey base.FormatKey) string {
 	var buf bytes.Buffer
 	if v.ComparerName != "" {
 		fmt.Fprintf(&buf, "  comparer:     %s", v.ComparerName)
@@ -482,7 +481,12 @@ func (v *VersionEdit) String() string {
 		fmt.Fprintf(&buf, "  deleted:       L%d %s\n", df.Level, df.FileNum)
 	}
 	for _, nf := range v.NewFiles {
-		fmt.Fprintf(&buf, "  added:         L%d %s", nf.Level, nf.Meta.String())
+		fmt.Fprintf(&buf, "  added:         L%d", nf.Level)
+		if verbose {
+			fmt.Fprintf(&buf, " %s", nf.Meta.DebugString(fmtKey, true /* verbose */))
+		} else {
+			fmt.Fprintf(&buf, " %s", nf.Meta.String())
+		}
 		if nf.Meta.CreationTime != 0 {
 			fmt.Fprintf(&buf, " (%s)",
 				time.Unix(nf.Meta.CreationTime, 0).UTC().Format(time.RFC3339))
@@ -490,6 +494,16 @@ func (v *VersionEdit) String() string {
 		fmt.Fprintln(&buf)
 	}
 	return buf.String()
+}
+
+// DebugString is a more verbose version of String(). Use this in tests.
+func (v *VersionEdit) DebugString(fmtKey base.FormatKey) string {
+	return v.string(true /* verbose */, fmtKey)
+}
+
+// String implements fmt.Stringer for a VersionEdit.
+func (v *VersionEdit) String() string {
+	return v.string(false /* verbose */, base.DefaultFormatter)
 }
 
 // Encode encodes an edit to the specified writer.

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -388,20 +388,24 @@ func TestFileMetadata_ParseRoundTrip(t *testing.T) {
 	}{
 		{
 			name:  "point keys only",
-			input: "000001:[a#0,SET-z#0,DEL] points:[a#0,SET-z#0,DEL]",
+			input: "000001:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL]",
 		},
 		{
 			name:  "range keys only",
-			input: "000001:[a#0,RANGEKEYSET-z#0,RANGEKEYDEL] ranges:[a#0,RANGEKEYSET-z#0,RANGEKEYDEL]",
+			input: "000001:[a#0,RANGEKEYSET-z#0,RANGEKEYDEL] seqnums:[0-0] ranges:[a#0,RANGEKEYSET-z#0,RANGEKEYDEL]",
 		},
 		{
 			name:  "point and range keys",
-			input: "000001:[a#0,RANGEKEYSET-d#0,DEL] points:[b#0,SET-d#0,DEL] ranges:[a#0,RANGEKEYSET-c#0,RANGEKEYDEL]",
+			input: "000001:[a#0,RANGEKEYSET-d#0,DEL] seqnums:[0-0] points:[b#0,SET-d#0,DEL] ranges:[a#0,RANGEKEYSET-c#0,RANGEKEYDEL]",
+		},
+		{
+			name:  "point and range keys with nonzero senums",
+			input: "000001:[a#3,RANGEKEYSET-d#4,DEL] seqnums:[3-7] points:[b#3,SET-d#4,DEL] ranges:[a#3,RANGEKEYSET-c#5,RANGEKEYDEL]",
 		},
 		{
 			name:   "whitespace",
 			input:  " 000001 : [ a#0,SET - z#0,DEL] points : [ a#0,SET - z#0,DEL] ",
-			output: "000001:[a#0,SET-z#0,DEL] points:[a#0,SET-z#0,DEL]",
+			output: "000001:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL]",
 		},
 	}
 	for _, tc := range testCases {

--- a/testdata/compaction_picker_scores
+++ b/testdata/compaction_picker_scores
@@ -206,11 +206,11 @@ L6  	385 K  -
 lsm verbose
 ----
 5:
-  000004:[aa#2,SET-dd#2,SET] points:[aa#2,SET-dd#2,SET]
-  000005:[e#2,SET-e#2,SET] points:[e#2,SET-e#2,SET]
+  000004:[aa#2,SET-dd#2,SET] seqnums:[2-2] points:[aa#2,SET-dd#2,SET]
+  000005:[e#2,SET-e#2,SET] seqnums:[2-2] points:[e#2,SET-e#2,SET]
 6:
-  000006:[a#1,SET-d#1,SET] points:[a#1,SET-d#1,SET]
-  000007:[e#1,SET-e#1,SET] points:[e#1,SET-e#1,SET]
+  000006:[a#1,SET-d#1,SET] seqnums:[1-1] points:[a#1,SET-d#1,SET]
+  000007:[e#1,SET-e#1,SET] seqnums:[1-1] points:[e#1,SET-e#1,SET]
 
 # Attempting to schedule a compaction should begin a L5->L6 compaction.
 

--- a/testdata/excise
+++ b/testdata/excise
@@ -33,8 +33,8 @@ excise c k
 would excise 2 files, use ingest-and-excise to excise.
   deleted:       L0 000006
   deleted:       L6 000004
-  added:         L6 000007:[a#10,1-a#10,1]
-  added:         L6 000008:[l#10,1-l#10,1]
+  added:         L6 000007:[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET]
+  added:         L6 000008:[l#10,SET-l#10,SET] seqnums:[10-10] points:[l#10,SET-l#10,SET]
 
 
 excise a e
@@ -42,33 +42,33 @@ excise a e
 would excise 2 files, use ingest-and-excise to excise.
   deleted:       L0 000006
   deleted:       L6 000004
-  added:         L0 000009:[f#12,1-f#12,1]
-  added:         L6 000010:[l#10,1-l#10,1]
+  added:         L0 000009:[f#12,SET-f#12,SET] seqnums:[11-12] points:[f#12,SET-f#12,SET]
+  added:         L6 000010:[l#10,SET-l#10,SET] seqnums:[10-10] points:[l#10,SET-l#10,SET]
 
 excise e z
 ----
 would excise 2 files, use ingest-and-excise to excise.
   deleted:       L0 000006
   deleted:       L6 000004
-  added:         L0 000011:[d#11,1-d#11,1]
-  added:         L6 000012:[a#10,1-a#10,1]
+  added:         L0 000011:[d#11,SET-d#11,SET] seqnums:[11-12] points:[d#11,SET-d#11,SET]
+  added:         L6 000012:[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET]
 
 excise f l
 ----
 would excise 2 files, use ingest-and-excise to excise.
   deleted:       L0 000006
   deleted:       L6 000004
-  added:         L0 000013:[d#11,1-d#11,1]
-  added:         L6 000014:[a#10,1-a#10,1]
-  added:         L6 000015:[l#10,1-l#10,1]
+  added:         L0 000013:[d#11,SET-d#11,SET] seqnums:[11-12] points:[d#11,SET-d#11,SET]
+  added:         L6 000014:[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET]
+  added:         L6 000015:[l#10,SET-l#10,SET] seqnums:[10-10] points:[l#10,SET-l#10,SET]
 
 excise f ll
 ----
 would excise 2 files, use ingest-and-excise to excise.
   deleted:       L0 000006
   deleted:       L6 000004
-  added:         L0 000016:[d#11,1-d#11,1]
-  added:         L6 000017:[a#10,1-a#10,1]
+  added:         L0 000016:[d#11,SET-d#11,SET] seqnums:[11-12] points:[d#11,SET-d#11,SET]
+  added:         L6 000017:[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET]
 
 excise p q
 ----
@@ -138,14 +138,14 @@ excise f g
 ----
 would excise 1 files, use ingest-and-excise to excise.
   deleted:       L0 000005
-  added:         L0 000006:[b#11,1-b#11,1]
-  added:         L0 000007:[g#11,15-i#72057594037927935,15]
+  added:         L0 000006:[b#11,SET-b#11,SET] seqnums:[11-11] points:[b#11,SET-b#11,SET]
+  added:         L0 000007:[g#11,RANGEDEL-i#inf,RANGEDEL] seqnums:[11-11] points:[g#11,RANGEDEL-i#inf,RANGEDEL]
 
 excise b c
 ----
 would excise 1 files, use ingest-and-excise to excise.
   deleted:       L0 000005
-  added:         L0 000008:[g#11,15-i#72057594037927935,15]
+  added:         L0 000008:[g#11,RANGEDEL-i#inf,RANGEDEL] seqnums:[11-11] points:[g#11,RANGEDEL-i#inf,RANGEDEL]
 
 excise i j
 ----
@@ -159,6 +159,6 @@ excise c d
 would excise 2 files, use ingest-and-excise to excise.
   deleted:       L0 000005
   deleted:       L6 000004
-  added:         L0 000009:[b#11,1-b#11,1]
-  added:         L0 000010:[g#11,15-i#72057594037927935,15]
-  added:         L6 000011:[d#10,21-f#72057594037927935,21]
+  added:         L0 000009:[b#11,SET-b#11,SET] seqnums:[11-11] points:[b#11,SET-b#11,SET]
+  added:         L0 000010:[g#11,RANGEDEL-i#inf,RANGEDEL] seqnums:[11-11] points:[g#11,RANGEDEL-i#inf,RANGEDEL]
+  added:         L6 000011:[d#10,RANGEKEYSET-f#inf,RANGEKEYSET] seqnums:[10-10] ranges:[d#10,RANGEKEYSET-f#inf,RANGEKEYSET]

--- a/testdata/format_major_version_split_user_key_migration
+++ b/testdata/format_major_version_split_user_key_migration
@@ -3,7 +3,7 @@ L1
 d.SET.110:d e.SET.140:e
 ----
 1:
-  000004:[d#110,SET-e#140,SET] points:[d#110,SET-e#140,SET]
+  000004:[d#110,SET-e#140,SET] seqnums:[110-140] points:[d#110,SET-e#140,SET]
 
 reopen
 ----
@@ -21,8 +21,8 @@ set d d
 force-ingest paths=(cd) level=1
 ----
 1:
-  000008:[c#141,SET-d#141,SET] points:[c#141,SET-d#141,SET]
-  000004:[d#110,SET-e#140,SET] points:[d#110,SET-e#140,SET]
+  000008:[c#141,SET-d#141,SET] seqnums:[141-141] points:[c#141,SET-d#141,SET]
+  000004:[d#110,SET-e#140,SET] seqnums:[110-140] points:[d#110,SET-e#140,SET]
 
 format-major-version
 ----
@@ -90,9 +90,9 @@ L1
 x.SET.0:x y.SET.5:y
 ----
 1:
-  000004:[b#0,SET-c#5,SET] points:[b#0,SET-c#5,SET]
-  000005:[l#5,SET-m#0,SET] points:[l#5,SET-m#0,SET]
-  000006:[x#0,SET-y#5,SET] points:[x#0,SET-y#5,SET]
+  000004:[b#0,SET-c#5,SET] seqnums:[0-5] points:[b#0,SET-c#5,SET]
+  000005:[l#5,SET-m#0,SET] seqnums:[0-5] points:[l#5,SET-m#0,SET]
+  000006:[x#0,SET-y#5,SET] seqnums:[0-5] points:[x#0,SET-y#5,SET]
 
 build ab
 set a a
@@ -107,11 +107,11 @@ set x x
 force-ingest paths=(ab, wx) level=1
 ----
 1:
-  000007:[a#10,SET-b#10,SET] points:[a#10,SET-b#10,SET]
-  000004:[b#0,SET-c#5,SET] points:[b#0,SET-c#5,SET]
-  000005:[l#5,SET-m#0,SET] points:[l#5,SET-m#0,SET]
-  000008:[w#11,SET-x#11,SET] points:[w#11,SET-x#11,SET]
-  000006:[x#0,SET-y#5,SET] points:[x#0,SET-y#5,SET]
+  000007:[a#10,SET-b#10,SET] seqnums:[10-10] points:[a#10,SET-b#10,SET]
+  000004:[b#0,SET-c#5,SET] seqnums:[0-5] points:[b#0,SET-c#5,SET]
+  000005:[l#5,SET-m#0,SET] seqnums:[0-5] points:[l#5,SET-m#0,SET]
+  000008:[w#11,SET-x#11,SET] seqnums:[11-11] points:[w#11,SET-x#11,SET]
+  000006:[x#0,SET-y#5,SET] seqnums:[0-5] points:[x#0,SET-y#5,SET]
 
 format-major-version
 ----

--- a/testdata/marked_for_compaction
+++ b/testdata/marked_for_compaction
@@ -6,9 +6,9 @@ L1
   d.SET.0:foo
 ----
 0.0:
-  000004:[c#11,SET-c#11,SET] points:[c#11,SET-c#11,SET]
+  000004:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET]
 1:
-  000005:[c#0,SET-d#0,SET] points:[c#0,SET-d#0,SET]
+  000005:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET]
 
 mark-for-compaction file=000005
 ----
@@ -23,6 +23,6 @@ maybe-compact
 [JOB 100] compacted(rewrite) L1 [000005] (670 B) + L1 [] (0 B) -> L1 [000006] (670 B), in 1.0s (2.0s total), output rate 670 B/s
 [JOB 100] compacted(rewrite) L0 [000004] (665 B) + L0 [] (0 B) -> L0 [000007] (665 B), in 1.0s (2.0s total), output rate 665 B/s
 0.0:
-  000007:[c#11,SET-c#11,SET] points:[c#11,SET-c#11,SET]
+  000007:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET]
 1:
-  000006:[c#0,SET-d#0,SET] points:[c#0,SET-d#0,SET]
+  000006:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET]


### PR DESCRIPTION
Previously, we were leaving the Smallest,Largest SeqNum fields unset in the FileMetadata after we did an excise. This broke snapshot handling even if we weren't reading an excised key range through a snapshot; this is because we could excise a file that has an open snapshot reading some keys but not the exciseed keys, and the new file would contain zero seqnums in its FileMetadata, resulting in incorrect results.

This change fixes this bug, and improves a lot of datadriven testing across the project to better test for seqnum fields in the FileMetadata.