### PR TITLE
metamorphic: add diagrams, key simplification, more useful messages

### DIFF
--- a/metamorphic/diagram.go
+++ b/metamorphic/diagram.go
@@ -1,0 +1,95 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package metamorphic
+
+import "strings"
+
+// TryToGenerateDiagram attempts to generate a user-readable ASCII diagram of
+// the keys involved in the operations.
+//
+// If the diagram would be too large to be practical, returns the empty string
+// (with no error).
+func TryToGenerateDiagram(opsData []byte) (string, error) {
+	ops, err := parse(opsData, parserOpts{})
+	if err != nil {
+		return "", err
+	}
+	if len(ops) > 200 {
+		return "", nil
+	}
+	keySet := make(map[string]struct{})
+	for _, o := range ops {
+		for _, r := range o.diagramKeyRanges() {
+			keySet[string(r.Start)] = struct{}{}
+			keySet[string(r.End)] = struct{}{}
+		}
+	}
+	if len(keySet) == 0 {
+		return "", nil
+	}
+	keys := sortedKeys(keySet)
+	axis1, axis2, pos := genAxis(keys)
+	if len(axis1) > 200 {
+		return "", nil
+	}
+
+	var rows []string
+	for _, o := range ops {
+		ranges := o.diagramKeyRanges()
+		var row strings.Builder
+		for _, r := range ranges {
+			s := pos[string(r.Start)]
+			e := pos[string(r.End)]
+			for row.Len() < s {
+				row.WriteByte(' ')
+			}
+			row.WriteByte('|')
+			if e > s {
+				for row.Len() < e {
+					row.WriteByte('-')
+				}
+				row.WriteByte('|')
+			}
+		}
+		for row.Len() <= len(axis1) {
+			row.WriteByte(' ')
+		}
+		row.WriteString(o.String())
+
+		rows = append(rows, row.String())
+	}
+	rows = append(rows, axis1, axis2)
+	return strings.Join(rows, "\n"), nil
+}
+
+// genAxis generates the horizontal key axis and returns two rows (one for axis
+// one for labels), along with a map from key to column.
+
+// Example:
+//
+//	axisRow:    |----|----|----|
+//	labelRow:   a    bar  foo  zed
+//	pos:        a:0, bar:5, foo:10, zed:15
+func genAxis(keys []string) (axisRow string, labelRow string, pos map[string]int) {
+	const minSpaceBetweenKeys = 4
+	const minSpaceBetweenKeyLabels = 2
+	var a, b strings.Builder
+	pos = make(map[string]int)
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteString(strings.Repeat(" ", minSpaceBetweenKeyLabels))
+			for b.Len() <= a.Len()+minSpaceBetweenKeys {
+				b.WriteByte(' ')
+			}
+			for a.Len() < b.Len() {
+				a.WriteByte('-')
+			}
+		}
+		pos[k] = a.Len()
+		a.WriteByte('|')
+		b.WriteString(k)
+	}
+	return a.String(), b.String(), pos
+}

--- a/metamorphic/diagram_test.go
+++ b/metamorphic/diagram_test.go
@@ -1,0 +1,28 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package metamorphic
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+)
+
+func TestDiagram(t *testing.T) {
+	datadriven.RunTest(t, "testdata/diagram", func(t *testing.T, d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "diagram":
+			res, err := TryToGenerateDiagram([]byte(d.Input))
+			if err != nil {
+				return err.Error()
+			}
+			return res
+
+		default:
+			return fmt.Sprintf("unknown command: %s", d.Cmd)
+		}
+	})
+}

--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -165,6 +165,11 @@ func RunAndCompare(t *testing.T, rootDir string, rOpts ...RunOption) {
 		}
 	}()
 
+	topLevelTestName := t.Name()
+	for path.Dir(topLevelTestName) != "." {
+		topLevelTestName = path.Dir(topLevelTestName)
+	}
+
 	rng := rand.New(rand.NewSource(runOpts.seed))
 	opCount := runOpts.ops.Uint64(rng)
 
