### PR TITLE
pebble: Fix TestManualCompaction Flaky Test

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1248,9 +1248,6 @@ func TestValidateVersionEdit(t *testing.T) {
 }
 
 func TestManualCompaction(t *testing.T) {
-	// skip flaky test until fixed (https://github.com/cockroachdb/pebble/issues/2613)
-	t.Skip()
-
 	var mem vfs.FS
 	var d *DB
 	defer func() {
@@ -1589,7 +1586,7 @@ func TestManualCompaction(t *testing.T) {
 		},
 		{
 			testData:   "testdata/manual_compaction_set_with_del",
-			minVersion: FormatSetWithDelete,
+			minVersion: FormatBlockPropertyCollector,
 			maxVersion: FormatPrePebblev1MarkedCompacted,
 		},
 		{


### PR DESCRIPTION
This change ensures that `TestManualCompaction` uses table format `TableFormatPebblev1` as the size of the sstable properties block was changed in the following pr https://github.com/cockroachdb/pebble/pull/2585

Fixes: #2613