### PR TITLE
compact: minor fix to the splitter

### DIFF
--- a/internal/compact/testdata/output_splitter
+++ b/internal/compact/testdata/output_splitter
@@ -164,3 +164,10 @@ h 20
 i 30
 ----
 h 20: split at "ga"
+
+# Verify that we never split at the first key.
+run start-key=a limit-key=ga target-size=1
+a 10
+b 20
+----
+b 20: split at "b"


### PR DESCRIPTION
Make sure we never split on the first key. In this case we were
returning SplitKey equal to the first key, which is not allowed.

Note that the newly added check is not in a hot path.

This doesn't cause visible problems currently because the compaction
code initializes the output writer lazily, and a nil `Writer`
has an estimated size of 0. It becomes a problem if we initialize the
writer upfront, since an empty but initialized writer has a few bytes
of estimated size.