### PR TITLE
ingest: fix ingestion metric for flushableIngest

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -1408,6 +1408,7 @@ func (d *DB) handleIngestAsFlushable(
 		}
 	}
 
+	d.mu.versions.metrics.Ingest.Count++
 	currMem := d.mu.mem.mutable
 	// NB: Placing ingested sstables above the current memtables
 	// requires rotating of the existing memtables/WAL. There is

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -334,7 +334,7 @@ Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
-Ingestions: 1  as flushable: 1 (1.2KB in 2 tables)
+Ingestions: 2  as flushable: 1 (1.2KB in 2 tables)
 
 sstables
 ----

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -484,7 +484,7 @@ Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
-Ingestions: 0  as flushable: 2 (1.8KB in 3 tables)
+Ingestions: 2  as flushable: 2 (1.8KB in 3 tables)
 Iter category stats:
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
@@ -546,7 +546,7 @@ Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
-Ingestions: 0  as flushable: 2 (1.8KB in 3 tables)
+Ingestions: 2  as flushable: 2 (1.8KB in 3 tables)
 Iter category stats:
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
@@ -622,7 +622,7 @@ Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
-Ingestions: 1  as flushable: 2 (1.8KB in 3 tables)
+Ingestions: 3  as flushable: 2 (1.8KB in 3 tables)
 Iter category stats:
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
@@ -723,7 +723,7 @@ Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
-Ingestions: 2  as flushable: 2 (1.8KB in 3 tables)
+Ingestions: 4  as flushable: 2 (1.8KB in 3 tables)
 Iter category stats:
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}


### PR DESCRIPTION
When we were previously ingesting as a flushable, we were not incrementing the `metrics.Ingest.Count` metric.