### PR TITLE
wal: reenable TestFailoverWriter

### DIFF
--- a/internal/testutils/duration.go
+++ b/internal/testutils/duration.go
@@ -1,0 +1,25 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package testutils
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// DurationIsAtLeast verifies that the given duration is at least the given
+// value.
+func DurationIsAtLeast(t testing.TB, d, minValue time.Duration) {
+	t.Helper()
+	if runtime.GOOS == "windows" && minValue < 10*time.Millisecond {
+		// Windows timer precision is coarse (on the order of 1 millisecond) and can
+		// cause the duration for short operations to be 0.
+		return
+	}
+	require.GreaterOrEqual(t, d, minValue)
+}


### PR DESCRIPTION
Unskip the test and just skip the time check, which is flaky on Windows because of its coarse timer. Add a test helper and use it for another similar existing case.

Fixes #3289.