### PR TITLE
github: automatically add storage team to PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cockroachdb/storage


### PR DESCRIPTION
Add a CODEOWNERS file that sets the storage team as a reviewer.