### PR TITLE
db: remove compaction.disableSpanElision

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -745,7 +745,6 @@ func TestCompactionTransform(t *testing.T) {
 		case "transform":
 			var snapshots []uint64
 			var keyRanges []manifest.UserKeyRange
-			disableElision := td.HasArg("disable-elision")
 			td.MaybeScanArgs(t, "snapshots", &snapshots)
 			if arg, ok := td.Arg("in-use-key-ranges"); ok {
 				for _, keyRange := range arg.Vals {
@@ -768,10 +767,9 @@ func TestCompactionTransform(t *testing.T) {
 			}
 			var outSpan keyspan.Span
 			c := compaction{
-				cmp:                base.DefaultComparer.Compare,
-				comparer:           base.DefaultComparer,
-				disableSpanElision: disableElision,
-				inuseKeyRanges:     keyRanges,
+				cmp:            base.DefaultComparer.Compare,
+				comparer:       base.DefaultComparer,
+				inuseKeyRanges: keyRanges,
 			}
 			transformer := rangeKeyCompactionTransform(base.DefaultComparer.Equal, snapshots, c.elideRangeTombstone)
 			if err := transformer.Transform(base.DefaultComparer.Compare, span, &outSpan); err != nil {

--- a/data_test.go
+++ b/data_test.go
@@ -882,7 +882,6 @@ func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) 
 		if err != nil {
 			return err
 		}
-		c.disableSpanElision = true
 		// NB: define allows the test to exactly specify which keys go
 		// into which sstables. If the test has a small target file
 		// size to test grandparent limits, etc, the maxOutputFileSize

--- a/testdata/compaction_transform
+++ b/testdata/compaction_transform
@@ -1,27 +1,27 @@
 
 # Test snapshot striping and coalescing.
 
-transform snapshots=(5,10,15) disable-elision
+transform snapshots=(5,10,15) in-use-key-ranges=(a-z)
 a-c:{(#9,RANGEKEYSET,@3,foo5) (#4,RANGEKEYSET,@3,foo3) (#3,RANGEKEYSET,@3,foo2)}
 ----
 a-c:{(#9,RANGEKEYSET,@3,foo5) (#4,RANGEKEYSET,@3,foo3)}
 
-transform snapshots=(5,10,15) disable-elision
+transform snapshots=(5,10,15) in-use-key-ranges=(a-z)
 a-c:{(#9,RANGEKEYUNSET,@3) (#8,RANGEKEYSET,@3,foo5) (#4,RANGEKEYSET,@3,foo3) (#3,RANGEKEYSET,@3,foo2)}
 ----
 a-c:{(#9,RANGEKEYUNSET,@3) (#4,RANGEKEYSET,@3,foo3)}
 
-transform snapshots=(5,10,15) disable-elision
+transform snapshots=(5,10,15) in-use-key-ranges=(a-z)
 a-c:{(#9,RANGEKEYDEL) (#8,RANGEKEYSET,@3,foo5) (#4,RANGEKEYSET,@3,foo3) (#3,RANGEKEYSET,@3,foo2)}
 ----
 a-c:{(#9,RANGEKEYDEL) (#4,RANGEKEYSET,@3,foo3)}
 
-transform snapshots=(5,10,15) disable-elision
+transform snapshots=(5,10,15) in-use-key-ranges=(a-z)
 a-c:{(#11,RANGEKEYDEL) (#8,RANGEKEYSET,@3,foo5) (#4,RANGEKEYSET,@3,foo3) (#3,RANGEKEYSET,@3,foo2)}
 ----
 a-c:{(#11,RANGEKEYDEL) (#8,RANGEKEYSET,@3,foo5) (#4,RANGEKEYSET,@3,foo3)}
 
-transform disable-elision
+transform in-use-key-ranges=(a-z)
 a-c:{(#11,RANGEKEYDEL) (#8,RANGEKEYSET,@3,foo5) (#4,RANGEKEYSET,@3,foo3) (#3,RANGEKEYSET,@3,foo2)}
 ----
 a-c:{(#11,RANGEKEYDEL)}
@@ -110,7 +110,7 @@ a-c:{(#11,RANGEKEYSET,@3,foo5) (#11,RANGEKEYUNSET,@3) (#11,RANGEKEYDEL)}
 ----
 a-c:{(#11,RANGEKEYSET,@3,foo5) (#11,RANGEKEYDEL)}
 
-transform disable-elision
+transform in-use-key-ranges=(a-z)
 a-c:{(#11,RANGEKEYSET,@3,foo5) (#11,RANGEKEYUNSET,@3) (#11,RANGEKEYDEL)
 ----
 a-c:{(#11,RANGEKEYSET,@3,foo5) (#11,RANGEKEYDEL)}


### PR DESCRIPTION
We remove this field which is not very useful (tests can just pass a
large in-use key range instead).

We also consult `inUseEntireRange` in `elideRangeTombstone` which
seems like an omission. We also simplify `allowZeroSeqNum()`.