### PR TITLE
wal: failover write path code

### DIFF
--- a/open.go
+++ b/open.go
@@ -322,19 +322,18 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 	})
 	walManager := &wal.StandaloneManager{}
 	err = walManager.Init(wal.Options{
-		Primary:                        wal.Dir{FS: opts.FS, Dirname: walDirname},
-		Secondary:                      wal.Dir{},
-		MinUnflushedWALNum:             wal.NumWAL(d.mu.versions.minUnflushedLogNum),
-		MaxNumRecyclableLogs:           opts.MemTableStopWritesThreshold + 1,
-		NoSyncOnClose:                  opts.NoSyncOnClose,
-		BytesPerSync:                   opts.WALBytesPerSync,
-		PreallocateSize:                d.walPreallocateSize,
-		MinSyncInterval:                opts.WALMinSyncInterval,
-		FsyncLatency:                   d.mu.log.metrics.fsyncLatency,
-		QueueSemChan:                   d.commit.logSyncQSem,
-		ElevatedWriteStallThresholdLag: 0,
-		Logger:                         opts.Logger,
-		EventListener:                  walEventListenerAdaptor{l: opts.EventListener},
+		Primary:              wal.Dir{FS: opts.FS, Dirname: walDirname},
+		Secondary:            wal.Dir{},
+		MinUnflushedWALNum:   wal.NumWAL(d.mu.versions.minUnflushedLogNum),
+		MaxNumRecyclableLogs: opts.MemTableStopWritesThreshold + 1,
+		NoSyncOnClose:        opts.NoSyncOnClose,
+		BytesPerSync:         opts.WALBytesPerSync,
+		PreallocateSize:      d.walPreallocateSize,
+		MinSyncInterval:      opts.WALMinSyncInterval,
+		FsyncLatency:         d.mu.log.metrics.fsyncLatency,
+		QueueSemChan:         d.commit.logSyncQSem,
+		Logger:               opts.Logger,
+		EventListener:        walEventListenerAdaptor{l: opts.EventListener},
 	})
 	if err != nil {
 		return nil, err

--- a/vfs/errorfs/errorfs.go
+++ b/vfs/errorfs/errorfs.go
@@ -83,6 +83,8 @@ const (
 	OpFileSync
 	// OpFileSyncData describes a file sync operation.
 	OpFileSyncData
+	// OpFileSyncTo describes a file sync operation.
+	OpFileSyncTo
 	// OpFileFlush describes a file flush operation.
 	OpFileFlush
 )
@@ -92,7 +94,7 @@ func (o OpKind) ReadOrWrite() OpReadWrite {
 	switch o {
 	case OpOpen, OpOpenDir, OpList, OpStat, OpGetDiskUsage, OpFileRead, OpFileReadAt, OpFileStat:
 		return OpIsRead
-	case OpCreate, OpLink, OpRemove, OpRemoveAll, OpRename, OpReuseForWrite, OpMkdirAll, OpLock, OpFileClose, OpFileWrite, OpFileWriteAt, OpFileSync, OpFileSyncData, OpFileFlush, OpFilePreallocate:
+	case OpCreate, OpLink, OpRemove, OpRemoveAll, OpRename, OpReuseForWrite, OpMkdirAll, OpLock, OpFileClose, OpFileWrite, OpFileWriteAt, OpFileSync, OpFileSyncData, OpFileSyncTo, OpFileFlush, OpFilePreallocate:
 		return OpIsWrite
 	default:
 		panic(fmt.Sprintf("unrecognized op %v\n", o))
@@ -535,7 +537,9 @@ func (f *errorFile) SyncData() error {
 }
 
 func (f *errorFile) SyncTo(length int64) (fullSync bool, err error) {
-	// TODO(jackson): Consider error injection.
+	if err := f.inj.MaybeError(Op{Kind: OpFileSyncTo, Path: f.path}); err != nil {
+		return false, err
+	}
 	return f.file.SyncTo(length)
 }
 

--- a/wal/failover_manager.go
+++ b/wal/failover_manager.go
@@ -9,7 +9,168 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble/vfs"
+	"golang.org/x/exp/rand"
 )
+
+// dirProber probes the primary dir, until it is confirmed to be healthy. If
+// it doesn't have enough samples, it is deemed to be unhealthy. It is only
+// used for failback to the primary.
+type dirProber struct {
+	fs vfs.FS
+	// The full path of the file to use for the probe. The probe is destructive
+	// in that it deletes and (re)creates the file.
+	filename string
+	// The probing interval, when enabled.
+	interval time.Duration
+	timeSource
+	// buf holds the random bytes that are written during the probe.
+	buf [100 << 10]byte
+	// enabled is signaled to enable and disable probing. The initial state of
+	// the prober is disabled.
+	enabled chan bool
+	mu      struct {
+		sync.Mutex
+		// Circular buffer of history samples.
+		history [probeHistoryLength]time.Duration
+		// The history is in [firstProbeIndex, nextProbeIndex).
+		firstProbeIndex int
+		nextProbeIndex  int
+	}
+	iterationForTesting chan<- struct{}
+}
+
+const probeHistoryLength = 128
+
+// Large value.
+const failedProbeDuration = 24 * 60 * 60 * time.Second
+
+// There is no close/stop method on the dirProber -- use stopper.
+func (p *dirProber) init(
+	fs vfs.FS,
+	filename string,
+	interval time.Duration,
+	stopper *stopper,
+	ts timeSource,
+	notifyIterationForTesting chan<- struct{},
+) {
+	*p = dirProber{
+		fs:                  fs,
+		filename:            filename,
+		interval:            interval,
+		timeSource:          ts,
+		enabled:             make(chan bool),
+		iterationForTesting: notifyIterationForTesting,
+	}
+	// Random bytes for writing, to defeat any FS compression optimization.
+	_, err := rand.Read(p.buf[:])
+	if err != nil {
+		panic(err)
+	}
+	stopper.runAsync(func() {
+		p.probeLoop(stopper.shouldQuiesce())
+	})
+}
+
+func (p *dirProber) probeLoop(shouldQuiesce <-chan struct{}) {
+	ticker := p.timeSource.newTicker(p.interval)
+	ticker.stop()
+	tickerCh := ticker.ch()
+	done := false
+	var enabled bool
+	for !done {
+		select {
+		case <-tickerCh:
+			if !enabled {
+				// Could have a tick waiting before we disabled it. Ignore.
+				continue
+			}
+			probeDur := func() time.Duration {
+				// Delete, create, write, sync.
+				start := p.timeSource.now()
+				_ = p.fs.Remove(p.filename)
+				f, err := p.fs.Create(p.filename)
+				if err != nil {
+					return failedProbeDuration
+				}
+				defer f.Close()
+				n, err := f.Write(p.buf[:])
+				if err != nil {
+					return failedProbeDuration
+				}
+				if n != len(p.buf) {
+					panic("invariant violation")
+				}
+				err = f.Sync()
+				if err != nil {
+					return failedProbeDuration
+				}
+				return p.timeSource.now().Sub(start)
+			}()
+			p.mu.Lock()
+			nextIndex := p.mu.nextProbeIndex % probeHistoryLength
+			p.mu.history[nextIndex] = probeDur
+			p.mu.nextProbeIndex++
+			numSamples := p.mu.nextProbeIndex - p.mu.firstProbeIndex
+			if numSamples > probeHistoryLength {
+				// Length has exceeded capacity, i.e., overwritten the first probe.
+				p.mu.firstProbeIndex++
+			}
+			p.mu.Unlock()
+
+		case <-shouldQuiesce:
+			done = true
+
+		case enabled = <-p.enabled:
+			if enabled {
+				ticker.reset(p.interval)
+			} else {
+				ticker.stop()
+				p.mu.Lock()
+				p.mu.firstProbeIndex = 0
+				p.mu.nextProbeIndex = 0
+				p.mu.Unlock()
+			}
+		}
+		if p.iterationForTesting != nil {
+			p.iterationForTesting <- struct{}{}
+		}
+	}
+}
+
+func (p *dirProber) enableProbing() {
+	p.enabled <- true
+}
+
+func (p *dirProber) disableProbing() {
+	p.enabled <- false
+}
+
+func (p *dirProber) getMeanMax(interval time.Duration) (time.Duration, time.Duration) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	numSamples := p.mu.nextProbeIndex - p.mu.firstProbeIndex
+	samplesNeeded := int((interval + p.interval - 1) / p.interval)
+	if samplesNeeded == 0 {
+		panic("interval is too short")
+	} else if samplesNeeded > probeHistoryLength {
+		panic("interval is too long")
+	}
+	if samplesNeeded > numSamples {
+		// Not enough samples, so assume not yet healthy.
+		return failedProbeDuration, failedProbeDuration
+	}
+	offset := numSamples - samplesNeeded
+	var sum, max time.Duration
+	for i := p.mu.firstProbeIndex + offset; i < p.mu.nextProbeIndex; i++ {
+		sampleDur := p.mu.history[i%probeHistoryLength]
+		sum += sampleDur
+		if max < sampleDur {
+			max = sampleDur
+		}
+	}
+	mean := sum / time.Duration(samplesNeeded)
+	return mean, max
+}
 
 type dirIndex int
 
@@ -28,6 +189,353 @@ type dirAndFileHandle struct {
 type switchableWriter interface {
 	switchToNewDir(dirAndFileHandle) error
 	ongoingLatencyOrErrorForCurDir() (time.Duration, error)
+}
+
+type failoverMonitorOptions struct {
+	// The primary and secondary dir.
+	dirs [numDirIndices]dirAndFileHandle
+
+	FailoverOptions
+	stopper *stopper
+}
+
+// failoverMonitor monitors the latency and error observed by the
+// switchableWriter, and does failover by switching the dir. It also monitors
+// the primary dir for failback.
+type failoverMonitor struct {
+	opts   failoverMonitorOptions
+	prober dirProber
+	mu     struct {
+		sync.Mutex
+		// dirIndex and lastFailbackTime are only modified by monitorLoop. They
+		// are protected by the mutex for concurrent reads.
+
+		// dirIndex is the directory to use by writer (if non-nil), or when the
+		// writer becomes non-nil.
+		dirIndex
+		// The time at which the monitor last failed back to the primary. This is
+		// only relevant when dirIndex == primaryDirIndex.
+		lastFailBackTime time.Time
+		// The current failoverWriter, exposed via a narrower interface.
+		writer switchableWriter
+	}
+}
+
+func newFailoverMonitor(opts failoverMonitorOptions) *failoverMonitor {
+	m := &failoverMonitor{
+		opts: opts,
+	}
+	m.prober.init(opts.dirs[primaryDirIndex].FS,
+		opts.dirs[primaryDirIndex].FS.PathJoin(opts.dirs[primaryDirIndex].Dirname, "probe-file"),
+		opts.PrimaryDirProbeInterval, opts.stopper, opts.timeSource, opts.proberIterationForTesting)
+	opts.stopper.runAsync(func() {
+		m.monitorLoop(opts.stopper.shouldQuiesce())
+	})
+	return m
+}
+
+// Called when previous writer is closed
+func (m *failoverMonitor) noWriter() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.mu.writer = nil
+}
+
+// writerCreateFunc is allowed to return nil, if there is an error. It is not
+// the responsibility of failoverMonitor to handle that error. So this should
+// not be due to an IO error (which failoverMonitor is interested in).
+func (m *failoverMonitor) newWriter(writerCreateFunc func(dir dirAndFileHandle) switchableWriter) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.mu.writer != nil {
+		panic("previous writer not closed")
+	}
+	m.mu.writer = writerCreateFunc(m.opts.dirs[m.mu.dirIndex])
+}
+
+func (m *failoverMonitor) elevateWriteStallThresholdForFailover() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.mu.dirIndex == secondaryDirIndex {
+		return true
+	}
+	intervalSinceFailedback := m.opts.timeSource.now().Sub(m.mu.lastFailBackTime)
+	return intervalSinceFailedback < m.opts.ElevatedWriteStallThresholdLag
+}
+
+// lastWriterInfo is state maintained in the monitorLoop for the latest
+// switchable writer. It is mainly used to dampen the switching.
+type lastWriterInfo struct {
+	writer                 switchableWriter
+	numSwitches            int
+	ongoingLatencyAtSwitch time.Duration
+	errorCounts            [numDirIndices]int
+}
+
+func (m *failoverMonitor) monitorLoop(shouldQuiesce <-chan struct{}) {
+	ticker := m.opts.timeSource.newTicker(m.opts.UnhealthySamplingInterval)
+	if m.opts.monitorIterationForTesting != nil {
+		m.opts.monitorIterationForTesting <- struct{}{}
+	}
+	tickerCh := ticker.ch()
+	dirIndex := primaryDirIndex
+	var lastWriter lastWriterInfo
+	for {
+		select {
+		case <-shouldQuiesce:
+			ticker.stop()
+			return
+		case <-tickerCh:
+			writerOngoingLatency, writerErr := func() (time.Duration, error) {
+				m.mu.Lock()
+				defer m.mu.Unlock()
+				if m.mu.writer != lastWriter.writer {
+					lastWriter = lastWriterInfo{writer: m.mu.writer}
+				}
+				if lastWriter.writer == nil {
+					return 0, nil
+				}
+				return lastWriter.writer.ongoingLatencyOrErrorForCurDir()
+			}()
+			switchDir := false
+			// Arbitrary value.
+			const highSecondaryErrorCountThreshold = 2
+			// We don't consider a switch if currently using the primary dir and the
+			// secondary dir has high enough errors. It is more likely that someone
+			// has misconfigured a secondary e.g. wrong permissions or not enough
+			// disk space. We only remember the error history in the context of the
+			// lastWriter since an operator can fix the underlying misconfiguration.
+			if !(lastWriter.errorCounts[secondaryDirIndex] >= highSecondaryErrorCountThreshold &&
+				dirIndex == primaryDirIndex) {
+				// Switching heuristics. Subject to change based on real world experience.
+				if writerErr != nil {
+					// An error causes an immediate switch, since a LogWriter with an
+					// error is useless.
+					lastWriter.errorCounts[dirIndex]++
+					switchDir = true
+				} else if writerOngoingLatency > m.opts.UnhealthyOperationLatencyThreshold {
+					// Arbitrary value.
+					const switchImmediatelyCountThreshold = 2
+					// High latency. Switch immediately if the number of switches that
+					// have been done is below the threshold, since that gives us an
+					// observation of both dirs. Once above that threshold, decay the
+					// switch rate by increasing the observed latency needed for a
+					// switch.
+					if lastWriter.numSwitches < switchImmediatelyCountThreshold ||
+						writerOngoingLatency > 2*lastWriter.ongoingLatencyAtSwitch {
+						switchDir = true
+						lastWriter.ongoingLatencyAtSwitch = writerOngoingLatency
+					}
+					// Else high latency, but not high enough yet to motivate switch.
+				} else if dirIndex == secondaryDirIndex {
+					// The writer looks healthy. We can still switch if the writer is using the
+					// secondary dir and the primary is healthy again.
+					primaryMean, primaryMax := m.prober.getMeanMax(m.opts.HealthyInterval)
+					if primaryMean < m.opts.HealthyProbeLatencyThreshold &&
+						primaryMax < m.opts.HealthyProbeLatencyThreshold {
+						switchDir = true
+					}
+				}
+			}
+			if switchDir {
+				lastWriter.numSwitches++
+				if dirIndex == secondaryDirIndex {
+					// Switching back to primary, so don't need to probe to see if
+					// primary is healthy.
+					m.prober.disableProbing()
+					dirIndex = primaryDirIndex
+				} else {
+					m.prober.enableProbing()
+					dirIndex = secondaryDirIndex
+				}
+				dir := m.opts.dirs[dirIndex]
+				m.mu.Lock()
+				m.mu.dirIndex = dirIndex
+				if dirIndex == primaryDirIndex {
+					m.mu.lastFailBackTime = m.opts.timeSource.now()
+				}
+				if m.mu.writer != nil {
+					m.mu.writer.switchToNewDir(dir)
+				}
+				m.mu.Unlock()
+			}
+		}
+		if m.opts.monitorStateForTesting != nil {
+			m.opts.monitorStateForTesting(lastWriter.numSwitches, lastWriter.ongoingLatencyAtSwitch)
+		}
+		if m.opts.monitorIterationForTesting != nil {
+			m.opts.monitorIterationForTesting <- struct{}{}
+		}
+	}
+}
+
+func (o *FailoverOptions) ensureDefaults() {
+	if o.PrimaryDirProbeInterval == 0 {
+		o.PrimaryDirProbeInterval = time.Second
+	}
+	if o.HealthyProbeLatencyThreshold == 0 {
+		o.HealthyProbeLatencyThreshold = 100 * time.Millisecond
+	}
+	if o.HealthyInterval == 0 {
+		o.HealthyInterval = 2 * time.Minute
+	}
+	if o.UnhealthySamplingInterval == 0 {
+		o.UnhealthySamplingInterval = 100 * time.Millisecond
+	}
+	if o.UnhealthyOperationLatencyThreshold == 0 {
+		o.UnhealthyOperationLatencyThreshold = 200 * time.Millisecond
+	}
+}
+
+type failoverManager struct {
+	opts Options
+	// TODO(jackson/sumeer): read-path etc.
+
+	dirHandles [numDirIndices]vfs.File
+	stopper    *stopper
+	monitor    *failoverMonitor
+}
+
+var _ Manager = &failoverManager{}
+
+// TODO(sumeer):
+//
+// - log recycling: only those in primary dir. Keep track of those where
+//   record.LogWriter closed. Those are the only ones we can recycle.
+//
+// - log deletion: if record.LogWriter did not close yet, the cleaner may
+//   get an error when deleting or renaming (only under windows?).
+//
+// - calls to EventListener
+
+// Init implements Manager.
+func (wm *failoverManager) Init(o Options) error {
+	if o.timeSource == nil {
+		o.timeSource = defaultTime{}
+	}
+	o.FailoverOptions.ensureDefaults()
+	stopper := newStopper()
+	var dirs [numDirIndices]dirAndFileHandle
+	for i, dir := range []Dir{o.Primary, o.Secondary} {
+		dirs[i].Dir = dir
+		f, err := dir.FS.OpenDir(dir.Dirname)
+		if err != nil {
+			return err
+		}
+		dirs[i].File = f
+	}
+	fmOpts := failoverMonitorOptions{
+		dirs:            dirs,
+		FailoverOptions: o.FailoverOptions,
+		stopper:         stopper,
+	}
+	monitor := newFailoverMonitor(fmOpts)
+	// TODO(jackson): list dirs and assemble a list of all NumWALs and
+	// corresponding log files.
+
+	*wm = failoverManager{
+		opts:       o,
+		dirHandles: [numDirIndices]vfs.File{dirs[primaryDirIndex].File, dirs[secondaryDirIndex].File},
+		stopper:    stopper,
+		monitor:    monitor,
+	}
+	return nil
+}
+
+// List implements Manager.
+func (wm *failoverManager) List() ([]NumWAL, error) {
+	// TODO(jackson):
+	return nil, nil
+}
+
+// Obsolete implements Manager.
+func (wm *failoverManager) Obsolete(
+	minUnflushedNum NumWAL, noRecycle bool,
+) (toDelete []DeletableLog, err error) {
+	// TODO(sumeer):
+	return nil, nil
+}
+
+// OpenForRead implements Manager.
+func (wm *failoverManager) OpenForRead(wn NumWAL) (Reader, error) {
+	// TODO(jackson):
+	//
+	// Temporary implementation note: Gap and de-duping logic on read.
+	//
+	// Gap can be there in adjacent logs but not between log n and the union of logs 0..n-1.
+	// Entries 0..50 sent to log 0.
+	// Entries 0..60 sent to log 1
+	// Log 0 commits up to 50
+	// Entries 50..100 sent to log 2
+	// Log 2 commits all of these.
+	// Log 1 only commits 0..10 and node fails and restarts.
+	return nil, nil
+}
+
+// Create implements Manager.
+func (wm *failoverManager) Create(wn NumWAL, jobID int) (Writer, error) {
+	fwOpts := failoverWriterOpts{
+		wn:                   wn,
+		logger:               wm.opts.Logger,
+		timeSource:           wm.opts.timeSource,
+		noSyncOnClose:        wm.opts.NoSyncOnClose,
+		bytesPerSync:         wm.opts.BytesPerSync,
+		preallocateSize:      wm.opts.PreallocateSize,
+		minSyncInterval:      wm.opts.MinSyncInterval,
+		fsyncLatency:         wm.opts.FsyncLatency,
+		queueSemChan:         wm.opts.QueueSemChan,
+		stopper:              wm.stopper,
+		writerClosed:         wm.writerClosed,
+		writerCreatedForTest: wm.opts.logWriterCreatedForTesting,
+	}
+	var err error
+	var ww *failoverWriter
+	writerCreateFunc := func(dir dirAndFileHandle) switchableWriter {
+		ww, err = newFailoverWriter(fwOpts, dir)
+		if err != nil {
+			return nil
+		}
+		return ww
+	}
+	wm.monitor.newWriter(writerCreateFunc)
+	return ww, err
+}
+
+// ListFiles implements Manager.
+func (wm *failoverManager) ListFiles(wn NumWAL) (files []CopyableLog, err error) {
+	// TODO(sumeer):
+	return nil, nil
+}
+
+// ElevateWriteStallThresholdForFailover implements Manager.
+func (wm *failoverManager) ElevateWriteStallThresholdForFailover() bool {
+	return wm.monitor.elevateWriteStallThresholdForFailover()
+}
+
+func (wm *failoverManager) writerClosed() {
+	wm.monitor.noWriter()
+}
+
+// Stats implements Manager.
+func (wm *failoverManager) Stats() Stats {
+	// TODO(sumeer):
+	return Stats{}
+}
+
+// Close implements Manager.
+func (wm *failoverManager) Close() error {
+	wm.stopper.stop()
+	// Since all goroutines are stopped, can close the dirs.
+	var err error
+	for _, f := range wm.dirHandles {
+		err = firstError(err, f.Close())
+	}
+	return err
+}
+
+// RecyclerForTesting implements Manager.
+func (wm *failoverManager) RecyclerForTesting() *LogRecycler {
+	return nil
 }
 
 type stopper struct {
@@ -60,5 +568,55 @@ func (s *stopper) stop() {
 	s.wg.Wait()
 }
 
+// timeSource and tickerI are extracted from CockroachDB's timeutil, with
+// removal of support for Timer, and added support in the manual
+// implementation for reset.
+
+// timeSource is used to interact with the clock and tickers. Abstracts
+// time.Now and time.NewTicker for testing.
+type timeSource interface {
+	now() time.Time
+	newTicker(duration time.Duration) tickerI
+}
+
+// tickerI is an interface wrapping time.Ticker.
+type tickerI interface {
+	reset(duration time.Duration)
+	stop()
+	ch() <-chan time.Time
+}
+
+// defaultTime is a timeSource using the time package.
+type defaultTime struct{}
+
+var _ timeSource = defaultTime{}
+
+func (defaultTime) now() time.Time {
+	return time.Now()
+}
+
+func (defaultTime) newTicker(duration time.Duration) tickerI {
+	return (*defaultTicker)(time.NewTicker(duration))
+}
+
+// defaultTicker uses time.Ticker.
+type defaultTicker time.Ticker
+
+var _ tickerI = &defaultTicker{}
+
+func (t *defaultTicker) reset(duration time.Duration) {
+	(*time.Ticker)(t).Reset(duration)
+}
+
+func (t *defaultTicker) stop() {
+	(*time.Ticker)(t).Stop()
+}
+
+func (t *defaultTicker) ch() <-chan time.Time {
+	return (*time.Ticker)(t).C
+}
+
 // Make lint happy.
+var _ = (*failoverMonitor).noWriter
+var _ = (*failoverManager).writerClosed
 var _ = (&stopper{}).shouldQuiesce

--- a/wal/failover_manager_test.go
+++ b/wal/failover_manager_test.go
@@ -1,0 +1,491 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package wal
+
+import (
+	"container/list"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/cockroachdb/pebble/vfs/errorfs"
+	"github.com/stretchr/testify/require"
+)
+
+func (p *dirProber) printStateForTesting() string {
+	var b strings.Builder
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for i := p.mu.firstProbeIndex; i < p.mu.nextProbeIndex; i++ {
+		sampleDur := p.mu.history[i%probeHistoryLength]
+		fmt.Fprintf(&b, " %d: %s", i, sampleDur.String())
+	}
+	return b.String()
+}
+
+func (m *failoverMonitor) printStateForTesting() string {
+	var b strings.Builder
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	fmt.Fprintf(&b, "dir index: %d", m.mu.dirIndex)
+	if !(m.mu.lastFailBackTime == time.Time{}) {
+		fmt.Fprintf(
+			&b, " failback time: %s", time.Duration(m.mu.lastFailBackTime.UnixNano()).String())
+	}
+	return b.String()
+}
+
+// manualTime implements timeSource.
+type manualTime struct {
+	mu struct {
+		sync.Mutex
+		now time.Time
+		// tickers is a list with element type *manualTicker.
+		tickers list.List
+	}
+}
+
+func newManualTime(initialTime time.Time) *manualTime {
+	mt := manualTime{}
+	mt.mu.now = initialTime
+	mt.mu.tickers.Init()
+	return &mt
+}
+
+var _ timeSource = &manualTime{}
+
+func (m *manualTime) now() time.Time {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.mu.now
+}
+
+func (m *manualTime) newTicker(duration time.Duration) tickerI {
+	if duration <= 0 {
+		panic("non-positive interval for NewTicker")
+	}
+	t := &manualTicker{
+		m: m,
+		// We allocate a big buffer so that sending a tick never blocks.
+		channel: make(chan time.Time, 10000),
+	}
+	return m.insertTicker(t, duration)
+}
+
+func (m *manualTime) insertTicker(t *manualTicker, duration time.Duration) tickerI {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	t.duration = duration
+	t.nextTick = m.mu.now.Add(duration)
+	t.element = m.mu.tickers.PushBack(t)
+	return t
+}
+
+// advance forwards the current time by the given duration.
+func (m *manualTime) advance(duration time.Duration) {
+	now := m.now().Add(duration)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !now.After(m.mu.now) {
+		return
+	}
+	m.mu.now = now
+	// Fire off any tickers.
+	for e := m.mu.tickers.Front(); e != nil; e = e.Next() {
+		t := e.Value.(*manualTicker)
+		for !t.nextTick.After(now) {
+			select {
+			case t.channel <- t.nextTick:
+			default:
+				panic("ticker channel full")
+			}
+			t.nextTick = t.nextTick.Add(t.duration)
+		}
+	}
+}
+
+func (m *manualTime) removeTicker(t *manualTicker) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if t.element != nil {
+		m.mu.tickers.Remove(t.element)
+		t.element = nil
+	}
+}
+
+// manualTicker implements tickerI.
+type manualTicker struct {
+	m       *manualTime
+	element *list.Element
+
+	duration time.Duration
+	nextTick time.Time
+	channel  chan time.Time
+}
+
+func (t *manualTicker) reset(duration time.Duration) {
+	t.m.removeTicker(t)
+loop:
+	for {
+		select {
+		case <-t.channel:
+		default:
+			break loop
+		}
+	}
+	t.m.insertTicker(t, duration)
+}
+
+func (t *manualTicker) stop() {
+	t.m.removeTicker(t)
+}
+
+func (t *manualTicker) ch() <-chan time.Time {
+	return t.channel
+}
+
+func TestDirProber(t *testing.T) {
+	memFS := vfs.NewMem()
+	var ts *manualTime
+	var fs *blockingFS
+	var prober *dirProber
+	var stopper *stopper
+	var iterationForTesting chan struct{}
+	datadriven.RunTest(t, "testdata/dir_prober",
+		func(t *testing.T, td *datadriven.TestData) string {
+			switch td.Cmd {
+			case "init":
+				stopper = newStopper()
+				ts = newManualTime(time.UnixMilli(0))
+				var injs []errorfs.Injector
+				var interval time.Duration
+				for _, cmdArg := range td.CmdArgs {
+					switch cmdArg.Key {
+					case "inject-errors":
+						if len(injs) != 0 {
+							return "duplicate inject-errors"
+						}
+						injs = make([]errorfs.Injector, len(cmdArg.Vals))
+						for i := 0; i < len(cmdArg.Vals); i++ {
+							inj, err := errorfs.ParseDSL(cmdArg.Vals[i])
+							if err != nil {
+								return fmt.Sprintf("%s: %s", cmdArg.Vals[i], err.Error())
+							}
+							injs[i] = inj
+						}
+					case "interval":
+						if len(cmdArg.Vals) != 1 {
+							return fmt.Sprintf("len of interval is incorrect %d", len(cmdArg.Vals))
+						}
+						var err error
+						interval, err = time.ParseDuration(cmdArg.Vals[0])
+						if err != nil {
+							return err.Error()
+						}
+					default:
+						return fmt.Sprintf("unknown arg %s", cmdArg.Key)
+					}
+				}
+				fsToWrap := vfs.FS(memFS)
+				if len(injs) != 0 {
+					fsToWrap = errorfs.Wrap(fsToWrap, errorfs.Any(injs...))
+				}
+				fs = newBlockingFS(fsToWrap)
+				iterationForTesting = make(chan struct{}, 50)
+				prober = &dirProber{}
+				prober.init(fs, "foo", interval, stopper, ts, iterationForTesting)
+				return ""
+
+			case "enable":
+				prober.enableProbing()
+				if td.HasArg("wait") {
+					recvWithDeadline(t, td, "", iterationForTesting)
+				}
+				return "enabled"
+
+			case "disable":
+				prober.disableProbing()
+				if td.HasArg("wait") {
+					recvWithDeadline(t, td, "", iterationForTesting)
+				}
+				return "disabled"
+
+			case "stop":
+				stopper.stop()
+				return "stopped"
+
+			case "block-io-config":
+				conf := blockingWrite | blockingSync
+				if td.HasArg("unblock") {
+					conf = 0
+				}
+				fs.setConf("foo", conf)
+				return ""
+
+			case "wait-for-and-unblock-io":
+				sendWithDeadline(t, td, "", fs.waitForBlockAndUnblock("foo"))
+				return ""
+
+			case "get-mean-max":
+				durArg, ok := td.Arg("dur")
+				require.True(t, ok)
+				dur, err := time.ParseDuration(durArg.Vals[0])
+				require.NoError(t, err)
+				mean, max := prober.getMeanMax(dur)
+				return fmt.Sprintf("mean: %s, max: %s, state:%s",
+					mean.String(), max.String(), prober.printStateForTesting())
+
+			case "advance-time":
+				durArg, ok := td.Arg("dur")
+				require.True(t, ok)
+				dur, err := time.ParseDuration(durArg.Vals[0])
+				require.NoError(t, err)
+				ts.advance(dur)
+				if td.HasArg("wait") {
+					recvWithDeadline(t, td, "", iterationForTesting)
+				}
+				return fmt.Sprintf("now: %dms", ts.now().UnixNano()/int64(time.Millisecond))
+
+			default:
+				return fmt.Sprintf("unknown command: %s", td.Cmd)
+			}
+		})
+}
+
+func TestManagerFailover(t *testing.T) {
+	errorToStr := func(err error) string {
+		if err != nil {
+			return err.Error()
+		}
+		return "ok"
+	}
+	waitForOngoingLatencyOrErr := func(t *testing.T, td *datadriven.TestData, ww *failoverWriter) {
+		const sleepDur = time.Millisecond
+		for i := 0; i < 20000; i++ {
+			r := ww.recorderForCurDir()
+			if r.ongoingOperationStart.Load() != 0 {
+				return
+			}
+			if r.error.Load() != nil {
+				return
+			}
+			time.Sleep(sleepDur)
+		}
+		t.Fatalf("waitForOngoingLatencyOrErr expired at %s", td.Pos)
+	}
+	var proberIterationForTesting chan struct{}
+	var monitorIterationForTesting chan struct{}
+	var monitorStateBuf strings.Builder
+	monitorStateForTesting := func(numSwitches int, ongoingLatencyAtSwitch time.Duration) {
+		fmt.Fprintf(&monitorStateBuf, " num-switches: %d, ongoing-latency-at-switch: %s",
+			numSwitches, ongoingLatencyAtSwitch.String())
+	}
+	var logWriterCreatedForTesting chan struct{}
+	var ts *manualTime
+	var memFS *vfs.MemFS
+	var fs *blockingFS
+	var fm *failoverManager
+	var fw *failoverWriter
+	dirs := [numDirIndices]string{"pri", "sec"}
+	datadriven.RunTest(t, "testdata/manager_failover",
+		func(t *testing.T, td *datadriven.TestData) string {
+			switch td.Cmd {
+			case "init-manager":
+				ts = newManualTime(time.UnixMilli(0))
+				memFS = vfs.NewMem()
+				proberIterationForTesting = make(chan struct{}, 50000)
+				monitorIterationForTesting = make(chan struct{}, 50000)
+				monitorStateBuf.Reset()
+				logWriterCreatedForTesting = make(chan struct{}, 100)
+				var injs []errorfs.Injector
+				for _, cmdArg := range td.CmdArgs {
+					switch cmdArg.Key {
+					case "inject-errors":
+						if len(injs) != 0 {
+							return "duplicate inject-errors"
+						}
+						injs = make([]errorfs.Injector, len(cmdArg.Vals))
+						for i := 0; i < len(cmdArg.Vals); i++ {
+							inj, err := errorfs.ParseDSL(cmdArg.Vals[i])
+							if err != nil {
+								return fmt.Sprintf("%s: %s", cmdArg.Vals[i], err.Error())
+							}
+							injs[i] = inj
+						}
+					default:
+						return fmt.Sprintf("unknown arg %s", cmdArg.Key)
+					}
+				}
+				fsToWrap := vfs.FS(memFS)
+				if len(injs) != 0 {
+					fsToWrap = errorfs.Wrap(fsToWrap, errorfs.Any(injs...))
+				}
+				fs = newBlockingFS(fsToWrap)
+				fm = &failoverManager{}
+				o := Options{
+					Primary:              Dir{FS: fs, Dirname: dirs[primaryDirIndex]},
+					Secondary:            Dir{FS: fs, Dirname: dirs[secondaryDirIndex]},
+					MinUnflushedWALNum:   0,
+					MaxNumRecyclableLogs: 0,
+					NoSyncOnClose:        false,
+					BytesPerSync:         0,
+					PreallocateSize:      func() int { return 0 },
+					MinSyncInterval:      nil,
+					FsyncLatency:         nil,
+					QueueSemChan:         nil,
+					Logger:               nil,
+					EventListener:        nil,
+				}
+				require.NoError(t, memFS.MkdirAll(dirs[primaryDirIndex], 0755))
+				require.NoError(t, memFS.MkdirAll(dirs[secondaryDirIndex], 0755))
+				// All thresholds are 50ms.
+				o.FailoverOptions = FailoverOptions{
+					PrimaryDirProbeInterval:      100 * time.Millisecond,
+					HealthyProbeLatencyThreshold: 50 * time.Millisecond,
+					// Healthy history of length 2 is sufficient to switch back.
+					HealthyInterval: 200 * time.Millisecond,
+					// Use 75ms to not align with PrimaryDirProbeInterval, to avoid
+					// races.
+					UnhealthySamplingInterval:          75 * time.Millisecond,
+					UnhealthyOperationLatencyThreshold: 50 * time.Millisecond,
+					ElevatedWriteStallThresholdLag:     10 * time.Second,
+					timeSource:                         ts,
+					monitorIterationForTesting:         monitorIterationForTesting,
+					proberIterationForTesting:          proberIterationForTesting,
+					monitorStateForTesting:             monitorStateForTesting,
+					logWriterCreatedForTesting:         logWriterCreatedForTesting,
+				}
+				err := fm.Init(o)
+				return errorToStr(err)
+
+			case "create-writer":
+				var walNum int
+				td.ScanArgs(t, "wal-num", &walNum)
+				w, err := fm.Create(NumWAL(walNum), 0)
+				if err != nil {
+					return err.Error()
+				}
+				fw = w.(*failoverWriter)
+				return "ok"
+
+			case "close-writer":
+				_, err := fw.Close()
+				return errorToStr(err)
+
+			case "close-manager":
+				err := fm.Close()
+				return errorToStr(err)
+
+			case "advance-time":
+				durArg, ok := td.Arg("dur")
+				require.True(t, ok)
+				dur, err := time.ParseDuration(durArg.Vals[0])
+				require.NoError(t, err)
+				ts.advance(dur)
+				var b strings.Builder
+				if td.HasArg("wait-monitor") {
+					recvWithDeadline(t, td, "monitor", monitorIterationForTesting)
+					fmt.Fprintf(&b, "monitor state: %s%s\n", fm.monitor.printStateForTesting(),
+						monitorStateBuf.String())
+					monitorStateBuf.Reset()
+				}
+				if td.HasArg("wait-prober") {
+					recvWithDeadline(t, td, "prober", proberIterationForTesting)
+					fmt.Fprintf(&b, "prober state:%s\n", fm.monitor.prober.printStateForTesting())
+				}
+				if td.HasArg("wait-ongoing-io") {
+					waitForOngoingLatencyOrErr(t, td, fw)
+				}
+				if td.HasArg("wait-for-log-writer") {
+					recvWithDeadline(t, td, "log-writer", logWriterCreatedForTesting)
+				}
+				fmt.Fprintf(&b, "now: %s", time.Duration(ts.now().UnixNano()).String())
+				return b.String()
+
+			case "elevate-write-stall-threshold":
+				return fmt.Sprintf("%t\n", fm.ElevateWriteStallThresholdForFailover())
+
+			case "block-io-config":
+				var filename string
+				td.ScanArgs(t, "filename", &filename)
+				var conf blockingConf
+				if td.HasArg("create") {
+					conf |= blockingCreate
+				}
+				if td.HasArg("write") {
+					conf |= blockingWrite
+				}
+				if td.HasArg("sync") {
+					conf |= blockingSync
+				}
+				if td.HasArg("close") {
+					conf |= blockingClose
+				}
+				if td.HasArg("open-dir") {
+					conf |= blockingOpenDir
+				}
+				fs.setConf(filename, conf)
+				return fmt.Sprintf("%s: 0b%b", filename, uint8(conf))
+
+			case "wait-for-and-unblock-io":
+				var filename string
+				td.ScanArgs(t, "filename", &filename)
+				sendWithDeadline(t, td, "", fs.waitForBlockAndUnblock(filename))
+				return ""
+
+			case "list-fs":
+				var filenames []string
+				for i := range dirs {
+					fns, err := memFS.List(dirs[i])
+					require.NoError(t, err)
+					for _, fn := range fns {
+						filenames = append(filenames, memFS.PathJoin(dirs[i], fn))
+					}
+				}
+				slices.Sort(filenames)
+				var b strings.Builder
+				for _, f := range filenames {
+					fmt.Fprintf(&b, "%s\n", f)
+				}
+				return b.String()
+
+			default:
+				return fmt.Sprintf("unknown command: %s", td.Cmd)
+			}
+		})
+}
+
+func sendWithDeadline(t *testing.T, td *datadriven.TestData, waitStr string, ch chan<- struct{}) {
+	timer := time.NewTimer(20 * time.Second)
+	select {
+	case ch <- struct{}{}:
+		timer.Stop()
+	case <-timer.C:
+		t.Fatalf("send expired at %s %s", td.Pos, waitStr)
+	}
+}
+
+func recvWithDeadline(t *testing.T, td *datadriven.TestData, waitStr string, ch <-chan struct{}) {
+	timer := time.NewTimer(20 * time.Second)
+	select {
+	case <-ch:
+		timer.Stop()
+	case <-timer.C:
+		t.Fatalf("send expired at %s %s", td.Pos, waitStr)
+	}
+}
+
+// TODO(sumeer): test wrap around of history in dirProber.
+
+// TODO(sumeer): the failover datadriven test cases are not easy to write,
+// since we need to wait until all activities triggered by manualTime.advance
+// are complete. Currently this is done by waiting on various channels etc.
+// which exposes implementation detail. See concurrency_test.monitor, in
+// CockroachDB, for an alternative.

