### PR TITLE
metamorphic: fix passed test.run argument

### DIFF
--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -519,6 +519,7 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 		writers = append(writers, os.Stdout)
 	}
 	h := newHistory(runOpts.failRegexp, writers...)
+	defer h.Close()
 
 	m := newTest(ops)
 	require.NoError(t, m.init(h, dir, testOpts, runOpts.numInstances))

--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -221,7 +221,7 @@ func RunAndCompare(t *testing.T, rootDir string, rOpts ...RunOption) {
 		args := []string{
 			"-keep=" + fmt.Sprint(runOpts.keep),
 			"-run-dir=" + runDir,
-			"-test.run=" + t.Name() + "$",
+			"-test.run=" + topLevelTestName + "$",
 		}
 		if runOpts.numInstances > 1 {
 			args = append(args, "--num-instances="+strconv.Itoa(runOpts.numInstances))


### PR DESCRIPTION
#### metamorphic: fix passed test.run argument

In #2093 we accidentally changed the argument to `test.run` to be the
full subtest name (e.g. `-test.run=TestMeta/execution/random-015$`)
instead of just the top-level name. This makes the `$` ineffective and
we end up running both `TestMeta` and `TestMetaTwoInstance`.

#### metamorphic: prevent write-after-close through history

The history object implements a logger object which can be used after
the end of the test if a database isn't closed. This can cause writes
to the history file after close (which can result in subtle issues).

This commit adds a `Close()` method to `history` which causes further
logging calls to be ignored.
