### PR TITLE
record: LogWriter changes for use in failover WAL writing

### DIFF
--- a/record/log_writer.go
+++ b/record/log_writer.go
@@ -150,12 +150,14 @@ func (q *syncQueue) pop(head, tail uint32, err error, queueSemChan chan struct{}
 		*slot.err = err
 		slot.wg = nil
 		slot.err = nil
-		// We need to bump the tail count before signalling the wait group as
-		// signalling the wait group can trigger release a blocked goroutine which
-		// will try to enqueue before we've "freed" space in the queue.
+		// We need to bump the tail count before releasing the queueSemChan
+		// semaphore as releasing the semaphore can cause a blocked goroutine to
+		// acquire the semaphore and enqueue before we've "freed" space in the
+		// queue.
 		q.headTail.Add(1)
 		wg.Done()
-		// Is always non-nil in production.
+		// Is always non-nil in production, unless using wal package for WAL
+		// failover.
 		if queueSemChan != nil {
 			<-queueSemChan
 		}
@@ -164,17 +166,180 @@ func (q *syncQueue) pop(head, tail uint32, err error, queueSemChan chan struct{}
 	return nil
 }
 
+// pendingSyncs abstracts out the handling of pending sync requests. In
+// standalone mode the implementation is a thin wrapper around syncQueue. In
+// the mode where the LogWriter can be subject to failover, there is no queue
+// kept in the LogWriter and the signaling to those waiting for sync is
+// handled in the wal package.
+//
+// To avoid heap allocations due to the use of this interface, the parameters
+// and return values follow some strict rules:
+//   - The PendingSync parameter can be reused by the caller after push returns.
+//     The implementation should be a pointer backed by a struct that is already
+//     heap allocated, which the caller can reuse for the next push call.
+//   - The pendingSyncSnapshot return value must be backed by the pendingSyncs
+//     implementation, so calling snapshotForPop again will cause the previous
+//     snapshot to be overwritten.
+type pendingSyncs interface {
+	push(PendingSync)
+	setBlocked()
+	clearBlocked()
+	empty() bool
+	snapshotForPop() pendingSyncsSnapshot
+	pop(snap pendingSyncsSnapshot, err error) error
+}
+
+type pendingSyncsSnapshot interface {
+	empty() bool
+}
+
+// PendingSync abstracts the sync specification for a record queued on the
+// LogWriter. The only implementations are provided in this package since
+// syncRequested is not exported.
+type PendingSync interface {
+	syncRequested() bool
+}
+
+// The implementation of pendingSyncs in standalone mode.
+type pendingSyncsWithSyncQueue struct {
+	syncQueue
+	syncQueueLen    *base.GaugeSampleMetric
+	snapshotBacking syncQueueSnapshot
+	// See the comment for LogWriterConfig.QueueSemChan.
+	queueSemChan chan struct{}
+}
+
+var _ pendingSyncs = &pendingSyncsWithSyncQueue{}
+
+func (q *pendingSyncsWithSyncQueue) push(ps PendingSync) {
+	ps2 := ps.(*pendingSyncForSyncQueue)
+	q.syncQueue.push(ps2.wg, ps2.err)
+}
+
+func (q *pendingSyncsWithSyncQueue) snapshotForPop() pendingSyncsSnapshot {
+	head, tail, realLength := q.syncQueue.load()
+	q.snapshotBacking = syncQueueSnapshot{
+		head: head,
+		tail: tail,
+	}
+	q.syncQueueLen.AddSample(int64(realLength))
+	return &q.snapshotBacking
+}
+
+func (q *pendingSyncsWithSyncQueue) pop(snap pendingSyncsSnapshot, err error) error {
+	s := snap.(*syncQueueSnapshot)
+	return q.syncQueue.pop(s.head, s.tail, err, q.queueSemChan)
+}
+
+// The implementation of pendingSyncsSnapshot in standalone mode.
+type syncQueueSnapshot struct {
+	head, tail uint32
+}
+
+func (s *syncQueueSnapshot) empty() bool {
+	return s.head == s.tail
+}
+
+// The implementation of pendingSync in standalone mode.
+type pendingSyncForSyncQueue struct {
+	wg  *sync.WaitGroup
+	err *error
+}
+
+func (ps *pendingSyncForSyncQueue) syncRequested() bool {
+	return ps.wg != nil
+}
+
+// The implementation of pendingSyncs in failover mode.
+type pendingSyncsWithHighestSyncIndex struct {
+	// The highest "index" queued that is requesting a sync. Initialized
+	// to NoSyncIndex, and reset to NoSyncIndex after the sync.
+	index           atomic.Int64
+	snapshotBacking PendingSyncIndex
+	// blocked is an atomic boolean which indicates whether syncing is currently
+	// blocked or can proceed. It is used by the implementation of
+	// min-sync-interval to block syncing until the min interval has passed.
+	blocked                   atomic.Bool
+	externalSyncQueueCallback ExternalSyncQueueCallback
+}
+
+// NoSyncIndex is the value of PendingSyncIndex when a sync is not requested.
+const NoSyncIndex = -1
+
+func (si *pendingSyncsWithHighestSyncIndex) init(
+	externalSyncQueueCallback ExternalSyncQueueCallback,
+) {
+	si.index.Store(NoSyncIndex)
+	si.externalSyncQueueCallback = externalSyncQueueCallback
+}
+
+func (si *pendingSyncsWithHighestSyncIndex) push(ps PendingSync) {
+	ps2 := ps.(*PendingSyncIndex)
+	si.index.Store(ps2.Index)
+}
+
+func (si *pendingSyncsWithHighestSyncIndex) setBlocked() {
+	si.blocked.Store(true)
+}
+
+func (si *pendingSyncsWithHighestSyncIndex) clearBlocked() {
+	si.blocked.Store(false)
+}
+
+func (si *pendingSyncsWithHighestSyncIndex) empty() bool {
+	return si.load() == NoSyncIndex
+}
+
+func (si *pendingSyncsWithHighestSyncIndex) snapshotForPop() pendingSyncsSnapshot {
+	si.snapshotBacking = PendingSyncIndex{Index: si.load()}
+	return &si.snapshotBacking
+}
+
+func (si *pendingSyncsWithHighestSyncIndex) load() int64 {
+	index := si.index.Load()
+	if index != NoSyncIndex && si.blocked.Load() {
+		index = NoSyncIndex
+	}
+	return index
+}
+
+func (si *pendingSyncsWithHighestSyncIndex) pop(snap pendingSyncsSnapshot, err error) error {
+	index := snap.(*PendingSyncIndex)
+	if index.Index == NoSyncIndex {
+		return nil
+	}
+	// Set to NoSyncIndex if a higher index has not queued.
+	si.index.CompareAndSwap(index.Index, NoSyncIndex)
+	si.externalSyncQueueCallback(*index, err)
+	return nil
+}
+
+// PendingSyncIndex implements both pendingSyncsSnapshot and PendingSync.
+type PendingSyncIndex struct {
+	// Index is some state meaningful to the user of LogWriter. The LogWriter
+	// itself only examines whether Index is equal to NoSyncIndex.
+	Index int64
+}
+
+func (s *PendingSyncIndex) empty() bool {
+	return s.Index == NoSyncIndex
+}
+
+func (s *PendingSyncIndex) syncRequested() bool {
+	return s.Index != NoSyncIndex
+}
+
 // flusherCond is a specialized condition variable that allows its condition to
 // change and readiness be signalled without holding its associated mutex. In
 // particular, when a waiter is added to syncQueue atomically, this condition
 // variable can be signalled without holding flusher.Mutex.
 type flusherCond struct {
 	mu   *sync.Mutex
-	q    *syncQueue
+	q    pendingSyncs
 	cond sync.Cond
 }
 
-func (c *flusherCond) init(mu *sync.Mutex, q *syncQueue) {
+func (c *flusherCond) init(mu *sync.Mutex, q pendingSyncs) {
 	c.mu = mu
 	c.q = q
 	// Yes, this is a bit circular, but that is intentional. flusherCond.cond.L
@@ -259,8 +424,12 @@ type LogWriter struct {
 	logNum uint32
 	// blockNum is the zero based block number for the current block.
 	blockNum int64
-	// err is any accumulated error. TODO(peter): This needs to be protected in
-	// some fashion. Perhaps using atomic.Value.
+	// err is any accumulated error. It originates in flusher.err, and is
+	// updated to reflect flusher.err when a block is full and getting enqueued.
+	// Therefore, there is a lag between when flusher.err has a non-nil error,
+	// and when that non-nil error is reflected in LogWriter.err. On close, it
+	// is set to errClosedWriter to inform accidental future calls to
+	// SyncRecord*.
 	err error
 	// block is the current block being written. Protected by flusher.Mutex.
 	block *block
@@ -286,8 +455,10 @@ type LogWriter struct {
 		minSyncInterval durationFunc
 		fsyncLatency    prometheus.Histogram
 		pending         []*block
-		syncQ           syncQueue
-		metrics         *LogWriterMetrics
+		// Pushing and popping from pendingSyncs does not require flusher mutex to
+		// be held.
+		pendingSyncs pendingSyncs
+		metrics      *LogWriterMetrics
 	}
 
 	// afterFunc is a hook to allow tests to mock out the timer functionality
@@ -295,8 +466,11 @@ type LogWriter struct {
 	// time.AfterFunc.
 	afterFunc func(d time.Duration, f func()) syncTimer
 
-	// See the comment for LogWriterConfig.QueueSemChan.
-	queueSemChan chan struct{}
+	// Backing for both pendingSyncs implementations.
+	pendingSyncsBackingQ     pendingSyncsWithSyncQueue
+	pendingSyncsBackingIndex pendingSyncsWithHighestSyncIndex
+
+	pendingSyncForSyncQueueBacking pendingSyncForSyncQueue
 }
 
 // LogWriterConfig is a struct used for configuring new LogWriters
@@ -308,7 +482,24 @@ type LogWriterConfig struct {
 	// the syncQueue from overflowing (which will cause a panic). All production
 	// code ensures this is non-nil.
 	QueueSemChan chan struct{}
+
+	// ExternalSyncQueueCallback is set to non-nil when the LogWriter is used
+	// as part of a WAL implementation that can failover between LogWriters.
+	//
+	// In this case, QueueSemChan is always nil, and SyncRecordGeneralized must
+	// be used with a PendingSync parameter that is implemented by
+	// PendingSyncIndex. When an index is synced (which implies all earlier
+	// indices are also synced), this callback is invoked. The caller must not
+	// hold any mutex when invoking this callback, since the lock ordering
+	// requirement in this case is that any higher layer locks (in the wal
+	// package) precede the lower layer locks (in the record package). These
+	// callbacks are serialized since they are invoked from the flushLoop.
+	ExternalSyncQueueCallback ExternalSyncQueueCallback
 }
+
+// ExternalSyncQueueCallback is to be run when a PendingSync has been
+// processed, either successfully or with an error.
+type ExternalSyncQueueCallback func(doneSync PendingSyncIndex, err error)
 
 // initialAllocatedBlocksCap is the initial capacity of the various slices
 // intended to hold LogWriter blocks. The LogWriter may allocate more blocks
@@ -323,6 +514,9 @@ var blockPool = sync.Pool{
 }
 
 // NewLogWriter returns a new LogWriter.
+//
+// The io.Writer may also be used as an io.Closer and syncer. No other methods
+// will be called on the writer.
 func NewLogWriter(
 	w io.Writer, logNum base.DiskFileNum, logWriterConfig LogWriterConfig,
 ) *LogWriter {
@@ -340,14 +534,25 @@ func NewLogWriter(
 		afterFunc: func(d time.Duration, f func()) syncTimer {
 			return time.AfterFunc(d, f)
 		},
-		queueSemChan: logWriterConfig.QueueSemChan,
 	}
+	m := &LogWriterMetrics{}
+	if logWriterConfig.ExternalSyncQueueCallback != nil {
+		r.pendingSyncsBackingIndex.init(logWriterConfig.ExternalSyncQueueCallback)
+		r.flusher.pendingSyncs = &r.pendingSyncsBackingIndex
+	} else {
+		r.pendingSyncsBackingQ = pendingSyncsWithSyncQueue{
+			syncQueueLen: &m.SyncQueueLen,
+			queueSemChan: logWriterConfig.QueueSemChan,
+		}
+		r.flusher.pendingSyncs = &r.pendingSyncsBackingQ
+	}
+
 	r.free.blocks = make([]*block, 0, initialAllocatedBlocksCap)
 	r.block = blockPool.Get().(*block)
-	r.flusher.ready.init(&r.flusher.Mutex, &r.flusher.syncQ)
+	r.flusher.ready.init(&r.flusher.Mutex, r.flusher.pendingSyncs)
 	r.flusher.closed = make(chan struct{})
 	r.flusher.pending = make([]*block, 0, cap(r.free.blocks))
-	r.flusher.metrics = &LogWriterMetrics{}
+	r.flusher.metrics = m
 
 	f := &r.flusher
 	f.minSyncInterval = logWriterConfig.WALMinSyncInterval
@@ -423,14 +628,14 @@ func (w *LogWriter) flushLoop(context.Context) {
 			// the current block can be added to the pending blocks list after we release
 			// the flusher lock, but it won't be part of pending.
 			written := w.block.written.Load()
-			if len(f.pending) > 0 || written > w.block.flushed || !f.syncQ.empty() {
+			if len(f.pending) > 0 || written > w.block.flushed || !f.pendingSyncs.empty() {
 				break
 			}
 			if f.close {
 				// If the writer is closed, pretend the sync timer fired immediately so
 				// that we can process any queued sync requests.
-				f.syncQ.clearBlocked()
-				if !f.syncQ.empty() {
+				f.pendingSyncs.clearBlocked()
+				if !f.pendingSyncs.empty() {
 					break
 				}
 				return
@@ -439,6 +644,18 @@ func (w *LogWriter) flushLoop(context.Context) {
 			continue
 		}
 		// Found work to do, so no longer idle.
+		//
+		// NB: it is safe to read pending before loading from the syncQ since
+		// mutations to pending require the w.flusher mutex, which is held here.
+		// There is no risk that someone will concurrently add to pending, so the
+		// following sequence, which would pick up a syncQ entry without the
+		// corresponding data, is impossible:
+		//
+		// Thread enqueueing       This thread
+		//                         1. read pending
+		// 2. add block to pending
+		// 3. add to syncQ
+		//                         4. read syncQ
 		workStartTime := time.Now()
 		idleDuration := workStartTime.Sub(idleStartTime)
 		pending = append(pending[:0], f.pending...)
@@ -448,8 +665,7 @@ func (w *LogWriter) flushLoop(context.Context) {
 		// Grab the list of sync waiters. Note that syncQueue.load() will return
 		// 0,0 while we're waiting for the min-sync-interval to expire. This
 		// allows flushing to proceed even if we're not ready to sync.
-		head, tail, realSyncQLen := f.syncQ.load()
-		f.metrics.SyncQueueLen.AddSample(int64(realSyncQLen))
+		snap := f.pendingSyncs.snapshotForPop()
 
 		// Grab the portion of the current block that requires flushing. Note that
 		// the current block can be added to the pending blocks list after we
@@ -461,25 +677,29 @@ func (w *LogWriter) flushLoop(context.Context) {
 		data := w.block.buf[w.block.flushed:written]
 		w.block.flushed = written
 
+		fErr := f.err
+		f.Unlock()
 		// If flusher has an error, we propagate it to waiters. Note in spite of
 		// error we consume the pending list above to free blocks for writers.
-		if f.err != nil {
-			f.syncQ.pop(head, tail, f.err, w.queueSemChan)
+		if fErr != nil {
+			// NB: pop may invoke ExternalSyncQueueCallback, which is why we have
+			// called f.Unlock() above. We will acquire the lock again below.
+			f.pendingSyncs.pop(snap, fErr)
 			// Update the idleStartTime if work could not be done, so that we don't
 			// include the duration we tried to do work as idle. We don't bother
 			// with the rest of the accounting, which means we will undercount.
 			idleStartTime = time.Now()
+			f.Lock()
 			continue
 		}
-		f.Unlock()
-		synced, syncLatency, bytesWritten, err := w.flushPending(data, pending, head, tail)
+		synced, syncLatency, bytesWritten, err := w.flushPending(data, pending, snap)
 		f.Lock()
 		if synced && f.fsyncLatency != nil {
 			f.fsyncLatency.Observe(float64(syncLatency))
 		}
 		f.err = err
 		if f.err != nil {
-			f.syncQ.clearBlocked()
+			f.pendingSyncs.clearBlocked()
 			// Update the idleStartTime if work could not be done, so that we don't
 			// include the duration we tried to do work as idle. We don't bother
 			// with the rest of the accounting, which means we will undercount.
@@ -491,10 +711,10 @@ func (w *LogWriter) flushLoop(context.Context) {
 			// A sync was performed. Make sure we've waited for the min sync
 			// interval before syncing again.
 			if min := f.minSyncInterval(); min > 0 {
-				f.syncQ.setBlocked()
+				f.pendingSyncs.setBlocked()
 				if syncTimer == nil {
 					syncTimer = w.afterFunc(min, func() {
-						f.syncQ.clearBlocked()
+						f.pendingSyncs.clearBlocked()
 						f.ready.Signal()
 					})
 				} else {
@@ -512,7 +732,7 @@ func (w *LogWriter) flushLoop(context.Context) {
 }
 
 func (w *LogWriter) flushPending(
-	data []byte, pending []*block, head, tail uint32,
+	data []byte, pending []*block, snap pendingSyncsSnapshot,
 ) (synced bool, syncLatency time.Duration, bytesWritten int64, err error) {
 	defer func() {
 		// Translate panics into errors. The errors will cause flushLoop to shut
@@ -535,14 +755,16 @@ func (w *LogWriter) flushPending(
 		_, err = w.w.Write(data)
 	}
 
-	synced = head != tail
+	synced = !snap.empty()
 	if synced {
 		if err == nil && w.s != nil {
 			syncLatency, err = w.syncWithLatency()
+		} else {
+			synced = false
 		}
 		f := &w.flusher
-		if popErr := f.syncQ.pop(head, tail, err, w.queueSemChan); popErr != nil {
-			return synced, syncLatency, bytesWritten, popErr
+		if popErr := f.pendingSyncs.pop(snap, err); popErr != nil {
+			return synced, syncLatency, bytesWritten, firstError(err, popErr)
 		}
 	}
 
@@ -595,6 +817,16 @@ func (w *LogWriter) queueBlock() {
 // Close flushes and syncs any unwritten data and closes the writer.
 // Where required, external synchronisation is provided by commitPipeline.mu.
 func (w *LogWriter) Close() error {
+	return w.closeInternal(PendingSyncIndex{Index: NoSyncIndex})
+}
+
+// CloseWithLastQueuedRecord is like Close, but optionally accepts a
+// lastQueuedRecord, that the caller will be notified about when synced.
+func (w *LogWriter) CloseWithLastQueuedRecord(lastQueuedRecord PendingSyncIndex) error {
+	return w.closeInternal(lastQueuedRecord)
+}
+
+func (w *LogWriter) closeInternal(lastQueuedRecord PendingSyncIndex) error {
 	f := &w.flusher
 
 	// Emit an EOF trailer signifying the end of this log. This helps readers
@@ -621,18 +853,21 @@ func (w *LogWriter) Close() error {
 		syncLatency, err = w.syncWithLatency()
 	}
 	f.Lock()
-	if f.fsyncLatency != nil {
+	if err == nil && f.fsyncLatency != nil {
 		f.fsyncLatency.Observe(float64(syncLatency))
 	}
 	free := w.free.blocks
 	f.Unlock()
 
+	// NB: the caller of closeInternal may not care about a non-nil cerr below
+	// if all queued writes have been successfully written and synced.
+	if lastQueuedRecord.Index != NoSyncIndex {
+		w.pendingSyncsBackingIndex.externalSyncQueueCallback(lastQueuedRecord, err)
+	}
 	if w.c != nil {
 		cerr := w.c.Close()
 		w.c = nil
-		if cerr != nil {
-			return cerr
-		}
+		err = firstError(err, cerr)
 	}
 
 	for _, b := range free {
@@ -643,6 +878,15 @@ func (w *LogWriter) Close() error {
 
 	w.err = errClosedWriter
 	return err
+}
+
+// firstError returns the first non-nil error of err0 and err1, or nil if both
+// are nil.
+func firstError(err0, err1 error) error {
+	if err0 != nil {
+		return err0
+	}
+	return err1
 }
 
 // WriteRecord writes a complete record. Returns the offset just past the end
@@ -661,6 +905,16 @@ func (w *LogWriter) WriteRecord(p []byte) (int64, error) {
 func (w *LogWriter) SyncRecord(
 	p []byte, wg *sync.WaitGroup, err *error,
 ) (logSize int64, err2 error) {
+	w.pendingSyncForSyncQueueBacking = pendingSyncForSyncQueue{
+		wg:  wg,
+		err: err,
+	}
+	return w.SyncRecordGeneralized(p, &w.pendingSyncForSyncQueueBacking)
+}
+
+// SyncRecordGeneralized is a version of SyncRecord that accepts a
+// PendingSync.
+func (w *LogWriter) SyncRecordGeneralized(p []byte, ps PendingSync) (logSize int64, err2 error) {
 	if w.err != nil {
 		return -1, w.err
 	}
@@ -673,14 +927,14 @@ func (w *LogWriter) SyncRecord(
 		p = w.emitFragment(i, p)
 	}
 
-	if wg != nil {
+	if ps.syncRequested() {
 		// If we've been asked to persist the record, add the WaitGroup to the sync
 		// queue and signal the flushLoop. Note that flushLoop will write partial
 		// blocks to the file if syncing has been requested. The contract is that
 		// any record written to the LogWriter to this point will be flushed to the
 		// OS and synced to disk.
 		f := &w.flusher
-		f.syncQ.push(wg, err)
+		f.pendingSyncs.push(ps)
 		f.ready.Signal()
 	}
 

--- a/record/log_writer_test.go
+++ b/record/log_writer_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"math/rand"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -76,11 +77,12 @@ func TestSyncQueue(t *testing.T) {
 
 func TestFlusherCond(t *testing.T) {
 	var mu sync.Mutex
-	var q syncQueue
 	var c flusherCond
 	var closed bool
 
-	c.init(&mu, &q)
+	psq := &pendingSyncsWithSyncQueue{}
+	c.init(&mu, psq)
+	q := &psq.syncQueue
 
 	var flusherWG sync.WaitGroup
 	flusherWG.Add(1)
@@ -299,7 +301,8 @@ func TestMinSyncInterval(t *testing.T) {
 		}
 		// NB: we can't use syncQueue.load() here as that will return 0,0 while the
 		// syncQueue is blocked.
-		head, tail := w.flusher.syncQ.unpack(w.flusher.syncQ.headTail.Load())
+		syncQ := w.flusher.pendingSyncs.(*pendingSyncsWithSyncQueue)
+		head, tail := syncQ.unpack(syncQ.headTail.Load())
 		waiters := head - tail
 		if waiters != uint32(i+1) {
 			t.Fatalf("expected %d waiters, but found %d", i+1, waiters)
@@ -553,6 +556,183 @@ func TestQueueWALBlocks(t *testing.T) {
 	require.GreaterOrEqual(t, logSize, int64(numBlocks*blockSize))
 }
 
+func TestPendingSyncsWithHighestSyncIndex(t *testing.T) {
+	var psi PendingSyncIndex
+	psi.Index = NoSyncIndex
+	require.True(t, psi.empty())
+	require.False(t, psi.syncRequested())
+	psi.Index = 0
+	require.False(t, psi.empty())
+	require.True(t, psi.syncRequested())
+
+	type indexAndErr struct {
+		PendingSyncIndex
+		error
+	}
+	var cbValues []indexAndErr
+	var q pendingSyncsWithHighestSyncIndex
+	q.init(func(doneSync PendingSyncIndex, err error) {
+		cbValues = append(cbValues, indexAndErr{PendingSyncIndex: doneSync, error: err})
+	})
+	require.True(t, q.empty())
+	q.push(&psi)
+	require.False(t, q.empty())
+	require.Equal(t, int64(0), q.load())
+	require.Equal(t, int64(0), q.snapshotForPop().(*PendingSyncIndex).Index)
+	q.setBlocked()
+	require.True(t, q.empty())
+	require.Equal(t, int64(NoSyncIndex), q.load())
+	require.Equal(t, int64(NoSyncIndex), q.snapshotForPop().(*PendingSyncIndex).Index)
+	q.clearBlocked()
+	require.False(t, q.empty())
+	require.Equal(t, int64(0), q.load())
+
+	const highestIndex = 100
+	testErr := errors.New("test error")
+	var popDone sync.WaitGroup
+	popDone.Add(1)
+	// Goroutine that pops.
+	go func() {
+		var poppedIndex int64
+		for poppedIndex != highestIndex {
+			if !q.empty() {
+				snap := q.snapshotForPop()
+				require.False(t, snap.empty())
+				poppedIndex = snap.(*PendingSyncIndex).Index
+				require.NotEqual(t, int64(NoSyncIndex), poppedIndex)
+				var err error
+				// Inject error for all even index pops.
+				if poppedIndex%2 == 0 {
+					err = testErr
+				}
+				require.NoError(t, q.pop(snap, err))
+			}
+		}
+		popDone.Done()
+	}()
+	// Goroutine that pushes.
+	go func() {
+		// Already pushed 0, so start at index 1.
+		for i := 1; i <= highestIndex; i++ {
+			psi.Index = int64(i)
+			q.push(&psi)
+			// Randomly inject sleep, to allow pop to catch up, so that highestIndex
+			// doesn't overwrite everything. With this, we see some sparseness of
+			// indices in pops, but we get enough popped indices.
+			if rand.Intn(2) == 0 {
+				time.Sleep(time.Millisecond)
+			}
+		}
+	}()
+	popDone.Wait()
+	latestValue := int64(NoSyncIndex)
+	for _, cbVal := range cbValues {
+		if cbVal.Index%2 == 0 {
+			require.Equal(t, testErr, cbVal.error)
+		} else {
+			require.NoError(t, cbVal.error)
+		}
+		require.Less(t, latestValue, cbVal.Index)
+		latestValue = cbVal.Index
+	}
+	require.Equal(t, int64(highestIndex), latestValue)
+}
+
+func TestSyncRecordGeneralized(t *testing.T) {
+	f := &syncFile{}
+	// Write two records, where the first one requests a sync. The callback
+	// should execute for both since the second is synced on close.
+	lastSync := int64(-1)
+	cbChan := make(chan struct{}, 2)
+	w := NewLogWriter(f, 0, LogWriterConfig{
+		WALFsyncLatency: prometheus.NewHistogram(prometheus.HistogramOpts{}),
+		ExternalSyncQueueCallback: func(doneSync PendingSyncIndex, err error) {
+			require.NoError(t, err)
+			require.Equal(t, lastSync+1, doneSync.Index)
+			lastSync++
+			cbChan <- struct{}{}
+		},
+	})
+	offset, err := w.SyncRecordGeneralized([]byte("hello"), &PendingSyncIndex{})
+	require.NoError(t, err)
+	<-cbChan
+	require.Equal(t, offset, f.writePos.Load())
+	require.Equal(t, offset, f.syncPos.Load())
+
+	offset, err = w.SyncRecordGeneralized([]byte("world"), &PendingSyncIndex{Index: NoSyncIndex})
+	require.NoError(t, err)
+	time.Sleep(5 * time.Millisecond)
+	select {
+	case <-cbChan:
+		t.Fatalf("should not sync")
+	default:
+	}
+	if f.writePos.Load() == offset {
+		require.NotEqual(t, f.writePos.Load(), f.syncPos.Load())
+	}
+	require.NoError(t, w.CloseWithLastQueuedRecord(PendingSyncIndex{Index: 1}))
+	<-cbChan
+	require.Equal(t, int64(1), lastSync)
+	require.Equal(t, f.syncPos.Load(), f.writePos.Load())
+}
+
+type syncFileWithError struct {
+	syncFile
+	err error
+}
+
+func (f *syncFileWithError) Sync() error {
+	if f.err != nil {
+		return f.err
+	}
+	return f.syncFile.Sync()
+}
+
+func TestSyncRecordGeneralizedWithCloseError(t *testing.T) {
+	f := &syncFileWithError{}
+	// Write two records, where the first one requests a sync. The callback
+	// should execute for both since the second attempts to sync on close. The
+	// sync on close gets an error, so the callback has an error too.
+	lastSync := int64(-1)
+	cbChan := make(chan struct{}, 2)
+	w := NewLogWriter(f, 0, LogWriterConfig{
+		WALFsyncLatency: prometheus.NewHistogram(prometheus.HistogramOpts{}),
+		ExternalSyncQueueCallback: func(doneSync PendingSyncIndex, err error) {
+			if doneSync.Index == 1 {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, lastSync+1, doneSync.Index)
+			lastSync++
+			cbChan <- struct{}{}
+		},
+	})
+	offset, err := w.SyncRecordGeneralized([]byte("hello"), &PendingSyncIndex{})
+	require.NoError(t, err)
+	<-cbChan
+	require.Equal(t, offset, f.writePos.Load())
+	require.Equal(t, offset, f.syncPos.Load())
+
+	// Set error for next sync.
+	f.err = errorfs.ErrInjected
+	offset, err = w.SyncRecordGeneralized([]byte("world"), &PendingSyncIndex{Index: NoSyncIndex})
+	require.NoError(t, err)
+	time.Sleep(5 * time.Millisecond)
+	select {
+	case <-cbChan:
+		t.Fatalf("should not sync")
+	default:
+	}
+	if f.writePos.Load() == offset {
+		require.NotEqual(t, f.writePos.Load(), f.syncPos.Load())
+	}
+	require.Error(t, w.CloseWithLastQueuedRecord(PendingSyncIndex{Index: 1}))
+	<-cbChan
+	require.Equal(t, int64(1), lastSync)
+	require.Less(t, f.syncPos.Load(), f.writePos.Load())
+}
+
 // BenchmarkQueueWALBlocks exercises queueing within the LogWriter. It can be
 // useful to measure allocations involved when flushing is slow enough to
 // accumulate a large backlog fo queued blocks.
@@ -589,5 +769,37 @@ func BenchmarkQueueWALBlocks(b *testing.B) {
 				require.NoError(b, w.Close())
 			}
 		})
+	}
+}
+
+// BenchmarkWriteWALBlocksAllocs exercises the PendingSync and related
+// interfaces for the generalized write path, to ensure there are no extra
+// allocations.
+func BenchmarkWriteWALBlocksAllocs(b *testing.B) {
+	const dataVolume = 64 << 20 /* 64 MB */
+	writeSize := 64
+	record := make([]byte, writeSize)
+	numRecords := dataVolume / writeSize
+
+	for j := 0; j < b.N; j++ {
+		b.StopTimer()
+		f := vfstest.DiscardFile
+		w := NewLogWriter(f, 0, LogWriterConfig{
+			WALFsyncLatency:           prometheus.NewHistogram(prometheus.HistogramOpts{}),
+			ExternalSyncQueueCallback: func(doneSync PendingSyncIndex, err error) {},
+		})
+
+		var psi PendingSyncIndex
+		b.StartTimer()
+		for i := 0; i < numRecords; i++ {
+			psi.Index = int64(i)
+			if _, err := w.SyncRecordGeneralized(record[:], &psi); err != nil {
+				b.Fatal(err)
+			}
+		}
+		// Close to ensure everything is written.
+		require.NoError(b, w.CloseWithLastQueuedRecord(psi))
+		b.StopTimer()
+		b.SetBytes(dataVolume)
 	}
 }


### PR DESCRIPTION
The syncQueue is generalized via the pendingSyncs and helper interfaces. pendingSyncs has two implementations, one for the standalone case where there is a real queue (backed by syncQueue), and one for the failover case where the LogWriter only tracks the latest record that has requested a sync.

LogWriterConfig.ExternalSyncQueueCallback is introduced for the failover case to inform the caller when a particular record index is synced. This callback is also utilized on close, to inform the caller of the tail of the records that have now been synced (even if they did not originally request to be synced).

SyncRecordGeneralized and CloseWithLastQueuedRecord are the new methods that will be used in the failover case.

Informs #3230

Informs CRDB-35401