### PR TITLE
internal/manifest: add TestInUseKeyRangesRandomized

### DIFF
--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -1,0 +1,129 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package manifest_test
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors/oserror"
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/metamorphic"
+	"github.com/cockroachdb/pebble/record"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/rand"
+)
+
+// TestInuseKeyRangesRandomized is a randomized test that generates a random
+// database (using the Pebble metamorphic tests), and then tests calculating
+// in-use key ranges for random spans. It asserts that all files that overlap
+// the span are contained within the resulting list of key ranges.
+func TestInuseKeyRangesRandomized(t *testing.T) {
+	seed := uint64(time.Now().UnixNano())
+	t.Logf("seed: %d", seed)
+	rng := rand.New(rand.NewSource(seed))
+
+	// Generate a random database by running the metamorphic test.
+	testOpts := metamorphic.RandomOptions(rng, nil /* custom opt parsers */)
+	testOpts.Opts.Cache.Ref()
+	{
+		ops := metamorphic.GenerateOps(rng, 10000, metamorphic.WriteOpConfig())
+		test, err := metamorphic.New(ops, testOpts, "" /* dir */, io.Discard)
+		require.NoError(t, err)
+		require.NoError(t, metamorphic.Execute(test))
+	}
+	t.Log("Constructed test database state")
+	v := replayManifest(t, testOpts.Opts, "")
+	t.Log(v.DebugString(base.DefaultFormatter))
+
+	const maxKeyLen = 12
+	const maxSuffix = 20
+	ks := testkeys.Alpha(maxKeyLen)
+	smallest := make([]byte, maxKeyLen+testkeys.MaxSuffixLen)
+	largest := make([]byte, maxKeyLen+testkeys.MaxSuffixLen)
+	for i := 0; i < 1000; i++ {
+		n := testkeys.WriteKeyAt(smallest[:cap(smallest)], ks, rng.Int63n(ks.Count()), rng.Int63n(maxSuffix))
+		smallest = smallest[:n]
+		n = testkeys.WriteKeyAt(largest[:cap(largest)], ks, rng.Int63n(ks.Count()), rng.Int63n(maxSuffix))
+		largest = largest[:n]
+		if testOpts.Opts.Comparer.Compare(smallest, largest) > 0 {
+			smallest, largest = largest, smallest
+		}
+
+		level := rng.Intn(manifest.NumLevels)
+		cmp := testOpts.Opts.Comparer.Compare
+		keyRanges := v.CalculateInuseKeyRanges(cmp, level, manifest.NumLevels-1, smallest, largest)
+		t.Logf("%d: [%s, %s] levels L%d-L6: ", i, smallest, largest, level)
+		for _, kr := range keyRanges {
+			t.Logf("  [%s,%s]", kr.Start, kr.End)
+		}
+
+		for l := level; l < manifest.NumLevels; l++ {
+			o := v.Overlaps(l, cmp, smallest, largest, false /* exclusiveEnd */)
+			iter := o.Iter()
+			for f := iter.First(); f != nil; f = iter.Next() {
+				// CalculateInuseKeyRanges only guarantees that it returns key
+				// ranges covering in-use ranges within [smallest, largest]. If
+				// this file extends before or after smallest/largest, truncate
+				// it to be within [smallest,largest] for the purpose of
+				// correctness checking.
+				fileSmallest := f.Smallest.UserKey
+				fileLargest := f.Largest.UserKey
+				if cmp(fileSmallest, smallest) < 0 {
+					fileSmallest = smallest
+				}
+				if cmp(fileLargest, largest) > 0 {
+					fileLargest = largest
+				}
+
+				var containedWithin bool
+				for _, kr := range keyRanges {
+					containedWithin = containedWithin || (cmp(fileSmallest, kr.Start) >= 0 && cmp(fileLargest, kr.End) <= 0)
+				}
+				if !containedWithin {
+					t.Fatalf("file L%d.%s overlaps [%s, %s] but no in-use key range contains it",
+						l, f, smallest, largest)
+				}
+			}
+		}
+	}
+}
+
+func replayManifest(t *testing.T, opts *pebble.Options, dirname string) *manifest.Version {
+	desc, err := pebble.Peek(dirname, opts.FS)
+	require.NoError(t, err)
+	if !desc.Exists {
+		t.Fatal(oserror.ErrNotExist)
+	}
+
+	// Replay the manifest to get the current version.
+	f, err := opts.FS.Open(desc.ManifestFilename)
+	require.NoError(t, err)
+	defer f.Close()
+
+	cmp := opts.Comparer
+	var bve manifest.BulkVersionEdit
+	bve.AddedByFileNum = make(map[base.FileNum]*manifest.FileMetadata)
+	rr := record.NewReader(f, 0 /* logNum */)
+	for {
+		r, err := rr.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		var ve manifest.VersionEdit
+		require.NoError(t, ve.Decode(r))
+		require.NoError(t, bve.Accumulate(&ve))
+	}
+	v, err := bve.Apply(
+		nil /* version */, cmp.Compare, base.DefaultFormatter, opts.FlushSplitBytes,
+		opts.Experimental.ReadCompactionRate, nil /* zombies */)
+	require.NoError(t, err)
+	return v
+}

