### PR TITLE
rename FormatSyntheticSuffixes major format version to FormatSynethicSuffixPrefix

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -1283,6 +1283,7 @@ func runIngestExternalCmd(td *datadriven.TestData, d *DB, locator string) error 
 	external := make([]ExternalFile, 0)
 	usePrefixChange := false
 	var fromPrefix, toPrefix []byte
+	var syntheticSuffix []byte
 	for i := range td.CmdArgs {
 		switch td.CmdArgs[i].Key {
 		case "prefix-replace":
@@ -1293,6 +1294,8 @@ func runIngestExternalCmd(td *datadriven.TestData, d *DB, locator string) error 
 			fromPrefix = []byte(vals[0])
 			toPrefix = []byte(vals[1])
 			usePrefixChange = true
+		case "suffix-replace":
+			syntheticSuffix = []byte(td.CmdArgs[i].Vals[0])
 		}
 	}
 	for _, arg := range strings.Split(td.Input, "\n") {
@@ -1315,6 +1318,7 @@ func runIngestExternalCmd(td *datadriven.TestData, d *DB, locator string) error 
 			ef.ContentPrefix = fromPrefix
 			ef.SyntheticPrefix = toPrefix
 		}
+		ef.SyntheticSuffix = syntheticSuffix
 		external = append(external, ef)
 	}
 

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -178,12 +178,12 @@ const (
 	// a format major version.
 	FormatVirtualSSTables
 
-	// FormatSyntheticPrefixes is a format major version that adds support for
-	// sstables to have their content exposed in a different prefix of keyspace
-	// than the actual prefix persisted in the keys in such sstables. The prefix
-	// replacement information is stored in new fields in the Manifest and thus
-	// requires a format major version.
-	FormatSyntheticPrefixes
+	// FormatSyntheticPrefixSuffix is a format major version that adds support for
+	// sstables to have their content exposed in a different prefix or suffix of
+	// keyspace than the actual prefix/suffix persisted in the keys in such
+	// sstables. The prefix and suffix replacement information is stored in new
+	// fields in the Manifest and thus requires a format major version.
+	FormatSyntheticPrefixSuffix
 
 	// TODO(msbutler): add major version for synthetic suffixes
 
@@ -222,7 +222,7 @@ func (v FormatMajorVersion) MaxTableFormat() sstable.TableFormat {
 	switch v {
 	case FormatDefault, FormatFlushableIngest, FormatPrePebblev1MarkedCompacted:
 		return sstable.TableFormatPebblev3
-	case FormatDeleteSizedAndObsolete, FormatVirtualSSTables, FormatSyntheticPrefixes:
+	case FormatDeleteSizedAndObsolete, FormatVirtualSSTables, FormatSyntheticPrefixSuffix:
 		return sstable.TableFormatPebblev4
 	default:
 		panic(fmt.Sprintf("pebble: unsupported format major version: %s", v))
@@ -234,7 +234,7 @@ func (v FormatMajorVersion) MaxTableFormat() sstable.TableFormat {
 func (v FormatMajorVersion) MinTableFormat() sstable.TableFormat {
 	switch v {
 	case FormatDefault, FormatFlushableIngest, FormatPrePebblev1MarkedCompacted,
-		FormatDeleteSizedAndObsolete, FormatVirtualSSTables, FormatSyntheticPrefixes:
+		FormatDeleteSizedAndObsolete, FormatVirtualSSTables, FormatSyntheticPrefixSuffix:
 		return sstable.TableFormatPebblev1
 	default:
 		panic(fmt.Sprintf("pebble: unsupported format major version: %s", v))
@@ -268,8 +268,8 @@ var formatMajorVersionMigrations = map[FormatMajorVersion]func(*DB) error{
 	FormatVirtualSSTables: func(d *DB) error {
 		return d.finalizeFormatVersUpgrade(FormatVirtualSSTables)
 	},
-	FormatSyntheticPrefixes: func(d *DB) error {
-		return d.finalizeFormatVersUpgrade(FormatSyntheticPrefixes)
+	FormatSyntheticPrefixSuffix: func(d *DB) error {
+		return d.finalizeFormatVersUpgrade(FormatSyntheticPrefixSuffix)
 	},
 }
 

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -23,7 +23,7 @@ func TestFormatMajorVersionStableValues(t *testing.T) {
 	require.Equal(t, FormatPrePebblev1MarkedCompacted, FormatMajorVersion(14))
 	require.Equal(t, FormatDeleteSizedAndObsolete, FormatMajorVersion(15))
 	require.Equal(t, FormatVirtualSSTables, FormatMajorVersion(16))
-	require.Equal(t, FormatSyntheticPrefixes, FormatMajorVersion(17))
+	require.Equal(t, FormatSyntheticPrefixSuffix, FormatMajorVersion(17))
 
 	// When we add a new version, we should add a check for the new version in
 	// addition to updating these expected values.
@@ -51,8 +51,8 @@ func TestRatchetFormat(t *testing.T) {
 	require.Equal(t, FormatDeleteSizedAndObsolete, d.FormatMajorVersion())
 	require.NoError(t, d.RatchetFormatMajorVersion(FormatVirtualSSTables))
 	require.Equal(t, FormatVirtualSSTables, d.FormatMajorVersion())
-	require.NoError(t, d.RatchetFormatMajorVersion(FormatSyntheticPrefixes))
-	require.Equal(t, FormatSyntheticPrefixes, d.FormatMajorVersion())
+	require.NoError(t, d.RatchetFormatMajorVersion(FormatSyntheticPrefixSuffix))
+	require.Equal(t, FormatSyntheticPrefixSuffix, d.FormatMajorVersion())
 
 	require.NoError(t, d.Close())
 
@@ -206,7 +206,7 @@ func TestFormatMajorVersions_TableFormat(t *testing.T) {
 		FormatPrePebblev1MarkedCompacted: {sstable.TableFormatPebblev1, sstable.TableFormatPebblev3},
 		FormatDeleteSizedAndObsolete:     {sstable.TableFormatPebblev1, sstable.TableFormatPebblev4},
 		FormatVirtualSSTables:            {sstable.TableFormatPebblev1, sstable.TableFormatPebblev4},
-		FormatSyntheticPrefixes:          {sstable.TableFormatPebblev1, sstable.TableFormatPebblev4},
+		FormatSyntheticPrefixSuffix:      {sstable.TableFormatPebblev1, sstable.TableFormatPebblev4},
 	}
 
 	// Valid versions.

--- a/ingest.go
+++ b/ingest.go
@@ -1320,10 +1320,13 @@ func (d *DB) ingest(
 	if (exciseSpan.Valid() || len(shared) > 0 || len(external) > 0) && d.FormatMajorVersion() < FormatVirtualSSTables {
 		return IngestOperationStats{}, errors.New("pebble: format major version too old for excise, shared or external sstable ingestion")
 	}
-	if len(external) > 0 && d.FormatMajorVersion() < FormatSyntheticPrefixes {
+	if len(external) > 0 && d.FormatMajorVersion() < FormatSyntheticPrefixSuffix {
 		for i := range external {
 			if len(external[i].SyntheticPrefix) > 0 {
 				return IngestOperationStats{}, errors.New("pebble: format major version too old for synthetic prefix ingestion")
+			}
+			if len(external[i].SyntheticSuffix) > 0 {
+				return IngestOperationStats{}, errors.New("pebble: format major version too old for synthetic suffix ingestion")
 			}
 		}
 	}

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1745,7 +1745,7 @@ func TestIngestExternal(t *testing.T) {
 
 	var remoteStorage remote.Storage
 
-	reset := func() {
+	reset := func(majorVersion FormatMajorVersion) {
 		if d != nil {
 			require.NoError(t, d.Close())
 		}
@@ -1754,6 +1754,7 @@ func TestIngestExternal(t *testing.T) {
 		require.NoError(t, mem.MkdirAll("ext", 0755))
 		remoteStorage = remote.NewInMem()
 		opts := &Options{
+			Comparer:              testkeys.Comparer,
 			FS:                    mem,
 			L0CompactionThreshold: 100,
 			L0StopWritesThreshold: 100,
@@ -1761,7 +1762,7 @@ func TestIngestExternal(t *testing.T) {
 			EventListener: &EventListener{FlushEnd: func(info FlushInfo) {
 				flushed = true
 			}},
-			FormatMajorVersion: FormatNewest,
+			FormatMajorVersion: majorVersion,
 		}
 		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"external-locator": remoteStorage,
@@ -1778,12 +1779,16 @@ func TestIngestExternal(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, d.SetCreatorID(1))
 	}
-	reset()
+	reset(FormatNewest)
 
 	datadriven.RunTest(t, "testdata/ingest_external", func(t *testing.T, td *datadriven.TestData) string {
 		switch td.Cmd {
 		case "reset":
-			reset()
+			majorVersion := int64(FormatNewest)
+			if td.HasArg("format-major-version") {
+				td.ScanArgs(t, "format-major-version", &majorVersion)
+			}
+			reset(FormatMajorVersion(majorVersion))
 			return ""
 		case "batch":
 			b := d.NewIndexedBatch()

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -190,6 +190,54 @@ g: (foo, .)
 h: (foo, .)
 .
 
+# Test that ingestion with a prefix or suffix replacement rule fails on older
+# major versions
+
+reset format-major-version=16
+----
+
+build-remote f5
+set ef foo
+set eg foo
+set eh foo
+----
+
+ingest-external prefix-replace=(e,f)
+f5,10,ff,fi
+----
+pebble: format major version too old for synthetic prefix ingestion
+
+
+ingest-external suffix-replace=@5
+f5,10,ff,fi
+----
+pebble: format major version too old for synthetic suffix ingestion
+
+
+# Test plumbing for ingestion with suffix replacement
+reset
+----
+
+build-remote f1
+set a@1 foo
+set b@2 foo
+set c@1 foo
+----
+
+ingest-external suffix-replace=@5
+f1,10,a,d
+----
+
+iter
+first
+next
+next
+----
+a@5: (foo, .)
+b@5: (foo, .)
+c@5: (foo, .)
+
+
 # Test the case when we are ingesting part of a RANGEDEL.
 reset
 ----


### PR DESCRIPTION
PR https://github.com/cockroachdb/pebble/pull/3240 introduced synthetic suffix replacement, whose use should be gated on 
a major format version. This follow up patch gates its use on the same major
format version added for prefix replacement and renames the version to
FormatSyntheticSuffixPrefix. This patch also adds more testing around synthetic
suffix ingestion.