### PR TITLE
keyspan: add logging infrastructure for iterator stacks

### DIFF
--- a/error_iter.go
+++ b/error_iter.go
@@ -75,12 +75,13 @@ type errorKeyspanIter struct {
 // errorKeyspanIter implements the keyspan.FragmentIterator interface.
 var _ keyspan.FragmentIterator = (*errorKeyspanIter)(nil)
 
-func (*errorKeyspanIter) SeekGE(key []byte) *keyspan.Span { return nil }
-func (*errorKeyspanIter) SeekLT(key []byte) *keyspan.Span { return nil }
-func (*errorKeyspanIter) First() *keyspan.Span            { return nil }
-func (*errorKeyspanIter) Last() *keyspan.Span             { return nil }
-func (*errorKeyspanIter) Next() *keyspan.Span             { return nil }
-func (*errorKeyspanIter) Prev() *keyspan.Span             { return nil }
-func (i *errorKeyspanIter) Error() error                  { return i.err }
-func (i *errorKeyspanIter) Close() error                  { return i.err }
-func (*errorKeyspanIter) String() string                  { return "error" }
+func (*errorKeyspanIter) SeekGE(key []byte) *keyspan.Span  { return nil }
+func (*errorKeyspanIter) SeekLT(key []byte) *keyspan.Span  { return nil }
+func (*errorKeyspanIter) First() *keyspan.Span             { return nil }
+func (*errorKeyspanIter) Last() *keyspan.Span              { return nil }
+func (*errorKeyspanIter) Next() *keyspan.Span              { return nil }
+func (*errorKeyspanIter) Prev() *keyspan.Span              { return nil }
+func (i *errorKeyspanIter) Error() error                   { return i.err }
+func (i *errorKeyspanIter) Close() error                   { return i.err }
+func (*errorKeyspanIter) String() string                   { return "error" }
+func (*errorKeyspanIter) WrapChildren(wrap keyspan.WrapFn) {}

--- a/internal/keyspan/assert_iter.go
+++ b/internal/keyspan/assert_iter.go
@@ -171,3 +171,8 @@ func (i *assertIter) Error() error {
 func (i *assertIter) Close() error {
 	return i.iter.Close()
 }
+
+// WrapChildren implements FragmentIterator.
+func (i *assertIter) WrapChildren(wrap WrapFn) {
+	i.iter = wrap(i.iter)
+}

--- a/internal/keyspan/bounded.go
+++ b/internal/keyspan/bounded.go
@@ -266,3 +266,8 @@ func (i *BoundedIter) checkBackwardBound(span *Span) *Span {
 	}
 	return span
 }
+
+// WrapChildren implements FragmentIterator.
+func (i *BoundedIter) WrapChildren(wrap WrapFn) {
+	i.iter = wrap(i.iter)
+}

--- a/internal/keyspan/datadriven_test.go
+++ b/internal/keyspan/datadriven_test.go
@@ -375,6 +375,10 @@ func (p *probeIterator) Close() error {
 	return p.err
 }
 
+func (p *probeIterator) WrapChildren(wrap WrapFn) {
+	p.iter = wrap(p.iter)
+}
+
 // runIterCmd evaluates a datadriven command controlling an internal
 // keyspan.FragmentIterator, writing the results of the iterator operations to
 // the provided writer.

--- a/internal/keyspan/defragment.go
+++ b/internal/keyspan/defragment.go
@@ -537,3 +537,8 @@ func (i *DefragmentingIter) saveBytes(b []byte) []byte {
 	i.currBuf, b = i.currBuf.Copy(b)
 	return b
 }
+
+// WrapChildren implements FragmentIterator.
+func (i *DefragmentingIter) WrapChildren(wrap WrapFn) {
+	i.iter = wrap(i.iter)
+}

--- a/internal/keyspan/filter.go
+++ b/internal/keyspan/filter.go
@@ -113,3 +113,8 @@ func (i *filteringIter) filter(span *Span, dir int8) *Span {
 	}
 	return span
 }
+
+// WrapChildren implements FragmentIterator.
+func (i *filteringIter) WrapChildren(wrap WrapFn) {
+	i.iter = wrap(i.iter)
+}

--- a/internal/keyspan/iter.go
+++ b/internal/keyspan/iter.go
@@ -60,6 +60,11 @@ type FragmentIterator interface {
 	// multiple times. Other methods should not be called after the iterator has
 	// been closed.
 	Close() error
+
+	// WrapChildren wraps any child iterators using the given function. The
+	// function can call WrapChildren to recursively wrap an entire iterator
+	// stack. Used only for debug logging.
+	WrapChildren(wrap WrapFn)
 }
 
 // TableNewSpanIter creates a new iterator for range key spans for the given
