### PR TITLE
crl-release-22.2: vfs: default to Unix semantics in MemFS

### DIFF
--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1630,6 +1630,7 @@ func TestIngestCleanup(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
 			mem := vfs.NewMem()
+			mem.UseWindowsSemantics(true)
 
 			// Create the files in the VFS.
 			metaMap := make(map[base.FileNum]vfs.File)


### PR DESCRIPTION
Backport of #2065. Informs cockroachdb/cockroach#112087.

----

Default to Unix semantics in MemFS. The Windows semantics are left as configurable for unit tests that seek to ensure we don't remove open files, when possible.

There are existing cases where we cannot satisfy Windows semantics, and Go does not support opening files with the appropriate `FILE_SHARE_DELETE` permission bit (see golang/go#34681, golang/go#32088). The MemFS's implementation of Windows semantics is useful for ensuring we don't regress in the cases where we can satisfy Windows semantics.

Close #2064.
Informs #1236.