### PR TITLE
metamorphic: export a usable interface for running custom variants

### DIFF
--- a/metamorphic/example_test.go
+++ b/metamorphic/example_test.go
@@ -1,0 +1,29 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package metamorphic_test
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/cockroachdb/pebble/metamorphic"
+	"golang.org/x/exp/rand"
+)
+
+func ExampleExecute() {
+	const seed = 1698702489658104000
+	rng := rand.New(rand.NewSource(seed))
+
+	// Generate a random database by running the metamorphic test.
+	testOpts := metamorphic.RandomOptions(rng, nil /* custom opt parsers */)
+	ops := metamorphic.GenerateOps(rng, 10000, metamorphic.DefaultOpConfig())
+	test, err := metamorphic.New(ops, testOpts, "" /* dir */, io.Discard)
+	if err != nil {
+		panic(err)
+	}
+	err = metamorphic.Execute(test)
+	fmt.Print(err)
+	// Output: <nil>
+}

--- a/metamorphic/generator.go
+++ b/metamorphic/generator.go
@@ -49,7 +49,7 @@ func (o iterOpts) IsZero() bool {
 }
 
 type generator struct {
-	cfg config
+	cfg OpConfig
 	rng *rand.Rand
 
 	init *initOp
@@ -104,7 +104,7 @@ type generator struct {
 	iterReaderID map[objID]objID
 }
 
-func newGenerator(rng *rand.Rand, cfg config, km *keyManager) *generator {
+func newGenerator(rng *rand.Rand, cfg OpConfig, km *keyManager) *generator {
 	g := &generator{
 		cfg:                   cfg,
 		rng:                   rng,
@@ -133,57 +133,57 @@ func newGenerator(rng *rand.Rand, cfg config, km *keyManager) *generator {
 	return g
 }
 
-func generate(rng *rand.Rand, count uint64, cfg config, km *keyManager) []op {
+func generate(rng *rand.Rand, count uint64, cfg OpConfig, km *keyManager) []op {
 	g := newGenerator(rng, cfg, km)
 
 	generators := []func(){
-		batchAbort:                  g.batchAbort,
-		batchCommit:                 g.batchCommit,
-		dbCheckpoint:                g.dbCheckpoint,
-		dbCompact:                   g.dbCompact,
-		dbFlush:                     g.dbFlush,
-		dbRatchetFormatMajorVersion: g.dbRatchetFormatMajorVersion,
-		dbRestart:                   g.dbRestart,
-		iterClose:                   g.randIter(g.iterClose),
-		iterFirst:                   g.randIter(g.iterFirst),
-		iterLast:                    g.randIter(g.iterLast),
-		iterNext:                    g.randIter(g.iterNext),
-		iterNextWithLimit:           g.randIter(g.iterNextWithLimit),
-		iterNextPrefix:              g.randIter(g.iterNextPrefix),
-		iterCanSingleDelete:         g.randIter(g.iterCanSingleDelete),
-		iterPrev:                    g.randIter(g.iterPrev),
-		iterPrevWithLimit:           g.randIter(g.iterPrevWithLimit),
-		iterSeekGE:                  g.randIter(g.iterSeekGE),
-		iterSeekGEWithLimit:         g.randIter(g.iterSeekGEWithLimit),
-		iterSeekLT:                  g.randIter(g.iterSeekLT),
-		iterSeekLTWithLimit:         g.randIter(g.iterSeekLTWithLimit),
-		iterSeekPrefixGE:            g.randIter(g.iterSeekPrefixGE),
-		iterSetBounds:               g.randIter(g.iterSetBounds),
-		iterSetOptions:              g.randIter(g.iterSetOptions),
-		newBatch:                    g.newBatch,
-		newIndexedBatch:             g.newIndexedBatch,
-		newIter:                     g.newIter,
-		newIterUsingClone:           g.newIterUsingClone,
-		newSnapshot:                 g.newSnapshot,
-		readerGet:                   g.readerGet,
-		replicate:                   g.replicate,
-		snapshotClose:               g.snapshotClose,
-		writerApply:                 g.writerApply,
-		writerDelete:                g.writerDelete,
-		writerDeleteRange:           g.writerDeleteRange,
-		writerIngest:                g.writerIngest,
-		writerIngestAndExcise:       g.writerIngestAndExcise,
-		writerMerge:                 g.writerMerge,
-		writerRangeKeyDelete:        g.writerRangeKeyDelete,
-		writerRangeKeySet:           g.writerRangeKeySet,
-		writerRangeKeyUnset:         g.writerRangeKeyUnset,
-		writerSet:                   g.writerSet,
-		writerSingleDelete:          g.writerSingleDelete,
+		OpBatchAbort:                  g.batchAbort,
+		OpBatchCommit:                 g.batchCommit,
+		OpDBCheckpoint:                g.dbCheckpoint,
+		OpDBCompact:                   g.dbCompact,
+		OpDBFlush:                     g.dbFlush,
+		OpDBRatchetFormatMajorVersion: g.dbRatchetFormatMajorVersion,
+		OpDBRestart:                   g.dbRestart,
+		OpIterClose:                   g.randIter(g.iterClose),
+		OpIterFirst:                   g.randIter(g.iterFirst),
+		OpIterLast:                    g.randIter(g.iterLast),
+		OpIterNext:                    g.randIter(g.iterNext),
+		OpIterNextWithLimit:           g.randIter(g.iterNextWithLimit),
+		OpIterNextPrefix:              g.randIter(g.iterNextPrefix),
+		OpIterCanSingleDelete:         g.randIter(g.iterCanSingleDelete),
+		OpIterPrev:                    g.randIter(g.iterPrev),
+		OpIterPrevWithLimit:           g.randIter(g.iterPrevWithLimit),
+		OpIterSeekGE:                  g.randIter(g.iterSeekGE),
+		OpIterSeekGEWithLimit:         g.randIter(g.iterSeekGEWithLimit),
+		OpIterSeekLT:                  g.randIter(g.iterSeekLT),
+		OpIterSeekLTWithLimit:         g.randIter(g.iterSeekLTWithLimit),
+		OpIterSeekPrefixGE:            g.randIter(g.iterSeekPrefixGE),
+		OpIterSetBounds:               g.randIter(g.iterSetBounds),
+		OpIterSetOptions:              g.randIter(g.iterSetOptions),
+		OpNewBatch:                    g.newBatch,
+		OpNewIndexedBatch:             g.newIndexedBatch,
+		OpNewIter:                     g.newIter,
+		OpNewIterUsingClone:           g.newIterUsingClone,
+		OpNewSnapshot:                 g.newSnapshot,
+		OpReaderGet:                   g.readerGet,
+		OpReplicate:                   g.replicate,
+		OpSnapshotClose:               g.snapshotClose,
+		OpWriterApply:                 g.writerApply,
+		OpWriterDelete:                g.writerDelete,
+		OpWriterDeleteRange:           g.writerDeleteRange,
+		OpWriterIngest:                g.writerIngest,
+		OpWriterIngestAndExcise:       g.writerIngestAndExcise,
+		OpWriterMerge:                 g.writerMerge,
+		OpWriterRangeKeyDelete:        g.writerRangeKeyDelete,
+		OpWriterRangeKeySet:           g.writerRangeKeySet,
+		OpWriterRangeKeyUnset:         g.writerRangeKeyUnset,
+		OpWriterSet:                   g.writerSet,
+		OpWriterSingleDelete:          g.writerSingleDelete,
 	}
 
 	// TPCC-style deck of cards randomization. Every time the end of the deck is
 	// reached, we shuffle the deck.
-	deck := randvar.NewDeck(g.rng, cfg.ops...)
+	deck := randvar.NewDeck(g.rng, cfg.ops[:]...)
 
 	defer func() {
 		if r := recover(); r != nil {

--- a/metamorphic/generator.go
+++ b/metamorphic/generator.go
@@ -48,6 +48,15 @@ func (o iterOpts) IsZero() bool {
 		o.maskSuffix == nil && o.filterMin == 0 && o.filterMax == 0 && !o.useL6Filters
 }
 
+// GenerateOps generates n random operations, drawing randomness from the
+// provided pseudorandom generator and using cfg to determine the distribution
+// of op types.
+func GenerateOps(rng *rand.Rand, n uint64, cfg OpConfig) Ops {
+	// Generate a new set of random ops, writing them to <dir>/ops. These will be
+	// read by the child processes when performing a test run.
+	return generate(rng, n, cfg, newKeyManager(1 /* num instances */))
+}
+
 type generator struct {
 	cfg OpConfig
 	rng *rand.Rand

--- a/metamorphic/generator_test.go
+++ b/metamorphic/generator_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestGenerator(t *testing.T) {
 	rng := randvar.NewRand()
-	g := newGenerator(rng, defaultConfig(), newKeyManager(1 /* numInstances */))
+	g := newGenerator(rng, DefaultOpConfig(), newKeyManager(1 /* numInstances */))
 
 	g.newBatch()
 	g.newBatch()
@@ -63,7 +63,7 @@ func TestGenerator(t *testing.T) {
 		t.Logf("\n%s", g)
 	}
 
-	g = newGenerator(rng, defaultConfig(), newKeyManager(1 /* numInstances */))
+	g = newGenerator(rng, DefaultOpConfig(), newKeyManager(1 /* numInstances */))
 
 	g.newSnapshot()
 	g.newSnapshot()
@@ -96,7 +96,7 @@ func TestGenerator(t *testing.T) {
 		t.Logf("\n%s", g)
 	}
 
-	g = newGenerator(rng, defaultConfig(), newKeyManager(1 /* numInstances */))
+	g = newGenerator(rng, DefaultOpConfig(), newKeyManager(1 /* numInstances */))
 
 	g.newIndexedBatch()
 	g.newIndexedBatch()
@@ -130,7 +130,7 @@ func TestGeneratorRandom(t *testing.T) {
 	seed := uint64(time.Now().UnixNano())
 	ops := randvar.NewUniform(1000, 10000)
 	cfgs := []string{"default", "multiInstance"}
-	generateFromSeed := func(cfg config) string {
+	generateFromSeed := func(cfg OpConfig) string {
 		rng := rand.New(rand.NewSource(seed))
 		count := ops.Uint64(rng)
 		return formatOps(generate(rng, count, cfg, newKeyManager(cfg.numInstances)))
@@ -138,9 +138,9 @@ func TestGeneratorRandom(t *testing.T) {
 
 	for i := range cfgs {
 		t.Run(fmt.Sprintf("config=%s", cfgs[i]), func(t *testing.T) {
-			cfg := defaultConfig
+			cfg := DefaultOpConfig
 			if cfgs[i] == "multiInstance" {
-				cfg = func() config {
+				cfg = func() OpConfig {
 					cfg := multiInstanceConfig()
 					cfg.numInstances = 2
 					return cfg
@@ -170,7 +170,7 @@ func TestGeneratorRandom(t *testing.T) {
 
 func TestGenerateRandKeyToReadInRange(t *testing.T) {
 	rng := randvar.NewRand()
-	g := newGenerator(rng, defaultConfig(), newKeyManager(1 /* numInstances */))
+	g := newGenerator(rng, DefaultOpConfig(), newKeyManager(1 /* numInstances */))
 	// Seed 100 initial keys.
 	for i := 0; i < 100; i++ {
 		_ = g.randKeyToWrite(1.0)
@@ -199,7 +199,7 @@ func TestGenerateRandKeyToReadInRange(t *testing.T) {
 
 func TestGenerateDisjointKeyRanges(t *testing.T) {
 	rng := randvar.NewRand()
-	g := newGenerator(rng, defaultConfig(), newKeyManager(1 /* numInstances */))
+	g := newGenerator(rng, DefaultOpConfig(), newKeyManager(1 /* numInstances */))
 
 	for i := 0; i < 10; i++ {
 		keyRanges := g.generateDisjointKeyRanges(5)

--- a/metamorphic/key_manager_test.go
+++ b/metamorphic/key_manager_test.go
@@ -195,11 +195,11 @@ func TestOpWrittenKeys(t *testing.T) {
 
 func TestLoadPrecedingKeys(t *testing.T) {
 	rng := randvar.NewRand()
-	cfg := defaultConfig()
+	cfg := DefaultOpConfig()
 	km := newKeyManager(1 /* numInstances */)
 	ops := generate(rng, 1000, cfg, km)
 
-	cfg2 := defaultConfig()
+	cfg2 := DefaultOpConfig()
 	km2 := newKeyManager(1 /* numInstances */)
 	loadPrecedingKeys(t, ops, &cfg2, km2)
 

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/bloom"
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage/remote"
@@ -79,7 +80,7 @@ func parseOptions(
 				if err != nil {
 					panic(err)
 				}
-				opts.threads = v
+				opts.Threads = v
 				return true
 			case "TestOptions.disable_block_property_collector":
 				v, err := strconv.ParseBool(value)
@@ -179,8 +180,8 @@ func optionsToString(opts *TestOptions) string {
 	if opts.initialStateDesc != "" {
 		fmt.Fprintf(&buf, "  initial_state_desc=%s\n", opts.initialStateDesc)
 	}
-	if opts.threads != 0 {
-		fmt.Fprintf(&buf, "  threads=%d\n", opts.threads)
+	if opts.Threads != 0 {
+		fmt.Fprintf(&buf, "  threads=%d\n", opts.Threads)
 	}
 	if opts.disableBlockPropertyCollector {
 		fmt.Fprintf(&buf, "  disable_block_property_collector=%t\n", opts.disableBlockPropertyCollector)
@@ -226,12 +227,16 @@ func optionsToString(opts *TestOptions) string {
 func defaultTestOptions() *TestOptions {
 	return &TestOptions{
 		Opts:    defaultOptions(),
-		threads: 16,
+		Threads: 16,
 	}
 }
 
 func defaultOptions() *pebble.Options {
 	opts := &pebble.Options{
+		// Use an archive cleaner to ease post-mortem debugging.
+		Cleaner: base.ArchiveCleaner{},
+		// Always use our custom comparer which provides a Split method,
+		// splitting keys at the trailing '@'.
 		Comparer:           testkeys.Comparer,
 		FS:                 vfs.NewMem(),
 		FormatMajorVersion: defaultFormatMajorVersion,
@@ -255,12 +260,20 @@ func defaultOptions() *pebble.Options {
 type TestOptions struct {
 	// Opts holds the *pebble.Options for the test.
 	Opts *pebble.Options
+	// Threads configures the parallelism of the test. Each thread will run in
+	// an independent goroutine and be responsible for executing operations
+	// against an independent set of objects. The outcome of any individual
+	// operation will still be deterministic, with the metamorphic test
+	// inserting synchronization where necessary.
+	Threads int
 	// CustomOptions holds custom test options that are defined outside of this
 	// package.
 	CustomOpts []CustomOption
-	useDisk    bool
-	strictFS   bool
-	threads    int
+
+	// internal
+
+	useDisk  bool
+	strictFS bool
 	// Use Batch.Apply rather than DB.Ingest.
 	ingestUsingApply bool
 	// Use Batch.DeleteSized rather than Batch.Delete.
@@ -468,7 +481,9 @@ func standardOptions() []*TestOptions {
 	return opts
 }
 
-func randomOptions(
+// RandomOptions generates a random set of operations, drawing randomness from
+// rng.
+func RandomOptions(
 	rng *rand.Rand, customOptionParsers map[string]func(string) (CustomOption, bool),
 ) *TestOptions {
 	testOpts := defaultTestOptions()
@@ -587,7 +602,7 @@ func randomOptions(
 	// sufficient.
 	testOpts.useDisk = false
 	testOpts.strictFS = rng.Intn(2) != 0 // Only relevant for MemFS.
-	testOpts.threads = rng.Intn(runtime.GOMAXPROCS(0)) + 1
+	testOpts.Threads = rng.Intn(runtime.GOMAXPROCS(0)) + 1
 	if testOpts.strictFS {
 		opts.DisableWAL = false
 	}

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -142,7 +142,7 @@ func TestOptionsRoundtrip(t *testing.T) {
 	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 	for i := 0; i < 100; i++ {
 		t.Run(fmt.Sprintf("random-%03d", i), func(t *testing.T) {
-			o := randomOptions(rng, nil)
+			o := RandomOptions(rng, nil)
 			defer maybeUnref(o)
 			checkOptions(t, o)
 		})

--- a/metamorphic/parser_test.go
+++ b/metamorphic/parser_test.go
@@ -32,7 +32,7 @@ func TestParserRandom(t *testing.T) {
 	cfgs := []string{"default", "multiInstance"}
 	for i := range cfgs {
 		t.Run(fmt.Sprintf("config=%s", cfgs[i]), func(t *testing.T) {
-			cfg := defaultConfig()
+			cfg := DefaultOpConfig()
 			if cfgs[i] == "multiInstance" {
 				cfg = multiInstanceConfig()
 				cfg.numInstances = 2


### PR DESCRIPTION
**metamorphic: export OpType and its variants, OpConfig, DefaultOpConfig**

This commit exports the OpType and its variants, as well as related type
OpConfig and constructor DefaultOpConfig. This is in preparation for future
work that will allow other Pebble packages to run variants of the metamorphic
test with custom operation distributions.

**metamorphic: export a usable interface for running custom variants**

This commit refactors and exports a minimal interface necessary for generating
and running a set of operations against a randomized configuration. This
intended to be used in future work to make randomized testing easier, for
example by easily constructing a randomized database state by running the
metamorphic test with only write operations.