### PR TITLE
metamorphic: add testing for synthetic suffix

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -1107,35 +1107,42 @@ type ExternalFile struct {
 	// Locator is the shared.Locator that can be used with objProvider to
 	// resolve a reference to this external sstable.
 	Locator remote.Locator
+
 	// ObjName is the unique name of this sstable on Locator.
 	ObjName string
+
 	// Size of the referenced proportion of the virtualized sstable. An estimate
 	// is acceptable in lieu of the backing file size.
 	Size uint64
+
 	// SmallestUserKey and LargestUserKey are the [smallest,largest) user key
 	// bounds of the sstable. Both these bounds are loose i.e. it's possible for
 	// the sstable to not span the entirety of this range. However, multiple
 	// ExternalFiles in one ingestion must all have non-overlapping
 	// [smallest, largest) spans. Note that this Largest bound is exclusive.
 	SmallestUserKey, LargestUserKey []byte
+
 	// HasPointKey and HasRangeKey denote whether this file contains point keys
 	// or range keys. If both structs are false, an error is returned during
 	// ingestion.
 	HasPointKey, HasRangeKey bool
+
 	// ContentPrefix and SyntheticPrefix denote a prefix replacement rule causing
 	// a file, in which all keys have prefix ContentPrefix, to appear whenever it
 	// is accessed as if those keys all instead have prefix SyntheticPrefix.
+	//
 	// SyntheticPrefix must be a prefix of both SmallestUserKey and LargestUserKey.
 	ContentPrefix, SyntheticPrefix []byte
+
 	// SyntheticSuffix will replace the suffix of every key in the file during
 	// iteration. Note that the file itself is not modified, rather, every key
 	// returned by an iterator will have the synthetic suffix.
 	//
-  // The SyntheticSuffix must sort before any non-empty suffixes in the backing
-  // sstable.
-	//
-	// If SyntheticSuffix is set, then SmallestUserKey and LargestUserKey must not
-	// have suffixes.
+	// SyntheticSuffix can only be used under the following conditions:
+	//  - the synthetic suffix must sort before any non-empty suffixes in the
+	//    backing sst;
+	//  - SmallestUserKey and LargestUserKey must not have suffixes;
+	//  - the backing sst must not contain multiple keys with the same prefix.
 	SyntheticSuffix []byte
 }
 

--- a/internal/testkeys/testkeys.go
+++ b/internal/testkeys/testkeys.go
@@ -102,6 +102,11 @@ var Comparer = &base.Comparer{
 	Name:  "pebble.internal.testkeys",
 }
 
