### PR TITLE
manifest: virtual iterator bounds checking virtual sstable metadata

### DIFF
--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -324,7 +324,9 @@ func TestVirtualReadsWiring(t *testing.T) {
 	v2.SmallestPointKey = v2.Smallest
 
 	v1.ValidateVirtual(parentFile)
+	d.checkVirtualBounds(v1, nil /* iterOptions */)
 	v2.ValidateVirtual(parentFile)
+	d.checkVirtualBounds(v2, nil /* iterOptions */)
 
 	// Write the version edit.
 	fileMetrics := func(ve *versionEdit) map[int]*LevelMetrics {

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -100,7 +100,9 @@ func TestLatestRefCounting(t *testing.T) {
 	m2.SmallestPointKey = m2.Smallest
 
 	m1.ValidateVirtual(f)
+	d.checkVirtualBounds(m1, nil /* iterOptions */)
 	m2.ValidateVirtual(f)
+	d.checkVirtualBounds(m2, nil /* iterOptions */)
 
 	fileMetrics := func(ve *versionEdit) map[int]*LevelMetrics {
 		metrics := newFileMetrics(ve.NewFiles)
@@ -282,7 +284,9 @@ func TestVirtualSSTableManifestReplay(t *testing.T) {
 	m2.Stats.NumEntries = 1
 
 	m1.ValidateVirtual(f)
+	d.checkVirtualBounds(m1, nil /* iterOptions */)
 	m2.ValidateVirtual(f)
+	d.checkVirtualBounds(m2, nil /* iterOptions */)
 
 	fileMetrics := func(ve *versionEdit) map[int]*LevelMetrics {
 		metrics := newFileMetrics(ve.NewFiles)


### PR DESCRIPTION
Added a check inside of `FileMetadata.ValidateVirtual()` to check if the keys returned from a virtual sstable are within the bounds of the Smallest and Largest metadata keys.