### PR TITLE
*: implement EventuallyFileOnlySnapshots

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1071,8 +1071,8 @@ func (b *Batch) SetRepr(data []byte) error {
 // The returned Iterator observes all of the Batch's existing mutations, but no
 // later mutations. Its view can be refreshed via RefreshBatchSnapshot or
 // SetOptions().
-func (b *Batch) NewIter(o *IterOptions) *Iterator {
-	return b.NewIterWithContext(context.Background(), o)
+func (b *Batch) NewIter(o *IterOptions) (*Iterator, error) {
+	return b.NewIterWithContext(context.Background(), o), nil
 }
 
 // NewIterWithContext is like NewIter, and additionally accepts a context for

--- a/batch.go
+++ b/batch.go
@@ -1081,7 +1081,7 @@ func (b *Batch) NewIterWithContext(ctx context.Context, o *IterOptions) *Iterato
 	if b.index == nil {
 		return &Iterator{err: ErrNotIndexed}
 	}
-	return b.db.newIter(ctx, b, nil /* snapshot */, o)
+	return b.db.newIter(ctx, b, snapshotIterOpts{}, o)
 }
 
 // newInternalIter creates a new internalIterator that iterates over the

--- a/batch_test.go
+++ b/batch_test.go
@@ -270,7 +270,7 @@ func TestBatchEmpty(t *testing.T) {
 	require.NoError(t, err)
 	defer d.Close()
 	ib := newIndexedBatch(d, DefaultComparer)
-	iter := ib.NewIter(nil)
+	iter, _ := ib.NewIter(nil)
 	require.False(t, iter.First())
 	iter2, err := iter.Clone(CloneOptions{})
 	require.NoError(t, err)
@@ -418,7 +418,7 @@ func TestIndexedBatchReset(t *testing.T) {
 	require.Nil(t, b.rangeKeyIndex)
 
 	count := func(ib *Batch) int {
-		iter := ib.NewIter(nil)
+		iter, _ := ib.NewIter(nil)
 		defer iter.Close()
 		iter2, err := iter.Clone(CloneOptions{})
 		require.NoError(t, err)
@@ -433,7 +433,7 @@ func TestIndexedBatchReset(t *testing.T) {
 		return count[0]
 	}
 	contains := func(ib *Batch, key, value string) bool {
-		iter := ib.NewIter(nil)
+		iter, _ := ib.NewIter(nil)
 		defer iter.Close()
 		iter2, err := iter.Clone(CloneOptions{})
 		require.NoError(t, err)
@@ -497,13 +497,13 @@ func TestIndexedBatchMutation(t *testing.T) {
 			return ""
 		case "new-batch-iter":
 			name := td.CmdArgs[0].String()
-			iters[name] = b.NewIter(&IterOptions{
+			iters[name], _ = b.NewIter(&IterOptions{
 				KeyTypes: IterKeyTypePointsAndRanges,
 			})
 			return ""
 		case "new-db-iter":
 			name := td.CmdArgs[0].String()
-			iters[name] = d.NewIter(&IterOptions{
+			iters[name], _ = d.NewIter(&IterOptions{
 				KeyTypes: IterKeyTypePointsAndRanges,
 			})
 			return ""
@@ -581,7 +581,7 @@ func TestIndexedBatch_GlobalVisibility(t *testing.T) {
 	// Create an iterator over an empty indexed batch.
 	b := newIndexedBatch(d, DefaultComparer)
 	iterOpts := IterOptions{KeyTypes: IterKeyTypePointsAndRanges}
-	iter := b.NewIter(&iterOpts)
+	iter, _ := b.NewIter(&iterOpts)
 	defer iter.Close()
 
 	// Mutate the database's committed state.
@@ -1523,7 +1523,7 @@ func TestBatchSpanCaching(t *testing.T) {
 		case p < .55: /* 45 % */
 			// Create a new iterator directly from the batch and check that it
 			// observes the correct state.
-			iter := b.NewIter(&IterOptions{KeyTypes: IterKeyTypePointsAndRanges})
+			iter, _ := b.NewIter(&IterOptions{KeyTypes: IterKeyTypePointsAndRanges})
 			checkIter(iter, nextWriteKey)
 			iters[nextWriteKey] = append(iters[nextWriteKey], iter)
 		default: /* 45 % */

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -139,7 +139,7 @@ func TestCheckpoint(t *testing.T) {
 			}
 			memLog.Reset()
 			d := dbs[td.CmdArgs[0].String()]
-			iter := d.NewIter(nil)
+			iter, _ := d.NewIter(nil)
 			for valid := iter.First(); valid; valid = iter.Next() {
 				memLog.Infof("%s %s", iter.Key(), iter.Value())
 			}
@@ -280,7 +280,7 @@ func TestCheckpointFlushWAL(t *testing.T) {
 	{
 		d, err := Open(checkpointPath, opts)
 		require.NoError(t, err)
-		iter := d.NewIter(nil)
+		iter, _ := d.NewIter(nil)
 		require.True(t, iter.First())
 		require.Equal(t, key, iter.Key())
 		require.Equal(t, value, iter.Value())
@@ -335,7 +335,7 @@ func TestCheckpointManyFiles(t *testing.T) {
 	{
 		d, err := Open(checkpointPath, opts)
 		require.NoError(t, err)
-		iter := d.NewIter(nil)
+		iter, _ := d.NewIter(nil)
 		require.True(t, iter.First())
 		require.NoError(t, iter.Error())
 		n := 1

--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -131,7 +131,8 @@ func (p pebbleDB) Flush() error {
 }
 
 func (p pebbleDB) NewIter(opts *pebble.IterOptions) iterator {
-	return p.d.NewIter(opts)
+	iter, _ := p.d.NewIter(opts)
+	return iter
 }
 
 func (p pebbleDB) NewBatch() batch {

--- a/compaction.go
+++ b/compaction.go
@@ -2137,6 +2137,7 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 				// ranges this snapshot is interested in, this EFOS cannot transition to
 				// a file-only snapshot as keys in that range could now be deleted. Move
 				// onto the next snapshot.
+				s.efos.releaseReadState()
 				s = s.next
 				continue
 			}

--- a/compaction.go
+++ b/compaction.go
@@ -2118,6 +2118,36 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 				d.mu.versions.metrics.Flush.AsIngestTableCount += l.TablesIngested
 			}
 		}
+
+		// Update if any eventually file-only snapshots have now transitioned to
+		// being file-only.
+		earliestUnflushedSeqNum := d.getEarliestUnflushedSeqNumLocked()
+		currentVersion := d.mu.versions.currentVersion()
+		for s := d.mu.snapshots.root.next; s != &d.mu.snapshots.root; {
+			if s.efos == nil {
+				s = s.next
+				continue
+			}
+			if base.Visible(earliestUnflushedSeqNum, s.efos.seqNum, InternalKeySeqNumMax) {
+				s = s.next
+				continue
+			}
+			if s.efos.excised.Load() {
+				// If a concurrent excise has happened that overlaps with one of the key
+				// ranges this snapshot is interested in, this EFOS cannot transition to
+				// a file-only snapshot as keys in that range could now be deleted. Move
+				// onto the next snapshot.
+				s = s.next
+				continue
+			}
+			currentVersion.Ref()
+
+			// NB: s.efos.transitionToFileOnlySnapshot could close s, in which
+			// case s.next would be nil. Save it before calling it.
+			next := s.next
+			_ = s.efos.transitionToFileOnlySnapshot(currentVersion)
+			s = next
+		}
 	}
 	// Signal FlushEnd after installing the new readState. This helps for unit
 	// tests that use the callback to trigger a read using an iterator with

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1436,7 +1436,7 @@ func TestManualCompaction(t *testing.T) {
 					db:     d,
 					seqNum: InternalKeySeqNumMax,
 				}
-				iter := snap.NewIter(nil)
+				iter, _ := snap.NewIter(nil)
 				return runIterCmd(td, iter, true)
 
 			case "lsm":
@@ -2148,7 +2148,7 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 					db:     d,
 					seqNum: InternalKeySeqNumMax,
 				}
-				iter := snap.NewIter(nil)
+				iter, _ := snap.NewIter(nil)
 				return runIterCmd(td, iter, true)
 
 			case "reset":

--- a/db.go
+++ b/db.go
@@ -74,7 +74,7 @@ type Reader interface {
 	// NewIter returns an iterator that is unpositioned (Iterator.Valid() will
 	// return false). The iterator can be positioned via a call to SeekGE,
 	// SeekLT, First or Last.
-	NewIter(o *IterOptions) *Iterator
+	NewIter(o *IterOptions) (*Iterator, error)
 
 	// Close closes the Reader. It may or may not close any underlying io.Reader
 	// or io.Writer, depending on how the DB was created.
@@ -1471,14 +1471,14 @@ func (d *DB) NewIndexedBatch() *Batch {
 // to maintain a long-lived point-in-time view of the DB state can lead to an
 // apparent memory and disk usage leak. Use snapshots (see NewSnapshot) for
 // point-in-time snapshots which avoids these problems.
-func (d *DB) NewIter(o *IterOptions) *Iterator {
+func (d *DB) NewIter(o *IterOptions) (*Iterator, error) {
 	return d.NewIterWithContext(context.Background(), o)
 }
 
 // NewIterWithContext is like NewIter, and additionally accepts a context for
 // tracing.
-func (d *DB) NewIterWithContext(ctx context.Context, o *IterOptions) *Iterator {
-	return d.newIter(ctx, nil /* batch */, snapshotIterOpts{}, o)
+func (d *DB) NewIterWithContext(ctx context.Context, o *IterOptions) (*Iterator, error) {
+	return d.newIter(ctx, nil /* batch */, snapshotIterOpts{}, o), nil
 }
 
 // NewSnapshot returns a point-in-time view of the current DB state. Iterators

--- a/db.go
+++ b/db.go
@@ -980,12 +980,31 @@ var iterAllocPool = sync.Pool{
 	},
 }
 
+// snapshotIterOpts denotes snapshot-related iterator options when calling
+// newIter. These are the possible cases for a snapshotIterOpts:
+//   - No snapshot: All fields are zero values.
+//   - Classic snapshot: Only `seqNum` is set. The latest readState will be used
+//     and the specified seqNum will be used as the snapshot seqNum.
+//   - EventuallyFileOnlySnapshot (EFOS) in pre-file-only state: `readState` and
+//     `seqNum` are set. The specified readState is used with the snapshot
+//     sequence number.
+//   - EFOS in file-only state: Only `seqNum` and `vers` are set. No readState
+//     is referenced, as all the relevant SSTs are referenced by the *version.
+type snapshotIterOpts struct {
+	seqNum    uint64
+	readState *readState
+	vers      *version
+}
+
 // newIter constructs a new iterator, merging in batch iterators as an extra
 // level.
-func (d *DB) newIter(ctx context.Context, batch *Batch, s *Snapshot, o *IterOptions) *Iterator {
+func (d *DB) newIter(
+	ctx context.Context, batch *Batch, sOpts snapshotIterOpts, o *IterOptions,
+) *Iterator {
 	if err := d.closed.Load(); err != nil {
 		panic(err)
 	}
+	seqNum := sOpts.seqNum
 	if o.rangeKeys() {
 		if d.FormatMajorVersion() < FormatRangeKeys {
 			panic(fmt.Sprintf(
@@ -997,7 +1016,7 @@ func (d *DB) newIter(ctx context.Context, batch *Batch, s *Snapshot, o *IterOpti
 	if o != nil && o.RangeKeyMasking.Suffix != nil && o.KeyTypes != IterKeyTypePointsAndRanges {
 		panic("pebble: range key masking requires IterKeyTypePointsAndRanges")
 	}
-	if (batch != nil || s != nil) && (o != nil && o.OnlyReadGuaranteedDurable) {
+	if (batch != nil || seqNum != 0) && (o != nil && o.OnlyReadGuaranteedDurable) {
 		// We could add support for OnlyReadGuaranteedDurable on snapshots if
 		// there was a need: this would require checking that the sequence number
 		// of the snapshot has been flushed, by comparing with
@@ -1007,14 +1026,20 @@ func (d *DB) newIter(ctx context.Context, batch *Batch, s *Snapshot, o *IterOpti
 	// Grab and reference the current readState. This prevents the underlying
 	// files in the associated version from being deleted if there is a current
 	// compaction. The readState is unref'd by Iterator.Close().
-	readState := d.loadReadState()
+	readState := sOpts.readState
+	if readState == nil && sOpts.vers == nil {
+		// NB: loadReadState() calls readState.ref().
+		readState = d.loadReadState()
+	} else if readState != nil {
+		readState.ref()
+	} else {
+		// s.vers != nil
+		sOpts.vers.Ref()
+	}
 
 	// Determine the seqnum to read at after grabbing the read state (current and
 	// memtables) above.
-	var seqNum uint64
-	if s != nil {
-		seqNum = s.seqNum
-	} else {
+	if seqNum == 0 {
 		seqNum = d.mu.versions.visibleSeqNum.Load()
 	}
 
@@ -1028,6 +1053,7 @@ func (d *DB) newIter(ctx context.Context, batch *Batch, s *Snapshot, o *IterOpti
 		merge:               d.merge,
 		comparer:            *d.opts.Comparer,
 		readState:           readState,
+		version:             sOpts.vers,
 		keyBuf:              buf.keyBuf,
 		prefixOrFullSeekKey: buf.prefixOrFullSeekKey,
 		boundsBuf:           buf.boundsBuf,
@@ -1057,7 +1083,10 @@ func (d *DB) newIter(ctx context.Context, batch *Batch, s *Snapshot, o *IterOpti
 func finishInitializingIter(ctx context.Context, buf *iterAlloc) *Iterator {
 	// Short-hand.
 	dbi := &buf.dbi
-	memtables := dbi.readState.memtables
+	var memtables flushableList
+	if dbi.readState != nil {
+		memtables = dbi.readState.memtables
+	}
 	if dbi.opts.OnlyReadGuaranteedDurable {
 		memtables = nil
 	} else {
@@ -1196,7 +1225,7 @@ func (d *DB) ScanInternal(
 			UpperBound: upper,
 		},
 	}
-	iter := d.newInternalIter(nil /* snapshot */, scanInternalOpts)
+	iter := d.newInternalIter(snapshotIterOpts{} /* snapshot */, scanInternalOpts)
 	defer iter.close()
 	return scanInternalImpl(ctx, lower, upper, iter, scanInternalOpts)
 }
@@ -1208,31 +1237,39 @@ func (d *DB) ScanInternal(
 // TODO(bilal): This method has a lot of similarities with db.newIter as well as
 // finishInitializingIter. Both pairs of methods should be refactored to reduce
 // this duplication.
-func (d *DB) newInternalIter(s *Snapshot, o *scanInternalOptions) *scanInternalIterator {
+func (d *DB) newInternalIter(sOpts snapshotIterOpts, o *scanInternalOptions) *scanInternalIterator {
 	if err := d.closed.Load(); err != nil {
 		panic(err)
 	}
 	// Grab and reference the current readState. This prevents the underlying
 	// files in the associated version from being deleted if there is a current
 	// compaction. The readState is unref'd by Iterator.Close().
-	readState := d.loadReadState()
+	readState := sOpts.readState
+	if readState == nil && sOpts.vers == nil {
+		readState = d.loadReadState()
+	} else if readState != nil {
+		readState.ref()
+	}
+	if sOpts.vers != nil {
+		sOpts.vers.Ref()
+	}
 
 	// Determine the seqnum to read at after grabbing the read state (current and
 	// memtables) above.
-	var seqNum uint64
-	if s == nil {
+	seqNum := sOpts.seqNum
+	if seqNum == 0 {
 		seqNum = d.mu.versions.visibleSeqNum.Load()
-	} else {
-		seqNum = s.seqNum
 	}
 
 	// Bundle various structures under a single umbrella in order to allocate
 	// them together.
 	buf := iterAllocPool.Get().(*iterAlloc)
 	dbi := &scanInternalIterator{
+		db:              d,
 		comparer:        d.opts.Comparer,
 		merge:           d.opts.Merger.Merge,
 		readState:       readState,
+		version:         sOpts.vers,
 		alloc:           buf,
 		newIters:        d.newIters,
 		newIterRangeKey: d.tableNewRangeKeyIter,
@@ -1251,7 +1288,10 @@ func (d *DB) newInternalIter(s *Snapshot, o *scanInternalOptions) *scanInternalI
 
 func finishInitializingInternalIter(buf *iterAlloc, i *scanInternalIterator) *scanInternalIterator {
 	// Short-hand.
-	memtables := i.readState.memtables
+	var memtables flushableList
+	if i.readState != nil {
+		memtables = i.readState.memtables
+	}
 	// We only need to read from memtables which contain sequence numbers older
 	// than seqNum. Trim off newer memtables.
 	for j := len(memtables) - 1; j >= 0; j-- {
@@ -1306,7 +1346,10 @@ func (i *Iterator) constructPointIter(
 	}
 	numMergingLevels += len(memtables)
 
-	current := i.readState.current
+	current := i.version
+	if current == nil {
+		current = i.readState.current
+	}
 	numMergingLevels += len(current.L0SublevelFiles)
 	numLevelIters += len(current.L0SublevelFiles)
 	for level := 1; level < len(current.Levels); level++ {
@@ -1435,7 +1478,7 @@ func (d *DB) NewIter(o *IterOptions) *Iterator {
 // NewIterWithContext is like NewIter, and additionally accepts a context for
 // tracing.
 func (d *DB) NewIterWithContext(ctx context.Context, o *IterOptions) *Iterator {
-	return d.newIter(ctx, nil /* batch */, nil /* snapshot */, o)
+	return d.newIter(ctx, nil /* batch */, snapshotIterOpts{}, o)
 }
 
 // NewSnapshot returns a point-in-time view of the current DB state. Iterators
@@ -1459,6 +1502,28 @@ func (d *DB) NewSnapshot() *Snapshot {
 	d.mu.snapshots.pushBack(s)
 	d.mu.Unlock()
 	return s
+}
+
+// NewEventuallyFileOnlySnapshot returns a point-in-time view of the current DB
+// state, similar to NewSnapshot. See the comment at EventuallyFileOnlySnapshot
+// for its semantics.
+func (d *DB) NewEventuallyFileOnlySnapshot(keyRanges []KeyRange) *EventuallyFileOnlySnapshot {
+	if err := d.closed.Load(); err != nil {
+		panic(err)
+	}
+
+	internalKeyRanges := make([]internalKeyRange, len(keyRanges))
+	for i := range keyRanges {
+		if i > 0 && d.cmp(keyRanges[i-1].End, keyRanges[i].Start) > 0 {
+			panic("pebble: key ranges for eventually-file-only-snapshot not in order")
+		}
+		internalKeyRanges[i] = internalKeyRange{
+			smallest: base.MakeInternalKey(keyRanges[i].Start, InternalKeySeqNumMax, InternalKeyKindMax),
+			largest:  base.MakeExclusiveSentinelKey(InternalKeyKindRangeDelete, keyRanges[i].End),
+		}
+	}
+
+	return d.makeEventuallyFileOnlySnapshot(keyRanges, internalKeyRanges)
 }
 
 // Close closes the DB.
@@ -1631,6 +1696,10 @@ func (d *DB) Compact(start, end []byte, parallelize bool) error {
 		}
 	}
 
+	keyRanges := make([]internalKeyRange, len(meta))
+	for i := range meta {
+		keyRanges[i] = internalKeyRange{smallest: m.Smallest, largest: m.Largest}
+	}
 	// Determine if any memtable overlaps with the compaction range. We wait for
 	// any such overlap to flush (initiating a flush if necessary).
 	mem, err := func() (*flushableEntry, error) {
@@ -1640,7 +1709,7 @@ func (d *DB) Compact(start, end []byte, parallelize bool) error {
 		// overlaps.
 		for i := len(d.mu.mem.queue) - 1; i >= 0; i-- {
 			mem := d.mu.mem.queue[i]
-			if ingestMemtableOverlaps(d.cmp, mem, meta) {
+			if ingestMemtableOverlaps(d.cmp, mem, keyRanges) {
 				var err error
 				if mem.flushable == d.mu.mem.mutable {
 					// We have to hold both commitPipeline.mu and DB.mu when calling
@@ -2740,7 +2809,7 @@ func (d *DB) ScanStatistics(
 		},
 		rateLimitFunc: rateLimitFunc,
 	}
-	iter := d.newInternalIter(nil /* snapshot */, scanInternalOpts)
+	iter := d.newInternalIter(snapshotIterOpts{}, scanInternalOpts)
 	defer iter.close()
 
 	err := scanInternalImpl(ctx, lower, upper, iter, scanInternalOpts)

--- a/db_test.go
+++ b/db_test.go
@@ -493,7 +493,7 @@ func TestMergeOrderSameAfterFlush(t *testing.T) {
 
 	key := []byte("a")
 	verify := func(expected string) {
-		iter := d.NewIter(nil)
+		iter, _ := d.NewIter(nil)
 		if !iter.SeekGE([]byte("a")) {
 			t.Fatal("expected one value, but got empty iterator")
 		}
@@ -696,7 +696,7 @@ func TestIterLeak(t *testing.T) {
 					if flush {
 						require.NoError(t, d.Flush())
 					}
-					iter := d.NewIter(nil)
+					iter, _ := d.NewIter(nil)
 					iter.First()
 					if !leak {
 						require.NoError(t, iter.Close())
@@ -746,7 +746,7 @@ func TestIterLeakSharedCache(t *testing.T) {
 
 					// Check if leak detection works with only one db closing.
 					{
-						iter1 := d1.NewIter(nil)
+						iter1, _ := d1.NewIter(nil)
 						iter1.First()
 						if !leak {
 							require.NoError(t, iter1.Close())
@@ -764,7 +764,7 @@ func TestIterLeakSharedCache(t *testing.T) {
 					}
 
 					{
-						iter2 := d2.NewIter(nil)
+						iter2, _ := d2.NewIter(nil)
 						iter2.First()
 						if !leak {
 							require.NoError(t, iter2.Close())
@@ -837,7 +837,7 @@ func TestMemTableReservation(t *testing.T) {
 	// Flush in the presence of an active iterator. The iterator will hold a
 	// reference to a readState which will in turn hold a reader reference to the
 	// memtable.
-	iter := d.NewIter(nil)
+	iter, _ := d.NewIter(nil)
 	require.NoError(t, d.Flush())
 	// The flush moved the recycled memtable into position as an active mutable
 	// memtable. There are now two allocated memtables: 1 mutable and 1 pinned
@@ -895,7 +895,7 @@ func TestCacheEvict(t *testing.T) {
 	}
 
 	require.NoError(t, d.Flush())
-	iter := d.NewIter(nil)
+	iter, _ := d.NewIter(nil)
 	for iter.First(); iter.Valid(); iter.Next() {
 	}
 	require.NoError(t, iter.Close())
@@ -1116,7 +1116,7 @@ func TestDBClosed(t *testing.T) {
 	b := d.NewIndexedBatch()
 	require.True(t, errors.Is(catch(func() { _ = b.Commit(nil) }), ErrClosed))
 	require.True(t, errors.Is(catch(func() { _ = d.Apply(b, nil) }), ErrClosed))
-	require.True(t, errors.Is(catch(func() { _ = b.NewIter(nil) }), ErrClosed))
+	require.True(t, errors.Is(catch(func() { _, _ = b.NewIter(nil) }), ErrClosed))
 }
 
 func TestDBConcurrentCommitCompactFlush(t *testing.T) {
@@ -1238,7 +1238,7 @@ func TestCloseCleanerRace(t *testing.T) {
 		require.NoError(t, db.Set([]byte("a"), []byte("something"), Sync))
 		require.NoError(t, db.Flush())
 		// Ref the sstables so cannot be deleted.
-		it := db.NewIter(nil)
+		it, _ := db.NewIter(nil)
 		require.NotNil(t, it)
 		require.NoError(t, db.DeleteRange([]byte("a"), []byte("b"), Sync))
 		require.NoError(t, db.Compact([]byte("a"), []byte("b"), false))
@@ -1452,14 +1452,14 @@ func TestTracing(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	iter := d.NewIterWithContext(ctx, nil)
+	iter, _ := d.NewIterWithContext(ctx, nil)
 	iter.SeekGE([]byte("hello"))
 	iter.Close()
 	require.Equal(t, iterTraceString, tracer.buf.String())
 
 	tracer.buf.Reset()
 	snap := d.NewSnapshot()
-	iter = snap.NewIterWithContext(ctx, nil)
+	iter, _ = snap.NewIterWithContext(ctx, nil)
 	iter.SeekGE([]byte("hello"))
 	iter.Close()
 	require.Equal(t, iterTraceString, tracer.buf.String())
@@ -1924,7 +1924,7 @@ func BenchmarkNewIterReadAmp(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				b.StartTimer()
-				iter := d.NewIter(nil)
+				iter, _ := d.NewIter(nil)
 				b.StopTimer()
 				require.NoError(b, iter.Close())
 			}

--- a/error_test.go
+++ b/error_test.go
@@ -125,7 +125,7 @@ func TestErrors(t *testing.T) {
 			return err
 		}
 
-		iter := d.NewIter(nil)
+		iter, _ := d.NewIter(nil)
 		for valid := iter.First(); valid; valid = iter.Next() {
 		}
 		if err := iter.Close(); err != nil {
@@ -211,7 +211,7 @@ func TestRequireReadError(t *testing.T) {
 
 		// Now perform foreground ops with error injection enabled.
 		inj.SetIndex(index)
-		iter := d.NewIter(nil)
+		iter, _ := d.NewIter(nil)
 		if err := iter.Error(); err != nil {
 			return err
 		}
@@ -315,7 +315,7 @@ func TestCorruptReadError(t *testing.T) {
 
 		// Now perform foreground ops with corruption injection enabled.
 		fs.index.Store(index)
-		iter := d.NewIter(nil)
+		iter, _ := d.NewIter(nil)
 		if err := iter.Error(); err != nil {
 			return err
 		}

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -103,7 +103,7 @@ func testBasicDB(d *DB) error {
 		return err
 	}
 
-	iter := d.NewIter(nil)
+	iter, _ := d.NewIter(nil)
 	for valid := iter.First(); valid; valid = iter.Next() {
 	}
 	if err := iter.Close(); err != nil {

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -519,7 +519,7 @@ func TestOverlappingIngestedSSTs(t *testing.T) {
 			return ""
 
 		case "iter":
-			iter := d.NewIter(nil)
+			iter, _ := d.NewIter(nil)
 			return runIterCmd(td, iter, true)
 
 		case "lsm":
@@ -675,7 +675,7 @@ func TestExcise(t *testing.T) {
 			return runGetCmd(t, td, d)
 
 		case "iter":
-			iter := d.NewIter(&IterOptions{
+			iter, _ := d.NewIter(&IterOptions{
 				KeyTypes: IterKeyTypePointsAndRanges,
 			})
 			return runIterCmd(td, iter, true)
@@ -970,7 +970,10 @@ func TestIngestShared(t *testing.T) {
 					reader = efos[arg.Vals[0]]
 				}
 			}
-			iter := reader.NewIter(o)
+			iter, err := reader.NewIter(o)
+			if err != nil {
+				return err.Error()
+			}
 			return runIterCmd(td, iter, true)
 
 		case "lsm":
@@ -1252,7 +1255,7 @@ func TestIngestExternal(t *testing.T) {
 			return runGetCmd(t, td, d)
 
 		case "iter":
-			iter := d.NewIter(&IterOptions{
+			iter, _ := d.NewIter(&IterOptions{
 				KeyTypes: IterKeyTypePointsAndRanges,
 			})
 			return runIterCmd(td, iter, true)
@@ -1631,7 +1634,7 @@ func TestIngest(t *testing.T) {
 			return runGetCmd(t, td, d)
 
 		case "iter":
-			iter := d.NewIter(&IterOptions{
+			iter, _ := d.NewIter(&IterOptions{
 				KeyTypes: IterKeyTypePointsAndRanges,
 			})
 			return runIterCmd(td, iter, true)

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -746,7 +746,11 @@ func TestExcise(t *testing.T) {
 
 func TestIngestShared(t *testing.T) {
 	var d, d1, d2 *DB
+	var efos map[string]*EventuallyFileOnlySnapshot
 	defer func() {
+		for _, e := range efos {
+			require.NoError(t, e.Close())
+		}
 		if d1 != nil {
 			require.NoError(t, d1.Close())
 		}
@@ -758,12 +762,16 @@ func TestIngestShared(t *testing.T) {
 	replicateCounter := 1
 
 	reset := func() {
+		for _, e := range efos {
+			require.NoError(t, e.Close())
+		}
 		if d1 != nil {
 			require.NoError(t, d1.Close())
 		}
 		if d2 != nil {
 			require.NoError(t, d2.Close())
 		}
+		efos = make(map[string]*EventuallyFileOnlySnapshot)
 
 		sstorage := remote.NewInMem()
 		mem1 := vfs.NewMem()
@@ -779,6 +787,9 @@ func TestIngestShared(t *testing.T) {
 			DebugCheck:            DebugCheckLevels,
 			FormatMajorVersion:    ExperimentalFormatVirtualSSTables,
 		}
+		// lel.
+		lel := MakeLoggingEventListener(DefaultLogger)
+		opts1.EventListener = &lel
 		opts1.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"": sstorage,
 		})
@@ -945,6 +956,8 @@ func TestIngestShared(t *testing.T) {
 
 		case "iter":
 			o := &IterOptions{KeyTypes: IterKeyTypePointsAndRanges}
+			var reader Reader
+			reader = d
 			for _, arg := range td.CmdArgs {
 				switch arg.Key {
 				case "mask-suffix":
@@ -953,9 +966,11 @@ func TestIngestShared(t *testing.T) {
 					o.RangeKeyMasking.Filter = func() BlockPropertyFilterMask {
 						return sstable.NewTestKeysMaskingFilter()
 					}
+				case "snapshot":
+					reader = efos[arg.Vals[0]]
 				}
 			}
-			iter := d.NewIter(o)
+			iter := reader.NewIter(o)
 			return runIterCmd(td, iter, true)
 
 		case "lsm":
@@ -979,7 +994,7 @@ func TestIngestShared(t *testing.T) {
 			}
 			var exciseSpan KeyRange
 			if len(td.CmdArgs) != 2 {
-				panic("insufficient args for compact command")
+				panic("insufficient args for excise command")
 			}
 			exciseSpan.Start = []byte(td.CmdArgs[0].Key)
 			exciseSpan.End = []byte(td.CmdArgs[1].Key)
@@ -1004,6 +1019,36 @@ func TestIngestShared(t *testing.T) {
 			d.mu.versions.logUnlock()
 			d.mu.Unlock()
 			return fmt.Sprintf("would excise %d files, use ingest-and-excise to excise.\n%s", len(ve.DeletedFiles), ve.String())
+
+		case "file-only-snapshot":
+			if len(td.CmdArgs) != 1 {
+				panic("insufficient args for file-only-snapshot command")
+			}
+			name := td.CmdArgs[0].Key
+			var keyRanges []KeyRange
+			for _, line := range strings.Split(td.Input, "\n") {
+				fields := strings.Fields(line)
+				if len(fields) != 2 {
+					return "expected two fields for file-only snapshot KeyRanges"
+				}
+				kr := KeyRange{Start: []byte(fields[0]), End: []byte(fields[1])}
+				keyRanges = append(keyRanges, kr)
+			}
+
+			s := d.NewEventuallyFileOnlySnapshot(keyRanges)
+			efos[name] = s
+			return "ok"
+
+		case "wait-for-file-only-snapshot":
+			if len(td.CmdArgs) != 1 {
+				panic("insufficient args for file-only-snapshot command")
+			}
+			name := td.CmdArgs[0].Key
+			err := efos[name].WaitForFileOnlySnapshot(1 * time.Millisecond)
+			if err != nil {
+				return err.Error()
+			}
+			return "ok"
 
 		case "compact":
 			err := runCompactCmd(td, d)
@@ -1320,11 +1365,12 @@ func TestIngestMemtableOverlaps(t *testing.T) {
 				case "overlaps":
 					var buf bytes.Buffer
 					for _, data := range strings.Split(d.Input, "\n") {
-						var meta []*fileMetadata
+						var keyRanges []internalKeyRange
 						for _, part := range strings.Fields(data) {
-							meta = append(meta, parseMeta(part))
+							meta := parseMeta(part)
+							keyRanges = append(keyRanges, internalKeyRange{smallest: meta.Smallest, largest: meta.Largest})
 						}
-						fmt.Fprintf(&buf, "%t\n", ingestMemtableOverlaps(mem.cmp, mem, meta))
+						fmt.Fprintf(&buf, "%t\n", ingestMemtableOverlaps(mem.cmp, mem, keyRanges))
 					}
 					return buf.String()
 

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1166,6 +1166,420 @@ func TestSimpleIngestShared(t *testing.T) {
 	// of d and e have been updated.
 }
 
+type blockedCompaction struct {
+	startBlock, unblock chan struct{}
+}
+
+func TestConcurrentExcise(t *testing.T) {
+	var d, d1, d2 *DB
+	var efos map[string]*EventuallyFileOnlySnapshot
+	backgroundErrs := make(chan error, 5)
+	var compactions map[string]*blockedCompaction
+	defer func() {
+		for _, e := range efos {
+			require.NoError(t, e.Close())
+		}
+		if d1 != nil {
+			require.NoError(t, d1.Close())
+		}
+		if d2 != nil {
+			require.NoError(t, d2.Close())
+		}
+	}()
+	creatorIDCounter := uint64(1)
+	replicateCounter := 1
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	var blockNextCompaction bool
+	var blockedJobID int
+	var blockedCompactionName string
+	var blockedCompactionsMu sync.Mutex // protects the above three variables.
+
+	reset := func() {
+		wg.Wait()
+		for _, e := range efos {
+			require.NoError(t, e.Close())
+		}
+		if d1 != nil {
+			require.NoError(t, d1.Close())
+		}
+		if d2 != nil {
+			require.NoError(t, d2.Close())
+		}
+		efos = make(map[string]*EventuallyFileOnlySnapshot)
+		compactions = make(map[string]*blockedCompaction)
+		backgroundErrs = make(chan error, 5)
+
+		var el EventListener
+		el.EnsureDefaults(testLogger{t: t})
+		el.FlushBegin = func(info FlushInfo) {
+			// Don't block flushes
+		}
+		el.BackgroundError = func(err error) {
+			backgroundErrs <- err
+		}
+		el.CompactionBegin = func(info CompactionInfo) {
+			if info.Reason == "move" {
+				return
+			}
+			blockedCompactionsMu.Lock()
+			defer blockedCompactionsMu.Unlock()
+			if blockNextCompaction {
+				blockNextCompaction = false
+				blockedJobID = info.JobID
+			}
+		}
+		el.TableCreated = func(info TableCreateInfo) {
+			blockedCompactionsMu.Lock()
+			if info.JobID != blockedJobID {
+				blockedCompactionsMu.Unlock()
+				return
+			}
+			blockedJobID = 0
+			c := compactions[blockedCompactionName]
+			blockedCompactionName = ""
+			blockedCompactionsMu.Unlock()
+			c.startBlock <- struct{}{}
+			<-c.unblock
+		}
+
+		sstorage := remote.NewInMem()
+		mem1 := vfs.NewMem()
+		mem2 := vfs.NewMem()
+		require.NoError(t, mem1.MkdirAll("ext", 0755))
+		require.NoError(t, mem2.MkdirAll("ext", 0755))
+		opts1 := &Options{
+			Comparer:              testkeys.Comparer,
+			LBaseMaxBytes:         1,
+			FS:                    mem1,
+			L0CompactionThreshold: 100,
+			L0StopWritesThreshold: 100,
+			DebugCheck:            DebugCheckLevels,
+			FormatMajorVersion:    ExperimentalFormatVirtualSSTables,
+		}
+		// lel.
+		lel := MakeLoggingEventListener(DefaultLogger)
+		tel := TeeEventListener(lel, el)
+		opts1.EventListener = &tel
+		opts1.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+			"": sstorage,
+		})
+		opts1.Experimental.CreateOnShared = true
+		opts1.Experimental.CreateOnSharedLocator = ""
+		// Disable automatic compactions because otherwise we'll race with
+		// delete-only compactions triggered by ingesting range tombstones.
+		opts1.DisableAutomaticCompactions = true
+
+		opts2 := &Options{}
+		*opts2 = *opts1
+		opts2.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+			"": sstorage,
+		})
+		opts2.Experimental.CreateOnShared = true
+		opts2.Experimental.CreateOnSharedLocator = ""
+		opts2.FS = mem2
+
+		var err error
+		d1, err = Open("", opts1)
+		require.NoError(t, err)
+		require.NoError(t, d1.SetCreatorID(creatorIDCounter))
+		creatorIDCounter++
+		d2, err = Open("", opts2)
+		require.NoError(t, err)
+		require.NoError(t, d2.SetCreatorID(creatorIDCounter))
+		creatorIDCounter++
+		d = d1
+	}
+	reset()
+
+	datadriven.RunTest(t, "testdata/concurrent_excise", func(t *testing.T, td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "reset":
+			reset()
+			return ""
+		case "switch":
+			if len(td.CmdArgs) != 1 {
+				return "usage: switch <1 or 2>"
+			}
+			switch td.CmdArgs[0].Key {
+			case "1":
+				d = d1
+			case "2":
+				d = d2
+			default:
+				return "usage: switch <1 or 2>"
+			}
+			return "ok"
+		case "batch":
+			b := d.NewIndexedBatch()
+			if err := runBatchDefineCmd(td, b); err != nil {
+				return err.Error()
+			}
+			if err := b.Commit(nil); err != nil {
+				return err.Error()
+			}
+			return ""
+		case "build":
+			if err := runBuildCmd(td, d, d.opts.FS); err != nil {
+				return err.Error()
+			}
+			return ""
+
+		case "flush":
+			if err := d.Flush(); err != nil {
+				return err.Error()
+			}
+			return ""
+
+		case "ingest":
+			if err := runIngestCmd(td, d, d.opts.FS); err != nil {
+				return err.Error()
+			}
+			// Wait for a possible flush.
+			d.mu.Lock()
+			for d.mu.compact.flushing {
+				d.mu.compact.cond.Wait()
+			}
+			d.mu.Unlock()
+			return ""
+
+		case "ingest-and-excise":
+			if err := runIngestAndExciseCmd(td, d, d.opts.FS); err != nil {
+				return err.Error()
+			}
+			// Wait for a possible flush.
+			d.mu.Lock()
+			for d.mu.compact.flushing {
+				d.mu.compact.cond.Wait()
+			}
+			d.mu.Unlock()
+			return ""
+
+		case "replicate":
+			if len(td.CmdArgs) != 4 {
+				return "usage: replicate <from-db-num> <to-db-num> <start-key> <end-key>"
+			}
+			var from, to *DB
+			switch td.CmdArgs[0].Key {
+			case "1":
+				from = d1
+			case "2":
+				from = d2
+			default:
+				return "usage: replicate <from-db-num> <to-db-num> <start-key> <end-key>"
+			}
+			switch td.CmdArgs[1].Key {
+			case "1":
+				to = d1
+			case "2":
+				to = d2
+			default:
+				return "usage: replicate <from-db-num> <to-db-num> <start-key> <end-key>"
+			}
+			startKey := []byte(td.CmdArgs[2].Key)
+			endKey := []byte(td.CmdArgs[3].Key)
+
+			writeOpts := d.opts.MakeWriterOptions(0 /* level */, to.opts.FormatMajorVersion.MaxTableFormat())
+			sstPath := fmt.Sprintf("ext/replicate%d.sst", replicateCounter)
+			f, err := to.opts.FS.Create(sstPath)
+			require.NoError(t, err)
+			replicateCounter++
+			w := sstable.NewWriter(objstorageprovider.NewFileWritable(f), writeOpts)
+
+			var sharedSSTs []SharedSSTMeta
+			err = from.ScanInternal(context.TODO(), startKey, endKey,
+				func(key *InternalKey, value LazyValue, _ IteratorLevel) error {
+					val, _, err := value.Value(nil)
+					require.NoError(t, err)
+					require.NoError(t, w.Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val))
+					return nil
+				},
+				func(start, end []byte, seqNum uint64) error {
+					require.NoError(t, w.DeleteRange(start, end))
+					return nil
+				},
+				func(start, end []byte, keys []keyspan.Key) error {
+					s := keyspan.Span{
+						Start:     start,
+						End:       end,
+						Keys:      keys,
+						KeysOrder: 0,
+					}
+					require.NoError(t, rangekey.Encode(&s, func(k base.InternalKey, v []byte) error {
+						return w.AddRangeKey(base.MakeInternalKey(k.UserKey, 0, k.Kind()), v)
+					}))
+					return nil
+				},
+				func(sst *SharedSSTMeta) error {
+					sharedSSTs = append(sharedSSTs, *sst)
+					return nil
+				},
+			)
+			require.NoError(t, err)
+			require.NoError(t, w.Close())
+
+			_, err = to.IngestAndExcise([]string{sstPath}, sharedSSTs, KeyRange{Start: startKey, End: endKey})
+			require.NoError(t, err)
+			return fmt.Sprintf("replicated %d shared SSTs", len(sharedSSTs))
+
+		case "get":
+			return runGetCmd(t, td, d)
+
+		case "iter":
+			o := &IterOptions{KeyTypes: IterKeyTypePointsAndRanges}
+			var reader Reader
+			reader = d
+			for _, arg := range td.CmdArgs {
+				switch arg.Key {
+				case "mask-suffix":
+					o.RangeKeyMasking.Suffix = []byte(arg.Vals[0])
+				case "mask-filter":
+					o.RangeKeyMasking.Filter = func() BlockPropertyFilterMask {
+						return sstable.NewTestKeysMaskingFilter()
+					}
+				case "snapshot":
+					reader = efos[arg.Vals[0]]
+				}
+			}
+			iter, err := reader.NewIter(o)
+			if err != nil {
+				return err.Error()
+			}
+			return runIterCmd(td, iter, true)
+
+		case "lsm":
+			return runLSMCmd(td, d)
+
+		case "metrics":
+			// The asynchronous loading of table stats can change metrics, so
+			// wait for all the tables' stats to be loaded.
+			d.mu.Lock()
+			d.waitTableStats()
+			d.mu.Unlock()
+
+			return d.Metrics().String()
+
+		case "wait-pending-table-stats":
+			return runTableStatsCmd(td, d)
+
+		case "excise":
+			ve := &versionEdit{
+				DeletedFiles: map[deletedFileEntry]*fileMetadata{},
+			}
+			var exciseSpan KeyRange
+			if len(td.CmdArgs) != 2 {
+				panic("insufficient args for excise command")
+			}
+			exciseSpan.Start = []byte(td.CmdArgs[0].Key)
+			exciseSpan.End = []byte(td.CmdArgs[1].Key)
+
+			d.mu.Lock()
+			d.mu.versions.logLock()
+			d.mu.Unlock()
+			current := d.mu.versions.currentVersion()
+			for level := range current.Levels {
+				iter := current.Levels[level].Iter()
+				for m := iter.SeekGE(d.cmp, exciseSpan.Start); m != nil && d.cmp(m.Smallest.UserKey, exciseSpan.End) < 0; m = iter.Next() {
+					_, err := d.excise(exciseSpan, m, ve, level)
+					if err != nil {
+						d.mu.Lock()
+						d.mu.versions.logUnlock()
+						d.mu.Unlock()
+						return fmt.Sprintf("error when excising %s: %s", m.FileNum, err.Error())
+					}
+				}
+			}
+			d.mu.Lock()
+			d.mu.versions.logUnlock()
+			d.mu.Unlock()
+			return fmt.Sprintf("would excise %d files, use ingest-and-excise to excise.\n%s", len(ve.DeletedFiles), ve.String())
+
+		case "file-only-snapshot":
+			if len(td.CmdArgs) != 1 {
+				panic("insufficient args for file-only-snapshot command")
+			}
+			name := td.CmdArgs[0].Key
+			var keyRanges []KeyRange
+			for _, line := range strings.Split(td.Input, "\n") {
+				fields := strings.Fields(line)
+				if len(fields) != 2 {
+					return "expected two fields for file-only snapshot KeyRanges"
+				}
+				kr := KeyRange{Start: []byte(fields[0]), End: []byte(fields[1])}
+				keyRanges = append(keyRanges, kr)
+			}
+
+			s := d.NewEventuallyFileOnlySnapshot(keyRanges)
+			efos[name] = s
+			return "ok"
+
+		case "wait-for-file-only-snapshot":
+			if len(td.CmdArgs) != 1 {
+				panic("insufficient args for file-only-snapshot command")
+			}
+			name := td.CmdArgs[0].Key
+			err := efos[name].WaitForFileOnlySnapshot(1 * time.Millisecond)
+			if err != nil {
+				return err.Error()
+			}
+			return "ok"
+
+		case "unblock":
+			name := td.CmdArgs[0].Key
+			blockedCompactionsMu.Lock()
+			c := compactions[name]
+			delete(compactions, name)
+			blockedCompactionsMu.Unlock()
+			c.unblock <- struct{}{}
+			return "ok"
+
+		case "compact":
+			async := false
+			var otherArgs []datadriven.CmdArg
+			var bc *blockedCompaction
+			for i := range td.CmdArgs {
+				switch td.CmdArgs[i].Key {
+				case "block":
+					name := td.CmdArgs[i].Vals[0]
+					bc = &blockedCompaction{startBlock: make(chan struct{}), unblock: make(chan struct{})}
+					blockedCompactionsMu.Lock()
+					compactions[name] = bc
+					blockNextCompaction = true
+					blockedCompactionName = name
+					blockedCompactionsMu.Unlock()
+					async = true
+				default:
+					otherArgs = append(otherArgs, td.CmdArgs[i])
+				}
+			}
+			var tdClone datadriven.TestData
+			tdClone = *td
+			tdClone.CmdArgs = otherArgs
+			if !async {
+				err := runCompactCmd(td, d)
+				if err != nil {
+					return err.Error()
+				}
+			} else {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					_ = runCompactCmd(&tdClone, d)
+				}()
+				<-bc.startBlock
+				return "spun off in separate goroutine"
+			}
+			return "ok"
+		case "wait-for-background-error":
+			err := <-backgroundErrs
+			return err.Error()
+		default:
+			return fmt.Sprintf("unknown command: %s", td.Cmd)
+		}
+	})
+}
+
 func TestIngestExternal(t *testing.T) {
 	var mem vfs.FS
 	var d *DB

--- a/iterator.go
+++ b/iterator.go
@@ -187,7 +187,9 @@ type Iterator struct {
 	comparer  base.Comparer
 	iter      internalIterator
 	pointIter internalIterator
+	// Either readState or version is set, but not both.
 	readState *readState
+	version   *version
 	// rangeKey holds iteration state specific to iteration over range keys.
 	// The range key field may be nil if the Iterator has never been configured
 	// to iterate over range keys. Its non-nilness cannot be used to determine
@@ -2224,6 +2226,10 @@ func (i *Iterator) Close() error {
 		i.readState = nil
 	}
 
+	if i.version != nil {
+		i.version.Unref()
+	}
+
 	for _, readers := range i.externalReaders {
 		for _, r := range readers {
 			err = firstError(err, r.Close())
@@ -2655,11 +2661,22 @@ func (i *Iterator) CloneWithContext(ctx context.Context, opts CloneOptions) (*It
 	}
 
 	readState := i.readState
-	if readState == nil {
+	vers := i.version
+	if readState == nil && vers == nil {
 		return nil, errors.Errorf("cannot Clone a closed Iterator")
 	}
 	// i is already holding a ref, so there is no race with unref here.
-	readState.ref()
+	//
+	// TODO(bilal): If the underlying iterator was created on a snapshot, we could
+	// grab a reference to the current readState instead of reffing the original
+	// readState. This allows us to release references to some zombie sstables
+	// and memtables.
+	if readState != nil {
+		readState.ref()
+	}
+	if vers != nil {
+		vers.Ref()
+	}
 	// Bundle various structures under a single umbrella in order to allocate
 	// them together.
 	buf := iterAllocPool.Get().(*iterAlloc)
@@ -2671,6 +2688,7 @@ func (i *Iterator) CloneWithContext(ctx context.Context, opts CloneOptions) (*It
 		merge:               i.merge,
 		comparer:            i.comparer,
 		readState:           readState,
+		version:             vers,
 		keyBuf:              buf.keyBuf,
 		prefixOrFullSeekKey: buf.prefixOrFullSeekKey,
 		boundsBuf:           buf.boundsBuf,

--- a/iterator_example_test.go
+++ b/iterator_example_test.go
@@ -25,7 +25,7 @@ func ExampleIterator() {
 		}
 	}
 
-	iter := db.NewIter(nil)
+	iter, _ := db.NewIter(nil)
 	for iter.First(); iter.Valid(); iter.Next() {
 		fmt.Printf("%s\n", iter.Key())
 	}
@@ -73,7 +73,7 @@ func ExampleIterator_prefixIteration() {
 		}
 	}
 
-	iter := db.NewIter(prefixIterOptions([]byte("hello")))
+	iter, _ := db.NewIter(prefixIterOptions([]byte("hello")))
 	for iter.First(); iter.Valid(); iter.Next() {
 		fmt.Printf("%s\n", iter.Key())
 	}
@@ -101,7 +101,7 @@ func ExampleIterator_SeekGE() {
 		}
 	}
 
-	iter := db.NewIter(nil)
+	iter, _ := db.NewIter(nil)
 	if iter.SeekGE([]byte("a")); iter.Valid() {
 		fmt.Printf("%s\n", iter.Key())
 	}

--- a/iterator_histories_test.go
+++ b/iterator_histories_test.go
@@ -37,7 +37,7 @@ func TestIterHistories(t *testing.T) {
 		iters := map[string]*Iterator{}
 		batches := map[string]*Batch{}
 		newIter := func(name string, reader Reader, o *IterOptions) *Iterator {
-			it := reader.NewIter(o)
+			it, _ := reader.NewIter(o)
 			iters[name] = it
 			return it
 		}

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -698,7 +698,7 @@ func TestReadSampling(t *testing.T) {
 					db:     d,
 					seqNum: InternalKeySeqNumMax,
 				}
-				iter = snap.NewIter(nil)
+				iter, _ = snap.NewIter(nil)
 				iter.readSampling.forceReadSampling = true
 			}
 			return runIterCmd(td, iter, false)
@@ -806,7 +806,7 @@ func TestIteratorTableFilter(t *testing.T) {
 				db:     d,
 				seqNum: InternalKeySeqNumMax,
 			}
-			iter := snap.NewIter(iterOpts)
+			iter, _ := snap.NewIter(iterOpts)
 			return runIterCmd(td, iter, true)
 
 		default:
@@ -863,7 +863,7 @@ func TestIteratorNextPrev(t *testing.T) {
 				seqNum: InternalKeySeqNumMax,
 			}
 			td.MaybeScanArgs(t, "seq", &snap.seqNum)
-			iter := snap.NewIter(nil)
+			iter, _ := snap.NewIter(nil)
 			return runIterCmd(td, iter, true)
 
 		default:
@@ -919,7 +919,7 @@ func TestIteratorStats(t *testing.T) {
 				seqNum: InternalKeySeqNumMax,
 			}
 			td.MaybeScanArgs(t, "seq", &snap.seqNum)
-			iter := snap.NewIter(nil)
+			iter, _ := snap.NewIter(nil)
 			return runIterCmd(td, iter, true)
 
 		default:
@@ -1018,7 +1018,7 @@ func TestIteratorSeekOpt(t *testing.T) {
 					db:     d,
 					seqNum: InternalKeySeqNumMax,
 				}
-				iter = snap.NewIter(nil)
+				iter, _ = snap.NewIter(nil)
 				iter.readSampling.forceReadSampling = true
 				iter.comparer.Split = func(a []byte) int { return len(a) }
 				iter.forceEnableSeekOpt = true
@@ -1344,7 +1344,7 @@ func TestIteratorBlockIntervalFilter(t *testing.T) {
 					opts.PointKeyFilters[i], opts.PointKeyFilters[j] =
 						opts.PointKeyFilters[j], opts.PointKeyFilters[i]
 				})
-				iter := d.NewIter(&opts)
+				iter, _ := d.NewIter(&opts)
 				return runIterCmd(td, iter, true)
 
 			default:
@@ -1430,7 +1430,7 @@ func TestIteratorRandomizedBlockIntervalFilter(t *testing.T) {
 		sstable.NewBlockIntervalFilter("0",
 			uint64(lower), uint64(upper)),
 	}
-	iter := d.NewIter(&iterOpts)
+	iter, _ := d.NewIter(&iterOpts)
 	defer func() {
 		require.NoError(t, iter.Close())
 	}()
@@ -1466,7 +1466,7 @@ func TestIteratorGuaranteedDurable(t *testing.T) {
 			}
 			reader.Close()
 		}()
-		iter := reader.NewIter(&iterOptions)
+		iter, _ := reader.NewIter(&iterOptions)
 		defer iter.Close()
 	}
 	t.Run("snapshot", func(t *testing.T) {
@@ -1478,7 +1478,7 @@ func TestIteratorGuaranteedDurable(t *testing.T) {
 	t.Run("db", func(t *testing.T) {
 		d.Set([]byte("k"), []byte("v"), nil)
 		foundKV := func(o *IterOptions) bool {
-			iter := d.NewIter(o)
+			iter, _ := d.NewIter(o)
 			defer iter.Close()
 			iter.SeekGE([]byte("k"))
 			return iter.Valid()
@@ -1552,7 +1552,7 @@ func TestIteratorBoundsLifetimes(t *testing.T) {
 			var label string
 			td.ScanArgs(t, "label", &label)
 			lower, upper := parseBounds(td)
-			iterators[label] = d.NewIter(&IterOptions{
+			iterators[label], _ = d.NewIter(&IterOptions{
 				LowerBound: lower,
 				UpperBound: upper,
 			})
@@ -1811,9 +1811,9 @@ func testSetOptionsEquivalence(t *testing.T, seed uint64) {
 		generateNewOptions()
 		fmt.Fprintf(&history, "new options: %s\n", iterOptionsString(&o))
 
-		newIter = d.NewIter(&o)
+		newIter, _ = d.NewIter(&o)
 		if longLivedIter == nil {
-			longLivedIter = d.NewIter(&o)
+			longLivedIter, _ = d.NewIter(&o)
 		} else {
 			longLivedIter.SetOptions(&o)
 		}
@@ -2301,7 +2301,7 @@ func BenchmarkBlockPropertyFilter(b *testing.B) {
 								uint64(0), uint64(1)),
 						}
 					}
-					iter := d.NewIter(&iterOpts)
+					iter, _ := d.NewIter(&iterOpts)
 					b.ResetTimer()
 					for i := 0; i < b.N; i++ {
 						valid := iter.First()
@@ -2492,8 +2492,8 @@ func TestRangeKeyMaskingRandomized(t *testing.T) {
 		},
 	}
 
-	iter1 := d1.NewIter(&iter1Opts)
-	iter2 := d2.NewIter(&iter2Opts)
+	iter1, _ := d1.NewIter(&iter1Opts)
+	iter2, _ := d2.NewIter(&iter2Opts)
 	defer func() {
 		if err := iter1.Close(); err != nil {
 			t.Fatal(err)
@@ -2628,7 +2628,7 @@ func BenchmarkIterator_RangeKeyMasking(b *testing.B) {
 				b.Run("seekprefix", func(b *testing.B) {
 					b.ResetTimer()
 					for i := 0; i < b.N; i++ {
-						iter := d.NewIter(&iterOpts)
+						iter, _ := d.NewIter(&iterOpts)
 						count := 0
 						for j := 0; j < len(keys); j++ {
 							if !iter.SeekPrefixGE(keys[j]) {
@@ -2646,7 +2646,7 @@ func BenchmarkIterator_RangeKeyMasking(b *testing.B) {
 				b.Run("next", func(b *testing.B) {
 					b.ResetTimer()
 					for i := 0; i < b.N; i++ {
-						iter := d.NewIter(&iterOpts)
+						iter, _ := d.NewIter(&iterOpts)
 						count := 0
 						for valid := iter.First(); valid; valid = iter.Next() {
 							if hasPoint, _ := iter.HasPointAndRange(); hasPoint {
@@ -2662,7 +2662,7 @@ func BenchmarkIterator_RangeKeyMasking(b *testing.B) {
 			b.Run("backward", func(b *testing.B) {
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					iter := d.NewIter(&iterOpts)
+					iter, _ := d.NewIter(&iterOpts)
 					count := 0
 					for valid := iter.Last(); valid; valid = iter.Prev() {
 						if hasPoint, _ := iter.HasPointAndRange(); hasPoint {
@@ -2730,7 +2730,7 @@ func BenchmarkIteratorScan(b *testing.B) {
 					b.Run(fmt.Sprintf("keys=%d,r-amp=%d,key-types=%s", keyCount, readAmp, keyTypes), func(b *testing.B) {
 						for i := 0; i < b.N; i++ {
 							b.StartTimer()
-							iter := d.NewIter(&iterOpts)
+							iter, _ := d.NewIter(&iterOpts)
 							valid := iter.First()
 							for valid {
 								valid = iter.Next()
@@ -2806,7 +2806,7 @@ func BenchmarkIteratorScanNextPrefix(b *testing.B) {
 										IterKeyTypePointsOnly, IterKeyTypePointsAndRanges} {
 										b.Run(fmt.Sprintf("key-types=%s", keyTypes), func(b *testing.B) {
 											iterOpts := IterOptions{KeyTypes: keyTypes}
-											iter := d.NewIter(&iterOpts)
+											iter, _ := d.NewIter(&iterOpts)
 											var valid bool
 											b.ResetTimer()
 											for i := 0; i < b.N; i++ {
@@ -2867,9 +2867,9 @@ func BenchmarkCombinedIteratorSeek(b *testing.B) {
 						iterOpts := IterOptions{KeyTypes: IterKeyTypePointsAndRanges}
 						var it *Iterator
 						if useBatch {
-							it = batch.NewIter(&iterOpts)
+							it, _ = batch.NewIter(&iterOpts)
 						} else {
-							it = d.NewIter(&iterOpts)
+							it, _ = d.NewIter(&iterOpts)
 						}
 						for j := 0; j < len(keys); j++ {
 							if !it.SeekGE(keys[j]) {
@@ -2900,7 +2900,7 @@ func BenchmarkCombinedIteratorSeek_Bounded(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		it := d.NewIter(&iterOpts)
+		it, _ := d.NewIter(&iterOpts)
 		for j := lower; j < upper; j++ {
 			if !it.SeekGE(keys[j]) {
 				b.Errorf("key %q missing", keys[j])
@@ -2924,7 +2924,7 @@ func BenchmarkCombinedIteratorSeekPrefix(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		it := d.NewIter(&iterOpts)
+		it, _ := d.NewIter(&iterOpts)
 		for j := lower; j < upper; j++ {
 			if !it.SeekPrefixGE(keys[j]) {
 				b.Errorf("key %q missing", keys[j])
@@ -3017,7 +3017,7 @@ func BenchmarkSeekPrefixTombstones(b *testing.B) {
 	d.mu.Unlock()
 
 	seekKey := testkeys.Key(ks, 1)
-	iter := d.NewIter(nil)
+	iter, _ := d.NewIter(nil)
 	defer iter.Close()
 	b.ResetTimer()
 	defer b.StopTimer()

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -704,7 +704,7 @@ func (o *newIterOp) run(t *test, h historyRecorder) {
 
 	var i *pebble.Iterator
 	for {
-		i = r.NewIter(opts)
+		i, _ = r.NewIter(opts)
 		if err := i.Error(); !errors.Is(err, errorfs.ErrInjected) {
 			break
 		}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -209,7 +209,7 @@ func TestMetrics(t *testing.T) {
 					return err.Error()
 				}
 			}
-			iter := d.NewIter(nil)
+			iter, _ := d.NewIter(nil)
 			// Some iterators (eg. levelIter) do not instantiate the underlying
 			// iterator until the first positioning call. Position the iterator
 			// so that levelIters will have loaded an sstable.

--- a/open_test.go
+++ b/open_test.go
@@ -496,7 +496,7 @@ func TestOpenReadOnly(t *testing.T) {
 			return err
 		}())
 
-		checkIter := func(iter *Iterator) {
+		checkIter := func(iter *Iterator, err error) {
 			t.Helper()
 
 			var keys []string
@@ -536,7 +536,7 @@ func TestOpenReadOnly(t *testing.T) {
 func TestOpenWALReplay(t *testing.T) {
 	largeValue := []byte(strings.Repeat("a", 100<<10))
 	hugeValue := []byte(strings.Repeat("b", 10<<20))
-	checkIter := func(iter *Iterator) {
+	checkIter := func(iter *Iterator, err error) {
 		t.Helper()
 
 		var keys []string

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -81,7 +81,7 @@ func TestRangeDel(t *testing.T) {
 				seqNum: InternalKeySeqNumMax,
 			}
 			td.MaybeScanArgs(t, "seq", &snap.seqNum)
-			iter := snap.NewIter(nil)
+			iter, _ := snap.NewIter(nil)
 			return runIterCmd(td, iter, true)
 
 		default:
@@ -331,7 +331,7 @@ func TestRangeDelCompactionTruncation(t *testing.T) {
 		}
 
 		keys := func() string {
-			iter := d.NewIter(nil)
+			iter, _ := d.NewIter(nil)
 			defer iter.Close()
 			var buf bytes.Buffer
 			var sep string
@@ -637,7 +637,7 @@ func benchmarkRangeDelIterate(b *testing.B, entries, deleted int, snapshotCompac
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		iter := d.NewIter(nil)
+		iter, _ := d.NewIter(nil)
 		iter.SeekGE(from)
 		if deleted < entries {
 			if !iter.Valid() {

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -111,7 +111,7 @@ func runReplayTest(t *testing.T, path string) {
 			return ""
 		case "scan-keys":
 			var buf bytes.Buffer
-			it := r.d.NewIter(nil)
+			it, _ := r.d.NewIter(nil)
 			defer it.Close()
 			for valid := it.First(); valid; valid = it.Next() {
 				fmt.Fprintf(&buf, "%s: %s\n", it.Key(), it.Value())

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -399,11 +399,13 @@ type IteratorLevel struct {
 // *must* return the range delete as well as the range key unset/delete that did
 // the shadowing.
 type scanInternalIterator struct {
+	db              *DB
 	opts            scanInternalOptions
 	comparer        *base.Comparer
 	merge           Merge
 	iter            internalIterator
 	readState       *readState
+	version         *version
 	rangeKey        *iteratorRangeKeyState
 	pointKeyIter    internalIterator
 	iterKey         *InternalKey
@@ -605,15 +607,18 @@ func scanInternalImpl(
 	// of keys. For files that are shared, call visitSharedFile with a truncated
 	// version of that file.
 	cmp := iter.comparer.Compare
-	db := iter.readState.db
-	provider := db.objProvider
+	provider := iter.db.ObjProvider()
 	seqNum := iter.seqNum
+	current := iter.version
+	if current == nil {
+		current = iter.readState.current
+	}
 	if opts.visitSharedFile != nil {
 		if provider == nil {
 			panic("expected non-nil Provider in skip-shared iteration mode")
 		}
 		for level := sharedLevelsStart; level < numLevels; level++ {
-			files := iter.readState.current.Levels[level].Iter()
+			files := current.Levels[level].Iter()
 			for f := files.SeekGE(cmp, lower); f != nil && cmp(f.Smallest.UserKey, upper) < 0; f = files.Next() {
 				var objMeta objstorage.ObjectMetadata
 				var err error
@@ -629,7 +634,7 @@ func scanInternalImpl(
 				}
 				var sst *SharedSSTMeta
 				var skip bool
-				sst, skip, err = iter.readState.db.truncateSharedFile(ctx, lower, upper, level, f, objMeta)
+				sst, skip, err = iter.db.truncateSharedFile(ctx, lower, upper, level, f, objMeta)
 				if err != nil {
 					return err
 				}
@@ -699,8 +704,10 @@ func (i *scanInternalIterator) constructPointIter(memtables flushableList, buf *
 	numMergingLevels := len(memtables)
 	numLevelIters := 0
 
-	current := i.readState.current
-
+	current := i.version
+	if current == nil {
+		current = i.readState.current
+	}
 	numMergingLevels += len(current.L0SublevelFiles)
 	numLevelIters += len(current.L0SublevelFiles)
 
@@ -822,19 +829,24 @@ func (i *scanInternalIterator) constructRangeKeyIter() {
 		&i.rangeKey.rangeKeyBuffers.internal)
 
 	// Next are the flushables: memtables and large batches.
-	for j := len(i.readState.memtables) - 1; j >= 0; j-- {
-		mem := i.readState.memtables[j]
-		// We only need to read from memtables which contain sequence numbers older
-		// than seqNum.
-		if logSeqNum := mem.logSeqNum; logSeqNum >= i.seqNum {
-			continue
-		}
-		if rki := mem.newRangeKeyIter(&i.opts.IterOptions); rki != nil {
-			i.rangeKey.iterConfig.AddLevel(rki)
+	if i.readState != nil {
+		for j := len(i.readState.memtables) - 1; j >= 0; j-- {
+			mem := i.readState.memtables[j]
+			// We only need to read from memtables which contain sequence numbers older
+			// than seqNum.
+			if logSeqNum := mem.logSeqNum; logSeqNum >= i.seqNum {
+				continue
+			}
+			if rki := mem.newRangeKeyIter(&i.opts.IterOptions); rki != nil {
+				i.rangeKey.iterConfig.AddLevel(rki)
+			}
 		}
 	}
 
-	current := i.readState.current
+	current := i.version
+	if current == nil {
+		current = i.readState.current
+	}
 	// Next are the file levels: L0 sub-levels followed by lower levels.
 	//
 	// Add file-specific iterators for L0 files containing range keys. This is less
@@ -925,7 +937,12 @@ func (i *scanInternalIterator) close() error {
 	if err := i.iter.Close(); err != nil {
 		return err
 	}
-	i.readState.unref()
+	if i.readState != nil {
+		i.readState.unref()
+	}
+	if i.version != nil {
+		i.version.Unref()
+	}
 	if i.rangeKey != nil {
 		i.rangeKey.PrepareForReuse()
 		*i.rangeKey = iteratorRangeKeyState{

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
@@ -212,6 +213,7 @@ func TestScanInternal(t *testing.T) {
 	}
 	batches := map[string]*Batch{}
 	snaps := map[string]*Snapshot{}
+	efos := map[string]*EventuallyFileOnlySnapshot{}
 	parseOpts := func(td *datadriven.TestData) (*Options, error) {
 		opts := &Options{
 			FS:                 vfs.NewMem(),
@@ -294,6 +296,10 @@ func TestScanInternal(t *testing.T) {
 			err = firstError(err, snap.Close())
 			delete(snaps, key)
 		}
+		for key, es := range efos {
+			err = firstError(err, es.Close())
+			delete(efos, key)
+		}
 		if d != nil {
 			err = firstError(err, d.Close())
 			d = nil
@@ -339,6 +345,34 @@ func TestScanInternal(t *testing.T) {
 			td.ScanArgs(t, "name", &name)
 			snaps[name] = s
 			return ""
+		case "wait-for-file-only-snapshot":
+			if len(td.CmdArgs) != 1 {
+				panic("insufficient args for file-only-snapshot command")
+			}
+			name := td.CmdArgs[0].Key
+			es := efos[name]
+			if err := es.WaitForFileOnlySnapshot(1 * time.Millisecond); err != nil {
+				return err.Error()
+			}
+			return "ok"
+		case "file-only-snapshot":
+			if len(td.CmdArgs) != 1 {
+				panic("insufficient args for file-only-snapshot command")
+			}
+			name := td.CmdArgs[0].Key
+			var keyRanges []KeyRange
+			for _, line := range strings.Split(td.Input, "\n") {
+				fields := strings.Fields(line)
+				if len(fields) != 2 {
+					return "expected two fields for file-only snapshot KeyRanges"
+				}
+				kr := KeyRange{Start: []byte(fields[0]), End: []byte(fields[1])}
+				keyRanges = append(keyRanges, kr)
+			}
+
+			s := d.NewEventuallyFileOnlySnapshot(keyRanges)
+			efos[name] = s
+			return "ok"
 		case "batch":
 			var name string
 			td.MaybeScanArgs(t, "name", &name)
@@ -405,6 +439,13 @@ func TestScanInternal(t *testing.T) {
 						return fmt.Sprintf("no snapshot found for name %s", name)
 					}
 					reader = snap
+				case "file-only-snapshot":
+					name := arg.Vals[0]
+					efos, ok := efos[name]
+					if !ok {
+						return fmt.Sprintf("no snapshot found for name %s", name)
+					}
+					reader = efos
 				case "skip-shared":
 					fileVisitor = func(sst *SharedSSTMeta) error {
 						fmt.Fprintf(&b, "shared file: %s [%s-%s] [point=%s-%s] [range=%s-%s]\n", sst.fileNum, sst.Smallest.String(), sst.Largest.String(), sst.SmallestPointKey.String(), sst.LargestPointKey.String(), sst.SmallestRangeKey.String(), sst.LargestRangeKey.String())

--- a/snapshot.go
+++ b/snapshot.go
@@ -8,15 +8,27 @@ import (
 	"context"
 	"io"
 	"math"
+	"sync"
+	"sync/atomic"
+	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/rangekey"
 )
+
+// ErrSnapshotExcised is returned from WaitForFileOnlySnapshot if an excise
+// overlapping with one of the EventuallyFileOnlySnapshot's KeyRanges gets
+// applied before the transition of that EFOS to a file-only snapshot.
+var ErrSnapshotExcised = errors.New("pebble: snapshot excised before conversion to file-only snapshot")
 
 // Snapshot provides a read-only point-in-time view of the DB state.
 type Snapshot struct {
 	// The db the snapshot was created from.
 	db     *DB
 	seqNum uint64
+
+	// Set if part of an EventuallyFileOnlySnapshot.
+	efos *EventuallyFileOnlySnapshot
 
 	// The list the snapshot is linked into.
 	list *snapshotList
@@ -44,17 +56,17 @@ func (s *Snapshot) Get(key []byte) ([]byte, io.Closer, error) {
 // NewIter returns an iterator that is unpositioned (Iterator.Valid() will
 // return false). The iterator can be positioned via a call to SeekGE,
 // SeekLT, First or Last.
-func (s *Snapshot) NewIter(o *IterOptions) *Iterator {
+func (s *Snapshot) NewIter(o *IterOptions) (*Iterator, error) {
 	return s.NewIterWithContext(context.Background(), o)
 }
 
 // NewIterWithContext is like NewIter, and additionally accepts a context for
 // tracing.
-func (s *Snapshot) NewIterWithContext(ctx context.Context, o *IterOptions) *Iterator {
+func (s *Snapshot) NewIterWithContext(ctx context.Context, o *IterOptions) (*Iterator, error) {
 	if s.db == nil {
 		panic(ErrClosed)
 	}
-	return s.db.newIter(ctx, nil /* batch */, s, o)
+	return s.db.newIter(ctx, nil /* batch */, snapshotIterOpts{seqNum: s.seqNum}, o), nil
 }
 
 // ScanInternal scans all internal keys within the specified bounds, truncating
@@ -87,21 +99,15 @@ func (s *Snapshot) ScanInternal(
 		},
 	}
 
-	iter := s.db.newInternalIter(s, scanInternalOpts)
+	iter := s.db.newInternalIter(snapshotIterOpts{seqNum: s.seqNum}, scanInternalOpts)
 	defer iter.close()
 
 	return scanInternalImpl(ctx, lower, upper, iter, scanInternalOpts)
 }
 
-// Close closes the snapshot, releasing its resources. Close must be called.
-// Failure to do so will result in a tiny memory leak and a large leak of
-// resources on disk due to the entries the snapshot is preventing from being
-// deleted.
-func (s *Snapshot) Close() error {
-	if s.db == nil {
-		panic(ErrClosed)
-	}
-	s.db.mu.Lock()
+// closeLocked is similar to Close(), except it requires that db.mu be held
+// by the caller.
+func (s *Snapshot) closeLocked() error {
 	s.db.mu.snapshots.remove(s)
 
 	// If s was the previous earliest snapshot, we might be able to reclaim
@@ -109,9 +115,24 @@ func (s *Snapshot) Close() error {
 	if e := s.db.mu.snapshots.earliest(); e > s.seqNum {
 		s.db.maybeScheduleCompactionPicker(pickElisionOnly)
 	}
-	s.db.mu.Unlock()
 	s.db = nil
 	return nil
+}
+
+// Close closes the snapshot, releasing its resources. Close must be called.
+// Failure to do so will result in a tiny memory leak and a large leak of
+// resources on disk due to the entries the snapshot is preventing from being
+// deleted.
+//
+// d.mu must NOT be held by the caller.
+func (s *Snapshot) Close() error {
+	db := s.db
+	if db == nil {
+		panic(ErrClosed)
+	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	return s.closeLocked()
 }
 
 type snapshotList struct {
@@ -180,4 +201,325 @@ func (l *snapshotList) remove(s *Snapshot) {
 	s.next = nil // avoid memory leaks
 	s.prev = nil // avoid memory leaks
 	s.list = nil // avoid memory leaks
+}
+
+// EventuallyFileOnlySnapshot (aka EFOS) provides a read-only point-in-time view
+// of the database state, similar to Snapshot. A EventuallyFileOnlySnapshot
+// induces less write amplification than Snapshot, at the cost of increased space
+// amplification. While a Snapshot may increase write amplification across all
+// flushes and compactions for the duration of its lifetime, an
+// EventuallyFileOnlySnapshot only incurs that cost for flushes/compactions if
+// memtables at the time of EFOS instantiation contained keys that the EFOS is
+// interested in (i.e. its protectedRanges). In that case, the EFOS prevents
+// elision of keys visible to it, similar to a Snapshot, until those memtables
+// are flushed, and once that happens, the "EventuallyFileOnlySnapshot"
+// transitions to a file-only snapshot state in which it pins zombies sstables
+// like an open Iterator would, without pinning any memtables. Callers that can
+// tolerate the increased space amplification of pinning zombie sstables until
+// the snapshot is closed may prefer EventuallyFileOnlySnapshots for their
+// reduced write amplification. Callers that desire the benefits of the file-only
+// state that requires no pinning of memtables should call
+// `WaitForFileOnlySnapshot()` (and possibly re-mint an EFOS if it returns
+// ErrSnapshotExcised) before relying on the EFOS to keep producing iterators
+// with zero write-amp and zero pinning of memtables in memory.
+//
+// EventuallyFileOnlySnapshots interact with the IngestAndExcise operation in
+// subtle ways. Unlike Snapshots, EFOS guarantees that their read-only
+// point-in-time view is unaltered by the excision. However, if a concurrent
+// excise were to happen on one of the protectedRanges, WaitForFileOnlySnapshot()
+// would return ErrSnapshotExcised and the EFOS would maintain a reference to the
+// underlying readState (and by extension, zombie memtables) for its lifetime.
+// This could lead to increased memory utilization, which is why callers should
+// call WaitForFileOnlySnapshot() if they expect an EFOS to be long-lived.
+type EventuallyFileOnlySnapshot struct {
+	mu struct {
+		// NB: If both this mutex and db.mu are being grabbed, db.mu should be
+		// grabbed _before_ grabbing this one.
+		sync.Mutex
+
+		// transitioned is signalled when this EFOS transitions to being a file-only
+		// snapshot.
+		transitioned sync.Cond
+
+		// Either the {snap,readState} fields are set below, or the version is set at
+		// any given point of time. If a snapshot is referenced, this is not a
+		// file-only snapshot yet, and if a version is set (and ref'd) this is a
+		// file-only snapshot.
+
+		// The wrapped regular snapshot, if not a file-only snapshot yet. The
+		// readState has already been ref()d once if it's set.
+		snap      *Snapshot
+		readState *readState
+		// The wrapped version reference, if a file-only snapshot.
+		vers *version
+	}
+
+	// Key ranges to watch for an excise on.
+	protectedRanges []KeyRange
+	// excised, if true, signals that the above ranges were excised during the
+	// lifetime of this snapshot.
+	excised atomic.Bool
+
+	// The db the snapshot was created from.
+	db     *DB
+	seqNum uint64
+
+	closed chan struct{}
+}
+
+func (d *DB) makeEventuallyFileOnlySnapshot(
+	keyRanges []KeyRange, internalKeyRanges []internalKeyRange,
+) *EventuallyFileOnlySnapshot {
+	isFileOnly := true
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	seqNum := d.mu.versions.visibleSeqNum.Load()
+	// Check if any of the keyRanges overlap with a memtable.
+	for i := range d.mu.mem.queue {
+		mem := d.mu.mem.queue[i]
+		if ingestMemtableOverlaps(d.cmp, mem, internalKeyRanges) {
+			isFileOnly = false
+			break
+		}
+	}
+	es := &EventuallyFileOnlySnapshot{
+		db:              d,
+		seqNum:          seqNum,
+		protectedRanges: keyRanges,
+		closed:          make(chan struct{}),
+	}
+	es.mu.transitioned.L = &es.mu
+	if isFileOnly {
+		es.mu.vers = d.mu.versions.currentVersion()
+		es.mu.vers.Ref()
+	} else {
+		s := &Snapshot{
+			db:     d,
+			seqNum: seqNum,
+		}
+		s.efos = es
+		es.mu.snap = s
+		es.mu.readState = d.loadReadState()
+		d.mu.snapshots.pushBack(s)
+	}
+	return es
+}
+
+// Transitions this EventuallyFileOnlySnapshot to a file-only snapshot. Requires
+// earliestUnflushedSeqNum and vers to correspond to the same Version from the
+// current or a past acquisition of db.mu. vers must have been Ref()'d before
+// that mutex was released, if it was released.
+//
+// NB: The caller is expected to check for es.excised before making this
+// call.
+//
+// d.mu must be held when calling this method.
+func (es *EventuallyFileOnlySnapshot) transitionToFileOnlySnapshot(vers *version) error {
+	es.mu.Lock()
+	select {
+	case <-es.closed:
+		vers.UnrefLocked()
+		es.mu.Unlock()
+		return ErrClosed
+	default:
+	}
+	if es.mu.snap == nil {
+		es.mu.Unlock()
+		panic("pebble: tried to transition an eventually-file-only-snapshot twice")
+	}
+	// The caller has already called Ref() on vers.
+	es.mu.vers = vers
+	// NB: The callers should have already done a check of es.excised.
+	oldSnap := es.mu.snap
+	oldReadState := es.mu.readState
+	es.mu.snap = nil
+	es.mu.readState = nil
+	es.mu.transitioned.Broadcast()
+	es.mu.Unlock()
+	// It's okay to close a snapshot even if iterators are already open on it.
+	oldReadState.unrefLocked()
+	return oldSnap.closeLocked()
+}
+
+// releaseReadState is called to release reference to a readState when
+// es.excised == true. This is to free up memory as quickly as possible; all
+// other snapshot resources are kept around until Close() is called. Safe for
+// idempotent calls.
+//
+// d.mu must be held when calling this method.
+func (es *EventuallyFileOnlySnapshot) releaseReadState() {
+	if !es.excised.Load() {
+		panic("pebble: releasing read state of eventually-file-only-snapshot but was not excised")
+	}
+	es.mu.Lock()
+	defer es.mu.Unlock()
+	if es.mu.readState != nil {
+		es.mu.readState.unrefLocked()
+		es.db.maybeScheduleObsoleteTableDeletionLocked()
+	}
+}
+
+// WaitForFileOnlySnapshot blocks the calling goroutine until this snapshot
+// has been converted into a file-only snapshot (i.e. all memtables containing
+// keys < seqNum are flushed). A duration can be passed in, and if nonzero,
+// a delayed flush will be scheduled at that duration if necessary.
+//
+// Idempotent; can be called multiple times with no side effects.
+func (es *EventuallyFileOnlySnapshot) WaitForFileOnlySnapshot(dur time.Duration) error {
+	es.mu.Lock()
+	if es.mu.vers != nil {
+		// Fast path.
+		es.mu.Unlock()
+		return nil
+	}
+	es.mu.Unlock()
+
+	es.db.mu.Lock()
+	earliestUnflushedSeqNum := es.db.getEarliestUnflushedSeqNumLocked()
+	for earliestUnflushedSeqNum < es.seqNum {
+		select {
+		case <-es.closed:
+			es.db.mu.Unlock()
+			return ErrClosed
+		default:
+		}
+		// Check if the current mutable memtable contains keys less than seqNum.
+		// If so, rotate it.
+		if es.db.mu.mem.mutable.logSeqNum < es.seqNum && dur.Nanoseconds() > 0 {
+			es.db.maybeScheduleDelayedFlush(es.db.mu.mem.mutable, dur)
+		} else {
+			es.db.maybeScheduleFlush()
+		}
+		es.db.mu.compact.cond.Wait()
+
+		earliestUnflushedSeqNum = es.db.getEarliestUnflushedSeqNumLocked()
+	}
+	if es.excised.Load() {
+		es.db.mu.Unlock()
+		return ErrSnapshotExcised
+	}
+	es.db.mu.Unlock()
+
+	es.mu.Lock()
+	defer es.mu.Unlock()
+
+	// Wait for transition to file-only snapshot.
+	if es.mu.vers == nil {
+		es.mu.transitioned.Wait()
+	}
+	return nil
+}
+
+// Close closes the file-only snapshot and releases all referenced resources.
+// Not idempotent.
+func (es *EventuallyFileOnlySnapshot) Close() error {
+	close(es.closed)
+	es.db.mu.Lock()
+	defer es.db.mu.Unlock()
+	es.mu.Lock()
+	defer es.mu.Unlock()
+
+	if es.mu.snap != nil {
+		if err := es.mu.snap.closeLocked(); err != nil {
+			return err
+		}
+	}
+	if es.mu.readState != nil {
+		es.mu.readState.unrefLocked()
+		es.db.maybeScheduleObsoleteTableDeletionLocked()
+	}
+	if es.mu.vers != nil {
+		es.mu.vers.UnrefLocked()
+	}
+	return nil
+}
+
+// Get implements the Reader interface.
+func (es *EventuallyFileOnlySnapshot) Get(key []byte) (value []byte, closer io.Closer, err error) {
+	panic("unimplemented")
+}
+
+// NewIter returns an iterator that is unpositioned (Iterator.Valid() will
+// return false). The iterator can be positioned via a call to SeekGE,
+// SeekLT, First or Last.
+func (es *EventuallyFileOnlySnapshot) NewIter(o *IterOptions) (*Iterator, error) {
+	return es.NewIterWithContext(context.Background(), o)
+}
+
+// NewIterWithContext is like NewIter, and additionally accepts a context for
+// tracing.
+func (es *EventuallyFileOnlySnapshot) NewIterWithContext(
+	ctx context.Context, o *IterOptions,
+) (*Iterator, error) {
+	select {
+	case <-es.closed:
+		panic(ErrClosed)
+	default:
+	}
+
+	es.mu.Lock()
+	defer es.mu.Unlock()
+	if es.mu.vers != nil {
+		sOpts := snapshotIterOpts{seqNum: es.seqNum, vers: es.mu.vers}
+		return es.db.newIter(ctx, nil /* batch */, sOpts, o), nil
+	}
+
+	if es.excised.Load() {
+		return nil, ErrSnapshotExcised
+	}
+	sOpts := snapshotIterOpts{seqNum: es.seqNum, readState: es.mu.readState}
+	return es.db.newIter(ctx, nil /* batch */, sOpts, o), nil
+}
+
+// ScanInternal scans all internal keys within the specified bounds, truncating
+// any rangedels and rangekeys to those bounds. For use when an external user
+// needs to be aware of all internal keys that make up a key range.
+//
+// See comment on db.ScanInternal for the behaviour that can be expected of
+// point keys deleted by range dels and keys masked by range keys.
+func (es *EventuallyFileOnlySnapshot) ScanInternal(
+	ctx context.Context,
+	lower, upper []byte,
+	visitPointKey func(key *InternalKey, value LazyValue, iterInfo IteratorLevel) error,
+	visitRangeDel func(start, end []byte, seqNum uint64) error,
+	visitRangeKey func(start, end []byte, keys []rangekey.Key) error,
+	visitSharedFile func(sst *SharedSSTMeta) error,
+) error {
+	if es.db == nil {
+		panic(ErrClosed)
+	}
+	if es.excised.Load() {
+		return ErrSnapshotExcised
+	}
+	var sOpts snapshotIterOpts
+	es.mu.Lock()
+	if es.mu.vers != nil {
+		sOpts = snapshotIterOpts{
+			seqNum: es.seqNum,
+			vers:   es.mu.vers,
+		}
+	} else {
+		sOpts = snapshotIterOpts{
+			seqNum:    es.seqNum,
+			readState: es.mu.readState,
+		}
+	}
+	es.mu.Unlock()
+	opts := &scanInternalOptions{
+		IterOptions: IterOptions{
+			KeyTypes:   IterKeyTypePointsAndRanges,
+			LowerBound: lower,
+			UpperBound: upper,
+		},
+		visitPointKey:    visitPointKey,
+		visitRangeDel:    visitRangeDel,
+		visitRangeKey:    visitRangeKey,
+		visitSharedFile:  visitSharedFile,
+		skipSharedLevels: visitSharedFile != nil,
+	}
+	iter := es.db.newInternalIter(sOpts, opts)
+	defer iter.close()
+
+	return scanInternalImpl(ctx, lower, upper, iter, opts)
 }

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -154,9 +154,9 @@ func testSnapshotImpl(t *testing.T, newSnapshot func(d *DB) Reader) {
 				if snapshot == nil {
 					return fmt.Sprintf("unable to find snapshot \"%s\"", name)
 				}
-				iter = snapshot.NewIter(nil)
+				iter, _ = snapshot.NewIter(nil)
 			} else {
-				iter = d.NewIter(nil)
+				iter, _ = d.NewIter(nil)
 			}
 			defer iter.Close()
 
@@ -289,7 +289,7 @@ func TestSnapshotRangeDeletionStress(t *testing.T) {
 			}()
 
 			// Count the keys at this snapshot.
-			iter := snapshots[r].NewIter(nil)
+			iter, _ := snapshots[r].NewIter(nil)
 			var keysFound int
 			for iter.First(); iter.Valid(); iter.Next() {
 				keysFound++

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -45,9 +45,9 @@ func TestSnapshotListToSlice(t *testing.T) {
 	}
 }
 
-func TestSnapshot(t *testing.T) {
+func testSnapshotImpl(t *testing.T, newSnapshot func(d *DB) Reader) {
 	var d *DB
-	var snapshots map[string]*Snapshot
+	var snapshots map[string]Reader
 
 	close := func() {
 		for _, s := range snapshots {
@@ -87,7 +87,7 @@ func TestSnapshot(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			snapshots = make(map[string]*Snapshot)
+			snapshots = make(map[string]Reader)
 
 			for _, line := range strings.Split(td.Input, "\n") {
 				parts := strings.Fields(line)
@@ -115,7 +115,7 @@ func TestSnapshot(t *testing.T) {
 					if len(parts) != 2 {
 						return fmt.Sprintf("%s expects 1 argument", parts[0])
 					}
-					snapshots[parts[1]] = d.NewSnapshot()
+					snapshots[parts[1]] = newSnapshot(d)
 				case "compact":
 					if len(parts) != 2 {
 						return fmt.Sprintf("%s expects 1 argument", parts[0])
@@ -201,6 +201,19 @@ func TestSnapshot(t *testing.T) {
 		default:
 			return fmt.Sprintf("unknown command: %s", td.Cmd)
 		}
+	})
+}
+
+func TestSnapshot(t *testing.T) {
+	testSnapshotImpl(t, func(d *DB) Reader {
+		return d.NewSnapshot()
+	})
+}
+
+func TestEventuallyFileOnlySnapshot(t *testing.T) {
+	testSnapshotImpl(t, func(d *DB) Reader {
+		// NB: all keys in testdata/snapshot fall within the ASCII keyrange a-z.
+		return d.NewEventuallyFileOnlySnapshot([]KeyRange{{Start: []byte("a"), End: []byte("z")}})
 	})
 }
 

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -380,7 +380,7 @@ func TestVirtualReadsWiring(t *testing.T) {
 	require.Equal(t, 2, int(d.Metrics().Levels[6].NumFiles))
 
 	// These reads will go through the table cache.
-	iter := d.NewIter(nil)
+	iter, _ := d.NewIter(nil)
 	expected := []byte{'a', 'f', 'z'}
 	for i, x := 0, iter.First(); x; i, x = i+1, iter.Next() {
 		require.Equal(t, []byte{expected[i]}, iter.Value())

--- a/testdata/concurrent_excise
+++ b/testdata/concurrent_excise
@@ -1,0 +1,176 @@
+
+reset
+----
+
+switch 1
+----
+ok
+
+batch
+set d foo
+set e bar
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+switch 2
+----
+ok
+
+batch
+set c fooz
+set f foobar
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+batch
+set d foobar
+----
+
+flush
+----
+
+lsm
+----
+0.0:
+  000007:[d#12,SET-d#12,SET]
+6:
+  000005:[c#10,SET-f#11,SET]
+
+compact a-z block=c1
+----
+spun off in separate goroutine
+
+iter
+first
+next
+next
+next
+next
+----
+c: (fooz, .)
+d: (foobar, .)
+f: (foobar, .)
+.
+.
+
+# This excise should cancel the in-flight compaction, causing it to error out
+# below. The eventually file-only snapshot should go through because it's not
+# waiting on any keys in memtables
+
+file-only-snapshot s1
+  c e
+----
+ok
+
+replicate 1 2 b e
+----
+replicated 1 shared SSTs
+
+unblock c1
+----
+ok
+
+wait-for-file-only-snapshot s1
+----
+ok
+
+lsm
+----
+6:
+  000010:[d#13,SET-d#13,SET]
+  000011:[f#11,SET-f#11,SET]
+
+compact a-z
+----
+ok
+
+wait-for-background-error
+----
+pebble: compaction cancelled by a concurrent operation, will retry compaction
+
+iter
+first
+next
+next
+next
+next
+----
+d: (foo, .)
+f: (foobar, .)
+.
+.
+.
+
+batch
+set d fo
+set ee foobar
+set f3 something
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+switch 1
+----
+ok
+
+# The below file-only snapshot should be errored out by the concurrent excise.
+
+batch
+set d something
+----
+
+flush
+----
+
+batch
+set dd memory
+----
+
+file-only-snapshot s2
+ c e
+----
+ok
+
+iter snapshot=s2
+first
+next
+next
+next
+----
+d: (something, .)
+dd: (memory, .)
+e: (bar, .)
+.
+
+replicate 2 1 c dd
+----
+replicated 1 shared SSTs
+
+wait-for-file-only-snapshot s2
+----
+pebble: snapshot excised before conversion to file-only snapshot
+
+iter snapshot=s2
+first
+next
+next
+next
+----
+pebble: snapshot excised before conversion to file-only snapshot

--- a/testdata/ingest_shared
+++ b/testdata/ingest_shared
@@ -735,3 +735,384 @@ bb: (., [bb-f) @8=foo UPDATED)
 e: (baz, [bb-f) @8=foo)
 ff: (notcovered, . UPDATED)
 .
+
+# Tests for Eventually file-only snapshots.
+
+reset
+----
+
+switch 1
+----
+ok
+
+batch
+set a foo
+set b bar
+set c baz
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+switch 2
+----
+ok
+
+batch
+set b foobar
+----
+
+file-only-snapshot s1
+ aa bb
+ e f
+----
+ok
+
+lsm
+----
+
+iter snapshot=s1
+first
+next
+next
+----
+b: (foobar, .)
+.
+.
+
+# The below call should do a flush.
+
+wait-for-file-only-snapshot s1
+----
+ok
+
+lsm
+----
+0.0:
+  000005:[b#10,SET-b#10,SET]
+
+iter snapshot=s1
+first
+next
+next
+----
+b: (foobar, .)
+.
+.
+
+replicate 1 2 a d
+----
+replicated 1 shared SSTs
+
+iter snapshot=s1
+first
+next
+next
+----
+b: (foobar, .)
+.
+.
+
+iter
+first
+next
+next
+next
+----
+a: (foo, .)
+b: (bar, .)
+c: (baz, .)
+.
+
+switch 1
+----
+ok
+
+batch
+del c
+----
+
+# The below excise and wait should succeed as the flush will end up transitioning
+# the file-only snapshot.
+
+lsm
+----
+6:
+  000005:[a#10,SET-c#12,SET]
+
+file-only-snapshot s2
+ a cc
+----
+ok
+
+iter snapshot=s2
+first
+next
+next
+next
+next
+----
+a: (foo, .)
+b: (bar, .)
+.
+.
+.
+
+flush
+----
+
+compact a-z
+----
+ok
+
+replicate 2 1 a d
+----
+replicated 1 shared SSTs
+
+wait-for-file-only-snapshot s2
+----
+ok
+
+iter snapshot=s2
+first
+next
+next
+next
+----
+a: (foo, .)
+b: (bar, .)
+.
+.
+
+iter snapshot=s2
+first
+clone
+first
+next
+next
+next
+----
+a: (foo, .)
+.
+a: (foo, .)
+b: (bar, .)
+.
+.
+
+iter
+first
+next
+next
+next
+next
+----
+a: (foo, .)
+b: (bar, .)
+c: (baz, .)
+.
+.
+
+batch
+set d foo
+set e bar
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+switch 2
+----
+ok
+
+flush
+----
+
+batch
+set f foobar
+----
+
+# The below file-only snapshot is the more challenging case of a partial overlap
+# between an excise and a file-only snapshot. In this case the EFOS transition
+# blocks on the memtable but the excise proceeds through, causing the EFOS'
+# WaitForFileOnlySnapshot() call to error out. Snapshot consistency is still
+# maintained through the readState.
+
+file-only-snapshot s3
+ c g
+----
+ok
+
+iter snapshot=s3
+first
+next
+next
+next
+next
+----
+a: (foo, .)
+b: (bar, .)
+c: (baz, .)
+f: (foobar, .)
+.
+
+iter snapshot=s3
+first
+next
+clone
+first
+next
+next
+next
+----
+a: (foo, .)
+b: (bar, .)
+.
+a: (foo, .)
+b: (bar, .)
+c: (baz, .)
+f: (foobar, .)
+
+
+replicate 1 2 b e
+----
+replicated 2 shared SSTs
+
+wait-for-file-only-snapshot s3
+----
+pebble: snapshot excised before conversion to file-only snapshot
+
+iter snapshot=s3
+first
+next
+next
+next
+next
+----
+a: (foo, .)
+b: (bar, .)
+c: (baz, .)
+f: (foobar, .)
+.
+
+iter snapshot=s3
+first
+next
+clone
+first
+next
+next
+next
+----
+a: (foo, .)
+b: (bar, .)
+.
+a: (foo, .)
+b: (bar, .)
+c: (baz, .)
+f: (foobar, .)
+
+iter
+first
+next
+next
+next
+next
+----
+a: (foo, .)
+b: (bar, .)
+c: (baz, .)
+d: (foo, .)
+f: (foobar, .)
+
+# The below example tests for a file-only snapshot that overlaps completely
+# with an excise right after it. The wait succeeds and snapshot consistency is
+# maintained.
+
+reset
+----
+
+switch 1
+----
+ok
+
+batch
+set a foo
+set b bar
+set c baz
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+switch 2
+----
+ok
+
+batch
+set d foobar
+----
+
+file-only-snapshot s4
+ b e
+----
+ok
+
+iter snapshot=s4
+first
+next
+next
+----
+d: (foobar, .)
+.
+.
+
+replicate 1 2 b e
+----
+replicated 1 shared SSTs
+
+wait-for-file-only-snapshot s4
+----
+ok
+
+iter snapshot=s4
+first
+next
+next
+----
+d: (foobar, .)
+.
+.
+
+compact a-z
+----
+ok
+
+iter snapshot=s4
+first
+next
+next
+----
+d: (foobar, .)
+.
+.
+
+iter
+first
+next
+next
+----
+b: (bar, .)
+c: (baz, .)
+.

--- a/testdata/ingest_shared
+++ b/testdata/ingest_shared
@@ -942,8 +942,8 @@ set f foobar
 # The below file-only snapshot is the more challenging case of a partial overlap
 # between an excise and a file-only snapshot. In this case the EFOS transition
 # blocks on the memtable but the excise proceeds through, causing the EFOS'
-# WaitForFileOnlySnapshot() call to error out. Snapshot consistency is still
-# maintained through the readState.
+# WaitForFileOnlySnapshot() call to error out. Opening iterators also returns
+# the same errors.
 
 file-only-snapshot s3
  c g
@@ -996,11 +996,7 @@ next
 next
 next
 ----
-a: (foo, .)
-b: (bar, .)
-c: (baz, .)
-f: (foobar, .)
-.
+pebble: snapshot excised before conversion to file-only snapshot
 
 iter snapshot=s3
 first
@@ -1011,13 +1007,7 @@ next
 next
 next
 ----
-a: (foo, .)
-b: (bar, .)
-.
-a: (foo, .)
-b: (bar, .)
-c: (baz, .)
-f: (foobar, .)
+pebble: snapshot excised before conversion to file-only snapshot
 
 iter
 first

--- a/testdata/scan_internal
+++ b/testdata/scan_internal
@@ -17,6 +17,20 @@ set e foo
 ----
 committed 2 keys
 
+file-only-snapshot efos1
+  b g
+----
+ok
+
+# EFOS work with scan-internal.
+
+scan-internal file-only-snapshot=efos1
+----
+a-c:{(#10,RANGEKEYSET,@5,boop)}
+b#12,1 (d)
+c-e:{(#11,RANGEKEYSET,@5,beep)}
+e#13,1 (foo)
+
 flush
 ----
 
@@ -51,12 +65,23 @@ b-d#14,RANGEDEL
 c-e:{(#11,RANGEKEYSET,@5,beep)}
 e#13,1 (foo)
 
-# Snapshots work with internal iters.
+# Snapshots work with scan internal.
 
 scan-internal snapshot=foo
 ----
 a-c:{(#10,RANGEKEYSET,@5,boop)}
 c-e:{(#11,RANGEKEYSET,@5,beep)}
+
+wait-for-file-only-snapshot efos1
+----
+ok
+
+scan-internal file-only-snapshot=efos1
+----
+a-c:{(#10,RANGEKEYSET,@5,boop)}
+b#12,1 (d)
+c-e:{(#11,RANGEKEYSET,@5,beep)}
+e#13,1 (foo)
 
 # Force keys newer than the snapshot into a lower level, then try skip-shared
 # iteration through it. This should return an error as it would expose keys

--- a/tool/db.go
+++ b/tool/db.go
@@ -413,7 +413,7 @@ func (d *dbT) runScan(cmd *cobra.Command, args []string) {
 	fmtValues := d.fmtValue.spec != "null"
 	var count int64
 
-	iter := db.NewIter(&pebble.IterOptions{
+	iter, _ := db.NewIter(&pebble.IterOptions{
 		UpperBound: d.end,
 	})
 	for valid := iter.SeekGE(d.start); valid; valid = iter.Next() {


### PR DESCRIPTION
This change adds a new type of snapshots, EventuallyFileOnlySnapshots, that only stay in the snapshot list until all memtables with keys less than the snapshot have been flushed. After that, these file-only snapshots switch to holding a Version ref (which is akin to holding a readState ref minus the memtables). This allows for a good balance between the write-amp implications of staying in the snapshot list for too long, and the space-amp concerns with holding onto obsolete files.

Fixes #2740.