### PR TITLE
*: implement local to remote/shared copy compaction

### DIFF
--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -105,7 +105,7 @@ func newPebbleDB(dir string) DB {
 			// Store all shared objects on local disk, for convenience.
 			"": remote.NewLocalFS(pathToLocalSharedStorage, vfs.Default),
 		})
-		opts.Experimental.CreateOnShared = true
+		opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
 		if secondaryCacheSize != 0 {
 			opts.Experimental.SecondaryCacheSizeBytes = secondaryCacheSize
 		}

--- a/compaction.go
+++ b/compaction.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invalidating"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/private"
@@ -26,6 +27,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"golang.org/x/exp/constraints"
@@ -460,7 +462,12 @@ type compactionKind int
 const (
 	compactionKindDefault compactionKind = iota
 	compactionKindFlush
+	// compactionKindMove denotes a move compaction where the input file is
+	// retained and linked in a new level without being obsoleted.
 	compactionKindMove
+	// compactionKindCopy denotes a copy compaction where the input file is
+	// copied byte-by-byte into a new file with a new FileNum in the output level.
+	compactionKindCopy
 	compactionKindDeleteOnly
 	compactionKindElisionOnly
 	compactionKindRead
@@ -486,6 +493,8 @@ func (k compactionKind) String() string {
 		return "rewrite"
 	case compactionKindIngestedFlushable:
 		return "ingested-flushable"
+	case compactionKindCopy:
+		return "copy"
 	}
 	return "?"
 }
@@ -712,7 +721,9 @@ func (c *compaction) makeInfo(jobID int) CompactionInfo {
 	return info
 }
 
-func newCompaction(pc *pickedCompaction, opts *Options, beganAt time.Time) *compaction {
+func newCompaction(
+	pc *pickedCompaction, opts *Options, beganAt time.Time, provider objstorage.Provider,
+) *compaction {
 	c := &compaction{
 		kind:              compactionKindDefault,
 		cmp:               pc.cmp,
@@ -747,15 +758,41 @@ func newCompaction(pc *pickedCompaction, opts *Options, beganAt time.Time) *comp
 			c.smallest.UserKey, c.largest.UserKey, c.largest.IsExclusiveSentinel())
 	}
 	c.setupInuseKeyRanges()
-
 	c.kind = pc.kind
+
 	if c.kind == compactionKindDefault && c.outputLevel.files.Empty() && !c.hasExtraLevelData() &&
 		c.startLevel.files.Len() == 1 && c.grandparents.SizeSum() <= c.maxOverlapBytes {
-		// This compaction can be converted into a trivial move from one level
+		// This compaction can be converted into a move or copy from one level
 		// to the next. We avoid such a move if there is lots of overlapping
 		// grandparent data. Otherwise, the move could create a parent file
 		// that will require a very expensive merge later on.
-		c.kind = compactionKindMove
+		iter := c.startLevel.files.Iter()
+		meta := iter.First()
+		isRemote := false
+		// We should always be passed a provider, except in some unit tests.
+		if provider != nil {
+			objMeta, err := provider.Lookup(fileTypeTable, meta.FileNum.DiskFileNum())
+			if err != nil {
+				panic(errors.Wrapf(err, "cannot lookup table %s in provider", meta.FileNum))
+			}
+			isRemote = objMeta.IsRemote()
+		}
+		// Avoid a trivial move or copy if all of these are true, as rewriting a
+		// new file is better:
+		//
+		// 1) The source file is a virtual sstable
+		// 2) The existing file `meta` is on non-remote storage
+		// 3) The output level prefers shared storage
+		mustCopy := !isRemote && remote.ShouldCreateShared(opts.Experimental.CreateOnShared, c.outputLevel.level)
+		if mustCopy {
+			// If the source is virtual, it's best to just rewrite the file as all
+			// conditions in the above comment are met.
+			if !meta.Virtual {
+				c.kind = compactionKindCopy
+			}
+		} else {
+			c.kind = compactionKindMove
+		}
 	}
 	return c
 }
