### PR TITLE
Fix cornercase in capping memory allowance

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1381,7 +1381,7 @@ func (b *Batch) countData() []byte {
 
 func (b *Batch) grow(n int) {
 	newSize := len(b.data) + n
-	if uint64(newSize) >= maxBatchSize {
+	if uint64(newSize) > maxBatchSize {
 		panic(ErrBatchTooLarge)
 	}
 	if newSize > cap(b.data) {

--- a/batch_test.go
+++ b/batch_test.go
@@ -986,7 +986,7 @@ func TestBatchTooLarge(t *testing.T) {
 				result = r
 			}
 		}()
-		b.grow(maxBatchSize)
+		b.grow(maxBatchSize + 1)
 	}()
 	require.EqualValues(t, ErrBatchTooLarge, result)
 }

--- a/options.go
+++ b/options.go
@@ -1662,8 +1662,8 @@ func (o *Options) Validate() error {
 		fmt.Fprintf(&buf, "L0StopWritesThreshold (%d) must be >= L0CompactionThreshold (%d)\n",
 			o.L0StopWritesThreshold, o.L0CompactionThreshold)
 	}
-	if uint64(o.MemTableSize) >= maxMemTableSize {
-		fmt.Fprintf(&buf, "MemTableSize (%s) must be < %s\n",
+	if uint64(o.MemTableSize) > maxMemTableSize {
+		fmt.Fprintf(&buf, "MemTableSize (%s) must be <= %s\n",
 			humanize.Bytes.Uint64(uint64(o.MemTableSize)), humanize.Bytes.Uint64(maxMemTableSize))
 	}
 	if o.MemTableStopWritesThreshold < 2 {

--- a/options_test.go
+++ b/options_test.go
@@ -280,7 +280,7 @@ func TestOptionsValidate(t *testing.T) {
 [Options]
   mem_table_size=4294967296
 `,
-			`MemTableSize \(4\.0GB\) must be < [2|4]\.0GB`,
+			`MemTableSize \(4\.0GB\) must be <= [2|4]\.0GB`,
 		},
 		{`
 [Options]


### PR DESCRIPTION
This pull request addresses a corner case when capping the pebble memory allowance. On a 32-bit machine, the memory usage is capped at MaxInt32 (note that this value is also inclusive), and on a 64-bit machine, it's capped at MaxUint32. These edge values should also be considered valid options.