### PR TITLE
crl-release-23.2: internal/keyspan: fix defragmenting iterator error handling

### DIFF
--- a/internal/dsl/dsl.go
+++ b/internal/dsl/dsl.go
@@ -1,0 +1,160 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// Package dsl provides facilities for parsing lisp-like domain-specific
+// languages (DSL).
+package dsl
+
+import (
+	"fmt"
+	"go/scanner"
+	"go/token"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// NewParser constructs a new Parser of a lisp-like DSL.
+func NewParser[T any]() *Parser[T] {
+	p := new(Parser[T])
+	p.constants = make(map[string]func() T)
+	p.funcs = make(map[string]func(*Parser[T], *Scanner) T)
+	return p
+}
+
+// NewPredicateParser constructs a new Parser of a Lisp-like DSL, where the
+// resulting type implements Predicate[E]. NewPredicateParser predefines a few
+// useful functions: Not, And, Or, OnIndex.
+func NewPredicateParser[E any]() *Parser[Predicate[E]] {
+	p := NewParser[Predicate[E]]()
+	p.DefineFunc("Not", parseNot[E])
+	p.DefineFunc("And", parseAnd[E])
+	p.DefineFunc("Or", parseOr[E])
+	p.DefineFunc("OnIndex", parseOnIndex[E])
+	return p
+}
+
+// A Parser holds the rules and logic for parsing a DSL.
+type Parser[T any] struct {
+	constants map[string]func() T
+	funcs     map[string]func(*Parser[T], *Scanner) T
+}
+
+// DefineConstant adds a new constant to the Parser's supported DSL. Whenever
+// the provided identifier is used within a constant context, the provided
+// closure is invoked to instantiate an appropriate AST value.
+func (p *Parser[T]) DefineConstant(identifier string, instantiate func() T) {
+	p.constants[identifier] = instantiate
+}
+
+// DefineFunc adds a new func to the Parser's supported DSL. Whenever the
+// provided identifier is used within a function invocation context, the
+// provided closure is invoked to instantiate an appropriate AST value.
+func (p *Parser[T]) DefineFunc(identifier string, parseFunc func(*Parser[T], *Scanner) T) {
+	p.funcs[identifier] = parseFunc
+}
+
+// Parse parses the provided input string.
+func (p *Parser[T]) Parse(d string) (ret T, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			var ok bool
+			err, ok = r.(error)
+			if !ok {
+				panic(r)
+			}
+		}
+	}()
+
+	fset := token.NewFileSet()
+	file := fset.AddFile("", -1, len(d))
+	var s Scanner
+	s.Init(file, []byte(strings.TrimSpace(d)), nil /* no error handler */, 0)
+	tok := s.Scan()
+	ret = p.ParseFromPos(&s, tok)
+	tok = s.Scan()
+	if tok.Kind == token.SEMICOLON {
+		tok = s.Scan()
+	}
+	assertTok(tok, token.EOF)
+	return ret, err
+}
+
+// ParseFromPos parses from the provided current position and associated
+// scanner. If the parser fails to parse, it panics. This function is intended
+// to be used when composing Parsers of various types.
+func (p *Parser[T]) ParseFromPos(s *Scanner, tok Token) T {
+	switch tok.Kind {
+	case token.IDENT:
+		// A constant without any parens, eg. `Reads`.
+		p, ok := p.constants[tok.Lit]
+		if !ok {
+			panic(errors.Errorf("dsl: unknown constant %q", tok.Lit))
+		}
+		return p()
+	case token.LPAREN:
+		// Otherwise it's an expression, eg: (OnIndex 1)
+		tok = s.Consume(token.IDENT)
+		fp, ok := p.funcs[tok.Lit]
+		if !ok {
+			panic(errors.Errorf("dsl: unknown func %q", tok.Lit))
+		}
+		return fp(p, s)
+	default:
+		panic(errors.Errorf("dsl: unexpected token %s; expected IDENT or LPAREN", tok.String()))
+	}
+}
+
+// A Scanner holds the scanner's internal state while processing a given text.
+type Scanner struct {
+	scanner.Scanner
+}
+
+// Scan scans the next token and returns it.
+func (s *Scanner) Scan() Token {
+	pos, tok, lit := s.Scanner.Scan()
+	return Token{pos, tok, lit}
+}
+
+// Consume scans the next token. If the token is not of the provided token, it
+// panics. It returns the token itself.
+func (s *Scanner) Consume(expect token.Token) Token {
+	t := s.Scan()
+	assertTok(t, expect)
+	return t
+}
+
+// ConsumeString scans the next token. It panics if the next token is not a
+// string, or if unable to unquote the string. It returns the unquoted string
+// contents.
+func (s *Scanner) ConsumeString() string {
+	lit := s.Consume(token.STRING).Lit
+	str, err := strconv.Unquote(lit)
+	if err != nil {
+		panic(errors.Newf("dsl: unquoting %q: %v", lit, err))
+	}
+	return str
+}
+
+// Token is a lexical token scanned from an input text.
+type Token struct {
+	pos  token.Pos
+	Kind token.Token
+	Lit  string
+}
+
+// String implements fmt.Stringer.
+func (t *Token) String() string {
+	if t.Lit != "" {
+		return fmt.Sprintf("(%s, %q) at pos %v", t.Kind, t.Lit, t.pos)
+	}
+	return fmt.Sprintf("%s at pos %v", t.Kind, t.pos)
+}
+
+func assertTok(tok Token, expect token.Token) {
+	if tok.Kind != expect {
+		panic(errors.Errorf("dsl: unexpected token %s; expected %s", tok.String(), expect))
+	}
+}

