### PR TITLE
objstorage: fix up redaction, error message formatting

### DIFF
--- a/objstorage/objstorage.go
+++ b/objstorage/objstorage.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/sharedcache"
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/cockroachdb/redact"
 )
 
 // Readable is the handle for an object that is open for reading.
@@ -166,6 +167,11 @@ type CreatorID uint64
 func (c CreatorID) IsSet() bool { return c != 0 }
 
 func (c CreatorID) String() string { return fmt.Sprintf("%d", c) }
+
+// SafeFormat implements redact.SafeFormatter.
+func (c CreatorID) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("%d", redact.SafeUint(c))
+}
 
 // SharedCleanupMethod indicates the method for cleaning up unused shared objects.
 type SharedCleanupMethod uint8

--- a/objstorage/objstorageprovider/provider.go
+++ b/objstorage/objstorageprovider/provider.go
@@ -255,7 +255,7 @@ func (p *provider) Create(
 		w, meta, err = p.vfsCreate(ctx, fileType, fileNum)
 	}
 	if err != nil {
-		err = errors.Wrapf(err, "creating object %s", errors.Safe(fileNum))
+		err = errors.Wrapf(err, "creating object %s", fileNum)
 		return nil, objstorage.ObjectMetadata{}, err
 	}
 	p.addMetadata(meta)
@@ -292,7 +292,7 @@ func (p *provider) Remove(fileType base.FileType, fileNum base.DiskFileNum) erro
 		// We want to be able to retry a Remove, so we keep the object in our list.
 		// TODO(radu): we should mark the object as "zombie" and not allow any other
 		// operations.
-		return errors.Wrapf(err, "removing object %s", errors.Safe(fileNum))
+		return errors.Wrapf(err, "removing object %s", fileNum)
 	}
 
 	p.removeMetadata(fileNum)
@@ -404,13 +404,13 @@ func (p *provider) Lookup(
 		return objstorage.ObjectMetadata{}, errors.Wrapf(
 			os.ErrNotExist,
 			"file %s (type %d) unknown to the objstorage provider",
-			errors.Safe(fileNum), errors.Safe(fileType),
+			fileNum, errors.Safe(fileType),
 		)
 	}
 	if meta.FileType != fileType {
 		return objstorage.ObjectMetadata{}, errors.AssertionFailedf(
 			"file %s type mismatch (known type %d, expected type %d)",
-			errors.Safe(fileNum), errors.Safe(meta.FileType), errors.Safe(fileType),
+			fileNum, errors.Safe(meta.FileType), errors.Safe(fileType),
 		)
 	}
 	return meta, nil

--- a/objstorage/objstorageprovider/remote.go
+++ b/objstorage/objstorageprovider/remote.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/remoteobjcat"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/sharedcache"
 	"github.com/cockroachdb/pebble/objstorage/remote"
+	"github.com/cockroachdb/redact"
 )
 
 // remoteSubsystem contains the provider fields related to remote storage.
@@ -233,7 +234,7 @@ func (p *provider) sharedCreateRef(meta objstorage.ObjectMetadata) error {
 		err = writer.Close()
 	}
 	if err != nil {
-		return errors.Wrapf(err, "creating marker object %q", refName)
+		return errors.Wrapf(err, "creating marker object %q", errors.Safe(refName))
 	}
 	return nil
 }
@@ -265,7 +266,7 @@ func (p *provider) sharedCreate(
 	objName := remoteObjectName(meta)
 	writer, err := storage.CreateObject(objName)
 	if err != nil {
-		return nil, objstorage.ObjectMetadata{}, errors.Wrapf(err, "creating object %q", objName)
+		return nil, objstorage.ObjectMetadata{}, errors.Wrapf(err, "creating object %q", errors.Safe(objName))
 	}
 	return &sharedWritable{
 		p:             p,
@@ -290,19 +291,19 @@ func (p *provider) remoteOpenForReading(
 		if _, err := meta.Remote.Storage.Size(refName); err != nil {
 			if meta.Remote.Storage.IsNotExistError(err) {
 				if opts.MustExist {
-					p.st.Logger.Fatalf("marker object %q does not exist", refName)
+					p.st.Logger.Fatalf("marker object %q does not exist", errors.Safe(refName))
 					// TODO(radu): maybe list references for the object.
 				}
-				return nil, errors.Errorf("marker object %q does not exist", refName)
+				return nil, errors.Errorf("marker object %q does not exist", errors.Safe(refName))
 			}
-			return nil, errors.Wrapf(err, "checking marker object %q", refName)
+			return nil, errors.Wrapf(err, "checking marker object %q", errors.Safe(refName))
 		}
 	}
 	objName := remoteObjectName(meta)
 	reader, size, err := meta.Remote.Storage.ReadObject(ctx, objName)
 	if err != nil {
 		if opts.MustExist && meta.Remote.Storage.IsNotExistError(err) {
-			p.st.Logger.Fatalf("object %q does not exist", objName)
+			p.st.Logger.Fatalf("object %q does not exist", redact.SafeString(objName))
 			// TODO(radu): maybe list references for the object.
 		}
 		return nil, err

--- a/objstorage/objstorageprovider/remoteobjcat/catalog.go
+++ b/objstorage/objstorageprovider/remoteobjcat/catalog.go
@@ -138,7 +138,7 @@ func (c *Catalog) SetCreatorID(id objstorage.CreatorID) error {
 
 	ve := VersionEdit{CreatorID: id}
 	if err := c.writeToCatalogFileLocked(&ve); err != nil {
-		return errors.Wrapf(err, "pebble: could not write to remote object catalog: %v", err)
+		return errors.Wrapf(err, "pebble: could not write to remote object catalog")
 	}
 	c.mu.creatorID = id
 	return nil
@@ -240,7 +240,7 @@ func (c *Catalog) ApplyBatch(b Batch) error {
 	}
 
 	if err := c.writeToCatalogFileLocked(&b.ve); err != nil {
-		return errors.Wrapf(err, "pebble: could not write to remote object catalog: %v", err)
+		return errors.Wrapf(err, "pebble: could not write to remote object catalog")
 	}
 
 	// Add new objects before deleting any objects. This allows for cases where

--- a/objstorage/remote/storage.go
+++ b/objstorage/remote/storage.go
@@ -7,6 +7,8 @@ package remote
 import (
 	"context"
 	"io"
+
+	"github.com/cockroachdb/redact"
 )
 
 // Locator is an opaque string identifying a remote.Storage implementation.
@@ -15,6 +17,11 @@ import (
 // stored on disk in the shared object catalog and are passed around as part of
 // RemoteObjectBacking; they can also appear in error messages.
 type Locator string
+
+// SafeFormat implements redact.SafeFormatter.
+func (l Locator) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("%s", redact.SafeString(l))
+}
 
 // StorageFactory is used to return Storage implementations based on locators. A
 // Pebble store that uses shared storage is configured with a StorageFactory.


### PR DESCRIPTION
Fix up a few instances where nonsensitive data could be redacted in logs or error messages, and a couple instances where errors were included twice (once as the target of Wrapf, and once as a formatting operand to Wrapf).