### PR TITLE
tool: replace DirectoryLock with OpenOptions

### DIFF
--- a/tool/db.go
+++ b/tool/db.go
@@ -44,6 +44,7 @@ type dbT struct {
 	comparers       sstable.Comparers
 	mergers         sstable.Mergers
 	openErrEnhancer func(error) error
+	openOptions     []OpenOption
 
 	// Flags.
 	comparerName  string
@@ -65,12 +66,14 @@ func newDB(
 	comparers sstable.Comparers,
 	mergers sstable.Mergers,
 	openErrEnhancer func(error) error,
+	openOptions []OpenOption,
 ) *dbT {
 	d := &dbT{
 		opts:            opts,
 		comparers:       comparers,
 		mergers:         mergers,
 		openErrEnhancer: openErrEnhancer,
+		openOptions:     openOptions,
 	}
 	d.fmtKey.mustSet("quoted")
 	d.fmtValue.mustSet("[%x]")
@@ -283,11 +286,13 @@ func (d *dbT) loadOptions(dir string) error {
 	return nil
 }
 
-type openOption interface {
-	apply(opts *pebble.Options)
+// OpenOption is an option that may be applied to the *pebble.Options before
+// calling pebble.Open.
+type OpenOption interface {
+	Apply(dirname string, opts *pebble.Options)
 }
 
-func (d *dbT) openDB(dir string, openOptions ...openOption) (*pebble.DB, error) {
+func (d *dbT) openDB(dir string, openOptions ...OpenOption) (*pebble.DB, error) {
 	db, err := d.openDBInternal(dir, openOptions...)
 	if err != nil {
 		if d.openErrEnhancer != nil {
@@ -298,7 +303,7 @@ func (d *dbT) openDB(dir string, openOptions ...openOption) (*pebble.DB, error) 
 	return db, nil
 }
 
-func (d *dbT) openDBInternal(dir string, openOptions ...openOption) (*pebble.DB, error) {
+func (d *dbT) openDBInternal(dir string, openOptions ...OpenOption) (*pebble.DB, error) {
 	if err := d.loadOptions(dir); err != nil {
 		return nil, errors.Wrap(err, "error loading options")
 	}
@@ -316,7 +321,10 @@ func (d *dbT) openDBInternal(dir string, openOptions ...openOption) (*pebble.DB,
 	}
 	opts := *d.opts
 	for _, opt := range openOptions {
-		opt.apply(&opts)
+		opt.Apply(dir, &opts)
+	}
+	for _, opt := range d.openOptions {
+		opt.Apply(dir, &opts)
 	}
 	opts.Cache = pebble.NewCache(128 << 20 /* 128 MB */)
 	defer opts.Cache.Unref()
@@ -348,7 +356,7 @@ func (d *dbT) runCheck(cmd *cobra.Command, args []string) {
 
 type nonReadOnly struct{}
 
-func (n nonReadOnly) apply(opts *pebble.Options) {
+func (n nonReadOnly) Apply(dirname string, opts *pebble.Options) {
 	opts.ReadOnly = false
 	// Increase the L0 compaction threshold to reduce the likelihood of an
 	// unintended compaction changing test output.


### PR DESCRIPTION
In #3395 I added a new tool.DirectoryLock option for passing an already-acquired directory lock. This was motivated by cockroachdb/cockroach#120156 which begins to acquire the lock before loading encryption-at-rest state. When adding that option, I forgot the nuance that the tool doesn't know what database you'll open at the time the tool is initialized. When a node has multiple stores, the operator might try to open any of them. CockroachDB will lazily initialize the encryptedFS for a store only once the tool attempts to access a path within the store.

This commit removes the DirectoryLock option and adds a new OpenOptions option that allows the caller to pass in arbitrary OpenOptions that are run when constructing the pebble.Options to use. CockroachDB will be able to implement an OpenOption that opens the relevant encryptedFS when invoked and settings Options.Lock directly.