### PR TITLE
*: return *InternalKV from internal iterators

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -964,9 +964,9 @@ func TestBatchRangeOps(t *testing.T) {
 					fmt.Fprintln(&buf, s)
 				}
 			} else {
-				for k, v := internalIter.First(); k != nil; k, v = internalIter.Next() {
-					k.SetSeqNum(k.SeqNum() &^ InternalKeySeqNumBatch)
-					fmt.Fprintf(&buf, "%s:%s\n", k, v.InPlaceValue())
+				for kv := internalIter.First(); kv != nil; kv = internalIter.Next() {
+					kv.SetSeqNum(kv.SeqNum() &^ InternalKeySeqNumBatch)
+					fmt.Fprintf(&buf, "%s:%s\n", kv.InternalKey, kv.InPlaceValue())
 				}
 			}
 			return buf.String()
@@ -1145,8 +1145,8 @@ func TestFlushableBatchDeleteRange(t *testing.T) {
 }
 
 func scanInternalIter(w io.Writer, ii internalIterator) {
-	for k, v := ii.First(); k != nil; k, v = ii.Next() {
-		fmt.Fprintf(w, "%s:%s\n", k, v.InPlaceValue())
+	for kv := ii.First(); kv != nil; kv = ii.Next() {
+		fmt.Fprintf(w, "%s:%s\n", kv.InternalKey, kv.InPlaceValue())
 	}
 }
 
@@ -1169,7 +1169,7 @@ func TestFlushableBatchBytesIterated(t *testing.T) {
 		it := fb.newFlushIter(nil, &bytesIterated)
 
 		var prevIterated uint64
-		for key, _ := it.First(); key != nil; key, _ = it.Next() {
+		for kv := it.First(); kv != nil; kv = it.Next() {
 			if bytesIterated < prevIterated {
 				t.Fatalf("bytesIterated moved backward: %d < %d", bytesIterated, prevIterated)
 			}

--- a/compaction.go
+++ b/compaction.go
@@ -895,18 +895,18 @@ func newFlush(
 
 	smallestSet, largestSet := false, false
 	updatePointBounds := func(iter internalIterator) {
-		if key, _ := iter.First(); key != nil {
+		if kv := iter.First(); kv != nil {
 			if !smallestSet ||
-				base.InternalCompare(c.cmp, c.smallest, *key) > 0 {
+				base.InternalCompare(c.cmp, c.smallest, kv.InternalKey) > 0 {
 				smallestSet = true
-				c.smallest = key.Clone()
+				c.smallest = kv.InternalKey.Clone()
 			}
 		}
-		if key, _ := iter.Last(); key != nil {
+		if kv := iter.Last(); kv != nil {
 			if !largestSet ||
-				base.InternalCompare(c.cmp, c.largest, *key) < 0 {
+				base.InternalCompare(c.cmp, c.largest, kv.InternalKey) < 0 {
 				largestSet = true
-				c.largest = key.Clone()
+				c.largest = kv.InternalKey.Clone()
 			}
 		}
 	}

--- a/compaction_iter_test.go
+++ b/compaction_iter_test.go
@@ -79,9 +79,8 @@ func (m *debugMerger) Finish(includesBase bool) ([]byte, io.Closer, error) {
 
 func TestCompactionIter(t *testing.T) {
 	var merge Merge
-	var keys []InternalKey
+	var kvs []base.InternalKV
 	var rangeKeys []keyspan.Span
-	var vals [][]byte
 	var snapshots []uint64
 	var elideTombstones bool
 	var allowZeroSeqnum bool
@@ -104,7 +103,7 @@ func TestCompactionIter(t *testing.T) {
 		// SSTables are not released while iterating, and therefore not
 		// susceptible to use-after-free bugs, we skip the zeroing of
 		// RangeDelete keys.
-		fi := &fakeIter{keys: keys, vals: vals}
+		fi := &fakeIter{kvs: kvs}
 		interleavingIter = &keyspan.InterleavingIter{}
 		interleavingIter.Init(
 			base.DefaultComparer,
@@ -149,22 +148,23 @@ func TestCompactionIter(t *testing.T) {
 					len(d.CmdArgs[0].Vals) > 0 && d.CmdArgs[0].Vals[0] == "deletable" {
 					merge = newDeletableSumValueMerger
 				}
-				keys = keys[:0]
-				vals = vals[:0]
+				kvs = kvs[:0]
 				rangeKeys = rangeKeys[:0]
 				for _, key := range strings.Split(d.Input, "\n") {
 					j := strings.Index(key, ":")
-					keys = append(keys, base.ParseInternalKey(key[:j]))
 
+					var kv base.InternalKV
+					kv.InternalKey = base.ParseInternalKey(key[:j])
 					if strings.HasPrefix(key[j+1:], "varint(") {
 						valueStr := strings.TrimSuffix(strings.TrimPrefix(key[j+1:], "varint("), ")")
 						v, err := strconv.ParseUint(valueStr, 10, 64)
 						require.NoError(t, err)
 						encodedValue := binary.AppendUvarint([]byte(nil), v)
-						vals = append(vals, encodedValue)
+						kv.LazyValue = base.MakeInPlaceValue(encodedValue)
 					} else {
-						vals = append(vals, []byte(key[j+1:]))
+						kv.LazyValue = base.MakeInPlaceValue([]byte(key[j+1:]))
 					}
+					kvs = append(kvs, kv)
 				}
 				return ""
 

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -966,8 +966,8 @@ func TestCompaction(t *testing.T) {
 
 	get1 := func(iter internalIterator) (ret string) {
 		b := &bytes.Buffer{}
-		for key, _ := iter.First(); key != nil; key, _ = iter.Next() {
-			b.Write(key.UserKey)
+		for kv := iter.First(); kv != nil; kv = iter.Next() {
+			b.Write(kv.UserKey)
 		}
 		if err := iter.Close(); err != nil {
 			t.Fatalf("iterator Close: %v", err)

--- a/db.go
+++ b/db.go
@@ -2863,7 +2863,7 @@ func (d *DB) checkVirtualBounds(m *fileMetadata) {
 			defer rangeDelIter.Close()
 		}
 
-		pointKey, _ := pointIter.First()
+		pointKey := pointIter.First()
 		var rangeDel *keyspan.Span
 		if rangeDelIter != nil {
 			rangeDel = rangeDelIter.First()
@@ -2875,7 +2875,7 @@ func (d *DB) checkVirtualBounds(m *fileMetadata) {
 			panic(errors.Newf("pebble: virtual sstable %s lower point key bound is not tight", m.FileNum))
 		}
 
-		pointKey, _ = pointIter.Last()
+		pointKey = pointIter.Last()
 		rangeDel = nil
 		if rangeDelIter != nil {
 			rangeDel = rangeDelIter.Last()
@@ -2888,9 +2888,9 @@ func (d *DB) checkVirtualBounds(m *fileMetadata) {
 		}
 
 		// Check that iterator keys are within bounds.
-		for key, _ := pointIter.First(); key != nil; key, _ = pointIter.Next() {
-			if d.cmp(key.UserKey, m.SmallestPointKey.UserKey) < 0 || d.cmp(key.UserKey, m.LargestPointKey.UserKey) > 0 {
-				panic(errors.Newf("pebble: virtual sstable %s point key %s is not within bounds", m.FileNum, key.UserKey))
+		for kv := pointIter.First(); kv != nil; kv = pointIter.Next() {
+			if d.cmp(kv.UserKey, m.SmallestPointKey.UserKey) < 0 || d.cmp(kv.UserKey, m.LargestPointKey.UserKey) > 0 {
+				panic(errors.Newf("pebble: virtual sstable %s point key %s is not within bounds", m.FileNum, kv.UserKey))
 			}
 		}
 

--- a/error_iter.go
+++ b/error_iter.go
@@ -20,38 +20,36 @@ func newErrorIter(err error) *errorIter {
 	return &errorIter{err: err}
 }
 
-func (c *errorIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, base.LazyValue) {
-	return nil, base.LazyValue{}
+func (c *errorIter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
+	return nil
 }
 
-func (c *errorIter) SeekPrefixGE(
-	prefix, key []byte, flags base.SeekGEFlags,
-) (*base.InternalKey, base.LazyValue) {
-	return nil, base.LazyValue{}
+func (c *errorIter) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) *base.InternalKV {
+	return nil
 }
 
-func (c *errorIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, base.LazyValue) {
-	return nil, base.LazyValue{}
+func (c *errorIter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
+	return nil
 }
 
-func (c *errorIter) First() (*InternalKey, base.LazyValue) {
-	return nil, base.LazyValue{}
+func (c *errorIter) First() *base.InternalKV {
+	return nil
 }
 
-func (c *errorIter) Last() (*InternalKey, base.LazyValue) {
-	return nil, base.LazyValue{}
+func (c *errorIter) Last() *base.InternalKV {
+	return nil
 }
 
-func (c *errorIter) Next() (*InternalKey, base.LazyValue) {
-	return nil, base.LazyValue{}
+func (c *errorIter) Next() *base.InternalKV {
+	return nil
 }
 
-func (c *errorIter) Prev() (*InternalKey, base.LazyValue) {
-	return nil, base.LazyValue{}
+func (c *errorIter) Prev() *base.InternalKV {
+	return nil
 }
 
-func (c *errorIter) NextPrefix([]byte) (*InternalKey, base.LazyValue) {
-	return nil, base.LazyValue{}
+func (c *errorIter) NextPrefix([]byte) *base.InternalKV {
+	return nil
 }
 
 func (c *errorIter) Error() error {

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -396,28 +396,26 @@ func (s *simpleLevelIter) resetFilteredIters() {
 	s.firstKeysBuf = s.firstKeysBuf[:0]
 	s.err = nil
 	for i := range s.iters {
-		var iterKey *base.InternalKey
+		var iterKV *base.InternalKV
 		if s.lowerBound != nil {
-			iterKey, _ = s.iters[i].SeekGE(s.lowerBound, base.SeekGEFlagsNone)
+			iterKV = s.iters[i].SeekGE(s.lowerBound, base.SeekGEFlagsNone)
 		} else {
-			iterKey, _ = s.iters[i].First()
+			iterKV = s.iters[i].First()
 		}
-		if iterKey != nil {
+		if iterKV != nil {
 			s.filtered = append(s.filtered, s.iters[i])
 			bufStart := len(s.firstKeysBuf)
-			s.firstKeysBuf = append(s.firstKeysBuf, iterKey.UserKey...)
-			s.firstKeys = append(s.firstKeys, s.firstKeysBuf[bufStart:bufStart+len(iterKey.UserKey)])
+			s.firstKeysBuf = append(s.firstKeysBuf, iterKV.UserKey...)
+			s.firstKeys = append(s.firstKeys, s.firstKeysBuf[bufStart:bufStart+len(iterKV.UserKey)])
 		} else if err := s.iters[i].Error(); err != nil {
 			s.err = err
 		}
 	}
 }
 
-func (s *simpleLevelIter) SeekGE(
-	key []byte, flags base.SeekGEFlags,
-) (*base.InternalKey, base.LazyValue) {
+func (s *simpleLevelIter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	if s.err != nil {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	// Find the first file that is entirely >= key. The file before that could
 	// contain the key we're looking for.
@@ -430,8 +428,8 @@ func (s *simpleLevelIter) SeekGE(
 		s.currentIdx = n
 	}
 	if s.currentIdx < len(s.filtered) {
-		if iterKey, val := s.filtered[s.currentIdx].SeekGE(key, flags); iterKey != nil {
-			return iterKey, val
+		if iterKV := s.filtered[s.currentIdx].SeekGE(key, flags); iterKV != nil {
+			return iterKV
 		}
 		if err := s.filtered[s.currentIdx].Error(); err != nil {
 			s.err = err
@@ -443,81 +441,78 @@ func (s *simpleLevelIter) SeekGE(
 
 func (s *simpleLevelIter) skipEmptyFileForward(
 	seekKey []byte, flags base.SeekGEFlags,
-) (*base.InternalKey, base.LazyValue) {
-	var iterKey *base.InternalKey
-	var val base.LazyValue
+) *base.InternalKV {
+	var iterKV *base.InternalKV
 	for s.currentIdx >= 0 && s.currentIdx < len(s.filtered) && s.err == nil {
 		if seekKey != nil {
-			iterKey, val = s.filtered[s.currentIdx].SeekGE(seekKey, flags)
+			iterKV = s.filtered[s.currentIdx].SeekGE(seekKey, flags)
 		} else if s.lowerBound != nil {
-			iterKey, val = s.filtered[s.currentIdx].SeekGE(s.lowerBound, flags)
+			iterKV = s.filtered[s.currentIdx].SeekGE(s.lowerBound, flags)
 		} else {
-			iterKey, val = s.filtered[s.currentIdx].First()
+			iterKV = s.filtered[s.currentIdx].First()
 		}
-		if iterKey != nil {
-			return iterKey, val
+		if iterKV != nil {
+			return iterKV
 		}
 		if err := s.filtered[s.currentIdx].Error(); err != nil {
 			s.err = err
 		}
 		s.currentIdx++
 	}
-	return nil, base.LazyValue{}
+	return nil
 }
 
 func (s *simpleLevelIter) SeekPrefixGE(
 	prefix, key []byte, flags base.SeekGEFlags,
-) (*base.InternalKey, base.LazyValue) {
+) *base.InternalKV {
 	panic("unimplemented")
 }
 
-func (s *simpleLevelIter) SeekLT(
-	key []byte, flags base.SeekLTFlags,
-) (*base.InternalKey, base.LazyValue) {
+func (s *simpleLevelIter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
 	panic("unimplemented")
 }
 
-func (s *simpleLevelIter) First() (*base.InternalKey, base.LazyValue) {
+func (s *simpleLevelIter) First() *base.InternalKV {
 	if s.err != nil {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	s.currentIdx = 0
 	return s.skipEmptyFileForward(nil /* seekKey */, base.SeekGEFlagsNone)
 }
 
-func (s *simpleLevelIter) Last() (*base.InternalKey, base.LazyValue) {
+func (s *simpleLevelIter) Last() *base.InternalKV {
 	panic("unimplemented")
 }
 
-func (s *simpleLevelIter) Next() (*base.InternalKey, base.LazyValue) {
+func (s *simpleLevelIter) Next() *base.InternalKV {
 	if s.err != nil {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	if s.currentIdx < 0 || s.currentIdx >= len(s.filtered) {
-		return nil, base.LazyValue{}
+		return nil
 	}
-	if iterKey, val := s.filtered[s.currentIdx].Next(); iterKey != nil {
-		return iterKey, val
+	if iterKV := s.filtered[s.currentIdx].Next(); iterKV != nil {
+		return iterKV
 	}
 	s.currentIdx++
 	return s.skipEmptyFileForward(nil /* seekKey */, base.SeekGEFlagsNone)
 }
 
-func (s *simpleLevelIter) NextPrefix(succKey []byte) (*base.InternalKey, base.LazyValue) {
+func (s *simpleLevelIter) NextPrefix(succKey []byte) *base.InternalKV {
 	if s.err != nil {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	if s.currentIdx < 0 || s.currentIdx >= len(s.filtered) {
-		return nil, base.LazyValue{}
+		return nil
 	}
-	if iterKey, val := s.filtered[s.currentIdx].NextPrefix(succKey); iterKey != nil {
-		return iterKey, val
+	if iterKV := s.filtered[s.currentIdx].NextPrefix(succKey); iterKV != nil {
+		return iterKV
 	}
 	s.currentIdx++
 	return s.skipEmptyFileForward(succKey /* seekKey */, base.SeekGEFlagsNone)
 }
 
-func (s *simpleLevelIter) Prev() (*base.InternalKey, base.LazyValue) {
+func (s *simpleLevelIter) Prev() *base.InternalKV {
 	panic("unimplemented")
 }
 

--- a/external_iterator_test.go
+++ b/external_iterator_test.go
@@ -137,8 +137,8 @@ func TestSimpleIterError(t *testing.T) {
 	s.init(IterOptions{})
 	defer s.Close()
 
-	iterKey, _ := s.First()
-	require.Nil(t, iterKey)
+	iterKV := s.First()
+	require.Nil(t, iterKV)
 	require.Error(t, s.Error())
 }
 
@@ -294,12 +294,12 @@ func TestIterRandomizedMaybeFilteredKeys(t *testing.T) {
 				}
 				lastSeekKey = append(lastSeekKey[:0], seekKey...)
 
-				newKey, _ := iter.SeekGE(seekKey, flags)
-				if newKey == nil || !bytes.Equal(newKey.UserKey, seekKey) {
+				newKV := iter.SeekGE(seekKey, flags)
+				if newKV == nil || !bytes.Equal(newKV.UserKey, seekKey) {
 					// We skipped some keys. Check if maybeFilteredKeys is true.
 					formattedNewKey := "<nil>"
-					if newKey != nil {
-						formattedNewKey = fmt.Sprintf("%s", testkeys.Comparer.FormatKey(newKey.UserKey))
+					if newKV != nil {
+						formattedNewKey = fmt.Sprintf("%s", testkeys.Comparer.FormatKey(newKV.UserKey))
 					}
 					require.True(t, iter.MaybeFilteredKeys(), "seeked for key = %s, got key = %s indicating block property filtering but MaybeFilteredKeys = false", testkeys.Comparer.FormatKey(seekKey), formattedNewKey)
 				}

--- a/flushable_test.go
+++ b/flushable_test.go
@@ -123,8 +123,8 @@ func TestIngestedSSTFlushableAPI(t *testing.T) {
 		case "iter":
 			iter := flushable.newIter(nil)
 			var buf bytes.Buffer
-			for x, _ := iter.First(); x != nil; x, _ = iter.Next() {
-				buf.WriteString(x.String())
+			for x := iter.First(); x != nil; x = iter.Next() {
+				buf.WriteString(x.InternalKey.String())
 				buf.WriteString("\n")
 			}
 			iter.Close()

--- a/internal/arenaskl/flush_iterator.go
+++ b/internal/arenaskl/flush_iterator.go
@@ -34,21 +34,15 @@ func (it *flushIterator) String() string {
 	return "memtable"
 }
 
-func (it *flushIterator) SeekGE(
-	key []byte, flags base.SeekGEFlags,
-) (*base.InternalKey, base.LazyValue) {
+func (it *flushIterator) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	panic("pebble: SeekGE unimplemented")
 }
 
-func (it *flushIterator) SeekPrefixGE(
-	prefix, key []byte, flags base.SeekGEFlags,
-) (*base.InternalKey, base.LazyValue) {
+func (it *flushIterator) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	panic("pebble: SeekPrefixGE unimplemented")
 }
 
-func (it *flushIterator) SeekLT(
-	key []byte, flags base.SeekLTFlags,
-) (*base.InternalKey, base.LazyValue) {
+func (it *flushIterator) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
 	panic("pebble: SeekLT unimplemented")
 }
 
@@ -56,33 +50,34 @@ func (it *flushIterator) SeekLT(
 // if the iterator is pointing at a valid entry, and (nil, nil) otherwise. Note
 // that First only checks the upper bound. It is up to the caller to ensure
 // that key is greater than or equal to the lower bound.
-func (it *flushIterator) First() (*base.InternalKey, base.LazyValue) {
-	key, val := it.Iterator.First()
-	if key == nil {
-		return nil, base.LazyValue{}
+func (it *flushIterator) First() *base.InternalKV {
+	kv := it.Iterator.First()
+	if kv == nil {
+		return nil
 	}
 	*it.bytesIterated += uint64(it.nd.allocSize)
-	return key, val
+	return kv
 }
 
 // Next advances to the next position. Returns the key and value if the
 // iterator is pointing at a valid entry, and (nil, nil) otherwise.
 // Note: flushIterator.Next mirrors the implementation of Iterator.Next
 // due to performance. Keep the two in sync.
-func (it *flushIterator) Next() (*base.InternalKey, base.LazyValue) {
+func (it *flushIterator) Next() *base.InternalKV {
 	it.nd = it.list.getNext(it.nd, 0)
 	if it.nd == it.list.tail {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	it.decodeKey()
 	*it.bytesIterated += uint64(it.nd.allocSize)
-	return &it.key, base.MakeInPlaceValue(it.value())
+	it.kv.LazyValue = base.MakeInPlaceValue(it.value())
+	return &it.kv
 }
 
-func (it *flushIterator) NextPrefix(succKey []byte) (*base.InternalKey, base.LazyValue) {
+func (it *flushIterator) NextPrefix(succKey []byte) *base.InternalKV {
 	panic("pebble: NextPrefix unimplemented")
 }
 
-func (it *flushIterator) Prev() (*base.InternalKey, base.LazyValue) {
+func (it *flushIterator) Prev() *base.InternalKV {
 	panic("pebble: Prev unimplemented")
 }

--- a/internal/arenaskl/iterator.go
+++ b/internal/arenaskl/iterator.go
@@ -39,7 +39,7 @@ func (s *splice) init(prev, next *node) {
 type Iterator struct {
 	list  *Skiplist
 	nd    *node
-	key   base.InternalKey
+	kv    base.InternalKV
 	lower []byte
 	upper []byte
 }
@@ -77,49 +77,49 @@ func (it *Iterator) Error() error {
 // pointing at a valid entry, and (nil, nil) otherwise. Note that SeekGE only
 // checks the upper bound. It is up to the caller to ensure that key is greater
 // than or equal to the lower bound.
-func (it *Iterator) SeekGE(key []byte, flags base.SeekGEFlags) (*base.InternalKey, base.LazyValue) {
+func (it *Iterator) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	if flags.TrySeekUsingNext() {
 		if it.nd == it.list.tail {
 			// Iterator is done.
-			return nil, base.LazyValue{}
+			return nil
 		}
-		less := it.list.cmp(it.key.UserKey, key) < 0
+		less := it.list.cmp(it.kv.UserKey, key) < 0
 		// Arbitrary constant. By measuring the seek cost as a function of the
 		// number of elements in the skip list, and fitting to a model, we
 		// could adjust the number of nexts based on the current size of the
 		// skip list.
 		const numNexts = 5
 		for i := 0; less && i < numNexts; i++ {
-			k, _ := it.Next()
-			if k == nil {
+			kv := it.Next()
+			if kv == nil {
 				// Iterator is done.
-				return nil, base.LazyValue{}
+				return nil
 			}
-			less = it.list.cmp(it.key.UserKey, key) < 0
+			less = it.list.cmp(it.kv.UserKey, key) < 0
 		}
 		if !less {
-			return &it.key, base.MakeInPlaceValue(it.value())
+			it.kv.LazyValue = base.MakeInPlaceValue(it.value())
+			return &it.kv
 		}
 	}
 	_, it.nd, _ = it.seekForBaseSplice(key)
 	if it.nd == it.list.tail {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	it.decodeKey()
-	if it.upper != nil && it.list.cmp(it.upper, it.key.UserKey) <= 0 {
+	if it.upper != nil && it.list.cmp(it.upper, it.kv.UserKey) <= 0 {
 		it.nd = it.list.tail
-		return nil, base.LazyValue{}
+		return nil
 	}
-	return &it.key, base.MakeInPlaceValue(it.value())
+	it.kv.LazyValue = base.MakeInPlaceValue(it.value())
+	return &it.kv
 }
 
 // SeekPrefixGE moves the iterator to the first entry whose key is greater than
 // or equal to the given key. This method is equivalent to SeekGE and is
 // provided so that an arenaskl.Iterator implements the
 // internal/base.InternalIterator interface.
-func (it *Iterator) SeekPrefixGE(
-	prefix, key []byte, flags base.SeekGEFlags,
-) (*base.InternalKey, base.LazyValue) {
+func (it *Iterator) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	return it.SeekGE(key, flags)
 }
 
@@ -127,92 +127,97 @@ func (it *Iterator) SeekPrefixGE(
 // key. Returns the key and value if the iterator is pointing at a valid entry,
 // and (nil, nil) otherwise. Note that SeekLT only checks the lower bound. It
 // is up to the caller to ensure that key is less than the upper bound.
-func (it *Iterator) SeekLT(key []byte, flags base.SeekLTFlags) (*base.InternalKey, base.LazyValue) {
+func (it *Iterator) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
 	// NB: the top-level Iterator has already adjusted key based on
 	// the upper-bound.
 	it.nd, _, _ = it.seekForBaseSplice(key)
 	if it.nd == it.list.head {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	it.decodeKey()
-	if it.lower != nil && it.list.cmp(it.lower, it.key.UserKey) > 0 {
+	if it.lower != nil && it.list.cmp(it.lower, it.kv.UserKey) > 0 {
 		it.nd = it.list.head
-		return nil, base.LazyValue{}
+		return nil
 	}
-	return &it.key, base.MakeInPlaceValue(it.value())
+	it.kv.LazyValue = base.MakeInPlaceValue(it.value())
+	return &it.kv
 }
 
 // First seeks position at the first entry in list. Returns the key and value
 // if the iterator is pointing at a valid entry, and (nil, nil) otherwise. Note
 // that First only checks the upper bound. It is up to the caller to ensure
 // that key is greater than or equal to the lower bound (e.g. via a call to SeekGE(lower)).
-func (it *Iterator) First() (*base.InternalKey, base.LazyValue) {
+func (it *Iterator) First() *base.InternalKV {
 	it.nd = it.list.getNext(it.list.head, 0)
 	if it.nd == it.list.tail {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	it.decodeKey()
-	if it.upper != nil && it.list.cmp(it.upper, it.key.UserKey) <= 0 {
+	if it.upper != nil && it.list.cmp(it.upper, it.kv.InternalKey.UserKey) <= 0 {
 		it.nd = it.list.tail
-		return nil, base.LazyValue{}
+		return nil
 	}
-	return &it.key, base.MakeInPlaceValue(it.value())
+	it.kv.LazyValue = base.MakeInPlaceValue(it.value())
+	return &it.kv
 }
 
 // Last seeks position at the last entry in list. Returns the key and value if
 // the iterator is pointing at a valid entry, and (nil, nil) otherwise. Note
 // that Last only checks the lower bound. It is up to the caller to ensure that
 // key is less than the upper bound (e.g. via a call to SeekLT(upper)).
-func (it *Iterator) Last() (*base.InternalKey, base.LazyValue) {
+func (it *Iterator) Last() *base.InternalKV {
 	it.nd = it.list.getPrev(it.list.tail, 0)
 	if it.nd == it.list.head {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	it.decodeKey()
-	if it.lower != nil && it.list.cmp(it.lower, it.key.UserKey) > 0 {
+	if it.lower != nil && it.list.cmp(it.lower, it.kv.InternalKey.UserKey) > 0 {
 		it.nd = it.list.head
-		return nil, base.LazyValue{}
+		return nil
 	}
-	return &it.key, base.MakeInPlaceValue(it.value())
+	it.kv.LazyValue = base.MakeInPlaceValue(it.value())
+	return &it.kv
 }
 
 // Next advances to the next position. Returns the key and value if the
 // iterator is pointing at a valid entry, and (nil, nil) otherwise.
 // Note: flushIterator.Next mirrors the implementation of Iterator.Next
 // due to performance. Keep the two in sync.
-func (it *Iterator) Next() (*base.InternalKey, base.LazyValue) {
+func (it *Iterator) Next() *base.InternalKV {
 	it.nd = it.list.getNext(it.nd, 0)
 	if it.nd == it.list.tail {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	it.decodeKey()
-	if it.upper != nil && it.list.cmp(it.upper, it.key.UserKey) <= 0 {
+	if it.upper != nil && it.list.cmp(it.upper, it.kv.UserKey) <= 0 {
 		it.nd = it.list.tail
-		return nil, base.LazyValue{}
+		return nil
 	}
-	return &it.key, base.MakeInPlaceValue(it.value())
+	it.kv.LazyValue = base.MakeInPlaceValue(it.value())
+	return &it.kv
 }
 
 // NextPrefix advances to the next position with a new prefix. Returns the key
 // and value if the iterator is pointing at a valid entry, and (nil, nil)
 // otherwise.
-func (it *Iterator) NextPrefix(succKey []byte) (*base.InternalKey, base.LazyValue) {
+func (it *Iterator) NextPrefix(succKey []byte) *base.InternalKV {
 	return it.SeekGE(succKey, base.SeekGEFlagsNone.EnableTrySeekUsingNext())
 }
 
 // Prev moves to the previous position. Returns the key and value if the
 // iterator is pointing at a valid entry, and (nil, nil) otherwise.
-func (it *Iterator) Prev() (*base.InternalKey, base.LazyValue) {
+func (it *Iterator) Prev() *base.InternalKV {
 	it.nd = it.list.getPrev(it.nd, 0)
 	if it.nd == it.list.head {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	it.decodeKey()
-	if it.lower != nil && it.list.cmp(it.lower, it.key.UserKey) > 0 {
+	if it.lower != nil && it.list.cmp(it.lower, it.kv.UserKey) > 0 {
 		it.nd = it.list.head
-		return nil, base.LazyValue{}
+		return nil
 	}
-	return &it.key, base.MakeInPlaceValue(it.value())
+	it.kv.LazyValue = base.MakeInPlaceValue(it.value())
+	return &it.kv
 }
 
 // value returns the value at the current position.
@@ -239,8 +244,8 @@ func (it *Iterator) SetBounds(lower, upper []byte) {
 }
 
 func (it *Iterator) decodeKey() {
-	it.key.UserKey = it.list.arena.getBytes(it.nd.keyOffset, it.nd.keySize)
-	it.key.Trailer = it.nd.keyTrailer
+	it.kv.UserKey = it.list.arena.getBytes(it.nd.keyOffset, it.nd.keySize)
+	it.kv.Trailer = it.nd.keyTrailer
 }
 
 func (it *Iterator) seekForBaseSplice(key []byte) (prev, next *node, found bool) {

--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -161,6 +161,12 @@ func (k InternalKeyKind) String() string {
 	return fmt.Sprintf("UNKNOWN:%d", k)
 }
 
+// InternalKV represents a single internal key-value pair.
+type InternalKV struct {
+	InternalKey
+	LazyValue
+}
+
 // InternalKey is a key used for the in-memory and on-disk partial DBs that
 // make up a pebble DB.
 //

--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -98,7 +98,7 @@ type InternalIterator interface {
 	// is pointing at a valid entry, and (nil, nilv) otherwise. Note that SeekGE
 	// only checks the upper bound. It is up to the caller to ensure that key
 	// is greater than or equal to the lower bound.
-	SeekGE(key []byte, flags SeekGEFlags) (*InternalKey, LazyValue)
+	SeekGE(key []byte, flags SeekGEFlags) *InternalKV
 
 	// SeekPrefixGE moves the iterator to the first key/value pair whose key is
 	// greater than or equal to the given key. Returns the key and value if the
@@ -123,28 +123,28 @@ type InternalIterator interface {
 	// not supporting reverse iteration in prefix iteration mode until a
 	// different positioning routine (SeekGE, SeekLT, First or Last) switches the
 	// iterator out of prefix iteration.
-	SeekPrefixGE(prefix, key []byte, flags SeekGEFlags) (*InternalKey, LazyValue)
+	SeekPrefixGE(prefix, key []byte, flags SeekGEFlags) *InternalKV
 
 	// SeekLT moves the iterator to the last key/value pair whose key is less
 	// than the given key. Returns the key and value if the iterator is pointing
 	// at a valid entry, and (nil, nilv) otherwise. Note that SeekLT only checks
 	// the lower bound. It is up to the caller to ensure that key is less than
 	// the upper bound.
-	SeekLT(key []byte, flags SeekLTFlags) (*InternalKey, LazyValue)
+	SeekLT(key []byte, flags SeekLTFlags) *InternalKV
 
 	// First moves the iterator the the first key/value pair. Returns the key and
 	// value if the iterator is pointing at a valid entry, and (nil, nilv)
 	// otherwise. Note that First only checks the upper bound. It is up to the
 	// caller to ensure that First() is not called when there is a lower bound,
 	// and instead call SeekGE(lower).
-	First() (*InternalKey, LazyValue)
+	First() *InternalKV
 
 	// Last moves the iterator the the last key/value pair. Returns the key and
 	// value if the iterator is pointing at a valid entry, and (nil, nilv)
 	// otherwise. Note that Last only checks the lower bound. It is up to the
 	// caller to ensure that Last() is not called when there is an upper bound,
 	// and instead call SeekLT(upper).
-	Last() (*InternalKey, LazyValue)
+	Last() *InternalKV
 
 	// Next moves the iterator to the next key/value pair. Returns the key and
 	// value if the iterator is pointing at a valid entry, and (nil, nilv)
@@ -155,7 +155,7 @@ type InternalIterator interface {
 	// key/value pair due to either a prior call to SeekLT or Prev which returned
 	// (nil, nilv). It is not allowed to call Next when the previous call to SeekGE,
 	// SeekPrefixGE or Next returned (nil, nilv).
-	Next() (*InternalKey, LazyValue)
+	Next() *InternalKV
 
 	// NextPrefix moves the iterator to the next key/value pair with a different
 	// prefix than the key at the current iterator position. Returns the key and
@@ -171,7 +171,7 @@ type InternalIterator interface {
 	// positioning operation or a call to a forward positioning method that
 	// returned (nil, nilv). It is also not allowed to call NextPrefix when the
 	// iterator is in prefix iteration mode.
-	NextPrefix(succKey []byte) (*InternalKey, LazyValue)
+	NextPrefix(succKey []byte) *InternalKV
 
 	// Prev moves the iterator to the previous key/value pair. Returns the key
 	// and value if the iterator is pointing at a valid entry, and (nil, nilv)
@@ -182,7 +182,7 @@ type InternalIterator interface {
 	// key/value pair due to either a prior call to SeekGE or Next which returned
 	// (nil, nilv). It is not allowed to call Prev when the previous call to SeekLT
 	// or Prev returned (nil, nilv).
-	Prev() (*InternalKey, LazyValue)
+	Prev() *InternalKV
 
 	// Error returns any accumulated error. It may not include errors returned
 	// to the client when calling LazyValue.Value().

--- a/internal/invalidating/iter.go
+++ b/internal/invalidating/iter.go
@@ -25,8 +25,7 @@ func MaybeWrapIfInvariants(iter base.InternalIterator) base.InternalIterator {
 // returned key/value to all 1s.
 type iter struct {
 	iter        base.InternalIterator
-	lastKey     *base.InternalKey
-	lastValue   base.LazyValue
+	lastKV      *base.InternalKV
 	ignoreKinds [base.InternalKeyKindMax + 1]bool
 	err         error
 }
@@ -61,84 +60,80 @@ func NewIter(originalIterator base.InternalIterator, opts ...Option) base.Intern
 	return i
 }
 
-func (i *iter) update(
-	key *base.InternalKey, value base.LazyValue,
-) (*base.InternalKey, base.LazyValue) {
+func (i *iter) update(kv *base.InternalKV) *base.InternalKV {
 	i.trashLastKV()
-	if key == nil {
-		i.lastKey = nil
-		i.lastValue = base.LazyValue{}
-		return nil, base.LazyValue{}
+	if kv == nil {
+		i.lastKV = nil
+		return nil
 	}
 
-	i.lastKey = &base.InternalKey{}
-	*i.lastKey = key.Clone()
-	i.lastValue = base.LazyValue{
-		ValueOrHandle: append(make([]byte, 0, len(value.ValueOrHandle)), value.ValueOrHandle...),
+	i.lastKV = &base.InternalKV{
+		InternalKey: kv.InternalKey.Clone(),
+		LazyValue: base.LazyValue{
+			ValueOrHandle: append(make([]byte, 0, len(kv.ValueOrHandle)), kv.ValueOrHandle...),
+		},
 	}
-	if value.Fetcher != nil {
+	if kv.Fetcher != nil {
 		fetcher := new(base.LazyFetcher)
-		*fetcher = *value.Fetcher
-		i.lastValue.Fetcher = fetcher
+		*fetcher = *kv.Fetcher
+		i.lastKV.Fetcher = fetcher
 	}
-	return i.lastKey, i.lastValue
+	return i.lastKV
 }
 
 func (i *iter) trashLastKV() {
-	if i.lastKey == nil {
+	if i.lastKV == nil {
 		return
 	}
-	if i.ignoreKinds[i.lastKey.Kind()] {
+	if i.ignoreKinds[i.lastKV.Kind()] {
 		return
 	}
 
-	if i.lastKey != nil {
-		for j := range i.lastKey.UserKey {
-			i.lastKey.UserKey[j] = 0xff
+	if i.lastKV != nil {
+		for j := range i.lastKV.UserKey {
+			i.lastKV.UserKey[j] = 0xff
 		}
-		i.lastKey.Trailer = 0xffffffffffffffff
+		i.lastKV.Trailer = 0xffffffffffffffff
 	}
-	for j := range i.lastValue.ValueOrHandle {
-		i.lastValue.ValueOrHandle[j] = 0xff
+	for j := range i.lastKV.ValueOrHandle {
+		i.lastKV.ValueOrHandle[j] = 0xff
 	}
-	if i.lastValue.Fetcher != nil {
+	if i.lastKV.Fetcher != nil {
 		// Not all the LazyFetcher fields are visible, so we zero out the last
 		// value's Fetcher struct entirely.
-		*i.lastValue.Fetcher = base.LazyFetcher{}
+		*i.lastKV.Fetcher = base.LazyFetcher{}
 	}
 }
 
-func (i *iter) SeekGE(key []byte, flags base.SeekGEFlags) (*base.InternalKey, base.LazyValue) {
+func (i *iter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	return i.update(i.iter.SeekGE(key, flags))
 }
 
-func (i *iter) SeekPrefixGE(
-	prefix, key []byte, flags base.SeekGEFlags,
-) (*base.InternalKey, base.LazyValue) {
+func (i *iter) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	return i.update(i.iter.SeekPrefixGE(prefix, key, flags))
 }
 
-func (i *iter) SeekLT(key []byte, flags base.SeekLTFlags) (*base.InternalKey, base.LazyValue) {
+func (i *iter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
 	return i.update(i.iter.SeekLT(key, flags))
 }
 
-func (i *iter) First() (*base.InternalKey, base.LazyValue) {
+func (i *iter) First() *base.InternalKV {
 	return i.update(i.iter.First())
 }
 
-func (i *iter) Last() (*base.InternalKey, base.LazyValue) {
+func (i *iter) Last() *base.InternalKV {
 	return i.update(i.iter.Last())
 }
 
-func (i *iter) Next() (*base.InternalKey, base.LazyValue) {
+func (i *iter) Next() *base.InternalKV {
 	return i.update(i.iter.Next())
 }
 
-func (i *iter) Prev() (*base.InternalKey, base.LazyValue) {
+func (i *iter) Prev() *base.InternalKV {
 	return i.update(i.iter.Prev())
 }
 
-func (i *iter) NextPrefix(succKey []byte) (*base.InternalKey, base.LazyValue) {
+func (i *iter) NextPrefix(succKey []byte) *base.InternalKV {
 	return i.update(i.iter.NextPrefix(succKey))
 }
 

--- a/internal/keyspan/interleaving_iter_test.go
+++ b/internal/keyspan/interleaving_iter_test.go
@@ -79,15 +79,15 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 		split: testkeys.Comparer.Split,
 	}
 
-	var prevKey *base.InternalKey
-	formatKey := func(k *base.InternalKey, _ base.LazyValue) {
-		if k == nil {
+	var prevKV *base.InternalKV
+	formatKey := func(kv *base.InternalKV) {
+		if kv == nil {
 			fmt.Fprint(&buf, ".")
 			return
 		}
-		prevKey = k
+		prevKV = kv
 		s := iter.Span()
-		fmt.Fprintf(&buf, "PointKey: %s\n", k.String())
+		fmt.Fprintf(&buf, "PointKey: %s\n", kv.InternalKey.String())
 		if s != nil {
 			fmt.Fprintf(&buf, "Span: %s\n-", s)
 		} else {
@@ -113,12 +113,12 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 				InterleavingIterOpts{Mask: &hooks})
 			return "OK"
 		case "define-pointkeys":
-			var points []base.InternalKey
+			var points []base.InternalKV
 			lines := strings.Split(strings.TrimSpace(td.Input), "\n")
 			for _, line := range lines {
-				points = append(points, base.ParseInternalKey(line))
+				points = append(points, base.InternalKV{InternalKey: base.ParseInternalKey(line)})
 			}
-			pointIter = pointIterator{cmp: cmp, keys: points}
+			pointIter = pointIterator{cmp: cmp, kvs: points}
 			hooks.maskSuffix = nil
 			iter.Init(testkeys.Comparer, &pointIter, &keyspanIter,
 				InterleavingIterOpts{Mask: &hooks})
@@ -127,7 +127,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 			buf.Reset()
 			// Clear any previous bounds.
 			iter.SetBounds(nil, nil)
-			prevKey = nil
+			prevKV = nil
 			lines := strings.Split(strings.TrimSpace(td.Input), "\n")
 			for _, line := range lines {
 				bufLen := buf.Len()
@@ -145,7 +145,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 				case "next":
 					formatKey(iter.Next())
 				case "next-prefix":
-					succKey := testkeys.Comparer.ImmediateSuccessor(nil, prevKey.UserKey[:testkeys.Comparer.Split(prevKey.UserKey)])
+					succKey := testkeys.Comparer.ImmediateSuccessor(nil, prevKV.UserKey[:testkeys.Comparer.Split(prevKV.UserKey)])
 					formatKey(iter.NextPrefix(succKey))
 				case "prev":
 					formatKey(iter.Prev())
@@ -188,7 +188,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 
 type pointIterator struct {
 	cmp   base.Compare
-	keys  []base.InternalKey
+	kvs   []base.InternalKV
 	lower []byte
 	upper []byte
 	index int
@@ -196,89 +196,83 @@ type pointIterator struct {
 
 var _ base.InternalIterator = &pointIterator{}
 
-func (i *pointIterator) SeekGE(
-	key []byte, flags base.SeekGEFlags,
-) (*base.InternalKey, base.LazyValue) {
-	i.index = sort.Search(len(i.keys), func(j int) bool {
-		return i.cmp(i.keys[j].UserKey, key) >= 0
+func (i *pointIterator) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
+	i.index = sort.Search(len(i.kvs), func(j int) bool {
+		return i.cmp(i.kvs[j].UserKey, key) >= 0
 	})
-	if i.index < 0 || i.index >= len(i.keys) {
-		return nil, base.LazyValue{}
+	if i.index < 0 || i.index >= len(i.kvs) {
+		return nil
 	}
-	if i.upper != nil && i.cmp(i.keys[i.index].UserKey, i.upper) >= 0 {
-		return nil, base.LazyValue{}
+	if i.upper != nil && i.cmp(i.kvs[i.index].UserKey, i.upper) >= 0 {
+		return nil
 	}
-	return &i.keys[i.index], base.LazyValue{}
+	return &i.kvs[i.index]
 }
 
-func (i *pointIterator) SeekPrefixGE(
-	prefix, key []byte, flags base.SeekGEFlags,
-) (*base.InternalKey, base.LazyValue) {
+func (i *pointIterator) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	return i.SeekGE(key, flags)
 }
 
-func (i *pointIterator) SeekLT(
-	key []byte, flags base.SeekLTFlags,
-) (*base.InternalKey, base.LazyValue) {
-	i.index = sort.Search(len(i.keys), func(j int) bool {
-		return i.cmp(i.keys[j].UserKey, key) >= 0
+func (i *pointIterator) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
+	i.index = sort.Search(len(i.kvs), func(j int) bool {
+		return i.cmp(i.kvs[j].UserKey, key) >= 0
 	})
 	i.index--
-	if i.index < 0 || i.index >= len(i.keys) {
-		return nil, base.LazyValue{}
+	if i.index < 0 || i.index >= len(i.kvs) {
+		return nil
 	}
-	if i.lower != nil && i.cmp(i.keys[i.index].UserKey, i.lower) < 0 {
-		return nil, base.LazyValue{}
+	if i.lower != nil && i.cmp(i.kvs[i.index].UserKey, i.lower) < 0 {
+		return nil
 	}
-	return &i.keys[i.index], base.LazyValue{}
+	return &i.kvs[i.index]
 }
 
-func (i *pointIterator) First() (*base.InternalKey, base.LazyValue) {
+func (i *pointIterator) First() *base.InternalKV {
 	i.index = 0
-	if i.index < 0 || i.index >= len(i.keys) {
-		return nil, base.LazyValue{}
+	if i.index < 0 || i.index >= len(i.kvs) {
+		return nil
 	}
-	if i.upper != nil && i.cmp(i.keys[i.index].UserKey, i.upper) >= 0 {
-		return nil, base.LazyValue{}
+	if i.upper != nil && i.cmp(i.kvs[i.index].UserKey, i.upper) >= 0 {
+		return nil
 	}
-	return &i.keys[i.index], base.LazyValue{}
+	return &i.kvs[i.index]
 }
 
-func (i *pointIterator) Last() (*base.InternalKey, base.LazyValue) {
-	i.index = len(i.keys) - 1
-	if i.index < 0 || i.index >= len(i.keys) {
-		return nil, base.LazyValue{}
+func (i *pointIterator) Last() *base.InternalKV {
+	i.index = len(i.kvs) - 1
+	if i.index < 0 || i.index >= len(i.kvs) {
+		return nil
 	}
-	if i.lower != nil && i.cmp(i.keys[i.index].UserKey, i.lower) < 0 {
-		return nil, base.LazyValue{}
+	if i.lower != nil && i.cmp(i.kvs[i.index].UserKey, i.lower) < 0 {
+		return nil
 	}
-	return &i.keys[i.index], base.LazyValue{}
+	return &i.kvs[i.index]
 }
 
-func (i *pointIterator) Next() (*base.InternalKey, base.LazyValue) {
+func (i *pointIterator) Next() *base.InternalKV {
 	i.index++
-	if i.index < 0 || i.index >= len(i.keys) {
-		return nil, base.LazyValue{}
+	if i.index < 0 || i.index >= len(i.kvs) {
+		return nil
 	}
-	if i.upper != nil && i.cmp(i.keys[i.index].UserKey, i.upper) >= 0 {
-		return nil, base.LazyValue{}
+	if i.upper != nil && i.cmp(i.kvs[i.index].UserKey, i.upper) >= 0 {
+		return nil
 	}
-	return &i.keys[i.index], base.LazyValue{}
+	return &i.kvs[i.index]
 }
 
-func (i *pointIterator) NextPrefix(succKey []byte) (*base.InternalKey, base.LazyValue) {
+func (i *pointIterator) NextPrefix(succKey []byte) *base.InternalKV {
 	return i.SeekGE(succKey, base.SeekGEFlagsNone)
 }
 
-func (i *pointIterator) Prev() (*base.InternalKey, base.LazyValue) {
+func (i *pointIterator) Prev() *base.InternalKV {
 	i.index--
-	if i.index < 0 || i.index >= len(i.keys) {
-		return nil, base.LazyValue{}
+	if i.index < 0 || i.index >= len(i.kvs) {
+		return nil
 	}
-	if i.lower != nil && i.cmp(i.keys[i.index].UserKey, i.lower) < 0 {
-		return nil, base.LazyValue{}
+	if i.lower != nil && i.cmp(i.kvs[i.index].UserKey, i.lower) < 0 {
+		return nil
 	}
-	return &i.keys[i.index], base.LazyValue{}
+	return &i.kvs[i.index]
 }
 
 func (i *pointIterator) Close() error   { return nil }

--- a/internal_test.go
+++ b/internal_test.go
@@ -23,9 +23,14 @@ func newInternalIterAdapter(iter internalIterator) *internalIterAdapter {
 	}
 }
 
-func (i *internalIterAdapter) update(key *InternalKey, val LazyValue) bool {
-	i.key = key
-	if v, _, err := val.Value(nil); err != nil {
+func (i *internalIterAdapter) update(kv *base.InternalKV) bool {
+	if kv == nil {
+		i.key, i.val = nil, nil
+		return false
+	}
+
+	i.key = &kv.InternalKey
+	if v, _, err := kv.Value(nil); err != nil {
 		i.key = nil
 		i.val = nil
 		i.err = err

--- a/iterator.go
+++ b/iterator.go
@@ -217,10 +217,9 @@ type Iterator struct {
 	// allocations. opts.LowerBound and opts.UpperBound point into this slice.
 	boundsBuf    [2][]byte
 	boundsBufIdx int
-	// iterKey, iterValue reflect the latest position of iter, except when
-	// SetBounds is called. In that case, these are explicitly set to nil.
-	iterKey             *InternalKey
-	iterValue           LazyValue
+	// iterKV reflects the latest position of iter, except when SetBounds is
+	// called. In that case, these are explicitly set to nil.
+	iterKV              *base.InternalKV
 	alloc               *iterAlloc
 	getIterAlloc        *getIterAlloc
 	prefixOrFullSeekKey []byte
@@ -529,8 +528,8 @@ func (i *Iterator) findNextEntry(limit []byte) {
 		return
 	}
 
-	for i.iterKey != nil {
-		key := *i.iterKey
+	for i.iterKV != nil {
+		key := i.iterKV.InternalKey
 
 		if i.hasPrefix {
 			if n := i.split(key.UserKey); !i.equal(i.prefixOrFullSeekKey, key.UserKey[:n]) {
@@ -544,7 +543,7 @@ func (i *Iterator) findNextEntry(limit []byte) {
 		// the behavior non-deterministic (since the behavior will vary based
 		// on what has been compacted), which makes it hard to test with the
 		// metamorphic test. So we forego that performance optimization.
-		if limit != nil && i.cmp(limit, i.iterKey.UserKey) <= 0 {
+		if limit != nil && i.cmp(limit, i.iterKV.UserKey) <= 0 {
 			i.iterValidityState = IterAtLimit
 			i.pos = iterPosCurForwardPaused
 			return
@@ -552,7 +551,7 @@ func (i *Iterator) findNextEntry(limit []byte) {
 
 		// If the user has configured a SkipPoint function, invoke it to see
 		// whether we should skip over the current user key.
-		if i.opts.SkipPoint != nil && key.Kind() != InternalKeyKindRangeKeySet && i.opts.SkipPoint(i.iterKey.UserKey) {
+		if i.opts.SkipPoint != nil && key.Kind() != InternalKeyKindRangeKeySet && i.opts.SkipPoint(i.iterKV.UserKey) {
 			// NB: We could call nextUserKey, but in some cases the SkipPoint
 			// predicate function might be cheaper than nextUserKey's key copy
 			// and key comparison. This should be the case for MVCC suffix
@@ -561,7 +560,7 @@ func (i *Iterator) findNextEntry(limit []byte) {
 			// whether we skip over just the internal key, the user key, or even
 			// the key prefix.
 			i.stats.ForwardStepCount[InternalIterCall]++
-			i.iterKey, i.iterValue = i.iter.Next()
+			i.iterKV = i.iter.Next()
 			continue
 		}
 
@@ -595,7 +594,7 @@ func (i *Iterator) findNextEntry(limit []byte) {
 		case InternalKeyKindSet, InternalKeyKindSetWithDelete:
 			i.keyBuf = append(i.keyBuf[:0], key.UserKey...)
 			i.key = i.keyBuf
-			i.value = i.iterValue
+			i.value = i.iterKV.LazyValue
 			i.iterValidityState = IterValid
 			i.saveRangeKey()
 			return
@@ -643,14 +642,14 @@ func (i *Iterator) nextPointCurrentUserKey() bool {
 
 	i.pos = iterPosCurForward
 
-	i.iterKey, i.iterValue = i.iter.Next()
+	i.iterKV = i.iter.Next()
 	i.stats.ForwardStepCount[InternalIterCall]++
-	if i.iterKey == nil || !i.equal(i.key, i.iterKey.UserKey) {
+	if i.iterKV == nil || !i.equal(i.key, i.iterKV.UserKey) {
 		i.pos = iterPosNext
 		return false
 	}
 
-	key := *i.iterKey
+	key := i.iterKV.InternalKey
 	switch key.Kind() {
 	case InternalKeyKindRangeKeySet:
 		// RangeKeySets must always be interleaved as the first internal key
@@ -665,7 +664,7 @@ func (i *Iterator) nextPointCurrentUserKey() bool {
 		return false
 
 	case InternalKeyKindSet, InternalKeyKindSetWithDelete:
-		i.value = i.iterValue
+		i.value = i.iterKV.LazyValue
 		return true
 
 	case InternalKeyKindMerge:
@@ -686,7 +685,7 @@ func (i *Iterator) nextPointCurrentUserKey() bool {
 // mergeForward does not update iterValidityState.
 func (i *Iterator) mergeForward(key base.InternalKey) (valid bool) {
 	var iterValue []byte
-	iterValue, _, i.err = i.iterValue.Value(nil)
+	iterValue, _, i.err = i.iterKV.Value(nil)
 	if i.err != nil {
 		return false
 	}
@@ -725,17 +724,17 @@ func (i *Iterator) closeValueCloser() error {
 }
 
 func (i *Iterator) nextUserKey() {
-	if i.iterKey == nil {
+	if i.iterKV == nil {
 		return
 	}
-	trailer := i.iterKey.Trailer
-	done := i.iterKey.Trailer <= base.InternalKeyZeroSeqnumMaxTrailer
+	trailer := i.iterKV.Trailer
+	done := trailer <= base.InternalKeyZeroSeqnumMaxTrailer
 	if i.iterValidityState != IterValid {
-		i.keyBuf = append(i.keyBuf[:0], i.iterKey.UserKey...)
+		i.keyBuf = append(i.keyBuf[:0], i.iterKV.UserKey...)
 		i.key = i.keyBuf
 	}
 	for {
-		i.iterKey, i.iterValue = i.iter.Next()
+		i.iterKV = i.iter.Next()
 		i.stats.ForwardStepCount[InternalIterCall]++
 		// NB: We're guaranteed to be on the next user key if the previous key
 		// had a zero sequence number (`done`), or the new key has a trailer
@@ -746,14 +745,14 @@ func (i *Iterator) nextUserKey() {
 		// distributed writes. We expect it to trigger very frequently when
 		// iterating through ingested sstables, which contain keys that all have
 		// the same sequence number.
-		if done || i.iterKey == nil || i.iterKey.Trailer >= trailer {
+		if done || i.iterKV == nil || i.iterKV.Trailer >= trailer {
 			break
 		}
-		if !i.equal(i.key, i.iterKey.UserKey) {
+		if !i.equal(i.key, i.iterKV.UserKey) {
 			break
 		}
-		done = i.iterKey.Trailer <= base.InternalKeyZeroSeqnumMaxTrailer
-		trailer = i.iterKey.Trailer
+		done = i.iterKV.Trailer <= base.InternalKeyZeroSeqnumMaxTrailer
+		trailer = i.iterKV.Trailer
 	}
 }
 
@@ -886,15 +885,15 @@ func (i *Iterator) findPrevEntry(limit []byte) {
 	// findNextEntry, this is being done to make the behavior of limit
 	// deterministic to allow for metamorphic testing. It is not required by
 	// the best-effort contract of limit.
-	for i.iterKey != nil {
-		key := *i.iterKey
+	for i.iterKV != nil {
+		key := i.iterKV.InternalKey
 
 		// NB: We cannot pause if the current key is covered by a range key.
 		// Otherwise, the user might not ever learn of a range key that covers
 		// the key space being iterated over in which there are no point keys.
 		// Since limits are best effort, ignoring the limit in this case is
 		// allowed by the contract of limit.
-		if firstLoopIter && limit != nil && i.cmp(limit, i.iterKey.UserKey) > 0 && !i.rangeKeyWithinLimit(limit) {
+		if firstLoopIter && limit != nil && i.cmp(limit, i.iterKV.UserKey) > 0 && !i.rangeKeyWithinLimit(limit) {
 			i.iterValidityState = IterAtLimit
 			i.pos = iterPosCurReversePaused
 			return
@@ -944,8 +943,8 @@ func (i *Iterator) findPrevEntry(limit []byte) {
 			// whether we skip over just the internal key, the user key, or even
 			// the key prefix.
 			i.stats.ReverseStepCount[InternalIterCall]++
-			i.iterKey, i.iterValue = i.iter.Prev()
-			if limit != nil && i.iterKey != nil && i.cmp(limit, i.iterKey.UserKey) > 0 && !i.rangeKeyWithinLimit(limit) {
+			i.iterKV = i.iter.Prev()
+			if limit != nil && i.iterKV != nil && i.cmp(limit, i.iterKV.UserKey) > 0 && !i.rangeKeyWithinLimit(limit) {
 				i.iterValidityState = IterAtLimit
 				i.pos = iterPosCurReversePaused
 				return
@@ -975,7 +974,7 @@ func (i *Iterator) findPrevEntry(limit []byte) {
 			// that we can maintain the invariant during backward iteration that
 			// i.iterPos = iterPosPrev.
 			i.stats.ReverseStepCount[InternalIterCall]++
-			i.iterKey, i.iterValue = i.iter.Prev()
+			i.iterKV = i.iter.Prev()
 
 			// Set rangeKeyBoundary so that on the next iteration, we know to
 			// return the key even if the MERGE point key is deleted.
@@ -985,7 +984,7 @@ func (i *Iterator) findPrevEntry(limit []byte) {
 			i.value = LazyValue{}
 			i.iterValidityState = IterExhausted
 			valueMerger = nil
-			i.iterKey, i.iterValue = i.iter.Prev()
+			i.iterKV = i.iter.Prev()
 			i.stats.ReverseStepCount[InternalIterCall]++
 			// Compare with the limit. We could optimize by only checking when
 			// we step to the previous user key, but detecting that requires a
@@ -996,7 +995,7 @@ func (i *Iterator) findPrevEntry(limit []byte) {
 			// other than the firstLoopIter and SkipPoint cases above, where we
 			// could step to a different user key and start processing it for
 			// returning to the caller.
-			if limit != nil && i.iterKey != nil && i.cmp(limit, i.iterKey.UserKey) > 0 && !i.rangeKeyWithinLimit(limit) {
+			if limit != nil && i.iterKV != nil && i.cmp(limit, i.iterKV.UserKey) > 0 && !i.rangeKeyWithinLimit(limit) {
 				i.iterValidityState = IterAtLimit
 				i.pos = iterPosCurReversePaused
 				return
@@ -1010,10 +1009,10 @@ func (i *Iterator) findPrevEntry(limit []byte) {
 			// call, so use valueBuf instead. Note that valueBuf is only used
 			// in this one instance; everywhere else (eg. in findNextEntry),
 			// we just point i.value to the unsafe i.iter-owned value buffer.
-			i.value, i.valueBuf = i.iterValue.Clone(i.valueBuf[:0], &i.fetcher)
+			i.value, i.valueBuf = i.iterKV.LazyValue.Clone(i.valueBuf[:0], &i.fetcher)
 			i.saveRangeKey()
 			i.iterValidityState = IterValid
-			i.iterKey, i.iterValue = i.iter.Prev()
+			i.iterKV = i.iter.Prev()
 			i.stats.ReverseStepCount[InternalIterCall]++
 			valueMerger = nil
 			continue
@@ -1024,7 +1023,7 @@ func (i *Iterator) findPrevEntry(limit []byte) {
 				i.key = i.keyBuf
 				i.saveRangeKey()
 				var iterValue []byte
-				iterValue, _, i.err = i.iterValue.Value(nil)
+				iterValue, _, i.err = i.iterKV.Value(nil)
 				if i.err != nil {
 					return
 				}
@@ -1048,7 +1047,7 @@ func (i *Iterator) findPrevEntry(limit []byte) {
 				}
 				valueMerger, i.err = i.merge(i.key, value)
 				var iterValue []byte
-				iterValue, _, i.err = i.iterValue.Value(nil)
+				iterValue, _, i.err = i.iterKV.Value(nil)
 				if i.err != nil {
 					return
 				}
@@ -1061,7 +1060,7 @@ func (i *Iterator) findPrevEntry(limit []byte) {
 				}
 			} else {
 				var iterValue []byte
-				iterValue, _, i.err = i.iterValue.Value(nil)
+				iterValue, _, i.err = i.iterKV.Value(nil)
 				if i.err != nil {
 					return
 				}
@@ -1071,7 +1070,7 @@ func (i *Iterator) findPrevEntry(limit []byte) {
 					return
 				}
 			}
-			i.iterKey, i.iterValue = i.iter.Prev()
+			i.iterKV = i.iter.Prev()
 			i.stats.ReverseStepCount[InternalIterCall]++
 			continue
 
@@ -1082,7 +1081,7 @@ func (i *Iterator) findPrevEntry(limit []byte) {
 		}
 	}
 
-	// i.iterKey == nil, so broke out of the preceding loop.
+	// i.iterKV == nil, so broke out of the preceding loop.
 	if i.iterValidityState == IterValid {
 		i.pos = iterPosPrev
 		if valueMerger != nil {
@@ -1103,22 +1102,22 @@ func (i *Iterator) findPrevEntry(limit []byte) {
 }
 
 func (i *Iterator) prevUserKey() {
-	if i.iterKey == nil {
+	if i.iterKV == nil {
 		return
 	}
 	if i.iterValidityState != IterValid {
 		// If we're going to compare against the prev key, we need to save the
 		// current key.
-		i.keyBuf = append(i.keyBuf[:0], i.iterKey.UserKey...)
+		i.keyBuf = append(i.keyBuf[:0], i.iterKV.UserKey...)
 		i.key = i.keyBuf
 	}
 	for {
-		i.iterKey, i.iterValue = i.iter.Prev()
+		i.iterKV = i.iter.Prev()
 		i.stats.ReverseStepCount[InternalIterCall]++
-		if i.iterKey == nil {
+		if i.iterKV == nil {
 			break
 		}
-		if !i.equal(i.key, i.iterKey.UserKey) {
+		if !i.equal(i.key, i.iterKV.UserKey) {
 			break
 		}
 	}
@@ -1131,13 +1130,13 @@ func (i *Iterator) mergeNext(key InternalKey, valueMerger ValueMerger) {
 
 	// Loop looking for older values for this key and merging them.
 	for {
-		i.iterKey, i.iterValue = i.iter.Next()
+		i.iterKV = i.iter.Next()
 		i.stats.ForwardStepCount[InternalIterCall]++
-		if i.iterKey == nil {
+		if i.iterKV == nil {
 			i.pos = iterPosNext
 			return
 		}
-		key = *i.iterKey
+		key = i.iterKV.InternalKey
 		if !i.equal(i.key, key.UserKey) {
 			// We've advanced to the next key.
 			i.pos = iterPosNext
@@ -1156,7 +1155,7 @@ func (i *Iterator) mergeNext(key InternalKey, valueMerger ValueMerger) {
 		case InternalKeyKindSet, InternalKeyKindSetWithDelete:
 			// We've hit a Set value. Merge with the existing value and return.
 			var iterValue []byte
-			iterValue, _, i.err = i.iterValue.Value(nil)
+			iterValue, _, i.err = i.iterKV.Value(nil)
 			if i.err != nil {
 				return
 			}
@@ -1167,7 +1166,7 @@ func (i *Iterator) mergeNext(key InternalKey, valueMerger ValueMerger) {
 			// We've hit another Merge value. Merge with the existing value and
 			// continue looping.
 			var iterValue []byte
-			iterValue, _, i.err = i.iterValue.Value(nil)
+			iterValue, _, i.err = i.iterKV.Value(nil)
 			if i.err != nil {
 				return
 			}
@@ -1282,9 +1281,9 @@ func (i *Iterator) SeekGEWithLimit(key []byte, limit []byte) IterValidityState {
 			if invariants.Enabled && flags.TrySeekUsingNext() && !i.forceEnableSeekOpt && disableSeekOpt(key, uintptr(unsafe.Pointer(i))) {
 				flags = flags.DisableTrySeekUsingNext()
 			}
-			if !flags.BatchJustRefreshed() && i.pos == iterPosCurForwardPaused && i.cmp(key, i.iterKey.UserKey) <= 0 {
+			if !flags.BatchJustRefreshed() && i.pos == iterPosCurForwardPaused && i.cmp(key, i.iterKV.UserKey) <= 0 {
 				// Have some work to do, but don't need to seek, and we can
-				// start doing findNextEntry from i.iterKey.
+				// start doing findNextEntry from i.iterKV.
 				seekInternalIter = false
 			}
 		}
@@ -1302,14 +1301,14 @@ func (i *Iterator) SeekGEWithLimit(key []byte, limit []byte) IterValidityState {
 	// use the NextPrefix iterator positioning operation.
 	if seekInternalIter && i.forwardOnly && lastPositioningOp != invalidatedLastPositionOp &&
 		i.pos == iterPosCurForward && !hasPrefix && i.iterValidityState == IterValid &&
-		i.cmp(key, i.iterKey.UserKey) > 0 {
+		i.cmp(key, i.iterKV.UserKey) > 0 {
 		flags = flags.EnableTrySeekUsingNext()
 		if invariants.Enabled && flags.TrySeekUsingNext() && !i.forceEnableSeekOpt && disableSeekOpt(key, uintptr(unsafe.Pointer(i))) {
 			flags = flags.DisableTrySeekUsingNext()
 		}
 	}
 	if seekInternalIter {
-		i.iterKey, i.iterValue = i.iter.SeekGE(key, flags)
+		i.iterKV = i.iter.SeekGE(key, flags)
 		i.stats.ForwardSeekCount[InternalIterCall]++
 	}
 	i.findNextEntry(limit)
@@ -1464,7 +1463,7 @@ func (i *Iterator) SeekPrefixGE(key []byte) bool {
 		}
 		key = upperBound
 	}
-	i.iterKey, i.iterValue = i.iter.SeekPrefixGE(i.prefixOrFullSeekKey, key, flags)
+	i.iterKV = i.iter.SeekPrefixGE(i.prefixOrFullSeekKey, key, flags)
 	i.stats.ForwardSeekCount[InternalIterCall]++
 	i.findNextEntry(nil)
 	i.maybeSampleRead()
@@ -1555,15 +1554,15 @@ func (i *Iterator) SeekLTWithLimit(key []byte, limit []byte) IterValidityState {
 					return i.iterValidityState
 				}
 			}
-			if i.pos == iterPosCurReversePaused && i.cmp(i.iterKey.UserKey, key) < 0 {
+			if i.pos == iterPosCurReversePaused && i.cmp(i.iterKV.UserKey, key) < 0 {
 				// Have some work to do, but don't need to seek, and we can
-				// start doing findPrevEntry from i.iterKey.
+				// start doing findPrevEntry from i.iterKV.
 				seekInternalIter = false
 			}
 		}
 	}
 	if seekInternalIter {
-		i.iterKey, i.iterValue = i.iter.SeekLT(key, base.SeekLTFlagsNone)
+		i.iterKV = i.iter.SeekLT(key, base.SeekLTFlagsNone)
 		i.stats.ReverseSeekCount[InternalIterCall]++
 	}
 	i.findPrevEntry(limit)
@@ -1726,7 +1725,7 @@ func (i *Iterator) nextPrefix() IterValidityState {
 		// Switching directions.
 		// Unless the iterator was exhausted, reverse iteration needs to
 		// position the iterator at iterPosPrev.
-		if i.iterKey != nil {
+		if i.iterKV != nil {
 			i.err = errors.New("switching from reverse to forward but iter is not at prev")
 			i.iterValidityState = IterExhausted
 			return i.iterValidityState
@@ -1740,7 +1739,7 @@ func (i *Iterator) nextPrefix() IterValidityState {
 		//
 		// Switching directions; The iterator must not be exhausted since it
 		// paused.
-		if i.iterKey == nil {
+		if i.iterKV == nil {
 			i.err = errors.New("switching paused from reverse to forward but iter is exhausted")
 			i.iterValidityState = IterExhausted
 			return i.iterValidityState
@@ -1749,7 +1748,7 @@ func (i *Iterator) nextPrefix() IterValidityState {
 	case iterPosPrev:
 		// The underlying iterator is pointed to the previous key (this can
 		// only happen when switching iteration directions).
-		if i.iterKey == nil {
+		if i.iterKV == nil {
 			// We're positioned before the first key. Need to reposition to point to
 			// the first key.
 			i.iterFirstWithinBounds()
@@ -1758,10 +1757,10 @@ func (i *Iterator) nextPrefix() IterValidityState {
 			// i.key. iterPosPrev guarantees that it's positioned at the last
 			// key with the user key less than i.key, so we're guaranteed to
 			// land on the correct key with a single Next.
-			i.iterKey, i.iterValue = i.iter.Next()
-			if invariants.Enabled && !i.equal(i.iterKey.UserKey, i.key) {
+			i.iterKV = i.iter.Next()
+			if invariants.Enabled && !i.equal(i.iterKV.UserKey, i.key) {
 				i.opts.logger.Fatalf("pebble: invariant violation: Nexting internal iterator from iterPosPrev landed on %q, not %q",
-					i.iterKey.UserKey, i.key)
+					i.iterKV.UserKey, i.key)
 			}
 		}
 		// The internal iterator is now positioned at i.key. Advance to the next
@@ -1770,10 +1769,10 @@ func (i *Iterator) nextPrefix() IterValidityState {
 	case iterPosNext:
 		// Already positioned on the next key. Only call nextPrefixKey if the
 		// next key shares the same prefix.
-		if i.iterKey != nil {
+		if i.iterKV != nil {
 			currKeyPrefixLen := i.split(i.key)
-			iterKeyPrefixLen := i.split(i.iterKey.UserKey)
-			if bytes.Equal(i.iterKey.UserKey[:iterKeyPrefixLen], i.key[:currKeyPrefixLen]) {
+			iterKeyPrefixLen := i.split(i.iterKV.UserKey)
+			if bytes.Equal(i.iterKV.UserKey[:iterKeyPrefixLen], i.key[:currKeyPrefixLen]) {
 				i.internalNextPrefix(currKeyPrefixLen)
 			}
 		}
@@ -1786,7 +1785,7 @@ func (i *Iterator) nextPrefix() IterValidityState {
 }
 
 func (i *Iterator) internalNextPrefix(currKeyPrefixLen int) {
-	if i.iterKey == nil {
+	if i.iterKV == nil {
 		return
 	}
 	// The Next "fast-path" is not really a fast-path when there is more than
@@ -1794,20 +1793,20 @@ func (i *Iterator) internalNextPrefix(currKeyPrefixLen int) {
 	// slowdown (~10%) for one version if we remove it and only call NextPrefix.
 	// When there are two versions, only calling NextPrefix is ~30% faster.
 	i.stats.ForwardStepCount[InternalIterCall]++
-	if i.iterKey, i.iterValue = i.iter.Next(); i.iterKey == nil {
+	if i.iterKV = i.iter.Next(); i.iterKV == nil {
 		return
 	}
-	iterKeyPrefixLen := i.split(i.iterKey.UserKey)
-	if !bytes.Equal(i.iterKey.UserKey[:iterKeyPrefixLen], i.key[:currKeyPrefixLen]) {
+	iterKeyPrefixLen := i.split(i.iterKV.UserKey)
+	if !bytes.Equal(i.iterKV.UserKey[:iterKeyPrefixLen], i.key[:currKeyPrefixLen]) {
 		return
 	}
 	i.stats.ForwardStepCount[InternalIterCall]++
 	i.prefixOrFullSeekKey = i.comparer.ImmediateSuccessor(i.prefixOrFullSeekKey[:0], i.key[:currKeyPrefixLen])
-	i.iterKey, i.iterValue = i.iter.NextPrefix(i.prefixOrFullSeekKey)
-	if invariants.Enabled && i.iterKey != nil {
-		if iterKeyPrefixLen := i.split(i.iterKey.UserKey); i.cmp(i.iterKey.UserKey[:iterKeyPrefixLen], i.prefixOrFullSeekKey) < 0 {
+	i.iterKV = i.iter.NextPrefix(i.prefixOrFullSeekKey)
+	if invariants.Enabled && i.iterKV != nil {
+		if iterKeyPrefixLen := i.split(i.iterKV.UserKey); i.cmp(i.iterKV.UserKey[:iterKeyPrefixLen], i.prefixOrFullSeekKey) < 0 {
 			panic(errors.AssertionFailedf("pebble: iter.NextPrefix did not advance beyond the current prefix: now at %q; expected to be geq %q",
-				i.iterKey, i.prefixOrFullSeekKey))
+				i.iterKV, i.prefixOrFullSeekKey))
 		}
 	}
 }
@@ -1859,7 +1858,7 @@ func (i *Iterator) nextWithLimit(limit []byte) IterValidityState {
 		// Switching directions.
 		// Unless the iterator was exhausted, reverse iteration needs to
 		// position the iterator at iterPosPrev.
-		if i.iterKey != nil {
+		if i.iterKV != nil {
 			i.err = errors.New("switching from reverse to forward but iter is not at prev")
 			i.iterValidityState = IterExhausted
 			return i.iterValidityState
@@ -1870,7 +1869,7 @@ func (i *Iterator) nextWithLimit(limit []byte) IterValidityState {
 	case iterPosCurReversePaused:
 		// Switching directions.
 		// The iterator must not be exhausted since it paused.
-		if i.iterKey == nil {
+		if i.iterKV == nil {
 			i.err = errors.New("switching paused from reverse to forward but iter is exhausted")
 			i.iterValidityState = IterExhausted
 			return i.iterValidityState
@@ -1883,7 +1882,7 @@ func (i *Iterator) nextWithLimit(limit []byte) IterValidityState {
 		// nextUserKey to save the current key i.iter is pointing at in order
 		// to determine when the next user-key is reached.
 		i.iterValidityState = IterExhausted
-		if i.iterKey == nil {
+		if i.iterKV == nil {
 			// We're positioned before the first key. Need to reposition to point to
 			// the first key.
 			i.iterFirstWithinBounds()
@@ -1981,7 +1980,7 @@ func (i *Iterator) PrevWithLimit(limit []byte) IterValidityState {
 		// to prevUserKey to save the current key i.iter is pointing at in
 		// order to determine when the prev user-key is reached.
 		i.iterValidityState = IterExhausted
-		if i.iterKey == nil {
+		if i.iterKV == nil {
 			// We're positioned after the last key. Need to reposition to point to
 			// the last key.
 			i.iterLastWithinBounds()
@@ -2002,9 +2001,9 @@ func (i *Iterator) PrevWithLimit(limit []byte) IterValidityState {
 func (i *Iterator) iterFirstWithinBounds() {
 	i.stats.ForwardSeekCount[InternalIterCall]++
 	if lowerBound := i.opts.GetLowerBound(); lowerBound != nil {
-		i.iterKey, i.iterValue = i.iter.SeekGE(lowerBound, base.SeekGEFlagsNone)
+		i.iterKV = i.iter.SeekGE(lowerBound, base.SeekGEFlagsNone)
 	} else {
-		i.iterKey, i.iterValue = i.iter.First()
+		i.iterKV = i.iter.First()
 	}
 }
 
@@ -2013,9 +2012,9 @@ func (i *Iterator) iterFirstWithinBounds() {
 func (i *Iterator) iterLastWithinBounds() {
 	i.stats.ReverseSeekCount[InternalIterCall]++
 	if upperBound := i.opts.GetUpperBound(); upperBound != nil {
-		i.iterKey, i.iterValue = i.iter.SeekLT(upperBound, base.SeekLTFlagsNone)
+		i.iterKV = i.iter.SeekLT(upperBound, base.SeekLTFlagsNone)
 	} else {
-		i.iterKey, i.iterValue = i.iter.Last()
+		i.iterKV = i.iter.Last()
 	}
 }
 
@@ -2625,8 +2624,7 @@ func (i *Iterator) SetOptions(o *IterOptions) {
 func (i *Iterator) invalidate() {
 	i.lastPositioningOp = invalidatedLastPositionOp
 	i.hasPrefix = false
-	i.iterKey = nil
-	i.iterValue = LazyValue{}
+	i.iterKV = nil
 	i.err = nil
 	// This switch statement isn't necessary for correctness since callers
 	// should call a repositioning method. We could have arbitrarily set i.pos

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -48,8 +48,7 @@ var testKeyValuePairs = []string{
 type fakeIter struct {
 	lower    []byte
 	upper    []byte
-	keys     []InternalKey
-	vals     [][]byte
+	kvs      []base.InternalKV
 	index    int
 	valid    bool
 	closeErr error
@@ -68,14 +67,14 @@ func fakeIkey(s string) InternalKey {
 }
 
 func newFakeIterator(closeErr error, keys ...string) *fakeIter {
-	ikeys := make([]InternalKey, len(keys))
+	kvs := make([]base.InternalKV, len(keys))
 	for i, k := range keys {
-		ikeys[i] = fakeIkey(k)
+		kvs[i] = base.InternalKV{InternalKey: fakeIkey(k)}
 	}
 	return &fakeIter{
-		keys:     ikeys,
+		kvs:      kvs,
 		index:    0,
-		valid:    len(ikeys) > 0,
+		valid:    len(kvs) > 0,
 		closeErr: closeErr,
 	}
 }
@@ -84,111 +83,109 @@ func (f *fakeIter) String() string {
 	return "fake"
 }
 
-func (f *fakeIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, base.LazyValue) {
+func (f *fakeIter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	f.valid = false
-	for f.index = 0; f.index < len(f.keys); f.index++ {
+	for f.index = 0; f.index < len(f.kvs); f.index++ {
 		if DefaultComparer.Compare(key, f.key().UserKey) <= 0 {
 			if f.upper != nil && DefaultComparer.Compare(f.upper, f.key().UserKey) <= 0 {
-				return nil, base.LazyValue{}
+				return nil
 			}
 			f.valid = true
-			return f.Key(), f.Value()
+			return &f.kvs[f.index]
 		}
 	}
-	return nil, base.LazyValue{}
+	return nil
 }
 
-func (f *fakeIter) SeekPrefixGE(
-	prefix, key []byte, flags base.SeekGEFlags,
-) (*base.InternalKey, base.LazyValue) {
+func (f *fakeIter) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	return f.SeekGE(key, flags)
 }
 
-func (f *fakeIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, base.LazyValue) {
+func (f *fakeIter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
 	f.valid = false
-	for f.index = len(f.keys) - 1; f.index >= 0; f.index-- {
+	for f.index = len(f.kvs) - 1; f.index >= 0; f.index-- {
 		if DefaultComparer.Compare(key, f.key().UserKey) > 0 {
 			if f.lower != nil && DefaultComparer.Compare(f.lower, f.key().UserKey) > 0 {
-				return nil, base.LazyValue{}
+				return nil
 			}
 			f.valid = true
-			return f.Key(), f.Value()
+			return &f.kvs[f.index]
 		}
 	}
-	return nil, base.LazyValue{}
+	return nil
 }
 
-func (f *fakeIter) First() (*InternalKey, base.LazyValue) {
+func (f *fakeIter) First() *base.InternalKV {
 	f.valid = false
 	f.index = -1
-	if key, _ := f.Next(); key == nil {
-		return nil, base.LazyValue{}
+	if kv := f.Next(); kv == nil {
+		return nil
 	}
 	if f.upper != nil && DefaultComparer.Compare(f.upper, f.key().UserKey) <= 0 {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	f.valid = true
-	return f.Key(), f.Value()
+	return &f.kvs[f.index]
 }
 
-func (f *fakeIter) Last() (*InternalKey, base.LazyValue) {
+func (f *fakeIter) Last() *base.InternalKV {
 	f.valid = false
-	f.index = len(f.keys)
-	if key, _ := f.Prev(); key == nil {
-		return nil, base.LazyValue{}
+	f.index = len(f.kvs)
+	if kv := f.Prev(); kv == nil {
+		return nil
 	}
 	if f.lower != nil && DefaultComparer.Compare(f.lower, f.key().UserKey) > 0 {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	f.valid = true
-	return f.Key(), f.Value()
+	return &f.kvs[f.index]
 }
 
-func (f *fakeIter) Next() (*InternalKey, base.LazyValue) {
+func (f *fakeIter) Next() *base.InternalKV {
 	f.valid = false
-	if f.index == len(f.keys) {
-		return nil, base.LazyValue{}
+	if f.index == len(f.kvs) {
+		return nil
 	}
 	f.index++
-	if f.index == len(f.keys) {
-		return nil, base.LazyValue{}
+	if f.index == len(f.kvs) {
+		return nil
 	}
 	if f.upper != nil && DefaultComparer.Compare(f.upper, f.key().UserKey) <= 0 {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	f.valid = true
-	return f.Key(), f.Value()
+	return &f.kvs[f.index]
 }
 
-func (f *fakeIter) Prev() (*InternalKey, base.LazyValue) {
+func (f *fakeIter) Prev() *base.InternalKV {
 	f.valid = false
 	if f.index < 0 {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	f.index--
 	if f.index < 0 {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	if f.lower != nil && DefaultComparer.Compare(f.lower, f.key().UserKey) > 0 {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	f.valid = true
-	return f.Key(), f.Value()
+	return &f.kvs[f.index]
 }
 
-func (f *fakeIter) NextPrefix(succKey []byte) (*InternalKey, base.LazyValue) {
+func (f *fakeIter) NextPrefix(succKey []byte) *base.InternalKV {
 	return f.SeekGE(succKey, base.SeekGEFlagsNone)
 }
 
 // key returns the current Key the iterator is positioned at regardless of the
 // value of f.valid.
 func (f *fakeIter) key() *InternalKey {
-	return &f.keys[f.index]
+	return &f.kvs[f.index].InternalKey
 }
 
 func (f *fakeIter) Key() *InternalKey {
 	if f.valid {
-		return &f.keys[f.index]
+		return &f.kvs[f.index].InternalKey
 	}
 	// It is invalid to call Key() when Valid() returns false. Rather than
 	// returning nil here which would technically be more correct, return a
@@ -196,20 +193,20 @@ func (f *fakeIter) Key() *InternalKey {
 	// implementations. This provides better testing of users of
 	// InternalIterators.
 	if f.index < 0 {
-		return &f.keys[0]
+		return &f.kvs[0].InternalKey
 	}
-	return &f.keys[len(f.keys)-1]
+	return &f.kvs[len(f.kvs)-1].InternalKey
 }
 
 func (f *fakeIter) Value() base.LazyValue {
-	if f.index >= 0 && f.index < len(f.vals) {
-		return base.MakeInPlaceValue(f.vals[f.index])
+	if f.index >= 0 && f.index < len(f.kvs) {
+		return f.kvs[f.index].LazyValue
 	}
 	return base.LazyValue{}
 }
 
 func (f *fakeIter) Valid() bool {
-	return f.index >= 0 && f.index < len(f.keys) && f.valid
+	return f.index >= 0 && f.index < len(f.kvs) && f.valid
 }
 
 func (f *fakeIter) Error() error {
@@ -279,8 +276,8 @@ func testIterator(
 	for _, tc := range testCases {
 		var b bytes.Buffer
 		iter := invalidating.NewIter(newFunc(tc.iters...))
-		for key, _ := iter.First(); key != nil; key, _ = iter.Next() {
-			fmt.Fprintf(&b, "<%s:%d>", key.UserKey, key.SeqNum())
+		for kv := iter.First(); kv != nil; kv = iter.Next() {
+			fmt.Fprintf(&b, "<%s:%d>", kv.UserKey, kv.SeqNum())
 		}
 		if err := iter.Close(); err != nil {
 			fmt.Fprintf(&b, "err=%v", err)
@@ -381,8 +378,7 @@ func (m *deletableSumValueMerger) DeletableFinish(
 
 func TestIterator(t *testing.T) {
 	var merge Merge
-	var keys []InternalKey
-	var vals [][]byte
+	var kvs []base.InternalKV
 
 	newIter := func(seqNum uint64, opts IterOptions) *Iterator {
 		if merge == nil {
@@ -403,8 +399,7 @@ func TestIterator(t *testing.T) {
 		iter := newMergingIter(nil /* logger */, &it.stats.InternalStats, it.cmp, it.split, &fakeIter{
 			lower: opts.GetLowerBound(),
 			upper: opts.GetUpperBound(),
-			keys:  keys,
-			vals:  vals,
+			kvs:   kvs,
 		})
 		iter.snapshot = seqNum
 		// NB: This Iterator cannot be cloned since it is not constructed
@@ -420,12 +415,13 @@ func TestIterator(t *testing.T) {
 			if arg, ok := d.Arg("merger"); ok && len(arg.Vals[0]) > 0 && arg.Vals[0] == "deletable" {
 				merge = newDeletableSumValueMerger
 			}
-			keys = keys[:0]
-			vals = vals[:0]
+			kvs = kvs[:0]
 			for _, key := range strings.Split(d.Input, "\n") {
 				j := strings.Index(key, ":")
-				keys = append(keys, base.ParseInternalKey(key[:j]))
-				vals = append(vals, []byte(key[j+1:]))
+				kvs = append(kvs, base.InternalKV{
+					InternalKey: base.ParseInternalKey(key[:j]),
+					LazyValue:   base.MakeInPlaceValue([]byte(key[j+1:])),
+				})
 			}
 			return ""
 
@@ -818,9 +814,7 @@ type iterSeekOptWrapper struct {
 	seekGEUsingNext, seekPrefixGEUsingNext *int
 }
 
-func (i *iterSeekOptWrapper) SeekGE(
-	key []byte, flags base.SeekGEFlags,
-) (*InternalKey, base.LazyValue) {
+func (i *iterSeekOptWrapper) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	if flags.TrySeekUsingNext() {
 		*i.seekGEUsingNext++
 	}
@@ -829,7 +823,7 @@ func (i *iterSeekOptWrapper) SeekGE(
 
 func (i *iterSeekOptWrapper) SeekPrefixGE(
 	prefix, key []byte, flags base.SeekGEFlags,
-) (*InternalKey, base.LazyValue) {
+) *base.InternalKV {
 	if flags.TrySeekUsingNext() {
 		*i.seekPrefixGEUsingNext++
 	}
@@ -933,29 +927,27 @@ type errorSeekIter struct {
 	err                   error
 }
 
-func (i *errorSeekIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, base.LazyValue) {
+func (i *errorSeekIter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	if i.tryInjectError() {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	i.err = nil
 	i.seekCount++
 	return i.internalIterator.SeekGE(key, flags)
 }
 
-func (i *errorSeekIter) SeekPrefixGE(
-	prefix, key []byte, flags base.SeekGEFlags,
-) (*InternalKey, base.LazyValue) {
+func (i *errorSeekIter) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	if i.tryInjectError() {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	i.err = nil
 	i.seekCount++
 	return i.internalIterator.SeekPrefixGE(prefix, key, flags)
 }
 
-func (i *errorSeekIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, base.LazyValue) {
+func (i *errorSeekIter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
 	if i.tryInjectError() {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	i.err = nil
 	i.seekCount++
@@ -972,26 +964,26 @@ func (i *errorSeekIter) tryInjectError() bool {
 	return false
 }
 
-func (i *errorSeekIter) First() (*InternalKey, base.LazyValue) {
+func (i *errorSeekIter) First() *base.InternalKV {
 	i.err = nil
 	return i.internalIterator.First()
 }
 
-func (i *errorSeekIter) Last() (*InternalKey, base.LazyValue) {
+func (i *errorSeekIter) Last() *base.InternalKV {
 	i.err = nil
 	return i.internalIterator.Last()
 }
 
-func (i *errorSeekIter) Next() (*InternalKey, base.LazyValue) {
+func (i *errorSeekIter) Next() *base.InternalKV {
 	if i.err != nil {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	return i.internalIterator.Next()
 }
 
-func (i *errorSeekIter) Prev() (*InternalKey, base.LazyValue) {
+func (i *errorSeekIter) Prev() *base.InternalKV {
 	if i.err != nil {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	return i.internalIterator.Prev()
 }
@@ -1004,16 +996,13 @@ func (i *errorSeekIter) Error() error {
 }
 
 func TestIteratorSeekOptErrors(t *testing.T) {
-	var keys []InternalKey
-	var vals [][]byte
-
+	var kvs []base.InternalKV
 	var errorIter errorSeekIter
 	newIter := func(opts IterOptions) *Iterator {
 		iter := &fakeIter{
 			lower: opts.GetLowerBound(),
 			upper: opts.GetUpperBound(),
-			keys:  keys,
-			vals:  vals,
+			kvs:   kvs,
 		}
 		errorIter = errorSeekIter{internalIterator: invalidating.NewIter(iter)}
 		// NB: This Iterator cannot be cloned since it is not constructed
@@ -1029,12 +1018,13 @@ func TestIteratorSeekOptErrors(t *testing.T) {
 	datadriven.RunTest(t, "testdata/iterator_seek_opt_errors", func(t *testing.T, d *datadriven.TestData) string {
 		switch d.Cmd {
 		case "define":
-			keys = keys[:0]
-			vals = vals[:0]
+			kvs = kvs[:0]
 			for _, key := range strings.Split(d.Input, "\n") {
 				j := strings.Index(key, ":")
-				keys = append(keys, base.ParseInternalKey(key[:j]))
-				vals = append(vals, []byte(key[j+1:]))
+				kvs = append(kvs, base.InternalKV{
+					InternalKey: base.ParseInternalKey(key[:j]),
+					LazyValue:   base.MakeInPlaceValue([]byte(key[j+1:])),
+				})
 			}
 			return ""
 

--- a/level_iter.go
+++ b/level_iter.go
@@ -97,11 +97,11 @@ type levelIter struct {
 	tableOpts IterOptions
 	// The LSM level this levelIter is initialized for.
 	level manifest.Level
-	// The keys to return when iterating past an sstable boundary and that
+	// The KVs to return when iterating past an sstable boundary and that
 	// boundary is a range deletion tombstone. The boundary could be smallest
 	// (i.e. arrived at with Prev), or largest (arrived at with Next).
-	smallestBoundary *InternalKey
-	largestBoundary  *InternalKey
+	smallestBoundary *base.InternalKV
+	largestBoundary  *base.InternalKV
 	// combinedIterState may be set when a levelIter is used during user
 	// iteration. Although levelIter only iterates over point keys, it's also
 	// responsible for lazily constructing the combined range & point iterator
@@ -112,10 +112,10 @@ type levelIter struct {
 	// the levelIter passes over a file containing range keys. See the
 	// lazyCombinedIter for more details.
 	combinedIterState *combinedIterState
-	// A synthetic boundary key to return when SeekPrefixGE finds an sstable
+	// A synthetic boundary kv to return when SeekPrefixGE finds an sstable
 	// which doesn't contain the search key, but which does contain range
 	// tombstones.
-	syntheticBoundary InternalKey
+	syntheticBoundary base.InternalKV
 	// The iter for the current file. It is nil under any of the following conditions:
 	// - files.Current() == nil
 	// - err != nil
@@ -706,25 +706,25 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) loadFileReturnIndicato
 
 // In race builds we verify that the keys returned by levelIter lie within
 // [lower,upper).
-func (l *levelIter) verify(key *InternalKey, val base.LazyValue) (*InternalKey, base.LazyValue) {
+func (l *levelIter) verify(kv *base.InternalKV) *base.InternalKV {
 	// Note that invariants.Enabled is a compile time constant, which means the
 	// block of code will be compiled out of normal builds making this method
 	// eligible for inlining. Do not change this to use a variable.
-	if invariants.Enabled && !l.disableInvariants && key != nil {
+	if invariants.Enabled && !l.disableInvariants && kv != nil {
 		// We allow returning a boundary key that is outside of the lower/upper
 		// bounds as such keys are always range tombstones which will be skipped by
 		// the Iterator.
-		if l.lower != nil && key != l.smallestBoundary && l.cmp(key.UserKey, l.lower) < 0 {
-			l.logger.Fatalf("levelIter %s: lower bound violation: %s < %s\n%s", l.level, key, l.lower, debug.Stack())
+		if l.lower != nil && kv != l.smallestBoundary && l.cmp(kv.UserKey, l.lower) < 0 {
+			l.logger.Fatalf("levelIter %s: lower bound violation: %s < %s\n%s", l.level, kv.InternalKey, l.lower, debug.Stack())
 		}
-		if l.upper != nil && key != l.largestBoundary && l.cmp(key.UserKey, l.upper) > 0 {
-			l.logger.Fatalf("levelIter %s: upper bound violation: %s > %s\n%s", l.level, key, l.upper, debug.Stack())
+		if l.upper != nil && kv != l.largestBoundary && l.cmp(kv.UserKey, l.upper) > 0 {
+			l.logger.Fatalf("levelIter %s: upper bound violation: %s > %s\n%s", l.level, kv.InternalKey, l.upper, debug.Stack())
 		}
 	}
-	return key, val
+	return kv
 }
 
-func (l *levelIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, base.LazyValue) {
+func (l *levelIter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	l.err = nil // clear cached iteration error
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
@@ -734,22 +734,20 @@ func (l *levelIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, ba
 	// IterOptions.LowerBound.
 	loadFileIndicator := l.loadFile(l.findFileGE(key, flags), +1)
 	if loadFileIndicator == noFileLoaded {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	if loadFileIndicator == newFileLoaded {
 		// File changed, so l.iter has changed, and that iterator is not
 		// positioned appropriately.
 		flags = flags.DisableTrySeekUsingNext()
 	}
-	if ikey, val := l.iter.SeekGE(key, flags); ikey != nil {
-		return l.verify(ikey, val)
+	if kv := l.iter.SeekGE(key, flags); kv != nil {
+		return l.verify(kv)
 	}
 	return l.verify(l.skipEmptyFileForward())
 }
 
-func (l *levelIter) SeekPrefixGE(
-	prefix, key []byte, flags base.SeekGEFlags,
-) (*base.InternalKey, base.LazyValue) {
+func (l *levelIter) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	l.err = nil // clear cached iteration error
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
@@ -760,15 +758,15 @@ func (l *levelIter) SeekPrefixGE(
 	// IterOptions.LowerBound.
 	loadFileIndicator := l.loadFile(l.findFileGE(key, flags), +1)
 	if loadFileIndicator == noFileLoaded {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	if loadFileIndicator == newFileLoaded {
 		// File changed, so l.iter has changed, and that iterator is not
 		// positioned appropriately.
 		flags = flags.DisableTrySeekUsingNext()
 	}
-	if key, val := l.iter.SeekPrefixGE(prefix, key, flags); key != nil {
-		return l.verify(key, val)
+	if kv := l.iter.SeekPrefixGE(prefix, key, flags); kv != nil {
+		return l.verify(kv)
 	}
 	// When SeekPrefixGE returns nil, we have not necessarily reached the end of
 	// the sstable. All we know is that a key with prefix does not exist in the
@@ -784,18 +782,19 @@ func (l *levelIter) SeekPrefixGE(
 				l.boundaryContext.isSyntheticIterBoundsKey = true
 				l.boundaryContext.isIgnorableBoundaryKey = false
 			}
-			return l.verify(l.largestBoundary, base.LazyValue{})
+			return l.verify(l.largestBoundary)
 		}
 		// Return the file's largest bound, ensuring this file stays open until
 		// the mergingIter advances beyond the file's bounds. We set
 		// isIgnorableBoundaryKey to signal that the actual key returned should
 		// be ignored, and does not represent a real key in the database.
-		l.largestBoundary = &l.iterFile.LargestPointKey
+		l.syntheticBoundary = base.InternalKV{InternalKey: l.iterFile.LargestPointKey}
+		l.largestBoundary = &l.syntheticBoundary
 		if l.boundaryContext != nil {
 			l.boundaryContext.isSyntheticIterBoundsKey = false
 			l.boundaryContext.isIgnorableBoundaryKey = true
 		}
-		return l.verify(l.largestBoundary, base.LazyValue{})
+		return l.verify(l.largestBoundary)
 	}
 	// It is possible that we are here because bloom filter matching failed. In
 	// that case it is likely that all keys matching the prefix are wholly
@@ -815,12 +814,12 @@ func (l *levelIter) SeekPrefixGE(
 		n = len(l.iterFile.LargestPointKey.UserKey)
 	}
 	if l.cmp(prefix, l.iterFile.LargestPointKey.UserKey[:n]) < 0 {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	return l.verify(l.skipEmptyFileForward())
 }
 
-func (l *levelIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, base.LazyValue) {
+func (l *levelIter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
 	l.err = nil // clear cached iteration error
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
@@ -830,15 +829,15 @@ func (l *levelIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, ba
 	// NB: the top-level Iterator has already adjusted key based on
 	// IterOptions.UpperBound.
 	if l.loadFile(l.findFileLT(key, flags), -1) == noFileLoaded {
-		return nil, base.LazyValue{}
+		return nil
 	}
-	if key, val := l.iter.SeekLT(key, flags); key != nil {
-		return l.verify(key, val)
+	if kv := l.iter.SeekLT(key, flags); kv != nil {
+		return l.verify(kv)
 	}
 	return l.verify(l.skipEmptyFileBackward())
 }
 
-func (l *levelIter) First() (*InternalKey, base.LazyValue) {
+func (l *levelIter) First() *base.InternalKV {
 	l.err = nil // clear cached iteration error
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
@@ -848,15 +847,15 @@ func (l *levelIter) First() (*InternalKey, base.LazyValue) {
 	// NB: the top-level Iterator will call SeekGE if IterOptions.LowerBound is
 	// set.
 	if l.loadFile(l.files.First(), +1) == noFileLoaded {
-		return nil, base.LazyValue{}
+		return nil
 	}
-	if key, val := l.iter.First(); key != nil {
-		return l.verify(key, val)
+	if kv := l.iter.First(); kv != nil {
+		return l.verify(kv)
 	}
 	return l.verify(l.skipEmptyFileForward())
 }
 
-func (l *levelIter) Last() (*InternalKey, base.LazyValue) {
+func (l *levelIter) Last() *base.InternalKV {
 	l.err = nil // clear cached iteration error
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
@@ -866,17 +865,17 @@ func (l *levelIter) Last() (*InternalKey, base.LazyValue) {
 	// NB: the top-level Iterator will call SeekLT if IterOptions.UpperBound is
 	// set.
 	if l.loadFile(l.files.Last(), -1) == noFileLoaded {
-		return nil, base.LazyValue{}
+		return nil
 	}
-	if key, val := l.iter.Last(); key != nil {
-		return l.verify(key, val)
+	if kv := l.iter.Last(); kv != nil {
+		return l.verify(kv)
 	}
 	return l.verify(l.skipEmptyFileBackward())
 }
 
-func (l *levelIter) Next() (*InternalKey, base.LazyValue) {
+func (l *levelIter) Next() *base.InternalKV {
 	if l.err != nil || l.iter == nil {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
@@ -894,30 +893,30 @@ func (l *levelIter) Next() (*InternalKey, base.LazyValue) {
 			if l.rangeDelIterPtr != nil {
 				*l.rangeDelIterPtr = nil
 			}
-			return nil, base.LazyValue{}
+			return nil
 		}
 		// We're stepping past the boundary key, so now we can load the next file.
 		if l.loadFile(l.files.Next(), +1) != noFileLoaded {
-			if key, val := l.iter.First(); key != nil {
-				return l.verify(key, val)
+			if kv := l.iter.First(); kv != nil {
+				return l.verify(kv)
 			}
 			return l.verify(l.skipEmptyFileForward())
 		}
-		return nil, base.LazyValue{}
+		return nil
 
 	default:
 		// Reset the smallest boundary since we're moving away from it.
 		l.smallestBoundary = nil
-		if key, val := l.iter.Next(); key != nil {
-			return l.verify(key, val)
+		if kv := l.iter.Next(); kv != nil {
+			return l.verify(kv)
 		}
 	}
 	return l.verify(l.skipEmptyFileForward())
 }
 
-func (l *levelIter) NextPrefix(succKey []byte) (*InternalKey, base.LazyValue) {
+func (l *levelIter) NextPrefix(succKey []byte) *base.InternalKV {
 	if l.err != nil || l.iter == nil {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
@@ -935,7 +934,7 @@ func (l *levelIter) NextPrefix(succKey []byte) (*InternalKey, base.LazyValue) {
 			if l.rangeDelIterPtr != nil {
 				*l.rangeDelIterPtr = nil
 			}
-			return nil, base.LazyValue{}
+			return nil
 		}
 		// We're stepping past the boundary key, so we need to load a later
 		// file.
@@ -944,8 +943,8 @@ func (l *levelIter) NextPrefix(succKey []byte) (*InternalKey, base.LazyValue) {
 		// Reset the smallest boundary since we're moving away from it.
 		l.smallestBoundary = nil
 
-		if key, val := l.iter.NextPrefix(succKey); key != nil {
-			return l.verify(key, val)
+		if kv := l.iter.NextPrefix(succKey); kv != nil {
+			return l.verify(kv)
 		}
 		// Fall through to seeking.
 	}
@@ -957,17 +956,17 @@ func (l *levelIter) NextPrefix(succKey []byte) (*InternalKey, base.LazyValue) {
 	if l.loadFile(l.findFileGE(succKey, metadataSeekFlags), +1) != noFileLoaded {
 		// NB: The SeekGE on the file's iterator must not set TrySeekUsingNext,
 		// because l.iter is unpositioned.
-		if key, val := l.iter.SeekGE(succKey, base.SeekGEFlagsNone); key != nil {
-			return l.verify(key, val)
+		if kv := l.iter.SeekGE(succKey, base.SeekGEFlagsNone); kv != nil {
+			return l.verify(kv)
 		}
 		return l.verify(l.skipEmptyFileForward())
 	}
-	return nil, base.LazyValue{}
+	return nil
 }
 
-func (l *levelIter) Prev() (*InternalKey, base.LazyValue) {
+func (l *levelIter) Prev() *base.InternalKV {
 	if l.err != nil || l.iter == nil {
-		return nil, base.LazyValue{}
+		return nil
 	}
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
@@ -985,30 +984,29 @@ func (l *levelIter) Prev() (*InternalKey, base.LazyValue) {
 			if l.rangeDelIterPtr != nil {
 				*l.rangeDelIterPtr = nil
 			}
-			return nil, base.LazyValue{}
+			return nil
 		}
 		// We're stepping past the boundary key, so now we can load the prev file.
 		if l.loadFile(l.files.Prev(), -1) != noFileLoaded {
-			if key, val := l.iter.Last(); key != nil {
-				return l.verify(key, val)
+			if kv := l.iter.Last(); kv != nil {
+				return l.verify(kv)
 			}
 			return l.verify(l.skipEmptyFileBackward())
 		}
-		return nil, base.LazyValue{}
+		return nil
 
 	default:
 		// Reset the largest boundary since we're moving away from it.
 		l.largestBoundary = nil
-		if key, val := l.iter.Prev(); key != nil {
-			return l.verify(key, val)
+		if kv := l.iter.Prev(); kv != nil {
+			return l.verify(kv)
 		}
 	}
 	return l.verify(l.skipEmptyFileBackward())
 }
 
-func (l *levelIter) skipEmptyFileForward() (*InternalKey, base.LazyValue) {
-	var key *InternalKey
-	var val base.LazyValue
+func (l *levelIter) skipEmptyFileForward() *base.InternalKV {
+	var kv *base.InternalKV
 	// The first iteration of this loop starts with an already exhausted
 	// l.iter. The reason for the exhaustion is either that we iterated to the
 	// end of the sstable, or our iteration was terminated early due to the
@@ -1024,7 +1022,7 @@ func (l *levelIter) skipEmptyFileForward() (*InternalKey, base.LazyValue) {
 	// file that does not have an exhausted iterator causes the code to return
 	// that key, else the behavior described above if there is a corresponding
 	// rangeDelIterPtr.
-	for ; key == nil; key, val = l.iter.First() {
+	for ; kv == nil; kv = l.iter.First() {
 		if l.rangeDelIterPtr != nil {
 			// We're being used as part of a mergingIter and we've exhausted the
 			// current sstable. If an upper bound is present and the upper bound lies
@@ -1045,21 +1043,22 @@ func (l *levelIter) skipEmptyFileForward() (*InternalKey, base.LazyValue) {
 					if l.boundaryContext != nil {
 						l.boundaryContext.isSyntheticIterBoundsKey = true
 					}
-					return l.largestBoundary, base.LazyValue{}
+					return l.largestBoundary
 				}
 				// Else there are no range deletions in this sstable. This
 				// helps with performance when many levels are populated with
 				// sstables and most don't have any actual keys within the
 				// bounds.
-				return nil, base.LazyValue{}
+				return nil
 			}
 			// If the boundary is a range deletion tombstone, return that key.
 			if l.iterFile.LargestPointKey.Kind() == InternalKeyKindRangeDelete {
-				l.largestBoundary = &l.iterFile.LargestPointKey
+				l.syntheticBoundary.InternalKey = l.iterFile.LargestPointKey
+				l.largestBoundary = &l.syntheticBoundary
 				if l.boundaryContext != nil {
 					l.boundaryContext.isIgnorableBoundaryKey = true
 				}
-				return l.largestBoundary, base.LazyValue{}
+				return l.largestBoundary
 			}
 			// If the last point iterator positioning op might've skipped keys,
 			// it's possible the file's range deletions are still relevant to
@@ -1083,25 +1082,25 @@ func (l *levelIter) skipEmptyFileForward() (*InternalKey, base.LazyValue) {
 			// the next file.
 			if *l.rangeDelIterPtr != nil && l.filteredIter != nil &&
 				l.filteredIter.MaybeFilteredKeys() {
-				l.largestBoundary = &l.iterFile.Largest
+				l.syntheticBoundary.InternalKey = l.iterFile.Largest
+				l.largestBoundary = &l.syntheticBoundary
 				if l.boundaryContext != nil {
 					l.boundaryContext.isIgnorableBoundaryKey = true
 				}
-				return l.largestBoundary, base.LazyValue{}
+				return l.largestBoundary
 			}
 		}
 
 		// Current file was exhausted. Move to the next file.
 		if l.loadFile(l.files.Next(), +1) == noFileLoaded {
-			return nil, base.LazyValue{}
+			return nil
 		}
 	}
-	return key, val
+	return kv
 }
 
-func (l *levelIter) skipEmptyFileBackward() (*InternalKey, base.LazyValue) {
-	var key *InternalKey
-	var val base.LazyValue
+func (l *levelIter) skipEmptyFileBackward() *base.InternalKV {
+	var kv *base.InternalKV
 	// The first iteration of this loop starts with an already exhausted
 	// l.iter. The reason for the exhaustion is either that we iterated to the
 	// end of the sstable, or our iteration was terminated early due to the
@@ -1116,7 +1115,7 @@ func (l *levelIter) skipEmptyFileBackward() (*InternalKey, base.LazyValue) {
 	// file that does not have an exhausted iterator causes the code to return
 	// that key, else the behavior described above if there is a corresponding
 	// rangeDelIterPtr.
-	for ; key == nil; key, val = l.iter.Last() {
+	for ; kv == nil; kv = l.iter.Last() {
 		if l.rangeDelIterPtr != nil {
 			// We're being used as part of a mergingIter and we've exhausted the
 			// current sstable. If a lower bound is present and the lower bound lies
@@ -1137,21 +1136,22 @@ func (l *levelIter) skipEmptyFileBackward() (*InternalKey, base.LazyValue) {
 					if l.boundaryContext != nil {
 						l.boundaryContext.isSyntheticIterBoundsKey = true
 					}
-					return l.smallestBoundary, base.LazyValue{}
+					return l.smallestBoundary
 				}
 				// Else there are no range deletions in this sstable. This
 				// helps with performance when many levels are populated with
 				// sstables and most don't have any actual keys within the
 				// bounds.
-				return nil, base.LazyValue{}
+				return nil
 			}
 			// If the boundary is a range deletion tombstone, return that key.
 			if l.iterFile.SmallestPointKey.Kind() == InternalKeyKindRangeDelete {
-				l.smallestBoundary = &l.iterFile.SmallestPointKey
+				l.syntheticBoundary.InternalKey = l.iterFile.SmallestPointKey
+				l.smallestBoundary = &l.syntheticBoundary
 				if l.boundaryContext != nil {
 					l.boundaryContext.isIgnorableBoundaryKey = true
 				}
-				return l.smallestBoundary, base.LazyValue{}
+				return l.smallestBoundary
 			}
 			// If the last point iterator positioning op skipped keys, it's
 			// possible the file's range deletions are still relevant to other
@@ -1174,20 +1174,21 @@ func (l *levelIter) skipEmptyFileBackward() (*InternalKey, base.LazyValue) {
 			// the top of the heap and immediately skip the entry, advancing to
 			// the next file.
 			if *l.rangeDelIterPtr != nil && l.filteredIter != nil && l.filteredIter.MaybeFilteredKeys() {
-				l.smallestBoundary = &l.iterFile.Smallest
+				l.syntheticBoundary.InternalKey = l.iterFile.Smallest
+				l.smallestBoundary = &l.syntheticBoundary
 				if l.boundaryContext != nil {
 					l.boundaryContext.isIgnorableBoundaryKey = true
 				}
-				return l.smallestBoundary, base.LazyValue{}
+				return l.smallestBoundary
 			}
 		}
 
 		// Current file was exhausted. Move to the previous file.
 		if l.loadFile(l.files.Prev(), -1) == noFileLoaded {
-			return nil, base.LazyValue{}
+			return nil
 		}
 	}
-	return key, val
+	return kv
 }
 
 func (l *levelIter) Error() error {

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -52,8 +52,10 @@ func TestLevelIter(t *testing.T) {
 				f := &fakeIter{}
 				for _, key := range strings.Fields(line) {
 					j := strings.Index(key, ":")
-					f.keys = append(f.keys, base.ParseInternalKey(key[:j]))
-					f.vals = append(f.vals, []byte(key[j+1:]))
+					f.kvs = append(f.kvs, base.InternalKV{
+						InternalKey: base.ParseInternalKey(key[:j]),
+						LazyValue:   base.MakeInPlaceValue([]byte(key[j+1:])),
+					})
 				}
 				iters = append(iters, f)
 
@@ -61,8 +63,8 @@ func TestLevelIter(t *testing.T) {
 					FileNum: FileNum(len(metas)),
 				}).ExtendPointKeyBounds(
 					DefaultComparer.Compare,
-					f.keys[0],
-					f.keys[len(f.keys)-1],
+					f.kvs[0].InternalKey,
+					f.kvs[len(f.kvs)-1].InternalKey,
 				)
 				meta.InitPhysicalBacking()
 				metas = append(metas, meta)
@@ -360,8 +362,8 @@ type levelIterTestIter struct {
 }
 
 func (i *levelIterTestIter) rangeDelSeek(
-	key []byte, ikey *InternalKey, val base.LazyValue, dir int,
-) (*InternalKey, base.LazyValue) {
+	key []byte, kv *base.InternalKV, dir int,
+) *base.InternalKV {
 	var tombstone keyspan.Span
 	if i.rangeDelIter != nil {
 		var t *keyspan.Span
@@ -374,40 +376,40 @@ func (i *levelIterTestIter) rangeDelSeek(
 			tombstone = t.Visible(1000)
 		}
 	}
-	if ikey == nil {
-		return &InternalKey{
-			UserKey: []byte(fmt.Sprintf("./%s", tombstone)),
-		}, base.LazyValue{}
+	if kv == nil {
+		return &base.InternalKV{
+			InternalKey: base.InternalKey{UserKey: []byte(fmt.Sprintf("./%s", tombstone))},
+			LazyValue:   base.LazyValue{},
+		}
 	}
-	return &InternalKey{
-		UserKey: []byte(fmt.Sprintf("%s/%s", ikey.UserKey, tombstone)),
-		Trailer: ikey.Trailer,
-	}, val
+	return &base.InternalKV{
+		InternalKey: base.InternalKey{
+			UserKey: []byte(fmt.Sprintf("%s/%s", kv.UserKey, tombstone)),
+			Trailer: kv.Trailer,
+		},
+		LazyValue: kv.LazyValue,
+	}
 }
 
 func (i *levelIterTestIter) String() string {
 	return "level-iter-test"
 }
 
-func (i *levelIterTestIter) SeekGE(
-	key []byte, flags base.SeekGEFlags,
-) (*InternalKey, base.LazyValue) {
-	ikey, val := i.levelIter.SeekGE(key, flags)
-	return i.rangeDelSeek(key, ikey, val, 1)
+func (i *levelIterTestIter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
+	kv := i.levelIter.SeekGE(key, flags)
+	return i.rangeDelSeek(key, kv, 1)
 }
 
 func (i *levelIterTestIter) SeekPrefixGE(
 	prefix, key []byte, flags base.SeekGEFlags,
-) (*base.InternalKey, base.LazyValue) {
-	ikey, val := i.levelIter.SeekPrefixGE(prefix, key, flags)
-	return i.rangeDelSeek(key, ikey, val, 1)
+) *base.InternalKV {
+	kv := i.levelIter.SeekPrefixGE(prefix, key, flags)
+	return i.rangeDelSeek(key, kv, 1)
 }
 
-func (i *levelIterTestIter) SeekLT(
-	key []byte, flags base.SeekLTFlags,
-) (*InternalKey, base.LazyValue) {
-	ikey, val := i.levelIter.SeekLT(key, flags)
-	return i.rangeDelSeek(key, ikey, val, -1)
+func (i *levelIterTestIter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
+	kv := i.levelIter.SeekLT(key, flags)
+	return i.rangeDelSeek(key, kv, -1)
 }
 
 func TestLevelIterSeek(t *testing.T) {
@@ -505,11 +507,11 @@ func buildLevelIterTables(
 	for i := range readers {
 		iter, err := readers[i].NewIter(nil /* lower */, nil /* upper */)
 		require.NoError(b, err)
-		smallest, _ := iter.First()
+		smallest := iter.First()
 		meta[i] = &fileMetadata{}
 		meta[i].FileNum = FileNum(i)
-		largest, _ := iter.Last()
-		meta[i].ExtendPointKeyBounds(opts.Comparer.Compare, (*smallest).Clone(), (*largest).Clone())
+		largest := iter.Last()
+		meta[i].ExtendPointKeyBounds(opts.Comparer.Compare, (smallest.InternalKey).Clone(), (largest.InternalKey).Clone())
 		meta[i].InitPhysicalBacking()
 	}
 	slice := manifest.NewLevelSliceKeySorted(base.DefaultComparer.Compare, meta)
@@ -585,10 +587,10 @@ func BenchmarkLevelIterSeqSeekGEWithBounds(b *testing.B) {
 								pos := i % (keyCount - 1)
 								l.SetBounds(keys[pos], keys[pos+1])
 								// SeekGE will return keys[pos].
-								k, _ := l.SeekGE(keys[pos], base.SeekGEFlagsNone)
+								kv := l.SeekGE(keys[pos], base.SeekGEFlagsNone)
 								// Next() will get called once and return nil.
-								for k != nil {
-									k, _ = l.Next()
+								for kv != nil {
+									kv = l.Next()
 								}
 							}
 							l.Close()
@@ -672,11 +674,11 @@ func BenchmarkLevelIterNext(b *testing.B) {
 
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {
-								key, _ := l.Next()
-								if key == nil {
-									key, _ = l.First()
+								kv := l.Next()
+								if kv == nil {
+									kv = l.First()
 								}
-								_ = key
+								_ = kv
 							}
 							l.Close()
 						})
@@ -706,11 +708,11 @@ func BenchmarkLevelIterPrev(b *testing.B) {
 
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {
-								key, _ := l.Prev()
-								if key == nil {
-									key, _ = l.Last()
+								kv := l.Prev()
+								if kv == nil {
+									kv = l.Last()
 								}
-								_ = key
+								_ = kv
 							}
 							l.Close()
 						})

--- a/mem_table.go
+++ b/mem_table.go
@@ -361,8 +361,8 @@ func (f *keySpanFrags) get(
 		}
 		it := skl.NewIter(nil, nil)
 		var keysDst []keyspan.Key
-		for key, val := it.First(); key != nil; key, val = it.Next() {
-			s, err := constructSpan(*key, val.InPlaceValue(), keysDst)
+		for kv := it.First(); kv != nil; kv = it.Next() {
+			s, err := constructSpan(kv.InternalKey, kv.InPlaceValue(), keysDst)
 			if err != nil {
 				panic(err)
 			}

--- a/mem_table_test.go
+++ b/mem_table_test.go
@@ -28,18 +28,18 @@ import (
 // not contain the key.
 func (m *memTable) get(key []byte) (value []byte, err error) {
 	it := m.skl.NewIter(nil, nil)
-	ikey, val := it.SeekGE(key, base.SeekGEFlagsNone)
-	if ikey == nil {
+	kv := it.SeekGE(key, base.SeekGEFlagsNone)
+	if kv == nil {
 		return nil, ErrNotFound
 	}
-	if !m.equal(key, ikey.UserKey) {
+	if !m.equal(key, kv.UserKey) {
 		return nil, ErrNotFound
 	}
-	switch ikey.Kind() {
+	switch kv.Kind() {
 	case InternalKeyKindDelete, InternalKeyKindSingleDelete, InternalKeyKindDeleteSized:
 		return nil, ErrNotFound
 	default:
-		return val.InPlaceValue(), nil
+		return kv.InPlaceValue(), nil
 	}
 }
 
@@ -428,27 +428,27 @@ func BenchmarkMemTableIterSeekGE(b *testing.B) {
 func BenchmarkMemTableIterNext(b *testing.B) {
 	m, _ := buildMemTable(b)
 	iter := m.newIter(nil)
-	_, _ = iter.First()
+	_ = iter.First()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		key, _ := iter.Next()
-		if key == nil {
-			key, _ = iter.First()
+		kv := iter.Next()
+		if kv == nil {
+			kv = iter.First()
 		}
-		_ = key
+		_ = kv
 	}
 }
 
 func BenchmarkMemTableIterPrev(b *testing.B) {
 	m, _ := buildMemTable(b)
 	iter := m.newIter(nil)
-	_, _ = iter.Last()
+	_ = iter.Last()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		key, _ := iter.Prev()
-		if key == nil {
-			key, _ = iter.Last()
+		kv := iter.Prev()
+		if kv == nil {
+			kv = iter.Last()
 		}
-		_ = key
+		_ = kv
 	}
 }

--- a/merging_iter_heap.go
+++ b/merging_iter_heap.go
@@ -19,7 +19,7 @@ func (h *mergingIterHeap) clear() {
 }
 
 func (h *mergingIterHeap) less(i, j int) bool {
-	ikey, jkey := h.items[i].iterKey, h.items[j].iterKey
+	ikey, jkey := h.items[i].iterKV.InternalKey, h.items[j].iterKV.InternalKey
 	if c := h.cmp(ikey.UserKey, jkey.UserKey); c != 0 {
 		if h.reverse {
 			return c > 0

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -58,8 +58,10 @@ func TestMergingIterSeek(t *testing.T) {
 				f := &fakeIter{}
 				for _, key := range strings.Fields(line) {
 					j := strings.Index(key, ":")
-					f.keys = append(f.keys, base.ParseInternalKey(key[:j]))
-					f.vals = append(f.vals, []byte(key[j+1:]))
+					f.kvs = append(f.kvs, base.InternalKV{
+						InternalKey: base.ParseInternalKey(key[:j]),
+						LazyValue:   base.MakeInPlaceValue([]byte(key[j+1:])),
+					})
 				}
 				iters = append(iters, f)
 			}
@@ -118,8 +120,10 @@ func TestMergingIterNextPrev(t *testing.T) {
 						iters[i] = f
 						for _, key := range strings.Fields(c[i]) {
 							j := strings.Index(key, ":")
-							f.keys = append(f.keys, base.ParseInternalKey(key[:j]))
-							f.vals = append(f.vals, []byte(key[j+1:]))
+							f.kvs = append(f.kvs, base.InternalKV{
+								InternalKey: base.ParseInternalKey(key[:j]),
+								LazyValue:   base.MakeInPlaceValue([]byte(key[j+1:])),
+							})
 						}
 					}
 
@@ -408,11 +412,11 @@ func BenchmarkMergingIterNext(b *testing.B) {
 
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {
-								key, _ := m.Next()
-								if key == nil {
-									key, _ = m.First()
+								kv := m.Next()
+								if kv == nil {
+									kv = m.First()
 								}
-								_ = key
+								_ = kv
 							}
 							m.Close()
 						})
@@ -444,11 +448,11 @@ func BenchmarkMergingIterPrev(b *testing.B) {
 
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {
-								key, _ := m.Prev()
-								if key == nil {
-									key, _ = m.Last()
+								kv := m.Prev()
+								if kv == nil {
+									kv = m.Last()
 								}
-								_ = key
+								_ = kv
 							}
 							m.Close()
 						})
@@ -593,14 +597,14 @@ func buildLevelsForMergingIterSeqSeek(
 		for j := range readers[i] {
 			iter, err := readers[i][j].NewIter(nil /* lower */, nil /* upper */)
 			require.NoError(b, err)
-			smallest, _ := iter.First()
+			smallestKV := iter.First()
 			meta[j] = &fileMetadata{}
 			// The same FileNum is being reused across different levels, which
 			// is harmless for the benchmark since each level has its own iterator
 			// creation func.
 			meta[j].FileNum = FileNum(j)
-			largest, _ := iter.Last()
-			meta[j].ExtendPointKeyBounds(opts.Comparer.Compare, smallest.Clone(), largest.Clone())
+			largestKV := iter.Last()
+			meta[j].ExtendPointKeyBounds(opts.Comparer.Compare, smallestKV.InternalKey.Clone(), largestKV.InternalKey.Clone())
 			meta[j].InitPhysicalBacking()
 		}
 		levelSlices[i] = manifest.NewLevelSliceSpecificOrder(meta)
@@ -664,9 +668,9 @@ func BenchmarkMergingIterSeqSeekGEWithBounds(b *testing.B) {
 					pos := i % (keyCount - 1)
 					m.SetBounds(keys[pos], keys[pos+1])
 					// SeekGE will return keys[pos].
-					k, _ := m.SeekGE(keys[pos], base.SeekGEFlagsNone)
-					for k != nil {
-						k, _ = m.Next()
+					kv := m.SeekGE(keys[pos], base.SeekGEFlagsNone)
+					for kv != nil {
+						kv = m.Next()
 					}
 				}
 				m.Close()

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -510,17 +510,17 @@ func (o *ingestOp) build(t *test, h historyRecorder, b *pebble.Batch, i int) (st
 	)
 
 	var lastUserKey []byte
-	for key, value := iter.First(); key != nil; key, value = iter.Next() {
+	for kv := iter.First(); kv != nil; kv = iter.Next() {
 		// Ignore duplicate keys.
-		if equal(lastUserKey, key.UserKey) {
+		if equal(lastUserKey, kv.UserKey) {
 			continue
 		}
 		// NB: We don't have to copy the key or value since we're reading from a
 		// batch which doesn't do prefix compression.
-		lastUserKey = key.UserKey
+		lastUserKey = kv.UserKey
 
-		key.SetSeqNum(base.SeqNumZero)
-		if err := w.Add(*key, value.InPlaceValue()); err != nil {
+		kv.SetSeqNum(base.SeqNumZero)
+		if err := w.Add(kv.InternalKey, kv.InPlaceValue()); err != nil {
 			return "", err
 		}
 	}
@@ -602,21 +602,21 @@ func (o *ingestOp) collapseBatch(
 
 	if pointIter != nil {
 		var lastUserKey []byte
-		for key, value := pointIter.First(); key != nil; key, value = pointIter.Next() {
+		for kv := pointIter.First(); kv != nil; kv = pointIter.Next() {
 			// Ignore duplicate keys.
-			if equal(lastUserKey, key.UserKey) {
+			if equal(lastUserKey, kv.UserKey) {
 				continue
 			}
 			// NB: We don't have to copy the key or value since we're reading from a
 			// batch which doesn't do prefix compression.
-			lastUserKey = key.UserKey
+			lastUserKey = kv.UserKey
 
 			var err error
-			switch key.Kind() {
+			switch kv.Kind() {
 			case pebble.InternalKeyKindDelete:
-				err = collapsed.Delete(key.UserKey, nil)
+				err = collapsed.Delete(kv.UserKey, nil)
 			case pebble.InternalKeyKindDeleteSized:
-				v, _ := binary.Uvarint(value.InPlaceValue())
+				v, _ := binary.Uvarint(kv.InPlaceValue())
 				// Batch.DeleteSized takes just the length of the value being
 				// deleted and adds the key's length to derive the overall entry
 				// size of the value being deleted. This has already been done
@@ -624,17 +624,17 @@ func (o *ingestOp) collapseBatch(
 				// the key length from the encoded value before calling
 				// collapsed.DeleteSized, which will again add the key length
 				// before encoding.
-				err = collapsed.DeleteSized(key.UserKey, uint32(v-uint64(len(key.UserKey))), nil)
+				err = collapsed.DeleteSized(kv.UserKey, uint32(v-uint64(len(kv.UserKey))), nil)
 			case pebble.InternalKeyKindSingleDelete:
-				err = collapsed.SingleDelete(key.UserKey, nil)
+				err = collapsed.SingleDelete(kv.UserKey, nil)
 			case pebble.InternalKeyKindSet:
-				err = collapsed.Set(key.UserKey, value.InPlaceValue(), nil)
+				err = collapsed.Set(kv.UserKey, kv.InPlaceValue(), nil)
 			case pebble.InternalKeyKindMerge:
-				err = collapsed.Merge(key.UserKey, value.InPlaceValue(), nil)
+				err = collapsed.Merge(kv.UserKey, kv.InPlaceValue(), nil)
 			case pebble.InternalKeyKindLogData:
-				err = collapsed.LogData(key.UserKey, nil)
+				err = collapsed.LogData(kv.UserKey, nil)
 			default:
-				err = errors.Errorf("unknown batch record kind: %d", key.Kind())
+				err = errors.Errorf("unknown batch record kind: %d", kv.Kind())
 			}
 			if err != nil {
 				return nil, err

--- a/range_keys.go
+++ b/range_keys.go
@@ -447,8 +447,8 @@ var _ internalIterator = (*lazyCombinedIter)(nil)
 // operations that land in the middle of a range key and must truncate to the
 // user-provided seek key.
 func (i *lazyCombinedIter) initCombinedIteration(
-	dir int8, pointKey *InternalKey, pointValue base.LazyValue, seekKey []byte,
-) (*InternalKey, base.LazyValue) {
+	dir int8, pointKV *base.InternalKV, seekKey []byte,
+) *base.InternalKV {
 	// Invariant: i.parent.rangeKey is nil.
 	// Invariant: !i.combinedIterState.initialized.
 	if invariants.Enabled {
@@ -496,11 +496,11 @@ func (i *lazyCombinedIter) initCombinedIteration(
 		// key instead to `bar`. It is guaranteed that no range key exists
 		// earlier than `bar`, otherwise a levelIter would've observed it and
 		// set `combinedIterState.key` to its start key.
-		if pointKey != nil {
-			if dir == +1 && i.parent.cmp(i.combinedIterState.key, pointKey.UserKey) > 0 {
-				seekKey = pointKey.UserKey
-			} else if dir == -1 && i.parent.cmp(seekKey, pointKey.UserKey) < 0 {
-				seekKey = pointKey.UserKey
+		if pointKV != nil {
+			if dir == +1 && i.parent.cmp(i.combinedIterState.key, pointKV.UserKey) > 0 {
+				seekKey = pointKV.UserKey
+			} else if dir == -1 && i.parent.cmp(seekKey, pointKV.UserKey) < 0 {
+				seekKey = pointKV.UserKey
 			}
 		}
 	}
@@ -546,103 +546,99 @@ func (i *lazyCombinedIter) initCombinedIteration(
 		if i.parent.hasPrefix {
 			prefix = i.parent.prefixOrFullSeekKey
 		}
-		return i.parent.rangeKey.iiter.InitSeekGE(prefix, seekKey, pointKey, pointValue)
+		return i.parent.rangeKey.iiter.InitSeekGE(prefix, seekKey, pointKV)
 	}
-	return i.parent.rangeKey.iiter.InitSeekLT(seekKey, pointKey, pointValue)
+	return i.parent.rangeKey.iiter.InitSeekLT(seekKey, pointKV)
 }
 
-func (i *lazyCombinedIter) SeekGE(
-	key []byte, flags base.SeekGEFlags,
-) (*InternalKey, base.LazyValue) {
+func (i *lazyCombinedIter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	if i.combinedIterState.initialized {
 		return i.parent.rangeKey.iiter.SeekGE(key, flags)
 	}
-	k, v := i.pointIter.SeekGE(key, flags)
+	kv := i.pointIter.SeekGE(key, flags)
 	if i.combinedIterState.triggered {
-		return i.initCombinedIteration(+1, k, v, key)
+		return i.initCombinedIteration(+1, kv, key)
 	}
-	return k, v
+	return kv
 }
 
 func (i *lazyCombinedIter) SeekPrefixGE(
 	prefix, key []byte, flags base.SeekGEFlags,
-) (*InternalKey, base.LazyValue) {
+) *base.InternalKV {
 	if i.combinedIterState.initialized {
 		return i.parent.rangeKey.iiter.SeekPrefixGE(prefix, key, flags)
 	}
-	k, v := i.pointIter.SeekPrefixGE(prefix, key, flags)
+	kv := i.pointIter.SeekPrefixGE(prefix, key, flags)
 	if i.combinedIterState.triggered {
-		return i.initCombinedIteration(+1, k, v, key)
+		return i.initCombinedIteration(+1, kv, key)
 	}
-	return k, v
+	return kv
 }
 
-func (i *lazyCombinedIter) SeekLT(
-	key []byte, flags base.SeekLTFlags,
-) (*InternalKey, base.LazyValue) {
+func (i *lazyCombinedIter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
 	if i.combinedIterState.initialized {
 		return i.parent.rangeKey.iiter.SeekLT(key, flags)
 	}
-	k, v := i.pointIter.SeekLT(key, flags)
+	kv := i.pointIter.SeekLT(key, flags)
 	if i.combinedIterState.triggered {
-		return i.initCombinedIteration(-1, k, v, key)
+		return i.initCombinedIteration(-1, kv, key)
 	}
-	return k, v
+	return kv
 }
 
-func (i *lazyCombinedIter) First() (*InternalKey, base.LazyValue) {
+func (i *lazyCombinedIter) First() *base.InternalKV {
 	if i.combinedIterState.initialized {
 		return i.parent.rangeKey.iiter.First()
 	}
-	k, v := i.pointIter.First()
+	kv := i.pointIter.First()
 	if i.combinedIterState.triggered {
-		return i.initCombinedIteration(+1, k, v, nil)
+		return i.initCombinedIteration(+1, kv, nil)
 	}
-	return k, v
+	return kv
 }
 
-func (i *lazyCombinedIter) Last() (*InternalKey, base.LazyValue) {
+func (i *lazyCombinedIter) Last() *base.InternalKV {
 	if i.combinedIterState.initialized {
 		return i.parent.rangeKey.iiter.Last()
 	}
-	k, v := i.pointIter.Last()
+	kv := i.pointIter.Last()
 	if i.combinedIterState.triggered {
-		return i.initCombinedIteration(-1, k, v, nil)
+		return i.initCombinedIteration(-1, kv, nil)
 	}
-	return k, v
+	return kv
 }
 
-func (i *lazyCombinedIter) Next() (*InternalKey, base.LazyValue) {
+func (i *lazyCombinedIter) Next() *base.InternalKV {
 	if i.combinedIterState.initialized {
 		return i.parent.rangeKey.iiter.Next()
 	}
-	k, v := i.pointIter.Next()
+	kv := i.pointIter.Next()
 	if i.combinedIterState.triggered {
-		return i.initCombinedIteration(+1, k, v, nil)
+		return i.initCombinedIteration(+1, kv, nil)
 	}
-	return k, v
+	return kv
 }
 
-func (i *lazyCombinedIter) NextPrefix(succKey []byte) (*InternalKey, base.LazyValue) {
+func (i *lazyCombinedIter) NextPrefix(succKey []byte) *base.InternalKV {
 	if i.combinedIterState.initialized {
 		return i.parent.rangeKey.iiter.NextPrefix(succKey)
 	}
-	k, v := i.pointIter.NextPrefix(succKey)
+	kv := i.pointIter.NextPrefix(succKey)
 	if i.combinedIterState.triggered {
-		return i.initCombinedIteration(+1, k, v, nil)
+		return i.initCombinedIteration(+1, kv, nil)
 	}
-	return k, v
+	return kv
 }
 
-func (i *lazyCombinedIter) Prev() (*InternalKey, base.LazyValue) {
+func (i *lazyCombinedIter) Prev() *base.InternalKV {
 	if i.combinedIterState.initialized {
 		return i.parent.rangeKey.iiter.Prev()
 	}
-	k, v := i.pointIter.Prev()
+	kv := i.pointIter.Prev()
 	if i.combinedIterState.triggered {
-		return i.initCombinedIteration(-1, k, v, nil)
+		return i.initCombinedIteration(-1, kv, nil)
 	}
-	return k, v
+	return kv
 }
 
 func (i *lazyCombinedIter) Error() error {

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -1004,11 +1004,11 @@ func loadFlushedSSTableKeys(
 				return err
 			}
 			defer iter.Close()
-			for k, lv := iter.First(); k != nil; k, lv = iter.Next() {
+			for kv := iter.First(); kv != nil; kv = iter.Next() {
 				var key flushedKey
-				key.Trailer = k.Trailer
-				bufs.alloc, key.UserKey = bufs.alloc.Copy(k.UserKey)
-				if v, callerOwned, err := lv.Value(nil); err != nil {
+				key.Trailer = kv.Trailer
+				bufs.alloc, key.UserKey = bufs.alloc.Copy(kv.UserKey)
+				if v, callerOwned, err := kv.Value(nil); err != nil {
 					return err
 				} else if callerOwned {
 					key.value = v

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -505,8 +505,10 @@ func TestPointCollapsingIter(t *testing.T) {
 						})
 						continue
 					}
-					f.keys = append(f.keys, k)
-					f.vals = append(f.vals, v)
+					f.kvs = append(f.kvs, base.InternalKV{
+						InternalKey: k,
+						LazyValue:   base.MakeInPlaceValue(v),
+					})
 				}
 			}
 

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -939,8 +939,8 @@ func TestBlockProperties(t *testing.T) {
 					var blocks []int
 					var i int
 					iter, _ := newBlockIter(r.Compare, indexH.Get())
-					for key, value := iter.First(); key != nil; key, value = iter.Next() {
-						bh, err := decodeBlockHandleWithProperties(value.InPlaceValue())
+					for kv := iter.First(); kv != nil; kv = iter.Next() {
+						bh, err := decodeBlockHandleWithProperties(kv.InPlaceValue())
 						if err != nil {
 							return err.Error()
 						}
@@ -1302,9 +1302,9 @@ func runBlockPropsCmd(r *Reader, td *datadriven.TestData) string {
 		return nil
 	}
 
-	for key, val := i.First(); key != nil; key, val = i.Next() {
-		sb.WriteString(fmt.Sprintf("%s:\n", key))
-		bhp, err := decodeBlockHandleWithProperties(val.InPlaceValue())
+	for kv := i.First(); kv != nil; kv = i.Next() {
+		sb.WriteString(fmt.Sprintf("%s:\n", kv.InternalKey))
+		bhp, err := decodeBlockHandleWithProperties(kv.InPlaceValue())
 		if err != nil {
 			return err.Error()
 		}
@@ -1324,9 +1324,9 @@ func runBlockPropsCmd(r *Reader, td *datadriven.TestData) string {
 				r.Compare, subIndex.Get(), 0 /* globalSeqNum */, false); err != nil {
 				return err.Error()
 			}
-			for key, value := subiter.First(); key != nil; key, value = subiter.Next() {
-				sb.WriteString(fmt.Sprintf("  %s:\n", key))
-				dataBH, err := decodeBlockHandleWithProperties(value.InPlaceValue())
+			for kv := subiter.First(); kv != nil; kv = subiter.Next() {
+				sb.WriteString(fmt.Sprintf("  %s:\n", kv.InternalKey))
+				dataBH, err := decodeBlockHandleWithProperties(kv.InPlaceValue())
 				if err != nil {
 					return err.Error()
 				}

--- a/sstable/block_test.go
+++ b/sstable/block_test.go
@@ -145,8 +145,8 @@ func TestInvalidInternalKeyDecoding(t *testing.T) {
 	for _, tc := range testCases {
 		i := blockIter{}
 		i.decodeInternalKey([]byte(tc))
-		require.Nil(t, i.ikey.UserKey)
-		require.Equal(t, uint64(InternalKeyKindInvalid), i.ikey.Trailer)
+		require.Nil(t, i.ikv.UserKey)
+		require.Equal(t, uint64(InternalKeyKindInvalid), i.ikv.Trailer)
 	}
 }
 
@@ -331,18 +331,18 @@ func TestBlockIterKeyStability(t *testing.T) {
 	// restart-interval of 1 so that prefix compression was not performed.
 	for j := range expected {
 		keys := [][]byte{}
-		for key, _ := i.SeekGE(expected[j], base.SeekGEFlagsNone); key != nil; key, _ = i.Next() {
-			check(key.UserKey)
-			keys = append(keys, key.UserKey)
+		for kv := i.SeekGE(expected[j], base.SeekGEFlagsNone); kv != nil; kv = i.Next() {
+			check(kv.UserKey)
+			keys = append(keys, kv.UserKey)
 		}
 		require.EqualValues(t, expected[j:], keys)
 	}
 
 	for j := range expected {
 		keys := [][]byte{}
-		for key, _ := i.SeekLT(expected[j], base.SeekLTFlagsNone); key != nil; key, _ = i.Prev() {
-			check(key.UserKey)
-			keys = append(keys, key.UserKey)
+		for kv := i.SeekLT(expected[j], base.SeekLTFlagsNone); kv != nil; kv = i.Prev() {
+			check(kv.UserKey)
+			keys = append(keys, kv.UserKey)
 		}
 		for i, j := 0, len(keys)-1; i < j; i, j = i+1, j-1 {
 			keys[i], keys[j] = keys[j], keys[i]
@@ -375,18 +375,18 @@ func TestBlockIterReverseDirections(t *testing.T) {
 			require.NoError(t, err)
 
 			pos := 3
-			if key, _ := i.SeekLT([]byte("carrot"), base.SeekLTFlagsNone); !bytes.Equal(keys[pos], key.UserKey) {
-				t.Fatalf("expected %s, but found %s", keys[pos], key.UserKey)
+			if kv := i.SeekLT([]byte("carrot"), base.SeekLTFlagsNone); !bytes.Equal(keys[pos], kv.UserKey) {
+				t.Fatalf("expected %s, but found %s", keys[pos], kv.UserKey)
 			}
 			for pos > targetPos {
 				pos--
-				if key, _ := i.Prev(); !bytes.Equal(keys[pos], key.UserKey) {
-					t.Fatalf("expected %s, but found %s", keys[pos], key.UserKey)
+				if kv := i.Prev(); !bytes.Equal(keys[pos], kv.UserKey) {
+					t.Fatalf("expected %s, but found %s", keys[pos], kv.UserKey)
 				}
 			}
 			pos++
-			if key, _ := i.Next(); !bytes.Equal(keys[pos], key.UserKey) {
-				t.Fatalf("expected %s, but found %s", keys[pos], key.UserKey)
+			if kv := i.Next(); !bytes.Equal(keys[pos], kv.UserKey) {
+				t.Fatalf("expected %s, but found %s", keys[pos], kv.UserKey)
 			}
 		})
 	}

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -186,7 +186,7 @@ func (l *Layout) Describe(
 		switch b.name {
 		case "data", "range-del", "range-key":
 			iter, _ := newBlockIter(r.Compare, h.Get())
-			for key, value := iter.First(); key != nil; key, value = iter.Next() {
+			for kv := iter.First(); kv != nil; kv = iter.Next() {
 				ptr := unsafe.Pointer(uintptr(iter.ptr) + uintptr(iter.offset))
 				shared, ptr := decodeVarint(ptr)
 				unshared, ptr := decodeVarint(ptr)
@@ -210,36 +210,36 @@ func (l *Layout) Describe(
 				if fmtRecord != nil {
 					fmt.Fprintf(w, "              ")
 					if l.Format < TableFormatPebblev3 {
-						fmtRecord(key, value.InPlaceValue())
+						fmtRecord(&kv.InternalKey, kv.InPlaceValue())
 					} else {
 						// InPlaceValue() will succeed even for data blocks where the
 						// actual value is in a different location, since this value was
 						// fetched from a blockIter which does not know about value
 						// blocks.
-						v := value.InPlaceValue()
-						if base.TrailerKind(key.Trailer) != InternalKeyKindSet {
-							fmtRecord(key, v)
+						v := kv.InPlaceValue()
+						if base.TrailerKind(kv.Trailer) != InternalKeyKindSet {
+							fmtRecord(&kv.InternalKey, v)
 						} else if !isValueHandle(valuePrefix(v[0])) {
-							fmtRecord(key, v[1:])
+							fmtRecord(&kv.InternalKey, v[1:])
 						} else {
 							vh := decodeValueHandle(v[1:])
-							fmtRecord(key, []byte(fmt.Sprintf("value handle %+v", vh)))
+							fmtRecord(&kv.InternalKey, []byte(fmt.Sprintf("value handle %+v", vh)))
 						}
 					}
 				}
 
-				if base.InternalCompare(r.Compare, lastKey, *key) >= 0 {
+				if base.InternalCompare(r.Compare, lastKey, kv.InternalKey) >= 0 {
 					fmt.Fprintf(w, "              WARNING: OUT OF ORDER KEYS!\n")
 				}
-				lastKey.Trailer = key.Trailer
-				lastKey.UserKey = append(lastKey.UserKey[:0], key.UserKey...)
+				lastKey.Trailer = kv.Trailer
+				lastKey.UserKey = append(lastKey.UserKey[:0], kv.UserKey...)
 			}
 			formatRestarts(iter.data, iter.restarts, iter.numRestarts)
 			formatTrailer()
 		case "index", "top-index":
 			iter, _ := newBlockIter(r.Compare, h.Get())
-			for key, value := iter.First(); key != nil; key, value = iter.Next() {
-				bh, err := decodeBlockHandleWithProperties(value.InPlaceValue())
+			for kv := iter.First(); kv != nil; kv = iter.Next() {
+				bh, err := decodeBlockHandleWithProperties(kv.InPlaceValue())
 				if err != nil {
 					fmt.Fprintf(w, "%10d    [err: %s]\n", b.Offset+uint64(iter.offset), err)
 					continue

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -648,11 +648,11 @@ func (r *Reader) transformRangeDelV1(b []byte) ([]byte, error) {
 		return nil, err
 	}
 	var tombstones []keyspan.Span
-	for key, value := iter.First(); key != nil; key, value = iter.Next() {
+	for kv := iter.First(); kv != nil; kv = iter.Next() {
 		t := keyspan.Span{
-			Start: key.UserKey,
-			End:   value.InPlaceValue(),
-			Keys:  []keyspan.Key{{Trailer: key.Trailer}},
+			Start: kv.UserKey,
+			End:   kv.InPlaceValue(),
+			Keys:  []keyspan.Key{{Trailer: kv.Trailer}},
 		}
 		tombstones = append(tombstones, t)
 	}
@@ -823,8 +823,8 @@ func (r *Reader) Layout() (*Layout, error) {
 	if r.Properties.IndexPartitions == 0 {
 		l.Index = append(l.Index, r.indexBH)
 		iter, _ := newBlockIter(r.Compare, indexH.Get())
-		for key, value := iter.First(); key != nil; key, value = iter.Next() {
-			dataBH, err := decodeBlockHandleWithProperties(value.InPlaceValue())
+		for kv := iter.First(); kv != nil; kv = iter.Next() {
+			dataBH, err := decodeBlockHandleWithProperties(kv.InPlaceValue())
 			if err != nil {
 				return nil, errCorruptIndexEntry
 			}
@@ -837,8 +837,8 @@ func (r *Reader) Layout() (*Layout, error) {
 		l.TopIndex = r.indexBH
 		topIter, _ := newBlockIter(r.Compare, indexH.Get())
 		iter := &blockIter{}
-		for key, value := topIter.First(); key != nil; key, value = topIter.Next() {
-			indexBH, err := decodeBlockHandleWithProperties(value.InPlaceValue())
+		for kv := topIter.First(); kv != nil; kv = topIter.Next() {
+			indexBH, err := decodeBlockHandleWithProperties(kv.InPlaceValue())
 			if err != nil {
 				return nil, errCorruptIndexEntry
 			}
@@ -853,8 +853,8 @@ func (r *Reader) Layout() (*Layout, error) {
 				false /* hideObsoletePoints */); err != nil {
 				return nil, err
 			}
-			for key, value := iter.First(); key != nil; key, value = iter.Next() {
-				dataBH, err := decodeBlockHandleWithProperties(value.InPlaceValue())
+			for kv := iter.First(); kv != nil; kv = iter.Next() {
+				dataBH, err := decodeBlockHandleWithProperties(kv.InPlaceValue())
 				if len(dataBH.Props) > 0 {
 					alloc, dataBH.Props = alloc.Copy(dataBH.Props)
 				}
@@ -997,12 +997,12 @@ func (r *Reader) EstimateDiskUsage(start, end []byte) (uint64, error) {
 			return 0, err
 		}
 
-		key, val := topIter.SeekGE(start, base.SeekGEFlagsNone)
-		if key == nil {
+		kv := topIter.SeekGE(start, base.SeekGEFlagsNone)
+		if kv == nil {
 			// The range falls completely after this file, or an error occurred.
 			return 0, topIter.Error()
 		}
-		startIdxBH, err := decodeBlockHandleWithProperties(val.InPlaceValue())
+		startIdxBH, err := decodeBlockHandleWithProperties(kv.InPlaceValue())
 		if err != nil {
 			return 0, errCorruptIndexEntry
 		}
@@ -1017,13 +1017,13 @@ func (r *Reader) EstimateDiskUsage(start, end []byte) (uint64, error) {
 			return 0, err
 		}
 
-		key, val = topIter.SeekGE(end, base.SeekGEFlagsNone)
-		if key == nil {
+		kv = topIter.SeekGE(end, base.SeekGEFlagsNone)
+		if kv == nil {
 			if err := topIter.Error(); err != nil {
 				return 0, err
 			}
 		} else {
-			endIdxBH, err := decodeBlockHandleWithProperties(val.InPlaceValue())
+			endIdxBH, err := decodeBlockHandleWithProperties(kv.InPlaceValue())
 			if err != nil {
 				return 0, errCorruptIndexEntry
 			}
@@ -1042,12 +1042,12 @@ func (r *Reader) EstimateDiskUsage(start, end []byte) (uint64, error) {
 	// startIdxIter should not be nil at this point, while endIdxIter can be if the
 	// range spans past the end of the file.
 
-	key, val := startIdxIter.SeekGE(start, base.SeekGEFlagsNone)
-	if key == nil {
+	kv := startIdxIter.SeekGE(start, base.SeekGEFlagsNone)
+	if kv == nil {
 		// The range falls completely after this file, or an error occurred.
 		return 0, startIdxIter.Error()
 	}
-	startBH, err := decodeBlockHandleWithProperties(val.InPlaceValue())
+	startBH, err := decodeBlockHandleWithProperties(kv.InPlaceValue())
 	if err != nil {
 		return 0, errCorruptIndexEntry
 	}
@@ -1070,15 +1070,15 @@ func (r *Reader) EstimateDiskUsage(start, end []byte) (uint64, error) {
 		// The range spans beyond this file. Include data blocks through the last.
 		return includeInterpolatedValueBlocksSize(r.Properties.DataSize - startBH.Offset), nil
 	}
-	key, val = endIdxIter.SeekGE(end, base.SeekGEFlagsNone)
-	if key == nil {
+	kv = endIdxIter.SeekGE(end, base.SeekGEFlagsNone)
+	if kv == nil {
 		if err := endIdxIter.Error(); err != nil {
 			return 0, err
 		}
 		// The range spans beyond this file. Include data blocks through the last.
 		return includeInterpolatedValueBlocksSize(r.Properties.DataSize - startBH.Offset), nil
 	}
-	endBH, err := decodeBlockHandleWithProperties(val.InPlaceValue())
+	endBH, err := decodeBlockHandleWithProperties(kv.InPlaceValue())
 	if err != nil {
 		return 0, errCorruptIndexEntry
 	}

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -221,33 +221,33 @@ func rewriteBlocks(
 			bw.restarts = make([]uint32, 0, iter.numRestarts)
 		}
 
-		for key, val := iter.First(); key != nil; key, val = iter.Next() {
-			if key.Kind() != InternalKeyKindSet {
+		for kv := iter.First(); kv != nil; kv = iter.Next() {
+			if kv.Kind() != InternalKeyKindSet {
 				return errBadKind
 			}
-			si := split(key.UserKey)
-			oldSuffix := key.UserKey[si:]
+			si := split(kv.UserKey)
+			oldSuffix := kv.UserKey[si:]
 			if !bytes.Equal(oldSuffix, from) {
 				err := errors.Errorf("key has suffix %q, expected %q", oldSuffix, from)
 				return err
 			}
 			newLen := si + len(to)
 			if cap(scratch.UserKey) < newLen {
-				scratch.UserKey = make([]byte, 0, len(key.UserKey)*2+len(to)-len(from))
+				scratch.UserKey = make([]byte, 0, len(kv.UserKey)*2+len(to)-len(from))
 			}
 
-			scratch.Trailer = key.Trailer
+			scratch.Trailer = kv.Trailer
 			scratch.UserKey = scratch.UserKey[:newLen]
-			copy(scratch.UserKey, key.UserKey[:si])
+			copy(scratch.UserKey, kv.UserKey[:si])
 			copy(scratch.UserKey[si:], to)
 
 			// NB: for TableFormatPebblev3 and higher, since
 			// !iter.lazyValueHandling.hasValuePrefix, it will return the raw value
 			// in the block, which includes the 1-byte prefix. This is fine since bw
 			// also does not know about the prefix and will preserve it in bw.add.
-			v := val.InPlaceValue()
+			v := kv.InPlaceValue()
 			if invariants.Enabled && r.tableFormat >= TableFormatPebblev3 &&
-				key.Kind() == InternalKeyKindSet {
+				kv.Kind() == InternalKeyKindSet {
 				if len(v) < 1 {
 					return errors.Errorf("value has no prefix")
 				}
@@ -483,28 +483,28 @@ func RewriteKeySuffixesViaWriter(
 	}
 	defer i.Close()
 
-	k, v := i.First()
+	kv := i.First()
 	var scratch InternalKey
-	for k != nil {
-		if k.Kind() != InternalKeyKindSet {
+	for kv != nil {
+		if kv.Kind() != InternalKeyKindSet {
 			return nil, errors.New("invalid key type")
 		}
-		oldSuffix := k.UserKey[r.Split(k.UserKey):]
+		oldSuffix := kv.UserKey[r.Split(kv.UserKey):]
 		if !bytes.Equal(oldSuffix, from) {
 			return nil, errors.Errorf("key has suffix %q, expected %q", oldSuffix, from)
 		}
-		scratch.UserKey = append(scratch.UserKey[:0], k.UserKey[:len(k.UserKey)-len(from)]...)
+		scratch.UserKey = append(scratch.UserKey[:0], kv.UserKey[:len(kv.UserKey)-len(from)]...)
 		scratch.UserKey = append(scratch.UserKey, to...)
-		scratch.Trailer = k.Trailer
+		scratch.Trailer = kv.Trailer
 
-		val, _, err := v.Value(nil)
+		val, _, err := kv.Value(nil)
 		if err != nil {
 			return nil, err
 		}
 		if w.addPoint(scratch, val, false); err != nil {
 			return nil, err
 		}
-		k, v = i.Next()
+		kv = i.Next()
 	}
 	if err := rewriteRangeKeyBlockToWriter(r, w, from, to); err != nil {
 		return nil, err

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -368,11 +368,11 @@ func TestWriterWithValueBlocks(t *testing.T) {
 			var values []base.LazyValue
 			n := 0
 			var b []byte
-			for k, lv := iter.First(); k != nil; k, lv = iter.Next() {
+			for kv := iter.First(); kv != nil; kv = iter.Next() {
 				var lvClone base.LazyValue
-				lvClone, b = lv.Clone(b, &fetchers[n])
-				if lv.Fetcher != nil {
-					_, callerOwned, err := lv.Value(nil)
+				lvClone, b = kv.LazyValue.Clone(b, &fetchers[n])
+				if kv.Fetcher != nil {
+					_, callerOwned, err := kv.Value(nil)
 					require.False(t, callerOwned)
 					require.NoError(t, err)
 				}
@@ -896,9 +896,9 @@ func TestWriterRace(t *testing.T) {
 			require.NoError(t, err)
 			defer it.Close()
 			ki := 0
-			for k, v := it.First(); k != nil; k, v = it.Next() {
-				require.Equal(t, k.UserKey, keys[ki])
-				vBytes, _, err := v.Value(nil)
+			for kv := it.First(); kv != nil; kv = it.Next() {
+				require.Equal(t, kv.UserKey, keys[ki])
+				vBytes, _, err := kv.Value(nil)
 				require.NoError(t, err)
 				require.Equal(t, vBytes, val)
 				ki++

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -605,15 +605,15 @@ func testTableCacheRandomAccess(t *testing.T, concurrent bool) {
 				errc <- errors.Errorf("i=%d, fileNum=%d: find: %v", i, fileNum, err)
 				return
 			}
-			key, value := iter.SeekGE([]byte("k"), base.SeekGEFlagsNone)
+			kv := iter.SeekGE([]byte("k"), base.SeekGEFlagsNone)
 			if concurrent {
 				time.Sleep(time.Duration(sleepTime) * time.Microsecond)
 			}
-			if key == nil {
+			if kv == nil {
 				errc <- errors.Errorf("i=%d, fileNum=%d: valid.0: got false, want true", i, fileNum)
 				return
 			}
-			v, _, err := value.Value(nil)
+			v, _, err := kv.Value(nil)
 			if err != nil {
 				errc <- errors.Errorf("i=%d, fileNum=%d: err extracting value: %v", err)
 			}
@@ -621,7 +621,7 @@ func testTableCacheRandomAccess(t *testing.T, concurrent bool) {
 				errc <- errors.Errorf("i=%d, fileNum=%d: value: got %d bytes, want %d", i, fileNum, got, fileNum)
 				return
 			}
-			if key, _ := iter.Next(); key != nil {
+			if kv := iter.Next(); kv != nil {
 				errc <- errors.Errorf("i=%d, fileNum=%d: next.1: got true, want false", i, fileNum)
 				return
 			}

--- a/tool/find.go
+++ b/tool/find.go
@@ -451,7 +451,7 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 				return err
 			}
 			defer iter.Close()
-			key, value := iter.SeekGE(searchKey, base.SeekGEFlagsNone)
+			kv := iter.SeekGE(searchKey, base.SeekGEFlagsNone)
 
 			// We configured sstable.Reader to return raw tombstones which requires a
 			// bit more work here to put them in a form that can be iterated in
@@ -487,23 +487,23 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 			rangeDel := rangeDelIter.First()
 
 			foundRef := false
-			for key != nil || rangeDel != nil {
-				if key != nil &&
-					(rangeDel == nil || r.Compare(key.UserKey, rangeDel.Start) < 0) {
-					if r.Compare(searchKey, key.UserKey) != 0 {
-						key, value = nil, base.LazyValue{}
+			for kv != nil || rangeDel != nil {
+				if kv != nil &&
+					(rangeDel == nil || r.Compare(kv.UserKey, rangeDel.Start) < 0) {
+					if r.Compare(searchKey, kv.UserKey) != 0 {
+						kv = nil
 						continue
 					}
-					v, _, err := value.Value(nil)
+					v, _, err := kv.Value(nil)
 					if err != nil {
 						return err
 					}
 					refs = append(refs, findRef{
-						key:     key.Clone(),
+						key:     kv.InternalKey.Clone(),
 						value:   append([]byte(nil), v...),
 						fileNum: fileNum,
 					})
-					key, value = iter.Next()
+					kv = iter.Next()
 				} else {
 					// Use rangedel.Encode to add a reference for each key
 					// within the span.

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -197,25 +197,25 @@ func (s *sstableT) runCheck(cmd *cobra.Command, args []string) {
 		}
 
 		var lastKey base.InternalKey
-		for key, _ := iter.First(); key != nil; key, _ = iter.Next() {
-			if base.InternalCompare(r.Compare, lastKey, *key) >= 0 {
+		for kv := iter.First(); kv != nil; kv = iter.Next() {
+			if base.InternalCompare(r.Compare, lastKey, kv.InternalKey) >= 0 {
 				fmt.Fprintf(stdout, "WARNING: OUT OF ORDER KEYS!\n")
 				if s.fmtKey.spec != "null" {
 					fmt.Fprintf(stdout, "    %s >= %s\n",
-						lastKey.Pretty(s.fmtKey.fn), key.Pretty(s.fmtKey.fn))
+						lastKey.Pretty(s.fmtKey.fn), kv.InternalKey.Pretty(s.fmtKey.fn))
 				}
 			}
-			lastKey.Trailer = key.Trailer
-			lastKey.UserKey = append(lastKey.UserKey[:0], key.UserKey...)
+			lastKey.Trailer = kv.Trailer
+			lastKey.UserKey = append(lastKey.UserKey[:0], kv.UserKey...)
 
 			if prefixIter != nil {
-				n := r.Split(key.UserKey)
-				prefix := key.UserKey[:n]
-				key2, _ := prefixIter.SeekPrefixGE(prefix, key.UserKey, base.SeekGEFlagsNone)
-				if key2 == nil {
+				n := r.Split(kv.UserKey)
+				prefix := kv.UserKey[:n]
+				kv2 := prefixIter.SeekPrefixGE(prefix, kv.UserKey, base.SeekGEFlagsNone)
+				if kv2 == nil {
 					fmt.Fprintf(stdout, "WARNING: PREFIX ITERATION FAILURE!\n")
 					if s.fmtKey.spec != "null" {
-						fmt.Fprintf(stdout, "    %s not found\n", key.Pretty(s.fmtKey.fn))
+						fmt.Fprintf(stdout, "    %s not found\n", kv2.InternalKey.Pretty(s.fmtKey.fn))
 					}
 				}
 			}
@@ -392,7 +392,7 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 			return
 		}
 		defer iter.Close()
-		key, value := iter.SeekGE(s.start, base.SeekGEFlagsNone)
+		kv := iter.SeekGE(s.start, base.SeekGEFlagsNone)
 
 		// We configured sstable.Reader to return raw tombstones which requires a
 		// bit more work here to put them in a form that can be iterated in
@@ -435,29 +435,29 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 		count := s.count
 
 		var lastKey base.InternalKey
-		for key != nil || rangeDel != nil {
-			if key != nil && (rangeDel == nil || r.Compare(key.UserKey, rangeDel.Start) < 0) {
+		for kv != nil || rangeDel != nil {
+			if kv != nil && (rangeDel == nil || r.Compare(kv.UserKey, rangeDel.Start) < 0) {
 				// The filter specifies a prefix of the key.
 				//
 				// TODO(peter): Is using prefix comparison like this kosher for all
 				// comparers? Probably not, but it is for common ones such as the
 				// Pebble default and CockroachDB's comparer.
-				if s.filter == nil || bytes.HasPrefix(key.UserKey, s.filter) {
+				if s.filter == nil || bytes.HasPrefix(kv.UserKey, s.filter) {
 					fmt.Fprint(stdout, prefix)
-					v, _, err := value.Value(nil)
+					v, _, err := kv.Value(nil)
 					if err != nil {
 						fmt.Fprintf(stdout, "%s%s\n", prefix, err)
 						return
 					}
-					formatKeyValue(stdout, s.fmtKey, s.fmtValue, key, v)
+					formatKeyValue(stdout, s.fmtKey, s.fmtValue, &kv.InternalKey, v)
 
 				}
-				if base.InternalCompare(r.Compare, lastKey, *key) >= 0 {
+				if base.InternalCompare(r.Compare, lastKey, kv.InternalKey) >= 0 {
 					fmt.Fprintf(stdout, "%s    WARNING: OUT OF ORDER KEYS!\n", prefix)
 				}
-				lastKey.Trailer = key.Trailer
-				lastKey.UserKey = append(lastKey.UserKey[:0], key.UserKey...)
-				key, value = iter.Next()
+				lastKey.Trailer = kv.Trailer
+				lastKey.UserKey = append(lastKey.UserKey[:0], kv.UserKey...)
+				kv = iter.Next()
 			} else {
 				// If a filter is specified, we want to output any range tombstone
 				// which overlaps the prefix. The comparison on the start key is


### PR DESCRIPTION
This is a very large, fundamental change to the iterator stack, so I'd like to give it plenty of discussion. I put the PR together ahead of time so that we could clearly see what it looks like, but I'm happy to discard it if we decide against it. Also, speaking of large PRs, this one is truly massive. However, it is purely mechanical, and almost all of it trivially so. The levelIter's `smallestBoundary`,`largestBoundary` fields required maybe the least trivial changes.

If we decide to move forward and it would ease review, I'm also happy to split it across multiple PRs using adapter types to bridge interface gaps.

----

Previously, internal iterators' positioning methods returned two return values, a pointer to an internal key and a LazyValue struct. This commit collapses these two return values into a single return value: a pointer to an InternalKV struct. The key and value buffers were already owned by the underlying iterator, so passing the base.LazyValue as a value did not decouple the two. Propagating a single *InternalKV pointer can be cheaper in some instnaces.

More importantly, it allows us to propagate additional information without increasing the amount of copying up and down the iterator stack. I anticipate this being useful in the implementation of cockroachdb/cockroach#111001, allowing us to propagate checksums alongside keys and values. Merging this change before the branch cut will reduce the pain of any backports.

Iterator microbenchmarks show movement in both directions, mostly ± ~4%.

```
goos: linux
goarch: amd64
pkg: github.com/cockroachdb/pebble
cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
                                                                                                                │   old.txt    │                new.txt                 │
                                                                                                                │    sec/op    │    sec/op     vs base                  │
IteratorSeekGE-24                                                                                                 714.6n ±  2%   747.1n ±  3%   +4.54% (p=0.000 n=10)
IteratorNext-24                                                                                                   26.18n ±  0%   25.53n ±  0%   -2.50% (p=0.000 n=10)
IteratorPrev-24                                                                                                   35.49n ±  0%   36.48n ±  1%   +2.78% (p=0.000 n=10)
IteratorSeqSeekPrefixGENotFound/skip=1/two-level=false/bloom=false/with-tombstone=false-24                        503.8n ±  0%   497.8n ±  0%   -1.18% (p=0.000 n=10)
IteratorSeqSeekPrefixGENotFound/skip=1/two-level=false/bloom=false/with-tombstone=true-24                         388.8n ±  0%   384.8n ±  0%   -1.02% (p=0.000 n=10)
IteratorSeqSeekPrefixGENotFound/skip=1/two-level=false/bloom=true/with-tombstone=false-24                         1.070µ ±  0%   1.082µ ±  0%   +1.17% (p=0.000 n=10)
IteratorSeqSeekPrefixGENotFound/skip=1/two-level=false/bloom=true/with-tombstone=true-24                          465.7n ±  1%   467.9n ±  1%   +0.48% (p=0.009 n=10)
IteratorSeqSeekPrefixGENotFound/skip=1/two-level=true/bloom=false/with-tombstone=false-24                         582.6n ±  0%   559.3n ±  0%   -4.00% (p=0.000 n=10)
IteratorSeqSeekPrefixGENotFound/skip=1/two-level=true/bloom=false/with-tombstone=true-24                          403.8n ±  0%   399.6n ±  0%   -1.03% (p=0.000 n=10)
IteratorSeqSeekPrefixGENotFound/skip=1/two-level=true/bloom=true/with-tombstone=false-24                          1.093µ ±  0%   1.103µ ±  1%   +0.87% (p=0.000 n=10)
IteratorSeqSeekPrefixGENotFound/skip=1/two-level=true/bloom=true/with-tombstone=true-24                           464.9n ±  1%   471.7n ±  0%   +1.46% (p=0.000 n=10)
IteratorSeqSeekPrefixGENotFound/skip=2/two-level=false/bloom=false/with-tombstone=false-24                        503.7n ±  0%   497.9n ±  0%   -1.15% (p=0.000 n=10)
IteratorSeqSeekPrefixGENotFound/skip=2/two-level=false/bloom=false/with-tombstone=true-24                         389.1n ±  0%   384.4n ±  0%   -1.21% (p=0.000 n=10)
IteratorSeqSeekPrefixGENotFound/skip=2/two-level=false/bloom=true/with-tombstone=false-24                         1.068µ ±  1%   1.085µ ±  1%   +1.54% (p=0.000 n=10)
IteratorSeqSeekPrefixGENotFound/skip=2/two-level=false/bloom=true/with-tombstone=true-24                          463.1n ±  1%   463.9n ±  1%        ~ (p=0.631 n=10)
IteratorSeqSeekPrefixGENotFound/skip=2/two-level=true/bloom=false/with-tombstone=false-24                         583.0n ±  0%   559.1n ±  0%   -4.08% (p=0.000 n=10)
IteratorSeqSeekPrefixGENotFound/skip=2/two-level=true/bloom=false/with-tombstone=true-24                          403.4n ±  0%   399.6n ±  0%   -0.94% (p=0.000 n=10)
IteratorSeqSeekPrefixGENotFound/skip=2/two-level=true/bloom=true/with-tombstone=false-24                          1.094µ ±  1%   1.103µ ±  0%   +0.82% (p=0.000 n=10)
IteratorSeqSeekPrefixGENotFound/skip=2/two-level=true/bloom=true/with-tombstone=true-24                           463.2n ±  1%   462.9n ±  0%        ~ (p=0.305 n=10)
IteratorSeqSeekPrefixGENotFound/skip=4/two-level=false/bloom=false/with-tombstone=false-24                        504.9n ±  0%   498.9n ±  0%   -1.19% (p=0.000 n=10)
IteratorSeqSeekPrefixGENotFound/skip=4/two-level=false/bloom=false/with-tombstone=true-24                         389.6n ±  0%   385.6n ±  0%   -1.03% (p=0.000 n=10)
IteratorSeqSeekPrefixGENotFound/skip=4/two-level=false/bloom=true/with-tombstone=false-24                         1.060µ ±  0%   1.065µ ±  0%   +0.42% (p=0.012 n=10)
IteratorSeqSeekPrefixGENotFound/skip=4/two-level=false/bloom=true/with-tombstone=true-24                          461.8n ±  0%   460.2n ±  0%   -0.36% (p=0.041 n=10)
IteratorSeqSeekPrefixGENotFound/skip=4/two-level=true/bloom=false/with-tombstone=false-24                         584.1n ±  0%   560.3n ±  0%   -4.08% (p=0.000 n=10)
IteratorSeqSeekPrefixGENotFound/skip=4/two-level=true/bloom=false/with-tombstone=true-24                          404.3n ±  0%   400.7n ±  0%   -0.90% (p=0.000 n=10)
IteratorSeqSeekPrefixGENotFound/skip=4/two-level=true/bloom=true/with-tombstone=false-24                          1.085µ ±  0%   1.090µ ±  1%   +0.46% (p=0.003 n=10)
IteratorSeqSeekPrefixGENotFound/skip=4/two-level=true/bloom=true/with-tombstone=true-24                           463.4n ±  0%   462.0n ±  1%        ~ (p=0.255 n=10)
IteratorSeqSeekPrefixGEFound/skip=1/two-level=false/bloom=false/with-tombstone=false-24                           605.7n ±  0%   593.3n ±  0%   -2.03% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=1/two-level=false/bloom=false/with-tombstone=true-24                            489.3n ±  0%   483.3n ±  0%   -1.24% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=1/two-level=false/bloom=true/with-tombstone=false-24                            1.269µ ±  0%   1.243µ ±  1%   -2.01% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=1/two-level=false/bloom=true/with-tombstone=true-24                             755.5n ±  0%   742.8n ±  0%   -1.69% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=1/two-level=true/bloom=false/with-tombstone=false-24                            683.7n ±  0%   663.3n ±  0%   -2.98% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=1/two-level=true/bloom=false/with-tombstone=true-24                             508.2n ±  0%   498.3n ±  0%   -1.94% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=1/two-level=true/bloom=true/with-tombstone=false-24                             1.268µ ±  0%   1.238µ ±  1%   -2.41% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=1/two-level=true/bloom=true/with-tombstone=true-24                              776.4n ±  0%   754.6n ±  1%   -2.81% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=2/two-level=false/bloom=false/with-tombstone=false-24                           641.5n ±  0%   629.6n ±  0%   -1.86% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=2/two-level=false/bloom=false/with-tombstone=true-24                            521.8n ±  0%   514.2n ±  0%   -1.46% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=2/two-level=false/bloom=true/with-tombstone=false-24                            1.302µ ±  0%   1.282µ ±  0%   -1.57% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=2/two-level=false/bloom=true/with-tombstone=true-24                             783.1n ±  0%   767.3n ±  0%   -2.02% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=2/two-level=true/bloom=false/with-tombstone=false-24                            721.1n ±  0%   700.3n ±  0%   -2.88% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=2/two-level=true/bloom=false/with-tombstone=true-24                             540.3n ±  0%   529.8n ±  0%   -1.93% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=2/two-level=true/bloom=true/with-tombstone=false-24                             1.305µ ±  0%   1.272µ ±  0%   -2.53% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=2/two-level=true/bloom=true/with-tombstone=true-24                              803.2n ±  0%   779.1n ±  1%   -3.00% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=4/two-level=false/bloom=false/with-tombstone=false-24                           709.9n ±  0%   694.5n ±  0%   -2.16% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=4/two-level=false/bloom=false/with-tombstone=true-24                            588.5n ±  0%   578.8n ±  0%   -1.65% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=4/two-level=false/bloom=true/with-tombstone=false-24                            1.377µ ±  0%   1.348µ ±  1%   -2.07% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=4/two-level=false/bloom=true/with-tombstone=true-24                             842.3n ±  0%   824.4n ±  1%   -2.13% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=4/two-level=true/bloom=false/with-tombstone=false-24                            791.5n ±  0%   768.2n ±  0%   -2.94% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=4/two-level=true/bloom=false/with-tombstone=true-24                             610.2n ±  0%   595.6n ±  0%   -2.39% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=4/two-level=true/bloom=true/with-tombstone=false-24                             1.377µ ±  0%   1.341µ ±  0%   -2.58% (p=0.000 n=10)
IteratorSeqSeekPrefixGEFound/skip=4/two-level=true/bloom=true/with-tombstone=true-24                              861.5n ±  1%   841.1n ±  1%   -2.37% (p=0.000 n=10)
IteratorSeqSeekGEWithBounds/two-level=false-24                                                                    912.5n ±  1%   893.6n ±  1%   -2.07% (p=0.000 n=10)
IteratorSeqSeekGEWithBounds/two-level=true-24                                                                     911.4n ±  0%   893.6n ±  0%   -1.95% (p=0.000 n=10)
IteratorSeekGENoop/withLimit=false-24                                                                             45.12n ±  1%   50.98n ±  0%  +12.98% (p=0.000 n=10)
IteratorSeekGENoop/withLimit=true-24                                                                              82.73n ±  0%   89.69n ±  0%   +8.41% (p=0.000 n=10)
Iterator_RangeKeyMasking/range-keys-suffixes=@10/forward/seekprefix-24                                            45.07m ±  5%   44.94m ±  3%        ~ (p=0.393 n=10)
Iterator_RangeKeyMasking/range-keys-suffixes=@10/forward/next-24                                                  4.023m ±  1%   3.974m ±  1%   -1.23% (p=0.019 n=10)
Iterator_RangeKeyMasking/range-keys-suffixes=@10/backward-24                                                      4.877m ±  1%   4.843m ±  1%        ~ (p=0.247 n=10)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/forward/seekprefix-24                                            44.63m ±  5%   44.79m ±  5%        ~ (p=0.579 n=10)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/forward/next-24                                                  3.584m ±  1%   3.546m ±  1%   -1.04% (p=0.002 n=10)
Iterator_RangeKeyMasking/range-keys-suffixes=@50/backward-24                                                      4.188m ±  1%   4.213m ±  2%        ~ (p=0.796 n=10)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/forward/seekprefix-24                                            44.41m ±  3%   45.65m ±  2%   +2.79% (p=0.035 n=10)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/forward/next-24                                                  2.109m ±  1%   2.115m ±  1%        ~ (p=0.579 n=10)
Iterator_RangeKeyMasking/range-keys-suffixes=@75/backward-24                                                      2.700m ±  1%   2.744m ±  1%   +1.64% (p=0.000 n=10)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/forward/seekprefix-24                                           43.51m ±  2%   44.56m ±  5%   +2.40% (p=0.029 n=10)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/forward/next-24                                                 323.5µ ±  0%   317.1µ ±  1%   -2.00% (p=0.000 n=10)
Iterator_RangeKeyMasking/range-keys-suffixes=@100/backward-24                                                     621.6µ ±  1%   621.2µ ±  1%        ~ (p=0.739 n=10)
IteratorScan/keys=100,r-amp=1,key-types=points-only-24                                                            9.158µ ±  2%   9.227µ ±  1%        ~ (p=0.315 n=10)
IteratorScan/keys=100,r-amp=1,key-types=points-and-ranges-24                                                      9.680µ ± 20%   9.619µ ±  1%        ~ (p=0.481 n=10)
IteratorScan/keys=100,r-amp=3,key-types=points-only-24                                                            16.13µ ±  5%   16.62µ ± 16%   +3.06% (p=0.029 n=10)
IteratorScan/keys=100,r-amp=3,key-types=points-and-ranges-24                                                      16.54µ ± 42%   16.54µ ±  0%        ~ (p=0.869 n=10)
IteratorScan/keys=100,r-amp=7,key-types=points-only-24                                                            23.16µ ±  8%   24.06µ ± 18%   +3.92% (p=0.019 n=10)
IteratorScan/keys=100,r-amp=7,key-types=points-and-ranges-24                                                      23.68µ ±  1%   23.98µ ±  2%   +1.29% (p=0.005 n=10)
IteratorScan/keys=100,r-amp=10,key-types=points-only-24                                                           28.10µ ±  1%   28.39µ ± 24%   +1.05% (p=0.005 n=10)
IteratorScan/keys=100,r-amp=10,key-types=points-and-ranges-24                                                     28.68µ ± 23%   28.78µ ± 23%        ~ (p=0.353 n=10)
IteratorScan/keys=1000,r-amp=1,key-types=points-only-24                                                           72.03µ ±  0%   72.78µ ±  1%   +1.04% (p=0.002 n=10)
IteratorScan/keys=1000,r-amp=1,key-types=points-and-ranges-24                                                     75.56µ ±  0%   75.98µ ±  1%   +0.56% (p=0.000 n=10)
IteratorScan/keys=1000,r-amp=3,key-types=points-only-24                                                           119.7µ ±  0%   121.9µ ±  0%   +1.82% (p=0.000 n=10)
IteratorScan/keys=1000,r-amp=3,key-types=points-and-ranges-24                                                     123.8µ ±  0%   125.7µ ±  0%   +1.54% (p=0.000 n=10)
IteratorScan/keys=1000,r-amp=7,key-types=points-only-24                                                           153.1µ ±  1%   155.0µ ±  0%   +1.23% (p=0.002 n=10)
IteratorScan/keys=1000,r-amp=7,key-types=points-and-ranges-24                                                     156.8µ ±  1%   159.3µ ±  1%   +1.55% (p=0.002 n=10)
IteratorScan/keys=1000,r-amp=10,key-types=points-only-24                                                          164.6µ ±  0%   167.6µ ±  0%   +1.82% (p=0.000 n=10)
IteratorScan/keys=1000,r-amp=10,key-types=points-and-ranges-24                                                    169.3µ ±  1%   171.9µ ±  0%   +1.51% (p=0.001 n=10)
IteratorScan/keys=10000,r-amp=1,key-types=points-only-24                                                          706.3µ ±  0%   717.6µ ±  4%   +1.60% (p=0.001 n=10)
IteratorScan/keys=10000,r-amp=1,key-types=points-and-ranges-24                                                    739.2µ ±  1%   751.0µ ±  0%   +1.59% (p=0.000 n=10)
IteratorScan/keys=10000,r-amp=3,key-types=points-only-24                                                          1.155m ±  0%   1.180m ±  0%   +2.15% (p=0.000 n=10)
IteratorScan/keys=10000,r-amp=3,key-types=points-and-ranges-24                                                    1.195m ±  0%   1.219m ±  0%   +2.01% (p=0.000 n=10)
IteratorScan/keys=10000,r-amp=7,key-types=points-only-24                                                          1.441m ±  0%   1.467m ±  0%   +1.76% (p=0.000 n=10)
IteratorScan/keys=10000,r-amp=7,key-types=points-and-ranges-24                                                    1.481m ±  0%   1.507m ±  0%   +1.80% (p=0.000 n=10)
IteratorScan/keys=10000,r-amp=10,key-types=points-only-24                                                         1.526m ±  0%   1.569m ±  1%   +2.79% (p=0.000 n=10)
IteratorScan/keys=10000,r-amp=10,key-types=points-and-ranges-24                                                   1.573m ±  0%   1.609m ±  1%   +2.34% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=1/ramp=1/value-blocks=false/key-types=points-only-24              143.5n ±  0%   140.9n ±  0%   -1.78% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=1/ramp=1/value-blocks=false/key-types=points-and-ranges-24        147.8n ±  0%   144.8n ±  0%   -2.03% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=1/ramp=1/value-blocks=true/key-types=points-only-24               144.1n ±  0%   141.7n ±  0%   -1.63% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=1/ramp=1/value-blocks=true/key-types=points-and-ranges-24         148.2n ±  0%   145.3n ±  0%   -1.99% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=1/ramp=3/value-blocks=false/key-types=points-only-24              217.3n ±  0%   215.9n ±  0%   -0.64% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=1/ramp=3/value-blocks=false/key-types=points-and-ranges-24        220.8n ±  0%   219.6n ±  0%   -0.57% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=1/ramp=3/value-blocks=true/key-types=points-only-24               216.0n ±  0%   214.5n ±  0%   -0.72% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=1/ramp=3/value-blocks=true/key-types=points-and-ranges-24         220.4n ±  0%   218.1n ±  0%   -1.00% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=1/ramp=7/value-blocks=false/key-types=points-only-24              270.0n ±  0%   270.2n ±  0%        ~ (p=0.146 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=1/ramp=7/value-blocks=false/key-types=points-and-ranges-24        274.1n ±  0%   275.1n ±  1%   +0.36% (p=0.013 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=1/ramp=7/value-blocks=true/key-types=points-only-24               271.2n ±  0%   268.6n ±  0%   -0.96% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=1/ramp=7/value-blocks=true/key-types=points-and-ranges-24         275.6n ±  0%   272.3n ±  0%   -1.20% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=1/ramp=10/value-blocks=false/key-types=points-only-24             301.5n ±  0%   301.6n ±  0%        ~ (p=0.322 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=1/ramp=10/value-blocks=false/key-types=points-and-ranges-24       306.2n ±  0%   305.2n ±  0%   -0.36% (p=0.001 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=1/ramp=10/value-blocks=true/key-types=points-only-24              303.1n ±  0%   298.6n ±  0%   -1.48% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=1/ramp=10/value-blocks=true/key-types=points-and-ranges-24        307.3n ±  0%   303.4n ±  0%   -1.29% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=2/ramp=1/value-blocks=false/key-types=points-only-24              253.2n ±  0%   246.2n ±  0%   -2.76% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=2/ramp=1/value-blocks=false/key-types=points-and-ranges-24        260.2n ±  0%   252.1n ±  0%   -3.13% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=2/ramp=1/value-blocks=true/key-types=points-only-24               253.0n ±  0%   246.8n ±  0%   -2.43% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=2/ramp=1/value-blocks=true/key-types=points-and-ranges-24         260.4n ±  0%   252.8n ±  0%   -2.94% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=2/ramp=3/value-blocks=false/key-types=points-only-24              399.3n ±  0%   391.9n ±  0%   -1.84% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=2/ramp=3/value-blocks=false/key-types=points-and-ranges-24        405.7n ±  0%   397.5n ±  0%   -2.01% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=2/ramp=3/value-blocks=true/key-types=points-only-24               400.5n ±  0%   389.0n ±  0%   -2.86% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=2/ramp=3/value-blocks=true/key-types=points-and-ranges-24         406.4n ±  0%   395.6n ±  0%   -2.66% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=2/ramp=7/value-blocks=false/key-types=points-only-24              469.8n ±  0%   461.8n ±  0%   -1.69% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=2/ramp=7/value-blocks=false/key-types=points-and-ranges-24        475.9n ±  0%   467.3n ±  0%   -1.83% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=2/ramp=7/value-blocks=true/key-types=points-only-24               470.2n ±  0%   461.7n ±  0%   -1.80% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=2/ramp=7/value-blocks=true/key-types=points-and-ranges-24         477.3n ±  0%   467.2n ±  0%   -2.11% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=2/ramp=10/value-blocks=false/key-types=points-only-24             507.2n ±  0%   504.8n ±  0%   -0.47% (p=0.017 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=2/ramp=10/value-blocks=false/key-types=points-and-ranges-24       513.4n ±  0%   513.0n ±  0%        ~ (p=0.271 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=2/ramp=10/value-blocks=true/key-types=points-only-24              507.1n ±  0%   503.8n ±  0%   -0.65% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=2/ramp=10/value-blocks=true/key-types=points-and-ranges-24        514.6n ±  0%   509.9n ±  0%   -0.92% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=10/ramp=1/value-blocks=false/key-types=points-only-24             283.6n ±  0%   275.9n ±  0%   -2.72% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=10/ramp=1/value-blocks=false/key-types=points-and-ranges-24       291.6n ±  0%   281.8n ±  0%   -3.36% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=10/ramp=1/value-blocks=true/key-types=points-only-24              283.7n ±  1%   276.2n ±  0%   -2.63% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=10/ramp=1/value-blocks=true/key-types=points-and-ranges-24        291.6n ±  0%   282.3n ±  0%   -3.21% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=10/ramp=3/value-blocks=false/key-types=points-only-24             442.3n ±  0%   433.6n ±  0%   -1.98% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=10/ramp=3/value-blocks=false/key-types=points-and-ranges-24       449.6n ±  0%   439.2n ±  0%   -2.31% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=10/ramp=3/value-blocks=true/key-types=points-only-24              443.2n ±  0%   434.4n ±  0%   -2.00% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=10/ramp=3/value-blocks=true/key-types=points-and-ranges-24        450.5n ±  0%   439.8n ±  0%   -2.36% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=10/ramp=7/value-blocks=false/key-types=points-only-24             517.5n ±  0%   509.1n ±  1%   -1.63% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=10/ramp=7/value-blocks=false/key-types=points-and-ranges-24       525.1n ±  0%   515.7n ±  0%   -1.79% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=10/ramp=7/value-blocks=true/key-types=points-only-24              514.5n ±  0%   508.4n ±  0%   -1.20% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=10/ramp=7/value-blocks=true/key-types=points-and-ranges-24        522.5n ±  0%   515.6n ±  0%   -1.32% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=10/ramp=10/value-blocks=false/key-types=points-only-24            557.9n ±  0%   555.3n ±  0%   -0.47% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=10/ramp=10/value-blocks=false/key-types=points-and-ranges-24      566.3n ±  0%   560.3n ±  0%   -1.05% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=10/ramp=10/value-blocks=true/key-types=points-only-24             558.0n ±  0%   556.6n ±  0%   -0.23% (p=0.027 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=10/ramp=10/value-blocks=true/key-types=points-and-ranges-24       566.5n ±  0%   562.4n ±  0%   -0.73% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=100/ramp=1/value-blocks=false/key-types=points-only-24            616.8n ±  0%   608.5n ±  0%   -1.34% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=100/ramp=1/value-blocks=false/key-types=points-and-ranges-24      620.8n ±  0%   614.1n ±  0%   -1.08% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=100/ramp=1/value-blocks=true/key-types=points-only-24             615.5n ±  0%   606.4n ±  0%   -1.49% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=100/ramp=1/value-blocks=true/key-types=points-and-ranges-24       619.9n ±  0%   613.0n ±  0%   -1.11% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=100/ramp=3/value-blocks=false/key-types=points-only-24            851.4n ±  0%   843.9n ±  0%   -0.88% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=100/ramp=3/value-blocks=false/key-types=points-and-ranges-24      856.5n ±  0%   850.0n ±  0%   -0.76% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=100/ramp=3/value-blocks=true/key-types=points-only-24             852.7n ±  0%   843.0n ±  0%   -1.14% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=100/ramp=3/value-blocks=true/key-types=points-and-ranges-24       857.7n ±  0%   849.7n ±  0%   -0.93% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=100/ramp=7/value-blocks=false/key-types=points-only-24            963.4n ±  0%   958.7n ±  0%   -0.48% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=100/ramp=7/value-blocks=false/key-types=points-and-ranges-24      969.5n ±  0%   961.8n ±  0%   -0.80% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=100/ramp=7/value-blocks=true/key-types=points-only-24             967.0n ±  0%   956.9n ±  0%   -1.04% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=100/ramp=7/value-blocks=true/key-types=points-and-ranges-24       972.6n ±  0%   963.3n ±  0%   -0.96% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=100/ramp=10/value-blocks=false/key-types=points-only-24           1.042µ ±  0%   1.036µ ±  0%   -0.62% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=100/ramp=10/value-blocks=false/key-types=points-and-ranges-24     1.048µ ±  0%   1.042µ ±  0%   -0.62% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=100/ramp=10/value-blocks=true/key-types=points-only-24            1.040µ ±  0%   1.032µ ±  0%   -0.82% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=10/versions=100/ramp=10/value-blocks=true/key-types=points-and-ranges-24      1.048µ ±  0%   1.040µ ±  0%   -0.76% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=1/ramp=1/value-blocks=false/key-types=points-only-24             109.3n ±  0%   107.8n ±  0%   -1.33% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=1/ramp=1/value-blocks=false/key-types=points-and-ranges-24       112.8n ±  0%   111.4n ±  0%   -1.20% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=1/ramp=1/value-blocks=true/key-types=points-only-24              109.2n ±  0%   108.0n ±  0%   -1.10% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=1/ramp=1/value-blocks=true/key-types=points-and-ranges-24        112.8n ±  0%   111.4n ±  0%   -1.20% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=1/ramp=3/value-blocks=false/key-types=points-only-24             149.0n ±  0%   148.0n ±  0%   -0.70% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=1/ramp=3/value-blocks=false/key-types=points-and-ranges-24       152.5n ±  0%   150.9n ±  0%   -1.02% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=1/ramp=3/value-blocks=true/key-types=points-only-24              149.1n ±  0%   147.8n ±  0%   -0.91% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=1/ramp=3/value-blocks=true/key-types=points-and-ranges-24        152.6n ±  0%   150.8n ±  0%   -1.18% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=1/ramp=7/value-blocks=false/key-types=points-only-24             188.8n ±  1%   186.6n ±  0%   -1.17% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=1/ramp=7/value-blocks=false/key-types=points-and-ranges-24       193.2n ±  0%   190.1n ±  0%   -1.55% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=1/ramp=7/value-blocks=true/key-types=points-only-24              189.1n ±  0%   187.1n ±  0%   -1.06% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=1/ramp=7/value-blocks=true/key-types=points-and-ranges-24        193.6n ±  0%   190.9n ±  1%   -1.37% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=1/ramp=10/value-blocks=false/key-types=points-only-24            211.2n ±  0%   209.4n ±  0%   -0.88% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=1/ramp=10/value-blocks=false/key-types=points-and-ranges-24      216.5n ±  0%   213.7n ±  0%   -1.29% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=1/ramp=10/value-blocks=true/key-types=points-only-24             211.4n ±  0%   211.0n ±  0%   -0.19% (p=0.021 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=1/ramp=10/value-blocks=true/key-types=points-and-ranges-24       216.5n ±  0%   214.7n ±  0%   -0.83% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=2/ramp=1/value-blocks=false/key-types=points-only-24             208.5n ±  0%   201.5n ±  0%   -3.36% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=2/ramp=1/value-blocks=false/key-types=points-and-ranges-24       215.1n ±  0%   207.2n ±  0%   -3.67% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=2/ramp=1/value-blocks=true/key-types=points-only-24              208.5n ±  0%   201.3n ±  0%   -3.48% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=2/ramp=1/value-blocks=true/key-types=points-and-ranges-24        214.6n ±  0%   207.2n ±  0%   -3.43% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=2/ramp=3/value-blocks=false/key-types=points-only-24             305.2n ±  0%   297.6n ±  0%   -2.49% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=2/ramp=3/value-blocks=false/key-types=points-and-ranges-24       312.4n ±  0%   303.2n ±  0%   -2.94% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=2/ramp=3/value-blocks=true/key-types=points-only-24              305.8n ±  0%   298.8n ±  0%   -2.26% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=2/ramp=3/value-blocks=true/key-types=points-and-ranges-24        312.4n ±  0%   304.6n ±  0%   -2.48% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=2/ramp=7/value-blocks=false/key-types=points-only-24             359.8n ±  0%   353.6n ±  0%   -1.71% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=2/ramp=7/value-blocks=false/key-types=points-and-ranges-24       366.6n ±  0%   360.4n ±  0%   -1.68% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=2/ramp=7/value-blocks=true/key-types=points-only-24              358.8n ±  0%   353.5n ±  0%   -1.48% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=2/ramp=7/value-blocks=true/key-types=points-and-ranges-24        365.8n ±  0%   359.9n ±  0%   -1.61% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=2/ramp=10/value-blocks=false/key-types=points-only-24            386.0n ±  0%   384.2n ±  0%   -0.45% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=2/ramp=10/value-blocks=false/key-types=points-and-ranges-24      393.9n ±  0%   390.1n ±  0%   -0.95% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=2/ramp=10/value-blocks=true/key-types=points-only-24             385.6n ±  0%   384.9n ±  0%        ~ (p=0.158 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=2/ramp=10/value-blocks=true/key-types=points-and-ranges-24       393.2n ±  0%   390.9n ±  0%   -0.59% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=10/ramp=1/value-blocks=false/key-types=points-only-24            247.9n ±  0%   239.6n ±  0%   -3.33% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=10/ramp=1/value-blocks=false/key-types=points-and-ranges-24      254.4n ±  0%   246.1n ±  0%   -3.24% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=10/ramp=1/value-blocks=true/key-types=points-only-24             248.1n ±  0%   239.6n ±  0%   -3.43% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=10/ramp=1/value-blocks=true/key-types=points-and-ranges-24       254.9n ±  0%   245.2n ±  0%   -3.77% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=10/ramp=3/value-blocks=false/key-types=points-only-24            364.6n ±  0%   357.2n ±  0%   -2.03% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=10/ramp=3/value-blocks=false/key-types=points-and-ranges-24      370.9n ±  0%   361.9n ±  0%   -2.41% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=10/ramp=3/value-blocks=true/key-types=points-only-24             364.2n ±  0%   355.7n ±  0%   -2.32% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=10/ramp=3/value-blocks=true/key-types=points-and-ranges-24       370.5n ±  0%   361.2n ±  0%   -2.51% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=10/ramp=7/value-blocks=false/key-types=points-only-24            421.2n ±  0%   415.1n ±  0%   -1.46% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=10/ramp=7/value-blocks=false/key-types=points-and-ranges-24      428.4n ±  0%   420.9n ±  0%   -1.75% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=10/ramp=7/value-blocks=true/key-types=points-only-24             422.2n ±  0%   414.9n ±  0%   -1.74% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=10/ramp=7/value-blocks=true/key-types=points-and-ranges-24       430.1n ±  0%   421.3n ±  0%   -2.03% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=10/ramp=10/value-blocks=false/key-types=points-only-24           459.0n ±  0%   455.3n ±  0%   -0.80% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=10/ramp=10/value-blocks=false/key-types=points-and-ranges-24     466.1n ±  0%   460.5n ±  0%   -1.19% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=10/ramp=10/value-blocks=true/key-types=points-only-24            458.7n ±  0%   455.0n ±  0%   -0.81% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=10/ramp=10/value-blocks=true/key-types=points-and-ranges-24      466.0n ±  0%   460.7n ±  0%   -1.14% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=100/ramp=1/value-blocks=false/key-types=points-only-24           623.6n ±  0%   613.3n ±  0%   -1.65% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=100/ramp=1/value-blocks=false/key-types=points-and-ranges-24     629.3n ±  0%   619.4n ±  0%   -1.57% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=100/ramp=1/value-blocks=true/key-types=points-only-24            624.2n ±  0%   614.1n ±  0%   -1.63% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=100/ramp=1/value-blocks=true/key-types=points-and-ranges-24      629.6n ±  0%   619.8n ±  0%   -1.55% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=100/ramp=3/value-blocks=false/key-types=points-only-24           799.1n ±  0%   787.6n ±  1%   -1.43% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=100/ramp=3/value-blocks=false/key-types=points-and-ranges-24     805.4n ±  0%   792.7n ±  0%   -1.58% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=100/ramp=3/value-blocks=true/key-types=points-only-24            797.6n ±  0%   793.0n ±  0%   -0.58% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=100/ramp=3/value-blocks=true/key-types=points-and-ranges-24      805.1n ±  0%   797.3n ±  0%   -0.97% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=100/ramp=7/value-blocks=false/key-types=points-only-24           3.121µ ±  1%   2.999µ ±  0%   -3.93% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=100/ramp=7/value-blocks=false/key-types=points-and-ranges-24     3.131µ ±  1%   3.012µ ±  0%   -3.79% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=100/ramp=7/value-blocks=true/key-types=points-only-24            3.104µ ±  1%   2.988µ ±  1%   -3.75% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=100/ramp=7/value-blocks=true/key-types=points-and-ranges-24      3.122µ ±  0%   3.011µ ±  0%   -3.56% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=100/ramp=10/value-blocks=false/key-types=points-only-24          3.234µ ±  0%   3.106µ ±  1%   -3.97% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=100/ramp=10/value-blocks=false/key-types=points-and-ranges-24    3.247µ ±  1%   3.114µ ±  1%   -4.11% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=100/ramp=10/value-blocks=true/key-types=points-only-24           3.234µ ±  1%   3.099µ ±  0%   -4.18% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=100/versions=100/ramp=10/value-blocks=true/key-types=points-and-ranges-24     3.250µ ±  0%   3.120µ ±  0%   -4.00% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=1000/versions=1/ramp=1/value-blocks=false/key-types=points-only-24            109.0n ±  0%   108.2n ±  0%   -0.69% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=1000/versions=1/ramp=1/value-blocks=false/key-types=points-and-ranges-24      112.5n ±  0%   111.5n ±  0%   -0.89% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=1000/versions=1/ramp=1/value-blocks=true/key-types=points-only-24             109.5n ±  0%   107.8n ±  0%   -1.46% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=1000/versions=1/ramp=1/value-blocks=true/key-types=points-and-ranges-24       112.9n ±  0%   111.3n ±  0%   -1.42% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=1000/versions=1/ramp=3/value-blocks=false/key-types=points-only-24            134.8n ±  0%   135.2n ±  1%        ~ (p=0.339 n=10)
IteratorScanNextPrefix/keysPerLevel=1000/versions=1/ramp=3/value-blocks=false/key-types=points-and-ranges-24      138.8n ±  0%   138.0n ±  0%   -0.50% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=1000/versions=1/ramp=3/value-blocks=true/key-types=points-only-24             135.0n ±  0%   135.2n ±  1%        ~ (p=0.360 n=10)
IteratorScanNextPrefix/keysPerLevel=1000/versions=1/ramp=3/value-blocks=true/key-types=points-and-ranges-24       138.8n ±  0%   137.6n ±  0%   -0.83% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=1000/versions=1/ramp=7/value-blocks=false/key-types=points-only-24            175.9n ±  0%   174.0n ±  0%   -1.05% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=1000/versions=1/ramp=7/value-blocks=false/key-types=points-and-ranges-24      180.6n ±  0%   177.6n ±  1%   -1.63% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=1000/versions=1/ramp=7/value-blocks=true/key-types=points-only-24             176.0n ±  0%   174.4n ±  0%   -0.94% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=1000/versions=1/ramp=7/value-blocks=true/key-types=points-and-ranges-24       180.2n ±  0%   177.8n ±  0%   -1.36% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=1000/versions=1/ramp=10/value-blocks=false/key-types=points-only-24           200.5n ±  0%   198.8n ±  0%   -0.90% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=1000/versions=1/ramp=10/value-blocks=false/key-types=points-and-ranges-24     205.4n ±  0%   202.8n ±  0%   -1.29% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=1000/versions=1/ramp=10/value-blocks=true/key-types=points-only-24            200.8n ±  0%   199.2n ±  0%   -0.82% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=1000/versions=1/ramp=10/value-blocks=true/key-types=points-and-ranges-24      205.3n ±  0%   203.3n ±  0%   -0.97% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=1000/versions=2/ramp=1/value-blocks=false/key-types=points-only-24            209.1n ±  0%   201.9n ±  0%   -3.44% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=1000/versions=2/ramp=1/value-blocks=false/key-types=points-and-ranges-24      215.6n ±  0%   207.4n ±  0%   -3.80% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=1000/versions=2/ramp=1/value-blocks=true/key-types=points-only-24             208.6n ±  0%   201.8n ±  0%   -3.26% (p=0.000 n=10)
IteratorScanNextPrefix/keysPerLevel=1000/versions=2/ramp=1/value-blocks=true/key-types=points-and-ranges-24       215.1n ±  0%   207.5n ±  0%   -3.56% (p=0.000 n=10)
```