### PR TITLE
metamorphic: fix unbounded snapshot access

### DIFF
--- a/metamorphic/generator.go
+++ b/metamorphic/generator.go
@@ -737,13 +737,13 @@ func (g *generator) newIterUsingClone() {
 		refreshBatch = g.rng.Intn(2) == 1
 	}
 
-	var opts iterOpts
+	opts := g.itersLastOpts[existingIterID]
+	// With 50% probability, consider modifying the iterator options used by the
+	// clone.
 	if g.rng.Intn(2) == 1 {
 		g.maybeMutateOptions(readerID, &opts)
-		g.itersLastOpts[iterID] = opts
-	} else {
-		g.itersLastOpts[iterID] = g.itersLastOpts[existingIterID]
 	}
+	g.itersLastOpts[iterID] = opts
 
 	g.iterCreationTimestamp[iterID] = g.keyManager.nextMetaTimestamp()
 	g.iterReaderID[iterID] = g.iterReaderID[existingIterID]


### PR DESCRIPTION
Previously, when cloning an iterator backed by a bounded snapshot, the metamorphic test would sometimes clear all iterator options. This included terator bounds which are required to keep the iterator's access within the snapshot's bounds to prevent nondeterminism outside those bounds. This commit fixes this, by defaulting to the cloned iterator's options in these cases.

Resolves #2969.