### PR TITLE
wal: convert UnhealthyOperationLatencyThreshold to a func()

### DIFF
--- a/wal/failover_manager.go
+++ b/wal/failover_manager.go
@@ -315,7 +315,7 @@ func (m *failoverMonitor) monitorLoop(shouldQuiesce <-chan struct{}) {
 					// error is useless.
 					lastWriter.errorCounts[dirIndex]++
 					switchDir = true
-				} else if writerOngoingLatency > m.opts.UnhealthyOperationLatencyThreshold {
+				} else if writerOngoingLatency > m.opts.UnhealthyOperationLatencyThreshold() {
 					// Arbitrary value.
 					const switchImmediatelyCountThreshold = 2
 					// High latency. Switch immediately if the number of switches that
@@ -384,8 +384,10 @@ func (o *FailoverOptions) ensureDefaults() {
 	if o.UnhealthySamplingInterval == 0 {
 		o.UnhealthySamplingInterval = 100 * time.Millisecond
 	}
-	if o.UnhealthyOperationLatencyThreshold == 0 {
-		o.UnhealthyOperationLatencyThreshold = 200 * time.Millisecond
+	if o.UnhealthyOperationLatencyThreshold == nil {
+		o.UnhealthyOperationLatencyThreshold = func() time.Duration {
+			return 200 * time.Millisecond
+		}
 	}
 }
 

--- a/wal/failover_manager_test.go
+++ b/wal/failover_manager_test.go
@@ -358,7 +358,7 @@ func TestManagerFailover(t *testing.T) {
 					// Use 75ms to not align with PrimaryDirProbeInterval, to avoid
 					// races.
 					UnhealthySamplingInterval:          75 * time.Millisecond,
-					UnhealthyOperationLatencyThreshold: 50 * time.Millisecond,
+					UnhealthyOperationLatencyThreshold: func() time.Duration { return 50 * time.Millisecond },
 					ElevatedWriteStallThresholdLag:     10 * time.Second,
 					timeSource:                         ts,
 					monitorIterationForTesting:         monitorIterationForTesting,

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -172,7 +172,7 @@ type FailoverOptions struct {
 	UnhealthySamplingInterval time.Duration
 	// UnhealthyOperationLatencyThreshold is the latency threshold that is
 	// considered unhealthy, for operations done by a LogWriter.
-	UnhealthyOperationLatencyThreshold time.Duration
+	UnhealthyOperationLatencyThreshold func() time.Duration
 
 	// ElevatedWriteStallThresholdLag is the duration for which an elevated
 	// threshold should continue after a switch back to the primary dir. This is


### PR DESCRIPTION
Make UnhealthyOperationLatencyThreshold a `func() time.Duration` to allow dynamically modifying the threshold at runtime. This will be used by CockroachDB to tie the setting to a cluster setting.

Informs #3230.