### PR TITLE
arenaskl: lift key trailer onto node

### DIFF
--- a/internal/arenaskl/iterator.go
+++ b/internal/arenaskl/iterator.go
@@ -18,7 +18,6 @@
 package arenaskl
 
 import (
-	"encoding/binary"
 	"sync"
 
 	"github.com/cockroachdb/pebble/internal/base"
@@ -240,17 +239,8 @@ func (it *Iterator) SetBounds(lower, upper []byte) {
 }
 
 func (it *Iterator) decodeKey() {
-	b := it.list.arena.getBytes(it.nd.keyOffset, it.nd.keySize)
-	// This is a manual inline of base.DecodeInternalKey, because the Go compiler
-	// seems to refuse to automatically inline it currently.
-	l := len(b) - 8
-	if l >= 0 {
-		it.key.Trailer = binary.LittleEndian.Uint64(b[l:])
-		it.key.UserKey = b[:l:l]
-	} else {
-		it.key.Trailer = uint64(base.InternalKeyKindInvalid)
-		it.key.UserKey = nil
-	}
+	it.key.UserKey = it.list.arena.getBytes(it.nd.keyOffset, it.nd.keySize)
+	it.key.Trailer = it.nd.keyTrailer
 }
 
 func (it *Iterator) seekForBaseSplice(key []byte) (prev, next *node, found bool) {

--- a/internal/arenaskl/skl_test.go
+++ b/internal/arenaskl/skl_test.go
@@ -970,21 +970,3 @@ func BenchmarkSeekPrefixGE(b *testing.B) {
 // 		})
 // 	}
 // }
-
-func TestInvalidInternalKeyDecoding(t *testing.T) {
-	a := newArena(arenaSize)
-
-	// We synthetically fill the arena with an invalid key
-	// that doesn't have an 8 byte trailer.
-	nd, err := newRawNode(a, 1, 1, 1)
-	require.Nil(t, err)
-
-	l := NewSkiplist(a, bytes.Compare)
-	it := Iterator{
-		list: l,
-		nd:   nd,
-	}
-	it.decodeKey()
-	require.Nil(t, it.key.UserKey)
-	require.Equal(t, uint64(base.InternalKeyKindInvalid), it.key.Trailer)
-}


### PR DESCRIPTION
Previously, the memtable keys had their trailer encoded after the user key in the same format used within batches or sstables. This adds some minor overhead during iteration, requiring extracting the trailer before key comparisons. This commit lifts the key trailer up into a field on the node struct. While worthwhile in its own right, this also prepares for multiple nodes within the memtable sharing the same copy of the user key (see #2683).

```
                                       │   old2.txt   │               new2.txt               │
                                       │    sec/op    │    sec/op     vs base                │
ReadWrite/frac_0-24                      455.1n ±  4%   409.1n ±  4%  -10.11% (p=0.000 n=10)
ReadWrite/frac_10-24                     423.4n ±  4%   387.5n ±  4%   -8.46% (p=0.000 n=10)
ReadWrite/frac_20-24                     398.4n ±  6%   365.0n ±  6%   -8.37% (p=0.001 n=10)
ReadWrite/frac_30-24                     368.8n ±  5%   327.3n ±  5%  -11.25% (p=0.000 n=10)
ReadWrite/frac_40-24                     324.8n ±  5%   318.0n ±  4%        ~ (p=0.481 n=10)
ReadWrite/frac_50-24                     305.2n ±  6%   272.9n ±  6%  -10.60% (p=0.000 n=10)
ReadWrite/frac_60-24                     271.2n ±  2%   235.8n ±  7%  -13.06% (p=0.000 n=10)
ReadWrite/frac_70-24                     224.0n ±  8%   211.7n ±  5%        ~ (p=0.052 n=10)
ReadWrite/frac_80-24                     181.5n ±  5%   168.3n ±  3%   -7.22% (p=0.001 n=10)
ReadWrite/frac_90-24                     138.1n ±  5%   131.9n ±  4%   -4.49% (p=0.018 n=10)
ReadWrite/frac_100-24                    3.491n ± 58%   2.922n ± 83%        ~ (p=0.055 n=10)
OrderedWrite-24                          125.3n ±  1%   123.1n ±  0%   -1.76% (p=0.000 n=10)
IterNext-24                              11.46n ±  0%   10.57n ±  0%   -7.81% (p=0.000 n=10)
IterPrev-24                              11.62n ±  1%   10.61n ±  0%   -8.73% (p=0.000 n=10)
SeekPrefixGE/skip=1/use-next=false-24    543.2n ±  1%   482.4n ±  1%  -11.21% (p=0.000 n=10)
SeekPrefixGE/skip=1/use-next=true-24     233.0n ±  1%   228.4n ±  0%   -1.95% (p=0.000 n=10)
SeekPrefixGE/skip=2/use-next=false-24    550.2n ±  1%   492.7n ±  0%  -10.47% (p=0.000 n=10)
SeekPrefixGE/skip=2/use-next=true-24     251.8n ±  1%   247.9n ±  0%   -1.55% (p=0.000 n=10)
SeekPrefixGE/skip=4/use-next=false-24    558.1n ±  1%   499.6n ±  0%  -10.48% (p=0.000 n=10)
SeekPrefixGE/skip=4/use-next=true-24     298.1n ±  1%   288.6n ±  0%   -3.17% (p=0.000 n=10)
SeekPrefixGE/skip=8/use-next=false-24    569.8n ±  1%   508.7n ±  0%  -10.71% (p=0.000 n=10)
SeekPrefixGE/skip=8/use-next=true-24     665.5n ±  2%   604.5n ±  1%   -9.16% (p=0.000 n=10)
SeekPrefixGE/skip=16/use-next=false-24   570.9n ±  1%   513.4n ±  0%  -10.08% (p=0.000 n=10)
SeekPrefixGE/skip=16/use-next=true-24    683.5n ±  1%   610.2n ±  0%  -10.72% (p=0.000 n=10)
geomean                                  216.1n         198.3n         -8.22%
```