### PR TITLE
compact: move iterator arguments into a struct

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2771,10 +2771,18 @@ func (d *DB) runCompaction(
 	}
 	c.allowedZeroSeqNum = c.allowZeroSeqNum()
 	iiter = invalidating.MaybeWrapIfInvariants(iiter)
-	iter := compact.NewIter(c.cmp, c.equal, d.merge, iiter, snapshots,
-		c.allowedZeroSeqNum, c.elideTombstone,
-		c.elideRangeTombstone, d.opts.Experimental.IneffectualSingleDeleteCallback,
-		d.opts.Experimental.SingleDeleteInvariantViolationCallback)
+	cfg := compact.IterConfig{
+		Cmp:                                    c.cmp,
+		Equal:                                  c.equal,
+		Merge:                                  d.merge,
+		Snapshots:                              snapshots,
+		AllowZeroSeqNum:                        c.allowedZeroSeqNum,
+		ElideTombstone:                         c.elideTombstone,
+		ElideRangeTombstone:                    c.elideRangeTombstone,
+		IneffectualSingleDeleteCallback:        d.opts.Experimental.IneffectualSingleDeleteCallback,
+		SingleDeleteInvariantViolationCallback: d.opts.Experimental.SingleDeleteInvariantViolationCallback,
+	}
+	iter := compact.NewIter(cfg, iiter)
 
 	var (
 		createdFiles    []base.DiskFileNum

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1136,15 +1136,15 @@ func TestValidateVersionEdit(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			err := validateVersionEdit(tc.ve, tc.vFunc, base.DefaultFormatter)
+			logger := &base.InMemLogger{}
+			validateVersionEdit(tc.ve, tc.vFunc, base.DefaultFormatter, logger)
+			msg := strings.TrimSpace(logger.String())
 			if tc.wantErr != nil {
-				if !errors.Is(err, tc.wantErr) {
-					t.Fatalf("got: %s; want: %s", err, tc.wantErr)
+				if !strings.Contains(msg, tc.wantErr.Error()) {
+					t.Fatalf("got: %q; want: %s", msg, tc.wantErr)
 				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("got %s; wanted no error", err)
+			} else if msg != "" {
+				t.Fatalf("got %s; wanted no error", msg)
 			}
 		})
 	}

--- a/internal/base/logger.go
+++ b/internal/base/logger.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"runtime"
 	"sync"
 
 	"github.com/cockroachdb/pebble/internal/invariants"
@@ -88,8 +87,7 @@ func (b *InMemLogger) Errorf(format string, args ...interface{}) {
 
 // Fatalf is part of the Logger interface.
 func (b *InMemLogger) Fatalf(format string, args ...interface{}) {
-	b.Infof(format, args...)
-	runtime.Goexit()
+	b.Infof("FATAL: "+format, args...)
 }
 
 // LoggerAndTracer defines an interface for logging and tracing.

--- a/internal/compact/iterator_test.go
+++ b/internal/compact/iterator_test.go
@@ -90,26 +90,26 @@ func TestCompactionIter(t *testing.T) {
 			}
 		}
 		resetSingleDelStats()
-		return NewIter(
-			base.DefaultComparer.Compare,
-			base.DefaultComparer.Equal,
-			merge,
-			iter,
-			snapshots,
-			allowZeroSeqnum,
-			func([]byte) bool {
+		cfg := IterConfig{
+			Cmp:             base.DefaultComparer.Compare,
+			Equal:           base.DefaultComparer.Equal,
+			Merge:           merge,
+			Snapshots:       snapshots,
+			AllowZeroSeqNum: allowZeroSeqnum,
+			ElideTombstone: func([]byte) bool {
 				return elideTombstones
 			},
-			func(_, _ []byte) bool {
+			ElideRangeTombstone: func(_, _ []byte) bool {
 				return elideTombstones
 			},
-			func(userKey []byte) {
+			IneffectualSingleDeleteCallback: func(userKey []byte) {
 				ineffectualSingleDeleteKeys = append(ineffectualSingleDeleteKeys, string(userKey))
 			},
-			func(userKey []byte) {
+			SingleDeleteInvariantViolationCallback: func(userKey []byte) {
 				invariantViolationSingleDeleteKeys = append(invariantViolationSingleDeleteKeys, string(userKey))
 			},
-		)
+		}
+		return NewIter(cfg, iter)
 	}
 
 	runTest := func(t *testing.T, file string) {

--- a/internal/compact/snapshots.go
+++ b/internal/compact/snapshots.go
@@ -10,6 +10,8 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 )
 
+// Snapshots stores a list of snapshot sequence numbers, in ascending order.
+//
 // Snapshots are lightweight point-in-time views of the DB state. At its core,
 // a snapshot is a sequence number along with a guarantee from Pebble that it
 // will maintain the view of the database at that sequence number. Part of this


### PR DESCRIPTION
#### compact: move iterator arguments into a struct

We move the compaction iterator parameters to `IterConfig` which gives
us a natural place to include documentation and makes the calling code
cleaner.

#### db: minor cleanup of compaction code

Some cleanup of compaction code:
 - cleaner validation of VersionEdits
 - extract out specialized compaction code (for delete-only, move,
   etc)
