### PR TITLE
snapshot: Prevent indefinite wait on compact sync.Cond in EFOS

### DIFF
--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1047,7 +1047,7 @@ func TestIngestShared(t *testing.T) {
 				panic("insufficient args for file-only-snapshot command")
 			}
 			name := td.CmdArgs[0].Key
-			err := efos[name].WaitForFileOnlySnapshot(1 * time.Millisecond)
+			err := efos[name].WaitForFileOnlySnapshot(context.TODO(), 1*time.Millisecond)
 			if err != nil {
 				return err.Error()
 			}
@@ -1519,7 +1519,7 @@ func TestConcurrentExcise(t *testing.T) {
 				panic("insufficient args for file-only-snapshot command")
 			}
 			name := td.CmdArgs[0].Key
-			err := efos[name].WaitForFileOnlySnapshot(1 * time.Millisecond)
+			err := efos[name].WaitForFileOnlySnapshot(context.TODO(), 1*time.Millisecond)
 			if err != nil {
 				return err.Error()
 			}

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -351,7 +351,7 @@ func TestScanInternal(t *testing.T) {
 			}
 			name := td.CmdArgs[0].Key
 			es := efos[name]
-			if err := es.WaitForFileOnlySnapshot(1 * time.Millisecond); err != nil {
+			if err := es.WaitForFileOnlySnapshot(context.TODO(), 1*time.Millisecond); err != nil {
 				return err.Error()
 			}
 			return "ok"


### PR DESCRIPTION
Previously, if we went down the maybeScheduleFlush path instead of the maybeScheduleDelayedFlush path, we could end up in an indefinite wait for a compaction. This change updates a conditional there to ensure we have a flush happening before we wait on the flush conditional.

Also add a context.Context in WaitForFileOnly() to allow callers to use context cancellation to avoid busy-waiting if necessary.