### PR TITLE
db: retry manual compactions that get cancelled

### DIFF
--- a/db.go
+++ b/db.go
@@ -1759,9 +1759,15 @@ func (d *DB) Compact(start, end []byte, parallelize bool) error {
 	}
 
 	for level := 0; level < maxLevelWithFiles; {
-		if err := d.manualCompact(
-			iStart.UserKey, iEnd.UserKey, level, parallelize); err != nil {
-			return err
+		for {
+			if err := d.manualCompact(
+				iStart.UserKey, iEnd.UserKey, level, parallelize); err != nil {
+				if errors.Is(err, ErrCancelledCompaction) {
+					continue
+				}
+				return err
+			}
+			break
 		}
 		level++
 		if level == numLevels-1 {


### PR DESCRIPTION
Previously, we wouldn't retry a manual compaction if it returned ErrCancelledCompaction, even though the error message states that that compaction will be retried. Instead we returned this error to the caller.

This change checks for that particular error case and follows it up by retrying a compaction on that level.

Fixes #3011.