### PR TITLE
metamorphic: minor fixes to the reducer

### DIFF
--- a/internal/metamorphic/reduce_test.go
+++ b/internal/metamorphic/reduce_test.go
@@ -182,7 +182,7 @@ func (r *reducer) try(t *testing.T, ops []string) bool {
 		t.Logf("  Diagram: %s", diagramPath)
 	}
 
-	t.Logf(`  go test ./internal/metamorphic -run "%s$" -v %s %q`, t.Name(), runFlags[0], runFlags[1])
+	t.Logf(`  go test ./internal/metamorphic -tags invariants -run "%s$" -v %s %q`, t.Name(), runFlags[0], runFlags[1])
 	if r.lastSavedDir != "" {
 		require.NoError(t, os.RemoveAll(r.lastSavedDir))
 	}

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -1110,7 +1110,17 @@ func (o *newIterOp) syncObjs() objIDSlice {
 	return objs
 }
 
-func (o *newIterOp) keys() []*[]byte                     { return nil }
+func (o *newIterOp) keys() []*[]byte {
+	var res []*[]byte
+	if o.lower != nil {
+		res = append(res, &o.lower)
+	}
+	if o.upper != nil {
+		res = append(res, &o.upper)
+	}
+	return res
+}
+
 func (o *newIterOp) diagramKeyRanges() []pebble.KeyRange { return nil }
 
 // newIterUsingCloneOp models a Iterator.Clone operation.

--- a/metamorphic/simplify.go
+++ b/metamorphic/simplify.go
@@ -4,7 +4,11 @@
 
 package metamorphic
 
-import "sort"
+import (
+	"sort"
+
+	"github.com/cockroachdb/pebble/internal/testkeys"
+)
 
 // TryToSimplifyKeys parses the operations data and tries to reassign keys to
 // single lowercase characters. Note that the result is not necessarily
@@ -49,6 +53,8 @@ func sortedKeys(in map[string]struct{}) []string {
 	for k := range in {
 		sorted = append(sorted, k)
 	}
-	sort.Strings(sorted)
+	sort.Slice(sorted, func(i, j int) bool {
+		return testkeys.Comparer.Compare([]byte(sorted[i]), []byte(sorted[j])) < 0
+	})
 	return sorted
 }


### PR DESCRIPTION
We weren't using the right key comparer for diagrams and simplification. We also weren't exposing the iterator bounds as keys.