### PR TITLE
manifest: add FileBackings structure

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -190,10 +190,11 @@ func (d *DB) Checkpoint(
 	manifestFileNum := d.mu.versions.manifestFileNum
 	manifestSize := d.mu.versions.manifest.Size()
 	optionsFileNum := d.optionsFileNum
+
 	virtualBackingFiles := make(map[base.DiskFileNum]struct{})
-	for diskFileNum := range d.mu.versions.backingState.fileBackingMap {
-		virtualBackingFiles[diskFileNum] = struct{}{}
-	}
+	d.mu.versions.fileBackings.ForEach(func(backing *fileBacking) {
+		virtualBackingFiles[backing.DiskFileNum] = struct{}{}
+	})
 
 	queuedLogNums := make([]wal.NumWAL, 0, len(memQueue))
 	for i := range memQueue {

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -133,14 +132,10 @@ func TestCheckpoint(t *testing.T) {
 			d := dbs[td.CmdArgs[0].String()]
 			d.mu.Lock()
 			d.mu.versions.logLock()
-			var fileNums []base.DiskFileNum
-			for _, b := range d.mu.versions.backingState.fileBackingMap {
-				fileNums = append(fileNums, b.DiskFileNum)
-			}
+			fileNums := d.mu.versions.fileBackings.DiskFileNums()
 			d.mu.versions.logUnlock()
 			d.mu.Unlock()
 
-			slices.Sort(fileNums)
 			var buf bytes.Buffer
 			for _, f := range fileNums {
 				buf.WriteString(fmt.Sprintf("%s\n", f.String()))

--- a/db.go
+++ b/db.go
@@ -2145,17 +2145,9 @@ func (d *DB) Metrics() *Metrics {
 
 	d.mu.versions.logLock()
 	metrics.private.manifestFileSize = uint64(d.mu.versions.manifest.Size())
-	metrics.Table.BackingTableCount = uint64(len(d.mu.versions.backingState.fileBackingMap))
-	metrics.Table.BackingTableSize = d.mu.versions.backingState.fileBackingSize
-	if invariants.Enabled {
-		var totalSize uint64
-		for _, backing := range d.mu.versions.backingState.fileBackingMap {
-			totalSize += backing.Size
-		}
-		if totalSize != metrics.Table.BackingTableSize {
-			panic("pebble: invalid backing table size accounting")
-		}
-	}
+	backingCount, backingTotalSize := d.mu.versions.fileBackings.Stats()
+	metrics.Table.BackingTableCount = uint64(backingCount)
+	metrics.Table.BackingTableSize = backingTotalSize
 	d.mu.versions.logUnlock()
 
 	metrics.LogWriter.FsyncLatency = d.mu.log.metrics.fsyncLatency

--- a/internal/manifest/file_backings.go
+++ b/internal/manifest/file_backings.go
@@ -1,0 +1,86 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package manifest
+
+import (
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/invariants"
+	"golang.org/x/exp/slices"
+)
+
+// FileBackings contains information about a set of FileBackings.
+type FileBackings struct {
+	m map[base.DiskFileNum]*FileBacking
+	// totalSize is the sum of the sizes of the fileBackings in m.
+	totalSize uint64
+}
+
+// Get returns the backing for the given DiskFileNum. If it doesn't exist,
+// returns ok = false.
+func (b *FileBackings) Get(n base.DiskFileNum) (_ *FileBacking, ok bool) {
+	backing, ok := b.m[n]
+	return backing, ok
+}
+
+// Add a new backing to the set. Another backing for the same DiskFilNum must
+// not exist.
+func (b *FileBackings) Add(backing *FileBacking) {
+	if b.m == nil {
+		b.m = make(map[base.DiskFileNum]*FileBacking)
+	} else {
+		_, ok := b.m[backing.DiskFileNum]
+		if ok {
+			panic("pebble: trying to add an existing file backing")
+		}
+	}
+	b.m[backing.DiskFileNum] = backing
+	b.totalSize += backing.Size
+}
+
+// Remove the backing associated with the given DiskFileNum, if it exists.
+func (b *FileBackings) Remove(n base.DiskFileNum) {
+	backing, ok := b.m[n]
+	if ok {
+		delete(b.m, n)
+		b.totalSize -= backing.Size
+	}
+}
+
+// Stats returns the number and total size of all the backings.
+func (b *FileBackings) Stats() (count int, totalSize uint64) {
+	if invariants.Enabled {
+		b.Check()
+	}
+	return len(b.m), b.totalSize
+}
+
+// ForEach calls fn on each backing, in an unspecified order.
+func (b *FileBackings) ForEach(fn func(backing *FileBacking)) {
+	for _, backing := range b.m {
+		fn(backing)
+	}
+}
+
+// DiskFileNums returns disk file nums of all the backing in the set, in sorted
+// order.
+func (b *FileBackings) DiskFileNums() []base.DiskFileNum {
+	res := make([]base.DiskFileNum, 0, len(b.m))
+	for n := range b.m {
+		res = append(res, n)
+	}
+	slices.Sort(res)
+	return res
+}
+
+// Check verifies the internal consistency.
+func (b *FileBackings) Check() {
+	var totalSize uint64
+	for _, backing := range b.m {
+		totalSize += backing.Size
+	}
+	if totalSize != b.totalSize {
+		panic("pebble: invalid backing table size accounting")
+	}
+}


### PR DESCRIPTION
We currently maintain a map of `FileBacking`s in the pebble package
and pass callbacks to add and remove backings to the `manifest`
package. This commit cleans this up by defining a `FileBackings` data
structure in `manifest` and passing that instead.