### PR TITLE
db: fix flaky TestLatestRefCounting

### DIFF
--- a/version_set_test.go
+++ b/version_set_test.go
@@ -223,10 +223,6 @@ func TestLatestRefCounting(t *testing.T) {
 	require.False(t, ok)
 	require.Equal(t, 0, int(m2.FileBacking.VirtualizedSize.Load()))
 	checkBackingSize(t, d)
-
-	// Make sure that the backing file is added to the obsolete tables list.
-	require.Equal(t, 1, len(d.mu.versions.obsoleteTables))
-
 }
 
 // TODO(bananabrick): Convert TestLatestRefCounting and this test into a single


### PR DESCRIPTION
This check is racy in both directions:
 - we can check "too early", in that an asynchronous `collectTableStats` might still be holding a reference
 - we can check "too late", in that cleanup of the obsolete table has already happened

Since object cleanup is not the main point of this test, this commit removes this check altogether.

Fixes #3043