### PR TITLE
metamorphic: allow snapshots in multi-instance, remove `dbObjID`

### DIFF
--- a/metamorphic/config.go
+++ b/metamorphic/config.go
@@ -172,13 +172,10 @@ func defaultConfig() config {
 func multiInstanceConfig() config {
 	cfg := defaultConfig()
 	cfg.ops[replicate] = 5
+	// Single deletes and merges are disabled in multi-instance mode, as
+	// replicateOp doesn't support them.
 	cfg.ops[writerSingleDelete] = 0
 	cfg.ops[writerMerge] = 0
-	// TODO(bilal): The disabled operations below should also be supported
-	// in the two-instance test, once they're updated to work in multi-instance
-	// mode.
-	cfg.ops[newSnapshot] = 0
-	cfg.ops[snapshotClose] = 0
 	return cfg
 }
 

--- a/metamorphic/generator_test.go
+++ b/metamorphic/generator_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestGenerator(t *testing.T) {
 	rng := randvar.NewRand()
-	g := newGenerator(rng, defaultConfig(), newKeyManager())
+	g := newGenerator(rng, defaultConfig(), newKeyManager(1 /* numInstances */))
 
 	g.newBatch()
 	g.newBatch()
@@ -63,7 +63,7 @@ func TestGenerator(t *testing.T) {
 		t.Logf("\n%s", g)
 	}
 
-	g = newGenerator(rng, defaultConfig(), newKeyManager())
+	g = newGenerator(rng, defaultConfig(), newKeyManager(1 /* numInstances */))
 
 	g.newSnapshot()
 	g.newSnapshot()
@@ -96,7 +96,7 @@ func TestGenerator(t *testing.T) {
 		t.Logf("\n%s", g)
 	}
 
-	g = newGenerator(rng, defaultConfig(), newKeyManager())
+	g = newGenerator(rng, defaultConfig(), newKeyManager(1 /* numInstances */))
 
 	g.newIndexedBatch()
 	g.newIndexedBatch()
@@ -133,7 +133,7 @@ func TestGeneratorRandom(t *testing.T) {
 	generateFromSeed := func(cfg config) string {
 		rng := rand.New(rand.NewSource(seed))
 		count := ops.Uint64(rng)
-		return formatOps(generate(rng, count, cfg, newKeyManager()))
+		return formatOps(generate(rng, count, cfg, newKeyManager(cfg.numInstances)))
 	}
 
 	for i := range cfgs {
@@ -170,7 +170,7 @@ func TestGeneratorRandom(t *testing.T) {
 
 func TestGenerateRandKeyToReadInRange(t *testing.T) {
 	rng := randvar.NewRand()
-	g := newGenerator(rng, defaultConfig(), newKeyManager())
+	g := newGenerator(rng, defaultConfig(), newKeyManager(1 /* numInstances */))
 	// Seed 100 initial keys.
 	for i := 0; i < 100; i++ {
 		_ = g.randKeyToWrite(1.0)
@@ -199,7 +199,7 @@ func TestGenerateRandKeyToReadInRange(t *testing.T) {
 
 func TestGenerateDisjointKeyRanges(t *testing.T) {
 	rng := randvar.NewRand()
-	g := newGenerator(rng, defaultConfig(), newKeyManager())
+	g := newGenerator(rng, defaultConfig(), newKeyManager(1 /* numInstances */))
 
 	for i := 0; i < 10; i++ {
 		keyRanges := g.generateDisjointKeyRanges(5)

--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -166,7 +166,7 @@ func RunAndCompare(t *testing.T, rootDir string, rOpts ...RunOption) {
 
 	// Generate a new set of random ops, writing them to <dir>/ops. These will be
 	// read by the child processes when performing a test run.
-	km := newKeyManager()
+	km := newKeyManager(runOpts.numInstances)
 	cfg := presetConfigs[rng.Intn(len(presetConfigs))]
 	if runOpts.previousOpsPath != "" {
 		// During cross-version testing, we load keys from an `ops` file

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -157,7 +157,7 @@ func TestBlockPropertiesParse(t *testing.T) {
 	metaDir := t.TempDir()
 
 	rng := rand.New(rand.NewSource(fixedSeed))
-	ops := generate(rng, numOps, presetConfigs[0], newKeyManager())
+	ops := generate(rng, numOps, presetConfigs[0], newKeyManager(1 /* numInstances */))
 	opsPath := filepath.Join(metaDir, "ops")
 	formattedOps := formatOps(ops)
 	require.NoError(t, os.WriteFile(opsPath, []byte(formattedOps), 0644))

--- a/metamorphic/parser.go
+++ b/metamorphic/parser.go
@@ -46,7 +46,7 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	case *applyOp:
 		return &t.writerID, nil, []interface{}{&t.batchID}
 	case *checkpointOp:
-		return nil, nil, []interface{}{&t.spans}
+		return &t.dbID, nil, []interface{}{&t.spans}
 	case *closeOp:
 		return &t.objID, nil, nil
 	case *compactOp:
@@ -84,7 +84,7 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	case *newIterUsingCloneOp:
 		return &t.existingIterID, &t.iterID, []interface{}{&t.refreshBatch, &t.lower, &t.upper, &t.keyTypes, &t.filterMin, &t.filterMax, &t.useL6Filters, &t.maskSuffix}
 	case *newSnapshotOp:
-		return nil, &t.snapID, []interface{}{&t.bounds}
+		return &t.dbID, &t.snapID, []interface{}{&t.bounds}
 	case *iterNextOp:
 		return &t.iterID, nil, []interface{}{&t.limit}
 	case *iterNextPrefixOp:
@@ -506,6 +506,8 @@ func computeDerivedFields(ops []op) {
 	objToDB := make(map[objID]objID)
 	for i := range ops {
 		switch v := ops[i].(type) {
+		case *newSnapshotOp:
+			objToDB[v.snapID] = v.dbID
 		case *newIterOp:
 			iterToReader[v.iterID] = v.readerID
 			dbReaderID := v.readerID
@@ -513,9 +515,7 @@ func computeDerivedFields(ops []op) {
 				dbReaderID = objToDB[dbReaderID]
 			}
 			objToDB[v.iterID] = dbReaderID
-			if v.readerID.tag() == batchTag {
-				v.derivedDBID = dbReaderID
-			}
+			v.derivedDBID = dbReaderID
 		case *newIterUsingCloneOp:
 			v.derivedReaderID = iterToReader[v.existingIterID]
 			iterToReader[v.iterID] = v.derivedReaderID
@@ -549,16 +549,11 @@ func computeDerivedFields(ops []op) {
 		case *getOp:
 			if derivedDBID, ok := objToDB[v.readerID]; ok {
 				v.derivedDBID = derivedDBID
-			} else if v.readerID.tag() == snapTag {
-				// TODO(bilal): This is legacy behaviour as snapshots aren't supported in
-				// two-instance mode yet. Track snapshots in g.objDB and objToDB and remove this
-				// conditional.
-				v.derivedDBID = dbObjID
 			}
 		case *batchCommitOp:
 			v.dbID = objToDB[v.batchID]
 		case *closeOp:
-			if derivedDBID, ok := objToDB[v.objID]; ok {
+			if derivedDBID, ok := objToDB[v.objID]; ok && v.objID.tag() != dbTag {
 				v.derivedDBID = derivedDBID
 			}
 		case *ingestOp:

--- a/metamorphic/parser_test.go
+++ b/metamorphic/parser_test.go
@@ -37,7 +37,7 @@ func TestParserRandom(t *testing.T) {
 				cfg = multiInstanceConfig()
 				cfg.numInstances = 2
 			}
-			ops := generate(randvar.NewRand(), 10000, cfg, newKeyManager())
+			ops := generate(randvar.NewRand(), 10000, cfg, newKeyManager(cfg.numInstances))
 			src := formatOps(ops)
 
 			parsedOps, err := parse([]byte(src))


### PR DESCRIPTION
This change deprecates and removes `generator.db` in the metamorphic package as it's duplicated by the `dbs` slice that was added to support multi-instance mode. All uses of `dbObjID` outside of tests are also updated to support multi-instance mode, and rely on deriving db IDs or having them passed-in instead of assuming one.

Snapshot operations are also updated to track the underlying DB IDs, and are now re-enabled in multi-instance mode albeit with some limitations that will be addressed in #2885.