### PR TITLE
Implement APIs for creating batch with pre-allocated size

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1294,12 +1294,16 @@ func (b *Batch) Indexed() bool {
 	return b.index != nil
 }
 
-func (b *Batch) init(cap int) {
+// init ensures that the batch data slice is initialized to meet the
+// minimum required size and allocates space for the batch header.
+func (b *Batch) init(bytes int) {
 	n := batchInitialSize
-	for n < cap {
+	for n < bytes {
 		n *= 2
 	}
-	b.data = rawalloc.New(batchHeaderLen, n)
+	if cap(b.data) < n {
+		b.data = rawalloc.New(batchHeaderLen, n)
+	}
 	b.setCount(0)
 	b.setSeqNum(0)
 	b.data = b.data[:batchHeaderLen]

--- a/batch.go
+++ b/batch.go
@@ -367,6 +367,14 @@ func newBatch(db *DB) *Batch {
 	return b
 }
 
+func newBatchWithSize(db *DB, size int) *Batch {
+	b := newBatch(db)
+	if cap(b.data) < size {
+		b.data = rawalloc.New(0, size)
+	}
+	return b
+}
+
 func newIndexedBatch(db *DB, comparer *Comparer) *Batch {
 	i := indexedBatchPool.Get().(*indexedBatch)
 	i.batch.cmp = comparer.Compare
@@ -376,6 +384,14 @@ func newIndexedBatch(db *DB, comparer *Comparer) *Batch {
 	i.batch.index = &i.index
 	i.batch.index.Init(&i.batch.data, i.batch.cmp, i.batch.abbreviatedKey)
 	return &i.batch
+}
+
+func newIndexedBatchWithSize(db *DB, comparer *Comparer, size int) *Batch {
+	b := newIndexedBatch(db, comparer)
+	if cap(b.data) < size {
+		b.data = rawalloc.New(0, size)
+	}
+	return b
 }
 
 // nextSeqNum returns the batch "sequence number" that will be given to the next
@@ -1296,9 +1312,9 @@ func (b *Batch) Indexed() bool {
 
 // init ensures that the batch data slice is initialized to meet the
 // minimum required size and allocates space for the batch header.
-func (b *Batch) init(bytes int) {
+func (b *Batch) init(size int) {
 	n := batchInitialSize
-	for n < bytes {
+	for n < size {
 		n *= 2
 	}
 	if cap(b.data) < n {

--- a/db.go
+++ b/db.go
@@ -1454,6 +1454,12 @@ func (d *DB) NewBatch() *Batch {
 	return newBatch(d)
 }
 
+// NewBatchWithSize is mostly identical to NewBatch, but it will allocate the
+// the specified memory space for the internal slice in advance.
+func (d *DB) NewBatchWithSize(size int) *Batch {
+	return newBatchWithSize(d, size)
+}
+
 // NewIndexedBatch returns a new empty read-write batch. Any reads on the batch
 // will read from both the batch and the DB. If the batch is committed it will
 // be applied to the DB. An indexed batch is slower that a non-indexed batch
@@ -1461,6 +1467,12 @@ func (d *DB) NewBatch() *Batch {
 // NewBatch instead.
 func (d *DB) NewIndexedBatch() *Batch {
 	return newIndexedBatch(d, d.opts.Comparer)
+}
+
+// NewIndexedBatchWithSize is mostly identical to NewIndexedBatch, but it will
+// allocate the the specified memory space for the internal slice in advance.
+func (d *DB) NewIndexedBatchWithSize(size int) *Batch {
+	return newIndexedBatchWithSize(d, d.opts.Comparer, size)
 }
 
 // NewIter returns an iterator that is unpositioned (Iterator.Valid() will


### PR DESCRIPTION
This PR introduces two APIs for creating batch object with pre-allocated memory space.

It's very useful in case of large batch construction if the rough batch size is aware in advance,
which can prevent several rounds of unnecessary memory allocations and mitigate memory
peak because of instant memory allocation in a short time.

This PR also fixes a tiny issue in batch.Init which always allocate the memory space. Pebble
has batchPool and indexedBatchPool internally in order to reuse the allocated memory. This
unexpected behavior is break the original intention.