### PR TITLE
metamorphic: fix range key ingestion

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -659,31 +659,38 @@ func (b *Batch) prepareDeferredKeyRecord(keyLen int, kind InternalKeyKind) {
 	b.data = b.data[:pos+keyLen]
 }
 
-// AddInternalKey allows the caller to add an internal key of point key kinds to
-// a batch. Passing in an internal key of kind RangeKey* or RangeDelete will
-// result in a panic. Note that the seqnum in the internal key is effectively
-// ignored, even though the Kind is preserved. This is because the batch format
-// does not allow for a per-key seqnum to be specified, only a batch-wide one.
+// AddInternalKey allows the caller to add an internal key of point key or range
+// key kinds (but not RangeDelete) to a batch. Passing in an internal key of
+// kind RangeDelete will result in a panic. Note that the seqnum in the internal
+// key is effectively ignored, even though the Kind is preserved. This is
+// because the batch format does not allow for a per-key seqnum to be specified,
+// only a batch-wide one.
 //
 // Note that non-indexed keys (IngestKeyKind{LogData,IngestSST}) are not
 // supported with this method as they require specialized logic.
 func (b *Batch) AddInternalKey(key *base.InternalKey, value []byte, _ *WriteOptions) error {
 	keyLen := len(key.UserKey)
 	hasValue := false
-	switch key.Kind() {
-	case InternalKeyKindRangeDelete, InternalKeyKindRangeKeySet, InternalKeyKindRangeKeyUnset, InternalKeyKindRangeKeyDelete:
-		panic("unexpected range delete or range key kind in AddInternalKey")
+	switch kind := key.Kind(); kind {
+	case InternalKeyKindRangeDelete:
+		panic("unexpected range delete in AddInternalKey")
 	case InternalKeyKindSingleDelete, InternalKeyKindDelete:
-		b.prepareDeferredKeyRecord(len(key.UserKey), key.Kind())
-	default:
-		b.prepareDeferredKeyValueRecord(keyLen, len(value), key.Kind())
+		b.prepareDeferredKeyRecord(keyLen, kind)
+		b.deferredOp.index = b.index
+	case InternalKeyKindRangeKeySet, InternalKeyKindRangeKeyUnset, InternalKeyKindRangeKeyDelete:
+		b.prepareDeferredKeyValueRecord(keyLen, len(value), kind)
 		hasValue = true
+		b.incrementRangeKeysCount()
+	default:
+		b.prepareDeferredKeyValueRecord(keyLen, len(value), kind)
+		hasValue = true
+		b.deferredOp.index = b.index
 	}
-	b.deferredOp.index = b.index
 	copy(b.deferredOp.Key, key.UserKey)
 	if hasValue {
 		copy(b.deferredOp.Value, value)
 	}
+
 	// TODO(peter): Manually inline DeferredBatchOp.Finish(). Mid-stack inlining
 	// in go1.13 will remove the need for this.
 	if b.index != nil {

--- a/batch_test.go
+++ b/batch_test.go
@@ -45,8 +45,7 @@ func testBatch(t *testing.T, size int) {
 
 		for _, tc := range testCases {
 			if indexedPointKindsOnly && (tc.kind == InternalKeyKindLogData || tc.kind == InternalKeyKindIngestSST ||
-				tc.kind == InternalKeyKindRangeKeyUnset || tc.kind == InternalKeyKindRangeKeySet ||
-				tc.kind == InternalKeyKindRangeKeyDelete || tc.kind == InternalKeyKindRangeDelete) {
+				tc.kind == InternalKeyKindRangeDelete) {
 				continue
 			}
 			kind, k, v, ok := r.Next()
@@ -186,8 +185,7 @@ func testBatch(t *testing.T, size int) {
 	// Kind-specific methods.
 	for _, tc := range testCases {
 		if tc.kind == InternalKeyKindLogData || tc.kind == InternalKeyKindIngestSST ||
-			tc.kind == InternalKeyKindRangeKeyUnset || tc.kind == InternalKeyKindRangeKeySet ||
-			tc.kind == InternalKeyKindRangeKeyDelete || tc.kind == InternalKeyKindRangeDelete {
+			tc.kind == InternalKeyKindRangeDelete {
 			continue
 		}
 		key := []byte(tc.key)


### PR DESCRIPTION
Previously, the integration of range keys into the metamorphic test's ingest operation had a couple of bugs:

When constructing the sstable to ingest, the batch's range keys were fragmented, their sequence numbers zeroed and then written to the sstable. This allowed for a range key to be both SET and UNSET at the same suffix at the same sequence number, which is prohibited. Within a sequence number, range keys are required to be internally consistent. This commit resolves this issue by first coalescing the range keys and writing them out to the table. This mirrors the treatment of point keys in which we drop all but the most recent InternalKey at any particular user key.

When the ingestUsingApply test option was set, the batch's range keys were fragmented and then the individual keys were written to the collapsed batch in Trailer descending order through the user-facing mutation methods. This effectively reversed the order of precedence for all range keys, assigning earlier sequence numbers to the range keys that previously had relatively later sequence numbers. This commit adapts the collapseBatch function to treat range keys slightly differently, instead iterating through the batch and copying the keys verbatim to the collapsed batch through the AddInternalKey method. This allows the ingestUsingApply batch to apply the range keys in their unfragmented form, deferring fragmentation.

Fix #3062.
Fix #3063.