### PR TITLE
compact: relax splitter frontier requirement

### DIFF
--- a/internal/compact/splitting_test.go
+++ b/internal/compact/splitting_test.go
@@ -7,6 +7,7 @@ package compact
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
 	"strings"
 	"testing"
 
@@ -51,11 +52,15 @@ func TestOutputSplitter(t *testing.T) {
 				targetFileSize, grandparents.Iter(), f,
 			)
 			var last string
-			for _, l := range strings.Split(d.Input, "\n") {
+			for i, l := range strings.Split(d.Input, "\n") {
 				var key string
 				var estimatedSize uint64
 				fmt.Sscanf(l, "%s %d", &key, &estimatedSize)
-				f.Advance([]byte(key))
+				// Advance the frontier, except (sometimes) for the first key where the
+				// splitter allows for the frontier to already be at the next user key.
+				if i > 0 || rand.Intn(2) == 0 {
+					f.Advance([]byte(key))
+				}
 				if s.ShouldSplitBefore([]byte(key), estimatedSize, func() []byte { return []byte(last) }) {
 					return fmt.Sprintf("%s %d: split at %q", key, estimatedSize, s.SplitKey())
 				}

--- a/internal/compact/testdata/output_splitter
+++ b/internal/compact/testdata/output_splitter
@@ -171,3 +171,11 @@ a 10
 b 20
 ----
 b 20: split at "b"
+
+# Verify that we can jump over many boundaries before the first key.
+run start-key=a limit-key=g target-size=100
+f1 10
+f2 10
+gg 10
+----
+gg 10: split at "g"

--- a/testdata/manual_compaction_set_with_del_sstable_Pebblev4
+++ b/testdata/manual_compaction_set_with_del_sstable_Pebblev4
@@ -182,7 +182,8 @@ compact a-e L1
 ----
 L2:
   000009:[a#3,SET-c#inf,RANGEDEL]
-  000010:[c#2,RANGEDEL-h#3,SET]
+  000010:[c#2,RANGEDEL-e#inf,RANGEDEL]
+  000011:[e#2,RANGEDEL-h#3,SET]
 L3:
   000006:[a#0,SET-b#0,SET]
   000007:[c#0,SET-d#0,SET]


### PR DESCRIPTION
`NewOutputSplitter` requires the `firstKey` to be at or after the
current frontier (because it relies on the frontier tripping the
boundaries before the corresponding `ShouldSplitBefore` call).

In practice, this requirement is bothersome: if there are range del or
range key spans, the current table would start at the previous split
key, which can be behind the frontier. The current code uses the next
point key but this is not ideal - we may want to split a span multiple
times in-between two very far-away points.

This change relaxes this requirement by manually checking the
boundaries the first time `ShouldSplitBefore` is called. The
compaction code is improved to provide the correct first key.