### PR TITLE
*: allow virtual sstables to truncate range keys/dels

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1410,7 +1410,7 @@ func (c *compaction) newInputIter(
 			// any range tombstones completely outside file bounds.
 			rangeDelIter = keyspan.Truncate(
 				c.cmp, rangeDelIter, lowerBound.UserKey, upperBound.UserKey,
-				&f.Smallest, &f.Largest, false, /* panicOnPartialOverlap */
+				&f.Smallest, &f.Largest, false, /* panicOnUpperTruncate */
 			)
 		}
 		if rangeDelIter == nil {

--- a/ingest.go
+++ b/ingest.go
@@ -84,6 +84,10 @@ func ingestValidateKey(opts *Options, key *InternalKey) error {
 func ingestLoad1Shared(
 	opts *Options, sm SharedSSTMeta, fileNum base.DiskFileNum,
 ) (*fileMetadata, error) {
+	if sm.Size == 0 {
+		// Disallow 0 file sizes
+		return nil, errors.New("pebble: cannot ingest shared file with size 0")
+	}
 	// Don't load table stats. Doing a round trip to shared storage, one SST
 	// at a time is not worth it as it slows down ingestion.
 	meta := &fileMetadata{}
@@ -103,7 +107,9 @@ func ingestLoad1Shared(
 		meta.SmallestRangeKey = sm.SmallestRangeKey
 		meta.LargestRangeKey = sm.LargestRangeKey
 		meta.SmallestRangeKey.SetSeqNum(seqNum)
-		meta.LargestRangeKey.SetSeqNum(seqNum)
+		if !meta.LargestRangeKey.IsExclusiveSentinel() {
+			meta.LargestRangeKey.SetSeqNum(seqNum)
+		}
 		meta.SmallestSeqNum = seqNum
 		meta.LargestSeqNum = seqNum
 		// Initialize meta.{Smallest,Largest} and others by calling this.
@@ -114,7 +120,9 @@ func ingestLoad1Shared(
 		meta.SmallestPointKey = sm.SmallestPointKey
 		meta.LargestPointKey = sm.LargestPointKey
 		meta.SmallestPointKey.SetSeqNum(seqNum)
-		meta.LargestPointKey.SetSeqNum(seqNum)
+		if !meta.LargestPointKey.IsExclusiveSentinel() {
+			meta.LargestPointKey.SetSeqNum(seqNum)
+		}
 		meta.SmallestSeqNum = seqNum
 		meta.LargestSeqNum = seqNum
 		// Initialize meta.{Smallest,Largest} and others by calling this.
@@ -356,7 +364,7 @@ func ingestSortAndVerify(cmp Compare, lr ingestLoadResult, exciseSpan KeyRange) 
 	for i := range lr.sharedMeta {
 		f := lr.sharedMeta[i]
 		if !exciseSpan.Contains(cmp, f.Smallest) || !exciseSpan.Contains(cmp, f.Largest) {
-			return errors.AssertionFailedf("pebble: shared file outside of excise span")
+			return errors.AssertionFailedf("pebble: shared file outside of excise span, span [%s-%s), file = %s", exciseSpan.Start, exciseSpan.End, f.String())
 		}
 	}
 	if len(lr.localMeta) <= 1 || len(lr.localPaths) <= 1 {
@@ -453,6 +461,20 @@ func ingestLink(
 		return err
 	}
 	for i := range sharedObjMetas {
+		// One corner case around file sizes we need to be mindful of, is that
+		// if one of the shareObjs was initially created by us (and has boomeranged
+		// back from another node), we'll need to update the FileBacking's size
+		// to be the true underlying size. Otherwise, we could hit errors when we
+		// open the db again after a crash/restart (see checkConsistency in open.go),
+		// plus it more accurately allows us to prioritize compactions of files
+		// that were originally created by us.
+		if !objProvider.IsForeign(sharedObjMetas[i]) {
+			size, err := objProvider.Size(sharedObjMetas[i])
+			if err != nil {
+				return err
+			}
+			lr.sharedMeta[i].FileBacking.Size = uint64(size)
+		}
 		if opts.EventListener.TableCreated != nil {
 			opts.EventListener.TableCreated(TableCreateInfo{
 				JobID:   jobID,
@@ -1455,6 +1477,13 @@ func (d *DB) excise(
 			if err != nil {
 				return nil, err
 			}
+			if leftFile.Size == 0 {
+				// On occasion, estimateSize gives us a low estimate, i.e. a 0 file size,
+				// such as if the excised file only has range keys/dels and no point
+				// keys. This can cause panics in places where we divide by file sizes.
+				// Correct for it here.
+				leftFile.Size = 1
+			}
 			if err := leftFile.Validate(d.cmp, d.opts.Comparer.FormatKey); err != nil {
 				return nil, err
 			}
@@ -1557,6 +1586,13 @@ func (d *DB) excise(
 		rightFile.Size, err = d.tableCache.estimateSize(m, rightFile.Smallest.UserKey, rightFile.Largest.UserKey)
 		if err != nil {
 			return nil, err
+		}
+		if rightFile.Size == 0 {
+			// On occasion, estimateSize gives us a low estimate, i.e. a 0 file size,
+			// such as if the excised file only has range keys/dels and no point keys.
+			// This can cause panics in places where we divide by file sizes. Correct
+			// for it here.
+			rightFile.Size = 1
 		}
 		ve.NewFiles = append(ve.NewFiles, newFileEntry{Level: level, Meta: rightFile})
 		if !backingTableCreated {

--- a/internal/keyspan/truncate.go
+++ b/internal/keyspan/truncate.go
@@ -14,7 +14,7 @@ func Truncate(
 	iter FragmentIterator,
 	lower, upper []byte,
 	start, end *base.InternalKey,
-	panicOnPartialOverlap bool,
+	panicOnUpperTruncate bool,
 ) FragmentIterator {
 	return Filter(iter, func(in *Span, out *Span) (keep bool) {
 		out.Start, out.End = in.Start, in.End
@@ -57,7 +57,6 @@ func Truncate(
 		var truncated bool
 		// Truncate the bounds to lower and upper.
 		if cmp(in.Start, lower) < 0 {
-			truncated = true
 			out.Start = lower
 		}
 		if cmp(in.End, upper) > 0 {
@@ -65,8 +64,8 @@ func Truncate(
 			out.End = upper
 		}
 
-		if panicOnPartialOverlap && truncated {
-			panic("pebble: bounds should not be truncated")
+		if panicOnUpperTruncate && truncated {
+			panic("pebble: upper bound should not be truncated")
 		}
 
 		return !out.Empty() && cmp(out.Start, out.End) < 0

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -288,6 +288,33 @@ type PhysicalFileMeta struct {
 // VirtualFileMeta is used by functions which want a guarantee that their input
 // belongs to a virtual sst and not a physical sst.
 //
+// A VirtualFileMeta inherits all the same fields as a FileMetadata. These
+// fields have additional invariants imposed on them, and/or slightly varying
+// meanings:
+//   - Smallest and Largest (and their counterparts
+//     {Smallest, Largest}{Point,Range}Key) remain tight bounds that represent a
+//     key at that exact bound. We make the effort to determine the next smallest
+//     or largest key in an sstable after virtualizing it, to maintain this
+//     tightness. If the largest is a sentinel key (IsExclusiveSentinel()), it
+//     could mean that a rangedel or range key ends at that user key, or has been
+//     truncated to that user key.
+//   - One invariant is that if a rangedel or range key is truncated on its
+//     upper bound, the virtual sstable *must* have a rangedel or range key
+//     sentinel key as its upper bound. This is because truncation yields
+//     an exclusive upper bound for the rangedel/rangekey, and if there are
+//     any points at that exclusive upper bound within the same virtual
+//     sstable, those could get uncovered by this truncation. We enforce this
+//     invariant in calls to keyspan.Truncate.
+//   - Size is an estimate of the size of the virtualized portion of this sstable.
+//     The underlying file's size is stored in FileBacking.Size, though it could
+//     also be estimated or could correspond to just the referenced portion of
+//     a file (eg. if the file originated on another node).
+//   - SmallestSeqNum and LargestSeqNum are loose bounds for virtual sstables.
+//     This means that all keys in the virtual sstable must have seqnums within
+//     [SmallestSeqNum, LargestSeqNum], however there's no guarantee that there's
+//     a key with a seqnum at either of the bounds. Calculating tight seqnum
+//     bounds would be too expensive and deliver little value.
+//
 // NB: This type should only be constructed by calling FileMetadata.VirtualMeta.
 type VirtualFileMeta struct {
 	*FileMetadata

--- a/open.go
+++ b/open.go
@@ -1086,9 +1086,15 @@ func checkConsistency(v *manifest.Version, dirname string, objProvider objstorag
 			dedup[backingState.DiskFileNum] = struct{}{}
 			fileNum := backingState.DiskFileNum
 			fileSize := backingState.Size
+			// We allow foreign objects to have a mismatch between sizes. This is
+			// because we might skew the backing size stored by our objprovider
+			// to prevent us from over-prioritizing this file for compaction.
 			meta, err := objProvider.Lookup(base.FileTypeTable, fileNum)
 			var size int64
 			if err == nil {
+				if objProvider.IsForeign(meta) {
+					continue
+				}
 				size, err = objProvider.Size(meta)
 			}
 			if err != nil {

--- a/table_stats.go
+++ b/table_stats.go
@@ -886,7 +886,7 @@ func newCombinedDeletionKeyspanIter(
 		// See docs/range_deletions.md for why this is necessary.
 		iter = keyspan.Truncate(
 			comparer.Compare, iter, m.Smallest.UserKey, m.Largest.UserKey,
-			nil, nil, false, /* panicOnPartialOverlap */
+			nil, nil, false, /* panicOnUpperTruncate */
 		)
 		mIter.AddLevel(iter)
 	}

--- a/testdata/ingest_shared
+++ b/testdata/ingest_shared
@@ -479,7 +479,7 @@ lsm
 0.0:
   000004:[a@3#10,SET-c@9#10,SET]
 5:
-  000005:[b#2,RANGEDEL-d#2,RANGEDEL]
+  000005:[b#2,RANGEDEL-d#inf,RANGEDEL]
 6:
   000006:[a@3#1,SET-e#1,SET]
 
@@ -569,3 +569,183 @@ b: (bcd, . UPDATED)
 c: (cde, .)
 d: (foobar, .)
 e: (barbaz, .)
+
+reset
+----
+
+switch 1
+----
+ok
+
+batch
+set a@3 o
+set b@5 foo
+set c@6 bar
+set e baz
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+build s2
+del-range bb g
+----
+
+ingest s2
+----
+
+lsm
+----
+5:
+  000006:[bb#14,RANGEDEL-g#inf,RANGEDEL]
+6:
+  000005:[a@3#10,SET-e#13,SET]
+
+switch 2
+----
+ok
+
+batch
+set ff notdeleted
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+lsm
+----
+6:
+  000005:[ff#10,SET-ff#10,SET]
+
+# This replication should truncate the range deletion in pebble instance 1
+# at f, leaving ff undeleted.
+
+replicate 1 2 b f
+----
+replicated 2 shared SSTs
+
+lsm
+----
+5:
+  000007:[bb#2,RANGEDEL-f#inf,RANGEDEL]
+6:
+  000008:[b@5#1,SET-e#1,SET]
+  000005:[ff#10,SET-ff#10,SET]
+
+iter
+seek-ge b
+next
+next
+----
+b@5: (foo, .)
+ff: (notdeleted, .)
+.
+
+# Same as above, but with a truncated range key instead of a truncated range del.
+
+reset
+----
+
+switch 1
+----
+ok
+
+batch
+set a@3 o
+set b@5 foo
+set c@6 bar
+set e baz
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+build s3
+range-key-set bb g @8 foo
+----
+
+ingest s3
+----
+
+lsm
+----
+5:
+  000006:[bb#14,RANGEKEYSET-g#inf,RANGEKEYSET]
+6:
+  000005:[a@3#10,SET-e#13,SET]
+
+switch 2
+----
+ok
+
+batch
+set ff notcovered
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+lsm
+----
+6:
+  000005:[ff#10,SET-ff#10,SET]
+
+# This replication should truncate the range key in pebble instance 1
+# at f, leaving ff uncovered.
+
+replicate 1 2 b f
+----
+replicated 2 shared SSTs
+
+lsm
+----
+5:
+  000007:[bb#2,RANGEKEYSET-f#inf,RANGEKEYSET]
+6:
+  000008:[b@5#1,SET-e#1,SET]
+  000005:[ff#10,SET-ff#10,SET]
+
+iter
+seek-ge b
+next
+next
+next
+next
+next
+----
+b@5: (foo, .)
+bb: (., [bb-f) @8=foo UPDATED)
+c@6: (bar, [bb-f) @8=foo)
+e: (baz, [bb-f) @8=foo)
+ff: (notcovered, . UPDATED)
+.
+
+
+iter mask-filter mask-suffix=@9
+seek-ge b
+next
+next
+next
+next
+----
+b@5: (foo, .)
+bb: (., [bb-f) @8=foo UPDATED)
+e: (baz, [bb-f) @8=foo)
+ff: (notcovered, . UPDATED)
+.


### PR DESCRIPTION
Previously, our virtual sstable read code panicked if we saw a rangedel or rangekey get truncated at a virtual sstable file bound. While this is rare, this is an allowable use of virtual sstables in Cockroach and one that will (on rare occasion) happen organically, eg. when there are two range dels or range keys that abut each other while in different KV ranges (thereby getting defragmented by Pebble, which isn't aware of CockroachDB ranges).

Also add a guard against 0 filesizes, which can cause panics in compaction code.