### PR TITLE
base: default Split to trivial implementation

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -957,7 +957,7 @@ func (b *Batch) DeleteRangeDeferred(startLen, endLen int) *DeferredBatchOp {
 //
 // It is safe to modify the contents of the arguments after RangeKeySet returns.
 func (b *Batch) RangeKeySet(start, end, suffix, value []byte, _ *WriteOptions) error {
-	if invariants.Enabled && b.db != nil && b.db.opts.Comparer.Split != nil {
+	if invariants.Enabled && b.db != nil {
 		// RangeKeySet is only supported on prefix keys.
 		if b.db.opts.Comparer.Split(start) != len(start) {
 			panic("RangeKeySet called with suffixed start key")
@@ -1013,7 +1013,7 @@ func (b *Batch) incrementRangeKeysCount() {
 // It is safe to modify the contents of the arguments after RangeKeyUnset
 // returns.
 func (b *Batch) RangeKeyUnset(start, end, suffix []byte, _ *WriteOptions) error {
-	if invariants.Enabled && b.db != nil && b.db.opts.Comparer.Split != nil {
+	if invariants.Enabled && b.db != nil {
 		// RangeKeyUnset is only supported on prefix keys.
 		if b.db.opts.Comparer.Split(start) != len(start) {
 			panic("RangeKeyUnset called with suffixed start key")
@@ -1055,7 +1055,7 @@ func (b *Batch) rangeKeyUnsetDeferred(startLen, internalValueLen int) *DeferredB
 // It is safe to modify the contents of the arguments after RangeKeyDelete
 // returns.
 func (b *Batch) RangeKeyDelete(start, end []byte, _ *WriteOptions) error {
-	if invariants.Enabled && b.db != nil && b.db.opts.Comparer.Split != nil {
+	if invariants.Enabled && b.db != nil {
 		// RangeKeyDelete is only supported on prefix keys.
 		if b.db.opts.Comparer.Split(start) != len(start) {
 			panic("RangeKeyDelete called with suffixed start key")

--- a/get_iter.go
+++ b/get_iter.go
@@ -186,12 +186,7 @@ func (g *getIter) Next() (*InternalKey, base.LazyValue) {
 				g.levelIter.initBoundaryContext(&bc)
 				g.iter = &g.levelIter
 
-				// Compute the key prefix for bloom filtering if split function is
-				// specified, or use the user key as default.
-				prefix := g.key
-				if g.comparer.Split != nil {
-					prefix = g.key[:g.comparer.Split(g.key)]
-				}
+				prefix := g.key[:g.comparer.Split(g.key)]
 				g.iterKey, g.iterValue = g.iter.SeekPrefixGE(prefix, g.key, base.SeekGEFlagsNone)
 				if err := g.iter.Error(); err != nil {
 					g.err = err
@@ -231,10 +226,7 @@ func (g *getIter) Next() (*InternalKey, base.LazyValue) {
 
 		// Compute the key prefix for bloom filtering if split function is
 		// specified, or use the user key as default.
-		prefix := g.key
-		if g.comparer.Split != nil {
-			prefix = g.key[:g.comparer.Split(g.key)]
-		}
+		prefix := g.key[:g.comparer.Split(g.key)]
 		g.iterKey, g.iterValue = g.iter.SeekPrefixGE(prefix, g.key, base.SeekGEFlagsNone)
 		if err := g.iter.Error(); err != nil {
 			g.err = err

--- a/ingest.go
+++ b/ingest.go
@@ -1193,7 +1193,7 @@ func (d *DB) IngestAndExcise(
 	if d.opts.ReadOnly {
 		return IngestOperationStats{}, ErrReadOnly
 	}
-	if invariants.Enabled && d.opts.Comparer.Split != nil {
+	if invariants.Enabled {
 		// Excise is only supported on prefix keys.
 		if d.opts.Comparer.Split(exciseSpan.Start) != len(exciseSpan.Start) {
 			panic("IngestAndExcise called with suffixed start key")

--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -108,12 +108,12 @@ type InternalIterator interface {
 	// that key is greater than or equal to the lower bound.
 	//
 	// The prefix argument is used by some InternalIterator implementations (e.g.
-	// sstable.Reader) to avoid expensive operations. A user-defined Split
-	// function must be supplied to the Comparer for the DB. The supplied prefix
-	// will be the prefix of the given key returned by that Split function. If
-	// the iterator is able to determine that no key with the prefix exists, it
-	// can return (nil,nilv). Unlike SeekGE, this is not an indication that
-	// iteration is exhausted.
+	// sstable.Reader) to avoid expensive operations. This operation is only
+	// useful when a user-defined Split function is supplied to the Comparer for
+	// the DB. The supplied prefix will be the prefix of the given key returned by
+	// that Split function. If the iterator is able to determine that no key with
+	// the prefix exists, it can return (nil,nilv). Unlike SeekGE, this is not an
+	// indication that iteration is exhausted.
 	//
 	// Note that the iterator may return keys not matching the prefix. It is up
 	// to the caller to check if the prefix matches.

--- a/iterator.go
+++ b/iterator.go
@@ -1421,9 +1421,6 @@ func (i *Iterator) SeekPrefixGE(key []byte) bool {
 	i.requiresReposition = false
 	i.err = nil // clear cached iteration error
 	i.stats.ForwardSeekCount[InterfaceCall]++
-	if i.comparer.Split == nil {
-		panic("pebble: split must be provided for SeekPrefixGE")
-	}
 	if i.comparer.ImmediateSuccessor == nil && i.opts.KeyTypes != IterKeyTypePointsOnly {
 		panic("pebble: ImmediateSuccessor must be provided for SeekPrefixGE with range keys")
 	}
@@ -2483,14 +2480,12 @@ func (i *Iterator) processBounds(lower, upper []byte) {
 	if upper != nil {
 		buf = append(buf, upper...)
 		i.opts.UpperBound = buf[len(buf)-len(upper):]
-		if i.comparer.Split != nil {
-			if i.comparer.Split(i.opts.UpperBound) != len(i.opts.UpperBound) {
-				// Setting an upper bound that is a versioned MVCC key. This means
-				// that a key can have some MVCC versions before the upper bound and
-				// some after. This causes significant complications for NextPrefix,
-				// so we bar the user of NextPrefix.
-				i.nextPrefixNotPermittedByUpperBound = true
-			}
+		if i.comparer.Split(i.opts.UpperBound) != len(i.opts.UpperBound) {
+			// Setting an upper bound that is a versioned MVCC key. This means
+			// that a key can have some MVCC versions before the upper bound and
+			// some after. This causes significant complications for NextPrefix,
+			// so we bar the user of NextPrefix.
+			i.nextPrefixNotPermittedByUpperBound = true
 		}
 	} else {
 		i.opts.UpperBound = nil

--- a/level_iter.go
+++ b/level_iter.go
@@ -772,15 +772,7 @@ func (l *levelIter) SeekPrefixGE(
 	// next file will defeat the optimization for the next SeekPrefixGE that is
 	// called with flags.TrySeekUsingNext(), since for sparse key spaces it is
 	// likely that the next key will also be contained in the current file.
-	var n int
-	if l.split != nil {
-		// If the split function is specified, calculate the prefix length accordingly.
-		n = l.split(l.iterFile.LargestPointKey.UserKey)
-	} else {
-		// If the split function is not specified, the entire key is used as the
-		// prefix. This case can occur when getIter uses SeekPrefixGE.
-		n = len(l.iterFile.LargestPointKey.UserKey)
-	}
+	n := l.split(l.iterFile.LargestPointKey.UserKey)
 	if l.cmp(prefix, l.iterFile.LargestPointKey.UserKey[:n]) < 0 {
 		return nil, base.LazyValue{}
 	}

--- a/snapshot.go
+++ b/snapshot.go
@@ -421,13 +421,7 @@ func (es *EventuallyFileOnlySnapshot) Get(key []byte) (value []byte, closer io.C
 	if err != nil {
 		return nil, nil, err
 	}
-	var valid bool
-	if es.db.opts.Comparer.Split != nil {
-		valid = iter.SeekPrefixGE(key)
-	} else {
-		valid = iter.SeekGE(key)
-	}
-	if !valid {
+	if !iter.SeekPrefixGE(key) {
 		if err = firstError(iter.Error(), iter.Close()); err != nil {
 			return nil, nil, err
 		}

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -811,10 +811,7 @@ func (w *Writer) makeAddPointDecisionV3(
 ) (setHasSamePrefix bool, writeToValueBlock bool, isObsolete bool, err error) {
 	prevPointKeyInfo := w.lastPointKeyInfo
 	w.lastPointKeyInfo.userKeyLen = len(key.UserKey)
-	w.lastPointKeyInfo.prefixLen = w.lastPointKeyInfo.userKeyLen
-	if w.split != nil {
-		w.lastPointKeyInfo.prefixLen = w.split(key.UserKey)
-	}
+	w.lastPointKeyInfo.prefixLen = w.split(key.UserKey)
 	w.lastPointKeyInfo.trailer = key.Trailer
 	w.lastPointKeyInfo.isObsolete = false
 	if !w.meta.HasPointKeys {
@@ -1370,12 +1367,8 @@ func (w *Writer) tempRangeKeyCopy(k []byte) []byte {
 
 func (w *Writer) maybeAddToFilter(key []byte) {
 	if w.filter != nil {
-		if w.split != nil {
-			prefix := key[:w.split(key)]
-			w.filter.addKey(prefix)
-		} else {
-			w.filter.addKey(key)
-		}
+		prefix := key[:w.split(key)]
+		w.filter.addKey(prefix)
 	}
 }
 


### PR DESCRIPTION
This change makes `Comparer.EnsureDefaults` set a trivial `Split`
implementation which returns the full length of the key. This
simplifies code which had to check `Split != nil`, and we no longer
have to think about what are the semantics of a given operation when
`Split` is  `nil`.