### PR TITLE
scan_internal: don't visit empty external files

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -1179,23 +1179,6 @@ type ExternalFile struct {
 	Level uint8
 }
 
-func (e *ExternalFile) cloneFromFileMeta(f *fileMetadata) {
-	*e = ExternalFile{
-		Bounds: KeyRange{
-			Start: append([]byte(nil), f.Smallest.UserKey...),
-			End:   append([]byte(nil), f.Largest.UserKey...),
-		},
-		HasPointKey: f.HasPointKeys,
-		HasRangeKey: f.HasRangeKeys,
-		Size:        f.Size,
-	}
-	e.SyntheticSuffix = append([]byte(nil), f.SyntheticSuffix...)
-	if pr := f.PrefixReplacement; pr != nil {
-		e.ContentPrefix = append([]byte(nil), pr.ContentPrefix...)
-		e.SyntheticPrefix = append([]byte(nil), pr.SyntheticPrefix...)
-	}
-}
-
 // IngestWithStats does the same as Ingest, and additionally returns
 // IngestOperationStats.
 func (d *DB) IngestWithStats(paths []string) (IngestOperationStats, error) {

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -695,3 +695,19 @@ a: (d2-v1, .)
 b: (d1-v1, .)
 d: (d1-v1, .)
 e: (d2-v1, .)
+
+reset
+----
+
+build-remote trunctest
+set a foo
+set b bar
+----
+
+ingest-external
+trunctest bounds=(a,c)
+----
+
+replicate 1 2 c z
+----
+replicated 0 external SSTs


### PR DESCRIPTION
When truncating external files to our scan bounds, we may find that the file has Start == End. Other validation in ingest asserts these are invalid bounds.