### PR TITLE
manifest: store comparer in Version

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -733,7 +733,7 @@ func newCompaction(
 	// Compute the set of outputLevel+1 files that overlap this compaction (these
 	// are the grandparent sstables).
 	if c.outputLevel.level+1 < numLevels {
-		c.grandparents = c.version.Overlaps(c.outputLevel.level+1, c.cmp,
+		c.grandparents = c.version.Overlaps(c.outputLevel.level+1,
 			c.smallest.UserKey, c.largest.UserKey, c.largest.IsExclusiveSentinel())
 	}
 	c.setupInuseKeyRanges()
@@ -972,7 +972,7 @@ func newFlush(
 	if opts.FlushSplitBytes > 0 {
 		c.maxOutputFileSize = uint64(opts.Level(0).TargetFileSize)
 		c.maxOverlapBytes = maxGrandparentOverlapBytes(opts, 0)
-		c.grandparents = c.version.Overlaps(baseLevel, c.cmp, c.smallest.UserKey,
+		c.grandparents = c.version.Overlaps(baseLevel, c.smallest.UserKey,
 			c.largest.UserKey, c.largest.IsExclusiveSentinel())
 		adjustGrandparentOverlapBytesForFlush(c, flushingBytes)
 	}
@@ -1002,7 +1002,7 @@ func (c *compaction) setupInuseKeyRanges() {
 	// calculateInuseKeyRanges will return a series of sorted spans. Overlapping
 	// or abutting spans have already been merged.
 	c.inuseKeyRanges = c.version.CalculateInuseKeyRanges(
-		c.cmp, level, numLevels-1, c.smallest.UserKey, c.largest.UserKey,
+		level, numLevels-1, c.smallest.UserKey, c.largest.UserKey,
 	)
 	// Check if there's a single in-use span that encompasses the entire key
 	// range of the compaction. This is an optimization to avoid key comparisons
@@ -2176,7 +2176,7 @@ func (d *DB) maybeScheduleDownloadCompaction(env compactionEnv, maxConcurrentCom
 		var err error
 		var level int
 		for i := range v.Levels {
-			overlaps := v.Overlaps(i, d.cmp, download.start, download.end, true /* exclusiveEnd */)
+			overlaps := v.Overlaps(i, download.start, download.end, true /* exclusiveEnd */)
 			iter := overlaps.Iter()
 			provider := d.objProvider
 			for f := iter.First(); f != nil; f = iter.Next() {
@@ -2565,7 +2565,7 @@ func checkDeleteCompactionHints(
 		// The hint h will be resolved and dropped, regardless of whether
 		// there are any tables that can be deleted.
 		for l := h.tombstoneLevel + 1; l < numLevels; l++ {
-			overlaps := v.Overlaps(l, cmp, h.start, h.end, true /* exclusiveEnd */)
+			overlaps := v.Overlaps(l, h.start, h.end, true /* exclusiveEnd */)
 			iter := overlaps.Iter()
 			for m := iter.First(); m != nil; m = iter.Next() {
 				if m.IsCompacting() || !h.canDelete(cmp, m, snapshots) || files[m] {

--- a/compaction.go
+++ b/compaction.go
@@ -707,7 +707,7 @@ func newCompaction(
 	c := &compaction{
 		kind:              compactionKindDefault,
 		cmp:               pc.cmp,
-		equal:             opts.equal(),
+		equal:             opts.Comparer.Equal,
 		comparer:          opts.Comparer,
 		formatKey:         opts.Comparer.FormatKey,
 		inputs:            pc.inputs,
@@ -782,7 +782,7 @@ func newDeleteOnlyCompaction(
 	c := &compaction{
 		kind:      compactionKindDeleteOnly,
 		cmp:       opts.Comparer.Compare,
-		equal:     opts.equal(),
+		equal:     opts.Comparer.Equal,
 		comparer:  opts.Comparer,
 		formatKey: opts.Comparer.FormatKey,
 		logger:    opts.Logger,
@@ -873,7 +873,7 @@ func newFlush(
 	c := &compaction{
 		kind:              compactionKindFlush,
 		cmp:               opts.Comparer.Compare,
-		equal:             opts.equal(),
+		equal:             opts.Comparer.Equal,
 		comparer:          opts.Comparer,
 		formatKey:         opts.Comparer.FormatKey,
 		logger:            opts.Logger,

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -420,7 +420,7 @@ func (pc *pickedCompaction) setupInputs(
 	// sstables. No need to do this for intra-L0 compactions; outputLevel.files is
 	// left empty for those.
 	if startLevel.level != pc.outputLevel.level {
-		pc.outputLevel.files = pc.version.Overlaps(pc.outputLevel.level, pc.cmp, pc.smallest.UserKey,
+		pc.outputLevel.files = pc.version.Overlaps(pc.outputLevel.level, pc.smallest.UserKey,
 			pc.largest.UserKey, pc.largest.IsExclusiveSentinel())
 		if anyTablesCompacting(pc.outputLevel.files) {
 			return false
@@ -514,7 +514,7 @@ func (pc *pickedCompaction) grow(
 	if pc.outputLevel.files.Empty() {
 		return false
 	}
-	grow0 := pc.version.Overlaps(startLevel.level, pc.cmp, sm.UserKey,
+	grow0 := pc.version.Overlaps(startLevel.level, sm.UserKey,
 		la.UserKey, la.IsExclusiveSentinel())
 	if anyTablesCompacting(grow0) {
 		return false
@@ -528,7 +528,7 @@ func (pc *pickedCompaction) grow(
 	// We need to include the outputLevel iter because without it, in a multiLevel scenario,
 	// sm1 and la1 could shift the output level keyspace when pc.outputLevel.files is set to grow1.
 	sm1, la1 := manifest.KeyRange(pc.cmp, grow0.Iter(), pc.outputLevel.files.Iter())
-	grow1 := pc.version.Overlaps(pc.outputLevel.level, pc.cmp, sm1.UserKey,
+	grow1 := pc.version.Overlaps(pc.outputLevel.level, sm1.UserKey,
 		la1.UserKey, la1.IsExclusiveSentinel())
 	if anyTablesCompacting(grow1) {
 		return false
@@ -1560,7 +1560,7 @@ func pickAutoLPositive(
 	if pc.startLevel.level == 0 {
 		cmp := opts.Comparer.Compare
 		smallest, largest := manifest.KeyRange(cmp, pc.startLevel.files.Iter())
-		pc.startLevel.files = vers.Overlaps(0, cmp, smallest.UserKey,
+		pc.startLevel.files = vers.Overlaps(0, smallest.UserKey,
 			largest.UserKey, largest.IsExclusiveSentinel())
 		if pc.startLevel.files.Empty() {
 			panic("pebble: empty compaction")
@@ -1768,7 +1768,7 @@ func pickManualCompaction(
 	}
 	pc = newPickedCompaction(opts, vers, manual.level, defaultOutputLevel(manual.level, baseLevel), baseLevel)
 	manual.outputLevel = pc.outputLevel.level
-	pc.startLevel.files = vers.Overlaps(manual.level, opts.Comparer.Compare, manual.start, manual.end, false)
+	pc.startLevel.files = vers.Overlaps(manual.level, manual.start, manual.end, false)
 	if pc.startLevel.files.Empty() {
 		// Nothing to do
 		return nil, false
@@ -1854,8 +1854,7 @@ func (p *compactionPickerByScore) pickReadTriggeredCompaction(
 func pickReadTriggeredCompactionHelper(
 	p *compactionPickerByScore, rc *readCompaction, env compactionEnv,
 ) (pc *pickedCompaction) {
-	cmp := p.opts.Comparer.Compare
-	overlapSlice := p.vers.Overlaps(rc.level, cmp, rc.start, rc.end, false /* exclusiveEnd */)
+	overlapSlice := p.vers.Overlaps(rc.level, rc.start, rc.end, false /* exclusiveEnd */)
 	if overlapSlice.Empty() {
 		// If there is no overlap, then the file with the key range
 		// must have been compacted away. So, we don't proceed to
@@ -1888,7 +1887,7 @@ func pickReadTriggeredCompactionHelper(
 
 	// Prevent read compactions which are too wide.
 	outputOverlaps := pc.version.Overlaps(
-		pc.outputLevel.level, pc.cmp, pc.smallest.UserKey,
+		pc.outputLevel.level, pc.smallest.UserKey,
 		pc.largest.UserKey, pc.largest.IsExclusiveSentinel())
 	if outputOverlaps.SizeSum() > pc.maxReadCompactionBytes {
 		return nil

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -501,9 +501,8 @@ func TestCompactionPickerL0(t *testing.T) {
 			version := newVersion(opts, fileMetas)
 			version.L0Sublevels.InitCompactingFileInfo(inProgressL0Compactions(inProgressCompactions))
 			vs := &versionSet{
-				opts:    opts,
-				cmp:     DefaultComparer.Compare,
-				cmpName: DefaultComparer.Name,
+				opts: opts,
+				cmp:  DefaultComparer,
 			}
 			vs.versions.Init(nil)
 			vs.append(version)
@@ -725,9 +724,8 @@ func TestCompactionPickerConcurrency(t *testing.T) {
 			version := newVersion(opts, fileMetas)
 			version.L0Sublevels.InitCompactingFileInfo(inProgressL0Compactions(inProgressCompactions))
 			vs := &versionSet{
-				opts:    opts,
-				cmp:     DefaultComparer.Compare,
-				cmpName: DefaultComparer.Name,
+				opts: opts,
+				cmp:  DefaultComparer,
 			}
 			vs.versions.Init(nil)
 			vs.append(version)
@@ -843,9 +841,8 @@ func TestCompactionPickerPickReadTriggered(t *testing.T) {
 
 			vers = newVersion(opts, fileMetas)
 			vs := &versionSet{
-				opts:    opts,
-				cmp:     DefaultComparer.Compare,
-				cmpName: DefaultComparer.Name,
+				opts: opts,
+				cmp:  DefaultComparer,
 			}
 			vs.versions.Init(nil)
 			vs.append(vers)
@@ -1049,7 +1046,7 @@ func TestPickedCompactionSetupInputs(t *testing.T) {
 				pc.outputLevel.level = pc.startLevel.level + 1
 			}
 			pc.version = newVersion(opts, files)
-			pc.startLevel.files = pc.version.Overlaps(pc.startLevel.level, pc.cmp,
+			pc.startLevel.files = pc.version.Overlaps(pc.startLevel.level,
 				[]byte(args[0].String()), []byte(args[1].String()), false /* exclusiveEnd */)
 
 			var isCompacting bool
@@ -1263,9 +1260,8 @@ func TestCompactionOutputFileSize(t *testing.T) {
 
 			vers = newVersion(opts, fileMetas)
 			vs := &versionSet{
-				opts:    opts,
-				cmp:     DefaultComparer.Compare,
-				cmpName: DefaultComparer.Name,
+				opts: opts,
+				cmp:  DefaultComparer,
 			}
 			vs.versions.Init(nil)
 			vs.append(vers)

--- a/data_test.go
+++ b/data_test.go
@@ -1337,7 +1337,7 @@ func runLSMCmd(td *datadriven.TestData, d *DB) string {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if td.HasArg("verbose") {
-		return d.mu.versions.currentVersion().DebugString(d.opts.Comparer.FormatKey)
+		return d.mu.versions.currentVersion().DebugString()
 	}
 	return d.mu.versions.currentVersion().String()
 }

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -379,7 +379,7 @@ func TestGetIter(t *testing.T) {
 		},
 	}
 
-	cmp := testkeys.Comparer.Compare
+	cmp := testkeys.Comparer
 	for _, tc := range testCases {
 		desc := tc.description[:strings.Index(tc.description, ":")]
 
@@ -412,7 +412,7 @@ func TestGetIter(t *testing.T) {
 					t.Fatalf("desc=%q: memtable Set: %v", desc, err)
 				}
 
-				meta.ExtendPointKeyBounds(cmp, ikey, ikey)
+				meta.ExtendPointKeyBounds(cmp.Compare, ikey, ikey)
 				if i == 0 {
 					meta.SmallestSeqNum = ikey.SeqNum()
 					meta.LargestSeqNum = ikey.SeqNum()
@@ -428,8 +428,8 @@ func TestGetIter(t *testing.T) {
 
 			files[tt.level] = append(files[tt.level], meta)
 		}
-		v := manifest.NewVersion(cmp, base.DefaultFormatter, 10<<20, files)
-		err := v.CheckOrdering(cmp, base.DefaultFormatter)
+		v := manifest.NewVersion(cmp, 10<<20, files)
+		err := v.CheckOrdering()
 		if tc.badOrdering && err == nil {
 			t.Errorf("desc=%q: want bad ordering, got nil error", desc)
 			continue

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -3624,6 +3624,6 @@ func runBenchmarkManySSTablesInUseKeyRanges(b *testing.B, d *DB, count int) {
 	smallest := []byte("0")
 	largest := []byte("z")
 	for i := 0; i < b.N; i++ {
-		_ = v.CalculateInuseKeyRanges(d.cmp, 0, numLevels-1, smallest, largest)
+		_ = v.CalculateInuseKeyRanges(0, numLevels-1, smallest, largest)
 	}
 }

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1897,16 +1897,21 @@ func TestIngestExternal(t *testing.T) {
 
 func TestIngestMemtableOverlaps(t *testing.T) {
 	comparers := []Comparer{
-		{Name: "default", Compare: DefaultComparer.Compare, FormatKey: DefaultComparer.FormatKey},
 		{
-			Name:      "reverse",
-			Compare:   func(a, b []byte) int { return DefaultComparer.Compare(b, a) },
-			FormatKey: DefaultComparer.FormatKey,
+			Name:    "default",
+			Compare: DefaultComparer.Compare,
+		},
+		{
+			Name:    "reverse",
+			Compare: func(a, b []byte) int { return DefaultComparer.Compare(b, a) },
 		},
 	}
 	m := make(map[string]*Comparer)
 	for i := range comparers {
 		c := &comparers[i]
+		c.AbbreviatedKey = func(key []byte) uint64 { panic("unimplemented") }
+		c.Successor = func(dst, a []byte) []byte { panic("unimplemented") }
+		c.Separator = func(dst, a, b []byte) []byte { panic("unimplemented") }
 		m[c.Name] = c
 	}
 

--- a/internal/base/comparer.go
+++ b/internal/base/comparer.go
@@ -161,6 +161,9 @@ func (c *Comparer) EnsureDefaults() *Comparer {
 	if c == nil {
 		return DefaultComparer
 	}
+	if c.Compare == nil || c.AbbreviatedKey == nil || c.Separator == nil || c.Successor == nil || c.Name == "" {
+		panic("invalid Comparer: mandatory field not set")
+	}
 	if c.Equal != nil && c.FormatKey != nil {
 		return c
 	}

--- a/internal/keyspan/keyspanimpl/level_iter_test.go
+++ b/internal/keyspan/keyspanimpl/level_iter_test.go
@@ -310,7 +310,7 @@ func TestLevelIterEquivalence(t *testing.T) {
 				amap[metas[i].FileNum] = metas[i]
 			}
 			b.Added[6] = amap
-			v, err := b.Apply(nil, base.DefaultComparer.Compare, base.DefaultFormatter, 0, 0, nil)
+			v, err := b.Apply(nil, base.DefaultComparer, 0, 0, nil)
 			require.NoError(t, err)
 			levelIter.Init(
 				keyspan.SpanIterOptions{}, base.DefaultComparer.Compare, tableNewIters,
@@ -454,7 +454,7 @@ func TestLevelIter(t *testing.T) {
 					amap[metas[i].FileNum] = metas[i]
 				}
 				b.Added[6] = amap
-				v, err := b.Apply(nil, base.DefaultComparer.Compare, base.DefaultFormatter, 0, 0, nil)
+				v, err := b.Apply(nil, base.DefaultComparer, 0, 0, nil)
 				require.NoError(t, err)
 				iter = NewLevelIter(
 					keyspan.SpanIterOptions{}, base.DefaultComparer.Compare,

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -51,7 +51,7 @@ func readManifest(filename string) (*Version, error) {
 		if err := bve.Accumulate(&ve); err != nil {
 			return nil, err
 		}
-		if v, err = bve.Apply(v, base.DefaultComparer.Compare, base.DefaultFormatter, 10<<20, 32000, nil); err != nil {
+		if v, err = bve.Apply(v, base.DefaultComparer, 10<<20, 32000, nil); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -41,7 +41,7 @@ func TestInuseKeyRangesRandomized(t *testing.T) {
 	}
 	t.Log("Constructed test database state")
 	v := replayManifest(t, testOpts.Opts, "")
-	t.Log(v.DebugString(base.DefaultFormatter))
+	t.Log(v.DebugString())
 
 	const maxKeyLen = 12
 	const maxSuffix = 20
@@ -59,14 +59,14 @@ func TestInuseKeyRangesRandomized(t *testing.T) {
 
 		level := rng.Intn(manifest.NumLevels)
 		cmp := testOpts.Opts.Comparer.Compare
-		keyRanges := v.CalculateInuseKeyRanges(cmp, level, manifest.NumLevels-1, smallest, largest)
+		keyRanges := v.CalculateInuseKeyRanges(level, manifest.NumLevels-1, smallest, largest)
 		t.Logf("%d: [%s, %s] levels L%d-L6: ", i, smallest, largest, level)
 		for _, kr := range keyRanges {
 			t.Logf("  [%s,%s]", kr.Start, kr.End)
 		}
 
 		for l := level; l < manifest.NumLevels; l++ {
-			o := v.Overlaps(l, cmp, smallest, largest, false /* exclusiveEnd */)
+			o := v.Overlaps(l, smallest, largest, false /* exclusiveEnd */)
 			iter := o.Iter()
 			for f := iter.First(); f != nil; f = iter.Next() {
 				// CalculateInuseKeyRanges only guarantees that it returns key
@@ -123,7 +123,7 @@ func replayManifest(t *testing.T, opts *pebble.Options, dirname string) *manifes
 		require.NoError(t, bve.Accumulate(&ve))
 	}
 	v, err := bve.Apply(
-		nil /* version */, cmp.Compare, base.DefaultFormatter, opts.FlushSplitBytes,
+		nil /* version */, cmp, opts.FlushSplitBytes,
 		opts.Experimental.ReadCompactionRate, nil /* zombies */)
 	require.NoError(t, err)
 	return v

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -486,7 +486,7 @@ func TestVersionEditApply(t *testing.T) {
 							}
 							if isVersion {
 								if v == nil {
-									v = new(Version)
+									v = &Version{cmp: base.DefaultComparer}
 									for l := 0; l < NumLevels; l++ {
 										v.Levels[l] = makeLevelMetadata(base.DefaultComparer.Compare, l, nil /* files */)
 									}
@@ -512,8 +512,9 @@ func TestVersionEditApply(t *testing.T) {
 					}
 				}
 
+				const flushSplitBytes = 10 * 1024 * 1024
 				if v != nil {
-					if err := v.InitL0Sublevels(base.DefaultComparer.Compare, base.DefaultFormatter, 10<<20); err != nil {
+					if err := v.InitL0Sublevels(flushSplitBytes); err != nil {
 						return err.Error()
 					}
 				}
@@ -526,7 +527,7 @@ func TestVersionEditApply(t *testing.T) {
 					}
 				}
 				zombies := make(map[base.DiskFileNum]uint64)
-				newv, err := bve.Apply(v, base.DefaultComparer.Compare, base.DefaultFormatter, 10<<20, 32000, zombies)
+				newv, err := bve.Apply(v, base.DefaultComparer, flushSplitBytes, 32000, zombies)
 				if err != nil {
 					return err.Error()
 				}

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -252,8 +252,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 				files[i+1] = levels[i]
 			}
 			version := manifest.NewVersion(
-				base.DefaultComparer.Compare,
-				base.DefaultFormatter,
+				base.DefaultComparer,
 				0,
 				files)
 			readState := &readState{current: version}

--- a/open.go
+++ b/open.go
@@ -201,7 +201,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 		dirname:             dirname,
 		opts:                opts,
 		cmp:                 opts.Comparer.Compare,
-		equal:               opts.equal(),
+		equal:               opts.Comparer.Equal,
 		merge:               opts.Merger.Merge,
 		split:               opts.Comparer.Split,
 		abbreviatedKey:      opts.Comparer.AbbreviatedKey,

--- a/open_test.go
+++ b/open_test.go
@@ -1245,8 +1245,6 @@ func TestCheckConsistency(t *testing.T) {
 	require.NoError(t, err)
 	defer provider.Close()
 
-	cmp := base.DefaultComparer.Compare
-	fmtKey := base.DefaultComparer.FormatKey
 	parseMeta := func(s string) (*manifest.FileMetadata, error) {
 		if len(s) == 0 {
 			return nil, nil
@@ -1308,7 +1306,7 @@ func TestCheckConsistency(t *testing.T) {
 					}
 				}
 
-				v := manifest.NewVersion(cmp, fmtKey, 0, filesByLevel)
+				v := manifest.NewVersion(base.DefaultComparer, 0, filesByLevel)
 				err := checkConsistency(v, dir, provider)
 				if err != nil {
 					if redactErr {

--- a/open_test.go
+++ b/open_test.go
@@ -348,8 +348,11 @@ func TestOpenOptionsCheck(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, d.Close())
 
+	fooCmp := *base.DefaultComparer
+	fooCmp.Name = "foo"
+
 	opts = &Options{
-		Comparer: &Comparer{Name: "foo"},
+		Comparer: &fooCmp,
 		FS:       mem,
 	}
 	_, err = Open("", opts)

--- a/options.go
+++ b/options.go
@@ -1072,15 +1072,15 @@ func (o *Options) EnsureDefaults() *Options {
 	if o == nil {
 		o = &Options{}
 	}
+	o.Comparer = o.Comparer.EnsureDefaults()
+
 	if o.BytesPerSync <= 0 {
 		o.BytesPerSync = 512 << 10 // 512 KB
 	}
 	if o.Cleaner == nil {
 		o.Cleaner = DeleteCleaner{}
 	}
-	if o.Comparer == nil {
-		o.Comparer = DefaultComparer
-	}
+
 	if o.Experimental.DisableIngestAsFlushable == nil {
 		o.Experimental.DisableIngestAsFlushable = func() bool { return false }
 	}
@@ -1230,13 +1230,6 @@ func (o *Options) AddEventListener(l EventListener) {
 		l = TeeEventListener(l, *o.EventListener)
 	}
 	o.EventListener = &l
-}
-
-func (o *Options) equal() Equal {
-	if o.Comparer.Equal == nil {
-		return bytes.Equal
-	}
-	return o.Comparer.Equal
 }
 
 // initMaps initializes the Comparers, Filters, and Mergers maps.

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -714,8 +714,7 @@ func (r *Runner) prepareWorkloadSteps(ctx context.Context) error {
 	currentVersion := func() (*manifest.Version, error) {
 		var err error
 		v, err = bve.Apply(v,
-			r.Opts.Comparer.Compare,
-			r.Opts.Comparer.FormatKey,
+			r.Opts.Comparer,
 			r.Opts.FlushSplitBytes,
 			r.Opts.Experimental.ReadCompactionRate,
 			nil /* zombies */)

--- a/table_stats.go
+++ b/table_stats.go
@@ -149,7 +149,7 @@ func (d *DB) collectTableStats() bool {
 		v := d.mu.versions.currentVersion()
 		keepHints := hints[:0]
 		for _, h := range hints {
-			if v.Contains(h.tombstoneLevel, d.cmp, h.tombstoneFile) {
+			if v.Contains(h.tombstoneLevel, h.tombstoneFile) {
 				keepHints = append(keepHints, h)
 			}
 		}
@@ -185,7 +185,7 @@ func (d *DB) loadNewFileStats(
 		// The file isn't guaranteed to still be live in the readState's
 		// version. It may have been deleted or moved. Skip it if it's not in
 		// the expected level.
-		if !rs.current.Contains(nf.Level, d.cmp, nf.Meta) {
+		if !rs.current.Contains(nf.Level, nf.Meta) {
 			continue
 		}
 
@@ -500,7 +500,7 @@ func (d *DB) estimateSizesBeneath(
 	}
 
 	for l := level + 1; l < numLevels; l++ {
-		overlaps := v.Overlaps(l, d.cmp, meta.Smallest.UserKey,
+		overlaps := v.Overlaps(l, meta.Smallest.UserKey,
 			meta.Largest.UserKey, meta.Largest.IsExclusiveSentinel())
 		iter := overlaps.Iter()
 		for file = iter.First(); file != nil; file = iter.Next() {
@@ -553,7 +553,7 @@ func (d *DB) estimateReclaimedSizeBeneath(
 	// additional I/O to read the file's index blocks.
 	hintSeqNum = math.MaxUint64
 	for l := level + 1; l < numLevels; l++ {
-		overlaps := v.Overlaps(l, d.cmp, start, end, true /* exclusiveEnd */)
+		overlaps := v.Overlaps(l, start, end, true /* exclusiveEnd */)
 		iter := overlaps.Iter()
 		for file := iter.First(); file != nil; file = iter.Next() {
 			startCmp := d.cmp(start, file.Smallest.UserKey)

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -191,7 +191,7 @@ func TestTableStats(t *testing.T) {
 
 func TestTableRangeDeletionIter(t *testing.T) {
 	var m *fileMetadata
-	cmp := base.DefaultComparer.Compare
+	cmp := base.DefaultComparer
 	fs := vfs.NewMem()
 	datadriven.RunTest(t, "testdata/table_stats_deletion_iter", func(t *testing.T, td *datadriven.TestData) string {
 		switch cmd := td.Cmd; cmd {
@@ -233,15 +233,15 @@ func TestTableRangeDeletionIter(t *testing.T) {
 				return err.Error()
 			}
 			if meta.HasPointKeys {
-				m.ExtendPointKeyBounds(cmp, meta.SmallestPoint, meta.LargestPoint)
+				m.ExtendPointKeyBounds(cmp.Compare, meta.SmallestPoint, meta.LargestPoint)
 			}
 			if meta.HasRangeDelKeys {
-				m.ExtendPointKeyBounds(cmp, meta.SmallestRangeDel, meta.LargestRangeDel)
+				m.ExtendPointKeyBounds(cmp.Compare, meta.SmallestRangeDel, meta.LargestRangeDel)
 			}
 			if meta.HasRangeKeys {
-				m.ExtendRangeKeyBounds(cmp, meta.SmallestRangeKey, meta.LargestRangeKey)
+				m.ExtendRangeKeyBounds(cmp.Compare, meta.SmallestRangeKey, meta.LargestRangeKey)
 			}
-			return m.DebugString(base.DefaultFormatter, false /* verbose */)
+			return m.DebugString(cmp.FormatKey, false /* verbose */)
 		case "spans":
 			f, err := fs.Open("tmp.sst")
 			if err != nil {
@@ -257,7 +257,7 @@ func TestTableRangeDeletionIter(t *testing.T) {
 				return err.Error()
 			}
 			defer r.Close()
-			iter, err := newCombinedDeletionKeyspanIter(base.DefaultComparer, r, m)
+			iter, err := newCombinedDeletionKeyspanIter(cmp, r, m)
 			if err != nil {
 				return err.Error()
 			}

--- a/tool/db.go
+++ b/tool/db.go
@@ -529,7 +529,7 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 			}
 		}
 		v, err := bve.Apply(
-			nil /* version */, cmp.Compare, d.fmtKey.fn, d.opts.FlushSplitBytes,
+			nil /* version */, cmp, d.opts.FlushSplitBytes,
 			d.opts.Experimental.ReadCompactionRate, nil, /* zombies */
 		)
 		if err != nil {

--- a/tool/lsm.go
+++ b/tool/lsm.go
@@ -232,7 +232,9 @@ func (l *lsmT) readManifest(path string) []*manifest.VersionEdit {
 			}
 			l.fmtKey.setForComparer(ve.ComparerName, l.comparers)
 		} else if l.cmp == nil {
-			l.cmp = base.DefaultComparer
+			l.cmp = &base.Comparer{}
+			*l.cmp = *base.DefaultComparer
+			l.cmp.FormatKey = l.fmtKey.fn
 		}
 	}
 	return edits
@@ -320,7 +322,7 @@ func (l *lsmT) buildEdits(edits []*manifest.VersionEdit) error {
 			}
 		}
 
-		v := manifest.NewVersion(l.cmp.Compare, l.fmtKey.fn, 0, currentFiles)
+		v := manifest.NewVersion(l.cmp, 0, currentFiles)
 		edit.Sublevels = make(map[base.FileNum]int)
 		for sublevel, files := range v.L0SublevelFiles {
 			iter := files.Iter()

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -242,7 +242,7 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 
 			if comparer != nil {
 				v, err := bve.Apply(
-					nil /* version */, comparer.Compare, m.fmtKey.fn, 0,
+					nil /* version */, comparer, 0,
 					m.opts.Experimental.ReadCompactionRate,
 					nil, /* zombies */
 				)
@@ -552,7 +552,7 @@ func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
 				}
 				// TODO(sbhola): add option to Apply that reports all errors instead of
 				// one error.
-				newv, err := bve.Apply(v, cmp.Compare, m.fmtKey.fn, 0, m.opts.Experimental.ReadCompactionRate, nil /* zombies */)
+				newv, err := bve.Apply(v, cmp, 0, m.opts.Experimental.ReadCompactionRate, nil /* zombies */)
 				if err != nil {
 					fmt.Fprintf(stdout, "%s: offset: %d err: %s\n",
 						arg, offset, err)


### PR DESCRIPTION
This PR is only for the top commit (the rest is #3346).

The `Version` and `VersionEdit` code has a ton of `Compare` and
`FormatKey` arguments passed around. We simplify all this code by
storing a `*base.Comparer` reference in `Version` and `versionSet`.