### PR TITLE
wal,db: add FailoverWriteAndSyncLatency histogram

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -552,7 +552,9 @@ func (m *Metrics) SafeFormat(w redact.SafePrinter, _ rune) {
 		humanize.Bytes.Uint64(m.WAL.BytesIn),
 		humanize.Bytes.Uint64(m.WAL.BytesWritten),
 		redact.Safe(percent(int64(m.WAL.BytesWritten)-int64(m.WAL.BytesIn), int64(m.WAL.BytesIn))))
-	if m.WAL.Failover == (wal.FailoverStats{}) {
+	failoverStats := m.WAL.Failover
+	failoverStats.FailoverWriteAndSyncLatency = nil
+	if failoverStats == (wal.FailoverStats{}) {
 		w.Printf("\n")
 	} else {
 		w.Printf(" failover: (switches: %d, primary: %s, secondary: %s)\n", m.WAL.Failover.DirSwitchCount,

--- a/open.go
+++ b/open.go
@@ -365,6 +365,9 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 	if opts.WALFailover != nil {
 		walOpts.Secondary = opts.WALFailover.Secondary
 		walOpts.FailoverOptions = opts.WALFailover.FailoverOptions
+		walOpts.FailoverWriteAndSyncLatency = prometheus.NewHistogram(prometheus.HistogramOpts{
+			Buckets: FsyncLatencyBuckets,
+		})
 	}
 	walDirs := append(walOpts.Dirs(), opts.WALRecoveryDirs...)
 	wals, err := wal.Scan(walDirs...)

--- a/wal/failover_manager.go
+++ b/wal/failover_manager.go
@@ -614,20 +614,21 @@ func (wm *failoverManager) Create(wn NumWAL, jobID int) (Writer, error) {
 		}
 	}()
 	fwOpts := failoverWriterOpts{
-		wn:                   wn,
-		logger:               wm.opts.Logger,
-		timeSource:           wm.opts.timeSource,
-		jobID:                jobID,
-		logCreator:           wm.logCreator,
-		noSyncOnClose:        wm.opts.NoSyncOnClose,
-		bytesPerSync:         wm.opts.BytesPerSync,
-		preallocateSize:      wm.opts.PreallocateSize,
-		minSyncInterval:      wm.opts.MinSyncInterval,
-		fsyncLatency:         wm.opts.FsyncLatency,
-		queueSemChan:         wm.opts.QueueSemChan,
-		stopper:              wm.stopper,
-		writerClosed:         wm.writerClosed,
-		writerCreatedForTest: wm.opts.logWriterCreatedForTesting,
+		wn:                          wn,
+		logger:                      wm.opts.Logger,
+		timeSource:                  wm.opts.timeSource,
+		jobID:                       jobID,
+		logCreator:                  wm.logCreator,
+		noSyncOnClose:               wm.opts.NoSyncOnClose,
+		bytesPerSync:                wm.opts.BytesPerSync,
+		preallocateSize:             wm.opts.PreallocateSize,
+		minSyncInterval:             wm.opts.MinSyncInterval,
+		fsyncLatency:                wm.opts.FsyncLatency,
+		queueSemChan:                wm.opts.QueueSemChan,
+		stopper:                     wm.stopper,
+		failoverWriteAndSyncLatency: wm.opts.FailoverWriteAndSyncLatency,
+		writerClosed:                wm.writerClosed,
+		writerCreatedForTest:        wm.opts.logWriterCreatedForTesting,
 	}
 	var err error
 	var ww *failoverWriter
@@ -664,6 +665,7 @@ func (wm *failoverManager) writerClosed(llse logicalLogWithSizesEtc) {
 func (wm *failoverManager) Stats() Stats {
 	obsoleteLogsCount, obsoleteLogSize := wm.recycler.Stats()
 	failoverStats := wm.monitor.stats()
+	failoverStats.FailoverWriteAndSyncLatency = wm.opts.FailoverWriteAndSyncLatency
 	wm.mu.Lock()
 	defer wm.mu.Unlock()
 	var liveFileCount int

--- a/wal/testdata/manager_failover
+++ b/wal/testdata/manager_failover
@@ -95,7 +95,7 @@ advance-time dur=0ms wait-for-log-writer
 ----
 now: 1ms
 
-write-record value=mammoth
+write-record value=mammoth sync
 ----
 offset: 18
 
@@ -111,6 +111,7 @@ stats:
   obsolete: count 2 size 22
   live: count 1 size 18
   failover: switches 0 pri-dur 1ms sec-dur 0s
+  latency sample count: 1
 
 create-writer wal-num=7
 ----
@@ -139,6 +140,7 @@ stats:
   obsolete: count 2 size 22
   live: count 2 size 34
   failover: switches 0 pri-dur 1ms sec-dur 0s
+  latency sample count: 1
 
 obsolete min-unflushed=7
 ----
@@ -173,6 +175,7 @@ stats:
   obsolete: count 0 size 0
   live: count 1 size 29
   failover: switches 0 pri-dur 1ms sec-dur 0s
+  latency sample count: 1
 
 write-record value=woolly
 ----
@@ -194,6 +197,7 @@ stats:
   obsolete: count 0 size 0
   live: count 1 size 38
   failover: switches 0 pri-dur 1ms sec-dur 0s
+  latency sample count: 1
 
 close-manager
 ----

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -142,6 +142,9 @@ type Options struct {
 	EventListener EventListener
 
 	FailoverOptions
+	// FailoverWriteAndSyncLatency is only populated when WAL failover is
+	// configured.
+	FailoverWriteAndSyncLatency prometheus.Histogram
 }
 
 // Init constructs and initializes a WAL manager from the provided options and
@@ -300,6 +303,13 @@ type FailoverStats struct {
 	// SecondaryWriteDuration is the cumulative duration for which WAL writes
 	// are using the secondary directory.
 	SecondaryWriteDuration time.Duration
+
+	// FailoverWriteAndSyncLatency measures the latency of writing and syncing a
+	// set of writes that were synced together. Each sample represents the
+	// highest latency observed across the writes in the set of writes. It gives
+	// us a sense of the user-observed latency, which can be much lower than the
+	// underlying fsync latency, when WAL failover is working effectively.
+	FailoverWriteAndSyncLatency prometheus.Histogram
 }
 
 // Manager handles all WAL work.


### PR DESCRIPTION
FailoverWriteAndSyncLatency measures the latency of writing and syncing a set of writes that were synced together. Each sample represents the highest latency observed across the writes in the set of writes. It gives us a sense of the user-observed latency, which can be much lower than the underlying fsync latency, when WAL failover is working effectively.

Informs #122364