### PR TITLE
metamorphic: generate IngestAndExcise op on prefix keys

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/batchskl"
 	"github.com/cockroachdb/pebble/internal/humanize"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/private"
 	"github.com/cockroachdb/pebble/internal/rangedel"
@@ -931,6 +932,15 @@ func (b *Batch) DeleteRangeDeferred(startLen, endLen int) *DeferredBatchOp {
 //
 // It is safe to modify the contents of the arguments after RangeKeySet returns.
 func (b *Batch) RangeKeySet(start, end, suffix, value []byte, _ *WriteOptions) error {
+	if invariants.Enabled && b.db != nil && b.db.opts.Comparer.Split != nil {
+		// RangeKeySet is only supported on prefix keys.
+		if b.db.opts.Comparer.Split(start) != len(start) {
+			panic("RangeKeySet called with suffixed start key")
+		}
+		if b.db.opts.Comparer.Split(end) != len(end) {
+			panic("RangeKeySet called with suffixed end key")
+		}
+	}
 	suffixValues := [1]rangekey.SuffixValue{{Suffix: suffix, Value: value}}
 	internalValueLen := rangekey.EncodedSetValueLen(end, suffixValues[:])
 
@@ -981,6 +991,15 @@ func (b *Batch) incrementRangeKeysCount() {
 // It is safe to modify the contents of the arguments after RangeKeyUnset
 // returns.
 func (b *Batch) RangeKeyUnset(start, end, suffix []byte, _ *WriteOptions) error {
+	if invariants.Enabled && b.db != nil && b.db.opts.Comparer.Split != nil {
+		// RangeKeyUnset is only supported on prefix keys.
+		if b.db.opts.Comparer.Split(start) != len(start) {
+			panic("RangeKeyUnset called with suffixed start key")
+		}
+		if b.db.opts.Comparer.Split(end) != len(end) {
+			panic("RangeKeyUnset called with suffixed end key")
+		}
+	}
 	suffixes := [1][]byte{suffix}
 	internalValueLen := rangekey.EncodedUnsetValueLen(end, suffixes[:])
 
@@ -1014,6 +1033,15 @@ func (b *Batch) rangeKeyUnsetDeferred(startLen, internalValueLen int) *DeferredB
 // It is safe to modify the contents of the arguments after RangeKeyDelete
 // returns.
 func (b *Batch) RangeKeyDelete(start, end []byte, _ *WriteOptions) error {
+	if invariants.Enabled && b.db != nil && b.db.opts.Comparer.Split != nil {
+		// RangeKeyDelete is only supported on prefix keys.
+		if b.db.opts.Comparer.Split(start) != len(start) {
+			panic("RangeKeyDelete called with suffixed start key")
+		}
+		if b.db.opts.Comparer.Split(end) != len(end) {
+			panic("RangeKeyDelete called with suffixed end key")
+		}
+	}
 	deferredOp := b.RangeKeyDeleteDeferred(len(start), len(end))
 	copy(deferredOp.Key, start)
 	copy(deferredOp.Value, end)

--- a/data_test.go
+++ b/data_test.go
@@ -578,7 +578,7 @@ func runBuildRemoteCmd(td *datadriven.TestData, d *DB, storage remote.Storage) e
 }
 
 func runBuildCmd(td *datadriven.TestData, d *DB, fs vfs.FS) error {
-	b := d.NewIndexedBatch()
+	b := newIndexedBatch(nil, d.opts.Comparer)
 	if err := runBatchDefineCmd(td, b); err != nil {
 		return err
 	}

--- a/db.go
+++ b/db.go
@@ -839,7 +839,6 @@ func (d *DB) applyInternal(batch *Batch, opts *WriteOptions, noSyncWait bool) er
 		if d.split == nil {
 			return errNoSplit
 		}
-		// TODO(jackson): Assert that all range key operands are suffixless.
 	}
 	batch.committing = true
 

--- a/ingest.go
+++ b/ingest.go
@@ -1160,6 +1160,15 @@ func (d *DB) IngestAndExcise(
 	if d.opts.ReadOnly {
 		return IngestOperationStats{}, ErrReadOnly
 	}
+	if invariants.Enabled && d.opts.Comparer.Split != nil {
+		// Excise is only supported on prefix keys.
+		if d.opts.Comparer.Split(exciseSpan.Start) != len(exciseSpan.Start) {
+			panic("IngestAndExcise called with suffixed start key")
+		}
+		if d.opts.Comparer.Split(exciseSpan.End) != len(exciseSpan.End) {
+			panic("IngestAndExcise called with suffixed end key")
+		}
+	}
 	return d.ingest(paths, ingestTargetLevel, shared, exciseSpan, nil /* external */)
 }
 

--- a/metamorphic/generator.go
+++ b/metamorphic/generator.go
@@ -1172,15 +1172,7 @@ func (g *generator) replicate() {
 		dest = g.dbs.rand(g.rng)
 	}
 
-	var startKey, endKey []byte
-	startKey = g.randKeyToRead(0.001) // 0.1% new keys
-	endKey = g.randKeyToRead(0.001)   // 0.1% new keys
-	for g.equal(startKey, endKey) {
-		endKey = g.randKeyToRead(0.01) // 1% new keys
-	}
-	if g.cmp(startKey, endKey) > 0 {
-		startKey, endKey = endKey, startKey
-	}
+	startKey, endKey := g.prefixKeyRange()
 	g.add(&replicateOp{
 		source: source,
 		dest:   dest,
@@ -1451,14 +1443,7 @@ func (g *generator) writerIngestAndExcise() {
 	batchID := g.liveBatches.rand(g.rng)
 	g.removeBatchFromGenerator(batchID)
 
-	start := g.randKeyToWrite(0.001)
-	end := g.randKeyToWrite(0.001)
-	for g.equal(start, end) {
-		end = g.randKeyToWrite(0.001)
-	}
-	if g.cmp(start, end) > 0 {
-		start, end = end, start
-	}
+	start, end := g.prefixKeyRange()
 	derivedDBID := g.objDB[batchID]
 
 	g.add(&ingestAndExciseOp{

--- a/metamorphic/key_manager.go
+++ b/metamorphic/key_manager.go
@@ -406,13 +406,7 @@ func (k *keyManager) update(o op) {
 			k.mergeKeysInto(batchID, s.dbID)
 		}
 		k.checkForDelOrSingleDelTransitionInDB(s.dbID)
-	case *ingestAndExciseOp:
-		// Merge all keys in the batch with the keys in the DB.
-		k.mergeKeysInto(s.batchID, s.dbID)
-		k.checkForDelOrSingleDelTransitionInDB(s.dbID)
-	case *replicateOp:
-		k.mergeKeysInto(s.source, s.dest)
-		k.checkForDelOrSingleDelTransitionInDB(s.dest)
+	// TODO(bilal): Handle replicateOp and ingestAndExciseOp here.
 	case *applyOp:
 		// Merge the keys from this writer into the parent writer.
 		k.mergeKeysInto(s.batchID, s.writerID)

--- a/metamorphic/key_manager.go
+++ b/metamorphic/key_manager.go
@@ -410,6 +410,9 @@ func (k *keyManager) update(o op) {
 		// Merge all keys in the batch with the keys in the DB.
 		k.mergeKeysInto(s.batchID, s.dbID)
 		k.checkForDelOrSingleDelTransitionInDB(s.dbID)
+	case *replicateOp:
+		k.mergeKeysInto(s.source, s.dest)
+		k.checkForDelOrSingleDelTransitionInDB(s.dest)
 	case *applyOp:
 		// Merge the keys from this writer into the parent writer.
 		k.mergeKeysInto(s.batchID, s.writerID)
@@ -522,7 +525,6 @@ func opWrittenKeys(untypedOp op) [][]byte {
 	case *getOp:
 	case *ingestOp:
 	case *ingestAndExciseOp:
-		return [][]byte{t.exciseStart, t.exciseEnd}
 	case *initOp:
 	case *iterFirstOp:
 	case *iterLastOp:
@@ -550,7 +552,6 @@ func opWrittenKeys(untypedOp op) [][]byte {
 	case *singleDeleteOp:
 		return [][]byte{t.key}
 	case *replicateOp:
-		return [][]byte{t.start, t.end}
 	}
 	return nil
 }

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -821,7 +821,7 @@ func (o *ingestAndExciseOp) run(t *test, h historyRecorder) {
 	err = firstError(err, err2)
 	err = firstError(err, b.Close())
 
-	if writerMeta.Properties.NumEntries == 0 {
+	if writerMeta.Properties.NumEntries == 0 && writerMeta.Properties.NumRangeKeys() == 0 {
 		// No-op.
 		h.Recordf("%s // %v", o, err)
 		return
@@ -1585,7 +1585,7 @@ func (r *replicateOp) runSharedReplicate(
 		h.Recordf("%s // %v", r, err)
 		return
 	}
-	if len(sharedSSTs) == 0 && meta.Properties.NumEntries == 0 {
+	if len(sharedSSTs) == 0 && meta.Properties.NumEntries == 0 && meta.Properties.NumRangeKeys() == 0 {
 		// IngestAndExcise below will be a no-op. We should do a
 		// DeleteRange+RangeKeyDel to mimic the behaviour of the non-shared-replicate
 		// case.


### PR DESCRIPTION
This change adds an invariant-gated assertion that all range key operations are on suffix-less keys, as having range key operations on suffixed keys can break NextPrefix(). It also updates the metamorphic IngestAndExcise operation to only generate prefixes, as it does a RangeKeyDelete in
the non-excise case.

Fixes #3113.
Fixes #3121.