### PR TITLE
replay: bump up Eventually timeout in TestCompactionsQuiesce under race

### DIFF
--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -507,6 +507,9 @@ func TestCompactionsQuiesce(t *testing.T) {
 			wait := 30 * time.Second
 			if invariants.Enabled {
 				wait = time.Minute
+				if invariants.RaceEnabled {
+					wait = 5 * time.Minute
+				}
 			}
 
 			// The above call to [Wait] should eventually return. [Wait] blocks


### PR DESCRIPTION
Currently, we don't increase the timeout for the require.Eventually call on compactions finishing up under race builds. This change increases the timeout to 5x what it otherwise is, recognizing that race+asan builds have this test running much slower than otherwise.

Fixes #2355 