### PR TITLE
Makefile: update stress-crossversion to include 23.2 and not 22.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ crossversion-meta:
 
 .PHONY: stress-crossversion
 stress-crossversion:
-	STRESS=1 ./scripts/run-crossversion-meta.sh crl-release-21.2 crl-release-22.1 crl-release-22.2 crl-release-23.1 master
+	STRESS=1 ./scripts/run-crossversion-meta.sh crl-release-22.1 crl-release-22.2 crl-release-23.1 crl-release-23.2 master
 
 .PHONY: generate
 generate:


### PR DESCRIPTION
Update the stress-crossversion Makefile target to drop 22.1 as the starting version and add 23.2 as the penultimate version.