### PR TITLE
db: simplify ScanInternal()

### DIFF
--- a/ingest_test.go
+++ b/ingest_test.go
@@ -932,8 +932,6 @@ func TestIngestShared(t *testing.T) {
 					sharedSSTs = append(sharedSSTs, *sst)
 					return nil
 				},
-				false,
-				nil, /* rateLimitFunc */
 			)
 			require.NoError(t, err)
 			require.NoError(t, w.Close())

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -208,8 +208,6 @@ func TestScanInternal(t *testing.T) {
 			visitRangeDel func(start, end []byte, seqNum uint64) error,
 			visitRangeKey func(start, end []byte, keys []rangekey.Key) error,
 			visitSharedFile func(sst *SharedSSTMeta) error,
-			includeObsoleteKeys bool,
-			rateLimitFunc func(key *InternalKey, val LazyValue),
 		) error
 	}
 	batches := map[string]*Batch{}
@@ -430,8 +428,6 @@ func TestScanInternal(t *testing.T) {
 					return nil
 				},
 				fileVisitor,
-				false,
-				nil, /* rateLimitFunc */
 			)
 			if err != nil {
 				return err.Error()

--- a/snapshot.go
+++ b/snapshot.go
@@ -70,20 +70,16 @@ func (s *Snapshot) ScanInternal(
 	visitRangeDel func(start, end []byte, seqNum uint64) error,
 	visitRangeKey func(start, end []byte, keys []rangekey.Key) error,
 	visitSharedFile func(sst *SharedSSTMeta) error,
-	includeObsoleteKeys bool,
-	rateLimitFunc func(key *InternalKey, value LazyValue),
 ) error {
 	if s.db == nil {
 		panic(ErrClosed)
 	}
 	scanInternalOpts := &scanInternalOptions{
-		visitPointKey:       visitPointKey,
-		visitRangeDel:       visitRangeDel,
-		visitRangeKey:       visitRangeKey,
-		visitSharedFile:     visitSharedFile,
-		skipSharedLevels:    visitSharedFile != nil,
-		includeObsoleteKeys: includeObsoleteKeys,
-		rateLimitFunc:       rateLimitFunc,
+		visitPointKey:    visitPointKey,
+		visitRangeDel:    visitRangeDel,
+		visitRangeKey:    visitRangeKey,
+		visitSharedFile:  visitSharedFile,
+		skipSharedLevels: visitSharedFile != nil,
 		IterOptions: IterOptions{
 			KeyTypes:   IterKeyTypePointsAndRanges,
 			LowerBound: lower,


### PR DESCRIPTION
The use-cases of ScanInternal and ScanStatistics have deviated a fair bit. This change has ScanStatistics call scanInternalImpl directly, and makes ScanInternal's function signature match the comment on it again around inclusion of obsolete key.

Reduces merge conflicts in in-flight PRs.