### PR TITLE
crl-release-24.1: db,wal: avoid Batch.refData allocation

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -204,11 +204,11 @@ type Batch struct {
 	// To resolve this data race, this [lifecycle] atomic is used to determine
 	// safety and responsibility of reusing a batch. The low bits of the atomic
 	// are used as a reference count (really just the lowest bit—in practice
-	// there's only 1 code path that references). The [Batch.refData] func is
-	// passed into [wal.Writer]'s WriteRecord method. The wal.Writer guarantees
-	// that if it will read [Batch.data] after the call to WriteRecord returns,
-	// it will increment the reference count. When it's complete, it'll
-	// unreference through invoking [Batch.unrefData].
+	// there's only 1 code path that references). The [Batch] is passed into
+	// [wal.Writer]'s WriteRecord method as a [RefCount] implementation. The
+	// wal.Writer guarantees that if it will read [Batch.data] after the call to
+	// WriteRecord returns, it will increment the reference count. When it's
+	// complete, it'll unreference through invoking [Batch.Unref].
 	//
 	// When the committer of a batch indicates intent to recycle a Batch through
 	// calling [Batch.Reset] or [Batch.Close], the lifecycle atomic is read. If
@@ -218,7 +218,7 @@ type Batch struct {
 	// In [Batch.Close], we set a special high bit [batchClosedBit] on lifecycle
 	// that indicates that the user will not use [Batch] again and we're free to
 	// recycle it when safe. When the commit pipeline eventually calls
-	// [Batch.unrefData], the [batchClosedBit] is noticed and the batch is
+	// [Batch.Unref], the [batchClosedBit] is noticed and the batch is
 	// recycled.
 	lifecycle atomic.Int32
 }
@@ -228,16 +228,17 @@ type Batch struct {
 // prevented immediate recycling.
 const batchClosedBit = 1 << 30
 
-// refData is passed to (wal.Writer).WriteRecord. If the WAL writer may need to
-// read b.data after it returns, it invokes refData to increment the lifecycle's
-// reference count. When it's finished, it invokes the returned function
-// [Batch.unrefData].
-func (b *Batch) refData() (unref func()) {
+// TODO(jackson): Hide the wal.RefCount implementation from the public Batch interface.
+
+// Ref implements wal.RefCount. If the WAL writer may need to read b.data after
+// it returns, it invokes Ref to increment the lifecycle's reference count. When
+// it's finished, it invokes Unref.
+func (b *Batch) Ref() {
 	b.lifecycle.Add(+1)
-	return b.unrefData
 }
 
-func (b *Batch) unrefData() {
+// Unref implemets wal.RefCount.
+func (b *Batch) Unref() {
 	if v := b.lifecycle.Add(-1); (v ^ batchClosedBit) == 0 {
 		// The [batchClosedBit] high bit is set, and there are no outstanding
 		// references. The user of the Batch called [Batch.Close], expecting the

--- a/batch_test.go
+++ b/batch_test.go
@@ -464,11 +464,11 @@ func TestBatchReuse(t *testing.T) {
 					fmt.Fprintf(&buf, "%s = %b\n", l, v)
 				case fields.Index(1) == "refData":
 					// Command of the form: b1.refData()
-					batches[fields.Index(0).Str()].refData()
+					batches[fields.Index(0).Str()].Ref()
 					fmt.Fprintf(&buf, "%s\n", l)
 				case fields.Index(1) == "unrefData":
 					// Command of the form: b1.unrefData()
-					batches[fields.Index(0).Str()].unrefData()
+					batches[fields.Index(0).Str()].Unref()
 					fmt.Fprintf(&buf, "%s\n", l)
 				case fields.Index(1) == "Close":
 					// Command of the form: b1.Close()

--- a/db.go
+++ b/db.go
@@ -913,7 +913,7 @@ func (d *DB) commitWrite(b *Batch, syncWG *sync.WaitGroup, syncErr *error) (*mem
 		b.flushable.setSeqNum(b.SeqNum())
 		if !d.opts.DisableWAL {
 			var err error
-			size, err = d.mu.log.writer.WriteRecord(repr, wal.SyncOptions{Done: syncWG, Err: syncErr}, b.refData)
+			size, err = d.mu.log.writer.WriteRecord(repr, wal.SyncOptions{Done: syncWG, Err: syncErr}, b)
 			if err != nil {
 				panic(err)
 			}
@@ -951,7 +951,7 @@ func (d *DB) commitWrite(b *Batch, syncWG *sync.WaitGroup, syncErr *error) (*mem
 	}
 
 	if b.flushable == nil {
-		size, err = d.mu.log.writer.WriteRecord(repr, wal.SyncOptions{Done: syncWG, Err: syncErr}, b.refData)
+		size, err = d.mu.log.writer.WriteRecord(repr, wal.SyncOptions{Done: syncWG, Err: syncErr}, b)
 		if err != nil {
 			panic(err)
 		}

--- a/wal/standalone_manager.go
+++ b/wal/standalone_manager.go
@@ -268,7 +268,7 @@ var _ Writer = &standaloneWriter{}
 
 // WriteRecord implements Writer.
 func (w *standaloneWriter) WriteRecord(
-	p []byte, opts SyncOptions, _ RefFunc,
+	p []byte, opts SyncOptions, _ RefCount,
 ) (logicalOffset int64, err error) {
 	return w.w.SyncRecord(p, opts.Done, opts.Err)
 }


### PR DESCRIPTION
24.1 backport of #3565.

----

Passing in the Batch.refData func into (wal.Writer).WriteRecord forced an allocation for every committed batch. This commit defines a new wal.RefCount interface implemented by Batch to avoid the allocation.

Informs cockroachdb/cockroach#123236.