### PR TITLE
db: fix mergingIter, levelIter error propagation

### DIFF
--- a/internal/itertest/dsl.go
+++ b/internal/itertest/dsl.go
@@ -1,0 +1,199 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package itertest
+
+import (
+	"fmt"
+	"go/token"
+	"strings"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/dsl"
+	"github.com/cockroachdb/pebble/vfs/errorfs"
+)
+
+// Predicate encodes conditional logic that yields a boolean.
+type Predicate = dsl.Predicate[*ProbeContext]
+
+// NewParser constructs a Probe parser.
+func NewParser() *dsl.Parser[Probe] {
+	predicateParser := dsl.NewPredicateParser[*ProbeContext]()
+	for i, name := range opNames {
+		opKind := OpKind(i)
+		predicateParser.DefineConstant(name, func() dsl.Predicate[*ProbeContext] {
+			// An OpKind implements dsl.Predicate[*ProbeContext].
+			return opKind
+		})
+	}
+	predicateParser.DefineFunc("UserKey",
+		func(p *dsl.Parser[Predicate], s *dsl.Scanner) dsl.Predicate[*ProbeContext] {
+			userKey := s.ConsumeString()
+			s.Consume(token.RPAREN)
+			return UserKey(userKey)
+		})
+
+	probeParser := dsl.NewParser[Probe]()
+	probeParser.DefineConstant("ErrInjected", func() Probe { return ErrInjected })
+	probeParser.DefineConstant("noop", Noop)
+	probeParser.DefineConstant("Nil", Nil)
+	probeParser.DefineFunc("If",
+		func(p *dsl.Parser[Probe], s *dsl.Scanner) Probe {
+			pred := If(
+				predicateParser.ParseFromPos(s, s.Scan()),
+				probeParser.ParseFromPos(s, s.Scan()),
+				probeParser.ParseFromPos(s, s.Scan()),
+			)
+			s.Consume(token.RPAREN)
+			return pred
+		})
+	probeParser.DefineFunc("ReturnKV",
+		func(p *dsl.Parser[Probe], s *dsl.Scanner) Probe {
+			ik := base.ParseInternalKey(s.ConsumeString())
+			val := []byte(s.ConsumeString())
+			s.Consume(token.RPAREN)
+			return ReturnKV(&ik, val)
+		})
+	probeParser.DefineFunc("Log",
+		func(p *dsl.Parser[Probe], s *dsl.Scanner) (ret Probe) {
+			ret = loggingProbe{prefix: s.ConsumeString()}
+			s.Consume(token.RPAREN)
+			return ret
+		})
+	return probeParser
+}
+
+// ErrInjected is an error artificially injected for testing.
+var ErrInjected = Error("ErrInjected", errorfs.ErrInjected)
+
+// Error returns a Probe that returns the provided error. The name is Name
+// returned by String().
+func Error(name string, err error) *ErrorProbe {
+	return &ErrorProbe{name: name, err: err}
+}
+
+// ErrorProbe is a Probe that injects an error.
+type ErrorProbe struct {
+	name string
+	err  error
+}
+
+// String implements fmt.Stringer.
+func (p *ErrorProbe) String() string {
+	return p.name
+}
+
+// Error implements error, so that injected error values may be used as probes
+// that inject themselves.
+func (p *ErrorProbe) Error() error {
+	return p.err
+}
+
+// Probe implements the Probe interface, replacing the iterator return value
+// with an error.
+func (p *ErrorProbe) Probe(pctx *ProbeContext) {
+	pctx.Op.Return.Err = p.err
+	pctx.Op.Return.Key = nil
+	pctx.Op.Return.Value = base.LazyValue{}
+}
+
+// If a conditional Probe. If its predicate evaluates to true, it probes using
+// its Then probe. If its predicate evalutes to false, it probes using its Else
+// probe.
+func If(pred Predicate, thenProbe, elseProbe Probe) Probe {
+	return ifProbe{pred, thenProbe, elseProbe}
+}
+
+type ifProbe struct {
+	Predicate Predicate
+	Then      Probe
+	Else      Probe
+}
+
+// String implements fmt.Stringer.
+func (p ifProbe) String() string { return fmt.Sprintf("(If %s %s %s)", p.Predicate, p.Then, p.Else) }
+
+// Probe implements Probe.
+func (p ifProbe) Probe(pctx *ProbeContext) {
+	if p.Predicate.Evaluate(pctx) {
+		p.Then.Probe(pctx)
+	} else {
+		p.Else.Probe(pctx)
+	}
+}
+
+type loggingProbe struct {
+	prefix string
+}
+
+func (lp loggingProbe) String() string { return fmt.Sprintf("(Log %q)", lp.prefix) }
+func (lp loggingProbe) Probe(pctx *ProbeContext) {
+	opStr := strings.TrimPrefix(pctx.Kind.String(), "Op")
+	fmt.Fprintf(pctx.Log, "%s%s(", lp.prefix, opStr)
+	if pctx.SeekKey != nil {
+		fmt.Fprintf(pctx.Log, "%q", pctx.SeekKey)
+	}
+	fmt.Fprint(pctx.Log, ") = ")
+	if pctx.Return.Key == nil {
+		fmt.Fprint(pctx.Log, "nil")
+		if pctx.Return.Err != nil {
+			fmt.Fprintf(pctx.Log, " <err=%q>", pctx.Return.Err)
+		}
+	} else {
+		v, _, err := pctx.Return.Value.Value(nil)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Fprintf(pctx.Log, "(%s,%q)", pctx.Return.Key, v)
+	}
+	fmt.Fprintln(pctx.Log)
+}
+
+// UserKey implements a predicate that evaluates to true if the returned
+// InternalKey holds a specific user key.
+type UserKey []byte
+
+// String implements fmt.Stringer.
+func (p UserKey) String() string { return fmt.Sprintf("(UserKey %q)", string(p)) }
+
+// Evaluate implements Predicate.
+func (p UserKey) Evaluate(pctx *ProbeContext) bool {
+	return pctx.Op.Return.Key != nil && pctx.Comparer.Equal(pctx.Op.Return.Key.UserKey, p)
+}
+
+// ReturnKV returns a Probe that modifies an operation's return value to the
+// provided KV pair.
+func ReturnKV(k *base.InternalKey, v []byte) Probe {
+	return &returnKV{k, v}
+}
+
+type returnKV struct {
+	*base.InternalKey
+	Value []byte
+}
+
+// Probe implements Probe.
+func (kv *returnKV) Probe(pctx *ProbeContext) {
+	pctx.Op.Return.Key = kv.InternalKey
+	pctx.Op.Return.Value = base.MakeInPlaceValue(kv.Value)
+}
+
+// Noop returns a Probe that does nothing.
+func Noop() Probe { return noop{} }
+
+type noop struct{}
+
+func (noop) String() string           { return "noop" }
+func (noop) Probe(pctx *ProbeContext) {}
+
+// Nil returns a Probe that always returns nil.
+func Nil() Probe { return returnNil{} }
+
+type returnNil struct{}
+
+func (returnNil) String() string { return "Nil" }
+func (returnNil) Probe(pctx *ProbeContext) {
+	pctx.Op.Return.Key = nil
+	pctx.Op.Return.Value = base.LazyValue{}
+}

