### PR TITLE
metamorphic: Only enable ingest split if FMV is >= VirtualSSTs

### DIFF
--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -548,7 +548,7 @@ func randomOptions(
 		}
 	}
 	testOpts.seedEFOS = rng.Uint64()
-	testOpts.ingestSplit = rng.Intn(2) == 0
+	testOpts.ingestSplit = rng.Intn(2) == 0 && opts.FormatMajorVersion >= pebble.FormatVirtualSSTables
 	opts.Experimental.IngestSplit = func() bool { return testOpts.ingestSplit }
 
 	return testOpts


### PR DESCRIPTION
Previously we were enabling ingest splits even if the format major version was < FormatVirtualSSTables, resulting in errors lower down in the manifest when we created backing tables. This change fixes it.

Fixes #2940.