### PR TITLE
wal: separate read interface from Manager

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -374,9 +374,9 @@ func TestLargeBatch(t *testing.T) {
 	logNum := func() base.DiskFileNum {
 		d.mu.Lock()
 		defer d.mu.Unlock()
-		walNums, err := d.mu.log.manager.List()
+		logs, err := d.mu.log.manager.List()
 		require.NoError(t, err)
-		return base.DiskFileNum(walNums[len(walNums)-1])
+		return base.DiskFileNum(logs[len(logs)-1].Num)
 	}
 	fileSize := func(fileNum base.DiskFileNum) int64 {
 		info, err := d.opts.FS.Stat(base.MakeFilepath(d.opts.FS, "", fileTypeLog, fileNum))
@@ -1979,7 +1979,7 @@ func TestRecycleLogs(t *testing.T) {
 		defer d.mu.Unlock()
 		walNums, err := d.mu.log.manager.List()
 		require.NoError(t, err)
-		return base.DiskFileNum(walNums[len(walNums)-1])
+		return base.DiskFileNum(walNums[len(walNums)-1].Num)
 	}
 	logCount := func() int {
 		d.mu.Lock()

--- a/wal/failover_manager.go
+++ b/wal/failover_manager.go
@@ -409,7 +409,7 @@ var _ Manager = &failoverManager{}
 // - calls to EventListener
 
 // Init implements Manager.
-func (wm *failoverManager) Init(o Options) error {
+func (wm *failoverManager) Init(o Options, initial Logs) error {
 	if o.timeSource == nil {
 		o.timeSource = defaultTime{}
 	}
@@ -443,9 +443,8 @@ func (wm *failoverManager) Init(o Options) error {
 }
 
 // List implements Manager.
-func (wm *failoverManager) List() ([]NumWAL, error) {
-	// TODO(jackson):
-	return nil, nil
+func (wm *failoverManager) List() (Logs, error) {
+	return Scan(wm.opts.Primary, wm.opts.Secondary)
 }
 
 // Obsolete implements Manager.
@@ -453,22 +452,6 @@ func (wm *failoverManager) Obsolete(
 	minUnflushedNum NumWAL, noRecycle bool,
 ) (toDelete []DeletableLog, err error) {
 	// TODO(sumeer):
-	return nil, nil
-}
-
-// OpenForRead implements Manager.
-func (wm *failoverManager) OpenForRead(wn NumWAL) (Reader, error) {
-	// TODO(jackson):
-	//
-	// Temporary implementation note: Gap and de-duping logic on read.
-	//
-	// Gap can be there in adjacent logs but not between log n and the union of logs 0..n-1.
-	// Entries 0..50 sent to log 0.
-	// Entries 0..60 sent to log 1
-	// Log 0 commits up to 50
-	// Entries 50..100 sent to log 2
-	// Log 2 commits all of these.
-	// Log 1 only commits 0..10 and node fails and restarts.
 	return nil, nil
 }
 
@@ -499,12 +482,6 @@ func (wm *failoverManager) Create(wn NumWAL, jobID int) (Writer, error) {
 	}
 	wm.monitor.newWriter(writerCreateFunc)
 	return ww, err
-}
-
-// ListFiles implements Manager.
-func (wm *failoverManager) ListFiles(wn NumWAL) (files []CopyableLog, err error) {
-	// TODO(sumeer):
-	return nil, nil
 }
 
 // ElevateWriteStallThresholdForFailover implements Manager.

--- a/wal/failover_manager_test.go
+++ b/wal/failover_manager_test.go
@@ -362,7 +362,9 @@ func TestManagerFailover(t *testing.T) {
 					monitorStateForTesting:             monitorStateForTesting,
 					logWriterCreatedForTesting:         logWriterCreatedForTesting,
 				}
-				err := fm.Init(o)
+				logs, err := Scan(o.Dirs()...)
+				require.NoError(t, err)
+				err = fm.Init(o, logs)
 				return errorToStr(err)
 
 			case "create-writer":

--- a/wal/log_recycler.go
+++ b/wal/log_recycler.go
@@ -42,14 +42,14 @@ func (r *LogRecycler) Init(maxNumLogFiles int) {
 
 // MinRecycleLogNum returns the current minimum log number that is allowed to
 // be recycled.
-func (r *LogRecycler) MinRecycleLogNum() base.DiskFileNum {
-	return r.minRecycleLogNum
+func (r *LogRecycler) MinRecycleLogNum() NumWAL {
+	return NumWAL(r.minRecycleLogNum)
 }
 
 // SetMinRecycleLogNum sets the minimum log number that is allowed to be
 // recycled.
-func (r *LogRecycler) SetMinRecycleLogNum(n base.DiskFileNum) {
-	r.minRecycleLogNum = n
+func (r *LogRecycler) SetMinRecycleLogNum(n NumWAL) {
+	r.minRecycleLogNum = base.DiskFileNum(n)
 }
 
 // Add attempts to recycle the log file specified by logInfo. Returns true if

--- a/wal/reader_test.go
+++ b/wal/reader_test.go
@@ -50,7 +50,7 @@ func TestList(t *testing.T) {
 					Dirname: dirname,
 				})
 			}
-			logs, err := listLogs(dirs...)
+			logs, err := Scan(dirs...)
 			if err != nil {
 				return err.Error()
 			}
@@ -196,9 +196,9 @@ func TestReader(t *testing.T) {
 			var forceLogNameIndexes []uint64
 			td.ScanArgs(t, "logNum", &logNum)
 			td.MaybeScanArgs(t, "forceLogNameIndexes", &forceLogNameIndexes)
-			logs, err := listLogs(Dir{FS: fs})
+			logs, err := Scan(Dir{FS: fs})
 			require.NoError(t, err)
-			log, ok := logs.get(NumWAL(logNum))
+			log, ok := logs.Get(NumWAL(logNum))
 			if !ok {
 				return "not found"
 			}
@@ -216,8 +216,8 @@ func TestReader(t *testing.T) {
 					segments = slices.Insert(segments, j, segment{logNameIndex: logNameIndex(li), dir: Dir{FS: fs}})
 				}
 			}
-
-			r := newVirtualWALReader(log.NumWAL, segments)
+			ll := LogicalLog{Num: log.Num, segments: segments}
+			r := ll.OpenForRead()
 			for {
 				rr, off, err := r.NextRecord()
 				fmt.Fprintf(&buf, "r.NextRecord() = (rr, %s, %v)\n", off, err)


### PR DESCRIPTION
This commit separates the interface for reading WAL files from the Manager interface.  This helps unify some code on the read path, but it also makes it easier to support changing configuration (eg, changing secondary location or disabling failover).