### PR TITLE
crl-release-23.1: bump commit pipeline constants

### DIFF
--- a/record/log_writer.go
+++ b/record/log_writer.go
@@ -38,7 +38,7 @@ type syncer interface {
 }
 
 const (
-	syncConcurrencyBits = 9
+	syncConcurrencyBits = 12
 
 	// SyncConcurrency is the maximum number of concurrent sync operations that
 	// can be performed. Note that a sync operation is initiated either by a call


### PR DESCRIPTION
This includes a 23.1 backport of #2764. Additionally, it contains a safer alternative to #2762, bumping the maximum allocated LogWriter blocks to 512. These are being backported as a part of a commitment to a customer.