### PR TITLE
objstorageprovider: fix atomicfs.Marker leak

### DIFF
--- a/objstorage/objstorageprovider/remoteobjcat/catalog.go
+++ b/objstorage/objstorageprovider/remoteobjcat/catalog.go
@@ -147,7 +147,12 @@ func (c *Catalog) SetCreatorID(id objstorage.CreatorID) error {
 
 // Close any open files.
 func (c *Catalog) Close() error {
-	return c.closeCatalogFile()
+	var err error
+	if c.mu.marker != nil {
+		err = c.mu.marker.Close()
+		c.mu.marker = nil
+	}
+	return errors.CombineErrors(err, c.closeCatalogFile())
 }
 
 func (c *Catalog) closeCatalogFile() error {

--- a/objstorage/objstorageprovider/remoteobjcat/testdata/catalog
+++ b/objstorage/objstorageprovider/remoteobjcat/testdata/catalog
@@ -59,6 +59,7 @@ error applying batch: deleting non-existent object 001000
 
 close
 ----
+close: test
 close: test/REMOTE-OBJ-CATALOG-000001
 
 open test
@@ -92,6 +93,7 @@ marker.remote-obj-catalog.000002.REMOTE-OBJ-CATALOG-000002
 
 close
 ----
+close: test
 close: test/REMOTE-OBJ-CATALOG-000002
 
 open test
@@ -103,6 +105,7 @@ creator-id: 5
 
 close
 ----
+close: test
 
 open other-path
 ----
@@ -137,6 +140,7 @@ marker.remote-obj-catalog.000002.REMOTE-OBJ-CATALOG-000002
 
 close
 ----
+close: other-path
 close: other-path/REMOTE-OBJ-CATALOG-000001
 
 open test

--- a/objstorage/objstorageprovider/testdata/provider/shared_attach
+++ b/objstorage/objstorageprovider/testdata/provider/shared_attach
@@ -65,6 +65,7 @@ close
 ----
 <local fs> sync: p1
 <local fs> sync: p1/REMOTE-OBJ-CATALOG-000001
+<local fs> close: p1
 <local fs> close: p1/REMOTE-OBJ-CATALOG-000001
 <local fs> close: p1
 

--- a/objstorage/objstorageprovider/testdata/provider/shared_basic
+++ b/objstorage/objstorageprovider/testdata/provider/shared_basic
@@ -54,6 +54,7 @@ close
 ----
 <local fs> sync: p1
 <local fs> sync: p1/REMOTE-OBJ-CATALOG-000001
+<local fs> close: p1
 <local fs> close: p1/REMOTE-OBJ-CATALOG-000001
 <local fs> close: p1
 
@@ -128,5 +129,6 @@ close
 <local fs> sync: p1
 <local fs> remove: p1/REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p1/REMOTE-OBJ-CATALOG-000002
+<local fs> close: p1
 <local fs> close: p1/REMOTE-OBJ-CATALOG-000002
 <local fs> close: p1

--- a/objstorage/objstorageprovider/testdata/provider/shared_no_ref
+++ b/objstorage/objstorageprovider/testdata/provider/shared_no_ref
@@ -67,6 +67,7 @@ size: 100
 close
 ----
 <local fs> sync: p1/REMOTE-OBJ-CATALOG-000001
+<local fs> close: p1
 <local fs> close: p1/REMOTE-OBJ-CATALOG-000001
 <local fs> close: p1
 


### PR DESCRIPTION
Fix a leak of the atomicfs.Marker and its directory file descriptor.