### PR TITLE
crl-release-23.2: db: enforce no split user keys in CheckOrdering

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1586,7 +1586,8 @@ func TestManualCompaction(t *testing.T) {
 		{
 			testData:   "testdata/manual_compaction_set_with_del",
 			minVersion: FormatBlockPropertyCollector,
-			maxVersion: FormatPrePebblev1MarkedCompacted,
+			// This test exercises split user keys.
+			maxVersion: FormatSplitUserKeysMarkedCompacted - 1,
 		},
 		{
 			testData:   "testdata/singledel_manual_compaction",
@@ -1607,7 +1608,8 @@ func TestManualCompaction(t *testing.T) {
 		{
 			testData:   "testdata/manual_compaction_file_boundaries",
 			minVersion: FormatBlockPropertyCollector,
-			maxVersion: FormatPrePebblev1MarkedCompacted,
+			// This test exercises split user keys.
+			maxVersion: FormatSplitUserKeysMarkedCompacted - 1,
 		},
 		{
 			testData:   "testdata/manual_compaction_file_boundaries_delsized",

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -219,6 +219,18 @@ func (v FormatMajorVersion) MinTableFormat() sstable.TableFormat {
 	}
 }
 
+// orderingInvariants returns an enum encoding the set of invariants that must
+// hold within the receiver format major version. Invariants only get stricter
+// as the format major version advances, so it is okay to retrieve the
+// invariants from the current format major version and by the time the
+// invariants are enforced, the format major version has advanced.
+func (v FormatMajorVersion) orderingInvariants() manifest.OrderingInvariants {
+	if v < FormatSplitUserKeysMarkedCompacted {
+		return manifest.AllowSplitUserKeys
+	}
+	return manifest.ProhibitSplitUserKeys
+}
+
 // formatMajorVersionMigrations defines the migrations from one format
 // major version to the next. Each migration is defined as a closure
 // which will be invoked on the database before the new format major

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -515,7 +515,7 @@ func TestGetIter(t *testing.T) {
 			files[tt.level] = append(files[tt.level], meta)
 		}
 		v := manifest.NewVersion(cmp, base.DefaultFormatter, 10<<20, files)
-		err := v.CheckOrdering(cmp, base.DefaultFormatter)
+		err := v.CheckOrdering(cmp, base.DefaultFormatter, manifest.AllowSplitUserKeys)
 		if tc.badOrdering && err == nil {
 			t.Errorf("desc=%q: want bad ordering, got nil error", desc)
 			continue

--- a/internal/keyspan/level_iter_test.go
+++ b/internal/keyspan/level_iter_test.go
@@ -309,7 +309,7 @@ func TestLevelIterEquivalence(t *testing.T) {
 				amap[metas[i].FileNum] = metas[i]
 			}
 			b.Added[6] = amap
-			v, err := b.Apply(nil, base.DefaultComparer.Compare, base.DefaultFormatter, 0, 0, nil)
+			v, err := b.Apply(nil, base.DefaultComparer.Compare, base.DefaultFormatter, 0, 0, nil, manifest.ProhibitSplitUserKeys)
 			require.NoError(t, err)
 			levelIter.Init(
 				SpanIterOptions{}, base.DefaultComparer.Compare, tableNewIters,
@@ -448,7 +448,7 @@ func TestLevelIter(t *testing.T) {
 					amap[metas[i].FileNum] = metas[i]
 				}
 				b.Added[6] = amap
-				v, err := b.Apply(nil, base.DefaultComparer.Compare, base.DefaultFormatter, 0, 0, nil)
+				v, err := b.Apply(nil, base.DefaultComparer.Compare, base.DefaultFormatter, 0, 0, nil, manifest.ProhibitSplitUserKeys)
 				require.NoError(t, err)
 				iter = NewLevelIter(
 					SpanIterOptions{}, base.DefaultComparer.Compare,

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -50,7 +50,7 @@ func readManifest(filename string) (*Version, error) {
 		if err := bve.Accumulate(&ve); err != nil {
 			return nil, err
 		}
-		if v, err = bve.Apply(v, base.DefaultComparer.Compare, base.DefaultFormatter, 10<<20, 32000, nil); err != nil {
+		if v, err = bve.Apply(v, base.DefaultComparer.Compare, base.DefaultFormatter, 10<<20, 32000, nil, ProhibitSplitUserKeys); err != nil {
 			return nil, err
 		}
 	}
@@ -447,7 +447,7 @@ func TestL0Sublevels(t *testing.T) {
 			for sublevel, files := range sublevels.levelFiles {
 				slice := NewLevelSliceSpecificOrder(files)
 				err := CheckOrdering(base.DefaultComparer.Compare, base.DefaultFormatter,
-					L0Sublevel(sublevel), slice.Iter())
+					L0Sublevel(sublevel), slice.Iter(), ProhibitSplitUserKeys)
 				if err != nil {
 					return err.Error()
 				}

--- a/internal/manifest/testdata/version_check_ordering
+++ b/internal/manifest/testdata/version_check_ordering
@@ -174,6 +174,16 @@ check-ordering
   000001:[a#1,SET-b#2,SET]
   000002:[b#1,SET-d#4,SET]
 ----
+L1 files 000001 and 000002 have overlapping ranges: [a#1,SET-b#2,SET] vs [b#1,SET-d#4,SET]
+1:
+  000001:[a#1,SET-b#2,SET] seqnums:[0-0] points:[a#1,SET-b#2,SET]
+  000002:[b#1,SET-d#4,SET] seqnums:[0-0] points:[b#1,SET-d#4,SET]
+
+check-ordering allow-split-user-keys
+1:
+  000001:[a#1,SET-b#2,SET]
+  000002:[b#1,SET-d#4,SET]
+----
 OK
 
 check-ordering

--- a/internal/manifest/testdata/version_edit_apply
+++ b/internal/manifest/testdata/version_edit_apply
@@ -102,11 +102,11 @@ zombies []
 
 apply
  L2
-  3:[a#1,SET-c#2,SET]
+  3:[b#1,SET-c#2,SET]
   4:[d#3,SET-f#4,SET]
-  5:[h#3,SET-j#4,SET]
+  5:[h#3,SET-h#2,SET]
   2:[n#5,SET-q#3,SET]
-  1:[q#2,SET-t#1,SET]
+  1:[r#2,SET-t#1,SET]
 edit
  delete
   L2
@@ -120,9 +120,9 @@ edit
 ----
 2:
   000006:[a#10,SET-a#7,SET]
-  000003:[a#1,SET-c#2,SET]
+  000003:[b#1,SET-c#2,SET]
   000007:[e#1,SET-g#2,SET]
-  000005:[h#3,SET-j#4,SET]
+  000005:[h#3,SET-h#2,SET]
   000010:[j#3,SET-m#2,SET]
   000002:[n#5,SET-q#3,SET]
 zombies [{1} {4}]

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -1353,16 +1353,20 @@ func (v *Version) Overlaps(
 // CheckOrdering checks that the files are consistent with respect to
 // increasing file numbers (for level 0 files) and increasing and non-
 // overlapping internal key ranges (for level non-0 files).
-func (v *Version) CheckOrdering(cmp Compare, format base.FormatKey) error {
+func (v *Version) CheckOrdering(
+	cmp Compare, format base.FormatKey, order OrderingInvariants,
+) error {
 	for sublevel := len(v.L0SublevelFiles) - 1; sublevel >= 0; sublevel-- {
 		sublevelIter := v.L0SublevelFiles[sublevel].Iter()
-		if err := CheckOrdering(cmp, format, L0Sublevel(sublevel), sublevelIter); err != nil {
+		// Sublevels have NEVER allowed split user keys, so we can pass
+		// ProhibitSplitUserKeys.
+		if err := CheckOrdering(cmp, format, L0Sublevel(sublevel), sublevelIter, ProhibitSplitUserKeys); err != nil {
 			return base.CorruptionErrorf("%s\n%s", err, v.DebugString(format))
 		}
 	}
 
 	for level, lm := range v.Levels {
-		if err := CheckOrdering(cmp, format, Level(level), lm.Iter()); err != nil {
+		if err := CheckOrdering(cmp, format, Level(level), lm.Iter(), order); err != nil {
 			return base.CorruptionErrorf("%s\n%s", err, v.DebugString(format))
 		}
 	}
@@ -1431,10 +1435,34 @@ func (l *VersionList) Remove(v *Version) {
 	v.list = nil // avoid memory leaks
 }
 
+// OrderingInvariants dictates the file ordering invariants active.
+type OrderingInvariants int8
+
+const (
+	// ProhibitSplitUserKeys indicates that adjacent files within a level cannot
+	// contain the same user key.
+	ProhibitSplitUserKeys OrderingInvariants = iota
+	// AllowSplitUserKeys indicates that adjacent files within a level may
+	// contain the same user key. This is only allowed by historical format
+	// major versions.
+	//
+	// TODO(jackson): Remove.
+	AllowSplitUserKeys
+)
+
 // CheckOrdering checks that the files are consistent with respect to
 // seqnums (for level 0 files -- see detailed comment below) and increasing and non-
 // overlapping internal key ranges (for non-level 0 files).
-func CheckOrdering(cmp Compare, format base.FormatKey, level Level, files LevelIterator) error {
+//
+// The ordering field may be passed AllowSplitUserKeys to allow adjacent files that are both
+// inclusive of the same user key. Pebble no longer creates version edits
+// installing such files, and Pebble databases with sufficiently high format
+// major version should no longer have any such files within their LSM.
+// TODO(jackson): Remove AllowSplitUserKeys when we remove support for the
+// earlier format major versions.
+func CheckOrdering(
+	cmp Compare, format base.FormatKey, level Level, files LevelIterator, ordering OrderingInvariants,
+) error {
 	// The invariants to check for L0 sublevels are the same as the ones to
 	// check for all other levels. However, if L0 is not organized into
 	// sublevels, or if all L0 files are being passed in, we do the legacy L0
@@ -1512,11 +1540,29 @@ func CheckOrdering(cmp Compare, format base.FormatKey, level Level, files LevelI
 						prev.Smallest.Pretty(format), prev.Largest.Pretty(format),
 						f.Smallest.Pretty(format), f.Largest.Pretty(format))
 				}
-				if base.InternalCompare(cmp, prev.Largest, f.Smallest) >= 0 {
-					return base.CorruptionErrorf("%s files %s and %s have overlapping ranges: [%s-%s] vs [%s-%s]",
-						errors.Safe(level), errors.Safe(prev.FileNum), errors.Safe(f.FileNum),
-						prev.Smallest.Pretty(format), prev.Largest.Pretty(format),
-						f.Smallest.Pretty(format), f.Largest.Pretty(format))
+
+				// What's considered "overlapping" is dependent on the format
+				// major version. If ordering=ProhibitSplitUserKeys, then both
+				// files cannot contain keys with the same user keys. If the
+				// bounds have the same user key, the previous file's boundary
+				// must have a Trailer indicating that it's exclusive.
+				switch ordering {
+				case AllowSplitUserKeys:
+					if base.InternalCompare(cmp, prev.Largest, f.Smallest) >= 0 {
+						return base.CorruptionErrorf("%s files %s and %s have overlapping ranges: [%s-%s] vs [%s-%s]",
+							errors.Safe(level), errors.Safe(prev.FileNum), errors.Safe(f.FileNum),
+							prev.Smallest.Pretty(format), prev.Largest.Pretty(format),
+							f.Smallest.Pretty(format), f.Largest.Pretty(format))
+					}
+				case ProhibitSplitUserKeys:
+					if v := cmp(prev.Largest.UserKey, f.Smallest.UserKey); v > 0 || (v == 0 && !prev.Largest.IsExclusiveSentinel()) {
+						return base.CorruptionErrorf("%s files %s and %s have overlapping ranges: [%s-%s] vs [%s-%s]",
+							errors.Safe(level), errors.Safe(prev.FileNum), errors.Safe(f.FileNum),
+							prev.Smallest.Pretty(format), prev.Largest.Pretty(format),
+							f.Smallest.Pretty(format), f.Largest.Pretty(format))
+					}
+				default:
+					panic("unreachable")
 				}
 			}
 		}

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -854,6 +854,7 @@ func AccumulateIncompleteAndApplySingleVE(
 	backingStateMap map[base.DiskFileNum]*FileBacking,
 	addBackingFunc func(*FileBacking),
 	removeBackingFunc func(base.DiskFileNum),
+	orderingInvariants OrderingInvariants,
 ) (_ *Version, zombies map[base.DiskFileNum]uint64, _ error) {
 	if len(ve.RemovedBackingTables) != 0 {
 		panic("pebble: invalid incomplete version edit")
@@ -865,7 +866,7 @@ func AccumulateIncompleteAndApplySingleVE(
 	}
 	zombies = make(map[base.DiskFileNum]uint64)
 	v, err := b.Apply(
-		curr, cmp, formatKey, flushSplitBytes, readCompactionRate, zombies,
+		curr, cmp, formatKey, flushSplitBytes, readCompactionRate, zombies, orderingInvariants,
 	)
 	if err != nil {
 		return nil, nil, err
@@ -906,6 +907,7 @@ func (b *BulkVersionEdit) Apply(
 	flushSplitBytes int64,
 	readCompactionRate int64,
 	zombies map[base.DiskFileNum]uint64,
+	orderingInvariants OrderingInvariants,
 ) (*Version, error) {
 	addZombie := func(state *FileBacking) {
 		if zombies != nil {
@@ -1089,7 +1091,7 @@ func (b *BulkVersionEdit) Apply(
 			} else if err := v.InitL0Sublevels(cmp, formatKey, flushSplitBytes); err != nil {
 				return nil, errors.Wrap(err, "pebble: internal error")
 			}
-			if err := CheckOrdering(cmp, formatKey, Level(0), v.Levels[level].Iter()); err != nil {
+			if err := CheckOrdering(cmp, formatKey, Level(0), v.Levels[level].Iter(), orderingInvariants); err != nil {
 				return nil, errors.Wrap(err, "pebble: internal error")
 			}
 			continue
@@ -1110,7 +1112,7 @@ func (b *BulkVersionEdit) Apply(
 					end.Prev()
 				}
 			})
-			if err := CheckOrdering(cmp, formatKey, Level(level), check.Iter()); err != nil {
+			if err := CheckOrdering(cmp, formatKey, Level(level), check.Iter(), orderingInvariants); err != nil {
 				return nil, errors.Wrap(err, "pebble: internal error")
 			}
 		}

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -514,7 +514,7 @@ func TestVersionEditApply(t *testing.T) {
 					}
 				}
 				zombies := make(map[base.DiskFileNum]uint64)
-				newv, err := bve.Apply(v, base.DefaultComparer.Compare, base.DefaultFormatter, 10<<20, 32000, zombies)
+				newv, err := bve.Apply(v, base.DefaultComparer.Compare, base.DefaultFormatter, 10<<20, 32000, zombies, ProhibitSplitUserKeys)
 				if err != nil {
 					return err.Error()
 				}

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -290,6 +290,10 @@ func TestCheckOrdering(t *testing.T) {
 		func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "check-ordering":
+				orderingInvariants := ProhibitSplitUserKeys
+				if d.HasArg("allow-split-user-keys") {
+					orderingInvariants = AllowSplitUserKeys
+				}
 				v, err := ParseVersionDebug(cmp, fmtKey, 10<<20, d.Input)
 				if err != nil {
 					return err.Error()
@@ -300,7 +304,7 @@ func TestCheckOrdering(t *testing.T) {
 					m.SmallestSeqNum = m.Smallest.SeqNum()
 					m.LargestSeqNum = m.Largest.SeqNum()
 				})
-				if err = v.CheckOrdering(cmp, base.DefaultFormatter); err != nil {
+				if err = v.CheckOrdering(cmp, base.DefaultFormatter, orderingInvariants); err != nil {
 					return err.Error()
 				}
 				return "OK"

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -718,7 +718,8 @@ func (r *Runner) prepareWorkloadSteps(ctx context.Context) error {
 			r.Opts.Comparer.FormatKey,
 			r.Opts.FlushSplitBytes,
 			r.Opts.Experimental.ReadCompactionRate,
-			nil /* zombies */)
+			nil, /* zombies */
+			manifest.ProhibitSplitUserKeys)
 		bve = manifest.BulkVersionEdit{AddedByFileNum: bve.AddedByFileNum}
 		return v, err
 	}

--- a/testdata/compaction_check_ordering
+++ b/testdata/compaction_check_ordering
@@ -117,7 +117,7 @@ L0.0
   a.SET.1-b.SET.2
   b.SET.1-d.SET.5
 ----
-OK
+L0.0 files 000001 and 000002 have overlapping ranges: [a#1,SET-b#2,SET] vs [b#1,SET-d#5,SET]
 
 # Single sublevel, ordering is incorrect.
 check-ordering
@@ -158,4 +158,4 @@ L0.1
   a.SET.5-b.SET.6
   b.SET.7-d.SET.8
 ----
-L0.1 files 000003 and 000004 have overlapping ranges: [a#5,SET-b#6,SET] vs [b#7,SET-d#8,SET]
+L0.0 files 000001 and 000002 have overlapping ranges: [a#1,SET-b#2,SET] vs [b#1,SET-d#4,SET]

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -110,7 +110,7 @@ range-deletions-bytes-estimate: 776
 
 # Same as above, except range tombstone covers multiple grandparent file boundaries.
 
-define target-file-sizes=(1, 1, 1, 1)
+define target-file-sizes=(1, 1, 1, 1) format-major-version=1
 L1
   a.SET.3:v
 L2

--- a/testdata/manual_compaction_file_boundaries_delsized
+++ b/testdata/manual_compaction_file_boundaries_delsized
@@ -440,13 +440,13 @@ L3
 L3
   ad.SET.004:<rand-bytes=1000>
 L3
-  ad.SET.005:<rand-bytes=1000>
+  ae.SET.005:<rand-bytes=1000>
 L3
-  ad.SET.006:<rand-bytes=1000>
+  af.SET.006:<rand-bytes=1000>
 L3
-  ad.SET.007:<rand-bytes=1000>
+  ag.SET.007:<rand-bytes=1000>
 L3
-  ad.SET.008:<rand-bytes=1000>
+  ah.SET.008:<rand-bytes=1000>
 L3
   c.SET.009:<rand-bytes=1000>
 L3
@@ -466,11 +466,11 @@ L3
   000006:[a#1,SET-a#1,SET]
   000007:[ab#2,SET-ab#2,SET]
   000008:[ac#3,SET-ac#3,SET]
-  000013:[ad#8,SET-ad#8,SET]
-  000012:[ad#7,SET-ad#7,SET]
-  000011:[ad#6,SET-ad#6,SET]
-  000010:[ad#5,SET-ad#5,SET]
   000009:[ad#4,SET-ad#4,SET]
+  000010:[ae#5,SET-ae#5,SET]
+  000011:[af#6,SET-af#6,SET]
+  000012:[ag#7,SET-ag#7,SET]
+  000013:[ah#8,SET-ah#8,SET]
   000014:[c#9,SET-c#9,SET]
   000015:[d#10,SET-d#10,SET]
   000016:[e#11,SET-e#11,SET]
@@ -487,11 +487,11 @@ compact a-zz L1
   000006:[a#1,SET-a#1,SET]
   000007:[ab#2,SET-ab#2,SET]
   000008:[ac#3,SET-ac#3,SET]
-  000013:[ad#8,SET-ad#8,SET]
-  000012:[ad#7,SET-ad#7,SET]
-  000011:[ad#6,SET-ad#6,SET]
-  000010:[ad#5,SET-ad#5,SET]
   000009:[ad#4,SET-ad#4,SET]
+  000010:[ae#5,SET-ae#5,SET]
+  000011:[af#6,SET-af#6,SET]
+  000012:[ag#7,SET-ag#7,SET]
+  000013:[ah#8,SET-ah#8,SET]
   000014:[c#9,SET-c#9,SET]
   000015:[d#10,SET-d#10,SET]
   000016:[e#11,SET-e#11,SET]
@@ -508,11 +508,11 @@ L3:
   000006:[a#1,1-a#1,1]: 1667 bytes (1.6KB)
   000007:[ab#2,1-ab#2,1]: 1668 bytes (1.6KB)
   000008:[ac#3,1-ac#3,1]: 1668 bytes (1.6KB)
-  000013:[ad#8,1-ad#8,1]: 1668 bytes (1.6KB)
-  000012:[ad#7,1-ad#7,1]: 1668 bytes (1.6KB)
-  000011:[ad#6,1-ad#6,1]: 1668 bytes (1.6KB)
-  000010:[ad#5,1-ad#5,1]: 1668 bytes (1.6KB)
   000009:[ad#4,1-ad#4,1]: 1668 bytes (1.6KB)
+  000010:[ae#5,1-ae#5,1]: 1668 bytes (1.6KB)
+  000011:[af#6,1-af#6,1]: 1668 bytes (1.6KB)
+  000012:[ag#7,1-ag#7,1]: 1668 bytes (1.6KB)
+  000013:[ah#8,1-ah#8,1]: 1668 bytes (1.6KB)
   000014:[c#9,1-c#9,1]: 1667 bytes (1.6KB)
   000015:[d#10,1-d#10,1]: 1667 bytes (1.6KB)
   000016:[e#11,1-e#11,1]: 1667 bytes (1.6KB)

--- a/testdata/manual_compaction_set_with_del_sstable_Pebblev4
+++ b/testdata/manual_compaction_set_with_del_sstable_Pebblev4
@@ -125,7 +125,7 @@ L3
   e.SET.0:v
   f.SET.1:v
 L3
-  f.SET.0:v
+  g.SET.1:v
   g.SET.0:v
 ----
 1:
@@ -136,20 +136,19 @@ L3
   000006:[a#0,SET-b#0,SET]
   000007:[c#0,SET-d#0,SET]
   000008:[e#0,SET-f#1,SET]
-  000009:[f#0,SET-g#0,SET]
+  000009:[g#1,SET-g#1,SET]
 
 compact a-e L1
 ----
 2:
   000010:[a#3,SETWITHDEL-c#inf,RANGEDEL]
   000011:[c#2,RANGEDEL-e#inf,RANGEDEL]
-  000012:[e#2,RANGEDEL-f#inf,RANGEDEL]
-  000013:[f#2,RANGEDEL-g#inf,RANGEDEL]
+  000012:[e#2,RANGEDEL-g#inf,RANGEDEL]
 3:
   000006:[a#0,SET-b#0,SET]
   000007:[c#0,SET-d#0,SET]
   000008:[e#0,SET-f#1,SET]
-  000009:[f#0,SET-g#0,SET]
+  000009:[g#1,SET-g#1,SET]
 
 # A range tombstone covers multiple grandparent file boundaries between point keys,
 # rather than after all point keys.
@@ -257,41 +256,6 @@ compact a-h L1
 3:
   000007:[grandparent#0,SET-grandparent#0,SET]
   000008:[m#0,SET-m#0,SET]
-
-# Setup such that grandparent overlap limit is exceeded multiple times at the same user key ("b").
-# Ensures the compaction output files are non-overlapping.
-
-define target-file-sizes=(1, 1, 1, 1)
-L1
-  a.SET.2:v
-  c.SET.2:v
-L2
-  a.RANGEDEL.3:c
-L3
-  b.SET.2:v
-L3
-  b.SET.1:v
-L3
-  b.SET.0:v
-----
-1:
-  000004:[a#2,SET-c#2,SET]
-2:
-  000005:[a#3,RANGEDEL-c#inf,RANGEDEL]
-3:
-  000006:[b#2,SET-b#2,SET]
-  000007:[b#1,SET-b#1,SET]
-  000008:[b#0,SET-b#0,SET]
-
-compact a-c L1
-----
-2:
-  000009:[a#3,RANGEDEL-b#inf,RANGEDEL]
-  000010:[b#3,RANGEDEL-c#2,SET]
-3:
-  000006:[b#2,SET-b#2,SET]
-  000007:[b#1,SET-b#1,SET]
-  000008:[b#0,SET-b#0,SET]
 
 # Regression test for a bug where compaction would stop process range
 # tombstones for an input level upon finding an sstable in the input
@@ -770,47 +734,6 @@ compact a-r L1
   000007:[q#8,RANGEDEL-r#inf,RANGEDEL]
 3:
   000006:[q#6,SET-q#6,SET]
-
-define target-file-sizes=(100, 100, 100)
-L1
-  a.RANGEDEL.10:b
-  b.SET.0:foo
-  d.RANGEDEL.0:e
-  j.SET.10:foo
-L2
-  f.RANGEDEL.7:g
-L3
-  c.SET.6:6
-L3
-  c.SET.5:5
-L3
-  c.SET.4:4
-L4
-  a.SET.0:0
-  f.SET.0:0
-----
-1:
-  000004:[a#10,RANGEDEL-j#10,SET]
-2:
-  000005:[f#7,RANGEDEL-g#inf,RANGEDEL]
-3:
-  000006:[c#6,SET-c#6,SET]
-  000007:[c#5,SET-c#5,SET]
-  000008:[c#4,SET-c#4,SET]
-4:
-  000009:[a#0,SET-f#0,SET]
-
-compact a-r L1
-----
-2:
-  000010:[a#10,RANGEDEL-b#0,SET]
-  000011:[d#0,RANGEDEL-j#10,SET]
-3:
-  000006:[c#6,SET-c#6,SET]
-  000007:[c#5,SET-c#5,SET]
-  000008:[c#4,SET-c#4,SET]
-4:
-  000009:[a#0,SET-f#0,SET]
 
 # Test a snapshot that separates a range deletion from all the data that it
 # deletes. Ensure that we respect the target-file-size and split into multiple

--- a/tool/db.go
+++ b/tool/db.go
@@ -531,6 +531,7 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 		v, err := bve.Apply(
 			nil /* version */, cmp.Compare, d.fmtKey.fn, d.opts.FlushSplitBytes,
 			d.opts.Experimental.ReadCompactionRate, nil, /* zombies */
+			manifest.AllowSplitUserKeys,
 		)
 		if err != nil {
 			return err

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -237,7 +237,7 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 				v, err := bve.Apply(
 					nil /* version */, cmp.Compare, m.fmtKey.fn, 0,
 					m.opts.Experimental.ReadCompactionRate,
-					nil, /* zombies */
+					nil /* zombies */, manifest.AllowSplitUserKeys,
 				)
 				if err != nil {
 					fmt.Fprintf(stdout, "%s\n", err)
@@ -545,7 +545,7 @@ func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
 				}
 				// TODO(sbhola): add option to Apply that reports all errors instead of
 				// one error.
-				newv, err := bve.Apply(v, cmp.Compare, m.fmtKey.fn, 0, m.opts.Experimental.ReadCompactionRate, nil /* zombies */)
+				newv, err := bve.Apply(v, cmp.Compare, m.fmtKey.fn, 0, m.opts.Experimental.ReadCompactionRate, nil /* zombies */, manifest.AllowSplitUserKeys)
 				if err != nil {
 					fmt.Fprintf(stdout, "%s: offset: %d err: %s\n",
 						arg, offset, err)

--- a/version_set.go
+++ b/version_set.go
@@ -310,6 +310,7 @@ func (vs *versionSet) load(
 	newVersion, err := bve.Apply(
 		nil, vs.cmp, opts.Comparer.FormatKey, opts.FlushSplitBytes,
 		opts.Experimental.ReadCompactionRate, nil, /* zombies */
+		getFormatMajorVersion().orderingInvariants(),
 	)
 	if err != nil {
 		return err
@@ -444,6 +445,8 @@ func (vs *versionSet) logAndApply(
 	}
 
 	currentVersion := vs.currentVersion()
+	fmv := vs.getFormatMajorVersion()
+	orderingInvariants := fmv.orderingInvariants()
 	var newVersion *version
 
 	// Generate a new manifest if we don't currently have one, or forceRotation
@@ -521,6 +524,7 @@ func (vs *versionSet) logAndApply(
 			ve, currentVersion, vs.cmp, vs.opts.Comparer.FormatKey,
 			vs.opts.FlushSplitBytes, vs.opts.Experimental.ReadCompactionRate,
 			vs.backingState.fileBackingMap, vs.addFileBacking, vs.removeFileBacking,
+			orderingInvariants,
 		)
 		if err != nil {
 			return errors.Wrap(err, "MANIFEST apply failed")


### PR DESCRIPTION
23.2 backport of #3085.

----

Adapt CheckOrdering to perform its overlap comparisons using the stricter requirement that adjacent files not contain the same user key. Since we still support the earlier format major versions that predate this requirement, this behavior is gated behind an OrderingInvariants enum variant determined by the active format major version.

Some of the tests that use more recent format major versions still created test cases with split user keys, and they needed to be adjusted.