### PR TITLE
metamorphic: re-enable ingest split and ingestAndExcise in TestMeta

### DIFF
--- a/metamorphic/config.go
+++ b/metamorphic/config.go
@@ -175,7 +175,7 @@ func DefaultOpConfig() OpConfig {
 			OpWriterDelete:                100,
 			OpWriterDeleteRange:           50,
 			OpWriterIngest:                100,
-			OpWriterIngestAndExcise:       0, // TODO(bilal): Enable this.
+			OpWriterIngestAndExcise:       50,
 			OpWriterLogData:               10,
 			OpWriterMerge:                 100,
 			OpWriterRangeKeySet:           10,
@@ -313,7 +313,6 @@ func WriteOpConfig() OpConfig {
 func multiInstanceConfig() OpConfig {
 	cfg := DefaultOpConfig()
 	cfg.ops[OpReplicate] = 5
-	cfg.ops[OpWriterIngestAndExcise] = 50
 	// Single deletes and merges are disabled in multi-instance mode, as
 	// replicateOp and ingestAndExciseOp don't support them.
 	cfg.ops[OpWriterSingleDelete] = 0

--- a/metamorphic/generator.go
+++ b/metamorphic/generator.go
@@ -1283,6 +1283,8 @@ func (g *generator) writerIngestAndExcise() {
 		derivedDBID: derivedDBID,
 		exciseStart: start,
 		exciseEnd:   end,
+		// TODO(bilal): Uncomment this when known bugs are fixed.
+		//sstContainsExciseTombstone: g.rng.Intn(2) == 0,
 	})
 }
 

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -882,10 +882,11 @@ func (o *ingestOp) keys() []*[]byte                     { return nil }
 func (o *ingestOp) diagramKeyRanges() []pebble.KeyRange { return nil }
 
 type ingestAndExciseOp struct {
-	dbID                   objID
-	batchID                objID
-	derivedDBID            objID
-	exciseStart, exciseEnd []byte
+	dbID                       objID
+	batchID                    objID
+	derivedDBID                objID
+	exciseStart, exciseEnd     []byte
+	sstContainsExciseTombstone bool
 }
 
 func (o *ingestAndExciseOp) run(t *Test, h historyRecorder) {
@@ -899,6 +900,12 @@ func (o *ingestAndExciseOp) run(t *Test, h historyRecorder) {
 		// No-op.
 		h.Recordf("%s // %v", o, err)
 		return
+	}
+	if t.testOpts.useExcise && o.sstContainsExciseTombstone {
+		// Add a rangedel and rangekeydel to the batch. This ensures it'll end up
+		// inside the sstable.
+		err = firstError(err, b.DeleteRange(o.exciseStart, o.exciseEnd, t.writeOpts))
+		err = firstError(err, b.RangeKeyDelete(o.exciseStart, o.exciseEnd, t.writeOpts))
 	}
 	path, writerMeta, err2 := buildForIngest(t, o.dbID, b, 0 /* i */)
 	if err2 != nil {
@@ -926,7 +933,7 @@ func (o *ingestAndExciseOp) run(t *Test, h historyRecorder) {
 			_, err := t.getDB(o.dbID).IngestAndExcise([]string{path}, nil /* shared */, nil /* external */, pebble.KeyRange{
 				Start: o.exciseStart,
 				End:   o.exciseEnd,
-			}, false)
+			}, o.sstContainsExciseTombstone)
 			return err
 		}))
 	} else {
@@ -950,7 +957,7 @@ func (o *ingestAndExciseOp) syncObjs() objIDSlice {
 }
 
 func (o *ingestAndExciseOp) String() string {
-	return fmt.Sprintf("%s.IngestAndExcise(%s, %q, %q)", o.dbID, o.batchID, o.exciseStart, o.exciseEnd)
+	return fmt.Sprintf("%s.IngestAndExcise(%s, %q, %q, %t /* sstContainsExciseTombstone */)", o.dbID, o.batchID, o.exciseStart, o.exciseEnd, o.sstContainsExciseTombstone)
 }
 
 func (o *ingestAndExciseOp) keys() []*[]byte {

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -765,10 +765,7 @@ func RandomOptions(
 	}
 
 	testOpts.seedEFOS = rng.Uint64()
-	// TODO(bilal): Enable ingestSplit when known bugs with virtual sstables
-	// are addressed.
-	//
-	// testOpts.ingestSplit = rng.Intn(2) == 0
+	testOpts.ingestSplit = rng.Intn(2) == 0
 	opts.Experimental.IngestSplit = func() bool { return testOpts.ingestSplit }
 	testOpts.useExcise = rng.Intn(2) == 0
 	if testOpts.useExcise {

--- a/metamorphic/parser.go
+++ b/metamorphic/parser.go
@@ -76,7 +76,7 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	case *ingestOp:
 		return &t.dbID, nil, []interface{}{&t.batchIDs}
 	case *ingestAndExciseOp:
-		return &t.dbID, nil, []interface{}{&t.batchID, &t.exciseStart, &t.exciseEnd}
+		return &t.dbID, nil, []interface{}{&t.batchID, &t.exciseStart, &t.exciseEnd, &t.sstContainsExciseTombstone}
 	case *ingestExternalFilesOp:
 		return &t.dbID, nil, []interface{}{&t.objs}
 	case *initOp:


### PR DESCRIPTION
Previously, we disabled these features in the main metamorphic test to try to tease out issues elsewhere. However, seeing as these features are being turned on in 24.1 and have been stable for a while, we should turn it on in the main metamorphic test.

This change also implements the bulk of #3432 (i.e. the case where we can flushable-ingest an excise) but leaves it off as it's failing at the moment.