### PR TITLE
db: avoid levelIter's unnecessary opening of range deletion iterator

### DIFF
--- a/level_iter.go
+++ b/level_iter.go
@@ -583,8 +583,13 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) loadFileReturnIndicato
 			continue
 		}
 
+		iterKinds := iterPointKeys
+		if l.rangeDelIterPtr != nil {
+			iterKinds |= iterRangeDeletions
+		}
+
 		var iters iterSet
-		iters, l.err = l.newIters(l.ctx, l.iterFile, &l.tableOpts, l.internalOpts, iterPointKeys|iterRangeDeletions)
+		iters, l.err = l.newIters(l.ctx, l.iterFile, &l.tableOpts, l.internalOpts, iterKinds)
 		if l.err != nil {
 			return noFileLoaded
 		}
@@ -592,8 +597,6 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) loadFileReturnIndicato
 		if l.rangeDelIterPtr != nil {
 			*l.rangeDelIterPtr = iters.rangeDeletion
 			l.rangeDelIterCopy = iters.rangeDeletion
-		} else if iters.rangeDeletion != nil {
-			iters.rangeDeletion.Close()
 		}
 		return newFileLoaded
 	}


### PR DESCRIPTION
Adjust levelIter.loadFile to only open a range deletion iterator if configured to surface range deletions (rangeDelItrPtr != nil).