### PR TITLE
pebble: expose the secondary cache size as an option

### DIFF
--- a/options.go
+++ b/options.go
@@ -1214,6 +1214,7 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  wal_bytes_per_sync=%d\n", o.WALBytesPerSync)
 	fmt.Fprintf(&buf, "  max_writer_concurrency=%d\n", o.Experimental.MaxWriterConcurrency)
 	fmt.Fprintf(&buf, "  force_writer_parallelism=%t\n", o.Experimental.ForceWriterParallelism)
+	fmt.Fprintf(&buf, "  secondary_cache_size=%d\n", o.Experimental.SecondaryCacheSize)
 
 	// Private options.
 	//
@@ -1483,6 +1484,8 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				o.Experimental.MaxWriterConcurrency, err = strconv.Atoi(value)
 			case "force_writer_parallelism":
 				o.Experimental.ForceWriterParallelism, err = strconv.ParseBool(value)
+			case "secondary_cache_size":
+				o.Experimental.SecondaryCacheSize, err = strconv.ParseInt(value, 10, 64)
 			default:
 				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key, value) {
 					return nil

--- a/options_test.go
+++ b/options_test.go
@@ -105,6 +105,7 @@ func TestOptionsString(t *testing.T) {
   wal_bytes_per_sync=0
   max_writer_concurrency=0
   force_writer_parallelism=false
+  secondary_cache_size=0
 
 [Level "0"]
   block_restart_interval=16
@@ -238,6 +239,7 @@ func TestOptionsParse(t *testing.T) {
 			opts.Experimental.TableCacheShards = 500
 			opts.Experimental.MaxWriterConcurrency = 1
 			opts.Experimental.ForceWriterParallelism = true
+			opts.Experimental.SecondaryCacheSize = 1024
 			opts.EnsureDefaults()
 			str := opts.String()
 


### PR DESCRIPTION
**pebble: expose the secondary cache size as an option**

This commit exposes the secondary cache size as part of pebble.Options. This enables controlling the setting via the CRDB --store flag.