### PR TITLE
pebble: Fix TestGetSSTableMetricsSingleNode flake

### DIFF
--- a/db.go
+++ b/db.go
@@ -1984,7 +1984,15 @@ func (d *DB) SSTables(opts ...SSTablesOption) ([][]SSTableInfo, error) {
 					}
 					spanBytes = size
 				}
-				destTables[j].Properties.UserProperties["approximate-span-bytes"] = strconv.FormatUint(spanBytes, 10)
+				propertiesCopy := *destTables[j].Properties
+
+				// Deep copy user properties so approximate span bytes can be added.
+				propertiesCopy.UserProperties = make(map[string]string, len(destTables[j].Properties.UserProperties)+1)
+				for k, v := range destTables[j].Properties.UserProperties {
+					propertiesCopy.UserProperties[k] = v
+				}
+				propertiesCopy.UserProperties["approximate-span-bytes"] = strconv.FormatUint(spanBytes, 10)
+				destTables[j].Properties = &propertiesCopy
 			}
 			j++
 		}


### PR DESCRIPTION
The builtins test `TestGetSSTableMetricsSingleNode` flakes due to a data race (modifying SSTable.Properties.UserProperties) on pebble side without making a copy.

Fixes: https://github.com/cockroachdb/cockroach/issues/106817