### PR TITLE
metamorphic: support --try-to-reduce with --compare

### DIFF
--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -66,6 +66,10 @@ func runTestMeta(t *testing.T, multiInstance bool) {
 			onceOpts = append(onceOpts, metamorphic.MultiInstance(2))
 		}
 		testRootDir, runSubdirs := runOnceFlags.ParseCompare()
+		if runOnceFlags.TryToReduce {
+			tryToReduceCompare(t, runOnceFlags.Dir, testRootDir, runSubdirs)
+			return
+		}
 		metamorphic.Compare(t, testRootDir, runOnceFlags.Seed, runSubdirs, onceOpts...)
 
 	case runOnceFlags.RunDir != "":

--- a/internal/metamorphic/metarunner/main.go
+++ b/internal/metamorphic/metarunner/main.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/cockroachdb/pebble/internal/metamorphic/metaflags"
 	"github.com/cockroachdb/pebble/metamorphic"
@@ -27,8 +26,8 @@ func main() {
 	t := &mockT{}
 	switch {
 	case runOnceFlags.Compare != "":
-		runDirs := strings.Split(runOnceFlags.Compare, ",")
-		metamorphic.Compare(t, runOnceFlags.Dir, runOnceFlags.Seed, runDirs, onceOpts...)
+		testRootDir, runSubdirs := runOnceFlags.ParseCompare()
+		metamorphic.Compare(t, testRootDir, runOnceFlags.Seed, runSubdirs, onceOpts...)
 
 	case runOnceFlags.RunDir != "":
 		// The --run-dir flag is specified either in the child process (see


### PR DESCRIPTION
#### metamorphic: improve --compare flag

The compare flag currently has format
`231220-164251.3552792807512/random-003,231220-164251.3552792807512/random-025`

This is dissimilar from the `--run-dir` format (which includes the
`_meta` dir) and is dissimilar from the format used to report a
failure, which is `_meta/231220-164251.3552792807512/{standard-000,random-025}`.

This change updates the flag to use the
`test-root-dir/{run1,run2,...}` format that is used to report
failures.

#### metamorphic: support --try-to-reduce with --compare

We generalize the reducer code to allow reducing compare failures.