### PR TITLE
db: fix sstable bound inversion in ingestSynthesizeShared

### DIFF
--- a/testdata/ingest_shared
+++ b/testdata/ingest_shared
@@ -1240,3 +1240,60 @@ c: (., [c-cc) @7=foo UPDATED)
 dd: (., [dd-e) @7=foo UPDATED)
 .
 .
+
+# Regression test for https://github.com/cockroachdb/pebble/issues/3225
+# Handle cases where an sstable starts and ends at the same user key but different
+# internal key, and the ordering of internal key kinds changes due to seqnum
+# substitution.
+
+reset
+----
+
+switch 1
+----
+ok
+
+batch
+set a foo
+----
+
+file-only-snapshot s11
+ a z
+----
+ok
+
+batch
+del a
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+lsm
+----
+6:
+  000005:[a#11,DEL-a#10,SET]
+
+replicate 1 2 a z
+----
+replicated 1 shared SSTs
+
+switch 2
+----
+ok
+
+lsm
+----
+6:
+  000005:[a#10,SET-a#10,DEL]
+
+iter
+first
+next
+----
+.
+.


### PR DESCRIPTION
Previously, for shared file ingestions, we could have seqnum substitution result in invalid bounds (eg. smallest > largest). This change detects this case as an artifact of seqnum substitution and addresses it.

Fixes #3225.