### PR TITLE
ci: check that make generate did not change anything

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,9 @@ jobs:
 
     - run: make test generate
 
+    - name: Assert workspace clean
+      run: scripts/check-workspace-clean.sh
+
   linux-32bit:
     name: go-linux-32bit
     runs-on: ubuntu-latest

--- a/scripts/check-workspace-clean.sh
+++ b/scripts/check-workspace-clean.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# The workspace is clean iff `git status --porcelain` produces no output. Any
+# output is either an error message or a listing of an untracked/dirty file.
+if [[ "$(git status --porcelain 2>&1)" != "" ]]; then
+  git status >&2 || true
+  git diff --no-ext-diff -a >&2 || true
+  echo "" >&2
+  echo "Error: make generate resulted in changes" >&2
+  exit 1
+fi
+


### PR DESCRIPTION
We run `make test generate` in CI, but the main point of that would be to check that all generated stuff is up to date.

This commit adds a last step that checks that the workspace is clean.