### PR TITLE
metamorphic: add --try-to-reduce flag

### DIFF
--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -63,6 +63,10 @@ func TestMeta(t *testing.T) {
 		// runOptions() below) or the user specified it manually in order to re-run
 		// a test.
 		onceOpts := runOnceFlags.MakeRunOnceOptions()
+		if runOnceFlags.TryToReduce {
+			tryToReduce(t, runOnceFlags.Dir, runOnceFlags.RunDir)
+			return
+		}
 		metamorphic.RunOnce(t, runOnceFlags.RunDir, runOnceFlags.Seed, filepath.Join(runOnceFlags.RunDir, "history"), onceOpts...)
 
 	default:
@@ -85,6 +89,10 @@ func TestMetaTwoInstance(t *testing.T) {
 		// a test.
 		onceOpts := runOnceFlags.MakeRunOnceOptions()
 		onceOpts = append(onceOpts, metamorphic.MultiInstance(2))
+		if runOnceFlags.TryToReduce {
+			tryToReduce(t, runOnceFlags.Dir, runOnceFlags.RunDir)
+			return
+		}
 		metamorphic.RunOnce(t, runOnceFlags.RunDir, runOnceFlags.Seed, filepath.Join(runOnceFlags.RunDir, "history"), onceOpts...)
 
 	default:

--- a/internal/metamorphic/metaflags/meta_flags.go
+++ b/internal/metamorphic/metaflags/meta_flags.go
@@ -81,6 +81,10 @@ type RunOnceFlags struct {
 	RunDir string
 	// Compare applies to metamorphic.Compare. See "compare" flag below.
 	Compare string
+	// TryToReduce enables a mode where we try to find a minimal subset of
+	// operations that reproduce a problem during a test run (e.g. panic or
+	// internal error).
+	TryToReduce bool
 }
 
 func initRunOnceFlags(c *CommonFlags) *RunOnceFlags {
@@ -93,6 +97,11 @@ func initRunOnceFlags(c *CommonFlags) *RunOnceFlags {
 the result of the run from the first options file in the list. Example, -compare
 random-003,standard-000. The dir flag should have the directory containing these directories.
 Example, -dir _meta/200610-203012.077`)
+
+	flag.BoolVar(&ro.TryToReduce, "try-to-reduce", false,
+		`if set, we will try to reduce the number of operations that cause a failure. The
+verbose flag should be used with this flag.`)
+
 	return ro
 }
 

--- a/internal/metamorphic/reduce_test.go
+++ b/internal/metamorphic/reduce_test.go
@@ -1,0 +1,151 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package metamorphic
+
+import (
+	"bytes"
+	"context"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// tryToReduce starts with a run that reproduces a failure of t.Name() and tries
+// to reduce the number of ops to find a minimal reproduction.
+//
+// Sample usage:
+//
+//	go test -run TestMetaTwoInstance ./internal/metamorphic \
+//	  --run-dir _meta/231220-073015.8533726292752/random-027 \
+//	  --tags invariants --try-to-reduce -v
+//
+// The test will save the smallest reproduction found and print out the relevant
+// information.
+func tryToReduce(t *testing.T, rootDir string, runDir string) {
+	r := makeReducer(t, rootDir, runDir)
+	r.Run(t)
+}
+
+// reducer is a helper that starts with a reproduction of a RunOnce failure and
+// tries to reduce the number of operations.
+type reducer struct {
+	optionsData []byte
+	ops         []string
+
+	// rootDir is the directory storing test state (normally _meta). See
+	// CommonFlags.Dir.
+	rootDir string
+
+	lastSavedDir string
+}
+
+func makeReducer(t *testing.T, rootDir string, runDir string) *reducer {
+	runDir = filepath.Clean(runDir)
+	opsPath := filepath.Join(filepath.Dir(runDir), "ops")
+	opsData, err := os.ReadFile(opsPath)
+	require.NoError(t, err)
+	ops := strings.Split(strings.TrimSpace(string(opsData)), "\n")
+
+	// Load options file.
+	options, err := os.ReadFile(filepath.Join(runDir, "OPTIONS"))
+	require.NoError(t, err)
+
+	t.Logf("Starting with %d operations", len(ops))
+
+	return &reducer{
+		optionsData: options,
+		ops:         ops,
+		rootDir:     rootDir,
+	}
+}
+
+// setupRunDir creates a run directory with the given ops and returns it.
+func (r *reducer) setupRunDir(t *testing.T, ops []string) (metaDir, testDir string) {
+	metaDir, err := os.MkdirTemp(r.rootDir, "reduce-"+time.Now().Format("060102-150405.000"))
+	require.NoError(t, err)
+	testDir = filepath.Join(metaDir, "run")
+	require.NoError(t, os.MkdirAll(testDir, 0755))
+
+	// Write the OPTIONS file.
+	require.NoError(t, os.WriteFile(filepath.Join(testDir, "OPTIONS"), r.optionsData, 0644))
+	// Write the ops file.
+	require.NoError(t, os.WriteFile(filepath.Join(metaDir, "ops"), []byte(strings.Join(ops, "\n")), 0644))
+	return metaDir, testDir
+}
+
+func (r *reducer) try(t *testing.T, ops []string) bool {
+	metaDir, testDir := r.setupRunDir(t, ops)
+
+	args := []string{
+		"-test.run", t.Name() + "$",
+		"-test.v",
+		"--keep",
+		"--dir", metaDir,
+		"--run-dir", testDir,
+	}
+
+	var output bytes.Buffer
+	cmd := exec.CommandContext(context.Background(), os.Args[0], args...)
+	cmd.Stderr = &output
+	cmd.Stdout = &output
+	err := cmd.Run()
+	// If the test succeeds or fails with an internal test error, we removed
+	// important ops.
+	if err == nil || strings.Contains(output.String(), "metamorphic test internal error") {
+		require.NoError(t, os.RemoveAll(metaDir))
+		return false
+	}
+
+	logFile := filepath.Join(metaDir, "log")
+	require.NoError(t, os.WriteFile(logFile, output.Bytes(), 0644))
+	t.Logf("Reduced to %d ops; saved log %v and run dir %v", len(ops), logFile, testDir)
+	// Only keep one saved dir.
+	if r.lastSavedDir != "" {
+		require.NoError(t, os.RemoveAll(r.lastSavedDir))
+	}
+	r.lastSavedDir = metaDir
+	return true
+}
+
+func (r *reducer) Run(t *testing.T) {
+	ops := r.ops
+	// We start with a high probability of removing elements, and once we can't
+	// find any reductions we decrease it. This works well even if the problem is
+	// not deterministic and isn't reproduced on every run.
+	for removeProbability := 0.1; removeProbability > 1e-5; removeProbability *= 0.5 {
+		t.Logf("removeProbability %.2f", removeProbability)
+		for i := 0; i < 100; i++ {
+			o := randomSubset(t, ops, removeProbability)
+			if r.try(t, o) {
+				ops = o
+				// Reset the counter.
+				i = -1
+			}
+		}
+	}
+}
+
+func randomSubset(t *testing.T, ops []string, removeProbability float64) []string {
+	require.Greater(t, len(ops), 1)
+	// The first op is always Init; we need to keep it.
+	res := ops[:1:1]
+	ops = ops[1:]
+	// Regardless of the probability, we choose at least one op to remove.
+	x := rand.Intn(len(ops))
+	for i := range ops {
+		if i == x || rand.Float64() < removeProbability {
+			// Remove this op.
+			continue
+		}
+		res = append(res, ops[i])
+	}
+	return res
+}

--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -438,7 +438,6 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 
 	ops, err := parse(opsData, parserOpts{})
 	require.NoError(t, err)
-	_ = ops
 
 	optionsPath := filepath.Join(runDir, "OPTIONS")
 	optionsData, err := os.ReadFile(optionsPath)

--- a/metamorphic/parser.go
+++ b/metamorphic/parser.go
@@ -523,7 +523,7 @@ func (p *parser) tokenf(tok token.Token, lit string) string {
 }
 
 func (p *parser) errorf(pos token.Pos, format string, args ...interface{}) error {
-	return errors.New(p.fset.Position(pos).String() + ": " + fmt.Sprintf(format, args...))
+	return errors.New("metamorphic test internal error: " + p.fset.Position(pos).String() + ": " + fmt.Sprintf(format, args...))
 }
 
 // computeDerivedFields makes one pass through the provided operations, filling

--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -381,8 +381,8 @@ func (t *Test) clearObj(id objID) {
 }
 
 func (t *Test) getBatch(id objID) *pebble.Batch {
-	if id.tag() != batchTag {
-		panic(fmt.Sprintf("invalid batch ID: %s", id))
+	if id.tag() != batchTag || t.batches[id.slot()] == nil {
+		panic(fmt.Sprintf("metamorphic test internal error: invalid batch ID: %s", id))
 	}
 	return t.batches[id.slot()]
 }

--- a/metamorphic/testdata/parser
+++ b/metamorphic/testdata/parser
@@ -1,40 +1,40 @@
 parse
 foo
 ----
-1:1: unable to parse objectID: "foo"
+metamorphic test internal error: 1:1: unable to parse objectID: "foo"
 
 parse
 "foo"
 ----
-1:1: unexpected token: STRING "\"foo\""
+metamorphic test internal error: 1:1: unexpected token: STRING "\"foo\""
 
 parse
 db.bar()
 ----
-1:1: unknown op db1.bar
+metamorphic test internal error: 1:1: unknown op db1.bar
 
 parse
 db.Apply()
 ----
-1:10: unexpected token: ")"
+metamorphic test internal error: 1:10: unexpected token: ")"
 
 parse
 db.Apply(hello)
 ----
-1:10: unable to parse objectID: "hello"
+metamorphic test internal error: 1:10: unable to parse objectID: "hello"
 
 parse
 db.NewBatch()
 ----
-1:1: assignment expected for db1.NewBatch
+metamorphic test internal error: 1:1: assignment expected for db1.NewBatch
 
 parse
 batch0 = db.Apply()
 ----
-1:10: cannot use db1.Apply in assignment
+metamorphic test internal error: 1:10: cannot use db1.Apply in assignment
 
 parse
 batch0 = db.NewBatch()
 batch0.First()
 ----
-2:1: batch0.First: First is not a method on batch0
+metamorphic test internal error: 2:1: batch0.First: First is not a method on batch0


### PR DESCRIPTION
This change adds a variation of `RunOnce` where we try to reduce the
number of ops that reproduce a problem.

Currently it can be used by tests that fail (e.g. with a panic or
internal error); extending it to "compare" mode in the future should
be easy.

Sample usage:
```
go test -run TestMetaTwoInstance ./internal/metamorphic \
  --run-dir _meta/231220-073015.8533726292752/random-027 \
  --tags invariants --try-to-reduce -v
```

The test will save the smallest reproduction found and print out the
relevant information.