### PR TITLE
crl-release-23.1: db: improve delete pacing

### DIFF
--- a/db.go
+++ b/db.go
@@ -297,7 +297,7 @@ type DB struct {
 	closed   *atomic.Value
 	closedCh chan struct{}
 
-	deletionLimiter limiter
+	deletionPacer pacer
 
 	// Async deletion jobs spawned by cleaners increment this WaitGroup, and
 	// call Done when completed. Once `d.mu.cleaning` is false, the db.Close()


### PR DESCRIPTION
Delete pacing is currently an on or off decision. If we are running out of space or have too many obsolete bytes in relation to live bytes, we disable pacing. Otherwise we pace at the configured rate (128MB by default in CRDB).

This change improves pacing by keeping track of the average deletion rate over the last 5 minutes and increasing the target rate to match this rate if necessary. The intention is to avoid deletions lagging behind.

Informs #2662.

I have tested this change against a heavy write workload where deletion is known to lag behind (resulting in 10k+ goroutines waiting in the pacer); with the change, the goroutine count is small and stable (after the first 5-10 minutes):
![image](https://github.com/cockroachdb/pebble/assets/16544120/f3a44763-8d18-4770-ae83-4dcb2c124eca)
