### PR TITLE
crl-release-23.2: internal/keyspan: fix InterleavingIter error handling

### DIFF
--- a/internal/keyspan/truncate_test.go
+++ b/internal/keyspan/truncate_test.go
@@ -5,9 +5,7 @@
 package keyspan
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"strings"
 	"testing"
 
@@ -90,60 +88,4 @@ func TestTruncate(t *testing.T) {
 			return fmt.Sprintf("unknown command: %s", d.Cmd)
 		}
 	})
-}
-
-// runIterCmd evaluates a datadriven command controlling an internal
-// keyspan.FragmentIterator, returning a string with the results of the iterator
-// operations.
-func runIterCmd(t *testing.T, td *datadriven.TestData, iter FragmentIterator) string {
-	var buf bytes.Buffer
-	lines := strings.Split(strings.TrimSpace(td.Input), "\n")
-	for i, line := range lines {
-		if i > 0 {
-			fmt.Fprintln(&buf)
-		}
-		line = strings.TrimSpace(line)
-		i := strings.IndexByte(line, '#')
-		iterCmd := line
-		if i > 0 {
-			iterCmd = string(line[:i])
-		}
-		dataDrivenRunIterOp(&buf, iter, iterCmd)
-	}
-	return buf.String()
-}
-
-func dataDrivenRunIterOp(w io.Writer, it FragmentIterator, op string) {
-	fields := strings.FieldsFunc(op, func(r rune) bool { return iterDelim[r] })
-	var s *Span
-	switch strings.ToLower(fields[0]) {
-	case "first":
-		s = it.First()
-	case "last":
-		s = it.Last()
-	case "seekge", "seek-ge":
-		if len(fields) == 1 {
-			panic(fmt.Sprintf("unable to parse iter op %q", op))
-		}
-		s = it.SeekGE([]byte(fields[1]))
-	case "seeklt", "seek-lt":
-		if len(fields) == 1 {
-			panic(fmt.Sprintf("unable to parse iter op %q", op))
-		}
-		s = it.SeekLT([]byte(fields[1]))
-	case "next":
-		s = it.Next()
-	case "prev":
-		s = it.Prev()
-	default:
-		panic(fmt.Sprintf("unrecognized iter op %q", fields[0]))
-	}
-	if s == nil {
-		fmt.Fprint(w, "<nil>")
-		if err := it.Error(); err != nil {
-			fmt.Fprintf(w, " err=<%s>", it.Error())
-		}
-		return
-	}
-	fmt.Fprint(w, s)
 }

--- a/iterator.go
+++ b/iterator.go
@@ -2209,7 +2209,13 @@ func (i *Iterator) RangeKeys() []RangeKeyData {
 // Valid returns true if the iterator is positioned at a valid key/value pair
 // and false otherwise.
 func (i *Iterator) Valid() bool {
-	return i.iterValidityState == IterValid && !i.requiresReposition
+	valid := i.iterValidityState == IterValid && !i.requiresReposition
+	if invariants.Enabled {
+		if err := i.Error(); valid && err != nil {
+			panic(errors.WithSecondaryError(errors.AssertionFailedf("pebble: iterator is valid with non-nil Error"), err))
+		}
+	}
+	return valid
 }
 
 // Error returns any accumulated error.


### PR DESCRIPTION
This is a 23.2 backport of #3021 and #3035.

----

Previously, the InterleavingIter could violate the InternalIterator contract when an error is encountered. If one of its two child iterators encountered an error and returned a nil KV pair, the iterator could yield a non-nil KV to the caller. This commit updates the interleaving iterator error handling to accumulate any encountered errors on a field and always yield nil.

This bug was surfaced by a new 'invariants' tag assertion in Valid, asserting that Error() returns nil if the iterator is valid. With this invariants tag, existing tests surface the assertion failure. Additional test coverage will come with #1115.