### PR TITLE
sstable: fix two level iterator bug with virtual tables

### DIFF
--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -291,6 +291,7 @@ func (i *singleLevelIterator) initBounds() {
 	i.blockLower = i.lower
 	if i.blockLower != nil {
 		key, _ := i.data.First()
+		// TODO(radu): this should be <= 0
 		if key != nil && i.cmp(i.blockLower, key.UserKey) < 0 {
 			// The lower-bound is less than the first key in the block. No need
 			// to check the lower-bound again for this block.
@@ -298,15 +299,39 @@ func (i *singleLevelIterator) initBounds() {
 		}
 	}
 	i.blockUpper = i.upper
+	// TODO(radu): this should be >= 0 if blockUpper is inclusive.
 	if i.blockUpper != nil && i.cmp(i.blockUpper, i.index.Key().UserKey) > 0 {
 		// The upper-bound is greater than the index key which itself is greater
 		// than or equal to every key in the block. No need to check the
 		// upper-bound again for this block. Even if blockUpper is inclusive
 		// because of upper being inclusive, we can still safely set blockUpper
 		// to nil here.
-		//
-		// TODO(bananabrick): We could also set blockUpper to nil for the >=
-		// case, if blockUpper is inclusive.
+		i.blockUpper = nil
+	}
+}
+
+func (i *singleLevelIterator) initBoundsForAlreadyLoadedBlock() {
+	// TODO(radu): determine automatically if we need to call First or not and
+	// unify this function with initBounds().
+	if i.data.getFirstUserKey() == nil {
+		panic("initBoundsForAlreadyLoadedBlock must not be called on empty or corrupted block")
+	}
+	i.blockLower = i.lower
+	if i.blockLower != nil {
+		firstUserKey := i.data.getFirstUserKey()
+		// TODO(radu): this should be <= 0
+		if firstUserKey != nil && i.cmp(i.blockLower, firstUserKey) < 0 {
+			// The lower-bound is less than the first key in the block. No need
+			// to check the lower-bound again for this block.
+			i.blockLower = nil
+		}
+	}
+	i.blockUpper = i.upper
+	// TODO(radu): this should be >= 0 if blockUpper is inclusive.
+	if i.blockUpper != nil && i.cmp(i.blockUpper, i.index.Key().UserKey) > 0 {
+		// The upper-bound is greater than the index key which itself is greater
+		// than or equal to every key in the block. No need to check the
+		// upper-bound again for this block.
 		i.blockUpper = nil
 	}
 }
@@ -524,28 +549,6 @@ func (i *singleLevelIterator) resolveMaybeExcluded(dir int8) intersectsResult {
 	}
 	_, _ = i.index.Next()
 	return blockIntersects
-}
-
-func (i *singleLevelIterator) initBoundsForAlreadyLoadedBlock() {
-	if i.data.getFirstUserKey() == nil {
-		panic("initBoundsForAlreadyLoadedBlock must not be called on empty or corrupted block")
-	}
-	i.blockLower = i.lower
-	if i.blockLower != nil {
-		firstUserKey := i.data.getFirstUserKey()
-		if firstUserKey != nil && i.cmp(i.blockLower, firstUserKey) < 0 {
-			// The lower-bound is less than the first key in the block. No need
-			// to check the lower-bound again for this block.
-			i.blockLower = nil
-		}
-	}
-	i.blockUpper = i.upper
-	if i.blockUpper != nil && i.cmp(i.blockUpper, i.index.Key().UserKey) > 0 {
-		// The upper-bound is greater than the index key which itself is greater
-		// than or equal to every key in the block. No need to check the
-		// upper-bound again for this block.
-		i.blockUpper = nil
-	}
 }
 
 // The number of times to call Next/Prev in a block before giving up and seeking.
