### PR TITLE
replay: Deflake TestCompactionsQuiesce by waiting for sstable copy

### DIFF
--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -571,7 +571,7 @@ func buildHeavyWorkload(t *testing.T) vfs.FS {
 		require.NoError(t, b.Commit(pebble.NoSync))
 		require.NoError(t, d.Flush())
 	}
-	wc.Stop()
+	wc.WaitAndStop()
 
 	defer d.Close()
 	return destFS


### PR DESCRIPTION
All the replay datadriven tests wait for all enqueued sstables to finish copying to the collection directory before we terminate the workload collector. The one exception is TestCompactionsQuiesce which currently calls the Stop() method even if there are sstables waiting to be copied. This change delays the call to Stop() until all enqueued sstables have been copied over.

Fixes #2833.