### PR TITLE
db: Bring back call to deleteObsoleteFiles in Close()

### DIFF
--- a/db.go
+++ b/db.go
@@ -1543,6 +1543,12 @@ func (d *DB) Close() error {
 		err = firstError(err, errors.Errorf("leaked memtable reservation: %d", errors.Safe(reserved)))
 	}
 
+	// Since we called d.readState.val.unrefLocked() above, we are expected to
+	// manually schedule deletion of obsolete files.
+	if len(d.mu.versions.obsoleteTables) > 0 {
+		d.deleteObsoleteFiles(d.mu.nextJobID)
+	}
+
 	d.mu.Unlock()
 	d.compactionSchedulers.Wait()
 


### PR DESCRIPTION
Before #2641, we had a conditional to explicitly schedule deletion of obsolete files in db.Close(). We took it out as part of the deletion refactor as the comment on it made it seem no longer necessary. However, the code for readState.unrefLocked(), which we call earlier in Close(), explicitly states that it does not schedule obsolete file deletion and that it expects the caller to schedule that. Since we're calling readState.unrefLocked() here, we should be doing said deletion.

Fixes #2708.