### PR TITLE
db,metamorphic: add TestIteratorErrors

### DIFF
--- a/external_test.go
+++ b/external_test.go
@@ -1,0 +1,112 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble_test
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble/metamorphic"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/cockroachdb/pebble/vfs/errorfs"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/rand"
+)
+
+// TestIteratorErrors is a randomized test designed to ensure that errors
+// encountered by reads are properly propagated through to the user. It uses the
+// metamorphic tests configured with only write operations to first generate a
+// random database. It then uses the metamorphic tests to run a random set of
+// read operations against the generated database, randomly injecting errors at
+// the VFS layer. If an error is injected over the course of an operation, it
+// expects the error to surface to the operation output. If it doesn't, the test
+// fails.
+func TestIteratorErrors(t *testing.T) {
+	seed := time.Now().UnixNano()
+	t.Logf("Using seed %d", seed)
+	rng := rand.New(rand.NewSource(uint64(seed)))
+
+	// Generate a random database by running the metamorphic test with the
+	// WriteOpConfig. We'll perform ~10,000 random operations that mutate the
+	// state of the database.
+	testOpts := metamorphic.RandomOptions(rng, nil /* custom opt parsers */)
+	// With even a very small injection probability, it's relatively
+	// unlikely that pebble.DebugCheckLevels will successfully complete
+	// without being interrupted by an ErrInjected. Omit these checks.
+	// TODO(jackson): Alternatively, we could wrap pebble.DebugCheckLevels,
+	// mark the error value as having originated from CheckLevels, and retry
+	// at most once. We would need to skip retrying on the second invocation
+	// of DebugCheckLevels. It's all likely more trouble than it's worth.
+	testOpts.Opts.DebugCheck = nil
+	// Disable the physical FS so we don't need to worry about paths down below.
+	if fs := testOpts.Opts.FS; fs == nil || fs == vfs.Default {
+		testOpts.Opts.FS = vfs.NewMem()
+	}
+
+	testOpts.Opts.Cache.Ref()
+	{
+		test, err := metamorphic.New(
+			metamorphic.GenerateOps(rng, 10000, metamorphic.WriteOpConfig()),
+			testOpts, "" /* dir */, io.Discard)
+		require.NoError(t, err)
+		require.NoError(t, metamorphic.Execute(test))
+	}
+	t.Log("Constructed test database state")
+	{
+		testOpts.Opts.DisableTableStats = true
+		testOpts.Opts.DisableAutomaticCompactions = true
+
+		// Create an errorfs injector that injects ErrInjected on 5% of reads.
+		// Wrap it in both a counter and a toggle so that we a) know wether an
+		// error was injected over the course of an operation, and b) so that we
+		// can disable error injection during Open.
+		predicate := errorfs.And(errorfs.Reads, errorfs.Randomly(0.50, seed))
+		counter := errorfs.Counter{Injector: errorfs.ErrInjected.If(predicate)}
+		toggle := errorfs.Toggle{Injector: &counter}
+		testOpts.Opts.FS = errorfs.Wrap(testOpts.Opts.FS, &toggle)
+		testOpts.Opts.ReadOnly = true
+
+		test, err := metamorphic.New(
+			metamorphic.GenerateOps(rng, 500, metamorphic.ReadOpConfig()),
+			testOpts, "" /* dir */, &testWriter{t: t})
+		require.NoError(t, err)
+
+		// Begin injecting errors.
+		toggle.On()
+
+		prevCount := counter.Load()
+		more := true
+		for i := 0; more; i++ {
+			var operationOutput string
+			more, operationOutput, err = test.Step()
+			// test.Step returns an error if the test called Fatalf. Error
+			// injection should NOT trigger calls to Fatalf.
+			if err != nil {
+				t.Fatal(err)
+			}
+			newCount := counter.Load()
+			if diff := newCount - prevCount; diff > 0 {
+				if !strings.Contains(operationOutput, errorfs.ErrInjected.Error()) {
+					t.Errorf("Injected %d errors in op %d but the operation output %q does not contain the injected error: %+v",
+						diff, i, operationOutput, counter.LastError())
+				}
+			}
+			prevCount = newCount
+		}
+		t.Logf("Injected %d errors over the course of the test.", counter.Load())
+	}
+}
+
+type testWriter struct {
+	t *testing.T
+}
+
+func (w *testWriter) Write(b []byte) (int, error) {
+	w.t.Log(string(bytes.TrimSpace(b)))
+	return len(b), nil
+}

