### PR TITLE
db: add virtual backing protection mechanism

### DIFF
--- a/internal/manifest/testdata/virtual_backings
+++ b/internal/manifest/testdata/virtual_backings
@@ -2,14 +2,14 @@
 add n=1 size=100
 ----
 1 virtual backings, total size 100:
-  000001:  size=100  useCount=0  virtualizedSize=0
+  000001:  size=100  useCount=0  protectionCount=0  virtualizedSize=0
 unused virtual backings: 000001
 
 add n=2 size=200
 ----
 2 virtual backings, total size 300:
-  000001:  size=100  useCount=0  virtualizedSize=0
-  000002:  size=200  useCount=0  virtualizedSize=0
+  000001:  size=100  useCount=0  protectionCount=0  virtualizedSize=0
+  000002:  size=200  useCount=0  protectionCount=0  virtualizedSize=0
 unused virtual backings: 000001 000002
 
 add n=2 size=200
@@ -19,51 +19,107 @@ pebble: trying to add an existing file backing
 add-table n=1 size=10
 ----
 2 virtual backings, total size 300:
-  000001:  size=100  useCount=1  virtualizedSize=10
-  000002:  size=200  useCount=0  virtualizedSize=0
+  000001:  size=100  useCount=1  protectionCount=0  virtualizedSize=10
+  000002:  size=200  useCount=0  protectionCount=0  virtualizedSize=0
 unused virtual backings: 000002
 
 add-table n=1 size=10
 ----
 2 virtual backings, total size 300:
-  000001:  size=100  useCount=2  virtualizedSize=20
-  000002:  size=200  useCount=0  virtualizedSize=0
+  000001:  size=100  useCount=2  protectionCount=0  virtualizedSize=20
+  000002:  size=200  useCount=0  protectionCount=0  virtualizedSize=0
 unused virtual backings: 000002
 
 add-table n=1 size=10
 ----
 2 virtual backings, total size 300:
-  000001:  size=100  useCount=3  virtualizedSize=30
-  000002:  size=200  useCount=0  virtualizedSize=0
+  000001:  size=100  useCount=3  protectionCount=0  virtualizedSize=30
+  000002:  size=200  useCount=0  protectionCount=0  virtualizedSize=0
 unused virtual backings: 000002
 
 remove n=1
 ----
-backing 000001 still in use (useCount=3)
+backing 000001 still in use (useCount=3 protectionCount=0)
 
 remove-table n=1 size=10
 ----
 2 virtual backings, total size 300:
-  000001:  size=100  useCount=2  virtualizedSize=20
-  000002:  size=200  useCount=0  virtualizedSize=0
+  000001:  size=100  useCount=2  protectionCount=0  virtualizedSize=20
+  000002:  size=200  useCount=0  protectionCount=0  virtualizedSize=0
 unused virtual backings: 000002
 
 remove-table n=1 size=10
 ----
 2 virtual backings, total size 300:
-  000001:  size=100  useCount=1  virtualizedSize=10
-  000002:  size=200  useCount=0  virtualizedSize=0
+  000001:  size=100  useCount=1  protectionCount=0  virtualizedSize=10
+  000002:  size=200  useCount=0  protectionCount=0  virtualizedSize=0
 unused virtual backings: 000002
 
 remove-table n=1 size=10
 ----
 2 virtual backings, total size 300:
-  000001:  size=100  useCount=0  virtualizedSize=0
-  000002:  size=200  useCount=0  virtualizedSize=0
+  000001:  size=100  useCount=0  protectionCount=0  virtualizedSize=0
+  000002:  size=200  useCount=0  protectionCount=0  virtualizedSize=0
 unused virtual backings: 000001 000002
 
 remove n=1
 ----
 1 virtual backings, total size 200:
