### PR TITLE
internal/keyspan: simplify Get and fix error handling

### DIFF
--- a/get_iter.go
+++ b/get_iter.go
@@ -83,8 +83,9 @@ func (g *getIter) Next() (*InternalKey, base.LazyValue) {
 			// key. Every call to levelIter.Next() potentially switches to a new
 			// table and thus reinitializes rangeDelIter.
 			if g.rangeDelIter != nil {
-				g.tombstone = keyspan.Get(g.comparer.Compare, g.rangeDelIter, g.key)
-				if g.err = g.rangeDelIter.Close(); g.err != nil {
+				g.tombstone, g.err = keyspan.Get(g.comparer.Compare, g.rangeDelIter, g.key)
+				g.err = firstError(g.err, g.rangeDelIter.Close())
+				if g.err != nil {
 					return nil, base.LazyValue{}
 				}
 				g.rangeDelIter = nil

--- a/internal/keyspan/fragmenter_test.go
+++ b/internal/keyspan/fragmenter_test.go
@@ -131,7 +131,8 @@ func TestFragmenter(t *testing.T) {
 	// number. This is a simple version of what full processing of range
 	// tombstones looks like.
 	deleted := func(key []byte, seq, readSeq uint64) bool {
-		s := Get(cmp, iter, key)
+		s, err := Get(cmp, iter, key)
+		require.NoError(t, err)
 		return s != nil && s.CoversAt(readSeq, seq)
 	}
 

--- a/internal/keyspan/get.go
+++ b/internal/keyspan/get.go
@@ -6,48 +6,23 @@ package keyspan
 
 import "github.com/cockroachdb/pebble/internal/base"
 
-// Get returns the newest span that contains the target key. If no span
-// contains the target key, an empty span is returned. The snapshot
-// parameter controls the visibility of spans (only spans older than the
-// snapshot sequence number are visible). The iterator must contain
+// Get returns the newest span that contains the target key. If no span contains
+// the target key, an empty span is returned. The iterator must contain
 // fragmented spans: no span may overlap another.
-func Get(cmp base.Compare, iter FragmentIterator, key []byte) *Span {
-	// NB: We use SeekLT in order to land on the proper span for a search
-	// key that resides in the middle of a span. Consider the scenario:
-	//
-	//     a---e
-	//         e---i
-	//
-	// The spans are indexed by their start keys `a` and `e`. If the
-	// search key is `c` we want to land on the span [a,e). If we were
-	// to use SeekGE then the search key `c` would land on the span
-	// [e,i) and we'd have to backtrack. The one complexity here is what
-	// happens for the search key `e`. In that case SeekLT will land us
-	// on the span [a,e) and we'll have to move forward.
-	iterSpan := iter.SeekLT(key)
-	if iterSpan == nil {
-		iterSpan = iter.Next()
-		if iterSpan == nil {
-			// The iterator is empty.
-			return nil
-		}
-		if cmp(key, iterSpan.Start) < 0 {
-			// The search key lies before the first span.
-			return nil
-		}
+//
+// If an error occurs while seeking iter, a nil span and non-nil error is
+// returned.
+func Get(cmp base.Compare, iter FragmentIterator, key []byte) (*Span, error) {
+	// NB: FragmentIterator.SeekGE moves the iterator to the first span covering
+	// a key greater than or equal to the given key. This is equivalent to
+	// seeking to the first span with an end key greater than the given key.
+	iterSpan := iter.SeekGE(key)
+	switch {
+	case iterSpan == nil:
+		return nil, iter.Error()
+	case cmp(iterSpan.Start, key) > 0:
+		return nil, nil
+	default:
+		return iterSpan, nil
 	}
-
-	// Invariant: key > iterSpan.Start
-	if cmp(key, iterSpan.End) >= 0 {
-		// The current span lies before the search key. Advance the iterator
-		// once to potentially land on a key with a start key exactly equal to
-		// key. (See the comment at the beginning of this function.)
-		iterSpan = iter.Next()
-		if iterSpan == nil || cmp(key, iterSpan.Start) < 0 {
-			// We've run out of spans or we've moved on to a span which
-			// starts after our search key.
-			return nil
-		}
-	}
-	return iterSpan
 }

--- a/internal/keyspan/get_test.go
+++ b/internal/keyspan/get_test.go
@@ -1,0 +1,51 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package keyspan
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+)
+
+func TestGet(t *testing.T) {
+	cmp := testkeys.Comparer.Compare
+	var buf bytes.Buffer
+	var spans []Span
+	datadriven.RunTest(t, "testdata/get", func(t *testing.T, td *datadriven.TestData) string {
+		buf.Reset()
+		switch td.Cmd {
+		case "define":
+			spans = spans[:0]
+			lines := strings.Split(strings.TrimSpace(td.Input), "\n")
+			for _, line := range lines {
+				spans = append(spans, ParseSpan(line))
+			}
+			return ""
+		case "get":
+			var iter FragmentIterator = NewIter(cmp, spans)
+			if cmdArg, ok := td.Arg("probes"); ok {
+				iter = attachProbes(iter, probeContext{log: &buf},
+					parseProbes(cmdArg.Vals...)...)
+			}
+
+			for _, line := range strings.Split(strings.TrimSpace(td.Input), "\n") {
+				s, err := Get(cmp, iter, []byte(line))
+				if err != nil {
+					fmt.Fprintf(&buf, "Get(%q) = nil <err=%q>\n", line, err)
+					continue
+				}
+				fmt.Fprintf(&buf, "Get(%q) = %v\n", line, s)
+			}
+			return buf.String()
+		default:
+			return fmt.Sprintf("unrecognized command %q", td.Cmd)
+		}
+	})
+}

--- a/internal/keyspan/testdata/get
+++ b/internal/keyspan/testdata/get
@@ -1,0 +1,56 @@
+define
+a-c:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+c-d:{(#4,RANGEKEYSET,@3,bananas)}
+d-e:{(#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
+----
+
+
+
+get
+a
+cat
+d
+dog
+e
+f
+----
+Get("a") = a-c:{(#3,RANGEKEYUNSET,@5) (#2,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@3,bananas)}
+Get("cat") = c-d:{(#4,RANGEKEYSET,@3,bananas)}
+Get("d") = d-e:{(#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
+Get("dog") = d-e:{(#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@1,pineapple)}
+Get("e") = <nil>
+Get("f") = <nil>
+
+get probes=(ErrInjected, (Log "#  iter."))
+a
+cat
+d
+dog
+e
+f
+----
+#  iter.SeekGE("a") = nil <err="injected error">
+Get("a") = nil <err="injected error">
+#  iter.SeekGE("cat") = nil <err="injected error">
+Get("cat") = nil <err="injected error">
+#  iter.SeekGE("d") = nil <err="injected error">
+Get("d") = nil <err="injected error">
+#  iter.SeekGE("dog") = nil <err="injected error">
+Get("dog") = nil <err="injected error">
+#  iter.SeekGE("e") = nil <err="injected error">
+Get("e") = nil <err="injected error">
+#  iter.SeekGE("f") = nil <err="injected error">
+Get("f") = nil <err="injected error">
+
+define
+c-e:{(#1,RANGEDEL)}
+----
+
+get
+boo
+foo
+cat
+----
+Get("boo") = <nil>
+Get("foo") = <nil>
+Get("cat") = c-e:{(#1,RANGEDEL)}


### PR DESCRIPTION
The keyspan.Get helper is used by `DB.Get` to retrieve range deletions overlapping a particular key. It was written before #2146 when a `SeekGE(k)` seeked the iterator to the first span with a _start key_ ≥ k. In #2146, the semantics of `SeekGE(k)` was modified to seek to the first span with an end key greater than k (or, more intuitively, the first span to "cover" a key ≥ k). With the new semantics, a simple `SeekGE` seeks to the span covering `k` if any, and `keyspan.Get` only needs to verify that the returned span doesn't lie wholly after `k`.

Despite being written against the old iterator interface, the previous keyspan.Get implementation remained correct in the absence of iterator errors after #2146. However, if an iterator error occurred during the SeekLT, keyspan.Get would improperly step the iterator forward without consulting `FragmentIterator.Error()`.