### PR TITLE
db: allow runtime configuration of compression

### DIFF
--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -392,7 +392,7 @@ func TestCheckpointManyFiles(t *testing.T) {
 	// Disable compression to speed up the test.
 	opts.EnsureDefaults()
 	for i := range opts.Levels {
-		opts.Levels[i].Compression = NoCompression
+		opts.Levels[i].Compression = func() Compression { return NoCompression }
 	}
 
 	d, err := Open("", opts)

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -686,11 +686,11 @@ func RandomOptions(
 	// We use either no compression, snappy compression or zstd compression.
 	switch rng.Intn(3) {
 	case 0:
-		lopts.Compression = pebble.NoCompression
+		lopts.Compression = func() sstable.Compression { return pebble.NoCompression }
 	case 1:
-		lopts.Compression = pebble.ZstdCompression
+		lopts.Compression = func() sstable.Compression { return pebble.ZstdCompression }
 	default:
-		lopts.Compression = pebble.SnappyCompression
+		lopts.Compression = func() sstable.Compression { return pebble.SnappyCompression }
 	}
 	opts.Levels = []pebble.LevelOptions{lopts}
 

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -75,6 +75,13 @@ func TestOptionsRoundtrip(t *testing.T) {
 		"Experimental.IngestSplit:",
 		"Experimental.RemoteStorage:",
 		"Experimental.SingleDeleteInvariantViolationCallback:",
+		"Levels[0].Compression:",
+		"Levels[1].Compression:",
+		"Levels[2].Compression:",
+		"Levels[3].Compression:",
+		"Levels[4].Compression:",
+		"Levels[5].Compression:",
+		"Levels[6].Compression:",
 		"WALFailover.FailoverOptions.UnhealthyOperationLatencyThreshold:",
 		// Floating points
 		"Experimental.PointTombstoneWeight:",


### PR DESCRIPTION
Allow clients to change configuration of the compression algorithm at runtime. This will be used to tie the compression algorithm to a CockroachDB cluster setting, enabling opt-in use of zstd.