### PR TITLE
compaction: move elision of range keys to the iterator

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/internal/testutils"
@@ -599,46 +598,6 @@ func TestElideTombstone(t *testing.T) {
 				return fmt.Sprintf("unknown command: %s", td.Cmd)
 			}
 		})
-}
-
-func TestCompactionTransform(t *testing.T) {
-	datadriven.RunTest(t, "testdata/compaction_transform", func(t *testing.T, td *datadriven.TestData) string {
-		switch td.Cmd {
-		case "transform":
-			var snapshots []uint64
-			var keyRanges []base.UserKeyBounds
-			td.MaybeScanArgs(t, "snapshots", &snapshots)
-			if arg, ok := td.Arg("in-use-key-ranges"); ok {
-				for _, keyRange := range arg.Vals {
-					parts := strings.SplitN(keyRange, "-", 2)
-					start := []byte(strings.TrimSpace(parts[0]))
-					end := []byte(strings.TrimSpace(parts[1]))
-					keyRanges = append(keyRanges, base.UserKeyBoundsInclusive(start, end))
-				}
-			}
-			span := keyspan.ParseSpan(td.Input)
-			for i := range span.Keys {
-				if i > 0 {
-					if span.Keys[i-1].Trailer < span.Keys[i].Trailer {
-						return "span keys not sorted"
-					}
-				}
-			}
-			var outSpan keyspan.Span
-			c := compaction{
-				cmp:            base.DefaultComparer.Compare,
-				comparer:       base.DefaultComparer,
-				inuseKeyRanges: keyRanges,
-			}
-			transformer := rangeKeyCompactionTransform(base.DefaultComparer.Equal, snapshots, c.elideRangeTombstone)
-			if err := transformer.Transform(base.DefaultComparer.Compare, span, &outSpan); err != nil {
-				return fmt.Sprintf("error: %s", err)
-			}
-			return outSpan.String()
-		default:
-			return fmt.Sprintf("unknown command: %s", td.Cmd)
-		}
-	})
 }
 
 type cpuPermissionGranter struct {

--- a/internal/compact/iterator_test.go
+++ b/internal/compact/iterator_test.go
@@ -291,6 +291,64 @@ func TestCompactionIter(t *testing.T) {
 	runTest(t, "testdata/iter_delete_sized")
 }
 
+// TestIterRangeKeys tests the range key coalescing and striping logic.
+func TestIterRangeKeys(t *testing.T) {
+	datadriven.RunTest(t, "testdata/iter_range_keys", func(t *testing.T, td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "transform":
+			var snapshots []uint64
+			var keyRanges []base.UserKeyBounds
+			td.MaybeScanArgs(t, "snapshots", &snapshots)
+			if arg, ok := td.Arg("in-use-key-ranges"); ok {
+				for _, keyRange := range arg.Vals {
+					parts := strings.SplitN(keyRange, "-", 2)
+					start := []byte(strings.TrimSpace(parts[0]))
+					end := []byte(strings.TrimSpace(parts[1]))
+					keyRanges = append(keyRanges, base.UserKeyBoundsInclusive(start, end))
+				}
+			}
+			span := keyspan.ParseSpan(td.Input)
+			for i := range span.Keys {
+				if i > 0 {
+					if span.Keys[i-1].Trailer < span.Keys[i].Trailer {
+						return "span keys not sorted"
+					}
+				}
+			}
+
+			cfg := IterConfig{
+				Cmp:             base.DefaultComparer.Compare,
+				Equal:           base.DefaultComparer.Equal,
+				Snapshots:       snapshots,
+				AllowZeroSeqNum: false,
+				ElideTombstone:  nil,
+				ElideRangeTombstone: func(start, end []byte) bool {
+					b := base.UserKeyBoundsEndExclusive(start, end)
+					for i := range keyRanges {
+						if keyRanges[i].Overlaps(base.DefaultComparer.Compare, &b) {
+							return false
+						}
+					}
+					return true
+				},
+			}
+			input, _, _ := makeInputIter(nil, nil, nil)
+
+			iter := NewIter(cfg, input)
+			iter.AddRangeKeySpan(&span)
+
+			outSpans := iter.RangeKeysUpTo(nil)
+			var b strings.Builder
+			for i := range outSpans {
+				fmt.Fprintf(&b, "%s\n", outSpans[i].String())
+			}
+			return b.String()
+		default:
+			return fmt.Sprintf("unknown command: %s", td.Cmd)
+		}
+	})
+}
+
 // makeInputIter creates an iterator that can be used as an input for the
 // compaction Iter, along with rangeDel and rangeKey interleaving iterators
 // which can be used to retrieve the span corresponding to a range del or range

--- a/internal/compact/testdata/iter_range_keys
+++ b/internal/compact/testdata/iter_range_keys
@@ -49,7 +49,6 @@ a-c:{(#11,RANGEKEYDEL) (#8,RANGEKEYSET,@3,foo5)}
 transform
 a-c:{(#11,RANGEKEYDEL) (#8,RANGEKEYSET,@3,foo5) (#4,RANGEKEYSET,@3,foo3) (#3,RANGEKEYSET,@3,foo2)}
 ----
-a-c:{}
 
 # Test RANGEKEYDELs are preserved over in-use key ranges in the last snapshot stripe.
 # in-use key ranges cover keys that exist in lower levels of the LSM, so dropping
@@ -77,7 +76,6 @@ a-c:{(#13,RANGEKEYSET,@3,bar1) (#12,RANGEKEYSET,@2,bar2)}
 transform
 a-c:{(#11,RANGEKEYUNSET,@3) (#8,RANGEKEYSET,@3,foo5) (#4,RANGEKEYSET,@3,foo3) (#3,RANGEKEYSET,@3,foo2)}
 ----
-a-c:{}
 
 transform in-use-key-ranges=(b-d)
 a-c:{(#11,RANGEKEYUNSET,@3) (#8,RANGEKEYSET,@3,foo5) (#4,RANGEKEYSET,@3,foo3) (#3,RANGEKEYSET,@3,foo2)}


### PR DESCRIPTION
We move the elision of range keys from a transformer in the merging
iterator to the compaction iterator. This is consistent with how we
are handling tombstones, and will make it easier to push down all the
elision logic into the iterator.