### PR TITLE
sstable, sharedcache: reduce test memory usage

### DIFF
--- a/objstorage/objstorageprovider/sharedcache/shared_cache_test.go
+++ b/objstorage/objstorageprovider/sharedcache/shared_cache_test.go
@@ -136,7 +136,7 @@ func TestSharedCacheRandomized(t *testing.T) {
 		return func(t *testing.T) {
 			for _, concurrentReads := range []bool{false, true} {
 				t.Run(fmt.Sprintf("concurrentReads=%v", concurrentReads), func(t *testing.T) {
-					maxShards := 64
+					maxShards := 32
 					if invariants.RaceEnabled {
 						maxShards = 8
 					}
@@ -206,8 +206,8 @@ func TestSharedCacheRandomized(t *testing.T) {
 			exp := rand.Intn(11) + 10   // [10, 20]
 			randomBlockSize := 1 << exp // [1 KB, 1 MB]
 
-			factor := rand.Intn(10) + 1                                // [1, 10]
-			randomShardingBlockSize := int64(randomBlockSize * factor) // [1 KB, 10 MB]
+			factor := rand.Intn(4) + 1                                 // [1, 4]
+			randomShardingBlockSize := int64(randomBlockSize * factor) // [1 KB, 4 MB]
 
 			t.Run("random block and sharding block size", helper(randomBlockSize, randomShardingBlockSize))
 		}

--- a/sstable/unsafe_test.go
+++ b/sstable/unsafe_test.go
@@ -18,9 +18,11 @@ import (
 
 func TestGetBytes(t *testing.T) {
 	const size = (1 << 31) - 1
-	block := make([]byte, size)
+	// No need to actually allocate a huge slice, which can cause OOM on small
+	// machines (like the GitHub CI runners).
+	block := make([]byte, 100)
 	data := getBytes(unsafe.Pointer(&block[0]), size)
-	require.EqualValues(t, len(block), len(data))
+	require.EqualValues(t, size, len(data))
 }
 
 func TestDecodeVarint(t *testing.T) {


### PR DESCRIPTION
Fixes #2849.

#### sstable: reduce test memory usage

Reduce memory usage of TestGetBytes which allocates a 2GB slice. We
don't actually do anything with the data so we can allocate a small
slice.

#### sharedcache: reduce random test sizes

Reduce the maximum sharding block size to 4MB from 10MB (we always use
1MB in production) and reduce the maximum number of shards from 64 to
32. This reduces the memory footprint of the test significantly.
