### PR TITLE
crl-release-23.1: tool: better errors in case of encrypted store

### DIFF
--- a/open.go
+++ b/open.go
@@ -73,7 +73,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	// Open the database and WAL directories first.
 	walDirname, dataDir, walDir, err := prepareAndOpenDirs(dirname, opts)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "error opening database at %q", dirname)
 	}
 	defer func() {
 		if db == nil {
@@ -1061,6 +1061,12 @@ var ErrDBAlreadyExists = errors.New("pebble: database already exists")
 //
 // Note that errors can be wrapped with more details; use errors.Is().
 var ErrDBNotPristine = errors.New("pebble: database already exists and is not pristine")
+
+// IsCorruptionError returns true if the given error indicates database
+// corruption.
+func IsCorruptionError(err error) bool {
+	return errors.Is(err, base.ErrCorruption)
+}
 
 func checkConsistency(v *manifest.Version, dirname string, objProvider *objstorage.Provider) error {
 	var buf bytes.Buffer

--- a/options.go
+++ b/options.go
@@ -1220,7 +1220,11 @@ func parseOptions(s string, fn func(section, key, value string) error) error {
 
 		pos := strings.Index(line, "=")
 		if pos < 0 {
-			return errors.Errorf("pebble: invalid key=value syntax: %s", errors.Safe(line))
+			const maxLen = 50
+			if len(line) > maxLen {
+				line = line[:maxLen-3] + "..."
+			}
+			return base.CorruptionErrorf("invalid key=value syntax: %q", errors.Safe(line))
 		}
 
 		key := strings.TrimSpace(line[:pos])

--- a/tool/testdata/corrupt-options-db/OPTIONS-000002
+++ b/tool/testdata/corrupt-options-db/OPTIONS-000002
@@ -1,0 +1,1 @@
+blargle

--- a/tool/testdata/db_check
+++ b/tool/testdata/db_check
@@ -5,7 +5,14 @@ accepts 1 arg(s), received 0
 db check
 non-existent
 ----
-pebble: database "non-existent" does not exist
+error opening database at "non-existent": pebble: database "non-existent" does not exist
+
+db check
+./testdata/corrupt-options-db
+----
+error loading options: invalid key=value syntax: "blargle"
+Custom message in case of corruption error.
+
 
 db check
 ../testdata/db-stage-4

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -5,7 +5,7 @@ accepts 1 arg(s), received 0
 db lsm
 non-existent
 ----
-pebble: database "non-existent" does not exist
+error opening database at "non-existent": pebble: database "non-existent" does not exist
 
 db lsm
 ../testdata/db-stage-4

--- a/tool/testdata/db_scan
+++ b/tool/testdata/db_scan
@@ -5,7 +5,13 @@ accepts 1 arg(s), received 0
 db scan
 non-existent
 ----
-pebble: database "non-existent" does not exist
+error opening database at "non-existent": pebble: database "non-existent" does not exist
+
+db scan
+./testdata/corrupt-options-db
+----
+error loading options: invalid key=value syntax: "blargle"
+Custom message in case of corruption error.
 
 db scan
 ../testdata/db-stage-4


### PR DESCRIPTION
This commit improves the output of the pebble tool when it is run against an encrypted store and the encryption key is not set up correctly.

Until now, we get a very obscure "invalid key=value syntax" error from inside the options parsing code. What's worse the error contains unescaped non-printable characters which can end up erasing the message prefix altogether.

Finally, the errors show up on stdout instead of stderr.

This commit
 - escapes the non-printable characters and limits the length in the above error message
 - adds more context as to where the error is coming from
 - marks the error as a corruption error
 - adds an option to the tool to allow augmenting open errors. From the cockroach side, we can mention encryption in corruption cases.
 - switches to using stderr for all `pebble db` subcommand errors.

Before:
```
$ go run ./cmd/pebble db scan /home/radu/local/1/data
<invalid UTF-8 garbage>
```

After:
```
$ go run ./cmd/pebble db scan /home/radu/local/1/data
error loading options: invalid key=value syntax: "\x96N\xa71$D\x81p\x1cƻ\xc1U\xee6\x88\x80\xd1\xdf\xf7R\x9c\xe2\xe5\xa2\xd2H\xb4\xd1\r+('W\xfeu\x9b\xbd1\xcafC\xd6\x01r\x80c..."
```