--- a/wal/testdata/dir_prober
+++ b/wal/testdata/dir_prober
@@ -1,0 +1,99 @@
+# First write to probe file has error.
+init interval=200ms inject-errors=((ErrInjected (And Writes (PathMatch "foo") (OnIndex 0))))
+----
+
+enable wait
+----
+enabled
+
+# No history, so mean and max is failedProbeDuration.
+get-mean-max dur=400ms
+----
+mean: 24h0m0s, max: 24h0m0s, state:
+
+# One probe attempt, which resulted in error.
+advance-time dur=300ms wait
+----
+now: 300ms
+
+# History records a failedProbeDuration.
+get-mean-max dur=400ms
+----
+mean: 24h0m0s, max: 24h0m0s, state: 0: 24h0m0s
+
+# Second probe attempt. Succeeds in 0s.
+advance-time dur=200ms wait
+----
+now: 500ms
+
+# History has two attempts.
+get-mean-max dur=400ms
+----
+mean: 12h0m0s, max: 24h0m0s, state: 0: 24h0m0s 1: 0s
+
+# Not enough history for 401ms.
+get-mean-max dur=401ms
+----
+mean: 24h0m0s, max: 24h0m0s, state: 0: 24h0m0s 1: 0s
+
+# Block both write and sync.
+block-io-config
+----
+
+advance-time dur=200ms
+----
+now: 700ms
+
+# Unblock the write. And we know that write was waiting.
+wait-for-and-unblock-io
+----
+
+# History is unchanged, since sync is blocked.
+get-mean-max dur=600ms
+----
+mean: 24h0m0s, max: 24h0m0s, state: 0: 24h0m0s 1: 0s
+
+advance-time dur=60ms
+----
+now: 760ms
+
+# Unblock the sync. 60ms of latency was incurred.
+wait-for-and-unblock-io
+----
+
+# Wait for the history to be updated.
+advance-time dur=0ms wait
+----
+now: 760ms
+
+block-io-config unblock
+----
+
+# History has the third sample with 60ms latency.
+get-mean-max dur=600ms
+----
+mean: 8h0m0.02s, max: 24h0m0s, state: 0: 24h0m0s 1: 0s 2: 60ms
+
+# Insufficient history.
+get-mean-max dur=1s
+----
+mean: 24h0m0s, max: 24h0m0s, state: 0: 24h0m0s 1: 0s 2: 60ms
+
+# One sample is sufficient.
+get-mean-max dur=200ms
+----
+mean: 60ms, max: 60ms, state: 0: 24h0m0s 1: 0s 2: 60ms
+
+# Use last two samples.
+get-mean-max dur=201ms
+----
+mean: 30ms, max: 60ms, state: 0: 24h0m0s 1: 0s 2: 60ms
+
+disable wait
+----
+disabled
+
+# No samples.
+get-mean-max dur=600ms
+----
+mean: 24h0m0s, max: 24h0m0s, state:

