### PR TITLE
crl-release-23.1: internal/cache: mark panic messages as redaction-safe

### DIFF
--- a/internal/cache/refcnt_normal.go
+++ b/internal/cache/refcnt_normal.go
@@ -10,6 +10,8 @@ package cache
 import (
 	"fmt"
 	"sync/atomic"
+
+	"github.com/cockroachdb/redact"
 )
 
 // refcnt provides an atomic reference count. This version is used when the
@@ -31,14 +33,14 @@ func (v *refcnt) refs() int32 {
 func (v *refcnt) acquire() {
 	switch v := v.val.Add(1); {
 	case v <= 1:
-		panic(fmt.Sprintf("pebble: inconsistent reference count: %d", v))
+		panic(redact.Safe(fmt.Sprintf("pebble: inconsistent reference count: %d", v)))
 	}
 }
 
 func (v *refcnt) release() bool {
 	switch v := v.val.Add(-1); {
 	case v < 0:
-		panic(fmt.Sprintf("pebble: inconsistent reference count: %d", v))
+		panic(redact.Safe(fmt.Sprintf("pebble: inconsistent reference count: %d", v)))
 	case v == 0:
 		return true
 	default:


### PR DESCRIPTION
Backport of #2797.

----

Informs cockroachdb/cockroach#84971.