### PR TITLE
metamorphic: fix block property collectors integration

### DIFF
--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/randvar"
 	"github.com/cockroachdb/pebble/internal/testkeys"
@@ -410,8 +409,11 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 	optionsData, err := os.ReadFile(optionsPath)
 	require.NoError(t, err)
 
-	opts := &pebble.Options{}
-	testOpts := &TestOptions{Opts: opts}
+	// NB: It's important to use defaultTestOptions() here as the base into
+	// which we parse the serialized options. It contains the relevant defaults,
+	// like the appropriate block-property collectors.
+	testOpts := defaultTestOptions()
+	opts := testOpts.Opts
 	require.NoError(t, parseOptions(testOpts, string(optionsData), runOpts.customOptionParsers))
 
 	// Always use our custom comparer which provides a Split method, splitting

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -82,8 +82,14 @@ func parseOptions(
 				opts.threads = v
 				return true
 			case "TestOptions.disable_block_property_collector":
-				opts.disableBlockPropertyCollector = true
-				opts.Opts.BlockPropertyCollectors = nil
+				v, err := strconv.ParseBool(value)
+				if err != nil {
+					panic(err)
+				}
+				opts.disableBlockPropertyCollector = v
+				if v {
+					opts.Opts.BlockPropertyCollectors = nil
+				}
 				return true
 			case "TestOptions.enable_value_blocks":
 				opts.enableValueBlocks = true
@@ -132,6 +138,7 @@ func parseOptions(
 		},
 	}
 	err := opts.Opts.Parse(data, hooks)
+	opts.Opts.EnsureDefaults()
 	return err
 }
 
