### PR TITLE
metamorphic: Ignore ErrCancelledCompaction in background errors

### DIFF
--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -73,7 +73,7 @@ func (t *test) init(h *history, dir string, testOpts *TestOptions) error {
 	// difference between in-memory and on-disk which causes different code paths
 	// and timings to be exercised.
 	maybeExit := func(err error) {
-		if err == nil || errors.Is(err, errorfs.ErrInjected) {
+		if err == nil || errors.Is(err, errorfs.ErrInjected) || errors.Is(err, pebble.ErrCancelledCompaction) {
 			return
 		}
 		t.maybeSaveData()


### PR DESCRIPTION
Previously, if we cancelled a compaction due to an excise or ingest-split, the resultant error would error out the metamorphic test as it wasn't ignored in the metamorphic test's EventListener.

This change updates the ignore rule in the metamorphic test to not exit out on a background error that is ErrCancelledCompaction.

Fixes #2948.