### PR TITLE
pebble: panic on incorrect strict MemFS methods use

### DIFF
--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -117,11 +117,11 @@ func (y *MemFS) String() string {
 // SetIgnoreSyncs sets the MemFS.ignoreSyncs field. See the usage comment with NewStrictMem() for
 // details.
 func (y *MemFS) SetIgnoreSyncs(ignoreSyncs bool) {
-	y.mu.Lock()
 	if !y.strict {
 		// noop
 		return
 	}
+	y.mu.Lock()
 	y.ignoreSyncs = ignoreSyncs
 	y.mu.Unlock()
 }

--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -118,8 +118,7 @@ func (y *MemFS) String() string {
 // details.
 func (y *MemFS) SetIgnoreSyncs(ignoreSyncs bool) {
 	if !y.strict {
-		// noop
-		return
+		panic("SetIgnoreSyncs can only be used on a strict MemFS")
 	}
 	y.mu.Lock()
 	y.ignoreSyncs = ignoreSyncs
@@ -130,8 +129,7 @@ func (y *MemFS) SetIgnoreSyncs(ignoreSyncs bool) {
 // NewStrictMem() for details.
 func (y *MemFS) ResetToSyncedState() {
 	if !y.strict {
-		// noop
-		return
+		panic("ResetToSyncedState can only be used on a strict MemFS")
 	}
 	y.mu.Lock()
 	y.root.resetToSyncedState()


### PR DESCRIPTION
Strict `MemFS` methods can be used by mistake on a non-strict `MemFS`. Panic if this happens, instead of (previously) ignoring this silently. This saves a test writer time being confused if they mis-use the type.