### PR TITLE
doc: minor updates to documentation

### DIFF
--- a/docs/io_profiling.md
+++ b/docs/io_profiling.md
@@ -179,7 +179,7 @@ The `blktrace` tool records similar info to `perf`, but is targeted to
 the block layer instead of being general purpose. The `blktrace`
 command records data, while the `blkparse` command parses and displays
 data. The `btrace` command is a shortcut for piping the output from
-`blktrace` directly into `blkparse.
+`blktrace` directly into `blkparse`.
 
 ### Installation
 

--- a/docs/js/write-throughput.js
+++ b/docs/js/write-throughput.js
@@ -1,4 +1,4 @@
-// TODO(travers): support multiple time-seriies on the summary chart, once we
+// TODO(travers): support multiple time-series on the summary chart, once we
 // have data available.
 const writeThroughputWorkload = "write/values=1024";
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -52,7 +52,7 @@ In order to support manual memory management for the Block Cache and
 MemTables, Pebble needs to precisely track their lifetime. This was
 already being done for the MemTable in order to account for its memory
 usage in metrics. It was mostly being done for the Block Cache. Values
-stores in the Block Cache are reference counted and are returned to
+stored in the Block Cache are reference counted and are returned to
 the "alloc cache" when their reference count falls
 to 0. Unfortunately, this tracking wasn't precise and there were
 numerous cases where the cache values were being leaked. This was

--- a/docs/range_deletions.md
+++ b/docs/range_deletions.md
@@ -2,7 +2,7 @@
 
 TODO: The following explanation of range deletions does not take into account
 the recent change to prohibit splitting of a user key between sstables. This
-change simplifies the logic, removing 'improperly truncated range tombstones.'
+change simplifies the logic, removing 'improperly truncated range tombstones'.
 
 TODO: The following explanation of range deletions ignores the
 kind/trailer that appears at the end of keys after the sequence
@@ -40,7 +40,7 @@ We will sometimes use ImmediatePredecessor and ImmediateSuccessor in
 the following for illustrating an idea, but we do not rely on them as
 something that is viable to produce for a particular kind of key. And
 even if viable, these functions are not currently provided to
-RockDB/Pebble.
+RocksDB/Pebble.
 
 ### Visualization
 
@@ -171,7 +171,7 @@ The range deletes written to these ssts are
 ```
 
 The Pebble code that achieves this effect is in
-`rangedel.Fragmenter`. It is a code structuring artifact that sst1
+`keyspan.Fragmenter`. It is a code structuring artifact that sst1
 does not contain a range delete equal to `["c", "f")#10` and sst4 does
 not contain `["f", "g")#10`. However for the range deletes in sst2 and
 sst3 we cannot do any better because we don't know what the key

--- a/internal/cache/entry_normal.go
+++ b/internal/cache/entry_normal.go
@@ -24,7 +24,7 @@ const (
 	// entries are Go allocated rather than manually allocated.
 	//
 	// If cgo is disabled we need to allocate the entries using the Go allocator
-	// and is violates the Go GC rules to put Go pointers (such as the entry
+	// and this violates the Go GC rules to put Go pointers (such as the entry
 	// pointer fields) into untyped memory (i.e. a []byte).
 	entriesGoAllocated = invariants.RaceEnabled || !cgoEnabled
 )

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -615,7 +615,7 @@ compact a-f L1
 # Test a scenario where we the last point key in an sstable has a
 # seqnum of 0, but there is another range tombstone later in the
 # compaction. This scenario was previously triggering an assertion due
-# to the rangedel.Fragmenter being finished prematurely.
+# to the keyspan.Fragmenter being finished prematurely.
 
 define target-file-sizes=(1, 1, 1)
 L1

--- a/testdata/manual_compaction_set_with_del
+++ b/testdata/manual_compaction_set_with_del
@@ -616,7 +616,7 @@ compact a-f L1
 # Test a scenario where we the last point key in an sstable has a
 # seqnum of 0, but there is another range tombstone later in the
 # compaction. This scenario was previously triggering an assertion due
-# to the rangedel.Fragmenter being finished prematurely.
+# to the keyspan.Fragmenter being finished prematurely.
 
 define target-file-sizes=(1, 1, 1)
 L1

--- a/testdata/manual_compaction_set_with_del_sstable_Pebblev4
+++ b/testdata/manual_compaction_set_with_del_sstable_Pebblev4
@@ -616,7 +616,7 @@ compact a-f L1
 # Test a scenario where we the last point key in an sstable has a
 # seqnum of 0, but there is another range tombstone later in the
 # compaction. This scenario was previously triggering an assertion due
-# to the rangedel.Fragmenter being finished prematurely.
+# to the keyspan.Fragmenter being finished prematurely.
 
 define target-file-sizes=(1, 1, 1)
 L1


### PR DESCRIPTION
Description:
1. Fixed a few minor typos in documentation.
2. While renaming `rangedel` -> `keyspan` in [PR](https://github.com/cockroachdb/pebble/pull/1352), a few
references to `rangedel.Fragmenter` weren't updated. This is fixed.