### PR TITLE
add external file iteration to scanInternal

### DIFF
--- a/db.go
+++ b/db.go
@@ -1244,14 +1244,15 @@ func (d *DB) ScanInternal(
 	visitRangeDel func(start, end []byte, seqNum uint64) error,
 	visitRangeKey func(start, end []byte, keys []rangekey.Key) error,
 	visitSharedFile func(sst *SharedSSTMeta) error,
+	visitExternalFile func(sst *ExternalFile) error,
 ) error {
 	scanInternalOpts := &scanInternalOptions{
-		CategoryAndQoS:   categoryAndQoS,
-		visitPointKey:    visitPointKey,
-		visitRangeDel:    visitRangeDel,
-		visitRangeKey:    visitRangeKey,
-		visitSharedFile:  visitSharedFile,
-		skipSharedLevels: visitSharedFile != nil,
+		CategoryAndQoS:    categoryAndQoS,
+		visitPointKey:     visitPointKey,
+		visitRangeDel:     visitRangeDel,
+		visitRangeKey:     visitRangeKey,
+		visitSharedFile:   visitSharedFile,
+		visitExternalFile: visitExternalFile,
 		IterOptions: IterOptions{
 			KeyTypes:   IterKeyTypePointsAndRanges,
 			LowerBound: lower,

--- a/ingest.go
+++ b/ingest.go
@@ -1118,6 +1118,26 @@ type ExternalFile struct {
 	// iteration. Note that the file itself is not modifed, rather, every key
 	// returned by an iterator will have the synthetic suffix.
 	SyntheticSuffix []byte
+
+	// Level denotes the level at which this file was presetnt at read time
+	// if the external file was returned by a scan of an existing Pebble
+	// instance. If Level is 0, this field is ignored.
+	Level uint8
+}
+
+func (e *ExternalFile) cloneFromFileMeta(f *fileMetadata) {
+	*e = ExternalFile{
+		SmallestUserKey: append([]byte(nil), f.Smallest.UserKey...),
+		LargestUserKey:  append([]byte(nil), f.Largest.UserKey...),
+		HasPointKey:     f.HasPointKeys,
+		HasRangeKey:     f.HasRangeKeys,
+		Size:            f.Size,
+	}
+	e.SyntheticSuffix = append([]byte(nil), f.SyntheticSuffix...)
+	if pr := f.PrefixReplacement; pr != nil {
+		e.ContentPrefix = append([]byte(nil), pr.ContentPrefix...)
+		e.SyntheticPrefix = append([]byte(nil), pr.SyntheticPrefix...)
+	}
 }
 
 // IngestWithStats does the same as Ingest, and additionally returns

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1085,6 +1085,7 @@ func testIngestSharedImpl(
 					sharedSSTs = append(sharedSSTs, *sst)
 					return nil
 				},
+				nil,
 			)
 			require.NoError(t, err)
 			require.NoError(t, w.Close())
@@ -1573,6 +1574,7 @@ func TestConcurrentExcise(t *testing.T) {
 					sharedSSTs = append(sharedSSTs, *sst)
 					return nil
 				},
+				nil,
 			)
 			require.NoError(t, err)
 			require.NoError(t, w.Close())

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -1824,6 +1824,7 @@ func (r *replicateOp) runSharedReplicate(
 			sharedSSTs = append(sharedSSTs, *sst)
 			return nil
 		},
+		nil,
 	)
 	if err != nil {
 		h.Recordf("%s // %v", r, err)

--- a/options.go
+++ b/options.go
@@ -260,14 +260,11 @@ type scanInternalOptions struct {
 	sstable.CategoryAndQoS
 	IterOptions
 
-	visitPointKey   func(key *InternalKey, value LazyValue, iterInfo IteratorLevel) error
-	visitRangeDel   func(start, end []byte, seqNum uint64) error
-	visitRangeKey   func(start, end []byte, keys []rangekey.Key) error
-	visitSharedFile func(sst *SharedSSTMeta) error
-
-	// skipSharedLevels skips levels that are shareable (level >=
-	// sharedLevelStart).
-	skipSharedLevels bool
+	visitPointKey     func(key *InternalKey, value LazyValue, iterInfo IteratorLevel) error
+	visitRangeDel     func(start, end []byte, seqNum uint64) error
+	visitRangeKey     func(start, end []byte, keys []rangekey.Key) error
+	visitSharedFile   func(sst *SharedSSTMeta) error
+	visitExternalFile func(sst *ExternalFile) error
 
 	// includeObsoleteKeys specifies whether keys shadowed by newer internal keys
 	// are exposed. If false, only one internal key per user key is exposed.

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -433,6 +433,48 @@ type scanInternalIterator struct {
 	boundsBufIdx int
 }
 
+// truncateExternalFile truncates an External file's [SmallestUserKey,
+// LargestKserKey] fields to [lower, upper). A ExternalFile is
+// produced that is suitable for external consumption by other Pebble
+// instances.
+//
+// TODO(ssd) 2024-01-26: truncateSharedFile reads the file to try to
+// create the the smallest possible bounds.  Here, I just blindly
+// truncate them. This may mean we include this SST in iterations it
+// isn't really needed in.  Since we don't expect External files to be
+// long-lived in the pebble instance, I think this is OK.
+//
+// TODO(ssd) 2024-01-26: Potentially de-duplicate with
+// truncateSharedFile.
+func (d *DB) truncateExternalFile(
+	ctx context.Context,
+	lower, upper []byte,
+	level int,
+	file *fileMetadata,
+	objMeta objstorage.ObjectMetadata,
+) *ExternalFile {
+	cmp := d.cmp
+	sst := &ExternalFile{}
+	sst.cloneFromFileMeta(file)
+	sst.Level = uint8(level)
+	sst.ObjName = objMeta.Remote.CustomObjectName
+	sst.Locator = objMeta.Remote.Locator
+	needsLowerTruncate := cmp(lower, file.Smallest.UserKey) > 0
+	needsUpperTruncate := cmp(upper, file.Largest.UserKey) < 0 || (cmp(upper, file.Largest.UserKey) == 0 && !file.Largest.IsExclusiveSentinel())
+
+	if needsLowerTruncate {
+		sst.SmallestUserKey = sst.SmallestUserKey[:0]
+		sst.SmallestUserKey = append(sst.SmallestUserKey, lower...)
+	}
+
+	if needsUpperTruncate {
+		sst.LargestUserKey = sst.LargestUserKey[:0]
+		sst.LargestUserKey = append(sst.LargestUserKey, upper...)
+	}
+
+	return sst
+}
+
 // truncateSharedFile truncates a shared file's [Smallest, Largest] fields to
 // [lower, upper), potentially opening iterators on the file to find keys within
 // the requested bounds. A SharedSSTMeta is produced that is suitable for
@@ -629,11 +671,13 @@ func scanInternalImpl(
 	if current == nil {
 		current = iter.readState.current
 	}
-	if opts.visitSharedFile != nil {
+
+	if opts.visitSharedFile != nil || opts.visitExternalFile != nil {
 		if provider == nil {
 			panic("expected non-nil Provider in skip-shared iteration mode")
 		}
-		for level := sharedLevelsStart; level < numLevels; level++ {
+
+		for level := opts.skipLevelForOpts(); level < numLevels; level++ {
 			files := current.Levels[level].Iter()
 			for f := files.SeekGE(cmp, lower); f != nil && cmp(f.Smallest.UserKey, upper) < 0; f = files.Next() {
 				var objMeta objstorage.ObjectMetadata
@@ -642,24 +686,45 @@ func scanInternalImpl(
 				if err != nil {
 					return err
 				}
-				if !objMeta.IsShared() {
-					return errors.Wrapf(ErrInvalidSkipSharedIteration, "file %s is not shared", objMeta.DiskFileNum)
+
+				if !objMeta.IsShared() && !objMeta.IsExternal() {
+					return errors.Wrapf(ErrInvalidSkipSharedIteration, "file %s is not shared or external", objMeta.DiskFileNum)
 				}
+
+				if objMeta.IsShared() && opts.visitSharedFile == nil {
+					// TODO(ssd) 2024-01-26: Perhaps create a different error type here.
+					return errors.Wrapf(ErrInvalidSkipSharedIteration, "shared file is present but no shared file visitor is defined")
+				}
+
+				if objMeta.IsExternal() && opts.visitExternalFile == nil {
+					// TODO(ssd) 2024-01-26: Perhaps create a different error type here.
+					return errors.Wrapf(ErrInvalidSkipSharedIteration, "external file is present but no external file visitor is defined")
+				}
+
 				if !base.Visible(f.LargestSeqNum, seqNum, base.InternalKeySeqNumMax) {
 					return errors.Wrapf(ErrInvalidSkipSharedIteration, "file %s contains keys newer than snapshot", objMeta.DiskFileNum)
 				}
-				var sst *SharedSSTMeta
-				var skip bool
-				sst, skip, err = iter.db.truncateSharedFile(ctx, lower, upper, level, f, objMeta)
-				if err != nil {
-					return err
+
+				if objMeta.IsShared() {
+					var sst *SharedSSTMeta
+					var skip bool
+					sst, skip, err = iter.db.truncateSharedFile(ctx, lower, upper, level, f, objMeta)
+					if err != nil {
+						return err
+					}
+					if skip {
+						continue
+					}
+					if err = opts.visitSharedFile(sst); err != nil {
+						return err
+					}
+				} else if objMeta.IsExternal() {
+					sst := iter.db.truncateExternalFile(ctx, lower, upper, level, f, objMeta)
+					if err := opts.visitExternalFile(sst); err != nil {
+						return err
+					}
 				}
-				if skip {
-					continue
-				}
-				if err = opts.visitSharedFile(sst); err != nil {
-					return err
-				}
+
 			}
 		}
 	}
@@ -718,6 +783,16 @@ func scanInternalImpl(
 	return nil
 }
 
+func (opts *scanInternalOptions) skipLevelForOpts() int {
+	if opts.visitSharedFile != nil {
+		return sharedLevelsStart
+	}
+	if opts.visitExternalFile != nil {
+		return 6
+	}
+	return 0
+}
+
 // constructPointIter constructs a merging iterator and sets i.iter to it.
 func (i *scanInternalIterator) constructPointIter(
 	categoryAndQoS sstable.CategoryAndQoS, memtables flushableList, buf *iterAlloc,
@@ -739,11 +814,15 @@ func (i *scanInternalIterator) constructPointIter(
 	numMergingLevels += len(current.L0SublevelFiles)
 	numLevelIters += len(current.L0SublevelFiles)
 
+	// skipGEThanLevel skips levels that >= the given level, if it
+	// is non-zero.
+	skipGEThanLevel := i.opts.skipLevelForOpts()
+
 	for level := 1; level < len(current.Levels); level++ {
 		if current.Levels[level].Empty() {
 			continue
 		}
-		if i.opts.skipSharedLevels && level >= sharedLevelsStart {
+		if skipGEThanLevel > 0 && level >= skipGEThanLevel {
 			continue
 		}
 		numMergingLevels++
@@ -818,7 +897,7 @@ func (i *scanInternalIterator) constructPointIter(
 		if current.Levels[level].Empty() {
 			continue
 		}
-		if i.opts.skipSharedLevels && level >= sharedLevelsStart {
+		if skipGEThanLevel > 0 && level >= skipGEThanLevel {
 			continue
 		}
 		i.iterLevels[mlevelsIndex] = IteratorLevel{Kind: IteratorLevelLSM, Level: level}
@@ -909,7 +988,7 @@ func (i *scanInternalIterator) constructRangeKeyIter() error {
 		if current.RangeKeyLevels[level].Empty() {
 			continue
 		}
-		if i.opts.skipSharedLevels && level >= sharedLevelsStart {
+		if skipStart := i.opts.skipLevelForOpts(); skipStart > 0 && level >= skipStart {
 			continue
 		}
 		li := i.rangeKey.iterConfig.NewLevelIter()

--- a/snapshot.go
+++ b/snapshot.go
@@ -80,17 +80,18 @@ func (s *Snapshot) ScanInternal(
 	visitRangeDel func(start, end []byte, seqNum uint64) error,
 	visitRangeKey func(start, end []byte, keys []rangekey.Key) error,
 	visitSharedFile func(sst *SharedSSTMeta) error,
+	visitExternalFile func(sst *ExternalFile) error,
 ) error {
 	if s.db == nil {
 		panic(ErrClosed)
 	}
 	scanInternalOpts := &scanInternalOptions{
-		CategoryAndQoS:   categoryAndQoS,
-		visitPointKey:    visitPointKey,
-		visitRangeDel:    visitRangeDel,
-		visitRangeKey:    visitRangeKey,
-		visitSharedFile:  visitSharedFile,
-		skipSharedLevels: visitSharedFile != nil,
+		CategoryAndQoS:    categoryAndQoS,
+		visitPointKey:     visitPointKey,
+		visitRangeDel:     visitRangeDel,
+		visitRangeKey:     visitRangeKey,
+		visitSharedFile:   visitSharedFile,
+		visitExternalFile: visitExternalFile,
 		IterOptions: IterOptions{
 			KeyTypes:   IterKeyTypePointsAndRanges,
 			LowerBound: lower,
@@ -483,6 +484,7 @@ func (es *EventuallyFileOnlySnapshot) ScanInternal(
 	visitRangeDel func(start, end []byte, seqNum uint64) error,
 	visitRangeKey func(start, end []byte, keys []rangekey.Key) error,
 	visitSharedFile func(sst *SharedSSTMeta) error,
+	visitExternalFile func(sst *ExternalFile) error,
 ) error {
 	if es.db == nil {
 		panic(ErrClosed)
@@ -495,11 +497,11 @@ func (es *EventuallyFileOnlySnapshot) ScanInternal(
 			LowerBound: lower,
 			UpperBound: upper,
 		},
-		visitPointKey:    visitPointKey,
-		visitRangeDel:    visitRangeDel,
-		visitRangeKey:    visitRangeKey,
-		visitSharedFile:  visitSharedFile,
-		skipSharedLevels: visitSharedFile != nil,
+		visitPointKey:     visitPointKey,
+		visitRangeDel:     visitRangeDel,
+		visitRangeKey:     visitRangeKey,
+		visitSharedFile:   visitSharedFile,
+		visitExternalFile: visitExternalFile,
 	}
 	es.mu.Lock()
 	if es.mu.vers != nil {

--- a/testdata/scan_internal
+++ b/testdata/scan_internal
@@ -462,3 +462,92 @@ shared file: 000005 [b#11,1-d#13,1] [point=b#11,1-d#13,1] [range=#0,0-#0,0]
 scan-internal skip-shared lower=a upper=aaa
 ----
 shared file: 000005 [a#10,21-aa#72057594037927935,21] [point=#0,0-#0,0] [range=a#10,21-aa#72057594037927935,21]
+
+
+reset
+----
+
+batch ingest-external=file1
+set a foo
+set b bar
+set c baz
+----
+wrote 3 keys to batch ""
+
+batch commit
+set d bat
+----
+committed 1 keys
+
+flush
+----
+
+lsm
+----
+0.0:
+  000006:[d#11,SET-d#11,SET]
+6:
+  000004:[a#10,DELSIZED-c\x00#inf,RANGEDEL]
+
+
+
+scan-internal skip-shared skip-external lower=m upper=n
+----
+
+scan-internal skip-shared skip-external lower=a upper=f
+----
+external file: external-storage file1 [0x61-0x6300] (hasPoint: true, hasRange: false)
+d#11,1 (bat)
+
+
+reset
+----
+
+batch commit
+set d bat
+----
+committed 1 keys
+
+flush
+----
+
+batch ingest-external=file1
+set a foo
+set b bar
+set c baz
+----
+wrote 3 keys to batch ""
+
+flush
+----
+
+compact a-z
+----
+6:
+  000006:[a#11,DELSIZED-c\x00#inf,RANGEDEL]
+  000005:[d#10,SET-d#10,SET]
+
+scan-internal skip-shared skip-external lower=m upper=n
+----
+
+scan-internal skip-shared skip-external lower=a upper=f
+----
+external file: external-storage file1 [0x61-0x6300] (hasPoint: true, hasRange: false)
+shared file: 000005 [d#10,1-d#10,1] [point=d#10,1-d#10,1] [range=#0,0-#0,0]
+
+scan-internal skip-shared lower=a upper=f
+----
+external file is present but no external file visitor is defined: pebble: cannot use skip-shared iteration due to non-shareable files in lower levels
+
+
+scan-internal skip-external lower=a upper=f
+----
+shared file is present but no shared file visitor is defined: pebble: cannot use skip-shared iteration due to non-shareable files in lower levels
+
+
+scan-internal lower=a upper=f
+----
+a#11,1 (foo)
+b#11,1 (bar)
+c#11,1 (baz)
+d#10,1 (bat)


### PR DESCRIPTION
Like the sharedFileVisitor, the new externalFileVisitor allows the caller to process external files directly.

In a follow up PR, we will teach ingest how to process these similar to how it processes SharedSSTs

In this PR, the externalFileVisitor only applies to L6 and L6 must be completely external or shared files.