### PR TITLE
db: fix flaky test on Windows

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -3187,68 +3187,68 @@ func TestCompactionOutputSplitters(t *testing.T) {
 }
 
 func TestCompactFlushQueuedMemTableAndFlushMetrics(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test is flaky on windows")
-	}
+	t.Run("", func(t *testing.T) {
+		// Verify that manual compaction forces a flush of a queued memtable.
 
-	// Verify that manual compaction forces a flush of a queued memtable.
+		mem := vfs.NewMem()
+		d, err := Open("", testingRandomized(t, &Options{
+			FS: mem,
+		}).WithFSDefaults())
+		require.NoError(t, err)
 
-	mem := vfs.NewMem()
-	d, err := Open("", testingRandomized(t, &Options{
-		FS: mem,
-	}).WithFSDefaults())
-	require.NoError(t, err)
-
-	// Add the key "a" to the memtable, then fill up the memtable with the key
-	// prefix "b". The compaction will only overlap with the queued memtable,
-	// not the mutable memtable.
-	// NB: The initial memtable size is 256KB, which is filled up with random
-	// values which typically don't compress well. The test also appends the
-	// random value to the "b" key to limit overwriting of the same key, which
-	// would get collapsed at flush time since there are no open snapshots.
-	value := make([]byte, 50)
-	_, err = crand.Read(value)
-	require.NoError(t, err)
-	require.NoError(t, d.Set([]byte("a"), value, nil))
-	for {
+		// Add the key "a" to the memtable, then fill up the memtable with the key
+		// prefix "b". The compaction will only overlap with the queued memtable,
+		// not the mutable memtable.
+		// NB: The initial memtable size is 256KB, which is filled up with random
+		// values which typically don't compress well. The test also appends the
+		// random value to the "b" key to limit overwriting of the same key, which
+		// would get collapsed at flush time since there are no open snapshots.
+		value := make([]byte, 50)
 		_, err = crand.Read(value)
 		require.NoError(t, err)
-		require.NoError(t, d.Set(append([]byte("b"), value...), value, nil))
-		d.mu.Lock()
-		done := len(d.mu.mem.queue) == 2
-		d.mu.Unlock()
-		if done {
-			break
-		}
-	}
-
-	require.NoError(t, d.Compact([]byte("a"), []byte("a\x00"), false))
-	d.mu.Lock()
-	require.Equal(t, 1, len(d.mu.mem.queue))
-	d.mu.Unlock()
-	// Flush metrics are updated after and non-atomically with the memtable
-	// being removed from the queue.
-	func() {
-		begin := time.Now()
+		require.NoError(t, d.Set([]byte("a"), value, nil))
 		for {
+			_, err = crand.Read(value)
+			require.NoError(t, err)
+			require.NoError(t, d.Set(append([]byte("b"), value...), value, nil))
+			d.mu.Lock()
+			done := len(d.mu.mem.queue) == 2
+			d.mu.Unlock()
+			if done {
+				break
+			}
+		}
+
+		require.NoError(t, d.Compact([]byte("a"), []byte("a\x00"), false))
+		d.mu.Lock()
+		require.Equal(t, 1, len(d.mu.mem.queue))
+		d.mu.Unlock()
+		// Flush metrics are updated after and non-atomically with the memtable
+		// being removed from the queue.
+		for begin := time.Now(); ; {
 			metrics := d.Metrics()
 			require.NotNil(t, metrics)
-			if int64(50<<10) < metrics.Flush.WriteThroughput.Bytes {
+			if metrics.Flush.WriteThroughput.Bytes >= 50*1024 {
 				// The writes (during which the flush is idle) and the flush work
 				// should not be so fast as to be unrealistic. If these turn out to be
 				// flaky we could instead inject a clock.
-				tinyInterval := int64(50 * time.Microsecond)
-				require.Less(t, tinyInterval, int64(metrics.Flush.WriteThroughput.WorkDuration))
-				require.Less(t, tinyInterval, int64(metrics.Flush.WriteThroughput.IdleDuration))
-				return
+				//
+				// Windows timer precision is bad (on the order of 1 millisecond) and
+				// can cause the duration to be 0.
+				if runtime.GOOS != "windows" {
+					tinyInterval := 50 * time.Microsecond
+					require.Less(t, tinyInterval, metrics.Flush.WriteThroughput.WorkDuration)
+					require.Less(t, tinyInterval, metrics.Flush.WriteThroughput.IdleDuration)
+				}
+				break
 			}
 			if time.Since(begin) > 2*time.Second {
-				t.Fatal()
+				t.Fatal("flush did not happen")
 			}
 			time.Sleep(time.Millisecond)
 		}
-	}()
-	require.NoError(t, d.Close())
+		require.NoError(t, d.Close())
+	})
 }
 
 func TestCompactFlushQueuedLargeBatch(t *testing.T) {


### PR DESCRIPTION
`TestCompactFlushQueuedMemTableAndFlushMetrics` is disabled on Windows, where it is flaky because the test encounters a zero `WorkDuration`.

The timer precision on Windows is pretty bad (I believe 1ms) so it's possible we see a value of 0 when it took less than that.

This commit omits just this check on Windows and reenables the test. I tested this in a draft PR where I made the test run 1000 times.

Fixes #1673