### PR TITLE
wal: delete recovered logs in Open

### DIFF
--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -22,7 +22,7 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     6 |     0     0B     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
 total |     1   709B     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 0B  written: 0B (0% overhead)
+WAL: 0 files (0B)  in: 0B  written: 0B (0% overhead)
 Flushes: 0
 Compactions: 0  estimated debt: 0B  in progress: 0 (0B)
              default: 0  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0

--- a/wal/failover_manager_test.go
+++ b/wal/failover_manager_test.go
@@ -368,7 +368,11 @@ func TestManagerFailover(t *testing.T) {
 				}
 				logs, err := Scan(o.Dirs()...)
 				require.NoError(t, err)
-				err = fm.Init(o, logs)
+				var minUnflushedNum NumWAL
+				if n := logs.MaxNum(); n != 0 {
+					minUnflushedNum = n + 1
+				}
+				err = fm.Init(o, minUnflushedNum)
 				var b strings.Builder
 				fmt.Fprintf(&b, "%s\n", errorToStr(err))
 				if err == nil {

--- a/wal/reader.go
+++ b/wal/reader.go
@@ -86,6 +86,29 @@ func (ll LogicalLog) String() string {
 	return sb.String()
 }
 
+// AppendDeletableLogs appends all of the LogicalLog's constituent physical
+// files as DeletableLogs to dst, returning the modified slice.
+// AppendDeletableLogs will Stat physical files to determine physical sizes.
+// AppendDeletableLogs does not make any judgmenet on whether a log file is
+// obsolete, so callers must take care not to delete logs that are still
+// unflushed.
+func AppendDeletableLogs(dst []DeletableLog, ll LogicalLog) ([]DeletableLog, error) {
+	for i := range ll.segments {
+		fs, path := ll.SegmentLocation(i)
+		stat, err := fs.Stat(path)
+		if err != nil {
+			return dst, err
+		}
+		dst = append(dst, DeletableLog{
+			FS:             fs,
+			Path:           path,
+			NumWAL:         ll.Num,
+			ApproxFileSize: uint64(stat.Size()),
+		})
+	}
+	return dst, nil
+}
+
 // Scan finds all log files in the provided directories. It returns an
 // ordered list of WALs in increasing NumWAL order.
 func Scan(dirs ...Dir) (Logs, error) {
@@ -136,6 +159,14 @@ func (l Logs) Get(num NumWAL) (LogicalLog, bool) {
 		return LogicalLog{}, false
 	}
 	return l[i], true
+}
+
+// MaxNum returns the largest Num in the list of logs.
+func (l Logs) MaxNum() NumWAL {
+	if len(l) == 0 {
+		return 0
+	}
+	return l[len(l)-1].Num
 }
 
 func newVirtualWALReader(wal LogicalLog) *virtualWALReader {

--- a/wal/testdata/manager_failover
+++ b/wal/testdata/manager_failover
@@ -63,12 +63,9 @@ recycler min-log-num: 3
 
 list-and-stats
 ----
-logs:
-  000001: {(pri,000)}
-  000002: {(pri,000)}
 stats:
   obsolete: count 0 size 0
-  live: count 2 size 22
+  live: count 0 size 0
 
 # Wait for monitor ticker to start.
 advance-time dur=1ms wait-monitor
@@ -115,21 +112,16 @@ ok
 list-and-stats
 ----
 logs:
-  000001: {(pri,000)}
-  000002: {(pri,000)}
   000005: {(pri,000)}
   000007: {(pri,000)}
 stats:
   obsolete: count 0 size 0
-  live: count 4 size 56
+  live: count 2 size 34
 
 obsolete min-unflushed=7
 ----
 ok
 recycler non-empty, front filenum: 5 size: 18
-to delete:
-  wal 1: path: pri/000001.log size: 11
-  wal 2: path: pri/000002.log size: 11
 
 obsolete min-unflushed=8 no-recycle
 ----

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -249,7 +249,7 @@ type Stats struct {
 //     the caller does it via commitPipeline.mu).
 type Manager interface {
 	// Init initializes the Manager.
-	Init(o Options, initial Logs) error
+	Init(o Options, minRecycleLogNum NumWAL) error
 	// List returns the virtual WALs in ascending order.
 	List() (Logs, error)
 	// Obsolete informs the manager that all virtual WALs less than


### PR DESCRIPTION
Adjust the Open logic to delete logs discovered on Open without ever propagating them to the WAL manager. This has the advantage that each WAL manager queue only needs to maintain information about WALs of the type that it creates. For example, if WAL failover was previously enabled but is no longer, any logical WALs that are split across multiple physical files will be deleted by Open and never need to enter the standalone manager's log queue.