-  000002:  size=200  useCount=0  virtualizedSize=0
+  000002:  size=200  useCount=0  protectionCount=0  virtualizedSize=0
+unused virtual backings: 000002
+
+protect n=2
+----
+1 virtual backings, total size 200:
+  000002:  size=200  useCount=0  protectionCount=1  virtualizedSize=0
+
+protect n=2
+----
+1 virtual backings, total size 200:
+  000002:  size=200  useCount=0  protectionCount=2  virtualizedSize=0
+
+unprotect n=2
+----
+1 virtual backings, total size 200:
+  000002:  size=200  useCount=0  protectionCount=1  virtualizedSize=0
+
+remove n=2
+----
+backing 000002 still in use (useCount=0 protectionCount=1)
+
+unprotect n=2
+----
+1 virtual backings, total size 200:
+  000002:  size=200  useCount=0  protectionCount=0  virtualizedSize=0
+unused virtual backings: 000002
+
+add-table n=2 size=10
+----
+1 virtual backings, total size 200:
+  000002:  size=200  useCount=1  protectionCount=0  virtualizedSize=10
+
+add-table n=2 size=10
+----
+1 virtual backings, total size 200:
+  000002:  size=200  useCount=2  protectionCount=0  virtualizedSize=20
+
+protect n=2
+----
+1 virtual backings, total size 200:
+  000002:  size=200  useCount=2  protectionCount=1  virtualizedSize=20
+
+remove-table n=2 size=10
+----
+1 virtual backings, total size 200:
+  000002:  size=200  useCount=1  protectionCount=1  virtualizedSize=10
+
+remove-table n=2 size=10
+----
+1 virtual backings, total size 200:
+  000002:  size=200  useCount=0  protectionCount=1  virtualizedSize=0
+
+unprotect n=2
+----
+1 virtual backings, total size 200:
+  000002:  size=200  useCount=0  protectionCount=0  virtualizedSize=0
 unused virtual backings: 000002

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -396,6 +396,9 @@ type FileBacking struct {
 	// backing across all versions that have a non-zero reference count. The tables
 	// in each version are maintained in a copy-on-write B-tree and each B-tree node
 	// keeps a reference on the respective backings.
+	//
+	// In addition, a reference count is taken for every backing in the latest
+	// version's VirtualBackings (necessary to support Protect/Unprotect).
 	refs atomic.Int32
 }
 

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -924,9 +924,15 @@ func (b *BulkVersionEdit) Accumulate(ve *VersionEdit) error {
 		}
 	}
 
-	// Since a file can be removed from backing files in exactly one version
-	// edit it is safe to just append without any de-duplication.
-	b.RemovedFileBacking = append(b.RemovedFileBacking, ve.RemovedBackingTables...)
+	for _, n := range ve.RemovedBackingTables {
+		if _, ok := b.AddedFileBacking[n]; ok {
+			delete(b.AddedFileBacking, n)
+		} else {
+			// Since a file can be removed from backing files in exactly one version
+			// edit it is safe to just append without any de-duplication.
+			b.RemovedFileBacking = append(b.RemovedFileBacking, n)
+		}
+	}
 
 	return nil
 }

