### PR TITLE
keyspan: simplify Truncate, Filter

### DIFF
--- a/internal/keyspan/filter.go
+++ b/internal/keyspan/filter.go
@@ -6,13 +6,10 @@ package keyspan
 
 import "github.com/cockroachdb/pebble/internal/base"
 
-// FilterFunc defines a transform from the input Span into the output Span. The
-// function returns true if the Span should be returned by the iterator, and
-// false if the Span should be skipped. The FilterFunc is permitted to mutate
-// the output Span, for example, to elice certain keys, or update the Span's
-// bounds if so desired. The output Span's Keys slice may be reused to reduce
-// allocations.
-type FilterFunc func(in *Span, out *Span) (keep bool)
+// FilterFunc is a callback that allows filtering keys from a Span. The result
+// is the set of keys that should be retained (using buf as a buffer). If the
+// result has no keys, the span is skipped altogether.
+type FilterFunc func(span *Span, buf []Key) []Key
 
 // filteringIter is a FragmentIterator that uses a FilterFunc to select which
 // Spans from the input iterator are returned in the output.
@@ -45,17 +42,7 @@ func (i *filteringIter) SeekGE(key []byte) (*Span, error) {
 	if err != nil {
 		return nil, err
 	}
-	s, err = i.filter(s, +1)
-	if err != nil {
-		return nil, err
-	}
-	// i.filter could return a span that's less than key, _if_ the filterFunc
-	// (which has no knowledge of the seek key) mutated the span to end at a key
-	// less than or equal to `key`. Detect this case and next/invalidate the iter.
-	if s != nil && i.cmp(s.End, key) <= 0 {
-		return i.Next()
-	}
-	return s, nil
+	return i.filter(s, +1)
 }
 
 // SeekLT implements FragmentIterator.
@@ -64,17 +51,7 @@ func (i *filteringIter) SeekLT(key []byte) (*Span, error) {
 	if err != nil {
 		return nil, err
 	}
-	span, err = i.filter(span, -1)
-	if err != nil {
-		return nil, err
-	}
-	// i.filter could return a span that's >= key, _if_ the filterFunc (which has
-	// no knowledge of the seek key) mutated the span to start at a key greater
-	// than or equal to `key`. Detect this case and prev/invalidate the iter.
-	if span != nil && i.cmp(span.Start, key) >= 0 {
-		return i.Prev()
-	}
-	return span, nil
+	return i.filter(span, -1)
 }
 
 // First implements FragmentIterator.
