### PR TITLE
internal/keyspan: remove datadriven runtime dep

### DIFF
--- a/internal/keyspan/bounded_test.go
+++ b/internal/keyspan/bounded_test.go
@@ -60,7 +60,7 @@ func TestBoundedIter(t *testing.T) {
 			buf.Reset()
 			lower, upper := getBounds(td)
 			iter.SetBounds(lower, upper)
-			RunIterCmd(td, &iter, &buf)
+			RunIterCmd(td.Input, &iter, &buf)
 			return buf.String()
 		default:
 			return fmt.Sprintf("unrecognized command %q", td.Cmd)

--- a/internal/keyspan/keyspanimpl/merging_iter_test.go
+++ b/internal/keyspan/keyspanimpl/merging_iter_test.go
@@ -69,7 +69,7 @@ func TestMergingIter(t *testing.T) {
 			}
 			var iter MergingIter
 			iter.Init(cmp, keyspan.VisibleTransform(snapshot), new(MergingBuffers), iters...)
-			keyspan.RunIterCmd(td, &iter, &buf)
+			keyspan.RunIterCmd(td.Input, &iter, &buf)
 			return buf.String()
 		default:
 			return fmt.Sprintf("unrecognized command %q", td.Cmd)

--- a/internal/keyspan/test_utils.go
+++ b/internal/keyspan/test_utils.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/dsl"
 )
@@ -381,8 +380,8 @@ func (p *probeIterator) WrapChildren(wrap WrapFn) {
 // RunIterCmd evaluates a datadriven command controlling an internal
 // keyspan.FragmentIterator, writing the results of the iterator operations to
 // the provided writer.
-func RunIterCmd(td *datadriven.TestData, iter FragmentIterator, w io.Writer) {
-	lines := strings.Split(strings.TrimSpace(td.Input), "\n")
+func RunIterCmd(tdInput string, iter FragmentIterator, w io.Writer) {
+	lines := strings.Split(strings.TrimSpace(tdInput), "\n")
 	for i, line := range lines {
 		if i > 0 {
 			fmt.Fprintln(w)

--- a/internal/keyspan/truncate_test.go
+++ b/internal/keyspan/truncate_test.go
@@ -88,7 +88,7 @@ func TestTruncate(t *testing.T) {
 
 		case "saved-iter":
 			var buf bytes.Buffer
-			RunIterCmd(d, savedIter, &buf)
+			RunIterCmd(d.Input, savedIter, &buf)
 			return buf.String()
 
 		default:


### PR DESCRIPTION
In #3293 some helpers were exported for reuse in other tests and the file suffix of _test was removed, however this meant that the keyspan package started to link in datadriven even in non-test binaries. This is not desired, as datadriven has init-registered flags such as rewrite and should only be linked in test binaries.

Fortunately the helpers only needed a string field so we don't need to use 'datadriven' to pass it that.