### PR TITLE
db: double check file reference counts when loading file

### DIFF
--- a/flushable_test.go
+++ b/flushable_test.go
@@ -59,13 +59,18 @@ func TestIngestedSSTFlushableAPI(t *testing.T) {
 		// We can reuse the ingestLoad function for this test even if we're
 		// not actually ingesting a file.
 		lr, err := ingestLoad(d.opts, d.FormatMajorVersion(), paths, nil, nil, d.cacheID, pendingOutputs, d.objProvider, jobID)
-		meta := lr.localMeta
 		if err != nil {
 			panic(err)
 		}
+		meta := lr.localMeta
 		if len(meta) == 0 {
 			// All of the sstables to be ingested were empty. Nothing to do.
 			panic("empty sstable")
+		}
+		// The table cache requires the *fileMetadata to have a positive
+		// reference count. Fake a reference before we try to load the file.
+		for _, f := range meta {
+			f.Ref()
 		}
 
 		// Verify the sstables do not overlap.

--- a/table_cache.go
+++ b/table_cache.go
@@ -730,6 +730,10 @@ func (c *tableCacheShard) findNode(
 			}
 		}()
 	}
+	if refs := meta.Refs(); refs <= 0 {
+		panic(errors.AssertionFailedf("attempting to load file %s with refs=%d from table cache",
+			meta, refs))
+	}
 
 	// Fast-path for a hit in the cache.
 	c.mu.RLock()


### PR DESCRIPTION
Double check the file reference counts before attempting to find/create a table
cache node for a file. Once a file's reference count falls to zero, the file
becomes obsolete and may be deleted at any moment.

Today if we have a race, break this invariant and attempt to load a file with a
nonpositive reference count, it's relatively unlikely that it manifests as an
error. Typically tables remain open in the table cache, allowing the table
cache to serve the request even if the file is no longer linked into the data
directory. Additionally, even if it's not in the table cache presently,
deletion of obsolete files may be delayed due to deletion pacing, hiding the
race.

This commit preemptively asserts on the file reference counts. I opted for not
restricting this invariant check to invariants builds because it's cheap
relative to a table cache lookup, and it's a particularly tricky form of
corruption to debug otherwise.

Informs https://github.com/cockroachdb/cockroach/issues/110645.