### PR TITLE
metamorphic: revert IngestAndExcise integration

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/batchskl"
 	"github.com/cockroachdb/pebble/internal/humanize"
-	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/private"
 	"github.com/cockroachdb/pebble/internal/rangedel"
@@ -932,15 +931,6 @@ func (b *Batch) DeleteRangeDeferred(startLen, endLen int) *DeferredBatchOp {
 //
 // It is safe to modify the contents of the arguments after RangeKeySet returns.
 func (b *Batch) RangeKeySet(start, end, suffix, value []byte, _ *WriteOptions) error {
-	if invariants.Enabled && b.db != nil && b.db.opts.Comparer.Split != nil {
-		// RangeKeySet is only supported on prefix keys.
-		if b.db.opts.Comparer.Split(start) != len(start) {
-			panic("RangeKeySet called with suffixed start key")
-		}
-		if b.db.opts.Comparer.Split(end) != len(end) {
-			panic("RangeKeySet called with suffixed end key")
-		}
-	}
 	suffixValues := [1]rangekey.SuffixValue{{Suffix: suffix, Value: value}}
 	internalValueLen := rangekey.EncodedSetValueLen(end, suffixValues[:])
 
@@ -991,15 +981,6 @@ func (b *Batch) incrementRangeKeysCount() {
 // It is safe to modify the contents of the arguments after RangeKeyUnset
 // returns.
 func (b *Batch) RangeKeyUnset(start, end, suffix []byte, _ *WriteOptions) error {
-	if invariants.Enabled && b.db != nil && b.db.opts.Comparer.Split != nil {
-		// RangeKeyUnset is only supported on prefix keys.
-		if b.db.opts.Comparer.Split(start) != len(start) {
-			panic("RangeKeyUnset called with suffixed start key")
-		}
-		if b.db.opts.Comparer.Split(end) != len(end) {
-			panic("RangeKeyUnset called with suffixed end key")
-		}
-	}
 	suffixes := [1][]byte{suffix}
 	internalValueLen := rangekey.EncodedUnsetValueLen(end, suffixes[:])
 
@@ -1033,15 +1014,6 @@ func (b *Batch) rangeKeyUnsetDeferred(startLen, internalValueLen int) *DeferredB
 // It is safe to modify the contents of the arguments after RangeKeyDelete
 // returns.
 func (b *Batch) RangeKeyDelete(start, end []byte, _ *WriteOptions) error {
-	if invariants.Enabled && b.db != nil && b.db.opts.Comparer.Split != nil {
-		// RangeKeyDelete is only supported on prefix keys.
-		if b.db.opts.Comparer.Split(start) != len(start) {
-			panic("RangeKeyDelete called with suffixed start key")
-		}
-		if b.db.opts.Comparer.Split(end) != len(end) {
-			panic("RangeKeyDelete called with suffixed end key")
-		}
-	}
 	deferredOp := b.RangeKeyDeleteDeferred(len(start), len(end))
 	copy(deferredOp.Key, start)
 	copy(deferredOp.Value, end)

--- a/data_test.go
+++ b/data_test.go
@@ -578,7 +578,7 @@ func runBuildRemoteCmd(td *datadriven.TestData, d *DB, storage remote.Storage) e
 }
 
 func runBuildCmd(td *datadriven.TestData, d *DB, fs vfs.FS) error {
-	b := newIndexedBatch(nil, d.opts.Comparer)
+	b := d.NewIndexedBatch()
 	if err := runBatchDefineCmd(td, b); err != nil {
 		return err
 	}

--- a/db.go
+++ b/db.go
@@ -1001,12 +1001,9 @@ var iterAllocPool = sync.Pool{
 //     and the specified seqNum will be used as the snapshot seqNum.
 //   - EFOS in file-only state: Only `seqNum` and `vers` are set. All the
 //     relevant SSTs are referenced by the *version.
-//   - EFOS that has been excised but is in alwaysCreateIters mode (tests only).
-//     Only `seqNum` and `readState` are set.
 type snapshotIterOpts struct {
-	seqNum    uint64
-	vers      *version
-	readState *readState
+	seqNum uint64
+	vers   *version
 }
 
 type batchIterOpts struct {
@@ -1060,13 +1057,8 @@ func (d *DB) newIter(
 		// files in the associated version from being deleted if there is a current
 		// compaction. The readState is unref'd by Iterator.Close().
 		if internalOpts.snapshot.vers == nil {
-			if internalOpts.snapshot.readState != nil {
-				readState = internalOpts.snapshot.readState
-				readState.ref()
-			} else {
-				// NB: loadReadState() calls readState.ref().
-				readState = d.loadReadState()
-			}
+			// NB: loadReadState() calls readState.ref().
+			readState = d.loadReadState()
 		} else {
 			// vers != nil
 			internalOpts.snapshot.vers.Ref()
@@ -1297,12 +1289,7 @@ func (d *DB) newInternalIter(
 	// compaction. The readState is unref'd by Iterator.Close().
 	var readState *readState
 	if sOpts.vers == nil {
-		if sOpts.readState != nil {
-			readState = sOpts.readState
-			readState.ref()
-		} else {
-			readState = d.loadReadState()
-		}
+		readState = d.loadReadState()
 	}
 	if sOpts.vers != nil {
 		sOpts.vers.Ref()

--- a/db.go
+++ b/db.go
@@ -839,6 +839,7 @@ func (d *DB) applyInternal(batch *Batch, opts *WriteOptions, noSyncWait bool) er
 		if d.split == nil {
 			return errNoSplit
 		}
+		// TODO(jackson): Assert that all range key operands are suffixless.
 	}
 	batch.committing = true
 

--- a/ingest.go
+++ b/ingest.go
@@ -1160,15 +1160,6 @@ func (d *DB) IngestAndExcise(
 	if d.opts.ReadOnly {
 		return IngestOperationStats{}, ErrReadOnly
 	}
-	if invariants.Enabled && d.opts.Comparer.Split != nil {
-		// Excise is only supported on prefix keys.
-		if d.opts.Comparer.Split(exciseSpan.Start) != len(exciseSpan.Start) {
-			panic("IngestAndExcise called with suffixed start key")
-		}
-		if d.opts.Comparer.Split(exciseSpan.End) != len(exciseSpan.End) {
-			panic("IngestAndExcise called with suffixed end key")
-		}
-	}
 	return d.ingest(paths, ingestTargetLevel, shared, exciseSpan, nil /* external */)
 }
 

--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -76,7 +76,6 @@ func TestMetaTwoInstance(t *testing.T) {
 	case runOnceFlags.Compare != "":
 		runDirs := strings.Split(runOnceFlags.Compare, ",")
 		onceOpts := runOnceFlags.MakeRunOnceOptions()
-		onceOpts = append(onceOpts, metamorphic.MultiInstance(2))
 		metamorphic.Compare(t, runOnceFlags.Dir, runOnceFlags.Seed, runDirs, onceOpts...)
 
 	case runOnceFlags.RunDir != "":
@@ -84,7 +83,6 @@ func TestMetaTwoInstance(t *testing.T) {
 		// runOptions() below) or the user specified it manually in order to re-run
 		// a test.
 		onceOpts := runOnceFlags.MakeRunOnceOptions()
-		onceOpts = append(onceOpts, metamorphic.MultiInstance(2))
 		metamorphic.RunOnce(t, runOnceFlags.RunDir, runOnceFlags.Seed, filepath.Join(runOnceFlags.RunDir, "history"), onceOpts...)
 
 	default:

--- a/metamorphic/config.go
+++ b/metamorphic/config.go
@@ -45,7 +45,6 @@ const (
 	writerDelete
 	writerDeleteRange
 	writerIngest
-	writerIngestAndExcise
 	writerMerge
 	writerRangeKeyDelete
 	writerRangeKeySet
@@ -155,7 +154,6 @@ func defaultConfig() config {
 			writerDelete:                100,
 			writerDeleteRange:           50,
 			writerIngest:                100,
-			writerIngestAndExcise:       50,
 			writerMerge:                 100,
 			writerRangeKeySet:           10,
 			writerRangeKeyUnset:         10,

--- a/metamorphic/generator.go
+++ b/metamorphic/generator.go
@@ -1172,7 +1172,15 @@ func (g *generator) replicate() {
 		dest = g.dbs.rand(g.rng)
 	}
 
-	startKey, endKey := g.prefixKeyRange()
+	var startKey, endKey []byte
+	startKey = g.randKeyToRead(0.001) // 0.1% new keys
+	endKey = g.randKeyToRead(0.001)   // 0.1% new keys
+	for g.equal(startKey, endKey) {
+		endKey = g.randKeyToRead(0.01) // 1% new keys
+	}
+	if g.cmp(startKey, endKey) > 0 {
+		startKey, endKey = endKey, startKey
+	}
 	g.add(&replicateOp{
 		source: source,
 		dest:   dest,
@@ -1443,7 +1451,14 @@ func (g *generator) writerIngestAndExcise() {
 	batchID := g.liveBatches.rand(g.rng)
 	g.removeBatchFromGenerator(batchID)
 
-	start, end := g.prefixKeyRange()
+	start := g.randKeyToWrite(0.001)
+	end := g.randKeyToWrite(0.001)
+	for g.equal(start, end) {
+		end = g.randKeyToWrite(0.001)
+	}
+	if g.cmp(start, end) > 0 {
+		start, end = end, start
+	}
 	derivedDBID := g.objDB[batchID]
 
 	g.add(&ingestAndExciseOp{

--- a/metamorphic/key_manager.go
+++ b/metamorphic/key_manager.go
@@ -406,7 +406,13 @@ func (k *keyManager) update(o op) {
 			k.mergeKeysInto(batchID, s.dbID)
 		}
 		k.checkForDelOrSingleDelTransitionInDB(s.dbID)
-	// TODO(bilal): Handle replicateOp and ingestAndExciseOp here.
+	case *ingestAndExciseOp:
+		// Merge all keys in the batch with the keys in the DB.
+		k.mergeKeysInto(s.batchID, s.dbID)
+		k.checkForDelOrSingleDelTransitionInDB(s.dbID)
+	case *replicateOp:
+		k.mergeKeysInto(s.source, s.dest)
+		k.checkForDelOrSingleDelTransitionInDB(s.dest)
 	case *applyOp:
 		// Merge the keys from this writer into the parent writer.
 		k.mergeKeysInto(s.batchID, s.writerID)

--- a/metamorphic/key_manager.go
+++ b/metamorphic/key_manager.go
@@ -410,9 +410,6 @@ func (k *keyManager) update(o op) {
 		// Merge all keys in the batch with the keys in the DB.
 		k.mergeKeysInto(s.batchID, s.dbID)
 		k.checkForDelOrSingleDelTransitionInDB(s.dbID)
-	case *replicateOp:
-		k.mergeKeysInto(s.source, s.dest)
-		k.checkForDelOrSingleDelTransitionInDB(s.dest)
 	case *applyOp:
 		// Merge the keys from this writer into the parent writer.
 		k.mergeKeysInto(s.batchID, s.writerID)
@@ -525,6 +522,7 @@ func opWrittenKeys(untypedOp op) [][]byte {
 	case *getOp:
 	case *ingestOp:
 	case *ingestAndExciseOp:
+		return [][]byte{t.exciseStart, t.exciseEnd}
 	case *initOp:
 	case *iterFirstOp:
 	case *iterLastOp:
@@ -552,6 +550,7 @@ func opWrittenKeys(untypedOp op) [][]byte {
 	case *singleDeleteOp:
 		return [][]byte{t.key}
 	case *replicateOp:
+		return [][]byte{t.start, t.end}
 	}
 	return nil
 }

--- a/metamorphic/key_manager.go
+++ b/metamorphic/key_manager.go
@@ -406,10 +406,6 @@ func (k *keyManager) update(o op) {
 			k.mergeKeysInto(batchID, s.dbID)
 		}
 		k.checkForDelOrSingleDelTransitionInDB(s.dbID)
-	case *ingestAndExciseOp:
-		// Merge all keys in the batch with the keys in the DB.
-		k.mergeKeysInto(s.batchID, s.dbID)
-		k.checkForDelOrSingleDelTransitionInDB(s.dbID)
 	case *applyOp:
 		// Merge the keys from this writer into the parent writer.
 		k.mergeKeysInto(s.batchID, s.writerID)
@@ -521,8 +517,6 @@ func opWrittenKeys(untypedOp op) [][]byte {
 	case *flushOp:
 	case *getOp:
 	case *ingestOp:
-	case *ingestAndExciseOp:
-		return [][]byte{t.exciseStart, t.exciseEnd}
 	case *initOp:
 	case *iterFirstOp:
 	case *iterLastOp:

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -821,7 +821,7 @@ func (o *ingestAndExciseOp) run(t *test, h historyRecorder) {
 	err = firstError(err, err2)
 	err = firstError(err, b.Close())
 
-	if writerMeta.Properties.NumEntries == 0 && writerMeta.Properties.NumRangeKeys() == 0 {
+	if writerMeta.Properties.NumEntries == 0 {
 		// No-op.
 		h.Recordf("%s // %v", o, err)
 		return
@@ -1585,7 +1585,7 @@ func (r *replicateOp) runSharedReplicate(
 		h.Recordf("%s // %v", r, err)
 		return
 	}
-	if len(sharedSSTs) == 0 && meta.Properties.NumEntries == 0 && meta.Properties.NumRangeKeys() == 0 {
+	if len(sharedSSTs) == 0 && meta.Properties.NumEntries == 0 {
 		// IngestAndExcise below will be a no-op. We should do a
 		// DeleteRange+RangeKeyDel to mimic the behaviour of the non-shared-replicate
 		// case.

--- a/metamorphic/parser.go
+++ b/metamorphic/parser.go
@@ -69,8 +69,6 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 		return &t.readerID, nil, []interface{}{&t.key}
 	case *ingestOp:
 		return &t.dbID, nil, []interface{}{&t.batchIDs}
-	case *ingestAndExciseOp:
-		return &t.dbID, nil, []interface{}{&t.batchID, &t.exciseStart, &t.exciseEnd}
 	case *initOp:
 		return nil, nil, []interface{}{&t.dbSlots, &t.batchSlots, &t.iterSlots, &t.snapshotSlots}
 	case *iterLastOp:
@@ -134,7 +132,6 @@ var methods = map[string]*methodInfo{
 	"Flush":                     makeMethod(flushOp{}, dbTag),
 	"Get":                       makeMethod(getOp{}, dbTag, batchTag, snapTag),
 	"Ingest":                    makeMethod(ingestOp{}, dbTag),
-	"IngestAndExcise":           makeMethod(ingestAndExciseOp{}, dbTag),
 	"Init":                      makeMethod(initOp{}, dbTag),
 	"Last":                      makeMethod(iterLastOp{}, iterTag),
 	"Merge":                     makeMethod(mergeOp{}, dbTag, batchTag),
@@ -591,8 +588,6 @@ func computeDerivedFields(ops []op) {
 			for i := range v.batchIDs {
 				v.derivedDBIDs[i] = objToDB[v.batchIDs[i]]
 			}
-		case *ingestAndExciseOp:
-			v.derivedDBID = objToDB[v.batchID]
 		case *deleteOp:
 			derivedDBID := v.writerID
 			if v.writerID.tag() != dbTag {

--- a/options.go
+++ b/options.go
@@ -973,11 +973,6 @@ type Options struct {
 		// against the FS are made after the DB is closed, the FS may leak a
 		// goroutine indefinitely.
 		fsCloser io.Closer
-
-		// efosAlwaysCreatesIterators is set by some tests to force
-		// EventuallyFileOnlySnapshots to always create iterators, even after a
-		// conflicting excise.
-		efosAlwaysCreatesIterators bool
 	}
 }
 
@@ -1149,13 +1144,6 @@ func (o *Options) AddEventListener(l EventListener) {
 		l = TeeEventListener(l, *o.EventListener)
 	}
 	o.EventListener = &l
-}
-
-// TestingAlwaysCreateEFOSIterators is used to toggle a private option for
-// having EventuallyFileOnlySnapshots always create iterators. Meant to only
-// be used in tests.
-func (o *Options) TestingAlwaysCreateEFOSIterators(value bool) {
-	o.private.efosAlwaysCreatesIterators = value
 }
 
 func (o *Options) equal() Equal {

--- a/snapshot.go
+++ b/snapshot.go
@@ -250,10 +250,6 @@ type EventuallyFileOnlySnapshot struct {
 		snap *Snapshot
 		// The wrapped version reference, if a file-only snapshot.
 		vers *version
-
-		// The readState corresponding to when this EFOS was created. Only set
-		// if alwaysCreateIters is true.
-		rs *readState
 	}
 
 	// Key ranges to watch for an excise on.
@@ -265,12 +261,6 @@ type EventuallyFileOnlySnapshot struct {
 	// The db the snapshot was created from.
 	db     *DB
 	seqNum uint64
-
-	// If true, this EventuallyFileOnlySnapshot will always generate iterators that
-	// retain snapshot semantics, by holding onto the readState if a conflicting
-	// excise were to happen. Only used in some tests to enforce deterministic
-	// behaviour around excises.
-	alwaysCreateIters bool
 
 	closed chan struct{}
 }
@@ -292,14 +282,10 @@ func (d *DB) makeEventuallyFileOnlySnapshot(
 		}
 	}
 	es := &EventuallyFileOnlySnapshot{
-		db:                d,
-		seqNum:            seqNum,
-		protectedRanges:   keyRanges,
-		closed:            make(chan struct{}),
-		alwaysCreateIters: d.opts.private.efosAlwaysCreatesIterators,
-	}
-	if es.alwaysCreateIters {
-		es.mu.rs = d.loadReadState()
+		db:              d,
+		seqNum:          seqNum,
+		protectedRanges: keyRanges,
+		closed:          make(chan struct{}),
 	}
 	if isFileOnly {
 		es.mu.vers = d.mu.versions.currentVersion()
@@ -443,9 +429,6 @@ func (es *EventuallyFileOnlySnapshot) Close() error {
 	if es.mu.vers != nil {
 		es.mu.vers.UnrefLocked()
 	}
-	if es.mu.rs != nil {
-		es.mu.rs.unrefLocked()
-	}
 	return nil
 }
 
@@ -481,31 +464,6 @@ func (es *EventuallyFileOnlySnapshot) NewIter(o *IterOptions) (*Iterator, error)
 	return es.NewIterWithContext(context.Background(), o)
 }
 
-func (es *EventuallyFileOnlySnapshot) newAlwaysCreateIterWithContext(
-	ctx context.Context, o *IterOptions,
-) (*Iterator, error) {
-	// Grab the db mutex. This avoids races down below, where we could get
-	// excised between the es.excised.Load() call, and the newIter call.
-	es.db.mu.Lock()
-	defer es.db.mu.Unlock()
-	es.mu.Lock()
-	defer es.mu.Unlock()
-	if es.mu.vers != nil {
-		sOpts := snapshotIterOpts{seqNum: es.seqNum, vers: es.mu.vers}
-		return es.db.newIter(ctx, nil /* batch */, newIterOpts{snapshot: sOpts}, o), nil
-	}
-
-	sOpts := snapshotIterOpts{seqNum: es.seqNum}
-	if es.excised.Load() {
-		if es.mu.rs == nil {
-			return nil, errors.AssertionFailedf("unexpected nil readState in EFOS' alwaysCreateIters mode")
-		}
-		sOpts.readState = es.mu.rs
-	}
-	iter := es.db.newIter(ctx, nil /* batch */, newIterOpts{snapshot: sOpts}, o)
-	return iter, nil
-}
-
 // NewIterWithContext is like NewIter, and additionally accepts a context for
 // tracing.
 func (es *EventuallyFileOnlySnapshot) NewIterWithContext(
@@ -517,9 +475,6 @@ func (es *EventuallyFileOnlySnapshot) NewIterWithContext(
 	default:
 	}
 
-	if es.alwaysCreateIters {
-		return es.newAlwaysCreateIterWithContext(ctx, o)
-	}
 	es.mu.Lock()
 	defer es.mu.Unlock()
 	if es.mu.vers != nil {
@@ -527,14 +482,14 @@ func (es *EventuallyFileOnlySnapshot) NewIterWithContext(
 		return es.db.newIter(ctx, nil /* batch */, newIterOpts{snapshot: sOpts}, o), nil
 	}
 
-	sOpts := snapshotIterOpts{seqNum: es.seqNum}
 	if es.excised.Load() {
 		return nil, ErrSnapshotExcised
 	}
+	sOpts := snapshotIterOpts{seqNum: es.seqNum}
 	iter := es.db.newIter(ctx, nil /* batch */, newIterOpts{snapshot: sOpts}, o)
 
 	// If excised is true, then keys relevant to the snapshot might not be
-	// present in the readState being used by the iterator.
+	// present in the readState being used by the iterator. Error out.
 	if es.excised.Load() {
 		iter.Close()
 		return nil, ErrSnapshotExcised
@@ -560,10 +515,22 @@ func (es *EventuallyFileOnlySnapshot) ScanInternal(
 	if es.db == nil {
 		panic(ErrClosed)
 	}
-	if es.excised.Load() && !es.alwaysCreateIters {
+	if es.excised.Load() {
 		return ErrSnapshotExcised
 	}
 	var sOpts snapshotIterOpts
+	es.mu.Lock()
+	if es.mu.vers != nil {
+		sOpts = snapshotIterOpts{
+			seqNum: es.seqNum,
+			vers:   es.mu.vers,
+		}
+	} else {
+		sOpts = snapshotIterOpts{
+			seqNum: es.seqNum,
+		}
+	}
+	es.mu.Unlock()
 	opts := &scanInternalOptions{
 		CategoryAndQoS: categoryAndQoS,
 		IterOptions: IterOptions{
@@ -577,43 +544,15 @@ func (es *EventuallyFileOnlySnapshot) ScanInternal(
 		visitSharedFile:  visitSharedFile,
 		skipSharedLevels: visitSharedFile != nil,
 	}
-	if es.alwaysCreateIters {
-		// Grab the db mutex. This avoids races down below as it prevents excises
-		// from taking effect until the iterator is instantiated.
-		es.db.mu.Lock()
-	}
-	es.mu.Lock()
-	if es.mu.vers != nil {
-		sOpts = snapshotIterOpts{
-			seqNum: es.seqNum,
-			vers:   es.mu.vers,
-		}
-	} else {
-		if es.excised.Load() && es.alwaysCreateIters {
-			sOpts = snapshotIterOpts{
-				readState: es.mu.rs,
-				seqNum:    es.seqNum,
-			}
-		} else {
-			sOpts = snapshotIterOpts{
-				seqNum: es.seqNum,
-			}
-		}
-	}
-	es.mu.Unlock()
 	iter, err := es.db.newInternalIter(ctx, sOpts, opts)
 	if err != nil {
 		return err
 	}
 	defer iter.close()
-	if es.alwaysCreateIters {
-		// See the similar conditional above where we grab this mutex.
-		es.db.mu.Unlock()
-	}
 
 	// If excised is true, then keys relevant to the snapshot might not be
 	// present in the readState being used by the iterator. Error out.
-	if es.excised.Load() && !es.alwaysCreateIters {
+	if es.excised.Load() {
 		return ErrSnapshotExcised
 	}
 

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -111,9 +111,6 @@ func (m *manifestT) printLevels(cmp base.Compare, stdout io.Writer, v *manifest.
 					fmt.Fprintf(stdout, "  %s:%d", f.FileNum, f.Size)
 					formatSeqNumRange(stdout, f.SmallestSeqNum, f.LargestSeqNum)
 					formatKeyRange(stdout, m.fmtKey, &f.Smallest, &f.Largest)
-					if f.Virtual {
-						fmt.Fprintf(stdout, "(virtual:backingNum=%s)", f.FileBacking.DiskFileNum)
-					}
 					fmt.Fprintf(stdout, "\n")
 				})
 			}
@@ -128,9 +125,6 @@ func (m *manifestT) printLevels(cmp base.Compare, stdout io.Writer, v *manifest.
 			fmt.Fprintf(stdout, "  %s:%d", f.FileNum, f.Size)
 			formatSeqNumRange(stdout, f.SmallestSeqNum, f.LargestSeqNum)
 			formatKeyRange(stdout, m.fmtKey, &f.Smallest, &f.Largest)
-			if f.Virtual {
-				fmt.Fprintf(stdout, "(virtual:backingNum=%s)", f.FileBacking.DiskFileNum)
-			}
 			fmt.Fprintf(stdout, "\n")
 		}
 	}


### PR DESCRIPTION
Revert commits 0f084ca9ef80783c7ff95f86408717b1a95ec180, 596d16da9806bc3c5622f6cc8faf415f6904f79c and 1b9268afc8ca6cae8c10dd7d9e4067dbde03256b that together integrate IngestAndExcise into the metamorphic tests. Virtual sstables are still unstable and leading to persistent metamorphic failures. This PR reverts the integration for now until the underlying issue can be fixed. This partially motivated by the need to get metamorphic test coverage of single deletes now.

Informs #3128.