@@ -194,12 +201,10 @@ func optionsToString(opts *TestOptions) string {
 }
 
 func defaultTestOptions() *TestOptions {
-	o := &TestOptions{
+	return &TestOptions{
 		Opts:    defaultOptions(),
 		threads: 16,
 	}
-	o.Opts.BlockPropertyCollectors = blockPropertyCollectorConstructors
-	return o
 }
 
 func defaultOptions() *pebble.Options {
@@ -210,8 +215,8 @@ func defaultOptions() *pebble.Options {
 		Levels: []pebble.LevelOptions{{
 			FilterPolicy: bloom.FilterPolicy(10),
 		}},
+		BlockPropertyCollectors: blockPropertyCollectorConstructors,
 	}
-	opts.EnsureDefaults()
 	return opts
 }
 
@@ -421,9 +426,8 @@ func standardOptions() []*TestOptions {
 func randomOptions(
 	rng *rand.Rand, customOptionParsers map[string]func(string) (CustomOption, bool),
 ) *TestOptions {
-	var testOpts = &TestOptions{}
-	opts := defaultOptions()
-	testOpts.Opts = opts
+	testOpts := defaultTestOptions()
+	opts := testOpts.Opts
 
 	// There are some private options, which we don't want users to fiddle with.
 	// There's no way to set it through the public interface. The only method is
@@ -491,15 +495,20 @@ func randomOptions(
 	lopts.BlockSizeThreshold = 50 + rng.Intn(50)   // 50 - 100
 	lopts.IndexBlockSize = 1 << uint(rng.Intn(24)) // 1 - 16MB
 	lopts.TargetFileSize = 1 << uint(rng.Intn(28)) // 1 - 256MB
+
 	// We either use no bloom filter, the default filter, or a filter with
-	// randomized bits-per-key setting.
+	// randomized bits-per-key setting. We zero out the Filters map. It'll get
+	// repopulated on EnsureDefaults accordingly.
+	opts.Filters = nil
 	switch rng.Intn(3) {
 	case 0:
+		lopts.FilterPolicy = nil
 	case 1:
 		lopts.FilterPolicy = bloom.FilterPolicy(10)
 	default:
 		lopts.FilterPolicy = newTestingFilterPolicy(1 << rng.Intn(5))
 	}
+
 	// We use either no compression, snappy compression or zstd compression.
 	switch rng.Intn(3) {
 	case 0:
@@ -523,9 +532,9 @@ func randomOptions(
 	testOpts.ingestUsingApply = rng.Intn(2) != 0
 	testOpts.deleteSized = rng.Intn(2) != 0
 	testOpts.replaceSingleDelete = rng.Intn(2) != 0
-	testOpts.disableBlockPropertyCollector = rng.Intn(2) != 0
-	if !testOpts.disableBlockPropertyCollector {
-		testOpts.Opts.BlockPropertyCollectors = blockPropertyCollectorConstructors
+	testOpts.disableBlockPropertyCollector = rng.Intn(2) == 1
+	if testOpts.disableBlockPropertyCollector {
+		testOpts.Opts.BlockPropertyCollectors = nil
 	}
 	testOpts.enableValueBlocks = opts.FormatMajorVersion >= pebble.FormatSSTableValueBlocks &&
 		rng.Intn(2) != 0
@@ -550,7 +559,7 @@ func randomOptions(
 	testOpts.seedEFOS = rng.Uint64()
 	testOpts.ingestSplit = rng.Intn(2) == 0
 	opts.Experimental.IngestSplit = func() bool { return testOpts.ingestSplit }
-
+	testOpts.Opts.EnsureDefaults()
 	return testOpts
 }
 

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -6,12 +6,16 @@ package metamorphic
 
 import (
 	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
@@ -54,7 +58,7 @@ func TestSetupInitialState(t *testing.T) {
 }
 
 func TestOptionsRoundtrip(t *testing.T) {
-	// Some fields mut be ignored to avoid spurious diffs.
+	// Some fields must be ignored to avoid spurious diffs.
 	ignorePrefixes := []string{
 		// Pointers
 		"Cache:",
@@ -62,6 +66,7 @@ func TestOptionsRoundtrip(t *testing.T) {
 		"FS:",
 		"TableCache:",
 		// Function pointers
+		"BlockPropertyCollectors:",
 		"EventListener:",
 		"MaxConcurrentCompactions:",
 		"Experimental.EnableValueBlocks:",
@@ -82,11 +87,14 @@ func TestOptionsRoundtrip(t *testing.T) {
 
 	checkOptions := func(t *testing.T, o *TestOptions) {
 		s := optionsToString(o)
+		t.Logf("Serialized options:\n%s\n", s)
+
 		parsed := defaultTestOptions()
 		require.NoError(t, parseOptions(parsed, s, nil))
 		maybeUnref(parsed)
 		got := optionsToString(parsed)
 		require.Equal(t, s, got)
+		t.Logf("Re-serialized options:\n%s\n", got)
 
 		// In some options, the closure obscures the underlying value. Check
 		// that the return values are equal.
@@ -102,6 +110,7 @@ func TestOptionsRoundtrip(t *testing.T) {
 			require.Equal(t, o.Opts.Experimental.IngestSplit(), parsed.Opts.Experimental.IngestSplit())
 		}
 		require.Equal(t, o.Opts.MaxConcurrentCompactions(), parsed.Opts.MaxConcurrentCompactions())
+		require.Equal(t, len(o.Opts.BlockPropertyCollectors), len(parsed.Opts.BlockPropertyCollectors))
 
 		diff := pretty.Diff(o.Opts, parsed.Opts)
 		cleaned := diff[:0]
@@ -123,18 +132,72 @@ func TestOptionsRoundtrip(t *testing.T) {
 	standard := standardOptions()
 	for i := range standard {
 		t.Run(fmt.Sprintf("standard-%03d", i), func(t *testing.T) {
+			defer maybeUnref(standard[i])
 			checkOptions(t, standard[i])
-			maybeUnref(standard[i])
 		})
 	}
 	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 	for i := 0; i < 100; i++ {
 		t.Run(fmt.Sprintf("random-%03d", i), func(t *testing.T) {
 			o := randomOptions(rng, nil)
+			defer maybeUnref(o)
 			checkOptions(t, o)
-			maybeUnref(o)
 		})
 	}
+}
+
+// TestBlockPropertiesParse ensures that the testkeys block property collector
+// is in use by default. It runs a single OPTIONS run of the metamorphic tests
+// and scans the resulting data directory to ensure there's at least one sstable
+// with the property. It runs the test with the archive cleaner to avoid any
+// flakiness from small working sets of keys.
+func TestBlockPropertiesParse(t *testing.T) {
+	const fixedSeed = 1
+	const numOps = 10_000
+	metaDir := t.TempDir()
+
+	rng := rand.New(rand.NewSource(fixedSeed))
+	ops := generate(rng, numOps, presetConfigs[0], newKeyManager())
+	opsPath := filepath.Join(metaDir, "ops")
+	formattedOps := formatOps(ops)
+	require.NoError(t, os.WriteFile(opsPath, []byte(formattedOps), 0644))
+
+	runDir := filepath.Join(metaDir, "run")
+	require.NoError(t, os.MkdirAll(runDir, os.ModePerm))
+	optionsPath := filepath.Join(runDir, "OPTIONS")
+	opts := defaultTestOptions()
+	opts.Opts.EnsureDefaults()
+	opts.Opts.Cleaner = pebble.ArchiveCleaner{}
+	optionsStr := optionsToString(opts)
+	require.NoError(t, os.WriteFile(optionsPath, []byte(optionsStr), 0644))
+
+	RunOnce(t, runDir, fixedSeed, filepath.Join(runDir, "history"), KeepData{})
+	var foundTableBlockProperty bool
+	require.NoError(t, filepath.Walk(filepath.Join(runDir, "data"),
+		func(path string, info fs.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if filepath.Ext(path) != ".sst" {
+				return nil
+			}
+			f, err := vfs.Default.Open(path)
+			if err != nil {
+				return err
+			}
+			readable, err := sstable.NewSimpleReadable(f)
+			if err != nil {
+				return err
+			}
+			r, err := sstable.NewReader(readable, opts.Opts.MakeReaderOptions())
+			if err != nil {
+				return err
+			}
+			_, ok := r.Properties.UserProperties[opts.Opts.BlockPropertyCollectors[0]().Name()]
+			foundTableBlockProperty = foundTableBlockProperty || ok
+			return r.Close()
+		}))
+	require.True(t, foundTableBlockProperty)
 }
 
 func TestCustomOptionParser(t *testing.T) {


### PR DESCRIPTION
Fix a bug where the testkeys timestamp suffix block property collectors were unused. This is coverage that we had but was lost at some point.

I've added a focused unit test to cover this case. This increases overall meta-only test coverage from 67.9% to 68.6%.

Close #2931.