### PR TITLE
metamorphic: convert TestKeyManager to datadriven

### DIFF
--- a/metamorphic/key_manager_test.go
+++ b/metamorphic/key_manager_test.go
@@ -2,13 +2,15 @@ package metamorphic
 
 import (
 	"bytes"
+	"fmt"
+	"io"
+	"strings"
 	"testing"
 
+	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/randvar"
 	"github.com/stretchr/testify/require"
 )
-
-var dbObjID objID = makeObjID(dbTag, 1)
 
 func TestObjKey(t *testing.T) {
 	testCases := []struct {
@@ -283,220 +285,78 @@ func TestKeyManager_MergeInto(t *testing.T) {
 	require.NotContains(t, m.byObj, fromID)
 }
 
-type seqFn func(t *testing.T, k *keyManager)
-
-func updateForOp(op op) seqFn {
-	return func(t *testing.T, k *keyManager) {
-		k.update(op)
+func mustParseObjID(s string) objID {
+	id, err := parseObjID(s)
+	if err != nil {
+		panic(err)
 	}
+	return id
 }
 
-func addKey(key []byte, expected bool) seqFn {
-	return func(t *testing.T, k *keyManager) {
-		require.Equal(t, expected, k.addNewKey(key))
+func printKeys(w io.Writer, keys [][]byte) {
+	if len(keys) == 0 {
+		fmt.Fprintln(w, "(none)")
+		return
 	}
-}
-
-func eligibleRead(key []byte, val bool) seqFn {
-	return func(t *testing.T, k *keyManager) {
-		require.Equal(t, val, contains(key, k.eligibleReadKeys()))
-	}
-}
-
-func eligibleWrite(key []byte, val bool) seqFn {
-	return func(t *testing.T, k *keyManager) {
-		require.Equal(t, val, contains(key, k.eligibleWriteKeys()))
-	}
-}
-
-func eligibleSingleDelete(key []byte, val bool, id objID) seqFn {
-	return func(t *testing.T, k *keyManager) {
-		require.Equal(t, val, contains(key, k.eligibleSingleDeleteKeys(id, dbObjID)))
-	}
-}
-
-func contains(key []byte, keys [][]byte) bool {
-	for _, k := range keys {
-		if bytes.Equal(key, k) {
-			return true
+	for i, key := range keys {
+		if i > 0 {
+			fmt.Fprint(w, ", ")
 		}
+		fmt.Fprintf(w, "%q", key)
 	}
-	return false
+	fmt.Fprintln(w)
 }
 
 func TestKeyManager(t *testing.T) {
-	var (
-		id1  = makeObjID(batchTag, 0)
-		id2  = makeObjID(batchTag, 1)
-		key1 = []byte("foo")
-	)
-
-	testCases := []struct {
-		description string
-		ops         []seqFn
-		wantPanic   bool
-	}{
-		{
-			description: "set, single del, on db",
-			ops: []seqFn{
-				addKey(key1, true),
-				addKey(key1, false),
-				eligibleRead(key1, true),
-				eligibleWrite(key1, true),
-				eligibleSingleDelete(key1, false, dbObjID),
-				eligibleSingleDelete(key1, false, id1),
-				updateForOp(&setOp{writerID: dbObjID, key: key1}),
-				eligibleRead(key1, true),
-				eligibleWrite(key1, true),
-				eligibleSingleDelete(key1, true, dbObjID),
-				eligibleSingleDelete(key1, true, id1),
-				updateForOp(&singleDeleteOp{writerID: dbObjID, key: key1}),
-				eligibleRead(key1, true),
-				eligibleWrite(key1, true),
-				eligibleSingleDelete(key1, false, dbObjID),
-			},
-		},
-		{
-			description: "set, single del, on batch",
-			ops: []seqFn{
-				addKey(key1, true),
-				updateForOp(&setOp{writerID: id1, key: key1}),
-				eligibleRead(key1, true),
-				eligibleWrite(key1, true),
-				eligibleSingleDelete(key1, false, dbObjID),
-				eligibleSingleDelete(key1, true, id1),
-				eligibleSingleDelete(key1, false, id2),
-				updateForOp(&singleDeleteOp{writerID: id1, key: key1}),
-				eligibleRead(key1, true),
-				eligibleWrite(key1, false),
-				eligibleSingleDelete(key1, false, dbObjID),
-				eligibleSingleDelete(key1, false, id1),
-				updateForOp(&applyOp{batchID: id1, writerID: dbObjID}),
-				eligibleWrite(key1, true),
-				eligibleSingleDelete(key1, false, dbObjID),
-			},
-		},
-		{
-			description: "set on db, single del on batch",
-			ops: []seqFn{
-				addKey(key1, true),
-				updateForOp(&setOp{writerID: dbObjID, key: key1}),
-				eligibleWrite(key1, true),
-				eligibleSingleDelete(key1, true, dbObjID),
-				eligibleSingleDelete(key1, true, id1),
-				updateForOp(&singleDeleteOp{writerID: id1, key: key1}),
-				eligibleWrite(key1, false),
-				eligibleSingleDelete(key1, false, dbObjID),
-				eligibleSingleDelete(key1, false, id1),
-				updateForOp(&applyOp{batchID: id1, writerID: dbObjID}),
-				eligibleWrite(key1, true),
-				eligibleSingleDelete(key1, false, dbObjID),
-				updateForOp(&setOp{writerID: dbObjID, key: key1}),
-				eligibleSingleDelete(key1, true, dbObjID),
-				eligibleSingleDelete(key1, true, id1),
-			},
-		},
-		{
-			description: "set, del, set, single del, on db",
-			ops: []seqFn{
-				addKey(key1, true),
-				updateForOp(&setOp{writerID: dbObjID, key: key1}),
-				updateForOp(&deleteOp{writerID: dbObjID, key: key1}),
-				eligibleWrite(key1, true),
-				eligibleSingleDelete(key1, false, dbObjID),
-				updateForOp(&setOp{writerID: dbObjID, key: key1}),
-				eligibleWrite(key1, true),
-				eligibleSingleDelete(key1, true, dbObjID),
-				updateForOp(&singleDeleteOp{writerID: dbObjID, key: key1}),
-				eligibleWrite(key1, true),
-				eligibleSingleDelete(key1, false, dbObjID),
-			},
-		},
-		{
-			description: "set, del, set, del, on batches",
-			ops: []seqFn{
-				addKey(key1, true),
-				updateForOp(&setOp{writerID: id1, key: key1}),
-				updateForOp(&deleteOp{writerID: id1, key: key1}),
-				updateForOp(&setOp{writerID: id1, key: key1}),
-				eligibleWrite(key1, true),
-				eligibleSingleDelete(key1, false, id1),
-				updateForOp(&applyOp{batchID: id1, writerID: dbObjID}),
-				eligibleWrite(key1, true),
-				// Not eligible for single del since the set count is 2.
-				eligibleSingleDelete(key1, false, dbObjID),
-				updateForOp(&setOp{writerID: dbObjID, key: key1}),
-				// Not eligible for single del since the set count is 3.
-				eligibleSingleDelete(key1, false, dbObjID),
-				updateForOp(&deleteOp{writerID: id2, key: key1}),
-				updateForOp(&applyOp{batchID: id2, writerID: dbObjID}),
-				// Set count is 0.
-				eligibleSingleDelete(key1, false, dbObjID),
-				// Set count is 1.
-				updateForOp(&setOp{writerID: dbObjID, key: key1}),
-				eligibleSingleDelete(key1, true, dbObjID),
-			},
-		},
-		{
-			description: "set, merge, del, set, single del, on db",
-			ops: []seqFn{
-				addKey(key1, true),
-				updateForOp(&setOp{writerID: dbObjID, key: key1}),
-				eligibleSingleDelete(key1, true, dbObjID),
-				updateForOp(&mergeOp{writerID: dbObjID, key: key1}),
-				eligibleSingleDelete(key1, false, dbObjID),
-				updateForOp(&deleteOp{writerID: dbObjID, key: key1}),
-				eligibleWrite(key1, true),
-				eligibleSingleDelete(key1, false, dbObjID),
-				updateForOp(&setOp{writerID: dbObjID, key: key1}),
-				eligibleWrite(key1, true),
-				eligibleSingleDelete(key1, true, dbObjID),
-				updateForOp(&singleDeleteOp{writerID: dbObjID, key: key1}),
-				eligibleWrite(key1, true),
-				eligibleSingleDelete(key1, false, dbObjID),
-			},
-		},
-		{
-			description: "set, del on db, set, single del on batch",
-			ops: []seqFn{
-				addKey(key1, true),
-				updateForOp(&setOp{writerID: dbObjID, key: key1}),
-				eligibleSingleDelete(key1, true, dbObjID),
-				updateForOp(&deleteOp{writerID: dbObjID, key: key1}),
-				eligibleWrite(key1, true),
-				eligibleSingleDelete(key1, false, dbObjID),
-				updateForOp(&setOp{writerID: id1, key: key1}),
-				eligibleWrite(key1, true),
-				eligibleSingleDelete(key1, false, dbObjID),
-				eligibleSingleDelete(key1, true, id1),
-				updateForOp(&singleDeleteOp{writerID: id1, key: key1}),
-				eligibleWrite(key1, false),
-				eligibleSingleDelete(key1, false, id1),
-				eligibleSingleDelete(key1, false, dbObjID),
-				updateForOp(&applyOp{batchID: id1, writerID: dbObjID}),
-				eligibleWrite(key1, true),
-				eligibleSingleDelete(key1, false, dbObjID),
-				updateForOp(&setOp{writerID: dbObjID, key: key1}),
-				eligibleSingleDelete(key1, true, dbObjID),
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			m := newKeyManager(1 /* numInstances */)
-			tFunc := func() {
-				for _, op := range tc.ops {
-					op(t, m)
+	var buf bytes.Buffer
+	km := newKeyManager(1 /* numInstances */)
+	datadriven.RunTest(t, "testdata/key_manager", func(t *testing.T, td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "reset":
+			km = newKeyManager(1 /* numInstances */)
+			return ""
+		case "run":
+			buf.Reset()
+			for _, line := range strings.Split(td.Input, "\n") {
+				fields := strings.Fields(line)
+				switch fields[0] {
+				case "add-new-key":
+					if km.addNewKey([]byte(fields[1])) {
+						fmt.Fprintf(&buf, "%q is new\n", fields[1])
+					} else {
+						fmt.Fprintf(&buf, "%q already tracked\n", fields[1])
+					}
+				case "keys":
+				case "read-keys":
+					fmt.Fprintf(&buf, "read keys: ")
+					printKeys(&buf, km.eligibleReadKeys())
+				case "write-keys":
+					fmt.Fprintf(&buf, "write keys: ")
+					printKeys(&buf, km.eligibleWriteKeys())
+				case "singledel-keys":
+					fmt.Fprintf(&buf, "singledel keys: ")
+					printKeys(&buf, km.eligibleSingleDeleteKeys(
+						mustParseObjID(fields[1]), mustParseObjID(fields[2])))
+				case "op":
+					ops, err := parse([]byte(strings.TrimPrefix(line, "op")), parserOpts{
+						allowUndefinedObjs: true,
+					})
+					if err != nil {
+						t.Fatal(err)
+					} else if len(ops) != 1 {
+						t.Fatalf("expected 1 op but found %d", len(ops))
+					}
+					km.update(ops[0])
+					fmt.Fprintf(&buf, "[%s]\n", ops[0])
+				default:
+					return fmt.Sprintf("unrecognized subcommand %q", fields[0])
 				}
 			}
-			if tc.wantPanic {
-				require.Panics(t, tFunc)
-			} else {
-				tFunc()
-			}
-		})
-	}
+			return buf.String()
+		default:
+			return fmt.Sprintf("unrecognized command %q", td.Cmd)
+		}
+	})
 }
 
 func TestOpWrittenKeys(t *testing.T) {

--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -176,7 +176,7 @@ func RunAndCompare(t *testing.T, rootDir string, rOpts ...RunOption) {
 		opsPath := filepath.Join(filepath.Dir(filepath.Clean(runOpts.previousOpsPath)), "ops")
 		opsData, err := os.ReadFile(opsPath)
 		require.NoError(t, err)
-		ops, err := parse(opsData)
+		ops, err := parse(opsData, parserOpts{})
 		require.NoError(t, err)
 		loadPrecedingKeys(t, ops, &cfg, km)
 	}
@@ -421,7 +421,7 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 	opsData, err := os.ReadFile(opsPath)
 	require.NoError(t, err)
 
-	ops, err := parse(opsData)
+	ops, err := parse(opsData, parserOpts{})
 	require.NoError(t, err)
 	_ = ops
 

--- a/metamorphic/parser_test.go
+++ b/metamorphic/parser_test.go
@@ -17,7 +17,7 @@ func TestParser(t *testing.T) {
 	datadriven.RunTest(t, "testdata/parser", func(t *testing.T, d *datadriven.TestData) string {
 		switch d.Cmd {
 		case "parse":
-			ops, err := parse([]byte(d.Input))
+			ops, err := parse([]byte(d.Input), parserOpts{})
 			if err != nil {
 				return err.Error()
 			}
@@ -40,7 +40,7 @@ func TestParserRandom(t *testing.T) {
 			ops := generate(randvar.NewRand(), 10000, cfg, newKeyManager(cfg.numInstances))
 			src := formatOps(ops)
 
-			parsedOps, err := parse([]byte(src))
+			parsedOps, err := parse([]byte(src), parserOpts{})
 			if err != nil {
 				t.Fatalf("%s\n%s", err, src)
 			}
@@ -57,7 +57,7 @@ func TestParserNilBounds(t *testing.T) {
 			iterOpts: iterOpts{},
 		},
 	})
-	parsedOps, err := parse([]byte(formatted))
+	parsedOps, err := parse([]byte(formatted), parserOpts{})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(parsedOps))
 	v := parsedOps[0].(*newIterOp)

--- a/metamorphic/testdata/key_manager
+++ b/metamorphic/testdata/key_manager
@@ -1,0 +1,288 @@
+# run subcommands
+#
+# add-new-key <key>
+# read-keys
+# write-keys
+# singledel-keys <writerID> <dbID>
+# op <operation string as printed to ops files>
+
+run
+add-new-key foo
+add-new-key foo
+----
+"foo" is new
+"foo" already tracked
+
+# Test SET; SINGLEDEL on DB.
+
+run
+read-keys
+write-keys
+singledel-keys db1 db1
+singledel-keys batch1 db1
+op db1.Set("foo", "foo")
+read-keys
+write-keys
+singledel-keys db1 db1
+singledel-keys batch1 db1
+op db1.SingleDelete("foo", false)
+read-keys
+write-keys
+singledel-keys db1 db1
+----
+read keys: "foo"
+write keys: "foo"
+singledel keys: (none)
+singledel keys: (none)
+[db1.Set("foo", "foo")]
+read keys: "foo"
+write keys: "foo"
+singledel keys: "foo"
+singledel keys: "foo"
+[db1.SingleDelete("foo", false /* maybeReplaceDelete */)]
+read keys: "foo"
+write keys: "foo"
+singledel keys: (none)
+
+
+# Test SET; SINGLEDEL on batch on separate key.
+
+run
+add-new-key bar
+op batch1.Set("bar", "bar")
+read-keys
+write-keys
+singledel-keys db1 db1
+singledel-keys batch1 db1
+singledel-keys batch2 db1
+op batch1.SingleDelete("bar", false)
+read-keys
+write-keys
+singledel-keys db1 db1
+singledel-keys batch1 db1
+op db1.Apply(batch1)
+write-keys
+singledel-keys db1 db1
+----
+"bar" is new
+[batch1.Set("bar", "bar")]
+read keys: "bar", "foo"
+write keys: "bar", "foo"
+singledel keys: (none)
+singledel keys: "bar"
+singledel keys: (none)
+[batch1.SingleDelete("bar", false /* maybeReplaceDelete */)]
+read keys: "bar", "foo"
+write keys: "foo"
+singledel keys: (none)
+singledel keys: (none)
+[db1.Apply(batch1)]
+write keys: "bar", "foo"
+singledel keys: (none)
+
+# Test SET on db; SINGLEDEL on batch.
+
+reset
+----
+
+run
+add-new-key foo
+op db1.Set("foo", "foo")
+write-keys
+singledel-keys db1 db1
+singledel-keys batch1 db1
+op batch1.SingleDelete("foo", false)
+write-keys
+singledel-keys db1 db1
+singledel-keys batch1 db1
+op db1.Apply(batch1)
+write-keys
+singledel-keys db1 db1
+op db1.Set("foo", "foo")
+singledel-keys db1 db1
+singledel-keys batch1 db1
+----
+"foo" is new
+[db1.Set("foo", "foo")]
+write keys: "foo"
+singledel keys: "foo"
+singledel keys: "foo"
+[batch1.SingleDelete("foo", false /* maybeReplaceDelete */)]
+write keys: (none)
+singledel keys: (none)
+singledel keys: (none)
+[db1.Apply(batch1)]
+write keys: "foo"
+singledel keys: (none)
+[db1.Set("foo", "foo")]
+singledel keys: "foo"
+singledel keys: "foo"
+
+# Test SET; DEL; SET; SingleDelete on db.
+
+reset
+----
+
+run
+add-new-key foo
+op db1.Set("foo", "foo")
+op db1.Delete("foo")
+write-keys
+singledel-keys db1 db1
+op db1.Set("foo", "foo")
+write-keys
+singledel-keys db1 db1
+op db1.SingleDelete("foo", false)
+write-keys
+singledel-keys db1 db1
+----
+"foo" is new
+[db1.Set("foo", "foo")]
+[db1.Delete("foo")]
+write keys: "foo"
+singledel keys: (none)
+[db1.Set("foo", "foo")]
+write keys: "foo"
+singledel keys: "foo"
+[db1.SingleDelete("foo", false /* maybeReplaceDelete */)]
+write keys: "foo"
+singledel keys: (none)
+
+# Test SET; DEL; SET; DEL on batches.
+
+reset
+----
+
+run
+add-new-key foo
+op batch1.Set("foo", "foo")
+op batch1.Delete("foo")
+op batch1.Set("foo", "foo")
+write-keys
+singledel-keys batch1 db1
+op db1.Apply(batch1)
+write-keys
+----
+"foo" is new
+[batch1.Set("foo", "foo")]
+[batch1.Delete("foo")]
+[batch1.Set("foo", "foo")]
+write keys: "foo"
+singledel keys: (none)
+[db1.Apply(batch1)]
+write keys: "foo"
+
+# "foo" should not be eliible for single delete because set count is 2.
+
+run
+singledel-keys db1 db1
+----
+singledel keys: (none)
+
+run
+op db1.Set("foo", "foo")
+----
+[db1.Set("foo", "foo")]
+
+# "foo" should still not be eliible for single delete because set count is 3.
+
+run
+singledel-keys db1 db1
+----
+singledel keys: (none)
+
+
+run
+op batch2.Delete("foo")
+op db1.Apply(batch2)
+singledel-keys db1 db1
+op db1.Set("foo", "foo")
+singledel-keys db1 db1
+----
+[batch2.Delete("foo")]
+[db1.Apply(batch2)]
+singledel keys: (none)
+[db1.Set("foo", "foo")]
+singledel keys: "foo"
+
+# Test SET; MERGE; DEL; SINGLEDEL on DB.
+
+reset
+----
+
+run
+add-new-key foo
+op db.Set("foo", "foo")
+singledel-keys db1 db1
+op db1.Merge("foo", "foo")
+singledel-keys db1 db1
+op db1.Delete("foo")
+write-keys
+singledel-keys db1 db1
+op db1.Set("foo", "foo")
+write-keys
+singledel-keys db1 db1
+op db1.SingleDelete("foo", false)
+write-keys
+singledel-keys db1 db1
+----
+"foo" is new
+[db1.Set("foo", "foo")]
+singledel keys: "foo"
+[db1.Merge("foo", "foo")]
+singledel keys: (none)
+[db1.Delete("foo")]
+write keys: "foo"
+singledel keys: (none)
+[db1.Set("foo", "foo")]
+write keys: "foo"
+singledel keys: "foo"
+[db1.SingleDelete("foo", false /* maybeReplaceDelete */)]
+write keys: "foo"
+singledel keys: (none)
+
+# Test SET; DEL (db); SET; SINGLEDEL (batch)
+
+reset
+----
+
+run
+add-new-key foo
+op db1.Set("foo", "foo")
+singledel-keys db1 db1
+op db1.Delete("foo")
+write-keys
+singledel-keys db1 db1
+op db1.Set("foo", "foo")
+write-keys
+singledel-keys db1 db1
+singledel-keys batch1 db1
+op batch1.SingleDelete("foo", false)
+write-keys
+singledel-keys db1 db1
+singledel-keys batch1 db1
+op db1.Apply(batch1)
+write-keys
+singledel-keys db1 db1
+op db1.Set("foo", "foo")
+singledel-keys db1 db1
+----
+"foo" is new
+[db1.Set("foo", "foo")]
+singledel keys: "foo"
+[db1.Delete("foo")]
+write keys: "foo"
+singledel keys: (none)
+[db1.Set("foo", "foo")]
+write keys: "foo"
+singledel keys: "foo"
+singledel keys: "foo"
+[batch1.SingleDelete("foo", false /* maybeReplaceDelete */)]
+write keys: (none)
+singledel keys: (none)
+singledel keys: (none)
+[db1.Apply(batch1)]
+write keys: "foo"
+singledel keys: (none)
+[db1.Set("foo", "foo")]
+singledel keys: "foo"


### PR DESCRIPTION
Convert the TestKeyManager test and its existing test cases to a datadriven format. Future work will add additional test cases, and new functionality around tracking of range deleted spans.