### PR TITLE
vfs: pass start time in nanos to disk-health timing functions

### DIFF
--- a/vfs/disk_health_test.go
+++ b/vfs/disk_health_test.go
@@ -372,7 +372,7 @@ func TestDiskHealthChecking_File_Underflow(t *testing.T) {
 		// Given the packing scheme, 35 years of process uptime will lead to a delta
 		// that is too large to fit in the packed int64.
 		tCreate := time.Now().Add(-35 * time.Hour * 24 * 365)
-		hcFile.createTime = tCreate
+		hcFile.createTimeNanos = tCreate.UnixNano()
 
 		// Assert that the time since tCreate (in milliseconds) is indeed greater
 		// than the max delta that can fit.
@@ -387,7 +387,7 @@ func TestDiskHealthChecking_File_Underflow(t *testing.T) {
 		// Given the packing scheme, 34 years of process uptime will lead to a delta
 		// that is just small enough to fit in the packed int64.
 		tCreate := time.Now().Add(-34 * time.Hour * 24 * 365)
-		hcFile.createTime = tCreate
+		hcFile.createTimeNanos = tCreate.UnixNano()
 
 		require.True(t, time.Since(tCreate).Milliseconds() < 1<<deltaBits-1)
 		require.NotPanics(t, func() { _, _ = hcFile.Write([]byte("should be fine")) })


### PR DESCRIPTION
Pass the start time in the form of nanoseconds since the unix epoch as a parameter to timeDiskOp and timeFilesystemOp. This aids post-mortem debugging when the disk-health checker fatals the process and GOTRACEBACK is set to dump the stacks, including arguments. The start time argument will be printed in hex form, allowing us to decode the start time of the operation. This can be used to confirm that the timed operation was still inflight at the time stacks were collected.

Close #3009.