### PR TITLE
db: add simplified Download() that does copy compactions

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1671,6 +1671,19 @@ type readCompaction struct {
 	fileNum base.FileNum
 }
 
+type downloadSpan struct {
+	start []byte
+	end   []byte
+	// doneChans contains a list of channels passed into compactions as done
+	// channels. Each channel has a buffer size of 1 and is only passed into
+	// one compaction. This slice can grow over the lifetime of a downloadSpan.
+	doneChans []chan error
+	// compactionsStarted is the number of compactions started for this
+	// downloadSpan. Must be equal to len(doneChans)-1, i.e. there's one spare
+	// doneChan created each time a compaction starts up, for the next compaction.
+	compactionsStarted int
+}
+
 func (d *DB) addInProgressCompaction(c *compaction) {
 	d.mu.compact.inProgress[c] = struct{}{}
 	var isBase, isIntraL0 bool
@@ -2305,6 +2318,66 @@ func pickElisionOnly(picker compactionPicker, env compactionEnv) *pickedCompacti
 	return picker.pickElisionOnlyCompaction(env)
 }
 
+// maybeScheduleDownloadCompaction schedules a download compaction.
+//
+// Requires d.mu to be held.
+func (d *DB) maybeScheduleDownloadCompaction(env compactionEnv, maxConcurrentCompactions int) {
+	for len(d.mu.compact.downloads) > 0 && d.mu.compact.compactingCount < maxConcurrentCompactions {
+		v := d.mu.versions.currentVersion()
+		download := d.mu.compact.downloads[0]
+		env.inProgressCompactions = d.getInProgressCompactionInfoLocked(nil)
+		var externalFile *fileMetadata
+		var err error
+		var level int
+		for i := range v.Levels {
+			overlaps := v.Overlaps(i, d.cmp, download.start, download.end, true /* exclusiveEnd */)
+			iter := overlaps.Iter()
+			provider := d.objProvider
+			for f := iter.First(); f != nil; f = iter.Next() {
+				var objMeta objstorage.ObjectMetadata
+				objMeta, err = provider.Lookup(fileTypeTable, f.FileBacking.DiskFileNum)
+				if err != nil {
+					break
+				}
+				if objMeta.IsExternal() {
+					if f.IsCompacting() {
+						continue
+					}
+					externalFile = f
+					level = i
+					break
+				}
+			}
+			if externalFile != nil || err != nil {
+				break
+			}
+		}
+		if err != nil {
+			d.mu.compact.downloads = d.mu.compact.downloads[1:]
+			download.doneChans[download.compactionsStarted] <- err
+			continue
+		}
+		if externalFile == nil {
+			// The entirety of this span is downloaded, or is being downloaded right
+			// now. No need to schedule additional downloads for this span.
+			d.mu.compact.downloads = d.mu.compact.downloads[1:]
+			continue
+		}
+		pc := pickDownloadCompaction(v, d.opts, env, d.mu.versions.picker.getBaseLevel(), download, level, externalFile)
+		if pc != nil {
+			doneCh := download.doneChans[download.compactionsStarted]
+			download.compactionsStarted++
+			// Create another doneChan for the next compaction.
+			download.doneChans = append(download.doneChans, make(chan error, 1))
+
+			c := newCompaction(pc, d.opts, d.timeNow(), d.ObjProvider())
+			d.mu.compact.compactingCount++
+			d.addInProgressCompaction(c)
+			go d.compact(c, doneCh)
+		}
+	}
+}
+
 // maybeScheduleCompactionPicker schedules a compaction if necessary,
 // calling `pickFunc` to pick automatic compactions.
 //
@@ -2399,6 +2472,8 @@ func (d *DB) maybeScheduleCompactionPicker(
 		d.addInProgressCompaction(c)
 		go d.compact(c, nil)
 	}
+
+	d.maybeScheduleDownloadCompaction(env, maxConcurrentCompactions)
 }
 
 // deleteCompactionHintType indicates whether the deleteCompactionHint was

