### PR TITLE
crl-release-23.2: backport compactionIter changes for SingleDelete assertions

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3019,7 +3019,9 @@ func (d *DB) runCompaction(
 	iiter = invalidating.MaybeWrapIfInvariants(iiter)
 	iter := newCompactionIter(c.cmp, c.equal, c.formatKey, d.merge, iiter, snapshots,
 		&c.rangeDelFrag, &c.rangeKeyFrag, c.allowedZeroSeqNum, c.elideTombstone,
-		c.elideRangeTombstone, d.FormatMajorVersion())
+		c.elideRangeTombstone, d.opts.Experimental.IneffectualSingleDeleteCallback,
+		d.opts.Experimental.SingleDeleteInvariantViolationCallback,
+		d.FormatMajorVersion())
 
 	var (
 		createdFiles    []base.DiskFileNum

--- a/compaction_iter.go
+++ b/compaction_iter.go
@@ -522,7 +522,7 @@ func (i *compactionIter) Next() (*InternalKey, []byte) {
 				// into a SET.
 				var includesBase bool
 				switch i.key.Kind() {
-				case InternalKeyKindSet:
+				case InternalKeyKindSet, InternalKeyKindSetWithDelete:
 					includesBase = true
 				case InternalKeyKindMerge:
 				default:
@@ -832,7 +832,8 @@ func (i *compactionIter) mergeNext(valueMerger ValueMerger) stripeChangeType {
 			// We've hit a deletion tombstone. Return everything up to this point and
 			// then skip entries until the next snapshot stripe. We change the kind
 			// of the result key to a Set so that it shadows keys in lower
-			// levels. That is, MERGE+DEL -> SET.
+			// levels. That is, MERGE+DEL -> SETWITHDEL.
+			//
 			// We do the same for SingleDelete since SingleDelete is only
 			// permitted (with deterministic behavior) for keys that have been
 			// set once since the last SingleDelete/Delete, so everything
@@ -845,7 +846,7 @@ func (i *compactionIter) mergeNext(valueMerger ValueMerger) stripeChangeType {
 			// single Set, and then merge in any following Sets, but that is
 			// complicated wrt code and unnecessary given the narrow permitted
 			// use of SingleDelete.
-			i.key.SetKind(InternalKeyKindSet)
+			i.key.SetKind(InternalKeyKindSetWithDelete)
 			i.skip = true
 			return sameStripeSkippable
 

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -219,6 +219,13 @@ func defaultOptions() *pebble.Options {
 		}},
 		BlockPropertyCollectors: blockPropertyCollectorConstructors,
 	}
+	// TODO(sumeer): add IneffectualSingleDeleteCallback that panics by
+	// supporting a test option that does not generate ineffectual single
+	// deletes.
+	opts.Experimental.SingleDeleteInvariantViolationCallback = func(
+		userKey []byte) {
+		panic(errors.AssertionFailedf("single del invariant violations on key %q", userKey))
+	}
 	return opts
 }
 

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -69,10 +69,12 @@ func TestOptionsRoundtrip(t *testing.T) {
 		"BlockPropertyCollectors:",
 		"EventListener:",
 		"MaxConcurrentCompactions:",
-		"Experimental.EnableValueBlocks:",
 		"Experimental.DisableIngestAsFlushable:",
-		"Experimental.RemoteStorage:",
+		"Experimental.EnableValueBlocks:",
+		"Experimental.IneffectualSingleDeleteCallback:",
 		"Experimental.IngestSplit:",
+		"Experimental.RemoteStorage:",
+		"Experimental.SingleDeleteInvariantViolationCallback:",
 		// Floating points
 		"Experimental.PointTombstoneWeight:",
 	}

--- a/testdata/compaction_iter
+++ b/testdata/compaction_iter
@@ -787,7 +787,7 @@ iter
 first
 next
 ----
-a#6,1:b[base]
+a#6,18:b[base]
 .
 
 # Non-deterministic use of SINGLEDEL where there are two older SETs that have
@@ -803,7 +803,7 @@ iter
 first
 next
 ----
-a#6,1:b[base]
+a#6,18:b[base]
 .
 
 define
@@ -1067,21 +1067,21 @@ iter
 first
 next
 ----
-a#5,1:5[base]
+a#5,18:5[base]
 .
 
 iter allow-zero-seqnum=true
 first
 next
 ----
-a#0,1:5[base]
+a#0,18:5[base]
 .
 
 iter elide-tombstones=true
 first
 next
 ----
-a#5,1:5[base]
+a#5,18:5[base]
 .
 
 iter snapshots=2
@@ -1089,7 +1089,7 @@ first
 next
 next
 ----
-a#5,1:5[base]
+a#5,18:5[base]
 a#1,2:1
 .
 
@@ -1098,7 +1098,7 @@ first
 next
 next
 ----
-a#5,1:5[base]
+a#5,18:5[base]
 a#1,2:1
 .
 

--- a/testdata/compaction_iter
+++ b/testdata/compaction_iter
@@ -682,6 +682,7 @@ iter elide-tombstones=true
 first
 ----
 .
+ineffectual-single-deletes: a
 
 define
 a.SINGLEDEL.2:
@@ -694,6 +695,7 @@ next
 ----
 a#2,7:
 .
+ineffectual-single-deletes: a
 
 define
 a.SINGLEDEL.3:
@@ -705,6 +707,7 @@ iter
 first
 ----
 .
+ineffectual-single-deletes: a
 
 define
 a.SET.3:a
@@ -720,6 +723,7 @@ next
 a#3,1:a
 b#2,0:
 .
+ineffectual-single-deletes: b
 
 define
 a.SINGLEDEL.2:
@@ -732,11 +736,13 @@ next
 ----
 a#2,0:
 .
+ineffectual-single-deletes: a
 
 iter elide-tombstones=true
 first
 ----
 .
+ineffectual-single-deletes: a
 
 define
 a.SINGLEDEL.2:
@@ -745,9 +751,7 @@ a.MERGE.1:
 
 iter
 first
-next
 ----
-a#2,0:
 .
 
 iter elide-tombstones=true
@@ -777,6 +781,15 @@ next
 a#2,1:b
 .
 
+# We don't notice the ineffectual single delete since the SET causes all
+# SingleDelete error checking to be skipped.
+iter elide-tombstones=true
+first
+next
+----
+a#2,1:b
+.
+
 define
 a.MERGE.6:b
 a.SINGLEDEL.5:
@@ -791,7 +804,8 @@ a#6,18:b[base]
 .
 
 # Non-deterministic use of SINGLEDEL where there are two older SETs that have
-# not been deleted or single deleted. It is permitted to shadow both.
+# not been deleted or single deleted. It is permitted to shadow both, since
+# MERGE turns into a SETWITHDELETE when it meets the SINGLEDEL.
 define
 a.MERGE.6:b
 a.SINGLEDEL.5:
@@ -831,6 +845,7 @@ next
 ----
 a#1,1:a
 .
+invariant-violation-single-deletes: a
 
 define
 a.SINGLEDEL.3:
@@ -838,12 +853,14 @@ a.MERGE.2:b
 a.MERGE.1:a
 ----
 
+# SINGLEDEL consumes the first MERGE.
 iter
 first
 next
 ----
-a#3,0:
+a#1,2:a
 .
+invariant-violation-single-deletes: a
 
 define
 a.SINGLEDEL.4:
@@ -918,6 +935,7 @@ next
 ----
 a#2,1:ab[base]
 .
+invariant-violation-single-deletes: a
 
 iter snapshots=2
 first
@@ -927,6 +945,7 @@ next
 a#2,2:b
 a#1,1:a
 .
+invariant-violation-single-deletes: a
 
 iter snapshots=3
 first
@@ -934,6 +953,7 @@ next
 ----
 a#2,1:ab[base]
 .
+invariant-violation-single-deletes: a
 
 iter snapshots=(2,3,4)
 first

--- a/testdata/compaction_iter
+++ b/testdata/compaction_iter
@@ -447,7 +447,7 @@ next
 tombstones
 ----
 a#3,15:c
-b#5,1:de[base]
+b#5,2:de
 d#5,2:bc
 d#3,15:f
 .
@@ -1102,8 +1102,7 @@ a#5,18:5[base]
 a#1,2:1
 .
 
-# Verify that we transform merge+rangedel -> set. This isn't strictly
-# necessary, but provides consistency with the behavior for merge+del.
+# Verify that merge+rangedel -> merge.
 
 define
 a.RANGEDEL.3:c
@@ -1118,7 +1117,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 .
 
 iter allow-zero-seqnum=true
@@ -1127,7 +1126,7 @@ next
 next
 ----
 a#3,15:c
-b#0,1:5[base]
+b#0,2:5
 .
 
 iter snapshots=2
@@ -1136,7 +1135,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 b#1,2:1
 
 define
@@ -1152,7 +1151,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 .
 
 iter snapshots=2
@@ -1161,7 +1160,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 b#1,2:1
 
 # NB: Zero values are skipped by deletable merger.

--- a/testdata/compaction_iter_delete_sized
+++ b/testdata/compaction_iter_delete_sized
@@ -679,6 +679,7 @@ iter elide-tombstones=true
 first
 ----
 .
+ineffectual-single-deletes: a
 
 define
 a.SINGLEDEL.2:
@@ -691,6 +692,7 @@ next
 ----
 a#2,7:
 .
+ineffectual-single-deletes: a
 
 define
 a.SINGLEDEL.3:
@@ -702,6 +704,7 @@ iter
 first
 ----
 .
+ineffectual-single-deletes: a
 
 define
 a.SET.3:a
@@ -717,6 +720,7 @@ next
 a#3,1:a
 b#2,0:
 .
+ineffectual-single-deletes: b
 
 define
 a.SINGLEDEL.2:
@@ -729,11 +733,13 @@ next
 ----
 a#2,0:
 .
+ineffectual-single-deletes: a
 
 iter elide-tombstones=true
 first
 ----
 .
+ineffectual-single-deletes: a
 
 define
 a.SINGLEDEL.2:
@@ -742,9 +748,7 @@ a.MERGE.1:
 
 iter
 first
-next
 ----
-a#2,0:
 .
 
 iter elide-tombstones=true
@@ -776,6 +780,15 @@ next
 a#2,18:b
 .
 
+# We don't notice the ineffectual single delete since the SET causes all
+# SingleDelete error checking to be skipped.
+iter elide-tombstones=true
+first
+next
+----
+a#2,18:b
+.
+
 define
 a.MERGE.6:b
 a.SINGLEDEL.5:
@@ -790,7 +803,8 @@ a#6,18:b[base]
 .
 
 # Non-deterministic use of SINGLEDEL where there are two older SETs that have
-# not been deleted or single deleted. It is permitted to shadow both.
+# not been deleted or single deleted. It is permitted to shadow both, since
+# MERGE turns into a SETWITHDELETE when it meets the SINGLEDEL.
 define
 a.MERGE.6:b
 a.SINGLEDEL.5:
@@ -830,6 +844,7 @@ next
 ----
 a#1,1:a
 .
+invariant-violation-single-deletes: a
 
 define
 a.SINGLEDEL.3:
@@ -837,12 +852,14 @@ a.MERGE.2:b
 a.MERGE.1:a
 ----
 
+# SINGLEDEL consumes the first MERGE.
 iter
 first
 next
 ----
-a#3,0:
+a#1,2:a
 .
+invariant-violation-single-deletes: a
 
 define
 a.SINGLEDEL.4:
@@ -917,6 +934,7 @@ next
 ----
 a#2,1:ab[base]
 .
+invariant-violation-single-deletes: a
 
 iter snapshots=2
 first
@@ -926,6 +944,7 @@ next
 a#2,2:b
 a#1,1:a
 .
+invariant-violation-single-deletes: a
 
 iter snapshots=3
 first
@@ -933,6 +952,7 @@ next
 ----
 a#2,1:ab[base]
 .
+invariant-violation-single-deletes: a
 
 iter snapshots=(2,3,4)
 first
@@ -1782,6 +1802,25 @@ a#5,15:d
 
 define
 a.SINGLEDEL.6:
+a.SET.5:foo
+a.RANGEDEL.4:d
+a.SET.4:bar
+----
+
+# The SINGLEDEL invariant checking can't see past the RANGEDEL and see that
+# the a.SET.4 violates the invariant. This is a code artifact that will be
+# improved when range deletes are interleaved at the maximal sequence number.
+iter
+first
+next
+next
+----
+a#4,15:d
+a#4,1:bar
+.
+
+define
+a.SINGLEDEL.6:
 a.SETWITHDEL.5:foo
 a.RANGEDEL.5:d
 ----
@@ -1894,3 +1933,22 @@ next
 ----
 a#5,18:foo[base]
 .
+
+define
+a.SINGLEDEL.4:
+a.MERGE.3:a3
+a.SET.2:a2
+b.SINGLEDEL.6:
+b.SET.5:b5
+b.SETWITHDEL.4:b4
+----
+
+iter
+first
+next
+next
+----
+a#2,1:a2
+b#4,18:b4
+.
+invariant-violation-single-deletes: a,b

--- a/testdata/compaction_iter_delete_sized
+++ b/testdata/compaction_iter_delete_sized
@@ -786,7 +786,7 @@ iter
 first
 next
 ----
-a#6,1:b[base]
+a#6,18:b[base]
 .
 
 # Non-deterministic use of SINGLEDEL where there are two older SETs that have
@@ -802,7 +802,7 @@ iter
 first
 next
 ----
-a#6,1:b[base]
+a#6,18:b[base]
 .
 
 define
@@ -1066,21 +1066,21 @@ iter
 first
 next
 ----
-a#5,1:5[base]
+a#5,18:5[base]
 .
 
 iter allow-zero-seqnum=true
 first
 next
 ----
-a#0,1:5[base]
+a#0,18:5[base]
 .
 
 iter elide-tombstones=true
 first
 next
 ----
-a#5,1:5[base]
+a#5,18:5[base]
 .
 
 iter snapshots=2
@@ -1088,7 +1088,7 @@ first
 next
 next
 ----
-a#5,1:5[base]
+a#5,18:5[base]
 a#1,2:1
 .
 
@@ -1097,7 +1097,7 @@ first
 next
 next
 ----
-a#5,1:5[base]
+a#5,18:5[base]
 a#1,2:1
 .
 
@@ -1863,7 +1863,7 @@ missized-dels=0
 
 # Regression test for #3087.
 #
-# Whne a DELSIZED and a SINGLEDEL meet in a compaction, a DEL key should be
+# When a DELSIZED and a SINGLEDEL meet in a compaction, a DEL key should be
 # emitted.
 
 define
@@ -1878,4 +1878,20 @@ first
 next
 ----
 a#5,0:
+.
+
+# When a MERGE and a DEL[SIZED] meet in a compaction, a SETWITHDEL key (NOT a
+# SET) should be emitted. Otherwise, a sequence such as SINGLEDDEL, MERGE, DEL,
+# SET could result in the SET re-appearing.
+
+define
+a.MERGE.5:foo
+a.DEL.3:
+----
+
+iter
+first
+next
+----
+a#5,18:foo[base]
 .

--- a/testdata/compaction_iter_delete_sized
+++ b/testdata/compaction_iter_delete_sized
@@ -444,7 +444,7 @@ next
 tombstones
 ----
 a#3,15:c
-b#5,1:de[base]
+b#5,2:de
 d#5,2:bc
 d#3,15:f
 .
@@ -1101,8 +1101,7 @@ a#5,18:5[base]
 a#1,2:1
 .
 
-# Verify that we transform merge+rangedel -> set. This isn't strictly
-# necessary, but provides consistency with the behavior for merge+del.
+# Verify that merge+rangedel -> merge.
 
 define
 a.RANGEDEL.3:c
@@ -1117,7 +1116,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 .
 
 iter allow-zero-seqnum=true
@@ -1126,7 +1125,7 @@ next
 next
 ----
 a#3,15:c
-b#0,1:5[base]
+b#0,2:5
 .
 
 iter snapshots=2
@@ -1135,7 +1134,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 b#1,2:1
 
 define
@@ -1151,7 +1150,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 .
 
 iter snapshots=2
@@ -1160,7 +1159,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 b#1,2:1
 
 # SET that meets a DEL is transformed into a SETWITHDEL.
@@ -1296,7 +1295,7 @@ next
 ----
 a#3,1:c
 a#2,15:z
-a#0,18:b
+a#0,1:b
 .
 
 iter allow-zero-seqnum=true snapshots=2

--- a/testdata/compaction_iter_set_with_del
+++ b/testdata/compaction_iter_set_with_del
@@ -786,7 +786,7 @@ iter
 first
 next
 ----
-a#6,1:b[base]
+a#6,18:b[base]
 .
 
 # Non-deterministic use of SINGLEDEL where there are two older SETs that have
@@ -802,7 +802,7 @@ iter
 first
 next
 ----
-a#6,1:b[base]
+a#6,18:b[base]
 .
 
 define
@@ -1066,21 +1066,21 @@ iter
 first
 next
 ----
-a#5,1:5[base]
+a#5,18:5[base]
 .
 
 iter allow-zero-seqnum=true
 first
 next
 ----
-a#0,1:5[base]
+a#0,18:5[base]
 .
 
 iter elide-tombstones=true
 first
 next
 ----
-a#5,1:5[base]
+a#5,18:5[base]
 .
 
 iter snapshots=2
@@ -1088,7 +1088,7 @@ first
 next
 next
 ----
-a#5,1:5[base]
+a#5,18:5[base]
 a#1,2:1
 .
 
@@ -1097,7 +1097,7 @@ first
 next
 next
 ----
-a#5,1:5[base]
+a#5,18:5[base]
 a#1,2:1
 .
 

--- a/testdata/compaction_iter_set_with_del
+++ b/testdata/compaction_iter_set_with_del
@@ -679,6 +679,7 @@ iter elide-tombstones=true
 first
 ----
 .
+ineffectual-single-deletes: a
 
 define
 a.SINGLEDEL.2:
@@ -691,6 +692,7 @@ next
 ----
 a#2,7:
 .
+ineffectual-single-deletes: a
 
 define
 a.SINGLEDEL.3:
@@ -702,6 +704,7 @@ iter
 first
 ----
 .
+ineffectual-single-deletes: a
 
 define
 a.SET.3:a
@@ -717,6 +720,7 @@ next
 a#3,1:a
 b#2,0:
 .
+ineffectual-single-deletes: b
 
 define
 a.SINGLEDEL.2:
@@ -729,11 +733,13 @@ next
 ----
 a#2,0:
 .
+ineffectual-single-deletes: a
 
 iter elide-tombstones=true
 first
 ----
 .
+ineffectual-single-deletes: a
 
 define
 a.SINGLEDEL.2:
@@ -742,9 +748,7 @@ a.MERGE.1:
 
 iter
 first
-next
 ----
-a#2,0:
 .
 
 iter elide-tombstones=true
@@ -776,6 +780,15 @@ next
 a#2,18:b
 .
 
+# We don't notice the ineffectual single delete since the SET causes all
+# SingleDelete error checking to be skipped.
+iter elide-tombstones=true
+first
+next
+----
+a#2,18:b
+.
+
 define
 a.MERGE.6:b
 a.SINGLEDEL.5:
@@ -790,7 +803,8 @@ a#6,18:b[base]
 .
 
 # Non-deterministic use of SINGLEDEL where there are two older SETs that have
-# not been deleted or single deleted. It is permitted to shadow both.
+# not been deleted or single deleted. It is permitted to shadow both, since
+# MERGE turns into a SETWITHDELETE when it meets the SINGLEDEL.
 define
 a.MERGE.6:b
 a.SINGLEDEL.5:
@@ -830,6 +844,7 @@ next
 ----
 a#1,1:a
 .
+invariant-violation-single-deletes: a
 
 define
 a.SINGLEDEL.3:
@@ -837,12 +852,14 @@ a.MERGE.2:b
 a.MERGE.1:a
 ----
 
+# SINGLEDEL consumes the first MERGE.
 iter
 first
 next
 ----
-a#3,0:
+a#1,2:a
 .
+invariant-violation-single-deletes: a
 
 define
 a.SINGLEDEL.4:
@@ -917,6 +934,7 @@ next
 ----
 a#2,1:ab[base]
 .
+invariant-violation-single-deletes: a
 
 iter snapshots=2
 first
@@ -926,6 +944,7 @@ next
 a#2,2:b
 a#1,1:a
 .
+invariant-violation-single-deletes: a
 
 iter snapshots=3
 first
@@ -933,6 +952,7 @@ next
 ----
 a#2,1:ab[base]
 .
+invariant-violation-single-deletes: a
 
 iter snapshots=(2,3,4)
 first

--- a/testdata/compaction_iter_set_with_del
+++ b/testdata/compaction_iter_set_with_del
@@ -444,7 +444,7 @@ next
 tombstones
 ----
 a#3,15:c
-b#5,1:de[base]
+b#5,2:de
 d#5,2:bc
 d#3,15:f
 .
@@ -1101,8 +1101,7 @@ a#5,18:5[base]
 a#1,2:1
 .
 
-# Verify that we transform merge+rangedel -> set. This isn't strictly
-# necessary, but provides consistency with the behavior for merge+del.
+# Verify that merge+rangedel -> merge.
 
 define
 a.RANGEDEL.3:c
@@ -1117,7 +1116,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 .
 
 iter allow-zero-seqnum=true
@@ -1126,7 +1125,7 @@ next
 next
 ----
 a#3,15:c
-b#0,1:5[base]
+b#0,2:5
 .
 
 iter snapshots=2
@@ -1135,7 +1134,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 b#1,2:1
 
 define
@@ -1151,7 +1150,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 .
 
 iter snapshots=2
@@ -1160,7 +1159,7 @@ next
 next
 ----
 a#3,15:c
-b#5,1:5[base]
+b#5,2:5
 b#1,2:1
 
 # SET that meets a DEL is transformed into a SETWITHDEL.
@@ -1296,7 +1295,7 @@ next
 ----
 a#3,1:c
 a#2,15:z
-a#0,18:b
+a#0,1:b
 .
 
 iter allow-zero-seqnum=true snapshots=2


### PR DESCRIPTION
(clean) Backport of https://github.com/cockroachdb/pebble/pull/3118, https://github.com/cockroachdb/pebble/pull/3143, https://github.com/cockroachdb/pebble/pull/3153

The first PR is needed since the latter PRs include the MERGE case. The MERGE + SINGLEDEL is not exercised in CockroachDB.

Informs https://github.com/cockroachdb/cockroach/issues/115881