### PR TITLE
db: verify virtualBackings in invariants mode

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -192,7 +192,7 @@ func (d *DB) Checkpoint(
 	optionsFileNum := d.optionsFileNum
 
 	virtualBackingFiles := make(map[base.DiskFileNum]struct{})
-	d.mu.versions.fileBackings.ForEach(func(backing *fileBacking) {
+	d.mu.versions.virtualBackings.ForEach(func(backing *fileBacking) {
 		virtualBackingFiles[backing.DiskFileNum] = struct{}{}
 	})
 

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -132,7 +132,7 @@ func TestCheckpoint(t *testing.T) {
 			d := dbs[td.CmdArgs[0].String()]
 			d.mu.Lock()
 			d.mu.versions.logLock()
-			fileNums := d.mu.versions.fileBackings.DiskFileNums()
+			fileNums := d.mu.versions.virtualBackings.DiskFileNums()
 			d.mu.versions.logUnlock()
 			d.mu.Unlock()
 

--- a/db.go
+++ b/db.go
@@ -2136,7 +2136,7 @@ func (d *DB) Metrics() *Metrics {
 
 	d.mu.versions.logLock()
 	metrics.private.manifestFileSize = uint64(d.mu.versions.manifest.Size())
-	backingCount, backingTotalSize := d.mu.versions.fileBackings.Stats()
+	backingCount, backingTotalSize := d.mu.versions.virtualBackings.Stats()
 	metrics.Table.BackingTableCount = uint64(backingCount)
 	metrics.Table.BackingTableSize = backingTotalSize
 	d.mu.versions.logUnlock()

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -526,6 +526,13 @@ func (v *VersionEdit) string(verbose bool, fmtKey base.FormatKey) string {
 		}
 		fmt.Fprintln(&buf)
 	}
+
+	for _, b := range v.CreatedBackingTables {
+		fmt.Fprintf(&buf, "  add backing:   %s\n", b.DiskFileNum)
+	}
+	for _, n := range v.RemovedBackingTables {
+		fmt.Fprintf(&buf, "  del backing:   %s\n", n)
+	}
 	return buf.String()
 }
 

--- a/testdata/excise
+++ b/testdata/excise
@@ -35,6 +35,7 @@ would excise 2 files, use ingest-and-excise to excise.
   deleted:       L6 000004
   added:         L6 000007(000004):[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET]
   added:         L6 000008(000004):[l#10,SET-l#10,SET] seqnums:[10-10] points:[l#10,SET-l#10,SET]
+  add backing:   000004
 
 
 excise a e
@@ -44,6 +45,8 @@ would excise 2 files, use ingest-and-excise to excise.
   deleted:       L6 000004
   added:         L0 000009(000006):[f#12,SET-f#12,SET] seqnums:[11-12] points:[f#12,SET-f#12,SET]
   added:         L6 000010(000004):[l#10,SET-l#10,SET] seqnums:[10-10] points:[l#10,SET-l#10,SET]
+  add backing:   000006
+  add backing:   000004
 
 excise e z
 ----
@@ -52,6 +55,8 @@ would excise 2 files, use ingest-and-excise to excise.
   deleted:       L6 000004
   added:         L0 000011(000006):[d#11,SET-d#11,SET] seqnums:[11-12] points:[d#11,SET-d#11,SET]
   added:         L6 000012(000004):[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET]
+  add backing:   000006
+  add backing:   000004
 
 excise f l
 ----
@@ -61,6 +66,8 @@ would excise 2 files, use ingest-and-excise to excise.
   added:         L0 000013(000006):[d#11,SET-d#11,SET] seqnums:[11-12] points:[d#11,SET-d#11,SET]
   added:         L6 000014(000004):[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET]
   added:         L6 000015(000004):[l#10,SET-l#10,SET] seqnums:[10-10] points:[l#10,SET-l#10,SET]
+  add backing:   000006
+  add backing:   000004
 
 excise f ll
 ----
@@ -69,6 +76,8 @@ would excise 2 files, use ingest-and-excise to excise.
   deleted:       L6 000004
   added:         L0 000016(000006):[d#11,SET-d#11,SET] seqnums:[11-12] points:[d#11,SET-d#11,SET]
   added:         L6 000017(000004):[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET]
+  add backing:   000006
+  add backing:   000004
 
 excise p q
 ----
@@ -156,12 +165,14 @@ would excise 1 files, use ingest-and-excise to excise.
   deleted:       L0 000005
   added:         L0 000006(000005):[b#11,SET-b#11,SET] seqnums:[11-11] points:[b#11,SET-b#11,SET]
   added:         L0 000007(000005):[g#11,RANGEDEL-i#inf,RANGEDEL] seqnums:[11-11] points:[g#11,RANGEDEL-i#inf,RANGEDEL]
+  add backing:   000005
 
 excise b c
 ----
 would excise 1 files, use ingest-and-excise to excise.
   deleted:       L0 000005
   added:         L0 000008(000005):[g#11,RANGEDEL-i#inf,RANGEDEL] seqnums:[11-11] points:[g#11,RANGEDEL-i#inf,RANGEDEL]
+  add backing:   000005
 
 excise i j
 ----
@@ -178,6 +189,8 @@ would excise 2 files, use ingest-and-excise to excise.
   added:         L0 000009(000005):[b#11,SET-b#11,SET] seqnums:[11-11] points:[b#11,SET-b#11,SET]
   added:         L0 000010(000005):[g#11,RANGEDEL-i#inf,RANGEDEL] seqnums:[11-11] points:[g#11,RANGEDEL-i#inf,RANGEDEL]
   added:         L6 000011(000004):[d#10,RANGEKEYSET-f#inf,RANGEKEYSET] seqnums:[10-10] ranges:[d#10,RANGEKEYSET-f#inf,RANGEKEYSET]
+  add backing:   000005
+  add backing:   000004
 
 reset
 ----

--- a/testdata/ingest_shared
+++ b/testdata/ingest_shared
@@ -114,6 +114,7 @@ would excise 1 files, use ingest-and-excise to excise.
   deleted:       L6 000007
   added:         L6 000008:[a#0,SET-d#0,SET]
   added:         L6 000009:[l#0,SET-l#0,SET]
+  add backing:   000007
 
 replicate 2 1 e gg
 ----

--- a/testdata/ingest_shared_lower
+++ b/testdata/ingest_shared_lower
@@ -114,6 +114,7 @@ would excise 1 files, use ingest-and-excise to excise.
   deleted:       L6 000008
   added:         L6 000009:[a#0,SET-d#0,SET]
   added:         L6 000010:[l#0,SET-l#0,SET]
+  add backing:   000008
 
 replicate 2 1 e gg
 ----

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -31,7 +31,7 @@ func writeAndIngest(t *testing.T, mem vfs.FS, d *DB, k InternalKey, v []byte, fi
 // d.mu should be help. logLock should not be held.
 func checkBackingSize(t *testing.T, d *DB) {
 	d.mu.versions.logLock()
-	d.mu.versions.fileBackings.Check()
+	d.mu.versions.virtualBackings.Check()
 	d.mu.versions.logUnlock()
 }
 
@@ -156,7 +156,7 @@ func TestLatestRefCounting(t *testing.T) {
 	// to the physical sstable.
 	require.Equal(t, 2, int(m1.LatestRefs()))
 	require.Equal(t, 0, len(d.mu.versions.obsoleteTables))
-	require.Equal(t, []base.DiskFileNum{f.FileBacking.DiskFileNum}, d.mu.versions.fileBackings.DiskFileNums())
+	require.Equal(t, []base.DiskFileNum{f.FileBacking.DiskFileNum}, d.mu.versions.virtualBackings.DiskFileNums())
 	require.Equal(t, f.Size, m2.FileBacking.VirtualizedSize.Load())
 	checkBackingSize(t, d)
 
@@ -176,7 +176,7 @@ func TestLatestRefCounting(t *testing.T) {
 	require.Equal(t, 1, int(m2.LatestRefs()))
 	require.Equal(t, 0, len(d.mu.versions.zombieTables))
 	require.Equal(t, 0, len(d.mu.versions.obsoleteTables))
-	require.Equal(t, []base.DiskFileNum{f.FileBacking.DiskFileNum}, d.mu.versions.fileBackings.DiskFileNums())
+	require.Equal(t, []base.DiskFileNum{f.FileBacking.DiskFileNum}, d.mu.versions.virtualBackings.DiskFileNums())
 	require.Equal(t, m2.Size, m2.FileBacking.VirtualizedSize.Load())
 	checkBackingSize(t, d)
 
@@ -193,7 +193,7 @@ func TestLatestRefCounting(t *testing.T) {
 	require.Equal(t, 1, int(m2.LatestRefs()))
 	require.Equal(t, 0, len(d.mu.versions.zombieTables))
 	require.Equal(t, 0, len(d.mu.versions.obsoleteTables))
-	require.Equal(t, []base.DiskFileNum{f.FileBacking.DiskFileNum}, d.mu.versions.fileBackings.DiskFileNums())
+	require.Equal(t, []base.DiskFileNum{f.FileBacking.DiskFileNum}, d.mu.versions.virtualBackings.DiskFileNums())
 	require.Equal(t, m2.Size, m2.FileBacking.VirtualizedSize.Load())
 
 	// Delete m2 from L6.
@@ -208,7 +208,7 @@ func TestLatestRefCounting(t *testing.T) {
 	require.Equal(t, 0, int(m2.LatestRefs()))
 	require.Equal(t, 1, len(d.mu.versions.zombieTables))
 	require.Equal(t, f.Size, d.mu.versions.zombieTables[f.FileBacking.DiskFileNum])
-	require.Equal(t, []base.DiskFileNum{}, d.mu.versions.fileBackings.DiskFileNums())
+	require.Equal(t, []base.DiskFileNum{}, d.mu.versions.virtualBackings.DiskFileNums())
 	require.Equal(t, 0, int(m2.FileBacking.VirtualizedSize.Load()))
 	checkBackingSize(t, d)
 }
@@ -333,7 +333,7 @@ func TestVirtualSSTableManifestReplay(t *testing.T) {
 
 	require.Equal(t, 2, int(m1.LatestRefs()))
 	require.Equal(t, 0, len(d.mu.versions.obsoleteTables))
-	require.Equal(t, []base.DiskFileNum{f.FileBacking.DiskFileNum}, d.mu.versions.fileBackings.DiskFileNums())
+	require.Equal(t, []base.DiskFileNum{f.FileBacking.DiskFileNum}, d.mu.versions.virtualBackings.DiskFileNums())
 	require.Equal(t, f.Size, m2.FileBacking.VirtualizedSize.Load())
 
 	// Snapshot version edit will be written to a new manifest due to the flush.
@@ -356,7 +356,7 @@ func TestVirtualSSTableManifestReplay(t *testing.T) {
 
 	require.Equal(t, 2, int(virtualFile.LatestRefs()))
 	require.Equal(t, 0, len(d.mu.versions.obsoleteTables))
-	require.Equal(t, []base.DiskFileNum{f.FileBacking.DiskFileNum}, d.mu.versions.fileBackings.DiskFileNums())
+	require.Equal(t, []base.DiskFileNum{f.FileBacking.DiskFileNum}, d.mu.versions.virtualBackings.DiskFileNums())
 	require.Equal(t, f.Size, virtualFile.FileBacking.VirtualizedSize.Load())
 	checkBackingSize(t, d)
 	d.mu.Unlock()
@@ -376,7 +376,7 @@ func TestVirtualSSTableManifestReplay(t *testing.T) {
 	}
 	require.Nil(t, virtualFile)
 	require.Equal(t, 0, len(d.mu.versions.obsoleteTables))
-	require.Equal(t, []base.DiskFileNum{}, d.mu.versions.fileBackings.DiskFileNums())
+	require.Equal(t, []base.DiskFileNum{}, d.mu.versions.virtualBackings.DiskFileNums())
 	checkBackingSize(t, d)
 	d.mu.Unlock()
 
@@ -397,7 +397,7 @@ func TestVirtualSSTableManifestReplay(t *testing.T) {
 	}
 	require.Nil(t, virtualFile)
 	require.Equal(t, 0, len(d.mu.versions.obsoleteTables))
-	require.Equal(t, []base.DiskFileNum{}, d.mu.versions.fileBackings.DiskFileNums())
+	require.Equal(t, []base.DiskFileNum{}, d.mu.versions.virtualBackings.DiskFileNums())
 	checkBackingSize(t, d)
 	d.mu.Unlock()
 	require.NoError(t, d.Close())


### PR DESCRIPTION
#### manifest: show created/deleted backings in VersionEdit.String


#### db: rename fileBackings to virtualBackings

Rename to clarify that this includes only backings for virtual
sstables.

#### db: verify virtualBackings in invariants mode

And fix the copy compaction code to create the backing in the
manifest.