### PR TITLE
db: fix batch recycling data race with WAL failover

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -367,7 +367,7 @@ func (p *commitPipeline) AllocateSeqNum(
 	// performance critical code paths.
 
 	b := newBatch(nil)
-	defer b.release()
+	defer b.Close()
 
 	// Give the batch a count of 1 so that the log and visible sequence number
 	// are incremented correctly.

--- a/commit_test.go
+++ b/commit_test.go
@@ -416,7 +416,7 @@ func BenchmarkCommitPipeline(b *testing.B) {
 									b.Fatal(err)
 								}
 							}
-							batch.release()
+							batch.Close()
 						}
 					})
 				})

--- a/mem_table_test.go
+++ b/mem_table_test.go
@@ -363,7 +363,7 @@ func TestMemTableConcurrentDeleteRange(t *testing.T) {
 				b.DeleteRange(start, end, nil)
 				n := seqNum.Add(1) - 1
 				require.NoError(t, m.apply(b, n))
-				b.release()
+				b.Close()
 
 				var count int
 				it := m.newRangeDelIter(nil)

--- a/testdata/batch_reuse
+++ b/testdata/batch_reuse
@@ -1,0 +1,137 @@
+# Test a simple NewBatch + Close sequence without any reference counting.
+# This is the common case when configured without WAL failover. We cheat and
+# read the length [b1.Len()] at the end to ensure the batch was reset.
+
+run
+b1 = db.NewBatch()
+b1.Len()
+b1.Set("foo", "hello world")
+b1.Len()
+b1.lifecycle
+b1.Close()
+# At this point the batch is reused. It's not legal to call any methods
+# on the batch, but we cheat and introspect the length to make sure it's
+# reset to the length of the batch header.
+b1.lifecycle
+b1.Len()
+----
+b1 = db.NewBatch()
+b1.Len() = 12
+b1.Set("foo", "hello world")
+b1.Len() = 19
+b1.lifecycle = 0
+b1.Close() = <nil>
+# At this point the batch is reused. It's not legal to call any methods
+# on the batch, but we cheat and introspect the length to make sure it's
+# reset to the length of the batch header.
+b1.lifecycle = 0
+b1.Len() = 12
+
+run
+b2 = db.NewBatch()
+b2.Len()
+b2.Set("foo", "hello world")
+b2.Len()
+b2.lifecycle
+b2.refData()
+b2.lifecycle
+b2.unrefData()
+b2.lifecycle
+b2.Len()
+b2.Close()
+# At this point the batch has been inserted into the pool. It's not legal to
+# call any methods on the batch, but we cheat and introspect the length to make
+# sure it's reset to the length of the batch header.
+b2.Len()
+----
+b2 = db.NewBatch()
+b2.Len() = 12
+b2.Set("foo", "hello world")
+b2.Len() = 19
+b2.lifecycle = 0
+b2.refData()
+b2.lifecycle = 1
+b2.unrefData()
+b2.lifecycle = 0
+b2.Len() = 19
+b2.Close() = <nil>
+# At this point the batch has been inserted into the pool. It's not legal to
+# call any methods on the batch, but we cheat and introspect the length to make
+# sure it's reset to the length of the batch header.
+b2.Len() = 12
+
+run
+b3 = db.NewBatch()
+b3.Len()
+b3.Set("foo", "hello world")
+b3.Len()
+b3.lifecycle
+b3.refData()
+b3.lifecycle
+b3.Close()
+# Although Close() has been called, b3 should not yet be in the pool (or
+# have been zeroed out yet). The open reference count prevents it.
+b3.lifecycle
+b3.Len()
+# Calling Close() again should error.
+b3.Close()
+b3.unrefData()
+# At this point the batch has been inserted into the pool. It's not legal to
+# call any methods on the batch, but we cheat and introspect the length to make
+# sure it's reset to the length of the batch header.
+b3.lifecycle
+b3.Len()
+----
+b3 = db.NewBatch()
+b3.Len() = 12
+b3.Set("foo", "hello world")
+b3.Len() = 19
+b3.lifecycle = 0
+b3.refData()
+b3.lifecycle = 1
+b3.Close() = <nil>
+# Although Close() has been called, b3 should not yet be in the pool (or
+# have been zeroed out yet). The open reference count prevents it.
+b3.lifecycle = 1000000000000000000000000000001
+b3.Len() = 19
+# Calling Close() again should error.
+b3.Close() = pebble: closed
+b3.unrefData()
+# At this point the batch has been inserted into the pool. It's not legal to
+# call any methods on the batch, but we cheat and introspect the length to make
+# sure it's reset to the length of the batch header.
+b3.lifecycle = 0
+b3.Len() = 12
+
+run
+b4 = new(Batch)
+b4.Len()
+b4.Set("foo", "hello world")
+b4.Len()
+cap(b4.data)
+b4.lifecycle
+b4.refData()
+b4.lifecycle
+b4.Reset()
+# At this point the batch has been reset to be logically empty. The b.data slice
+# will have been released because of the outstanding reference.
+b4.Len()
+cap(b4.data)
+b4.unrefData()
+b4.lifecycle
+----
+b4 = new(Batch)
+b4.Len() = 12
+b4.Set("foo", "hello world")
+b4.Len() = 19
+cap(b4.data) = 1024
+b4.lifecycle = 0
+b4.refData()
+b4.lifecycle = 1
+b4.Reset()
+# At this point the batch has been reset to be logically empty. The b.data slice
+# will have been released because of the outstanding reference.
+b4.Len() = 12
+cap(b4.data) = 0
+b4.unrefData()
+b4.lifecycle = 0

--- a/wal/failover_manager_test.go
+++ b/wal/failover_manager_test.go
@@ -441,7 +441,7 @@ func TestManagerFailover(t *testing.T) {
 			case "write-record":
 				var value string
 				td.ScanArgs(t, "value", &value)
-				offset, err := fw.WriteRecord([]byte(value), SyncOptions{})
+				offset, err := fw.WriteRecord([]byte(value), SyncOptions{}, nil)
 				require.NoError(t, err)
 				return fmt.Sprintf("offset: %d", offset)
 
@@ -572,7 +572,7 @@ func TestFailoverManager_Quiesce(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		w, err := m.Create(NumWAL(i), i)
 		require.NoError(t, err)
-		_, err = w.WriteRecord([]byte("hello world"), SyncOptions{})
+		_, err = w.WriteRecord([]byte("hello world"), SyncOptions{}, nil)
 		require.NoError(t, err)
 		_, err = w.Close()
 		require.NoError(t, err)

--- a/wal/failover_writer_test.go
+++ b/wal/failover_writer_test.go
@@ -354,7 +354,7 @@ func TestFailoverWriter(t *testing.T) {
 					syncs = append(syncs, synco)
 					var value string
 					td.ScanArgs(t, "value", &value)
-					offset, err := w.WriteRecord([]byte(value), synco)
+					offset, err := w.WriteRecord([]byte(value), synco, nil)
 					require.NoError(t, err)
 					// The offset can be non-deterministic depending on which LogWriter
 					// is being written to, so print it only when requested.
@@ -653,7 +653,7 @@ func TestConcurrentWritersWithManyRecords(t *testing.T) {
 		queueSemChan <- struct{}{}
 		wg.Add(1)
 		synco := SyncOptions{Done: wg, Err: new(error)}
-		_, err := ww.WriteRecord(records[i], synco)
+		_, err := ww.WriteRecord(records[i], synco, nil)
 		require.NoError(t, err)
 		if i > 0 && i%switchInterval == 0 {
 			dirIndex = (dirIndex + 1) % 2

--- a/wal/standalone_manager.go
+++ b/wal/standalone_manager.go
@@ -269,7 +269,7 @@ var _ Writer = &standaloneWriter{}
 
 // WriteRecord implements Writer.
 func (w *standaloneWriter) WriteRecord(
-	p []byte, opts SyncOptions,
+	p []byte, opts SyncOptions, _ RefFunc,
 ) (logicalOffset int64, err error) {
 	return w.w.SyncRecord(p, opts.Done, opts.Err)
 }


### PR DESCRIPTION
Fix a data race between Batch reuse and WAL failover. Before the existence of WAL failover, a committed batch was read synchronously during the commit pipeline's call to LogWriter.[Write|Sync]Record. When Batch.Commit returned, the caller was guaranteed that the Batch was safe for reuse. The Batch could be reused either immediately and explcitly through calling Reset, or implicitly through calling Close which added the Batch to a sync.Pool.

Now, when  WAL failover is configured, a committed batch must be retained by the WAL writer until the batch has been durably synced, because it may need to re-encode the batch into a new WAL block for a new WAL file in the event of a failover. If the Batch was reused before the wal.Writer's reads completed, the wal.Writer could read the mutated batch representation.

This commit fixes the race by adding a new lifecycle atomic to the Batch that serves as:
  a) a reference count for the wal.Writer's reference to the batch data
  b) a flag to signal that the caller has called Close on the Batch

See the comment on Batch.lifecycle for detailed mechanics.

Fix #3375.