### PR TITLE
db: propagate errors from levelIter.skipEmptyFile[Forward|Backward]

### DIFF
--- a/level_iter.go
+++ b/level_iter.go
@@ -1014,10 +1014,6 @@ func (l *levelIter) Prev() (*InternalKey, base.LazyValue) {
 }
 
 func (l *levelIter) skipEmptyFileForward() (*InternalKey, base.LazyValue) {
-	if l.iter.Error() != nil {
-		return nil, base.LazyValue{}
-	}
-
 	var key *InternalKey
 	var val base.LazyValue
 	// The first iteration of this loop starts with an already exhausted
@@ -1036,6 +1032,9 @@ func (l *levelIter) skipEmptyFileForward() (*InternalKey, base.LazyValue) {
 	// that key, else the behavior described above if there is a corresponding
 	// rangeDelIterPtr.
 	for ; key == nil; key, val = l.iter.First() {
+		if l.iter.Error() != nil {
+			return nil, base.LazyValue{}
+		}
 		if l.rangeDelIterPtr != nil {
 			// We're being used as part of a mergingIter and we've exhausted the
 			// current sstable. If an upper bound is present and the upper bound lies
@@ -1111,10 +1110,6 @@ func (l *levelIter) skipEmptyFileForward() (*InternalKey, base.LazyValue) {
 }
 
 func (l *levelIter) skipEmptyFileBackward() (*InternalKey, base.LazyValue) {
-	if l.iter.Error() != nil {
-		return nil, base.LazyValue{}
-	}
-
 	var key *InternalKey
 	var val base.LazyValue
 	// The first iteration of this loop starts with an already exhausted
@@ -1132,6 +1127,9 @@ func (l *levelIter) skipEmptyFileBackward() (*InternalKey, base.LazyValue) {
 	// that key, else the behavior described above if there is a corresponding
 	// rangeDelIterPtr.
 	for ; key == nil; key, val = l.iter.Last() {
+		if l.iter.Error() != nil {
+			return nil, base.LazyValue{}
+		}
 		if l.rangeDelIterPtr != nil {
 			// We're being used as part of a mergingIter and we've exhausted the
 			// current sstable. If a lower bound is present and the lower bound lies

--- a/testdata/merging_iter
+++ b/testdata/merging_iter
@@ -840,3 +840,45 @@ err=injected error
 #  iter.SeekPrefixGE("b") = (b#19,1,"19")
 #  rangedelIter.opSpanSeekGE("b") = nil <err="injected error">
 err=injected error
+
+# Ensure that when a level iterator is progressing to the next, it propagates
+# errors on First/Last.
+
+define
+L
+a.SET.10 c.SET.10
+a.SET.10:a10 c.SET.10:c10
+d.SET.10 g.SET.10
+d.SET.10:d10 g.SET.10:g10
+----
+1:
+  000031:[a#10,SET-c#10,SET]
+  000032:[d#10,SET-g#10,SET]
+
+iter probe-points=(000031,(Log "#  000031.")) probe-points=(000032,(If OpFirst ErrInjected noop),(Log "#  000032."))
+first
+next
+next
+----
+#  000031.First() = (a#10,1,"a10")
+a#10,1:a10
+#  000031.Next() = (c#10,1,"c10")
+c#10,1:c10
+#  000031.Next() = nil
+#  000031.Close() = nil
+#  000032.First() = nil <err="injected error">
+err=injected error
+
+iter probe-points=(000031,(If OpLast ErrInjected noop),(Log "#  000031.")) probe-points=(000032,(Log "#  000032."))
+last
+prev
+prev
+----
+#  000032.Last() = (g#10,1,"g10")
+g#10,1:g10
+#  000032.Prev() = (d#10,1,"d10")
+d#10,1:d10
+#  000032.Prev() = nil
+#  000032.Close() = nil
+#  000031.Last() = nil <err="injected error">
+err=injected error


### PR DESCRIPTION
Previously, if a levelIter exhausted a file, advanced to the next file and found no KVs within the file, it advanced past the file without checkign whether the seek errored.