### PR TITLE
db: set hideObsoletePoints for "boomerang" files

### DIFF
--- a/format_major_version.go
+++ b/format_major_version.go
@@ -197,6 +197,10 @@ const (
 // Pebble version.
 const FormatMinSupported = FormatFlushableIngest
 
+// FormatMinForSharedObjects it the minimum format version that supports shared
+// objects (see CreateOnShared option).
+const FormatMinForSharedObjects = FormatVirtualSSTables
+
 // IsSupported returns true if the version is supported by the current Pebble
 // version.
 func (v FormatMajorVersion) IsSupported() bool {

--- a/ingest.go
+++ b/ingest.go
@@ -1172,6 +1172,12 @@ func (d *DB) IngestAndExcise(
 			panic("IngestAndExcise called with suffixed end key")
 		}
 	}
+	if v := d.FormatMajorVersion(); v < FormatMinForSharedObjects {
+		return IngestOperationStats{}, errors.Errorf(
+			"store has format major version %d; IngestAndExise requires at least %d",
+			v, FormatMinForSharedObjects,
+		)
+	}
 	return d.ingest(paths, ingestTargetLevel, shared, exciseSpan, nil /* external */)
 }
 

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -446,11 +446,13 @@ func standardOptions() []*TestOptions {
 [Options]
   format_major_version=%s
 `, newestFormatMajorVersionToTest),
-		27: `
+		27: fmt.Sprintf(`
+[Options]
+  format_major_version=%s
 [TestOptions]
   shared_storage_enabled=true
   secondary_cache_enabled=true
-`,
+`, pebble.FormatMinForSharedObjects),
 	}
 
 	opts := make([]*TestOptions, len(stdOpts))
@@ -603,6 +605,9 @@ func randomOptions(
 	// 20% of time, enable shared storage.
 	if rng.Intn(5) == 0 {
 		testOpts.sharedStorageEnabled = true
+		if testOpts.Opts.FormatMajorVersion < pebble.FormatMinForSharedObjects {
+			testOpts.Opts.FormatMajorVersion = pebble.FormatMinForSharedObjects
+		}
 		inMemShared := remote.NewInMem()
 		testOpts.Opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"": inMemShared,
@@ -630,12 +635,14 @@ func randomOptions(
 	// testOpts.ingestSplit = rng.Intn(2) == 0
 	opts.Experimental.IngestSplit = func() bool { return testOpts.ingestSplit }
 	testOpts.useExcise = rng.Intn(2) == 0
-	if testOpts.useExcise || testOpts.useSharedReplicate {
-		testOpts.efosAlwaysCreatesIters = rng.Intn(2) == 0
-		opts.TestingAlwaysCreateEFOSIterators(testOpts.efosAlwaysCreatesIters)
+	if testOpts.useExcise {
 		if testOpts.Opts.FormatMajorVersion < pebble.FormatVirtualSSTables {
 			testOpts.Opts.FormatMajorVersion = pebble.FormatVirtualSSTables
 		}
+	}
+	if testOpts.useExcise || testOpts.useSharedReplicate {
+		testOpts.efosAlwaysCreatesIters = rng.Intn(2) == 0
+		opts.TestingAlwaysCreateEFOSIterators(testOpts.efosAlwaysCreatesIters)
 	}
 	testOpts.Opts.EnsureDefaults()
 	return testOpts

--- a/options.go
+++ b/options.go
@@ -1123,6 +1123,9 @@ func (o *Options) EnsureDefaults() *Options {
 
 	if o.FormatMajorVersion == FormatDefault {
 		o.FormatMajorVersion = FormatMinSupported
+		if o.Experimental.CreateOnShared != remote.CreateOnSharedNone {
+			o.FormatMajorVersion = FormatMinForSharedObjects
+		}
 	}
 
 	if o.FS == nil {
@@ -1743,6 +1746,11 @@ func (o *Options) Validate() error {
 	if o.FormatMajorVersion < FormatMinSupported || o.FormatMajorVersion > internalFormatNewest {
 		fmt.Fprintf(&buf, "FormatMajorVersion (%d) must be between %d and %d\n",
 			o.FormatMajorVersion, FormatMinSupported, internalFormatNewest)
+	}
+	if o.Experimental.CreateOnShared != remote.CreateOnSharedNone && o.FormatMajorVersion < FormatMinForSharedObjects {
+		fmt.Fprintf(&buf, "FormatMajorVersion (%d) when CreateOnShared is set must be at least %d\n",
+			o.FormatMajorVersion, FormatMinForSharedObjects)
+
 	}
 	if o.TableCache != nil && o.Cache != o.TableCache.cache {
 		fmt.Fprintf(&buf, "underlying cache in the TableCache and the Cache dont match\n")

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -46,7 +46,7 @@ func TestScanStatistics(t *testing.T) {
 			FS:                 vfs.NewMem(),
 			Logger:             testLogger{t: t},
 			Comparer:           testkeys.Comparer,
-			FormatMajorVersion: FormatMinSupported,
+			FormatMajorVersion: FormatMinForSharedObjects,
 			BlockPropertyCollectors: []func() BlockPropertyCollector{
 				sstable.NewTestKeysBlockPropertyCollector,
 			},

--- a/table_cache.go
+++ b/table_cache.go
@@ -545,10 +545,11 @@ func (c *tableCacheShard) newIters(
 		rp = &tableCacheShardReaderProvider{c: c, file: file, dbOpts: dbOpts}
 	}
 
-	if provider.IsSharedForeign(objMeta) {
+	if objMeta.IsShared() && v.reader.Properties.GlobalSeqNum != 0 {
 		if tableFormat < sstable.TableFormatPebblev4 {
-			return nil, nil, errors.New("pebble: shared foreign sstable has a lower table format than expected")
+			return nil, nil, errors.New("pebble: shared ingested sstable has a lower table format than expected")
 		}
+		// The table is shared and ingested.
 		hideObsoletePoints = true
 	}
 	var categoryAndQoS sstable.CategoryAndQoS

--- a/testdata/batch_reader
+++ b/testdata/batch_reader
@@ -95,4 +95,3 @@ scan
 ----
 Count: 1
 err: decoding user key: pebble: invalid batch
-

--- a/testdata/scan_statistics
+++ b/testdata/scan_statistics
@@ -143,4 +143,4 @@ compact a-z
 scan-statistics lower=a upper=z show-snapshot-pinned
 ----
 Aggregate:
-  snapshot pinned count: 1
+  snapshot pinned count: 0


### PR DESCRIPTION
#### db: add version checks around shared files

We now require the `VirtualSSTables` format to use shared files. This
helps with replication via shared ingest and excise, which requires V4
table format.

We update the metamorphic tests to use the correct version when shared
storage is enabled.

#### db: set hideObsoletePoints for "boomerang" files

We weren't setting this flag correctly When a shared file is ingested
by another store and then ingested back into the original store,
leading to an "out of order keys" error in `TestMetaTwoInstances`.

Informs #3174.