--- a/metamorphic/config.go
+++ b/metamorphic/config.go
@@ -188,6 +188,63 @@ func DefaultOpConfig() OpConfig {
 	}
 }
 
+// WriteOpConfig builds an OpConfig suitable for generating a random test
+// database. It generates Writer operations and some meta database operations
+// like flushes and manual compactions, but it does not generate any reads.
+func WriteOpConfig() OpConfig {
+	return OpConfig{
+		// dbClose is not in this list since it is deterministically generated once, at the end of the test.
+		ops: [NumOpTypes]int{
+			OpBatchAbort:                  0,
+			OpBatchCommit:                 5,
+			OpDBCheckpoint:                0,
+			OpDBCompact:                   1,
+			OpDBFlush:                     2,
+			OpDBRatchetFormatMajorVersion: 1,
+			OpDBRestart:                   2,
+			OpIterClose:                   0,
+			OpIterFirst:                   0,
+			OpIterLast:                    0,
+			OpIterNext:                    0,
+			OpIterNextWithLimit:           0,
+			OpIterNextPrefix:              0,
+			OpIterPrev:                    0,
+			OpIterPrevWithLimit:           0,
+			OpIterSeekGE:                  0,
+			OpIterSeekGEWithLimit:         0,
+			OpIterSeekLT:                  0,
+			OpIterSeekLTWithLimit:         0,
+			OpIterSeekPrefixGE:            0,
+			OpIterSetBounds:               0,
+			OpIterSetOptions:              0,
+			OpNewBatch:                    10,
+			OpNewIndexedBatch:             0,
+			OpNewIter:                     0,
+			OpNewIterUsingClone:           0,
+			OpNewSnapshot:                 10,
+			OpReaderGet:                   0,
+			OpSnapshotClose:               10,
+			OpWriterApply:                 10,
+			OpWriterDelete:                100,
+			OpWriterDeleteRange:           20,
+			OpWriterIngest:                100,
+			OpWriterMerge:                 100,
+			OpWriterRangeKeySet:           10,
+			OpWriterRangeKeyUnset:         10,
+			OpWriterRangeKeyDelete:        5,
+			OpWriterSet:                   100,
+			OpWriterSingleDelete:          50,
+		},
+		// Use a new prefix 75% of the time (and 25% of the time use an existing
+		// prefix with an alternative suffix).
+		newPrefix: 0.75,
+		// Use a skewed distribution of suffixes to mimic MVCC timestamps. The
+		// range will be widened whenever a suffix is found to already be in use
+		// for a particular prefix.
+		writeSuffixDist: mustDynamic(randvar.NewSkewedLatest(0, 1, 0.99)),
+	}
+}
+
 func multiInstanceConfig() OpConfig {
 	cfg := DefaultOpConfig()
 	cfg.ops[OpReplicate] = 5


### PR DESCRIPTION
This commit adds a randomized test for CalculateInUseKeyRanges. One possible explanation for #114421 could be a compaction incorrectly eliding a tombstone too early, before it's deleted the key it's intended to delete. When a compaction begins, we calculate the "in-use key ranges" beneath the compaction. If a tombstone overlaps an in-use key range, it cannot be elided because there may exist a key that the tombstone should delete within the in-use key range.

This randomized test is intended to shake out any unconsidered edge cases within the non-trivial calculation of in-use key ranges performed during compaction setup.