### PR TITLE
db: cleanup btree obsoletion logic

### DIFF
--- a/internal/manifest/btree_test.go
+++ b/internal/manifest/btree_test.go
@@ -487,7 +487,7 @@ func TestBTreeCloneConcurrentOperations(t *testing.T) {
 		}
 	}
 
-	var obsolete []*FileMetadata
+	var obsolete []*FileBacking
 	for i := range trees {
 		obsolete = append(obsolete, trees[i].Release()...)
 	}

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -30,7 +30,7 @@ func (lm *LevelMetadata) clone() LevelMetadata {
 	}
 }
 
-func (lm *LevelMetadata) release() (obsolete []*FileMetadata) {
+func (lm *LevelMetadata) release() (obsolete []*FileBacking) {
 	return lm.tree.Release()
 }
 

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -1204,12 +1204,7 @@ func (v *Version) Unref() {
 		l := v.list
 		l.mu.Lock()
 		l.Remove(v)
-		obsolete := v.unrefFiles()
-		fileBacking := make([]*FileBacking, len(obsolete))
-		for i, f := range obsolete {
-			fileBacking[i] = f.FileBacking
-		}
-		v.Deleted(fileBacking)
+		v.Deleted(v.unrefFiles())
 		l.mu.Unlock()
 	}
 }
@@ -1221,17 +1216,12 @@ func (v *Version) Unref() {
 func (v *Version) UnrefLocked() {
 	if v.refs.Add(-1) == 0 {
 		v.list.Remove(v)
-		obsolete := v.unrefFiles()
-		fileBacking := make([]*FileBacking, len(obsolete))
-		for i, f := range obsolete {
-			fileBacking[i] = f.FileBacking
-		}
-		v.Deleted(fileBacking)
+		v.Deleted(v.unrefFiles())
 	}
 }
 
-func (v *Version) unrefFiles() []*FileMetadata {
-	var obsolete []*FileMetadata
+func (v *Version) unrefFiles() []*FileBacking {
+	var obsolete []*FileBacking
 	for _, lm := range v.Levels {
 		obsolete = append(obsolete, lm.release()...)
 	}


### PR DESCRIPTION
1. By returning FileBackings from the LevelMetadata.release functions, we can clean up some duplication in Version.Unref and Version.UnrefLocked.

2.
It is not obvious how Pebble determines when it is okay to delete the backing sstable associated with a virtual sstable.

The flow is that Filemetadata refcounting actually happens on the FileBacking. Multiple virtual sstables with the same backing sstable will share the same FileBacking struct. Once the refcount on the FileBacking struct hits 0, we know that 0 virtual sstables require that FileBacking, and therefore it is safe to delete the backing sstable.

This pr adds some commentary which explains this.

It was a bit awkward prior to this pr when a btree returns an obsolete virtual metadata, and then we grab the filebacking from the obsolete virtual meta to delete that.