### PR TITLE
vfs: fix hard link names in MemFS.String()

### DIFF
--- a/vfs/mem_fs_test.go
+++ b/vfs/mem_fs_test.go
@@ -227,12 +227,19 @@ func TestList(t *testing.T) {
 		}
 	}
 
+	require.NoError(t, fs.Link("/foo/3", "/bar/link-to-3"))
+	require.NoError(t, fs.Link("/foo/3", "/bar/another-link-to-3"))
+
 	{
 		got := fs.String()
+		// TODO(pav-kv): fix the bar/link-to-3 and bar/another-link-to-3 link names.
+		// Currently String() erroneously prints the name of the linked file.
 		const want = `          /
        0    a
             bar/
+       0      3
        0      baz
+       0      3
             foo/
        0      0
        0      1
@@ -249,8 +256,8 @@ func TestList(t *testing.T) {
 
 	testCases := []string{
 		"/:a bar foo foot",
-		"/bar:baz",
-		"/bar/:baz",
+		"/bar:another-link-to-3 baz link-to-3",
+		"/bar/:another-link-to-3 baz link-to-3",
 		"/baz:",
 		"/baz/:",
 		"/foo:0 1 2 3",

--- a/vfs/mem_fs_test.go
+++ b/vfs/mem_fs_test.go
@@ -232,14 +232,12 @@ func TestList(t *testing.T) {
 
 	{
 		got := fs.String()
-		// TODO(pav-kv): fix the bar/link-to-3 and bar/another-link-to-3 link names.
-		// Currently String() erroneously prints the name of the linked file.
 		const want = `          /
        0    a
             bar/
-       0      3
+       0      another-link-to-3
        0      baz
-       0      3
+       0      link-to-3
             foo/
        0      0
        0      1


### PR DESCRIPTION
This PR fixes a bug in `MemFS.String()` method. For hard links created using the `Link()` method, `String()` previously printed the original file name rather than the name of the link.