### PR TITLE
metamorphic: support retaining prefixes when simplifying keys

### DIFF
--- a/internal/metamorphic/reduce_test.go
+++ b/internal/metamorphic/reduce_test.go
@@ -206,10 +206,14 @@ func (r *reducer) Run(t *testing.T) {
 		}
 	}
 	// Try to simplify the keys.
-	newOpsData, err := metamorphic.TryToSimplifyKeys([]byte(strings.Join(ops, "\n")))
-	require.NoError(t, err)
-	o := strings.Split(strings.TrimSpace(string(newOpsData)), "\n")
-	r.try(t, o)
+	opsData := []byte(strings.Join(ops, "\n"))
+	for _, retainSuffixes := range []bool{false, true} {
+		newOpsData := metamorphic.TryToSimplifyKeys(opsData, retainSuffixes)
+		o := strings.Split(strings.TrimSpace(string(newOpsData)), "\n")
+		if r.try(t, o) {
+			return
+		}
+	}
 }
 
 func randomSubset(t *testing.T, ops []string, removeProbability float64) []string {

--- a/metamorphic/simplify_test.go
+++ b/metamorphic/simplify_test.go
@@ -15,10 +15,8 @@ func TestSimplifyKeys(t *testing.T) {
 	datadriven.RunTest(t, "testdata/simplify", func(t *testing.T, d *datadriven.TestData) string {
 		switch d.Cmd {
 		case "simplify-keys":
-			res, err := TryToSimplifyKeys([]byte(d.Input))
-			if err != nil {
-				return err.Error()
-			}
+			retainSuffixes := d.HasArg("retain-suffixes")
+			res := TryToSimplifyKeys([]byte(d.Input), retainSuffixes)
 			return string(res)
 
 		default:

--- a/metamorphic/testdata/simplify
+++ b/metamorphic/testdata/simplify
@@ -15,3 +15,21 @@ db2.Compact("apple", "raspberry", true /* parallelize */)
 db2.RangeKeySet("a", "b", "", "")
 snap9 = db2.NewSnapshot("a", "b")
 db2.Compact("a", "b", true /* parallelize */)
+
+simplify-keys
+db2.RangeKeySet("apple@1", "raspberry", "", "")
+snap9 = db2.NewSnapshot("apple@1", "raspberry@4")
+db2.Compact("apple@1", "raspberry@4", true /* parallelize */)
+----
+db2.RangeKeySet("a", "b", "", "")
+snap9 = db2.NewSnapshot("a", "c")
+db2.Compact("a", "c", true /* parallelize */)
+
+simplify-keys retain-suffixes
+db2.RangeKeySet("apple@1", "raspberry", "", "")
+snap9 = db2.NewSnapshot("apple@1", "raspberry@4")
+db2.Compact("apple@1", "raspberry@4", true /* parallelize */)
+----
+db2.RangeKeySet("a@1", "b", "", "")
+snap9 = db2.NewSnapshot("a@1", "b@4")
+db2.Compact("a@1", "b@4", true /* parallelize */)


### PR DESCRIPTION
When we `--try-to-reduce` a failure, we try to simplify the keys into
single letters. This commit adds a mode where we only simplify the
prefixes and retain the suffixes.