### PR TITLE
sstable: remove valueBlockReader.ctx field

### DIFF
--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -218,7 +218,6 @@ func (i *singleLevelIterator) init(
 			// separated to their callers, they can put this valueBlockReader into a
 			// sync.Pool.
 			i.vbReader = &valueBlockReader{
-				ctx:    ctx,
 				bpOpen: i,
 				rp:     rp,
 				vbih:   r.valueBIH,
@@ -417,9 +416,9 @@ func (i *singleLevelIterator) loadBlock(dir int8) loadBlockResult {
 // readBlockForVBR implements the blockProviderWhenOpen interface for use by
 // the valueBlockReader.
 func (i *singleLevelIterator) readBlockForVBR(
-	ctx context.Context, h BlockHandle, stats *base.InternalIteratorStats,
+	h BlockHandle, stats *base.InternalIteratorStats,
 ) (bufferHandle, error) {
-	ctx = objiotracing.WithBlockType(ctx, objiotracing.ValueBlock)
+	ctx := objiotracing.WithBlockType(i.ctx, objiotracing.ValueBlock)
 	return i.reader.readBlock(ctx, h, nil, i.vbRH, stats, i.bufferPool)
 }
 

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -181,7 +181,6 @@ func (i *twoLevelIterator) init(
 	if r.tableFormat >= TableFormatPebblev3 {
 		if r.Properties.NumValueBlocks > 0 {
 			i.vbReader = &valueBlockReader{
-				ctx:    ctx,
 				bpOpen: i,
 				rp:     rp,
 				vbih:   r.valueBIH,


### PR DESCRIPTION
blockProviderWhenOpen.readBlockForVBR no longer takes a context.Context parameter. There are two implementations of this interface:
- singleLevelIterator, which is used when the sstable iterator has not been closed. singleLevelIterator has a context to use in the call to Reader.readBlock.
- blockProviderWhenClosed, which is used when the sstable iterator has been closed. This is the rare case. We use the background context in this case. Given that valueBlockReader is not meant to outlive the root iterator in the iterator tree, and the context is set and propagated down from the root iterator, we could have kept the valueBlockReader.ctx field and set it in the corresponding sstable iterator's SetContext() implementation, but we choose to err on the side of safety for this rare case (and fewer structs with a context field is generally better).

Informs https://github.com/cockroachdb/cockroach/issues/114235