### PR TITLE
db: clean up levelIter, mergingIter unit tests

### DIFF
--- a/internal/itertest/datadriven.go
+++ b/internal/itertest/datadriven.go
@@ -15,44 +15,65 @@ import (
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/stretchr/testify/require"
 )
 
 type iterCmdOpts struct {
-	fmtKV func(io.Writer, *base.InternalKey, []byte, base.InternalIterator)
-	stats *base.InternalIteratorStats
+	fmtKV           formatKV
+	withoutNewlines bool
+	stats           *base.InternalIteratorStats
 }
 
 // An IterOpt configures the behavior of RunInternalIterCmd.
 type IterOpt func(*iterCmdOpts)
 
-// Verbose configures RunInternalIterCmd to output verbose results.
-func Verbose(opts *iterCmdOpts) { opts.fmtKV = verboseFmt }
+// A formatKV configures the formatting to use when presenting key-value pairs.
+type formatKV func(w io.Writer, key *base.InternalKey, v []byte, iter base.InternalIterator)
 
 // Condensed configures RunInternalIterCmd to output condensed results without
-// values.
-func Condensed(opts *iterCmdOpts) { opts.fmtKV = condensedFmt }
+// values, collapsed onto a single line.
+func Condensed(opts *iterCmdOpts) {
+	opts.fmtKV = condensedFormatKV
+	opts.withoutNewlines = true
+}
+
+// Verbose configures RunInternalIterCmd to output verbose results.
+func Verbose(opts *iterCmdOpts) { opts.fmtKV = verboseFormatKV }
+
+// WithSpan configures RunInternalIterCmd to print the span returned by spanFunc
+// after each iteration operation.
+func WithSpan(spanFunc func() *keyspan.Span) IterOpt {
+	return func(opts *iterCmdOpts) {
+		prevFmtKV := opts.fmtKV
+		opts.fmtKV = func(w io.Writer, key *base.InternalKey, v []byte, iter base.InternalIterator) {
+			prevFmtKV(w, key, v, iter)
+			if s := spanFunc(); s != nil {
+				fmt.Fprintf(w, " / %s", s)
+			}
+		}
+	}
+}
 
 // WithStats configures RunInternalIterCmd to collect iterator stats in the
 // struct pointed to by stats.
 func WithStats(stats *base.InternalIteratorStats) IterOpt {
-	return func(opts *iterCmdOpts) {
-		opts.stats = stats
-	}
+	return func(opts *iterCmdOpts) { opts.stats = stats }
 }
 
