### PR TITLE
db,wal: avoid Batch.refData allocation

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -467,11 +467,11 @@ func TestBatchReuse(t *testing.T) {
 					fmt.Fprintf(&buf, "%s = %b\n", l, v)
 				case fields.Index(1) == "refData":
 					// Command of the form: b1.refData()
-					batches[fields.Index(0).Str()].refData()
+					batches[fields.Index(0).Str()].Ref()
 					fmt.Fprintf(&buf, "%s\n", l)
 				case fields.Index(1) == "unrefData":
 					// Command of the form: b1.unrefData()
-					batches[fields.Index(0).Str()].unrefData()
+					batches[fields.Index(0).Str()].Unref()
 					fmt.Fprintf(&buf, "%s\n", l)
 				case fields.Index(1) == "Close":
 					// Command of the form: b1.Close()

--- a/db.go
+++ b/db.go
@@ -923,7 +923,7 @@ func (d *DB) commitWrite(b *Batch, syncWG *sync.WaitGroup, syncErr *error) (*mem
 		b.flushable.setSeqNum(b.SeqNum())
 		if !d.opts.DisableWAL {
 			var err error
-			size, err = d.mu.log.writer.WriteRecord(repr, wal.SyncOptions{Done: syncWG, Err: syncErr}, b.refData)
+			size, err = d.mu.log.writer.WriteRecord(repr, wal.SyncOptions{Done: syncWG, Err: syncErr}, b)
 			if err != nil {
 				panic(err)
 			}
@@ -961,7 +961,7 @@ func (d *DB) commitWrite(b *Batch, syncWG *sync.WaitGroup, syncErr *error) (*mem
 	}
 
 	if b.flushable == nil {
-		size, err = d.mu.log.writer.WriteRecord(repr, wal.SyncOptions{Done: syncWG, Err: syncErr}, b.refData)
+		size, err = d.mu.log.writer.WriteRecord(repr, wal.SyncOptions{Done: syncWG, Err: syncErr}, b)
 		if err != nil {
 			panic(err)
 		}

--- a/wal/standalone_manager.go
+++ b/wal/standalone_manager.go
@@ -268,7 +268,7 @@ var _ Writer = &standaloneWriter{}
 
 // WriteRecord implements Writer.
 func (w *standaloneWriter) WriteRecord(
-	p []byte, opts SyncOptions, _ RefFunc,
+	p []byte, opts SyncOptions, _ RefCount,
 ) (logicalOffset int64, err error) {
 	return w.w.SyncRecord(p, opts.Done, opts.Err)
 }

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -384,11 +384,11 @@ type Writer interface {
 	//
 	// Some Writer implementations may continue to read p after WriteRecord
 	// returns. This is an obstacle to reusing p's memory. If the caller would
-	// like to reuse p's memory, the caller may pass a non-nil [RefFunc].
-	// If the Writer will retain p, it will invoke the [RefFunc] before
-	// returning. When it's finished, it will invoke the func returned by the
-	// [RefFunc] to release its reference.
-	WriteRecord(p []byte, opts SyncOptions, ref RefFunc) (logicalOffset int64, err error)
+	// like to reuse p's memory, the caller may pass a non-nil [RefCount].  If
+	// the Writer will retain p, it will invoke the [RefCount] before returning.
+	// When it's finished, it will invoke the func returned by the [RefCount] to
+	// release its reference.
+	WriteRecord(p []byte, opts SyncOptions, ref RefCount) (logicalOffset int64, err error)
 	// Close the writer.
 	Close() (logicalOffset int64, err error)
 	// Metrics must be called after Close. The callee will no longer modify the
@@ -396,9 +396,14 @@ type Writer interface {
 	Metrics() record.LogWriterMetrics
 }
 
-// RefFunc holds funcs to increment a reference count associated with a record
-// passed to [Writer.WriteRecord]. See the comment on WriteRecord.
-type RefFunc func() (unref func())
+// RefCount is a reference count associated with a record passed to
+// [Writer.WriteRecord]. See the comment on WriteRecord.
+type RefCount interface {
+	// Ref increments the reference count.
+	Ref()
+	// Unref increments the reference count.
+	Unref()
+}
 
 // Reader reads a virtual WAL.
 type Reader interface {


### PR DESCRIPTION
Passing in the Batch.refData func into (wal.Writer).WriteRecord forced an allocation for every committed batch. This commit defines a new wal.RefCount interface implemented by Batch to avoid the allocation.

Informs cockroachdb/cockroach#123236.