### PR TITLE
go.mod: specify Go 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,4 +43,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0 // indirect
 )
 
-go 1.19
+go 1.20


### PR DESCRIPTION
Cockroach now uses 1.20.