### PR TITLE
objstorage: rename Shared to Remote in the objstorage provider API

### DIFF
--- a/cleaner.go
+++ b/cleaner.go
@@ -181,8 +181,8 @@ func (cm *cleanupManager) needsPacing(fileType base.FileType, fileNum base.DiskF
 		// delete anything, so we don't need to pace.
 		return false
 	}
-	// Don't throttle deletion of shared objects.
-	return !meta.IsShared()
+	// Don't throttle deletion of remote objects.
+	return !meta.IsRemote()
 }
 
 // maybePace sleeps before deleting an object if appropriate. It is always

--- a/db.go
+++ b/db.go
@@ -2005,15 +2005,17 @@ func (d *DB) SSTables(opts ...SSTablesOption) ([][]SSTableInfo, error) {
 			if err != nil {
 				return nil, err
 			}
-			if objMeta.IsShared() {
-				if d.objProvider.IsForeign(objMeta) {
-					destTables[j].BackingType = BackingTypeSharedForeign
-				} else if objMeta.Shared.CleanupMethod == objstorage.SharedNoCleanup {
-					destTables[j].BackingType = BackingTypeExternal
+			if objMeta.IsRemote() {
+				if objMeta.IsShared() {
+					if d.objProvider.IsForeign(objMeta) {
+						destTables[j].BackingType = BackingTypeSharedForeign
+					} else {
+						destTables[j].BackingType = BackingTypeShared
+					}
 				} else {
-					destTables[j].BackingType = BackingTypeShared
+					destTables[j].BackingType = BackingTypeExternal
 				}
-				destTables[j].Locator = objMeta.Shared.Locator
+				destTables[j].Locator = objMeta.Remote.Locator
 			} else {
 				destTables[j].BackingType = BackingTypeLocal
 			}
@@ -2102,9 +2104,9 @@ func (d *DB) EstimateDiskUsageByBackingType(
 				if err != nil {
 					return 0, 0, 0, err
 				}
-				if meta.IsShared() {
+				if meta.IsRemote() {
 					remoteSize += file.Size
-					if meta.Shared.CleanupMethod == objstorage.SharedNoCleanup {
+					if meta.Remote.CleanupMethod == objstorage.SharedNoCleanup {
 						externalSize += file.Size
 					}
 				}
@@ -2137,9 +2139,9 @@ func (d *DB) EstimateDiskUsageByBackingType(
 				if err != nil {
 					return 0, 0, 0, err
 				}
-				if meta.IsShared() {
+				if meta.IsRemote() {
 					remoteSize += size
-					if meta.Shared.CleanupMethod == objstorage.SharedNoCleanup {
+					if meta.Remote.CleanupMethod == objstorage.SharedNoCleanup {
 						externalSize += size
 					}
 				}

--- a/ingest.go
+++ b/ingest.go
@@ -449,19 +449,19 @@ func ingestLink(
 			})
 		}
 	}
-	sharedObjs := make([]objstorage.SharedObjectToAttach, 0, len(shared))
+	sharedObjs := make([]objstorage.RemoteObjectToAttach, 0, len(shared))
 	for i := range shared {
 		backing, err := shared[i].Backing.Get()
 		if err != nil {
 			return err
 		}
-		sharedObjs = append(sharedObjs, objstorage.SharedObjectToAttach{
+		sharedObjs = append(sharedObjs, objstorage.RemoteObjectToAttach{
 			FileNum:  lr.sharedMeta[i].FileBacking.DiskFileNum,
 			FileType: fileTypeTable,
 			Backing:  backing,
 		})
 	}
-	sharedObjMetas, err := objProvider.AttachSharedObjects(sharedObjs)
+	sharedObjMetas, err := objProvider.AttachRemoteObjects(sharedObjs)
 	if err != nil {
 		return err
 	}
@@ -473,7 +473,7 @@ func ingestLink(
 		// open the db again after a crash/restart (see checkConsistency in open.go),
 		// plus it more accurately allows us to prioritize compactions of files
 		// that were originally created by us.
-		if !objProvider.IsForeign(sharedObjMetas[i]) {
+		if sharedObjMetas[i].IsShared() && !objProvider.IsForeign(sharedObjMetas[i]) {
 			size, err := objProvider.Size(sharedObjMetas[i])
 			if err != nil {
 				return err

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1092,7 +1092,7 @@ func TestSimpleIngestShared(t *testing.T) {
 	}
 
 	m := metaMap[base.FileNum(2).DiskFileNum()]
-	handle, err := provider2.SharedObjectBacking(&m)
+	handle, err := provider2.RemoteObjectBacking(&m)
 	require.NoError(t, err)
 	size, err := provider2.Size(m)
 	require.NoError(t, err)

--- a/objstorage/objstorageprovider/shared_backing.go
+++ b/objstorage/objstorageprovider/shared_backing.go
@@ -43,44 +43,44 @@ const (
 
 func (p *provider) encodeSharedObjectBacking(
 	meta *objstorage.ObjectMetadata,
-) (objstorage.SharedObjectBacking, error) {
-	if !meta.IsShared() {
+) (objstorage.RemoteObjectBacking, error) {
+	if !meta.IsRemote() {
 		return nil, errors.AssertionFailedf("object %s not on shared storage", meta.DiskFileNum)
 	}
 
 	buf := make([]byte, 0, binary.MaxVarintLen64*4)
 	buf = binary.AppendUvarint(buf, tagCreatorID)
-	buf = binary.AppendUvarint(buf, uint64(meta.Shared.CreatorID))
+	buf = binary.AppendUvarint(buf, uint64(meta.Remote.CreatorID))
 	// TODO(radu): encode file type as well?
 	buf = binary.AppendUvarint(buf, tagCreatorFileNum)
-	buf = binary.AppendUvarint(buf, uint64(meta.Shared.CreatorFileNum.FileNum()))
+	buf = binary.AppendUvarint(buf, uint64(meta.Remote.CreatorFileNum.FileNum()))
 	buf = binary.AppendUvarint(buf, tagCleanupMethod)
-	buf = binary.AppendUvarint(buf, uint64(meta.Shared.CleanupMethod))
-	if meta.Shared.CleanupMethod == objstorage.SharedRefTracking {
+	buf = binary.AppendUvarint(buf, uint64(meta.Remote.CleanupMethod))
+	if meta.Remote.CleanupMethod == objstorage.SharedRefTracking {
 		buf = binary.AppendUvarint(buf, tagRefCheckID)
 		buf = binary.AppendUvarint(buf, uint64(p.shared.creatorID))
 		buf = binary.AppendUvarint(buf, uint64(meta.DiskFileNum.FileNum()))
 	}
-	if meta.Shared.Locator != "" {
+	if meta.Remote.Locator != "" {
 		buf = binary.AppendUvarint(buf, tagLocator)
-		buf = encodeString(buf, string(meta.Shared.Locator))
+		buf = encodeString(buf, string(meta.Remote.Locator))
 	}
-	if meta.Shared.CustomObjectName != "" {
+	if meta.Remote.CustomObjectName != "" {
 		buf = binary.AppendUvarint(buf, tagCustomObjectName)
-		buf = encodeString(buf, meta.Shared.CustomObjectName)
+		buf = encodeString(buf, meta.Remote.CustomObjectName)
 	}
 	return buf, nil
 }
 
 type sharedObjectBackingHandle struct {
-	backing objstorage.SharedObjectBacking
+	backing objstorage.RemoteObjectBacking
 	fileNum base.DiskFileNum
 	p       *provider
 }
 
-func (s *sharedObjectBackingHandle) Get() (objstorage.SharedObjectBacking, error) {
+func (s *sharedObjectBackingHandle) Get() (objstorage.RemoteObjectBacking, error) {
 	if s.backing == nil {
-		return nil, errors.Errorf("SharedObjectBackingHandle.Get() called after Close()")
+		return nil, errors.Errorf("RemoteObjectBackingHandle.Get() called after Close()")
 	}
 	return s.backing, nil
 }
@@ -92,12 +92,12 @@ func (s *sharedObjectBackingHandle) Close() {
 	}
 }
 
-var _ objstorage.SharedObjectBackingHandle = (*sharedObjectBackingHandle)(nil)
+var _ objstorage.RemoteObjectBackingHandle = (*sharedObjectBackingHandle)(nil)
 
-// SharedObjectBacking is part of the objstorage.Provider interface.
-func (p *provider) SharedObjectBacking(
+// RemoteObjectBacking is part of the objstorage.Provider interface.
+func (p *provider) RemoteObjectBacking(
 	meta *objstorage.ObjectMetadata,
-) (objstorage.SharedObjectBackingHandle, error) {
+) (objstorage.RemoteObjectBackingHandle, error) {
 	backing, err := p.encodeSharedObjectBacking(meta)
 	if err != nil {
 		return nil, err
@@ -110,20 +110,20 @@ func (p *provider) SharedObjectBacking(
 	}, nil
 }
 
-// CreateSharedObjectBacking is part of the objstorage.Provider interface.
-func (p *provider) CreateSharedObjectBacking(
+// CreateExternalObjectBacking is part of the objstorage.Provider interface.
+func (p *provider) CreateExternalObjectBacking(
 	locator shared.Locator, objName string,
-) (objstorage.SharedObjectBacking, error) {
+) (objstorage.RemoteObjectBacking, error) {
 	var meta objstorage.ObjectMetadata
-	meta.Shared.Locator = locator
-	meta.Shared.CustomObjectName = objName
-	meta.Shared.CleanupMethod = objstorage.SharedNoCleanup
+	meta.Remote.Locator = locator
+	meta.Remote.CustomObjectName = objName
+	meta.Remote.CleanupMethod = objstorage.SharedNoCleanup
 	return p.encodeSharedObjectBacking(&meta)
 }
 
 type decodedBacking struct {
 	meta objstorage.ObjectMetadata
-	// refToCheck is set only when meta.Shared.CleanupMethod is RefTracking
+	// refToCheck is set only when meta.Remote.CleanupMethod is RefTracking
 	refToCheck struct {
 		creatorID objstorage.CreatorID
 		fileNum   base.DiskFileNum
@@ -132,9 +132,9 @@ type decodedBacking struct {
 
 // decodeSharedObjectBacking decodes the shared object metadata.
 //
-// Note that the meta.Shared.Storage field is not set.
+// Note that the meta.Remote.Storage field is not set.
 func decodeSharedObjectBacking(
-	fileType base.FileType, fileNum base.DiskFileNum, buf objstorage.SharedObjectBacking,
+	fileType base.FileType, fileNum base.DiskFileNum, buf objstorage.RemoteObjectBacking,
 ) (decodedBacking, error) {
 	var creatorID, creatorFileNum, cleanupMethod, refCheckCreatorID, refCheckFileNum uint64
 	var locator, customObjName string
@@ -195,18 +195,18 @@ func decodeSharedObjectBacking(
 	var res decodedBacking
 	res.meta.DiskFileNum = fileNum
 	res.meta.FileType = fileType
-	res.meta.Shared.CreatorID = objstorage.CreatorID(creatorID)
-	res.meta.Shared.CreatorFileNum = base.FileNum(creatorFileNum).DiskFileNum()
-	res.meta.Shared.CleanupMethod = objstorage.SharedCleanupMethod(cleanupMethod)
-	if res.meta.Shared.CleanupMethod == objstorage.SharedRefTracking {
+	res.meta.Remote.CreatorID = objstorage.CreatorID(creatorID)
+	res.meta.Remote.CreatorFileNum = base.FileNum(creatorFileNum).DiskFileNum()
+	res.meta.Remote.CleanupMethod = objstorage.SharedCleanupMethod(cleanupMethod)
+	if res.meta.Remote.CleanupMethod == objstorage.SharedRefTracking {
 		if refCheckCreatorID == 0 || refCheckFileNum == 0 {
 			return decodedBacking{}, errors.Newf("shared object backing missing ref to check")
 		}
 		res.refToCheck.creatorID = objstorage.CreatorID(refCheckCreatorID)
 		res.refToCheck.fileNum = base.FileNum(refCheckFileNum).DiskFileNum()
 	}
-	res.meta.Shared.Locator = shared.Locator(locator)
-	res.meta.Shared.CustomObjectName = customObjName
+	res.meta.Remote.Locator = shared.Locator(locator)
+	res.meta.Remote.CustomObjectName = customObjName
 	return res, nil
 }
 
@@ -231,9 +231,9 @@ func decodeString(br io.ByteReader) (string, error) {
 	return string(buf), nil
 }
 
-// AttachSharedObjects is part of the objstorage.Provider interface.
-func (p *provider) AttachSharedObjects(
-	objs []objstorage.SharedObjectToAttach,
+// AttachRemoteObjects is part of the objstorage.Provider interface.
+func (p *provider) AttachRemoteObjects(
+	objs []objstorage.RemoteObjectToAttach,
 ) ([]objstorage.ObjectMetadata, error) {
 	decoded := make([]decodedBacking, len(objs))
 	for i, o := range objs {
@@ -242,7 +242,7 @@ func (p *provider) AttachSharedObjects(
 		if err != nil {
 			return nil, err
 		}
-		decoded[i].meta.Shared.Storage, err = p.ensureStorage(decoded[i].meta.Shared.Locator)
+		decoded[i].meta.Remote.Storage, err = p.ensureStorage(decoded[i].meta.Remote.Locator)
 		if err != nil {
 			return nil, err
 		}
@@ -251,7 +251,7 @@ func (p *provider) AttachSharedObjects(
 	// Create the reference marker objects.
 	// TODO(radu): parallelize this.
 	for _, d := range decoded {
-		if d.meta.Shared.CleanupMethod != objstorage.SharedRefTracking {
+		if d.meta.Remote.CleanupMethod != objstorage.SharedRefTracking {
 			continue
 		}
 		if err := p.sharedCreateRef(d.meta); err != nil {
@@ -260,10 +260,10 @@ func (p *provider) AttachSharedObjects(
 		}
 		// Check the "origin"'s reference.
 		refName := sharedObjectRefName(d.meta, d.refToCheck.creatorID, d.refToCheck.fileNum)
-		if _, err := d.meta.Shared.Storage.Size(refName); err != nil {
+		if _, err := d.meta.Remote.Storage.Size(refName); err != nil {
 			_ = p.sharedUnref(d.meta)
 			// TODO(radu): clean up references previously created in this loop.
-			if d.meta.Shared.Storage.IsNotExistError(err) {
+			if d.meta.Remote.Storage.IsNotExistError(err) {
 				return nil, errors.Errorf("origin marker object %q does not exist;"+
 					" object probably removed from the provider which created the backing", refName)
 			}
@@ -278,10 +278,10 @@ func (p *provider) AttachSharedObjects(
 			p.mu.shared.catalogBatch.AddObject(sharedobjcat.SharedObjectMetadata{
 				FileNum:        d.meta.DiskFileNum,
 				FileType:       d.meta.FileType,
-				CreatorID:      d.meta.Shared.CreatorID,
-				CreatorFileNum: d.meta.Shared.CreatorFileNum,
-				CleanupMethod:  d.meta.Shared.CleanupMethod,
-				Locator:        d.meta.Shared.Locator,
+				CreatorID:      d.meta.Remote.CreatorID,
+				CreatorFileNum: d.meta.Remote.CreatorFileNum,
+				CleanupMethod:  d.meta.Remote.CleanupMethod,
+				Locator:        d.meta.Remote.Locator,
 			})
 		}
 	}()

--- a/objstorage/objstorageprovider/shared_backing_test.go
+++ b/objstorage/objstorageprovider/shared_backing_test.go
@@ -37,14 +37,14 @@ func TestSharedObjectBacking(t *testing.T) {
 				DiskFileNum: base.FileNum(1).DiskFileNum(),
 				FileType:    base.FileTypeTable,
 			}
-			meta.Shared.CreatorID = 100
-			meta.Shared.CreatorFileNum = base.FileNum(200).DiskFileNum()
-			meta.Shared.CleanupMethod = cleanup
-			meta.Shared.Locator = "foo"
-			meta.Shared.CustomObjectName = "obj-name"
-			meta.Shared.Storage = sharedStorage
+			meta.Remote.CreatorID = 100
+			meta.Remote.CreatorFileNum = base.FileNum(200).DiskFileNum()
+			meta.Remote.CleanupMethod = cleanup
+			meta.Remote.Locator = "foo"
+			meta.Remote.CustomObjectName = "obj-name"
+			meta.Remote.Storage = sharedStorage
 
-			h, err := p.SharedObjectBacking(&meta)
+			h, err := p.RemoteObjectBacking(&meta)
 			require.NoError(t, err)
 			buf, err := h.Get()
 			require.NoError(t, err)
@@ -56,8 +56,8 @@ func TestSharedObjectBacking(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, uint64(100), uint64(d1.meta.DiskFileNum.FileNum()))
 			require.Equal(t, base.FileTypeTable, d1.meta.FileType)
-			d1.meta.Shared.Storage = sharedStorage
-			require.Equal(t, meta.Shared, d1.meta.Shared)
+			d1.meta.Remote.Storage = sharedStorage
+			require.Equal(t, meta.Remote, d1.meta.Remote)
 			if cleanup == objstorage.SharedRefTracking {
 				require.Equal(t, creatorID, d1.refToCheck.creatorID)
 				require.Equal(t, base.FileNum(1).DiskFileNum(), d1.refToCheck.fileNum)
@@ -77,8 +77,8 @@ func TestSharedObjectBacking(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, uint64(100), uint64(d2.meta.DiskFileNum.FileNum()))
 				require.Equal(t, base.FileTypeTable, d2.meta.FileType)
-				d2.meta.Shared.Storage = sharedStorage
-				require.Equal(t, meta.Shared, d2.meta.Shared)
+				d2.meta.Remote.Storage = sharedStorage
+				require.Equal(t, meta.Remote, d2.meta.Remote)
 				if cleanup == objstorage.SharedRefTracking {
 					require.Equal(t, creatorID, d2.refToCheck.creatorID)
 					require.Equal(t, base.FileNum(1).DiskFileNum(), d2.refToCheck.fileNum)
@@ -109,13 +109,13 @@ func TestCreateSharedObjectBacking(t *testing.T) {
 
 	require.NoError(t, p.SetCreatorID(1))
 
-	backing, err := p.CreateSharedObjectBacking("foo", "custom-obj-name")
+	backing, err := p.CreateExternalObjectBacking("foo", "custom-obj-name")
 	require.NoError(t, err)
 	d, err := decodeSharedObjectBacking(base.FileTypeTable, base.FileNum(100).DiskFileNum(), backing)
 	require.NoError(t, err)
 	require.Equal(t, uint64(100), uint64(d.meta.DiskFileNum.FileNum()))
 	require.Equal(t, base.FileTypeTable, d.meta.FileType)
-	require.Equal(t, shared.Locator("foo"), d.meta.Shared.Locator)
-	require.Equal(t, "custom-obj-name", d.meta.Shared.CustomObjectName)
-	require.Equal(t, objstorage.SharedNoCleanup, d.meta.Shared.CleanupMethod)
+	require.Equal(t, shared.Locator("foo"), d.meta.Remote.Locator)
+	require.Equal(t, "custom-obj-name", d.meta.Remote.CustomObjectName)
+	require.Equal(t, objstorage.SharedNoCleanup, d.meta.Remote.CleanupMethod)
 }

--- a/objstorage/objstorageprovider/shared_obj_name.go
+++ b/objstorage/objstorageprovider/shared_obj_name.go
@@ -16,14 +16,14 @@ import (
 // For sstables, the format is: <hash>-<creator-id>-<file-num>.sst
 // For example: 1a3f-2-000001.sst
 func sharedObjectName(meta objstorage.ObjectMetadata) string {
-	if meta.Shared.CustomObjectName != "" {
-		return meta.Shared.CustomObjectName
+	if meta.Remote.CustomObjectName != "" {
+		return meta.Remote.CustomObjectName
 	}
 	switch meta.FileType {
 	case base.FileTypeTable:
 		return fmt.Sprintf(
 			"%04x-%d-%06d.sst",
-			objHash(meta), meta.Shared.CreatorID, meta.Shared.CreatorFileNum.FileNum(),
+			objHash(meta), meta.Remote.CreatorID, meta.Remote.CreatorFileNum.FileNum(),
 		)
 	}
 	panic("unknown FileType")
@@ -37,33 +37,33 @@ func sharedObjectName(meta objstorage.ObjectMetadata) string {
 func sharedObjectRefName(
 	meta objstorage.ObjectMetadata, refCreatorID objstorage.CreatorID, refFileNum base.DiskFileNum,
 ) string {
-	if meta.Shared.CleanupMethod != objstorage.SharedRefTracking {
+	if meta.Remote.CleanupMethod != objstorage.SharedRefTracking {
 		panic("ref object used when ref tracking disabled")
 	}
-	if meta.Shared.CustomObjectName != "" {
+	if meta.Remote.CustomObjectName != "" {
 		return fmt.Sprintf(
-			"%s.ref.%d.%06d", meta.Shared.CustomObjectName, refCreatorID, refFileNum.FileNum(),
+			"%s.ref.%d.%06d", meta.Remote.CustomObjectName, refCreatorID, refFileNum.FileNum(),
 		)
 	}
 	switch meta.FileType {
 	case base.FileTypeTable:
 		return fmt.Sprintf(
 			"%04x-%d-%06d.sst.ref.%d.%06d",
-			objHash(meta), meta.Shared.CreatorID, meta.Shared.CreatorFileNum.FileNum(), refCreatorID, refFileNum.FileNum(),
+			objHash(meta), meta.Remote.CreatorID, meta.Remote.CreatorFileNum.FileNum(), refCreatorID, refFileNum.FileNum(),
 		)
 	}
 	panic("unknown FileType")
 }
 
 func sharedObjectRefPrefix(meta objstorage.ObjectMetadata) string {
-	if meta.Shared.CustomObjectName != "" {
-		return meta.Shared.CustomObjectName + ".ref."
+	if meta.Remote.CustomObjectName != "" {
+		return meta.Remote.CustomObjectName + ".ref."
 	}
 	switch meta.FileType {
 	case base.FileTypeTable:
 		return fmt.Sprintf(
 			"%04x-%d-%06d.sst.ref.",
-			objHash(meta), meta.Shared.CreatorID, meta.Shared.CreatorFileNum.FileNum(),
+			objHash(meta), meta.Remote.CreatorID, meta.Remote.CreatorFileNum.FileNum(),
 		)
 	}
 	panic("unknown FileType")
@@ -75,7 +75,7 @@ func sharedObjectRefPrefix(meta objstorage.ObjectMetadata) string {
 //
 // For example: 1a3f-2-000001.sst.ref.5.000008
 func (p *provider) sharedObjectRefName(meta objstorage.ObjectMetadata) string {
-	if meta.Shared.CleanupMethod != objstorage.SharedRefTracking {
+	if meta.Remote.CleanupMethod != objstorage.SharedRefTracking {
 		panic("ref object used when ref tracking disabled")
 	}
 	return sharedObjectRefName(meta, p.shared.creatorID, meta.DiskFileNum)
@@ -87,5 +87,5 @@ func (p *provider) sharedObjectRefName(meta objstorage.ObjectMetadata) string {
 func objHash(meta objstorage.ObjectMetadata) uint16 {
 	const prime1 = 7459
 	const prime2 = 17539
-	return uint16(uint64(meta.Shared.CreatorID)*prime1 + uint64(meta.Shared.CreatorFileNum.FileNum())*prime2)
+	return uint16(uint64(meta.Remote.CreatorID)*prime1 + uint64(meta.Remote.CreatorFileNum.FileNum())*prime2)
 }

--- a/objstorage/objstorageprovider/shared_obj_name_test.go
+++ b/objstorage/objstorageprovider/shared_obj_name_test.go
@@ -23,17 +23,17 @@ func TestSharedObjectNames(t *testing.T) {
 			var meta objstorage.ObjectMetadata
 			meta.DiskFileNum = base.FileNum(rand.Intn(100000)).DiskFileNum()
 			meta.FileType = supportedFileTypes[rand.Int()%len(supportedFileTypes)]
-			meta.Shared.CreatorID = objstorage.CreatorID(rand.Int63())
-			meta.Shared.CreatorFileNum = base.FileNum(rand.Intn(100000)).DiskFileNum()
+			meta.Remote.CreatorID = objstorage.CreatorID(rand.Int63())
+			meta.Remote.CreatorFileNum = base.FileNum(rand.Intn(100000)).DiskFileNum()
 			if rand.Intn(4) == 0 {
-				meta.Shared.CustomObjectName = fmt.Sprintf("foo-%d.sst", rand.Intn(10000))
+				meta.Remote.CustomObjectName = fmt.Sprintf("foo-%d.sst", rand.Intn(10000))
 			}
 
 			obj := sharedObjectName(meta)
 			// Cross-check against cleaner implementations.
-			expObj := meta.Shared.CustomObjectName
+			expObj := meta.Remote.CustomObjectName
 			if expObj == "" {
-				expObj = fmt.Sprintf("%04x-%s-%s", objHash(meta), meta.Shared.CreatorID, base.MakeFilename(meta.FileType, meta.Shared.CreatorFileNum))
+				expObj = fmt.Sprintf("%04x-%s-%s", objHash(meta), meta.Remote.CreatorID, base.MakeFilename(meta.FileType, meta.Remote.CreatorFileNum))
 			}
 			require.Equal(t, expObj, obj)
 
@@ -50,8 +50,8 @@ func TestSharedObjectNames(t *testing.T) {
 		var meta objstorage.ObjectMetadata
 		meta.DiskFileNum = base.FileNum(123).DiskFileNum()
 		meta.FileType = base.FileTypeTable
-		meta.Shared.CreatorID = objstorage.CreatorID(456)
-		meta.Shared.CreatorFileNum = base.FileNum(789).DiskFileNum()
+		meta.Remote.CreatorID = objstorage.CreatorID(456)
+		meta.Remote.CreatorFileNum = base.FileNum(789).DiskFileNum()
 		require.Equal(t, sharedObjectName(meta), "0e17-456-000789.sst")
 		require.Equal(t, sharedObjectRefPrefix(meta), "0e17-456-000789.sst.ref.")
 

--- a/objstorage/shared/storage.go
+++ b/objstorage/shared/storage.go
@@ -13,7 +13,7 @@ import (
 //
 // The Locator must not contain secrets (like authentication keys). Locators are
 // stored on disk in the shared object catalog and are passed around as part of
-// SharedObjectBacking; they can also appear in error messages.
+// RemoteObjectBacking; they can also appear in error messages.
 type Locator string
 
 // StorageFactory is used to return Storage implementations based on locators. A

--- a/open.go
+++ b/open.go
@@ -814,7 +814,7 @@ func (d *DB) replayWAL(
 					if err != nil {
 						return nil, 0, errors.Wrap(err, "pebble: error when looking up ingested SSTs")
 					}
-					if objMeta.IsShared() {
+					if objMeta.IsRemote() {
 						readable, err = d.objProvider.OpenForReading(context.TODO(), fileTypeTable, n, objstorage.OpenOptions{MustExist: true})
 						if err != nil {
 							return nil, 0, errors.Wrap(err, "pebble: error when opening flushable ingest files")

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -45,7 +45,7 @@ var ErrInvalidSkipSharedIteration = errors.New("pebble: cannot use skip-shared i
 type SharedSSTMeta struct {
 	// Backing is the shared object underlying this SST. Can be attached to an
 	// objstorage.Provider.
-	Backing objstorage.SharedObjectBackingHandle
+	Backing objstorage.RemoteObjectBackingHandle
 
 	// Smallest and Largest internal keys for the overall bounds. The kind and
 	// SeqNum of these will reflect what is physically present on the source Pebble
@@ -725,7 +725,7 @@ func (d *DB) truncateSharedFile(
 	sst = &SharedSSTMeta{}
 	sst.cloneFromFileMeta(file)
 	sst.Level = uint8(level)
-	sst.Backing, err = d.objProvider.SharedObjectBacking(&objMeta)
+	sst.Backing, err = d.objProvider.RemoteObjectBacking(&objMeta)
 	if err != nil {
 		return nil, false, err
 	}


### PR DESCRIPTION
`IsShared()` is split into `IsRemote()`, `IsShared()`, `IsExternal()`.

I tried to update the former uses of `IsShared()` appropriately - use `IsRemote()` in most cases but keep using `IsShared()` in the disagg storage code for skip-shared iteration. These callsites can use reviewing though.

I can wait to merge this when it is convenient, given the other ongoing work.