### PR TITLE
manifest: fix some tests that have split keys

### DIFF
--- a/internal/manifest/level_metadata_test.go
+++ b/internal/manifest/level_metadata_test.go
@@ -130,6 +130,8 @@ func runIterCmd(t *testing.T, d *datadriven.TestData, iter LevelIterator, verbos
 		default:
 			return fmt.Sprintf("unknown command %q", parts[0])
 		}
+		buf.WriteString(line)
+		buf.WriteString(": ")
 		if m == nil {
 			fmt.Fprintln(&buf, ".")
 		} else {

--- a/internal/manifest/testdata/level_iterator
+++ b/internal/manifest/testdata/level_iterator
@@ -10,12 +10,12 @@ seek-lt z
 seek-ge a
 seek-ge z
 ----
-.
-.
-.
-.
-.
-.
+first: .
+last: .
+seek-lt a: .
+seek-lt z: .
+seek-ge a: .
+seek-ge z: .
 
 define
 [ a.SET.1-b.SET.2 ]
@@ -24,7 +24,7 @@ define
 iter
 last
 ----
-000001:[a#1,SET-b#2,SET]
+last: 000001:[a#1,SET-b#2,SET]
 
 iter
 first
@@ -32,28 +32,28 @@ next
 prev
 prev
 ----
-000001:[a#1,SET-b#2,SET]
-.
-000001:[a#1,SET-b#2,SET]
-.
+first: 000001:[a#1,SET-b#2,SET]
+next: .
+prev: 000001:[a#1,SET-b#2,SET]
+prev: .
 
 iter
 seek-ge a
 seek-ge b
 seek-ge c
 ----
-000001:[a#1,SET-b#2,SET]
-000001:[a#1,SET-b#2,SET]
-.
+seek-ge a: 000001:[a#1,SET-b#2,SET]
+seek-ge b: 000001:[a#1,SET-b#2,SET]
+seek-ge c: .
 
 iter
 seek-lt a
 seek-lt b
 seek-lt z
 ----
-.
-000001:[a#1,SET-b#2,SET]
-000001:[a#1,SET-b#2,SET]
+seek-lt a: .
+seek-lt b: 000001:[a#1,SET-b#2,SET]
+seek-lt z: 000001:[a#1,SET-b#2,SET]
 
 define
 [ b.SET.1-c.SET.2 ]
@@ -65,10 +65,10 @@ seek-ge d
 seek-lt a
 seek-lt z
 ----
-000001:[b#1,SET-c#2,SET]
-.
-.
-000001:[b#1,SET-c#2,SET]
+seek-ge a: 000001:[b#1,SET-c#2,SET]
+seek-ge d: .
+seek-lt a: .
+seek-lt z: 000001:[b#1,SET-c#2,SET]
 
 
 define
@@ -81,10 +81,10 @@ prev
 last
 next
 ----
-000002:[c#3,SET-d#4,SET]
-.
-000003:[e#5,SET-f#6,SET]
-.
+first: 000002:[c#3,SET-d#4,SET]
+prev: .
+last: 000003:[e#5,SET-f#6,SET]
+next: .
 
 iter
 seek-ge a
@@ -93,11 +93,11 @@ seek-ge c
 seek-ge h
 prev
 ----
-000002:[c#3,SET-d#4,SET]
-000002:[c#3,SET-d#4,SET]
-000002:[c#3,SET-d#4,SET]
-.
-000003:[e#5,SET-f#6,SET]
+seek-ge a: 000002:[c#3,SET-d#4,SET]
+seek-ge b: 000002:[c#3,SET-d#4,SET]
+seek-ge c: 000002:[c#3,SET-d#4,SET]
+seek-ge h: .
+prev: 000003:[e#5,SET-f#6,SET]
 
 iter
 seek-lt b
@@ -106,11 +106,11 @@ seek-lt a
 next
 seek-lt z
 ----
-.
-000002:[c#3,SET-d#4,SET]
-.
-000002:[c#3,SET-d#4,SET]
-000003:[e#5,SET-f#6,SET]
+seek-lt b: .
+next: 000002:[c#3,SET-d#4,SET]
+seek-lt a: .
+next: 000002:[c#3,SET-d#4,SET]
+seek-lt z: 000003:[e#5,SET-f#6,SET]
 
 define
 a.SET.1-b.SET.2 c.SET.3-d.SET.4 e.SET.5-f.SET.6 g.SET.7-h.SET.8 [ ]
@@ -122,7 +122,7 @@ seek-lt cat
 first
 last
 ----
-.
-.
-.
-.
+seek-ge cat: .
+seek-lt cat: .
+first: .
+last: .

--- a/internal/manifest/testdata/level_iterator_filtered
+++ b/internal/manifest/testdata/level_iterator_filtered
@@ -9,11 +9,11 @@ seek-ge n
 seek-ge o
 seek-ge p
 ----
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-.
-.
+seek-ge a: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+seek-ge m: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+seek-ge n: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+seek-ge o: .
+seek-ge p: .
 
 iter key-type=ranges
 seek-ge a
@@ -22,11 +22,11 @@ seek-ge n
 seek-ge o
 seek-ge p
 ----
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-.
-.
-.
-.
+seek-ge a: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+seek-ge m: .
+seek-ge n: .
+seek-ge o: .
+seek-ge p: .
 
 iter key-type=points
 seek-lt a
@@ -40,16 +40,16 @@ seek-lt n
 seek-lt o
 seek-lt p
 ----
-.
-.
-.
-.
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+seek-lt a: .
+seek-lt b: .
+seek-lt c: .
+seek-lt j: .
+seek-lt k: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+seek-lt l: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+seek-lt m: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+seek-lt n: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+seek-lt o: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+seek-lt p: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
 
 iter key-type=ranges
 seek-lt a
@@ -63,16 +63,16 @@ seek-lt n
 seek-lt o
 seek-lt p
 ----
-.
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+seek-lt a: .
+seek-lt b: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+seek-lt c: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+seek-lt j: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+seek-lt k: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+seek-lt l: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+seek-lt m: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+seek-lt n: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+seek-lt o: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+seek-lt p: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
 
 iter key-type=points
 seek-lt a
@@ -82,12 +82,12 @@ seek-ge o
 prev
 prev
 ----
-.
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-.
-.
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-.
+seek-lt a: .
+next: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+next: .
+seek-ge o: .
+prev: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+prev: .
 
 iter key-type=ranges
 seek-lt a
@@ -97,12 +97,12 @@ seek-ge m
 prev
 prev
 ----
-.
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-.
-.
-000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
-.
+seek-lt a: .
+next: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+next: .
+seek-ge m: .
+prev: 000000:[a#42,RANGEKEYSET-o#inf,RANGEDEL] seqnums:[0-0] points:[j#0,SET-o#inf,RANGEDEL] ranges:[a#42,RANGEKEYSET-m#inf,RANGEKEYSET]
+prev: .
 
 define
 000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
@@ -123,14 +123,14 @@ seek-ge cantalope
 seek-ge d
 seek-ge dragonfruit
 ----
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
-000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
-000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
-000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
-000002:[e#9,SET-f#2,DEL] seqnums:[0-0] points:[e#9,SET-f#2,DEL]
+seek-ge a: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-ge apple: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-ge b: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-ge banana: 000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
+seek-ge c: 000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
+seek-ge cantalope: 000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
+seek-ge d: 000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
+seek-ge dragonfruit: 000002:[e#9,SET-f#2,DEL] seqnums:[0-0] points:[e#9,SET-f#2,DEL]
 
 iter key-type=points
 seek-lt a
@@ -142,14 +142,14 @@ seek-lt cantalope
 seek-lt d
 seek-lt dragonfruit
 ----
-.
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
-000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
-000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
+seek-lt a: .
+seek-lt apple: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-lt b: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-lt banana: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-lt c: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-lt cantalope: 000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
+seek-lt d: 000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
+seek-lt dragonfruit: 000001:[c#9,SET-d#2,DEL] seqnums:[0-0] points:[c#9,SET-d#2,DEL]
 
 iter key-type=ranges
 seek-ge a
@@ -161,14 +161,14 @@ seek-ge cantalope
 seek-ge d
 seek-ge dragonfruit
 ----
-.
-.
-.
-.
-.
-.
-.
-.
+seek-ge a: .
+seek-ge apple: .
+seek-ge b: .
+seek-ge banana: .
+seek-ge c: .
+seek-ge cantalope: .
+seek-ge d: .
+seek-ge dragonfruit: .
 
 iter key-type=ranges
 seek-lt a
@@ -180,14 +180,14 @@ seek-lt cantalope
 seek-lt d
 seek-lt dragonfruit
 ----
-.
-.
-.
-.
-.
-.
-.
-.
+seek-lt a: .
+seek-lt apple: .
+seek-lt b: .
+seek-lt banana: .
+seek-lt c: .
+seek-lt cantalope: .
+seek-lt d: .
+seek-lt dragonfruit: .
 
 define
 000000:[a#9,SET-b#2,DEL] points:[a#9,SET-b#2,DEL]
@@ -223,29 +223,29 @@ seek-ge k
 seek-ge kiwi
 seek-ge l
 ----
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
-000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
-000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
-.
-.
+seek-ge a: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-ge apple: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-ge b: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-ge banana: 000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+seek-ge c: 000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+seek-ge cantalope: 000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+seek-ge d: 000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+seek-ge dragonfruit: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-ge e: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-ge elderberry: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-ge f: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-ge figs: 000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+seek-ge g: 000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+seek-ge guava: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-ge h: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-ge huckleberry: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-ge i: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-ge incaberry: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-ge j: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-ge jujube: 000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
+seek-ge k: 000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
+seek-ge kiwi: .
+seek-ge l: .
 
 iter key-type=both
 seek-lt a
@@ -272,29 +272,29 @@ seek-lt k
 seek-lt kiwi
 seek-lt l
 ----
-.
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
-000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
-000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
-000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
-000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
+seek-lt a: .
+seek-lt apple: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-lt b: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-lt banana: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-lt c: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-lt cantalope: 000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+seek-lt d: 000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+seek-lt dragonfruit: 000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+seek-lt e: 000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+seek-lt elderberry: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-lt f: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-lt figs: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-lt g: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-lt guava: 000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+seek-lt h: 000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+seek-lt huckleberry: 000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+seek-lt i: 000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+seek-lt incaberry: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-lt j: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-lt jujube: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-lt k: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-lt kiwi: 000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
+seek-lt l: 000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
 
 
 iter key-type=points
@@ -322,29 +322,29 @@ seek-ge k
 seek-ge kiwi
 seek-ge l
 ----
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
-000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
-000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
-000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
-000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
-.
-.
+seek-ge a: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-ge apple: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-ge b: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-ge banana: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-ge c: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-ge cantalope: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-ge d: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-ge dragonfruit: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-ge e: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-ge elderberry: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-ge f: 000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+seek-ge figs: 000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+seek-ge g: 000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+seek-ge guava: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-ge h: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-ge huckleberry: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-ge i: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-ge incaberry: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-ge j: 000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
+seek-ge jujube: 000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
+seek-ge k: 000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
+seek-ge kiwi: .
+seek-ge l: .
 
 iter key-type=points
 seek-lt a
@@ -371,29 +371,29 @@ seek-lt k
 seek-lt kiwi
 seek-lt l
 ----
-.
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
-000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
-000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
-000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
-000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
-000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
+seek-lt a: .
+seek-lt apple: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-lt b: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-lt banana: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-lt c: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-lt cantalope: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-lt d: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-lt dragonfruit: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-lt e: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+seek-lt elderberry: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-lt f: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-lt figs: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-lt g: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-lt guava: 000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+seek-lt h: 000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+seek-lt huckleberry: 000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+seek-lt i: 000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+seek-lt incaberry: 000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+seek-lt j: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-lt jujube: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-lt k: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-lt kiwi: 000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
+seek-lt l: 000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
 
 iter key-type=ranges
 seek-ge a
@@ -420,29 +420,29 @@ seek-ge k
 seek-ge kiwi
 seek-ge l
 ----
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-.
-.
-.
-.
+seek-ge a: 000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+seek-ge apple: 000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+seek-ge b: 000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+seek-ge banana: 000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+seek-ge c: 000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+seek-ge cantalope: 000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+seek-ge d: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-ge dragonfruit: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-ge e: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-ge elderberry: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-ge f: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-ge figs: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-ge g: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-ge guava: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-ge h: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-ge huckleberry: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-ge i: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-ge incaberry: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-ge j: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-ge jujube: .
+seek-ge k: .
+seek-ge kiwi: .
+seek-ge l: .
 
 iter key-type=ranges
 seek-lt a
@@ -469,29 +469,29 @@ seek-lt k
 seek-lt kiwi
 seek-lt l
 ----
-.
-.
-.
-.
-.
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-lt a: .
+seek-lt apple: .
+seek-lt b: .
+seek-lt banana: .
+seek-lt c: .
+seek-lt cantalope: 000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+seek-lt d: 000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+seek-lt dragonfruit: 000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+seek-lt e: 000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+seek-lt elderberry: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-lt f: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-lt figs: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-lt g: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-lt guava: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-lt h: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-lt huckleberry: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-lt i: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+seek-lt incaberry: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-lt j: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-lt jujube: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-lt k: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-lt kiwi: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+seek-lt l: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
 
 iter key-type=both
 first
@@ -502,13 +502,13 @@ next
 next
 next
 ----
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
-.
+first: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+next: 000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+next: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+next: 000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+next: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+next: 000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
+next: .
 
 iter key-type=points
 first
@@ -518,12 +518,12 @@ next
 next
 next
 ----
-000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
-.
+first: 000000:[a#9,SET-b#2,DEL] seqnums:[0-0] points:[a#9,SET-b#2,DEL]
+next: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+next: 000003:[g#9,SET-g#2,DEL] seqnums:[0-0] points:[g#9,SET-g#2,DEL]
+next: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+next: 000005:[k#9,SET-k#2,DEL] seqnums:[0-0] points:[k#9,SET-k#2,DEL]
+next: .
 
 iter key-type=ranges
 first
@@ -531,7 +531,7 @@ next
 next
 next
 ----
-000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
-000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
-000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
-.
+first: 000001:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[0-0] ranges:[c#9,RANGEKEYSET-d#inf,RANGEKEYSET]
+next: 000002:[e#9,SET-f#inf,RANGEKEYDEL] seqnums:[0-0] points:[e#9,SET-elderberry#2,DEL] ranges:[e#3,RANGEKEYSET-f#inf,RANGEKEYDEL]
+next: 000004:[i#9,RANGEKEYSET-j#2,RANGEKEYSET] seqnums:[0-0] points:[incaberry#9,SET-incaettry#9,SET] ranges:[i#9,RANGEKEYSET-j#2,RANGEKEYSET]
+next: .

--- a/internal/manifest/testdata/overlaps
+++ b/internal/manifest/testdata/overlaps
@@ -4,37 +4,36 @@ L0:
   000701:[c#7018,SET-f#7019,SET]
   000702:[f#7028,SET-g#7029,SET]
   000703:[x#7038,SET-y#7039,SET]
-  000704:[n#7048,SET-p#7049,SET]
-  000705:[p#7058,SET-p#7059,SET]
-  000706:[p#7068,SET-u#7069,SET]
+  000704:[n#7048,SET-o#7049,SET]
+  000705:[p#7059,SET-p#7058,SET]
+  000706:[q#7068,SET-u#7069,SET]
   000707:[r#7078,SET-s#7079,SET]
 L1:
   000710:[a#7140,SET-d#inf,RANGEDEL]
   000711:[d#7108,SET-g#7109,SET]
-  000712:[g#7118,SET-j#7119,SET]
-  000713:[n#7128,SET-p#7129,SET]
-  000714:[p#7148,SET-p#7149,SET]
-  000715:[p#7138,SET-u#7139,SET]
+  000712:[h#7118,SET-j#7119,SET]
+  000713:[n#7128,SET-o#7129,SET]
+  000714:[p#7149,SET-p#7148,SET]
+  000715:[q#7138,SET-u#7139,SET]
 ----
-L0.3:
-  000704:[n#7048,SET-p#7049,SET]
 L0.2:
   000700:[b#7008,SET-e#7009,SET]
-  000705:[p#7058,SET-p#7059,SET]
 L0.1:
   000701:[c#7018,SET-f#7019,SET]
-  000706:[p#7068,SET-u#7069,SET]
+  000706:[q#7068,SET-u#7069,SET]
 L0.0:
   000702:[f#7028,SET-g#7029,SET]
+  000704:[n#7048,SET-o#7049,SET]
+  000705:[p#7059,SET-p#7058,SET]
   000707:[r#7078,SET-s#7079,SET]
   000703:[x#7038,SET-y#7039,SET]
 L1:
   000710:[a#7140,SET-d#inf,RANGEDEL]
   000711:[d#7108,SET-g#7109,SET]
-  000712:[g#7118,SET-j#7119,SET]
-  000713:[n#7128,SET-p#7129,SET]
-  000714:[p#7148,SET-p#7149,SET]
-  000715:[p#7138,SET-u#7139,SET]
+  000712:[h#7118,SET-j#7119,SET]
+  000713:[n#7128,SET-o#7129,SET]
+  000714:[p#7149,SET-p#7148,SET]
+  000715:[q#7138,SET-u#7139,SET]
 
 # Level 0
 
@@ -77,9 +76,9 @@ overlaps level=0 start=a end=z exclusive-end=false
 000701:[c#7018,SET-f#7019,SET]
 000702:[f#7028,SET-g#7029,SET]
 000703:[x#7038,SET-y#7039,SET]
-000704:[n#7048,SET-p#7049,SET]
-000705:[p#7058,SET-p#7059,SET]
-000706:[p#7068,SET-u#7069,SET]
+000704:[n#7048,SET-o#7049,SET]
+000705:[p#7059,SET-p#7058,SET]
+000706:[q#7068,SET-u#7069,SET]
 000707:[r#7078,SET-s#7079,SET]
 
 overlaps level=0 start=c end=e exclusive-end=false
@@ -107,14 +106,11 @@ overlaps level=0 start=b end=f exclusive-end=true
 
 overlaps level=0 start=g end=n exclusive-end=false
 ----
-7 files:
+4 files:
 000700:[b#7008,SET-e#7009,SET]
 000701:[c#7018,SET-f#7019,SET]
 000702:[f#7028,SET-g#7029,SET]
-000704:[n#7048,SET-p#7049,SET]
-000705:[p#7058,SET-p#7059,SET]
-000706:[p#7068,SET-u#7069,SET]
-000707:[r#7078,SET-s#7079,SET]
+000704:[n#7048,SET-o#7049,SET]
 
 overlaps level=0 start=h end=i exclusive-end=false
 ----
@@ -122,18 +118,15 @@ overlaps level=0 start=h end=i exclusive-end=false
 
 overlaps level=0 start=h end=o exclusive-end=false
 ----
-4 files:
-000704:[n#7048,SET-p#7049,SET]
-000705:[p#7058,SET-p#7059,SET]
-000706:[p#7068,SET-u#7069,SET]
-000707:[r#7078,SET-s#7079,SET]
+1 files:
+000704:[n#7048,SET-o#7049,SET]
 
 overlaps level=0 start=h end=u exclusive-end=false
 ----
 4 files:
-000704:[n#7048,SET-p#7049,SET]
-000705:[p#7058,SET-p#7059,SET]
-000706:[p#7068,SET-u#7069,SET]
+000704:[n#7048,SET-o#7049,SET]
+000705:[p#7059,SET-p#7058,SET]
+000706:[q#7068,SET-u#7069,SET]
 000707:[r#7078,SET-s#7079,SET]
 
 overlaps level=0 start=k end=l exclusive-end=false
@@ -142,97 +135,78 @@ overlaps level=0 start=k end=l exclusive-end=false
 
 overlaps level=0 start=k end=o exclusive-end=false
 ----
-4 files:
-000704:[n#7048,SET-p#7049,SET]
-000705:[p#7058,SET-p#7059,SET]
-000706:[p#7068,SET-u#7069,SET]
-000707:[r#7078,SET-s#7079,SET]
+1 files:
+000704:[n#7048,SET-o#7049,SET]
 
 overlaps level=0 start=k end=p exclusive-end=false
 ----
-4 files:
-000704:[n#7048,SET-p#7049,SET]
-000705:[p#7058,SET-p#7059,SET]
-000706:[p#7068,SET-u#7069,SET]
-000707:[r#7078,SET-s#7079,SET]
+2 files:
+000704:[n#7048,SET-o#7049,SET]
+000705:[p#7059,SET-p#7058,SET]
 
 overlaps level=0 start=n end=o exclusive-end=false
 ----
-4 files:
-000704:[n#7048,SET-p#7049,SET]
-000705:[p#7058,SET-p#7059,SET]
-000706:[p#7068,SET-u#7069,SET]
-000707:[r#7078,SET-s#7079,SET]
+1 files:
+000704:[n#7048,SET-o#7049,SET]
 
 overlaps level=0 start=n end=z exclusive-end=false
 ----
 5 files:
 000703:[x#7038,SET-y#7039,SET]
-000704:[n#7048,SET-p#7049,SET]
-000705:[p#7058,SET-p#7059,SET]
-000706:[p#7068,SET-u#7069,SET]
+000704:[n#7048,SET-o#7049,SET]
+000705:[p#7059,SET-p#7058,SET]
+000706:[q#7068,SET-u#7069,SET]
 000707:[r#7078,SET-s#7079,SET]
 
 overlaps level=0 start=o end=z exclusive-end=false
 ----
 5 files:
 000703:[x#7038,SET-y#7039,SET]
-000704:[n#7048,SET-p#7049,SET]
-000705:[p#7058,SET-p#7059,SET]
-000706:[p#7068,SET-u#7069,SET]
+000704:[n#7048,SET-o#7049,SET]
+000705:[p#7059,SET-p#7058,SET]
+000706:[q#7068,SET-u#7069,SET]
 000707:[r#7078,SET-s#7079,SET]
 
 overlaps level=0 start=p end=z exclusive-end=false
 ----
-5 files:
+4 files:
 000703:[x#7038,SET-y#7039,SET]
-000704:[n#7048,SET-p#7049,SET]
-000705:[p#7058,SET-p#7059,SET]
-000706:[p#7068,SET-u#7069,SET]
+000705:[p#7059,SET-p#7058,SET]
+000706:[q#7068,SET-u#7069,SET]
 000707:[r#7078,SET-s#7079,SET]
 
 overlaps level=0 start=q end=z exclusive-end=false
 ----
-5 files:
+3 files:
 000703:[x#7038,SET-y#7039,SET]
-000704:[n#7048,SET-p#7049,SET]
-000705:[p#7058,SET-p#7059,SET]
-000706:[p#7068,SET-u#7069,SET]
+000706:[q#7068,SET-u#7069,SET]
 000707:[r#7078,SET-s#7079,SET]
 
 overlaps level=0 start=r end=s exclusive-end=false
 ----
-4 files:
-000704:[n#7048,SET-p#7049,SET]
-000705:[p#7058,SET-p#7059,SET]
-000706:[p#7068,SET-u#7069,SET]
+2 files:
+000706:[q#7068,SET-u#7069,SET]
 000707:[r#7078,SET-s#7079,SET]
 
 overlaps level=0 start=r end=z exclusive-end=false
 ----
-5 files:
+3 files:
 000703:[x#7038,SET-y#7039,SET]
-000704:[n#7048,SET-p#7049,SET]
-000705:[p#7058,SET-p#7059,SET]
-000706:[p#7068,SET-u#7069,SET]
+000706:[q#7068,SET-u#7069,SET]
 000707:[r#7078,SET-s#7079,SET]
 
 overlaps level=0 start=s end=z exclusive-end=false
 ----
-5 files:
+3 files:
 000703:[x#7038,SET-y#7039,SET]
-000704:[n#7048,SET-p#7049,SET]
-000705:[p#7058,SET-p#7059,SET]
-000706:[p#7068,SET-u#7069,SET]
+000706:[q#7068,SET-u#7069,SET]
 000707:[r#7078,SET-s#7079,SET]
 
 overlaps level=0 start=u end=z exclusive-end=false
 ----
-5 files:
+3 files:
 000703:[x#7038,SET-y#7039,SET]
-000704:[n#7048,SET-p#7049,SET]
-000705:[p#7058,SET-p#7059,SET]
-000706:[p#7068,SET-u#7069,SET]
+000706:[q#7068,SET-u#7069,SET]
 000707:[r#7078,SET-s#7079,SET]
 
 overlaps level=0 start=y end=z exclusive-end=false
@@ -270,10 +244,9 @@ overlaps level=1 start=a end=e exclusive-end=false
 
 overlaps level=1 start=a end=g exclusive-end=false
 ----
-3 files:
+2 files:
 000710:[a#7140,SET-d#inf,RANGEDEL]
 000711:[d#7108,SET-g#7109,SET]
-000712:[g#7118,SET-j#7119,SET]
 
 overlaps level=1 start=a end=g exclusive-end=true
 ----
@@ -286,20 +259,20 @@ overlaps level=1 start=a end=z exclusive-end=false
 6 files:
 000710:[a#7140,SET-d#inf,RANGEDEL]
 000711:[d#7108,SET-g#7109,SET]
-000712:[g#7118,SET-j#7119,SET]
-000713:[n#7128,SET-p#7129,SET]
-000714:[p#7148,SET-p#7149,SET]
-000715:[p#7138,SET-u#7139,SET]
+000712:[h#7118,SET-j#7119,SET]
+000713:[n#7128,SET-o#7129,SET]
+000714:[p#7149,SET-p#7148,SET]
+000715:[q#7138,SET-u#7139,SET]
 
 overlaps level=1 start=a end=z exclusive-end=true
 ----
 6 files:
 000710:[a#7140,SET-d#inf,RANGEDEL]
 000711:[d#7108,SET-g#7109,SET]
-000712:[g#7118,SET-j#7119,SET]
-000713:[n#7128,SET-p#7129,SET]
-000714:[p#7148,SET-p#7149,SET]
-000715:[p#7138,SET-u#7139,SET]
+000712:[h#7118,SET-j#7119,SET]
+000713:[n#7128,SET-o#7129,SET]
+000714:[p#7149,SET-p#7148,SET]
+000715:[q#7138,SET-u#7139,SET]
 
 overlaps level=1 start=c end=e exclusive-end=false
 ----
@@ -316,38 +289,38 @@ overlaps level=1 start=g end=n exclusive-end=false
 ----
 3 files:
 000711:[d#7108,SET-g#7109,SET]
-000712:[g#7118,SET-j#7119,SET]
-000713:[n#7128,SET-p#7129,SET]
+000712:[h#7118,SET-j#7119,SET]
+000713:[n#7128,SET-o#7129,SET]
 
 overlaps level=1 start=h end=i exclusive-end=false
 ----
 1 files:
-000712:[g#7118,SET-j#7119,SET]
+000712:[h#7118,SET-j#7119,SET]
 
 overlaps level=1 start=h end=n exclusive-end=true
 ----
 1 files:
-000712:[g#7118,SET-j#7119,SET]
+000712:[h#7118,SET-j#7119,SET]
 
 overlaps level=1 start=h end=n exclusive-end=false
 ----
 2 files:
-000712:[g#7118,SET-j#7119,SET]
-000713:[n#7128,SET-p#7129,SET]
+000712:[h#7118,SET-j#7119,SET]
+000713:[n#7128,SET-o#7129,SET]
 
 overlaps level=1 start=h end=o exclusive-end=false
 ----
 2 files:
-000712:[g#7118,SET-j#7119,SET]
-000713:[n#7128,SET-p#7129,SET]
+000712:[h#7118,SET-j#7119,SET]
+000713:[n#7128,SET-o#7129,SET]
 
 overlaps level=1 start=h end=u exclusive-end=false
 ----
 4 files:
-000712:[g#7118,SET-j#7119,SET]
-000713:[n#7128,SET-p#7129,SET]
-000714:[p#7148,SET-p#7149,SET]
-000715:[p#7138,SET-u#7139,SET]
+000712:[h#7118,SET-j#7119,SET]
+000713:[n#7128,SET-o#7129,SET]
+000714:[p#7149,SET-p#7148,SET]
+000715:[q#7138,SET-u#7139,SET]
 
 overlaps level=1 start=k end=l exclusive-end=false
 ----
@@ -356,70 +329,68 @@ overlaps level=1 start=k end=l exclusive-end=false
 overlaps level=1 start=k end=o exclusive-end=false
 ----
 1 files:
-000713:[n#7128,SET-p#7129,SET]
+000713:[n#7128,SET-o#7129,SET]
 
 overlaps level=1 start=k end=p exclusive-end=false
 ----
-3 files:
-000713:[n#7128,SET-p#7129,SET]
-000714:[p#7148,SET-p#7149,SET]
-000715:[p#7138,SET-u#7139,SET]
+2 files:
+000713:[n#7128,SET-o#7129,SET]
+000714:[p#7149,SET-p#7148,SET]
 
 overlaps level=1 start=k end=p exclusive-end=true
 ----
 1 files:
-000713:[n#7128,SET-p#7129,SET]
+000713:[n#7128,SET-o#7129,SET]
 
 overlaps level=1 start=n end=o exclusive-end=false
 ----
 1 files:
-000713:[n#7128,SET-p#7129,SET]
+000713:[n#7128,SET-o#7129,SET]
 
 overlaps level=1 start=n end=z exclusive-end=false
 ----
 3 files:
-000713:[n#7128,SET-p#7129,SET]
-000714:[p#7148,SET-p#7149,SET]
-000715:[p#7138,SET-u#7139,SET]
+000713:[n#7128,SET-o#7129,SET]
+000714:[p#7149,SET-p#7148,SET]
+000715:[q#7138,SET-u#7139,SET]
 
 overlaps level=1 start=o end=z exclusive-end=false
 ----
 3 files:
-000713:[n#7128,SET-p#7129,SET]
-000714:[p#7148,SET-p#7149,SET]
-000715:[p#7138,SET-u#7139,SET]
+000713:[n#7128,SET-o#7129,SET]
+000714:[p#7149,SET-p#7148,SET]
+000715:[q#7138,SET-u#7139,SET]
 
 overlaps level=1 start=p end=z exclusive-end=false
 ----
-3 files:
-000713:[n#7128,SET-p#7129,SET]
-000714:[p#7148,SET-p#7149,SET]
-000715:[p#7138,SET-u#7139,SET]
+2 files:
+000714:[p#7149,SET-p#7148,SET]
+000715:[q#7138,SET-u#7139,SET]
 
 overlaps level=1 start=q end=z exclusive-end=false
 ----
 1 files:
-000715:[p#7138,SET-u#7139,SET]
+000715:[q#7138,SET-u#7139,SET]
 
 overlaps level=1 start=r end=s exclusive-end=false
 ----
 1 files:
-000715:[p#7138,SET-u#7139,SET]
+000715:[q#7138,SET-u#7139,SET]
 
 overlaps level=1 start=r end=z exclusive-end=false
 ----
 1 files:
-000715:[p#7138,SET-u#7139,SET]
+000715:[q#7138,SET-u#7139,SET]
 
 overlaps level=1 start=s end=z exclusive-end=false
 ----
 1 files:
-000715:[p#7138,SET-u#7139,SET]
+000715:[q#7138,SET-u#7139,SET]
 
 overlaps level=1 start=u end=z exclusive-end=false
 ----
 1 files:
-000715:[p#7138,SET-u#7139,SET]
+000715:[q#7138,SET-u#7139,SET]
 
 overlaps level=1 start=y end=z exclusive-end=false
 ----

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -1249,7 +1249,11 @@ func ParseVersionDebug(comparer *base.Comparer, flushSplitBytes int64, s string)
 	// partial order that represents newest to oldest. Reverse the order of L0
 	// files to ensure we construct the same sublevels.
 	slices.Reverse(files[0])
-	return NewVersion(comparer, flushSplitBytes, files), nil
+	v := NewVersion(comparer, flushSplitBytes, files)
+	if err := v.CheckOrdering(); err != nil {
+		return nil, err
+	}
+	return v, nil
 }
 
 // Refs returns the number of references to the version.

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -188,25 +188,25 @@ func TestContains(t *testing.T) {
 	m11 := newFileMeta(
 		711,
 		1,
-		base.ParseInternalKey("g.SET.7118"),
+		base.ParseInternalKey("h.SET.7118"),
 		base.ParseInternalKey("j.SET.7119"),
 	)
 	m12 := newFileMeta(
 		712,
 		1,
 		base.ParseInternalKey("n.SET.7128"),
-		base.ParseInternalKey("p.SET.7129"),
+		base.ParseInternalKey("o.SET.7129"),
 	)
 	m13 := newFileMeta(
 		713,
 		1,
-		base.ParseInternalKey("p.SET.7148"),
 		base.ParseInternalKey("p.SET.7149"),
+		base.ParseInternalKey("p.SET.7148"),
 	)
 	m14 := newFileMeta(
 		714,
 		1,
-		base.ParseInternalKey("p.SET.7138"),
+		base.ParseInternalKey("q.SET.7138"),
 		base.ParseInternalKey("u.SET.7139"),
 	)
 
@@ -217,6 +217,7 @@ func TestContains(t *testing.T) {
 		},
 		cmp: testkeys.Comparer,
 	}
+	require.NoError(t, v.CheckOrdering())
 
 	testCases := []struct {
 		level int

--- a/testdata/download_cursor
+++ b/testdata/download_cursor
@@ -4,16 +4,16 @@
 # Basic test to verify cursor iteration.
 define
 L0:
-  1(101):[a#1,SET-a#1,SET] seqnums:[3-3]
-  2(102):[b#1,SET-d#1,SET] seqnums:[3-3]
+  1(101):[a#1,SET-a#1,SET] seqnums:[5-5]
+  2(102):[b#1,SET-d#1,SET] seqnums:[4-4]
   3(103):[e#1,SET-g#1,SET] seqnums:[3-3]
   4(104):[a#1,SET-c#1,SET] seqnums:[2-2]
 L2:
   5(105):[b#1,SET-c#1,SET]
 ----
 L0.1:
-  000001(000101):[a#1,SET-a#1,SET] seqnums:[3-3] points:[a#1,SET-a#1,SET]
-  000002(000102):[b#1,SET-d#1,SET] seqnums:[3-3] points:[b#1,SET-d#1,SET]
+  000001(000101):[a#1,SET-a#1,SET] seqnums:[5-5] points:[a#1,SET-a#1,SET]
+  000002(000102):[b#1,SET-d#1,SET] seqnums:[4-4] points:[b#1,SET-d#1,SET]
 L0.0:
   000004(000104):[a#1,SET-c#1,SET] seqnums:[2-2] points:[a#1,SET-c#1,SET]
   000003(000103):[e#1,SET-g#1,SET] seqnums:[3-3] points:[e#1,SET-g#1,SET]
@@ -49,16 +49,16 @@ iterate:
 # Verify that non-external files are skipped.
 define
 L0:
-  1:[a#1,SET-a#1,SET] seqnums:[3-3]
-  2(102):[b#1,SET-d#1,SET] seqnums:[3-3]
+  1:[a#1,SET-a#1,SET] seqnums:[5-5]
+  2(102):[b#1,SET-d#1,SET] seqnums:[4-4]
   3:[e#1,SET-g#1,SET] seqnums:[3-3]
   4(104):[a#1,SET-c#1,SET] seqnums:[2-2]
 L2:
   5(105):[b#1,SET-c#1,SET] seqnums:[1-1]
 ----
 L0.1:
-  000001:[a#1,SET-a#1,SET] seqnums:[3-3] points:[a#1,SET-a#1,SET]
-  000002(000102):[b#1,SET-d#1,SET] seqnums:[3-3] points:[b#1,SET-d#1,SET]
+  000001:[a#1,SET-a#1,SET] seqnums:[5-5] points:[a#1,SET-a#1,SET]
+  000002(000102):[b#1,SET-d#1,SET] seqnums:[4-4] points:[b#1,SET-d#1,SET]
 L0.0:
   000004(000104):[a#1,SET-c#1,SET] seqnums:[2-2] points:[a#1,SET-c#1,SET]
   000003:[e#1,SET-g#1,SET] seqnums:[3-3] points:[e#1,SET-g#1,SET]


### PR DESCRIPTION
#### manifest: fix some tests that have split keys

Fix some tests that have split keys which are no longer allowed. Add
`CheckOrdering` calls to check validity going forward.

#### manifest: show iterator command in output

This makes it easier to read the output of tests with many iterator
commands.

