### PR TITLE
pebble: export bucketing scheme used for secondary cache

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -300,6 +300,13 @@ var (
 		prometheus.LinearBuckets(0.0, float64(time.Microsecond*100), 50),
 		prometheus.ExponentialBucketsRange(float64(time.Millisecond*5), float64(10*time.Second), 50)...,
 	)
+
+	// SecondaryCacheIOBuckets exported to enable exporting from package pebble to
+	// enable exporting metrics with below buckets in CRDB.
+	SecondaryCacheIOBuckets = sharedcache.IOBuckets
+	// SecondaryCacheChannelWriteBuckets exported to enable exporting from package
+	// pebble to enable exporting metrics with below buckets in CRDB.
+	SecondaryCacheChannelWriteBuckets = sharedcache.ChannelWriteBuckets
 )
 
 // DiskSpaceUsage returns the total disk space used by the database in bytes,


### PR DESCRIPTION
This is needed to follow up on https://github.com/cockroachdb/cockroach/pull/110818 & complete the metrics work.

**pebble: export bucketing scheme used for secondary cache**

This commit exports the bucketing scheme used for histograms exported by the secondary cache, to enable exporting said metrics in CRDB itself.