### PR TITLE
*: shared ingestion fixes

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -1155,7 +1155,7 @@ func runSSTablePropertiesCmd(t *testing.T, td *datadriven.TestData, d *DB) strin
 	var v sstable.VirtualReader
 	props := r.Properties.String()
 	if m != nil && m.Virtual {
-		v = sstable.MakeVirtualReader(r, m.VirtualMeta())
+		v = sstable.MakeVirtualReader(r, m.VirtualMeta(), false /* isForeign */)
 		props = v.Properties.String()
 	}
 	if len(td.Input) == 0 {

--- a/db.go
+++ b/db.go
@@ -2942,6 +2942,15 @@ func (d *DB) checkVirtualBounds(m *fileMetadata) {
 		return
 	}
 
+	objMeta, err := d.objProvider.Lookup(fileTypeTable, m.FileBacking.DiskFileNum)
+	if err != nil {
+		panic(err)
+	}
+	if objMeta.IsExternal() {
+		// Nothing to do; bounds are expected to be loose.
+		return
+	}
+
 	if m.HasPointKeys {
 		pointIter, rangeDelIter, err := d.newIters(context.TODO(), m, nil, internalIterOpts{})
 		if err != nil {

--- a/ingest.go
+++ b/ingest.go
@@ -1529,12 +1529,6 @@ func (d *DB) ingest(
 		}
 	}
 
-	if invariants.Enabled {
-		for _, sharedMeta := range loadResult.sharedMeta {
-			d.checkVirtualBounds(sharedMeta)
-		}
-	}
-
 	info := TableIngestInfo{
 		JobID:     jobID,
 		Err:       err,
@@ -1737,7 +1731,6 @@ func (d *DB) excise(
 				return nil, err
 			}
 			leftFile.ValidateVirtual(m)
-			d.checkVirtualBounds(leftFile)
 			ve.NewFiles = append(ve.NewFiles, newFileEntry{Level: level, Meta: leftFile})
 			needsBacking = true
 			numCreatedFiles++
@@ -1859,7 +1852,6 @@ func (d *DB) excise(
 			rightFile.Size = 1
 		}
 		rightFile.ValidateVirtual(m)
-		d.checkVirtualBounds(rightFile)
 		ve.NewFiles = append(ve.NewFiles, newFileEntry{Level: level, Meta: rightFile})
 		needsBacking = true
 		numCreatedFiles++

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -668,7 +668,17 @@ func scanInternalImpl(
 		case InternalKeyKindRangeKeyDelete, InternalKeyKindRangeKeyUnset, InternalKeyKindRangeKeySet:
 			if opts.visitRangeKey != nil {
 				span := iter.unsafeSpan()
-				if err := opts.visitRangeKey(span.Start, span.End, span.Keys); err != nil {
+				// NB: The caller isn't interested in the sequence numbers of these
+				// range keys. Rather, the caller wants them to be in trailer order
+				// _after_ zeroing of sequence numbers. Copy span.Keys, sort it, and then
+				// call visitRangeKey.
+				keysCopy := make([]keyspan.Key, len(span.Keys))
+				for i := range span.Keys {
+					keysCopy[i] = span.Keys[i]
+					keysCopy[i].Trailer = base.MakeTrailer(0, span.Keys[i].Kind())
+				}
+				keyspan.SortKeysByTrailer(&keysCopy)
+				if err := opts.visitRangeKey(span.Start, span.End, keysCopy); err != nil {
 					return err
 				}
 			}

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -380,7 +380,7 @@ func (r *Reader) newCompactionIter(
 		err := i.init(
 			context.Background(),
 			r, v, nil /* lower */, nil /* upper */, nil,
-			false /* useFilter */, false, /* hideObsoletePoints */
+			false /* useFilter */, v != nil && v.isForeign, /* hideObsoletePoints */
 			nil /* stats */, categoryAndQoS, statsCollector, rp, bufferPool,
 		)
 		if err != nil {
@@ -395,7 +395,7 @@ func (r *Reader) newCompactionIter(
 	i := singleLevelIterPool.Get().(*singleLevelIterator)
 	err := i.init(
 		context.Background(), r, v, nil /* lower */, nil, /* upper */
-		nil, false /* useFilter */, false, /* hideObsoletePoints */
+		nil, false /* useFilter */, v != nil && v.isForeign, /* hideObsoletePoints */
 		nil /* stats */, categoryAndQoS, statsCollector, rp, bufferPool,
 	)
 	if err != nil {

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -345,7 +345,7 @@ func TestVirtualReader(t *testing.T) {
 			vMeta.ValidateVirtual(meta.FileMetadata)
 
 			vMeta1 = vMeta.VirtualMeta()
-			v = MakeVirtualReader(r, vMeta1)
+			v = MakeVirtualReader(r, vMeta1, false /* isForeign */)
 			return formatVirtualReader(&v)
 
 		case "citer":

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -27,10 +27,11 @@ type VirtualReader struct {
 
 // Lightweight virtual sstable state which can be passed to sstable iterators.
 type virtualState struct {
-	lower   InternalKey
-	upper   InternalKey
-	fileNum base.FileNum
-	Compare Compare
+	lower     InternalKey
+	upper     InternalKey
+	fileNum   base.FileNum
+	Compare   Compare
+	isForeign bool
 }
 
 func ceilDiv(a, b uint64) uint64 {
@@ -39,16 +40,19 @@ func ceilDiv(a, b uint64) uint64 {
 
 // MakeVirtualReader is used to contruct a reader which can read from virtual
 // sstables.
-func MakeVirtualReader(reader *Reader, meta manifest.VirtualFileMeta) VirtualReader {
+func MakeVirtualReader(
+	reader *Reader, meta manifest.VirtualFileMeta, isForeign bool,
+) VirtualReader {
 	if reader.fileNum != meta.FileBacking.DiskFileNum {
 		panic("pebble: invalid call to MakeVirtualReader")
 	}
 
 	vState := virtualState{
-		lower:   meta.Smallest,
-		upper:   meta.Largest,
-		fileNum: meta.FileNum,
-		Compare: reader.Compare,
+		lower:     meta.Smallest,
+		upper:     meta.Largest,
+		fileNum:   meta.FileNum,
+		Compare:   reader.Compare,
+		isForeign: isForeign,
 	}
 	v := VirtualReader{
 		vState: vState,

--- a/testdata/scan_internal
+++ b/testdata/scan_internal
@@ -26,9 +26,9 @@ ok
 
 scan-internal file-only-snapshot=efos1
 ----
-a-c:{(#10,RANGEKEYSET,@5,boop)}
+a-c:{(#0,RANGEKEYSET,@5,boop)}
 b#12,1 (d)
-c-e:{(#11,RANGEKEYSET,@5,beep)}
+c-e:{(#0,RANGEKEYSET,@5,beep)}
 e#13,1 (foo)
 
 flush
@@ -36,9 +36,9 @@ flush
 
 scan-internal
 ----
-a-c:{(#10,RANGEKEYSET,@5,boop)}
+a-c:{(#0,RANGEKEYSET,@5,boop)}
 b#12,1 (d)
-c-e:{(#11,RANGEKEYSET,@5,beep)}
+c-e:{(#0,RANGEKEYSET,@5,beep)}
 e#13,1 (foo)
 
 # Keys deleted by rangedels are elided.
@@ -50,9 +50,9 @@ committed 1 keys
 
 scan-internal
 ----
-a-c:{(#10,RANGEKEYSET,@5,boop)}
+a-c:{(#0,RANGEKEYSET,@5,boop)}
 b-d#14,RANGEDEL
-c-e:{(#11,RANGEKEYSET,@5,beep)}
+c-e:{(#0,RANGEKEYSET,@5,beep)}
 e#13,1 (foo)
 
 flush
@@ -60,17 +60,17 @@ flush
 
 scan-internal
 ----
-a-c:{(#10,RANGEKEYSET,@5,boop)}
+a-c:{(#0,RANGEKEYSET,@5,boop)}
 b-d#14,RANGEDEL
-c-e:{(#11,RANGEKEYSET,@5,beep)}
+c-e:{(#0,RANGEKEYSET,@5,beep)}
 e#13,1 (foo)
 
 # Snapshots work with scan internal.
 
 scan-internal snapshot=foo
 ----
-a-c:{(#10,RANGEKEYSET,@5,boop)}
-c-e:{(#11,RANGEKEYSET,@5,beep)}
+a-c:{(#0,RANGEKEYSET,@5,boop)}
+c-e:{(#0,RANGEKEYSET,@5,beep)}
 
 wait-for-file-only-snapshot efos1
 ----
@@ -78,9 +78,9 @@ ok
 
 scan-internal file-only-snapshot=efos1
 ----
-a-c:{(#10,RANGEKEYSET,@5,boop)}
+a-c:{(#0,RANGEKEYSET,@5,boop)}
 b#12,1 (d)
-c-e:{(#11,RANGEKEYSET,@5,beep)}
+c-e:{(#0,RANGEKEYSET,@5,beep)}
 e#13,1 (foo)
 
 # Force keys newer than the snapshot into a lower level, then try skip-shared
@@ -105,15 +105,15 @@ file 000008 contains keys newer than snapshot: pebble: cannot use skip-shared it
 
 scan-internal lower=bb upper=dd
 ----
-bb-c:{(#10,RANGEKEYSET,@5,boop)}
+bb-c:{(#0,RANGEKEYSET,@5,boop)}
 bb-d#14,RANGEDEL
-c-dd:{(#11,RANGEKEYSET,@5,beep)}
+c-dd:{(#0,RANGEKEYSET,@5,beep)}
 
 scan-internal lower=b upper=cc
 ----
-b-c:{(#10,RANGEKEYSET,@5,boop)}
+b-c:{(#0,RANGEKEYSET,@5,boop)}
 b-cc#14,RANGEDEL
-c-cc:{(#11,RANGEKEYSET,@5,beep)}
+c-cc:{(#0,RANGEKEYSET,@5,beep)}
 
 reset
 ----
@@ -150,10 +150,10 @@ committed 1 keys
 
 scan-internal
 ----
-a-b:{(#13,RANGEKEYDEL)}
-b-c:{(#10,RANGEKEYSET,@8,foo) (#12,RANGEKEYUNSET,@6)}
-c-d:{(#12,RANGEKEYUNSET,@6)}
-d-e:{(#11,RANGEKEYSET,@6,bar)}
+a-b:{(#0,RANGEKEYDEL)}
+b-c:{(#0,RANGEKEYSET,@8,foo) (#0,RANGEKEYUNSET,@6)}
+c-d:{(#0,RANGEKEYUNSET,@6)}
+d-e:{(#0,RANGEKEYSET,@6,bar)}
 
 flush
 ----
@@ -168,10 +168,10 @@ lsm
 
 scan-internal
 ----
-a-b:{(#13,RANGEKEYDEL)}
-b-c:{(#10,RANGEKEYSET,@8,foo) (#12,RANGEKEYUNSET,@6)}
-c-d:{(#12,RANGEKEYUNSET,@6)}
-d-e:{(#11,RANGEKEYSET,@6,bar)}
+a-b:{(#0,RANGEKEYDEL)}
+b-c:{(#0,RANGEKEYSET,@8,foo) (#0,RANGEKEYUNSET,@6)}
+c-d:{(#0,RANGEKEYUNSET,@6)}
+d-e:{(#0,RANGEKEYSET,@6,bar)}
 
 # Range key masking is not exercised, with range keys that could mask point
 # keys being returned alongside point keys.
@@ -192,9 +192,9 @@ committed 2 keys
 
 scan-internal
 ----
-a-c:{(#11,RANGEKEYSET,@5,boop)}
+a-c:{(#0,RANGEKEYSET,@5,boop)}
 b@3#10,1 (bar)
-c-e:{(#12,RANGEKEYSET,@5,beep)}
+c-e:{(#0,RANGEKEYSET,@5,beep)}
 
 # Point keys are collapsed in a way similar to a compaction.
 
@@ -283,7 +283,7 @@ lsm
 
 scan-internal
 ----
-a-c:{(#11,RANGEKEYSET,@5,boop)}
+a-c:{(#0,RANGEKEYSET,@5,boop)}
 b@3#10,1 (bar)
 c-e#12,RANGEDEL
 f@8#13,1 (baz)


### PR DESCRIPTION
Contains 3 commits, each of which contains some fixes around shared/foreign sstables.

### *: set hideObsoletePoints=true for shared foreign sstables

Previously, we weren't setting hideObsoletePoints to true for
compaction iters created out of shared foreign sstables. This
change addresses that by passing that state through virtualState
in VirtualReader through to the old Reader.

Unblocks https://github.com/cockroachdb/pebble/pull/3044.

### ingest: don't call checkVirtualBounds() in ingestion

Previously, we were calling checkVirtualBounds on FileMetadatas
before they were installed. This would lead to panics in invariant
builds as we would try to load an uninstalled FileMetadata
from the table cache.

This change removes the checkVirtualBounds call, making it a test-only
thing. Adding a check after version installation also doesn't guarantee
that refs will be nonzero, as a compaction immediately after ingestApply
is possible.

Only an issue with invariants builds. Unblocks https://github.com/cockroachdb/pebble/pull/3044.


### scan_internal: Sort keys by kind before calling visitor

Previously, we were passing range keys that were sorted by trailer
descending right from ScanInternal. However, the caller isn't
interested in seqnum-based sorting, only kind-based trailer sorting.
This change zeroes seqnums before sorting the keys.

Unblocks https://github.com/cockroachdb/pebble/pull/3044.