--- a/internal/itertest/probe.go
+++ b/internal/itertest/probe.go
@@ -1,0 +1,263 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package itertest
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/dsl"
+)
+
+// OpKind indicates the type of iterator operation being performed.
+type OpKind int8
+
+const (
+	// OpSeekGE indicates a SeekGE internal iterator operation.
+	OpSeekGE OpKind = iota
+	// OpSeekPrefixGE indicates a SeekPrefixGE internal iterator operation.
+	OpSeekPrefixGE
+	// OpSeekLT indicates a SeekLT internal iterator operation.
+	OpSeekLT
+	// OpFirst indicates a First internal iterator operation.
+	OpFirst
+	// OpLast indicates a Last internal iterator operation.
+	OpLast
+	// OpNext indicates a Next internal iterator operation.
+	OpNext
+	// OpNextPrefix indicates a NextPrefix internal iterator operation.
+	OpNextPrefix
+	// OpPrev indicates a Prev internal iterator operation.
+	OpPrev
+	// OpClose indicates a Close internal iterator operation.
+	OpClose
+	numOpKinds
+)
+
+var opNames = [numOpKinds]string{
+	OpSeekGE:       "OpSeekGE",
+	OpSeekPrefixGE: "OpSeekPrefixGE",
+	OpSeekLT:       "OpSeekLT",
+	OpFirst:        "OpFirst",
+	OpLast:         "OpLast",
+	OpNext:         "OpNext",
+	OpNextPrefix:   "OpNextPrefix",
+	OpPrev:         "OpPrev",
+	OpClose:        "OpClose",
+}
+
+// OpKind implements Predicate.
+var _ Predicate = OpKind(0)
+
+// String imlements fmt.Stringer.
+func (o OpKind) String() string { return opNames[o] }
+
+// Evaluate implements Predicate.
+func (o OpKind) Evaluate(pctx *ProbeContext) bool { return pctx.Op.Kind == o }
+
+// Op describes an individual iterator operation being performed.
+type Op struct {
+	Kind    OpKind
+	SeekKey []byte
+	// Return is initialized with the return result of the underlying iterator.
+	// Probes may mutate them.
+	Return struct {
+		Key   *base.InternalKey
+		Value base.LazyValue
+		Err   error
+	}
+}
+
+// Probe defines an interface for probes that may inspect or mutate internal
+// iterator behavior.
+type Probe interface {
+	// Probe inspects, and possibly manipulates, iterator operations' results.
+	Probe(*ProbeContext)
+}
+
+// ProbeContext provides the context within which a Probe is run. It includes
+// information about the iterator operation in progress.
+type ProbeContext struct {
+	Op
+	ProbeState
+}
+
+// ProbeState holds state additional to the context of the operation that's
+// accessible to probes.
+type ProbeState struct {
+	*base.Comparer
+	Log io.Writer
+}
+
+// Attach takes an iterator, an initial state and a probe, returning an iterator
+// that will invoke the provided Probe on all internal iterator operations.
+func Attach(
+	iter base.InternalIterator, initialState ProbeState, probes ...Probe,
+) base.InternalIterator {
+	for i := range probes {
+		iter = &probeIterator{
+			iter:  iter,
+			probe: probes[i],
+			probeCtx: ProbeContext{
+				ProbeState: initialState,
+			},
+		}
+	}
+	return iter
+}
+
+// MustParseProbes parses each DSL string as a separate probe, returning a slice
+// of parsed probes. Panics if any of the probes fail to parse.
+func MustParseProbes(parser *dsl.Parser[Probe], probeDSLs ...string) []Probe {
+	probes := make([]Probe, len(probeDSLs))
+	var err error
+	for i := range probeDSLs {
+		probes[i], err = parser.Parse(probeDSLs[i])
+		if err != nil {
+			panic(err)
+		}
+	}
+	return probes
+}
+
+type probeIterator struct {
+	iter     base.InternalIterator
+	probe    Probe
+	probeCtx ProbeContext
+}
+
+// Assert that errIterator implements the internal iterator interface.
+var _ base.InternalIterator = (*probeIterator)(nil)
+
+// handleOp takes an Op representing the iterator operation performed, and the
+// underlying iterator's return value. It populates `Return.Err` and invokes the
+// probe.
+func (p *probeIterator) handleOp(preProbeOp Op) (*base.InternalKey, base.LazyValue) {
+	p.probeCtx.Op = preProbeOp
+	if preProbeOp.Return.Key == nil && p.iter != nil {
+		p.probeCtx.Op.Return.Err = p.iter.Error()
+	}
+
+	p.probe.Probe(&p.probeCtx)
+	return p.probeCtx.Op.Return.Key, p.probeCtx.Op.Return.Value
+}
+
+func (p *probeIterator) SeekGE(
+	key []byte, flags base.SeekGEFlags,
+) (*base.InternalKey, base.LazyValue) {
+	op := Op{
+		Kind:    OpSeekGE,
+		SeekKey: key,
+	}
+	if p.iter != nil {
+		op.Return.Key, op.Return.Value = p.iter.SeekGE(key, flags)
+	}
+	return p.handleOp(op)
+}
+
+func (p *probeIterator) SeekPrefixGE(
+	prefix, key []byte, flags base.SeekGEFlags,
+) (*base.InternalKey, base.LazyValue) {
+	op := Op{
+		Kind:    OpSeekPrefixGE,
+		SeekKey: key,
+	}
+	if p.iter != nil {
+		op.Return.Key, op.Return.Value = p.iter.SeekPrefixGE(prefix, key, flags)
+	}
+	return p.handleOp(op)
+}
+
+func (p *probeIterator) SeekLT(
+	key []byte, flags base.SeekLTFlags,
+) (*base.InternalKey, base.LazyValue) {
+	op := Op{
+		Kind:    OpSeekLT,
+		SeekKey: key,
+	}
+	if p.iter != nil {
+		op.Return.Key, op.Return.Value = p.iter.SeekLT(key, flags)
+	}
+	return p.handleOp(op)
+}
+
+func (p *probeIterator) First() (*base.InternalKey, base.LazyValue) {
+	op := Op{Kind: OpFirst}
+	if p.iter != nil {
+		op.Return.Key, op.Return.Value = p.iter.First()
+	}
+	return p.handleOp(op)
+}
+
+func (p *probeIterator) Last() (*base.InternalKey, base.LazyValue) {
+	op := Op{Kind: OpLast}
+	if p.iter != nil {
+		op.Return.Key, op.Return.Value = p.iter.Last()
+	}
+	return p.handleOp(op)
+}
+
+func (p *probeIterator) Next() (*base.InternalKey, base.LazyValue) {
+	op := Op{Kind: OpNext}
+	if p.iter != nil {
+		op.Return.Key, op.Return.Value = p.iter.Next()
+	}
+	return p.handleOp(op)
+}
+
+func (p *probeIterator) NextPrefix(succKey []byte) (*base.InternalKey, base.LazyValue) {
+	op := Op{Kind: OpNextPrefix, SeekKey: succKey}
+	if p.iter != nil {
+		op.Return.Key, op.Return.Value = p.iter.NextPrefix(succKey)
+	}
+	return p.handleOp(op)
+}
+
+func (p *probeIterator) Prev() (*base.InternalKey, base.LazyValue) {
+	op := Op{Kind: OpPrev}
+	if p.iter != nil {
+		op.Return.Key, op.Return.Value = p.iter.Prev()
+	}
+	return p.handleOp(op)
+}
+
+func (p *probeIterator) Error() error {
+	return p.probeCtx.Op.Return.Err
+}
+
+func (p *probeIterator) Close() error {
+	op := Op{Kind: OpClose}
+	if p.iter != nil {
+		op.Return.Err = p.iter.Close()
+	}
+
+	// NB: Can't use handleOp because a close returns its error value directly
+	// (and does not return a KV pair). We don't want to call iter.Error()
+	// again, but rather use the error directly returned by iter.Close().
+	p.probeCtx.Op = op
+	p.probe.Probe(&p.probeCtx)
+	return p.Error()
+}
+
+func (p *probeIterator) SetBounds(lower, upper []byte) {
+	if p.iter != nil {
+		p.iter.SetBounds(lower, upper)
+	}
+}
+
+func (p *probeIterator) SetContext(ctx context.Context) {
+	if p.iter != nil {
+		p.iter.SetContext(ctx)
+	}
+}
+
+func (p *probeIterator) String() string {
+	if p.iter != nil {
+		return fmt.Sprintf("probeIterator(%q)", p.iter.String())
+	}
+	return "probeIterator(nil)"
+}

