### PR TITLE
db: memtable optimization for duplicate keys

### DIFF
--- a/internal/arenaskl/race_test.go
+++ b/internal/arenaskl/race_test.go
@@ -29,7 +29,7 @@ func TestNodeArenaEnd(t *testing.T) {
 	// path.
 	for i := uint32(1); i < 256; i++ {
 		a := newArena(i)
-		_, err := newNode(a, 1, ikey, val)
+		_, err := newNode(a, 1, ikey, val, nil)
 		if err == nil {
 			// We reached an arena size big enough to allocate a node.
 			// If there's an issue at the boundary, the race detector would


### PR DESCRIPTION
With our existing skiplist memtable implementation, each duplicate key written will copy the entire key into the memtable arena. These new, frequent writes can quickly fill a memtable forcing a flush. Triggering early flushes hurts write bandwidth efficiency, because it makes it less likely that the raft log entries contained within the memtable will be truncated before the flush. The optimization done in this pr is that during insertion, if we find a key with the same user key, we encode its offset in the new node instead of making a copy.

Fixes: #2683