### PR TITLE
crl-release-23.1: sstable: fix backport of monotonic bounds bug fix

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -1973,7 +1973,7 @@ func (i *twoLevelIterator) SeekPrefixGE(
 	// block load.
 
 	var dontSeekWithinSingleLevelIter bool
-	if i.topLevelIndex.isDataInvalidated() || !i.topLevelIndex.valid() || !i.index.isDataInvalidated() || err != nil ||
+	if i.topLevelIndex.isDataInvalidated() || !i.topLevelIndex.valid() || i.index.isDataInvalidated() || err != nil ||
 		(i.boundsCmp <= 0 && !flags.TrySeekUsingNext()) || i.cmp(key, i.topLevelIndex.Key().UserKey) > 0 {
 		// Slow-path: need to position the topLevelIndex.
 


### PR DESCRIPTION
The 23.1 backport of the monotonic bounds bug fix was unclean due to recent churn that split reader.go into multiple files. In the rebase, the SeekPrefixGE i.index.isDataInvalidated condition was inverted. This was caught by the new blockIter data-validity assertions.

It will take some legwork to produce a unit test that exercises exactly the condition that is uncaught by existing unit tests, and I don't want that to block correcting this backport.

Fix #2856.