### PR TITLE
db: don't assign LogDatas sequence numbers in flushable batches

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -1051,7 +1051,10 @@ func TestFlushableBatch(t *testing.T) {
 			for _, key := range strings.Split(d.Input, "\n") {
 				j := strings.Index(key, ":")
 				ikey := base.ParseInternalKey(key[:j])
-				value := []byte(fmt.Sprint(ikey.SeqNum()))
+				value := []byte(key[j+1:])
+				if len(value) == 0 {
+					value = []byte(fmt.Sprintf("%d", ikey.SeqNum()))
+				}
 				switch ikey.Kind() {
 				case InternalKeyKindDelete:
 					require.NoError(t, batch.Delete(ikey.UserKey, nil))
@@ -1059,6 +1062,8 @@ func TestFlushableBatch(t *testing.T) {
 					require.NoError(t, batch.Set(ikey.UserKey, value, nil))
 				case InternalKeyKindMerge:
 					require.NoError(t, batch.Merge(ikey.UserKey, value, nil))
+				case InternalKeyKindLogData:
+					require.NoError(t, batch.LogData(ikey.UserKey, nil))
 				case InternalKeyKindRangeDelete:
 					require.NoError(t, batch.DeleteRange(ikey.UserKey, value, nil))
 				case InternalKeyKindRangeKeyDelete:

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -1112,6 +1112,9 @@ func (b *BulkVersionEdit) Apply(
 					s1 := describeSublevels(base.DefaultFormatter, false /* verbose */, copyOfSublevels.Levels)
 					s2 := describeSublevels(base.DefaultFormatter, false /* verbose */, v.L0Sublevels.Levels)
 					if s1 != s2 {
+						// Add verbosity.
+						s1 := describeSublevels(base.DefaultFormatter, true /* verbose */, copyOfSublevels.Levels)
+						s2 := describeSublevels(base.DefaultFormatter, true /* verbose */, v.L0Sublevels.Levels)
 						panic(fmt.Sprintf("incremental L0 sublevel generation produced different output than regeneration: %s != %s", s1, s2))
 					}
 				}

--- a/testdata/flushable_batch
+++ b/testdata/flushable_batch
@@ -154,3 +154,33 @@ seek-ge b
 ----
 a:1
 .
+
+# Test a LogData interleaved among batch data. The LogData entry should not be
+# assigned a sequence number or appear within the iterator output.
+
+define
+b.SET.1:
+a.SET.1:
+c.SET.1:
+b.LOGDATA.2:
+1.RANGEDEL.3:
+a.SET.2:
+2.RANGEKEYSET.4:
+1.RANGEKEYDEL.3:
+c.MERGE.2:
+b.DEL.3:
+2.RANGEKEYUNSET.3:
+----
+
+dump seq=0
+----
+a#4,1:2
+a#1,1:1
+b#8,0:
+b#0,1:1
+c#7,2:2
+c#2,1:1
+1-3:{(#3,RANGEDEL)}
+1-2:{(#6,RANGEKEYDEL)}
+2-3:{(#9,RANGEKEYUNSET,3) (#6,RANGEKEYDEL) (#5,RANGEKEYSET,4,4)}
+3-4:{(#5,RANGEKEYSET,4,4)}


### PR DESCRIPTION
**internal/manifest: add verbosity in panic message** 

When pancing due to a L0 sublevels assertion failure, include the verbose
sublevels data in the panic message.

**db: don't assign LogDatas sequence numbers in flushable batches**

In https://github.com/cockroachdb/pebble/pull/3277 the calculation of a batch's memtable size and count was corrected to
no longer allocate memtable space or sequence numbers for LogData entries in
all cases. However the existing code was dependent on the sequence number
allocation for LogData entries when the batch was considered "large" and
enqueued among the flushables. When the large batch was indexed, LogDatas were
indexed and assigned sequence numbers (relative to the batch's first sequence
number). Since sequence numbers are not allocated for LogDatas, the remaining
batch's KVs could overflow beyond the sequence numbers allocated to the batch,
allowing sequence number inversion.

This bug existed before https://github.com/cockroachdb/pebble/pull/3277 if the batch in question was created through
DB.NewBatch and not populated through `Batch.Apply` or `Batch.SetRepr`.

Fix https://github.com/cockroachdb/pebble/issues/3284.
Fix https://github.com/cockroachdb/pebble/issues/3285.