### PR TITLE
crl-release-22.2: tool: better errors in case of encrypted store

### DIFF
--- a/open.go
+++ b/open.go
@@ -861,3 +861,9 @@ func (l *Lock) Close() error {
 	defer func() { l.fileLock = nil }()
 	return l.fileLock.Close()
 }
+
+// IsCorruptionError returns true if the given error indicates database
+// corruption.
+func IsCorruptionError(err error) bool {
+	return errors.Is(err, base.ErrCorruption)
+}

--- a/options.go
+++ b/options.go
@@ -1133,7 +1133,11 @@ func parseOptions(s string, fn func(section, key, value string) error) error {
 
 		pos := strings.Index(line, "=")
 		if pos < 0 {
-			return errors.Errorf("pebble: invalid key=value syntax: %s", errors.Safe(line))
+			const maxLen = 50
+			if len(line) > maxLen {
+				line = line[:maxLen-3] + "..."
+			}
+			return base.CorruptionErrorf("invalid key=value syntax: %q", errors.Safe(line))
 		}
 
 		key := strings.TrimSpace(line[:pos])

--- a/tool/data_test.go
+++ b/tool/data_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/datadriven"
 	"github.com/cockroachdb/pebble/internal/testkeys"
@@ -105,12 +106,19 @@ func runTests(t *testing.T, path string) {
 					m.Name = "test-merger"
 					return &m
 				}()
+				openErrEnhancer := func(err error) error {
+					if errors.Is(err, base.ErrCorruption) {
+						return base.CorruptionErrorf("%v\nCustom message in case of corruption error.", err)
+					}
+					return err
+				}
 
 				tool := New(
 					DefaultComparer(comparer),
 					Comparers(altComparer, testkeys.Comparer),
 					Mergers(merger),
 					FS(fs),
+					OpenErrEnhancer(openErrEnhancer),
 				)
 
 				c := &cobra.Command{}

--- a/tool/db.go
+++ b/tool/db.go
@@ -37,9 +37,10 @@ type dbT struct {
 	Space      *cobra.Command
 
 	// Configuration.
-	opts      *pebble.Options
-	comparers sstable.Comparers
-	mergers   sstable.Mergers
+	opts            *pebble.Options
+	comparers       sstable.Comparers
+	mergers         sstable.Mergers
+	openErrEnhancer func(error) error
 
 	// Flags.
 	comparerName string
@@ -52,11 +53,17 @@ type dbT struct {
 	verbose      bool
 }
 
-func newDB(opts *pebble.Options, comparers sstable.Comparers, mergers sstable.Mergers) *dbT {
+func newDB(
+	opts *pebble.Options,
+	comparers sstable.Comparers,
+	mergers sstable.Mergers,
+	openErrEnhancer func(error) error,
+) *dbT {
 	d := &dbT{
-		opts:      opts,
-		comparers: comparers,
-		mergers:   mergers,
+		opts:            opts,
+		comparers:       comparers,
+		mergers:         mergers,
+		openErrEnhancer: openErrEnhancer,
 	}
 	d.fmtKey.mustSet("quoted")
 	d.fmtValue.mustSet("[%x]")
@@ -254,8 +261,19 @@ type openOption interface {
 }
 
 func (d *dbT) openDB(dir string, openOptions ...openOption) (*pebble.DB, error) {
-	if err := d.loadOptions(dir); err != nil {
+	db, err := d.openDBInternal(dir, openOptions...)
+	if err != nil {
+		if d.openErrEnhancer != nil {
+			err = d.openErrEnhancer(err)
+		}
 		return nil, err
+	}
+	return db, nil
+}
+
+func (d *dbT) openDBInternal(dir string, openOptions ...openOption) (*pebble.DB, error) {
+	if err := d.loadOptions(dir); err != nil {
+		return nil, errors.Wrap(err, "error loading options")
 	}
 	if d.comparerName != "" {
 		d.opts.Comparer = d.comparers[d.comparerName]
@@ -278,24 +296,24 @@ func (d *dbT) openDB(dir string, openOptions ...openOption) (*pebble.DB, error) 
 	return pebble.Open(dir, &opts)
 }
 
-func (d *dbT) closeDB(stdout io.Writer, db *pebble.DB) {
+func (d *dbT) closeDB(stderr io.Writer, db *pebble.DB) {
 	if err := db.Close(); err != nil {
-		fmt.Fprintf(stdout, "%s\n", err)
+		fmt.Fprintf(stderr, "%s\n", err)
 	}
 }
 
 func (d *dbT) runCheck(cmd *cobra.Command, args []string) {
-	stdout := cmd.OutOrStdout()
+	stdout, stderr := cmd.OutOrStdout(), cmd.ErrOrStderr()
 	db, err := d.openDB(args[0])
 	if err != nil {
-		fmt.Fprintf(stdout, "%s\n", err)
+		fmt.Fprintf(stderr, "%s\n", err)
 		return
 	}
-	defer d.closeDB(stdout, db)
+	defer d.closeDB(stderr, db)
 
 	var stats pebble.CheckLevelsStats
 	if err := db.CheckLevels(&stats); err != nil {
-		fmt.Fprintf(stdout, "%s\n", err)
+		fmt.Fprintf(stderr, "%s\n", err)
 	}
 	fmt.Fprintf(stdout, "checked %d %s and %d %s\n",
 		stats.NumPoints, makePlural("point", stats.NumPoints), stats.NumTombstones, makePlural("tombstone", int64(stats.NumTombstones)))
@@ -311,37 +329,37 @@ func (n nonReadOnly) apply(opts *pebble.Options) {
 }
 
 func (d *dbT) runCheckpoint(cmd *cobra.Command, args []string) {
-	stdout := cmd.OutOrStdout()
+	stderr := cmd.ErrOrStderr()
 	db, err := d.openDB(args[0], nonReadOnly{})
 	if err != nil {
-		fmt.Fprintf(stdout, "%s\n", err)
+		fmt.Fprintf(stderr, "%s\n", err)
 		return
 	}
-	defer d.closeDB(stdout, db)
+	defer d.closeDB(stderr, db)
 	destDir := args[1]
 
 	if err := db.Checkpoint(destDir); err != nil {
-		fmt.Fprintf(stdout, "%s\n", err)
+		fmt.Fprintf(stderr, "%s\n", err)
 	}
 }
 
 func (d *dbT) runGet(cmd *cobra.Command, args []string) {
-	stdout := cmd.OutOrStdout()
+	stdout, stderr := cmd.OutOrStdout(), cmd.ErrOrStderr()
 	db, err := d.openDB(args[0])
 	if err != nil {
-		fmt.Fprintf(stdout, "%s\n", err)
+		fmt.Fprintf(stderr, "%s\n", err)
 		return
 	}
-	defer d.closeDB(stdout, db)
+	defer d.closeDB(stderr, db)
 	var k key
 	if err := k.Set(args[1]); err != nil {
-		fmt.Fprintf(stdout, "%s\n", err)
+		fmt.Fprintf(stderr, "%s\n", err)
 		return
 	}
 
 	val, closer, err := db.Get(k)
 	if err != nil {
-		fmt.Fprintf(stdout, "%s\n", err)
+		fmt.Fprintf(stderr, "%s\n", err)
 		return
 	}
 	defer func() {
@@ -355,25 +373,25 @@ func (d *dbT) runGet(cmd *cobra.Command, args []string) {
 }
 
 func (d *dbT) runLSM(cmd *cobra.Command, args []string) {
-	stdout := cmd.OutOrStdout()
+	stdout, stderr := cmd.OutOrStdout(), cmd.ErrOrStderr()
 	db, err := d.openDB(args[0])
 	if err != nil {
-		fmt.Fprintf(stdout, "%s\n", err)
+		fmt.Fprintf(stderr, "%s\n", err)
 		return
 	}
-	defer d.closeDB(stdout, db)
+	defer d.closeDB(stderr, db)
 
 	fmt.Fprintf(stdout, "%s", db.Metrics())
 }
 
 func (d *dbT) runScan(cmd *cobra.Command, args []string) {
-	stdout := cmd.OutOrStdout()
+	stdout, stderr := cmd.OutOrStdout(), cmd.ErrOrStderr()
 	db, err := d.openDB(args[0])
 	if err != nil {
-		fmt.Fprintf(stdout, "%s\n", err)
+		fmt.Fprintf(stderr, "%s\n", err)
 		return
 	}
-	defer d.closeDB(stdout, db)
+	defer d.closeDB(stderr, db)
 
 	// Update the internal formatter if this comparator has one specified.
 	if d.opts.Comparer != nil {
@@ -412,7 +430,7 @@ func (d *dbT) runScan(cmd *cobra.Command, args []string) {
 	}
 
 	if err := iter.Close(); err != nil {
-		fmt.Fprintf(stdout, "%s\n", err)
+		fmt.Fprintf(stderr, "%s\n", err)
 	}
 
 	elapsed := timeNow().Sub(start)
@@ -422,7 +440,7 @@ func (d *dbT) runScan(cmd *cobra.Command, args []string) {
 }
 
 func (d *dbT) runSpace(cmd *cobra.Command, args []string) {
-	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
+	stdout, stderr := cmd.OutOrStdout(), cmd.ErrOrStderr()
 	db, err := d.openDB(args[0])
 	if err != nil {
 		fmt.Fprintf(stderr, "%s\n", err)
@@ -439,7 +457,7 @@ func (d *dbT) runSpace(cmd *cobra.Command, args []string) {
 }
 
 func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
-	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
+	stdout, stderr := cmd.OutOrStdout(), cmd.ErrOrStderr()
 	dirname := args[0]
 	err := func() error {
 		desc, err := pebble.Peek(dirname, d.opts.FS)
@@ -564,25 +582,25 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 }
 
 func (d *dbT) runSet(cmd *cobra.Command, args []string) {
-	stdout := cmd.OutOrStdout()
+	stderr := cmd.ErrOrStderr()
 	db, err := d.openDB(args[0], nonReadOnly{})
 	if err != nil {
-		fmt.Fprintf(stdout, "%s\n", err)
+		fmt.Fprintf(stderr, "%s\n", err)
 		return
 	}
-	defer d.closeDB(stdout, db)
+	defer d.closeDB(stderr, db)
 	var k, v key
 	if err := k.Set(args[1]); err != nil {
-		fmt.Fprintf(stdout, "%s\n", err)
+		fmt.Fprintf(stderr, "%s\n", err)
 		return
 	}
 	if err := v.Set(args[2]); err != nil {
-		fmt.Fprintf(stdout, "%s\n", err)
+		fmt.Fprintf(stderr, "%s\n", err)
 		return
 	}
 
 	if err := db.Set(k, v, nil); err != nil {
-		fmt.Fprintf(stdout, "%s\n", err)
+		fmt.Fprintf(stderr, "%s\n", err)
 	}
 }
 

--- a/tool/testdata/corrupt-options-db/OPTIONS-000002
+++ b/tool/testdata/corrupt-options-db/OPTIONS-000002
@@ -1,0 +1,1 @@
+blargle

--- a/tool/testdata/db_check
+++ b/tool/testdata/db_check
@@ -8,6 +8,12 @@ non-existent
 open non-existent: file does not exist
 
 db check
+./testdata/corrupt-options-db
+----
+error loading options: invalid key=value syntax: "blargle"
+Custom message in case of corruption error.
+
+db check
 ../testdata/db-stage-4
 ----
 checked 6 points and 0 tombstone

--- a/tool/testdata/db_scan
+++ b/tool/testdata/db_scan
@@ -8,6 +8,12 @@ non-existent
 open non-existent: file does not exist
 
 db scan
+./testdata/corrupt-options-db
+----
+error loading options: invalid key=value syntax: "blargle"
+Custom message in case of corruption error.
+
+db scan
 ../testdata/db-stage-4
 ----
 foo [66697665]


### PR DESCRIPTION
This commit improves the output of the pebble tool when it is run against an encrypted store and the encryption key is not set up correctly.

Until now, we get a very obscure "invalid key=value syntax" error from inside the options parsing code. What's worse the error contains unescaped non-printable characters which can end up erasing the message prefix altogether.

Finally, the errors show up on stdout instead of stderr.

This commit
 - escapes the non-printable characters and limits the length in the above error message
 - adds more context as to where the error is coming from
 - marks the error as a corruption error
 - adds an option to the tool to allow augmenting open errors. From the cockroach side, we can mention encryption in corruption cases.
 - switches to using stderr for all `pebble db` subcommand errors.

Before:
```
$ go run ./cmd/pebble db scan /home/radu/local/1/data
<invalid UTF-8 garbage>
```

After:
```
$ go run ./cmd/pebble db scan /home/radu/local/1/data
error loading options: invalid key=value syntax: "\x96N\xa71$D\x81p\x1cƻ\xc1U\xee6\x88\x80\xd1\xdf\xf7R\x9c\xe2\xe5\xa2\xd2H\xb4\xd1\r+('W\xfeu\x9b\xbd1\xcafC\xd6\x01r\x80c..."
```