### PR TITLE
*: remove bytesIterated

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -1279,34 +1279,6 @@ func scanKeyspanIterator(w io.Writer, ki keyspan.FragmentIterator) {
 	}
 }
 
-func TestFlushableBatchBytesIterated(t *testing.T) {
-	batch := newBatch(nil)
-	for j := 0; j < 1000; j++ {
-		key := make([]byte, 8+j%3)
-		value := make([]byte, 7+j%5)
-		batch.Set(key, value, nil)
-
-		fb, err := newFlushableBatch(batch, DefaultComparer)
-		require.NoError(t, err)
-
-		var bytesIterated uint64
-		it := fb.newFlushIter(nil, &bytesIterated)
-
-		var prevIterated uint64
-		for kv := it.First(); kv != nil; kv = it.Next() {
-			if bytesIterated < prevIterated {
-				t.Fatalf("bytesIterated moved backward: %d < %d", bytesIterated, prevIterated)
-			}
-			prevIterated = bytesIterated
-		}
-
-		expected := fb.inuseBytes()
-		if bytesIterated != expected {
-			t.Fatalf("bytesIterated: got %d, want %d", bytesIterated, expected)
-		}
-	}
-}
-
 func TestEmptyFlushableBatch(t *testing.T) {
 	// Verify that we can create a flushable batch on an empty batch.
 	fb, err := newFlushableBatch(newBatch(nil), DefaultComparer)

--- a/flushable.go
+++ b/flushable.go
@@ -22,7 +22,7 @@ import (
 // flushable defines the interface for immutable memtables.
 type flushable interface {
 	newIter(o *IterOptions) internalIterator
-	newFlushIter(o *IterOptions, bytesFlushed *uint64) internalIterator
+	newFlushIter(o *IterOptions) internalIterator
 	newRangeDelIter(o *IterOptions) keyspan.FragmentIterator
 	newRangeKeyIter(o *IterOptions) keyspan.FragmentIterator
 	containsRangeKeys() bool
@@ -226,7 +226,7 @@ func (s *ingestedFlushable) newIter(o *IterOptions) internalIterator {
 }
 
 // newFlushIter is part of the flushable interface.
-func (s *ingestedFlushable) newFlushIter(o *IterOptions, bytesFlushed *uint64) internalIterator {
+func (s *ingestedFlushable) newFlushIter(*IterOptions) internalIterator {
 	// newFlushIter is only used for writing memtables to disk as sstables.
 	// Since ingested sstables are already present on disk, they don't need to
 	// make use of a flush iter.

--- a/internal/arenaskl/flush_iterator.go
+++ b/internal/arenaskl/flush_iterator.go
@@ -24,7 +24,6 @@ import "github.com/cockroachdb/pebble/internal/base"
 // simply value copying the struct.
 type flushIterator struct {
 	Iterator
-	bytesIterated *uint64
 }
 
 // flushIterator implements the base.InternalIterator interface.
@@ -51,12 +50,7 @@ func (it *flushIterator) SeekLT(key []byte, flags base.SeekLTFlags) *base.Intern
 // that First only checks the upper bound. It is up to the caller to ensure
 // that key is greater than or equal to the lower bound.
 func (it *flushIterator) First() *base.InternalKV {
-	kv := it.Iterator.First()
-	if kv == nil {
-		return nil
-	}
-	*it.bytesIterated += uint64(it.nd.allocSize)
-	return kv
+	return it.Iterator.First()
 }
 
 // Next advances to the next position. Returns the key and value if the
@@ -69,7 +63,6 @@ func (it *flushIterator) Next() *base.InternalKV {
 		return nil
 	}
 	it.decodeKey()
-	*it.bytesIterated += uint64(it.nd.allocSize)
 	it.kv.V = base.MakeInPlaceValue(it.value())
 	return &it.kv
 }

--- a/internal/arenaskl/skl.go
+++ b/internal/arenaskl/skl.go
@@ -307,10 +307,9 @@ func (s *Skiplist) NewIter(lower, upper []byte) *Iterator {
 // NewFlushIter returns a new flushIterator, which is similar to an Iterator
 // but also sets the current number of the bytes that have been iterated
 // through.
-func (s *Skiplist) NewFlushIter(bytesFlushed *uint64) base.InternalIterator {
+func (s *Skiplist) NewFlushIter() base.InternalIterator {
 	return &flushIterator{
-		Iterator:      Iterator{list: s, nd: s.head},
-		bytesIterated: bytesFlushed,
+		Iterator: Iterator{list: s, nd: s.head},
 	}
 }
 

--- a/internal/arenaskl/skl_test.go
+++ b/internal/arenaskl/skl_test.go
@@ -769,35 +769,6 @@ func TestIteratorBounds(t *testing.T) {
 	require.False(t, it.Prev())
 }
 
-func TestBytesIterated(t *testing.T) {
-	l := NewSkiplist(newArena(arenaSize), bytes.Compare)
-	emptySize := l.arena.Size()
-	for i := 0; i < 200; i++ {
-		bytesIterated := l.bytesIterated(t)
-		expected := uint64(l.arena.Size() - emptySize)
-		if bytesIterated != expected {
-			t.Fatalf("bytesIterated: got %d, want %d", bytesIterated, expected)
-		}
-		l.Add(base.InternalKey{UserKey: []byte{byte(i)}}, nil)
-	}
-}
-
-// bytesIterated returns the number of bytes iterated in the skiplist.
-func (s *Skiplist) bytesIterated(t *testing.T) (bytesIterated uint64) {
-	x := s.NewFlushIter(&bytesIterated)
-	var prevIterated uint64
-	for kv := x.First(); kv != nil; kv = x.Next() {
-		if bytesIterated < prevIterated {
-			t.Fatalf("bytesIterated moved backward: %d < %d", bytesIterated, prevIterated)
-		}
-		prevIterated = bytesIterated
-	}
-	if x.Close() != nil {
-		return 0
-	}
-	return bytesIterated
-}
-
 func randomKey(rng *rand.Rand, b []byte) base.InternalKey {
 	key := rng.Uint32()
 	key2 := rng.Uint32()

--- a/level_iter.go
+++ b/level_iter.go
@@ -17,7 +17,10 @@ import (
 )
 
 type internalIterOpts struct {
-	bytesIterated      *uint64
+	// if compaction is set, sstable-level iterators will be created using
+	// NewCompactionIter; these iterators have a more constrained interface
+	// and are optimized for the sequential scan of a compaction.
+	compaction         bool
 	bufferPool         *sstable.BufferPool
 	stats              *base.InternalIteratorStats
 	boundLimitedFilter sstable.BoundLimitedBlockPropertyFilter

--- a/mem_table.go
+++ b/mem_table.go
@@ -260,8 +260,8 @@ func (m *memTable) newIter(o *IterOptions) internalIterator {
 }
 
 // newFlushIter is part of the flushable interface.
-func (m *memTable) newFlushIter(o *IterOptions, bytesFlushed *uint64) internalIterator {
-	return m.skl.NewFlushIter(bytesFlushed)
+func (m *memTable) newFlushIter(o *IterOptions) internalIterator {
+	return m.skl.NewFlushIter()
 }
 
 // newRangeDelIter is part of the flushable interface.

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -388,18 +388,16 @@ func (r *Reader) NewIter(transforms IterTransforms, lower, upper []byte) (Iterat
 // after itself and returns a nil iterator.
 func (r *Reader) NewCompactionIter(
 	transforms IterTransforms,
-	bytesIterated *uint64,
 	categoryAndQoS CategoryAndQoS,
 	statsCollector *CategoryStatsCollector,
 	rp ReaderProvider,
 	bufferPool *BufferPool,
 ) (Iterator, error) {
-	return r.newCompactionIter(transforms, bytesIterated, categoryAndQoS, statsCollector, rp, nil, bufferPool)
+	return r.newCompactionIter(transforms, categoryAndQoS, statsCollector, rp, nil, bufferPool)
 }
 
 func (r *Reader) newCompactionIter(
 	transforms IterTransforms,
-	bytesIterated *uint64,
 	categoryAndQoS CategoryAndQoS,
 	statsCollector *CategoryStatsCollector,
 	rp ReaderProvider,
@@ -420,10 +418,7 @@ func (r *Reader) newCompactionIter(
 			return nil, err
 		}
 		i.setupForCompaction()
-		return &twoLevelCompactionIterator{
-			twoLevelIterator: i,
-			bytesIterated:    bytesIterated,
-		}, nil
+		return &twoLevelCompactionIterator{twoLevelIterator: i}, nil
 	}
 	i := singleLevelIterPool.Get().(*singleLevelIterator)
 	err := i.init(
@@ -434,10 +429,7 @@ func (r *Reader) newCompactionIter(
 		return nil, err
 	}
 	i.setupForCompaction()
-	return &compactionIterator{
-		singleLevelIterator: i,
-		bytesIterated:       bytesIterated,
-	}, nil
+	return &compactionIterator{singleLevelIterator: i}, nil
 }
 
 // NewRawRangeDelIter returns an internal iterator for the contents of the

--- a/sstable/reader_common.go
+++ b/sstable/reader_common.go
@@ -33,7 +33,6 @@ type CommonReader interface {
 
 	NewCompactionIter(
 		transforms IterTransforms,
-		bytesIterated *uint64,
 		categoryAndQoS CategoryAndQoS,
 		statsCollector *CategoryStatsCollector,
 		rp ReaderProvider,

--- a/sstable/reader_iter.go
+++ b/sstable/reader_iter.go
@@ -175,8 +175,6 @@ func checkRangeKeyFragmentBlockIterator(obj interface{}) {
 // bytes that have been iterated through.
 type compactionIterator struct {
 	*singleLevelIterator
-	bytesIterated *uint64
-	prevOffset    uint64
 }
 
 // compactionIterator implements the base.InternalIterator interface.
@@ -258,10 +256,6 @@ func (i *compactionIterator) skipForward(kv *base.InternalKV) *base.InternalKV {
 			}
 		}
 	}
-
-	curOffset := i.recordOffset()
-	*i.bytesIterated += uint64(curOffset - i.prevOffset)
-	i.prevOffset = curOffset
 
 	// We have an upper bound when the table is virtual.
 	if i.upper != nil && kv != nil {

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -594,24 +594,6 @@ func (i *singleLevelIterator) trySeekLTUsingPrevWithinBlock(
 	return kv, false
 }
 
-func (i *singleLevelIterator) recordOffset() uint64 {
-	offset := i.dataBH.Offset
-	if i.data.valid() {
-		// - i.dataBH.Length/len(i.data.data) is the compression ratio. If
-		//   uncompressed, this is 1.
-		// - i.data.nextOffset is the uncompressed position of the current record
-		//   in the block.
-		// - i.dataBH.Offset is the offset of the block in the sstable before
-		//   decompression.
-		offset += (uint64(i.data.nextOffset) * i.dataBH.Length) / uint64(len(i.data.data))
-	} else {
-		// Last entry in the block must increment bytes iterated by the size of the block trailer
-		// and restart points.
-		offset += i.dataBH.Length + blockTrailerLen
-	}
-	return offset
-}
-
 // SeekGE implements internalIterator.SeekGE, as documented in the pebble
 // package. Note that SeekGE only checks the upper bound. It is up to the
 // caller to ensure that key is greater than or equal to the lower bound.

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -995,8 +995,6 @@ func (i *twoLevelIterator) Close() error {
 // were separated due to performance.
 type twoLevelCompactionIterator struct {
 	*twoLevelIterator
-	bytesIterated *uint64
-	prevOffset    uint64
 }
 
 // twoLevelCompactionIterator implements the base.InternalIterator interface.
@@ -1082,10 +1080,6 @@ func (i *twoLevelCompactionIterator) skipForward(kv *base.InternalKV) *base.Inte
 			}
 		}
 	}
-
-	curOffset := i.recordOffset()
-	*i.bytesIterated += uint64(curOffset - i.prevOffset)
-	i.prevOffset = curOffset
 
 	// We have an upper bound when the table is virtual.
 	if i.upper != nil && kv != nil {

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -91,14 +91,13 @@ func MakeVirtualReader(reader *Reader, p VirtualReaderParams) VirtualReader {
 // NewCompactionIter is the compaction iterator function for virtual readers.
 func (v *VirtualReader) NewCompactionIter(
 	transforms IterTransforms,
-	bytesIterated *uint64,
 	categoryAndQoS CategoryAndQoS,
 	statsCollector *CategoryStatsCollector,
 	rp ReaderProvider,
 	bufferPool *BufferPool,
 ) (Iterator, error) {
 	return v.reader.newCompactionIter(
-		transforms, bytesIterated, categoryAndQoS, statsCollector, rp, &v.vState, bufferPool)
+		transforms, categoryAndQoS, statsCollector, rp, &v.vState, bufferPool)
 }
 
 // NewIterWithBlockPropertyFiltersAndContextEtc wraps

--- a/table_cache.go
+++ b/table_cache.go
@@ -601,9 +601,9 @@ func (c *tableCacheShard) newPointIter(
 	if opts != nil {
 		categoryAndQoS = opts.CategoryAndQoS
 	}
-	if internalOpts.bytesIterated != nil {
+	if internalOpts.compaction {
 		iter, err = cr.NewCompactionIter(
-			transforms, internalOpts.bytesIterated, categoryAndQoS, dbOpts.sstStatsCollector, rp,
+			transforms, categoryAndQoS, dbOpts.sstStatsCollector, rp,
 			internalOpts.bufferPool)
 	} else {
 		iter, err = cr.NewIterWithBlockPropertyFiltersAndContextEtc(


### PR DESCRIPTION
Remove the bytesIterated used in flushes and compactions to incrementally update compaction.bytesIterated. It was a vestige of an attempt at pacing flushes and compactions to reduce impact on foreground traffic. That pacing logic had been inactive for years and has been removed from the code base for a while.

The only remaining use was for the flush throughput metric, but this metric did not require an incrementally-updated value, only an aggregate after the flush has completed.