### PR TITLE
scan_internal: Fix seqnum comparison

### DIFF
--- a/scan_internal.go
+++ b/scan_internal.go
@@ -907,7 +907,7 @@ func scanInternalImpl(
 				if !objMeta.IsShared() {
 					return errors.Wrapf(ErrInvalidSkipSharedIteration, "file %s is not shared", objMeta.DiskFileNum)
 				}
-				if f.LargestSeqNum > seqNum {
+				if !base.Visible(f.LargestSeqNum, seqNum, base.InternalKeySeqNumMax) {
 					return errors.Wrapf(ErrInvalidSkipSharedIteration, "file %s contains keys newer than snapshot", objMeta.DiskFileNum)
 				}
 				var sst *SharedSSTMeta


### PR DESCRIPTION
Previously, we were returning an error if the largest seqnum of a file was strictly greater than the snapshot seqnum in skip-shared iteration and the file was in a shared level, for consistency reasons. However as snapshots only make visible keys that are strictly less than the snapshot sequence number, the comparison should have been greater than or equals.

This change resolves that by replacing the comparison with a call to base.Visible.