### PR TITLE
sstable: add block level synthetic prefix support

### DIFF
--- a/sstable/block.go
+++ b/sstable/block.go
@@ -5,6 +5,7 @@
 package sstable
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"unsafe"
@@ -404,20 +405,22 @@ type blockIter struct {
 	cachedBuf []byte
 	handle    bufferHandle
 	// for block iteration for already loaded blocks.
-	firstUserKey      []byte
-	lazyValueHandling struct {
+	firstUserKey           []byte
+	firstUserKeyWithPrefix []byte
+	lazyValueHandling      struct {
 		vbr            *valueBlockReader
 		hasValuePrefix bool
 	}
 	hideObsoletePoints bool
+	prefix             SyntheticPrefix
 }
 
 // blockIter implements the base.InternalIterator interface.
 var _ base.InternalIterator = (*blockIter)(nil)
 
-func newBlockIter(cmp Compare, block block) (*blockIter, error) {
+func newBlockIter(cmp Compare, block block, syntheticPrefix SyntheticPrefix) (*blockIter, error) {
 	i := &blockIter{}
-	return i, i.init(cmp, block, 0, false)
+	return i, i.init(cmp, block, 0, false, syntheticPrefix)
 }
 
 func (i *blockIter) String() string {
@@ -425,19 +428,24 @@ func (i *blockIter) String() string {
 }
 
 func (i *blockIter) init(
-	cmp Compare, block block, globalSeqNum uint64, hideObsoletePoints bool,
+	cmp Compare, block block, globalSeqNum uint64, hideObsoletePoints bool, syntheticPrefix SyntheticPrefix,
 ) error {
 	numRestarts := int32(binary.LittleEndian.Uint32(block[len(block)-4:]))
 	if numRestarts == 0 {
 		return base.CorruptionErrorf("pebble/table: invalid table (block has no restart points)")
 	}
+	i.prefix = syntheticPrefix
 	i.cmp = cmp
 	i.restarts = int32(len(block)) - 4*(1+numRestarts)
 	i.numRestarts = numRestarts
 	i.globalSeqNum = globalSeqNum
 	i.ptr = unsafe.Pointer(&block[0])
 	i.data = block
-	i.fullKey = i.fullKey[:0]
+	if i.prefix != nil {
+		i.fullKey = append(i.fullKey[:0], i.prefix...)
+	} else {
+		i.fullKey = i.fullKey[:0]
+	}
 	i.val = nil
 	i.hideObsoletePoints = hideObsoletePoints
 	i.clearCache()
@@ -457,11 +465,11 @@ func (i *blockIter) init(
 //     ingested.
 //   - Foreign sstable iteration: globalSeqNum is always set.
 func (i *blockIter) initHandle(
-	cmp Compare, block bufferHandle, globalSeqNum uint64, hideObsoletePoints bool,
+	cmp Compare, block bufferHandle, globalSeqNum uint64, hideObsoletePoints bool, syntheticPrefix SyntheticPrefix,
 ) error {
 	i.handle.Release()
 	i.handle = block
-	return i.init(cmp, block.Get(), globalSeqNum, hideObsoletePoints)
+	return i.init(cmp, block.Get(), globalSeqNum, hideObsoletePoints, syntheticPrefix)
 }
 
 func (i *blockIter) invalidate() {
@@ -482,10 +490,11 @@ func (i *blockIter) isDataInvalidated() bool {
 
 func (i *blockIter) resetForReuse() blockIter {
 	return blockIter{
-		fullKey:   i.fullKey[:0],
-		cached:    i.cached[:0],
-		cachedBuf: i.cachedBuf[:0],
-		data:      nil,
+		fullKey:                i.fullKey[:0],
+		cached:                 i.cached[:0],
+		cachedBuf:              i.cachedBuf[:0],
+		firstUserKeyWithPrefix: i.firstUserKeyWithPrefix[:0],
+		data:                   nil,
 	}
 }
 
@@ -557,6 +566,7 @@ func (i *blockIter) readEntry() {
 		ptr = unsafe.Pointer(uintptr(ptr) + 5)
 	}
 
+	shared += uint32(len(i.prefix))
 	unsharedKey := getBytes(ptr, int(unshared))
 	// TODO(sumeer): move this into the else block below.
 	i.fullKey = append(i.fullKey[:shared], unsharedKey...)
@@ -633,6 +643,9 @@ func (i *blockIter) readFirstKey() error {
 		i.firstUserKey = nil
 		return base.CorruptionErrorf("pebble/table: invalid firstKey in block")
 	}
+	if i.prefix != nil {
+		i.firstUserKey = append(append(i.firstUserKeyWithPrefix[:0], i.prefix...), i.firstUserKey...)
+	}
 	return nil
 }
 
@@ -691,6 +704,17 @@ func (i *blockIter) getFirstUserKey() []byte {
 func (i *blockIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, base.LazyValue) {
 	if invariants.Enabled && i.isDataInvalidated() {
 		panic(errors.AssertionFailedf("invalidated blockIter used"))
+	}
+
+	searchKey := key
+	if i.prefix != nil {
+		if !bytes.HasPrefix(key, i.prefix) {
+			if i.cmp(i.prefix, key) >= 0 {
+				return i.First()
+			}
+			return nil, base.LazyValue{}
+		}
+		searchKey = key[len(i.prefix):]
 	}
 
 	i.clearCache()
@@ -756,7 +780,7 @@ func (i *blockIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, ba
 			}
 			// Else k is invalid, and left as nil
 
-			if i.cmp(key, k) > 0 {
+			if i.cmp(searchKey, k) > 0 {
 				// The search key is greater than the user key at this restart point.
 				// Search beyond this restart point, since we are trying to find the
 				// first restart point with a user key >= the search key.
@@ -833,6 +857,17 @@ func (i *blockIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, ba
 	var index int32
 
 	{
+		searchKey := key
+		if i.prefix != nil {
+			if !bytes.HasPrefix(key, i.prefix) {
+				if i.cmp(i.prefix, key) < 0 {
+					return i.Last()
+				}
+				return nil, base.LazyValue{}
+			}
+			searchKey = key[len(i.prefix):]
+		}
+
 		// NB: manually inlined sort.Search is ~5% faster.
 		//
 		// Define f(-1) == false and f(n) == true.
@@ -889,7 +924,7 @@ func (i *blockIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, ba
 			}
 			// Else k is invalid, and left as nil
 
-			if i.cmp(key, k) > 0 {
+			if i.cmp(searchKey, k) > 0 {
 				// The search key is greater than the user key at this restart point.
 				// Search beyond this restart point, since we are trying to find the
 				// first restart point with a user key >= the search key.
@@ -1225,6 +1260,9 @@ func (i *blockIter) nextPrefixV3(succKey []byte) (*InternalKey, base.LazyValue) 
 			d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
 			value = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 			ptr = unsafe.Pointer(uintptr(ptr) + 5)
+		}
+		if i.prefix != nil {
+			shared += uint32(len(i.prefix))
 		}
 		// The starting position of the value.
 		valuePtr := unsafe.Pointer(uintptr(ptr) + uintptr(unshared))

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -938,7 +938,7 @@ func TestBlockProperties(t *testing.T) {
 
 					var blocks []int
 					var i int
-					iter, _ := newBlockIter(r.Compare, indexH.Get())
+					iter, _ := newBlockIter(r.Compare, indexH.Get(), nil)
 					for key, value := iter.First(); key != nil; key, value = iter.Next() {
 						bh, err := decodeBlockHandleWithProperties(value.InPlaceValue())
 						if err != nil {
@@ -1274,7 +1274,7 @@ func runBlockPropsCmd(r *Reader, td *datadriven.TestData) string {
 		return err.Error()
 	}
 	twoLevelIndex := r.Properties.IndexPartitions > 0
-	i, err := newBlockIter(r.Compare, bh.Get())
+	i, err := newBlockIter(r.Compare, bh.Get(), nil)
 	if err != nil {
 		return err.Error()
 	}
@@ -1322,7 +1322,7 @@ func runBlockPropsCmd(r *Reader, td *datadriven.TestData) string {
 				return err.Error()
 			}
 			if err := subiter.init(
-				r.Compare, subIndex.Get(), 0 /* globalSeqNum */, false); err != nil {
+				r.Compare, subIndex.Get(), 0 /* globalSeqNum */, false, r.syntheticPrefix); err != nil {
 				return err.Error()
 			}
 			for key, value := subiter.First(); key != nil; key, value = subiter.Next() {

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -24,18 +24,19 @@ type Layout struct {
 	// ValidateBlockChecksums, which validates a static list of BlockHandles
 	// referenced in this struct.
 
-	Data       []BlockHandleWithProperties
-	Index      []BlockHandle
-	TopIndex   BlockHandle
-	Filter     BlockHandle
-	RangeDel   BlockHandle
-	RangeKey   BlockHandle
-	ValueBlock []BlockHandle
-	ValueIndex BlockHandle
-	Properties BlockHandle
-	MetaIndex  BlockHandle
-	Footer     BlockHandle
-	Format     TableFormat
+	Data            []BlockHandleWithProperties
+	Index           []BlockHandle
+	TopIndex        BlockHandle
+	Filter          BlockHandle
+	RangeDel        BlockHandle
+	RangeKey        BlockHandle
+	ValueBlock      []BlockHandle
+	ValueIndex      BlockHandle
+	Properties      BlockHandle
+	MetaIndex       BlockHandle
+	Footer          BlockHandle
+	Format          TableFormat
+	SyntheticPrefix SyntheticPrefix
 }
 
 // Describe returns a description of the layout. If the verbose parameter is
@@ -186,7 +187,7 @@ func (l *Layout) Describe(
 		var lastKey InternalKey
 		switch b.name {
 		case "data", "range-del", "range-key":
-			iter, _ := newBlockIter(r.Compare, h.Get())
+			iter, _ := newBlockIter(r.Compare, h.Get(), l.SyntheticPrefix)
 			for key, value := iter.First(); key != nil; key, value = iter.Next() {
 				ptr := unsafe.Pointer(uintptr(iter.ptr) + uintptr(iter.offset))
 				shared, ptr := decodeVarint(ptr)
@@ -238,7 +239,7 @@ func (l *Layout) Describe(
 			formatRestarts(iter.data, iter.restarts, iter.numRestarts)
 			formatTrailer()
 		case "index", "top-index":
-			iter, _ := newBlockIter(r.Compare, h.Get())
+			iter, _ := newBlockIter(r.Compare, h.Get(), l.SyntheticPrefix)
 			for key, value := iter.First(); key != nil; key, value = iter.Next() {
 				bh, err := decodeBlockHandleWithProperties(value.InPlaceValue())
 				if err != nil {

--- a/sstable/prefix_replacing_iterator.go
+++ b/sstable/prefix_replacing_iterator.go
@@ -113,7 +113,9 @@ func (p *prefixReplacingIterator) SeekLT(
 		p.i.First()
 		return p.rewriteResult(p.i.Prev())
 	}
-	return p.rewriteResult(p.i.SeekLT(p.rewriteArg(key), flags))
+	key = p.rewriteArg(key)
+	resKey, resResult := p.i.SeekLT(key, flags)
+	return p.rewriteResult(resKey, resResult)
 }
 
 // First implements the Iterator interface.

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -213,7 +213,7 @@ func (i *singleLevelIterator) init(
 	i.stats = stats
 	i.hideObsoletePoints = hideObsoletePoints
 	i.bufferPool = bufferPool
-	err = i.index.initHandle(i.cmp, indexH, r.Properties.GlobalSeqNum, false)
+	err = i.index.initHandle(i.cmp, indexH, r.Properties.GlobalSeqNum, false, r.syntheticPrefix)
 	if err != nil {
 		// blockIter.Close releases indexH and always returns a nil error
 		_ = i.index.Close()
@@ -435,7 +435,7 @@ func (i *singleLevelIterator) loadBlock(dir int8) loadBlockResult {
 		i.err = err
 		return loadBlockFailed
 	}
-	i.err = i.data.initHandle(i.cmp, block, i.reader.Properties.GlobalSeqNum, i.hideObsoletePoints)
+	i.err = i.data.initHandle(i.cmp, block, i.reader.Properties.GlobalSeqNum, i.hideObsoletePoints, i.reader.syntheticPrefix)
 	if i.err != nil {
 		// The block is partially loaded, and we don't want it to appear valid.
 		i.data.invalidate()
@@ -821,6 +821,9 @@ func (i *singleLevelIterator) seekPrefixGE(
 		if i.err != nil {
 			i.data.invalidate()
 			return nil, base.LazyValue{}
+		}
+		if i.reader.syntheticPrefix != nil {
+			prefix = bytes.TrimPrefix(prefix, i.reader.syntheticPrefix)
 		}
 		mayContain := i.reader.tableFilter.mayContain(dataH.Get(), prefix)
 		dataH.Release()

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -67,7 +67,7 @@ func (i *twoLevelIterator) loadIndex(dir int8) loadBlockResult {
 		i.err = err
 		return loadBlockFailed
 	}
-	if i.err = i.index.initHandle(i.cmp, indexBlock, i.reader.Properties.GlobalSeqNum, false); i.err == nil {
+	if i.err = i.index.initHandle(i.cmp, indexBlock, i.reader.Properties.GlobalSeqNum, false, i.reader.syntheticPrefix); i.err == nil {
 		return loadBlockOK
 	}
 	return loadBlockFailed
@@ -175,7 +175,7 @@ func (i *twoLevelIterator) init(
 	i.stats = stats
 	i.hideObsoletePoints = hideObsoletePoints
 	i.bufferPool = bufferPool
-	err = i.topLevelIndex.initHandle(i.cmp, topLevelIndexH, r.Properties.GlobalSeqNum, false)
+	err = i.topLevelIndex.initHandle(i.cmp, topLevelIndexH, r.Properties.GlobalSeqNum, false, r.syntheticPrefix)
 	if err != nil {
 		// blockIter.Close releases topLevelIndexH and always returns a nil error
 		_ = i.topLevelIndex.Close()

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -707,7 +707,7 @@ func indexLayoutString(t *testing.T, r *Reader) string {
 	var buf strings.Builder
 	twoLevelIndex := r.Properties.IndexType == twoLevelIndex
 	buf.WriteString("index entries:\n")
-	iter, err := newBlockIter(r.Compare, indexH.Get())
+	iter, err := newBlockIter(r.Compare, indexH.Get(), r.syntheticPrefix)
 	defer func() {
 		require.NoError(t, iter.Close())
 	}()
@@ -721,7 +721,7 @@ func indexLayoutString(t *testing.T, r *Reader) string {
 				context.Background(), bh.BlockHandle, nil, nil, nil, nil, nil)
 			require.NoError(t, err)
 			defer b.Release()
-			iter2, err := newBlockIter(r.Compare, b.Get())
+			iter2, err := newBlockIter(r.Compare, b.Get(), r.syntheticPrefix)
 			defer func() {
 				require.NoError(t, iter2.Close())
 			}()
@@ -1402,11 +1402,12 @@ func buildTestTable(
 	blockSize, indexBlockSize int,
 	compression Compression,
 	prefix []byte,
+	readerOpts ...ReaderOption,
 ) *Reader {
 	provider, err := objstorageprovider.Open(objstorageprovider.DefaultSettings(vfs.NewMem(), "" /* dirName */))
 	require.NoError(t, err)
 	defer provider.Close()
-	return buildTestTableWithProvider(t, provider, numEntries, blockSize, indexBlockSize, compression, prefix)
+	return buildTestTableWithProvider(t, provider, numEntries, blockSize, indexBlockSize, compression, prefix, readerOpts...)
 }
 
 func buildTestTableWithProvider(
@@ -1416,6 +1417,7 @@ func buildTestTableWithProvider(
 	blockSize, indexBlockSize int,
 	compression Compression,
 	prefix []byte,
+	readerOpts ...ReaderOption,
 ) *Reader {
 	f0, _, err := provider.Create(context.Background(), base.FileTypeTable, base.DiskFileNum(0), objstorage.CreateOptions{})
 	require.NoError(t, err)
@@ -1447,7 +1449,9 @@ func buildTestTableWithProvider(
 	defer c.Unref()
 	r, err := NewReader(f1, ReaderOptions{
 		Cache: c,
-	})
+	},
+		readerOpts...,
+	)
 	require.NoError(t, err)
 	return r
 }

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -90,7 +90,7 @@ func (v *VirtualReader) NewCompactionIter(
 ) (Iterator, error) {
 	i, err := v.reader.newCompactionIter(
 		bytesIterated, categoryAndQoS, statsCollector, rp, &v.vState, bufferPool)
-	if err == nil && v.vState.prefixChange != nil {
+	if err == nil && v.vState.prefixChange != nil && !v.reader.syntheticPrefix.Implements(v.vState.prefixChange) {
 		i = newPrefixReplacingIterator(i, v.vState.prefixChange.ContentPrefix, v.vState.prefixChange.SyntheticPrefix, v.reader.Compare)
 	}
 	return i, err
@@ -113,7 +113,7 @@ func (v *VirtualReader) NewIterWithBlockPropertyFiltersAndContextEtc(
 	i, err := v.reader.newIterWithBlockPropertyFiltersAndContext(
 		ctx, lower, upper, filterer, hideObsoletePoints, useFilterBlock, stats,
 		categoryAndQoS, statsCollector, rp, &v.vState)
-	if err == nil && v.vState.prefixChange != nil {
+	if err == nil && v.vState.prefixChange != nil && !v.reader.syntheticPrefix.Implements(v.vState.prefixChange) {
 		i = newPrefixReplacingIterator(i, v.vState.prefixChange.ContentPrefix, v.vState.prefixChange.SyntheticPrefix, v.reader.Compare)
 	}
 	return i, err

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -201,7 +201,7 @@ func rewriteBlocks(
 		if err != nil {
 			return err
 		}
-		if err := iter.init(r.Compare, inputBlock, r.Properties.GlobalSeqNum, false); err != nil {
+		if err := iter.init(r.Compare, inputBlock, r.Properties.GlobalSeqNum, false, r.syntheticPrefix); err != nil {
 			return err
 		}
 

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -222,7 +222,7 @@ Zombie tables: 0 (0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Block cache: 6 entries (1.1KB)  hit rate: 11.1%
-Table cache: 1 entries (808B)  hit rate: 40.0%
+Table cache: 1 entries (832B)  hit rate: 40.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
@@ -321,7 +321,7 @@ Zombie tables: 0 (0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Block cache: 12 entries (2.3KB)  hit rate: 14.3%
-Table cache: 1 entries (808B)  hit rate: 50.0%
+Table cache: 1 entries (832B)  hit rate: 50.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -52,7 +52,7 @@ Zombie tables: 0 (0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Block cache: 6 entries (1.2KB)  hit rate: 35.7%
-Table cache: 1 entries (808B)  hit rate: 50.0%
+Table cache: 1 entries (832B)  hit rate: 50.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -68,7 +68,7 @@ Zombie tables: 0 (0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Block cache: 3 entries (556B)  hit rate: 0.0%
-Table cache: 1 entries (808B)  hit rate: 0.0%
+Table cache: 1 entries (832B)  hit rate: 0.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
@@ -201,7 +201,7 @@ Zombie tables: 1 (661B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Block cache: 3 entries (556B)  hit rate: 42.9%
-Table cache: 1 entries (808B)  hit rate: 66.7%
+Table cache: 1 entries (832B)  hit rate: 66.7%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
@@ -467,7 +467,7 @@ Zombie tables: 0 (0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Block cache: 12 entries (2.4KB)  hit rate: 24.5%
-Table cache: 1 entries (808B)  hit rate: 60.0%
+Table cache: 1 entries (832B)  hit rate: 60.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
@@ -528,7 +528,7 @@ Zombie tables: 0 (0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Block cache: 12 entries (2.4KB)  hit rate: 24.5%
-Table cache: 1 entries (808B)  hit rate: 60.0%
+Table cache: 1 entries (832B)  hit rate: 60.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0


### PR DESCRIPTION
This adds the concept of synthetic prefixes to sstable readers and their underlying block iterators, treating the synthetic prefix as an extra shared prefix, shared even by restart keys.

When a reader is configured with a synthetic prefix, it will assume that that prefix is implicitly prepended to every key in the underlying sst blocks when interacting with or returning those keys.