### PR TITLE
sstable: fix compaction iterator bug with prefix replacement

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -510,6 +510,11 @@ func runBuildRemoteCmd(td *datadriven.TestData, d *DB, storage remote.Storage) e
 	}
 
 	writeOpts := d.opts.MakeWriterOptions(0 /* level */, tableFormat)
+	if rand.Intn(4) == 0 {
+		// Force two-level indexes.
+		writeOpts.BlockSize = 5
+		writeOpts.IndexBlockSize = 5
+	}
 
 	f, err := storage.CreateObject(path)
 	if err != nil {

--- a/sstable/reader_common.go
+++ b/sstable/reader_common.go
@@ -79,14 +79,14 @@ type PrefixReplacement struct {
 	SyntheticPrefix []byte
 }
 
-// ReplaceArg replaces the new prefix in the argument with the original prefix.
-func (p *PrefixReplacement) ReplaceArg(src []byte) []byte {
-	return p.replace(src, p.SyntheticPrefix, p.ContentPrefix)
+// Apply replaces the content prefix in the key with the synthetic prefix.
+func (p *PrefixReplacement) Apply(key []byte) []byte {
+	return p.replace(key, p.ContentPrefix, p.SyntheticPrefix)
 }
 
-// ReplaceResult replaces the original prefix in the result with the new prefix.
-func (p *PrefixReplacement) ReplaceResult(key []byte) []byte {
-	return p.replace(key, p.ContentPrefix, p.SyntheticPrefix)
+// Invert replaces the synthetic prefix in the key with the content prefix.
+func (p *PrefixReplacement) Invert(src []byte) []byte {
+	return p.replace(src, p.SyntheticPrefix, p.ContentPrefix)
 }
 
 func (p *PrefixReplacement) replace(key, from, to []byte) []byte {

--- a/sstable/reader_iter.go
+++ b/sstable/reader_iter.go
@@ -280,9 +280,10 @@ func (i *compactionIterator) skipForward(
 	*i.bytesIterated += uint64(curOffset - i.prevOffset)
 	i.prevOffset = curOffset
 
-	if i.vState != nil && key != nil {
-		cmp := i.cmp(key.UserKey, i.vState.upper.UserKey)
-		if cmp > 0 || (i.vState.upper.IsExclusiveSentinel() && cmp == 0) {
+	// We have an upper bound when the table is virtual.
+	if i.upper != nil && key != nil {
+		cmp := i.cmp(key.UserKey, i.upper)
+		if cmp > 0 || (!i.endKeyInclusive && cmp == 0) {
 			return nil, base.LazyValue{}
 		}
 	}

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -1113,9 +1113,10 @@ func (i *twoLevelCompactionIterator) skipForward(
 	*i.bytesIterated += uint64(curOffset - i.prevOffset)
 	i.prevOffset = curOffset
 
-	if i.vState != nil && key != nil {
-		cmp := i.cmp(key.UserKey, i.vState.upper.UserKey)
-		if cmp > 0 || (i.vState.upper.IsExclusiveSentinel() && cmp == 0) {
+	// We have an upper bound when the table is virtual.
+	if i.upper != nil && key != nil {
+		cmp := i.cmp(key.UserKey, i.upper)
+		if cmp > 0 || (!i.endKeyInclusive && cmp == 0) {
 			return nil, base.LazyValue{}
 		}
 	}

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -160,8 +160,8 @@ func (v *VirtualReader) NewRawRangeDelIter(
 	upper := &v.vState.upper
 
 	if v.vState.prefixChange != nil {
-		lower = &InternalKey{UserKey: v.vState.prefixChange.ReplaceArg(lower.UserKey), Trailer: lower.Trailer}
-		upper = &InternalKey{UserKey: v.vState.prefixChange.ReplaceArg(upper.UserKey), Trailer: upper.Trailer}
+		lower = &InternalKey{UserKey: v.vState.prefixChange.Invert(lower.UserKey), Trailer: lower.Trailer}
+		upper = &InternalKey{UserKey: v.vState.prefixChange.Invert(upper.UserKey), Trailer: upper.Trailer}
 
 		iter = keyspan.Truncate(
 			v.reader.Compare, iter, lower.UserKey, upper.UserKey,
@@ -229,8 +229,8 @@ func (v *VirtualReader) NewRawRangeKeyIter(
 	}
 
 	if v.vState.prefixChange != nil {
-		lower = &InternalKey{UserKey: v.vState.prefixChange.ReplaceArg(lower.UserKey), Trailer: lower.Trailer}
-		upper = &InternalKey{UserKey: v.vState.prefixChange.ReplaceArg(upper.UserKey), Trailer: upper.Trailer}
+		lower = &InternalKey{UserKey: v.vState.prefixChange.Invert(lower.UserKey), Trailer: lower.Trailer}
+		upper = &InternalKey{UserKey: v.vState.prefixChange.Invert(upper.UserKey), Trailer: upper.Trailer}
 		iter = keyspan.Truncate(
 			v.reader.Compare, iter, lower.UserKey, upper.UserKey,
 			lower, upper, !v.vState.upper.IsExclusiveSentinel(), /* panicOnUpperTruncate */
@@ -287,8 +287,8 @@ func (v *virtualState) constrainBounds(
 		}
 	}
 	if v.prefixChange != nil {
-		first = v.prefixChange.ReplaceArg(first)
-		last = v.prefixChange.ReplaceArg(last)
+		first = v.prefixChange.Invert(first)
+		last = v.prefixChange.Invert(last)
 	}
 	// TODO(bananabrick): What if someone passes in bounds completely outside of
 	// virtual sstable bounds?

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -418,3 +418,65 @@ iter
 seek-lt de
 ----
 a1: (foo, .)
+
+
+# Test compactions with synthetic prefix.
+reset
+----
+
+build-remote ext
+set ax ax
+set da da
+set db db
+set dc dc
+set ux ux
+----
+
+# Replace prefix with one greater than the original one.
+ingest-external prefix-replace=(d,e)
+ext,10,ea,ed
+----
+
+# Replace prefix with one smaller than the original one.
+ingest-external prefix-replace=(d,b)
+ext,10,ba,bd
+----
+
+# Write some keys so we actually perform a compaction.
+batch
+set a a
+set c c
+set f f
+----
+
+compact a z
+----
+
+lsm
+----
+6:
+  000008:[a#0,SET-f#0,SET]
+
+# Make sure we see both ba..bc and ea..ec.
+iter
+first
+next
+next
+next
+next
+next
+next
+next
+next
+next
+----
+a: (a, .)
+ba: (da, .)
+bb: (db, .)
+bc: (dc, .)
+c: (c, .)
+ea: (da, .)
+eb: (db, .)
+ec: (dc, .)
+f: (f, .)
+.


### PR DESCRIPTION
#### manifest: rename PrefixReplacement methods

The `ReplaceArg / ReplaceResult` methods are not too descriptive, I
always have to look at the code to remember which does what. Renaming
to `Apply` and `Invert`.

#### sstable: fix compaction iterator bug with prefix replacement

The sstable compaction iterators stop when the key exceeds
`vState.upper`; however this is incorrect when we replace prefixes
(the key has the content prefix and `vState.upper` has the synthetic
prefix).

Switch to using `i.upper` which is in the "content prefix space" and
was already calculated at initialization.