### PR TITLE
db: wire virtual sstable space amp heuristic

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1079,9 +1079,10 @@ func pickCompactionSeedFile(
 	vers *version, opts *Options, level, outputLevel int, earliestSnapshotSeqNum uint64,
 ) (manifest.LevelFile, bool) {
 	// Select the file within the level to compact. We want to minimize write
-	// amplification, but also ensure that deletes are propagated to the
-	// bottom level in a timely fashion so as to reclaim disk space. A table's
-	// smallest sequence number provides a measure of its age. The ratio of
+	// amplification, ensure that deletes are propagated to the bottom level in
+	// a timely fashion so as to reclaim disk space, and also ensure that virtual
+	// sstable's which are contributing to a high space amplification are compacted.
+	// A table's smallest sequence number provides a measure of its age. The ratio of
 	// overlapping-bytes / table-size gives an indication of write
 	// amplification (a smaller ratio is preferrable).
 	//
@@ -1089,12 +1090,18 @@ func pickCompactionSeedFile(
 	// heuristic. It chooses the file with the minimum overlapping ratio with
 	// the target level, which minimizes write amplification.
 	//
-	// It uses a "compensated size" for the denominator, which is the file
-	// size but artificially inflated by an estimate of the space that may be
-	// reclaimed through compaction. Currently, we only compensate for range
-	// deletions and only with a rough estimate of the reclaimable bytes. This
-	// differs from RocksDB which only compensates for point tombstones and
-	// only if they exceed the number of non-deletion entries in table.
+	// It uses a "compensated size" + "virtual space amp" for the denominator.
+	// 
+	// "compensated size" is the file size but artificially inflated by an estimate
+	// of the space that may be reclaimed through compaction. Currently, we only
+	// compensate for range deletions and only with a rough estimate of the
+	// reclaimable bytes. This differs from RocksDB which only compensates for
+	// point tombstones and only if they exceed the number of non-deletion entries
+	// in table.
+	//
+	// "virtual space amp" is the contribution to space amplification due to a
+	// virtual sstable. See the comment above FileBacking.VirtualizedSize to
+	// see how this is computed.
 	//
 	// TODO(peter): For concurrent compactions, we may want to try harder to
 	// pick a seed file whose resulting compaction bounds do not overlap with
@@ -1182,7 +1189,7 @@ func pickCompactionSeedFile(
 		}
 
 		compSz := compensatedSize(f)
-		scaledRatio := overlappingBytes * 1024 / compSz
+		scaledRatio := overlappingBytes * 1024 / (compSz + f.VirtualSpaceAmpProportion())
 		if scaledRatio < smallestRatio {
 			smallestRatio = scaledRatio
 			file = startIter.Take()

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -1326,6 +1326,7 @@ func TestCompactionPickerCompensatedSize(t *testing.T) {
 	}
 }
 
+// TODO(bananabrick): Add tests for virtual sstable file picking here.
 func TestCompactionPickerPickFile(t *testing.T) {
 	fs := vfs.NewMem()
 	opts := &Options{

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -365,9 +365,6 @@ type FileBacking struct {
 	// The intuition is that if FileBacking.Size - FileBacking.VirtualizedSize
 	// is high, then the space amplification due to virtual sstables is
 	// high, and we should pick the virtual sstable with a higher priority.
-	//
-	// TODO(bananabrick): Compensate the virtual sstable file size using
-	// the VirtualizedSize during compaction picking and test.
 	VirtualizedSize atomic.Uint64
 	DiskFileNum     base.DiskFileNum
 	Size            uint64
@@ -451,6 +448,18 @@ func (m *FileMetadata) LatestRef() {
 	if m.Virtual {
 		m.FileBacking.VirtualizedSize.Add(m.Size)
 	}
+}
+
+// VirtualSpaceAmpProportion computes a virtual sstable's contribution to space
+// amplification. See comment above FileBacking.VirtualizedSize for the
+// reasoning behind this computation.
+func (m *FileMetadata) VirtualSpaceAmpProportion() uint64 {
+	if !m.Virtual {
+		return 0
+	}
+	virtualizedSize := m.FileBacking.VirtualizedSize.Load()
+	latestRefs := m.LatestRefs()
+	return (m.FileBacking.Size - virtualizedSize) / uint64(latestRefs)
 }
 
 // LatestUnref decrements the latest ref count associated with the backing


### PR DESCRIPTION
We compute the space used by the backing file, the virtual files for which have already been compacted.

Then, we divide this by the number of virtual sstables which have this backing file to get a given virtual sstable's contribution to the space amp, `VirtualSpaceAmpProportion`.

Then in pickCompactionSeedFile, we divide the overlapping ratio by compensated size + `VirtualSpaceAmpProportion`.

The larger the virtual space amp proportion the more likely it is that the file gets picked for compaction.

Fixes: https://github.com/cockroachdb/pebble/issues/2323