### PR TITLE
sharedcache: introduce metrics

### DIFF
--- a/db.go
+++ b/db.go
@@ -1966,7 +1966,11 @@ func (d *DB) Metrics() *Metrics {
 	metrics.BlockCache = d.opts.Cache.Metrics()
 	metrics.TableCache, metrics.Filter = d.tableCache.metrics()
 	metrics.TableIters = int64(d.tableCache.iterCount())
+
+	metrics.SecondaryCacheMetrics = d.objProvider.Metrics()
+
 	metrics.Uptime = d.timeNow().Sub(d.openedAt)
+
 	return metrics
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/humanize"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/sharedcache"
 	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/redact"
@@ -27,6 +28,11 @@ type FilterMetrics = sstable.FilterMetrics
 // ThroughputMetric is a cumulative throughput metric. See the detailed
 // comment in base.
 type ThroughputMetric = base.ThroughputMetric
+
+// SecondaryCacheMetrics holds metrics for the persistent secondary cache
+// that caches commonly accessed blocks from blob storage on a local
+// file system.
+type SecondaryCacheMetrics = sharedcache.Metrics
 
 // LevelMetrics holds per-level metrics such as the number of files and total
 // size of the files, and compaction related metrics.
@@ -263,6 +269,8 @@ type Metrics struct {
 		record.LogWriterMetrics
 	}
 
+	SecondaryCacheMetrics SecondaryCacheMetrics
+
 	private struct {
 		optionsFileSize  uint64
 		manifestFileSize uint64
@@ -353,6 +361,7 @@ func (m *Metrics) Total() LevelMetrics {
 //	Zombie tables: 16 (15B)
 //	Block cache: 2 entries (1B)  hit rate: 42.9%
 //	Table cache: 18 entries (17B)  hit rate: 48.7%
+//	Secondary cache: 40 entries (40B)  hit rate: 49.9%
 //	Snapshots: 4  earliest seq num: 1024
 //	Table iters: 21
 //	Filter utility: 47.4%
@@ -487,6 +496,15 @@ func (m *Metrics) SafeFormat(w redact.SafePrinter, _ rune) {
 	}
 	formatCacheMetrics(&m.BlockCache, "Block cache")
 	formatCacheMetrics(&m.TableCache, "Table cache")
+
+	formatSharedCacheMetrics := func(w redact.SafePrinter, m *SecondaryCacheMetrics, name redact.SafeString) {
+		w.Printf("%s: %s entries (%s)  hit rate: %.1f%%\n",
+			name,
+			humanize.Count.Int64(m.Count),
+			humanize.Bytes.Int64(m.Size),
+			redact.Safe(hitRate(m.ReadsWithFullHit, m.ReadsWithPartialHit+m.ReadsWithNoHit)))
+	}
+	formatSharedCacheMetrics(w, &m.SecondaryCacheMetrics, "Secondary cache")
 
 	w.Printf("Snapshots: %d  earliest seq num: %d\n",
 		redact.Safe(m.Snapshots.Count),

--- a/objstorage/objstorage.go
+++ b/objstorage/objstorage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/sharedcache"
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -287,6 +288,10 @@ type Provider interface {
 	// IsNotExistError indicates whether the error is known to report that a file or
 	// directory does not exist.
 	IsNotExistError(err error) bool
+
+	// Metrics returns metrics about objstorage. Currently, it only returns metrics
+	// about the shared cache.
+	Metrics() sharedcache.Metrics
 }
 
 // RemoteObjectBacking encodes the metadata necessary to incorporate a shared

--- a/objstorage/objstorageprovider/provider.go
+++ b/objstorage/objstorageprovider/provider.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/remoteobjcat"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/sharedcache"
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -437,6 +438,14 @@ func (p *provider) List() []objstorage.ObjectMetadata {
 		return res[i].DiskFileNum.FileNum() < res[j].DiskFileNum.FileNum()
 	})
 	return res
+}
+
+// Metrics is part of the objstorage.Provider interface.
+func (p *provider) Metrics() sharedcache.Metrics {
+	if p.remote.cache != nil {
+		return p.remote.cache.Metrics()
+	}
+	return sharedcache.Metrics{}
 }
 
 func (p *provider) addMetadata(meta objstorage.ObjectMetadata) {

--- a/objstorage/objstorageprovider/sharedcache/shared_cache_helpers_test.go
+++ b/objstorage/objstorageprovider/sharedcache/shared_cache_helpers_test.go
@@ -1,9 +1,5 @@
 package sharedcache
 
-func (c *Cache) Misses() int32 {
-	return c.misses.Load()
-}
-
 func (c *Cache) WaitForWritesToComplete() {
 	close(c.writeWorkers.tasksCh)
 	c.writeWorkers.doneWaitGroup.Wait()

--- a/objstorage/objstorageprovider/sharedcache/shared_cache_test.go
+++ b/objstorage/objstorageprovider/sharedcache/shared_cache_test.go
@@ -80,7 +80,7 @@ func TestSharedCache(t *testing.T) {
 
 				return ""
 			case "read", "read-for-compaction":
-				missesBefore := cache.Misses()
+				missesBefore := cache.Metrics().ReadsWithPartialHit + cache.Metrics().ReadsWithNoHit
 				offset := mustParseBytesArg(t, d, "offset")
 				size := mustParseBytesArg(t, d, "size")
 
@@ -105,7 +105,7 @@ func TestSharedCache(t *testing.T) {
 
 				// TODO(josh): Not tracing out filesystem activity here, since logging_fs.go
 				// doesn't trace calls to ReadAt or WriteAt. We should consider changing this.
-				missesAfter := cache.Misses()
+				missesAfter := cache.Metrics().ReadsWithPartialHit + cache.Metrics().ReadsWithNoHit
 				return fmt.Sprintf("misses=%d", missesAfter-missesBefore)
 			default:
 				d.Fatalf(t, "unknown command %s", d.Cmd)

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -288,6 +288,7 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B)
 Block cache: 6 entries (1.1KB)  hit rate: 11.1%
 Table cache: 1 entries (800B)  hit rate: 40.0%
+Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -384,6 +385,7 @@ MemTables: 1 (512KB)  zombie: 1 (512KB)
 Zombie tables: 0 (0B)
 Block cache: 12 entries (2.3KB)  hit rate: 14.3%
 Table cache: 1 entries (800B)  hit rate: 50.0%
+Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -51,6 +51,7 @@ MemTables: 1 (256KB)  zombie: 0 (0B)
 Zombie tables: 0 (0B)
 Block cache: 6 entries (1.2KB)  hit rate: 35.7%
 Table cache: 1 entries (800B)  hit rate: 50.0%
+Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -20,6 +20,7 @@ MemTables: 12 (11B)  zombie: 14 (13B)
 Zombie tables: 16 (15B)
 Block cache: 2 entries (1B)  hit rate: 42.9%
 Table cache: 18 entries (17B)  hit rate: 48.7%
+Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 4  earliest seq num: 1024
 Table iters: 21
 Filter utility: 47.4%
@@ -64,6 +65,7 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B)
 Block cache: 3 entries (528B)  hit rate: 0.0%
 Table cache: 1 entries (800B)  hit rate: 0.0%
+Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
 Filter utility: 0.0%
@@ -115,6 +117,7 @@ MemTables: 1 (256KB)  zombie: 2 (512KB)
 Zombie tables: 2 (1.2KB)
 Block cache: 5 entries (1.0KB)  hit rate: 42.9%
 Table cache: 2 entries (1.6KB)  hit rate: 66.7%
+Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 2
 Filter utility: 0.0%
@@ -151,6 +154,7 @@ MemTables: 1 (256KB)  zombie: 2 (512KB)
 Zombie tables: 2 (1.2KB)
 Block cache: 5 entries (1.0KB)  hit rate: 42.9%
 Table cache: 2 entries (1.6KB)  hit rate: 66.7%
+Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 2
 Filter utility: 0.0%
@@ -184,6 +188,7 @@ MemTables: 1 (256KB)  zombie: 2 (512KB)
 Zombie tables: 1 (633B)
 Block cache: 3 entries (528B)  hit rate: 42.9%
 Table cache: 1 entries (800B)  hit rate: 66.7%
+Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
 Filter utility: 0.0%
@@ -220,6 +225,7 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B)
 Block cache: 0 entries (0B)  hit rate: 42.9%
 Table cache: 0 entries (0B)  hit rate: 66.7%
+Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -282,6 +288,7 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B)
 Block cache: 0 entries (0B)  hit rate: 42.9%
 Table cache: 0 entries (0B)  hit rate: 66.7%
+Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -328,6 +335,7 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B)
 Block cache: 0 entries (0B)  hit rate: 27.3%
 Table cache: 0 entries (0B)  hit rate: 58.3%
+Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -420,6 +428,7 @@ MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
 Zombie tables: 0 (0B)
 Block cache: 12 entries (2.3KB)  hit rate: 31.1%
 Table cache: 3 entries (2.3KB)  hit rate: 57.9%
+Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -30,6 +30,7 @@ MemTables: 1 (256KB)  zombie: 0 (0B)
 Zombie tables: 0 (0B)
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%
+Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/pebble/issues/2687.

**sharedcache: introduce metrics**

This commit adds various metrics to the shared cache. In a follow up PR, I will export these metrics as time-series metrics from CRDB.