### PR TITLE
metamorphic: increase probability of non-move multilevel compactions

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1716,6 +1716,9 @@ type MultiLevelHeuristic interface {
 
 	// Returns if the heuristic allows L0 to be involved in ML compaction
 	allowL0() bool
+
+	// String implements fmt.Stringer.
+	String() string
 }
 
 // NoMultiLevel will never add an additional level to the compaction.
@@ -1729,9 +1732,8 @@ func (nml NoMultiLevel) pick(
 	return pc
 }
 
-func (nml NoMultiLevel) allowL0() bool {
-	return false
-}
+func (nml NoMultiLevel) allowL0() bool  { return false }
+func (nml NoMultiLevel) String() string { return "none" }
 
 func (pc *pickedCompaction) predictedWriteAmp() float64 {
 	var bytesToCompact uint64
@@ -1798,6 +1800,11 @@ func (wa WriteAmpHeuristic) pick(
 
 func (wa WriteAmpHeuristic) allowL0() bool {
 	return wa.AllowL0
+}
+
+// String implements fmt.Stringer.
+func (wa WriteAmpHeuristic) String() string {
+	return fmt.Sprintf("wamp(%.2f, %t)", wa.AddPropensity, wa.AllowL0)
 }
 
 // Helper method to pick compactions originating from L0. Uses information about

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -930,9 +930,8 @@ func (d alwaysMultiLevel) pick(
 	return pcMulti
 }
 
-func (d alwaysMultiLevel) allowL0() bool {
-	return false
-}
+func (d alwaysMultiLevel) allowL0() bool  { return false }
+func (d alwaysMultiLevel) String() string { return "always" }
 
 func TestPickedCompactionSetupInputs(t *testing.T) {
 	opts := &Options{}

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -493,6 +493,23 @@ func randomOptions(
 	if rng.Intn(2) == 0 {
 		opts.Experimental.DisableIngestAsFlushable = func() bool { return true }
 	}
+
+	// We either use no multilevel compactions, multilevel compactions with the
+	// default (zero) additional propensity, or multilevel compactions with an
+	// additional propensity to encourage more multilevel compactions than we
+	// ohterwise would.
+	switch rng.Intn(3) {
+	case 0:
+		opts.Experimental.MultiLevelCompactionHeuristic = pebble.NoMultiLevel{}
+	case 1:
+		opts.Experimental.MultiLevelCompactionHeuristic = pebble.WriteAmpHeuristic{}
+	default:
+		opts.Experimental.MultiLevelCompactionHeuristic = pebble.WriteAmpHeuristic{
+			AddPropensity: rng.Float64() * float64(rng.Intn(3)), // [0,3.0)
+			AllowL0:       rng.Intn(4) == 1,                     // 25% of the time
+		}
+	}
+
 	var lopts pebble.LevelOptions
 	lopts.BlockRestartInterval = 1 + rng.Intn(64)  // 1 - 64
 	lopts.BlockSize = 1 << uint(rng.Intn(24))      // 1 - 16MB

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -75,6 +75,7 @@ func TestOptionsRoundtrip(t *testing.T) {
 		"Experimental.IngestSplit:",
 		// Floating points
 		"Experimental.PointTombstoneWeight:",
+		"Experimental.MultiLevelCompactionHeuristic.AddPropensity",
 	}
 
 	// Ensure that we unref any caches created, so invariants builds don't

--- a/options.go
+++ b/options.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -1238,6 +1239,9 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  mem_table_stop_writes_threshold=%d\n", o.MemTableStopWritesThreshold)
 	fmt.Fprintf(&buf, "  min_deletion_rate=%d\n", o.TargetByteDeletionRate)
 	fmt.Fprintf(&buf, "  merger=%s\n", o.Merger.Name)
+	if o.Experimental.MultiLevelCompactionHeuristic != nil {
+		fmt.Fprintf(&buf, "  multilevel_compaction_heuristic=%s\n", o.Experimental.MultiLevelCompactionHeuristic.String())
+	}
 	fmt.Fprintf(&buf, "  read_compaction_rate=%d\n", o.Experimental.ReadCompactionRate)
 	fmt.Fprintf(&buf, "  read_sampling_multiplier=%d\n", o.Experimental.ReadSamplingMultiplier)
 	fmt.Fprintf(&buf, "  strict_wal_tail=%t\n", o.private.strictWALTail)
@@ -1492,6 +1496,32 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 			case "min_flush_rate":
 				// Do nothing; option existed in older versions of pebble, and
 				// may be meaningful again eventually.
+			case "multilevel_compaction_heuristic":
+				switch {
+				case value == "none":
+					o.Experimental.MultiLevelCompactionHeuristic = NoMultiLevel{}
+				case strings.HasPrefix(value, "wamp"):
+					fields := strings.FieldsFunc(strings.TrimPrefix(value, "wamp"), func(r rune) bool {
+						return unicode.IsSpace(r) || r == ',' || r == '(' || r == ')'
+					})
+					if len(fields) != 2 {
+						err = errors.Newf("require 2 arguments")
+					}
+					var h WriteAmpHeuristic
+					if err == nil {
+						h.AddPropensity, err = strconv.ParseFloat(fields[0], 64)
+					}
+					if err == nil {
+						h.AllowL0, err = strconv.ParseBool(fields[1])
+					}
+					if err == nil {
+						o.Experimental.MultiLevelCompactionHeuristic = h
+					} else {
+						err = errors.Wrapf(err, "unexpected wamp heuristic arguments: %s", value)
+					}
+				default:
+					err = errors.Newf("unrecognized multilevel compaction heuristic: %s", value)
+				}
 			case "point_tombstone_weight":
 				// Do nothing; deprecated.
 			case "strict_wal_tail":

--- a/options_test.go
+++ b/options_test.go
@@ -95,6 +95,7 @@ func TestOptionsString(t *testing.T) {
   mem_table_stop_writes_threshold=2
   min_deletion_rate=0
   merger=pebble.concatenate
+  multilevel_compaction_heuristic=wamp(0.00, false)
   read_compaction_rate=16000
   read_sampling_multiplier=16
   strict_wal_tail=true

--- a/replay/testdata/replay
+++ b/replay/testdata/replay
@@ -13,7 +13,7 @@ tree
        0      LOCK
       98      MANIFEST-000001
      122      MANIFEST-000008
-    1189      OPTIONS-000003
+    1241      OPTIONS-000003
        0      marker.format-version.000007.008
        0      marker.manifest.000002.MANIFEST-000008
             simple/
@@ -24,7 +24,7 @@ tree
       25        000004.log
      658        000005.sst
       98        MANIFEST-000001
-    1189        OPTIONS-000003
+    1241        OPTIONS-000003
        0        marker.format-version.000001.008
        0        marker.manifest.000001.MANIFEST-000001
 
@@ -57,6 +57,7 @@ cat build/OPTIONS-000003
   mem_table_stop_writes_threshold=2
   min_deletion_rate=0
   merger=pebble.concatenate
+  multilevel_compaction_heuristic=wamp(0.00, false)
   read_compaction_rate=16000
   read_sampling_multiplier=16
   strict_wal_tail=true

--- a/replay/testdata/replay_paced
+++ b/replay/testdata/replay_paced
@@ -15,7 +15,7 @@ tree
        0      LOCK
      122      MANIFEST-000008
      205      MANIFEST-000011
-    1189      OPTIONS-000003
+    1241      OPTIONS-000003
        0      marker.format-version.000007.008
        0      marker.manifest.000003.MANIFEST-000011
             high_read_amp/
@@ -27,7 +27,7 @@ tree
       39        000009.log
      632        000010.sst
      157        MANIFEST-000011
-    1189        OPTIONS-000003
+    1241        OPTIONS-000003
        0        marker.format-version.000001.008
        0        marker.manifest.000001.MANIFEST-000011
 

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -77,7 +77,7 @@ Ingestions: 0  as flushable: 0 (0B in 0 tables)
 
 disk-usage
 ----
-1.9KB
+2.0KB
 
 batch
 set b 2
@@ -133,7 +133,7 @@ Iter category stats:
 
 disk-usage
 ----
-3.3KB
+3.4KB
 
 # Closing iter a will release one of the zombie memtables.
 
@@ -256,7 +256,7 @@ Iter category stats:
 
 disk-usage
 ----
-2.0KB
+2.1KB
 
 additional-metrics
 ----


### PR DESCRIPTION
Adapt the multilevel compaction heuristic into a metamorphic option, allowing
random option runs to use no multilevel compactions, multilevel compactions
with the default write amplification heuristic, and multilevel compactions with
additional, artificially inflated propensity.

Previously, the metamorphic tests tended to exercise simple multilevel
compactions, and especially multilevel move compactions. Now some random runs
should schedule a higher portion of nontrivial multilevel compactions.