### PR TITLE
internal/rangekey: fix invariant check with onlySets=false

### DIFF
--- a/internal/rangekey/coalesce.go
+++ b/internal/rangekey/coalesce.go
@@ -212,8 +212,10 @@ func (ui *UserIteratorConfig) ShouldDefragment(equal base.Equal, a, b *keyspan.S
 				b.Keys[i].Kind() != base.InternalKeyKindRangeKeySet) {
 				panic("pebble: unexpected non-RangeKeySet during defragmentation")
 			}
-			if i > 0 && (ui.comparer.Compare(a.Keys[i].Suffix, a.Keys[i-1].Suffix) < 0 ||
-				ui.comparer.Compare(b.Keys[i].Suffix, b.Keys[i-1].Suffix) < 0) {
+			// Don't do a comparison with RangeKeyDeletes, as those will always sort
+			// to the end and have no suffix.
+			if i > 0 && ((a.Keys[i].Kind() != base.InternalKeyKindRangeKeyDelete && ui.comparer.Compare(a.Keys[i].Suffix, a.Keys[i-1].Suffix) < 0) ||
+				(b.Keys[i].Kind() != base.InternalKeyKindRangeKeyDelete && ui.comparer.Compare(b.Keys[i].Suffix, b.Keys[i-1].Suffix) < 0)) {
 				panic("pebble: range keys not ordered by suffix during defragmentation")
 			}
 		}


### PR DESCRIPTION
In the invariants build, with onlySets set to false (i.e. in ScanInternal), we would see RangeKeyDels in the coalescer that would sort to the end of the span.Keys when in BySuffixAsc order. This is expected and should not trip up the invariant panic, but it was.