### PR TITLE
objstorage: rename 'shared' to 'remote'

### DIFF
--- a/db.go
+++ b/db.go
@@ -2561,7 +2561,7 @@ func firstError(err0, err1 error) error {
 }
 
 // SetCreatorID sets the CreatorID which is needed in order to use shared objects.
-// Shared object usage is disabled until this method is called the first time.
+// Remote object usage is disabled until this method is called the first time.
 // Once set, the Creator ID is persisted and cannot change.
 //
 // Does nothing if SharedStorage was not set in the options when the DB was

--- a/ingest.go
+++ b/ingest.go
@@ -858,7 +858,7 @@ func ingestTargetLevel(
 //     local sstables. This is the step where overlap with memtables is
 //     determined. If there is overlap, we remember the most recent memtable
 //     that overlaps.
-//  6. Update the sequence number in the ingested local sstables. (Shared
+//  6. Update the sequence number in the ingested local sstables. (Remote
 //     sstables get fixed sequence numbers that were determined at load time.)
 //  7. Wait for the most recent memtable that overlaps to flush (if any).
 //  8. Add the ingested sstables to the version (DB.ingestApply).
@@ -1295,7 +1295,7 @@ func (d *DB) ingest(
 		}
 	}
 
-	// NB: Shared-sstable-only ingestions do not assign a sequence number to
+	// NB: Remote-sstable-only ingestions do not assign a sequence number to
 	// any sstables.
 	globalSeqNum := uint64(0)
 	if len(loadResult.localMeta) > 0 {

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1030,11 +1030,11 @@ func TestSimpleIngestShared(t *testing.T) {
 		NoSyncOnClose:       opts2.NoSyncOnClose,
 		BytesPerSync:        opts2.BytesPerSync,
 	}
-	providerSettings.Shared.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+	providerSettings.Remote.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 		"": remote.NewInMem(),
 	})
-	providerSettings.Shared.CreateOnShared = true
-	providerSettings.Shared.CreateOnSharedLocator = ""
+	providerSettings.Remote.CreateOnShared = true
+	providerSettings.Remote.CreateOnSharedLocator = ""
 
 	provider2, err := objstorageprovider.Open(providerSettings)
 	require.NoError(t, err)
@@ -1059,9 +1059,9 @@ func TestSimpleIngestShared(t *testing.T) {
 			L0CompactionThreshold: 100,
 			L0StopWritesThreshold: 100,
 		}
-		opts.Experimental.RemoteStorage = providerSettings.Shared.StorageFactory
-		opts.Experimental.CreateOnShared = providerSettings.Shared.CreateOnShared
-		opts.Experimental.CreateOnSharedLocator = providerSettings.Shared.CreateOnSharedLocator
+		opts.Experimental.RemoteStorage = providerSettings.Remote.StorageFactory
+		opts.Experimental.CreateOnShared = providerSettings.Remote.CreateOnShared
+		opts.Experimental.CreateOnSharedLocator = providerSettings.Remote.CreateOnSharedLocator
 
 		var err error
 		d, err = Open("", opts)

--- a/objstorage/objstorageprovider/remote_backing_test.go
+++ b/objstorage/objstorageprovider/remote_backing_test.go
@@ -24,7 +24,7 @@ func TestSharedObjectBacking(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			st := DefaultSettings(vfs.NewMem(), "")
 			sharedStorage := remote.NewInMem()
-			st.Shared.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+			st.Remote.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 				"foo": sharedStorage,
 			})
 			p, err := Open(st)
@@ -52,7 +52,7 @@ func TestSharedObjectBacking(t *testing.T) {
 			_, err = h.Get()
 			require.Error(t, err)
 
-			d1, err := decodeSharedObjectBacking(base.FileTypeTable, base.FileNum(100).DiskFileNum(), buf)
+			d1, err := decodeRemoteObjectBacking(base.FileTypeTable, base.FileNum(100).DiskFileNum(), buf)
 			require.NoError(t, err)
 			require.Equal(t, uint64(100), uint64(d1.meta.DiskFileNum.FileNum()))
 			require.Equal(t, base.FileTypeTable, d1.meta.FileType)
@@ -73,7 +73,7 @@ func TestSharedObjectBacking(t *testing.T) {
 				buf2 = binary.AppendUvarint(buf2, 2)
 				buf2 = append(buf2, 1, 1)
 
-				d2, err := decodeSharedObjectBacking(base.FileTypeTable, base.FileNum(100).DiskFileNum(), buf2)
+				d2, err := decodeRemoteObjectBacking(base.FileTypeTable, base.FileNum(100).DiskFileNum(), buf2)
 				require.NoError(t, err)
 				require.Equal(t, uint64(100), uint64(d2.meta.DiskFileNum.FileNum()))
 				require.Equal(t, base.FileTypeTable, d2.meta.FileType)
@@ -89,7 +89,7 @@ func TestSharedObjectBacking(t *testing.T) {
 
 				buf3 := buf2
 				buf3 = binary.AppendUvarint(buf3, tagNotSafeToIgnoreMask+5)
-				_, err = decodeSharedObjectBacking(meta.FileType, meta.DiskFileNum, buf3)
+				_, err = decodeRemoteObjectBacking(meta.FileType, meta.DiskFileNum, buf3)
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "unknown tag")
 			})
@@ -100,7 +100,7 @@ func TestSharedObjectBacking(t *testing.T) {
 func TestCreateSharedObjectBacking(t *testing.T) {
 	st := DefaultSettings(vfs.NewMem(), "")
 	sharedStorage := remote.NewInMem()
-	st.Shared.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+	st.Remote.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 		"foo": sharedStorage,
 	})
 	p, err := Open(st)
