### PR TITLE
vfs: add disk write metrics to disk health checking vfs

### DIFF
--- a/options.go
+++ b/options.go
@@ -1221,7 +1221,7 @@ func (o *Options) WithFSDefaults() *Options {
 	if o.FS == nil {
 		o.FS = vfs.Default
 	}
-	o.FS, o.private.fsCloser = vfs.WithDiskHealthChecks(o.FS, 5*time.Second,
+	o.FS, o.private.fsCloser = vfs.WithDiskHealthChecks(o.FS, 5*time.Second, nil,
 		func(info vfs.DiskSlowInfo) {
 			o.EventListener.DiskSlow(info)
 		})

--- a/vfs/disk_health.go
+++ b/vfs/disk_health.go
@@ -5,10 +5,12 @@
 package vfs
 
 import (
+	"cmp"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -100,8 +102,53 @@ func (o OpType) String() string {
 	}
 }
 
-// diskHealthCheckingFile is a File wrapper to detect slow disk operations, and
-// call onSlowDisk if a disk operation is seen to exceed diskSlowThreshold.
+// DiskWriteCategory is a user-understandable string used to identify and aggregate
+// stats for disk writes. The prefix "pebble-" is reserved for internal Pebble categories.
+//
+// Some examples include, pebble-wal, pebble-memtable-flush, pebble-manifest and in the
+// Cockroach context includes, sql-spill, range-snapshot, node-log.
+type DiskWriteCategory string
+
+// WriteCategoryUnspecified denotes a disk write without a significant category.
+const WriteCategoryUnspecified = "unspecified"
+
+// DiskWriteStatsAggregate is an aggregate of the bytes written to disk for a given category.
+type DiskWriteStatsAggregate struct {
+	Category     DiskWriteCategory
+	BytesWritten uint64
+}
+
+// DiskWriteStatsCollector collects and aggregates disk write metrics per category.
+type DiskWriteStatsCollector struct {
+	mu       sync.Mutex
+	statsMap map[DiskWriteCategory]*atomic.Uint64
+}
+
+// NewDiskWriteStatsCollector instantiates a new DiskWriteStatsCollector.
+func NewDiskWriteStatsCollector() *DiskWriteStatsCollector {
+	return &DiskWriteStatsCollector{
+		statsMap: make(map[DiskWriteCategory]*atomic.Uint64),
+	}
+}
+
+// GetStats returns the aggregated metrics for all categories.
+func (d *DiskWriteStatsCollector) GetStats() []DiskWriteStatsAggregate {
+	var stats []DiskWriteStatsAggregate
+	d.mu.Lock()
+	for category, numBytes := range d.statsMap {
+		stats = append(stats, DiskWriteStatsAggregate{
+			Category:     category,
+			BytesWritten: numBytes.Load(),
+		})
+	}
+	d.mu.Unlock()
+	slices.SortFunc(stats, func(a, b DiskWriteStatsAggregate) int { return cmp.Compare(a.Category, b.Category) })
+	return stats
+}
+
+// diskHealthCheckingFile is a File wrapper to collect disk write stats,
+// detect slow disk operations, and call onSlowDisk if a disk operation
+// is seen to exceed diskSlowThreshold.
 //
 // This struct creates a goroutine (in startTicker()) that, at every tick
 // interval, sees if there's a disk operation taking longer than the specified
@@ -136,15 +183,38 @@ type diskHealthCheckingFile struct {
 	// across process boundaries.
 	lastWritePacked atomic.Uint64
 	createTimeNanos int64
+
+	// aggBytesWritten points to an atomic that aggregates the bytes written
+	// for files that belong to a specific DiskWriteCategory. This pointer is also stored in the
+	// DiskWriteStatsCollector for metric collection.
+	aggBytesWritten *atomic.Uint64
 }
+
+// diskHealthCheckingFile implements File.
+var _ File = (*diskHealthCheckingFile)(nil)
 
 // newDiskHealthCheckingFile instantiates a new diskHealthCheckingFile, with the
 // specified time threshold and event listener.
 func newDiskHealthCheckingFile(
 	file File,
 	diskSlowThreshold time.Duration,
+	category DiskWriteCategory,
+	statsCollector *DiskWriteStatsCollector,
 	onSlowDisk func(OpType OpType, writeSizeInBytes int, duration time.Duration),
 ) *diskHealthCheckingFile {
+	var bytesWritten *atomic.Uint64
+	if statsCollector != nil {
+		statsCollector.mu.Lock()
+		if aggStats, ok := statsCollector.statsMap[category]; !ok {
+			bytesWritten = new(atomic.Uint64)
+			statsCollector.statsMap[category] = bytesWritten
+		} else {
+			bytesWritten = aggStats
+		}
+		statsCollector.mu.Unlock()
+	} else {
+		bytesWritten = new(atomic.Uint64)
+	}
 	return &diskHealthCheckingFile{
 		file:              file,
 		onSlowDisk:        onSlowDisk,
@@ -153,6 +223,8 @@ func newDiskHealthCheckingFile(
 
 		stopper:         make(chan struct{}),
 		createTimeNanos: time.Now().UnixNano(),
+
+		aggBytesWritten: bytesWritten,
 	}
 }
 
@@ -215,14 +287,16 @@ func (d *diskHealthCheckingFile) Write(p []byte) (n int, err error) {
 	d.timeDiskOp(OpTypeWrite, int64(len(p)), func() {
 		n, err = d.file.Write(p)
 	}, time.Now().UnixNano())
+	d.aggBytesWritten.Add(uint64(n))
 	return n, err
 }
 
-// Write implements the io.WriterAt interface.
+// WriteAt implements the io.WriterAt interface.
 func (d *diskHealthCheckingFile) WriteAt(p []byte, ofs int64) (n int, err error) {
 	d.timeDiskOp(OpTypeWrite, int64(len(p)), func() {
 		n, err = d.file.WriteAt(p, ofs)
 	}, time.Now().UnixNano())
+	d.aggBytesWritten.Add(uint64(n))
 	return n, err
 }
 
@@ -285,7 +359,7 @@ func (d *diskHealthCheckingFile) SyncTo(length int64) (fullSync bool, err error)
 func (d *diskHealthCheckingFile) timeDiskOp(
 	opType OpType, writeSizeInBytes int64, op func(), startNanos int64,
 ) {
-	if d == nil {
+	if d == nil || d.diskSlowThreshold == 0 {
 		op()
 		return
 	}
@@ -432,6 +506,7 @@ func (i DiskSlowInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 type diskHealthCheckingFS struct {
 	tickInterval      time.Duration
 	diskSlowThreshold time.Duration
+	statsCollector    *DiskWriteStatsCollector
 	onSlowDisk        func(DiskSlowInfo)
 	fs                FS
 	mu                struct {
@@ -463,13 +538,16 @@ type slot struct {
 var _ FS = (*diskHealthCheckingFS)(nil)
 
 // WithDiskHealthChecks wraps an FS and ensures that all write-oriented
-// operations on the FS are wrapped with disk health detection checks. Disk
-// operations that are observed to take longer than diskSlowThreshold trigger an
-// onSlowDisk call.
+// operations on the FS are wrapped with disk health detection checks and
+// aggregated. Disk operations that are observed to take longer than
+// diskSlowThreshold trigger an onSlowDisk call.
 //
 // A threshold of zero disables disk-health checking.
 func WithDiskHealthChecks(
-	innerFS FS, diskSlowThreshold time.Duration, onSlowDisk func(info DiskSlowInfo),
+	innerFS FS,
+	diskSlowThreshold time.Duration,
+	statsCollector *DiskWriteStatsCollector,
+	onSlowDisk func(info DiskSlowInfo),
 ) (FS, io.Closer) {
 	if diskSlowThreshold == 0 {
 		return innerFS, noopCloser{}
@@ -479,6 +557,7 @@ func WithDiskHealthChecks(
 		fs:                innerFS,
 		tickInterval:      defaultTickInterval,
 		diskSlowThreshold: diskSlowThreshold,
+		statsCollector:    statsCollector,
 		onSlowDisk:        onSlowDisk,
 	}
 	fs.mu.stopper = make(chan struct{})
@@ -657,15 +736,17 @@ func (d *diskHealthCheckingFS) Create(name string) (File, error) {
 	if d.diskSlowThreshold == 0 {
 		return f, nil
 	}
-	checkingFile := newDiskHealthCheckingFile(f, d.diskSlowThreshold, func(opType OpType, writeSizeInBytes int, duration time.Duration) {
-		d.onSlowDisk(
-			DiskSlowInfo{
-				Path:      name,
-				OpType:    opType,
-				WriteSize: writeSizeInBytes,
-				Duration:  duration,
-			})
-	})
+	// TODO(cheranm): add plumbing to pass down valid category.
+	checkingFile := newDiskHealthCheckingFile(f, d.diskSlowThreshold, WriteCategoryUnspecified, d.statsCollector,
+		func(opType OpType, writeSizeInBytes int, duration time.Duration) {
+			d.onSlowDisk(
+				DiskSlowInfo{
+					Path:      name,
+					OpType:    opType,
+					WriteSize: writeSizeInBytes,
+					Duration:  duration,
+				})
+		})
 	checkingFile.startTicker()
 	return checkingFile, nil
 }
@@ -710,7 +791,12 @@ func (d *diskHealthCheckingFS) Open(name string, opts ...OpenOption) (File, erro
 
 // OpenReadWrite implements the FS interface.
 func (d *diskHealthCheckingFS) OpenReadWrite(name string, opts ...OpenOption) (File, error) {
-	return d.fs.OpenReadWrite(name, opts...)
+	f, err := d.fs.OpenReadWrite(name, opts...)
+	if err != nil {
+		return nil, err
+	}
+	// TODO(cheranm): add plumbing to pass down valid category.
+	return newDiskHealthCheckingFile(f, 0, WriteCategoryUnspecified, d.statsCollector, func(opType OpType, writeSizeInBytes int, duration time.Duration) {}), nil
 }
 
 // OpenDir implements the FS interface.
@@ -783,15 +869,17 @@ func (d *diskHealthCheckingFS) ReuseForWrite(oldname, newname string) (File, err
 	if d.diskSlowThreshold == 0 {
 		return f, nil
 	}
-	checkingFile := newDiskHealthCheckingFile(f, d.diskSlowThreshold, func(opType OpType, writeSizeInBytes int, duration time.Duration) {
-		d.onSlowDisk(
-			DiskSlowInfo{
-				Path:      newname,
-				OpType:    opType,
-				WriteSize: writeSizeInBytes,
-				Duration:  duration,
-			})
-	})
+	// TODO(cheranm): add plumbing to pass down valid category.
+	checkingFile := newDiskHealthCheckingFile(f, d.diskSlowThreshold, WriteCategoryUnspecified, d.statsCollector,
+		func(opType OpType, writeSizeInBytes int, duration time.Duration) {
+			d.onSlowDisk(
+				DiskSlowInfo{
+					Path:      newname,
+					OpType:    opType,
+					WriteSize: writeSizeInBytes,
+					Duration:  duration,
+				})
+		})
 	checkingFile.startTicker()
 	return checkingFile, nil
 }

--- a/vfs/disk_health_test.go
+++ b/vfs/disk_health_test.go
@@ -215,6 +215,58 @@ func (m mockFS) GetDiskUsage(path string) (DiskUsage, error) {
 
 var _ FS = &mockFS{}
 
+func TestDiskHealthChecking_WriteStatsCollector(t *testing.T) {
+	writeBuffer := []byte("test")
+	writeSizeInBytes := uint64(len(writeBuffer))
+
+	testCases := []struct {
+		desc            string
+		writeCategories []DiskWriteCategory
+		numWrites       int
+		wantStats       []DiskWriteStatsAggregate
+	}{
+		{
+			desc:            "no write registered",
+			writeCategories: []DiskWriteCategory{},
+			numWrites:       0,
+			wantStats:       []DiskWriteStatsAggregate(nil),
+		},
+		{
+			desc:            "multiple writes to a single category",
+			writeCategories: []DiskWriteCategory{"test1"},
+			numWrites:       2,
+			wantStats: []DiskWriteStatsAggregate{
+				{Category: "test1", BytesWritten: 2 * writeSizeInBytes},
+			},
+		},
+		{
+			desc:            "writes to multiple categories",
+			writeCategories: []DiskWriteCategory{"test1", "test2"},
+			numWrites:       2,
+			wantStats: []DiskWriteStatsAggregate{
+				{Category: "test1", BytesWritten: 2 * writeSizeInBytes},
+				{Category: "test2", BytesWritten: 2 * writeSizeInBytes},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			statsCollector := NewDiskWriteStatsCollector()
+			for _, category := range tc.writeCategories {
+				f := newDiskHealthCheckingFile(&mockFile{syncAndWriteDuration: 0}, 0, category, statsCollector,
+					func(OpType OpType, writeSizeInBytes int, duration time.Duration) {})
+				for i := 0; i < tc.numWrites; i++ {
+					n, err := f.Write(writeBuffer)
+					require.NoError(t, err)
+					require.Equal(t, writeSizeInBytes, uint64(n))
+				}
+			}
+			expectedStats := statsCollector.GetStats()
+			require.Equal(t, tc.wantStats, expectedStats)
+		})
+	}
+}
+
 func TestDiskHealthChecking_File(t *testing.T) {
 	oldTickInterval := defaultTickInterval
 	defaultTickInterval = time.Millisecond
@@ -255,7 +307,7 @@ func TestDiskHealthChecking_File(t *testing.T) {
 			mockFS := &mockFS{create: func(name string) (File, error) {
 				return mockFile{syncAndWriteDuration: tc.writeDuration}, nil
 			}}
-			fs, closer := WithDiskHealthChecks(mockFS, slowThreshold,
+			fs, closer := WithDiskHealthChecks(mockFS, slowThreshold, nil,
 				func(info DiskSlowInfo) {
 					diskSlow <- info
 				})
@@ -362,10 +414,11 @@ func TestDiskHealthChecking_File_PackingAndUnpacking(t *testing.T) {
 
 func TestDiskHealthChecking_File_Underflow(t *testing.T) {
 	f := &mockFile{}
-	hcFile := newDiskHealthCheckingFile(f, 1*time.Second, func(opType OpType, writeSizeInBytes int, duration time.Duration) {
-		// We expect to panic before sending the event.
-		t.Fatalf("unexpected slow disk event")
-	})
+	hcFile := newDiskHealthCheckingFile(f, 1*time.Second, "test-category", nil,
+		func(opType OpType, writeSizeInBytes int, duration time.Duration) {
+			// We expect to panic before sending the event.
+			t.Fatalf("unexpected slow disk event")
+		})
 	defer hcFile.Close()
 
 	t.Run("too large delta leads to panic", func(t *testing.T) {
@@ -481,7 +534,7 @@ func TestDiskHealthChecking_Filesystem(t *testing.T) {
 	var stallCount atomic.Uint64
 	unstall := make(chan struct{})
 	var lastOpType OpType
-	fs, closer := WithDiskHealthChecks(filesystemOpsMockFS(unstall), stallThreshold,
+	fs, closer := WithDiskHealthChecks(filesystemOpsMockFS(unstall), stallThreshold, nil,
 		func(info DiskSlowInfo) {
 			require.Equal(t, 0, info.WriteSize)
 			stallCount.Add(1)
@@ -530,7 +583,7 @@ func TestDiskHealthChecking_Filesystem_Close(t *testing.T) {
 	files := []string{"foo", "bar", "bax"}
 	var lastPath string
 	stalled := make(chan string)
-	fs, closer := WithDiskHealthChecks(mockFS, stallThreshold,
+	fs, closer := WithDiskHealthChecks(mockFS, stallThreshold, nil,
 		func(info DiskSlowInfo) {
 			if lastPath != info.Path {
 				lastPath = info.Path

--- a/vfs/fd_test.go
+++ b/vfs/fd_test.go
@@ -21,8 +21,8 @@ func TestFileWrappersHaveFd(t *testing.T) {
 	defer os.Remove(filename)
 
 	// File wrapper case 1: Check if diskHealthCheckingFile has Fd().
-	fs2, closer := WithDiskHealthChecks(Default, 10*time.Second,
-		func(info DiskSlowInfo) {})
+	fs2, closer := WithDiskHealthChecks(Default, 10*time.Second, nil, func(info DiskSlowInfo) {})
+
 	defer closer.Close()
 	f2, err := fs2.Open(filename)
 	require.NoError(t, err)


### PR DESCRIPTION
This commit introduces a disk write stats collector to the disk health checking virtual file system. It makes it possible to aggregate the bytes written on a `Write([]byte)` call and identify the behaviour that is responsible. This commit will be followed up with changes to pass down the write category to the vfs layer and changes to export categorized write metrics at the cockroach layer.

Informs cockroachdb/cockroach#115434