### PR TITLE
internal/keyspan: fix InterleavingIter error handling

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -2211,7 +2211,13 @@ func (i *Iterator) RangeKeys() []RangeKeyData {
 // Valid returns true if the iterator is positioned at a valid key/value pair
 // and false otherwise.
 func (i *Iterator) Valid() bool {
-	return i.iterValidityState == IterValid && !i.requiresReposition
+	valid := i.iterValidityState == IterValid && !i.requiresReposition
+	if invariants.Enabled {
+		if err := i.Error(); valid && err != nil {
+			panic(errors.WithSecondaryError(errors.AssertionFailedf("pebble: iterator is valid with non-nil Error"), err))
+		}
+	}
+	return valid
 }
 
 // Error returns any accumulated error.


### PR DESCRIPTION
Previously, the InterleavingIter could violate the InternalIterator contract when an error is encountered. If one of its two child iterators encountered an error and returned a nil KV pair, the iterator could yield a non-nil KV to the caller. This commit updates the interleaving iterator error handling to accumulate any encountered errors on a field and always yield nil.

This bug was surfaced by a new 'invariants' tag assertion in Valid, asserting that Error() returns nil if the iterator is valid. With this invariants tag, existing tests surface the assertion failure. Additional test coverage will come with #1115.