### PR TITLE
batchskl: clear cached bound nodes in SetBounds

### DIFF
--- a/internal/batchskl/iterator.go
+++ b/internal/batchskl/iterator.go
@@ -201,6 +201,8 @@ func (it *Iterator) String() string {
 func (it *Iterator) SetBounds(lower, upper []byte) {
 	it.lower = lower
 	it.upper = upper
+	it.lowerNode = 0
+	it.upperNode = 0
 }
 
 func (it *Iterator) seekForBaseSplice(key []byte, abbreviatedKey uint64) (prev, next uint32) {

--- a/testdata/internal_iter_bounds
+++ b/testdata/internal_iter_bounds
@@ -30,3 +30,21 @@ b:2
 b:1
 .
 b:1
+
+# Test changing the bounds. The new bounds should be in effect.
+
+iter lower=b upper=c
+seek-ge d
+set-bounds lower=a upper=z
+seek-ge d
+----
+.
+d:2
+
+iter lower=b upper=c
+seek-lt b
+set-bounds lower=a upper=z
+seek-lt b
+----
+.
+a:1


### PR DESCRIPTION
Since 5bcf51bf44 the batchskl.Iterator has cached nodes corresponding to lower or upper bounds. These cached nodes were not cleared in calls to SetBounds, allowing incorrect results when the bounds changed.

Close #3564.