### PR TITLE
open: Don't enforce size match for virtual sstables on db open

### DIFF
--- a/open.go
+++ b/open.go
@@ -1084,6 +1084,10 @@ func checkConsistency(v *manifest.Version, dirname string, objProvider objstorag
 				continue
 			}
 			dedup[backingState.DiskFileNum] = struct{}{}
+			// No need to enforce sizes for virtual sstables.
+			if f.Virtual {
+				continue
+			}
 			fileNum := backingState.DiskFileNum
 			fileSize := backingState.Size
 			meta, err := objProvider.Lookup(base.FileTypeTable, fileNum)


### PR DESCRIPTION
Currently, we verify that file sizes match between disk and file metadatas upon db open. This is an unhelpful exercise with virtual sstables as we expect to see mismatches there between the underlying backing file and the virtualized view of the sstable.