### PR TITLE
tool/logs: add support for flushable ingestions

### DIFF
--- a/tool/logs/compaction_test.go
+++ b/tool/logs/compaction_test.go
@@ -40,6 +40,9 @@ const (
 	compactionStartNoNodeStoreLine23_1 = `I211215 14:26:56.012382 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n?,pebble,s?] 1216510  [JOB 284925] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4 M)`
 	compactionStartNoNodeStoreLine     = `I211215 14:26:56.012382 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n?,pebble,s?] 1216510  [JOB 284925] compacting(default) L2 [442555] (4.2 M) + L3 [445853] (8.4MB)`
 	flushStartNoNodeStoreLine          = `I211213 16:23:48.903751 21136 3@vendor/github.com/cockroachdb/pebble/event.go:599 ⋮ [n?,pebble,s?] 24 [JOB 10] flushing 2 memtables to L0`
+
+	flushableIngestionLine23_1 = `I230831 04:13:28.824280 3780 3@pebble/event.go:685 ⋮ [n10,s10,pebble] 365  [JOB 226] flushed 6 ingested flushables L0:024334 (1.5 K) + L0:024339 (1.0 K) + L0:024335 (1.9 K) + L0:024336 (1.1 K) + L0:024337 (1.1 K) + L0:024338 (12 K) in 0.0s (0.0s total), output rate 67 M/s`
+	flushableIngestionLine     = `I230831 04:13:28.824280 3780 3@pebble/event.go:685 ⋮ [n10,s10,pebble] 365  [JOB 226] flushed 6 ingested flushables L0:024334 (1.5KB) + L0:024339 (1.0KB) + L0:024335 (1.9KB) + L0:024336 (1.1KB) + L0:024337 (1.1KB) + L0:024338 (12KB) in 0.0s (0.0s total), output rate 67MB/s`
 )
 
 func TestCompactionLogs_Regex(t *testing.T) {
@@ -233,6 +236,44 @@ func TestCompactionLogs_Regex(t *testing.T) {
 			line: readAmpLine23_1,
 			matches: map[int]string{
 				readAmpPatternValueIdx: "5",
+			},
+		},
+		{
+			name: "ingestion during flush job 23.1",
+			re:   flushableIngestedPattern,
+			line: flushableIngestionLine23_1,
+			matches: map[int]string{
+				flushableIngestedPatternJobIdx: "226",
+			},
+		},
+		{
+			name: "ingestion during flush 23.1",
+			re:   ingestedFilePattern,
+			line: flushableIngestionLine23_1,
+			matches: map[int]string{
+				// Just looking at the first match for these.
+				ingestedFilePatternLevelIdx: "0",
+				ingestedFilePatternFileIdx:  "024334",
+				ingestedFilePatternBytesIdx: "1.5 K",
+			},
+		},
+		{
+			name: "ingestion during flush job",
+			re:   flushableIngestedPattern,
+			line: flushableIngestionLine,
+			matches: map[int]string{
+				flushableIngestedPatternJobIdx: "226",
+			},
+		},
+		{
+			name: "ingestion during flush",
+			re:   ingestedFilePattern,
+			line: flushableIngestionLine,
+			matches: map[int]string{
+				// Just looking at the first match for these.
+				ingestedFilePatternLevelIdx: "0",
+				ingestedFilePatternFileIdx:  "024334",
+				ingestedFilePatternBytesIdx: "1.5KB",
 			},
 		},
 	}

--- a/tool/logs/testdata/compactions-23-1
+++ b/tool/logs/testdata/compactions-23-1
@@ -440,16 +440,16 @@ node: 24, store: 24
      to: 220228 15:59
   r-amp: NaN
 _kind______from______to_____________________________________count___bytes______time
-ingest               L0                                         9   140MB
+ingest               L0                                         3   140MB
 ingest               L5                                         3   3.6KB
-total                                                          12   140MB        0s
+total                                                           6   140MB        0s
 node: 24, store: 24
    from: 220228 16:01
      to: 220228 16:02
   r-amp: NaN
 _kind______from______to_____________________________________count___bytes______time
-ingest               L0                                        12   160MB
-total                                                          12   160MB        0s
+ingest               L0                                         6   160MB
+total                                                           6   160MB        0s
 
 reset
 ----
