### PR TITLE
crl-release-23.1: Makefile: update crossversion-meta to test 22.2 -> 23.1 only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ GOFLAGS :=
 STRESSFLAGS :=
 TAGS := invariants
 TESTS := .
-LATEST_RELEASE := $(shell git fetch origin && git branch -r --list '*/crl-release-*' | grep -o 'crl-release-.*$$' | sort | tail -1)
 
 .PHONY: all
 all:
@@ -51,11 +50,11 @@ stressmeta: stress
 
 .PHONY: crossversion-meta
 crossversion-meta:
-	git checkout ${LATEST_RELEASE}; \
-		${GO} test -c ./internal/metamorphic -o './internal/metamorphic/crossversion/${LATEST_RELEASE}.test'; \
+	git checkout crl-release-22.2; \
+		${GO} test -c ./internal/metamorphic -o './internal/metamorphic/crossversion/crl-release-22.2.test'; \
 		git checkout -; \
 		${GO} test -c ./internal/metamorphic -o './internal/metamorphic/crossversion/head.test'; \
-		${GO} test -tags '$(TAGS)' ${testflags} -v -run 'TestMetaCrossVersion' ./internal/metamorphic/crossversion --version '${LATEST_RELEASE},${LATEST_RELEASE},${LATEST_RELEASE}.test' --version 'HEAD,HEAD,./head.test'
+		${GO} test -tags '$(TAGS)' ${testflags} -v -run 'TestMetaCrossVersion' ./internal/metamorphic/crossversion --version 'crl-release-22.2,22.2,crl-release-22.2.test' --version 'HEAD,HEAD,./head.test'
 
 .PHONY: stress-crossversion
 stress-crossversion:


### PR DESCRIPTION
Previously the `crossversion-meta` target would test 23.2 -> 23.1 (moving back releases) because it always used the latest release. Update the Makefile to always test 22.2 -> 23.1 on the 23.1 release branch.