### PR TITLE
metamorphic: add external files ingest operation

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -181,6 +181,10 @@ func ingestLoad1External(
 	if !e.HasRangeKey && !e.HasPointKey {
 		return nil, errors.New("pebble: cannot ingest external file with no point or range keys")
 	}
+	// #3287: range keys don't yet work correctly when the range key bounds are not tight.
+	if e.HasRangeKey {
+		return nil, errors.New("pebble: range keys not supported in external files")
+	}
 	// Don't load table stats. Doing a round trip to shared storage, one SST
 	// at a time is not worth it as it slows down ingestion.
 	meta := &fileMetadata{

--- a/level_iter.go
+++ b/level_iter.go
@@ -1200,7 +1200,7 @@ func (l *levelIter) SetContext(ctx context.Context) {
 
 func (l *levelIter) String() string {
 	if l.iterFile != nil {
-		return fmt.Sprintf("%s: fileNum=%s", l.level, l.iter.String())
+		return fmt.Sprintf("%s: fileNum=%s", l.level, l.iterFile.FileNum.String())
 	}
 	return fmt.Sprintf("%s: fileNum=<nil>", l.level)
 }

--- a/metamorphic/build.go
+++ b/metamorphic/build.go
@@ -5,7 +5,9 @@
 package metamorphic
 
 import (
+	"context"
 	"fmt"
+	"slices"
 
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -32,7 +34,6 @@ func writeSSTForIngestion(
 	rangeKeyIter keyspan.FragmentIterator,
 	writable objstorage.Writable,
 	targetFMV pebble.FormatMajorVersion,
-	bounds pebble.KeyRange,
 ) (*sstable.WriterMetadata, error) {
 	writerOpts := t.opts.MakeWriterOptions(0, targetFMV.MaxTableFormat())
 	if t.testOpts.disableValueBlocksForIngestSSTables {
@@ -62,7 +63,11 @@ func writeSSTForIngestion(
 			value = pebble.LazyValue{}
 			key.SetKind(pebble.InternalKeyKindDelete)
 		}
-		if err := w.Add(*key, value.InPlaceValue()); err != nil {
+		valBytes, _, err := value.Value(nil)
+		if err != nil {
+			return nil, err
+		}
+		if err := w.Add(*key, valBytes); err != nil {
 			return nil, err
 		}
 	}
@@ -73,9 +78,7 @@ func writeSSTForIngestion(
 	if rangeDelIter != nil {
 		span, err := rangeDelIter.First()
 		for ; span != nil; span, err = rangeDelIter.Next() {
-			startCopy := append([]byte(nil), span.Start...)
-			endCopy := append([]byte(nil), span.End...)
-			if err := w.DeleteRange(startCopy, endCopy); err != nil {
+			if err := w.DeleteRange(slices.Clone(span.Start), slices.Clone(span.End)); err != nil {
 				return nil, err
 			}
 		}
@@ -99,11 +102,9 @@ func writeSSTForIngestion(
 			// containing keys that both set and unset the same suffix at the
 			// same sequence number is nonsensical, so we "coalesce" or collapse
 			// the keys.
-			startCopy := append([]byte(nil), span.Start...)
-			endCopy := append([]byte(nil), span.End...)
 			collapsed := keyspan.Span{
-				Start: startCopy,
-				End:   endCopy,
+				Start: slices.Clone(span.Start),
+				End:   slices.Clone(span.End),
 				Keys:  make([]keyspan.Key, 0, len(span.Keys)),
 			}
 			rangekey.Coalesce(
@@ -151,7 +152,105 @@ func buildForIngest(
 		iter, rangeDelIter, rangeKeyIter,
 		writable,
 		db.FormatMajorVersion(),
-		pebble.KeyRange{},
 	)
 	return path, meta, err
+}
+
+// buildForIngest builds a local SST file containing the keys in the given
+// external object (truncated to the given bounds) and returns its path and
+// metadata.
+func buildForIngestExternalEmulation(
+	t *Test, dbID objID, externalObjID objID, bounds pebble.KeyRange, i int,
+) (path string, _ *sstable.WriterMetadata) {
+	path = t.opts.FS.PathJoin(t.tmpDir, fmt.Sprintf("ext%d-%d", dbID.slot(), i))
+	f, err := t.opts.FS.Create(path)
+	panicIfErr(err)
+
+	reader, pointIter, rangeDelIter, rangeKeyIter := openExternalObj(t, externalObjID, bounds)
+	defer reader.Close()
+
+	writable := objstorageprovider.NewFileWritable(f)
+	meta, err := writeSSTForIngestion(
+		t,
+		pointIter, rangeDelIter, rangeKeyIter,
+		writable,
+		t.minFMV(),
+	)
+	if err != nil {
+		panic(err)
+	}
+	return path, meta
+}
+
+func openExternalObj(
+	t *Test, externalObjID objID, bounds pebble.KeyRange,
+) (
+	reader *sstable.Reader,
+	pointIter base.InternalIterator,
+	rangeDelIter keyspan.FragmentIterator,
+	rangeKeyIter keyspan.FragmentIterator,
+) {
+	objReader, objSize, err := t.externalStorage.ReadObject(context.Background(), externalObjName(externalObjID))
+	panicIfErr(err)
+	opts := sstable.ReaderOptions{
+		Comparer: t.opts.Comparer,
+	}
+	reader, err = sstable.NewReader(objstorageprovider.NewRemoteReadable(objReader, objSize), opts)
+	panicIfErr(err)
+
+	pointIter, err = reader.NewIter(bounds.Start, bounds.End)
+	panicIfErr(err)
+
+	rangeDelIter, err = reader.NewRawRangeDelIter()
+	panicIfErr(err)
+	if rangeDelIter != nil {
+		rangeDelIter = keyspan.Truncate(
+			t.opts.Comparer.Compare,
+			rangeDelIter,
+			bounds.Start, bounds.End,
+			nil /* start */, nil /* end */, false, /* panicOnUpperTruncate */
+		)
+	}
+
+	rangeKeyIter, err = reader.NewRawRangeKeyIter()
+	panicIfErr(err)
+	if rangeKeyIter != nil {
+		rangeKeyIter = keyspan.Truncate(
+			t.opts.Comparer.Compare,
+			rangeKeyIter,
+			bounds.Start, bounds.End,
+			nil /* start */, nil /* end */, false, /* panicOnUpperTruncate */
+		)
+	}
+	return reader, pointIter, rangeDelIter, rangeKeyIter
+}
+
+// externalObjIsEmpty returns true if the given external object has no point or
+// range keys withing the given bounds.
+func externalObjIsEmpty(t *Test, externalObjID objID, bounds pebble.KeyRange) bool {
+	reader, pointIter, rangeDelIter, rangeKeyIter := openExternalObj(t, externalObjID, bounds)
+	defer reader.Close()
+	defer closeIters(pointIter, rangeDelIter, rangeKeyIter)
+
+	key, _ := pointIter.First()
+	panicIfErr(pointIter.Error())
+	if key != nil {
+		return false
+	}
+	for _, it := range []keyspan.FragmentIterator{rangeDelIter, rangeKeyIter} {
+		if it != nil {
+			span, err := it.First()
+			panicIfErr(err)
+			if span != nil {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func panicIfErr(err error) {
+	if err != nil {
+		panic(err)
+	}
 }

--- a/metamorphic/build.go
+++ b/metamorphic/build.go
@@ -1,0 +1,157 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package metamorphic
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/keyspan"
+	"github.com/cockroachdb/pebble/internal/private"
+	"github.com/cockroachdb/pebble/internal/rangekey"
+	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/sstable"
+)
+
+// writeSSTForIngestion writes an SST that is to be ingested, either directly or
+// as an external file.
+//
+// If convertDelSizedToDel is set, then any DeleteSized keys are converted to
+// Delete keys; this is useful when the database that will ingest the file is at
+// a format that doesn't support DeleteSized.
+//
+// Closes the iterators in all cases.
+func writeSSTForIngestion(
+	t *Test,
+	pointIter base.InternalIterator,
+	rangeDelIter keyspan.FragmentIterator,
+	rangeKeyIter keyspan.FragmentIterator,
+	writable objstorage.Writable,
+	targetFMV pebble.FormatMajorVersion,
+	bounds pebble.KeyRange,
+) (*sstable.WriterMetadata, error) {
+	writerOpts := t.opts.MakeWriterOptions(0, targetFMV.MaxTableFormat())
+	if t.testOpts.disableValueBlocksForIngestSSTables {
+		writerOpts.DisableValueBlocks = true
+	}
+	w := sstable.NewWriter(writable, writerOpts)
+	pointIterCloser := base.CloseHelper(pointIter)
+	defer pointIterCloser.Close()
+	rangeDelIterCloser := base.CloseHelper(rangeDelIter)
+	defer rangeDelIterCloser.Close()
+	rangeKeyIterCloser := base.CloseHelper(rangeKeyIter)
+	defer rangeKeyIterCloser.Close()
+
+	var lastUserKey []byte
+	for key, value := pointIter.First(); key != nil; key, value = pointIter.Next() {
+		// Ignore duplicate keys.
+		if t.opts.Comparer.Equal(lastUserKey, key.UserKey) {
+			continue
+		}
+		lastUserKey = append(lastUserKey[:0], key.UserKey...)
+
+		key.SetSeqNum(base.SeqNumZero)
+		// It's possible that we wrote the key on a batch from a db that supported
+		// DeleteSized, but will be ingesting into a db that does not. Detect this
+		// case and translate the key to an InternalKeyKindDelete.
+		if targetFMV < pebble.FormatDeleteSizedAndObsolete && key.Kind() == pebble.InternalKeyKindDeleteSized {
+			value = pebble.LazyValue{}
+			key.SetKind(pebble.InternalKeyKindDelete)
+		}
+		if err := w.Add(*key, value.InPlaceValue()); err != nil {
+			return nil, err
+		}
+	}
+	if err := pointIterCloser.Close(); err != nil {
+		return nil, err
+	}
+
+	if rangeDelIter != nil {
+		span, err := rangeDelIter.First()
+		for ; span != nil; span, err = rangeDelIter.Next() {
+			startCopy := append([]byte(nil), span.Start...)
+			endCopy := append([]byte(nil), span.End...)
+			if err := w.DeleteRange(startCopy, endCopy); err != nil {
+				return nil, err
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+		if err := rangeDelIterCloser.Close(); err != nil {
+			return nil, err
+		}
+	}
+
+	if rangeKeyIter != nil {
+		span, err := rangeKeyIter.First()
+		for ; span != nil; span, err = rangeKeyIter.Next() {
+			// Coalesce the keys of this span and then zero the sequence
+			// numbers. This is necessary in order to make the range keys within
+			// the ingested sstable internally consistent at the sequence number
+			// it's ingested at. The individual keys within a batch are
+			// committed at unique sequence numbers, whereas all the keys of an
+			// ingested sstable are given the same sequence number. A span
+			// containing keys that both set and unset the same suffix at the
+			// same sequence number is nonsensical, so we "coalesce" or collapse
+			// the keys.
+			startCopy := append([]byte(nil), span.Start...)
+			endCopy := append([]byte(nil), span.End...)
+			collapsed := keyspan.Span{
+				Start: startCopy,
+				End:   endCopy,
+				Keys:  make([]keyspan.Key, 0, len(span.Keys)),
+			}
+			rangekey.Coalesce(
+				t.opts.Comparer.Compare, t.opts.Comparer.Equal, span.Keys, &collapsed.Keys,
+			)
+			for i := range collapsed.Keys {
+				collapsed.Keys[i].Trailer = base.MakeTrailer(0, collapsed.Keys[i].Kind())
+			}
+			keyspan.SortKeysByTrailer(&collapsed.Keys)
+			if err := rangekey.Encode(&collapsed, w.AddRangeKey); err != nil {
+				return nil, err
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+		if err := rangeKeyIterCloser.Close(); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+	return w.Metadata()
+}
+
+// buildForIngest builds a local SST file containing the keys in the given batch
+// and returns its path and metadata.
+func buildForIngest(
+	t *Test, dbID objID, b *pebble.Batch, i int,
+) (path string, _ *sstable.WriterMetadata, _ error) {
+	path = t.opts.FS.PathJoin(t.tmpDir, fmt.Sprintf("ext%d-%d", dbID.slot(), i))
+	f, err := t.opts.FS.Create(path)
+	if err != nil {
+		return "", nil, err
+	}
+	db := t.getDB(dbID)
+
+	iter, rangeDelIter, rangeKeyIter := private.BatchSort(b)
+
+	writable := objstorageprovider.NewFileWritable(f)
+	meta, err := writeSSTForIngestion(
+		t,
+		iter, rangeDelIter, rangeKeyIter,
+		writable,
+		db.FormatMajorVersion(),
+		pebble.KeyRange{},
+	)
+	return path, meta, err
+}

--- a/metamorphic/config.go
+++ b/metamorphic/config.go
@@ -41,6 +41,7 @@ const (
 	OpNewIter
 	OpNewIterUsingClone
 	OpNewSnapshot
+	OpNewExternalObj
 	OpReaderGet
 	OpReplicate
 	OpSnapshotClose
@@ -49,6 +50,7 @@ const (
 	OpWriterDeleteRange
 	OpWriterIngest
 	OpWriterIngestAndExcise
+	OpWriterIngestExternalFiles
 	OpWriterLogData
 	OpWriterMerge
 	OpWriterRangeKeyDelete
@@ -179,6 +181,8 @@ func DefaultOpConfig() OpConfig {
 			OpWriterRangeKeyDelete:        5,
 			OpWriterSet:                   100,
 			OpWriterSingleDelete:          50,
+			OpNewExternalObj:              2,
+			OpWriterIngestExternalFiles:   20,
 		},
 		// Use a new prefix 75% of the time (and 25% of the time use an existing
 		// prefix with an alternative suffix).
@@ -309,9 +313,14 @@ func multiInstanceConfig() OpConfig {
 	cfg.ops[OpReplicate] = 5
 	cfg.ops[OpWriterIngestAndExcise] = 50
 	// Single deletes and merges are disabled in multi-instance mode, as
-	// replicateOp doesn't support them.
+	// replicateOp and ingestAndExciseOp don't support them.
 	cfg.ops[OpWriterSingleDelete] = 0
 	cfg.ops[OpWriterMerge] = 0
+
+	// TODO(radu): external file ingest doesn't yet work with OpReplicate ("cannot
+	// use skip-shared iteration due to non-shareable files in lower levels").
+	cfg.ops[OpNewExternalObj] = 0
+	cfg.ops[OpWriterIngestExternalFiles] = 0
 	return cfg
 }
 

--- a/metamorphic/key_generator.go
+++ b/metamorphic/key_generator.go
@@ -227,7 +227,7 @@ func (kg *keyGenerator) randKey(newKeyProbability float64, bounds *pebble.KeyRan
 		key = append(key, testkeys.Suffix(suffix)...)
 	}
 	if kg.cmp(key, bounds.Start) < 0 || kg.cmp(key, bounds.End) >= 0 {
-		panic(fmt.Sprintf("invalid randKey %q  bounds: [%q, %q) %v %v", key, bounds.Start, bounds.End, kg.cmp(key, bounds.Start), kg.cmp(key, bounds.End)))
+		panic(fmt.Sprintf("invalid randKey %q; bounds: [%q, %q) %v %v", key, bounds.Start, bounds.End, kg.cmp(key, bounds.Start), kg.cmp(key, bounds.End)))
 	}
 	// We might (rarely) produce an existing key here, that's ok.
 	kg.keyManager.addNewKey(key)

--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -527,12 +527,12 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 	if err := Execute(m); err != nil {
 		fmt.Fprintf(os.Stderr, "Seed: %d\n", seed)
 		fmt.Fprintln(os.Stderr, err)
-		m.maybeSaveData()
+		m.saveInMemoryData()
 		os.Exit(1)
 	}
 
 	if runOpts.keep && !testOpts.useDisk {
-		m.maybeSaveData()
+		m.saveInMemoryData()
 	}
 }
 

--- a/metamorphic/parser.go
+++ b/metamorphic/parser.go
@@ -9,12 +9,11 @@ import (
 	"go/scanner"
 	"go/token"
 	"reflect"
+	"slices"
 	"strconv"
-	"strings"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
-	"golang.org/x/exp/slices"
 )
 
 type methodInfo struct {
@@ -40,8 +39,11 @@ func makeMethod(i interface{}, tags ...objTag) *methodInfo {
 // args returns the receiverID, targetID and arguments for the op. The
 // receiverID is the ID of the object the op will be applied to. The targetID
 // is the ID of the object for assignment. If the method does not return a new
-// object, then targetID will be nil. The argument list is just what it sounds
-// like: the list of arguments for the operation.
+// object, then targetID will be nil.
+//
+// The argument list returns pointers to operation fields that map to arguments
+// for the operation. The last argument can be a pointer to a slice,
+// corresponding to a variable number of arguments.
 func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	switch t := op.(type) {
 	case *applyOp:
@@ -72,8 +74,10 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 		return &t.dbID, nil, []interface{}{&t.batchIDs}
 	case *ingestAndExciseOp:
 		return &t.dbID, nil, []interface{}{&t.batchID, &t.exciseStart, &t.exciseEnd}
+	case *ingestExternalFilesOp:
+		return &t.dbID, nil, []interface{}{&t.objs}
 	case *initOp:
-		return nil, nil, []interface{}{&t.dbSlots, &t.batchSlots, &t.iterSlots, &t.snapshotSlots}
+		return nil, nil, []interface{}{&t.dbSlots, &t.batchSlots, &t.iterSlots, &t.snapshotSlots, &t.externalObjSlots}
 	case *iterLastOp:
 		return &t.iterID, nil, nil
 	case *logDataOp:
@@ -90,6 +94,8 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 		return &t.existingIterID, &t.iterID, []interface{}{&t.refreshBatch, &t.lower, &t.upper, &t.keyTypes, &t.filterMin, &t.filterMax, &t.useL6Filters, &t.maskSuffix}
 	case *newSnapshotOp:
 		return &t.dbID, &t.snapID, []interface{}{&t.bounds}
+	case *newExternalObjOp:
+		return &t.batchID, &t.externalObjID, nil
 	case *iterNextOp:
 		return &t.iterID, nil, []interface{}{&t.limit}
 	case *iterNextPrefixOp:
@@ -138,6 +144,7 @@ var methods = map[string]*methodInfo{
 	"Get":                       makeMethod(getOp{}, dbTag, batchTag, snapTag),
 	"Ingest":                    makeMethod(ingestOp{}, dbTag),
 	"IngestAndExcise":           makeMethod(ingestAndExciseOp{}, dbTag),
+	"IngestExternalFiles":       makeMethod(ingestExternalFilesOp{}, dbTag),
 	"Init":                      makeMethod(initOp{}, dbTag),
 	"Last":                      makeMethod(iterLastOp{}, iterTag),
 	"LogData":                   makeMethod(logDataOp{}, dbTag, batchTag),
@@ -146,6 +153,7 @@ var methods = map[string]*methodInfo{
 	"NewIndexedBatch":           makeMethod(newIndexedBatchOp{}, dbTag),
 	"NewIter":                   makeMethod(newIterOp{}, dbTag, batchTag, snapTag),
 	"NewSnapshot":               makeMethod(newSnapshotOp{}, dbTag),
+	"NewExternalObj":            makeMethod(newExternalObjOp{}, batchTag),
 	"Next":                      makeMethod(iterNextOp{}, iterTag),
 	"NextPrefix":                makeMethod(iterNextPrefixOp{}, iterTag),
 	"InternalNext":              makeMethod(iterCanSingleDelOp{}, iterTag),
@@ -260,30 +268,6 @@ func (p *parser) parseOp() op {
 	panic(p.errorf(pos, "unexpected token: %q", p.tokenf(tok, lit)))
 }
 
-func parseObjID(str string) (objID, error) {
-	var tag objTag
-	switch {
-	case strings.HasPrefix(str, "db"):
-		tag, str = dbTag, str[2:]
-		if str == "" {
-			str = "1"
-		}
-	case strings.HasPrefix(str, "batch"):
-		tag, str = batchTag, str[5:]
-	case strings.HasPrefix(str, "iter"):
-		tag, str = iterTag, str[4:]
-	case strings.HasPrefix(str, "snap"):
-		tag, str = snapTag, str[4:]
-	default:
-		return 0, errors.Newf("unable to parse objectID: %q", str)
-	}
-	id, err := strconv.ParseInt(str, 10, 32)
-	if err != nil {
-		return 0, err
-	}
-	return makeObjID(tag, uint32(id)), nil
-}
-
 func (p *parser) parseObjID(pos token.Pos, str string) objID {
 	id, err := parseObjID(str)
 	if err != nil {
@@ -304,156 +288,66 @@ func unquoteBytes(lit string) []byte {
 }
 
 func (p *parser) parseArgs(op op, methodName string, args []interface{}) {
-	pos, _ := p.scanToken(token.LPAREN)
-	for i := range args {
-		if i > 0 {
-			pos, _ = p.scanToken(token.COMMA)
-		}
+	pos, list := p.parseList()
+	p.scanToken(token.SEMICOLON)
 
+	// The last argument can have variable length.
+	var varArg interface{}
+	if len(args) > 0 {
+		switch args[len(args)-1].(type) {
+		case *[]objID, *[]pebble.KeyRange, *[]pebble.CheckpointSpan, *[]externalObjWithBounds:
+			varArg = args[len(args)-1]
+			args = args[:len(args)-1]
+		}
+	}
+
+	if len(list) < len(args) {
+		panic(p.errorf(pos, "%s: not enough arguments", methodName))
+	}
+	if len(list) > len(args) && varArg == nil {
+		panic(p.errorf(pos, "%s: too many arguments", methodName))
+	}
+
+	for i := range args {
+		elem := list[i]
 		switch t := args[i].(type) {
 		case *uint32:
-			_, lit := p.scanToken(token.INT)
-			val, err := strconv.ParseUint(lit, 10, 32)
+			elem.expectToken(p, token.INT)
+			val, err := strconv.ParseUint(elem.lit, 10, 32)
 			if err != nil {
-				panic(err)
+				panic(p.errorf(elem.pos, "error parsing %q: %s", elem.lit, err))
 			}
 			*t = uint32(val)
 
 		case *uint64:
-			_, lit := p.scanToken(token.INT)
-			val, err := strconv.ParseUint(lit, 10, 64)
+			elem.expectToken(p, token.INT)
+			val, err := strconv.ParseUint(elem.lit, 10, 64)
 			if err != nil {
-				panic(err)
+				panic(p.errorf(elem.pos, "error parsing %q: %s", elem.lit, err))
 			}
-			*t = uint64(val)
+			*t = val
 
 		case *[]byte:
-			_, lit := p.scanToken(token.STRING)
-			*t = unquoteBytes(lit)
+			elem.expectToken(p, token.STRING)
+			*t = unquoteBytes(elem.lit)
 
 		case *bool:
-			_, lit := p.scanToken(token.IDENT)
-			b, err := strconv.ParseBool(lit)
+			elem.expectToken(p, token.IDENT)
+			b, err := strconv.ParseBool(elem.lit)
 			if err != nil {
-				panic(err)
+				panic(p.errorf(elem.pos, "error parsing %q: %s", elem.lit, err))
 			}
 			*t = b
 
 		case *objID:
-			pos, lit := p.scanToken(token.IDENT)
-			*t = p.parseObjID(pos, lit)
-
-		case *[]pebble.KeyRange:
-			var pending pebble.KeyRange
-			for {
-				pos, tok, lit := p.s.Scan()
-				switch tok {
-				case token.STRING:
-					x := unquoteBytes(lit)
-					if pending.Start == nil {
-						pending.Start = x
-					} else {
-						pending.End = x
-						*t = append(*t, pending)
-						pending = pebble.KeyRange{}
-					}
-					pos, tok, lit := p.s.Scan()
-					switch tok {
-					case token.COMMA:
-						continue
-					case token.RPAREN:
-						p.scanToken(token.SEMICOLON)
-						return
-					default:
-						panic(p.errorf(pos, "unexpected token: %q", p.tokenf(tok, lit)))
-					}
-				case token.RPAREN:
-					p.scanToken(token.SEMICOLON)
-					return
-				default:
-					panic(p.errorf(pos, "unexpected token: %q", p.tokenf(tok, lit)))
-				}
-			}
-
-		case *[]objID:
-			for {
-				pos, tok, lit := p.s.Scan()
-				switch tok {
-				case token.IDENT:
-					*t = append(*t, p.parseObjID(pos, lit))
-					pos, tok, lit := p.s.Scan()
-					switch tok {
-					case token.COMMA:
-						continue
-					case token.RPAREN:
-						p.scanToken(token.SEMICOLON)
-						return
-					default:
-						panic(p.errorf(pos, "unexpected token: %q", p.tokenf(tok, lit)))
-					}
-				case token.RPAREN:
-					p.scanToken(token.SEMICOLON)
-					return
-				default:
-					panic(p.errorf(pos, "unexpected token: %q", p.tokenf(tok, lit)))
-				}
-			}
-
-		case *[]pebble.CheckpointSpan:
-			pos, tok, lit := p.s.Scan()
-			switch tok {
-			case token.RPAREN:
-				// No spans.
-				*t = nil
-				p.scanToken(token.SEMICOLON)
-				return
-
-			case token.STRING:
-				var keys [][]byte
-				for {
-					s, err := strconv.Unquote(lit)
-					if err != nil {
-						panic(p.errorf(pos, "unquoting %q: %v", lit, err))
-					}
-					keys = append(keys, []byte(s))
-
-					pos, tok, lit = p.s.Scan()
-					switch tok {
-					case token.COMMA:
-						pos, tok, lit = p.s.Scan()
-						if tok != token.STRING {
-							panic(p.errorf(pos, "unexpected token: %q", p.tokenf(tok, lit)))
-						}
-						continue
-
-					case token.RPAREN:
-						p.scanToken(token.SEMICOLON)
-						if len(keys)%2 == 1 {
-							panic(p.errorf(pos, "expected even number of keys"))
-						}
-						*t = make([]pebble.CheckpointSpan, len(keys)/2)
-						for i := range *t {
-							(*t)[i] = pebble.CheckpointSpan{
-								Start: keys[i*2],
-								End:   keys[i*2+1],
-							}
-						}
-						return
-
-					default:
-						panic(p.errorf(pos, "unexpected token: %q", p.tokenf(tok, lit)))
-					}
-				}
-
-			default:
-				panic(p.errorf(pos, "unexpected token: %q", p.tokenf(tok, lit)))
-			}
+			elem.expectToken(p, token.IDENT)
+			*t = p.parseObjID(elem.pos, elem.lit)
 
 		case *pebble.FormatMajorVersion:
-			_, lit := p.scanToken(token.INT)
-			val, err := strconv.ParseUint(lit, 10, 64)
+			elem.expectToken(p, token.INT)
+			val, err := strconv.ParseUint(elem.lit, 10, 64)
 			if err != nil {
-				panic(err)
+				panic(p.errorf(elem.pos, "error parsing %q: %s", elem.lit, err))
 			}
 			*t = pebble.FormatMajorVersion(val)
 
@@ -461,8 +355,135 @@ func (p *parser) parseArgs(op op, methodName string, args []interface{}) {
 			panic(p.errorf(pos, "%s: unsupported arg[%d] type: %T", methodName, i, args[i]))
 		}
 	}
-	p.scanToken(token.RPAREN)
-	p.scanToken(token.SEMICOLON)
+
+	if varArg != nil {
+		list = list[len(args):]
+		switch t := varArg.(type) {
+		case *[]objID:
+			*t = p.parseObjIDs(list)
+		case *[]pebble.KeyRange:
+			*t = p.parseKeyRanges(list)
+		case *[]pebble.CheckpointSpan:
+			*t = p.parseCheckpointSpans(list)
+		case *[]externalObjWithBounds:
+			*t = p.parseExternalObjsWithBounds(list)
+		default:
+			// We already checked for these types when we set varArgs.
+			panic("unreachable")
+		}
+	}
+}
+
+type listElem struct {
+	pos token.Pos
+	tok token.Token
+	lit string
+}
+
+func (e listElem) expectToken(p *parser, expTok token.Token) {
+	if e.tok != expTok {
+		panic(p.errorf(e.pos, "unexpected token: %q", p.tokenf(e.tok, e.lit)))
+	}
+}
+
+// parseKeyRange parses an arbitrary number of comma separated STRING/IDENT/INT
+// tokens surrounded by parens.
+func (p *parser) parseList() (token.Pos, []listElem) {
+	p.scanToken(token.LPAREN)
+	var list []listElem
+	for {
+		pos, tok, lit := p.s.Scan()
+		if len(list) == 0 && tok == token.RPAREN {
+			return pos, nil
+		}
+
+		switch tok {
+		case token.STRING, token.IDENT, token.INT:
+			list = append(list, listElem{
+				pos: pos,
+				tok: tok,
+				lit: lit,
+			})
+			pos, tok, lit = p.s.Scan()
+			switch tok {
+			case token.COMMA:
+				continue
+			case token.RPAREN:
+				return pos, list
+			}
+		}
+		panic(p.errorf(pos, "unexpected token: %q", p.tokenf(tok, lit)))
+	}
+}
+
+func (p *parser) parseObjIDs(list []listElem) []objID {
+	res := make([]objID, len(list))
+	for i, elem := range list {
+		res[i] = p.parseObjID(elem.pos, elem.lit)
+	}
+	return res
+}
+
+func (p *parser) parseKeys(list []listElem) [][]byte {
+	res := make([][]byte, len(list))
+	for i, elem := range list {
+		elem.expectToken(p, token.STRING)
+		res[i] = unquoteBytes(elem.lit)
+	}
+	return res
+}
+
+func (p *parser) parseKeyRanges(list []listElem) []pebble.KeyRange {
+	keys := p.parseKeys(list)
+	if len(keys)%2 == 1 {
+		panic(p.errorf(list[0].pos, "expected even number of keys"))
+	}
+	res := make([]pebble.KeyRange, len(keys)/2)
+	for i := range res {
+		res[i].Start = keys[2*i]
+		res[i].End = keys[2*i+1]
+	}
+	return res
+}
+
+func (p *parser) parseCheckpointSpans(list []listElem) []pebble.CheckpointSpan {
+	keys := p.parseKeys(list)
+	if len(keys)%2 == 1 {
+		panic(p.errorf(list[0].pos, "expected even number of keys"))
+	}
+	if len(keys) == 0 {
+		// Necessary for round-trip tests which differentiate between nil and empty slice.
+		return nil
+	}
+	res := make([]pebble.CheckpointSpan, len(keys)/2)
+	for i := range res {
+		res[i] = pebble.CheckpointSpan{
+			Start: keys[i*2],
+			End:   keys[i*2+1],
+		}
+	}
+	return res
+}
+
+func (p *parser) parseExternalObjsWithBounds(list []listElem) []externalObjWithBounds {
+	if len(list)%3 != 0 {
+		panic(p.errorf(list[0].pos, "expected number of arguments to be multiple of 3"))
+	}
+	objs := make([]externalObjWithBounds, len(list)/3)
+	for i := range objs {
+		list[0].expectToken(p, token.IDENT)
+		list[1].expectToken(p, token.STRING)
+		list[2].expectToken(p, token.STRING)
+		objs[i] = externalObjWithBounds{
+			externalObjID: p.parseObjID(list[0].pos, list[0].lit),
+			bounds: pebble.KeyRange{
+				Start: unquoteBytes(list[1].lit),
+				End:   unquoteBytes(list[2].lit),
+			},
+		}
+		list = list[3:]
+	}
+	return objs
 }
 
 func (p *parser) scanToken(expected token.Token) (pos token.Pos, lit string) {

--- a/metamorphic/testdata/diagram
+++ b/metamorphic/testdata/diagram
@@ -1,5 +1,5 @@
 diagram
-Init(2 /* dbs */, 49 /* batches */, 63 /* iters */, 45 /* snapshots */)
+Init(2 /* dbs */, 49 /* batches */, 63 /* iters */, 45 /* snapshots */, 0 /* externalObjs */)
 db2.RangeKeySet("c", "h", "@6", "foo")
 snap9 = db2.NewSnapshot("a", "z")
 db2.RangeKeyDelete("d", "f")
@@ -8,7 +8,7 @@ db2.Replicate(db1, "b", "f")
 iter25 = db1.NewIter("", "", 2 /* key types */, 0, 0, false /* use L6 filters */, "@7" /* masking suffix */)
 iter25.SeekGE("e", "")
 ----
-                                                        Init(2 /* dbs */, 49 /* batches */, 63 /* iters */, 45 /* snapshots */)
+                                                        Init(2 /* dbs */, 49 /* batches */, 63 /* iters */, 45 /* snapshots */, 0 /* externalObjs */)
             |-----------------------------|             db2.RangeKeySet("c", "h", "@6", "foo")
 |-----------------------------------------------------| snap9 = db2.NewSnapshot("a", "z")
                   |-----------|                         db2.RangeKeyDelete("d", "f")

--- a/metamorphic/testdata/parser
+++ b/metamorphic/testdata/parser
@@ -1,7 +1,7 @@
 parse
 foo
 ----
-metamorphic test internal error: 1:1: unable to parse objectID: "foo"
+metamorphic test internal error: 1:1: unknown object type: "foo"
 
 parse
 "foo"
@@ -16,12 +16,12 @@ metamorphic test internal error: 1:1: unknown op db1.bar
 parse
 db.Apply()
 ----
-metamorphic test internal error: 1:10: unexpected token: ")"
+metamorphic test internal error: 1:10: Apply: not enough arguments
 
 parse
 db.Apply(hello)
 ----
-metamorphic test internal error: 1:10: unable to parse objectID: "hello"
+metamorphic test internal error: 1:10: unknown object type: "hello"
 
 parse
 db.NewBatch()

--- a/metamorphic/utils.go
+++ b/metamorphic/utils.go
@@ -7,7 +7,10 @@ package metamorphic
 import (
 	"fmt"
 	"sort"
+	"strconv"
+	"strings"
 
+	"github.com/cockroachdb/errors"
 	"golang.org/x/exp/rand"
 )
 
@@ -19,11 +22,21 @@ const (
 	batchTag
 	iterTag
 	snapTag
+	externalObjTag
+	numObjTags
 )
+
+var objTagPrefix = [numObjTags]string{
+	dbTag:          "db",
+	batchTag:       "batch",
+	iterTag:        "iter",
+	snapTag:        "snap",
+	externalObjTag: "external",
+}
 
 // objID identifies a particular object. The top 4-bits store the tag
 // identifying the type of object, while the bottom 28-bits store the slot used
-// to index with the test.{batches,iters,snapshots} slices.
+// to index with the test.{batches,iters,snapshots,externalObjs} slices.
 type objID uint32
 
 func makeObjID(t objTag, slot uint32) objID {
@@ -39,17 +52,25 @@ func (i objID) slot() uint32 {
 }
 
 func (i objID) String() string {
-	switch i.tag() {
-	case dbTag:
-		return fmt.Sprintf("db%d", i.slot())
-	case batchTag:
-		return fmt.Sprintf("batch%d", i.slot())
-	case iterTag:
-		return fmt.Sprintf("iter%d", i.slot())
-	case snapTag:
-		return fmt.Sprintf("snap%d", i.slot())
+	return fmt.Sprintf("%s%d", objTagPrefix[i.tag()], i.slot())
+}
+
+func parseObjID(str string) (objID, error) {
+	// To provide backward compatibility, treat "db" as "db1". Note that unlike
+	// the others, db slots are 1-indexed.
+	if str == "db" {
+		str = "db1"
 	}
-	return fmt.Sprintf("unknown%d", i.slot())
+	for tag := objTag(1); tag < numObjTags; tag++ {
+		if strings.HasPrefix(str, objTagPrefix[tag]) {
+			id, err := strconv.ParseInt(str[len(objTagPrefix[tag]):], 10, 32)
+			if err != nil {
+				return 0, err
+			}
+			return makeObjID(tag, uint32(id)), nil
+		}
+	}
+	return 0, errors.Newf("unknown object type: %q", str)
 }
 
 // objIDSlice is an unordered set of integers used when random selection of an

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -1101,16 +1101,13 @@ func (i *singleLevelIterator) SeekLT(
 // to ensure that key is greater than or equal to the lower bound (e.g. via a
 // call to SeekGE(lower)).
 func (i *singleLevelIterator) First() (*InternalKey, base.LazyValue) {
-	// If the iterator was created on a virtual sstable, we will SeekGE to the
-	// lower bound instead of using First, because First does not respect
-	// bounds.
-	if i.vState != nil {
+	// If we have a lower bound, use SeekGE. Note that in general this is not
+	// supported usage, except when the lower bound is there because the table is
+	// virtual.
+	if i.lower != nil {
 		return i.SeekGE(i.lower, base.SeekGEFlagsNone)
 	}
 
-	if i.lower != nil {
-		panic("singleLevelIterator.First() used despite lower bound")
-	}
 	i.positionedUsingLatestBounds = true
 	i.maybeFilteredKeysSingleLevel = false
 

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -716,15 +716,11 @@ func (i *twoLevelIterator) SeekLT(
 // to ensure that key is greater than or equal to the lower bound (e.g. via a
 // call to SeekGE(lower)).
 func (i *twoLevelIterator) First() (*InternalKey, base.LazyValue) {
-	// If the iterator was created on a virtual sstable, we will SeekGE to the
-	// lower bound instead of using First, because First does not respect
-	// bounds.
-	if i.vState != nil {
-		return i.SeekGE(i.lower, base.SeekGEFlagsNone)
-	}
-
+	// If we have a lower bound, use SeekGE. Note that in general this is not
+	// supported usage, except when the lower bound is there because the table is
+	// virtual.
 	if i.lower != nil {
-		panic("twoLevelIterator.First() used despite lower bound")
+		return i.SeekGE(i.lower, base.SeekGEFlagsNone)
 	}
 	i.exhaustedBounds = 0
 	i.maybeFilteredKeysTwoLevel = false


### PR DESCRIPTION
#### metamorphic: minor reorganization of buildForIngest code


#### metamorphic: add external files ingest operation

This commit adds two new operations:
 - `newExternalObjOp` transforms a batch into an external object.
 - `ingestExtternalFilesOp` ingests random parts of random external
   objects. If external storage is not enabled, this operation is
   emulated by creating sst files in the local FS and ingesting those.

The support of external storage is a setting independent of the shared
storage setting, allowing us to test more combinations. The external
storage uses the `"external"` locator whereas shared storage uses the
empty locator.