--- a/wal/testdata/failover_writer/blocking
+++ b/wal/testdata/failover_writer/blocking
@@ -74,7 +74,10 @@ offset: 35
 # See if first log writer is blocked on write and indicating ongoing latency.
 # Because we did not request a sync, the log writer is not trying to do a
 # write. But the record is in the log writer's buffer.
-ongoing-latency writer-index=0
+#
+# TODO(sumeer): this flakes under stress, with the flushLoop picking up the
+# write even though it should not. Fix or remove.
+ongoing-latency writer-index=0 none
 ----
 no ongoing
 
@@ -88,17 +91,29 @@ switch
 ----
 ok
 
+# We did not request a sync, so we have a race where sometimes the flush loop
+# will see the record, and sometimes it won't yet, which leads to
+# non-determinism in this test. To make it deterministic, we add two more
+# records.
+write sync=true value=sheep print-offset
+----
+offset: 51
+
+write sync=false value=yak print-offset
+----
+offset: 65
+
 # Ensure second log writer is blocked on write and indicating ongoing latency.
 ongoing-latency writer-index=1
 ----
 found ongoing
 
-# Close can complete when second log writer writes the second record, but it
-# is blocked.
+# Close can complete when second log writer writes the records, but it is
+# blocked.
 close-async
 ----
 
