### PR TITLE
base: add UserKeyBounds

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -75,7 +75,8 @@ func excludeFromCheckpoint(f *fileMetadata, opt *checkpointOptions, cmp Compare)
 		return false
 	}
 	for _, s := range opt.restrictToSpans {
-		if f.Overlaps(cmp, s.Start, s.End, true /* exclusiveEnd */) {
+		spanBounds := base.UserKeyBoundsEndExclusive(s.Start, s.End)
+		if f.Overlaps(cmp, &spanBounds) {
 			return false
 		}
 	}

--- a/compaction.go
+++ b/compaction.go
@@ -390,6 +390,10 @@ func (c *compaction) makeInfo(jobID int) CompactionInfo {
 	return info
 }
 
+func (c *compaction) userKeyBounds() base.UserKeyBounds {
+	return base.UserKeyBoundsFromInternal(c.smallest, c.largest)
+}
+
 func newCompaction(
 	pc *pickedCompaction, opts *Options, beganAt time.Time, provider objstorage.Provider,
 ) *compaction {
@@ -422,8 +426,7 @@ func newCompaction(
 	// Compute the set of outputLevel+1 files that overlap this compaction (these
 	// are the grandparent sstables).
 	if c.outputLevel.level+1 < numLevels {
-		c.grandparents = c.version.Overlaps(c.outputLevel.level+1,
-			c.smallest.UserKey, c.largest.UserKey, c.largest.IsExclusiveSentinel())
+		c.grandparents = c.version.Overlaps(c.outputLevel.level+1, c.userKeyBounds())
 	}
 	c.setupInuseKeyRanges()
 	c.kind = pc.kind
@@ -657,8 +660,7 @@ func newFlush(
 	if opts.FlushSplitBytes > 0 {
 		c.maxOutputFileSize = uint64(opts.Level(0).TargetFileSize)
 		c.maxOverlapBytes = maxGrandparentOverlapBytes(opts, 0)
-		c.grandparents = c.version.Overlaps(baseLevel, c.smallest.UserKey,
-			c.largest.UserKey, c.largest.IsExclusiveSentinel())
+		c.grandparents = c.version.Overlaps(baseLevel, c.userKeyBounds())
 		adjustGrandparentOverlapBytesForFlush(c, flushingBytes)
 	}
 
@@ -1866,8 +1868,9 @@ func (d *DB) maybeScheduleDownloadCompaction(env compactionEnv, maxConcurrentCom
 		var externalFile *fileMetadata
 		var err error
 		var level int
+		bounds := base.UserKeyBoundsEndExclusive(download.start, download.end)
 		for i := range v.Levels {
-			overlaps := v.Overlaps(i, download.start, download.end, true /* exclusiveEnd */)
+			overlaps := v.Overlaps(i, bounds)
 			iter := overlaps.Iter()
 			provider := d.objProvider
 			for f := iter.First(); f != nil; f = iter.Next() {
@@ -2256,7 +2259,7 @@ func checkDeleteCompactionHints(
 		// The hint h will be resolved and dropped, regardless of whether
 		// there are any tables that can be deleted.
 		for l := h.tombstoneLevel + 1; l < numLevels; l++ {
-			overlaps := v.Overlaps(l, h.start, h.end, true /* exclusiveEnd */)
+			overlaps := v.Overlaps(l, base.UserKeyBoundsEndExclusive(h.start, h.end))
 			iter := overlaps.Iter()
 			for m := iter.First(); m != nil; m = iter.Next() {
 				if m.IsCompacting() || !h.canDelete(cmp, m, snapshots) || files[m] {

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -226,6 +226,10 @@ type pickedCompaction struct {
 	pickerMetrics compactionPickerMetrics
 }
 
+func (pc *pickedCompaction) userKeyBounds() base.UserKeyBounds {
+	return base.UserKeyBoundsFromInternal(pc.smallest, pc.largest)
+}
+
 func defaultOutputLevel(startLevel, baseLevel int) int {
 	outputLevel := startLevel + 1
 	if startLevel == 0 {
@@ -421,8 +425,7 @@ func (pc *pickedCompaction) setupInputs(
 	// sstables. No need to do this for intra-L0 compactions; outputLevel.files is
 	// left empty for those.
 	if startLevel.level != pc.outputLevel.level {
-		pc.outputLevel.files = pc.version.Overlaps(pc.outputLevel.level, pc.smallest.UserKey,
-			pc.largest.UserKey, pc.largest.IsExclusiveSentinel())
+		pc.outputLevel.files = pc.version.Overlaps(pc.outputLevel.level, pc.userKeyBounds())
 		if anyTablesCompacting(pc.outputLevel.files) {
 			return false
 		}
@@ -515,8 +518,7 @@ func (pc *pickedCompaction) grow(
 	if pc.outputLevel.files.Empty() {
 		return false
 	}
-	grow0 := pc.version.Overlaps(startLevel.level, sm.UserKey,
-		la.UserKey, la.IsExclusiveSentinel())
+	grow0 := pc.version.Overlaps(startLevel.level, base.UserKeyBoundsFromInternal(sm, la))
 	if anyTablesCompacting(grow0) {
 		return false
 	}
@@ -529,8 +531,7 @@ func (pc *pickedCompaction) grow(
 	// We need to include the outputLevel iter because without it, in a multiLevel scenario,
 	// sm1 and la1 could shift the output level keyspace when pc.outputLevel.files is set to grow1.
 	sm1, la1 := manifest.KeyRange(pc.cmp, grow0.Iter(), pc.outputLevel.files.Iter())
-	grow1 := pc.version.Overlaps(pc.outputLevel.level, sm1.UserKey,
-		la1.UserKey, la1.IsExclusiveSentinel())
+	grow1 := pc.version.Overlaps(pc.outputLevel.level, base.UserKeyBoundsFromInternal(sm1, la1))
 	if anyTablesCompacting(grow1) {
 		return false
 	}
@@ -1603,8 +1604,7 @@ func pickAutoLPositive(
 	if pc.startLevel.level == 0 {
 		cmp := opts.Comparer.Compare
 		smallest, largest := manifest.KeyRange(cmp, pc.startLevel.files.Iter())
-		pc.startLevel.files = vers.Overlaps(0, smallest.UserKey,
-			largest.UserKey, largest.IsExclusiveSentinel())
+		pc.startLevel.files = vers.Overlaps(0, base.UserKeyBoundsFromInternal(smallest, largest))
 		if pc.startLevel.files.Empty() {
 			panic("pebble: empty compaction")
 		}
@@ -1811,7 +1811,7 @@ func pickManualCompaction(
 	}
 	pc = newPickedCompaction(opts, vers, manual.level, defaultOutputLevel(manual.level, baseLevel), baseLevel)
 	manual.outputLevel = pc.outputLevel.level
-	pc.startLevel.files = vers.Overlaps(manual.level, manual.start, manual.end, false)
+	pc.startLevel.files = vers.Overlaps(manual.level, base.UserKeyBoundsInclusive(manual.start, manual.end))
 	if pc.startLevel.files.Empty() {
 		// Nothing to do
 		return nil, false
@@ -1897,7 +1897,7 @@ func (p *compactionPickerByScore) pickReadTriggeredCompaction(
 func pickReadTriggeredCompactionHelper(
 	p *compactionPickerByScore, rc *readCompaction, env compactionEnv,
 ) (pc *pickedCompaction) {
-	overlapSlice := p.vers.Overlaps(rc.level, rc.start, rc.end, false /* exclusiveEnd */)
+	overlapSlice := p.vers.Overlaps(rc.level, base.UserKeyBoundsInclusive(rc.start, rc.end))
 	if overlapSlice.Empty() {
 		// If there is no overlap, then the file with the key range
 		// must have been compacted away. So, we don't proceed to
@@ -1929,9 +1929,7 @@ func pickReadTriggeredCompactionHelper(
 	pc.kind = compactionKindRead
 
 	// Prevent read compactions which are too wide.
-	outputOverlaps := pc.version.Overlaps(
-		pc.outputLevel.level, pc.smallest.UserKey,
-		pc.largest.UserKey, pc.largest.IsExclusiveSentinel())
+	outputOverlaps := pc.version.Overlaps(pc.outputLevel.level, pc.userKeyBounds())
 	if outputOverlaps.SizeSum() > pc.maxReadCompactionBytes {
 		return nil
 	}

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -1047,8 +1047,10 @@ func TestPickedCompactionSetupInputs(t *testing.T) {
 				pc.outputLevel.level = pc.startLevel.level + 1
 			}
 			pc.version = newVersion(opts, files)
-			pc.startLevel.files = pc.version.Overlaps(pc.startLevel.level,
-				[]byte(args[0].String()), []byte(args[1].String()), false /* exclusiveEnd */)
+			pc.startLevel.files = pc.version.Overlaps(
+				pc.startLevel.level,
+				base.UserKeyBoundsInclusive([]byte(args[0].String()), []byte(args[1].String())),
+			)
 
 			var isCompacting bool
 			if !pc.setupInputs(opts, availBytes, pc.startLevel) {

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1211,8 +1211,8 @@ func TestManualCompaction(t *testing.T) {
 		ongoingCompaction.outputLevel = &ongoingCompaction.inputs[1]
 		// Mark files as compacting.
 		curr := d.mu.versions.currentVersion()
-		ongoingCompaction.startLevel.files = curr.Overlaps(startLevel, start, end, false)
-		ongoingCompaction.outputLevel.files = curr.Overlaps(outputLevel, start, end, false)
+		ongoingCompaction.startLevel.files = curr.Overlaps(startLevel, base.UserKeyBoundsInclusive(start, end))
+		ongoingCompaction.outputLevel.files = curr.Overlaps(outputLevel, base.UserKeyBoundsInclusive(start, end))
 		for _, cl := range ongoingCompaction.inputs {
 			iter := cl.files.Iter()
 			for f := iter.First(); f != nil; f = iter.Next() {

--- a/flushable.go
+++ b/flushable.go
@@ -11,7 +11,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/keyspan/keyspanimpl"
 	"github.com/cockroachdb/pebble/internal/manifest"
@@ -50,10 +52,11 @@ const (
 )
 
 type bounded interface {
-	// InternalKeyBounds returns a start key and an end key. Both bounds are
-	// inclusive.
-	InternalKeyBounds() (InternalKey, InternalKey)
+	UserKeyBounds() base.UserKeyBounds
 }
+
+var _ bounded = (*fileMetadata)(nil)
+var _ bounded = KeyRange{}
 
 func sliceAsBounded[B bounded](s []B) []bounded {
 	ret := make([]bounded, len(s))
@@ -148,6 +151,7 @@ type flushableList []*flushableEntry
 // ingestedFlushable is the implementation of the flushable interface for the
 // ingesting sstables which are added to the flushable list.
 type ingestedFlushable struct {
+	// files are non-overlapping and ordered (according to their bounds).
 	files            []physicalMeta
 	comparer         *Comparer
 	newIters         tableNewIters
@@ -166,6 +170,15 @@ func newIngestedFlushable(
 	newIters tableNewIters,
 	newRangeKeyIters keyspanimpl.TableNewSpanIter,
 ) *ingestedFlushable {
+	if invariants.Enabled {
+		for i := 1; i < len(files); i++ {
+			prev := files[i-1].UserKeyBounds()
+			this := files[i].UserKeyBounds()
+			if prev.End.IsUpperBoundFor(comparer.Compare, this.Start) {
+				panic(errors.AssertionFailedf("ingested flushable files overlap: %s %s", prev, this))
+			}
+		}
+	}
 	var physicalFiles []physicalMeta
 	var hasRangeKeys bool
 	for _, f := range files {
@@ -288,32 +301,43 @@ func (s *ingestedFlushable) readyForFlush() bool {
 func (s *ingestedFlushable) computePossibleOverlaps(
 	fn func(bounded) shouldContinue, bounded ...bounded,
 ) {
-	for i := range bounded {
-		smallest, largest := bounded[i].InternalKeyBounds()
-		for j := 0; j < len(s.files); j++ {
-			if sstableKeyCompare(s.comparer.Compare, s.files[j].Largest, smallest) >= 0 {
-				// This file's largest key is larger than smallest. Either the
-				// file overlaps the bounds, or it lies strictly after the
-				// bounds. Either way we can stop iterating since the files are
-				// sorted. But first, determine if there's overlap and call fn
-				// if necessary.
-				if sstableKeyCompare(s.comparer.Compare, s.files[j].Smallest, largest) <= 0 {
-					// The file overlaps in key boundaries. The file doesn't necessarily
-					// contain any keys within the key range, but we would need to
-					// perform I/O to know for sure. The flushable interface dictates
-					// that we're not permitted to perform I/O here, so err towards
-					// assuming overlap.
-					if !fn(bounded[i]) {
-						return
-					}
-				}
-				break
+	for _, b := range bounded {
+		bounds := b.UserKeyBounds()
+		if s.anyFileOverlaps(b, &bounds) {
+			// Some file overlaps in key boundaries. The file doesn't necessarily
+			// contain any keys within the key range, but we would need to perform I/O
+			// to know for sure. The flushable interface dictates that we're not
+			// permitted to perform I/O here, so err towards assuming overlap.
+			if !fn(b) {
+				return
 			}
 		}
 	}
 }
 
-// computePossibleOverlapsGenericImpl is an implemention of the flushable
+// anyFileBoundsOverlap returns true if there is at least a file in s.files with
+// bounds that overlap the given bounds.
+func (s *ingestedFlushable) anyFileOverlaps(b bounded, bounds *base.UserKeyBounds) bool {
+	// Note that s.files are non-overlapping and sorted.
+	for _, f := range s.files {
+		fileBounds := f.UserKeyBounds()
+		if !fileBounds.End.IsUpperBoundFor(s.comparer.Compare, bounds.Start) {
+			// The file ends before the bounds start. Go to the next file.
+			continue
+		}
+		if !bounds.End.IsUpperBoundFor(s.comparer.Compare, fileBounds.Start) {
+			// The file starts after the bounds end. There is no overlap, and
+			// further files will not overlap either (the files are sorted).
+			return false
+		}
+		// There is overlap. Note that UserKeyBounds.Overlaps() performs exactly the
+		// checks above.
+		return true
+	}
+	return false
+}
+
+// computePossibleOverlapsGenericImpl is an implementation of the flushable
 // interface's computePossibleOverlaps function for flushable implementations
 // with only in-memory state that do not have special requirements and should
 // read through the ordinary flushable iterators.
@@ -327,9 +351,7 @@ func computePossibleOverlapsGenericImpl[F flushable](
 	rangeDelIter := f.newRangeDelIter(nil)
 	rkeyIter := f.newRangeKeyIter(nil)
 	for _, b := range bounded {
-		s, l := b.InternalKeyBounds()
-		kr := internalKeyRange{s, l}
-		if overlapWithIterator(iter, &rangeDelIter, rkeyIter, kr, cmp) {
+		if overlapWithIterator(iter, &rangeDelIter, rkeyIter, b.UserKeyBounds(), cmp) {
 			if !fn(b) {
 				break
 			}

--- a/ingest.go
+++ b/ingest.go
@@ -40,6 +40,8 @@ func sstableKeyCompare(userCmp Compare, a, b InternalKey) int {
 
 // KeyRange encodes a key range in user key space. A KeyRange's Start is
 // inclusive while its End is exclusive.
+//
+// KeyRange is equivalent to base.UserKeyBounds with exclusive end.
 type KeyRange struct {
 	Start, End []byte
 }
@@ -55,11 +57,9 @@ func (k *KeyRange) Contains(cmp base.Compare, key InternalKey) bool {
 	return (v < 0 || (v == 0 && key.IsExclusiveSentinel())) && cmp(k.Start, key.UserKey) <= 0
 }
 
-// InternalKeyBounds returns the key range as internal key bounds, with the end
-// boundary represented as an exclusive range delete sentinel key.
-func (k KeyRange) InternalKeyBounds() (InternalKey, InternalKey) {
-	return base.MakeInternalKey(k.Start, InternalKeySeqNumMax, InternalKeyKindMax),
-		base.MakeExclusiveSentinelKey(InternalKeyKindRangeDelete, k.End)
+// UserKeyBounds returns the KeyRange as UserKeyBounds. Also implements the internal `bounded` interface.
+func (k KeyRange) UserKeyBounds() base.UserKeyBounds {
+	return base.UserKeyBoundsEndExclusive(k.Start, k.End)
 }
 
 // OverlapsInternalKeyRange checks if the specified internal key range has an
@@ -67,16 +67,17 @@ func (k KeyRange) InternalKeyBounds() (InternalKey, InternalKey) {
 // of smallest-largest within k, rather just that there's some intersection
 // between the two ranges.
 func (k *KeyRange) OverlapsInternalKeyRange(cmp base.Compare, smallest, largest InternalKey) bool {
-	v := cmp(k.Start, largest.UserKey)
-	return v <= 0 && !(largest.IsExclusiveSentinel() && v == 0) &&
-		cmp(k.End, smallest.UserKey) > 0
+	ukb := k.UserKeyBounds()
+	b := base.UserKeyBoundsFromInternal(smallest, largest)
+	return ukb.Overlaps(cmp, &b)
 }
 
 // Overlaps checks if the specified file has an overlap with the KeyRange.
 // Note that we aren't checking for full containment of m within k, rather just
 // that there's some intersection between m and k's bounds.
 func (k *KeyRange) Overlaps(cmp base.Compare, m *fileMetadata) bool {
-	return k.OverlapsInternalKeyRange(cmp, m.Smallest, m.Largest)
+	b := k.UserKeyBounds()
+	return m.Overlaps(cmp, &b)
 }
 
 // OverlapsKeyRange checks if this span overlaps with the provided KeyRange.
@@ -746,16 +747,14 @@ func ingestUpdateSeqNum(
 	return nil
 }
 
-// Denotes an internal key range. Smallest and largest are both inclusive.
-type internalKeyRange struct {
-	smallest, largest InternalKey
-}
-
+// overlapWIthIterator returns true if the given iterators produce keys or spans
+// overlapping the given UserKeyBounds. May return false positives (e.g. in
+// error cases).
 func overlapWithIterator(
 	iter internalIterator,
 	rangeDelIter *keyspan.FragmentIterator,
 	rkeyIter keyspan.FragmentIterator,
-	keyRange internalKeyRange,
+	bounds base.UserKeyBounds,
 	cmp Compare,
 ) bool {
 	// Check overlap with point operations.
@@ -777,10 +776,9 @@ func overlapWithIterator(
 	//    means boundary < L and hence is similar to 1).
 	// 4) boundary == L and L is sentinel,
 	//    we'll always overlap since for any values of i,j ranges [i, k) and [j, k) always overlap.
-	key, _ := iter.SeekGE(keyRange.smallest.UserKey, base.SeekGEFlagsNone)
+	key, _ := iter.SeekGE(bounds.Start, base.SeekGEFlagsNone)
 	if key != nil {
-		c := sstableKeyCompare(cmp, *key, keyRange.largest)
-		if c <= 0 {
+		if bounds.End.IsUpperBoundForInternalKey(cmp, *key) {
 			return true
 		}
 	}
@@ -791,37 +789,20 @@ func overlapWithIterator(
 
 	computeOverlapWithSpans := func(rIter keyspan.FragmentIterator) (bool, error) {
 		// NB: The spans surfaced by the fragment iterator are non-overlapping.
-		span, err := rIter.SeekLT(keyRange.smallest.UserKey)
+		span, err := rIter.SeekGE(bounds.Start)
 		if err != nil {
 			return false, err
-		} else if span == nil {
-			span, err = rIter.Next()
-			if err != nil {
-				return false, err
-			}
 		}
 		for ; span != nil; span, err = rIter.Next() {
-			if span.Empty() {
-				continue
-			}
-			key := span.SmallestKey()
-			c := sstableKeyCompare(cmp, key, keyRange.largest)
-			if c > 0 {
-				// The start of the span is after the largest key in the
-				// ingested table.
+			if !bounds.End.IsUpperBoundFor(cmp, span.Start) {
+				// The span starts after our bounds.
 				return false, nil
 			}
-			if cmp(span.End, keyRange.smallest.UserKey) > 0 {
-				// The end of the span is greater than the smallest in the
-				// table. Note that the span end key is exclusive, thus ">0"
-				// instead of ">=0".
+			if !span.Empty() {
 				return true, nil
 			}
 		}
-		if err != nil {
-			return false, err
-		}
-		return false, nil
+		return false, err
 	}
 
 	// rkeyIter is either a range key level iter, or a range key iterator
@@ -948,11 +929,7 @@ func ingestTargetLevel(
 			v.L0Sublevels.Levels[subLevel].Iter(), manifest.Level(0), manifest.KeyTypeRange,
 		)
 
-		kr := internalKeyRange{
-			smallest: meta.Smallest,
-			largest:  meta.Largest,
-		}
-		overlap := overlapWithIterator(iter, &rangeDelIter, &levelIter, kr, comparer.Compare)
+		overlap := overlapWithIterator(iter, &rangeDelIter, &levelIter, meta.UserKeyBounds(), comparer.Compare)
 		err := iter.Close() // Closes range del iter as well.
 		err = firstError(err, levelIter.Close())
 		if err != nil {
@@ -978,11 +955,7 @@ func ingestTargetLevel(
 			v.Levels[level].Iter(), manifest.Level(level), manifest.KeyTypeRange,
 		)
 
-		kr := internalKeyRange{
-			smallest: meta.Smallest,
-			largest:  meta.Largest,
-		}
-		overlap := overlapWithIterator(levelIter, &rangeDelIter, rkeyLevelIter, kr, comparer.Compare)
+		overlap := overlapWithIterator(levelIter, &rangeDelIter, rkeyLevelIter, meta.UserKeyBounds(), comparer.Compare)
 		err := levelIter.Close() // Closes range del iter as well.
 		err = firstError(err, rkeyLevelIter.Close())
 		if err != nil {
@@ -994,8 +967,7 @@ func ingestTargetLevel(
 
 		// Check boundary overlap.
 		var candidateSplitFile *fileMetadata
-		boundaryOverlaps := v.Overlaps(level, meta.Smallest.UserKey,
-			meta.Largest.UserKey, meta.Largest.IsExclusiveSentinel())
+		boundaryOverlaps := v.Overlaps(level, meta.UserKeyBounds())
 		if !boundaryOverlaps.Empty() {
 			// We are already guaranteed to not have any data overlaps with files
 			// in boundaryOverlaps, otherwise we'd have returned in the above if
@@ -2062,6 +2034,7 @@ func (d *DB) ingestSplit(
 	replacedFiles map[base.FileNum][]newFileEntry,
 ) error {
 	for _, s := range files {
+		ingestFileBounds := s.ingestFile.UserKeyBounds()
 		// replacedFiles can be thought of as a tree, where we start iterating with
 		// s.splitFile and run its fileNum through replacedFiles, then find which of
 		// the replaced files overlaps with s.ingestFile, which becomes the new
@@ -2079,7 +2052,7 @@ func (d *DB) ingestSplit(
 			}
 			updatedSplitFile := false
 			for i := range replaced {
-				if replaced[i].Meta.Overlaps(d.cmp, s.ingestFile.Smallest.UserKey, s.ingestFile.Largest.UserKey, s.ingestFile.Largest.IsExclusiveSentinel()) {
+				if replaced[i].Meta.Overlaps(d.cmp, &ingestFileBounds) {
 					if updatedSplitFile {
 						// This should never happen because the earlier ingestTargetLevel
 						// function only finds split file candidates that are guaranteed to
@@ -2132,7 +2105,8 @@ func (d *DB) ingestSplit(
 		}
 		replacedFiles[splitFile.FileNum] = added
 		for i := range added {
-			if s.ingestFile.Overlaps(d.cmp, added[i].Meta.Smallest.UserKey, added[i].Meta.Largest.UserKey, added[i].Meta.Largest.IsExclusiveSentinel()) {
+			addedBounds := added[i].Meta.UserKeyBounds()
+			if s.ingestFile.Overlaps(d.cmp, &addedBounds) {
 				panic("ingest-time split produced a file that overlaps with ingested file")
 			}
 		}
@@ -2335,7 +2309,7 @@ func (d *DB) ingestApply(
 		// for files, and if they are, we should signal those compactions to error
 		// out.
 		for level := range current.Levels {
-			overlaps := current.Overlaps(level, exciseSpan.Start, exciseSpan.End, true /* exclusiveEnd */)
+			overlaps := current.Overlaps(level, exciseSpan.UserKeyBounds())
 			iter := overlaps.Iter()
 
 			for m := iter.First(); m != nil; m = iter.Next() {

--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -463,11 +463,13 @@ func (k InternalKey) Pretty(f FormatKey) fmt.Formatter {
 // with the same user key if used as an end boundary. See the comment on
 // InternalKeyRangeDeletionSentinel.
 func (k InternalKey) IsExclusiveSentinel() bool {
+	if (k.Trailer >> 8) != InternalKeySeqNumMax {
+		return false
+	}
 	switch kind := k.Kind(); kind {
-	case InternalKeyKindRangeDelete:
-		return k.Trailer == InternalKeyRangeDeleteSentinel
-	case InternalKeyKindRangeKeyDelete, InternalKeyKindRangeKeyUnset, InternalKeyKindRangeKeySet:
-		return (k.Trailer >> 8) == InternalKeySeqNumMax
+	case InternalKeyKindRangeDelete, InternalKeyKindRangeKeyDelete,
+		InternalKeyKindRangeKeyUnset, InternalKeyKindRangeKeySet:
+		return true
 	default:
 		return false
 	}

--- a/internal/base/key_bounds.go
+++ b/internal/base/key_bounds.go
@@ -1,0 +1,163 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package base
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/pebble/internal/invariants"
+)
+
+// BoundaryKind indicates if a boundary is exclusive or inclusive.
+type BoundaryKind uint8
+
+// The two possible values of BoundaryKind.
+//
+// Note that we prefer Exclusive to be the zero value, so that zero
+// UserKeyBounds are not valid.
+const (
+	Exclusive BoundaryKind = iota
+	Inclusive
+)
+
+// UserKeyBoundary represents the endpoint of a bound which can be exclusive or
+// inclusive.
+type UserKeyBoundary struct {
+	Key  []byte
+	Kind BoundaryKind
+}
+
+// UserKeyInclusive creates an inclusive user key boundary.
+func UserKeyInclusive(userKey []byte) UserKeyBoundary {
+	return UserKeyBoundary{
+		Key:  userKey,
+		Kind: Inclusive,
+	}
+}
+
+// UserKeyExclusive creates an exclusive user key boundary.
+func UserKeyExclusive(userKey []byte) UserKeyBoundary {
+	return UserKeyBoundary{
+		Key:  userKey,
+		Kind: Exclusive,
+	}
+}
+
+// UserKeyExclusiveIf creates a user key boundary which can be either inclusive
+// or exclusive.
+func UserKeyExclusiveIf(userKey []byte, exclusive bool) UserKeyBoundary {
+	kind := Inclusive
+	if exclusive {
+		kind = Exclusive
+	}
+	return UserKeyBoundary{
+		Key:  userKey,
+		Kind: kind,
+	}
+}
+
+// IsUpperBoundFor returns true if the boundary is an upper bound for the key;
+// i.e. the key is less than the boundary key OR they are equal and the boundary
+// is inclusive.
+func (eb UserKeyBoundary) IsUpperBoundFor(cmp Compare, userKey []byte) bool {
+	c := cmp(userKey, eb.Key)
+	return c < 0 || (c == 0 && eb.Kind == Inclusive)
+}
+
+// IsUpperBoundForInternalKey returns true if boundary is an upper bound for the
+// given internal key.
+func (eb UserKeyBoundary) IsUpperBoundForInternalKey(cmp Compare, key InternalKey) bool {
+	c := cmp(key.UserKey, eb.Key)
+	return c < 0 || (c == 0 && (eb.Kind == Inclusive || key.IsExclusiveSentinel()))
+}
+
+// UserKeyBounds is a user key interval with an inclusive start boundary and
+// with an end boundary that can be either inclusive or exclusive.
+type UserKeyBounds struct {
+	Start []byte
+	End   UserKeyBoundary
+}
+
+// UserKeyBoundsInclusive creates the bounds [start, end].
+func UserKeyBoundsInclusive(start []byte, end []byte) UserKeyBounds {
+	return UserKeyBounds{
+		Start: start,
+		End:   UserKeyInclusive(end),
+	}
+}
+
+// UserKeyBoundsEndExclusive creates the bounds [start, end).
+func UserKeyBoundsEndExclusive(start []byte, end []byte) UserKeyBounds {
+	return UserKeyBounds{
+		Start: start,
+		End:   UserKeyExclusive(end),
+	}
+}
+
+// UserKeyBoundsEndExclusiveIf creates either [start, end] or [start, end) bounds.
+func UserKeyBoundsEndExclusiveIf(start []byte, end []byte, exclusive bool) UserKeyBounds {
+	return UserKeyBounds{
+		Start: start,
+		End:   UserKeyExclusiveIf(end, exclusive),
+	}
+}
+
+// UserKeyBoundsFromInternal creates the bounds
+// [smallest.UserKey, largest.UserKey] or [smallest.UserKey, largest.UserKey) if
+// largest is an exclusive sentinel.
+//
+// smallest must not be an exclusive sentinel.
+func UserKeyBoundsFromInternal(smallest, largest InternalKey) UserKeyBounds {
+	if invariants.Enabled && smallest.IsExclusiveSentinel() {
+		panic("smallest key is exclusive sentinel")
+	}
+	return UserKeyBoundsEndExclusiveIf(smallest.UserKey, largest.UserKey, largest.IsExclusiveSentinel())
+}
+
+// Valid returns true if the bounds contain at least a user key.
+func (b *UserKeyBounds) Valid(cmp Compare) bool {
+	return b.End.IsUpperBoundFor(cmp, b.Start)
+}
+
+// Overlaps returns true if the bounds overlap.
+func (b *UserKeyBounds) Overlaps(cmp Compare, other *UserKeyBounds) bool {
+	// There is no overlap iff one interval starts after the other ends.
+	return other.End.IsUpperBoundFor(cmp, b.Start) && b.End.IsUpperBoundFor(cmp, other.Start)
+}
+
+// ContainsBounds returns true if b completely overlaps other.
+func (b *UserKeyBounds) ContainsBounds(cmp Compare, other *UserKeyBounds) bool {
+	if cmp(b.Start, other.Start) > 0 {
+		return false
+	}
+	c := cmp(other.End.Key, b.End.Key)
+	return c < 0 || (c == 0 && (b.End.Kind == Inclusive || other.End.Kind == Exclusive))
+}
+
+// ContainsUserKey returns true if the user key is within the bounds.
+func (b *UserKeyBounds) ContainsUserKey(cmp Compare, userKey []byte) bool {
+	return cmp(b.Start, userKey) <= 0 && b.End.IsUpperBoundFor(cmp, userKey)
+}
+
+// ContainsInternalKey returns true if the internal key is within the bounds.
+func (b *UserKeyBounds) ContainsInternalKey(cmp Compare, key InternalKey) bool {
+	c := cmp(b.Start, key.UserKey)
+	return (c < 0 || (c == 0 && !key.IsExclusiveSentinel())) &&
+		b.End.IsUpperBoundForInternalKey(cmp, key)
+}
+
+func (b UserKeyBounds) String() string {
+	return b.Format(DefaultFormatter)
+}
+
+// Format converts the bounds to a string of the form "[foo, bar]" or
+// "[foo, bar)", using the given key formatter.
+func (b UserKeyBounds) Format(fmtKey FormatKey) string {
+	endC := ']'
+	if b.End.Kind == Exclusive {
+		endC = ')'
+	}
+	return fmt.Sprintf("[%s, %s%c", fmtKey(b.Start), fmtKey(b.End.Key), endC)
+}

--- a/internal/keyspan/span.go
+++ b/internal/keyspan/span.go
@@ -126,6 +126,11 @@ func (s *Span) Empty() bool {
 	return s == nil || len(s.Keys) == 0
 }
 
+// Bounds returns Start and End as UserKeyBounds.
+func (s *Span) Bounds() base.UserKeyBounds {
+	return base.UserKeyBoundsEndExclusive(s.Start, s.End)
+}
+
 // SmallestKey returns the smallest internal key defined by the span's keys.
 // It requires the Span's keys be in ByTrailerDesc order. It panics if the span
 // contains no keys or its keys are sorted in a different order.

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -119,8 +119,7 @@ func (lm *LevelMetadata) Find(cmp base.Compare, m *FileMetadata) *LevelFile {
 	if lm.level != 0 {
 		// If lm holds files for levels >0, we can narrow our search by binary
 		// searching by bounds.
-		o := overlaps(iter, cmp, m.Smallest.UserKey,
-			m.Largest.UserKey, m.Largest.IsExclusiveSentinel())
+		o := overlaps(iter, cmp, m.UserKeyBounds())
 		iter = o.Iter()
 	}
 	for f := iter.First(); f != nil; f = iter.Next() {

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -66,7 +66,7 @@ func TestInuseKeyRangesRandomized(t *testing.T) {
 		}
 
 		for l := level; l < manifest.NumLevels; l++ {
-			o := v.Overlaps(l, smallest, largest, false /* exclusiveEnd */)
+			o := v.Overlaps(l, base.UserKeyBoundsInclusive(smallest, largest))
 			iter := o.Iter()
 			for f := iter.First(); f != nil; f = iter.Next() {
 				// CalculateInuseKeyRanges only guarantees that it returns key

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -1110,8 +1110,7 @@ func (b *BulkVersionEdit) Apply(
 
 		// Check consistency of the level in the vicinity of our edits.
 		if sm != nil && la != nil {
-			overlap := overlaps(v.Levels[level].Iter(), comparer.Compare, sm.Smallest.UserKey,
-				la.Largest.UserKey, la.Largest.IsExclusiveSentinel())
+			overlap := overlaps(v.Levels[level].Iter(), comparer.Compare, sm.UserKeyBounds())
 			// overlap contains all of the added files. We want to ensure that
 			// the added files are consistent with neighboring existing files
 			// too, so reslice the overlap to pull in a neighbor on each side.

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -107,7 +107,7 @@ func TestOverlaps(t *testing.T) {
 			d.ScanArgs(t, "start", &start)
 			d.ScanArgs(t, "end", &end)
 			d.ScanArgs(t, "exclusive-end", &exclusiveEnd)
-			overlaps := v.Overlaps(level, []byte(start), []byte(end), exclusiveEnd)
+			overlaps := v.Overlaps(level, base.UserKeyBoundsEndExclusiveIf([]byte(start), []byte(end), exclusiveEnd))
 			var buf bytes.Buffer
 			fmt.Fprintf(&buf, "%d files:\n", overlaps.Len())
 			overlaps.Each(func(f *FileMetadata) {

--- a/table_stats.go
+++ b/table_stats.go
@@ -500,8 +500,7 @@ func (d *DB) estimateSizesBeneath(
 	}
 
 	for l := level + 1; l < numLevels; l++ {
-		overlaps := v.Overlaps(l, meta.Smallest.UserKey,
-			meta.Largest.UserKey, meta.Largest.IsExclusiveSentinel())
+		overlaps := v.Overlaps(l, meta.UserKeyBounds())
 		iter := overlaps.Iter()
 		for file = iter.First(); file != nil; file = iter.Next() {
 			var err error
@@ -553,7 +552,7 @@ func (d *DB) estimateReclaimedSizeBeneath(
 	// additional I/O to read the file's index blocks.
 	hintSeqNum = math.MaxUint64
 	for l := level + 1; l < numLevels; l++ {
-		overlaps := v.Overlaps(l, start, end, true /* exclusiveEnd */)
+		overlaps := v.Overlaps(l, base.UserKeyBoundsEndExclusive(start, end))
 		iter := overlaps.Iter()
 		for file := iter.First(); file != nil; file = iter.Next() {
 			startCmp := d.cmp(start, file.Smallest.UserKey)


### PR DESCRIPTION
This commit adds `UserKeyBounds` which represents a range of user keys with inclusive start boundary and either inclusive or exclusive range boundary.

This replaces ad-hoc code in various places.

Note: I think there are more places where this can be used and I will look at them as a follow-up, I just didn't want it all in one PR.