### PR TITLE
wal: handle initial obsolete logs

### DIFF
--- a/open_test.go
+++ b/open_test.go
@@ -595,7 +595,7 @@ func TestOpenWALReplay(t *testing.T) {
 
 			if readOnly {
 				m := d.Metrics()
-				require.Equal(t, int64(logCount), m.WAL.Files)
+				require.Equal(t, int64(logCount), m.WAL.ObsoleteFiles)
 				d.mu.Lock()
 				require.NotNil(t, d.mu.mem.mutable)
 				d.mu.Unlock()

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -22,7 +22,7 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     6 |     0     0B     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
 total |     1   709B     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 0B  written: 0B (0% overhead)
+WAL: 0 files (0B)  in: 0B  written: 0B (0% overhead)
 Flushes: 0
 Compactions: 0  estimated debt: 0B  in progress: 0 (0B)
              default: 0  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0

--- a/wal/testdata/manager_failover
+++ b/wal/testdata/manager_failover
@@ -63,12 +63,9 @@ recycler min-log-num: 3
 
 list-and-stats
 ----
-logs:
-  000001: {(pri,000)}
-  000002: {(pri,000)}
 stats:
-  obsolete: count 0 size 0
-  live: count 2 size 22
+  obsolete: count 2 size 22
+  live: count 0 size 0
 
 # Wait for monitor ticker to start.
 advance-time dur=1ms wait-monitor
@@ -115,13 +112,11 @@ ok
 list-and-stats
 ----
 logs:
-  000001: {(pri,000)}
-  000002: {(pri,000)}
   000005: {(pri,000)}
   000007: {(pri,000)}
 stats:
-  obsolete: count 0 size 0
-  live: count 4 size 56
+  obsolete: count 2 size 22
+  live: count 2 size 34
 
 obsolete min-unflushed=7
 ----


### PR DESCRIPTION
During Open, there may exist log files that were constructed from a previous WAL configuration. Adjust both the standalone and failover WAL managers to account for WALs of a kind other than their own by separately recording these initial logs as obsolete.

Informs #3230

Informs [CRDB-35401](https://cockroachlabs.atlassian.net/browse/CRDB-35401)