### PR TITLE
manifest: more accurate in-use key ranges

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2391,7 +2391,7 @@ func TestCompactionInuseKeyRanges(t *testing.T) {
 						if i > 0 {
 							fmt.Fprintf(&buf, " ")
 						}
-						fmt.Fprintf(&buf, "%s-%s", r.Start, r.End.Key)
+						fmt.Fprintf(&buf, "%s", r.String())
 					}
 					fmt.Fprintf(&buf, "\n")
 				}

--- a/db.go
+++ b/db.go
@@ -1877,7 +1877,7 @@ func (d *DB) splitManualCompaction(
 			level: level,
 			done:  make(chan error, 1),
 			start: keyRange.Start,
-			end:   keyRange.End,
+			end:   keyRange.End.Key,
 			split: true,
 		})
 	}

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -417,7 +417,7 @@ func TestL0Sublevels(t *testing.T) {
 
 				keyRanges := sublevels.InUseKeyRanges(smallest, largest)
 				for i, r := range keyRanges {
-					fmt.Fprintf(&buf, "%s-%s", sublevels.formatKey(r.Start), sublevels.formatKey(r.End))
+					fmt.Fprintf(&buf, "%s-%s", sublevels.formatKey(r.Start), sublevels.formatKey(r.End.Key))
 					if i < len(keyRanges)-1 {
 						fmt.Fprint(&buf, ", ")
 					}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -74,18 +74,17 @@ func TestInuseKeyRangesRandomized(t *testing.T) {
 				// this file extends before or after smallest/largest, truncate
 				// it to be within [smallest,largest] for the purpose of
 				// correctness checking.
-				fileSmallest := f.Smallest.UserKey
-				fileLargest := f.Largest.UserKey
-				if cmp(fileSmallest, smallest) < 0 {
-					fileSmallest = smallest
+				b := f.UserKeyBounds()
+				if cmp(b.Start, smallest) < 0 {
+					b.Start = smallest
 				}
-				if cmp(fileLargest, largest) > 0 {
-					fileLargest = largest
+				if cmp(b.End.Key, largest) >= 0 {
+					b.End = base.UserKeyInclusive(largest)
 				}
 
 				var containedWithin bool
 				for _, kr := range keyRanges {
-					containedWithin = containedWithin || (cmp(fileSmallest, kr.Start) >= 0 && kr.End.IsUpperBoundFor(cmp, fileLargest))
+					containedWithin = containedWithin || kr.ContainsBounds(cmp, &b)
 				}
 				if !containedWithin {
 					t.Fatalf("file L%d.%s overlaps [%s, %s] but no in-use key range contains it",

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -62,7 +62,7 @@ func TestInuseKeyRangesRandomized(t *testing.T) {
 		keyRanges := v.CalculateInuseKeyRanges(level, manifest.NumLevels-1, smallest, largest)
 		t.Logf("%d: [%s, %s] levels L%d-L6: ", i, smallest, largest, level)
 		for _, kr := range keyRanges {
-			t.Logf("  [%s,%s]", kr.Start, kr.End)
+			t.Logf("  %s", kr.String())
 		}
 
 		for l := level; l < manifest.NumLevels; l++ {
@@ -85,7 +85,7 @@ func TestInuseKeyRangesRandomized(t *testing.T) {
 
 				var containedWithin bool
 				for _, kr := range keyRanges {
-					containedWithin = containedWithin || (cmp(fileSmallest, kr.Start) >= 0 && cmp(fileLargest, kr.End) <= 0)
+					containedWithin = containedWithin || (cmp(fileSmallest, kr.Start) >= 0 && kr.End.IsUpperBoundFor(cmp, fileLargest))
 				}
 				if !containedWithin {
 					t.Fatalf("file L%d.%s overlaps [%s, %s] but no in-use key range contains it",

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -452,7 +452,7 @@ func TestCalculateInuseKeyRanges(t *testing.T) {
 		depth    int
 		smallest []byte
 		largest  []byte
-		want     []UserKeyRange
+		want     []base.UserKeyBounds
 	}{
 		{
 			name: "No files in next level",
@@ -476,15 +476,9 @@ func TestCalculateInuseKeyRanges(t *testing.T) {
 			depth:    2,
 			smallest: []byte("a"),
 			largest:  []byte("e"),
-			want: []UserKeyRange{
-				{
-					Start: []byte("a"),
-					End:   []byte("c"),
-				},
-				{
-					Start: []byte("d"),
-					End:   []byte("e"),
-				},
+			want: []base.UserKeyBounds{
+				base.UserKeyBoundsInclusive([]byte("a"), []byte("c")),
+				base.UserKeyBoundsInclusive([]byte("d"), []byte("e")),
 			},
 		},
 		{
@@ -523,23 +517,11 @@ func TestCalculateInuseKeyRanges(t *testing.T) {
 			depth:    2,
 			smallest: []byte("a"),
 			largest:  []byte("z"),
-			want: []UserKeyRange{
-				{
-					Start: []byte("a"),
-					End:   []byte("c"),
-				},
-				{
-					Start: []byte("d"),
-					End:   []byte("i"),
-				},
-				{
-					Start: []byte("l"),
-					End:   []byte("p"),
-				},
-				{
-					Start: []byte("s"),
-					End:   []byte("w"),
-				},
+			want: []base.UserKeyBounds{
+				base.UserKeyBoundsInclusive([]byte("a"), []byte("c")),
+				base.UserKeyBoundsInclusive([]byte("d"), []byte("i")),
+				base.UserKeyBoundsInclusive([]byte("l"), []byte("p")),
+				base.UserKeyBoundsInclusive([]byte("s"), []byte("w")),
 			},
 		},
 		{
@@ -590,23 +572,11 @@ func TestCalculateInuseKeyRanges(t *testing.T) {
 			depth:    2,
 			smallest: []byte("a"),
 			largest:  []byte("z"),
-			want: []UserKeyRange{
-				{
-					Start: []byte("a"),
-					End:   []byte("c"),
-				},
-				{
-					Start: []byte("d"),
-					End:   []byte("e"),
-				},
-				{
-					Start: []byte("m"),
-					End:   []byte("q"),
-				},
-				{
-					Start: []byte("s"),
-					End:   []byte("w"),
-				},
+			want: []base.UserKeyBounds{
+				base.UserKeyBoundsInclusive([]byte("a"), []byte("c")),
+				base.UserKeyBoundsInclusive([]byte("d"), []byte("e")),
+				base.UserKeyBoundsInclusive([]byte("m"), []byte("q")),
+				base.UserKeyBoundsInclusive([]byte("s"), []byte("w")),
 			},
 		},
 		{
@@ -651,15 +621,9 @@ func TestCalculateInuseKeyRanges(t *testing.T) {
 			depth:    2,
 			smallest: []byte("a"),
 			largest:  []byte("z"),
-			want: []UserKeyRange{
-				{
-					Start: []byte("a"),
-					End:   []byte("c"),
-				},
-				{
-					Start: []byte("d"),
-					End:   []byte("w"),
-				},
+			want: []base.UserKeyBounds{
+				base.UserKeyBoundsInclusive([]byte("a"), []byte("c")),
+				base.UserKeyBoundsInclusive([]byte("d"), []byte("w")),
 			},
 		},
 	}

--- a/testdata/compaction_elide_tombstone
+++ b/testdata/compaction_elide_tombstone
@@ -205,4 +205,4 @@ elideTombstone("a") = true
 elideTombstone("b") = true
 elideTombstone("g") = false
 elideTombstone("goo") = false
-elideTombstone("z") = false
+elideTombstone("z") = true

--- a/testdata/compaction_inuse_key_ranges
+++ b/testdata/compaction_inuse_key_ranges
@@ -18,8 +18,8 @@ L0 c d
 L0 g h
 L1 a b
 ----
-L0 a-b: a-b
-L0 c-d: d-e
+L0 a-b: [a, b]
+L0 c-d: [d, e]
 L0 g-h: .
 L1 a-b: .
 
@@ -40,9 +40,9 @@ L1 a aa
 L1 a b
 L2 a z
 ----
-L0 a-c: a-c
+L0 a-c: [a, c]
 L1 a-aa: .
-L1 a-b: b-c
+L1 a-b: [b, c]
 L2 a-z: .
 
 define
@@ -60,8 +60,8 @@ inuse-key-ranges
 L0 a c
 L0 a b
 ----
-L0 a-c: a-b c-d
-L0 a-b: a-b
+L0 a-c: [a, b] [c, d]
+L0 a-b: [a, b]
 
 define
 L1
@@ -77,7 +77,7 @@ L2:
 inuse-key-ranges
 L0 a c
 ----
-L0 a-c: a-c
+L0 a-c: [a, c]
 
 define
 L1
@@ -93,7 +93,7 @@ L2:
 inuse-key-ranges
 L0 a c
 ----
-L0 a-c: a-b c-d
+L0 a-c: [a, b] [c, d]
 
 define
 L1
@@ -113,9 +113,9 @@ L0 a z
 L0 a c
 L0 g z
 ----
-L0 a-z: a-b c-d f-g i-j
-L0 a-c: a-b c-d
-L0 g-z: i-j
+L0 a-z: [a, b] [c, d] [f, g] [i, j]
+L0 a-c: [a, b] [c, d]
+L0 g-z: [i, j]
 
 define
 L1
@@ -139,7 +139,7 @@ L6:
 inuse-key-ranges
 L0 a z
 ----
-L0 a-z: a-j k-z
+L0 a-z: [a, j] [k, z]
 
 define
 L0
@@ -164,7 +164,7 @@ L6:
 inuse-key-ranges
 L0 a z
 ----
-L0 a-z: a-j k-z
+L0 a-z: [a, j] [k, z]
 
 define
 L0
@@ -196,10 +196,10 @@ L0 q r
 L0 1 2
 L0 ddd dddd
 ----
-L0 a-z: a-dd e-p
-L0 e-p: e-p
-L0 e-f: e-m
-L0 b-c: b-dd
+L0 a-z: [a, dd] [e, p]
+L0 e-p: [e, p]
+L0 e-f: [e, m]
+L0 b-c: [b, dd]
 L0 q-r: .
 L0 1-2: .
 L0 ddd-dddd: .
@@ -240,13 +240,13 @@ L5 mm zz
 L5 l x
 L5 l zz
 ----
-L5 a-z: m-z
+L5 a-z: [m, z]
 L5 a-b: .
-L5 m-z: m-z
-L5 m-zz: m-z
-L5 mm-zz: m-z
-L5 l-x: m-z
-L5 l-zz: m-z
+L5 m-z: [m, z]
+L5 m-zz: [m, z]
+L5 mm-zz: [m, z]
+L5 l-x: [m, z]
+L5 l-zz: [m, z]
 
 inuse-key-ranges
 L3 a z
@@ -255,21 +255,21 @@ L3 k m
 L3 l ll
 L3 b n
 ----
-L3 a-z: f-k m-z
-L3 f-k: f-k
-L3 k-m: m-z
+L3 a-z: [f, k] [m, z]
+L3 f-k: [f, k]
+L3 k-m: [m, z]
 L3 l-ll: .
-L3 b-n: f-k m-z
+L3 b-n: [f, k] [m, z]
 
 inuse-key-ranges
 L2 a z
 ----
-L2 a-z: b-c f-k m-z
+L2 a-z: [b, c] [f, k] [m, z]
 
 inuse-key-ranges
 L1 a z
 ----
-L1 a-z: b-d f-k m-z
+L1 a-z: [b, d] [f, k] [m, z]
 
 inuse-key-ranges
 L0 a z
@@ -278,11 +278,11 @@ L0 a b
 L0 bb bc
 L0 f k
 ----
-L0 a-z: a-k m-z
-L0 a-k: a-k
-L0 a-b: a-c
-L0 bb-bc: b-c
-L0 f-k: d-k
+L0 a-z: [a, k] [m, z]
+L0 a-k: [a, k]
+L0 a-b: [a, c]
+L0 bb-bc: [b, c]
+L0 f-k: [d, k]
 
 define
 L1
@@ -321,16 +321,16 @@ L0 p z
 L0 pp z
 L0 oo z
 ----
-L3 a-z: a-f w-z
-L2 a-z: a-k s-z
-L1 a-z: a-n o-z
-L0 a-z: a-z
-L0 a-n: a-p
-L0 a-mm: a-p
-L0 a-nn: a-p
-L0 p-z: o-z
-L0 pp-z: o-z
-L0 oo-z: m-z
+L3 a-z: [a, f] [w, z]
+L2 a-z: [a, k] [s, z]
+L1 a-z: [a, n] [o, z]
+L0 a-z: [a, z]
+L0 a-n: [a, p]
+L0 a-mm: [a, p]
+L0 a-nn: [a, p]
+L0 p-z: [o, z]
+L0 pp-z: [o, z]
+L0 oo-z: [m, z]
 
 define
 L1
@@ -351,8 +351,8 @@ inuse-key-ranges
 L0 a c
 L0 a cc
 ----
-L0 a-c: a-c
-L0 a-cc: a-c cc-cca
+L0 a-c: [a, c]
+L0 a-cc: [a, c] [cc, cca]
 
 define
 L1
@@ -379,10 +379,10 @@ L0 a cc
 L0 a d
 L0 c c
 ----
-L0 a-c: a-ca
-L0 a-cc: a-d
-L0 a-d: a-d
-L0 c-c: c-ca
+L0 a-c: [a, ca]
+L0 a-cc: [a, d]
+L0 a-d: [a, d]
+L0 c-c: [c, ca]
 
 define
 L0
@@ -415,5 +415,5 @@ inuse-key-ranges
 L0 a z
 L1 a z
 ----
-L0 a-z: a-aa b-ba bb-bba c-ca d-i
-L1 a-z: b-ba bb-bba c-ca e-ea
+L0 a-z: [a, aa] [b, ba] [bb, bba] [c, ca] [d, i]
+L1 a-z: [b, ba] [bb, bba] [c, ca] [e, ea]

--- a/testdata/compaction_inuse_key_ranges
+++ b/testdata/compaction_inuse_key_ranges
@@ -19,7 +19,7 @@ L0 g h
 L1 a b
 ----
 L0 a-b: [a, b]
-L0 c-d: [d, e]
+L0 c-d: [d, e)
 L0 g-h: .
 L1 a-b: .
 
@@ -113,9 +113,9 @@ L0 a z
 L0 a c
 L0 g z
 ----
-L0 a-z: [a, b] [c, d] [f, g] [i, j]
-L0 a-c: [a, b] [c, d]
-L0 g-z: [i, j]
+L0 a-z: [a, b) [c, d) [f, g) [i, j)
+L0 a-c: [a, b) [c, d)
+L0 g-z: [i, j)
 
 define
 L1
@@ -139,7 +139,7 @@ L6:
 inuse-key-ranges
 L0 a z
 ----
-L0 a-z: [a, j] [k, z]
+L0 a-z: [a, j) [k, z)
 
 define
 L0
@@ -164,7 +164,7 @@ L6:
 inuse-key-ranges
 L0 a z
 ----
-L0 a-z: [a, j] [k, z]
+L0 a-z: [a, j) [k, z)
 
 define
 L0
@@ -196,10 +196,10 @@ L0 q r
 L0 1 2
 L0 ddd dddd
 ----
-L0 a-z: [a, dd] [e, p]
-L0 e-p: [e, p]
-L0 e-f: [e, m]
-L0 b-c: [b, dd]
+L0 a-z: [a, dd) [e, p)
+L0 e-p: [e, p)
+L0 e-f: [e, m)
+L0 b-c: [b, dd)
 L0 q-r: .
 L0 1-2: .
 L0 ddd-dddd: .
@@ -240,13 +240,13 @@ L5 mm zz
 L5 l x
 L5 l zz
 ----
-L5 a-z: [m, z]
+L5 a-z: [m, z)
 L5 a-b: .
-L5 m-z: [m, z]
-L5 m-zz: [m, z]
-L5 mm-zz: [m, z]
-L5 l-x: [m, z]
-L5 l-zz: [m, z]
+L5 m-z: [m, z)
+L5 m-zz: [m, z)
+L5 mm-zz: [m, z)
+L5 l-x: [m, z)
+L5 l-zz: [m, z)
 
 inuse-key-ranges
 L3 a z
@@ -255,21 +255,21 @@ L3 k m
 L3 l ll
 L3 b n
 ----
-L3 a-z: [f, k] [m, z]
-L3 f-k: [f, k]
-L3 k-m: [m, z]
+L3 a-z: [f, k) [m, z)
+L3 f-k: [f, k)
+L3 k-m: [m, z)
 L3 l-ll: .
-L3 b-n: [f, k] [m, z]
+L3 b-n: [f, k) [m, z)
 
 inuse-key-ranges
 L2 a z
 ----
-L2 a-z: [b, c] [f, k] [m, z]
+L2 a-z: [b, c) [f, k) [m, z)
 
 inuse-key-ranges
 L1 a z
 ----
-L1 a-z: [b, d] [f, k] [m, z]
+L1 a-z: [b, d) [f, k) [m, z)
 
 inuse-key-ranges
 L0 a z
@@ -278,11 +278,11 @@ L0 a b
 L0 bb bc
 L0 f k
 ----
-L0 a-z: [a, k] [m, z]
-L0 a-k: [a, k]
-L0 a-b: [a, c]
-L0 bb-bc: [b, c]
-L0 f-k: [d, k]
+L0 a-z: [a, k) [m, z)
+L0 a-k: [a, k)
+L0 a-b: [a, c)
+L0 bb-bc: [b, c)
+L0 f-k: [d, k)
 
 define
 L1
@@ -321,16 +321,16 @@ L0 p z
 L0 pp z
 L0 oo z
 ----
-L3 a-z: [a, f] [w, z]
-L2 a-z: [a, k] [s, z]
-L1 a-z: [a, n] [o, z]
-L0 a-z: [a, z]
-L0 a-n: [a, p]
-L0 a-mm: [a, p]
-L0 a-nn: [a, p]
-L0 p-z: [o, z]
-L0 pp-z: [o, z]
-L0 oo-z: [m, z]
+L3 a-z: [a, f) [w, z)
+L2 a-z: [a, k) [s, z)
+L1 a-z: [a, n) [o, z)
+L0 a-z: [a, z)
+L0 a-n: [a, p)
+L0 a-mm: [a, p)
+L0 a-nn: [a, p)
+L0 p-z: [o, z)
+L0 pp-z: [o, z)
+L0 oo-z: [m, z)
 
 define
 L1
@@ -351,8 +351,8 @@ inuse-key-ranges
 L0 a c
 L0 a cc
 ----
-L0 a-c: [a, c]
-L0 a-cc: [a, c] [cc, cca]
+L0 a-c: [a, c)
+L0 a-cc: [a, c) [cc, cca)
 
 define
 L1
@@ -379,10 +379,10 @@ L0 a cc
 L0 a d
 L0 c c
 ----
-L0 a-c: [a, ca]
-L0 a-cc: [a, d]
-L0 a-d: [a, d]
-L0 c-c: [c, ca]
+L0 a-c: [a, ca)
+L0 a-cc: [a, d)
+L0 a-d: [a, d)
+L0 c-c: [c, ca)
 
 define
 L0
@@ -415,5 +415,5 @@ inuse-key-ranges
 L0 a z
 L1 a z
 ----
-L0 a-z: [a, aa] [b, ba] [bb, bba] [c, ca] [d, i]
-L1 a-z: [b, ba] [bb, bba] [c, ca] [e, ea]
+L0 a-z: [a, aa) [b, ba) [bb, bba) [c, ca) [d, i)
+L1 a-z: [b, ba) [bb, bba) [c, ca) [e, ea)


### PR DESCRIPTION
#### manifest: use UserKeyBounds for in use ranges

This is a mechanical change to remove `UserKeyRanges` and switch to
`UserKeyBounds` for in-use key ranges. They are still always
inclusive.

#### db: better printing of bounds in TestCompactionInuseKeyRanges

Use the `UserKeyBounds` format, which shows whether the end bound is
exclusive or inclusive.

#### manifest: more accurate in-use key ranges

We now take into account the exclusivity of the largest key, with more
accurate ("tighter") resulting ranges.