### PR TITLE
vfs/errorfs: add Randomly

### DIFF
--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -453,7 +453,9 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 
 	// Wrap the filesystem with one that will inject errors into read
 	// operations with *errorRate probability.
-	opts.FS = errorfs.Wrap(opts.FS, errorfs.WithProbability(errorfs.OpIsRead, runOpts.errorRate))
+	opts.FS = errorfs.Wrap(opts.FS, errorfs.ErrInjected.If(
+		errorfs.And(errorfs.Reads, errorfs.Randomly(runOpts.errorRate, int64(seed))),
+	))
 
 	if opts.WALDir != "" {
 		opts.WALDir = opts.FS.PathJoin(runDir, opts.WALDir)

--- a/vfs/errorfs/errorfs.go
+++ b/vfs/errorfs/errorfs.go
@@ -7,12 +7,9 @@ package errorfs
 import (
 	"fmt"
 	"io"
-	"math/rand"
 	"os"
 	"strings"
-	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
@@ -148,23 +145,6 @@ func (ii *InjectIndex) MaybeError(op Op) error {
 		return nil
 	}
 	return ErrInjected
-}
-
-// WithProbability returns a function that returns an error with the provided
-// probability when passed op. It may be passed to Wrap to inject an error
-// into an ErrFS with the provided probability. p should be within the range
-// [0.0,1.0].
-func WithProbability(op OpReadWrite, p float64) Injector {
-	mu := new(sync.Mutex)
-	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
-	return InjectorFunc(func(currOp Op) error {
-		mu.Lock()
-		defer mu.Unlock()
-		if currOp.Kind.ReadOrWrite() == op && rnd.Float64() < p {
-			return errors.WithStack(ErrInjected)
-		}
-		return nil
-	})
 }
 
 // InjectorFunc implements the Injector interface for a function with

--- a/vfs/errorfs/testdata/errorfs
+++ b/vfs/errorfs/testdata/errorfs
@@ -54,3 +54,22 @@ parse-dsl
 parsing err: errorfs: unexpected token IDENT ("_") at char 28; expected INT
 parsing err: errorfs: unexpected token IDENT ("foo") at char 28; expected INT
 (ErrInjected (FileReadAt 1052363))
+
+parse-dsl
+(ErrInjected (Randomly 0))
+(ErrInjected (Randomly 0.1))
+(ErrInjected (Randomly 0.2 18520850252))
+(ErrInjected (Randomly 1.2 18520850252))
+(ErrInjected (Randomly -0.3 18520850252))
+(ErrInjected (Randomly 18520850252 0.25))
+(ErrInjected (And (PathMatch "*.sst") (Randomly 0.05 185957252)))
+(ErrInjected (And (PathMatch "*.sst") (Randomly 0.05)))
+----
+parsing err: errorfs: unexpected token INT ("0") at char 24; expected FLOAT
+(ErrInjected (Randomly 0.10))
+(ErrInjected (Randomly 0.20 18520850252))
+parsing err: errorfs: Randomly proability p must be within p ≤ 1.0
+parsing err: errorfs: unexpected token - ("") at char 24; expected FLOAT
+parsing err: errorfs: unexpected token INT ("18520850252") at char 24; expected FLOAT
+(ErrInjected (And (PathMatch "*.sst") (Randomly 0.05 185957252)))
+(ErrInjected (And (PathMatch "*.sst") (Randomly 0.05)))


### PR DESCRIPTION
Add a new Randomly errorfs predicate to replace the old WithProbability injector. The Randomly predicate takes a probability and optionally a seed.  I intend to use it in randomized tests by first generating a datadriven randomized test, and then executing it.

The predicate is deterministic with respect to file paths: its behavior for a particular file is deterministic regardless of intervening evaluations for operations on other files. This can be used to ensure determinism despite nondeterministic concurrency if the concurrency is constrained to separate files.