### PR TITLE
github: code coverage workflows

### DIFF
--- a/.github/workflows/code-cover-gen.yaml
+++ b/.github/workflows/code-cover-gen.yaml
@@ -1,0 +1,65 @@
+name: PR code coverage (generate)
+
+on:
+  # This workflow does not have access to secrets because it runs on top of
+  # potentially unsafe changes.
+  pull_request:
+    types: [ opened, reopened, synchronize ]
+    branches: [ master ]
+
+jobs:
+  # The results of this job are uploaded as artifacts. A separate job will
+  # download the artifacts and upload them to a GCS bucket.
+  code-cover-gen:
+    runs-on: ubuntu-latest
+    env:
+      PR: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # By default, checkout merges the PR into the current master.
+          # Instead, we want to check out the PR as-is.
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Fetch all branches and history (we'll need the origin/master ref and
+          # the base commit).
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.20"
+
+      - name: Generate "after" coverage
+        shell: bash
+        run: |
+          set -e
+          mkdir -p artifacts
+          make testcoverage COVER_PROFILE=artifacts/cover-after.out
+          go run github.com/cockroachdb/code-cov-utils/gocover2json@latest \
+            --trim-prefix github.com/cockroachdb/pebble \
+            artifacts/cover-after.out artifacts/cover-${PR}-${HEAD_SHA}.json
+
+      # Running the "before" coverage for each PR (rather than in a job that
+      # runs on push) is a little odd, but it allows restricting the packages on
+      # a per-PR basis (if it becomes necessary in the future).
+      - name: Generate "before" coverage
+        shell: bash
+        run: |
+          set -e
+          # Note that github.event.pull_request.base.sha is not what we want -
+          # it is the current master tip, not the commit this PR is actually
+          # based on.
+          BASE_SHA=$(git merge-base origin/master ${HEAD_SHA})
+          git checkout -f ${BASE_SHA}
+          make testcoverage COVER_PROFILE=artifacts/cover-before.out
+          SHA=$(git rev-parse HEAD)
+          go run github.com/cockroachdb/code-cov-utils/gocover2json@latest \
+            --trim-prefix github.com/cockroachdb/pebble \
+            artifacts/cover-before.out artifacts/cover-${PR}-${BASE_SHA}.json
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: cover
+          path: artifacts/cover-*.json

--- a/.github/workflows/code-cover-publish.yaml
+++ b/.github/workflows/code-cover-publish.yaml
@@ -1,0 +1,55 @@
+name: PR code coverage (publish)
+
+on:
+  workflow_run:
+    workflows: [ "PR code coverage (generate)" ]
+    types: [ "completed" ]
+
+
+jobs:
+  # This job downloads the artifacts genearted by the code-cover-gen job and
+  # uploads them to a GCS bucket, from where Reviewable can access them.
+  code-cover-publish:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "cover"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/cover.zip', Buffer.from(download.data));
+
+      - run: |
+          mkdir -p cover
+          unzip cover.zip -d cover
+
+      - name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.CODECOVER_SERVICE_ACCOUNT_KEY }}'
+
+      - name: 'Upload to GCS'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: 'cover'
+          glob: '**/cover-*.json'
+          parent: false
+          destination: 'crl-codecover-public/pr-pebble/'
+          process_gcloudignore: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Github action artifacts.
+artifacts
 # Profiling artifacts.
 cpu.*.prof
 heap.prof


### PR DESCRIPTION
This change adds two github action workflows which run on each PR: one
generates unit test code coverage data, and one publishes the coverage
data to a GCS bucket (from where Reviewable can use it).

Two workflows are required for security (the first workflow runs
potentially malicious code from a fork); for more details, see
https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
