### PR TITLE
db: fix levelIter tests to obey bounds

### DIFF
--- a/level_iter.go
+++ b/level_iter.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"runtime/debug"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/keyspan"
@@ -630,6 +631,10 @@ func (l *levelIter) verify(kv *base.InternalKV) *base.InternalKV {
 }
 
 func (l *levelIter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
+	if invariants.Enabled && l.lower != nil && l.cmp(key, l.lower) < 0 {
+		panic(errors.AssertionFailedf("levelIter SeekGE to key %q violates lower bound %q", key, l.lower))
+	}
+
 	l.err = nil // clear cached iteration error
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
@@ -653,6 +658,10 @@ func (l *levelIter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV 
 }
 
 func (l *levelIter) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) *base.InternalKV {
+	if invariants.Enabled && l.lower != nil && l.cmp(key, l.lower) < 0 {
+		panic(errors.AssertionFailedf("levelIter SeekGE to key %q violates lower bound %q", key, l.lower))
+	}
+
 	l.err = nil // clear cached iteration error
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
@@ -722,6 +731,10 @@ func (l *levelIter) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) *ba
 }
 
 func (l *levelIter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
+	if invariants.Enabled && l.upper != nil && l.cmp(key, l.upper) > 0 {
+		panic(errors.AssertionFailedf("levelIter SeekLT to key %q violates upper bound %q", key, l.upper))
+	}
+
 	l.err = nil // clear cached iteration error
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
@@ -740,6 +753,10 @@ func (l *levelIter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV 
 }
 
 func (l *levelIter) First() *base.InternalKV {
+	if invariants.Enabled && l.lower != nil {
+		panic(errors.AssertionFailedf("levelIter First called while lower bound %q is set", l.lower))
+	}
+
 	l.err = nil // clear cached iteration error
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
@@ -758,6 +775,10 @@ func (l *levelIter) First() *base.InternalKV {
 }
 
 func (l *levelIter) Last() *base.InternalKV {
+	if invariants.Enabled && l.upper != nil {
+		panic(errors.AssertionFailedf("levelIter Last called while upper bound %q is set", l.upper))
+	}
+
 	l.err = nil // clear cached iteration error
 	if l.boundaryContext != nil {
 		l.boundaryContext.isSyntheticIterBoundsKey = false

--- a/testdata/level_iter
+++ b/testdata/level_iter
@@ -161,24 +161,20 @@ d#4,SET:4
 
 iter lower=a
 seek-ge a
-first
 ----
-a#1,SET:1
 a#1,SET:1
 
 iter
 set-bounds lower=a
 seek-ge a
-first
 ----
-a#1,SET:1
 a#1,SET:1
 
 iter
 set-bounds lower=dd upper=f
-seek-lt dc
+seek-lt dd
 set-bounds lower=a upper=f
-seek-lt dc
+seek-lt dd
 prev
 prev
 prev
@@ -227,127 +223,91 @@ load c lower=b upper=e
 ----
 [,]
 
-# levelIter only checks lower bound when loading sstables.
 iter lower=b
-seek-ge a
-first
+seek-ge b
 ----
-a#1,SET:1
-a#1,SET:1
+b#2,SET:2
 
 iter lower=c
-seek-ge a
-first
+seek-ge c
 ----
-c#3,SET:3
 c#3,SET:3
 
 iter
 set-bounds lower=b
-seek-ge a
-first
+seek-ge b
 ----
-a#1,SET:1
-a#1,SET:1
+b#2,SET:2
 
 iter
 set-bounds lower=c
-seek-ge a
-first
+seek-ge c
 ----
-c#3,SET:3
 c#3,SET:3
 
-# levelIter only checks lower bound when loading sstables.
 iter lower=d
-seek-ge a
-first
+seek-ge d
 ----
-c#3,SET:3
-c#3,SET:3
+d#4,SET:4
 
 iter lower=e
-seek-ge a
-first
+seek-ge e
 ----
-.
 .
 
 iter upper=e
 seek-lt e
-last
 ----
-dd#5,SET:5
 dd#5,SET:5
 
 iter
 set-bounds lower=d
-seek-ge a
-first
+seek-ge d
 ----
-c#3,SET:3
-c#3,SET:3
+d#4,SET:4
 
 iter
 set-bounds lower=e
-seek-ge a
-first
+seek-ge e
 ----
-.
 .
 
 iter
 set-bounds upper=e
 seek-lt e
-last
 ----
-dd#5,SET:5
 dd#5,SET:5
 
-# levelIter only checks upper bound when loading sstables.
 iter upper=d
-seek-lt e
-last
+seek-lt d
 ----
-d#4,SET:4
-d#4,SET:4
+c#3,SET:3
 
 iter upper=c
-seek-lt e
-last
+seek-lt c
 ----
-b#2,SET:2
 b#2,SET:2
 
 iter
 set-bounds upper=d
-seek-lt e
-last
+seek-lt d
 ----
-d#4,SET:4
-d#4,SET:4
+c#3,SET:3
 
 iter
 set-bounds upper=c
-seek-lt e
-last
+seek-lt c
 ----
-b#2,SET:2
 b#2,SET:2
 
-# levelIter only checks upper bound when loading sstables.
 iter upper=b
-seek-lt e
-last
+seek-lt b
 ----
-b#2,SET:2
-b#2,SET:2
+a#1,SET:1
 
 iter upper=a
-seek-lt e
-last
+seek-lt a
 ----
-.
 .
 
 iter upper=dd
@@ -359,18 +319,14 @@ d#4,SET:4
 
 iter
 set-bounds upper=b
-seek-lt e
-last
+seek-lt b
 ----
-b#2,SET:2
-b#2,SET:2
+a#1,SET:1
 
 iter
 set-bounds upper=a
-seek-lt e
-last
+seek-lt a
 ----
-.
 .
 
 iter
@@ -391,7 +347,7 @@ dd#5,SET:5
 .
 
 iter lower=dd
-seek-prefix-ge d
+seek-prefix-ge dd
 next
 ----
 dd#5,SET:5


### PR DESCRIPTION
The internal iterator contract requires callers to use SeekLT(upper) or SeekGE(lower) rather than First or Last when upper/lower bounds are set. This commit fixes the levelIter unit tests to avoid testing this case, and adds new invariant-build checks to ensure this contract is obeyed by levelIter users.