### PR TITLE
all: replace path.Join with filepath.Join

### DIFF
--- a/cmd/pebble/fsbench.go
+++ b/cmd/pebble/fsbench.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -216,7 +216,7 @@ func createBench(benchName string, benchDescription string) fsBenchmark {
 			}
 
 			start := time.Now()
-			fh := createFile(path.Join(dirpath, fmt.Sprintf("%s%d", pref, numFiles)))
+			fh := createFile(filepath.Join(dirpath, fmt.Sprintf("%s%d", pref, numFiles)))
 			syncFile(bench.dir)
 			hist.Record(time.Since(start))
 
@@ -265,7 +265,7 @@ func deleteBench(
 		// prepopulate the directory
 		prePref := "pre_temp_"
 		for i := 0; i < preNumFiles; i++ {
-			fh := createFile(path.Join(dirpath, fmt.Sprintf("%s%d", prePref, i)))
+			fh := createFile(filepath.Join(dirpath, fmt.Sprintf("%s%d", prePref, i)))
 			if preFileSize > 0 {
 				writeToFile(fh, preFileSize)
 				syncFile(fh)
@@ -281,12 +281,12 @@ func deleteBench(
 			}
 
 			filename := "newfile"
-			fh := createFile(path.Join(dirpath, filename))
+			fh := createFile(filepath.Join(dirpath, filename))
 			writeToFile(fh, fileSize)
 			syncFile(fh)
 
 			start := time.Now()
-			deleteFile(path.Join(dirpath, filename))
+			deleteFile(filepath.Join(dirpath, filename))
 			hist.Record(time.Since(start))
 
 			return true
@@ -332,7 +332,7 @@ func deleteUniformBench(
 		// setup the operation to benchmark, and the cleaup functions.
 		pref := "temp_"
 		for i := 0; i < numFiles; i++ {
-			fh := createFile(path.Join(dirpath, fmt.Sprintf("%s%d", pref, i)))
+			fh := createFile(filepath.Join(dirpath, fmt.Sprintf("%s%d", pref, i)))
 			if fileSize > 0 {
 				writeToFile(fh, fileSize)
 				syncFile(fh)
@@ -352,7 +352,7 @@ func deleteUniformBench(
 			}
 
 			start := time.Now()
-			deleteFile(path.Join(dirpath, fmt.Sprintf("%s%d", pref, numFiles-1)))
+			deleteFile(filepath.Join(dirpath, fmt.Sprintf("%s%d", pref, numFiles-1)))
 			hist.Record(time.Since(start))
 
 			numFiles--
@@ -408,7 +408,7 @@ func writeSyncBench(
 			fileNum      int
 			bytesWritten int64
 		}
-		benchData.fh = createFile(path.Join(dirpath, fmt.Sprintf("%s%d", pref, benchData.fileNum)))
+		benchData.fh = createFile(filepath.Join(dirpath, fmt.Sprintf("%s%d", pref, benchData.fileNum)))
 
 		bench.run = func(hist *namedHistogram) bool {
 			if benchData.done.Load() {
@@ -419,7 +419,7 @@ func writeSyncBench(
 				closeFile(benchData.fh)
 				benchData.fileNum++
 				benchData.bytesWritten = 0
-				benchData.fh = createFile(path.Join(dirpath, fmt.Sprintf("%s%d", pref, benchData.fileNum)))
+				benchData.fh = createFile(filepath.Join(dirpath, fmt.Sprintf("%s%d", pref, benchData.fileNum)))
 			}
 
 			benchData.bytesWritten += writeSize
@@ -481,7 +481,7 @@ func diskUsageBench(
 			fileNum      int
 			bytesWritten int64
 		}
-		benchData.fh = createFile(path.Join(dirpath, fmt.Sprintf("%s%d", pref, benchData.fileNum)))
+		benchData.fh = createFile(filepath.Join(dirpath, fmt.Sprintf("%s%d", pref, benchData.fileNum)))
 
 		bench.run = func(hist *namedHistogram) bool {
 			if benchData.done.Load() {
@@ -492,7 +492,7 @@ func diskUsageBench(
 				closeFile(benchData.fh)
 				benchData.fileNum++
 				benchData.bytesWritten = 0
-				benchData.fh = createFile(path.Join(dirpath, fmt.Sprintf("%s%d", pref, benchData.fileNum)))
+				benchData.fh = createFile(filepath.Join(dirpath, fmt.Sprintf("%s%d", pref, benchData.fileNum)))
 			}
 
 			benchData.bytesWritten += writeSize

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -11,7 +11,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -2073,7 +2072,7 @@ func (r *replicateOp) run(t *Test, h historyRecorder) {
 
 	source := t.getDB(r.source)
 	dest := t.getDB(r.dest)
-	sstPath := path.Join(t.tmpDir, fmt.Sprintf("ext-replicate%d.sst", t.idx))
+	sstPath := filepath.Join(t.tmpDir, fmt.Sprintf("ext-replicate%d.sst", t.idx))
 	f, err := t.opts.FS.Create(sstPath, vfs.WriteCategoryUnspecified)
 	if err != nil {
 		h.Recordf("%s // %v", r, err)

--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -186,7 +185,7 @@ func (t *Test) init(
 		var db *pebble.DB
 		var err error
 		if len(t.dbs) > 1 {
-			dir = path.Join(t.dir, fmt.Sprintf("db%d", i+1))
+			dir = filepath.Join(t.dir, fmt.Sprintf("db%d", i+1))
 		}
 		err = t.withRetries(func() error {
 			db, err = pebble.Open(dir, t.opts)
@@ -305,7 +304,7 @@ func (t *Test) restartDB(dbID objID) error {
 		}
 		dir := t.dir
 		if len(t.dbs) > 1 {
-			dir = path.Join(dir, fmt.Sprintf("db%d", dbID.slot()))
+			dir = filepath.Join(dir, fmt.Sprintf("db%d", dbID.slot()))
 		}
 		t.dbs[dbID.slot()-1], err = pebble.Open(dir, t.opts)
 		if err != nil {

--- a/objstorage/remote/localfs.go
+++ b/objstorage/remote/localfs.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -43,7 +43,7 @@ func (s *localFSStore) Close() error {
 func (s *localFSStore) ReadObject(
 	ctx context.Context, objName string,
 ) (_ ObjectReader, objSize int64, _ error) {
-	f, err := s.vfs.Open(path.Join(s.dirname, objName))
+	f, err := s.vfs.Open(filepath.Join(s.dirname, objName))
 	if err != nil {
 		return nil, 0, err
 	}
@@ -80,7 +80,7 @@ func (r *localFSReader) Close() error {
 
 // CreateObject is part of the remote.Storage interface.
 func (s *localFSStore) CreateObject(objName string) (io.WriteCloser, error) {
-	file, err := s.vfs.Create(path.Join(s.dirname, objName), vfs.WriteCategoryUnspecified)
+	file, err := s.vfs.Create(filepath.Join(s.dirname, objName), vfs.WriteCategoryUnspecified)
 	return file, err
 }
 
@@ -95,12 +95,12 @@ func (s *localFSStore) List(prefix, delimiter string) ([]string, error) {
 
 // Delete is part of the remote.Storage interface.
 func (s *localFSStore) Delete(objName string) error {
-	return s.vfs.Remove(path.Join(s.dirname, objName))
+	return s.vfs.Remove(filepath.Join(s.dirname, objName))
 }
 
 // Size is part of the remote.Storage interface.
 func (s *localFSStore) Size(objName string) (int64, error) {
-	f, err := s.vfs.Open(path.Join(s.dirname, objName))
+	f, err := s.vfs.Open(filepath.Join(s.dirname, objName))
 	if err != nil {
 		return 0, err
 	}

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -996,7 +996,7 @@ func TestBytesIterated(t *testing.T) {
 }
 
 func TestCompactionIteratorSetupForCompaction(t *testing.T) {
-	tmpDir := path.Join(t.TempDir())
+	tmpDir := filepath.Join(t.TempDir())
 	provider, err := objstorageprovider.Open(objstorageprovider.DefaultSettings(vfs.Default, tmpDir))
 	require.NoError(t, err)
 	defer provider.Close()
@@ -1034,7 +1034,7 @@ func TestCompactionIteratorSetupForCompaction(t *testing.T) {
 }
 
 func TestReadaheadSetupForV3TablesWithMultipleVersions(t *testing.T) {
-	tmpDir := path.Join(t.TempDir())
+	tmpDir := filepath.Join(t.TempDir())
 	provider, err := objstorageprovider.Open(objstorageprovider.DefaultSettings(vfs.Default, tmpDir))
 	require.NoError(t, err)
 	defer provider.Close()
@@ -1634,7 +1634,7 @@ func TestValidateBlockChecksums(t *testing.T) {
 		f, err := os.Open(filepath.Join("testdata", file))
 		require.NoError(t, err)
 
-		pathCopy := path.Join(t.TempDir(), path.Base(file))
+		pathCopy := filepath.Join(t.TempDir(), path.Base(file))
 		fCopy, err := os.OpenFile(pathCopy, os.O_CREATE|os.O_RDWR, 0600)
 		require.NoError(t, err)
 		defer fCopy.Close()

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -1210,7 +1210,7 @@ func TestTableCacheNoSuchFileError(t *testing.T) {
 	if sst == "" {
 		t.Fatalf("no SST found after flush")
 	}
-	require.NoError(t, mem.Remove(path.Join(dirname, sst)))
+	require.NoError(t, mem.Remove(filepath.Join(dirname, sst)))
 
 	_, _, _ = d.Get([]byte("a"))
 	require.NotZero(t, len(logger.fatalMsgs), "no fatal message emitted")

--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -537,7 +538,7 @@ func (*MemFS) PathBase(p string) string {
 func (*MemFS) PathJoin(elem ...string) string {
 	// Note that MemFS uses forward slashes for its separator, hence the use of
 	// path.Join, not filepath.Join.
-	return path.Join(elem...)
+	return filepath.Join(elem...)
 }
 
 // PathDir implements FS.PathDir.


### PR DESCRIPTION
path.Join is separated by '/', but the window system file separator is' \ '

filepath.Join can automatically select delimiters based on the system