### PR TITLE
*: more DiskFileNum cleanup

### DIFF
--- a/cleaner.go
+++ b/cleaner.go
@@ -228,14 +228,14 @@ func (cm *cleanupManager) deleteObsoleteFile(
 		cm.opts.EventListener.WALDeleted(WALDeleteInfo{
 			JobID:   jobID,
 			Path:    path,
-			FileNum: fileNum.FileNum(),
+			FileNum: fileNum,
 			Err:     err,
 		})
 	case fileTypeManifest:
 		cm.opts.EventListener.ManifestDeleted(ManifestDeleteInfo{
 			JobID:   jobID,
 			Path:    path,
-			FileNum: fileNum.FileNum(),
+			FileNum: fileNum,
 			Err:     err,
 		})
 	case fileTypeTable:
@@ -267,7 +267,7 @@ func (cm *cleanupManager) deleteObsoleteObject(
 		cm.opts.EventListener.TableDeleted(TableDeleteInfo{
 			JobID:   jobID,
 			Path:    path,
-			FileNum: fileNum.FileNum(),
+			FileNum: fileNum,
 			Err:     err,
 		})
 	}

--- a/compaction.go
+++ b/compaction.go
@@ -3064,7 +3064,7 @@ func (d *DB) runCompaction(
 			JobID:   jobID,
 			Reason:  reason,
 			Path:    d.objProvider.Path(objMeta),
-			FileNum: fileNum,
+			FileNum: fileNum.DiskFileNum(),
 		})
 		if c.kind != compactionKindFlush {
 			writable = &compactionWritable{
@@ -3613,7 +3613,7 @@ func (d *DB) scanObsoleteFiles(list []string) {
 			}
 			obsoleteManifests = append(obsoleteManifests, fi)
 		case fileTypeOptions:
-			if diskFileNum.FileNum() >= d.optionsFileNum.FileNum() {
+			if diskFileNum >= d.optionsFileNum {
 				continue
 			}
 			fi := fileInfo{fileNum: diskFileNum}

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2713,7 +2713,7 @@ func TestCompactionErrorCleanup(t *testing.T) {
 	// protected by d.mu
 	var (
 		initialSetupDone bool
-		tablesCreated    []FileNum
+		tablesCreated    []base.DiskFileNum
 	)
 
 	mem := vfs.NewMem()
@@ -3742,7 +3742,7 @@ func TestCompactionErrorStats(t *testing.T) {
 	// protected by d.mu
 	var (
 		useInjector   bool
-		tablesCreated []FileNum
+		tablesCreated []base.DiskFileNum
 	)
 
 	mem := vfs.NewMem()

--- a/data_test.go
+++ b/data_test.go
@@ -1146,7 +1146,7 @@ func runSSTablePropertiesCmd(t *testing.T, td *datadriven.TestData, d *DB) strin
 	// Note that m can be nil here if the sstable exists in the file system, but
 	// not in the lsm. If m is nil just assume that file is not virtual.
 
-	backingFileNum := base.FileNum(uint64(file)).DiskFileNum()
+	backingFileNum := base.DiskFileNum(file)
 	if m != nil {
 		backingFileNum = m.FileBacking.DiskFileNum
 	}

--- a/db.go
+++ b/db.go
@@ -2812,14 +2812,14 @@ func (d *DB) recycleWAL() (newLogNum base.DiskFileNum, prevLogSize uint64) {
 	}
 
 	if recycleOK {
-		err = firstError(err, d.logRecycler.pop(recycleLog.fileNum.FileNum()))
+		err = firstError(err, d.logRecycler.pop(recycleLog.fileNum))
 	}
 
 	d.opts.EventListener.WALCreated(WALCreateInfo{
 		JobID:           jobID,
 		Path:            newLogName,
 		FileNum:         newLogNum,
-		RecycledFileNum: recycleLog.fileNum.FileNum(),
+		RecycledFileNum: recycleLog.fileNum,
 		Err:             err,
 	})
 

--- a/db_test.go
+++ b/db_test.go
@@ -806,7 +806,7 @@ func TestMemTableReservation(t *testing.T) {
 	helloWorld := []byte("hello world")
 	value := cache.Alloc(len(helloWorld))
 	copy(value.Buf(), helloWorld)
-	opts.Cache.Set(tmpID, base.FileNum(0).DiskFileNum(), 0, value).Release()
+	opts.Cache.Set(tmpID, base.DiskFileNum(0), 0, value).Release()
 
 	d, err := Open("", opts)
 	require.NoError(t, err)
@@ -823,7 +823,7 @@ func TestMemTableReservation(t *testing.T) {
 		t.Fatalf("expected 2 refs, but found %d", refs)
 	}
 	// Verify the memtable reservation has caused our test block to be evicted.
-	if h := opts.Cache.Get(tmpID, base.FileNum(0).DiskFileNum(), 0); h.Get() != nil {
+	if h := opts.Cache.Get(tmpID, base.DiskFileNum(0), 0); h.Get() != nil {
 		t.Fatalf("expected failure, but found success: %s", h.Get())
 	}
 

--- a/event.go
+++ b/event.go
@@ -270,7 +270,7 @@ type ManifestDeleteInfo struct {
 	// JobID is the ID of the job the caused the Manifest to be deleted.
 	JobID   int
 	Path    string
-	FileNum FileNum
+	FileNum base.DiskFileNum
 	Err     error
 }
 
@@ -294,7 +294,7 @@ type TableCreateInfo struct {
 	// "ingesting".
 	Reason  string
 	Path    string
-	FileNum FileNum
+	FileNum base.DiskFileNum
 }
 
 func (i TableCreateInfo) String() string {
@@ -311,7 +311,7 @@ func (i TableCreateInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 type TableDeleteInfo struct {
 	JobID   int
 	Path    string
-	FileNum FileNum
+	FileNum base.DiskFileNum
 	Err     error
 }
 
@@ -418,7 +418,7 @@ type WALCreateInfo struct {
 	FileNum base.DiskFileNum
 	// The file number of a previous WAL which was recycled to create this
 	// one. Zero if recycling did not take place.
-	RecycledFileNum FileNum
+	RecycledFileNum base.DiskFileNum
 	Err             error
 }
 
@@ -447,7 +447,7 @@ type WALDeleteInfo struct {
 	// JobID is the ID of the job the caused the WAL to be deleted.
 	JobID   int
 	Path    string
-	FileNum FileNum
+	FileNum base.DiskFileNum
 	Err     error
 }
 

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -340,7 +340,7 @@ func TestEventListenerRedact(t *testing.T) {
 	l := MakeLoggingEventListener(redactLogger{logger: &log})
 	l.WALDeleted(WALDeleteInfo{
 		JobID:   5,
-		FileNum: FileNum(20),
+		FileNum: base.DiskFileNum(20),
 		Err:     errors.Errorf("unredacted error: %s", "unredacted string"),
 	})
 	require.Equal(t, "[JOB 5] WAL delete error: unredacted error: ‹×›\n", log.String())

--- a/ingest.go
+++ b/ingest.go
@@ -189,7 +189,7 @@ func ingestLoad1External(
 			JobID:   jobID,
 			Reason:  "ingesting",
 			Path:    objprovider.Path(metas[0]),
-			FileNum: fileNum.FileNum(),
+			FileNum: fileNum,
 		})
 	}
 	// In the name of keeping this ingestion as fast as possible, we avoid
@@ -575,7 +575,7 @@ func ingestLink(
 				JobID:   jobID,
 				Reason:  "ingesting",
 				Path:    objProvider.Path(objMeta),
-				FileNum: lr.localMeta[i].FileNum,
+				FileNum: lr.localMeta[i].FileNum.DiskFileNum(),
 			})
 		}
 	}
@@ -615,7 +615,7 @@ func ingestLink(
 				JobID:   jobID,
 				Reason:  "ingesting",
 				Path:    objProvider.Path(sharedObjMetas[i]),
-				FileNum: lr.sharedMeta[i].FileNum,
+				FileNum: lr.sharedMeta[i].FileNum.DiskFileNum(),
 			})
 		}
 	}

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -128,7 +128,7 @@ func TestIngestLoad(t *testing.T) {
 				Comparer: DefaultComparer,
 				FS:       mem,
 			}).WithFSDefaults()
-			lr, err := ingestLoad(opts, dbVersion, []string{"ext"}, nil, nil, 0, []base.DiskFileNum{base.FileNum(1).DiskFileNum()}, nil, 0)
+			lr, err := ingestLoad(opts, dbVersion, []string{"ext"}, nil, nil, 0, []base.DiskFileNum{base.DiskFileNum(1)}, nil, 0)
 			if err != nil {
 				return err.Error()
 			}
@@ -165,7 +165,7 @@ func TestIngestLoadRand(t *testing.T) {
 	expected := make([]*fileMetadata, len(paths))
 	for i := range paths {
 		paths[i] = fmt.Sprint(i)
-		pending[i] = base.FileNum(rng.Uint64()).DiskFileNum()
+		pending[i] = base.DiskFileNum(rng.Uint64())
 		expected[i] = &fileMetadata{
 			FileNum: pending[i].FileNum(),
 		}
@@ -235,7 +235,7 @@ func TestIngestLoadInvalid(t *testing.T) {
 		Comparer: DefaultComparer,
 		FS:       mem,
 	}).WithFSDefaults()
-	if _, err := ingestLoad(opts, internalFormatNewest, []string{"invalid"}, nil, nil, 0, []base.DiskFileNum{base.FileNum(1).DiskFileNum()}, nil, 0); err == nil {
+	if _, err := ingestLoad(opts, internalFormatNewest, []string{"invalid"}, nil, nil, 0, []base.DiskFileNum{base.DiskFileNum(1)}, nil, 0); err == nil {
 		t.Fatalf("expected error, but found success")
 	}
 }
@@ -363,7 +363,7 @@ func TestIngestLink(t *testing.T) {
 					if fileTypeTable != ftype {
 						t.Fatalf("expected table, but found %d", ftype)
 					}
-					if j != int(fileNum.FileNum()) {
+					if j != int(fileNum) {
 						t.Fatalf("expected table %d, but found %d", j, fileNum)
 					}
 					f, err := opts.FS.Open(opts.FS.PathJoin(dir, files[j]))
@@ -1257,7 +1257,7 @@ func TestSimpleIngestShared(t *testing.T) {
 		metaMap[fn.DiskFileNum()] = meta
 	}
 
-	m := metaMap[base.FileNum(2).DiskFileNum()]
+	m := metaMap[base.DiskFileNum(2)]
 	handle, err := provider2.RemoteObjectBacking(&m)
 	require.NoError(t, err)
 	size, err := provider2.Size(m)

--- a/internal/base/filenames_test.go
+++ b/internal/base/filenames_test.go
@@ -66,18 +66,18 @@ func TestFilenameRoundTrip(t *testing.T) {
 	}
 	fs := vfs.NewMem()
 	for fileType, numbered := range testCases {
-		fileNums := []FileNum{0}
+		fileNums := []DiskFileNum{0}
 		if numbered {
-			fileNums = []FileNum{0, 1, 2, 3, 10, 42, 99, 1001}
+			fileNums = []DiskFileNum{0, 1, 2, 3, 10, 42, 99, 1001}
 		}
 		for _, fileNum := range fileNums {
-			filename := MakeFilepath(fs, "foo", fileType, fileNum.DiskFileNum())
+			filename := MakeFilepath(fs, "foo", fileType, fileNum)
 			gotFT, gotFN, gotOK := ParseFilename(fs, filename)
 			if !gotOK {
 				t.Errorf("could not parse %q", filename)
 				continue
 			}
-			if gotFT != fileType || gotFN.FileNum() != fileNum {
+			if gotFT != fileType || gotFN != fileNum {
 				t.Errorf("filename=%q: got %v, %v, want %v, %v", filename, gotFT, gotFN, fileType, fileNum)
 				continue
 			}

--- a/internal/cache/clockpro.go
+++ b/internal/cache/clockpro.go
@@ -765,7 +765,7 @@ func (c *Cache) getShard(id uint64, fileNum base.DiskFileNum, offset uint64) *sh
 		h ^= uint64(id & 0xff)
 		id >>= 8
 	}
-	fileNumVal := uint64(fileNum.FileNum())
+	fileNumVal := uint64(fileNum)
 	for i := 0; i < 8; i++ {
 		h *= prime64
 		h ^= uint64(fileNumVal) & 0xff

--- a/internal/cache/clockpro_test.go
+++ b/internal/cache/clockpro_test.go
@@ -39,11 +39,11 @@ func TestCache(t *testing.T) {
 		wantHit := fields[1][0] == 'h'
 
 		var hit bool
-		h := cache.Get(1, base.FileNum(uint64(key)).DiskFileNum(), 0)
+		h := cache.Get(1, base.DiskFileNum(key), 0)
 		if v := h.Get(); v == nil {
 			value := Alloc(1)
 			value.Buf()[0] = fields[0][0]
-			cache.Set(1, base.FileNum(uint64(key)).DiskFileNum(), 0, value).Release()
+			cache.Set(1, base.DiskFileNum(key), 0, value).Release()
 		} else {
 			hit = true
 			if !bytes.Equal(v, fields[0][:1]) {
@@ -69,28 +69,28 @@ func TestCacheDelete(t *testing.T) {
 	cache := newShards(100, 1)
 	defer cache.Unref()
 
-	cache.Set(1, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 5)).Release()
-	cache.Set(1, base.FileNum(1).DiskFileNum(), 0, testValue(cache, "a", 5)).Release()
-	cache.Set(1, base.FileNum(2).DiskFileNum(), 0, testValue(cache, "a", 5)).Release()
+	cache.Set(1, base.DiskFileNum(0), 0, testValue(cache, "a", 5)).Release()
+	cache.Set(1, base.DiskFileNum(1), 0, testValue(cache, "a", 5)).Release()
+	cache.Set(1, base.DiskFileNum(2), 0, testValue(cache, "a", 5)).Release()
 	if expected, size := int64(15), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	cache.Delete(1, base.FileNum(1).DiskFileNum(), 0)
+	cache.Delete(1, base.DiskFileNum(1), 0)
 	if expected, size := int64(10), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	if h := cache.Get(1, base.FileNum(0).DiskFileNum(), 0); h.Get() == nil {
+	if h := cache.Get(1, base.DiskFileNum(0), 0); h.Get() == nil {
 		t.Fatalf("expected to find block 0/0")
 	} else {
 		h.Release()
 	}
-	if h := cache.Get(1, base.FileNum(1).DiskFileNum(), 0); h.Get() != nil {
+	if h := cache.Get(1, base.DiskFileNum(1), 0); h.Get() != nil {
 		t.Fatalf("expected to not find block 1/0")
 	} else {
 		h.Release()
 	}
 	// Deleting a non-existing block does nothing.
-	cache.Delete(1, base.FileNum(1).DiskFileNum(), 0)
+	cache.Delete(1, base.DiskFileNum(1), 0)
 	if expected, size := int64(10), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
@@ -100,23 +100,23 @@ func TestEvictFile(t *testing.T) {
 	cache := newShards(100, 1)
 	defer cache.Unref()
 
-	cache.Set(1, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 5)).Release()
-	cache.Set(1, base.FileNum(1).DiskFileNum(), 0, testValue(cache, "a", 5)).Release()
-	cache.Set(1, base.FileNum(2).DiskFileNum(), 0, testValue(cache, "a", 5)).Release()
-	cache.Set(1, base.FileNum(2).DiskFileNum(), 1, testValue(cache, "a", 5)).Release()
-	cache.Set(1, base.FileNum(2).DiskFileNum(), 2, testValue(cache, "a", 5)).Release()
+	cache.Set(1, base.DiskFileNum(0), 0, testValue(cache, "a", 5)).Release()
+	cache.Set(1, base.DiskFileNum(1), 0, testValue(cache, "a", 5)).Release()
+	cache.Set(1, base.DiskFileNum(2), 0, testValue(cache, "a", 5)).Release()
+	cache.Set(1, base.DiskFileNum(2), 1, testValue(cache, "a", 5)).Release()
+	cache.Set(1, base.DiskFileNum(2), 2, testValue(cache, "a", 5)).Release()
 	if expected, size := int64(25), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	cache.EvictFile(1, base.FileNum(0).DiskFileNum())
+	cache.EvictFile(1, base.DiskFileNum(0))
 	if expected, size := int64(20), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	cache.EvictFile(1, base.FileNum(1).DiskFileNum())
+	cache.EvictFile(1, base.DiskFileNum(1))
 	if expected, size := int64(15), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	cache.EvictFile(1, base.FileNum(2).DiskFileNum())
+	cache.EvictFile(1, base.DiskFileNum(2))
 	if expected, size := int64(0), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
@@ -128,28 +128,28 @@ func TestEvictAll(t *testing.T) {
 	cache := newShards(100, 1)
 	defer cache.Unref()
 
-	cache.Set(1, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 101)).Release()
-	cache.Set(1, base.FileNum(1).DiskFileNum(), 0, testValue(cache, "a", 101)).Release()
+	cache.Set(1, base.DiskFileNum(0), 0, testValue(cache, "a", 101)).Release()
+	cache.Set(1, base.DiskFileNum(1), 0, testValue(cache, "a", 101)).Release()
 }
 
 func TestMultipleDBs(t *testing.T) {
 	cache := newShards(100, 1)
 	defer cache.Unref()
 
-	cache.Set(1, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 5)).Release()
-	cache.Set(2, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "b", 5)).Release()
+	cache.Set(1, base.DiskFileNum(0), 0, testValue(cache, "a", 5)).Release()
+	cache.Set(2, base.DiskFileNum(0), 0, testValue(cache, "b", 5)).Release()
 	if expected, size := int64(10), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	cache.EvictFile(1, base.FileNum(0).DiskFileNum())
+	cache.EvictFile(1, base.DiskFileNum(0))
 	if expected, size := int64(5), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	h := cache.Get(1, base.FileNum(0).DiskFileNum(), 0)
+	h := cache.Get(1, base.DiskFileNum(0), 0)
 	if v := h.Get(); v != nil {
 		t.Fatalf("expected not present, but found %s", v)
 	}
-	h = cache.Get(2, base.FileNum(0).DiskFileNum(), 0)
+	h = cache.Get(2, base.DiskFileNum(0), 0)
 	if v := h.Get(); string(v) != "bbbbb" {
 		t.Fatalf("expected bbbbb, but found %s", v)
 	} else {
@@ -161,27 +161,27 @@ func TestZeroSize(t *testing.T) {
 	cache := newShards(0, 1)
 	defer cache.Unref()
 
-	cache.Set(1, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 5)).Release()
+	cache.Set(1, base.DiskFileNum(0), 0, testValue(cache, "a", 5)).Release()
 }
 
 func TestReserve(t *testing.T) {
 	cache := newShards(4, 2)
 	defer cache.Unref()
 
-	cache.Set(1, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 1)).Release()
-	cache.Set(2, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 1)).Release()
+	cache.Set(1, base.DiskFileNum(0), 0, testValue(cache, "a", 1)).Release()
+	cache.Set(2, base.DiskFileNum(0), 0, testValue(cache, "a", 1)).Release()
 	require.EqualValues(t, 2, cache.Size())
 	r := cache.Reserve(1)
 	require.EqualValues(t, 0, cache.Size())
-	cache.Set(1, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 1)).Release()
-	cache.Set(2, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 1)).Release()
-	cache.Set(3, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 1)).Release()
-	cache.Set(4, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 1)).Release()
+	cache.Set(1, base.DiskFileNum(0), 0, testValue(cache, "a", 1)).Release()
+	cache.Set(2, base.DiskFileNum(0), 0, testValue(cache, "a", 1)).Release()
+	cache.Set(3, base.DiskFileNum(0), 0, testValue(cache, "a", 1)).Release()
+	cache.Set(4, base.DiskFileNum(0), 0, testValue(cache, "a", 1)).Release()
 	require.EqualValues(t, 2, cache.Size())
 	r()
 	require.EqualValues(t, 2, cache.Size())
-	cache.Set(1, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 1)).Release()
-	cache.Set(2, base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 1)).Release()
+	cache.Set(1, base.DiskFileNum(0), 0, testValue(cache, "a", 1)).Release()
+	cache.Set(2, base.DiskFileNum(0), 0, testValue(cache, "a", 1)).Release()
 	require.EqualValues(t, 4, cache.Size())
 }
 
@@ -217,7 +217,7 @@ func TestCacheStressSetExisting(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			for j := 0; j < 10000; j++ {
-				cache.Set(1, base.FileNum(0).DiskFileNum(), uint64(i), testValue(cache, "a", 1)).Release()
+				cache.Set(1, base.DiskFileNum(0), uint64(i), testValue(cache, "a", 1)).Release()
 				runtime.Gosched()
 			}
 		}(i)
@@ -233,7 +233,7 @@ func BenchmarkCacheGet(b *testing.B) {
 
 	for i := 0; i < size; i++ {
 		v := testValue(cache, "a", 1)
-		cache.Set(1, base.FileNum(0).DiskFileNum(), uint64(i), v).Release()
+		cache.Set(1, base.DiskFileNum(0), uint64(i), v).Release()
 	}
 
 	b.ResetTimer()
@@ -241,7 +241,7 @@ func BenchmarkCacheGet(b *testing.B) {
 		rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 
 		for pb.Next() {
-			h := cache.Get(1, base.FileNum(0).DiskFileNum(), uint64(rng.Intn(size)))
+			h := cache.Get(1, base.DiskFileNum(0), uint64(rng.Intn(size)))
 			if h.Get() == nil {
 				b.Fatal("failed to lookup value")
 			}
@@ -259,7 +259,7 @@ func TestReserveColdTarget(t *testing.T) {
 	defer cache.Unref()
 
 	for i := 0; i < 50; i++ {
-		cache.Set(uint64(i+1), base.FileNum(0).DiskFileNum(), 0, testValue(cache, "a", 1)).Release()
+		cache.Set(uint64(i+1), base.DiskFileNum(0), 0, testValue(cache, "a", 1)).Release()
 	}
 
 	if cache.Size() != 50 {

--- a/internal/cache/robin_hood.go
+++ b/internal/cache/robin_hood.go
@@ -24,7 +24,7 @@ func robinHoodHash(k key, shift uint32) uint32 {
 	const m = 11400714819323198485
 	h := hashSeed
 	h ^= k.id * m
-	h ^= uint64(k.fileNum.FileNum()) * m
+	h ^= uint64(k.fileNum) * m
 	h ^= k.offset * m
 	return uint32(h >> shift)
 }

--- a/internal/cache/robin_hood_test.go
+++ b/internal/cache/robin_hood_test.go
@@ -45,7 +45,7 @@ func TestRobinHoodMap(t *testing.T) {
 			// 40% insert.
 			var k key
 			k.id = rng.Uint64()
-			k.fileNum = base.FileNum(rng.Uint64()).DiskFileNum()
+			k.fileNum = base.DiskFileNum(rng.Uint64())
 			k.offset = rng.Uint64()
 			e := &entry{}
 			goMap[k] = e
@@ -93,7 +93,7 @@ func BenchmarkGoMapInsert(b *testing.B) {
 	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 	keys := make([]key, benchSize)
 	for i := range keys {
-		keys[i].fileNum = base.FileNum(rng.Uint64n(1 << 20)).DiskFileNum()
+		keys[i].fileNum = base.DiskFileNum(rng.Uint64n(1 << 20))
 		keys[i].offset = uint64(rng.Intn(1 << 20))
 	}
 	b.ResetTimer()
@@ -114,7 +114,7 @@ func BenchmarkRobinHoodInsert(b *testing.B) {
 	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 	keys := make([]key, benchSize)
 	for i := range keys {
-		keys[i].fileNum = base.FileNum(rng.Uint64n(1 << 20)).DiskFileNum()
+		keys[i].fileNum = base.DiskFileNum(rng.Uint64n(1 << 20))
 		keys[i].offset = uint64(rng.Intn(1 << 20))
 	}
 	e := &entry{}
@@ -140,7 +140,7 @@ func BenchmarkGoMapLookupHit(b *testing.B) {
 	m := make(map[key]*entry, len(keys))
 	e := &entry{}
 	for i := range keys {
-		keys[i].fileNum = base.FileNum(rng.Uint64n(1 << 20)).DiskFileNum()
+		keys[i].fileNum = base.DiskFileNum(rng.Uint64n(1 << 20))
 		keys[i].offset = uint64(rng.Intn(1 << 20))
 		m[keys[i]] = e
 	}
@@ -165,7 +165,7 @@ func BenchmarkRobinHoodLookupHit(b *testing.B) {
 	m := newRobinHoodMap(len(keys))
 	e := &entry{}
 	for i := range keys {
-		keys[i].fileNum = base.FileNum(rng.Uint64n(1 << 20)).DiskFileNum()
+		keys[i].fileNum = base.DiskFileNum(rng.Uint64n(1 << 20))
 		keys[i].offset = uint64(rng.Intn(1 << 20))
 		m.Put(keys[i], e)
 	}
@@ -192,7 +192,7 @@ func BenchmarkGoMapLookupMiss(b *testing.B) {
 	e := &entry{}
 	for i := range keys {
 		keys[i].id = 1
-		keys[i].fileNum = base.FileNum(rng.Uint64n(1 << 20)).DiskFileNum()
+		keys[i].fileNum = base.DiskFileNum(rng.Uint64n(1 << 20))
 		keys[i].offset = uint64(rng.Intn(1 << 20))
 		m[keys[i]] = e
 		keys[i].id = 2
@@ -219,7 +219,7 @@ func BenchmarkRobinHoodLookupMiss(b *testing.B) {
 	e := &entry{}
 	for i := range keys {
 		keys[i].id = 1
-		keys[i].fileNum = base.FileNum(rng.Uint64n(1 << 20)).DiskFileNum()
+		keys[i].fileNum = base.DiskFileNum(rng.Uint64n(1 << 20))
 		keys[i].offset = uint64(rng.Intn(1 << 20))
 		m.Put(keys[i], e)
 		keys[i].id = 2

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -212,7 +212,7 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 				return err
 			}
 			v.RemovedBackingTables = append(
-				v.RemovedBackingTables, base.FileNum(n).DiskFileNum(),
+				v.RemovedBackingTables, base.DiskFileNum(n),
 			)
 		case tagCreatedBackingTable:
 			dfn, err := d.readUvarint()
@@ -224,7 +224,7 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 				return err
 			}
 			fileBacking := &FileBacking{
-				DiskFileNum: base.FileNum(dfn).DiskFileNum(),
+				DiskFileNum: base.DiskFileNum(dfn),
 				Size:        size,
 			}
 			v.CreatedBackingTables = append(v.CreatedBackingTables, fileBacking)
@@ -447,7 +447,7 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 				Meta:  m,
 			}
 			if virtualState.virtual {
-				nfe.BackingFileNum = base.FileNum(virtualState.backingFileNum).DiskFileNum()
+				nfe.BackingFileNum = base.DiskFileNum(virtualState.backingFileNum)
 			}
 			v.NewFiles = append(v.NewFiles, nfe)
 
@@ -546,11 +546,11 @@ func (v *VersionEdit) Encode(w io.Writer) error {
 	}
 	for _, dfn := range v.RemovedBackingTables {
 		e.writeUvarint(tagRemovedBackingTable)
-		e.writeUvarint(uint64(dfn.FileNum()))
+		e.writeUvarint(uint64(dfn))
 	}
 	for _, fileBacking := range v.CreatedBackingTables {
 		e.writeUvarint(tagCreatedBackingTable)
-		e.writeUvarint(uint64(fileBacking.DiskFileNum.FileNum()))
+		e.writeUvarint(uint64(fileBacking.DiskFileNum))
 		e.writeUvarint(fileBacking.Size)
 	}
 	// RocksDB requires LastSeqNum to be encoded for the first MANIFEST entry,
@@ -621,7 +621,7 @@ func (v *VersionEdit) Encode(w io.Writer) error {
 			}
 			if x.Meta.Virtual {
 				e.writeUvarint(customTagVirtual)
-				e.writeUvarint(uint64(x.Meta.FileBacking.DiskFileNum.FileNum()))
+				e.writeUvarint(uint64(x.Meta.FileBacking.DiskFileNum))
 			}
 			if x.Meta.PrefixReplacement != nil {
 				e.writeUvarint(customTagPrefixRewrite)

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -203,14 +203,12 @@ func TestVersionEditRoundTrip(t *testing.T) {
 		{},
 		// A complete version edit.
 		{
-			ComparerName:       "11",
-			MinUnflushedLogNum: 22,
-			ObsoletePrevLogNum: 33,
-			NextFileNum:        44,
-			LastSeqNum:         55,
-			RemovedBackingTables: []base.DiskFileNum{
-				base.FileNum(10).DiskFileNum(), base.FileNum(11).DiskFileNum(),
-			},
+			ComparerName:         "11",
+			MinUnflushedLogNum:   22,
+			ObsoletePrevLogNum:   33,
+			NextFileNum:          44,
+			LastSeqNum:           55,
+			RemovedBackingTables: []base.DiskFileNum{10, 11},
 			CreatedBackingTables: []*FileBacking{m5.FileBacking, m6.FileBacking},
 			DeletedFiles: map[DeletedFileEntry]*FileMetadata{
 				{

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -209,7 +209,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 				if err != nil {
 					return err.Error()
 				}
-				cacheOpts := private.SSTableCacheOpts(0, base.FileNum(uint64(fileNum)-1).DiskFileNum()).(sstable.ReaderOption)
+				cacheOpts := private.SSTableCacheOpts(0, base.DiskFileNum(fileNum-1)).(sstable.ReaderOption)
 				r, err := sstable.NewReader(readable, sstable.ReaderOptions{}, cacheOpts)
 				if err != nil {
 					return err.Error()

--- a/objstorage/objstorage.go
+++ b/objstorage/objstorage.go
@@ -145,7 +145,7 @@ func (meta *ObjectMetadata) AssertValid() {
 			if meta.Remote.CreatorID == 0 {
 				panic(errors.AssertionFailedf("CreatorID not set"))
 			}
-			if meta.Remote.CreatorFileNum == base.FileNum(0).DiskFileNum() {
+			if meta.Remote.CreatorFileNum == 0 {
 				panic(errors.AssertionFailedf("CreatorFileNum not set"))
 			}
 		}

--- a/objstorage/objstorageprovider/provider_test.go
+++ b/objstorage/objstorageprovider/provider_test.go
@@ -300,8 +300,8 @@ func TestSharedMultipleLocators(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, p2.SetCreatorID(2))
 
-	file1 := base.FileNum(1).DiskFileNum()
-	file2 := base.FileNum(2).DiskFileNum()
+	file1 := base.DiskFileNum(1)
+	file2 := base.DiskFileNum(2)
 
 	for i, provider := range []objstorage.Provider{p1, p2} {
 		w, _, err := provider.Create(ctx, base.FileTypeTable, file1, objstorage.CreateOptions{
@@ -410,14 +410,14 @@ func TestAttachCustomObject(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = p1.AttachRemoteObjects([]objstorage.RemoteObjectToAttach{{
-		FileNum:  base.FileNum(1).DiskFileNum(),
+		FileNum:  base.DiskFileNum(1),
 		FileType: base.FileTypeTable,
 		Backing:  backing,
 	}})
 	require.NoError(t, err)
 
 	// Verify the provider can read the object.
-	r, err := p1.OpenForReading(ctx, base.FileTypeTable, base.FileNum(1).DiskFileNum(), objstorage.OpenOptions{})
+	r, err := p1.OpenForReading(ctx, base.FileTypeTable, base.DiskFileNum(1), objstorage.OpenOptions{})
 	require.NoError(t, err)
 	require.Equal(t, int64(len(data)), r.Size())
 	buf := make([]byte, r.Size())
@@ -427,7 +427,7 @@ func TestAttachCustomObject(t *testing.T) {
 
 	// Verify that we can extract a correct backing from this provider and attach
 	// the object to another provider.
-	meta, err := p1.Lookup(base.FileTypeTable, base.FileNum(1).DiskFileNum())
+	meta, err := p1.Lookup(base.FileTypeTable, base.DiskFileNum(1))
 	require.NoError(t, err)
 	handle, err := p1.RemoteObjectBacking(&meta)
 	require.NoError(t, err)
@@ -443,14 +443,14 @@ func TestAttachCustomObject(t *testing.T) {
 	require.NoError(t, p2.SetCreatorID(2))
 
 	_, err = p2.AttachRemoteObjects([]objstorage.RemoteObjectToAttach{{
-		FileNum:  base.FileNum(10).DiskFileNum(),
+		FileNum:  base.DiskFileNum(10),
 		FileType: base.FileTypeTable,
 		Backing:  backing,
 	}})
 	require.NoError(t, err)
 
 	// Verify the provider can read the object.
-	r, err = p2.OpenForReading(ctx, base.FileTypeTable, base.FileNum(10).DiskFileNum(), objstorage.OpenOptions{})
+	r, err = p2.OpenForReading(ctx, base.FileTypeTable, base.DiskFileNum(10), objstorage.OpenOptions{})
 	require.NoError(t, err)
 	require.Equal(t, int64(len(data)), r.Size())
 	buf = make([]byte, r.Size())
@@ -473,7 +473,7 @@ func TestNotExistError(t *testing.T) {
 	require.NoError(t, provider.SetCreatorID(1))
 
 	for i, shared := range []bool{false, true} {
-		fileNum := base.FileNum(1 + i).DiskFileNum()
+		fileNum := base.DiskFileNum(1 + i)
 		name := "local"
 		if shared {
 			name = "remote"

--- a/objstorage/objstorageprovider/remote_backing.go
+++ b/objstorage/objstorageprovider/remote_backing.go
@@ -53,13 +53,13 @@ func (p *provider) encodeRemoteObjectBacking(
 	buf = binary.AppendUvarint(buf, uint64(meta.Remote.CreatorID))
 	// TODO(radu): encode file type as well?
 	buf = binary.AppendUvarint(buf, tagCreatorFileNum)
-	buf = binary.AppendUvarint(buf, uint64(meta.Remote.CreatorFileNum.FileNum()))
+	buf = binary.AppendUvarint(buf, uint64(meta.Remote.CreatorFileNum))
 	buf = binary.AppendUvarint(buf, tagCleanupMethod)
 	buf = binary.AppendUvarint(buf, uint64(meta.Remote.CleanupMethod))
 	if meta.Remote.CleanupMethod == objstorage.SharedRefTracking {
 		buf = binary.AppendUvarint(buf, tagRefCheckID)
 		buf = binary.AppendUvarint(buf, uint64(p.remote.shared.creatorID))
-		buf = binary.AppendUvarint(buf, uint64(meta.DiskFileNum.FileNum()))
+		buf = binary.AppendUvarint(buf, uint64(meta.DiskFileNum))
 	}
 	if meta.Remote.Locator != "" {
 		buf = binary.AppendUvarint(buf, tagLocator)
@@ -196,14 +196,14 @@ func decodeRemoteObjectBacking(
 	res.meta.DiskFileNum = fileNum
 	res.meta.FileType = fileType
 	res.meta.Remote.CreatorID = objstorage.CreatorID(creatorID)
-	res.meta.Remote.CreatorFileNum = base.FileNum(creatorFileNum).DiskFileNum()
+	res.meta.Remote.CreatorFileNum = base.DiskFileNum(creatorFileNum)
 	res.meta.Remote.CleanupMethod = objstorage.SharedCleanupMethod(cleanupMethod)
 	if res.meta.Remote.CleanupMethod == objstorage.SharedRefTracking {
 		if refCheckCreatorID == 0 || refCheckFileNum == 0 {
 			return decodedBacking{}, errors.Newf("remote object backing missing ref to check")
 		}
 		res.refToCheck.creatorID = objstorage.CreatorID(refCheckCreatorID)
-		res.refToCheck.fileNum = base.FileNum(refCheckFileNum).DiskFileNum()
+		res.refToCheck.fileNum = base.DiskFileNum(refCheckFileNum)
 	}
 	res.meta.Remote.Locator = remote.Locator(locator)
 	res.meta.Remote.CustomObjectName = customObjName

--- a/objstorage/objstorageprovider/remote_backing_test.go
+++ b/objstorage/objstorageprovider/remote_backing_test.go
@@ -34,11 +34,11 @@ func TestSharedObjectBacking(t *testing.T) {
 			const creatorID = objstorage.CreatorID(99)
 			require.NoError(t, p.SetCreatorID(creatorID))
 			meta := objstorage.ObjectMetadata{
-				DiskFileNum: base.FileNum(1).DiskFileNum(),
+				DiskFileNum: base.DiskFileNum(1),
 				FileType:    base.FileTypeTable,
 			}
 			meta.Remote.CreatorID = 100
-			meta.Remote.CreatorFileNum = base.FileNum(200).DiskFileNum()
+			meta.Remote.CreatorFileNum = base.DiskFileNum(200)
 			meta.Remote.CleanupMethod = cleanup
 			meta.Remote.Locator = "foo"
 			meta.Remote.CustomObjectName = "obj-name"
@@ -52,18 +52,18 @@ func TestSharedObjectBacking(t *testing.T) {
 			_, err = h.Get()
 			require.Error(t, err)
 
-			d1, err := decodeRemoteObjectBacking(base.FileTypeTable, base.FileNum(100).DiskFileNum(), buf)
+			d1, err := decodeRemoteObjectBacking(base.FileTypeTable, base.DiskFileNum(100), buf)
 			require.NoError(t, err)
-			require.Equal(t, uint64(100), uint64(d1.meta.DiskFileNum.FileNum()))
+			require.Equal(t, uint64(100), uint64(d1.meta.DiskFileNum))
 			require.Equal(t, base.FileTypeTable, d1.meta.FileType)
 			d1.meta.Remote.Storage = sharedStorage
 			require.Equal(t, meta.Remote, d1.meta.Remote)
 			if cleanup == objstorage.SharedRefTracking {
 				require.Equal(t, creatorID, d1.refToCheck.creatorID)
-				require.Equal(t, base.FileNum(1).DiskFileNum(), d1.refToCheck.fileNum)
+				require.Equal(t, base.DiskFileNum(1), d1.refToCheck.fileNum)
 			} else {
 				require.Equal(t, objstorage.CreatorID(0), d1.refToCheck.creatorID)
-				require.Equal(t, base.FileNum(0).DiskFileNum(), d1.refToCheck.fileNum)
+				require.Equal(t, base.DiskFileNum(0), d1.refToCheck.fileNum)
 			}
 
 			t.Run("unknown-tags", func(t *testing.T) {
@@ -73,18 +73,18 @@ func TestSharedObjectBacking(t *testing.T) {
 				buf2 = binary.AppendUvarint(buf2, 2)
 				buf2 = append(buf2, 1, 1)
 
-				d2, err := decodeRemoteObjectBacking(base.FileTypeTable, base.FileNum(100).DiskFileNum(), buf2)
+				d2, err := decodeRemoteObjectBacking(base.FileTypeTable, base.DiskFileNum(100), buf2)
 				require.NoError(t, err)
-				require.Equal(t, uint64(100), uint64(d2.meta.DiskFileNum.FileNum()))
+				require.Equal(t, uint64(100), uint64(d2.meta.DiskFileNum))
 				require.Equal(t, base.FileTypeTable, d2.meta.FileType)
 				d2.meta.Remote.Storage = sharedStorage
 				require.Equal(t, meta.Remote, d2.meta.Remote)
 				if cleanup == objstorage.SharedRefTracking {
 					require.Equal(t, creatorID, d2.refToCheck.creatorID)
-					require.Equal(t, base.FileNum(1).DiskFileNum(), d2.refToCheck.fileNum)
+					require.Equal(t, base.DiskFileNum(1), d2.refToCheck.fileNum)
 				} else {
 					require.Equal(t, objstorage.CreatorID(0), d2.refToCheck.creatorID)
-					require.Equal(t, base.FileNum(0).DiskFileNum(), d2.refToCheck.fileNum)
+					require.Equal(t, base.DiskFileNum(0), d2.refToCheck.fileNum)
 				}
 
 				buf3 := buf2
@@ -111,9 +111,9 @@ func TestCreateSharedObjectBacking(t *testing.T) {
 
 	backing, err := p.CreateExternalObjectBacking("foo", "custom-obj-name")
 	require.NoError(t, err)
-	d, err := decodeRemoteObjectBacking(base.FileTypeTable, base.FileNum(100).DiskFileNum(), backing)
+	d, err := decodeRemoteObjectBacking(base.FileTypeTable, base.DiskFileNum(100), backing)
 	require.NoError(t, err)
-	require.Equal(t, uint64(100), uint64(d.meta.DiskFileNum.FileNum()))
+	require.Equal(t, uint64(100), uint64(d.meta.DiskFileNum))
 	require.Equal(t, base.FileTypeTable, d.meta.FileType)
 	require.Equal(t, remote.Locator("foo"), d.meta.Remote.Locator)
 	require.Equal(t, "custom-obj-name", d.meta.Remote.CustomObjectName)
@@ -134,7 +134,7 @@ func TestAttachRemoteObjects(t *testing.T) {
 	require.NoError(t, err)
 	_, err = p.AttachRemoteObjects([]objstorage.RemoteObjectToAttach{{
 		FileType: base.FileTypeTable,
-		FileNum:  base.FileNum(100).DiskFileNum(),
+		FileNum:  100,
 		Backing:  backing,
 	}})
 	require.NoError(t, err)

--- a/objstorage/objstorageprovider/remote_obj_name.go
+++ b/objstorage/objstorageprovider/remote_obj_name.go
@@ -23,7 +23,7 @@ func remoteObjectName(meta objstorage.ObjectMetadata) string {
 	case base.FileTypeTable:
 		return fmt.Sprintf(
 			"%04x-%d-%06d.sst",
-			objHash(meta), meta.Remote.CreatorID, meta.Remote.CreatorFileNum.FileNum(),
+			objHash(meta), meta.Remote.CreatorID, meta.Remote.CreatorFileNum,
 		)
 	}
 	panic("unknown FileType")
@@ -42,14 +42,14 @@ func sharedObjectRefName(
 	}
 	if meta.Remote.CustomObjectName != "" {
 		return fmt.Sprintf(
-			"%s.ref.%d.%06d", meta.Remote.CustomObjectName, refCreatorID, refFileNum.FileNum(),
+			"%s.ref.%d.%06d", meta.Remote.CustomObjectName, refCreatorID, refFileNum,
 		)
 	}
 	switch meta.FileType {
 	case base.FileTypeTable:
 		return fmt.Sprintf(
 			"%04x-%d-%06d.sst.ref.%d.%06d",
-			objHash(meta), meta.Remote.CreatorID, meta.Remote.CreatorFileNum.FileNum(), refCreatorID, refFileNum.FileNum(),
+			objHash(meta), meta.Remote.CreatorID, meta.Remote.CreatorFileNum, refCreatorID, refFileNum,
 		)
 	}
 	panic("unknown FileType")
@@ -63,7 +63,7 @@ func sharedObjectRefPrefix(meta objstorage.ObjectMetadata) string {
 	case base.FileTypeTable:
 		return fmt.Sprintf(
 			"%04x-%d-%06d.sst.ref.",
-			objHash(meta), meta.Remote.CreatorID, meta.Remote.CreatorFileNum.FileNum(),
+			objHash(meta), meta.Remote.CreatorID, meta.Remote.CreatorFileNum,
 		)
 	}
 	panic("unknown FileType")
@@ -87,5 +87,5 @@ func (p *provider) sharedObjectRefName(meta objstorage.ObjectMetadata) string {
 func objHash(meta objstorage.ObjectMetadata) uint16 {
 	const prime1 = 7459
 	const prime2 = 17539
-	return uint16(uint64(meta.Remote.CreatorID)*prime1 + uint64(meta.Remote.CreatorFileNum.FileNum())*prime2)
+	return uint16(uint64(meta.Remote.CreatorID)*prime1 + uint64(meta.Remote.CreatorFileNum)*prime2)
 }

--- a/objstorage/objstorageprovider/remote_obj_name_test.go
+++ b/objstorage/objstorageprovider/remote_obj_name_test.go
@@ -21,10 +21,10 @@ func TestSharedObjectNames(t *testing.T) {
 		}
 		for it := 0; it < 100; it++ {
 			var meta objstorage.ObjectMetadata
-			meta.DiskFileNum = base.FileNum(rand.Intn(100000)).DiskFileNum()
+			meta.DiskFileNum = base.DiskFileNum(rand.Intn(100000))
 			meta.FileType = supportedFileTypes[rand.Int()%len(supportedFileTypes)]
 			meta.Remote.CreatorID = objstorage.CreatorID(rand.Int63())
-			meta.Remote.CreatorFileNum = base.FileNum(rand.Intn(100000)).DiskFileNum()
+			meta.Remote.CreatorFileNum = base.DiskFileNum(rand.Intn(100000))
 			if rand.Intn(4) == 0 {
 				meta.Remote.CustomObjectName = fmt.Sprintf("foo-%d.sst", rand.Intn(10000))
 			}
@@ -48,10 +48,10 @@ func TestSharedObjectNames(t *testing.T) {
 
 	t.Run("example", func(t *testing.T) {
 		var meta objstorage.ObjectMetadata
-		meta.DiskFileNum = base.FileNum(123).DiskFileNum()
+		meta.DiskFileNum = base.DiskFileNum(123)
 		meta.FileType = base.FileTypeTable
 		meta.Remote.CreatorID = objstorage.CreatorID(456)
-		meta.Remote.CreatorFileNum = base.FileNum(789).DiskFileNum()
+		meta.Remote.CreatorFileNum = base.DiskFileNum(789)
 		require.Equal(t, remoteObjectName(meta), "0e17-456-000789.sst")
 		require.Equal(t, sharedObjectRefPrefix(meta), "0e17-456-000789.sst.ref.")
 

--- a/objstorage/objstorageprovider/remoteobjcat/catalog_test.go
+++ b/objstorage/objstorageprovider/remoteobjcat/catalog_test.go
@@ -45,11 +45,11 @@ func TestCatalog(t *testing.T) {
 			}
 			vals := toUInt64(args...)
 			return remoteobjcat.RemoteObjectMetadata{
-				FileNum: base.FileNum(vals[0]).DiskFileNum(),
+				FileNum: base.DiskFileNum(vals[0]),
 				// When we support other file types, we should let the test determine this.
 				FileType:       base.FileTypeTable,
 				CreatorID:      objstorage.CreatorID(vals[1]),
-				CreatorFileNum: base.FileNum(vals[2]).DiskFileNum(),
+				CreatorFileNum: base.DiskFileNum(vals[2]),
 			}
 		}
 
@@ -140,11 +140,11 @@ func TestCatalog(t *testing.T) {
 			for batchIdx := 0; batchIdx < n; batchIdx++ {
 				for i := 0; i < size; i++ {
 					b.AddObject(remoteobjcat.RemoteObjectMetadata{
-						FileNum: base.FileNum(rand.Uint64()).DiskFileNum(),
+						FileNum: base.DiskFileNum(rand.Uint64()),
 						// When we support other file types, we should let the test determine this.
 						FileType:       base.FileTypeTable,
 						CreatorID:      objstorage.CreatorID(rand.Uint64()),
-						CreatorFileNum: base.FileNum(rand.Uint64()).DiskFileNum(),
+						CreatorFileNum: base.DiskFileNum(rand.Uint64()),
 					})
 				}
 				if err := cat.ApplyBatch(b); err != nil {

--- a/objstorage/objstorageprovider/remoteobjcat/version_edit.go
+++ b/objstorage/objstorageprovider/remoteobjcat/version_edit.go
@@ -78,10 +78,10 @@ func (v *VersionEdit) Encode(w io.Writer) error {
 			return err
 		}
 		buf = binary.AppendUvarint(buf, uint64(tagNewObject))
-		buf = binary.AppendUvarint(buf, uint64(meta.FileNum.FileNum()))
+		buf = binary.AppendUvarint(buf, uint64(meta.FileNum))
 		buf = binary.AppendUvarint(buf, objType)
 		buf = binary.AppendUvarint(buf, uint64(meta.CreatorID))
-		buf = binary.AppendUvarint(buf, uint64(meta.CreatorFileNum.FileNum()))
+		buf = binary.AppendUvarint(buf, uint64(meta.CreatorFileNum))
 		buf = binary.AppendUvarint(buf, uint64(meta.CleanupMethod))
 		if meta.Locator != "" {
 			buf = binary.AppendUvarint(buf, uint64(tagNewObjectLocator))
@@ -97,7 +97,7 @@ func (v *VersionEdit) Encode(w io.Writer) error {
 
 	for _, dfn := range v.DeletedObjects {
 		buf = binary.AppendUvarint(buf, uint64(tagDeletedObject))
-		buf = binary.AppendUvarint(buf, uint64(dfn.FileNum()))
+		buf = binary.AppendUvarint(buf, uint64(dfn))
 	}
 	if v.CreatorID.IsSet() {
 		buf = binary.AppendUvarint(buf, uint64(tagCreatorID))
@@ -166,10 +166,10 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 
 			if err == nil {
 				v.NewObjects = append(v.NewObjects, RemoteObjectMetadata{
-					FileNum:          base.FileNum(fileNum).DiskFileNum(),
+					FileNum:          base.DiskFileNum(fileNum),
 					FileType:         fileType,
 					CreatorID:        objstorage.CreatorID(creatorID),
-					CreatorFileNum:   base.FileNum(creatorFileNum).DiskFileNum(),
+					CreatorFileNum:   base.DiskFileNum(creatorFileNum),
 					CleanupMethod:    objstorage.SharedCleanupMethod(cleanupMethod),
 					Locator:          remote.Locator(locator),
 					CustomObjectName: customName,
@@ -180,7 +180,7 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 			var fileNum uint64
 			fileNum, err = binary.ReadUvarint(br)
 			if err == nil {
-				v.DeletedObjects = append(v.DeletedObjects, base.FileNum(fileNum).DiskFileNum())
+				v.DeletedObjects = append(v.DeletedObjects, base.DiskFileNum(fileNum))
 			}
 
 		case tagCreatorID:

--- a/objstorage/objstorageprovider/remoteobjcat/version_edit_test.go
+++ b/objstorage/objstorageprovider/remoteobjcat/version_edit_test.go
@@ -24,10 +24,10 @@ func TestVersionEditRoundTrip(t *testing.T) {
 		{
 			NewObjects: []RemoteObjectMetadata{
 				{
-					FileNum:          base.FileNum(1).DiskFileNum(),
+					FileNum:          base.DiskFileNum(1),
 					FileType:         base.FileTypeTable,
 					CreatorID:        12,
-					CreatorFileNum:   base.FileNum(123).DiskFileNum(),
+					CreatorFileNum:   base.DiskFileNum(123),
 					CleanupMethod:    objstorage.SharedNoCleanup,
 					Locator:          "",
 					CustomObjectName: "foo",
@@ -35,39 +35,39 @@ func TestVersionEditRoundTrip(t *testing.T) {
 			},
 		},
 		{
-			DeletedObjects: []base.DiskFileNum{base.FileNum(1).DiskFileNum()},
+			DeletedObjects: []base.DiskFileNum{base.DiskFileNum(1)},
 		},
 		{
 			CreatorID: 12345,
 			NewObjects: []RemoteObjectMetadata{
 				{
-					FileNum:          base.FileNum(1).DiskFileNum(),
+					FileNum:          base.DiskFileNum(1),
 					FileType:         base.FileTypeTable,
 					CreatorID:        12,
-					CreatorFileNum:   base.FileNum(123).DiskFileNum(),
+					CreatorFileNum:   base.DiskFileNum(123),
 					CleanupMethod:    objstorage.SharedRefTracking,
 					Locator:          "foo",
 					CustomObjectName: "",
 				},
 				{
-					FileNum:          base.FileNum(2).DiskFileNum(),
+					FileNum:          base.DiskFileNum(2),
 					FileType:         base.FileTypeTable,
 					CreatorID:        22,
-					CreatorFileNum:   base.FileNum(223).DiskFileNum(),
+					CreatorFileNum:   base.DiskFileNum(223),
 					Locator:          "bar",
 					CustomObjectName: "obj1",
 				},
 				{
-					FileNum:          base.FileNum(3).DiskFileNum(),
+					FileNum:          base.DiskFileNum(3),
 					FileType:         base.FileTypeTable,
 					CreatorID:        32,
-					CreatorFileNum:   base.FileNum(323).DiskFileNum(),
+					CreatorFileNum:   base.DiskFileNum(323),
 					CleanupMethod:    objstorage.SharedRefTracking,
 					Locator:          "baz",
 					CustomObjectName: "obj2",
 				},
 			},
-			DeletedObjects: []base.DiskFileNum{base.FileNum(4).DiskFileNum(), base.FileNum(5).DiskFileNum()},
+			DeletedObjects: []base.DiskFileNum{base.DiskFileNum(4), base.DiskFileNum(5)},
 		},
 	} {
 		if err := checkRoundTrip(ve); err != nil {

--- a/objstorage/objstorageprovider/sharedcache/shared_cache.go
+++ b/objstorage/objstorageprovider/sharedcache/shared_cache.go
@@ -365,7 +365,7 @@ func (c *Cache) set(fileNum base.DiskFileNum, p []byte, ofs int64) error {
 
 func (c *Cache) getShard(fileNum base.DiskFileNum, ofs int64) *shard {
 	const prime64 = 1099511628211
-	hash := uint64(fileNum.FileNum())*prime64 + uint64(ofs/c.shardingBlockSize)
+	hash := uint64(fileNum)*prime64 + uint64(ofs/c.shardingBlockSize)
 	// TODO(josh): Instance change ops are often run in production. Such an operation
 	// updates len(c.shards); see openSharedCache. As a result, the behavior of this
 	// function changes, and the cache empties out at restart time. We may want a better

--- a/objstorage/objstorageprovider/sharedcache/shared_cache_test.go
+++ b/objstorage/objstorageprovider/sharedcache/shared_cache_test.go
@@ -62,7 +62,7 @@ func TestSharedCache(t *testing.T) {
 			case "write":
 				size := mustParseBytesArg(t, d, "size")
 
-				writable, _, err := provider.Create(ctx, base.FileTypeTable, base.FileNum(1).DiskFileNum(), objstorage.CreateOptions{})
+				writable, _, err := provider.Create(ctx, base.FileTypeTable, base.DiskFileNum(1), objstorage.CreateOptions{})
 				require.NoError(t, err)
 				defer writable.Finish()
 
@@ -84,7 +84,7 @@ func TestSharedCache(t *testing.T) {
 				offset := mustParseBytesArg(t, d, "offset")
 				size := mustParseBytesArg(t, d, "size")
 
-				readable, err := provider.OpenForReading(ctx, base.FileTypeTable, base.FileNum(1).DiskFileNum(), objstorage.OpenOptions{})
+				readable, err := provider.OpenForReading(ctx, base.FileTypeTable, base.DiskFileNum(1), objstorage.OpenOptions{})
 				require.NoError(t, err)
 				defer readable.Close()
 
@@ -92,7 +92,7 @@ func TestSharedCache(t *testing.T) {
 				flags := sharedcache.ReadFlags{
 					ReadOnly: d.Cmd == "read-for-compaction",
 				}
-				err = cache.ReadAt(ctx, base.FileNum(1).DiskFileNum(), got, int64(offset), readable, readable.Size(), flags)
+				err = cache.ReadAt(ctx, base.DiskFileNum(1), got, int64(offset), readable, readable.Size(), flags)
 				// We always expect cache.ReadAt to succeed.
 				require.NoError(t, err)
 				// It is easier to assert this condition programmatically, rather than returning
@@ -147,7 +147,7 @@ func TestSharedCacheRandomized(t *testing.T) {
 					require.NoError(t, err)
 					defer cache.Close()
 
-					writable, _, err := provider.Create(ctx, base.FileTypeTable, base.FileNum(1).DiskFileNum(), objstorage.CreateOptions{})
+					writable, _, err := provider.Create(ctx, base.FileTypeTable, base.DiskFileNum(1), objstorage.CreateOptions{})
 					require.NoError(t, err)
 
 					// With invariants on, Write will modify its input buffer.
@@ -163,7 +163,7 @@ func TestSharedCacheRandomized(t *testing.T) {
 					require.NoError(t, writable.Write(wrote))
 					require.NoError(t, writable.Finish())
 
-					readable, err := provider.OpenForReading(ctx, base.FileTypeTable, base.FileNum(1).DiskFileNum(), objstorage.OpenOptions{})
+					readable, err := provider.OpenForReading(ctx, base.FileTypeTable, base.DiskFileNum(1), objstorage.OpenOptions{})
 					require.NoError(t, err)
 					defer readable.Close()
 
@@ -176,12 +176,12 @@ func TestSharedCacheRandomized(t *testing.T) {
 							offset := rand.Int63n(size)
 
 							got := make([]byte, size-offset)
-							err := cache.ReadAt(ctx, base.FileNum(1).DiskFileNum(), got, offset, readable, readable.Size(), sharedcache.ReadFlags{})
+							err := cache.ReadAt(ctx, base.DiskFileNum(1), got, offset, readable, readable.Size(), sharedcache.ReadFlags{})
 							require.NoError(t, err)
 							require.Equal(t, objData[int(offset):], got)
 
 							got = make([]byte, size-offset)
-							err = cache.ReadAt(ctx, base.FileNum(1).DiskFileNum(), got, offset, readable, readable.Size(), sharedcache.ReadFlags{})
+							err = cache.ReadAt(ctx, base.DiskFileNum(1), got, offset, readable, readable.Size(), sharedcache.ReadFlags{})
 							require.NoError(t, err)
 							require.Equal(t, objData[int(offset):], got)
 						}()

--- a/open.go
+++ b/open.go
@@ -375,7 +375,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 		name string
 	}
 	var logFiles []fileNumAndName
-	var previousOptionsFileNum FileNum
+	var previousOptionsFileNum base.DiskFileNum
 	var previousOptionsFilename string
 	for _, filename := range ls {
 		ft, fn, ok := base.ParseFilename(opts.FS, filename)
@@ -385,8 +385,8 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 
 		// Don't reuse any obsolete file numbers to avoid modifying an
 		// ingested sstable's original external file.
-		if d.mu.versions.nextFileNum <= uint64(fn.FileNum()) {
-			d.mu.versions.nextFileNum = uint64(fn.FileNum()) + 1
+		if d.mu.versions.nextFileNum <= uint64(fn) {
+			d.mu.versions.nextFileNum = uint64(fn) + 1
 		}
 
 		switch ft {
@@ -394,12 +394,12 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 			if fn >= d.mu.versions.minUnflushedLogNum {
 				logFiles = append(logFiles, fileNumAndName{fn, filename})
 			}
-			if d.logRecycler.minRecycleLogNum <= fn.FileNum() {
-				d.logRecycler.minRecycleLogNum = fn.FileNum() + 1
+			if d.logRecycler.minRecycleLogNum <= fn {
+				d.logRecycler.minRecycleLogNum = fn + 1
 			}
 		case fileTypeOptions:
-			if previousOptionsFileNum < fn.FileNum() {
-				previousOptionsFileNum = fn.FileNum()
+			if previousOptionsFileNum < fn {
+				previousOptionsFileNum = fn
 				previousOptionsFilename = filename
 			}
 		case fileTypeTemp, fileTypeOldTemp:
@@ -670,7 +670,7 @@ func GetVersion(dir string, fs vfs.FS) (string, error) {
 		return "", err
 	}
 	var version string
-	lastOptionsSeen := FileNum(0)
+	lastOptionsSeen := base.DiskFileNum(0)
 	for _, filename := range ls {
 		ft, fn, ok := base.ParseFilename(fs, filename)
 		if !ok {
@@ -682,9 +682,9 @@ func GetVersion(dir string, fs vfs.FS) (string, error) {
 			// processed, reset version. This is because rocksdb often
 			// writes multiple options files without deleting previous ones.
 			// Otherwise, skip parsing this options file.
-			if fn.FileNum() > lastOptionsSeen {
+			if fn > lastOptionsSeen {
 				version = ""
-				lastOptionsSeen = fn.FileNum()
+				lastOptionsSeen = fn
 			} else {
 				continue
 			}
@@ -876,7 +876,7 @@ func (d *DB) replayWAL(
 					if n <= 0 {
 						panic("pebble: ingest sstable file num is invalid.")
 					}
-					fileNums = append(fileNums, base.FileNum(fileNum).DiskFileNum())
+					fileNums = append(fileNums, base.DiskFileNum(fileNum))
 				}
 				addFileNum(encodedFileNum)
 
@@ -1117,7 +1117,7 @@ func Peek(dirname string, fs vfs.FS) (*DBDesc, error) {
 // LockDirectory may be used to expand the critical section protected by the
 // database lock to include setup before the call to Open.
 func LockDirectory(dirname string, fs vfs.FS) (*Lock, error) {
-	fileLock, err := fs.Lock(base.MakeFilepath(fs, dirname, fileTypeLock, base.FileNum(0).DiskFileNum()))
+	fileLock, err := fs.Lock(base.MakeFilepath(fs, dirname, fileTypeLock, base.DiskFileNum(0)))
 	if err != nil {
 		return nil, err
 	}

--- a/open_test.go
+++ b/open_test.go
@@ -1073,7 +1073,7 @@ func TestGetVersion(t *testing.T) {
 	require.Equal(t, "0.1", version)
 
 	// Case 3: Manually created OPTIONS file with a higher number.
-	highestOptionsNum := FileNum(0)
+	highestOptionsNum := base.DiskFileNum(0)
 	ls, err := mem.List("")
 	require.NoError(t, err)
 	for _, filename := range ls {
@@ -1083,8 +1083,8 @@ func TestGetVersion(t *testing.T) {
 		}
 		switch ft {
 		case fileTypeOptions:
-			if fn.FileNum() > highestOptionsNum {
-				highestOptionsNum = fn.FileNum()
+			if fn > highestOptionsNum {
+				highestOptionsNum = fn
 			}
 		}
 	}
@@ -1362,8 +1362,8 @@ func TestOpenRatchetsNextFileNum(t *testing.T) {
 
 	// Create a shared file with the newest file num and then close the db.
 	d.mu.Lock()
-	nextFileNum := d.mu.versions.getNextFileNum()
-	w, _, err := d.objProvider.Create(context.TODO(), fileTypeTable, nextFileNum.DiskFileNum(), objstorage.CreateOptions{PreferSharedStorage: true})
+	nextFileNum := d.mu.versions.getNextDiskFileNum()
+	w, _, err := d.objProvider.Create(context.TODO(), fileTypeTable, nextFileNum, objstorage.CreateOptions{PreferSharedStorage: true})
 	require.NoError(t, err)
 	require.NoError(t, w.Write([]byte("foobar")))
 	require.NoError(t, w.Finish())

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -334,14 +334,14 @@ func collectCorpus(t *testing.T, fs *vfs.MemFS, name string) {
 			if fT != "file" {
 				fileNumInt, err := strconv.Atoi(td.CmdArgs[2].String())
 				require.NoError(t, err)
-				fileNum := base.FileNum(fileNumInt)
+				fileNum := base.DiskFileNum(fileNumInt)
 				switch fT {
 				case "table":
-					filePath = base.MakeFilepath(fs, dir, base.FileTypeTable, fileNum.DiskFileNum())
+					filePath = base.MakeFilepath(fs, dir, base.FileTypeTable, fileNum)
 				case "log":
-					filePath = base.MakeFilepath(fs, dir, base.FileTypeLog, fileNum.DiskFileNum())
+					filePath = base.MakeFilepath(fs, dir, base.FileTypeLog, fileNum)
 				case "manifest":
-					filePath = base.MakeFilepath(fs, dir, base.FileTypeManifest, fileNum.DiskFileNum())
+					filePath = base.MakeFilepath(fs, dir, base.FileTypeManifest, fileNum)
 				}
 			}
 			f, err := fs.Create(filePath)

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -191,7 +191,7 @@ func runBuildRawCmd(
 	}
 	defer provider.Close()
 
-	f0, _, err := provider.Create(context.Background(), base.FileTypeTable, base.FileNum(0).DiskFileNum(), objstorage.CreateOptions{})
+	f0, _, err := provider.Create(context.Background(), base.FileTypeTable, base.DiskFileNum(0), objstorage.CreateOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -238,7 +238,7 @@ func runBuildRawCmd(
 		return nil, nil, err
 	}
 
-	f1, err := provider.OpenForReading(context.Background(), base.FileTypeTable, base.FileNum(0).DiskFileNum(), objstorage.OpenOptions{})
+	f1, err := provider.OpenForReading(context.Background(), base.FileTypeTable, base.DiskFileNum(0), objstorage.OpenOptions{})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -143,7 +143,7 @@ func (c *cacheOpts) readerApply(r *Reader) {
 	if r.cacheID == 0 {
 		r.cacheID = c.cacheID
 	}
-	if r.fileNum.FileNum() == 0 {
+	if r.fileNum == 0 {
 		r.fileNum = c.fileNum
 	}
 }
@@ -152,7 +152,7 @@ func (c *cacheOpts) writerApply(w *Writer) {
 	if w.cacheID == 0 {
 		w.cacheID = c.cacheID
 	}
-	if w.fileNum.FileNum() == 0 {
+	if w.fileNum == 0 {
 		w.fileNum = c.fileNum
 	}
 }
@@ -507,7 +507,7 @@ func (r *Reader) readRangeKey(
 }
 
 func checkChecksum(
-	checksumType ChecksumType, b []byte, bh BlockHandle, fileNum base.FileNum,
+	checksumType ChecksumType, b []byte, bh BlockHandle, fileNum base.DiskFileNum,
 ) error {
 	expectedChecksum := binary.LittleEndian.Uint32(b[bh.Length+1:])
 	var computedChecksum uint32
@@ -523,7 +523,7 @@ func checkChecksum(
 	if expectedChecksum != computedChecksum {
 		return base.CorruptionErrorf(
 			"pebble/table: invalid table %s (checksum mismatch at %d/%d)",
-			errors.Safe(fileNum), errors.Safe(bh.Offset), errors.Safe(bh.Length))
+			fileNum, errors.Safe(bh.Offset), errors.Safe(bh.Length))
 	}
 	return nil
 }
@@ -623,7 +623,7 @@ func (r *Reader) readBlock(
 		compressed.release()
 		return bufferHandle{}, err
 	}
-	if err := checkChecksum(r.checksumType, compressed.get(), bh, r.fileNum.FileNum()); err != nil {
+	if err := checkChecksum(r.checksumType, compressed.get(), bh, r.fileNum); err != nil {
 		compressed.release()
 		return bufferHandle{}, err
 	}

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -1040,7 +1040,7 @@ func TestReadaheadSetupForV3TablesWithMultipleVersions(t *testing.T) {
 	provider, err := objstorageprovider.Open(objstorageprovider.DefaultSettings(vfs.Default, tmpDir))
 	require.NoError(t, err)
 	defer provider.Close()
-	f0, _, err := provider.Create(context.Background(), base.FileTypeTable, base.FileNum(0).DiskFileNum(), objstorage.CreateOptions{})
+	f0, _, err := provider.Create(context.Background(), base.FileTypeTable, base.DiskFileNum(0), objstorage.CreateOptions{})
 	require.NoError(t, err)
 
 	w := NewWriter(f0, WriterOptions{
@@ -1058,7 +1058,7 @@ func TestReadaheadSetupForV3TablesWithMultipleVersions(t *testing.T) {
 		}
 	}
 	require.NoError(t, w.Close())
-	f1, err := provider.OpenForReading(context.Background(), base.FileTypeTable, base.FileNum(0).DiskFileNum(), objstorage.OpenOptions{})
+	f1, err := provider.OpenForReading(context.Background(), base.FileTypeTable, base.DiskFileNum(0), objstorage.OpenOptions{})
 	require.NoError(t, err)
 	r, err := NewReader(f1, ReaderOptions{Comparer: testkeys.Comparer})
 	require.NoError(t, err)
@@ -1417,7 +1417,7 @@ func buildTestTableWithProvider(
 	compression Compression,
 	prefix []byte,
 ) *Reader {
-	f0, _, err := provider.Create(context.Background(), base.FileTypeTable, base.FileNum(0).DiskFileNum(), objstorage.CreateOptions{})
+	f0, _, err := provider.Create(context.Background(), base.FileTypeTable, base.DiskFileNum(0), objstorage.CreateOptions{})
 	require.NoError(t, err)
 
 	w := NewWriter(f0, WriterOptions{
@@ -1440,7 +1440,7 @@ func buildTestTableWithProvider(
 	require.NoError(t, w.Close())
 
 	// Re-open that Filename for reading.
-	f1, err := provider.OpenForReading(context.Background(), base.FileTypeTable, base.FileNum(0).DiskFileNum(), objstorage.OpenOptions{})
+	f1, err := provider.OpenForReading(context.Background(), base.FileTypeTable, base.DiskFileNum(0), objstorage.OpenOptions{})
 	require.NoError(t, err)
 
 	c := cache.New(128 << 20)

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -1775,7 +1775,7 @@ func compressAndChecksum(b []byte, compression Compression, blockBuf *blockBuf) 
 func (w *Writer) writeCompressedBlock(block []byte, blockTrailerBuf []byte) (BlockHandle, error) {
 	bh := BlockHandle{Offset: w.meta.Size, Length: uint64(len(block))}
 
-	if w.cacheID != 0 && w.fileNum.FileNum() != 0 {
+	if w.cacheID != 0 && w.fileNum != 0 {
 		// Remove the block being written from the cache. This provides defense in
 		// depth against bugs which cause cache collisions.
 		//
@@ -1802,7 +1802,7 @@ func (w *Writer) writeCompressedBlock(block []byte, blockTrailerBuf []byte) (Blo
 // return a BlockHandle.
 func (w *Writer) Write(blockWithTrailer []byte) (n int, err error) {
 	offset := w.meta.Size
-	if w.cacheID != 0 && w.fileNum.FileNum() != 0 {
+	if w.cacheID != 0 && w.fileNum != 0 {
 		// Remove the block being written from the cache. This provides defense in
 		// depth against bugs which cause cache collisions.
 		//

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -578,7 +578,7 @@ func TestWriterClearCache(t *testing.T) {
 		Comparer:    testkeys.Comparer,
 		TableFormat: TableFormatPebblev3,
 	}
-	cacheOpts := &cacheOpts{cacheID: 1, fileNum: base.FileNum(1).DiskFileNum()}
+	cacheOpts := &cacheOpts{cacheID: 1, fileNum: 1}
 	invalidData := func() *cache.Value {
 		invalid := []byte("invalid data")
 		v := cache.Alloc(len(invalid))

--- a/table_cache.go
+++ b/table_cache.go
@@ -337,7 +337,7 @@ func NewTableCache(cache *Cache, numShards int, size int) *TableCache {
 }
 
 func (c *TableCache) getShard(fileNum base.DiskFileNum) *tableCacheShard {
-	return c.shards[uint64(fileNum.FileNum())%uint64(len(c.shards))]
+	return c.shards[uint64(fileNum)%uint64(len(c.shards))]
 }
 
 type tableCacheKey struct {
@@ -1129,7 +1129,7 @@ func (v *tableCacheValue) load(loadInfo loadInfo, c *tableCacheShard, dbOpts *ta
 	}
 	if err != nil {
 		v.err = errors.Wrapf(
-			err, "pebble: backing file %s error", errors.Safe(loadInfo.backingFileNum.FileNum()))
+			err, "pebble: backing file %s error", loadInfo.backingFileNum)
 	}
 	if v.err == nil && loadInfo.smallestSeqNum == loadInfo.largestSeqNum {
 		v.reader.Properties.GlobalSeqNum = loadInfo.largestSeqNum

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -105,7 +105,7 @@ func (fs *tableCacheTestFS) validateOpenTables(f func(i, gotO, gotC int) error) 
 
 		numStillOpen := 0
 		for i := 0; i < tableCacheTestNumTables; i++ {
-			filename := base.MakeFilepath(fs, "", fileTypeTable, base.FileNum(uint64(i)).DiskFileNum())
+			filename := base.MakeFilepath(fs, "", fileTypeTable, base.DiskFileNum(i))
 			gotO, gotC := fs.openCounts[filename], fs.closeCounts[filename]
 			if gotO > gotC {
 				numStillOpen++
@@ -135,7 +135,7 @@ func (fs *tableCacheTestFS) validateNoneStillOpen() error {
 		defer fs.mu.Unlock()
 
 		for i := 0; i < tableCacheTestNumTables; i++ {
-			filename := base.MakeFilepath(fs, "", fileTypeTable, base.FileNum(uint64(i)).DiskFileNum())
+			filename := base.MakeFilepath(fs, "", fileTypeTable, base.DiskFileNum(i))
 			gotO, gotC := fs.openCounts[filename], fs.closeCounts[filename]
 			if gotO != gotC {
 				return errors.Errorf("i=%d: opened %d times, closed %d times", i, gotO, gotC)
@@ -172,7 +172,7 @@ func newTableCacheContainerTest(
 	defer objProvider.Close()
 
 	for i := 0; i < tableCacheTestNumTables; i++ {
-		w, _, err := objProvider.Create(context.Background(), fileTypeTable, base.FileNum(uint64(i)).DiskFileNum(), objstorage.CreateOptions{})
+		w, _, err := objProvider.Create(context.Background(), fileTypeTable, base.DiskFileNum(i), objstorage.CreateOptions{})
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "fs.Create")
 		}
@@ -786,7 +786,7 @@ func testTableCacheEvictionsInternal(t *testing.T, rangeIter bool) {
 			t.Fatalf("i=%d, j=%d: close: %v", i, j, err)
 		}
 
-		c.evict(base.FileNum(lo + rng.Uint64n(hi-lo)).DiskFileNum())
+		c.evict(base.DiskFileNum(lo + rng.Uint64n(hi-lo)))
 	}
 
 	sumEvicted, nEvicted := 0, 0
@@ -857,8 +857,8 @@ func TestSharedTableCacheEvictions(t *testing.T) {
 			t.Fatalf("i=%d, j=%d: close: %v", i, j, err)
 		}
 
-		c1.evict(base.FileNum(lo + rng.Uint64n(hi-lo)).DiskFileNum())
-		c2.evict(base.FileNum(lo + rng.Uint64n(hi-lo)).DiskFileNum())
+		c1.evict(base.DiskFileNum(lo + rng.Uint64n(hi-lo)))
+		c2.evict(base.DiskFileNum(lo + rng.Uint64n(hi-lo)))
 	}
 
 	check := func(fs *tableCacheTestFS, c *tableCacheContainer) (float64, float64, float64) {
@@ -1120,7 +1120,7 @@ func TestTableCacheClockPro(t *testing.T) {
 		// Ensure that underlying sstables exist on disk, creating each table the
 		// first time it is seen.
 		if !tables[key] {
-			makeTable(base.FileNum(uint64(key)).DiskFileNum())
+			makeTable(base.DiskFileNum(key))
 			tables[key] = true
 		}
 

--- a/tool/find.go
+++ b/tool/find.go
@@ -238,8 +238,8 @@ func (f *findT) readManifests(stdout io.Writer) {
 				if ve.ComparerName != "" {
 					f.comparerName = ve.ComparerName
 				}
-				if num := ve.MinUnflushedLogNum.FileNum(); num != 0 {
-					f.editRefs[num] = append(f.editRefs[num], i)
+				if num := ve.MinUnflushedLogNum; num != 0 {
+					f.editRefs[num.FileNum()] = append(f.editRefs[num.FileNum()], i)
 				}
 				for df := range ve.DeletedFiles {
 					f.editRefs[df.FileNum] = append(f.editRefs[df.FileNum], i)

--- a/tool/make_test_remotecat.go
+++ b/tool/make_test_remotecat.go
@@ -34,10 +34,10 @@ func main() {
 
 	var b remoteobjcat.Batch
 	b.AddObject(remoteobjcat.RemoteObjectMetadata{
-		FileNum:        base.FileNum(1).DiskFileNum(),
+		FileNum:        base.DiskFileNum(1),
 		FileType:       base.FileTypeTable,
 		CreatorID:      3,
-		CreatorFileNum: base.FileNum(1).DiskFileNum(),
+		CreatorFileNum: base.DiskFileNum(1),
 		CleanupMethod:  objstorage.SharedRefTracking,
 		Locator:        "foo",
 	})
@@ -46,16 +46,16 @@ func main() {
 	}
 	b.Reset()
 	b.AddObject(remoteobjcat.RemoteObjectMetadata{
-		FileNum:        base.FileNum(2).DiskFileNum(),
+		FileNum:        base.DiskFileNum(2),
 		FileType:       base.FileTypeTable,
 		CreatorID:      5,
-		CreatorFileNum: base.FileNum(10).DiskFileNum(),
+		CreatorFileNum: base.DiskFileNum(10),
 		CleanupMethod:  objstorage.SharedRefTracking,
 		Locator:        "foo",
 	})
-	b.DeleteObject(base.FileNum(1).DiskFileNum())
+	b.DeleteObject(base.DiskFileNum(1))
 	b.AddObject(remoteobjcat.RemoteObjectMetadata{
-		FileNum:          base.FileNum(3).DiskFileNum(),
+		FileNum:          base.DiskFileNum(3),
 		FileType:         base.FileTypeTable,
 		CleanupMethod:    objstorage.SharedRefTracking,
 		Locator:          "bar",

--- a/tool/wal.go
+++ b/tool/wal.go
@@ -79,7 +79,7 @@ func (w *walT) runDump(cmd *cobra.Command, args []string) {
 			// anyways (which will likely fail when we try to read the file).
 			_, fileNum, ok := base.ParseFilename(w.opts.FS, arg)
 			if !ok {
-				fileNum = base.FileNum(0).DiskFileNum()
+				fileNum = 0
 			}
 
 			f, err := w.opts.FS.Open(arg)

--- a/version_set.go
+++ b/version_set.go
@@ -879,18 +879,18 @@ func findCurrentManifest(
 	var filename string
 	marker, filename, err = atomicfs.LocateMarker(fs, dirname, manifestMarkerName)
 	if err != nil {
-		return nil, base.FileNum(0).DiskFileNum(), false, err
+		return nil, 0, false, err
 	}
 
 	if filename == "" {
 		// The marker hasn't been set yet. This database doesn't exist.
-		return marker, base.FileNum(0).DiskFileNum(), false, nil
+		return marker, 0, false, nil
 	}
 
 	var ok bool
 	_, manifestNum, ok = base.ParseFilename(fs, filename)
 	if !ok {
-		return marker, base.FileNum(0).DiskFileNum(), false, base.CorruptionErrorf("pebble: MANIFEST name %q is malformed", errors.Safe(filename))
+		return marker, 0, false, base.CorruptionErrorf("pebble: MANIFEST name %q is malformed", errors.Safe(filename))
 	}
 	return marker, manifestNum, true, nil
 }


### PR DESCRIPTION
This commit switches from `FileNum` to `DiskFileNum` in more places where we are referring to non-table files.

We also clean up conversions like `FileNum(..).DiskFileNum()` which can now just be `DiskFileNum(..)`.