### PR TITLE
github: add nightly stress action

### DIFF
--- a/.github/workflows/stress.yaml
+++ b/.github/workflows/stress.yaml
@@ -1,0 +1,24 @@
+name: Nightly stress test
+
+on:
+  schedule:
+    - cron: '00 10 * * * '
+  workflow_dispatch:
+
+jobs:
+
+  linux-stress:
+    name: linux-stress
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.21"
+
+      - name: Run unit tests under stress
+        run: |
+          go install github.com/cockroachdb/stress@latest
+          scripts/stress.sh

--- a/scripts/stress.sh
+++ b/scripts/stress.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Stress all packages, one at a time. This allows for a more useful output.
+for p in $(go list ./... | sed 's#github.com/cockroachdb/pebble#.#'); do
+echo
+  echo ""
+  echo ""
+  echo "Stressing $p"
+  echo ""
+  make stress STRESSFLAGS='-maxtime 5m -maxruns 100' "PKG=$p"
+done


### PR DESCRIPTION
Add a nightly unit tests stress run. This won't autofile issues (requires more work); for now we can keep an eye on the build.