@@ -476,3 +476,24 @@ _kind______from______to___default____move___elide__delete___count___in(B)__out(B
 compact      L5      L6         1       1       0       0       2   128MB   3.6MB   4.0MB      0B        1s
 compact      L6      L6         0       0       0       1       1      0B      0B      0B    11MB        0s
 total                           1       1       0       1       3   128MB   3.6MB   4.0MB    11MB        1s
+
+reset
+----
+
+log
+I230831 04:13:28.824280 3780 3@pebble/event.go:685 ⋮ [n10,s10,pebble] 365  [JOB 226] flushed 6 ingested flushables L0:024334 (1.5 K) + L0:024339 (1.0 K) + L0:024335 (1.9 K) + L0:024336 (1.1 K) + L0:024337 (1.1 K) + L0:024338 (12 K) in 0.0s (0.0s total), output rate 67 M/s
+
+I230831 04:13:28.689575 3717 3@pebble/event.go:685 ⋮ [n10,s10,pebble] 345  [JOB 219] flushed 6 ingested flushables L0:024323 (1.5 K) + L0:024328 (1.0 K) + L0:024324 (2.0 K) + L2:024325 (1.1 K) + L2:024326 (1.1 K) + L0:024327 (54 K) in 0.0s (0.0s total), output rate 152 M/s
+----
+0.log
+
+summarize
+----
+node: 10, store: 10
+   from: 230831 04:13
+     to: 230831 04:14
+  r-amp: NaN
+_kind______from______to_____________________________________count___bytes______time
+ingest               L0                                        10    77KB
+ingest               L2                                         2   2.2KB
+total                                                          12    79KB        0s

--- a/tool/logs/testdata/compactions-latest
+++ b/tool/logs/testdata/compactions-latest
@@ -440,16 +440,16 @@ node: 24, store: 24
      to: 220228 15:59
   r-amp: NaN
 _kind______from______to_____________________________________count___bytes______time
-ingest               L0                                         9   140MB
+ingest               L0                                         3   140MB
 ingest               L5                                         3   3.6KB
-total                                                          12   140MB        0s
+total                                                           6   140MB        0s
 node: 24, store: 24
    from: 220228 16:01
      to: 220228 16:02
   r-amp: NaN
 _kind______from______to_____________________________________count___bytes______time
-ingest               L0                                        12   160MB
-total                                                          12   160MB        0s
+ingest               L0                                         6   160MB
+total                                                           6   160MB        0s
 
 reset
 ----
@@ -476,3 +476,24 @@ _kind______from______to___default____move___elide__delete___count___in(B)__out(B
 compact      L5      L6         1       1       0       0       2   128MB   3.6MB   4.0MB      0B        1s
 compact      L6      L6         0       0       0       1       1      0B      0B      0B    11MB        0s
 total                           1       1       0       1       3   128MB   3.6MB   4.0MB    11MB        1s
+
+reset
+----
+
+log
+I230831 04:13:28.824280 3780 3@pebble/event.go:685 ⋮ [n10,s10,pebble] 365  [JOB 226] flushed 6 ingested flushables L0:024334 (1.5KB) + L0:024339 (1.0KB) + L0:024335 (1.9KB) + L0:024336 (1.1KB) + L0:024337 (1.1KB) + L0:024338 (12KB) in 0.0s (0.0s total), output rate 67MB/s
+
+I230831 04:13:28.689575 3717 3@pebble/event.go:685 ⋮ [n10,s10,pebble] 345  [JOB 219] flushed 6 ingested flushables L0:024323 (1.5KB) + L0:024328 (1.0KB) + L0:024324 (2.0KB) + L2:024325 (1.1KB) + L2:024326 (1.1KB) + L0:024327 (54KB) in 0.0s (0.0s total), output rate 152MB/s
+----
+0.log
+
+summarize
+----
+node: 10, store: 10
+   from: 230831 04:13
+     to: 230831 04:14
+  r-amp: NaN
+_kind______from______to_____________________________________count___bytes______time
+ingest               L0                                        10    77KB
+ingest               L2                                         2   2.2KB
+total                                                          12    79KB        0s


### PR DESCRIPTION
There are two kinds of log lines which are relevant to flushable ingestions.

The first one is of the form:
```
ingested as flushable 024323 (1.5KB), 024328 (1.0KB), 024324 (2.0KB), 024325 (1.1KB), 024326 (1.1KB), 024327 (54KB)
```

The second one is of the form:
```
flushed 6 ingested flushables L0:024323 (1.5KB) + L0:024328 (1.0KB) + L0:024324 (2.0KB) + L2:024325 (1.1KB) + L2:024326 (1.1KB) + L0:024327 (54KB) in 0.0s (0.0s total), output rate 152MB/s
```

The first type gets printed when we perform a flushable ingestion, and the second type gets printed when we actually ingest the sstables during the flush.

For now, we ignore the first log type, and parse the second log type as ingestions.

On the following logs:
```
I230831 04:13:28.689575 3717 3@pebble/event.go:685 ⋮ [n10,s10,pebble] 345  [JOB 219] flushed 6 ingested flushables L0:024323 (1.5KB) + L0:024328 (1.0KB) + L0:024324 (2.0KB) + L2:024325 (1.1KB) + L2:024326 (1.1KB) + L0:024327 (54KB) in 0.0s (0.0s total), output rate 152MB/s

I230831 04:13:28.824280 3780 3@pebble/event.go:685 ⋮ [n10,s10,pebble] 365  [JOB 226] flushed 6 ingested flushables L0:024334 (1.5KB) + L0:024339 (1.0KB) + L0:024335 (1.9KB) + L0:024336 (1.1KB) + L0:024337 (1.1KB) + L0:024338 (12KB) in 0.0s (0.0s total), output rate 67MB/s
```

We get the following ingestion summary:
```
_kind______from______to_____________________________________count___bytes______time
flush                L0                                         2   227KB        0s
ingest               L0                                        10    77KB
ingest               L2                                         2   2.2KB
total                                                          14   306KB        0s
_kind______from______to___default____move___elide__delete___count___in(B)__out(B)__mov(B)__del(B)______time
compact      L2      L3         2       0       0       0       2    31MB    31MB      0B      0B        0s
compact      L3      L4         0       4       0       0       4      0B      0B    60MB      0B        0s
compact      L4      L5         2       3       0       0       5    64MB    64MB    32MB      0B        0s
compact      L5      L6         4       0       0       0       4   320MB   320MB      0B      0B        0s
compact      L6      L6         0       0      32       1      33   1.3GB   1.3GB      0B   4.4MB        3s
total                           8       7      32       1      48   1.7GB   1.7GB    92MB   4.4MB        4s
```

Fixes: https://github.com/cockroachdb/pebble/issues/2899