### PR TITLE
testkeys: replace RandomSeparator

### DIFF
--- a/internal/testkeys/testkeys.go
+++ b/internal/testkeys/testkeys.go
@@ -17,6 +17,7 @@ import (
 	"cmp"
 	"fmt"
 	"math"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -29,6 +30,8 @@ const alpha = "abcdefghijklmnopqrstuvwxyz"
 const suffixDelim = '@'
 
 var inverseAlphabet = make(map[byte]int64, len(alpha))
+
+var prefixRE = regexp.MustCompile("[" + alpha + "]+")
 
 func init() {
 	for i := range alpha {
@@ -281,21 +284,22 @@ func (a alphabet) EveryN(n int64) Keyspace {
 }
 
 func keyCount(n, l int) int64 {
-	if n == 0 {
-		return 0
-	} else if n == 1 {
-		return int64(l)
-	}
 	// The number of representable keys in the keyspace is a function of the
-	// length of the alphabet n and the max key length l. Consider how the
-	// number of representable keys grows as l increases:
-	//
-	// l = 1: n
-	// l = 2: n + n^2
-	// l = 3: n + n^2 + n^3
-	// ...
-	// Σ i=(1...l) n^i = n*(n^l - 1)/(n-1)
-	return (int64(n) * (int64(math.Pow(float64(n), float64(l))) - 1)) / int64(n-1)
+	// length of the alphabet n and the max key length l:
+	//   n + n^2 + ... + n^l
+	x := int64(1)
+	res := int64(0)
+	for i := 1; i <= l; i++ {
+		if x >= math.MaxInt64/int64(n) {
+			panic("overflow")
+		}
+		x *= int64(n)
+		res += x
+		if res < 0 {
+			panic("overflow")
+		}
+	}
+	return res
 }
 
 func (a alphabet) key(buf []byte, idx int64) int {
@@ -377,128 +381,71 @@ func computeAlphabetKeyIndex(key []byte, alphabet map[byte]int64, n int) int64 {
 	return ret
 }
 
-func abs(a int64) int64 {
-	if a < 0 {
-		return -a
+// RandomPrefixInRange returns a random prefix in the range [a, b), where a and
+// b are prefixes.
+func RandomPrefixInRange(a, b []byte, rng *rand.Rand) []byte {
+	assertValidPrefix(a)
+	assertValidPrefix(b)
+	assertLess(a, b)
+	commonPrefix := 0
+	for commonPrefix < len(a)-1 && commonPrefix < len(b)-1 && a[commonPrefix] == b[commonPrefix] {
+		commonPrefix++
 	}
-	return a
+
+	// We will generate a piece of a key from the Alpha(maxLength) keyspace. Note
+	// that maxLength cannot be higher than ~13 or we will encounter overflows.
+	maxLength := 4 + rng.Intn(8)
+
+	// Skip any common prefix (but leave at least one character in each key).
+	skipPrefix := 0
+	for skipPrefix+1 < min(len(a), len(b)) && a[skipPrefix] == b[skipPrefix] {
+		skipPrefix++
+	}
+	aPiece := a[skipPrefix:]
+	bPiece := b[skipPrefix:]
+	if len(aPiece) > maxLength {
+		// The trimmed prefix is smaller than a; we must be careful below to not
+		// return a key smaller than a.
+		aPiece = aPiece[:maxLength]
+	}
+	if len(bPiece) > maxLength {
+		// The trimmed prefix is smaller than b, so we will still respect the bound.
+		bPiece = bPiece[:maxLength]
+	}
+	assertLess(aPiece, bPiece)
+	apIdx := computeAlphabetKeyIndex(aPiece, inverseAlphabet, maxLength)
+	bpIdx := computeAlphabetKeyIndex(bPiece, inverseAlphabet, maxLength)
+	if bpIdx <= apIdx {
+		panic("unreachable")
+	}
+	generatedIdx := apIdx + rng.Int63n(bpIdx-apIdx)
+	if generatedIdx == apIdx {
+		// Return key a. We handle this separately in case we trimmed aPiece above.
+		return append([]byte(nil), a...)
+	}
+	dst := make([]byte, skipPrefix+maxLength)
+	copy(dst, a[:skipPrefix])
+	pieceLen := WriteKey(dst[skipPrefix:], Alpha(maxLength), generatedIdx)
+	dst = dst[:skipPrefix+pieceLen]
+	assertLE(a, dst)
+	assertLess(dst, b)
+	return dst
 }
 
-// RandomSeparator returns a random alphabetic key k such that a < k < b,
-// pulling randomness from the provided random number generator. If dst is
-// provided and the generated key fits within dst's capacity, the returned slice
-// will use dst's memory.
-//
-// If a prefix P exists such that Prefix(a) < P < Prefix(b), the generated key
-// will consist of the prefix P appended with the provided suffix. A zero suffix
-// generates an unsuffixed key. If no such prefix P exists, RandomSeparator will
-// try to find a key k with either Prefix(a) or Prefix(b) such that a < k < b,
-// but the generated key will not use the provided suffix. Note that it's
-// possible that no separator key exists (eg, a='a@2', b='a@1'), in which case
-// RandomSeparator returns nil.
-//
-// If RandomSeparator generates a new prefix, the generated prefix will have
-// length at most MAX(maxLength, len(Prefix(a)), len(Prefix(b))).
-//
-// RandomSeparator panics if a or b fails to decode.
-func RandomSeparator(dst, a, b []byte, suffix int64, maxLength int, rng *rand.Rand) []byte {
+func assertValidPrefix(p []byte) {
+	if !prefixRE.Match(p) {
+		panic(fmt.Sprintf("invalid prefix %q", p))
+	}
+}
+
+func assertLess(a, b []byte) {
 	if Comparer.Compare(a, b) >= 0 {
-		return nil
+		panic(fmt.Sprintf("invalid key ordering: %q >= %q", a, b))
 	}
+}
 
-	// Determine both keys' logical prefixes and suffixes.
-	ai := Comparer.Split(a)
-	bi := Comparer.Split(b)
-	ap := a[:ai]
-	bp := b[:bi]
-	maxLength = max(maxLength, len(ap), len(bp))
-	var as, bs int64
-	var err error
-	if ai != len(a) {
-		as, err = ParseSuffix(a[ai:])
-		if err != nil {
-			panic(fmt.Sprintf("failed to parse suffix of %q", a))
-		}
+func assertLE(a, b []byte) {
+	if Comparer.Compare(a, b) > 0 {
+		panic(fmt.Sprintf("invalid key ordering: %q > %q", a, b))
 	}
-	if bi != len(b) {
-		bs, err = ParseSuffix(b[bi:])
-		if err != nil {
-			panic(fmt.Sprintf("failed to parse suffix of %q", b))
-		}
-	}
-
-	apIdx := computeAlphabetKeyIndex(ap, inverseAlphabet, maxLength)
-	bpIdx := computeAlphabetKeyIndex(bp, inverseAlphabet, maxLength)
-	diff := bpIdx - apIdx
-	generatedIdx := bpIdx
-	if diff > 0 {
-		var add int64 = diff + 1
-		var start int64 = apIdx
-		if as == 1 {
-			// There's no expressible key with prefix a greater than a@1. So,
-			// exclude ap.
-			start = apIdx + 1
-			add = diff
-		}
-		if bs == 0 {
-			// No key with prefix b can sort before b@0. We don't want to pick b.
-			add--
-		}
-		// We're allowing generated id to be in the range [start, start + add - 1].
-		if start > start+add-1 {
-			return nil
-		}
-		// If we can generate a key which is actually in the middle of apIdx
-		// and bpIdx use it so that we don't have to bother about timestamps.
-		generatedIdx = rng.Int63n(add) + start
-		for diff > 1 && generatedIdx == apIdx || generatedIdx == bpIdx {
-			generatedIdx = rng.Int63n(add) + start
-		}
-	}
-
-	switch {
-	case generatedIdx == apIdx && generatedIdx == bpIdx:
-		if abs(bs-as) <= 1 {
-			// There's no expressible suffix between the two, and there's no
-			// possible separator key.
-			return nil
-		}
-		// The key b is >= key a, but has the same prefix, so b must have the
-		// smaller timestamp, unless a has timestamp of 0.
-		//
-		// NB: The zero suffix (suffix-less) sorts before all other suffixes, so
-		// any suffix we generate will be greater than it.
-		if as == 0 {
-			// bs > as
-			suffix = bs + rng.Int63n(10) + 1
-		} else {
-			// bs < as.
-			// Generate suffix in range [bs + 1, as - 1]
-			suffix = bs + 1 + rng.Int63n(as-bs-1)
-		}
-	case generatedIdx == apIdx:
-		// NB: The zero suffix (suffix-less) sorts before all other suffixes, so
-		// any suffix we generate will be greater than it.
-		if as == 0 && suffix == 0 {
-			suffix++
-		} else if as != 0 && suffix >= as {
-			suffix = rng.Int63n(as)
-		}
-	case generatedIdx == bpIdx:
-		if suffix <= bs {
-			suffix = bs + rng.Int63n(10) + 1
-		}
-	}
-	if sz := maxLength + SuffixLen(suffix); cap(dst) < sz {
-		dst = make([]byte, sz)
-	} else {
-		dst = dst[:cap(dst)]
-	}
-	var w int
-	if suffix == 0 {
-		w = WriteKey(dst, Alpha(maxLength), generatedIdx)
-	} else {
-		w = WriteKeyAt(dst, Alpha(maxLength), generatedIdx, suffix)
-	}
-	return dst[:w]
 }

--- a/metamorphic/generator.go
+++ b/metamorphic/generator.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/internal/randvar"
-	"github.com/cockroachdb/pebble/internal/testkeys"
 	"golang.org/x/exp/rand"
 )
 
@@ -221,7 +220,7 @@ func (g *generator) add(op op) {
 
 // prefixKeyRange generates a [start, end) pair consisting of two prefix keys.
 func (g *generator) prefixKeyRange() ([]byte, []byte) {
-	keys := g.keyGenerator.UniqueKeys(2, func() []byte { return g.keyGenerator.RandPrefix(0.001) })
+	keys := g.keyGenerator.UniqueKeys(2, func() []byte { return g.keyGenerator.RandPrefix(0.01) })
 	return keys[0], keys[1]
 }
 
@@ -449,32 +448,21 @@ func (g *generator) maybeSetSnapshotIterBounds(readerID objID, opts *iterOpts) b
 		return false
 	}
 	// Pick a random keyrange within one of the snapshot's key ranges.
-	parentBounds := snapBounds[g.rng.Intn(len(snapBounds))]
+	parentBounds := pickOneUniform(g.rng, snapBounds)
 	// With 10% probability, use the parent start bound as-is.
 	if g.rng.Float64() <= 0.1 {
 		opts.lower = parentBounds.Start
 	} else {
-		opts.lower = testkeys.RandomSeparator(
-			nil, /* dst */
-			parentBounds.Start,
-			parentBounds.End,
-			0, /* suffix */
-			4+g.rng.Intn(8),
-			g.rng,
-		)
+		opts.lower = g.keyGenerator.RandKeyInRange(0.1, parentBounds)
 	}
 	// With 10% probability, use the parent end bound as-is.
 	if g.rng.Float64() <= 0.1 {
 		opts.upper = parentBounds.End
 	} else {
-		opts.upper = testkeys.RandomSeparator(
-			nil, /* dst */
-			opts.lower,
-			parentBounds.End,
-			0, /* suffix */
-			4+g.rng.Intn(8),
-			g.rng,
-		)
+		opts.upper = g.keyGenerator.RandKeyInRange(0.1, pebble.KeyRange{
+			Start: opts.lower,
+			End:   parentBounds.End,
+		})
 	}
 	return true
 }

--- a/metamorphic/key_generator.go
+++ b/metamorphic/key_generator.go
@@ -5,6 +5,7 @@
 package metamorphic
 
 import (
+	"cmp"
 	"fmt"
 	"slices"
 
@@ -63,10 +64,13 @@ func (kg *keyGenerator) UniqueKeys(n int, genFn func() []byte) [][]byte {
 	keys := make([][]byte, n)
 	used := make(map[string]struct{}, n)
 	for i := range keys {
-		for {
+		for attempts := 0; ; attempts++ {
 			keys[i] = genFn()
 			if _, exists := used[string(keys[i])]; !exists {
 				break
+			}
+			if attempts > 100000 {
+				panic("could not generate unique key")
 			}
 		}
 		used[string(keys[i])] = struct{}{}
@@ -177,21 +181,10 @@ func (kg *keyGenerator) randKey(newKeyProbability float64, bounds *pebble.KeyRan
 			}
 		}
 		// Otherwise fall through to generating a new prefix.
-		fallthrough
+	}
 
-	default:
-		// Use a new prefix, producing a new user key.
-		suffix := int64(kg.cfg.writeSuffixDist.Uint64(kg.rng))
-
-		// If we have bounds in which we need to generate the key, use
-		// testkeys.RandomSeparator to generate a key between the bounds.
-		if bounds != nil {
-			targetLength := 4 + kg.rng.Intn(8)
-			return testkeys.RandomSeparator(
-				nil, kg.prefix(bounds.Start), kg.prefix(bounds.End),
-				suffix, targetLength, kg.rng,
-			)
-		}
+	if bounds == nil {
+		suffix := kg.SkewedSuffixInt(0.01)
 		for {
 			key := kg.generateKeyWithSuffix(4, 12, suffix)
 			if !kg.keyManager.prefixExists(kg.prefix(key)) {
@@ -202,6 +195,43 @@ func (kg *keyGenerator) randKey(newKeyProbability float64, bounds *pebble.KeyRan
 			}
 		}
 	}
+	// We need to generate a key between the bounds.
+	startPrefix, startSuffix := kg.parseKey(bounds.Start)
+	endPrefix, endSuffix := kg.parseKey(bounds.End)
+	var prefix []byte
+	var suffix int64
+	if kg.equal(startPrefix, endPrefix) {
+		prefix = startPrefix
+		// Bounds have the same prefix, generate a suffix in-between.
+		if cmpSuffix(startSuffix, endSuffix) >= 0 {
+			panic(fmt.Sprintf("invalid bounds [%q, %q)", bounds.Start, bounds.End))
+		}
+		suffix = kg.SkewedSuffixInt(0.01)
+		for !(cmpSuffix(startSuffix, suffix) <= 0 && cmpSuffix(suffix, endSuffix) < 0) {
+			// The suffix we want must exist in the current suffix range, we don't
+			// want to keep increasing it here.
+			suffix = kg.SkewedSuffixInt(0)
+		}
+	} else {
+		prefix = testkeys.RandomPrefixInRange(startPrefix, endPrefix, kg.rng)
+		suffix = kg.SkewedSuffixInt(0.01)
+		if kg.equal(prefix, startPrefix) {
+			// We can't use a suffix which sorts before startSuffix.
+			for cmpSuffix(suffix, startSuffix) < 0 {
+				suffix = kg.SkewedSuffixInt(0.01)
+			}
+		}
+	}
+	key := slices.Clip(prefix)
+	if suffix != 0 {
+		key = append(key, testkeys.Suffix(suffix)...)
+	}
+	if kg.cmp(key, bounds.Start) < 0 || kg.cmp(key, bounds.End) >= 0 {
+		panic(fmt.Sprintf("invalid randKey %q  bounds: [%q, %q) %v %v", key, bounds.Start, bounds.End, kg.cmp(key, bounds.Start), kg.cmp(key, bounds.End)))
+	}
+	// We might (rarely) produce an existing key here, that's ok.
+	kg.keyManager.addNewKey(key)
+	return key
 }
 
 // generateKeyWithSuffix generates a key with a random prefix and the given
@@ -212,6 +242,20 @@ func (kg *keyGenerator) generateKeyWithSuffix(minPrefixLen, maxPrefixLen int, su
 		return prefix
 	}
 	return append(prefix, testkeys.Suffix(suffix)...)
+}
+
+// cmpSuffix compares two suffixes, where suffix 0 means there is no suffix.
+func cmpSuffix(s1, s2 int64) int {
+	switch {
+	case s1 == s2:
+		return 0
+	case s1 == 0:
+		return -1
+	case s2 == 0:
+		return +1
+	default:
+		return cmp.Compare(s2, s1)
+	}
 }
 
 func (kg *keyGenerator) cmp(a, b []byte) int {
@@ -227,7 +271,20 @@ func (kg *keyGenerator) split(a []byte) int {
 }
 
 func (kg *keyGenerator) prefix(a []byte) []byte {
-	return a[:kg.split(a)]
+	n := kg.split(a)
+	return a[:n:n]
+}
+
+func (kg *keyGenerator) parseKey(k []byte) (prefix []byte, suffix int64) {
+	n := kg.split(k)
+	if n == len(k) {
+		return k, 0
+	}
+	suffix, err := testkeys.ParseSuffix(k[n:])
+	if err != nil {
+		panic(fmt.Sprintf("error parsing suffix for key %q", k))
+	}
+	return k[:n:n], suffix
 }
 
 func randBytes(rng *rand.Rand, minLen, maxLen int) []byte {


### PR DESCRIPTION
The `RandomSeparator` function is complex and very fragile: it can
fail and return `nil`, and it can return incorrect results if one of
the input keys is longer than ~13 characters (because of overflows in
the `Alpha` keyspace calculations).

In this commit we:
 - add overflow assertions to `keyCount`
 - replace `RandomSeparator` with a simpler `RandomPrefixInRange`
   which returns a prefix in the `[a, b)` range. This function cannot
   fail and supports any key lengths.
 - change the metamorphic key generator to add a suffix to the
   generated prefix.