### PR TITLE
objstorage: simplify AttachRemoteObjects

### DIFF
--- a/flushable_test.go
+++ b/flushable_test.go
@@ -83,7 +83,7 @@ func TestIngestedSSTFlushableAPI(t *testing.T) {
 		// (e.g. because the files reside on a different filesystem), ingestLink will
 		// fall back to copying, and if that fails we undo our work and return an
 		// error.
-		if err := ingestLink(jobID, d.opts, d.objProvider, lr, nil /* shared */); err != nil {
+		if err := ingestLink(jobID, d.opts, d.objProvider, lr, nil /* shared */, nil /* external */); err != nil {
 			panic("couldn't hard link sstables")
 		}
 

--- a/flushable_test.go
+++ b/flushable_test.go
@@ -48,9 +48,9 @@ func TestIngestedSSTFlushableAPI(t *testing.T) {
 
 	loadFileMeta := func(paths []string) []*fileMetadata {
 		d.mu.Lock()
-		pendingOutputs := make([]base.DiskFileNum, len(paths))
+		pendingOutputs := make([]base.FileNum, len(paths))
 		for i := range paths {
-			pendingOutputs[i] = d.mu.versions.getNextDiskFileNum()
+			pendingOutputs[i] = d.mu.versions.getNextFileNum()
 		}
 		jobID := d.mu.nextJobID
 		d.mu.nextJobID++

--- a/ingest.go
+++ b/ingest.go
@@ -99,7 +99,7 @@ func ingestValidateKey(opts *Options, key *InternalKey) error {
 // ingestSynthesizeShared constructs a fileMetadata for one shared sstable owned
 // or shared by another node.
 func ingestSynthesizeShared(
-	opts *Options, sm SharedSSTMeta, fileNum base.DiskFileNum,
+	opts *Options, sm SharedSSTMeta, fileNum base.FileNum,
 ) (*fileMetadata, error) {
 	if sm.Size == 0 {
 		// Disallow 0 file sizes
@@ -108,14 +108,14 @@ func ingestSynthesizeShared(
 	// Don't load table stats. Doing a round trip to shared storage, one SST
 	// at a time is not worth it as it slows down ingestion.
 	meta := &fileMetadata{
-		// For simplicity, we use the same number for both the FileNum and the
-		// DiskFileNum (even though this is a virtual sstable).
-		FileNum:      FileNum(fileNum),
+		FileNum:      fileNum,
 		CreationTime: time.Now().Unix(),
 		Virtual:      true,
 		Size:         sm.Size,
 	}
-	meta.InitProviderBacking(fileNum)
+	// For simplicity, we use the same number for both the FileNum and the
+	// DiskFileNum (even though this is a virtual sstable).
+	meta.InitProviderBacking(base.DiskFileNum(fileNum))
 	// Set the underlying FileBacking's size to the same size as the virtualized
 	// view of the sstable. This ensures that we don't over-prioritize this
 	// sstable for compaction just yet, as we do not have a clear sense of what
@@ -166,11 +166,7 @@ func ingestSynthesizeShared(
 // ingestLoad1External loads the fileMetadata for one external sstable.
 // Sequence number and target level calculation happens during prepare/apply.
 func ingestLoad1External(
-	opts *Options,
-	e ExternalFile,
-	fileNum base.DiskFileNum,
-	objProvider objstorage.Provider,
-	jobID int,
+	opts *Options, e ExternalFile, fileNum base.FileNum, objProvider objstorage.Provider, jobID int,
 ) (*fileMetadata, error) {
 	if e.Size == 0 {
 		// Disallow 0 file sizes
@@ -182,14 +178,14 @@ func ingestLoad1External(
 	// Don't load table stats. Doing a round trip to shared storage, one SST
 	// at a time is not worth it as it slows down ingestion.
 	meta := &fileMetadata{
-		// For simplicity, we use the same number for both the FileNum and the
-		// DiskFileNum (even though this is a virtual sstable).
-		FileNum:      FileNum(fileNum),
+		FileNum:      fileNum,
 		CreationTime: time.Now().Unix(),
 		Virtual:      true,
 		Size:         e.Size,
 	}
-	meta.InitProviderBacking(fileNum)
+	// For simplicity, we use the same number for both the FileNum and the
+	// DiskFileNum (even though this is a virtual sstable).
+	meta.InitProviderBacking(base.DiskFileNum(fileNum))
 
 	// Try to resolve a reference to the external file.
 	backing, err := objProvider.CreateExternalObjectBacking(e.Locator, e.ObjName)
@@ -197,7 +193,7 @@ func ingestLoad1External(
 		return nil, err
 	}
 	metas, err := objProvider.AttachRemoteObjects([]objstorage.RemoteObjectToAttach{{
-		FileNum:  fileNum,
+		FileNum:  meta.FileBacking.DiskFileNum,
 		FileType: fileTypeTable,
 		Backing:  backing,
 	}})
@@ -209,7 +205,7 @@ func ingestLoad1External(
 			JobID:   jobID,
 			Reason:  "ingesting",
 			Path:    objProvider.Path(metas[0]),
-			FileNum: fileNum,
+			FileNum: meta.FileBacking.DiskFileNum,
 		})
 	}
 	// In the name of keeping this ingestion as fast as possible, we avoid
@@ -220,12 +216,18 @@ func ingestLoad1External(
 	largestCopy := make([]byte, len(e.LargestUserKey))
 	copy(largestCopy, e.LargestUserKey)
 	if e.HasPointKey {
-		meta.ExtendPointKeyBounds(opts.Comparer.Compare, base.MakeInternalKey(smallestCopy, 0, InternalKeyKindMax),
-			base.MakeRangeDeleteSentinelKey(largestCopy))
+		meta.ExtendPointKeyBounds(
+			opts.Comparer.Compare,
+			base.MakeInternalKey(smallestCopy, 0, InternalKeyKindMax),
+			base.MakeRangeDeleteSentinelKey(largestCopy),
+		)
 	}
 	if e.HasRangeKey {
-		meta.ExtendRangeKeyBounds(opts.Comparer.Compare, base.MakeInternalKey(smallestCopy, 0, InternalKeyKindRangeKeySet),
-			base.MakeExclusiveSentinelKey(InternalKeyKindRangeKeyDelete, largestCopy))
+		meta.ExtendRangeKeyBounds(
+			opts.Comparer.Compare,
+			base.MakeInternalKey(smallestCopy, 0, InternalKeyKindRangeKeyMax),
+			base.MakeExclusiveSentinelKey(InternalKeyKindRangeKeyMin, largestCopy),
+		)
 	}
 
 	// Set the underlying FileBacking's size to the same size as the virtualized
@@ -254,9 +256,9 @@ func ingestLoad1(
 	fmv FormatMajorVersion,
 	readable objstorage.Readable,
 	cacheID uint64,
-	fileNum base.DiskFileNum,
+	fileNum base.FileNum,
 ) (*fileMetadata, error) {
-	cacheOpts := private.SSTableCacheOpts(cacheID, fileNum).(sstable.ReaderOption)
+	cacheOpts := private.SSTableCacheOpts(cacheID, base.PhysicalTableDiskFileNum(fileNum)).(sstable.ReaderOption)
 	r, err := sstable.NewReader(readable, opts.MakeReaderOptions(), cacheOpts)
 	if err != nil {
 		return nil, err
@@ -276,7 +278,7 @@ func ingestLoad1(
 	}
 
 	meta := &fileMetadata{}
-	meta.FileNum = base.PhysicalTableFileNum(fileNum)
+	meta.FileNum = fileNum
 	meta.Size = uint64(readable.Size())
 	meta.CreationTime = time.Now().Unix()
 	meta.InitPhysicalBacking()
@@ -407,7 +409,7 @@ func ingestLoad(
 	shared []SharedSSTMeta,
 	external []ExternalFile,
 	cacheID uint64,
-	pending []base.DiskFileNum,
+	pending []base.FileNum,
 	objProvider objstorage.Provider,
 	jobID int,
 ) (ingestLoadResult, error) {
@@ -1326,9 +1328,9 @@ func (d *DB) ingest(
 	// ordering. The sorting of L0 tables by sequence number avoids relying on
 	// that (busted) invariant.
 	d.mu.Lock()
-	pendingOutputs := make([]base.DiskFileNum, len(paths)+len(shared)+len(external))
+	pendingOutputs := make([]base.FileNum, len(paths)+len(shared)+len(external))
 	for i := 0; i < len(paths)+len(shared)+len(external); i++ {
-		pendingOutputs[i] = d.mu.versions.getNextDiskFileNum()
+		pendingOutputs[i] = d.mu.versions.getNextFileNum()
 	}
 
 	jobID := d.mu.nextJobID

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -128,7 +128,7 @@ func TestIngestLoad(t *testing.T) {
 				Comparer: DefaultComparer,
 				FS:       mem,
 			}).WithFSDefaults()
-			lr, err := ingestLoad(opts, dbVersion, []string{"ext"}, nil, nil, 0, []base.DiskFileNum{base.DiskFileNum(1)}, nil, 0)
+			lr, err := ingestLoad(opts, dbVersion, []string{"ext"}, nil, nil, 0, []base.FileNum{1}, nil, 0)
 			if err != nil {
 				return err.Error()
 			}
@@ -161,13 +161,13 @@ func TestIngestLoadRand(t *testing.T) {
 	}
 
 	paths := make([]string, 1+rng.Intn(10))
-	pending := make([]base.DiskFileNum, len(paths))
+	pending := make([]base.FileNum, len(paths))
 	expected := make([]*fileMetadata, len(paths))
 	for i := range paths {
 		paths[i] = fmt.Sprint(i)
-		pending[i] = base.DiskFileNum(rng.Uint64())
+		pending[i] = base.FileNum(rng.Uint64())
 		expected[i] = &fileMetadata{
-			FileNum: base.PhysicalTableFileNum(pending[i]),
+			FileNum: pending[i],
 		}
 		expected[i].StatsMarkValid()
 
@@ -235,7 +235,7 @@ func TestIngestLoadInvalid(t *testing.T) {
 		Comparer: DefaultComparer,
 		FS:       mem,
 	}).WithFSDefaults()
-	if _, err := ingestLoad(opts, internalFormatNewest, []string{"invalid"}, nil, nil, 0, []base.DiskFileNum{base.DiskFileNum(1)}, nil, 0); err == nil {
+	if _, err := ingestLoad(opts, internalFormatNewest, []string{"invalid"}, nil, nil, 0, []base.FileNum{1}, nil, 0); err == nil {
 		t.Fatalf("expected error, but found success")
 	}
 }

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -332,7 +332,7 @@ func TestIngestLink(t *testing.T) {
 			}
 
 			lr := ingestLoadResult{localMeta: meta, localPaths: paths}
-			err = ingestLink(0 /* jobID */, opts, objProvider, lr, nil /* shared */)
+			err = ingestLink(0 /* jobID */, opts, objProvider, lr, nil /* shared */, nil /* external */)
 			if i < count {
 				if err == nil {
 					t.Fatalf("expected error, but found success")
@@ -400,7 +400,7 @@ func TestIngestLinkFallback(t *testing.T) {
 	meta := []*fileMetadata{{FileNum: 1}}
 	meta[0].InitPhysicalBacking()
 	lr := ingestLoadResult{localMeta: meta, localPaths: []string{"source"}}
-	err = ingestLink(0, opts, objProvider, lr, nil /* shared */)
+	err = ingestLink(0, opts, objProvider, lr, nil /* shared */, nil /* external */)
 	require.NoError(t, err)
 
 	dest, err := mem.Open("000001.sst")

--- a/internal.go
+++ b/internal.go
@@ -22,6 +22,8 @@ const (
 	InternalKeyKindRangeKeySet     = base.InternalKeyKindRangeKeySet
 	InternalKeyKindRangeKeyUnset   = base.InternalKeyKindRangeKeyUnset
 	InternalKeyKindRangeKeyDelete  = base.InternalKeyKindRangeKeyDelete
+	InternalKeyKindRangeKeyMin     = base.InternalKeyKindRangeKeyMin
+	InternalKeyKindRangeKeyMax     = base.InternalKeyKindRangeKeyMax
 	InternalKeyKindIngestSST       = base.InternalKeyKindIngestSST
 	InternalKeyKindDeleteSized     = base.InternalKeyKindDeleteSized
 	InternalKeyKindInvalid         = base.InternalKeyKindInvalid

--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -80,6 +80,9 @@ const (
 	InternalKeyKindRangeKeyUnset InternalKeyKind = 20
 	InternalKeyKindRangeKeySet   InternalKeyKind = 21
 
+	InternalKeyKindRangeKeyMin InternalKeyKind = InternalKeyKindRangeKeyDelete
+	InternalKeyKindRangeKeyMax InternalKeyKind = InternalKeyKindRangeKeySet
+
 	// InternalKeyKindIngestSST is used to distinguish a batch that corresponds to
 	// the WAL entry for ingested sstables that are added to the flushable
 	// queue. This InternalKeyKind cannot appear, amongst other key kinds in a

--- a/objstorage/objstorage.go
+++ b/objstorage/objstorage.go
@@ -287,6 +287,9 @@ type Provider interface {
 	CreateExternalObjectBacking(locator remote.Locator, objName string) (RemoteObjectBacking, error)
 
 	// AttachRemoteObjects registers existing remote objects with this provider.
+	//
+	// The objects are not guaranteed to be durable (accessible in case of
+	// crashes) until Sync is called.
 	AttachRemoteObjects(objs []RemoteObjectToAttach) ([]ObjectMetadata, error)
 
 	Close() error

--- a/objstorage/objstorageprovider/provider.go
+++ b/objstorage/objstorageprovider/provider.go
@@ -456,11 +456,15 @@ func (p *provider) Metrics() sharedcache.Metrics {
 }
 
 func (p *provider) addMetadata(meta objstorage.ObjectMetadata) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.addMetadataLocked(meta)
+}
+
+func (p *provider) addMetadataLocked(meta objstorage.ObjectMetadata) {
 	if invariants.Enabled {
 		meta.AssertValid()
 	}
-	p.mu.Lock()
-	defer p.mu.Unlock()
 	p.mu.knownObjects[meta.DiskFileNum] = meta
 	if meta.IsRemote() {
 		p.mu.remote.catalogBatch.AddObject(remoteobjcat.RemoteObjectMetadata{

--- a/objstorage/objstorageprovider/remote.go
+++ b/objstorage/objstorageprovider/remote.go
@@ -126,9 +126,9 @@ func (p *provider) sharedClose() error {
 	if p.st.Remote.StorageFactory == nil {
 		return nil
 	}
-	var err error
+	err := p.sharedSync()
 	if p.remote.cache != nil {
-		err = p.remote.cache.Close()
+		err = firstError(err, p.remote.cache.Close())
 		p.remote.cache = nil
 	}
 	if p.remote.catalog != nil {

--- a/objstorage/objstorageprovider/testdata/provider/shared_attach
+++ b/objstorage/objstorageprovider/testdata/provider/shared_attach
@@ -101,7 +101,6 @@ b3 103
 <remote> create object "eaac-1-000003.sst.ref.2.000103"
 <remote> close writer for "eaac-1-000003.sst.ref.2.000103" after 0 bytes
 <remote> size of object "eaac-1-000003.sst.ref.1.000003": 0
-<local fs> sync: p2/REMOTE-OBJ-CATALOG-000001
 000101 -> remote://61a6-1-000001.sst
 000102 -> remote://a629-1-000002.sst
 000103 -> remote://eaac-1-000003.sst

--- a/objstorage/objstorageprovider/testdata/provider/shared_attach_after_unref
+++ b/objstorage/objstorageprovider/testdata/provider/shared_attach_after_unref
@@ -45,7 +45,6 @@ p5b1 101
 <remote> create object "d632-5-000001.sst.ref.6.000101"
 <remote> close writer for "d632-5-000001.sst.ref.6.000101" after 0 bytes
 <remote> size of object "d632-5-000001.sst.ref.5.000001": 0
-<local fs> sync: p6/REMOTE-OBJ-CATALOG-000001
 000101 -> remote://d632-5-000001.sst
 
 switch p5

--- a/objstorage/objstorageprovider/testdata/provider/shared_attach_multi
+++ b/objstorage/objstorageprovider/testdata/provider/shared_attach_multi
@@ -49,7 +49,6 @@ b1 103
 <remote> create object "61a6-1-000001.sst.ref.2.000103"
 <remote> close writer for "61a6-1-000001.sst.ref.2.000103" after 0 bytes
 <remote> size of object "61a6-1-000001.sst.ref.1.000001": 0
-<local fs> sync: p2/REMOTE-OBJ-CATALOG-000001
 000101 -> remote://61a6-1-000001.sst
 000102 -> remote://61a6-1-000001.sst
 000103 -> remote://61a6-1-000001.sst

--- a/objstorage/objstorageprovider/testdata/provider/shared_no_ref
+++ b/objstorage/objstorageprovider/testdata/provider/shared_no_ref
@@ -134,7 +134,6 @@ attach
 b1 101
 b2 102
 ----
-<local fs> sync: p2/REMOTE-OBJ-CATALOG-000001
 000101 -> remote://61a6-1-000001.sst
 000102 -> remote://61a6-1-000001.sst
 

--- a/objstorage/objstorageprovider/testdata/provider/shared_remove
+++ b/objstorage/objstorageprovider/testdata/provider/shared_remove
@@ -66,7 +66,6 @@ b2 102
 <remote> create object "a629-1-000002.sst.ref.2.000102"
 <remote> close writer for "a629-1-000002.sst.ref.2.000102" after 0 bytes
 <remote> size of object "a629-1-000002.sst.ref.1.000002": 0
-<local fs> sync: p2/REMOTE-OBJ-CATALOG-000001
 000101 -> remote://61a6-1-000001.sst
 000102 -> remote://a629-1-000002.sst
 

--- a/open.go
+++ b/open.go
@@ -929,7 +929,7 @@ func (d *DB) replayWAL(
 						}
 					}
 					// NB: ingestLoad1 will close readable.
-					meta[i], err = ingestLoad1(d.opts, d.FormatMajorVersion(), readable, d.cacheID, n)
+					meta[i], err = ingestLoad1(d.opts, d.FormatMajorVersion(), readable, d.cacheID, base.PhysicalTableFileNum(n))
 					if err != nil {
 						return nil, 0, errors.Wrap(err, "pebble: error when loading flushable ingest files")
 					}


### PR DESCRIPTION
#### ingest: use FileNum instead of DiskNum when loading tables

We pass around pending `FileNum`s instead of `DiskFileNum`s, which
better matches the usage.

#### ingest: attach external objects at link time

Move the attaching of external objects to the link phase. We already
attach the shared objects at this phase. We now attach all remote
objects with a single call.

#### objstorage: simplify AttachRemoteObjects

Simplify `AttachRemoteObjects` to not call `sharedSync`. We already
call `Sync` as part of ingestion.

Add a call `sharedSync` when closing the provider (this should be a
no-op in practice, other than tests).