### PR TITLE
crl-release-23.2: db: add an error return value to BatchReader.Next

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -41,10 +41,10 @@ const (
 var ErrNotIndexed = errors.New("pebble: batch not indexed")
 
 // ErrInvalidBatch indicates that a batch is invalid or otherwise corrupted.
-var ErrInvalidBatch = errors.New("pebble: invalid batch")
+var ErrInvalidBatch = base.MarkCorruptionError(errors.New("pebble: invalid batch"))
 
 // ErrBatchTooLarge indicates that a batch is invalid or otherwise corrupted.
-var ErrBatchTooLarge = errors.Newf("pebble: batch too large: >= %s", humanize.Bytes.Uint64(maxBatchSize))
+var ErrBatchTooLarge = base.MarkCorruptionError(errors.Newf("pebble: batch too large: >= %s", humanize.Bytes.Uint64(maxBatchSize)))
 
 // DeferredBatchOp represents a batch operation (eg. set, merge, delete) that is
 // being inserted into the batch. Indexing is not performed on the specified key
@@ -449,18 +449,21 @@ func (b *Batch) release() {
 	}
 }
 
-func (b *Batch) refreshMemTableSize() {
+func (b *Batch) refreshMemTableSize() error {
 	b.memTableSize = 0
 	if len(b.data) < batchHeaderLen {
-		return
+		return nil
 	}
 
 	b.countRangeDels = 0
 	b.countRangeKeys = 0
 	b.minimumFormatMajorVersion = 0
 	for r := b.Reader(); ; {
-		kind, key, value, ok := r.Next()
+		kind, key, value, ok, err := r.Next()
 		if !ok {
+			if err != nil {
+				return err
+			}
 			break
 		}
 		switch kind {
@@ -484,6 +487,7 @@ func (b *Batch) refreshMemTableSize() {
 	if b.countRangeKeys > 0 && b.minimumFormatMajorVersion < FormatRangeKeys {
 		b.minimumFormatMajorVersion = FormatRangeKeys
 	}
+	return nil
 }
 
 // Apply the operations contained in the batch to the receiver batch.
@@ -497,7 +501,7 @@ func (b *Batch) Apply(batch *Batch, _ *WriteOptions) error {
 		return nil
 	}
 	if len(batch.data) < batchHeaderLen {
-		return base.CorruptionErrorf("pebble: invalid batch")
+		return ErrInvalidBatch
 	}
 
 	offset := len(b.data)
@@ -514,8 +518,11 @@ func (b *Batch) Apply(batch *Batch, _ *WriteOptions) error {
 		// order to update the index.
 		for iter := BatchReader(b.data[offset:]); len(iter) > 0; {
 			offset := uintptr(unsafe.Pointer(&iter[0])) - uintptr(unsafe.Pointer(&b.data[0]))
-			kind, key, value, ok := iter.Next()
+			kind, key, value, ok, err := iter.Next()
 			if !ok {
+				if err != nil {
+					return err
+				}
 				break
 			}
 			switch kind {
@@ -1096,11 +1103,12 @@ func (b *Batch) SetRepr(data []byte) error {
 	}
 	b.data = data
 	b.count = uint64(binary.LittleEndian.Uint32(b.countData()))
+	var err error
 	if b.db != nil {
 		// Only track memTableSize for batches that will be committed to the DB.
-		b.refreshMemTableSize()
+		err = b.refreshMemTableSize()
 	}
-	return nil
+	return err
 }
 
 // NewIter returns an iterator that is unpositioned (Iterator.Valid() will
@@ -1456,6 +1464,11 @@ func (b *Batch) Reader() BatchReader {
 }
 
 func batchDecodeStr(data []byte) (odata []byte, s []byte, ok bool) {
+	// TODO(jackson): This will index out of bounds if there's no varint or an
+	// invalid varint (eg, a single 0xff byte). Correcting will add a bit of
+	// overhead. We could avoid that overhead whenever len(data) >=
+	// binary.MaxVarint32?
+
 	var v uint32
 	var n int
 	ptr := unsafe.Pointer(&data[0])
@@ -1518,19 +1531,21 @@ func ReadBatch(repr []byte) (r BatchReader, count uint32) {
 	return repr[batchHeaderLen:], count
 }
 
-// Next returns the next entry in this batch. The final return value is false
-// if the batch is corrupt. The end of batch is reached when len(r)==0.
-func (r *BatchReader) Next() (kind InternalKeyKind, ukey []byte, value []byte, ok bool) {
+// Next returns the next entry in this batch, if there is one. If the reader has
+// reached the end of the batch, Next returns ok=false and a nil error. If the
+// batch is corrupt and the next entry is illegible, Next returns ok=false and a
+// non-nil error.
+func (r *BatchReader) Next() (kind InternalKeyKind, ukey []byte, value []byte, ok bool, err error) {
 	if len(*r) == 0 {
-		return 0, nil, nil, false
+		return 0, nil, nil, false, nil
 	}
 	kind = InternalKeyKind((*r)[0])
 	if kind > InternalKeyKindMax {
-		return 0, nil, nil, false
+		return 0, nil, nil, false, errors.Wrapf(ErrInvalidBatch, "invalid key kind 0x%x", (*r)[0])
 	}
 	*r, ukey, ok = batchDecodeStr((*r)[1:])
 	if !ok {
-		return 0, nil, nil, false
+		return 0, nil, nil, false, errors.Wrapf(ErrInvalidBatch, "decoding user key")
 	}
 	switch kind {
 	case InternalKeyKindSet, InternalKeyKindMerge, InternalKeyKindRangeDelete,
@@ -1538,10 +1553,10 @@ func (r *BatchReader) Next() (kind InternalKeyKind, ukey []byte, value []byte, o
 		InternalKeyKindDeleteSized:
 		*r, value, ok = batchDecodeStr(*r)
 		if !ok {
-			return 0, nil, nil, false
+			return 0, nil, nil, false, errors.Wrapf(ErrInvalidBatch, "decoding %s value", kind)
 		}
 	}
-	return kind, ukey, value, true
+	return kind, ukey, value, true, nil
 }
 
 // Note: batchIter mirrors the implementation of flushableBatchIter. Keep the
@@ -1743,7 +1758,7 @@ var _ flushable = (*flushableBatch)(nil)
 // interface. This allows the batch to act like a memtable and be placed in the
 // queue of flushable memtables. Note that the flushable batch takes ownership
 // of the batch data.
-func newFlushableBatch(batch *Batch, comparer *Comparer) *flushableBatch {
+func newFlushableBatch(batch *Batch, comparer *Comparer) (*flushableBatch, error) {
 	b := &flushableBatch{
 		data:      batch.data,
 		cmp:       comparer.Compare,
@@ -1764,8 +1779,11 @@ func newFlushableBatch(batch *Batch, comparer *Comparer) *flushableBatch {
 		var index uint32
 		for iter := BatchReader(b.data[batchHeaderLen:]); len(iter) > 0; index++ {
 			offset := uintptr(unsafe.Pointer(&iter[0])) - uintptr(unsafe.Pointer(&b.data[0]))
-			kind, key, _, ok := iter.Next()
+			kind, key, _, ok, err := iter.Next()
 			if !ok {
+				if err != nil {
+					return nil, err
+				}
 				break
 			}
 			entry := flushableBatchEntry{
@@ -1837,7 +1855,7 @@ func newFlushableBatch(batch *Batch, comparer *Comparer) *flushableBatch {
 		}
 		fragmentRangeKeys(frag, it, len(rangeKeyOffsets))
 	}
-	return b
+	return b, nil
 }
 
 func (b *flushableBatch) setSeqNum(seqNum uint64) {
@@ -2263,7 +2281,10 @@ func batchSort(
 		rangeKeyIter := b.newRangeKeyIter(nil, math.MaxUint64)
 		return pointIter, rangeDelIter, rangeKeyIter
 	}
-	f := newFlushableBatch(b, b.db.opts.Comparer)
+	f, err := newFlushableBatch(b, b.db.opts.Comparer)
+	if err != nil {
+		panic(err)
+	}
 	return f.newIter(nil), f.newRangeDelIter(nil), f.newRangeKeyIter(nil)
 }
 

--- a/batch_test.go
+++ b/batch_test.go
@@ -7,6 +7,7 @@ package pebble
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"math"
@@ -16,6 +17,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode"
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
@@ -48,8 +50,11 @@ func testBatch(t *testing.T, size int) {
 				tc.kind == InternalKeyKindRangeKeyDelete || tc.kind == InternalKeyKindRangeDelete) {
 				continue
 			}
-			kind, k, v, ok := r.Next()
+			kind, k, v, ok, err := r.Next()
 			if !ok {
+				if err != nil {
+					t.Fatal(err)
+				}
 				t.Fatalf("next returned !ok: test case = %v", tc)
 			}
 			key, value := string(k), string(v)
@@ -653,7 +658,9 @@ func TestIndexedBatch_GlobalVisibility(t *testing.T) {
 
 func TestFlushableBatchReset(t *testing.T) {
 	var b Batch
-	b.flushable = newFlushableBatch(&b, DefaultComparer)
+	var err error
+	b.flushable, err = newFlushableBatch(&b, DefaultComparer)
+	require.NoError(t, err)
 
 	b.Reset()
 	require.Nil(t, b.flushable)
@@ -1003,7 +1010,9 @@ func TestFlushableBatchIter(t *testing.T) {
 				value := []byte(fmt.Sprint(ikey.SeqNum()))
 				batch.Set(ikey.UserKey, value, nil)
 			}
-			b = newFlushableBatch(batch, DefaultComparer)
+			var err error
+			b, err = newFlushableBatch(batch, DefaultComparer)
+			require.NoError(t, err)
 			return ""
 
 		case "iter":
@@ -1044,7 +1053,9 @@ func TestFlushableBatch(t *testing.T) {
 					require.NoError(t, batch.RangeKeyUnset(ikey.UserKey, value, value, nil))
 				}
 			}
-			b = newFlushableBatch(batch, DefaultComparer)
+			var err error
+			b, err = newFlushableBatch(batch, DefaultComparer)
+			require.NoError(t, err)
 			return ""
 
 		case "iter":
@@ -1122,7 +1133,9 @@ func TestFlushableBatchDeleteRange(t *testing.T) {
 			if err := runBatchDefineCmd(td, b); err != nil {
 				return err.Error()
 			}
-			fb = newFlushableBatch(b, DefaultComparer)
+			var err error
+			fb, err = newFlushableBatch(b, DefaultComparer)
+			require.NoError(t, err)
 			return ""
 
 		case "scan":
@@ -1163,7 +1176,8 @@ func TestFlushableBatchBytesIterated(t *testing.T) {
 		value := make([]byte, 7+j%5)
 		batch.Set(key, value, nil)
 
-		fb := newFlushableBatch(batch, DefaultComparer)
+		fb, err := newFlushableBatch(batch, DefaultComparer)
+		require.NoError(t, err)
 
 		var bytesIterated uint64
 		it := fb.newFlushIter(nil, &bytesIterated)
@@ -1185,7 +1199,8 @@ func TestFlushableBatchBytesIterated(t *testing.T) {
 
 func TestEmptyFlushableBatch(t *testing.T) {
 	// Verify that we can create a flushable batch on an empty batch.
-	fb := newFlushableBatch(newBatch(nil), DefaultComparer)
+	fb, err := newFlushableBatch(newBatch(nil), DefaultComparer)
+	require.NoError(t, err)
 	it := newInternalIterAdapter(fb.newIter(nil))
 	require.False(t, it.First())
 }
@@ -1330,6 +1345,52 @@ func TestBatchCommitStats(t *testing.T) {
 		}
 	}
 	require.NoError(t, err)
+}
+
+func TestBatchReader(t *testing.T) {
+	datadriven.RunTest(t, "testdata/batch_reader", func(t *testing.T, td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "scan":
+			var repr bytes.Buffer
+			for i, l := range strings.Split(td.Input, "\n") {
+				// Remove any trailing comments behind #.
+				if i := strings.IndexRune(l, '#'); i >= 0 {
+					l = l[:i]
+				}
+				// Strip all whitespace from the line.
+				l = strings.Map(func(r rune) rune {
+					if unicode.IsSpace(r) {
+						return -1
+					}
+					return r
+				}, l)
+				b, err := hex.DecodeString(l)
+				if err != nil {
+					return fmt.Sprintf("failed to decode hex; line %d", i)
+				}
+				repr.Write(b)
+			}
+			r, count := ReadBatch(repr.Bytes())
+			var out strings.Builder
+			fmt.Fprintf(&out, "Count: %d\n", count)
+			for {
+				kind, ukey, value, ok, err := r.Next()
+				if !ok {
+					if err != nil {
+						fmt.Fprintf(&out, "err: %s\n", err)
+					} else {
+						fmt.Fprint(&out, "eof")
+					}
+					break
+				}
+				fmt.Fprintf(&out, "%s: %q: %q\n", kind, ukey, value)
+			}
+			return out.String()
+
+		default:
+			return fmt.Sprintf("unrecognized command %q", td.Cmd)
+		}
+	})
 }
 
 func BenchmarkBatchSet(b *testing.B) {

--- a/db.go
+++ b/db.go
@@ -840,10 +840,16 @@ func (d *DB) applyInternal(batch *Batch, opts *WriteOptions, noSyncWait bool) er
 	batch.committing = true
 
 	if batch.db == nil {
-		batch.refreshMemTableSize()
+		if err := batch.refreshMemTableSize(); err != nil {
+			return err
+		}
 	}
 	if batch.memTableSize >= d.largeBatchThreshold {
-		batch.flushable = newFlushableBatch(batch, d.opts.Comparer)
+		var err error
+		batch.flushable, err = newFlushableBatch(batch, d.opts.Comparer)
+		if err != nil {
+			return err
+		}
 	}
 	if err := d.commit.Commit(batch, sync, noSyncWait); err != nil {
 		// There isn't much we can do on an error here. The commit pipeline will be

--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/cockroachdb/redact"
 )
 
 const (
@@ -159,6 +161,11 @@ func (k InternalKeyKind) String() string {
 		return internalKeyKindNames[k]
 	}
 	return fmt.Sprintf("UNKNOWN:%d", k)
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (k InternalKeyKind) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Print(redact.SafeString(k.String()))
 }
 
 // InternalKey is a key used for the in-memory and on-disk partial DBs that

--- a/mem_table.go
+++ b/mem_table.go
@@ -211,11 +211,13 @@ func (m *memTable) apply(batch *Batch, seqNum uint64) error {
 	var tombstoneCount, rangeKeyCount uint32
 	startSeqNum := seqNum
 	for r := batch.Reader(); ; seqNum++ {
-		kind, ukey, value, ok := r.Next()
+		kind, ukey, value, ok, err := r.Next()
 		if !ok {
+			if err != nil {
+				return err
+			}
 			break
 		}
-		var err error
 		ikey := base.MakeInternalKey(ukey, seqNum, kind)
 		switch kind {
 		case InternalKeyKindRangeDelete:

--- a/open.go
+++ b/open.go
@@ -709,6 +709,11 @@ func (d *DB) replayWAL(
 		batchesReplayed int64 // number of batches replayed
 	)
 
+	// TODO(jackson): This function is interspersed with panics, in addition to
+	// corruption error propagation. Audit them to ensure we're truly only
+	// panicking where the error points to Pebble bug and not user or
+	// hardware-induced corruption.
+
 	if d.opts.ReadOnly {
 		// In read-only mode, we replay directly into the mutable memtable which will
 		// never be flushed.
@@ -763,6 +768,11 @@ func (d *DB) replayWAL(
 		ve.NewFiles = append(ve.NewFiles, newVE.NewFiles...)
 		return nil
 	}
+	defer func() {
+		if err != nil {
+			err = errors.WithDetailf(err, "replaying log %s, offset %d", logNum, offset)
+		}
+	}()
 
 	for {
 		offset = rr.Offset()
@@ -804,7 +814,9 @@ func (d *DB) replayWAL(
 		batchesReplayed++
 		{
 			br := b.Reader()
-			if kind, encodedFileNum, _, _ := br.Next(); kind == InternalKeyKindIngestSST {
+			if kind, encodedFileNum, _, ok, err := br.Next(); err != nil {
+				return nil, 0, err
+			} else if ok && kind == InternalKeyKindIngestSST {
 				fileNums := make([]base.DiskFileNum, 0, b.Count())
 				addFileNum := func(encodedFileNum []byte) {
 					fileNum, n := binary.Uvarint(encodedFileNum)
@@ -816,7 +828,10 @@ func (d *DB) replayWAL(
 				addFileNum(encodedFileNum)
 
 				for i := 1; i < int(b.Count()); i++ {
-					kind, encodedFileNum, _, ok := br.Next()
+					kind, encodedFileNum, _, ok, err := br.Next()
+					if err != nil {
+						return nil, 0, err
+					}
 					if kind != InternalKeyKindIngestSST {
 						panic("pebble: invalid batch key kind.")
 					}
@@ -826,7 +841,9 @@ func (d *DB) replayWAL(
 					addFileNum(encodedFileNum)
 				}
 
-				if _, _, _, ok := br.Next(); ok {
+				if _, _, _, ok, err := br.Next(); err != nil {
+					return nil, 0, err
+				} else if ok {
 					panic("pebble: invalid number of entries in batch.")
 				}
 
@@ -919,7 +936,10 @@ func (d *DB) replayWAL(
 			// Make a copy of the data slice since it is currently owned by buf and will
 			// be reused in the next iteration.
 			b.data = append([]byte(nil), b.data...)
-			b.flushable = newFlushableBatch(&b, d.opts.Comparer)
+			b.flushable, err = newFlushableBatch(&b, d.opts.Comparer)
+			if err != nil {
+				return nil, 0, err
+			}
 			entry := d.newFlushableEntry(b.flushable, logNum, b.SeqNum())
 			// Disable memory accounting by adding a reader ref that will never be
 			// removed.

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -205,7 +205,8 @@ func TestLoadFlushedSSTableKeys(t *testing.T) {
 			}
 
 			br, _ := pebble.ReadBatch(b.Repr())
-			for kind, ukey, v, ok := br.Next(); ok; kind, ukey, v, ok = br.Next() {
+			kind, ukey, v, ok, err := br.Next()
+			for ; ok; kind, ukey, v, ok, err = br.Next() {
 				fmt.Fprintf(&buf, "%s.%s", ukey, kind)
 				switch kind {
 				case base.InternalKeyKindRangeDelete,
@@ -229,6 +230,9 @@ func TestLoadFlushedSSTableKeys(t *testing.T) {
 					fmt.Fprintf(&buf, ": %x", v)
 				}
 				fmt.Fprintln(&buf)
+			}
+			if err != nil {
+				fmt.Fprintf(&buf, "err: %s\n", err)
 			}
 
 			s := buf.String()

--- a/testdata/batch_reader
+++ b/testdata/batch_reader
@@ -1,0 +1,98 @@
+scan
+----
+Count: 0
+eof
+
+scan
+ffffffffffffffffffffffffffffffffffffffffffffffff
+----
+Count: 4294967295
+err: invalid key kind 0xff: pebble: invalid batch
+
+scan
+0000000000000000 01000000   # Seqnum = 0, Count = 1
+00 01 61                    # DEL "a"
+----
+Count: 1
+DEL: "a": ""
+eof
+
+scan
+0000000000000000 01000000   # Seqnum = 0, Count = 1
+01 01 62 01 62              # SET "b" = "b"
+----
+Count: 1
+SET: "b": "b"
+eof
+
+scan
+0000000000000000 01000000   # Seqnum = 0, Count = 1
+01 01 62 01 62              # SET "b" = "b"
+----
+Count: 1
+SET: "b": "b"
+eof
+
+scan
+0000000000000000 02000000   # Seqnum = 0, Count = 2
+00 01 61                    # DEL "a"
+01 01 62 01 62              # SET "b" = "b"
+----
+Count: 2
+DEL: "a": ""
+SET: "b": "b"
+eof
+
+scan
+0000000000000000 03000000   # Seqnum = 0, Count = 3
+00 01 61                    # DEL "a"
+01 01 62 01 62              # SET "b" = "b"
+0F 01 62 01 63              # RANGEDEL "b" = "c"
+----
+Count: 3
+DEL: "a": ""
+SET: "b": "b"
+RANGEDEL: "b": "c"
+eof
+
+scan
+0000000000000000 03000000   # Seqnum = 0, Count = 3
+00 01 61                    # DEL "a"
+01 01 62 01 62              # SET "b" = "b"
+0F 01 62 01                 # RANGEDEL "b"... missing end key string data
+----
+Count: 3
+DEL: "a": ""
+SET: "b": "b"
+err: decoding RANGEDEL value: pebble: invalid batch
+
+scan
+0000000000000000 03000000   # Seqnum = 0, Count = 3
+00 01 61                    # DEL "a"
+01 01 62 01 62              # SET "b" = "b"
+0F 01 62 01                 # RANGEDEL "b"... missing end key string data
+----
+Count: 3
+DEL: "a": ""
+SET: "b": "b"
+err: decoding RANGEDEL value: pebble: invalid batch
+
+
+scan
+0000000000000000 03000000   # Seqnum = 0, Count = 3
+00 01 61                    # DEL "a"
+01 01 62 01 62              # SET "b" = "b"
+1F 01 62 01                 # "1F" kind is garbage
+----
+Count: 3
+DEL: "a": ""
+SET: "b": "b"
+err: invalid key kind 0x1f: pebble: invalid batch
+
+scan
+0000000000000000 01000000   # Seqnum = 0, Count = 1
+01 01                       # SET missing user key string data
+----
+Count: 1
+err: decoding user key: pebble: invalid batch
+

--- a/testdata/compaction_iter
+++ b/testdata/compaction_iter
@@ -238,7 +238,7 @@ a.SET.1:c
 iter
 first
 ----
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.SET.2:b
@@ -250,7 +250,7 @@ first
 next
 ----
 a#2,1:b
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.MERGE.2:b
@@ -262,7 +262,7 @@ first
 next
 ----
 a#2,2:b
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.INVALID.2:c
@@ -273,7 +273,7 @@ iter
 first
 tombstones
 ----
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 .
 
 define

--- a/testdata/compaction_iter_delete_sized
+++ b/testdata/compaction_iter_delete_sized
@@ -238,7 +238,7 @@ a.SET.1:c
 iter
 first
 ----
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.SET.2:b
@@ -250,7 +250,7 @@ first
 next
 ----
 a#2,18:b
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.MERGE.2:b
@@ -262,7 +262,7 @@ first
 next
 ----
 a#2,2:b
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.INVALID.2:c
@@ -273,7 +273,7 @@ iter
 first
 tombstones
 ----
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 .
 
 define
@@ -1338,7 +1338,7 @@ first
 next
 ----
 a#2,18:b
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.SET.3:c
@@ -1351,7 +1351,7 @@ first
 next
 ----
 a#3,18:c
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 # SINGLEDEL that meets a SETWITHDEL is transformed into a DEL.
 

--- a/testdata/compaction_iter_set_with_del
+++ b/testdata/compaction_iter_set_with_del
@@ -238,7 +238,7 @@ a.SET.1:c
 iter
 first
 ----
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.SET.2:b
@@ -250,7 +250,7 @@ first
 next
 ----
 a#2,18:b
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.MERGE.2:b
@@ -262,7 +262,7 @@ first
 next
 ----
 a#2,2:b
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.INVALID.2:c
@@ -273,7 +273,7 @@ iter
 first
 tombstones
 ----
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 .
 
 define
@@ -1338,7 +1338,7 @@ first
 next
 ----
 a#2,18:b
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 define
 a.SET.3:c
@@ -1351,7 +1351,7 @@ first
 next
 ----
 a#3,18:c
-err=invalid internal key kind: 191
+err=invalid internal key kind: INVALID
 
 # SINGLEDEL that meets a SETWITHDEL is transformed into a DEL.
 

--- a/tool/find.go
+++ b/tool/find.go
@@ -352,8 +352,12 @@ func (f *findT) searchLogs(stdout io.Writer, searchKey []byte, refs []findRef) [
 				}
 				seqNum := b.SeqNum()
 				for r := b.Reader(); ; seqNum++ {
-					kind, ukey, value, ok := r.Next()
+					kind, ukey, value, ok, err := r.Next()
 					if !ok {
+						if err != nil {
+							fmt.Fprintf(stdout, "%s: corrupt log file: %v", path, err)
+							break
+						}
 						break
 					}
 					ikey := base.MakeInternalKey(ukey, seqNum, kind)

--- a/tool/wal.go
+++ b/tool/wal.go
@@ -119,14 +119,17 @@ func (w *walT) runDump(cmd *cobra.Command, args []string) {
 
 				b = pebble.Batch{}
 				if err := b.SetRepr(buf.Bytes()); err != nil {
-					fmt.Fprintf(stdout, "corrupt log file %q: %v", arg, err)
+					fmt.Fprintf(stdout, "corrupt batch within log file %q: %v", arg, err)
 					return
 				}
 				fmt.Fprintf(stdout, "%d(%d) seq=%d count=%d\n",
 					offset, len(b.Repr()), b.SeqNum(), b.Count())
 				for r, idx := b.Reader(), 0; ; idx++ {
-					kind, ukey, value, ok := r.Next()
+					kind, ukey, value, ok, err := r.Next()
 					if !ok {
+						if err != nil {
+							fmt.Fprintf(stdout, "corrupt batch within log file %q: %v", arg, err)
+						}
 						break
 					}
 					fmt.Fprintf(stdout, "    %s(", kind)


### PR DESCRIPTION
23.2 backport of #3103.

----

Previously BatchReader.Next had a subtle API. If Next returned ok=false, the caller is responsible for checking len(r) and interpreting it as corruption if len(r) > 0. This commit introduces an explicit error return value.

Fixes #3023.