### PR TITLE
crl-release-23.2: db: ensure Metrics.WAL.BytesWritten is nondecreasing

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2142,7 +2142,6 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 				// calculation even when the WAL is disabled.
 				metrics.BytesIn = metrics.BytesFlushed
 			} else {
-				metrics := c.metrics[0]
 				for i := 0; i < n; i++ {
 					metrics.BytesIn += d.mu.mem.queue[i].logSize
 				}

--- a/db.go
+++ b/db.go
@@ -2543,6 +2543,16 @@ func (d *DB) rotateMemtable(newLogNum FileNum, logSeqNum uint64, prev *memTable)
 	var entry *flushableEntry
 	d.mu.mem.mutable, entry = d.newMemTable(newLogNum, logSeqNum)
 	d.mu.mem.queue = append(d.mu.mem.queue, entry)
+	// d.logSize tracks the log size of the WAL file corresponding to the most
+	// recent flushable. The log size of the previous mutable memtable no longer
+	// applies to the current mutable memtable.
+	//
+	// It's tempting to perform this update in rotateWAL, but that would not be
+	// atomic with the enqueue of the new flushable. A call to DB.Metrics()
+	// could acquire DB.mu after the WAL has been rotated but before the new
+	// memtable has been appended; this would result in omitting the log size of
+	// the most recent flushable.
+	d.logSize.Store(0)
 	d.updateReadStateLocked(nil)
 	if prev.writerUnref() {
 		d.maybeScheduleFlush()

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -278,9 +278,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   662B     0B       0 |     - | 1.3KB |     0     0B |     0     0B |     1   662B | 1.3KB |   1  0.5
-total |     3  2.0KB     0B       0 |     - |  825B |     1   717B |     0     0B |     4  3.4KB | 1.3KB |   3  4.2
+total |     3  2.0KB     0B       0 |     - |  798B |     1   717B |     0     0B |     4  3.4KB | 1.3KB |   3  4.3
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (27B)  in: 48B  written: 108B (125% overhead)
+WAL: 1 files (0B)  in: 48B  written: 81B (69% overhead)
 Flushes: 3
 Compactions: 1  estimated debt: 2.0KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -377,9 +377,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     2  1.3KB     0B       0 |     - | 1.3KB |     1   717B |     0     0B |     1   662B | 1.3KB |   1  0.5
-total |     6  4.0KB     0B       0 |     - | 2.2KB |     3  2.1KB |     0     0B |     5  5.5KB | 1.3KB |   5  2.4
+total |     6  4.0KB     0B       0 |     - | 2.2KB |     3  2.1KB |     0     0B |     5  5.4KB | 1.3KB |   5  2.5
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (29B)  in: 82B  written: 137B (67% overhead)
+WAL: 1 files (0B)  in: 82B  written: 108B (32% overhead)
 Flushes: 6
 Compactions: 1  estimated debt: 4.0KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -370,16 +370,16 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     4  2.7KB     0B       0 |  0.80 |   81B |     2  1.4KB |     0     0B |     4  2.6KB |    0B |   4 32.7
+    0 |     4  2.7KB     0B       0 |  0.80 |  108B |     2  1.4KB |     0     0B |     4  2.6KB |    0B |   4 24.5
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     2  1.3KB     0B       0 |     - | 1.3KB |     1   717B |     0     0B |     1   662B | 1.3KB |   1  0.5
-total |     6  4.0KB     0B       0 |     - | 2.2KB |     3  2.1KB |     0     0B |     5  5.4KB | 1.3KB |   5  2.5
+total |     6  4.0KB     0B       0 |     - | 2.2KB |     3  2.1KB |     0     0B |     5  5.5KB | 1.3KB |   5  2.4
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (29B)  in: 82B  written: 110B (34% overhead)
+WAL: 1 files (29B)  in: 82B  written: 137B (67% overhead)
 Flushes: 6
 Compactions: 1  estimated debt: 4.0KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -57,9 +57,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     0     0B     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-total |     1   661B     0B       0 |     - |   56B |     0     0B |     0     0B |     1   717B |    0B |   1 12.8
+total |     1   661B     0B       0 |     - |   28B |     0     0B |     0     0B |     1   689B |    0B |   1 24.6
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (28B)  in: 17B  written: 56B (229% overhead)
+WAL: 1 files (0B)  in: 17B  written: 28B (65% overhead)
 Flushes: 1
 Compactions: 0  estimated debt: 0B  in progress: 0 (0B)
              default: 0  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -111,9 +111,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   667B     0B       0 |     - | 1.3KB |     0     0B |     0     0B |     1   667B | 1.3KB |   1  0.5
-total |     1   667B     0B       0 |     - |   84B |     0     0B |     0     0B |     3  2.0KB | 1.3KB |   1 24.7
+total |     1   667B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  2.0KB | 1.3KB |   1 36.5
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (28B)  in: 34B  written: 84B (147% overhead)
+WAL: 1 files (0B)  in: 34B  written: 56B (65% overhead)
 Flushes: 2
 Compactions: 1  estimated debt: 0B  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -150,9 +150,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   667B     0B       0 |     - | 1.3KB |     0     0B |     0     0B |     1   667B | 1.3KB |   1  0.5
-total |     1   667B     0B       0 |     - |   84B |     0     0B |     0     0B |     3  2.0KB | 1.3KB |   1 24.7
+total |     1   667B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  2.0KB | 1.3KB |   1 36.5
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (28B)  in: 34B  written: 84B (147% overhead)
+WAL: 1 files (0B)  in: 34B  written: 56B (65% overhead)
 Flushes: 2
 Compactions: 1  estimated debt: 0B  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -186,9 +186,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   667B     0B       0 |     - | 1.3KB |     0     0B |     0     0B |     1   667B | 1.3KB |   1  0.5
-total |     1   667B     0B       0 |     - |   84B |     0     0B |     0     0B |     3  2.0KB | 1.3KB |   1 24.7
+total |     1   667B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  2.0KB | 1.3KB |   1 36.5
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (28B)  in: 34B  written: 84B (147% overhead)
+WAL: 1 files (0B)  in: 34B  written: 56B (65% overhead)
 Flushes: 2
 Compactions: 1  estimated debt: 0B  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -225,9 +225,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   667B     0B       0 |     - | 1.3KB |     0     0B |     0     0B |     1   667B | 1.3KB |   1  0.5
-total |     1   667B     0B       0 |     - |   84B |     0     0B |     0     0B |     3  2.0KB | 1.3KB |   1 24.7
+total |     1   667B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  2.0KB | 1.3KB |   1 36.5
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (28B)  in: 34B  written: 84B (147% overhead)
+WAL: 1 files (0B)  in: 34B  written: 56B (65% overhead)
 Flushes: 2
 Compactions: 1  estimated debt: 0B  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -290,9 +290,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   667B     0B       0 |     - | 1.3KB |     0     0B |     0     0B |     1   667B | 1.3KB |   1  0.5
-total |     4  2.9KB    38B       0 |     - |  242B |     0     0B |     0     0B |     6  4.4KB | 1.3KB |   2 18.6
+total |     4  2.9KB    38B       0 |     - |  149B |     0     0B |     0     0B |     6  4.3KB | 1.3KB |   2 29.7
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (93B)  in: 116B  written: 242B (109% overhead)
+WAL: 1 files (0B)  in: 116B  written: 149B (28% overhead)
 Flushes: 3
 Compactions: 1  estimated debt: 2.9KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -339,9 +339,9 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     3  2.2KB    41B       0 |     - | 3.5KB |     0     0B |     0     0B |     3  2.2KB | 3.5KB |   1  0.6
-total |     3  2.2KB    41B       0 |     - |  242B |     0     0B |     0     0B |     8  6.0KB | 3.5KB |   1 25.3
+total |     3  2.2KB    41B       0 |     - |  149B |     0     0B |     0     0B |     8  5.9KB | 3.5KB |   1 40.5
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (93B)  in: 116B  written: 242B (109% overhead)
+WAL: 1 files (0B)  in: 116B  written: 149B (28% overhead)
 Flushes: 3
 Compactions: 2  estimated debt: 0B  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
@@ -436,7 +436,7 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     6 |     3  2.2KB    41B       0 |     - | 3.5KB |     0     0B |     0     0B |     3  2.2KB | 3.5KB |   1  0.6
 total |     7  5.0KB    41B       0 |     - | 2.3KB |     3  2.1KB |     0     0B |     9  8.7KB | 3.5KB |   3  3.8
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (26B)  in: 176B  written: 213B (21% overhead)
+WAL: 1 files (0B)  in: 176B  written: 187B (6% overhead)
 Flushes: 8
 Compactions: 2  estimated debt: 5.0KB  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -427,7 +427,7 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     4  2.8KB     0B       0 |  0.50 |  149B |     3  2.1KB |     0     0B |     6  4.2KB |    0B |   2 28.8
+    0 |     4  2.8KB     0B       0 |  0.50 |  187B |     3  2.1KB |     0     0B |     6  4.2KB |    0B |   2 22.9
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
@@ -436,7 +436,7 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     6 |     3  2.2KB    41B       0 |     - | 3.5KB |     0     0B |     0     0B |     3  2.2KB | 3.5KB |   1  0.6
 total |     7  5.0KB    41B       0 |     - | 2.3KB |     3  2.1KB |     0     0B |     9  8.7KB | 3.5KB |   3  3.8
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (26B)  in: 176B  written: 175B (-1% overhead)
+WAL: 1 files (26B)  in: 176B  written: 213B (21% overhead)
 Flushes: 8
 Compactions: 2  estimated debt: 5.0KB  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0


### PR DESCRIPTION
23.2 backport of #3555