### PR TITLE
db: use DiskFileName for manifest files and memtables

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -298,7 +298,7 @@ func (d *DB) Checkpoint(
 	}
 
 	ckErr = d.writeCheckpointManifest(
-		fs, formatVers, destDir, dir, manifestFileNum.DiskFileNum(), manifestSize,
+		fs, formatVers, destDir, dir, manifestFileNum, manifestSize,
 		excludedFiles, removeBackingTables,
 	)
 	if ckErr != nil {
@@ -313,7 +313,7 @@ func (d *DB) Checkpoint(
 		if logNum == 0 {
 			continue
 		}
-		srcPath := base.MakeFilepath(fs, d.walDirname, fileTypeLog, logNum.DiskFileNum())
+		srcPath := base.MakeFilepath(fs, d.walDirname, fileTypeLog, logNum)
 		destPath := fs.PathJoin(destDir, fs.PathBase(srcPath))
 		ckErr = vfs.Copy(fs, srcPath, destPath)
 		if ckErr != nil {
@@ -368,7 +368,7 @@ func (d *DB) writeCheckpointManifest(
 		// need to append another record with the excluded files (we cannot simply
 		// append a record after a raw data copy; see
 		// https://github.com/cockroachdb/cockroach/issues/100935).
-		r := record.NewReader(&io.LimitedReader{R: src, N: manifestSize}, manifestFileNum.FileNum())
+		r := record.NewReader(&io.LimitedReader{R: src, N: manifestSize}, manifestFileNum)
 		w := record.NewWriter(dst)
 		for {
 			rr, err := r.Next()
@@ -421,7 +421,7 @@ func (d *DB) writeCheckpointManifest(
 	if err != nil {
 		return err
 	}
-	if err := setCurrentFunc(formatVers, manifestMarker, fs, destDirPath, destDir)(manifestFileNum.FileNum()); err != nil {
+	if err := setCurrentFunc(formatVers, manifestMarker, fs, destDirPath, destDir)(manifestFileNum); err != nil {
 		return err
 	}
 	return manifestMarker.Close()

--- a/compaction.go
+++ b/compaction.go
@@ -3670,7 +3670,7 @@ func (d *DB) scanObsoleteFiles(list []string) {
 		}
 		switch fileType {
 		case fileTypeLog:
-			if diskFileNum.FileNum() >= minUnflushedLogNum {
+			if diskFileNum >= minUnflushedLogNum {
 				continue
 			}
 			fi := fileInfo{fileNum: diskFileNum}
@@ -3679,7 +3679,7 @@ func (d *DB) scanObsoleteFiles(list []string) {
 			}
 			obsoleteLogs = append(obsoleteLogs, fi)
 		case fileTypeManifest:
-			if diskFileNum.FileNum() >= manifestFileNum {
+			if diskFileNum >= manifestFileNum {
 				continue
 			}
 			fi := fileInfo{fileNum: diskFileNum}
@@ -3785,7 +3785,7 @@ func (d *DB) deleteObsoleteFiles(jobID int) {
 		// log that has not had its contents flushed to an sstable. We can recycle
 		// the prefix of d.mu.log.queue with log numbers less than
 		// minUnflushedLogNum.
-		if d.mu.log.queue[i].fileNum.FileNum() >= d.mu.versions.minUnflushedLogNum {
+		if d.mu.log.queue[i].fileNum >= d.mu.versions.minUnflushedLogNum {
 			obsoleteLogs = d.mu.log.queue[:i]
 			d.mu.log.queue = d.mu.log.queue[i:]
 			d.mu.versions.metrics.WAL.Files -= int64(len(obsoleteLogs))

--- a/db_test.go
+++ b/db_test.go
@@ -943,7 +943,7 @@ func TestRollManifest(t *testing.T) {
 	d, err := Open("", opts)
 	require.NoError(t, err)
 
-	manifestFileNumber := func() FileNum {
+	manifestFileNumber := func() base.DiskFileNum {
 		d.mu.Lock()
 		defer d.mu.Unlock()
 		return d.mu.versions.manifestFileNum
@@ -961,7 +961,7 @@ func TestRollManifest(t *testing.T) {
 	}
 
 	lastManifestNum := manifestFileNumber()
-	manifestNums := []base.FileNum{lastManifestNum}
+	manifestNums := []base.DiskFileNum{lastManifestNum}
 	for i := 0; i < 5; i++ {
 		// MaxManifestFileSize is 1, but the rollover logic also counts edits
 		// since the last snapshot to decide on rollover, so do as many flushes as

--- a/event.go
+++ b/event.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/humanize"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/manifest"
@@ -247,7 +248,7 @@ type ManifestCreateInfo struct {
 	JobID int
 	Path  string
 	// The file number of the new Manifest.
-	FileNum FileNum
+	FileNum base.DiskFileNum
 	Err     error
 }
 
@@ -414,7 +415,7 @@ type WALCreateInfo struct {
 	JobID int
 	Path  string
 	// The file number of the new WAL.
-	FileNum FileNum
+	FileNum base.DiskFileNum
 	// The file number of a previous WAL which was recycled to create this
 	// one. Zero if recycling did not take place.
 	RecycledFileNum FileNum

--- a/flushable.go
+++ b/flushable.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 )
@@ -46,7 +47,7 @@ type flushableEntry struct {
 	delayedFlushForcedAt time.Time
 	// logNum corresponds to the WAL that contains the records present in the
 	// receiver.
-	logNum FileNum
+	logNum base.DiskFileNum
 	// logSize is the size in bytes of the associated WAL. Protected by DB.mu.
 	logSize uint64
 	// The current logSeqNum at the time the memtable was created. This is

--- a/flushable_test.go
+++ b/flushable_test.go
@@ -50,7 +50,7 @@ func TestIngestedSSTFlushableAPI(t *testing.T) {
 		d.mu.Lock()
 		pendingOutputs := make([]base.DiskFileNum, len(paths))
 		for i := range paths {
-			pendingOutputs[i] = d.mu.versions.getNextFileNum().DiskFileNum()
+			pendingOutputs[i] = d.mu.versions.getNextDiskFileNum()
 		}
 		jobID := d.mu.nextJobID
 		d.mu.nextJobID++

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -241,7 +241,7 @@ var formatMajorVersionMigrations = map[FormatMajorVersion]func(*DB) error{
 		// guaranteed to exist, because we unconditionally locate it
 		// during Open.
 		manifestFileNum := d.mu.versions.manifestFileNum
-		filename := base.MakeFilename(fileTypeManifest, manifestFileNum.DiskFileNum())
+		filename := base.MakeFilename(fileTypeManifest, manifestFileNum)
 		if err := d.mu.versions.manifestMarker.Move(filename); err != nil {
 			return errors.Wrap(err, "moving manifest marker")
 		}

--- a/ingest.go
+++ b/ingest.go
@@ -1160,7 +1160,7 @@ func (d *DB) IngestAndExcise(
 
 // Both DB.mu and commitPipeline.mu must be held while this is called.
 func (d *DB) newIngestedFlushableEntry(
-	meta []*fileMetadata, seqNum uint64, logNum FileNum,
+	meta []*fileMetadata, seqNum uint64, logNum base.DiskFileNum,
 ) (*flushableEntry, error) {
 	// Update the sequence number for all of the sstables in the
 	// metadata. Writing the metadata to the manifest when the
@@ -1287,7 +1287,7 @@ func (d *DB) ingest(
 	d.mu.Lock()
 	pendingOutputs := make([]base.DiskFileNum, len(paths)+len(shared)+len(external))
 	for i := 0; i < len(paths)+len(shared)+len(external); i++ {
-		pendingOutputs[i] = d.mu.versions.getNextFileNum().DiskFileNum()
+		pendingOutputs[i] = d.mu.versions.getNextDiskFileNum()
 	}
 
 	jobID := d.mu.nextJobID

--- a/internal/base/filenames_test.go
+++ b/internal/base/filenames_test.go
@@ -110,5 +110,5 @@ directory contains 10 files, 3 unknown, 1 tables, 1 logs, 1 manifests`, buf.buf.
 func TestRedactFileNum(t *testing.T) {
 	// Ensure that redaction never redacts file numbers.
 	require.Equal(t, redact.RedactableString("000005"), redact.Sprint(FileNum(5)))
-	require.Equal(t, redact.RedactableString("000005"), redact.Sprint(DiskFileNum{fn: 5}))
+	require.Equal(t, redact.RedactableString("000005"), redact.Sprint(DiskFileNum(5)))
 }

--- a/internal/manifest/testdata/version_edit_apply
+++ b/internal/manifest/testdata/version_edit_apply
@@ -125,7 +125,7 @@ edit
   000005:[h#3,SET-j#4,SET]
   000010:[j#3,SET-m#2,SET]
   000002:[n#5,SET-q#3,SET]
-zombies [{1} {4}]
+zombies [1 4]
 
 apply
 edit
@@ -153,7 +153,7 @@ edit
   L1
    2
 ----
-zombies [{1} {2}]
+zombies [1 2]
 
 # Deletion of a non-existent table results in an error.
 

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -94,7 +94,7 @@ type VersionEdit struct {
 	// mutations that have not been flushed to an sstable.
 	//
 	// This is an optional field, and 0 represents it is not set.
-	MinUnflushedLogNum base.FileNum
+	MinUnflushedLogNum base.DiskFileNum
 
 	// ObsoletePrevLogNum is a historic artifact from LevelDB that is not used by
 	// Pebble, RocksDB, or even LevelDB. Its use in LevelDB was deprecated in
@@ -104,7 +104,7 @@ type VersionEdit struct {
 
 	// The next file number. A single counter is used to assign file numbers
 	// for the WAL, MANIFEST, sstable, and OPTIONS files.
-	NextFileNum base.FileNum
+	NextFileNum uint64
 
 	// LastSeqNum is an upper bound on the sequence numbers that have been
 	// assigned in flushed WALs. Unflushed WALs (that will be replayed during
@@ -175,14 +175,14 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 			v.ComparerName = string(s)
 
 		case tagLogNumber:
-			n, err := d.readFileNum()
+			n, err := d.readUvarint()
 			if err != nil {
 				return err
 			}
-			v.MinUnflushedLogNum = n
+			v.MinUnflushedLogNum = base.DiskFileNum(n)
 
 		case tagNextFileNumber:
-			n, err := d.readFileNum()
+			n, err := d.readUvarint()
 			if err != nil {
 				return err
 			}

--- a/open.go
+++ b/open.go
@@ -268,7 +268,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 			return nil, errors.Wrapf(ErrDBAlreadyExists, "dirname=%q", dirname)
 		}
 		// Load the version set.
-		if err := d.mu.versions.load(dirname, opts, manifestFileNum.FileNum(), manifestMarker, setCurrent, d.FormatMajorVersion, &d.mu.Mutex); err != nil {
+		if err := d.mu.versions.load(dirname, opts, manifestFileNum, manifestMarker, setCurrent, d.FormatMajorVersion, &d.mu.Mutex); err != nil {
 			return nil, err
 		}
 		if opts.ErrorIfNotPristine {
@@ -336,7 +336,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 
 	// Replay any newer log files than the ones named in the manifest.
 	type fileNumAndName struct {
-		num  FileNum
+		num  base.DiskFileNum
 		name string
 	}
 	var logFiles []fileNumAndName
@@ -350,14 +350,14 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 
 		// Don't reuse any obsolete file numbers to avoid modifying an
 		// ingested sstable's original external file.
-		if d.mu.versions.nextFileNum <= fn.FileNum() {
-			d.mu.versions.nextFileNum = fn.FileNum() + 1
+		if d.mu.versions.nextFileNum <= uint64(fn.FileNum()) {
+			d.mu.versions.nextFileNum = uint64(fn.FileNum()) + 1
 		}
 
 		switch ft {
 		case fileTypeLog:
-			if fn.FileNum() >= d.mu.versions.minUnflushedLogNum {
-				logFiles = append(logFiles, fileNumAndName{fn.FileNum(), filename})
+			if fn >= d.mu.versions.minUnflushedLogNum {
+				logFiles = append(logFiles, fileNumAndName{fn, filename})
 			}
 			if d.logRecycler.minRecycleLogNum <= fn.FileNum() {
 				d.logRecycler.minRecycleLogNum = fn.FileNum() + 1
@@ -385,8 +385,8 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	// objProvider. This avoids FileNum collisions with obsolete sstables.
 	objects := d.objProvider.List()
 	for _, obj := range objects {
-		if d.mu.versions.nextFileNum <= obj.DiskFileNum.FileNum() {
-			d.mu.versions.nextFileNum = obj.DiskFileNum.FileNum() + 1
+		if d.mu.versions.nextFileNum <= uint64(obj.DiskFileNum) {
+			d.mu.versions.nextFileNum = uint64(obj.DiskFileNum) + 1
 		}
 	}
 
@@ -423,7 +423,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 
 	if !d.opts.ReadOnly {
 		// Create an empty .log file.
-		newLogNum := d.mu.versions.getNextFileNum()
+		newLogNum := d.mu.versions.getNextDiskFileNum()
 
 		// This logic is slightly different than RocksDB's. Specifically, RocksDB
 		// sets MinUnflushedLogNum to max-recovered-log-num + 1. We set it to the
@@ -445,8 +445,8 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 			entry.readerUnrefLocked(true)
 		}
 
-		newLogName := base.MakeFilepath(opts.FS, d.walDirname, fileTypeLog, newLogNum.DiskFileNum())
-		d.mu.log.queue = append(d.mu.log.queue, fileInfo{fileNum: newLogNum.DiskFileNum(), fileSize: 0})
+		newLogName := base.MakeFilepath(opts.FS, d.walDirname, fileTypeLog, newLogNum)
+		d.mu.log.queue = append(d.mu.log.queue, fileInfo{fileNum: newLogNum, fileSize: 0})
 		logFile, err := opts.FS.Create(newLogName)
 		if err != nil {
 			return nil, err
@@ -497,7 +497,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 
 	if !d.opts.ReadOnly {
 		// Write the current options to disk.
-		d.optionsFileNum = d.mu.versions.getNextFileNum().DiskFileNum()
+		d.optionsFileNum = d.mu.versions.getNextDiskFileNum()
 		tmpPath := base.MakeFilepath(opts.FS, dirname, fileTypeTemp, d.optionsFileNum)
 		optionsPath := base.MakeFilepath(opts.FS, dirname, fileTypeOptions, d.optionsFileNum)
 
@@ -690,7 +690,12 @@ func GetVersion(dir string, fs vfs.FS) (string, error) {
 // d.mu must be held when calling this, but the mutex may be dropped and
 // re-acquired during the course of this method.
 func (d *DB) replayWAL(
-	jobID int, ve *versionEdit, fs vfs.FS, filename string, logNum FileNum, strictWALTail bool,
+	jobID int,
+	ve *versionEdit,
+	fs vfs.FS,
+	filename string,
+	logNum base.DiskFileNum,
+	strictWALTail bool,
 ) (toFlush flushableList, maxSeqNum uint64, err error) {
 	file, err := fs.Open(filename)
 	if err != nil {

--- a/record/log_writer.go
+++ b/record/log_writer.go
@@ -323,7 +323,9 @@ var blockPool = sync.Pool{
 }
 
 // NewLogWriter returns a new LogWriter.
-func NewLogWriter(w io.Writer, logNum base.FileNum, logWriterConfig LogWriterConfig) *LogWriter {
+func NewLogWriter(
+	w io.Writer, logNum base.DiskFileNum, logWriterConfig LogWriterConfig,
+) *LogWriter {
 	c, _ := w.(io.Closer)
 	s, _ := w.(syncer)
 	r := &LogWriter{

--- a/record/record.go
+++ b/record/record.go
@@ -187,7 +187,7 @@ type Reader struct {
 // NewReader returns a new reader. If the file contains records encoded using
 // the recyclable record format, then the log number in those records must
 // match the specified logNum.
-func NewReader(r io.Reader, logNum base.FileNum) *Reader {
+func NewReader(r io.Reader, logNum base.DiskFileNum) *Reader {
 	return &Reader{
 		r:        r,
 		logNum:   uint32(logNum),

--- a/replay/workload_capture.go
+++ b/replay/workload_capture.go
@@ -198,7 +198,7 @@ func (w *WorkloadCollector) onManifestCreated(info pebble.ManifestCreateInfo) {
 
 	// mark the manifest file as ready for processing to prevent it from being
 	// cleaned before we process it.
-	fileName := base.MakeFilename(base.FileTypeManifest, info.FileNum.DiskFileNum())
+	fileName := base.MakeFilename(base.FileTypeManifest, info.FileNum)
 	w.mu.fileState[fileName] |= readyForProcessing
 	w.mu.manifests = append(w.mu.manifests, &manifestDetails{
 		sourceFilepath: info.Path,

--- a/replay/workload_capture_test.go
+++ b/replay/workload_capture_test.go
@@ -66,7 +66,7 @@ func TestWorkloadCollector(t *testing.T) {
 				var fileNum uint64
 				var err error
 				td.ScanArgs(t, "filenum", &fileNum)
-				path := base.MakeFilepath(fs, srcDir, base.FileTypeManifest, base.FileNum(fileNum).DiskFileNum())
+				path := base.MakeFilepath(fs, srcDir, base.FileTypeManifest, base.DiskFileNum(fileNum))
 				currentManifest, err = fs.Create(path)
 				require.NoError(t, err)
 				_, err = currentManifest.Write(randData(100))
@@ -74,7 +74,7 @@ func TestWorkloadCollector(t *testing.T) {
 
 				c.onManifestCreated(pebble.ManifestCreateInfo{
 					Path:    path,
-					FileNum: base.FileNum(fileNum),
+					FileNum: base.DiskFileNum(fileNum),
 				})
 				return ""
 			case "flush":

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -285,7 +285,7 @@ func TestVirtualReadsWiring(t *testing.T) {
 	l6 := currVersion.Levels[6]
 	l6FileIter := l6.Iter()
 	parentFile := l6FileIter.First()
-	f1 := d.mu.versions.nextFileNum
+	f1 := FileNum(d.mu.versions.nextFileNum)
 	f2 := f1 + 1
 	d.mu.versions.nextFileNum += 2
 

--- a/tool/wal.go
+++ b/tool/wal.go
@@ -93,7 +93,7 @@ func (w *walT) runDump(cmd *cobra.Command, args []string) {
 
 			var b pebble.Batch
 			var buf bytes.Buffer
-			rr := record.NewReader(f, fileNum.FileNum())
+			rr := record.NewReader(f, fileNum)
 			for {
 				offset := rr.Offset()
 				r, err := rr.Next()

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -73,7 +73,7 @@ func TestLatestRefCounting(t *testing.T) {
 
 	// Grab some new file nums.
 	d.mu.Lock()
-	f1 := d.mu.versions.nextFileNum
+	f1 := FileNum(d.mu.versions.nextFileNum)
 	f2 := f1 + 1
 	d.mu.versions.nextFileNum += 2
 	d.mu.Unlock()
@@ -260,7 +260,7 @@ func TestVirtualSSTableManifestReplay(t *testing.T) {
 
 	// Grab some new file nums.
 	d.mu.Lock()
-	f1 := d.mu.versions.nextFileNum
+	f1 := FileNum(d.mu.versions.nextFileNum)
 	f2 := f1 + 1
 	d.mu.versions.nextFileNum += 2
 	d.mu.Unlock()


### PR DESCRIPTION
These subsystems deal with on-disk files, using `DiskFileName` is more appropriate. This reduces the number of conversions in the code a lot. There are only a few `DiskFileName.FileName()` conversions left.

We change `DiskFileNum` to be a `uint64` like `FileNum`, so that `DiskFileNum`s can also be compared and printed as integers.