### PR TITLE
sstable: clean up UpdateKeySuffixes

### DIFF
--- a/iterator_test.go
+++ b/iterator_test.go
@@ -485,6 +485,16 @@ func (c *minSeqNumPropertyCollector) FinishTable(buf []byte) ([]byte, error) {
 	return binary.AppendUvarint(buf, c.minSeqNum), nil
 }
 
+func (c *minSeqNumPropertyCollector) AddCollectedWithSuffixReplacement(
+	oldProp []byte, oldSuffix, newSuffix []byte,
+) error {
+	return errors.Errorf("not implemented")
+}
+
+func (c *minSeqNumPropertyCollector) SupportsSuffixReplacement() bool {
+	return false
+}
+
 // minSeqNumFilter is a BlockPropertyFilter that uses the
 // minSeqNumPropertyCollector data to filter out entire tables.
 type minSeqNumFilter struct {
@@ -1121,6 +1131,8 @@ type testBlockIntervalCollector struct {
 	lower, upper  uint64
 }
 
+var _ sstable.DataBlockIntervalCollector = (*testBlockIntervalCollector)(nil)
+
 func (bi *testBlockIntervalCollector) Add(key InternalKey, value []byte) error {
 	k := key.UserKey
 	if len(k) < bi.numLength+bi.offsetFromEnd {
@@ -1154,6 +1166,16 @@ func (bi *testBlockIntervalCollector) FinishDataBlock() (lower uint64, upper uin
 	l, u := bi.lower, bi.upper
 	bi.lower, bi.upper = 0, 0
 	return l, u, nil
+}
+
+func (bi *testBlockIntervalCollector) AddCollectedWithSuffixReplacement(
+	oldLower, oldUpper uint64, oldSuffix, newSuffix []byte,
+) error {
+	return errors.Errorf("not implemented")
+}
+
+func (bi *testBlockIntervalCollector) SupportsSuffixReplacement() bool {
+	return false
 }
 
 func TestIteratorBlockIntervalFilter(t *testing.T) {

--- a/sstable/block_property_obsolete.go
+++ b/sstable/block_property_obsolete.go
@@ -63,8 +63,8 @@ func (o *obsoleteKeyBlockPropertyCollector) FinishTable(buf []byte) ([]byte, err
 	return obsoleteKeyBlockPropertyEncode(!o.tableIsNonObsolete, buf), nil
 }
 
-// UpdateKeySuffixes is part of the BlockPropertyCollector interface.
-func (o *obsoleteKeyBlockPropertyCollector) UpdateKeySuffixes(
+// AddCollectedWithSuffixReplacement is part of the BlockPropertyCollector interface.
+func (o *obsoleteKeyBlockPropertyCollector) AddCollectedWithSuffixReplacement(
 	oldProp []byte, oldSuffix, newSuffix []byte,
 ) error {
 	// Verify the property is valid.
@@ -75,6 +75,11 @@ func (o *obsoleteKeyBlockPropertyCollector) UpdateKeySuffixes(
 	// Suffix rewriting currently loses the obsolete bit.
 	o.blockIsNonObsolete = true
 	return nil
+}
+
+// SupportsSuffixReplacement is part of the BlockPropertyCollector interface.
+func (o *obsoleteKeyBlockPropertyCollector) SupportsSuffixReplacement() bool {
+	return true
 }
 
 // obsoleteKeyBlockPropertyFilter implements the filter that excludes blocks

--- a/sstable/block_property_test_utils.go
+++ b/sstable/block_property_test_utils.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 )
@@ -139,4 +140,16 @@ func (c *testKeysSuffixIntervalCollector) FinishDataBlock() (lower, upper uint64
 	c.lower, c.upper = 0, 0
 	c.initialized = false
 	return l, u, nil
+}
+
+// AddCollectedWithSuffixReplacement is part of the DataBlockIntervalCollector interface.
+func (c *testKeysSuffixIntervalCollector) AddCollectedWithSuffixReplacement(
+	oldLower, oldUpper uint64, oldSuffix, newSuffix []byte,
+) error {
+	return errors.Errorf("not implemented")
+}
+
+// SupportsSuffixReplacement part of the DataBlockIntervalCollector interface.
+func (c *testKeysSuffixIntervalCollector) SupportsSuffixReplacement() bool {
+	return false
 }

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -697,6 +697,8 @@ type testBlockPropCollector struct {
 	err     error
 }
 
+var _ BlockPropertyCollector = (*testBlockPropCollector)(nil)
+
 func (c *testBlockPropCollector) Name() string { return "testBlockPropCollector" }
 
 func (c *testBlockPropCollector) Add(_ InternalKey, _ []byte) error {
@@ -727,6 +729,16 @@ func (c *testBlockPropCollector) FinishTable(_ []byte) ([]byte, error) {
 		return nil, c.err
 	}
 	return nil, nil
+}
+
+func (c *testBlockPropCollector) AddCollectedWithSuffixReplacement(
+	oldProp []byte, oldSuffix, newSuffix []byte,
+) error {
+	return errors.Errorf("not implemented")
+}
+
+func (c *testBlockPropCollector) SupportsSuffixReplacement() bool {
+	return false
 }
 
 func TestWriterBlockPropertiesErrors(t *testing.T) {


### PR DESCRIPTION
This change cleans up the design of `SuffixReplaceableBlockCollector`: instead of having a separate optional interface, we fold this functionality in the `BlockPropertyCollector` and
`DataBlockIntervalCollector` interfaces. This makes things much easier to follow.

Note that the old design was especially problematic for `DataBlockIntervalCollector`: we were passing the encoded properties to the implementation but the encoding of intervals into properties is implemented by Pebble. This works only because the Cockroach implementation (`pebbleDataBlockMVCCTimeIntervalCollector`) does not need to look at the old properties at all.