### PR TITLE
metamorphic: add per-op timeout

### DIFF
--- a/internal/metamorphic/metaflags/meta_flags.go
+++ b/internal/metamorphic/metaflags/meta_flags.go
@@ -14,7 +14,9 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/randvar"
 	"github.com/cockroachdb/pebble/metamorphic"
 )
@@ -40,6 +42,8 @@ type CommonFlags struct {
 	// NumInstances is the number of Pebble instances to create in one run. See
 	// "num-instances" flag below.
 	NumInstances int
+	// OpTimeout is a per-operation timeout.
+	OpTimeout time.Duration
 }
 
 func initCommonFlags() *CommonFlags {
@@ -71,6 +75,12 @@ func initCommonFlags() *CommonFlags {
 		"limit execution of a single run to the provided number of threads; must be ≥ 1")
 
 	flag.IntVar(&c.NumInstances, "num-instances", 1, "number of pebble instances to create (default: 1)")
+
+	defaultOpTimeout := 1 * time.Minute
+	if invariants.RaceEnabled {
+		defaultOpTimeout *= 5
+	}
+	flag.DurationVar(&c.OpTimeout, "op-timeout", defaultOpTimeout, "per-op timeout")
 
 	return c
 }
@@ -185,6 +195,7 @@ func InitAllFlags() (*RunOnceFlags, *RunFlags) {
 func (ro *RunOnceFlags) MakeRunOnceOptions() []metamorphic.RunOnceOption {
 	onceOpts := []metamorphic.RunOnceOption{
 		metamorphic.MaxThreads(ro.MaxThreads),
+		metamorphic.OpTimeout(ro.OpTimeout),
 	}
 	if ro.Keep {
 		onceOpts = append(onceOpts, metamorphic.KeepData{})
@@ -236,6 +247,7 @@ func (r *RunFlags) MakeRunOptions() []metamorphic.RunOption {
 		metamorphic.Seed(r.Seed),
 		metamorphic.OpCount(r.Ops.Static),
 		metamorphic.MaxThreads(r.MaxThreads),
+		metamorphic.OpTimeout(r.OpTimeout),
 	}
 	if r.Keep {
 		opts = append(opts, metamorphic.KeepData{})


### PR DESCRIPTION
Add a per-op timeout. The default value is a very conservative 5
minutes so we don't cause flakiness in stress/race builds. It can be
changed with `--op-timeout`.

This should help detect hung operations under stress, which I believe
would otherwise keep running.