### PR TITLE
*: handle non-Sets correctly in UserIteratorConfig

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -426,14 +426,18 @@ func runBatchDefineCmd(d *datadriven.TestData, b *Batch) error {
 			}
 			err = b.Merge([]byte(parts[1]), []byte(parts[2]), nil)
 		case "range-key-set":
-			if len(parts) != 5 {
-				return errors.Errorf("%s expects 4 arguments", parts[0])
+			if len(parts) < 4 || len(parts) > 5 {
+				return errors.Errorf("%s expects 3 or 4 arguments", parts[0])
+			}
+			var val []byte
+			if len(parts) == 5 {
+				val = []byte(parts[4])
 			}
 			err = b.RangeKeySet(
 				[]byte(parts[1]),
 				[]byte(parts[2]),
 				[]byte(parts[3]),
-				[]byte(parts[4]),
+				val,
 				nil)
 		case "range-key-unset":
 			if len(parts) != 4 {

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -312,7 +312,7 @@ func finishInitializingExternal(ctx context.Context, it *Iterator) {
 					base.InternalKeySeqNumMax,
 					it.opts.LowerBound, it.opts.UpperBound,
 					&it.hasPrefix, &it.prefixOrFullSeekKey,
-					true /* onlySets */, &it.rangeKey.internal,
+					false /* internalKeys */, &it.rangeKey.internal,
 				)
 				for i := range rangeKeyIters {
 					it.rangeKey.iterConfig.AddLevel(rangeKeyIters[i])

--- a/internal/rangekey/coalesce.go
+++ b/internal/rangekey/coalesce.go
@@ -52,15 +52,15 @@ import (
 //	                        │
 //	                        ╰── <?>.Next
 type UserIteratorConfig struct {
-	snapshot   uint64
-	comparer   *base.Comparer
-	miter      keyspan.MergingIter
-	biter      keyspan.BoundedIter
-	diter      keyspan.DefragmentingIter
-	liters     [manifest.NumLevels]keyspan.LevelIter
-	litersUsed int
-	onlySets   bool
-	bufs       *Buffers
+	snapshot     uint64
+	comparer     *base.Comparer
+	miter        keyspan.MergingIter
+	biter        keyspan.BoundedIter
+	diter        keyspan.DefragmentingIter
+	liters       [manifest.NumLevels]keyspan.LevelIter
+	litersUsed   int
+	internalKeys bool
+	bufs         *Buffers
 }
 
 // Buffers holds various buffers used for range key iteration. They're exposed
@@ -79,9 +79,10 @@ func (bufs *Buffers) PrepareForReuse() {
 
 // Init initializes the range key iterator stack for user iteration. The
 // resulting fragment iterator applies range key semantics, defragments spans
-// according to their user-observable state and, if onlySets = true, removes all
+// according to their user-observable state and, if !internalKeys, removes all
 // Keys other than RangeKeySets describing the current state of range keys. The
-// resulting spans contain Keys sorted by Suffix.
+// resulting spans contain Keys sorted by suffix (unless internalKeys is true,
+// in which case they remain sorted by trailer descending).
 //
 // The snapshot sequence number parameter determines which keys are visible. Any
 // keys not visible at the provided snapshot are ignored.
@@ -91,16 +92,20 @@ func (ui *UserIteratorConfig) Init(
 	lower, upper []byte,
 	hasPrefix *bool,
 	prefix *[]byte,
-	onlySets bool,
+	internalKeys bool,
 	bufs *Buffers,
 	iters ...keyspan.FragmentIterator,
 ) keyspan.FragmentIterator {
 	ui.snapshot = snapshot
 	ui.comparer = comparer
-	ui.onlySets = onlySets
+	ui.internalKeys = internalKeys
 	ui.miter.Init(comparer.Compare, ui, &bufs.merging, iters...)
 	ui.biter.Init(comparer.Compare, comparer.Split, &ui.miter, lower, upper, hasPrefix, prefix)
-	ui.diter.Init(comparer, &ui.biter, ui, keyspan.StaticDefragmentReducer, &bufs.defragmenting)
+	if internalKeys {
+		ui.diter.Init(comparer, &ui.biter, keyspan.DefragmentInternal, keyspan.StaticDefragmentReducer, &bufs.defragmenting)
+	} else {
+		ui.diter.Init(comparer, &ui.biter, ui, keyspan.StaticDefragmentReducer, &bufs.defragmenting)
+	}
 	ui.litersUsed = 0
 	ui.bufs = bufs
 	return &ui.diter
@@ -136,7 +141,8 @@ func (ui *UserIteratorConfig) SetBounds(lower, upper []byte) {
 // of unset keys, removal of keys overwritten by a set at the same suffix, etc)
 // and then non-RangeKeySet keys are removed. The resulting transformed spans
 // only contain RangeKeySets describing the state visible at the provided
-// sequence number, and hold their Keys sorted by Suffix.
+// sequence number, and hold their Keys sorted by Suffix (except if internalKeys
+// is true, then keys remain sorted by trailer.
 func (ui *UserIteratorConfig) Transform(cmp base.Compare, s keyspan.Span, dst *keyspan.Span) error {
 	// Apply shadowing of keys.
 	dst.Start = s.Start
@@ -148,9 +154,16 @@ func (ui *UserIteratorConfig) Transform(cmp base.Compare, s keyspan.Span, dst *k
 	if err := coalesce(ui.comparer.Equal, &ui.bufs.sortBuf, ui.snapshot, s.Keys); err != nil {
 		return err
 	}
-	// During user iteration over range keys, unsets and deletes don't matter.
-	// Remove them if onlySets = true. This step helps logical defragmentation
-	// during iteration.
+	if ui.internalKeys {
+		if s.KeysOrder != keyspan.ByTrailerDesc {
+			panic("unexpected key ordering in UserIteratorTransform with internalKeys = true")
+		}
+		dst.Keys = ui.bufs.sortBuf.Keys
+		keyspan.SortKeysByTrailer(&dst.Keys)
+		return nil
+	}
+	// During user iteration over range keys, unsets and deletes don't matter. This
+	// step helps logical defragmentation during iteration.
 	keys := ui.bufs.sortBuf.Keys
 	dst.Keys = dst.Keys[:0]
 	for i := range keys {
@@ -164,17 +177,11 @@ func (ui *UserIteratorConfig) Transform(cmp base.Compare, s keyspan.Span, dst *k
 			if invariants.Enabled && len(dst.Keys) > 0 && cmp(dst.Keys[len(dst.Keys)-1].Suffix, keys[i].Suffix) > 0 {
 				panic("pebble: keys unexpectedly not in ascending suffix order")
 			}
-			if ui.onlySets {
-				// Skip.
-				continue
-			}
-			dst.Keys = append(dst.Keys, keys[i])
+			// Skip.
+			continue
 		case base.InternalKeyKindRangeKeyDelete:
-			if ui.onlySets {
-				// Skip.
-				continue
-			}
-			dst.Keys = append(dst.Keys, keys[i])
+			// Skip.
+			continue
 		default:
 			return base.CorruptionErrorf("pebble: unrecognized range key kind %s", keys[i].Kind())
 		}
@@ -193,6 +200,10 @@ func (ui *UserIteratorConfig) Transform(cmp base.Compare, s keyspan.Span, dst *k
 // sequence numbers). It's intended for use during user iteration, when the
 // wrapped keyspan iterator is merging spans across all levels of the LSM.
 func (ui *UserIteratorConfig) ShouldDefragment(equal base.Equal, a, b *keyspan.Span) bool {
+	// This method is not called with internalKeys = true.
+	if ui.internalKeys {
+		panic("unexpected call to ShouldDefragment with internalKeys = true")
+	}
 	// This implementation must only be used on spans that have transformed by
 	// ui.Transform. The transform applies shadowing, removes all keys besides
 	// the resulting Sets and sorts the keys by suffix. Since shadowing has been
@@ -208,14 +219,12 @@ func (ui *UserIteratorConfig) ShouldDefragment(equal base.Equal, a, b *keyspan.S
 	ret := true
 	for i := range a.Keys {
 		if invariants.Enabled {
-			if ui.onlySets && (a.Keys[i].Kind() != base.InternalKeyKindRangeKeySet ||
-				b.Keys[i].Kind() != base.InternalKeyKindRangeKeySet) {
+			if a.Keys[i].Kind() != base.InternalKeyKindRangeKeySet ||
+				b.Keys[i].Kind() != base.InternalKeyKindRangeKeySet {
 				panic("pebble: unexpected non-RangeKeySet during defragmentation")
 			}
-			// Don't do a comparison with RangeKeyDeletes, as those will always sort
-			// to the end and have no suffix.
-			if i > 0 && ((a.Keys[i].Kind() != base.InternalKeyKindRangeKeyDelete && ui.comparer.Compare(a.Keys[i].Suffix, a.Keys[i-1].Suffix) < 0) ||
-				(b.Keys[i].Kind() != base.InternalKeyKindRangeKeyDelete && ui.comparer.Compare(b.Keys[i].Suffix, b.Keys[i-1].Suffix) < 0)) {
+			if i > 0 && (ui.comparer.Compare(a.Keys[i].Suffix, a.Keys[i-1].Suffix) < 0 ||
+				ui.comparer.Compare(b.Keys[i].Suffix, b.Keys[i-1].Suffix) < 0) {
 				panic("pebble: range keys not ordered by suffix during defragmentation")
 			}
 		}

--- a/internal/rangekey/coalesce_test.go
+++ b/internal/rangekey/coalesce_test.go
@@ -151,7 +151,7 @@ func TestDefragmenting(t *testing.T) {
 			var userIterCfg UserIteratorConfig
 			iter := userIterCfg.Init(testkeys.Comparer, base.InternalKeySeqNumMax,
 				nil /* lower */, nil, /* upper */
-				&hasPrefix, &prefix, true /* onlySets */, new(Buffers),
+				&hasPrefix, &prefix, false /* internalKeys */, new(Buffers),
 				keyspan.NewIter(cmp, spans))
 			for _, line := range strings.Split(td.Input, "\n") {
 				runIterOp(&buf, iter, line)
@@ -233,11 +233,11 @@ func testDefragmentingIteRandomizedOnce(t *testing.T, seed int64) {
 	var referenceCfg, fragmentedCfg UserIteratorConfig
 	referenceIter := referenceCfg.Init(testkeys.Comparer, base.InternalKeySeqNumMax,
 		nil /* lower */, nil, /* upper */
-		new(bool), new([]byte), true /* ßonlySets */, new(Buffers),
+		new(bool), new([]byte), false /* internalKeys */, new(Buffers),
 		keyspan.NewIter(cmp, original))
 	fragmentedIter := fragmentedCfg.Init(testkeys.Comparer, base.InternalKeySeqNumMax,
 		nil /* lower */, nil, /* upper */
-		new(bool), new([]byte), true /* onlySets */, new(Buffers),
+		new(bool), new([]byte), false /* internalKeys */, new(Buffers),
 		keyspan.NewIter(cmp, fragmented))
 
 	// Generate 100 random operations and run them against both iterators.
@@ -370,7 +370,7 @@ func BenchmarkTransform(b *testing.B) {
 	var ui UserIteratorConfig
 	reinit := func() {
 		bufs.PrepareForReuse()
-		_ = ui.Init(testkeys.Comparer, math.MaxUint64, nil, nil, new(bool), nil, false /* onlySets */, &bufs)
+		_ = ui.Init(testkeys.Comparer, math.MaxUint64, nil, nil, new(bool), nil, true /* internalKeys */, &bufs)
 	}
 
 	for _, shadowing := range []bool{false, true} {

--- a/range_keys.go
+++ b/range_keys.go
@@ -19,7 +19,7 @@ import (
 func (i *Iterator) constructRangeKeyIter() {
 	i.rangeKey.rangeKeyIter = i.rangeKey.iterConfig.Init(
 		&i.comparer, i.seqNum, i.opts.LowerBound, i.opts.UpperBound,
-		&i.hasPrefix, &i.prefixOrFullSeekKey, true /* onlySets */, &i.rangeKey.rangeKeyBuffers.internal)
+		&i.hasPrefix, &i.prefixOrFullSeekKey, false /* internalKeys */, &i.rangeKey.rangeKeyBuffers.internal)
 
 	// If there's an indexed batch with range keys, include it.
 	if i.batch != nil {

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -852,7 +852,7 @@ func (i *scanInternalIterator) constructRangeKeyIter() {
 	// RangeKeyUnsets and RangeKeyDels.
 	i.rangeKey.rangeKeyIter = i.rangeKey.iterConfig.Init(
 		i.comparer, i.seqNum, i.opts.LowerBound, i.opts.UpperBound,
-		nil /* hasPrefix */, nil /* prefix */, false, /* onlySets */
+		nil /* hasPrefix */, nil /* prefix */, true, /* internalKeys */
 		&i.rangeKey.rangeKeyBuffers.internal)
 
 	// Next are the flushables: memtables and large batches.

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -19,9 +19,10 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/itertest"
 	"github.com/cockroachdb/pebble/internal/keyspan"
+	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/objstorage/remote"
-	"github.com/cockroachdb/pebble/rangekey"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -215,7 +216,7 @@ func TestScanInternal(t *testing.T) {
 			lower, upper []byte,
 			visitPointKey func(key *InternalKey, value LazyValue, iterInfo IteratorLevel) error,
 			visitRangeDel func(start, end []byte, seqNum uint64) error,
-			visitRangeKey func(start, end []byte, keys []rangekey.Key) error,
+			visitRangeKey func(start, end []byte, keys []keyspan.Key) error,
 			visitSharedFile func(sst *SharedSSTMeta) error,
 		) error
 	}
@@ -227,7 +228,7 @@ func TestScanInternal(t *testing.T) {
 			FS:                 vfs.NewMem(),
 			Logger:             testLogger{t: t},
 			Comparer:           testkeys.Comparer,
-			FormatMajorVersion: FormatRangeKeys,
+			FormatMajorVersion: FormatVirtualSSTables,
 			BlockPropertyCollectors: []func() BlockPropertyCollector{
 				sstable.NewTestKeysBlockPropertyCollector,
 			},
@@ -385,6 +386,7 @@ func TestScanInternal(t *testing.T) {
 			var name string
 			td.MaybeScanArgs(t, "name", &name)
 			commit := td.HasArg("commit")
+			ingest := td.HasArg("ingest")
 			b := d.NewIndexedBatch()
 			require.NoError(t, runBatchDefineCmd(td, b))
 			var err error
@@ -397,6 +399,35 @@ func TestScanInternal(t *testing.T) {
 					}()
 					err = b.Commit(nil)
 				}()
+			} else if ingest {
+				points, rangeDels, rangeKeys := batchSort(b)
+				file, err := d.opts.FS.Create("temp0.sst")
+				require.NoError(t, err)
+				w := sstable.NewWriter(objstorageprovider.NewFileWritable(file), d.opts.MakeWriterOptions(0, sstable.TableFormatPebblev4))
+				for span := rangeDels.First(); span != nil; span = rangeDels.Next() {
+					require.NoError(t, w.DeleteRange(span.Start, span.End))
+				}
+				rangeDels.Close()
+				for span := rangeKeys.First(); span != nil; span = rangeKeys.Next() {
+					keys := []keyspan.Key{}
+					for i := range span.Keys {
+						keys = append(keys, span.Keys[i])
+						keys[i].Trailer = base.MakeTrailer(0, keys[i].Kind())
+					}
+					keyspan.SortKeysByTrailer(&keys)
+					newSpan := &keyspan.Span{Start: span.Start, End: span.End, Keys: keys}
+					rangekey.Encode(newSpan, w.AddRangeKey)
+				}
+				rangeKeys.Close()
+				for key, val := points.First(); key != nil; key, val = points.Next() {
+					var value []byte
+					value, _, err = val.Value(value)
+					require.NoError(t, err)
+					require.NoError(t, w.Add(*key, value))
+				}
+				points.Close()
+				require.NoError(t, w.Close())
+				require.NoError(t, d.Ingest([]string{"temp0.sst"}))
 			} else if name != "" {
 				batches[name] = b
 			}
@@ -471,7 +502,7 @@ func TestScanInternal(t *testing.T) {
 					fmt.Fprintf(&b, "%s-%s#%d,RANGEDEL\n", start, end, seqNum)
 					return nil
 				},
-				func(start, end []byte, keys []rangekey.Key) error {
+				func(start, end []byte, keys []keyspan.Key) error {
 					s := keyspan.Span{Start: start, End: end, Keys: keys}
 					fmt.Fprintf(&b, "%s\n", s.String())
 					return nil

--- a/testdata/scan_internal
+++ b/testdata/scan_internal
@@ -122,8 +122,8 @@ reset
 # the unset/del must also be returned to the user.
 
 batch commit
-range-key-set a c @8 foo
-range-key-set b e @6 bar
+range-key-set a c @8
+range-key-set b e @6
 ----
 committed 2 keys
 
@@ -151,9 +151,9 @@ committed 1 keys
 scan-internal
 ----
 a-b:{(#0,RANGEKEYDEL)}
-b-c:{(#0,RANGEKEYSET,@8,foo) (#0,RANGEKEYUNSET,@6)}
+b-c:{(#0,RANGEKEYSET,@8) (#0,RANGEKEYUNSET,@6)}
 c-d:{(#0,RANGEKEYUNSET,@6)}
-d-e:{(#0,RANGEKEYSET,@6,bar)}
+d-e:{(#0,RANGEKEYSET,@6)}
 
 flush
 ----
@@ -169,9 +169,39 @@ lsm
 scan-internal
 ----
 a-b:{(#0,RANGEKEYDEL)}
-b-c:{(#0,RANGEKEYSET,@8,foo) (#0,RANGEKEYUNSET,@6)}
+b-c:{(#0,RANGEKEYSET,@8) (#0,RANGEKEYUNSET,@6)}
 c-d:{(#0,RANGEKEYUNSET,@6)}
-d-e:{(#0,RANGEKEYSET,@6,bar)}
+d-e:{(#0,RANGEKEYSET,@6)}
+
+batch ingest
+range-key-set e f @3
+range-key-unset f g @3
+----
+wrote 2 keys to batch ""
+
+scan-internal
+----
+a-b:{(#0,RANGEKEYDEL)}
+b-c:{(#0,RANGEKEYSET,@8) (#0,RANGEKEYUNSET,@6)}
+c-d:{(#0,RANGEKEYUNSET,@6)}
+d-e:{(#0,RANGEKEYSET,@6)}
+e-f:{(#0,RANGEKEYSET,@3)}
+f-g:{(#0,RANGEKEYUNSET,@3)}
+
+batch ingest
+range-key-unset e f @3
+range-key-set f g @3
+----
+wrote 2 keys to batch ""
+
+scan-internal
+----
+a-b:{(#0,RANGEKEYDEL)}
+b-c:{(#0,RANGEKEYSET,@8) (#0,RANGEKEYUNSET,@6)}
+c-d:{(#0,RANGEKEYUNSET,@6)}
+d-e:{(#0,RANGEKEYSET,@6)}
+e-f:{(#0,RANGEKEYUNSET,@3)}
+f-g:{(#0,RANGEKEYSET,@3)}
 
 # Range key masking is not exercised, with range keys that could mask point
 # keys being returned alongside point keys.


### PR DESCRIPTION
This change moves the `scanInternalIterator` use case of
UserIteratorConfig over to something that's closer to
rangeKeyCompactionTransform, where internal keys are coalesced
using rangekey.coalesce, key order is maintained at ByTrailerDesc,
and defragmentation happens by internal key using
keyspan.DefragmentInternal. The onlySets var is renamed to internalKeys
and its meaning is reversed.

Fixes #3058.