### PR TITLE
tool/logs: account for tenant id while log parsing

### DIFF
--- a/tool/logs/compaction.go
+++ b/tool/logs/compaction.go
@@ -32,7 +32,7 @@ var (
 	logContextPattern = regexp.MustCompile(
 		`^.*` +
 			/* Timestamp        */ `(?P<timestamp>\d{6} \d{2}:\d{2}:\d{2}.\d{6}).*` +
-			/* Node / Store     */ `\[n(?P<node>\d+|\?).*,s(?P<store>\d+|\?).*?\].*`,
+			/* Node / Store     */ `\[.*n(?P<node>\d+|\?).*,s(?P<store>\d+|\?).*?\].*`,
 	)
 	logContextPatternTimestampIdx = logContextPattern.SubexpIndex("timestamp")
 	logContextPatternNodeIdx      = logContextPattern.SubexpIndex("node")


### PR DESCRIPTION
Log lines such as `I230710 18:19:03.853105 12040683868 3@pebble/event.go:701 ⋮ [T1,n3,s3,pebble] 145261232 [JOB 24997441] sstable deleted 57807347` would not be parsed correctly prior to this pr.