### PR TITLE
db: add Options.DisableTableStats

### DIFF
--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -39,7 +39,7 @@ func TestCheckpoint(t *testing.T) {
 		L0CompactionThreshold:       10,
 		DisableAutomaticCompactions: true,
 	}
-	opts.private.disableTableStats = true
+	opts.DisableTableStats = true
 	opts.private.testingAlwaysWaitForCleanup = true
 
 	datadriven.RunTest(t, "testdata/checkpoint", func(t *testing.T, td *datadriven.TestData) string {

--- a/cleaner_test.go
+++ b/cleaner_test.go
@@ -108,7 +108,7 @@ func TestCleaner(t *testing.T) {
 				}
 			}
 			// Asynchronous table stats retrieval makes the output flaky.
-			opts.private.disableTableStats = true
+			opts.DisableTableStats = true
 			opts.private.testingAlwaysWaitForCleanup = true
 			d, err := Open(dir, opts)
 			if err != nil {

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -1465,13 +1465,13 @@ func TestCompactionPickerScores(t *testing.T) {
 
 		case "disable-table-stats":
 			d.mu.Lock()
-			d.opts.private.disableTableStats = true
+			d.opts.DisableTableStats = true
 			d.mu.Unlock()
 			return ""
 
 		case "enable-table-stats":
 			d.mu.Lock()
-			d.opts.private.disableTableStats = false
+			d.opts.DisableTableStats = false
 			d.maybeCollectTableStatsLocked()
 			d.mu.Unlock()
 			return ""

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1846,6 +1846,9 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 		opts := (&Options{
 			FS:         vfs.NewMem(),
 			DebugCheck: DebugCheckLevels,
+			// Collection of table stats can trigger compactions. As we want full
+			// control over when compactions are run, disable stats by default.
+			DisableTableStats: true,
 			EventListener: &EventListener{
 				CompactionEnd: func(info CompactionInfo) {
 					if compactInfo != nil {
@@ -1856,10 +1859,6 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 			},
 			FormatMajorVersion: internalFormatNewest,
 		}).WithFSDefaults()
-
-		// Collection of table stats can trigger compactions. As we want full
-		// control over when compactions are run, disable stats by default.
-		opts.private.disableTableStats = true
 
 		return opts, nil
 	}
@@ -1953,10 +1952,10 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 				// Force collection of table stats. This requires re-enabling the
 				// collection flag. We also do not want compactions to run as part of
 				// the stats collection job, so we disable it temporarily.
-				d.opts.private.disableTableStats = false
+				d.opts.DisableTableStats = false
 				d.opts.DisableAutomaticCompactions = true
 				defer func() {
-					d.opts.private.disableTableStats = true
+					d.opts.DisableTableStats = true
 					d.opts.DisableAutomaticCompactions = false
 				}()
 

--- a/data_test.go
+++ b/data_test.go
@@ -780,7 +780,7 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 			if err != nil {
 				return nil, errors.Errorf("%s: could not parse %q as bool: %s", td.Cmd, arg.Vals[0], err)
 			}
-			opts.private.disableTableStats = !enable
+			opts.DisableTableStats = !enable
 		case "block-size":
 			size, err := strconv.Atoi(arg.Vals[0])
 			if err != nil {
@@ -1350,7 +1350,7 @@ func parseDBOptionsArgs(opts *Options, args []datadriven.CmdArg) error {
 			if err != nil {
 				return errors.Errorf("%s: could not parse %q as bool: %s", cmdArg.Key, cmdArg.Vals[0], err)
 			}
-			opts.private.disableTableStats = !enable
+			opts.DisableTableStats = !enable
 		case "format-major-version":
 			v, err := strconv.Atoi(cmdArg.Vals[0])
 			if err != nil {

--- a/db_test.go
+++ b/db_test.go
@@ -789,16 +789,16 @@ func TestIterLeakSharedCache(t *testing.T) {
 
 func TestMemTableReservation(t *testing.T) {
 	opts := &Options{
-		Cache:        NewCache(128 << 10 /* 128 KB */),
-		MemTableSize: initialMemTableSize,
-		FS:           vfs.NewMem(),
+		Cache: NewCache(128 << 10 /* 128 KB */),
+		// We're going to be looking at and asserting the global memtable reservation
+		// amount below so we don't want to race with any triggered stats collections.
+		DisableTableStats: true,
+		MemTableSize:      initialMemTableSize,
+		FS:                vfs.NewMem(),
 	}
 	defer opts.Cache.Unref()
 	opts.testingRandomized(t)
 	opts.EnsureDefaults()
-	// We're going to be looking at and asserting the global memtable reservation
-	// amount below so we don't want to race with any triggered stats collections.
-	opts.private.disableTableStats = true
 
 	// Add a block to the cache. Note that the memtable size is larger than the
 	// cache size, so opening the DB should cause this block to be evicted.

--- a/error_test.go
+++ b/error_test.go
@@ -172,11 +172,11 @@ func TestRequireReadError(t *testing.T) {
 		ii := errorfs.OnIndex(-1)
 		fs := errorfs.Wrap(vfs.NewMem(), errorfs.ErrInjected.If(ii))
 		opts := &Options{
+			DisableTableStats:  true,
 			FS:                 fs,
 			Logger:             panicLogger{},
 			FormatMajorVersion: formatVersion,
 		}
-		opts.private.disableTableStats = true
 		d, err := Open("", opts)
 		require.NoError(t, err)
 
@@ -265,11 +265,11 @@ func TestCorruptReadError(t *testing.T) {
 		}
 		fs.index.Store(-1)
 		opts := &Options{
+			DisableTableStats:  true,
 			FS:                 fs,
 			Logger:             panicLogger{},
 			FormatMajorVersion: formatVersion,
 		}
-		opts.private.disableTableStats = true
 		d, err := Open("", opts)
 		if err != nil {
 			t.Fatalf("%v", err)
@@ -361,11 +361,11 @@ func TestDBWALRotationCrash(t *testing.T) {
 
 	run := func(fs *errorfs.FS, k int32) (err error) {
 		opts := &Options{
-			FS:           fs,
-			Logger:       panicLogger{},
-			MemTableSize: 2048,
+			DisableTableStats: true,
+			FS:                fs,
+			Logger:            panicLogger{},
+			MemTableSize:      2048,
 		}
-		opts.private.disableTableStats = true
 		d, err := Open("", opts)
 		if err != nil || triggered() {
 			return err

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -47,6 +47,11 @@ func TestEventListener(t *testing.T) {
 				flushEnd(info)
 			}
 			opts := &Options{
+				// The table stats collector runs asynchronously and its
+				// timing is less predictable. It increments nextJobID, which
+				// can make these tests flaky. The TableStatsLoaded event is
+				// tested separately in TestTableStats.
+				DisableTableStats:     true,
 				FS:                    vfs.WithLogging(mem, memLog.Infof),
 				FormatMajorVersion:    internalFormatNewest,
 				EventListener:         &lel,
@@ -54,11 +59,6 @@ func TestEventListener(t *testing.T) {
 				L0CompactionThreshold: 10,
 				WALDir:                "wal",
 			}
-			// The table stats collector runs asynchronously and its
-			// timing is less predictable. It increments nextJobID, which
-			// can make these tests flaky. The TableStatsLoaded event is
-			// tested separately in TestTableStats.
-			opts.private.disableTableStats = true
 			var err error
 			d, err = Open("db", opts)
 			if err != nil {

--- a/options.go
+++ b/options.go
@@ -875,6 +875,15 @@ type Options struct {
 	// externally when running a manual compaction, and internally for tests.
 	DisableAutomaticCompactions bool
 
+	// DisableTableStats dictates whether tables should be loaded asynchronously
+	// to compute statistics that inform compaction heuristics. The collection
+	// of table stats improves compaction of tombstones, reclaiming disk space
+	// more quickly and in some cases reducing write amplification in the
+	// presence of tombstones. Disabling table stats may be useful in tests
+	// that require determinism as the asynchronicity of table stats collection
+	// introduces significant nondeterminism.
+	DisableTableStats bool
+
 	// NoSyncOnClose decides whether the Pebble instance will enforce a
 	// close-time synchronization (e.g., fdatasync() or sync_file_range())
 	// on files it writes to. Setting this to true removes the guarantee for a
@@ -981,9 +990,6 @@ type Options struct {
 		// option to avoid littering the public interface with options that we
 		// do not want to allow users to actually configure.
 		disableLazyCombinedIteration bool
-
-		// A private option to disable stats collection.
-		disableTableStats bool
 
 		// testingAlwaysWaitForCleanup is set by some tests to force waiting for
 		// obsolete file deletion (to make events deterministic).

--- a/table_stats.go
+++ b/table_stats.go
@@ -71,7 +71,7 @@ func (d *DB) updateTableStatsLocked(newFiles []manifest.NewFileEntry) {
 func (d *DB) shouldCollectTableStatsLocked() bool {
 	return !d.mu.tableStats.loading &&
 		d.closed.Load() == nil &&
-		!d.opts.private.disableTableStats &&
+		!d.opts.DisableTableStats &&
 		(len(d.mu.tableStats.pending) > 0 || !d.mu.tableStats.loadedInitial)
 }
 

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -25,16 +25,16 @@ func TestTableStats(t *testing.T) {
 	// loadedInfo is protected by d.mu.
 	var loadedInfo *TableStatsInfo
 	opts := &Options{
-		FS: vfs.NewMem(),
+		Comparer:                    testkeys.Comparer,
+		DisableAutomaticCompactions: true,
+		FormatMajorVersion:          FormatMinSupported,
+		FS:                          vfs.NewMem(),
 		EventListener: &EventListener{
 			TableStatsLoaded: func(info TableStatsInfo) {
 				loadedInfo = &info
 			},
 		},
 	}
-	opts.DisableAutomaticCompactions = true
-	opts.Comparer = testkeys.Comparer
-	opts.FormatMajorVersion = FormatMinSupported
 
 	d, err := Open("", opts)
 	require.NoError(t, err)
@@ -49,13 +49,13 @@ func TestTableStats(t *testing.T) {
 		switch td.Cmd {
 		case "disable":
 			d.mu.Lock()
-			d.opts.private.disableTableStats = true
+			d.opts.DisableTableStats = true
 			d.mu.Unlock()
 			return ""
 
 		case "enable":
 			d.mu.Lock()
-			d.opts.private.disableTableStats = false
+			d.opts.DisableTableStats = false
 			d.maybeCollectTableStatsLocked()
 			d.mu.Unlock()
 			return ""


### PR DESCRIPTION
Export the previously private disableTableStats field to allow external users access. This is intended for use within external tests that require additional determinism.