### PR TITLE
db: refactor table cache newIters

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2891,9 +2891,9 @@ func TestCompactionCheckOrdering(t *testing.T) {
 				}
 
 				newIters := func(
-					_ context.Context, _ *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts,
-				) (internalIterator, keyspan.FragmentIterator, error) {
-					return &errorIter{}, nil, nil
+					_ context.Context, _ *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts, _ iterKinds,
+				) (iterSet, error) {
+					return iterSet{point: &errorIter{}}, nil
 				}
 				result := "OK"
 				_, err := c.newInputIter(newIters, nil, nil)

--- a/db.go
+++ b/db.go
@@ -3076,42 +3076,33 @@ func (d *DB) checkVirtualBounds(m *fileMetadata) {
 		return
 	}
 
+	iters, err := d.newIters.all(context.TODO(), m, nil, internalIterOpts{})
+	if err != nil {
+		panic(errors.Wrap(err, "pebble: error creating iterators"))
+	}
+	defer iters.CloseAll()
+
 	if m.HasPointKeys {
-		pointIter, rangeDelIter, err := d.newIters(context.TODO(), m, nil, internalIterOpts{})
-		if err != nil {
-			panic(errors.Wrap(err, "pebble: error creating point iterator"))
-		}
-
-		defer pointIter.Close()
-		if rangeDelIter != nil {
-			defer rangeDelIter.Close()
-		}
-
-		pointKey, _ := pointIter.First()
-		var rangeDel *keyspan.Span
-		if rangeDelIter != nil {
-			rangeDel, err = rangeDelIter.First()
-			if err != nil {
-				panic(err)
-			}
-		}
+		pointIter := iters.Point()
+		rangeDelIter := iters.RangeDeletion()
 
 		// Check that the lower bound is tight.
+		pointKey, _ := pointIter.First()
+		rangeDel, err := rangeDelIter.First()
+		if err != nil {
+			panic(err)
+		}
 		if (rangeDel == nil || d.cmp(rangeDel.SmallestKey().UserKey, m.SmallestPointKey.UserKey) != 0) &&
 			(pointKey == nil || d.cmp(pointKey.UserKey, m.SmallestPointKey.UserKey) != 0) {
 			panic(errors.Newf("pebble: virtual sstable %s lower point key bound is not tight", m.FileNum))
 		}
 
-		pointKey, _ = pointIter.Last()
-		rangeDel = nil
-		if rangeDelIter != nil {
-			rangeDel, err = rangeDelIter.Last()
-			if err != nil {
-				panic(err)
-			}
-		}
-
 		// Check that the upper bound is tight.
+		pointKey, _ = pointIter.Last()
+		rangeDel, err = rangeDelIter.Last()
+		if err != nil {
+			panic(err)
+		}
 		if (rangeDel == nil || d.cmp(rangeDel.LargestKey().UserKey, m.LargestPointKey.UserKey) != 0) &&
 			(pointKey == nil || d.cmp(pointKey.UserKey, m.LargestPointKey.UserKey) != 0) {
 			panic(errors.Newf("pebble: virtual sstable %s upper point key bound is not tight", m.FileNum))
@@ -3123,32 +3114,24 @@ func (d *DB) checkVirtualBounds(m *fileMetadata) {
 				panic(errors.Newf("pebble: virtual sstable %s point key %s is not within bounds", m.FileNum, key.UserKey))
 			}
 		}
-
-		if rangeDelIter != nil {
-			s, err := rangeDelIter.First()
-			for ; s != nil; s, err = rangeDelIter.Next() {
-				if d.cmp(s.SmallestKey().UserKey, m.SmallestPointKey.UserKey) < 0 {
-					panic(errors.Newf("pebble: virtual sstable %s point key %s is not within bounds", m.FileNum, s.SmallestKey().UserKey))
-				}
-				if d.cmp(s.LargestKey().UserKey, m.LargestPointKey.UserKey) > 0 {
-					panic(errors.Newf("pebble: virtual sstable %s point key %s is not within bounds", m.FileNum, s.LargestKey().UserKey))
-				}
+		s, err := rangeDelIter.First()
+		for ; s != nil; s, err = rangeDelIter.Next() {
+			if d.cmp(s.SmallestKey().UserKey, m.SmallestPointKey.UserKey) < 0 {
+				panic(errors.Newf("pebble: virtual sstable %s point key %s is not within bounds", m.FileNum, s.SmallestKey().UserKey))
 			}
-			if err != nil {
-				panic(err)
+			if d.cmp(s.LargestKey().UserKey, m.LargestPointKey.UserKey) > 0 {
+				panic(errors.Newf("pebble: virtual sstable %s point key %s is not within bounds", m.FileNum, s.LargestKey().UserKey))
 			}
+		}
+		if err != nil {
+			panic(err)
 		}
 	}
 
 	if !m.HasRangeKeys {
 		return
 	}
-
-	rangeKeyIter, err := d.tableNewRangeKeyIter(m, keyspan.SpanIterOptions{})
-	if err != nil {
-		panic(errors.Wrap(err, "pebble: error creating range key iterator"))
-	}
-	defer rangeKeyIter.Close()
+	rangeKeyIter := iters.RangeKey()
 
 	// Check that the lower bound is tight.
 	if s, err := rangeKeyIter.First(); err != nil {

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -139,9 +139,8 @@ func NewExternalIterWithContext(
 		// Add the readers to the Iterator so that Close closes them, and
 		// SetOptions can re-construct iterators from them.
 		externalReaders: readers,
-		newIters: func(
-			ctx context.Context, f *manifest.FileMetadata, opts *IterOptions,
-			internalOpts internalIterOpts) (internalIterator, keyspan.FragmentIterator, error) {
+		newIters: func(context.Context, *manifest.FileMetadata, *IterOptions,
+			internalIterOpts, iterKinds) (iterSet, error) {
 			// NB: External iterators are currently constructed without any
 			// `levelIters`. newIters should never be called. When we support
 			// organizing multiple non-overlapping files into a single level

--- a/flushable.go
+++ b/flushable.go
@@ -219,7 +219,7 @@ func (s *ingestedFlushable) constructRangeDelIter(
 ) (keyspan.FragmentIterator, error) {
 	// Note that the keyspan level iter expects a non-nil iterator to be
 	// returned even if there is an error. So, we return the emptyKeyspanIter.
-	iter, rangeDelIter, err := s.newIters(context.Background(), file, nil, internalIterOpts{})
+	iter, rangeDelIter, err := s.newIters.TODO(context.Background(), file, nil, internalIterOpts{})
 	if err != nil {
 		return emptyKeyspanIter, err
 	}

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 )
@@ -387,13 +386,13 @@ func TestGetIter(t *testing.T) {
 		// m is a map from file numbers to DBs.
 		m := map[FileNum]*memTable{}
 		newIter := func(
-			_ context.Context, file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts,
-		) (internalIterator, keyspan.FragmentIterator, error) {
+			_ context.Context, file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts, _ iterKinds,
+		) (iterSet, error) {
 			d, ok := m[file.FileNum]
 			if !ok {
-				return nil, nil, errors.New("no such file")
+				return iterSet{}, errors.New("no such file")
 			}
-			return d.newIter(nil), nil, nil
+			return iterSet{point: d.newIter(nil)}, nil
 		}
 
 		var files [numLevels][]*fileMetadata

--- a/ingest.go
+++ b/ingest.go
@@ -1663,7 +1663,7 @@ func (d *DB) excise(
 			// This file will contain point keys
 			smallestPointKey := m.SmallestPointKey
 			var err error
-			iter, rangeDelIter, err = d.newIters(context.TODO(), m, &IterOptions{
+			iter, rangeDelIter, err = d.newIters.TODO(context.TODO(), m, &IterOptions{
 				CategoryAndQoS: sstable.CategoryAndQoS{
 					Category: "pebble-ingest",
 					QoSLevel: sstable.LatencySensitiveQoSLevel,
@@ -1781,7 +1781,7 @@ func (d *DB) excise(
 		largestPointKey := m.LargestPointKey
 		var err error
 		if iter == nil && rangeDelIter == nil {
-			iter, rangeDelIter, err = d.newIters(context.TODO(), m, &IterOptions{
+			iter, rangeDelIter, err = d.newIters.TODO(context.TODO(), m, &IterOptions{
 				CategoryAndQoS: sstable.CategoryAndQoS{
 					Category: "pebble-ingest",
 					QoSLevel: sstable.LatencySensitiveQoSLevel,

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/bytealloc"
 	"github.com/cockroachdb/pebble/internal/invalidating"
-	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
@@ -919,14 +918,14 @@ func TestIteratorSeekOpt(t *testing.T) {
 			oldNewIters := d.newIters
 			d.newIters = func(
 				ctx context.Context, file *manifest.FileMetadata, opts *IterOptions,
-				internalOpts internalIterOpts) (internalIterator, keyspan.FragmentIterator, error) {
-				iter, rangeIter, err := oldNewIters(ctx, file, opts, internalOpts)
-				iterWrapped := &iterSeekOptWrapper{
-					internalIterator:      iter,
+				internalOpts internalIterOpts, kinds iterKinds) (iterSet, error) {
+				iters, err := oldNewIters(ctx, file, opts, internalOpts, kinds)
+				iters.point = &iterSeekOptWrapper{
+					internalIterator:      iters.point,
 					seekGEUsingNext:       &seekGEUsingNext,
 					seekPrefixGEUsingNext: &seekPrefixGEUsingNext,
 				}
-				return iterWrapped, rangeIter, err
+				return iters, err
 			}
 			return s
 

--- a/level_checker.go
+++ b/level_checker.go
@@ -385,7 +385,7 @@ func checkRangeTombstones(c *checkConfig) error {
 		for f := files.First(); f != nil; f = files.Next() {
 			lf := files.Take()
 			//lower, upper := manifest.KeyRange(c.cmp, lf.Iter())
-			iterToClose, iter, err := c.newIters(
+			iterToClose, iter, err := c.newIters.TODO(
 				context.Background(), lf.FileMetadata, &IterOptions{level: manifest.Level(lsmLevel)}, internalIterOpts{})
 			if err != nil {
 				return err

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -95,17 +95,20 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 
 	var fileNum FileNum
 	newIters :=
-		func(_ context.Context, file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts) (internalIterator, keyspan.FragmentIterator, error) {
+		func(_ context.Context, file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts, _ iterKinds) (iterSet, error) {
 			r := readers[file.FileNum]
 			rangeDelIter, err := r.NewRawRangeDelIter()
 			if err != nil {
-				return nil, nil, err
+				return iterSet{}, err
 			}
 			iter, err := r.NewIter(nil /* lower */, nil /* upper */)
 			if err != nil {
-				return nil, nil, err
+				return iterSet{}, err
 			}
-			return iter, rangeDelIter, nil
+			return iterSet{
+				point:         iter,
+				rangeDeletion: rangeDelIter,
+			}, nil
 		}
 
 	fm := &failMerger{}

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -36,12 +36,12 @@ func TestLevelIter(t *testing.T) {
 	var files manifest.LevelSlice
 
 	newIters := func(
-		_ context.Context, file *manifest.FileMetadata, opts *IterOptions, _ internalIterOpts,
-	) (internalIterator, keyspan.FragmentIterator, error) {
+		_ context.Context, file *manifest.FileMetadata, opts *IterOptions, _ internalIterOpts, _ iterKinds,
+	) (iterSet, error) {
 		f := *iters[file.FileNum]
 		f.lower = opts.GetLowerBound()
 		f.upper = opts.GetUpperBound()
-		return &f, nil, nil
+		return iterSet{point: &f}, nil
 	}
 
 	datadriven.RunTest(t, "testdata/level_iter", func(t *testing.T, d *datadriven.TestData) string {
@@ -123,10 +123,10 @@ func TestLevelIter(t *testing.T) {
 			var tableOpts *IterOptions
 			newIters2 := func(
 				ctx context.Context, file *manifest.FileMetadata, opts *IterOptions,
-				internalOpts internalIterOpts,
-			) (internalIterator, keyspan.FragmentIterator, error) {
+				internalOpts internalIterOpts, kinds iterKinds,
+			) (iterSet, error) {
 				tableOpts = opts
-				return newIters(ctx, file, opts, internalOpts)
+				return newIters(ctx, file, opts, internalOpts, kinds)
 			}
 
 			iter := newLevelIter(context.Background(), opts, testkeys.Comparer, newIters2, files.Iter(), manifest.Level(level), internalIterOpts{})
@@ -158,20 +158,24 @@ func newLevelIterTest() *levelIterTest {
 }
 
 func (lt *levelIterTest) newIters(
-	ctx context.Context, file *manifest.FileMetadata, opts *IterOptions, iio internalIterOpts,
-) (internalIterator, keyspan.FragmentIterator, error) {
+	ctx context.Context,
+	file *manifest.FileMetadata,
+	opts *IterOptions,
+	iio internalIterOpts,
+	kinds iterKinds,
+) (iterSet, error) {
 	lt.itersCreated++
 	iter, err := lt.readers[file.FileNum].NewIterWithBlockPropertyFiltersAndContextEtc(
 		ctx, opts.LowerBound, opts.UpperBound, nil, false, true, iio.stats, sstable.CategoryAndQoS{},
 		nil, sstable.TrivialReaderProvider{Reader: lt.readers[file.FileNum]})
 	if err != nil {
-		return nil, nil, err
+		return iterSet{}, err
 	}
 	rangeDelIter, err := lt.readers[file.FileNum].NewRawRangeDelIter()
 	if err != nil {
-		return nil, nil, err
+		return iterSet{}, err
 	}
-	return iter, rangeDelIter, nil
+	return iterSet{point: iter, rangeDeletion: rangeDelIter}, nil
 }
 
 func (lt *levelIterTest) runClear(d *datadriven.TestData) string {
@@ -535,10 +539,10 @@ func BenchmarkLevelIterSeekGE(b *testing.B) {
 							readers, metas, keys, cleanup := buildLevelIterTables(b, blockSize, restartInterval, count)
 							defer cleanup()
 							newIters := func(
-								_ context.Context, file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts,
-							) (internalIterator, keyspan.FragmentIterator, error) {
+								_ context.Context, file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts, _ iterKinds,
+							) (iterSet, error) {
 								iter, err := readers[file.FileNum].NewIter(nil /* lower */, nil /* upper */)
-								return iter, nil, err
+								return iterSet{point: iter}, err
 							}
 							l := newLevelIter(context.Background(), IterOptions{}, DefaultComparer, newIters, metas.Iter(), manifest.Level(level), internalIterOpts{})
 							rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
@@ -576,11 +580,11 @@ func BenchmarkLevelIterSeqSeekGEWithBounds(b *testing.B) {
 							// This newIters is cheaper than in practice since it does not do
 							// tableCacheShard.findNode.
 							newIters := func(
-								_ context.Context, file *manifest.FileMetadata, opts *IterOptions, _ internalIterOpts,
-							) (internalIterator, keyspan.FragmentIterator, error) {
+								_ context.Context, file *manifest.FileMetadata, opts *IterOptions, _ internalIterOpts, _ iterKinds,
+							) (iterSet, error) {
 								iter, err := readers[file.FileNum].NewIter(
 									opts.LowerBound, opts.UpperBound)
-								return iter, nil, err
+								return iterSet{point: iter}, err
 							}
 							l := newLevelIter(context.Background(), IterOptions{}, DefaultComparer, newIters, metas.Iter(), manifest.Level(level), internalIterOpts{})
 							// Fake up the range deletion initialization, to resemble the usage
@@ -618,11 +622,11 @@ func BenchmarkLevelIterSeqSeekPrefixGE(b *testing.B) {
 	// This newIters is cheaper than in practice since it does not do
 	// tableCacheShard.findNode.
 	newIters := func(
-		_ context.Context, file *manifest.FileMetadata, opts *IterOptions, _ internalIterOpts,
-	) (internalIterator, keyspan.FragmentIterator, error) {
+		_ context.Context, file *manifest.FileMetadata, opts *IterOptions, _ internalIterOpts, _ iterKinds,
+	) (iterSet, error) {
 		iter, err := readers[file.FileNum].NewIter(
 			opts.LowerBound, opts.UpperBound)
-		return iter, nil, err
+		return iterSet{point: iter}, err
 	}
 
 	for _, skip := range []int{1, 2, 4, 8, 16} {
@@ -669,10 +673,10 @@ func BenchmarkLevelIterNext(b *testing.B) {
 							readers, metas, _, cleanup := buildLevelIterTables(b, blockSize, restartInterval, count)
 							defer cleanup()
 							newIters := func(
-								_ context.Context, file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts,
-							) (internalIterator, keyspan.FragmentIterator, error) {
+								_ context.Context, file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts, _ iterKinds,
+							) (iterSet, error) {
 								iter, err := readers[file.FileNum].NewIter(nil /* lower */, nil /* upper */)
-								return iter, nil, err
+								return iterSet{point: iter}, err
 							}
 							l := newLevelIter(context.Background(), IterOptions{}, testkeys.Comparer, newIters, metas.Iter(), manifest.Level(level), internalIterOpts{})
 
@@ -703,10 +707,10 @@ func BenchmarkLevelIterPrev(b *testing.B) {
 							readers, metas, _, cleanup := buildLevelIterTables(b, blockSize, restartInterval, count)
 							defer cleanup()
 							newIters := func(
-								_ context.Context, file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts,
-							) (internalIterator, keyspan.FragmentIterator, error) {
+								_ context.Context, file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts, _ iterKinds,
+							) (iterSet, error) {
 								iter, err := readers[file.FileNum].NewIter(nil /* lower */, nil /* upper */)
-								return iter, nil, err
+								return iterSet{point: iter}, err
 							}
 							l := newLevelIter(context.Background(), IterOptions{}, DefaultComparer, newIters, metas.Iter(), manifest.Level(level), internalIterOpts{})
 

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -464,7 +464,7 @@ func (d *DB) truncateSharedFile(
 
 	// We will need to truncate file bounds in at least one direction. Open all
 	// relevant iterators.
-	iter, rangeDelIter, err := d.newIters(ctx, file, &IterOptions{
+	iter, rangeDelIter, err := d.newIters.TODO(ctx, file, &IterOptions{
 		LowerBound: lower,
 		UpperBound: upper,
 		level:      manifest.Level(level),

--- a/table_cache.go
+++ b/table_cache.go
@@ -140,14 +140,32 @@ func (c *tableCacheContainer) newIters(
 	file *manifest.FileMetadata,
 	opts *IterOptions,
 	internalOpts internalIterOpts,
-) (internalIterator, keyspan.FragmentIterator, error) {
-	return c.tableCache.getShard(file.FileBacking.DiskFileNum).newIters(ctx, file, opts, internalOpts, &c.dbOpts)
+	kinds iterKinds,
+) (iterSet, error) {
+	return c.tableCache.getShard(file.FileBacking.DiskFileNum).newIters(ctx, file, opts, internalOpts, &c.dbOpts, kinds)
 }
 
 func (c *tableCacheContainer) newRangeKeyIter(
-	file *manifest.FileMetadata, opts keyspan.SpanIterOptions,
+	file *manifest.FileMetadata, spanOpts keyspan.SpanIterOptions,
 ) (keyspan.FragmentIterator, error) {
-	return c.tableCache.getShard(file.FileBacking.DiskFileNum).newRangeKeyIter(file, opts, &c.dbOpts)
+	s := c.tableCache.getShard(file.FileBacking.DiskFileNum)
+	// Calling findNode gives us the responsibility of decrementing v's
+	// refCount. A range key iterator doesn't need to hold on to the underlying
+	// Reader, so we're able to unrefValue regardless of whether we succeed or
+	// fail.
+	v := s.findNode(file, &c.dbOpts)
+	defer s.unrefValue(v)
+	if v.err != nil {
+		return nil, v.err
+	}
+	iter, err := s.newRangeKeyIter(v, createCommonReader(v, file), spanOpts)
+	if err != nil {
+		return nil, err
+	}
+	if iter == nil {
+		iter = emptyKeyspanIter
+	}
+	return iter, err
 }
 
 // getTableProperties returns the properties associated with the backing physical
@@ -201,17 +219,13 @@ func (c *tableCacheContainer) estimateSize(
 	return size, nil
 }
 
-// createCommonReader creates a Reader for this file. isShared, if true for
-// virtual sstables, is passed into the vSSTable reader so its iterators can
-// collapse obsolete points accordingly.
-func createCommonReader(
-	v *tableCacheValue, file *fileMetadata, isShared bool,
-) sstable.CommonReader {
+// createCommonReader creates a Reader for this file.
+func createCommonReader(v *tableCacheValue, file *fileMetadata) sstable.CommonReader {
 	// TODO(bananabrick): We suffer an allocation if file is a virtual sstable.
 	var cr sstable.CommonReader = v.reader
 	if file.Virtual {
 		virtualReader := sstable.MakeVirtualReader(
-			v.reader, file.VirtualMeta(), isShared,
+			v.reader, file.VirtualMeta(), v.isShared,
 		)
 		cr = &virtualReader
 	}
@@ -227,12 +241,7 @@ func (c *tableCacheContainer) withCommonReader(
 	if v.err != nil {
 		return v.err
 	}
-	provider := c.dbOpts.objProvider
-	objMeta, err := provider.Lookup(fileTypeTable, meta.FileBacking.DiskFileNum)
-	if err != nil {
-		return err
-	}
-	return fn(createCommonReader(v, meta, objMeta.IsShared()))
+	return fn(createCommonReader(v, meta))
 }
 
 func (c *tableCacheContainer) withReader(meta physicalMeta, fn func(*sstable.Reader) error) error {
@@ -430,7 +439,8 @@ func (c *tableCacheShard) newIters(
 	opts *IterOptions,
 	internalOpts internalIterOpts,
 	dbOpts *tableCacheOpts,
-) (internalIterator, keyspan.FragmentIterator, error) {
+	kinds iterKinds,
+) (iterSet, error) {
 	// TODO(sumeer): constructing the Reader should also use a plumbed context,
 	// since parts of the sstable are read during the construction. The Reader
 	// should not remember that context since the Reader can be long-lived.
@@ -442,11 +452,64 @@ func (c *tableCacheShard) newIters(
 	v := c.findNode(file, dbOpts)
 	if v.err != nil {
 		defer c.unrefValue(v)
-		return nil, nil, v.err
+		return iterSet{}, v.err
 	}
 
-	hideObsoletePoints := false
-	var pointKeyFilters []BlockPropertyFilter
+	// Note: This suffers an allocation for virtual sstables.
+	cr := createCommonReader(v, file)
+	var iters iterSet
+	var err error
+	if kinds.RangeKey() {
+		iters.rangeKey, err = c.newRangeKeyIter(v, cr, opts.SpanIterOptions())
+	}
+	if kinds.RangeDeletion() && err == nil {
+		iters.rangeDeletion, err = c.newRangeDelIter(ctx, file, cr, dbOpts)
+	}
+	if kinds.Point() && err == nil {
+		iters.point, err = c.newPointIter(ctx, v, file, cr, opts, internalOpts, dbOpts)
+	}
+	if err != nil {
+		// NB: There's a subtlety here: Because the point iterator is the last
+		// iterator we attempt to create, it's not possible for:
+		//   err != nil && iters.point != nil
+		// If it were possible, we'd need to account for it to avoid double
+		// unref-ing here, once during CloseAll and once during `unrefValue`.
+		iters.CloseAll()
+		c.unrefValue(v)
+		return iterSet{}, err
+	}
+	// Only point iterators ever require the reader stay pinned in the cache. If
+	// we're not returning a point iterator to the caller, we need to unref v.
+	// There's an added subtlety that iters.point may be non-nil but not a true
+	// iterator that's ref'd the underlying reader if block filters excluded the
+	// entirety of the table.
+	//
+	// TODO(jackson): This `filteredAll` subtlety can be removed after the
+	// planned #2863 refactor, when there will be no need to return a special
+	// empty iterator type to signify that point keys were filtered.
+	if iters.point == nil || iters.point == filteredAll {
+		c.unrefValue(v)
+	}
+	return iters, nil
+}
+
+// newPointIter is an internal helper that constructs a point iterator over a
+// sstable. This function is for internal use only, and callers should use
+// newIters instead.
+func (c *tableCacheShard) newPointIter(
+	ctx context.Context,
+	v *tableCacheValue,
+	file *manifest.FileMetadata,
+	cr sstable.CommonReader,
+	opts *IterOptions,
+	internalOpts internalIterOpts,
+	dbOpts *tableCacheOpts,
+) (internalIterator, error) {
+	var (
+		hideObsoletePoints bool = false
+		pointKeyFilters    []BlockPropertyFilter
+		filterer           *sstable.BlockPropertiesFilterer
+	)
 	if opts != nil {
 		// This code is appending (at most one filter) in-place to
 		// opts.PointKeyFilters even though the slice is shared for iterators in
@@ -470,64 +533,18 @@ func (c *tableCacheShard) newIters(
 		hideObsoletePoints, pointKeyFilters =
 			v.reader.TryAddBlockPropertyFilterForHideObsoletePoints(
 				opts.snapshotForHideObsoletePoints, file.LargestSeqNum, opts.PointKeyFilters)
-	}
-	ok := true
-	var filterer *sstable.BlockPropertiesFilterer
-	var err error
-	if opts != nil {
+
+		var ok bool
+		var err error
 		ok, filterer, err = c.checkAndIntersectFilters(v, opts.TableFilter,
 			pointKeyFilters, internalOpts.boundLimitedFilter)
-	}
-	if err != nil {
-		c.unrefValue(v)
-		return nil, nil, err
-	}
-
-	provider := dbOpts.objProvider
-	// Check if this file is a foreign file.
-	objMeta, err := provider.Lookup(fileTypeTable, file.FileBacking.DiskFileNum)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Note: This suffers an allocation for virtual sstables.
-	cr := createCommonReader(v, file, objMeta.IsShared())
-
-	// NB: range-del iterator does not maintain a reference to the table, nor
-	// does it need to read from it after creation.
-	rangeDelIter, err := cr.NewRawRangeDelIter()
-	if err != nil {
-		c.unrefValue(v)
-		return nil, nil, err
-	}
-
-	// Assert expected bounds in tests.
-	if invariants.Enabled && rangeDelIter != nil {
-		cmp := base.DefaultComparer.Compare
-		if dbOpts.opts.Comparer != nil {
-			cmp = dbOpts.opts.Comparer.Compare
+		if err != nil {
+			return nil, err
+		} else if !ok {
+			// Return an empty iterator. This iterator has no mutable state, so
+			// using a singleton is fine.
+			return filteredAll, err
 		}
-		// TODO(radu): we should be using AssertBounds, but it currently fails in
-		// some cases (#3167).
-		rangeDelIter = keyspan.AssertUserKeyBounds(
-			rangeDelIter, file.SmallestPointKey.UserKey, file.LargestPointKey.UserKey, cmp,
-		)
-	}
-
-	if !ok {
-		c.unrefValue(v)
-		// Return an empty iterator. This iterator has no mutable state, so
-		// using a singleton is fine.
-		// NB: We still return the potentially non-empty rangeDelIter. This
-		// ensures the iterator observes the file's range deletions even if the
-		// block property filters exclude all the file's point keys. The range
-		// deletions may still delete keys lower in the LSM in files that DO
-		// match the active filters.
-		//
-		// The point iterator returned must implement the filteredIter
-		// interface, so that the level iterator surfaces file boundaries when
-		// range deletions are present.
-		return filteredAll, rangeDelIter, err
 	}
 
 	var iter sstable.Iterator
@@ -538,16 +555,16 @@ func (c *tableCacheShard) newIters(
 	}
 	tableFormat, err := v.reader.TableFormat()
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	var rp sstable.ReaderProvider
 	if tableFormat >= sstable.TableFormatPebblev3 && v.reader.Properties.NumValueBlocks > 0 {
 		rp = &tableCacheShardReaderProvider{c: c, file: file, dbOpts: dbOpts}
 	}
 
-	if objMeta.IsShared() && v.reader.Properties.GlobalSeqNum != 0 {
+	if v.isShared && v.reader.Properties.GlobalSeqNum != 0 {
 		if tableFormat < sstable.TableFormatPebblev4 {
-			return nil, nil, errors.New("pebble: shared ingested sstable has a lower table format than expected")
+			return nil, errors.New("pebble: shared ingested sstable has a lower table format than expected")
 		}
 		// The table is shared and ingested.
 		hideObsoletePoints = true
@@ -566,16 +583,11 @@ func (c *tableCacheShard) newIters(
 			internalOpts.stats, categoryAndQoS, dbOpts.sstStatsCollector, rp)
 	}
 	if err != nil {
-		if rangeDelIter != nil {
-			_ = rangeDelIter.Close()
-		}
-		c.unrefValue(v)
-		return nil, nil, err
+		return nil, err
 	}
 	// NB: v.closeHook takes responsibility for calling unrefValue(v) here. Take
 	// care to avoid introducing an allocation here by adding a closure.
 	iter.SetCloseHook(v.closeHook)
-
 	c.iterCount.Add(1)
 	dbOpts.iterCount.Add(1)
 	if invariants.RaceEnabled {
@@ -583,73 +595,56 @@ func (c *tableCacheShard) newIters(
 		c.mu.iters[iter] = debug.Stack()
 		c.mu.Unlock()
 	}
-	return iter, rangeDelIter, nil
+	return iter, nil
 }
 
-func (c *tableCacheShard) newRangeKeyIter(
-	file *manifest.FileMetadata, opts keyspan.SpanIterOptions, dbOpts *tableCacheOpts,
+// newRangeDelIter is an internal helper that constructs an iterator over a
+// sstable's range deletions. This function is for table-cache internal use
+// only, and callers should use newIters instead.
+func (c *tableCacheShard) newRangeDelIter(
+	ctx context.Context, file *manifest.FileMetadata, cr sstable.CommonReader, dbOpts *tableCacheOpts,
 ) (keyspan.FragmentIterator, error) {
-	// Calling findNode gives us the responsibility of decrementing v's
-	// refCount. If opening the underlying table resulted in error, then we
-	// decrement this straight away. Otherwise, we pass that responsibility to
-	// the sstable iterator, which decrements when it is closed.
-	v := c.findNode(file, dbOpts)
-	if v.err != nil {
-		defer c.unrefValue(v)
-		return nil, v.err
+	// NB: range-del iterator does not maintain a reference to the table, nor
+	// does it need to read from it after creation.
+	rangeDelIter, err := cr.NewRawRangeDelIter()
+	if err != nil {
+		return nil, err
 	}
+	// Assert expected bounds in tests.
+	if invariants.Enabled && rangeDelIter != nil {
+		cmp := base.DefaultComparer.Compare
+		if dbOpts.opts.Comparer != nil {
+			cmp = dbOpts.opts.Comparer.Compare
+		}
+		// TODO(radu): we should be using AssertBounds, but it currently fails in
+		// some cases (#3167).
+		rangeDelIter = keyspan.AssertUserKeyBounds(
+			rangeDelIter, file.SmallestPointKey.UserKey, file.LargestPointKey.UserKey, cmp,
+		)
+	}
+	return rangeDelIter, nil
+}
 
-	ok := true
-	var err error
+// newRangeKeyIter is an internal helper that constructs an iterator over a
+// sstable's range keys. This function is for table-cache internal use only, and
+// callers should use newIters instead.
+func (c *tableCacheShard) newRangeKeyIter(
+	v *tableCacheValue, cr sstable.CommonReader, opts keyspan.SpanIterOptions,
+) (keyspan.FragmentIterator, error) {
 	// Don't filter a table's range keys if the file contains RANGEKEYDELs.
 	// The RANGEKEYDELs may delete range keys in other levels. Skipping the
 	// file's range key blocks may surface deleted range keys below. This is
 	// done here, rather than deferring to the block-property collector in order
 	// to maintain parity with point keys and the treatment of RANGEDELs.
-	if v.reader.Properties.NumRangeKeyDels == 0 {
-		ok, _, err = c.checkAndIntersectFilters(v, nil, opts.RangeKeyFilters, nil)
-	}
-	if err != nil {
-		c.unrefValue(v)
-		return nil, err
-	}
-	if !ok {
-		c.unrefValue(v)
-		// Return the empty iterator. This iterator has no mutable state, so
-		// using a singleton is fine.
-		return emptyKeyspanIter, err
-	}
-
-	var iter keyspan.FragmentIterator
-	if file.Virtual {
-		provider := dbOpts.objProvider
-		var objMeta objstorage.ObjectMetadata
-		objMeta, err = provider.Lookup(fileTypeTable, file.FileBacking.DiskFileNum)
-		if err == nil {
-			virtualReader := sstable.MakeVirtualReader(
-				v.reader, file.VirtualMeta(), objMeta.IsShared(),
-			)
-			iter, err = virtualReader.NewRawRangeKeyIter()
+	if v.reader.Properties.NumRangeKeyDels == 0 && len(opts.RangeKeyFilters) > 0 {
+		ok, _, err := c.checkAndIntersectFilters(v, nil, opts.RangeKeyFilters, nil)
+		if err != nil {
+			return nil, err
+		} else if !ok {
+			return nil, nil
 		}
-	} else {
-		iter, err = v.reader.NewRawRangeKeyIter()
 	}
-
-	// iter is a block iter that holds the entire value of the block in memory.
-	// No need to hold onto a ref of the cache value.
-	c.unrefValue(v)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if iter == nil {
-		// NewRawRangeKeyIter can return nil even if there's no error. However,
-		// the keyspan.LevelIter expects a non-nil iterator if err is nil.
-		return emptyKeyspanIter, nil
-	}
-
-	return iter, nil
+	return cr.NewRawRangeKeyIter()
 }
 
 type tableCacheShardReaderProvider struct {
@@ -1104,6 +1099,7 @@ type tableCacheValue struct {
 	closeHook func(i sstable.Iterator) error
 	reader    *sstable.Reader
 	err       error
+	isShared  bool
 	loaded    chan struct{}
 	// Reference count for the value. The reader is closed when the reference
 	// count drops to zero.
@@ -1126,6 +1122,11 @@ func (v *tableCacheValue) load(loadInfo loadInfo, c *tableCacheShard, dbOpts *ta
 	if err == nil {
 		cacheOpts := private.SSTableCacheOpts(dbOpts.cacheID, loadInfo.backingFileNum).(sstable.ReaderOption)
 		v.reader, err = sstable.NewReader(f, dbOpts.opts, cacheOpts, dbOpts.filterMetrics)
+	}
+	if err == nil {
+		var objMeta objstorage.ObjectMetadata
+		objMeta, err = dbOpts.objProvider.Lookup(fileTypeTable, loadInfo.backingFileNum)
+		v.isShared = objMeta.IsShared()
 	}
 	if err != nil {
 		v.err = errors.Wrapf(
@@ -1225,3 +1226,71 @@ func (n *tableCacheNode) unlink() *tableCacheNode {
 	n.links.next = n
 	return next
 }
+
+// iterSet holds a set of iterators of various key kinds, all constructed over
+// the same data structure (eg, an sstable). A subset of the fields may be
+// populated depending on the `iterKinds` passed to newIters.
+type iterSet struct {
+	point         internalIterator
+	rangeDeletion keyspan.FragmentIterator
+	rangeKey      keyspan.FragmentIterator
+}
+
+// Point returns the contained point iterator. If there is no point iterator,
+// Point returns a non-nil empty point iterator.
+func (s *iterSet) Point() internalIterator {
+	if s.point == nil {
+		return emptyIter
+	}
+	return s.point
+}
+
+// RangeDeletion returns the contained range deletion iterator. If there is no
+// range deletion iterator, RangeDeletion returns a non-nil empty keyspan
+// iterator.
+func (s *iterSet) RangeDeletion() keyspan.FragmentIterator {
+	if s.rangeDeletion == nil {
+		return emptyKeyspanIter
+	}
+	return s.rangeDeletion
+}
+
+// RangeKey returns the contained range key iterator. If there is no range key
+// iterator, RangeKey returns a non-nil empty keyspan iterator.
+func (s *iterSet) RangeKey() keyspan.FragmentIterator {
+	if s.rangeKey == nil {
+		return emptyKeyspanIter
+	}
+	return s.rangeKey
+}
+
+// CloseAll closes all of the held iterators. If CloseAll is called, then Close
+// must be not be called on the consitutent iterators.
+func (s *iterSet) CloseAll() error {
+	var err error
+	if s.point != nil {
+		err = s.point.Close()
+	}
+	if s.rangeDeletion != nil {
+		err = firstError(err, s.rangeDeletion.Close())
+	}
+	if s.rangeKey != nil {
+		err = firstError(err, s.rangeKey.Close())
+	}
+	return err
+}
+
+// iterKinds is a bitmap indicating a set of kinds of iterators. Callers may
+// bitwise-OR iterPointKeys, iterRangeDeletions and/or iterRangeKeys together to
+// represent a set of desired iterator kinds.
+type iterKinds int8
+
+func (t iterKinds) Point() bool         { return (t & iterPointKeys) != 0 }
+func (t iterKinds) RangeDeletion() bool { return (t & iterRangeDeletions) != 0 }
+func (t iterKinds) RangeKey() bool      { return (t & iterRangeKeys) != 0 }
+
+const (
+	iterPointKeys iterKinds = 1 << iota
+	iterRangeDeletions
+	iterRangeKeys
+)

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -609,7 +609,7 @@ func testTableCacheRandomAccess(t *testing.T, concurrent bool) {
 			m.InitPhysicalBacking()
 			m.Ref()
 			defer m.Unref()
-			iter, _, err := c.newIters(context.Background(), m, nil, internalIterOpts{})
+			iter, _, err := tableNewIters(c.newIters).TODO(context.Background(), m, nil, internalIterOpts{})
 			if err != nil {
 				errc <- errors.Errorf("i=%d, fileNum=%d: find: %v", i, fileNum, err)
 				return
@@ -674,7 +674,7 @@ func testTableCacheFrequentlyUsedInternal(t *testing.T, rangeIter bool) {
 			if rangeIter {
 				iter, err = c.newRangeKeyIter(m, keyspan.SpanIterOptions{})
 			} else {
-				iter, _, err = c.newIters(context.Background(), m, nil, internalIterOpts{})
+				iter, _, err = tableNewIters(c.newIters).TODO(context.Background(), m, nil, internalIterOpts{})
 			}
 			if err != nil {
 				t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
@@ -721,11 +721,11 @@ func TestSharedTableCacheFrequentlyUsed(t *testing.T) {
 			m := &fileMetadata{FileNum: FileNum(j)}
 			m.InitPhysicalBacking()
 			m.Ref()
-			iter1, _, err := c1.newIters(context.Background(), m, nil, internalIterOpts{})
+			iter1, _, err := tableNewIters(c1.newIters).TODO(context.Background(), m, nil, internalIterOpts{})
 			if err != nil {
 				t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
 			}
-			iter2, _, err := c2.newIters(context.Background(), m, nil, internalIterOpts{})
+			iter2, _, err := tableNewIters(c2.newIters).TODO(context.Background(), m, nil, internalIterOpts{})
 			if err != nil {
 				t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
 			}
@@ -777,7 +777,7 @@ func testTableCacheEvictionsInternal(t *testing.T, rangeIter bool) {
 		if rangeIter {
 			iter, err = c.newRangeKeyIter(m, keyspan.SpanIterOptions{})
 		} else {
-			iter, _, err = c.newIters(context.Background(), m, nil, internalIterOpts{})
+			iter, _, err = tableNewIters(c.newIters).TODO(context.Background(), m, nil, internalIterOpts{})
 		}
 		if err != nil {
 			t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
@@ -839,12 +839,12 @@ func TestSharedTableCacheEvictions(t *testing.T) {
 		m := &fileMetadata{FileNum: FileNum(j)}
 		m.InitPhysicalBacking()
 		m.Ref()
-		iter1, _, err := c1.newIters(context.Background(), m, nil, internalIterOpts{})
+		iter1, _, err := tableNewIters(c1.newIters).TODO(context.Background(), m, nil, internalIterOpts{})
 		if err != nil {
 			t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
 		}
 
-		iter2, _, err := c2.newIters(context.Background(), m, nil, internalIterOpts{})
+		iter2, _, err := tableNewIters(c2.newIters).TODO(context.Background(), m, nil, internalIterOpts{})
 		if err != nil {
 			t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
 		}
@@ -907,7 +907,7 @@ func TestTableCacheIterLeak(t *testing.T) {
 	m.InitPhysicalBacking()
 	m.Ref()
 	defer m.Unref()
-	iter, _, err := c.newIters(context.Background(), m, nil, internalIterOpts{})
+	iter, _, err := tableNewIters(c.newIters).TODO(context.Background(), m, nil, internalIterOpts{})
 	require.NoError(t, err)
 
 	if err := c.close(); err == nil {
@@ -934,7 +934,7 @@ func TestSharedTableCacheIterLeak(t *testing.T) {
 	m.InitPhysicalBacking()
 	m.Ref()
 	defer m.Unref()
-	iter, _, err := c1.newIters(context.Background(), m, nil, internalIterOpts{})
+	iter, _, err := tableNewIters(c1.newIters).TODO(context.Background(), m, nil, internalIterOpts{})
 	require.NoError(t, err)
 
 	if err := c1.close(); err == nil {
@@ -972,13 +972,13 @@ func TestTableCacheRetryAfterFailure(t *testing.T) {
 	m.InitPhysicalBacking()
 	m.Ref()
 	defer m.Unref()
-	if _, _, err = c.newIters(context.Background(), m, nil, internalIterOpts{}); err == nil {
+	if _, _, err = tableNewIters(c.newIters).TODO(context.Background(), m, nil, internalIterOpts{}); err == nil {
 		t.Fatalf("expected failure, but found success")
 	}
 	require.Equal(t, "pebble: backing file 000000 error: injected error", err.Error())
 	fs.setOpenError(false /* enabled */)
 	var iter internalIterator
-	iter, _, err = c.newIters(context.Background(), m, nil, internalIterOpts{})
+	iter, _, err = tableNewIters(c.newIters).TODO(context.Background(), m, nil, internalIterOpts{})
 	require.NoError(t, err)
 	require.NoError(t, iter.Close())
 	fs.validate(t, c, nil)
@@ -1036,7 +1036,7 @@ func TestTableCacheErrorBadMagicNumber(t *testing.T) {
 	m.InitPhysicalBacking()
 	m.Ref()
 	defer m.Unref()
-	if _, _, err = c.newIters(context.Background(), m, nil, internalIterOpts{}); err == nil {
+	if _, _, err = tableNewIters(c.newIters).TODO(context.Background(), m, nil, internalIterOpts{}); err == nil {
 		t.Fatalf("expected failure, but found success")
 	}
 	require.Equal(t,
@@ -1161,16 +1161,16 @@ func BenchmarkNewItersAlloc(b *testing.B) {
 	d.mu.Unlock()
 
 	// Open once so that the Reader is cached.
-	iter, _, err := d.newIters(context.Background(), m, nil, internalIterOpts{})
-	require.NoError(b, iter.Close())
+	iters, err := d.newIters(context.Background(), m, nil, internalIterOpts{}, iterPointKeys|iterRangeDeletions)
+	require.NoError(b, iters.CloseAll())
 	require.NoError(b, err)
 
 	for i := 0; i < b.N; i++ {
 		b.StartTimer()
-		iter, _, err := d.newIters(context.Background(), m, nil, internalIterOpts{})
+		iters, err := d.newIters(context.Background(), m, nil, internalIterOpts{}, iterPointKeys|iterRangeDeletions)
 		b.StopTimer()
 		require.NoError(b, err)
-		require.NoError(b, iter.Close())
+		require.NoError(b, iters.CloseAll())
 	}
 }
 

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -207,29 +207,23 @@ open: db/000005.sst
 read-at(630, 53): db/000005.sst
 read-at(593, 37): db/000005.sst
 read-at(74, 519): db/000005.sst
-read-at(47, 27): db/000005.sst
-open: db/000005.sst
-close: db/000005.sst
 open: db/000009.sst
 read-at(625, 53): db/000009.sst
 read-at(588, 37): db/000009.sst
 read-at(69, 519): db/000009.sst
-read-at(42, 27): db/000009.sst
-open: db/000009.sst
-close: db/000009.sst
 open: db/000007.sst
 read-at(630, 53): db/000007.sst
 read-at(593, 37): db/000007.sst
 read-at(74, 519): db/000007.sst
-read-at(47, 27): db/000007.sst
-open: db/000007.sst
-close: db/000007.sst
+read-at(47, 27): db/000005.sst
 open: db/000005.sst
 read-at(0, 47): db/000005.sst
+read-at(47, 27): db/000007.sst
 open: db/000007.sst
 read-at(0, 47): db/000007.sst
 create: db/000010.sst
 close: db/000005.sst
+read-at(42, 27): db/000009.sst
 open: db/000009.sst
 read-at(0, 42): db/000009.sst
 close: db/000007.sst

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -69,20 +69,16 @@ open: db/000005.sst
 read-at(607, 53): db/000005.sst
 read-at(570, 37): db/000005.sst
 read-at(79, 491): db/000005.sst
-read-at(52, 27): db/000005.sst
-open: db/000005.sst
-close: db/000005.sst
 open: db/000007.sst
 read-at(581, 53): db/000007.sst
 read-at(544, 37): db/000007.sst
 read-at(53, 491): db/000007.sst
-read-at(26, 27): db/000007.sst
-open: db/000007.sst
-close: db/000007.sst
+read-at(52, 27): db/000005.sst
 open: db/000005.sst
 read-at(0, 52): db/000005.sst
 create: db/000008.sst
 close: db/000005.sst
+read-at(26, 27): db/000007.sst
 open: db/000007.sst
 read-at(0, 26): db/000007.sst
 close: db/000007.sst

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -97,18 +97,14 @@ open: db/000005.sst
 read-at(609, 53): db/000005.sst
 read-at(572, 37): db/000005.sst
 read-at(53, 519): db/000005.sst
-read-at(26, 27): db/000005.sst
-open: db/000005.sst
-close: db/000005.sst
 open: db/000008.sst
 read-at(609, 53): db/000008.sst
 read-at(572, 37): db/000008.sst
 read-at(53, 519): db/000008.sst
-read-at(26, 27): db/000008.sst
-open: db/000008.sst
-close: db/000008.sst
+read-at(26, 27): db/000005.sst
 open: db/000005.sst
 read-at(0, 26): db/000005.sst
+read-at(26, 27): db/000008.sst
 open: db/000008.sst
 read-at(0, 26): db/000008.sst
 close: db/000008.sst
@@ -221,7 +217,7 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Block cache: 6 entries (1.1KB)  hit rate: 11.1%
+Block cache: 6 entries (1.1KB)  hit rate: 0.0%
 Table cache: 1 entries (808B)  hit rate: 40.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -320,7 +316,7 @@ MemTables: 1 (512KB)  zombie: 1 (512KB)
 Zombie tables: 0 (0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Block cache: 12 entries (2.3KB)  hit rate: 14.3%
+Block cache: 12 entries (2.3KB)  hit rate: 7.7%
 Table cache: 1 entries (808B)  hit rate: 50.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -121,7 +121,7 @@ MemTables: 1 (256KB)  zombie: 2 (512KB)
 Zombie tables: 2 (1.3KB)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Block cache: 5 entries (1.1KB)  hit rate: 42.9%
+Block cache: 5 entries (1.1KB)  hit rate: 33.3%
 Table cache: 2 entries (1.6KB)  hit rate: 66.7%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -129,7 +129,7 @@ Table iters: 2
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:132 BlockBytesInCache:88 BlockReadDuration:10ms}
+   pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
 
 disk-usage
 ----
@@ -162,7 +162,7 @@ MemTables: 1 (256KB)  zombie: 2 (512KB)
 Zombie tables: 2 (1.3KB)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Block cache: 5 entries (1.1KB)  hit rate: 42.9%
+Block cache: 5 entries (1.1KB)  hit rate: 33.3%
 Table cache: 2 entries (1.6KB)  hit rate: 66.7%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -170,7 +170,7 @@ Table iters: 2
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:132 BlockBytesInCache:88 BlockReadDuration:10ms}
+   pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
 
 # Closing iter c will release one of the zombie sstables. The other
 # zombie sstable is still referenced by iter b.
@@ -200,7 +200,7 @@ MemTables: 1 (256KB)  zombie: 2 (512KB)
 Zombie tables: 1 (661B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Block cache: 3 entries (556B)  hit rate: 42.9%
+Block cache: 3 entries (556B)  hit rate: 33.3%
 Table cache: 1 entries (808B)  hit rate: 66.7%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -209,7 +209,7 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Iter category stats:
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
-   pebble-compaction, non-latency: {BlockBytes:132 BlockBytesInCache:88 BlockReadDuration:10ms}
+   pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
 
 disk-usage
 ----
@@ -242,7 +242,7 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Block cache: 0 entries (0B)  hit rate: 42.9%
+Block cache: 0 entries (0B)  hit rate: 33.3%
 Table cache: 0 entries (0B)  hit rate: 66.7%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -252,7 +252,7 @@ Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Iter category stats:
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
-   pebble-compaction, non-latency: {BlockBytes:132 BlockBytesInCache:88 BlockReadDuration:10ms}
+   pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
 
 disk-usage
 ----
@@ -311,7 +311,7 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Block cache: 0 entries (0B)  hit rate: 42.9%
+Block cache: 0 entries (0B)  hit rate: 33.3%
 Table cache: 0 entries (0B)  hit rate: 66.7%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -321,7 +321,7 @@ Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Iter category stats:
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
-   pebble-compaction, non-latency: {BlockBytes:132 BlockBytesInCache:88 BlockReadDuration:10ms}
+   pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
 
 additional-metrics
 ----
@@ -364,7 +364,7 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Block cache: 0 entries (0B)  hit rate: 27.3%
+Block cache: 0 entries (0B)  hit rate: 14.3%
 Table cache: 0 entries (0B)  hit rate: 58.3%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -374,7 +374,7 @@ Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Iter category stats:
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
-   pebble-compaction, non-latency: {BlockBytes:411 BlockBytesInCache:154 BlockReadDuration:60ms}
+   pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
 
 additional-metrics
 ----
@@ -466,7 +466,7 @@ MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
 Zombie tables: 0 (0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Block cache: 12 entries (2.4KB)  hit rate: 24.5%
+Block cache: 12 entries (2.4KB)  hit rate: 16.7%
 Table cache: 1 entries (808B)  hit rate: 60.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -476,7 +476,7 @@ Ingestions: 0  as flushable: 2 (2.1KB in 3 tables)
 Iter category stats:
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
-   pebble-compaction, non-latency: {BlockBytes:411 BlockBytesInCache:154 BlockReadDuration:60ms}
+   pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
        pebble-ingest,     latency: {BlockBytes:192 BlockBytesInCache:128 BlockReadDuration:10ms}
 
 batch
@@ -527,7 +527,7 @@ MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
 Zombie tables: 0 (0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Block cache: 12 entries (2.4KB)  hit rate: 24.5%
+Block cache: 12 entries (2.4KB)  hit rate: 16.7%
 Table cache: 1 entries (808B)  hit rate: 60.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -537,7 +537,7 @@ Ingestions: 0  as flushable: 2 (2.1KB in 3 tables)
 Iter category stats:
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
-   pebble-compaction, non-latency: {BlockBytes:411 BlockBytesInCache:154 BlockReadDuration:60ms}
+   pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
        pebble-ingest,     latency: {BlockBytes:192 BlockBytesInCache:128 BlockReadDuration:10ms}
 
 build ext1
@@ -612,7 +612,7 @@ Ingestions: 1  as flushable: 2 (2.1KB in 3 tables)
 Iter category stats:
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
-   pebble-compaction, non-latency: {BlockBytes:411 BlockBytesInCache:154 BlockReadDuration:60ms}
+   pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
        pebble-ingest,     latency: {BlockBytes:328 BlockBytesInCache:128 BlockReadDuration:30ms}
 
 # Virtualize a virtual sstable.
@@ -712,5 +712,5 @@ Ingestions: 2  as flushable: 2 (2.1KB in 3 tables)
 Iter category stats:
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
-   pebble-compaction, non-latency: {BlockBytes:941 BlockBytesInCache:640 BlockReadDuration:70ms}
+   pebble-compaction, non-latency: {BlockBytes:677 BlockBytesInCache:376 BlockReadDuration:70ms}
        pebble-ingest,     latency: {BlockBytes:400 BlockBytesInCache:200 BlockReadDuration:30ms}


### PR DESCRIPTION
This commit refactors the interface of the table cache `newIters` method to support creation of any of a sstable's iterators, including its point iterator, range deletion iterator and range key iterator. This is motivated by the refactor planned in #2863, which in turn requires refactoring some of the newIters call sites that determine whether ingested sstables overlap existing tables.

There's also a minor benefit that a compaction setup no longer needs to open point iterators and then immediately close them when initializing the range deletion iterators.

```
goos: linux
goarch: amd64
pkg: github.com/cockroachdb/pebble
cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
              │ old-NewItersAlloc.txt │       new-NewItersAlloc.txt        │
              │        sec/op         │   sec/op     vs base               │
NewItersAlloc             427.0n ± 1%   412.1n ± 1%  -3.47% (p=0.000 n=10)

              │ old-NewItersAlloc.txt │     new-NewItersAlloc.txt      │
              │         B/op          │    B/op     vs base            │
NewItersAlloc              0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

              │ old-NewItersAlloc.txt │     new-NewItersAlloc.txt      │
              │       allocs/op       │ allocs/op   vs base            │
NewItersAlloc              0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```