### PR TITLE
metamorphic: apply a few small key manager simplifications

### DIFF
--- a/metamorphic/key_manager_test.go
+++ b/metamorphic/key_manager_test.go
@@ -236,17 +236,6 @@ func TestKeyManager_GetOrInit(t *testing.T) {
 	require.Equal(t, meta1, meta2)
 }
 
-func TestKeyManager_Contains(t *testing.T) {
-	id := makeObjID(dbTag, 1)
-	key := []byte("foo")
-
-	m := newKeyManager(1 /* numInstances */)
-	require.False(t, m.contains(id, key))
-
-	m.getOrInit(id, key)
-	require.True(t, m.contains(id, key))
-}
-
 func TestKeyManager_MergeInto(t *testing.T) {
 	fromID := makeObjID(batchTag, 1)
 	toID := makeObjID(dbTag, 1)


### PR DESCRIPTION
This commit applies a few small simplifications to the metamorphic test key manager:

The contains method was unused and is removed. The mergeInto method unnecessarily branched when appending keyUpdates to the keyMeta log. The mergeKeysInto method unnecessarily sorted using the composite objKey type's String method output, when the sort can be performed directly on the key type.