### PR TITLE
sstable: add error injection unit test, fix NextPrefix bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/cockroachdb/datadriven v1.0.3-0.20230413201302-be42291fc80f
 	github.com/cockroachdb/errors v1.11.1
+	github.com/cockroachdb/metamorphic v0.0.0-20231108215700-4ba948b56895
 	github.com/cockroachdb/redact v1.1.5
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06
 	github.com/ghemawat/stream v0.0.0-20171120220530-696b145b53b9
@@ -18,7 +19,7 @@ require (
 	github.com/prometheus/client_golang v1.12.0
 	github.com/prometheus/client_model v0.2.1-0.20210607210712-147c58e9608a
 	github.com/spf13/cobra v1.0.0
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
 	golang.org/x/perf v0.0.0-20230113213139-801c7ef9e5c5
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/cockroachdb/errors v1.11.1 h1:xSEW75zKaKCWzR3OfxXUxgrk/NtT4G1MiOv5lWZ
 github.com/cockroachdb/errors v1.11.1/go.mod h1:8MUxA3Gi6b25tYlFEBGLf+D8aISL+M4MIpiWMSNRfxw=
 github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b h1:r6VH0faHjZeQy818SGhaone5OnYfxFR/+AzdY3sf5aE=
 github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
+github.com/cockroachdb/metamorphic v0.0.0-20231108215700-4ba948b56895 h1:XANOgPYtvELQ/h4IrmPAohXqe2pWA8Bwhejr3VQoZsA=
+github.com/cockroachdb/metamorphic v0.0.0-20231108215700-4ba948b56895/go.mod h1:aPd7gM9ov9M8v32Yy5NJrDyOcD8z642dqs+F0CeNXfA=
 github.com/cockroachdb/redact v1.1.5 h1:u1PMllDkdFfPWaNGMyLD1+so+aq3uUItthCFqzwPJ30=
 github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAKVxetITBuuhv3BI9cMrmStnpT18zmgmTxunpo=
@@ -313,16 +315,12 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/sstable/random_test.go
+++ b/sstable/random_test.go
@@ -1,0 +1,395 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"fmt"
+	"math/rand"
+	"runtime/debug"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/metamorphic"
+	"github.com/cockroachdb/pebble/bloom"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/bytealloc"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/cockroachdb/pebble/vfs/errorfs"
+	"github.com/stretchr/testify/require"
+)
+
+// IterIterator_RandomErrors builds random sstables and runs random iterator
+// operations against them while randomly injecting errors. It ensures that if
+// an error is injected during an operation, operation surfaces the error to the
+// caller.
+func TestIterator_RandomErrors(t *testing.T) {
+	root := time.Now().UnixNano()
+	// Run the test a few times with various seeds for more consistent code
+	// coverage.
+	for i := int64(0); i < 50; i++ {
+		seed := root + i
+		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
+			runErrorInjectionTest(t, seed)
+		})
+	}
+}
+
+func runErrorInjectionTest(t *testing.T, seed int64) {
+	t.Logf("seed %d", seed)
+	fs := vfs.NewMem()
+	f, err := fs.Create("random.sst")
+	require.NoError(t, err)
+	rng := rand.New(rand.NewSource(seed))
+	cfg := randomTableConfig{
+		wopts:     nil, /* leave to randomize */
+		keys:      testkeys.Alpha(3 + rng.Intn(2)),
+		keyCount:  10_000,
+		maxValLen: rng.Intn(64) + 1,
+		maxSuffix: rng.Int63n(95) + 5,
+		maxSeqNum: rng.Int63n(1000) + 10,
+		rng:       rng,
+	}
+	cfg.randomize()
+	_, err = buildRandomSSTable(f, cfg)
+	require.NoError(t, err)
+
+	f, err = fs.Open("random.sst")
+	require.NoError(t, err)
+	// Randomly inject errors into 25% of file operations. We use an
+	// errorfs.Toggle to avoid injecting errors until the file has been opened.
+	toggle := &errorfs.Toggle{Injector: errorfs.ErrInjected.If(errorfs.Randomly(0.25, seed))}
+	counter := &errorfs.Counter{Injector: toggle}
+	var stack []byte
+	f = errorfs.WrapFile(f, errorfs.InjectorFunc(func(op errorfs.Op) error {
+		err := counter.MaybeError(op)
+		if err != nil {
+			// Save the stack trace of the most recently injected error.
+			stack = debug.Stack()
+		}
+		return err
+	}))
+	readable, err := NewSimpleReadable(f)
+	require.NoError(t, err)
+	r, err := NewReader(readable, cfg.readerOpts())
+	require.NoError(t, err)
+	defer r.Close()
+
+	var filterer *BlockPropertiesFilterer
+	if rng.Float64() < 0.75 {
+		low, high := uint64(cfg.randSuffix()), uint64(cfg.randSuffix())
+		if low > high {
+			low, high = high, low
+		}
+		filterer = newBlockPropertiesFilterer([]BlockPropertyFilter{
+			NewTestKeysBlockPropertyFilter(low, high),
+		}, nil)
+	}
+
+	// TOOD(jackson): NewIterWithBlockPropertyFilters returns an iterator over
+	// point keys only. Should we add variants of this test that run random
+	// operations on the range deletion and range key iterators?
+	var stats base.InternalIteratorStats
+	it, err := r.NewIterWithBlockPropertyFilters(
+		nil /* lower TODO */, nil, /* upper TODO */
+		filterer,
+		rng.Intn(2) == 1, /* use filter block */
+		&stats,
+		CategoryAndQoS{},
+		nil, /* CategoryStatsCollector */
+		TrivialReaderProvider{r},
+	)
+	require.NoError(t, err)
+	defer it.Close()
+
+	// Begin injecting errors.
+	toggle.On()
+
+	ops := opRunner{randomTableConfig: cfg, it: it}
+	nextOp := metamorphic.Weighted[func() bool]{
+		{Item: ops.runSeekGE, Weight: 2},
+		{Item: ops.runSeekPrefixGE, Weight: 2},
+		{Item: ops.runSeekLT, Weight: 2},
+		{Item: ops.runFirst, Weight: 1},
+		{Item: ops.runLast, Weight: 1},
+		{Item: ops.runNext, Weight: 5},
+		{Item: ops.runNextPrefix, Weight: 5},
+		{Item: ops.runPrev, Weight: 5},
+	}.RandomDeck(rng)
+
+	for i := 0; i < 1000; i++ {
+		beforeCount := counter.Load()
+
+		// nextOp returns a function that *may* run the operation. If the
+		// current test state makes the operation an invalid operation, the the
+		// function returns `false` indicating it was not run. If the operation
+		// is a valid operation and was performed, `opFunc` returns true.
+		//
+		// This loop will run exactly 1 operation, skipping randomly chosen
+		// operations that cannot be run on an iterator in its current state.
+		for opFunc := nextOp(); !opFunc(); {
+			opFunc = nextOp()
+		}
+
+		t.Logf("%s = %s [err = %v]", ops.latestOpDesc, ops.k, it.Error())
+		afterCount := counter.Load()
+		// TODO(jackson): Consider running all commands against a parallel
+		// iterator constructed over a sstable containing the same data in a
+		// standard construction (eg, typical block sizes) and no error
+		// injection. Then we can assert the results are identical.
+
+		if afterCount > beforeCount {
+			if ops.k != nil || it.Error() == nil {
+				t.Errorf("error swallowed during %s with stack %s",
+					ops.latestOpDesc, string(stack))
+			}
+		}
+	}
+}
+
+type opRunner struct {
+	randomTableConfig
+	it Iterator
+
+	latestOpDesc  string
+	latestSeekKey []byte
+	dir           int8
+	k             *base.InternalKey
+	v             base.LazyValue
+}
+
+func (r *opRunner) runSeekGE() bool {
+	k := r.randKey()
+	flags := base.SeekGEFlagsNone
+	if strings.HasPrefix(r.latestOpDesc, "SeekGE") &&
+		r.wopts.Comparer.Compare(k, r.latestSeekKey) > 0 && r.rng.Intn(2) == 1 {
+		flags = flags.EnableTrySeekUsingNext()
+	}
+	r.latestOpDesc = fmt.Sprintf("SeekGE(%q, TrySeekUsingNext()=%t)",
+		k, flags.TrySeekUsingNext())
+	r.latestSeekKey = k
+	r.k, r.v = r.it.SeekGE(k, base.SeekGEFlagsNone)
+	r.dir = +1
+	return true
+}
+
+func (r *opRunner) runSeekPrefixGE() bool {
+	k := r.randKey()
+	i := r.wopts.Comparer.Split(k)
+	flags := base.SeekGEFlagsNone
+	if strings.HasPrefix(r.latestOpDesc, "SeekPrefixGE") &&
+		r.wopts.Comparer.Compare(k, r.latestSeekKey) > 0 && r.rng.Intn(2) == 1 {
+		flags = flags.EnableTrySeekUsingNext()
+	}
+	r.latestOpDesc = fmt.Sprintf("SeekPrefixGE(%q, %q, TrySeekUsingNext()=%t)",
+		k[:i], k, flags.TrySeekUsingNext())
+	r.latestSeekKey = k
+	r.k, r.v = r.it.SeekPrefixGE(k[:i], k, flags)
+	r.dir = +1
+	return true
+}
+
+func (r *opRunner) runSeekLT() bool {
+	k := r.randKey()
+	r.latestOpDesc = fmt.Sprintf("SeekLT(%q)", k)
+	r.k, r.v = r.it.SeekLT(k, base.SeekLTFlagsNone)
+	r.dir = -1
+	return true
+}
+
+func (r *opRunner) runFirst() bool {
+	r.latestOpDesc = "First()"
+	r.k, r.v = r.it.First()
+	r.dir = +1
+	return true
+}
+
+func (r *opRunner) runLast() bool {
+	r.latestOpDesc = "Last()"
+	r.k, r.v = r.it.Last()
+	r.dir = -1
+	return true
+}
+
+func (r *opRunner) runNext() bool {
+	if r.dir == +1 && r.k == nil {
+		return false
+	}
+	r.latestOpDesc = "Next()"
+	r.k, r.v = r.it.Next()
+	r.dir = +1
+	return true
+}
+
+func (r *opRunner) runNextPrefix() bool {
+	// NextPrefix cannot be called to change directions or when an iterator is
+	// exhausted.
+	if r.dir == -1 || r.k == nil {
+		return false
+	}
+	p := r.k.UserKey[:r.wopts.Comparer.Split(r.k.UserKey)]
+	succKey := r.wopts.Comparer.ImmediateSuccessor(nil, p)
+	r.latestOpDesc = fmt.Sprintf("NextPrefix(%q)", succKey)
+	r.k, r.v = r.it.NextPrefix(succKey)
+	r.dir = +1
+	return true
+}
+
+func (r *opRunner) runPrev() bool {
+	if r.dir == -1 && r.k == nil {
+		return false
+	}
+	r.latestOpDesc = "Prev()"
+	r.k, r.v = r.it.Prev()
+	r.dir = -1
+	return true
+}
+
+type randomTableConfig struct {
+	wopts     *WriterOptions
+	keys      testkeys.Keyspace
+	keyCount  int
+	maxValLen int
+	maxSuffix int64
+	maxSeqNum int64
+	rng       *rand.Rand
+}
+
+func (cfg *randomTableConfig) readerOpts() ReaderOptions {
+	rOpts := ReaderOptions{
+		Comparer: testkeys.Comparer,
+		Filters:  map[string]FilterPolicy{},
+	}
+	if cfg.wopts.FilterPolicy != nil {
+		rOpts.Filters[cfg.wopts.FilterPolicy.Name()] = cfg.wopts.FilterPolicy
+	}
+	return rOpts
+}
+
+func (cfg *randomTableConfig) randomize() {
+	if cfg.wopts == nil {
+		cfg.wopts = &WriterOptions{
+			// Test all table formats in [TableFormatLevelDB, TableFormatMax].
+			TableFormat:             TableFormat(cfg.rng.Intn(int(TableFormatMax)) + 1),
+			BlockRestartInterval:    (1 << cfg.rng.Intn(6)),             // {1, 2, 4, ..., 32}
+			BlockSizeThreshold:      min(int(100*cfg.rng.Float64()), 1), // 1-100%
+			BlockSize:               (1 << cfg.rng.Intn(18)),            // {1, 2, 4, ..., 128 KiB}
+			IndexBlockSize:          (1 << cfg.rng.Intn(20)),            // {1, 2, 4, ..., 512 KiB}
+			BlockPropertyCollectors: nil,
+			WritingToLowestLevel:    cfg.rng.Intn(2) == 1,
+			Parallelism:             cfg.rng.Intn(2) == 1,
+		}
+		if v := cfg.rng.Intn(11); v > 0 {
+			cfg.wopts.FilterPolicy = bloom.FilterPolicy(v)
+		}
+		if cfg.wopts.TableFormat >= TableFormatPebblev1 && cfg.rng.Float64() < 0.75 {
+			cfg.wopts.BlockPropertyCollectors = append(cfg.wopts.BlockPropertyCollectors, NewTestKeysBlockPropertyCollector)
+		}
+	}
+	cfg.wopts.ensureDefaults()
+	cfg.wopts.Comparer = testkeys.Comparer
+}
+
+func (cfg *randomTableConfig) randKey() []byte {
+	return testkeys.KeyAt(cfg.keys, cfg.randKeyIdx(), cfg.randSuffix())
+}
+func (cfg *randomTableConfig) randSuffix() int64 { return cfg.rng.Int63n(cfg.maxSuffix + 1) }
+func (cfg *randomTableConfig) randKeyIdx() int64 { return cfg.rng.Int63n(cfg.keys.Count()) }
+
+func buildRandomSSTable(f vfs.File, cfg randomTableConfig) (*WriterMetadata, error) {
+	// Construct a weighted distribution of key kinds.
+	kinds := metamorphic.Weighted[base.InternalKeyKind]{
+		{Item: base.InternalKeyKindSet, Weight: 25},
+		{Item: base.InternalKeyKindSetWithDelete, Weight: 25},
+		{Item: base.InternalKeyKindDelete, Weight: 5},
+		{Item: base.InternalKeyKindSingleDelete, Weight: 2},
+		{Item: base.InternalKeyKindMerge, Weight: 1},
+	}
+	// TODO(jackson): Support writing range deletions and range keys.
+	// TestIterator_RandomErrors only reads through the point iterator, so those
+	// keys won't be visible regardless, but their existence should be benign.
+
+	// DELSIZED require Pebblev4 or later.
+	if cfg.wopts.TableFormat >= TableFormatPebblev4 {
+		kinds = append(kinds, metamorphic.ItemWeight[base.InternalKeyKind]{
+			Item: base.InternalKeyKindDeleteSized, Weight: 5,
+		})
+	}
+	nextRandomKind := kinds.RandomDeck(cfg.rng)
+
+	type keyID struct {
+		idx    int64
+		suffix int64
+		seqNum int64
+	}
+	keyMap := make(map[keyID]bool)
+	// Constrain the space we generate keys to the middle 90% of the keyspace.
+	// This helps exercise code paths that are only run when a seek key is
+	// beyond or before all index block entries.
+	sstKeys := cfg.keys.Slice(cfg.keys.Count()/20, cfg.keys.Count()-cfg.keys.Count()/20)
+	randomKey := func() keyID {
+		k := keyID{
+			idx:    cfg.rng.Int63n(sstKeys.Count()),
+			suffix: cfg.rng.Int63n(cfg.maxSuffix + 1),
+			seqNum: cfg.rng.Int63n(cfg.maxSeqNum + 1),
+		}
+		// If we've already generated this exact key, try again.
+		for keyMap[k] {
+			k = keyID{
+				idx:    cfg.rng.Int63n(sstKeys.Count()),
+				suffix: cfg.rng.Int63n(cfg.maxSuffix + 1),
+				seqNum: cfg.rng.Int63n(cfg.maxSeqNum + 1),
+			}
+		}
+		keyMap[k] = true
+		return k
+	}
+
+	var alloc bytealloc.A
+	keys := make([]base.InternalKey, cfg.keyCount)
+	for i := range keys {
+		keyID := randomKey()
+		kind := nextRandomKind()
+
+		var keyBuf []byte
+		alloc, keyBuf = alloc.Alloc(testkeys.SuffixLen(keyID.suffix) + cfg.keys.MaxLen())
+		n := testkeys.WriteKeyAt(keyBuf, sstKeys, keyID.idx, keyID.suffix)
+		keys[i] = base.MakeInternalKey(keyBuf[:n], uint64(keyID.seqNum), kind)
+	}
+	// The Writer requires the keys to be written in sorted order. Sort them.
+	slices.SortFunc(keys, func(a, b base.InternalKey) int {
+		return base.InternalCompare(testkeys.Comparer.Compare, a, b)
+	})
+
+	// Release keyMap and alloc; we don't need them and this function can be
+	// memory intensive.
+	keyMap = nil
+	alloc = nil
+
+	valueBuf := make([]byte, cfg.maxValLen)
+	w := NewWriter(objstorageprovider.NewFileWritable(f), *cfg.wopts)
+	for i := 0; i < len(keys); i++ {
+		var value []byte
+		switch keys[i].Kind() {
+		case base.InternalKeyKindSet, base.InternalKeyKindMerge:
+			value = valueBuf[:cfg.rng.Intn(cfg.maxValLen+1)]
+			cfg.rng.Read(value)
+		}
+		if err := w.Add(keys[i], value); err != nil {
+			return nil, err
+		}
+	}
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+	metadata, err := w.Metadata()
+	if err != nil {
+		return nil, err
+	}
+	return metadata, nil
+}

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -1139,6 +1139,8 @@ func (i *singleLevelIterator) Next() (*InternalKey, base.LazyValue) {
 	i.boundsCmp = 0
 
 	if i.err != nil {
+		// TODO(jackson): Can this case be turned into a panic? Once an error is
+		// encountered, the iterator must be re-seeked.
 		return nil, base.LazyValue{}
 	}
 	if key, val := i.data.Next(); key != nil {
@@ -1164,6 +1166,8 @@ func (i *singleLevelIterator) NextPrefix(succKey []byte) (*InternalKey, base.Laz
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
 	i.boundsCmp = 0
 	if i.err != nil {
+		// TODO(jackson): Can this case be turned into a panic? Once an error is
+		// encountered, the iterator must be re-seeked.
 		return nil, base.LazyValue{}
 	}
 	if key, val := i.data.NextPrefix(succKey); key != nil {

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -791,6 +791,8 @@ func (i *twoLevelIterator) Next() (*InternalKey, base.LazyValue) {
 	i.boundsCmp = 0
 	i.maybeFilteredKeysTwoLevel = false
 	if i.err != nil {
+		// TODO(jackson): Can this case be turned into a panic? Once an error is
+		// encountered, the iterator must be re-seeked.
 		return nil, base.LazyValue{}
 	}
 	if key, val := i.singleLevelIterator.Next(); key != nil {
@@ -808,6 +810,8 @@ func (i *twoLevelIterator) NextPrefix(succKey []byte) (*InternalKey, base.LazyVa
 	i.boundsCmp = 0
 	i.maybeFilteredKeysTwoLevel = false
 	if i.err != nil {
+		// TODO(jackson): Can this case be turned into a panic? Once an error is
+		// encountered, the iterator must be re-seeked.
 		return nil, base.LazyValue{}
 	}
 	if key, val := i.singleLevelIterator.NextPrefix(succKey); key != nil {

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -817,6 +817,11 @@ func (i *twoLevelIterator) NextPrefix(succKey []byte) (*InternalKey, base.LazyVa
 	if key, val := i.singleLevelIterator.NextPrefix(succKey); key != nil {
 		return key, val
 	}
+	// key == nil
+	if i.err != nil {
+		return nil, base.LazyValue{}
+	}
+
 	// Did not find prefix in the existing second-level index block. This is the
 	// slow-path where we seek the iterator.
 	var ikey *InternalKey


### PR DESCRIPTION
Add a unit test that constructs sstables with random point keys using random
options and runs a random set of iterator operations against them. Randomly
inject errors into the VFS operations performed, and assert that if an error
was injected, it's also surfaced by the sstable.Iterator.

This test surfaced one new bug in #3052. This bug is fixed in the third commit.

Informs #1115.
Fixes #3052.