### PR TITLE
db: by default don't log to standard output

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -12,20 +12,10 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/errorfs"
 	"github.com/stretchr/testify/require"
 )
-
-type panicLogger struct{}
-
-func (l panicLogger) Infof(format string, args ...interface{}) {
-}
-
-func (l panicLogger) Fatalf(format string, args ...interface{}) {
-	panic(errors.Errorf("fatal: "+format, args...))
-}
 
 // corruptFS injects a corruption in the `index`th byte read.
 type corruptFS struct {

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -788,7 +788,7 @@ func TestIngestShared(t *testing.T) {
 			FormatMajorVersion:    ExperimentalFormatVirtualSSTables,
 		}
 		// lel.
-		lel := MakeLoggingEventListener(DefaultLogger)
+		lel := MakeLoggingEventListener(testLogger{t})
 		opts1.EventListener = &lel
 		opts1.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"": sstorage,
@@ -1259,7 +1259,7 @@ func TestConcurrentExcise(t *testing.T) {
 			FormatMajorVersion:    ExperimentalFormatVirtualSSTables,
 		}
 		// lel.
-		lel := MakeLoggingEventListener(DefaultLogger)
+		lel := MakeLoggingEventListener(testLogger{t})
 		tel := TeeEventListener(lel, el)
 		opts1.EventListener = &tel
 		opts1.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -201,6 +201,7 @@ func defaultOptions() *pebble.Options {
 		Levels: []pebble.LevelOptions{{
 			FilterPolicy: bloom.FilterPolicy(10),
 		}},
+		Logger: pebble.DefaultLogger,
 	}
 	opts.EnsureDefaults()
 	return opts

--- a/options.go
+++ b/options.go
@@ -1038,7 +1038,7 @@ func (o *Options) EnsureDefaults() *Options {
 		}
 	}
 	if o.Logger == nil {
-		o.Logger = DefaultLogger
+		o.Logger = panicLogger{}
 	}
 	if o.EventListener == nil {
 		o.EventListener = &EventListener{}
@@ -1705,4 +1705,13 @@ func (o *Options) MakeWriterOptions(level int, format sstable.TableFormat) sstab
 	writerOpts.FilterType = levelOpts.FilterType
 	writerOpts.IndexBlockSize = levelOpts.IndexBlockSize
 	return writerOpts
+}
+
+type panicLogger struct{}
+
+func (l panicLogger) Infof(format string, args ...interface{}) {
+}
+
+func (l panicLogger) Fatalf(format string, args ...interface{}) {
+	panic(errors.Errorf("fatal: "+format, args...))
 }


### PR DESCRIPTION
Previously, by default an Options struct without a set Logger would default to logging to stdout using Go's standard library logging. This made unit tests particularly verbose. This is a backwards incompatible change, and to restore previous behavior clients that leave Logger unset should explicitly set it to pebble.DefaultLogger.