### PR TITLE
db: add DebugString method

### DIFF
--- a/db.go
+++ b/db.go
@@ -3082,3 +3082,10 @@ func (d *DB) checkVirtualBounds(m *fileMetadata) {
 		panic(err)
 	}
 }
+
+// DebugString returns a debugging string describing the LSM.
+func (d *DB) DebugString() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.mu.versions.currentVersion().DebugString(base.DefaultFormatter)
+}

--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -527,6 +527,17 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 	if err := Execute(m); err != nil {
 		fmt.Fprintf(os.Stderr, "Seed: %d\n", seed)
 		fmt.Fprintln(os.Stderr, err)
+	}
+
+	// If we have unclosed databases, print LSM details. This will be the case
+	// when we use --try-to-reduce.
+	for i, db := range m.dbs {
+		if db != nil {
+			fmt.Fprintf(os.Stderr, "\ndb%d:\n%s", i+1, db.DebugString())
+		}
+	}
+
+	if err != nil {
 		m.saveInMemoryData()
 		os.Exit(1)
 	}


### PR DESCRIPTION
Add a `DB.DebugString()` method which can be used during debugging.
The meta test uses it to log the final state of the db (which after
reduction will be right after the problematic operation).