### PR TITLE
metamorphic: add external files ingest operation

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3389,6 +3389,7 @@ func (d *DB) runCompaction(
 
 		// Each inner loop iteration processes one key from the input iterator.
 		for ; key != nil; key, val = iter.Next() {
+			//fmt.Printf("compaction iter loop: %v\n", key)
 			if split := splitter.shouldSplitBefore(key, tw); split == splitNow {
 				break
 			}

--- a/compaction_iter.go
+++ b/compaction_iter.go
@@ -350,6 +350,7 @@ func (i *compactionIter) Next() (*InternalKey, []byte) {
 	i.valid = false
 
 	for i.iterKey != nil {
+		//fmt.Printf("compactionIter.Next loop: %v\n", *i.iterKey)
 		// If we entered a new snapshot stripe with the same key, any key we
 		// return on this iteration is only returned because the open snapshot
 		// prevented it from being elided or merged with the key returned for
@@ -589,6 +590,7 @@ func (i *compactionIter) skipInStripe() {
 func (i *compactionIter) iterNext() bool {
 	var iterValue LazyValue
 	i.iterKey, iterValue = i.iter.Next()
+	//fmt.Printf("compactionIter.iterNext(%s): %v\n", i.iter.String(), i.iterKey)
 	i.iterValue, _, i.err = iterValue.Value(nil)
 	if i.err != nil {
 		i.iterKey = nil

--- a/level_iter.go
+++ b/level_iter.go
@@ -1256,7 +1256,7 @@ func (l *levelIter) SetContext(ctx context.Context) {
 
 func (l *levelIter) String() string {
 	if l.iterFile != nil {
-		return fmt.Sprintf("%s: fileNum=%s", l.level, l.iter.String())
+		return fmt.Sprintf("%s: fileNum=%s", l.level, l.iterFile.String())
 	}
 	return fmt.Sprintf("%s: fileNum=<nil>", l.level)
 }

--- a/metamorphic/build.go
+++ b/metamorphic/build.go
@@ -1,0 +1,161 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package metamorphic
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/keyspan"
+	"github.com/cockroachdb/pebble/internal/private"
+	"github.com/cockroachdb/pebble/internal/rangekey"
+	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/sstable"
+)
+
+// writeSSTForIngestion writes an SST that is to be ingested, either directly or
+// as an external file.
+//
+// If convertDelSizedToDel is set, then any DeleteSized keys are converted to
+// Delete keys; this is useful when the database that will ingest the file is at
+// a format that doesn't support DeleteSized.
+//
+// Closes the iterators in all cases.
+func writeSSTForIngestion(
+	pointIter base.InternalIterator,
+	rangeDelIter keyspan.FragmentIterator,
+	rangeKeyIter keyspan.FragmentIterator,
+	equal base.Equal,
+	compare base.Compare,
+	writerOpts sstable.WriterOptions,
+	writable objstorage.Writable,
+	convertDelSizedToDel bool,
+) (*sstable.WriterMetadata, error) {
+	w := sstable.NewWriter(writable, writerOpts)
+	defer closeIters(pointIter, rangeDelIter, rangeKeyIter)
+
+	var lastUserKey []byte
+	for key, value := pointIter.First(); key != nil; key, value = pointIter.Next() {
+		// Ignore duplicate keys.
+		if equal(lastUserKey, key.UserKey) {
+			continue
+		}
+		lastUserKey = append(lastUserKey[:0], key.UserKey...)
+
+		key.SetSeqNum(base.SeqNumZero)
+		// It's possible that we wrote the key on a batch from a db that supported
+		// DeleteSized, but are now ingesting into a db that does not. Detect
+		// this case and translate the key to an InternalKeyKindDelete.
+		if convertDelSizedToDel && key.Kind() == pebble.InternalKeyKindDeleteSized {
+			value = pebble.LazyValue{}
+			key.SetKind(pebble.InternalKeyKindDelete)
+		}
+		if err := w.Add(*key, value.InPlaceValue()); err != nil {
+			return nil, err
+		}
+	}
+	if err := pointIter.Close(); err != nil {
+		return nil, err
+	}
+
+	if rangeDelIter != nil {
+		// NB: The range tombstones have already been fragmented by the Batch.
+		var startCopy, endCopy []byte
+		t, err := rangeDelIter.First()
+		for ; t != nil; t, err = rangeDelIter.Next() {
+			startCopy = append(startCopy[:0], t.Start...)
+			endCopy = append(endCopy[:0], t.End...)
+			if err := w.DeleteRange(startCopy, endCopy); err != nil {
+				return nil, err
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+		if err := rangeDelIter.Close(); err != nil {
+			return nil, err
+		}
+	}
+
+	if rangeKeyIter != nil {
+		var startCopy, endCopy []byte
+		span, err := rangeKeyIter.First()
+		for ; span != nil; span, err = rangeKeyIter.Next() {
+			// Coalesce the keys of this span and then zero the sequence
+			// numbers. This is necessary in order to make the range keys within
+			// the ingested sstable internally consistent at the sequence number
+			// it's ingested at. The individual keys within a batch are
+			// committed at unique sequence numbers, whereas all the keys of an
+			// ingested sstable are given the same sequence number. A span
+			// containing keys that both set and unset the same suffix at the
+			// same sequence number is nonsensical, so we "coalesce" or collapse
+			// the keys.
+			startCopy = append(startCopy[:0], span.Start...)
+			endCopy = append(endCopy[:0], span.End...)
+			collapsed := keyspan.Span{
+				Start: startCopy,
+				End:   endCopy,
+				Keys:  make([]keyspan.Key, 0, len(span.Keys)),
+			}
+			if err := rangekey.Coalesce(compare, equal, span.Keys, &collapsed.Keys); err != nil {
+				return nil, err
+			}
+			for i := range collapsed.Keys {
+				collapsed.Keys[i].Trailer = base.MakeTrailer(0, collapsed.Keys[i].Kind())
+			}
+			keyspan.SortKeysByTrailer(&collapsed.Keys)
+			if err := rangekey.Encode(&collapsed, w.AddRangeKey); err != nil {
+				return nil, err
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+		if err := rangeKeyIter.Close(); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+	return w.Metadata()
+}
+
+func buildForIngest(
+	t *Test, dbID objID, b *pebble.Batch, i int,
+) (string, *sstable.WriterMetadata, error) {
+	path := t.opts.FS.PathJoin(t.tmpDir, fmt.Sprintf("ext%d-%d", dbID.slot(), i))
+	f, err := t.opts.FS.Create(path)
+	if err != nil {
+		return "", nil, err
+	}
+	db := t.getDB(dbID)
+
+	iter, rangeDelIter, rangeKeyIter := private.BatchSort(b)
+
+	tableFormat := db.FormatMajorVersion().MaxTableFormat()
+	wOpts := t.opts.MakeWriterOptions(0, tableFormat)
+	if t.testOpts.disableValueBlocksForIngestSSTables {
+		wOpts.DisableValueBlocks = true
+	}
+	writable := objstorageprovider.NewFileWritable(f)
+	// It's possible that we wrote the key on a batch from a db that supported
+	// DeleteSized, but are now ingesting into a db that does not. Detect
+	// this case and translate the key to an InternalKeyKindDelete.
+	convertDelSizedToDel := !t.isFMV(dbID, pebble.FormatDeleteSizedAndObsolete)
+
+	meta, err := writeSSTForIngestion(
+		iter, rangeDelIter, rangeKeyIter,
+		t.opts.Comparer.Equal,
+		t.opts.Comparer.Compare,
+		wOpts,
+		writable,
+		convertDelSizedToDel,
+	)
+	return path, meta, err
+}

--- a/metamorphic/build.go
+++ b/metamorphic/build.go
@@ -5,6 +5,7 @@
 package metamorphic
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/cockroachdb/pebble"
@@ -24,36 +25,55 @@ import (
 // Delete keys; this is useful when the database that will ingest the file is at
 // a format that doesn't support DeleteSized.
 //
+// If bounds are specified, all points and ranges are truncated to the
+// [Start, End) range.
+//
 // Closes the iterators in all cases.
 func writeSSTForIngestion(
+	t *Test,
 	pointIter base.InternalIterator,
 	rangeDelIter keyspan.FragmentIterator,
 	rangeKeyIter keyspan.FragmentIterator,
-	equal base.Equal,
-	compare base.Compare,
-	writerOpts sstable.WriterOptions,
 	writable objstorage.Writable,
-	convertDelSizedToDel bool,
+	targetFMV pebble.FormatMajorVersion,
+	bounds pebble.KeyRange,
 ) (*sstable.WriterMetadata, error) {
+	writerOpts := t.opts.MakeWriterOptions(0, targetFMV.MaxTableFormat())
+	if t.testOpts.disableValueBlocksForIngestSSTables {
+		writerOpts.DisableValueBlocks = true
+	}
 	w := sstable.NewWriter(writable, writerOpts)
+	// TODO(radu): this seems like it should work.
 	defer closeIters(pointIter, rangeDelIter, rangeKeyIter)
 
 	var lastUserKey []byte
-	for key, value := pointIter.First(); key != nil; key, value = pointIter.Next() {
+	var key *base.InternalKey
+	var value base.LazyValue
+	if bounds.Start == nil {
+		key, value = pointIter.First()
+	} else {
+		key, value = pointIter.SeekGE(bounds.Start, base.SeekGEFlagsNone)
+	}
+
+	for ; key != nil; key, value = pointIter.Next() {
+		if bounds.End != nil && t.opts.Comparer.Compare(key.UserKey, bounds.End) >= 0 {
+			break
+		}
 		// Ignore duplicate keys.
-		if equal(lastUserKey, key.UserKey) {
+		if t.opts.Comparer.Equal(lastUserKey, key.UserKey) {
 			continue
 		}
 		lastUserKey = append(lastUserKey[:0], key.UserKey...)
 
 		key.SetSeqNum(base.SeqNumZero)
 		// It's possible that we wrote the key on a batch from a db that supported
-		// DeleteSized, but are now ingesting into a db that does not. Detect
-		// this case and translate the key to an InternalKeyKindDelete.
-		if convertDelSizedToDel && key.Kind() == pebble.InternalKeyKindDeleteSized {
+		// DeleteSized, but will be ingesting into a db that does not. Detect this
+		// case and translate the key to an InternalKeyKindDelete.
+		if targetFMV < pebble.FormatDeleteSizedAndObsolete && key.Kind() == pebble.InternalKeyKindDeleteSized {
 			value = pebble.LazyValue{}
 			key.SetKind(pebble.InternalKeyKindDelete)
 		}
+		fmt.Printf("Add %v\n", *key)
 		if err := w.Add(*key, value.InPlaceValue()); err != nil {
 			return nil, err
 		}
@@ -63,12 +83,19 @@ func writeSSTForIngestion(
 	}
 
 	if rangeDelIter != nil {
-		// NB: The range tombstones have already been fragmented by the Batch.
-		var startCopy, endCopy []byte
-		t, err := rangeDelIter.First()
-		for ; t != nil; t, err = rangeDelIter.Next() {
-			startCopy = append(startCopy[:0], t.Start...)
-			endCopy = append(endCopy[:0], t.End...)
+		if bounds.Start != nil || bounds.End != nil {
+			rangeDelIter = keyspan.Truncate(
+				t.opts.Comparer.Compare,
+				rangeDelIter,
+				bounds.Start, bounds.End,
+				nil /* start */, nil /* end */, false, /* panicOnUpperTruncate */
+			)
+		}
+		span, err := rangeDelIter.First()
+		for ; span != nil; span, err = rangeDelIter.Next() {
+			startCopy := append([]byte(nil), span.Start...)
+			endCopy := append([]byte(nil), span.End...)
+			fmt.Printf("DeleteRange %q %q\n", startCopy, endCopy)
 			if err := w.DeleteRange(startCopy, endCopy); err != nil {
 				return nil, err
 			}
@@ -82,7 +109,14 @@ func writeSSTForIngestion(
 	}
 
 	if rangeKeyIter != nil {
-		var startCopy, endCopy []byte
+		if bounds.Start != nil || bounds.End != nil {
+			rangeKeyIter = keyspan.Truncate(
+				t.opts.Comparer.Compare,
+				rangeKeyIter,
+				bounds.Start, bounds.End,
+				nil /* start */, nil /* end */, false, /* panicOnUpperTruncate */
+			)
+		}
 		span, err := rangeKeyIter.First()
 		for ; span != nil; span, err = rangeKeyIter.Next() {
 			// Coalesce the keys of this span and then zero the sequence
@@ -94,20 +128,23 @@ func writeSSTForIngestion(
 			// containing keys that both set and unset the same suffix at the
 			// same sequence number is nonsensical, so we "coalesce" or collapse
 			// the keys.
-			startCopy = append(startCopy[:0], span.Start...)
-			endCopy = append(endCopy[:0], span.End...)
+			startCopy := append([]byte(nil), span.Start...)
+			endCopy := append([]byte(nil), span.End...)
 			collapsed := keyspan.Span{
 				Start: startCopy,
 				End:   endCopy,
 				Keys:  make([]keyspan.Key, 0, len(span.Keys)),
 			}
-			if err := rangekey.Coalesce(compare, equal, span.Keys, &collapsed.Keys); err != nil {
+			if err := rangekey.Coalesce(
+				t.opts.Comparer.Compare, t.opts.Comparer.Equal, span.Keys, &collapsed.Keys,
+			); err != nil {
 				return nil, err
 			}
 			for i := range collapsed.Keys {
 				collapsed.Keys[i].Trailer = base.MakeTrailer(0, collapsed.Keys[i].Kind())
 			}
 			keyspan.SortKeysByTrailer(&collapsed.Keys)
+			fmt.Printf("AddRangeKey %q %q\n", startCopy, endCopy)
 			if err := rangekey.Encode(&collapsed, w.AddRangeKey); err != nil {
 				return nil, err
 			}
@@ -126,10 +163,12 @@ func writeSSTForIngestion(
 	return w.Metadata()
 }
 
+// buildForIngest builds a local SST file containing the keys in the given batch
+// and returns its path and metadata.
 func buildForIngest(
 	t *Test, dbID objID, b *pebble.Batch, i int,
-) (string, *sstable.WriterMetadata, error) {
-	path := t.opts.FS.PathJoin(t.tmpDir, fmt.Sprintf("ext%d-%d", dbID.slot(), i))
+) (path string, _ *sstable.WriterMetadata, _ error) {
+	path = t.opts.FS.PathJoin(t.tmpDir, fmt.Sprintf("ext%d-%d", dbID.slot(), i))
 	f, err := t.opts.FS.Create(path)
 	if err != nil {
 		return "", nil, err
@@ -138,24 +177,63 @@ func buildForIngest(
 
 	iter, rangeDelIter, rangeKeyIter := private.BatchSort(b)
 
-	tableFormat := db.FormatMajorVersion().MaxTableFormat()
-	wOpts := t.opts.MakeWriterOptions(0, tableFormat)
-	if t.testOpts.disableValueBlocksForIngestSSTables {
-		wOpts.DisableValueBlocks = true
-	}
 	writable := objstorageprovider.NewFileWritable(f)
-	// It's possible that we wrote the key on a batch from a db that supported
-	// DeleteSized, but are now ingesting into a db that does not. Detect
-	// this case and translate the key to an InternalKeyKindDelete.
-	convertDelSizedToDel := !t.isFMV(dbID, pebble.FormatDeleteSizedAndObsolete)
-
 	meta, err := writeSSTForIngestion(
+		t,
 		iter, rangeDelIter, rangeKeyIter,
-		t.opts.Comparer.Equal,
-		t.opts.Comparer.Compare,
-		wOpts,
 		writable,
-		convertDelSizedToDel,
+		db.FormatMajorVersion(),
+		pebble.KeyRange{},
 	)
+	return path, meta, err
+}
+
+// buildForIngest builds a local SST file containing the keys in the given
+// external object (truncated to the given bounds) and returns its path and
+// metadata.
+func buildForIngestExternalEmulation(
+	t *Test, dbID objID, externalObjID objID, bounds pebble.KeyRange, i int,
+) (path string, _ *sstable.WriterMetadata, _ error) {
+	path = t.opts.FS.PathJoin(t.tmpDir, fmt.Sprintf("ext%d-%d", dbID.slot(), i))
+	fmt.Printf("buildForIngestExternalEmulation %v\n", path)
+	f, err := t.opts.FS.Create(path)
+	if err != nil {
+		return "", nil, err
+	}
+
+	objReader, objSize, err := t.externalStorage.ReadObject(context.Background(), externalObjName(externalObjID))
+	if err != nil {
+		return "", nil, err
+	}
+	opts := sstable.ReaderOptions{
+		Comparer: t.opts.Comparer,
+	}
+	reader, err := sstable.NewReader(objstorageprovider.NewRemoteReadable(objReader, objSize), opts)
+	if err != nil {
+		return "", nil, err
+	}
+	defer reader.Close()
+	pointIter, err := reader.NewIter(bounds.Start, bounds.End)
+	if err != nil {
+		return "", nil, err
+	}
+	rangeDelIter, err := reader.NewRawRangeDelIter()
+	if err != nil {
+		return "", nil, err
+	}
+	rangeKeyIter, err := reader.NewRawRangeKeyIter()
+	if err != nil {
+		return "", nil, err
+	}
+
+	writable := objstorageprovider.NewFileWritable(f)
+	meta, err := writeSSTForIngestion(
+		t,
+		pointIter, rangeDelIter, rangeKeyIter,
+		writable,
+		t.minFMV(),
+		bounds,
+	)
+	fmt.Printf("buildForIngestExternalEmulation %v done\n", path)
 	return path, meta, err
 }

--- a/metamorphic/config.go
+++ b/metamorphic/config.go
@@ -41,6 +41,7 @@ const (
 	OpNewIter
 	OpNewIterUsingClone
 	OpNewSnapshot
+	OpNewExternalObj
 	OpReaderGet
 	OpReplicate
 	OpSnapshotClose
@@ -49,6 +50,7 @@ const (
 	OpWriterDeleteRange
 	OpWriterIngest
 	OpWriterIngestAndExcise
+	OpWriterIngestExternalFiles
 	OpWriterMerge
 	OpWriterRangeKeyDelete
 	OpWriterRangeKeySet
@@ -170,13 +172,15 @@ func DefaultOpConfig() OpConfig {
 			OpWriterDelete:                100,
 			OpWriterDeleteRange:           50,
 			OpWriterIngest:                100,
-			OpWriterIngestAndExcise:       0, // TODO(bilal): Enable this.
+			OpWriterIngestAndExcise:       50,
 			OpWriterMerge:                 100,
 			OpWriterRangeKeySet:           10,
 			OpWriterRangeKeyUnset:         10,
 			OpWriterRangeKeyDelete:        5,
 			OpWriterSet:                   100,
 			OpWriterSingleDelete:          50,
+			OpNewExternalObj:              2,
+			OpWriterIngestExternalFiles:   20,
 		},
 		// Use a new prefix 75% of the time (and 25% of the time use an existing
 		// prefix with an alternative suffix).
@@ -303,7 +307,6 @@ func WriteOpConfig() OpConfig {
 func multiInstanceConfig() OpConfig {
 	cfg := DefaultOpConfig()
 	cfg.ops[OpReplicate] = 5
-	cfg.ops[OpWriterIngestAndExcise] = 50
 	// Single deletes and merges are disabled in multi-instance mode, as
 	// replicateOp doesn't support them.
 	cfg.ops[OpWriterSingleDelete] = 0

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -619,7 +619,7 @@ func (o *ingestOp) run(t *Test, h historyRecorder) {
 	for i, id := range o.batchIDs {
 		b := t.getBatch(id)
 		t.clearObj(id)
-		path, err2 := o.build(t, h, b, i)
+		path, _, err2 := buildForIngest(t, o.dbID, b, i)
 		if err2 != nil {
 			h.Recordf("Build(%s) // %v", id, err2)
 		}
@@ -635,123 +635,6 @@ func (o *ingestOp) run(t *Test, h historyRecorder) {
 	}))
 
 	h.Recordf("%s // %v", o, err)
-}
-
-func buildForIngest(
-	t *Test, dbID objID, h historyRecorder, b *pebble.Batch, i int,
-) (string, *sstable.WriterMetadata, error) {
-	path := t.opts.FS.PathJoin(t.tmpDir, fmt.Sprintf("ext%d-%d", dbID.slot(), i))
-	f, err := t.opts.FS.Create(path)
-	if err != nil {
-		return "", nil, err
-	}
-	db := t.getDB(dbID)
-
-	iter, rangeDelIter, rangeKeyIter := private.BatchSort(b)
-	defer closeIters(iter, rangeDelIter, rangeKeyIter)
-
-	equal := t.opts.Comparer.Equal
-	tableFormat := db.FormatMajorVersion().MaxTableFormat()
-	wOpts := t.opts.MakeWriterOptions(0, tableFormat)
-	if t.testOpts.disableValueBlocksForIngestSSTables {
-		wOpts.DisableValueBlocks = true
-	}
-	w := sstable.NewWriter(objstorageprovider.NewFileWritable(f), wOpts)
-
-	var lastUserKey []byte
-	for key, value := iter.First(); key != nil; key, value = iter.Next() {
-		// Ignore duplicate keys.
-		if equal(lastUserKey, key.UserKey) {
-			continue
-		}
-		// NB: We don't have to copy the key or value since we're reading from a
-		// batch which doesn't do prefix compression.
-		lastUserKey = key.UserKey
-
-		key.SetSeqNum(base.SeqNumZero)
-		// It's possible that we wrote the key on a batch from a db that supported
-		// DeleteSized, but are now ingesting into a db that does not. Detect
-		// this case and translate the key to an InternalKeyKindDelete.
-		if key.Kind() == pebble.InternalKeyKindDeleteSized && !t.isFMV(dbID, pebble.FormatDeleteSizedAndObsolete) {
-			value = pebble.LazyValue{}
-			key.SetKind(pebble.InternalKeyKindDelete)
-		}
-		if err := w.Add(*key, value.InPlaceValue()); err != nil {
-			return "", nil, err
-		}
-	}
-	if err := iter.Close(); err != nil {
-		return "", nil, err
-	}
-	iter = nil
-
-	if rangeDelIter != nil {
-		// NB: The range tombstones have already been fragmented by the Batch.
-		t, err := rangeDelIter.First()
-		for ; t != nil; t, err = rangeDelIter.Next() {
-			// NB: We don't have to copy the key or value since we're reading from a
-			// batch which doesn't do prefix compression.
-			if err := w.DeleteRange(t.Start, t.End); err != nil {
-				return "", nil, err
-			}
-		}
-		if err != nil {
-			return "", nil, err
-		}
-		if err := rangeDelIter.Close(); err != nil {
-			return "", nil, err
-		}
-		rangeDelIter = nil
-	}
-
-	if rangeKeyIter != nil {
-		span, err := rangeKeyIter.First()
-		for ; span != nil; span, err = rangeKeyIter.Next() {
-			// Coalesce the keys of this span and then zero the sequence
-			// numbers. This is necessary in order to make the range keys within
-			// the ingested sstable internally consistent at the sequence number
-			// it's ingested at. The individual keys within a batch are
-			// committed at unique sequence numbers, whereas all the keys of an
-			// ingested sstable are given the same sequence number. A span
-			// contaning keys that both set and unset the same suffix at the
-			// same sequence number is nonsensical, so we "coalesce" or collapse
-			// the keys.
-			collapsed := keyspan.Span{
-				Start: span.Start,
-				End:   span.End,
-				Keys:  make([]keyspan.Key, 0, len(span.Keys)),
-			}
-			err = rangekey.Coalesce(t.opts.Comparer.Compare, equal, span.Keys, &collapsed.Keys)
-			if err != nil {
-				return "", nil, err
-			}
-			for i := range collapsed.Keys {
-				collapsed.Keys[i].Trailer = base.MakeTrailer(0, collapsed.Keys[i].Kind())
-			}
-			keyspan.SortKeysByTrailer(&collapsed.Keys)
-			if err := rangekey.Encode(&collapsed, w.AddRangeKey); err != nil {
-				return "", nil, err
-			}
-		}
-		if err != nil {
-			return "", nil, err
-		}
-		if err := rangeKeyIter.Close(); err != nil {
-			return "", nil, err
-		}
-		rangeKeyIter = nil
-	}
-
-	if err := w.Close(); err != nil {
-		return "", nil, err
-	}
-	meta, err := w.Metadata()
-	return path, meta, err
-}
-
-func (o *ingestOp) build(t *Test, h historyRecorder, b *pebble.Batch, i int) (string, error) {
-	path, _, err := buildForIngest(t, o.dbID, h, b, i)
-	return path, err
 }
 
 func (o *ingestOp) receiver() objID { return o.dbID }
@@ -945,7 +828,7 @@ func (o *ingestAndExciseOp) run(t *Test, h historyRecorder) {
 		h.Recordf("%s // %v", o, err)
 		return
 	}
-	path, writerMeta, err2 := o.build(t, h, b, 0 /* i */)
+	path, writerMeta, err2 := buildForIngest(t, o.dbID, b, 0 /* i */)
 	if err2 != nil {
 		h.Recordf("Build(%s) // %v", o.batchID, err2)
 		return
@@ -981,12 +864,6 @@ func (o *ingestAndExciseOp) run(t *Test, h historyRecorder) {
 	}
 
 	h.Recordf("%s // %v", o, err)
-}
-
-func (o *ingestAndExciseOp) build(
-	t *Test, h historyRecorder, b *pebble.Batch, i int,
-) (string, *sstable.WriterMetadata, error) {
-	return buildForIngest(t, o.dbID, h, b, i)
 }
 
 func (o *ingestAndExciseOp) receiver() objID { return o.dbID }

--- a/metamorphic/parser.go
+++ b/metamorphic/parser.go
@@ -10,7 +10,6 @@ import (
 	"go/token"
 	"reflect"
 	"strconv"
-	"strings"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
@@ -40,8 +39,11 @@ func makeMethod(i interface{}, tags ...objTag) *methodInfo {
 // args returns the receiverID, targetID and arguments for the op. The
 // receiverID is the ID of the object the op will be applied to. The targetID
 // is the ID of the object for assignment. If the method does not return a new
-// object, then targetID will be nil. The argument list is just what it sounds
-// like: the list of arguments for the operation.
+// object, then targetID will be nil.
+//
+// The argument list returns pointers to operation fields that map to arguments
+// for the operation. The last argument can be a pointer to a slice,
+// corresponding to a variable number of arguments.
 func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	switch t := op.(type) {
 	case *applyOp:
@@ -72,8 +74,10 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 		return &t.dbID, nil, []interface{}{&t.batchIDs}
 	case *ingestAndExciseOp:
 		return &t.dbID, nil, []interface{}{&t.batchID, &t.exciseStart, &t.exciseEnd}
+	case *ingestExternalFilesOp:
+		return &t.dbID, nil, []interface{}{&t.objs}
 	case *initOp:
-		return nil, nil, []interface{}{&t.dbSlots, &t.batchSlots, &t.iterSlots, &t.snapshotSlots}
+		return nil, nil, []interface{}{&t.dbSlots, &t.batchSlots, &t.iterSlots, &t.snapshotSlots, &t.externalObjSlots}
 	case *iterLastOp:
 		return &t.iterID, nil, nil
 	case *mergeOp:
@@ -88,6 +92,8 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 		return &t.existingIterID, &t.iterID, []interface{}{&t.refreshBatch, &t.lower, &t.upper, &t.keyTypes, &t.filterMin, &t.filterMax, &t.useL6Filters, &t.maskSuffix}
 	case *newSnapshotOp:
 		return &t.dbID, &t.snapID, []interface{}{&t.bounds}
+	case *newExternalObjOp:
+		return &t.batchID, &t.externalObjID, nil
 	case *iterNextOp:
 		return &t.iterID, nil, []interface{}{&t.limit}
 	case *iterNextPrefixOp:
@@ -136,6 +142,7 @@ var methods = map[string]*methodInfo{
 	"Get":                       makeMethod(getOp{}, dbTag, batchTag, snapTag),
 	"Ingest":                    makeMethod(ingestOp{}, dbTag),
 	"IngestAndExcise":           makeMethod(ingestAndExciseOp{}, dbTag),
+	"IngestExternalFiles":       makeMethod(ingestExternalFilesOp{}, dbTag),
 	"Init":                      makeMethod(initOp{}, dbTag),
 	"Last":                      makeMethod(iterLastOp{}, iterTag),
 	"Merge":                     makeMethod(mergeOp{}, dbTag, batchTag),
@@ -143,6 +150,7 @@ var methods = map[string]*methodInfo{
 	"NewIndexedBatch":           makeMethod(newIndexedBatchOp{}, dbTag),
 	"NewIter":                   makeMethod(newIterOp{}, dbTag, batchTag, snapTag),
 	"NewSnapshot":               makeMethod(newSnapshotOp{}, dbTag),
+	"NewExternalObj":            makeMethod(newExternalObjOp{}, batchTag),
 	"Next":                      makeMethod(iterNextOp{}, iterTag),
 	"NextPrefix":                makeMethod(iterNextPrefixOp{}, iterTag),
 	"InternalNext":              makeMethod(iterCanSingleDelOp{}, iterTag),
@@ -257,30 +265,6 @@ func (p *parser) parseOp() op {
 	panic(p.errorf(pos, "unexpected token: %q", p.tokenf(tok, lit)))
 }
 
-func parseObjID(str string) (objID, error) {
-	var tag objTag
-	switch {
-	case strings.HasPrefix(str, "db"):
-		tag, str = dbTag, str[2:]
-		if str == "" {
-			str = "1"
-		}
-	case strings.HasPrefix(str, "batch"):
-		tag, str = batchTag, str[5:]
-	case strings.HasPrefix(str, "iter"):
-		tag, str = iterTag, str[4:]
-	case strings.HasPrefix(str, "snap"):
-		tag, str = snapTag, str[4:]
-	default:
-		return 0, errors.Newf("unable to parse objectID: %q", str)
-	}
-	id, err := strconv.ParseInt(str, 10, 32)
-	if err != nil {
-		return 0, err
-	}
-	return makeObjID(tag, uint32(id)), nil
-}
-
 func (p *parser) parseObjID(pos token.Pos, str string) objID {
 	id, err := parseObjID(str)
 	if err != nil {
@@ -301,156 +285,66 @@ func unquoteBytes(lit string) []byte {
 }
 
 func (p *parser) parseArgs(op op, methodName string, args []interface{}) {
-	pos, _ := p.scanToken(token.LPAREN)
-	for i := range args {
-		if i > 0 {
-			pos, _ = p.scanToken(token.COMMA)
-		}
+	pos, list := p.parseList()
+	p.scanToken(token.SEMICOLON)
 
+	// The last argument can have variable length.
+	var varArg interface{}
+	if len(args) > 0 {
+		switch args[len(args)-1].(type) {
+		case *[]objID, *[]pebble.KeyRange, *[]pebble.CheckpointSpan, *[]externalObjWithBounds:
+			varArg = args[len(args)-1]
+			args = args[:len(args)-1]
+		}
+	}
+
+	if len(list) < len(args) {
+		panic(p.errorf(pos, "%s: not enough arguments", methodName))
+	}
+	if len(list) > len(args) && varArg == nil {
+		panic(p.errorf(pos, "%s: too many arguments", methodName))
+	}
+
+	for i := range args {
+		elem := list[i]
 		switch t := args[i].(type) {
 		case *uint32:
-			_, lit := p.scanToken(token.INT)
-			val, err := strconv.ParseUint(lit, 10, 32)
+			elem.expectToken(p, token.INT)
+			val, err := strconv.ParseUint(elem.lit, 10, 32)
 			if err != nil {
-				panic(err)
+				panic(p.errorf(elem.pos, "error parsing %q: %s", elem.lit, err))
 			}
 			*t = uint32(val)
 
 		case *uint64:
-			_, lit := p.scanToken(token.INT)
-			val, err := strconv.ParseUint(lit, 10, 64)
+			elem.expectToken(p, token.INT)
+			val, err := strconv.ParseUint(elem.lit, 10, 64)
 			if err != nil {
-				panic(err)
+				panic(p.errorf(elem.pos, "error parsing %q: %s", elem.lit, err))
 			}
-			*t = uint64(val)
+			*t = val
 
 		case *[]byte:
-			_, lit := p.scanToken(token.STRING)
-			*t = unquoteBytes(lit)
+			elem.expectToken(p, token.STRING)
+			*t = unquoteBytes(elem.lit)
 
 		case *bool:
-			_, lit := p.scanToken(token.IDENT)
-			b, err := strconv.ParseBool(lit)
+			elem.expectToken(p, token.IDENT)
+			b, err := strconv.ParseBool(elem.lit)
 			if err != nil {
-				panic(err)
+				panic(p.errorf(elem.pos, "error parsing %q: %s", elem.lit, err))
 			}
 			*t = b
 
 		case *objID:
-			pos, lit := p.scanToken(token.IDENT)
-			*t = p.parseObjID(pos, lit)
-
-		case *[]pebble.KeyRange:
-			var pending pebble.KeyRange
-			for {
-				pos, tok, lit := p.s.Scan()
-				switch tok {
-				case token.STRING:
-					x := unquoteBytes(lit)
-					if pending.Start == nil {
-						pending.Start = x
-					} else {
-						pending.End = x
-						*t = append(*t, pending)
-						pending = pebble.KeyRange{}
-					}
-					pos, tok, lit := p.s.Scan()
-					switch tok {
-					case token.COMMA:
-						continue
-					case token.RPAREN:
-						p.scanToken(token.SEMICOLON)
-						return
-					default:
-						panic(p.errorf(pos, "unexpected token: %q", p.tokenf(tok, lit)))
-					}
-				case token.RPAREN:
-					p.scanToken(token.SEMICOLON)
-					return
-				default:
-					panic(p.errorf(pos, "unexpected token: %q", p.tokenf(tok, lit)))
-				}
-			}
-
-		case *[]objID:
-			for {
-				pos, tok, lit := p.s.Scan()
-				switch tok {
-				case token.IDENT:
-					*t = append(*t, p.parseObjID(pos, lit))
-					pos, tok, lit := p.s.Scan()
-					switch tok {
-					case token.COMMA:
-						continue
-					case token.RPAREN:
-						p.scanToken(token.SEMICOLON)
-						return
-					default:
-						panic(p.errorf(pos, "unexpected token: %q", p.tokenf(tok, lit)))
-					}
-				case token.RPAREN:
-					p.scanToken(token.SEMICOLON)
-					return
-				default:
-					panic(p.errorf(pos, "unexpected token: %q", p.tokenf(tok, lit)))
-				}
-			}
-
-		case *[]pebble.CheckpointSpan:
-			pos, tok, lit := p.s.Scan()
-			switch tok {
-			case token.RPAREN:
-				// No spans.
-				*t = nil
-				p.scanToken(token.SEMICOLON)
-				return
-
-			case token.STRING:
-				var keys [][]byte
-				for {
-					s, err := strconv.Unquote(lit)
-					if err != nil {
-						panic(p.errorf(pos, "unquoting %q: %v", lit, err))
-					}
-					keys = append(keys, []byte(s))
-
-					pos, tok, lit = p.s.Scan()
-					switch tok {
-					case token.COMMA:
-						pos, tok, lit = p.s.Scan()
-						if tok != token.STRING {
-							panic(p.errorf(pos, "unexpected token: %q", p.tokenf(tok, lit)))
-						}
-						continue
-
-					case token.RPAREN:
-						p.scanToken(token.SEMICOLON)
-						if len(keys)%2 == 1 {
-							panic(p.errorf(pos, "expected even number of keys"))
-						}
-						*t = make([]pebble.CheckpointSpan, len(keys)/2)
-						for i := range *t {
-							(*t)[i] = pebble.CheckpointSpan{
-								Start: keys[i*2],
-								End:   keys[i*2+1],
-							}
-						}
-						return
-
-					default:
-						panic(p.errorf(pos, "unexpected token: %q", p.tokenf(tok, lit)))
-					}
-				}
-
-			default:
-				panic(p.errorf(pos, "unexpected token: %q", p.tokenf(tok, lit)))
-			}
+			elem.expectToken(p, token.IDENT)
+			*t = p.parseObjID(elem.pos, elem.lit)
 
 		case *pebble.FormatMajorVersion:
-			_, lit := p.scanToken(token.INT)
-			val, err := strconv.ParseUint(lit, 10, 64)
+			elem.expectToken(p, token.INT)
+			val, err := strconv.ParseUint(elem.lit, 10, 64)
 			if err != nil {
-				panic(err)
+				panic(p.errorf(elem.pos, "error parsing %q: %s", elem.lit, err))
 			}
 			*t = pebble.FormatMajorVersion(val)
 
@@ -458,8 +352,131 @@ func (p *parser) parseArgs(op op, methodName string, args []interface{}) {
 			panic(p.errorf(pos, "%s: unsupported arg[%d] type: %T", methodName, i, args[i]))
 		}
 	}
-	p.scanToken(token.RPAREN)
-	p.scanToken(token.SEMICOLON)
+
+	if varArg != nil {
+		list = list[len(args):]
+		switch t := varArg.(type) {
+		case *[]objID:
+			*t = p.parseObjIDs(list)
+		case *[]pebble.KeyRange:
+			*t = p.parseKeyRanges(list)
+		case *[]pebble.CheckpointSpan:
+			*t = p.parseCheckpointSpans(list)
+		case *[]externalObjWithBounds:
+			*t = p.parseExternalObjsWithBounds(list)
+		default:
+			// We already checked for these types when we set varArgs.
+			panic("unreachable")
+		}
+	}
+}
+
+type listElem struct {
+	pos token.Pos
+	tok token.Token
+	lit string
+}
+
+func (e listElem) expectToken(p *parser, expTok token.Token) {
+	if e.tok != expTok {
+		panic(p.errorf(e.pos, "unexpected token: %q", p.tokenf(e.tok, e.lit)))
+	}
+}
+
+// parseKeyRange parses an arbitrary number of comma separated STRING/IDENT/INT
+// tokens surrounded by parens.
+func (p *parser) parseList() (token.Pos, []listElem) {
+	p.scanToken(token.LPAREN)
+	var list []listElem
+	for {
+		pos, tok, lit := p.s.Scan()
+		if len(list) == 0 && tok == token.RPAREN {
+			return pos, nil
+		}
+
+		switch tok {
+		case token.STRING, token.IDENT, token.INT:
+			list = append(list, listElem{
+				pos: pos,
+				tok: tok,
+				lit: lit,
+			})
+			pos, tok, lit = p.s.Scan()
+			switch tok {
+			case token.COMMA:
+				continue
+			case token.RPAREN:
+				return pos, list
+			}
+		}
+		panic(p.errorf(pos, "unexpected token: %q", p.tokenf(tok, lit)))
+	}
+}
+
+func (p *parser) parseObjIDs(list []listElem) []objID {
+	res := make([]objID, len(list))
+	for i, elem := range list {
+		res[i] = p.parseObjID(elem.pos, elem.lit)
+	}
+	return res
+}
+
+func (p *parser) parseKeys(list []listElem) [][]byte {
+	res := make([][]byte, len(list))
+	for i, elem := range list {
+		elem.expectToken(p, token.STRING)
+		res[i] = unquoteBytes(elem.lit)
+	}
+	return res
+}
+
+func (p *parser) parseKeyRanges(list []listElem) []pebble.KeyRange {
+	keys := p.parseKeys(list)
+	if len(keys)%2 == 1 {
+		panic(p.errorf(list[0].pos, "expected even number of keys"))
+	}
+	res := make([]pebble.KeyRange, len(keys)/2)
+	for i := range res {
+		res[i].Start = keys[2*i]
+		res[i].End = keys[2*i+1]
+	}
+	return res
+}
+
+func (p *parser) parseCheckpointSpans(list []listElem) []pebble.CheckpointSpan {
+	keys := p.parseKeys(list)
+	if len(keys)%2 == 1 {
+		panic(p.errorf(list[0].pos, "expected even number of keys"))
+	}
+	res := make([]pebble.CheckpointSpan, len(keys)/2)
+	for i := range res {
+		res[i] = pebble.CheckpointSpan{
+			Start: keys[i*2],
+			End:   keys[i*2+1],
+		}
+	}
+	return res
+}
+
+func (p *parser) parseExternalObjsWithBounds(list []listElem) []externalObjWithBounds {
+	if len(list)%3 != 0 {
+		panic(p.errorf(list[0].pos, "expected number of arguments to be multiple of 3"))
+	}
+	objs := make([]externalObjWithBounds, len(list)/3)
+	for i := range objs {
+		list[0].expectToken(p, token.IDENT)
+		list[1].expectToken(p, token.STRING)
+		list[2].expectToken(p, token.STRING)
+		objs[i] = externalObjWithBounds{
+			externalObjID: p.parseObjID(list[0].pos, list[0].lit),
+			bounds: pebble.KeyRange{
+				Start: unquoteBytes(list[1].lit),
+				End:   unquoteBytes(list[2].lit),
+			},
+		}
+		list = list[3:]
+	}
+	return objs
 }
 
 func (p *parser) scanToken(expected token.Token) (pos token.Pos, lit string) {


### PR DESCRIPTION
#### metamorphic: minor reorganization of buildForIngest code


#### metamorphic: add external files ingest operation

This commit adds two new operations:
 - `newExternalObjOp` creates an external object from a batch.
 - `ingestExtternalFilesOp` ingests random parts of random external
   objects. If shared storage is not enabled, this operation is
   emulated by creating sst files in the local FS and ingesting those.