### PR TITLE
db: support virtual sstables in block checksum validation

### DIFF
--- a/ingest_test.go
+++ b/ingest_test.go
@@ -606,6 +606,9 @@ func TestExcise(t *testing.T) {
 		// Disable automatic compactions because otherwise we'll race with
 		// delete-only compactions triggered by ingesting range tombstones.
 		opts.DisableAutomaticCompactions = true
+		// Set this to true to add some testing for the virtual sstable validation
+		// code paths.
+		opts.Experimental.ValidateOnIngest = true
 
 		var err error
 		d, err = Open("", opts)

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -89,6 +89,12 @@ func (v *VirtualReader) NewIterWithBlockPropertyFiltersAndContextEtc(
 	)
 }
 
+// ValidateBlockChecksumsOnBacking will call ValidateBlockChecksumsOnBacking on the underlying reader.
+// Note that block checksum validation is NOT restricted to virtual sstable bounds.
+func (v *VirtualReader) ValidateBlockChecksumsOnBacking() error {
+	return v.reader.ValidateBlockChecksums()
+}
+
 // NewRawRangeDelIter wraps Reader.NewRawRangeDelIter.
 func (v *VirtualReader) NewRawRangeDelIter() (keyspan.FragmentIterator, error) {
 	iter, err := v.reader.NewRawRangeDelIter()


### PR DESCRIPTION
Supports validation of virtual sstable block checksums during ingestion.
It was easier to deduplicate the virtual sstables by file backing to
ensure that the checksums for each file are only validated once. We
could also implement a VirtualReader.ValidateVirtual function which only
validates blocks which fall within virtual sstable bounds, but that
seems like too much work for a feature which is off by default and was
never turned on.

This pr also prepares us for
https://github.com/cockroachdb/pebble/issues/2885. The metamorphic test
might set `ValidateOnIngest` to true in which case we'll hit a panic.