@@ -244,7 +249,16 @@ func RunAndCompare(t *testing.T, rootDir string, rOpts ...RunOption) {
 ===== OPS =====
 %s
 ===== HISTORY =====
-%s`, runOpts.seed, err, out, optionsStr, formattedOps, readFile(filepath.Join(runDir, "history")))
+%s
+To reduce:  go test ./internal/metamorphic -tags invariants -run '%s$' --run-dir %s --try-to-reduce -v`,
+				runOpts.seed,
+				err,
+				out,
+				optionsStr,
+				formattedOps,
+				readFile(filepath.Join(runDir, "history")),
+				topLevelTestName, runDir,
+			)
 		}
 	}
 
@@ -300,18 +314,25 @@ func RunAndCompare(t *testing.T, rootDir string, rOpts ...RunOption) {
 					optionsStrB := optionsToString(options[names[i]])
 
 					fmt.Printf(`
-		===== SEED =====
-		%d
-		===== DIFF =====
-		%s/{%s,%s}
-		%s
-		===== OPTIONS %s =====
-		%s
-		===== OPTIONS %s =====
-		%s
-		===== OPS =====
-		%s
-		`, runOpts.seed, metaDir, names[0], names[i], text, names[0], optionsStrA, names[i], optionsStrB, formattedOps)
+===== SEED =====
+%d
+===== DIFF =====
+%s/{%s,%s}
+%s
+===== OPTIONS %s =====
+%s
+===== OPTIONS %s =====
+%s
+===== OPS =====
+%s
+To reduce:  go test ./internal/metamorphic -tags invariants -run '%s$' --compare "%s/{%s,%s}" --try-to-reduce -v
+`,
+						runOpts.seed,
+						metaDir, names[0], names[i], text,
+						names[0], optionsStrA,
+						names[i], optionsStrB,
+						formattedOps,
+						topLevelTestName, metaDir, names[0], names[i])
 					os.Exit(1)
 				}
 			})

--- a/metamorphic/simplify.go
+++ b/metamorphic/simplify.go
@@ -1,0 +1,54 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package metamorphic
+
+import "sort"
+
+// TryToSimplifyKeys parses the operations data and tries to reassign keys to
+// single lowercase characters. Note that the result is not necessarily
+// semantically equivalent.
+//
+// On success it returns the new operations data.
+//
+// If there are too many distinct keys, returns nil (and no error).
+func TryToSimplifyKeys(opsData []byte) ([]byte, error) {
+	ops, err := parse(opsData, parserOpts{})
+	if err != nil {
+		return nil, err
+	}
+	keys := make(map[string]struct{})
+	for i := range ops {
+		for _, k := range ops[i].keys() {
+			keys[string(*k)] = struct{}{}
+		}
+	}
+	if len(keys) > ('z' - 'a' + 1) {
+		return nil, nil
+	}
+	sorted := sortedKeys(keys)
+	ordinals := make(map[string]int, len(sorted))
+	for i, k := range sorted {
+		ordinals[k] = i
+	}
+	// TODO(radu): We reassign the user keys, ignoring the prefix and suffix
+	// composition. This is sufficient to reproduce a class of problems, but if it
+	// fails, we should try to simplify just the prefix and retain the suffix.
+	for i := range ops {
+		for _, k := range ops[i].keys() {
+			idx := ordinals[string(*k)]
+			*k = []byte{'a' + byte(idx)}
+		}
+	}
+	return []byte(formatOps(ops)), nil
+}
+
+func sortedKeys(in map[string]struct{}) []string {
+	var sorted []string
+	for k := range in {
+		sorted = append(sorted, k)
+	}
+	sort.Strings(sorted)
+	return sorted
+}

--- a/metamorphic/simplify_test.go
+++ b/metamorphic/simplify_test.go
@@ -1,0 +1,28 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package metamorphic
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+)
+
+func TestSimplifyKeys(t *testing.T) {
+	datadriven.RunTest(t, "testdata/simplify", func(t *testing.T, d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "simplify-keys":
+			res, err := TryToSimplifyKeys([]byte(d.Input))
+			if err != nil {
+				return err.Error()
+			}
+			return string(res)
+
+		default:
+			return fmt.Sprintf("unknown command: %s", d.Cmd)
+		}
+	})
+}

--- a/metamorphic/testdata/diagram
+++ b/metamorphic/testdata/diagram
@@ -1,0 +1,31 @@
+diagram
+Init(2 /* dbs */, 49 /* batches */, 63 /* iters */, 45 /* snapshots */)
+db2.RangeKeySet("c", "h", "@6", "foo")
+snap9 = db2.NewSnapshot("a", "z")
+db2.RangeKeyDelete("d", "f")
+db2.Compact("g", "i", true /* parallelize */)
+db2.Replicate(db1, "b", "f")
+iter25 = db1.NewIter("", "", 2 /* key types */, 0, 0, false /* use L6 filters */, "@7" /* masking suffix */)
+iter25.SeekGE("e", "")
+----
+                                                        Init(2 /* dbs */, 49 /* batches */, 63 /* iters */, 45 /* snapshots */)
+            |-----------------------------|             db2.RangeKeySet("c", "h", "@6", "foo")
+|-----------------------------------------------------| snap9 = db2.NewSnapshot("a", "z")
+                  |-----------|                         db2.RangeKeyDelete("d", "f")
+                                    |-----------|       db2.Compact("g", "i", true /* parallelize */)
+      |-----------------------|                         db2.Replicate(db1, "b", "f")
+                                                        iter25 = db1.NewIter("", "", 2 /* key types */, 0, 0, false /* use L6 filters */, "@7" /* masking suffix */)
+                        |                               iter25.SeekGE("e", "")
+|-----|-----|-----|-----|-----|-----|-----|-----|-----|
+a     b     c     d     e     f     g     h     i     z
+
+diagram
+db2.RangeKeySet("apple", "raspberry", "", "")
+snap9 = db2.NewSnapshot("banana", "durian", "guanabana", "pineapple")
+db2.Compact("cranberry", "pear", true /* parallelize */)
+----
+|-------------------------------------------------------------| db2.RangeKeySet("apple", "raspberry", "", "")
+       |------------------|       |----------------|            snap9 = db2.NewSnapshot("banana", "durian", "guanabana", "pineapple")
+               |-----------------------------|                  db2.Compact("cranberry", "pear", true /* parallelize */)
+|------|-------|----------|-------|----------|-----|----------|
+apple  banana  cranberry  durian  guanabana  pear  pineapple  raspberry

--- a/metamorphic/testdata/simplify
+++ b/metamorphic/testdata/simplify
@@ -1,0 +1,17 @@
+simplify-keys
+db2.RangeKeySet("apple", "raspberry", "", "")
+snap9 = db2.NewSnapshot("banana", "durian", "guanabana", "pineapple")
+db2.Compact("cranberry", "pear", true /* parallelize */)
+----
+db2.RangeKeySet("a", "h", "", "")
+snap9 = db2.NewSnapshot("b", "d", "e", "g")
+db2.Compact("c", "f", true /* parallelize */)
+
+simplify-keys
+db2.RangeKeySet("apple", "raspberry", "", "")
+snap9 = db2.NewSnapshot("apple", "raspberry")
+db2.Compact("apple", "raspberry", true /* parallelize */)
+----
+db2.RangeKeySet("a", "b", "", "")
+snap9 = db2.NewSnapshot("a", "b")
+db2.Compact("a", "b", true /* parallelize */)


### PR DESCRIPTION
This commit makes a few improvements to the metamorphic test:
 - as part of `--try-to-reduce`, we now also try to simplify keys to
   single characters; we also set a timeout and treat timeouts as
   "bad" op sequences.
 - we add support for diagrams that show the relevant keys or key
   ranges for each operation; `--try-to-reduce` generates diagrams
   when they would be of reasonable size.
 - we improve error messages to show the `go test` command line that
   can be used to reduce the ops; `--try-to-reduce` shows the
   `go test` command line that can be used to re-run with the final
   ops.