### PR TITLE
ingest: don't assume flushable ingests are locally present

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -79,8 +79,8 @@ func ingestValidateKey(opts *Options, key *InternalKey) error {
 	return nil
 }
 
-// ingestLoad1Shared loads the fileMetadata for one shared sstable. It also
-// sets the sequence numbers for a shared sstable.
+// ingestLoad1Shared loads the fileMetadata for one shared sstable owned or
+// shared by another node. It also sets the sequence numbers for a shared sstable.
 func ingestLoad1Shared(
 	opts *Options, sm SharedSSTMeta, fileNum base.DiskFileNum,
 ) (*fileMetadata, error) {
@@ -135,19 +135,15 @@ func ingestLoad1Shared(
 	return meta, nil
 }
 
+// ingestLoad1 creates the FileMetadata for one file. This file will be owned
+// by this store.
 func ingestLoad1(
-	opts *Options, fmv FormatMajorVersion, path string, cacheID uint64, fileNum base.DiskFileNum,
+	opts *Options,
+	fmv FormatMajorVersion,
+	readable objstorage.Readable,
+	cacheID uint64,
+	fileNum base.DiskFileNum,
 ) (*fileMetadata, error) {
-	f, err := opts.FS.Open(path)
-	if err != nil {
-		return nil, err
-	}
-
-	readable, err := sstable.NewSimpleReadable(f)
-	if err != nil {
-		return nil, err
-	}
-
 	cacheOpts := private.SSTableCacheOpts(cacheID, fileNum).(sstable.ReaderOption)
 	r, err := sstable.NewReader(readable, opts.MakeReaderOptions(), cacheOpts)
 	if err != nil {
@@ -302,7 +298,16 @@ func ingestLoad(
 	meta := make([]*fileMetadata, 0, len(paths))
 	newPaths := make([]string, 0, len(paths))
 	for i := range paths {
-		m, err := ingestLoad1(opts, fmv, paths[i], cacheID, pending[i])
+		f, err := opts.FS.Open(paths[i])
+		if err != nil {
+			return ingestLoadResult{}, err
+		}
+
+		readable, err := sstable.NewSimpleReadable(f)
+		if err != nil {
+			return ingestLoadResult{}, err
+		}
+		m, err := ingestLoad1(opts, fmv, readable, cacheID, pending[i])
 		if err != nil {
 			return ingestLoadResult{}, err
 		}
@@ -1107,7 +1112,6 @@ func (d *DB) ingest(
 	var mut *memTable
 	// asFlushable indicates whether the sstable was ingested as a flushable.
 	var asFlushable bool
-	var overlapWithExciseSpan bool
 	prepare := func(seqNum uint64) {
 		// Note that d.commit.mu is held by commitPipeline when calling prepare.
 
@@ -1159,7 +1163,6 @@ func (d *DB) ingest(
 					if mem == nil {
 						mem = m
 					}
-					overlapWithExciseSpan = true
 				}
 			}
 			err := iter.Close()
@@ -1192,16 +1195,16 @@ func (d *DB) ingest(
 		// The ingestion overlaps with some entry in the flushable queue.
 		if d.FormatMajorVersion() < FormatFlushableIngest ||
 			d.opts.Experimental.DisableIngestAsFlushable() ||
-			len(shared) > 0 || overlapWithExciseSpan ||
+			len(shared) > 0 || exciseSpan.Valid() ||
 			(len(d.mu.mem.queue) > d.opts.MemTableStopWritesThreshold-1) {
 			// We're not able to ingest as a flushable,
 			// so we must synchronously flush.
 			//
 			// TODO(bilal): Currently, if any of the files being ingested are shared or
-			// there's overlap between the memtable and an excise span, we cannot use
-			// flushable ingests and need to wait synchronously. Either remove this
-			// caveat by fleshing out flushable ingest logic to also account for these
-			// cases, or remove this TODO.
+			// there's an excise span present, we cannot use flushable ingests and need
+			// to wait synchronously. Either remove this caveat by fleshing out
+			// flushable ingest logic to also account for these cases, or remove this
+			// comment. Tracking issue: https://github.com/cockroachdb/pebble/issues/2676
 			if mem.flushable == d.mu.mem.mutable {
 				err = d.makeRoomForWrite(nil)
 			}

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -1219,11 +1219,6 @@ func (o *dbRatchetFormatMajorVersionOp) syncObjs() objIDSlice { return nil }
 type dbRestartOp struct{}
 
 func (o *dbRestartOp) run(t *test, h historyRecorder) {
-	// TODO(josh): db.Restart does not work with shared storage yet.
-	if t.testOpts.sharedStorageEnabled {
-		h.Recordf("%s", o)
-		return
-	}
 	if err := t.restartDB(); err != nil {
 		h.Recordf("%s // %v", o, err)
 		h.history.err.Store(errors.Wrap(err, "dbRestartOp"))


### PR DESCRIPTION
Previously, the flushable ingest code assumed that all flushable ingested SSTs were locally present on vfs.FS, and the replayWAL code for that type of recovery bypassed the objProvider. This change updates replayWAL and ingestLoad to allow for the case where an ingested SST has already been copied/linked into shared storage.

Fixes #2717.