### PR TITLE
crl-release-23.1: sstable: fix two-level iterator NextPrefix error propagation

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -2256,6 +2256,10 @@ func (i *twoLevelIterator) NextPrefix(succKey []byte) (*InternalKey, base.LazyVa
 	if key, val := i.singleLevelIterator.NextPrefix(succKey); key != nil {
 		return key, val
 	}
+	// key == nil
+	if i.err != nil {
+		return nil, base.LazyValue{}
+	}
 	// Did not find prefix in the existing second-level index block. This is the
 	// slow-path where we seek the iterator.
 	var ikey *InternalKey


### PR DESCRIPTION
23.1 backport of the bug fix contained in #3051.

----

Previously, if reading the index or data block encountered an error while handling a NextPrefix operation on a sstable with a two-level index, the error was swallowed. This commit fixes the bug, returning to the caller so that the error may be propagated up the iterator stack.

This could benefit from a targeted unit test, but we don't yet have the machinery in place within the sstable package. In the meantime, the randomized test that surfaced the bug reproduces it on near every run.

Fix #3052.