-func defaultFmt(w io.Writer, key *base.InternalKey, v []byte, iter base.InternalIterator) {
+func defaultFormatKV(w io.Writer, key *base.InternalKey, v []byte, iter base.InternalIterator) {
 	if key != nil {
-		fmt.Fprintf(w, "%s:%s\n", key.UserKey, v)
+		fmt.Fprintf(w, "%s:%s", key.UserKey, v)
 	} else if err := iter.Error(); err != nil {
-		fmt.Fprintf(w, "err=%v\n", err)
+		fmt.Fprintf(w, "err=%v", err)
 	} else {
-		fmt.Fprintf(w, ".\n")
+		fmt.Fprintf(w, ".")
 	}
 }
 
-func condensedFmt(w io.Writer, key *base.InternalKey, v []byte, iter base.InternalIterator) {
+// condensedFormatKV is a FormatKV that outputs condensed results.
+func condensedFormatKV(w io.Writer, key *base.InternalKey, v []byte, iter base.InternalIterator) {
 	if key != nil {
 		fmt.Fprintf(w, "<%s:%d>", key.UserKey, key.SeqNum())
 	} else if err := iter.Error(); err != nil {
@@ -62,12 +83,13 @@ func condensedFmt(w io.Writer, key *base.InternalKey, v []byte, iter base.Intern
 	}
 }
 
-func verboseFmt(w io.Writer, key *base.InternalKey, v []byte, iter base.InternalIterator) {
+// verboseFormatKV is a FormatKV that outputs verbose results.
+func verboseFormatKV(w io.Writer, key *base.InternalKey, v []byte, iter base.InternalIterator) {
 	if key != nil {
-		fmt.Fprintf(w, "%s:%s\n", key, v)
+		fmt.Fprintf(w, "%s:%s", key, v)
 		return
 	}
-	defaultFmt(w, key, v, iter)
+	defaultFormatKV(w, key, v, iter)
 }
 
 // RunInternalIterCmd evaluates a datadriven command controlling an internal
@@ -86,7 +108,7 @@ func RunInternalIterCmd(
 func RunInternalIterCmdWriter(
 	t *testing.T, w io.Writer, d *datadriven.TestData, iter base.InternalIterator, opts ...IterOpt,
 ) {
-	o := iterCmdOpts{fmtKV: defaultFmt}
+	o := iterCmdOpts{fmtKV: defaultFormatKV}
 	for _, opt := range opts {
 		opt(&o)
 	}
@@ -201,6 +223,8 @@ func RunInternalIterCmdWriter(
 			return
 		}
 		o.fmtKV(w, key, value, iter)
-
+		if !o.withoutNewlines {
+			fmt.Fprintln(w)
+		}
 	}
 }

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -186,7 +186,7 @@ func (lt *levelIterTest) newIters(
 	return set, nil
 }
 
-func (lt *levelIterTest) runClear(d *datadriven.TestData) string {
+func (lt *levelIterTest) runClear() string {
 	lt.mem = vfs.NewMem()
 	for _, r := range lt.readers {
 		r.Close()
@@ -298,13 +298,13 @@ func (lt *levelIterTest) runBuild(d *datadriven.TestData) string {
 
 func TestLevelIterBoundaries(t *testing.T) {
 	lt := newLevelIterTest()
-	defer lt.runClear(nil)
+	defer lt.runClear()
 
 	var iter *levelIter
 	datadriven.RunTest(t, "testdata/level_iter_boundaries", func(t *testing.T, d *datadriven.TestData) string {
 		switch d.Cmd {
 		case "clear":
-			return lt.runClear(d)
+			return lt.runClear()
 
 		case "build":
 			return lt.runBuild(d)
@@ -368,6 +368,9 @@ func TestLevelIterBoundaries(t *testing.T) {
 type levelIterTestIter struct {
 	*levelIter
 	rangeDelIter keyspan.FragmentIterator
+	// rangeDel is only set on seeks: SeekGE, SeekLT, SeekPrefixGE.
+	// TODO(jackson): Clean this up when #2863 is resolved.
+	rangeDel *keyspan.Span
 }
 
 func must(err error) {
@@ -376,10 +379,14 @@ func must(err error) {
 	}
 }
 
+func (i *levelIterTestIter) getRangeDel() *keyspan.Span {
+	return i.rangeDel
+}
+
 func (i *levelIterTestIter) rangeDelSeek(
 	key []byte, kv *base.InternalKV, dir int,
 ) *base.InternalKV {
-	var tombstone keyspan.Span
+	i.rangeDel = nil
 	if i.rangeDelIter != nil {
 		var t *keyspan.Span
 		var err error
@@ -393,21 +400,11 @@ func (i *levelIterTestIter) rangeDelSeek(
 		// positioning methods.
 		must(err)
 		if t != nil {
-			tombstone = t.Visible(1000)
+			i.rangeDel = new(keyspan.Span)
+			*i.rangeDel = t.Visible(1000)
 		}
 	}
-	if kv == nil {
-		return &base.InternalKV{
-			K: base.InternalKey{UserKey: []byte(fmt.Sprintf("./%s", tombstone))},
-		}
-	}
-	return &base.InternalKV{
-		K: base.InternalKey{
-			UserKey: []byte(fmt.Sprintf("%s/%s", kv.K.UserKey, tombstone)),
-			Trailer: kv.K.Trailer,
-		},
-		V: kv.V,
-	}
+	return kv
 }
 
 func (i *levelIterTestIter) String() string {
@@ -431,14 +428,24 @@ func (i *levelIterTestIter) SeekLT(key []byte, flags base.SeekLTFlags) *base.Int
 	return i.rangeDelSeek(key, kv, -1)
 }
 
+func (i *levelIterTestIter) Next() *base.InternalKV {
+	i.rangeDel = nil
+	return i.levelIter.Next()
+}
+
+func (i *levelIterTestIter) Prev() *base.InternalKV {
+	i.rangeDel = nil
+	return i.levelIter.Prev()
+}
+
 func TestLevelIterSeek(t *testing.T) {
 	lt := newLevelIterTest()
-	defer lt.runClear(nil)
+	defer lt.runClear()
 
 	datadriven.RunTest(t, "testdata/level_iter_seek", func(t *testing.T, d *datadriven.TestData) string {
 		switch d.Cmd {
 		case "clear":
-			return lt.runClear(d)
+			return lt.runClear()
 
 		case "build":
 			return lt.runBuild(d)
@@ -451,7 +458,7 @@ func TestLevelIterSeek(t *testing.T) {
 				manifest.Level(level), internalIterOpts{stats: &stats})
 			defer iter.Close()
 			iter.initRangeDel(&iter.rangeDelIter)
-			return itertest.RunInternalIterCmd(t, d, iter, itertest.Verbose, itertest.WithStats(&stats))
+			return itertest.RunInternalIterCmd(t, d, iter, itertest.Verbose, itertest.WithSpan(iter.getRangeDel), itertest.WithStats(&stats))
 
 		case "iters-created":
 			return fmt.Sprintf("%d", lt.itersCreated)

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/itertest"
@@ -164,18 +165,25 @@ func (lt *levelIterTest) newIters(
 ) (iterSet, error) {
 	lt.itersCreated++
 	transforms := file.IterTransforms()
-	iter, err := lt.readers[file.FileNum].NewIterWithBlockPropertyFiltersAndContextEtc(
-		ctx, transforms,
-		opts.LowerBound, opts.UpperBound, nil, true /* useFilterBlock */, iio.stats, sstable.CategoryAndQoS{},
-		nil, sstable.TrivialReaderProvider{Reader: lt.readers[file.FileNum]})
-	if err != nil {
-		return iterSet{}, err
+	var set iterSet
+	if kinds.Point() {
+		iter, err := lt.readers[file.FileNum].NewIterWithBlockPropertyFiltersAndContextEtc(
+			ctx, transforms,
+			opts.LowerBound, opts.UpperBound, nil, true /* useFilterBlock */, iio.stats, sstable.CategoryAndQoS{},
+			nil, sstable.TrivialReaderProvider{Reader: lt.readers[file.FileNum]})
+		if err != nil {
+			return iterSet{}, errors.CombineErrors(err, set.CloseAll())
+		}
+		set.point = iter
 	}
-	rangeDelIter, err := lt.readers[file.FileNum].NewRawRangeDelIter(transforms)
-	if err != nil {
-		return iterSet{}, err
+	if kinds.RangeDeletion() {
+		rangeDelIter, err := lt.readers[file.FileNum].NewRawRangeDelIter(transforms)
+		if err != nil {
+			return iterSet{}, errors.CombineErrors(err, set.CloseAll())
+		}
+		set.rangeDeletion = rangeDelIter
 	}
-	return iterSet{point: iter, rangeDeletion: rangeDelIter}, nil
+	return set, nil
 }
 
 func (lt *levelIterTest) runClear(d *datadriven.TestData) string {
@@ -344,7 +352,10 @@ func TestLevelIterBoundaries(t *testing.T) {
 			if iter.iterFile == nil {
 				return "nil iterFile"
 			}
-			return fmt.Sprintf("file %d", iter.iterFile.FileNum)
+			if iter.iter != nil {
+				return fmt.Sprintf("file %s [loaded]", iter.iterFile.FileNum)
+			}
+			return fmt.Sprintf("file %s [not loaded]", iter.iterFile.FileNum)
 
 		default:
 			return fmt.Sprintf("unknown command: %s", d.Cmd)

--- a/testdata/level_iter_boundaries
+++ b/testdata/level_iter_boundaries
@@ -271,7 +271,7 @@ a#3,SET:z
 
 file-pos
 ----
-file 0
+file 000000 [loaded]
 
 iter save continue
 seek-prefix-ge a
@@ -282,7 +282,7 @@ a#3,SET:z
 
 file-pos
 ----
-file 0
+file 000000 [loaded]
 
 iter save continue
 set-bounds lower=b upper=c
@@ -292,7 +292,7 @@ seek-ge b
 
 file-pos
 ----
-file 0
+file 000000 [loaded]
 
 iter save continue
 seek-prefix-ge b
@@ -301,7 +301,7 @@ seek-prefix-ge b
 
 file-pos
 ----
-file 0
+file 000000 [loaded]
 
 # Seek to an earlier position just as a sanity check.
 iter save continue
@@ -314,7 +314,7 @@ a#3,SET:z
 
 file-pos
 ----
-file 0
+file 000000 [loaded]
 
 iter save continue
 set-bounds lower=d upper=e
@@ -326,7 +326,7 @@ d#4,SET:z
 
 file-pos
 ----
-file 1
+file 000001 [not loaded]
 
 iter save continue
 seek-prefix-ge d
@@ -337,7 +337,7 @@ d#4,SET:z
 
 file-pos
 ----
-file 1
+file 000001 [not loaded]
 
 iter save continue
 set-bounds lower=e upper=f
@@ -351,7 +351,7 @@ f#72057594037927935,RANGEDEL:
 
 file-pos
 ----
-file 1
+file 000001 [loaded]
 
 iter save continue
 seek-lt f
@@ -364,7 +364,7 @@ e#5,SET:
 
 file-pos
 ----
-file 0
+file 000000 [not loaded]
 
 iter save continue
 set-bounds lower=f upper=g
@@ -378,7 +378,7 @@ f#72057594037927935,RANGEDEL:
 
 file-pos
 ----
-file 1
+file 000001 [loaded]
 
 iter continue
 ----

--- a/testdata/level_iter_seek
+++ b/testdata/level_iter_seek
@@ -34,13 +34,13 @@ h.SET.3:h
 iter
 seek-ge d
 ----
-f/d-e:{(#6,RANGEDEL)}#5,SET:f
+f#5,SET:f / d-e:{(#6,RANGEDEL)}
 
 iter
 set-bounds upper=d
 seek-ge d
 ----
-d/d-e:{(#6,RANGEDEL)}#72057594037927935,RANGEDEL:
+d#72057594037927935,RANGEDEL: / d-e:{(#6,RANGEDEL)}
 
 iter
 set-bounds upper=d
@@ -50,7 +50,7 @@ prev
 next
 next
 ----
-c/d-e:{(#6,RANGEDEL)}#7,SET:c
+c#7,SET:c / d-e:{(#6,RANGEDEL)}
 d#72057594037927935,RANGEDEL:
 c#7,SET:c
 d#72057594037927935,RANGEDEL:
@@ -61,7 +61,7 @@ d#72057594037927935,RANGEDEL:
 iter
 seek-prefix-ge d
 ----
-f/d-e:{(#6,RANGEDEL)}#5,SET:
+f#5,SET: / d-e:{(#6,RANGEDEL)}
 
 # Tests a sequence of SeekPrefixGE with monotonically increasing keys, some of
 # which are present and some not (so fail the bloom filter match). The seek to
@@ -75,13 +75,13 @@ seek-prefix-ge g
 seek-prefix-ge gg
 seek-prefix-ge h
 ----
-./<invalid>#0,DEL:
-c/d-e:{(#6,RANGEDEL)}#7,SET:c
-f/d-e:{(#6,RANGEDEL)}#5,SET:
-f/<invalid>#5,SET:f
-g/<invalid>#4,SET:g
-./<invalid>#0,DEL:
-h/<invalid>#3,SET:h
+.
+c#7,SET:c / d-e:{(#6,RANGEDEL)}
+f#5,SET: / d-e:{(#6,RANGEDEL)}
+f#5,SET:f
+g#4,SET:g
+.
+h#3,SET:h
 
 # Test that when sequentially iterate through all 3 files, the stats
 # accumulate as we close a file and switch to the next one. Also, while in the
@@ -110,7 +110,7 @@ stats
 reset-stats
 stats
 ----
-a/<invalid>#9,SET:a
+a#9,SET:a
 {BlockBytes:56 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 b#8,SET:b
@@ -133,7 +133,7 @@ iter
 set-bounds lower=d
 seek-lt d
 ----
-d/d-e:{(#6,RANGEDEL)}#72057594037927935,RANGEDEL:
+d#72057594037927935,RANGEDEL: / d-e:{(#6,RANGEDEL)}
 
 iter
 set-bounds lower=d
@@ -143,7 +143,7 @@ next
 prev
 prev
 ----
-f/d-e:{(#6,RANGEDEL)}#5,SET:f
+f#5,SET:f / d-e:{(#6,RANGEDEL)}
 d#72057594037927935,RANGEDEL:
 f#5,SET:f
 d#72057594037927935,RANGEDEL:
@@ -211,7 +211,7 @@ prev
 next
 next
 ----
-e/d-e:{(#6,RANGEDEL)}#72057594037927935,RANGEDEL:
+e#72057594037927935,RANGEDEL: / d-e:{(#6,RANGEDEL)}
 c#7,SET:c
 e#72057594037927935,RANGEDEL:
 f#8,SET:f
@@ -222,7 +222,7 @@ next
 prev
 prev
 ----
-a/a-b:{(#5,RANGEDEL)}#5,RANGEDEL:
+a#5,RANGEDEL: / a-b:{(#5,RANGEDEL)}
 c#7,SET:c
 a#5,RANGEDEL:
 .
@@ -245,8 +245,8 @@ seek-lt c
 seek-ge d
 prev
 ----
-b/<invalid>#1,SET:b
-e/d-e:{(#2,RANGEDEL)}#72057594037927935,RANGEDEL:
+b#1,SET:b
+e#72057594037927935,RANGEDEL: / d-e:{(#2,RANGEDEL)}
 b#1,SET:b
 
 # Verify that next when positioned at the smallest boundary returns
@@ -267,8 +267,8 @@ seek-ge d
 seek-lt d
 next
 ----
-d/<invalid>#2,SET:d
-a/a-b:{(#1,RANGEDEL)}#1,RANGEDEL:
+d#2,SET:d
+a#1,RANGEDEL: / a-b:{(#1,RANGEDEL)}
 d#2,SET:d
 
 # Verify SeekPrefixGE correctness with trySeekUsingNext=true
@@ -322,17 +322,17 @@ seek-prefix-ge h true
 seek-prefix-ge i true
 seek-prefix-ge j true
 ----
-a/c-e:{(#4,RANGEDEL)}#1,SET:a
-a/c-e:{(#4,RANGEDEL)}#1,SET:a
-b/c-e:{(#4,RANGEDEL)}#2,SET:b
+a#1,SET:a / c-e:{(#4,RANGEDEL)}
+a#1,SET:a / c-e:{(#4,RANGEDEL)}
+b#2,SET:b / c-e:{(#4,RANGEDEL)}
 e#72057594037927935,RANGEDEL:
-e/c-e:{(#4,RANGEDEL)}#72057594037927935,RANGEDEL:
-e/c-e:{(#4,RANGEDEL)}#72057594037927935,RANGEDEL:
-f/<invalid>#5,SINGLEDEL:
-g/<invalid>#6,SET:g
-h/<invalid>#7,SINGLEDEL:
-i/<invalid>#6,SET:i
-j/<invalid>#7,SET:j
+e#72057594037927935,RANGEDEL: / c-e:{(#4,RANGEDEL)}
+e#72057594037927935,RANGEDEL: / c-e:{(#4,RANGEDEL)}
+f#5,SINGLEDEL:
+g#6,SET:g
+h#7,SINGLEDEL:
+i#6,SET:i
+j#7,SET:j
 
 # Seeks to keys that are in the next file, so cannot use Next.
 iter
@@ -341,10 +341,10 @@ seek-prefix-ge e true
 seek-prefix-ge i true
 seek-prefix-ge j true
 ----
-a/c-e:{(#4,RANGEDEL)}#1,SET:a
-e/<invalid>#4,SET:e
-i/<invalid>#6,SET:i
-j/<invalid>#7,SET:j
+a#1,SET:a / c-e:{(#4,RANGEDEL)}
+e#4,SET:e
+i#6,SET:i
+j#7,SET:j
 
 # Verify that we do not open files that do not have point keys.
 
@@ -386,7 +386,7 @@ seek-ge f
 next
 next
 ----
-f/<invalid>#5,SET:f
+f#5,SET:f
 f#5,SET:
 i#4,SET:i
 


### PR DESCRIPTION
The unit tests TestMergingIterCornerCases, TestLevelIterBoundaries and TestLevelIterSeek all fake tableNewIters implementations, but previously these implementations ignored the requested iterator types, always constructing both point and range deletion iterators.

Additionally, the output of TestLevelIterBoundaries is adjusted to make it clearer when the levelIter has actually opened a file.