### PR TITLE
crl-release-23.2: event: mark `FormatMajorVersion` as safe from redaction

### DIFF
--- a/format_major_version.go
+++ b/format_major_version.go
@@ -28,10 +28,13 @@ import (
 // FormatVersion that the default corresponds to may change with time.
 type FormatMajorVersion uint64
 
+// SafeValue implements redact.SafeValue.
+func (v FormatMajorVersion) SafeValue() {}
+
 // String implements fmt.Stringer.
 func (v FormatMajorVersion) String() string {
-	// NB: This must not change. It's used as the value for the the
-	// on-disk version marker file.
+	// NB: This must not change. It's used as the value for the on-disk
+	// version marker file.
 	//
 	// Specifically, this value must always parse as a base 10 integer
 	// that fits in a uint64. We format it as zero-padded, 3-digit


### PR DESCRIPTION
Trying that again: #2997 had a base branch of master and merging noop'd the empty commit 😅 


23.2 backport of #2992.

----

Previously nearly all events logged by the `EventListener` used types that had been marked as safe by implementing `SafeFormatter`, defining them as non-sensitive and not requiring redaction in logs, however `FormatMajorVersion` had been excluded. This change makes `FormatMajorVersion` a `redact.SafeValue` as well.