### PR TITLE
Revert "db: add SkipPoint iterator option"

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -550,21 +550,6 @@ func (i *Iterator) findNextEntry(limit []byte) {
 			return
 		}
 
-		// If the user has configured a SkipPoint function, invoke it to see
-		// whether we should skip over the current user key.
-		if i.opts.SkipPoint != nil && key.Kind() != InternalKeyKindRangeKeySet && i.opts.SkipPoint(i.iterKey.UserKey) {
-			// NB: We could call nextUserKey, but in some cases the SkipPoint
-			// predicate function might be cheaper than nextUserKey's key copy
-			// and key comparison. This should be the case for MVCC suffix
-			// comparisons, for example. In the future, we could expand the
-			// SkipPoint interface to give the implementor more control over
-			// whether we skip over just the internal key, the user key, or even
-			// the key prefix.
-			i.stats.ForwardStepCount[InternalIterCall]++
-			i.iterKey, i.iterValue = i.iter.Next()
-			continue
-		}
-
 		switch key.Kind() {
 		case InternalKeyKindRangeKeySet:
 			// Save the current key.
@@ -926,26 +911,6 @@ func (i *Iterator) findPrevEntry(limit []byte) {
 			}
 		}
 
-		// If the user has configured a SkipPoint function, invoke it to see
-		// whether we should skip over the current user key.
-		if i.opts.SkipPoint != nil && key.Kind() != InternalKeyKindRangeKeySet && i.opts.SkipPoint(key.UserKey) {
-			// NB: We could call prevUserKey, but in some cases the SkipPoint
-			// predicate function might be cheaper than prevUserKey's key copy
-			// and key comparison. This should be the case for MVCC suffix
-			// comparisons, for example. In the future, we could expand the
-			// SkipPoint interface to give the implementor more control over
-			// whether we skip over just the internal key, the user key, or even
-			// the key prefix.
-			i.stats.ReverseStepCount[InternalIterCall]++
-			i.iterKey, i.iterValue = i.iter.Prev()
-			if limit != nil && i.iterKey != nil && i.cmp(limit, i.iterKey.UserKey) > 0 && !i.rangeKeyWithinLimit(limit) {
-				i.iterValidityState = IterAtLimit
-				i.pos = iterPosCurReversePaused
-				return
-			}
-			continue
-		}
-
 		switch key.Kind() {
 		case InternalKeyKindRangeKeySet:
 			// Range key start boundary markers are interleaved with the maximum
@@ -983,12 +948,12 @@ func (i *Iterator) findPrevEntry(limit []byte) {
 			// Compare with the limit. We could optimize by only checking when
 			// we step to the previous user key, but detecting that requires a
 			// comparison too. Note that this position may already passed a
-			// number of versions of this user key, but they are all deleted, so
-			// the fact that a subsequent Prev*() call will not see them is
+			// number of versions of this user key, but they are all deleted,
+			// so the fact that a subsequent Prev*() call will not see them is
 			// harmless. Also note that this is the only place in the loop,
-			// other than the firstLoopIter and SkipPoint cases above, where we
-			// could step to a different user key and start processing it for
-			// returning to the caller.
+			// other than the firstLoopIter case above, where we could step
+			// to a different user key and start processing it for returning
+			// to the caller.
 			if limit != nil && i.iterKey != nil && i.cmp(limit, i.iterKey.UserKey) > 0 && !i.rangeKeyWithinLimit(limit) {
 				i.iterValidityState = IterAtLimit
 				i.pos = iterPosCurReversePaused
@@ -2463,8 +2428,7 @@ func (i *Iterator) SetOptions(o *IterOptions) {
 	// If either options specify block property filters for an iterator stack,
 	// reconstruct it.
 	if i.pointIter != nil && (closeBoth || len(o.PointKeyFilters) > 0 || len(i.opts.PointKeyFilters) > 0 ||
-		o.RangeKeyMasking.Filter != nil || i.opts.RangeKeyMasking.Filter != nil || o.SkipPoint != nil ||
-		i.opts.SkipPoint != nil) {
+		o.RangeKeyMasking.Filter != nil || i.opts.RangeKeyMasking.Filter != nil) {
 		i.err = firstError(i.err, i.pointIter.Close())
 		i.pointIter = nil
 	}

--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -260,13 +260,15 @@ func (t *test) setBatch(id objID, b *pebble.Batch) {
 	t.batches[id.slot()] = b
 }
 
-func (t *test) setIter(id objID, i *pebble.Iterator) {
+func (t *test) setIter(id objID, i *pebble.Iterator, filterMin, filterMax uint64) {
 	if id.tag() != iterTag {
 		panic(fmt.Sprintf("invalid iter ID: %s", id))
 	}
 	t.iters[id.slot()] = &retryableIter{
-		iter:    i,
-		lastKey: nil,
+		iter:      i,
+		lastKey:   nil,
+		filterMin: filterMin,
+		filterMax: filterMax,
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -119,16 +119,6 @@ type IterOptions struct {
 	// false to skip scanning. This function must be thread-safe since the same
 	// function can be used by multiple iterators, if the iterator is cloned.
 	TableFilter func(userProps map[string]string) bool
-	// SkipPoint may be used to skip over point keys that don't match an
-	// arbitrary predicate during iteration. If set, the Iterator invokes
-	// SkipPoint for keys encountered. If SkipPoint returns true, the iterator
-	// will skip the key without yielding it to the iterator operation in
-	// progress.
-	//
-	// SkipPoint must be a pure function and always return the same result when
-	// provided the same arguments. The iterator may call SkipPoint multiple
-	// times for the same user key.
-	SkipPoint func(userKey []byte) bool
 	// PointKeyFilters can be used to avoid scanning tables and blocks in tables
 	// when iterating over point keys. This slice represents an intersection
 	// across all filters, i.e., all filters must indicate that the block is


### PR DESCRIPTION
This reverts commit 895ffed51f35c1e1867b7b6bf6330e8bec58210c.

This was insufficiently tested because #2932 wasn't merged yet, and there
appears to be an unidentified interaction. Reverting this will allow us to
restore testing of block property filters, and then I can reexamine this
refactor.