### PR TITLE
metamorphic: Fixes duplicate batch close issue

### DIFF
--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -84,7 +84,7 @@ func (o *applyOp) run(t *test, h historyRecorder) {
 		err = w.Apply(b, t.writeOpts)
 	}
 	h.Recordf("%s // %v", o, err)
-	_ = b.Close()
+	// batch will be closed by a closeOp which is guaranteed to be generated
 }
 
 func (o *applyOp) String() string  { return fmt.Sprintf("%s.Apply(%s)", o.writerID, o.batchID) }


### PR DESCRIPTION
Fixes the issue where a batch is closed twice when adding a closeOp after an applyOp. The `batch.close()` call in `applyOp.run` has been removed.

Fixes: #2671