### PR TITLE
.*: support async stats for virtual sstables

### DIFF
--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -49,6 +49,9 @@ type TableStats struct {
 	// The number of point and range deletion entries in the table.
 	NumDeletions uint64
 	// NumRangeKeySets is the total number of range key sets in the table.
+	//
+	// NB: If there's a chance that the sstable contains any range key sets,
+	// then NumRangeKeySets must be > 0.
 	NumRangeKeySets uint64
 	// Estimate of the total disk space that may be dropped by this table's
 	// point deletions by compacting them.
@@ -173,11 +176,9 @@ type FileMetadata struct {
 	// Size is the size of the file, in bytes. Size is an approximate value for
 	// virtual sstables.
 	//
-	// INVARIANT: when !FileMetadata.Virtual, Size == FileBacking.Size.
-	//
-	// TODO(bananabrick): Size is currently used in metrics, and for many key
-	// Pebble level heuristics. Make sure that the heuristics will still work
-	// appropriately with an approximate value of size.
+	// INVARIANTS:
+	// - When !FileMetadata.Virtual, Size == FileBacking.Size.
+	// - Size should be non-zero. Size 0 virtual sstables must not be created.
 	Size uint64
 	// File creation time in seconds since the epoch (1970-01-01 00:00:00
 	// UTC). For ingested sstables, this corresponds to the time the file was
@@ -302,6 +303,7 @@ type PhysicalFileMeta struct {
 //     The underlying file's size is stored in FileBacking.Size, though it could
 //     also be estimated or could correspond to just the referenced portion of
 //     a file (eg. if the file originated on another node).
+//   - Size must be > 0.
 //   - SmallestSeqNum and LargestSeqNum are loose bounds for virtual sstables.
 //     This means that all keys in the virtual sstable must have seqnums within
 //     [SmallestSeqNum, LargestSeqNum], however there's no guarantee that there's

--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -25,10 +25,20 @@ var propBoolFalse = []byte{'0'}
 
 var propOffsetTagMap = make(map[uintptr]string)
 
-func init() {
-	t := reflect.TypeOf(Properties{})
+func generateTagMaps(t reflect.Type) {
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
+		if f.Type.Kind() == reflect.Struct {
+			if tag := f.Tag.Get("prop"); i == 0 && tag == "pebble.embbeded_common_properties" {
+				// CommonProperties struct embedded in Properties. Note that since
+				// CommonProperties is placed at the top of properties we can use
+				// the offsets of the fields within CommonProperties to determine
+				// the offsets of those fields within Properties.
+				generateTagMaps(f.Type)
+				continue
+			}
+			panic("pebble: unknown struct type in Properties")
+		}
 		if tag := f.Tag.Get("prop"); tag != "" {
 			switch f.Type.Kind() {
 			case reflect.Bool:
@@ -44,10 +54,75 @@ func init() {
 	}
 }
 
+func init() {
+	t := reflect.TypeOf(Properties{})
+	generateTagMaps(t)
+}
+
+// CommonProperties holds properties for either a virtual or a physical sstable. This
+// can be used by code which doesn't care to make the distinction between physical
+// and virtual sstables properties.
+//
+// For virtual sstables, fields are constructed through extrapolation upon virtual
+// reader construction. See MakeVirtualReader for implementation details.
+//
+// NB: The values of these properties can affect correctness. For example,
+// if NumRangeKeySets == 0, but the sstable actually contains range keys, then
+// the iterators will behave incorrectly.
+type CommonProperties struct {
+	// The number of entries in this table.
+	NumEntries uint64 `prop:"rocksdb.num.entries"`
+	// Total raw key size.
+	RawKeySize uint64 `prop:"rocksdb.raw.key.size"`
+	// Total raw value size.
+	RawValueSize uint64 `prop:"rocksdb.raw.value.size"`
+	// Total raw key size of point deletion tombstones. This value is comparable
+	// to RawKeySize.
+	RawPointTombstoneKeySize uint64 `prop:"pebble.raw.point-tombstone.key.size"`
+	// Sum of the raw value sizes carried by point deletion tombstones
+	// containing size estimates. See the DeleteSized key kind. This value is
+	// comparable to Raw{Key,Value}Size.
+	RawPointTombstoneValueSize uint64 `prop:"pebble.raw.point-tombstone.value.size"`
+	// The number of point deletion entries ("tombstones") in this table that
+	// carry a size hint indicating the size of the value the tombstone deletes.
+	NumSizedDeletions uint64 `prop:"pebble.num.deletions.sized"`
+	// The number of deletion entries in this table, including both point and
+	// range deletions.
+	NumDeletions uint64 `prop:"rocksdb.deleted.keys"`
+	// The number of range deletions in this table.
+	NumRangeDeletions uint64 `prop:"rocksdb.num.range-deletions"`
+	// The number of RANGEKEYDELs in this table.
+	NumRangeKeyDels uint64 `prop:"pebble.num.range-key-dels"`
+	// The number of RANGEKEYSETs in this table.
+	NumRangeKeySets uint64 `prop:"pebble.num.range-key-sets"`
+	// Total size of value blocks and value index block. Only serialized if > 0.
+	ValueBlocksSize uint64 `prop:"pebble.value-blocks.size"`
+}
+
+// String is only used for testing purposes.
+func (c *CommonProperties) String() string {
+	var buf bytes.Buffer
+	v := reflect.ValueOf(*c)
+	loaded := make(map[uintptr]struct{})
+	writeProperties(loaded, v, &buf)
+	return buf.String()
+}
+
+// NumPointDeletions is the number of point deletions in the sstable. For virtual
+// sstables, this is an estimate.
+func (c *CommonProperties) NumPointDeletions() uint64 {
+	return c.NumDeletions - c.NumRangeDeletions
+}
+
 // Properties holds the sstable property values. The properties are
 // automatically populated during sstable creation and load from the properties
 // meta block when an sstable is opened.
 type Properties struct {
+	// CommonProperties needs to be at the top of the Properties struct so that the
+	// offsets of the fields in CommonProperties match the offsets of the embedded
+	// fields of CommonProperties in Properties.
+	CommonProperties `prop:"pebble.embbeded_common_properties"`
+
 	// The name of the comparer used in this table.
 	ComparerName string `prop:"rocksdb.comparator"`
 	// The compression algorithm used to compress blocks.
@@ -81,22 +156,8 @@ type Properties struct {
 	MergerName string `prop:"rocksdb.merge.operator"`
 	// The number of blocks in this table.
 	NumDataBlocks uint64 `prop:"rocksdb.num.data.blocks"`
-	// The number of deletion entries in this table, including both point and
-	// range deletions.
-	NumDeletions uint64 `prop:"rocksdb.deleted.keys"`
-	// The number of point deletion entries ("tombstones") in this table that
-	// carry a size hint indicating the size of the value the tombstone deletes.
-	NumSizedDeletions uint64 `prop:"pebble.num.deletions.sized"`
-	// The number of entries in this table.
-	NumEntries uint64 `prop:"rocksdb.num.entries"`
 	// The number of merge operands in the table.
 	NumMergeOperands uint64 `prop:"rocksdb.merge.operands"`
-	// The number of range deletions in this table.
-	NumRangeDeletions uint64 `prop:"rocksdb.num.range-deletions"`
-	// The number of RANGEKEYDELs in this table.
-	NumRangeKeyDels uint64 `prop:"pebble.num.range-key-dels"`
-	// The number of RANGEKEYSETs in this table.
-	NumRangeKeySets uint64 `prop:"pebble.num.range-key-sets"`
 	// The number of RANGEKEYUNSETs in this table.
 	NumRangeKeyUnsets uint64 `prop:"pebble.num.range-key-unsets"`
 	// The number of value blocks in this table. Only serialized if > 0.
@@ -111,21 +172,10 @@ type Properties struct {
 	// A comma separated list of names of the property collectors used in this
 	// table.
 	PropertyCollectorNames string `prop:"rocksdb.property.collectors"`
-	// Total raw key size.
-	RawKeySize uint64 `prop:"rocksdb.raw.key.size"`
-	// Total raw key size of point deletion tombstones. This value is comparable
-	// to RawKeySize.
-	RawPointTombstoneKeySize uint64 `prop:"pebble.raw.point-tombstone.key.size"`
-	// Sum of the raw value sizes carried by point deletion tombstones
-	// containing size estimates. See the DeleteSized key kind. This value is
-	// comparable to Raw{Key,Value}Size.
-	RawPointTombstoneValueSize uint64 `prop:"pebble.raw.point-tombstone.value.size"`
 	// Total raw rangekey key size.
 	RawRangeKeyKeySize uint64 `prop:"pebble.raw.range-key.key.size"`
 	// Total raw rangekey value size.
 	RawRangeKeyValueSize uint64 `prop:"pebble.raw.range-key.value.size"`
-	// Total raw value size.
-	RawValueSize uint64 `prop:"rocksdb.raw.value.size"`
 	// The total number of keys in this table that were pinned by open snapshots.
 	SnapshotPinnedKeys uint64 `prop:"pebble.num.snapshot-pinned-keys"`
 	// The cumulative bytes of keys in this table that were pinned by
@@ -138,8 +188,6 @@ type Properties struct {
 	TopLevelIndexSize uint64 `prop:"rocksdb.top-level.index.size"`
 	// User collected properties.
 	UserProperties map[string]string
-	// Total size of value blocks and value index block. Only serialized if > 0.
-	ValueBlocksSize uint64 `prop:"pebble.value-blocks.size"`
 	// If filtering is enabled, was the filter created on the whole key.
 	WholeKeyFiltering bool `prop:"rocksdb.block.based.table.whole.key.filtering"`
 
@@ -160,12 +208,15 @@ func (p *Properties) NumRangeKeys() uint64 {
 	return p.NumRangeKeyDels + p.NumRangeKeySets + p.NumRangeKeyUnsets
 }
 
-func (p *Properties) String() string {
-	var buf bytes.Buffer
-	v := reflect.ValueOf(*p)
+func writeProperties(loaded map[uintptr]struct{}, v reflect.Value, buf *bytes.Buffer) {
 	vt := v.Type()
 	for i := 0; i < v.NumField(); i++ {
 		ft := vt.Field(i)
+		if ft.Type.Kind() == reflect.Struct {
+			// Embedded struct within the properties.
+			writeProperties(loaded, v.Field(i), buf)
+			continue
+		}
 		tag := ft.Tag.Get("prop")
 		if tag == "" {
 			continue
@@ -175,25 +226,33 @@ func (p *Properties) String() string {
 		// TODO(peter): Use f.IsZero() when we can rely on go1.13.
 		if zero := reflect.Zero(f.Type()); zero.Interface() == f.Interface() {
 			// Skip printing of zero values which were not loaded from disk.
-			if _, ok := p.Loaded[ft.Offset]; !ok {
+			if _, ok := loaded[ft.Offset]; !ok {
 				continue
 			}
 		}
 
-		fmt.Fprintf(&buf, "%s: ", tag)
+		fmt.Fprintf(buf, "%s: ", tag)
 		switch ft.Type.Kind() {
 		case reflect.Bool:
-			fmt.Fprintf(&buf, "%t\n", f.Bool())
+			fmt.Fprintf(buf, "%t\n", f.Bool())
 		case reflect.Uint32:
-			fmt.Fprintf(&buf, "%d\n", f.Uint())
+			fmt.Fprintf(buf, "%d\n", f.Uint())
 		case reflect.Uint64:
-			fmt.Fprintf(&buf, "%d\n", f.Uint())
+			fmt.Fprintf(buf, "%d\n", f.Uint())
 		case reflect.String:
-			fmt.Fprintf(&buf, "%s\n", f.String())
+			fmt.Fprintf(buf, "%s\n", f.String())
 		default:
 			panic("not reached")
 		}
 	}
+}
+
+func (p *Properties) String() string {
+	var buf bytes.Buffer
+	v := reflect.ValueOf(*p)
+	writeProperties(p.Loaded, v, &buf)
+
+	// Write the UserProperties.
 	keys := make([]string, 0, len(p.UserProperties))
 	for key := range p.UserProperties {
 		keys = append(keys, key)
@@ -217,7 +276,7 @@ func (p *Properties) load(
 	for valid := i.First(); valid; valid = i.Next() {
 		if f, ok := propTagMap[string(i.Key().UserKey)]; ok {
 			p.Loaded[f.Offset] = struct{}{}
-			field := v.FieldByIndex(f.Index)
+			field := v.FieldByName(f.Name)
 			switch f.Type.Kind() {
 			case reflect.Bool:
 				field.SetBool(bytes.Equal(i.Value(), propBoolTrue))

--- a/sstable/properties_test.go
+++ b/sstable/properties_test.go
@@ -20,6 +20,13 @@ import (
 
 func TestPropertiesLoad(t *testing.T) {
 	expected := Properties{
+		CommonProperties: CommonProperties{
+			NumEntries:        1727,
+			NumDeletions:      17,
+			NumRangeDeletions: 17,
+			RawKeySize:        23938,
+			RawValueSize:      1912,
+		},
 		ComparerName:           "leveldb.BytewiseComparator",
 		CompressionName:        "Snappy",
 		CompressionOptions:     "window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; ",
@@ -28,13 +35,8 @@ func TestPropertiesLoad(t *testing.T) {
 		IndexSize:              325,
 		MergerName:             "nullptr",
 		NumDataBlocks:          14,
-		NumEntries:             1727,
-		NumDeletions:           17,
-		NumRangeDeletions:      17,
 		PrefixExtractorName:    "nullptr",
 		PropertyCollectorNames: "[KeyCountPropertyCollector]",
-		RawKeySize:             23938,
-		RawValueSize:           1912,
 		UserProperties: map[string]string{
 			"test.key-count": "1727",
 		},
@@ -61,6 +63,15 @@ func TestPropertiesLoad(t *testing.T) {
 
 func TestPropertiesSave(t *testing.T) {
 	expected := &Properties{
+		CommonProperties: CommonProperties{
+			NumDeletions:      15,
+			NumEntries:        16,
+			NumRangeDeletions: 18,
+			NumRangeKeyDels:   19,
+			NumRangeKeySets:   20,
+			RawKeySize:        25,
+			RawValueSize:      26,
+		},
 		ComparerName:           "comparator name",
 		CompressionName:        "compression name",
 		CompressionOptions:     "compression option",
@@ -75,27 +86,19 @@ func TestPropertiesSave(t *testing.T) {
 		IsStrictObsolete:       true,
 		MergerName:             "merge operator name",
 		NumDataBlocks:          14,
-		NumDeletions:           15,
-		NumEntries:             16,
 		NumMergeOperands:       17,
-		NumRangeDeletions:      18,
-		NumRangeKeyDels:        19,
-		NumRangeKeySets:        20,
 		NumRangeKeyUnsets:      21,
 		NumValueBlocks:         22,
 		NumValuesInValueBlocks: 23,
 		PrefixExtractorName:    "prefix extractor name",
 		PrefixFiltering:        true,
 		PropertyCollectorNames: "prefix collector names",
-		RawKeySize:             25,
-		RawValueSize:           26,
 		TopLevelIndexSize:      27,
 		WholeKeyFiltering:      true,
 		UserProperties: map[string]string{
 			"user-prop-a": "1",
 			"user-prop-b": "2",
 		},
-		ValueBlocksSize: 28,
 	}
 
 	check1 := func(expected *Properties) {

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -242,9 +242,29 @@ func TestVirtualReader(t *testing.T) {
 		fmt.Fprintf(&b, "bounds:  [%s-%s]\n", v.vState.lower, v.vState.upper)
 		fmt.Fprintf(&b, "filenum: %s\n", v.vState.fileNum.String())
 		fmt.Fprintf(
-			&b, "props:   %d,%d\n",
+			&b, "props: %s: %d, %s: %d, %s: %d, %s: %d, %s: %d, %s: %d, %s: %d, %s: %d, %s: %d, %s: %d, %s: %d\n",
+			"NumEntries",
+			v.Properties.NumEntries,
+			"RawKeySize",
 			v.Properties.RawKeySize,
+			"RawValueSize",
 			v.Properties.RawValueSize,
+			"RawPointTombstoneKeySize",
+			v.Properties.RawPointTombstoneKeySize,
+			"RawPointTombstoneValueSize",
+			v.Properties.RawPointTombstoneValueSize,
+			"NumSizedDeletions",
+			v.Properties.NumSizedDeletions,
+			"NumDeletions",
+			v.Properties.NumDeletions,
+			"NumRangeDeletions",
+			v.Properties.NumRangeDeletions,
+			"NumRangeKeyDels",
+			v.Properties.NumRangeKeyDels,
+			"NumRangeKeySets",
+			v.Properties.NumRangeKeySets,
+			"ValueBlocksSize",
+			v.Properties.ValueBlocksSize,
 		)
 		return b.String()
 	}

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -22,13 +22,7 @@ import (
 type VirtualReader struct {
 	vState     virtualState
 	reader     *Reader
-	Properties struct {
-		// RawKeySize, RawValueSize are set upon construction of a
-		// VirtualReader. The values of the fields is extrapolated. See
-		// MakeVirtualReader for implementation details.
-		RawKeySize   uint64
-		RawValueSize uint64
-	}
+	Properties CommonProperties
 }
 
 // Lightweight virtual sstable state which can be passed to sstable iterators.
@@ -37,6 +31,10 @@ type virtualState struct {
 	upper   InternalKey
 	fileNum base.FileNum
 	Compare Compare
+}
+
+func ceilDiv(a, b uint64) uint64 {
+	return (a + b - 1) / b
 }
 
 // MakeVirtualReader is used to contruct a reader which can read from virtual
@@ -57,11 +55,21 @@ func MakeVirtualReader(reader *Reader, meta manifest.VirtualFileMeta) VirtualRea
 		reader: reader,
 	}
 
-	v.Properties.RawKeySize =
-		(reader.Properties.RawKeySize * meta.Size) / meta.FileBacking.Size
-	v.Properties.RawValueSize =
-		(reader.Properties.RawValueSize * meta.Size) / meta.FileBacking.Size
+	v.Properties.RawKeySize = ceilDiv(reader.Properties.RawKeySize*meta.Size, meta.FileBacking.Size)
+	v.Properties.RawValueSize = ceilDiv(reader.Properties.RawValueSize*meta.Size, meta.FileBacking.Size)
+	v.Properties.NumEntries = ceilDiv(reader.Properties.NumEntries*meta.Size, meta.FileBacking.Size)
+	v.Properties.NumDeletions = ceilDiv(reader.Properties.NumDeletions*meta.Size, meta.FileBacking.Size)
+	v.Properties.NumRangeDeletions = ceilDiv(reader.Properties.NumRangeDeletions*meta.Size, meta.FileBacking.Size)
+	v.Properties.NumRangeKeyDels = ceilDiv(reader.Properties.NumRangeKeyDels*meta.Size, meta.FileBacking.Size)
 
+	// Note that we rely on NumRangeKeySets for correctness. If the sstable may
+	// contain range keys, then NumRangeKeySets must be > 0. ceilDiv works because
+	// meta.Size will not be 0 for virtual sstables.
+	v.Properties.NumRangeKeySets = ceilDiv(reader.Properties.NumRangeKeySets*meta.Size, meta.FileBacking.Size)
+	v.Properties.ValueBlocksSize = ceilDiv(reader.Properties.ValueBlocksSize*meta.Size, meta.FileBacking.Size)
+	v.Properties.NumSizedDeletions = ceilDiv(reader.Properties.NumSizedDeletions*meta.Size, meta.FileBacking.Size)
+	v.Properties.RawPointTombstoneKeySize = ceilDiv(reader.Properties.RawPointTombstoneKeySize*meta.Size, meta.FileBacking.Size)
+	v.Properties.RawPointTombstoneValueSize = ceilDiv(reader.Properties.RawPointTombstoneValueSize*meta.Size, meta.FileBacking.Size)
 	return v
 }
 
@@ -186,4 +194,9 @@ func (v *virtualState) constrainBounds(
 func (v *VirtualReader) EstimateDiskUsage(start, end []byte) (uint64, error) {
 	_, f, l := v.vState.constrainBounds(start, end, true /* endInclusive */)
 	return v.reader.EstimateDiskUsage(f, l)
+}
+
+// CommonProperties implements the CommonReader interface.
+func (v *VirtualReader) CommonProperties() *CommonProperties {
+	return &v.Properties
 }

--- a/sstable/testdata/virtual_reader
+++ b/sstable/testdata/virtual_reader
@@ -20,7 +20,7 @@ virtualize b.SET.1-c.SET.1
 ----
 bounds:  [b#1,1-c#1,1]
 filenum: 000002
-props:   2,0
+props: NumEntries: 1, RawKeySize: 3, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 0
 
 citer
 ----
@@ -41,7 +41,7 @@ virtualize b.SET.1-c.SET.1
 ----
 bounds:  [b#1,1-c#1,1]
 filenum: 000004
-props:   1,0
+props: NumEntries: 1, RawKeySize: 2, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 0
 
 citer
 ----
@@ -124,12 +124,12 @@ rangekey: [a#11,21-z#72057594037927935,21]
 seqnums:  [1-12]
 
 # Note that we shouldn't have range del spans which cross virtual sstable
-# boundaries.
+# boundaries. NumRangeKeySets must be > 1.
 virtualize a.SET.1-f.SET.1
 ----
 bounds:  [a#1,1-f#1,1]
 filenum: 000006
-props:   3,0
+props: NumEntries: 1, RawKeySize: 4, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 1, NumRangeDeletions: 1, NumRangeKeyDels: 0, NumRangeKeySets: 1, ValueBlocksSize: 0
 
 scan-range-del
 ----
@@ -159,7 +159,7 @@ virtualize dd.SET.5-ddd.SET.6
 ----
 bounds:  [dd#5,1-ddd#6,1]
 filenum: 000008
-props:   9,1
+props: NumEntries: 1, RawKeySize: 10, RawValueSize: 2, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 0
 
 # Check lower bound enforcement during SeekPrefixGE.
 iter
@@ -190,7 +190,7 @@ virtualize c.SET.3-f.SET.6
 ----
 bounds:  [c#3,1-f#6,1]
 filenum: 000010
-props:   8,0
+props: NumEntries: 1, RawKeySize: 9, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 0
 
 # Just test a basic iterator once virtual sstable bounds have been set.
 iter
@@ -290,7 +290,7 @@ virtualize c.SET.3-f.SET.1:ff
 ----
 bounds:  [c#3,1-f#0,1]
 filenum: 000012
-props:   10,1
+props: NumEntries: 2, RawKeySize: 11, RawValueSize: 2, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 3
 
 iter
 set-bounds lower=d upper=e
@@ -343,7 +343,7 @@ virtualize f.SET.6-h.SET.9
 ----
 bounds:  [f#6,1-h#9,1]
 filenum: 000013
-props:   10,1
+props: NumEntries: 2, RawKeySize: 11, RawValueSize: 2, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 3
 
 iter
 seek-lt z
@@ -382,7 +382,7 @@ virtualize dd.SET.5-ddd.SET.6
 ----
 bounds:  [dd#5,1-ddd#6,1]
 filenum: 000015
-props:   3,0
+props: NumEntries: 1, RawKeySize: 4, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 0
 
 # Check lower bound enforcement during SeekPrefixGE.
 iter
@@ -413,7 +413,7 @@ virtualize c.SET.3-f.SET.6
 ----
 bounds:  [c#3,1-f#6,1]
 filenum: 000017
-props:   6,0
+props: NumEntries: 1, RawKeySize: 7, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 0
 
 # Just test a basic iterator once virtual sstable bounds have been set.
 iter
@@ -513,7 +513,7 @@ virtualize c.SET.3-f.SET.1:ff
 ----
 bounds:  [c#3,1-f#0,1]
 filenum: 000019
-props:   6,0
+props: NumEntries: 1, RawKeySize: 7, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 2
 
 iter
 set-bounds lower=d upper=e
@@ -566,7 +566,7 @@ virtualize f.SET.6-h.SET.9
 ----
 bounds:  [f#6,1-h#9,1]
 filenum: 000020
-props:   6,0
+props: NumEntries: 1, RawKeySize: 7, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 2
 
 iter
 seek-lt z
@@ -605,7 +605,7 @@ virtualize a.SET.1-e.RANGEDEL.72057594037927935
 ----
 bounds:  [a#1,1-e#72057594037927935,15]
 filenum: 000022
-props:   3,0
+props: NumEntries: 1, RawKeySize: 4, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 1, NumRangeDeletions: 1, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 0
 
 iter
 first
@@ -644,7 +644,7 @@ virtualize a.SET.1-e.RANGEDEL.72057594037927935
 ----
 bounds:  [a#1,1-e#72057594037927935,15]
 filenum: 000024
-props:   3,0
+props: NumEntries: 1, RawKeySize: 4, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 1, NumRangeDeletions: 1, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 0
 
 iter
 first
@@ -666,3 +666,27 @@ d#2,1:d
 scan-range-del
 ----
 d-e:{(#4,RANGEDEL)}
+
+# Test NumRangeKeySets.
+build twoLevel
+a.SET.1:a
+b.SET.5:b
+d.SET.2:d
+f.SET.3:f
+d.RANGEDEL.4:e
+rangekey: a-d:{(#11,RANGEKEYSET,@t10,foo)}
+g.RANGEDEL.5:l
+rangekey: y-z:{(#12,RANGEKEYSET,@t11,foo)}
+----
+point:    [a#1,1-f#3,1]
+rangedel: [d#4,15-l#72057594037927935,15]
+rangekey: [a#11,21-z#72057594037927935,21]
+seqnums:  [1-12]
+
+# Virtual sstable doesn't contain range key set, but NumRangeKeySets in the
+# properties must be > 0.
+virtualize a.SET.1-b.SET.5
+----
+bounds:  [a#1,1-b#5,1]
+filenum: 000026
+props: NumEntries: 1, RawKeySize: 3, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 1, NumRangeDeletions: 1, NumRangeKeyDels: 0, NumRangeKeySets: 1, ValueBlocksSize: 0

--- a/table_stats.go
+++ b/table_stats.go
@@ -186,14 +186,9 @@ func (d *DB) loadNewFileStats(
 			continue
 		}
 
-		if nf.Meta.Virtual {
-			// cannot load virtual table stats
-			continue
-		}
-
 		stats, newHints, err := d.loadTableStats(
 			rs.current, nf.Level,
-			nf.Meta.PhysicalMeta(),
+			nf.Meta,
 		)
 		if err != nil {
 			d.opts.EventListener.BackgroundError(err)
@@ -222,23 +217,12 @@ func (d *DB) scanReadStateTableStats(
 	for l, levelMetadata := range rs.current.Levels {
 		iter := levelMetadata.Iter()
 		for f := iter.First(); f != nil; f = iter.Next() {
-			if f.Virtual {
-				// TODO(bananabrick): Support stats collection for virtual
-				// sstables.
-				continue
-			}
-
 			// NB: We're not holding d.mu which protects f.Stats, but only the
 			// active stats collection job updates f.Stats for active files,
 			// and we ensure only one goroutine runs it at a time through
 			// d.mu.tableStats.loading. This makes it safe to read validity
 			// through f.Stats.ValidLocked despite not holding d.mu.
 			if f.StatsValid() {
-				continue
-			}
-			// TODO(bilal): Remove this guard when table stats collection is
-			// implemented for virtual sstables.
-			if f.Virtual {
 				continue
 			}
 
@@ -253,7 +237,7 @@ func (d *DB) scanReadStateTableStats(
 			}
 
 			stats, newHints, err := d.loadTableStats(
-				rs.current, l, f.PhysicalMeta(),
+				rs.current, l, f,
 			)
 			if err != nil {
 				// Set `moreRemain` so we'll try again.
@@ -271,25 +255,22 @@ func (d *DB) scanReadStateTableStats(
 	return fill, hints, moreRemain
 }
 
-// loadTableStats currently only supports stats collection for physical
-// sstables.
-//
-// TODO(bananabrick): Support stats collection for virtual sstables.
 func (d *DB) loadTableStats(
-	v *version, level int, meta physicalMeta,
+	v *version, level int, meta *fileMetadata,
 ) (manifest.TableStats, []deleteCompactionHint, error) {
 	var stats manifest.TableStats
 	var compactionHints []deleteCompactionHint
-	err := d.tableCache.withReader(
-		meta, func(r *sstable.Reader) (err error) {
-			stats.NumEntries = r.Properties.NumEntries
-			stats.NumDeletions = r.Properties.NumDeletions
-			if r.Properties.NumPointDeletions() > 0 {
-				if err = d.loadTablePointKeyStats(r, v, level, meta, &stats); err != nil {
+	err := d.tableCache.withCommonReader(
+		meta, func(r sstable.CommonReader) (err error) {
+			props := r.CommonProperties()
+			stats.NumEntries = props.NumEntries
+			stats.NumDeletions = props.NumDeletions
+			if props.NumPointDeletions() > 0 {
+				if err = d.loadTablePointKeyStats(props, v, level, meta, &stats); err != nil {
 					return
 				}
 			}
-			if r.Properties.NumRangeDeletions > 0 || r.Properties.NumRangeKeyDels > 0 {
+			if props.NumRangeDeletions > 0 || props.NumRangeKeyDels > 0 {
 				if compactionHints, err = d.loadTableRangeDelStats(
 					r, v, level, meta, &stats,
 				); err != nil {
@@ -299,8 +280,8 @@ func (d *DB) loadTableStats(
 			// TODO(travers): Once we have real-world data, consider collecting
 			// additional stats that may provide improved heuristics for compaction
 			// picking.
-			stats.NumRangeKeySets = r.Properties.NumRangeKeySets
-			stats.ValueBlocksSize = r.Properties.ValueBlocksSize
+			stats.NumRangeKeySets = props.NumRangeKeySets
+			stats.ValueBlocksSize = props.ValueBlocksSize
 			return
 		})
 	if err != nil {
@@ -312,7 +293,11 @@ func (d *DB) loadTableStats(
 // loadTablePointKeyStats calculates the point key statistics for the given
 // table. The provided manifest.TableStats are updated.
 func (d *DB) loadTablePointKeyStats(
-	r *sstable.Reader, v *version, level int, meta physicalMeta, stats *manifest.TableStats,
+	props *sstable.CommonProperties,
+	v *version,
+	level int,
+	meta *fileMetadata,
+	stats *manifest.TableStats,
 ) error {
 	// TODO(jackson): If the file has a wide keyspace, the average
 	// value size beneath the entire file might not be representative
@@ -320,21 +305,21 @@ func (d *DB) loadTablePointKeyStats(
 	// We could write the ranges of 'clusters' of point tombstones to
 	// a sstable property and call averageValueSizeBeneath for each of
 	// these narrower ranges to improve the estimate.
-	avgValLogicalSize, compressionRatio, err := d.estimateSizesBeneath(v, level, meta)
+	avgValLogicalSize, compressionRatio, err := d.estimateSizesBeneath(v, level, meta, props)
 	if err != nil {
 		return err
 	}
 	stats.PointDeletionsBytesEstimate =
-		pointDeletionsBytesEstimate(meta.Size, &r.Properties, avgValLogicalSize, compressionRatio)
+		pointDeletionsBytesEstimate(meta.Size, props, avgValLogicalSize, compressionRatio)
 	return nil
 }
 
 // loadTableRangeDelStats calculates the range deletion and range key deletion
 // statistics for the given table.
 func (d *DB) loadTableRangeDelStats(
-	r *sstable.Reader, v *version, level int, meta physicalMeta, stats *manifest.TableStats,
+	r sstable.CommonReader, v *version, level int, meta *fileMetadata, stats *manifest.TableStats,
 ) ([]deleteCompactionHint, error) {
-	iter, err := newCombinedDeletionKeyspanIter(d.opts.Comparer, r, meta.FileMetadata)
+	iter, err := newCombinedDeletionKeyspanIter(d.opts.Comparer, r, meta)
 	if err != nil {
 		return nil, err
 	}
@@ -423,7 +408,7 @@ func (d *DB) loadTableRangeDelStats(
 			hintType:                hintType,
 			start:                   make([]byte, len(start)),
 			end:                     make([]byte, len(end)),
-			tombstoneFile:           meta.FileMetadata,
+			tombstoneFile:           meta,
 			tombstoneLevel:          level,
 			tombstoneLargestSeqNum:  s.LargestSeqNum(),
 			tombstoneSmallestSeqNum: s.SmallestSeqNum(),
@@ -437,12 +422,21 @@ func (d *DB) loadTableRangeDelStats(
 }
 
 func (d *DB) estimateSizesBeneath(
-	v *version, level int, meta physicalMeta,
+	v *version, level int, meta *fileMetadata, fileProps *sstable.CommonProperties,
 ) (avgValueLogicalSize, compressionRatio float64, err error) {
 	// Find all files in lower levels that overlap with meta,
 	// summing their value sizes and entry counts.
-	file := meta.FileMetadata
+	file := meta
 	var fileSum, keySum, valSum, entryCount uint64
+	// Include the file itself. This is important because in some instances, the
+	// computed compression ratio is applied to the tombstones contained within
+	// `meta` itself. If there are no files beneath `meta` in the LSM, we would
+	// calculate a compression ratio of 0 which is not accurate for the file's
+	// own tombstones.
+	fileSum += file.Size
+	entryCount += fileProps.NumEntries
+	keySum += fileProps.RawKeySize
+	valSum += fileProps.RawValueSize
 
 	addPhysicalTableStats := func(r *sstable.Reader) (err error) {
 		fileSum += file.Size
@@ -457,15 +451,6 @@ func (d *DB) estimateSizesBeneath(
 		keySum += v.Properties.RawKeySize
 		valSum += v.Properties.RawValueSize
 		return nil
-	}
-
-	// Include the file itself. This is important because in some instances, the
-	// computed compression ratio is applied to the tombstones contained within
-	// `meta` itself. If there are no files beneath `meta` in the LSM, we would
-	// calculate a compression ratio of 0 which is not accurate for the file's
-	// own tombstones.
-	if err = d.tableCache.withReader(meta, addPhysicalTableStats); err != nil {
-		return 0, 0, err
 	}
 
 	for l := level + 1; l < numLevels; l++ {
@@ -637,8 +622,9 @@ func maybeSetStatsFromProperties(meta physicalMeta, props *sstable.Properties) b
 		// doesn't require any additional IO and since the number of point
 		// deletions in the file is low, the error introduced by this crude
 		// estimate is expected to be small.
-		avgValSize, compressionRatio := estimatePhysicalSizes(meta.Size, props)
-		pointEstimate = pointDeletionsBytesEstimate(meta.Size, props, avgValSize, compressionRatio)
+		commonProps := &props.CommonProperties
+		avgValSize, compressionRatio := estimatePhysicalSizes(meta.Size, commonProps)
+		pointEstimate = pointDeletionsBytesEstimate(meta.Size, commonProps, avgValSize, compressionRatio)
 	}
 
 	meta.Stats.NumEntries = props.NumEntries
@@ -652,7 +638,7 @@ func maybeSetStatsFromProperties(meta physicalMeta, props *sstable.Properties) b
 }
 
 func pointDeletionsBytesEstimate(
-	fileSize uint64, props *sstable.Properties, avgValLogicalSize, compressionRatio float64,
+	fileSize uint64, props *sstable.CommonProperties, avgValLogicalSize, compressionRatio float64,
 ) (estimate uint64) {
 	if props.NumEntries == 0 {
 		return 0
@@ -675,7 +661,7 @@ func pointDeletionsBytesEstimate(
 	// tombstones' encoded values.
 	//
 	// For un-sized point tombstones (DELs), we estimate assuming that each
-	// point tombstone on average covers 1 key and using average vaue sizes.
+	// point tombstone on average covers 1 key and using average value sizes.
 	// This is almost certainly an overestimate, but that's probably okay
 	// because point tombstones can slow range iterations even when they don't
 	// cover a key.
@@ -739,7 +725,7 @@ func pointDeletionsBytesEstimate(
 }
 
 func estimatePhysicalSizes(
-	fileSize uint64, props *sstable.Properties,
+	fileSize uint64, props *sstable.CommonProperties,
 ) (avgValLogicalSize, compressionRatio float64) {
 	// RawKeySize and RawValueSize are uncompressed totals. Scale according to
 	// the data size to account for compression, index blocks and metadata
@@ -812,7 +798,7 @@ func estimatePhysicalSizes(
 // corresponding to the largest and smallest sequence numbers encountered across
 // the range deletes and range keys deletes that comprised the merged spans.
 func newCombinedDeletionKeyspanIter(
-	comparer *base.Comparer, r *sstable.Reader, m *fileMetadata,
+	comparer *base.Comparer, cr sstable.CommonReader, m *fileMetadata,
 ) (keyspan.FragmentIterator, error) {
 	// The range del iter and range key iter are each wrapped in their own
 	// defragmenting iter. For each iter, abutting spans can always be merged.
@@ -874,7 +860,7 @@ func newCombinedDeletionKeyspanIter(
 	})
 	mIter.Init(comparer.Compare, transform, new(keyspan.MergingBuffers))
 
-	iter, err := r.NewRawRangeDelIter()
+	iter, err := cr.NewRawRangeDelIter()
 	if err != nil {
 		return nil, err
 	}
@@ -891,7 +877,7 @@ func newCombinedDeletionKeyspanIter(
 		mIter.AddLevel(iter)
 	}
 
-	iter, err = r.NewRawRangeKeyIter()
+	iter, err = cr.NewRawRangeKeyIter()
 	if err != nil {
 		return nil, err
 	}

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -22,11 +22,10 @@ import (
 )
 
 func TestTableStats(t *testing.T) {
-	fs := vfs.NewMem()
 	// loadedInfo is protected by d.mu.
 	var loadedInfo *TableStatsInfo
 	opts := &Options{
-		FS: fs,
+		FS: vfs.NewMem(),
 		EventListener: &EventListener{
 			TableStatsLoaded: func(info TableStatsInfo) {
 				loadedInfo = &info
@@ -129,8 +128,20 @@ func TestTableStats(t *testing.T) {
 			}
 			return buf.String()
 
+		case "lsm":
+			d.mu.Lock()
+			s := d.mu.versions.currentVersion().String()
+			d.mu.Unlock()
+			return s
+
+		case "build":
+			if err := runBuildCmd(td, d, d.opts.FS); err != nil {
+				return err.Error()
+			}
+			return ""
+
 		case "ingest-and-excise":
-			if err := runIngestAndExciseCmd(td, d, fs); err != nil {
+			if err := runIngestAndExciseCmd(td, d, d.opts.FS); err != nil {
 				return err.Error()
 			}
 			// Wait for a possible flush.
@@ -163,6 +174,11 @@ func TestTableStats(t *testing.T) {
 			s := d.mu.versions.currentVersion().String()
 			d.mu.Unlock()
 			return s
+
+		case "metadata-stats":
+			// Prints some metadata about some sstable which is currently in the
+			// latest version.
+			return runMetadataCommand(t, td, d)
 
 		case "properties":
 			return runSSTablePropertiesCmd(t, td, d)

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -129,6 +129,18 @@ func TestTableStats(t *testing.T) {
 			}
 			return buf.String()
 
+		case "ingest-and-excise":
+			if err := runIngestAndExciseCmd(td, d, fs); err != nil {
+				return err.Error()
+			}
+			// Wait for a possible flush.
+			d.mu.Lock()
+			for d.mu.compact.flushing {
+				d.mu.compact.cond.Wait()
+			}
+			d.mu.Unlock()
+			return ""
+
 		case "wait-pending-table-stats":
 			return runTableStatsCmd(td, d)
 

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -569,3 +569,343 @@ flush
 metric keys.missized-tombstones-count
 ----
 keys.missized-tombstones-count: 1
+
+# Virtual sstables tests. Note that these tests are just for sanity checking
+# purposes. Small sstables lead to inaccurate values during extrapolation.
+define format-major-version=16
+----
+
+batch
+set a 1
+set b 2
+del d
+----
+
+flush
+----
+0.0:
+  000005:[a#10,SET-d#12,DEL]
+
+metadata-stats file=5
+----
+size: 726
+
+# Just grab the physical sstable properties as these are used to construct the
+# virtual sstable properties.
+properties file=5
+rocksdb
+pebble
+----
+rocksdb:
+  rocksdb.num.entries: 3
+  rocksdb.raw.key.size: 27
+  rocksdb.raw.value.size: 2
+  rocksdb.deleted.keys: 1
+  rocksdb.num.range-deletions: 0
+  rocksdb.comparator: pebble.internal.testkeys
+  rocksdb.compression: Snappy
+  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
+  rocksdb.data.size: 53
+  rocksdb.filter.size: 0
+  rocksdb.index.size: 27
+  rocksdb.block.based.table.index.type: 0
+  rocksdb.merge.operator: pebble.concatenate
+  rocksdb.num.data.blocks: 1
+  rocksdb.merge.operands: 0
+  rocksdb.prefix.extractor.name: nullptr
+  rocksdb.block.based.table.prefix.filtering: false
+  rocksdb.property.collectors: [obsolete-key]
+  rocksdb.block.based.table.whole.key.filtering: false
+pebble:
+  pebble.raw.point-tombstone.key.size: 1
+  rocksdb.comparator: pebble.internal.testkeys
+  rocksdb.merge.operator: pebble.concatenate
+
+build ext1
+set f f
+----
+
+ingest-and-excise ext1 excise=b-c
+----
+
+lsm
+----
+0.0:
+  000007:[a#10,SET-a#10,SET]
+  000008:[d#12,DEL-d#12,DEL]
+6:
+  000006:[f#13,SET-f#13,SET]
+
+metadata-stats file=7
+----
+size: 53
+
+metadata-stats file=8
+----
+size: 53
+
+# Note that the backing file size is much larger than the virtual file sizes.
+# For tiny sstables, the metadata contained in the sstable is much larger than
+# the actual sizes.
+
+# While sstable 8 has no point tombstones, because of the nature of extrapolation
+# both file 7 and file 8 will have a point tombstone key size property. Because
+# of this both the files have a point deletion bytes estimate.
+properties file=7
+----
+rocksdb.num.entries: 1
+rocksdb.raw.key.size: 2
+rocksdb.raw.value.size: 1
+pebble.raw.point-tombstone.key.size: 1
+rocksdb.deleted.keys: 1
+
+properties file=8
+----
+rocksdb.num.entries: 1
+rocksdb.raw.key.size: 2
+rocksdb.raw.value.size: 1
+pebble.raw.point-tombstone.key.size: 1
+rocksdb.deleted.keys: 1
+
+wait-pending-table-stats
+000007
+----
+num-entries: 1
+num-deletions: 1
+num-range-key-sets: 0
+point-deletions-bytes-estimate: 53
+range-deletions-bytes-estimate: 0
+
+wait-pending-table-stats
+000008
+----
+num-entries: 1
+num-deletions: 1
+num-range-key-sets: 0
+point-deletions-bytes-estimate: 53
+range-deletions-bytes-estimate: 0
+
+# Create an sstable with a range key set.
+batch
+set a a
+set b b
+set d d
+range-key-set e ee @1 foo
+----
+
+flush
+----
+0.1:
+  000010:[a#14,SET-ee#inf,RANGEKEYSET]
+0.0:
+  000007:[a#10,SET-a#10,SET]
+  000008:[d#12,DEL-d#12,DEL]
+6:
+  000006:[f#13,SET-f#13,SET]
+
+properties file=10
+rocksdb
+pebble
+----
+rocksdb:
+  rocksdb.num.entries: 3
+  rocksdb.raw.key.size: 27
+  rocksdb.raw.value.size: 3
+  rocksdb.deleted.keys: 0
+  rocksdb.num.range-deletions: 0
+  rocksdb.comparator: pebble.internal.testkeys
+  rocksdb.compression: Snappy
+  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
+  rocksdb.data.size: 47
+  rocksdb.filter.size: 0
+  rocksdb.index.size: 27
+  rocksdb.block.based.table.index.type: 0
+  rocksdb.merge.operator: pebble.concatenate
+  rocksdb.num.data.blocks: 1
+  rocksdb.merge.operands: 0
+  rocksdb.prefix.extractor.name: nullptr
+  rocksdb.block.based.table.prefix.filtering: false
+  rocksdb.property.collectors: [obsolete-key]
+  rocksdb.block.based.table.whole.key.filtering: false
+pebble:
+  pebble.num.range-key-dels: 0
+  pebble.num.range-key-sets: 1
+  rocksdb.comparator: pebble.internal.testkeys
+  rocksdb.merge.operator: pebble.concatenate
+  pebble.num.range-key-unsets: 0
+  pebble.raw.range-key.key.size: 9
+  pebble.raw.range-key.value.size: 10
+
+metadata-stats file=10
+----
+size: 828
+
+build ext2
+set z z
+----
+
+ingest-and-excise ext2 excise=b-c
+----
+
+lsm
+----
+0.1:
+  000012:[a#14,SET-a#14,SET]
+  000013:[d#16,SET-ee#inf,RANGEKEYSET]
+0.0:
+  000007:[a#10,SET-a#10,SET]
+  000008:[d#12,DEL-d#12,DEL]
+6:
+  000006:[f#13,SET-f#13,SET]
+  000011:[z#18,SET-z#18,SET]
+
+metadata-stats file=12
+----
+size: 47
+
+metadata-stats file=13
+----
+size: 47
+
+# range key sets shows up for both files. This is expected.
+properties file=12
+----
+rocksdb.num.entries: 1
+rocksdb.raw.key.size: 2
+rocksdb.raw.value.size: 1
+pebble.num.range-key-sets: 1
+
+properties file=13
+----
+rocksdb.num.entries: 1
+rocksdb.raw.key.size: 2
+rocksdb.raw.value.size: 1
+pebble.num.range-key-sets: 1
+
+wait-pending-table-stats
+000012
+----
+num-entries: 1
+num-deletions: 0
+num-range-key-sets: 1
+point-deletions-bytes-estimate: 0
+range-deletions-bytes-estimate: 0
+
+wait-pending-table-stats
+000013
+----
+num-entries: 1
+num-deletions: 0
+num-range-key-sets: 1
+point-deletions-bytes-estimate: 0
+range-deletions-bytes-estimate: 0
+
+# Create an sstable with range deletes to view the range delete byte estimates.
+
+# Compact everything to L6. Range deletion bytes estimate doesn't account for
+# bytes in L0.
+compact a-z
+----
+6:
+  000014:[a#0,SET-a#0,SET]
+  000015:[d#0,SETWITHDEL-d#0,SETWITHDEL]
+  000016:[e#17,RANGEKEYSET-ee#inf,RANGEKEYSET]
+  000006:[f#13,SET-f#13,SET]
+  000011:[z#18,SET-z#18,SET]
+
+batch
+del-range a e
+----
+
+flush
+----
+0.0:
+  000018:[a#19,RANGEDEL-e#inf,RANGEDEL]
+6:
+  000014:[a#0,SET-a#0,SET]
+  000015:[d#0,SETWITHDEL-d#0,SETWITHDEL]
+  000016:[e#17,RANGEKEYSET-ee#inf,RANGEKEYSET]
+  000006:[f#13,SET-f#13,SET]
+  000011:[z#18,SET-z#18,SET]
+
+properties file=18
+rocksdb
+pebble
+----
+rocksdb:
+  rocksdb.num.entries: 1
+  rocksdb.raw.key.size: 9
+  rocksdb.raw.value.size: 1
+  rocksdb.deleted.keys: 1
+  rocksdb.num.range-deletions: 1
+  rocksdb.comparator: pebble.internal.testkeys
+  rocksdb.compression: Snappy
+  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
+  rocksdb.data.size: 13
+  rocksdb.filter.size: 0
+  rocksdb.index.size: 29
+  rocksdb.block.based.table.index.type: 0
+  rocksdb.merge.operator: pebble.concatenate
+  rocksdb.num.data.blocks: 1
+  rocksdb.merge.operands: 0
+  rocksdb.prefix.extractor.name: nullptr
+  rocksdb.block.based.table.prefix.filtering: false
+  rocksdb.property.collectors: [obsolete-key]
+  rocksdb.block.based.table.whole.key.filtering: false
+pebble:
+  rocksdb.comparator: pebble.internal.testkeys
+  rocksdb.merge.operator: pebble.concatenate
+
+build ext3
+set zz zz
+----
+
+ingest-and-excise ext3 excise=b-c
+----
+
+lsm
+----
+0.0:
+  000020:[a#19,RANGEDEL-b#inf,RANGEDEL]
+  000021:[c#19,RANGEDEL-e#inf,RANGEDEL]
+6:
+  000014:[a#0,SET-a#0,SET]
+  000015:[d#0,SETWITHDEL-d#0,SETWITHDEL]
+  000016:[e#17,RANGEKEYSET-ee#inf,RANGEKEYSET]
+  000006:[f#13,SET-f#13,SET]
+  000011:[z#18,SET-z#18,SET]
+  000019:[zz#20,SET-zz#20,SET]
+
+properties file=20
+----
+rocksdb.num.entries: 1
+rocksdb.raw.key.size: 1
+rocksdb.raw.value.size: 1
+rocksdb.deleted.keys: 1
+rocksdb.num.range-deletions: 1
+
+properties file=21
+----
+rocksdb.num.entries: 1
+rocksdb.raw.key.size: 1
+rocksdb.raw.value.size: 1
+rocksdb.deleted.keys: 1
+rocksdb.num.range-deletions: 1
+
+wait-pending-table-stats
+000020
+----
+num-entries: 1
+num-deletions: 1
+num-range-key-sets: 0
+point-deletions-bytes-estimate: 0
+range-deletions-bytes-estimate: 661
+
+wait-pending-table-stats
+000021
+----
+num-entries: 1
+num-deletions: 1
+num-range-key-sets: 0
+point-deletions-bytes-estimate: 0
+range-deletions-bytes-estimate: 660

--- a/tool/testdata/sstable_properties
+++ b/tool/testdata/sstable_properties
@@ -129,6 +129,11 @@ sstable properties
 ../sstable/testdata/h.no-compression.two_level_index.sst
 ----
 h.no-compression.two_level_index.sst
+rocksdb.num.entries: 1727
+rocksdb.raw.key.size: 23938
+rocksdb.raw.value.size: 1912
+rocksdb.deleted.keys: 17
+rocksdb.num.range-deletions: 17
 rocksdb.comparator: leveldb.BytewiseComparator
 rocksdb.compression: NoCompression
 rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
@@ -141,15 +146,10 @@ rocksdb.index.size: 408
 rocksdb.block.based.table.index.type: 2
 rocksdb.merge.operator: nullptr
 rocksdb.num.data.blocks: 14
-rocksdb.deleted.keys: 17
-rocksdb.num.entries: 1727
 rocksdb.merge.operands: 0
-rocksdb.num.range-deletions: 17
 rocksdb.prefix.extractor.name: nullptr
 rocksdb.block.based.table.prefix.filtering: false
 rocksdb.property.collectors: [KeyCountPropertyCollector]
-rocksdb.raw.key.size: 23938
-rocksdb.raw.value.size: 1912
 rocksdb.top-level.index.size: 70
 rocksdb.block.based.table.whole.key.filtering: false
 test.key-count: 1727
@@ -162,6 +162,11 @@ sstable properties
 testdata/find-db/archive/000011.sst
 ----
 000011.sst
+rocksdb.num.entries: 8
+rocksdb.raw.key.size: 88
+rocksdb.raw.value.size: 13
+rocksdb.deleted.keys: 2
+rocksdb.num.range-deletions: 1
 rocksdb.comparator: alt-comparer
 rocksdb.compression: Snappy
 rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
@@ -171,15 +176,10 @@ rocksdb.index.size: 27
 rocksdb.block.based.table.index.type: 0
 rocksdb.merge.operator: test-merger
 rocksdb.num.data.blocks: 1
-rocksdb.deleted.keys: 2
-rocksdb.num.entries: 8
 rocksdb.merge.operands: 1
-rocksdb.num.range-deletions: 1
 rocksdb.prefix.extractor.name: nullptr
 rocksdb.block.based.table.prefix.filtering: false
 rocksdb.property.collectors: []
-rocksdb.raw.key.size: 88
-rocksdb.raw.value.size: 13
 rocksdb.block.based.table.whole.key.filtering: false
 
 sstable properties


### PR DESCRIPTION
Currently, virtual sstables lack stats unless they're set upon
creation. Even if these stats are set upon creation, they will
be lost upon a db restart.

This pr adds support to compute virtual sstable table stats
asynchronously.

To easily support this with minimal code changes, we introduce a
CommonReader interface meant to be used by those who don't care
if they're reading from a virtual or a physical sstable.

To support the CommonReader, we introduce a CommonProps type which
contains either virtual or physical sstable properties which are
useful to the users of the CommonReader.

Fixes: https://github.com/cockroachdb/pebble/issues/2558