### PR TITLE
crl-release-23.2: Makefile: update crossversion-meta to test 23.1 -> 23.2 only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOFLAGS :=
 STRESSFLAGS :=
 TAGS := invariants
 TESTS := .
-LATEST_RELEASE := $(shell git fetch origin && git branch -r --list '*/crl-release-*' | grep -o 'crl-release-.*$$' | sort | tail -1)
+PREV_RELEASE := crl-release-23.1
 COVER_PROFILE := coverprofile.out
 
 .PHONY: all
@@ -63,11 +63,11 @@ stressmeta: stress
 
 .PHONY: crossversion-meta
 crossversion-meta:
-	git checkout ${LATEST_RELEASE}; \
-		${GO} test -c ./internal/metamorphic -o './internal/metamorphic/crossversion/${LATEST_RELEASE}.test'; \
+	git checkout ${PREV_RELEASE}; \
+		${GO} test -c ./internal/metamorphic -o './internal/metamorphic/crossversion/${PREV_RELEASE}.test'; \
 		git checkout -; \
 		${GO} test -c ./internal/metamorphic -o './internal/metamorphic/crossversion/head.test'; \
-		${GO} test -tags '$(TAGS)' ${testflags} -v -run 'TestMetaCrossVersion' ./internal/metamorphic/crossversion --version '${LATEST_RELEASE},${LATEST_RELEASE},${LATEST_RELEASE}.test' --version 'HEAD,HEAD,./head.test'
+		${GO} test -tags '$(TAGS)' ${testflags} -v -run 'TestMetaCrossVersion' ./internal/metamorphic/crossversion --version '${PREV_RELEASE},${PREV_RELEASE},${PREV_RELEASE}.test' --version 'HEAD,HEAD,./head.test'
 
 .PHONY: stress-crossversion
 stress-crossversion:


### PR DESCRIPTION
Previously the `crossversion-meta` target would test 23.2 -> 23.2 (moving laterally) because it always used the latest release. Update the Makefile to always test 23.1 -> 23.2 on the 23.2 release branch.