### PR TITLE
metamorphic: Add TestMetaTwoInstance

### DIFF
--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -70,3 +70,24 @@ func TestMeta(t *testing.T) {
 		metamorphic.RunAndCompare(t, runFlags.Dir, opts...)
 	}
 }
+
+func TestMetaTwoInstance(t *testing.T) {
+	switch {
+	case runOnceFlags.Compare != "":
+		runDirs := strings.Split(runOnceFlags.Compare, ",")
+		onceOpts := runOnceFlags.MakeRunOnceOptions()
+		metamorphic.Compare(t, runOnceFlags.Dir, runOnceFlags.Seed, runDirs, onceOpts...)
+
+	case runOnceFlags.RunDir != "":
+		// The --run-dir flag is specified either in the child process (see
+		// runOptions() below) or the user specified it manually in order to re-run
+		// a test.
+		onceOpts := runOnceFlags.MakeRunOnceOptions()
+		metamorphic.RunOnce(t, runOnceFlags.RunDir, runOnceFlags.Seed, filepath.Join(runOnceFlags.RunDir, "history"), onceOpts...)
+
+	default:
+		opts := runFlags.MakeRunOptions()
+		opts = append(opts, metamorphic.MultiInstance(2))
+		metamorphic.RunAndCompare(t, runFlags.Dir, opts...)
+	}
+}

