### PR TITLE
ingest: expose inclusive bounds for ExternalFile end keys

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -1321,8 +1321,8 @@ func runIngestExternalCmd(
 			switch arg.Key {
 			case "bounds":
 				nArgs(2)
-				ef.Bounds.Start = []byte(arg.Vals[0])
-				ef.Bounds.End = []byte(arg.Vals[1])
+				ef.StartKey = []byte(arg.Vals[0])
+				ef.EndKey = []byte(arg.Vals[1])
 			case "bounds-are-inclusive":
 				nArgs(1)
 				b, err := strconv.ParseBool(arg.Vals[0])
@@ -1330,7 +1330,7 @@ func runIngestExternalCmd(
 					usageErr(fmt.Sprintf("%s should have boolean argument: %v",
 						arg.Key, err))
 				}
-				ef.BoundsHasInclusiveEndKey = b
+				ef.EndKeyIsInclusive = b
 			case "size":
 				nArgs(1)
 				arg.Scan(t, 0, &ef.Size)
@@ -1347,7 +1347,7 @@ func runIngestExternalCmd(
 				usageErr(fmt.Sprintf("unknown argument %v", arg.Key))
 			}
 		}
-		if ef.Bounds.Start == nil {
+		if ef.StartKey == nil {
 			usageErr("no bounds specified")
 		}
 

--- a/data_test.go
+++ b/data_test.go
@@ -1323,7 +1323,14 @@ func runIngestExternalCmd(
 				nArgs(2)
 				ef.Bounds.Start = []byte(arg.Vals[0])
 				ef.Bounds.End = []byte(arg.Vals[1])
-
+			case "bounds-are-inclusive":
+				nArgs(1)
+				b, err := strconv.ParseBool(arg.Vals[0])
+				if err != nil {
+					usageErr(fmt.Sprintf("%s should have boolean argument: %v",
+						arg.Key, err))
+				}
+				ef.BoundsHasInclusiveEndKey = b
 			case "size":
 				nArgs(1)
 				arg.Scan(t, 0, &ef.Size)

--- a/ingest.go
+++ b/ingest.go
@@ -181,7 +181,11 @@ func ingestLoad1External(
 	if !e.HasRangeKey && !e.HasPointKey {
 		return nil, errors.New("pebble: cannot ingest external file with no point or range keys")
 	}
-	if opts.Comparer.Compare(e.Bounds.Start, e.Bounds.End) >= 0 {
+
+	if opts.Comparer.Compare(e.Bounds.Start, e.Bounds.End) > 0 {
+		return nil, errors.Newf("pebble: external file bounds [%q, %q) are invalid", e.Bounds.Start, e.Bounds.End)
+	}
+	if opts.Comparer.Compare(e.Bounds.Start, e.Bounds.End) == 0 && !e.BoundsHasInclusiveEndKey {
 		return nil, errors.Newf("pebble: external file bounds [%q, %q) are invalid", e.Bounds.Start, e.Bounds.End)
 	}
 	if n := opts.Comparer.Split(e.Bounds.Start); n != len(e.Bounds.Start) {
@@ -218,11 +222,17 @@ func ingestLoad1External(
 	smallestCopy := slices.Clone(e.Bounds.Start)
 	largestCopy := slices.Clone(e.Bounds.End)
 	if e.HasPointKey {
-		meta.ExtendPointKeyBounds(
-			opts.Comparer.Compare,
-			base.MakeInternalKey(smallestCopy, 0, InternalKeyKindMax),
-			base.MakeRangeDeleteSentinelKey(largestCopy),
-		)
+		if e.BoundsHasInclusiveEndKey {
+			meta.ExtendPointKeyBounds(
+				opts.Comparer.Compare,
+				base.MakeInternalKey(smallestCopy, 0, InternalKeyKindMax),
+				base.MakeInternalKey(largestCopy, 0, 0))
+		} else {
+			meta.ExtendPointKeyBounds(
+				opts.Comparer.Compare,
+				base.MakeInternalKey(smallestCopy, 0, InternalKeyKindMax),
+				base.MakeRangeDeleteSentinelKey(largestCopy))
+		}
 	}
 	if e.HasRangeKey {
 		meta.ExtendRangeKeyBounds(
@@ -1142,6 +1152,10 @@ type ExternalFile struct {
 	// Multiple ExternalFiles in one ingestion must all have non-overlapping
 	// bounds.
 	Bounds KeyRange
+
+	// BoundsHasInclusiveEndKey is true if Bounds.End should be
+	// treated as inclusive.
+	BoundsHasInclusiveEndKey bool
 
 	// HasPointKey and HasRangeKey denote whether this file contains point keys
 	// or range keys. If both structs are false, an error is returned during

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -980,10 +980,12 @@ func (o *ingestExternalFilesOp) run(t *Test, h historyRecorder) {
 		for i, obj := range objs {
 			meta := t.getExternalObj(obj.externalObjID)
 			external[i] = pebble.ExternalFile{
-				Locator: "external",
-				ObjName: externalObjName(obj.externalObjID),
-				Size:    meta.sstMeta.Size,
-				Bounds:  obj.bounds,
+				Locator:           "external",
+				ObjName:           externalObjName(obj.externalObjID),
+				Size:              meta.sstMeta.Size,
+				StartKey:          obj.bounds.Start,
+				EndKey:            obj.bounds.End,
+				EndKeyIsInclusive: false,
 				// Note: if the table has point/range keys, we don't know for sure whether
 				// this particular range has any, but that's acceptable.
 				HasPointKey:     meta.sstMeta.HasPointKeys || meta.sstMeta.HasRangeDelKeys,

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -475,15 +475,13 @@ func TestScanInternal(t *testing.T) {
 
 				writeSST(points, rangeDels, rangeKeys, objstorageprovider.NewRemoteWritable(file))
 				ef := ExternalFile{
-					ObjName: objName,
-					Locator: remote.Locator("external-storage"),
-					Size:    10,
-					Bounds: KeyRange{
-						Start: smallest.UserKey,
-						End:   largest.UserKey,
-					},
-					BoundsHasInclusiveEndKey: true,
-					HasPointKey:              true,
+					ObjName:           objName,
+					Locator:           remote.Locator("external-storage"),
+					Size:              10,
+					StartKey:          smallest.UserKey,
+					EndKey:            largest.UserKey,
+					EndKeyIsInclusive: true,
+					HasPointKey:       true,
 				}
 				_, err = d.IngestExternalFiles([]ExternalFile{ef})
 				require.NoError(t, err)
@@ -554,8 +552,8 @@ func TestScanInternal(t *testing.T) {
 					externalFileVisitor = func(sst *ExternalFile) error {
 						fmt.Fprintf(&b, "external file: %s %s [0x%s-0x%s] (hasPoint: %v, hasRange: %v)\n",
 							sst.Locator, sst.ObjName,
-							hex.EncodeToString(sst.Bounds.Start),
-							hex.EncodeToString(sst.Bounds.End),
+							hex.EncodeToString(sst.StartKey),
+							hex.EncodeToString(sst.EndKey),
 							sst.HasPointKey, sst.HasRangeKey)
 						return nil
 					}

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -616,3 +616,34 @@ trunctest bounds=(a,c)
 replicate 1 2 c z
 ----
 replicated 0 external SSTs
+
+reset
+----
+
+build-remote inclusive_bounds_test
+set a foo
+set b bar
+set c baz
+----
+
+ingest-external
+inclusive_bounds_test bounds=(a,c) bounds-are-inclusive=true
+----
+
+lsm
+----
+L6:
+  000004(000004):[a#10,DELSIZED-c#10,DEL]
+
+replicate 1 2 a d
+----
+replicated 1 external SSTs
+
+iter
+first
+next
+next
+----
+a: (foo, .)
+b: (bar, .)
+c: (baz, .)

--- a/testdata/scan_internal
+++ b/testdata/scan_internal
@@ -486,7 +486,7 @@ lsm
 L0.0:
   000006:[d#11,SET-d#11,SET]
 L6:
-  000004(000004):[a#10,DELSIZED-c\x00#inf,RANGEDEL]
+  000004(000004):[a#10,DELSIZED-c#10,DEL]
 
 
 
@@ -495,7 +495,7 @@ scan-internal skip-external lower=m upper=n
 
 scan-internal skip-external lower=a upper=f
 ----
-external file: external-storage file1 [0x61-0x6300] (hasPoint: true, hasRange: false)
+external file: external-storage file1 [0x61-0x63] (hasPoint: true, hasRange: false)
 d#11,SET (bat)
 
 
@@ -523,7 +523,7 @@ flush
 compact a-z
 ----
 L6:
-  000006(000006):[a#11,DELSIZED-c\x00#inf,RANGEDEL]
+  000006(000006):[a#11,DELSIZED-c#11,DEL]
   000005:[d#10,SET-d#10,SET]
 
 scan-internal skip-external lower=m upper=n
@@ -531,7 +531,7 @@ scan-internal skip-external lower=m upper=n
 
 scan-internal skip-external lower=a upper=f
 ----
-external file: external-storage file1 [0x61-0x6300] (hasPoint: true, hasRange: false)
+external file: external-storage file1 [0x61-0x63] (hasPoint: true, hasRange: false)
 d#10,SET (bat)
 
 scan-internal skip-shared lower=a upper=f


### PR DESCRIPTION
An excise can result in an external file having an inclusive bounds. But, previously we would erroneously expose that as an exclusive bounds.

Here, we add a boolean that indicates whether the Bounds on and ExternalFile are inclusive.