### PR TITLE
db: change AssertUserKeyBounds to AssertBounds

### DIFF
--- a/table_stats.go
+++ b/table_stats.go
@@ -963,10 +963,8 @@ func newCombinedDeletionKeyspanIter(
 	if iter != nil {
 		// Assert expected bounds in tests.
 		if invariants.Enabled {
-			// TODO(radu): we should be using AssertBounds, but it currently fails in
-			// some cases (#3167).
-			iter = keyspan.AssertUserKeyBounds(
-				iter, m.SmallestRangeKey.UserKey, m.LargestRangeKey.UserKey, comparer.Compare,
+			iter = keyspan.AssertBounds(
+				iter, m.SmallestRangeKey, m.LargestRangeKey.UserKey, comparer.Compare,
 			)
 		}
 		// Wrap the range key iterator in a filter that elides keys other than range


### PR DESCRIPTION
This is a follow-up to #3262; there was one more TODO left to switch
to `AssertBounds`.