--- a/db.go
+++ b/db.go
@@ -427,6 +427,9 @@ type DB struct {
 			// The list of manual compactions. The next manual compaction to perform
 			// is at the start of the list. New entries are added to the end.
 			manual []*manualCompaction
+			// downloads is the list of suggested download tasks. The next download to
+			// perform is at the start of the list. New entries are added to the end.
+			downloads []*downloadSpan
 			// inProgress is the set of in-progress flushes and compactions.
 			// It's used in the calculation of some metrics and to initialize L0
 			// sublevels' state. Some of the compactions contained within this
@@ -1894,6 +1897,108 @@ type DownloadSpan struct {
 	EndKey []byte
 }
 
+func (d *DB) downloadSpan(ctx context.Context, span DownloadSpan) error {
+	dSpan := &downloadSpan{
+		start: span.StartKey,
+		end:   span.EndKey,
+		// Protected by d.mu.
+		doneChans: make([]chan error, 1),
+	}
+	dSpan.doneChans[0] = make(chan error, 1)
+	doneChan := dSpan.doneChans[0]
+	compactionIdx := 0
+
+	func() {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+
+		d.mu.compact.downloads = append(d.mu.compact.downloads, dSpan)
+		d.maybeScheduleCompaction()
+	}()
+
+	// Requires d.mu to be held.
+	noExternalFilesInSpan := func() (noExternalFiles bool) {
+		vers := d.mu.versions.currentVersion()
+
+		for i := 0; i < len(vers.Levels); i++ {
+			if vers.Levels[i].Empty() {
+				continue
+			}
+			overlap := vers.Overlaps(i, d.cmp, span.StartKey, span.EndKey, true /* exclusiveEnd */)
+			foundExternalFile := false
+			overlap.Each(func(metadata *manifest.FileMetadata) {
+				objMeta, err := d.objProvider.Lookup(fileTypeTable, metadata.FileBacking.DiskFileNum)
+				if err != nil {
+					return
+				}
+				if objMeta.IsExternal() {
+					foundExternalFile = true
+				}
+			})
+			if foundExternalFile {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Requires d.mu to be held.
+	removeUsFromList := func() {
+		// Check where we are in d.mu.compact.downloads. Remove us from the
+		// list.
+		for i := range d.mu.compact.downloads {
+			if d.mu.compact.downloads[i] != dSpan {
+				continue
+			}
+			copy(d.mu.compact.downloads[i:], d.mu.compact.downloads[i+1:])
+			d.mu.compact.downloads = d.mu.compact.downloads[:len(d.mu.compact.downloads)-1]
+			break
+		}
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			d.mu.Lock()
+			defer d.mu.Unlock()
+			removeUsFromList()
+			return ctx.Err()
+		case err := <-doneChan:
+			if err != nil {
+				d.mu.Lock()
+				defer d.mu.Unlock()
+				removeUsFromList()
+				return err
+			}
+			compactionIdx++
+			// Grab the next doneCh to wait on.
+			func() {
+				d.mu.Lock()
+				defer d.mu.Unlock()
+				doneChan = dSpan.doneChans[compactionIdx]
+			}()
+		default:
+			doneSpan := func() bool {
+				d.mu.Lock()
+				defer d.mu.Unlock()
+				// It's possible to have downloaded all files without writing to any
+				// doneChans. This is expected if there are a significant amount
+				// of overlapping writes that schedule regular, non-download compactions.
+				if noExternalFilesInSpan() {
+					removeUsFromList()
+					return true
+				}
+				d.maybeScheduleCompaction()
+				d.mu.compact.cond.Wait()
+				return false
+			}()
+			if doneSpan {
+				return nil
+			}
+		}
+	}
+}
+
 // Download ensures that the LSM does not use any external sstables for the
 // given key ranges. It does so by performing appropriate compactions so that
 // all external data becomes available locally.
@@ -1908,7 +2013,23 @@ type DownloadSpan struct {
 // TODO(radu): consider passing a priority/impact knob to express how important
 // the download is (versus live traffic performance, LSM health).
 func (d *DB) Download(ctx context.Context, spans []DownloadSpan) error {
-	return errors.Errorf("not implemented")
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	if err := d.closed.Load(); err != nil {
+		panic(err)
+	}
+	if d.opts.ReadOnly {
+		return ErrReadOnly
+	}
+	for i := range spans {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := d.downloadSpan(ctx, spans[i]); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Flush the memtable to stable storage.

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -120,3 +120,35 @@ lsm
   000004:[a#10,DELSIZED-c#inf,RANGEDEL]
   000007:[c#11,DELSIZED-f#inf,RANGEDEL]
   000008:[f#12,DELSIZED-hh#inf,RANGEDEL]
+
+download a j
+----
+ok
+
+lsm
+----
+6:
+  000009:[a#0,SET-b#0,SET]
+  000010:[c#0,SET-e#0,SET]
+  000011:[f#0,SET-h#0,SET]
+
+iter
+first
+next
+next
+next
+next
+next
+next
+next
+next
+----
+a: (foo, .)
+b: (bar, .)
+c: (foobarbaz, .)
+d: (haha, .)
+e: (something, .)
+f: (foo, .)
+g: (foo, .)
+h: (foo, .)
+.


### PR DESCRIPTION
This change adds a simplified Download() API implementation that uses any spare compaction concurrency to schedule copy compactions on the next external file in the download spans passed in. It also tracks for progress in `Download()` and returns when all external files are gone.