+// The comparator is similar to the one in Cockroach; when the prefixes are
+// equal:
+//   - a key without a suffix is smaller than one with a suffix;
+//   - when both keys have a suffix, the key with the larger (decoded) suffix
+//     value is smaller.
 func compare(a, b []byte) int {
 	ai, bi := split(a), split(b)
 	if v := bytes.Compare(a[:ai], b[:bi]); v != 0 {

--- a/metamorphic/key_generator.go
+++ b/metamorphic/key_generator.go
@@ -207,7 +207,12 @@ func (kg *keyGenerator) randKey(newKeyProbability float64, bounds *pebble.KeyRan
 			panic(fmt.Sprintf("invalid bounds [%q, %q)", bounds.Start, bounds.End))
 		}
 		suffix = kg.SkewedSuffixInt(0.01)
-		for !(cmpSuffix(startSuffix, suffix) <= 0 && cmpSuffix(suffix, endSuffix) < 0) {
+		for i := 0; !(cmpSuffix(startSuffix, suffix) <= 0 && cmpSuffix(suffix, endSuffix) < 0); i++ {
+			if i > 10 {
+				// This value is always >= startSuffix and < endSuffix.
+				suffix = (startSuffix + endSuffix) / 2
+				break
+			}
 			// The suffix we want must exist in the current suffix range, we don't
 			// want to keep increasing it here.
 			suffix = kg.SkewedSuffixInt(0)
@@ -217,8 +222,12 @@ func (kg *keyGenerator) randKey(newKeyProbability float64, bounds *pebble.KeyRan
 		suffix = kg.SkewedSuffixInt(0.01)
 		if kg.equal(prefix, startPrefix) {
 			// We can't use a suffix which sorts before startSuffix.
-			for cmpSuffix(suffix, startSuffix) < 0 {
-				suffix = kg.SkewedSuffixInt(0.01)
+			for i := 0; cmpSuffix(suffix, startSuffix) < 0; i++ {
+				if i > 10 {
+					suffix = startSuffix
+					break
+				}
+				suffix = kg.SkewedSuffixInt(0)
 			}
 		}
 	}

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -478,9 +478,22 @@ func standardOptions() []*TestOptions {
   format_major_version=%s
 [TestOptions]
   shared_storage_enabled=true
-  external_storage_enabled=true
   secondary_cache_enabled=true
 `, pebble.FormatMinForSharedObjects),
+		28: fmt.Sprintf(`
+[Options]
+  format_major_version=%s
+[TestOptions]
+  external_storage_enabled=true
+`, pebble.FormatSyntheticPrefixSuffix),
+		29: fmt.Sprintf(`
+[Options]
+  format_major_version=%s
+[TestOptions]
+  shared_storage_enabled=true
+  external_storage_enabled=true
+  secondary_cache_enabled=false
+`, pebble.FormatSyntheticPrefixSuffix),
 	}
 
 	opts := make([]*TestOptions, len(stdOpts))
@@ -662,8 +675,8 @@ func RandomOptions(
 	// 50% of time, enable external storage.
 	if rng.Intn(2) == 0 {
 		testOpts.externalStorageEnabled = true
-		if testOpts.Opts.FormatMajorVersion < pebble.FormatMinForSharedObjects {
-			testOpts.Opts.FormatMajorVersion = pebble.FormatMinForSharedObjects
+		if testOpts.Opts.FormatMajorVersion < pebble.FormatSyntheticPrefixSuffix {
+			testOpts.Opts.FormatMajorVersion = pebble.FormatSyntheticPrefixSuffix
 		}
 		testOpts.externalStorageFS = remote.NewInMem()
 	}

--- a/metamorphic/parser.go
+++ b/metamorphic/parser.go
@@ -466,22 +466,25 @@ func (p *parser) parseCheckpointSpans(list []listElem) []pebble.CheckpointSpan {
 }
 
 func (p *parser) parseExternalObjsWithBounds(list []listElem) []externalObjWithBounds {
-	if len(list)%3 != 0 {
-		panic(p.errorf(list[0].pos, "expected number of arguments to be multiple of 3"))
+	const numArgs = 4
+	if len(list)%numArgs != 0 {
+		panic(p.errorf(list[0].pos, "expected number of arguments to be multiple of %d", numArgs))
 	}
-	objs := make([]externalObjWithBounds, len(list)/3)
+	objs := make([]externalObjWithBounds, len(list)/numArgs)
 	for i := range objs {
 		list[0].expectToken(p, token.IDENT)
 		list[1].expectToken(p, token.STRING)
 		list[2].expectToken(p, token.STRING)
+		list[3].expectToken(p, token.STRING)
 		objs[i] = externalObjWithBounds{
 			externalObjID: p.parseObjID(list[0].pos, list[0].lit),
 			bounds: pebble.KeyRange{
 				Start: unquoteBytes(list[1].lit),
 				End:   unquoteBytes(list[2].lit),
 			},
+			syntheticSuffix: unquoteBytes(list[3].lit),
 		}
-		list = list[3:]
+		list = list[numArgs:]
 	}
 	return objs
 }

--- a/sstable/block_property.go
+++ b/sstable/block_property.go
@@ -489,10 +489,6 @@ func (b *BlockIntervalFilter) SyntheticSuffixIntersects(prop []byte, suffix []by
 	if err != nil {
 		return false, err
 	}
-	if newLower < i.upper {
-		// This isn't an =< comparator because the original i.upper bound is exclusive.
-		return false, base.CorruptionErrorf(fmt.Sprintf("the synthetic suffix %d is the less than the property upper bound %d", newLower, i.upper))
-	}
 	newInterval := interval{lower: newLower, upper: newUpper}
 	return newInterval.intersects(b.filterInterval), nil
 }

--- a/sstable/block_property_test_utils.go
+++ b/sstable/block_property_test_utils.go
@@ -5,6 +5,7 @@
 package sstable
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/cockroachdb/pebble/internal/base"
@@ -35,7 +36,26 @@ func NewTestKeysBlockPropertyCollector() BlockPropertyCollector {
 // and keys with suffixes within the range [filterMin, filterMax). For keys with
 // suffixes outside the range, iteration is nondeterministic.
 func NewTestKeysBlockPropertyFilter(filterMin, filterMax uint64) *BlockIntervalFilter {
-	return NewBlockIntervalFilter(testKeysBlockPropertyName, filterMin, filterMax, nil)
+	return NewBlockIntervalFilter(testKeysBlockPropertyName, filterMin, filterMax, testKeysBlockIntervalSyntheticReplacer{})
+}
+
+var _ BlockIntervalSyntheticReplacer = testKeysBlockIntervalSyntheticReplacer{}
+
+type testKeysBlockIntervalSyntheticReplacer struct{}
+
+// AdjustIntervalWithSyntheticSuffix implements BlockIntervalSyntheticReplacer.
+func (sr testKeysBlockIntervalSyntheticReplacer) AdjustIntervalWithSyntheticSuffix(
+	lower uint64, upper uint64, suffix []byte,
+) (adjustedLower uint64, adjustedUpper uint64, err error) {
+	decoded, err := testkeys.ParseSuffix(suffix)
+	if err != nil {
+		return 0, 0, err
+	}
+	// The testKeysSuffixIntervalCollector below maps keys with no suffix to MaxUint64; ignore it.
+	if upper != math.MaxUint64 && uint64(decoded) < upper {
+		panic(fmt.Sprintf("the synthetic suffix %d is less than the property upper bound %d", decoded, upper))
+	}
+	return uint64(decoded), uint64(decoded) + 1, nil
 }
 
 // NewTestKeysMaskingFilter constructs a TestKeysMaskingFilter that implements
@@ -70,7 +90,7 @@ func (f TestKeysMaskingFilter) Intersects(prop []byte) (bool, error) {
 
 // SyntheticSuffixIntersects implements the BlockPropertyFilter interface.
 func (f TestKeysMaskingFilter) SyntheticSuffixIntersects(prop []byte, suffix []byte) (bool, error) {
-	panic("unimplemented")
+	return f.BlockIntervalFilter.SyntheticSuffixIntersects(prop, suffix)
 }
 
 var _ DataBlockIntervalCollector = (*testKeysSuffixIntervalCollector)(nil)

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -158,10 +158,11 @@ func (c *cacheOpts) writerApply(w *Writer) {
 }
 
 // SyntheticSuffix will replace every suffix of every key surfaced during block
-// iteration. The client should only initiate a reader with SuffixReplacement if:
-//
-// (1) no two keys in the sst share the same prefix
-// (2) pebble.Compare(replacementSuffix,originalSuffix) > 0, for all keys
+// iteration. A synthetic suffix can be used if:
+//  1. no two keys in the sst share the same prefix; and
+//  2. pebble.Compare(prefix + replacementSuffix, prefix + originalSuffix) < 0,
+//     for all keys in the backing sst which have a suffix (i.e. originalSuffix
+//     is not empty).
 type SyntheticSuffix []byte
 
 // rawTombstonesOpt is a Reader open option for specifying that range

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -237,6 +237,16 @@ a@5: (foo, .)
 b@5: (foo, .)
 c@5: (foo, .)
 
+# Verify that we require bounds without suffix if we use suffix replacement.
+ingest-external suffix-replace=@5
+f6,10,a@1,z@10
+----
+pebble: synthetic suffix is set but smallest key has suffix
+
+ingest-external suffix-replace=@5
+f6,10,a,z@10
+----
+pebble: synthetic suffix is set but largest key has suffix
 
 # Test the case when we are ingesting part of a RANGEDEL.
 reset


### PR DESCRIPTION
#### ingest: require boundary keys without suffix for external ingest with suffix

Require that the smallest and largest keys for the external file have
no suffix when we are doing suffix replacement. This is sufficient for
our use case and makes things easier to reason about.

We also improve and correct a few comments around suffix replacement.

#### metamorphic: add testing for synthetic suffix

Add a random synthetic suffix for external ingestion.

One difficulty is that the synthetic suffix has to be larger (as an
integer value) than all suffixes in the object. We can't easily
determine this at generation time, so we generate a random suffix and
at runtime determine if it's ok to use or not.
