### PR TITLE
wal: allow runtime toggling of WAL failover

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -2058,7 +2058,7 @@ func TestWALFailoverAvoidsWriteStall(t *testing.T) {
 	secondary := wal.Dir{FS: mem, Dirname: "secondary"}
 	walFailover := &WALFailoverOptions{Secondary: secondary, FailoverOptions: wal.FailoverOptions{
 		UnhealthySamplingInterval:          100 * time.Millisecond,
-		UnhealthyOperationLatencyThreshold: func() time.Duration { return time.Second },
+		UnhealthyOperationLatencyThreshold: func() (time.Duration, bool) { return time.Second, true },
 	}}
 	o := &Options{
 		FS:                          primaryFS,

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -629,8 +629,8 @@ func RandomOptions(
 				HealthyProbeLatencyThreshold: healthyThreshold,
 				HealthyInterval:              healthyInterval,
 				UnhealthySamplingInterval:    scaleDuration(unhealthyThreshold, 0.10, 0.50), // Between 10-50% of the unhealthy threshold
-				UnhealthyOperationLatencyThreshold: func() time.Duration {
-					return unhealthyThreshold
+				UnhealthyOperationLatencyThreshold: func() (time.Duration, bool) {
+					return unhealthyThreshold, true
 				},
 				ElevatedWriteStallThresholdLag: expRandDuration(rng, 5*referenceDur, 2*time.Second),
 			},

--- a/options.go
+++ b/options.go
@@ -1380,6 +1380,7 @@ func (o *Options) String() string {
 	}
 
 	if o.WALFailover != nil {
+		unhealthyThreshold, _ := o.WALFailover.FailoverOptions.UnhealthyOperationLatencyThreshold()
 		fmt.Fprintf(&buf, "\n")
 		fmt.Fprintf(&buf, "[WAL Failover]\n")
 		fmt.Fprintf(&buf, "  secondary_dir=%s\n", o.WALFailover.Secondary.Dirname)
@@ -1387,7 +1388,7 @@ func (o *Options) String() string {
 		fmt.Fprintf(&buf, "  healthy_probe_latency_threshold=%s\n", o.WALFailover.FailoverOptions.HealthyProbeLatencyThreshold)
 		fmt.Fprintf(&buf, "  healthy_interval=%s\n", o.WALFailover.FailoverOptions.HealthyInterval)
 		fmt.Fprintf(&buf, "  unhealthy_sampling_interval=%s\n", o.WALFailover.FailoverOptions.UnhealthySamplingInterval)
-		fmt.Fprintf(&buf, "  unhealthy_operation_latency_threshold=%s\n", o.WALFailover.FailoverOptions.UnhealthyOperationLatencyThreshold())
+		fmt.Fprintf(&buf, "  unhealthy_operation_latency_threshold=%s\n", unhealthyThreshold)
 		fmt.Fprintf(&buf, "  elevated_write_stall_threshold_lag=%s\n", o.WALFailover.FailoverOptions.ElevatedWriteStallThresholdLag)
 	}
 
@@ -1707,8 +1708,8 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 			case "unhealthy_operation_latency_threshold":
 				var threshold time.Duration
 				threshold, err = time.ParseDuration(value)
-				o.WALFailover.UnhealthyOperationLatencyThreshold = func() time.Duration {
-					return threshold
+				o.WALFailover.UnhealthyOperationLatencyThreshold = func() (time.Duration, bool) {
+					return threshold, true
 				}
 			case "elevated_write_stall_threshold_lag":
 				o.WALFailover.ElevatedWriteStallThresholdLag, err = time.ParseDuration(value)

--- a/wal/testdata/manager_failover
+++ b/wal/testdata/manager_failover
@@ -664,3 +664,43 @@ list-fs
 pri/000001-002.log
 pri/probe-file
 sec/000001-001.log
+
+# Test that if UnhealthyOperationLatencyThreshold says not to allow failovers
+# yet, failover doesn't occur even if the primary errors.
+
+init-manager disable-failover inject-errors=((ErrInjected (And Writes (PathMatch "*/000001.log"))))
+----
+ok
+recycler min-log-num: 0
+
+# Wait for monitor ticker to start.
+advance-time dur=0ms wait-monitor
+----
+monitor state: dir index: 0
+now: 0s
+
+create-writer wal-num=1
+----
+ok
+
+# Wait until create error has been noticed.
+advance-time dur=1ms wait-ongoing-io wait-for-log-writer
+----
+now: 1ms
+
+# Wait until monitor sees the error.
+advance-time dur=74ms wait-monitor
+----
+monitor state: dir index: 0 num-switches: 0, ongoing-latency-at-switch: 0s
+now: 75ms
+
+close-writer
+----
+injected error
+
+close-manager
+----
+ok
+
+list-fs
+----

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -184,8 +184,10 @@ type FailoverOptions struct {
 	// errors in the latest LogWriter.
 	UnhealthySamplingInterval time.Duration
 	// UnhealthyOperationLatencyThreshold is the latency threshold that is
-	// considered unhealthy, for operations done by a LogWriter.
-	UnhealthyOperationLatencyThreshold func() time.Duration
+	// considered unhealthy, for operations done by a LogWriter. The second return
+	// value indicates whether we should consider failover at all. If the second
+	// return value is false, failover is disabled.
+	UnhealthyOperationLatencyThreshold func() (time.Duration, bool)
 
 	// ElevatedWriteStallThresholdLag is the duration for which an elevated
 	// threshold should continue after a switch back to the primary dir. This is
@@ -218,8 +220,8 @@ func (o *FailoverOptions) EnsureDefaults() {
 		o.UnhealthySamplingInterval = 100 * time.Millisecond
 	}
 	if o.UnhealthyOperationLatencyThreshold == nil {
-		o.UnhealthyOperationLatencyThreshold = func() time.Duration {
-			return 200 * time.Millisecond
+		o.UnhealthyOperationLatencyThreshold = func() (time.Duration, bool) {
+			return 200 * time.Millisecond, true
 		}
 	}
 }


### PR DESCRIPTION
This commit adds a new bool return value to the option func UnhealthyOperationLatencyThreshold that allows the client to dynamically toggle whether failover is permitted. This will be used by Cockroach to prevent failover until cluster version finalization begins.

Informs #3230.