### PR TITLE
record: increase SyncConcurrency

### DIFF
--- a/record/log_writer.go
+++ b/record/log_writer.go
@@ -39,7 +39,7 @@ type syncer interface {
 }
 
 const (
-	syncConcurrencyBits = 9
+	syncConcurrencyBits = 12
 
 	// SyncConcurrency is the maximum number of concurrent sync operations that
 	// can be performed. Note that a sync operation is initiated either by a call


### PR DESCRIPTION
Increase record.SyncConcurrency to 4096 to allow additional concurrency within the commit pipeline. In workloads with heavy writes and high concurrency, we've observed semaphore queueing artificially increasing tail latencies.

Here's a graph of a kv0 workload with 2KiB writes. Before ~16:00 cockroach was running with just #2762, and after was running with #2762 and this commit:

<img width="1004" alt="Screenshot 2023-07-21 at 12 32 23 PM" src="https://github.com/cockroachdb/pebble/assets/867352/36fcb85c-950f-4bbe-8179-dbfeb9b2dda1">
