### PR TITLE
crl-release-24.1: db: ensure Metrics.WAL.BytesWritten is nondecreasing

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1699,7 +1699,6 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 				// calculation even when the WAL is disabled.
 				metrics.BytesIn = metrics.BytesFlushed
 			} else {
-				metrics := c.metrics[0]
 				for i := 0; i < n; i++ {
 					metrics.BytesIn += d.mu.mem.queue[i].logSize
 				}

--- a/db.go
+++ b/db.go
@@ -373,7 +373,7 @@ type DB struct {
 			manager wal.Manager
 			// The number of input bytes to the log. This is the raw size of the
 			// batches written to the WAL, without the overhead of the record
-			// envelopes.
+			// envelopes. Requires DB.mu to be held when read or written.
 			bytesIn uint64
 			// The Writer is protected by commitPipeline.mu. This allows log writes
 			// to be performed without holding DB.mu, but requires both
@@ -2487,7 +2487,7 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 		var prevLogSize uint64
 		if !d.opts.DisableWAL {
 			now := time.Now()
-			newLogNum, prevLogSize = d.recycleWAL()
+			newLogNum, prevLogSize = d.rotateWAL()
 			if b != nil {
 				b.commitStats.WALRotationDuration += time.Since(now)
 			}
@@ -2565,9 +2565,13 @@ func (d *DB) rotateMemtable(newLogNum base.DiskFileNum, logSeqNum uint64, prev *
 	}
 }
 
+// rotateWAL creates a new write-ahead log, possibly recycling a previous WAL's
+// files. It returns the file number assigned to the new WAL, and the size of
+// the previous WAL file.
+//
 // Both DB.mu and commitPipeline.mu must be held by the caller. Note that DB.mu
 // may be released and reacquired.
-func (d *DB) recycleWAL() (newLogNum base.DiskFileNum, prevLogSize uint64) {
+func (d *DB) rotateWAL() (newLogNum base.DiskFileNum, prevLogSize uint64) {
 	if d.opts.DisableWAL {
 		panic("pebble: invalid function call")
 	}

--- a/db.go
+++ b/db.go
@@ -2559,6 +2559,16 @@ func (d *DB) rotateMemtable(newLogNum base.DiskFileNum, logSeqNum uint64, prev *
 	var entry *flushableEntry
 	d.mu.mem.mutable, entry = d.newMemTable(newLogNum, logSeqNum)
 	d.mu.mem.queue = append(d.mu.mem.queue, entry)
+	// d.logSize tracks the log size of the WAL file corresponding to the most
+	// recent flushable. The log size of the previous mutable memtable no longer
+	// applies to the current mutable memtable.
+	//
+	// It's tempting to perform this update in rotateWAL, but that would not be
+	// atomic with the enqueue of the new flushable. A call to DB.Metrics()
+	// could acquire DB.mu after the WAL has been rotated but before the new
+	// memtable has been appended; this would result in omitting the log size of
+	// the most recent flushable.
+	d.logSize.Store(0)
 	d.updateReadStateLocked(nil)
 	if prev.writerUnref() {
 		d.maybeScheduleFlush()

--- a/ingest.go
+++ b/ingest.go
@@ -1439,7 +1439,12 @@ func (d *DB) handleIngestAsFlushable(
 		// We create a new WAL for the flushable instead of reusing the end of
 		// the previous WAL. This simplifies the increment of the minimum
 		// unflushed log number, and also simplifies WAL replay.
-		logNum, _ = d.recycleWAL()
+		var prevLogSize uint64
+		logNum, prevLogSize = d.rotateWAL()
+		// As the rotator of the WAL, we're responsible for updating the
+		// previous flushable queue tail's log size.
+		d.mu.mem.queue[len(d.mu.mem.queue)-1].logSize = prevLogSize
+
 		d.mu.Unlock()
 		err := d.commit.directWrite(b)
 		if err != nil {
@@ -1459,13 +1464,14 @@ func (d *DB) handleIngestAsFlushable(
 	// the appropriate value below.
 	newLogNum := d.mu.mem.queue[len(d.mu.mem.queue)-1].logNum
 	if !d.opts.DisableWAL {
-		// This is WAL num of the next mutable memtable which comes after the
-		// ingestedFlushable in the flushable queue. The mutable memtable
-		// will be created below.
-		newLogNum, _ = d.recycleWAL()
-		if err != nil {
-			return err
-		}
+		// newLogNum will be the WAL num of the next mutable memtable which
+		// comes after the ingestedFlushable in the flushable queue. The mutable
+		// memtable will be created below.
+		//
+		// The prevLogSize returned by rotateWAL is the WAL to which the
+		// flushable ingest keys were appended. This intermediary WAL is only
+		// used to record the flushable ingest and nothing else.
+		newLogNum, entry.logSize = d.rotateWAL()
 	}
 
 	d.mu.versions.metrics.Ingest.Count++

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -7,10 +7,13 @@ package pebble
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/cache"
@@ -19,6 +22,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/cockroachdb/pebble/vfs/errorfs"
 	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/require"
 )
@@ -420,4 +424,66 @@ func TestMetricsWAmpDisableWAL(t *testing.T) {
 	tot := m.Total()
 	require.Greater(t, tot.WriteAmp(), 1.0)
 	require.NoError(t, d.Close())
+}
+
+// TestMetricsWALBytesWrittenMonotonicity tests that the
+// Metrics.WAL.BytesWritten metric is always nondecreasing.
+// It's a regression test for issue #3505.
+func TestMetricsWALBytesWrittenMonotonicity(t *testing.T) {
+	fs := errorfs.Wrap(vfs.NewMem(), errorfs.RandomLatency(nil, 100*time.Microsecond, time.Now().UnixNano()))
+	d, err := Open("", &Options{
+		FS: fs,
+		// Use a tiny memtable size so that we get frequent flushes. While a
+		// flush is in-progress or completing, the WAL bytes written should
+		// remain nondecreasing.
+		MemTableSize: 1 << 20, /* 20 KiB */
+	})
+	require.NoError(t, err)
+
+	stopCh := make(chan struct{})
+
+	ks := testkeys.Alpha(3)
+	var wg sync.WaitGroup
+	const concurrentWriters = 5
+	wg.Add(concurrentWriters)
+	for w := 0; w < concurrentWriters; w++ {
+		go func() {
+			defer wg.Done()
+			data := make([]byte, 1<<10) // 1 KiB
+			rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+			_, err := rng.Read(data)
+			require.NoError(t, err)
+
+			buf := make([]byte, ks.MaxLen())
+			for i := 0; ; i++ {
+				select {
+				case <-stopCh:
+					return
+				default:
+				}
+				n := testkeys.WriteKey(buf, ks, int64(i)%ks.Count())
+				require.NoError(t, d.Set(buf[:n], data, NoSync))
+			}
+		}()
+	}
+
+	func() {
+		defer func() { close(stopCh) }()
+		abort := time.After(time.Second)
+		var prevWALBytesWritten uint64
+		for {
+			select {
+			case <-abort:
+				return
+			default:
+			}
+
+			m := d.Metrics()
+			if m.WAL.BytesWritten < prevWALBytesWritten {
+				t.Fatalf("WAL bytes written decreased: %d -> %d", prevWALBytesWritten, m.WAL.BytesWritten)
+			}
+			prevWALBytesWritten = m.WAL.BytesWritten
+		}
+	}()
+	wg.Wait()
 }

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -217,9 +217,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   590B     0B       0 |     - | 1.2KB |     0     0B |     0     0B |     1   590B | 1.2KB |   1  0.5
-total |     3  1.8KB     0B       0 |     - |  730B |     1   622B |     0     0B |     4  3.0KB | 1.2KB |   3  4.2
+total |     3  1.8KB     0B       0 |     - |  703B |     1   622B |     0     0B |     4  3.0KB | 1.2KB |   3  4.4
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (27B)  in: 48B  written: 108B (125% overhead)
+WAL: 1 files (0B)  in: 48B  written: 81B (69% overhead)
 Flushes: 3
 Compactions: 1  estimated debt: 1.8KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -317,9 +317,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     2  1.2KB     0B       0 |     - | 1.2KB |     1   622B |     0     0B |     1   590B | 1.2KB |   1  0.5
-total |     6  3.6KB     0B       0 |     - | 2.0KB |     3  1.8KB |     0     0B |     5  4.8KB | 1.2KB |   5  2.5
+total |     6  3.6KB     0B       0 |     - | 1.9KB |     3  1.8KB |     0     0B |     5  4.8KB | 1.2KB |   5  2.5
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (29B)  in: 82B  written: 137B (67% overhead)
+WAL: 1 files (0B)  in: 82B  written: 108B (32% overhead)
 Flushes: 6
 Compactions: 1  estimated debt: 3.6KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -310,16 +310,16 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     4  2.4KB     0B       0 |  0.80 |   81B |     2  1.2KB |     0     0B |     4  2.3KB |    0B |   4 29.1
+    0 |     4  2.4KB     0B       0 |  0.80 |  108B |     2  1.2KB |     0     0B |     4  2.3KB |    0B |   4 21.9
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     2  1.2KB     0B       0 |     - | 1.2KB |     1   622B |     0     0B |     1   590B | 1.2KB |   1  0.5
-total |     6  3.6KB     0B       0 |     - | 1.9KB |     3  1.8KB |     0     0B |     5  4.8KB | 1.2KB |   5  2.5
+total |     6  3.6KB     0B       0 |     - | 2.0KB |     3  1.8KB |     0     0B |     5  4.8KB | 1.2KB |   5  2.5
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (29B)  in: 82B  written: 110B (34% overhead)
+WAL: 1 files (29B)  in: 82B  written: 137B (67% overhead)
 Flushes: 6
 Compactions: 1  estimated debt: 3.6KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -460,7 +460,7 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     4  2.4KB     0B       0 |  0.50 |  149B |     3  1.8KB |     0     0B |     6  3.8KB |    0B |   2 25.9
+    0 |     4  2.4KB     0B       0 |  0.50 |  187B |     3  1.8KB |     0     0B |     6  3.8KB |    0B |   2 20.6
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
@@ -469,7 +469,7 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     6 |     3  2.0KB    41B       0 |     - | 3.2KB |     0     0B |     0     0B |     3  2.0KB | 3.2KB |   1  0.6
 total |     7  4.4KB    41B       0 |     - | 2.0KB |     3  1.8KB |     0     0B |     9  7.8KB | 3.2KB |   3  3.9
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (26B)  in: 176B  written: 175B (-1% overhead)
+WAL: 1 files (26B)  in: 176B  written: 213B (21% overhead)
 Flushes: 8
 Compactions: 2  estimated debt: 4.4KB  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -522,16 +522,16 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     7  4.2KB     0B       0 |  0.50 |  207B |     3  1.8KB |     0     0B |     9  5.5KB |    0B |   2 27.4
+    0 |     7  4.2KB     0B       0 |  0.50 |  245B |     3  1.8KB |     0     0B |     9  5.5KB |    0B |   2 23.1
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     3  2.0KB    41B       0 |     - | 3.2KB |     0     0B |     0     0B |     3  2.0KB | 3.2KB |   1  0.6
-total |    10  6.2KB    41B       0 |     - | 2.1KB |     3  1.8KB |     0     0B |    12  9.6KB | 3.2KB |   3  4.6
+total |    10  6.2KB    41B       0 |     - | 2.1KB |     3  1.8KB |     0     0B |    12  9.7KB | 3.2KB |   3  4.6
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (58B)  in: 223B  written: 265B (19% overhead)
+WAL: 1 files (58B)  in: 223B  written: 303B (36% overhead)
 Flushes: 9
 Compactions: 2  estimated debt: 6.2KB  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -598,7 +598,7 @@ metrics zero-cache-hits-misses
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     7  3.1KB     0B       2 |  0.50 |  207B |     3  1.8KB |     0     0B |     9  5.5KB |    0B |   2 27.4
+    0 |     7  3.1KB     0B       2 |  0.50 |  245B |     3  1.8KB |     0     0B |     9  5.5KB |    0B |   2 23.1
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
@@ -607,7 +607,7 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     6 |     4  2.6KB    41B       0 |     - | 3.2KB |     1   621B |     0     0B |     3  2.0KB | 3.2KB |   1  0.6
 total |    11  5.7KB    41B       2 |     - | 2.7KB |     4  2.4KB |     0     0B |    12   10KB | 3.2KB |   3  3.8
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (58B)  in: 223B  written: 265B (19% overhead)
+WAL: 1 files (58B)  in: 223B  written: 303B (36% overhead)
 Flushes: 9
 Compactions: 2  estimated debt: 5.7KB  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -699,7 +699,7 @@ metrics zero-cache-hits-misses
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |  207B |     3  1.8KB |     0     0B |     9  5.5KB |    0B |   0 27.4
+    0 |     0     0B     0B       0 |  0.00 |  245B |     3  1.8KB |     0     0B |     9  5.5KB |    0B |   0 23.1
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
@@ -708,7 +708,7 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     6 |     6  3.9KB    41B       0 |     - | 6.3KB |     2  1.2KB |     0     0B |     4  2.6KB | 6.3KB |   1  0.4
 total |     6  3.9KB    41B       0 |     - | 3.3KB |     5  3.0KB |     0     0B |    13   12KB | 6.3KB |   1  3.5
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (58B)  in: 223B  written: 265B (19% overhead)
+WAL: 1 files (58B)  in: 223B  written: 303B (36% overhead)
 Flushes: 9
 Compactions: 3  estimated debt: 0B  in progress: 0 (0B)
              default: 3  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -61,9 +61,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     0     0B     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-total |     1   589B     0B       0 |     - |   56B |     0     0B |     0     0B |     1   645B |    0B |   1 11.5
+total |     1   589B     0B       0 |     - |   28B |     0     0B |     0     0B |     1   617B |    0B |   1 22.0
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (28B)  in: 17B  written: 56B (229% overhead)
+WAL: 1 files (0B)  in: 17B  written: 28B (65% overhead)
 Flushes: 1
 Compactions: 0  estimated debt: 0B  in progress: 0 (0B)
              default: 0  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -116,9 +116,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   595B     0B       0 |     - | 1.2KB |     0     0B |     0     0B |     1   595B | 1.2KB |   1  0.5
-total |     1   595B     0B       0 |     - |   84B |     0     0B |     0     0B |     3  1.8KB | 1.2KB |   1 22.1
+total |     1   595B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  1.8KB | 1.2KB |   1 32.7
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (28B)  in: 34B  written: 84B (147% overhead)
+WAL: 1 files (0B)  in: 34B  written: 56B (65% overhead)
 Flushes: 2
 Compactions: 1  estimated debt: 0B  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -158,9 +158,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   595B     0B       0 |     - | 1.2KB |     0     0B |     0     0B |     1   595B | 1.2KB |   1  0.5
-total |     1   595B     0B       0 |     - |   84B |     0     0B |     0     0B |     3  1.8KB | 1.2KB |   1 22.1
+total |     1   595B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  1.8KB | 1.2KB |   1 32.7
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (28B)  in: 34B  written: 84B (147% overhead)
+WAL: 1 files (0B)  in: 34B  written: 56B (65% overhead)
 Flushes: 2
 Compactions: 1  estimated debt: 0B  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -197,9 +197,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   595B     0B       0 |     - | 1.2KB |     0     0B |     0     0B |     1   595B | 1.2KB |   1  0.5
-total |     1   595B     0B       0 |     - |   84B |     0     0B |     0     0B |     3  1.8KB | 1.2KB |   1 22.1
+total |     1   595B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  1.8KB | 1.2KB |   1 32.7
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (28B)  in: 34B  written: 84B (147% overhead)
+WAL: 1 files (0B)  in: 34B  written: 56B (65% overhead)
 Flushes: 2
 Compactions: 1  estimated debt: 0B  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -240,9 +240,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   595B     0B       0 |     - | 1.2KB |     0     0B |     0     0B |     1   595B | 1.2KB |   1  0.5
-total |     1   595B     0B       0 |     - |   84B |     0     0B |     0     0B |     3  1.8KB | 1.2KB |   1 22.1
+total |     1   595B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  1.8KB | 1.2KB |   1 32.7
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (28B)  in: 34B  written: 84B (147% overhead)
+WAL: 1 files (0B)  in: 34B  written: 56B (65% overhead)
 Flushes: 2
 Compactions: 1  estimated debt: 0B  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -310,9 +310,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   595B     0B       0 |     - | 1.2KB |     0     0B |     0     0B |     1   595B | 1.2KB |   1  0.5
-total |     4  2.6KB    38B       0 |     - |  242B |     0     0B |     0     0B |     6  4.0KB | 1.2KB |   2 16.9
+total |     4  2.6KB    38B       0 |     - |  149B |     0     0B |     0     0B |     6  3.9KB | 1.2KB |   2 26.8
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (93B)  in: 116B  written: 242B (109% overhead)
+WAL: 1 files (0B)  in: 116B  written: 149B (28% overhead)
 Flushes: 3
 Compactions: 1  estimated debt: 2.6KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -364,9 +364,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     3  2.0KB    41B       0 |     - | 3.2KB |     0     0B |     0     0B |     3  2.0KB | 3.2KB |   1  0.6
-total |     3  2.0KB    41B       0 |     - |  242B |     0     0B |     0     0B |     8  5.4KB | 3.2KB |   1 23.0
+total |     3  2.0KB    41B       0 |     - |  149B |     0     0B |     0     0B |     8  5.3KB | 3.2KB |   1 36.7
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (93B)  in: 116B  written: 242B (109% overhead)
+WAL: 1 files (0B)  in: 116B  written: 149B (28% overhead)
 Flushes: 3
 Compactions: 2  estimated debt: 0B  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -469,7 +469,7 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     6 |     3  2.0KB    41B       0 |     - | 3.2KB |     0     0B |     0     0B |     3  2.0KB | 3.2KB |   1  0.6
 total |     7  4.4KB    41B       0 |     - | 2.0KB |     3  1.8KB |     0     0B |     9  7.8KB | 3.2KB |   3  3.9
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (26B)  in: 176B  written: 213B (21% overhead)
+WAL: 1 files (0B)  in: 176B  written: 187B (6% overhead)
 Flushes: 8
 Compactions: 2  estimated debt: 4.4KB  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -529,9 +529,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     3  2.0KB    41B       0 |     - | 3.2KB |     0     0B |     0     0B |     3  2.0KB | 3.2KB |   1  0.6
-total |    10  6.2KB    41B       0 |     - | 2.1KB |     3  1.8KB |     0     0B |    12  9.7KB | 3.2KB |   3  4.6
+total |    10  6.2KB    41B       0 |     - | 2.1KB |     3  1.8KB |     0     0B |    12  9.6KB | 3.2KB |   3  4.7
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (58B)  in: 223B  written: 303B (36% overhead)
+WAL: 1 files (0B)  in: 223B  written: 245B (10% overhead)
 Flushes: 9
 Compactions: 2  estimated debt: 6.2KB  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -607,7 +607,7 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     6 |     4  2.6KB    41B       0 |     - | 3.2KB |     1   621B |     0     0B |     3  2.0KB | 3.2KB |   1  0.6
 total |    11  5.7KB    41B       2 |     - | 2.7KB |     4  2.4KB |     0     0B |    12   10KB | 3.2KB |   3  3.8
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (58B)  in: 223B  written: 303B (36% overhead)
+WAL: 1 files (0B)  in: 223B  written: 245B (10% overhead)
 Flushes: 9
 Compactions: 2  estimated debt: 5.7KB  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -708,7 +708,7 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     6 |     6  3.9KB    41B       0 |     - | 6.3KB |     2  1.2KB |     0     0B |     4  2.6KB | 6.3KB |   1  0.4
 total |     6  3.9KB    41B       0 |     - | 3.3KB |     5  3.0KB |     0     0B |    13   12KB | 6.3KB |   1  3.5
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (58B)  in: 223B  written: 303B (36% overhead)
+WAL: 1 files (0B)  in: 223B  written: 245B (10% overhead)
 Flushes: 9
 Compactions: 3  estimated debt: 0B  in progress: 0 (0B)
              default: 3  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -759,9 +759,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     0     0B     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-total |     1   604B     0B       0 |     - |   76B |     0     0B |     0     0B |     1   680B |    0B |   1  8.9
+total |     1   604B     0B       0 |     - |   38B |     0     0B |     0     0B |     1   642B |    0B |   1 16.9
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (38B)  in: 27B  written: 76B (181% overhead)
+WAL: 1 files (0B)  in: 27B  written: 38B (41% overhead)
 Flushes: 1
 Compactions: 0  estimated debt: 0B  in progress: 0 (0B)
              default: 0  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -796,9 +796,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   604B     0B       0 |     - |  604B |     0     0B |     0     0B |     1   604B |    0B |   1  1.0
-total |     1   604B     0B       0 |     - |   76B |     0     0B |     0     0B |     2  1.3KB |    0B |   1 16.9
+total |     1   604B     0B       0 |     - |   38B |     0     0B |     0     0B |     2  1.2KB |    0B |   1 32.8
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (38B)  in: 27B  written: 76B (181% overhead)
+WAL: 1 files (0B)  in: 27B  written: 38B (41% overhead)
 Flushes: 1
 Compactions: 0  estimated debt: 0B  in progress: 0 (0B)
              default: 0  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -842,9 +842,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   604B     0B       0 |     - |  604B |     0     0B |     0     0B |     1   604B |    0B |   1  1.0
-total |     2  1.2KB     0B       0 |     - |  697B |     1   621B |     0     0B |     2  1.9KB |    0B |   2  2.7
+total |     2  1.2KB     0B       0 |     - |  659B |     1   621B |     0     0B |     2  1.8KB |    0B |   2  2.8
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (38B)  in: 27B  written: 76B (181% overhead)
+WAL: 1 files (0B)  in: 27B  written: 38B (41% overhead)
 Flushes: 1
 Compactions: 0  estimated debt: 1.2KB  in progress: 0 (0B)
              default: 0  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -889,9 +889,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   604B     0B       0 |     - |  604B |     0     0B |     0     0B |     1   604B |    0B |   1  1.0
-total |     3  1.8KB     0B       0 |     - |  715B |     1   621B |     0     0B |     3  2.5KB |    0B |   3  3.5
+total |     3  1.8KB     0B       0 |     - |  687B |     1   621B |     0     0B |     3  2.4KB |    0B |   3  3.6
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (28B)  in: 44B  written: 94B (114% overhead)
+WAL: 1 files (0B)  in: 44B  written: 66B (50% overhead)
 Flushes: 2
 Compactions: 0  estimated debt: 1.8KB  in progress: 0 (0B)
              default: 0  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0


### PR DESCRIPTION
24.1 backport of #3555