### PR TITLE
db: fix some iterator error paths

### DIFF
--- a/cleaner.go
+++ b/cleaner.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/tokenbucket"
 )
@@ -122,10 +121,6 @@ func (cm *cleanupManager) EnqueueJob(jobID int, obsoleteFiles []obsoleteFile) {
 	cm.mu.totalJobs++
 	cm.maybeLogLocked()
 	cm.mu.Unlock()
-
-	if invariants.Enabled && len(cm.jobsCh) >= cap(cm.jobsCh)-2 {
-		panic("cleanup jobs queue full")
-	}
 
 	cm.jobsCh <- job
 }

--- a/get_iter.go
+++ b/get_iter.go
@@ -73,6 +73,10 @@ func (g *getIter) Last() (*InternalKey, base.LazyValue) {
 func (g *getIter) Next() (*InternalKey, base.LazyValue) {
 	if g.iter != nil {
 		g.iterKey, g.iterValue = g.iter.Next()
+		if err := g.iter.Error(); err != nil {
+			g.err = err
+			return nil, base.LazyValue{}
+		}
 	}
 
 	for {
@@ -134,6 +138,10 @@ func (g *getIter) Next() (*InternalKey, base.LazyValue) {
 				base.InternalKeySeqNumMax,
 			)
 			g.iterKey, g.iterValue = g.iter.SeekGE(g.key, base.SeekGEFlagsNone)
+			if err := g.iter.Error(); err != nil {
+				g.err = err
+				return nil, base.LazyValue{}
+			}
 			g.batch = nil
 			continue
 		}
@@ -151,6 +159,10 @@ func (g *getIter) Next() (*InternalKey, base.LazyValue) {
 			g.rangeDelIter = m.newRangeDelIter(nil)
 			g.mem = g.mem[:n-1]
 			g.iterKey, g.iterValue = g.iter.SeekGE(g.key, base.SeekGEFlagsNone)
+			if err := g.iter.Error(); err != nil {
+				g.err = err
+				return nil, base.LazyValue{}
+			}
 			continue
 		}
 
@@ -181,6 +193,11 @@ func (g *getIter) Next() (*InternalKey, base.LazyValue) {
 					prefix = g.key[:g.comparer.Split(g.key)]
 				}
 				g.iterKey, g.iterValue = g.iter.SeekPrefixGE(prefix, g.key, base.SeekGEFlagsNone)
+				if err := g.iter.Error(); err != nil {
+					g.err = err
+					return nil, base.LazyValue{}
+				}
+
 				if bc.isSyntheticIterBoundsKey || bc.isIgnorableBoundaryKey {
 					g.iterKey = nil
 					g.iterValue = base.LazyValue{}
@@ -219,6 +236,10 @@ func (g *getIter) Next() (*InternalKey, base.LazyValue) {
 			prefix = g.key[:g.comparer.Split(g.key)]
 		}
 		g.iterKey, g.iterValue = g.iter.SeekPrefixGE(prefix, g.key, base.SeekGEFlagsNone)
+		if err := g.iter.Error(); err != nil {
+			g.err = err
+			return nil, base.LazyValue{}
+		}
 		if bc.isSyntheticIterBoundsKey || bc.isIgnorableBoundaryKey {
 			g.iterKey = nil
 			g.iterValue = base.LazyValue{}

--- a/internal/keyspan/interleaving_iter.go
+++ b/internal/keyspan/interleaving_iter.go
@@ -207,11 +207,14 @@ func (i *InterleavingIter) Init(
 	keyspanIter FragmentIterator,
 	opts InterleavingIterOpts,
 ) {
+	keyspanIter = MaybeAssert(keyspanIter, comparer.Compare)
+	// To debug:
+	// keyspanIter = InjectLogging(keyspanIter, base.DefaultLogger)
 	*i = InterleavingIter{
 		cmp:         comparer.Compare,
 		comparer:    comparer,
 		pointIter:   pointIter,
-		keyspanIter: MaybeAssert(keyspanIter, comparer.Compare),
+		keyspanIter: keyspanIter,
 		mask:        opts.Mask,
 		lower:       opts.LowerBound,
 		upper:       opts.UpperBound,

--- a/internal/keyspan/logging_iter.go
+++ b/internal/keyspan/logging_iter.go
@@ -37,7 +37,7 @@ func newLoggingIter(state *loggingState, iter FragmentIterator) FragmentIterator
 	return &loggingIter{
 		iter:    iter,
 		state:   state,
-		context: fmt.Sprintf("%T:", iter),
+		context: fmt.Sprintf("%T(%p):", iter, iter),
 	}
 }
 

--- a/internal/keyspan/logging_iter_test.go
+++ b/internal/keyspan/logging_iter_test.go
@@ -6,6 +6,7 @@ package keyspan
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -34,7 +35,10 @@ func TestLoggingIter(t *testing.T) {
 			iter = InjectLogging(iter, l)
 			runFragmentIteratorCmd(iter, d.Input, nil)
 			require.NoError(t, iter.Close())
-			return l.String()
+			out := l.String()
+			// Hide pointer values.
+			r := regexp.MustCompile(`\(0x[0-9a-f]+\)`)
+			return r.ReplaceAllString(out, "")
 
 		default:
 			return fmt.Sprintf("unknown command: %s", d.Cmd)

--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -331,11 +331,11 @@ func (t *Test) maybeSaveData() {
 	}
 }
 
-// Step runs one single operation, returning whether or not there are additional
-// operations, the operation's output and an error if any occurred while running
-// the operation.
+// Step runs one single operation, returning: whether there are additional
+// operations remaining; the operation's output; and an error if any occurred
+// while running the operation.
 //
-// Step may be used in stead of Execute to advance a test one operation at a
+// Step may be used instead of Execute to advance a test one operation at a
 // time.
 func (t *Test) Step() (more bool, operationOutput string, err error) {
 	more = t.step(t.h, func(format string, args ...interface{}) {

--- a/vfs/errorfs/errorfs.go
+++ b/vfs/errorfs/errorfs.go
@@ -223,17 +223,15 @@ func (c *Counter) MaybeError(op Op) error {
 // Load returns the number of errors injected.
 func (c *Counter) Load() uint64 {
 	c.mu.Lock()
-	v := c.mu.v
-	c.mu.Unlock()
-	return v
+	defer c.mu.Unlock()
+	return c.mu.v
 }
 
 // LastError returns the last non-nil error injected.
 func (c *Counter) LastError() error {
 	c.mu.Lock()
-	err := c.mu.lastErr
-	c.mu.Unlock()
-	return err
+	defer c.mu.Unlock()
+	return c.mu.lastErr
 }
 
 // Toggle wraps an Injector. By default, Toggle injects nothing. When toggled on


### PR DESCRIPTION
#### db: fix some iterator error paths

Fixes `TestIteratorErrors` failures.

We also improve the `Counter` injector to keep track of the stack
trace when the last error was injected.

Fixes #3234

#### db: remove panic when cleanup jobs queue is full

This assertion was hit while stress-testing `TestIteratorErrors`. It
is not necessary, since the code is designed to block as needed. It
was there to make sure we never block under normal circumstances.
