### PR TITLE
db: rework backing refcount management

### DIFF
--- a/internal/keyspan/keyspanimpl/level_iter_test.go
+++ b/internal/keyspan/keyspanimpl/level_iter_test.go
@@ -310,7 +310,7 @@ func TestLevelIterEquivalence(t *testing.T) {
 				amap[metas[i].FileNum] = metas[i]
 			}
 			b.Added[6] = amap
-			v, err := b.Apply(nil, base.DefaultComparer, 0, 0, nil)
+			v, err := b.Apply(nil, base.DefaultComparer, 0, 0)
 			require.NoError(t, err)
 			levelIter.Init(
 				keyspan.SpanIterOptions{}, base.DefaultComparer.Compare, tableNewIters,
@@ -454,7 +454,7 @@ func TestLevelIter(t *testing.T) {
 					amap[metas[i].FileNum] = metas[i]
 				}
 				b.Added[6] = amap
-				v, err := b.Apply(nil, base.DefaultComparer, 0, 0, nil)
+				v, err := b.Apply(nil, base.DefaultComparer, 0, 0)
 				require.NoError(t, err)
 				iter = NewLevelIter(
 					keyspan.SpanIterOptions{}, base.DefaultComparer.Compare,

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -51,7 +51,7 @@ func readManifest(filename string) (*Version, error) {
 		if err := bve.Accumulate(&ve); err != nil {
 			return nil, err
 		}
-		if v, err = bve.Apply(v, base.DefaultComparer, 10<<20, 32000, nil); err != nil {
+		if v, err = bve.Apply(v, base.DefaultComparer, 10<<20, 32000); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -124,7 +124,7 @@ func replayManifest(t *testing.T, opts *pebble.Options, dirname string) *manifes
 	}
 	v, err := bve.Apply(
 		nil /* version */, cmp, opts.FlushSplitBytes,
-		opts.Experimental.ReadCompactionRate, nil /* zombies */)
+		opts.Experimental.ReadCompactionRate)
 	require.NoError(t, err)
 	return v
 }

--- a/internal/manifest/testdata/version_edit_apply
+++ b/internal/manifest/testdata/version_edit_apply
@@ -16,7 +16,6 @@ edit
 2:
   000001:[a#1,SET-b#2,SET]
   000004:[c#3,SET-d#4,SET]
-zombies []
 
 apply
  L0
@@ -59,7 +58,6 @@ edit
   000002:[c#3,SET-d#4,SET]
 0.0:
   000001:[a#1,SET-c#2,SET]
-zombies []
 
 apply
  L0
@@ -76,7 +74,6 @@ edit
   000001:[a#1,SET-c#2,SET]
 0.0:
   000004:[b#0,SET-d#0,SET]
-zombies []
 
 
 apply
@@ -90,7 +87,6 @@ edit
   000004:[b#3,SET-d#5,SET]
 0.0:
   000001:[a#1,SET-c#2,SET]
-zombies []
 
 apply
  L0
@@ -98,7 +94,6 @@ apply
 ----
 0.0:
   000001:[a#1,SET-c#2,SET]
-zombies []
 
 apply
  L2
@@ -125,7 +120,6 @@ edit
   000005:[h#3,SET-h#2,SET]
   000010:[j#3,SET-m#2,SET]
   000002:[n#5,SET-q#3,SET]
-zombies [1 4]
 
 apply
 edit
@@ -137,9 +131,6 @@ edit
 2:
   000006:[a#10,SET-a#7,SET]
   000010:[j#3,SET-m#2,SET]
-zombies []
-
-# Verify that the zombies map is populated correctly.
 
 apply
  L0
@@ -153,7 +144,6 @@ edit
   L1
    2
 ----
-zombies [1 2]
 
 # Deletion of a non-existent table results in an error.
 
@@ -188,4 +178,3 @@ edit
 ----
 2:
   000005:[s#3,SET-z#4,SET]
-zombies []

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -506,7 +506,7 @@ func (m *FileMetadata) LatestRef() {
 }
 
 // LatestUnref decrements the latest ref count associated with the backing
-// sstable.
+// sstable and returns the new refcount.
 func (m *FileMetadata) LatestUnref() int32 {
 	if m.Virtual {
 		m.FileBacking.VirtualizedSize.Add(-m.Size)

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"os"
 	"reflect"
-	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -526,23 +525,11 @@ func TestVersionEditApply(t *testing.T) {
 						return err.Error()
 					}
 				}
-				zombies := make(map[base.DiskFileNum]uint64)
-				newv, err := bve.Apply(v, base.DefaultComparer, flushSplitBytes, 32000, zombies)
+				newv, err := bve.Apply(v, base.DefaultComparer, flushSplitBytes, 32000)
 				if err != nil {
 					return err.Error()
 				}
-
-				zombieFileNums := make([]base.DiskFileNum, 0, len(zombies))
-				if len(veList) == 1 {
-					// Only care about zombies if a single version edit was
-					// being applied.
-					for fileNum := range zombies {
-						zombieFileNums = append(zombieFileNums, fileNum)
-					}
-					slices.Sort(zombieFileNums)
-				}
-
-				return fmt.Sprintf("%szombies %d\n", newv, zombieFileNums)
+				return newv.String()
 
 			default:
 				return fmt.Sprintf("unknown command: %s", d.Cmd)

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -716,8 +716,7 @@ func (r *Runner) prepareWorkloadSteps(ctx context.Context) error {
 		v, err = bve.Apply(v,
 			r.Opts.Comparer,
 			r.Opts.FlushSplitBytes,
-			r.Opts.Experimental.ReadCompactionRate,
-			nil /* zombies */)
+			r.Opts.Experimental.ReadCompactionRate)
 		bve = manifest.BulkVersionEdit{AddedByFileNum: bve.AddedByFileNum}
 		return v, err
 	}

--- a/tool/db.go
+++ b/tool/db.go
@@ -530,7 +530,7 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 		}
 		v, err := bve.Apply(
 			nil /* version */, cmp, d.opts.FlushSplitBytes,
-			d.opts.Experimental.ReadCompactionRate, nil, /* zombies */
+			d.opts.Experimental.ReadCompactionRate,
 		)
 		if err != nil {
 			return err

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -244,7 +244,6 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 				v, err := bve.Apply(
 					nil /* version */, comparer, 0,
 					m.opts.Experimental.ReadCompactionRate,
-					nil, /* zombies */
 				)
 				if err != nil {
 					fmt.Fprintf(stdout, "%s\n", err)
@@ -552,7 +551,7 @@ func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
 				}
 				// TODO(sbhola): add option to Apply that reports all errors instead of
 				// one error.
-				newv, err := bve.Apply(v, cmp, 0, m.opts.Experimental.ReadCompactionRate, nil /* zombies */)
+				newv, err := bve.Apply(v, cmp, 0, m.opts.Experimental.ReadCompactionRate)
 				if err != nil {
 					fmt.Fprintf(stdout, "%s: offset: %d err: %s\n",
 						arg, offset, err)


### PR DESCRIPTION
Previously, the logic for maintaining the `virtualBackings` map was very convoluted; in addition, modification happened outside `DB.mu` which makes the map unusable outside the log lock (we will want to use it for finding existing external backings).

`Apply` is no longer responsible for updating the backing refcounts and the `virtualBackings` map (and for updating a zombies map). It is more straightforward to do that separately (and under `DB.mu`); this allows us to remove `AccumulateIncompleteAndApplySingleVE` as well, which was semantically dubious (e.g. it modified `ve`).