--- a/internal/dsl/predicates.go
+++ b/internal/dsl/predicates.go
@@ -1,0 +1,136 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package dsl
+
+import (
+	"fmt"
+	"go/token"
+	"strconv"
+	"strings"
+	"sync/atomic"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Predicate encodes conditional logic that yields a boolean.
+type Predicate[E any] interface {
+	Evaluate(E) bool
+	String() string
+}
+
+// Not returns a Predicate that negates the provided predicate.
+func Not[E any](p Predicate[E]) Predicate[E] { return not[E]{Predicate: p} }
+
+// And returns a Predicate that evaluates to true if all its operands evaluate
+// to true.
+func And[E any](preds ...Predicate[E]) Predicate[E] { return and[E](preds) }
+
+// Or returns a Predicate that evaluates to true if any of its operands evaluate
+// true.
+func Or[E any](preds ...Predicate[E]) Predicate[E] { return or[E](preds) }
+
+// OnIndex returns a Predicate that evaluates to true on its N-th call.
+func OnIndex[E any](n int32) *Index[E] {
+	p := new(Index[E])
+	p.Int32.Store(n)
+	return p
+}
+
+// Index is a Predicate that evaluates to true only on its N-th invocation.
+type Index[E any] struct {
+	atomic.Int32
+}
+
+// String implements fmt.Stringer.
+func (p *Index[E]) String() string {
+	return fmt.Sprintf("(OnIndex %d)", p.Int32.Load())
+}
+
+// Evaluate implements Predicate.
+func (p *Index[E]) Evaluate(E) bool { return p.Int32.Add(-1) == -1 }
+
+type not[E any] struct {
+	Predicate[E]
+}
+
+func (p not[E]) String() string    { return fmt.Sprintf("(Not %s)", p.Predicate.String()) }
+func (p not[E]) Evaluate(e E) bool { return !p.Predicate.Evaluate(e) }
+
+type and[E any] []Predicate[E]
+
+func (p and[E]) String() string {
+	var sb strings.Builder
+	sb.WriteString("(And")
+	for i := 0; i < len(p); i++ {
+		sb.WriteRune(' ')
+		sb.WriteString(p[i].String())
+	}
+	sb.WriteRune(')')
+	return sb.String()
+}
+
+func (p and[E]) Evaluate(e E) bool {
+	ok := true
+	for i := range p {
+		ok = ok && p[i].Evaluate(e)
+	}
+	return ok
+}
+
+type or[E any] []Predicate[E]
+
+func (p or[E]) String() string {
+	var sb strings.Builder
+	sb.WriteString("(Or")
+	for i := 0; i < len(p); i++ {
+		sb.WriteRune(' ')
+		sb.WriteString(p[i].String())
+	}
+	sb.WriteRune(')')
+	return sb.String()
+}
+
+func (p or[E]) Evaluate(e E) bool {
+	ok := false
+	for i := range p {
+		ok = ok || p[i].Evaluate(e)
+	}
+	return ok
+}
+
+func parseNot[E any](p *Parser[Predicate[E]], s *Scanner) Predicate[E] {
+	preds := parseVariadicPredicate(p, s)
+	if len(preds) != 1 {
+		panic(errors.Newf("dsl: not accepts exactly 1 argument, given %d", len(preds)))
+	}
+	return not[E]{Predicate: preds[0]}
+}
+
+func parseAnd[E any](p *Parser[Predicate[E]], s *Scanner) Predicate[E] {
+	return And[E](parseVariadicPredicate[E](p, s)...)
+}
+
+func parseOr[E any](p *Parser[Predicate[E]], s *Scanner) Predicate[E] {
+	return Or[E](parseVariadicPredicate[E](p, s)...)
+}
+
+func parseOnIndex[E any](p *Parser[Predicate[E]], s *Scanner) Predicate[E] {
+	i, err := strconv.ParseInt(s.Consume(token.INT).Lit, 10, 32)
+	if err != nil {
+		panic(err)
+	}
+	s.Consume(token.RPAREN)
+	return OnIndex[E](int32(i))
+}
+
+func parseVariadicPredicate[E any](p *Parser[Predicate[E]], s *Scanner) (ret []Predicate[E]) {
+	tok := s.Scan()
+	for tok.Kind == token.LPAREN || tok.Kind == token.IDENT {
+		ret = append(ret, p.ParseFromPos(s, tok))
+		tok = s.Scan()
+	}
+	assertTok(tok, token.RPAREN)
+	return ret
+}

--- a/internal/keyspan/bounded_test.go
+++ b/internal/keyspan/bounded_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/testkeys"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBoundedIter(t *testing.T) {
@@ -61,34 +60,7 @@ func TestBoundedIter(t *testing.T) {
 			buf.Reset()
 			lower, upper := getBounds(td)
 			iter.SetBounds(lower, upper)
-
-			lines := strings.Split(strings.TrimSpace(td.Input), "\n")
-			for _, line := range lines {
-				line = strings.TrimSpace(line)
-				i := strings.IndexByte(line, ' ')
-				iterCmd := line
-				if i > 0 {
-					iterCmd = string(line[:i])
-				}
-				switch iterCmd {
-				case "first":
-					fmt.Fprintln(&buf, iter.First())
-				case "last":
-					fmt.Fprintln(&buf, iter.Last())
-				case "next":
-					fmt.Fprintln(&buf, iter.Next())
-				case "prev":
-					fmt.Fprintln(&buf, iter.Prev())
-				case "seek-ge":
-					fmt.Fprintln(&buf, iter.SeekGE([]byte(strings.TrimSpace(line[i:]))))
-				case "seek-lt":
-					fmt.Fprintln(&buf, iter.SeekLT([]byte(strings.TrimSpace(line[i:]))))
-				default:
-					return fmt.Sprintf("unrecognized iter command %q", iterCmd)
-				}
-				require.NoError(t, iter.Error())
-			}
-			return strings.TrimSpace(buf.String())
+			return runIterCmd(t, td, &iter)
 		default:
 			return fmt.Sprintf("unrecognized command %q", td.Cmd)
 		}

--- a/internal/keyspan/datadriven_test.go
+++ b/internal/keyspan/datadriven_test.go
@@ -1,0 +1,71 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package keyspan
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+)
+
+// runIterCmd evaluates a datadriven command controlling an internal
+// keyspan.FragmentIterator, returning a string with the results of the iterator
+// operations.
+func runIterCmd(t *testing.T, td *datadriven.TestData, iter FragmentIterator) string {
+	var buf bytes.Buffer
+	lines := strings.Split(strings.TrimSpace(td.Input), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		i := strings.IndexByte(line, '#')
+		iterCmd := line
+		if i > 0 {
+			iterCmd = string(line[:i])
+		}
+		runIterOp(&buf, iter, iterCmd)
+		fmt.Fprintln(&buf)
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+var iterDelim = map[rune]bool{',': true, ' ': true, '(': true, ')': true, '"': true}
+
+func runIterOp(w io.Writer, it FragmentIterator, op string) {
+	fields := strings.FieldsFunc(op, func(r rune) bool { return iterDelim[r] })
+	var s *Span
+	switch strings.ToLower(fields[0]) {
+	case "first":
+		s = it.First()
+	case "last":
+		s = it.Last()
+	case "seekge", "seek-ge":
+		if len(fields) == 1 {
+			panic(fmt.Sprintf("unable to parse iter op %q", op))
+		}
+		s = it.SeekGE([]byte(fields[1]))
+	case "seeklt", "seek-lt":
+		if len(fields) == 1 {
+			panic(fmt.Sprintf("unable to parse iter op %q", op))
+		}
+		s = it.SeekLT([]byte(fields[1]))
+	case "next":
+		s = it.Next()
+	case "prev":
+		s = it.Prev()
+	default:
+		panic(fmt.Sprintf("unrecognized iter op %q", fields[0]))
+	}
+	if s == nil {
+		fmt.Fprint(w, "<nil>")
+		if err := it.Error(); err != nil {
+			fmt.Fprintf(w, " err=<%s>", it.Error())
+		}
+		return
+	}
+	fmt.Fprint(w, s)
+}

--- a/internal/keyspan/datadriven_test.go
+++ b/internal/keyspan/datadriven_test.go
@@ -7,12 +7,374 @@ package keyspan
 import (
 	"bytes"
 	"fmt"
+	"go/token"
 	"io"
+	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/dsl"
 )
+
+// This file contains testing facilities for Spans and FragmentIterators. It's
+// defined here so that it may be used by the keyspan package to test its
+// various FragmentIterator implementations.
+//
+// TODO(jackson): Move keyspan.{Span,Key,FragmentIterator} into internal/base,
+// and then move the testing facilities to an independent package, eg
+// internal/itertest.
+
+// probe defines an interface for probes that may inspect or mutate internal
+// span iterator behavior.
+type probe interface {
+	// probe inspects, and possibly manipulates, iterator operations' results.
+	probe(*probeContext)
+}
+
+func parseProbes(probeDSLs ...string) []probe {
+	probes := make([]probe, len(probeDSLs))
+	var err error
+	for i := range probeDSLs {
+		probes[i], err = probeParser.Parse(probeDSLs[i])
+		if err != nil {
+			panic(err)
+		}
+	}
+	return probes
+}
+
+func attachProbes(iter FragmentIterator, pctx probeContext, probes ...probe) FragmentIterator {
+	if pctx.log == nil {
+		pctx.log = io.Discard
+	}
+	for i := range probes {
+		iter = &probeIterator{
+			iter:     iter,
+			probe:    probes[i],
+			probeCtx: pctx,
+		}
+	}
+	return iter
+}
+
+// probeContext provides the context within which a probe is run. It includes
+// information about the iterator operation in progress.
+type probeContext struct {
+	op
+	log io.Writer
+}
+
+type op struct {
+	Kind    OpKind
+	SeekKey []byte
+	Span    *Span
+	Err     error
+}
+
+// ErrInjected is an error artificially injected for testing.
+var ErrInjected = &errorProbe{name: "ErrInjected", err: errors.New("injected error")}
+
+var probeParser = func() *dsl.Parser[probe] {
+	valuerParser := dsl.NewParser[valuer]()
+	valuerParser.DefineConstant("StartKey", func() valuer { return startKey{} })
+	valuerParser.DefineFunc("Bytes",
+		func(p *dsl.Parser[valuer], s *dsl.Scanner) valuer {
+			v := bytesConstant{bytes: []byte(s.ConsumeString())}
+			s.Consume(token.RPAREN)
+			return v
+		})
+
+	predicateParser := dsl.NewPredicateParser[*probeContext]()
+	predicateParser.DefineFunc("Equal",
+		func(p *dsl.Parser[dsl.Predicate[*probeContext]], s *dsl.Scanner) dsl.Predicate[*probeContext] {
+			eq := equal{
+				valuerParser.ParseFromPos(s, s.Scan()),
+				valuerParser.ParseFromPos(s, s.Scan()),
+			}
+			s.Consume(token.RPAREN)
+			return eq
+		})
+	for i, name := range opNames {
+		opKind := OpKind(i)
+		predicateParser.DefineConstant(name, func() dsl.Predicate[*probeContext] {
+			// An OpKind implements dsl.Predicate[*probeContext].
+			return opKind
+		})
+	}
+	probeParser := dsl.NewParser[probe]()
+	probeParser.DefineConstant("ErrInjected", func() probe { return ErrInjected })
+	probeParser.DefineConstant("noop", func() probe { return noop{} })
+	probeParser.DefineFunc("If",
+		func(p *dsl.Parser[probe], s *dsl.Scanner) probe {
+			probe := ifProbe{
+				predicateParser.ParseFromPos(s, s.Scan()),
+				probeParser.ParseFromPos(s, s.Scan()),
+				probeParser.ParseFromPos(s, s.Scan()),
+			}
+			s.Consume(token.RPAREN)
+			return probe
+		})
+	probeParser.DefineFunc("Return",
+		func(p *dsl.Parser[probe], s *dsl.Scanner) (ret probe) {
+			switch tok := s.Scan(); tok.Kind {
+			case token.STRING:
+				str, err := strconv.Unquote(tok.Lit)
+				if err != nil {
+					panic(err)
+				}
+				span := ParseSpan(str)
+				ret = returnSpan{s: &span}
+			case token.IDENT:
+				switch tok.Lit {
+				case "nil":
+					ret = returnSpan{s: nil}
+				default:
+					panic(errors.Newf("unrecognized return value %q", tok.Lit))
+				}
+			}
+			s.Consume(token.RPAREN)
+			return ret
+		})
+	probeParser.DefineFunc("Log",
+		func(p *dsl.Parser[probe], s *dsl.Scanner) (ret probe) {
+			ret = loggingProbe{prefix: s.ConsumeString()}
+			s.Consume(token.RPAREN)
+			return ret
+		})
+	return probeParser
+}()
+
+// probe implementations
+
+type errorProbe struct {
+	name string
+	err  error
+}
+
+func (p *errorProbe) String() string { return p.name }
+func (p *errorProbe) Error() error   { return p.err }
+func (p *errorProbe) probe(pctx *probeContext) {
+	pctx.op.Err = p.err
+	pctx.op.Span = nil
+}
+
+// ifProbe is a conditional probe. If its predicate evaluates to true, it probes
+// using its Then probe. If its predicate evalutes to false, it probes using its
+// Else probe.
+type ifProbe struct {
+	Predicate dsl.Predicate[*probeContext]
+	Then      probe
+	Else      probe
+}
+
+func (p ifProbe) String() string { return fmt.Sprintf("(If %s %s %s)", p.Predicate, p.Then, p.Else) }
+func (p ifProbe) probe(pctx *probeContext) {
+	if p.Predicate.Evaluate(pctx) {
+		p.Then.probe(pctx)
+	} else {
+		p.Else.probe(pctx)
+	}
+}
+
+type returnSpan struct {
+	s *Span
+}
+
+func (p returnSpan) String() string {
+	if p.s == nil {
+		return "(Return nil)"
+	}
+	return fmt.Sprintf("(Return %q)", p.s.String())
+}
+
+func (p returnSpan) probe(pctx *probeContext) {
+	pctx.op.Span = p.s
+	pctx.op.Err = nil
+}
+
+type noop struct{}
+
+func (noop) String() string           { return "Noop" }
+func (noop) probe(pctx *probeContext) {}
+
+type loggingProbe struct {
+	prefix string
+}
+
+func (lp loggingProbe) String() string { return fmt.Sprintf("(Log %q)", lp.prefix) }
+func (lp loggingProbe) probe(pctx *probeContext) {
+	opStr := strings.TrimPrefix(pctx.op.Kind.String(), "Op")
+	fmt.Fprintf(pctx.log, "%s%s(", lp.prefix, opStr)
+	if pctx.op.SeekKey != nil {
+		fmt.Fprintf(pctx.log, "%q", pctx.op.SeekKey)
+	}
+	fmt.Fprint(pctx.log, ") = ")
+	if pctx.op.Span == nil {
+		fmt.Fprint(pctx.log, "nil")
+		if pctx.op.Err != nil {
+			fmt.Fprintf(pctx.log, " <err=%q>", pctx.op.Err)
+		}
+	} else {
+		fmt.Fprint(pctx.log, pctx.op.Span.String())
+	}
+	fmt.Fprintln(pctx.log)
+}
+
+// dsl.Predicate[*probeContext] implementations.
+
+type equal struct {
+	a, b valuer
+}
+
+func (e equal) String() string { return fmt.Sprintf("(Equal %s %s)", e.a, e.b) }
+func (e equal) Evaluate(pctx *probeContext) bool {
+	return reflect.DeepEqual(e.a.value(pctx), e.b.value(pctx))
+}
+
+// OpKind indicates the type of iterator operation being performed.
+type OpKind int8
+
+const (
+	OpSeekGE OpKind = iota
+	OpSeekLT
+	OpFirst
+	OpLast
+	OpNext
+	OpPrev
+	OpClose
+	numOpKinds
+)
+
+func (o OpKind) String() string                   { return opNames[o] }
+func (o OpKind) Evaluate(pctx *probeContext) bool { return pctx.op.Kind == o }
+
+var opNames = [numOpKinds]string{
+	OpSeekGE: "OpSeekGE",
+	OpSeekLT: "OpSeekLT",
+	OpFirst:  "OpFirst",
+	OpLast:   "OpLast",
+	OpNext:   "OpNext",
+	OpPrev:   "OpPrev",
+	OpClose:  "OpClose",
+}
+
+// valuer implementations
+
+type valuer interface {
+	fmt.Stringer
+	value(pctx *probeContext) any
+}
+
+type bytesConstant struct {
+	bytes []byte
+}
+
+func (b bytesConstant) String() string               { return fmt.Sprintf("%q", string(b.bytes)) }
+func (b bytesConstant) value(pctx *probeContext) any { return b.bytes }
+
+type startKey struct{}
+
+func (s startKey) String() string { return "StartKey" }
+func (s startKey) value(pctx *probeContext) any {
+	if pctx.op.Span == nil {
+		return nil
+	}
+	return pctx.op.Span.Start
+}
+
+type probeIterator struct {
+	iter     FragmentIterator
+	err      error
+	probe    probe
+	probeCtx probeContext
+}
+
+// Assert that probeIterator implements the fragment iterator interface.
+var _ FragmentIterator = (*probeIterator)(nil)
+
+func (p *probeIterator) handleOp(preProbeOp op) *Span {
+	p.probeCtx.op = preProbeOp
+	if preProbeOp.Span == nil && p.iter != nil {
+		p.probeCtx.op.Err = p.iter.Error()
+	}
+
+	p.probe.probe(&p.probeCtx)
+	p.err = p.probeCtx.op.Err
+	return p.probeCtx.op.Span
+}
+
+func (p *probeIterator) SeekGE(key []byte) *Span {
+	op := op{
+		Kind:    OpSeekGE,
+		SeekKey: key,
+	}
+	if p.iter != nil {
+		op.Span = p.iter.SeekGE(key)
+	}
+	return p.handleOp(op)
+}
+
+func (p *probeIterator) SeekLT(key []byte) *Span {
+	op := op{
+		Kind:    OpSeekLT,
+		SeekKey: key,
+	}
+	if p.iter != nil {
+		op.Span = p.iter.SeekLT(key)
+	}
+	return p.handleOp(op)
+}
+
+func (p *probeIterator) First() *Span {
+	op := op{Kind: OpFirst}
+	if p.iter != nil {
+		op.Span = p.iter.First()
+	}
+	return p.handleOp(op)
+}
+
+func (p *probeIterator) Last() *Span {
+	op := op{Kind: OpLast}
+	if p.iter != nil {
+		op.Span = p.iter.Last()
+	}
+	return p.handleOp(op)
+}
+
+func (p *probeIterator) Next() *Span {
+	op := op{Kind: OpNext}
+	if p.iter != nil {
+		op.Span = p.iter.Next()
+	}
+	return p.handleOp(op)
+}
+
+func (p *probeIterator) Prev() *Span {
+	op := op{Kind: OpPrev}
+	if p.iter != nil {
+		op.Span = p.iter.Prev()
+	}
+	return p.handleOp(op)
+}
+
+func (p *probeIterator) Error() error {
+	return p.err
+}
+
+func (p *probeIterator) Close() error {
+	op := op{Kind: OpClose}
+	if p.iter != nil {
+		op.Err = p.iter.Close()
+	}
+
+	p.probeCtx.op = op
+	p.probe.probe(&p.probeCtx)
+	p.err = p.probeCtx.op.Err
+	return p.err
+}
 
 // runIterCmd evaluates a datadriven command controlling an internal
 // keyspan.FragmentIterator, returning a string with the results of the iterator
@@ -20,7 +382,10 @@ import (
 func runIterCmd(t *testing.T, td *datadriven.TestData, iter FragmentIterator) string {
 	var buf bytes.Buffer
 	lines := strings.Split(strings.TrimSpace(td.Input), "\n")
-	for _, line := range lines {
+	for i, line := range lines {
+		if i > 0 {
+			fmt.Fprintln(&buf)
+		}
 		line = strings.TrimSpace(line)
 		i := strings.IndexByte(line, '#')
 		iterCmd := line
@@ -28,9 +393,8 @@ func runIterCmd(t *testing.T, td *datadriven.TestData, iter FragmentIterator) st
 			iterCmd = string(line[:i])
 		}
 		runIterOp(&buf, iter, iterCmd)
-		fmt.Fprintln(&buf)
 	}
-	return strings.TrimSpace(buf.String())
+	return buf.String()
 }
 
 var iterDelim = map[rune]bool{',': true, ' ': true, '(': true, ')': true, '"': true}

--- a/internal/keyspan/iter.go
+++ b/internal/keyspan/iter.go
@@ -51,6 +51,8 @@ type FragmentIterator interface {
 	Prev() *Span
 
 	// Error returns any accumulated error.
+	//
+	// TODO(jackson): Lift errors into return values on the positioning methods.
 	Error() error
 
 	// Close closes the iterator and returns any accumulated error. Exhausting

--- a/internal/keyspan/merging_iter_test.go
+++ b/internal/keyspan/merging_iter_test.go
@@ -21,10 +21,7 @@ import (
 
 func TestMergingIter(t *testing.T) {
 	cmp := base.DefaultComparer.Compare
-	var buf bytes.Buffer
 	var iter MergingIter
-
-	formatSpan := func(s *Span) { fmt.Fprintln(&buf, s) }
 
 	datadriven.RunTest(t, "testdata/merging_iter", func(t *testing.T, td *datadriven.TestData) string {
 		switch td.Cmd {
@@ -58,34 +55,7 @@ func TestMergingIter(t *testing.T) {
 			iter.Init(cmp, VisibleTransform(snapshot), new(MergingBuffers), iters...)
 			return fmt.Sprintf("%d levels", len(iters))
 		case "iter":
-			buf.Reset()
-			lines := strings.Split(strings.TrimSpace(td.Input), "\n")
-			for _, line := range lines {
-				line = strings.TrimSpace(line)
-				i := strings.IndexByte(line, ' ')
-				iterCmd := line
-				if i > 0 {
-					iterCmd = string(line[:i])
-				}
-				switch iterCmd {
-				case "first":
-					formatSpan(iter.First())
-				case "last":
-					formatSpan(iter.Last())
-				case "next":
-					formatSpan(iter.Next())
-				case "prev":
-					formatSpan(iter.Prev())
-				case "seek-ge":
-					formatSpan(iter.SeekGE([]byte(strings.TrimSpace(line[i:]))))
-				case "seek-lt":
-					formatSpan(iter.SeekLT([]byte(strings.TrimSpace(line[i:]))))
-				default:
-					return fmt.Sprintf("unrecognized iter command %q", iterCmd)
-				}
-				require.NoError(t, iter.Error())
-			}
-			return strings.TrimSpace(buf.String())
+			return runIterCmd(t, td, &iter)
 
 		default:
 			return fmt.Sprintf("unrecognized command %q", td.Cmd)

--- a/internal/keyspan/testdata/defragmenting_iter
+++ b/internal/keyspan/testdata/defragmenting_iter
@@ -14,12 +14,12 @@ last
 prev
 prev
 ----
-first     a-c:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
-next      c-d:{(#4,RANGEKEYSET,@3,bananas)}
-next      d-e:{(#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
-last      d-e:{(#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
-prev      c-d:{(#4,RANGEKEYSET,@3,bananas)}
-prev      a-c:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+a-c:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+c-d:{(#4,RANGEKEYSET,@3,bananas)}
+d-e:{(#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
+d-e:{(#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
+c-d:{(#4,RANGEKEYSET,@3,bananas)}
+a-c:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
 
 iter
 first
@@ -31,14 +31,14 @@ prev
 prev
 prev
 ----
-first     a-c:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
-next      c-d:{(#4,RANGEKEYSET,@3,bananas)}
-next      d-e:{(#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
-next      .
-last      d-e:{(#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
-prev      c-d:{(#4,RANGEKEYSET,@3,bananas)}
-prev      a-c:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
-prev      .
+a-c:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+c-d:{(#4,RANGEKEYSET,@3,bananas)}
+d-e:{(#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
+<nil>
+d-e:{(#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
+c-d:{(#4,RANGEKEYSET,@3,bananas)}
+a-c:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+<nil>
 
 # Test a scenario that SHOULD result in internal defragmentation ([a,c) and
 # [c,d) should be merged.
@@ -54,9 +54,9 @@ first
 next
 next
 ----
-first     a-d:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
-next      d-e:{(#1,RANGEKEYSET,@3,bananas)}
-next      .
+a-d:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+d-e:{(#1,RANGEKEYSET,@3,bananas)}
+<nil>
 
 # Test defragmenting in both directions at seek keys.
 
@@ -77,23 +77,23 @@ next
 seeklt d
 prev
 ----
-seekge b  a-f:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
-prev      .
-seekge b  a-f:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
-next      f-t:{(#3,RANGEKEYSET,@3,bananas)}
-seeklt d  a-f:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
-next      f-t:{(#3,RANGEKEYSET,@3,bananas)}
-seeklt d  a-f:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
-prev      .
+a-f:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+<nil>
+a-f:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+f-t:{(#3,RANGEKEYSET,@3,bananas)}
+a-f:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+f-t:{(#3,RANGEKEYSET,@3,bananas)}
+a-f:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+<nil>
 
 iter
 seeklt d
 next
 prev
 ----
-seeklt d  a-f:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
-next      f-t:{(#3,RANGEKEYSET,@3,bananas)}
-prev      a-f:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+a-f:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+f-t:{(#3,RANGEKEYSET,@3,bananas)}
+a-f:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
 
 # Test next-ing and prev-ing around seek keys.
 
@@ -111,10 +111,10 @@ prev
 next
 next
 ----
-seekge r  f-t:{(#3,RANGEKEYSET,@3,bananas)}
-prev      a-f:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
-next      f-t:{(#3,RANGEKEYSET,@3,bananas)}
-next      t-z:{(#4,RANGEKEYSET,@2,oranges)}
+f-t:{(#3,RANGEKEYSET,@3,bananas)}
+a-f:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+f-t:{(#3,RANGEKEYSET,@3,bananas)}
+t-z:{(#4,RANGEKEYSET,@2,oranges)}
 
 iter
 seekge f
@@ -125,13 +125,13 @@ seekge u
 seekge v
 seekge z
 ----
-seekge f  f-t:{(#3,RANGEKEYSET,@3,bananas)}
-seekge h  f-t:{(#3,RANGEKEYSET,@3,bananas)}
-seekge p  f-t:{(#3,RANGEKEYSET,@3,bananas)}
-seekge t  t-z:{(#4,RANGEKEYSET,@2,oranges)}
-seekge u  t-z:{(#4,RANGEKEYSET,@2,oranges)}
-seekge v  t-z:{(#4,RANGEKEYSET,@2,oranges)}
-seekge z  .
+f-t:{(#3,RANGEKEYSET,@3,bananas)}
+f-t:{(#3,RANGEKEYSET,@3,bananas)}
+f-t:{(#3,RANGEKEYSET,@3,bananas)}
+t-z:{(#4,RANGEKEYSET,@2,oranges)}
+t-z:{(#4,RANGEKEYSET,@2,oranges)}
+t-z:{(#4,RANGEKEYSET,@2,oranges)}
+<nil>
 
 iter
 seeklt f
@@ -141,12 +141,12 @@ seeklt t
 seeklt u
 seeklt z
 ----
-seeklt f  a-f:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
-seeklt h  f-t:{(#3,RANGEKEYSET,@3,bananas)}
-seeklt p  f-t:{(#3,RANGEKEYSET,@3,bananas)}
-seeklt t  f-t:{(#3,RANGEKEYSET,@3,bananas)}
-seeklt u  t-z:{(#4,RANGEKEYSET,@2,oranges)}
-seeklt z  t-z:{(#4,RANGEKEYSET,@2,oranges)}
+a-f:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+f-t:{(#3,RANGEKEYSET,@3,bananas)}
+f-t:{(#3,RANGEKEYSET,@3,bananas)}
+f-t:{(#3,RANGEKEYSET,@3,bananas)}
+t-z:{(#4,RANGEKEYSET,@2,oranges)}
+t-z:{(#4,RANGEKEYSET,@2,oranges)}
 
 # Test iteration with a reducer that collects keys across all spans that
 # constitute a defragmented span. Abutting spans are always combined.
@@ -167,12 +167,12 @@ last
 prev
 prev
 ----
-first     a-d:{(#5,RANGEDEL) (#4,RANGEDEL) (#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
-next      e-g:{(#2,RANGEDEL) (#1,RANGEDEL)}
-next      .
-last      e-g:{(#2,RANGEDEL) (#1,RANGEDEL)}
-prev      a-d:{(#5,RANGEDEL) (#4,RANGEDEL) (#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
-prev      .
+a-d:{(#5,RANGEDEL) (#4,RANGEDEL) (#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
+e-g:{(#2,RANGEDEL) (#1,RANGEDEL)}
+<nil>
+e-g:{(#2,RANGEDEL) (#1,RANGEDEL)}
+a-d:{(#5,RANGEDEL) (#4,RANGEDEL) (#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
+<nil>
 
 # Test defragmentation of non-empty (i.e. more than one value) fragments, while
 # empty fragments are left untouched.
@@ -192,11 +192,11 @@ next
 next
 next
 ----
-first     a-d:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
-next      d-e:{}
-next      e-f:{}
-next      g-h:{(#1,RANGEKEYSET,@3,bananas)}
-next      .
+a-d:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+d-e:{}
+e-f:{}
+g-h:{(#1,RANGEKEYSET,@3,bananas)}
+<nil>
 
 iter
 last
@@ -205,11 +205,11 @@ prev
 prev
 prev
 ----
-last      g-h:{(#1,RANGEKEYSET,@3,bananas)}
-prev      e-f:{}
-prev      d-e:{}
-prev      a-d:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
-prev      .
+g-h:{(#1,RANGEKEYSET,@3,bananas)}
+e-f:{}
+d-e:{}
+a-d:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+<nil>
 
 iter
 seekge d
@@ -221,14 +221,14 @@ prev
 prev
 prev
 ----
-seekge d  d-e:{}
-next      e-f:{}
-prev      d-e:{}
-seekge e  e-f:{}
-next      g-h:{(#1,RANGEKEYSET,@3,bananas)}
-prev      e-f:{}
-prev      d-e:{}
-prev      a-d:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+d-e:{}
+e-f:{}
+d-e:{}
+e-f:{}
+g-h:{(#1,RANGEKEYSET,@3,bananas)}
+e-f:{}
+d-e:{}
+a-d:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
 
 iter
 seeklt e
@@ -240,11 +240,11 @@ prev
 prev
 prev
 ----
-seeklt e  d-e:{}
-next      e-f:{}
-prev      d-e:{}
-seeklt f  e-f:{}
-next      g-h:{(#1,RANGEKEYSET,@3,bananas)}
-prev      e-f:{}
-prev      d-e:{}
-prev      a-d:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+d-e:{}
+e-f:{}
+d-e:{}
+e-f:{}
+g-h:{(#1,RANGEKEYSET,@3,bananas)}
+e-f:{}
+d-e:{}
+a-d:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}

--- a/internal/keyspan/testdata/defragmenting_iter
+++ b/internal/keyspan/testdata/defragmenting_iter
@@ -248,3 +248,148 @@ g-h:{(#1,RANGEKEYSET,@3,bananas)}
 e-f:{}
 d-e:{}
 a-d:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+
+# Test that the defragmenting iterator does yield errors in cases that do not
+# need to defragment.
+
+define
+a-c:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+c-d:{(#4,RANGEKEYSET,@3,bananas)}
+d-e:{(#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
+----
+
+iter probes=(ErrInjected)
+seek-ge b
+seek-lt d
+first
+last
+----
+<nil> err=<injected error>
+<nil> err=<injected error>
+<nil> err=<injected error>
+<nil> err=<injected error>
+
+# Next and Prev may only be called on positioned iterators, so to test
+# propagation of errors on Next or Prev, we must use a probe that injects errors
+# on Next or Prev but leaves seeks untouched.
+#
+# The situation is complicated by the fact that a seek on the defragmenting
+# iterator will result in Next/Prevs on the embedded iterator (in order to peek
+# ahead to see if anything needs to be defragmented).
+#
+# First we test the seeks too result in injected errors when they Next/Prev
+# ahead to determine if there's anything to defragment.
+
+iter probes=((If (Or OpNext OpPrev) ErrInjected noop), (Log "#  inner."))
+seek-ge b
+next
+seek-lt cat
+prev
+----
+#  inner.SeekGE("b") = a-c:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+#  inner.Prev() = nil <err="injected error">
+<nil> err=<injected error>
+#  inner.Next() = nil <err="injected error">
+<nil> err=<injected error>
+#  inner.SeekLT("cat") = c-d:{(#4,RANGEKEYSET,@3,bananas)}
+#  inner.Next() = nil <err="injected error">
+<nil> err=<injected error>
+#  inner.Prev() = nil <err="injected error">
+<nil> err=<injected error>
+
+# Use a probe that injects errors whenever we otherwise would've returned the
+# c-d span. First and Last calls should both return errors because during
+# defragmenting they'll step the internal iterator on to the error position.
+
+iter probes=((If (Equal StartKey (Bytes "c")) ErrInjected noop), (Log "#  inner."))
+first
+last
+----
+#  inner.First() = a-c:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+#  inner.Next() = nil <err="injected error">
+<nil> err=<injected error>
+#  inner.Last() = d-e:{(#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
+#  inner.Prev() = nil <err="injected error">
+<nil> err=<injected error>
+
+# In order to test that errors are injected when Next-ing the top-level
+# iterator, define test data that includes 5 spans.
+
+define
+a-b:{(#3,RANGEKEYUNSET,@5)}
+b-c:{(#4,RANGEKEYSET,@5,apples)}
+c-d:{(#5,RANGEKEYSET,@3,bananas)}
+d-e:{(#6,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
+e-f:{(#4,RANGEKEYSET,@1,pineapple)}
+----
+
+# Use a probe that injects errors whenever we would've otherwise returned the
+# c-d span. Our initial First/Last seeks should not step on to the error
+# position and should not error. The subsequent Next/Prev however should.
+
+iter probes=((If (Equal StartKey (Bytes "c")) ErrInjected noop), (Log "#  inner."))
+first
+next
+last
+prev
+----
+#  inner.First() = a-b:{(#3,RANGEKEYUNSET,@5)}
+#  inner.Next() = b-c:{(#4,RANGEKEYSET,@5,apples)}
+a-b:{(#3,RANGEKEYUNSET,@5)}
+#  inner.Next() = nil <err="injected error">
+<nil> err=<injected error>
+#  inner.Last() = e-f:{(#4,RANGEKEYSET,@1,pineapple)}
+#  inner.Prev() = d-e:{(#6,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
+e-f:{(#4,RANGEKEYSET,@1,pineapple)}
+#  inner.Prev() = nil <err="injected error">
+<nil> err=<injected error>
+
+# When seeking, the defragmenting iterator needs to defragment in both
+# directions. A forward seek first defragments in the reverse direction, and
+# then in the forward direction. A backward seek does the inverse. If an error
+# is encountered while performing the first defragment scan, it must be
+# surfaced.
+#
+# To test this scenario we again inject errors instead of the c-d span.
+#   - The SeekGE('d') should land on d-e, try to defragment backward first and
+#     encounter the error.
+#   - The SeekLT('c') should land on b-c, try to defragment forward first and
+#     encounter the error.
+iter probes=((If (Equal StartKey (Bytes "c")) ErrInjected noop), (Log "#  inner."))
+seek-ge d
+seek-lt c
+----
+#  inner.SeekGE("d") = d-e:{(#6,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
+#  inner.Prev() = nil <err="injected error">
+<nil> err=<injected error>
+#  inner.SeekLT("c") = b-c:{(#4,RANGEKEYSET,@5,apples)}
+#  inner.Next() = nil <err="injected error">
+<nil> err=<injected error>
+
+# When changing directions in some circumstances we step an iterator and then
+# defragment twice; once to skip over the current span and once to construct the
+# next defragmented span in the new iteration direction. If the first step of
+# the iterator surfaces an error, ensure that it's still propagated.
+iter probes=((If (And OpPrev (Equal StartKey (Bytes "c"))) ErrInjected noop), (Log "#  inner."))
+seek-ge c
+prev
+----
+#  inner.SeekGE("c") = c-d:{(#5,RANGEKEYSET,@3,bananas)}
+#  inner.Prev() = b-c:{(#4,RANGEKEYSET,@5,apples)}
+#  inner.Next() = c-d:{(#5,RANGEKEYSET,@3,bananas)}
+#  inner.Next() = d-e:{(#6,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
+c-d:{(#5,RANGEKEYSET,@3,bananas)}
+#  inner.Prev() = nil <err="injected error">
+<nil> err=<injected error>
+
+iter probes=((If (And OpNext (Equal StartKey (Bytes "c"))) ErrInjected noop), (Log "#  inner."))
+seek-lt d
+next
+----
+#  inner.SeekLT("d") = c-d:{(#5,RANGEKEYSET,@3,bananas)}
+#  inner.Next() = d-e:{(#6,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
+#  inner.Prev() = c-d:{(#5,RANGEKEYSET,@3,bananas)}
+#  inner.Prev() = b-c:{(#4,RANGEKEYSET,@5,apples)}
+c-d:{(#5,RANGEKEYSET,@3,bananas)}
+#  inner.Next() = nil <err="injected error">
+<nil> err=<injected error>


### PR DESCRIPTION
This is a 23.2 backport of #3029 and #3034 in order to fix and test the range key defragmenting iterator's handling of errors.

----

**internal/dsl: new package**

Extract the parsing logic of vfs/errorfs's DSL into a separate package
providing generic interfaces for parsing lisp-esque DSLs.

Some error pathways are difficult to test only through filesystem-injected
errors. This new package prepares for a similar DSL for errors injected by a
special InternalIterator that wraps other internal iterators.

**internal/keyspan: consolidate datadriven iterator ops**

Previously, a few different datadriven test repeated logic for driving a
FragmentIterator through datadriven commands. This commit refactors them to
share code for driving these datadriven commands.

**internal/keyspan: fix defragmenting iterator error handling**

A single iterator operation performed on a keyspan defragmenting iterator may
result in many iterator operations performed against its inner iterator.
Previously, in some circumstances if an error occurred during an inner iterator
operation other than the final one, the error was silently swallowed. This
allowed incorrect results, including spans that were not fully defragmented.

This commit fixes these bugs. It also introduces some internal keyspan testing
facilities that build on the new internal/dsl package to provide iterator
"probes" for use in the keyspan datadriven tests. These probes may be used to
conditionally inject errors, mutate return values or log operations.

Future work will use these probes to expand error-handling unit tests for the
other iterators within the keyspan package.