### PR TITLE
replay: pass correct replay bool flags on reruns

### DIFF
--- a/cmd/pebble/replay.go
+++ b/cmd/pebble/replay.go
@@ -89,10 +89,10 @@ func (c *replayConfig) args() (args []string) {
 		args = append(args, "--max-writes", fmt.Sprint(c.maxWritesMB))
 	}
 	if c.streamLogs {
-		args = append(args, "--stream-logs", fmt.Sprint(c.streamLogs))
+		args = append(args, "--stream-logs")
 	}
 	if c.ignoreCheckpoint {
-		args = append(args, "--ignore-checkpoint", fmt.Sprint(c.ignoreCheckpoint))
+		args = append(args, "--ignore-checkpoint")
 	}
 	if c.optionsString != "" {
 		args = append(args, "--options", c.optionsString)


### PR DESCRIPTION
Previously, if the user passed --stream-logs or --ignore-checkpoint and with a --count>2, the replay tool would fail on the second run because the bool args would get incorrectly passed to syscall.Exec(). Specifically, for these flags, an additional `true` arg would get passed, which the cobra parser does not appreciate.