### PR TITLE
db: compactionIter.nextInStripe skips RANGEDEL covered keys in the sa…

### DIFF
--- a/testdata/compaction_iter
+++ b/testdata/compaction_iter
@@ -447,7 +447,7 @@ next
 tombstones
 ----
 a#3,15:c
-b#5,1:de[base]
+b#5,2:de
 d#5,2:bc
 d#3,15:f
 .
@@ -1102,8 +1102,7 @@ a#5,18:5[base]
 a#1,2:1
 .
 
-# Verify that we transform merge+rangedel -> set. This isn't strictly
-# necessary, but provides consistency with the behavior for merge+del.
+# Verify that merge+rangedel -> merge.
 
 define
 a.RANGEDEL.3:c
@@ -1118,7 +1117,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 .
 
 iter allow-zero-seqnum=true
@@ -1127,7 +1126,7 @@ next
 next
 ----
 a#3,15:c
-b#0,1:5[base]
+b#0,2:5
 .
 
 iter snapshots=2
@@ -1136,7 +1135,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 b#1,2:1
 
 define
@@ -1152,7 +1151,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 .
 
 iter snapshots=2
@@ -1161,7 +1160,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 b#1,2:1
 
 # NB: Zero values are skipped by deletable merger.

--- a/testdata/compaction_iter_delete_sized
+++ b/testdata/compaction_iter_delete_sized
@@ -444,7 +444,7 @@ next
 tombstones
 ----
 a#3,15:c
-b#5,1:de[base]
+b#5,2:de
 d#5,2:bc
 d#3,15:f
 .
@@ -1101,8 +1101,7 @@ a#5,18:5[base]
 a#1,2:1
 .
 
-# Verify that we transform merge+rangedel -> set. This isn't strictly
-# necessary, but provides consistency with the behavior for merge+del.
+# Verify that merge+rangedel -> merge.
 
 define
 a.RANGEDEL.3:c
@@ -1117,7 +1116,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 .
 
 iter allow-zero-seqnum=true
@@ -1126,7 +1125,7 @@ next
 next
 ----
 a#3,15:c
-b#0,1:5[base]
+b#0,2:5
 .
 
 iter snapshots=2
@@ -1135,7 +1134,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 b#1,2:1
 
 define
@@ -1151,7 +1150,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 .
 
 iter snapshots=2
@@ -1160,7 +1159,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 b#1,2:1
 
 # SET that meets a DEL is transformed into a SETWITHDEL.
@@ -1296,7 +1295,7 @@ next
 ----
 a#3,1:c
 a#2,15:z
-a#0,18:b
+a#0,1:b
 .
 
 iter allow-zero-seqnum=true snapshots=2

--- a/testdata/compaction_iter_set_with_del
+++ b/testdata/compaction_iter_set_with_del
@@ -444,7 +444,7 @@ next
 tombstones
 ----
 a#3,15:c
-b#5,1:de[base]
+b#5,2:de
 d#5,2:bc
 d#3,15:f
 .
@@ -1101,8 +1101,7 @@ a#5,18:5[base]
 a#1,2:1
 .
 
-# Verify that we transform merge+rangedel -> set. This isn't strictly
-# necessary, but provides consistency with the behavior for merge+del.
+# Verify that merge+rangedel -> merge.
 
 define
 a.RANGEDEL.3:c
@@ -1117,7 +1116,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 .
 
 iter allow-zero-seqnum=true
@@ -1126,7 +1125,7 @@ next
 next
 ----
 a#3,15:c
-b#0,1:5[base]
+b#0,2:5
 .
 
 iter snapshots=2
@@ -1135,7 +1134,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 b#1,2:1
 
 define
@@ -1151,7 +1150,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 .
 
 iter snapshots=2
@@ -1160,7 +1159,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 b#1,2:1
 
 # SET that meets a DEL is transformed into a SETWITHDEL.
@@ -1296,7 +1295,7 @@ next
 ----
 a#3,1:c
 a#2,15:z
-a#0,18:b
+a#0,1:b
 .
 
 iter allow-zero-seqnum=true snapshots=2


### PR DESCRIPTION
…me stripe

This change allows us to stop remembering to check for visibly covered keys in callers. For example:
- deleteSizedNext did not account for visibly covered SETs when it did the size computation.
- singleDeleteNext was willing to consume the SINGLEDEL even if the SET was covered by a RANGEDEL (though this is not a bug, since everything below the RANGEDEL is deleted).

This change does effect mergeNext in that MERGE plus an older RANGEDEL will not get converted to a SET. This is not a semantic change to MERGE behavior.