### PR TITLE
sstable: fix PrefixReplacingIterator.SetBounds memory aliasing

### DIFF
--- a/sstable/prefix_replacing_iterator.go
+++ b/sstable/prefix_replacing_iterator.go
@@ -163,7 +163,13 @@ func (p *prefixReplacingIterator) SetBounds(lower, upper []byte) {
 		p.i.SetBounds(lower, upper)
 		return
 	}
-	p.i.SetBounds(p.rewriteArg(lower), p.rewriteArg2(upper))
+	if lower != nil {
+		lower = append([]byte{}, p.rewriteArg(lower)...)
+	}
+	if upper != nil {
+		upper = append([]byte{}, p.rewriteArg(upper)...)
+	}
+	p.i.SetBounds(lower, upper)
 }
 
 func (p *prefixReplacingIterator) MaybeFilteredKeys() bool {

--- a/sstable/prefix_replacing_iterator_test.go
+++ b/sstable/prefix_replacing_iterator_test.go
@@ -53,7 +53,7 @@ func TestPrefixReplacingIterator(t *testing.T) {
 				require.Equal(t, k(19), got.UserKey)
 			})
 
-			t.Run("Sets", func(t *testing.T) {
+			t.Run("SetBounds", func(t *testing.T) {
 				it.SetBounds(k(5), k(15))
 				defer it.SetBounds(nil, nil)
 
@@ -64,9 +64,7 @@ func TestPrefixReplacingIterator(t *testing.T) {
 				require.Equal(t, k(14), got.UserKey)
 
 				got, _ = it.SeekLT(k(100), base.SeekLTFlagsNone)
-				// TODO(dt): Shouldn't this be upper-1? why is it nil?
-				// i.e. require.Equal(t, k(14), got.UserKey) ?
-				require.Nil(t, got)
+				require.Equal(t, k(19), got.UserKey)
 			})
 
 			t.Run("SetHookAndCtx", func(t *testing.T) {


### PR DESCRIPTION
Previously SetBounds was passing the underlying iterator bounds that would mutate on the next call to any of the methods of the iterator, causing the unexpected value in the test case that is updated here as well.