### PR TITLE
crl-release-22.2: manifest: grab manifest lock when calling InitCompactingFileInfo

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1442,8 +1442,9 @@ func (d *DB) addInProgressCompaction(c *compaction) {
 // indicates whether the compaction state should be rolled back to its original
 // state in the case of an unsuccessful compaction.
 //
-// DB.mu must be held when calling this method. All writes to the manifest for
-// this compaction should have completed by this point.
+// DB.mu must be held when calling this method, however this method can drop and
+// re-acquire that mutex. All writes to the manifest for this compaction should
+// have completed by this point.
 func (d *DB) removeInProgressCompaction(c *compaction, rollback bool) {
 	for _, cl := range c.inputs {
 		iter := cl.files.Iter()
@@ -1471,7 +1472,17 @@ func (d *DB) removeInProgressCompaction(c *compaction, rollback bool) {
 	delete(d.mu.compact.inProgress, c)
 
 	l0InProgress := inProgressL0Compactions(d.getInProgressCompactionInfoLocked(c))
-	d.mu.versions.currentVersion().L0Sublevels.InitCompactingFileInfo(l0InProgress)
+	func() {
+		// InitCompactingFileInfo requires that no other manifest writes be
+		// happening in parallel with it, i.e. we're not in the midst of installing
+		// another version. Otherwise, it's possible that we've created another
+		// L0Sublevels instance, but not added it to the versions list, causing
+		// all the indices in FileMetadata to be inaccurate. To ensure this,
+		// grab the manifest lock.
+		d.mu.versions.logLock()
+		defer d.mu.versions.logUnlock()
+		d.mu.versions.currentVersion().L0Sublevels.InitCompactingFileInfo(l0InProgress)
+	}()
 }
 
 func (d *DB) calculateDiskAvailableBytes() uint64 {


### PR DESCRIPTION
Previously, we had one case where we could be calling InitCompactingFileInfo (a method on L0Sublevels that must be called on the most-recently-created L0Sublevels) on a failed compaction while another version was being installed but was in the process of writing to the manifest, and had hence dropped the db mutex during IO. This had the potential to panic on a case where we expect the interval indices in FileMetadata to match exactly with those in the latest version's L0Sublevels. If there's a newer L0Sublevels being created that hasn't been installed into the versions list yet, the two are expected to be out of sync.

This change resolves this by grabbing the manifest lock before calling InitCompactingFileInfo in clearCompactionState.

Will address cockroachdb/cockroach#109866 when it lands in cockroach.