### PR TITLE
objstorage: add MemObj for testing

### DIFF
--- a/objstorage/test_utils.go
+++ b/objstorage/test_utils.go
@@ -1,0 +1,63 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package objstorage
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/pkg/errors"
+)
+
+// MemObj is an in-memory implementation of the Writable and Readable that holds
+// all data in memory.
+//
+// A zero MemObj can be populated with data through its Writable methods, and
+// then can be repeatedly used as a Readable.
+type MemObj struct {
+	buf bytes.Buffer
+}
+
+var _ Writable = (*MemObj)(nil)
+var _ Readable = (*MemObj)(nil)
+
+// Finish is part of the Writable interface.
+func (f *MemObj) Finish() error { return nil }
+
+// Abort is part of the Writable interface.
+func (f *MemObj) Abort() { f.buf.Reset() }
+
+// Write is part of the Writable interface.
+func (f *MemObj) Write(p []byte) error {
+	_, err := f.buf.Write(p)
+	return err
+}
+
+// Data returns the in-memory buffer behind this MemObj.
+func (f *MemObj) Data() []byte {
+	return f.buf.Bytes()
+}
+
+// ReadAt is part of the Readable interface.
+func (f *MemObj) ReadAt(ctx context.Context, p []byte, off int64) error {
+	if f.Size() < off+int64(len(p)) {
+		return errors.Errorf("read past the end of object")
+	}
+	copy(p, f.Data()[off:off+int64(len(p))])
+	return nil
+}
+
+// Close is part of the Readable interface.
+func (f *MemObj) Close() error { return nil }
+
+// Size is part of the Readable interface.
+func (f *MemObj) Size() int64 {
+	return int64(f.buf.Len())
+}
+
+// NewReadHandle is part of the Readable interface.
+func (f *MemObj) NewReadHandle(ctx context.Context) ReadHandle {
+	return &NoopReadHandle{readable: f}
+}

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -67,7 +67,7 @@ func runBuildCmd(
 	td *datadriven.TestData, writerOpts *WriterOptions, cacheSize int,
 ) (*WriterMetadata, *Reader, error) {
 
-	f0 := &memFile{}
+	f0 := &objstorage.MemObj{}
 	if err := optsFromArgs(td, writerOpts); err != nil {
 		return nil, nil, err
 	}
@@ -510,7 +510,7 @@ func runRewriteCmd(
 		return nil, r, err
 	}
 
-	f := &memFile{}
+	f := &objstorage.MemObj{}
 	meta, _, err := rewriteKeySuffixesInBlocks(r, f, opts, from, to, 2)
 	if err != nil {
 		return nil, r, errors.Wrap(err, "rewrite failed")

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -946,7 +946,7 @@ func TestWriterRace(t *testing.T) {
 				Compression: NoCompression,
 			}
 			defer wg.Done()
-			f := &memFile{}
+			f := &objstorage.MemObj{}
 			w := NewWriter(f, opts)
 			for ki := 0; ki < len(keys); ki++ {
 				require.NoError(


### PR DESCRIPTION
Add an in-memory implementation of Writable/Readable and replace
existing test implementations.