### PR TITLE
metamorphic: use WAL failover

### DIFF
--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -500,6 +500,19 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 		require.NoError(t, setupInitialState(dir, testOpts))
 	}
 
+	if testOpts.Opts.WALFailover != nil {
+		if runOpts.numInstances > 1 {
+			// TODO(bilal,jackson): Allow opts to diverge on a per-instance
+			// basis, and use that to set unique WAL dirs for all instances in
+			// multi-instance mode.
+			testOpts.Opts.WALFailover = nil
+		} else {
+			testOpts.Opts.WALFailover.Secondary.FS = opts.FS
+			testOpts.Opts.WALFailover.Secondary.Dirname = opts.FS.PathJoin(
+				runDir, testOpts.Opts.WALFailover.Secondary.Dirname)
+		}
+	}
+
 	if opts.WALDir != "" {
 		if runOpts.numInstances > 1 {
 			// TODO(bilal): Allow opts to diverge on a per-instance basis, and use

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -75,6 +75,7 @@ func TestOptionsRoundtrip(t *testing.T) {
 		"Experimental.IngestSplit:",
 		"Experimental.RemoteStorage:",
 		"Experimental.SingleDeleteInvariantViolationCallback:",
+		"WALFailover.FailoverOptions.UnhealthyOperationLatencyThreshold:",
 		// Floating points
 		"Experimental.PointTombstoneWeight:",
 		"Experimental.MultiLevelCompactionHeuristic.AddPropensity",


### PR DESCRIPTION
Integrates WAL failover into the metamorphic tests as a random option with random durations. Future work #2482 will expand the circumstances in which we'll actually exercise failover by injecting artifical I/O latency.

Informs #3230.