### PR TITLE
wal: add facilities to list WAL files across Dirs

### DIFF
--- a/internal/base/filenames.go
+++ b/internal/base/filenames.go
@@ -96,27 +96,27 @@ func ParseFilename(fs vfs.FS, filename string) (fileType FileType, dfn DiskFileN
 	case filename == "LOCK":
 		return FileTypeLock, 0, true
 	case strings.HasPrefix(filename, "MANIFEST-"):
-		dfn, ok = parseDiskFileNum(filename[len("MANIFEST-"):])
+		dfn, ok = ParseDiskFileNum(filename[len("MANIFEST-"):])
 		if !ok {
 			break
 		}
 		return FileTypeManifest, dfn, true
 	case strings.HasPrefix(filename, "OPTIONS-"):
-		dfn, ok = parseDiskFileNum(filename[len("OPTIONS-"):])
+		dfn, ok = ParseDiskFileNum(filename[len("OPTIONS-"):])
 		if !ok {
 			break
 		}
 		return FileTypeOptions, dfn, ok
 	case strings.HasPrefix(filename, "CURRENT.") && strings.HasSuffix(filename, ".dbtmp"):
 		s := strings.TrimSuffix(filename[len("CURRENT."):], ".dbtmp")
-		dfn, ok = parseDiskFileNum(s)
+		dfn, ok = ParseDiskFileNum(s)
 		if !ok {
 			break
 		}
 		return FileTypeOldTemp, dfn, ok
 	case strings.HasPrefix(filename, "temporary.") && strings.HasSuffix(filename, ".dbtmp"):
 		s := strings.TrimSuffix(filename[len("temporary."):], ".dbtmp")
-		dfn, ok = parseDiskFileNum(s)
+		dfn, ok = ParseDiskFileNum(s)
 		if !ok {
 			break
 		}
@@ -126,7 +126,7 @@ func ParseFilename(fs vfs.FS, filename string) (fileType FileType, dfn DiskFileN
 		if i < 0 {
 			break
 		}
-		dfn, ok = parseDiskFileNum(filename[:i])
+		dfn, ok = ParseDiskFileNum(filename[:i])
 		if !ok {
 			break
 		}
@@ -141,7 +141,8 @@ func ParseFilename(fs vfs.FS, filename string) (fileType FileType, dfn DiskFileN
 	return 0, dfn, false
 }
 
-func parseDiskFileNum(s string) (dfn DiskFileNum, ok bool) {
+// ParseDiskFileNum parses the provided string as a disk file number.
+func ParseDiskFileNum(s string) (dfn DiskFileNum, ok bool) {
 	u, err := strconv.ParseUint(s, 10, 64)
 	if err != nil {
 		return dfn, false

--- a/open.go
+++ b/open.go
@@ -817,8 +817,7 @@ func (d *DB) replayWAL(
 	}()
 
 	for {
-		offset = rr.LogicalOffset()
-		r, err := rr.NextRecord()
+		r, offset, err := rr.NextRecord()
 		if err == nil {
 			_, err = io.Copy(&buf, r)
 		}
@@ -837,7 +836,7 @@ func (d *DB) replayWAL(
 		}
 
 		if buf.Len() < batchrepr.HeaderLen {
-			return nil, 0, base.CorruptionErrorf("pebble: corrupt wal %s (offset %d)",
+			return nil, 0, base.CorruptionErrorf("pebble: corrupt wal %s (offset %s)",
 				errors.Safe(base.DiskFileNum(wn)), offset)
 		}
 

--- a/wal/reader.go
+++ b/wal/reader.go
@@ -1,0 +1,87 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package wal
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+)
+
+// A segment represents an individual physical file that makes up a contiguous
+// segment of a logical WAL. If a failover occurred during a WAL's lifetime, a
+// WAL may be composed of multiple segments.
+type segment struct {
+	logNameIndex logNameIndex
+	dir          Dir
+}
+
+func (s segment) String() string {
+	return fmt.Sprintf("(%s,%s)", s.dir.Dirname, s.logNameIndex)
+}
+
+// A logicalWAL identifies a logical WAL and its consituent segment files.
+type logicalWAL struct {
+	NumWAL
+	// segments contains the list of the consistuent physical segment files that
+	// make up the single logical WAL file. segments is ordered by increasing
+	// logIndex.
+	segments []segment
+}
+
+func (w logicalWAL) String() string {
+	var sb strings.Builder
+	sb.WriteString(base.DiskFileNum(w.NumWAL).String())
+	sb.WriteString(": {")
+	for i := range w.segments {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(w.segments[i].String())
+	}
+	sb.WriteString("}")
+	return sb.String()
+}
+
+// listLogs finds all log files in the provided directories. It returns an
+// ordered list of WALs in increasing NumWAL order.
+func listLogs(dirs ...Dir) ([]logicalWAL, error) {
+	var wals []logicalWAL
+	for _, d := range dirs {
+		ls, err := d.FS.List(d.Dirname)
+		if err != nil {
+			return nil, errors.Wrapf(err, "reading %q", d.Dirname)
+		}
+		for _, name := range ls {
+			dfn, li, ok := parseLogFilename(name)
+			if !ok {
+				continue
+			}
+			// Have we seen this logical log number yet?
+			i, found := slices.BinarySearchFunc(wals, dfn, func(lw logicalWAL, n NumWAL) int {
+				return cmp.Compare(lw.NumWAL, n)
+			})
+			if !found {
+				wals = slices.Insert(wals, i, logicalWAL{NumWAL: dfn, segments: make([]segment, 0, 1)})
+			}
+
+			// Ensure we haven't seen this log index yet, and find where it
+			// slots within this log's segments.
+			j, found := slices.BinarySearchFunc(wals[i].segments, li, func(s segment, li logNameIndex) int {
+				return cmp.Compare(s.logNameIndex, li)
+			})
+			if found {
+				return nil, errors.Errorf("wal: duplicate logIndex=%s for WAL %s in %s and %s",
+					li, dfn, d.Dirname, wals[i].segments[j].dir.Dirname)
+			}
+			wals[i].segments = slices.Insert(wals[i].segments, j, segment{logNameIndex: li, dir: d})
+		}
+	}
+	return wals, nil
+}

--- a/wal/reader_test.go
+++ b/wal/reader_test.go
@@ -1,0 +1,87 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package wal
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestList(t *testing.T) {
+	var buf bytes.Buffer
+	filesystems := map[string]*vfs.MemFS{}
+	getFS := func(name string) *vfs.MemFS {
+		if _, ok := filesystems[name]; !ok {
+			filesystems[name] = vfs.NewMem()
+		}
+		return filesystems[name]
+	}
+
+	datadriven.RunTest(t, "testdata/list", func(t *testing.T, td *datadriven.TestData) string {
+		buf.Reset()
+		switch td.Cmd {
+		case "list":
+			var dirs []Dir
+			for _, arg := range td.CmdArgs {
+				var dirname string
+				if len(arg.Vals) > 1 {
+					dirname = arg.Vals[1]
+				}
+				dirs = append(dirs, Dir{
+					FS:      getFS(arg.Vals[0]),
+					Dirname: dirname,
+				})
+			}
+			logs, err := listLogs(dirs...)
+			if err != nil {
+				return err.Error()
+			}
+			for i := range logs {
+				fmt.Fprintln(&buf, logs[i].String())
+			}
+			return buf.String()
+		case "reset":
+			clear(filesystems)
+			return ""
+		case "touch":
+			for _, l := range strings.Split(strings.TrimSpace(td.Input), "\n") {
+				if l == "" {
+					continue
+				}
+				fields := strings.Fields(l)
+				fsName := fields[0]
+				filename := fields[1]
+
+				fs := getFS(fsName)
+				require.NoError(t, fs.MkdirAll(fs.PathDir(filename), os.ModePerm))
+				f, err := fs.Create(filename)
+				require.NoError(t, err)
+				require.NoError(t, f.Close())
+			}
+
+			// Sort the filesystem names for determinism.
+			var names []string
+			for name := range filesystems {
+				names = append(names, name)
+			}
+			slices.Sort(names)
+			for _, name := range names {
+				fmt.Fprintf(&buf, "%s:\n", name)
+				fmt.Fprint(&buf, filesystems[name].String())
+			}
+			return buf.String()
+		default:
+			return fmt.Sprintf("unrecognized command %q", td.Cmd)
+		}
+	})
+}

--- a/wal/testdata/list
+++ b/wal/testdata/list
@@ -1,0 +1,144 @@
+touch
+a wals/000001.log
+a wals/000002.log
+a wals/1-cockroach.log
+a wals/CURRENT
+a wals/cockroach.log
+a wals/unknown-file
+a wals/unknown-file.log
+----
+a:
+          /
+            wals/
+       0      000001.log
+       0      000002.log
+       0      1-cockroach.log
+       0      CURRENT
+       0      cockroach.log
+       0      unknown-file
+       0      unknown-file.log
+
+# Filesystem b is empty.
+
+list fs=(a,wals) fs=(b,)
+----
+000001: {(wals,000)}
+000002: {(wals,000)}
+
+# Directory `wals` does not exist yet on filesystem b.
+
+list fs=(a,wals) fs=(b,wals)
+----
+reading "wals": open wals/: file does not exist
+
+touch
+b wals/000003.log
+----
+a:
+          /
+            wals/
+       0      000001.log
+       0      000002.log
+       0      1-cockroach.log
+       0      CURRENT
+       0      cockroach.log
+       0      unknown-file
+       0      unknown-file.log
+b:
+          /
+            wals/
+       0      000003.log
+
+# Now that (b,wals) exists, listing should succeed and find filesystem b's WAL.
+
+list fs=(a,wals) fs=(b,wals)
+----
+000001: {(wals,000)}
+000002: {(wals,000)}
+000003: {(wals,000)}
+
+# Two log files for the same log index (in this case the implicit 000).
+
+touch
+b wals/000002.log
+----
+a:
+          /
+            wals/
+       0      000001.log
+       0      000002.log
+       0      1-cockroach.log
+       0      CURRENT
+       0      cockroach.log
+       0      unknown-file
+       0      unknown-file.log
+b:
+          /
+            wals/
+       0      000002.log
+       0      000003.log
+
+list fs=(a,wals) fs=(b,wals)
+----
+wal: duplicate logIndex=000 for WAL 000002 in wals and wals
+
+reset
+----
+
+# Interleaved log indexes.
+
+touch
+a a/000099.log
+b b/000099-001.log
+a a/000099-002.log
+b b/000099-003.log
+----
+a:
+          /
+            a/
+       0      000099-002.log
+       0      000099.log
+b:
+          /
+            b/
+       0      000099-001.log
+       0      000099-003.log
+
+list fs=(a,a) fs=(b,b)
+----
+000099: {(a,000), (b,001), (a,002), (b,003)}
+
+reset
+----
+
+# Skipped log indexes.
+
+touch
+c c/000002.log
+c c/000101.log
+c c/000101-002.log
+c c/000101-004.log
+d d/000101-005.log
+c c/000191.log
+c c/000242.log
+----
+c:
+          /
+            c/
+       0      000002.log
+       0      000101-002.log
+       0      000101-004.log
+       0      000101.log
+       0      000191.log
+       0      000242.log
+d:
+          /
+            d/
+       0      000101-005.log
+
+list fs=(c,c) fs=(d,d)
+----
+000002: {(c,000)}
+000101: {(c,000), (c,002), (c,004), (d,005)}
+000191: {(c,000)}
+000242: {(c,000)}


### PR DESCRIPTION
Add some internal (still unexported) facilities for listing the WAL files across several directories, ordering the consitutent files by log number and index.