### PR TITLE
db: unconditionally interleave ignorable boundaries

### DIFF
--- a/external_iterator_test.go
+++ b/external_iterator_test.go
@@ -7,21 +7,16 @@ package pebble
 import (
 	"bytes"
 	"fmt"
-	"math"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/itertest"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/rand"
 )
 
 func TestExternalIterator(t *testing.T) {
@@ -139,172 +134,6 @@ func TestSimpleIterError(t *testing.T) {
 	iterKey, _ := s.First()
 	require.Nil(t, iterKey)
 	require.Error(t, s.Error())
-}
-
-func TestIterRandomizedMaybeFilteredKeys(t *testing.T) {
-	mem := vfs.NewMem()
-
-	seed := *seed
-	if seed == 0 {
-		seed = uint64(time.Now().UnixNano())
-		t.Logf("seed: %d", seed)
-	}
-	rng := rand.New(rand.NewSource(seed))
-	numKeys := 100 + rng.Intn(5000)
-	// The block property filter will exclude keys with suffixes [0, tsSeparator-1].
-	// We use the first "part" of the keyspace below to write keys >= tsSeparator,
-	// and the second part to write keys < tsSeparator. Successive parts (if any)
-	// will contain keys at random before or after the separator.
-	tsSeparator := 10 + rng.Int63n(5000)
-	const keyLen = 5
-
-	// We split the keyspace into logical "parts" which are disjoint slices of the
-	// keyspace. That is, the keyspace a-z could be comprised of parts {a-k, l-z}.
-	// We rely on this partitioning when generating timestamps to give us some
-	// predictable clustering of timestamps in sstable blocks, however it is not
-	// strictly necessary for this test.
-	alpha := testkeys.Alpha(keyLen)
-	numParts := rng.Intn(3) + 2
-	blockSize := 16 + rng.Intn(64)
-
-	c := cache.New(128 << 20)
-	defer c.Unref()
-
-	for fileIdx, twoLevelIndex := range []bool{false, true} {
-		t.Run(fmt.Sprintf("twoLevelIndex=%v", twoLevelIndex), func(t *testing.T) {
-			keys := make([][]byte, 0, numKeys)
-
-			filename := fmt.Sprintf("test-%d", fileIdx)
-			f0, err := mem.Create(filename)
-			require.NoError(t, err)
-
-			indexBlockSize := 4096
-			if twoLevelIndex {
-				indexBlockSize = 1
-			}
-			w := sstable.NewWriter(objstorageprovider.NewFileWritable(f0), sstable.WriterOptions{
-				BlockSize:      blockSize,
-				Comparer:       testkeys.Comparer,
-				IndexBlockSize: indexBlockSize,
-				TableFormat:    sstable.TableFormatPebblev2,
-				BlockPropertyCollectors: []func() BlockPropertyCollector{
-					func() BlockPropertyCollector {
-						return sstable.NewTestKeysBlockPropertyCollector()
-					},
-				},
-			})
-			buf := make([]byte, alpha.MaxLen()+testkeys.MaxSuffixLen)
-			valBuf := make([]byte, 20)
-			keyIdx := int64(0)
-			for i := 0; i < numParts; i++ {
-				// The first two parts of the keyspace are special. The first one has
-				// all keys with timestamps greater than tsSeparator, while the second
-				// one has all keys with timestamps less than tsSeparator. Any additional
-				// keys could have timestamps at random before or after the tsSeparator.
-				maxKeysPerPart := numKeys / numParts
-				for j := 0; j < maxKeysPerPart; j++ {
-					var ts int64
-					if i == 0 {
-						ts = rng.Int63n(5000) + tsSeparator
-					} else if i == 1 {
-						ts = rng.Int63n(tsSeparator)
-					} else {
-						ts = rng.Int63n(tsSeparator + 5000)
-					}
-					n := testkeys.WriteKeyAt(buf, alpha, keyIdx*alpha.Count()/int64(numKeys), ts)
-					keys = append(keys, append([]byte(nil), buf[:n]...))
-					randStr(valBuf, rng)
-					require.NoError(t, w.Set(buf[:n], valBuf))
-					keyIdx++
-				}
-			}
-			require.NoError(t, w.Close())
-
-			// Re-open that filename for reading.
-			f1, err := mem.Open(filename)
-			require.NoError(t, err)
-
-			readable, err := sstable.NewSimpleReadable(f1)
-			require.NoError(t, err)
-
-			r, err := sstable.NewReader(readable, sstable.ReaderOptions{
-				Cache:    c,
-				Comparer: testkeys.Comparer,
-			})
-			require.NoError(t, err)
-			defer r.Close()
-
-			filter := sstable.NewTestKeysBlockPropertyFilter(uint64(tsSeparator), math.MaxUint64)
-			filterer, err := sstable.IntersectsTable([]BlockPropertyFilter{filter}, nil, r.Properties.UserProperties, nil)
-			require.NoError(t, err)
-			require.NotNil(t, filterer)
-
-			var iter sstable.Iterator
-			iter, err = r.NewIterWithBlockPropertyFilters(
-				sstable.NoTransforms, nil, nil, filterer, false /* useFilterBlock */, nil, /* stats */
-				sstable.CategoryAndQoS{}, nil, sstable.TrivialReaderProvider{Reader: r})
-			require.NoError(t, err)
-			defer iter.Close()
-			var lastSeekKey, lowerBound, upperBound []byte
-			narrowBoundsMode := false
-
-			for i := 0; i < 10000; i++ {
-				if rng.Intn(8) == 0 {
-					// Toggle narrow bounds mode.
-					if narrowBoundsMode {
-						// Reset bounds.
-						lowerBound, upperBound = nil, nil
-						iter.SetBounds(nil /* lower */, nil /* upper */)
-					}
-					narrowBoundsMode = !narrowBoundsMode
-				}
-				keyIdx := rng.Intn(len(keys))
-				seekKey := keys[keyIdx]
-				if narrowBoundsMode {
-					// Case 1: We just entered narrow bounds mode, and both bounds
-					// are nil. Set a lower/upper bound.
-					//
-					// Case 2: The seek key is outside our last bounds.
-					//
-					// In either case, pick a narrow range of keys to set bounds on,
-					// let's say keys[keyIdx-5] and keys[keyIdx+5], before doing our
-					// seek operation. Picking narrow bounds increases the chance of
-					// monotonic bound changes.
-					cmp := testkeys.Comparer.Compare
-					case1 := lowerBound == nil && upperBound == nil
-					case2 := (lowerBound != nil && cmp(lowerBound, seekKey) > 0) || (upperBound != nil && cmp(upperBound, seekKey) <= 0)
-					if case1 || case2 {
-						lowerBound = nil
-						if keyIdx-5 >= 0 {
-							lowerBound = keys[keyIdx-5]
-						}
-						upperBound = nil
-						if keyIdx+5 < len(keys) {
-							upperBound = keys[keyIdx+5]
-						}
-						iter.SetBounds(lowerBound, upperBound)
-					}
-					// Case 3: The current seek key is within the previously-set bounds.
-					// No need to change bounds.
-				}
-				flags := base.SeekGEFlagsNone
-				if lastSeekKey != nil && bytes.Compare(seekKey, lastSeekKey) > 0 {
-					flags = flags.EnableTrySeekUsingNext()
-				}
-				lastSeekKey = append(lastSeekKey[:0], seekKey...)
-
-				newKey, _ := iter.SeekGE(seekKey, flags)
-				if newKey == nil || !bytes.Equal(newKey.UserKey, seekKey) {
-					// We skipped some keys. Check if maybeFilteredKeys is true.
-					formattedNewKey := "<nil>"
-					if newKey != nil {
-						formattedNewKey = fmt.Sprintf("%s", testkeys.Comparer.FormatKey(newKey.UserKey))
-					}
-					require.True(t, iter.MaybeFilteredKeys(), "seeked for key = %s, got key = %s indicating block property filtering but MaybeFilteredKeys = false", testkeys.Comparer.FormatKey(seekKey), formattedNewKey)
-				}
-			}
-		})
-	}
 }
 
 func BenchmarkExternalIter_NonOverlapping_Scan(b *testing.B) {

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -1028,10 +1028,7 @@ func TestBlockProperties(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			return runIterCmd(td, iter, false, runIterCmdEveryOpAfter(func(w io.Writer) {
-				// After every op, point the value of MaybeFilteredKeys.
-				fmt.Fprintf(w, " MaybeFilteredKeys()=%t", iter.MaybeFilteredKeys())
-			}))
+			return runIterCmd(td, iter, false)
 
 		default:
 			return fmt.Sprintf("unknown command: %s", td.Cmd)
@@ -1119,9 +1116,6 @@ func TestBlockProperties_BoundLimited(t *testing.T) {
 				// iterator output.
 				io.Copy(w, &buf)
 				buf.Reset()
-			}), runIterCmdEveryOpAfter(func(w io.Writer) {
-				// After every op, point the value of MaybeFilteredKeys.
-				fmt.Fprintf(w, " MaybeFilteredKeys()=%t", iter.MaybeFilteredKeys())
 			}))
 		default:
 			return fmt.Sprintf("unrecognized command %q", td.Cmd)

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -270,17 +270,12 @@ type runIterCmdOption func(*runIterCmdOptions)
 
 type runIterCmdOptions struct {
 	everyOp       func(io.Writer)
-	everyOpAfter  func(io.Writer)
 	stats         *base.InternalIteratorStats
 	maskingFilter TestKeysMaskingFilter
 }
 
 func runIterCmdEveryOp(everyOp func(io.Writer)) runIterCmdOption {
 	return func(opts *runIterCmdOptions) { opts.everyOp = everyOp }
-}
-
-func runIterCmdEveryOpAfter(everyOp func(io.Writer)) runIterCmdOption {
-	return func(opts *runIterCmdOptions) { opts.everyOpAfter = everyOp }
 }
 
 func runIterCmdStats(stats *base.InternalIteratorStats) runIterCmdOption {
@@ -488,9 +483,6 @@ func runIterCmd(
 			fmt.Fprintf(&b, "<err=%v>", err)
 		} else {
 			fmt.Fprintf(&b, ".")
-		}
-		if opts.everyOpAfter != nil {
-			opts.everyOpAfter(&b)
 		}
 		b.WriteString("\n")
 	}

--- a/sstable/reader_iter.go
+++ b/sstable/reader_iter.go
@@ -20,17 +20,6 @@ type Iterator interface {
 	// NextPrefix implements (base.InternalIterator).NextPrefix.
 	NextPrefix(succKey []byte) (*InternalKey, base.LazyValue)
 
-	// MaybeFilteredKeys may be called when an iterator is exhausted to indicate
-	// whether or not the last positioning method may have skipped any keys due
-	// to block-property filters. This is used by the Pebble levelIter to
-	// control when an iterator steps to the next sstable.
-	//
-	// MaybeFilteredKeys may always return false positives, that is it may
-	// return true when no keys were filtered. It should only be called when the
-	// iterator is exhausted. It must never return false negatives when the
-	// iterator is exhausted.
-	MaybeFilteredKeys() bool
-
 	SetCloseHook(fn func(i Iterator) error)
 }
 

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -16,11 +16,7 @@ import (
 
 type twoLevelIterator struct {
 	singleLevelIterator
-	// maybeFilteredKeysSingleLevel indicates whether the last iterator
-	// positioning operation may have skipped any index blocks due to
-	// block-property filters when positioning the top-level-index.
-	maybeFilteredKeysTwoLevel bool
-	topLevelIndex             blockIter
+	topLevelIndex blockIter
 }
 
 // twoLevelIterator implements the base.InternalIterator interface.
@@ -56,7 +52,6 @@ func (i *twoLevelIterator) loadIndex(dir int8) loadBlockResult {
 			intersects = i.resolveMaybeExcluded(dir)
 		}
 		if intersects == blockExcluded {
-			i.maybeFilteredKeysTwoLevel = true
 			return loadBlockIrrelevant
 		}
 		// blockIntersects
@@ -208,21 +203,6 @@ func (i *twoLevelIterator) String() string {
 	return i.reader.fileNum.String()
 }
 
-// MaybeFilteredKeys may be called when an iterator is exhausted to indicate
-// whether or not the last positioning method may have skipped any keys due to
-// block-property filters.
-func (i *twoLevelIterator) MaybeFilteredKeys() bool {
-	// While reading sstables with two-level indexes, knowledge of whether we've
-	// filtered keys is tracked separately for each index level. The
-	// seek-using-next optimizations have different criteria. We can only reset
-	// maybeFilteredKeys back to false during a seek when NOT using the
-	// fast-path that uses the current iterator position.
-	//
-	// If either level might have filtered keys to arrive at the current
-	// iterator position, return MaybeFilteredKeys=true.
-	return i.maybeFilteredKeysTwoLevel || i.maybeFilteredKeysSingleLevel
-}
-
 // SeekGE implements internalIterator.SeekGE, as documented in the pebble
 // package. Note that SeekGE only checks the upper bound. It is up to the
 // caller to ensure that key is greater than or equal to the lower bound.
@@ -255,16 +235,6 @@ func (i *twoLevelIterator) SeekGE(
 
 	// SeekGE performs various step-instead-of-seeking optimizations: eg enabled
 	// by trySeekUsingNext, or by monotonically increasing bounds (i.boundsCmp).
-	// Care must be taken to ensure that when performing these optimizations and
-	// the iterator becomes exhausted, i.maybeFilteredKeys is set appropriately.
-	// Consider a previous SeekGE that filtered keys from k until the current
-	// iterator position.
-	//
-	// If the previous SeekGE exhausted the iterator while seeking within the
-	// two-level index, it's possible keys greater than or equal to the current
-	// search key were filtered through skipped index blocks. We must not reuse
-	// the position of the two-level index iterator without remembering the
-	// previous value of maybeFilteredKeys.
 
 	// We fall into the slow path if i.index.isDataInvalidated() even if the
 	// top-level iterator is already positioned correctly and all other
@@ -282,7 +252,6 @@ func (i *twoLevelIterator) SeekGE(
 		// The previous exhausted state of singleLevelIterator is no longer
 		// relevant, since we may be moving to a different index block.
 		i.exhaustedBounds = 0
-		i.maybeFilteredKeysTwoLevel = false
 		flags = flags.DisableTrySeekUsingNext()
 		var ikey *InternalKey
 		if ikey, _ = i.topLevelIndex.SeekGE(key, flags); ikey == nil {
@@ -342,15 +311,15 @@ func (i *twoLevelIterator) SeekGE(
 		// index block. No need to reset the state of singleLevelIterator.
 		//
 		// Note that cases 1 and 2 never overlap, and one of them must be true,
-		// but we have some test code (TestIterRandomizedMaybeFilteredKeys) that
-		// sets both to true, so we fix things here and then do an invariant
+		// but we used to have some test code (TestIterRandomizedMaybeFilteredKeys)
+		// that set both to true, so we fix things here and then do an invariant
 		// check.
 		//
 		// This invariant checking is important enough that we do not gate it
 		// behind invariants.Enabled.
 		if i.boundsCmp > 0 {
-			// TODO(sumeer): fix TestIterRandomizedMaybeFilteredKeys so as to not
-			// need this behavior.
+			// TODO(sumeer): fix now that TestIterRandomizedMaybeFilteredKeys does
+			// nnot exist.
 			flags = flags.DisableTrySeekUsingNext()
 		}
 		if i.boundsCmp > 0 == flags.TrySeekUsingNext() {
@@ -450,17 +419,7 @@ func (i *twoLevelIterator) SeekPrefixGE(
 
 	// SeekPrefixGE performs various step-instead-of-seeking optimizations: eg
 	// enabled by trySeekUsingNext, or by monotonically increasing bounds
-	// (i.boundsCmp).  Care must be taken to ensure that when performing these
-	// optimizations and the iterator becomes exhausted,
-	// i.maybeFilteredKeysTwoLevel is set appropriately.  Consider a previous
-	// SeekPrefixGE that filtered keys from k until the current iterator
-	// position.
-	//
-	// If the previous SeekPrefixGE exhausted the iterator while seeking within
-	// the two-level index, it's possible keys greater than or equal to the
-	// current search key were filtered through skipped index blocks. We must
-	// not reuse the position of the two-level index iterator without
-	// remembering the previous value of maybeFilteredKeysTwoLevel.
+	// (i.boundsCmp).
 
 	// We fall into the slow path if i.index.isDataInvalidated() even if the
 	// top-level iterator is already positioned correctly and all other
@@ -478,7 +437,6 @@ func (i *twoLevelIterator) SeekPrefixGE(
 		// The previous exhausted state of singleLevelIterator is no longer
 		// relevant, since we may be moving to a different index block.
 		i.exhaustedBounds = 0
-		i.maybeFilteredKeysTwoLevel = false
 		flags = flags.DisableTrySeekUsingNext()
 		var ikey *InternalKey
 		if ikey, _ = i.topLevelIndex.SeekGE(key, flags); ikey == nil {
@@ -603,7 +561,6 @@ func (i *twoLevelIterator) virtualLastSeekLE() (*InternalKey, base.LazyValue) {
 	// Seek optimization only applies until iterator is first positioned with a
 	// SeekGE or SeekLT after SetBounds.
 	i.boundsCmp = 0
-	i.maybeFilteredKeysTwoLevel = false
 	ikey, _ := i.topLevelIndex.SeekGE(key, base.SeekGEFlagsNone)
 	// We can have multiple internal keys with the same user key as the seek
 	// key. In that case, we want the last (greatest) internal key.
@@ -662,7 +619,6 @@ func (i *twoLevelIterator) SeekLT(
 	// NB: If a bound-limited block property filter is configured, it's
 	// externally ensured that the filter is disabled (through returning
 	// Intersects=false irrespective of the block props provided) during seeks.
-	i.maybeFilteredKeysTwoLevel = false
 	if ikey, _ = i.topLevelIndex.SeekGE(key, base.SeekGEFlagsNone); ikey == nil {
 		if ikey, _ = i.topLevelIndex.Last(); ikey == nil {
 			i.data.invalidate()
@@ -724,7 +680,6 @@ func (i *twoLevelIterator) First() (*InternalKey, base.LazyValue) {
 		return i.SeekGE(i.lower, base.SeekGEFlagsNone)
 	}
 	i.exhaustedBounds = 0
-	i.maybeFilteredKeysTwoLevel = false
 	i.err = nil // clear cached iteration error
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
 	i.boundsCmp = 0
@@ -777,7 +732,6 @@ func (i *twoLevelIterator) Last() (*InternalKey, base.LazyValue) {
 		panic("twoLevelIterator.Last() used despite upper bound")
 	}
 	i.exhaustedBounds = 0
-	i.maybeFilteredKeysTwoLevel = false
 	i.err = nil // clear cached iteration error
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
 	i.boundsCmp = 0
@@ -818,7 +772,6 @@ func (i *twoLevelIterator) Last() (*InternalKey, base.LazyValue) {
 func (i *twoLevelIterator) Next() (*InternalKey, base.LazyValue) {
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
 	i.boundsCmp = 0
-	i.maybeFilteredKeysTwoLevel = false
 	if i.err != nil {
 		// TODO(jackson): Can this case be turned into a panic? Once an error is
 		// encountered, the iterator must be re-seeked.
@@ -837,7 +790,6 @@ func (i *twoLevelIterator) NextPrefix(succKey []byte) (*InternalKey, base.LazyVa
 	}
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
 	i.boundsCmp = 0
-	i.maybeFilteredKeysTwoLevel = false
 	if i.err != nil {
 		// TODO(jackson): Can this case be turned into a panic? Once an error is
 		// encountered, the iterator must be re-seeked.
@@ -886,7 +838,6 @@ func (i *twoLevelIterator) NextPrefix(succKey []byte) (*InternalKey, base.LazyVa
 func (i *twoLevelIterator) Prev() (*InternalKey, base.LazyValue) {
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
 	i.boundsCmp = 0
-	i.maybeFilteredKeysTwoLevel = false
 	if i.err != nil {
 		return nil, base.LazyValue{}
 	}

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -310,18 +310,9 @@ func (i *twoLevelIterator) SeekGE(
 		// i.topLevelIndex.Key().UserKey) <= 0, we are at the correct lower level
 		// index block. No need to reset the state of singleLevelIterator.
 		//
-		// Note that cases 1 and 2 never overlap, and one of them must be true,
-		// but we used to have some test code (TestIterRandomizedMaybeFilteredKeys)
-		// that set both to true, so we fix things here and then do an invariant
-		// check.
-		//
+		// Note that cases 1 and 2 never overlap, and one of them must be true.
 		// This invariant checking is important enough that we do not gate it
 		// behind invariants.Enabled.
-		if i.boundsCmp > 0 {
-			// TODO(sumeer): fix now that TestIterRandomizedMaybeFilteredKeys does
-			// nnot exist.
-			flags = flags.DisableTrySeekUsingNext()
-		}
 		if i.boundsCmp > 0 == flags.TrySeekUsingNext() {
 			panic(fmt.Sprintf("inconsistency in optimization case 1 %t and case 2 %t",
 				i.boundsCmp > 0, flags.TrySeekUsingNext()))

--- a/sstable/testdata/block_properties
+++ b/sstable/testdata/block_properties
@@ -391,8 +391,8 @@ iter lower=a point-key-filter=(suffix-point-keys-only,1,2)
 seek-lt h
 last
 ----
-<a@1:1> MaybeFilteredKeys()=true
-<a@1:1> MaybeFilteredKeys()=true
+<a@1:1>
+<a@1:1>
 
 # Same as above, but each index block holds 2 keys. This exercises a variant of
 # the above bug. Specifically, the bounds check performed /within/ skipBackward,
@@ -438,7 +438,7 @@ g#72057594037927935,SEPARATOR:
 iter lower=a upper=z point-key-filter=(suffix-point-keys-only,1,2)
 seek-lt h
 ----
-<a@1:1> MaybeFilteredKeys()=true
+<a@1:1>
 
 # Test MaybeFilteredKeys().
 
@@ -453,12 +453,12 @@ next
 seek-ge b
 seek-ge e@3
 ----
-<a@1:1> MaybeFilteredKeys()=false
-<e@3:5> MaybeFilteredKeys()=true
-<f@5:3> MaybeFilteredKeys()=false
-. MaybeFilteredKeys()=false
-<e@3:5> MaybeFilteredKeys()=true
-<e@3:5> MaybeFilteredKeys()=false
+<a@1:1>
+<e@3:5>
+<f@5:3>
+.
+<e@3:5>
+<e@3:5>
 
 
 # NB: `seek-ge e` and `seek-ge dog` return MaybeFilteredKeys()=true, despite no
@@ -473,8 +473,8 @@ iter point-key-filter=(suffix-point-keys-only,1,9)
 seek-ge e
 seek-ge dog
 ----
-<e@3:5> MaybeFilteredKeys()=true
-<e@3:5> MaybeFilteredKeys()=true
+<e@3:5>
+<e@3:5>
 
 iter point-key-filter=(suffix-point-keys-only,1,100)
 first
@@ -487,15 +487,15 @@ next
 seek-lt d
 seek-ge d
 ----
-<a@1:1> MaybeFilteredKeys()=false
-<b@10:2> MaybeFilteredKeys()=false
-<c@15:3> MaybeFilteredKeys()=false
-<d@25:4> MaybeFilteredKeys()=false
-<e@3:5> MaybeFilteredKeys()=false
-<f@5:3> MaybeFilteredKeys()=false
-. MaybeFilteredKeys()=false
-<c@15:3> MaybeFilteredKeys()=false
-<d@25:4> MaybeFilteredKeys()=false
+<a@1:1>
+<b@10:2>
+<c@15:3>
+<d@25:4>
+<e@3:5>
+<f@5:3>
+.
+<c@15:3>
+<d@25:4>
 
 # [10,16) intersects {b@10, c@15}.
 
@@ -510,15 +510,15 @@ seek-lt f
 seek-lt e
 seek-lt d
 ----
-<c@15:3> MaybeFilteredKeys()=true
-<b@10:2> MaybeFilteredKeys()=false
-. MaybeFilteredKeys()=true
-. MaybeFilteredKeys()=true
-<b@10:2> MaybeFilteredKeys()=false
-<c@15:3> MaybeFilteredKeys()=false
-<c@15:3> MaybeFilteredKeys()=true
-<c@15:3> MaybeFilteredKeys()=true
-<c@15:3> MaybeFilteredKeys()=false
+<c@15:3>
+<b@10:2>
+.
+.
+<b@10:2>
+<c@15:3>
+<c@15:3>
+<c@15:3>
+<c@15:3>
 
 # Test monotonically increasing bounds optimization, with the first seek
 # filtering keys. The subsequent seek must not reuse the current iterator
@@ -531,10 +531,10 @@ seek-ge d
 set-bounds lower=ee upper=g
 seek-ge ee
 ----
-. MaybeFilteredKeys()=false
-. MaybeFilteredKeys()=true
-. MaybeFilteredKeys()=true
-. MaybeFilteredKeys()=true
+.
+.
+.
+.
 
 iter point-key-filter=(suffix-point-keys-only,10,16)
 set-bounds lower=a upper=b
@@ -543,11 +543,11 @@ set-bounds lower=b upper=e
 seek-ge b
 seek-ge bb
 ----
-. MaybeFilteredKeys()=false
-. MaybeFilteredKeys()=true
-. MaybeFilteredKeys()=true
-<b@10:2> MaybeFilteredKeys()=true
-<c@15:3> MaybeFilteredKeys()=false
+.
+.
+.
+<b@10:2>
+<c@15:3>
 
 # Test monotonically decreasing bounds optimization, with the first seek
 # filtering keys. The subsequent seek must not reuse the current iterator
@@ -563,13 +563,13 @@ set-bounds lower=a upper=c
 seek-lt c
 seek-lt b
 ----
-. MaybeFilteredKeys()=false
-. MaybeFilteredKeys()=true
-. MaybeFilteredKeys()=true
-<c@15:3> MaybeFilteredKeys()=true
-. MaybeFilteredKeys()=true
-<b@10:2> MaybeFilteredKeys()=false
-. MaybeFilteredKeys()=true
+.
+.
+.
+<c@15:3>
+.
+<b@10:2>
+.
 
 # The below case tests try-seek-using-next.
 #
@@ -585,11 +585,11 @@ seek-ge bb true
 seek-ge c@16 true
 seek-ge c@19 true
 ----
-<b@10:2> MaybeFilteredKeys()=true
-<b@10:2> MaybeFilteredKeys()=true
-<c@15:3> MaybeFilteredKeys()=false
-. MaybeFilteredKeys()=true
-. MaybeFilteredKeys()=true
+<b@10:2>
+<b@10:2>
+<c@15:3>
+.
+.
 
 # Test another case of monotonically increasing bounds optimization, with a
 # different index block structure. The first seek down below should filter keys,
@@ -626,10 +626,10 @@ seek-ge d
 set-bounds lower=e upper=g
 seek-ge ee
 ----
-. MaybeFilteredKeys()=false
-. MaybeFilteredKeys()=true
-. MaybeFilteredKeys()=true
-. MaybeFilteredKeys()=true
+.
+.
+.
+.
 
 # Test another case of monotonically increasing bounds optimization, with a new
 # index block structure: This one has only one level. The first seek down below
@@ -665,10 +665,10 @@ seek-ge d
 set-bounds lower=ee upper=g
 seek-ge ee
 ----
-. MaybeFilteredKeys()=false
-. MaybeFilteredKeys()=true
-. MaybeFilteredKeys()=true
-. MaybeFilteredKeys()=true
+.
+.
+.
+.
 
 # Create a table with a single block of point keys to test suffix replacement
 # injection during block property filtering

--- a/sstable/testdata/block_properties_boundlimited
+++ b/sstable/testdata/block_properties_boundlimited
@@ -47,18 +47,18 @@ next
 next
 ----
     filter.Intersects([2, 6)) = (true, <nil>)
-<a@5:1> MaybeFilteredKeys()=false
-<b@2:2> MaybeFilteredKeys()=false
+<a@5:1>
+<b@2:2>
     filter.Intersects([3, 10)) = (true, <nil>)
-<c@9:3> MaybeFilteredKeys()=false
-<d@3:4> MaybeFilteredKeys()=false
+<c@9:3>
+<d@3:4>
     filter.Intersects([0, 3)) = (true, <nil>)
-<e@2:5> MaybeFilteredKeys()=false
-<f@0:6> MaybeFilteredKeys()=false
+<e@2:5>
+<f@0:6>
     filter.Intersects([3, 9)) = (true, <nil>)
-<g@8:7> MaybeFilteredKeys()=false
-<h@3:8> MaybeFilteredKeys()=false
-. MaybeFilteredKeys()=false
+<g@8:7>
+<h@3:8>
+.
 
 # Test an interator with a bound-limited filter that excludes one block, the
 # third block.
@@ -73,17 +73,17 @@ next
 next
 ----
     filter.Intersects([2, 6)) = (true, <nil>)
-<a@5:1> MaybeFilteredKeys()=false
-<b@2:2> MaybeFilteredKeys()=false
+<a@5:1>
+<b@2:2>
     filter.Intersects([3, 10)) = (true, <nil>)
-<c@9:3> MaybeFilteredKeys()=false
-<d@3:4> MaybeFilteredKeys()=false
+<c@9:3>
+<d@3:4>
     filter.Intersects([0, 3)) = (false, <nil>)
     filter.KeyIsWithinUpperBound(g) = true
     filter.Intersects([3, 9)) = (true, <nil>)
-<g@8:7> MaybeFilteredKeys()=true
-<h@3:8> MaybeFilteredKeys()=false
-. MaybeFilteredKeys()=false
+<g@8:7>
+<h@3:8>
+.
 
 # Test the same case but with an upper bound set that prevents skipping the
 # block.
@@ -100,19 +100,19 @@ next
 next
 ----
     filter.Intersects([2, 6)) = (true, <nil>)
-<a@5:1> MaybeFilteredKeys()=false
-<b@2:2> MaybeFilteredKeys()=false
+<a@5:1>
+<b@2:2>
     filter.Intersects([3, 10)) = (true, <nil>)
-<c@9:3> MaybeFilteredKeys()=false
-<d@3:4> MaybeFilteredKeys()=false
+<c@9:3>
+<d@3:4>
     filter.Intersects([0, 3)) = (false, <nil>)
     filter.KeyIsWithinUpperBound(g) = false
-<e@2:5> MaybeFilteredKeys()=false
-<f@0:6> MaybeFilteredKeys()=false
+<e@2:5>
+<f@0:6>
     filter.Intersects([3, 9)) = (true, <nil>)
-<g@8:7> MaybeFilteredKeys()=false
-<h@3:8> MaybeFilteredKeys()=false
-. MaybeFilteredKeys()=false
+<g@8:7>
+<h@3:8>
+.
 
 # Test the same case above but inject a synthetic suffix 
 # that causes block 3 to intersect in the filter
@@ -127,16 +127,16 @@ next
 next
 ----
     filter.SyntheticSuffixIntersects([2, 6)) = (true, <nil>)
-<a@5:1> MaybeFilteredKeys()=false
-<b@2:2> MaybeFilteredKeys()=false
+<a@5:1>
+<b@2:2>
     filter.SyntheticSuffixIntersects([3, 10)) = (true, <nil>)
-<c@9:3> MaybeFilteredKeys()=false
-<d@3:4> MaybeFilteredKeys()=false
+<c@9:3>
+<d@3:4>
     filter.SyntheticSuffixIntersects([0, 3)) = (true, <nil>)
-<e@2:5> MaybeFilteredKeys()=false
-<f@0:6> MaybeFilteredKeys()=false
+<e@2:5>
+<f@0:6>
     filter.SyntheticSuffixIntersects([3, 9)) = (true, <nil>)
-<g@8:7> MaybeFilteredKeys()=false
+<g@8:7>
 
 # Test a case that filters the first two blocks. The third block is not filtered
 # due to block-property intersection. The fourth block is not filtered due to
@@ -154,13 +154,13 @@ next
     filter.Intersects([3, 10)) = (false, <nil>)
     filter.KeyIsWithinUpperBound(e) = true
     filter.Intersects([0, 3)) = (true, <nil>)
-<e@2:5> MaybeFilteredKeys()=true
-<f@0:6> MaybeFilteredKeys()=false
+<e@2:5>
+<f@0:6>
     filter.Intersects([3, 9)) = (false, <nil>)
     filter.KeyIsWithinUpperBound(i) = false
-<g@8:7> MaybeFilteredKeys()=false
-<h@3:8> MaybeFilteredKeys()=false
-. MaybeFilteredKeys()=false
+<g@8:7>
+<h@3:8>
+.
 
 # Test a similar case in reverse. In reverse if the very first block is reached,
 # we do not know whether or not it's actually within the bounds because we don't
@@ -180,12 +180,12 @@ prev
     filter.Intersects([0, 3)) = (false, <nil>)
     filter.KeyIsWithinLowerBound(e) = true
     filter.Intersects([3, 10)) = (true, <nil>)
-<d@3:4> MaybeFilteredKeys()=true
-<c@9:3> MaybeFilteredKeys()=false
+<d@3:4>
+<c@9:3>
     filter.Intersects([2, 6)) = (false, <nil>)
-<b@2:2> MaybeFilteredKeys()=false
-<a@5:1> MaybeFilteredKeys()=false
-. MaybeFilteredKeys()=false
+<b@2:2>
+<a@5:1>
+.
 
 # Add tests with other non-limited filters set, including one with the same
 # Name.

--- a/testdata/level_iter_boundaries
+++ b/testdata/level_iter_boundaries
@@ -131,8 +131,10 @@ c.SET.2:c
 iter
 first
 next
+next
 ----
 c#2,SET:c
+c#2,SET:
 .
 
 iter

--- a/testdata/level_iter_seek
+++ b/testdata/level_iter_seek
@@ -105,6 +105,8 @@ next
 stats
 next
 stats
+next
+stats
 reset-stats
 stats
 ----
@@ -116,6 +118,8 @@ b#8,SET:b
 c#7,SET:c
 {BlockBytes:56 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 f#5,SET:f
+{BlockBytes:56 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+f#5,SET:
 {BlockBytes:56 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 g#4,SET:g
 {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
@@ -380,8 +384,10 @@ j.SET.3:j
 iter
 seek-ge f
 next
+next
 ----
 f/<invalid>#5,SET:f
+f#5,SET:
 i#4,SET:i
 
 # The below count should be 2, as we skip over the rangekey-only file.

--- a/testdata/merging_iter
+++ b/testdata/merging_iter
@@ -40,7 +40,7 @@ c#27,SET:27
 e#10,SET:10
 g#20,SET:20
 .
-{BlockBytes:116 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:5 ValueBytes:8 PointCount:5 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:116 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:6 ValueBytes:8 PointCount:6 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 
 # seekGE() should not allow the rangedel to act on points in the lower sstable that are after it.


### PR DESCRIPTION
**db: unconditionally interleave ignorable boundaries**

The levelIter has a concept of ignorable boundary keys. When a levelIter
exhausts a file's point keys, it's possible that the same file still contains
range deletions relevant to other levels of the LSM. The levelIter will, under
some conditions, interleave the largest boundary key of the sstable into
iteration as an 'ignorable boundary key,' so that the file's range deletions
remain accessible until all other levels progress beyound the file's boundary.

When block-property filters are in use, a file's point key iterator may become
exhausted early, before the file's range deletions are irrelevant, even if the
file's largest key is not a range deletion. To work around this subtlety, the
sstable iterator previously would surface knowledge of whether any point keys
may have been skipped through a MaybeFilteredKeys method. The levelIter used
this method to determine when to interleave an ignorable largest boundary in
case there may be additional relevant range deletions.

This commit removes the conditioning on the output of MaybeFilteredKeys,
instead unconditionally interleaving a synthetic boundary at a file's largest
point key if the levelIter user is using the file's range deletion iterator.
This simplifies the logic and removes a fragile reliance on the sstable's
iterators accounting of when it may have filtered keys.

Future work (https://github.com/cockroachdb/pebble/issues/2863) will remove the need to interleave synthetic boundaries at
all, instead interleaving the range deletion bounds themselves among point
keys.

Informs https://github.com/cockroachdb/pebble/issues/2863.
Close https://github.com/cockroachdb/pebble/issues/3334.

**sstable: remove Iterator.MaybeFilteredKeys**

Remove the MaybeFilteredKeys method that surfaced knowledge of whether an
sstable iterator may have omitted keys due to block-property filters. With the
previous commit's refactor to unconditionally interleave sstable largest
boundaries when using a levelIter to drive range deletion iteration, we no
longer need to know whether keys might've been filtered. This reduces the
code complexity considerably.

**sstable: strengthen assertion around mutual exclusion of seek optimizations**

Previously an assertion that the TrySeekUsingNext and monotonic bounds
optimizations could not simultaneously be active was disabled due to the
TestIterRandomizedMaybeFilteredKeys test that could violate the invariant. The
test has been removed (along with the method it was testing), so we can
now uncondtionally restore the invariant.