--- a/internal/itertest/probe_test.go
+++ b/internal/itertest/probe_test.go
@@ -1,0 +1,45 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package itertest
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+)
+
+func TestProbes(t *testing.T) {
+	var sb strings.Builder
+	parser := NewParser()
+	var iter base.InternalIterator
+	datadriven.RunTest(t, "testdata/probes", func(t *testing.T, td *datadriven.TestData) string {
+		sb.Reset()
+		switch td.Cmd {
+		case "new":
+			iter = nil
+			// new expects each line to describe a probe in the DSL. Each probe
+			// is used to wrap the iterator resulting from attaching the probe
+			// on the previous line.
+			for _, l := range strings.Split(strings.TrimSpace(td.Input), "\n") {
+				probe, err := parser.Parse(l)
+				if err != nil {
+					return fmt.Sprintf("parsing err: %s\n", err)
+				}
+				iter = Attach(iter, ProbeState{
+					Comparer: testkeys.Comparer,
+				}, probe)
+			}
+			return sb.String()
+		case "iter":
+			return RunInternalIterCmd(t, td, iter, Verbose)
+		default:
+			return fmt.Sprintf("unrecognized command %q", td.Cmd)
+		}
+	})
+}

--- a/internal/itertest/testdata/probes
+++ b/internal/itertest/testdata/probes
@@ -1,0 +1,146 @@
+# Create a probe that ignores the inner iterator's return values
+# and instead returns a specific KV. It should apply to all internal
+# iterator operations because there's no conditional logic.
+
+new
+(ReturnKV "bar.SET.2" "value")
+----
+
+iter
+first
+next
+seek-ge foo
+seek-lt bar
+last
+prev
+----
+bar#2,1:value
+bar#2,1:value
+bar#2,1:value
+bar#2,1:value
+bar#2,1:value
+bar#2,1:value
+
+# Create an identical probe as above, and then wrap it in a "noop" probe.
+# A noop probe does nothing; it passes through the child iterator's results
+# verbatim, so the iteration results should be the same.
+
+new
+(ReturnKV "bar.SET.2" "value")
+noop
+----
+
+iter
+first
+next
+seek-ge foo
+seek-lt bar
+last
+prev
+----
+bar#2,1:value
+bar#2,1:value
+bar#2,1:value
+bar#2,1:value
+bar#2,1:value
+bar#2,1:value
+
+# Again, create an iterator with similar probes but this time with an additional
+# probe level that ignores the inner return values and injects errors.
+
+new
+(ReturnKV "bar.SET.2" "value")
+noop
+ErrInjected
+----
+
+iter
+first
+next
+seek-ge foo
+seek-lt bar
+last
+prev
+----
+err=injected error
+err=injected error
+err=injected error
+err=injected error
+err=injected error
+err=injected error
+
+# Create a probe that returns a specific KV on seeks and errors on
+# Next and Prev.
+
+new
+(If (Or OpNext OpPrev) ErrInjected (ReturnKV "bar.SET.2" "value"))
+----
+
+iter
+first
+next
+seek-ge foo
+seek-lt bar
+last
+prev
+----
+bar#2,1:value
+err=injected error
+bar#2,1:value
+bar#2,1:value
+bar#2,1:value
+err=injected error
+
+# Create a probe that returns an error on the 3rd seek-ge.
+
+new
+(If (And OpSeekGE (OnIndex 2)) ErrInjected (ReturnKV "ok.SET.1" "ok"))
+----
+
+iter
+first
+next
+seek-ge foo
+seek-lt bar
+last
+prev
+seek-ge bar
+seek-ge bax
+seek-ge bop
+----
+ok#1,1:ok
+ok#1,1:ok
+ok#1,1:ok
+ok#1,1:ok
+ok#1,1:ok
+ok#1,1:ok
+ok#1,1:ok
+err=injected error
+ok#1,1:ok
+
+# Create a probe that always returns nil, except for on the 3rd seek-ge.
+
+new
+(If (And OpSeekGE (OnIndex 2)) (ReturnKV "ok.SET.1" "ok") Nil)
+----
+
+iter
+first
+next
+seek-ge foo
+seek-lt bar
+last
+prev
+seek-ge bar
+seek-ge bax
+seek-ge bop
+----
+.
+.
+.
+.
+.
+.
+.
+ok#1,1:ok
+.

