### PR TITLE
db: propagate Comparer into levelIter

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1340,7 +1340,7 @@ func (c *compaction) newInputIter(
 			// initRangeDel, the levelIter will close and forget the range
 			// deletion iterator when it steps on to a new file. Surfacing range
 			// deletions to compactions are handled below.
-			iters = append(iters, newLevelIter(iterOpts, c.cmp, nil /* split */, newIters,
+			iters = append(iters, newLevelIter(iterOpts, c.comparer, newIters,
 				level.files.Iter(), l, internalIterOpts{
 					bytesIterated: &c.bytesIterated,
 					bufferPool:    &c.bufferPool,
@@ -1914,7 +1914,7 @@ func (d *DB) runIngestFlush(c *compaction) (*manifest.VersionEdit, error) {
 		suggestSplit := d.opts.Experimental.IngestSplit != nil && d.opts.Experimental.IngestSplit() &&
 			d.FormatMajorVersion() >= FormatVirtualSSTables
 		level, fileToSplit, err = ingestTargetLevel(
-			d.newIters, d.tableNewRangeKeyIter, iterOpts, d.cmp,
+			d.newIters, d.tableNewRangeKeyIter, iterOpts, d.opts.Comparer,
 			c.version, baseLevel, d.mu.compact.inProgress, file.FileMetadata,
 			suggestSplit,
 		)

--- a/data_test.go
+++ b/data_test.go
@@ -1427,7 +1427,7 @@ func runForceIngestCmd(td *datadriven.TestData, d *DB) error {
 		tableNewIters,
 		keyspan.TableNewSpanIter,
 		IterOptions,
-		Compare,
+		*Comparer,
 		*version,
 		int,
 		map[*compaction]struct{},

--- a/db.go
+++ b/db.go
@@ -559,9 +559,7 @@ func (d *DB) getInternal(key []byte, b *Batch, s *Snapshot) ([]byte, io.Closer, 
 	get := &buf.get
 	*get = getIter{
 		logger:   d.opts.Logger,
-		cmp:      d.cmp,
-		equal:    d.equal,
-		split:    d.split,
+		comparer: d.opts.Comparer,
 		newIters: d.newIters,
 		snapshot: seqNum,
 		key:      key,
@@ -1418,8 +1416,7 @@ func (i *Iterator) constructPointIter(
 	addLevelIterForFiles := func(files manifest.LevelIterator, level manifest.Level) {
 		li := &levels[levelsIndex]
 
-		li.init(
-			ctx, i.opts, i.comparer.Compare, i.comparer.Split, i.newIters, files, level, internalOpts)
+		li.init(ctx, i.opts, &i.comparer, i.newIters, files, level, internalOpts)
 		li.initRangeDel(&mlevels[mlevelsIndex].rangeDelIter)
 		li.initBoundaryContext(&mlevels[mlevelsIndex].levelIterBoundaryContext)
 		li.initCombinedIterState(&i.lazyCombinedIter.combinedIterState)

--- a/flushable_test.go
+++ b/flushable_test.go
@@ -117,7 +117,7 @@ func TestIngestedSSTFlushableAPI(t *testing.T) {
 
 			meta := loadFileMeta(paths)
 			flushable = newIngestedFlushable(
-				meta, d.cmp, d.split, d.newIters, d.tableNewRangeKeyIter,
+				meta, d.opts.Comparer, d.newIters, d.tableNewRangeKeyIter,
 			)
 			return ""
 		case "iter":

--- a/get_iter.go
+++ b/get_iter.go
@@ -19,9 +19,7 @@ import (
 // lazily.
 type getIter struct {
 	logger       Logger
-	cmp          Compare
-	equal        Equal
-	split        Split
+	comparer     *Comparer
 	newIters     tableNewIters
 	snapshot     uint64
 	key          []byte
@@ -84,7 +82,7 @@ func (g *getIter) Next() (*InternalKey, base.LazyValue) {
 			// key. Every call to levelIter.Next() potentially switches to a new
 			// table and thus reinitializes rangeDelIter.
 			if g.rangeDelIter != nil {
-				g.tombstone = keyspan.Get(g.cmp, g.rangeDelIter, g.key)
+				g.tombstone = keyspan.Get(g.comparer.Compare, g.rangeDelIter, g.key)
 				if g.err = g.rangeDelIter.Close(); g.err != nil {
 					return nil, base.LazyValue{}
 				}
@@ -102,7 +100,7 @@ func (g *getIter) Next() (*InternalKey, base.LazyValue) {
 					g.iter = nil
 					return nil, base.LazyValue{}
 				}
-				if g.equal(g.key, key.UserKey) {
+				if g.comparer.Equal(g.key, key.UserKey) {
 					if !key.Visible(g.snapshot, base.InternalKeySeqNumMax) {
 						g.iterKey, g.iterValue = g.iter.Next()
 						continue
@@ -160,7 +158,7 @@ func (g *getIter) Next() (*InternalKey, base.LazyValue) {
 				files := g.l0[n-1].Iter()
 				g.l0 = g.l0[:n-1]
 				iterOpts := IterOptions{logger: g.logger, snapshotForHideObsoletePoints: g.snapshot}
-				g.levelIter.init(context.Background(), iterOpts, g.cmp, g.split, g.newIters,
+				g.levelIter.init(context.Background(), iterOpts, g.comparer, g.newIters,
 					files, manifest.L0Sublevel(n), internalIterOpts{})
 				g.levelIter.initRangeDel(&g.rangeDelIter)
 				bc := levelIterBoundaryContext{}
@@ -170,8 +168,8 @@ func (g *getIter) Next() (*InternalKey, base.LazyValue) {
 				// Compute the key prefix for bloom filtering if split function is
 				// specified, or use the user key as default.
 				prefix := g.key
-				if g.split != nil {
-					prefix = g.key[:g.split(g.key)]
+				if g.comparer.Split != nil {
+					prefix = g.key[:g.comparer.Split(g.key)]
 				}
 				g.iterKey, g.iterValue = g.iter.SeekPrefixGE(prefix, g.key, base.SeekGEFlagsNone)
 				if bc.isSyntheticIterBoundsKey || bc.isIgnorableBoundaryKey {
@@ -192,7 +190,7 @@ func (g *getIter) Next() (*InternalKey, base.LazyValue) {
 		}
 
 		iterOpts := IterOptions{logger: g.logger, snapshotForHideObsoletePoints: g.snapshot}
-		g.levelIter.init(context.Background(), iterOpts, g.cmp, g.split, g.newIters,
+		g.levelIter.init(context.Background(), iterOpts, g.comparer, g.newIters,
 			g.version.Levels[g.level].Iter(), manifest.Level(g.level), internalIterOpts{})
 		g.levelIter.initRangeDel(&g.rangeDelIter)
 		bc := levelIterBoundaryContext{}
@@ -203,8 +201,8 @@ func (g *getIter) Next() (*InternalKey, base.LazyValue) {
 		// Compute the key prefix for bloom filtering if split function is
 		// specified, or use the user key as default.
 		prefix := g.key
-		if g.split != nil {
-			prefix = g.key[:g.split(g.key)]
+		if g.comparer.Split != nil {
+			prefix = g.key[:g.comparer.Split(g.key)]
 		}
 		g.iterKey, g.iterValue = g.iter.SeekPrefixGE(prefix, g.key, base.SeekGEFlagsNone)
 		if bc.isSyntheticIterBoundsKey || bc.isIgnorableBoundaryKey {

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -466,7 +466,6 @@ func TestGetIter(t *testing.T) {
 	}
 
 	cmp := testkeys.Comparer.Compare
-	equal := testkeys.Comparer.Equal
 	for _, tc := range testCases {
 		desc := tc.description[:strings.Index(tc.description, ":")]
 
@@ -532,8 +531,7 @@ func TestGetIter(t *testing.T) {
 			}
 
 			get := &buf.get
-			get.cmp = cmp
-			get.equal = equal
+			get.comparer = testkeys.Comparer
 			get.newIters = newIter
 			get.key = ikey.UserKey
 			get.l0 = v.L0SublevelFiles

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1937,7 +1937,7 @@ func TestIngestTargetLevel(t *testing.T) {
 			readState := d.loadReadState()
 			c := &checkConfig{
 				logger:    d.opts.Logger,
-				cmp:       d.cmp,
+				comparer:  d.opts.Comparer,
 				readState: readState,
 				newIters:  d.newIters,
 				// TODO: runDBDefineCmd doesn't properly update the visible
@@ -1968,9 +1968,8 @@ func TestIngestTargetLevel(t *testing.T) {
 				meta := parseMeta(target)
 				level, overlapFile, err := ingestTargetLevel(
 					d.newIters, d.tableNewRangeKeyIter, IterOptions{logger: d.opts.Logger},
-					d.cmp, d.mu.versions.currentVersion(), 1, d.mu.compact.inProgress, meta,
-					suggestSplit,
-				)
+					d.opts.Comparer, d.mu.versions.currentVersion(), 1, d.mu.compact.inProgress, meta,
+					suggestSplit)
 				if err != nil {
 					return err.Error()
 				}

--- a/level_checker.go
+++ b/level_checker.go
@@ -345,7 +345,7 @@ func iterateAndCheckTombstones(
 
 type checkConfig struct {
 	logger    Logger
-	cmp       Compare
+	comparer  *Comparer
 	readState *readState
 	newIters  tableNewIters
 	seqNum    uint64
@@ -353,6 +353,9 @@ type checkConfig struct {
 	merge     Merge
 	formatKey base.FormatKey
 }
+
+// cmp is shorthand for comparer.Compare.
+func (c *checkConfig) cmp(a, b []byte) int { return c.comparer.Compare(a, b) }
 
 func checkRangeTombstones(c *checkConfig) error {
 	var level int
@@ -571,7 +574,7 @@ func (d *DB) CheckLevels(stats *CheckLevelsStats) error {
 
 	checkConfig := &checkConfig{
 		logger:    d.opts.Logger,
-		cmp:       d.cmp,
+		comparer:  d.opts.Comparer,
 		readState: readState,
 		newIters:  d.newIters,
 		seqNum:    seqNum,
@@ -639,7 +642,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 		manifestIter := current.L0SublevelFiles[sublevel].Iter()
 		iterOpts := IterOptions{logger: c.logger}
 		li := &levelIter{}
-		li.init(context.Background(), iterOpts, c.cmp, nil /* split */, c.newIters, manifestIter,
+		li.init(context.Background(), iterOpts, c.comparer, c.newIters, manifestIter,
 			manifest.L0Sublevel(sublevel), internalIterOpts{})
 		li.initRangeDel(&mlevelAlloc[0].rangeDelIter)
 		li.initBoundaryContext(&mlevelAlloc[0].levelIterBoundaryContext)
@@ -653,7 +656,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 
 		iterOpts := IterOptions{logger: c.logger}
 		li := &levelIter{}
-		li.init(context.Background(), iterOpts, c.cmp, nil /* split */, c.newIters,
+		li.init(context.Background(), iterOpts, c.comparer, c.newIters,
 			current.Levels[level].Iter(), manifest.Level(level), internalIterOpts{})
 		li.initRangeDel(&mlevelAlloc[0].rangeDelIter)
 		li.initBoundaryContext(&mlevelAlloc[0].levelIterBoundaryContext)

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -83,7 +83,6 @@ func (f *failMerger) Close() error {
 
 func TestCheckLevelsCornerCases(t *testing.T) {
 	memFS := vfs.NewMem()
-	cmp := DefaultComparer.Compare
 	var levels [][]*fileMetadata
 	formatKey := DefaultComparer.FormatKey
 	// Indexed by fileNum
@@ -140,7 +139,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 				largestKey := base.ParseInternalKey(keys[1])
 				m := (&fileMetadata{
 					FileNum: fileNum,
-				}).ExtendPointKeyBounds(cmp, smallestKey, largestKey)
+				}).ExtendPointKeyBounds(DefaultComparer.Compare, smallestKey, largestKey)
 				m.InitPhysicalBacking()
 				*li = append(*li, m)
 
@@ -167,7 +166,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 				}
 				var tombstones []keyspan.Span
 				frag := keyspan.Fragmenter{
-					Cmp:    cmp,
+					Cmp:    DefaultComparer.Compare,
 					Format: formatKey,
 					Emit: func(fragmented keyspan.Span) {
 						tombstones = append(tombstones, fragmented)
@@ -256,7 +255,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 				files)
 			readState := &readState{current: version}
 			c := &checkConfig{
-				cmp:       cmp,
+				comparer:  DefaultComparer,
 				readState: readState,
 				newIters:  newIters,
 				seqNum:    InternalKeySeqNumMax,

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/rangedel"
+	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -260,7 +261,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 					continue
 				}
 				li := &levelIter{}
-				li.init(context.Background(), IterOptions{}, cmp, func(a []byte) int { return len(a) },
+				li.init(context.Background(), IterOptions{}, testkeys.Comparer,
 					newIters, slice.Iter(), manifest.Level(i), internalIterOpts{stats: &stats})
 				i := len(levelIters)
 				levelIters = append(levelIters, mergingIterLevel{iter: li})
@@ -627,8 +628,7 @@ func buildMergingIter(readers [][]*sstable.Reader, levelSlices []manifest.LevelS
 			}
 			return iter, rdIter, err
 		}
-		l := newLevelIter(IterOptions{}, DefaultComparer.Compare,
-			func(a []byte) int { return len(a) }, newIters, levelSlices[i].Iter(),
+		l := newLevelIter(IterOptions{}, testkeys.Comparer, newIters, levelSlices[i].Iter(),
 			manifest.Level(level), internalIterOpts{})
 		l.initRangeDel(&mils[level].rangeDelIter)
 		l.initBoundaryContext(&mils[level].levelIterBoundaryContext)
@@ -636,7 +636,7 @@ func buildMergingIter(readers [][]*sstable.Reader, levelSlices []manifest.LevelS
 	}
 	var stats base.InternalIteratorStats
 	m := &mergingIter{}
-	m.init(nil /* logger */, &stats, DefaultComparer.Compare,
+	m.init(nil /* logger */, &stats, testkeys.Comparer.Compare,
 		func(a []byte) int { return len(a) }, mils...)
 	return m
 }

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -763,7 +763,7 @@ func (i *scanInternalIterator) constructPointIter(memtables flushableList, buf *
 		rli := &rangeDelLevels[levelsIndex]
 
 		li.init(
-			context.Background(), i.opts.IterOptions, i.comparer.Compare, i.comparer.Split, i.newIters, files, level,
+			context.Background(), i.opts.IterOptions, i.comparer, i.newIters, files, level,
 			internalIterOpts{})
 		li.initBoundaryContext(&mlevels[mlevelsIndex].levelIterBoundaryContext)
 		mlevels[mlevelsIndex].iter = li


### PR DESCRIPTION
Rather than propagating just the individual Compare and Split funcs, propagate the entire *Comparer further, and specifically to the levelIter. In some places this makes for smaller, more readable call sites, but it's primarily motivated by future changes that will propagate the Comparer further into a keyspan.InterleavingIter per-levelIter.