### PR TITLE
db: defer loading L0 range key blocks during iterator construction 

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -1453,6 +1453,15 @@ func runLSMCmd(td *datadriven.TestData, d *DB) string {
 func parseDBOptionsArgs(opts *Options, args []datadriven.CmdArg) error {
 	for _, cmdArg := range args {
 		switch cmdArg.Key {
+		case "auto-compactions":
+			switch cmdArg.Vals[0] {
+			case "off":
+				opts.DisableAutomaticCompactions = true
+			case "on":
+				opts.DisableAutomaticCompactions = false
+			default:
+				return errors.Errorf("Unrecognized %q arg value: %q", cmdArg.Key, cmdArg.Vals[0])
+			}
 		case "inject-errors":
 			injs := make([]errorfs.Injector, len(cmdArg.Vals))
 			for i := 0; i < len(cmdArg.Vals); i++ {

--- a/testdata/iter_histories/errors
+++ b/testdata/iter_histories/errors
@@ -57,3 +57,43 @@ b: (b, .)
 c: (c, .)
 d: (d, .)
 .
+
+# Regression test for #2994.
+#
+# Previously, an error while loading an L0 sstable's range key block could
+# result in an iterator that would always return the same error. Now, the IO is
+# deferred to the first seek. If a seek encounters an IO error, re-seeking the
+# iterator should re-attempt the failed IO operation, potentially succeeding if
+# the IO error was transient.
+
+define auto-compactions=off
+L0
+  a.SET.9:a
+  rangekey:c-d:{(#0,RANGEKEYSET,@1,foo)}
+  e@2.SET.2:e@2
+----
+0.0:
+  000004:[a#9,SET-e@2#2,SET]
+
+layout filename=000004.sst
+----
+         0  data (38)
+        43  index (35)
+        83  range-key (29)
+       117  properties (645)
+       767  meta-index (57)
+       829  footer (53)
+       882  EOF
+
+# Inject an error on the first `ReadAt` call on 000004.sst's range key block
+# (which is at offset 83).
+
+reopen auto-compactions=off enable-table-stats=false inject-errors=((ErrInjected (And (PathMatch "000004.sst") (OpFileReadAt 83) (OnIndex 0))))
+----
+
+combined-iter
+first
+first
+----
+err=injected error
+a: (a, .)

--- a/vfs/errorfs/errorfs.go
+++ b/vfs/errorfs/errorfs.go
@@ -31,6 +31,9 @@ type Op struct {
 	Kind OpKind
 	// Path is the path of the file of the file being operated on.
 	Path string
+	// Offset is the offset of an operation. It's set for OpFileReadAt and
+	// OpFileWriteAt operations.
+	Offset int64
 }
 
 // OpKind is an enum describing the type of operation.
@@ -423,7 +426,11 @@ func (f *errorFile) Read(p []byte) (int, error) {
 }
 
 func (f *errorFile) ReadAt(p []byte, off int64) (int, error) {
-	if err := f.inj.MaybeError(Op{Kind: OpFileReadAt, Path: f.path}); err != nil {
+	if err := f.inj.MaybeError(Op{
+		Kind:   OpFileReadAt,
+		Path:   f.path,
+		Offset: off,
+	}); err != nil {
 		return 0, err
 	}
 	return f.file.ReadAt(p, off)
@@ -436,11 +443,15 @@ func (f *errorFile) Write(p []byte) (int, error) {
 	return f.file.Write(p)
 }
 
-func (f *errorFile) WriteAt(p []byte, ofs int64) (int, error) {
-	if err := f.inj.MaybeError(Op{Kind: OpFileWriteAt, Path: f.path}); err != nil {
+func (f *errorFile) WriteAt(p []byte, off int64) (int, error) {
+	if err := f.inj.MaybeError(Op{
+		Kind:   OpFileWriteAt,
+		Path:   f.path,
+		Offset: off,
+	}); err != nil {
 		return 0, err
 	}
-	return f.file.WriteAt(p, ofs)
+	return f.file.WriteAt(p, off)
 }
 
 func (f *errorFile) Stat() (os.FileInfo, error) {

--- a/vfs/errorfs/testdata/errorfs
+++ b/vfs/errorfs/testdata/errorfs
@@ -45,3 +45,12 @@ parsing err: errorfs: unknown error "And"
 parsing err: errorfs: unknown error "Or"
 parsing err: errorfs: unexpected token IDENT ("foo") at char 23; expected INT
 parsing err: strconv.ParseInt: parsing "9223372036854775807": value out of range
+
+parse-dsl
+(ErrInjected (OpFileReadAt _))
+(ErrInjected (OpFileReadAt foo))
+(ErrInjected (OpFileReadAt 1052363))
+----
+parsing err: errorfs: unexpected token IDENT ("_") at char 28; expected INT
+parsing err: errorfs: unexpected token IDENT ("foo") at char 28; expected INT
+(ErrInjected (FileReadAt 1052363))


### PR DESCRIPTION
Previously, construction of an iterator over range keys that found sstables
containing range keys within L0 performed I/O to load the range key blocks
during iterator construction. This was less efficient: If the iterator
ultimately didn't need to read the keyspace overlapping the sstables containing
range keys, the block loads were unnecessary.

More significantly, if the I/O failed during iterator construction, the
resulting iterator was unusable. It would always error with the original error
returned by the failed block load. This is a deviation from iterator error
handling across the rest of the iterator stack, which allows an Iterator to be
re-seeked to clear the current iterator error.

Resolves https://github.com/cockroachdb/pebble/issues/2994.