### PR TITLE
metamorphic: special handling of assertion errors

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -491,14 +491,14 @@ func ingestSortAndVerify(cmp Compare, lr ingestLoadResult, exciseSpan KeyRange) 
 	// fit within the exciseSpan.
 	for _, f := range lr.shared {
 		if !exciseSpan.Contains(cmp, f.Smallest) || !exciseSpan.Contains(cmp, f.Largest) {
-			return errors.AssertionFailedf("pebble: shared file outside of excise span, span [%s-%s), file = %s", exciseSpan.Start, exciseSpan.End, f.String())
+			return errors.Newf("pebble: shared file outside of excise span, span [%s-%s), file = %s", exciseSpan.Start, exciseSpan.End, f.String())
 		}
 	}
 	if len(lr.external) > 0 {
 		if len(lr.local) > 0 || len(lr.shared) > 0 {
 			// Currently we only support external ingests on their own. If external
 			// files are present alongside local/shared files, return an error.
-			return errors.AssertionFailedf("pebble: external files cannot be ingested atomically alongside other types of files")
+			return errors.Newf("pebble: external files cannot be ingested atomically alongside other types of files")
 		}
 		// Sort according to the smallest key.
 		slices.SortFunc(lr.external, func(a, b ingestExternalMeta) int {
@@ -506,7 +506,7 @@ func ingestSortAndVerify(cmp Compare, lr ingestLoadResult, exciseSpan KeyRange) 
 		})
 		for i := 1; i < len(lr.external); i++ {
 			if sstableKeyCompare(cmp, lr.external[i-1].Largest, lr.external[i].Smallest) >= 0 {
-				return errors.AssertionFailedf("pebble: external sstables have overlapping ranges")
+				return errors.Newf("pebble: external sstables have overlapping ranges")
 			}
 		}
 		return nil
@@ -522,7 +522,7 @@ func ingestSortAndVerify(cmp Compare, lr ingestLoadResult, exciseSpan KeyRange) 
 
 	for i := 1; i < len(lr.local); i++ {
 		if sstableKeyCompare(cmp, lr.local[i-1].Largest, lr.local[i].Smallest) >= 0 {
-			return errors.AssertionFailedf("pebble: local ingestion sstables have overlapping ranges")
+			return errors.Newf("pebble: local ingestion sstables have overlapping ranges")
 		}
 	}
 	if len(lr.shared) == 0 {

--- a/metamorphic/history.go
+++ b/metamorphic/history.go
@@ -148,6 +148,13 @@ type historyRecorder struct {
 
 // Recordf records the results of a single operation.
 func (h historyRecorder) Recordf(format string, args ...interface{}) {
+	// Check for assertion errors.
+	for _, a := range args {
+		if err, ok := a.(error); ok && errors.IsAssertionFailure(err) {
+			fmt.Fprintf(os.Stderr, "%+v", err)
+			panic(err)
+		}
+	}
 	h.history.Recordf(h.op, format, args...)
 	// If the history recorder was configured with an additional record func,
 	// invoke it. This can be used to collect the per-operation output when

--- a/sstable/prefix_replacing_iterator.go
+++ b/sstable/prefix_replacing_iterator.go
@@ -41,8 +41,13 @@ type prefixReplacingIterator struct {
 	empty bool
 }
 
-var errInputPrefixMismatch = errors.New("key argument does not have prefix required for replacement")
-var errOutputPrefixMismatch = errors.New("key returned does not have prefix required for replacement")
+func errInputPrefixMismatch() error {
+	return errors.AssertionFailedf("key argument does not have prefix required for replacement")
+}
+
+func errOutputPrefixMismatch() error {
+	return errors.AssertionFailedf("key returned does not have prefix required for replacement")
+}
 
 var _ Iterator = (*prefixReplacingIterator)(nil)
 
@@ -101,7 +106,7 @@ func (p *prefixReplacingIterator) rewriteResult(
 		return k, v
 	}
 	if !bytes.HasPrefix(k.UserKey, p.contentPrefix) {
-		p.err = errOutputPrefixMismatch
+		p.err = errOutputPrefixMismatch()
 		if invariants.Enabled {
 			panic(p.err)
 		}
@@ -280,7 +285,7 @@ func newPrefixReplacingFragmentIterator(
 
 func (p *prefixReplacingFragmentIterator) rewriteArg(key []byte) ([]byte, error) {
 	if !bytes.HasPrefix(key, p.syntheticPrefix) {
-		return nil, errInputPrefixMismatch
+		return nil, errInputPrefixMismatch()
 	}
 	p.arg = append(p.arg[:len(p.contentPrefix)], key[len(p.syntheticPrefix):]...)
 	return p.arg, nil
@@ -293,7 +298,7 @@ func (p *prefixReplacingFragmentIterator) rewriteSpan(
 		return sp, err
 	}
 	if !bytes.HasPrefix(sp.Start, p.contentPrefix) || !bytes.HasPrefix(sp.End, p.contentPrefix) {
-		return nil, errOutputPrefixMismatch
+		return nil, errOutputPrefixMismatch()
 	}
 	sp.Start = append(p.out1[:len(p.syntheticPrefix)], sp.Start[len(p.contentPrefix):]...)
 	sp.End = append(p.out2[:len(p.syntheticPrefix)], sp.End[len(p.contentPrefix):]...)


### PR DESCRIPTION
Check for assertion errors when recording history and display their
stacktrace and panic. This helps with debugging.

We also fix some cases where we return an assertion error when we are
checking an API input; assertion errors should indicate a bug inside
Pebble.