### PR TITLE
testdata: Fix merge skew in TestManualCompaction

### DIFF
--- a/testdata/manual_compaction_range_keys
+++ b/testdata/manual_compaction_range_keys
@@ -15,34 +15,34 @@ L3
   c.SET.0:v
 ----
 0.0:
-  000004:[a#4,RANGEKEYSET-c#inf,RANGEKEYSET] points:[a#3,SET-a#3,SET] ranges:[a#4,RANGEKEYSET-c#inf,RANGEKEYSET]
+  000004:[a#4,RANGEKEYSET-c#inf,RANGEKEYSET] seqnums:[3-4] points:[a#3,SET-a#3,SET] ranges:[a#4,RANGEKEYSET-c#inf,RANGEKEYSET]
 2:
-  000005:[a#2,SET-a#2,SET] points:[a#2,SET-a#2,SET]
+  000005:[a#2,SET-a#2,SET] seqnums:[2-2] points:[a#2,SET-a#2,SET]
 3:
-  000006:[a#0,SET-c#inf,RANGEKEYSET] points:[a#0,SET-b#0,SET] ranges:[b#1,RANGEKEYSET-c#inf,RANGEKEYSET]
-  000007:[c#0,SET-c#0,SET] points:[c#0,SET-c#0,SET]
+  000006:[a#0,SET-c#inf,RANGEKEYSET] seqnums:[0-1] points:[a#0,SET-b#0,SET] ranges:[b#1,RANGEKEYSET-c#inf,RANGEKEYSET]
+  000007:[c#0,SET-c#0,SET] seqnums:[0-0] points:[c#0,SET-c#0,SET]
 
 compact a-d L0
 ----
 1:
-  000008:[a#4,RANGEKEYSET-c#inf,RANGEKEYSET] points:[a#3,SET-a#3,SET] ranges:[a#4,RANGEKEYSET-c#inf,RANGEKEYSET]
+  000008:[a#4,RANGEKEYSET-c#inf,RANGEKEYSET] seqnums:[3-4] points:[a#3,SET-a#3,SET] ranges:[a#4,RANGEKEYSET-c#inf,RANGEKEYSET]
 2:
-  000005:[a#2,SET-a#2,SET] points:[a#2,SET-a#2,SET]
+  000005:[a#2,SET-a#2,SET] seqnums:[2-2] points:[a#2,SET-a#2,SET]
 3:
-  000006:[a#0,SET-c#inf,RANGEKEYSET] points:[a#0,SET-b#0,SET] ranges:[b#1,RANGEKEYSET-c#inf,RANGEKEYSET]
-  000007:[c#0,SET-c#0,SET] points:[c#0,SET-c#0,SET]
+  000006:[a#0,SET-c#inf,RANGEKEYSET] seqnums:[0-1] points:[a#0,SET-b#0,SET] ranges:[b#1,RANGEKEYSET-c#inf,RANGEKEYSET]
+  000007:[c#0,SET-c#0,SET] seqnums:[0-0] points:[c#0,SET-c#0,SET]
 
 compact a-d L1
 ----
 2:
-  000009:[a#4,RANGEKEYSET-c#inf,RANGEKEYSET] points:[a#3,SET-a#3,SET] ranges:[a#4,RANGEKEYSET-c#inf,RANGEKEYSET]
+  000009:[a#4,RANGEKEYSET-c#inf,RANGEKEYSET] seqnums:[3-4] points:[a#3,SET-a#3,SET] ranges:[a#4,RANGEKEYSET-c#inf,RANGEKEYSET]
 3:
-  000006:[a#0,SET-c#inf,RANGEKEYSET] points:[a#0,SET-b#0,SET] ranges:[b#1,RANGEKEYSET-c#inf,RANGEKEYSET]
-  000007:[c#0,SET-c#0,SET] points:[c#0,SET-c#0,SET]
+  000006:[a#0,SET-c#inf,RANGEKEYSET] seqnums:[0-1] points:[a#0,SET-b#0,SET] ranges:[b#1,RANGEKEYSET-c#inf,RANGEKEYSET]
+  000007:[c#0,SET-c#0,SET] seqnums:[0-0] points:[c#0,SET-c#0,SET]
 
 compact a-d L2
 ----
 3:
-  000010:[a#4,RANGEKEYSET-b#inf,RANGEKEYSET] points:[a#0,SET-a#0,SET] ranges:[a#4,RANGEKEYSET-b#inf,RANGEKEYSET]
-  000011:[b#4,RANGEKEYSET-c#inf,RANGEKEYSET] points:[b#0,SET-b#0,SET] ranges:[b#4,RANGEKEYSET-c#inf,RANGEKEYSET]
-  000007:[c#0,SET-c#0,SET] points:[c#0,SET-c#0,SET]
+  000010:[a#4,RANGEKEYSET-b#inf,RANGEKEYSET] seqnums:[0-4] points:[a#0,SET-a#0,SET] ranges:[a#4,RANGEKEYSET-b#inf,RANGEKEYSET]
+  000011:[b#4,RANGEKEYSET-c#inf,RANGEKEYSET] seqnums:[0-4] points:[b#0,SET-b#0,SET] ranges:[b#4,RANGEKEYSET-c#inf,RANGEKEYSET]
+  000007:[c#0,SET-c#0,SET] seqnums:[0-0] points:[c#0,SET-c#0,SET]


### PR DESCRIPTION
When #2670 merged, it did not incorporate a test change from #2677 that necessitated one more datadriven test rewrite, resulting in broken tests on master. This change fixes the merge skew by running `TestManualCompaction` with `-rewrite` to pick up changes from