### PR TITLE
scripts: add code coverage script

### DIFF
--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -5,14 +5,11 @@
 package metamorphic
 
 import (
-	"flag"
-	"math"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 
-	"github.com/cockroachdb/pebble/internal/randvar"
+	"github.com/cockroachdb/pebble/internal/metamorphic/metaflags"
 	"github.com/cockroachdb/pebble/metamorphic"
 )
 
@@ -24,68 +21,15 @@ import (
 //   a variable length suffix).
 // - Add support for Writer.LogData
 
-var (
-	dir = flag.String("dir", "_meta",
-		"the directory storing test state")
-	fs = flag.String("fs", "rand",
-		`force the tests to use either memory or disk-backed filesystems (valid: "mem", "disk", "rand")`)
-	// TODO: default error rate to a non-zero value. Currently, retrying is
-	// non-deterministic because of the Ierator.*WithLimit() methods since
-	// they may say that the Iterator is not valid, but be positioned at a
-	// certain key that can be returned in the future if the limit is changed.
-	// Since that key is hidden from clients of Iterator, the retryableIter
-	// using SeekGE will not necessarily position the Iterator that saw an
-	// injected error at the same place as an Iterator that did not see that
-	// error.
-	errorRate = flag.Float64("error-rate", 0.0,
-		"rate of errors injected into filesystem operations (0 ≤ r < 1)")
-	failRE = flag.String("fail", "",
-		"fail the test if the supplied regular expression matches the output")
-	traceFile = flag.String("trace-file", "",
-		"write an execution trace to `<run-dir>/file`")
-	keep = flag.Bool("keep", false,
-		"keep the DB directory even on successful runs")
-	seed = flag.Uint64("seed", 0,
-		"a pseudorandom number generator seed")
-	ops        = randvar.NewFlag("uniform:5000-10000")
-	maxThreads = flag.Int("max-threads", math.MaxInt,
-		"limit execution of a single run to the provided number of threads; must be ≥ 1")
-	runDir = flag.String("run-dir", "",
-		"the specific configuration to (re-)run (used for post-mortem debugging)")
-	compare = flag.String("compare", "",
-		`comma separated list of options files to compare. The result of each run is compared with
-the result of the run from the first options file in the list. Example, -compare
-random-003,standard-000. The dir flag should have the directory containing these directories.
-Example, -dir _meta/200610-203012.077`)
+var runOnceFlags, runFlags = metaflags.InitAllFlags()
 
-	// The following options may be used for split-version metamorphic testing.
-	// To perform split-version testing, the client runs the metamorphic tests
-	// on an earlier Pebble SHA passing the `--keep` flag. The client then
-	// switches to the later Pebble SHA, setting the below options to point to
-	// the `ops` file and one of the previous run's data directories.
-	previousOps = flag.String("previous-ops", "",
-		"path to an ops file, used to prepopulate the set of keys operations draw from")
-	initialStatePath = flag.String("initial-state", "",
-		"path to a database's data directory, used to prepopulate the test run's databases")
-	initialStateDesc = flag.String("initial-state-desc", "",
-		`a human-readable description of the initial database state.
-		If set this parameter is written to the OPTIONS to aid in
-		debugging. It's intended to describe the lineage of a
-		database's state, including sufficient information for
-		reproduction (eg, SHA, prng seed, etc).`)
-)
-
-func init() {
-	flag.Var(ops, "ops", "")
-}
-
-// TestMeta generates a random set of operations to run, then runs the test
-// with different options. See standardOptions() for the set of options that
-// are always run, and randomOptions() for the randomly generated options. The
-// number of operations to generate is determined by the `--ops` flag. If a
-// failure occurs, the output is kept in `_meta/<test>`, though note that a
-// subsequent invocation will overwrite that output. A test can be re-run by
-// using the `--run-dir` flag. For example:
+// TestMeta generates a random set of operations to run, then runs multiple
+// instances of the test with varying options. See standardOptions() for the set
+// of options that are always run, and randomOptions() for the randomly
+// generated options. The number of operations to generate is determined by the
+// `--ops` flag. If a failure occurs, the output is kept in `_meta/<test>`,
+// though note that a subsequent invocation will overwrite that output. A test
+// can be re-run by using the `--run-dir` flag. For example:
 //
 //	go test -v -run TestMeta --run-dir _meta/standard-017
 //
@@ -102,58 +46,27 @@ func init() {
 // and options. This must be run on the same commit SHA as the original
 // failure, otherwise changes to the metamorphic tests may cause the generated
 // operations and options to differ.
+//
+// Each instance of the test is run in a different process, by executing the
+// same binary (i.e. os.Args[0]) and passing `--run_dir`; the "inner" binary can
+// be customized via the --inner-binary flag (used for code coverage
+// instrumentation).
 func TestMeta(t *testing.T) {
-	opts := []metamorphic.RunOption{
-		metamorphic.Seed(*seed),
-		metamorphic.OpCount(ops.Static),
-		metamorphic.MaxThreads(*maxThreads),
-	}
-	onceOpts := []metamorphic.RunOnceOption{
-		metamorphic.MaxThreads(*maxThreads),
-	}
+	switch {
+	case runOnceFlags.Compare != "":
+		runDirs := strings.Split(runOnceFlags.Compare, ",")
+		onceOpts := runOnceFlags.MakeRunOnceOptions()
+		metamorphic.Compare(t, runOnceFlags.Dir, runOnceFlags.Seed, runDirs, onceOpts...)
 
-	if *keep {
-		opts = append(opts, metamorphic.KeepData{})
-		onceOpts = append(onceOpts, metamorphic.KeepData{})
-	}
-	if *failRE != "" {
-		opts = append(opts, metamorphic.FailOnMatch{Regexp: regexp.MustCompile(*failRE)})
-		onceOpts = append(onceOpts, metamorphic.FailOnMatch{Regexp: regexp.MustCompile(*failRE)})
-	}
-	if *errorRate > 0 {
-		opts = append(opts, metamorphic.InjectErrorsRate(*errorRate))
-		onceOpts = append(onceOpts, metamorphic.InjectErrorsRate(*errorRate))
-	}
-	if *traceFile != "" {
-		opts = append(opts, metamorphic.RuntimeTrace(*traceFile))
-	}
-	if *previousOps != "" {
-		opts = append(opts, metamorphic.ExtendPreviousRun(*previousOps, *initialStatePath, *initialStateDesc))
-	}
-	// If the filesystem type was forced, all tests will use that value.
-	switch *fs {
-	case "", "rand", "default":
-		// No-op. Use the generated value for the filesystem.
-	case "disk":
-		opts = append(opts, metamorphic.UseDisk)
-	case "mem":
-		opts = append(opts, metamorphic.UseInMemory)
-	default:
-		t.Fatalf("unknown forced filesystem type: %q", *fs)
-	}
-
-	if *compare != "" {
-		runDirs := strings.Split(*compare, ",")
-		metamorphic.Compare(t, *dir, *seed, runDirs, onceOpts...)
-		return
-	}
-
-	if *runDir != "" {
+	case runOnceFlags.RunDir != "":
 		// The --run-dir flag is specified either in the child process (see
 		// runOptions() below) or the user specified it manually in order to re-run
 		// a test.
-		metamorphic.RunOnce(t, *runDir, *seed, filepath.Join(*runDir, "history"), onceOpts...)
-		return
+		onceOpts := runOnceFlags.MakeRunOnceOptions()
+		metamorphic.RunOnce(t, runOnceFlags.RunDir, runOnceFlags.Seed, filepath.Join(runOnceFlags.RunDir, "history"), onceOpts...)
+
+	default:
+		opts := runFlags.MakeRunOptions()
+		metamorphic.RunAndCompare(t, runFlags.Dir, opts...)
 	}
-	metamorphic.RunAndCompare(t, *dir, opts...)
 }

--- a/internal/metamorphic/metaflags/meta_flags.go
+++ b/internal/metamorphic/metaflags/meta_flags.go
@@ -1,0 +1,223 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// Package metaflags defines command-line flags for the metamorphic tests and
+// provides functionality to construct the respective
+// metamorphic.RunOptions/RunOnceOptions.
+package metaflags
+
+import (
+	"flag"
+	"fmt"
+	"math"
+	"regexp"
+
+	"github.com/cockroachdb/pebble/internal/randvar"
+	"github.com/cockroachdb/pebble/metamorphic"
+)
+
+// CommonFlags contains flags that apply to both metamorphic.Run and
+// metamorphic.RunOnce/Compare.
+type CommonFlags struct {
+	// Dir is the directory storing test state. See "dir" flag below.
+	Dir string
+	// Seed for generation of random operations. See "seed" flag below.
+	Seed uint64
+	// ErrorRate is the rate of injected filesystem errors. See "error-rate" flag
+	// below.
+	ErrorRate float64
+	// FailRE causes the test to fail if the output matches this regex. See "fail"
+	// flag below.
+	FailRE string
+	// Keep determines if the DB directory is kept on successful runs. See "keep"
+	// flag below.
+	Keep bool
+	// MaxThreads used by a single run. See "max-threads" flag below.
+	MaxThreads int
+}
+
+func initCommonFlags() *CommonFlags {
+	c := &CommonFlags{}
+	flag.StringVar(&c.Dir, "dir", "_meta",
+		"the directory storing test state")
+
+	flag.Uint64Var(&c.Seed, "seed", 0,
+		"a pseudorandom number generator seed")
+
+	// TODO: default error rate to a non-zero value. Currently, retrying is
+	// non-deterministic because of the Ierator.*WithLimit() methods since
+	// they may say that the Iterator is not valid, but be positioned at a
+	// certain key that can be returned in the future if the limit is changed.
+	// Since that key is hidden from clients of Iterator, the retryableIter
+	// using SeekGE will not necessarily position the Iterator that saw an
+	// injected error at the same place as an Iterator that did not see that
+	// error.
+	flag.Float64Var(&c.ErrorRate, "error-rate", 0.0,
+		"rate of errors injected into filesystem operations (0 ≤ r < 1)")
+
+	flag.StringVar(&c.FailRE, "fail", "",
+		"fail the test if the supplied regular expression matches the output")
+
+	flag.BoolVar(&c.Keep, "keep", false,
+		"keep the DB directory even on successful runs")
+
+	flag.IntVar(&c.MaxThreads, "max-threads", math.MaxInt,
+		"limit execution of a single run to the provided number of threads; must be ≥ 1")
+
+	return c
+}
+
+// RunOnceFlags contains flags that apply only to metamorphic.RunOnce/Compare.
+type RunOnceFlags struct {
+	*CommonFlags
+	// RunDir applies to metamorphic.RunOnce and contains the specific
+	// configuration of the run. See "run-dir" flag below.
+	RunDir string
+	// Compare applies to metamorphic.Compare. See "compare" flag below.
+	Compare string
+}
+
+func initRunOnceFlags(c *CommonFlags) *RunOnceFlags {
+	ro := &RunOnceFlags{CommonFlags: c}
+	flag.StringVar(&ro.RunDir, "run-dir", "",
+		"the specific configuration to (re-)run (used for post-mortem debugging)")
+
+	flag.StringVar(&ro.Compare, "compare", "",
+		`comma separated list of options files to compare. The result of each run is compared with
+the result of the run from the first options file in the list. Example, -compare
+random-003,standard-000. The dir flag should have the directory containing these directories.
+Example, -dir _meta/200610-203012.077`)
+	return ro
+}
+
+// RunFlags contains flags that apply only to metamorphic.Run.
+type RunFlags struct {
+	*CommonFlags
+	// FS controls the type of filesystems to use. See "fs" flag below.
+	FS string
+	// TraceFile for execution tracing. See "trace-file" flag below.
+	TraceFile string
+	// Ops describes how the total number of operations is generated. See "ops" flags below.
+	Ops randvar.Flag
+	// InnerBinary is the binary to invoke for a single run. See "inner-binary"
+	// flag below.
+	InnerBinary string
+	// PreviousOps is the path to the ops file of a previous run. See the
+	// "previous-ops" flag below.
+	PreviousOps string
+	// InitialStatePath is the path to a database data directory from a previous
+	// run. See the "initial-state" flag below.
+	InitialStatePath string
+	// InitialStateDesc is a human-readable description of the initial database
+	// state. See "initial-state-desc" flag below.
+	InitialStateDesc string
+}
+
+func initRunFlags(c *CommonFlags) *RunFlags {
+	r := &RunFlags{CommonFlags: c}
+	flag.StringVar(&r.FS, "fs", "rand",
+		`force the tests to use either memory or disk-backed filesystems (valid: "mem", "disk", "rand")`)
+
+	flag.StringVar(&r.TraceFile, "trace-file", "",
+		"write an execution trace to `<run-dir>/file`")
+
+	if err := r.Ops.Set("uniform:5000-10000"); err != nil {
+		panic(err)
+	}
+	flag.Var(&r.Ops, "ops", "uniform:5000-10000")
+
+	flag.StringVar(&r.InnerBinary, "inner-binary", "",
+		`binary to run for each instance of the test (this same binary by default); cannot be used
+with --run-dir or --compare`)
+
+	// The following options may be used for split-version metamorphic testing.
+	// To perform split-version testing, the client runs the metamorphic tests
+	// on an earlier Pebble SHA passing the `--keep` flag. The client then
+	// switches to the later Pebble SHA, setting the below options to point to
+	// the `ops` file and one of the previous run's data directories.
+
+	flag.StringVar(&r.PreviousOps, "previous-ops", "",
+		"path to an ops file, used to prepopulate the set of keys operations draw from")
+
+	flag.StringVar(&r.InitialStatePath, "initial-state", "",
+		"path to a database's data directory, used to prepopulate the test run's databases")
+
+	flag.StringVar(&r.InitialStateDesc, "initial-state-desc", "",
+		`a human-readable description of the initial database state.
+		If set this parameter is written to the OPTIONS to aid in
+		debugging. It's intended to describe the lineage of a
+		database's state, including sufficient information for
+		reproduction (eg, SHA, prng seed, etc).`)
+	return r
+}
+
+// InitRunOnceFlags initializes the flags that are used for a single run of the
+// metamorphic test.
+func InitRunOnceFlags() *RunOnceFlags {
+	return initRunOnceFlags(initCommonFlags())
+}
+
+// InitAllFlags initializes all metamorphic test flags: those used for a
+// single run, and those used for a "top level" run.
+func InitAllFlags() (*RunOnceFlags, *RunFlags) {
+	c := initCommonFlags()
+	return initRunOnceFlags(c), initRunFlags(c)
+}
+
+// MakeRunOnceOptions constructs RunOnceOptions based on the flags.
+func (ro *RunOnceFlags) MakeRunOnceOptions() []metamorphic.RunOnceOption {
+	onceOpts := []metamorphic.RunOnceOption{
+		metamorphic.MaxThreads(ro.MaxThreads),
+	}
+	if ro.Keep {
+		onceOpts = append(onceOpts, metamorphic.KeepData{})
+	}
+	if ro.FailRE != "" {
+		onceOpts = append(onceOpts, metamorphic.FailOnMatch{Regexp: regexp.MustCompile(ro.FailRE)})
+	}
+	if ro.ErrorRate > 0 {
+		onceOpts = append(onceOpts, metamorphic.InjectErrorsRate(ro.ErrorRate))
+	}
+	return onceOpts
+}
+
+// MakeRunOptions constructs RunOptions based on the flags.
+func (r *RunFlags) MakeRunOptions() []metamorphic.RunOption {
+	opts := []metamorphic.RunOption{
+		metamorphic.Seed(r.Seed),
+		metamorphic.OpCount(r.Ops.Static),
+		metamorphic.MaxThreads(r.MaxThreads),
+	}
+	if r.Keep {
+		opts = append(opts, metamorphic.KeepData{})
+	}
+	if r.FailRE != "" {
+		opts = append(opts, metamorphic.FailOnMatch{Regexp: regexp.MustCompile(r.FailRE)})
+	}
+	if r.ErrorRate > 0 {
+		opts = append(opts, metamorphic.InjectErrorsRate(r.ErrorRate))
+	}
+	if r.TraceFile != "" {
+		opts = append(opts, metamorphic.RuntimeTrace(r.TraceFile))
+	}
+	if r.PreviousOps != "" {
+		opts = append(opts, metamorphic.ExtendPreviousRun(r.PreviousOps, r.InitialStatePath, r.InitialStateDesc))
+	}
+
+	// If the filesystem type was forced, all tests will use that value.
+	switch r.FS {
+	case "", "rand", "default":
+		// No-op. Use the generated value for the filesystem.
+	case "disk":
+		opts = append(opts, metamorphic.UseDisk)
+	case "mem":
+		opts = append(opts, metamorphic.UseInMemory)
+	default:
+		panic(fmt.Sprintf("unknown forced filesystem type: %q", r.FS))
+	}
+	if r.InnerBinary != "" {
+		opts = append(opts, metamorphic.InnerBinary(r.InnerBinary))
+	}
+	return opts
+}

--- a/internal/metamorphic/metarunner/main.go
+++ b/internal/metamorphic/metarunner/main.go
@@ -1,0 +1,66 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// metarunner is a utility which runs metamorphic.RunOnce or Compare. It is
+// equivalent to executing `internal/metamorphic.TestMeta` with `--run-dir` or
+// `--compare`. It is used for code coverage instrumentation.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cockroachdb/pebble/internal/metamorphic/metaflags"
+	"github.com/cockroachdb/pebble/metamorphic"
+)
+
+var runOnceFlags = metaflags.InitRunOnceFlags()
+var _ = flag.String("test.run", "", `ignored; used for compatibility with TestMeta`)
+
+func main() {
+	flag.Parse()
+	onceOpts := runOnceFlags.MakeRunOnceOptions()
+	t := &mockT{}
+	switch {
+	case runOnceFlags.Compare != "":
+		runDirs := strings.Split(runOnceFlags.Compare, ",")
+		metamorphic.Compare(t, runOnceFlags.Dir, runOnceFlags.Seed, runDirs, onceOpts...)
+
+	case runOnceFlags.RunDir != "":
+		// The --run-dir flag is specified either in the child process (see
+		// runOptions() below) or the user specified it manually in order to re-run
+		// a test.
+		metamorphic.RunOnce(t, runOnceFlags.RunDir, runOnceFlags.Seed, filepath.Join(runOnceFlags.RunDir, "history"), onceOpts...)
+
+	default:
+		t.Errorf("--compare or --run-dir must be used")
+	}
+
+	if t.Failed() {
+		// Make sure we return an error code.
+		t.FailNow()
+	}
+}
+
+type mockT struct {
+	failed bool
+}
+
+var _ metamorphic.TestingT = (*mockT)(nil)
+
+func (t *mockT) Errorf(format string, args ...interface{}) {
+	t.failed = true
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+}
+
+func (t *mockT) FailNow() {
+	os.Exit(2)
+}
+
+func (t *mockT) Failed() bool {
+	return t.failed
+}

--- a/scripts/code-coverage.sh
+++ b/scripts/code-coverage.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+mkdir -p artifacts
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+test_failed=0
+# The coverpkg argument ensures that coverage is not restricted to the tested
+# package; so this will get us overall coverage for all tests.
+go test ./... -coverprofile=artifacts/profile-tests.gocov -coverpkg=./... || test_failed=1
+
+# The metamorphic test executes itself for each run; we don't get coverage for
+# the inner run. To fix this, we use metarunner as the "inner" binary and we
+# instrument it with coverage (see https://go.dev/testing/coverage/#building).
+go build -o "${tmpdir}/metarunner" -cover ./internal/metamorphic/metarunner
+mkdir -p "${tmpdir}/metacover"
+
+GOCOVERDIR="${tmpdir}/metacover" go test ./internal/metamorphic \
+  -count 50 --inner-binary="${tmpdir}/metarunner" || test_failed=1
+
+go tool covdata textfmt -i "${tmpdir}/metacover" -o artifacts/profile-meta.gocov
+
+# TODO(radu): make the crossversion metamorphic test work.
+
+go run github.com/cockroachdb/code-cov-utils/convert@v1.1.0 -out artifacts/profile-tests.lcov \
+  -trim-prefix github.com/cockroachdb/pebble/ \
+  artifacts/profile-tests.gocov
+
+go run github.com/cockroachdb/code-cov-utils/convert@v1.1.0 -out artifacts/profile-meta.lcov \
+  -trim-prefix github.com/cockroachdb/pebble/ \
+  artifacts/profile-meta.gocov
+
+go run github.com/cockroachdb/code-cov-utils/convert@v1.1.0 -out artifacts/profile-tests-and-meta.lcov \
+  -trim-prefix github.com/cockroachdb/pebble/ \
+  artifacts/profile-tests.gocov artifacts/profile-meta.gocov
+
+if [ $test_failed -eq 1 ]; then
+  echo "WARNING: some tests have failed; coverage might be incomplete."
+fi


### PR DESCRIPTION
#### metamorphic: allow coverage instrumentation

`TestMeta` runs multiple instances of itself in other processes by
executing the same binary (`os.Args[0]`). This doesn't work with the
go test code coverage infrastructure - the "inner" call is not
covered.

To address this, we modify `TestMeta` to allow specifying the "inner
binary" and we create a regular binary `metarunner` that can run a
single instance of `TestMeta` (i.e. either `--run-dir` or `--compare`
is passed). This will allow building `metarunner` with binary coverage
instrumentation (see https://go.dev/testing/coverage/#building).

#### scripts: add code coverage script

Add a script that collects overall code coverage profiles from all
tests (including the metamorphic test).

It generates three profiles, in LCOV format: `profile-tests.lcov`,
`profile-meta.lcov`, and `profile-combined.lcov`.

The intention is to make this script run nightly and add a front end
to visualize the coverage.