### PR TITLE
db: prefix replacement fixes

### DIFF
--- a/sstable/prefix_replacing_iterator_test.go
+++ b/sstable/prefix_replacing_iterator_test.go
@@ -32,9 +32,11 @@ func TestPrefixReplacingIterator(t *testing.T) {
 
 			raw := rawIter.(*singleLevelIterator)
 
-			it := newPrefixReplacingIterator(raw, tc.from, tc.to, DefaultComparer.Compare)
+			it := newPrefixReplacingIterator(raw, tc.from, tc.to, tc.to, DefaultComparer.Compare)
 
-			kMin, kMax, k := []byte{0}, []byte("~"), func(i uint64) []byte {
+			kMin := []byte{0}
+			kMax := []byte("~")
+			k := func(i uint64) []byte {
 				return binary.BigEndian.AppendUint64(tc.to[:len(tc.to):len(tc.to)], i)
 			}
 
@@ -99,9 +101,6 @@ func TestPrefixReplacingIterator(t *testing.T) {
 			})
 
 			t.Run("SeekPrefixGE", func(t *testing.T) {
-				got, _ = it.SeekPrefixGE(tc.to, kMin, base.SeekGEFlagsNone)
-				require.Equal(t, k(0), got.UserKey)
-
 				got, _ = it.SeekPrefixGE(tc.to, k(0), base.SeekGEFlagsNone)
 				require.Equal(t, k(0), got.UserKey)
 
@@ -112,9 +111,6 @@ func TestPrefixReplacingIterator(t *testing.T) {
 				require.Equal(t, k(11), got.UserKey)
 
 				got, _ = it.SeekPrefixGE(tc.to, k(100), base.SeekGEFlagsNone)
-				require.Nil(t, got)
-
-				got, _ = it.SeekPrefixGE(tc.to, kMax, base.SeekGEFlagsNone)
 				require.Nil(t, got)
 			})
 

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -1270,7 +1270,11 @@ func TestRandomizedSuffixRewriter(t *testing.T) {
 			context.Background(),
 			nil, nil, nil, false,
 			true, nil, CategoryAndQoS{}, nil,
-			TrivialReaderProvider{Reader: eReader}, &virtualState{syntheticSuffix: syntheticSuffix})
+			TrivialReaderProvider{Reader: eReader}, &virtualState{
+				lower:           base.MakeInternalKey([]byte("a"), base.InternalKeySeqNumMax, base.InternalKeyKindSet),
+				upper:           base.MakeRangeDeleteSentinelKey([]byte("zzzzzzzzzzzzzzzzzzz")),
+				syntheticSuffix: syntheticSuffix,
+			})
 		require.NoError(t, err)
 		return iter, func() {
 			require.NoError(t, iter.Close())

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -364,3 +364,57 @@ ge: (something, .)
 gg: (foo, .)
 gh: (foo, .)
 gi: (foo, .)
+
+# Test seeks with keys outside of the synthetic prefix range.
+reset
+----
+
+build-remote f9
+set i foo
+----
+
+ingest-external prefix-replace=(,c)
+f9,10,cg,ck
+----
+
+iter
+seek-ge bp
+----
+ci: (foo, .)
+
+iter
+seek-prefix-ge bp
+----
+.
+
+iter
+seek-lt de
+----
+ci: (foo, .)
+
+reset
+----
+
+batch
+set a1 foo
+set ci1 bar
+set z1 baz
+----
+
+build-remote f10
+del-range i j
+----
+
+ingest-external prefix-replace=(,c)
+f10,10,cg,ck
+----
+
+iter
+seek-ge bp
+----
+z1: (baz, .)
+
+iter
+seek-lt de
+----
+a1: (foo, .)


### PR DESCRIPTION
The prefix replacing iterators did not support arguments that don't
start with the synthetic prefix. We fix this by adding a `keyInRange`
argument that we can compare against when we are outside the synthetic
prefix range to figure out which side we are on.

We also fix assertions in `maybeVerifyKey` which were not correct when
prefix replacement is used.

Fixes #3319.