@@ -1351,8 +1354,8 @@ func (i *singleLevelIterator) Prev() (*InternalKey, base.LazyValue) {
 
 func (i *singleLevelIterator) skipForward() (*InternalKey, base.LazyValue) {
 	for {
-		var key *InternalKey
-		if key, _ = i.index.Next(); key == nil {
+		indexKey, _ := i.index.Next()
+		if indexKey == nil {
 			i.data.invalidate()
 			break
 		}
@@ -1363,7 +1366,7 @@ func (i *singleLevelIterator) skipForward() (*InternalKey, base.LazyValue) {
 			}
 			if result == loadBlockFailed {
 				// We checked that i.index was at a valid entry, so
-				// loadBlockFailed could not have happened due to to i.index
+				// loadBlockFailed could not have happened due to i.index
 				// being exhausted, and must be due to an error.
 				panic("loadBlock should not have failed with no error")
 			}
@@ -1374,7 +1377,7 @@ func (i *singleLevelIterator) skipForward() (*InternalKey, base.LazyValue) {
 			// separator, the same user key can span multiple blocks. If upper
 			// is exclusive we use >= below, else we use >.
 			if i.upper != nil {
-				cmp := i.cmp(key.UserKey, i.upper)
+				cmp := i.cmp(indexKey.UserKey, i.upper)
 				if (!i.endKeyInclusive && cmp >= 0) || cmp > 0 {
 					i.exhaustedBounds = +1
 					return nil, base.LazyValue{}
@@ -1382,7 +1385,42 @@ func (i *singleLevelIterator) skipForward() (*InternalKey, base.LazyValue) {
 			}
 			continue
 		}
-		if key, val := i.data.First(); key != nil {
+		var key *InternalKey
+		var val base.LazyValue
+		// It is possible that skipBackward went too far and the virtual table lower
+		// bound is after the first key in the block we are about to load, in which
+		// case we must use SeekGE.
+		//
+		// An example of how this can happen:
+		//
+		//   Data block 1 - contains keys a@1, c@1
+		//   Data block 2 - contains keys e@1, g@1
+		//   Data block 3 - contains keys i@2, k@2
+		//
+		//   The virtual table lower bound is f. We have a range key masking filter
+		//   that filters keys with @1 suffix. We are positioned inside block 3 then
+		//   we Prev(). Block 2 is entirely filtered out, which makes us move to
+		//   block 1. Now the range key masking filter gets an update (via
+		//   SpanChanged) and it no longer filters out any keys. At this point if a
+		//   Next happens, we will load block 2 but it would not be legal to return
+		//   "e@1" which is outside the virtual bounds.
+		//
+		//   The core of the problem is that skipBackward doesn't know it can stop
+		//   at block 2, because it doesn't know what keys are at the start of that
+		//   block. This is why we don't have this problem in the opposite
+		//   direction: skipForward will never go beyond the last relevant block
+		//   because it looks at the separator key which is an upper bound for the
+		//   block.
+		//
+		// Note that this is only a problem with virtual tables; we make no
+		// guarantees wrt an iterator lower bound when we iterate forward. But we
+		// must never return keys that are not inside the virtual table.
+		if i.vState != nil && i.blockLower != nil {
+			key, val = i.data.SeekGE(i.lower, base.SeekGEFlagsNone)
+		} else {
+			key, val = i.data.First()
+		}
+		if key != nil {
 			if i.blockUpper != nil {
 				cmp := i.cmp(key.UserKey, i.blockUpper)
 				if (!i.endKeyInclusive && cmp >= 0) || cmp > 0 {
@@ -1398,8 +1436,8 @@ func (i *singleLevelIterator) skipForward() (*InternalKey, base.LazyValue) {
 
 func (i *singleLevelIterator) skipBackward() (*InternalKey, base.LazyValue) {
 	for {
-		var key *InternalKey
-		if key, _ = i.index.Prev(); key == nil {
+		indexKey, _ := i.index.Prev()
+		if indexKey == nil {
 			i.data.invalidate()
 			break
 		}
@@ -1419,7 +1457,7 @@ func (i *singleLevelIterator) skipBackward() (*InternalKey, base.LazyValue) {
 			// bound is already exceeded. Note that the previous block starts with
 			// keys <= key.UserKey since even though this is the current block's
 			// separator, the same user key can span multiple blocks.
-			if i.lower != nil && i.cmp(key.UserKey, i.lower) < 0 {
+			if i.lower != nil && i.cmp(indexKey.UserKey, i.lower) < 0 {
 				i.exhaustedBounds = -1
 				return nil, base.LazyValue{}
 			}

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -901,9 +901,42 @@ func (i *twoLevelIterator) skipForward() (*InternalKey, base.LazyValue) {
 		if i.err != nil || i.exhaustedBounds > 0 {
 			return nil, base.LazyValue{}
 		}
+
+		// It is possible that skipBackward went too far and the virtual table lower
+		// bound is after the first key in the block we are about to load, in which
+		// case we must use SeekGE below. The keys in the block we are about to load
+		// start right after the topLevelIndex key (before we Next).
+		//
+		// An example of how this can happen:
+		//
+		//   Second-level index block 1 - contains keys a@1, c@1
+		//   Second-level index block 2 - contains keys e@1, g@1
+		//   Second-level index block 3 - contains keys i@2, k@2
+		//
+		//   The virtual table lower bound is f. We have a range key masking filter
+		//   that filters keys with @1 suffix. We are positioned inside block 3 then
+		//   we Prev(). Block 2 is entirely filtered out, which makes us move to
+		//   block 1. Now the range key masking filter gets an update (via
+		//   SpanChanged) and it no longer filters out any keys. At this point if a
+		//   Next happens, we will load block 2 but it would not be legal to return
+		//   "e@1" which is outside the virtual bounds.
+		//
+		//   The core of the problem is that skipBackward doesn't know it can stop
+		//   at block 2, because it doesn't know what keys are at the start of that
+		//   block. This is why we don't have this problem in the opposite
+		//   direction: skipForward will never go beyond the last relevant block
+		//   because it looks at the separator key which is an upper bound for the
+		//   block.
+		//
+		// Note that this is only a problem with virtual tables; we make no
+		// guarantees wrt an iterator lower bound when we iterate forward. But we
+		// must never return keys that are not inside the virtual table.
+		useSeek := i.vState != nil &&
+			(!i.topLevelIndex.valid() || base.InternalCompare(i.cmp, i.topLevelIndex.ikey, i.vState.lower) < 0)
+
 		i.exhaustedBounds = 0
-		var ikey *InternalKey
-		if ikey, _ = i.topLevelIndex.Next(); ikey == nil {
+		topLevelKey, _ := i.topLevelIndex.Next()
+		if topLevelKey == nil {
 			i.data.invalidate()
 			i.index.invalidate()
 			return nil, base.LazyValue{}
@@ -913,7 +946,14 @@ func (i *twoLevelIterator) skipForward() (*InternalKey, base.LazyValue) {
 			return nil, base.LazyValue{}
 		}
 		if result == loadBlockOK {
-			if ikey, val := i.singleLevelIterator.firstInternal(); ikey != nil {
+			var ikey *InternalKey
+			var val base.LazyValue
+			if useSeek {
+				ikey, val = i.singleLevelIterator.SeekGE(i.lower, base.SeekGEFlagsNone)
+			} else {
+				ikey, val = i.singleLevelIterator.firstInternal()
+			}
+			if ikey != nil {
 				return i.maybeVerifyKey(ikey, val)
 			}
 			// Next iteration will return if singleLevelIterator set
@@ -927,7 +967,7 @@ func (i *twoLevelIterator) skipForward() (*InternalKey, base.LazyValue) {
 			// multiple index blocks. If upper is exclusive we use >=
 			// below, else we use >.
 			if i.upper != nil {
-				cmp := i.cmp(ikey.UserKey, i.upper)
+				cmp := i.cmp(topLevelKey.UserKey, i.upper)
 				if (!i.endKeyInclusive && cmp >= 0) || cmp > 0 {
 					i.exhaustedBounds = +1
 					// Next iteration will return.
@@ -943,8 +983,8 @@ func (i *twoLevelIterator) skipBackward() (*InternalKey, base.LazyValue) {
 			return nil, base.LazyValue{}
 		}
 		i.exhaustedBounds = 0
-		var ikey *InternalKey
-		if ikey, _ = i.topLevelIndex.Prev(); ikey == nil {
+		topLevelKey, _ := i.topLevelIndex.Prev()
+		if topLevelKey == nil {
 			i.data.invalidate()
 			i.index.invalidate()
 			return nil, base.LazyValue{}
@@ -954,9 +994,11 @@ func (i *twoLevelIterator) skipBackward() (*InternalKey, base.LazyValue) {
 			return nil, base.LazyValue{}
 		}
 		if result == loadBlockOK {
-			if ikey, val := i.singleLevelIterator.lastInternal(); ikey != nil {
+			ikey, val := i.singleLevelIterator.lastInternal()
+			if ikey != nil {
 				return i.maybeVerifyKey(ikey, val)
 			}
+
 			// Next iteration will return if singleLevelIterator set
 			// exhaustedBounds = -1.
 		} else {
@@ -966,7 +1008,7 @@ func (i *twoLevelIterator) skipBackward() (*InternalKey, base.LazyValue) {
 			// the previous entry starts with keys <= ikey.UserKey since even
 			// though this is the current block's separator, the same user key
 			// can span multiple index blocks.
-			if i.lower != nil && i.cmp(ikey.UserKey, i.lower) < 0 {
+			if i.lower != nil && i.cmp(topLevelKey.UserKey, i.lower) < 0 {
 				i.exhaustedBounds = -1
 				// Next iteration will return.
 			}

--- a/sstable/testdata/virtual_reader
+++ b/sstable/testdata/virtual_reader
@@ -16,19 +16,22 @@ seqnums:  [1-1]
 # and for tiny sstables, virtual sstable sizes aren't accurate. In this
 # testcase, the virtual sstable size is 50, whereas the backing sstable size is
 # 850.
-virtualize b.SET.1-c.SET.1
+virtualize lower=b.SET.1 upper=c.SET.1
 ----
 bounds:  [b#1,SET-c#1,SET]
 filenum: 000001
-props: NumEntries: 1, RawKeySize: 3, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 0
+props:
+  rocksdb.num.entries: 1
+  rocksdb.raw.key.size: 3
+  rocksdb.raw.value.size: 1
 
-citer
+compaction-iter
 ----
 b#1,SET:b
 c#1,SET:c
 
 # Test 2: Similar to test 1 but force two level iterators.
-build twoLevel
+build block-size=1 index-block-size=1
 a.SET.1:a
 b.SET.1:b
 c.SET.1:c
@@ -37,13 +40,16 @@ d.SET.1:d
 point:    [a#1,SET-d#1,SET]
 seqnums:  [1-1]
 
-virtualize b.SET.1-c.SET.1
+virtualize lower=b.SET.1 upper=c.SET.1
 ----
 bounds:  [b#1,SET-c#1,SET]
 filenum: 000002
-props: NumEntries: 1, RawKeySize: 3, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 0
+props:
+  rocksdb.num.entries: 1
+  rocksdb.raw.key.size: 3
+  rocksdb.raw.value.size: 1
 
-citer
+compaction-iter
 ----
 b#1,SET:b
 c#1,SET:c
@@ -109,7 +115,7 @@ scan-range-key
 
 # Test 3: Tests raw range key/range del iterators, and makes sure that they
 # respect virtual bounds.
-build twoLevel
+build block-size=1 index-block-size=1
 a.SET.1:a
 d.SET.2:d
 f.SET.3:f
@@ -125,11 +131,17 @@ seqnums:  [1-12]
 
 # Note that we shouldn't have range del spans which cross virtual sstable
 # boundaries. NumRangeKeySets must be > 1.
-virtualize a.SET.1-f.SET.1
+virtualize lower=a.SET.1 upper=f.SET.1
 ----
 bounds:  [a#1,SET-f#1,SET]
 filenum: 000003
-props: NumEntries: 1, RawKeySize: 4, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 1, NumRangeDeletions: 1, NumRangeKeyDels: 0, NumRangeKeySets: 1, ValueBlocksSize: 0
+props:
+  rocksdb.num.entries: 1
+  rocksdb.raw.key.size: 4
+  rocksdb.raw.value.size: 1
+  rocksdb.deleted.keys: 1
+  rocksdb.num.range-deletions: 1
+  pebble.num.range-key-sets: 1
 
 scan-range-del
 ----
@@ -155,11 +167,14 @@ h.SET.9:h
 point:    [a#1,SET-h#9,SET]
 seqnums:  [1-9]
 
-virtualize dd.SET.5-ddd.SET.6
+virtualize lower=dd.SET.5 upper=ddd.SET.6
 ----
 bounds:  [dd#5,SET-ddd#6,SET]
 filenum: 000004
-props: NumEntries: 2, RawKeySize: 11, RawValueSize: 2, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 0
+props:
+  rocksdb.num.entries: 2
+  rocksdb.raw.key.size: 11
+  rocksdb.raw.value.size: 2
 
 # Check lower bound enforcement during SeekPrefixGE.
 iter
@@ -186,11 +201,14 @@ point:    [a#1,SET-h#9,SET]
 seqnums:  [1-9]
 
 # Set bounds c-f for the virtual sstable.
-virtualize c.SET.3-f.SET.6
+virtualize lower=c.SET.3 upper=f.SET.6
 ----
 bounds:  [c#3,SET-f#6,SET]
 filenum: 000005
-props: NumEntries: 2, RawKeySize: 11, RawValueSize: 2, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 0
+props:
+  rocksdb.num.entries: 2
+  rocksdb.raw.key.size: 11
+  rocksdb.raw.value.size: 2
 
 # Just test a basic iterator once virtual sstable bounds have been set.
 iter
@@ -208,14 +226,14 @@ next
 
 # Create an iterator with bounds. External bounds should still be restricted
 # along with virtual sstable bounds.
-iter a-d
+iter lower=a upper=d
 first
 next
 ----
 <c:3>:c
 .
 
-iter d-g
+iter lower=d upper=g
 first
 next
 next
@@ -286,11 +304,15 @@ h.SET.9:h
 point:    [a#1,SET-h#9,SET]
 seqnums:  [1-9]
 
-virtualize c.SET.3-f.SET.1:ff
+virtualize lower=c.SET.3 upper=f.SET.1:ff
 ----
 bounds:  [c#3,SET-f#0,SET]
 filenum: 000006
-props: NumEntries: 2, RawKeySize: 13, RawValueSize: 2, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 3
+props:
+  rocksdb.num.entries: 2
+  rocksdb.raw.key.size: 13
+  rocksdb.raw.value.size: 2
+  pebble.value-blocks.size: 3
 
 iter
 set-bounds lower=d upper=e
@@ -339,11 +361,15 @@ last
 ----
 <f:1>:ff
 
-virtualize f.SET.6-h.SET.9
+virtualize lower=f.SET.6 upper=h.SET.9
 ----
 bounds:  [f#6,SET-h#9,SET]
 filenum: 000007
-props: NumEntries: 2, RawKeySize: 13, RawValueSize: 2, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 3
+props:
+  rocksdb.num.entries: 2
+  rocksdb.raw.key.size: 13
+  rocksdb.raw.value.size: 2
+  pebble.value-blocks.size: 3
 
 iter
 seek-lt z
@@ -365,7 +391,7 @@ last
 <f:1>:ff
 
 # Test 5: Same as test 4, but force two level iterators.
-build twoLevel
+build block-size=1 index-block-size=1
 a.SET.1:a
 b.SET.2:b
 c.SET.3:c
@@ -378,11 +404,14 @@ h.SET.9:h
 point:    [a#1,SET-h#9,SET]
 seqnums:  [1-9]
 
-virtualize dd.SET.5-ddd.SET.6
+virtualize lower=dd.SET.5 upper=ddd.SET.6
 ----
 bounds:  [dd#5,SET-ddd#6,SET]
 filenum: 000008
-props: NumEntries: 1, RawKeySize: 4, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 0
+props:
+  rocksdb.num.entries: 1
+  rocksdb.raw.key.size: 4
+  rocksdb.raw.value.size: 1
 
 # Check lower bound enforcement during SeekPrefixGE.
 iter
@@ -395,7 +424,7 @@ next
 .
 
 # Build a simpler sstable for the rest of the tests.
-build twoLevel
+build block-size=1 index-block-size=1
 a.SET.1:a
 b.SET.2:b
 c.SET.3:c
@@ -409,11 +438,14 @@ point:    [a#1,SET-h#9,SET]
 seqnums:  [1-9]
 
 # Set bounds c-f for the virtual sstable.
-virtualize c.SET.3-f.SET.6
+virtualize lower=c.SET.3 upper=f.SET.6
 ----
 bounds:  [c#3,SET-f#6,SET]
 filenum: 000009
-props: NumEntries: 1, RawKeySize: 7, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 0
+props:
+  rocksdb.num.entries: 1
+  rocksdb.raw.key.size: 7
+  rocksdb.raw.value.size: 1
 
 # Just test a basic iterator once virtual sstable bounds have been set.
 iter
@@ -431,14 +463,14 @@ next
 
 # Create an iterator with bounds. External bounds should still be restricted
 # along with virtual sstable bounds.
-iter a-d
+iter lower=a upper=d
 first
 next
 ----
 <c:3>:c
 .
 
-iter d-g
+iter lower=d upper=g
 first
 next
 next
@@ -495,7 +527,7 @@ prev
 .
 
 # Test SeekLT
-build twoLevel
+build block-size=1 index-block-size=1
 a.SET.1:a
 b.SET.2:b
 c.SET.3:c
@@ -509,11 +541,15 @@ h.SET.9:h
 point:    [a#1,SET-h#9,SET]
 seqnums:  [1-9]
 
-virtualize c.SET.3-f.SET.1:ff
+virtualize lower=c.SET.3 upper=f.SET.1:ff
 ----
 bounds:  [c#3,SET-f#0,SET]
 filenum: 000010
-props: NumEntries: 1, RawKeySize: 7, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 2
+props:
+  rocksdb.num.entries: 1
+  rocksdb.raw.key.size: 7
+  rocksdb.raw.value.size: 1
+  pebble.value-blocks.size: 2
 
 iter
 set-bounds lower=d upper=e
@@ -562,11 +598,15 @@ last
 ----
 <f:1>:ff
 
-virtualize f.SET.6-h.SET.9
+virtualize lower=f.SET.6 upper=h.SET.9
 ----
 bounds:  [f#6,SET-h#9,SET]
 filenum: 000011
-props: NumEntries: 1, RawKeySize: 7, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 2
+props:
+  rocksdb.num.entries: 1
+  rocksdb.raw.key.size: 7
+  rocksdb.raw.value.size: 1
+  pebble.value-blocks.size: 2
 
 iter
 seek-lt z
@@ -601,11 +641,16 @@ point:    [a#1,SET-f#5,SET]
 rangedel: [d#4,RANGEDEL-e#72057594037927935,RANGEDEL]
 seqnums:  [1-5]
 
-virtualize a.SET.1-e.RANGEDEL.72057594037927935
+virtualize lower=a.SET.1 upper=e.RANGEDEL.72057594037927935
 ----
 bounds:  [a#1,SET-e#72057594037927935,RANGEDEL]
 filenum: 000012
-props: NumEntries: 1, RawKeySize: 4, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 1, NumRangeDeletions: 1, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 0
+props:
+  rocksdb.num.entries: 1
+  rocksdb.raw.key.size: 4
+  rocksdb.raw.value.size: 1
+  rocksdb.deleted.keys: 1
+  rocksdb.num.range-deletions: 1
 
 iter
 first
@@ -619,7 +664,7 @@ seek-lt f
 <d:2>:d
 
 # Don't expose e from the compaction iter.
-citer
+compaction-iter
 ----
 a#1,SET:a
 d#2,SET:d
@@ -629,7 +674,7 @@ scan-range-del
 d-e:{(#4,RANGEDEL)}
 
 
-build twoLevel
+build block-size=1 index-block-size=1
 a.SET.1:a
 d.SET.2:d
 e.SET.3:e
@@ -640,11 +685,16 @@ point:    [a#1,SET-f#5,SET]
 rangedel: [d#4,RANGEDEL-e#72057594037927935,RANGEDEL]
 seqnums:  [1-5]
 
-virtualize a.SET.1-e.RANGEDEL.72057594037927935
+virtualize lower=a.SET.1 upper=e.RANGEDEL.72057594037927935
 ----
 bounds:  [a#1,SET-e#72057594037927935,RANGEDEL]
 filenum: 000013
-props: NumEntries: 1, RawKeySize: 4, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 1, NumRangeDeletions: 1, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 0
+props:
+  rocksdb.num.entries: 1
+  rocksdb.raw.key.size: 4
+  rocksdb.raw.value.size: 1
+  rocksdb.deleted.keys: 1
+  rocksdb.num.range-deletions: 1
 
 iter
 first
@@ -658,7 +708,7 @@ seek-lt f
 <d:2>:d
 
 # Don't expose e from the compaction iter.
-citer
+compaction-iter
 ----
 a#1,SET:a
 d#2,SET:d
@@ -668,7 +718,7 @@ scan-range-del
 d-e:{(#4,RANGEDEL)}
 
 # Test NumRangeKeySets.
-build twoLevel
+build block-size=1 index-block-size=1
 a.SET.1:a
 b.SET.5:b
 d.SET.2:d
@@ -685,15 +735,21 @@ seqnums:  [1-12]
 
 # Virtual sstable doesn't contain range key set, but NumRangeKeySets in the
 # properties must be > 0.
-virtualize a.SET.1-b.SET.5
+virtualize lower=a.SET.1 upper=b.SET.5
 ----
 bounds:  [a#1,SET-b#5,SET]
 filenum: 000014
-props: NumEntries: 1, RawKeySize: 3, RawValueSize: 1, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 1, NumRangeDeletions: 1, NumRangeKeyDels: 0, NumRangeKeySets: 1, ValueBlocksSize: 0
+props:
+  rocksdb.num.entries: 1
+  rocksdb.raw.key.size: 3
+  rocksdb.raw.value.size: 1
+  rocksdb.deleted.keys: 1
+  rocksdb.num.range-deletions: 1
+  pebble.num.range-key-sets: 1
 
 # Test that a virtual reader with a suffix replacement rule replaces the
 # suffixes from the backing file during iteration.
-build with-suffix
+build
 a@2.SET.1:a
 b@4.SET.2:b
 c@3.SET.3:c
@@ -709,11 +765,14 @@ seqnums:  [1-9]
 # Set bounds c@7-f@2 for the virtual sstable. Notice that we correctly elide c
 # because post suffix replacement, it is not in the bounds. Further, notice that
 # we do surface f because post suffix replacement, it is within the bounds.
-virtualize c@7.SET.3-f@4.SET.8 suffix=@8
+virtualize lower=c@7.SET.3 upper=f@4.SET.8 suffix=@8
 ----
 bounds:  [c@7#3,SET-f@4#8,SET]
 filenum: 000015
-props: NumEntries: 2, RawKeySize: 15, RawValueSize: 2, RawPointTombstoneKeySize: 0, RawPointTombstoneValueSize: 0, NumSizedDeletions: 0, NumDeletions: 0, NumRangeDeletions: 0, NumRangeKeyDels: 0, NumRangeKeySets: 0, ValueBlocksSize: 0
+props:
+  rocksdb.num.entries: 2
+  rocksdb.raw.key.size: 15
+  rocksdb.raw.value.size: 2
 
 # Just test a basic iterator once virtual sstable bounds have been set.
 iter

--- a/sstable/testdata/virtual_reader_iter
+++ b/sstable/testdata/virtual_reader_iter
@@ -618,3 +618,59 @@ next
 <e@8:5>:e
 <f@8:6>:f
 .
+
+build
+aa@2.SET.1:aa
+ab@1.SET.1:ab
+ac@1.SET.1:ac
+ad@1.SET.1:ad
+ae@1.SET.1:ae
+af@1.SET.1:af
+ba@1.SET.1:ba
+bb@1.SET.1:bb
+bc@2.SET.1:bc
+bd@1.SET.1:bd
+be@3.SET.1:be
+bf@1.SET.1:bf
+ca@1.SET.1:ca
+cb@1.SET.1:cb
+cc@1.SET.1:cc
+cd@1.SET.1:cd
+ce@1.SET.1:ce
+cf@1.SET.1:cf
+----
+point:    [aa@2#1,SET-cf@1#1,SET]
+seqnums:  [1-1]
+
+virtualize lower=ae1.SET.1 upper=ca@1.SET.1
+----
+bounds:  [ae1#1,SET-ca@1#1,SET]
+
+iter with-masking-filter
+mask-suffix @2
+first
+next
+next
+prev
+prev
+----
+<bc@2:1>:bc
+<be@3:1>:be
+.
+<be@3:1>:be
+<bc@2:1>:bc
+
+# Regression test for #3450: filter out the block that intersects the lower
+# bound on Prev, reconfigure the filter, and do Next.
+iter with-masking-filter
+mask-suffix @2
+seek-lt c
+prev
+prev
+mask-suffix @1
+next
+----
+<be@3:1>:be
+<bc@2:1>:bc
+.
+<af@1:1>:af

--- a/sstable/testdata/virtual_reader_iter
+++ b/sstable/testdata/virtual_reader_iter
@@ -1,6 +1,6 @@
-# Test 1: Start with a simple sanity checking test which uses singleLevel
-# iterators as the backing iterator for the sstable. This will also test the
-# compaction iterator since it's the simplest.
+# Start with a simple sanity checking test which uses singleLevel iterators as
+# the backing iterator for the sstable. This will also test the compaction
+# iterator since it's the simplest.
 build
 a.SET.1:a
 b.SET.1:b
@@ -10,102 +10,14 @@ d.SET.1:d
 point:    [a#1,SET-d#1,SET]
 seqnums:  [1-1]
 
-# Note that the RawKeySize,RawValueSize aren't accurate here because we use
-# Reader.EstimateDiskUsage with virtual sstables bounds to determine virtual
-# sstable size which is then used to extrapolate virtual sstable properties,
-# and for tiny sstables, virtual sstable sizes aren't accurate. In this
-# testcase, the virtual sstable size is 50, whereas the backing sstable size is
-# 850.
 virtualize lower=b.SET.1 upper=c.SET.1
 ----
 bounds:  [b#1,SET-c#1,SET]
-filenum: 000001
-props:
-  rocksdb.num.entries: 1
-  rocksdb.raw.key.size: 3
-  rocksdb.raw.value.size: 1
 
 compaction-iter
 ----
 b#1,SET:b
 c#1,SET:c
-
-# Test 2: Similar to test 1 but force two level iterators.
-build block-size=1 index-block-size=1
-a.SET.1:a
-b.SET.1:b
-c.SET.1:c
-d.SET.1:d
-----
-point:    [a#1,SET-d#1,SET]
-seqnums:  [1-1]
-
-virtualize lower=b.SET.1 upper=c.SET.1
-----
-bounds:  [b#1,SET-c#1,SET]
-filenum: 000002
-props:
-  rocksdb.num.entries: 1
-  rocksdb.raw.key.size: 3
-  rocksdb.raw.value.size: 1
-
-compaction-iter
-----
-b#1,SET:b
-c#1,SET:c
-
-# Test the constrain bounds function. It performs some subtle shrinking and
-# expanding of bounds. The current virtual sstable bounds are [b,c].
-# 1. start key < virtual sstable start key, end key is exclusive.
-constrain a,bb,false
-----
-b,bb,false
-
-# 2. start key < virtual sstable start key, end key is inclusive.
-constrain a,bb,true
-----
-b,bb,true
-
-# 3. start key is within virtual sstable bounds, end key is at virtual sstable
-# end bound, but is exclusive.
-constrain bb,c,false
-----
-bb,c,false
-
-# 3. start key is within virtual sstable bounds, end key is at virtual sstable
-# end bound, but is inclusive.
-constrain bb,c,true
-----
-bb,c,true
-
-# 4. start key is within virtual sstable bounds, end key is above virtual
-# sstable end bound and is exclusive.
-constrain bb,e,false
-----
-bb,c,true
-
-# 5. start key is within virtual sstable bounds, end key is above virtual
-# sstable end bound and is inclusive.
-constrain bb,e,true
-----
-bb,c,true
-
-# 6. Both start, end keys fit within virtual sstable bounds.
-constrain bb,bbb,false
-----
-bb,bbb,false
-
-# 6. Both start, end keys are out of bounds, but overlap.
-constrain a,d,false
-----
-b,c,true
-
-# 7. start, end keys have no overlap with virtual sstable bounds. Note that
-# lower becomes greater than upper here. We support this in the iterators
-# and don't return any keys for this case.
-constrain a,aa,false
-----
-b,aa,false
 
 scan-range-del
 ----
@@ -113,7 +25,7 @@ scan-range-del
 scan-range-key
 ----
 
-# Test 3: Tests raw range key/range del iterators, and makes sure that they
+# Test raw range key/range del iterators, and make sure that they
 # respect virtual bounds.
 build block-size=1 index-block-size=1
 a.SET.1:a
@@ -134,14 +46,6 @@ seqnums:  [1-12]
 virtualize lower=a.SET.1 upper=f.SET.1
 ----
 bounds:  [a#1,SET-f#1,SET]
-filenum: 000003
-props:
-  rocksdb.num.entries: 1
-  rocksdb.raw.key.size: 4
-  rocksdb.raw.value.size: 1
-  rocksdb.deleted.keys: 1
-  rocksdb.num.range-deletions: 1
-  pebble.num.range-key-sets: 1
 
 scan-range-del
 ----
@@ -151,7 +55,7 @@ scan-range-key
 ----
 a-d:{(#11,RANGEKEYSET,@t10,foo)}
 
-# Test 4: Test iterators with various bounds, and various operations. This calls
+# Test iterators with various bounds, and various operations. This calls
 # VirtualReader.NewIterWithBlockPropertyFilters and performs various operations
 # on those.
 build
@@ -170,11 +74,6 @@ seqnums:  [1-9]
 virtualize lower=dd.SET.5 upper=ddd.SET.6
 ----
 bounds:  [dd#5,SET-ddd#6,SET]
-filenum: 000004
-props:
-  rocksdb.num.entries: 2
-  rocksdb.raw.key.size: 11
-  rocksdb.raw.value.size: 2
 
 # Check lower bound enforcement during SeekPrefixGE.
 iter
@@ -204,11 +103,6 @@ seqnums:  [1-9]
 virtualize lower=c.SET.3 upper=f.SET.6
 ----
 bounds:  [c#3,SET-f#6,SET]
-filenum: 000005
-props:
-  rocksdb.num.entries: 2
-  rocksdb.raw.key.size: 11
-  rocksdb.raw.value.size: 2
 
 # Just test a basic iterator once virtual sstable bounds have been set.
 iter
@@ -307,12 +201,6 @@ seqnums:  [1-9]
 virtualize lower=c.SET.3 upper=f.SET.1:ff
 ----
 bounds:  [c#3,SET-f#0,SET]
-filenum: 000006
-props:
-  rocksdb.num.entries: 2
-  rocksdb.raw.key.size: 13
-  rocksdb.raw.value.size: 2
-  pebble.value-blocks.size: 3
 
 iter
 set-bounds lower=d upper=e
@@ -364,12 +252,6 @@ last
 virtualize lower=f.SET.6 upper=h.SET.9
 ----
 bounds:  [f#6,SET-h#9,SET]
-filenum: 000007
-props:
-  rocksdb.num.entries: 2
-  rocksdb.raw.key.size: 13
-  rocksdb.raw.value.size: 2
-  pebble.value-blocks.size: 3
 
 iter
 seek-lt z
@@ -407,11 +289,6 @@ seqnums:  [1-9]
 virtualize lower=dd.SET.5 upper=ddd.SET.6
 ----
 bounds:  [dd#5,SET-ddd#6,SET]
-filenum: 000008
-props:
-  rocksdb.num.entries: 1
-  rocksdb.raw.key.size: 4
-  rocksdb.raw.value.size: 1
 
 # Check lower bound enforcement during SeekPrefixGE.
 iter
@@ -441,11 +318,6 @@ seqnums:  [1-9]
 virtualize lower=c.SET.3 upper=f.SET.6
 ----
 bounds:  [c#3,SET-f#6,SET]
-filenum: 000009
-props:
-  rocksdb.num.entries: 1
-  rocksdb.raw.key.size: 7
-  rocksdb.raw.value.size: 1
 
 # Just test a basic iterator once virtual sstable bounds have been set.
 iter
@@ -544,12 +416,6 @@ seqnums:  [1-9]
 virtualize lower=c.SET.3 upper=f.SET.1:ff
 ----
 bounds:  [c#3,SET-f#0,SET]
-filenum: 000010
-props:
-  rocksdb.num.entries: 1
-  rocksdb.raw.key.size: 7
-  rocksdb.raw.value.size: 1
-  pebble.value-blocks.size: 2
 
 iter
 set-bounds lower=d upper=e
@@ -601,12 +467,6 @@ last
 virtualize lower=f.SET.6 upper=h.SET.9
 ----
 bounds:  [f#6,SET-h#9,SET]
-filenum: 000011
-props:
-  rocksdb.num.entries: 1
-  rocksdb.raw.key.size: 7
-  rocksdb.raw.value.size: 1
-  pebble.value-blocks.size: 2
 
 iter
 seek-lt z
@@ -644,13 +504,6 @@ seqnums:  [1-5]
 virtualize lower=a.SET.1 upper=e.RANGEDEL.72057594037927935
 ----
 bounds:  [a#1,SET-e#72057594037927935,RANGEDEL]
-filenum: 000012
-props:
-  rocksdb.num.entries: 1
-  rocksdb.raw.key.size: 4
-  rocksdb.raw.value.size: 1
-  rocksdb.deleted.keys: 1
-  rocksdb.num.range-deletions: 1
 
 iter
 first
@@ -688,13 +541,6 @@ seqnums:  [1-5]
 virtualize lower=a.SET.1 upper=e.RANGEDEL.72057594037927935
 ----
 bounds:  [a#1,SET-e#72057594037927935,RANGEDEL]
-filenum: 000013
-props:
-  rocksdb.num.entries: 1
-  rocksdb.raw.key.size: 4
-  rocksdb.raw.value.size: 1
-  rocksdb.deleted.keys: 1
-  rocksdb.num.range-deletions: 1
 
 iter
 first
@@ -738,14 +584,6 @@ seqnums:  [1-12]
 virtualize lower=a.SET.1 upper=b.SET.5
 ----
 bounds:  [a#1,SET-b#5,SET]
-filenum: 000014
-props:
-  rocksdb.num.entries: 1
-  rocksdb.raw.key.size: 3
-  rocksdb.raw.value.size: 1
-  rocksdb.deleted.keys: 1
-  rocksdb.num.range-deletions: 1
-  pebble.num.range-key-sets: 1
 
 # Test that a virtual reader with a suffix replacement rule replaces the
 # suffixes from the backing file during iteration.
@@ -768,11 +606,6 @@ seqnums:  [1-9]
 virtualize lower=c@7.SET.3 upper=f@4.SET.8 suffix=@8
 ----
 bounds:  [c@7#3,SET-f@4#8,SET]
-filenum: 000015
-props:
-  rocksdb.num.entries: 2
-  rocksdb.raw.key.size: 15
-  rocksdb.raw.value.size: 2
 
 # Just test a basic iterator once virtual sstable bounds have been set.
 iter

--- a/sstable/testdata/virtual_reader_props
+++ b/sstable/testdata/virtual_reader_props
@@ -1,0 +1,145 @@
+# Simple sanity test with single level index.
+build
+a.SET.1:a
+b.SET.1:b
+c.SET.1:c
+d.SET.1:d
+----
+point:    [a#1,SET-d#1,SET]
+seqnums:  [1-1]
+
+# Note that the raw key/value sizes aren't accurate here because we use
+# Reader.EstimateDiskUsage with virtual sstables bounds to determine virtual
+# sstable size which is then used to extrapolate virtual sstable properties, and
+# for tiny sstables, virtual sstable sizes aren't accurate. In this testcase,
+# the virtual sstable size is 50, whereas the backing sstable size is 850.
+virtualize lower=b.SET.1 upper=c.SET.1 show-props
+----
+bounds:  [b#1,SET-c#1,SET]
+filenum: 000001
+props:
+  rocksdb.num.entries: 1
+  rocksdb.raw.key.size: 3
+  rocksdb.raw.value.size: 1
+
+# Test 2: Similar to test 1 but force two level iterators.
+build block-size=1 index-block-size=1
+a.SET.1:a
+b.SET.1:b
+c.SET.1:c
+d.SET.1:d
+----
+point:    [a#1,SET-d#1,SET]
+seqnums:  [1-1]
+
+virtualize lower=b.SET.1 upper=c.SET.1 show-props
+----
+bounds:  [b#1,SET-c#1,SET]
+filenum: 000002
+props:
+  rocksdb.num.entries: 1
+  rocksdb.raw.key.size: 3
+  rocksdb.raw.value.size: 1
+
+# Test the constrain bounds function. It performs some subtle shrinking and
+# expanding of bounds. The current virtual sstable bounds are [b,c].
+# 1. start key < virtual sstable start key, end key is exclusive.
+constrain a,bb,false
+----
+b,bb,false
+
+# 2. start key < virtual sstable start key, end key is inclusive.
+constrain a,bb,true
+----
+b,bb,true
+
+# 3. start key is within virtual sstable bounds, end key is at virtual sstable
+# end bound, but is exclusive.
+constrain bb,c,false
+----
+bb,c,false
+
+# 3. start key is within virtual sstable bounds, end key is at virtual sstable
+# end bound, but is inclusive.
+constrain bb,c,true
+----
+bb,c,true
+
+# 4. start key is within virtual sstable bounds, end key is above virtual
+# sstable end bound and is exclusive.
+constrain bb,e,false
+----
+bb,c,true
+
+# 5. start key is within virtual sstable bounds, end key is above virtual
+# sstable end bound and is inclusive.
+constrain bb,e,true
+----
+bb,c,true
+
+# 6. Both start, end keys fit within virtual sstable bounds.
+constrain bb,bbb,false
+----
+bb,bbb,false
+
+# 6. Both start, end keys are out of bounds, but overlap.
+constrain a,d,false
+----
+b,c,true
+
+# 7. start, end keys have no overlap with virtual sstable bounds. Note that
+# lower becomes greater than upper here. We support this in the iterators
+# and don't return any keys for this case.
+constrain a,aa,false
+----
+b,aa,false
+
+build block-size=1 index-block-size=1
+a.SET.1:a
+d.SET.2:d
+f.SET.3:f
+d.RANGEDEL.4:e
+rangekey: a-d:{(#11,RANGEKEYSET,@t10,foo)}
+g.RANGEDEL.5:l
+rangekey: y-z:{(#12,RANGEKEYSET,@t11,foo)}
+----
+point:    [a#1,SET-f#3,SET]
+rangedel: [d#4,RANGEDEL-l#72057594037927935,RANGEDEL]
+rangekey: [a#11,RANGEKEYSET-z#72057594037927935,RANGEKEYSET]
+seqnums:  [1-12]
+
+# Note that we shouldn't have range del spans which cross virtual sstable
+# boundaries; num.range-key-sets must be >= 1.
+virtualize lower=a.SET.1 upper=f.SET.1 show-props
+----
+bounds:  [a#1,SET-f#1,SET]
+filenum: 000003
+props:
+  rocksdb.num.entries: 1
+  rocksdb.raw.key.size: 4
+  rocksdb.raw.value.size: 1
+  rocksdb.deleted.keys: 1
+  rocksdb.num.range-deletions: 1
+  pebble.num.range-key-sets: 1
+
+build
+a.SET.1:a
+b.SET.2:b
+c.SET.3:c
+d.SET.4:d
+dd.SET.5:dd
+ddd.SET.6:ddd
+g.SET.8:g
+h.SET.9:h
+----
+point:    [a#1,SET-h#9,SET]
+seqnums:  [1-9]
+
+virtualize lower=dd.SET.5 upper=ddd.SET.6 show-props
+----
+bounds:  [dd#5,SET-ddd#6,SET]
+filenum: 000004
+props:
+  rocksdb.num.entries: 2
+  rocksdb.raw.key.size: 11
+  rocksdb.raw.value.size: 2

--- a/sstable/testdata/virtual_reader_props
+++ b/sstable/testdata/virtual_reader_props
@@ -38,7 +38,7 @@ bounds:  [b#1,SET-c#1,SET]
 filenum: 000002
 props:
   rocksdb.num.entries: 1
-  rocksdb.raw.key.size: 3
+  rocksdb.raw.key.size: 2
   rocksdb.raw.value.size: 1
 
 # Test the constrain bounds function. It performs some subtle shrinking and
@@ -140,6 +140,6 @@ virtualize lower=dd.SET.5 upper=ddd.SET.6 show-props
 bounds:  [dd#5,SET-ddd#6,SET]
 filenum: 000004
 props:
-  rocksdb.num.entries: 2
-  rocksdb.raw.key.size: 11
+  rocksdb.num.entries: 1
+  rocksdb.raw.key.size: 10
   rocksdb.raw.value.size: 2


### PR DESCRIPTION
#### sstable: fix two level iterator bug with virtual tables

Consider the following iterator operations: SeekLT, Prev, Prev
(returns nil), Next.

For a top-level or regular index block, it is possible that
`skipBackward` moves beyond the last index block that intersects the
vtable.  Then, when we do Next, we move back to that block and return
the smallest key inside that block, but this is incorrect if the lower
bound is inside this block.

In normal circumstances, `skipBackward` can't move beyond the last
index block; but it is possible when range key masking is in use: on
the filter causes the index block that intersects the vtable to be
skipped. Then the `rangeKeyMasking` filter is updated, and on the Next
call, the block is no longer skipped.

Note that this can't happen in the other direction - this is because
the index key is an end bound for the indexed block and that makes the
boundary check "tight" in `skipForward` but "loose" in `skipBackward`.

This change makes it so that we use `SeekGE` instead of
`firstInternal` when appropriate.

Fixes #3450

#### sstable: TestVirtualReader cleanup

Some cleanup for this test:
 - use proper directive argument format for bounds
 - remove one-off `twoLevel` argument, replace with already supported
   `block-size` and `index-block-size`
 - use standard formatting for properties
 - rename `citer` dirwective to `compaction-iter`

#### sstable: split virtual reader tests

Split the virtual reader tests into one that is focused on the
properties and one that is focused on iterator correctness. We run the
latter with randomized block sizes.

#### sstable: add virtual reader tests with masking

Add support for controlling masking with an interator command and add
a test cases that reproduces #3450.
