### PR TITLE
objstorage: rename objstorage/shared package to remote and rename SharedStorage to RemoteStorage in options

### DIFF
--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -101,7 +101,7 @@ func newPebbleDB(dir string) DB {
 	}
 
 	if pathToLocalSharedStorage != "" {
-		opts.Experimental.SharedStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			// Store all shared objects on local disk, for convenience.
 			"": remote.NewLocalFS(pathToLocalSharedStorage, vfs.Default),
 		})

--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/bytealloc"
-	"github.com/cockroachdb/pebble/objstorage/shared"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/vfs"
 )
 
@@ -101,9 +101,9 @@ func newPebbleDB(dir string) DB {
 	}
 
 	if pathToLocalSharedStorage != "" {
-		opts.Experimental.SharedStorage = shared.MakeSimpleFactory(map[shared.Locator]shared.Storage{
+		opts.Experimental.SharedStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			// Store all shared objects on local disk, for convenience.
-			"": shared.NewLocalFS(pathToLocalSharedStorage, vfs.Default),
+			"": remote.NewLocalFS(pathToLocalSharedStorage, vfs.Default),
 		})
 		opts.Experimental.CreateOnShared = true
 		if secondaryCacheSize != 0 {

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
-	"github.com/cockroachdb/pebble/objstorage/shared"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/errorfs"
@@ -3881,8 +3881,8 @@ func TestCompaction_LogAndApplyFails(t *testing.T) {
 func TestSharedObjectDeletePacing(t *testing.T) {
 	var opts Options
 	opts.FS = vfs.NewMem()
-	opts.Experimental.SharedStorage = shared.MakeSimpleFactory(map[shared.Locator]shared.Storage{
-		"": shared.NewInMem(),
+	opts.Experimental.SharedStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		"": remote.NewInMem(),
 	})
 	opts.Experimental.CreateOnShared = true
 	opts.TargetByteDeletionRate = 1

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -3881,7 +3881,7 @@ func TestCompaction_LogAndApplyFails(t *testing.T) {
 func TestSharedObjectDeletePacing(t *testing.T) {
 	var opts Options
 	opts.FS = vfs.NewMem()
-	opts.Experimental.SharedStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+	opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 		"": remote.NewInMem(),
 	})
 	opts.Experimental.CreateOnShared = true

--- a/db.go
+++ b/db.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/manual"
 	"github.com/cockroachdb/pebble/objstorage"
-	"github.com/cockroachdb/pebble/objstorage/shared"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/rangekey"
 	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/sstable"
@@ -1939,9 +1939,9 @@ type SSTableInfo struct {
 	BackingSSTNum base.FileNum
 	// BackingType is the type of storage backing this sstable.
 	BackingType BackingType
-	// Locator is the shared.Locator backing this sstable, if one was specified
-	// during ingest.
-	Locator shared.Locator
+	// Locator is the remote.Locator backing this sstable, if the backing type is
+	// not BackingTypeLocal.
+	Locator remote.Locator
 
 	// Properties is the sstable properties of this table. If Virtual is true,
 	// then the Properties are associated with the backing sst.

--- a/db.go
+++ b/db.go
@@ -2567,7 +2567,7 @@ func firstError(err0, err1 error) error {
 // Does nothing if SharedStorage was not set in the options when the DB was
 // opened or if the DB is in read-only mode.
 func (d *DB) SetCreatorID(creatorID uint64) error {
-	if d.opts.Experimental.SharedStorage == nil || d.opts.ReadOnly {
+	if d.opts.Experimental.RemoteStorage == nil || d.opts.ReadOnly {
 		return nil
 	}
 	return d.objProvider.SetCreatorID(objstorage.CreatorID(creatorID))

--- a/ingest.go
+++ b/ingest.go
@@ -827,7 +827,7 @@ func ingestTargetLevel(
 //
 // Two types of sstables are accepted for ingestion(s): one is sstables present
 // in the instance's vfs.FS and can be referenced locally. The other is sstables
-// present in shared.Storage, referred to as shared or foreign sstables. These
+// present in remote.Storage, referred to as shared or foreign sstables. These
 // shared sstables can be linked through objstorageprovider.Provider, and do not
 // need to already be present on the local vfs.FS. Foreign sstables must all fit
 // in an excise span, and are destined for a level specified in SharedSSTMeta.
@@ -914,14 +914,14 @@ func (d *DB) IngestWithStats(paths []string) (IngestOperationStats, error) {
 }
 
 // IngestAndExcise does the same as IngestWithStats, and additionally accepts a
-// list of shared files to ingest that can be read from a shared.Storage through
+// list of shared files to ingest that can be read from a remote.Storage through
 // a Provider. All the shared files must live within exciseSpan, and any existing
 // keys in exciseSpan are deleted by turning existing sstables into virtual
 // sstables (if not virtual already) and shrinking their spans to exclude
 // exciseSpan. See the comment at Ingest for a more complete picture of the
 // ingestion process.
 //
-// Panics if this DB instance was not instantiated with a shared.Storage and
+// Panics if this DB instance was not instantiated with a remote.Storage and
 // shared sstables are present.
 func (d *DB) IngestAndExcise(
 	paths []string, shared []SharedSSTMeta, exciseSpan KeyRange,

--- a/ingest.go
+++ b/ingest.go
@@ -1049,7 +1049,7 @@ func (d *DB) ingest(
 	shared []SharedSSTMeta,
 	exciseSpan KeyRange,
 ) (IngestOperationStats, error) {
-	if len(shared) > 0 && d.opts.Experimental.SharedStorage == nil {
+	if len(shared) > 0 && d.opts.Experimental.RemoteStorage == nil {
 		panic("cannot ingest shared sstables with nil SharedStorage")
 	}
 	if (exciseSpan.Valid() || len(shared) > 0) && d.opts.FormatMajorVersion < ExperimentalFormatVirtualSSTables {

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -779,7 +779,7 @@ func TestIngestShared(t *testing.T) {
 			DebugCheck:            DebugCheckLevels,
 			FormatMajorVersion:    ExperimentalFormatVirtualSSTables,
 		}
-		opts1.Experimental.SharedStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		opts1.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"": sstorage,
 		})
 		opts1.Experimental.CreateOnShared = true
@@ -790,7 +790,7 @@ func TestIngestShared(t *testing.T) {
 
 		opts2 := &Options{}
 		*opts2 = *opts1
-		opts2.Experimental.SharedStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		opts2.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"": sstorage,
 		})
 		opts2.Experimental.CreateOnShared = true
@@ -1059,7 +1059,7 @@ func TestSimpleIngestShared(t *testing.T) {
 			L0CompactionThreshold: 100,
 			L0StopWritesThreshold: 100,
 		}
-		opts.Experimental.SharedStorage = providerSettings.Shared.StorageFactory
+		opts.Experimental.RemoteStorage = providerSettings.Shared.StorageFactory
 		opts.Experimental.CreateOnShared = providerSettings.Shared.CreateOnShared
 		opts.Experimental.CreateOnSharedLocator = providerSettings.Shared.CreateOnSharedLocator
 

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
-	"github.com/cockroachdb/pebble/objstorage/shared"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -765,7 +765,7 @@ func TestIngestShared(t *testing.T) {
 			require.NoError(t, d2.Close())
 		}
 
-		sstorage := shared.NewInMem()
+		sstorage := remote.NewInMem()
 		mem1 := vfs.NewMem()
 		mem2 := vfs.NewMem()
 		require.NoError(t, mem1.MkdirAll("ext", 0755))
@@ -779,7 +779,7 @@ func TestIngestShared(t *testing.T) {
 			DebugCheck:            DebugCheckLevels,
 			FormatMajorVersion:    ExperimentalFormatVirtualSSTables,
 		}
-		opts1.Experimental.SharedStorage = shared.MakeSimpleFactory(map[shared.Locator]shared.Storage{
+		opts1.Experimental.SharedStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"": sstorage,
 		})
 		opts1.Experimental.CreateOnShared = true
@@ -790,7 +790,7 @@ func TestIngestShared(t *testing.T) {
 
 		opts2 := &Options{}
 		*opts2 = *opts1
-		opts2.Experimental.SharedStorage = shared.MakeSimpleFactory(map[shared.Locator]shared.Storage{
+		opts2.Experimental.SharedStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"": sstorage,
 		})
 		opts2.Experimental.CreateOnShared = true
@@ -1030,8 +1030,8 @@ func TestSimpleIngestShared(t *testing.T) {
 		NoSyncOnClose:       opts2.NoSyncOnClose,
 		BytesPerSync:        opts2.BytesPerSync,
 	}
-	providerSettings.Shared.StorageFactory = shared.MakeSimpleFactory(map[shared.Locator]shared.Storage{
-		"": shared.NewInMem(),
+	providerSettings.Shared.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		"": remote.NewInMem(),
 	})
 	providerSettings.Shared.CreateOnShared = true
 	providerSettings.Shared.CreateOnSharedLocator = ""

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/testkeys"
-	"github.com/cockroachdb/pebble/objstorage/shared"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"golang.org/x/exp/rand"
@@ -94,8 +94,8 @@ func parseOptions(
 				return true
 			case "TestOptions.shared_storage_enabled":
 				opts.sharedStorageEnabled = true
-				opts.Opts.Experimental.SharedStorage = shared.MakeSimpleFactory(map[shared.Locator]shared.Storage{
-					"": shared.NewInMem(),
+				opts.Opts.Experimental.SharedStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+					"": remote.NewInMem(),
 				})
 				opts.Opts.Experimental.CreateOnShared = true
 				return true
@@ -500,8 +500,8 @@ func randomOptions(
 	// 20% of time, enable shared storage.
 	if rng.Intn(5) == 0 {
 		testOpts.sharedStorageEnabled = true
-		testOpts.Opts.Experimental.SharedStorage = shared.MakeSimpleFactory(map[shared.Locator]shared.Storage{
-			"": shared.NewInMem(),
+		testOpts.Opts.Experimental.SharedStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+			"": remote.NewInMem(),
 		})
 		testOpts.Opts.Experimental.CreateOnShared = true
 		// If shared storage is enabled, enable secondary cache 50% of time.

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -94,7 +94,7 @@ func parseOptions(
 				return true
 			case "TestOptions.shared_storage_enabled":
 				opts.sharedStorageEnabled = true
-				opts.Opts.Experimental.SharedStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+				opts.Opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 					"": remote.NewInMem(),
 				})
 				opts.Opts.Experimental.CreateOnShared = true
@@ -500,7 +500,7 @@ func randomOptions(
 	// 20% of time, enable shared storage.
 	if rng.Intn(5) == 0 {
 		testOpts.sharedStorageEnabled = true
-		testOpts.Opts.Experimental.SharedStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		testOpts.Opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"": remote.NewInMem(),
 		})
 		testOpts.Opts.Experimental.CreateOnShared = true

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -66,7 +66,7 @@ func TestOptionsRoundtrip(t *testing.T) {
 		"MaxConcurrentCompactions:",
 		"Experimental.EnableValueBlocks:",
 		"Experimental.DisableIngestAsFlushable:",
-		"Experimental.SharedStorage:",
+		"Experimental.RemoteStorage:",
 		// Floating points
 		"Experimental.PointTombstoneWeight:",
 	}

--- a/objstorage/objstorage.go
+++ b/objstorage/objstorage.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/objstorage/shared"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/vfs"
 )
 
@@ -105,11 +105,11 @@ type ObjectMetadata struct {
 		CustomObjectName string
 		// CleanupMethod indicates the method for cleaning up unused shared objects.
 		CleanupMethod SharedCleanupMethod
-		// Locator identifies the shared.Storage implementation for this object.
-		Locator shared.Locator
-		// Storage is the shared.Storage object corresponding to the Locator. Used
+		// Locator identifies the remote.Storage implementation for this object.
+		Locator remote.Locator
+		// Storage is the remote.Storage object corresponding to the Locator. Used
 		// to avoid lookups in hot paths.
-		Storage shared.Storage
+		Storage remote.Storage
 	}
 }
 
@@ -207,7 +207,7 @@ type CreateOptions struct {
 // created by the provider, or existing objects the Provider was informed about
 // via AddObjects.
 //
-// Objects are currently backed by a vfs.File or a shared.Storage object.
+// Objects are currently backed by a vfs.File or a remote.Storage object.
 type Provider interface {
 	// OpenForReading opens an existing object.
 	OpenForReading(
@@ -279,7 +279,7 @@ type Provider interface {
 	// CreateExternalObjectBacking creates a backing for an existing object with a
 	// custom object name. The object is considered to be managed outside of
 	// Pebble and will never be removed by Pebble.
-	CreateExternalObjectBacking(locator shared.Locator, objName string) (RemoteObjectBacking, error)
+	CreateExternalObjectBacking(locator remote.Locator, objName string) (RemoteObjectBacking, error)
 
 	// AttachRemoteObjects registers existing remote objects with this provider.
 	AttachRemoteObjects(objs []RemoteObjectToAttach) ([]ObjectMetadata, error)

--- a/objstorage/objstorageprovider/provider.go
+++ b/objstorage/objstorageprovider/provider.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/sharedobjcat"
-	"github.com/cockroachdb/pebble/objstorage/shared"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/vfs"
 )
 
@@ -40,7 +40,7 @@ type provider struct {
 			// Sync is called.
 			catalogBatch sharedobjcat.Batch
 
-			storageObjects map[shared.Locator]shared.Storage
+			storageObjects map[remote.Locator]remote.Storage
 		}
 
 		// localObjectsChanged is set if non-shared objects were created or deleted
@@ -94,13 +94,13 @@ type Settings struct {
 	// Fields here are set only if the provider is to support shared objects
 	// (experimental).
 	Shared struct {
-		StorageFactory shared.StorageFactory
+		StorageFactory remote.StorageFactory
 
 		// If CreateOnShared is true, sstables are created on shared storage using
 		// the CreateOnSharedLocator (when the PreferSharedStorage create option is
 		// true).
 		CreateOnShared        bool
-		CreateOnSharedLocator shared.Locator
+		CreateOnSharedLocator remote.Locator
 
 		// CacheSizeBytes is the size of the on-disk block cache for objects
 		// on shared storage. If it is 0, no cache is used.
@@ -302,7 +302,7 @@ func (p *provider) isNotExistError(meta objstorage.ObjectMetadata, err error) bo
 // IsNotExistError is part of the objstorage.Provider interface.
 func (p *provider) IsNotExistError(err error) bool {
 	// We use errors.Mark(err, os.ErrNotExist) for not-exist errors coming from
-	// shared.Storage.
+	// remote.Storage.
 	return oserror.IsNotExist(err)
 }
 

--- a/objstorage/objstorageprovider/shared.go
+++ b/objstorage/objstorageprovider/shared.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/sharedcache"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/sharedobjcat"
-	"github.com/cockroachdb/pebble/objstorage/shared"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 )
 
 // sharedSubsystem contains the provider fields related to shared storage.
@@ -101,7 +101,7 @@ func (p *provider) sharedInit() error {
 		o.Remote.CustomObjectName = meta.CustomObjectName
 		o.Remote.Storage, err = p.ensureStorageLocked(o.Remote.Locator)
 		if err != nil {
-			return errors.Wrapf(err, "creating shared.Storage object for locator '%s'", o.Remote.Locator)
+			return errors.Wrapf(err, "creating remote.Storage object for locator '%s'", o.Remote.Locator)
 		}
 		if invariants.Enabled {
 			o.AssertValid()
@@ -213,7 +213,7 @@ func (p *provider) sharedCreate(
 	_ context.Context,
 	fileType base.FileType,
 	fileNum base.DiskFileNum,
-	locator shared.Locator,
+	locator remote.Locator,
 	opts objstorage.CreateOptions,
 ) (objstorage.Writable, objstorage.ObjectMetadata, error) {
 	if err := p.sharedCheckInitialized(); err != nil {
@@ -318,9 +318,9 @@ func (p *provider) sharedUnref(meta objstorage.ObjectMetadata) error {
 	return nil
 }
 
-func (p *provider) ensureStorageLocked(locator shared.Locator) (shared.Storage, error) {
+func (p *provider) ensureStorageLocked(locator remote.Locator) (remote.Storage, error) {
 	if p.mu.shared.storageObjects == nil {
-		p.mu.shared.storageObjects = make(map[shared.Locator]shared.Storage)
+		p.mu.shared.storageObjects = make(map[remote.Locator]remote.Storage)
 	}
 	if res, ok := p.mu.shared.storageObjects[locator]; ok {
 		return res, nil
@@ -333,7 +333,7 @@ func (p *provider) ensureStorageLocked(locator shared.Locator) (shared.Storage, 
 	p.mu.shared.storageObjects[locator] = res
 	return res, nil
 }
-func (p *provider) ensureStorage(locator shared.Locator) (shared.Storage, error) {
+func (p *provider) ensureStorage(locator remote.Locator) (remote.Storage, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.ensureStorageLocked(locator)

--- a/objstorage/objstorageprovider/shared_backing.go
+++ b/objstorage/objstorageprovider/shared_backing.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/sharedobjcat"
-	"github.com/cockroachdb/pebble/objstorage/shared"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 )
 
 const (
@@ -26,7 +26,7 @@ const (
 	// allows the "target" provider to check that the "source" provider kept its
 	// reference on the object alive.
 	tagRefCheckID = 4
-	// tagLocator encodes the shared.Locator; if absent the locator is "". It is
+	// tagLocator encodes the remote.Locator; if absent the locator is "". It is
 	// followed by the locator string length and the locator string.
 	tagLocator = 5
 	// tagLocator encodes a custom object name (if present). It is followed by the
@@ -112,7 +112,7 @@ func (p *provider) RemoteObjectBacking(
 
 // CreateExternalObjectBacking is part of the objstorage.Provider interface.
 func (p *provider) CreateExternalObjectBacking(
-	locator shared.Locator, objName string,
+	locator remote.Locator, objName string,
 ) (objstorage.RemoteObjectBacking, error) {
 	var meta objstorage.ObjectMetadata
 	meta.Remote.Locator = locator
@@ -205,7 +205,7 @@ func decodeSharedObjectBacking(
 		res.refToCheck.creatorID = objstorage.CreatorID(refCheckCreatorID)
 		res.refToCheck.fileNum = base.FileNum(refCheckFileNum).DiskFileNum()
 	}
-	res.meta.Remote.Locator = shared.Locator(locator)
+	res.meta.Remote.Locator = remote.Locator(locator)
 	res.meta.Remote.CustomObjectName = customObjName
 	return res, nil
 }

--- a/objstorage/objstorageprovider/shared_backing_test.go
+++ b/objstorage/objstorageprovider/shared_backing_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/objstorage"
-	"github.com/cockroachdb/pebble/objstorage/shared"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
@@ -23,8 +23,8 @@ func TestSharedObjectBacking(t *testing.T) {
 		}
 		t.Run(name, func(t *testing.T) {
 			st := DefaultSettings(vfs.NewMem(), "")
-			sharedStorage := shared.NewInMem()
-			st.Shared.StorageFactory = shared.MakeSimpleFactory(map[shared.Locator]shared.Storage{
+			sharedStorage := remote.NewInMem()
+			st.Shared.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 				"foo": sharedStorage,
 			})
 			p, err := Open(st)
@@ -99,8 +99,8 @@ func TestSharedObjectBacking(t *testing.T) {
 
 func TestCreateSharedObjectBacking(t *testing.T) {
 	st := DefaultSettings(vfs.NewMem(), "")
-	sharedStorage := shared.NewInMem()
-	st.Shared.StorageFactory = shared.MakeSimpleFactory(map[shared.Locator]shared.Storage{
+	sharedStorage := remote.NewInMem()
+	st.Shared.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 		"foo": sharedStorage,
 	})
 	p, err := Open(st)
@@ -115,7 +115,7 @@ func TestCreateSharedObjectBacking(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(100), uint64(d.meta.DiskFileNum.FileNum()))
 	require.Equal(t, base.FileTypeTable, d.meta.FileType)
-	require.Equal(t, shared.Locator("foo"), d.meta.Remote.Locator)
+	require.Equal(t, remote.Locator("foo"), d.meta.Remote.Locator)
 	require.Equal(t, "custom-obj-name", d.meta.Remote.CustomObjectName)
 	require.Equal(t, objstorage.SharedNoCleanup, d.meta.Remote.CleanupMethod)
 }

--- a/objstorage/objstorageprovider/shared_readable.go
+++ b/objstorage/objstorageprovider/shared_readable.go
@@ -11,15 +11,15 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/sharedcache"
-	"github.com/cockroachdb/pebble/objstorage/shared"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 )
 
 const sharedMaxReadaheadSize = 1024 * 1024 /* 1MB */
 
 // sharedReadable is a very simple implementation of Readable on top of the
-// ReadCloser returned by shared.Storage.CreateObject.
+// ReadCloser returned by remote.Storage.CreateObject.
 type sharedReadable struct {
-	objReader shared.ObjectReader
+	objReader remote.ObjectReader
 	size      int64
 	fileNum   base.DiskFileNum
 	provider  *provider
@@ -28,7 +28,7 @@ type sharedReadable struct {
 var _ objstorage.Readable = (*sharedReadable)(nil)
 
 func (p *provider) newSharedReadable(
-	objReader shared.ObjectReader, size int64, fileNum base.DiskFileNum,
+	objReader remote.ObjectReader, size int64, fileNum base.DiskFileNum,
 ) *sharedReadable {
 	return &sharedReadable{
 		objReader: objReader,

--- a/objstorage/objstorageprovider/shared_writable.go
+++ b/objstorage/objstorageprovider/shared_writable.go
@@ -11,7 +11,7 @@ import (
 )
 
 // sharedWritable is a very simple implementation of Writable on top of the
-// WriteCloser returned by shared.Storage.CreateObject.
+// WriteCloser returned by remote.Storage.CreateObject.
 type sharedWritable struct {
 	p             *provider
 	meta          objstorage.ObjectMetadata

--- a/objstorage/objstorageprovider/sharedcache/shared_cache.go
+++ b/objstorage/objstorageprovider/sharedcache/shared_cache.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
-	"github.com/cockroachdb/pebble/objstorage/shared"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/vfs"
 )
 
@@ -111,7 +111,7 @@ func (c *Cache) ReadAt(
 	fileNum base.DiskFileNum,
 	p []byte,
 	ofs int64,
-	objReader shared.ObjectReader,
+	objReader remote.ObjectReader,
 	objSize int64,
 	flags ReadFlags,
 ) error {

--- a/objstorage/objstorageprovider/sharedobjcat/catalog.go
+++ b/objstorage/objstorageprovider/sharedobjcat/catalog.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/objstorage"
-	"github.com/cockroachdb/pebble/objstorage/shared"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/atomicfs"
@@ -59,8 +59,8 @@ type SharedObjectMetadata struct {
 	CreatorFileNum base.DiskFileNum
 	// CleanupMethod indicates the method for cleaning up unused shared objects.
 	CleanupMethod objstorage.SharedCleanupMethod
-	// Locator identifies a shared.Storage implementation.
-	Locator shared.Locator
+	// Locator identifies a remote.Storage implementation.
+	Locator remote.Locator
 	// CustomObjectName (if it is set) overrides the object name that is normally
 	// derived from the CreatorID and CreatorFileNum.
 	CustomObjectName string

--- a/objstorage/objstorageprovider/sharedobjcat/version_edit.go
+++ b/objstorage/objstorageprovider/sharedobjcat/version_edit.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/objstorage"
-	"github.com/cockroachdb/pebble/objstorage/shared"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 )
 
 // versionEdit is a modification to the shared object state which can be encoded
@@ -170,7 +170,7 @@ func (v *versionEdit) Decode(r io.Reader) error {
 					CreatorID:        objstorage.CreatorID(creatorID),
 					CreatorFileNum:   base.FileNum(creatorFileNum).DiskFileNum(),
 					CleanupMethod:    objstorage.SharedCleanupMethod(cleanupMethod),
-					Locator:          shared.Locator(locator),
+					Locator:          remote.Locator(locator),
 					CustomObjectName: customName,
 				})
 			}

--- a/objstorage/remote/factory.go
+++ b/objstorage/remote/factory.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package shared
+package remote
 
 import "github.com/pkg/errors"
 

--- a/objstorage/remote/localfs.go
+++ b/objstorage/remote/localfs.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package shared
+package remote
 
 import (
 	"context"
@@ -13,7 +13,7 @@ import (
 	"github.com/cockroachdb/pebble/vfs"
 )
 
-// NewLocalFS returns a vfs-backed implementation of the shared.Storage
+// NewLocalFS returns a vfs-backed implementation of the remote.Storage
 // interface (for testing). All objects will be stored at the directory
 // dirname.
 func NewLocalFS(dirname string, fs vfs.FS) Storage {
@@ -24,7 +24,7 @@ func NewLocalFS(dirname string, fs vfs.FS) Storage {
 	return store
 }
 
-// localFSStore is a vfs-backed implementation of the shared.Storage
+// localFSStore is a vfs-backed implementation of the remote.Storage
 // interface (for testing).
 type localFSStore struct {
 	dirname string
@@ -33,13 +33,13 @@ type localFSStore struct {
 
 var _ Storage = (*localFSStore)(nil)
 
-// Close is part of the shared.Storage interface.
+// Close is part of the remote.Storage interface.
 func (s *localFSStore) Close() error {
 	*s = localFSStore{}
 	return nil
 }
 
-// ReadObject is part of the shared.Storage interface.
+// ReadObject is part of the remote.Storage interface.
 func (s *localFSStore) ReadObject(
 	ctx context.Context, objName string,
 ) (_ ObjectReader, objSize int64, _ error) {
@@ -78,13 +78,13 @@ func (r *localFSReader) Close() error {
 	return nil
 }
 
-// CreateObject is part of the shared.Storage interface.
+// CreateObject is part of the remote.Storage interface.
 func (s *localFSStore) CreateObject(objName string) (io.WriteCloser, error) {
 	file, err := s.vfs.Create(path.Join(s.dirname, objName))
 	return file, err
 }
 
-// List is part of the shared.Storage interface.
+// List is part of the remote.Storage interface.
 func (s *localFSStore) List(prefix, delimiter string) ([]string, error) {
 	// TODO(josh): For the intended use case of localfs.go of running 'pebble bench',
 	// List can always return <nil, nil>, since this indicates a file has only one ref,
@@ -93,12 +93,12 @@ func (s *localFSStore) List(prefix, delimiter string) ([]string, error) {
 	return nil, nil
 }
 
-// Delete is part of the shared.Storage interface.
+// Delete is part of the remote.Storage interface.
 func (s *localFSStore) Delete(objName string) error {
 	return s.vfs.Remove(path.Join(s.dirname, objName))
 }
 
-// Size is part of the shared.Storage interface.
+// Size is part of the remote.Storage interface.
 func (s *localFSStore) Size(objName string) (int64, error) {
 	f, err := s.vfs.Open(path.Join(s.dirname, objName))
 	if err != nil {
@@ -112,7 +112,7 @@ func (s *localFSStore) Size(objName string) (int64, error) {
 	return stat.Size(), nil
 }
 
-// IsNotExistError is part of the shared.Storage interface.
+// IsNotExistError is part of the remote.Storage interface.
 func (s *localFSStore) IsNotExistError(err error) bool {
 	return err == os.ErrNotExist
 }

--- a/objstorage/remote/logging.go
+++ b/objstorage/remote/logging.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package shared
+package remote
 
 import (
 	"context"
@@ -20,7 +20,7 @@ func WithLogging(wrapped Storage, logf func(fmt string, args ...interface{})) St
 	}
 }
 
-// loggingStore wraps a shared.Storage implementation and emits logs of the
+// loggingStore wraps a remote.Storage implementation and emits logs of the
 // operations.
 type loggingStore struct {
 	logf    func(fmt string, args ...interface{})

--- a/objstorage/remote/mem.go
+++ b/objstorage/remote/mem.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package shared
+package remote
 
 import (
 	"bytes"
@@ -13,7 +13,7 @@ import (
 	"sync"
 )
 
-// NewInMem returns an in-memory implementation of the shared.Storage
+// NewInMem returns an in-memory implementation of the remote.Storage
 // interface (for testing).
 func NewInMem() Storage {
 	store := &inMemStore{}
@@ -21,7 +21,7 @@ func NewInMem() Storage {
 	return store
 }
 
-// inMemStore is an in-memory implementation of the shared.Storage interface
+// inMemStore is an in-memory implementation of the remote.Storage interface
 // (for testing).
 type inMemStore struct {
 	mu struct {

--- a/objstorage/remote/storage.go
+++ b/objstorage/remote/storage.go
@@ -2,14 +2,14 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package shared
+package remote
 
 import (
 	"context"
 	"io"
 )
 
-// Locator is an opaque string identifying a shared.Storage implementation.
+// Locator is an opaque string identifying a remote.Storage implementation.
 //
 // The Locator must not contain secrets (like authentication keys). Locators are
 // stored on disk in the shared object catalog and are passed around as part of

--- a/open.go
+++ b/open.go
@@ -297,7 +297,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		NoSyncOnClose:       opts.NoSyncOnClose,
 		BytesPerSync:        opts.BytesPerSync,
 	}
-	providerSettings.Shared.StorageFactory = opts.Experimental.SharedStorage
+	providerSettings.Shared.StorageFactory = opts.Experimental.RemoteStorage
 	providerSettings.Shared.CreateOnShared = opts.Experimental.CreateOnShared
 	providerSettings.Shared.CreateOnSharedLocator = opts.Experimental.CreateOnSharedLocator
 	providerSettings.Shared.CacheSizeBytes = opts.Experimental.SecondaryCacheSize

--- a/options.go
+++ b/options.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/humanize"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
-	"github.com/cockroachdb/pebble/objstorage/shared"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -661,12 +661,12 @@ type Options struct {
 		// wrote a file should not delete it if other Pebble instances are known to
 		// be reading this file. This FS is expected to have slower read/write
 		// performance than the default FS above.
-		SharedStorage shared.StorageFactory
+		SharedStorage remote.StorageFactory
 
 		// If CreateOnShred is true, any new sstables are created on shared storage,
 		// using CreateOnSharedLocator. Can only be used when SharedStorage is set.
 		CreateOnShared        bool
-		CreateOnSharedLocator shared.Locator
+		CreateOnSharedLocator remote.Locator
 
 		// CacheSizeBytes is the size of the on-disk block cache for objects
 		// on shared storage. If it is 0, no cache is used.

--- a/options.go
+++ b/options.go
@@ -653,18 +653,18 @@ type Options struct {
 		// major version is at least `FormatFlushableIngest`.
 		DisableIngestAsFlushable func() bool
 
-		// SharedStorage is a second FS-like storage medium that can be shared
-		// between multiple Pebble instances. It is used to store sstables only, and
-		// is managed by objstorage.Provider. Each sstable might only be written to
-		// by one Pebble instance, but other Pebble instances can possibly read the
-		// same files if they have the path to get to them. The pebble instance that
-		// wrote a file should not delete it if other Pebble instances are known to
-		// be reading this file. This FS is expected to have slower read/write
-		// performance than the default FS above.
-		SharedStorage remote.StorageFactory
+		// RemoteStorage enables use of remote storage (e.g. S3) for storing
+		// sstables. Setting this option enables use of CreateOnShared option and
+		// allows ingestion of external files.
+		RemoteStorage remote.StorageFactory
 
-		// If CreateOnShred is true, any new sstables are created on shared storage,
-		// using CreateOnSharedLocator. Can only be used when SharedStorage is set.
+		// If CreateOnShared is true, any new sstables are created on remote storage
+		// (using CreateOnSharedLocator). These sstables can be shared between
+		// different Pebble instances; the lifecycle of such objects is managed by
+		// the cluster.
+		//
+		// Can only be used when RemoteStorage is set (and recognizes
+		// CreateOnSharedLocator).
 		CreateOnShared        bool
 		CreateOnSharedLocator remote.Locator
 

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/testkeys"
-	"github.com/cockroachdb/pebble/objstorage/shared"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/rangekey"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -47,8 +47,8 @@ func TestScanInternal(t *testing.T) {
 				sstable.NewTestKeysBlockPropertyCollector,
 			},
 		}
-		opts.Experimental.SharedStorage = shared.MakeSimpleFactory(map[shared.Locator]shared.Storage{
-			"": shared.NewInMem(),
+		opts.Experimental.SharedStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+			"": remote.NewInMem(),
 		})
 		opts.Experimental.CreateOnShared = true
 		opts.Experimental.CreateOnSharedLocator = ""

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -47,7 +47,7 @@ func TestScanInternal(t *testing.T) {
 				sstable.NewTestKeysBlockPropertyCollector,
 			},
 		}
-		opts.Experimental.SharedStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"": remote.NewInMem(),
 		})
 		opts.Experimental.CreateOnShared = true

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -130,7 +130,7 @@ func New(opts ...Option) *T {
 func (t *T) ConfigureSharedStorage(
 	s remote.StorageFactory, createOnShared bool, createOnSharedLocator remote.Locator,
 ) {
-	t.opts.Experimental.SharedStorage = s
+	t.opts.Experimental.RemoteStorage = s
 	t.opts.Experimental.CreateOnShared = createOnShared
 	t.opts.Experimental.CreateOnSharedLocator = createOnSharedLocator
 }

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/objstorage/shared"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/spf13/cobra"
@@ -128,7 +128,7 @@ func New(opts ...Option) *T {
 
 // ConfigureSharedStorage updates the shared storage options.
 func (t *T) ConfigureSharedStorage(
-	s shared.StorageFactory, createOnShared bool, createOnSharedLocator shared.Locator,
+	s remote.StorageFactory, createOnShared bool, createOnSharedLocator remote.Locator,
 ) {
 	t.opts.Experimental.SharedStorage = s
 	t.opts.Experimental.CreateOnShared = createOnShared


### PR DESCRIPTION
#### objstorage: rename objstorage/shared package to remote


#### db: rename Experimental.SharedStorage to RemoteStorage in Options

---

There will be some upcoming work inside the objstorage provider to rename things and separate the aspect of supporting remote storage vs supporting shared storage. We should allow external files even if shared storage is not enabled / we don't have a creator ID.