### PR TITLE
pebble: Add option to include `ApproximateSpanBytes` to `db.SSTables()`

### DIFF
--- a/db.go
+++ b/db.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1861,6 +1862,8 @@ type sstablesOptions struct {
 	// if set, return sstables that overlap the key range (end-exclusive)
 	start []byte
 	end   []byte
+
+	withApproximateSpanBytes bool
 }
 
 // SSTablesOption set optional parameter used by `DB.SSTables`.
@@ -1877,11 +1880,21 @@ func WithProperties() SSTablesOption {
 }
 
 // WithKeyRangeFilter ensures returned sstables overlap start and end (end-exclusive)
-// if start and end are both nil these properties have no effect
+// if start and end are both nil these properties have no effect.
 func WithKeyRangeFilter(start, end []byte) SSTablesOption {
 	return func(opt *sstablesOptions) {
 		opt.end = end
 		opt.start = start
+	}
+}
+
+// WithApproximateSpanBytes enables capturing the approximate number of bytes that
+// overlap the provided key span for each sstable.
+// NOTE: this option can only be used with WithKeyRangeFilter and WithProperties
+// provided.
+func WithApproximateSpanBytes() SSTablesOption {
+	return func(opt *sstablesOptions) {
+		opt.withApproximateSpanBytes = true
 	}
 }
 
@@ -1910,6 +1923,13 @@ func (d *DB) SSTables(opts ...SSTablesOption) ([][]SSTableInfo, error) {
 		fn(opt)
 	}
 
+	if opt.withApproximateSpanBytes && !opt.withProperties {
+		return nil, errors.Errorf("Cannot use WithApproximateSpanBytes without WithProperties option.")
+	}
+	if opt.withApproximateSpanBytes && (opt.start == nil || opt.end == nil) {
+		return nil, errors.Errorf("Cannot use WithApproximateSpanBytes without WithKeyRangeFilter option.")
+	}
+
 	// Grab and reference the current readState.
 	readState := d.loadReadState()
 	defer readState.unref()
@@ -1933,6 +1953,7 @@ func (d *DB) SSTables(opts ...SSTablesOption) ([][]SSTableInfo, error) {
 			if opt.start != nil && opt.end != nil && !m.Overlaps(d.opts.Comparer.Compare, opt.start, opt.end, true /* exclusive end */) {
 				continue
 			}
+
 			destTables[j] = SSTableInfo{TableInfo: m.TableInfo()}
 			if opt.withProperties {
 				p, err := d.tableCache.getTableProperties(
@@ -1945,6 +1966,20 @@ func (d *DB) SSTables(opts ...SSTablesOption) ([][]SSTableInfo, error) {
 			}
 			destTables[j].Virtual = m.Virtual
 			destTables[j].BackingSSTNum = m.FileBacking.DiskFileNum.FileNum()
+
+			if opt.withApproximateSpanBytes {
+				var spanBytes uint64
+				if m.ContainedWithinSpan(d.opts.Comparer.Compare, opt.start, opt.end) {
+					spanBytes = m.Size
+				} else {
+					size, err := d.tableCache.estimateSize(m, opt.start, opt.end)
+					if err != nil {
+						return nil, err
+					}
+					spanBytes = size
+				}
+				destTables[j].Properties.UserProperties["approximate-span-bytes"] = strconv.FormatUint(spanBytes, 10)
+			}
 			j++
 		}
 		destLevels[i] = destTables[:j]

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -585,6 +585,13 @@ func (m *FileMetadata) Overlaps(cmp Compare, start []byte, end []byte, exclusive
 	return true
 }
 
+// ContainedWithinSpan returns true if the file key range completely overlaps with the
+// given range ("end" is assumed to exclusive).
+func (m *FileMetadata) ContainedWithinSpan(cmp Compare, start, end []byte) bool {
+	lowerCmp, upperCmp := cmp(m.Smallest.UserKey, start), cmp(m.Largest.UserKey, end)
+	return lowerCmp >= 0 && (upperCmp < 0 || (upperCmp == 0 && m.Largest.IsExclusiveSentinel()))
+}
+
 // ContainsKeyType returns whether or not the file contains keys of the provided
 // type.
 func (m *FileMetadata) ContainsKeyType(kt KeyType) bool {


### PR DESCRIPTION
This change allows an option `WithApproximateSpanBytes` to be included to a `db.SSTables()` call. This will add a metric `approximateSpanBytes` which will be the number of bytes that overlap the given key span.

More detail in https://github.com/cockroachdb/cockroach/issues/102604#issuecomment-1610052155

Informs: https://github.com/cockroachdb/cockroach/issues/102604