### PR TITLE
compact: move interleaving iterators to compact.Iter

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2457,7 +2457,7 @@ func TestCompactionCheckOrdering(t *testing.T) {
 					return iterSet{point: &errorIter{}}, nil
 				}
 				result := "OK"
-				_, err := c.newInputIter(newIters, nil)
+				_, _, _, err := c.newInputIters(newIters, nil)
 				if err != nil {
 					result = fmt.Sprint(err)
 				}


### PR DESCRIPTION
During compaction, we obtain rangedel and rangekey spans by querying
the interleaving iterators that are used as input to `compact.Iter`.
To reduce this tight coupling, we move the interleaving iterators to
`compact.Iter`. We now pass the point/rangedel/rangekey iterators
separately and we use new `compact.Iter` methods to obtain the
relevant spans.