--- a/internal/keyspan/seek.go
+++ b/internal/keyspan/seek.go
@@ -23,12 +23,14 @@ func SeekLE(cmp base.Compare, iter FragmentIterator, key []byte) *Span {
 	iterSpan := iter.SeekLT(key)
 
 	if iterSpan == nil {
-		// Advance the iterator once to see if the next span has a start key
-		// equal to key.
-		iterSpan = iter.Next()
-		if iterSpan == nil || cmp(key, iterSpan.Start) < 0 {
-			// The iterator is exhausted or we've hit the next span.
-			return nil
+		if iter.Error() == nil {
+			// Advance the iterator once to see if the next span has a start key
+			// equal to key.
+			iterSpan = iter.Next()
+			if iterSpan == nil || cmp(key, iterSpan.Start) < 0 {
+				// The iterator is exhausted or we've hit the next span.
+				return nil
+			}
 		}
 	} else {
 		// Invariant: key > iterSpan.Start
@@ -37,7 +39,7 @@ func SeekLE(cmp base.Compare, iter FragmentIterator, key []byte) *Span {
 			// the next span contains the search key. If it doesn't, we'll backup
 			// and return to our earlier candidate.
 			iterSpan = iter.Next()
-			if iterSpan == nil || cmp(key, iterSpan.Start) < 0 {
+			if (iterSpan == nil && iter.Error() == nil) || cmp(key, iterSpan.Start) < 0 {
 				// The next span is past our search key or there is no next span. Go
 				// back.
 				iterSpan = iter.Prev()

--- a/keyspan_probe_test.go
+++ b/keyspan_probe_test.go
@@ -1,0 +1,387 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"fmt"
+	"go/token"
+	"io"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/dsl"
+	"github.com/cockroachdb/pebble/internal/keyspan"
+)
+
+// This file contains testing facilities for Spans and FragmentIterators. It's
+// a copy of the facilities defined in internal/keyspan/datadriven_test.go.
+//
+// TODO(jackson): Move keyspan.{Span,Key,FragmentIterator} into internal/base,
+// and then move the testing facilities to an independent package, eg
+// internal/itertest, where it may be shared by both uses.
+
+// keyspanProbe defines an interface for probes that may inspect or mutate internal
+// span iterator behavior.
+type keyspanProbe interface {
+	// probe inspects, and possibly manipulates, iterator operations' results.
+	probe(*keyspanProbeContext)
+}
+
+func parseKeyspanProbes(probeDSLs ...string) []keyspanProbe {
+	probes := make([]keyspanProbe, len(probeDSLs))
+	var err error
+	for i := range probeDSLs {
+		probes[i], err = probeParser.Parse(probeDSLs[i])
+		if err != nil {
+			panic(err)
+		}
+	}
+	return probes
+}
+
+func attachKeyspanProbes(
+	iter keyspan.FragmentIterator, pctx keyspanProbeContext, probes ...keyspanProbe,
+) keyspan.FragmentIterator {
+	if pctx.log == nil {
+		pctx.log = io.Discard
+	}
+	for i := range probes {
+		iter = &probeKeyspanIterator{
+			iter:     iter,
+			probe:    probes[i],
+			probeCtx: pctx,
+		}
+	}
+	return iter
+}
+
+// keyspanProbeContext provides the context within which a probe is run. It includes
+// information about the iterator operation in progress.
+type keyspanProbeContext struct {
+	keyspanOp
+	log io.Writer
+}
+
+type keyspanOp struct {
+	Kind    keyspanOpKind
+	SeekKey []byte
+	Span    *keyspan.Span
+	Err     error
+}
+
+// errInjected is an error artificially injected for testing.
+var errInjected = &errorProbe{name: "ErrInjected", err: errors.New("injected error")}
+
+var probeParser = func() *dsl.Parser[keyspanProbe] {
+	valuerParser := dsl.NewParser[valuer]()
+	valuerParser.DefineConstant("StartKey", func() valuer { return startKey{} })
+	valuerParser.DefineConstant("SeekKey", func() valuer { return seekKey{} })
+	valuerParser.DefineFunc("Bytes",
+		func(p *dsl.Parser[valuer], s *dsl.Scanner) valuer {
+			v := bytesConstant{bytes: []byte(s.ConsumeString())}
+			s.Consume(token.RPAREN)
+			return v
+		})
+
+	predicateParser := dsl.NewPredicateParser[*keyspanProbeContext]()
+	predicateParser.DefineFunc("Equal",
+		func(p *dsl.Parser[dsl.Predicate[*keyspanProbeContext]], s *dsl.Scanner) dsl.Predicate[*keyspanProbeContext] {
+			eq := equal{
+				valuerParser.ParseFromPos(s, s.Scan()),
+				valuerParser.ParseFromPos(s, s.Scan()),
+			}
+			s.Consume(token.RPAREN)
+			return eq
+		})
+	for i, name := range opNames {
+		opKind := keyspanOpKind(i)
+		predicateParser.DefineConstant(name, func() dsl.Predicate[*keyspanProbeContext] {
+			// An OpKind implements dsl.Predicate[*probeContext].
+			return opKind
+		})
+	}
+	probeParser := dsl.NewParser[keyspanProbe]()
+	probeParser.DefineConstant("ErrInjected", func() keyspanProbe { return errInjected })
+	probeParser.DefineConstant("noop", func() keyspanProbe { return noop{} })
+	probeParser.DefineFunc("If",
+		func(p *dsl.Parser[keyspanProbe], s *dsl.Scanner) keyspanProbe {
+			probe := ifProbe{
+				predicateParser.ParseFromPos(s, s.Scan()),
+				probeParser.ParseFromPos(s, s.Scan()),
+				probeParser.ParseFromPos(s, s.Scan()),
+			}
+			s.Consume(token.RPAREN)
+			return probe
+		})
+	probeParser.DefineFunc("Return",
+		func(p *dsl.Parser[keyspanProbe], s *dsl.Scanner) (ret keyspanProbe) {
+			switch tok := s.Scan(); tok.Kind {
+			case token.STRING:
+				str, err := strconv.Unquote(tok.Lit)
+				if err != nil {
+					panic(err)
+				}
+				span := keyspan.ParseSpan(str)
+				ret = returnSpan{s: &span}
+			case token.IDENT:
+				switch tok.Lit {
+				case "nil":
+					ret = returnSpan{s: nil}
+				default:
+					panic(errors.Newf("unrecognized return value %q", tok.Lit))
+				}
+			}
+			s.Consume(token.RPAREN)
+			return ret
+		})
+	probeParser.DefineFunc("Log",
+		func(p *dsl.Parser[keyspanProbe], s *dsl.Scanner) (ret keyspanProbe) {
+			ret = loggingProbe{prefix: s.ConsumeString()}
+			s.Consume(token.RPAREN)
+			return ret
+		})
+	return probeParser
+}()
+
+// probe implementations
+
+type errorProbe struct {
+	name string
+	err  error
+}
+
+func (p *errorProbe) String() string { return p.name }
+func (p *errorProbe) Error() error   { return p.err }
+func (p *errorProbe) probe(pctx *keyspanProbeContext) {
+	pctx.keyspanOp.Err = p.err
+	pctx.keyspanOp.Span = nil
+}
+
+// ifProbe is a conditional probe. If its predicate evaluates to true, it probes
+// using its Then probe. If its predicate evalutes to false, it probes using its
+// Else probe.
+type ifProbe struct {
+	Predicate dsl.Predicate[*keyspanProbeContext]
+	Then      keyspanProbe
+	Else      keyspanProbe
+}
+
+func (p ifProbe) String() string { return fmt.Sprintf("(If %s %s %s)", p.Predicate, p.Then, p.Else) }
+func (p ifProbe) probe(pctx *keyspanProbeContext) {
+	if p.Predicate.Evaluate(pctx) {
+		p.Then.probe(pctx)
+	} else {
+		p.Else.probe(pctx)
+	}
+}
+
+type returnSpan struct {
+	s *keyspan.Span
+}
+
+func (p returnSpan) String() string {
+	if p.s == nil {
+		return "(Return nil)"
+	}
+	return fmt.Sprintf("(Return %q)", p.s.String())
+}
+
+func (p returnSpan) probe(pctx *keyspanProbeContext) {
+	pctx.keyspanOp.Span = p.s
+	pctx.keyspanOp.Err = nil
+}
+
+type noop struct{}
+
+func (noop) String() string                  { return "Noop" }
+func (noop) probe(pctx *keyspanProbeContext) {}
+
+type loggingProbe struct {
+	prefix string
+}
+
+func (lp loggingProbe) String() string { return fmt.Sprintf("(Log %q)", lp.prefix) }
+func (lp loggingProbe) probe(pctx *keyspanProbeContext) {
+	opStr := strings.TrimPrefix(pctx.keyspanOp.Kind.String(), "Op")
+	fmt.Fprintf(pctx.log, "%s%s(", lp.prefix, opStr)
+	if pctx.keyspanOp.SeekKey != nil {
+		fmt.Fprintf(pctx.log, "%q", pctx.keyspanOp.SeekKey)
+	}
+	fmt.Fprint(pctx.log, ") = ")
+	if pctx.keyspanOp.Span == nil {
+		fmt.Fprint(pctx.log, "nil")
+		if pctx.keyspanOp.Err != nil {
+			fmt.Fprintf(pctx.log, " <err=%q>", pctx.keyspanOp.Err)
+		}
+	} else {
+		fmt.Fprint(pctx.log, pctx.keyspanOp.Span.String())
+	}
+	fmt.Fprintln(pctx.log)
+}
+
+// dsl.Predicate[*probeContext] implementations.
+
+type equal struct {
+	a, b valuer
+}
+
+func (e equal) String() string { return fmt.Sprintf("(Equal %s %s)", e.a, e.b) }
+func (e equal) Evaluate(pctx *keyspanProbeContext) bool {
+	return reflect.DeepEqual(e.a.value(pctx), e.b.value(pctx))
+}
+
+// keyspanOpKind indicates the type of iterator operation being performed.
+type keyspanOpKind int8
+
+const (
+	opSpanSeekGE keyspanOpKind = iota
+	opSpanSeekLT
+	opSpanFirst
+	opSpanLast
+	opSpanNext
+	opSpanPrev
+	opSpanClose
+	numKeyspanOpKinds
+)
+
+func (o keyspanOpKind) String() string                          { return opNames[o] }
+func (o keyspanOpKind) Evaluate(pctx *keyspanProbeContext) bool { return pctx.keyspanOp.Kind == o }
+
+var opNames = [numKeyspanOpKinds]string{
+	opSpanSeekGE: "opSpanSeekGE",
+	opSpanSeekLT: "opSpanSeekLT",
+	opSpanFirst:  "opSpanFirst",
+	opSpanLast:   "opSpanLast",
+	opSpanNext:   "opSpanNext",
+	opSpanPrev:   "opSpanPrev",
+	opSpanClose:  "opSpanClose",
+}
+
+// valuer implementations
+
+type valuer interface {
+	fmt.Stringer
+	value(pctx *keyspanProbeContext) any
+}
+
+type bytesConstant struct {
+	bytes []byte
+}
+
+func (b bytesConstant) String() string                      { return fmt.Sprintf("%q", string(b.bytes)) }
+func (b bytesConstant) value(pctx *keyspanProbeContext) any { return b.bytes }
+
+type startKey struct{}
+
+func (s startKey) String() string { return "StartKey" }
+func (s startKey) value(pctx *keyspanProbeContext) any {
+	if pctx.keyspanOp.Span == nil {
+		return nil
+	}
+	return pctx.keyspanOp.Span.Start
+}
+
+type seekKey struct{}
+
+func (s seekKey) String() string { return "SeekKey" }
+func (s seekKey) value(pctx *keyspanProbeContext) any {
+	if pctx.keyspanOp.SeekKey == nil {
+		return nil
+	}
+	return pctx.keyspanOp.SeekKey
+}
+
+type probeKeyspanIterator struct {
+	iter     keyspan.FragmentIterator
+	err      error
+	probe    keyspanProbe
+	probeCtx keyspanProbeContext
+}
+
+// Assert that probeIterator implements the fragment iterator interface.
+var _ keyspan.FragmentIterator = (*probeKeyspanIterator)(nil)
+
+func (p *probeKeyspanIterator) handleOp(preProbeOp keyspanOp) *keyspan.Span {
+	p.probeCtx.keyspanOp = preProbeOp
+	if preProbeOp.Span == nil && p.iter != nil {
+		p.probeCtx.keyspanOp.Err = p.iter.Error()
+	}
+
+	p.probe.probe(&p.probeCtx)
+	p.err = p.probeCtx.keyspanOp.Err
+	return p.probeCtx.keyspanOp.Span
+}
+
+func (p *probeKeyspanIterator) SeekGE(key []byte) *keyspan.Span {
+	op := keyspanOp{
+		Kind:    opSpanSeekGE,
+		SeekKey: key,
+	}
+	if p.iter != nil {
+		op.Span = p.iter.SeekGE(key)
+	}
+	return p.handleOp(op)
+}
+
+func (p *probeKeyspanIterator) SeekLT(key []byte) *keyspan.Span {
+	op := keyspanOp{
+		Kind:    opSpanSeekLT,
+		SeekKey: key,
+	}
+	if p.iter != nil {
+		op.Span = p.iter.SeekLT(key)
+	}
+	return p.handleOp(op)
+}
+
+func (p *probeKeyspanIterator) First() *keyspan.Span {
+	op := keyspanOp{Kind: opSpanFirst}
+	if p.iter != nil {
+		op.Span = p.iter.First()
+	}
+	return p.handleOp(op)
+}
+
+func (p *probeKeyspanIterator) Last() *keyspan.Span {
+	op := keyspanOp{Kind: opSpanLast}
+	if p.iter != nil {
+		op.Span = p.iter.Last()
+	}
+	return p.handleOp(op)
+}
+
+func (p *probeKeyspanIterator) Next() *keyspan.Span {
+	op := keyspanOp{Kind: opSpanNext}
+	if p.iter != nil {
+		op.Span = p.iter.Next()
+	}
+	return p.handleOp(op)
+}
+
+func (p *probeKeyspanIterator) Prev() *keyspan.Span {
+	op := keyspanOp{Kind: opSpanPrev}
+	if p.iter != nil {
+		op.Span = p.iter.Prev()
+	}
+	return p.handleOp(op)
+}
+
+func (p *probeKeyspanIterator) Error() error {
+	return p.err
+}
+
+func (p *probeKeyspanIterator) Close() error {
+	op := keyspanOp{Kind: opSpanClose}
+	if p.iter != nil {
+		op.Err = p.iter.Close()
+	}
+
+	p.probeCtx.keyspanOp = op
+	p.probe.probe(&p.probeCtx)
+	p.err = p.probeCtx.keyspanOp.Err
+	return p.err
+}

--- a/level_iter.go
+++ b/level_iter.go
@@ -771,6 +771,9 @@ func (l *levelIter) SeekPrefixGE(
 	if key, val := l.iter.SeekPrefixGE(prefix, key, flags); key != nil {
 		return l.verify(key, val)
 	}
+	if err := l.iter.Error(); err != nil {
+		return nil, base.LazyValue{}
+	}
 	// When SeekPrefixGE returns nil, we have not necessarily reached the end of
 	// the sstable. All we know is that a key with prefix does not exist in the
 	// current sstable. We do know that the key lies within the bounds of the
@@ -948,6 +951,9 @@ func (l *levelIter) NextPrefix(succKey []byte) (*InternalKey, base.LazyValue) {
 		if key, val := l.iter.NextPrefix(succKey); key != nil {
 			return l.verify(key, val)
 		}
+		if l.iter.Error() != nil {
+			return nil, base.LazyValue{}
+		}
 		// Fall through to seeking.
 	}
 
@@ -1008,6 +1014,10 @@ func (l *levelIter) Prev() (*InternalKey, base.LazyValue) {
 }
 
 func (l *levelIter) skipEmptyFileForward() (*InternalKey, base.LazyValue) {
+	if l.iter.Error() != nil {
+		return nil, base.LazyValue{}
+	}
+
 	var key *InternalKey
 	var val base.LazyValue
 	// The first iteration of this loop starts with an already exhausted
@@ -1101,6 +1111,10 @@ func (l *levelIter) skipEmptyFileForward() (*InternalKey, base.LazyValue) {
 }
 
 func (l *levelIter) skipEmptyFileBackward() (*InternalKey, base.LazyValue) {
+	if l.iter.Error() != nil {
+		return nil, base.LazyValue{}
+	}
+
 	var key *InternalKey
 	var val base.LazyValue
 	// The first iteration of this loop starts with an already exhausted

--- a/testdata/merging_iter
+++ b/testdata/merging_iter
@@ -53,6 +53,19 @@ e#10,1:10
 g#20,1:20
 .
 
+iter probe-rangedels=(000000,(Log "#  000000.rangeDelIter.")) probe-rangedels=(000001,(If (Equal SeekKey (Bytes "g")) ErrInjected noop),(Log "#  000001.rangeDelIter."))
+seek-ge d
+next
+----
+#  000000.rangeDelIter.opSpanSeekGE("d") = a-f:{(#8,RANGEDEL)}
+#  000001.rangeDelIter.opSpanSeekGE("e") = e-f:{(#8,RANGEDEL)}
+#  000000.rangeDelIter.opSpanSeekGE("e") = a-f:{(#8,RANGEDEL)}
+#  000000.rangeDelIter.opSpanClose() = nil
+#  000001.rangeDelIter.opSpanSeekGE("e") = e-f:{(#8,RANGEDEL)}
+e#10,1:10
+#  000001.rangeDelIter.opSpanSeekGE("g") = nil <err="injected error">
+err=injected error
+
 # isPrevEntryDeleted() should not allow the rangedel to act on the points in the lower sstable
 # that are after it.
 iter
@@ -347,6 +360,20 @@ d#6,1:6
 d#6,1:6
 d#4,1:4
 
+# Test the above but an error is encountered when Prev-ing to establish the min
+# heap. The error should be propagated up.
+iter probe-points=(000011,(If OpPrev ErrInjected noop),(Log "# L1.000011.")) probe-points=(000012,(Log "# L2.000012."))
+set-bounds lower=d
+seek-ge d
+prev
+----
+# L1.000011.SeekGE("d") = (d#6,1,"6")
+# L2.000012.SeekGE("d") = (d#4,1,"4")
+d#6,1:6
+# L2.000012.Prev() = nil
+# L1.000011.Prev() = nil <err="injected error">
+err=injected error
+
 # Check the behavior of reverse prefix iteration.
 
 iter
@@ -387,6 +414,19 @@ c#3,1:3
 .
 c#3,1:3
 c#9,1:9
+
+# Test the above scenario, but an error is encountered when Next-ing to switch
+# to a max heap. The error should be propagated to the caller.
+iter probe-points=(000013,(If OpNext ErrInjected noop),(Log "# L1.000013.")) probe-points=(000014,(Log "# L2.000014."))
+set-bounds upper=d
+seek-lt d
+next
+----
+# L1.000013.SeekLT("d") = (c#9,1,"9")
+# L2.000014.SeekLT("d") = (c#3,1,"3")
+c#3,1:3
+# L1.000013.Next() = nil <err="injected error">
+err=injected error
 
 # Verify that the tombstone for the current level is updated correctly
 # when we advance the iterator on the level and step into a new
@@ -508,6 +548,21 @@ next
 iwoeionch#792,1:792
 .
 
+# Test the above case, but injecting an error when we re-seek the iterator in
+# accordance with the lower bound. The error should be propagated.
+
+iter probe-points=(000022,(Log "#  000022.")) probe-points=(000023,(If OpSeekGE ErrInjected noop),(Log "#  000023.")) probe-points=(000024,(Log "#  000024."))
+set-bounds lower=cz upper=jd
+seek-lt jd
+next
+----
+#  000022.SeekLT("jd") = (iwoeionch#792,1,"792")
+#  000023.SeekLT("c") = nil
+#  000024.SeekLT("c") = nil
+iwoeionch#792,1:792
+#  000023.SeekGE("cz") = nil <err="injected error">
+err=injected error
+
 # Exercise the early stopping behavior for prefix iteration when encountering
 # range deletion tombstones. Keys a, d are not deleted, while the rest are.
 define
@@ -590,3 +645,198 @@ f#21,1:21
 {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:6 ValueBytes:10 PointCount:6 PointsCoveredByRangeTombstones:4 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 .
 {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:6 ValueBytes:10 PointCount:6 PointsCoveredByRangeTombstones:4 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+
+# Test a dead simple error handling case of a 1-level seek erroring.
+
+define
+L
+a.SET.30 g.RANGEDEL.72057594037927935
+a.SET.30:30 a.RANGEDEL.20:g b.SET.19:19 c.SET.18:18 d.SET.17:17 e.SET.16:16 f.SET.21:21
+----
+1:
+  000027:[a#30,SET-g#inf,RANGEDEL]
+
+iter probe-points=(000027,ErrInjected,(Log "#  L1.000027."))
+first
+last
+seek-ge boo
+seek-lt coo
+seek-prefix-ge b
+----
+#  L1.000027.First() = nil <err="injected error">
+err=injected error
+#  L1.000027.Last() = nil <err="injected error">
+err=injected error
+#  L1.000027.SeekGE("boo") = nil <err="injected error">
+err=injected error
+#  L1.000027.SeekLT("coo") = nil <err="injected error">
+err=injected error
+#  L1.000027.SeekPrefixGE("b") = nil <err="injected error">
+err=injected error
+
+# Test error injection with two simple levels.
+
+define
+L
+a.SET.30 c.SET.27
+a.SET.30:30 c.SET.27:27
+L
+e.SET.10 g.SET.20
+e.SET.10:10 g.SET.20:20
+----
+1:
+  000028:[a#30,SET-c#27,SET]
+2:
+  000029:[e#10,SET-g#20,SET]
+
+# Inject errors for each of the L1 operations.
+
+iter probe-points=(000028,ErrInjected,(Log "# L1.000028.")) probe-points=(000029,(Log "# L2.000029."))
+first
+last
+seek-ge boo
+seek-lt coo
+seek-prefix-ge b
+----
+# L1.000028.First() = nil <err="injected error">
+err=injected error
+# L1.000028.Last() = nil <err="injected error">
+err=injected error
+# L1.000028.SeekGE("boo") = nil <err="injected error">
+err=injected error
+# L1.000028.SeekLT("coo") = nil <err="injected error">
+err=injected error
+# L1.000028.SeekPrefixGE("b") = nil <err="injected error">
+err=injected error
+
+# Inject errors for each of the L2 operations.
+
+iter probe-points=(000028,(Log "# L1.000028.")) probe-points=(000029,ErrInjected,(Log "# L2.000029."))
+first
+last
+seek-ge boo
+seek-lt coo
+seek-prefix-ge b
+----
+# L1.000028.First() = (a#30,1,"30")
+# L2.000029.First() = nil <err="injected error">
+err=injected error
+# L1.000028.Last() = (c#27,1,"27")
+# L2.000029.Last() = nil <err="injected error">
+err=injected error
+# L1.000028.SeekGE("boo") = (c#27,1,"27")
+# L2.000029.SeekGE("boo") = nil <err="injected error">
+err=injected error
+# L1.000028.SeekLT("coo") = (c#27,1,"27")
+# L2.000029.Close() = nil <err="injected error">
+err=injected error
+# L1.000028.SeekPrefixGE("b") = (c#27,1,"27")
+# L2.000029.SeekPrefixGE("b") = nil <err="injected error">
+err=injected error
+
+# Inject errors during L1.{Next,NextPrefix,Prev}.
+
+iter probe-points=(000028,(If (Or OpNext OpNextPrefix OpPrev) ErrInjected noop),(Log "# L1.000028.")) probe-points=(000029,(Log "# L2.000029."))
+first
+next
+first
+next-prefix
+last
+prev
+prev
+prev
+----
+# L1.000028.First() = (a#30,1,"30")
+# L2.000029.First() = (e#10,1,"10")
+a#30,1:30
+# L1.000028.Next() = nil <err="injected error">
+err=injected error
+# L1.000028.First() = (a#30,1,"30")
+# L2.000029.First() = (e#10,1,"10")
+a#30,1:30
+# L1.000028.NextPrefix("a\x00") = nil <err="injected error">
+err=injected error
+# L1.000028.Last() = (c#27,1,"27")
+# L2.000029.Last() = (g#20,1,"20")
+g#20,1:20
+# L2.000029.Prev() = (e#10,1,"10")
+e#10,1:10
+# L2.000029.Prev() = nil
+# L2.000029.Close() = nil
+c#27,1:27
+# L1.000028.Prev() = nil <err="injected error">
+err=injected error
+
+# Inject errors during L2.{Next,NextPrefix,Prev}.
+
+iter probe-points=(000028,(Log "# L1.000028.")) probe-points=(000029,(If (Or OpNext OpNextPrefix OpPrev) ErrInjected noop),(Log "# L2.000029."))
+first
+next
+next
+next
+first
+next-prefix
+next-prefix
+next-prefix
+last
+prev
+----
+# L1.000028.First() = (a#30,1,"30")
+# L2.000029.First() = (e#10,1,"10")
+a#30,1:30
+# L1.000028.Next() = (c#27,1,"27")
+c#27,1:27
+# L1.000028.Next() = nil
+# L1.000028.Close() = nil
+e#10,1:10
+# L2.000029.Next() = nil <err="injected error">
+err=injected error
+# L1.000028.First() = (a#30,1,"30")
+# L2.000029.First() = (e#10,1,"10")
+a#30,1:30
+# L1.000028.NextPrefix("a\x00") = (c#27,1,"27")
+c#27,1:27
+# L1.000028.NextPrefix("c\x00") = nil
+# L1.000028.Close() = nil
+e#10,1:10
+# L2.000029.NextPrefix("e\x00") = nil <err="injected error">
+err=injected error
+# L1.000028.Last() = (c#27,1,"27")
+# L2.000029.Last() = (g#20,1,"20")
+g#20,1:20
+# L2.000029.Prev() = nil <err="injected error">
+err=injected error
+
+# Test errors reading the range deletion block of an sstable with a simple
+# single-sstable version that contains a range deletion deleting keys within the
+# same table.
+define
+L
+a.SET.30 g.RANGEDEL.72057594037927935
+a.SET.30:30 a.RANGEDEL.20:g b.SET.19:19 c.SET.18:18 d.SET.17:17 e.SET.16:16 f.SET.21:21
+----
+1:
+  000030:[a#30,SET-g#inf,RANGEDEL]
+
+iter probe-points=(000030,(Log "#  iter.")) probe-rangedels=(000030,ErrInjected,(Log "#  rangedelIter."))
+first
+last
+seek-ge boo
+seek-lt coo
+seek-prefix-ge b
+----
+#  iter.First() = (a#30,1,"30")
+#  rangedelIter.opSpanSeekGE("a") = nil <err="injected error">
+err=injected error
+#  iter.Last() = (f#21,1,"21")
+#  rangedelIter.opSpanSeekLT("f") = nil <err="injected error">
+err=injected error
+#  iter.SeekGE("boo") = (c#18,1,"18")
+#  rangedelIter.opSpanSeekGE("boo") = nil <err="injected error">
+err=injected error
+#  iter.SeekLT("coo") = (c#18,1,"18")
+#  rangedelIter.opSpanSeekLT("coo") = nil <err="injected error">
+err=injected error
+#  iter.SeekPrefixGE("b") = (b#19,1,"19")
+#  rangedelIter.opSpanSeekGE("b") = nil <err="injected error">
+err=injected error


### PR DESCRIPTION
**internal/itertest: add iterator probes**

This commit introduces facilities for attaching 'probes' to internal iterators.
A probe is invoked on every operation against the iterator and provided with
information about the operation in-progress and its results. A probe may modify
the return result freely.

Building off the work in vfs/errorfs and internal/dsl, this commit introduces a
DSL for expressing probes and the circumstances with which they should
activate.

In the immediate term, probes will be used for error injection in intenral
iterator unit tests.

**db: fix mergingIter, levelIter error propagation**

This commit adds facilities for unit testing error propagation in the merging
iterator and level iterator through defining "probes" for individual file point
iterators or range deletion iterators. Additional unit testing reveals a host
of unpropagated errors, which in several cases resulted in incorrect results
including skipped keys and surfacing deleted keys.

The unit tests and bug fixes included within this commit are not comprehensive.
Randomized tests introduced in future commits will ensure that we have
comprehensive coverage. Future bug fixes will be able to use the testing
facilities introduced in this commit to add focused regression tests.

Some of the facilities are copied into the pebble package from internal/keyspan
temporarily. In future refactors, these will be consolidated within a common
package. Those refactors are deferred to ensure that these bug fixes are easily
able to be backported to previous releases.

Informs #1115.