### PR TITLE
db: move size check for remote files to table stats job

### DIFF
--- a/open.go
+++ b/open.go
@@ -1140,13 +1140,12 @@ func checkConsistency(v *manifest.Version, dirname string, objProvider objstorag
 			dedup[backingState.DiskFileNum] = struct{}{}
 			fileNum := backingState.DiskFileNum
 			fileSize := backingState.Size
-			// We allow foreign objects to have a mismatch between sizes. This is
-			// because we might skew the backing size stored by our objprovider
-			// to prevent us from over-prioritizing this file for compaction.
+			// We skip over remote objects; those are instead checked asynchronously
+			// by the table stats loading job.
 			meta, err := objProvider.Lookup(base.FileTypeTable, fileNum)
 			var size int64
 			if err == nil {
-				if objProvider.IsSharedForeign(meta) {
+				if meta.IsRemote() {
 					continue
 				}
 				size, err = objProvider.Size(meta)

--- a/table_stats.go
+++ b/table_stats.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
@@ -214,6 +215,7 @@ func (d *DB) scanReadStateTableStats(
 ) ([]collectedStats, []deleteCompactionHint, bool) {
 	moreRemain := false
 	var hints []deleteCompactionHint
+	sizesChecked := make(map[base.DiskFileNum]struct{})
 	for l, levelMetadata := range rs.current.Levels {
 		iter := levelMetadata.Iter()
 		for f := iter.First(); f != nil; f = iter.Next() {
@@ -234,6 +236,41 @@ func (d *DB) scanReadStateTableStats(
 			if len(fill) == cap(fill) {
 				moreRemain = true
 				return fill, hints, moreRemain
+			}
+
+			// If the file is remote and not SharedForeign, we should check if its size
+			// matches. This is because checkConsistency skips over remote files.
+			// SharedForeign files are skipped as their sizes are allowed to have a
+			// mismatch; the size stored in the FileBacking is just the part of the
+			// file that is referenced by this Pebble instance, not the size of the
+			// whole object.
+			objMeta, err := d.objProvider.Lookup(fileTypeTable, f.FileBacking.DiskFileNum)
+			if err != nil {
+				// Set `moreRemain` so we'll try again.
+				moreRemain = true
+				d.opts.EventListener.BackgroundError(err)
+				continue
+			}
+			if _, ok := sizesChecked[f.FileBacking.DiskFileNum]; !ok && objMeta.IsRemote() &&
+				!d.objProvider.IsSharedForeign(objMeta) {
+
+				size, err := d.objProvider.Size(objMeta)
+				fileSize := f.FileBacking.Size
+				if err != nil {
+					moreRemain = true
+					d.opts.EventListener.BackgroundError(err)
+					continue
+				}
+				if size != int64(fileSize) {
+					err := errors.Errorf(
+						"during consistency check in loadTableStats: L%d: %s: object size mismatch (%s): %d (provider) != %d (MANIFEST)",
+						errors.Safe(l), f.FileNum, d.objProvider.Path(objMeta),
+						errors.Safe(size), errors.Safe(fileSize))
+					d.opts.EventListener.BackgroundError(err)
+					d.opts.Logger.Fatalf("%s", err)
+				}
+
+				sizesChecked[f.FileBacking.DiskFileNum] = struct{}{}
 			}
 
 			stats, newHints, err := d.loadTableStats(

--- a/testdata/ingest_shared
+++ b/testdata/ingest_shared
@@ -229,9 +229,9 @@ replicate 2 1 a z
 ----
 replicated 3 shared SSTs
 
-switch 1
+restart
 ----
-ok
+ok, note that the active db has been set to 1 (use 'switch' to change)
 
 iter
 first
@@ -625,6 +625,23 @@ lsm
 6:
   000008:[b@5#11,SET-e#11,SET]
   000005:[ff#10,SET-ff#10,SET]
+
+iter
+seek-ge b
+next
+next
+----
+b@5: (foo, .)
+ff: (notdeleted, .)
+.
+
+restart
+----
+ok, note that the active db has been set to 1 (use 'switch' to change)
+
+switch 2
+----
+ok
 
 iter
 seek-ge b


### PR DESCRIPTION
This change moves the Size() check for remote files to the asynchronous table stats loading job instead of the previous synchronous check during Open(). This greatly speeds up the time it takes to load up Pebble and make a node live, if the store had a lot of remote files before the restart.