### PR TITLE
db: Fix FormatMajorVersion check in version_set for VSSTs

### DIFF
--- a/open.go
+++ b/open.go
@@ -260,7 +260,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		}
 
 		// Create the DB.
-		if err := d.mu.versions.create(jobID, dirname, opts, manifestMarker, setCurrent, &d.mu.Mutex); err != nil {
+		if err := d.mu.versions.create(jobID, dirname, opts, manifestMarker, setCurrent, d.FormatMajorVersion, &d.mu.Mutex); err != nil {
 			return nil, err
 		}
 	} else {
@@ -268,7 +268,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 			return nil, errors.Wrapf(ErrDBAlreadyExists, "dirname=%q", dirname)
 		}
 		// Load the version set.
-		if err := d.mu.versions.load(dirname, opts, manifestFileNum.FileNum(), manifestMarker, setCurrent, &d.mu.Mutex); err != nil {
+		if err := d.mu.versions.load(dirname, opts, manifestFileNum.FileNum(), manifestMarker, setCurrent, d.FormatMajorVersion, &d.mu.Mutex); err != nil {
 			return nil, err
 		}
 		if opts.ErrorIfNotPristine {


### PR DESCRIPTION
Previously, if the FormatMajorVersion was ratcheted forward post-DB initialization, the options would still keep reflecting the old FMV while the new dynamic FMV has moved forward. The Manifest code had an assertion on not adding Virtual SSTable backing entries based on the FormatMajorVersion in the Options and not the dynamically updated one, resulting in spurious assertion errors. This change addresses that code to look at the more up-to-date FMV.

Fixes #2940.