### PR TITLE
sstable: remove PreviousPointKeyOpt

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2675,7 +2675,6 @@ func (d *DB) runCompaction(
 	// compaction loop to make a copy of each key ahead of time. Users
 	// must be careful, because the byte slice returned by UnsafeKey
 	// points directly into the Writer's block buffer.
-	var prevPointKey sstable.PreviousPointKeyOpt
 	var cpuWorkHandle CPUWorkHandle
 	defer func() {
 		if cpuWorkHandle != nil {
@@ -2760,7 +2759,7 @@ func (d *DB) runCompaction(
 			d.opts.Experimental.MaxWriterConcurrency > 0 &&
 				(cpuWorkHandle.Permitted() || d.opts.Experimental.ForceWriterParallelism)
 
-		tw = sstable.NewWriter(writable, writerOpts, cacheOpts, &prevPointKey)
+		tw = sstable.NewWriter(writable, writerOpts, cacheOpts)
 
 		fileMeta.CreationTime = time.Now().Unix()
 		ve.NewFiles = append(ve.NewFiles, newFileEntry{
@@ -2991,7 +2990,7 @@ func (d *DB) runCompaction(
 		// Return the largest point key written to tw or the start of
 		// the current range deletion in the fragmenter, whichever is
 		// greater.
-		prevPoint := prevPointKey.UnsafeKey()
+		prevPoint := tw.UnsafeLastPointKey()
 		if c.cmp(prevPoint.UserKey, iter.FirstTombstoneStart()) > 0 {
 			return prevPoint.UserKey
 		}

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -2151,32 +2151,19 @@ type WriterOption interface {
 	writerApply(*Writer)
 }
 
-// PreviousPointKeyOpt is a WriterOption that provides access to the last
-// point key written to the writer while building a sstable.
-type PreviousPointKeyOpt struct {
-	w *Writer
-}
-
-// UnsafeKey returns the last point key written to the writer to which this
-// option was passed during creation. The returned key points directly into
+// UnsafeLastPointKey returns the last point key written to the writer to which
+// this option was passed during creation. The returned key points directly into
 // a buffer belonging to the Writer. The value's lifetime ends the next time a
 // point key is added to the Writer.
-// Invariant: UnsafeKey isn't and shouldn't be called after the Writer is closed.
-func (o PreviousPointKeyOpt) UnsafeKey() base.InternalKey {
-	if o.w == nil {
-		return base.InvalidInternalKey
-	}
-
-	if o.w.dataBlockBuf.dataBlock.nEntries >= 1 {
-		// o.w.dataBlockBuf.dataBlock.curKey is guaranteed to point to the last point key
+//
+// Must not be called after Writer is closed.
+func (w *Writer) UnsafeLastPointKey() base.InternalKey {
+	if w.dataBlockBuf.dataBlock.nEntries >= 1 {
+		// w.dataBlockBuf.dataBlock.curKey is guaranteed to point to the last point key
 		// which was added to the Writer.
-		return o.w.dataBlockBuf.dataBlock.getCurKey()
+		return w.dataBlockBuf.dataBlock.getCurKey()
 	}
 	return base.InternalKey{}
-}
-
-func (o *PreviousPointKeyOpt) writerApply(w *Writer) {
-	o.w = w
 }
 
 // NewWriter returns a new table writer for the file. Closing the writer will


### PR DESCRIPTION
This code removes the `PreviousPointKeyOpt` and replaces it with a simple method on the writer.