### PR TITLE
internal/keyspan: refactor interleaving iterator tests

### DIFF
--- a/internal/keyspan/interleaving_iter.go
+++ b/internal/keyspan/interleaving_iter.go
@@ -724,7 +724,7 @@ func (i *InterleavingIter) prevPos() {
 		case i.span == nil:
 			panic("withinSpan=true, but i.span == nil")
 		case i.pointKV == nil:
-			i.pos = posKeyspanEnd
+			i.pos = posKeyspanStart
 		default:
 			// i.withinSpan && i.pointKey != nil && i.span != nil
 			if i.cmp(i.span.Start, i.pointKV.K.UserKey) > 0 {

--- a/internal/keyspan/testdata/interleaving_iter
+++ b/internal/keyspan/testdata/interleaving_iter
@@ -1,4 +1,4 @@
-define-rangekeys
+define-spans
 a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 c-d:{(#4,RANGEKEYSET,@3,coconut)}
 e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
@@ -265,7 +265,7 @@ PointKey: q#72057594037927935,RANGEKEYSET
 Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 -
 
-define-rangekeys
+define-spans
 a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 c-d:{(#4,RANGEKEYSET,@3,coconut)}
 e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
@@ -354,7 +354,7 @@ PointKey: h#72057594037927935,RANGEKEYDEL
 Span: h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)}
 -
 
-define-rangekeys
+define-spans
 a-z:{(#5,RANGEKEYSET,@5,apples)}
 ----
 OK
@@ -485,7 +485,7 @@ Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
 
 # Test sparse range keys.
 
-define-rangekeys
+define-spans
 ace-bat:{(#5,RANGEKEYSET,@5,v5)}
 x-z:{(#6,RANGEKEYSET,@6,v5)}
 ----
@@ -606,7 +606,7 @@ Span: <invalid>
 
 # First, Last, SeekLT and SeekGE elide spans without Sets.
 
-define-rangekeys
+define-spans
 b-d:{(#5,RANGEKEYDEL)}
 f-g:{(#6,RANGEKEYDEL)}
 ----
@@ -647,7 +647,7 @@ Span: b-d:{(#5,RANGEKEYDEL)}
 # Test a scenario where Next is out of point keys, the current range key has
 # already been interleaved, and there are no more range keys.
 
-define-rangekeys
+define-spans
 w-y:{(#5,RANGEKEYSET,@1,v1)}
 y-z:{(#5,RANGEKEYDEL)}
 ----
@@ -691,7 +691,7 @@ Span: w-y:{(#5,RANGEKEYSET,@1,v1)}
 -- SpanChanged(nil)
 .
 
-define-rangekeys
+define-spans
 a-z:{(#5,RANGEKEYSET,@1,v1)}
 ----
 OK
@@ -750,7 +750,7 @@ Span: c-z:{(#5,RANGEKEYSET,@1,v1)}
 # Test switching directions after exhausting a range key iterator.
 # Switching reverse to forward iteration.
 
-define-rangekeys
+define-spans
 j-l:{(#3,RANGEKEYSET,@1,v0)}
 ----
 OK
@@ -807,7 +807,7 @@ Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
 # Test switching directions after exhausting a range key iterator.
 # Switching forward to reverse iteration.
 
-define-rangekeys
+define-spans
 j-l:{(#3,RANGEKEYSET,@1,v0)}
 ----
 OK
@@ -850,7 +850,7 @@ Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
 
 # Test a seek that moves the lower bound beyond the upper bound.
 
-define-rangekeys
+define-spans
 a-d:{(#10,RANGEKEYSET,@5,apples)}
 ----
 OK
@@ -882,7 +882,7 @@ seek-lt a
 # iterator's bounds, despite the fact the SeekLT search key is exclusive. See
 # the comment in keyspanSeekLT.
 
-define-rangekeys
+define-spans
 b-f:{(#1,RANGEKEYSET,@1,foo)}
 ----
 OK
@@ -902,7 +902,7 @@ seek-lt d
 
 # Test seek-prefix-ge and its truncation of bounds to the prefix's bounds.
 
-define-rangekeys
+define-spans
 b-d:{(#5,RANGEKEYSET,@1,foo)}
 f-g:{(#6,RANGEKEYSET,@1,foo)}
 ----
@@ -944,7 +944,7 @@ Span: b-d:{(#5,RANGEKEYSET,@1,foo)}
 
 # Test NextPrefix
 
-define-rangekeys
+define-spans
 b-e:{(#5,RANGEKEYSET,@9,foo)}
 f-g:{(#6,RANGEKEYSET,@9,foo)}
 ----

--- a/internal/keyspan/testdata/interleaving_iter_masking
+++ b/internal/keyspan/testdata/interleaving_iter_masking
@@ -14,7 +14,7 @@
 #         a b c d e f g h i j k l m n o p q
 #
 
-define-rangekeys
+define-spans
 e-f:{(#1,RANGEKEYSET,@9,foo)}
 f-h:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@3,bar)}
 h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
@@ -31,12 +31,7 @@ n@4.SET.1
 ----
 OK
 
-set-masking-threshold
-@7
-----
-OK
-
-iter
+iter masking-threshold=@7
 first
 next
 next
@@ -77,7 +72,7 @@ Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
 -- SpanChanged(nil)
 .
 
-iter
+iter masking-threshold=@7
 last
 prev
 prev
@@ -118,7 +113,7 @@ Span: <invalid>
 -- SpanChanged(nil)
 .
 
-iter
+iter masking-threshold=@7
 seek-ge a
 seek-ge c
 seek-ge h
@@ -168,12 +163,7 @@ Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
 # Setting the masking threshold to @9 should result in l@8 being masked by
 # [e,m)@9.
 
-set-masking-threshold
-@9
-----
-OK
-
-iter
+iter masking-threshold=@9
 seek-ge l
 next
 seek-lt l
@@ -204,7 +194,7 @@ PointKey: h#72057594037927935,RANGEKEYSET
 Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
 -
 
-iter
+iter masking-threshold=@9
 seek-ge l
 next
 ----
@@ -218,7 +208,7 @@ PointKey: m#72057594037927935,RANGEKEYSET
 Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
 -
 
-define-rangekeys
+define-spans
 a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
 ----
 OK
@@ -231,16 +221,11 @@ b@2.SET.1
 ----
 OK
 
-set-masking-threshold
-@10
-----
-OK
-
 # Test that both a@3 and b@2 are masked by the rangekey.
 # The unsuffixed point key 'a' and the point key at a higher timestamp 'a@12'
 # are not masked.
 
-iter
+iter masking-threshold=@10
 first
 next
 next
@@ -260,7 +245,7 @@ Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
 -- SpanChanged(nil)
 .
 
-iter
+iter masking-threshold=@10
 last
 prev
 prev
@@ -283,12 +268,12 @@ Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
 # Try the same test, but with a range key that sorts before the masking
 # threshold (eg, higher MVCC timestamp). Nothing should be masked.
 
-define-rangekeys
+define-spans
 a-c:{(#2,RANGEKEYSET,@20,apples)}
 ----
 OK
 
-iter
+iter masking-threshold=@10
 first
 next
 next
@@ -316,7 +301,7 @@ Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
 -- SpanChanged(nil)
 .
 
-iter
+iter masking-threshold=@10
 last
 prev
 prev
@@ -348,12 +333,12 @@ Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
 # Unset, and no Set. Nothing should be masked. No range keys should be surfaced,
 # because there are none.
 
-define-rangekeys
+define-spans
 a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 ----
 OK
 
-iter
+iter masking-threshold=@10
 first
 next
 next
@@ -376,7 +361,7 @@ Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 -- SpanChanged(nil)
 .
 
-iter
+iter masking-threshold=@10
 last
 prev
 prev
@@ -402,7 +387,7 @@ Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 # Test a scenario where a point key is masked in the forward direction, which in
 # turn requires nexting to the next range key as well.
 
-define-rangekeys
+define-spans
 a-c:{(#1,RANGEKEYSET,@5,apples)}
 c-z:{(#1,RANGEKEYSET,@10,bananas)}
 ----
@@ -415,12 +400,7 @@ j@11.SET.3
 ----
 OK
 
-set-masking-threshold
-@20
-----
-OK
-
-iter
+iter masking-threshold=@20
 first
 next
 next
@@ -438,7 +418,7 @@ PointKey: j@11#3,SET
 Span: c-z:{(#1,RANGEKEYSET,@10,bananas)}
 -
 
-iter
+iter masking-threshold=@20
 last
 prev
 prev
@@ -459,7 +439,7 @@ Span: a-c:{(#1,RANGEKEYSET,@5,apples)}
 # Test a scenario where a there's an empty range key, requiring the interleaving
 # iter to call SpanChanged(nil) which should clear the previous mask.
 
-define-rangekeys
+define-spans
 a-c:{(#1,RANGEKEYSET,@10,apples)}
 c-e:{}
 e-f:{(#1,RANGEKEYSET,@5,bananas)}
@@ -473,12 +453,7 @@ d@9.SET.3
 ----
 OK
 
-set-masking-threshold
-@20
-----
-OK
-
-iter
+iter masking-threshold=@20
 seek-ge a
 next
 next


### PR DESCRIPTION
**internal/keyspan: refactor interleaving iterator tests**

Refactor the interleaving iterator tests to take the masking threshold on the
iterator command. Rename 'define-rangekeys' to 'define-spans'.

**internal/keyspan: fix interleaving iter intermediary state**

Previously in InterleavingIter.prevPos when
  a) moving from a point key
  b) the point key was contained within a span
  c) no lesser point key exists
prevPos would improperly move to posKeyspanEnd instead of posKeyspanStart. This
doesn't have any externally visible impact on the behavior of the
InterleavingIter because end boundaries are not interleaved: prevPos is called
again before returning to the user, ensuring we step to posKeyspanStart. With
cases.