### PR TITLE
vfs/errorfs: expand interface and extract parsing logic

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2913,7 +2913,7 @@ func TestCompactionErrorCleanup(t *testing.T) {
 				if initialSetupDone {
 					tablesCreated = append(tablesCreated, info.FileNum)
 					if len(tablesCreated) >= 2 {
-						ii.SetIndex(0)
+						ii.Store(0)
 					}
 				}
 			},

--- a/data_test.go
+++ b/data_test.go
@@ -1465,7 +1465,7 @@ func parseDBOptionsArgs(opts *Options, args []datadriven.CmdArg) error {
 		case "inject-errors":
 			injs := make([]errorfs.Injector, len(cmdArg.Vals))
 			for i := 0; i < len(cmdArg.Vals); i++ {
-				inj, err := errorfs.ParseInjectorFromDSL(cmdArg.Vals[i])
+				inj, err := errorfs.Parse(cmdArg.Vals[i])
 				if err != nil {
 					return err
 				}

--- a/error_test.go
+++ b/error_test.go
@@ -210,7 +210,7 @@ func TestRequireReadError(t *testing.T) {
 		}
 
 		// Now perform foreground ops with error injection enabled.
-		ii.SetIndex(index)
+		ii.Store(index)
 		iter, _ := d.NewIter(nil)
 		if err := iter.Error(); err != nil {
 			return err
@@ -237,7 +237,7 @@ func TestRequireReadError(t *testing.T) {
 		// Reaching here implies all read operations succeeded. This
 		// should only happen when we reached a large enough index at
 		// which `errorfs.FS` did not return any error.
-		if i := ii.Index(); i < 0 {
+		if i := ii.Load(); i < 0 {
 			t.Errorf("FS error injected %d ops ago went unreported", -i)
 		}
 		if numFound != 2 {

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -2212,7 +2212,7 @@ func TestIngestError(t *testing.T) {
 				}
 			}()
 
-			ii.SetIndex(i)
+			ii.Store(i)
 			err1 := d.Ingest([]string{"ext0"})
 			err2 := d.Ingest([]string{"ext1"})
 			err := firstError(err1, err2)
@@ -2226,7 +2226,7 @@ func TestIngestError(t *testing.T) {
 
 		// If the injector's index is non-negative, the i-th filesystem
 		// operation was never executed.
-		if ii.Index() >= 0 {
+		if ii.Load() >= 0 {
 			break
 		}
 	}

--- a/internal/dsl/dsl.go
+++ b/internal/dsl/dsl.go
@@ -1,0 +1,149 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// Package dsl provides facilities for parsing lisp-like domain-specific
+// languages (DSL).
+package dsl
+
+import (
+	"fmt"
+	"go/scanner"
+	"go/token"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// NewParser constructs a new Parser of a lisp-like DSL.
+func NewParser[T any]() *Parser[T] {
+	p := new(Parser[T])
+	p.constants = make(map[string]func() T)
+	p.funcs = make(map[string]func(*Parser[T], *Scanner) T)
+	return p
+}
+
+// NewPredicateParser constructs a new Parser of a Lisp-like DSL, where the
+// resulting type implements Predicate[E]. NewPredicateParser predefines a few
+// useful functions: Not, And, Or, OnIndex.
+func NewPredicateParser[E any]() *Parser[Predicate[E]] {
+	p := NewParser[Predicate[E]]()
+	p.DefineFunc("Not", parseNot[E])
+	p.DefineFunc("And", parseAnd[E])
+	p.DefineFunc("Or", parseOr[E])
+	p.DefineFunc("OnIndex", parseOnIndex[E])
+	return p
+}
+
+// A Parser holds the rules and logic for parsing a DSL.
+type Parser[T any] struct {
+	constants map[string]func() T
+	funcs     map[string]func(*Parser[T], *Scanner) T
+}
+
+// DefineConstant adds a new constant to the Parser's supported DSL. Whenever
+// the provided identifier is used within a constant context, the provided
+// closure is invoked to instantiate an appropriate AST value.
+func (p *Parser[T]) DefineConstant(identifier string, instantiate func() T) {
+	p.constants[identifier] = instantiate
+}
+
+// DefineFunc adds a new func to the Parser's supported DSL. Whenever the
+// provided identifier is used within a function invocation context, the
+// provided closure is invoked to instantiate an appropriate AST value.
+func (p *Parser[T]) DefineFunc(identifier string, parseFunc func(*Parser[T], *Scanner) T) {
+	p.funcs[identifier] = parseFunc
+}
+
+// Parse parses the provided input string.
+func (p *Parser[T]) Parse(d string) (ret T, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			var ok bool
+			err, ok = r.(error)
+			if !ok {
+				panic(r)
+			}
+		}
+	}()
+
+	fset := token.NewFileSet()
+	file := fset.AddFile("", -1, len(d))
+	var s Scanner
+	s.Init(file, []byte(strings.TrimSpace(d)), nil /* no error handler */, 0)
+	tok := s.Scan()
+	ret, err = p.ParseFromPos(&s, tok)
+	if err != nil {
+		return ret, err
+	}
+	tok = s.Scan()
+	if tok.Kind == token.SEMICOLON {
+		tok = s.Scan()
+	}
+	assertTok(tok, token.EOF)
+	return ret, err
+}
+
+// ParseFromPos parses from the provided current position and associated
+// scanner.
+func (p *Parser[T]) ParseFromPos(s *Scanner, tok Token) (ret T, err error) {
+	switch tok.Kind {
+	case token.IDENT:
+		// A constant without any parens, eg. `Reads`.
+		p, ok := p.constants[tok.Lit]
+		if !ok {
+			return ret, errors.Errorf("errorfs: dsl constant %q", tok.Lit)
+		}
+		return p(), nil
+	case token.LPAREN:
+		// Otherwise it's an expression, eg: (OnIndex 1)
+		tok = s.Consume(token.IDENT)
+		fp, ok := p.funcs[tok.Lit]
+		if !ok {
+			return ret, errors.Errorf("dsl: unknown func %q", tok.Lit)
+		}
+		return fp(p, s), nil
+	default:
+		return ret, errors.Errorf("dsl: unexpected token %s; expected IDENT or LPAREN", tok)
+	}
+}
+
+// A Scanner holds the scanner's internal state while processing a given text.
+type Scanner struct {
+	scanner.Scanner
+}
+
+// Scan scans the next token and returns it.
+func (s *Scanner) Scan() Token {
+	pos, tok, lit := s.Scanner.Scan()
+	return Token{pos, tok, lit}
+}
+
+// Consume scans the next token. If the token is not of the provided token, it
+// panics. It returns the token itself.
+func (s *Scanner) Consume(expect token.Token) Token {
+	t := s.Scan()
+	assertTok(t, expect)
+	return t
+}
+
+// Token is a lexical token scanned from an input text.
+type Token struct {
+	pos  token.Pos
+	Kind token.Token
+	Lit  string
+}
+
+// String implements fmt.Stringer.
+func (t *Token) String() string {
+	if t.Lit != "" {
+		return fmt.Sprintf("(%s, %q) at pos %v", t.Kind, t.Lit, t.pos)
+	}
+	return fmt.Sprintf("%s at pos %v", t.Kind, t.pos)
+}
+
+func assertTok(tok Token, expect token.Token) {
+	if tok.Kind != expect {
+		panic(errors.Errorf("dsl: unexpected token %s; expected %s", tok.String(), expect))
+	}
+}

--- a/internal/dsl/predicates.go
+++ b/internal/dsl/predicates.go
@@ -1,0 +1,140 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package dsl
+
+import (
+	"fmt"
+	"go/token"
+	"strconv"
+	"strings"
+	"sync/atomic"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Predicate encodes conditional logic that yields a boolean.
+type Predicate[E any] interface {
+	Evaluate(E) bool
+	String() string
+}
+
+// Not returns a Predicate that negates the provided predicate.
+func Not[E any](p Predicate[E]) Predicate[E] { return not[E]{Predicate: p} }
+
+// And returns a Predicate that evaluates to true if all its operands evaluate
+// to true.
+func And[E any](preds ...Predicate[E]) Predicate[E] { return and[E](preds) }
+
+// Or returns a Predicate that evaluates to true if any of its operands evaluate
+// true.
+func Or[E any](preds ...Predicate[E]) Predicate[E] { return or[E](preds) }
+
+// OnIndex returns a Predicate that evaluates to true on its N-th call.
+func OnIndex[E any](n int32) *Index[E] {
+	p := new(Index[E])
+	p.Int32.Store(n)
+	return p
+}
+
+// Index is a Predicate that evaluates to true only on its N-th invocation.
+type Index[E any] struct {
+	atomic.Int32
+}
+
+// String implements fmt.Stringer.
+func (p *Index[E]) String() string {
+	return fmt.Sprintf("(OnIndex %d)", p.Int32.Load())
+}
+
+// Evaluate implements Predicate.
+func (p *Index[E]) Evaluate(E) bool { return p.Int32.Add(-1) == -1 }
+
+type not[E any] struct {
+	Predicate[E]
+}
+
+func (p not[E]) String() string    { return fmt.Sprintf("(Not %s)", p.Predicate.String()) }
+func (p not[E]) Evaluate(e E) bool { return !p.Predicate.Evaluate(e) }
+
+type and[E any] []Predicate[E]
+
+func (p and[E]) String() string {
+	var sb strings.Builder
+	sb.WriteString("(And")
+	for i := 0; i < len(p); i++ {
+		sb.WriteRune(' ')
+		sb.WriteString(p[i].String())
+	}
+	sb.WriteRune(')')
+	return sb.String()
+}
+
+func (p and[E]) Evaluate(e E) bool {
+	ok := true
+	for i := range p {
+		ok = ok && p[i].Evaluate(e)
+	}
+	return ok
+}
+
+type or[E any] []Predicate[E]
+
+func (p or[E]) String() string {
+	var sb strings.Builder
+	sb.WriteString("(Or")
+	for i := 0; i < len(p); i++ {
+		sb.WriteRune(' ')
+		sb.WriteString(p[i].String())
+	}
+	sb.WriteRune(')')
+	return sb.String()
+}
+
+func (p or[E]) Evaluate(e E) bool {
+	ok := false
+	for i := range p {
+		ok = ok || p[i].Evaluate(e)
+	}
+	return ok
+}
+
+func parseNot[E any](p *Parser[Predicate[E]], s *Scanner) Predicate[E] {
+	preds := parseVariadicPredicate(p, s)
+	if len(preds) != 1 {
+		panic(errors.Newf("dsl: not accepts exactly 1 argument, given %d", len(preds)))
+	}
+	return not[E]{Predicate: preds[0]}
+}
+
+func parseAnd[E any](p *Parser[Predicate[E]], s *Scanner) Predicate[E] {
+	return And[E](parseVariadicPredicate[E](p, s)...)
+}
+
+func parseOr[E any](p *Parser[Predicate[E]], s *Scanner) Predicate[E] {
+	return Or[E](parseVariadicPredicate[E](p, s)...)
+}
+
+func parseOnIndex[E any](p *Parser[Predicate[E]], s *Scanner) Predicate[E] {
+	i, err := strconv.ParseInt(s.Consume(token.INT).Lit, 10, 32)
+	if err != nil {
+		panic(err)
+	}
+	s.Consume(token.RPAREN)
+	return OnIndex[E](int32(i))
+}
+
+func parseVariadicPredicate[E any](p *Parser[Predicate[E]], s *Scanner) (ret []Predicate[E]) {
+	tok := s.Scan()
+	for tok.Kind == token.LPAREN || tok.Kind == token.IDENT {
+		pred, err := p.ParseFromPos(s, tok)
+		if err != nil {
+			panic(err)
+		}
+		ret = append(ret, pred)
+		tok = s.Scan()
+	}
+	assertTok(tok, token.RPAREN)
+	return ret
+}

--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/dsl"
 	"github.com/cockroachdb/pebble/internal/randvar"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/vfs"
@@ -473,7 +474,7 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 	// Wrap the filesystem with one that will inject errors into read
 	// operations with *errorRate probability.
 	opts.FS = errorfs.Wrap(opts.FS, errorfs.ErrInjected.If(
-		errorfs.And(errorfs.Reads, errorfs.Randomly(runOpts.errorRate, int64(seed))),
+		dsl.And[errorfs.Op](errorfs.Reads, errorfs.Randomly(runOpts.errorRate, int64(seed))),
 	))
 
 	if opts.WALDir != "" {

--- a/vfs/errorfs/dsl.go
+++ b/vfs/errorfs/dsl.go
@@ -7,21 +7,20 @@ package errorfs
 import (
 	"encoding/binary"
 	"fmt"
-	"go/scanner"
 	"go/token"
 	"hash/maphash"
 	"math/rand"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/dsl"
 )
 
 // MustParse parses an Injector from the DSL, panicking if parsing fails.
 func MustParse(s string) Injector {
-	inj, err := ParseInjectorFromDSL(s)
+	inj, err := Parse(s)
 	if err != nil {
 		panic(err)
 	}
@@ -33,10 +32,7 @@ func MustParsef(s string, args ...interface{}) Injector { return MustParse(fmt.S
 
 // Predicate encodes conditional logic that determines whether to inject an
 // error.
-type Predicate interface {
-	evaluate(Op) bool
-	String() string
-}
+type Predicate = dsl.Predicate[Op]
 
 // PathMatch returns a predicate that returns true if an operation's file path
 // matches the provided pattern according to filepath.Match.
@@ -52,7 +48,7 @@ func (pm *pathMatch) String() string {
 	return fmt.Sprintf("(PathMatch %q)", pm.pattern)
 }
 
-func (pm *pathMatch) evaluate(op Op) bool {
+func (pm *pathMatch) Evaluate(op Op) bool {
 	matched, err := filepath.Match(pm.pattern, op.Path)
 	if err != nil {
 		// Only possible error is ErrBadPattern, indicating an issue with
@@ -65,7 +61,7 @@ func (pm *pathMatch) evaluate(op Op) bool {
 var (
 	// Reads is a predicate that returns true iff an operation is a read
 	// operation.
-	Reads Predicate = opKindPred{kind: OpIsRead}
+	Reads dsl.Predicate[Op] = opKindPred{kind: OpIsRead}
 	// Writes is a predicate that returns true iff an operation is a write
 	// operation.
 	Writes Predicate = opKindPred{kind: OpIsWrite}
@@ -81,7 +77,7 @@ func (o *opFileReadAt) String() string {
 	return fmt.Sprintf("(FileReadAt %d)", o.offset)
 }
 
-func (o *opFileReadAt) evaluate(op Op) bool {
+func (o *opFileReadAt) Evaluate(op Op) bool {
 	return op.Kind == OpFileReadAt && o.offset == op.Offset
 }
 
@@ -90,71 +86,11 @@ type opKindPred struct {
 }
 
 func (p opKindPred) String() string      { return p.kind.String() }
-func (p opKindPred) evaluate(op Op) bool { return p.kind == op.Kind.ReadOrWrite() }
-
-// Not returns a predicate that negates the provided predicate.
-func Not(p Predicate) Predicate { return not{Predicate: p} }
-
-type not struct {
-	Predicate
-}
-
-func (n not) String() string     { return fmt.Sprintf("(Not %s)", n.Predicate.String()) }
-func (n not) evaluate(o Op) bool { return !n.Predicate.evaluate(o) }
-
-// And returns a predicate that returns true if all its operands return true.
-func And(preds ...Predicate) Predicate { return and(preds) }
-
-type and []Predicate
-
-func (a and) String() string {
-	var sb strings.Builder
-	sb.WriteString("(And")
-	for i := 0; i < len(a); i++ {
-		sb.WriteRune(' ')
-		sb.WriteString(a[i].String())
-	}
-	sb.WriteRune(')')
-	return sb.String()
-}
-
-func (a and) evaluate(o Op) bool {
-	ok := true
-	for _, p := range a {
-		ok = ok && p.evaluate(o)
-	}
-	return ok
-}
-
-// Or returns a predicate that returns true if any of its operands return true.
-func Or(preds ...Predicate) Predicate { return or(preds) }
-
-type or []Predicate
-
-func (e or) String() string {
-	var sb strings.Builder
-	sb.WriteString("(Or")
-	for i := 0; i < len(e); i++ {
-		sb.WriteRune(' ')
-		sb.WriteString(e[i].String())
-	}
-	sb.WriteRune(')')
-	return sb.String()
-}
-
-func (e or) evaluate(o Op) bool {
-	ok := false
-	for _, p := range e {
-		ok = ok || p.evaluate(o)
-	}
-	return ok
-}
+func (p opKindPred) Evaluate(op Op) bool { return p.kind == op.Kind.ReadOrWrite() }
 
 // OnIndex returns a predicate that returns true on its (n+1)-th invocation.
 func OnIndex(index int32) *InjectIndex {
-	ii := &InjectIndex{}
-	ii.index.Store(index)
-	return ii
+	return &InjectIndex{Index: dsl.OnIndex[Op](index)}
 }
 
 // Randomly constructs a new predicate that pseudorandomly evaluates to true
@@ -189,7 +125,7 @@ func (rs *randomSeed) String() string {
 	return fmt.Sprintf("(Randomly %.2f %d)", rs.p, rs.rootSeed)
 }
 
-func (rs *randomSeed) evaluate(op Op) bool {
+func (rs *randomSeed) Evaluate(op Op) bool {
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
 	prng, ok := rs.mu.perFilePrng[op.Path]
@@ -213,8 +149,8 @@ func (rs *randomSeed) evaluate(op Op) bool {
 	return prng.Float64() < rs.p
 }
 
-// ParseInjectorFromDSL parses a string encoding a lisp-like DSL describing when
-// errors should be injected.
+// Parse parses a string encoding a lisp-like DSL describing when errors should
+// be injected.
 //
 // Errors:
 // - ErrInjected is the only error currently supported by the DSL.
@@ -253,34 +189,8 @@ func (rs *randomSeed) evaluate(op Op) bool {
 //
 // Example: (ErrInjected (And (PathMatch "*.sst") (OnIndex 5))) is a rule set
 // that will inject an error on the 5-th I/O operation involving an sstable.
-func ParseInjectorFromDSL(d string) (inj Injector, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			var ok bool
-			err, ok = r.(error)
-			if !ok {
-				panic(r)
-			}
-		}
-	}()
-
-	fset := token.NewFileSet()
-	file := fset.AddFile("", -1, len(d))
-	var s scanner.Scanner
-	s.Init(file, []byte(strings.TrimSpace(d)), nil /* no error handler */, 0)
-	pos, tok, lit := s.Scan()
-	inj, err = parseDSLInjectorFromPos(&s, pos, tok, lit)
-	if err != nil {
-		return nil, err
-	}
-	pos, tok, lit = s.Scan()
-	if tok == token.SEMICOLON {
-		pos, tok, lit = s.Scan()
-	}
-	if tok != token.EOF {
-		return nil, errors.Errorf("errorfs: unexpected token %s (%q) at char %v; expected EOF", tok, lit, pos)
-	}
-	return inj, err
+func Parse(d string) (inj Injector, err error) {
+	return dslInjectorParser.Parse(d)
 }
 
 // LabelledError is an error that also implements Injector, unconditionally
@@ -302,7 +212,7 @@ func (le LabelledError) String() string {
 
 // MaybeError implements Injector.
 func (le LabelledError) MaybeError(op Op) error {
-	if le.predicate == nil || le.predicate.evaluate(op) {
+	if le.predicate == nil || le.predicate.Evaluate(op) {
 		return le
 	}
 	return nil
@@ -310,7 +220,7 @@ func (le LabelledError) MaybeError(op Op) error {
 
 // If returns an Injector that returns the receiver error if the provided
 // predicate evalutes to true.
-func (le LabelledError) If(p Predicate) Injector {
+func (le LabelledError) If(p Predicate) LabelledError {
 	le.predicate = p
 	return le
 }
@@ -318,142 +228,52 @@ func (le LabelledError) If(p Predicate) Injector {
 // AddError defines a new error that may be used within the DSL parsed by
 // ParseInjectorFromDSL and will inject the provided error.
 func AddError(le LabelledError) {
-	dslKnownErrors[le.label] = le
-}
-
-var (
-	dslPredicateExprs     map[string]func(*scanner.Scanner) Predicate
-	dslPredicateConstants map[string]func(*scanner.Scanner) Predicate
-	dslKnownErrors        map[string]LabelledError
-)
-
-func init() {
-	dslKnownErrors = map[string]LabelledError{}
-	dslPredicateConstants = map[string]func(*scanner.Scanner) Predicate{
-		"Reads":  func(s *scanner.Scanner) Predicate { return Reads },
-		"Writes": func(s *scanner.Scanner) Predicate { return Writes },
-	}
-	for i, name := range opNames {
-		opKind := OpKind(i)
-		dslPredicateConstants[name] = func(s *scanner.Scanner) Predicate {
-			// An OpKind implements Predicate.
-			return opKind
-		}
-	}
-	// Parsers for predicate exprs of the form `(ident ...)`.
-	dslPredicateExprs = map[string]func(*scanner.Scanner) Predicate{
-		"PathMatch": func(s *scanner.Scanner) Predicate {
-			pattern := mustUnquote(consumeTok(s, token.STRING))
-			consumeTok(s, token.RPAREN)
-			return PathMatch(pattern)
-		},
-		"OnIndex": func(s *scanner.Scanner) Predicate {
-			i, err := strconv.ParseInt(consumeTok(s, token.INT), 10, 32)
+	// Define the error both as a constant that unconditionally injects the
+	// error, and as a function that injects the error only if the provided
+	// predicate evaluates to true.
+	dslInjectorParser.DefineConstant(le.label, func() LabelledError { return le })
+	dslInjectorParser.DefineFunc(le.label,
+		func(p *dsl.Parser[LabelledError], s *dsl.Scanner) LabelledError {
+			pred, err := dslPredicateParser.ParseFromPos(s, s.Scan())
 			if err != nil {
 				panic(err)
 			}
-			consumeTok(s, token.RPAREN)
-			return OnIndex(int32(i))
-		},
-		"And": func(s *scanner.Scanner) Predicate {
-			return And(parseVariadicPredicate(s)...)
-		},
-		"Or": func(s *scanner.Scanner) Predicate {
-			return Or(parseVariadicPredicate(s)...)
-		},
-		"Not": func(s *scanner.Scanner) Predicate {
-			preds := parseVariadicPredicate(s)
-			if len(preds) != 1 {
-				panic(errors.Newf("not accepts exactly 1 argument, given %d", len(preds)))
-			}
-			return not{Predicate: preds[0]}
-		},
-		"OpFileReadAt": func(s *scanner.Scanner) Predicate {
-			return parseFileReadAtOp(s)
-		},
-		"Randomly": func(s *scanner.Scanner) Predicate {
-			return parseRandomly(s)
-		},
-	}
+			s.Consume(token.RPAREN)
+			return le.If(pred)
+		})
+}
+
+var (
+	dslInjectorParser  *dsl.Parser[LabelledError]     = dsl.NewParser[LabelledError]()
+	dslPredicateParser *dsl.Parser[dsl.Predicate[Op]] = dsl.NewPredicateParser[Op]()
+)
+
+func init() {
 	AddError(ErrInjected)
-}
 
-func parseVariadicPredicate(s *scanner.Scanner) (ret []Predicate) {
-	pos, tok, lit := s.Scan()
-	for tok == token.LPAREN || tok == token.IDENT {
-		pred, err := parseDSLPredicateFromPos(s, pos, tok, lit)
-		if err != nil {
-			panic(err)
-		}
-		ret = append(ret, pred)
-		pos, tok, lit = s.Scan()
+	dslPredicateParser.DefineConstant("Reads", func() dsl.Predicate[Op] { return Reads })
+	dslPredicateParser.DefineConstant("Writes", func() dsl.Predicate[Op] { return Writes })
+	for i, name := range opNames {
+		opKind := OpKind(i)
+		dslPredicateParser.DefineConstant(name, func() dsl.Predicate[Op] {
+			// An OpKind implements dsl.Predicate[Op].
+			return opKind
+		})
 	}
-	if tok != token.RPAREN {
-		panic(errors.Errorf("errorfs: unexpected token %s (%q) at char %v; expected RPAREN", tok, lit, pos))
-	}
-	return ret
-}
-
-func parseDSLInjectorFromPos(
-	s *scanner.Scanner, pos token.Pos, tok token.Token, lit string,
-) (Injector, error) {
-	switch tok {
-	case token.IDENT:
-		// It's an injector of the form `ErrInjected`.
-		le, ok := dslKnownErrors[lit]
-		if !ok {
-			return nil, errors.Errorf("errorfs: unknown error %q", lit)
-		}
-		return le, nil
-	case token.LPAREN:
-		// Otherwise it's an expression, eg: (ErrInjected (And ...))
-		lit = consumeTok(s, token.IDENT)
-		le, ok := dslKnownErrors[lit]
-		if !ok {
-			return nil, errors.Errorf("errorfs: unknown error %q", lit)
-		}
-		pos, tok, lit := s.Scan()
-		pred, err := parseDSLPredicateFromPos(s, pos, tok, lit)
-		if err != nil {
-			panic(err)
-		}
-		consumeTok(s, token.RPAREN)
-		return le.If(pred), nil
-	default:
-		return nil, errors.Errorf("errorfs: unexpected token %s (%q) at char %v; expected IDENT or LPAREN", tok, lit, pos)
-	}
-}
-
-func parseDSLPredicateFromPos(
-	s *scanner.Scanner, pos token.Pos, tok token.Token, lit string,
-) (Predicate, error) {
-	switch tok {
-	case token.IDENT:
-		// It's a predicate of the form `Reads`.
-		p, ok := dslPredicateConstants[lit]
-		if !ok {
-			return nil, errors.Errorf("errorfs: unknown predicate constant %q", lit)
-		}
-		return p(s), nil
-	case token.LPAREN:
-		// Otherwise it's an expression, eg: (OnIndex 1)
-		lit = consumeTok(s, token.IDENT)
-		p, ok := dslPredicateExprs[lit]
-		if !ok {
-			return nil, errors.Errorf("errorfs: unknown predicate func %q", lit)
-		}
-		return p(s), nil
-	default:
-		return nil, errors.Errorf("errorfs: unexpected token %s (%q) at char %v; expected IDENT or LPAREN", tok, lit, pos)
-	}
-}
-
-func consumeTok(s *scanner.Scanner, expected token.Token) (lit string) {
-	pos, tok, lit := s.Scan()
-	if tok != expected {
-		panic(errors.Errorf("errorfs: unexpected token %s (%q) at char %v; expected %s", tok, lit, pos, expected))
-	}
-	return lit
+	dslPredicateParser.DefineFunc("PathMatch",
+		func(p *dsl.Parser[dsl.Predicate[Op]], s *dsl.Scanner) dsl.Predicate[Op] {
+			pattern := mustUnquote(s.Consume(token.STRING).Lit)
+			s.Consume(token.RPAREN)
+			return PathMatch(pattern)
+		})
+	dslPredicateParser.DefineFunc("OpFileReadAt",
+		func(p *dsl.Parser[dsl.Predicate[Op]], s *dsl.Scanner) dsl.Predicate[Op] {
+			return parseFileReadAtOp(s)
+		})
+	dslPredicateParser.DefineFunc("Randomly",
+		func(p *dsl.Parser[dsl.Predicate[Op]], s *dsl.Scanner) dsl.Predicate[Op] {
+			return parseRandomly(s)
+		})
 }
 
 func mustUnquote(lit string) string {
@@ -464,19 +284,17 @@ func mustUnquote(lit string) string {
 	return s
 }
 
-func parseFileReadAtOp(s *scanner.Scanner) *opFileReadAt {
-	lit := consumeTok(s, token.INT)
-	off, err := strconv.ParseInt(lit, 10, 64)
+func parseFileReadAtOp(s *dsl.Scanner) *opFileReadAt {
+	off, err := strconv.ParseInt(s.Consume(token.INT).Lit, 10, 64)
 	if err != nil {
 		panic(err)
 	}
-	consumeTok(s, token.RPAREN)
+	s.Consume(token.RPAREN)
 	return &opFileReadAt{offset: off}
 }
 
-func parseRandomly(s *scanner.Scanner) Predicate {
-	lit := consumeTok(s, token.FLOAT)
-	p, err := strconv.ParseFloat(lit, 64)
+func parseRandomly(s *dsl.Scanner) Predicate {
+	p, err := strconv.ParseFloat(s.Consume(token.FLOAT).Lit, 64)
 	if err != nil {
 		panic(err)
 	} else if p > 1.0 {
@@ -486,17 +304,17 @@ func parseRandomly(s *scanner.Scanner) Predicate {
 	}
 
 	var seed int64
-	pos, tok, lit := s.Scan()
-	switch tok {
+	tok := s.Scan()
+	switch tok.Kind {
 	case token.RPAREN:
 	case token.INT:
-		seed, err = strconv.ParseInt(lit, 10, 64)
+		seed, err = strconv.ParseInt(tok.Lit, 10, 64)
 		if err != nil {
 			panic(err)
 		}
-		consumeTok(s, token.RPAREN)
+		s.Consume(token.RPAREN)
 	default:
-		panic(errors.Errorf("errorfs: unexpected token %s (%q) at char %v; expected RPAREN | FLOAT", tok, lit, pos))
+		panic(errors.Errorf("errorfs: unexpected token %s; expected RPAREN | FLOAT", tok))
 	}
 	return Randomly(p, seed)
 }

--- a/vfs/errorfs/errorfs_test.go
+++ b/vfs/errorfs/errorfs_test.go
@@ -19,7 +19,7 @@ func TestErrorFS(t *testing.T) {
 		switch td.Cmd {
 		case "parse-dsl":
 			for _, l := range strings.Split(strings.TrimSpace(td.Input), "\n") {
-				inj, err := ParseInjectorFromDSL(l)
+				inj, err := Parse(l)
 				if err != nil {
 					fmt.Fprintf(&sb, "parsing err: %s\n", err)
 				} else {

--- a/vfs/errorfs/testdata/errorfs
+++ b/vfs/errorfs/testdata/errorfs
@@ -73,3 +73,16 @@ parsing err: errorfs: unexpected token - ("") at char 24; expected FLOAT
 parsing err: errorfs: unexpected token INT ("18520850252") at char 24; expected FLOAT
 (ErrInjected (And (PathMatch "*.sst") (Randomly 0.05 185957252)))
 (ErrInjected (And (PathMatch "*.sst") (Randomly 0.05)))
+
+parse-dsl
+(ErrInjected OpCreate)
+(ErrInjected OpFileReadAt)
+(ErrInjected OpOpen)
+(ErrInjected (Or OpOpen OpFileRead OpFileWrite OpFileReadAt))
+(ErrInjected (Not (Or OpOpen OpFileRead OpFileWrite OpFileReadAt)))
+----
+(ErrInjected OpCreate)
+(ErrInjected OpFileReadAt)
+(ErrInjected OpOpen)
+(ErrInjected (Or OpOpen OpFileRead OpFileWrite OpFileReadAt))
+(ErrInjected (Not (Or OpOpen OpFileRead OpFileWrite OpFileReadAt)))

--- a/vfs/errorfs/testdata/errorfs
+++ b/vfs/errorfs/testdata/errorfs
@@ -33,17 +33,17 @@ ErrInjected()
 (ErrInjected (OnIndex foo))
 (ErrInjected (OnIndex 9223372036854775807))
 ----
-parsing err: errorfs: unknown error "errInjected"
-parsing err: errorfs: unexpected token ( ("") at char 12; expected EOF
-parsing err: errorfs: unexpected token IDENT ("foo") at char 25; expected STRING
-parsing err: errorfs: unknown error "alwoes"
-parsing err: errorfs: unexpected token STRING ("\"\"") at char 37; expected )
-parsing err: errorfs: unknown predicate constant "PathMatch"
-parsing err: errorfs: unexpected token IDENT ("ErrInjected") at char 23; expected INT
-parsing err: errorfs: unknown error "Or"
-parsing err: errorfs: unknown error "And"
-parsing err: errorfs: unknown error "Or"
-parsing err: errorfs: unexpected token IDENT ("foo") at char 23; expected INT
+parsing err: errorfs: dsl constant "errInjected"
+parsing err: dsl: unexpected token ( at pos 12; expected EOF
+parsing err: dsl: unexpected token (IDENT, "foo") at pos 25; expected STRING
+parsing err: dsl: unknown func "alwoes"
+parsing err: dsl: unexpected token (STRING, "\"\"") at pos 37; expected )
+parsing err: errorfs: dsl constant "PathMatch"
+parsing err: dsl: unexpected token (IDENT, "ErrInjected") at pos 23; expected INT
+parsing err: dsl: unknown func "Or"
+parsing err: dsl: unknown func "And"
+parsing err: dsl: unknown func "Or"
+parsing err: dsl: unexpected token (IDENT, "foo") at pos 23; expected INT
 parsing err: strconv.ParseInt: parsing "9223372036854775807": value out of range
 
 parse-dsl
@@ -51,8 +51,8 @@ parse-dsl
 (ErrInjected (OpFileReadAt foo))
 (ErrInjected (OpFileReadAt 1052363))
 ----
-parsing err: errorfs: unexpected token IDENT ("_") at char 28; expected INT
-parsing err: errorfs: unexpected token IDENT ("foo") at char 28; expected INT
+parsing err: dsl: unexpected token (IDENT, "_") at pos 28; expected INT
+parsing err: dsl: unexpected token (IDENT, "foo") at pos 28; expected INT
 (ErrInjected (FileReadAt 1052363))
 
 parse-dsl
@@ -65,12 +65,12 @@ parse-dsl
 (ErrInjected (And (PathMatch "*.sst") (Randomly 0.05 185957252)))
 (ErrInjected (And (PathMatch "*.sst") (Randomly 0.05)))
 ----
-parsing err: errorfs: unexpected token INT ("0") at char 24; expected FLOAT
+parsing err: dsl: unexpected token (INT, "0") at pos 24; expected FLOAT
 (ErrInjected (Randomly 0.10))
 (ErrInjected (Randomly 0.20 18520850252))
 parsing err: errorfs: Randomly proability p must be within p ≤ 1.0
-parsing err: errorfs: unexpected token - ("") at char 24; expected FLOAT
-parsing err: errorfs: unexpected token INT ("18520850252") at char 24; expected FLOAT
+parsing err: dsl: unexpected token - at pos 24; expected FLOAT
+parsing err: dsl: unexpected token (INT, "18520850252") at pos 24; expected FLOAT
 (ErrInjected (And (PathMatch "*.sst") (Randomly 0.05 185957252)))
 (ErrInjected (And (PathMatch "*.sst") (Randomly 0.05)))
 


### PR DESCRIPTION
The first commit adds a few additional errorfs injectors and predicates. Together these primitives allow the replacement of a few custom injectors across the codebase, by refactoring them in terms of these primitives.

The new primitives:

- A Toggle type implements errorfs.Injector and allows toggling whether an injector should be used at runtime.
- A Counter type implements errorfs.Injector and counts the number of injected errors. It allows tests to ensure that errors are surfaced appropriately and not swallowed.
- A Not predicate allows for negating other predicates.
- The OpKind type now implements the Predicate interface and is integrated into the DSL as a predicate constant that returns true if the operation is of the same kind.

The second commit extracts much of the DSL parsing logic into a separate package, internal/dsl. This allows other packages to define their own DSLs easily.