### PR TITLE
metamorphic: add variant that constructs many versions

### DIFF
--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -165,7 +165,7 @@ func RunAndCompare(t *testing.T, rootDir string, rOpts ...RunOption) {
 	// Generate a new set of random ops, writing them to <dir>/ops. These will be
 	// read by the child processes when performing a test run.
 	km := newKeyManager()
-	cfg := defaultConfig()
+	cfg := presetConfigs[rng.Intn(len(presetConfigs))]
 	if runOpts.previousOpsPath != "" {
 		// During cross-version testing, we load keys from an `ops` file
 		// produced by a metamorphic test run of an earlier Pebble version.


### PR DESCRIPTION
Previously, the metamorphic test always generated operations according to a fixed distribution. This commit adds a second configuration and adjusts the test to randomly chose between available configurations. The new configuration strongly prefers generating versions of existing key prefixes when generating a new key. Additionally, it generates significantly fewer deletion write operations in order to allow a test run to accumulate a more sizable working set of live keys.

This new configuration is sufficient to exercise all the non-error cases within the ssblock nextPrefix code paths (#2921).

The overall impact on metamorphic test code coverage is minor, moving from 67.3% to 67.7%.

Close #2921.
Informs #2041.