### PR TITLE
sstable: add CategoryStats.BlockReadDuration

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
-	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -1412,10 +1411,7 @@ func (t *testTracer) IsTracingEnabled(ctx context.Context) bool {
 }
 
 func TestTracing(t *testing.T) {
-	if !invariants.Enabled {
-		// The test relies on timing behavior injected when invariants.Enabled.
-		return
-	}
+	defer sstable.DeterministicReadBlockDurationForTesting()()
 	var tracer testTracer
 	c := NewCache(0)
 	defer c.Unref()

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -97,6 +97,7 @@ func TestMetrics(t *testing.T) {
 	if runtime.GOARCH == "386" {
 		t.Skip("skipped on 32-bit due to slightly varied output")
 	}
+	defer sstable.DeterministicReadBlockDurationForTesting()()
 	c := cache.New(cacheDefaultSize)
 	defer c.Unref()
 	opts := &Options{
@@ -267,6 +268,7 @@ func TestMetrics(t *testing.T) {
 			d.mu.Unlock()
 
 			m := d.Metrics()
+			// Some subset of cases show non-determinism in cache hits/misses.
 			if td.HasArg("zero-cache-hits-misses") {
 				// Avoid non-determinism.
 				m.TableCache.Hits = 0

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -129,7 +129,7 @@ Table iters: 2
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:132 BlockBytesInCache:88}
+   pebble-compaction, non-latency: {BlockBytes:132 BlockBytesInCache:88 BlockReadDuration:10ms}
 
 disk-usage
 ----
@@ -170,7 +170,7 @@ Table iters: 2
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:132 BlockBytesInCache:88}
+   pebble-compaction, non-latency: {BlockBytes:132 BlockBytesInCache:88 BlockReadDuration:10ms}
 
 # Closing iter c will release one of the zombie sstables. The other
 # zombie sstable is still referenced by iter b.
@@ -208,8 +208,8 @@ Table iters: 1
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Iter category stats:
-                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44}
-   pebble-compaction, non-latency: {BlockBytes:132 BlockBytesInCache:88}
+                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
+   pebble-compaction, non-latency: {BlockBytes:132 BlockBytesInCache:88 BlockReadDuration:10ms}
 
 disk-usage
 ----
@@ -250,9 +250,9 @@ Table iters: 0
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Iter category stats:
-                   b,     latency: {BlockBytes:44 BlockBytesInCache:0}
-                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44}
-   pebble-compaction, non-latency: {BlockBytes:132 BlockBytesInCache:88}
+                   b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
+   pebble-compaction, non-latency: {BlockBytes:132 BlockBytesInCache:88 BlockReadDuration:10ms}
 
 disk-usage
 ----
@@ -319,9 +319,9 @@ Table iters: 0
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Iter category stats:
-                   b,     latency: {BlockBytes:44 BlockBytesInCache:0}
-                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44}
-   pebble-compaction, non-latency: {BlockBytes:132 BlockBytesInCache:88}
+                   b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
+   pebble-compaction, non-latency: {BlockBytes:132 BlockBytesInCache:88 BlockReadDuration:10ms}
 
 additional-metrics
 ----
@@ -372,9 +372,9 @@ Table iters: 0
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Iter category stats:
-                   b,     latency: {BlockBytes:44 BlockBytesInCache:0}
-                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44}
-   pebble-compaction, non-latency: {BlockBytes:411 BlockBytesInCache:154}
+                   b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
+   pebble-compaction, non-latency: {BlockBytes:411 BlockBytesInCache:154 BlockReadDuration:60ms}
 
 additional-metrics
 ----
@@ -474,10 +474,10 @@ Table iters: 0
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 2 (2.1KB in 3 tables)
 Iter category stats:
-                   b,     latency: {BlockBytes:44 BlockBytesInCache:0}
-                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44}
-   pebble-compaction, non-latency: {BlockBytes:411 BlockBytesInCache:154}
-       pebble-ingest,     latency: {BlockBytes:192 BlockBytesInCache:128}
+                   b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
+   pebble-compaction, non-latency: {BlockBytes:411 BlockBytesInCache:154 BlockReadDuration:60ms}
+       pebble-ingest,     latency: {BlockBytes:192 BlockBytesInCache:128 BlockReadDuration:10ms}
 
 batch
 set g g
@@ -535,10 +535,10 @@ Table iters: 0
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 2 (2.1KB in 3 tables)
 Iter category stats:
-                   b,     latency: {BlockBytes:44 BlockBytesInCache:0}
-                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44}
-   pebble-compaction, non-latency: {BlockBytes:411 BlockBytesInCache:154}
-       pebble-ingest,     latency: {BlockBytes:192 BlockBytesInCache:128}
+                   b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
+   pebble-compaction, non-latency: {BlockBytes:411 BlockBytesInCache:154 BlockReadDuration:60ms}
+       pebble-ingest,     latency: {BlockBytes:192 BlockBytesInCache:128 BlockReadDuration:10ms}
 
 build ext1
 set z z
@@ -610,10 +610,10 @@ Table iters: 0
 Filter utility: 0.0%
 Ingestions: 1  as flushable: 2 (2.1KB in 3 tables)
 Iter category stats:
-                   b,     latency: {BlockBytes:44 BlockBytesInCache:0}
-                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44}
-   pebble-compaction, non-latency: {BlockBytes:411 BlockBytesInCache:154}
-       pebble-ingest,     latency: {BlockBytes:328 BlockBytesInCache:128}
+                   b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
+   pebble-compaction, non-latency: {BlockBytes:411 BlockBytesInCache:154 BlockReadDuration:60ms}
+       pebble-ingest,     latency: {BlockBytes:328 BlockBytesInCache:128 BlockReadDuration:30ms}
 
 # Virtualize a virtual sstable.
 build ext1
@@ -710,7 +710,7 @@ Table iters: 0
 Filter utility: 0.0%
 Ingestions: 2  as flushable: 2 (2.1KB in 3 tables)
 Iter category stats:
-                   b,     latency: {BlockBytes:44 BlockBytesInCache:0}
-                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44}
-   pebble-compaction, non-latency: {BlockBytes:941 BlockBytesInCache:640}
-       pebble-ingest,     latency: {BlockBytes:400 BlockBytesInCache:200}
+                   b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
+   pebble-compaction, non-latency: {BlockBytes:941 BlockBytesInCache:640 BlockReadDuration:70ms}
+       pebble-ingest,     latency: {BlockBytes:400 BlockBytesInCache:200 BlockReadDuration:30ms}


### PR DESCRIPTION
This could be helpful if some categories are seeing faster reads due to environmental effects (such as page cache or caches in virtual block devices).