### PR TITLE
[crl-release-23.2] *: handle non-Sets correctly in UserIteratorConfig

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -576,14 +576,18 @@ func runBatchDefineCmd(d *datadriven.TestData, b *Batch) error {
 			}
 			err = b.Merge([]byte(parts[1]), []byte(parts[2]), nil)
 		case "range-key-set":
-			if len(parts) != 5 {
-				return errors.Errorf("%s expects 4 arguments", parts[0])
+			if len(parts) < 4 || len(parts) > 5 {
+				return errors.Errorf("%s expects 3 or 4 arguments", parts[0])
+			}
+			var val []byte
+			if len(parts) == 5 {
+				val = []byte(parts[4])
 			}
 			err = b.RangeKeySet(
 				[]byte(parts[1]),
 				[]byte(parts[2]),
 				[]byte(parts[3]),
-				[]byte(parts[4]),
+				val,
 				nil)
 		case "range-key-unset":
 			if len(parts) != 4 {

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -311,7 +311,7 @@ func finishInitializingExternal(ctx context.Context, it *Iterator) {
 					base.InternalKeySeqNumMax,
 					it.opts.LowerBound, it.opts.UpperBound,
 					&it.hasPrefix, &it.prefixOrFullSeekKey,
-					true /* onlySets */, &it.rangeKey.internal,
+					false /* internalKeys */, &it.rangeKey.internal,
 				)
 				for i := range rangeKeyIters {
 					it.rangeKey.iterConfig.AddLevel(rangeKeyIters[i])

--- a/internal/rangekey/coalesce.go
+++ b/internal/rangekey/coalesce.go
@@ -52,15 +52,15 @@ import (
 //	                        │
 //	                        ╰── <?>.Next
 type UserIteratorConfig struct {
-	snapshot   uint64
-	comparer   *base.Comparer
-	miter      keyspan.MergingIter
-	biter      keyspan.BoundedIter
-	diter      keyspan.DefragmentingIter
-	liters     [manifest.NumLevels]keyspan.LevelIter
-	litersUsed int
-	onlySets   bool
-	bufs       *Buffers
+	snapshot     uint64
+	comparer     *base.Comparer
+	miter        keyspan.MergingIter
+	biter        keyspan.BoundedIter
+	diter        keyspan.DefragmentingIter
+	liters       [manifest.NumLevels]keyspan.LevelIter
+	litersUsed   int
+	internalKeys bool
+	bufs         *Buffers
 }
 
 // Buffers holds various buffers used for range key iteration. They're exposed
@@ -79,9 +79,10 @@ func (bufs *Buffers) PrepareForReuse() {
 
 // Init initializes the range key iterator stack for user iteration. The
 // resulting fragment iterator applies range key semantics, defragments spans
-// according to their user-observable state and, if onlySets = true, removes all
+// according to their user-observable state and, if !internalKeys, removes all
 // Keys other than RangeKeySets describing the current state of range keys. The
-// resulting spans contain Keys sorted by Suffix.
+// resulting spans contain Keys sorted by suffix (unless internalKeys is true,
+// in which case they remain sorted by trailer descending).
 //
 // The snapshot sequence number parameter determines which keys are visible. Any
 // keys not visible at the provided snapshot are ignored.
@@ -91,16 +92,20 @@ func (ui *UserIteratorConfig) Init(
 	lower, upper []byte,
 	hasPrefix *bool,
 	prefix *[]byte,
-	onlySets bool,
+	internalKeys bool,
 	bufs *Buffers,
 	iters ...keyspan.FragmentIterator,
 ) keyspan.FragmentIterator {
 	ui.snapshot = snapshot
 	ui.comparer = comparer
-	ui.onlySets = onlySets
+	ui.internalKeys = internalKeys
 	ui.miter.Init(comparer.Compare, ui, &bufs.merging, iters...)
 	ui.biter.Init(comparer.Compare, comparer.Split, &ui.miter, lower, upper, hasPrefix, prefix)
-	ui.diter.Init(comparer, &ui.biter, ui, keyspan.StaticDefragmentReducer, &bufs.defragmenting)
+	if internalKeys {
+		ui.diter.Init(comparer, &ui.biter, keyspan.DefragmentInternal, keyspan.StaticDefragmentReducer, &bufs.defragmenting)
+	} else {
+		ui.diter.Init(comparer, &ui.biter, ui, keyspan.StaticDefragmentReducer, &bufs.defragmenting)
+	}
 	ui.litersUsed = 0
 	ui.bufs = bufs
 	return &ui.diter
@@ -136,7 +141,8 @@ func (ui *UserIteratorConfig) SetBounds(lower, upper []byte) {
 // of unset keys, removal of keys overwritten by a set at the same suffix, etc)
 // and then non-RangeKeySet keys are removed. The resulting transformed spans
 // only contain RangeKeySets describing the state visible at the provided
-// sequence number, and hold their Keys sorted by Suffix.
+// sequence number, and hold their Keys sorted by Suffix (except if internalKeys
+// is true, then keys remain sorted by trailer.
 func (ui *UserIteratorConfig) Transform(cmp base.Compare, s keyspan.Span, dst *keyspan.Span) error {
 	// Apply shadowing of keys.
 	dst.Start = s.Start
@@ -148,9 +154,16 @@ func (ui *UserIteratorConfig) Transform(cmp base.Compare, s keyspan.Span, dst *k
 	if err := coalesce(ui.comparer.Equal, &ui.bufs.sortBuf, ui.snapshot, s.Keys); err != nil {
 		return err
 	}
-	// During user iteration over range keys, unsets and deletes don't matter.
-	// Remove them if onlySets = true. This step helps logical defragmentation
-	// during iteration.
+	if ui.internalKeys {
+		if s.KeysOrder != keyspan.ByTrailerDesc {
+			panic("unexpected key ordering in UserIteratorTransform with internalKeys = true")
+		}
+		dst.Keys = ui.bufs.sortBuf.Keys
+		keyspan.SortKeysByTrailer(&dst.Keys)
+		return nil
+	}
+	// During user iteration over range keys, unsets and deletes don't matter. This
+	// step helps logical defragmentation during iteration.
 	keys := ui.bufs.sortBuf.Keys
 	dst.Keys = dst.Keys[:0]
 	for i := range keys {
@@ -164,17 +177,11 @@ func (ui *UserIteratorConfig) Transform(cmp base.Compare, s keyspan.Span, dst *k
 			if invariants.Enabled && len(dst.Keys) > 0 && cmp(dst.Keys[len(dst.Keys)-1].Suffix, keys[i].Suffix) > 0 {
 				panic("pebble: keys unexpectedly not in ascending suffix order")
 			}
-			if ui.onlySets {
-				// Skip.
-				continue
-			}
-			dst.Keys = append(dst.Keys, keys[i])
+			// Skip.
+			continue
 		case base.InternalKeyKindRangeKeyDelete:
-			if ui.onlySets {
-				// Skip.
-				continue
-			}
-			dst.Keys = append(dst.Keys, keys[i])
+			// Skip.
+			continue
 		default:
 			return base.CorruptionErrorf("pebble: unrecognized range key kind %s", keys[i].Kind())
 		}
@@ -193,6 +200,10 @@ func (ui *UserIteratorConfig) Transform(cmp base.Compare, s keyspan.Span, dst *k
 // sequence numbers). It's intended for use during user iteration, when the
 // wrapped keyspan iterator is merging spans across all levels of the LSM.
 func (ui *UserIteratorConfig) ShouldDefragment(equal base.Equal, a, b *keyspan.Span) bool {
+	// This method is not called with internalKeys = true.
+	if ui.internalKeys {
+		panic("unexpected call to ShouldDefragment with internalKeys = true")
+	}
 	// This implementation must only be used on spans that have transformed by
 	// ui.Transform. The transform applies shadowing, removes all keys besides
 	// the resulting Sets and sorts the keys by suffix. Since shadowing has been
@@ -208,8 +219,8 @@ func (ui *UserIteratorConfig) ShouldDefragment(equal base.Equal, a, b *keyspan.S
 	ret := true
 	for i := range a.Keys {
 		if invariants.Enabled {
-			if ui.onlySets && (a.Keys[i].Kind() != base.InternalKeyKindRangeKeySet ||
-				b.Keys[i].Kind() != base.InternalKeyKindRangeKeySet) {
+			if a.Keys[i].Kind() != base.InternalKeyKindRangeKeySet ||
+				b.Keys[i].Kind() != base.InternalKeyKindRangeKeySet {
 				panic("pebble: unexpected non-RangeKeySet during defragmentation")
 			}
 			if i > 0 && (ui.comparer.Compare(a.Keys[i].Suffix, a.Keys[i-1].Suffix) < 0 ||

--- a/internal/rangekey/coalesce_test.go
+++ b/internal/rangekey/coalesce_test.go
@@ -151,7 +151,7 @@ func TestDefragmenting(t *testing.T) {
 			var userIterCfg UserIteratorConfig
 			iter := userIterCfg.Init(testkeys.Comparer, base.InternalKeySeqNumMax,
 				nil /* lower */, nil, /* upper */
-				&hasPrefix, &prefix, true /* onlySets */, new(Buffers),
+				&hasPrefix, &prefix, false /* internalKeys */, new(Buffers),
 				keyspan.NewIter(cmp, spans))
 			for _, line := range strings.Split(td.Input, "\n") {
 				runIterOp(&buf, iter, line)
@@ -233,11 +233,11 @@ func testDefragmentingIteRandomizedOnce(t *testing.T, seed int64) {
 	var referenceCfg, fragmentedCfg UserIteratorConfig
 	referenceIter := referenceCfg.Init(testkeys.Comparer, base.InternalKeySeqNumMax,
 		nil /* lower */, nil, /* upper */
-		new(bool), new([]byte), true /* ßonlySets */, new(Buffers),
+		new(bool), new([]byte), false /* internalKeys */, new(Buffers),
 		keyspan.NewIter(cmp, original))
 	fragmentedIter := fragmentedCfg.Init(testkeys.Comparer, base.InternalKeySeqNumMax,
 		nil /* lower */, nil, /* upper */
-		new(bool), new([]byte), true /* onlySets */, new(Buffers),
+		new(bool), new([]byte), false /* internalKeys */, new(Buffers),
 		keyspan.NewIter(cmp, fragmented))
 
 	// Generate 100 random operations and run them against both iterators.
@@ -370,7 +370,7 @@ func BenchmarkTransform(b *testing.B) {
 	var ui UserIteratorConfig
 	reinit := func() {
 		bufs.PrepareForReuse()
-		_ = ui.Init(testkeys.Comparer, math.MaxUint64, nil, nil, new(bool), nil, false /* onlySets */, &bufs)
+		_ = ui.Init(testkeys.Comparer, math.MaxUint64, nil, nil, new(bool), nil, true /* internalKeys */, &bufs)
 	}
 
 	for _, shadowing := range []bool{false, true} {

--- a/range_keys.go
+++ b/range_keys.go
@@ -17,7 +17,7 @@ import (
 func (i *Iterator) constructRangeKeyIter() {
 	i.rangeKey.rangeKeyIter = i.rangeKey.iterConfig.Init(
 		&i.comparer, i.seqNum, i.opts.LowerBound, i.opts.UpperBound,
-		&i.hasPrefix, &i.prefixOrFullSeekKey, true /* onlySets */, &i.rangeKey.rangeKeyBuffers.internal)
+		&i.hasPrefix, &i.prefixOrFullSeekKey, false /* internalKeys */, &i.rangeKey.rangeKeyBuffers.internal)
 
 	// If there's an indexed batch with range keys, include it.
 	if i.batch != nil {

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -833,7 +833,7 @@ func (i *scanInternalIterator) constructRangeKeyIter() {
 	// RangeKeyUnsets and RangeKeyDels.
 	i.rangeKey.rangeKeyIter = i.rangeKey.iterConfig.Init(
 		i.comparer, i.seqNum, i.opts.LowerBound, i.opts.UpperBound,
-		nil /* hasPrefix */, nil /* prefix */, false, /* onlySets */
+		nil /* hasPrefix */, nil /* prefix */, true, /* internalKeys */
 		&i.rangeKey.rangeKeyBuffers.internal)
 
 	// Next are the flushables: memtables and large batches.

--- a/testdata/scan_internal
+++ b/testdata/scan_internal
@@ -122,8 +122,8 @@ reset
 # the unset/del must also be returned to the user.
 
 batch commit
-range-key-set a c @8 foo
-range-key-set b e @6 bar
+range-key-set a c @8
+range-key-set b e @6
 ----
 committed 2 keys
 
@@ -151,9 +151,9 @@ committed 1 keys
 scan-internal
 ----
 a-b:{(#13,RANGEKEYDEL)}
-b-c:{(#10,RANGEKEYSET,@8,foo) (#12,RANGEKEYUNSET,@6)}
+b-c:{(#12,RANGEKEYUNSET,@6) (#10,RANGEKEYSET,@8)}
 c-d:{(#12,RANGEKEYUNSET,@6)}
-d-e:{(#11,RANGEKEYSET,@6,bar)}
+d-e:{(#11,RANGEKEYSET,@6)}
 
 flush
 ----
@@ -169,9 +169,39 @@ lsm
 scan-internal
 ----
 a-b:{(#13,RANGEKEYDEL)}
-b-c:{(#10,RANGEKEYSET,@8,foo) (#12,RANGEKEYUNSET,@6)}
+b-c:{(#12,RANGEKEYUNSET,@6) (#10,RANGEKEYSET,@8)}
 c-d:{(#12,RANGEKEYUNSET,@6)}
-d-e:{(#11,RANGEKEYSET,@6,bar)}
+d-e:{(#11,RANGEKEYSET,@6)}
+
+batch ingest
+range-key-set e f @3
+range-key-unset f g @3
+----
+wrote 2 keys to batch ""
+
+scan-internal
+----
+a-b:{(#13,RANGEKEYDEL)}
+b-c:{(#12,RANGEKEYUNSET,@6) (#10,RANGEKEYSET,@8)}
+c-d:{(#12,RANGEKEYUNSET,@6)}
+d-e:{(#11,RANGEKEYSET,@6)}
+e-f:{(#14,RANGEKEYSET,@3)}
+f-g:{(#14,RANGEKEYUNSET,@3)}
+
+batch ingest
+range-key-unset e f @3
+range-key-set f g @3
+----
+wrote 2 keys to batch ""
+
+scan-internal
+----
+a-b:{(#13,RANGEKEYDEL)}
+b-c:{(#12,RANGEKEYUNSET,@6) (#10,RANGEKEYSET,@8)}
+c-d:{(#12,RANGEKEYUNSET,@6)}
+d-e:{(#11,RANGEKEYSET,@6)}
+e-f:{(#15,RANGEKEYUNSET,@3)}
+f-g:{(#15,RANGEKEYSET,@3)}
 
 # Range key masking is not exercised, with range keys that could mask point
 # keys being returned alongside point keys.


### PR DESCRIPTION
Backport of #3069.

----

This change moves the `scanInternalIterator` use case of UserIteratorConfig over to something that's closer to rangeKeyCompactionTransform, where internal keys are coalesced using rangekey.coalesce, key order is maintained at ByTrailerDesc, and defragmentation happens by internal key using
keyspan.DefragmentInternal. The onlySets var is renamed to internalKeys and its meaning is reversed.

Fixes #3058.