### PR TITLE
scripts: generate code coverage with invariants build tag

### DIFF
--- a/scripts/code-coverage.sh
+++ b/scripts/code-coverage.sh
@@ -16,12 +16,12 @@ trap 'rm -rf "$tmpdir"' EXIT
 test_failed=0
 # The coverpkg argument ensures that coverage is not restricted to the tested
 # package; so this will get us overall coverage for all tests.
-go test ./... -coverprofile=artifacts/profile-tests.gocov -coverpkg=./... || test_failed=1
+go test -tags invariants ./... -coverprofile=artifacts/profile-tests.gocov -coverpkg=./... || test_failed=1
 
 # The metamorphic test executes itself for each run; we don't get coverage for
 # the inner run. To fix this, we use metarunner as the "inner" binary and we
 # instrument it with coverage (see https://go.dev/testing/coverage/#building).
-go build -o "${tmpdir}/metarunner" -cover ./internal/metamorphic/metarunner
+go build -tags invariants -o "${tmpdir}/metarunner" -cover ./internal/metamorphic/metarunner
 mkdir -p "${tmpdir}/metacover"
 
 GOCOVERDIR="${tmpdir}/metacover" go test ./internal/metamorphic \


### PR DESCRIPTION
We have a significant number of assertions across the codebase gated behind the invariants build tag. This code is run in CI and during the long-running nightly metamorphic tests. When generating code coverage profiles, run with this build tag to also capture code blocks that run with invariants.Enabled.