### PR TITLE
crl-release-23.2: minor fix to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ versions for CockroachDB releases.
 | 22.2                | FormatMostCompatible               | FormatPrePebblev1Marked   |
 | 23.1                | FormatSplitUserKeysMarkedCompacted | FormatFlushableIngest     |
 | 23.2                | FormatSplitUserKeysMarkedCompacted | FormatVirtualSSTables     |
-| 24.1 plan           | FormatSSTableValueBlocks           |                           |
 
 ## Pedigree
 


### PR DESCRIPTION
The version for 24.1 is incorrect. Removing the entire row given that it's a future release.