### PR TITLE
sstable: use simple user keys in BoundLimitedBlockPropertyFilter

### DIFF
--- a/range_keys.go
+++ b/range_keys.go
@@ -370,24 +370,24 @@ func (m *rangeKeyMasking) Intersects(prop []byte) (bool, error) {
 // KeyIsWithinLowerBound implements the limitedBlockPropertyFilter interface
 // defined in the sstable package. It's used to restrict the masking block
 // property filter to only applying within the bounds of the active range key.
-func (m *rangeKeyMasking) KeyIsWithinLowerBound(ik *InternalKey) bool {
+func (m *rangeKeyMasking) KeyIsWithinLowerBound(key []byte) bool {
 	// Invariant: m.maskSpan != nil
 	//
-	// The provided `ik` is an inclusive lower bound of the block we're
+	// The provided `key` is an inclusive lower bound of the block we're
 	// considering skipping.
-	return m.cmp(m.maskSpan.Start, ik.UserKey) <= 0
+	return m.cmp(m.maskSpan.Start, key) <= 0
 }
 
 // KeyIsWithinUpperBound implements the limitedBlockPropertyFilter interface
 // defined in the sstable package. It's used to restrict the masking block
 // property filter to only applying within the bounds of the active range key.
-func (m *rangeKeyMasking) KeyIsWithinUpperBound(ik *InternalKey) bool {
+func (m *rangeKeyMasking) KeyIsWithinUpperBound(key []byte) bool {
 	// Invariant: m.maskSpan != nil
 	//
-	// The provided `ik` is an *inclusive* upper bound of the block we're
+	// The provided `key` is an *inclusive* upper bound of the block we're
 	// considering skipping, so the range key's end must be strictly greater
 	// than the block bound for the block to be within bounds.
-	return m.cmp(m.maskSpan.End, ik.UserKey) > 0
+	return m.cmp(m.maskSpan.End, key) > 0
 }
 
 // lazyCombinedIter implements the internalIterator interface, wrapping a

--- a/sstable/block_property.go
+++ b/sstable/block_property.go
@@ -189,13 +189,13 @@ type BoundLimitedBlockPropertyFilter interface {
 	// indicates that the filter may be used to filter blocks that exclusively
 	// contain keys ≥ `key`, so long as the blocks' keys also satisfy the upper
 	// bound.
-	KeyIsWithinLowerBound(key *InternalKey) bool
+	KeyIsWithinLowerBound(key []byte) bool
 	// KeyIsWithinUpperBound tests whether the provided internal key falls
 	// within the current upper bound of the filter. A true return value
 	// indicates that the filter may be used to filter blocks that exclusively
 	// contain keys ≤ `key`, so long as the blocks' keys also satisfy the lower
 	// bound.
-	KeyIsWithinUpperBound(key *InternalKey) bool
+	KeyIsWithinUpperBound(key []byte) bool
 }
 
 // BlockIntervalCollector is a helper implementation of BlockPropertyCollector

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -1135,11 +1135,11 @@ func (bl *boundLimitedWrapper) Intersects(prop []byte) (bool, error) {
 	return v, err
 }
 
-func (bl *boundLimitedWrapper) KeyIsWithinLowerBound(key *InternalKey) (ret bool) {
+func (bl *boundLimitedWrapper) KeyIsWithinLowerBound(key []byte) (ret bool) {
 	if bl.lower == nil {
 		ret = true
 	} else {
-		ret = base.InternalCompare(bl.cmp, *key, *bl.lower) >= 0
+		ret = bl.cmp(key, bl.lower.UserKey) >= 0
 	}
 	if bl.w != nil {
 		fmt.Fprintf(bl.w, "    filter.KeyIsWithinLowerBound(%s) = %t\n", key, ret)
@@ -1147,11 +1147,11 @@ func (bl *boundLimitedWrapper) KeyIsWithinLowerBound(key *InternalKey) (ret bool
 	return ret
 }
 
-func (bl *boundLimitedWrapper) KeyIsWithinUpperBound(key *InternalKey) (ret bool) {
+func (bl *boundLimitedWrapper) KeyIsWithinUpperBound(key []byte) (ret bool) {
 	if bl.upper == nil {
 		ret = true
 	} else {
-		ret = base.InternalCompare(bl.cmp, *key, *bl.upper) <= 0
+		ret = bl.cmp(key, bl.upper.UserKey) <= 0
 	}
 	if bl.w != nil {
 		fmt.Fprintf(bl.w, "    filter.KeyIsWithinUpperBound(%s) = %t\n", key, ret)

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -446,7 +446,7 @@ func (i *singleLevelIterator) resolveMaybeExcluded(dir int8) intersectsResult {
 	// need.
 	if dir > 0 {
 		// Forward iteration.
-		if i.bpfs.boundLimitedFilter.KeyIsWithinUpperBound(i.index.Key()) {
+		if i.bpfs.boundLimitedFilter.KeyIsWithinUpperBound(i.index.Key().UserKey) {
 			return blockExcluded
 		}
 		return blockIntersects
@@ -475,7 +475,7 @@ func (i *singleLevelIterator) resolveMaybeExcluded(dir int8) intersectsResult {
 		// there's a two-level index, it could potentially provide a lower
 		// bound, but the code refactoring necessary to read it doesn't seem
 		// worth the payoff. We fall through to loading the block.
-	} else if i.bpfs.boundLimitedFilter.KeyIsWithinLowerBound(peekKey) {
+	} else if i.bpfs.boundLimitedFilter.KeyIsWithinLowerBound(peekKey.UserKey) {
 		// The lower-bound on the original block falls within the filter's
 		// bounds, and we can skip the block (after restoring our current index
 		// position).

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -94,7 +94,7 @@ func (i *twoLevelIterator) resolveMaybeExcluded(dir int8) intersectsResult {
 	// are ≤ topLevelIndex.Key(). For forward iteration, this is all we need.
 	if dir > 0 {
 		// Forward iteration.
-		if i.bpfs.boundLimitedFilter.KeyIsWithinUpperBound(i.topLevelIndex.Key()) {
+		if i.bpfs.boundLimitedFilter.KeyIsWithinUpperBound(i.topLevelIndex.Key().UserKey) {
 			return blockExcluded
 		}
 		return blockIntersects
@@ -123,7 +123,7 @@ func (i *twoLevelIterator) resolveMaybeExcluded(dir int8) intersectsResult {
 		// we knew the lower bound for the entire table, it could provide a
 		// lower bound, but the code refactoring necessary to read it doesn't
 		// seem worth the payoff. We fall through to loading the block.
-	} else if i.bpfs.boundLimitedFilter.KeyIsWithinLowerBound(peekKey) {
+	} else if i.bpfs.boundLimitedFilter.KeyIsWithinLowerBound(peekKey.UserKey) {
 		// The lower-bound on the original index block falls within the filter's
 		// bounds, and we can skip the block (after restoring our current
 		// top-level index position).

--- a/sstable/testdata/block_properties_boundlimited
+++ b/sstable/testdata/block_properties_boundlimited
@@ -79,7 +79,7 @@ next
 <c@9:3> MaybeFilteredKeys()=false
 <d@3:4> MaybeFilteredKeys()=false
     filter.Intersects([0, 3)) = (false, <nil>)
-    filter.KeyIsWithinUpperBound(g#72057594037927935,17) = true
+    filter.KeyIsWithinUpperBound(g) = true
     filter.Intersects([3, 9)) = (true, <nil>)
 <g@8:7> MaybeFilteredKeys()=true
 <h@3:8> MaybeFilteredKeys()=false
@@ -106,7 +106,7 @@ next
 <c@9:3> MaybeFilteredKeys()=false
 <d@3:4> MaybeFilteredKeys()=false
     filter.Intersects([0, 3)) = (false, <nil>)
-    filter.KeyIsWithinUpperBound(g#72057594037927935,17) = false
+    filter.KeyIsWithinUpperBound(g) = false
 <e@2:5> MaybeFilteredKeys()=false
 <f@0:6> MaybeFilteredKeys()=false
     filter.Intersects([3, 9)) = (true, <nil>)
@@ -126,14 +126,14 @@ next
 next
 ----
     filter.Intersects([2, 6)) = (false, <nil>)
-    filter.KeyIsWithinUpperBound(c#72057594037927935,17) = true
+    filter.KeyIsWithinUpperBound(c) = true
     filter.Intersects([3, 10)) = (false, <nil>)
-    filter.KeyIsWithinUpperBound(e#72057594037927935,17) = true
+    filter.KeyIsWithinUpperBound(e) = true
     filter.Intersects([0, 3)) = (true, <nil>)
 <e@2:5> MaybeFilteredKeys()=true
 <f@0:6> MaybeFilteredKeys()=false
     filter.Intersects([3, 9)) = (false, <nil>)
-    filter.KeyIsWithinUpperBound(i#72057594037927935,17) = false
+    filter.KeyIsWithinUpperBound(i) = false
 <g@8:7> MaybeFilteredKeys()=false
 <h@3:8> MaybeFilteredKeys()=false
 . MaybeFilteredKeys()=false
@@ -152,9 +152,9 @@ prev
 prev
 ----
     filter.Intersects([3, 9)) = (false, <nil>)
-    filter.KeyIsWithinLowerBound(g#72057594037927935,17) = true
+    filter.KeyIsWithinLowerBound(g) = true
     filter.Intersects([0, 3)) = (false, <nil>)
-    filter.KeyIsWithinLowerBound(e#72057594037927935,17) = true
+    filter.KeyIsWithinLowerBound(e) = true
     filter.Intersects([3, 10)) = (true, <nil>)
 <d@3:4> MaybeFilteredKeys()=true
 <c@9:3> MaybeFilteredKeys()=false


### PR DESCRIPTION
The BoundLimitedBlockPropertyFilter interface previously unnecessarily accepted InternalKeys for bounds. Index block internal keys always have identical, unmeaningful trailers.