### PR TITLE
internal/dsl: new package

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2913,7 +2913,7 @@ func TestCompactionErrorCleanup(t *testing.T) {
 				if initialSetupDone {
 					tablesCreated = append(tablesCreated, info.FileNum)
 					if len(tablesCreated) >= 2 {
-						ii.SetIndex(0)
+						ii.Store(0)
 					}
 				}
 			},

--- a/data_test.go
+++ b/data_test.go
@@ -1465,7 +1465,7 @@ func parseDBOptionsArgs(opts *Options, args []datadriven.CmdArg) error {
 		case "inject-errors":
 			injs := make([]errorfs.Injector, len(cmdArg.Vals))
 			for i := 0; i < len(cmdArg.Vals); i++ {
-				inj, err := errorfs.ParseInjectorFromDSL(cmdArg.Vals[i])
+				inj, err := errorfs.ParseDSL(cmdArg.Vals[i])
 				if err != nil {
 					return err
 				}

--- a/error_test.go
+++ b/error_test.go
@@ -210,7 +210,7 @@ func TestRequireReadError(t *testing.T) {
 		}
 
 		// Now perform foreground ops with error injection enabled.
-		ii.SetIndex(index)
+		ii.Store(index)
 		iter, _ := d.NewIter(nil)
 		if err := iter.Error(); err != nil {
 			return err
@@ -237,7 +237,7 @@ func TestRequireReadError(t *testing.T) {
 		// Reaching here implies all read operations succeeded. This
 		// should only happen when we reached a large enough index at
 		// which `errorfs.FS` did not return any error.
-		if i := ii.Index(); i < 0 {
+		if i := ii.Load(); i < 0 {
 			t.Errorf("FS error injected %d ops ago went unreported", -i)
 		}
 		if numFound != 2 {

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -2212,7 +2212,7 @@ func TestIngestError(t *testing.T) {
 				}
 			}()
 
-			ii.SetIndex(i)
+			ii.Store(i)
 			err1 := d.Ingest([]string{"ext0"})
 			err2 := d.Ingest([]string{"ext1"})
 			err := firstError(err1, err2)
@@ -2226,7 +2226,7 @@ func TestIngestError(t *testing.T) {
 
 		// If the injector's index is non-negative, the i-th filesystem
 		// operation was never executed.
-		if ii.Index() >= 0 {
+		if ii.Load() >= 0 {
 			break
 		}
 	}

--- a/internal/dsl/dsl.go
+++ b/internal/dsl/dsl.go
@@ -1,0 +1,160 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// Package dsl provides facilities for parsing lisp-like domain-specific
+// languages (DSL).
+package dsl
+
+import (
+	"fmt"
+	"go/scanner"
+	"go/token"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// NewParser constructs a new Parser of a lisp-like DSL.
+func NewParser[T any]() *Parser[T] {
+	p := new(Parser[T])
+	p.constants = make(map[string]func() T)
+	p.funcs = make(map[string]func(*Parser[T], *Scanner) T)
+	return p
+}
+
+// NewPredicateParser constructs a new Parser of a Lisp-like DSL, where the
+// resulting type implements Predicate[E]. NewPredicateParser predefines a few
+// useful functions: Not, And, Or, OnIndex.
+func NewPredicateParser[E any]() *Parser[Predicate[E]] {
+	p := NewParser[Predicate[E]]()
+	p.DefineFunc("Not", parseNot[E])
+	p.DefineFunc("And", parseAnd[E])
+	p.DefineFunc("Or", parseOr[E])
+	p.DefineFunc("OnIndex", parseOnIndex[E])
+	return p
+}
+
+// A Parser holds the rules and logic for parsing a DSL.
+type Parser[T any] struct {
+	constants map[string]func() T
+	funcs     map[string]func(*Parser[T], *Scanner) T
+}
+
+// DefineConstant adds a new constant to the Parser's supported DSL. Whenever
+// the provided identifier is used within a constant context, the provided
+// closure is invoked to instantiate an appropriate AST value.
+func (p *Parser[T]) DefineConstant(identifier string, instantiate func() T) {
+	p.constants[identifier] = instantiate
+}
+
+// DefineFunc adds a new func to the Parser's supported DSL. Whenever the
+// provided identifier is used within a function invocation context, the
+// provided closure is invoked to instantiate an appropriate AST value.
+func (p *Parser[T]) DefineFunc(identifier string, parseFunc func(*Parser[T], *Scanner) T) {
+	p.funcs[identifier] = parseFunc
+}
+
+// Parse parses the provided input string.
+func (p *Parser[T]) Parse(d string) (ret T, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			var ok bool
+			err, ok = r.(error)
+			if !ok {
+				panic(r)
+			}
+		}
+	}()
+
+	fset := token.NewFileSet()
+	file := fset.AddFile("", -1, len(d))
+	var s Scanner
+	s.Init(file, []byte(strings.TrimSpace(d)), nil /* no error handler */, 0)
+	tok := s.Scan()
+	ret = p.ParseFromPos(&s, tok)
+	tok = s.Scan()
+	if tok.Kind == token.SEMICOLON {
+		tok = s.Scan()
+	}
+	assertTok(tok, token.EOF)
+	return ret, err
+}
+
+// ParseFromPos parses from the provided current position and associated
+// scanner. If the parser fails to parse, it panics. This function is intended
+// to be used when composing Parsers of various types.
+func (p *Parser[T]) ParseFromPos(s *Scanner, tok Token) T {
+	switch tok.Kind {
+	case token.IDENT:
+		// A constant without any parens, eg. `Reads`.
+		p, ok := p.constants[tok.Lit]
+		if !ok {
+			panic(errors.Errorf("dsl: unknown constant %q", tok.Lit))
+		}
+		return p()
+	case token.LPAREN:
+		// Otherwise it's an expression, eg: (OnIndex 1)
+		tok = s.Consume(token.IDENT)
+		fp, ok := p.funcs[tok.Lit]
+		if !ok {
+			panic(errors.Errorf("dsl: unknown func %q", tok.Lit))
+		}
+		return fp(p, s)
+	default:
+		panic(errors.Errorf("dsl: unexpected token %s; expected IDENT or LPAREN", tok.String()))
+	}
+}
+
+// A Scanner holds the scanner's internal state while processing a given text.
+type Scanner struct {
+	scanner.Scanner
+}
+
+// Scan scans the next token and returns it.
+func (s *Scanner) Scan() Token {
+	pos, tok, lit := s.Scanner.Scan()
+	return Token{pos, tok, lit}
+}
+
+// Consume scans the next token. If the token is not of the provided token, it
+// panics. It returns the token itself.
+func (s *Scanner) Consume(expect token.Token) Token {
+	t := s.Scan()
+	assertTok(t, expect)
+	return t
+}
+
+// ConsumeString scans the next token. It panics if the next token is not a
+// string, or if unable to unquote the string. It returns the unquoted string
+// contents.
+func (s *Scanner) ConsumeString() string {
+	lit := s.Consume(token.STRING).Lit
+	str, err := strconv.Unquote(lit)
+	if err != nil {
+		panic(errors.Newf("dsl: unquoting %q: %v", lit, err))
+	}
+	return str
+}
+
+// Token is a lexical token scanned from an input text.
+type Token struct {
+	pos  token.Pos
+	Kind token.Token
+	Lit  string
+}
+
+// String implements fmt.Stringer.
+func (t *Token) String() string {
+	if t.Lit != "" {
+		return fmt.Sprintf("(%s, %q) at pos %v", t.Kind, t.Lit, t.pos)
+	}
+	return fmt.Sprintf("%s at pos %v", t.Kind, t.pos)
+}
+
+func assertTok(tok Token, expect token.Token) {
+	if tok.Kind != expect {
+		panic(errors.Errorf("dsl: unexpected token %s; expected %s", tok.String(), expect))
+	}
+}

--- a/internal/dsl/predicates.go
+++ b/internal/dsl/predicates.go
@@ -1,0 +1,136 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package dsl
+
+import (
+	"fmt"
+	"go/token"
+	"strconv"
+	"strings"
+	"sync/atomic"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Predicate encodes conditional logic that yields a boolean.
+type Predicate[E any] interface {
+	Evaluate(E) bool
+	String() string
+}
+
+// Not returns a Predicate that negates the provided predicate.
+func Not[E any](p Predicate[E]) Predicate[E] { return not[E]{Predicate: p} }
+
+// And returns a Predicate that evaluates to true if all its operands evaluate
+// to true.
+func And[E any](preds ...Predicate[E]) Predicate[E] { return and[E](preds) }
+
+// Or returns a Predicate that evaluates to true if any of its operands evaluate
+// true.
+func Or[E any](preds ...Predicate[E]) Predicate[E] { return or[E](preds) }
+
+// OnIndex returns a Predicate that evaluates to true on its N-th call.
+func OnIndex[E any](n int32) *Index[E] {
+	p := new(Index[E])
+	p.Int32.Store(n)
+	return p
+}
+
+// Index is a Predicate that evaluates to true only on its N-th invocation.
+type Index[E any] struct {
+	atomic.Int32
+}
+
+// String implements fmt.Stringer.
+func (p *Index[E]) String() string {
+	return fmt.Sprintf("(OnIndex %d)", p.Int32.Load())
+}
+
+// Evaluate implements Predicate.
+func (p *Index[E]) Evaluate(E) bool { return p.Int32.Add(-1) == -1 }
+
+type not[E any] struct {
+	Predicate[E]
+}
+
+func (p not[E]) String() string    { return fmt.Sprintf("(Not %s)", p.Predicate.String()) }
+func (p not[E]) Evaluate(e E) bool { return !p.Predicate.Evaluate(e) }
+
+type and[E any] []Predicate[E]
+
+func (p and[E]) String() string {
+	var sb strings.Builder
+	sb.WriteString("(And")
+	for i := 0; i < len(p); i++ {
+		sb.WriteRune(' ')
+		sb.WriteString(p[i].String())
+	}
+	sb.WriteRune(')')
+	return sb.String()
+}
+
+func (p and[E]) Evaluate(e E) bool {
+	ok := true
+	for i := range p {
+		ok = ok && p[i].Evaluate(e)
+	}
+	return ok
+}
+
+type or[E any] []Predicate[E]
+
+func (p or[E]) String() string {
+	var sb strings.Builder
+	sb.WriteString("(Or")
+	for i := 0; i < len(p); i++ {
+		sb.WriteRune(' ')
+		sb.WriteString(p[i].String())
+	}
+	sb.WriteRune(')')
+	return sb.String()
+}
+
+func (p or[E]) Evaluate(e E) bool {
+	ok := false
+	for i := range p {
+		ok = ok || p[i].Evaluate(e)
+	}
+	return ok
+}
+
+func parseNot[E any](p *Parser[Predicate[E]], s *Scanner) Predicate[E] {
+	preds := parseVariadicPredicate(p, s)
+	if len(preds) != 1 {
+		panic(errors.Newf("dsl: not accepts exactly 1 argument, given %d", len(preds)))
+	}
+	return not[E]{Predicate: preds[0]}
+}
+
+func parseAnd[E any](p *Parser[Predicate[E]], s *Scanner) Predicate[E] {
+	return And[E](parseVariadicPredicate[E](p, s)...)
+}
+
+func parseOr[E any](p *Parser[Predicate[E]], s *Scanner) Predicate[E] {
+	return Or[E](parseVariadicPredicate[E](p, s)...)
+}
+
+func parseOnIndex[E any](p *Parser[Predicate[E]], s *Scanner) Predicate[E] {
+	i, err := strconv.ParseInt(s.Consume(token.INT).Lit, 10, 32)
+	if err != nil {
+		panic(err)
+	}
+	s.Consume(token.RPAREN)
+	return OnIndex[E](int32(i))
+}
+
+func parseVariadicPredicate[E any](p *Parser[Predicate[E]], s *Scanner) (ret []Predicate[E]) {
+	tok := s.Scan()
+	for tok.Kind == token.LPAREN || tok.Kind == token.IDENT {
+		ret = append(ret, p.ParseFromPos(s, tok))
+		tok = s.Scan()
+	}
+	assertTok(tok, token.RPAREN)
+	return ret
+}

--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/dsl"
 	"github.com/cockroachdb/pebble/internal/randvar"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/vfs"
@@ -473,7 +474,7 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 	// Wrap the filesystem with one that will inject errors into read
 	// operations with *errorRate probability.
 	opts.FS = errorfs.Wrap(opts.FS, errorfs.ErrInjected.If(
-		errorfs.And(errorfs.Reads, errorfs.Randomly(runOpts.errorRate, int64(seed))),
+		dsl.And[errorfs.Op](errorfs.Reads, errorfs.Randomly(runOpts.errorRate, int64(seed))),
 	))
 
 	if opts.WALDir != "" {

--- a/vfs/errorfs/errorfs_test.go
+++ b/vfs/errorfs/errorfs_test.go
@@ -19,7 +19,7 @@ func TestErrorFS(t *testing.T) {
 		switch td.Cmd {
 		case "parse-dsl":
 			for _, l := range strings.Split(strings.TrimSpace(td.Input), "\n") {
-				inj, err := ParseInjectorFromDSL(l)
+				inj, err := ParseDSL(l)
 				if err != nil {
 					fmt.Fprintf(&sb, "parsing err: %s\n", err)
 				} else {

--- a/vfs/errorfs/testdata/errorfs
+++ b/vfs/errorfs/testdata/errorfs
@@ -33,17 +33,17 @@ ErrInjected()
 (ErrInjected (OnIndex foo))
 (ErrInjected (OnIndex 9223372036854775807))
 ----
-parsing err: errorfs: unknown error "errInjected"
-parsing err: errorfs: unexpected token ( ("") at char 12; expected EOF
-parsing err: errorfs: unexpected token IDENT ("foo") at char 25; expected STRING
-parsing err: errorfs: unknown error "alwoes"
-parsing err: errorfs: unexpected token STRING ("\"\"") at char 37; expected )
-parsing err: errorfs: unknown predicate constant "PathMatch"
-parsing err: errorfs: unexpected token IDENT ("ErrInjected") at char 23; expected INT
-parsing err: errorfs: unknown error "Or"
-parsing err: errorfs: unknown error "And"
-parsing err: errorfs: unknown error "Or"
-parsing err: errorfs: unexpected token IDENT ("foo") at char 23; expected INT
+parsing err: dsl: unknown constant "errInjected"
+parsing err: dsl: unexpected token ( at pos 12; expected EOF
+parsing err: dsl: unexpected token (IDENT, "foo") at pos 25; expected STRING
+parsing err: dsl: unknown func "alwoes"
+parsing err: dsl: unexpected token (STRING, "\"\"") at pos 37; expected )
+parsing err: dsl: unknown constant "PathMatch"
+parsing err: dsl: unexpected token (IDENT, "ErrInjected") at pos 23; expected INT
+parsing err: dsl: unknown func "Or"
+parsing err: dsl: unknown func "And"
+parsing err: dsl: unknown func "Or"
+parsing err: dsl: unexpected token (IDENT, "foo") at pos 23; expected INT
 parsing err: strconv.ParseInt: parsing "9223372036854775807": value out of range
 
 parse-dsl
@@ -51,8 +51,8 @@ parse-dsl
 (ErrInjected (OpFileReadAt foo))
 (ErrInjected (OpFileReadAt 1052363))
 ----
-parsing err: errorfs: unexpected token IDENT ("_") at char 28; expected INT
-parsing err: errorfs: unexpected token IDENT ("foo") at char 28; expected INT
+parsing err: dsl: unexpected token (IDENT, "_") at pos 28; expected INT
+parsing err: dsl: unexpected token (IDENT, "foo") at pos 28; expected INT
 (ErrInjected (FileReadAt 1052363))
 
 parse-dsl
@@ -65,11 +65,11 @@ parse-dsl
 (ErrInjected (And (PathMatch "*.sst") (Randomly 0.05 185957252)))
 (ErrInjected (And (PathMatch "*.sst") (Randomly 0.05)))
 ----
-parsing err: errorfs: unexpected token INT ("0") at char 24; expected FLOAT
+parsing err: dsl: unexpected token (INT, "0") at pos 24; expected FLOAT
 (ErrInjected (Randomly 0.10))
 (ErrInjected (Randomly 0.20 18520850252))
 parsing err: errorfs: Randomly proability p must be within p ≤ 1.0
-parsing err: errorfs: unexpected token - ("") at char 24; expected FLOAT
-parsing err: errorfs: unexpected token INT ("18520850252") at char 24; expected FLOAT
+parsing err: dsl: unexpected token - at pos 24; expected FLOAT
+parsing err: dsl: unexpected token (INT, "18520850252") at pos 24; expected FLOAT
 (ErrInjected (And (PathMatch "*.sst") (Randomly 0.05 185957252)))
 (ErrInjected (And (PathMatch "*.sst") (Randomly 0.05)))


### PR DESCRIPTION
Extract the parsing logic of vfs/errorfs's DSL into a separate package providing generic interfaces for parsing lisp-esque DSLs.

Some error pathways are difficult to test only through filesystem-injected errors. This new package prepares for a similar DSL for errors injected by a special InternalIterator that wraps other internal iterators.