### PR TITLE
ci: use any 1.20 go version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: "1.20.1"
+        go-version: "1.20"
 
     - run: make test generate
 
@@ -32,9 +32,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: "1.20.1"
+        go-version: "1.20"
 
     - run: make crossversion-meta
 
@@ -45,9 +45,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: "1.20.1"
+        go-version: "1.20"
 
     - run: make testrace TAGS=
 
@@ -58,9 +58,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: "1.20.1"
+        go-version: "1.20"
 
     - run: make test TAGS=
 
@@ -71,9 +71,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: "1.20.1"
+        go-version: "1.20"
 
     - run: CGO_ENABLED=0 make test TAGS=
 
@@ -84,9 +84,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: "1.20.1"
+        go-version: "1.20"
 
     - run: make test
 
@@ -97,9 +97,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: "1.20.1"
+        go-version: "1.20"
 
     - run: go test -v ./...
 
@@ -110,9 +110,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: "1.20.1"
+        go-version: "1.20"
 
     - name: FreeBSD build
       env:
@@ -136,9 +136,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: "1.20.1"
+        go-version: "1.20"
 
     - name: mod-tidy-check
       run: make mod-tidy-check


### PR DESCRIPTION
The CI job prescribes go version 1.20.1. The github action runners
cache version 1.20.6 and the setup is much faster (instant) for that
version. So we require 1.20 instead and let github choose the point
version.

We also use the v4 of setup-go which caches dependencies by default.