### PR TITLE
db: require ExternalFile bounds without suffixes

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -1313,8 +1313,8 @@ func runIngestExternalCmd(t testing.TB, td *datadriven.TestData, d *DB, locator 
 			switch arg.Key {
 			case "bounds":
 				nArgs(2)
-				ef.SmallestUserKey = []byte(arg.Vals[0])
-				ef.LargestUserKey = []byte(arg.Vals[1])
+				ef.Bounds.Start = []byte(arg.Vals[0])
+				ef.Bounds.End = []byte(arg.Vals[1])
 
 			case "size":
 				nArgs(1)
@@ -1337,7 +1337,7 @@ func runIngestExternalCmd(t testing.TB, td *datadriven.TestData, d *DB, locator 
 				usageErr(fmt.Sprintf("unknown argument %v", arg.Key))
 			}
 		}
-		if ef.SmallestUserKey == nil {
+		if ef.Bounds.Start == nil {
 			usageErr("no bounds specified")
 		}
 

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -987,11 +987,10 @@ func (o *ingestExternalFilesOp) run(t *Test, h historyRecorder) {
 		for i, obj := range objs {
 			meta := t.getExternalObj(obj.externalObjID)
 			external[i] = pebble.ExternalFile{
-				Locator:         "external",
-				ObjName:         externalObjName(obj.externalObjID),
-				Size:            meta.sstMeta.Size,
-				SmallestUserKey: obj.bounds.Start,
-				LargestUserKey:  obj.bounds.End,
+				Locator: "external",
+				ObjName: externalObjName(obj.externalObjID),
+				Size:    meta.sstMeta.Size,
+				Bounds:  obj.bounds,
 				// Note: if the table has point/range keys, we don't know for sure whether
 				// this particular range has any, but that's acceptable.
 				HasPointKey:     meta.sstMeta.HasPointKeys || meta.sstMeta.HasRangeDelKeys,

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -259,16 +259,22 @@ a@5: (foo, .)
 b@5: (foo, .)
 c@5: (foo, .)
 
-# Verify that we require bounds without suffix if we use suffix replacement.
+# Verify that we require bounds without suffix.
 ingest-external
-f6 bounds=(a@1,z@10) synthetic-suffix=@5
+f6 bounds=(a@1,z)
 ----
-pebble: synthetic suffix is set but smallest key has suffix
+pebble: external file bounds start key "a@1" has suffix
 
 ingest-external
-f6 bounds=(a,z@10) synthetic-suffix=@5
+f6 bounds=(a,z@10)
 ----
-pebble: synthetic suffix is set but largest key has suffix
+pebble: external file bounds end key "z@10" has suffix
+
+# Verify that we require valid bounds.
+ingest-external
+f6 bounds=(c,a)
+----
+pebble: external file bounds ["c", "a") are invalid
 
 # Test the case when we are ingesting part of a RANGEDEL.
 reset


### PR DESCRIPTION
We already require this when `SyntheticSuffix` is used.

Also, use `Bounds KeyRange` instead of `SmallestUserKey/LargestUserKey`
in `ExternalFile`.