@@ -111,7 +111,7 @@ func TestCreateSharedObjectBacking(t *testing.T) {
 
 	backing, err := p.CreateExternalObjectBacking("foo", "custom-obj-name")
 	require.NoError(t, err)
-	d, err := decodeSharedObjectBacking(base.FileTypeTable, base.FileNum(100).DiskFileNum(), backing)
+	d, err := decodeRemoteObjectBacking(base.FileTypeTable, base.FileNum(100).DiskFileNum(), backing)
 	require.NoError(t, err)
 	require.Equal(t, uint64(100), uint64(d.meta.DiskFileNum.FileNum()))
 	require.Equal(t, base.FileTypeTable, d.meta.FileType)

--- a/objstorage/objstorageprovider/remote_obj_name.go
+++ b/objstorage/objstorageprovider/remote_obj_name.go
@@ -11,11 +11,11 @@ import (
 	"github.com/cockroachdb/pebble/objstorage"
 )
 
-// sharedObjectName returns the name of an object on shared storage.
+// remoteObjectName returns the name of an object on remote storage.
 //
 // For sstables, the format is: <hash>-<creator-id>-<file-num>.sst
 // For example: 1a3f-2-000001.sst
-func sharedObjectName(meta objstorage.ObjectMetadata) string {
+func remoteObjectName(meta objstorage.ObjectMetadata) string {
 	if meta.Remote.CustomObjectName != "" {
 		return meta.Remote.CustomObjectName
 	}
@@ -78,7 +78,7 @@ func (p *provider) sharedObjectRefName(meta objstorage.ObjectMetadata) string {
 	if meta.Remote.CleanupMethod != objstorage.SharedRefTracking {
 		panic("ref object used when ref tracking disabled")
 	}
-	return sharedObjectRefName(meta, p.shared.creatorID, meta.DiskFileNum)
+	return sharedObjectRefName(meta, p.remote.shared.creatorID, meta.DiskFileNum)
 }
 
 // objHash returns a 16-bit hash value derived from the creator ID and creator

--- a/objstorage/objstorageprovider/remote_obj_name_test.go
+++ b/objstorage/objstorageprovider/remote_obj_name_test.go
@@ -29,7 +29,7 @@ func TestSharedObjectNames(t *testing.T) {
 				meta.Remote.CustomObjectName = fmt.Sprintf("foo-%d.sst", rand.Intn(10000))
 			}
 
-			obj := sharedObjectName(meta)
+			obj := remoteObjectName(meta)
 			// Cross-check against cleaner implementations.
 			expObj := meta.Remote.CustomObjectName
 			if expObj == "" {
@@ -52,7 +52,7 @@ func TestSharedObjectNames(t *testing.T) {
 		meta.FileType = base.FileTypeTable
 		meta.Remote.CreatorID = objstorage.CreatorID(456)
 		meta.Remote.CreatorFileNum = base.FileNum(789).DiskFileNum()
-		require.Equal(t, sharedObjectName(meta), "0e17-456-000789.sst")
+		require.Equal(t, remoteObjectName(meta), "0e17-456-000789.sst")
 		require.Equal(t, sharedObjectRefPrefix(meta), "0e17-456-000789.sst.ref.")
 
 		refCreatorID := objstorage.CreatorID(101112)

--- a/objstorage/objstorageprovider/testdata/provider/shared_attach
+++ b/objstorage/objstorageprovider/testdata/provider/shared_attach
@@ -15,24 +15,24 @@ open p1 1
 
 create 1 shared 1 100
 ----
-<shared> create object "61a6-1-000001.sst"
-<shared> close writer for "61a6-1-000001.sst" after 100 bytes
-<shared> create object "61a6-1-000001.sst.ref.1.000001"
-<shared> close writer for "61a6-1-000001.sst.ref.1.000001" after 0 bytes
+<remote> create object "61a6-1-000001.sst"
+<remote> close writer for "61a6-1-000001.sst" after 100 bytes
+<remote> create object "61a6-1-000001.sst.ref.1.000001"
+<remote> close writer for "61a6-1-000001.sst.ref.1.000001" after 0 bytes
 
 create 2 shared 2 200
 ----
-<shared> create object "a629-1-000002.sst"
-<shared> close writer for "a629-1-000002.sst" after 200 bytes
-<shared> create object "a629-1-000002.sst.ref.1.000002"
-<shared> close writer for "a629-1-000002.sst.ref.1.000002" after 0 bytes
+<remote> create object "a629-1-000002.sst"
+<remote> close writer for "a629-1-000002.sst" after 200 bytes
+<remote> create object "a629-1-000002.sst.ref.1.000002"
+<remote> close writer for "a629-1-000002.sst.ref.1.000002" after 0 bytes
 
 create 3 shared 3 300
 ----
-<shared> create object "eaac-1-000003.sst"
-<shared> close writer for "eaac-1-000003.sst" after 300 bytes
-<shared> create object "eaac-1-000003.sst.ref.1.000003"
-<shared> close writer for "eaac-1-000003.sst.ref.1.000003" after 0 bytes
+<remote> create object "eaac-1-000003.sst"
+<remote> close writer for "eaac-1-000003.sst" after 300 bytes
+<remote> create object "eaac-1-000003.sst.ref.1.000003"
+<remote> close writer for "eaac-1-000003.sst.ref.1.000003" after 0 bytes
 
 create 100 local 100 15
 ----
@@ -42,15 +42,15 @@ create 100 local 100 15
 
 list
 ----
-000001 -> shared://61a6-1-000001.sst
-000002 -> shared://a629-1-000002.sst
-000003 -> shared://eaac-1-000003.sst
+000001 -> remote://61a6-1-000001.sst
+000002 -> remote://a629-1-000002.sst
+000003 -> remote://eaac-1-000003.sst
 000100 -> p1/000100.sst
 
 # Can't get backing of local object.
 save-backing foo 100
 ----
-object 000100 not on shared storage
+object 000100 not on remote storage
 
 save-backing b1 1
 ----
@@ -82,69 +82,69 @@ open p2 2
 
 create 100 shared 100 15
 ----
-<shared> create object "fd72-2-000100.sst"
-<shared> close writer for "fd72-2-000100.sst" after 15 bytes
-<shared> create object "fd72-2-000100.sst.ref.2.000100"
-<shared> close writer for "fd72-2-000100.sst.ref.2.000100" after 0 bytes
+<remote> create object "fd72-2-000100.sst"
+<remote> close writer for "fd72-2-000100.sst" after 15 bytes
+<remote> create object "fd72-2-000100.sst.ref.2.000100"
+<remote> close writer for "fd72-2-000100.sst.ref.2.000100" after 0 bytes
 
 attach
 b1 101
 b2 102
 b3 103
 ----
-<shared> create object "61a6-1-000001.sst.ref.2.000101"
-<shared> close writer for "61a6-1-000001.sst.ref.2.000101" after 0 bytes
-<shared> size of object "61a6-1-000001.sst.ref.1.000001": 0
-<shared> create object "a629-1-000002.sst.ref.2.000102"
-<shared> close writer for "a629-1-000002.sst.ref.2.000102" after 0 bytes
-<shared> size of object "a629-1-000002.sst.ref.1.000002": 0
-<shared> create object "eaac-1-000003.sst.ref.2.000103"
-<shared> close writer for "eaac-1-000003.sst.ref.2.000103" after 0 bytes
-<shared> size of object "eaac-1-000003.sst.ref.1.000003": 0
+<remote> create object "61a6-1-000001.sst.ref.2.000101"
+<remote> close writer for "61a6-1-000001.sst.ref.2.000101" after 0 bytes
+<remote> size of object "61a6-1-000001.sst.ref.1.000001": 0
+<remote> create object "a629-1-000002.sst.ref.2.000102"
+<remote> close writer for "a629-1-000002.sst.ref.2.000102" after 0 bytes
+<remote> size of object "a629-1-000002.sst.ref.1.000002": 0
+<remote> create object "eaac-1-000003.sst.ref.2.000103"
+<remote> close writer for "eaac-1-000003.sst.ref.2.000103" after 0 bytes
+<remote> size of object "eaac-1-000003.sst.ref.1.000003": 0
 <local fs> sync: p2/REMOTE-OBJ-CATALOG-000001
-000101 -> shared://61a6-1-000001.sst
-000102 -> shared://a629-1-000002.sst
-000103 -> shared://eaac-1-000003.sst
+000101 -> remote://61a6-1-000001.sst
+000102 -> remote://a629-1-000002.sst
+000103 -> remote://eaac-1-000003.sst
 
 list
 ----
-000100 -> shared://fd72-2-000100.sst
-000101 -> shared://61a6-1-000001.sst
-000102 -> shared://a629-1-000002.sst
-000103 -> shared://eaac-1-000003.sst
+000100 -> remote://fd72-2-000100.sst
+000101 -> remote://61a6-1-000001.sst
+000102 -> remote://a629-1-000002.sst
+000103 -> remote://eaac-1-000003.sst
 
 read 101
 0 100
 15 10
 ----
-<shared> size of object "61a6-1-000001.sst.ref.2.000101": 0
-<shared> create reader for object "61a6-1-000001.sst": 100 bytes
+<remote> size of object "61a6-1-000001.sst.ref.2.000101": 0
+<remote> create reader for object "61a6-1-000001.sst": 100 bytes
 size: 100
-<shared> read object "61a6-1-000001.sst" at 0 (length 100)
+<remote> read object "61a6-1-000001.sst" at 0 (length 100)
 0 100: ok (salt 1)
-<shared> read object "61a6-1-000001.sst" at 15 (length 10)
+<remote> read object "61a6-1-000001.sst" at 15 (length 10)
 15 10: ok (salt 1)
-<shared> close reader for "61a6-1-000001.sst"
+<remote> close reader for "61a6-1-000001.sst"
 
 read 102
 0 200
 90 100
 ----
-<shared> size of object "a629-1-000002.sst.ref.2.000102": 0
-<shared> create reader for object "a629-1-000002.sst": 200 bytes
+<remote> size of object "a629-1-000002.sst.ref.2.000102": 0
+<remote> create reader for object "a629-1-000002.sst": 200 bytes
 size: 200
-<shared> read object "a629-1-000002.sst" at 0 (length 200)
+<remote> read object "a629-1-000002.sst" at 0 (length 200)
 0 200: ok (salt 2)
-<shared> read object "a629-1-000002.sst" at 90 (length 100)
+<remote> read object "a629-1-000002.sst" at 90 (length 100)
 90 100: ok (salt 2)
-<shared> close reader for "a629-1-000002.sst"
+<remote> close reader for "a629-1-000002.sst"
 
 read 103
 0 300
 ----
-<shared> size of object "eaac-1-000003.sst.ref.2.000103": 0
-<shared> create reader for object "eaac-1-000003.sst": 300 bytes
+<remote> size of object "eaac-1-000003.sst.ref.2.000103": 0
+<remote> create reader for object "eaac-1-000003.sst": 300 bytes
 size: 300
-<shared> read object "eaac-1-000003.sst" at 0 (length 300)
+<remote> read object "eaac-1-000003.sst" at 0 (length 300)
 0 300: ok (salt 3)
-<shared> close reader for "eaac-1-000003.sst"
+<remote> close reader for "eaac-1-000003.sst"

--- a/objstorage/objstorageprovider/testdata/provider/shared_attach_after_unref
+++ b/objstorage/objstorageprovider/testdata/provider/shared_attach_after_unref
@@ -14,10 +14,10 @@ open p5 5
 
 create 1 shared 1 100
 ----
-<shared> create object "d632-5-000001.sst"
-<shared> close writer for "d632-5-000001.sst" after 100 bytes
-<shared> create object "d632-5-000001.sst.ref.5.000001"
-<shared> close writer for "d632-5-000001.sst.ref.5.000001" after 0 bytes
+<remote> create object "d632-5-000001.sst"
+<remote> close writer for "d632-5-000001.sst" after 100 bytes
+<remote> create object "d632-5-000001.sst.ref.5.000001"
+<remote> close writer for "d632-5-000001.sst.ref.5.000001" after 0 bytes
 
 save-backing p5b1 1
 ----
@@ -42,11 +42,11 @@ open p6 6
 attach
 p5b1 101
 ----
-<shared> create object "d632-5-000001.sst.ref.6.000101"
-<shared> close writer for "d632-5-000001.sst.ref.6.000101" after 0 bytes
-<shared> size of object "d632-5-000001.sst.ref.5.000001": 0
+<remote> create object "d632-5-000001.sst.ref.6.000101"
+<remote> close writer for "d632-5-000001.sst.ref.6.000101" after 0 bytes
+<remote> size of object "d632-5-000001.sst.ref.5.000001": 0
 <local fs> sync: p6/REMOTE-OBJ-CATALOG-000001
-000101 -> shared://d632-5-000001.sst
+000101 -> remote://d632-5-000001.sst
 
 switch p5
 ----
@@ -57,10 +57,10 @@ close-backing p5b1
 
 create 2 shared 2 100
 ----
-<shared> create object "1ab5-5-000002.sst"
-<shared> close writer for "1ab5-5-000002.sst" after 100 bytes
-<shared> create object "1ab5-5-000002.sst.ref.5.000002"
-<shared> close writer for "1ab5-5-000002.sst.ref.5.000002" after 0 bytes
+<remote> create object "1ab5-5-000002.sst"
+<remote> close writer for "1ab5-5-000002.sst" after 100 bytes
+<remote> create object "1ab5-5-000002.sst.ref.5.000002"
+<remote> close writer for "1ab5-5-000002.sst.ref.5.000002" after 0 bytes
 
 save-backing p5b2 2
 ----
@@ -71,9 +71,9 @@ close-backing p5b2
 
 remove 2
 ----
-<shared> delete object "1ab5-5-000002.sst.ref.5.000002"
-<shared> list (prefix="1ab5-5-000002.sst.ref.", delimiter="")
-<shared> delete object "1ab5-5-000002.sst"
+<remote> delete object "1ab5-5-000002.sst.ref.5.000002"
+<remote> list (prefix="1ab5-5-000002.sst.ref.", delimiter="")
+<remote> delete object "1ab5-5-000002.sst"
 
 switch p6
 ----
@@ -82,10 +82,10 @@ switch p6
 attach
 p5b2 102
 ----
-<shared> create object "1ab5-5-000002.sst.ref.6.000102"
-<shared> close writer for "1ab5-5-000002.sst.ref.6.000102" after 0 bytes
-<shared> size of object "1ab5-5-000002.sst.ref.5.000002": error: file does not exist
-<shared> delete object "1ab5-5-000002.sst.ref.6.000102"
-<shared> list (prefix="1ab5-5-000002.sst.ref.", delimiter="")
-<shared> delete object "1ab5-5-000002.sst"
+<remote> create object "1ab5-5-000002.sst.ref.6.000102"
+<remote> close writer for "1ab5-5-000002.sst.ref.6.000102" after 0 bytes
+<remote> size of object "1ab5-5-000002.sst.ref.5.000002": error: file does not exist
+<remote> delete object "1ab5-5-000002.sst.ref.6.000102"
+<remote> list (prefix="1ab5-5-000002.sst.ref.", delimiter="")
+<remote> delete object "1ab5-5-000002.sst"
 error: origin marker object "1ab5-5-000002.sst.ref.5.000002" does not exist; object probably removed from the provider which created the backing

--- a/objstorage/objstorageprovider/testdata/provider/shared_attach_multi
+++ b/objstorage/objstorageprovider/testdata/provider/shared_attach_multi
@@ -14,10 +14,10 @@ open p1 1
 
 create 1 shared 1 100
 ----
-<shared> create object "61a6-1-000001.sst"
-<shared> close writer for "61a6-1-000001.sst" after 100 bytes
-<shared> create object "61a6-1-000001.sst.ref.1.000001"
-<shared> close writer for "61a6-1-000001.sst.ref.1.000001" after 0 bytes
+<remote> create object "61a6-1-000001.sst"
+<remote> close writer for "61a6-1-000001.sst" after 100 bytes
+<remote> create object "61a6-1-000001.sst.ref.1.000001"
+<remote> close writer for "61a6-1-000001.sst.ref.1.000001" after 0 bytes
 
 save-backing b1 1
 ----
@@ -40,19 +40,19 @@ b1 101
 b1 102
 b1 103
 ----
-<shared> create object "61a6-1-000001.sst.ref.2.000101"
-<shared> close writer for "61a6-1-000001.sst.ref.2.000101" after 0 bytes
-<shared> size of object "61a6-1-000001.sst.ref.1.000001": 0
-<shared> create object "61a6-1-000001.sst.ref.2.000102"
-<shared> close writer for "61a6-1-000001.sst.ref.2.000102" after 0 bytes
-<shared> size of object "61a6-1-000001.sst.ref.1.000001": 0
-<shared> create object "61a6-1-000001.sst.ref.2.000103"
-<shared> close writer for "61a6-1-000001.sst.ref.2.000103" after 0 bytes
-<shared> size of object "61a6-1-000001.sst.ref.1.000001": 0
+<remote> create object "61a6-1-000001.sst.ref.2.000101"
+<remote> close writer for "61a6-1-000001.sst.ref.2.000101" after 0 bytes
+<remote> size of object "61a6-1-000001.sst.ref.1.000001": 0
+<remote> create object "61a6-1-000001.sst.ref.2.000102"
+<remote> close writer for "61a6-1-000001.sst.ref.2.000102" after 0 bytes
+<remote> size of object "61a6-1-000001.sst.ref.1.000001": 0
+<remote> create object "61a6-1-000001.sst.ref.2.000103"
+<remote> close writer for "61a6-1-000001.sst.ref.2.000103" after 0 bytes
+<remote> size of object "61a6-1-000001.sst.ref.1.000001": 0
 <local fs> sync: p2/REMOTE-OBJ-CATALOG-000001
-000101 -> shared://61a6-1-000001.sst
-000102 -> shared://61a6-1-000001.sst
-000103 -> shared://61a6-1-000001.sst
+000101 -> remote://61a6-1-000001.sst
+000102 -> remote://61a6-1-000001.sst
+000103 -> remote://61a6-1-000001.sst
 
 close-backing b1
 ----
@@ -63,30 +63,30 @@ switch p1
 
 remove 1
 ----
-<shared> delete object "61a6-1-000001.sst.ref.1.000001"
-<shared> list (prefix="61a6-1-000001.sst.ref.", delimiter="")
-<shared>  - 61a6-1-000001.sst.ref.2.000101
-<shared>  - 61a6-1-000001.sst.ref.2.000102
-<shared>  - 61a6-1-000001.sst.ref.2.000103
+<remote> delete object "61a6-1-000001.sst.ref.1.000001"
+<remote> list (prefix="61a6-1-000001.sst.ref.", delimiter="")
+<remote>  - 61a6-1-000001.sst.ref.2.000101
+<remote>  - 61a6-1-000001.sst.ref.2.000102
+<remote>  - 61a6-1-000001.sst.ref.2.000103
 
 switch p2
 ----
 
 remove 101
 ----
-<shared> delete object "61a6-1-000001.sst.ref.2.000101"
-<shared> list (prefix="61a6-1-000001.sst.ref.", delimiter="")
-<shared>  - 61a6-1-000001.sst.ref.2.000102
-<shared>  - 61a6-1-000001.sst.ref.2.000103
+<remote> delete object "61a6-1-000001.sst.ref.2.000101"
+<remote> list (prefix="61a6-1-000001.sst.ref.", delimiter="")
+<remote>  - 61a6-1-000001.sst.ref.2.000102
+<remote>  - 61a6-1-000001.sst.ref.2.000103
 
 remove 103
 ----
-<shared> delete object "61a6-1-000001.sst.ref.2.000103"
-<shared> list (prefix="61a6-1-000001.sst.ref.", delimiter="")
-<shared>  - 61a6-1-000001.sst.ref.2.000102
+<remote> delete object "61a6-1-000001.sst.ref.2.000103"
+<remote> list (prefix="61a6-1-000001.sst.ref.", delimiter="")
+<remote>  - 61a6-1-000001.sst.ref.2.000102
 
 remove 102
 ----
-<shared> delete object "61a6-1-000001.sst.ref.2.000102"
-<shared> list (prefix="61a6-1-000001.sst.ref.", delimiter="")
-<shared> delete object "61a6-1-000001.sst"
+<remote> delete object "61a6-1-000001.sst.ref.2.000102"
+<remote> list (prefix="61a6-1-000001.sst.ref.", delimiter="")
+<remote> delete object "61a6-1-000001.sst"

--- a/objstorage/objstorageprovider/testdata/provider/shared_basic
+++ b/objstorage/objstorageprovider/testdata/provider/shared_basic
@@ -30,25 +30,25 @@ size: 100
 
 create 2 shared 2 100
 ----
-<shared> create object "a629-1-000002.sst"
-<shared> close writer for "a629-1-000002.sst" after 100 bytes
-<shared> create object "a629-1-000002.sst.ref.1.000002"
-<shared> close writer for "a629-1-000002.sst.ref.1.000002" after 0 bytes
+<remote> create object "a629-1-000002.sst"
+<remote> close writer for "a629-1-000002.sst" after 100 bytes
+<remote> create object "a629-1-000002.sst.ref.1.000002"
+<remote> close writer for "a629-1-000002.sst.ref.1.000002" after 0 bytes
 
 read 2
 0 100
 ----
-<shared> size of object "a629-1-000002.sst.ref.1.000002": 0
-<shared> create reader for object "a629-1-000002.sst": 100 bytes
+<remote> size of object "a629-1-000002.sst.ref.1.000002": 0
+<remote> create reader for object "a629-1-000002.sst": 100 bytes
 size: 100
-<shared> read object "a629-1-000002.sst" at 0 (length 100)
+<remote> read object "a629-1-000002.sst" at 0 (length 100)
 0 100: ok (salt 2)
-<shared> close reader for "a629-1-000002.sst"
+<remote> close reader for "a629-1-000002.sst"
 
 list
 ----
 000001 -> p1/000001.sst
-000002 -> shared://a629-1-000002.sst
+000002 -> remote://a629-1-000002.sst
 
 close
 ----
@@ -69,7 +69,7 @@ open p1 1
 list
 ----
 000001 -> p1/000001.sst
-000002 -> shared://a629-1-000002.sst
+000002 -> remote://a629-1-000002.sst
 
 remove 1
 ----
@@ -77,9 +77,9 @@ remove 1
 
 remove 2
 ----
-<shared> delete object "a629-1-000002.sst.ref.1.000002"
-<shared> list (prefix="a629-1-000002.sst.ref.", delimiter="")
-<shared> delete object "a629-1-000002.sst"
+<remote> delete object "a629-1-000002.sst.ref.1.000002"
+<remote> list (prefix="a629-1-000002.sst.ref.", delimiter="")
+<remote> delete object "a629-1-000002.sst"
 
 link-or-copy 3 local 3 100
 ----
@@ -100,22 +100,22 @@ link-or-copy 4 shared 4 100
 ----
 <local fs> create: temp-file-2
 <local fs> close: temp-file-2
-<shared> create object "2f2f-1-000004.sst"
+<remote> create object "2f2f-1-000004.sst"
 <local fs> open: temp-file-2
-<shared> close writer for "2f2f-1-000004.sst" after 100 bytes
-<shared> create object "2f2f-1-000004.sst.ref.1.000004"
-<shared> close writer for "2f2f-1-000004.sst.ref.1.000004" after 0 bytes
+<remote> close writer for "2f2f-1-000004.sst" after 100 bytes
+<remote> create object "2f2f-1-000004.sst.ref.1.000004"
+<remote> close writer for "2f2f-1-000004.sst.ref.1.000004" after 0 bytes
 <local fs> close: temp-file-2
 
 read 4
 0 100
 ----
-<shared> size of object "2f2f-1-000004.sst.ref.1.000004": 0
-<shared> create reader for object "2f2f-1-000004.sst": 100 bytes
+<remote> size of object "2f2f-1-000004.sst.ref.1.000004": 0
+<remote> create reader for object "2f2f-1-000004.sst": 100 bytes
 size: 100
-<shared> read object "2f2f-1-000004.sst" at 0 (length 100)
+<remote> read object "2f2f-1-000004.sst" at 0 (length 100)
 0 100: ok (salt 4)
-<shared> close reader for "2f2f-1-000004.sst"
+<remote> close reader for "2f2f-1-000004.sst"
 
 close
 ----

--- a/objstorage/objstorageprovider/testdata/provider/shared_no_ref
+++ b/objstorage/objstorageprovider/testdata/provider/shared_no_ref
@@ -15,54 +15,54 @@ open p1 1
 
 create 1 shared 1 100 no-ref-tracking
 ----
-<shared> create object "61a6-1-000001.sst"
-<shared> close writer for "61a6-1-000001.sst" after 100 bytes
+<remote> create object "61a6-1-000001.sst"
+<remote> close writer for "61a6-1-000001.sst" after 100 bytes
 
 read 1
 0 100
 ----
-<shared> create reader for object "61a6-1-000001.sst": 100 bytes
+<remote> create reader for object "61a6-1-000001.sst": 100 bytes
 size: 100
-<shared> read object "61a6-1-000001.sst" at 0 (length 100)
+<remote> read object "61a6-1-000001.sst" at 0 (length 100)
 0 100: ok (salt 1)
-<shared> close reader for "61a6-1-000001.sst"
+<remote> close reader for "61a6-1-000001.sst"
 
 create 2 shared 2 100 no-ref-tracking
 ----
-<shared> create object "a629-1-000002.sst"
-<shared> close writer for "a629-1-000002.sst" after 100 bytes
+<remote> create object "a629-1-000002.sst"
+<remote> close writer for "a629-1-000002.sst" after 100 bytes
 
 read 2
 0 100
 ----
-<shared> create reader for object "a629-1-000002.sst": 100 bytes
+<remote> create reader for object "a629-1-000002.sst": 100 bytes
 size: 100
-<shared> read object "a629-1-000002.sst" at 0 (length 100)
+<remote> read object "a629-1-000002.sst" at 0 (length 100)
 0 100: ok (salt 2)
-<shared> close reader for "a629-1-000002.sst"
+<remote> close reader for "a629-1-000002.sst"
 
 list
 ----
-000001 -> shared://61a6-1-000001.sst
-000002 -> shared://a629-1-000002.sst
+000001 -> remote://61a6-1-000001.sst
+000002 -> remote://a629-1-000002.sst
 
 link-or-copy 3 shared 3 100 no-ref-tracking
 ----
 <local fs> create: temp-file-1
 <local fs> close: temp-file-1
-<shared> create object "eaac-1-000003.sst"
+<remote> create object "eaac-1-000003.sst"
 <local fs> open: temp-file-1
-<shared> close writer for "eaac-1-000003.sst" after 100 bytes
+<remote> close writer for "eaac-1-000003.sst" after 100 bytes
 <local fs> close: temp-file-1
 
 read 3
 0 100
 ----
-<shared> create reader for object "eaac-1-000003.sst": 100 bytes
+<remote> create reader for object "eaac-1-000003.sst": 100 bytes
 size: 100
-<shared> read object "eaac-1-000003.sst" at 0 (length 100)
+<remote> read object "eaac-1-000003.sst" at 0 (length 100)
 0 100: ok (salt 3)
-<shared> close reader for "eaac-1-000003.sst"
+<remote> close reader for "eaac-1-000003.sst"
 
 close
 ----
@@ -81,36 +81,36 @@ open p1 1
 
 list
 ----
-000001 -> shared://61a6-1-000001.sst
-000002 -> shared://a629-1-000002.sst
-000003 -> shared://eaac-1-000003.sst
+000001 -> remote://61a6-1-000001.sst
+000002 -> remote://a629-1-000002.sst
+000003 -> remote://eaac-1-000003.sst
 
 read 1
 0 100
 ----
-<shared> create reader for object "61a6-1-000001.sst": 100 bytes
+<remote> create reader for object "61a6-1-000001.sst": 100 bytes
 size: 100
-<shared> read object "61a6-1-000001.sst" at 0 (length 100)
+<remote> read object "61a6-1-000001.sst" at 0 (length 100)
 0 100: ok (salt 1)
-<shared> close reader for "61a6-1-000001.sst"
+<remote> close reader for "61a6-1-000001.sst"
 
 read 2
 0 100
 ----
-<shared> create reader for object "a629-1-000002.sst": 100 bytes
+<remote> create reader for object "a629-1-000002.sst": 100 bytes
 size: 100
-<shared> read object "a629-1-000002.sst" at 0 (length 100)
+<remote> read object "a629-1-000002.sst" at 0 (length 100)
 0 100: ok (salt 2)
-<shared> close reader for "a629-1-000002.sst"
+<remote> close reader for "a629-1-000002.sst"
 
 read 3
 0 100
 ----
-<shared> create reader for object "eaac-1-000003.sst": 100 bytes
+<remote> create reader for object "eaac-1-000003.sst": 100 bytes
 size: 100
-<shared> read object "eaac-1-000003.sst" at 0 (length 100)
+<remote> read object "eaac-1-000003.sst" at 0 (length 100)
 0 100: ok (salt 3)
-<shared> close reader for "eaac-1-000003.sst"
+<remote> close reader for "eaac-1-000003.sst"
 
 save-backing b1 1
 ----
@@ -135,31 +135,31 @@ b1 101
 b2 102
 ----
 <local fs> sync: p2/REMOTE-OBJ-CATALOG-000001
-000101 -> shared://61a6-1-000001.sst
-000102 -> shared://61a6-1-000001.sst
+000101 -> remote://61a6-1-000001.sst
+000102 -> remote://61a6-1-000001.sst
 
 list
 ----
-000101 -> shared://61a6-1-000001.sst
-000102 -> shared://61a6-1-000001.sst
+000101 -> remote://61a6-1-000001.sst
+000102 -> remote://61a6-1-000001.sst
 
 read 101
 0 100
 ----
-<shared> create reader for object "61a6-1-000001.sst": 100 bytes
+<remote> create reader for object "61a6-1-000001.sst": 100 bytes
 size: 100
-<shared> read object "61a6-1-000001.sst" at 0 (length 100)
+<remote> read object "61a6-1-000001.sst" at 0 (length 100)
 0 100: ok (salt 1)
-<shared> close reader for "61a6-1-000001.sst"
+<remote> close reader for "61a6-1-000001.sst"
 
 read 102
 0 100
 ----
-<shared> create reader for object "61a6-1-000001.sst": 100 bytes
+<remote> create reader for object "61a6-1-000001.sst": 100 bytes
 size: 100
-<shared> read object "61a6-1-000001.sst" at 0 (length 100)
+<remote> read object "61a6-1-000001.sst" at 0 (length 100)
 0 100: ok (salt 1)
-<shared> close reader for "61a6-1-000001.sst"
+<remote> close reader for "61a6-1-000001.sst"
 
 # In this mode, all removes should be no-ops on the shared backend.
 remove 101

--- a/objstorage/objstorageprovider/testdata/provider/shared_readahead
+++ b/objstorage/objstorageprovider/testdata/provider/shared_readahead
@@ -12,10 +12,10 @@ open p1 1
 
 create 1 shared 1 2000000
 ----
-<shared> create object "61a6-1-000001.sst"
-<shared> close writer for "61a6-1-000001.sst" after 2000000 bytes
-<shared> create object "61a6-1-000001.sst.ref.1.000001"
-<shared> close writer for "61a6-1-000001.sst.ref.1.000001" after 0 bytes
+<remote> create object "61a6-1-000001.sst"
+<remote> close writer for "61a6-1-000001.sst" after 2000000 bytes
+<remote> create object "61a6-1-000001.sst.ref.1.000001"
+<remote> close writer for "61a6-1-000001.sst.ref.1.000001" after 0 bytes
 
 # We should be seeing larger and larger reads. But the last read should be
 # capped to the object size.
@@ -34,30 +34,30 @@ read 1
 800000 1000
 1500000 10000
 ----
-<shared> size of object "61a6-1-000001.sst.ref.1.000001": 0
-<shared> create reader for object "61a6-1-000001.sst": 2000000 bytes
+<remote> size of object "61a6-1-000001.sst.ref.1.000001": 0
+<remote> create reader for object "61a6-1-000001.sst": 2000000 bytes
 size: 2000000
-<shared> read object "61a6-1-000001.sst" at 0 (length 1000)
+<remote> read object "61a6-1-000001.sst" at 0 (length 1000)
 0 1000: ok (salt 1)
-<shared> read object "61a6-1-000001.sst" at 1000 (length 15000)
+<remote> read object "61a6-1-000001.sst" at 1000 (length 15000)
 1000 15000: ok (salt 1)
-<shared> read object "61a6-1-000001.sst" at 16000 (length 65536)
+<remote> read object "61a6-1-000001.sst" at 16000 (length 65536)
 16000 30000: ok (salt 1)
 46000 10000: ok (salt 1)
-<shared> read object "61a6-1-000001.sst" at 81536 (length 105536)
+<remote> read object "61a6-1-000001.sst" at 81536 (length 105536)
 56000 50000: ok (salt 1)
 106000 30000: ok (salt 1)
 150000 20000: ok (salt 1)
-<shared> read object "61a6-1-000001.sst" at 187072 (length 255072)
+<remote> read object "61a6-1-000001.sst" at 187072 (length 255072)
 180000 10000: ok (salt 1)
 210000 30000: ok (salt 1)
 300000 10000: ok (salt 1)
-<shared> read object "61a6-1-000001.sst" at 500000 (length 524288)
+<remote> read object "61a6-1-000001.sst" at 500000 (length 524288)
 500000 1000: ok (salt 1)
 800000 1000: ok (salt 1)
-<shared> read object "61a6-1-000001.sst" at 1500000 (length 500000)
+<remote> read object "61a6-1-000001.sst" at 1500000 (length 500000)
 1500000 10000: ok (salt 1)
-<shared> close reader for "61a6-1-000001.sst"
+<remote> close reader for "61a6-1-000001.sst"
 
 # When reading for a compaction, we should be doing large reads from the start.
 read 1 for-compaction
@@ -71,10 +71,10 @@ read 1 for-compaction
 180000 10000
 210000 30000
 ----
-<shared> size of object "61a6-1-000001.sst.ref.1.000001": 0
-<shared> create reader for object "61a6-1-000001.sst": 2000000 bytes
+<remote> size of object "61a6-1-000001.sst.ref.1.000001": 0
+<remote> create reader for object "61a6-1-000001.sst": 2000000 bytes
 size: 2000000
-<shared> read object "61a6-1-000001.sst" at 0 (length 1048576)
+<remote> read object "61a6-1-000001.sst" at 0 (length 1048576)
 0 1000: ok (salt 1)
 1000 15000: ok (salt 1)
 16000 30000: ok (salt 1)
@@ -84,4 +84,4 @@ size: 2000000
 150000 20000: ok (salt 1)
 180000 10000: ok (salt 1)
 210000 30000: ok (salt 1)
-<shared> close reader for "61a6-1-000001.sst"
+<remote> close reader for "61a6-1-000001.sst"

--- a/objstorage/objstorageprovider/testdata/provider/shared_remove
+++ b/objstorage/objstorageprovider/testdata/provider/shared_remove
@@ -12,24 +12,24 @@ open p1 1
 
 create 1 shared 1 100
 ----
-<shared> create object "61a6-1-000001.sst"
-<shared> close writer for "61a6-1-000001.sst" after 100 bytes
-<shared> create object "61a6-1-000001.sst.ref.1.000001"
-<shared> close writer for "61a6-1-000001.sst.ref.1.000001" after 0 bytes
+<remote> create object "61a6-1-000001.sst"
+<remote> close writer for "61a6-1-000001.sst" after 100 bytes
+<remote> create object "61a6-1-000001.sst.ref.1.000001"
+<remote> close writer for "61a6-1-000001.sst.ref.1.000001" after 0 bytes
 
 create 2 shared 2 100
 ----
-<shared> create object "a629-1-000002.sst"
-<shared> close writer for "a629-1-000002.sst" after 100 bytes
-<shared> create object "a629-1-000002.sst.ref.1.000002"
-<shared> close writer for "a629-1-000002.sst.ref.1.000002" after 0 bytes
+<remote> create object "a629-1-000002.sst"
+<remote> close writer for "a629-1-000002.sst" after 100 bytes
+<remote> create object "a629-1-000002.sst.ref.1.000002"
+<remote> close writer for "a629-1-000002.sst.ref.1.000002" after 0 bytes
 
 create 3 shared 3 100
 ----
-<shared> create object "eaac-1-000003.sst"
-<shared> close writer for "eaac-1-000003.sst" after 100 bytes
-<shared> create object "eaac-1-000003.sst.ref.1.000003"
-<shared> close writer for "eaac-1-000003.sst.ref.1.000003" after 0 bytes
+<remote> create object "eaac-1-000003.sst"
+<remote> close writer for "eaac-1-000003.sst" after 100 bytes
+<remote> create object "eaac-1-000003.sst.ref.1.000003"
+<remote> close writer for "eaac-1-000003.sst.ref.1.000003" after 0 bytes
 
 save-backing b1 1
 ----
@@ -51,38 +51,38 @@ open p2 2
 
 create 4 shared 4 100
 ----
-<shared> create object "4c52-2-000004.sst"
-<shared> close writer for "4c52-2-000004.sst" after 100 bytes
-<shared> create object "4c52-2-000004.sst.ref.2.000004"
-<shared> close writer for "4c52-2-000004.sst.ref.2.000004" after 0 bytes
+<remote> create object "4c52-2-000004.sst"
+<remote> close writer for "4c52-2-000004.sst" after 100 bytes
+<remote> create object "4c52-2-000004.sst.ref.2.000004"
+<remote> close writer for "4c52-2-000004.sst.ref.2.000004" after 0 bytes
 
 attach
 b1 101
 b2 102
 ----
-<shared> create object "61a6-1-000001.sst.ref.2.000101"
-<shared> close writer for "61a6-1-000001.sst.ref.2.000101" after 0 bytes
-<shared> size of object "61a6-1-000001.sst.ref.1.000001": 0
-<shared> create object "a629-1-000002.sst.ref.2.000102"
-<shared> close writer for "a629-1-000002.sst.ref.2.000102" after 0 bytes
-<shared> size of object "a629-1-000002.sst.ref.1.000002": 0
+<remote> create object "61a6-1-000001.sst.ref.2.000101"
+<remote> close writer for "61a6-1-000001.sst.ref.2.000101" after 0 bytes
+<remote> size of object "61a6-1-000001.sst.ref.1.000001": 0
+<remote> create object "a629-1-000002.sst.ref.2.000102"
+<remote> close writer for "a629-1-000002.sst.ref.2.000102" after 0 bytes
+<remote> size of object "a629-1-000002.sst.ref.1.000002": 0
 <local fs> sync: p2/REMOTE-OBJ-CATALOG-000001
-000101 -> shared://61a6-1-000001.sst
-000102 -> shared://a629-1-000002.sst
+000101 -> remote://61a6-1-000001.sst
+000102 -> remote://a629-1-000002.sst
 
 # Remove of object with no other refs; backing object should be removed.
 remove 4
 ----
-<shared> delete object "4c52-2-000004.sst.ref.2.000004"
-<shared> list (prefix="4c52-2-000004.sst.ref.", delimiter="")
-<shared> delete object "4c52-2-000004.sst"
+<remote> delete object "4c52-2-000004.sst.ref.2.000004"
+<remote> list (prefix="4c52-2-000004.sst.ref.", delimiter="")
+<remote> delete object "4c52-2-000004.sst"
 
 # Object shared with p2; backing object should not be removed.
 remove 101
 ----
-<shared> delete object "61a6-1-000001.sst.ref.2.000101"
-<shared> list (prefix="61a6-1-000001.sst.ref.", delimiter="")
-<shared>  - 61a6-1-000001.sst.ref.1.000001
+<remote> delete object "61a6-1-000001.sst.ref.2.000101"
+<remote> list (prefix="61a6-1-000001.sst.ref.", delimiter="")
+<remote>  - 61a6-1-000001.sst.ref.1.000001
 
 switch p1
 ----
@@ -100,6 +100,6 @@ switch p2
 
 remove 102
 ----
-<shared> delete object "a629-1-000002.sst.ref.2.000102"
-<shared> list (prefix="a629-1-000002.sst.ref.", delimiter="")
-<shared>  - a629-1-000002.sst.ref.1.000002
+<remote> delete object "a629-1-000002.sst.ref.2.000102"
+<remote> list (prefix="a629-1-000002.sst.ref.", delimiter="")
+<remote>  - a629-1-000002.sst.ref.1.000002

--- a/open.go
+++ b/open.go
@@ -297,10 +297,10 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		NoSyncOnClose:       opts.NoSyncOnClose,
 		BytesPerSync:        opts.BytesPerSync,
 	}
-	providerSettings.Shared.StorageFactory = opts.Experimental.RemoteStorage
-	providerSettings.Shared.CreateOnShared = opts.Experimental.CreateOnShared
-	providerSettings.Shared.CreateOnSharedLocator = opts.Experimental.CreateOnSharedLocator
-	providerSettings.Shared.CacheSizeBytes = opts.Experimental.SecondaryCacheSize
+	providerSettings.Remote.StorageFactory = opts.Experimental.RemoteStorage
+	providerSettings.Remote.CreateOnShared = opts.Experimental.CreateOnShared
+	providerSettings.Remote.CreateOnSharedLocator = opts.Experimental.CreateOnSharedLocator
+	providerSettings.Remote.CacheSizeBytes = opts.Experimental.SecondaryCacheSize
 
 	d.objProvider, err = objstorageprovider.Open(providerSettings)
 	if err != nil {


### PR DESCRIPTION
Shared objects refer to objects that have been created by a Pebble instance and are owned by the Pebble instances in a cluster. Remote objects can be shared objects or external objects (such as those attached by online restore).

In this commit we rename uses of "shared" to "remote" in objstorage provider code that applies to all types of remote objects. We now conceptually have a remote subsystem which itself contains a shared subsystem.