### PR TITLE
internal/rangekey: remove coalesce's error return value

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -524,9 +524,7 @@ func rangeKeyCompactionTransform(
 			}
 			if j > start {
 				keysDst := dst.Keys[usedLen:cap(dst.Keys)]
-				if err := rangekey.Coalesce(cmp, eq, s.Keys[start:j], &keysDst); err != nil {
-					return err
-				}
+				rangekey.Coalesce(cmp, eq, s.Keys[start:j], &keysDst)
 				if j == len(s.Keys) {
 					// This is the last snapshot stripe. Unsets and deletes can be elided.
 					keysDst = elideInLastStripe(keysDst)
@@ -538,9 +536,7 @@ func rangeKeyCompactionTransform(
 		}
 		if j < len(s.Keys) {
 			keysDst := dst.Keys[usedLen:cap(dst.Keys)]
-			if err := rangekey.Coalesce(cmp, eq, s.Keys[j:], &keysDst); err != nil {
-				return err
-			}
+			rangekey.Coalesce(cmp, eq, s.Keys[j:], &keysDst)
 			keysDst = elideInLastStripe(keysDst)
 			usedLen += len(keysDst)
 			dst.Keys = append(dst.Keys, keysDst...)

--- a/internal/rangekey/coalesce_test.go
+++ b/internal/rangekey/coalesce_test.go
@@ -37,9 +37,7 @@ func TestCoalesce(t *testing.T) {
 				Start: span.Start,
 				End:   span.End,
 			}
-			if err := Coalesce(cmp, eq, span.Keys, &coalesced.Keys); err != nil {
-				return err.Error()
-			}
+			Coalesce(cmp, eq, span.Keys, &coalesced.Keys)
 			fmt.Fprintln(&buf, coalesced)
 			return buf.String()
 		default:
@@ -77,9 +75,7 @@ func TestIter(t *testing.T) {
 					Cmp:  cmp,
 					Keys: dst.Keys[:0],
 				}
-				if err := coalesce(eq, &keysBySuffix, visibleSeqNum, s.Keys); err != nil {
-					return err
-				}
+				coalesce(eq, &keysBySuffix, visibleSeqNum, s.Keys)
 				// Update the span with the (potentially reduced) keys slice.  coalesce left
 				// the keys in *dst sorted by suffix. Re-sort them by trailer.
 				dst.Keys = keysBySuffix.Keys

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -721,10 +721,7 @@ func buildForIngest(
 				End:   span.End,
 				Keys:  make([]keyspan.Key, 0, len(span.Keys)),
 			}
-			err = rangekey.Coalesce(t.opts.Comparer.Compare, equal, span.Keys, &collapsed.Keys)
-			if err != nil {
-				return "", nil, err
-			}
+			rangekey.Coalesce(t.opts.Comparer.Compare, equal, span.Keys, &collapsed.Keys)
 			for i := range collapsed.Keys {
 				collapsed.Keys[i].Trailer = base.MakeTrailer(0, collapsed.Keys[i].Kind())
 			}


### PR DESCRIPTION
The coalesce function is infallible and never returns a non-nil error return value. Remove the error return value altogether.