### PR TITLE
sharedcache: add test cases that randomize block sizes

### DIFF
--- a/objstorage/objstorageprovider/provider.go
+++ b/objstorage/objstorageprovider/provider.go
@@ -109,6 +109,15 @@ type Settings struct {
 		// CacheBlockSize is the block size of the cache; if 0, the default of 32KB is used.
 		CacheBlockSize int
 
+		// ShardingBlockSize is the size of a shard block. The cache is split into contiguous
+		// ShardingBlockSize units. The units are distributed across multiple independent shards
+		// of the cache, via a hash(offset) modulo num shards operation. The cache replacement
+		// policies operate at the level of shard, not whole cache. This is done to reduce lock
+		// contention.
+		//
+		// If ShardingBlockSize is 0, the default of 1 MB is used.
+		ShardingBlockSize int64
+
 		// The number of independent shards the cache leverages. Each shard is the same size,
 		// and a hash of filenum & offset map a read to a certain shard. If set to 0,
 		// 2*runtime.GOMAXPROCS is used as the shard count.

--- a/objstorage/objstorageprovider/shared.go
+++ b/objstorage/objstorageprovider/shared.go
@@ -71,12 +71,19 @@ func (p *provider) sharedInit() error {
 			blockSize = defaultBlockSize
 		}
 
+		const defaultShardingBlockSize = 1024 * 1024
+		shardingBlockSize := p.st.Shared.ShardingBlockSize
+		if shardingBlockSize == 0 {
+			shardingBlockSize = defaultShardingBlockSize
+		}
+
 		numShards := p.st.Shared.CacheShardCount
 		if numShards == 0 {
 			numShards = 2 * runtime.GOMAXPROCS(0)
 		}
 
-		p.shared.cache, err = sharedcache.Open(p.st.FS, p.st.Logger, p.st.FSDirName, blockSize, p.st.Shared.CacheSizeBytes, numShards)
+		p.shared.cache, err = sharedcache.Open(
+			p.st.FS, p.st.Logger, p.st.FSDirName, blockSize, shardingBlockSize, p.st.Shared.CacheSizeBytes, numShards)
 		if err != nil {
 			return errors.Wrapf(err, "pebble: could not open shared object cache")
 		}

--- a/objstorage/objstorageprovider/sharedcache/shared_cache_helpers_test.go
+++ b/objstorage/objstorageprovider/sharedcache/shared_cache_helpers_test.go
@@ -1,9 +1,5 @@
 package sharedcache
 
-func ShardingBlockSize() int {
-	return shardingBlockSize
-}
-
 func (c *Cache) Misses() int32 {
 	return c.misses.Load()
 }

--- a/objstorage/objstorageprovider/sharedcache/shared_cache_test.go
+++ b/objstorage/objstorageprovider/sharedcache/shared_cache_test.go
@@ -21,8 +21,9 @@ import (
 func TestSharedCache(t *testing.T) {
 	ctx := context.Background()
 
-	numShards := 32
-	size := int64(sharedcache.ShardingBlockSize() * numShards)
+	const numShards = 32
+	const shardingBlockSize = 1024 * 1024
+	const size = shardingBlockSize * numShards
 
 	datadriven.Walk(t, "testdata/cache", func(t *testing.T, path string) {
 		var log base.InMemLogger
@@ -30,7 +31,8 @@ func TestSharedCache(t *testing.T) {
 			log.Infof("<local fs> "+fmt, args...)
 		})
 
-		cache, err := sharedcache.Open(fs, base.DefaultLogger, "", 32*1024, size, 32)
+		cache, err := sharedcache.Open(
+			fs, base.DefaultLogger, "", 32*1024, shardingBlockSize, size, 32)
 		require.NoError(t, err)
 		defer cache.Close()
 
@@ -130,66 +132,77 @@ func TestSharedCacheRandomized(t *testing.T) {
 
 	helper := func(
 		blockSize int,
-		concurrentReads bool) func(t *testing.T) {
+		shardingBlockSize int64) func(t *testing.T) {
 		return func(t *testing.T) {
-			numShards := rand.Intn(64) + 1
-			cacheSize := int64(sharedcache.ShardingBlockSize() * numShards) // minimum allowed cache size
+			for _, concurrentReads := range []bool{false, true} {
+				t.Run(fmt.Sprintf("concurrentReads=%v", concurrentReads), func(t *testing.T) {
+					numShards := rand.Intn(64) + 1
+					cacheSize := shardingBlockSize * int64(numShards) // minimum allowed cache size
 
-			cache, err := sharedcache.Open(fs, base.DefaultLogger, "", blockSize, cacheSize, numShards)
-			require.NoError(t, err)
-			defer cache.Close()
-
-			writable, _, err := provider.Create(ctx, base.FileTypeTable, base.FileNum(1).DiskFileNum(), objstorage.CreateOptions{})
-			require.NoError(t, err)
-			defer writable.Finish()
-
-			// With invariants on, Write will modify its input buffer.
-			size := rand.Int63n(cacheSize)
-			objData := make([]byte, size)
-			wrote := make([]byte, size)
-			for i := 0; i < int(size); i++ {
-				objData[i] = byte(i)
-				wrote[i] = byte(i)
-			}
-
-			err = writable.Write(wrote)
-			require.NoError(t, err)
-
-			readable, err := provider.OpenForReading(ctx, base.FileTypeTable, base.FileNum(1).DiskFileNum(), objstorage.OpenOptions{})
-			require.NoError(t, err)
-			defer readable.Close()
-
-			const numDistinctReads = 100
-			wg := sync.WaitGroup{}
-			for i := 0; i < numDistinctReads; i++ {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					offset := rand.Int63n(size)
-
-					got := make([]byte, size-offset)
-					err := cache.ReadAt(ctx, base.FileNum(1).DiskFileNum(), got, offset, readable, readable.Size(), sharedcache.ReadFlags{})
+					cache, err := sharedcache.Open(fs, base.DefaultLogger, "", blockSize, shardingBlockSize, cacheSize, numShards)
 					require.NoError(t, err)
-					require.Equal(t, objData[int(offset):], got)
+					defer cache.Close()
 
-					got = make([]byte, size-offset)
-					err = cache.ReadAt(ctx, base.FileNum(1).DiskFileNum(), got, offset, readable, readable.Size(), sharedcache.ReadFlags{})
+					writable, _, err := provider.Create(ctx, base.FileTypeTable, base.FileNum(1).DiskFileNum(), objstorage.CreateOptions{})
 					require.NoError(t, err)
-					require.Equal(t, objData[int(offset):], got)
-				}()
-				// If concurrent reads, only wait 50% of loop iterations on average.
-				if concurrentReads && rand.Intn(2) == 0 {
+
+					// With invariants on, Write will modify its input buffer.
+					size := rand.Int63n(cacheSize)
+					objData := make([]byte, size)
+					wrote := make([]byte, size)
+					for i := 0; i < int(size); i++ {
+						objData[i] = byte(i)
+						wrote[i] = byte(i)
+					}
+
+					require.NoError(t, writable.Write(wrote))
+					require.NoError(t, writable.Finish())
+
+					readable, err := provider.OpenForReading(ctx, base.FileTypeTable, base.FileNum(1).DiskFileNum(), objstorage.OpenOptions{})
+					require.NoError(t, err)
+					defer readable.Close()
+
+					const numDistinctReads = 100
+					wg := sync.WaitGroup{}
+					for i := 0; i < numDistinctReads; i++ {
+						wg.Add(1)
+						go func() {
+							defer wg.Done()
+							offset := rand.Int63n(size)
+
+							got := make([]byte, size-offset)
+							err := cache.ReadAt(ctx, base.FileNum(1).DiskFileNum(), got, offset, readable, readable.Size(), sharedcache.ReadFlags{})
+							require.NoError(t, err)
+							require.Equal(t, objData[int(offset):], got)
+
+							got = make([]byte, size-offset)
+							err = cache.ReadAt(ctx, base.FileNum(1).DiskFileNum(), got, offset, readable, readable.Size(), sharedcache.ReadFlags{})
+							require.NoError(t, err)
+							require.Equal(t, objData[int(offset):], got)
+						}()
+						// If concurrent reads, only wait 50% of loop iterations on average.
+						if concurrentReads && rand.Intn(2) == 0 {
+							wg.Wait()
+						}
+						if !concurrentReads {
+							wg.Wait()
+						}
+					}
 					wg.Wait()
-				}
-				if !concurrentReads {
-					wg.Wait()
-				}
+				})
 			}
-			wg.Wait()
 		}
 	}
-	t.Run("32 KB with serial reads", helper(32*1024, false))
-	t.Run("1 MB with serial reads", helper(1024*1024, false))
-	t.Run("32 KB with concurrent reads", helper(32*1024, true))
-	t.Run("1 MB with concurrent reads", helper(1024*1024, true))
+	t.Run("32 KB block size", helper(32*1024, 1024*1024))
+	t.Run("1 MB block size", helper(1024*1024, 1024*1024))
+
+	for i := 0; i < 5; i++ {
+		exp := rand.Intn(11) + 10   // [10, 20]
+		randomBlockSize := 1 << exp // [1 KB, 1 MB]
+
+		factor := rand.Intn(10) + 1                                // [1, 10]
+		randomShardingBlockSize := int64(randomBlockSize * factor) // [1 KB, 10 MB]
+
+		t.Run("random block and sharding block size", helper(randomBlockSize, randomShardingBlockSize))
+	}
 }


### PR DESCRIPTION
As suggested by @sumeerbhola at https://github.com/cockroachdb/pebble/pull/2561#pullrequestreview-1442486353.

**sharedcache: add test cases that randomize block sizes**

This commit introduces test cases that randomize both the block size & the sharding block size, as suggested by Sumeer with the comment "small block sizes should exercise all the loops relating to slowly filling up the read byte slice".

This commit also fixes a buglet in TestSharedCacheRandomized involving a missing call to writable.Finish.