### PR TITLE
db: use correct bounds for shared ingestion

### DIFF
--- a/internal/keyspan/truncate.go
+++ b/internal/keyspan/truncate.go
@@ -4,7 +4,11 @@
 
 package keyspan
 
-import "github.com/cockroachdb/pebble/internal/base"
+import (
+	"fmt"
+
+	"github.com/cockroachdb/pebble/internal/base"
+)
 
 // Truncate creates a new iterator where every span in the supplied iterator is
 // truncated to be contained within the range [lower, upper). If start and end
@@ -54,18 +58,16 @@ func Truncate(
 			}
 		}
 
-		var truncated bool
 		// Truncate the bounds to lower and upper.
 		if cmp(in.Start, lower) < 0 {
 			out.Start = lower
 		}
 		if cmp(in.End, upper) > 0 {
-			truncated = true
-			out.End = upper
-		}
+			if panicOnUpperTruncate {
+				panic(fmt.Sprintf("pebble: upper bound should not be truncated. span end: %q  bound %q", in.End, upper))
+			}
 
-		if panicOnUpperTruncate && truncated {
-			panic("pebble: upper bound should not be truncated")
+			out.End = upper
 		}
 
 		return !out.Empty() && cmp(out.Start, out.End) < 0

--- a/table_cache.go
+++ b/table_cache.go
@@ -668,10 +668,8 @@ func (c *tableCacheShard) newRangeDelIter(
 		if dbOpts.opts.Comparer != nil {
 			cmp = dbOpts.opts.Comparer.Compare
 		}
-		// TODO(radu): we should be using AssertBounds, but it currently fails in
-		// some cases (#3167).
-		rangeDelIter = keyspan.AssertUserKeyBounds(
-			rangeDelIter, file.SmallestPointKey.UserKey, file.LargestPointKey.UserKey, cmp,
+		rangeDelIter = keyspan.AssertBounds(
+			rangeDelIter, file.SmallestPointKey, file.LargestPointKey.UserKey, cmp,
 		)
 	}
 	return rangeDelIter, nil

--- a/table_stats.go
+++ b/table_stats.go
@@ -945,13 +945,10 @@ func newCombinedDeletionKeyspanIter(
 		// comparisons, so replacing those key comparisons with assertions
 		// should be roughly similar in performance.
 		//
-		// TODO(jackson): Only use Assert[UserKey]Bounds in invariants builds
-		// in the following release.
-		//
-		// TODO(radu): we should be using AssertBounds, but it currently fails in
-		// some cases (#3167).
-		iter = keyspan.AssertUserKeyBounds(
-			iter, m.SmallestPointKey.UserKey, m.LargestPointKey.UserKey, comparer.Compare,
+		// TODO(jackson): Only use AssertBounds in invariants builds in the
+		// following release.
+		iter = keyspan.AssertBounds(
+			iter, m.SmallestPointKey, m.LargestPointKey.UserKey, comparer.Compare,
 		)
 		dIter := &keyspan.DefragmentingIter{}
 		dIter.Init(comparer, iter, equal, reducer, new(keyspan.DefragmentingBuffers))

--- a/testdata/concurrent_excise
+++ b/testdata/concurrent_excise
@@ -89,7 +89,7 @@ ok
 lsm
 ----
 6:
-  000010:[d#14,SET-d#14,SET]
+  000010:[d#14,DELSIZED-d#14,DEL]
   000011:[f#11,SET-f#11,SET]
 
 compact a-z

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -189,3 +189,28 @@ fh: (foo, .)
 g: (foo, .)
 h: (foo, .)
 .
+
+# Test the case when we are ingesting part of a RANGEDEL.
+reset
+----
+
+batch
+set i bar
+----
+
+build-remote f6
+set b foo
+del-range f u
+----
+
+ingest-external
+f6,10,a,c
+f6,10,g,v
+----
+
+# The previous element cannot be i, because it is inside the [g, v) portion of
+# the [f, u) RANGEDEL.
+iter
+prev
+----
+b: (foo, .)

--- a/testdata/ingest_shared
+++ b/testdata/ingest_shared
@@ -50,7 +50,7 @@ replicated 1 shared SSTs
 lsm
 ----
 6:
-  000005:[d#11,SET-f#11,SET]
+  000005:[d#11,DELSIZED-f#11,DEL]
 
 iter
 first
@@ -368,7 +368,7 @@ lsm
 0.0:
   000004:[a@3#12,SET-d#inf,RANGEDEL]
 6:
-  000005:[a@3#11,SET-e#11,SET]
+  000005:[a@3#11,DELSIZED-e#11,DEL]
 
 iter
 first
@@ -467,9 +467,9 @@ lsm
 0.0:
   000004:[a@3#13,SET-c@9#13,SET]
 5:
-  000005:[b#12,RANGEDEL-d#inf,RANGEDEL]
+  000005:[b#12,DELSIZED-d#inf,RANGEDEL]
 6:
-  000006:[a@3#11,SET-e#11,SET]
+  000006:[a@3#11,DELSIZED-e#11,DEL]
 
 iter
 first
@@ -540,7 +540,7 @@ lsm
 ----
 6:
   000008:[a#10,RANGEKEYSET-aaa#inf,RANGEKEYSET]
-  000007:[b#14,SET-c#14,SET]
+  000007:[b#14,DELSIZED-c#14,DEL]
   000009:[d#11,SET-e#12,SET]
 
 iter
@@ -621,9 +621,9 @@ replicated 2 shared SSTs
 lsm
 ----
 5:
-  000007:[bb#13,RANGEDEL-f#inf,RANGEDEL]
+  000007:[bb#13,DELSIZED-f#inf,RANGEDEL]
 6:
-  000008:[b@5#12,SET-e#12,SET]
+  000008:[b@5#12,DELSIZED-e#12,DEL]
   000005:[ff#10,SET-ff#10,SET]
 
 iter
@@ -719,9 +719,9 @@ replicated 2 shared SSTs
 lsm
 ----
 5:
-  000007:[bb#13,RANGEKEYSET-f#inf,RANGEKEYSET]
+  000007:[bb#13,RANGEKEYSET-f#inf,RANGEKEYDEL]
 6:
-  000008:[b@5#12,SET-e#12,SET]
+  000008:[b@5#12,DELSIZED-e#12,DEL]
   000005:[ff#10,SET-ff#10,SET]
 
 iter
@@ -1298,7 +1298,7 @@ ok
 lsm
 ----
 6:
-  000005:[a#11,SET-a#11,DEL]
+  000005:[a#11,DELSIZED-a#11,DEL]
 
 iter
 first

--- a/testdata/ingest_shared_lower
+++ b/testdata/ingest_shared_lower
@@ -50,7 +50,7 @@ replicated 1 shared SSTs
 lsm
 ----
 6:
-  000005:[d#11,SET-f#11,SET]
+  000005:[d#11,DELSIZED-f#11,DEL]
 
 iter
 first
@@ -368,7 +368,7 @@ lsm
 0.0:
   000004:[a@3#12,SET-d#inf,RANGEDEL]
 6:
-  000005:[a@3#11,SET-e#11,SET]
+  000005:[a@3#11,DELSIZED-e#11,DEL]
 
 iter
 first
@@ -467,9 +467,9 @@ lsm
 0.0:
   000004:[a@3#13,SET-c@9#13,SET]
 5:
-  000005:[b#12,RANGEDEL-d#inf,RANGEDEL]
+  000005:[b#12,DELSIZED-d#inf,RANGEDEL]
 6:
-  000006:[a@3#11,SET-e#11,SET]
+  000006:[a@3#11,DELSIZED-e#11,DEL]
 
 iter
 first
@@ -540,7 +540,7 @@ lsm
 ----
 6:
   000009:[a#10,RANGEKEYSET-aaa#inf,RANGEKEYSET]
-  000008:[b#14,SET-c#14,SET]
+  000008:[b#14,DELSIZED-c#14,DEL]
   000010:[d#11,SET-e#12,SET]
 
 iter
@@ -621,9 +621,9 @@ replicated 2 shared SSTs
 lsm
 ----
 5:
-  000008:[bb#13,RANGEDEL-f#inf,RANGEDEL]
+  000008:[bb#13,DELSIZED-f#inf,RANGEDEL]
 6:
-  000009:[b@5#12,SET-e#12,SET]
+  000009:[b@5#12,DELSIZED-e#12,DEL]
   000006:[ff#10,SET-ff#10,SET]
 
 iter
@@ -702,9 +702,9 @@ replicated 2 shared SSTs
 lsm
 ----
 5:
-  000008:[bb#13,RANGEKEYSET-f#inf,RANGEKEYSET]
+  000008:[bb#13,RANGEKEYSET-f#inf,RANGEKEYDEL]
 6:
-  000009:[b@5#12,SET-e#12,SET]
+  000009:[b@5#12,DELSIZED-e#12,DEL]
   000006:[ff#10,SET-ff#10,SET]
 
 iter

--- a/testdata/level_iter_boundaries
+++ b/testdata/level_iter_boundaries
@@ -117,7 +117,7 @@ last
 prev
 ----
 a#1,1:b
-.
+a#1,1:
 
 clear
 ----
@@ -357,7 +357,7 @@ prev
 prev
 ----
 e#5,1:z
-.
+e#5,1:
 .
 
 file-pos


### PR DESCRIPTION
#### db: remove levelIter reliance on SmallestPointKey kind

The level iterator relies on checking if `SmallestPointKey` is of kind
`InternalKeyKindRangeDelete`. But in the case of external files, we
don't know the kind and we use `InternalKeyKindMax`.

We modify the code to always issue a synthetic boundary at the
smallest boundary if we have a rangeDel iterator, and adjust the logic
to potentially issue two synthetic boundaries (one at
`SmallestPointKey` and one at `Smallest`).

We add an external ingestion testcase which fails against the existing
code.

#### db: use correct bounds for shared ingestion

The kinds in the key bounds for shared ingestion can be incorrect
because of sequence number rewriting. We loosen the bounds to use the
minimum and maximum relevant kinds, similar to external file
ingestion.

We also switch to using `AssertBounds` instead of
`AssertUserKeyBounds` which is now possible.

Fixes #3167