### PR TITLE
sharedcache: data-driven test cosmetic improvements

### DIFF
--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/compaction_reads
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/compaction_reads
@@ -2,25 +2,25 @@ init
 ----
 initialized with block-size=32768 size=33554432 num-shards=32
 
-write 200000
+write size=200000
 ----
 
-read 10000 1024
+read offset=1024 size=10000
 ----
 misses=1
 
 # This should be in the cache.
-read-for-compaction 2000 4096
+read-for-compaction offset=4096 size=2000
 ----
 misses=0
 
 # This should miss the cache.
-read-for-compaction 100000 4096
+read-for-compaction offset=4096 size=100000
 ----
 misses=1
 
 # This should miss the cache again - we don't populate the cache when doing
 # compaction reads.
-read-for-compaction 100000 4096
+read-for-compaction offset=4096 size=100000
 ----
 misses=1

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/eof_handling
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/eof_handling
@@ -2,13 +2,13 @@ init
 ----
 initialized with block-size=32768 size=33554432 num-shards=32
 
-write 40000
+write size=40000
 ----
 
-read 4000 35000
+read offset=35000 size=4000
 ----
 misses=1
 
-read 4000 35000
+read offset=35000 size=4000
 ----
 misses=0

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/lru
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/lru
@@ -2,32 +2,32 @@ init num-shards=1 size=1M
 ----
 initialized with block-size=32768 size=1048576 num-shards=1
 
-write 1500000
+write size=1500000
 ----
 
-read 32768 0
-----
-misses=1
-
-read 32768 32768
+read offset=0 size=32K
 ----
 misses=1
 
-read 983040 65536
+read offset=32K size=32K
+----
+misses=1
+
+read offset=64K size=960K
 ----
 misses=1
 
 # The cache should now be full with the first MB. Read a new block.
-read 1048576 32768
+read offset=1M size=32K
 ----
 misses=1
 
 # The block that was evicted should have been the one at offset 0.
-read 32768 0
+read offset=0 size=32K
 ----
 misses=1
 
 # The block that was evicted should have been the one at offset 32768.
-read 32768 32768
+read offset=32K size=32K
 ----
 misses=1

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/lru
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/lru
@@ -1,4 +1,4 @@
-init num-shards=1 size=1048576
+init num-shards=1 size=1M
 ----
 initialized with block-size=32768 size=1048576 num-shards=1
 

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/read_larger_than_two_cache_shards
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/read_larger_than_two_cache_shards
@@ -4,13 +4,13 @@ init
 ----
 initialized with block-size=32768 size=33554432 num-shards=32
 
-write 3145728
+write size=3145728
 ----
 
-read 3145671 57
+read offset=57 size=3145671
 ----
 misses=1
 
-read 3145671 57
+read offset=57 size=3145671
 ----
 misses=0

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_blocks
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_blocks
@@ -4,17 +4,17 @@ init
 ----
 initialized with block-size=32768 size=33554432 num-shards=32
 
-write 32773
+write size=32773
 ----
 
-read 32773 0
+read offset=0 size=32773
 ----
 misses=1
 
-read 32773 0
+read offset=0 size=32773
 ----
 misses=0
 
-read 32716 57
+read offset=57 size=32716
 ----
 misses=0

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_blocks_with_first_read_at_big_offset
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_blocks_with_first_read_at_big_offset
@@ -4,13 +4,13 @@ init
 ----
 initialized with block-size=32768 size=33554432 num-shards=32
 
-write 32773
+write size=32773
 ----
 
-read 5 32768
+read offset=32768 size=5
 ----
 misses=1
 
-read 5 32768
+read offset=32768 size=5
 ----
 misses=0

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_blocks_with_first_read_at_offset
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_blocks_with_first_read_at_offset
@@ -4,13 +4,13 @@ init
 ----
 initialized with block-size=32768 size=33554432 num-shards=32
 
-write 32773
+write size=32773
 ----
 
-read 32716 57
+read offset=57 size=32716
 ----
 misses=1
 
-read 32716 57
+read offset=57 size=32716
 ----
 misses=0

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_shards
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_shards
@@ -4,17 +4,17 @@ init
 ----
 initialized with block-size=32768 size=33554432 num-shards=32
 
-write 1048776
+write size=1048776
 ----
 
-read 1048776 0
+read offset=0 size=1048776
 ----
 misses=1
 
-read 1048776 0
+read offset=0 size=1048776
 ----
 misses=0
 
-read 1048719 57
+read offset=57 size=1048719
 ----
 misses=0

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_shards_with_first_read_at_offset
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/read_that_hits_two_cache_shards_with_first_read_at_offset
@@ -4,13 +4,13 @@ init
 ----
 initialized with block-size=32768 size=33554432 num-shards=32
 
-write 1048776
+write size=1048776
 ----
 
-read 1048719 57
+read offset=57 size=1048719
 ----
 misses=1
 
-read 1048719 57
+read offset=57 size=1048719
 ----
 misses=0

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/small_read
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/small_read
@@ -4,17 +4,17 @@ init
 ----
 initialized with block-size=32768 size=33554432 num-shards=32
 
-write 10
+write size=10
 ----
 
-read 10 0
+read offset=0 size=10
 ----
 misses=1
 
-read 10 0
+read offset=0 size=10
 ----
 misses=0
 
-read 6 4
+read offset=4 size=6
 ----
 misses=0

--- a/objstorage/objstorageprovider/sharedcache/testdata/cache/small_read_with_first_read_at_offset
+++ b/objstorage/objstorageprovider/sharedcache/testdata/cache/small_read_with_first_read_at_offset
@@ -4,17 +4,17 @@ init
 ----
 initialized with block-size=32768 size=33554432 num-shards=32
 
-write 10
+write size=10
 ----
 
-read 6 4
+read offset=4 size=6
 ----
 misses=1
 
-read 6 4
+read offset=4 size=6
 ----
 misses=0
 
-read 10 0
+read offset=0 size=10
 ----
 misses=0


### PR DESCRIPTION
#### sharedcache: allow K/M/G suffixes in argument values


#### sharedcache: use arguments for reads and writes

This commit changes the read/write test directives to use named
arguments. This allows using K/M/G suffixes and makes the tests easier
to read. We also swap the order of offset and size in the tests since
the offset is typically first.
