### PR TITLE
db: extend compaction iterator comments, tests

### DIFF
--- a/compaction_iter.go
+++ b/compaction_iter.go
@@ -333,7 +333,7 @@ func (i *compactionIter) Next() (*InternalKey, []byte) {
 		return nil, nil
 	}
 
-	// Prior to this call to `Next()` we are in one of three situations with
+	// Prior to this call to `Next()` we are in one of four situations with
 	// respect to `iterKey` and related state:
 	//
 	// - `!skip && pos == iterPosNext`: `iterKey` is already at the next key.
@@ -342,11 +342,33 @@ func (i *compactionIter) Next() (*InternalKey, []byte) {
 	//   snapshot stripe.
 	// - `skip && pos == iterPosCurForward`: We are at the key that has been returned.
 	//   To move forward we skip skippable entries in the stripe.
+	// - `skip && pos == iterPosNext && i.iterStripeChange == sameStripeNonSkippable`:
+	//    This case may occur when skipping within a snapshot stripe and we
+	//    encounter either:
+	//      a) an invalid key kind; The previous call will have returned
+	//         whatever key it was processing and deferred handling of the
+	//         invalid key to this invocation of Next(). We're responsible for
+	//         ignoring skip=true and falling into the invalid key kind case
+	//         down below.
+	//      b) an interleaved range delete; This is a wart of the current code
+	//         structure. While skipping within a snapshot stripe, a range
+	//         delete interleaved at its start key and sequence number
+	//         interrupts the sequence of point keys. After we return the range
+	//         delete to the caller, we need to pick up skipping at where we
+	//         left off, so we preserve skip=true.
+	//    TODO(jackson): This last case is confusing and can be removed if we
+	//    interleave range deletions at the maximal sequence number using the
+	//    keyspan interleaving iterator. This is the treatment given to range
+	//    keys today.
 	if i.pos == iterPosCurForward {
 		if i.skip {
 			i.skipInStripe()
 		} else {
 			i.nextInStripe()
+		}
+	} else if i.skip {
+		if i.iterStripeChange != sameStripeNonSkippable {
+			panic(errors.AssertionFailedf("compaction iterator has skip=true, but iterator is at iterPosNext"))
 		}
 	}
 
@@ -430,6 +452,12 @@ func (i *compactionIter) Next() (*InternalKey, []byte) {
 					// can be elided skip skippable keys in the same stripe.
 					i.saveKey()
 					i.skipInStripe()
+					if i.iterStripeChange == newStripeSameKey {
+						panic(errors.AssertionFailedf("pebble: skipInStripe in last stripe found a new stripe within the same key"))
+					}
+					if !i.skip && i.iterStripeChange != newStripeNewKey {
+						panic(errors.AssertionFailedf("pebble: skipInStripe in last stripe disabled skip without advancing to new key"))
+					}
 					continue
 				} else {
 					// We're not at the last snapshot stripe, so the tombstone
@@ -831,6 +859,16 @@ func (i *compactionIter) mergeNext(valueMerger ValueMerger) stripeChangeType {
 	}
 }
 
+// singleDeleteNext processes a SingleDelete point tombstone. A SingleDelete, or
+// SINGLEDEL, is unique in that it deletes exactly 1 internal key. It's a
+// performance optimization when the client knows a user key has not been
+// overwritten, allowing the elision of the tombstone earlier, avoiding write
+// amplification.
+//
+// singleDeleteNext returns a boolean indicating whether or not the caller
+// should yield the SingleDelete key to the consumer of the compactionIter. If
+// singleDeleteNext returns false, the caller may consume/elide the
+// SingleDelete.
 func (i *compactionIter) singleDeleteNext() bool {
 	// Save the current key.
 	i.saveKey()
@@ -839,6 +877,8 @@ func (i *compactionIter) singleDeleteNext() bool {
 
 	// Loop until finds a key to be passed to the next level.
 	for {
+		// If we find a key that can't be skipped, return true so that the
+		// caller yields the SingleDelete to the caller.
 		if i.nextInStripe() != sameStripeSkippable {
 			i.pos = iterPosNext
 			return true
@@ -854,11 +894,26 @@ func (i *compactionIter) singleDeleteNext() bool {
 			return true
 
 		case InternalKeyKindSet:
+			// This SingleDelete deletes the Set, and we can now elide the
+			// SingleDel as well. We advance past the Set and return false to
+			// indicate to the main compaction loop that we should NOT yield the
+			// current SingleDel key to the compaction loop.
 			i.nextInStripe()
+			// TODO(jackson): We could assert that nextInStripe either a)
+			// stepped onto a new key, or b) stepped on to a Delete, DeleteSized
+			// or SingleDel key. This would detect improper uses of SingleDel,
+			// but only when all three internal keys meet in the same compaction
+			// which is not likely.
 			i.valid = false
 			return false
 
 		case InternalKeyKindSingleDelete:
+			// Two single deletes met in a compaction. With proper deterministic
+			// use of SingleDelete, this should never happen. The expectation is
+			// that there's exactly 1 set beneath a single delete. Currently, we
+			// opt to skip it.
+			// TODO(jackson): Should we make this an error? This would also
+			// allow us to simplify the code a bit by removing the for loop.
 			continue
 
 		default:
@@ -895,7 +950,7 @@ func (i *compactionIter) deleteSizedNext() (*base.InternalKey, []byte) {
 	i.pos = iterPosNext
 	for i.nextInStripe() == sameStripeSkippable {
 		switch i.iterKey.Kind() {
-		case InternalKeyKindDelete, InternalKeyKindDeleteSized:
+		case InternalKeyKindDelete, InternalKeyKindDeleteSized, InternalKeyKindSingleDelete:
 			// We encountered a tombstone (DEL, or DELSIZED) that's deleted by
 			// the original DELSIZED tombstone. This can happen in two cases:
 			//
@@ -930,14 +985,17 @@ func (i *compactionIter) deleteSizedNext() (*base.InternalKey, []byte) {
 			}
 			i.valueBuf = append(i.valueBuf[:0], i.iterValue...)
 			i.value = i.valueBuf
-			if i.iterKey.Kind() == InternalKeyKindDelete {
-				// Convert the DELSIZED to a DEL—The DEL we're eliding may not
-				// have deleted the key(s) it was intended to yet. The ordinary
-				// DEL compaction heuristics are better suited at that, plus we
-				// don't want to count it as a missized DEL. We early exit in
-				// this case, after skipping the remainder of the snapshot
-				// stripe.
+			if i.iterKey.Kind() != InternalKeyKindDeleteSized {
+				// Convert the DELSIZED to a DEL—The DEL/SINGLEDEL we're eliding
+				// may not have deleted the key(s) it was intended to yet. The
+				// ordinary DEL compaction heuristics are better suited at that,
+				// plus we don't want to count it as a missized DEL. We early
+				// exit in this case, after skipping the remainder of the
+				// snapshot stripe.
 				i.key.SetKind(i.iterKey.Kind())
+				// NB: We skipInStripe now, rather than returning leaving
+				// i.skip=true and returning early, because Next() requires
+				// that i.skip=true only if i.iterPos = iterPosCurForward.
 				i.skipInStripe()
 				return &i.key, i.value
 			}
@@ -955,6 +1013,9 @@ func (i *compactionIter) deleteSizedNext() (*base.InternalKey, []byte) {
 			// the snapshot stripe and return.
 			if len(i.value) == 0 {
 				i.key.SetKind(InternalKeyKindDelete)
+				// NB: We skipInStripe now, rather than returning leaving
+				// i.skip=true and returning early, because Next() requires
+				// that i.skip=true only if i.iterPos = iterPosCurForward.
 				i.skipInStripe()
 				return &i.key, i.value
 			}
@@ -982,8 +1043,11 @@ func (i *compactionIter) deleteSizedNext() (*base.InternalKey, []byte) {
 				// We opt for (4) under the rationale that we can't rely on the
 				// user-provided size for accuracy, so ordinary DEL heuristics
 				// are safer.
-				i.key.SetKind(InternalKeyKindDelete)
 				i.stats.countMissizedDels++
+				i.key.SetKind(InternalKeyKindDelete)
+				i.value = i.valueBuf[:0]
+				i.skipInStripe()
+				return &i.key, i.value
 			}
 			// NB: We remove the value regardless of whether the key was sized
 			// appropriately. The size encoded is 'consumed' the first time it

--- a/testdata/compaction_iter_delete_sized
+++ b/testdata/compaction_iter_delete_sized
@@ -1578,3 +1578,285 @@ next
 a#9,0:
 .
 missized-dels=1
+
+# Test a DELSIZED that shadows a SINGLEDEL'd key.
+
+define
+a.DELSIZED.4:varint(4)
+b.SINGLEDEL.3:
+b.SET.1:val
+----
+
+iter
+first
+next
+tombstones
+----
+a#4,23:varint(4)
+.
+.
+
+# Repeat the above but with elision of tombstones.
+
+iter elide-tombstones=t
+first
+tombstones
+----
+.
+.
+
+# Test DELSIZED shadowing SINGLEDEL.
+
+define
+a.DELSIZED.4:varint(4)
+a.SET.2:foo
+b.SINGLEDEL.3:
+b.SET.1:val
+----
+
+iter
+first
+next
+tombstones
+----
+a#4,23:
+.
+.
+
+# Repeat the above but with elision of tombstones.
+
+iter elide-tombstones=t
+first
+tombstones
+----
+.
+.
+
+# Test a very subtle sequence where a elision of tombstones is active, and a
+# unskippable RANGEDEL sits between a DELSIZED and the key it was intended to
+# delete. The unskippable RANGEDEL breaks the skipping of keys within the
+# snapshot stripe, but it's ultimately okay because we preserve skip=true across
+# the RANGEDEL return.
+
+define
+a.DELSIZED.5:varint(4)
+a.RANGEDEL.4:d
+a.SET.3:foo
+----
+
+iter elide-tombstones=t
+first
+next
+tombstones
+----
+a#4,15:d
+.
+.
+
+# Try the same test as above, but with allowing sequence number zeroing as well.
+
+iter elide-tombstones=t allow-zero-seqnum=t
+first
+next
+tombstones
+----
+a#4,15:d
+.
+.
+
+# Perform a variant of the above test but with a DEL key.
+
+define
+a.DEL.5:
+a.RANGEDEL.4:d
+a.SET.3:foo
+----
+
+iter elide-tombstones=t
+first
+next
+tombstones
+----
+a#4,15:d
+.
+.
+
+# Perform a variant of the above test but with a SINGLEDEL key.
+
+define
+a.SINGLEDEL.5:
+a.RANGEDEL.4:d
+a.SET.3:foo
+----
+
+iter elide-tombstones=t
+first
+next
+tombstones
+----
+a#4,15:d
+.
+.
+
+# Perform a few variants of the above but with a range del with a seqnum equal to
+# keys. NB: When seqnums are equal, the order of keys with various kinds is:
+#
+# DeleteSized < RangeKey{Delete,Unset,Set} < SetWithDelete < RangeDelete < SingleDelete < Set < Delete
+#
+# NB: Range keys are interleaved always at the maximal sequence number, so the
+# compaction iterator should always observe them first.
+
+define
+a.SINGLEDEL.6:
+a.SETWITHDEL.5:foo
+a.RANGEDEL.5:z
+----
+
+define-range-keys
+a-z:{(#5,RANGEKEYDEL)}
+----
+
+# In the following case, the SINGLEDEL meets a SETWITHDEL, promoting the
+# SINGLEDEL into a DEL.
+
+iter
+first
+next
+next
+next
+tombstones
+----
+a#72057594037927935,19:
+a#6,0:
+a#5,15:z
+.
+a-z#5
+.
+
+# In this case, SINGLEDEL is elided (despite its transformation into a DEL) due
+# to elide-tombstones=t.
+
+iter elide-tombstones=t
+first
+next
+next
+tombstones
+----
+a#72057594037927935,19:
+a#5,15:z
+.
+.
+
+define
+a.SINGLEDEL.6:
+a.RANGEDEL.5:d
+a.SET.5:foo
+----
+
+# NB: In this case, the RANGEDEL acts as an unintentional snapshot stripe
+# change. This is a code artifact, and we will be able to remove this behavior
+# when range deletes are interleaved at the maximal sequence number by an
+# interleaving iterator (like range keys are).
+
+iter
+first
+next
+next
+next
+tombstones
+----
+a#6,7:
+a#5,15:d
+a#5,1:foo
+.
+a-d#5
+.
+
+iter elide-tombstones=t allow-zero-seqnum=t
+first
+next
+tombstones
+----
+a#5,15:d
+.
+.
+
+define
+a.SINGLEDEL.6:
+a.SETWITHDEL.5:foo
+a.RANGEDEL.5:d
+----
+
+# When the SINGLEDEL and SETWITHDEL meet, the SINGLEDEL is promoted into a DEL.
+
+iter
+first
+next
+tombstones
+----
+a#6,0:
+a#5,15:d
+a-d#5
+.
+
+iter elide-tombstones=t
+first
+next
+tombstones
+----
+a#5,15:d
+.
+.
+
+define
+a.DELSIZED.6:varint(3)
+a.RANGEDEL.5:d
+a.SET.5:foo
+----
+
+iter
+first
+next
+tombstones
+----
+a#6,23:varint(3)
+a#5,15:d
+a-d#5
+.
+
+iter elide-tombstones=t
+first
+next
+tombstones
+----
+a#5,15:d
+.
+.
+
+# Test a DELSIZED with a value that fails to decode.
+
+define
+a.DELSIZED.5:notavarint
+a.SET.4:foo
+----
+
+iter
+first
+----
+err=DELSIZED holds invalid value: 6e6f7461766172696e74
+
+# Test a value-less DELSIZED.
+
+define
+a.DELSIZED.5:
+a.SET.4:foo
+a.SET.3:bar
+----
+
+iter print-missized-dels
+first
+next
+----
+a#5,0:
+.
+missized-dels=0


### PR DESCRIPTION
The compaction iterator had a few methods and complicated edge cases that were undocumented. This commit comments some of these and adds a new assertion. It also adds a few test cases around SINGLEDEL and DELSIZED, unfruitfully trying to reproduce some form of behavior that might explain cockroachdb/cockroach#114421.