### PR TITLE
db: simplify mergingIter direction switching

### DIFF
--- a/level_iter.go
+++ b/level_iter.go
@@ -614,6 +614,17 @@ func (l *levelIter) verify(kv *base.InternalKV) *base.InternalKV {
 		if l.upper != nil && kv != l.largestBoundary && l.cmp(kv.K.UserKey, l.upper) > 0 {
 			l.logger.Fatalf("levelIter %s: upper bound violation: %s > %s\n%s", l.level, kv, l.upper, debug.Stack())
 		}
+
+		if l.boundaryContext != nil && l.boundaryContext.isSyntheticIterBoundsKey {
+			switch {
+			case !kv.K.IsExclusiveSentinel():
+				l.logger.Fatalf("levelIter %s: returning %s and isSyntheticIterBounds=true", l.level, kv)
+			case l.lower == nil && l.upper == nil:
+				// If we knew the direction of iteration, we could verify that
+				// specifically the corresponding bound is non-nil.
+				l.logger.Fatalf("levelIter %s: returning %s but has no bounds", l.level, kv)
+			}
+		}
 	}
 	return kv
 }


### PR DESCRIPTION
The mergingIter logic for switching the direction of the heap has special handling for the "synthetic iterator bounds" that the levelIter interleaves when it encounters the largest key in a table. These conditionals were more complicated and involved than they needed to be. The isSyntheticIterBoundsKey flag implies that the current key is an exclusive sentinel and that there's a bound in the previously-active direction of iteration.