### PR TITLE
base: improve Comparer documentation and usability

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -707,7 +707,7 @@ func newCompaction(
 	c := &compaction{
 		kind:              compactionKindDefault,
 		cmp:               pc.cmp,
-		equal:             opts.equal(),
+		equal:             opts.Comparer.Equal,
 		comparer:          opts.Comparer,
 		formatKey:         opts.Comparer.FormatKey,
 		inputs:            pc.inputs,
@@ -782,7 +782,7 @@ func newDeleteOnlyCompaction(
 	c := &compaction{
 		kind:      compactionKindDeleteOnly,
 		cmp:       opts.Comparer.Compare,
-		equal:     opts.equal(),
+		equal:     opts.Comparer.Equal,
 		comparer:  opts.Comparer,
 		formatKey: opts.Comparer.FormatKey,
 		logger:    opts.Logger,
@@ -873,7 +873,7 @@ func newFlush(
 	c := &compaction{
 		kind:              compactionKindFlush,
 		cmp:               opts.Comparer.Compare,
-		equal:             opts.equal(),
+		equal:             opts.Comparer.Equal,
 		comparer:          opts.Comparer,
 		formatKey:         opts.Comparer.FormatKey,
 		logger:            opts.Logger,

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1897,16 +1897,21 @@ func TestIngestExternal(t *testing.T) {
 
 func TestIngestMemtableOverlaps(t *testing.T) {
 	comparers := []Comparer{
-		{Name: "default", Compare: DefaultComparer.Compare, FormatKey: DefaultComparer.FormatKey},
 		{
-			Name:      "reverse",
-			Compare:   func(a, b []byte) int { return DefaultComparer.Compare(b, a) },
-			FormatKey: DefaultComparer.FormatKey,
+			Name:    "default",
+			Compare: DefaultComparer.Compare,
+		},
+		{
+			Name:    "reverse",
+			Compare: func(a, b []byte) int { return DefaultComparer.Compare(b, a) },
 		},
 	}
 	m := make(map[string]*Comparer)
 	for i := range comparers {
 		c := &comparers[i]
+		c.AbbreviatedKey = func(key []byte) uint64 { panic("unimplemented") }
+		c.Successor = func(dst, a []byte) []byte { panic("unimplemented") }
+		c.Separator = func(dst, a, b []byte) []byte { panic("unimplemented") }
 		m[c.Name] = c
 	}
 

--- a/internal/base/comparer.go
+++ b/internal/base/comparer.go
@@ -161,6 +161,9 @@ func (c *Comparer) EnsureDefaults() *Comparer {
 	if c == nil {
 		return DefaultComparer
 	}
+	if c.Compare == nil || c.AbbreviatedKey == nil || c.Separator == nil || c.Successor == nil || c.Name == "" {
+		panic("invalid Comparer: mandatory field not set")
+	}
 	if c.Equal != nil && c.FormatKey != nil {
 		return c
 	}

--- a/open.go
+++ b/open.go
@@ -201,7 +201,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 		dirname:             dirname,
 		opts:                opts,
 		cmp:                 opts.Comparer.Compare,
-		equal:               opts.equal(),
+		equal:               opts.Comparer.Equal,
 		merge:               opts.Merger.Merge,
 		split:               opts.Comparer.Split,
 		abbreviatedKey:      opts.Comparer.AbbreviatedKey,

--- a/open_test.go
+++ b/open_test.go
@@ -348,8 +348,11 @@ func TestOpenOptionsCheck(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, d.Close())
 
+	fooCmp := *base.DefaultComparer
+	fooCmp.Name = "foo"
+
 	opts = &Options{
-		Comparer: &Comparer{Name: "foo"},
+		Comparer: &fooCmp,
 		FS:       mem,
 	}
 	_, err = Open("", opts)

--- a/options.go
+++ b/options.go
@@ -1072,15 +1072,15 @@ func (o *Options) EnsureDefaults() *Options {
 	if o == nil {
 		o = &Options{}
 	}
+	o.Comparer = o.Comparer.EnsureDefaults()
+
 	if o.BytesPerSync <= 0 {
 		o.BytesPerSync = 512 << 10 // 512 KB
 	}
 	if o.Cleaner == nil {
 		o.Cleaner = DeleteCleaner{}
 	}
-	if o.Comparer == nil {
-		o.Comparer = DefaultComparer
-	}
+
 	if o.Experimental.DisableIngestAsFlushable == nil {
 		o.Experimental.DisableIngestAsFlushable = func() bool { return false }
 	}
@@ -1230,13 +1230,6 @@ func (o *Options) AddEventListener(l EventListener) {
 		l = TeeEventListener(l, *o.EventListener)
 	}
 	o.EventListener = &l
-}
-
-func (o *Options) equal() Equal {
-	if o.Comparer.Equal == nil {
-		return bytes.Equal
-	}
-	return o.Comparer.Equal
 }
 
 // initMaps initializes the Comparers, Filters, and Mergers maps.


### PR DESCRIPTION
#### base: improve Comparer documentation and usability

This change documents the fields of `Comparer` and adds code to fill
in `Equal` and `FormatKey` fields with reasonable defaults (replacing
the `equals` wrapper; note that the wrapper used `bytes.Equal` as the
default whereas we now fall back to `Compare` instead).

Note that `FormatKey` is used unconditionally in various error
messages.

I am investigating separately adding a default for `Split` as well.

#### base: verify all mandatory Comparer fields are set
