### PR TITLE
event: remove infinite recursion in compactionAnnotations.SafeFormat

### DIFF
--- a/event.go
+++ b/event.go
@@ -94,7 +94,12 @@ func (ca compactionAnnotations) SafeFormat(w redact.SafePrinter, _ rune) {
 	if len(ca) == 0 {
 		return
 	}
-	w.Printf("%s ", redact.Safe(ca))
+	for i := range ca {
+		if i != 0 {
+			w.Print(" ")
+		}
+		w.Printf("%s", redact.SafeString(ca[i]))
+	}
 }
 
 func (i CompactionInfo) String() string {


### PR DESCRIPTION
We have an infinite recursion where we try to repeatedly call SafeFormat on compactionAnnotations, as we pass the unmodified ca variable as-is to redact.Safe. This change addresses that by breaking up the []string and formatting it individually.