### PR TITLE
crl-release-24.1: db: check for empty external ingestions

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -700,6 +700,68 @@ func (d *DB) ingestAttachRemote(jobID JobID, lr ingestLoadResult) error {
 		}
 	}
 
+	if invariants.Enabled || d.opts.Experimental.CheckExternalIngestions {
+		// Verify that the ingestion is not empty. Empty tables cause correctness
+		// issues in some iterators.
+		for i := range lr.external {
+			e := &lr.external[i]
+			isEmpty, err := func() (bool, error) {
+				readable, err := d.objProvider.OpenForReading(
+					context.Background(), fileTypeTable, e.FileBacking.DiskFileNum, objstorage.OpenOptions{},
+				)
+				if err != nil {
+					return false, err
+				}
+				reader, err := sstable.NewReader(readable, d.opts.MakeReaderOptions())
+				if err != nil {
+					readable.Close()
+					return false, err
+				}
+				defer reader.Close()
+				iter, err := reader.NewIter(e.IterTransforms(), nil, nil)
+				if err != nil {
+					return false, err
+				}
+				if iter != nil {
+					defer iter.Close()
+					if key, _ := iter.SeekGE(e.external.StartKey, base.SeekGEFlagsNone); key != nil {
+						cmp := d.opts.Comparer.Compare(key.UserKey, e.external.EndKey)
+						if cmp < 0 || (cmp == 0 && e.external.EndKeyIsInclusive) {
+							return false, nil
+						}
+					}
+					if err := iter.Error(); err != nil {
+						return false, err
+					}
+				}
+				rangeIter, err := reader.NewRawRangeDelIter(e.IterTransforms())
+				if err != nil {
+					return false, err
+				}
+				if rangeIter != nil {
+					defer rangeIter.Close()
+					span, err := rangeIter.SeekGE(e.external.StartKey)
+					if err != nil {
+						return false, err
+					}
+					if span != nil {
+						cmp := d.opts.Comparer.Compare(span.Start, e.external.EndKey)
+						if cmp < 0 || (cmp == 0 && e.external.EndKeyIsInclusive) {
+							return false, nil
+						}
+					}
+				}
+				return true, nil
+			}()
+			if err != nil {
+				return err
+			}
+			if isEmpty {
+				panic(fmt.Sprintf("external ingestion is empty: %s (%q %q)", e.external.ObjName, e.external.StartKey, e.external.EndKey))
+			}
+		}
+	}
+
 	if d.opts.EventListener.TableCreated != nil {
 		for i := range remoteObjMetas {
 			d.opts.EventListener.TableCreated(TableCreateInfo{

--- a/options.go
+++ b/options.go
@@ -682,6 +682,10 @@ type Options struct {
 		// major version is at least `FormatFlushableIngest`.
 		DisableIngestAsFlushable func() bool
 
+		// CheckExternalIngestions enables opening external ssts at ingest time and
+		// validating that they are not empty. Used for testing/debugging.
+		CheckExternalIngestions bool
+
 		// RemoteStorage enables use of remote storage (e.g. S3) for storing
 		// sstables. Setting this option enables use of CreateOnShared option and
 		// allows ingestion of external files.


### PR DESCRIPTION
This commit adds a check that the external ingestions are not empty.
This is not allowed and leads to errors or correctness issues down the
line.

We don't want to open all remote ssts files in production, so the
check only happens in invariants mode or if a new
CheckExternalIngestions option is set. This will be set by crdb in
tests.