### PR TITLE
db: update newIters callers to use new interface

### DIFF
--- a/flushable.go
+++ b/flushable.go
@@ -236,17 +236,11 @@ func (s *ingestedFlushable) newFlushIter(*IterOptions) internalIterator {
 func (s *ingestedFlushable) constructRangeDelIter(
 	file *manifest.FileMetadata, _ keyspan.SpanIterOptions,
 ) (keyspan.FragmentIterator, error) {
+	iters, err := s.newIters(context.Background(), file, nil, internalIterOpts{}, iterRangeDeletions)
 	// Note that the keyspan level iter expects a non-nil iterator to be
-	// returned even if there is an error. So, we return the emptyKeyspanIter.
-	iter, rangeDelIter, err := s.newIters.TODO(context.Background(), file, nil, internalIterOpts{})
-	if err != nil {
-		return emptyKeyspanIter, err
-	}
-	iter.Close()
-	if rangeDelIter == nil {
-		return emptyKeyspanIter, nil
-	}
-	return rangeDelIter, nil
+	// returned even if there is an error. So, we return iters.RangeDeletion()
+	// regardless of the value of err.
+	return iters.RangeDeletion(), err
 }
 
 // newRangeDelIter is part of the flushable interface.

--- a/table_cache.go
+++ b/table_cache.go
@@ -59,22 +59,6 @@ type tableNewIters func(
 	kinds iterKinds,
 ) (iterSet, error)
 
-// TODO implements the old tableNewIters interface that always attempted to open
-// a point iterator and a range deletion iterator. All call sites should be
-// updated to use `f` directly.
-func (f tableNewIters) TODO(
-	ctx context.Context,
-	file *manifest.FileMetadata,
-	opts *IterOptions,
-	internalOpts internalIterOpts,
-) (internalIterator, keyspan.FragmentIterator, error) {
-	iters, err := f(ctx, file, opts, internalOpts, iterPointKeys|iterRangeDeletions)
-	if err != nil {
-		return nil, nil, err
-	}
-	return iters.point, iters.rangeDeletion, nil
-}
-
 // tableNewRangeDelIter takes a tableNewIters and returns a TableNewSpanIter
 // for the rangedel iterator returned by tableNewIters.
 func tableNewRangeDelIter(

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -52,7 +52,7 @@ Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 601B
-Block cache: 6 entries (1009B)  hit rate: 35.7%
+Block cache: 6 entries (1009B)  hit rate: 30.8%
 Table cache: 1 entries (768B)  hit rate: 50.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0


### PR DESCRIPTION
Update the remaining users of tableNewIters.TODO to use the new interface and delete the TODO method.