### PR TITLE
sstable: better corrupt index entry errors

### DIFF
--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -415,13 +415,13 @@ func (i *singleLevelIterator) loadBlock(dir int8) loadBlockResult {
 	i.data.invalidate()
 	i.dataBH = bhp.BlockHandle
 	if err != nil {
-		i.err = errCorruptIndexEntry
+		i.err = errCorruptIndexEntry(err)
 		return loadBlockFailed
 	}
 	if i.bpfs != nil {
 		intersects, err := i.bpfs.intersects(bhp.Props)
 		if err != nil {
-			i.err = errCorruptIndexEntry
+			i.err = errCorruptIndexEntry(err)
 			return loadBlockFailed
 		}
 		if intersects == blockMaybeExcluded {

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -49,7 +49,7 @@ func (i *twoLevelIterator) loadIndex(dir int8) loadBlockResult {
 	if i.bpfs != nil {
 		intersects, err := i.bpfs.intersects(bhp.Props)
 		if err != nil {
-			i.err = errCorruptIndexEntry
+			i.err = errCorruptIndexEntry(err)
 			return loadBlockFailed
 		}
 		if intersects == blockMaybeExcluded {


### PR DESCRIPTION
All uses of `errCorruptIndexEntry` swallow the actual error. This
commit changes it into a function that retains the original error
message. We also panic in invariants mode.