### PR TITLE
db: ignore compensation in lower levels during compaction picking

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1334,7 +1334,7 @@ func (p *compactionPickerByScore) pickAuto(env compactionEnv) (pc *pickedCompact
 				p.addScoresToPickedCompactionMetrics(pc, scores)
 				pc.score = info.score
 				// TODO(bananabrick): Create an EventListener for logCompaction.
-				if false {
+				if true {
 					logCompaction(pc)
 				}
 				return pc
@@ -1355,7 +1355,7 @@ func (p *compactionPickerByScore) pickAuto(env compactionEnv) (pc *pickedCompact
 			p.addScoresToPickedCompactionMetrics(pc, scores)
 			pc.score = info.score
 			// TODO(bananabrick): Create an EventListener for logCompaction.
-			if false {
+			if true {
 				logCompaction(pc)
 			}
 			return pc

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -100,13 +100,18 @@ func (s sortCompactionLevelsByPriority) Len() int {
 // sorted list. The candidateLevelInfo for the level placed earlier is more likely
 // to be picked for a compaction.
 func (s sortCompactionLevelsByPriority) Less(i, j int) bool {
-	// Note: We use the score for the higher level, and the rawSmoothed score
-	// for the lower levels. We want to repsect the deletes in the higher levels
-	// and move them down to the lower levels.
-	if s[i].level < s[j].level {
-		return s[i].score >= s[j].rawSmoothed
+	// Just use raw scored to sort the list.
+	if s[i].rawSmoothed != s[j].rawSmoothed {
+		return s[i].rawSmoothed > s[j].rawSmoothed
 	}
-	return s[i].rawSmoothed > s[j].score
+	return s[i].level < s[j].level
+	// // Note: We use the score for the higher level, and the rawSmoothed score
+	// // for the lower levels. We want to repsect the deletes in the higher levels
+	// // and move them down to the lower levels.
+	// if s[i].level < s[j].level {
+	// 	return s[i].score >= s[j].rawSmoothed
+	// }
+	// return s[i].rawSmoothed > s[j].score
 }
 
 func (s sortCompactionLevelsByPriority) Swap(i, j int) {

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -90,18 +90,26 @@ func (info compactionInfo) String() string {
 	return buf.String()
 }
 
-type sortCompactionLevelsDecreasingScore []candidateLevelInfo
+type sortCompactionLevelsByPriority []candidateLevelInfo
 
-func (s sortCompactionLevelsDecreasingScore) Len() int {
+func (s sortCompactionLevelsByPriority) Len() int {
 	return len(s)
 }
-func (s sortCompactionLevelsDecreasingScore) Less(i, j int) bool {
-	if s[i].score != s[j].score {
-		return s[i].score > s[j].score
+
+// Less should return true, if s[i] must be placed earlier than s[j] in the final
+// sorted list. The candidateLevelInfo for the level placed earlier is more likely
+// to be picked for a compaction.
+func (s sortCompactionLevelsByPriority) Less(i, j int) bool {
+	// Note: We use the score for the higher level, and the rawSmoothed score
+	// for the lower levels. We want to repsect the deletes in the higher levels
+	// and move them down to the lower levels.
+	if s[i].level < s[j].level {
+		return s[i].score >= s[j].rawSmoothed
 	}
-	return s[i].level < s[j].level
+	return s[i].rawSmoothed > s[j].score
 }
-func (s sortCompactionLevelsDecreasingScore) Swap(i, j int) {
+
+func (s sortCompactionLevelsByPriority) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
@@ -673,7 +681,10 @@ type candidateLevelInfo struct {
 	// The raw score of the level to be compacted, calculated using
 	// uncompensated file sizes and without any adjustments.
 	rawScore float64
-	level    int
+	// rawSmoothed is the smoothed rawScore(rawScore for the level divided by
+	// the next levels rawScore).
+	rawSmoothed float64
+	level       int
 	// The level to compact to.
 	outputLevel int
 	// The file in level that will be compacted. Additional files may be
@@ -993,6 +1004,7 @@ func (p *compactionPickerByScore) calculateLevelScores(
 		// during score smoothing down below to prevent excessive
 		// prioritization of reclaiming disk space.
 		scores[level].rawScore = float64(p.vers.Levels[level].Size()+sizeAdjust[level].actual()) / float64(p.levelMaxBytes[level])
+		scores[level].rawSmoothed = scores[level].rawScore // will be smoothed later.
 	}
 
 	// Adjust each level's score by the score of the next level. If the next
@@ -1018,20 +1030,26 @@ func (p *compactionPickerByScore) calculateLevelScores(
 	//   L6        0.6        0.6       14 G       24 G
 	var prevLevel int
 	for level := p.baseLevel; level < numLevels; level++ {
+		// Avoid absurdly large scores by placing a floor on the score that we'll
+		// adjust a level by. The value of 0.01 was chosen somewhat arbitrarily
+		const minScore = 0.01
 		if scores[prevLevel].score >= 1 {
-			// Avoid absurdly large scores by placing a floor on the score that we'll
-			// adjust a level by. The value of 0.01 was chosen somewhat arbitrarily
-			const minScore = 0.01
 			if scores[level].rawScore >= minScore {
 				scores[prevLevel].score /= scores[level].rawScore
 			} else {
 				scores[prevLevel].score /= minScore
 			}
 		}
+		if scores[prevLevel].rawSmoothed >= 1 {
+			if scores[level].rawScore >= minScore {
+				scores[prevLevel].rawSmoothed /= scores[level].rawScore
+			} else {
+				scores[prevLevel].rawSmoothed /= minScore
+			}
+		}
 		prevLevel = level
 	}
-
-	sort.Sort(sortCompactionLevelsDecreasingScore(scores[:]))
+	sort.Sort(sortCompactionLevelsByPriority(scores[:]))
 	return scores
 }
 
@@ -1273,13 +1291,16 @@ func (p *compactionPickerByScore) pickAuto(env compactionEnv) (pc *pickedCompact
 			pc.startLevel.level, pc.outputLevel.level, buf.String())
 	}
 
-	// Check for a score-based compaction. "scores" has been sorted in order of
-	// decreasing score. For each level with a score >= 1, we attempt to find a
-	// compaction anchored at at that level.
+	// Check for a score-based compaction. For each level with a score >= 1, we
+	// attempt to find a compaction anchored at that level.
 	for i := range scores {
 		info := &scores[i]
 		if info.score < 1 {
-			break
+			// A level with score less than 1 can be placed earlier than a level
+			// with score > 1, if the earlier level has a higher original score
+			// but a lower compensated score. Say 0.7 vs 0.3, but the compensated
+			// scores are 0.7 vs 1.2.
+			continue
 		}
 		if info.level == numLevels-1 {
 			continue


### PR DESCRIPTION
If a lower levels score is higher than a higher levels score only due
to compensation, then we'll pick the higher level for compaction.

Compacting into a level which has a high score only due to compensation
shouldn't incur a higher write amp. We prioritize higher levels in this
way because we don't want L0 compaction bandwidth to vary due to
compensation in lower levels. Variation in L0 compaction bandwidth can
lead to AC queueing.

Consider two arbitrary candidateLevelInfos x, y where x.level < y.level.

Case 1: x.score > y.score && x.score > y.rawSmoothed.
The behaviour hasn't changed with this pr. x will be placed before y.

Case 2: x.score < y.score && x.score < y.rawSmoothed.
The behaviour hasn't changed with this pr. x will place after y.

Case 3: x.score < y.score && x.score > y.rawSmoothed.
In this case, we will place x before y, which is a behaviour change.
	
Case 3.1: x.rawSmoothed > y.rawSmoothed.
y.score is only higher because of compensation. As described above,
it is okay to pick the higher level in this case.

Case 3.2: x.rawSmoothed < y.rawSmoothed.
x.score is greater than y.rawSmoothed because of compensation in
x.level. But y.score > x.score because of compensation in
y.level. Since y.score is only greater than x.score due to
compensation it is okay to compact x.level first.