### PR TITLE
sstable: add NewPrefixReplacingIterator

### DIFF
--- a/format_major_version.go
+++ b/format_major_version.go
@@ -178,6 +178,13 @@ const (
 	// a format major version.
 	FormatVirtualSSTables
 
+	// FormatSyntheticPrefixes is a format major version that adds support for
+	// sstables to have their content exposed in a different prefix of keyspace
+	// than the actual prefix persisted in the keys in such sstables. The prefix
+	// replacement information is stored in new fields in the Manifest and thus
+	// requires a format major version.
+	FormatSyntheticPrefixes
+
 	// -- Add new versions here --
 
 	// FormatNewest is the most recent format major version.
@@ -209,7 +216,7 @@ func (v FormatMajorVersion) MaxTableFormat() sstable.TableFormat {
 	switch v {
 	case FormatDefault, FormatFlushableIngest, FormatPrePebblev1MarkedCompacted:
 		return sstable.TableFormatPebblev3
-	case FormatDeleteSizedAndObsolete, FormatVirtualSSTables:
+	case FormatDeleteSizedAndObsolete, FormatVirtualSSTables, FormatSyntheticPrefixes:
 		return sstable.TableFormatPebblev4
 	default:
 		panic(fmt.Sprintf("pebble: unsupported format major version: %s", v))
@@ -221,7 +228,7 @@ func (v FormatMajorVersion) MaxTableFormat() sstable.TableFormat {
 func (v FormatMajorVersion) MinTableFormat() sstable.TableFormat {
 	switch v {
 	case FormatDefault, FormatFlushableIngest, FormatPrePebblev1MarkedCompacted,
-		FormatDeleteSizedAndObsolete, FormatVirtualSSTables:
+		FormatDeleteSizedAndObsolete, FormatVirtualSSTables, FormatSyntheticPrefixes:
 		return sstable.TableFormatPebblev1
 	default:
 		panic(fmt.Sprintf("pebble: unsupported format major version: %s", v))
@@ -254,6 +261,9 @@ var formatMajorVersionMigrations = map[FormatMajorVersion]func(*DB) error{
 	},
 	FormatVirtualSSTables: func(d *DB) error {
 		return d.finalizeFormatVersUpgrade(FormatVirtualSSTables)
+	},
+	FormatSyntheticPrefixes: func(d *DB) error {
+		return d.finalizeFormatVersUpgrade(FormatSyntheticPrefixes)
 	},
 }
 

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -23,11 +23,12 @@ func TestFormatMajorVersionStableValues(t *testing.T) {
 	require.Equal(t, FormatPrePebblev1MarkedCompacted, FormatMajorVersion(14))
 	require.Equal(t, FormatDeleteSizedAndObsolete, FormatMajorVersion(15))
 	require.Equal(t, FormatVirtualSSTables, FormatMajorVersion(16))
+	require.Equal(t, FormatSyntheticPrefixes, FormatMajorVersion(17))
 
 	// When we add a new version, we should add a check for the new version in
 	// addition to updating these expected values.
-	require.Equal(t, FormatNewest, FormatMajorVersion(16))
-	require.Equal(t, internalFormatNewest, FormatMajorVersion(16))
+	require.Equal(t, FormatNewest, FormatMajorVersion(17))
+	require.Equal(t, internalFormatNewest, FormatMajorVersion(17))
 }
 
 func TestFormatMajorVersion_MigrationDefined(t *testing.T) {
@@ -50,6 +51,8 @@ func TestRatchetFormat(t *testing.T) {
 	require.Equal(t, FormatDeleteSizedAndObsolete, d.FormatMajorVersion())
 	require.NoError(t, d.RatchetFormatMajorVersion(FormatVirtualSSTables))
 	require.Equal(t, FormatVirtualSSTables, d.FormatMajorVersion())
+	require.NoError(t, d.RatchetFormatMajorVersion(FormatSyntheticPrefixes))
+	require.Equal(t, FormatSyntheticPrefixes, d.FormatMajorVersion())
 
 	require.NoError(t, d.Close())
 
@@ -203,6 +206,7 @@ func TestFormatMajorVersions_TableFormat(t *testing.T) {
 		FormatPrePebblev1MarkedCompacted: {sstable.TableFormatPebblev1, sstable.TableFormatPebblev3},
 		FormatDeleteSizedAndObsolete:     {sstable.TableFormatPebblev1, sstable.TableFormatPebblev4},
 		FormatVirtualSSTables:            {sstable.TableFormatPebblev1, sstable.TableFormatPebblev4},
+		FormatSyntheticPrefixes:          {sstable.TableFormatPebblev1, sstable.TableFormatPebblev4},
 	}
 
 	// Valid versions.

--- a/ingest.go
+++ b/ingest.go
@@ -214,6 +214,13 @@ func ingestLoad1External(
 	// what parts of this sstable are referenced by other nodes.
 	meta.FileBacking.Size = e.Size
 
+	if len(e.SyntheticPrefix) != 0 {
+		meta.PrefixReplacement = &manifest.PrefixReplacement{
+			ContentPrefix:   e.ContentPrefix,
+			SyntheticPrefix: e.SyntheticPrefix,
+		}
+	}
+
 	if err := meta.Validate(opts.Comparer.Compare, opts.Comparer.FormatKey); err != nil {
 		return nil, err
 	}
@@ -1112,6 +1119,11 @@ type ExternalFile struct {
 	// or range keys. If both structs are false, an error is returned during
 	// ingestion.
 	HasPointKey, HasRangeKey bool
+	// ContentPrefix and SyntheticPrefix denote a prefix replacement rule causing
+	// a file, in which all keys have prefix ContentPrefix, to appear whenever it
+	// is accessed as if those keys all instead have prefix SyntheticPrefix.
+	// SyntheticPrefix must be a prefix of both SmallestUserKey and LargestUserKey.
+	ContentPrefix, SyntheticPrefix []byte
 }
 
 // IngestWithStats does the same as Ingest, and additionally returns

--- a/ingest.go
+++ b/ingest.go
@@ -1308,6 +1308,13 @@ func (d *DB) ingest(
 	if (exciseSpan.Valid() || len(shared) > 0 || len(external) > 0) && d.FormatMajorVersion() < FormatVirtualSSTables {
 		return IngestOperationStats{}, errors.New("pebble: format major version too old for excise, shared or external sstable ingestion")
 	}
+	if len(external) > 0 && d.FormatMajorVersion() < FormatSyntheticPrefixes {
+		for i := range external {
+			if len(external[i].SyntheticPrefix) > 0 {
+				return IngestOperationStats{}, errors.New("pebble: format major version too old for synthetic prefix ingestion")
+			}
+		}
+	}
 	// Allocate file numbers for all of the files being ingested and mark them as
 	// pending in order to prevent them from being deleted. Note that this causes
 	// the file number ordering to be out of alignment with sequence number

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1718,7 +1718,7 @@ func TestIngestExternal(t *testing.T) {
 			EventListener: &EventListener{FlushEnd: func(info FlushInfo) {
 				flushed = true
 			}},
-			FormatMajorVersion: FormatVirtualSSTables,
+			FormatMajorVersion: FormatNewest,
 		}
 		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"external-locator": remoteStorage,

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -280,6 +280,26 @@ type PrefixReplacement struct {
 	ContentPrefix, SyntheticPrefix []byte
 }
 
+// ReplaceArg replaces the new prefix in the argument with the original prefix.
+func (p *PrefixReplacement) ReplaceArg(src []byte) []byte {
+	return p.replace(src, p.SyntheticPrefix, p.ContentPrefix)
+}
+
+// ReplaceResult replaces the original prefix in the result with the new prefix.
+func (p *PrefixReplacement) ReplaceResult(key []byte) []byte {
+	return p.replace(key, p.ContentPrefix, p.SyntheticPrefix)
+}
+
+func (p *PrefixReplacement) replace(key, from, to []byte) []byte {
+	if !bytes.HasPrefix(key, from) {
+		panic(fmt.Sprintf("unexpected prefix in replace: %s", key))
+	}
+	result := make([]byte, 0, len(to)+(len(key)-len(from)))
+	result = append(result, to...)
+	result = append(result, key[len(from):]...)
+	return result
+}
+
 // PhysicalFileMeta is used by functions which want a guarantee that their input
 // belongs to a physical sst and not a virtual sst.
 //

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -269,6 +269,15 @@ type FileMetadata struct {
 	boundTypeSmallest, boundTypeLargest boundType
 	// Virtual is true if the FileMetadata belongs to a virtual sstable.
 	Virtual bool
+
+	// PrefixReplacement is used for virtual files where the backing file has a
+	// different prefix on its keys than the span in which it is being exposed.
+	PrefixReplacement *PrefixReplacement
+}
+
+// PrefixReplacement represents a read-time replacement of a key prefix.
+type PrefixReplacement struct {
+	ContentPrefix, SyntheticPrefix []byte
 }
 
 // PhysicalFileMeta is used by functions which want a guarantee that their input
@@ -849,6 +858,18 @@ func (m *FileMetadata) Validate(cmp Compare, formatKey base.FormatKey) error {
 	// Ensure that FileMetadata.Init was called.
 	if m.FileBacking == nil {
 		return base.CorruptionErrorf("file metadata FileBacking not set")
+	}
+
+	if m.PrefixReplacement != nil {
+		if !m.Virtual {
+			return base.CorruptionErrorf("prefix replacement rule set with non-virtual file")
+		}
+		if !bytes.HasPrefix(m.Smallest.UserKey, m.PrefixReplacement.SyntheticPrefix) {
+			return base.CorruptionErrorf("virtual file with prefix replacement rules has smallest key with a different prefix: %s", m.Smallest.Pretty(formatKey))
+		}
+		if !bytes.HasPrefix(m.Largest.UserKey, m.PrefixReplacement.SyntheticPrefix) {
+			return base.CorruptionErrorf("virtual file with prefix replacement rules has largest key with a different prefix: %s", m.Largest.Pretty(formatKey))
+		}
 	}
 
 	return nil

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -63,6 +63,7 @@ const (
 	customTagPathID            = 65
 	customTagNonSafeIgnoreMask = 1 << 6
 	customTagVirtual           = 66
+	customTagPrefixRewrite     = 67
 )
 
 // DeletedFileEntry holds the state for a file deletion from a level. The file
@@ -336,6 +337,7 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 				virtual        bool
 				backingFileNum uint64
 			}{}
+			var virtualPrefix *PrefixReplacement
 			if tag == tagNewFile4 || tag == tagNewFile5 {
 				for {
 					customTag, err := d.readUvarint()
@@ -351,6 +353,20 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 							return err
 						}
 						virtualState.backingFileNum = n
+						continue
+					} else if customTag == customTagPrefixRewrite {
+						content, err := d.readBytes()
+						if err != nil {
+							return err
+						}
+						synthetic, err := d.readBytes()
+						if err != nil {
+							return err
+						}
+						virtualPrefix = &PrefixReplacement{
+							ContentPrefix:   content,
+							SyntheticPrefix: synthetic,
+						}
 						continue
 					}
 
@@ -390,6 +406,7 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 				LargestSeqNum:       largestSeqNum,
 				MarkedForCompaction: markedForCompaction,
 				Virtual:             virtualState.virtual,
+				PrefixReplacement:   virtualPrefix,
 			}
 			if tag != tagNewFile5 { // no range keys present
 				m.SmallestPointKey = base.DecodeInternalKey(smallestPointKey)
@@ -605,6 +622,11 @@ func (v *VersionEdit) Encode(w io.Writer) error {
 			if x.Meta.Virtual {
 				e.writeUvarint(customTagVirtual)
 				e.writeUvarint(uint64(x.Meta.FileBacking.DiskFileNum.FileNum()))
+			}
+			if x.Meta.PrefixReplacement != nil {
+				e.writeUvarint(customTagPrefixRewrite)
+				e.writeBytes(x.Meta.PrefixReplacement.ContentPrefix)
+				e.writeBytes(x.Meta.PrefixReplacement.SyntheticPrefix)
 			}
 			e.writeUvarint(customTagTerminate)
 		}

--- a/open_test.go
+++ b/open_test.go
@@ -193,7 +193,7 @@ func TestNewDBFilenames(t *testing.T) {
 			"LOCK",
 			"MANIFEST-000001",
 			"OPTIONS-000003",
-			"marker.format-version.000003.016",
+			"marker.format-version.000004.017",
 			"marker.manifest.000001.MANIFEST-000001",
 		},
 	}

--- a/sstable/prefix_replacing_iterator.go
+++ b/sstable/prefix_replacing_iterator.go
@@ -159,7 +159,7 @@ func (p *prefixReplacingIterator) SetBounds(lower, upper []byte) {
 	// Check if the underlying iterator requires un-rewritten bounds, i.e. if it
 	// is going to rewrite them itself or pass them to something e.g. vState that
 	// will rewrite them.
-	if x, ok := p.i.(interface{ SetBoundsWithVirtualPrefix() bool }); ok && x.SetBoundsWithVirtualPrefix() {
+	if x, ok := p.i.(interface{ SetBoundsWithSyntheticPrefix() bool }); ok && x.SetBoundsWithSyntheticPrefix() {
 		p.i.SetBounds(lower, upper)
 		return
 	}
@@ -221,9 +221,6 @@ func (p *prefixReplacingFragmentIterator) rewriteSpan(sp *keyspan.Span) *keyspan
 	}
 	sp.Start = append(p.out1[:len(p.dst)], sp.Start[len(p.src):]...)
 	sp.End = append(p.out2[:len(p.dst)], sp.End[len(p.src):]...)
-
-	// TODO(dt): RESOLVE DURING CODE REVIEW
-	// do I need to touch sp.Keys? is sp.Start/End actually assured to both have dst prefix?
 	return sp
 }
 

--- a/sstable/prefix_replacing_iterator.go
+++ b/sstable/prefix_replacing_iterator.go
@@ -187,9 +187,6 @@ type prefixReplacingFragmentIterator struct {
 	out1, out2 []byte
 }
 
-// TODO(dt): wire this up.
-var _ = newPrefixReplacingFragmentIterator
-
 // newPrefixReplacingFragmentIterator wraps a FragmentIterator over some reader
 // that contains range keys in some key span to make those range keys appear to
 // be remapped into some other key-span.

--- a/sstable/prefix_replacing_iterator.go
+++ b/sstable/prefix_replacing_iterator.go
@@ -1,0 +1,271 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/internal/keyspan"
+)
+
+type prefixReplacingIterator struct {
+	i         Iterator
+	cmp       base.Compare
+	src, dst  []byte
+	arg, arg2 []byte
+	res       InternalKey
+	err       error
+}
+
+var errInputPrefixMismatch = errors.New("key argument does not have prefix required for replacement")
+var errOutputPrefixMismatch = errors.New("key returned does not have prefix required for replacement")
+
+var _ Iterator = (*prefixReplacingIterator)(nil)
+
+// newPrefixReplacingIterator wraps an iterator over keys that have prefix `src`
+// in an iterator that will make them appear to have prefix `dst`. Every key
+// passed as an argument to methods on this iterator must have prefix `dst`, and
+// every key produced by the underlying iterator must have prefix `src`.
+//
+// INVARIANT: len(dst) > 0.
+func newPrefixReplacingIterator(i Iterator, src, dst []byte, cmp base.Compare) Iterator {
+	if invariants.Enabled && len(dst) == 0 {
+		panic("newPrefixReplacingIterator called without synthetic prefix")
+	}
+	return &prefixReplacingIterator{
+		i:   i,
+		cmp: cmp,
+		src: src, dst: dst,
+		arg: append([]byte{}, src...), arg2: append([]byte{}, src...),
+		res: InternalKey{UserKey: append([]byte{}, dst...)},
+	}
+}
+
+func (p *prefixReplacingIterator) SetContext(ctx context.Context) {
+	p.i.SetContext(ctx)
+}
+
+func (p *prefixReplacingIterator) rewriteArg(key []byte) []byte {
+	if !bytes.HasPrefix(key, p.dst) {
+		p.err = errInputPrefixMismatch
+		return key
+	}
+	p.arg = append(p.arg[:len(p.src)], key[len(p.dst):]...)
+	return p.arg
+}
+
+func (p *prefixReplacingIterator) rewriteArg2(key []byte) []byte {
+	if !bytes.HasPrefix(key, p.dst) {
+		p.err = errInputPrefixMismatch
+		return key
+	}
+	p.arg2 = append(p.arg2[:len(p.src)], key[len(p.dst):]...)
+	return p.arg2
+}
+
+func (p *prefixReplacingIterator) rewriteResult(
+	k *InternalKey, v base.LazyValue,
+) (*InternalKey, base.LazyValue) {
+	if k == nil {
+		return k, v
+	}
+	if !bytes.HasPrefix(k.UserKey, p.src) {
+		p.err = errOutputPrefixMismatch
+		if invariants.Enabled {
+			panic(p.err)
+		}
+		return nil, base.LazyValue{}
+	}
+	p.res.Trailer = k.Trailer
+	p.res.UserKey = append(p.res.UserKey[:len(p.dst)], k.UserKey[len(p.src):]...)
+	return &p.res, v
+}
+
+// SeekGE implements the Iterator interface.
+func (p *prefixReplacingIterator) SeekGE(
+	key []byte, flags base.SeekGEFlags,
+) (*InternalKey, base.LazyValue) {
+	return p.rewriteResult(p.i.SeekGE(p.rewriteArg(key), flags))
+}
+
+// SeekPrefixGE implements the Iterator interface.
+func (p *prefixReplacingIterator) SeekPrefixGE(
+	prefix, key []byte, flags base.SeekGEFlags,
+) (*InternalKey, base.LazyValue) {
+	return p.rewriteResult(p.i.SeekPrefixGE(p.rewriteArg2(prefix), p.rewriteArg(key), flags))
+}
+
+// SeekLT implements the Iterator interface.
+func (p *prefixReplacingIterator) SeekLT(
+	key []byte, flags base.SeekLTFlags,
+) (*InternalKey, base.LazyValue) {
+	cmp := p.cmp(key, p.dst)
+	if cmp < 0 {
+		// Exhaust the iterator by Prev()ing before the First key.
+		p.i.First()
+		return p.rewriteResult(p.i.Prev())
+	}
+	return p.rewriteResult(p.i.SeekLT(p.rewriteArg(key), flags))
+}
+
+// First implements the Iterator interface.
+func (p *prefixReplacingIterator) First() (*InternalKey, base.LazyValue) {
+	return p.rewriteResult(p.i.First())
+}
+
+// Last implements the Iterator interface.
+func (p *prefixReplacingIterator) Last() (*InternalKey, base.LazyValue) {
+	return p.rewriteResult(p.i.Last())
+}
+
+// Next implements the Iterator interface.
+func (p *prefixReplacingIterator) Next() (*InternalKey, base.LazyValue) {
+	return p.rewriteResult(p.i.Next())
+}
+
+// NextPrefix implements the Iterator interface.
+func (p *prefixReplacingIterator) NextPrefix(succKey []byte) (*InternalKey, base.LazyValue) {
+	return p.rewriteResult(p.i.NextPrefix(p.rewriteArg(succKey)))
+}
+
+// Prev implements the Iterator interface.
+func (p *prefixReplacingIterator) Prev() (*InternalKey, base.LazyValue) {
+	return p.rewriteResult(p.i.Prev())
+}
+
+// Error implements the Iterator interface.
+func (p *prefixReplacingIterator) Error() error {
+	if p.err != nil {
+		return p.err
+	}
+	return p.i.Error()
+}
+
+// Close implements the Iterator interface.
+func (p *prefixReplacingIterator) Close() error {
+	return p.i.Close()
+}
+
+// SetBounds implements the Iterator interface.
+func (p *prefixReplacingIterator) SetBounds(lower, upper []byte) {
+	// Check if the underlying iterator requires un-rewritten bounds, i.e. if it
+	// is going to rewrite them itself or pass them to something e.g. vState that
+	// will rewrite them.
+	if x, ok := p.i.(interface{ SetBoundsWithVirtualPrefix() bool }); ok && x.SetBoundsWithVirtualPrefix() {
+		p.i.SetBounds(lower, upper)
+		return
+	}
+	p.i.SetBounds(p.rewriteArg(lower), p.rewriteArg2(upper))
+}
+
+func (p *prefixReplacingIterator) MaybeFilteredKeys() bool {
+	return p.i.MaybeFilteredKeys()
+}
+
+// String implements the Iterator interface.
+func (p *prefixReplacingIterator) String() string {
+	return fmt.Sprintf("%s [%s->%s]", p.i.String(), hex.EncodeToString(p.src), hex.EncodeToString(p.dst))
+}
+
+func (p *prefixReplacingIterator) SetCloseHook(fn func(i Iterator) error) {
+	p.i.SetCloseHook(fn)
+}
+
+type prefixReplacingFragmentIterator struct {
+	i          keyspan.FragmentIterator
+	err        error
+	src, dst   []byte
+	arg        []byte
+	out1, out2 []byte
+}
+
+// TODO(dt): wire this up.
+var _ = newPrefixReplacingFragmentIterator
+
+// newPrefixReplacingFragmentIterator wraps a FragmentIterator over some reader
+// that contains range keys in some key span to make those range keys appear to
+// be remapped into some other key-span.
+func newPrefixReplacingFragmentIterator(
+	i keyspan.FragmentIterator, src, dst []byte,
+) keyspan.FragmentIterator {
+	return &prefixReplacingFragmentIterator{
+		i:   i,
+		src: src, dst: dst,
+		arg:  append([]byte{}, src...),
+		out1: append([]byte(nil), dst...),
+		out2: append([]byte(nil), dst...),
+	}
+}
+
+func (p *prefixReplacingFragmentIterator) rewriteArg(key []byte) []byte {
+	if !bytes.HasPrefix(key, p.dst) {
+		p.err = errInputPrefixMismatch
+		return key
+	}
+	p.arg = append(p.arg[:len(p.src)], key[len(p.dst):]...)
+	return p.arg
+}
+
+func (p *prefixReplacingFragmentIterator) rewriteSpan(sp *keyspan.Span) *keyspan.Span {
+	if !bytes.HasPrefix(sp.Start, p.src) || !bytes.HasPrefix(sp.End, p.src) {
+		p.err = errInputPrefixMismatch
+		return sp
+	}
+	sp.Start = append(p.out1[:len(p.dst)], sp.Start[len(p.src):]...)
+	sp.End = append(p.out2[:len(p.dst)], sp.End[len(p.src):]...)
+
+	// TODO(dt): RESOLVE DURING CODE REVIEW
+	// do I need to touch sp.Keys? is sp.Start/End actually assured to both have dst prefix?
+	return sp
+}
+
+// SeekGE implements the FragmentIterator interface.
+func (p *prefixReplacingFragmentIterator) SeekGE(key []byte) *keyspan.Span {
+	return p.rewriteSpan(p.i.SeekGE(p.rewriteArg(key)))
+}
+
+// SeekLT implements the FragmentIterator interface.
+func (p *prefixReplacingFragmentIterator) SeekLT(key []byte) *keyspan.Span {
+	return p.rewriteSpan(p.i.SeekLT(p.rewriteArg(key)))
+}
+
+// First implements the FragmentIterator interface.
+func (p *prefixReplacingFragmentIterator) First() *keyspan.Span {
+	return p.rewriteSpan(p.i.First())
+}
+
+// Last implements the FragmentIterator interface.
+func (p *prefixReplacingFragmentIterator) Last() *keyspan.Span {
+	return p.rewriteSpan(p.i.Last())
+}
+
+// Close implements the FragmentIterator interface.
+func (p *prefixReplacingFragmentIterator) Next() *keyspan.Span {
+	return p.rewriteSpan(p.i.Next())
+}
+
+// Prev implements the FragmentIterator interface.
+func (p *prefixReplacingFragmentIterator) Prev() *keyspan.Span {
+	return p.rewriteSpan(p.i.Prev())
+}
+
+// Error implements the FragmentIterator interface.
+func (p *prefixReplacingFragmentIterator) Error() error {
+	if p.err != nil {
+		return p.err
+	}
+	return p.i.Error()
+}
+
+// Close implements the FragmentIterator interface.
+func (p *prefixReplacingFragmentIterator) Close() error {
+	return p.i.Close()
+}

--- a/sstable/prefix_replacing_iterator_test.go
+++ b/sstable/prefix_replacing_iterator_test.go
@@ -1,0 +1,144 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrefixReplacingIterator(t *testing.T) {
+	for _, tc := range []struct{ from, to []byte }{
+		{from: []byte(""), to: []byte("bb")},
+		{from: []byte("aa"), to: []byte("aa")},
+		{from: []byte("aa"), to: []byte("bb")},
+		{from: []byte("bb"), to: []byte("aa")},
+		{from: []byte("aa"), to: []byte("zzz")},
+		{from: []byte("zzz"), to: []byte("aa")},
+	} {
+		t.Run(fmt.Sprintf("%s_%s", tc.from, tc.to), func(t *testing.T) {
+			r := buildTestTable(t, 20, 256, 256, DefaultCompression, tc.from)
+			defer r.Close()
+			rawIter, err := r.NewIter(nil, nil)
+			require.NoError(t, err)
+			defer rawIter.Close()
+
+			raw := rawIter.(*singleLevelIterator)
+
+			it := newPrefixReplacingIterator(raw, tc.from, tc.to, DefaultComparer.Compare)
+
+			kMin, kMax, k := []byte{0}, []byte("~"), func(i uint64) []byte {
+				return binary.BigEndian.AppendUint64(tc.to[:len(tc.to):len(tc.to)], i)
+			}
+
+			var got *base.InternalKey
+
+			t.Run("FirstNextLast", func(t *testing.T) {
+				got, _ = it.First()
+				require.Equal(t, k(0), got.UserKey)
+				got, _ = it.Next()
+				require.Equal(t, k(1), got.UserKey)
+				got, _ = it.Next()
+				require.Equal(t, k(2), got.UserKey)
+				got, _ = it.Prev()
+				require.Equal(t, k(1), got.UserKey)
+				got, _ = it.Last()
+				require.Equal(t, k(19), got.UserKey)
+			})
+
+			t.Run("Sets", func(t *testing.T) {
+				it.SetBounds(k(5), k(15))
+				defer it.SetBounds(nil, nil)
+
+				got, _ = it.SeekGE(k(16), base.SeekGEFlagsNone)
+				require.Nil(t, got)
+
+				got, _ = it.SeekGE(k(14), base.SeekGEFlagsNone)
+				require.Equal(t, k(14), got.UserKey)
+
+				got, _ = it.SeekLT(k(100), base.SeekLTFlagsNone)
+				// TODO(dt): Shouldn't this be upper-1? why is it nil?
+				// i.e. require.Equal(t, k(14), got.UserKey) ?
+				require.Nil(t, got)
+			})
+
+			t.Run("SetHookAndCtx", func(t *testing.T) {
+				it.SetCloseHook(func(i Iterator) error { return nil })
+				require.NotNil(t, raw.closeHook)
+				it.SetCloseHook(nil)
+				require.Nil(t, raw.closeHook)
+
+				require.Equal(t, context.Background(), raw.ctx)
+				ctx := context.WithValue(context.Background(), struct{}{}, "")
+				it.SetContext(ctx)
+				require.Equal(t, ctx, raw.ctx)
+				it.SetContext(context.Background())
+				require.Equal(t, context.Background(), raw.ctx)
+			})
+
+			t.Run("SeekGE", func(t *testing.T) {
+				got, _ = it.SeekGE(kMin, base.SeekGEFlagsNone)
+				require.Equal(t, k(0), got.UserKey)
+
+				got, _ = it.SeekGE(k(0), base.SeekGEFlagsNone)
+				require.Equal(t, k(0), got.UserKey)
+
+				got, _ = it.SeekGE(k(10), base.SeekGEFlagsNone)
+				require.Equal(t, k(10), got.UserKey)
+
+				got, _ = it.SeekGE(k(100), base.SeekGEFlagsNone)
+				require.Nil(t, got)
+
+				got, _ = it.SeekGE(kMax, base.SeekGEFlagsNone)
+				require.Nil(t, got)
+			})
+
+			t.Run("SeekPrefixGE", func(t *testing.T) {
+				got, _ = it.SeekPrefixGE(tc.to, kMin, base.SeekGEFlagsNone)
+				require.Equal(t, k(0), got.UserKey)
+
+				got, _ = it.SeekPrefixGE(tc.to, k(0), base.SeekGEFlagsNone)
+				require.Equal(t, k(0), got.UserKey)
+
+				got, _ = it.SeekPrefixGE(tc.to, k(10), base.SeekGEFlagsNone)
+				require.Equal(t, k(10), got.UserKey)
+
+				got, _ = it.Next()
+				require.Equal(t, k(11), got.UserKey)
+
+				got, _ = it.SeekPrefixGE(tc.to, k(100), base.SeekGEFlagsNone)
+				require.Nil(t, got)
+
+				got, _ = it.SeekPrefixGE(tc.to, kMax, base.SeekGEFlagsNone)
+				require.Nil(t, got)
+			})
+
+			t.Run("SeekLT", func(t *testing.T) {
+				got, _ = it.SeekLT(kMin, base.SeekLTFlagsNone)
+				require.Nil(t, got)
+
+				got, _ = it.SeekLT(k(0), base.SeekLTFlagsNone)
+				require.Nil(t, got)
+
+				got, _ = it.SeekLT(k(10), base.SeekLTFlagsNone)
+				require.Equal(t, k(9), got.UserKey)
+
+				got, _ = it.Next()
+				require.Equal(t, k(10), got.UserKey)
+
+				got, _ = it.SeekLT(k(100), base.SeekLTFlagsNone)
+				require.Equal(t, k(19), got.UserKey)
+
+				got, _ = it.SeekLT(kMax, base.SeekLTFlagsNone)
+				require.Equal(t, k(19), got.UserKey)
+			})
+		})
+	}
+}

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -321,6 +321,23 @@ func disableBoundsOpt(bound []byte, ptr uintptr) bool {
 // state and require this behavior to be deterministic.
 var ensureBoundsOptDeterminism bool
 
+// SetBoundsWithSyntheticPrefix indicates whether this iterator requires keys
+// passed to its SetBounds() method by a prefix rewriting wrapper to be *not*
+// rewritten to be in terms of this iterator's content, but instead be passed
+// as-is, i.e. with the synthetic prefix still on them.
+//
+// This allows an optimization when this iterator is passing these bounds on to
+// a vState to additionally constrain them. In said vState, passed bounds are
+// combined with the vState bounds which are in terms of the rewritten prefix.
+// If the caller rewrote bounds to be in terms of content prefix and SetBounds
+// passed those to vState, the vState would need to *un*rewrite them back to the
+// synthetic prefix in order to combine them with the vState bounds. Thus, if
+// this iterator knows bounds will be passed to vState, it can signal that it
+// they should be passed without being rewritten to skip converting to and fro.
+func (i singleLevelIterator) SetBoundsWithSyntheticPrefix() bool {
+	return i.vState != nil
+}
+
 // SetBounds implements internalIterator.SetBounds, as documented in the pebble
 // package. Note that the upper field is exclusive.
 func (i *singleLevelIterator) SetBounds(lower, upper []byte) {

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -944,7 +944,7 @@ func testBytesIteratedWithCompression(
 	for i, blockSize := range blockSizes {
 		for _, indexBlockSize := range blockSizes {
 			for _, numEntries := range []uint64{0, 1, maxNumEntries[i]} {
-				r := buildTestTable(t, numEntries, blockSize, indexBlockSize, compression)
+				r := buildTestTable(t, numEntries, blockSize, indexBlockSize, compression, nil)
 				var bytesIterated, prevIterated uint64
 				var pool BufferPool
 				pool.Init(5)
@@ -1002,7 +1002,7 @@ func TestCompactionIteratorSetupForCompaction(t *testing.T) {
 	for _, blockSize := range blockSizes {
 		for _, indexBlockSize := range blockSizes {
 			for _, numEntries := range []uint64{0, 1, 1e5} {
-				r := buildTestTableWithProvider(t, provider, numEntries, blockSize, indexBlockSize, DefaultCompression)
+				r := buildTestTableWithProvider(t, provider, numEntries, blockSize, indexBlockSize, DefaultCompression, nil)
 				var bytesIterated uint64
 				var pool BufferPool
 				pool.Init(5)
@@ -1393,12 +1393,12 @@ func TestReader_TableFormat(t *testing.T) {
 }
 
 func buildTestTable(
-	t *testing.T, numEntries uint64, blockSize, indexBlockSize int, compression Compression,
+	t *testing.T, numEntries uint64, blockSize, indexBlockSize int, compression Compression, prefix []byte,
 ) *Reader {
 	provider, err := objstorageprovider.Open(objstorageprovider.DefaultSettings(vfs.NewMem(), "" /* dirName */))
 	require.NoError(t, err)
 	defer provider.Close()
-	return buildTestTableWithProvider(t, provider, numEntries, blockSize, indexBlockSize, compression)
+	return buildTestTableWithProvider(t, provider, numEntries, blockSize, indexBlockSize, compression, prefix)
 }
 
 func buildTestTableWithProvider(
@@ -1407,6 +1407,7 @@ func buildTestTableWithProvider(
 	numEntries uint64,
 	blockSize, indexBlockSize int,
 	compression Compression,
+	prefix []byte,
 ) *Reader {
 	f0, _, err := provider.Create(context.Background(), base.FileTypeTable, base.FileNum(0).DiskFileNum(), objstorage.CreateOptions{})
 	require.NoError(t, err)
@@ -1420,9 +1421,10 @@ func buildTestTableWithProvider(
 
 	var ikey InternalKey
 	for i := uint64(0); i < numEntries; i++ {
-		key := make([]byte, 8+i%3)
+		key := make([]byte, len(prefix), uint64(len(prefix))+8+i%3)
+		copy(key, prefix)
 		value := make([]byte, i%100)
-		binary.BigEndian.PutUint64(key, i)
+		key = binary.BigEndian.AppendUint64(key, i)
 		ikey.UserKey = key
 		w.Add(ikey, value)
 	}

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -1393,7 +1393,11 @@ func TestReader_TableFormat(t *testing.T) {
 }
 
 func buildTestTable(
-	t *testing.T, numEntries uint64, blockSize, indexBlockSize int, compression Compression, prefix []byte,
+	t *testing.T,
+	numEntries uint64,
+	blockSize, indexBlockSize int,
+	compression Compression,
+	prefix []byte,
 ) *Reader {
 	provider, err := objstorageprovider.Open(objstorageprovider.DefaultSettings(vfs.NewMem(), "" /* dirName */))
 	require.NoError(t, err)

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -25,6 +25,10 @@ create: db/marker.format-version.000003.016
 close: db/marker.format-version.000003.016
 remove: db/marker.format-version.000002.015
 sync: db
+create: db/marker.format-version.000004.017
+close: db/marker.format-version.000004.017
+remove: db/marker.format-version.000003.016
+sync: db
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -87,9 +91,9 @@ close:
 open-dir: checkpoints/checkpoint1
 link: db/OPTIONS-000003 -> checkpoints/checkpoint1/OPTIONS-000003
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.016
-sync-data: checkpoints/checkpoint1/marker.format-version.000001.016
-close: checkpoints/checkpoint1/marker.format-version.000001.016
+create: checkpoints/checkpoint1/marker.format-version.000001.017
+sync-data: checkpoints/checkpoint1/marker.format-version.000001.017
+close: checkpoints/checkpoint1/marker.format-version.000001.017
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 link: db/000005.sst -> checkpoints/checkpoint1/000005.sst
@@ -127,9 +131,9 @@ close: checkpoints
 open-dir: checkpoints/checkpoint2
 link: db/OPTIONS-000003 -> checkpoints/checkpoint2/OPTIONS-000003
 open-dir: checkpoints/checkpoint2
-create: checkpoints/checkpoint2/marker.format-version.000001.016
-sync-data: checkpoints/checkpoint2/marker.format-version.000001.016
-close: checkpoints/checkpoint2/marker.format-version.000001.016
+create: checkpoints/checkpoint2/marker.format-version.000001.017
+sync-data: checkpoints/checkpoint2/marker.format-version.000001.017
+close: checkpoints/checkpoint2/marker.format-version.000001.017
 sync: checkpoints/checkpoint2
 close: checkpoints/checkpoint2
 link: db/000007.sst -> checkpoints/checkpoint2/000007.sst
@@ -162,9 +166,9 @@ close: checkpoints
 open-dir: checkpoints/checkpoint3
 link: db/OPTIONS-000003 -> checkpoints/checkpoint3/OPTIONS-000003
 open-dir: checkpoints/checkpoint3
-create: checkpoints/checkpoint3/marker.format-version.000001.016
-sync-data: checkpoints/checkpoint3/marker.format-version.000001.016
-close: checkpoints/checkpoint3/marker.format-version.000001.016
+create: checkpoints/checkpoint3/marker.format-version.000001.017
+sync-data: checkpoints/checkpoint3/marker.format-version.000001.017
+close: checkpoints/checkpoint3/marker.format-version.000001.017
 sync: checkpoints/checkpoint3
 close: checkpoints/checkpoint3
 link: db/000005.sst -> checkpoints/checkpoint3/000005.sst
@@ -254,7 +258,7 @@ list db
 LOCK
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000003.016
+marker.format-version.000004.017
 marker.manifest.000001.MANIFEST-000001
 
 list checkpoints/checkpoint1
@@ -264,7 +268,7 @@ list checkpoints/checkpoint1
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.016
+marker.format-version.000001.017
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint1 readonly
@@ -329,7 +333,7 @@ list checkpoints/checkpoint2
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.016
+marker.format-version.000001.017
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint2 readonly
@@ -369,7 +373,7 @@ list checkpoints/checkpoint3
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.016
+marker.format-version.000001.017
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint3 readonly
@@ -481,9 +485,9 @@ close: checkpoints
 open-dir: checkpoints/checkpoint4
 link: db/OPTIONS-000003 -> checkpoints/checkpoint4/OPTIONS-000003
 open-dir: checkpoints/checkpoint4
-create: checkpoints/checkpoint4/marker.format-version.000001.016
-sync-data: checkpoints/checkpoint4/marker.format-version.000001.016
-close: checkpoints/checkpoint4/marker.format-version.000001.016
+create: checkpoints/checkpoint4/marker.format-version.000001.017
+sync-data: checkpoints/checkpoint4/marker.format-version.000001.017
+close: checkpoints/checkpoint4/marker.format-version.000001.017
 sync: checkpoints/checkpoint4
 close: checkpoints/checkpoint4
 link: db/000010.sst -> checkpoints/checkpoint4/000010.sst
@@ -569,7 +573,7 @@ list db
 LOCK
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000003.016
+marker.format-version.000004.017
 marker.manifest.000001.MANIFEST-000001
 
 
@@ -584,9 +588,9 @@ close: checkpoints
 open-dir: checkpoints/checkpoint5
 link: db/OPTIONS-000003 -> checkpoints/checkpoint5/OPTIONS-000003
 open-dir: checkpoints/checkpoint5
-create: checkpoints/checkpoint5/marker.format-version.000001.016
-sync-data: checkpoints/checkpoint5/marker.format-version.000001.016
-close: checkpoints/checkpoint5/marker.format-version.000001.016
+create: checkpoints/checkpoint5/marker.format-version.000001.017
+sync-data: checkpoints/checkpoint5/marker.format-version.000001.017
+close: checkpoints/checkpoint5/marker.format-version.000001.017
 sync: checkpoints/checkpoint5
 close: checkpoints/checkpoint5
 link: db/000010.sst -> checkpoints/checkpoint5/000010.sst
@@ -675,9 +679,9 @@ close: checkpoints
 open-dir: checkpoints/checkpoint6
 link: db/OPTIONS-000003 -> checkpoints/checkpoint6/OPTIONS-000003
 open-dir: checkpoints/checkpoint6
-create: checkpoints/checkpoint6/marker.format-version.000001.016
-sync-data: checkpoints/checkpoint6/marker.format-version.000001.016
-close: checkpoints/checkpoint6/marker.format-version.000001.016
+create: checkpoints/checkpoint6/marker.format-version.000001.017
+sync-data: checkpoints/checkpoint6/marker.format-version.000001.017
+close: checkpoints/checkpoint6/marker.format-version.000001.017
 sync: checkpoints/checkpoint6
 close: checkpoints/checkpoint6
 link: db/000011.sst -> checkpoints/checkpoint6/000011.sst

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -32,6 +32,11 @@ close: db/marker.format-version.000003.016
 remove: db/marker.format-version.000002.015
 sync: db
 upgraded to format version: 016
+create: db/marker.format-version.000004.017
+close: db/marker.format-version.000004.017
+remove: db/marker.format-version.000003.016
+sync: db
+upgraded to format version: 017
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -343,9 +348,9 @@ close:
 open-dir: checkpoint
 link: db/OPTIONS-000003 -> checkpoint/OPTIONS-000003
 open-dir: checkpoint
-create: checkpoint/marker.format-version.000001.016
-sync-data: checkpoint/marker.format-version.000001.016
-close: checkpoint/marker.format-version.000001.016
+create: checkpoint/marker.format-version.000001.017
+sync-data: checkpoint/marker.format-version.000001.017
+close: checkpoint/marker.format-version.000001.017
 sync: checkpoint
 close: checkpoint
 link: db/000013.sst -> checkpoint/000013.sst

--- a/testdata/flushable_ingest
+++ b/testdata/flushable_ingest
@@ -60,7 +60,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000003.016
+marker.format-version.000004.017
 marker.manifest.000001.MANIFEST-000001
 
 # Test basic WAL replay
@@ -81,7 +81,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000003.016
+marker.format-version.000004.017
 marker.manifest.000001.MANIFEST-000001
 
 open
@@ -389,7 +389,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000003.016
+marker.format-version.000004.017
 marker.manifest.000001.MANIFEST-000001
 
 close
@@ -409,7 +409,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000003.016
+marker.format-version.000004.017
 marker.manifest.000001.MANIFEST-000001
 
 open
@@ -441,7 +441,7 @@ MANIFEST-000001
 MANIFEST-000012
 OPTIONS-000013
 ext
-marker.format-version.000003.016
+marker.format-version.000004.017
 marker.manifest.000002.MANIFEST-000012
 
 # Make sure that the new mutable memtable can accept writes.
@@ -584,7 +584,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000003.016
+marker.format-version.000004.017
 marker.manifest.000001.MANIFEST-000001
 
 close
@@ -603,7 +603,7 @@ MANIFEST-000001
 OPTIONS-000003
 ext
 ext1
-marker.format-version.000003.016
+marker.format-version.000004.017
 marker.manifest.000001.MANIFEST-000001
 
 ignoreSyncs false

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -152,3 +152,40 @@ f: (foo, .)
 g: (foo, .)
 h: (foo, .)
 .
+
+build-remote f5
+set ef foo
+set eg foo
+set eh foo
+----
+
+ingest-external prefix-replace=(e,f)
+f5,10,ff,fi
+----
+
+iter
+first
+next
+next
+next
+next
+next
+next
+next
+next
+next
+next
+next
+----
+a: (foo, .)
+b: (bar, .)
+c: (foobarbaz, .)
+d: (haha, .)
+e: (something, .)
+f: (foo, .)
+ff: (foo, .)
+fg: (foo, .)
+fh: (foo, .)
+g: (foo, .)
+h: (foo, .)
+.


### PR DESCRIPTION
These changes allow ingesting an sstable that contains keys that all have some prefix `old` as if it actually had been built with all of those keys with prefix `new`. This is done by changing "new" to "old" in the arguments to interactions with this sstable, and then changing "old" to "new" in the results of those interactions. 

There are plenty of potentially ways to implement similar behavior that might be more performant, however the goal of this initial implementation is more to demonstrate the functionality, and allow tests to start to be put in place to verify correctness, after which the performance can be optimized as needed (for example by pushing the replacement deeper into table reader, perhaps on specially-built tables that elide their common prefix, etc). 