--- a/internal/manifest/virtual_backings_test.go
+++ b/internal/manifest/virtual_backings_test.go
@@ -28,7 +28,7 @@ func TestVirtualBackings(t *testing.T) {
 
 		switch d.Cmd {
 		case "add":
-			bv.Add(&FileBacking{
+			bv.AddAndRef(&FileBacking{
 				DiskFileNum: n,
 				Size:        size,
 			})
@@ -49,6 +49,12 @@ func TestVirtualBackings(t *testing.T) {
 				FileBacking: &FileBacking{DiskFileNum: n},
 				Size:        size,
 			})
+
+		case "protect":
+			bv.Protect(n)
+
+		case "unprotect":
+			bv.Unprotect(n)
 
 		default:
 			d.Fatalf(t, "unknown command %q", d.Cmd)

--- a/testdata/version_set
+++ b/testdata/version_set
@@ -2,18 +2,24 @@ apply
   add-table: L2 000001:[a#1,SET-c#1,SET]
   add-table: L2 000002:[e#1,SET-h#1,SET]
 ----
-L2:
-  000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
-  000002:[e#1,SET-h#1,SET] seqnums:[0-0] points:[e#1,SET-h#1,SET] size:200
+applied:
+  last-seq-num:  99
+  add-table:     L2 000001:[a#1,SET-c#1,SET]
+  add-table:     L2 000002:[e#1,SET-h#1,SET]
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+    000002:[e#1,SET-h#1,SET] seqnums:[0-0] points:[e#1,SET-h#1,SET] size:200
 no virtual backings
 no zombie tables
 no obsolete tables
 
 reopen
 ----
-L2:
-  000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
-  000002:[e#1,SET-h#1,SET] seqnums:[0-0] points:[e#1,SET-h#1,SET] size:200
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+    000002:[e#1,SET-h#1,SET] seqnums:[0-0] points:[e#1,SET-h#1,SET] size:200
 no virtual backings
 no zombie tables
 no obsolete tables
@@ -24,11 +30,17 @@ apply
   add-table:   L2 000003(000002):[e#1,SET-h#1,SET]
   add-backing: 000002
 ----
-L2:
-  000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
-  000003(000002):[e#1,SET-h#1,SET] seqnums:[0-0] points:[e#1,SET-h#1,SET] size:300
+applied:
+  last-seq-num:  99
+  del-table:     L2 000002
+  add-table:     L2 000003(000002):[e#1,SET-h#1,SET]
+  add-backing:   000002
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+    000003(000002):[e#1,SET-h#1,SET] seqnums:[0-0] points:[e#1,SET-h#1,SET] size:300
 1 virtual backings, total size 2000:
-  000002:  size=2000  useCount=1  virtualizedSize=300
+  000002:  size=2000  useCount=1  protectionCount=0  virtualizedSize=300
 no zombie tables
 no obsolete tables
 
@@ -36,12 +48,16 @@ no obsolete tables
 apply
   add-table:   L2 000004(000002):[i#1,SET-k#1,SET]
 ----
-L2:
-  000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
-  000003(000002):[e#1,SET-h#1,SET] seqnums:[0-0] points:[e#1,SET-h#1,SET] size:300
-  000004(000002):[i#1,SET-k#1,SET] seqnums:[0-0] points:[i#1,SET-k#1,SET] size:400
+applied:
+  last-seq-num:  99
+  add-table:     L2 000004(000002):[i#1,SET-k#1,SET]
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+    000003(000002):[e#1,SET-h#1,SET] seqnums:[0-0] points:[e#1,SET-h#1,SET] size:300
+    000004(000002):[i#1,SET-k#1,SET] seqnums:[0-0] points:[i#1,SET-k#1,SET] size:400
 1 virtual backings, total size 2000:
-  000002:  size=2000  useCount=2  virtualizedSize=700
+  000002:  size=2000  useCount=2  protectionCount=0  virtualizedSize=700
 no zombie tables
 no obsolete tables
 
@@ -50,13 +66,18 @@ apply
   del-table:   L2 000003
   add-table:   L3 000003(000002):[e#1,SET-h#1,SET]
 ----
-L2:
-  000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
-  000004(000002):[i#1,SET-k#1,SET] seqnums:[0-0] points:[i#1,SET-k#1,SET] size:400
-L3:
-  000003(000002):[e#1,SET-h#1,SET] seqnums:[0-0] points:[e#1,SET-h#1,SET] size:300
+applied:
+  last-seq-num:  99
+  del-table:     L2 000003
+  add-table:     L3 000003(000002):[e#1,SET-h#1,SET]
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+    000004(000002):[i#1,SET-k#1,SET] seqnums:[0-0] points:[i#1,SET-k#1,SET] size:400
+  L3:
+    000003(000002):[e#1,SET-h#1,SET] seqnums:[0-0] points:[e#1,SET-h#1,SET] size:300
 1 virtual backings, total size 2000:
-  000002:  size=2000  useCount=2  virtualizedSize=700
+  000002:  size=2000  useCount=2  protectionCount=0  virtualizedSize=700
 no zombie tables
 no obsolete tables
 
@@ -64,21 +85,26 @@ no obsolete tables
 apply
   del-table:   L3 000003
 ----
-L2:
-  000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
-  000004(000002):[i#1,SET-k#1,SET] seqnums:[0-0] points:[i#1,SET-k#1,SET] size:400
+applied:
+  last-seq-num:  99
+  del-table:     L3 000003
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+    000004(000002):[i#1,SET-k#1,SET] seqnums:[0-0] points:[i#1,SET-k#1,SET] size:400
 1 virtual backings, total size 2000:
-  000002:  size=2000  useCount=1  virtualizedSize=400
+  000002:  size=2000  useCount=1  protectionCount=0  virtualizedSize=400
 no zombie tables
 no obsolete tables
 
 reopen
 ----
-L2:
-  000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
-  000004(000002):[i#1,SET-k#1,SET] seqnums:[0-0] points:[i#1,SET-k#1,SET] size:400
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+    000004(000002):[i#1,SET-k#1,SET] seqnums:[0-0] points:[i#1,SET-k#1,SET] size:400
 1 virtual backings, total size 2000:
-  000002:  size=2000  useCount=1  virtualizedSize=400
+  000002:  size=2000  useCount=1  protectionCount=0  virtualizedSize=400
 no zombie tables
 no obsolete tables
 
@@ -86,34 +112,45 @@ no obsolete tables
 apply
   del-table:   L2 000004
 ----
-L2:
-  000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+applied:
+  last-seq-num:  99
+  del-table:     L2 000004
+  del-backing:   000002
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
 no virtual backings
 zombie tables: 000002
 obsolete tables: 000002
 
 # Add a virtual table with a new backing (like an ingestion would).
 apply
-  add-table:   L1 000005(000010):[u#1,SET-v#1,SET]
-  add-backing: 000010
+  add-table:   L1 000005(000100):[u#1,SET-v#1,SET]
+  add-backing: 000100
 ----
-L1:
-  000005(000010):[u#1,SET-v#1,SET] seqnums:[0-0] points:[u#1,SET-v#1,SET] size:500
-L2:
-  000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
-1 virtual backings, total size 10000:
-  000010:  size=10000  useCount=1  virtualizedSize=500
+applied:
+  last-seq-num:  99
+  add-table:     L1 000005(000100):[u#1,SET-v#1,SET]
+  add-backing:   000100
+current version:
+  L1:
+    000005(000100):[u#1,SET-v#1,SET] seqnums:[0-0] points:[u#1,SET-v#1,SET] size:500
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+1 virtual backings, total size 100000:
+  000100:  size=100000  useCount=1  protectionCount=0  virtualizedSize=500
 zombie tables: 000002
 obsolete tables: 000002
 
-ref r1
+ref-version r1
 ----
-L1:
-  000005(000010):[u#1,SET-v#1,SET] seqnums:[0-0] points:[u#1,SET-v#1,SET] size:500
-L2:
-  000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
-1 virtual backings, total size 10000:
-  000010:  size=10000  useCount=1  virtualizedSize=500
+current version:
+  L1:
+    000005(000100):[u#1,SET-v#1,SET] seqnums:[0-0] points:[u#1,SET-v#1,SET] size:500
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+1 virtual backings, total size 100000:
+  000100:  size=100000  useCount=1  protectionCount=0  virtualizedSize=500
 zombie tables: 000002
 obsolete tables: 000002
 
@@ -122,17 +159,188 @@ obsolete tables: 000002
 apply
   del-table:   L1 000005
 ----
-L2:
-  000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+applied:
+  last-seq-num:  99
+  del-table:     L1 000005
+  del-backing:   000100
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
 no virtual backings
-zombie tables: 000002 000010
+zombie tables: 000002 000100
 obsolete tables: 000002
 
 # The backing is now obsolete.
-unref r1
+unref-version r1
 ----
-L2:
-  000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
 no virtual backings
-zombie tables: 000002 000010
-obsolete tables: 000002 000010
+zombie tables: 000002 000100
+obsolete tables: 000002 000100
+
+# Test backing protection mechanism.
+
+apply
+  add-table:   L1 000006(000101):[u#1,SET-v#1,SET]
+  add-table:   L1 000007(000101):[w#1,SET-x#1,SET]
+  add-backing: 000101
+----
+applied:
+  last-seq-num:  99
+  add-table:     L1 000006(000101):[u#1,SET-v#1,SET]
+  add-table:     L1 000007(000101):[w#1,SET-x#1,SET]
+  add-backing:   000101
+current version:
+  L1:
+    000006(000101):[u#1,SET-v#1,SET] seqnums:[0-0] points:[u#1,SET-v#1,SET] size:600
+    000007(000101):[w#1,SET-x#1,SET] seqnums:[0-0] points:[w#1,SET-x#1,SET] size:700
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+1 virtual backings, total size 101000:
+  000101:  size=101000  useCount=2  protectionCount=0  virtualizedSize=1300
+zombie tables: 000002 000100
+obsolete tables: 000002 000100
+
+protect-backing 101
+----
+current version:
+  L1:
+    000006(000101):[u#1,SET-v#1,SET] seqnums:[0-0] points:[u#1,SET-v#1,SET] size:600
+    000007(000101):[w#1,SET-x#1,SET] seqnums:[0-0] points:[w#1,SET-x#1,SET] size:700
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+1 virtual backings, total size 101000:
+  000101:  size=101000  useCount=2  protectionCount=1  virtualizedSize=1300
+zombie tables: 000002 000100
+obsolete tables: 000002 000100
+
+# We should not see a "del-backing" field here.
+apply
+  del-table: L1 000006
+  del-table: L1 000007
+----
+applied:
+  last-seq-num:  99
+  del-table:     L1 000006
+  del-table:     L1 000007
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+1 virtual backings, total size 101000:
+  000101:  size=101000  useCount=0  protectionCount=1  virtualizedSize=0
+zombie tables: 000002 000100
+obsolete tables: 000002 000100
+
+unprotect-backing 101
+----
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+1 virtual backings, total size 101000:
+  000101:  size=101000  useCount=0  protectionCount=0  virtualizedSize=0
+unused virtual backings: 000101
+zombie tables: 000002 000100
+obsolete tables: 000002 000100
+
+# Whatever this next apply is, it should remove the unused backing.
+apply
+  add-table: L3 000008:[a#1,SET-c#1,SET]
+----
+applied:
+  last-seq-num:  99
+  add-table:     L3 000008:[a#1,SET-c#1,SET]
+  del-backing:   000101
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+  L3:
+    000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
+no virtual backings
+zombie tables: 000002 000100 000101
+obsolete tables: 000002 000100 000101
+
+# Test handling of leaked protected backings.
+
+apply
+  add-table:   L1 000009(000102):[u#1,SET-v#1,SET]
+  add-backing: 000102
+----
+applied:
+  last-seq-num:  99
+  add-table:     L1 000009(000102):[u#1,SET-v#1,SET]
+  add-backing:   000102
+current version:
+  L1:
+    000009(000102):[u#1,SET-v#1,SET] seqnums:[0-0] points:[u#1,SET-v#1,SET] size:900
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+  L3:
+    000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
+1 virtual backings, total size 102000:
+  000102:  size=102000  useCount=1  protectionCount=0  virtualizedSize=900
+zombie tables: 000002 000100 000101
+obsolete tables: 000002 000100 000101
+
+protect-backing 102
+----
+current version:
+  L1:
+    000009(000102):[u#1,SET-v#1,SET] seqnums:[0-0] points:[u#1,SET-v#1,SET] size:900
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+  L3:
+    000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
+1 virtual backings, total size 102000:
+  000102:  size=102000  useCount=1  protectionCount=1  virtualizedSize=900
+zombie tables: 000002 000100 000101
+obsolete tables: 000002 000100 000101
+
+apply
+  del-table:   L1 000009
+----
+applied:
+  last-seq-num:  99
+  del-table:     L1 000009
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+  L3:
+    000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
+1 virtual backings, total size 102000:
+  000102:  size=102000  useCount=0  protectionCount=1  virtualizedSize=0
+zombie tables: 000002 000100 000101
+obsolete tables: 000002 000100 000101
+
+# Upon reopen, we still have a record of backing 102.
+reopen
+----
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+  L3:
+    000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
+1 virtual backings, total size 102000:
+  000102:  size=102000  useCount=0  protectionCount=0  virtualizedSize=0
+unused virtual backings: 000102
+no zombie tables
+no obsolete tables
+
+# Whatever this next apply is, it should remove the leaked backing.
+apply
+  add-table: L3 000010:[d#1,SET-e#1,SET]
+----
+applied:
+  last-seq-num:  99
+  add-table:     L3 000010:[d#1,SET-e#1,SET]
+  del-backing:   000102
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+  L3:
+    000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
+    000010:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] size:1000
+no virtual backings
+zombie tables: 000102
+obsolete tables: 000102

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"math/rand"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -116,13 +117,26 @@ func TestVersionSet(t *testing.T) {
 			if err != nil {
 				td.Fatalf(t, "%v", err)
 			}
+			// Show the edit, so that we can see the fields populated by Apply. We
+			// zero out the next file number because it is not deterministic (because
+			// of the randomized forceRotation).
+			ve.NextFileNum = 0
+			fmt.Fprintf(&buf, "applied:\n%s", ve.String())
 
-		case "ref":
+		case "protect-backing":
+			n, _ := strconv.Atoi(td.CmdArgs[0].String())
+			vs.virtualBackings.Protect(base.DiskFileNum(n))
+
+		case "unprotect-backing":
+			n, _ := strconv.Atoi(td.CmdArgs[0].String())
+			vs.virtualBackings.Unprotect(base.DiskFileNum(n))
+
+		case "ref-version":
 			name := td.CmdArgs[0].String()
 			refs[name] = vs.currentVersion()
 			refs[name].Ref()
 
-		case "unref":
+		case "unref-version":
 			name := td.CmdArgs[0].String()
 			refs[name].Unref()
 
@@ -162,7 +176,12 @@ func TestVersionSet(t *testing.T) {
 			td.Fatalf(t, "unknown command: %s", td.Cmd)
 		}
 
-		buf.WriteString(vs.currentVersion().DebugString())
+		fmt.Fprintf(&buf, "current version:\n")
+		for _, l := range strings.Split(vs.currentVersion().DebugString(), "\n") {
+			if l != "" {
+				fmt.Fprintf(&buf, "  %s\n", l)
+			}
+		}
 		buf.WriteString(vs.virtualBackings.String())
 		if len(vs.zombieTables) == 0 {
 			buf.WriteString("no zombie tables\n")


### PR DESCRIPTION
#### manifest: add Protect API to VirtualBackings

Add `Protect` and `Unprotect` which control a separate ref count on
each backing. This will allow external ingestions to temporarily
prevent a backing from being removed from the latest version.

#### db: handle protected backings in versionSet

This commit updates versionSet code to support protected virtual
backings. The main change is that we now also `Ref` all backings that
exist in `vs.virtualBackings`; we reorganize the code related to
zombie backings in `logAndApply` to facilitate maintaining these refs
correctly.