### PR TITLE
crl-release-22.2: cache: use atomic store on init

### DIFF
--- a/internal/cache/refcnt_normal.go
+++ b/internal/cache/refcnt_normal.go
@@ -19,7 +19,7 @@ type refcnt int32
 
 // initialize the reference count to the specified value.
 func (v *refcnt) init(val int32) {
-	*v = refcnt(val)
+	atomic.StoreInt32((*int32)(v), val)
 }
 
 func (v *refcnt) refs() int32 {

--- a/internal/cache/refcnt_tracing.go
+++ b/internal/cache/refcnt_tracing.go
@@ -25,7 +25,7 @@ type refcnt struct {
 }
 
 func (v *refcnt) init(val int32) {
-	v.val = val
+	atomic.StoreInt32(&v.val, val)
 	v.trace("init")
 }
 


### PR DESCRIPTION
The refcnt implementation uses non-atomic assignment on init. Mixing atomic and non-atomic operations is not good and it is conceivable that on some platforms, the non-atomic assignment might not always be "seen" by an atomic operation that happens very soon after.

This change switches to using `StoreInt32` on init.

Informs cockroachdb/cockroach#84971