### PR TITLE
cmd/pebble,replay: various benchmark replay adjustments

### DIFF
--- a/cmd/pebble/replay.go
+++ b/cmd/pebble/replay.go
@@ -209,7 +209,7 @@ func (c *replayConfig) initRunDir(r *replay.Runner) error {
 	}
 	if !c.ignoreCheckpoint {
 		checkpointDir := r.WorkloadFS.PathJoin(r.WorkloadPath, `checkpoint`)
-		verbosef("Attempting to initialize with checkpoint %q.\n", checkpointDir)
+		fmt.Printf("Attempting to initialize with checkpoint %q.\n", checkpointDir)
 		ok, err := vfs.Clone(
 			r.WorkloadFS,
 			vfs.Default,
@@ -222,7 +222,7 @@ func (c *replayConfig) initRunDir(r *replay.Runner) error {
 		if !ok {
 			return errors.Newf("no checkpoint %q exists; you may re-run with --ignore-checkpoint", checkpointDir)
 		}
-		verbosef("Run directory initialized with checkpoint %q.\n", checkpointDir)
+		fmt.Printf("Run directory initialized with checkpoint %q.\n", checkpointDir)
 	}
 	return nil
 }

--- a/cmd/pebble/replay_test.go
+++ b/cmd/pebble/replay_test.go
@@ -5,35 +5,48 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParseOptionsStr(t *testing.T) {
 	type testCase struct {
-		optionsStr string
-		options    *pebble.Options
+		c       replayConfig
+		options *pebble.Options
 	}
 
 	testCases := []testCase{
 		{
-			optionsStr: `[Options] max_concurrent_compactions=9`,
-			options:    &pebble.Options{MaxConcurrentCompactions: func() int { return 9 }},
+			c:       replayConfig{optionsString: `[Options] max_concurrent_compactions=9`},
+			options: &pebble.Options{MaxConcurrentCompactions: func() int { return 9 }},
 		},
 		{
-			optionsStr: `[Options] bytes_per_sync=90000`,
-			options:    &pebble.Options{BytesPerSync: 90000},
+			c:       replayConfig{optionsString: `[Options] bytes_per_sync=90000`},
+			options: &pebble.Options{BytesPerSync: 90000},
 		},
 		{
-			optionsStr: `[Options] [Level "0"] target_file_size=222`,
+			c:       replayConfig{optionsString: fmt.Sprintf(`[Options] cache_size=%d`, 16<<20 /* 16MB */)},
+			options: &pebble.Options{Cache: cache.New(16 << 20 /* 16 MB */)},
+		},
+		{
+			c: replayConfig{
+				maxCacheSize:  16 << 20, /* 16 MB */
+				optionsString: fmt.Sprintf(`[Options] cache_size=%d`, 10<<30 /* 10 GB */),
+			},
+			options: &pebble.Options{Cache: cache.New(16 << 20 /* 16 MB */)},
+		},
+		{
+			c: replayConfig{optionsString: `[Options] [Level "0"] target_file_size=222`},
 			options: &pebble.Options{Levels: []pebble.LevelOptions{
 				{TargetFileSize: 222},
 			}},
 		},
 		{
-			optionsStr: `[Options] lbase_max_bytes=10  max_open_files=20  [Level "0"] target_file_size=30 [Level "1"] index_block_size=40`,
+			c: replayConfig{optionsString: `[Options] lbase_max_bytes=10  max_open_files=20  [Level "0"] target_file_size=30 [Level "1"] index_block_size=40`},
 			options: &pebble.Options{
 				LBaseMaxBytes: 10,
 				MaxOpenFiles:  20,
@@ -47,12 +60,18 @@ func TestParseOptionsStr(t *testing.T) {
 
 	for _, tc := range testCases {
 		o := new(pebble.Options)
-		require.NoError(t, parseCustomOptions(tc.optionsStr, o))
+		require.NoError(t, tc.c.parseCustomOptions(tc.c.optionsString, o))
 		o.EnsureDefaults()
 		got := o.String()
 
 		tc.options.EnsureDefaults()
 		want := tc.options.String()
 		require.Equal(t, want, got)
+		if o.Cache != nil {
+			o.Cache.Unref()
+		}
+		if tc.options.Cache != nil {
+			tc.options.Cache.Unref()
+		}
 	}
 }

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -425,8 +425,8 @@ func TestBenchmarkString(t *testing.T) {
 		TotalWriteAmp:       5.6,
 		WorkloadDuration:    time.Second,
 		WriteBytes:          30 * (1 << 20),
-		WriteStalls:         105,
-		WriteStallsDuration: time.Minute,
+		WriteStalls:         map[string]int{"memtable": 1, "L0": 2},
+		WriteStallsDuration: map[string]time.Duration{"memtable": time.Minute, "L0": time.Hour},
 	}
 	m.Ingest.BytesIntoL0 = 5 << 20
 	m.Ingest.BytesWeightedByLevel = 9 << 20
@@ -451,7 +451,8 @@ BenchmarkBenchmarkReplay/tpcc/TombstoneCount/mean 1 295 tombstones
 BenchmarkBenchmarkReplay/tpcc/TombstoneCount/max 1 295 tombstones
 BenchmarkBenchmarkReplay/tpcc/Throughput 1 2.097152e+07 B/s
 BenchmarkBenchmarkReplay/tpcc/WriteAmp 1 5.6 wamp
-BenchmarkBenchmarkReplay/tpcc/WriteStalls 1 105 stalls 60 stallsec/op`),
+BenchmarkBenchmarkReplay/tpcc/WriteStall/memtable 1 1 stalls 60 stallsec/op
+BenchmarkBenchmarkReplay/tpcc/WriteStall/L0 1 2 stalls 3600 stallsec/op`),
 		strings.TrimSpace(buf.String()))
 }
 


### PR DESCRIPTION
[cmd/pebble: use non-default block cache size in replay tool](https://github.com/cockroachdb/pebble/commit/43a29468e25782b0dcdfa5d7fd657799288f2bea) 

If a block cache size is configured within a checkpoint's OPTIONS file, or if a
block cache size provided through the options string command-line flag, create
a cache of the provided size instead. Also, add a `--max-cache-size` CLI flag
so that a replay run that used a much larger block cache can be used on a
machine with less memory available.

[replay: calculate separate write stall metrics for each reason](https://github.com/cockroachdb/pebble/commit/123981e84e01ced75dd238416830a4190c76b7f1) 

The reason for the stall is important when reasoning about why a change moves
the metric.

[cmd/replay: always log checkpoint initialization](https://github.com/cockroachdb/pebble/commit/965e84bb119ffbfb10ac97035576352a0bc7766c) 

Verbose mode is verbose enough to affect performance numbers, so it's not
typically used. It would be helpful to still be able to determine when the node
was performing a copy of the storage directory.

[cmd/pebble: allow passing an explicit checkpoint directory path](https://github.com/cockroachdb/pebble/commit/3b21f9e1709d185cf81d78449c4292125da72e4b) 

This allows for copying a checkpoint to a separate filesystem before beginning
a test. Then runs of the test may link instead of copy files.