### PR TITLE
metamorphic: inject random IO latency

### DIFF
--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -479,6 +479,15 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 	} else {
 		opts.Cleaner = base.ArchiveCleaner{}
 	}
+	// Wrap the filesystem with a VFS that will inject random latency if
+	// the test options require it.
+	if testOpts.ioLatencyProbability > 0.0 {
+		opts.FS = errorfs.Wrap(opts.FS, errorfs.RandomLatency(
+			errorfs.Randomly(testOpts.ioLatencyProbability, testOpts.ioLatencySeed),
+			testOpts.ioLatencyMean,
+			testOpts.ioLatencySeed,
+		))
+	}
 
 	// Wrap the filesystem with one that will inject errors into read
 	// operations with *errorRate probability.


### PR DESCRIPTION
Inject random latency in some IO operations in some random configurations of the metamorphic test. This helps exercise code that's dependent on IO latency, most notably WAL failover.

Close #2482.