### PR TITLE
tool: add custom excise span option

### DIFF
--- a/tool/db.go
+++ b/tool/db.go
@@ -50,6 +50,7 @@ type dbT struct {
 	mergers         sstable.Mergers
 	openErrEnhancer func(error) error
 	openOptions     []OpenOption
+	exciseSpanFn    DBExciseSpanFn
 
 	// Flags.
 	comparerName  string
@@ -73,6 +74,7 @@ func newDB(
 	mergers sstable.Mergers,
 	openErrEnhancer func(error) error,
 	openOptions []OpenOption,
+	exciseSpanFn DBExciseSpanFn,
 ) *dbT {
 	d := &dbT{
 		opts:            opts,
@@ -80,6 +82,7 @@ func newDB(
 		mergers:         mergers,
 		openErrEnhancer: openErrEnhancer,
 		openOptions:     openOptions,
+		exciseSpanFn:    exciseSpanFn,
 	}
 	d.fmtKey.mustSet("quoted")
 	d.fmtValue.mustSet("[%x]")
@@ -516,16 +519,37 @@ func (d *dbT) runSpace(cmd *cobra.Command, args []string) {
 	fmt.Fprintf(stdout, "%d\n", bytes)
 }
 
+func (d *dbT) getExciseSpan() (pebble.KeyRange, error) {
+	// If a DBExciseSpanFn is specified, try to use it and see if it returns a
+	// valid span.
+	if d.exciseSpanFn != nil {
+		span, err := d.exciseSpanFn()
+		if err != nil {
+			return pebble.KeyRange{}, err
+		}
+		if span.Valid() {
+			if d.start != nil || d.end != nil {
+				return pebble.KeyRange{}, errors.Errorf(
+					"--start/--end cannot be used when span is specified by other methods.")
+			}
+			return span, nil
+		}
+	}
+	if d.start == nil || d.end == nil {
+		return pebble.KeyRange{}, errors.Errorf("excise range not specified.")
+	}
+	return pebble.KeyRange{
+		Start: d.start,
+		End:   d.end,
+	}, nil
+}
+
 func (d *dbT) runExcise(cmd *cobra.Command, args []string) {
 	stdout, stderr := cmd.OutOrStdout(), cmd.ErrOrStderr()
 
-	// Init range.
-	span := pebble.KeyRange{
-		Start: d.start,
-		End:   d.end,
-	}
-	if span.Start == nil || span.End == nil {
-		fmt.Fprintf(stderr, "Excise range not specified.\n")
+	span, err := d.getExciseSpan()
+	if err != nil {
+		fmt.Fprintf(stderr, "Error: %v\n", err)
 		return
 	}
 
@@ -543,6 +567,11 @@ func (d *dbT) runExcise(cmd *cobra.Command, args []string) {
 		return
 	}
 	defer d.closeDB(stdout, db)
+
+	// Update the internal formatter if this comparator has one specified.
+	if d.opts.Comparer != nil {
+		d.fmtKey.setForComparer(d.opts.Comparer.Name, d.comparers)
+	}
 
 	fmt.Fprintf(stdout, "Excising range:\n")
 	fmt.Fprintf(stdout, "  start: %s\n", d.fmtKey.fn(span.Start))

--- a/tool/testdata/db_excise
+++ b/tool/testdata/db_excise
@@ -27,21 +27,21 @@ scanned 5 records in 1.0s
 
 db excise foo
 ----
-Excise range not specified.
+Error: excise range not specified.
 
 db excise foo --start=gr
 ----
-Excise range not specified.
+Error: excise range not specified.
 
 db excise foo --end=t
 ----
-Excise range not specified.
+Error: excise range not specified.
 
 db excise foo --start=gr --end=t --yes
 ----
 Excising range:
-  start: gr
-  end:   t
+  start: test formatter: gr
+  end:   test formatter: t
 Excise complete.
 
 db scan foo
@@ -49,7 +49,6 @@ db scan foo
 test formatter: blue test value formatter: blue-val
 test formatter: yellow test value formatter: yellow-val
 scanned 2 records in 1.0s
-
 
 db scan testdata/broken-external-db
 ----


### PR DESCRIPTION
This commit adds an option to pass down a function for a custom method
to specify the excise span. On the CRDB side, we will add table/tenant
ID flags and when those flags are set, the function will return the
table span.

Informs [#122059](https://github.com/cockroachdb/cockroach/issues/122059)