### PR TITLE
manifest: add VersionEdit tests with virtual tables

### DIFF
--- a/internal/manifest/testdata/version_edit_apply
+++ b/internal/manifest/testdata/version_edit_apply
@@ -169,3 +169,49 @@ new version edit
 ----
 L2:
   000005:[s#3,SET-z#4,SET] seqnums:[0-0] points:[s#3,SET-z#4,SET]
+
+define v6
+L1:
+  000001:[a#2,SET-e#2,SET]
+L2:
+  000002:[c#1,SET-f#1,SET]
+----
+L1:
+  000001:[a#2,SET-e#2,SET] seqnums:[0-0] points:[a#2,SET-e#2,SET]
+L2:
+  000002:[c#1,SET-f#1,SET] seqnums:[0-0] points:[c#1,SET-f#1,SET]
+
+# Convert a physical table to virtual tables.
+apply v6
+  del-table: L1 000001
+  add-table: L1 000003(000009):[a#2,SET-b#2,SET]
+  add-table: L1 000004(000009):[c#2,SET-e#2,SET]
+  add-backing: 000009
+----
+L1:
+  000003(000009):[a#2,SET-b#2,SET] seqnums:[0-0] points:[a#2,SET-b#2,SET]
+  000004(000009):[c#2,SET-e#2,SET] seqnums:[0-0] points:[c#2,SET-e#2,SET]
+L2:
+  000002:[c#1,SET-f#1,SET] seqnums:[0-0] points:[c#1,SET-f#1,SET]
+
+define v7
+L1:
+  000003(000009):[a#2,SET-b#2,SET] seqnums:[0-0] points:[a#2,SET-b#2,SET]
+  000004(000009):[c#2,SET-e#2,SET] seqnums:[0-0] points:[c#2,SET-e#2,SET]
+L2:
+  000002:[c#1,SET-f#1,SET] seqnums:[0-0] points:[c#1,SET-f#1,SET]
+----
+L1:
+  000003(000009):[a#2,SET-b#2,SET] seqnums:[0-0] points:[a#2,SET-b#2,SET]
+  000004(000009):[c#2,SET-e#2,SET] seqnums:[0-0] points:[c#2,SET-e#2,SET]
+L2:
+  000002:[c#1,SET-f#1,SET] seqnums:[0-0] points:[c#1,SET-f#1,SET]
+
+# Remove virtual tables and their backing.
+apply v7
+  del-table: L1 000003
+  del-table: L1 000004
+  del-backing: 000009
+----
+L2:
+  000002:[c#1,SET-f#1,SET] seqnums:[0-0] points:[c#1,SET-f#1,SET]

--- a/internal/manifest/testdata/version_edit_apply
+++ b/internal/manifest/testdata/version_edit_apply
@@ -15,9 +15,9 @@ L0.0:
   000002:[c#3,SET-d#4,SET] seqnums:[3-4] points:[c#3,SET-d#4,SET]
 
 apply v1
-  deleted: L0 000001
-  added:   L2 000001:[a#1,SET-b#2,SET] seqnums:[1-2]
-  added:   L2 000004:[c#3,SET-d#4,SET] seqnums:[3-4]
+  del-table: L0 000001
+  add-table: L2 000001:[a#1,SET-b#2,SET] seqnums:[1-2]
+  add-table: L2 000004:[c#3,SET-d#4,SET] seqnums:[3-4]
 ----
 L0.0:
   000002:[c#3,SET-d#4,SET] seqnums:[3-4] points:[c#3,SET-d#4,SET]
@@ -26,14 +26,14 @@ L2:
   000004:[c#3,SET-d#4,SET] seqnums:[3-4] points:[c#3,SET-d#4,SET]
 
 apply v1
-  deleted: L1 000001
+  del-table: L1 000001
 ----
 pebble: internal error: No current or added files but have deleted files: 1
 
 apply v1
-  deleted: L0 000001
-  added:   L2 000001:[a#1,SET-b#2,SET] seqnums:[1-2]
-  added:   L2 000004:[b#3,SET-d#4,SET] seqnums:[3-4]
+  del-table: L0 000001
+  add-table: L2 000001:[a#1,SET-b#2,SET] seqnums:[1-2]
+  add-table: L2 000004:[b#3,SET-d#4,SET] seqnums:[3-4]
 ----
 pebble: internal error: L2 files 000001 and 000004 have overlapping ranges: [a#1,SET-b#2,SET] vs [b#3,SET-d#4,SET]
 
@@ -48,7 +48,7 @@ L0.0:
   000001:[a#1,SET-c#2,SET] seqnums:[1-2] points:[a#1,SET-c#2,SET]
 
 apply v2
-  added:   L0 000004:[b#3,SET-d#5,SET] seqnums:[3-5]
+  add-table: L0 000004:[b#3,SET-d#5,SET] seqnums:[3-5]
 ----
 L0.2:
   000004:[b#3,SET-d#5,SET] seqnums:[3-5] points:[b#3,SET-d#5,SET]
@@ -58,7 +58,7 @@ L0.0:
   000001:[a#1,SET-c#2,SET] seqnums:[1-2] points:[a#1,SET-c#2,SET]
 
 apply v2
-  added:   L0 000004:[b#0,SET-d#0,SET] seqnums:[0-0]
+  add-table: L0 000004:[b#0,SET-d#0,SET] seqnums:[0-0]
 ----
 L0.2:
   000002:[c#3,SET-d#4,SET] seqnums:[3-4] points:[c#3,SET-d#4,SET]
@@ -72,8 +72,8 @@ define empty
 ----
 
 apply empty
-  added:   L0 000001:[a#1,SET-c#2,SET] seqnums:[1-2]
-  added:   L0 000004:[b#3,SET-d#5,SET] seqnums:[3-5]
+  add-table: L0 000001:[a#1,SET-c#2,SET] seqnums:[1-2]
+  add-table: L0 000004:[b#3,SET-d#5,SET] seqnums:[3-5]
 ----
 L0.1:
   000004:[b#3,SET-d#5,SET] seqnums:[3-5] points:[b#3,SET-d#5,SET]
@@ -81,19 +81,19 @@ L0.0:
   000001:[a#1,SET-c#2,SET] seqnums:[1-2] points:[a#1,SET-c#2,SET]
 
 apply v2
-  added:   L0 000001:[a#1,SET-c#2,SET] seqnums:[1-2]
+  add-table: L0 000001:[a#1,SET-c#2,SET] seqnums:[1-2]
 ----
 pebble: files 000001 and 000001 collided on sort keys
 
 apply empty
-  added:   L0 000001:[a#1,SET-c#2,SET] seqnums:[1-2]
+  add-table: L0 000001:[a#1,SET-c#2,SET] seqnums:[1-2]
 ----
 L0.0:
   000001:[a#1,SET-c#2,SET] seqnums:[1-2] points:[a#1,SET-c#2,SET]
 
 apply empty
-  added:   L2 000010:[j#3,SET-m#2,SET]
-  added:   L2 000006:[a#10,SET-a#7,SET]
+  add-table: L2 000010:[j#3,SET-m#2,SET]
+  add-table: L2 000006:[a#10,SET-a#7,SET]
 ----
 L2:
   000006:[a#10,SET-a#7,SET] seqnums:[0-0] points:[a#10,SET-a#7,SET]
@@ -115,11 +115,11 @@ L2:
   000001:[r#2,SET-t#1,SET] seqnums:[0-0] points:[r#2,SET-t#1,SET]
 
 apply v3
-  deleted:  L2 000004
-  deleted:  L2 000001
-  added:    L2 000006:[a#10,SET-a#7,SET]
-  added:    L2 000007:[e#1,SET-g#2,SET]
-  added:    L2 000010:[j#3,SET-m#2,SET]
+  del-table: L2 000004
+  del-table: L2 000001
+  add-table: L2 000006:[a#10,SET-a#7,SET]
+  add-table: L2 000007:[e#1,SET-g#2,SET]
+  add-table: L2 000010:[j#3,SET-m#2,SET]
 ----
 L2:
   000006:[a#10,SET-a#7,SET] seqnums:[0-0] points:[a#10,SET-a#7,SET]
@@ -141,13 +141,13 @@ L1:
   000002:[c#3,SET-d#2,SET] seqnums:[0-0] points:[c#3,SET-d#2,SET]
 
 apply v4
-  deleted: L0 000001
-  deleted: L1 000002
+  del-table: L0 000001
+  del-table: L1 000002
 ----
 
 # Deletion of a non-existent table results in an error.
 apply v4
-  deleted: L0 000004
+  del-table: L0 000004
 ----
 error during Accumulate: pebble: file deleted L0.000004 before it was inserted
 
@@ -159,13 +159,13 @@ L0.0:
   000001:[a#1,SET-b#2,SET] seqnums:[0-0] points:[a#1,SET-b#2,SET]
 
 apply v5
-  deleted: L0 1
-  added: L2 000001:[a#1,SET-b#2,SET]
-  added: L2 000004:[c#3,SET-d#4,SET]
-  added: L2 000005:[s#3,SET-z#4,SET]
+  del-table: L0 1
+  add-table: L2 000001:[a#1,SET-b#2,SET]
+  add-table: L2 000004:[c#3,SET-d#4,SET]
+  add-table: L2 000005:[s#3,SET-z#4,SET]
 new version edit
-  deleted: L2 000001
-  deleted: L2 000004
+  del-table: L2 000001
+  del-table: L2 000004
 ----
 L2:
   000005:[s#3,SET-z#4,SET] seqnums:[0-0] points:[s#3,SET-z#4,SET]

--- a/internal/manifest/testutils.go
+++ b/internal/manifest/testutils.go
@@ -18,9 +18,9 @@ import (
 // ParseFileMetadataDebug.
 //
 // It takes a string and splits it into tokens. Tokens are separated by
-// whitespace; in addition separators ':', '[', ']', '-' are always separate
-// tokens. For example, the string `000001:[a - b]` results in tokens `000001`,
-// `:`, `[`, `a`, `-`, `b`, `]`.
+// whitespace; in addition separators "_-[]()" are always separate tokens. For
+// example, the string `000001:[a - b]` results in tokens `000001`,
+// `:`, `[`, `a`, `-`, `b`, `]`, .
 //
 // All debugParser methods throw panics instead of returning errors. The code
 // that uses a debugParser can recover them and convert them to errors.
@@ -30,7 +30,7 @@ type debugParser struct {
 	lastToken string
 }
 
-const debugParserSeparators = ":[]-"
+const debugParserSeparators = ":-[]()"
 
 func makeDebugParser(s string) debugParser {
 	p := debugParser{
@@ -136,6 +136,11 @@ func (p *debugParser) Uint64() uint64 {
 // FileNum parses the next token as a FileNum.
 func (p *debugParser) FileNum() base.FileNum {
 	return base.FileNum(p.Int())
+}
+
+// DiskFileNum parses the next token as a DiskFileNum.
+func (p *debugParser) DiskFileNum() base.DiskFileNum {
+	return base.DiskFileNum(p.Int())
 }
 
 // InternalKey parses the next token as an internal key.

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -588,6 +588,17 @@ func ParseVersionEditDebug(s string) (_ *VersionEdit, err error) {
 				FileNum: num,
 			}] = nil
 
+		case "add-backing":
+			n := p.DiskFileNum()
+			ve.CreatedBackingTables = append(ve.CreatedBackingTables, &FileBacking{
+				DiskFileNum: n,
+				Size:        100,
+			})
+
+		case "del-backing":
+			n := p.DiskFileNum()
+			ve.RemovedBackingTables = append(ve.RemovedBackingTables, n)
+
 		default:
 			return nil, errors.Errorf("field %q not implemented", field)
 		}

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -506,21 +506,21 @@ func TestParseVersionEditDebugRoundTrip(t *testing.T) {
 		output string
 	}{
 		{
-			input: `  added:         L1 000001:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL]`,
+			input: `  add-table:     L1 000001:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL]`,
 		},
 		{
-			input:  `added: L0 1:[a#0,SET-z#0,DEL]`,
-			output: `  added:         L0 000001:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL]`,
+			input:  `add-table: L0 1:[a#0,SET-z#0,DEL]`,
+			output: `  add-table:     L0 000001:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL]`,
 		},
 		{
-			input: `  deleted:       L1 000001`,
+			input: `  del-table:     L1 000001`,
 		},
 		{
 			input: strings.Join([]string{
-				`  deleted:       L1 000002`,
-				`  deleted:       L3 000003`,
-				`  added:         L1 000001:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL]`,
-				`  added:         L2 000002:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL]`,
+				`  del-table:     L1 000002`,
+				`  del-table:     L3 000003`,
+				`  add-table:     L1 000001:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL]`,
+				`  add-table:     L2 000002:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL]`,
 			}, "\n"),
 		},
 	}

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -404,6 +404,10 @@ func TestFileMetadata_ParseRoundTrip(t *testing.T) {
 			input:  " 000001 : [ a#0,SET - z#0,DEL] points : [ a#0,SET - z#0,DEL] ",
 			output: "000001:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL]",
 		},
+		{
+			name:  "virtual",
+			input: "000001(000008):[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL]",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/testdata/excise
+++ b/testdata/excise
@@ -31,53 +31,53 @@ L6:
 excise c k
 ----
 would excise 2 files, use ingest-and-excise to excise.
-  deleted:       L0 000006
-  deleted:       L6 000004
-  added:         L6 000007(000004):[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET]
-  added:         L6 000008(000004):[l#10,SET-l#10,SET] seqnums:[10-10] points:[l#10,SET-l#10,SET]
-  add backing:   000004
+  del-table:     L0 000006
+  del-table:     L6 000004
+  add-table:     L6 000007(000004):[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET]
+  add-table:     L6 000008(000004):[l#10,SET-l#10,SET] seqnums:[10-10] points:[l#10,SET-l#10,SET]
+  add-backing:   000004
 
 
 excise a e
 ----
 would excise 2 files, use ingest-and-excise to excise.
-  deleted:       L0 000006
-  deleted:       L6 000004
-  added:         L0 000009(000006):[f#12,SET-f#12,SET] seqnums:[11-12] points:[f#12,SET-f#12,SET]
-  added:         L6 000010(000004):[l#10,SET-l#10,SET] seqnums:[10-10] points:[l#10,SET-l#10,SET]
-  add backing:   000006
-  add backing:   000004
+  del-table:     L0 000006
+  del-table:     L6 000004
+  add-table:     L0 000009(000006):[f#12,SET-f#12,SET] seqnums:[11-12] points:[f#12,SET-f#12,SET]
+  add-table:     L6 000010(000004):[l#10,SET-l#10,SET] seqnums:[10-10] points:[l#10,SET-l#10,SET]
+  add-backing:   000006
+  add-backing:   000004
 
 excise e z
 ----
 would excise 2 files, use ingest-and-excise to excise.
-  deleted:       L0 000006
-  deleted:       L6 000004
-  added:         L0 000011(000006):[d#11,SET-d#11,SET] seqnums:[11-12] points:[d#11,SET-d#11,SET]
-  added:         L6 000012(000004):[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET]
-  add backing:   000006
-  add backing:   000004
+  del-table:     L0 000006
+  del-table:     L6 000004
+  add-table:     L0 000011(000006):[d#11,SET-d#11,SET] seqnums:[11-12] points:[d#11,SET-d#11,SET]
+  add-table:     L6 000012(000004):[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET]
+  add-backing:   000006
+  add-backing:   000004
 
 excise f l
 ----
 would excise 2 files, use ingest-and-excise to excise.
-  deleted:       L0 000006
-  deleted:       L6 000004
-  added:         L0 000013(000006):[d#11,SET-d#11,SET] seqnums:[11-12] points:[d#11,SET-d#11,SET]
-  added:         L6 000014(000004):[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET]
-  added:         L6 000015(000004):[l#10,SET-l#10,SET] seqnums:[10-10] points:[l#10,SET-l#10,SET]
-  add backing:   000006
-  add backing:   000004
+  del-table:     L0 000006
+  del-table:     L6 000004
+  add-table:     L0 000013(000006):[d#11,SET-d#11,SET] seqnums:[11-12] points:[d#11,SET-d#11,SET]
+  add-table:     L6 000014(000004):[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET]
+  add-table:     L6 000015(000004):[l#10,SET-l#10,SET] seqnums:[10-10] points:[l#10,SET-l#10,SET]
+  add-backing:   000006
+  add-backing:   000004
 
 excise f ll
 ----
 would excise 2 files, use ingest-and-excise to excise.
-  deleted:       L0 000006
-  deleted:       L6 000004
-  added:         L0 000016(000006):[d#11,SET-d#11,SET] seqnums:[11-12] points:[d#11,SET-d#11,SET]
-  added:         L6 000017(000004):[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET]
-  add backing:   000006
-  add backing:   000004
+  del-table:     L0 000006
+  del-table:     L6 000004
+  add-table:     L0 000016(000006):[d#11,SET-d#11,SET] seqnums:[11-12] points:[d#11,SET-d#11,SET]
+  add-table:     L6 000017(000004):[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET]
+  add-backing:   000006
+  add-backing:   000004
 
 excise p q
 ----
@@ -162,17 +162,17 @@ L6:
 excise f g
 ----
 would excise 1 files, use ingest-and-excise to excise.
-  deleted:       L0 000005
-  added:         L0 000006(000005):[b#11,SET-b#11,SET] seqnums:[11-11] points:[b#11,SET-b#11,SET]
-  added:         L0 000007(000005):[g#11,RANGEDEL-i#inf,RANGEDEL] seqnums:[11-11] points:[g#11,RANGEDEL-i#inf,RANGEDEL]
-  add backing:   000005
+  del-table:     L0 000005
+  add-table:     L0 000006(000005):[b#11,SET-b#11,SET] seqnums:[11-11] points:[b#11,SET-b#11,SET]
+  add-table:     L0 000007(000005):[g#11,RANGEDEL-i#inf,RANGEDEL] seqnums:[11-11] points:[g#11,RANGEDEL-i#inf,RANGEDEL]
+  add-backing:   000005
 
 excise b c
 ----
 would excise 1 files, use ingest-and-excise to excise.
-  deleted:       L0 000005
-  added:         L0 000008(000005):[g#11,RANGEDEL-i#inf,RANGEDEL] seqnums:[11-11] points:[g#11,RANGEDEL-i#inf,RANGEDEL]
-  add backing:   000005
+  del-table:     L0 000005
+  add-table:     L0 000008(000005):[g#11,RANGEDEL-i#inf,RANGEDEL] seqnums:[11-11] points:[g#11,RANGEDEL-i#inf,RANGEDEL]
+  add-backing:   000005
 
 excise i j
 ----
@@ -184,13 +184,13 @@ would excise 0 files, use ingest-and-excise to excise.
 excise c d
 ----
 would excise 2 files, use ingest-and-excise to excise.
-  deleted:       L0 000005
-  deleted:       L6 000004
-  added:         L0 000009(000005):[b#11,SET-b#11,SET] seqnums:[11-11] points:[b#11,SET-b#11,SET]
-  added:         L0 000010(000005):[g#11,RANGEDEL-i#inf,RANGEDEL] seqnums:[11-11] points:[g#11,RANGEDEL-i#inf,RANGEDEL]
-  added:         L6 000011(000004):[d#10,RANGEKEYSET-f#inf,RANGEKEYSET] seqnums:[10-10] ranges:[d#10,RANGEKEYSET-f#inf,RANGEKEYSET]
-  add backing:   000005
-  add backing:   000004
+  del-table:     L0 000005
+  del-table:     L6 000004
+  add-table:     L0 000009(000005):[b#11,SET-b#11,SET] seqnums:[11-11] points:[b#11,SET-b#11,SET]
+  add-table:     L0 000010(000005):[g#11,RANGEDEL-i#inf,RANGEDEL] seqnums:[11-11] points:[g#11,RANGEDEL-i#inf,RANGEDEL]
+  add-table:     L6 000011(000004):[d#10,RANGEKEYSET-f#inf,RANGEKEYSET] seqnums:[10-10] ranges:[d#10,RANGEKEYSET-f#inf,RANGEKEYSET]
+  add-backing:   000005
+  add-backing:   000004
 
 reset
 ----

--- a/testdata/ingest_shared
+++ b/testdata/ingest_shared
@@ -111,10 +111,10 @@ L6:
 excise e gg
 ----
 would excise 1 files, use ingest-and-excise to excise.
-  deleted:       L6 000007
-  added:         L6 000008:[a#0,SET-d#0,SET]
-  added:         L6 000009:[l#0,SET-l#0,SET]
-  add backing:   000007
+  del-table:     L6 000007
+  add-table:     L6 000008(000007):[a#0,SET-d#0,SET]
+  add-table:     L6 000009(000007):[l#0,SET-l#0,SET]
+  add-backing:   000007
 
 replicate 2 1 e gg
 ----

--- a/testdata/ingest_shared_lower
+++ b/testdata/ingest_shared_lower
@@ -111,10 +111,10 @@ L6:
 excise e gg
 ----
 would excise 1 files, use ingest-and-excise to excise.
-  deleted:       L6 000008
-  added:         L6 000009:[a#0,SET-d#0,SET]
-  added:         L6 000010:[l#0,SET-l#0,SET]
-  add backing:   000008
+  del-table:     L6 000008
+  add-table:     L6 000009(000008):[a#0,SET-d#0,SET]
+  add-table:     L6 000010(000008):[l#0,SET-l#0,SET]
+  add-backing:   000008
 
 replicate 2 1 e gg
 ----


### PR DESCRIPTION
#### manifest: improve VersionEdit stringification

This makes the format of the fields more consistent.

#### manifest: add VersionEdit tests with virtual tables

Improve the debug parsing methods to parse virtual tables and backing
operations and add some `version_edit_apply` tests with virtual
tables.