### PR TITLE
ingest: add ability to ingest external (not local or shared) files

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -1238,7 +1238,7 @@ func runForceIngestCmd(td *datadriven.TestData, d *DB) error {
 		*fileMetadata,
 	) (int, error) {
 		return level, nil
-	}, nil, KeyRange{})
+	}, nil /* shared */, KeyRange{}, nil /* external */)
 	return err
 }
 

--- a/flushable_test.go
+++ b/flushable_test.go
@@ -58,7 +58,7 @@ func TestIngestedSSTFlushableAPI(t *testing.T) {
 
 		// We can reuse the ingestLoad function for this test even if we're
 		// not actually ingesting a file.
-		lr, err := ingestLoad(d.opts, d.FormatMajorVersion(), paths, nil, d.cacheID, pendingOutputs)
+		lr, err := ingestLoad(d.opts, d.FormatMajorVersion(), paths, nil, nil, d.cacheID, pendingOutputs, d.objProvider, jobID)
 		meta := lr.localMeta
 		if err != nil {
 			panic(err)

--- a/ingest.go
+++ b/ingest.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/private"
 	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/objstorage/shared"
 	"github.com/cockroachdb/pebble/sstable"
 )
 
@@ -128,6 +129,138 @@ func ingestLoad1Shared(
 		// Initialize meta.{Smallest,Largest} and others by calling this.
 		meta.ExtendPointKeyBounds(opts.Comparer.Compare, meta.SmallestPointKey, meta.LargestPointKey)
 	}
+
+	if err := meta.Validate(opts.Comparer.Compare, opts.Comparer.FormatKey); err != nil {
+		return nil, err
+	}
+	return meta, nil
+}
+
+// ingestLoad1External loads the fileMetadata for one external sstable.
+// Sequence number and target level calculation happens during prepare/apply.
+func ingestLoad1External(
+	opts *Options,
+	e ExternalFile,
+	fileNum base.DiskFileNum,
+	objprovider objstorage.Provider,
+	jobID int,
+) (*fileMetadata, error) {
+	if e.Size == 0 {
+		// Disallow 0 file sizes
+		return nil, errors.New("pebble: cannot ingest external file with size 0")
+	}
+	// Don't load table stats. Doing a round trip to shared storage, one SST
+	// at a time is not worth it as it slows down ingestion.
+	meta := &fileMetadata{}
+	meta.FileNum = fileNum.FileNum()
+	meta.CreationTime = time.Now().Unix()
+	meta.Virtual = true
+	meta.Size = e.Size
+	meta.InitProviderBacking(fileNum)
+
+	// Try to resolve a reference to the external file.
+	backing, err := objprovider.CreateSharedObjectBacking(e.Locator, e.ObjName)
+	if err != nil {
+		return nil, err
+	}
+	metas, err := objprovider.AttachSharedObjects([]objstorage.SharedObjectToAttach{{
+		FileNum:  fileNum,
+		FileType: fileTypeTable,
+		Backing:  backing,
+	}})
+	if err != nil {
+		return nil, err
+	}
+	if opts.EventListener.TableCreated != nil {
+		opts.EventListener.TableCreated(TableCreateInfo{
+			JobID:   jobID,
+			Reason:  "ingesting",
+			Path:    objprovider.Path(metas[0]),
+			FileNum: fileNum.FileNum(),
+		})
+	}
+	readable, err := objprovider.OpenForReading(context.TODO(), fileTypeTable, fileNum, objstorage.OpenOptions{MustExist: true})
+	if err != nil {
+		return nil, err
+	}
+	reader, err := sstable.NewReader(readable, opts.MakeReaderOptions())
+	if err != nil {
+		return nil, err
+	}
+	pointKeyIter, err := reader.NewIter(e.SmallestUserKey, e.LargestUserKey)
+	var smallest, largest InternalKey
+	if err != nil {
+		return nil, err
+	}
+	defer pointKeyIter.Close()
+	smallestKey, _ := pointKeyIter.SeekGE(e.SmallestUserKey, base.SeekGEFlagsNone)
+	if smallestKey != nil {
+		smallest.CopyFrom(*smallestKey)
+	}
+	largestKey, _ := pointKeyIter.SeekLT(e.LargestUserKey, base.SeekLTFlagsNone)
+	if largestKey != nil {
+		largest.CopyFrom(*largestKey)
+	}
+	cmp := opts.Comparer.Compare
+	if smallest.UserKey != nil || largest.UserKey != nil {
+		meta.ExtendPointKeyBounds(cmp, smallest, largest)
+	}
+	{
+		// Figure out the range del bounds. Note that the use of Truncate means
+		// that we will never end up with spans that go outside [e.SmallestUserKey,
+		// e.LargestUserKey).
+		rawRangeDelIter, err := reader.NewRawRangeDelIter()
+		if err != nil {
+			return nil, err
+		}
+		rangeDelIter := keyspan.Truncate(cmp,
+			rawRangeDelIter, e.SmallestUserKey, e.LargestUserKey, nil, /* start */
+			nil /* end */, false /* panicOnUpperTruncate */)
+		defer rangeDelIter.Close()
+		span := rangeDelIter.SeekGE(e.SmallestUserKey)
+		var smallestRangeDel, largestRangeDel InternalKey
+		if span != nil {
+			smallestRangeDel.CopyFrom(span.SmallestKey())
+		}
+		span = rangeDelIter.SeekLT(e.LargestUserKey)
+		if span != nil {
+			largestRangeDel.CopyFrom(span.LargestKey())
+		}
+		if smallestRangeDel.UserKey != nil || largestRangeDel.UserKey != nil {
+			meta.ExtendPointKeyBounds(cmp, smallestRangeDel, largestRangeDel)
+		}
+	}
+	{
+		// Figure out the range key bounds. Note that the use of Truncate means
+		// that we will never end up with spans that go outside [e.SmallestUserKey,
+		// e.LargestUserKey).
+		rawRangeKeyIter, err := reader.NewRawRangeKeyIter()
+		if err != nil {
+			return nil, err
+		}
+		rangeKeyIter := keyspan.Truncate(cmp,
+			rawRangeKeyIter, e.SmallestUserKey, e.LargestUserKey, nil, /* start */
+			nil /* end */, false /* panicOnUpperTruncate */)
+		defer rangeKeyIter.Close()
+		span := rangeKeyIter.SeekGE(e.SmallestUserKey)
+		var smallestRangeKey, largestRangeKey InternalKey
+		if span != nil {
+			smallestRangeKey.CopyFrom(span.SmallestKey())
+		}
+		span = rangeKeyIter.SeekLT(e.LargestUserKey)
+		if span != nil {
+			largestRangeKey.CopyFrom(span.LargestKey())
+		}
+		if smallestRangeKey.UserKey != nil || largestRangeKey.UserKey != nil {
+			meta.ExtendRangeKeyBounds(cmp, smallestRangeKey, largestRangeKey)
+		}
+	}
+
+	// Set the underlying FileBacking's size to the same size as the virtualized
+	// view of the sstable. This ensures that we don't over-prioritize this
+	// sstable for compaction just yet, as we do not have a clear sense of
+	// what parts of this sstable are referenced by other nodes.
+	meta.FileBacking.Size = e.Size
 
 	if err := meta.Validate(opts.Comparer.Compare, opts.Comparer.FormatKey); err != nil {
 		return nil, err
@@ -283,8 +416,10 @@ func ingestLoad1(
 
 type ingestLoadResult struct {
 	localMeta, sharedMeta []*fileMetadata
+	externalMeta          []*fileMetadata
 	localPaths            []string
 	sharedLevels          []uint8
+	fileCount             int
 }
 
 func ingestLoad(
@@ -292,8 +427,11 @@ func ingestLoad(
 	fmv FormatMajorVersion,
 	paths []string,
 	shared []SharedSSTMeta,
+	external []ExternalFile,
 	cacheID uint64,
 	pending []base.DiskFileNum,
+	objProvider objstorage.Provider,
+	jobID int,
 ) (ingestLoadResult, error) {
 	meta := make([]*fileMetadata, 0, len(paths))
 	newPaths := make([]string, 0, len(paths))
@@ -316,8 +454,8 @@ func ingestLoad(
 			newPaths = append(newPaths, paths[i])
 		}
 	}
-	if len(shared) == 0 {
-		return ingestLoadResult{localMeta: meta, localPaths: newPaths}, nil
+	if len(shared) == 0 && len(external) == 0 {
+		return ingestLoadResult{localMeta: meta, localPaths: newPaths, fileCount: len(meta)}, nil
 	}
 	sharedMeta := make([]*fileMetadata, 0, len(shared))
 	levels := make([]uint8, 0, len(shared))
@@ -332,11 +470,21 @@ func ingestLoad(
 		sharedMeta = append(sharedMeta, m)
 		levels = append(levels, shared[i].Level)
 	}
+	externalMeta := make([]*fileMetadata, 0, len(external))
+	for i := range external {
+		m, err := ingestLoad1External(opts, external[i], pending[len(paths)+len(shared)+i], objProvider, jobID)
+		if err != nil {
+			return ingestLoadResult{}, err
+		}
+		externalMeta = append(externalMeta, m)
+	}
 	result := ingestLoadResult{
 		localMeta:    meta,
 		sharedMeta:   sharedMeta,
+		externalMeta: externalMeta,
 		localPaths:   newPaths,
 		sharedLevels: levels,
+		fileCount:    len(meta) + len(sharedMeta) + len(externalMeta),
 	}
 	return result, nil
 }
@@ -360,7 +508,9 @@ func (m metaAndPaths) Less(i, j int) bool {
 
 func (m metaAndPaths) Swap(i, j int) {
 	m.meta[i], m.meta[j] = m.meta[j], m.meta[i]
-	m.paths[i], m.paths[j] = m.paths[j], m.paths[i]
+	if m.paths != nil {
+		m.paths[i], m.paths[j] = m.paths[j], m.paths[i]
+	}
 }
 
 func ingestSortAndVerify(cmp Compare, lr ingestLoadResult, exciseSpan KeyRange) error {
@@ -371,6 +521,23 @@ func ingestSortAndVerify(cmp Compare, lr ingestLoadResult, exciseSpan KeyRange) 
 		if !exciseSpan.Contains(cmp, f.Smallest) || !exciseSpan.Contains(cmp, f.Largest) {
 			return errors.AssertionFailedf("pebble: shared file outside of excise span, span [%s-%s), file = %s", exciseSpan.Start, exciseSpan.End, f.String())
 		}
+	}
+	if len(lr.externalMeta) > 0 {
+		if len(lr.localMeta) > 0 || len(lr.sharedMeta) > 0 {
+			// Currently we only support external ingests on their own. If external
+			// files are present alongside local/shared files, return an error.
+			return errors.AssertionFailedf("pebble: external files cannot be ingested atomically alongside other types of files")
+		}
+		sort.Sort(&metaAndPaths{
+			meta: lr.externalMeta,
+			cmp:  cmp,
+		})
+		for i := 1; i < len(lr.externalMeta); i++ {
+			if sstableKeyCompare(cmp, lr.externalMeta[i-1].Largest, lr.externalMeta[i].Smallest) >= 0 {
+				return errors.AssertionFailedf("pebble: external sstables have overlapping ranges")
+			}
+		}
+		return nil
 	}
 	if len(lr.localMeta) <= 1 || len(lr.localPaths) <= 1 {
 		return nil
@@ -384,7 +551,7 @@ func ingestSortAndVerify(cmp Compare, lr ingestLoadResult, exciseSpan KeyRange) 
 
 	for i := 1; i < len(lr.localPaths); i++ {
 		if sstableKeyCompare(cmp, lr.localMeta[i-1].Largest, lr.localMeta[i].Smallest) >= 0 {
-			return errors.AssertionFailedf("pebble: external sstables have overlapping ranges")
+			return errors.AssertionFailedf("pebble: local ingestion sstables have overlapping ranges")
 		}
 	}
 	if len(lr.sharedMeta) == 0 {
@@ -489,6 +656,8 @@ func ingestLink(
 			})
 		}
 	}
+	// We do not need to do anything about lr.externalMetas. Those were already
+	// linked in ingestLoad.
 
 	return nil
 }
@@ -881,7 +1050,7 @@ func (d *DB) Ingest(paths []string) error {
 	if d.opts.ReadOnly {
 		return ErrReadOnly
 	}
-	_, err := d.ingest(paths, ingestTargetLevel, nil /* shared */, KeyRange{})
+	_, err := d.ingest(paths, ingestTargetLevel, nil /* shared */, KeyRange{}, nil /* external */)
 	return err
 }
 
@@ -901,6 +1070,27 @@ type IngestOperationStats struct {
 	MemtableOverlappingFiles int
 }
 
+// ExternalFile are external sstables that can be referenced through
+// objprovider and ingested as remote files that will not be refcounted or
+// cleaned up. For use with online restore. Note that the underlying sstable
+// could contain keys outside the [Smallest,Largest) bounds; however Pebble
+// is expected to only read the keys within those bounds.
+type ExternalFile struct {
+	// Locator is the shared.Locator that can be used with objProvider to
+	// resolve a reference to this external sstable.
+	Locator shared.Locator
+	// ObjName is the unique name of this sstable on Locator.
+	ObjName string
+	// Size of the referenced proportion of the virtualized sstable. An estimate
+	// is acceptable in lieu of the backing file size.
+	Size uint64
+	// SmallestUserKey and LargestUserKey are the [smallest,largest) user key
+	// bounds of the sstable. Note that this Largest bound is exclusive, and must
+	// be resolved into an inclusive user key bound through a SeekLT at ingestion
+	// time, to obey virtual FileMetadata guarantees.
+	SmallestUserKey, LargestUserKey []byte
+}
+
 // IngestWithStats does the same as Ingest, and additionally returns
 // IngestOperationStats.
 func (d *DB) IngestWithStats(paths []string) (IngestOperationStats, error) {
@@ -910,7 +1100,25 @@ func (d *DB) IngestWithStats(paths []string) (IngestOperationStats, error) {
 	if d.opts.ReadOnly {
 		return IngestOperationStats{}, ErrReadOnly
 	}
-	return d.ingest(paths, ingestTargetLevel, nil /* shared */, KeyRange{})
+	return d.ingest(paths, ingestTargetLevel, nil /* shared */, KeyRange{}, nil /* external */)
+}
+
+// IngestExternalFiles does the same as IngestWithStats, and additionally
+// accepts external files (with locator info that can be resolved using
+// d.opts.SharedStorage). These files must also be non-overlapping with
+// each other, and must be resolvable through
+func (d *DB) IngestExternalFiles(external []ExternalFile) (IngestOperationStats, error) {
+	if err := d.closed.Load(); err != nil {
+		panic(err)
+	}
+
+	if d.opts.ReadOnly {
+		return IngestOperationStats{}, ErrReadOnly
+	}
+	if d.opts.Experimental.SharedStorage == nil {
+		return IngestOperationStats{}, errors.New("pebble: cannot ingest external files without shared storage configured")
+	}
+	return d.ingest(nil, ingestTargetLevel, nil /* shared */, KeyRange{}, external)
 }
 
 // IngestAndExcise does the same as IngestWithStats, and additionally accepts a
@@ -932,7 +1140,7 @@ func (d *DB) IngestAndExcise(
 	if d.opts.ReadOnly {
 		return IngestOperationStats{}, ErrReadOnly
 	}
-	return d.ingest(paths, ingestTargetLevel, shared, exciseSpan)
+	return d.ingest(paths, ingestTargetLevel, shared, exciseSpan, nil /* external */)
 }
 
 // Both DB.mu and commitPipeline.mu must be held while this is called.
@@ -1048,12 +1256,13 @@ func (d *DB) ingest(
 	targetLevelFunc ingestTargetLevelFunc,
 	shared []SharedSSTMeta,
 	exciseSpan KeyRange,
+	external []ExternalFile,
 ) (IngestOperationStats, error) {
 	if len(shared) > 0 && d.opts.Experimental.SharedStorage == nil {
 		panic("cannot ingest shared sstables with nil SharedStorage")
 	}
-	if (exciseSpan.Valid() || len(shared) > 0) && d.opts.FormatMajorVersion < ExperimentalFormatVirtualSSTables {
-		return IngestOperationStats{}, errors.New("pebble: format major version too old for excise or shared sstable ingestion")
+	if (exciseSpan.Valid() || len(shared) > 0 || len(external) > 0) && d.opts.FormatMajorVersion < ExperimentalFormatVirtualSSTables {
+		return IngestOperationStats{}, errors.New("pebble: format major version too old for excise, shared or external sstable ingestion")
 	}
 	// Allocate file numbers for all of the files being ingested and mark them as
 	// pending in order to prevent them from being deleted. Note that this causes
@@ -1061,25 +1270,23 @@ func (d *DB) ingest(
 	// ordering. The sorting of L0 tables by sequence number avoids relying on
 	// that (busted) invariant.
 	d.mu.Lock()
-	pendingOutputs := make([]base.DiskFileNum, len(paths)+len(shared))
-	for i := range paths {
+	pendingOutputs := make([]base.DiskFileNum, len(paths)+len(shared)+len(external))
+	for i := 0; i < len(paths)+len(shared)+len(external); i++ {
 		pendingOutputs[i] = d.mu.versions.getNextFileNum().DiskFileNum()
 	}
-	for i := range shared {
-		pendingOutputs[len(paths)+i] = d.mu.versions.getNextFileNum().DiskFileNum()
-	}
+
 	jobID := d.mu.nextJobID
 	d.mu.nextJobID++
 	d.mu.Unlock()
 
-	// Load the metadata for all of the files being ingested. This step detects
+	// Load the metadata for all the files being ingested. This step detects
 	// and elides empty sstables.
-	loadResult, err := ingestLoad(d.opts, d.FormatMajorVersion(), paths, shared, d.cacheID, pendingOutputs)
+	loadResult, err := ingestLoad(d.opts, d.FormatMajorVersion(), paths, shared, external, d.cacheID, pendingOutputs, d.objProvider, jobID)
 	if err != nil {
 		return IngestOperationStats{}, err
 	}
 
-	if len(loadResult.localMeta) == 0 && len(loadResult.sharedMeta) == 0 {
+	if loadResult.fileCount == 0 {
 		// All of the sstables to be ingested were empty. Nothing to do.
 		return IngestOperationStats{}, nil
 	}
@@ -1107,7 +1314,7 @@ func (d *DB) ingest(
 	// metaFlushableOverlaps is a slice parallel to meta indicating which of the
 	// ingested sstables overlap some table in the flushable queue. It's used to
 	// approximate ingest-into-L0 stats when using flushable ingests.
-	metaFlushableOverlaps := make([]bool, len(loadResult.localMeta)+len(loadResult.sharedMeta))
+	metaFlushableOverlaps := make([]bool, loadResult.fileCount)
 	var mem *flushableEntry
 	var mut *memTable
 	// asFlushable indicates whether the sstable was ingested as a flushable.
@@ -1154,6 +1361,9 @@ func (d *DB) ingest(
 			for i := range loadResult.sharedMeta {
 				checkForOverlap(len(loadResult.localMeta)+i, loadResult.sharedMeta[i])
 			}
+			for i := range loadResult.externalMeta {
+				checkForOverlap(len(loadResult.localMeta)+len(loadResult.sharedMeta)+i, loadResult.externalMeta[i])
+			}
 			if exciseSpan.Valid() {
 				kr := internalKeyRange{
 					smallest: base.MakeInternalKey(exciseSpan.Start, InternalKeySeqNumMax, InternalKeyKindMax),
@@ -1195,7 +1405,7 @@ func (d *DB) ingest(
 		// The ingestion overlaps with some entry in the flushable queue.
 		if d.FormatMajorVersion() < FormatFlushableIngest ||
 			d.opts.Experimental.DisableIngestAsFlushable() ||
-			len(shared) > 0 || exciseSpan.Valid() ||
+			len(shared) > 0 || exciseSpan.Valid() || len(external) > 0 ||
 			(len(d.mu.mem.queue) > d.opts.MemTableStopWritesThreshold-1) {
 			// We're not able to ingest as a flushable,
 			// so we must synchronously flush.
@@ -1248,8 +1458,12 @@ func (d *DB) ingest(
 		//
 		// For shared sstables, we do not need to update sequence numbers. These
 		// sequence numbers are already set in ingestLoad.
+		metas := loadResult.localMeta
+		if len(loadResult.externalMeta) > 0 {
+			metas = loadResult.externalMeta
+		}
 		if err = ingestUpdateSeqNum(
-			d.cmp, d.opts.Comparer.FormatKey, seqNum, loadResult.localMeta,
+			d.cmp, d.opts.Comparer.FormatKey, seqNum, metas,
 		); err != nil {
 			if mut != nil {
 				if mut.writerUnref() {
@@ -1278,7 +1492,7 @@ func (d *DB) ingest(
 	// changes to the WAL and memtable. This will cause a bigger commit hiccup
 	// during ingestion.
 	d.commit.ingestSem <- struct{}{}
-	d.commit.AllocateSeqNum(len(loadResult.localPaths), prepare, apply)
+	d.commit.AllocateSeqNum(len(loadResult.localMeta)+len(loadResult.externalMeta), prepare, apply)
 	<-d.commit.ingestSem
 
 	if err != nil {
@@ -1300,6 +1514,9 @@ func (d *DB) ingest(
 	globalSeqNum := uint64(0)
 	if len(loadResult.localMeta) > 0 {
 		globalSeqNum = loadResult.localMeta[0].SmallestSeqNum
+	}
+	if len(loadResult.externalMeta) > 0 {
+		globalSeqNum = loadResult.externalMeta[0].SmallestSeqNum
 	}
 	info := TableIngestInfo{
 		JobID:        jobID,
@@ -1633,7 +1850,7 @@ func (d *DB) ingestApply(
 	defer d.mu.Unlock()
 
 	ve := &versionEdit{
-		NewFiles: make([]newFileEntry, len(lr.localMeta)+len(lr.sharedMeta)),
+		NewFiles: make([]newFileEntry, lr.fileCount),
 	}
 	if exciseSpan.Valid() {
 		ve.DeletedFiles = map[manifest.DeletedFileEntry]*manifest.FileMetadata{}
@@ -1663,18 +1880,25 @@ func (d *DB) ingestApply(
 	current := d.mu.versions.currentVersion()
 	baseLevel := d.mu.versions.picker.getBaseLevel()
 	iterOps := IterOptions{logger: d.opts.Logger}
-	for i := 0; i < len(lr.localMeta)+len(lr.sharedMeta); i++ {
+	for i := 0; i < lr.fileCount; i++ {
 		// Determine the lowest level in the LSM for which the sstable doesn't
 		// overlap any existing files in the level.
 		var m *fileMetadata
 		sharedIdx := -1
 		sharedLevel := -1
+		externalFile := false
 		if i < len(lr.localMeta) {
+			// local file.
 			m = lr.localMeta[i]
-		} else {
+		} else if (i - len(lr.localMeta)) < len(lr.sharedMeta) {
+			// shared file.
 			sharedIdx = i - len(lr.localMeta)
 			m = lr.sharedMeta[sharedIdx]
 			sharedLevel = int(lr.sharedLevels[sharedIdx])
+		} else {
+			// external file.
+			externalFile = true
+			m = lr.externalMeta[i-(len(lr.localMeta)+len(lr.sharedMeta))]
 		}
 		f := &ve.NewFiles[i]
 		var err error
@@ -1685,6 +1909,9 @@ func (d *DB) ingestApply(
 			}
 			ve.CreatedBackingTables = append(ve.CreatedBackingTables, m.FileBacking)
 		} else {
+			if externalFile {
+				ve.CreatedBackingTables = append(ve.CreatedBackingTables, m.FileBacking)
+			}
 			if exciseSpan.Valid() && exciseSpan.Contains(d.cmp, m.Smallest) && exciseSpan.Contains(d.cmp, m.Largest) {
 				// This file fits perfectly within the excise span. We can slot it at
 				// L6, or sharedLevelsStart - 1 if we have shared files.

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -126,7 +126,7 @@ func TestIngestLoad(t *testing.T) {
 				Comparer: DefaultComparer,
 				FS:       mem,
 			}).WithFSDefaults()
-			lr, err := ingestLoad(opts, dbVersion, []string{"ext"}, nil, 0, []base.DiskFileNum{base.FileNum(1).DiskFileNum()})
+			lr, err := ingestLoad(opts, dbVersion, []string{"ext"}, nil, nil, 0, []base.DiskFileNum{base.FileNum(1).DiskFileNum()}, nil, 0)
 			if err != nil {
 				return err.Error()
 			}
@@ -213,7 +213,7 @@ func TestIngestLoadRand(t *testing.T) {
 		Comparer: DefaultComparer,
 		FS:       mem,
 	}).WithFSDefaults()
-	lr, err := ingestLoad(opts, version, paths, nil, 0, pending)
+	lr, err := ingestLoad(opts, version, paths, nil, nil, 0, pending, nil, 0)
 	require.NoError(t, err)
 
 	for _, m := range lr.localMeta {
@@ -234,7 +234,7 @@ func TestIngestLoadInvalid(t *testing.T) {
 		Comparer: DefaultComparer,
 		FS:       mem,
 	}).WithFSDefaults()
-	if _, err := ingestLoad(opts, internalFormatNewest, []string{"invalid"}, nil, 0, []base.DiskFileNum{base.FileNum(1).DiskFileNum()}); err == nil {
+	if _, err := ingestLoad(opts, internalFormatNewest, []string{"invalid"}, nil, nil, 0, []base.DiskFileNum{base.FileNum(1).DiskFileNum()}, nil, 0); err == nil {
 		t.Fatalf("expected error, but found success")
 	}
 }

--- a/testdata/ingest_sort_and_verify
+++ b/testdata/ingest_sort_and_verify
@@ -28,20 +28,20 @@ a.SET.0-b.SET.0
 b.SET.0-d.SET.0
 e.SET.0-f.SET.0
 ----
-pebble: external sstables have overlapping ranges
+pebble: local ingestion sstables have overlapping ranges
 
 ingest cmp=default
 c.SET.0-d.SET.0
 d.SET.0-e.SET.0
 a.SET.0-b.SET.0
 ----
-pebble: external sstables have overlapping ranges
+pebble: local ingestion sstables have overlapping ranges
 
 ingest cmp=default
 a.SET.1-b.SET.1
 b.SET.0-c.SET.0
 ----
-pebble: external sstables have overlapping ranges
+pebble: local ingestion sstables have overlapping ranges
 
 ingest cmp=default
 a.RANGEDEL.0-b.RANGEDEL.72057594037927935
@@ -74,13 +74,13 @@ ingest cmp=default
 a.RANGEDEL.0-c.RANGEDEL.72057594037927935
 b.SET.0-d.SET.0
 ----
-pebble: external sstables have overlapping ranges
+pebble: local ingestion sstables have overlapping ranges
 
 ingest cmp=default
 b.RANGEDEL.0-d.RANGEDEL.72057594037927935
 a.SET.0-c.SET.0
 ----
-pebble: external sstables have overlapping ranges
+pebble: local ingestion sstables have overlapping ranges
 
 ingest cmp=default
 a.RANGEDEL.0-b.RANGEDEL.72057594037927935
@@ -119,20 +119,20 @@ f.SET.0-e.SET.0
 d.SET.0-b.SET.0
 b.SET.0-a.SET.0
 ----
-pebble: external sstables have overlapping ranges
+pebble: local ingestion sstables have overlapping ranges
 
 ingest cmp=reverse
 b.SET.0-a.SET.0
 e.SET.0-d.SET.0
 d.SET.0-c.SET.0
 ----
-pebble: external sstables have overlapping ranges
+pebble: local ingestion sstables have overlapping ranges
 
 ingest cmp=reverse
 c.SET.0-b.SET.0
 b.SET.1-a.SET.1
 ----
-pebble: external sstables have overlapping ranges
+pebble: local ingestion sstables have overlapping ranges
 
 ingest cmp=reverse
 b.RANGEDEL.0-a.RANGEDEL.72057594037927935
@@ -165,16 +165,16 @@ ingest cmp=reverse
 c.RANGEDEL.0-a.RANGEDEL.72057594037927935
 d.SET.0-b.SET.0
 ----
-pebble: external sstables have overlapping ranges
+pebble: local ingestion sstables have overlapping ranges
 
 ingest cmp=reverse
 d.RANGEDEL.0-b.RANGEDEL.72057594037927935
 c.SET.0-a.SET.0
 ----
-pebble: external sstables have overlapping ranges
+pebble: local ingestion sstables have overlapping ranges
 
 ingest cmp=reverse
 b.RANGEDEL.0-a.RANGEDEL.72057594037927935
 c.SET.0-b.SET.0
 ----
-pebble: external sstables have overlapping ranges
+pebble: local ingestion sstables have overlapping ranges


### PR DESCRIPTION
External files are files that can be referenced through the objprovider using a shared.Locator, and are not refcounted or have their lifecycle managed by any Pebble instances. This change adds the ability to ingest external files into Pebble through a new IngestExternalFile method on the DB.