### PR TITLE
manifest: fix bug when parsing the suffix rewrite tag

### DIFF
--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -50,6 +50,11 @@ func TestVERoundTripAndAccumulate(t *testing.T) {
 		CreationTime:   809060,
 		SmallestSeqNum: 9,
 		LargestSeqNum:  11,
+		PrefixReplacement: &PrefixReplacement{
+			ContentPrefix:   []byte("before"),
+			SyntheticPrefix: []byte("after"),
+		},
+		SyntheticSuffix: []byte("foo"),
 	}).ExtendPointKeyBounds(
 		cmp,
 		base.MakeInternalKey([]byte("a"), 0, base.InternalKeyKindSet),
@@ -129,6 +134,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 		SmallestSeqNum:      3,
 		LargestSeqNum:       5,
 		MarkedForCompaction: true,
+		SyntheticSuffix:     []byte("foo"),
 	}).ExtendPointKeyBounds(
 		cmp,
 		base.DecodeInternalKey([]byte("A\x00\x01\x02\x03\x04\x05\x06\x07")),


### PR DESCRIPTION
We were missing a `continue` which leads to an error when the suffix
rewrite tag is used (meaning we can't open a database).

This commit restructures the code into a single switch to make this
mistake less likely.