@@ -128,9 +105,17 @@ func (i *filteringIter) filter(span *Span, dir int8) (*Span, error) {
 	}
 	var err error
 	for span != nil {
-		if keep := i.filterFn(span, &i.span); keep {
+		keys := i.filterFn(span, i.span.Keys[:0])
+		if len(keys) > 0 {
+			i.span = Span{
+				Start:     span.Start,
+				End:       span.End,
+				Keys:      keys,
+				KeysOrder: span.KeysOrder,
+			}
 			return &i.span, nil
 		}
+
 		if dir == +1 {
 			span, err = i.iter.Next()
 		} else {

--- a/internal/keyspan/filter_test.go
+++ b/internal/keyspan/filter_test.go
@@ -18,16 +18,15 @@ func TestFilteringIter(t *testing.T) {
 	// makeFilter returns a FilterFunc that will filter out all keys in a Span
 	// that are not of the given kind. Empty spans are skipped.
 	makeFilter := func(kind base.InternalKeyKind) FilterFunc {
-		return func(in *Span, out *Span) (keep bool) {
-			out.Start, out.End = in.Start, in.End
-			out.Keys = out.Keys[:0]
+		return func(in *Span, buf []Key) []Key {
+			keys := buf[:0]
 			for _, k := range in.Keys {
 				if k.Kind() != kind {
 					continue
 				}
-				out.Keys = append(out.Keys, k)
+				keys = append(keys, k)
 			}
-			return len(out.Keys) > 0
+			return keys
 		}
 	}
 

--- a/internal/keyspan/testdata/truncate
+++ b/internal/keyspan/testdata/truncate
@@ -24,38 +24,6 @@ truncate a-e
 1:  b-d
 2:    de
 
-# The second range tombstone should be elided, as it starts after the
-# specified file end key.
-
-truncate a-e endKey=(d.SET.3)
-----
-1:  b-d
-
-# The second range tombstone should be back in the below example, as the
-# specified end key has a trailer (RANGEDEL.2) exactly matching that of the
-# rangedel tombstone's start key.
-
-truncate a-e endKey=(d.RANGEDEL.2)
-----
-1:  b-d
-2:    de
-
-truncate a-e endKey=(d.SET.1)
-----
-1:  b-d
-2:    de
-
-# Similarly, truncate range tombstones that end before the start key.
-
-truncate a-e startKey=(d.SET.3)
-----
-2:    de
-
-truncate a-e startKey=(c.SET.3)
-----
-1:  b-d
-2:    de
-
 truncate a-f
 ----
 1:  b-d

--- a/internal/keyspan/truncate.go
+++ b/internal/keyspan/truncate.go
@@ -14,8 +14,9 @@ import (
 // truncated to be contained within the given user key bounds.
 //
 // Note that fragment iterator Spans always have exclusive end-keys; if the
-// given bounds have an inclusive end key the input iterator must not produce a
-// span that contains that key.
+// given bounds have an inclusive end key, then the input iterator must not
+// produce a span that contains that key. The only difference between bounds.End
+// being inclusive vs exclusive is this extra check.
 func Truncate(cmp base.Compare, iter FragmentIterator, bounds base.UserKeyBounds) FragmentIterator {
 	return &truncatingIter{
 		iter:   iter,
@@ -132,7 +133,7 @@ func (i *truncatingIter) nextSpanWithinBounds(
 			}
 			return nil, false, err
 		}
-		// Intersect [span.Start, span.End) with [lower, upper).
+		// Intersect [span.Start, span.End) with [i.bounds.Start, i.bounds.End.Key).
 		spanBoundsChanged = false
 		start := span.Start
 		if i.cmp(start, i.bounds.Start) < 0 {

--- a/internal/keyspan/truncate.go
+++ b/internal/keyspan/truncate.go
@@ -5,71 +5,169 @@
 package keyspan
 
 import (
-	"fmt"
-
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/invariants"
 )
 
 // Truncate creates a new iterator where every span in the supplied iterator is
-// truncated to be contained within the range [lower, upper). If start and end
-// are specified, filter out any spans that are completely outside those bounds.
-func Truncate(
-	cmp base.Compare,
-	iter FragmentIterator,
-	lower, upper []byte,
-	start, end *base.InternalKey,
-	panicOnUpperTruncate bool,
-) FragmentIterator {
-	return Filter(iter, func(in *Span, out *Span) (keep bool) {
-		out.Start, out.End = in.Start, in.End
-		out.Keys = append(out.Keys[:0], in.Keys...)
+// truncated to be contained within the given user key bounds.
+//
+// Note that fragment iterator Spans always have exclusive end-keys; if the
+// given bounds have an inclusive end key the input iterator must not produce a
+// span that contains that key.
+func Truncate(cmp base.Compare, iter FragmentIterator, bounds base.UserKeyBounds) FragmentIterator {
+	return &truncatingIter{
+		iter:   iter,
+		cmp:    cmp,
+		bounds: bounds,
+	}
+}
 
-		// Ignore this span if it lies completely outside start, end. Note that
-		// end endInclusive indicated whether end is inclusive.
-		//
-		// The comparison between s.End and start is by user key only, as
-		// the span is exclusive at s.End, so comparing by user keys
-		// is sufficient.
-		if start != nil && cmp(in.End, start.UserKey) <= 0 {
-			return false
-		}
-		if end != nil {
-			v := cmp(in.Start, end.UserKey)
-			switch {
-			case v > 0:
-				// Wholly outside the end bound. Skip it.
-				return false
-			case v == 0:
-				// This span begins at the same user key as `end`. Whether or
-				// not any of the keys contained within the span are relevant is
-				// dependent on Trailers. Any keys contained within the span
-				// with trailers larger than end cover the small sliver of
-				// keyspace between [k#inf, k#<end-seqnum>]. Since keys are
-				// sorted descending by Trailer within the span, we need to find
-				// the prefix of keys with larger trailers.
-				for i := range in.Keys {
-					if in.Keys[i].Trailer < end.Trailer {
-						out.Keys = out.Keys[:i]
-						break
-					}
-				}
-			default:
-				// Wholly within the end bound. Keep it.
+type truncatingIter struct {
+	iter FragmentIterator
+	cmp  base.Compare
+
+	bounds base.UserKeyBounds
+
+	span Span
+}
+
+// SeekGE implements FragmentIterator.
+func (i *truncatingIter) SeekGE(key []byte) (*Span, error) {
+	span, err := i.iter.SeekGE(key)
+	if err != nil {
+		return nil, err
+	}
+	span, spanBoundsChanged, err := i.nextSpanWithinBounds(span, +1)
+	if err != nil {
+		return nil, err
+	}
+	// nextSpanWithinBounds could return a span that's less than key, if the end
+	// bound was truncated to end at a key less than or equal to `key`. Detect
+	// this case and next/invalidate the iter.
+	if spanBoundsChanged && i.cmp(span.End, key) <= 0 {
+		return i.Next()
+	}
+	return span, nil
+}
+
+// SeekLT implements FragmentIterator.
+func (i *truncatingIter) SeekLT(key []byte) (*Span, error) {
+	span, err := i.iter.SeekLT(key)
+	if err != nil {
+		return nil, err
+	}
+	span, spanBoundsChanged, err := i.nextSpanWithinBounds(span, -1)
+	if err != nil {
+		return nil, err
+	}
+	// nextSpanWithinBounds could return a span that's >= key, if the start bound
+	// was truncated to start at a key greater than or equal to `key`. Detect this
+	// case and prev/invalidate the iter.
+	if spanBoundsChanged && i.cmp(span.Start, key) >= 0 {
+		return i.Prev()
+	}
+	return span, nil
+}
+
+// First implements FragmentIterator.
+func (i *truncatingIter) First() (*Span, error) {
+	span, err := i.iter.First()
+	if err != nil {
+		return nil, err
+	}
+	span, _, err = i.nextSpanWithinBounds(span, +1)
+	return span, err
+}
+
+// Last implements FragmentIterator.
+func (i *truncatingIter) Last() (*Span, error) {
+	span, err := i.iter.Last()
+	if err != nil {
+		return nil, err
+	}
+	span, _, err = i.nextSpanWithinBounds(span, -1)
+	return span, err
+}
+
+// Next implements FragmentIterator.
+func (i *truncatingIter) Next() (*Span, error) {
+	span, err := i.iter.Next()
+	if err != nil {
+		return nil, err
+	}
+	span, _, err = i.nextSpanWithinBounds(span, +1)
+	return span, err
+}
+
+// Prev implements FragmentIterator.
+func (i *truncatingIter) Prev() (*Span, error) {
+	span, err := i.iter.Prev()
+	if err != nil {
+		return nil, err
+	}
+	span, _, err = i.nextSpanWithinBounds(span, -1)
+	return span, err
+}
+
+// Close implements FragmentIterator.
+func (i *truncatingIter) Close() error {
+	return i.iter.Close()
+}
+
+// nextSpanWithinBounds returns the first span (starting with the given span and
+// advancing in the given direction) that intersects the bounds. It returns a
+// span that is entirely within the bounds; spanBoundsChanged indicates if the span
+// bounds had to be truncated.
+func (i *truncatingIter) nextSpanWithinBounds(
+	span *Span, dir int8,
+) (_ *Span, spanBoundsChanged bool, _ error) {
+	var err error
+	for span != nil {
+		if i.bounds.End.Kind == base.Inclusive && span.Contains(i.cmp, i.bounds.End.Key) {
+			err := errors.AssertionFailedf("inclusive upper bound %q inside span %s", i.bounds.End.Key, span)
+			if invariants.Enabled {
+				panic(err)
 			}
+			return nil, false, err
 		}
-
-		// Truncate the bounds to lower and upper.
-		if cmp(in.Start, lower) < 0 {
-			out.Start = lower
+		// Intersect [span.Start, span.End) with [lower, upper).
+		spanBoundsChanged = false
+		start := span.Start
+		if i.cmp(start, i.bounds.Start) < 0 {
+			spanBoundsChanged = true
+			start = i.bounds.Start
 		}
-		if cmp(in.End, upper) > 0 {
-			if panicOnUpperTruncate {
-				panic(fmt.Sprintf("pebble: upper bound should not be truncated. span end: %q  bound %q", in.End, upper))
+		end := span.End
+		if i.cmp(end, i.bounds.End.Key) > 0 {
+			spanBoundsChanged = true
+			end = i.bounds.End.Key
+		}
+		if !spanBoundsChanged {
+			return span, false, nil
+		}
+		if i.cmp(start, end) < 0 {
+			i.span = Span{
+				Start:     start,
+				End:       end,
+				Keys:      span.Keys,
+				KeysOrder: span.KeysOrder,
 			}
-
-			out.End = upper
+			return &i.span, true, nil
 		}
+		// Span is outside of bounds, find the next one.
+		if dir == +1 {
+			span, err = i.iter.Next()
+		} else {
+			span, err = i.iter.Prev()
+		}
+	}
+	// NB: err may be nil or non-nil.
+	return nil, false, err
+}
 
-		return !out.Empty() && cmp(out.Start, out.End) < 0
-	}, cmp)
+// WrapChildren implements FragmentIterator.
+func (i *truncatingIter) WrapChildren(wrap WrapFn) {
+	i.iter = wrap(i.iter)
 }

--- a/internal/keyspan/truncate_test.go
+++ b/internal/keyspan/truncate_test.go
@@ -36,29 +36,13 @@ func TestTruncate(t *testing.T) {
 				t.Fatalf("expected 1-3 arguments: %s", d.CmdArgs)
 			}
 			parts := strings.Split(d.CmdArgs[0].String(), "-")
-			var startKey, endKey *base.InternalKey
-			if len(d.CmdArgs) > 1 {
-				for _, arg := range d.CmdArgs[1:] {
-					switch arg.Key {
-					case "startKey":
-						startKey = &base.InternalKey{}
-						*startKey = base.ParseInternalKey(arg.Vals[0])
-					case "endKey":
-						endKey = &base.InternalKey{}
-						*endKey = base.ParseInternalKey(arg.Vals[0])
-					}
-				}
-			}
 			if len(parts) != 2 {
 				t.Fatalf("malformed arg: %s", d.CmdArgs[0])
 			}
 			lower := []byte(parts[0])
 			upper := []byte(parts[1])
 
-			tIter := Truncate(
-				cmp, iter, lower, upper, startKey, endKey, false,
-			)
-			return tIter
+			return Truncate(cmp, iter, base.UserKeyBoundsEndExclusive(lower, upper))
 		}
 
 		switch d.Cmd {

--- a/metamorphic/build.go
+++ b/metamorphic/build.go
@@ -256,8 +256,7 @@ func openExternalObj(
 		rangeDelIter = keyspan.Truncate(
 			t.opts.Comparer.Compare,
 			rangeDelIter,
-			start, end,
-			nil /* start */, nil /* end */, false, /* panicOnUpperTruncate */
+			base.UserKeyBoundsEndExclusive(start, end),
 		)
 	}
 
@@ -267,8 +266,7 @@ func openExternalObj(
 		rangeKeyIter = keyspan.Truncate(
 			t.opts.Comparer.Compare,
 			rangeKeyIter,
-			start, end,
-			nil /* start */, nil /* end */, false, /* panicOnUpperTruncate */
+			base.UserKeyBoundsEndExclusive(start, end),
 		)
 	}
 	return reader, pointIter, rangeDelIter, rangeKeyIter

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -546,10 +546,7 @@ func (d *DB) truncateSharedFile(
 	}
 	defer iter.Close()
 	if rangeDelIter != nil {
-		rangeDelIter = keyspan.Truncate(
-			cmp, rangeDelIter, lower, upper, nil, nil,
-			false, /* panicOnUpperTruncate */
-		)
+		rangeDelIter = keyspan.Truncate(cmp, rangeDelIter, base.UserKeyBoundsEndExclusive(lower, upper))
 		defer rangeDelIter.Close()
 	}
 	rangeKeyIter, err := d.tableNewRangeKeyIter(file, keyspan.SpanIterOptions{})
@@ -557,10 +554,7 @@ func (d *DB) truncateSharedFile(
 		return nil, false, err
 	}
 	if rangeKeyIter != nil {
-		rangeKeyIter = keyspan.Truncate(
-			cmp, rangeKeyIter, lower, upper, nil, nil,
-			false, /* panicOnUpperTruncate */
-		)
+		rangeKeyIter = keyspan.Truncate(cmp, rangeKeyIter, base.UserKeyBoundsEndExclusive(lower, upper))
 		defer rangeKeyIter.Close()
 	}
 	// Check if we need to truncate on the left side. This means finding a new

--- a/table_stats.go
+++ b/table_stats.go
@@ -969,16 +969,15 @@ func newCombinedDeletionKeyspanIter(
 		}
 		// Wrap the range key iterator in a filter that elides keys other than range
 		// key deletions.
-		iter = keyspan.Filter(iter, func(in *keyspan.Span, out *keyspan.Span) (keep bool) {
-			out.Start, out.End = in.Start, in.End
-			out.Keys = out.Keys[:0]
+		iter = keyspan.Filter(iter, func(in *keyspan.Span, buf []keyspan.Key) []keyspan.Key {
+			keys := buf[:0]
 			for _, k := range in.Keys {
 				if k.Kind() != base.InternalKeyKindRangeKeyDelete {
 					continue
 				}
-				out.Keys = append(out.Keys, k)
+				keys = append(keys, k)
 			}
-			return len(out.Keys) > 0
+			return keys
 		}, comparer.Compare)
 		dIter := &keyspan.DefragmentingIter{}
 		dIter.Init(comparer, iter, equal, reducer, new(keyspan.DefragmentingBuffers))


### PR DESCRIPTION
#### keyspan: simplify and reimplement Truncate

We can simplify the Truncate operator, as we will never truncate
within the same user key. It now only takes user key bounds and is
much easier to reason about.

We also reimplement it so that we can simplify Filter.

#### keyspan: simplify Filter

The `FilterFunc` contract is not adequately spelled out; the code
makes certain unverified assumptions about how the bounds can be
changed.

Now that Truncate is a separate iterator, we no longer need Filter to
allow for changing bounds. We simplify `FilterFunc` to just return the
list of keys that are retained. We no longer need the extra
comparisons in `SeekGE/SeekLT`.
