### PR TITLE
crl-release-22.2: db: crash on logNum invariant violation

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -3077,66 +3077,6 @@ func TestCompactionOutputSplitters(t *testing.T) {
 		})
 }
 
-func TestFlushInvariant(t *testing.T) {
-	for _, disableWAL := range []bool{false, true} {
-		t.Run(fmt.Sprintf("disableWAL=%t", disableWAL), func(t *testing.T) {
-			for i := 0; i < 2; i++ {
-				t.Run("", func(t *testing.T) {
-					errCh := make(chan error, 1)
-					defer close(errCh)
-					d, err := Open("", testingRandomized(&Options{
-						DisableWAL: disableWAL,
-						FS:         vfs.NewMem(),
-						EventListener: EventListener{
-							BackgroundError: func(err error) {
-								select {
-								case errCh <- err:
-								default:
-								}
-							},
-						},
-						DebugCheck: DebugCheckLevels,
-					}))
-					require.NoError(t, err)
-
-					require.NoError(t, d.Set([]byte("hello"), nil, NoSync))
-
-					// Contort the DB into a state where it does something invalid.
-					d.mu.Lock()
-					switch i {
-					case 0:
-						// Force the next log number to be 0.
-						d.mu.versions.nextFileNum = 0
-					case 1:
-						// Force the flushing memtable to have a log number equal to the new
-						// log's number.
-						d.mu.mem.queue[len(d.mu.mem.queue)-1].logNum = d.mu.versions.nextFileNum
-					}
-					d.mu.Unlock()
-
-					flushCh, err := d.AsyncFlush()
-					require.NoError(t, err)
-
-					select {
-					case err := <-errCh:
-						if disableWAL {
-							t.Fatalf("expected success, but found %v", err)
-						} else if !errors.Is(err, errFlushInvariant) {
-							t.Fatalf("expected %q, but found %v", errFlushInvariant, err)
-						}
-					case <-flushCh:
-						if !disableWAL {
-							t.Fatalf("expected error but found success")
-						}
-					}
-
-					require.NoError(t, d.Close())
-				})
-			}
-		})
-	}
-}
-
 func TestCompactFlushQueuedMemTableAndFlushMetrics(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test is flaky on windows")


### PR DESCRIPTION
The flushing code currently returns an error if a logNum invariant is violated. However, it's unlikely that we'll be able to recover from a bug here, and we end up keeping the node up but without making any forward progress.

We switch to crashing in this case - a panic is much more visible and restarting the node has a better chance of making progress anyway.