### PR TITLE
compaction: move tombstone elision logic to internal/compact

### DIFF
--- a/internal/compact/testdata/tombstone_elider
+++ b/internal/compact/testdata/tombstone_elider
@@ -1,0 +1,96 @@
+init elide-nothing
+----
+
+points
+a
+b
+----
+a: don't elide
+b: don't elide
+
+ranges
+a-d
+a-g
+b-f
+----
+a-d: don't elide
+a-g: don't elide
+b-f: don't elide
+
+init in-use-ranges
+c-e
+g-j
+u-v
+----
+
+points
+a
+b
+c
+d
+e
+h
+k
+u
+w
+----
+a: elide
+b: elide
+c: don't elide
+d: don't elide
+e: elide
+h: don't elide
+k: elide
+u: don't elide
+w: elide
+
+ranges
+a-b
+a-c
+a-d
+a-e
+b-j
+b-c
+e-f
+e-g
+f-z
+f-g
+m-o
+m-n
+m-u
+m-v
+----
+a-b: elide
+a-c: elide
+a-d: don't elide
+a-e: don't elide
+b-j: don't elide
+b-c: elide
+e-f: elide
+e-g: elide
+f-z: don't elide
+f-g: elide
+m-o: elide
+m-n: elide
+m-u: elide
+m-v: don't elide
+
+# No ranges in use (elide everything).
+init in-use-ranges
+----
+
+points
+a
+b
+z
+----
+a: elide
+b: elide
+z: elide
+
+ranges
+a-c
+b-z
+----
+a-c: elide
+b-z: elide

--- a/internal/compact/testdata/tombstone_elision
+++ b/internal/compact/testdata/tombstone_elision
@@ -65,42 +65,30 @@ elideRangeTombstone("k", "l") = true
 
 define
 L1
