### PR TITLE
db: have excises wait for EFOS below them, reducing EFOS waits

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2083,14 +2083,6 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 				s = s.next
 				continue
 			}
-			if s.efos.excised.Load() {
-				// If a concurrent excise has happened that overlaps with one of the key
-				// ranges this snapshot is interested in, this EFOS cannot transition to
-				// a file-only snapshot as keys in that range could now be deleted. Move
-				// onto the next snapshot.
-				s = s.next
-				continue
-			}
 			currentVersion.Ref()
 
 			// NB: s.efos.transitionToFileOnlySnapshot could close s, in which

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -1664,14 +1664,6 @@ func (o *newSnapshotOp) run(t *Test, h historyRecorder) {
 	if createEfos || excisePossible {
 		s := t.getDB(o.dbID).NewEventuallyFileOnlySnapshot(bounds)
 		t.setSnapshot(o.snapID, s)
-		// If the EFOS isn't guaranteed to always create iterators, we must force
-		// a flush on this DB so it transitions this EFOS into a file-only snapshot.
-		if excisePossible && !t.testOpts.efosAlwaysCreatesIters {
-			err := t.getDB(o.dbID).Flush()
-			if err != nil {
-				h.Recordf("%s // %v", o, err)
-			}
-		}
 	} else {
 		s := t.getDB(o.dbID).NewSnapshot()
 		t.setSnapshot(o.snapID, s)

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -135,10 +135,6 @@ func parseOptions(
 			case "TestOptions.use_excise":
 				opts.useExcise = true
 				return true
-			case "TestOptions.efos_always_creates_iterators":
-				opts.efosAlwaysCreatesIters = true
-				opts.Opts.TestingAlwaysCreateEFOSIterators(true /* value */)
-				return true
 			default:
 				if customOptionParsers == nil {
 					return false
@@ -214,9 +210,6 @@ func optionsToString(opts *TestOptions) string {
 	}
 	if opts.useExcise {
 		fmt.Fprintf(&buf, "  use_excise=%v\n", opts.useExcise)
-	}
-	if opts.efosAlwaysCreatesIters {
-		fmt.Fprintf(&buf, "  efos_always_creates_iterators=%v\n", opts.efosAlwaysCreatesIters)
 	}
 	for _, customOpt := range opts.CustomOpts {
 		fmt.Fprintf(&buf, "  %s=%s\n", customOpt.Name(), customOpt.Value())
@@ -320,11 +313,6 @@ type TestOptions struct {
 	// excises. However !useExcise && !useSharedReplicate can be used to guarantee
 	// lack of excises.
 	useExcise bool
-	// Enables EFOS to always create iterators, even if a conflicting excise
-	// happens. Used to guarantee EFOS determinism when conflicting excises are
-	// in play. If false, EFOS determinism is maintained by having the DB do a
-	// flush after every new EFOS.
-	efosAlwaysCreatesIters bool
 }
 
 // CustomOption defines a custom option that configures the behavior of an
@@ -665,10 +653,6 @@ func RandomOptions(
 		if testOpts.Opts.FormatMajorVersion < pebble.FormatVirtualSSTables {
 			testOpts.Opts.FormatMajorVersion = pebble.FormatVirtualSSTables
 		}
-	}
-	if testOpts.useExcise || testOpts.useSharedReplicate {
-		testOpts.efosAlwaysCreatesIters = rng.Intn(2) == 0
-		opts.TestingAlwaysCreateEFOSIterators(testOpts.efosAlwaysCreatesIters)
 	}
 	testOpts.Opts.EnsureDefaults()
 	return testOpts

--- a/options.go
+++ b/options.go
@@ -1056,11 +1056,6 @@ type Options struct {
 		// against the FS are made after the DB is closed, the FS may leak a
 		// goroutine indefinitely.
 		fsCloser io.Closer
-
-		// efosAlwaysCreatesIterators is set by some tests to force
-		// EventuallyFileOnlySnapshots to always create iterators, even after a
-		// conflicting excise.
-		efosAlwaysCreatesIterators bool
 	}
 }
 
@@ -1235,13 +1230,6 @@ func (o *Options) AddEventListener(l EventListener) {
 		l = TeeEventListener(l, *o.EventListener)
 	}
 	o.EventListener = &l
-}
-
-// TestingAlwaysCreateEFOSIterators is used to toggle a private option for
-// having EventuallyFileOnlySnapshots always create iterators. Meant to only
-// be used in tests.
-func (o *Options) TestingAlwaysCreateEFOSIterators(value bool) {
-	o.private.efosAlwaysCreatesIterators = value
 }
 
 func (o *Options) equal() Equal {

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -438,7 +438,7 @@ lsm db
 6:
   000012:[a#0,SET-b#0,SET]
   000013:[d#0,SET-g#0,SET]
-  000011:[i#19,SET-k#19,SET]
+  000011:[i#20,SET-k#20,SET]
 
 build db ext2 format=pebblev2
 set z z
@@ -453,9 +453,9 @@ lsm db
 6:
   000012:[a#0,SET-b#0,SET]
   000013:[d#0,SET-g#0,SET]
-  000015:[i#19,SET-i#19,SET]
-  000016:[k#19,SET-k#19,SET]
-  000014:[z#20,SET-z#20,SET]
+  000015:[i#20,SET-i#20,SET]
+  000016:[k#20,SET-k#20,SET]
+  000014:[z#22,SET-z#22,SET]
 
 # scan db so that it is known what to expect from the checkpoints.
 scan db
@@ -661,9 +661,9 @@ lsm checkpoints/checkpoint5
   000017:[h#18,SET-h#18,SET]
 6:
   000013:[d#0,SET-g#0,SET]
-  000015:[i#19,SET-i#19,SET]
-  000016:[k#19,SET-k#19,SET]
-  000014:[z#20,SET-z#20,SET]
+  000015:[i#20,SET-i#20,SET]
+  000016:[k#20,SET-k#20,SET]
+  000014:[z#22,SET-z#22,SET]
 
 close checkpoints/checkpoint5
 ----
@@ -748,6 +748,6 @@ lsm checkpoints/checkpoint6
 0.0:
   000017:[h#18,SET-h#18,SET]
 6:
-  000015:[i#19,SET-i#19,SET]
-  000016:[k#19,SET-k#19,SET]
-  000014:[z#20,SET-z#20,SET]
+  000015:[i#20,SET-i#20,SET]
+  000016:[k#20,SET-k#20,SET]
+  000014:[z#22,SET-z#22,SET]

--- a/testdata/concurrent_excise
+++ b/testdata/concurrent_excise
@@ -89,7 +89,7 @@ ok
 lsm
 ----
 6:
-  000010:[d#13,SET-d#13,SET]
+  000010:[d#14,SET-d#14,SET]
   000011:[f#11,SET-f#11,SET]
 
 compact a-z
@@ -165,7 +165,7 @@ replicated 1 shared SSTs
 
 wait-for-file-only-snapshot s2
 ----
-pebble: snapshot excised before conversion to file-only snapshot
+ok
 
 iter snapshot=s2
 first
@@ -173,4 +173,7 @@ next
 next
 next
 ----
-pebble: snapshot excised before conversion to file-only snapshot
+d: (something, .)
+dd: (memory, .)
+e: (bar, .)
+.

--- a/testdata/excise
+++ b/testdata/excise
@@ -106,7 +106,7 @@ lsm
 ----
 6:
   000019:[a#10,SET-a#10,SET]
-  000018:[d#13,SET-e#13,SET]
+  000018:[d#14,SET-e#14,SET]
   000020:[l#10,SET-l#10,SET]
 
 iter
@@ -211,7 +211,7 @@ lsm
   000007:[a#10,SET-a#10,SET]
   000008:[d#12,SET-ee#inf,RANGEKEYSET]
 6:
-  000006:[z#14,SET-z#14,SET]
+  000006:[z#15,SET-z#15,SET]
 
 # Regression test for https://github.com/cockroachdb/pebble/issues/2947.
 reset
@@ -251,7 +251,7 @@ lsm
   000007:[a#10,SET-c#12,SET]
   000008:[e#14,SET-j#19,SET]
 6:
-  000006:[z#20,SET-z#20,SET]
+  000006:[z#21,SET-z#21,SET]
 
 build ext3
 set zz zz
@@ -268,8 +268,8 @@ lsm
   000010:[e#14,SET-f#15,SET]
   000011:[h#17,SET-j#19,SET]
 6:
-  000006:[z#20,SET-z#20,SET]
-  000009:[zz#21,SET-zz#21,SET]
+  000006:[z#21,SET-z#21,SET]
+  000009:[zz#23,SET-zz#23,SET]
 
 confirm-backing 7 10 11
 ----
@@ -287,8 +287,8 @@ lsm
   000010:[e#14,SET-f#15,SET]
   000011:[h#17,SET-j#19,SET]
 6:
-  000006:[z#20,SET-z#20,SET]
-  000009:[zz#21,SET-zz#21,SET]
+  000006:[z#21,SET-z#21,SET]
+  000009:[zz#23,SET-zz#23,SET]
 
 confirm-backing 7 10 11
 ----
@@ -326,7 +326,7 @@ lsm
 0.0:
   000007:[a#10,SET-c#12,SET]
 6:
-  000006:[z#15,SET-z#15,SET]
+  000006:[z#16,SET-z#16,SET]
 
 reopen
 ----
@@ -336,7 +336,7 @@ lsm
 0.0:
   000007:[a#10,SET-c#12,SET]
 6:
-  000006:[z#15,SET-z#15,SET]
+  000006:[z#16,SET-z#16,SET]
 
 # Regression test for #3128. A key at the upper bound of a virtual sstable
 # should not be skipped in reverse iteration with range key masking enabled.
@@ -402,7 +402,7 @@ lsm
 ----
 0.0:
   000011:[cc#17,RANGEKEYSET-f#17,MERGE]
-  000010:[z#18,SET-z#18,SET]
+  000010:[z#19,SET-z#19,SET]
 6:
   000012:[a@3#0,SET-bbsomethinglong@4#0,MERGE]
   000013:[d@6#0,MERGE-z#0,MERGE]
@@ -502,13 +502,16 @@ set c something
 
 ingest-and-excise ext5 excise=c-cc
 ----
+memtable flushed
 
 lsm
 ----
+0.0:
+  000012:[x#14,SET-x#14,SET]
 6:
-  000011:[a#0,SET-b#0,SET]
-  000010:[c#16,SET-c#16,SET]
-  000012:[d@6#15,DEL-d@6#0,SET]
+  000013:[a#0,SET-b#0,SET]
+  000010:[c#17,SET-c#17,SET]
+  000014:[d@6#15,DEL-d@6#0,SET]
 
 iter lower=c upper=e
 last

--- a/testdata/ingest_shared
+++ b/testdata/ingest_shared
@@ -50,7 +50,7 @@ replicated 1 shared SSTs
 lsm
 ----
 6:
-  000005:[d#10,SET-f#10,SET]
+  000005:[d#11,SET-f#11,SET]
 
 iter
 first
@@ -366,9 +366,9 @@ ok
 lsm
 ----
 0.0:
-  000004:[a@3#11,SET-d#inf,RANGEDEL]
+  000004:[a@3#12,SET-d#inf,RANGEDEL]
 6:
-  000005:[a@3#10,SET-e#10,SET]
+  000005:[a@3#11,SET-e#11,SET]
 
 iter
 first
@@ -465,11 +465,11 @@ ok
 lsm
 ----
 0.0:
-  000004:[a@3#12,SET-c@9#12,SET]
+  000004:[a@3#13,SET-c@9#13,SET]
 5:
-  000005:[b#11,RANGEDEL-d#inf,RANGEDEL]
+  000005:[b#12,RANGEDEL-d#inf,RANGEDEL]
 6:
-  000006:[a@3#10,SET-e#10,SET]
+  000006:[a@3#11,SET-e#11,SET]
 
 iter
 first
@@ -540,7 +540,7 @@ lsm
 ----
 6:
   000008:[a#10,RANGEKEYSET-aaa#inf,RANGEKEYSET]
-  000007:[b#13,SET-c#13,SET]
+  000007:[b#14,SET-c#14,SET]
   000009:[d#11,SET-e#12,SET]
 
 iter
@@ -621,9 +621,9 @@ replicated 2 shared SSTs
 lsm
 ----
 5:
-  000007:[bb#12,RANGEDEL-f#inf,RANGEDEL]
+  000007:[bb#13,RANGEDEL-f#inf,RANGEDEL]
 6:
-  000008:[b@5#11,SET-e#11,SET]
+  000008:[b@5#12,SET-e#12,SET]
   000005:[ff#10,SET-ff#10,SET]
 
 iter
@@ -719,9 +719,9 @@ replicated 2 shared SSTs
 lsm
 ----
 5:
-  000007:[bb#12,RANGEKEYSET-f#inf,RANGEKEYSET]
+  000007:[bb#13,RANGEKEYSET-f#inf,RANGEKEYSET]
 6:
-  000008:[b@5#11,SET-e#11,SET]
+  000008:[b@5#12,SET-e#12,SET]
   000005:[ff#10,SET-ff#10,SET]
 
 iter
@@ -958,9 +958,8 @@ set f foobar
 
 # The below file-only snapshot is the more challenging case of a partial overlap
 # between an excise and a file-only snapshot. In this case the EFOS transition
-# blocks on the memtable but the excise proceeds through, causing the EFOS'
-# WaitForFileOnlySnapshot() call to error out. Opening iterators also returns
-# the same errors.
+# blocks on the memtable. The excise should detect that and force the flush
+# before it happens, and snapshot semantics should be maintained.
 
 file-only-snapshot s3
  c g
@@ -1004,7 +1003,7 @@ replicated 2 shared SSTs
 
 wait-for-file-only-snapshot s3
 ----
-pebble: snapshot excised before conversion to file-only snapshot
+ok
 
 iter snapshot=s3
 first
@@ -1013,7 +1012,11 @@ next
 next
 next
 ----
-pebble: snapshot excised before conversion to file-only snapshot
+a: (foo, .)
+b: (bar, .)
+c: (baz, .)
+f: (foobar, .)
+.
 
 iter snapshot=s3
 first
@@ -1024,7 +1027,13 @@ next
 next
 next
 ----
-pebble: snapshot excised before conversion to file-only snapshot
+a: (foo, .)
+b: (bar, .)
+.
+a: (foo, .)
+b: (bar, .)
+c: (baz, .)
+f: (foobar, .)
 
 iter
 first
@@ -1220,7 +1229,7 @@ ok
 lsm
 ----
 6:
-  000008:[c#11,RANGEKEYSET-e#inf,RANGEKEYSET]
+  000008:[c#12,RANGEKEYSET-e#inf,RANGEKEYSET]
 
 switch 1
 ----
@@ -1289,7 +1298,7 @@ ok
 lsm
 ----
 6:
-  000005:[a#10,SET-a#10,DEL]
+  000005:[a#11,SET-a#11,DEL]
 
 iter
 first

--- a/testdata/ingest_shared_lower
+++ b/testdata/ingest_shared_lower
@@ -50,7 +50,7 @@ replicated 1 shared SSTs
 lsm
 ----
 6:
-  000005:[d#10,SET-f#10,SET]
+  000005:[d#11,SET-f#11,SET]
 
 iter
 first
@@ -366,9 +366,9 @@ ok
 lsm
 ----
 0.0:
-  000004:[a@3#11,SET-d#inf,RANGEDEL]
+  000004:[a@3#12,SET-d#inf,RANGEDEL]
 6:
-  000005:[a@3#10,SET-e#10,SET]
+  000005:[a@3#11,SET-e#11,SET]
 
 iter
 first
@@ -465,11 +465,11 @@ ok
 lsm
 ----
 0.0:
-  000004:[a@3#12,SET-c@9#12,SET]
+  000004:[a@3#13,SET-c@9#13,SET]
 5:
-  000005:[b#11,RANGEDEL-d#inf,RANGEDEL]
+  000005:[b#12,RANGEDEL-d#inf,RANGEDEL]
 6:
-  000006:[a@3#10,SET-e#10,SET]
+  000006:[a@3#11,SET-e#11,SET]
 
 iter
 first
@@ -540,7 +540,7 @@ lsm
 ----
 6:
   000009:[a#10,RANGEKEYSET-aaa#inf,RANGEKEYSET]
-  000008:[b#13,SET-c#13,SET]
+  000008:[b#14,SET-c#14,SET]
   000010:[d#11,SET-e#12,SET]
 
 iter
@@ -621,9 +621,9 @@ replicated 2 shared SSTs
 lsm
 ----
 5:
-  000008:[bb#12,RANGEDEL-f#inf,RANGEDEL]
+  000008:[bb#13,RANGEDEL-f#inf,RANGEDEL]
 6:
-  000009:[b@5#11,SET-e#11,SET]
+  000009:[b@5#12,SET-e#12,SET]
   000006:[ff#10,SET-ff#10,SET]
 
 iter
@@ -702,9 +702,9 @@ replicated 2 shared SSTs
 lsm
 ----
 5:
-  000008:[bb#12,RANGEKEYSET-f#inf,RANGEKEYSET]
+  000008:[bb#13,RANGEKEYSET-f#inf,RANGEKEYSET]
 6:
-  000009:[b@5#11,SET-e#11,SET]
+  000009:[b@5#12,SET-e#12,SET]
   000006:[ff#10,SET-ff#10,SET]
 
 iter
@@ -987,7 +987,7 @@ replicated 2 shared SSTs
 
 wait-for-file-only-snapshot s3
 ----
-pebble: snapshot excised before conversion to file-only snapshot
+ok
 
 iter snapshot=s3
 first
@@ -996,7 +996,11 @@ next
 next
 next
 ----
-pebble: snapshot excised before conversion to file-only snapshot
+a: (foo, .)
+b: (bar, .)
+c: (baz, .)
+f: (foobar, .)
+.
 
 iter snapshot=s3
 first
@@ -1007,7 +1011,13 @@ next
 next
 next
 ----
-pebble: snapshot excised before conversion to file-only snapshot
+a: (foo, .)
+b: (bar, .)
+.
+a: (foo, .)
+b: (bar, .)
+c: (baz, .)
+f: (foobar, .)
 
 iter
 first

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -563,7 +563,7 @@ lsm
   000008:[a#0,SET-b#0,SET]
   000013:[c@20#0,SET-c@16#0,SET]
   000014:[c@15#0,SET-c@14#0,SET]
-  000028:[z#32,SET-z#32,SET]
+  000028:[z#33,SET-z#33,SET]
 
 # There should be 2 backing tables. Note that tiny sstables have inaccurate
 # virtual sstable sizes.
@@ -640,8 +640,8 @@ lsm
   000008:[a#0,SET-b#0,SET]
   000013:[c@20#0,SET-c@16#0,SET]
   000014:[c@15#0,SET-c@14#0,SET]
-  000028:[z#32,SET-z#32,SET]
-  000031:[zz#33,SET-zz#33,SET]
+  000028:[z#33,SET-z#33,SET]
+  000031:[zz#35,SET-zz#35,SET]
 
 metrics-value
 num-backing
@@ -663,8 +663,8 @@ compact a-z
   000013:[c@20#0,SET-c@16#0,SET]
   000014:[c@15#0,SET-c@14#0,SET]
   000033:[d#0,SET-m#0,SET]
-  000028:[z#32,SET-z#32,SET]
-  000031:[zz#33,SET-zz#33,SET]
+  000028:[z#33,SET-z#33,SET]
+  000031:[zz#35,SET-zz#35,SET]
 
 # Virtual sstables metrics should be gone after the compaction.
 metrics-value

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -634,7 +634,7 @@ lsm
   000007:[a#10,SET-a#10,SET]
   000008:[d#12,DEL-d#12,DEL]
 6:
-  000006:[f#13,SET-f#13,SET]
+  000006:[f#14,SET-f#14,SET]
 
 metadata-stats file=7
 ----
@@ -696,12 +696,12 @@ range-key-set e ee @1 foo
 flush
 ----
 0.1:
-  000010:[a#14,SET-ee#inf,RANGEKEYSET]
+  000010:[a#15,SET-ee#inf,RANGEKEYSET]
 0.0:
   000007:[a#10,SET-a#10,SET]
   000008:[d#12,DEL-d#12,DEL]
 6:
-  000006:[f#13,SET-f#13,SET]
+  000006:[f#14,SET-f#14,SET]
 
 properties file=10
 rocksdb
@@ -750,14 +750,14 @@ ingest-and-excise ext2 excise=b-c
 lsm
 ----
 0.1:
-  000012:[a#14,SET-a#14,SET]
-  000013:[d#16,SET-ee#inf,RANGEKEYSET]
+  000012:[a#15,SET-a#15,SET]
+  000013:[d#17,SET-ee#inf,RANGEKEYSET]
 0.0:
   000007:[a#10,SET-a#10,SET]
   000008:[d#12,DEL-d#12,DEL]
 6:
-  000006:[f#13,SET-f#13,SET]
-  000011:[z#18,SET-z#18,SET]
+  000006:[f#14,SET-f#14,SET]
+  000011:[z#20,SET-z#20,SET]
 
 metadata-stats file=12
 ----
@@ -809,9 +809,9 @@ compact a-z
 6:
   000014:[a#0,SET-a#0,SET]
   000015:[d#0,SETWITHDEL-d#0,SETWITHDEL]
-  000016:[e#17,RANGEKEYSET-ee#inf,RANGEKEYSET]
-  000006:[f#13,SET-f#13,SET]
-  000011:[z#18,SET-z#18,SET]
+  000016:[e#18,RANGEKEYSET-ee#inf,RANGEKEYSET]
+  000006:[f#14,SET-f#14,SET]
+  000011:[z#20,SET-z#20,SET]
 
 batch
 del-range a e
@@ -820,13 +820,13 @@ del-range a e
 flush
 ----
 0.0:
-  000018:[a#19,RANGEDEL-e#inf,RANGEDEL]
+  000018:[a#21,RANGEDEL-e#inf,RANGEDEL]
 6:
   000014:[a#0,SET-a#0,SET]
   000015:[d#0,SETWITHDEL-d#0,SETWITHDEL]
-  000016:[e#17,RANGEKEYSET-ee#inf,RANGEKEYSET]
-  000006:[f#13,SET-f#13,SET]
-  000011:[z#18,SET-z#18,SET]
+  000016:[e#18,RANGEKEYSET-ee#inf,RANGEKEYSET]
+  000006:[f#14,SET-f#14,SET]
+  000011:[z#20,SET-z#20,SET]
 
 properties file=18
 rocksdb
@@ -866,15 +866,15 @@ ingest-and-excise ext3 excise=b-c
 lsm
 ----
 0.0:
-  000020:[a#19,RANGEDEL-b#inf,RANGEDEL]
-  000021:[c#19,RANGEDEL-e#inf,RANGEDEL]
+  000020:[a#21,RANGEDEL-b#inf,RANGEDEL]
+  000021:[c#21,RANGEDEL-e#inf,RANGEDEL]
 6:
   000014:[a#0,SET-a#0,SET]
   000015:[d#0,SETWITHDEL-d#0,SETWITHDEL]
-  000016:[e#17,RANGEKEYSET-ee#inf,RANGEKEYSET]
-  000006:[f#13,SET-f#13,SET]
-  000011:[z#18,SET-z#18,SET]
-  000019:[zz#20,SET-zz#20,SET]
+  000016:[e#18,RANGEKEYSET-ee#inf,RANGEKEYSET]
+  000006:[f#14,SET-f#14,SET]
+  000011:[z#20,SET-z#20,SET]
+  000019:[zz#23,SET-zz#23,SET]
 
 properties file=20
 ----


### PR DESCRIPTION
Previously, we had to make EventuallyFileOnlySnapshots (EFOS) wait for all relevant keys in their key bounds to be flushed, just in case an excise came in before that happened. This change avoids the need to do that by assigning a seqnum to every excise (which will be useful when we do #2676), and by flushing any memtables that overlap with the protected ranges of any EFOS that has a sequence number below the excise.

The reduction in waiting is desirable as actual conflicts between excises and EventuallyFileOnlySnapshots are rare, while users of EventuallyFileOnlySnapshots were previously stuck waiting or stuck doing excessive flushes at times when no such excises were happening.

Fixes #3210.