### PR TITLE
db: fix newly-introduced SINGLEDEL+DELSIZED bug

### DIFF
--- a/compaction_iter.go
+++ b/compaction_iter.go
@@ -992,7 +992,7 @@ func (i *compactionIter) deleteSizedNext() (*base.InternalKey, []byte) {
 				// plus we don't want to count it as a missized DEL. We early
 				// exit in this case, after skipping the remainder of the
 				// snapshot stripe.
-				i.key.SetKind(i.iterKey.Kind())
+				i.key.SetKind(InternalKeyKindDelete)
 				// NB: We skipInStripe now, rather than returning leaving
 				// i.skip=true and returning early, because Next() requires
 				// that i.skip=true only if i.iterPos = iterPosCurForward.

--- a/testdata/compaction_iter_delete_sized
+++ b/testdata/compaction_iter_delete_sized
@@ -1860,3 +1860,22 @@ next
 a#5,0:
 .
 missized-dels=0
+
+# Regression test for #3087.
+#
+# Whne a DELSIZED and a SINGLEDEL meet in a compaction, a DEL key should be
+# emitted.
+
+define
+a.DELSIZED.5:
+a.SINGLEDEL.3:
+a.SET.2:foo
+a.SET.1:bar
+----
+
+iter
+first
+next
+----
+a#5,0:
+.


### PR DESCRIPTION
In bfb2e6a (#3081) a small refactor the handling of DELSIZED introduced a bug when a DELSIZED shadows a SINGLEDEL. When a DELSIZED and a SINGLEDEL meet in a compaction, we began accidentally emitting a SINGLEDEL rather than a DEL, weakening the tombstone. Previously the problematic code branch was only ever executed when a DELSIZED and DEL met, so iterKey.Kind() was always DEL.

Fix #3087.