-  c.SET.801:c
-  g.SET.800:g
-L1
-  x.SET.701:x
-  y.SET.700:y
+  1:[c#801,SET-g#800,SET]
+  2:[x#701,SET-y#700,SET]
 L2
-  d.SET.601:d
-  h.SET.600:h
-L2
-  r.SET.501:r
-  t.SET.500:t
+  3:[d#601,SET-h#600,SET]
+  4:[r#501,SET-t#500,SET]
 L3
-  f.SET.401:f
-  g.SET.400:g
-L3
-  w.SET.301:w
-  x.SET.300:x
+  5:[f#401,SET-g#400,SET]
+  6:[w#301,SET-x#300,SET]
 L4
-  f.SET.201:f
-  m.SET.200:m
-L4
-  t.SET.101:t
-  t.SET.100:t
+  7:[f#201,SET-m#200,SET]
+  8:[t#101,SET-t#100,SET]
 ----
 L1:
-  000004:[c#801,SET-g#800,SET]
-  000005:[x#701,SET-y#700,SET]
+  000001:[c#801,SET-g#800,SET]
+  000002:[x#701,SET-y#700,SET]
 L2:
-  000006:[d#601,SET-h#600,SET]
-  000007:[r#501,SET-t#500,SET]
+  000003:[d#601,SET-h#600,SET]
+  000004:[r#501,SET-t#500,SET]
 L3:
-  000008:[f#401,SET-g#400,SET]
-  000009:[w#301,SET-x#300,SET]
+  000005:[f#401,SET-g#400,SET]
+  000006:[w#301,SET-x#300,SET]
 L4:
-  000010:[f#201,SET-m#200,SET]
-  000011:[t#101,SET-t#101,SET]
+  000007:[f#201,SET-m#200,SET]
+  000008:[t#101,SET-t#100,SET]
 
 elide start-level=1
 a-b
@@ -168,22 +156,15 @@ elideTombstone("y") = true
 elideTombstone("z") = true
 
 define
-L1
-  a.SET.3:v
-L2
-  a.RANGEDEL.2:g
-L3
-  a.SET.0:v
-  b.SET.0:v
-L3
-  c.SET.0:v
-  d.SET.0:v
-L3
-  e.SET.0:v
-  f.SET.1:v
-L3
-  g.SET.1:v
-  g.SET.0:v
+L1:
+  4:[a#3,SET-a#3,SET]
+L2:
+  5:[a#2,RANGEDEL-g#inf,RANGEDEL]
+L3:
+  6:[a#0,SET-b#0,SET]
+  7:[c#0,SET-d#0,SET]
+  8:[e#0,SET-f#1,SET]
+  9:[g#1,SET-g#1,SET]
 ----
 L1:
   000004:[a#3,SET-a#3,SET]
@@ -211,12 +192,11 @@ elideTombstone("f") = false
 elideTombstone("g") = false
 
 define
-L6
-  g.SET.0:g
-  h.RANGEDEL.1:z
+L6:
+  1:[g#0,SET-z#inf,RANGEDEL]
 ----
 L6:
-  000004:[g#0,SET-z#inf,RANGEDEL]
+  000001:[g#0,SET-z#inf,RANGEDEL]
 
 elide start-level=1
 a
@@ -232,7 +212,7 @@ z-zz
 ----
 elideTombstone("a") = true
 elideRangeTombstone("a", "f") = true
-elideRangeTombstone("a", "g") = false
+elideRangeTombstone("a", "g") = true
 elideRangeTombstone("a", "h") = false
 elideTombstone("b") = true
 elideTombstone("g") = false
@@ -242,43 +222,31 @@ elideTombstone("z") = true
 elideRangeTombstone("z", "zz") = true
 
 define
-L1
-  c.SET.801:c
-  g.SET.800:g
-L1
-  x.SET.701:x
-	y.SET.700:y
+L1:
+  1:[c#801,SET-g#800,SET]
+  2:[x#701,SET-y#700,SET]
 L2
-	d.SET.601:d
-	h.SET.600:h
-L2
-	r.SET.501:r
-	t.SET.500:t
-L3
-	f.SET.401:f
-	g.SET.400:g
-L3
-  w.SET.301:w
-  x.SET.300:x
-L4
-  f.SET.201:f
-  m.SET.200:m
-L4
-  t.SET.101:t
-  t.SET.100:t
+  3:[d#601,SET-h#600,SET]
+  4:[r#501,SET-t#500,SET]
+L3:
+  5:[f#401,SET-g#400,SET]
+  6:[w#301,SET-x#300,SET]
+L4:
+  7:[f#201,SET-m#200,SET]
+  8:[t#101,SET-t#101,SET]
 ----
 L1:
-  000004:[c#801,SET-g#800,SET]
-  000005:[x#701,SET-y#700,SET]
+  000001:[c#801,SET-g#800,SET]
+  000002:[x#701,SET-y#700,SET]
 L2:
-  000006:[d#601,SET-h#600,SET]
-  000007:[r#501,SET-t#500,SET]
+  000003:[d#601,SET-h#600,SET]
+  000004:[r#501,SET-t#500,SET]
 L3:
-  000008:[f#401,SET-g#400,SET]
-  000009:[w#301,SET-x#300,SET]
+  000005:[f#401,SET-g#400,SET]
+  000006:[w#301,SET-x#300,SET]
 L4:
-  000010:[f#201,SET-m#200,SET]
-  000011:[t#101,SET-t#101,SET]
+  000007:[f#201,SET-m#200,SET]
+  000008:[t#101,SET-t#101,SET]
 
 elide start-level=1
 b-c
@@ -304,7 +272,7 @@ y-z
 elideRangeTombstone("b", "c") = true
 elideRangeTombstone("c", "d") = true
 elideRangeTombstone("d", "e") = true
-elideRangeTombstone("e", "f") = false
+elideRangeTombstone("e", "f") = true
 elideRangeTombstone("f", "g") = false
 elideRangeTombstone("g", "h") = false
 elideRangeTombstone("h", "i") = false
@@ -313,10 +281,10 @@ elideRangeTombstone("m", "n") = false
 elideRangeTombstone("n", "o") = true
 elideRangeTombstone("q", "r") = true
 elideRangeTombstone("r", "s") = true
-elideRangeTombstone("s", "t") = false
+elideRangeTombstone("s", "t") = true
 elideRangeTombstone("t", "u") = false
 elideRangeTombstone("u", "v") = true
-elideRangeTombstone("v", "w") = false
+elideRangeTombstone("v", "w") = true
 elideRangeTombstone("w", "x") = false
 elideRangeTombstone("x", "y") = false
 elideRangeTombstone("y", "z") = true

--- a/internal/compact/testdata/tombstone_elision_setup
+++ b/internal/compact/testdata/tombstone_elision_setup
@@ -18,10 +18,10 @@ L0 c d
 L0 g h
 L1 a b
 ----
-L0 a-b: [a, b]
-L0 c-d: [d, e)
-L0 g-h: .
-L1 a-b: .
+L0 [a, b]: elide nothing
+L0 [c, d]: [d, e)
+L0 [g, h]: elide everything
+L1 [a, b]: elide everything
 
 define
 L1
@@ -40,10 +40,10 @@ L1 a aa
 L1 a b
 L2 a z
 ----
-L0 a-c: [a, c]
-L1 a-aa: .
-L1 a-b: [b, c]
-L2 a-z: .
+L0 [a, c]: elide nothing
+L1 [a, aa]: elide everything
+L1 [a, b]: [b, c]
+L2 [a, z]: elide everything
 
 define
 L1
@@ -60,8 +60,8 @@ inuse-key-ranges
 L0 a c
 L0 a b
 ----
-L0 a-c: [a, b] [c, d]
-L0 a-b: [a, b]
+L0 [a, c]: [a, b] [c, d]
+L0 [a, b]: elide nothing
 
 define
 L1
@@ -77,7 +77,7 @@ L2:
 inuse-key-ranges
 L0 a c
 ----
-L0 a-c: [a, c]
+L0 [a, c]: elide nothing
 
 define
 L1
@@ -93,7 +93,7 @@ L2:
 inuse-key-ranges
 L0 a c
 ----
-L0 a-c: [a, b] [c, d]
+L0 [a, c]: [a, b] [c, d]
 
 define
 L1
@@ -113,9 +113,9 @@ L0 a z
 L0 a c
 L0 g z
 ----
-L0 a-z: [a, b) [c, d) [f, g) [i, j)
-L0 a-c: [a, b) [c, d)
-L0 g-z: [i, j)
+L0 [a, z]: [a, b) [c, d) [f, g) [i, j)
+L0 [a, c]: [a, b) [c, d)
+L0 [g, z]: [i, j)
 
 define
 L1
@@ -139,7 +139,7 @@ L6:
 inuse-key-ranges
 L0 a z
 ----
-L0 a-z: [a, j) [k, z)
+L0 [a, z]: [a, j) [k, z)
 
 define
 L0
@@ -164,7 +164,7 @@ L6:
 inuse-key-ranges
 L0 a z
 ----
-L0 a-z: [a, j) [k, z)
+L0 [a, z]: [a, j) [k, z)
 
 define
 L0
@@ -196,13 +196,13 @@ L0 q r
 L0 1 2
 L0 ddd dddd
 ----
-L0 a-z: [a, dd) [e, p)
-L0 e-p: [e, p)
-L0 e-f: [e, m)
-L0 b-c: [b, dd)
-L0 q-r: .
-L0 1-2: .
-L0 ddd-dddd: .
+L0 [a, z]: [a, dd) [e, p)
+L0 [e, p]: [e, p)
+L0 [e, f]: elide nothing
+L0 [b, c]: elide nothing
+L0 [q, r]: elide everything
+L0 [1, 2]: elide everything
+L0 [ddd, dddd]: elide everything
 
 define
 L1
@@ -240,13 +240,13 @@ L5 mm zz
 L5 l x
 L5 l zz
 ----
-L5 a-z: [m, z)
-L5 a-b: .
-L5 m-z: [m, z)
-L5 m-zz: [m, z)
-L5 mm-zz: [m, z)
-L5 l-x: [m, z)
-L5 l-zz: [m, z)
+L5 [a, z]: [m, z)
+L5 [a, b]: elide everything
+L5 [m, z]: [m, z)
+L5 [m, zz]: [m, z)
+L5 [mm, zz]: [m, z)
+L5 [l, x]: [m, z)
+L5 [l, zz]: [m, z)
 
 inuse-key-ranges
 L3 a z
@@ -255,21 +255,21 @@ L3 k m
 L3 l ll
 L3 b n
 ----
-L3 a-z: [f, k) [m, z)
-L3 f-k: [f, k)
-L3 k-m: [m, z)
-L3 l-ll: .
-L3 b-n: [f, k) [m, z)
+L3 [a, z]: [f, k) [m, z)
+L3 [f, k]: [f, k)
+L3 [k, m]: [m, z)
+L3 [l, ll]: elide everything
+L3 [b, n]: [f, k) [m, z)
 
 inuse-key-ranges
 L2 a z
 ----
-L2 a-z: [b, c) [f, k) [m, z)
+L2 [a, z]: [b, c) [f, k) [m, z)
 
 inuse-key-ranges
 L1 a z
 ----
-L1 a-z: [b, d) [f, k) [m, z)
+L1 [a, z]: [b, d) [f, k) [m, z)
 
 inuse-key-ranges
 L0 a z
@@ -278,11 +278,11 @@ L0 a b
 L0 bb bc
 L0 f k
 ----
-L0 a-z: [a, k) [m, z)
-L0 a-k: [a, k)
-L0 a-b: [a, c)
-L0 bb-bc: [b, c)
-L0 f-k: [d, k)
+L0 [a, z]: [a, k) [m, z)
+L0 [a, k]: [a, k)
+L0 [a, b]: elide nothing
+L0 [bb, bc]: elide nothing
+L0 [f, k]: [d, k)
 
 define
 L1
@@ -321,16 +321,16 @@ L0 p z
 L0 pp z
 L0 oo z
 ----
-L3 a-z: [a, f) [w, z)
-L2 a-z: [a, k) [s, z)
-L1 a-z: [a, n) [o, z)
-L0 a-z: [a, z)
-L0 a-n: [a, p)
-L0 a-mm: [a, p)
-L0 a-nn: [a, p)
-L0 p-z: [o, z)
-L0 pp-z: [o, z)
-L0 oo-z: [m, z)
+L3 [a, z]: [a, f) [w, z)
+L2 [a, z]: [a, k) [s, z)
+L1 [a, z]: [a, n) [o, z)
+L0 [a, z]: [a, z)
+L0 [a, n]: elide nothing
+L0 [a, mm]: elide nothing
+L0 [a, nn]: elide nothing
+L0 [p, z]: [o, z)
+L0 [pp, z]: [o, z)
+L0 [oo, z]: [m, z)
 
 define
 L1
@@ -351,8 +351,8 @@ inuse-key-ranges
 L0 a c
 L0 a cc
 ----
-L0 a-c: [a, c)
-L0 a-cc: [a, c) [cc, cca)
+L0 [a, c]: [a, c)
+L0 [a, cc]: [a, c) [cc, cca)
 
 define
 L1
@@ -379,10 +379,10 @@ L0 a cc
 L0 a d
 L0 c c
 ----
-L0 a-c: [a, ca)
-L0 a-cc: [a, d)
-L0 a-d: [a, d)
-L0 c-c: [c, ca)
+L0 [a, c]: elide nothing
+L0 [a, cc]: elide nothing
+L0 [a, d]: [a, d)
+L0 [c, c]: elide nothing
 
 define
 L0
@@ -415,5 +415,5 @@ inuse-key-ranges
 L0 a z
 L1 a z
 ----
-L0 a-z: [a, aa) [b, ba) [bb, bba) [c, ca) [d, i)
-L1 a-z: [b, ba) [bb, bba) [c, ca) [e, ea)
+L0 [a, z]: [a, aa) [b, ba) [bb, bba) [c, ca) [d, i)
+L1 [a, z]: [b, ba) [bb, bba) [c, ca) [e, ea)

--- a/internal/compact/tombstone_elision.go
+++ b/internal/compact/tombstone_elision.go
@@ -1,0 +1,190 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package compact
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/internal/manifest"
+)
+
+// TombstoneElision is the information required to determine which tombstones
+// (in the bottom snapshot stripe) can be elided. For example, when compacting
+// into L6 (the lowest level), we can elide all tombstones (in the bottom
+// snapshot stripe).
+//
+// TombstoneElision can indicate that no tombstones can be elided, or it can
+// store a set of key ranges where only tombstones that do NOT overlap those key
+// ranges can be elided.
+//
+// Note that the concept of "tombstone" applies to range keys as well:
+// RangeKeyUnset and RangeKeyDelete are considered tombstones w.r.t other
+// range keys and can use TombstoneElision.
+type TombstoneElision struct {
+	mode        tombstoneElisionMode
+	inUseRanges []base.UserKeyBounds
+}
+
+type tombstoneElisionMode int8
+
+const (
+	elideNothing tombstoneElisionMode = iota
+	elideNotInUse
+)
+
+// NoTombstoneElision is used when no tombstones can be elided (e.g. the entire
+// compaction range is in use).
+func NoTombstoneElision() TombstoneElision {
+	return TombstoneElision{mode: elideNothing}
+}
+
+// ElideTombstonesOutsideOf is used when tombstones can be elided if they don't
+// overlap with a set of "in use" key ranges. These ranges must be ordered and
+// disjoint.
+func ElideTombstonesOutsideOf(inUseRanges []base.UserKeyBounds) TombstoneElision {
+	return TombstoneElision{
+		mode:        elideNotInUse,
+		inUseRanges: inUseRanges,
+	}
+}
+
+// ElidesNothing returns true if no tombstones will be elided.
+func (e TombstoneElision) ElidesNothing() bool {
+	return e.mode == elideNothing
+}
+
+// ElidesEverything returns true if all tombstones (in the bottom snapshot
+// stripe) can be elided.
+func (e TombstoneElision) ElidesEverything() bool {
+	return e.mode == elideNotInUse && len(e.inUseRanges) == 0
+}
+
+func (e TombstoneElision) String() string {
+	switch {
+	case e.ElidesNothing():
+		return "elide nothing"
+	case e.ElidesEverything():
+		return "elide everything"
+	default:
+		var b strings.Builder
+		for i, r := range e.inUseRanges {
+			if i > 0 {
+				b.WriteString(" ")
+			}
+			b.WriteString(r.String())
+		}
+		return b.String()
+	}
+}
+
+// pointTombstoneElider is used to check if point tombstones (i.e. DEL/SINGLEDELs) can
+// be elided.
+type pointTombstoneElider struct {
+	cmp     base.Compare
+	elision TombstoneElision
+	// inUseIdx is an index into elision.inUseRanges; it points to the first
+	// range that ends after the last key passed to ShouldElide.
+	inUseIdx int
+}
+
+func (te *pointTombstoneElider) Init(cmp base.Compare, elision TombstoneElision) {
+	*te = pointTombstoneElider{
+		cmp:     cmp,
+		elision: elision,
+	}
+}
+
+// ShouldElide returns true if a point tombstone with the given key can be
+// elided. The keys in multiple invocations to ShouldElide must be supplied in
+// order.
+func (te *pointTombstoneElider) ShouldElide(key []byte) bool {
+	if te.elision.ElidesNothing() {
+		return false
+	}
+
+	inUseRanges := te.elision.inUseRanges
+	if invariants.Enabled && te.inUseIdx > 0 && inUseRanges[te.inUseIdx-1].End.IsUpperBoundFor(te.cmp, key) {
+		panic("ShouldElidePoint called with out-of-order key")
+	}
+	// Advance inUseIdx to the first in-use range that ends after key.
+	for te.inUseIdx < len(te.elision.inUseRanges) && !inUseRanges[te.inUseIdx].End.IsUpperBoundFor(te.cmp, key) {
+		te.inUseIdx++
+	}
+	// We can elide the point tombstone if this range starts after the key.
+	return te.inUseIdx >= len(te.elision.inUseRanges) || te.cmp(inUseRanges[te.inUseIdx].Start, key) > 0
+}
+
+// rangeTombstoneElider is used to check if range tombstones can be elided.
+//
+// It can be used for RANGEDELs (in which case, the "in use" ranges reflect
+// point keys); or for RANGEKEYUNSET, RANGEKEYDELETE, in which case the "in use"
+// ranges reflect range keys.
+type rangeTombstoneElider struct {
+	cmp     base.Compare
+	elision TombstoneElision
+	// inUseIdx is an index into elision.inUseRanges; it points to the first
+	// range that ends after the last start key passed to ShouldElide.
+	inUseIdx int
+}
+
+func (te *rangeTombstoneElider) Init(cmp base.Compare, elision TombstoneElision) {
+	*te = rangeTombstoneElider{
+		cmp:     cmp,
+		elision: elision,
+	}
+}
+
+// ShouldElide returns true if the tombstone for the given end-exclusive range
+// can be elided. The start keys in multiple invocations to ShouldElide must be
+// supplied in order.
+func (te *rangeTombstoneElider) ShouldElide(start, end []byte) bool {
+	if te.elision.ElidesNothing() {
+		return false
+	}
+
+	inUseRanges := te.elision.inUseRanges
+	if invariants.Enabled && te.inUseIdx > 0 && inUseRanges[te.inUseIdx-1].End.IsUpperBoundFor(te.cmp, start) {
+		panic("ShouldElideRange called with out-of-order key")
+	}
+	// Advance inUseIdx to the first in-use range that ends after start.
+	for te.inUseIdx < len(te.elision.inUseRanges) && !inUseRanges[te.inUseIdx].End.IsUpperBoundFor(te.cmp, start) {
+		te.inUseIdx++
+	}
+	// We can elide the range tombstone if this range starts after the tombstone ends.
+	return te.inUseIdx >= len(te.elision.inUseRanges) || te.cmp(inUseRanges[te.inUseIdx].Start, end) >= 0
+}
+
+// SetupTombstoneElision calculates the TombstoneElision policies for a
+// compaction operating on the given version and output level.
+func SetupTombstoneElision(
+	cmp base.Compare, v *manifest.Version, outputLevel int, compactionBounds base.UserKeyBounds,
+) (dels, rangeKeys TombstoneElision) {
+	// We want to calculate the in-use key ranges from the levels below our output
+	// level, unless it is L0; L0 requires special treatment, since sstables
+	// within L0 may overlap.
+	startLevel := 0
+	if outputLevel > 0 {
+		startLevel = outputLevel + 1
+	}
+	// CalculateInuseKeyRanges will return a series of sorted spans. Overlapping
+	// or abutting spans have already been merged.
+	inUseKeyRanges := v.CalculateInuseKeyRanges(
+		startLevel, manifest.NumLevels-1, compactionBounds.Start, compactionBounds.End.Key,
+	)
+	// Check if there's a single in-use span that encompasses the entire key range
+	// of the compaction. This is an optimization to avoid key comparisons against
+	// the in-use ranges during the compaction when every key within the
+	// compaction overlaps with an in-use span.
+	if len(inUseKeyRanges) == 1 && inUseKeyRanges[0].ContainsBounds(cmp, &compactionBounds) {
+		dels = NoTombstoneElision()
+	} else {
+		dels = ElideTombstonesOutsideOf(inUseKeyRanges)
+	}
+	// TODO(radu): we should calculate in-use ranges separately for point keys and for range keys.
+	rangeKeys = dels
+	return dels, rangeKeys
+}

--- a/internal/compact/tombstone_elision_test.go
+++ b/internal/compact/tombstone_elision_test.go
@@ -1,0 +1,167 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package compact
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+)
+
+func TestTombstoneElider(t *testing.T) {
+	var elision TombstoneElision
+	toStr := map[bool]string{true: "elide", false: "don't elide"}
+	datadriven.RunTest(t, "testdata/tombstone_elider", func(t *testing.T, d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "init":
+			if len(d.CmdArgs) != 1 {
+				d.Fatalf(t, "init requires one arg: elide-nothing or in-use-ranges")
+			}
+			switch arg := d.CmdArgs[0].Key; arg {
+			case "elide-nothing":
+				elision = NoTombstoneElision()
+
+			case "in-use-ranges":
+				var inUseRanges []base.UserKeyBounds
+				if d.Input != "" {
+					for _, line := range strings.Split(d.Input, "\n") {
+						fields := strings.FieldsFunc(line, func(r rune) bool { return r == '-' })
+						if len(fields) != 2 {
+							d.Fatalf(t, "invalid range %q", line)
+						}
+						inUseRanges = append(inUseRanges, base.UserKeyBoundsEndExclusive([]byte(fields[0]), []byte(fields[1])))
+					}
+				}
+				elision = ElideTombstonesOutsideOf(inUseRanges)
+
+			default:
+				d.Fatalf(t, "unknown arg: %s", arg)
+			}
+
+		case "points":
+			var e pointTombstoneElider
+			e.Init(base.DefaultComparer.Compare, elision)
+			var results []string
+			for _, line := range strings.Split(d.Input, "\n") {
+				fields := strings.FieldsFunc(line, func(r rune) bool { return r == '-' })
+				if len(fields) != 1 {
+					d.Fatalf(t, "invalid point %q", line)
+				}
+				key := []byte(fields[0])
+				results = append(results, fmt.Sprintf("%s: %s", key, toStr[e.ShouldElide(key)]))
+			}
+			return strings.Join(results, "\n")
+
+		case "ranges":
+			var e rangeTombstoneElider
+			e.Init(base.DefaultComparer.Compare, elision)
+			var results []string
+			for _, line := range strings.Split(d.Input, "\n") {
+				fields := strings.FieldsFunc(line, func(r rune) bool { return r == '-' })
+				if len(fields) != 2 {
+					d.Fatalf(t, "invalid range %q", line)
+				}
+				start := []byte(fields[0])
+				end := []byte(fields[1])
+				results = append(results, fmt.Sprintf("%s-%s: %s", start, end, toStr[e.ShouldElide(start, end)]))
+			}
+			return strings.Join(results, "\n")
+
+		default:
+			d.Fatalf(t, "unknown command: %s", d.Cmd)
+		}
+		return ""
+	})
+}
+
+func TestSetupTombstoneElision(t *testing.T) {
+	var v *manifest.Version
+	datadriven.RunTest(t, "testdata/tombstone_elision_setup", func(t *testing.T, td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "define":
+			var err error
+			v, err = manifest.ParseVersionDebug(base.DefaultComparer, 64*1024, td.Input)
+			if err != nil {
+				td.Fatalf(t, "%v", err)
+			}
+			if err := v.CheckOrdering(); err != nil {
+				td.Fatalf(t, "%v", err)
+			}
+			return v.String()
+
+		case "inuse-key-ranges":
+			var buf bytes.Buffer
+			for _, line := range strings.Split(td.Input, "\n") {
+				parts := strings.Fields(line)
+				if len(parts) != 3 {
+					fmt.Fprintf(&buf, "expected <output-level> <smallest> <largest>: %q\n", line)
+					continue
+				}
+				outputLevel, err := strconv.Atoi(strings.TrimPrefix(parts[0], "L"))
+				if err != nil {
+					fmt.Fprintf(&buf, "expected <output-level> <smallest> <largest>: %q: %v\n", line, err)
+					continue
+				}
+				bounds := base.UserKeyBoundsInclusive([]byte(parts[1]), []byte(parts[2]))
+				res, _ := SetupTombstoneElision(base.DefaultComparer.Compare, v, outputLevel, bounds)
+				fmt.Fprintf(&buf, "L%d %s: %s\n", outputLevel, bounds, res)
+			}
+			return buf.String()
+
+		default:
+			return fmt.Sprintf("unknown command: %s", td.Cmd)
+		}
+	})
+}
+
+func TestTombstoneElision(t *testing.T) {
+	var v *manifest.Version
+	datadriven.RunTest(t, "testdata/tombstone_elision", func(t *testing.T, td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "define":
+			var err error
+			v, err = manifest.ParseVersionDebug(base.DefaultComparer, 64*1024, td.Input)
+			if err != nil {
+				td.Fatalf(t, "%v", err)
+			}
+			if err := v.CheckOrdering(); err != nil {
+				td.Fatalf(t, "%v", err)
+			}
+			if td.HasArg("verbose") {
+				return v.DebugString()
+			}
+			return v.String()
+		case "elide":
+			var startLevel int
+			td.ScanArgs(t, "start-level", &startLevel)
+			del, _ := SetupTombstoneElision(testkeys.Comparer.Compare, v, startLevel+1, base.UserKeyBoundsInclusive([]byte("a"), []byte("z")))
+			var p pointTombstoneElider
+			p.Init(testkeys.Comparer.Compare, del)
+			var r rangeTombstoneElider
+			r.Init(testkeys.Comparer.Compare, del)
+			var buf bytes.Buffer
+			for _, line := range strings.Split(td.Input, "\n") {
+				switch f := strings.FieldsFunc(line, func(r rune) bool { return r == '-' }); len(f) {
+				case 1:
+					fmt.Fprintf(&buf, "elideTombstone(%q) = %t\n", f[0], p.ShouldElide([]byte(f[0])))
+				case 2:
+					fmt.Fprintf(&buf, "elideRangeTombstone(%q, %q) = %t\n", f[0], f[1], r.ShouldElide([]byte(f[0]), []byte(f[1])))
+				default:
+					td.Fatalf(t, "invalid line %q", line)
+				}
+			}
+			return buf.String()
+		default:
+			return fmt.Sprintf("unknown command: %s", td.Cmd)
+		}
+	})
+}

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -1406,6 +1406,8 @@ func seekGT(iter *LevelIterator, cmp base.Compare, boundary base.UserKeyBoundary
 	}
 	// If boundary is inclusive or the file boundary is exclusive we do not
 	// tolerate an equal largest key.
+	// Note: we know f.Largest.UserKey >= boundary.End.Key so this condition is
+	// equivalent to boundary.End.IsUpperBoundForInternalKey(cmp, f.Largest).
 	if (boundary.Kind == base.Inclusive || f.Largest.IsExclusiveSentinel()) && cmp(boundary.Key, f.Largest.UserKey) == 0 {
 		return iter.Next()
 	}

--- a/testdata/manual_compaction_set_with_del_sstable_Pebblev4
+++ b/testdata/manual_compaction_set_with_del_sstable_Pebblev4
@@ -323,7 +323,7 @@ b: (2, .)
 z: (1, .)
 .
 
-# Regresion test for a bug in sstable smallest boundary generation
+# Regression test for a bug in sstable smallest boundary generation
 # where the smallest key for an sstable was set to a key "larger" than
 # the start key of the first range tombstone. This in turn fouled up
 # the processing logic of range tombstones used by mergingIter which
@@ -354,7 +354,7 @@ compact a-e L1
 L0.0:
   000004:[c#4,SET-c#4,SET]
 L2:
-  000008:[a#3,SET-b#inf,RANGEDEL]
+  000008:[a#3,SET-a#3,SET]
   000009:[b#2,RANGEDEL-e#inf,RANGEDEL]
 L3:
   000007:[b#1,SET-b#1,SET]


### PR DESCRIPTION
We move the logic that sets up the in-use key ranges and then uses
those to determine which tombstones need to be elided.

We store the in-use key ranges in a new type `TombstoneElision`. The
`TombstoneElision` is passed to the compaction iterator, replacing the
`ElideTombstone` and `ElideRangeTombstone` callbacks.

New point and range elider types are used to check against the in-use
ranges. They assume the "queries" are ordered.

The minor test result changes are due to the new code being better at
taking into account exclusive boundaries.