### PR TITLE
arenaskl: avoid repeated comparison with known tower

### DIFF
--- a/internal/arenaskl/iterator.go
+++ b/internal/arenaskl/iterator.go
@@ -248,8 +248,9 @@ func (it *Iterator) seekForBaseSplice(key []byte) (prev, next *node, found bool)
 	level := int(it.list.Height() - 1)
 
 	prev = it.list.head
+	var end *node
 	for {
-		prev, next, found = it.list.findSpliceForLevel(ikey, level, prev)
+		prev, next, found = it.list.findSpliceForLevel(ikey, level, prev, end)
 
 		if found {
 			if level != 0 {
@@ -263,7 +264,7 @@ func (it *Iterator) seekForBaseSplice(key []byte) (prev, next *node, found bool)
 		if level == 0 {
 			break
 		}
-
+		end = next
 		level--
 	}
 

--- a/internal/arenaskl/skl.go
+++ b/internal/arenaskl/skl.go
@@ -264,7 +264,7 @@ func (s *Skiplist) addInternal(key base.InternalKey, value []byte, ins *Inserter
 			// be helpful to try to use a different level as we redo the search,
 			// because it is unlikely that lots of nodes are inserted between prev
 			// and next.
-			prev, next, found = s.findSpliceForLevel(key, i, prev)
+			prev, next, found = s.findSpliceForLevel(key, i, prev, nil)
 			if found {
 				if i != 0 {
 					panic("how can another thread have inserted a node at a non-base level?")
@@ -384,11 +384,15 @@ func (s *Skiplist) findSplice(key base.InternalKey, ins *Inserter) (found bool) 
 		}
 	}
 
+	var end *node
 	for level = level - 1; level >= 0; level-- {
 		var next *node
-		prev, next, found = s.findSpliceForLevel(key, level, prev)
+		prev, next, found = s.findSpliceForLevel(key, level, prev, end)
 		if next == nil {
 			next = s.tail
+		}
+		if !found {
+			end = next
 		}
 		ins.spl[level].init(prev, next)
 	}
@@ -397,15 +401,20 @@ func (s *Skiplist) findSplice(key base.InternalKey, ins *Inserter) (found bool) 
 }
 
 func (s *Skiplist) findSpliceForLevel(
-	key base.InternalKey, level int, start *node,
+	key base.InternalKey, level int, start *node, end *node,
 ) (prev, next *node, found bool) {
 	prev = start
-
+	if end == nil {
+		// The 'end' defaults to being the tail node. The caller can pass a hit
+		// from an earlier iteration: A high tower, past the key, which we already
+		// have encountered.
+		end = s.tail
+	}
 	for {
 		// Assume prev.key < key.
 		next = s.getNext(prev, level)
-		if next == s.tail {
-			// Tail node, so done.
+		if next == end {
+			// Tail (or known element past the key).
 			break
 		}
 


### PR DESCRIPTION
This PR implements a small change to the skiplist operation. When iterating through the towers, it may happen that, the same "right-hand-tower" is hit twice on consecutive levels. It can actually happen pretty often, and in those cases there's no need to actually load the data from memory, since we already know that _that_ particular tower is past the key we are looking for. 

In practice, I'm not sure how large of an impact this change does. I didn't write any new benchmarks for it, and among the existing benchmarks, it appears to (maybe) make a change on `SeekPrefixGE`. 

```
name                                   old time/op  new time/op  delta
SeekPrefixGE/skip=1/use-next=false-8    634ns ±10%   582ns ±23%     ~     (p=0.151 n=5+5)
SeekPrefixGE/skip=1/use-next=true-8     269ns ± 7%   277ns ± 9%     ~     (p=0.310 n=5+5)
SeekPrefixGE/skip=2/use-next=false-8    632ns ±15%   607ns ±18%     ~     (p=0.548 n=5+5)
SeekPrefixGE/skip=2/use-next=true-8     275ns ±12%   297ns ±10%     ~     (p=0.310 n=5+5)
SeekPrefixGE/skip=4/use-next=false-8    569ns ±10%   589ns ±16%     ~     (p=0.690 n=5+5)
SeekPrefixGE/skip=4/use-next=true-8     314ns ± 7%   316ns ± 9%     ~     (p=0.690 n=5+5)
SeekPrefixGE/skip=8/use-next=false-8    721ns ±16%   624ns ± 3%  -13.42%  (p=0.032 n=5+5)
SeekPrefixGE/skip=8/use-next=true-8     677ns ±19%   698ns ± 9%     ~     (p=0.841 n=5+5)
SeekPrefixGE/skip=16/use-next=false-8   717ns ±15%   644ns ±10%     ~     (p=0.222 n=5+5)
SeekPrefixGE/skip=16/use-next=true-8    787ns ±14%   711ns ±13%     ~     (p=0.222 n=5+5)
```

Throwing this out there. Feel free to close it if you feel it is not worth the extra complexity. 