### PR TITLE
db: fix regression in table cache hot path

### DIFF
--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -1207,6 +1207,48 @@ func TestTableCacheNoSuchFileError(t *testing.T) {
 	require.Contains(t, logger.fatalMsgs[0], "directory contains 6 files, 0 unknown, 0 tables, 2 logs, 1 manifests")
 }
 
+func BenchmarkTableCacheHotPath(b *testing.B) {
+	mem := vfs.NewMem()
+	objProvider, err := objstorageprovider.Open(objstorageprovider.DefaultSettings(mem, ""))
+	require.NoError(b, err)
+	defer objProvider.Close()
+
+	makeTable := func(dfn base.DiskFileNum) {
+		require.NoError(b, err)
+		f, _, err := objProvider.Create(context.Background(), fileTypeTable, dfn, objstorage.CreateOptions{})
+		require.NoError(b, err)
+		w := sstable.NewWriter(f, sstable.WriterOptions{})
+		require.NoError(b, w.Set([]byte("a"), nil))
+		require.NoError(b, w.Close())
+	}
+
+	opts := &Options{
+		Cache: NewCache(8 << 20), // 8 MB
+	}
+	opts.EnsureDefaults()
+	defer opts.Cache.Unref()
+
+	cache := &tableCacheShard{}
+	cache.init(2)
+	dbOpts := &tableCacheOpts{}
+	dbOpts.loggerAndTracer = &base.LoggerWithNoopTracer{Logger: opts.Logger}
+	dbOpts.cacheID = 0
+	dbOpts.objProvider = objProvider
+	dbOpts.opts = opts.MakeReaderOptions()
+
+	makeTable(1)
+
+	m := &fileMetadata{FileNum: 1}
+	m.InitPhysicalBacking()
+	m.Ref()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v := cache.findNode(m, dbOpts)
+		cache.unrefValue(v)
+	}
+}
+
 type catchFatalLogger struct {
 	fatalMsgs []string
 }


### PR DESCRIPTION
#### db: add benchmark for table cache hit path

Add a benchmark for the hot path of `findNode` (when we hit the
cache).

#### db: fix regression in table cache hot path

A seemingly innocuous change in `tableCacheShard.findNode` resulted in
a new allocation. We named the return variable, then we captured it in
the `closeHook` callback, which I guess means that the pointer itself
needs to be put on the heap.

With this change `BenchmarkTableCacheHotPath` goes down from 1
alloc/op to 0, and the CRDB
`RefreshRange/linear-keys/refresh_window=[99.00,99.00]` benchmark goes
from 101 allocs/op to 61.

Informs https://github.com/cockroachdb/cockroach/issues/115215