### PR TITLE
db: rework mergingIter and levelIter synthetic keys

### DIFF
--- a/db.go
+++ b/db.go
@@ -1468,7 +1468,6 @@ func (i *Iterator) constructPointIter(
 
 			li.init(ctx, i.opts, &i.comparer, i.newIters, files, level, internalOpts)
 			li.initRangeDel(&mlevels[mlevelsIndex].rangeDelIter)
-			li.initBoundaryContext(&mlevels[mlevelsIndex].levelIterBoundaryContext)
 			li.initCombinedIterState(&i.lazyCombinedIter.combinedIterState)
 			mlevels[mlevelsIndex].levelIter = li
 			mlevels[mlevelsIndex].iter = invalidating.MaybeWrapIfInvariants(li)

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -307,7 +307,6 @@ func TestMergingIterCornerCases(t *testing.T) {
 				i := len(levelIters)
 				levelIters = append(levelIters, mergingIterLevel{iter: li})
 				li.initRangeDel(&levelIters[i].rangeDelIter)
-				li.initBoundaryContext(&levelIters[i].levelIterBoundaryContext)
 			}
 			miter := &mergingIter{}
 			miter.init(nil /* opts */, &stats, cmp, func(a []byte) int { return len(a) }, levelIters...)
@@ -679,7 +678,6 @@ func buildMergingIter(readers [][]*sstable.Reader, levelSlices []manifest.LevelS
 			context.Background(), IterOptions{}, testkeys.Comparer, newIters, levelSlices[i].Iter(),
 			manifest.Level(level), internalIterOpts{})
 		l.initRangeDel(&mils[level].rangeDelIter)
-		l.initBoundaryContext(&mils[level].levelIterBoundaryContext)
 		mils[level].iter = l
 	}
 	var stats base.InternalIteratorStats

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -900,7 +900,6 @@ func (i *scanInternalIterator) constructPointIter(
 		li.init(
 			i.ctx, i.opts.IterOptions, i.comparer, i.newIters, files, level,
 			internalIterOpts{})
-		li.initBoundaryContext(&mlevels[mlevelsIndex].levelIterBoundaryContext)
 		mlevels[mlevelsIndex].iter = li
 		rli.Init(keyspan.SpanIterOptions{RangeKeyFilters: i.opts.RangeKeyFilters},
 			i.comparer.Compare, tableNewRangeDelIter(i.ctx, i.newIters), files, level,

--- a/testdata/level_iter_boundaries
+++ b/testdata/level_iter_boundaries
@@ -12,7 +12,7 @@ prev
 ----
 d#72057594037927935,RANGEDEL:
 .
-a#1,RANGEDEL:
+a#72057594037927935,RANGEDEL:
 .
 
 iter
@@ -23,7 +23,7 @@ prev
 ----
 d#72057594037927935,RANGEDEL:
 .
-a#1,RANGEDEL:
+a#72057594037927935,RANGEDEL:
 .
 
 iter
@@ -34,7 +34,7 @@ prev
 ----
 d#72057594037927935,RANGEDEL:
 .
-a#1,RANGEDEL:
+a#72057594037927935,RANGEDEL:
 .
 
 iter
@@ -90,7 +90,7 @@ prev
 prev
 ----
 c#3,SET:c
-b#2,RANGEDEL:
+b#72057594037927935,RANGEDEL:
 a#1,SET:a
 .
 
@@ -117,7 +117,7 @@ last
 prev
 ----
 a#1,SET:b
-a#1,SET:
+a#72057594037927935,RANGEDEL:
 
 clear
 ----
@@ -134,7 +134,7 @@ next
 next
 ----
 c#2,SET:c
-c#2,SET:
+c#72057594037927935,RANGEDEL:
 .
 
 iter
@@ -143,7 +143,7 @@ prev
 prev
 ----
 c#2,SET:c
-a#1,RANGEDEL:
+a#72057594037927935,RANGEDEL:
 .
 
 # Regression test to check that Seek{GE,LT} work properly in certain
@@ -174,9 +174,9 @@ e#72057594037927935,RANGEDEL:
 d#3,SET:d
 e#72057594037927935,RANGEDEL:
 d#3,SET:d
-c#2,RANGEDEL:
+c#72057594037927935,RANGEDEL:
 d#3,SET:d
-c#2,RANGEDEL:
+c#72057594037927935,RANGEDEL:
 d#3,SET:d
 
 # Regression test to check that Seek{GE,LT}, First, and Last do not
@@ -359,7 +359,7 @@ prev
 prev
 ----
 e#5,SET:z
-e#5,SET:
+e#72057594037927935,RANGEDEL:
 .
 
 file-pos

--- a/testdata/level_iter_seek
+++ b/testdata/level_iter_seek
@@ -61,7 +61,7 @@ d#72057594037927935,RANGEDEL:
 iter
 seek-prefix-ge d
 ----
-f#5,SET: / d-e:{(#6,RANGEDEL)}
+f#72057594037927935,RANGEDEL: / d-e:{(#6,RANGEDEL)}
 
 # Tests a sequence of SeekPrefixGE with monotonically increasing keys, some of
 # which are present and some not (so fail the bloom filter match). The seek to
@@ -77,7 +77,7 @@ seek-prefix-ge h
 ----
 .
 c#7,SET:c / d-e:{(#6,RANGEDEL)}
-f#5,SET: / d-e:{(#6,RANGEDEL)}
+f#72057594037927935,RANGEDEL: / d-e:{(#6,RANGEDEL)}
 f#5,SET:f
 g#4,SET:g
 .
@@ -119,7 +119,7 @@ c#7,SET:c
 {BlockBytes:56 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 f#5,SET:f
 {BlockBytes:56 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
-f#5,SET:
+f#72057594037927935,RANGEDEL:
 {BlockBytes:56 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 g#4,SET:g
 {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
@@ -222,9 +222,9 @@ next
 prev
 prev
 ----
-a#5,RANGEDEL: / a-b:{(#5,RANGEDEL)}
+a#72057594037927935,RANGEDEL: / a-b:{(#5,RANGEDEL)}
 c#7,SET:c
-a#5,RANGEDEL:
+a#72057594037927935,RANGEDEL:
 .
 
 # Verify that prev when positioned at the largest boundary returns the
@@ -268,7 +268,7 @@ seek-lt d
 next
 ----
 d#2,SET:d
-a#1,RANGEDEL: / a-b:{(#1,RANGEDEL)}
+a#72057594037927935,RANGEDEL: / a-b:{(#1,RANGEDEL)}
 d#2,SET:d
 
 # Verify SeekPrefixGE correctness with trySeekUsingNext=true
@@ -387,7 +387,7 @@ next
 next
 ----
 f#5,SET:f
-f#5,SET:
+f#72057594037927935,RANGEDEL:
 i#4,SET:i
 
 # The below count should be 2, as we skip over the rangekey-only file.

--- a/testdata/merging_iter
+++ b/testdata/merging_iter
@@ -40,7 +40,7 @@ c#27,SET:27
 e#10,SET:10
 g#20,SET:20
 .
-{BlockBytes:116 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:6 ValueBytes:8 PointCount:6 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:116 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:4 ValueBytes:8 PointCount:4 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 
 # seekGE() should not allow the rangedel to act on points in the lower sstable that are after it.
@@ -636,9 +636,9 @@ a#30,SET:30
 f#21,SET:21
 {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:5 ValueBytes:10 PointCount:5 PointsCoveredByRangeTombstones:4 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 .
-{BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:6 ValueBytes:10 PointCount:6 PointsCoveredByRangeTombstones:4 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:5 ValueBytes:10 PointCount:5 PointsCoveredByRangeTombstones:4 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 .
-{BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:6 ValueBytes:10 PointCount:6 PointsCoveredByRangeTombstones:4 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+{BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:5 ValueBytes:10 PointCount:5 PointsCoveredByRangeTombstones:4 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 
 # Test a dead simple error handling case of a 1-level seek erroring.
 


### PR DESCRIPTION
The merging iterator and the level iterator are more tightly coupled than desired. Most of this coupling is a consequence of range deletions. The merging iterator is responsible for applying range deletions across levels and requires that the level iterator not progress to a new file until the file's range deletions are no longer relevant to other levels. It does this by interleaving "synthetic" keys. When these keys reach the top of the heap, it signals that all other levels have progressed to a point where the current file's range deletions are no longer relevant.

Previously, knowledge of which keys were interleaved "synthetic" keys was propagated indirectly—outside the internal iterator interface—through a pointer to a levelIterBoundaryContext struct with boolean fields. This commit instead always interleaves synthetic keys as range deletion exclusive sentinels. The merging iterator can infer which keys are synthetic by calling InternalKey.IsExclusiveSentinel. Propagating this information directly through the internal iterator interface is more direct and understandable.

Beyond needing to know which keys are synthetic, the merging iterator also must know when user-imposed iteration bounds have been reached. Ordinarily when bounds have been reached, internal iterators become exhausted. Since the levelIter's file's range deletions may still be relevant, it cannot and it interleaves a "synthetic" key at the iteration bound. When this key reaches the top of the merging iterator's heap, there are no more keys within bounds and the merging iterator is exhausted. To make this determination, we add a simple key comparison. The use of a key comparison is expected to be acceptable, because it's only performed when a synthetic key reaches the top of the heap. This additional key comparison should ultimately be eliminated when #2863 is complete.

Informs #2863.