### PR TITLE
db: add an error return value to BatchReader.Next

### DIFF
--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/cockroachdb/redact"
 )
 
 const (
@@ -160,6 +162,11 @@ func (k InternalKeyKind) String() string {
 		return internalKeyKindNames[k]
 	}
 	return fmt.Sprintf("UNKNOWN:%d", k)
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (k InternalKeyKind) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Print(redact.SafeString(k.String()))
 }
 
 // InternalKey is a key used for the in-memory and on-disk partial DBs that

--- a/mem_table.go
+++ b/mem_table.go
@@ -211,11 +211,13 @@ func (m *memTable) apply(batch *Batch, seqNum uint64) error {
 	var tombstoneCount, rangeKeyCount uint32
 	startSeqNum := seqNum
 	for r := batch.Reader(); ; seqNum++ {
-		kind, ukey, value, ok := r.Next()
+		kind, ukey, value, ok, err := r.Next()
 		if !ok {
+			if err != nil {
+				return err
+			}
 			break
 		}
-		var err error
 		ikey := base.MakeInternalKey(ukey, seqNum, kind)
 		switch kind {
 		case InternalKeyKindRangeDelete:

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -749,8 +749,11 @@ func (o *ingestOp) collapseBatch(
 	// private.BatchSort.
 	if rangeKeyIter != nil {
 		for r := b.Reader(); ; {
-			kind, key, value, ok := r.Next()
+			kind, key, value, ok, err := r.Next()
 			if !ok {
+				if err != nil {
+					return nil, err
+				}
 				break
 			} else if !rangekey.IsRangeKey(kind) {
 				continue

--- a/open.go
+++ b/open.go
@@ -717,6 +717,11 @@ func (d *DB) replayWAL(
 		batchesReplayed int64 // number of batches replayed
 	)
 
+	// TODO(jackson): This function is interspersed with panics, in addition to
+	// corruption error propagation. Audit them to ensure we're truly only
+	// panicking where the error points to Pebble bug and not user or
+	// hardware-induced corruption.
+
 	if d.opts.ReadOnly {
 		// In read-only mode, we replay directly into the mutable memtable which will
 		// never be flushed.
@@ -771,6 +776,11 @@ func (d *DB) replayWAL(
 		ve.NewFiles = append(ve.NewFiles, newVE.NewFiles...)
 		return nil
 	}
+	defer func() {
+		if err != nil {
+			err = errors.WithDetailf(err, "replaying log %s, offset %d", logNum, offset)
+		}
+	}()
 
 	for {
 		offset = rr.Offset()
@@ -812,7 +822,9 @@ func (d *DB) replayWAL(
 		batchesReplayed++
 		{
 			br := b.Reader()
-			if kind, encodedFileNum, _, _ := br.Next(); kind == InternalKeyKindIngestSST {
+			if kind, encodedFileNum, _, ok, err := br.Next(); err != nil {
+				return nil, 0, err
+			} else if ok && kind == InternalKeyKindIngestSST {
 				fileNums := make([]base.DiskFileNum, 0, b.Count())
 				addFileNum := func(encodedFileNum []byte) {
 					fileNum, n := binary.Uvarint(encodedFileNum)
@@ -824,7 +836,10 @@ func (d *DB) replayWAL(
 				addFileNum(encodedFileNum)
 
 				for i := 1; i < int(b.Count()); i++ {
-					kind, encodedFileNum, _, ok := br.Next()
+					kind, encodedFileNum, _, ok, err := br.Next()
+					if err != nil {
+						return nil, 0, err
+					}
 					if kind != InternalKeyKindIngestSST {
 						panic("pebble: invalid batch key kind.")
 					}
@@ -834,7 +849,9 @@ func (d *DB) replayWAL(
 					addFileNum(encodedFileNum)
 				}
 
-				if _, _, _, ok := br.Next(); ok {
+				if _, _, _, ok, err := br.Next(); err != nil {
+					return nil, 0, err
+				} else if ok {
 					panic("pebble: invalid number of entries in batch.")
 				}
 
@@ -927,7 +944,10 @@ func (d *DB) replayWAL(
 			// Make a copy of the data slice since it is currently owned by buf and will
 			// be reused in the next iteration.
 			b.data = slices.Clone(b.data)
-			b.flushable = newFlushableBatch(&b, d.opts.Comparer)
+			b.flushable, err = newFlushableBatch(&b, d.opts.Comparer)
+			if err != nil {
+				return nil, 0, err
+			}
 			entry := d.newFlushableEntry(b.flushable, logNum, b.SeqNum())
 			// Disable memory accounting by adding a reader ref that will never be
 			// removed.

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -205,7 +205,8 @@ func TestLoadFlushedSSTableKeys(t *testing.T) {
 			}
 
 			br, _ := pebble.ReadBatch(b.Repr())
-			for kind, ukey, v, ok := br.Next(); ok; kind, ukey, v, ok = br.Next() {
+			kind, ukey, v, ok, err := br.Next()
+			for ; ok; kind, ukey, v, ok, err = br.Next() {
 				fmt.Fprintf(&buf, "%s.%s", ukey, kind)
 				switch kind {
 				case base.InternalKeyKindRangeDelete,
@@ -229,6 +230,9 @@ func TestLoadFlushedSSTableKeys(t *testing.T) {
 					fmt.Fprintf(&buf, ": %x", v)
 				}
 				fmt.Fprintln(&buf)
+			}
+			if err != nil {
+				fmt.Fprintf(&buf, "err: %s\n", err)
 			}
 
 			s := buf.String()

--- a/testdata/batch_reader
+++ b/testdata/batch_reader
@@ -1,0 +1,98 @@
+scan
+----
+Count: 0
+eof
+
+scan
+ffffffffffffffffffffffffffffffffffffffffffffffff
+----
+Count: 4294967295
+err: invalid key kind 0xff: pebble: invalid batch
+
+scan
+0000000000000000 01000000   # Seqnum = 0, Count = 1
+00 01 61                    # DEL "a"
+----
+Count: 1
+DEL: "a": ""
+eof
+
+scan
+0000000000000000 01000000   # Seqnum = 0, Count = 1
+01 01 62 01 62              # SET "b" = "b"
+----
+Count: 1
+SET: "b": "b"
+eof
+
+scan
+0000000000000000 01000000   # Seqnum = 0, Count = 1
+01 01 62 01 62              # SET "b" = "b"
+----
+Count: 1
+SET: "b": "b"
+eof
+
+scan
+0000000000000000 02000000   # Seqnum = 0, Count = 2
+00 01 61                    # DEL "a"
+01 01 62 01 62              # SET "b" = "b"
+----
+Count: 2
+DEL: "a": ""
+SET: "b": "b"
+eof
+
+scan
+0000000000000000 03000000   # Seqnum = 0, Count = 3
+00 01 61                    # DEL "a"
+01 01 62 01 62              # SET "b" = "b"
+0F 01 62 01 63              # RANGEDEL "b" = "c"
+----
+Count: 3
+DEL: "a": ""
+SET: "b": "b"
+RANGEDEL: "b": "c"
+eof
+
+scan
+0000000000000000 03000000   # Seqnum = 0, Count = 3
+00 01 61                    # DEL "a"
+01 01 62 01 62              # SET "b" = "b"
+0F 01 62 01                 # RANGEDEL "b"... missing end key string data
+----
+Count: 3
+DEL: "a": ""
+SET: "b": "b"
+err: decoding RANGEDEL value: pebble: invalid batch
+
+scan
+0000000000000000 03000000   # Seqnum = 0, Count = 3
+00 01 61                    # DEL "a"
+01 01 62 01 62              # SET "b" = "b"
+0F 01 62 01                 # RANGEDEL "b"... missing end key string data
+----
+Count: 3
+DEL: "a": ""
+SET: "b": "b"
+err: decoding RANGEDEL value: pebble: invalid batch
+
+
+scan
+0000000000000000 03000000   # Seqnum = 0, Count = 3
+00 01 61                    # DEL "a"
+01 01 62 01 62              # SET "b" = "b"
+1F 01 62 01                 # "1F" kind is garbage
+----
+Count: 3
+DEL: "a": ""
+SET: "b": "b"
+err: invalid key kind 0x1f: pebble: invalid batch
+
+scan
+0000000000000000 01000000   # Seqnum = 0, Count = 1
+01 01                       # SET missing user key string data
+----
+Count: 1
+err: decoding user key: pebble: invalid batch
+

--- a/testdata/compaction_iter
+++ b/testdata/compaction_iter
@@ -238,7 +238,7 @@ a.SET.1:c
 iter
 first
 ----
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.SET.2:b
@@ -250,7 +250,7 @@ first
 next
 ----
 a#2,1:b
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.MERGE.2:b
@@ -262,7 +262,7 @@ first
 next
 ----
 a#2,2:b
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.INVALID.2:c
@@ -273,7 +273,7 @@ iter
 first
 tombstones
 ----
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 .
 
 define

--- a/testdata/compaction_iter_delete_sized
+++ b/testdata/compaction_iter_delete_sized
@@ -238,7 +238,7 @@ a.SET.1:c
 iter
 first
 ----
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.SET.2:b
@@ -250,7 +250,7 @@ first
 next
 ----
 a#2,18:b
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.MERGE.2:b
@@ -262,7 +262,7 @@ first
 next
 ----
 a#2,2:b
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.INVALID.2:c
@@ -273,7 +273,7 @@ iter
 first
 tombstones
 ----
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 .
 
 define
@@ -1338,7 +1338,7 @@ first
 next
 ----
 a#2,18:b
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.SET.3:c
@@ -1351,7 +1351,7 @@ first
 next
 ----
 a#3,18:c
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 # SINGLEDEL that meets a SETWITHDEL is transformed into a DEL.
 

--- a/testdata/compaction_iter_set_with_del
+++ b/testdata/compaction_iter_set_with_del
@@ -238,7 +238,7 @@ a.SET.1:c
 iter
 first
 ----
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.SET.2:b
@@ -250,7 +250,7 @@ first
 next
 ----
 a#2,18:b
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.MERGE.2:b
@@ -262,7 +262,7 @@ first
 next
 ----
 a#2,2:b
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.INVALID.2:c
@@ -273,7 +273,7 @@ iter
 first
 tombstones
 ----
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 .
 
 define
@@ -1338,7 +1338,7 @@ first
 next
 ----
 a#2,18:b
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.SET.3:c
@@ -1351,7 +1351,7 @@ first
 next
 ----
 a#3,18:c
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 # SINGLEDEL that meets a SETWITHDEL is transformed into a DEL.
 

--- a/tool/find.go
+++ b/tool/find.go
@@ -348,8 +348,12 @@ func (f *findT) searchLogs(stdout io.Writer, searchKey []byte, refs []findRef) [
 				}
 				seqNum := b.SeqNum()
 				for r := b.Reader(); ; seqNum++ {
-					kind, ukey, value, ok := r.Next()
+					kind, ukey, value, ok, err := r.Next()
 					if !ok {
+						if err != nil {
+							fmt.Fprintf(stdout, "%s: corrupt log file: %v", path, err)
+							break
+						}
 						break
 					}
 					ikey := base.MakeInternalKey(ukey, seqNum, kind)

--- a/tool/wal.go
+++ b/tool/wal.go
@@ -119,14 +119,17 @@ func (w *walT) runDump(cmd *cobra.Command, args []string) {
 
 				b = pebble.Batch{}
 				if err := b.SetRepr(buf.Bytes()); err != nil {
-					fmt.Fprintf(stdout, "corrupt log file %q: %v", arg, err)
+					fmt.Fprintf(stdout, "corrupt batch within log file %q: %v", arg, err)
 					return
 				}
 				fmt.Fprintf(stdout, "%d(%d) seq=%d count=%d\n",
 					offset, len(b.Repr()), b.SeqNum(), b.Count())
 				for r, idx := b.Reader(), 0; ; idx++ {
-					kind, ukey, value, ok := r.Next()
+					kind, ukey, value, ok, err := r.Next()
 					if !ok {
+						if err != nil {
+							fmt.Fprintf(stdout, "corrupt batch within log file %q: %v", arg, err)
+						}
 						break
 					}
 					fmt.Fprintf(stdout, "    %s(", kind)


### PR DESCRIPTION
Previously BatchReader.Next had a subtle API. If Next returned ok=false, the caller is responsible for checking len(r) and interpreting it as corruption if len(r) > 0. This commit introduces an explicit error return value.

Fixes #3023.