### PR TITLE
objstorageprovider: fix race in `GetExternalObjects`

### DIFF
--- a/objstorage/objstorageprovider/remote.go
+++ b/objstorage/objstorageprovider/remote.go
@@ -421,5 +421,5 @@ func (p *provider) ensureStorage(locator remote.Locator) (remote.Storage, error)
 func (p *provider) GetExternalObjects(locator remote.Locator, objName string) []base.DiskFileNum {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.mu.remote.getExternalObjects(locator, objName)
+	return slices.Clone(p.mu.remote.getExternalObjects(locator, objName))
 }


### PR DESCRIPTION
We currently call `GetExternalObjects` under the provider lock, which is correct. However, we return the slice directly and then use it outside the lock; this slice is part of the map and is modified in place when an object is removed (the `DeleteFunc` call in `removeExternalObject`).

The fix is to clone the slice. Note that the common path here is an empty slice (backing is not reused).

Fixes #3439