### PR TITLE
crl-release-22.1: manifest: grab manifest lock when calling InitCompactingFileInfo

### DIFF
--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -708,7 +708,7 @@ func (s *L0Sublevels) calculateFlushSplitKeys(flushSplitMaxBytes int64) {
 // InitCompactingFileInfo initializes internal flags relating to compacting
 // files. Must be called after sublevel initialization.
 //
-// Requires DB.mu to be held.
+// Requires DB.mu *and* the manifest lock to be held.
 func (s *L0Sublevels) InitCompactingFileInfo(inProgress []L0Compaction) {
 	for i := range s.orderedIntervals {
 		s.orderedIntervals[i].compactingFileCount = 0
@@ -720,6 +720,13 @@ func (s *L0Sublevels) InitCompactingFileInfo(inProgress []L0Compaction) {
 	for f := iter.First(); f != nil; f = iter.Next() {
 		if !f.Compacting {
 			continue
+		}
+		if invariants.Enabled {
+			if s.cmp(s.orderedIntervals[f.minIntervalIndex].startKey.key, f.Smallest.UserKey) != 0 || s.cmp(s.orderedIntervals[f.maxIntervalIndex+1].startKey.key, f.Largest.UserKey) != 0 {
+				panic(fmt.Sprintf("file %s has inconsistent L0 Sublevel interval bounds: %s-%s, %s-%s", f.FileNum,
+					s.orderedIntervals[f.minIntervalIndex].startKey.key, s.orderedIntervals[f.maxIntervalIndex+1].startKey.key,
+					f.Smallest.UserKey, f.Largest.UserKey))
+			}
 		}
 		for i := f.minIntervalIndex; i <= f.maxIntervalIndex; i++ {
 			interval := &s.orderedIntervals[i]


### PR DESCRIPTION
Previously, we had one case where we could be calling InitCompactingFileInfo (a method on L0Sublevels that must be called on the most-recently-created L0Sublevels) on a failed compaction while another version was being installed but was in the process of writing to the manifest, and had hence dropped the db mutex during IO. This had the potential to panic on a case where we expect the interval indices in FileMetadata to match exactly with those in the latest version's L0Sublevels. If there's a newer L0Sublevels being created that hasn't been installed into the versions list yet, the two are expected to be out of sync.

This change resolves this by grabbing the manifest lock before calling InitCompactingFileInfo in clearCompactionState.

Will address cockroachdb/cockroach#109866 when it lands in cockroach.