### PR TITLE
crl-release-23.2: db: guard against concurrent batch writes during Commit

### DIFF
--- a/db.go
+++ b/db.go
@@ -804,6 +804,9 @@ func (d *DB) applyInternal(batch *Batch, opts *WriteOptions, noSyncWait bool) er
 	if err := d.closed.Load(); err != nil {
 		panic(err)
 	}
+	if batch.committing {
+		panic("pebble: batch already committing")
+	}
 	if batch.applied.Load() {
 		panic("pebble: batch already applied")
 	}
@@ -834,6 +837,7 @@ func (d *DB) applyInternal(batch *Batch, opts *WriteOptions, noSyncWait bool) er
 		}
 		// TODO(jackson): Assert that all range key operands are suffixless.
 	}
+	batch.committing = true
 
 	if batch.db == nil {
 		batch.refreshMemTableSize()

--- a/open.go
+++ b/open.go
@@ -795,7 +795,8 @@ func (d *DB) replayWAL(
 
 		// Specify Batch.db so that Batch.SetRepr will compute Batch.memTableSize
 		// which is used below.
-		b = Batch{db: d}
+		b = Batch{}
+		b.db = d
 		b.SetRepr(buf.Bytes())
 		seqNum := b.SeqNum()
 		maxSeqNum = seqNum + uint64(b.Count())


### PR DESCRIPTION
23.2 backport of #3026.

Informs cockroachdb/cockroach#114421.

----

Add a guardrail that ensures a batch isn't in the process of being committed
when applying a mutation to the Batch. We've observed panics during batch
application that suggest concurrent modification of the batch, and these
guardrails will help surface any races more readily.

Informs https://github.com/cockroachdb/cockroach/issues/113268.
Informs https://github.com/cockroachdb/pebble/issues/3024.
Informs https://github.com/cockroachdb/pebble/issues/2873.