### PR TITLE
db: return iterator construction errors eagerly

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1133,7 +1133,7 @@ func (b *Batch) NewIter(o *IterOptions) (*Iterator, error) {
 // tracing.
 func (b *Batch) NewIterWithContext(ctx context.Context, o *IterOptions) (*Iterator, error) {
 	if b.index == nil {
-		return &Iterator{err: ErrNotIndexed}, nil
+		return nil, ErrNotIndexed
 	}
 	return b.db.newIter(ctx, b, newIterOpts{}, o), nil
 }
@@ -1146,7 +1146,7 @@ func (b *Batch) NewIterWithContext(ctx context.Context, o *IterOptions) (*Iterat
 // SetOptions().
 func (b *Batch) NewBatchOnlyIter(ctx context.Context, o *IterOptions) (*Iterator, error) {
 	if b.index == nil {
-		return &Iterator{err: ErrNotIndexed}, nil
+		return nil, ErrNotIndexed
 	}
 	return b.db.newIter(ctx, b, newIterOpts{batch: batchIterOpts{batchOnly: true}}, o), nil
 }

--- a/error_iter.go
+++ b/error_iter.go
@@ -18,10 +18,6 @@ type errorIter struct {
 // errorIter implements the base.InternalIterator interface.
 var _ internalIterator = (*errorIter)(nil)
 
-func newErrorIter(err error) *errorIter {
-	return &errorIter{err: err}
-}
-
 func (c *errorIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, base.LazyValue) {
 	return nil, base.LazyValue{}
 }
@@ -78,10 +74,6 @@ type errorKeyspanIter struct {
 
 // errorKeyspanIter implements the keyspan.FragmentIterator interface.
 var _ keyspan.FragmentIterator = (*errorKeyspanIter)(nil)
-
-func newErrorKeyspanIter(err error) *errorKeyspanIter {
-	return &errorKeyspanIter{err: err}
-}
 
 func (*errorKeyspanIter) SeekGE(key []byte) *keyspan.Span { return nil }
 func (*errorKeyspanIter) SeekLT(key []byte) *keyspan.Span { return nil }

--- a/range_keys.go
+++ b/range_keys.go
@@ -7,6 +7,7 @@ package pebble
 import (
 	"context"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/keyspan"
@@ -24,7 +25,8 @@ func (i *Iterator) constructRangeKeyIter() {
 	// If there's an indexed batch with range keys, include it.
 	if i.batch != nil {
 		if i.batch.index == nil {
-			i.rangeKey.iterConfig.AddLevel(newErrorKeyspanIter(ErrNotIndexed))
+			// This isn't an indexed batch. We shouldn't have gotten this far.
+			panic(errors.AssertionFailedf("creating an iterator over an unindexed batch"))
 		} else {
 			// Only include the batch's range key iterator if it has any keys.
 			// NB: This can force reconstruction of the rangekey iterator stack

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -847,7 +847,7 @@ func (i *scanInternalIterator) constructPointIter(
 // i.rangeKey.rangeKeyIter with the resulting iterator. This is similar to
 // Iterator.constructRangeKeyIter, except it doesn't handle batches and ensures
 // iterConfig does *not* elide unsets/deletes.
-func (i *scanInternalIterator) constructRangeKeyIter() {
+func (i *scanInternalIterator) constructRangeKeyIter() error {
 	// We want the bounded iter from iterConfig, but not the collapsing of
 	// RangeKeyUnsets and RangeKeyDels.
 	i.rangeKey.rangeKeyIter = i.rangeKey.iterConfig.Init(
@@ -890,8 +890,7 @@ func (i *scanInternalIterator) constructRangeKeyIter() {
 	for f := iter.Last(); f != nil; f = iter.Prev() {
 		spanIter, err := i.newIterRangeKey(f, i.opts.SpanIterOptions())
 		if err != nil {
-			i.rangeKey.iterConfig.AddLevel(&errorKeyspanIter{err: err})
-			continue
+			return err
 		}
 		i.rangeKey.iterConfig.AddLevel(spanIter)
 	}
@@ -910,6 +909,7 @@ func (i *scanInternalIterator) constructRangeKeyIter() {
 			manifest.Level(level), manifest.KeyTypeRange)
 		i.rangeKey.iterConfig.AddLevel(li)
 	}
+	return nil
 }
 
 // seekGE seeks this iterator to the first key that's greater than or equal

--- a/snapshot.go
+++ b/snapshot.go
@@ -105,7 +105,10 @@ func (s *Snapshot) ScanInternal(
 		},
 	}
 
-	iter := s.db.newInternalIter(ctx, snapshotIterOpts{seqNum: s.seqNum}, scanInternalOpts)
+	iter, err := s.db.newInternalIter(ctx, snapshotIterOpts{seqNum: s.seqNum}, scanInternalOpts)
+	if err != nil {
+		return err
+	}
 	defer iter.close()
 
 	return scanInternalImpl(ctx, lower, upper, iter, scanInternalOpts)
@@ -541,7 +544,10 @@ func (es *EventuallyFileOnlySnapshot) ScanInternal(
 		visitSharedFile:  visitSharedFile,
 		skipSharedLevels: visitSharedFile != nil,
 	}
-	iter := es.db.newInternalIter(ctx, sOpts, opts)
+	iter, err := es.db.newInternalIter(ctx, sOpts, opts)
+	if err != nil {
+		return err
+	}
 	defer iter.close()
 
 	// If excised is true, then keys relevant to the snapshot might not be


### PR DESCRIPTION
Previously iterator construction methods did not have a return value to surface errors (like ErrNotIndexed), so errors encountered during construction would be surfaced through the first iterator operation by installing an errorIter and/or errorKeyspanIter within the iterator stack. We now have error return values for all the iterator construction methods and can return these errors eagerly.

Similarly, the ScanInternal methods have error return values available and do not need to propagate iterator construction errors through adding fake iterators to the iterator stack.

For now, the errorIter and errorKeyspanIter types remain for a few test cases and to serve as "empty" iterator implementations when all a table's keys are excluded.