### PR TITLE
allow replication of external files

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -1268,7 +1268,7 @@ func runIngestAndExciseCmd(td *datadriven.TestData, d *DB, fs vfs.FS) error {
 		}
 	}
 
-	if _, err := d.IngestAndExcise(paths, nil /* shared */, exciseSpan); err != nil {
+	if _, err := d.IngestAndExcise(paths, nil /* shared */, nil /* external */, exciseSpan); err != nil {
 		return err
 	}
 	return nil

--- a/db.go
+++ b/db.go
@@ -1244,14 +1244,15 @@ func (d *DB) ScanInternal(
 	visitRangeDel func(start, end []byte, seqNum uint64) error,
 	visitRangeKey func(start, end []byte, keys []rangekey.Key) error,
 	visitSharedFile func(sst *SharedSSTMeta) error,
+	visitExternalFile func(sst *ExternalFile) error,
 ) error {
 	scanInternalOpts := &scanInternalOptions{
-		CategoryAndQoS:   categoryAndQoS,
-		visitPointKey:    visitPointKey,
-		visitRangeDel:    visitRangeDel,
-		visitRangeKey:    visitRangeKey,
-		visitSharedFile:  visitSharedFile,
-		skipSharedLevels: visitSharedFile != nil,
+		CategoryAndQoS:    categoryAndQoS,
+		visitPointKey:     visitPointKey,
+		visitRangeDel:     visitRangeDel,
+		visitRangeKey:     visitRangeKey,
+		visitSharedFile:   visitSharedFile,
+		visitExternalFile: visitExternalFile,
 		IterOptions: IterOptions{
 			KeyTypes:   IterKeyTypePointsAndRanges,
 			LowerBound: lower,

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1085,11 +1085,12 @@ func testIngestSharedImpl(
 					sharedSSTs = append(sharedSSTs, *sst)
 					return nil
 				},
+				nil,
 			)
 			require.NoError(t, err)
 			require.NoError(t, w.Close())
 
-			_, err = to.IngestAndExcise([]string{sstPath}, sharedSSTs, KeyRange{Start: startKey, End: endKey})
+			_, err = to.IngestAndExcise([]string{sstPath}, sharedSSTs, nil /* external */, KeyRange{Start: startKey, End: endKey})
 			require.NoError(t, err)
 			return fmt.Sprintf("replicated %d shared SSTs", len(sharedSSTs))
 
@@ -1317,7 +1318,7 @@ func TestSimpleIngestShared(t *testing.T) {
 		Level:            6,
 		Size:             uint64(size + 5),
 	}
-	_, err = d.IngestAndExcise([]string{}, []SharedSSTMeta{sharedSSTMeta}, KeyRange{Start: []byte("d"), End: []byte("ee")})
+	_, err = d.IngestAndExcise([]string{}, []SharedSSTMeta{sharedSSTMeta}, nil /* external */, KeyRange{Start: []byte("d"), End: []byte("ee")})
 	require.NoError(t, err)
 
 	// TODO(bilal): Once reading of shared sstables is in, verify that the values
@@ -1573,11 +1574,12 @@ func TestConcurrentExcise(t *testing.T) {
 					sharedSSTs = append(sharedSSTs, *sst)
 					return nil
 				},
+				nil,
 			)
 			require.NoError(t, err)
 			require.NoError(t, w.Close())
 
-			_, err = to.IngestAndExcise([]string{sstPath}, sharedSSTs, KeyRange{Start: startKey, End: endKey})
+			_, err = to.IngestAndExcise([]string{sstPath}, sharedSSTs, nil /* external */, KeyRange{Start: startKey, End: endKey})
 			require.NoError(t, err)
 			return fmt.Sprintf("replicated %d shared SSTs", len(sharedSSTs))
 
@@ -1740,17 +1742,27 @@ func TestConcurrentExcise(t *testing.T) {
 
 func TestIngestExternal(t *testing.T) {
 	var mem vfs.FS
-	var d *DB
+	var d, d1, d2 *DB
 	var flushed bool
 	defer func() {
-		require.NoError(t, d.Close())
+		if d1 != nil {
+			require.NoError(t, d1.Close())
+		}
+		if d2 != nil {
+			require.NoError(t, d2.Close())
+		}
 	}()
 
 	var remoteStorage remote.Storage
-
+	replicateCounter := 1
 	reset := func(majorVersion FormatMajorVersion) {
 		if d != nil {
-			require.NoError(t, d.Close())
+			if d1 != nil {
+				require.NoError(t, d1.Close())
+			}
+			if d2 != nil {
+				require.NoError(t, d2.Close())
+			}
 		}
 
 		mem = vfs.NewMem()
@@ -1778,9 +1790,13 @@ func TestIngestExternal(t *testing.T) {
 		opts.EventListener = &lel
 
 		var err error
-		d, err = Open("", opts)
+		d1, err = Open("d1", opts)
 		require.NoError(t, err)
-		require.NoError(t, d.SetCreatorID(1))
+		require.NoError(t, d1.SetCreatorID(1))
+		d2, err = Open("d2", opts)
+		require.NoError(t, err)
+		require.NoError(t, d2.SetCreatorID(2))
+		d = d1
 	}
 	reset(FormatNewest)
 
@@ -1807,7 +1823,19 @@ func TestIngestExternal(t *testing.T) {
 				return err.Error()
 			}
 			return ""
-
+		case "switch":
+			if len(td.CmdArgs) != 1 {
+				return "usage: switch <1 or 2>"
+			}
+			switch td.CmdArgs[0].Key {
+			case "1":
+				d = d1
+			case "2":
+				d = d2
+			default:
+				return "usage: switch <1 or 2>"
+			}
+			return "ok"
 		case "flush":
 			if err := d.Flush(); err != nil {
 				return err.Error()
@@ -1889,6 +1917,73 @@ func TestIngestExternal(t *testing.T) {
 				return err.Error()
 			}
 			return ""
+		case "replicate":
+			if len(td.CmdArgs) != 4 {
+				return "usage: replicate <from-db-num> <to-db-num> <start-key> <end-key>"
+			}
+			var from, to *DB
+			switch td.CmdArgs[0].Key {
+			case "1":
+				from = d1
+			case "2":
+				from = d2
+			default:
+				return "usage: replicate <from-db-num> <to-db-num> <start-key> <end-key>"
+			}
+			switch td.CmdArgs[1].Key {
+			case "1":
+				to = d1
+			case "2":
+				to = d2
+			default:
+				return "usage: replicate <from-db-num> <to-db-num> <start-key> <end-key>"
+			}
+			startKey := []byte(td.CmdArgs[2].Key)
+			endKey := []byte(td.CmdArgs[3].Key)
+
+			writeOpts := d.opts.MakeWriterOptions(0 /* level */, to.opts.FormatMajorVersion.MaxTableFormat())
+			sstPath := fmt.Sprintf("ext/replicate%d.sst", replicateCounter)
+			f, err := to.opts.FS.Create(sstPath)
+			require.NoError(t, err)
+			replicateCounter++
+			w := sstable.NewWriter(objstorageprovider.NewFileWritable(f), writeOpts)
+
+			var externalFiles []ExternalFile
+			err = from.ScanInternal(context.TODO(), sstable.CategoryAndQoS{}, startKey, endKey,
+				func(key *InternalKey, value LazyValue, _ IteratorLevel) error {
+					val, _, err := value.Value(nil)
+					require.NoError(t, err)
+					require.NoError(t, w.Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val))
+					return nil
+				},
+				func(start, end []byte, seqNum uint64) error {
+					require.NoError(t, w.DeleteRange(start, end))
+					return nil
+				},
+				func(start, end []byte, keys []keyspan.Key) error {
+					s := keyspan.Span{
+						Start:     start,
+						End:       end,
+						Keys:      keys,
+						KeysOrder: 0,
+					}
+					require.NoError(t, rangekey.Encode(&s, func(k base.InternalKey, v []byte) error {
+						return w.AddRangeKey(base.MakeInternalKey(k.UserKey, 0, k.Kind()), v)
+					}))
+					return nil
+				},
+				nil,
+				func(sst *ExternalFile) error {
+					externalFiles = append(externalFiles, *sst)
+					return nil
+				},
+			)
+			require.NoError(t, err)
+			require.NoError(t, w.Close())
+			_, err = to.IngestAndExcise([]string{sstPath}, nil /* sharedSSTs */, externalFiles, KeyRange{Start: startKey, End: endKey})
+			require.NoError(t, err)
+			return fmt.Sprintf("replicated %d external SSTs", len(externalFiles))
+
 		default:
 			return fmt.Sprintf("unknown command: %s", td.Cmd)
 		}

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/objstorage"
 )
 
 // LevelMetadata contains metadata for all of the files within
@@ -400,6 +401,8 @@ type LevelIterator struct {
 	start  *iterator
 	end    *iterator
 	filter KeyType
+
+	objProvider objstorage.Provider
 }
 
 func (i LevelIterator) String() string {
@@ -449,10 +452,11 @@ func (i *LevelIterator) Clone() LevelIterator {
 	// The start and end iterators are not cloned and are treated as
 	// immutable.
 	return LevelIterator{
-		iter:   i.iter.clone(),
-		start:  i.start,
-		end:    i.end,
-		filter: i.filter,
+		iter:        i.iter.clone(),
+		start:       i.start,
+		end:         i.end,
+		filter:      i.filter,
+		objProvider: i.objProvider,
 	}
 }
 
@@ -478,6 +482,14 @@ func (i *LevelIterator) empty() bool {
 func (i *LevelIterator) Filter(keyType KeyType) LevelIterator {
 	l := i.Clone()
 	l.filter = keyType
+	return l
+}
+
+// FilterRemoteFiles clones the iterator and sets the object provider
+// to use to filter remote files.
+func (i *LevelIterator) FilterRemoteFiles(objProvider objstorage.Provider) LevelIterator {
+	l := i.Clone()
+	l.objProvider = objProvider
 	return l
 }
 
@@ -605,6 +617,22 @@ func (i *LevelIterator) SeekLT(cmp Compare, userKey []byte) *FileMetadata {
 	return i.skipFilteredBackward(m)
 }
 
+func (i *LevelIterator) shouldFilter(meta *FileMetadata) bool {
+	shouldFilterOnKeyType := !meta.ContainsKeyType(i.filter)
+	if i.objProvider != nil {
+		objMeta, err := i.objProvider.Lookup(base.FileTypeTable, meta.FileBacking.DiskFileNum)
+		if err != nil {
+			// TODO(ssd): This panic is probably an
+			// indication I'm doing this at the wrong
+			// level.
+			panic(err)
+		}
+		shouldFilterOnFileType := objMeta.IsRemote()
+		return shouldFilterOnKeyType || shouldFilterOnFileType
+	}
+	return shouldFilterOnKeyType
+}
+
 // skipFilteredForward takes the file metadata at the iterator's current
 // position, and skips forward if the current key-type filter (i.filter)
 // excludes the file. It skips until it finds an unfiltered file or exhausts the
@@ -614,7 +642,7 @@ func (i *LevelIterator) SeekLT(cmp Compare, userKey []byte) *FileMetadata {
 // skipFilteredForward also enforces the upper bound, returning nil if at any
 // point the upper bound is exceeded.
 func (i *LevelIterator) skipFilteredForward(meta *FileMetadata) *FileMetadata {
-	for meta != nil && !meta.ContainsKeyType(i.filter) {
+	for meta != nil && i.shouldFilter(meta) {
 		i.iter.next()
 		if !i.iter.valid() {
 			meta = nil
@@ -638,7 +666,7 @@ func (i *LevelIterator) skipFilteredForward(meta *FileMetadata) *FileMetadata {
 // skipFilteredBackward also enforces the lower bound, returning nil if at any
 // point the lower bound is exceeded.
 func (i *LevelIterator) skipFilteredBackward(meta *FileMetadata) *FileMetadata {
-	for meta != nil && !meta.ContainsKeyType(i.filter) {
+	for meta != nil && i.shouldFilter(meta) {
 		i.iter.prev()
 		if !i.iter.valid() {
 			meta = nil

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -875,7 +875,7 @@ func (o *ingestAndExciseOp) run(t *Test, h historyRecorder) {
 
 	if t.testOpts.useExcise {
 		err = firstError(err, t.withRetries(func() error {
-			_, err := t.getDB(o.dbID).IngestAndExcise([]string{path}, nil /* sharedSSTs */, pebble.KeyRange{
+			_, err := t.getDB(o.dbID).IngestAndExcise([]string{path}, nil /* sharedSSTs */, nil /* external */, pebble.KeyRange{
 				Start: o.exciseStart,
 				End:   o.exciseEnd,
 			})
@@ -1887,6 +1887,7 @@ func (r *replicateOp) runSharedReplicate(
 			sharedSSTs = append(sharedSSTs, *sst)
 			return nil
 		},
+		nil,
 	)
 	if err != nil {
 		h.Recordf("%s // %v", r, err)
@@ -1918,7 +1919,7 @@ func (r *replicateOp) runSharedReplicate(
 		return
 	}
 
-	_, err = dest.IngestAndExcise([]string{sstPath}, sharedSSTs, pebble.KeyRange{Start: r.start, End: r.end})
+	_, err = dest.IngestAndExcise([]string{sstPath}, sharedSSTs, nil /* external */, pebble.KeyRange{Start: r.start, End: r.end})
 	h.Recordf("%s // %v", r, err)
 }
 

--- a/options.go
+++ b/options.go
@@ -261,14 +261,11 @@ type scanInternalOptions struct {
 	sstable.CategoryAndQoS
 	IterOptions
 
-	visitPointKey   func(key *InternalKey, value LazyValue, iterInfo IteratorLevel) error
-	visitRangeDel   func(start, end []byte, seqNum uint64) error
-	visitRangeKey   func(start, end []byte, keys []rangekey.Key) error
-	visitSharedFile func(sst *SharedSSTMeta) error
-
-	// skipSharedLevels skips levels that are shareable (level >=
-	// sharedLevelStart).
-	skipSharedLevels bool
+	visitPointKey     func(key *InternalKey, value LazyValue, iterInfo IteratorLevel) error
+	visitRangeDel     func(start, end []byte, seqNum uint64) error
+	visitRangeKey     func(start, end []byte, keys []rangekey.Key) error
+	visitSharedFile   func(sst *SharedSSTMeta) error
+	visitExternalFile func(sst *ExternalFile) error
 
 	// includeObsoleteKeys specifies whether keys shadowed by newer internal keys
 	// are exposed. If false, only one internal key per user key is exposed.

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -6,6 +6,7 @@ package pebble
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"math"
 	"strconv"
@@ -21,6 +22,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
@@ -218,11 +220,13 @@ func TestScanInternal(t *testing.T) {
 			visitRangeDel func(start, end []byte, seqNum uint64) error,
 			visitRangeKey func(start, end []byte, keys []keyspan.Key) error,
 			visitSharedFile func(sst *SharedSSTMeta) error,
+			visitExternalFile func(sst *ExternalFile) error,
 		) error
 	}
 	batches := map[string]*Batch{}
 	snaps := map[string]*Snapshot{}
 	efos := map[string]*EventuallyFileOnlySnapshot{}
+	extStorage := remote.NewInMem()
 	parseOpts := func(td *datadriven.TestData) (*Options, error) {
 		opts := &Options{
 			FS:                 vfs.NewMem(),
@@ -234,7 +238,8 @@ func TestScanInternal(t *testing.T) {
 			},
 		}
 		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-			"": remote.NewInMem(),
+			"external-storage": extStorage,
+			"":                 remote.NewInMem(),
 		})
 		opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
 		opts.Experimental.CreateOnSharedLocator = ""
@@ -291,6 +296,14 @@ func TestScanInternal(t *testing.T) {
 					opts.Merger = base.DefaultMerger
 				default:
 					return nil, errors.Newf("unrecognized Merger %q\n", cmdArg.Vals[0])
+				}
+			case "create-on-shared":
+				v, err := strconv.ParseBool(cmdArg.Vals[0])
+				if err != nil {
+					return nil, err
+				}
+				if !v {
+					opts.Experimental.CreateOnShared = remote.CreateOnSharedNone
 				}
 			}
 		}
@@ -387,23 +400,16 @@ func TestScanInternal(t *testing.T) {
 			td.MaybeScanArgs(t, "name", &name)
 			commit := td.HasArg("commit")
 			ingest := td.HasArg("ingest")
+			ingestExternal := td.HasArg("ingest-external")
 			b := d.NewIndexedBatch()
 			require.NoError(t, runBatchDefineCmd(td, b))
-			var err error
-			if commit {
-				func() {
-					defer func() {
-						if r := recover(); r != nil {
-							err = errors.New(r.(string))
-						}
-					}()
-					err = b.Commit(nil)
-				}()
-			} else if ingest {
-				points, rangeDels, rangeKeys := batchSort(b)
-				file, err := d.opts.FS.Create("temp0.sst")
-				require.NoError(t, err)
-				w := sstable.NewWriter(objstorageprovider.NewFileWritable(file), d.opts.MakeWriterOptions(0, sstable.TableFormatPebblev4))
+
+			writeSST := func(
+				points internalIterator,
+				rangeDels keyspan.FragmentIterator,
+				rangeKeys keyspan.FragmentIterator,
+				writer objstorage.Writable) {
+				w := sstable.NewWriter(writer, d.opts.MakeWriterOptions(0, sstable.TableFormatPebblev4))
 				{
 					span, err := rangeDels.First()
 					for ; span != nil; span, err = rangeDels.Next() {
@@ -428,14 +434,76 @@ func TestScanInternal(t *testing.T) {
 				}
 				require.NoError(t, rangeKeys.Close())
 				for key, val := points.First(); key != nil; key, val = points.Next() {
+					t.Logf("writing %s", *key)
 					var value []byte
+					var err error
 					value, _, err = val.Value(value)
 					require.NoError(t, err)
 					require.NoError(t, w.Add(*key, value))
 				}
 				points.Close()
 				require.NoError(t, w.Close())
+			}
+
+			var err error
+			if commit {
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							err = errors.New(r.(string))
+						}
+					}()
+					err = b.Commit(nil)
+				}()
+			} else if ingest {
+				points, rangeDels, rangeKeys := batchSort(b)
+				file, err := d.opts.FS.Create("temp0.sst")
+				require.NoError(t, err)
+				writeSST(points, rangeDels, rangeKeys, objstorageprovider.NewFileWritable(file))
 				require.NoError(t, d.Ingest([]string{"temp0.sst"}))
+			} else if ingestExternal {
+				// TODO(ssd) 2024-01-31: There must be
+				// a version of this somewhere in the
+				// pebble code base?
+				bytesNext := func(b []byte) []byte {
+					if cap(b) > len(b) {
+						bNext := b[:len(b)+1]
+						if bNext[len(bNext)-1] == 0 {
+							return bNext
+						}
+					}
+					bn := make([]byte, len(b)+1)
+					copy(bn, b)
+					bn[len(bn)-1] = 0
+					return bn
+
+				}
+
+				points, rangeDels, rangeKeys := batchSort(b)
+				largestUnsafe, _ := points.Last()
+				largest := largestUnsafe.Clone()
+				smallestUnsafe, _ := points.First()
+				smallest := smallestUnsafe.Clone()
+				t.Logf("got largest: %s, smallest: %s", largest, smallest)
+				var objName string
+				td.MaybeScanArgs(t, "ingest-external", &objName)
+				file, err := extStorage.CreateObject(objName)
+				require.NoError(t, err)
+				objstorageprovider.NewRemoteWritable(file)
+
+				writeSST(points, rangeDels, rangeKeys, objstorageprovider.NewRemoteWritable(file))
+				ef := ExternalFile{
+					ObjName: objName,
+					Locator: remote.Locator("external-storage"),
+					Size:    10,
+					Bounds: KeyRange{
+						Start: smallest.UserKey,
+						End:   bytesNext(largest.UserKey),
+					},
+					HasPointKey: true,
+				}
+				_, err = d.IngestExternalFiles([]ExternalFile{ef})
+				require.NoError(t, err)
 			} else if name != "" {
 				batches[name] = b
 			}
@@ -472,7 +540,8 @@ func TestScanInternal(t *testing.T) {
 			var lower, upper []byte
 			var reader scanInternalReader = d
 			var b strings.Builder
-			var fileVisitor func(sst *SharedSSTMeta) error
+			var sharedFileVisitor func(sst *SharedSSTMeta) error
+			var externalFileVisitor func(sst *ExternalFile) error
 			for _, arg := range td.CmdArgs {
 				switch arg.Key {
 				case "lower":
@@ -494,8 +563,17 @@ func TestScanInternal(t *testing.T) {
 					}
 					reader = efos
 				case "skip-shared":
-					fileVisitor = func(sst *SharedSSTMeta) error {
+					sharedFileVisitor = func(sst *SharedSSTMeta) error {
 						fmt.Fprintf(&b, "shared file: %s [%s-%s] [point=%s-%s] [range=%s-%s]\n", sst.fileNum, sst.Smallest.String(), sst.Largest.String(), sst.SmallestPointKey.String(), sst.LargestPointKey.String(), sst.SmallestRangeKey.String(), sst.LargestRangeKey.String())
+						return nil
+					}
+				case "skip-external":
+					externalFileVisitor = func(sst *ExternalFile) error {
+						fmt.Fprintf(&b, "external file: %s %s [0x%s-0x%s] (hasPoint: %v, hasRange: %v)\n",
+							sst.Locator, sst.ObjName,
+							hex.EncodeToString(sst.Bounds.Start),
+							hex.EncodeToString(sst.Bounds.End),
+							sst.HasPointKey, sst.HasRangeKey)
 						return nil
 					}
 				}
@@ -515,7 +593,8 @@ func TestScanInternal(t *testing.T) {
 					fmt.Fprintf(&b, "%s\n", s.String())
 					return nil
 				},
-				fileVisitor,
+				sharedFileVisitor,
+				externalFileVisitor,
 			)
 			if err != nil {
 				return err.Error()

--- a/snapshot.go
+++ b/snapshot.go
@@ -80,17 +80,18 @@ func (s *Snapshot) ScanInternal(
 	visitRangeDel func(start, end []byte, seqNum uint64) error,
 	visitRangeKey func(start, end []byte, keys []rangekey.Key) error,
 	visitSharedFile func(sst *SharedSSTMeta) error,
+	visitExternalFile func(sst *ExternalFile) error,
 ) error {
 	if s.db == nil {
 		panic(ErrClosed)
 	}
 	scanInternalOpts := &scanInternalOptions{
-		CategoryAndQoS:   categoryAndQoS,
-		visitPointKey:    visitPointKey,
-		visitRangeDel:    visitRangeDel,
-		visitRangeKey:    visitRangeKey,
-		visitSharedFile:  visitSharedFile,
-		skipSharedLevels: visitSharedFile != nil,
+		CategoryAndQoS:    categoryAndQoS,
+		visitPointKey:     visitPointKey,
+		visitRangeDel:     visitRangeDel,
+		visitRangeKey:     visitRangeKey,
+		visitSharedFile:   visitSharedFile,
+		visitExternalFile: visitExternalFile,
 		IterOptions: IterOptions{
 			KeyTypes:   IterKeyTypePointsAndRanges,
 			LowerBound: lower,
@@ -477,6 +478,7 @@ func (es *EventuallyFileOnlySnapshot) ScanInternal(
 	visitRangeDel func(start, end []byte, seqNum uint64) error,
 	visitRangeKey func(start, end []byte, keys []rangekey.Key) error,
 	visitSharedFile func(sst *SharedSSTMeta) error,
+	visitExternalFile func(sst *ExternalFile) error,
 ) error {
 	if es.db == nil {
 		panic(ErrClosed)
@@ -489,11 +491,11 @@ func (es *EventuallyFileOnlySnapshot) ScanInternal(
 			LowerBound: lower,
 			UpperBound: upper,
 		},
-		visitPointKey:    visitPointKey,
-		visitRangeDel:    visitRangeDel,
-		visitRangeKey:    visitRangeKey,
-		visitSharedFile:  visitSharedFile,
-		skipSharedLevels: visitSharedFile != nil,
+		visitPointKey:     visitPointKey,
+		visitRangeDel:     visitRangeDel,
+		visitRangeKey:     visitRangeKey,
+		visitSharedFile:   visitSharedFile,
+		visitExternalFile: visitExternalFile,
 	}
 	es.mu.Lock()
 	if es.mu.vers != nil {

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -495,7 +495,7 @@ set b b
 set c c
 ----
 
-ingest-external 
+ingest-external
 ext bounds=(ea,ed) synthetic-prefix=e
 ----
 
@@ -541,3 +541,157 @@ eb: (b, .)
 ec: (c, .)
 f: (f, .)
 .
+
+reset
+----
+
+build-remote f11
+set a foo
+set b bar
+----
+
+ingest-external
+f11 bounds=(a,c)
+----
+
+batch
+set a bar
+----
+
+iter
+first
+next
+----
+a: (bar, .)
+b: (bar, .)
+
+replicate 1 2 a z
+----
+replicated 1 external SSTs
+
+switch 2
+----
+ok
+
+iter
+first
+next
+----
+a: (bar, .)
+b: (bar, .)
+
+# Replicate with existing data in L6.
+
+reset
+----
+
+build-remote f12
+set a d1-v1
+set b d1-v1
+set c d1-v1
+set d d-1v1
+----
+
+ingest-external
+f12 bounds=(a,d)
+----
+
+batch
+set b d1-v2
+----
+
+switch 2
+----
+ok
+
+batch
+set a d2-v1
+set b d2-v1
+set c d2-v1
+set d d2-v1
+----
+
+compact a z
+----
+
+lsm
+----
+6:
+  000005:[a#10,SET-d#13,SET]
+
+replicate 1 2 b d
+----
+replicated 1 external SSTs
+
+
+iter
+first
+next
+next
+next
+----
+a: (d2-v1, .)
+b: (d1-v2, .)
+c: (d1-v1, .)
+d: (d2-v1, .)
+
+# Replicate with an internal file in L0
+
+reset
+----
+
+batch
+set d d1-v1
+set e d1-v1
+----
+
+compact a z
+----
+
+lsm
+----
+6:
+  000005:[d#10,SET-e#11,SET]
+
+build-remote f13
+set a d1-v1
+set b d1-v1
+----
+
+ingest-external
+f13 bounds=(a,c)
+----
+
+switch 2
+----
+ok
+
+batch
+set a d2-v1
+set b d2-v1
+set d d2-v1
+set e d2-v1
+----
+
+compact a z
+----
+
+lsm
+----
+6:
+  000005:[a#10,SET-e#13,SET]
+
+replicate 1 2 b e
+----
+replicated 1 external SSTs
+
+iter
+first
+next
+next
+next
+----
+a: (d2-v1, .)
+b: (d1-v1, .)
+d: (d1-v1, .)
+e: (d2-v1, .)

--- a/testdata/scan_internal
+++ b/testdata/scan_internal
@@ -462,3 +462,85 @@ shared file: 000005 [b#11,SET-d#13,SET] [point=b#11,SET-d#13,SET] [range=#0,DEL-
 scan-internal skip-shared lower=a upper=aaa
 ----
 shared file: 000005 [a#10,RANGEKEYSET-aa#72057594037927935,RANGEKEYSET] [point=#0,DEL-#0,DEL] [range=a#10,RANGEKEYSET-aa#72057594037927935,RANGEKEYSET]
+
+reset
+----
+
+batch ingest-external=file1
+set a foo
+set b bar
+set c baz
+----
+wrote 3 keys to batch ""
+
+batch commit
+set d bat
+----
+committed 1 keys
+
+flush
+----
+
+lsm
+----
+0.0:
+  000006:[d#11,SET-d#11,SET]
+6:
+  000004(000004):[a#10,DELSIZED-c\x00#inf,RANGEDEL]
+
+
+
+scan-internal skip-external lower=m upper=n
+----
+
+scan-internal skip-external lower=a upper=f
+----
+external file: external-storage file1 [0x61-0x6300] (hasPoint: true, hasRange: false)
+d#11,SET (bat)
+
+
+reset create-on-shared=false
+----
+
+batch commit
+set d bat
+----
+committed 1 keys
+
+flush
+----
+
+batch ingest-external=file1
+set a foo
+set b bar
+set c baz
+----
+wrote 3 keys to batch ""
+
+flush
+----
+
+compact a-z
+----
+6:
+  000006(000006):[a#11,DELSIZED-c\x00#inf,RANGEDEL]
+  000005:[d#10,SET-d#10,SET]
+
+scan-internal skip-external lower=m upper=n
+----
+
+scan-internal skip-external lower=a upper=f
+----
+external file: external-storage file1 [0x61-0x6300] (hasPoint: true, hasRange: false)
+d#10,SET (bat)
+
+scan-internal skip-shared lower=a upper=f
+----
+external file is present but no external file visitor is defined: pebble: cannot use skip-shared iteration due to non-shareable files in lower levels
+
+scan-internal lower=a upper=f
+----
+a#11,SET (foo)
+b#11,SET (bar)
+c#11,SET (baz)
+d#10,SET (bat)


### PR DESCRIPTION
This change contains three changes:

1. The ability to iterate over external files.

2. Allowing a mix of local and remote files at the _first_ level where remote files are present when iterating.

3. Supporting importing External files in the same way that we do for SharedSSTs.

Like the sharedFileVisitor, the new externalFileVisitor allows the caller to process external files directly.

In this PR, the externalFileVisitor only applies to L6 and L6 must be completely external or shared files.