-# Unblock writes on second log file
+# Unblock writes on second log file.
 wait-for-and-unblock filename=000001-001.log
 ----
 
@@ -113,11 +128,13 @@ wait-for-queue length=0
 # Ensure close succeeds. First writer is still blocked.
 wait-for-close do-not-stop-goroutines
 ----
-close: ok, offset: 35
+close: ok, offset: 65
 records:
   record 0: synced
   record 1: no sync
-write bytes metric: 29
+  record 2: synced
+  record 3: no sync
+write bytes metric: 59
 
 # Do a noop switch.
 switch
@@ -147,6 +164,8 @@ log files:
     EOF
   sec/000001-001.log
     0: mammoth
+    18: sheep
+    34: yak
     EOF
 log writers:
   writer 0: no error

--- a/wal/testdata/failover_writer/errors
+++ b/wal/testdata/failover_writer/errors
@@ -111,6 +111,11 @@ log writers:
 
 # Error is injected on sync of first (or first and second) record in first log
 # file.
+#
+# TODO(sumeer): this flakes under stress, with the primary file occasionally
+# containing woolly. Index 0 is create, index 1 is write, and index 2 is the
+# earliest the sync can happen, so this should work. Fix this or disable this
+# test case.
 init inject-errors=((ErrInjected (And Writes (PathMatch "*/000003.log") (OnIndex 2))))
 ----
 