--- a/metamorphic/config.go
+++ b/metamorphic/config.go
@@ -188,6 +188,61 @@ func DefaultOpConfig() OpConfig {
 	}
 }
 
+// ReadOpConfig builds an OpConfig that performs only read operations.
+func ReadOpConfig() OpConfig {
+	return OpConfig{
+		// dbClose is not in this list since it is deterministically generated once, at the end of the test.
+		ops: [NumOpTypes]int{
+			OpBatchAbort:                  0,
+			OpBatchCommit:                 0,
+			OpDBCheckpoint:                0,
+			OpDBCompact:                   0,
+			OpDBFlush:                     0,
+			OpDBRatchetFormatMajorVersion: 0,
+			OpDBRestart:                   0,
+			OpIterClose:                   5,
+			OpIterFirst:                   100,
+			OpIterLast:                    100,
+			OpIterNext:                    100,
+			OpIterNextWithLimit:           20,
+			OpIterNextPrefix:              20,
+			OpIterPrev:                    100,
+			OpIterPrevWithLimit:           20,
+			OpIterSeekGE:                  100,
+			OpIterSeekGEWithLimit:         20,
+			OpIterSeekLT:                  100,
+			OpIterSeekLTWithLimit:         20,
+			OpIterSeekPrefixGE:            100,
+			OpIterSetBounds:               100,
+			OpIterSetOptions:              10,
+			OpNewBatch:                    0,
+			OpNewIndexedBatch:             0,
+			OpNewIter:                     10,
+			OpNewIterUsingClone:           5,
+			OpNewSnapshot:                 10,
+			OpReaderGet:                   100,
+			OpSnapshotClose:               10,
+			OpWriterApply:                 0,
+			OpWriterDelete:                0,
+			OpWriterDeleteRange:           0,
+			OpWriterIngest:                0,
+			OpWriterMerge:                 0,
+			OpWriterRangeKeySet:           0,
+			OpWriterRangeKeyUnset:         0,
+			OpWriterRangeKeyDelete:        0,
+			OpWriterSet:                   0,
+			OpWriterSingleDelete:          0,
+		},
+		// Use a new prefix 75% of the time (and 25% of the time use an existing
+		// prefix with an alternative suffix).
+		newPrefix: 0.75,
+		// Use a skewed distribution of suffixes to mimic MVCC timestamps. The
+		// range will be widened whenever a suffix is found to already be in use
+		// for a particular prefix.
+		writeSuffixDist: mustDynamic(randvar.NewSkewedLatest(0, 1, 0.99)),
+	}
+}
+
 // WriteOpConfig builds an OpConfig suitable for generating a random test
 // database. It generates Writer operations and some meta database operations
 // like flushes and manual compactions, but it does not generate any reads.

--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -539,7 +539,7 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 // sink.
 func Execute(m *Test) error {
 	if m.testOpts.Threads <= 1 {
-		for m.step(m.h) {
+		for m.step(m.h, nil /* optionalRecordf */) {
 			if err := m.h.Error(); err != nil {
 				return err
 			}
@@ -574,7 +574,7 @@ func Execute(m *Test) error {
 					}
 				}
 
-				m.ops[idx].run(m, m.h.recorder(t, idx))
+				m.ops[idx].run(m, m.h.recorder(t, idx, nil /* optionalRecordf */))
 
 				// If this operation has a done channel, close it so that
 				// other operations that synchronize on this operation know

--- a/vfs/errorfs/dsl.go
+++ b/vfs/errorfs/dsl.go
@@ -22,6 +22,12 @@ import (
 // error.
 type Predicate = dsl.Predicate[Op]
 
+// And returns a predicate that evaluates to true if all of the operands
+// evaluate to true.
+func And(operands ...Predicate) Predicate {
+	return dsl.And[Op](operands...)
+}
+
 // PathMatch returns a predicate that returns true if an operation's file path
 // matches the provided pattern according to filepath.Match.
 func PathMatch(pattern string) Predicate {
@@ -250,7 +256,7 @@ func (le LabelledError) String() string {
 // MaybeError implements Injector.
 func (le LabelledError) MaybeError(op Op) error {
 	if le.predicate == nil || le.predicate.Evaluate(op) {
-		return le
+		return errors.WithStack(le)
 	}
 	return nil
 }


### PR DESCRIPTION
Add a new randomized test that ensures errors injected within iterator
operations are surfaced to end users. The test uses the metamorphic test
framework to first generate a random database. It again uses the metamorphic
test framework to run random read-only operations against the database,
injecting errors randomly to VFS operations. The test fails if an error was
injected during the course of an operation, but the operation did not surface
an error.

Informs #1115.