### PR TITLE
sharedcache: Deflake TestSharedCacheRandomized

### DIFF
--- a/objstorage/objstorageprovider/sharedcache/shared_cache_test.go
+++ b/objstorage/objstorageprovider/sharedcache/shared_cache_test.go
@@ -151,7 +151,8 @@ func TestSharedCacheRandomized(t *testing.T) {
 					require.NoError(t, err)
 
 					// With invariants on, Write will modify its input buffer.
-					size := rand.Int63n(cacheSize)
+					// If size == 0, we can see panics below, so force a nonzero size.
+					size := rand.Int63n(cacheSize-1) + 1
 					objData := make([]byte, size)
 					wrote := make([]byte, size)
 					for i := 0; i < int(size); i++ {


### PR DESCRIPTION
We can sometimes see flakes if rand.Int63 chooses a size of zero, as we feed that size into another Int63 call and it expects nonzero arguments. An example is https://github.com/cockroachdb/pebble/actions/runs/5907184465

This change fixes it by forcing a nonzero size.