### PR TITLE
internal/keyspan: test MergingIter error handling

### DIFF
--- a/internal/keyspan/bounded_test.go
+++ b/internal/keyspan/bounded_test.go
@@ -60,7 +60,8 @@ func TestBoundedIter(t *testing.T) {
 			buf.Reset()
 			lower, upper := getBounds(td)
 			iter.SetBounds(lower, upper)
-			return runIterCmd(t, td, &iter)
+			runIterCmd(t, td, &iter, &buf)
+			return buf.String()
 		default:
 			return fmt.Sprintf("unrecognized command %q", td.Cmd)
 		}

--- a/internal/keyspan/datadriven_test.go
+++ b/internal/keyspan/datadriven_test.go
@@ -5,7 +5,6 @@
 package keyspan
 
 import (
-	"bytes"
 	"fmt"
 	"go/token"
 	"io"
@@ -377,14 +376,13 @@ func (p *probeIterator) Close() error {
 }
 
 // runIterCmd evaluates a datadriven command controlling an internal
-// keyspan.FragmentIterator, returning a string with the results of the iterator
-// operations.
-func runIterCmd(t *testing.T, td *datadriven.TestData, iter FragmentIterator) string {
-	var buf bytes.Buffer
+// keyspan.FragmentIterator, writing the results of the iterator operations to
+// the provided writer.
+func runIterCmd(t *testing.T, td *datadriven.TestData, iter FragmentIterator, w io.Writer) {
 	lines := strings.Split(strings.TrimSpace(td.Input), "\n")
 	for i, line := range lines {
 		if i > 0 {
-			fmt.Fprintln(&buf)
+			fmt.Fprintln(w)
 		}
 		line = strings.TrimSpace(line)
 		i := strings.IndexByte(line, '#')
@@ -392,9 +390,8 @@ func runIterCmd(t *testing.T, td *datadriven.TestData, iter FragmentIterator) st
 		if i > 0 {
 			iterCmd = string(line[:i])
 		}
-		runIterOp(&buf, iter, iterCmd)
+		runIterOp(w, iter, iterCmd)
 	}
-	return buf.String()
 }
 
 var iterDelim = map[rune]bool{',': true, ' ': true, '(': true, ')': true, '"': true}

--- a/internal/keyspan/testdata/merging_iter
+++ b/internal/keyspan/testdata/merging_iter
@@ -29,17 +29,7 @@ q-z:{(#14,RANGEKEYSET,@9,mangos)}
 
 # Test snapshot filtering.
 
-define snapshot=12
-a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas)}
-c-d:{(#4,RANGEKEYSET,@3,coconut)}
-e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
-h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)}
-l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
-q-z:{(#14,RANGEKEYSET,@9,mangos)}
-----
-1 levels
-
-iter
+iter snapshot=12
 first
 next
 next
@@ -55,6 +45,40 @@ h-j:{}
 l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
 q-z:{}
 <nil>
+
+# Test error handling on seeks.
+
+iter probes=(0,ErrInjected,(Log "#  inner."))
+first
+last
+seek-ge boo
+seek-lt lemon
+----
+#  inner.First() = nil <err="injected error">
+<nil> err=<injected error>
+#  inner.Last() = nil <err="injected error">
+<nil> err=<injected error>
+#  inner.SeekLT("boo") = nil <err="injected error">
+<nil> err=<injected error>
+#  inner.SeekGE("lemon") = nil <err="injected error">
+<nil> err=<injected error>
+
+# Test error handling on steps.
+
+iter probes=(0,(If (Or OpNext OpPrev) ErrInjected noop),(Log "#  inner."))
+first
+next
+last
+prev
+----
+#  inner.First() = a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas)}
+a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas)}
+#  inner.Next() = nil <err="injected error">
+<nil> err=<injected error>
+#  inner.Last() = q-z:{(#14,RANGEKEYSET,@9,mangos)}
+q-z:{(#14,RANGEKEYSET,@9,mangos)}
+#  inner.Prev() = nil <err="injected error">
+<nil> err=<injected error>
 
 define
 b-d:{#10,RANGEKEYSET,@1,apples}
@@ -325,6 +349,273 @@ e-h:{(#8,RANGEKEYDEL)}
 h-k:{(#5,RANGEKEYDEL)}
 h-k:{(#5,RANGEKEYDEL)}
 h-k:{(#5,RANGEKEYDEL)}
+
+# Test error handling with multiple levels. Inject errors in all operations on
+# the first iterator, and none of the second iterator.
+
+iter probes=(0,ErrInjected,(Log "#  a.")) probes=(1,(Log "#  b."))
+seek-ge a
+seek-ge b
+seek-ge c
+seek-ge d
+seek-ge e
+seek-ge f
+seek-ge g
+seek-ge h
+seek-ge i
+seek-ge j
+seek-ge k
+seek-ge z
+----
+#  a.SeekLT("a") = nil <err="injected error">
+#  b.SeekLT("a") = nil
+<nil> err=<injected error>
+#  a.SeekLT("b") = nil <err="injected error">
+#  b.SeekLT("b") = a-c:{(#3,RANGEKEYUNSET,@1)}
+<nil> err=<injected error>
+#  a.SeekLT("c") = nil <err="injected error">
+#  b.SeekLT("c") = a-c:{(#3,RANGEKEYUNSET,@1)}
+<nil> err=<injected error>
+#  a.SeekLT("d") = nil <err="injected error">
+#  b.SeekLT("d") = a-c:{(#3,RANGEKEYUNSET,@1)}
+<nil> err=<injected error>
+#  a.SeekLT("e") = nil <err="injected error">
+#  b.SeekLT("e") = a-c:{(#3,RANGEKEYUNSET,@1)}
+<nil> err=<injected error>
+#  a.SeekLT("f") = nil <err="injected error">
+#  b.SeekLT("f") = a-c:{(#3,RANGEKEYUNSET,@1)}
+<nil> err=<injected error>
+#  a.SeekLT("g") = nil <err="injected error">
+#  b.SeekLT("g") = a-c:{(#3,RANGEKEYUNSET,@1)}
+<nil> err=<injected error>
+#  a.SeekLT("h") = nil <err="injected error">
+#  b.SeekLT("h") = a-c:{(#3,RANGEKEYUNSET,@1)}
+<nil> err=<injected error>
+#  a.SeekLT("i") = nil <err="injected error">
+#  b.SeekLT("i") = h-k:{(#5,RANGEKEYDEL)}
+<nil> err=<injected error>
+#  a.SeekLT("j") = nil <err="injected error">
+#  b.SeekLT("j") = h-k:{(#5,RANGEKEYDEL)}
+<nil> err=<injected error>
+#  a.SeekLT("k") = nil <err="injected error">
+#  b.SeekLT("k") = h-k:{(#5,RANGEKEYDEL)}
+<nil> err=<injected error>
+#  a.SeekLT("z") = nil <err="injected error">
+#  b.SeekLT("z") = h-k:{(#5,RANGEKEYDEL)}
+<nil> err=<injected error>
+
+# Test the same as above, but with errors injected on the second iterator.
+
+iter probes=(0,(Log "#  a.")) probes=(1,ErrInjected,(Log "#  b."))
+seek-ge a
+seek-ge b
+seek-ge c
+seek-ge d
+seek-ge e
+seek-ge f
+seek-ge g
+seek-ge h
+seek-ge i
+seek-ge j
+seek-ge k
+seek-ge z
+----
+#  a.SeekLT("a") = nil
+#  b.SeekLT("a") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekLT("b") = nil
+#  b.SeekLT("b") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekLT("c") = b-d:{(#10,RANGEKEYSET,@1,apples)}
+#  b.SeekLT("c") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekLT("d") = b-d:{(#10,RANGEKEYSET,@1,apples)}
+#  b.SeekLT("d") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekLT("e") = b-d:{(#10,RANGEKEYSET,@1,apples)}
+#  b.SeekLT("e") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekLT("f") = e-h:{(#8,RANGEKEYDEL)}
+#  b.SeekLT("f") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekLT("g") = e-h:{(#8,RANGEKEYDEL)}
+#  b.SeekLT("g") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekLT("h") = e-h:{(#8,RANGEKEYDEL)}
+#  b.SeekLT("h") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekLT("i") = e-h:{(#8,RANGEKEYDEL)}
+#  b.SeekLT("i") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekLT("j") = e-h:{(#8,RANGEKEYDEL)}
+#  b.SeekLT("j") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekLT("k") = e-h:{(#8,RANGEKEYDEL)}
+#  b.SeekLT("k") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekLT("z") = e-h:{(#8,RANGEKEYDEL)}
+#  b.SeekLT("z") = nil <err="injected error">
+<nil> err=<injected error>
+
+# Test SeekLTs with errors injected on the first iterator.
+
+iter probes=(0,ErrInjected,(Log "#  a.")) probes=(1,(Log "#  b."))
+seek-lt a
+seek-lt b
+seek-lt c
+seek-lt d
+seek-lt e
+seek-lt f
+seek-lt g
+seek-lt h
+seek-lt i
+seek-lt j
+seek-lt k
+seek-lt z
+----
+#  a.SeekGE("a") = nil <err="injected error">
+#  b.SeekGE("a") = a-c:{(#3,RANGEKEYUNSET,@1)}
+<nil> err=<injected error>
+#  a.SeekGE("b") = nil <err="injected error">
+#  b.SeekGE("b") = a-c:{(#3,RANGEKEYUNSET,@1)}
+<nil> err=<injected error>
+#  a.SeekGE("c") = nil <err="injected error">
+#  b.SeekGE("c") = h-k:{(#5,RANGEKEYDEL)}
+<nil> err=<injected error>
+#  a.SeekGE("d") = nil <err="injected error">
+#  b.SeekGE("d") = h-k:{(#5,RANGEKEYDEL)}
+<nil> err=<injected error>
+#  a.SeekGE("e") = nil <err="injected error">
+#  b.SeekGE("e") = h-k:{(#5,RANGEKEYDEL)}
+<nil> err=<injected error>
+#  a.SeekGE("f") = nil <err="injected error">
+#  b.SeekGE("f") = h-k:{(#5,RANGEKEYDEL)}
+<nil> err=<injected error>
+#  a.SeekGE("g") = nil <err="injected error">
+#  b.SeekGE("g") = h-k:{(#5,RANGEKEYDEL)}
+<nil> err=<injected error>
+#  a.SeekGE("h") = nil <err="injected error">
+#  b.SeekGE("h") = h-k:{(#5,RANGEKEYDEL)}
+<nil> err=<injected error>
+#  a.SeekGE("i") = nil <err="injected error">
+#  b.SeekGE("i") = h-k:{(#5,RANGEKEYDEL)}
+<nil> err=<injected error>
+#  a.SeekGE("j") = nil <err="injected error">
+#  b.SeekGE("j") = h-k:{(#5,RANGEKEYDEL)}
+<nil> err=<injected error>
+#  a.SeekGE("k") = nil <err="injected error">
+#  b.SeekGE("k") = nil
+<nil> err=<injected error>
+#  a.SeekGE("z") = nil <err="injected error">
+#  b.SeekGE("z") = nil
+<nil> err=<injected error>
+
+# Test SeekLTs with errors injected on the second iterator.
+
+iter probes=(0,(Log "#  a.")) probes=(1,ErrInjected,(Log "#  b."))
+seek-lt a
+seek-lt b
+seek-lt c
+seek-lt d
+seek-lt e
+seek-lt f
+seek-lt g
+seek-lt h
+seek-lt i
+seek-lt j
+seek-lt k
+seek-lt z
+----
+#  a.SeekGE("a") = b-d:{(#10,RANGEKEYSET,@1,apples)}
+#  b.SeekGE("a") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekGE("b") = b-d:{(#10,RANGEKEYSET,@1,apples)}
+#  b.SeekGE("b") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekGE("c") = b-d:{(#10,RANGEKEYSET,@1,apples)}
+#  b.SeekGE("c") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekGE("d") = e-h:{(#8,RANGEKEYDEL)}
+#  b.SeekGE("d") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekGE("e") = e-h:{(#8,RANGEKEYDEL)}
+#  b.SeekGE("e") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekGE("f") = e-h:{(#8,RANGEKEYDEL)}
+#  b.SeekGE("f") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekGE("g") = e-h:{(#8,RANGEKEYDEL)}
+#  b.SeekGE("g") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekGE("h") = nil
+#  b.SeekGE("h") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekGE("i") = nil
+#  b.SeekGE("i") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekGE("j") = nil
+#  b.SeekGE("j") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekGE("k") = nil
+#  b.SeekGE("k") = nil <err="injected error">
+<nil> err=<injected error>
+#  a.SeekGE("z") = nil
+#  b.SeekGE("z") = nil <err="injected error">
+<nil> err=<injected error>
+
+# Test error handling during Next.
+
+iter probes=(0,(If OpNext ErrInjected noop),(Log "#  a.")) probes=(1,(Log "#  b."))
+first
+next
+next
+next
+----
+#  a.First() = b-d:{(#10,RANGEKEYSET,@1,apples)}
+#  b.First() = a-c:{(#3,RANGEKEYUNSET,@1)}
+a-b:{(#3,RANGEKEYUNSET,@1)}
+b-c:{(#10,RANGEKEYSET,@1,apples) (#3,RANGEKEYUNSET,@1)}
+#  b.Next() = h-k:{(#5,RANGEKEYDEL)}
+c-d:{(#10,RANGEKEYSET,@1,apples)}
+#  a.Next() = nil <err="injected error">
+<nil> err=<injected error>
+
+iter probes=(0,(Log "#  a.")) probes=(1,(If OpNext ErrInjected noop),(Log "#  b."))
+first
+next
+next
+----
+#  a.First() = b-d:{(#10,RANGEKEYSET,@1,apples)}
+#  b.First() = a-c:{(#3,RANGEKEYUNSET,@1)}
+a-b:{(#3,RANGEKEYUNSET,@1)}
+b-c:{(#10,RANGEKEYSET,@1,apples) (#3,RANGEKEYUNSET,@1)}
+#  b.Next() = nil <err="injected error">
+<nil> err=<injected error>
+
+# Test error handling during Prev.
+
+iter probes=(0,(If OpPrev ErrInjected noop),(Log "#  a.")) probes=(1,(Log "#  b."))
+last
+prev
+prev
+----
+#  a.Last() = e-h:{(#8,RANGEKEYDEL)}
+#  b.Last() = h-k:{(#5,RANGEKEYDEL)}
+h-k:{(#5,RANGEKEYDEL)}
+#  b.Prev() = a-c:{(#3,RANGEKEYUNSET,@1)}
+e-h:{(#8,RANGEKEYDEL)}
+#  a.Prev() = nil <err="injected error">
+<nil> err=<injected error>
+
+iter probes=(0,(Log "#  a.")) probes=(1,(If OpPrev ErrInjected noop),(Log "#  b."))
+last
+prev
+----
+#  a.Last() = e-h:{(#8,RANGEKEYDEL)}
+#  b.Last() = h-k:{(#5,RANGEKEYDEL)}
+h-k:{(#5,RANGEKEYDEL)}
+#  b.Prev() = nil <err="injected error">
+<nil> err=<injected error>
 
 define
 a-f:{(#5,RANGEKEYDEL) (#4,RANGEKEYDEL)}


### PR DESCRIPTION
Expand the unit tests for the MergingIter to test error-handling cases. These
unit tests did not surface any bugs. Future work will add randomized unit tests
at the top-level pebble.Iterator level.