### PR TITLE
metamorphic: don't set synthetic suffix if there are duplicate prefixes

### DIFF
--- a/metamorphic/generator.go
+++ b/metamorphic/generator.go
@@ -1386,14 +1386,32 @@ func (g *generator) writerIngestExternalFiles() {
 		return g.cmp(o.bounds.Start, o.bounds.End) >= 0
 	})
 
+	// Randomly set synthetic suffixes.
 	for i := range objs {
-		// We can only use a synthetic suffix if we don't have range dels.
-		// TODO(radu): we will want to support this at some point.
-		if g.keyManager.objKeyMeta(objs[i].externalObjID).hasRangeDels {
-			continue
-		}
-
 		if g.rng.Intn(2) == 0 {
+			// We can only use a synthetic suffix if we don't have range dels.
+			// TODO(radu): we will want to support this at some point.
+			if g.keyManager.objKeyMeta(objs[i].externalObjID).hasRangeDels {
+				continue
+			}
+
+			// We can only use a synthetic suffix if we don't have multiple keys with
+			// the same prefix.
+			hasDuplicatePrefix := func() bool {
+				var prevPrefix []byte
+				for _, k := range g.keyManager.KeysForExternalIngest(objs[i]) {
+					prefix := g.prefix(k.key)
+					if g.cmp(prefix, prevPrefix) == 0 {
+						return true
+					}
+					prevPrefix = append(prevPrefix[:0], prefix...)
+				}
+				return false
+			}()
+			if hasDuplicatePrefix {
+				continue
+			}
+
 			// Generate a suffix that sorts before any previously generated suffix.
 			objs[i].syntheticSuffix = g.keyGenerator.IncMaxSuffix()
 		}

--- a/metamorphic/key_manager.go
+++ b/metamorphic/key_manager.go
@@ -313,6 +313,12 @@ func (k *keyManager) KeysForExternalIngest(obj externalObjWithBounds) []keyMeta 
 			res = append(res, km)
 		}
 	}
+	// Check for duplicate resulting keys.
+	for i := 1; i < len(res); i++ {
+		if k.comparer.Compare(res[i].key, res[i-1].key) == 0 {
+			panic(fmt.Sprintf("duplicate external ingest key %q", res[i].key))
+		}
+	}
 	return res
 }
 


### PR DESCRIPTION
We are not allowed to use a synthetic suffix if the relevant portion
of the external file has multiple keys with the same prefix. After
suffix replacement, they would become the same key.

I first added the code to check for duplicate keys in
`KeysForExternalIngest` and stressed just the generation part and it
reproduced. I then added the generator check and the panic  no longer
reproduces.

Fixes #3502