### PR TITLE
db: move skip-remote logic out of manifest.LevelIterator

### DIFF
--- a/db.go
+++ b/db.go
@@ -1335,7 +1335,9 @@ func finishInitializingInternalIter(
 	}
 	i.initializeBoundBufs(i.opts.LowerBound, i.opts.UpperBound)
 
-	i.constructPointIter(i.opts.CategoryAndQoS, memtables, buf)
+	if err := i.constructPointIter(i.opts.CategoryAndQoS, memtables, buf); err != nil {
+		return nil, err
+	}
 
 	// For internal iterators, we skip the lazy combined iteration optimization
 	// entirely, and create the range key iterator stack directly.


### PR DESCRIPTION
Previously, we were adding remote file skipping logic to LevelIterator alongside the logic to skip files without point/range keys. Since determining whether a file is remote or not requires an objprovider call, this change moves that to iterator construction and undo's the change to leveliterator.