### PR TITLE
metamorphic: fix tracking of external ingest keys with synthetic prefix

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -1143,7 +1143,7 @@ type ExternalFile struct {
 	//
 	// SyntheticSuffix can only be used under the following conditions:
 	//  - the synthetic suffix must sort before any non-empty suffixes in the
-	//    backing sst;
+	//    backing sst (the entire sst, not just the part restricted to Bounds).
 	//  - the backing sst must not contain multiple keys with the same prefix.
 	SyntheticSuffix []byte
 }

--- a/metamorphic/generator.go
+++ b/metamorphic/generator.go
@@ -784,9 +784,9 @@ func (g *generator) iterSeekGEWithLimit(iterID objID) {
 
 // inRangeKeys returns all keys in the range [lower, upper) associated with the
 // given object.
-func (g *generator) inRangeKeys(lower, upper []byte, o objID) []*keyMeta {
-	var inRangeKeys []*keyMeta
-	for _, keyMeta := range g.keyManager.sortedKeysForObj(o) {
+func (g *generator) inRangeKeys(lower, upper []byte, o objID) []keyMeta {
+	var inRangeKeys []keyMeta
+	for _, keyMeta := range g.keyManager.SortedKeysForObj(o) {
 		if g.cmp(keyMeta.key, lower) >= 0 && g.cmp(keyMeta.key, upper) < 0 {
 			inRangeKeys = append(inRangeKeys, keyMeta)
 		}

--- a/metamorphic/generator.go
+++ b/metamorphic/generator.go
@@ -1041,9 +1041,18 @@ func (g *generator) newExternalObj() {
 	if len(g.liveBatches) == 0 {
 		return
 	}
-	batchID := g.liveBatches.rand(g.rng)
-	if g.keyManager.objKeyMeta(batchID).bounds.IsUnset() {
-		return
+	var batchID objID
+	// Try to find a suitable batch.
+	for i := 0; ; i++ {
+		if i == 10 {
+			return
+		}
+		batchID = g.liveBatches.rand(g.rng)
+		okm := g.keyManager.objKeyMeta(batchID)
+		// #3287: IngestExternalFiles currently doesn't support range keys.
+		if !okm.bounds.IsUnset() && !okm.hasRangeKeys {
+			break
+		}
 	}
 	g.removeBatchFromGenerator(batchID)
 	objID := makeObjID(externalObjTag, g.init.externalObjSlots)

--- a/metamorphic/key_generator.go
+++ b/metamorphic/key_generator.go
@@ -102,6 +102,14 @@ func (kg *keyGenerator) SkewedSuffixInt(incMaxProb float64) int64 {
 	return int64(kg.cfg.writeSuffixDist.Uint64(kg.rng))
 }
 
+// IncMaxSuffix increases the max suffix range and returns the new maximum
+// suffix (which is guaranteed to be larger than any previously generated
+// suffix).
+func (kg *keyGenerator) IncMaxSuffix() []byte {
+	kg.cfg.writeSuffixDist.IncMax(1)
+	return testkeys.Suffix(int64(kg.cfg.writeSuffixDist.Max()))
+}
+
 // UniformSuffix returns a suffix in the same range as SkewedSuffix but with a
 // uniform distribution. This is used during reads to better exercise reading a
 // mix of older and newer keys. The suffix can be empty.

--- a/metamorphic/key_manager.go
+++ b/metamorphic/key_manager.go
@@ -265,15 +265,15 @@ func (k *keyManager) objKeyMeta(o objID) *objKeyMeta {
 	return m
 }
 
-// sortedKeysForObj returns all the values in objKeyMeta(o).keys, in sorted
+// SortedKeysForObj returns all the entries in objKeyMeta(o).keys, in sorted
 // order.
-func (k *keyManager) sortedKeysForObj(o objID) []*keyMeta {
+func (k *keyManager) SortedKeysForObj(o objID) []keyMeta {
 	okm := k.objKeyMeta(o)
-	res := make([]*keyMeta, 0, len(okm.keys))
+	res := make([]keyMeta, 0, len(okm.keys))
 	for _, m := range okm.keys {
-		res = append(res, m)
+		res = append(res, *m)
 	}
-	slices.SortFunc(res, func(a, b *keyMeta) int {
+	slices.SortFunc(res, func(a, b keyMeta) int {
 		cmp := k.comparer.Compare(a.key, b.key)
 		if cmp == 0 {
 			panic(fmt.Sprintf("distinct keys %q and %q compared as equal", a.key, b.key))
@@ -395,7 +395,7 @@ func (k *keyManager) doObjectBoundsOverlap(objIDs []objID) bool {
 func (k *keyManager) checkForSingleDelConflicts(srcObj, dstObj objID, srcCollapsed bool) [][]byte {
 	dstKeys := k.objKeyMeta(dstObj)
 	var conflicts [][]byte
-	for _, src := range k.sortedKeysForObj(srcObj) {
+	for _, src := range k.SortedKeysForObj(srcObj) {
 		// Single delete generation logic already ensures that both srcObj and
 		// dstObj's single deletes are deterministic within the context of their
 		// existing writes. However, applying srcObj on top of dstObj may

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -1770,12 +1770,6 @@ func (o *newExternalObjOp) run(t *Test, h historyRecorder) {
 
 	iter, rangeDelIter, rangeKeyIter := private.BatchSort(b)
 
-	// #3287: range keys are not supported yet.
-	if rangeKeyIter != nil {
-		rangeKeyIter.Close()
-		rangeKeyIter = nil
-	}
-
 	sstMeta, minSuffix, err := writeSSTForIngestion(
 		t,
 		iter, rangeDelIter, rangeKeyIter,
@@ -1786,6 +1780,11 @@ func (o *newExternalObjOp) run(t *Test, h historyRecorder) {
 	)
 	if err != nil {
 		panic(err)
+	}
+	if sstMeta.HasRangeKeys {
+		// #3287: IngestExternalFiles currently doesn't support range keys; we check
+		// for range keys in newExternalObj.
+		panic("external object has range keys")
 	}
 	t.setExternalObj(o.externalObjID, externalObjMeta{
 		sstMeta:   sstMeta,

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -1007,7 +1007,7 @@ func (o *ingestExternalFilesOp) syncObjs() objIDSlice {
 func (o *ingestExternalFilesOp) String() string {
 	strs := make([]string, len(o.objs))
 	for i, obj := range o.objs {
-		strs[i] = fmt.Sprintf("%s, %q, %q, %q", obj.externalObjID, obj.bounds.Start, obj.bounds.End, obj.syntheticSuffix)
+		strs[i] = fmt.Sprintf("%s, %q, %q, %q /* syntheticSuffix */", obj.externalObjID, obj.bounds.Start, obj.bounds.End, obj.syntheticSuffix)
 	}
 	return fmt.Sprintf("%s.IngestExternalFiles(%s)", o.dbID, strings.Join(strs, ", "))
 }

--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -69,9 +69,6 @@ type Test struct {
 
 type externalObjMeta struct {
 	sstMeta *sstable.WriterMetadata
-	// minSuffix is the minimum (according to the comparator) non-empty suffix in
-	// the object.
-	minSuffix []byte
 }
 
 func newTest(ops []op) *Test {


### PR DESCRIPTION
Note : `require ExternalFile bounds without suffixes` commit is a separate PR #3357

#### metamorphic: track whether objects have range dels/keys

We use this information to select a Batch without range keys when
creating an external object (rather than ignoring them). We will use
the range dels to correctly generate synthetic suffix/prefix upfront
(instead of correcting them during `run()`, which makes tracking key
histories inaccurate).

We also clean up the object merging code a bit.

#### metamorphic: return []keyMeta instead of []*keyMeta

Change `SortedKeysForObj` and `inRangeKeys` to return a slice of
`keyMeta` instead of `*keyMeta`. This makes it more clear that we
don't modify them (and allows local modification as needed).

#### metamorphic: generate correct synthetic suffixes up front


#### metamorphic: fix tracking of external ingest keys with synthetic prefix

This commit corrects the tracking of external ingestion keys in the
key manager when synthetic suffixes are used. This is important for
detecting SINGLEDEL conflicts correctly.

Fixes #3325