@@ -2349,7 +2386,7 @@ func (d *DB) maybeScheduleCompactionPicker(
 		env.inProgressCompactions = d.getInProgressCompactionInfoLocked(nil)
 		pc, retryLater := pickManualCompaction(v, d.opts, env, d.mu.versions.picker.getBaseLevel(), manual)
 		if pc != nil {
-			c := newCompaction(pc, d.opts, d.timeNow())
+			c := newCompaction(pc, d.opts, d.timeNow(), d.ObjProvider())
 			d.mu.compact.manual = d.mu.compact.manual[1:]
 			d.mu.compact.compactingCount++
 			d.addInProgressCompaction(c)
@@ -2376,7 +2413,7 @@ func (d *DB) maybeScheduleCompactionPicker(
 		if pc == nil {
 			break
 		}
-		c := newCompaction(pc, d.opts, d.timeNow())
+		c := newCompaction(pc, d.opts, d.timeNow(), d.ObjProvider())
 		d.mu.compact.compactingCount++
 		d.addInProgressCompaction(c)
 		go d.compact(c, nil)
@@ -2780,6 +2817,77 @@ type compactStats struct {
 	countMissizedDels    uint64
 }
 
+// runCopyCompaction runs a copy compaction where a new FileNum is created that
+// is a byte-for-byte copy of the input file. This is used in lieu of a move
+// compaction when a file is being moved across the local/remote storage
+// boundary.
+//
+// d.mu must be held when calling this method.
+func (d *DB) runCopyCompaction(
+	jobID int,
+	c *compaction,
+	meta *fileMetadata,
+	objMeta objstorage.ObjectMetadata,
+	versionEdit *versionEdit,
+) (ve *versionEdit, pendingOutputs []physicalMeta, retErr error) {
+	ve = versionEdit
+	if objMeta.IsRemote() || !remote.ShouldCreateShared(d.opts.Experimental.CreateOnShared, c.outputLevel.level) {
+		panic("pebble: scheduled a copy compaction that is not actually moving files to shared storage")
+	}
+	// Note that based on logic in the compaction picker, we're guaranteed
+	// meta.Virtual is false.
+	if meta.Virtual {
+		panic(errors.AssertionFailedf("cannot do a copy compaction of a virtual sstable across local/remote storage"))
+	}
+	// We are in the relatively more complex case where we need to copy this
+	// file to remote/shared storage. Drop the db mutex while we do the
+	// copy.
+	//
+	// To ease up cleanup of the local file and tracking of refs, we create
+	// a new FileNum. This has the potential of making the block cache less
+	// effective, however.
+	metaCopy := new(fileMetadata)
+	*metaCopy = fileMetadata{
+		Size:           meta.Size,
+		CreationTime:   meta.CreationTime,
+		SmallestSeqNum: meta.SmallestSeqNum,
+		LargestSeqNum:  meta.LargestSeqNum,
+		Stats:          meta.Stats,
+		Virtual:        meta.Virtual,
+	}
+	if meta.HasPointKeys {
+		metaCopy.ExtendPointKeyBounds(c.cmp, meta.SmallestPointKey, meta.LargestPointKey)
+	}
+	if meta.HasRangeKeys {
+		metaCopy.ExtendRangeKeyBounds(c.cmp, meta.SmallestRangeKey, meta.LargestRangeKey)
+	}
+	metaCopy.FileNum = d.mu.versions.getNextFileNum()
+	metaCopy.InitPhysicalBacking()
+	c.metrics = map[int]*LevelMetrics{
+		c.outputLevel.level: {
+			BytesIn:         meta.Size,
+			BytesCompacted:  meta.Size,
+			TablesCompacted: 1,
+		},
+	}
+	pendingOutputs = append(pendingOutputs, metaCopy.PhysicalMeta())
+
+	d.mu.Unlock()
+	defer d.mu.Lock()
+	_, err := d.objProvider.LinkOrCopyFromLocal(context.TODO(), d.opts.FS,
+		d.objProvider.Path(objMeta), fileTypeTable, metaCopy.FileBacking.DiskFileNum,
+		objstorage.CreateOptions{PreferSharedStorage: true})
+	if err != nil {
+		return ve, pendingOutputs, err
+	}
+	ve.NewFiles[0].Meta = metaCopy
+
+	if err := d.objProvider.Sync(); err != nil {
+		return nil, pendingOutputs, err
+	}
+	return ve, pendingOutputs, nil
+}
+
 // runCompactions runs a compaction that produces new on-disk tables from
 // memtables or old on-disk tables.
 //
@@ -2828,13 +2936,22 @@ func (d *DB) runCompaction(
 		panic("pebble: runCompaction cannot handle compactionKindIngestedFlushable.")
 	}
 
-	// Check for a trivial move of one table from one level to the next. We avoid
+	// Check for a move or copy of one table from one level to the next. We avoid
 	// such a move if there is lots of overlapping grandparent data. Otherwise,
 	// the move could create a parent file that will require a very expensive
 	// merge later on.
-	if c.kind == compactionKindMove {
+	if c.kind == compactionKindMove || c.kind == compactionKindCopy {
 		iter := c.startLevel.files.Iter()
 		meta := iter.First()
+		if invariants.Enabled {
+			if iter.Next() != nil {
+				panic("got more than one file for a move or copy compaction")
+			}
+		}
+		objMeta, err := d.objProvider.Lookup(fileTypeTable, meta.FileNum.DiskFileNum())
+		if err != nil {
+			return ve, pendingOutputs, stats, err
+		}
 		c.metrics = map[int]*LevelMetrics{
 			c.outputLevel.level: {
 				BytesMoved:  meta.Size,
@@ -2848,6 +2965,12 @@ func (d *DB) runCompaction(
 			NewFiles: []newFileEntry{
 				{Level: c.outputLevel.level, Meta: meta},
 			},
+		}
+		if c.kind == compactionKindCopy {
+			ve, pendingOutputs, retErr = d.runCopyCompaction(jobID, c, meta, objMeta, ve)
+			if retErr != nil {
+				return ve, pendingOutputs, stats, retErr
+			}
 		}
 		return ve, nil, stats, nil
 	}
@@ -3029,15 +3152,8 @@ func (d *DB) runCompaction(
 			}
 		}
 		// Prefer shared storage if present.
-		//
-		// TODO(bilal): This might be inefficient for short-lived files in higher
-		// levels if we're only writing to shared storage and not double-writing
-		// to local storage. Either implement double-writing functionality, or
-		// set PreferSharedStorage to c.outputLevel.level >= 5. The latter needs
-		// some careful handling around move compactions to ensure all files in
-		// lower levels are in shared storage.
 		createOpts := objstorage.CreateOptions{
-			PreferSharedStorage: true,
+			PreferSharedStorage: remote.ShouldCreateShared(d.opts.Experimental.CreateOnShared, c.outputLevel.level),
 		}
 		writable, objMeta, err := d.objProvider.Create(ctx, fileTypeTable, fileNum.DiskFileNum(), createOpts)
 		if err != nil {

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -536,7 +536,7 @@ func TestCompactionPickerL0(t *testing.T) {
 			var result strings.Builder
 			if pc != nil {
 				checkClone(t, pc)
-				c := newCompaction(pc, opts, time.Now())
+				c := newCompaction(pc, opts, time.Now(), nil /* provider */)
 				fmt.Fprintf(&result, "L%d -> L%d\n", pc.startLevel.level, pc.outputLevel.level)
 				fmt.Fprintf(&result, "L%d: %s\n", pc.startLevel.level, fileNums(pc.startLevel.files))
 				if !pc.outputLevel.files.Empty() {
@@ -756,7 +756,7 @@ func TestCompactionPickerConcurrency(t *testing.T) {
 			})
 			var result strings.Builder
 			if pc != nil {
-				c := newCompaction(pc, opts, time.Now())
+				c := newCompaction(pc, opts, time.Now(), nil /* provider */)
 				fmt.Fprintf(&result, "L%d -> L%d\n", pc.startLevel.level, pc.outputLevel.level)
 				fmt.Fprintf(&result, "L%d: %s\n", pc.startLevel.level, fileNums(pc.startLevel.files))
 				if !pc.outputLevel.files.Empty() {

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -515,7 +515,8 @@ func TestPickCompaction(t *testing.T) {
 		vs.picker = &tc.picker
 		pc, got := vs.picker.pickAuto(compactionEnv{diskAvailBytes: math.MaxUint64}), ""
 		if pc != nil {
-			c := newCompaction(pc, opts, time.Now())
+			c := newCompaction(pc, opts, time.Now(), nil /* provider */)
+
 			gotStart := fileNums(c.startLevel.files)
 			gotML := ""
 			observedMulti := len(c.extraLevels) > 0
@@ -1855,7 +1856,7 @@ func TestCompactionOutputLevel(t *testing.T) {
 				d.ScanArgs(t, "start", &start)
 				d.ScanArgs(t, "base", &base)
 				pc := newPickedCompaction(opts, version, start, defaultOutputLevel(start, base), base)
-				c := newCompaction(pc, opts, time.Now())
+				c := newCompaction(pc, opts, time.Now(), nil /* provider */)
 				return fmt.Sprintf("output=%d\nmax-output-file-size=%d\n",
 					c.outputLevel.level, c.maxOutputFileSize)
 
@@ -3828,7 +3829,7 @@ func TestSharedObjectDeletePacing(t *testing.T) {
 	opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 		"": remote.NewInMem(),
 	})
-	opts.Experimental.CreateOnShared = true
+	opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
 	opts.TargetByteDeletionRate = 1
 
 	d, err := Open("", &opts)

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -786,7 +786,9 @@ func TestExcise(t *testing.T) {
 	})
 }
 
-func TestIngestShared(t *testing.T) {
+func testIngestSharedImpl(
+	t *testing.T, createOnShared remote.CreateOnSharedStrategy, fileName string,
+) {
 	var d, d1, d2 *DB
 	var efos map[string]*EventuallyFileOnlySnapshot
 	defer func() {
@@ -822,8 +824,8 @@ func TestIngestShared(t *testing.T) {
 		require.NoError(t, mem2.MkdirAll("ext", 0755))
 		opts1 := &Options{
 			Comparer:              testkeys.Comparer,
-			LBaseMaxBytes:         1,
 			FS:                    mem1,
+			LBaseMaxBytes:         1,
 			L0CompactionThreshold: 100,
 			L0StopWritesThreshold: 100,
 			DebugCheck:            DebugCheckLevels,
@@ -835,7 +837,7 @@ func TestIngestShared(t *testing.T) {
 		opts1.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"": sstorage,
 		})
-		opts1.Experimental.CreateOnShared = true
+		opts1.Experimental.CreateOnShared = createOnShared
 		opts1.Experimental.CreateOnSharedLocator = ""
 		// Disable automatic compactions because otherwise we'll race with
 		// delete-only compactions triggered by ingesting range tombstones.
@@ -846,7 +848,7 @@ func TestIngestShared(t *testing.T) {
 		opts2.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"": sstorage,
 		})
-		opts2.Experimental.CreateOnShared = true
+		opts2.Experimental.CreateOnShared = createOnShared
 		opts2.Experimental.CreateOnSharedLocator = ""
 		opts2.FS = mem2
 
@@ -863,7 +865,7 @@ func TestIngestShared(t *testing.T) {
 	}
 	reset()
 
-	datadriven.RunTest(t, "testdata/ingest_shared", func(t *testing.T, td *datadriven.TestData) string {
+	datadriven.RunTest(t, fmt.Sprintf("testdata/%s", fileName), func(t *testing.T, td *datadriven.TestData) string {
 		switch td.Cmd {
 		case "reset":
 			reset()
@@ -1107,6 +1109,22 @@ func TestIngestShared(t *testing.T) {
 	})
 }
 
+func TestIngestShared(t *testing.T) {
+	for _, strategy := range []remote.CreateOnSharedStrategy{remote.CreateOnSharedAll, remote.CreateOnSharedLower} {
+		strategyStr := "all"
+		if strategy == remote.CreateOnSharedLower {
+			strategyStr = "lower"
+		}
+		t.Run(fmt.Sprintf("createOnShared=%s", strategyStr), func(t *testing.T) {
+			fileName := "ingest_shared"
+			if strategy == remote.CreateOnSharedLower {
+				fileName = "ingest_shared_lower"
+			}
+			testIngestSharedImpl(t, strategy, fileName)
+		})
+	}
+}
+
 func TestSimpleIngestShared(t *testing.T) {
 	mem := vfs.NewMem()
 	var d *DB
@@ -1128,7 +1146,7 @@ func TestSimpleIngestShared(t *testing.T) {
 	providerSettings.Remote.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 		"": remote.NewInMem(),
 	})
-	providerSettings.Remote.CreateOnShared = true
+	providerSettings.Remote.CreateOnShared = remote.CreateOnSharedAll
 	providerSettings.Remote.CreateOnSharedLocator = ""
 
 	provider2, err := objstorageprovider.Open(providerSettings)
@@ -1307,7 +1325,7 @@ func TestConcurrentExcise(t *testing.T) {
 		opts1.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"": sstorage,
 		})
-		opts1.Experimental.CreateOnShared = true
+		opts1.Experimental.CreateOnShared = remote.CreateOnSharedAll
 		opts1.Experimental.CreateOnSharedLocator = ""
 		// Disable automatic compactions because otherwise we'll race with
 		// delete-only compactions triggered by ingesting range tombstones.
@@ -1318,7 +1336,7 @@ func TestConcurrentExcise(t *testing.T) {
 		opts2.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"": sstorage,
 		})
-		opts2.Experimental.CreateOnShared = true
+		opts2.Experimental.CreateOnShared = remote.CreateOnSharedAll
 		opts2.Experimental.CreateOnSharedLocator = ""
 		opts2.FS = mem2
 
@@ -1653,7 +1671,7 @@ func TestIngestExternal(t *testing.T) {
 		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"external-locator": remoteStorage,
 		})
-		opts.Experimental.CreateOnShared = false
+		opts.Experimental.CreateOnShared = remote.CreateOnSharedNone
 		// Disable automatic compactions because otherwise we'll race with
 		// delete-only compactions triggered by ingesting range tombstones.
 		opts.DisableAutomaticCompactions = true

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -103,7 +103,9 @@ func parseOptions(
 				opts.Opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 					"": remote.NewInMem(),
 				})
-				opts.Opts.Experimental.CreateOnShared = true
+				if opts.Opts.Experimental.CreateOnShared == remote.CreateOnSharedNone {
+					opts.Opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
+				}
 				return true
 			case "TestOptions.secondary_cache_enabled":
 				opts.secondaryCacheEnabled = true
@@ -548,7 +550,12 @@ func randomOptions(
 		testOpts.Opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"": remote.NewInMem(),
 		})
-		testOpts.Opts.Experimental.CreateOnShared = true
+		// If shared storage is enabled, pick between writing all files on shared
+		// vs. lower levels only, 50% of the time.
+		testOpts.Opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
+		if rng.Intn(2) == 0 {
+			testOpts.Opts.Experimental.CreateOnShared = remote.CreateOnSharedLower
+		}
 		// If shared storage is enabled, enable secondary cache 50% of time.
 		if rng.Intn(2) == 0 {
 			testOpts.secondaryCacheEnabled = true

--- a/objstorage/objstorageprovider/provider.go
+++ b/objstorage/objstorageprovider/provider.go
@@ -97,10 +97,10 @@ type Settings struct {
 	Remote struct {
 		StorageFactory remote.StorageFactory
 
-		// If CreateOnShared is true, sstables are created on remote storage using
+		// If CreateOnShared is non-zero, sstables are created on remote storage using
 		// the CreateOnSharedLocator (when the PreferSharedStorage create option is
 		// true).
-		CreateOnShared        bool
+		CreateOnShared        remote.CreateOnSharedStrategy
 		CreateOnSharedLocator remote.Locator
 
 		// CacheSizeBytes is the size of the on-disk block cache for objects
@@ -249,7 +249,7 @@ func (p *provider) Create(
 	fileNum base.DiskFileNum,
 	opts objstorage.CreateOptions,
 ) (w objstorage.Writable, meta objstorage.ObjectMetadata, err error) {
-	if opts.PreferSharedStorage && p.st.Remote.CreateOnShared {
+	if opts.PreferSharedStorage && p.st.Remote.CreateOnShared != remote.CreateOnSharedNone {
 		w, meta, err = p.sharedCreate(ctx, fileType, fileNum, p.st.Remote.CreateOnSharedLocator, opts)
 	} else {
 		w, meta, err = p.vfsCreate(ctx, fileType, fileNum)
@@ -338,7 +338,7 @@ func (p *provider) LinkOrCopyFromLocal(
 	dstFileNum base.DiskFileNum,
 	opts objstorage.CreateOptions,
 ) (objstorage.ObjectMetadata, error) {
-	shared := opts.PreferSharedStorage && p.st.Remote.CreateOnShared
+	shared := opts.PreferSharedStorage && p.st.Remote.CreateOnShared != remote.CreateOnSharedNone
 	if !shared && srcFS == p.st.FS {
 		// Wrap the normal filesystem with one which wraps newly created files with
 		// vfs.NewSyncingFile.

--- a/objstorage/objstorageprovider/provider_test.go
+++ b/objstorage/objstorageprovider/provider_test.go
@@ -65,7 +65,7 @@ func TestProvider(t *testing.T) {
 				st := DefaultSettings(fs, fsDir)
 				if creatorID != 0 {
 					st.Remote.StorageFactory = sharedFactory
-					st.Remote.CreateOnShared = true
+					st.Remote.CreateOnShared = remote.CreateOnSharedAll
 					st.Remote.CreateOnSharedLocator = ""
 				}
 				require.NoError(t, fs.MkdirAll(fsDir, 0755))
@@ -286,7 +286,7 @@ func TestSharedMultipleLocators(t *testing.T) {
 
 	st1 := DefaultSettings(vfs.NewMem(), "")
 	st1.Remote.StorageFactory = sharedFactory
-	st1.Remote.CreateOnShared = true
+	st1.Remote.CreateOnShared = remote.CreateOnSharedAll
 	st1.Remote.CreateOnSharedLocator = "foo"
 	p1, err := Open(st1)
 	require.NoError(t, err)
@@ -294,7 +294,7 @@ func TestSharedMultipleLocators(t *testing.T) {
 
 	st2 := DefaultSettings(vfs.NewMem(), "")
 	st2.Remote.StorageFactory = sharedFactory
-	st2.Remote.CreateOnShared = true
+	st2.Remote.CreateOnShared = remote.CreateOnSharedAll
 	st2.Remote.CreateOnSharedLocator = "bar"
 	p2, err := Open(st2)
 	require.NoError(t, err)
@@ -466,7 +466,7 @@ func TestNotExistError(t *testing.T) {
 	st.Remote.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 		"": sharedStorage,
 	})
-	st.Remote.CreateOnShared = true
+	st.Remote.CreateOnShared = remote.CreateOnSharedAll
 	st.Remote.CreateOnSharedLocator = ""
 	provider, err := Open(st)
 	require.NoError(t, err)
@@ -554,7 +554,7 @@ func TestParallelSync(t *testing.T) {
 				"": remote.NewInMem(),
 			})
 
-			st.Remote.CreateOnShared = true
+			st.Remote.CreateOnShared = remote.CreateOnSharedAll
 			st.Remote.CreateOnSharedLocator = ""
 			p, err := Open(st)
 			require.NoError(t, err)

--- a/objstorage/remote/storage.go
+++ b/objstorage/remote/storage.go
@@ -22,6 +22,42 @@ type StorageFactory interface {
 	CreateStorage(locator Locator) (Storage, error)
 }
 
+// SharedLevelsStart denotes the highest (i.e. lowest numbered) level that will
+// have sstables shared across Pebble instances when doing skip-shared
+// iteration (see db.ScanInternal) or shared file ingestion (see
+// db.IngestAndExcise).
+const SharedLevelsStart = 5
+
+// CreateOnSharedStrategy specifies what table files should be created on shared
+// storage. For use with CreateOnShared in options.
+type CreateOnSharedStrategy int
+
+const (
+	// CreateOnSharedNone denotes no files being created on shared storage.
+	CreateOnSharedNone CreateOnSharedStrategy = iota
+	// CreateOnSharedLower denotes the creation of files in lower levels of the
+	// LSM (specifically, L5 and L6 as they're below SharedLevelsStart) on
+	// shared storage, and higher levels on local storage.
+	CreateOnSharedLower
+	// CreateOnSharedAll denotes the creation of all sstables on shared storage.
+	CreateOnSharedAll
+)
+
+// ShouldCreateShared returns whether new table files at the specified level
+// should be created on shared storage.
+func ShouldCreateShared(strategy CreateOnSharedStrategy, level int) bool {
+	switch strategy {
+	case CreateOnSharedAll:
+		return true
+	case CreateOnSharedNone:
+		return false
+	case CreateOnSharedLower:
+		return level >= SharedLevelsStart
+	default:
+		panic("unexpected CreateOnSharedStrategy value")
+	}
+}
+
 // Storage is an interface for a blob storage driver. This is lower-level
 // than an FS-like interface, however FS/File-like abstractions can be built on
 // top of these methods.

--- a/open_test.go
+++ b/open_test.go
@@ -1351,7 +1351,7 @@ func TestOpenRatchetsNextFileNum(t *testing.T) {
 	memShared := remote.NewInMem()
 
 	opts := &Options{FS: mem}
-	opts.Experimental.CreateOnShared = true
+	opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
 	opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 		"": memShared,
 	})

--- a/options.go
+++ b/options.go
@@ -685,14 +685,15 @@ type Options struct {
 		// allows ingestion of external files.
 		RemoteStorage remote.StorageFactory
 
-		// If CreateOnShared is true, any new sstables are created on remote storage
-		// (using CreateOnSharedLocator). These sstables can be shared between
-		// different Pebble instances; the lifecycle of such objects is managed by
-		// the cluster.
+		// If CreateOnShared is non-zero, new sstables are created on remote storage
+		// (using CreateOnSharedLocator and with the appropriate
+		// CreateOnSharedStrategy). These sstables can be shared between different
+		// Pebble instances; the lifecycle of such objects is managed by the
+		// remote.Storage constructed by options.RemoteStorage.
 		//
 		// Can only be used when RemoteStorage is set (and recognizes
 		// CreateOnSharedLocator).
-		CreateOnShared        bool
+		CreateOnShared        remote.CreateOnSharedStrategy
 		CreateOnSharedLocator remote.Locator
 
 		// CacheSizeBytesBytes is the size of the on-disk block cache for objects
@@ -1253,6 +1254,7 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  max_writer_concurrency=%d\n", o.Experimental.MaxWriterConcurrency)
 	fmt.Fprintf(&buf, "  force_writer_parallelism=%t\n", o.Experimental.ForceWriterParallelism)
 	fmt.Fprintf(&buf, "  secondary_cache_size_bytes=%d\n", o.Experimental.SecondaryCacheSizeBytes)
+	fmt.Fprintf(&buf, "  create_on_shared=%d\n", o.Experimental.CreateOnShared)
 
 	// Private options.
 	//
@@ -1528,6 +1530,10 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				o.Experimental.ForceWriterParallelism, err = strconv.ParseBool(value)
 			case "secondary_cache_size_bytes":
 				o.Experimental.SecondaryCacheSizeBytes, err = strconv.ParseInt(value, 10, 64)
+			case "create_on_shared":
+				var createOnSharedInt int64
+				createOnSharedInt, err = strconv.ParseInt(value, 10, 64)
+				o.Experimental.CreateOnShared = remote.CreateOnSharedStrategy(createOnSharedInt)
 			default:
 				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key, value) {
 					return nil

--- a/options_test.go
+++ b/options_test.go
@@ -106,6 +106,7 @@ func TestOptionsString(t *testing.T) {
   max_writer_concurrency=0
   force_writer_parallelism=false
   secondary_cache_size_bytes=0
+  create_on_shared=0
 
 [Level "0"]
   block_restart_interval=16

--- a/replay/testdata/replay
+++ b/replay/testdata/replay
@@ -13,7 +13,7 @@ tree
        0      LOCK
       98      MANIFEST-000001
      122      MANIFEST-000008
-    1168      OPTIONS-000003
+    1189      OPTIONS-000003
        0      marker.format-version.000007.008
        0      marker.manifest.000002.MANIFEST-000008
             simple/
@@ -24,7 +24,7 @@ tree
       25        000004.log
      658        000005.sst
       98        MANIFEST-000001
-    1168        OPTIONS-000003
+    1189        OPTIONS-000003
        0        marker.format-version.000001.008
        0        marker.manifest.000001.MANIFEST-000001
 
@@ -68,6 +68,7 @@ cat build/OPTIONS-000003
   max_writer_concurrency=0
   force_writer_parallelism=false
   secondary_cache_size_bytes=0
+  create_on_shared=0
 
 [Level "0"]
   block_restart_interval=16

--- a/replay/testdata/replay_paced
+++ b/replay/testdata/replay_paced
@@ -15,7 +15,7 @@ tree
        0      LOCK
      122      MANIFEST-000008
      205      MANIFEST-000011
-    1168      OPTIONS-000003
+    1189      OPTIONS-000003
        0      marker.format-version.000007.008
        0      marker.manifest.000003.MANIFEST-000011
             high_read_amp/
@@ -27,7 +27,7 @@ tree
       39        000009.log
      632        000010.sst
      157        MANIFEST-000011
-    1168        OPTIONS-000003
+    1189        OPTIONS-000003
        0        marker.format-version.000001.008
        0        marker.manifest.000001.MANIFEST-000011
 

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -14,12 +14,13 @@ import (
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 )
 
 const (
 	// In skip-shared iteration mode, keys in levels sharedLevelsStart and greater
 	// (i.e. lower in the LSM) are skipped.
-	sharedLevelsStart = 5
+	sharedLevelsStart = remote.SharedLevelsStart
 )
 
 // ErrInvalidSkipSharedIteration is returned by ScanInternal if it was called

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -52,7 +52,7 @@ func TestScanStatistics(t *testing.T) {
 		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"": remote.NewInMem(),
 		})
-		opts.Experimental.CreateOnShared = true
+		opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
 		opts.Experimental.CreateOnSharedLocator = ""
 		opts.DisableAutomaticCompactions = true
 		opts.EnsureDefaults()
@@ -227,7 +227,7 @@ func TestScanInternal(t *testing.T) {
 		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"": remote.NewInMem(),
 		})
-		opts.Experimental.CreateOnShared = true
+		opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
 		opts.Experimental.CreateOnSharedLocator = ""
 		opts.DisableAutomaticCompactions = true
 		opts.EnsureDefaults()

--- a/testdata/ingest_shared_lower
+++ b/testdata/ingest_shared_lower
@@ -1,0 +1,1108 @@
+
+switch 1
+----
+ok
+
+build ext0
+set a 1
+set l 2
+----
+
+ingest ext0
+----
+
+lsm
+----
+6:
+  000004:[a#10,SET-l#10,SET]
+
+
+batch
+set d foo
+set f bar
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+lsm
+----
+6:
+  000008:[a#0,SET-l#0,SET]
+
+switch 2
+----
+ok
+
+iter
+first
+----
+.
+
+replicate 1 2 d g
+----
+replicated 1 shared SSTs
+
+lsm
+----
+6:
+  000005:[d#10,SET-f#10,SET]
+
+iter
+first
+next
+next
+----
+d: (foo, .)
+f: (bar, .)
+.
+
+batch
+set e bar
+set f bar2
+set g bar3
+----
+
+iter
+first
+next
+next
+next
+----
+d: (foo, .)
+e: (bar, .)
+f: (bar2, .)
+g: (bar3, .)
+
+compact a-z
+----
+ok
+
+iter
+first
+next
+next
+next
+----
+d: (foo, .)
+e: (bar, .)
+f: (bar2, .)
+g: (bar3, .)
+
+# Write a new key at f, but don't compact it down.
+
+batch
+set f bar3
+----
+
+switch 1
+----
+ok
+
+lsm
+----
+6:
+  000008:[a#0,SET-l#0,SET]
+
+excise e gg
+----
+would excise 1 files, use ingest-and-excise to excise.
+  deleted:       L6 000008
+  added:         L6 000009:[a#0,1-d#0,1]
+  added:         L6 000010:[l#0,1-l#0,1]
+
+replicate 2 1 e gg
+----
+replicated 1 shared SSTs
+
+iter
+first
+next
+next
+next
+next
+----
+a: (1, .)
+d: (foo, .)
+e: (bar, .)
+f: (bar3, .)
+g: (bar3, .)
+
+# Range key masking test. Write some masked keys, then replicate before
+# compacting, then compact, then replicate back.
+
+batch
+set h@3 foobar
+set i@5 baz
+range-key-set g j @4 value
+----
+
+iter
+first
+next
+next
+next
+next
+next
+next
+next
+----
+a: (1, .)
+d: (foo, .)
+e: (bar, .)
+f: (bar3, .)
+g: (bar3, [g-j) @4=value UPDATED)
+h@3: (foobar, [g-j) @4=value)
+i@5: (baz, [g-j) @4=value)
+l: (2, . UPDATED)
+
+iter mask-filter mask-suffix=@6
+first
+next
+next
+next
+next
+next
+next
+----
+a: (1, .)
+d: (foo, .)
+e: (bar, .)
+f: (bar3, .)
+g: (bar3, [g-j) @4=value UPDATED)
+i@5: (baz, [g-j) @4=value)
+l: (2, . UPDATED)
+
+switch 2
+----
+ok
+
+replicate 1 2 a z
+----
+replicated 3 shared SSTs
+
+iter
+first
+next
+next
+next
+next
+next
+next
+next
+----
+a: (1, .)
+d: (foo, .)
+e: (bar, .)
+f: (bar3, .)
+g: (bar3, [g-j) @4=value UPDATED)
+h@3: (foobar, [g-j) @4=value)
+i@5: (baz, [g-j) @4=value)
+l: (2, . UPDATED)
+
+iter mask-filter mask-suffix=@6
+first
+next
+next
+next
+next
+next
+next
+----
+a: (1, .)
+d: (foo, .)
+e: (bar, .)
+f: (bar3, .)
+g: (bar3, [g-j) @4=value UPDATED)
+i@5: (baz, [g-j) @4=value)
+l: (2, . UPDATED)
+
+compact a-z
+----
+ok
+
+replicate 2 1 a z
+----
+replicated 3 shared SSTs
+
+switch 1
+----
+ok
+
+iter
+first
+next
+next
+next
+next
+next
+next
+next
+next
+----
+a: (1, .)
+d: (foo, .)
+e: (bar, .)
+f: (bar3, .)
+g: (bar3, [g-j) @4=value UPDATED)
+h@3: (foobar, [g-j) @4=value)
+i@5: (baz, [g-j) @4=value)
+l: (2, . UPDATED)
+.
+
+iter mask-filter mask-suffix=@6
+first
+next
+next
+next
+next
+next
+next
+next
+----
+a: (1, .)
+d: (foo, .)
+e: (bar, .)
+f: (bar3, .)
+g: (bar3, [g-j) @4=value UPDATED)
+i@5: (baz, [g-j) @4=value)
+l: (2, . UPDATED)
+.
+
+# Reverse iteration test with masking.
+
+iter mask-filter mask-suffix=@6
+last
+prev
+prev
+prev
+prev
+prev
+prev
+prev
+----
+l: (2, .)
+i@5: (baz, [g-j) @4=value UPDATED)
+g: (bar3, [g-j) @4=value)
+f: (bar3, . UPDATED)
+e: (bar, .)
+d: (foo, .)
+a: (1, .)
+.
+
+# Range del tests.
+
+reset
+----
+
+switch 1
+----
+ok
+
+batch
+set a@3 o
+set b@5 foo
+set c@6 bar
+set e baz
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+batch
+del-range b d
+----
+
+flush
+----
+
+batch
+set a@3 abc
+set b@7 notdeleted
+set c@9 foobar
+----
+
+flush
+----
+
+lsm
+----
+0.1:
+  000010:[a@3#15,SET-c@9#17,SET]
+0.0:
+  000008:[b#14,RANGEDEL-d#inf,RANGEDEL]
+6:
+  000006:[a@3#10,SET-e#13,SET]
+
+iter
+first
+next
+next
+next
+next
+----
+a@3: (abc, .)
+b@7: (notdeleted, .)
+c@9: (foobar, .)
+e: (baz, .)
+.
+
+replicate 1 2 a z
+----
+replicated 1 shared SSTs
+
+switch 2
+----
+ok
+
+lsm
+----
+0.0:
+  000004:[a@3#11,SET-d#inf,RANGEDEL]
+6:
+  000005:[a@3#10,SET-e#10,SET]
+
+iter
+first
+next
+next
+next
+next
+----
+a@3: (abc, .)
+b@7: (notdeleted, .)
+c@9: (foobar, .)
+e: (baz, .)
+.
+
+# Similar to the above test, except this time we bring the rangedel into
+# L5 using an ingestion.
+
+reset
+----
+
+switch 1
+----
+ok
+
+batch
+set a@3 o
+set b@5 foo
+set c@6 bar
+set e baz
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+build s1
+del-range b d
+----
+
+ingest s1
+----
+
+lsm
+----
+5:
+  000007:[b#14,RANGEDEL-d#inf,RANGEDEL]
+6:
+  000006:[a@3#10,SET-e#13,SET]
+
+batch
+set a@3 abc
+set b@7 notdeleted
+set c@9 foobar
+----
+
+flush
+----
+
+lsm
+----
+0.0:
+  000009:[a@3#15,SET-c@9#17,SET]
+5:
+  000007:[b#14,RANGEDEL-d#inf,RANGEDEL]
+6:
+  000006:[a@3#10,SET-e#13,SET]
+
+iter
+first
+next
+next
+next
+next
+next
+----
+a@3: (abc, .)
+b@7: (notdeleted, .)
+c@9: (foobar, .)
+e: (baz, .)
+.
+.
+
+replicate 1 2 a z
+----
+replicated 2 shared SSTs
+
+switch 2
+----
+ok
+
+lsm
+----
+0.0:
+  000004:[a@3#12,SET-c@9#12,SET]
+5:
+  000005:[b#11,RANGEDEL-d#inf,RANGEDEL]
+6:
+  000006:[a@3#10,SET-e#10,SET]
+
+iter
+first
+next
+next
+next
+next
+----
+a@3: (abc, .)
+b@7: (notdeleted, .)
+c@9: (foobar, .)
+e: (baz, .)
+.
+
+# Test for cases where an excise produces a range key on one side and point keys
+# on the other.
+
+reset
+----
+
+switch 1
+----
+ok
+
+batch
+range-key-set a aaa @3 foo
+set d foobar
+set e barbaz
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+lsm
+----
+6:
+  000006:[a#10,RANGEKEYSET-e#12,SET]
+
+switch 2
+----
+ok
+
+batch
+set b bcd
+set c cde
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+replicate 2 1 b cc
+----
+replicated 1 shared SSTs
+
+switch 1
+----
+ok
+
+lsm
+----
+6:
+  000009:[a#10,RANGEKEYSET-aaa#inf,RANGEKEYSET]
+  000008:[b#13,SET-c#13,SET]
+  000010:[d#11,SET-e#12,SET]
+
+iter
+first
+next
+next
+next
+next
+----
+a: (., [a-aaa) @3=foo UPDATED)
+b: (bcd, . UPDATED)
+c: (cde, .)
+d: (foobar, .)
+e: (barbaz, .)
+
+reset
+----
+
+switch 1
+----
+ok
+
+batch
+set a@3 o
+set b@5 foo
+set c@6 bar
+set e baz
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+build s2
+del-range bb g
+----
+
+ingest s2
+----
+
+lsm
+----
+5:
+  000007:[bb#14,RANGEDEL-g#inf,RANGEDEL]
+6:
+  000006:[a@3#10,SET-e#13,SET]
+
+switch 2
+----
+ok
+
+batch
+set ff notdeleted
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+lsm
+----
+6:
+  000006:[ff#10,SET-ff#10,SET]
+
+# This replication should truncate the range deletion in pebble instance 1
+# at f, leaving ff undeleted.
+
+replicate 1 2 b f
+----
+replicated 2 shared SSTs
+
+lsm
+----
+5:
+  000008:[bb#12,RANGEDEL-f#inf,RANGEDEL]
+6:
+  000009:[b@5#11,SET-e#11,SET]
+  000006:[ff#10,SET-ff#10,SET]
+
+iter
+seek-ge b
+next
+next
+----
+b@5: (foo, .)
+ff: (notdeleted, .)
+.
+
+# Same as above, but with a truncated range key instead of a truncated range del.
+
+reset
+----
+
+switch 1
+----
+ok
+
+batch
+set a@3 o
+set b@5 foo
+set c@6 bar
+set e baz
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+build s3
+range-key-set bb g @8 foo
+----
+
+ingest s3
+----
+
+lsm
+----
+5:
+  000007:[bb#14,RANGEKEYSET-g#inf,RANGEKEYSET]
+6:
+  000006:[a@3#10,SET-e#13,SET]
+
+switch 2
+----
+ok
+
+batch
+set ff notcovered
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+lsm
+----
+6:
+  000006:[ff#10,SET-ff#10,SET]
+
+# This replication should truncate the range key in pebble instance 1
+# at f, leaving ff uncovered.
+
+replicate 1 2 b f
+----
+replicated 2 shared SSTs
+
+lsm
+----
+5:
+  000008:[bb#12,RANGEKEYSET-f#inf,RANGEKEYSET]
+6:
+  000009:[b@5#11,SET-e#11,SET]
+  000006:[ff#10,SET-ff#10,SET]
+
+iter
+seek-ge b
+next
+next
+next
+next
+next
+----
+b@5: (foo, .)
+bb: (., [bb-f) @8=foo UPDATED)
+c@6: (bar, [bb-f) @8=foo)
+e: (baz, [bb-f) @8=foo)
+ff: (notcovered, . UPDATED)
+.
+
+
+iter mask-filter mask-suffix=@9
+seek-ge b
+next
+next
+next
+next
+----
+b@5: (foo, .)
+bb: (., [bb-f) @8=foo UPDATED)
+e: (baz, [bb-f) @8=foo)
+ff: (notcovered, . UPDATED)
+.
+
+# Tests for Eventually file-only snapshots.
+
+reset
+----
+
+switch 1
+----
+ok
+
+batch
+set a foo
+set b bar
+set c baz
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+switch 2
+----
+ok
+
+batch
+set b foobar
+----
+
+file-only-snapshot s1
+ aa bb
+ e f
+----
+ok
+
+lsm
+----
+
+iter snapshot=s1
+first
+next
+next
+----
+b: (foobar, .)
+.
+.
+
+# The below call should do a flush.
+
+wait-for-file-only-snapshot s1
+----
+ok
+
+lsm
+----
+0.0:
+  000005:[b#10,SET-b#10,SET]
+
+iter snapshot=s1
+first
+next
+next
+----
+b: (foobar, .)
+.
+.
+
+replicate 1 2 a d
+----
+replicated 1 shared SSTs
+
+iter snapshot=s1
+first
+next
+next
+----
+b: (foobar, .)
+.
+.
+
+iter
+first
+next
+next
+next
+----
+a: (foo, .)
+b: (bar, .)
+c: (baz, .)
+.
+
+switch 1
+----
+ok
+
+batch
+del c
+----
+
+# The below excise and wait should succeed as the flush will end up transitioning
+# the file-only snapshot.
+
+lsm
+----
+6:
+  000006:[a#10,SET-c#12,SET]
+
+file-only-snapshot s2
+ a cc
+----
+ok
+
+iter snapshot=s2
+first
+next
+next
+next
+next
+----
+a: (foo, .)
+b: (bar, .)
+.
+.
+.
+
+flush
+----
+
+compact a-z
+----
+ok
+
+replicate 2 1 a d
+----
+replicated 1 shared SSTs
+
+wait-for-file-only-snapshot s2
+----
+ok
+
+iter snapshot=s2
+first
+next
+next
+next
+----
+a: (foo, .)
+b: (bar, .)
+.
+.
+
+iter snapshot=s2
+first
+clone
+first
+next
+next
+next
+----
+a: (foo, .)
+.
+a: (foo, .)
+b: (bar, .)
+.
+.
+
+iter
+first
+next
+next
+next
+next
+----
+a: (foo, .)
+b: (bar, .)
+c: (baz, .)
+.
+.
+
+batch
+set d foo
+set e bar
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+switch 2
+----
+ok
+
+flush
+----
+
+batch
+set f foobar
+----
+
+# The below file-only snapshot is the more challenging case of a partial overlap
+# between an excise and a file-only snapshot. In this case the EFOS transition
+# blocks on the memtable but the excise proceeds through, causing the EFOS'
+# WaitForFileOnlySnapshot() call to error out. Opening iterators also returns
+# the same errors.
+
+file-only-snapshot s3
+ c g
+----
+ok
+
+iter snapshot=s3
+first
+next
+next
+next
+next
+----
+a: (foo, .)
+b: (bar, .)
+c: (baz, .)
+f: (foobar, .)
+.
+
+iter snapshot=s3
+first
+next
+clone
+first
+next
+next
+next
+----
+a: (foo, .)
+b: (bar, .)
+.
+a: (foo, .)
+b: (bar, .)
+c: (baz, .)
+f: (foobar, .)
+
+
+replicate 1 2 b e
+----
+replicated 2 shared SSTs
+
+wait-for-file-only-snapshot s3
+----
+pebble: snapshot excised before conversion to file-only snapshot
+
+iter snapshot=s3
+first
+next
+next
+next
+next
+----
+pebble: snapshot excised before conversion to file-only snapshot
+
+iter snapshot=s3
+first
+next
+clone
+first
+next
+next
+next
+----
+pebble: snapshot excised before conversion to file-only snapshot
+
+iter
+first
+next
+next
+next
+next
+----
+a: (foo, .)
+b: (bar, .)
+c: (baz, .)
+d: (foo, .)
+f: (foobar, .)
+
+# The below example tests for a file-only snapshot that overlaps completely
+# with an excise right after it. The wait succeeds and snapshot consistency is
+# maintained.
+
+reset
+----
+
+switch 1
+----
+ok
+
+batch
+set a foo
+set b bar
+set c baz
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+switch 2
+----
+ok
+
+batch
+set d foobar
+----
+
+file-only-snapshot s4
+ b e
+----
+ok
+
+iter snapshot=s4
+first
+next
+next
+----
+d: (foobar, .)
+.
+.
+
+replicate 1 2 b e
+----
+replicated 1 shared SSTs
+
+wait-for-file-only-snapshot s4
+----
+ok
+
+iter snapshot=s4
+first
+next
+next
+----
+d: (foobar, .)
+.
+.
+
+compact a-z
+----
+ok
+
+iter snapshot=s4
+first
+next
+next
+----
+d: (foobar, .)
+.
+.
+
+iter
+first
+next
+next
+----
+b: (bar, .)
+c: (baz, .)
+.

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -142,7 +142,9 @@ func New(opts ...Option) *T {
 
 // ConfigureSharedStorage updates the shared storage options.
 func (t *T) ConfigureSharedStorage(
-	s remote.StorageFactory, createOnShared bool, createOnSharedLocator remote.Locator,
+	s remote.StorageFactory,
+	createOnShared remote.CreateOnSharedStrategy,
+	createOnSharedLocator remote.Locator,
 ) {
 	t.opts.Experimental.RemoteStorage = s
 	t.opts.Experimental.CreateOnShared = createOnShared


### PR DESCRIPTION
This change adds the ability to do a copy compaction for a file from local to remote storage, by copying the underlying file and producing a new filenum + backing file. This gives us the flexibility to specify finer-grained placement rules for files in local vs remote storage, and we can use this to selectively place only L5/6 in shared storage, an option that is now Options.Experimental.CreateOnShared (which becomes an enum as opposed to the previous bool).

Fixes #2626.