### PR TITLE
db: introduce separate [WAL Failover] stanza in OPTIONS file

### DIFF
--- a/options_test.go
+++ b/options_test.go
@@ -193,17 +193,23 @@ func TestOptionsCheck(t *testing.T) {
 	require.Equal(t, ErrMissingWALRecoveryDir{Dir: "failover-wal-dir"},
 		(&Options{}).EnsureDefaults().Check(`
 [Options]
-  wal_dir_secondary=failover-wal-dir
+
+[WAL Failover]
+  secondary_dir=failover-wal-dir
 `))
 	// But not if it's configured as a WALRecoveryDir or current failover
 	// secondary dir.
 	require.NoError(t, (&Options{WALRecoveryDirs: []wal.Dir{{Dirname: "failover-wal-dir"}}}).EnsureDefaults().Check(`
 [Options]
-  wal_dir_secondary=failover-wal-dir
+
+[WAL Failover]
+  secondary_dir=failover-wal-dir
 `))
 	require.NoError(t, (&Options{WALFailover: &WALFailoverOptions{Secondary: wal.Dir{Dirname: "failover-wal-dir"}}}).EnsureDefaults().Check(`
 [Options]
-  wal_dir_secondary=failover-wal-dir
+
+[WAL Failover]
+  secondary_dir=failover-wal-dir
 `))
 }
 

--- a/testdata/open_wal_failover
+++ b/testdata/open_wal_failover
@@ -13,12 +13,10 @@ list path=(a,data)
   marker.format-version.000001.013
   marker.manifest.000001.MANIFEST-000001
 
-grep path=(a,data/OPTIONS-000003) pattern=wal
+# The OPTIONS file should not include a [WAL Failover] stanza.
+
+grep-between path=(a,data/OPTIONS-000003) start=(\[WAL Failover\]) end=^$
 ----
-  disable_wal=false
-  strict_wal_tail=true
-  wal_dir=
-  wal_bytes_per_sync=0
 
 # Open the same database with WAL failover configured, but pointing to a
 # different FS.
@@ -45,13 +43,15 @@ list path=(a,data)
 
 # The new OPTIONS file should declare the secondary WAL path.
 
-grep path=(a,data/OPTIONS-000006) pattern=wal
+grep-between path=(a,data/OPTIONS-000006) start=(\[WAL Failover\]) end=^$
 ----
-  disable_wal=false
-  strict_wal_tail=true
-  wal_dir=
-  wal_bytes_per_sync=0
-  wal_dir_secondary=secondary-wals
+  secondary_dir=secondary-wals
+  primary_dir_probe_interval=1s
+  healthy_probe_latency_threshold=100ms
+  healthy_interval=2m0s
+  unhealthy_sampling_interval=100ms
+  unhealthy_operation_latency_threshold=200ms
+  elevated_write_stall_threshold_lag=0s
 
 # Opening the same directory without providing the secondary path in either the
 # WAL failover configuration or as a WALRecoveryDir should error.


### PR DESCRIPTION
**db: introduce separate [WAL Failover] stanza in OPTIONS file**

Add a new [WAL Failover] stanza to the OPTIONS file and serialize all the exposed WAL failover options under the stanza. We don't anticipate users modifying these duration settings, but serializing them will help with the integration of the metamorphic test. In the metamorphic test, we'll be able to vary these settings from run to run and simulate a wider variety of behaviors.

**db: fix TestOpen_WALFailover data race**

Previously, there was a data race where the memFile may be Close'd while it was
was still being read.