### PR TITLE
internal/keyspan: simplify SeekLE, fix nil-pointer

### DIFF
--- a/internal/keyspan/iter.go
+++ b/internal/keyspan/iter.go
@@ -17,6 +17,11 @@ import (
 // positioning method. Some implementations (eg, keyspan.Iter) may provide
 // longer lifetimes but implementations need only guarantee stability until the
 // next positioning method.
+//
+// If any positioning method fails to find a span, the iterator is left
+// positioned at an exhausted position in the direction of iteration. For
+// example, a caller than finds SeekGE(k)=nil may call Prev to move the iterator
+// to the last span.
 type FragmentIterator interface {
 	// SeekGE moves the iterator to the first span covering a key greater than
 	// or equal to the given key. This is equivalent to seeking to the first

--- a/internal/keyspan/seek_test.go
+++ b/internal/keyspan/seek_test.go
@@ -18,24 +18,32 @@ import (
 func TestSeek(t *testing.T) {
 	cmp := base.DefaultComparer.Compare
 	fmtKey := base.DefaultComparer.FormatKey
-	var iter FragmentIterator
 	var buf bytes.Buffer
+	var spans []Span
 
 	datadriven.RunTest(t, "testdata/seek", func(t *testing.T, d *datadriven.TestData) string {
 		buf.Reset()
 		switch d.Cmd {
 		case "build":
-			spans := buildSpans(t, cmp, fmtKey, d.Input, base.InternalKeyKindRangeDelete)
+			spans = buildSpans(t, cmp, fmtKey, d.Input, base.InternalKeyKindRangeDelete)
 			for _, s := range spans {
 				fmt.Fprintln(&buf, s)
 			}
-			iter = NewIter(cmp, spans)
 			return buf.String()
 		case "seek-ge", "seek-le":
+			var iter FragmentIterator = NewIter(cmp, spans)
+			if cmdArg, ok := d.Arg("probes"); ok {
+				iter = attachProbes(iter, probeContext{log: &buf},
+					parseProbes(cmdArg.Vals...)...)
+			}
+
 			seek := SeekLE
 			if d.Cmd == "seek-ge" {
-				seek = func(_ base.Compare, iter FragmentIterator, key []byte) *Span {
-					return iter.SeekGE(key)
+				seek = func(_ base.Compare, iter FragmentIterator, key []byte) (*Span, error) {
+					if s := iter.SeekGE(key); s != nil {
+						return s, nil
+					}
+					return nil, iter.Error()
 				}
 			}
 
@@ -48,12 +56,16 @@ func TestSeek(t *testing.T) {
 				if err != nil {
 					return err.Error()
 				}
-				span := seek(cmp, iter, []byte(parts[0]))
-				if span != nil {
+				span, err := seek(cmp, iter, []byte(parts[0]))
+				if err != nil {
+					fmt.Fprintf(&buf, "<nil> <err=%q>\n", err)
+				} else if span == nil {
+					fmt.Fprintln(&buf, "<nil>")
+				} else {
 					visible := span.Visible(seq)
 					span = &visible
+					fmt.Fprintln(&buf, span)
 				}
-				fmt.Fprintln(&buf, span)
 			}
 			return buf.String()
 		default:

--- a/internal/keyspan/testdata/seek
+++ b/internal/keyspan/testdata/seek
@@ -14,6 +14,21 @@ b-d:{(#1,RANGEDEL)}
 b-d:{}
 <nil>
 
+seek-ge probes=(ErrInjected,(Log "#  iter."))
+a 2
+b 2
+b 1
+d 2
+----
+#  iter.SeekGE("a") = nil <err="injected error">
+<nil> <err="injected error">
+#  iter.SeekGE("b") = nil <err="injected error">
+<nil> <err="injected error">
+#  iter.SeekGE("b") = nil <err="injected error">
+<nil> <err="injected error">
+#  iter.SeekGE("d") = nil <err="injected error">
+<nil> <err="injected error">
+
 seek-le
 a 2
 b 2
@@ -24,6 +39,21 @@ d 2
 b-d:{(#1,RANGEDEL)}
 b-d:{}
 b-d:{(#1,RANGEDEL)}
+
+seek-le probes=(ErrInjected,(Log "#  iter."))
+a 2
+b 2
+b 1
+d 2
+----
+#  iter.SeekGE("a") = nil <err="injected error">
+<nil> <err="injected error">
+#  iter.SeekGE("b") = nil <err="injected error">
+<nil> <err="injected error">
+#  iter.SeekGE("b") = nil <err="injected error">
+<nil> <err="injected error">
+#  iter.SeekGE("d") = nil <err="injected error">
+<nil> <err="injected error">
 
 build
 3:  b-d
@@ -307,3 +337,33 @@ c-e:{}
 c-e:{}
 c-e:{}
 c-e:{(#5,RANGEDEL)}
+
+build
+1: a-c
+2: f-g
+----
+a-c:{(#1,RANGEDEL)}
+f-g:{(#2,RANGEDEL)}
+
+seek-le
+c 5
+d 5
+f 5
+----
+a-c:{(#1,RANGEDEL)}
+a-c:{(#1,RANGEDEL)}
+f-g:{(#2,RANGEDEL)}
+
+seek-le probes=((If OpPrev ErrInjected noop),(Log "#  iter."))
+c 5
+d 5
+f 5
+----
+#  iter.SeekGE("c") = f-g:{(#2,RANGEDEL)}
+#  iter.Prev() = nil <err="injected error">
+<nil> <err="injected error">
+#  iter.SeekGE("d") = f-g:{(#2,RANGEDEL)}
+#  iter.Prev() = nil <err="injected error">
+<nil> <err="injected error">
+#  iter.SeekGE("f") = f-g:{(#2,RANGEDEL)}
+f-g:{(#2,RANGEDEL)}

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -362,7 +362,14 @@ func (i *levelIterTestIter) rangeDelSeek(
 	if i.rangeDelIter != nil {
 		var t *keyspan.Span
 		if dir < 0 {
-			t = keyspan.SeekLE(i.levelIter.cmp, i.rangeDelIter, key)
+			var err error
+			t, err = keyspan.SeekLE(i.levelIter.cmp, i.rangeDelIter, key)
+			// TODO(jackson): Clean this up when the FragmentIterator interface
+			// is refactored to return an error return value from all
+			// positioning methods.
+			if err != nil {
+				panic(err)
+			}
 		} else {
 			t = i.rangeDelIter.SeekGE(key)
 		}

--- a/testdata/merging_iter
+++ b/testdata/merging_iter
@@ -829,13 +829,13 @@ seek-prefix-ge b
 #  rangedelIter.opSpanSeekGE("a") = nil <err="injected error">
 err=injected error
 #  iter.Last() = (f#21,1,"21")
-#  rangedelIter.opSpanSeekLT("f") = nil <err="injected error">
+#  rangedelIter.opSpanSeekGE("f") = nil <err="injected error">
 err=injected error
 #  iter.SeekGE("boo") = (c#18,1,"18")
 #  rangedelIter.opSpanSeekGE("boo") = nil <err="injected error">
 err=injected error
 #  iter.SeekLT("coo") = (c#18,1,"18")
-#  rangedelIter.opSpanSeekLT("coo") = nil <err="injected error">
+#  rangedelIter.opSpanSeekGE("coo") = nil <err="injected error">
 err=injected error
 #  iter.SeekPrefixGE("b") = (b#19,1,"19")
 #  rangedelIter.opSpanSeekGE("b") = nil <err="injected error">


### PR DESCRIPTION
Similar to #3209, this commit simplifies SeekLE for the new (as of #2146) FragmentIterator semantics. It also fixes a nil-pointer access if iter.Error()!= nil after Next-ing the iterator in the second else block.