### PR TITLE
metamorphic: add testing for prefix synthesis

### DIFF
--- a/metamorphic/config.go
+++ b/metamorphic/config.go
@@ -181,8 +181,8 @@ func DefaultOpConfig() OpConfig {
 			OpWriterRangeKeyDelete:        5,
 			OpWriterSet:                   100,
 			OpWriterSingleDelete:          50,
-			OpNewExternalObj:              2,
-			OpWriterIngestExternalFiles:   20,
+			OpNewExternalObj:              5,
+			OpWriterIngestExternalFiles:   100,
 		},
 		// Use a new prefix 75% of the time (and 25% of the time use an existing
 		// prefix with an alternative suffix).

--- a/metamorphic/generator.go
+++ b/metamorphic/generator.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/internal/randvar"
+	"github.com/cockroachdb/pebble/sstable"
 	"golang.org/x/exp/rand"
 )
 
@@ -1313,12 +1314,37 @@ func (g *generator) writerIngestExternalFiles() {
 		if g.cmp(start, end) == 0 {
 			end = objEnd
 		}
+		// Randomly set up prefix change.
+		var prefixChange *sstable.PrefixReplacement
+		// We can only use a synthetic prefix if we don't have range dels.
+		// TODO(radu): we will want to support this at some point.
+		if !g.keyManager.objKeyMeta(id).hasRangeDels && g.rng.Intn(2) == 0 {
+			prefixChange = &sstable.PrefixReplacement{
+				SyntheticPrefix: randBytes(g.rng, 1, 5),
+			}
+			// TODO(radu): fix prefix replacement implementation or remove
+			// ContentPrefix altogether.
+			if false {
+				prefixLen := 0
+				limit := min(len(start), len(end))
+				for ; prefixLen < limit && start[prefixLen] == end[prefixLen]; prefixLen++ {
+				}
+				prefixLen = g.rng.Intn(prefixLen + 1)
+				if prefixLen > 0 {
+					prefixChange.ContentPrefix = start[:prefixLen]
+				}
+			}
+			start = prefixChange.Apply(start)
+			end = prefixChange.Apply(end)
+		}
+
 		objs[i] = externalObjWithBounds{
 			externalObjID: id,
 			bounds: pebble.KeyRange{
 				Start: start,
 				End:   end,
 			},
+			prefixChange: prefixChange,
 		}
 	}
 

--- a/metamorphic/key_generator.go
+++ b/metamorphic/key_generator.go
@@ -305,10 +305,7 @@ func (kg *keyGenerator) parseKey(k []byte) (prefix []byte, suffix int64) {
 }
 
 func randBytes(rng *rand.Rand, minLen, maxLen int) []byte {
-	n := minLen
-	if maxLen > minLen {
-		n += rng.Intn(maxLen - minLen)
-	}
+	n := minLen + rng.Intn(maxLen-minLen+1)
 	if n == 0 {
 		return nil
 	}


### PR DESCRIPTION
This commit adds prefix synthesis (i.e. `PrefixReplacement` with empty
`ContentPrefix`) to the metamorphic test.

We generate a random prefix and prepend it to the initially-generated
bounds. We take it into account when emulating the ingestion and when
determining key histories.