### PR TITLE
crl-release-22.2: .github: build Windows on 1.19

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,7 +106,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: "1.18"
+        go-version: "1.20"
 
     - run: go test -v ./...
 


### PR DESCRIPTION
This commit updates the Windows CI job to use Go 1.19 instead of Go 1.18.

See golang/go#51007.