### PR TITLE
db: deflake TestConcurrentExcise

### DIFF
--- a/testdata/concurrent_excise
+++ b/testdata/concurrent_excise
@@ -284,12 +284,11 @@ unblock c1
 ----
 ok
 
+compact a-z
+----
+ok
+
 lsm
 ----
-L0.0:
-  000008:[a#12,SET-a#12,SET]
-  000010:[d#13,SET-e#14,SET]
 L6:
-  000005:[a#10,SET-a#10,SET]
-  000012:[b#16,SET-bb#16,SET]
-  000006:[e#11,SET-e#11,SET]
+  000016:[a#0,SET-e#0,SET]


### PR DESCRIPTION
Previously, the unblocking of a compaction was followed by an LSM printout, leading to a race where the datadriven output could or could not have reflected the output of the compaction. This change adds a manual compaction in between to flush out this race.

Fixes #3490.