### PR TITLE
*: use the constant manifest.NumLevels instead of literal value

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1663,7 +1663,7 @@ func pickAutoLPositive(
 	vers *version,
 	cInfo candidateLevelInfo,
 	baseLevel int,
-	levelMaxBytes [7]int64,
+	levelMaxBytes [numLevels]int64,
 ) (pc *pickedCompaction) {
 	if cInfo.level == 0 {
 		panic("pebble: pickAutoLPositive called for L0")

--- a/tool/logs/compaction.go
+++ b/tool/logs/compaction.go
@@ -19,8 +19,11 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/humanize"
+	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/spf13/cobra"
 )
+
+const numLevels = manifest.NumLevels
 
 var (
 	// Captures a common logging prefix that can be used as the context for the
@@ -514,8 +517,8 @@ type windowSummary struct {
 	compactionBytesMoved map[fromTo]uint64
 	compactionBytesDel   map[fromTo]uint64
 	compactionTime       map[fromTo]time.Duration
-	ingestedCount        [7]int
-	ingestedBytes        [7]uint64
+	ingestedCount        [numLevels]int
+	ingestedBytes        [numLevels]uint64
 	readAmps             []readAmp
 	longRunning          []event
 }


### PR DESCRIPTION
There is a constant definition for `manifest.NumLevels`. But the literal value `7` is still hard code in the codebase. The PR tries to fix this issue and replace the literal value with the constant `manifest.NumLevels`.