### PR TITLE
db: support changing directions of exhausted levelIter

### DIFF
--- a/testdata/level_iter
+++ b/testdata/level_iter
@@ -25,11 +25,23 @@ next
 next
 next
 next
+prev
+prev
+prev
+prev
+prev
+prev
 ----
 b#2,SET:2
 c#3,SET:3
 d#4,SET:4
 dd#5,SET:5
+.
+dd#5,SET:5
+d#4,SET:4
+c#3,SET:3
+b#2,SET:2
+a#1,SET:1
 .
 
 iter
@@ -37,64 +49,87 @@ seek-ge c
 next
 next
 next
+prev
 ----
 c#3,SET:3
 d#4,SET:4
 dd#5,SET:5
 .
+dd#5,SET:5
 
 iter
 seek-ge d
 next
 next
+prev
 ----
 d#4,SET:4
 dd#5,SET:5
 .
+dd#5,SET:5
 
 iter
 seek-ge dd
 next
+prev
 ----
 dd#5,SET:5
 .
+dd#5,SET:5
 
 iter
 seek-ge e
+prev
 ----
 .
+dd#5,SET:5
 
 iter
 seek-lt a
+next
 ----
 .
+a#1,SET:1
+
 
 iter
 seek-lt b
 prev
+next
 ----
 a#1,SET:1
 .
+a#1,SET:1
 
 iter
 seek-lt c
 prev
 prev
+next
+next
 ----
 b#2,SET:2
 a#1,SET:1
 .
+a#1,SET:1
+b#2,SET:2
 
 iter
 seek-lt d
 prev
 prev
 prev
+next
+next
+next
 ----
 c#3,SET:3
 b#2,SET:2
 a#1,SET:1
 .
+a#1,SET:1
+b#2,SET:2
+c#3,SET:3
 
 iter
 seek-lt e
@@ -103,6 +138,10 @@ prev
 prev
 prev
 prev
+next
+next
+next
+next
 ----
 dd#5,SET:5
 d#4,SET:4
@@ -110,6 +149,10 @@ c#3,SET:3
 b#2,SET:2
 a#1,SET:1
 .
+a#1,SET:1
+b#2,SET:2
+c#3,SET:3
+d#4,SET:4
 
 iter
 seek-prefix-ge a
@@ -167,40 +210,52 @@ a#1,SET:1
 iter
 set-bounds lower=a
 seek-ge a
+prev
+next
 ----
+a#1,SET:1
+.
 a#1,SET:1
 
 iter
 set-bounds lower=dd upper=f
 seek-lt dd
+next
 set-bounds lower=a upper=f
 seek-lt dd
 prev
 prev
 prev
 prev
+next
 ----
 .
+dd#5,SET:5
 d#4,SET:4
 c#3,SET:3
 b#2,SET:2
 a#1,SET:1
 .
+a#1,SET:1
 
 iter
 set-bounds lower=a upper=b
 seek-ge c
+prev
 set-bounds lower=a upper=f
 seek-ge c
 next
 next
 next
+prev
 ----
 .
+a#1,SET:1
 c#3,SET:3
 d#4,SET:4
 dd#5,SET:5
 .
+dd#5,SET:5
 
 # levelIter trims lower/upper bound in the options passed to sstables.
 load a
@@ -225,67 +280,117 @@ load c lower=b upper=e
 
 iter lower=b
 seek-ge b
+prev
+next
 ----
+b#2,SET:2
+.
 b#2,SET:2
 
 iter lower=c
 seek-ge c
+prev
+next
 ----
+c#3,SET:3
+.
 c#3,SET:3
 
 iter
 set-bounds lower=b
 seek-ge b
+prev
+next
 ----
+b#2,SET:2
+.
 b#2,SET:2
 
 iter
 set-bounds lower=c
 seek-ge c
+prev
+next
 ----
+c#3,SET:3
+.
 c#3,SET:3
 
 iter lower=d
 seek-ge d
+prev
+next
 ----
+d#4,SET:4
+.
 d#4,SET:4
 
 iter lower=e
 seek-ge e
+prev
+next
 ----
+.
+.
 .
 
 iter upper=e
 seek-lt e
+next
+prev
 ----
+dd#5,SET:5
+.
 dd#5,SET:5
 
 iter
 set-bounds lower=d
 seek-ge d
+prev
+next
 ----
+d#4,SET:4
+.
 d#4,SET:4
 
 iter
 set-bounds lower=e
 seek-ge e
+prev
+next
 ----
+.
+.
 .
 
 iter
 set-bounds upper=e
 seek-lt e
+next
+prev
+prev
 ----
 dd#5,SET:5
+.
+dd#5,SET:5
+d#4,SET:4
 
 iter upper=d
 seek-lt d
+next
+prev
 ----
+c#3,SET:3
+.
 c#3,SET:3
 
 iter upper=c
 seek-lt c
+next
+prev
 ----
+b#2,SET:2
+.
 b#2,SET:2
 
 iter
@@ -326,7 +431,11 @@ a#1,SET:1
 iter
 set-bounds upper=a
 seek-lt a
+next
+prev
 ----
+.
+.
 .
 
 iter
@@ -369,7 +478,11 @@ d#4,SET:4
 
 iter lower=c
 seek-lt c
+next
+prev
 ----
+.
+c#3,SET:3
 .
 
 iter
@@ -451,6 +564,8 @@ iter
 seek-ge c
 set-bounds upper=cc
 seek-ge d
+prev
 ----
 c#3,SET:3
 .
+c#3,SET:3


### PR DESCRIPTION
Previously the levelIter did not support changing directions from an exhausted iterator position. If a levelIter returned nil, the caller was responsible for repositioning the iterator in the other direction using a seek.