### PR TITLE
sstable: fix testing bug that omitted Pebblev4 table format

### DIFF
--- a/sstable/format.go
+++ b/sstable/format.go
@@ -27,7 +27,7 @@ const (
 	TableFormatPebblev4 // DELSIZED tombstones.
 	NumTableFormats
 
-	TableFormatMax = TableFormatPebblev4
+	TableFormatMax = NumTableFormats - 1
 )
 
 // TableFormatPebblev4, in addition to DELSIZED, introduces the use of

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -549,7 +549,7 @@ func forEveryTableFormat[I any](
 	t *testing.T, formatTable [NumTableFormats]I, runTest func(*testing.T, TableFormat, I),
 ) {
 	t.Helper()
-	for tf := TableFormatUnspecified + 1; tf < TableFormatMax; tf++ {
+	for tf := TableFormatUnspecified + 1; tf <= TableFormatMax; tf++ {
 		t.Run(tf.String(), func(t *testing.T) {
 			runTest(t, tf, formatTable[tf])
 		})


### PR DESCRIPTION
In #2829 some facilities for running tests against all table formats was introduced, but it mistakenly used `< MaxTableFormat`, omitting the max table format.