### PR TITLE
sharedcache: implement LRU policy

### DIFF
--- a/objstorage/objstorageprovider/sharedcache/shared_cache.go
+++ b/objstorage/objstorageprovider/sharedcache/shared_cache.go
@@ -256,9 +256,21 @@ type shard struct {
 		// TODO(josh): None of these datastructures are space-efficient.
 		// Focusing on correctness to start.
 		where whereMap
-		locks []lockState
-		free  []cacheBlockIndex
+		// blocks[0] is a sentinel block that serves as the head of the LRU list.
+		// blocks[1] is a sentinel block that serves as the head of the free list.
+		blocks []cacheBlockState
+		// Head of LRU list (doubly-linked circular).
+		lruHead cacheBlockIndex
+		// Head of free list (singly-linked chain).
+		freeHead cacheBlockIndex
 	}
+}
+
+type cacheBlockState struct {
+	lock    lockState
+	logical logicalBlockID
+	next    cacheBlockIndex
+	prev    cacheBlockIndex
 }
 
 // Maps a logical block in an SST to an index of the cache block with the
@@ -309,9 +321,11 @@ func (s *shard) init(
 	// cache contents will be over-written, since all metadata is only stored in
 	// memory.
 	s.mu.where = make(whereMap)
-	for i := int64(0); i < sizeInBlocks; i++ {
-		s.mu.locks = append(s.mu.locks, unlocked)
-		s.mu.free = append(s.mu.free, cacheBlockIndex(i))
+	s.mu.blocks = make([]cacheBlockState, sizeInBlocks)
+	s.mu.lruHead = invalidBlockIndex
+	s.mu.freeHead = invalidBlockIndex
+	for i := range s.mu.blocks {
+		s.freePush(cacheBlockIndex(i))
 	}
 
 	return nil
@@ -322,6 +336,59 @@ func (s *shard) close() error {
 		s.file = nil
 	}()
 	return s.file.Close()
+}
+
+// freePush pushes a block to the front of the free list.
+func (s *shard) freePush(index cacheBlockIndex) {
+	s.mu.blocks[index].next = s.mu.freeHead
+	s.mu.freeHead = index
+}
+
+// freePop removes the block from the front of the free list. Must not be called
+// if the list is empty (i.e. freeHead = invalidBlockIndex).
+func (s *shard) freePop() cacheBlockIndex {
+	index := s.mu.freeHead
+	s.mu.freeHead = s.mu.blocks[index].next
+	return index
+}
+
+// lruInsertFront inserts a block at the front of the LRU list.
+func (s *shard) lruInsertFront(index cacheBlockIndex) {
+	b := &s.mu.blocks[index]
+	if s.mu.lruHead == invalidBlockIndex {
+		b.next = index
+		b.prev = index
+	} else {
+		b.next = s.mu.lruHead
+		h := &s.mu.blocks[s.mu.lruHead]
+		b.prev = h.prev
+		s.mu.blocks[h.prev].next = index
+		h.prev = index
+	}
+	s.mu.lruHead = index
+}
+
+func (s *shard) lruNext(index cacheBlockIndex) cacheBlockIndex {
+	return s.mu.blocks[index].next
+}
+
+func (s *shard) lruPrev(index cacheBlockIndex) cacheBlockIndex {
+	return s.mu.blocks[index].prev
+}
+
+// lruUnlink removes a block from the LRU list.
+func (s *shard) lruUnlink(index cacheBlockIndex) {
+	b := &s.mu.blocks[index]
+	if b.next == index {
+		s.mu.lruHead = invalidBlockIndex
+	} else {
+		s.mu.blocks[b.prev].next = b.next
+		s.mu.blocks[b.next].prev = b.prev
+		if s.mu.lruHead == index {
+			s.mu.lruHead = b.next
+		}
+	}
+	b.next, b.prev = invalidBlockIndex, invalidBlockIndex
 }
 
 // get attempts to read the requested data from the shard. The data must not
@@ -365,14 +432,17 @@ func (s *shard) get(fileNum base.DiskFileNum, p []byte, ofs int64) (n int, _ err
 			s.mu.Unlock()
 			return n, nil
 		}
-		if s.mu.locks[cacheBlockIdx] == writeLockTaken {
+		if s.mu.blocks[cacheBlockIdx].lock == writeLockTaken {
 			// In practice, if we have two reads of the same SST block in close succession, we
 			// would expect the second to hit in the in-memory block cache. So it's not worth
 			// optimizing this case here.
 			s.mu.Unlock()
 			return n, nil
 		}
-		s.mu.locks[cacheBlockIdx] += readLockTakenInc
+		s.mu.blocks[cacheBlockIdx].lock += readLockTakenInc
+		// Move to front of the LRU list.
+		s.lruUnlink(cacheBlockIdx)
+		s.lruInsertFront(cacheBlockIdx)
 		s.mu.Unlock()
 
 		readAt := s.bm.BlockOffset(cacheBlockIdx)
@@ -443,43 +513,39 @@ func (s *shard) set(fileNum base.DiskFileNum, p []byte, ofs int64) error {
 
 		// Determine cache block index by looking at the free list and randomly evicting if
 		// it is empty.
-		var cacheBlockInd cacheBlockIndex
-		if len(s.mu.free) == 0 {
-			// TODO(josh): Right now, we do random eviction. Eventually, we will do something
-			// more sophisticated, e.g. leverage ClockPro.
-			foundBlockToEvict := false
-			var k logicalBlockID
-			for k1, v := range s.mu.where {
-				// This implies that hot blocks will not be evicted as often, meaning the
-				// eviction scheme is not quite random. I think that's fine for now, since we plan
-				// to leverage a more sophisticated eviction scheme eventually anyway.
-				lock := s.mu.locks[v]
-				if lock >= readLockTakenInc || lock == writeLockTaken {
-					continue
+		var cacheBlockIdx cacheBlockIndex
+		if s.mu.freeHead == invalidBlockIndex {
+			if invariants.Enabled && s.mu.lruHead == invalidBlockIndex {
+				panic("both LRU and free lists empty")
+			}
+
+			// Find the last element in the LRU list which is not locked.
+			for idx := s.lruPrev(s.mu.lruHead); ; idx = s.lruPrev(idx) {
+				if lock := s.mu.blocks[idx].lock; lock == unlocked {
+					cacheBlockIdx = idx
+					break
 				}
-				foundBlockToEvict = true
-				cacheBlockInd = v
-				k = k1
-				break
+				if idx == s.mu.lruHead {
+					// TODO(josh): We may want to block until a block frees up, instead of returning
+					// an error here. But I think we can do that later on, e.g. after running some production
+					// experiments.
+					s.mu.Unlock()
+					return errors.New("no block to evict so skipping write to cache")
+				}
 			}
-			// TODO(josh): We may want to block until a block frees up, instead of returning
-			// an error here. But I think we can do that later on, e.g. after running some production
-			// experiments.
-			if !foundBlockToEvict {
-				s.mu.Unlock()
-				return errors.New("no block to evict so skipping write to cache")
-			}
-			delete(s.mu.where, k)
+			s.lruUnlink(cacheBlockIdx)
+			delete(s.mu.where, s.mu.blocks[cacheBlockIdx].logical)
 		} else {
-			cacheBlockInd = s.mu.free[len(s.mu.free)-1]
-			s.mu.free = s.mu.free[:len(s.mu.free)-1]
+			cacheBlockIdx = s.freePop()
 		}
 
-		s.mu.where[k] = cacheBlockInd
-		s.mu.locks[cacheBlockInd] = writeLockTaken
+		s.lruInsertFront(cacheBlockIdx)
+		s.mu.where[k] = cacheBlockIdx
+		s.mu.blocks[cacheBlockIdx].logical = k
+		s.mu.blocks[cacheBlockIdx].lock = writeLockTaken
 		s.mu.Unlock()
 
-		writeAt := s.bm.BlockOffset(cacheBlockInd)
+		writeAt := s.bm.BlockOffset(cacheBlockIdx)
 
 		writeSize := s.bm.BlockSize()
 		if len(p[n:]) <= writeSize {
@@ -488,11 +554,16 @@ func (s *shard) set(fileNum base.DiskFileNum, p []byte, ofs int64) error {
 
 		_, err := s.file.WriteAt(p[n:n+writeSize], writeAt)
 		if err != nil {
-			s.freeBlock(k, cacheBlockInd)
+			// Free the block.
+			s.mu.Lock()
+			defer s.mu.Unlock()
+
+			delete(s.mu.where, k)
+			s.lruUnlink(cacheBlockIdx)
+			s.freePush(cacheBlockIdx)
 			return err
 		}
-		s.dropWriteLock(cacheBlockInd)
-
+		s.dropWriteLock(cacheBlockIdx)
 		n += writeSize
 	}
 }
@@ -500,11 +571,9 @@ func (s *shard) set(fileNum base.DiskFileNum, p []byte, ofs int64) error {
 // Doesn't inline currently. This might be okay, but something to keep in mind.
 func (s *shard) dropReadLock(cacheBlockInd cacheBlockIndex) {
 	s.mu.Lock()
-	s.mu.locks[cacheBlockInd] -= readLockTakenInc
-	if invariants.Enabled {
-		if s.mu.locks[cacheBlockInd] < 0 {
-			panic(fmt.Sprintf("unexpected lock state %v in dropReadLock: %v", s.mu.locks[cacheBlockInd], s.mu.locks))
-		}
+	s.mu.blocks[cacheBlockInd].lock -= readLockTakenInc
+	if invariants.Enabled && s.mu.blocks[cacheBlockInd].lock < 0 {
+		panic(fmt.Sprintf("unexpected lock state %v in dropReadLock", s.mu.blocks[cacheBlockInd].lock))
 	}
 	s.mu.Unlock()
 }
@@ -512,21 +581,10 @@ func (s *shard) dropReadLock(cacheBlockInd cacheBlockIndex) {
 // Doesn't inline currently. This might be okay, but something to keep in mind.
 func (s *shard) dropWriteLock(cacheBlockInd cacheBlockIndex) {
 	s.mu.Lock()
-	if invariants.Enabled {
-		if s.mu.locks[cacheBlockInd] != writeLockTaken {
-			panic(fmt.Sprintf("unexpected lock state %v in dropWriteLock: %v", s.mu.locks[cacheBlockInd], s.mu.locks))
-		}
+	if invariants.Enabled && s.mu.blocks[cacheBlockInd].lock != writeLockTaken {
+		panic(fmt.Sprintf("unexpected lock state %v in dropWriteLock", s.mu.blocks[cacheBlockInd].lock))
 	}
-	s.mu.locks[cacheBlockInd] = unlocked
-	s.mu.Unlock()
-}
-
-// Doesn't inline currently. This might be okay, but something to keep in mind.
-func (s *shard) freeBlock(k logicalBlockID, cacheBlockInd cacheBlockIndex) {
-	s.mu.Lock()
-	delete(s.mu.where, k)
-	s.mu.locks[cacheBlockInd] = unlocked
-	s.mu.free = append(s.mu.free, cacheBlockInd)
+	s.mu.blocks[cacheBlockInd].lock = unlocked
 	s.mu.Unlock()
 }
 
@@ -534,36 +592,42 @@ func (s *shard) assertShardStateIsConsistent() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	cacheBlockInds := make(map[cacheBlockIndex]bool)
-	for _, v := range s.mu.where {
-		if cacheBlockInds[v] {
-			panic(fmt.Sprintf("repeated cache block index (where): %v %v %v %v", v, cacheBlockInds, s.mu.where, s.mu.free))
-		}
-		cacheBlockInds[v] = true
-	}
-	for _, v := range s.mu.free {
-		if cacheBlockInds[v] {
-			panic(fmt.Sprintf("repeated cache block index (free): %v %v %v %v", v, cacheBlockInds, s.mu.where, s.mu.free))
-		}
-		cacheBlockInds[v] = true
-	}
-	for i := int64(0); i < s.sizeInBlocks; i++ {
-		if !cacheBlockInds[cacheBlockIndex(i)] {
-			panic(fmt.Sprintf("missing cache block index: %v %v %v %v", i, cacheBlockInds, s.mu.where, s.mu.free))
+	lruLen := 0
+	if s.mu.lruHead != invalidBlockIndex {
+		for b := s.mu.lruHead; ; {
+			lruLen++
+			if idx, ok := s.mu.where[s.mu.blocks[b].logical]; !ok || idx != b {
+				panic("block in LRU list with no entry in where map")
+			}
+			b = s.lruNext(b)
+			if b == s.mu.lruHead {
+				break
+			}
 		}
 	}
-	if int64(len(s.mu.locks)) != s.sizeInBlocks {
-		panic(fmt.Sprintf("lock table isn't correct size: %v %v", len(s.mu.locks), s.sizeInBlocks))
+	if lruLen != len(s.mu.where) {
+		panic(fmt.Sprintf("lru list len is %d but where map has %d entries", lruLen, len(s.mu.where)))
 	}
-	for _, ls := range s.mu.locks {
-		if ls < writeLockTaken {
-			panic(fmt.Sprintf("lock state %v is not allowed: %v", ls, s.mu.locks))
+	freeLen := 0
+	for n := s.mu.freeHead; n != invalidBlockIndex; n = s.mu.blocks[n].next {
+		freeLen++
+	}
+
+	if lruLen+freeLen != int(s.sizeInBlocks) {
+		panic(fmt.Sprintf("%d lru blocks and %d free blocks don't add up to %d", lruLen, freeLen, s.sizeInBlocks))
+	}
+	for i := range s.mu.blocks {
+		if state := s.mu.blocks[i].lock; state < writeLockTaken {
+			panic(fmt.Sprintf("lock state %v is not allowed", state))
 		}
 	}
 }
 
 // cacheBlockIndex is the index of a blockSize-aligned cache block.
 type cacheBlockIndex int64
+
+// invalidBlockIndex is used for the head of a list when the list is empty.
+const invalidBlockIndex cacheBlockIndex = -1
 
 // blockMath is a helper type for performing conversions between offsets and
 // block indexes.

--- a/objstorage/objstorageprovider/sharedcache/shared_cache_internal_test.go
+++ b/objstorage/objstorageprovider/sharedcache/shared_cache_internal_test.go
@@ -1,0 +1,90 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sharedcache
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSharedCacheLruList(t *testing.T) {
+	var s shard
+	s.mu.blocks = make([]cacheBlockState, 100)
+	expect := func(vals ...int) {
+		t.Helper()
+		if s.mu.lruHead == invalidBlockIndex {
+			if len(vals) != 0 {
+				t.Fatalf("expected non-empty list")
+			}
+			return
+		}
+		var list []int
+		prev := s.lruPrev(s.mu.lruHead)
+		b := s.mu.lruHead
+		for {
+			list = append(list, int(b))
+			if s.lruPrev(b) != prev {
+				t.Fatalf("back link broken: %d:next=%d,prev=%d  %d:next=%d,prev=%d",
+					prev, s.lruNext(prev), s.lruPrev(prev),
+					b, s.lruNext(b), s.lruPrev(b),
+				)
+			}
+			prev = b
+			b = s.lruNext(b)
+			if b == s.mu.lruHead {
+				break
+			}
+		}
+		if !reflect.DeepEqual(vals, list) {
+			t.Fatalf("expected %v, got %v", vals, list)
+		}
+	}
+
+	s.mu.lruHead = invalidBlockIndex
+	expect()
+	s.lruInsertFront(1)
+	expect(1)
+	s.lruInsertFront(10)
+	expect(10, 1)
+	s.lruInsertFront(5)
+	expect(5, 10, 1)
+	s.lruUnlink(5)
+	expect(10, 1)
+	s.lruUnlink(1)
+	expect(10)
+	s.lruUnlink(10)
+	expect()
+}
+
+func TestSharedCacheFreeList(t *testing.T) {
+	var s shard
+	s.mu.blocks = make([]cacheBlockState, 100)
+	expect := func(vals ...int) {
+		t.Helper()
+		var list []int
+		for b := s.mu.freeHead; b != invalidBlockIndex; b = s.mu.blocks[b].next {
+			list = append(list, int(b))
+		}
+		if !reflect.DeepEqual(vals, list) {
+			t.Fatalf("expected %v, got %v", vals, list)
+		}
+	}
+	s.mu.freeHead = invalidBlockIndex
+	expect()
+	s.freePush(1)
+	expect(1)
+	s.freePush(10)
+	expect(10, 1)
+	s.freePush(20)
+	expect(20, 10, 1)
+	require.Equal(t, cacheBlockIndex(20), s.freePop())
+	expect(10, 1)
+	require.Equal(t, cacheBlockIndex(10), s.freePop())
+	expect(1)
+	require.Equal(t, cacheBlockIndex(1), s.freePop())
+	expect()
+}

--- a/objstorage/objstorageprovider/sharedcache/shared_cache_test.go
+++ b/objstorage/objstorageprovider/sharedcache/shared_cache_test.go
@@ -21,21 +21,21 @@ import (
 func TestSharedCache(t *testing.T) {
 	ctx := context.Background()
 
-	numShards := 32
-	size := int64(sharedcache.ShardingBlockSize() * numShards)
-
 	datadriven.Walk(t, "testdata/cache", func(t *testing.T, path string) {
 		var log base.InMemLogger
 		fs := vfs.WithLogging(vfs.NewMem(), func(fmt string, args ...interface{}) {
 			log.Infof("<local fs> "+fmt, args...)
 		})
 
-		cache, err := sharedcache.Open(fs, base.DefaultLogger, "", 32*1024, size, 32)
-		require.NoError(t, err)
-		defer cache.Close()
-
 		provider, err := objstorageprovider.Open(objstorageprovider.DefaultSettings(fs, ""))
 		require.NoError(t, err)
+
+		var cache *sharedcache.Cache
+		defer func() {
+			if cache != nil {
+				cache.Close()
+			}
+		}()
 
 		var objData []byte
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
@@ -54,6 +54,23 @@ func TestSharedCache(t *testing.T) {
 
 			log.Reset()
 			switch d.Cmd {
+			case "init":
+				blockSize := 32 * 1024
+				numShards := 32
+				size := 32 * sharedcache.ShardingBlockSize()
+
+				d.MaybeScanArgs(t, "block-size", &blockSize)
+				d.MaybeScanArgs(t, "num-shards", &numShards)
+				d.MaybeScanArgs(t, "size", &size)
+				if size%(numShards*sharedcache.ShardingBlockSize()) != 0 {
+					d.Fatalf(t, "size (%d) must be a multiple of numShards (%d) * shardingBlockSize(%d)",
+						size, numShards, sharedcache.ShardingBlockSize(),
+					)
+				}
+				cache, err = sharedcache.Open(fs, base.DefaultLogger, "", blockSize, int64(size), numShards)
+				require.NoError(t, err)
+				return fmt.Sprintf("initialized with block-size=%d size=%d num-shards=%d", blockSize, size, numShards)
+
 			case "write":
 				var size int
 				scanArgs("<size>", &size)

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/compaction_reads
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/compaction_reads
@@ -1,3 +1,7 @@
+init
+----
+initialized with block-size=32768 size=33554432 num-shards=32
+
 write 200000
 ----
 

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/eof_handling
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/eof_handling
@@ -1,3 +1,7 @@
+init
+----
+initialized with block-size=32768 size=33554432 num-shards=32
+
 write 40000
 ----
 

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/lru
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/lru
@@ -1,0 +1,33 @@
+init num-shards=1 size=1048576
+----
+initialized with block-size=32768 size=1048576 num-shards=1
+
+write 1500000
+----
+
+read 32768 0
+----
+misses=1
+
+read 32768 32768
+----
+misses=1
+
+read 983040 65536
+----
+misses=1
+
+# The cache should now be full with the first MB. Read a new block.
+read 1048576 32768
+----
+misses=1
+
+# The block that was evicted should have been the one at offset 0.
+read 32768 0
+----
+misses=1
+
+# The block that was evicted should have been the one at offset 32768.
+read 32768 32768
+----
+misses=1

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/read_larger_than_two_cache_shards
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/read_larger_than_two_cache_shards
@@ -1,5 +1,9 @@
 # Read larger than two cache shards.
 
+init
+----
+initialized with block-size=32768 size=33554432 num-shards=32
+
 write 3145728
 ----
 

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_blocks
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_blocks
@@ -1,5 +1,9 @@
 # Large read that hits two cache blocks.
 
+init
+----
+initialized with block-size=32768 size=33554432 num-shards=32
+
 write 32773
 ----
 

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_blocks_with_first_read_at_big_offset
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_blocks_with_first_read_at_big_offset
@@ -1,5 +1,9 @@
 # Large read that hits two cache blocks, with first read at big offset.
 
+init
+----
+initialized with block-size=32768 size=33554432 num-shards=32
+
 write 32773
 ----
 

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_blocks_with_first_read_at_offset
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_blocks_with_first_read_at_offset
@@ -1,5 +1,9 @@
 # Large read that hits two cache blocks, with first read at offset.
 
+init
+----
+initialized with block-size=32768 size=33554432 num-shards=32
+
 write 32773
 ----
 

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_shards
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_shards
@@ -1,5 +1,9 @@
 # Large read that hits two cache shards.
 
+init
+----
+initialized with block-size=32768 size=33554432 num-shards=32
+
 write 1048776
 ----
 

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_shards_with_first_read_at_offset
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_shards_with_first_read_at_offset
@@ -1,5 +1,9 @@
 # Large read that hits two cache shards, with first read at offset.
 
+init
+----
+initialized with block-size=32768 size=33554432 num-shards=32
+
 write 1048776
 ----
 

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/small_read
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/small_read
@@ -1,5 +1,9 @@
 # Small read, with one miss then two hits.
 
+init
+----
+initialized with block-size=32768 size=33554432 num-shards=32
+
 write 10
 ----
 

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/small_read_with_first_read_at_offset
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/small_read_with_first_read_at_offset
@@ -1,5 +1,9 @@
 # Small read, with first read at offset.
 
+init
+----
+initialized with block-size=32768 size=33554432 num-shards=32
+
 write 10
 ----
 


### PR DESCRIPTION
This change replaces the current random replacement policy with a simple LRU policy. We maintain a doubly linked circular LRU list and a singly linked free block list.

This will be useful for running more experiments and is a stepping stone to implementing ClockPro.