### PR TITLE
db: flushable ingest excise fixes

### DIFF
--- a/metamorphic/config.go
+++ b/metamorphic/config.go
@@ -314,7 +314,7 @@ func multiInstanceConfig() OpConfig {
 	cfg := DefaultOpConfig()
 	cfg.ops[OpReplicate] = 5
 	// Single deletes and merges are disabled in multi-instance mode, as
-	// replicateOp and ingestAndExciseOp don't support them.
+	// replicateOp doesn't support them.
 	cfg.ops[OpWriterSingleDelete] = 0
 	cfg.ops[OpWriterMerge] = 0
 

--- a/metamorphic/generator.go
+++ b/metamorphic/generator.go
@@ -1294,13 +1294,12 @@ func (g *generator) writerIngestAndExcise() {
 	}
 
 	g.add(&ingestAndExciseOp{
-		dbID:        dbID,
-		batchID:     batchID,
-		derivedDBID: derivedDBID,
-		exciseStart: start,
-		exciseEnd:   end,
-		// TODO(bilal): Uncomment this when known bugs are fixed.
-		//sstContainsExciseTombstone: g.rng.Intn(2) == 0,
+		dbID:                       dbID,
+		batchID:                    batchID,
+		derivedDBID:                derivedDBID,
+		exciseStart:                start,
+		exciseEnd:                  end,
+		sstContainsExciseTombstone: g.rng.Intn(2) == 0,
 	})
 }
 

--- a/metamorphic/key_manager.go
+++ b/metamorphic/key_manager.go
@@ -636,18 +636,9 @@ func (k *keyManager) update(o op) {
 		//
 		// Remove all keys from the key manager within the excise span before
 		// merging the batch into the db.
-		ts := k.nextMetaTimestamp()
-		keyRange := pebble.KeyRange{Start: s.exciseStart, End: s.exciseEnd}
-		for _, key := range k.knownKeysInRange(keyRange) {
-			meta := k.getOrInit(s.batchID, key)
-			if meta.objID.tag() == dbTag {
-				meta.clear()
-			} else {
-				meta.history = append(meta.history, keyHistoryItem{
-					opType:        OpWriterDeleteRange, // Mimic a DeleteRange.
-					metaTimestamp: ts,
-				})
-			}
+		for _, key := range k.InRangeKeysForObj(s.dbID, s.exciseStart, s.exciseEnd) {
+			m := k.getOrInit(s.dbID, key.key)
+			m.clear()
 		}
 		k.objKeyMeta(s.batchID).CollapseKeys()
 		k.mergeObjectInto(s.batchID, s.dbID)

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -908,7 +908,7 @@ func (o *ingestAndExciseOp) run(t *Test, h historyRecorder) {
 		h.Recordf("%s // %v", o, err)
 		return
 	}
-	if t.testOpts.useExcise && o.sstContainsExciseTombstone {
+	if o.sstContainsExciseTombstone {
 		// Add a rangedel and rangekeydel to the batch. This ensures it'll end up
 		// inside the sstable.
 		err = firstError(err, b.DeleteRange(o.exciseStart, o.exciseEnd, t.writeOpts))

--- a/testdata/excise
+++ b/testdata/excise
@@ -632,10 +632,10 @@ flushable ingest
 lsm
 ----
 L0.0:
+  000010:[b#17,SET-f#17,SET]
   000013:[x#15,SET-x#15,SET]
 L6:
   000014(000009):[a#0,SET-a#0,SET]
-  000010:[b#17,SET-f#17,SET]
   000015(000009):[g#0,SET-g#0,SET]
 
 iter lower=c upper=e
@@ -650,5 +650,62 @@ c: (something, .)
 .
 .
 c: (something, .)
+.
+.
+
+batch
+set a old
+set aa old
+----
+
+flush
+----
+
+compact a z
+----
+
+lsm
+----
+L6:
+  000018:[a#0,SET-x#0,SET]
+
+batch commit
+----
+
+build ext5
+set a outside-span
+----
+
+build ext6
+set b somethingElse
+set c somethingElse
+set f somethingElse
+del b-e
+----
+
+ingest-and-excise ext5 ext6 excise=b-e contains-excise-tombstone
+----
+
+lsm
+----
+L0.0:
+  000019:[a#22,SET-a#22,SET]
+  000020:[b#23,SET-f#23,SET]
+L6:
+  000021(000018):[a#0,SET-aa#0,SET]
+  000022(000018):[f#0,SET-x#0,SET]
+
+iter lower=a upper=f
+first
+next
+next
+next
+next
+next
+----
+a: (outside-span, .)
+aa: (old, .)
+b: (somethingElse, .)
+c: (somethingElse, .)
 .
 .


### PR DESCRIPTION
Previously, we'd repeatedly call Excise() if we had multiple files to ingest, and we'd mutate the ingestSplitFile param. This change fixes that.

Also update the metamorphic test to resume testing IngestAndExcise with sstContainsExciseTombstone=true.