### PR TITLE
db: add SkipPoint iterator option

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -550,6 +550,21 @@ func (i *Iterator) findNextEntry(limit []byte) {
 			return
 		}
 
+		// If the user has configured a SkipPoint function, invoke it to see
+		// whether we should skip over the current user key.
+		if i.opts.SkipPoint != nil && key.Kind() != InternalKeyKindRangeKeySet && i.opts.SkipPoint(i.iterKey.UserKey) {
+			// NB: We could call nextUserKey, but in some cases the SkipPoint
+			// predicate function might be cheaper than nextUserKey's key copy
+			// and key comparison. This should be the case for MVCC suffix
+			// comparisons, for example. In the future, we could expand the
+			// SkipPoint interface to give the implementor more control over
+			// whether we skip over just the internal key, the user key, or even
+			// the key prefix.
+			i.stats.ForwardStepCount[InternalIterCall]++
+			i.iterKey, i.iterValue = i.iter.Next()
+			continue
+		}
+
 		switch key.Kind() {
 		case InternalKeyKindRangeKeySet:
 			// Save the current key.
@@ -619,6 +634,13 @@ func (i *Iterator) findNextEntry(limit []byte) {
 }
 
 func (i *Iterator) nextPointCurrentUserKey() bool {
+	// If the user has configured a SkipPoint function and the current user key
+	// would be skipped by it, there's no need to step forward looking for a
+	// point key. If we were to find one, it should be skipped anyways.
+	if i.opts.SkipPoint != nil && i.opts.SkipPoint(i.key) {
+		return false
+	}
+
 	i.pos = iterPosCurForward
 
 	i.iterKey, i.iterValue = i.iter.Next()
@@ -911,6 +933,26 @@ func (i *Iterator) findPrevEntry(limit []byte) {
 			}
 		}
 
+		// If the user has configured a SkipPoint function, invoke it to see
+		// whether we should skip over the current user key.
+		if i.opts.SkipPoint != nil && key.Kind() != InternalKeyKindRangeKeySet && i.opts.SkipPoint(key.UserKey) {
+			// NB: We could call prevUserKey, but in some cases the SkipPoint
+			// predicate function might be cheaper than prevUserKey's key copy
+			// and key comparison. This should be the case for MVCC suffix
+			// comparisons, for example. In the future, we could expand the
+			// SkipPoint interface to give the implementor more control over
+			// whether we skip over just the internal key, the user key, or even
+			// the key prefix.
+			i.stats.ReverseStepCount[InternalIterCall]++
+			i.iterKey, i.iterValue = i.iter.Prev()
+			if limit != nil && i.iterKey != nil && i.cmp(limit, i.iterKey.UserKey) > 0 && !i.rangeKeyWithinLimit(limit) {
+				i.iterValidityState = IterAtLimit
+				i.pos = iterPosCurReversePaused
+				return
+			}
+			continue
+		}
+
 		switch key.Kind() {
 		case InternalKeyKindRangeKeySet:
 			// Range key start boundary markers are interleaved with the maximum
@@ -948,12 +990,12 @@ func (i *Iterator) findPrevEntry(limit []byte) {
 			// Compare with the limit. We could optimize by only checking when
 			// we step to the previous user key, but detecting that requires a
 			// comparison too. Note that this position may already passed a
-			// number of versions of this user key, but they are all deleted,
-			// so the fact that a subsequent Prev*() call will not see them is
+			// number of versions of this user key, but they are all deleted, so
+			// the fact that a subsequent Prev*() call will not see them is
 			// harmless. Also note that this is the only place in the loop,
-			// other than the firstLoopIter case above, where we could step
-			// to a different user key and start processing it for returning
-			// to the caller.
+			// other than the firstLoopIter and SkipPoint cases above, where we
+			// could step to a different user key and start processing it for
+			// returning to the caller.
 			if limit != nil && i.iterKey != nil && i.cmp(limit, i.iterKey.UserKey) > 0 && !i.rangeKeyWithinLimit(limit) {
 				i.iterValidityState = IterAtLimit
 				i.pos = iterPosCurReversePaused
@@ -2428,7 +2470,8 @@ func (i *Iterator) SetOptions(o *IterOptions) {
 	// If either options specify block property filters for an iterator stack,
 	// reconstruct it.
 	if i.pointIter != nil && (closeBoth || len(o.PointKeyFilters) > 0 || len(i.opts.PointKeyFilters) > 0 ||
-		o.RangeKeyMasking.Filter != nil || i.opts.RangeKeyMasking.Filter != nil) {
+		o.RangeKeyMasking.Filter != nil || i.opts.RangeKeyMasking.Filter != nil || o.SkipPoint != nil ||
+		i.opts.SkipPoint != nil) {
 		i.err = firstError(i.err, i.pointIter.Close())
 		i.pointIter = nil
 	}

--- a/iterator_histories_test.go
+++ b/iterator_histories_test.go
@@ -309,6 +309,17 @@ func TestIterHistories(t *testing.T) {
 						o.PointKeyFilters = []sstable.BlockPropertyFilter{
 							sstable.NewTestKeysBlockPropertyFilter(min, max),
 						}
+						o.SkipPoint = func(k []byte) bool {
+							i := testkeys.Comparer.Split(k)
+							if i == len(k) {
+								return false
+							}
+							v, err := testkeys.ParseSuffix(k[i:])
+							if err != nil {
+								return false
+							}
+							return uint64(v) < min || uint64(v) >= max
+						}
 					case "snapshot":
 						s, err := strconv.ParseUint(arg.Vals[0], 10, 64)
 						if err != nil {

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/private"
+	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -711,7 +712,7 @@ func (o *newIterOp) run(t *test, h historyRecorder) {
 		// close this iter and retry NewIter
 		_ = i.Close()
 	}
-	t.setIter(o.iterID, i, o.filterMin, o.filterMax)
+	t.setIter(o.iterID, i)
 
 	// Trash the bounds to ensure that Pebble doesn't rely on the stability of
 	// the user-provided bounds.
@@ -763,13 +764,7 @@ func (o *newIterUsingCloneOp) run(t *test, h historyRecorder) {
 	if err != nil {
 		panic(err)
 	}
-	filterMin, filterMax := o.filterMin, o.filterMax
-	if cloneOpts.IterOptions == nil {
-		// We're adopting the same block property filters as iter, so we need to
-		// adopt the same run-time filters to ensure determinism.
-		filterMin, filterMax = iter.filterMin, iter.filterMax
-	}
-	t.setIter(o.iterID, i, filterMin, filterMax)
+	t.setIter(o.iterID, i)
 	h.Recordf("%s // %v", o, i.Error())
 }
 
@@ -853,9 +848,6 @@ func (o *iterSetOptionsOp) run(t *test, h historyRecorder) {
 	rand.Read(opts.LowerBound[:])
 	rand.Read(opts.UpperBound[:])
 
-	// Adjust the iterator's filters.
-	i.filterMin, i.filterMax = o.filterMin, o.filterMax
-
 	h.Recordf("%s // %v", o, i.Error())
 }
 
@@ -892,6 +884,22 @@ func iterOptions(o iterOpts) *pebble.IterOptions {
 	if o.filterMax > 0 {
 		opts.PointKeyFilters = []pebble.BlockPropertyFilter{
 			sstable.NewTestKeysBlockPropertyFilter(o.filterMin, o.filterMax),
+		}
+		// Enforce the timestamp bounds in SkipPoint, so that the iterator never
+		// returns a key outside the filterMin, filterMax bounds. This provides
+		// deterministic iteration.
+		opts.SkipPoint = func(k []byte) (skip bool) {
+			n := testkeys.Comparer.Split(k)
+			if n == len(k) {
+				// No suffix, don't skip it.
+				return false
+			}
+			v, err := testkeys.ParseSuffix(k[n:])
+			if err != nil {
+				panic(err)
+			}
+			ts := uint64(v)
+			return ts < o.filterMin || ts >= o.filterMax
 		}
 	}
 	return opts

--- a/metamorphic/retryable.go
+++ b/metamorphic/retryable.go
@@ -5,11 +5,8 @@
 package metamorphic
 
 import (
-	"bytes"
-
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
-	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/vfs/errorfs"
 )
 
@@ -31,68 +28,6 @@ func withRetries(fn func() error) error {
 type retryableIter struct {
 	iter    *pebble.Iterator
 	lastKey []byte
-
-	// When filterMax is >0, this iterator filters out keys with suffixes
-	// outside of the range [filterMin, filterMax). Keys without suffixes are
-	// surfaced. This is used to ensure determinism regardless of whether
-	// block-property filters filter keys or not.
-	filterMin, filterMax uint64
-
-	// rangeKeyChangeGuess is only used if the iterator has a filter set. A single
-	// operation on the retryableIter may result in many operations on
-	// retryableIter.iter if we need to skip filtered keys. Thus, the value of
-	// retryableIter.iter.RangeKeyChanged() will not necessarily indicate if the
-	// range key actually changed.
-	//
-	// Since one call to a positioning operation may lead to multiple
-	// positioning operations, we set rangeKeyChangeGuess to false, iff every single
-	// positioning operation returned iter.RangeKeyChanged() == false.
-	//
-	// rangeKeyChangeGuess == true implies that at least one of the many iterator
-	// operations returned RangeKeyChanged to true, but we may have false
-	// positives. We can't assume that the range key actually changed if
-	// iter.RangeKeyChanged() returns true after one of the positioning
-	// operations. Consider a db with two range keys, which are also in the same
-	// block, a-f, g-h where the iterator's filter excludes g-h. If the iterator
-	// is positioned on a-f, then a call to SeekLT(z), will position the iterator
-	// over g-h, but the retryableIter will call Prev and the iterator will be
-	// positioned back over a-f. In this case the range key hasn't changed, but
-	// one of the positioning operations will return iter.RangeKeyChanged() ==
-	// true.
-	rangeKeyChangeGuess bool
-
-	// rangeKeyChanged is the true accurate value of whether the range key has
-	// changed from the perspective of a client of the retryableIter. It is used
-	// to determine if rangeKeyChangeGuess is a false positive. It is computed
-	// by comparing the range key at the current position with the range key
-	// at the previous position.
-	rangeKeyChanged bool
-
-	// When a filter is set on the iterator, one positioning op from the
-	// perspective of a client of the retryableIter, may result in multiple
-	// intermediary positioning ops. This bool is set if the current positioning
-	// op is intermediate.
-	intermediatePosition bool
-
-	rkeyBuff []byte
-}
-
-func (i *retryableIter) shouldFilter() bool {
-	if i.filterMax == 0 {
-		return false
-	}
-	k := i.iter.Key()
-	n := testkeys.Comparer.Split(k)
-	if n == len(k) {
-		// No suffix, don't filter it.
-		return false
-	}
-	v, err := testkeys.ParseSuffix(k[n:])
-	if err != nil {
-		panic(err)
-	}
-	ts := uint64(v)
-	return ts < i.filterMin || ts >= i.filterMax
 }
 
 func (i *retryableIter) needRetry() bool {
@@ -124,61 +59,10 @@ func (i *retryableIter) Error() error {
 	return i.iter.Error()
 }
 
-// A call to an iterator positioning function may result in sub calls to other
-// iterator positioning functions. We need to run some code in the top level
-// call, so we use withPosition to reduce code duplication in the positioning
-// functions.
-func (i *retryableIter) withPosition(fn func()) {
-	// For the top level op, i.intermediatePosition must always be false.
-	intermediate := i.intermediatePosition
-	// Any subcalls to positioning ops will be intermediate.
-	i.intermediatePosition = true
-	defer func() {
-		i.intermediatePosition = intermediate
-	}()
-
-	if !intermediate {
-		// Clear out the previous value stored in the buff.
-		i.rkeyBuff = i.rkeyBuff[:0]
-		if _, hasRange := i.iter.HasPointAndRange(); hasRange {
-			// This is a top level positioning op. We should determine if the iter
-			// is positioned over a range key to later determine if the range key
-			// changed.
-			startTmp, _ := i.iter.RangeBounds()
-			i.rkeyBuff = append(i.rkeyBuff, startTmp...)
-
-		}
-		// Set this to false. Any positioning op can set this to true.
-		i.rangeKeyChangeGuess = false
-	}
-
-	fn()
-
-	if !intermediate {
-		// Check if the range key changed.
-		var newStartKey []byte
-		if _, hasRange := i.iter.HasPointAndRange(); hasRange {
-			newStartKey, _ = i.iter.RangeBounds()
-		}
-
-		i.rangeKeyChanged = !bytes.Equal(newStartKey, i.rkeyBuff)
-	}
-}
-
-func (i *retryableIter) updateRangeKeyChangedGuess() {
-	i.rangeKeyChangeGuess = i.rangeKeyChangeGuess || i.iter.RangeKeyChanged()
-}
-
 func (i *retryableIter) First() bool {
 	var valid bool
-	i.withPosition(func() {
-		i.withRetry(func() {
-			valid = i.iter.First()
-		})
-		i.updateRangeKeyChangedGuess()
-		if valid && i.shouldFilter() {
-			valid = i.Next()
-		}
+	i.withRetry(func() {
+		valid = i.iter.First()
 	})
 	return valid
 }
@@ -188,18 +72,7 @@ func (i *retryableIter) Key() []byte {
 }
 
 func (i *retryableIter) RangeKeyChanged() bool {
-	if i.filterMax == 0 {
-		return i.iter.RangeKeyChanged()
-	}
-
-	if !i.rangeKeyChangeGuess {
-		// false negatives shouldn't be possible so just return.
-		return false
-	}
-
-	// i.rangeKeyChangeGuess is true. This may be a false positive, so just
-	// return i.rangeKeyChanged which will always be correct.
-	return i.rangeKeyChanged
+	return i.iter.RangeKeyChanged()
 }
 
 func (i *retryableIter) HasPointAndRange() (bool, bool) {
@@ -216,42 +89,22 @@ func (i *retryableIter) RangeKeys() []pebble.RangeKeyData {
 
 func (i *retryableIter) Last() bool {
 	var valid bool
-	i.withPosition(func() {
-		i.withRetry(func() { valid = i.iter.Last() })
-		i.updateRangeKeyChangedGuess()
-		if valid && i.shouldFilter() {
-			valid = i.Prev()
-		}
-	})
+	i.withRetry(func() { valid = i.iter.Last() })
 	return valid
 }
 
 func (i *retryableIter) Next() bool {
 	var valid bool
-	i.withPosition(func() {
-		i.withRetry(func() {
-			valid = i.iter.Next()
-			i.updateRangeKeyChangedGuess()
-			for valid && i.shouldFilter() {
-				valid = i.iter.Next()
-				i.updateRangeKeyChangedGuess()
-			}
-		})
+	i.withRetry(func() {
+		valid = i.iter.Next()
 	})
 	return valid
 }
 
 func (i *retryableIter) NextWithLimit(limit []byte) pebble.IterValidityState {
 	var validity pebble.IterValidityState
-	i.withPosition(func() {
-		i.withRetry(func() {
-			validity = i.iter.NextWithLimit(limit)
-			i.updateRangeKeyChangedGuess()
-			for validity == pebble.IterValid && i.shouldFilter() {
-				validity = i.iter.NextWithLimit(limit)
-				i.updateRangeKeyChangedGuess()
-			}
-		})
+	i.withRetry(func() {
+		validity = i.iter.NextWithLimit(limit)
 	})
 	return validity
 
@@ -259,106 +112,55 @@ func (i *retryableIter) NextWithLimit(limit []byte) pebble.IterValidityState {
 
 func (i *retryableIter) NextPrefix() bool {
 	var valid bool
-	i.withPosition(func() {
-		i.withRetry(func() {
-			valid = i.iter.NextPrefix()
-			i.updateRangeKeyChangedGuess()
-			for valid && i.shouldFilter() {
-				valid = i.iter.Next()
-				i.updateRangeKeyChangedGuess()
-			}
-		})
+	i.withRetry(func() {
+		valid = i.iter.NextPrefix()
 	})
 	return valid
 }
 
 func (i *retryableIter) Prev() bool {
 	var valid bool
-	i.withPosition(func() {
-		i.withRetry(func() {
-			valid = i.iter.Prev()
-			i.updateRangeKeyChangedGuess()
-			for valid && i.shouldFilter() {
-				valid = i.iter.Prev()
-				i.updateRangeKeyChangedGuess()
-			}
-		})
+	i.withRetry(func() {
+		valid = i.iter.Prev()
 	})
 	return valid
 }
 
 func (i *retryableIter) PrevWithLimit(limit []byte) pebble.IterValidityState {
 	var validity pebble.IterValidityState
-	i.withPosition(func() {
-		i.withRetry(func() {
-			validity = i.iter.PrevWithLimit(limit)
-			i.updateRangeKeyChangedGuess()
-			for validity == pebble.IterValid && i.shouldFilter() {
-				validity = i.iter.PrevWithLimit(limit)
-				i.updateRangeKeyChangedGuess()
-			}
-		})
+	i.withRetry(func() {
+		validity = i.iter.PrevWithLimit(limit)
 	})
 	return validity
 }
 
 func (i *retryableIter) SeekGE(key []byte) bool {
 	var valid bool
-	i.withPosition(func() {
-		i.withRetry(func() { valid = i.iter.SeekGE(key) })
-		i.updateRangeKeyChangedGuess()
-		if valid && i.shouldFilter() {
-			valid = i.Next()
-		}
-	})
+	i.withRetry(func() { valid = i.iter.SeekGE(key) })
 	return valid
 }
 
 func (i *retryableIter) SeekGEWithLimit(key []byte, limit []byte) pebble.IterValidityState {
 	var validity pebble.IterValidityState
-	i.withPosition(func() {
-		i.withRetry(func() { validity = i.iter.SeekGEWithLimit(key, limit) })
-		i.updateRangeKeyChangedGuess()
-		if validity == pebble.IterValid && i.shouldFilter() {
-			validity = i.NextWithLimit(limit)
-		}
-	})
+	i.withRetry(func() { validity = i.iter.SeekGEWithLimit(key, limit) })
 	return validity
 }
 
 func (i *retryableIter) SeekLT(key []byte) bool {
 	var valid bool
-	i.withPosition(func() {
-		i.withRetry(func() { valid = i.iter.SeekLT(key) })
-		i.updateRangeKeyChangedGuess()
-		if valid && i.shouldFilter() {
-			valid = i.Prev()
-		}
-	})
+	i.withRetry(func() { valid = i.iter.SeekLT(key) })
 	return valid
 }
 
 func (i *retryableIter) SeekLTWithLimit(key []byte, limit []byte) pebble.IterValidityState {
 	var validity pebble.IterValidityState
-	i.withPosition(func() {
-		i.withRetry(func() { validity = i.iter.SeekLTWithLimit(key, limit) })
-		i.updateRangeKeyChangedGuess()
-		if validity == pebble.IterValid && i.shouldFilter() {
-			validity = i.PrevWithLimit(limit)
-		}
-	})
+	i.withRetry(func() { validity = i.iter.SeekLTWithLimit(key, limit) })
 	return validity
 }
 
 func (i *retryableIter) SeekPrefixGE(key []byte) bool {
 	var valid bool
-	i.withPosition(func() {
-		i.withRetry(func() { valid = i.iter.SeekPrefixGE(key) })
-		i.updateRangeKeyChangedGuess()
-		if valid && i.shouldFilter() {
-			valid = i.Next()
-		}
-	})
+	i.withRetry(func() { valid = i.iter.SeekPrefixGE(key) })
 	return valid
 }
 

--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -260,15 +260,13 @@ func (t *test) setBatch(id objID, b *pebble.Batch) {
 	t.batches[id.slot()] = b
 }
 
-func (t *test) setIter(id objID, i *pebble.Iterator, filterMin, filterMax uint64) {
+func (t *test) setIter(id objID, i *pebble.Iterator) {
 	if id.tag() != iterTag {
 		panic(fmt.Sprintf("invalid iter ID: %s", id))
 	}
 	t.iters[id.slot()] = &retryableIter{
-		iter:      i,
-		lastKey:   nil,
-		filterMin: filterMin,
-		filterMax: filterMax,
+		iter:    i,
+		lastKey: nil,
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -119,6 +119,16 @@ type IterOptions struct {
 	// false to skip scanning. This function must be thread-safe since the same
 	// function can be used by multiple iterators, if the iterator is cloned.
 	TableFilter func(userProps map[string]string) bool
+	// SkipPoint may be used to skip over point keys that don't match an
+	// arbitrary predicate during iteration. If set, the Iterator invokes
+	// SkipPoint for keys encountered. If SkipPoint returns true, the iterator
+	// will skip the key without yielding it to the iterator operation in
+	// progress.
+	//
+	// SkipPoint must be a pure function and always return the same result when
+	// provided the same arguments. The iterator may call SkipPoint multiple
+	// times for the same user key.
+	SkipPoint func(userKey []byte) bool
 	// PointKeyFilters can be used to avoid scanning tables and blocks in tables
 	// when iterating over point keys. This slice represents an intersection
 	// across all filters, i.e., all filters must indicate that the block is

--- a/testdata/iter_histories/skip_point
+++ b/testdata/iter_histories/skip_point
@@ -1,0 +1,115 @@
+reset
+----
+
+populate keylen=1 timestamps=(1, 10, 100)
+----
+wrote 78 keys
+
+# With a filter [20,30) all keys should be hidden, in both forward and reverse
+# iteration directions.
+
+combined-iter point-key-filter=(20,30)
+first
+last
+seek-ge d
+seek-lt m
+----
+.
+.
+.
+.
+
+# With a filter [1,2) only the keys @1 should be visible.
+# Test forward direction.
+
+combined-iter point-key-filter=(1,2)
+first
+next
+next
+next
+next
+next
+next
+next
+next
+next
+----
+a@1: (a@1, .)
+b@1: (b@1, .)
+c@1: (c@1, .)
+d@1: (d@1, .)
+e@1: (e@1, .)
+f@1: (f@1, .)
+g@1: (g@1, .)
+h@1: (h@1, .)
+i@1: (i@1, .)
+j@1: (j@1, .)
+
+
+# With a filter [1,2) only the keys @1 should be visible.
+# And reverse direction.
+
+combined-iter point-key-filter=(1,2)
+last
+prev
+prev
+prev
+prev
+prev
+prev
+prev
+prev
+prev
+----
+z@1: (z@1, .)
+y@1: (y@1, .)
+x@1: (x@1, .)
+w@1: (w@1, .)
+v@1: (v@1, .)
+u@1: (u@1, .)
+t@1: (t@1, .)
+s@1: (s@1, .)
+r@1: (r@1, .)
+q@1: (q@1, .)
+
+# With an expansive filter, all keys should be visible.
+
+combined-iter point-key-filter=(0,1000)
+first
+next
+seek-ge m
+prev
+seek-lt m
+next
+last
+----
+a@100: (a@100, .)
+a@10: (a@10, .)
+m@100: (m@100, .)
+l@1: (l@1, .)
+l@1: (l@1, .)
+m@100: (m@100, .)
+z@1: (z@1, .)
+
+# Test the case where a range key [a,z) is truncated to a seek key
+# at which there exists a point key, but the point key should be skipped.
+# The seek should stop at the seek key, but show no visible point key.
+
+batch commit
+range-key-set a z @5 boop
+----
+committed 1 keys
+
+combined-iter point-key-filter=(9,12)
+seek-ge c@1
+----
+c@1: (., [a-z) @5=boop UPDATED)
+
+
+# Try the same scenario, but this time with a filter that should NOT skip the
+# point key.
+
+combined-iter point-key-filter=(1,12)
+seek-ge c@1
+----
+c@1: (c@1, [a-z) @5=boop UPDATED)

--- a/testdata/iter_histories/with_limit
+++ b/testdata/iter_histories/with_limit
@@ -183,3 +183,24 @@ cat: valid (cat, [a-e) @1=foo UPDATED)
 a: valid (., [a-e) @1=foo)
 .
 a: (., [a-e) @1=foo UPDATED)
+
+# Test enforcing limits even while skipping point keys.
+
+reset
+----
+
+batch commit
+set b@9 b@9
+set c@2 c@2
+set d@8 d@8
+----
+committed 3 keys
+
+combined-iter point-key-filter=(6,10)
+last
+prev-limit c
+seek-ge-limit c@9 d
+----
+d@8: (d@8, .)
+. at-limit
+. at-limit


### PR DESCRIPTION
This commit was added in #2934 and reverted in #2943. It's brought back with a bug fix for the case where a range key is truncated to a user key that also exists as a point key, and that point key should be skipped by the predicate.

----

Add a new IterOption that allows a user to configure an arbitrary predicate of point keys that should be skipped in the form of a function. The Iterator consults this predicate for every internal key.

Use this new SkipPoint function to remove the complicated logic within the metamorphic test for ensuring determinisim of RangeKeyChanged() in the presence of time-bound block-property filters. A SkipPoint predicate may be combined with a block-property filter to achieve deterministic iteration.