### PR TITLE
db: check for empty external ingestions

### DIFF
--- a/options.go
+++ b/options.go
@@ -682,6 +682,10 @@ type Options struct {
 		// major version is at least `FormatFlushableIngest`.
 		DisableIngestAsFlushable func() bool
 
+		// CheckExternalIngestions enables opening external ssts at ingest time and
+		// validating that they are not empty. Used for testing/debugging.
+		CheckExternalIngestions bool
+
 		// RemoteStorage enables use of remote storage (e.g. S3) for storing
 		// sstables. Setting this option enables use of CreateOnShared option and
 		// allows ingestion of external files.


### PR DESCRIPTION
This commit adds in invariants-only check that the external ingestions are not empty. This is not allowed and leads to errors or correctness issues down the line.

Informs #122176