### PR TITLE
compaction: remove the useless condition in check to delete compactions

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2336,7 +2336,6 @@ func (d *DB) maybeScheduleCompactionPicker(
 	// cheap and reduce future compaction work.
 	if !d.opts.private.disableDeleteOnlyCompactions &&
 		len(d.mu.compact.deletionHints) > 0 &&
-		d.mu.compact.compactingCount < maxConcurrentCompactions &&
 		!d.opts.DisableAutomaticCompactions {
 		v := d.mu.versions.currentVersion()
 		snapshots := d.mu.snapshots.toSlice()


### PR DESCRIPTION
This PR removes the useless condition `d.mu.compact.compactingCount < maxConcurrentCompactions` in checking to delete compactions. Because the `db.mu` will be held while calling the function `maybeScheduleCompactionPicker`. The parallel compaction count limitation has been checked at L2308 and there is not any change between L2308 to L2337.

```go
	if d.mu.compact.compactingCount >= maxConcurrentCompactions {
		if len(d.mu.compact.manual) > 0 {
			// Inability to run head blocks later manual compactions.
			d.mu.compact.manual[0].retries++
		}
		return
	}
```