### PR TITLE
arenaskl: disallow arenas larger than 4GB

### DIFF
--- a/internal/arenaskl/arena_test.go
+++ b/internal/arenaskl/arena_test.go
@@ -34,19 +34,19 @@ func TestArenaSizeOverflow(t *testing.T) {
 	a := newArena(math.MaxUint32)
 
 	// Allocating under the limit throws no error.
-	offset, _, err := a.alloc(math.MaxUint16, 0, 0)
+	offset, _, err := a.alloc(math.MaxUint16, 1, 0)
 	require.Nil(t, err)
 	require.Equal(t, uint32(1), offset)
 	require.Equal(t, uint32(math.MaxUint16)+1, a.Size())
 
 	// Allocating over the limit could cause an accounting
 	// overflow if 32-bit arithmetic was used. It shouldn't.
-	_, _, err = a.alloc(math.MaxUint32, 0, 0)
+	_, _, err = a.alloc(math.MaxUint32, 1, 0)
 	require.Equal(t, ErrArenaFull, err)
 	require.Equal(t, uint32(math.MaxUint32), a.Size())
 
 	// Continuing to allocate continues to throw an error.
-	_, _, err = a.alloc(math.MaxUint16, 0, 0)
+	_, _, err = a.alloc(math.MaxUint16, 1, 0)
 	require.Equal(t, ErrArenaFull, err)
 	require.Equal(t, uint32(math.MaxUint32), a.Size())
 }

--- a/internal/arenaskl/node.go
+++ b/internal/arenaskl/node.go
@@ -29,7 +29,8 @@ import (
 // is used here. If a key/value overflows a uint32, it should not be added to
 // the skiplist.
 func MaxNodeSize(keySize, valueSize uint32) uint64 {
-	return uint64(maxNodeSize) + uint64(keySize) + uint64(valueSize) + align4
+	const maxPadding = nodeAlignment - 1
+	return uint64(maxNodeSize) + uint64(keySize) + uint64(valueSize) + maxPadding
 }
 
 type links struct {
@@ -94,7 +95,7 @@ func newRawNode(arena *Arena, height uint32, keySize, valueSize uint32) (nd *nod
 	unusedSize := uint32((maxHeight - int(height)) * linksSize)
 	nodeSize := uint32(maxNodeSize) - unusedSize
 
-	nodeOffset, allocSize, err := arena.alloc(nodeSize+keySize+valueSize, align4, unusedSize)
+	nodeOffset, allocSize, err := arena.alloc(nodeSize+keySize+valueSize, nodeAlignment, unusedSize)
 	if err != nil {
 		return
 	}

--- a/open.go
+++ b/open.go
@@ -37,11 +37,15 @@ const (
 
 	// The max batch size is limited by the uint32 offsets stored in
 	// internal/batchskl.node, DeferredBatchOp, and flushableBatchEntry.
-	maxBatchSize = 4 << 30 // 4 GB
+	// We limit the size to MaxUint32 so that the exclusive end of an allocation
+	// fits in uint32.
+	maxBatchSize = math.MaxUint32 // just short of 4 GB
 
 	// The max memtable size is limited by the uint32 offsets stored in
 	// internal/arenaskl.node, DeferredBatchOp, and flushableBatchEntry.
-	maxMemTableSize = 4 << 30 // 4 GB
+	// We limit the size to MaxUint32 so that the exclusive end of an allocation
+	// fits in uint32.
+	maxMemTableSize = math.MaxUint32 // just short of 4 GB
 )
 
 // TableCacheSize can be used to determine the table


### PR DESCRIPTION
This commit disallows creation of arenas larger than 4GB in invariants mode and otherwise limits the size to 4GB. The existing code could allow a larger buffer to be used, which would result in uint32 offset overflows.

We also cleanup the alignment argument so it's actually the alignment and not the maximum padding.