### PR TITLE
wal: adjust FailoverOptions defaults

### DIFF
--- a/testdata/open_wal_failover
+++ b/testdata/open_wal_failover
@@ -47,11 +47,11 @@ grep-between path=(a,data/OPTIONS-000006) start=(\[WAL Failover\]) end=^$
 ----
   secondary_dir=secondary-wals
   primary_dir_probe_interval=1s
-  healthy_probe_latency_threshold=100ms
-  healthy_interval=2m0s
+  healthy_probe_latency_threshold=25ms
+  healthy_interval=15s
   unhealthy_sampling_interval=100ms
-  unhealthy_operation_latency_threshold=200ms
-  elevated_write_stall_threshold_lag=0s
+  unhealthy_operation_latency_threshold=100ms
+  elevated_write_stall_threshold_lag=1m0s
 
 # Opening the same directory without providing the secondary path in either the
 # WAL failover configuration or as a WALRecoveryDir should error.

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -211,18 +211,21 @@ func (o *FailoverOptions) EnsureDefaults() {
 		o.PrimaryDirProbeInterval = time.Second
 	}
 	if o.HealthyProbeLatencyThreshold == 0 {
-		o.HealthyProbeLatencyThreshold = 100 * time.Millisecond
+		o.HealthyProbeLatencyThreshold = 25 * time.Millisecond
 	}
 	if o.HealthyInterval == 0 {
-		o.HealthyInterval = 2 * time.Minute
+		o.HealthyInterval = 15 * time.Second
 	}
 	if o.UnhealthySamplingInterval == 0 {
 		o.UnhealthySamplingInterval = 100 * time.Millisecond
 	}
 	if o.UnhealthyOperationLatencyThreshold == nil {
 		o.UnhealthyOperationLatencyThreshold = func() (time.Duration, bool) {
-			return 200 * time.Millisecond, true
+			return 100 * time.Millisecond, true
 		}
+	}
+	if o.ElevatedWriteStallThresholdLag == 0 {
+		o.ElevatedWriteStallThresholdLag = 60 * time.Second
 	}
 }
 


### PR DESCRIPTION
Adjust the FailoverOptions defaults to match our initial choices for use in Cockroach. Additionally, this provides a default for ElevatedWriteStallThresholdLag which previously had none.

Informs #3230.