### PR TITLE
crl-release-23.2: backport shared ingestion fixes

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -1309,7 +1309,7 @@ func runSSTablePropertiesCmd(t *testing.T, td *datadriven.TestData, d *DB) strin
 	var v sstable.VirtualReader
 	props := r.Properties.String()
 	if m != nil && m.Virtual {
-		v = sstable.MakeVirtualReader(r, m.VirtualMeta())
+		v = sstable.MakeVirtualReader(r, m.VirtualMeta(), false /* isForeign */)
 		props = v.Properties.String()
 	}
 	if len(td.Input) == 0 {

--- a/data_test.go
+++ b/data_test.go
@@ -576,14 +576,18 @@ func runBatchDefineCmd(d *datadriven.TestData, b *Batch) error {
 			}
 			err = b.Merge([]byte(parts[1]), []byte(parts[2]), nil)
 		case "range-key-set":
-			if len(parts) != 5 {
-				return errors.Errorf("%s expects 4 arguments", parts[0])
+			if len(parts) < 4 || len(parts) > 5 {
+				return errors.Errorf("%s expects 3 or 4 arguments", parts[0])
+			}
+			var val []byte
+			if len(parts) == 5 {
+				val = []byte(parts[4])
 			}
 			err = b.RangeKeySet(
 				[]byte(parts[1]),
 				[]byte(parts[2]),
 				[]byte(parts[3]),
-				[]byte(parts[4]),
+				val,
 				nil)
 		case "range-key-unset":
 			if len(parts) != 4 {

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -311,7 +311,7 @@ func finishInitializingExternal(ctx context.Context, it *Iterator) {
 					base.InternalKeySeqNumMax,
 					it.opts.LowerBound, it.opts.UpperBound,
 					&it.hasPrefix, &it.prefixOrFullSeekKey,
-					true /* onlySets */, &it.rangeKey.internal,
+					false /* internalKeys */, &it.rangeKey.internal,
 				)
 				for i := range rangeKeyIters {
 					it.rangeKey.iterConfig.AddLevel(rangeKeyIters[i])

--- a/internal/rangekey/coalesce.go
+++ b/internal/rangekey/coalesce.go
@@ -52,15 +52,15 @@ import (
 //	                        │
 //	                        ╰── <?>.Next
 type UserIteratorConfig struct {
-	snapshot   uint64
-	comparer   *base.Comparer
-	miter      keyspan.MergingIter
-	biter      keyspan.BoundedIter
-	diter      keyspan.DefragmentingIter
-	liters     [manifest.NumLevels]keyspan.LevelIter
-	litersUsed int
-	onlySets   bool
-	bufs       *Buffers
+	snapshot     uint64
+	comparer     *base.Comparer
+	miter        keyspan.MergingIter
+	biter        keyspan.BoundedIter
+	diter        keyspan.DefragmentingIter
+	liters       [manifest.NumLevels]keyspan.LevelIter
+	litersUsed   int
+	internalKeys bool
+	bufs         *Buffers
 }
 
 // Buffers holds various buffers used for range key iteration. They're exposed
@@ -79,9 +79,10 @@ func (bufs *Buffers) PrepareForReuse() {
 
 // Init initializes the range key iterator stack for user iteration. The
 // resulting fragment iterator applies range key semantics, defragments spans
-// according to their user-observable state and, if onlySets = true, removes all
+// according to their user-observable state and, if !internalKeys, removes all
 // Keys other than RangeKeySets describing the current state of range keys. The
-// resulting spans contain Keys sorted by Suffix.
+// resulting spans contain Keys sorted by suffix (unless internalKeys is true,
+// in which case they remain sorted by trailer descending).
 //
 // The snapshot sequence number parameter determines which keys are visible. Any
 // keys not visible at the provided snapshot are ignored.
@@ -91,16 +92,20 @@ func (ui *UserIteratorConfig) Init(
 	lower, upper []byte,
 	hasPrefix *bool,
 	prefix *[]byte,
-	onlySets bool,
+	internalKeys bool,
 	bufs *Buffers,
 	iters ...keyspan.FragmentIterator,
 ) keyspan.FragmentIterator {
 	ui.snapshot = snapshot
 	ui.comparer = comparer
-	ui.onlySets = onlySets
+	ui.internalKeys = internalKeys
 	ui.miter.Init(comparer.Compare, ui, &bufs.merging, iters...)
 	ui.biter.Init(comparer.Compare, comparer.Split, &ui.miter, lower, upper, hasPrefix, prefix)
-	ui.diter.Init(comparer, &ui.biter, ui, keyspan.StaticDefragmentReducer, &bufs.defragmenting)
+	if internalKeys {
+		ui.diter.Init(comparer, &ui.biter, keyspan.DefragmentInternal, keyspan.StaticDefragmentReducer, &bufs.defragmenting)
+	} else {
+		ui.diter.Init(comparer, &ui.biter, ui, keyspan.StaticDefragmentReducer, &bufs.defragmenting)
+	}
 	ui.litersUsed = 0
 	ui.bufs = bufs
 	return &ui.diter
@@ -136,7 +141,8 @@ func (ui *UserIteratorConfig) SetBounds(lower, upper []byte) {
 // of unset keys, removal of keys overwritten by a set at the same suffix, etc)
 // and then non-RangeKeySet keys are removed. The resulting transformed spans
 // only contain RangeKeySets describing the state visible at the provided
-// sequence number, and hold their Keys sorted by Suffix.
+// sequence number, and hold their Keys sorted by Suffix (except if internalKeys
+// is true, then keys remain sorted by trailer.
 func (ui *UserIteratorConfig) Transform(cmp base.Compare, s keyspan.Span, dst *keyspan.Span) error {
 	// Apply shadowing of keys.
 	dst.Start = s.Start
@@ -148,9 +154,16 @@ func (ui *UserIteratorConfig) Transform(cmp base.Compare, s keyspan.Span, dst *k
 	if err := coalesce(ui.comparer.Equal, &ui.bufs.sortBuf, ui.snapshot, s.Keys); err != nil {
 		return err
 	}
-	// During user iteration over range keys, unsets and deletes don't matter.
-	// Remove them if onlySets = true. This step helps logical defragmentation
-	// during iteration.
+	if ui.internalKeys {
+		if s.KeysOrder != keyspan.ByTrailerDesc {
+			panic("unexpected key ordering in UserIteratorTransform with internalKeys = true")
+		}
+		dst.Keys = ui.bufs.sortBuf.Keys
+		keyspan.SortKeysByTrailer(&dst.Keys)
+		return nil
+	}
+	// During user iteration over range keys, unsets and deletes don't matter. This
+	// step helps logical defragmentation during iteration.
 	keys := ui.bufs.sortBuf.Keys
 	dst.Keys = dst.Keys[:0]
 	for i := range keys {
@@ -164,17 +177,11 @@ func (ui *UserIteratorConfig) Transform(cmp base.Compare, s keyspan.Span, dst *k
 			if invariants.Enabled && len(dst.Keys) > 0 && cmp(dst.Keys[len(dst.Keys)-1].Suffix, keys[i].Suffix) > 0 {
 				panic("pebble: keys unexpectedly not in ascending suffix order")
 			}
-			if ui.onlySets {
-				// Skip.
-				continue
-			}
-			dst.Keys = append(dst.Keys, keys[i])
+			// Skip.
+			continue
 		case base.InternalKeyKindRangeKeyDelete:
-			if ui.onlySets {
-				// Skip.
-				continue
-			}
-			dst.Keys = append(dst.Keys, keys[i])
+			// Skip.
+			continue
 		default:
 			return base.CorruptionErrorf("pebble: unrecognized range key kind %s", keys[i].Kind())
 		}
@@ -193,6 +200,10 @@ func (ui *UserIteratorConfig) Transform(cmp base.Compare, s keyspan.Span, dst *k
 // sequence numbers). It's intended for use during user iteration, when the
 // wrapped keyspan iterator is merging spans across all levels of the LSM.
 func (ui *UserIteratorConfig) ShouldDefragment(equal base.Equal, a, b *keyspan.Span) bool {
+	// This method is not called with internalKeys = true.
+	if ui.internalKeys {
+		panic("unexpected call to ShouldDefragment with internalKeys = true")
+	}
 	// This implementation must only be used on spans that have transformed by
 	// ui.Transform. The transform applies shadowing, removes all keys besides
 	// the resulting Sets and sorts the keys by suffix. Since shadowing has been
@@ -208,8 +219,8 @@ func (ui *UserIteratorConfig) ShouldDefragment(equal base.Equal, a, b *keyspan.S
 	ret := true
 	for i := range a.Keys {
 		if invariants.Enabled {
-			if ui.onlySets && (a.Keys[i].Kind() != base.InternalKeyKindRangeKeySet ||
-				b.Keys[i].Kind() != base.InternalKeyKindRangeKeySet) {
+			if a.Keys[i].Kind() != base.InternalKeyKindRangeKeySet ||
+				b.Keys[i].Kind() != base.InternalKeyKindRangeKeySet {
 				panic("pebble: unexpected non-RangeKeySet during defragmentation")
 			}
 			if i > 0 && (ui.comparer.Compare(a.Keys[i].Suffix, a.Keys[i-1].Suffix) < 0 ||

--- a/internal/rangekey/coalesce_test.go
+++ b/internal/rangekey/coalesce_test.go
@@ -151,7 +151,7 @@ func TestDefragmenting(t *testing.T) {
 			var userIterCfg UserIteratorConfig
 			iter := userIterCfg.Init(testkeys.Comparer, base.InternalKeySeqNumMax,
 				nil /* lower */, nil, /* upper */
-				&hasPrefix, &prefix, true /* onlySets */, new(Buffers),
+				&hasPrefix, &prefix, false /* internalKeys */, new(Buffers),
 				keyspan.NewIter(cmp, spans))
 			for _, line := range strings.Split(td.Input, "\n") {
 				runIterOp(&buf, iter, line)
@@ -233,11 +233,11 @@ func testDefragmentingIteRandomizedOnce(t *testing.T, seed int64) {
 	var referenceCfg, fragmentedCfg UserIteratorConfig
 	referenceIter := referenceCfg.Init(testkeys.Comparer, base.InternalKeySeqNumMax,
 		nil /* lower */, nil, /* upper */
-		new(bool), new([]byte), true /* ßonlySets */, new(Buffers),
+		new(bool), new([]byte), false /* internalKeys */, new(Buffers),
 		keyspan.NewIter(cmp, original))
 	fragmentedIter := fragmentedCfg.Init(testkeys.Comparer, base.InternalKeySeqNumMax,
 		nil /* lower */, nil, /* upper */
-		new(bool), new([]byte), true /* onlySets */, new(Buffers),
+		new(bool), new([]byte), false /* internalKeys */, new(Buffers),
 		keyspan.NewIter(cmp, fragmented))
 
 	// Generate 100 random operations and run them against both iterators.
@@ -370,7 +370,7 @@ func BenchmarkTransform(b *testing.B) {
 	var ui UserIteratorConfig
 	reinit := func() {
 		bufs.PrepareForReuse()
-		_ = ui.Init(testkeys.Comparer, math.MaxUint64, nil, nil, new(bool), nil, false /* onlySets */, &bufs)
+		_ = ui.Init(testkeys.Comparer, math.MaxUint64, nil, nil, new(bool), nil, true /* internalKeys */, &bufs)
 	}
 
 	for _, shadowing := range []bool{false, true} {

--- a/range_keys.go
+++ b/range_keys.go
@@ -17,7 +17,7 @@ import (
 func (i *Iterator) constructRangeKeyIter() {
 	i.rangeKey.rangeKeyIter = i.rangeKey.iterConfig.Init(
 		&i.comparer, i.seqNum, i.opts.LowerBound, i.opts.UpperBound,
-		&i.hasPrefix, &i.prefixOrFullSeekKey, true /* onlySets */, &i.rangeKey.rangeKeyBuffers.internal)
+		&i.hasPrefix, &i.prefixOrFullSeekKey, false /* internalKeys */, &i.rangeKey.rangeKeyBuffers.internal)
 
 	// If there's an indexed batch with range keys, include it.
 	if i.batch != nil {

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -833,7 +833,7 @@ func (i *scanInternalIterator) constructRangeKeyIter() {
 	// RangeKeyUnsets and RangeKeyDels.
 	i.rangeKey.rangeKeyIter = i.rangeKey.iterConfig.Init(
 		i.comparer, i.seqNum, i.opts.LowerBound, i.opts.UpperBound,
-		nil /* hasPrefix */, nil /* prefix */, false, /* onlySets */
+		nil /* hasPrefix */, nil /* prefix */, true, /* internalKeys */
 		&i.rangeKey.rangeKeyBuffers.internal)
 
 	// Next are the flushables: memtables and large batches.

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -359,7 +359,7 @@ func (r *Reader) newCompactionIter(
 		err := i.init(
 			context.Background(),
 			r, v, nil /* lower */, nil /* upper */, nil,
-			false /* useFilter */, false, /* hideObsoletePoints */
+			false /* useFilter */, v != nil && v.isForeign, /* hideObsoletePoints */
 			nil /* stats */, rp, bufferPool,
 		)
 		if err != nil {
@@ -374,7 +374,7 @@ func (r *Reader) newCompactionIter(
 	i := singleLevelIterPool.Get().(*singleLevelIterator)
 	err := i.init(
 		context.Background(), r, v, nil /* lower */, nil, /* upper */
-		nil, false /* useFilter */, false, /* hideObsoletePoints */
+		nil, false /* useFilter */, v != nil && v.isForeign, /* hideObsoletePoints */
 		nil /* stats */, rp, bufferPool,
 	)
 	if err != nil {

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -341,7 +341,7 @@ func TestVirtualReader(t *testing.T) {
 			vMeta.ValidateVirtual(meta.FileMetadata)
 
 			vMeta1 = vMeta.VirtualMeta()
-			v = MakeVirtualReader(r, vMeta1)
+			v = MakeVirtualReader(r, vMeta1, false /* isForeign */)
 			return formatVirtualReader(&v)
 
 		case "citer":

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -27,10 +27,11 @@ type VirtualReader struct {
 
 // Lightweight virtual sstable state which can be passed to sstable iterators.
 type virtualState struct {
-	lower   InternalKey
-	upper   InternalKey
-	fileNum base.FileNum
-	Compare Compare
+	lower     InternalKey
+	upper     InternalKey
+	fileNum   base.FileNum
+	Compare   Compare
+	isForeign bool
 }
 
 func ceilDiv(a, b uint64) uint64 {
@@ -39,16 +40,19 @@ func ceilDiv(a, b uint64) uint64 {
 
 // MakeVirtualReader is used to contruct a reader which can read from virtual
 // sstables.
-func MakeVirtualReader(reader *Reader, meta manifest.VirtualFileMeta) VirtualReader {
+func MakeVirtualReader(
+	reader *Reader, meta manifest.VirtualFileMeta, isForeign bool,
+) VirtualReader {
 	if reader.fileNum != meta.FileBacking.DiskFileNum {
 		panic("pebble: invalid call to MakeVirtualReader")
 	}
 
 	vState := virtualState{
-		lower:   meta.Smallest,
-		upper:   meta.Largest,
-		fileNum: meta.FileNum,
-		Compare: reader.Compare,
+		lower:     meta.Smallest,
+		upper:     meta.Largest,
+		fileNum:   meta.FileNum,
+		Compare:   reader.Compare,
+		isForeign: isForeign,
 	}
 	v := VirtualReader{
 		vState: vState,

--- a/table_cache.go
+++ b/table_cache.go
@@ -194,12 +194,17 @@ func (c *tableCacheContainer) estimateSize(
 	return size, nil
 }
 
-func createCommonReader(v *tableCacheValue, file *fileMetadata) sstable.CommonReader {
+// createCommonReader creates a Reader for this file. isForeign, if true for
+// virtual sstables, is passed into the vSSTable reader so its iterators can
+// collapse obsolete points accordingly.
+func createCommonReader(
+	v *tableCacheValue, file *fileMetadata, isForeign bool,
+) sstable.CommonReader {
 	// TODO(bananabrick): We suffer an allocation if file is a virtual sstable.
 	var cr sstable.CommonReader = v.reader
 	if file.Virtual {
 		virtualReader := sstable.MakeVirtualReader(
-			v.reader, file.VirtualMeta(),
+			v.reader, file.VirtualMeta(), isForeign,
 		)
 		cr = &virtualReader
 	}
@@ -215,7 +220,12 @@ func (c *tableCacheContainer) withCommonReader(
 	if v.err != nil {
 		return v.err
 	}
-	return fn(createCommonReader(v, meta))
+	provider := c.dbOpts.objProvider
+	objMeta, err := provider.Lookup(fileTypeTable, meta.FileBacking.DiskFileNum)
+	if err != nil {
+		return err
+	}
+	return fn(createCommonReader(v, meta, provider.IsSharedForeign(objMeta)))
 }
 
 func (c *tableCacheContainer) withReader(meta physicalMeta, fn func(*sstable.Reader) error) error {
@@ -238,7 +248,12 @@ func (c *tableCacheContainer) withVirtualReader(
 	if v.err != nil {
 		return v.err
 	}
-	return fn(sstable.MakeVirtualReader(v.reader, meta))
+	provider := c.dbOpts.objProvider
+	objMeta, err := provider.Lookup(fileTypeTable, meta.FileBacking.DiskFileNum)
+	if err != nil {
+		return err
+	}
+	return fn(sstable.MakeVirtualReader(v.reader, meta, provider.IsSharedForeign(objMeta)))
 }
 
 func (c *tableCacheContainer) iterCount() int64 {
@@ -456,15 +471,15 @@ func (c *tableCacheShard) newIters(
 		return nil, nil, err
 	}
 
-	// Note: This suffers an allocation for virtual sstables.
-	cr := createCommonReader(v, file)
-
 	provider := dbOpts.objProvider
 	// Check if this file is a foreign file.
 	objMeta, err := provider.Lookup(fileTypeTable, file.FileBacking.DiskFileNum)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// Note: This suffers an allocation for virtual sstables.
+	cr := createCommonReader(v, file, provider.IsSharedForeign(objMeta))
 
 	// NB: range-del iterator does not maintain a reference to the table, nor
 	// does it need to read from it after creation.
@@ -575,10 +590,15 @@ func (c *tableCacheShard) newRangeKeyIter(
 
 	var iter keyspan.FragmentIterator
 	if file.Virtual {
-		virtualReader := sstable.MakeVirtualReader(
-			v.reader, file.VirtualMeta(),
-		)
-		iter, err = virtualReader.NewRawRangeKeyIter()
+		provider := dbOpts.objProvider
+		var objMeta objstorage.ObjectMetadata
+		objMeta, err = provider.Lookup(fileTypeTable, file.FileBacking.DiskFileNum)
+		if err == nil {
+			virtualReader := sstable.MakeVirtualReader(
+				v.reader, file.VirtualMeta(), provider.IsSharedForeign(objMeta),
+			)
+			iter, err = virtualReader.NewRawRangeKeyIter()
+		}
 	} else {
 		iter, err = v.reader.NewRawRangeKeyIter()
 	}

--- a/testdata/scan_internal
+++ b/testdata/scan_internal
@@ -26,9 +26,9 @@ ok
 
 scan-internal file-only-snapshot=efos1
 ----
-a-c:{(#10,RANGEKEYSET,@5,boop)}
+a-c:{(#0,RANGEKEYSET,@5,boop)}
 b#12,1 (d)
-c-e:{(#11,RANGEKEYSET,@5,beep)}
+c-e:{(#0,RANGEKEYSET,@5,beep)}
 e#13,1 (foo)
 
 flush
@@ -36,9 +36,9 @@ flush
 
 scan-internal
 ----
-a-c:{(#10,RANGEKEYSET,@5,boop)}
+a-c:{(#0,RANGEKEYSET,@5,boop)}
 b#12,1 (d)
-c-e:{(#11,RANGEKEYSET,@5,beep)}
+c-e:{(#0,RANGEKEYSET,@5,beep)}
 e#13,1 (foo)
 
 # Keys deleted by rangedels are elided.
@@ -50,9 +50,9 @@ committed 1 keys
 
 scan-internal
 ----
-a-c:{(#10,RANGEKEYSET,@5,boop)}
+a-c:{(#0,RANGEKEYSET,@5,boop)}
 b-d#14,RANGEDEL
-c-e:{(#11,RANGEKEYSET,@5,beep)}
+c-e:{(#0,RANGEKEYSET,@5,beep)}
 e#13,1 (foo)
 
 flush
@@ -60,17 +60,17 @@ flush
 
 scan-internal
 ----
-a-c:{(#10,RANGEKEYSET,@5,boop)}
+a-c:{(#0,RANGEKEYSET,@5,boop)}
 b-d#14,RANGEDEL
-c-e:{(#11,RANGEKEYSET,@5,beep)}
+c-e:{(#0,RANGEKEYSET,@5,beep)}
 e#13,1 (foo)
 
 # Snapshots work with scan internal.
 
 scan-internal snapshot=foo
 ----
-a-c:{(#10,RANGEKEYSET,@5,boop)}
-c-e:{(#11,RANGEKEYSET,@5,beep)}
+a-c:{(#0,RANGEKEYSET,@5,boop)}
+c-e:{(#0,RANGEKEYSET,@5,beep)}
 
 wait-for-file-only-snapshot efos1
 ----
@@ -78,9 +78,9 @@ ok
 
 scan-internal file-only-snapshot=efos1
 ----
-a-c:{(#10,RANGEKEYSET,@5,boop)}
+a-c:{(#0,RANGEKEYSET,@5,boop)}
 b#12,1 (d)
-c-e:{(#11,RANGEKEYSET,@5,beep)}
+c-e:{(#0,RANGEKEYSET,@5,beep)}
 e#13,1 (foo)
 
 # Force keys newer than the snapshot into a lower level, then try skip-shared
@@ -105,15 +105,15 @@ file 000008 contains keys newer than snapshot: pebble: cannot use skip-shared it
 
 scan-internal lower=bb upper=dd
 ----
-bb-c:{(#10,RANGEKEYSET,@5,boop)}
+bb-c:{(#0,RANGEKEYSET,@5,boop)}
 bb-d#14,RANGEDEL
-c-dd:{(#11,RANGEKEYSET,@5,beep)}
+c-dd:{(#0,RANGEKEYSET,@5,beep)}
 
 scan-internal lower=b upper=cc
 ----
-b-c:{(#10,RANGEKEYSET,@5,boop)}
+b-c:{(#0,RANGEKEYSET,@5,boop)}
 b-cc#14,RANGEDEL
-c-cc:{(#11,RANGEKEYSET,@5,beep)}
+c-cc:{(#0,RANGEKEYSET,@5,beep)}
 
 reset
 ----
@@ -150,10 +150,10 @@ committed 1 keys
 
 scan-internal
 ----
-a-b:{(#13,RANGEKEYDEL)}
-b-c:{(#12,RANGEKEYUNSET,@6) (#10,RANGEKEYSET,@8)}
-c-d:{(#12,RANGEKEYUNSET,@6)}
-d-e:{(#11,RANGEKEYSET,@6)}
+a-b:{(#0,RANGEKEYDEL)}
+b-c:{(#0,RANGEKEYSET,@8) (#0,RANGEKEYUNSET,@6)}
+c-d:{(#0,RANGEKEYUNSET,@6)}
+d-e:{(#0,RANGEKEYSET,@6)}
 
 flush
 ----
@@ -168,10 +168,10 @@ lsm
 
 scan-internal
 ----
-a-b:{(#13,RANGEKEYDEL)}
-b-c:{(#12,RANGEKEYUNSET,@6) (#10,RANGEKEYSET,@8)}
-c-d:{(#12,RANGEKEYUNSET,@6)}
-d-e:{(#11,RANGEKEYSET,@6)}
+a-b:{(#0,RANGEKEYDEL)}
+b-c:{(#0,RANGEKEYSET,@8) (#0,RANGEKEYUNSET,@6)}
+c-d:{(#0,RANGEKEYUNSET,@6)}
+d-e:{(#0,RANGEKEYSET,@6)}
 
 batch ingest
 range-key-set e f @3
@@ -181,12 +181,12 @@ wrote 2 keys to batch ""
 
 scan-internal
 ----
-a-b:{(#13,RANGEKEYDEL)}
-b-c:{(#12,RANGEKEYUNSET,@6) (#10,RANGEKEYSET,@8)}
-c-d:{(#12,RANGEKEYUNSET,@6)}
-d-e:{(#11,RANGEKEYSET,@6)}
-e-f:{(#14,RANGEKEYSET,@3)}
-f-g:{(#14,RANGEKEYUNSET,@3)}
+a-b:{(#0,RANGEKEYDEL)}
+b-c:{(#0,RANGEKEYSET,@8) (#0,RANGEKEYUNSET,@6)}
+c-d:{(#0,RANGEKEYUNSET,@6)}
+d-e:{(#0,RANGEKEYSET,@6)}
+e-f:{(#0,RANGEKEYSET,@3)}
+f-g:{(#0,RANGEKEYUNSET,@3)}
 
 batch ingest
 range-key-unset e f @3
@@ -196,12 +196,12 @@ wrote 2 keys to batch ""
 
 scan-internal
 ----
-a-b:{(#13,RANGEKEYDEL)}
-b-c:{(#12,RANGEKEYUNSET,@6) (#10,RANGEKEYSET,@8)}
-c-d:{(#12,RANGEKEYUNSET,@6)}
-d-e:{(#11,RANGEKEYSET,@6)}
-e-f:{(#15,RANGEKEYUNSET,@3)}
-f-g:{(#15,RANGEKEYSET,@3)}
+a-b:{(#0,RANGEKEYDEL)}
+b-c:{(#0,RANGEKEYSET,@8) (#0,RANGEKEYUNSET,@6)}
+c-d:{(#0,RANGEKEYUNSET,@6)}
+d-e:{(#0,RANGEKEYSET,@6)}
+e-f:{(#0,RANGEKEYUNSET,@3)}
+f-g:{(#0,RANGEKEYSET,@3)}
 
 # Range key masking is not exercised, with range keys that could mask point
 # keys being returned alongside point keys.
@@ -222,9 +222,9 @@ committed 2 keys
 
 scan-internal
 ----
-a-c:{(#11,RANGEKEYSET,@5,boop)}
+a-c:{(#0,RANGEKEYSET,@5,boop)}
 b@3#10,1 (bar)
-c-e:{(#12,RANGEKEYSET,@5,beep)}
+c-e:{(#0,RANGEKEYSET,@5,beep)}
 
 # Point keys are collapsed in a way similar to a compaction.
 
@@ -313,7 +313,7 @@ lsm
 
 scan-internal
 ----
-a-c:{(#11,RANGEKEYSET,@5,boop)}
+a-c:{(#0,RANGEKEYSET,@5,boop)}
 b@3#10,1 (bar)
 c-e#12,RANGEDEL
 f@8#13,1 (baz)

--- a/testdata/scan_internal
+++ b/testdata/scan_internal
@@ -122,8 +122,8 @@ reset
 # the unset/del must also be returned to the user.
 
 batch commit
-range-key-set a c @8 foo
-range-key-set b e @6 bar
+range-key-set a c @8
+range-key-set b e @6
 ----
 committed 2 keys
 
@@ -151,9 +151,9 @@ committed 1 keys
 scan-internal
 ----
 a-b:{(#13,RANGEKEYDEL)}
-b-c:{(#10,RANGEKEYSET,@8,foo) (#12,RANGEKEYUNSET,@6)}
+b-c:{(#12,RANGEKEYUNSET,@6) (#10,RANGEKEYSET,@8)}
 c-d:{(#12,RANGEKEYUNSET,@6)}
-d-e:{(#11,RANGEKEYSET,@6,bar)}
+d-e:{(#11,RANGEKEYSET,@6)}
 
 flush
 ----
@@ -169,9 +169,39 @@ lsm
 scan-internal
 ----
 a-b:{(#13,RANGEKEYDEL)}
-b-c:{(#10,RANGEKEYSET,@8,foo) (#12,RANGEKEYUNSET,@6)}
+b-c:{(#12,RANGEKEYUNSET,@6) (#10,RANGEKEYSET,@8)}
 c-d:{(#12,RANGEKEYUNSET,@6)}
-d-e:{(#11,RANGEKEYSET,@6,bar)}
+d-e:{(#11,RANGEKEYSET,@6)}
+
+batch ingest
+range-key-set e f @3
+range-key-unset f g @3
+----
+wrote 2 keys to batch ""
+
+scan-internal
+----
+a-b:{(#13,RANGEKEYDEL)}
+b-c:{(#12,RANGEKEYUNSET,@6) (#10,RANGEKEYSET,@8)}
+c-d:{(#12,RANGEKEYUNSET,@6)}
+d-e:{(#11,RANGEKEYSET,@6)}
+e-f:{(#14,RANGEKEYSET,@3)}
+f-g:{(#14,RANGEKEYUNSET,@3)}
+
+batch ingest
+range-key-unset e f @3
+range-key-set f g @3
+----
+wrote 2 keys to batch ""
+
+scan-internal
+----
+a-b:{(#13,RANGEKEYDEL)}
+b-c:{(#12,RANGEKEYUNSET,@6) (#10,RANGEKEYSET,@8)}
+c-d:{(#12,RANGEKEYUNSET,@6)}
+d-e:{(#11,RANGEKEYSET,@6)}
+e-f:{(#15,RANGEKEYUNSET,@3)}
+f-g:{(#15,RANGEKEYSET,@3)}
 
 # Range key masking is not exercised, with range keys that could mask point
 # keys being returned alongside point keys.


### PR DESCRIPTION
This change backports #3069 (1/1 commits) and #3074 (2/3 commits, the third being irrelevant for non-invariant builds)

---

### [scan_internal: Sort keys by kind before calling visitor](https://github.com/cockroachdb/pebble/commit/4f32102227690b9b57e9dbebe35f4b4987ffdfa1)

Previously, we were passing range keys that were sorted by trailer
descending right from ScanInternal. However, the caller isn't
interested in seqnum-based sorting, only kind-based trailer sorting.
This change zeroes seqnums before sorting the keys.

Unblocks https://github.com/cockroachdb/pebble/pull/3044.

### [*: set hideObsoletePoints=true for shared foreign sstables](https://github.com/cockroachdb/pebble/commit/673953238a2b69c2fb5f8c50e1cfb3799dbfb439)

Previously, we weren't setting hideObsoletePoints to true for
compaction iters created out of shared foreign sstables. This
change addresses that by passing that state through virtualState
in VirtualReader through to the old Reader.

Unblocks https://github.com/cockroachdb/pebble/pull/3044.

### [*: handle non-Sets correctly in UserIteratorConfig](https://github.com/cockroachdb/pebble/commit/de5ea48cfe13701ad85419f1b1388e3eb4875ecf)

This change moves the `scanInternalIterator` use case of
UserIteratorConfig over to something that's closer to
rangeKeyCompactionTransform, where internal keys are coalesced
using rangekey.coalesce, key order is maintained at ByTrailerDesc,
and defragmentation happens by internal key using
keyspan.DefragmentInternal. The onlySets var is renamed to internalKeys
and its meaning is reversed.

Fixes https://github.com/cockroachdb/pebble/issues/3058.