### PR TITLE
sstable: enforce lower bounds in virtualLastSeekLE()

### DIFF
--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -919,6 +919,11 @@ func (i *singleLevelIterator) virtualLastSeekLE(key []byte) (*InternalKey, base.
 		return nil, base.LazyValue{}
 	}
 	if result == loadBlockIrrelevant {
+		// Enforce the lower bound here, as we could have gone past it.
+		if i.lower != nil && i.cmp(ikey.UserKey, i.lower) < 0 {
+			i.exhaustedBounds = -1
+			return nil, base.LazyValue{}
+		}
 		// Want to skip to the previous block.
 		return i.skipBackward()
 	}
@@ -931,6 +936,11 @@ func (i *singleLevelIterator) virtualLastSeekLE(key []byte) (*InternalKey, base.
 	}
 	ikey, val = i.data.Prev()
 	if ikey != nil {
+		// Enforce the lower bound here, as we could have gone past it.
+		if i.blockLower != nil && i.cmp(ikey.UserKey, i.blockLower) < 0 {
+			i.exhaustedBounds = -1
+			return nil, base.LazyValue{}
+		}
 		return ikey, val
 	}
 	return i.skipBackward()
@@ -953,7 +963,7 @@ func (i *singleLevelIterator) SeekLT(
 		// first internal key with user key < key.
 		if cmp > 0 {
 			// Return the last key in the virtual sstable.
-			return i.virtualLast()
+			return i.maybeVerifyKey(i.virtualLast())
 		}
 	}
 
@@ -1133,7 +1143,7 @@ func (i *singleLevelIterator) firstInternal() (*InternalKey, base.LazyValue) {
 // SeekLT(upper))
 func (i *singleLevelIterator) Last() (*InternalKey, base.LazyValue) {
 	if i.vState != nil {
-		return i.virtualLast()
+		return i.maybeVerifyKey(i.virtualLast())
 	}
 
 	if i.upper != nil {

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -617,6 +617,9 @@ func (i *twoLevelIterator) virtualLastSeekLE(key []byte) (*InternalKey, base.Laz
 		return nil, base.LazyValue{}
 	}
 	if result == loadBlockIrrelevant {
+		if i.lower != nil && i.cmp(ikey.UserKey, i.lower) < 0 {
+			i.exhaustedBounds = -1
+		}
 		// Load the previous block.
 		return i.skipBackward()
 	}

--- a/testdata/excise
+++ b/testdata/excise
@@ -431,3 +431,96 @@ prev
 cc: (., [cc-f) @7=foo UPDATED)
 bbsomethinglong@4: (bazz, . UPDATED)
 b@5: (bar, .)
+
+# Regression test for #3236. Lower bounds are enforced in virtualLastSeekLE()
+# in the case where the actual virtual sstable last key is invisible due to
+# being obsolete. We create an EFOS to ensure that we create a virtual
+# sstable consisting only of obsolete keys with an excise, then do an iterator
+# operation that does a virtualLastSeekLE() on it.
+
+reset
+----
+
+batch
+set a foo
+set b bar
+----
+
+batch
+set d@6 baz
+----
+
+flush
+----
+
+compact a z
+----
+
+batch
+set d@6 something
+----
+
+flush
+----
+
+batch
+set x something
+----
+
+file-only-snapshot s1
+a z
+----
+ok
+
+build ext7
+del d@6
+----
+
+ingest ext7
+----
+
+lsm
+----
+0.1:
+  000008:[d@6#15,DEL-d@6#15,DEL]
+0.0:
+  000007:[d@6#13,SET-d@6#13,SET]
+6:
+  000005:[a#10,SET-d@6#12,SET]
+
+compact c e
+----
+
+lsm
+----
+6:
+  000009:[a#0,SET-d@6#0,SET]
+
+build ext5
+set c something
+----
+
+ingest-and-excise ext5 excise=c-cc
+----
+
+lsm
+----
+6:
+  000011:[a#0,SET-b#0,SET]
+  000010:[c#16,SET-c#16,SET]
+  000012:[d@6#15,DEL-d@6#0,SET]
+
+iter lower=c upper=e
+last
+prev
+prev
+seek-lt dd
+prev
+prev
+----
+c: (something, .)
+.
+.
+c: (something, .)
+.
+.


### PR DESCRIPTION
In the rare case where the data block iter does not return a key at the upper bound of the virtual sstable, such as due to the obsolete bit, we could go past the lower bound of the iterator in `virtualLastSeekLE`. This change addresses this by enforcing the lower bound in those conditionals in `virtualLast` where we previously weren't enforcing anything.

Fixes #3236.