--- a/internal/metamorphic/metaflags/meta_flags.go
+++ b/internal/metamorphic/metaflags/meta_flags.go
@@ -35,6 +35,9 @@ type CommonFlags struct {
 	Keep bool
 	// MaxThreads used by a single run. See "max-threads" flag below.
 	MaxThreads int
+	// NumInstances is the number of Pebble instances to create in one run. See
+	// "num-instances" flag below.
+	NumInstances int
 }
 
 func initCommonFlags() *CommonFlags {
@@ -64,6 +67,8 @@ func initCommonFlags() *CommonFlags {
 
 	flag.IntVar(&c.MaxThreads, "max-threads", math.MaxInt,
 		"limit execution of a single run to the provided number of threads; must be ≥ 1")
+
+	flag.IntVar(&c.NumInstances, "num-instances", 1, "number of pebble instances to create (default: 1)")
 
 	return c
 }
@@ -179,6 +184,9 @@ func (ro *RunOnceFlags) MakeRunOnceOptions() []metamorphic.RunOnceOption {
 	if ro.ErrorRate > 0 {
 		onceOpts = append(onceOpts, metamorphic.InjectErrorsRate(ro.ErrorRate))
 	}
+	if ro.NumInstances > 1 {
+		onceOpts = append(onceOpts, metamorphic.MultiInstance(ro.NumInstances))
+	}
 	return onceOpts
 }
 
@@ -203,6 +211,9 @@ func (r *RunFlags) MakeRunOptions() []metamorphic.RunOption {
 	}
 	if r.PreviousOps != "" {
 		opts = append(opts, metamorphic.ExtendPreviousRun(r.PreviousOps, r.InitialStatePath, r.InitialStateDesc))
+	}
+	if r.NumInstances > 1 {
+		opts = append(opts, metamorphic.MultiInstance(r.NumInstances))
 	}
 
 	// If the filesystem type was forced, all tests will use that value.

--- a/metamorphic/generator.go
+++ b/metamorphic/generator.go
@@ -56,6 +56,7 @@ type generator struct {
 
 	// keyManager tracks the state of keys a operation generation time.
 	keyManager *keyManager
+	dbs        objIDSlice
 	// Unordered sets of object IDs for live objects. Used to randomly select on
 	// object when generating an operation. There are 4 concrete objects: the DB
 	// (of which there is exactly 1), batches, iterators, and snapshots.
@@ -83,6 +84,9 @@ type generator struct {
 	// iterators. The iter set value will also be indexed by either the batches
 	// or snapshots maps.
 	iters map[objID]objIDSet
+	// objectID -> db: used to keep track of the DB a batch, iter, or snapshot
+	// was created on.
+	objDB map[objID]objID
 	// readerID -> reader iters: used to keep track of the open iterators on a
 	// reader. The iter set value will also be indexed by either the batches or
 	// snapshots maps. This map is the union of batches and snapshots maps.
@@ -103,10 +107,12 @@ func newGenerator(rng *rand.Rand, cfg config, km *keyManager) *generator {
 	g := &generator{
 		cfg:                   cfg,
 		rng:                   rng,
-		init:                  &initOp{},
+		init:                  &initOp{dbSlots: uint32(cfg.numInstances)},
 		keyManager:            km,
-		liveReaders:           objIDSlice{makeObjID(dbTag, 0)},
-		liveWriters:           objIDSlice{makeObjID(dbTag, 0)},
+		liveReaders:           objIDSlice{makeObjID(dbTag, 1)},
+		liveWriters:           objIDSlice{makeObjID(dbTag, 1)},
+		dbs:                   objIDSlice{makeObjID(dbTag, 1)},
+		objDB:                 make(map[objID]objID),
 		batches:               make(map[objID]objIDSet),
 		iters:                 make(map[objID]objIDSet),
 		readers:               make(map[objID]objIDSet),
@@ -115,6 +121,11 @@ func newGenerator(rng *rand.Rand, cfg config, km *keyManager) *generator {
 		itersLastOpts:         make(map[objID]iterOpts),
 		iterCreationTimestamp: make(map[objID]int),
 		iterReaderID:          make(map[objID]objID),
+	}
+	for i := 1; i < cfg.numInstances; i++ {
+		g.liveReaders = append(g.liveReaders, makeObjID(dbTag, uint32(i+1)))
+		g.liveWriters = append(g.liveWriters, makeObjID(dbTag, uint32(i+1)))
+		g.dbs = append(g.dbs, makeObjID(dbTag, uint32(i+1)))
 	}
 	// Note that the initOp fields are populated during generation.
 	g.ops = append(g.ops, g.init)
@@ -153,6 +164,7 @@ func generate(rng *rand.Rand, count uint64, cfg config, km *keyManager) []op {
 		newIterUsingClone:           g.newIterUsingClone,
 		newSnapshot:                 g.newSnapshot,
 		readerGet:                   g.readerGet,
+		replicate:                   g.replicate,
 		snapshotClose:               g.snapshotClose,
 		writerApply:                 g.writerApply,
 		writerDelete:                g.writerDelete,
@@ -435,8 +447,11 @@ func (g *generator) newBatch() {
 	g.init.batchSlots++
 	g.liveBatches = append(g.liveBatches, batchID)
 	g.liveWriters = append(g.liveWriters, batchID)
+	dbID := g.dbs.rand(g.rng)
+	g.objDB[batchID] = dbID
 
 	g.add(&newBatchOp{
+		dbID:    dbID,
 		batchID: batchID,
 	})
 }
@@ -451,8 +466,11 @@ func (g *generator) newIndexedBatch() {
 	iters := make(objIDSet)
 	g.batches[batchID] = iters
 	g.readers[batchID] = iters
+	dbID := g.dbs.rand(g.rng)
+	g.objDB[batchID] = dbID
 
 	g.add(&newIndexedBatchOp{
+		dbID:    dbID,
 		batchID: batchID,
 	})
 }
@@ -474,7 +492,7 @@ func (g *generator) removeBatchFromGenerator(batchID objID) {
 	for _, id := range iters.sorted() {
 		g.liveIters.remove(id)
 		delete(g.iters, id)
-		g.add(&closeOp{objID: id})
+		g.add(&closeOp{objID: id, derivedDBID: g.objDB[batchID]})
 	}
 }
 
@@ -486,7 +504,7 @@ func (g *generator) batchAbort() {
 	batchID := g.liveBatches.rand(g.rng)
 	g.removeBatchFromGenerator(batchID)
 
-	g.add(&closeOp{objID: batchID})
+	g.add(&closeOp{objID: batchID, derivedDBID: g.objDB[batchID]})
 }
 
 func (g *generator) batchCommit() {
@@ -495,11 +513,13 @@ func (g *generator) batchCommit() {
 	}
 
 	batchID := g.liveBatches.rand(g.rng)
+	dbID := g.objDB[batchID]
 	g.removeBatchFromGenerator(batchID)
 	g.add(&batchCommitOp{
+		dbID:    dbID,
 		batchID: batchID,
 	})
-	g.add(&closeOp{objID: batchID})
+	g.add(&closeOp{objID: batchID, derivedDBID: dbID})
 
 }
 
@@ -514,10 +534,15 @@ func (g *generator) dbClose() {
 	}
 	for len(g.liveBatches) > 0 {
 		batchID := g.liveBatches[0]
+		dbID := g.objDB[batchID]
 		g.removeBatchFromGenerator(batchID)
-		g.add(&closeOp{objID: batchID})
+		g.add(&closeOp{objID: batchID, derivedDBID: dbID})
 	}
-	g.add(&closeOp{objID: makeObjID(dbTag, 0)})
+	for len(g.dbs) > 0 {
+		db := g.dbs[0]
+		g.dbs = g.dbs[1:]
+		g.add(&closeOp{objID: db})
+	}
 }
 
 func (g *generator) dbCheckpoint() {
@@ -553,7 +578,9 @@ func (g *generator) dbCompact() {
 	if g.cmp(start, end) > 0 {
 		start, end = end, start
 	}
+	dbID := g.dbs.rand(g.rng)
 	g.add(&compactOp{
+		dbID:        dbID,
 		start:       start,
 		end:         end,
 		parallelize: g.rng.Float64() < 0.5,
@@ -561,7 +588,7 @@ func (g *generator) dbCompact() {
 }
 
 func (g *generator) dbFlush() {
-	g.add(&flushOp{})
+	g.add(&flushOp{dbObjID})
 }
 
 func (g *generator) dbRatchetFormatMajorVersion() {
@@ -570,14 +597,16 @@ func (g *generator) dbRatchetFormatMajorVersion() {
 	// version may be behind the database's format major version, in which case
 	// RatchetFormatMajorVersion should deterministically error.
 
+	dbID := g.dbs.rand(g.rng)
 	n := int(newestFormatMajorVersionToTest - minimumFormatMajorVersion)
 	vers := pebble.FormatMajorVersion(g.rng.Intn(n+1)) + minimumFormatMajorVersion
-	g.add(&dbRatchetFormatMajorVersionOp{vers: vers})
+	g.add(&dbRatchetFormatMajorVersionOp{dbID: dbID, vers: vers})
 }
 
 func (g *generator) dbRestart() {
 	// Close any live iterators and snapshots, so that we can close the DB
 	// cleanly.
+	dbID := g.dbs.rand(g.rng)
 	for len(g.liveIters) > 0 {
 		g.randIter(g.iterClose)()
 	}
@@ -587,14 +616,15 @@ func (g *generator) dbRestart() {
 	// Close the batches.
 	for len(g.liveBatches) > 0 {
 		batchID := g.liveBatches[0]
+		dbID := g.objDB[batchID]
 		g.removeBatchFromGenerator(batchID)
-		g.add(&closeOp{objID: batchID})
+		g.add(&closeOp{objID: batchID, derivedDBID: dbID})
 	}
-	if len(g.liveReaders) != 1 || len(g.liveWriters) != 1 {
+	if len(g.liveReaders) != len(g.dbs) || len(g.liveWriters) != len(g.dbs) {
 		panic(fmt.Sprintf("unexpected counts: liveReaders %d, liveWriters: %d",
 			len(g.liveReaders), len(g.liveWriters)))
 	}
-	g.add(&dbRestartOp{})
+	g.add(&dbRestartOp{dbID: dbID})
 }
 
 // maybeSetSnapshotIterBounds must be called whenever creating a new iterator or
@@ -654,6 +684,7 @@ func (g *generator) newIter() {
 		// closes.
 	}
 	g.iterReaderID[iterID] = readerID
+	g.deriveDB(iterID, readerID)
 
 	var opts iterOpts
 	if !g.maybeSetSnapshotIterBounds(readerID, &opts) {
@@ -694,10 +725,16 @@ func (g *generator) newIter() {
 	g.itersLastOpts[iterID] = opts
 	g.iterCreationTimestamp[iterID] = g.keyManager.nextMetaTimestamp()
 	g.iterReaderID[iterID] = readerID
+	var derivedDBID objID
+	if readerID.tag() == batchTag {
+		g.deriveDB(iterID, readerID)
+		derivedDBID = g.objDB[iterID]
+	}
 	g.add(&newIterOp{
-		readerID: readerID,
-		iterID:   iterID,
-		iterOpts: opts,
+		readerID:    readerID,
+		iterID:      iterID,
+		iterOpts:    opts,
+		derivedDBID: derivedDBID,
 	})
 }
 
@@ -719,6 +756,14 @@ func (g *generator) randKeyTypesAndMask() (keyTypes uint32, maskSuffix []byte) {
 	return keyTypes, maskSuffix
 }
 
+func (g *generator) deriveDB(readerID, parentID objID) {
+	dbParentID := parentID
+	if dbParentID.tag() != dbTag {
+		dbParentID = g.objDB[dbParentID]
+	}
+	g.objDB[readerID] = dbParentID
+}
+
 func (g *generator) newIterUsingClone() {
 	if len(g.liveIters) == 0 {
 		return
@@ -737,6 +782,7 @@ func (g *generator) newIterUsingClone() {
 	}
 	readerID := g.iterReaderID[existingIterID]
 	g.iterReaderID[iterID] = readerID
+	g.deriveDB(iterID, readerID)
 
 	var refreshBatch bool
 	if readerID.tag() == batchTag {
@@ -773,7 +819,7 @@ func (g *generator) iterClose(iterID objID) {
 		// closes.
 	}
 
-	g.add(&closeOp{objID: iterID})
+	g.add(&closeOp{objID: iterID, derivedDBID: g.objDB[iterID]})
 }
 
 func (g *generator) iterSetBounds(iterID objID) {
@@ -1101,7 +1147,44 @@ func (g *generator) readerGet() {
 	} else {
 		key = g.randKeyToRead(0.001) // 0.1% new keys
 	}
-	g.add(&getOp{readerID: readerID, key: key})
+	derivedDBID := objID(0)
+	if dbID, ok := g.objDB[readerID]; ok && readerID.tag() == batchTag {
+		derivedDBID = dbID
+	} else if readerID.tag() == snapTag {
+		// TODO(bilal): This is legacy behaviour as snapshots aren't supported in
+		// two-instance mode yet. Track snapshots in g.objDB and objToDB and remove this
+		// conditional.
+		derivedDBID = dbObjID
+	}
+	g.add(&getOp{readerID: readerID, key: key, derivedDBID: derivedDBID})
+}
+
+func (g *generator) replicate() {
+	if len(g.dbs) < 2 {
+		return
+	}
+
+	source := g.dbs.rand(g.rng)
+	dest := source
+	for dest == source {
+		dest = g.dbs.rand(g.rng)
+	}
+
+	var startKey, endKey []byte
+	startKey = g.randKeyToRead(0.001) // 0.1% new keys
+	endKey = g.randKeyToRead(0.001)   // 0.1% new keys
+	for g.cmp(startKey, endKey) == 0 {
+		endKey = g.randKeyToRead(0.01) // 1% new keys
+	}
+	if g.cmp(startKey, endKey) > 0 {
+		startKey, endKey = endKey, startKey
+	}
+	g.add(&replicateOp{
+		source: source,
+		dest:   dest,
+		start:  startKey,
+		end:    endKey,
+	})
 }
 
 // generateDisjointKeyRanges generates n disjoint key ranges.
@@ -1171,7 +1254,7 @@ func (g *generator) snapshotClose() {
 	for _, id := range iters.sorted() {
 		g.liveIters.remove(id)
 		delete(g.iters, id)
-		g.add(&closeOp{objID: id})
+		g.add(&closeOp{objID: id, derivedDBID: g.objDB[id]})
 	}
 
 	g.add(&closeOp{objID: snapID})
@@ -1186,11 +1269,19 @@ func (g *generator) writerApply() {
 	}
 
 	batchID := g.liveBatches.rand(g.rng)
+	dbID := g.objDB[batchID]
 
 	var writerID objID
 	for {
+		// NB: The writer we're applying to, as well as the batch we're applying,
+		// must be from the same DB. The writer could be the db itself. Applying
+		// a batch from one DB on another DB results in a panic, so avoid that.
 		writerID = g.liveWriters.rand(g.rng)
-		if writerID != batchID {
+		writerDBID := writerID
+		if writerID.tag() != dbTag {
+			writerDBID = g.objDB[writerID]
+		}
+		if writerID != batchID && writerDBID == dbID {
 			break
 		}
 	}
@@ -1202,7 +1293,8 @@ func (g *generator) writerApply() {
 		batchID:  batchID,
 	})
 	g.add(&closeOp{
-		batchID,
+		objID:       batchID,
+		derivedDBID: dbID,
 	})
 }
 
@@ -1212,9 +1304,14 @@ func (g *generator) writerDelete() {
 	}
 
 	writerID := g.liveWriters.rand(g.rng)
+	derivedDBID := writerID
+	if derivedDBID.tag() != dbTag {
+		derivedDBID = g.objDB[writerID]
+	}
 	g.add(&deleteOp{
-		writerID: writerID,
-		key:      g.randKeyToWrite(0.001), // 0.1% new keys
+		writerID:    writerID,
+		key:         g.randKeyToWrite(0.001), // 0.1% new keys
+		derivedDBID: derivedDBID,
 	})
 }
 
@@ -1309,6 +1406,7 @@ func (g *generator) writerIngest() {
 	// we can tolerate failure or not, and if the ingestOp encounters a
 	// failure, it would retry after splitting into single batch ingests.
 
+	dbID := g.dbs.rand(g.rng)
 	// Ingest between 1 and 3 batches.
 	batchIDs := make([]objID, 0, 1+g.rng.Intn(3))
 	canFail := cap(batchIDs) > 1
@@ -1332,8 +1430,14 @@ func (g *generator) writerIngest() {
 		g.removeBatchFromGenerator(batchID)
 		batchIDs = append(batchIDs, batchID)
 	}
+	derivedDBIDs := make([]objID, len(batchIDs))
+	for i := range batchIDs {
+		derivedDBIDs[i] = g.objDB[batchIDs[i]]
+	}
 	g.add(&ingestOp{
-		batchIDs: batchIDs,
+		dbID:         dbID,
+		batchIDs:     batchIDs,
+		derivedDBIDs: derivedDBIDs,
 	})
 }
 

--- a/metamorphic/generator_test.go
+++ b/metamorphic/generator_test.go
@@ -5,6 +5,7 @@
 package metamorphic
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -128,29 +129,42 @@ func TestGenerator(t *testing.T) {
 func TestGeneratorRandom(t *testing.T) {
 	seed := uint64(time.Now().UnixNano())
 	ops := randvar.NewUniform(1000, 10000)
-	generateFromSeed := func() string {
+	cfgs := []string{"default", "multiInstance"}
+	generateFromSeed := func(cfg config) string {
 		rng := rand.New(rand.NewSource(seed))
 		count := ops.Uint64(rng)
-		return formatOps(generate(rng, count, defaultConfig(), newKeyManager()))
+		return formatOps(generate(rng, count, cfg, newKeyManager()))
 	}
 
-	// Ensure that generate doesn't use any other source of randomness other
-	// than rng.
-	referenceOps := generateFromSeed()
-	for i := 0; i < 10; i++ {
-		regeneratedOps := generateFromSeed()
-		diff, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
-			A:       difflib.SplitLines(referenceOps),
-			B:       difflib.SplitLines(regeneratedOps),
-			Context: 1,
+	for i := range cfgs {
+		t.Run(fmt.Sprintf("config=%s", cfgs[i]), func(t *testing.T) {
+			cfg := defaultConfig
+			if cfgs[i] == "multiInstance" {
+				cfg = func() config {
+					cfg := multiInstanceConfig()
+					cfg.numInstances = 2
+					return cfg
+				}
+			}
+			// Ensure that generate doesn't use any other source of randomness other
+			// than rng.
+			referenceOps := generateFromSeed(cfg())
+			for i := 0; i < 10; i++ {
+				regeneratedOps := generateFromSeed(cfg())
+				diff, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+					A:       difflib.SplitLines(referenceOps),
+					B:       difflib.SplitLines(regeneratedOps),
+					Context: 1,
+				})
+				require.NoError(t, err)
+				if len(diff) > 0 {
+					t.Fatalf("Diff:\n%s", diff)
+				}
+			}
+			if testing.Verbose() {
+				t.Logf("\nOps:\n%s", referenceOps)
+			}
 		})
-		require.NoError(t, err)
-		if len(diff) > 0 {
-			t.Fatalf("Diff:\n%s", diff)
-		}
-	}
-	if testing.Verbose() {
-		t.Logf("\nOps:\n%s", referenceOps)
 	}
 }
 

--- a/metamorphic/key_manager.go
+++ b/metamorphic/key_manager.go
@@ -206,7 +206,7 @@ func (k *keyManager) nextMetaTimestamp() int {
 	return ret
 }
 
-var dbObjID objID = makeObjID(dbTag, 0)
+var dbObjID objID = makeObjID(dbTag, 1)
 
 // newKeyManager returns a pointer to a new keyManager. Callers should
 // interact with this using addNewKey, eligible*Keys, update,
@@ -549,6 +549,8 @@ func opWrittenKeys(untypedOp op) [][]byte {
 		return [][]byte{t.key}
 	case *singleDeleteOp:
 		return [][]byte{t.key}
+	case *replicateOp:
+		return [][]byte{t.start, t.end}
 	}
 	return nil
 }

--- a/metamorphic/key_manager_test.go
+++ b/metamorphic/key_manager_test.go
@@ -14,8 +14,8 @@ func TestObjKey(t *testing.T) {
 		want string
 	}{
 		{
-			key:  makeObjKey(makeObjID(dbTag, 0), []byte("foo")),
-			want: "db:foo",
+			key:  makeObjKey(makeObjID(dbTag, 1), []byte("foo")),
+			want: "db1:foo",
 		},
 		{
 			key:  makeObjKey(makeObjID(batchTag, 1), []byte("bar")),
@@ -31,7 +31,7 @@ func TestObjKey(t *testing.T) {
 }
 
 func TestGlobalStateIndicatesEligibleForSingleDelete(t *testing.T) {
-	key := makeObjKey(makeObjID(dbTag, 0), []byte("foo"))
+	key := makeObjKey(makeObjID(dbTag, 1), []byte("foo"))
 	testCases := []struct {
 		meta keyMeta
 		want bool
@@ -221,7 +221,7 @@ func TestKeyManager_GetOrInit(t *testing.T) {
 	m := newKeyManager()
 	require.NotContains(t, m.byObjKey, o.String())
 	require.NotContains(t, m.byObj, id)
-	require.Contains(t, m.byObj, makeObjID(dbTag, 0)) // Always contains the DB key.
+	require.Contains(t, m.byObj, makeObjID(dbTag, 1)) // Always contains the DB key.
 
 	meta1 := m.getOrInit(id, key)
 	require.Contains(t, m.byObjKey, o.String())
@@ -233,7 +233,7 @@ func TestKeyManager_GetOrInit(t *testing.T) {
 }
 
 func TestKeyManager_Contains(t *testing.T) {
-	id := makeObjID(dbTag, 0)
+	id := makeObjID(dbTag, 1)
 	key := []byte("foo")
 
 	m := newKeyManager()
@@ -245,7 +245,7 @@ func TestKeyManager_Contains(t *testing.T) {
 
 func TestKeyManager_MergeInto(t *testing.T) {
 	fromID := makeObjID(batchTag, 1)
-	toID := makeObjID(dbTag, 0)
+	toID := makeObjID(dbTag, 1)
 
 	m := newKeyManager()
 

--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -42,6 +43,7 @@ type runAndCompareOptions struct {
 	innerBinary       string
 	mutateTestOptions []func(*TestOptions)
 	customRuns        map[string]string
+	numInstances      int
 	runOnceOptions
 }
 
@@ -177,6 +179,13 @@ func RunAndCompare(t *testing.T, rootDir string, rOpts ...RunOption) {
 		require.NoError(t, err)
 		loadPrecedingKeys(t, ops, &cfg, km)
 	}
+	if runOpts.numInstances > 1 {
+		// The multi-instance variant does not support all operations yet.
+		//
+		// TODO(bilal): Address this and use the default configs.
+		cfg = multiInstancePresetConfig
+		cfg.numInstances = runOpts.numInstances
+	}
 	ops := generate(rng, opCount, cfg, km)
 	opsPath := filepath.Join(metaDir, "ops")
 	formattedOps := formatOps(ops)
@@ -203,6 +212,9 @@ func RunAndCompare(t *testing.T, rootDir string, rOpts ...RunOption) {
 			"-keep=" + fmt.Sprint(runOpts.keep),
 			"-run-dir=" + runDir,
 			"-test.run=" + t.Name() + "$",
+		}
+		if runOpts.numInstances > 1 {
+			args = append(args, "--num-instances="+strconv.Itoa(runOpts.numInstances))
 		}
 		if runOpts.traceFile != "" {
 			args = append(args, "-test.trace="+filepath.Join(runDir, runOpts.traceFile))
@@ -343,6 +355,7 @@ type runOnceOptions struct {
 	maxThreads          int
 	errorRate           float64
 	failRegexp          *regexp.Regexp
+	numInstances        int
 	customOptionParsers map[string]func(string) (CustomOption, bool)
 }
 
@@ -382,6 +395,12 @@ type FailOnMatch struct {
 
 func (f FailOnMatch) apply(ro *runAndCompareOptions) { ro.failRegexp = f.Regexp }
 func (f FailOnMatch) applyOnce(ro *runOnceOptions)   { ro.failRegexp = f.Regexp }
+
+// MultiInstance configures the number of pebble instances to create.
+type MultiInstance int
+
+func (m MultiInstance) apply(ro *runAndCompareOptions) { ro.numInstances = int(m) }
+func (m MultiInstance) applyOnce(ro *runOnceOptions)   { ro.numInstances = int(m) }
 
 // RunOnce performs one run of the metamorphic tests. RunOnce expects the
 // directory named by `runDir` to already exist and contain an `OPTIONS` file
@@ -458,7 +477,13 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 	))
 
 	if opts.WALDir != "" {
-		opts.WALDir = opts.FS.PathJoin(runDir, opts.WALDir)
+		if runOpts.numInstances > 1 {
+			// TODO(bilal): Allow opts to diverge on a per-instance basis, and use
+			// that to set unique WAL dirs for all instances in multi-instance mode.
+			opts.WALDir = ""
+		} else {
+			opts.WALDir = opts.FS.PathJoin(runDir, opts.WALDir)
+		}
 	}
 
 	historyFile, err := os.Create(historyPath)
@@ -472,7 +497,7 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 	h := newHistory(runOpts.failRegexp, writers...)
 
 	m := newTest(ops)
-	require.NoError(t, m.init(h, dir, testOpts))
+	require.NoError(t, m.init(h, dir, testOpts, runOpts.numInstances))
 
 	if threads <= 1 {
 		for m.step(h) {

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -254,6 +254,8 @@ type TestOptions struct {
 	asyncApplyToDB bool
 	// Enable the use of shared storage.
 	sharedStorageEnabled bool
+	// Enables the use of shared replication in TestOptions.
+	useSharedReplicate bool
 	// Enable the secondary cache. Only effective if sharedStorageEnabled is
 	// also true.
 	secondaryCacheEnabled bool
@@ -547,8 +549,9 @@ func randomOptions(
 	// 20% of time, enable shared storage.
 	if rng.Intn(5) == 0 {
 		testOpts.sharedStorageEnabled = true
+		inMemShared := remote.NewInMem()
 		testOpts.Opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-			"": remote.NewInMem(),
+			"": inMemShared,
 		})
 		// If shared storage is enabled, pick between writing all files on shared
 		// vs. lower levels only, 50% of the time.
@@ -562,6 +565,8 @@ func randomOptions(
 			// TODO(josh): Randomize various secondary cache settings.
 			testOpts.Opts.Experimental.SecondaryCacheSizeBytes = 1024 * 1024 * 32 // 32 MBs
 		}
+		// 50% of the time, enable shared replication.
+		testOpts.useSharedReplicate = rng.Intn(2) == 0
 	}
 	testOpts.seedEFOS = rng.Uint64()
 	testOpts.ingestSplit = rng.Intn(2) == 0

--- a/metamorphic/parser_test.go
+++ b/metamorphic/parser_test.go
@@ -29,20 +29,30 @@ func TestParser(t *testing.T) {
 }
 
 func TestParserRandom(t *testing.T) {
-	ops := generate(randvar.NewRand(), 10000, defaultConfig(), newKeyManager())
-	src := formatOps(ops)
+	cfgs := []string{"default", "multiInstance"}
+	for i := range cfgs {
+		t.Run(fmt.Sprintf("config=%s", cfgs[i]), func(t *testing.T) {
+			cfg := defaultConfig()
+			if cfgs[i] == "multiInstance" {
+				cfg = multiInstanceConfig()
+				cfg.numInstances = 2
+			}
+			ops := generate(randvar.NewRand(), 10000, cfg, newKeyManager())
+			src := formatOps(ops)
 
-	parsedOps, err := parse([]byte(src))
-	if err != nil {
-		t.Fatalf("%s\n%s", err, src)
+			parsedOps, err := parse([]byte(src))
+			if err != nil {
+				t.Fatalf("%s\n%s", err, src)
+			}
+			require.Equal(t, ops, parsedOps)
+		})
 	}
-	require.Equal(t, ops, parsedOps)
 }
 
 func TestParserNilBounds(t *testing.T) {
 	formatted := formatOps([]op{
 		&newIterOp{
-			readerID: makeObjID(dbTag, 0),
+			readerID: makeObjID(dbTag, 1),
 			iterID:   makeObjID(iterTag, 1),
 			iterOpts: iterOpts{},
 		},

--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"sort"
 	"strings"
 
@@ -24,8 +25,11 @@ type test struct {
 	opsWaitOn [][]int         // op index -> op indexes
 	opsDone   []chan struct{} // op index -> done channel
 	idx       int
-	// The DB the test is run on.
 	dir       string
+	// The DB the test is run on.
+	//
+	// TODO(bilal): The DB field is deprecated in favour of the dbs slice. Update
+	// all remaining uses of t.db to use t.dbs[] instead.
 	db        *pebble.DB
 	opts      *pebble.Options
 	testOpts  *TestOptions
@@ -33,6 +37,7 @@ type test struct {
 	tmpDir    string
 	// The slots for the batches, iterators, and snapshots. These are read and
 	// written by the ops to pass state from one op to another.
+	dbs       []*pebble.DB
 	batches   []*pebble.Batch
 	iters     []*retryableIter
 	snapshots []readerCloser
@@ -44,7 +49,7 @@ func newTest(ops []op) *test {
 	}
 }
 
-func (t *test) init(h *history, dir string, testOpts *TestOptions) error {
+func (t *test) init(h *history, dir string, testOpts *TestOptions, numInstances int) error {
 	t.dir = dir
 	t.testOpts = testOpts
 	t.writeOpts = pebble.NoSync
@@ -61,6 +66,9 @@ func (t *test) init(h *history, dir string, testOpts *TestOptions) error {
 		return withRetries(func() error {
 			return pebble.DebugCheckLevels(db)
 		})
+	}
+	if numInstances < 1 {
+		numInstances = 1
 	}
 
 	t.opsWaitOn, t.opsDone = computeSynchronizationPoints(t.ops)
@@ -127,28 +135,36 @@ func (t *test) init(h *history, dir string, testOpts *TestOptions) error {
 		}
 	}
 
-	var db *pebble.DB
-	var err error
-	err = withRetries(func() error {
-		db, err = pebble.Open(dir, t.opts)
-		return err
-	})
-	if err != nil {
-		return err
-	}
-	h.log.Printf("// db.Open() %v", err)
-
-	if t.testOpts.sharedStorageEnabled {
+	t.dbs = make([]*pebble.DB, numInstances)
+	for i := range t.dbs {
+		var db *pebble.DB
+		var err error
+		if len(t.dbs) > 1 {
+			dir = path.Join(t.dir, fmt.Sprintf("db%d", i+1))
+		}
 		err = withRetries(func() error {
-			return db.SetCreatorID(1)
+			db, err = pebble.Open(dir, t.opts)
+			return err
 		})
 		if err != nil {
 			return err
 		}
-		h.log.Printf("// db.SetCreatorID() %v", err)
+		t.dbs[i] = db
+		h.log.Printf("// db%d.Open() %v", i+1, err)
+
+		if t.testOpts.sharedStorageEnabled {
+			err = withRetries(func() error {
+				return db.SetCreatorID(uint64(i + 1))
+			})
+			if err != nil {
+				return err
+			}
+			h.log.Printf("// db%d.SetCreatorID() %v", i+1, err)
+		}
 	}
 
-	t.tmpDir = t.opts.FS.PathJoin(dir, "tmp")
+	var err error
+	t.tmpDir = t.opts.FS.PathJoin(t.dir, "tmp")
 	if err = t.opts.FS.MkdirAll(t.tmpDir, 0755); err != nil {
 		return err
 	}
@@ -180,15 +196,17 @@ func (t *test) init(h *history, dir string, testOpts *TestOptions) error {
 		}
 	}
 
-	t.db = db
+	t.db = t.dbs[0]
 	return nil
 }
 
-func (t *test) isFMV(fmv pebble.FormatMajorVersion) bool {
-	return t.db.FormatMajorVersion() >= fmv
+func (t *test) isFMV(dbID objID, fmv pebble.FormatMajorVersion) bool {
+	db := t.getDB(dbID)
+	return db.FormatMajorVersion() >= fmv
 }
 
-func (t *test) restartDB() error {
+func (t *test) restartDB(dbID objID) error {
+	db := t.getDB(dbID)
 	if !t.testOpts.strictFS {
 		return nil
 	}
@@ -198,7 +216,7 @@ func (t *test) restartDB() error {
 	if ok {
 		fs.SetIgnoreSyncs(true)
 	}
-	if err := t.db.Close(); err != nil {
+	if err := db.Close(); err != nil {
 		return err
 	}
 	// Release any resources held by custom options. This may be used, for
@@ -225,7 +243,15 @@ func (t *test) restartDB() error {
 				return err
 			}
 		}
-		t.db, err = pebble.Open(t.dir, t.opts)
+		dir := t.dir
+		if len(t.dbs) > 1 {
+			dir = path.Join(dir, fmt.Sprintf("db%d", dbID.slot()))
+		}
+		t.dbs[dbID.slot()-1], err = pebble.Open(dir, t.opts)
+		if err != nil {
+			return err
+		}
+		t.db = t.dbs[0]
 		return err
 	})
 	t.opts.Cache.Unref()
@@ -285,7 +311,7 @@ func (t *test) setSnapshot(id objID, s readerCloser) {
 func (t *test) clearObj(id objID) {
 	switch id.tag() {
 	case dbTag:
-		t.db = nil
+		t.dbs[id.slot()-1] = nil
 	case batchTag:
 		t.batches[id.slot()] = nil
 	case iterTag:
@@ -305,7 +331,7 @@ func (t *test) getBatch(id objID) *pebble.Batch {
 func (t *test) getCloser(id objID) io.Closer {
 	switch id.tag() {
 	case dbTag:
-		return t.db
+		return t.dbs[id.slot()-1]
 	case batchTag:
 		return t.batches[id.slot()]
 	case iterTag:
@@ -326,7 +352,7 @@ func (t *test) getIter(id objID) *retryableIter {
 func (t *test) getReader(id objID) pebble.Reader {
 	switch id.tag() {
 	case dbTag:
-		return t.db
+		return t.dbs[id.slot()-1]
 	case batchTag:
 		return t.batches[id.slot()]
 	case snapTag:
@@ -338,11 +364,20 @@ func (t *test) getReader(id objID) pebble.Reader {
 func (t *test) getWriter(id objID) pebble.Writer {
 	switch id.tag() {
 	case dbTag:
-		return t.db
+		return t.dbs[id.slot()-1]
 	case batchTag:
 		return t.batches[id.slot()]
 	}
 	panic(fmt.Sprintf("invalid writer ID: %s", id))
+}
+
+func (t *test) getDB(id objID) *pebble.DB {
+	switch id.tag() {
+	case dbTag:
+		return t.dbs[id.slot()-1]
+	default:
+		panic(fmt.Sprintf("invalid writer tag: %v", id.tag()))
+	}
 }
 
 // Compute the synchronization points between operations. When operating
@@ -369,10 +404,14 @@ func computeSynchronizationPoints(ops []op) (opsWaitOn [][]int, opsDone []chan s
 			// Only valid for i=0. For all other operations, the receiver should
 			// have been referenced by some other operation before it's used as
 			// a receiver.
-			if i != 0 {
-				panic(fmt.Sprintf("op %d on receiver %s; first reference of %s", i, receiver, receiver))
+			if i != 0 && receiver.tag() != dbTag {
+				panic(fmt.Sprintf("op %s on receiver %s; first reference of %s", ops[i].String(), receiver, receiver))
 			}
-			continue
+			// The initOp is a little special. We do want to store the objects it's
+			// syncing on, in `lastOpReference`.
+			if i != 0 {
+				continue
+			}
 		}
 
 		// The last operation that referenced `receiver` is the one at index

--- a/metamorphic/testdata/parser
+++ b/metamorphic/testdata/parser
@@ -11,7 +11,7 @@ parse
 parse
 db.bar()
 ----
-1:1: unknown op db.bar
+1:1: unknown op db1.bar
 
 parse
 db.Apply()
@@ -26,12 +26,12 @@ db.Apply(hello)
 parse
 db.NewBatch()
 ----
-1:1: assignment expected for db.NewBatch
+1:1: assignment expected for db1.NewBatch
 
 parse
 batch0 = db.Apply()
 ----
-1:10: cannot use db.Apply in assignment
+1:10: cannot use db1.Apply in assignment
 
 parse
 batch0 = db.NewBatch()

--- a/metamorphic/utils.go
+++ b/metamorphic/utils.go
@@ -41,7 +41,7 @@ func (i objID) slot() uint32 {
 func (i objID) String() string {
 	switch i.tag() {
 	case dbTag:
-		return "db"
+		return fmt.Sprintf("db%d", i.slot())
 	case batchTag:
 		return fmt.Sprintf("batch%d", i.slot())
 	case iterTag:


### PR DESCRIPTION
This change adds a two-instance metamorphic test as well as a new metamorphic test command, db.Replicate, that under some testOptions does a shared ingestion (i.e. ScanInternal with skip-shared iteration to only get keys above files in shared levels) along with an excise, and in other testOptions it does a normal ingestion with range deletes/rangekeydels to clear out the "replicated" range

Fixes #2711.