### PR TITLE
db: only create one CreatedBackingTables entry per sstable

### DIFF
--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -783,6 +783,12 @@ func (b *BulkVersionEdit) Accumulate(ve *VersionEdit) error {
 		b.AddedFileBacking = make(map[base.DiskFileNum]*FileBacking)
 	}
 	for _, fb := range ve.CreatedBackingTables {
+		if _, ok := b.AddedFileBacking[fb.DiskFileNum]; ok {
+			// There is already a FileBacking associated with fb.DiskFileNum.
+			// This should never happen. There must always be only one FileBacking
+			// associated with a backing sstable.
+			panic(fmt.Sprintf("pebble: duplicate file backing %s", fb.DiskFileNum.String()))
+		}
 		b.AddedFileBacking[fb.DiskFileNum] = fb
 	}
 

--- a/testdata/excise
+++ b/testdata/excise
@@ -196,3 +196,128 @@ lsm
   000008:[d#12,SET-ee#inf,RANGEKEYSET]
 6:
   000006:[z#14,SET-z#14,SET]
+
+# Regression test for https://github.com/cockroachdb/pebble/issues/2947.
+reset
+----
+
+batch
+set a a
+set b b
+set c c
+set d d
+set e e
+set f f
+set g g
+set h h
+set i i
+set j j
+----
+
+flush
+----
+
+lsm
+----
+0.0:
+  000005:[a#10,SET-j#19,SET]
+
+build ext2
+set z z
+----
+
+ingest-and-excise ext2 excise=d-e
+----
+
+lsm
+----
+0.0:
+  000007:[a#10,SET-c#12,SET]
+  000008:[e#14,SET-j#19,SET]
+6:
+  000006:[z#20,SET-z#20,SET]
+
+build ext3
+set zz zz
+----
+
+ingest-and-excise ext3 excise=g-h
+----
+
+# 7, 10, 11 should have the same file backing struct.
+lsm
+----
+0.0:
+  000007:[a#10,SET-c#12,SET]
+  000010:[e#14,SET-f#15,SET]
+  000011:[h#17,SET-j#19,SET]
+6:
+  000006:[z#20,SET-z#20,SET]
+  000009:[zz#21,SET-zz#21,SET]
+
+confirm-backing 7 10 11
+----
+file backings are the same
+
+reopen
+----
+
+# 7, 10, 11 should still have the same file backing struct even after manifest
+# replay.
+lsm
+----
+0.0:
+  000007:[a#10,SET-c#12,SET]
+  000010:[e#14,SET-f#15,SET]
+  000011:[h#17,SET-j#19,SET]
+6:
+  000006:[z#20,SET-z#20,SET]
+  000009:[zz#21,SET-zz#21,SET]
+
+confirm-backing 7 10 11
+----
+file backings are the same
+
+# Excise one boundary, the file backing should still be set.
+reset
+----
+
+batch
+set a a
+set b b
+set c c
+set d d
+set e e
+----
+
+flush
+----
+
+lsm
+----
+0.0:
+  000005:[a#10,SET-e#14,SET]
+
+build ext2
+set z z
+----
+
+ingest-and-excise ext2 excise=d-f
+----
+
+lsm
+----
+0.0:
+  000007:[a#10,SET-c#12,SET]
+6:
+  000006:[z#15,SET-z#15,SET]
+
+reopen
+----
+
+lsm
+----
+0.0:
+  000007:[a#10,SET-c#12,SET]
+6:
+  000006:[z#15,SET-z#15,SET]


### PR DESCRIPTION
Problem explained in detail in: https://github.com/cockroachdb/pebble/issues/2947#issuecomment-1738225516

We were adding too many CreatedBackingTables entries to the manifest. Such an
entry should only be added when an sstable is first virtualized. This is
mentioned as an invariant above VersionEdit.CreatedBackingTables.

Note that the excise function will create backing tables and add them to the
version edit. But these backing tables should only be added to the version edit,
if the sstable being virtualized is NOT virtual. If we're further virtualizing
an already virtual sstable, then a backing table entry associated with the file
backing will already be present in the manifest as part of an older version edit.