### PR TITLE
objstorage/objstorageprovider: save custom object name to catalog

### DIFF
--- a/objstorage/objstorage.go
+++ b/objstorage/objstorage.go
@@ -141,7 +141,7 @@ func (meta *ObjectMetadata) AssertValid() {
 			panic(errors.AssertionFailedf("meta.Remote not empty: %#v", meta.Remote))
 		}
 	} else {
-		if meta.Remote.CustomObjectName != "" {
+		if meta.Remote.CustomObjectName == "" {
 			if meta.Remote.CreatorID == 0 {
 				panic(errors.AssertionFailedf("CreatorID not set"))
 			}

--- a/objstorage/objstorageprovider/provider.go
+++ b/objstorage/objstorageprovider/provider.go
@@ -464,12 +464,13 @@ func (p *provider) addMetadata(meta objstorage.ObjectMetadata) {
 	p.mu.knownObjects[meta.DiskFileNum] = meta
 	if meta.IsRemote() {
 		p.mu.remote.catalogBatch.AddObject(remoteobjcat.RemoteObjectMetadata{
-			FileNum:        meta.DiskFileNum,
-			FileType:       meta.FileType,
-			CreatorID:      meta.Remote.CreatorID,
-			CreatorFileNum: meta.Remote.CreatorFileNum,
-			Locator:        meta.Remote.Locator,
-			CleanupMethod:  meta.Remote.CleanupMethod,
+			FileNum:          meta.DiskFileNum,
+			FileType:         meta.FileType,
+			CreatorID:        meta.Remote.CreatorID,
+			CreatorFileNum:   meta.Remote.CreatorFileNum,
+			Locator:          meta.Remote.Locator,
+			CleanupMethod:    meta.Remote.CleanupMethod,
+			CustomObjectName: meta.Remote.CustomObjectName,
 		})
 	} else {
 		p.mu.localObjectsChanged = true

--- a/objstorage/objstorageprovider/provider_test.go
+++ b/objstorage/objstorageprovider/provider_test.go
@@ -593,7 +593,7 @@ func TestParallelSync(t *testing.T) {
 							}
 						}
 					}
-				}(numOps*n, shared)
+				}(numOps*(n+1), shared)
 			}
 			wg.Wait()
 		})

--- a/objstorage/objstorageprovider/remote_backing.go
+++ b/objstorage/objstorageprovider/remote_backing.go
@@ -276,12 +276,13 @@ func (p *provider) AttachRemoteObjects(
 		defer p.mu.Unlock()
 		for _, d := range decoded {
 			p.mu.remote.catalogBatch.AddObject(remoteobjcat.RemoteObjectMetadata{
-				FileNum:        d.meta.DiskFileNum,
-				FileType:       d.meta.FileType,
-				CreatorID:      d.meta.Remote.CreatorID,
-				CreatorFileNum: d.meta.Remote.CreatorFileNum,
-				CleanupMethod:  d.meta.Remote.CleanupMethod,
-				Locator:        d.meta.Remote.Locator,
+				FileNum:          d.meta.DiskFileNum,
+				FileType:         d.meta.FileType,
+				CreatorID:        d.meta.Remote.CreatorID,
+				CreatorFileNum:   d.meta.Remote.CreatorFileNum,
+				CleanupMethod:    d.meta.Remote.CleanupMethod,
+				Locator:          d.meta.Remote.Locator,
+				CustomObjectName: d.meta.Remote.CustomObjectName,
 			})
 		}
 	}()


### PR DESCRIPTION
Previously, we weren't adding the custom object name to the catalog. As a result, upon re-opening, various parts of pebble would treat this external object as a local object.