### PR TITLE
objstorage: close the secondary cache

### DIFF
--- a/objstorage/objstorageprovider/provider.go
+++ b/objstorage/objstorageprovider/provider.go
@@ -184,9 +184,10 @@ func open(settings Settings) (p *provider, _ error) {
 
 // Close is part of the objstorage.Provider interface.
 func (p *provider) Close() error {
-	var err error
 	if p.fsDir != nil {
-		err = p.fsDir.Close()
+		if err := p.fsDir.Close(); err != nil {
+			return err
+		}
 		p.fsDir = nil
 	}
 	if objiotracing.Enabled {
@@ -195,7 +196,13 @@ func (p *provider) Close() error {
 			p.tracer = nil
 		}
 	}
-	return err
+	if p.shared.cache != nil {
+		if err := p.shared.cache.Close(); err != nil {
+			return err
+		}
+		p.shared.cache = nil
+	}
+	return nil
 }
 
 // OpenForReading opens an existing object.


### PR DESCRIPTION
**objstorage: close the secondary cache**

This commit closes the secondary cache from provider.Close. This way, calling db.Close closes the secondary cache. Since the secondary caches does writes asynchronously with respect to calls to ReadAt, this is required, to avoid metamorphic test failures. The metamorphic tests simulate server restarts via calling db.Close & then pebble.Open.

Thank you to Radu for finding this bug!