### PR TITLE
base: clean up FileNum <-> DiskFileNum conversions

### DIFF
--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -285,7 +285,7 @@ func TestCheckpointCompaction(t *testing.T) {
 					if tbl.Virtual {
 						continue
 					}
-					if _, err := fs.Stat(base.MakeFilepath(fs, dir, base.FileTypeTable, tbl.FileNum.DiskFileNum())); err != nil {
+					if _, err := fs.Stat(base.MakeFilepath(fs, dir, base.FileTypeTable, base.PhysicalTableDiskFileNum(tbl.FileNum))); err != nil {
 						t.Error(err)
 						return
 					}

--- a/db.go
+++ b/db.go
@@ -2241,7 +2241,7 @@ type SSTableInfo struct {
 	// Virtual indicates whether the sstable is virtual.
 	Virtual bool
 	// BackingSSTNum is the disk file number associated with the backing sstable.
-	// If Virtual is false, BackingSSTNum == FileNum.DiskFileNum().
+	// If Virtual is false, BackingSSTNum == PhysicalTableDiskFileNum(FileNum).
 	BackingSSTNum base.DiskFileNum
 	// BackingType is the type of storage backing this sstable.
 	BackingType BackingType

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -167,7 +167,7 @@ func TestIngestLoadRand(t *testing.T) {
 		paths[i] = fmt.Sprint(i)
 		pending[i] = base.DiskFileNum(rng.Uint64())
 		expected[i] = &fileMetadata{
-			FileNum: pending[i].FileNum(),
+			FileNum: base.PhysicalTableFileNum(pending[i]),
 		}
 		expected[i].StatsMarkValid()
 
@@ -1248,13 +1248,13 @@ func TestSimpleIngestShared(t *testing.T) {
 	{
 		// Create a shared file.
 		fn := base.FileNum(2)
-		f, meta, err := provider2.Create(context.TODO(), fileTypeTable, fn.DiskFileNum(), objstorage.CreateOptions{PreferSharedStorage: true})
+		f, meta, err := provider2.Create(context.TODO(), fileTypeTable, base.PhysicalTableDiskFileNum(fn), objstorage.CreateOptions{PreferSharedStorage: true})
 		require.NoError(t, err)
 		w := sstable.NewWriter(f, d.opts.MakeWriterOptions(0, d.opts.FormatMajorVersion.MaxTableFormat()))
 		w.Set([]byte("d"), []byte("shared"))
 		w.Set([]byte("e"), []byte("shared"))
 		w.Close()
-		metaMap[fn.DiskFileNum()] = meta
+		metaMap[base.PhysicalTableDiskFileNum(fn)] = meta
 	}
 
 	m := metaMap[base.DiskFileNum(2)]
@@ -3168,7 +3168,7 @@ func TestIngestCleanup(t *testing.T) {
 			// Create the files in the VFS.
 			metaMap := make(map[base.FileNum]objstorage.Writable)
 			for _, fn := range fns {
-				w, _, err := objProvider.Create(context.Background(), base.FileTypeTable, fn.DiskFileNum(), objstorage.CreateOptions{})
+				w, _, err := objProvider.Create(context.Background(), base.FileTypeTable, base.PhysicalTableDiskFileNum(fn), objstorage.CreateOptions{})
 				require.NoError(t, err)
 
 				metaMap[fn] = w

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -422,7 +422,10 @@ func (m *FileMetadata) InitPhysicalBacking() {
 		panic("pebble: virtual sstables should use a pre-existing FileBacking")
 	}
 	if m.FileBacking == nil {
-		m.FileBacking = &FileBacking{Size: m.Size, DiskFileNum: m.FileNum.DiskFileNum()}
+		m.FileBacking = &FileBacking{
+			DiskFileNum: base.PhysicalTableDiskFileNum(m.FileNum),
+			Size:        m.Size,
+		}
 	}
 }
 

--- a/objstorage/objstorageprovider/remote_backing_test.go
+++ b/objstorage/objstorageprovider/remote_backing_test.go
@@ -153,6 +153,6 @@ func TestAttachRemoteObjects(t *testing.T) {
 	o := objs[0]
 	require.Equal(t, remote.Locator("foo"), o.Remote.Locator)
 	require.Equal(t, "custom-obj-name", o.Remote.CustomObjectName)
-	require.Equal(t, uint64(100), uint64(o.DiskFileNum.FileNum()))
+	require.Equal(t, uint64(100), uint64(o.DiskFileNum))
 	require.Equal(t, base.FileTypeTable, o.FileType)
 }

--- a/objstorage/objstorageprovider/remoteobjcat/catalog_test.go
+++ b/objstorage/objstorageprovider/remoteobjcat/catalog_test.go
@@ -58,7 +58,7 @@ func TestCatalog(t *testing.T) {
 			if len(args) != 1 {
 				td.Fatalf(t, "delete <file-num>")
 			}
-			return base.FileNum(toUInt64(args[0])[0]).DiskFileNum()
+			return base.DiskFileNum(toUInt64(args[0])[0])
 		}
 
 		memLog.Reset()

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -822,7 +822,7 @@ func (r *Runner) prepareWorkloadSteps(ctx context.Context) error {
 				// corresponding sstables before being terminated.
 				if s.kind == flushStepKind || s.kind == ingestStepKind {
 					for _, fileNum := range newFiles {
-						if _, ok := r.workload.sstables[fileNum.FileNum()]; !ok {
+						if _, ok := r.workload.sstables[base.PhysicalTableFileNum(fileNum)]; !ok {
 							// TODO(jackson,leon): This isn't exactly an error
 							// condition. Give this more thought; do we want to
 							// require graceful exiting of workload collection,
@@ -907,7 +907,7 @@ func findWorkloadFiles(
 		case base.FileTypeManifest:
 			manifests = append(manifests, dirent)
 		case base.FileTypeTable:
-			sstables[fileNum.FileNum()] = struct{}{}
+			sstables[base.PhysicalTableFileNum(fileNum)] = struct{}{}
 		}
 	}
 	if len(manifests) == 0 {

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -168,7 +168,7 @@ func TestLoadFlushedSSTableKeys(t *testing.T) {
 		EventListener: &pebble.EventListener{
 			FlushEnd: func(info pebble.FlushInfo) {
 				for _, tbl := range info.Output {
-					diskFileNums = append(diskFileNums, tbl.FileNum.DiskFileNum())
+					diskFileNums = append(diskFileNums, base.PhysicalTableDiskFileNum(tbl.FileNum))
 				}
 			},
 		},

--- a/replay/workload_capture_test.go
+++ b/replay/workload_capture_test.go
@@ -95,7 +95,7 @@ func TestWorkloadCollector(t *testing.T) {
 					require.NoError(t, err)
 					tableInfo.FileNum = base.FileNum(fileNum)
 
-					p := writeFile(t, fs, srcDir, base.FileTypeTable, tableInfo.FileNum.DiskFileNum(), randData(int(tableInfo.Size)))
+					p := writeFile(t, fs, srcDir, base.FileTypeTable, base.PhysicalTableDiskFileNum(tableInfo.FileNum), randData(int(tableInfo.Size)))
 					fmt.Fprintf(&buf, "created %s\n", p)
 					flushInfo.Output = append(flushInfo.Output, tableInfo)
 
@@ -120,7 +120,7 @@ func TestWorkloadCollector(t *testing.T) {
 					require.NoError(t, err)
 					tableInfo.FileNum = base.FileNum(fileNum)
 
-					p := writeFile(t, fs, srcDir, base.FileTypeTable, tableInfo.FileNum.DiskFileNum(), randData(int(tableInfo.Size)))
+					p := writeFile(t, fs, srcDir, base.FileTypeTable, base.PhysicalTableDiskFileNum(tableInfo.FileNum), randData(int(tableInfo.Size)))
 					fmt.Fprintf(&buf, "created %s\n", p)
 					ingestInfo.Tables = append(ingestInfo.Tables, struct {
 						pebble.TableInfo

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -1020,8 +1020,7 @@ func TestTableCacheErrorBadMagicNumber(t *testing.T) {
 	const testFileNum = 3
 	objProvider, err := objstorageprovider.Open(objstorageprovider.DefaultSettings(fs, ""))
 	require.NoError(t, err)
-	w, _, err := objProvider.Create(context.Background(), fileTypeTable,
-		base.FileNum(testFileNum).DiskFileNum(), objstorage.CreateOptions{})
+	w, _, err := objProvider.Create(context.Background(), fileTypeTable, testFileNum, objstorage.CreateOptions{})
 	w.Write(buf)
 	require.NoError(t, w.Finish())
 	opts := &Options{}


### PR DESCRIPTION
We rename the methods to `PhysicalTableDiskFileNum` and
`PhysicalTableFileNum` which makes the assumption behind the
conversion evident at every call site. We also clean up some
unnecessary conversions and improve some relevant comments.