### PR TITLE
metamorphic: refactor key tracking for single deletes 

### DIFF
--- a/metamorphic/config.go
+++ b/metamorphic/config.go
@@ -53,6 +53,10 @@ const (
 	writerSingleDelete
 )
 
+func (o opType) isDelete() bool {
+	return o == writerDelete || o == writerDeleteRange || o == writerSingleDelete
+}
+
 type config struct {
 	// Weights for the operation mix to generate. ops[i] corresponds to the
 	// weight for opType(i).

--- a/metamorphic/key_manager.go
+++ b/metamorphic/key_manager.go
@@ -1,10 +1,13 @@
 package metamorphic
 
 import (
+	"bytes"
 	"cmp"
 	"fmt"
 	"slices"
+	"strings"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/testkeys"
@@ -22,7 +25,7 @@ type objKey struct {
 // makeObjKey returns a new objKey given and id and key.
 func makeObjKey(id objID, key []byte) objKey {
 	if id.tag() != dbTag && id.tag() != batchTag {
-		panic("unexpected non-writer tag")
+		panic(fmt.Sprintf("unexpected non-writer tag %v", id.tag()))
 	}
 	return objKey{id, key}
 }
@@ -33,101 +36,108 @@ func (o objKey) String() string {
 	return fmt.Sprintf("%s:%s", o.id, o.key)
 }
 
-type keyUpdate struct {
-	deleted bool
-	// metaTimestamp at which the write or delete op occurred.
-	metaTimestamp int
-}
-
 // keyMeta is metadata associated with an (objID, key) pair, where objID is
 // a writer containing the key.
 type keyMeta struct {
 	objKey
-
-	// The number of Sets of the key in this writer.
-	sets int
-	// The number of Merges of the key in this writer.
-	merges int
-	// singleDel can be true only if sets <= 1 && merges == 0 and the
-	// SingleDelete was added to this writer after the set.
-	singleDel bool
-	// The number of Deletes of the key in this writer.
-	dels int
-	// del can be true only if a Delete was added to this writer after the
-	// Sets and Merges counted above.
-	del bool
-
-	// updateOps should always be ordered by non-decreasing metaTimestamp.
-	// updateOps will not be updated if the key is range deleted. Therefore, it
-	// is a best effort sequence of updates to the key. updateOps is used to
-	// determine if an iterator created on the DB can read a certain key.
-	updateOps []keyUpdate
+	// history provides the history of writer operations applied against this
+	// key on this object. history is always ordered by non-decreasing
+	// metaTimestamp.
+	history keyHistory
 }
 
 func (m *keyMeta) clear() {
-	m.sets = 0
-	m.merges = 0
-	m.singleDel = false
-	m.del = false
-	m.dels = 0
-	m.updateOps = nil
+	m.history = m.history[:0]
 }
 
-// mergeInto merges this metadata this into the metadata for other.
-func (m *keyMeta) mergeInto(keyManager *keyManager, other *keyMeta) {
-	if other.del && !m.del {
-		// m's Sets and Merges are later.
-		if m.sets > 0 || m.merges > 0 {
-			other.del = false
+// mergeInto merges this metadata into the metadata for other, appending all of
+// its individual operations to dst at the provided timestamp.
+func (m *keyMeta) mergeInto(dst *keyMeta, ts int) {
+	for _, op := range m.history {
+		// If the key is being merged into a database object and the operation
+		// is a delete, we can clear the destination history. Database objects
+		// are end points in the merging of keys and won't be the source of a
+		// future merge. Deletions cause all other operations to behave as
+		// though the key was never written to the database at all, so we don't
+		// need to consider it for maintaining single delete invariants.
+		//
+		// NB: There's a subtlety here in that isDelete() will return true if
+		// opType is a writerSingleDelete, but single deletes are capable of
+		// leaking information about the history of writes. However, that's
+		// okay, because as long as we're properly generating single deletes
+		// according to the W1 invariant described in keyManager's comment, a
+		// single delete is equivalent to delete for the current history.
+		if dst.objKey.id.tag() == dbTag && op.opType.isDelete() {
+			dst.clear()
+			continue
 		}
-	} else {
-		other.del = m.del
-	}
-	// Sets, merges, dels are additive.
-	other.sets += m.sets
-	other.merges += m.merges
-	other.dels += m.dels
-
-	// Single deletes are preserved. This is valid since we are also
-	// maintaining a global invariant that SingleDelete will only be added for
-	// a key that has no inflight Sets or Merges (Sets have made their way to
-	// the DB), and no subsequent Sets or Merges will happen until the
-	// SingleDelete makes its way to the DB.
-	other.singleDel = other.singleDel || m.singleDel
-	if other.singleDel {
-		if other.sets > 1 || other.merges > 0 || other.dels > 0 {
-			panic(fmt.Sprintf("invalid sets %d or merges %d or dels %d",
-				other.sets, other.merges, other.dels))
-		}
-	}
-
-	// Determine if the key is visible or not after the keyMetas are merged.
-	// TODO(bananabrick): We currently only care about key updates which make it
-	// to the DB, since we only use key updates to determine if an iterator
-	// can read a key in the DB. We could extend the timestamp system to add
-	// support for iterators created on batches.
-	if other.del || other.singleDel {
-		other.updateOps = append(
-			other.updateOps, keyUpdate{true, keyManager.nextMetaTimestamp()},
-		)
-	} else {
-		other.updateOps = append(
-			other.updateOps, keyUpdate{false, keyManager.nextMetaTimestamp()},
-		)
+		dst.history = append(dst.history, keyHistoryItem{
+			opType:        op.opType,
+			metaTimestamp: ts,
+		})
 	}
 }
 
 // keyManager tracks the write operations performed on keys in the generation
-// phase of the metamorphic test. It makes the assumption that write
-// operations do not fail, since that can cause the keyManager state to be not
-// in-sync with the actual state of the writers. This assumption is needed to
-// correctly decide when it is safe to generate a SingleDelete. This
-// assumption is violated in a single place in the metamorphic test: ingestion
-// of multiple batches. We sidestep this issue in a narrow way in
-// generator.writerIngest by not ingesting multiple batches that contain
-// deletes or single deletes, since loss of those specific operations on a key
-// are what we cannot tolerate (doing SingleDelete on a key that has not been
-// written to because the Set was lost is harmless).
+// phase of the metamorphic test. It maintains histories of operations performed
+// against every unique user key on every writer object. These histories inform
+// operation generation in order to maintain invariants that Pebble requires of
+// end users, mostly around single deletions.
+//
+// A single deletion has a subtle requirement of the writer:
+//
+//	W1: The writer may only single delete a key `k` if `k` has been Set once
+//	    (and never MergeD) since the last delete.
+//
+// When a SINGLEDEL key deletes a SET key within a compaction, both the SET and
+// the SINGLEDEL keys are elided. If multiple SETs of the key exist within the
+// LSM, the SINGLEDEL reveals the lower SET. This behavior is dependent on the
+// internal LSM state and nondeterministic. To ensure determinism, the end user
+// must satisfy W1 and use single delete only when they can guarantee that the
+// key has been set at most once since the last delete, preventing this rollback
+// to a previous value.
+//
+// This W1 invariant requires a delicate dance during operation generation,
+// because independent batches may be independently built and committed. With
+// multi-instance variants of the metamorphic tests, keys in batches may
+// ultimately be committed to any of several DB instances. To satisfy these
+// requirements, the key manager tracks the history of every key on every
+// writable object. When generating a new single deletion operation, the
+// generator asks the key manager for a set of keys for which a single delete
+// maintains the W1 invariant within the object itself. This object-local W1
+// invariant (OLW1) is equivalent to W1 if one only ever performs write
+// operations directly against individual DB objects.
+//
+// However with the existence of batches that receive writes independent of DB
+// objects, W1 may be violated by appending the histories of two objects that
+// independently satisfy OLW1. Consider a sequence such as:
+//
+//  1. db1.Set("foo")
+//  2. batch1.Set("foo")
+//  3. batch1.SingleDelete("foo")
+//  4. db1.Apply(batch1)
+//
+// Both db1 and batch1 satisfy the object-local invariant OLW1. However the
+// composition of the histories created by appending batch1's operations to db1
+// creates a history that now violates W1 on db1. To detect this violation,
+// batch applications/commits and ingestions examine the tail of the destination
+// object's history and the head of the source batch's history. When a violation
+// is detected, these operations insert additional Delete operations to clear
+// the conflicting keys before proceeding with the conflicting operation. These
+// deletes reset the key history.
+//
+// Note that this generation-time key tracking requires that operations be
+// infallible, because a runtime failure would cause the key manager's state to
+// diverge from the runtime object state. Ingestion operations pose an obstacle,
+// because the generator may generate ingestions that fail due to overlapping
+// sstables. Today, this complication is sidestepped by avoiding ingestion of
+// multiple batches containing deletes or single deletes since loss of those
+// specific operations on a key are what we cannot tolerate (doing SingleDelete
+// on a key that has not been written to because the Set was lost is harmless).
+//
+// TODO(jackson): Instead, compute smallest and largest bounds of batches so
+// that we know at generation-time whether or not an ingestion operation will
+// fail and can avoid updating key state.
 type keyManager struct {
 	comparer *base.Comparer
 
@@ -148,57 +158,15 @@ type keyManager struct {
 	// globalKeys represents all the keys that have been generated so far. Not
 	// all these keys have been written to. globalKeys is sorted.
 	globalKeys [][]byte
-	// globalKeysMap contains the same keys as globalKeys. It ensures no
-	// duplication, and contains the aggregate state of the key across all
-	// writers, including inflight state that has not made its way to the DB
-	// yet.The keyMeta.objKey is uninitialized.
-	globalKeysMap map[string]*keyMeta
+	// globalKeysMap contains the same keys as globalKeys but in a map. It
+	// ensures no duplication.
+	globalKeysMap map[string]bool
 	// globalKeyPrefixes contains all the key prefixes (as defined by the
 	// comparer's Split) generated so far. globalKeyPrefixes is sorted.
 	globalKeyPrefixes [][]byte
 	// globalKeyPrefixesMap contains the same keys as globalKeyPrefixes. It
 	// ensures no duplication.
 	globalKeyPrefixesMap map[string]struct{}
-
-	// Using SingleDeletes imposes some constraints on the above state, and
-	// causes some state transitions that help with generating complex but
-	// correct sequences involving SingleDeletes.
-	// - Generating a SingleDelete requires for that key: global.merges==0 &&
-	//   global.sets==1 && global.dels==0 && !global.singleDel && (db.sets==1
-	//   || writer.sets==1), where global represents the entry in
-	//   globalKeysMap[key] and db represents the entry in
-	//   byObjKey[makeObjKey(makeObjID(dbTag, 0), key)], and writer is the
-	//   entry in byObjKey[makeObjKey(writerID, key)].
-	//
-	// - We do not track state changes due to range deletes, so one should
-	//   think of these counts as upper bounds. Also we are not preventing
-	//   interactions caused by concurrently in-flight range deletes and
-	//   SingleDelete. This is acceptable since it does not cause
-	//   non-determinism.
-	//
-	// - When the SingleDelete is generated, it is recorded as
-	//   writer.singleDel=true and global.singleDel=true. No more write
-	//   operations are permitted on this key until db.singleDel transitions
-	//   to true.
-	//
-	// - When db.singleDel transitions to true, we are guaranteed that no
-	//   writer other than the DB has any writes for this key. We set
-	//   db.singleDel and global.singleDel to false and the corresponding sets
-	//   and merges counts in global and db also to 0. This allows this key to
-	//   fully participate again in write operations. This means we can
-	//   generate sequences of the form:
-	//   SET => SINGLEDEL => SET* => MERGE* => DEL
-	//   SET => SINGLEDEL => SET => SINGLEDEL, among others.
-	//
-	// - The above logic is insufficient to generate sequences of the form
-	//   SET => DEL => SET => SINGLEDEL
-	//   To do this we need to track Deletes. When db.del transitions to true,
-	//   we check if db.sets==global.sets && db.merges==global.merges &&
-	//   db.dels==global.dels. If true, there are no in-flight
-	//   sets/merges/deletes to this key. We then default initialize the
-	//   global and db entries since one can behave as if this key was never
-	//   written in this system. This enables the above sequence, among
-	//   others.
 }
 
 func (k *keyManager) nextMetaTimestamp() int {
@@ -208,14 +176,14 @@ func (k *keyManager) nextMetaTimestamp() int {
 }
 
 // newKeyManager returns a pointer to a new keyManager. Callers should
-// interact with this using addNewKey, eligible*Keys, update,
+// interact with this using addNewKey, knownKeys, update,
 // canTolerateApplyFailure methods only.
 func newKeyManager(numInstances int) *keyManager {
 	m := &keyManager{
 		comparer:             testkeys.Comparer,
 		byObjKey:             make(map[string]*keyMeta),
 		byObj:                make(map[objID][]*keyMeta),
-		globalKeysMap:        make(map[string]*keyMeta),
+		globalKeysMap:        make(map[string]bool),
 		globalKeyPrefixesMap: make(map[string]struct{}),
 	}
 	for i := 1; i <= max(numInstances, 1); i++ {
@@ -227,18 +195,16 @@ func newKeyManager(numInstances int) *keyManager {
 // addNewKey adds the given key to the key manager for global key tracking.
 // Returns false iff this is not a new key.
 func (k *keyManager) addNewKey(key []byte) bool {
-	_, ok := k.globalKeysMap[string(key)]
-	if ok {
+	if k.globalKeysMap[string(key)] {
 		return false
 	}
-	keyString := string(key)
 	insertSorted(k.comparer.Compare, &k.globalKeys, key)
-	k.globalKeysMap[keyString] = &keyMeta{objKey: objKey{key: key}}
+	k.globalKeysMap[string(key)] = true
 
 	prefixLen := k.comparer.Split(key)
-	if _, ok := k.globalKeyPrefixesMap[keyString[:prefixLen]]; !ok {
+	if _, ok := k.globalKeyPrefixesMap[string(key[:prefixLen])]; !ok {
 		insertSorted(k.comparer.Compare, &k.globalKeyPrefixes, key[:prefixLen])
-		k.globalKeyPrefixesMap[keyString[:prefixLen]] = struct{}{}
+		k.globalKeyPrefixesMap[string(key[:prefixLen])] = struct{}{}
 	}
 	return true
 }
@@ -259,21 +225,14 @@ func (k *keyManager) getOrInit(id objID, key []byte) *keyMeta {
 	return m
 }
 
-// contains returns true if the (objID, key) pair is tracked by the keyManager.
-func (k *keyManager) contains(id objID, key []byte) bool {
-	_, ok := k.byObjKey[makeObjKey(id, key).String()]
-	return ok
-}
-
 // mergeKeysInto merges all metadata for all keys associated with the "from" ID
 // with the metadata for keys associated with the "to" ID.
-func (k *keyManager) mergeKeysInto(from, to objID) {
+func (k *keyManager) mergeKeysInto(from, to objID, mergeFunc func(src, dst *keyMeta, ts int)) {
 	msFrom, ok := k.byObj[from]
 	if !ok {
 		msFrom = []*keyMeta{}
 		k.byObj[from] = msFrom
 	}
-
 	msTo, ok := k.byObj[to]
 	if !ok {
 		msTo = []*keyMeta{}
@@ -282,23 +241,24 @@ func (k *keyManager) mergeKeysInto(from, to objID) {
 
 	// Sort to facilitate a merge.
 	slices.SortFunc(msFrom, func(a, b *keyMeta) int {
-		return cmp.Compare(a.String(), b.String())
+		return bytes.Compare(a.key, b.key)
 	})
 	slices.SortFunc(msTo, func(a, b *keyMeta) int {
-		return cmp.Compare(a.String(), b.String())
+		return bytes.Compare(a.key, b.key)
 	})
 
+	ts := k.nextMetaTimestamp()
 	var msNew []*keyMeta
 	var iTo int
 	for _, m := range msFrom {
 		// Move cursor on mTo forward.
-		for iTo < len(msTo) && string(msTo[iTo].key) < string(m.key) {
+		for iTo < len(msTo) && bytes.Compare(msTo[iTo].key, m.key) < 0 {
 			msNew = append(msNew, msTo[iTo])
 			iTo++
 		}
 
 		var mTo *keyMeta
-		if iTo < len(msTo) && string(msTo[iTo].key) == string(m.key) {
+		if iTo < len(msTo) && bytes.Equal(msTo[iTo].key, m.key) {
 			mTo = msTo[iTo]
 			iTo++
 		} else {
@@ -306,7 +266,7 @@ func (k *keyManager) mergeKeysInto(from, to objID) {
 			k.byObjKey[mTo.String()] = mTo
 		}
 
-		m.mergeInto(k, mTo)
+		mergeFunc(m, mTo, ts)
 		msNew = append(msNew, mTo)
 
 		delete(k.byObjKey, m.String()) // Unlink "from".
@@ -322,35 +282,117 @@ func (k *keyManager) mergeKeysInto(from, to objID) {
 	delete(k.byObj, from) // Unlink "from".
 }
 
-func (k *keyManager) checkForDelOrSingleDelTransition(dbMeta *keyMeta, globalMeta *keyMeta) {
-	if dbMeta.singleDel {
-		if !globalMeta.singleDel {
-			panic("inconsistency with globalMeta")
-		}
-		if dbMeta.del || globalMeta.del || dbMeta.dels > 0 || globalMeta.dels > 0 ||
-			dbMeta.merges > 0 || globalMeta.merges > 0 || dbMeta.sets != 1 || globalMeta.sets != 1 {
-			panic("inconsistency in metas when SingleDelete applied to DB")
-		}
-		dbMeta.clear()
-		globalMeta.clear()
-		return
-	}
-	if dbMeta.del && globalMeta.sets == dbMeta.sets && globalMeta.merges == dbMeta.merges &&
-		globalMeta.dels == dbMeta.dels {
-		if dbMeta.singleDel || globalMeta.singleDel {
-			panic("Delete should not have happened given SingleDelete")
-		}
-		dbMeta.clear()
-		globalMeta.clear()
-	}
-}
+// checkForSingleDelConflicts examines all the keys written to srcObj, and
+// determines whether any of the contained single deletes would be
+// nondeterministic if applied to dstObj in dstObj's current state. It returns a
+// slice of all the keys that are found to conflict. In order to preserve
+// determinism, the caller must delete the key from the destination before
+// writing src's mutations to dst in order to ensure determinism.
+//
+// It takes a `srcCollapsed` parameter that determines whether the source
+// history should be "collapsed" (see keyHistory.collapsed) before determining
+// whether the applied state will conflict. This is required to facilitate
+// ingestOps which are NOT equivalent to committing the batch, because they can
+// only commit 1 internal point key at each unique user key.
+func (k *keyManager) checkForSingleDelConflicts(srcObj, dstObj objID, srcCollapsed bool) [][]byte {
+	var conflicts [][]byte
+	for _, src := range k.byObj[srcObj] {
+		// Single delete generation logic already ensures that both srcObj and
+		// dstObj's single deletes are deterministic within the context of their
+		// existing writes. However, applying srcObj on top of dstObj may
+		// violate the invariants. Consider:
+		//
+		//    src: a.SET; a.SINGLEDEL;
+		//    dst: a.SET;
+		//
+		// The merged view is:
+		//
+		//    a.SET; a.SET; a.SINGLEDEL;
+		//
+		// This is invalid, because there is more than 1 value mutation of the
+		// key before the single delete.
+		//
+		// We walk the source object's history in chronological order, looking
+		// for a single delete that was written before a DEL/RANGEDEL. (NB: We
+		// don't need to look beyond a DEL/RANGEDEL, because these deletes bound
+		// any subsequently-written single deletes to applying to the keys
+		// within src's history between the two tombstones. We already know from
+		// per-object history invariants that any such single delete must be
+		// deterministic with respect to src's keys.)
+		var srcHasUnboundedSingleDelete bool
+		var srcValuesBeforeSingleDelete int
 
-func (k *keyManager) checkForDelOrSingleDelTransitionInDB(dbID objID) {
-	keys := k.byObj[dbID]
-	for _, dbMeta := range keys {
-		globalMeta := k.globalKeysMap[string(dbMeta.key)]
-		k.checkForDelOrSingleDelTransition(dbMeta, globalMeta)
+		// When the srcObj is being ingested (srcCollapsed=t), the semantics
+		// change. We must first "collapse" the key's history to represent the
+		// ingestion semantics.
+		srcHistory := src.history
+		if srcCollapsed {
+			srcHistory = src.history.collapsed()
+		}
+
+	srcloop:
+		for _, item := range srcHistory {
+			switch item.opType {
+			case writerDelete, writerDeleteRange:
+				// We found a DEL or RANGEDEL before any single delete. If src
+				// contains additional single deletes, their effects are limited
+				// to applying to later keys. Combining the two object histories
+				// doesn't pose any determinism risk.
+				break srcloop
+			case writerSingleDelete:
+				// We found a single delete. Since we found this single delete
+				// before a DEL or RANGEDEL, this delete has the potential to
+				// affect the visibility of keys in `dstObj`. We'll need to look
+				// for potential conflicts down below.
+				srcHasUnboundedSingleDelete = true
+				if srcValuesBeforeSingleDelete > 1 {
+					panic(errors.AssertionFailedf("unexpectedly found %d sets/merges within %s before single del",
+						srcValuesBeforeSingleDelete, srcObj))
+				}
+				break srcloop
+			case writerSet, writerMerge:
+				// We found a SET or MERGE operation for this key. If there's a
+				// subsequent single delete, we'll need to make sure there's not
+				// a SET or MERGE in the dst too.
+				srcValuesBeforeSingleDelete++
+			default:
+				panic(errors.AssertionFailedf("unexpected optype %d", item.opType))
+			}
+		}
+		if !srcHasUnboundedSingleDelete {
+			continue
+		}
+
+		dst, ok := k.byObjKey[makeObjKey(dstObj, src.key).String()]
+		// If the destination writer has no record of the key, the combined key
+		// history is simply the src object's key history which is valid due to
+		// per-object single deletion invariants.
+		if !ok {
+			continue
+		}
+
+		// We need to examine the trailing key history on dst.
+		consecutiveValues := srcValuesBeforeSingleDelete
+	dstloop:
+		for i := len(dst.history) - 1; i >= 0; i-- {
+			switch dst.history[i].opType {
+			case writerSet, writerMerge:
+				// A SET/MERGE may conflict if there's more than 1 consecutive
+				// SET/MERGEs.
+				consecutiveValues++
+				if consecutiveValues > 1 {
+					conflicts = append(conflicts, src.key)
+					break dstloop
+				}
+			case writerDelete, writerSingleDelete, writerDeleteRange:
+				// Dels clear the history, enabling use of single delete.
+				break dstloop
+			default:
+				panic(errors.AssertionFailedf("unexpected optype %d", dst.history[i].opType))
+			}
+		}
 	}
+	return conflicts
 }
 
 // update updates the internal state of the keyManager according to the given
@@ -359,74 +401,83 @@ func (k *keyManager) update(o op) {
 	switch s := o.(type) {
 	case *setOp:
 		meta := k.getOrInit(s.writerID, s.key)
-		globalMeta := k.globalKeysMap[string(s.key)]
-		meta.sets++ // Update the set count on this specific (id, key) pair.
-		meta.del = false
-		globalMeta.sets++
-		meta.updateOps = append(meta.updateOps, keyUpdate{false, k.nextMetaTimestamp()})
-		if meta.singleDel || globalMeta.singleDel {
-			panic("setting a key that has in-flight SingleDelete")
-		}
+		meta.history = append(meta.history, keyHistoryItem{
+			opType:        writerSet,
+			metaTimestamp: k.nextMetaTimestamp(),
+		})
 	case *mergeOp:
 		meta := k.getOrInit(s.writerID, s.key)
-		globalMeta := k.globalKeysMap[string(s.key)]
-		meta.merges++
-		meta.del = false
-		globalMeta.merges++
-		meta.updateOps = append(meta.updateOps, keyUpdate{false, k.nextMetaTimestamp()})
-		if meta.singleDel || globalMeta.singleDel {
-			panic("merging a key that has in-flight SingleDelete")
-		}
+		meta.history = append(meta.history, keyHistoryItem{
+			opType:        writerMerge,
+			metaTimestamp: k.nextMetaTimestamp(),
+		})
 	case *deleteOp:
 		meta := k.getOrInit(s.writerID, s.key)
-		globalMeta := k.globalKeysMap[string(s.key)]
-		meta.del = true
-		globalMeta.del = true
-		meta.dels++
-		globalMeta.dels++
-		meta.updateOps = append(meta.updateOps, keyUpdate{true, k.nextMetaTimestamp()})
-		if s.writerID.tag() == dbTag {
-			k.checkForDelOrSingleDelTransition(meta, globalMeta)
+		if meta.objKey.id.tag() == dbTag {
+			meta.clear()
+		} else {
+			meta.history = append(meta.history, keyHistoryItem{
+				opType:        writerDelete,
+				metaTimestamp: k.nextMetaTimestamp(),
+			})
+		}
+	case *deleteRangeOp:
+		// We track the history of discrete point keys, but a range deletion
+		// applies over a continuous key span of infinite keys. However, the key
+		// manager knows all keys that have been used in all operations, so we
+		// can discretize the range tombstone by adding it to every known key
+		// within the range.
+		ts := k.nextMetaTimestamp()
+		keyRange := pebble.KeyRange{Start: s.start, End: s.end}
+		for _, key := range k.knownKeysInRange(keyRange) {
+			meta := k.getOrInit(s.writerID, key)
+			if meta.objKey.id.tag() == dbTag {
+				meta.clear()
+			} else {
+				meta.history = append(meta.history, keyHistoryItem{
+					opType:        writerDeleteRange,
+					metaTimestamp: ts,
+				})
+			}
 		}
 	case *singleDeleteOp:
-		if !k.globalStateIndicatesEligibleForSingleDelete(s.key) {
-			panic("key ineligible for SingleDelete")
-		}
 		meta := k.getOrInit(s.writerID, s.key)
-		globalMeta := k.globalKeysMap[string(s.key)]
-		meta.singleDel = true
-		globalMeta.singleDel = true
-		meta.updateOps = append(meta.updateOps, keyUpdate{true, k.nextMetaTimestamp()})
-		if s.writerID.tag() == dbTag {
-			k.checkForDelOrSingleDelTransition(meta, globalMeta)
-		}
+		meta.history = append(meta.history, keyHistoryItem{
+			opType:        writerSingleDelete,
+			metaTimestamp: k.nextMetaTimestamp(),
+		})
 	case *ingestOp:
-		// For each batch, merge all keys with the keys in the DB.
+		// For each batch, merge the keys into the DB. We can't call
+		// keyMeta.mergeInto directly to merge, because ingest operations first
+		// "flatten" the batch (because you can't set the same key twice at a
+		// single sequence number). Instead we compute the collapsed history and
+		// merge that.
 		for _, batchID := range s.batchIDs {
-			k.mergeKeysInto(batchID, s.dbID)
+			k.mergeKeysInto(batchID, s.dbID, func(src, dst *keyMeta, ts int) {
+				collapsedSrc := keyMeta{
+					objKey:  src.objKey,
+					history: src.history.collapsed(),
+				}
+				collapsedSrc.mergeInto(dst, ts)
+			})
 		}
-		k.checkForDelOrSingleDelTransitionInDB(s.dbID)
 	case *applyOp:
 		// Merge the keys from this writer into the parent writer.
-		k.mergeKeysInto(s.batchID, s.writerID)
-		if s.writerID.tag() == dbTag {
-			k.checkForDelOrSingleDelTransitionInDB(s.writerID)
-		}
+		k.mergeKeysInto(s.batchID, s.writerID, (*keyMeta).mergeInto)
 	case *batchCommitOp:
 		// Merge the keys from the batch with the keys from the DB.
-		k.mergeKeysInto(s.batchID, s.dbID)
-		k.checkForDelOrSingleDelTransitionInDB(s.dbID)
+		k.mergeKeysInto(s.batchID, s.dbID, (*keyMeta).mergeInto)
 	}
 }
 
-func (k *keyManager) eligibleReadKeys() (keys [][]byte) {
+func (k *keyManager) knownKeys() (keys [][]byte) {
 	return k.globalKeys
 }
 
-// eligibleReadKeysInRange returns all eligible read keys within the range
+// knownKeysInRange returns all eligible read keys within the range
 // [start,end). The returned slice is owned by the keyManager and must not be
 // retained.
-func (k *keyManager) eligibleReadKeysInRange(kr pebble.KeyRange) (keys [][]byte) {
+func (k *keyManager) knownKeysInRange(kr pebble.KeyRange) (keys [][]byte) {
 	s, _ := slices.BinarySearchFunc(k.globalKeys, kr.Start, k.comparer.Compare)
 	e, _ := slices.BinarySearchFunc(k.globalKeys, kr.End, k.comparer.Compare)
 	if s >= e {
@@ -446,42 +497,26 @@ func (k *keyManager) prefixExists(prefix []byte) bool {
 	return exists
 }
 
-func (k *keyManager) eligibleWriteKeys() (keys [][]byte) {
-	// Creating and sorting this slice of keys is wasteful given that the
-	// caller will pick one, but makes it simpler for unit testing.
-	for _, v := range k.globalKeysMap {
-		if v.singleDel {
+// eligibleSingleDeleteKeys returns a slice of keys that can be safely single
+// deleted, given the writer id. Restricting single delete keys through this
+// method is used to ensure the OLW1 guarantee (see the keyManager comment) for
+// the provided object ID.
+func (k *keyManager) eligibleSingleDeleteKeys(o objID) (keys [][]byte) {
+	// Creating a slice of keys is wasteful given that the caller will pick one,
+	// but makes it simpler for unit testing.
+	for _, key := range k.globalKeys {
+		objKey := makeObjKey(o, key)
+		meta, ok := k.byObjKey[objKey.String()]
+		if !ok {
+			keys = append(keys, key)
 			continue
 		}
-		keys = append(keys, v.key)
-	}
-	slices.SortFunc(keys, k.comparer.Compare)
-	return keys
-}
-
-// eligibleSingleDeleteKeys returns a slice of keys that can be safely single
-// deleted, given the writer id.
-func (k *keyManager) eligibleSingleDeleteKeys(id, dbID objID) (keys [][]byte) {
-	// Creating and sorting this slice of keys is wasteful given that the
-	// caller will pick one, but makes it simpler for unit testing.
-	addForObjID := func(id objID) {
-		for _, m := range k.byObj[id] {
-			if m.sets == 1 && k.globalStateIndicatesEligibleForSingleDelete(m.key) {
-				keys = append(keys, m.key)
-			}
+		// Examine the history within this object.
+		if meta.history.canSingleDelete() {
+			keys = append(keys, key)
 		}
 	}
-	addForObjID(id)
-	if id.tag() != dbTag {
-		addForObjID(dbID)
-	}
-	slices.SortFunc(keys, k.comparer.Compare)
 	return keys
-}
-
-func (k *keyManager) globalStateIndicatesEligibleForSingleDelete(key []byte) bool {
-	m := k.globalKeysMap[string(key)]
-	return m.merges == 0 && m.sets == 1 && m.dels == 0 && !m.singleDel
 }
 
 // canTolerateApplyFailure is called with a batch ID and returns true iff a
@@ -495,11 +530,108 @@ func (k *keyManager) canTolerateApplyFailure(id objID) bool {
 		return true
 	}
 	for _, m := range ms {
-		if m.singleDel || m.del {
-			return false
+		for i := len(m.history) - 1; i >= 0; i-- {
+			if m.history[i].opType.isDelete() {
+				return false
+			}
 		}
 	}
 	return true
+}
+
+// a keyHistoryItem describes an individual operation performed on a key.
+type keyHistoryItem struct {
+	// opType may be writerSet, writerDelete, writerSingleDelete,
+	// writerDeleteRange or writerMerge only. No other opTypes may appear here.
+	opType        opType
+	metaTimestamp int
+}
+
+// keyHistory captures the history of mutations to a key in chronological order.
+type keyHistory []keyHistoryItem
+
+// before returns the subslice of the key history that happened strictly before
+// the provided meta timestamp.
+func (h keyHistory) before(metaTimestamp int) keyHistory {
+	i, _ := slices.BinarySearchFunc(h, metaTimestamp, func(a keyHistoryItem, ts int) int {
+		return cmp.Compare(a.metaTimestamp, ts)
+	})
+	return h[:i]
+}
+
+// canSingleDelete examines the tail of the history and returns true if a single
+// delete appended to this history would satisfy the single delete invariants.
+func (h keyHistory) canSingleDelete() bool {
+	if len(h) == 0 {
+		return true
+	}
+	switch o := h[len(h)-1].opType; o {
+	case writerDelete, writerDeleteRange, writerSingleDelete:
+		return true
+	case writerSet, writerMerge:
+		if len(h) == 1 {
+			return true
+		}
+		return h[len(h)-2].opType.isDelete()
+	default:
+		panic(errors.AssertionFailedf("unexpected writer op %v", o))
+	}
+}
+
+func (h keyHistory) String() string {
+	var sb strings.Builder
+	for i, it := range h {
+		if i > 0 {
+			fmt.Fprint(&sb, ", ")
+		}
+		switch it.opType {
+		case writerDelete:
+			fmt.Fprint(&sb, "del")
+		case writerDeleteRange:
+			fmt.Fprint(&sb, "delrange")
+		case writerSingleDelete:
+			fmt.Fprint(&sb, "singledel")
+		case writerSet:
+			fmt.Fprint(&sb, "set")
+		case writerMerge:
+			fmt.Fprint(&sb, "merge")
+		default:
+			fmt.Fprintf(&sb, "optype[v=%d]", it.opType)
+		}
+		fmt.Fprintf(&sb, "(%d)", it.metaTimestamp)
+	}
+	return sb.String()
+}
+
+// hasVisibleKey examines the tail of the history and returns true if the
+// history should end in a visible value for this key.
+func (h keyHistory) hasVisibleValue() bool {
+	if len(h) == 0 {
+		return false
+	}
+	return !h[len(h)-1].opType.isDelete()
+}
+
+// collapsed returns a new key history that's equivalent to the history created
+// by an ingestOp that "collapses" a batch's keys. See ingestOp.build.
+func (h keyHistory) collapsed() keyHistory {
+	var ret keyHistory
+	// When collapsing a batch, any range deletes are semantically applied
+	// first. Look for any range deletes and apply them.
+	for _, op := range h {
+		if op.opType == writerDeleteRange {
+			ret = append(ret, op)
+			break
+		}
+	}
+	// Among point keys, the most recently written key wins.
+	for i := len(h) - 1; i >= 0; i-- {
+		if h[i].opType != writerDeleteRange {
+			ret = append(ret, h[i])
+			break
+		}
+	}
+	return ret
 }
 
 func opWrittenKeys(untypedOp op) [][]byte {

--- a/metamorphic/key_manager_test.go
+++ b/metamorphic/key_manager_test.go
@@ -34,149 +34,6 @@ func TestObjKey(t *testing.T) {
 	}
 }
 
-func TestGlobalStateIndicatesEligibleForSingleDelete(t *testing.T) {
-	key := makeObjKey(makeObjID(dbTag, 1), []byte("foo"))
-	testCases := []struct {
-		meta keyMeta
-		want bool
-	}{
-		{
-			meta: keyMeta{
-				objKey: key,
-			},
-			want: false,
-		},
-		{
-			meta: keyMeta{
-				objKey: key,
-				sets:   1,
-			},
-			want: true,
-		},
-		{
-			meta: keyMeta{
-				objKey: key,
-				sets:   2,
-			},
-			want: false,
-		},
-		{
-			meta: keyMeta{
-				objKey: key,
-				sets:   1,
-				merges: 1,
-			},
-			want: false,
-		},
-		{
-			meta: keyMeta{
-				objKey: key,
-				sets:   1,
-				dels:   1,
-			},
-			want: false,
-		},
-		{
-			meta: keyMeta{
-				objKey:    key,
-				sets:      1,
-				singleDel: true,
-			},
-			want: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		k := newKeyManager(1)
-		t.Run("", func(t *testing.T) {
-			k.globalKeysMap[string(key.key)] = &tc.meta
-			require.Equal(t, tc.want, k.globalStateIndicatesEligibleForSingleDelete(key.key))
-		})
-	}
-}
-
-func TestKeyMeta_MergeInto(t *testing.T) {
-	testCases := []struct {
-		existing keyMeta
-		toMerge  keyMeta
-		expected keyMeta
-	}{
-		{
-			existing: keyMeta{
-				sets:      1,
-				merges:    0,
-				singleDel: false,
-			},
-			toMerge: keyMeta{
-				sets:      0,
-				merges:    0,
-				singleDel: true,
-			},
-			expected: keyMeta{
-				sets:      1,
-				merges:    0,
-				singleDel: true,
-				updateOps: []keyUpdate{
-					{deleted: true, metaTimestamp: 0},
-				},
-			},
-		},
-		{
-			existing: keyMeta{
-				sets:   3,
-				merges: 1,
-				dels:   7,
-			},
-			toMerge: keyMeta{
-				sets:   4,
-				merges: 2,
-				dels:   8,
-				del:    true,
-			},
-			expected: keyMeta{
-				sets:   7,
-				merges: 3,
-				dels:   15,
-				del:    true,
-				updateOps: []keyUpdate{
-					{deleted: true, metaTimestamp: 1},
-				},
-			},
-		},
-		{
-			existing: keyMeta{
-				sets:   3,
-				merges: 1,
-				dels:   7,
-				del:    true,
-			},
-			toMerge: keyMeta{
-				sets:   1,
-				merges: 0,
-				dels:   8,
-				del:    false,
-			},
-			expected: keyMeta{
-				sets:   4,
-				merges: 1,
-				dels:   15,
-				del:    false,
-				updateOps: []keyUpdate{
-					{deleted: false, metaTimestamp: 2},
-				},
-			},
-		},
-	}
-
-	keyManager := newKeyManager(1 /* numInstances */)
-	for _, tc := range testCases {
-		t.Run("", func(t *testing.T) {
-			tc.toMerge.mergeInto(keyManager, &tc.existing)
-			require.Equal(t, tc.expected, tc.existing)
-		})
-	}
-}
-
 func TestKeyManager_AddKey(t *testing.T) {
 	m := newKeyManager(1 /* numInstances */)
 	require.Empty(t, m.globalKeys)
@@ -236,55 +93,6 @@ func TestKeyManager_GetOrInit(t *testing.T) {
 	require.Equal(t, meta1, meta2)
 }
 
-func TestKeyManager_Contains(t *testing.T) {
-	id := makeObjID(dbTag, 1)
-	key := []byte("foo")
-
-	m := newKeyManager(1 /* numInstances */)
-	require.False(t, m.contains(id, key))
-
-	m.getOrInit(id, key)
-	require.True(t, m.contains(id, key))
-}
-
-func TestKeyManager_MergeInto(t *testing.T) {
-	fromID := makeObjID(batchTag, 1)
-	toID := makeObjID(dbTag, 1)
-
-	m := newKeyManager(1 /* numInstances */)
-
-	// Two keys in "from".
-	a := m.getOrInit(fromID, []byte("foo"))
-	a.sets = 1
-	b := m.getOrInit(fromID, []byte("bar"))
-	b.merges = 2
-
-	// One key in "to", with same value as a key in "from", that will be merged.
-	m.getOrInit(toID, []byte("foo"))
-
-	// Before, there are two sets.
-	require.Len(t, m.byObj[fromID], 2)
-	require.Len(t, m.byObj[toID], 1)
-
-	m.mergeKeysInto(fromID, toID)
-
-	// Keys in "from" sets are moved to "to" set.
-	require.Len(t, m.byObj[toID], 2)
-
-	// Key "foo" was merged into "to".
-	foo := m.getOrInit(toID, []byte("foo"))
-	require.Equal(t, 1, foo.sets) // value was merged.
-
-	// Key "bar" was merged into "to".
-	bar := m.getOrInit(toID, []byte("bar"))
-	require.Equal(t, 2, bar.merges) // value was unchanged.
-
-	// Keys in "from" sets are removed from maps.
-	require.NotContains(t, m.byObjKey, makeObjKey(fromID, a.key))
-	require.NotContains(t, m.byObjKey, makeObjKey(fromID, b.key))
-	require.NotContains(t, m.byObj, fromID)
-}
-
 func mustParseObjID(s string) objID {
 	id, err := parseObjID(s)
 	if err != nil {
@@ -327,22 +135,33 @@ func TestKeyManager(t *testing.T) {
 						fmt.Fprintf(&buf, "%q already tracked\n", fields[1])
 					}
 				case "keys":
-				case "read-keys":
-					fmt.Fprintf(&buf, "read keys: ")
-					printKeys(&buf, km.eligibleReadKeys())
-				case "write-keys":
-					fmt.Fprintf(&buf, "write keys: ")
-					printKeys(&buf, km.eligibleWriteKeys())
+					fmt.Fprintf(&buf, "keys: ")
+					printKeys(&buf, km.globalKeys)
 				case "singledel-keys":
-					fmt.Fprintf(&buf, "singledel keys: ")
-					printKeys(&buf, km.eligibleSingleDeleteKeys(
-						mustParseObjID(fields[1]), mustParseObjID(fields[2])))
+					objID := mustParseObjID(fields[1])
+					fmt.Fprintf(&buf, "can singledel on %s: ", objID)
+					printKeys(&buf, km.eligibleSingleDeleteKeys(objID))
+				case "conflicts":
+					var collapsed bool
+					args := fields[1:]
+					if args[0] == "collapsed" {
+						collapsed = true
+						args = args[1:]
+					}
+					src := mustParseObjID(args[0])
+					dst := mustParseObjID(args[1])
+					fmt.Fprintf(&buf, "conflicts merging %s", src)
+					if collapsed {
+						fmt.Fprint(&buf, " (collapsed)")
+					}
+					fmt.Fprintf(&buf, " into %s: ", dst)
+					printKeys(&buf, km.checkForSingleDelConflicts(src, dst, collapsed))
 				case "op":
 					ops, err := parse([]byte(strings.TrimPrefix(line, "op")), parserOpts{
 						allowUndefinedObjs: true,
 					})
 					if err != nil {
-						t.Fatal(err)
+						t.Fatalf("parsing line %q: %s", line, err)
 					} else if len(ops) != 1 {
 						t.Fatalf("expected 1 op but found %d", len(ops))
 					}

--- a/metamorphic/testdata/key_manager
+++ b/metamorphic/testdata/key_manager
@@ -1,9 +1,8 @@
 # run subcommands
 #
 # add-new-key <key>
-# read-keys
-# write-keys
-# singledel-keys <writerID> <dbID>
+# keys
+# singledel-keys <writerID>
 # op <operation string as printed to ops files>
 
 run
@@ -16,69 +15,56 @@ add-new-key foo
 # Test SET; SINGLEDEL on DB.
 
 run
-read-keys
-write-keys
-singledel-keys db1 db1
-singledel-keys batch1 db1
+keys
+singledel-keys db1
+singledel-keys batch1
 op db1.Set("foo", "foo")
-read-keys
-write-keys
-singledel-keys db1 db1
-singledel-keys batch1 db1
+keys
+singledel-keys db1
+singledel-keys batch1
 op db1.SingleDelete("foo", false)
-read-keys
-write-keys
-singledel-keys db1 db1
+keys
+singledel-keys db1
 ----
-read keys: "foo"
-write keys: "foo"
-singledel keys: (none)
-singledel keys: (none)
+keys: "foo"
+can singledel on db1: "foo"
+can singledel on batch1: "foo"
 [db1.Set("foo", "foo")]
-read keys: "foo"
-write keys: "foo"
-singledel keys: "foo"
-singledel keys: "foo"
+keys: "foo"
+can singledel on db1: "foo"
+can singledel on batch1: "foo"
 [db1.SingleDelete("foo", false /* maybeReplaceDelete */)]
-read keys: "foo"
-write keys: "foo"
-singledel keys: (none)
-
+keys: "foo"
+can singledel on db1: "foo"
 
 # Test SET; SINGLEDEL on batch on separate key.
 
 run
 add-new-key bar
 op batch1.Set("bar", "bar")
-read-keys
-write-keys
-singledel-keys db1 db1
-singledel-keys batch1 db1
-singledel-keys batch2 db1
+keys
+singledel-keys db1
+singledel-keys batch1
+singledel-keys batch2
 op batch1.SingleDelete("bar", false)
-read-keys
-write-keys
-singledel-keys db1 db1
-singledel-keys batch1 db1
+keys
+singledel-keys db1
+singledel-keys batch1
 op db1.Apply(batch1)
-write-keys
-singledel-keys db1 db1
+singledel-keys db1
 ----
 "bar" is new
 [batch1.Set("bar", "bar")]
-read keys: "bar", "foo"
-write keys: "bar", "foo"
-singledel keys: (none)
-singledel keys: "bar"
-singledel keys: (none)
+keys: "bar", "foo"
+can singledel on db1: "bar", "foo"
+can singledel on batch1: "bar", "foo"
+can singledel on batch2: "bar", "foo"
 [batch1.SingleDelete("bar", false /* maybeReplaceDelete */)]
-read keys: "bar", "foo"
-write keys: "foo"
-singledel keys: (none)
-singledel keys: (none)
+keys: "bar", "foo"
+can singledel on db1: "bar", "foo"
+can singledel on batch1: "bar", "foo"
 [db1.Apply(batch1)]
-write keys: "bar", "foo"
-singledel keys: (none)
+can singledel on db1: "bar", "foo"
 
 # Test SET on db; SINGLEDEL on batch.
 
@@ -88,35 +74,29 @@ reset
 run
 add-new-key foo
 op db1.Set("foo", "foo")
-write-keys
-singledel-keys db1 db1
-singledel-keys batch1 db1
+singledel-keys db1
+singledel-keys batch1
 op batch1.SingleDelete("foo", false)
-write-keys
-singledel-keys db1 db1
-singledel-keys batch1 db1
+singledel-keys db1
+singledel-keys batch1
 op db1.Apply(batch1)
-write-keys
-singledel-keys db1 db1
+singledel-keys db1
 op db1.Set("foo", "foo")
-singledel-keys db1 db1
-singledel-keys batch1 db1
+singledel-keys db1
+singledel-keys batch1
 ----
 "foo" is new
 [db1.Set("foo", "foo")]
-write keys: "foo"
-singledel keys: "foo"
-singledel keys: "foo"
+can singledel on db1: "foo"
+can singledel on batch1: "foo"
 [batch1.SingleDelete("foo", false /* maybeReplaceDelete */)]
-write keys: (none)
-singledel keys: (none)
-singledel keys: (none)
+can singledel on db1: "foo"
+can singledel on batch1: "foo"
 [db1.Apply(batch1)]
-write keys: "foo"
-singledel keys: (none)
+can singledel on db1: "foo"
 [db1.Set("foo", "foo")]
-singledel keys: "foo"
-singledel keys: "foo"
+can singledel on db1: "foo"
+can singledel on batch1: "foo"
 
 # Test SET; DEL; SET; SingleDelete on db.
 
@@ -127,26 +107,20 @@ run
 add-new-key foo
 op db1.Set("foo", "foo")
 op db1.Delete("foo")
-write-keys
-singledel-keys db1 db1
+singledel-keys db1
 op db1.Set("foo", "foo")
-write-keys
-singledel-keys db1 db1
+singledel-keys db1
 op db1.SingleDelete("foo", false)
-write-keys
-singledel-keys db1 db1
+singledel-keys db1
 ----
 "foo" is new
 [db1.Set("foo", "foo")]
 [db1.Delete("foo")]
-write keys: "foo"
-singledel keys: (none)
+can singledel on db1: "foo"
 [db1.Set("foo", "foo")]
-write keys: "foo"
-singledel keys: "foo"
+can singledel on db1: "foo"
 [db1.SingleDelete("foo", false /* maybeReplaceDelete */)]
-write keys: "foo"
-singledel keys: (none)
+can singledel on db1: "foo"
 
 # Test SET; DEL; SET; DEL on batches.
 
@@ -158,52 +132,58 @@ add-new-key foo
 op batch1.Set("foo", "foo")
 op batch1.Delete("foo")
 op batch1.Set("foo", "foo")
-write-keys
-singledel-keys batch1 db1
+singledel-keys batch1
 op db1.Apply(batch1)
-write-keys
 ----
 "foo" is new
 [batch1.Set("foo", "foo")]
 [batch1.Delete("foo")]
 [batch1.Set("foo", "foo")]
-write keys: "foo"
-singledel keys: (none)
+can singledel on batch1: "foo"
 [db1.Apply(batch1)]
-write keys: "foo"
 
-# "foo" should not be eliible for single delete because set count is 2.
+# "foo" should be eligible for single delete on db1 because a Delete separates
+# the two sets.
 
 run
-singledel-keys db1 db1
+singledel-keys db1
 ----
-singledel keys: (none)
+can singledel on db1: "foo"
+
+# A batch that contains its own Set and SingleDelete should conflict, because
+# the two Sets would stack.
+
+run
+op batch2.Set("foo", "foo")
+op batch2.SingleDelete("foo", false)
+conflicts batch2 db1
+----
+[batch2.Set("foo", "foo")]
+[batch2.SingleDelete("foo", false /* maybeReplaceDelete */)]
+conflicts merging batch2 into db1: "foo"
+
+# Setting "foo" again on the DB should result in the key no longer be eligible
+# for single delete because there are two stacked SETs on db1.s
 
 run
 op db1.Set("foo", "foo")
+singledel-keys db1
 ----
 [db1.Set("foo", "foo")]
-
-# "foo" should still not be eliible for single delete because set count is 3.
-
-run
-singledel-keys db1 db1
-----
-singledel keys: (none)
-
+can singledel on db1: (none)
 
 run
 op batch2.Delete("foo")
 op db1.Apply(batch2)
-singledel-keys db1 db1
+singledel-keys db1
 op db1.Set("foo", "foo")
-singledel-keys db1 db1
+singledel-keys db1
 ----
 [batch2.Delete("foo")]
 [db1.Apply(batch2)]
-singledel keys: (none)
+can singledel on db1: "foo"
 [db1.Set("foo", "foo")]
-singledel keys: "foo"
+can singledel on db1: "foo"
 
 # Test SET; MERGE; DEL; SINGLEDEL on DB.
 
@@ -213,33 +193,27 @@ reset
 run
 add-new-key foo
 op db.Set("foo", "foo")
-singledel-keys db1 db1
+singledel-keys db1
 op db1.Merge("foo", "foo")
-singledel-keys db1 db1
+singledel-keys db1
 op db1.Delete("foo")
-write-keys
-singledel-keys db1 db1
+singledel-keys db1
 op db1.Set("foo", "foo")
-write-keys
-singledel-keys db1 db1
+singledel-keys db1
 op db1.SingleDelete("foo", false)
-write-keys
-singledel-keys db1 db1
+singledel-keys db1
 ----
 "foo" is new
 [db1.Set("foo", "foo")]
-singledel keys: "foo"
+can singledel on db1: "foo"
 [db1.Merge("foo", "foo")]
-singledel keys: (none)
+can singledel on db1: (none)
 [db1.Delete("foo")]
-write keys: "foo"
-singledel keys: (none)
+can singledel on db1: "foo"
 [db1.Set("foo", "foo")]
-write keys: "foo"
-singledel keys: "foo"
+can singledel on db1: "foo"
 [db1.SingleDelete("foo", false /* maybeReplaceDelete */)]
-write keys: "foo"
-singledel keys: (none)
+can singledel on db1: "foo"
 
 # Test SET; DEL (db); SET; SINGLEDEL (batch)
 
@@ -249,40 +223,215 @@ reset
 run
 add-new-key foo
 op db1.Set("foo", "foo")
-singledel-keys db1 db1
+singledel-keys db1
 op db1.Delete("foo")
-write-keys
-singledel-keys db1 db1
+singledel-keys db1
 op db1.Set("foo", "foo")
-write-keys
-singledel-keys db1 db1
-singledel-keys batch1 db1
+singledel-keys db1
+singledel-keys batch1
 op batch1.SingleDelete("foo", false)
-write-keys
-singledel-keys db1 db1
-singledel-keys batch1 db1
+singledel-keys db1
+singledel-keys batch1
 op db1.Apply(batch1)
-write-keys
-singledel-keys db1 db1
+singledel-keys db1
 op db1.Set("foo", "foo")
-singledel-keys db1 db1
+singledel-keys db1
 ----
 "foo" is new
 [db1.Set("foo", "foo")]
-singledel keys: "foo"
+can singledel on db1: "foo"
 [db1.Delete("foo")]
-write keys: "foo"
-singledel keys: (none)
+can singledel on db1: "foo"
 [db1.Set("foo", "foo")]
-write keys: "foo"
-singledel keys: "foo"
-singledel keys: "foo"
+can singledel on db1: "foo"
+can singledel on batch1: "foo"
 [batch1.SingleDelete("foo", false /* maybeReplaceDelete */)]
-write keys: (none)
-singledel keys: (none)
-singledel keys: (none)
+can singledel on db1: "foo"
+can singledel on batch1: "foo"
 [db1.Apply(batch1)]
-write keys: "foo"
-singledel keys: (none)
+can singledel on db1: "foo"
 [db1.Set("foo", "foo")]
-singledel keys: "foo"
+can singledel on db1: "foo"
+
+# A delete range should "reset" keys, even if the delete range is applied to a
+# batch that doesn't yet contain the relevant key.
+
+reset
+----
+
+run
+add-new-key foo
+add-new-key bar
+op db1.Set("foo", "foo")
+op db1.Set("foo", "foo")
+singledel-keys db1
+op batch1.DeleteRange("a", "z")
+conflicts collapsed batch1 db1
+op db1.Apply(batch1)
+singledel-keys db1
+----
+"foo" is new
+"bar" is new
+[db1.Set("foo", "foo")]
+[db1.Set("foo", "foo")]
+can singledel on db1: "bar"
+[batch1.DeleteRange("a", "z")]
+conflicts merging batch1 (collapsed) into db1: (none)
+[db1.Apply(batch1)]
+can singledel on db1: "bar", "foo"
+
+# Ingestion flattens keys, with any range dels contained within the batch
+# semantically applying beneath the most recent point. In this case, foo should
+# remain eligible immediately after ingestion because the DeleteRange shadows
+# the original Set on db1. It should not be eligible after the final Set,
+# because the ingested set and the final set stack, both on top of the delete
+# range.
+
+reset
+----
+
+run
+add-new-key foo
+add-new-key bar
+op db1.Set("foo", "foo")
+singledel-keys db1
+op batch1.Set("foo", "foo")
+op batch1.DeleteRange("a", "z")
+conflicts collapsed batch1 db1
+op db1.Ingest(batch1)
+singledel-keys db1
+op db1.Set("foo", "foo")
+singledel-keys db1
+----
+"foo" is new
+"bar" is new
+[db1.Set("foo", "foo")]
+can singledel on db1: "bar", "foo"
+[batch1.Set("foo", "foo")]
+[batch1.DeleteRange("a", "z")]
+conflicts merging batch1 (collapsed) into db1: (none)
+[db1.Ingest(batch1)]
+can singledel on db1: "bar", "foo"
+[db1.Set("foo", "foo")]
+can singledel on db1: "bar"
+
+# Since ingestion flattens keys, foo should be single-deletable on the db after
+# ingest, even though it couldn't be single deleted from the batch before
+# ingestion.
+
+reset
+----
+
+run
+add-new-key foo
+op batch1.Set("foo", "foo")
+op batch1.Set("foo", "foo")
+conflicts collapsed batch1 db1
+singledel-keys batch1
+op db1.Ingest(batch1)
+singledel-keys db1
+----
+"foo" is new
+[batch1.Set("foo", "foo")]
+[batch1.Set("foo", "foo")]
+conflicts merging batch1 (collapsed) into db1: (none)
+can singledel on batch1: (none)
+[db1.Ingest(batch1)]
+can singledel on db1: "foo"
+
+
+# Because ingestion flattens keys, foo remains eligible for single delete the
+# entire test case. During flattening, the Delete wins over the Set.
+
+reset
+----
+
+run
+add-new-key foo
+op batch1.Set("foo", "foo")
+op batch1.Delete("foo")
+singledel-keys batch1
+op db1.Ingest(batch1)
+singledel-keys db1
+op db1.Set("foo", "foo")
+singledel-keys db1
+----
+"foo" is new
+[batch1.Set("foo", "foo")]
+[batch1.Delete("foo")]
+can singledel on batch1: "foo"
+[db1.Ingest(batch1)]
+can singledel on db1: "foo"
+[db1.Set("foo", "foo")]
+can singledel on db1: "foo"
+
+# Ingestion flattening means that the batch1.Set sits semantically on top of the
+# delete range despite being inserted to the batch before the delete range.
+
+reset
+----
+
+run
+add-new-key foo
+op batch1.Set("foo", "foo")
+op batch1.DeleteRange("a", "z")
+op db1.Ingest(batch1)
+op db1.Set("foo", "foo")
+singledel-keys db1
+----
+"foo" is new
+[batch1.Set("foo", "foo")]
+[batch1.DeleteRange("a", "z")]
+[db1.Ingest(batch1)]
+[db1.Set("foo", "foo")]
+can singledel on db1: (none)
+
+# In this scenario batch1 would conflict with db1 if it were applied as a batch
+# commit, but when ingested and "collapsed" it does not conflict.
+
+reset
+----
+
+run
+add-new-key foo
+op db1.Set("foo", "foo")
+op batch1.Set("foo", "foo")
+op batch1.SingleDelete("foo", false)
+conflicts batch1 db1
+conflicts collapsed batch1 db1
+op db1.Ingest(batch1)
+----
+"foo" is new
+[db1.Set("foo", "foo")]
+[batch1.Set("foo", "foo")]
+[batch1.SingleDelete("foo", false /* maybeReplaceDelete */)]
+conflicts merging batch1 into db1: "foo"
+conflicts merging batch1 (collapsed) into db1: (none)
+[db1.Ingest(batch1)]
+
+# Allow a MERGE to be deleted by a single delete, as long as it's the only
+# value-carrying key.
+
+reset
+----
+
+run
+add-new-key foo
+op db1.Merge("foo", "foo")
+singledel-keys db1
+op batch1.Merge("foo", "foo")
+op batch1.SingleDelete("foo", true)
+conflicts batch1 db1
+conflicts collapsed batch1 db1
+op db1.Merge("foo", "foo")
+singledel-keys db1
+----
+"foo" is new
+[db1.Merge("foo", "foo")]
+can singledel on db1: "foo"
+[batch1.Merge("foo", "foo")]
+[batch1.SingleDelete("foo", true /* maybeReplaceDelete */)]
+conflicts merging batch1 into db1: "foo"
+conflicts merging batch1 (collapsed) into db1: (none)
+[db1.Merge("foo", "foo")]
+can singledel on db1: (none)


### PR DESCRIPTION
This commit refactors the key tracking performed across objects and
decision-making around when to perform single deletes. Previously, the
metamorphic test tracked inflight writes to batches and restricted operations
to keys with inflight deletes (both SINGLEDEL and DEL). This commit takes an
alternative approach of tracking entire key histories per object and only
restricting per-object single deletes. This tracking alone is sufficient to
maintain single delete invariants for operations only performed directly
against the DB object.

Operations performed to batches and then committed to the database require
additional care. Rather than attempting to prevent violations from ever being
generated, this commit adapts the generator to detect violations and correct
them. When an applying or ingesting batch containing a single delete would
cause a violation of the single delete invariants, the generator generates
delete operations on the destination to avoid the violation. This allows single
deletes to be generated in a wider variety of circumstances and plays well with
the new multi-DB variants of the metamorphic test.