### PR TITLE
sharedcache: tolerate small sizes

### DIFF
--- a/objstorage/objstorageprovider/sharedcache/shared_cache.go
+++ b/objstorage/objstorageprovider/sharedcache/shared_cache.go
@@ -130,9 +130,10 @@ func Open(
 	sizeBytes int64,
 	numShards int,
 ) (*Cache, error) {
-	min := shardingBlockSize * int64(numShards)
-	if sizeBytes < min {
-		return nil, errors.Errorf("cache size %d lower than min %d", sizeBytes, min)
+	if minSize := shardingBlockSize * int64(numShards); sizeBytes < minSize {
+		// Up the size so that we have one block per shard. In practice, this should
+		// only happen in tests.
+		sizeBytes = minSize
 	}
 
 	c := &Cache{


### PR DESCRIPTION
Instead of erroring out when the cache size is too small given the number of shards, we up the size as needed.

Fixes #2935.