### PR TITLE
crl-release-23.1: db: crash on logNum invariant violation

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -30,7 +30,6 @@ import (
 )
 
 var errEmptyTable = errors.New("pebble: empty table")
-var errFlushInvariant = errors.New("pebble: flush next log number is unset")
 
 var compactLabels = pprof.Labels("pebble", "compact")
 var flushLabels = pprof.Labels("pebble", "flush")
@@ -1896,8 +1895,7 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 	// the commitPipeline.mu and then holding DB.mu. As an extra defensive
 	// measure, if we try to flush the memtable without also flushing the
 	// flushable batch in the same flush, since the memtable and flushableBatch
-	// have the same logNum, the errFlushInvariant check below will trigger and
-	// prevent the flush from continuing.
+	// have the same logNum, the logNum invariant check below will trigger.
 	var n, inputs int
 	var ingest bool
 	for ; n < len(d.mu.mem.queue)-1; n++ {
@@ -1943,9 +1941,11 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 	minUnflushedLogNum := d.mu.mem.queue[n].logNum
 	if !d.opts.DisableWAL {
 		for i := 0; i < n; i++ {
-			logNum := d.mu.mem.queue[i].logNum
-			if logNum >= minUnflushedLogNum {
-				return 0, errFlushInvariant
+			if logNum := d.mu.mem.queue[i].logNum; logNum >= minUnflushedLogNum {
+				panic(errors.AssertionFailedf("logNum invariant violated: flushing %d items; %d:type=%T,logNum=%d; %d:type=%T,logNum=%d",
+					n,
+					i, d.mu.mem.queue[i].flushable, logNum,
+					n, d.mu.mem.queue[n].flushable, minUnflushedLogNum))
 			}
 		}
 	}

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -3176,66 +3176,6 @@ func TestCompactionOutputSplitters(t *testing.T) {
 		})
 }
 
-func TestFlushInvariant(t *testing.T) {
-	for _, disableWAL := range []bool{false, true} {
-		t.Run(fmt.Sprintf("disableWAL=%t", disableWAL), func(t *testing.T) {
-			for i := 0; i < 2; i++ {
-				t.Run("", func(t *testing.T) {
-					errCh := make(chan error, 1)
-					defer close(errCh)
-					d, err := Open("", testingRandomized(&Options{
-						DisableWAL: disableWAL,
-						FS:         vfs.NewMem(),
-						EventListener: &EventListener{
-							BackgroundError: func(err error) {
-								select {
-								case errCh <- err:
-								default:
-								}
-							},
-						},
-						DebugCheck: DebugCheckLevels,
-					}).WithFSDefaults())
-					require.NoError(t, err)
-
-					require.NoError(t, d.Set([]byte("hello"), nil, NoSync))
-
-					// Contort the DB into a state where it does something invalid.
-					d.mu.Lock()
-					switch i {
-					case 0:
-						// Force the next log number to be 0.
-						d.mu.versions.nextFileNum = 0
-					case 1:
-						// Force the flushing memtable to have a log number equal to the new
-						// log's number.
-						d.mu.mem.queue[len(d.mu.mem.queue)-1].logNum = d.mu.versions.nextFileNum
-					}
-					d.mu.Unlock()
-
-					flushCh, err := d.AsyncFlush()
-					require.NoError(t, err)
-
-					select {
-					case err := <-errCh:
-						if disableWAL {
-							t.Fatalf("expected success, but found %v", err)
-						} else if !errors.Is(err, errFlushInvariant) {
-							t.Fatalf("expected %q, but found %v", errFlushInvariant, err)
-						}
-					case <-flushCh:
-						if !disableWAL {
-							t.Fatalf("expected error but found success")
-						}
-					}
-
-					require.NoError(t, d.Close())
-				})
-			}
-		})
-	}
-}
-
 func TestCompactFlushQueuedMemTableAndFlushMetrics(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test is flaky on windows")


### PR DESCRIPTION
The flushing code currently returns an error if a logNum invariant is violated. However, it's unlikely that we'll be able to recover from a bug here, and we end up keeping the node up but without making any forward progress.

We switch to crashing in this case - a panic is much more visible and restarting the node has a better chance of making progress anyway.