### PR TITLE
sstable: clear user properties in CopySpan

### DIFF
--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -180,7 +180,8 @@ type Properties struct {
 	SnapshotPinnedValueSize uint64 `prop:"pebble.raw.snapshot-pinned-values.size"`
 	// Size of the top-level index if kTwoLevelIndexSearch is used.
 	TopLevelIndexSize uint64 `prop:"rocksdb.top-level.index.size"`
-	// User collected properties.
+	// User collected properties. Currently, we only use them to store block
+	// properties aggregated at the table level.
 	UserProperties map[string]string
 
 	// Loaded set indicating which fields have been loaded from disk. Indexed by

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -2028,7 +2028,7 @@ func (w *Writer) Close() (err error) {
 	{
 		// Finish and record the prop collectors if props are not yet recorded.
 		// Pre-computed props might have been copied by specialized sst creators
-		// like suffix replacer or a span copier.
+		// like suffix replacer.
 		if len(w.props.UserProperties) == 0 {
 			userProps := make(map[string]string)
 			for i := range w.blockPropCollectors {

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -341,8 +341,8 @@ ok
 lsm verbose
 ----
 L6:
-  000006(000006):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:758
-  000007(000007):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:660
+  000006(000006):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:742
+  000007(000007):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:644
 
 reopen
 ----


### PR DESCRIPTION
The user properties contain the table block properties and the
presence of any such property implies that index entries have the same
properties. When we create a partial copy of an sst in `CopySpan`, we
don't calculate properties for index entries but non-existent
properties can still have meaning (for example, it means a
non-obsolete block for the obsolete property filter; and it means an
empty interval for the interval filter).

The fix is to just clear out the user properties so that the reader
knows there are no block properties collected.

Fixes #3485