### PR TITLE
internal/lint: update lint deps

### DIFF
--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -24,7 +24,7 @@ const (
 	cmdGo       = "go"
 	golint      = "golang.org/x/lint/golint@6edffad5e6160f5949cdefc81710b2706fbcd4f6"
 	staticcheck = "honnef.co/go/tools/cmd/staticcheck@2023.1.7"
-	crlfmt      = "github.com/cockroachdb/crlfmt@44a36ec7"
+	crlfmt      = "github.com/cockroachdb/crlfmt@461e8663"
 )
 
 func dirCmd(t *testing.T, dir string, name string, args ...string) stream.Filter {

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -23,7 +23,7 @@ import (
 const (
 	cmdGo       = "go"
 	golint      = "golang.org/x/lint/golint@6edffad5e6160f5949cdefc81710b2706fbcd4f6"
-	staticcheck = "honnef.co/go/tools/cmd/staticcheck@2023.1"
+	staticcheck = "honnef.co/go/tools/cmd/staticcheck@2023.1.7"
 	crlfmt      = "github.com/cockroachdb/crlfmt@44a36ec7"
 )
 


### PR DESCRIPTION
**internal/lint: update staticcheck**

Update staticcheck to 2023.1.7.

---

**internal/lint: update crlfmt**

Update to cockroachdb/crlfmt@461e8663b4b4887b1c6a6c9deaeeb775109a635f.