### PR TITLE
db, objiotracing: more DiskFileNum cleanup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
       with:
         go-version: "1.21"
 
-    - run: make test generate
+    - run: make test testobjiotracing generate
 
     - name: Assert workspace clean
       run: scripts/check-workspace-clean.sh

--- a/db.go
+++ b/db.go
@@ -2249,10 +2249,9 @@ type SSTableInfo struct {
 	manifest.TableInfo
 	// Virtual indicates whether the sstable is virtual.
 	Virtual bool
-	// BackingSSTNum is the file number associated with backing sstable which
-	// backs the sstable associated with this SSTableInfo. If Virtual is false,
-	// then BackingSSTNum == FileNum.
-	BackingSSTNum base.FileNum
+	// BackingSSTNum is the disk file number associated with the backing sstable.
+	// If Virtual is false, BackingSSTNum == FileNum.DiskFileNum().
+	BackingSSTNum base.DiskFileNum
 	// BackingType is the type of storage backing this sstable.
 	BackingType BackingType
 	// Locator is the remote.Locator backing this sstable, if the backing type is
@@ -2315,7 +2314,7 @@ func (d *DB) SSTables(opts ...SSTablesOption) ([][]SSTableInfo, error) {
 				destTables[j].Properties = p
 			}
 			destTables[j].Virtual = m.Virtual
-			destTables[j].BackingSSTNum = m.FileBacking.DiskFileNum.FileNum()
+			destTables[j].BackingSSTNum = m.FileBacking.DiskFileNum
 			objMeta, err := d.objProvider.Lookup(fileTypeTable, m.FileBacking.DiskFileNum)
 			if err != nil {
 				return nil, err

--- a/objstorage/objstorageprovider/objiotracing/obj_io_tracing.go
+++ b/objstorage/objstorageprovider/objiotracing/obj_io_tracing.go
@@ -59,7 +59,7 @@ type Event struct {
 	LevelPlusOne uint8
 	// Hardcoded padding so that struct layout doesn't depend on architecture.
 	_       uint32
-	FileNum base.FileNum
+	FileNum base.DiskFileNum
 	// HandleID is a unique identifier corresponding to an objstorage.ReadHandle;
 	// only set for read operations performed through a ReadHandle.
 	HandleID uint64

--- a/objstorage/objstorageprovider/objiotracing/obj_io_tracing_on.go
+++ b/objstorage/objstorageprovider/objiotracing/obj_io_tracing_on.go
@@ -76,7 +76,7 @@ func (t *Tracer) Close() {
 // WrapWritable wraps an objstorage.Writable with one that generates tracing
 // events.
 func (t *Tracer) WrapWritable(
-	ctx context.Context, w objstorage.Writable, fileNum base.FileNum,
+	ctx context.Context, w objstorage.Writable, fileNum base.DiskFileNum,
 ) objstorage.Writable {
 	return &writable{
 		w:       w,
@@ -87,7 +87,7 @@ func (t *Tracer) WrapWritable(
 
 type writable struct {
 	w         objstorage.Writable
-	fileNum   base.FileNum
+	fileNum   base.DiskFileNum
 	curOffset int64
 	g         eventGenerator
 }
@@ -125,7 +125,7 @@ func (w *writable) Abort() {
 // WrapReadable wraps an objstorage.Readable with one that generates tracing
 // events.
 func (t *Tracer) WrapReadable(
-	ctx context.Context, r objstorage.Readable, fileNum base.FileNum,
+	ctx context.Context, r objstorage.Readable, fileNum base.DiskFileNum,
 ) objstorage.Readable {
 	res := &readable{
 		r:       r,
@@ -137,7 +137,7 @@ func (t *Tracer) WrapReadable(
 
 type readable struct {
 	r       objstorage.Readable
-	fileNum base.FileNum
+	fileNum base.DiskFileNum
 	mu      struct {
 		sync.Mutex
 		g eventGenerator
@@ -147,7 +147,7 @@ type readable struct {
 var _ objstorage.Readable = (*readable)(nil)
 
 // ReadAt is part of the objstorage.Readable interface.
-func (r *readable) ReadAt(ctx context.Context, v []byte, off int64) (n int, err error) {
+func (r *readable) ReadAt(ctx context.Context, v []byte, off int64) error {
 	r.mu.Lock()
 	r.mu.g.add(ctx, Event{
 		Op:      ReadOp,
@@ -184,7 +184,7 @@ func (r *readable) NewReadHandle(ctx context.Context) objstorage.ReadHandle {
 
 type readHandle struct {
 	rh       objstorage.ReadHandle
-	fileNum  base.FileNum
+	fileNum  base.DiskFileNum
 	handleID uint64
 	g        eventGenerator
 }
@@ -192,7 +192,7 @@ type readHandle struct {
 var _ objstorage.ReadHandle = (*readHandle)(nil)
 
 // ReadAt is part of the objstorage.ReadHandle interface.
-func (rh *readHandle) ReadAt(ctx context.Context, p []byte, off int64) (n int, err error) {
+func (rh *readHandle) ReadAt(ctx context.Context, p []byte, off int64) error {
 	rh.g.add(ctx, Event{
 		Op:       ReadOp,
 		FileNum:  rh.fileNum,

--- a/objstorage/objstorageprovider/objiotracing/obj_io_tracing_test.go
+++ b/objstorage/objstorageprovider/objiotracing/obj_io_tracing_test.go
@@ -103,7 +103,7 @@ func TestTracing(t *testing.T) {
 	require.Greater(t, num(func(e Event) bool { return e.Op == objiotracing.WriteOp && e.Offset > 0 }), 0)
 
 	// Check that the FileNums are set and that we see at least two different files.
-	fileNums := make(map[base.FileNum]int)
+	fileNums := make(map[base.DiskFileNum]int)
 	for _, e := range events {
 		require.NotZero(t, e.FileNum)
 		fileNums[e.FileNum] += 1

--- a/tool/db_io_bench.go
+++ b/tool/db_io_bench.go
@@ -188,7 +188,7 @@ func (d *dbT) openBenchTables(db *pebble.DB) ([]objstorage.Readable, error) {
 	numsMap := make(map[base.DiskFileNum]struct{})
 	for l := startLevel; l < len(tables); l++ {
 		for _, t := range tables[l] {
-			n := t.BackingSSTNum.DiskFileNum()
+			n := t.BackingSSTNum
 			if _, ok := numsMap[n]; !ok {
 				nums = append(nums, n)
 				numsMap[n] = struct{}{}


### PR DESCRIPTION
#### db: change the type of SSTableInfo.BackingSSTNum

Switch to `DiskFileNum` which makes more sense and matches how it is
actually used.

#### objiotracing: fix the build and use DiskFileNum

The objiotracing build (`make testobjiotracing`) was broken. This
commit fixes it and switches to `DiskFileNum` in this layer.

We also add the `testobjiotracing` target to the linux CI build.