### PR TITLE
db: turn testingAlwaysWaitForCleanup into an option

### DIFF
--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -39,6 +39,7 @@ func TestCheckpoint(t *testing.T) {
 		DisableAutomaticCompactions: true,
 	}
 	opts.private.disableTableStats = true
+	opts.private.testingAlwaysWaitForCleanup = true
 
 	datadriven.RunTest(t, "testdata/checkpoint", func(t *testing.T, td *datadriven.TestData) string {
 		switch td.Cmd {

--- a/cleaner_test.go
+++ b/cleaner_test.go
@@ -109,12 +109,12 @@ func TestCleaner(t *testing.T) {
 			}
 			// Asynchronous table stats retrieval makes the output flaky.
 			opts.private.disableTableStats = true
+			opts.private.testingAlwaysWaitForCleanup = true
 			d, err := Open(dir, opts)
 			if err != nil {
 				return err.Error()
 			}
 			d.TestOnlyWaitForCleaning()
-			d.testingAlwaysWaitForCleanup = true
 			dbs[dir] = d
 			return memLog.String()
 

--- a/compaction.go
+++ b/compaction.go
@@ -3778,7 +3778,7 @@ func (d *DB) deleteObsoleteFiles(jobID int) {
 	if len(filesToDelete) > 0 {
 		d.cleanupManager.EnqueueJob(jobID, filesToDelete)
 	}
-	if d.testingAlwaysWaitForCleanup {
+	if d.opts.private.testingAlwaysWaitForCleanup {
 		d.cleanupManager.Wait()
 	}
 }

--- a/db.go
+++ b/db.go
@@ -316,9 +316,6 @@ type DB struct {
 	closedCh chan struct{}
 
 	cleanupManager *cleanupManager
-	// testingAlwaysWaitForCleanup is set by some tests to force waiting for
-	// obsolete file deletion (to make events deterministic).
-	testingAlwaysWaitForCleanup bool
 
 	// During an iterator close, we may asynchronously schedule read compactions.
 	// We want to wait for those goroutines to finish, before closing the DB.

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -69,7 +69,7 @@ func TestEventListener(t *testing.T) {
 				t = t.Add(time.Second)
 				return t
 			}
-			d.testingAlwaysWaitForCleanup = true
+			d.opts.private.testingAlwaysWaitForCleanup = true
 			return memLog.String()
 
 		case "close":

--- a/options.go
+++ b/options.go
@@ -955,6 +955,10 @@ type Options struct {
 		// A private option to disable stats collection.
 		disableTableStats bool
 
+		// testingAlwaysWaitForCleanup is set by some tests to force waiting for
+		// obsolete file deletion (to make events deterministic).
+		testingAlwaysWaitForCleanup bool
+
 		// fsCloser holds a closer that should be invoked after a DB using these
 		// Options is closed. This is used to automatically stop the
 		// long-running goroutine associated with the disk-health-checking FS.

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -704,6 +704,8 @@ sync: checkpoints/checkpoint5/temporary.000020.dbtmp
 close: checkpoints/checkpoint5/temporary.000020.dbtmp
 rename: checkpoints/checkpoint5/temporary.000020.dbtmp -> checkpoints/checkpoint5/OPTIONS-000020
 sync: checkpoints/checkpoint5
+remove: checkpoints/checkpoint5/000008.log
+remove: checkpoints/checkpoint5/OPTIONS-000003
 
 print-backing checkpoints/checkpoint5
 ----
@@ -792,6 +794,8 @@ sync: checkpoints/checkpoint6/temporary.000020.dbtmp
 close: checkpoints/checkpoint6/temporary.000020.dbtmp
 rename: checkpoints/checkpoint6/temporary.000020.dbtmp -> checkpoints/checkpoint6/OPTIONS-000020
 sync: checkpoints/checkpoint6
+remove: checkpoints/checkpoint6/000008.log
+remove: checkpoints/checkpoint6/OPTIONS-000003
 
 print-backing checkpoints/checkpoint6
 ----


### PR DESCRIPTION
There are some potential racy problems by making it a variable which is written to after the db is opened. All of the existing use cases can just use this variable as an option.