### PR TITLE
db: skip LogData when building flushable batch iterators

### DIFF
--- a/db.go
+++ b/db.go
@@ -775,6 +775,8 @@ func (d *DB) RangeKeyDelete(start, end []byte, opts *WriteOptions) error {
 // reuse them.
 //
 // It is safe to modify the contents of the arguments after Apply returns.
+//
+// Apply returns ErrInvalidBatch if the provided batch is invalid in any way.
 func (d *DB) Apply(batch *Batch, opts *WriteOptions) error {
 	return d.applyInternal(batch, opts, false)
 }

--- a/metamorphic/config.go
+++ b/metamorphic/config.go
@@ -49,6 +49,7 @@ const (
 	OpWriterDeleteRange
 	OpWriterIngest
 	OpWriterIngestAndExcise
+	OpWriterLogData
 	OpWriterMerge
 	OpWriterRangeKeyDelete
 	OpWriterRangeKeySet
@@ -171,6 +172,7 @@ func DefaultOpConfig() OpConfig {
 			OpWriterDeleteRange:           50,
 			OpWriterIngest:                100,
 			OpWriterIngestAndExcise:       0, // TODO(bilal): Enable this.
+			OpWriterLogData:               10,
 			OpWriterMerge:                 100,
 			OpWriterRangeKeySet:           10,
 			OpWriterRangeKeyUnset:         10,
@@ -226,6 +228,7 @@ func ReadOpConfig() OpConfig {
 			OpWriterDelete:                0,
 			OpWriterDeleteRange:           0,
 			OpWriterIngest:                0,
+			OpWriterLogData:               0,
 			OpWriterMerge:                 0,
 			OpWriterRangeKeySet:           0,
 			OpWriterRangeKeyUnset:         0,
@@ -283,6 +286,7 @@ func WriteOpConfig() OpConfig {
 			OpWriterDelete:                100,
 			OpWriterDeleteRange:           20,
 			OpWriterIngest:                100,
+			OpWriterLogData:               10,
 			OpWriterMerge:                 100,
 			OpWriterRangeKeySet:           10,
 			OpWriterRangeKeyUnset:         10,

--- a/metamorphic/generator.go
+++ b/metamorphic/generator.go
@@ -185,6 +185,7 @@ func generate(rng *rand.Rand, count uint64, cfg OpConfig, km *keyManager) []op {
 		OpWriterDeleteRange:           g.writerDeleteRange,
 		OpWriterIngest:                g.writerIngest,
 		OpWriterIngestAndExcise:       g.writerIngestAndExcise,
+		OpWriterLogData:               g.writerLogData,
 		OpWriterMerge:                 g.writerMerge,
 		OpWriterRangeKeyDelete:        g.writerRangeKeyDelete,
 		OpWriterRangeKeySet:           g.writerRangeKeySet,
@@ -1258,6 +1259,16 @@ func (g *generator) writerIngestAndExcise() {
 		derivedDBID: derivedDBID,
 		exciseStart: start,
 		exciseEnd:   end,
+	})
+}
+
+func (g *generator) writerLogData() {
+	if len(g.liveWriters) == 0 {
+		return
+	}
+	g.add(&logDataOp{
+		writerID: g.liveWriters.rand(g.rng),
+		data:     randBytes(g.rng, 0, g.expRandInt(10)),
 	})
 }
 

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -516,6 +516,27 @@ func (o *rangeKeyUnsetOp) diagramKeyRanges() []pebble.KeyRange {
 	return []pebble.KeyRange{{Start: o.start, End: o.end}}
 }
 
+// logDataOp models a Writer.LogData operation.
+type logDataOp struct {
+	writerID objID
+	data     []byte
+}
+
+func (o *logDataOp) run(t *Test, h historyRecorder) {
+	w := t.getWriter(o.writerID)
+	err := w.LogData(o.data, t.writeOpts)
+	h.Recordf("%s // %v", o, err)
+}
+
+func (o *logDataOp) String() string {
+	return fmt.Sprintf("%s.LogData(%q)", o.writerID, o.data)
+}
+
+func (o *logDataOp) receiver() objID                     { return o.writerID }
+func (o *logDataOp) syncObjs() objIDSlice                { return nil }
+func (o *logDataOp) keys() []*[]byte                     { return []*[]byte{} }
+func (o *logDataOp) diagramKeyRanges() []pebble.KeyRange { return []pebble.KeyRange{} }
+
 // newBatchOp models a Write.NewBatch operation.
 type newBatchOp struct {
 	dbID    objID

--- a/metamorphic/parser.go
+++ b/metamorphic/parser.go
@@ -76,6 +76,8 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 		return nil, nil, []interface{}{&t.dbSlots, &t.batchSlots, &t.iterSlots, &t.snapshotSlots}
 	case *iterLastOp:
 		return &t.iterID, nil, nil
+	case *logDataOp:
+		return &t.writerID, nil, []interface{}{&t.data}
 	case *mergeOp:
 		return &t.writerID, nil, []interface{}{&t.key, &t.value}
 	case *newBatchOp:
@@ -138,6 +140,7 @@ var methods = map[string]*methodInfo{
 	"IngestAndExcise":           makeMethod(ingestAndExciseOp{}, dbTag),
 	"Init":                      makeMethod(initOp{}, dbTag),
 	"Last":                      makeMethod(iterLastOp{}, iterTag),
+	"LogData":                   makeMethod(logDataOp{}, dbTag, batchTag),
 	"Merge":                     makeMethod(mergeOp{}, dbTag, batchTag),
 	"NewBatch":                  makeMethod(newBatchOp{}, dbTag),
 	"NewIndexedBatch":           makeMethod(newIndexedBatchOp{}, dbTag),


### PR DESCRIPTION
**db: skip LogData when building batch iterators**

Previously, if a batch containing a LogData was sufficiently large to be
considered a 'large batch' and enqueued among the in-memory flushables, it
would be surfaced to the eventual memtable flush. With the current compaction
iterator assertions, the flush would fail when it observed an unexpected key
kind. The `Batch.refreshMemTableSize` and `Batch.Apply` functions also had bugs
in which they failed to consider LogData keys, which meant that a batch only
containing a single large LogData could be considered a large batch if it was
committed through these code paths.

This commit adjusts all memtable-size calculations to skip LogDatas and error
on key kinds not explicitly handled. It also adjusts the construction of a
flushable batch to avoid indexing the offsets of LogData entries within a
batch, hiding all LogDatas from flush iteration.

**metamorphic: add Writer.LogData operation**

Exercise the Writer.LogData operation within the metamorphic tests.

Close #3275.