### PR TITLE
sstable: cleanup/move code, fix two-level when calling sync add

### DIFF
--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -272,6 +272,16 @@ func rewriteBlocks(
 	return nil
 }
 
+func checkWriterFilterMatchesReader(r *Reader, w *Writer) error {
+	if r.Properties.FilterPolicyName != w.filter.policyName() {
+		return errors.New("mismatched filters")
+	}
+	if was, is := r.Properties.ComparerName, w.props.ComparerName; was != is {
+		return errors.Errorf("mismatched Comparer %s vs %s, replacement requires same splitter to copy filters", was, is)
+	}
+	return nil
+}
+
 func rewriteDataBlocksToWriter(
 	r *Reader,
 	w *Writer,
@@ -287,11 +297,8 @@ func rewriteDataBlocksToWriter(
 	blocks := make([]blockWithSpan, len(data))
 
 	if w.filter != nil {
-		if r.Properties.FilterPolicyName != w.filter.policyName() {
-			return errors.New("mismatched filters")
-		}
-		if was, is := r.Properties.ComparerName, w.props.ComparerName; was != is {
-			return errors.Errorf("mismatched Comparer %s vs %s, replacement requires same splitter to copy filters", was, is)
+		if err := checkWriterFilterMatchesReader(r, w); err != nil {
+			return err
 		}
 	}
 

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -1572,6 +1572,9 @@ func (w *Writer) addPrevDataBlockToIndexBlockProps() {
 // Invariant:
 //  1. addIndexEntrySync must not store references to the prevKey, key InternalKey's,
 //     the tmp byte slice. That is, these must be either deep copied or encoded.
+//
+// TODO: Improve coverage of this method. e.g. tests passed without the line
+// `w.twoLevelIndex = true` previously.
 func (w *Writer) addIndexEntrySync(
 	prevKey, key InternalKey, bhp BlockHandleWithProperties, tmp []byte,
 ) error {
@@ -1586,7 +1589,7 @@ func (w *Writer) addIndexEntrySync(
 	if shouldFlush {
 		flushableIndexBlock = w.indexBlock
 		w.indexBlock = newIndexBlockBuf(w.coordination.parallelismEnabled)
-
+		w.twoLevelIndex = true
 		// Call BlockPropertyCollector.FinishIndexBlock, since we've decided to
 		// flush the index block.
 		props, err = w.finishIndexBlockProps()


### PR DESCRIPTION
Pulling these fixups out of an in-progress change to make it and them easier to review in isolation.