### PR TITLE
sstable: hide obsolete range keys for shared ingested sstables

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -1172,7 +1172,7 @@ func runSSTablePropertiesCmd(t *testing.T, td *datadriven.TestData, d *DB) strin
 	var v sstable.VirtualReader
 	props := r.Properties.String()
 	if m != nil && m.Virtual {
-		v = sstable.MakeVirtualReader(r, m.VirtualMeta(), false /* isForeign */)
+		v = sstable.MakeVirtualReader(r, m.VirtualMeta(), false /* isShared */)
 		props = v.Properties.String()
 	}
 	if len(td.Input) == 0 {

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -25,6 +26,9 @@ import (
 
 // Verify event listener actions, as well as expected filesystem operations.
 func TestEventListener(t *testing.T) {
+	if runtime.GOARCH == "386" {
+		t.Skip("skipped on 32-bit due to slightly varied output")
+	}
 	var d *DB
 	var memLog base.InMemLogger
 	mem := vfs.NewMem()

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"sort"
 	"strconv"
@@ -2116,6 +2117,9 @@ func TestIngest(t *testing.T) {
 	var mem vfs.FS
 	var d *DB
 	var flushed bool
+	if runtime.GOARCH == "386" {
+		t.Skip("skipped on 32-bit due to slightly varied output")
+	}
 	defer func() {
 		require.NoError(t, d.Close())
 	}()

--- a/internal/keyspan/transformer.go
+++ b/internal/keyspan/transformer.go
@@ -48,3 +48,102 @@ func VisibleTransform(snapshot uint64) Transformer {
 		return nil
 	})
 }
+
+// TransformerIter is a FragmentIterator that applies a Transformer on all
+// returned keys. Used for when a caller needs to apply a transformer on an
+// iterator but does not otherwise need the mergingiter's merging ability.
+type TransformerIter struct {
+	FragmentIterator
+
+	// Transformer is applied on every Span returned by this iterator.
+	Transformer Transformer
+	// Comparer in use for this keyspace.
+	Compare base.Compare
+
+	span Span
+	err  error
+}
+
+func (t *TransformerIter) applyTransform(span *Span) *Span {
+	t.span = Span{
+		Start: t.span.Start[:0],
+		End:   t.span.End[:0],
+		Keys:  t.span.Keys[:0],
+	}
+	if err := t.Transformer.Transform(t.Compare, *span, &t.span); err != nil {
+		t.err = err
+		return nil
+	}
+	return &t.span
+}
+
+// SeekGE implements the FragmentIterator interface.
+func (t *TransformerIter) SeekGE(key []byte) *Span {
+	span := t.FragmentIterator.SeekGE(key)
+	if span == nil {
+		return nil
+	}
+	return t.applyTransform(span)
+}
+
+// SeekLT implements the FragmentIterator interface.
+func (t *TransformerIter) SeekLT(key []byte) *Span {
+	span := t.FragmentIterator.SeekLT(key)
+	if span == nil {
+		return nil
+	}
+	return t.applyTransform(span)
+}
+
+// First implements the FragmentIterator interface.
+func (t *TransformerIter) First() *Span {
+	span := t.FragmentIterator.First()
+	if span == nil {
+		return nil
+	}
+	return t.applyTransform(span)
+}
+
+// Last implements the FragmentIterator interface.
+func (t *TransformerIter) Last() *Span {
+	span := t.FragmentIterator.Last()
+	if span == nil {
+		return nil
+	}
+	return t.applyTransform(span)
+}
+
+// Next implements the FragmentIterator interface.
+func (t *TransformerIter) Next() *Span {
+	span := t.FragmentIterator.Next()
+	if span == nil {
+		return nil
+	}
+	return t.applyTransform(span)
+}
+
+// Prev implements the FragmentIterator interface.
+func (t *TransformerIter) Prev() *Span {
+	span := t.FragmentIterator.Prev()
+	if span == nil {
+		return nil
+	}
+	return t.applyTransform(span)
+}
+
+// Error implements the FragmentIterator interface.
+func (t *TransformerIter) Error() error {
+	if t.err != nil {
+		return t.err
+	}
+	return t.FragmentIterator.Error()
+}
+
+// Close implements the FragmentIterator interface.
+func (t *TransformerIter) Close() error {
+	err := t.FragmentIterator.Close()
+	if err != nil {
+		return err
+	}
+	return t.err
+}

--- a/internal/rangekey/coalesce.go
+++ b/internal/rangekey/coalesce.go
@@ -6,6 +6,7 @@ package rangekey
 
 import (
 	"bytes"
+	"fmt"
 	"math"
 	"sort"
 
@@ -376,5 +377,80 @@ func coalesce(
 	if deleteIdx >= 0 {
 		keysBySuffix.Keys = append(keysBySuffix.Keys, keys[deleteIdx])
 	}
+	return nil
+}
+
+// ForeignSSTTransformer implements a keyspan.Transformer for range keys in
+// foreign sstables (i.e. shared sstables not created by us). It is largely
+// similar to the Transform function implemented in UserIteratorConfig in that
+// it calls coalesce to remove range keys shadowed by other range keys, but also
+// retains the range key that does the shadowing. In addition, it elides
+// RangeKey unsets/dels in L6 as they are inapplicable when reading from a
+// different Pebble instance.
+type ForeignSSTTransformer struct {
+	Comparer *base.Comparer
+	Level    int
+	sortBuf  keyspan.KeysBySuffix
+}
+
+// Transform implements the Transformer interface.
+func (f *ForeignSSTTransformer) Transform(
+	cmp base.Compare, s keyspan.Span, dst *keyspan.Span,
+) error {
+	// Apply shadowing of keys.
+	dst.Start = s.Start
+	dst.End = s.End
+	f.sortBuf = keyspan.KeysBySuffix{
+		Cmp:  cmp,
+		Keys: f.sortBuf.Keys[:0],
+	}
+	if err := coalesce(f.Comparer.Equal, &f.sortBuf, math.MaxUint64, s.Keys); err != nil {
+		return err
+	}
+	keys := f.sortBuf.Keys
+	dst.Keys = dst.Keys[:0]
+	for i := range keys {
+		seqNum := keys[i].SeqNum()
+		switch keys[i].Kind() {
+		case base.InternalKeyKindRangeKeySet:
+			if invariants.Enabled && len(dst.Keys) > 0 && cmp(dst.Keys[len(dst.Keys)-1].Suffix, keys[i].Suffix) > 0 {
+				panic("pebble: keys unexpectedly not in ascending suffix order")
+			}
+			switch f.Level {
+			case 5:
+				fallthrough
+			case 6:
+				if seqNum != base.SeqNumForLevel(f.Level) {
+					panic(fmt.Sprintf("pebble: expected range key iter to return seqnum %d, got %d", base.SeqNumForLevel(f.Level), seqNum))
+				}
+			}
+		case base.InternalKeyKindRangeKeyUnset:
+			if invariants.Enabled && len(dst.Keys) > 0 && cmp(dst.Keys[len(dst.Keys)-1].Suffix, keys[i].Suffix) > 0 {
+				panic("pebble: keys unexpectedly not in ascending suffix order")
+			}
+			fallthrough
+		case base.InternalKeyKindRangeKeyDelete:
+			switch f.Level {
+			case 5:
+				// Emit this key.
+				if seqNum != base.SeqNumForLevel(f.Level) {
+					panic(fmt.Sprintf("pebble: expected range key iter to return seqnum %d, got %d", base.SeqNumForLevel(f.Level), seqNum))
+				}
+			case 6:
+				// Skip this key, as foreign sstable in L6 do not need to emit range key
+				// unsets/dels as they do not apply to any other sstables.
+				continue
+			}
+		default:
+			return base.CorruptionErrorf("pebble: unrecognized range key kind %s", keys[i].Kind())
+		}
+		dst.Keys = append(dst.Keys, keyspan.Key{
+			Trailer: base.MakeTrailer(seqNum, keys[i].Kind()),
+			Suffix:  keys[i].Suffix,
+			Value:   keys[i].Value,
+		})
+	}
+	// coalesce results in dst.Keys being sorted by Suffix.
+	dst.KeysOrder = keyspan.BySuffixAsc
 	return nil
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -7,6 +7,7 @@ package pebble
 import (
 	"bytes"
 	"fmt"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -93,6 +94,9 @@ func exampleMetrics() Metrics {
 }
 
 func TestMetrics(t *testing.T) {
+	if runtime.GOARCH == "386" {
+		t.Skip("skipped on 32-bit due to slightly varied output")
+	}
 	c := cache.New(cacheDefaultSize)
 	defer c.Unref()
 	opts := &Options{

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -345,7 +345,7 @@ func TestVirtualReader(t *testing.T) {
 			vMeta.ValidateVirtual(meta.FileMetadata)
 
 			vMeta1 = vMeta.VirtualMeta()
-			v = MakeVirtualReader(r, vMeta1, false /* isForeign */)
+			v = MakeVirtualReader(r, vMeta1, false /* isSharedIngested */)
 			return formatVirtualReader(&v)
 
 		case "citer":

--- a/table_cache.go
+++ b/table_cache.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/private"
-	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
 	"github.com/cockroachdb/pebble/sstable"
@@ -202,17 +201,17 @@ func (c *tableCacheContainer) estimateSize(
 	return size, nil
 }
 
-// createCommonReader creates a Reader for this file. isForeign, if true for
+// createCommonReader creates a Reader for this file. isShared, if true for
 // virtual sstables, is passed into the vSSTable reader so its iterators can
 // collapse obsolete points accordingly.
 func createCommonReader(
-	v *tableCacheValue, file *fileMetadata, isForeign bool,
+	v *tableCacheValue, file *fileMetadata, isShared bool,
 ) sstable.CommonReader {
 	// TODO(bananabrick): We suffer an allocation if file is a virtual sstable.
 	var cr sstable.CommonReader = v.reader
 	if file.Virtual {
 		virtualReader := sstable.MakeVirtualReader(
-			v.reader, file.VirtualMeta(), isForeign,
+			v.reader, file.VirtualMeta(), isShared,
 		)
 		cr = &virtualReader
 	}
@@ -233,7 +232,7 @@ func (c *tableCacheContainer) withCommonReader(
 	if err != nil {
 		return err
 	}
-	return fn(createCommonReader(v, meta, provider.IsSharedForeign(objMeta)))
+	return fn(createCommonReader(v, meta, objMeta.IsShared()))
 }
 
 func (c *tableCacheContainer) withReader(meta physicalMeta, fn func(*sstable.Reader) error) error {
@@ -261,7 +260,7 @@ func (c *tableCacheContainer) withVirtualReader(
 	if err != nil {
 		return err
 	}
-	return fn(sstable.MakeVirtualReader(v.reader, meta, provider.IsSharedForeign(objMeta)))
+	return fn(sstable.MakeVirtualReader(v.reader, meta, objMeta.IsShared()))
 }
 
 func (c *tableCacheContainer) iterCount() int64 {
@@ -492,7 +491,7 @@ func (c *tableCacheShard) newIters(
 	}
 
 	// Note: This suffers an allocation for virtual sstables.
-	cr := createCommonReader(v, file, provider.IsSharedForeign(objMeta))
+	cr := createCommonReader(v, file, objMeta.IsShared())
 
 	// NB: range-del iterator does not maintain a reference to the table, nor
 	// does it need to read from it after creation.
@@ -628,7 +627,7 @@ func (c *tableCacheShard) newRangeKeyIter(
 		objMeta, err = provider.Lookup(fileTypeTable, file.FileBacking.DiskFileNum)
 		if err == nil {
 			virtualReader := sstable.MakeVirtualReader(
-				v.reader, file.VirtualMeta(), provider.IsSharedForeign(objMeta),
+				v.reader, file.VirtualMeta(), objMeta.IsShared(),
 			)
 			iter, err = virtualReader.NewRawRangeKeyIter()
 		}
@@ -648,29 +647,6 @@ func (c *tableCacheShard) newRangeKeyIter(
 		// NewRawRangeKeyIter can return nil even if there's no error. However,
 		// the keyspan.LevelIter expects a non-nil iterator if err is nil.
 		return emptyKeyspanIter, nil
-	}
-
-	objMeta, err := dbOpts.objProvider.Lookup(fileTypeTable, file.FileBacking.DiskFileNum)
-	if err != nil {
-		return nil, err
-	}
-	if dbOpts.objProvider.IsForeign(objMeta) {
-		if opts.Level == 0 {
-			panic("unexpected zero level when reading foreign file")
-		}
-		transform := &rangekey.ForeignSSTTransformer{
-			Comparer: dbOpts.opts.Comparer,
-			Level:    manifest.LevelToInt(opts.Level),
-		}
-		if iter == nil {
-			iter = emptyKeyspanIter
-		}
-		transformIter := &keyspan.TransformerIter{
-			FragmentIterator: iter,
-			Transformer:      transform,
-			Compare:          dbOpts.opts.Comparer.Compare,
-		}
-		return transformIter, nil
 	}
 
 	return iter, nil

--- a/table_cache.go
+++ b/table_cache.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/private"
+	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
 	"github.com/cockroachdb/pebble/sstable"
@@ -647,6 +648,29 @@ func (c *tableCacheShard) newRangeKeyIter(
 		// NewRawRangeKeyIter can return nil even if there's no error. However,
 		// the keyspan.LevelIter expects a non-nil iterator if err is nil.
 		return emptyKeyspanIter, nil
+	}
+
+	objMeta, err := dbOpts.objProvider.Lookup(fileTypeTable, file.FileBacking.DiskFileNum)
+	if err != nil {
+		return nil, err
+	}
+	if dbOpts.objProvider.IsForeign(objMeta) {
+		if opts.Level == 0 {
+			panic("unexpected zero level when reading foreign file")
+		}
+		transform := &rangekey.ForeignSSTTransformer{
+			Comparer: dbOpts.opts.Comparer,
+			Level:    manifest.LevelToInt(opts.Level),
+		}
+		if iter == nil {
+			iter = emptyKeyspanIter
+		}
+		transformIter := &keyspan.TransformerIter{
+			FragmentIterator: iter,
+			Transformer:      transform,
+			Compare:          dbOpts.opts.Comparer.Compare,
+		}
+		return transformIter, nil
 	}
 
 	return iter, nil

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -222,7 +222,7 @@ Zombie tables: 0 (0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Block cache: 6 entries (1.1KB)  hit rate: 11.1%
-Table cache: 1 entries (800B)  hit rate: 40.0%
+Table cache: 1 entries (808B)  hit rate: 40.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
@@ -321,7 +321,7 @@ Zombie tables: 0 (0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Block cache: 12 entries (2.3KB)  hit rate: 14.3%
-Table cache: 1 entries (800B)  hit rate: 50.0%
+Table cache: 1 entries (808B)  hit rate: 50.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -52,7 +52,7 @@ Zombie tables: 0 (0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Block cache: 6 entries (1.2KB)  hit rate: 35.7%
-Table cache: 1 entries (800B)  hit rate: 50.0%
+Table cache: 1 entries (808B)  hit rate: 50.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0

--- a/testdata/ingest_shared
+++ b/testdata/ingest_shared
@@ -1123,3 +1123,120 @@ next
 b: (bar, .)
 c: (baz, .)
 .
+
+# Regression test for #3174. Obsolete range keys in shared ingested SSTs should
+# not be surfaced.
+
+reset
+----
+
+switch 1
+----
+ok
+
+batch
+range-key-set c h @5 foo
+----
+
+file-only-snapshot s9
+ a z
+----
+ok
+
+batch
+range-key-del d f
+----
+
+iter snapshot=s9
+first
+next
+next
+----
+c: (., [c-h) @5=foo UPDATED)
+.
+.
+
+compact a-z
+----
+ok
+
+iter
+first
+next
+next
+----
+c: (., [c-d) @5=foo UPDATED)
+f: (., [f-h) @5=foo UPDATED)
+.
+
+lsm
+----
+6:
+  000005:[c#10,RANGEKEYSET-h#inf,RANGEKEYSET]
+
+replicate 1 2 a f
+----
+replicated 1 shared SSTs
+
+switch 2
+----
+ok
+
+iter
+first
+next
+next
+next
+----
+c: (., [c-d) @5=foo UPDATED)
+.
+.
+.
+
+batch
+range-key-set c e @7 foo
+----
+
+batch
+range-key-unset bb d @5
+----
+
+file-only-snapshot s10
+ a z
+----
+ok
+
+batch
+range-key-del cc dd
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+lsm
+----
+6:
+  000008:[c#11,RANGEKEYSET-e#inf,RANGEKEYSET]
+
+switch 1
+----
+ok
+
+replicate 2 1 a z
+----
+replicated 1 shared SSTs
+
+iter
+first
+next
+next
+next
+----
+c: (., [c-cc) @7=foo UPDATED)
+dd: (., [dd-e) @7=foo UPDATED)
+.
+.

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -68,7 +68,7 @@ Zombie tables: 0 (0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Block cache: 3 entries (556B)  hit rate: 0.0%
-Table cache: 1 entries (800B)  hit rate: 0.0%
+Table cache: 1 entries (808B)  hit rate: 0.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
@@ -201,7 +201,7 @@ Zombie tables: 1 (661B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Block cache: 3 entries (556B)  hit rate: 42.9%
-Table cache: 1 entries (800B)  hit rate: 66.7%
+Table cache: 1 entries (808B)  hit rate: 66.7%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
@@ -467,7 +467,7 @@ Zombie tables: 0 (0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Block cache: 12 entries (2.4KB)  hit rate: 31.1%
-Table cache: 3 entries (2.3KB)  hit rate: 57.9%
+Table cache: 3 entries (2.4KB)  hit rate: 57.9%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
@@ -529,7 +529,7 @@ Zombie tables: 0 (0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Block cache: 12 entries (2.4KB)  hit rate: 31.1%
-Table cache: 3 entries (2.3KB)  hit rate: 57.9%
+Table cache: 3 entries (2.4KB)  hit rate: 57.9%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0


### PR DESCRIPTION
This change updates the virtual sstable range key iterator to
hide obsolete range keys for shared ingested files. It does
this by reusing the ForeignSSTTransformer that was removed
in https://github.com/cockroachdb/pebble/pull/2782.

This change also cleans up some dangling references to the older
`isForeign` way of determining whether to hide obsolete keys,
in lieu of the newer isSharedIngested approach to address
boomerang shared files.

Fixes https://github.com/cockroachdb/pebble/issues/3174.