### PR TITLE
db: remove syntheticSuffix from loadInfo

### DIFF
--- a/table_cache.go
+++ b/table_cache.go
@@ -836,8 +836,7 @@ func (c *tableCacheShard) findNode(meta *fileMetadata, dbOpts *tableCacheOpts) *
 	// the same backing will use the same reader from the cache; so no information
 	// that can differ among these virtual tables can be plumbed into loadInfo.
 	info := loadInfo{
-		backingFileNum:  meta.FileBacking.DiskFileNum,
-		syntheticSuffix: meta.SyntheticSuffix,
+		backingFileNum: meta.FileBacking.DiskFileNum,
 	}
 	// All virtual tables sharing an ingested backing will have the same
 	// SmallestSeqNum=LargestSeqNum value. We assert that below.
@@ -1175,8 +1174,7 @@ type tableCacheValue struct {
 type loadInfo struct {
 	backingFileNum base.DiskFileNum
 	// See sstable.Properties.GlobalSeqNum.
-	globalSeqNum    uint64
-	syntheticSuffix []byte
+	globalSeqNum uint64
 }
 
 func (v *tableCacheValue) load(loadInfo loadInfo, c *tableCacheShard, dbOpts *tableCacheOpts) {


### PR DESCRIPTION
This looks like an accidental leftover (it's not used anywhere).