@@ -218,3 +223,6 @@ func (i *Iter) Close() error {
 func (i *Iter) String() string {
 	return "fragmented-spans"
 }
+
+// WrapChildren implements FragmentIterator.
+func (i *Iter) WrapChildren(wrap WrapFn) {}

--- a/internal/keyspan/iter_test.go
+++ b/internal/keyspan/iter_test.go
@@ -145,3 +145,6 @@ func (i *invalidatingIter) Next() *Span             { return i.invalidate(i.iter
 func (i *invalidatingIter) Prev() *Span             { return i.invalidate(i.iter.Prev()) }
 func (i *invalidatingIter) Close() error            { return i.iter.Close() }
 func (i *invalidatingIter) Error() error            { return i.iter.Error() }
+func (i *invalidatingIter) WrapChildren(wrap WrapFn) {
+	i.iter = wrap(i.iter)
+}

--- a/internal/keyspan/logging_iter.go
+++ b/internal/keyspan/logging_iter.go
@@ -1,0 +1,150 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package keyspan
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/pebble/internal/base"
+)
+
+// WrapFn is the prototype for a function that wraps a FragmentIterator.
+type WrapFn func(in FragmentIterator) FragmentIterator
+
+// InjectLogging wraps all iterators in a stack with logging iterators,
+// producing log messages showing each operation and its result.
+func InjectLogging(iter FragmentIterator, logger base.Logger) FragmentIterator {
+	// All iterators in the stack will use the same logging state.
+	state := &loggingState{
+		depth: 0,
+		log:   logger,
+	}
+	var wrap WrapFn
+	wrap = func(in FragmentIterator) FragmentIterator {
+		if in == nil {
+			return nil
+		}
+		// Recursively wrap all descendants.
+		in.WrapChildren(wrap)
+		return newLoggingIter(state, in)
+	}
+	return wrap(iter)
+}
+
+func newLoggingIter(state *loggingState, iter FragmentIterator) FragmentIterator {
+	return &loggingIter{
+		iter:    iter,
+		state:   state,
+		context: fmt.Sprintf("%T:", iter),
+	}
+}
+
+// loggingIter is a pass-through FragmentIterator wrapper which performs checks
+// on what the wrapped iterator returns.
+type loggingIter struct {
+	iter    FragmentIterator
+	state   *loggingState
+	context string
+}
+
+// loggingState is shared by all iterators in a stack.
+type loggingState struct {
+	depth int
+	log   base.Logger
+}
+
+func (i *loggingIter) opStartf(format string, args ...any) func(results ...any) {
+	op := fmt.Sprintf(format, args...)
+	msg := fmt.Sprintf("%s%s %s", strings.Repeat("  ", i.state.depth), i.context, op)
+
+	i.state.log.Infof("%s", msg)
+	savedDepth := i.state.depth
+	i.state.depth++
+
+	return func(results ...any) {
+		i.state.depth = savedDepth
+		if len(results) > 0 {
+			i.state.log.Infof("%s = %s", msg, fmt.Sprint(results...))
+		}
+	}
+}
+
+var _ FragmentIterator = (*loggingIter)(nil)
+
+// SeekGE implements FragmentIterator.
+func (i *loggingIter) SeekGE(key []byte) *Span {
+	opEnd := i.opStartf("SeekGE(%q)", key)
+	span := i.iter.SeekGE(key)
+	opEnd(span)
+	return span
+}
+
+// SeekLT implements FragmentIterator.
+func (i *loggingIter) SeekLT(key []byte) *Span {
+	opEnd := i.opStartf("SeekLT(%q)", key)
+	span := i.iter.SeekLT(key)
+	opEnd(span)
+	return span
+}
+
+// First implements FragmentIterator.
+func (i *loggingIter) First() *Span {
+	opEnd := i.opStartf("First()")
+	span := i.iter.First()
+	opEnd(span)
+	return span
+}
+
+// Last implements FragmentIterator.
+func (i *loggingIter) Last() *Span {
+	opEnd := i.opStartf("Last()")
+	span := i.iter.Last()
+	opEnd(span)
+	return span
+}
+
+// Next implements FragmentIterator.
+func (i *loggingIter) Next() *Span {
+	opEnd := i.opStartf("Next()")
+	span := i.iter.Next()
+	opEnd(span)
+	return span
+}
+
+// Prev implements FragmentIterator.
+func (i *loggingIter) Prev() *Span {
+	opEnd := i.opStartf("Prev()")
+	span := i.iter.Prev()
+	opEnd(span)
+	return span
+}
+
+// Error implements FragmentIterator.
+func (i *loggingIter) Error() error {
+	err := i.iter.Error()
+	if err != nil {
+		opEnd := i.opStartf("Error()")
+		opEnd(err)
+	}
+	return err
+}
+
+// Close implements FragmentIterator.
+func (i *loggingIter) Close() error {
+	opEnd := i.opStartf("Close()")
+	err := i.iter.Close()
+	if err != nil {
+		opEnd(err)
+	} else {
+		opEnd()
+	}
+	return err
+}
+
+// WrapChildren implements FragmentIterator.
+func (i *loggingIter) WrapChildren(wrap WrapFn) {
+	i.iter = wrap(i.iter)
+}

--- a/internal/keyspan/logging_iter_test.go
+++ b/internal/keyspan/logging_iter_test.go
@@ -1,0 +1,43 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package keyspan
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoggingIter(t *testing.T) {
+	var spans []Span
+	datadriven.RunTest(t, "testdata/logging_iter", func(t *testing.T, d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "define":
+			spans = nil
+			for _, line := range strings.Split(d.Input, "\n") {
+				spans = append(spans, ParseSpan(line))
+			}
+			return ""
+
+		case "iter":
+			l := &base.InMemLogger{}
+			var iter FragmentIterator
+			iter = NewIter(base.DefaultComparer.Compare, spans)
+			// Wrap with an assert as a very simple "stack" example.
+			iter = Assert(iter, base.DefaultComparer.Compare)
+			iter = InjectLogging(iter, l)
+			runFragmentIteratorCmd(iter, d.Input, nil)
+			require.NoError(t, iter.Close())
+			return l.String()
+
+		default:
+			return fmt.Sprintf("unknown command: %s", d.Cmd)
+		}
+	})
+}

--- a/internal/keyspan/testdata/logging_iter
+++ b/internal/keyspan/testdata/logging_iter
@@ -15,39 +15,39 @@ last
 prev
 ----
 *keyspan.assertIter: SeekGE("a")
-  *keyspan.Iter: SeekGE("a")
-  *keyspan.Iter: SeekGE("a") = a-b:{(#2,SET) (#1,SET)}
-*keyspan.assertIter: SeekGE("a") = a-b:{(#2,SET) (#1,SET)}
+ ├── *keyspan.Iter: SeekGE("a")
+ │    └── a-b:{(#2,SET) (#1,SET)}
+ └── a-b:{(#2,SET) (#1,SET)}
 *keyspan.assertIter: Next()
-  *keyspan.Iter: Next()
-  *keyspan.Iter: Next() = b-c:{(#2,SET) (#1,SET)}
-*keyspan.assertIter: Next() = b-c:{(#2,SET) (#1,SET)}
+ ├── *keyspan.Iter: Next()
+ │    └── b-c:{(#2,SET) (#1,SET)}
+ └── b-c:{(#2,SET) (#1,SET)}
 *keyspan.assertIter: Next()
-  *keyspan.Iter: Next()
-  *keyspan.Iter: Next() = c-d:{(#2,SET) (#1,SET)}
-*keyspan.assertIter: Next() = c-d:{(#2,SET) (#1,SET)}
+ ├── *keyspan.Iter: Next()
+ │    └── c-d:{(#2,SET) (#1,SET)}
+ └── c-d:{(#2,SET) (#1,SET)}
 *keyspan.assertIter: Prev()
-  *keyspan.Iter: Prev()
-  *keyspan.Iter: Prev() = b-c:{(#2,SET) (#1,SET)}
-*keyspan.assertIter: Prev() = b-c:{(#2,SET) (#1,SET)}
+ ├── *keyspan.Iter: Prev()
+ │    └── b-c:{(#2,SET) (#1,SET)}
+ └── b-c:{(#2,SET) (#1,SET)}
 *keyspan.assertIter: First()
-  *keyspan.Iter: First()
-  *keyspan.Iter: First() = a-b:{(#2,SET) (#1,SET)}
-*keyspan.assertIter: First() = a-b:{(#2,SET) (#1,SET)}
+ ├── *keyspan.Iter: First()
+ │    └── a-b:{(#2,SET) (#1,SET)}
+ └── a-b:{(#2,SET) (#1,SET)}
 *keyspan.assertIter: Next()
-  *keyspan.Iter: Next()
-  *keyspan.Iter: Next() = b-c:{(#2,SET) (#1,SET)}
-*keyspan.assertIter: Next() = b-c:{(#2,SET) (#1,SET)}
+ ├── *keyspan.Iter: Next()
+ │    └── b-c:{(#2,SET) (#1,SET)}
+ └── b-c:{(#2,SET) (#1,SET)}
 *keyspan.assertIter: Last()
-  *keyspan.Iter: Last()
-  *keyspan.Iter: Last() = c-d:{(#2,SET) (#1,SET)}
-*keyspan.assertIter: Last() = c-d:{(#2,SET) (#1,SET)}
+ ├── *keyspan.Iter: Last()
+ │    └── c-d:{(#2,SET) (#1,SET)}
+ └── c-d:{(#2,SET) (#1,SET)}
 *keyspan.assertIter: Prev()
-  *keyspan.Iter: Prev()
-  *keyspan.Iter: Prev() = b-c:{(#2,SET) (#1,SET)}
-*keyspan.assertIter: Prev() = b-c:{(#2,SET) (#1,SET)}
+ ├── *keyspan.Iter: Prev()
+ │    └── b-c:{(#2,SET) (#1,SET)}
+ └── b-c:{(#2,SET) (#1,SET)}
 *keyspan.assertIter: Close()
-  *keyspan.Iter: Close()
+ └── *keyspan.Iter: Close()
 
 iter
 seek-lt a
@@ -56,20 +56,20 @@ next
 next
 ----
 *keyspan.assertIter: SeekLT("a")
-  *keyspan.Iter: SeekLT("a")
-  *keyspan.Iter: SeekLT("a") = <nil>
-*keyspan.assertIter: SeekLT("a") = <nil>
+ ├── *keyspan.Iter: SeekLT("a")
+ │    └── <nil>
+ └── <nil>
 *keyspan.assertIter: SeekLT("c")
-  *keyspan.Iter: SeekLT("c")
-  *keyspan.Iter: SeekLT("c") = b-c:{(#2,SET) (#1,SET)}
-*keyspan.assertIter: SeekLT("c") = b-c:{(#2,SET) (#1,SET)}
+ ├── *keyspan.Iter: SeekLT("c")
+ │    └── b-c:{(#2,SET) (#1,SET)}
+ └── b-c:{(#2,SET) (#1,SET)}
 *keyspan.assertIter: Next()
-  *keyspan.Iter: Next()
-  *keyspan.Iter: Next() = c-d:{(#2,SET) (#1,SET)}
-*keyspan.assertIter: Next() = c-d:{(#2,SET) (#1,SET)}
+ ├── *keyspan.Iter: Next()
+ │    └── c-d:{(#2,SET) (#1,SET)}
+ └── c-d:{(#2,SET) (#1,SET)}
 *keyspan.assertIter: Next()
-  *keyspan.Iter: Next()
-  *keyspan.Iter: Next() = <nil>
-*keyspan.assertIter: Next() = <nil>
+ ├── *keyspan.Iter: Next()
+ │    └── <nil>
+ └── <nil>
 *keyspan.assertIter: Close()
-  *keyspan.Iter: Close()
+ └── *keyspan.Iter: Close()

--- a/internal/keyspan/testdata/logging_iter
+++ b/internal/keyspan/testdata/logging_iter
@@ -1,0 +1,75 @@
+define
+a-b:{(#2,SET) (#1,SET)}
+b-c:{(#2,SET) (#1,SET)}
+c-d:{(#2,SET) (#1,SET)}
+----
+
+iter
+seek-ge a
+next
+next
+prev
+first
+next
+last
+prev
+----
+*keyspan.assertIter: SeekGE("a")
+  *keyspan.Iter: SeekGE("a")
+  *keyspan.Iter: SeekGE("a") = a-b:{(#2,SET) (#1,SET)}
+*keyspan.assertIter: SeekGE("a") = a-b:{(#2,SET) (#1,SET)}
+*keyspan.assertIter: Next()
+  *keyspan.Iter: Next()
+  *keyspan.Iter: Next() = b-c:{(#2,SET) (#1,SET)}
+*keyspan.assertIter: Next() = b-c:{(#2,SET) (#1,SET)}
+*keyspan.assertIter: Next()
+  *keyspan.Iter: Next()
+  *keyspan.Iter: Next() = c-d:{(#2,SET) (#1,SET)}
+*keyspan.assertIter: Next() = c-d:{(#2,SET) (#1,SET)}
+*keyspan.assertIter: Prev()
+  *keyspan.Iter: Prev()
+  *keyspan.Iter: Prev() = b-c:{(#2,SET) (#1,SET)}
+*keyspan.assertIter: Prev() = b-c:{(#2,SET) (#1,SET)}
+*keyspan.assertIter: First()
+  *keyspan.Iter: First()
+  *keyspan.Iter: First() = a-b:{(#2,SET) (#1,SET)}
+*keyspan.assertIter: First() = a-b:{(#2,SET) (#1,SET)}
+*keyspan.assertIter: Next()
+  *keyspan.Iter: Next()
+  *keyspan.Iter: Next() = b-c:{(#2,SET) (#1,SET)}
+*keyspan.assertIter: Next() = b-c:{(#2,SET) (#1,SET)}
+*keyspan.assertIter: Last()
+  *keyspan.Iter: Last()
+  *keyspan.Iter: Last() = c-d:{(#2,SET) (#1,SET)}
+*keyspan.assertIter: Last() = c-d:{(#2,SET) (#1,SET)}
+*keyspan.assertIter: Prev()
+  *keyspan.Iter: Prev()
+  *keyspan.Iter: Prev() = b-c:{(#2,SET) (#1,SET)}
+*keyspan.assertIter: Prev() = b-c:{(#2,SET) (#1,SET)}
+*keyspan.assertIter: Close()
+  *keyspan.Iter: Close()
+
+iter
+seek-lt a
+seek-lt c
+next
+next
+----
+*keyspan.assertIter: SeekLT("a")
+  *keyspan.Iter: SeekLT("a")
+  *keyspan.Iter: SeekLT("a") = <nil>
+*keyspan.assertIter: SeekLT("a") = <nil>
+*keyspan.assertIter: SeekLT("c")
+  *keyspan.Iter: SeekLT("c")
+  *keyspan.Iter: SeekLT("c") = b-c:{(#2,SET) (#1,SET)}
+*keyspan.assertIter: SeekLT("c") = b-c:{(#2,SET) (#1,SET)}
+*keyspan.assertIter: Next()
+  *keyspan.Iter: Next()
+  *keyspan.Iter: Next() = c-d:{(#2,SET) (#1,SET)}
+*keyspan.assertIter: Next() = c-d:{(#2,SET) (#1,SET)}
+*keyspan.assertIter: Next()
+  *keyspan.Iter: Next()
+  *keyspan.Iter: Next() = <nil>
+*keyspan.assertIter: Next() = <nil>
+*keyspan.assertIter: Close()
+  *keyspan.Iter: Close()

--- a/internal/treeprinter/tree_printer.go
+++ b/internal/treeprinter/tree_printer.go
@@ -1,0 +1,350 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package treeprinter
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+var (
+	edgeLinkChr = rune('│')
+	edgeMidChr  = rune('├')
+	edgeLastChr = rune('└')
+	horLineChr  = rune('─')
+	bulletChr   = rune('•')
+)
+
+// Node is a handle associated with a specific depth in a tree. See below for
+// sample usage.
+type Node struct {
+	tree  *tree
+	level int
+}
+
+// New creates a tree printer and returns a sentinel node reference which
+// should be used to add the root. Sample usage:
+//
+//	tp := New()
+//	root := tp.Child("root")
+//	root.Child("child-1")
+//	root.Child("child-2").Child("grandchild\ngrandchild-more-info")
+//	root.Child("child-3")
+//
+//	fmt.Print(tp.String())
+//
+// Output:
+//
+//	root
+//	 ├── child-1
+//	 ├── child-2
+//	 │    └── grandchild
+//	 │        grandchild-more-info
+//	 └── child-3
+//
+// Note that the Child calls can't be rearranged arbitrarily; they have
+// to be in the order they need to be displayed (depth-first pre-order).
+func New() Node {
+	return NewWithStyle(DefaultStyle)
+}
+
+// NewWithStyle creates a tree printer like New, permitting customization of
+// the style of the resulting tree.
+func NewWithStyle(style Style) Node {
+	t := &tree{style: style}
+
+	switch style {
+	case CompactStyle:
+		t.edgeLink = []rune{edgeLinkChr}
+		t.edgeMid = []rune{edgeMidChr, ' '}
+		t.edgeLast = []rune{edgeLastChr, ' '}
+
+	case BulletStyle:
+		t.edgeLink = []rune{edgeLinkChr}
+		t.edgeMid = []rune{edgeMidChr, horLineChr, horLineChr, ' '}
+		t.edgeLast = []rune{edgeLastChr, horLineChr, horLineChr, ' '}
+
+	default:
+		t.edgeLink = []rune{' ', edgeLinkChr}
+		t.edgeMid = []rune{' ', edgeMidChr, horLineChr, horLineChr, ' '}
+		t.edgeLast = []rune{' ', edgeLastChr, horLineChr, horLineChr, ' '}
+	}
+
+	return Node{
+		tree:  t,
+		level: 0,
+	}
+}
+
+// Style is one of the predefined treeprinter styles.
+type Style int
+
+const (
+	// DefaultStyle is the default style. Example:
+	//
+	//   foo
+	//    ├── bar1
+	//    │   bar2
+	//    │    └── baz
+	//    └── qux
+	//
+	DefaultStyle Style = iota
+
+	// CompactStyle is a compact style, for deeper trees. Example:
+	//
+	//   foo
+	//   ├ bar1
+	//   │ bar2
+	//   │ └ baz
+	//   └ qux
+	//
+	CompactStyle
+
+	// BulletStyle is a style that shows a bullet for each node, and groups any
+	// other lines under that bullet. Example:
+	//
+	//   • foo
+	//   │
+	//   ├── • bar1
+	//   │   │ bar2
+	//   │   │
+	//   │   └── • baz
+	//   │
+	//   └── • qux
+	//
+	BulletStyle
+)
+
+// tree implements the tree printing machinery.
+//
+// All Nodes hold a reference to the tree and Node calls result in modification
+// of the tree. At any point in time, tree.rows contains the formatted tree that
+// was described by the Node calls performed so far.
+//
+// When new nodes are added, some of the characters of the previous formatted
+// tree need to be updated. Here is an example stepping through the state:
+//
+//	API call                       Rows
+//
+//
+//	tp := New()                    <empty>
+//
+//
+//	root := tp.Child("root")       root
+//
+//
+//	root.Child("child-1")          root
+//	                                └── child-1
+//
+//
+//	c2 := root.Child("child-2")    root
+//	                                ├── child-1
+//	                                └── child-2
+//
+//	  Note: here we had to go back up and change └─ into ├─ for child-1.
+//
+//
+//	c2.Child("grandchild")         root
+//	                                ├── child-1
+//	                                └── child-2
+//	                                     └── grandchild
+//
+//
+//	root.Child("child-3"           root
+//	                                ├── child-1
+//	                                ├── child-2
+//	                                │    └── grandchild
+//	                                └── child-3
+//
+//	  Note: here we had to go back up and change └─ into ├─ for child-2, and
+//	  add a │ on the grandchild row. In general, we may need to add an
+//	  arbitrary number of vertical bars.
+//
+// In order to perform these character changes, we maintain information about
+// the nodes on the bottom-most path.
+type tree struct {
+	style Style
+
+	// rows maintains the rows accumulated so far, as rune arrays.
+	rows [][]rune
+
+	// stack contains information pertaining to the nodes on the bottom-most path
+	// of the tree.
+	stack []nodeInfo
+
+	edgeLink []rune
+	edgeMid  []rune
+	edgeLast []rune
+}
+
+type nodeInfo struct {
+	// firstChildConnectRow is the index (in tree.rows) of the row up to which we
+	// have to connect the first child of this node.
+	firstChildConnectRow int
+
+	// nextSiblingConnectRow is the index (in tree.rows) of the row up to which we
+	// have to connect the next sibling of this node. Typically this is the same
+	// with firstChildConnectRow, except when the node has multiple rows. For
+	// example:
+	//
+	//      foo
+	//       └── bar1               <---- nextSiblingConnectRow
+	//           bar2               <---- firstChildConnectRow
+	//
+	// firstChildConnectRow is used when adding "baz", nextSiblingConnectRow
+	// is used when adding "qux":
+	//      foo
+	//       ├── bar1
+	//       │   bar2
+	//       │    └── baz
+	//       └── qux
+	//
+	nextSiblingConnectRow int
+}
+
+// set copies the string of runes into a given row, at a specific position. The
+// row is extended with spaces if needed.
+func (t *tree) set(rowIdx int, colIdx int, what []rune) {
+	// Extend the line if necessary.
+	for len(t.rows[rowIdx]) < colIdx+len(what) {
+		t.rows[rowIdx] = append(t.rows[rowIdx], ' ')
+	}
+	copy(t.rows[rowIdx][colIdx:], what)
+}
+
+// addRow adds a row with a given text, with the proper indentation for the
+// given level.
+func (t *tree) addRow(level int, text string) (rowIdx int) {
+	runes := []rune(text)
+	// Each level indents by this much.
+	k := len(t.edgeLast)
+	indent := level * k
+	row := make([]rune, indent+len(runes))
+	for i := 0; i < indent; i++ {
+		row[i] = ' '
+	}
+	copy(row[indent:], runes)
+	t.rows = append(t.rows, row)
+	return len(t.rows) - 1
+}
+
+// Childf adds a node as a child of the given node.
+func (n Node) Childf(format string, args ...interface{}) Node {
+	return n.Child(fmt.Sprintf(format, args...))
+}
+
+// Child adds a node as a child of the given node. Multi-line strings are
+// supported with appropriate indentation.
+func (n Node) Child(text string) Node {
+	if strings.ContainsRune(text, '\n') {
+		splitLines := strings.Split(text, "\n")
+		node := n.childLine(splitLines[0])
+		for _, l := range splitLines[1:] {
+			node.AddLine(l)
+		}
+		return node
+	}
+	return n.childLine(text)
+}
+
+// AddLine adds a new line to a node without an edge.
+func (n Node) AddLine(text string) {
+	t := n.tree
+	if t.style == BulletStyle {
+		text = "  " + text
+	}
+	rowIdx := t.addRow(n.level-1, text)
+	if t.style != BulletStyle {
+		t.stack[n.level-1].firstChildConnectRow = rowIdx
+	}
+}
+
+// childLine adds a node as a child of the given node.
+func (n Node) childLine(text string) Node {
+	t := n.tree
+	if t.style == BulletStyle {
+		text = fmt.Sprintf("%c %s", bulletChr, text)
+		if n.level > 0 {
+			n.AddEmptyLine()
+		}
+	}
+	rowIdx := t.addRow(n.level, text)
+	edgePos := (n.level - 1) * len(t.edgeLast)
+	if n.level == 0 {
+		// Case 1: root.
+		if len(t.stack) != 0 {
+			panic("multiple root nodes")
+		}
+	} else if len(t.stack) <= n.level {
+		// Case 2: first child. Connect to parent.
+		if len(t.stack) != n.level {
+			panic("misuse of node")
+		}
+		parentRow := t.stack[n.level-1].firstChildConnectRow
+		for i := parentRow + 1; i < rowIdx; i++ {
+			t.set(i, edgePos, t.edgeLink)
+		}
+		t.set(rowIdx, edgePos, t.edgeLast)
+	} else {
+		// Case 3: non-first child. Connect to sibling.
+		siblingRow := t.stack[n.level].nextSiblingConnectRow
+		t.set(siblingRow, edgePos, t.edgeMid)
+		for i := siblingRow + 1; i < rowIdx; i++ {
+			t.set(i, edgePos, t.edgeLink)
+		}
+		t.set(rowIdx, edgePos, t.edgeLast)
+		// Update the nextSiblingConnectRow.
+		t.stack = t.stack[:n.level]
+	}
+
+	t.stack = append(t.stack, nodeInfo{
+		firstChildConnectRow:  rowIdx,
+		nextSiblingConnectRow: rowIdx,
+	})
+
+	// Return a TreePrinter that can be used for children of this node.
+	return Node{
+		tree:  t,
+		level: n.level + 1,
+	}
+}
+
+// AddEmptyLine adds an empty line to the output; used to introduce vertical
+// spacing as needed.
+func (n Node) AddEmptyLine() {
+	n.tree.rows = append(n.tree.rows, []rune{})
+}
+
+// FormattedRows returns the formatted rows. Can only be called on the result of
+// treeprinter.New.
+func (n Node) FormattedRows() []string {
+	if n.level != 0 {
+		panic("Only the root can be stringified")
+	}
+	res := make([]string, len(n.tree.rows))
+	for i, r := range n.tree.rows {
+		res[i] = string(r)
+	}
+	return res
+}
+
+func (n Node) String() string {
+	if n.level != 0 {
+		panic("Only the root can be stringified")
+	}
+	var buf bytes.Buffer
+	for _, r := range n.tree.rows {
+		buf.WriteString(string(r))
+		buf.WriteByte('\n')
+	}
+	return buf.String()
+}

--- a/internal/treeprinter/tree_printer_test.go
+++ b/internal/treeprinter/tree_printer_test.go
@@ -1,0 +1,215 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package treeprinter
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTreePrinter(t *testing.T) {
+	tree := func(n Node) {
+		r := n.Child("root")
+		r.AddEmptyLine()
+		n1 := r.Childf("%d", 1)
+		n1.Child("1.1")
+		n12 := n1.Child("1.2")
+		r.AddEmptyLine()
+		r.AddEmptyLine()
+		n12.Child("1.2.1")
+		r.AddEmptyLine()
+		n12.Child("1.2.2")
+		n13 := n1.Child("1.3")
+		n13.AddEmptyLine()
+		n131 := n13.Child("1.3.1")
+		n131.AddLine("1.3.1a")
+		n13.Child("1.3.2\n1.3.2a")
+		n13.AddEmptyLine()
+		n131.Child("1.3.1.1\n1.3.1.1a")
+		n1.Child("1.4")
+		r.Child("2")
+	}
+
+	n := New()
+	tree(n)
+
+	res := n.String()
+	exp := `
+root
+ │
+ ├── 1
+ │    ├── 1.1
+ │    ├── 1.2
+ │    │    │
+ │    │    │
+ │    │    ├── 1.2.1
+ │    │    │
+ │    │    └── 1.2.2
+ │    ├── 1.3
+ │    │    │
+ │    │    ├── 1.3.1
+ │    │    │   1.3.1a
+ │    │    └── 1.3.2
+ │    │        1.3.2a
+ │    │         │
+ │    │         └── 1.3.1.1
+ │    │             1.3.1.1a
+ │    └── 1.4
+ └── 2
+`
+	exp = strings.TrimLeft(exp, "\n")
+	if res != exp {
+		t.Errorf("incorrect result:\n%s", res)
+	}
+
+	n = NewWithStyle(CompactStyle)
+	tree(n)
+	res = n.String()
+	exp = `
+root
+│
+├ 1
+│ ├ 1.1
+│ ├ 1.2
+│ │ │
+│ │ │
+│ │ ├ 1.2.1
+│ │ │
+│ │ └ 1.2.2
+│ ├ 1.3
+│ │ │
+│ │ ├ 1.3.1
+│ │ │ 1.3.1a
+│ │ └ 1.3.2
+│ │   1.3.2a
+│ │   │
+│ │   └ 1.3.1.1
+│ │     1.3.1.1a
+│ └ 1.4
+└ 2
+`
+	exp = strings.TrimLeft(exp, "\n")
+	if res != exp {
+		t.Errorf("incorrect result:\n%s", res)
+	}
+
+	n = NewWithStyle(BulletStyle)
+	tree(n)
+	res = n.String()
+	exp = `
+• root
+│
+│
+├── • 1
+│   │
+│   ├── • 1.1
+│   │
+│   ├── • 1.2
+│   │   │
+│   │   │
+│   │   │
+│   │   ├── • 1.2.1
+│   │   │
+│   │   │
+│   │   └── • 1.2.2
+│   │
+│   ├── • 1.3
+│   │   │
+│   │   │
+│   │   ├── • 1.3.1
+│   │   │     1.3.1a
+│   │   │
+│   │   └── • 1.3.2
+│   │       │ 1.3.2a
+│   │       │
+│   │       │
+│   │       └── • 1.3.1.1
+│   │             1.3.1.1a
+│   │
+│   └── • 1.4
+│
+└── • 2
+`
+	exp = strings.TrimLeft(exp, "\n")
+	if res != exp {
+		t.Errorf("incorrect result:\n%s", res)
+	}
+}
+
+func TestTreePrinterUTF(t *testing.T) {
+	n := New()
+
+	r := n.Child("root")
+	r1 := r.Child("日本語\n本語\n本語")
+	r1.Child("日本語\n本語\n本語")
+	r.Child("日本語\n本語\n本語")
+	res := n.String()
+	exp := `
+root
+ ├── 日本語
+ │   本語
+ │   本語
+ │    └── 日本語
+ │        本語
+ │        本語
+ └── 日本語
+     本語
+     本語
+`
+
+	exp = strings.TrimLeft(exp, "\n")
+	if res != exp {
+		t.Errorf("incorrect result:\n%s", res)
+	}
+}
+
+func TestTreePrinterNested(t *testing.T) {
+	// The output of a treeprinter can be used as a node inside a larger
+	// treeprinter. This is useful when formatting routines use treeprinter
+	// internally.
+	tp1 := New()
+	r1 := tp1.Child("root1")
+	r11 := r1.Child("1.1")
+	r11.Child("1.1.1")
+	r11.Child("1.1.2")
+	r1.Child("1.2")
+	tree1 := strings.TrimRight(tp1.String(), "\n")
+
+	tp2 := New()
+	r2 := tp2.Child("root2")
+	r2.Child("2.1")
+	r22 := r2.Child("2.2")
+	r22.Child("2.2.1")
+	tree2 := strings.TrimRight(tp2.String(), "\n")
+
+	tp := New()
+	r := tp.Child("tree of trees")
+	r.Child(tree1)
+	r.Child(tree2)
+	res := tp.String()
+	exp := `
+tree of trees
+ ├── root1
+ │    ├── 1.1
+ │    │    ├── 1.1.1
+ │    │    └── 1.1.2
+ │    └── 1.2
+ └── root2
+      ├── 2.1
+      └── 2.2
+           └── 2.2.1
+`
+
+	exp = strings.TrimLeft(exp, "\n")
+	if res != exp {
+		t.Errorf("incorrect result:\n%s", res)
+	}
+}

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -917,9 +917,15 @@ type newIterOp struct {
 	derivedDBID objID
 }
 
+// Enable this to enable debug logging of range key iterator operations.
+const debugIterators = false
+
 func (o *newIterOp) run(t *Test, h historyRecorder) {
 	r := t.getReader(o.readerID)
 	opts := iterOptions(o.iterOpts)
+	if debugIterators {
+		opts.DebugRangeKeyStack = true
+	}
 
 	var i *pebble.Iterator
 	for {

--- a/options.go
+++ b/options.go
@@ -191,6 +191,8 @@ type IterOptions struct {
 	// changed by calling SetOptions.
 	sstable.CategoryAndQoS
 
+	DebugRangeKeyStack bool
+
 	// Internal options.
 
 	logger Logger

--- a/range_keys.go
+++ b/range_keys.go
@@ -22,6 +22,12 @@ func (i *Iterator) constructRangeKeyIter() {
 		&i.comparer, i.seqNum, i.opts.LowerBound, i.opts.UpperBound,
 		&i.hasPrefix, &i.prefixOrFullSeekKey, false /* internalKeys */, &i.rangeKey.rangeKeyBuffers.internal)
 
+	if i.opts.DebugRangeKeyStack {
+		// The default logger is preferable to i.opts.getLogger(), at least in the
+		// metamorphic test.
+		i.rangeKey.rangeKeyIter = keyspan.InjectLogging(i.rangeKey.rangeKeyIter, base.DefaultLogger)
+	}
+
 	// If there's an indexed batch with range keys, include it.
 	if i.batch != nil {
 		if i.batch.index == nil {

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -1861,3 +1861,6 @@ func (i *fragmentBlockIter) String() string {
 func (i *fragmentBlockIter) SetCloseHook(fn func(i keyspan.FragmentIterator) error) {
 	i.closeHook = fn
 }
+
+// WrapChildren implements FragmentIterator.
+func (i *fragmentBlockIter) WrapChildren(wrap keyspan.WrapFn) {}

--- a/sstable/prefix_replacing_iterator.go
+++ b/sstable/prefix_replacing_iterator.go
@@ -263,3 +263,8 @@ func (p *prefixReplacingFragmentIterator) Error() error {
 func (p *prefixReplacingFragmentIterator) Close() error {
 	return p.i.Close()
 }
+
+// WrapChildren implements FragmentIterator.
+func (p *prefixReplacingFragmentIterator) WrapChildren(wrap keyspan.WrapFn) {
+	p.i = wrap(p.i)
+}


### PR DESCRIPTION
#### keyspan: add logging infrastructure for iterator stacks

This change adds a logging `FragmentIterator` and new infrastructure
that allows injecting logging iterators in an entire iterator stack.
This helps understand how and why the stack produces a certain result.

We do this by adding a `FragmentIterator.WrapChildren()` method which
uses a given wrap function to replace any children iterators. The
wrap function itself can call `WrapChildren` again to recursively do
the same to all iterators in the stack.

Some iterators that create new child iterators on the fly have to
remember the wrap function.

Sample output: https://gist.github.com/RaduBerinde/0200d3c4726966f24c1ef81ed02e440e

#### keyspan: use treeprinter for iterator stack logging

The treeprinter library was lifted from cockroach without changes.

Sample output: https://gist.github.com/RaduBerinde/cc744c9922868740169cd670bfdb8b2a