### PR TITLE
crl-release-23.1: cache: use atomic.Int32 wrappers, fix potential bug

### DIFF
--- a/internal/cache/refcnt_normal.go
+++ b/internal/cache/refcnt_normal.go
@@ -15,26 +15,28 @@ import (
 // refcnt provides an atomic reference count. This version is used when the
 // "tracing" build tag is not enabled. See refcnt_tracing.go for the "tracing"
 // enabled version.
-type refcnt int32
+type refcnt struct {
+	val atomic.Int32
+}
 
 // initialize the reference count to the specified value.
 func (v *refcnt) init(val int32) {
-	*v = refcnt(val)
+	v.val.Store(val)
 }
 
 func (v *refcnt) refs() int32 {
-	return atomic.LoadInt32((*int32)(v))
+	return v.val.Load()
 }
 
 func (v *refcnt) acquire() {
-	switch v := atomic.AddInt32((*int32)(v), 1); {
+	switch v := v.val.Add(1); {
 	case v <= 1:
 		panic(fmt.Sprintf("pebble: inconsistent reference count: %d", v))
 	}
 }
 
 func (v *refcnt) release() bool {
-	switch v := atomic.AddInt32((*int32)(v), -1); {
+	switch v := v.val.Add(-1); {
 	case v < 0:
 		panic(fmt.Sprintf("pebble: inconsistent reference count: %d", v))
 	case v == 0:


### PR DESCRIPTION
The refcnt implementation uses non-atomic assignment on init. Mixing atomic and non-atomic operations is not good and it is conceivable that on some platforms, the non-atomic assignment might not always be "seen" by an atomic operation that happens very soon after.

This change switches to atomic.Int32 wrapper and uses `Store` on init.

Informs cockroachdb/cockroach#84971