### PR TITLE
internal/keyspan: add error return value to FragmentIterator methods

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -981,7 +981,8 @@ func TestBatchRangeOps(t *testing.T) {
 
 			var buf bytes.Buffer
 			if fragmentIter != nil {
-				for s := fragmentIter.First(); s != nil; s = fragmentIter.Next() {
+				s, err := fragmentIter.First()
+				for ; s != nil; s, err = fragmentIter.Next() {
 					for i := range s.Keys {
 						s.Keys[i].Trailer = base.MakeTrailer(
 							s.Keys[i].SeqNum()&^base.InternalKeySeqNumBatch,
@@ -989,6 +990,9 @@ func TestBatchRangeOps(t *testing.T) {
 						)
 					}
 					fmt.Fprintln(&buf, s)
+				}
+				if err != nil {
+					return err.Error()
 				}
 			} else {
 				for k, v := internalIter.First(); k != nil; k, v = internalIter.Next() {
@@ -1184,8 +1188,12 @@ func scanInternalIter(w io.Writer, ii internalIterator) {
 }
 
 func scanKeyspanIterator(w io.Writer, ki keyspan.FragmentIterator) {
-	for s := ki.First(); s != nil; s = ki.Next() {
+	s, err := ki.First()
+	for ; s != nil; s, err = ki.Next() {
 		fmt.Fprintln(w, s)
+	}
+	if err != nil {
+		fmt.Fprintf(w, "err=%q", err.Error())
 	}
 }
 

--- a/error_iter.go
+++ b/error_iter.go
@@ -75,13 +75,12 @@ type errorKeyspanIter struct {
 // errorKeyspanIter implements the keyspan.FragmentIterator interface.
 var _ keyspan.FragmentIterator = (*errorKeyspanIter)(nil)
 
-func (*errorKeyspanIter) SeekGE(key []byte) *keyspan.Span  { return nil }
-func (*errorKeyspanIter) SeekLT(key []byte) *keyspan.Span  { return nil }
-func (*errorKeyspanIter) First() *keyspan.Span             { return nil }
-func (*errorKeyspanIter) Last() *keyspan.Span              { return nil }
-func (*errorKeyspanIter) Next() *keyspan.Span              { return nil }
-func (*errorKeyspanIter) Prev() *keyspan.Span              { return nil }
-func (i *errorKeyspanIter) Error() error                   { return i.err }
-func (i *errorKeyspanIter) Close() error                   { return i.err }
-func (*errorKeyspanIter) String() string                   { return "error" }
-func (*errorKeyspanIter) WrapChildren(wrap keyspan.WrapFn) {}
+func (i *errorKeyspanIter) SeekGE(key []byte) (*keyspan.Span, error) { return nil, i.err }
+func (i *errorKeyspanIter) SeekLT(key []byte) (*keyspan.Span, error) { return nil, i.err }
+func (i *errorKeyspanIter) First() (*keyspan.Span, error)            { return nil, i.err }
+func (i *errorKeyspanIter) Last() (*keyspan.Span, error)             { return nil, i.err }
+func (i *errorKeyspanIter) Next() (*keyspan.Span, error)             { return nil, i.err }
+func (i *errorKeyspanIter) Prev() (*keyspan.Span, error)             { return nil, i.err }
+func (i *errorKeyspanIter) Close() error                             { return i.err }
+func (*errorKeyspanIter) String() string                             { return "error" }
+func (*errorKeyspanIter) WrapChildren(wrap keyspan.WrapFn)           {}

--- a/flushable_test.go
+++ b/flushable_test.go
@@ -133,22 +133,30 @@ func TestIngestedSSTFlushableAPI(t *testing.T) {
 			iter := flushable.newRangeKeyIter(nil)
 			var buf bytes.Buffer
 			if iter != nil {
-				for span := iter.First(); span != nil; span = iter.Next() {
+				span, err := iter.First()
+				for ; span != nil; span, err = iter.Next() {
 					buf.WriteString(span.String())
 					buf.WriteString("\n")
 				}
-				iter.Close()
+				err = firstError(err, iter.Close())
+				if err != nil {
+					fmt.Fprintf(&buf, "err=%q", err.Error())
+				}
 			}
 			return buf.String()
 		case "rangedelIter":
 			iter := flushable.newRangeDelIter(nil)
 			var buf bytes.Buffer
 			if iter != nil {
-				for span := iter.First(); span != nil; span = iter.Next() {
+				span, err := iter.First()
+				for ; span != nil; span, err = iter.Next() {
 					buf.WriteString(span.String())
 					buf.WriteString("\n")
 				}
-				iter.Close()
+				err = firstError(err, iter.Close())
+				if err != nil {
+					fmt.Fprintf(&buf, "err=%q", err.Error())
+				}
 			}
 			return buf.String()
 		case "readyForFlush":

--- a/ingest.go
+++ b/ingest.go
@@ -318,17 +318,18 @@ func ingestLoad1(
 	if iter != nil {
 		defer iter.Close()
 		var smallest InternalKey
-		if s := iter.First(); s != nil {
+		if s, err := iter.First(); err != nil {
+			return nil, err
+		} else if s != nil {
 			key := s.SmallestKey()
 			if err := ingestValidateKey(opts, &key); err != nil {
 				return nil, err
 			}
 			smallest = key.Clone()
 		}
-		if err := iter.Error(); err != nil {
+		if s, err := iter.Last(); err != nil {
 			return nil, err
-		}
-		if s := iter.Last(); s != nil {
+		} else if s != nil {
 			k := s.SmallestKey()
 			if err := ingestValidateKey(opts, &k); err != nil {
 				return nil, err
@@ -347,17 +348,18 @@ func ingestLoad1(
 		if iter != nil {
 			defer iter.Close()
 			var smallest InternalKey
-			if s := iter.First(); s != nil {
+			if s, err := iter.First(); err != nil {
+				return nil, err
+			} else if s != nil {
 				key := s.SmallestKey()
 				if err := ingestValidateKey(opts, &key); err != nil {
 					return nil, err
 				}
 				smallest = key.Clone()
 			}
-			if err := iter.Error(); err != nil {
+			if s, err := iter.Last(); err != nil {
 				return nil, err
-			}
-			if s := iter.Last(); s != nil {
+			} else if s != nil {
 				k := s.SmallestKey()
 				if err := ingestValidateKey(opts, &k); err != nil {
 					return nil, err
@@ -366,9 +368,6 @@ func ingestLoad1(
 				// the table provides the upper bound for the table.
 				largest := s.LargestKey().Clone()
 				meta.ExtendRangeKeyBounds(opts.Comparer.Compare, smallest, largest)
-			}
-			if err := iter.Error(); err != nil {
-				return nil, err
 			}
 		}
 	}
@@ -747,13 +746,18 @@ func overlapWithIterator(
 		return true
 	}
 
-	computeOverlapWithSpans := func(rIter keyspan.FragmentIterator) bool {
+	computeOverlapWithSpans := func(rIter keyspan.FragmentIterator) (bool, error) {
 		// NB: The spans surfaced by the fragment iterator are non-overlapping.
-		span := rIter.SeekLT(keyRange.smallest.UserKey)
-		if span == nil {
-			span = rIter.Next()
+		span, err := rIter.SeekLT(keyRange.smallest.UserKey)
+		if err != nil {
+			return false, err
+		} else if span == nil {
+			span, err = rIter.Next()
+			if err != nil {
+				return false, err
+			}
 		}
-		for ; span != nil; span = rIter.Next() {
+		for ; span != nil; span, err = rIter.Next() {
 			if span.Empty() {
 				continue
 			}
@@ -762,26 +766,26 @@ func overlapWithIterator(
 			if c > 0 {
 				// The start of the span is after the largest key in the
 				// ingested table.
-				return false
+				return false, nil
 			}
 			if cmp(span.End, keyRange.smallest.UserKey) > 0 {
 				// The end of the span is greater than the smallest in the
 				// table. Note that the span end key is exclusive, thus ">0"
 				// instead of ">=0".
-				return true
+				return true, nil
 			}
 		}
-		// Assume overlap if iterator errored.
-		if err := rIter.Error(); err != nil {
-			return true
+		if err != nil {
+			return false, err
 		}
-		return false
+		return false, nil
 	}
 
 	// rkeyIter is either a range key level iter, or a range key iterator
 	// over a single file.
 	if rkeyIter != nil {
-		if computeOverlapWithSpans(rkeyIter) {
+		// If an error occurs, assume overlap.
+		if overlap, err := computeOverlapWithSpans(rkeyIter); overlap || err != nil {
 			return true
 		}
 	}
@@ -790,7 +794,9 @@ func overlapWithIterator(
 	if rangeDelIter == nil || *rangeDelIter == nil {
 		return false
 	}
-	return computeOverlapWithSpans(*rangeDelIter)
+	overlap, err := computeOverlapWithSpans(*rangeDelIter)
+	// If an error occurs, assume overlap.
+	return overlap || err != nil
 }
 
 // ingestTargetLevel returns the target level for a file being ingested.
@@ -1677,8 +1683,9 @@ func (d *DB) excise(
 			var lastRangeDel []byte
 			if rangeDelIter != nil {
 				defer rangeDelIter.Close()
-				rdel := rangeDelIter.SeekLT(exciseSpan.Start)
-				if rdel != nil {
+				if rdel, err := rangeDelIter.SeekLT(exciseSpan.Start); err != nil {
+					return nil, err
+				} else if rdel != nil {
 					lastRangeDel = append(lastRangeDel[:0], rdel.End...)
 					if d.cmp(lastRangeDel, exciseSpan.Start) > 0 {
 						lastRangeDel = exciseSpan.Start
@@ -1704,8 +1711,9 @@ func (d *DB) excise(
 			var lastRangeKey []byte
 			var lastRangeKeyKind InternalKeyKind
 			defer rangeKeyIter.Close()
-			rkey := rangeKeyIter.SeekLT(exciseSpan.Start)
-			if rkey != nil {
+			if rkey, err := rangeKeyIter.SeekLT(exciseSpan.Start); err != nil {
+				return nil, err
+			} else if rkey != nil {
 				lastRangeKey = append(lastRangeKey[:0], rkey.End...)
 				if d.cmp(lastRangeKey, exciseSpan.Start) > 0 {
 					lastRangeKey = exciseSpan.Start
@@ -1796,8 +1804,10 @@ func (d *DB) excise(
 		// Store the max of (exciseSpan.End, rdel.Start) in firstRangeDel. This
 		// needs to be a copy if the key is owned by the range del iter.
 		var firstRangeDel []byte
-		rdel := rangeDelIter.SeekGE(exciseSpan.End)
-		if rdel != nil {
+		rdel, err := rangeDelIter.SeekGE(exciseSpan.End)
+		if err != nil {
+			return nil, err
+		} else if rdel != nil {
 			firstRangeDel = append(firstRangeDel[:0], rdel.Start...)
 			if d.cmp(firstRangeDel, exciseSpan.End) < 0 {
 				firstRangeDel = exciseSpan.End
@@ -1823,8 +1833,10 @@ func (d *DB) excise(
 		// Store the max of (exciseSpan.End, rkey.Start) in firstRangeKey. This
 		// needs to be a copy if the key is owned by the range key iter.
 		var firstRangeKey []byte
-		rkey := rangeKeyIter.SeekGE(exciseSpan.End)
-		if rkey != nil {
+		rkey, err := rangeKeyIter.SeekGE(exciseSpan.End)
+		if err != nil {
+			return nil, err
+		} else if rkey != nil {
 			firstRangeKey = append(firstRangeKey[:0], rkey.Start...)
 			if d.cmp(firstRangeKey, exciseSpan.End) < 0 {
 				firstRangeKey = exciseSpan.End

--- a/internal/keyspan/assert_iter.go
+++ b/internal/keyspan/assert_iter.go
@@ -109,62 +109,57 @@ func (i *assertIter) check(span *Span) {
 }
 
 // SeekGE implements FragmentIterator.
-func (i *assertIter) SeekGE(key []byte) *Span {
-	span := i.iter.SeekGE(key)
+func (i *assertIter) SeekGE(key []byte) (*Span, error) {
+	span, err := i.iter.SeekGE(key)
 	if span != nil && i.cmp(span.End, key) <= 0 {
 		i.panicf("incorrect SeekGE(%q) span %s", key, span)
 	}
 	i.check(span)
-	return span
+	return span, err
 }
 
 // SeekLT implements FragmentIterator.
-func (i *assertIter) SeekLT(key []byte) *Span {
-	span := i.iter.SeekLT(key)
+func (i *assertIter) SeekLT(key []byte) (*Span, error) {
+	span, err := i.iter.SeekLT(key)
 	if span != nil && i.cmp(span.Start, key) >= 0 {
 		i.panicf("incorrect SeekLT(%q) span %s", key, span)
 	}
 	i.check(span)
-	return span
+	return span, err
 }
 
 // First implements FragmentIterator.
-func (i *assertIter) First() *Span {
-	span := i.iter.First()
+func (i *assertIter) First() (*Span, error) {
+	span, err := i.iter.First()
 	i.check(span)
-	return span
+	return span, err
 }
 
 // Last implements FragmentIterator.
-func (i *assertIter) Last() *Span {
-	span := i.iter.Last()
+func (i *assertIter) Last() (*Span, error) {
+	span, err := i.iter.Last()
 	i.check(span)
-	return span
+	return span, err
 }
 
 // Next implements FragmentIterator.
-func (i *assertIter) Next() *Span {
-	span := i.iter.Next()
+func (i *assertIter) Next() (*Span, error) {
+	span, err := i.iter.Next()
 	if span != nil && len(i.lastSpanEnd) > 0 && i.cmp(i.lastSpanEnd, span.Start) > 0 {
 		i.panicf("Next span %s not after last span end %q", span, i.lastSpanEnd)
 	}
 	i.check(span)
-	return span
+	return span, err
 }
 
 // Prev implements FragmentIterator.
-func (i *assertIter) Prev() *Span {
-	span := i.iter.Prev()
+func (i *assertIter) Prev() (*Span, error) {
+	span, err := i.iter.Prev()
 	if span != nil && len(i.lastSpanStart) > 0 && i.cmp(i.lastSpanStart, span.End) < 0 {
 		i.panicf("Prev span %s not before last span start %q", span, i.lastSpanStart)
 	}
 	i.check(span)
-	return span
-}
-
-// Error implements FragmentIterator.
-func (i *assertIter) Error() error {
-	return i.iter.Error()
+	return span, err
 }
 
 // Close implements FragmentIterator.

--- a/internal/keyspan/assert_iter_test.go
+++ b/internal/keyspan/assert_iter_test.go
@@ -49,8 +49,11 @@ func TestAssertBoundsIter(t *testing.T) {
 						res = fmt.Sprintf("%v", r)
 					}
 				}()
-				for span := iter.First(); span != nil; span = iter.Next() {
+				var span *Span
+				var err error
+				for span, err = iter.First(); span != nil; span, err = iter.Next() {
 				}
+				require.NoError(t, err)
 				return "OK"
 			}()
 

--- a/internal/keyspan/defragment.go
+++ b/internal/keyspan/defragment.go
@@ -195,11 +195,6 @@ func (i *DefragmentingIter) Init(
 	}
 }
 
-// Error returns any accumulated error.
-func (i *DefragmentingIter) Error() error {
-	return i.iter.Error()
-}
-
 // Close closes the underlying iterators.
 func (i *DefragmentingIter) Close() error {
 	return i.iter.Close()
@@ -208,14 +203,18 @@ func (i *DefragmentingIter) Close() error {
 // SeekGE moves the iterator to the first span covering a key greater than or
 // equal to the given key. This is equivalent to seeking to the first span with
 // an end key greater than the given key.
-func (i *DefragmentingIter) SeekGE(key []byte) *Span {
-	i.iterSpan = i.iter.SeekGE(key)
-	if i.iterSpan == nil {
+func (i *DefragmentingIter) SeekGE(key []byte) (*Span, error) {
+	var err error
+	i.iterSpan, err = i.iter.SeekGE(key)
+	switch {
+	case err != nil:
+		return nil, err
+	case i.iterSpan == nil:
 		i.iterPos = iterPosCurr
-		return nil
-	} else if i.iterSpan.Empty() {
+		return nil, nil
+	case i.iterSpan.Empty():
 		i.iterPos = iterPosCurr
-		return i.iterSpan
+		return i.iterSpan, nil
 	}
 	// If the span starts strictly after key, we know there mustn't be an
 	// earlier span that ends at i.iterSpan.Start, otherwise i.iter would've
@@ -227,18 +226,16 @@ func (i *DefragmentingIter) SeekGE(key []byte) *Span {
 	// The span we landed on has a Start bound ≤ key. There may be additional
 	// fragments before this span. Defragment backward to find the start of the
 	// defragmented span.
-	i.defragmentBackward()
-
-	// Defragmenting backward may have stopped because it encountered an error.
-	// If so, we must not continue so that i.iter.Error() (and thus i.Error())
-	// yields the error.
-	if i.iterSpan == nil && i.iter.Error() != nil {
-		return nil
+	if _, err := i.defragmentBackward(); err != nil {
+		return nil, err
 	}
-
 	if i.iterPos == iterPosPrev {
 		// Next once back onto the span.
-		i.iterSpan = i.iter.Next()
+		var err error
+		i.iterSpan, err = i.iter.Next()
+		if err != nil {
+			return nil, err
+		}
 	}
 	// Defragment the full span from its start.
 	return i.defragmentForward()
@@ -247,14 +244,18 @@ func (i *DefragmentingIter) SeekGE(key []byte) *Span {
 // SeekLT moves the iterator to the last span covering a key less than the
 // given key. This is equivalent to seeking to the last span with a start
 // key less than the given key.
-func (i *DefragmentingIter) SeekLT(key []byte) *Span {
-	i.iterSpan = i.iter.SeekLT(key)
-	if i.iterSpan == nil {
+func (i *DefragmentingIter) SeekLT(key []byte) (*Span, error) {
+	var err error
+	i.iterSpan, err = i.iter.SeekLT(key)
+	switch {
+	case err != nil:
+		return nil, err
+	case i.iterSpan == nil:
 		i.iterPos = iterPosCurr
-		return nil
-	} else if i.iterSpan.Empty() {
+		return nil, nil
+	case i.iterSpan.Empty():
 		i.iterPos = iterPosCurr
-		return i.iterSpan
+		return i.iterSpan, nil
 	}
 	// If the span ends strictly before key, we know there mustn't be a later
 	// span that starts at i.iterSpan.End, otherwise i.iter would've returned
@@ -266,45 +267,54 @@ func (i *DefragmentingIter) SeekLT(key []byte) *Span {
 	// The span we landed on has a End bound ≥ key. There may be additional
 	// fragments after this span. Defragment forward to find the end of the
 	// defragmented span.
-	i.defragmentForward()
-
-	// Defragmenting forward may have stopped because it encountered an error.
-	// If so, we must not continue so that i.iter.Error() (and thus i.Error())
-	// yields the error.
-	if i.iterSpan == nil && i.iter.Error() != nil {
-		return nil
+	if _, err := i.defragmentForward(); err != nil {
+		return nil, err
 	}
 
 	if i.iterPos == iterPosNext {
 		// Prev once back onto the span.
-		i.iterSpan = i.iter.Prev()
+		var err error
+		i.iterSpan, err = i.iter.Prev()
+		if err != nil {
+			return nil, err
+		}
 	}
 	// Defragment the full span from its end.
 	return i.defragmentBackward()
 }
 
 // First seeks the iterator to the first span and returns it.
-func (i *DefragmentingIter) First() *Span {
-	i.iterSpan = i.iter.First()
-	if i.iterSpan == nil {
+func (i *DefragmentingIter) First() (*Span, error) {
+	var err error
+	i.iterSpan, err = i.iter.First()
+	switch {
+	case err != nil:
+		return nil, err
+	case i.iterSpan == nil:
 		i.iterPos = iterPosCurr
-		return nil
+		return nil, nil
+	default:
+		return i.defragmentForward()
 	}
-	return i.defragmentForward()
 }
 
 // Last seeks the iterator to the last span and returns it.
-func (i *DefragmentingIter) Last() *Span {
-	i.iterSpan = i.iter.Last()
-	if i.iterSpan == nil {
+func (i *DefragmentingIter) Last() (*Span, error) {
+	var err error
+	i.iterSpan, err = i.iter.Last()
+	switch {
+	case err != nil:
+		return nil, err
+	case i.iterSpan == nil:
 		i.iterPos = iterPosCurr
-		return nil
+		return nil, nil
+	default:
+		return i.defragmentBackward()
 	}
-	return i.defragmentBackward()
 }
 
 // Next advances to the next span and returns it.
-func (i *DefragmentingIter) Next() *Span {
+func (i *DefragmentingIter) Next() (*Span, error) {
 	switch i.iterPos {
 	case iterPosPrev:
 		// Switching directions; The iterator is currently positioned over the
@@ -319,18 +329,23 @@ func (i *DefragmentingIter) Next() *Span {
 		//
 		// Next once to move onto y, defragment forward to land on the first z
 		// position.
-		i.iterSpan = i.iter.Next()
-		if invariants.Enabled && i.iterSpan == nil && i.iter.Error() == nil {
+		var err error
+		i.iterSpan, err = i.iter.Next()
+		if err != nil {
+			return nil, err
+		} else if i.iterSpan == nil {
 			panic("pebble: invariant violation: no next span while switching directions")
 		}
 		// We're now positioned on the first span that was defragmented into the
 		// current iterator position. Skip over the rest of the current iterator
 		// position's constitutent fragments. In the above example, this would
 		// land on the first 'z'.
-		i.defragmentForward()
+		if _, err = i.defragmentForward(); err != nil {
+			return nil, err
+		}
 		if i.iterSpan == nil {
 			i.iterPos = iterPosCurr
-			return nil
+			return nil, nil
 		}
 
 		// Now that we're positioned over the first of the next set of
@@ -343,16 +358,18 @@ func (i *DefragmentingIter) Next() *Span {
 			panic("pebble: invariant violation: iterPosCurr with valid iterSpan")
 		}
 
-		i.iterSpan = i.iter.Next()
+		var err error
+		i.iterSpan, err = i.iter.Next()
 		if i.iterSpan == nil {
-			return nil
+			// NB: err may be nil or non-nil.
+			return nil, err
 		}
 		return i.defragmentForward()
 	case iterPosNext:
 		// Already at the next span.
 		if i.iterSpan == nil {
 			i.iterPos = iterPosCurr
-			return nil
+			return nil, nil
 		}
 		return i.defragmentForward()
 	default:
@@ -361,13 +378,13 @@ func (i *DefragmentingIter) Next() *Span {
 }
 
 // Prev steps back to the previous span and returns it.
-func (i *DefragmentingIter) Prev() *Span {
+func (i *DefragmentingIter) Prev() (*Span, error) {
 	switch i.iterPos {
 	case iterPosPrev:
 		// Already at the previous span.
 		if i.iterSpan == nil {
 			i.iterPos = iterPosCurr
-			return nil
+			return nil, nil
 		}
 		return i.defragmentBackward()
 	case iterPosCurr:
@@ -377,9 +394,11 @@ func (i *DefragmentingIter) Prev() *Span {
 			panic("pebble: invariant violation: iterPosCurr with valid iterSpan")
 		}
 
-		i.iterSpan = i.iter.Prev()
+		var err error
+		i.iterSpan, err = i.iter.Prev()
 		if i.iterSpan == nil {
-			return nil
+			// NB: err may be nil or non-nil.
+			return nil, err
 		}
 		return i.defragmentBackward()
 	case iterPosNext:
@@ -395,21 +414,26 @@ func (i *DefragmentingIter) Prev() *Span {
 		//
 		// Prev once to move onto y, defragment backward to land on the last x
 		// position.
-		i.iterSpan = i.iter.Prev()
-		if invariants.Enabled && i.iterSpan == nil && i.iter.Error() == nil {
+		var err error
+		i.iterSpan, err = i.iter.Prev()
+		if err != nil {
+			return nil, err
+		} else if i.iterSpan == nil {
 			panic("pebble: invariant violation: no previous span while switching directions")
 		}
 		// We're now positioned on the last span that was defragmented into the
 		// current iterator position. Skip over the rest of the current iterator
 		// position's constitutent fragments. In the above example, this would
 		// land on the last 'x'.
-		i.defragmentBackward()
+		if _, err = i.defragmentBackward(); err != nil {
+			return nil, err
+		}
 
 		// Now that we're positioned over the last of the prev set of
 		// fragments, defragment backward.
 		if i.iterSpan == nil {
 			i.iterPos = iterPosCurr
-			return nil
+			return nil, nil
 		}
 		return i.defragmentBackward()
 	default:
@@ -427,18 +451,19 @@ func (i *DefragmentingIter) checkEqual(left, right *Span) bool {
 // defragmentForward defragments spans in the forward direction, starting from
 // i.iter's current position. The span at the current position must be non-nil,
 // but may be Empty().
-func (i *DefragmentingIter) defragmentForward() *Span {
+func (i *DefragmentingIter) defragmentForward() (*Span, error) {
 	if i.iterSpan.Empty() {
 		// An empty span will never be equal to another span; see checkEqual for
 		// why. To avoid loading non-empty range keys further ahead by calling Next,
 		// return early.
 		i.iterPos = iterPosCurr
-		return i.iterSpan
+		return i.iterSpan, nil
 	}
 	i.saveCurrent()
 
+	var err error
 	i.iterPos = iterPosNext
-	i.iterSpan = i.iter.Next()
+	i.iterSpan, err = i.iter.Next()
 	for i.iterSpan != nil {
 		if !i.equal(i.curr.End, i.iterSpan.Start) {
 			// Not a continuation.
@@ -451,36 +476,32 @@ func (i *DefragmentingIter) defragmentForward() *Span {
 		i.keyBuf = append(i.keyBuf[:0], i.iterSpan.End...)
 		i.curr.End = i.keyBuf
 		i.keysBuf = i.reduce(i.keysBuf, i.iterSpan.Keys)
-		i.iterSpan = i.iter.Next()
+		i.iterSpan, err = i.iter.Next()
 	}
 	// i.iterSpan == nil
-	//
-	// The inner iterator may return nil when it encounters an error. If there
-	// was an error, we don't know whether there is another span we should
-	// defragment or not. Return nil so that the caller knows they should check
-	// Error().
-	if i.iter.Error() != nil {
-		return nil
+	if err != nil {
+		return nil, err
 	}
 	i.curr.Keys = i.keysBuf
-	return &i.curr
+	return &i.curr, nil
 }
 
 // defragmentBackward defragments spans in the backward direction, starting from
 // i.iter's current position. The span at the current position must be non-nil,
 // but may be Empty().
-func (i *DefragmentingIter) defragmentBackward() *Span {
+func (i *DefragmentingIter) defragmentBackward() (*Span, error) {
 	if i.iterSpan.Empty() {
 		// An empty span will never be equal to another span; see checkEqual for
 		// why. To avoid loading non-empty range keys further ahead by calling Next,
 		// return early.
 		i.iterPos = iterPosCurr
-		return i.iterSpan
+		return i.iterSpan, nil
 	}
 	i.saveCurrent()
 
+	var err error
 	i.iterPos = iterPosPrev
-	i.iterSpan = i.iter.Prev()
+	i.iterSpan, err = i.iter.Prev()
 	for i.iterSpan != nil {
 		if !i.equal(i.curr.Start, i.iterSpan.End) {
 			// Not a continuation.
@@ -493,19 +514,14 @@ func (i *DefragmentingIter) defragmentBackward() *Span {
 		i.keyBuf = append(i.keyBuf[:0], i.iterSpan.Start...)
 		i.curr.Start = i.keyBuf
 		i.keysBuf = i.reduce(i.keysBuf, i.iterSpan.Keys)
-		i.iterSpan = i.iter.Prev()
+		i.iterSpan, err = i.iter.Prev()
 	}
 	// i.iterSpan == nil
-	//
-	// The inner iterator may return nil when it encounters an error. If there
-	// was an error, we don't know whether there is another span we should
-	// defragment or not. Return nil so that the caller knows they should check
-	// Error().
-	if i.iter.Error() != nil {
-		return nil
+	if err != nil {
+		return nil, err
 	}
 	i.curr.Keys = i.keysBuf
-	return &i.curr
+	return &i.curr, nil
 }
 
 func (i *DefragmentingIter) saveCurrent() {

--- a/internal/keyspan/filter.go
+++ b/internal/keyspan/filter.go
@@ -40,52 +40,77 @@ func Filter(iter FragmentIterator, filter FilterFunc, cmp base.Compare) Fragment
 }
 
 // SeekGE implements FragmentIterator.
-func (i *filteringIter) SeekGE(key []byte) *Span {
-	span := i.filter(i.iter.SeekGE(key), +1)
+func (i *filteringIter) SeekGE(key []byte) (*Span, error) {
+	s, err := i.iter.SeekGE(key)
+	if err != nil {
+		return nil, err
+	}
+	s, err = i.filter(s, +1)
+	if err != nil {
+		return nil, err
+	}
 	// i.filter could return a span that's less than key, _if_ the filterFunc
 	// (which has no knowledge of the seek key) mutated the span to end at a key
 	// less than or equal to `key`. Detect this case and next/invalidate the iter.
-	if span != nil && i.cmp(span.End, key) <= 0 {
+	if s != nil && i.cmp(s.End, key) <= 0 {
 		return i.Next()
 	}
-	return span
+	return s, nil
 }
 
 // SeekLT implements FragmentIterator.
-func (i *filteringIter) SeekLT(key []byte) *Span {
-	span := i.filter(i.iter.SeekLT(key), -1)
+func (i *filteringIter) SeekLT(key []byte) (*Span, error) {
+	span, err := i.iter.SeekLT(key)
+	if err != nil {
+		return nil, err
+	}
+	span, err = i.filter(span, -1)
+	if err != nil {
+		return nil, err
+	}
 	// i.filter could return a span that's >= key, _if_ the filterFunc (which has
 	// no knowledge of the seek key) mutated the span to start at a key greater
 	// than or equal to `key`. Detect this case and prev/invalidate the iter.
 	if span != nil && i.cmp(span.Start, key) >= 0 {
 		return i.Prev()
 	}
-	return span
+	return span, nil
 }
 
 // First implements FragmentIterator.
-func (i *filteringIter) First() *Span {
-	return i.filter(i.iter.First(), +1)
+func (i *filteringIter) First() (*Span, error) {
+	s, err := i.iter.First()
+	if err != nil {
+		return nil, err
+	}
+	return i.filter(s, +1)
 }
 
 // Last implements FragmentIterator.
-func (i *filteringIter) Last() *Span {
-	return i.filter(i.iter.Last(), -1)
+func (i *filteringIter) Last() (*Span, error) {
+	s, err := i.iter.Last()
+	if err != nil {
+		return nil, err
+	}
+	return i.filter(s, -1)
 }
 
 // Next implements FragmentIterator.
-func (i *filteringIter) Next() *Span {
-	return i.filter(i.iter.Next(), +1)
+func (i *filteringIter) Next() (*Span, error) {
+	s, err := i.iter.Next()
+	if err != nil {
+		return nil, err
+	}
+	return i.filter(s, +1)
 }
 
 // Prev implements FragmentIterator.
-func (i *filteringIter) Prev() *Span {
-	return i.filter(i.iter.Prev(), -1)
-}
-
-// Error implements FragmentIterator.
-func (i *filteringIter) Error() error {
-	return i.iter.Error()
+func (i *filteringIter) Prev() (*Span, error) {
+	s, err := i.iter.Prev()
+	if err != nil {
+		return nil, err
+	}
+	return i.filter(s, -1)
 }
 
 // Close implements FragmentIterator.
@@ -97,21 +122,23 @@ func (i *filteringIter) Close() error {
 // given Span. If the current Span is to be skipped, the iterator continues
 // iterating in the given direction until it lands on a Span that should be
 // returned, or the iterator becomes invalid.
-func (i *filteringIter) filter(span *Span, dir int8) *Span {
+func (i *filteringIter) filter(span *Span, dir int8) (*Span, error) {
 	if i.filterFn == nil {
-		return span
+		return span, nil
 	}
-	for i.Error() == nil && span != nil {
+	var err error
+	for span != nil {
 		if keep := i.filterFn(span, &i.span); keep {
-			return &i.span
+			return &i.span, nil
 		}
 		if dir == +1 {
-			span = i.iter.Next()
+			span, err = i.iter.Next()
 		} else {
-			span = i.iter.Prev()
+			span, err = i.iter.Prev()
 		}
 	}
-	return span
+	// NB: err may be nil or non-nil.
+	return span, err
 }
 
 // WrapChildren implements FragmentIterator.

--- a/internal/keyspan/get.go
+++ b/internal/keyspan/get.go
@@ -16,11 +16,11 @@ func Get(cmp base.Compare, iter FragmentIterator, key []byte) (*Span, error) {
 	// NB: FragmentIterator.SeekGE moves the iterator to the first span covering
 	// a key greater than or equal to the given key. This is equivalent to
 	// seeking to the first span with an end key greater than the given key.
-	iterSpan := iter.SeekGE(key)
+	iterSpan, err := iter.SeekGE(key)
 	switch {
-	case iterSpan == nil:
-		return nil, iter.Error()
-	case cmp(iterSpan.Start, key) > 0:
+	case err != nil:
+		return nil, err
+	case iterSpan != nil && cmp(iterSpan.Start, key) > 0:
 		return nil, nil
 	default:
 		return iterSpan, nil

--- a/internal/keyspan/interleaving_iter.go
+++ b/internal/keyspan/interleaving_iter.go
@@ -289,7 +289,7 @@ func (i *InterleavingIter) SeekGE(
 	if i.span != nil && i.cmp(key, i.span.End) < 0 && i.cmp(key, i.span.Start) >= 0 {
 		// We're seeking within the existing span's bounds. We still might need
 		// truncate the span to the iterator's bounds.
-		i.saveSpanForward(i.span)
+		i.saveSpanForward(i.span, nil)
 		i.savedKeyspan()
 	} else {
 		i.keyspanSeekGE(key, nil /* prefix */)
@@ -346,7 +346,7 @@ func (i *InterleavingIter) SeekPrefixGE(
 		if ei := i.comparer.Split(i.span.End); i.cmp(prefix, i.span.End[:ei]) < 0 {
 			// We're seeking within the existing span's bounds. We still might need
 			// truncate the span to the iterator's bounds.
-			i.saveSpanForward(i.span)
+			i.saveSpanForward(i.span, nil)
 			i.savedKeyspan()
 			seekKeyspanIter = false
 		}
@@ -375,7 +375,7 @@ func (i *InterleavingIter) SeekLT(
 	if i.span != nil && i.cmp(key, i.span.Start) > 0 && i.cmp(key, i.span.End) < 0 {
 		// We're seeking within the existing span's bounds. We still might need
 		// truncate the span to the iterator's bounds.
-		i.saveSpanBackward(i.span)
+		i.saveSpanBackward(i.span, nil)
 		// The span's start key is still not guaranteed to be less than key,
 		// because of the bounds enforcement. Consider the following example:
 		//
@@ -845,20 +845,13 @@ func (i *InterleavingIter) keyspanSeekLT(k []byte) {
 	i.savedKeyspan()
 }
 
-func (i *InterleavingIter) saveSpanForward(span *Span) {
+func (i *InterleavingIter) saveSpanForward(span *Span, err error) {
 	i.span = span
+	i.err = firstError(i.err, err)
 	i.truncated = false
 	i.truncatedSpan = Span{}
 	if i.span == nil {
-		i.err = firstError(i.err, i.keyspanIter.Error())
 		return
-	}
-	if invariants.Enabled {
-		if err := i.keyspanIter.Error(); err != nil {
-			panic(errors.WithSecondaryError(
-				errors.AssertionFailedf("pebble: %T keyspan iterator returned non-nil span %s while iter has error", i.keyspanIter, i.span),
-				err))
-		}
 	}
 	// Check the upper bound if we have one.
 	if i.upper != nil && i.cmp(i.span.Start, i.upper) >= 0 {
@@ -907,20 +900,13 @@ func (i *InterleavingIter) saveSpanForward(span *Span) {
 	}
 }
 
-func (i *InterleavingIter) saveSpanBackward(span *Span) {
+func (i *InterleavingIter) saveSpanBackward(span *Span, err error) {
 	i.span = span
+	i.err = firstError(i.err, err)
 	i.truncated = false
 	i.truncatedSpan = Span{}
 	if i.span == nil {
-		i.err = firstError(i.err, i.keyspanIter.Error())
 		return
-	}
-	if invariants.Enabled {
-		if err := i.keyspanIter.Error(); err != nil {
-			panic(errors.WithSecondaryError(
-				errors.AssertionFailedf("pebble: %T keyspan iterator returned non-nil span %s while iter has error", i.keyspanIter, i.span),
-				err))
-		}
 	}
 
 	// Check the lower bound if we have one.
@@ -1029,8 +1015,6 @@ func (i *InterleavingIter) verify(
 			panic("pebble: invariant violation: accumulated error swallowed")
 		case i.err == nil && i.pointIter.Error() != nil:
 			panic("pebble: invariant violation: pointIter swallowed")
-		case i.err == nil && i.keyspanIter.Error() != nil:
-			panic("pebble: invariant violation: keyspanIter error swallowed")
 		}
 	}
 	return k, v

--- a/internal/keyspan/level_iter.go
+++ b/internal/keyspan/level_iter.go
@@ -7,6 +7,7 @@ package keyspan
 import (
 	"fmt"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/manifest"
@@ -194,7 +195,7 @@ func (l *LevelIter) loadFile(file *manifest.FileMetadata, dir int) loadFileRetur
 }
 
 // SeekGE implements keyspan.FragmentIterator.
-func (l *LevelIter) SeekGE(key []byte) *Span {
+func (l *LevelIter) SeekGE(key []byte) (*Span, error) {
 	l.dir = +1
 	l.straddle = Span{}
 	l.straddleDir = 0
@@ -222,8 +223,8 @@ func (l *LevelIter) SeekGE(key []byte) *Span {
 			// cases similar to the above, while still retaining correctness.
 			// Return a straddling key instead of loading the file.
 			l.iterFile = f
-			if err := l.Close(); err != nil {
-				return l.verify(nil)
+			if l.err = l.Close(); l.err != nil {
+				return l.verify(nil, l.err)
 			}
 			l.straddleDir = +1
 			l.straddle = Span{
@@ -231,21 +232,23 @@ func (l *LevelIter) SeekGE(key []byte) *Span {
 				End:   f.SmallestRangeKey.UserKey,
 				Keys:  nil,
 			}
-			return l.verify(&l.straddle)
+			return l.verify(&l.straddle, nil)
 		}
 	}
 	loadFileIndicator := l.loadFile(f, +1)
 	if loadFileIndicator == noFileLoaded {
-		return l.verify(nil)
+		return l.verify(nil, l.err)
 	}
-	if span := l.iter.SeekGE(key); span != nil {
-		return l.verify(span)
+	if span, err := l.iter.SeekGE(key); err != nil {
+		return l.verify(nil, err)
+	} else if span != nil {
+		return l.verify(span, nil)
 	}
 	return l.skipEmptyFileForward()
 }
 
 // SeekLT implements keyspan.FragmentIterator.
-func (l *LevelIter) SeekLT(key []byte) *Span {
+func (l *LevelIter) SeekLT(key []byte) (*Span, error) {
 	l.dir = -1
 	l.straddle = Span{}
 	l.straddleDir = 0
@@ -273,8 +276,8 @@ func (l *LevelIter) SeekLT(key []byte) *Span {
 			// cases similar to the above, while still retaining correctness.
 			// Return a straddling key instead of loading the file.
 			l.iterFile = f
-			if err := l.Close(); err != nil {
-				return l.verify(nil)
+			if l.err = l.Close(); l.err != nil {
+				return l.verify(nil, l.err)
 			}
 			l.straddleDir = -1
 			l.straddle = Span{
@@ -282,54 +285,60 @@ func (l *LevelIter) SeekLT(key []byte) *Span {
 				End:   nextFile.SmallestRangeKey.UserKey,
 				Keys:  nil,
 			}
-			return l.verify(&l.straddle)
+			return l.verify(&l.straddle, nil)
 		}
 	}
 	if l.loadFile(f, -1) == noFileLoaded {
-		return l.verify(nil)
+		return l.verify(nil, l.err)
 	}
-	if span := l.iter.SeekLT(key); span != nil {
-		return l.verify(span)
+	if span, err := l.iter.SeekLT(key); err != nil {
+		return l.verify(nil, err)
+	} else if span != nil {
+		return l.verify(span, nil)
 	}
 	return l.skipEmptyFileBackward()
 }
 
 // First implements keyspan.FragmentIterator.
-func (l *LevelIter) First() *Span {
+func (l *LevelIter) First() (*Span, error) {
 	l.dir = +1
 	l.straddle = Span{}
 	l.straddleDir = 0
 	l.err = nil // clear cached iteration error
 
 	if l.loadFile(l.files.First(), +1) == noFileLoaded {
-		return l.verify(nil)
+		return l.verify(nil, l.err)
 	}
-	if span := l.iter.First(); span != nil {
-		return l.verify(span)
+	if span, err := l.iter.First(); err != nil {
+		return l.verify(nil, err)
+	} else if span != nil {
+		return l.verify(span, nil)
 	}
 	return l.skipEmptyFileForward()
 }
 
 // Last implements keyspan.FragmentIterator.
-func (l *LevelIter) Last() *Span {
+func (l *LevelIter) Last() (*Span, error) {
 	l.dir = -1
 	l.straddle = Span{}
 	l.straddleDir = 0
 	l.err = nil // clear cached iteration error
 
 	if l.loadFile(l.files.Last(), -1) == noFileLoaded {
-		return l.verify(nil)
+		return l.verify(nil, l.err)
 	}
-	if span := l.iter.Last(); span != nil {
-		return l.verify(span)
+	if span, err := l.iter.Last(); err != nil {
+		return l.verify(nil, err)
+	} else if span != nil {
+		return l.verify(span, nil)
 	}
 	return l.skipEmptyFileBackward()
 }
 
 // Next implements keyspan.FragmentIterator.
-func (l *LevelIter) Next() *Span {
+func (l *LevelIter) Next() (*Span, error) {
 	if l.err != nil || (l.iter == nil && l.iterFile == nil && l.dir > 0) {
-		return l.verify(nil)
+		return l.verify(nil, l.err)
 	}
 	if l.iter == nil && l.iterFile == nil {
 		// l.dir <= 0
@@ -338,17 +347,19 @@ func (l *LevelIter) Next() *Span {
 	l.dir = +1
 
 	if l.iter != nil {
-		if span := l.iter.Next(); span != nil {
-			return l.verify(span)
+		if span, err := l.iter.Next(); err != nil {
+			return l.verify(nil, err)
+		} else if span != nil {
+			return l.verify(span, nil)
 		}
 	}
 	return l.skipEmptyFileForward()
 }
 
 // Prev implements keyspan.FragmentIterator.
-func (l *LevelIter) Prev() *Span {
+func (l *LevelIter) Prev() (*Span, error) {
 	if l.err != nil || (l.iter == nil && l.iterFile == nil && l.dir < 0) {
-		return l.verify(nil)
+		return l.verify(nil, l.err)
 	}
 	if l.iter == nil && l.iterFile == nil {
 		// l.dir >= 0
@@ -357,14 +368,16 @@ func (l *LevelIter) Prev() *Span {
 	l.dir = -1
 
 	if l.iter != nil {
-		if span := l.iter.Prev(); span != nil {
-			return l.verify(span)
+		if span, err := l.iter.Prev(); err != nil {
+			return nil, err
+		} else if span != nil {
+			return l.verify(span, nil)
 		}
 	}
 	return l.skipEmptyFileBackward()
 }
 
-func (l *LevelIter) skipEmptyFileForward() *Span {
+func (l *LevelIter) skipEmptyFileForward() (*Span, error) {
 	if l.straddleDir == 0 && l.keyType == manifest.KeyTypeRange &&
 		l.iterFile != nil && l.iter != nil {
 		// We were at a file that had spans. Check if the next file that has
@@ -373,9 +386,8 @@ func (l *LevelIter) skipEmptyFileForward() *Span {
 		// a "straddle span" in l.straddle and return that.
 		//
 		// Straddle spans are not created in rangedel mode.
-		if err := l.Close(); err != nil {
-			l.err = err
-			return l.verify(nil)
+		if l.err = l.Close(); l.err != nil {
+			return l.verify(nil, l.err)
 		}
 		startKey := l.iterFile.LargestRangeKey.UserKey
 		// Resetting l.iterFile without loading the file into l.iter is okay and
@@ -383,7 +395,7 @@ func (l *LevelIter) skipEmptyFileForward() *Span {
 		// which it should be due to the Close() call above.
 		l.iterFile = l.files.Next()
 		if l.iterFile == nil {
-			return l.verify(nil)
+			return l.verify(nil, nil)
 		}
 		endKey := l.iterFile.SmallestRangeKey.UserKey
 		if l.cmp(startKey, endKey) < 0 {
@@ -394,7 +406,7 @@ func (l *LevelIter) skipEmptyFileForward() *Span {
 				End:   endKey,
 			}
 			l.straddleDir = +1
-			return l.verify(&l.straddle)
+			return l.verify(&l.straddle, nil)
 		}
 	} else if l.straddleDir < 0 {
 		// We were at a straddle key, but are now changing directions. l.iterFile
@@ -413,19 +425,22 @@ func (l *LevelIter) skipEmptyFileForward() *Span {
 			fileToLoad = l.files.Next()
 		}
 		if l.loadFile(fileToLoad, +1) == noFileLoaded {
-			return l.verify(nil)
+			return l.verify(nil, l.err)
 		}
-		span = l.iter.First()
+		span, l.err = l.iter.First()
+		if l.err != nil {
+			return l.verify(nil, l.err)
+		}
 		// In rangedel mode, we can expect to get empty files that we'd need to
 		// skip over, but not in range key mode.
 		if l.keyType == manifest.KeyTypeRange {
 			break
 		}
 	}
-	return l.verify(span)
+	return l.verify(span, l.err)
 }
 
-func (l *LevelIter) skipEmptyFileBackward() *Span {
+func (l *LevelIter) skipEmptyFileBackward() (*Span, error) {
 	// We were at a file that had spans. Check if the previous file that has
 	// spans is not directly adjacent to the current file i.e. there is a
 	// gap in the span keyspace between the two files. In that case, synthesize
@@ -434,9 +449,8 @@ func (l *LevelIter) skipEmptyFileBackward() *Span {
 	// Straddle spans are not created in rangedel mode.
 	if l.straddleDir == 0 && l.keyType == manifest.KeyTypeRange &&
 		l.iterFile != nil && l.iter != nil {
-		if err := l.Close(); err != nil {
-			l.err = err
-			return l.verify(nil)
+		if l.err = l.Close(); l.err != nil {
+			return l.verify(nil, l.err)
 		}
 		endKey := l.iterFile.SmallestRangeKey.UserKey
 		// Resetting l.iterFile without loading the file into l.iter is okay and
@@ -444,7 +458,7 @@ func (l *LevelIter) skipEmptyFileBackward() *Span {
 		// which it should be due to the Close() call above.
 		l.iterFile = l.files.Prev()
 		if l.iterFile == nil {
-			return l.verify(nil)
+			return l.verify(nil, nil)
 		}
 		startKey := l.iterFile.LargestRangeKey.UserKey
 		if l.cmp(startKey, endKey) < 0 {
@@ -455,7 +469,7 @@ func (l *LevelIter) skipEmptyFileBackward() *Span {
 				End:   endKey,
 			}
 			l.straddleDir = -1
-			return l.verify(&l.straddle)
+			return l.verify(&l.straddle, nil)
 		}
 	} else if l.straddleDir > 0 {
 		// We were at a straddle key, but are now changing directions. l.iterFile
@@ -472,9 +486,12 @@ func (l *LevelIter) skipEmptyFileBackward() *Span {
 			fileToLoad = l.files.Prev()
 		}
 		if l.loadFile(fileToLoad, -1) == noFileLoaded {
-			return l.verify(nil)
+			return l.verify(nil, l.err)
 		}
-		span = l.iter.Last()
+		span, l.err = l.iter.Last()
+		if l.err != nil {
+			return l.verify(span, l.err)
+		}
 		// In rangedel mode, we can expect to get empty files that we'd need to
 		// skip over, but not in range key mode as the filter on the FileMetadata
 		// should guarantee we always get a non-empty file.
@@ -482,30 +499,33 @@ func (l *LevelIter) skipEmptyFileBackward() *Span {
 			break
 		}
 	}
-	return l.verify(span)
+	return l.verify(span, l.err)
 }
 
 // verify is invoked whenever a span is returned from an iterator positioning
 // method to a caller. During invariant builds, it asserts invariants to the
 // caller.
-func (l *LevelIter) verify(s *Span) *Span {
+func (l *LevelIter) verify(s *Span, err error) (*Span, error) {
 	// NB: Do not add any logic outside the invariants.Enabled conditional to
 	// ensure that verify is always compiled away in production builds.
 	if invariants.Enabled {
+		if err != l.err {
+			panic(errors.AssertionFailedf("LevelIter.err (%v) != returned error (%v)", l.err, err))
+		}
+		if err != nil && s != nil {
+			panic(errors.AssertionFailedf("non-nil error returned alongside non-nil span"))
+		}
 		if f := l.files.Current(); f != l.iterFile {
 			panic(fmt.Sprintf("LevelIter.files.Current (%s) and l.iterFile (%s) diverged",
 				f, l.iterFile))
 		}
 	}
-	return s
+	return s, err
 }
 
 // Error implements keyspan.FragmentIterator.
 func (l *LevelIter) Error() error {
-	if l.err != nil || l.iter == nil {
-		return l.err
-	}
-	return l.iter.Error()
+	return l.err
 }
 
 // Close implements keyspan.FragmentIterator.

--- a/internal/keyspan/level_iter_test.go
+++ b/internal/keyspan/level_iter_test.go
@@ -320,24 +320,29 @@ func TestLevelIterEquivalence(t *testing.T) {
 
 		iter1.Init(base.DefaultComparer.Compare, VisibleTransform(base.InternalKeySeqNumMax), new(MergingBuffers), fileIters...)
 		iter2.Init(base.DefaultComparer.Compare, VisibleTransform(base.InternalKeySeqNumMax), new(MergingBuffers), levelIters...)
-		// Check iter1 and iter2 for equivalence.
 
-		require.Equal(t, iter1.First(), iter2.First(), "failed on test case %q", tc.name)
+		// Check iter1 and iter2 for equivalence.
+		s1, err1 := iter1.First()
+		s2, err2 := iter2.First()
+		require.NoError(t, err1)
+		require.NoError(t, err2)
+		require.Equal(t, s1, s2, "failed on test case %q", tc.name)
 		valid := true
 		for valid {
-			f1 := iter1.Next()
-			var f2 *Span
+			s1, err1 = iter1.Next()
+			require.NoError(t, err1)
 			for {
-				f2 = iter2.Next()
+				s2, err2 = iter2.Next()
+				require.NoError(t, err2)
 				// The level iter could produce empty spans that straddle between
 				// files. Ignore those.
-				if f2 == nil || !f2.Empty() {
+				if s2 == nil || !s2.Empty() {
 					break
 				}
 			}
 
-			require.Equal(t, f1, f2, "failed on test case %q", tc.name)
-			valid = f1 != nil && f2 != nil
+			require.Equal(t, s1, s2, "failed on test case %q", tc.name)
+			valid = s1 != nil && s2 != nil
 		}
 	}
 }

--- a/internal/keyspan/logging_iter.go
+++ b/internal/keyspan/logging_iter.go
@@ -85,61 +85,51 @@ func (i *loggingIter) opStartf(format string, args ...any) func(results ...any) 
 var _ FragmentIterator = (*loggingIter)(nil)
 
 // SeekGE implements FragmentIterator.
-func (i *loggingIter) SeekGE(key []byte) *Span {
+func (i *loggingIter) SeekGE(key []byte) (*Span, error) {
 	opEnd := i.opStartf("SeekGE(%q)", key)
-	span := i.iter.SeekGE(key)
-	opEnd(span)
-	return span
+	span, err := i.iter.SeekGE(key)
+	opEnd(span, err)
+	return span, err
 }
 
 // SeekLT implements FragmentIterator.
-func (i *loggingIter) SeekLT(key []byte) *Span {
+func (i *loggingIter) SeekLT(key []byte) (*Span, error) {
 	opEnd := i.opStartf("SeekLT(%q)", key)
-	span := i.iter.SeekLT(key)
-	opEnd(span)
-	return span
+	span, err := i.iter.SeekLT(key)
+	opEnd(span, err)
+	return span, err
 }
 
 // First implements FragmentIterator.
-func (i *loggingIter) First() *Span {
+func (i *loggingIter) First() (*Span, error) {
 	opEnd := i.opStartf("First()")
-	span := i.iter.First()
-	opEnd(span)
-	return span
+	span, err := i.iter.First()
+	opEnd(span, err)
+	return span, err
 }
 
 // Last implements FragmentIterator.
-func (i *loggingIter) Last() *Span {
+func (i *loggingIter) Last() (*Span, error) {
 	opEnd := i.opStartf("Last()")
-	span := i.iter.Last()
-	opEnd(span)
-	return span
+	span, err := i.iter.Last()
+	opEnd(span, err)
+	return span, err
 }
 
 // Next implements FragmentIterator.
-func (i *loggingIter) Next() *Span {
+func (i *loggingIter) Next() (*Span, error) {
 	opEnd := i.opStartf("Next()")
-	span := i.iter.Next()
-	opEnd(span)
-	return span
+	span, err := i.iter.Next()
+	opEnd(span, err)
+	return span, err
 }
 
 // Prev implements FragmentIterator.
-func (i *loggingIter) Prev() *Span {
+func (i *loggingIter) Prev() (*Span, error) {
 	opEnd := i.opStartf("Prev()")
-	span := i.iter.Prev()
-	opEnd(span)
-	return span
-}
-
-// Error implements FragmentIterator.
-func (i *loggingIter) Error() error {
-	err := i.iter.Error()
-	if err != nil {
-		opEnd := i.opStartf("Error()")
-		opEnd(err)
-	}
-	return err
+	span, err := i.iter.Prev()
+	opEnd(span, err)
+	return span, err
 }
 
 // Close implements FragmentIterator.

--- a/internal/keyspan/merging_iter_test.go
+++ b/internal/keyspan/merging_iter_test.go
@@ -192,30 +192,34 @@ func testFragmenterEquivalenceOnce(t *testing.T, seed int64) {
 		weight int
 		fn     func() (str string, f *Span, m *Span)
 	}
+	must := func(s *Span, err error) *Span {
+		require.NoError(t, err)
+		return s
+	}
 	ops := []opKind{
 		{weight: 2, fn: func() (string, *Span, *Span) {
-			return "First()", fragmenterIter.First(), mergingIter.First()
+			return "First()", must(fragmenterIter.First()), must(mergingIter.First())
 		}},
 		{weight: 2, fn: func() (string, *Span, *Span) {
-			return "Last()", fragmenterIter.Last(), mergingIter.Last()
+			return "Last()", must(fragmenterIter.Last()), must(mergingIter.Last())
 		}},
 		{weight: 5, fn: func() (string, *Span, *Span) {
 			k := testkeys.Key(ks, rng.Int63n(ks.Count()))
 			return fmt.Sprintf("SeekGE(%q)", k),
-				fragmenterIter.SeekGE(k),
-				mergingIter.SeekGE(k)
+				must(fragmenterIter.SeekGE(k)),
+				must(mergingIter.SeekGE(k))
 		}},
 		{weight: 5, fn: func() (string, *Span, *Span) {
 			k := testkeys.Key(ks, rng.Int63n(ks.Count()))
 			return fmt.Sprintf("SeekLT(%q)", k),
-				fragmenterIter.SeekLT(k),
-				mergingIter.SeekLT(k)
+				must(fragmenterIter.SeekLT(k)),
+				must(mergingIter.SeekLT(k))
 		}},
 		{weight: 50, fn: func() (string, *Span, *Span) {
-			return "Next()", fragmenterIter.Next(), mergingIter.Next()
+			return "Next()", must(fragmenterIter.Next()), must(mergingIter.Next())
 		}},
 		{weight: 50, fn: func() (string, *Span, *Span) {
-			return "Prev()", fragmenterIter.Prev(), mergingIter.Prev()
+			return "Prev()", must(fragmenterIter.Prev()), must(mergingIter.Prev())
 		}},
 	}
 	var totalWeight int

--- a/internal/keyspan/seek_test.go
+++ b/internal/keyspan/seek_test.go
@@ -40,10 +40,7 @@ func TestSeek(t *testing.T) {
 			seek := SeekLE
 			if d.Cmd == "seek-ge" {
 				seek = func(_ base.Compare, iter FragmentIterator, key []byte) (*Span, error) {
-					if s := iter.SeekGE(key); s != nil {
-						return s, nil
-					}
-					return nil, iter.Error()
+					return iter.SeekGE(key)
 				}
 			}
 

--- a/internal/keyspan/testdata/logging_iter
+++ b/internal/keyspan/testdata/logging_iter
@@ -16,36 +16,36 @@ prev
 ----
 *keyspan.assertIter: SeekGE("a")
  ├── *keyspan.Iter: SeekGE("a")
- │    └── a-b:{(#2,SET) (#1,SET)}
- └── a-b:{(#2,SET) (#1,SET)}
+ │    └── a-b:{(#2,SET) (#1,SET)} <nil>
+ └── a-b:{(#2,SET) (#1,SET)} <nil>
 *keyspan.assertIter: Next()
  ├── *keyspan.Iter: Next()
- │    └── b-c:{(#2,SET) (#1,SET)}
- └── b-c:{(#2,SET) (#1,SET)}
+ │    └── b-c:{(#2,SET) (#1,SET)} <nil>
+ └── b-c:{(#2,SET) (#1,SET)} <nil>
 *keyspan.assertIter: Next()
  ├── *keyspan.Iter: Next()
- │    └── c-d:{(#2,SET) (#1,SET)}
- └── c-d:{(#2,SET) (#1,SET)}
+ │    └── c-d:{(#2,SET) (#1,SET)} <nil>
+ └── c-d:{(#2,SET) (#1,SET)} <nil>
 *keyspan.assertIter: Prev()
  ├── *keyspan.Iter: Prev()
- │    └── b-c:{(#2,SET) (#1,SET)}
- └── b-c:{(#2,SET) (#1,SET)}
+ │    └── b-c:{(#2,SET) (#1,SET)} <nil>
+ └── b-c:{(#2,SET) (#1,SET)} <nil>
 *keyspan.assertIter: First()
  ├── *keyspan.Iter: First()
- │    └── a-b:{(#2,SET) (#1,SET)}
- └── a-b:{(#2,SET) (#1,SET)}
+ │    └── a-b:{(#2,SET) (#1,SET)} <nil>
+ └── a-b:{(#2,SET) (#1,SET)} <nil>
 *keyspan.assertIter: Next()
  ├── *keyspan.Iter: Next()
- │    └── b-c:{(#2,SET) (#1,SET)}
- └── b-c:{(#2,SET) (#1,SET)}
+ │    └── b-c:{(#2,SET) (#1,SET)} <nil>
+ └── b-c:{(#2,SET) (#1,SET)} <nil>
 *keyspan.assertIter: Last()
  ├── *keyspan.Iter: Last()
- │    └── c-d:{(#2,SET) (#1,SET)}
- └── c-d:{(#2,SET) (#1,SET)}
+ │    └── c-d:{(#2,SET) (#1,SET)} <nil>
+ └── c-d:{(#2,SET) (#1,SET)} <nil>
 *keyspan.assertIter: Prev()
  ├── *keyspan.Iter: Prev()
- │    └── b-c:{(#2,SET) (#1,SET)}
- └── b-c:{(#2,SET) (#1,SET)}
+ │    └── b-c:{(#2,SET) (#1,SET)} <nil>
+ └── b-c:{(#2,SET) (#1,SET)} <nil>
 *keyspan.assertIter: Close()
  └── *keyspan.Iter: Close()
 
@@ -57,19 +57,19 @@ next
 ----
 *keyspan.assertIter: SeekLT("a")
  ├── *keyspan.Iter: SeekLT("a")
- │    └── <nil>
- └── <nil>
+ │    └── <nil> <nil>
+ └── <nil> <nil>
 *keyspan.assertIter: SeekLT("c")
  ├── *keyspan.Iter: SeekLT("c")
- │    └── b-c:{(#2,SET) (#1,SET)}
- └── b-c:{(#2,SET) (#1,SET)}
+ │    └── b-c:{(#2,SET) (#1,SET)} <nil>
+ └── b-c:{(#2,SET) (#1,SET)} <nil>
 *keyspan.assertIter: Next()
  ├── *keyspan.Iter: Next()
- │    └── c-d:{(#2,SET) (#1,SET)}
- └── c-d:{(#2,SET) (#1,SET)}
+ │    └── c-d:{(#2,SET) (#1,SET)} <nil>
+ └── c-d:{(#2,SET) (#1,SET)} <nil>
 *keyspan.assertIter: Next()
  ├── *keyspan.Iter: Next()
- │    └── <nil>
- └── <nil>
+ │    └── <nil> <nil>
+ └── <nil> <nil>
 *keyspan.assertIter: Close()
  └── *keyspan.Iter: Close()

--- a/internal/keyspan/testdata/merging_iter
+++ b/internal/keyspan/testdata/merging_iter
@@ -368,40 +368,28 @@ seek-ge k
 seek-ge z
 ----
 #  a.SeekLT("a") = nil <err="injected error">
-#  b.SeekLT("a") = nil
 <nil> err=<injected error>
 #  a.SeekLT("b") = nil <err="injected error">
-#  b.SeekLT("b") = a-c:{(#3,RANGEKEYUNSET,@1)}
 <nil> err=<injected error>
 #  a.SeekLT("c") = nil <err="injected error">
-#  b.SeekLT("c") = a-c:{(#3,RANGEKEYUNSET,@1)}
 <nil> err=<injected error>
 #  a.SeekLT("d") = nil <err="injected error">
-#  b.SeekLT("d") = a-c:{(#3,RANGEKEYUNSET,@1)}
 <nil> err=<injected error>
 #  a.SeekLT("e") = nil <err="injected error">
-#  b.SeekLT("e") = a-c:{(#3,RANGEKEYUNSET,@1)}
 <nil> err=<injected error>
 #  a.SeekLT("f") = nil <err="injected error">
-#  b.SeekLT("f") = a-c:{(#3,RANGEKEYUNSET,@1)}
 <nil> err=<injected error>
 #  a.SeekLT("g") = nil <err="injected error">
-#  b.SeekLT("g") = a-c:{(#3,RANGEKEYUNSET,@1)}
 <nil> err=<injected error>
 #  a.SeekLT("h") = nil <err="injected error">
-#  b.SeekLT("h") = a-c:{(#3,RANGEKEYUNSET,@1)}
 <nil> err=<injected error>
 #  a.SeekLT("i") = nil <err="injected error">
-#  b.SeekLT("i") = h-k:{(#5,RANGEKEYDEL)}
 <nil> err=<injected error>
 #  a.SeekLT("j") = nil <err="injected error">
-#  b.SeekLT("j") = h-k:{(#5,RANGEKEYDEL)}
 <nil> err=<injected error>
 #  a.SeekLT("k") = nil <err="injected error">
-#  b.SeekLT("k") = h-k:{(#5,RANGEKEYDEL)}
 <nil> err=<injected error>
 #  a.SeekLT("z") = nil <err="injected error">
-#  b.SeekLT("z") = h-k:{(#5,RANGEKEYDEL)}
 <nil> err=<injected error>
 
 # Test the same as above, but with errors injected on the second iterator.
@@ -474,40 +462,28 @@ seek-lt k
 seek-lt z
 ----
 #  a.SeekGE("a") = nil <err="injected error">
-#  b.SeekGE("a") = a-c:{(#3,RANGEKEYUNSET,@1)}
 <nil> err=<injected error>
 #  a.SeekGE("b") = nil <err="injected error">
-#  b.SeekGE("b") = a-c:{(#3,RANGEKEYUNSET,@1)}
 <nil> err=<injected error>
 #  a.SeekGE("c") = nil <err="injected error">
-#  b.SeekGE("c") = h-k:{(#5,RANGEKEYDEL)}
 <nil> err=<injected error>
 #  a.SeekGE("d") = nil <err="injected error">
-#  b.SeekGE("d") = h-k:{(#5,RANGEKEYDEL)}
 <nil> err=<injected error>
 #  a.SeekGE("e") = nil <err="injected error">
-#  b.SeekGE("e") = h-k:{(#5,RANGEKEYDEL)}
 <nil> err=<injected error>
 #  a.SeekGE("f") = nil <err="injected error">
-#  b.SeekGE("f") = h-k:{(#5,RANGEKEYDEL)}
 <nil> err=<injected error>
 #  a.SeekGE("g") = nil <err="injected error">
-#  b.SeekGE("g") = h-k:{(#5,RANGEKEYDEL)}
 <nil> err=<injected error>
 #  a.SeekGE("h") = nil <err="injected error">
-#  b.SeekGE("h") = h-k:{(#5,RANGEKEYDEL)}
 <nil> err=<injected error>
 #  a.SeekGE("i") = nil <err="injected error">
-#  b.SeekGE("i") = h-k:{(#5,RANGEKEYDEL)}
 <nil> err=<injected error>
 #  a.SeekGE("j") = nil <err="injected error">
-#  b.SeekGE("j") = h-k:{(#5,RANGEKEYDEL)}
 <nil> err=<injected error>
 #  a.SeekGE("k") = nil <err="injected error">
-#  b.SeekGE("k") = nil
 <nil> err=<injected error>
 #  a.SeekGE("z") = nil <err="injected error">
-#  b.SeekGE("z") = nil
 <nil> err=<injected error>
 
 # Test SeekLTs with errors injected on the second iterator.

--- a/internal/keyspan/transformer.go
+++ b/internal/keyspan/transformer.go
@@ -62,89 +62,78 @@ type TransformerIter struct {
 	Compare base.Compare
 
 	span Span
-	err  error
 }
 
-func (t *TransformerIter) applyTransform(span *Span) *Span {
+func (t *TransformerIter) applyTransform(span *Span) (*Span, error) {
+	if span == nil {
+		return nil, nil
+	}
 	t.span = Span{
 		Start: t.span.Start[:0],
 		End:   t.span.End[:0],
 		Keys:  t.span.Keys[:0],
 	}
 	if err := t.Transformer.Transform(t.Compare, *span, &t.span); err != nil {
-		t.err = err
-		return nil
+		return nil, err
 	}
-	return &t.span
+	return &t.span, nil
 }
 
 // SeekGE implements the FragmentIterator interface.
-func (t *TransformerIter) SeekGE(key []byte) *Span {
-	span := t.FragmentIterator.SeekGE(key)
-	if span == nil {
-		return nil
+func (t *TransformerIter) SeekGE(key []byte) (*Span, error) {
+	span, err := t.FragmentIterator.SeekGE(key)
+	if err != nil {
+		return nil, err
 	}
 	return t.applyTransform(span)
 }
 
 // SeekLT implements the FragmentIterator interface.
-func (t *TransformerIter) SeekLT(key []byte) *Span {
-	span := t.FragmentIterator.SeekLT(key)
-	if span == nil {
-		return nil
+func (t *TransformerIter) SeekLT(key []byte) (*Span, error) {
+	span, err := t.FragmentIterator.SeekLT(key)
+	if err != nil {
+		return nil, err
 	}
 	return t.applyTransform(span)
 }
 
 // First implements the FragmentIterator interface.
-func (t *TransformerIter) First() *Span {
-	span := t.FragmentIterator.First()
-	if span == nil {
-		return nil
+func (t *TransformerIter) First() (*Span, error) {
+	span, err := t.FragmentIterator.First()
+	if err != nil {
+		return nil, err
 	}
 	return t.applyTransform(span)
 }
 
 // Last implements the FragmentIterator interface.
-func (t *TransformerIter) Last() *Span {
-	span := t.FragmentIterator.Last()
-	if span == nil {
-		return nil
+func (t *TransformerIter) Last() (*Span, error) {
+	span, err := t.FragmentIterator.Last()
+	if err != nil {
+		return nil, err
 	}
 	return t.applyTransform(span)
 }
 
 // Next implements the FragmentIterator interface.
-func (t *TransformerIter) Next() *Span {
-	span := t.FragmentIterator.Next()
-	if span == nil {
-		return nil
+func (t *TransformerIter) Next() (*Span, error) {
+	span, err := t.FragmentIterator.Next()
+	if err != nil {
+		return nil, err
 	}
 	return t.applyTransform(span)
 }
 
 // Prev implements the FragmentIterator interface.
-func (t *TransformerIter) Prev() *Span {
-	span := t.FragmentIterator.Prev()
-	if span == nil {
-		return nil
+func (t *TransformerIter) Prev() (*Span, error) {
+	span, err := t.FragmentIterator.Prev()
+	if err != nil {
+		return nil, err
 	}
 	return t.applyTransform(span)
 }
 
-// Error implements the FragmentIterator interface.
-func (t *TransformerIter) Error() error {
-	if t.err != nil {
-		return t.err
-	}
-	return t.FragmentIterator.Error()
-}
-
 // Close implements the FragmentIterator interface.
 func (t *TransformerIter) Close() error {
-	err := t.FragmentIterator.Close()
-	if err != nil {
-		return err
-	}
-	return t.err
+	return t.FragmentIterator.Close()
 }

--- a/internal/keyspan/truncate_test.go
+++ b/internal/keyspan/truncate_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTruncate(t *testing.T) {
@@ -70,9 +71,12 @@ func TestTruncate(t *testing.T) {
 			tIter := doTruncate()
 			defer tIter.Close()
 			var truncated []Span
-			for s := tIter.First(); s != nil; s = tIter.Next() {
+			var s *Span
+			var err error
+			for s, err = tIter.First(); s != nil; s, err = tIter.Next() {
 				truncated = append(truncated, s.ShallowClone())
 			}
+			require.NoError(t, err)
 			return formatAlphabeticSpans(truncated)
 
 		case "truncate-and-save-iter":

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -355,24 +355,28 @@ type levelIterTestIter struct {
 	rangeDelIter keyspan.FragmentIterator
 }
 
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
 func (i *levelIterTestIter) rangeDelSeek(
 	key []byte, ikey *InternalKey, val base.LazyValue, dir int,
 ) (*InternalKey, base.LazyValue) {
 	var tombstone keyspan.Span
 	if i.rangeDelIter != nil {
 		var t *keyspan.Span
+		var err error
 		if dir < 0 {
-			var err error
 			t, err = keyspan.SeekLE(i.levelIter.cmp, i.rangeDelIter, key)
-			// TODO(jackson): Clean this up when the FragmentIterator interface
-			// is refactored to return an error return value from all
-			// positioning methods.
-			if err != nil {
-				panic(err)
-			}
 		} else {
-			t = i.rangeDelIter.SeekGE(key)
+			t, err = i.rangeDelIter.SeekGE(key)
 		}
+		// TODO(jackson): Clean this up when the InternalIterator interface
+		// is refactored to return an error return value from all
+		// positioning methods.
+		must(err)
 		if t != nil {
 			tombstone = t.Visible(1000)
 		}

--- a/mem_table_test.go
+++ b/mem_table_test.go
@@ -367,11 +367,15 @@ func TestMemTableConcurrentDeleteRange(t *testing.T) {
 
 				var count int
 				it := m.newRangeDelIter(nil)
-				for s := it.SeekGE(start); s != nil; s = it.Next() {
+				s, err := it.SeekGE(start)
+				for ; s != nil; s, err = it.Next() {
 					if m.cmp(s.Start, end) >= 0 {
 						break
 					}
 					count += len(s.Keys)
+				}
+				if err != nil {
+					return err
 				}
 				if j+1 != count {
 					return errors.Errorf("%d: expected %d tombstones, but found %d", i, j+1, count)

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -373,11 +373,10 @@ func (m *mergingIter) initMinRangeDelIters(oldTopLevel int) error {
 		if l.rangeDelIter == nil {
 			continue
 		}
-		l.tombstone = l.rangeDelIter.SeekGE(item.iterKey.UserKey)
-		if l.tombstone == nil {
-			if err := l.rangeDelIter.Error(); err != nil {
-				return err
-			}
+		var err error
+		l.tombstone, err = l.rangeDelIter.SeekGE(item.iterKey.UserKey)
+		if err != nil {
+			return err
 		}
 	}
 	return nil
@@ -728,11 +727,10 @@ func (m *mergingIter) isNextEntryDeleted(item *mergingIterLevel) (bool, error) {
 			// levelIter in the future cannot contain item.iterKey). Also, it is possible that we
 			// will encounter parts of the range delete that should be ignored -- we handle that
 			// below.
-			l.tombstone = l.rangeDelIter.SeekGE(item.iterKey.UserKey)
-			if l.tombstone == nil {
-				if err := l.rangeDelIter.Error(); err != nil {
-					return false, err
-				}
+			var err error
+			l.tombstone, err = l.rangeDelIter.SeekGE(item.iterKey.UserKey)
+			if err != nil {
+				return false, err
 			}
 		}
 		if l.tombstone == nil {
@@ -1174,11 +1172,10 @@ func (m *mergingIter) seekGE(key []byte, level int, flags base.SeekGEFlags) erro
 			// so we can have a sstable with bounds [c#8, i#InternalRangeDelSentinel], and the
 			// tombstone is [b, k)#8 and the seek key is i: levelIter.SeekGE(i) will move past
 			// this sstable since it realizes the largest key is a InternalRangeDelSentinel.
-			l.tombstone = rangeDelIter.SeekGE(key)
-			if l.tombstone == nil {
-				if err := rangeDelIter.Error(); err != nil {
-					return err
-				}
+			var err error
+			l.tombstone, err = rangeDelIter.SeekGE(key)
+			if err != nil {
+				return err
 			}
 			if l.tombstone != nil && l.tombstone.VisibleAt(m.snapshot) && l.tombstone.Contains(m.heap.cmp, key) &&
 				(l.smallestUserKey == nil || m.heap.cmp(l.smallestUserKey, key) <= 0) {

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -687,12 +687,16 @@ func buildForIngest(
 
 	if rangeDelIter != nil {
 		// NB: The range tombstones have already been fragmented by the Batch.
-		for t := rangeDelIter.First(); t != nil; t = rangeDelIter.Next() {
+		t, err := rangeDelIter.First()
+		for ; t != nil; t, err = rangeDelIter.Next() {
 			// NB: We don't have to copy the key or value since we're reading from a
 			// batch which doesn't do prefix compression.
 			if err := w.DeleteRange(t.Start, t.End); err != nil {
 				return "", nil, err
 			}
+		}
+		if err != nil {
+			return "", nil, err
 		}
 		if err := rangeDelIter.Close(); err != nil {
 			return "", nil, err
@@ -701,7 +705,8 @@ func buildForIngest(
 	}
 
 	if rangeKeyIter != nil {
-		for span := rangeKeyIter.First(); span != nil; span = rangeKeyIter.Next() {
+		span, err := rangeKeyIter.First()
+		for ; span != nil; span, err = rangeKeyIter.Next() {
 			// Coalesce the keys of this span and then zero the sequence
 			// numbers. This is necessary in order to make the range keys within
 			// the ingested sstable internally consistent at the sequence number
@@ -728,7 +733,7 @@ func buildForIngest(
 				return "", nil, err
 			}
 		}
-		if err := rangeKeyIter.Error(); err != nil {
+		if err != nil {
 			return "", nil, err
 		}
 		if err := rangeKeyIter.Close(); err != nil {
@@ -800,12 +805,16 @@ func (o *ingestOp) collapseBatch(
 
 	if rangeDelIter != nil {
 		// NB: The range tombstones have already been fragmented by the Batch.
-		for t := rangeDelIter.First(); t != nil; t = rangeDelIter.Next() {
+		t, err := rangeDelIter.First()
+		for ; t != nil; t, err = rangeDelIter.Next() {
 			// NB: We don't have to copy the key or value since we're reading from a
 			// batch which doesn't do prefix compression.
 			if err := collapsed.DeleteRange(t.Start, t.End, nil); err != nil {
 				return nil, err
 			}
+		}
+		if err != nil {
+			return nil, err
 		}
 		if err := rangeDelIter.Close(); err != nil {
 			return nil, err

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -1023,7 +1023,8 @@ func loadFlushedSSTableKeys(
 				return err
 			} else if iter != nil {
 				defer iter.Close()
-				for s := iter.First(); s != nil; s = iter.Next() {
+				s, err := iter.First()
+				for ; s != nil; s, err = iter.Next() {
 					if err := rangedel.Encode(s, func(k base.InternalKey, v []byte) error {
 						var key flushedKey
 						key.Trailer = k.Trailer
@@ -1035,6 +1036,9 @@ func loadFlushedSSTableKeys(
 						return err
 					}
 				}
+				if err != nil {
+					return err
+				}
 			}
 
 			// Load all the range keys.
@@ -1042,7 +1046,8 @@ func loadFlushedSSTableKeys(
 				return err
 			} else if iter != nil {
 				defer iter.Close()
-				for s := iter.First(); s != nil; s = iter.Next() {
+				s, err := iter.First()
+				for ; s != nil; s, err = iter.Next() {
 					if err := rangekey.Encode(s, func(k base.InternalKey, v []byte) error {
 						var key flushedKey
 						key.Trailer = k.Trailer
@@ -1053,6 +1058,9 @@ func loadFlushedSSTableKeys(
 					}); err != nil {
 						return err
 					}
+				}
+				if err != nil {
+					return err
 				}
 			}
 			return nil

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -407,8 +407,12 @@ func TestVirtualReader(t *testing.T) {
 			defer iter.Close()
 
 			var buf bytes.Buffer
-			for s := iter.First(); s != nil; s = iter.Next() {
+			s, err := iter.First()
+			for ; s != nil; s, err = iter.Next() {
 				fmt.Fprintf(&buf, "%s\n", s)
+			}
+			if err != nil {
+				return err.Error()
 			}
 			return buf.String()
 
@@ -426,8 +430,12 @@ func TestVirtualReader(t *testing.T) {
 			defer iter.Close()
 
 			var buf bytes.Buffer
-			for s := iter.First(); s != nil; s = iter.Next() {
+			s, err := iter.First()
+			for ; s != nil; s, err = iter.Next() {
 				fmt.Fprintf(&buf, "%s\n", s)
+			}
+			if err != nil {
+				return err.Error()
 			}
 			return buf.String()
 

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -402,7 +402,8 @@ func rewriteRangeKeyBlockToWriter(r *Reader, w *Writer, from, to []byte) error {
 	}
 	defer iter.Close()
 
-	for s := iter.First(); s != nil; s = iter.Next() {
+	s, err := iter.First()
+	for ; s != nil; s, err = iter.Next() {
 		if !s.Valid() {
 			break
 		}
@@ -416,7 +417,7 @@ func rewriteRangeKeyBlockToWriter(r *Reader, w *Writer, from, to []byte) error {
 			s.Keys[i].Suffix = to
 		}
 
-		err := rangekey.Encode(s, func(k base.InternalKey, v []byte) error {
+		err = rangekey.Encode(s, func(k base.InternalKey, v []byte) error {
 			// Calling AddRangeKey instead of addRangeKeySpan bypasses the fragmenter.
 			// This is okay because the raw fragments off of `iter` are already
 			// fragmented, and suffix replacement should not affect fragmentation.
@@ -426,8 +427,7 @@ func rewriteRangeKeyBlockToWriter(r *Reader, w *Writer, from, to []byte) error {
 			return err
 		}
 	}
-
-	return nil
+	return err
 }
 
 type copyFilterWriter struct {

--- a/sstable/writer_rangekey_test.go
+++ b/sstable/writer_rangekey_test.go
@@ -112,8 +112,12 @@ func TestWriter_RangeKeys(t *testing.T) {
 			defer iter.Close()
 
 			var buf bytes.Buffer
-			for s := iter.First(); s != nil; s = iter.Next() {
+			s, err := iter.First()
+			for ; s != nil; s, err = iter.Next() {
 				_, _ = fmt.Fprintf(&buf, "%s\n", s)
+			}
+			if err != nil {
+				return err.Error()
 			}
 			return buf.String()
 

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -177,8 +177,12 @@ func runDataDriven(t *testing.T, file string, tableFormat TableFormat, paralleli
 			defer iter.Close()
 
 			var buf bytes.Buffer
-			for s := iter.First(); s != nil; s = iter.Next() {
+			s, err := iter.First()
+			for ; s != nil; s, err = iter.Next() {
 				fmt.Fprintf(&buf, "%s\n", s)
+			}
+			if err != nil {
+				return err.Error()
 			}
 			return buf.String()
 
@@ -193,8 +197,12 @@ func runDataDriven(t *testing.T, file string, tableFormat TableFormat, paralleli
 			defer iter.Close()
 
 			var buf bytes.Buffer
-			for s := iter.First(); s != nil; s = iter.Next() {
+			s, err := iter.First()
+			for ; s != nil; s, err = iter.Next() {
 				fmt.Fprintf(&buf, "%s\n", s)
+			}
+			if err != nil {
+				return err.Error()
 			}
 			return buf.String()
 

--- a/table_stats.go
+++ b/table_stats.go
@@ -371,7 +371,8 @@ func (d *DB) loadTableRangeDelStats(
 	// numbers. Also, merging abutting tombstones reduces the number of calls to
 	// estimateReclaimedSizeBeneath which is costly, and improves the accuracy of
 	// our overall estimate.
-	for s := iter.First(); s != nil; s = iter.Next() {
+	s, err := iter.First()
+	for ; s != nil; s, err = iter.Next() {
 		start, end := s.Start, s.End
 		// We only need to consider deletion size estimates for tables that contain
 		// RANGEDELs.
@@ -459,7 +460,10 @@ func (d *DB) loadTableRangeDelStats(
 		copy(hint.end, end)
 		compactionHints = append(compactionHints, hint)
 	}
-	return compactionHints, err
+	if err != nil {
+		return nil, err
+	}
+	return compactionHints, nil
 }
 
 func (d *DB) estimateSizesBeneath(

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -263,8 +263,12 @@ func TestTableRangeDeletionIter(t *testing.T) {
 			}
 			defer iter.Close()
 			var buf bytes.Buffer
-			for s := iter.First(); s != nil; s = iter.Next() {
+			s, err := iter.First()
+			for ; s != nil; s, err = iter.Next() {
 				buf.WriteString(s.String() + "\n")
+			}
+			if err != nil {
+				return err.Error()
 			}
 			if buf.Len() == 0 {
 				return "(none)"


### PR DESCRIPTION
This commit refactors the keyspan.FragmentIterator interface to propagate
errors from the positioning method that encounters the error, removing the
`Error()` method from the interface. This makes it more difficult to
accidentally ignore an error value by forgetting to check `Error()`.