--- a/wal/testdata/manager_failover
+++ b/wal/testdata/manager_failover
@@ -1,0 +1,387 @@
+# Simple test case that constructs two writers with no errors or latency.
+init-manager
+----
+ok
+
+# Wait for monitor ticker to start.
+advance-time dur=1ms wait-monitor
+----
+monitor state: dir index: 0
+now: 1ms
+
+create-writer wal-num=1
+----
+ok
+
+# Ensure LogWriter is created, so that it does not race with advance-time
+# below.
+advance-time dur=0ms wait-for-log-writer
+----
+now: 1ms
+
+# Wait for monitor tick. Still using primary dir.
+advance-time dur=75ms wait-monitor
+----
+monitor state: dir index: 0 num-switches: 0, ongoing-latency-at-switch: 0s
+now: 76ms
+
+close-writer
+----
+ok
+
+list-fs
+----
+pri/000001.log
+
+create-writer wal-num=2
+----
+ok
+
+close-writer
+----
+ok
+
+elevate-write-stall-threshold
+----
+false
+
+list-fs
+----
+pri/000001.log
+pri/000002.log
+
+close-manager
+----
+ok
+
+# Test where error on first log file creation causes switch to secondary, and
+# the secondary creation blocks for too long, causing switch back to the
+# primary.
+init-manager inject-errors=((ErrInjected (And Writes (PathMatch "*/000001.log") (OnIndex 0))))
+----
+ok
+
+block-io-config filename=000001-001.log create
+----
+000001-001.log: 0b1
+
+# Wait for monitor ticker to start.
+advance-time dur=1ms wait-monitor
+----
+monitor state: dir index: 0
+now: 1ms
+
+create-writer wal-num=1
+----
+ok
+
+# Wait until create error has been noticed.
+advance-time dur=1ms wait-ongoing-io wait-for-log-writer
+----
+now: 2ms
+
+# Wait until monitor sees the error and switches to secondary.
+advance-time dur=75ms wait-monitor wait-prober
+----
+monitor state: dir index: 1 num-switches: 1, ongoing-latency-at-switch: 0s
+prober state:
+now: 77ms
+
+# The switch to secondary blocks on creation.
+advance-time dur=0ms wait-ongoing-io
+----
+now: 77ms
+
+elevate-write-stall-threshold
+----
+true
+
+# Wait until monitor sees the slowness and switches back to primary.
+advance-time dur=80ms wait-monitor wait-prober wait-for-log-writer
+----
+monitor state: dir index: 0 failback time: 157ms num-switches: 2, ongoing-latency-at-switch: 80ms
+prober state:
+now: 157ms
+
+# Unblock creation on secondary.
+wait-for-and-unblock-io filename=000001-001.log
+----
+
+advance-time dur=1s
+----
+now: 1.157s
+
+elevate-write-stall-threshold
+----
+true
+
+close-writer
+----
+ok
+
+elevate-write-stall-threshold
+----
+true
+
+advance-time dur=10s
+----
+now: 11.157s
+
+elevate-write-stall-threshold
+----
+false
+
+create-writer wal-num=2
+----
+ok
+
+close-writer
+----
+ok
+
+close-manager
+----
+ok
+
+list-fs
+----
+pri/000001-002.log
+pri/000002.log
+sec/000001-001.log
+
+# Test with dampening of switching based on latency and secondary errors.
+#
+# Error in creation of files in the secondary.
+init-manager inject-errors=((ErrInjected (And Writes (PathMatch "sec/*.log"))))
+----
+ok
+
+# Block creation of the first 3 files in the primary.
+block-io-config filename=000001.log create
+----
+000001.log: 0b1
+
+block-io-config filename=000001-002.log create
+----
+000001-002.log: 0b1
+
+block-io-config filename=000001-004.log create
+----
+000001-004.log: 0b1
+
+# Wait for monitor ticker to start.
+advance-time dur=1ms wait-monitor
+----
+monitor state: dir index: 0
+now: 1ms
+
+create-writer wal-num=1
+----
+ok
+
+# Blocked in creation.
+advance-time dur=0ms wait-ongoing-io
+----
+now: 1ms
+
+# Wait until monitor sees the slowness and switches to secondary.
+advance-time dur=76ms wait-monitor wait-prober
+----
+monitor state: dir index: 1 num-switches: 1, ongoing-latency-at-switch: 76ms
+prober state:
+now: 77ms
+
+elevate-write-stall-threshold
+----
+true
+
+# Wait for the error.
+advance-time dur=0ms wait-ongoing-io wait-for-log-writer
+----
+now: 77ms
+
+list-fs
+----
+
+# Wait until monitor sees the error and switches back to primary.
+advance-time dur=75ms wait-monitor wait-prober
+----
+monitor state: dir index: 0 failback time: 152ms num-switches: 2, ongoing-latency-at-switch: 76ms
+prober state:
+now: 152ms
+
+# Blocked in creation.
+advance-time dur=0ms wait-ongoing-io
+----
+now: 152ms
+
+# Monitor sees the slowness but since latency is < 2*76ms, does not switch.
+advance-time dur=77ms wait-monitor
+----
+monitor state: dir index: 0 failback time: 152ms num-switches: 2, ongoing-latency-at-switch: 76ms
+now: 229ms
+
+# Wait until monitor sees the slowness and switches to secondary.
+advance-time dur=77ms wait-monitor wait-prober
+----
+monitor state: dir index: 1 failback time: 152ms num-switches: 3, ongoing-latency-at-switch: 154ms
+prober state:
+now: 306ms
+
+# Wait for the error.
+advance-time dur=0ms wait-ongoing-io wait-for-log-writer
+----
+now: 306ms
+
+# Wait until monitor sees the error and switches back to primary.
+advance-time dur=75ms wait-monitor wait-prober
+----
+monitor state: dir index: 0 failback time: 381ms num-switches: 4, ongoing-latency-at-switch: 154ms
+prober state:
+now: 381ms
+
+# Blocked in creation.
+advance-time dur=0ms wait-ongoing-io
+----
+now: 381ms
+
+advance-time dur=78ms wait-monitor
+----
+monitor state: dir index: 0 failback time: 381ms num-switches: 4, ongoing-latency-at-switch: 154ms
+now: 459ms
+
+advance-time dur=78ms wait-monitor
+----
+monitor state: dir index: 0 failback time: 381ms num-switches: 4, ongoing-latency-at-switch: 154ms
+now: 537ms
+
+advance-time dur=78ms wait-monitor
+----
+monitor state: dir index: 0 failback time: 381ms num-switches: 4, ongoing-latency-at-switch: 154ms
+now: 615ms
+
+advance-time dur=78ms wait-monitor
+----
+monitor state: dir index: 0 failback time: 381ms num-switches: 4, ongoing-latency-at-switch: 154ms
+now: 693ms
+
+# Unblock everything.
+block-io-config filename=000001.log
+----
+000001.log: 0b0
+
+block-io-config filename=000001-002.log
+----
+000001-002.log: 0b0
+
+block-io-config filename=000001-004.log
+----
+000001-004.log: 0b0
+
+close-writer
+----
+ok
+
+close-manager
+----
+ok
+
+list-fs
+----
+pri/000001-002.log
+pri/000001-004.log
+pri/000001.log
+
+# Test failback after primary is healthy.
+init-manager inject-errors=((ErrInjected (And Writes (PathMatch "*/000001.log"))))
+----
+ok
+
+# Wait for monitor ticker to start.
+advance-time dur=0ms wait-monitor
+----
+monitor state: dir index: 0
+now: 0s
+
+create-writer wal-num=1
+----
+ok
+
+# Wait until create error has been noticed.
+advance-time dur=1ms wait-ongoing-io wait-for-log-writer
+----
+now: 1ms
+
+# Wait until monitor sees the error and switches to secondary.
+advance-time dur=74ms wait-monitor wait-prober wait-for-log-writer
+----
+monitor state: dir index: 1 num-switches: 1, ongoing-latency-at-switch: 0s
+prober state:
+now: 75ms
+
+elevate-write-stall-threshold
+----
+true
+
+# Monitor will tick at 75ms, 150ms, 225ms, 300ms, ...
+# Prober will tick at 175ms, 275ms.
+#
+# We have already ensure the secondary is created, to ensure that creation
+# does not race with the advancement of time (otherwise we can accidentally
+# observe 75ms latency on the creation).
+
+advance-time dur=75ms wait-monitor
+----
+monitor state: dir index: 1 num-switches: 1, ongoing-latency-at-switch: 0s
+now: 150ms
+
+advance-time dur=25ms wait-prober
+----
+prober state: 0: 0s
+now: 175ms
+
+advance-time dur=50ms wait-monitor
+----
+monitor state: dir index: 1 num-switches: 1, ongoing-latency-at-switch: 0s
+now: 225ms
+
+advance-time dur=50ms wait-prober
+----
+prober state: 0: 0s 1: 0s
+now: 275ms
+
+advance-time dur=25ms wait-monitor wait-prober wait-for-log-writer
+----
+monitor state: dir index: 0 failback time: 300ms num-switches: 2, ongoing-latency-at-switch: 0s
+prober state:
+now: 300ms
+
+advance-time dur=1s
+----
+now: 1.3s
+
+elevate-write-stall-threshold
+----
+true
+
+advance-time dur=9s
+----
+now: 10.3s
+
+elevate-write-stall-threshold
+----
+false
+
+close-writer
+----
+ok
+
+close-manager
+----
+ok
+
+list-fs
+----
+pri/000001-002.log
+pri/probe-file
+sec/000001-001.log


### PR DESCRIPTION
failover_manager.go contains the failoverManager (which implements
wal.Manager) for the write path, and helper classes. dirProber monitors
the primary dir when failed over to use the secondary, to decide when to
failback to the primary. failoverMonitor uses the latency and error seen
by the current *LogWriter, and probing state, to decide when to switch to
a different dir.

Informs #3230

Informs CRDB-35401