### PR TITLE
record: allow unbounded queued blocks in LogWriter

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -319,7 +319,11 @@ type BatchCommitStats struct {
 	// commitPipeline.Commit.
 	SemaphoreWaitDuration time.Duration
 	// WALQueueWaitDuration is the wait time for allocating memory blocks in the
-	// LogWriter (due to the LogWriter not writing fast enough).
+	// LogWriter (due to the LogWriter not writing fast enough). At the moment
+	// this is duration is always zero because a single WAL will allow
+	// allocating memory blocks up to the entire memtable size. In the future,
+	// we may pipeline WALs and bound the WAL queued blocks separately, so this
+	// field is preserved for that possibility.
 	WALQueueWaitDuration time.Duration
 	// MemTableWriteStallDuration is the wait caused by a write stall due to too
 	// many memtables (due to not flushing fast enough).

--- a/commit_test.go
+++ b/commit_test.go
@@ -245,7 +245,7 @@ func TestCommitPipelineWALClose(t *testing.T) {
 			return nil
 		},
 		write: func(b *Batch, syncWG *sync.WaitGroup, syncErr *error) (*memTable, error) {
-			_, _, err := wal.SyncRecord(b.data, syncWG, syncErr)
+			_, err := wal.SyncRecord(b.data, syncWG, syncErr)
 			return nil, err
 		},
 	}
@@ -316,7 +316,7 @@ func BenchmarkCommitPipeline(b *testing.B) {
 								break
 							}
 
-							_, _, err := wal.SyncRecord(b.data, syncWG, syncErr)
+							_, err := wal.SyncRecord(b.data, syncWG, syncErr)
 							return mem, err
 						},
 					}

--- a/db.go
+++ b/db.go
@@ -909,7 +909,7 @@ func (d *DB) commitWrite(b *Batch, syncWG *sync.WaitGroup, syncErr *error) (*mem
 		b.flushable.setSeqNum(b.SeqNum())
 		if !d.opts.DisableWAL {
 			var err error
-			size, b.commitStats.WALQueueWaitDuration, err = d.mu.log.SyncRecord(repr, syncWG, syncErr)
+			size, err = d.mu.log.SyncRecord(repr, syncWG, syncErr)
 			if err != nil {
 				panic(err)
 			}
@@ -947,7 +947,7 @@ func (d *DB) commitWrite(b *Batch, syncWG *sync.WaitGroup, syncErr *error) (*mem
 	}
 
 	if b.flushable == nil {
-		size, b.commitStats.WALQueueWaitDuration, err = d.mu.log.SyncRecord(repr, syncWG, syncErr)
+		size, err = d.mu.log.SyncRecord(repr, syncWG, syncErr)
 		if err != nil {
 			panic(err)
 		}

--- a/vfs/vfstest/vfstest.go
+++ b/vfs/vfstest/vfstest.go
@@ -1,0 +1,32 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// Package vfstest provides facilities for interacting with or faking
+// filesystems during tests and benchmarks.
+package vfstest
+
+import (
+	"os"
+
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+// DiscardFile implements vfs.File but discards all written data and reads
+// without mutating input buffers.
+var DiscardFile vfs.File = (*discardFile)(nil)
+
+type discardFile struct{}
+
+func (*discardFile) Close() error                                   { return nil }
+func (*discardFile) Read(p []byte) (int, error)                     { return len(p), nil }
+func (*discardFile) ReadAt(p []byte, off int64) (int, error)        { return len(p), nil }
+func (*discardFile) Write(p []byte) (int, error)                    { return len(p), nil }
+func (*discardFile) WriteAt(p []byte, ofs int64) (int, error)       { return len(p), nil }
+func (*discardFile) Preallocate(offset, length int64) error         { return nil }
+func (*discardFile) Stat() (os.FileInfo, error)                     { return nil, nil }
+func (*discardFile) Sync() error                                    { return nil }
+func (*discardFile) SyncTo(length int64) (fullSync bool, err error) { return false, nil }
+func (*discardFile) SyncData() error                                { return nil }
+func (*discardFile) Prefetch(offset int64, length int64) error      { return nil }
+func (*discardFile) Fd() uintptr                                    { return 0 }


### PR DESCRIPTION
Previously, a LogWriter would allocate up to 16 blocks of 32 KiB for buffering WAL writes. If all 16 blocks had been allocated and no free blocks were available, a batch writing to the WAL would queue until the flushing goroutine freed blocks. In testing of write-heavy workloads, especially with larger value sizes, we've seen queueing at the LogWriter. This queueing blocks the commit pipeline, preventing any batches from committing regardless of priority and whether they require waiting for fsync.

This commit modifies LogWriter to allow the queueing of an unbounded number of blocks. In practice, for the current WAL, the memtable size serves as an upper bound. With a 64 MiB memtable, at most 64 MiB / 32 KiB = 2,048 blocks may queue. This is not an unreasonable of additional memory overhead for a write-heavy workload.

Beyond improving throughput for write-heavy workloads, removing this hard bound improves tolerance of momentary fsync stalls.

Informs cockroachdb/cockroach#88699.