### PR TITLE
db: avoid keyspanimpl.TableNewSpanIter closure allocation

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2460,7 +2460,7 @@ func TestCompactionCheckOrdering(t *testing.T) {
 					return iterSet{point: &errorIter{}}, nil
 				}
 				result := "OK"
-				_, _, _, err := c.newInputIters(newIters, nil)
+				_, _, _, err := c.newInputIters(newIters)
 				if err != nil {
 					result = fmt.Sprint(err)
 				}

--- a/flushable_test.go
+++ b/flushable_test.go
@@ -118,7 +118,7 @@ func TestIngestedSSTFlushableAPI(t *testing.T) {
 			}
 
 			meta := loadFileMeta(paths)
-			flushable = newIngestedFlushable(meta, d.opts.Comparer, d.newIters, d.tableNewRangeKeyIter, KeyRange{})
+			flushable = newIngestedFlushable(meta, d.opts.Comparer, d.newIters, KeyRange{})
 			return ""
 		case "iter":
 			iter := flushable.newIter(nil)

--- a/ingest.go
+++ b/ingest.go
@@ -1271,7 +1271,7 @@ func (d *DB) newIngestedFlushableEntry(
 		}
 	}
 
-	f := newIngestedFlushable(meta, d.opts.Comparer, d.newIters, d.tableNewRangeKeyIter, exciseSpan)
+	f := newIngestedFlushable(meta, d.opts.Comparer, d.newIters, exciseSpan)
 
 	// NB: The logNum/seqNum are the WAL number which we're writing this entry
 	// to and the sequence number within the WAL which we'll write this entry

--- a/internal/keyspan/keyspanimpl/level_iter_test.go
+++ b/internal/keyspan/keyspanimpl/level_iter_test.go
@@ -5,6 +5,7 @@
 package keyspanimpl
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -301,7 +302,7 @@ func TestLevelIterEquivalence(t *testing.T) {
 				metas = append(metas, meta)
 			}
 
-			tableNewIters := func(file *manifest.FileMetadata, iterOptions keyspan.SpanIterOptions) (keyspan.FragmentIterator, error) {
+			tableNewIters := func(_ context.Context, file *manifest.FileMetadata, iterOptions keyspan.SpanIterOptions) (keyspan.FragmentIterator, error) {
 				return keyspan.NewIter(base.DefaultComparer.Compare, tc.levels[j][file.FileNum-1]), nil
 			}
 			// Add all the fileMetadatas to L6.
@@ -314,6 +315,7 @@ func TestLevelIterEquivalence(t *testing.T) {
 			v, err := b.Apply(nil, base.DefaultComparer, 0, 0)
 			require.NoError(t, err)
 			levelIter.Init(
+				context.Background(),
 				keyspan.SpanIterOptions{}, base.DefaultComparer.Compare, tableNewIters,
 				v.Levels[6].Iter(), 0, manifest.KeyTypeRange,
 			)
@@ -440,7 +442,7 @@ func TestLevelIter(t *testing.T) {
 			}
 			if iter == nil {
 				var lastFileNum base.FileNum
-				tableNewIters := func(file *manifest.FileMetadata, _ keyspan.SpanIterOptions) (keyspan.FragmentIterator, error) {
+				tableNewIters := func(_ context.Context, file *manifest.FileMetadata, _ keyspan.SpanIterOptions) (keyspan.FragmentIterator, error) {
 					keyType := keyType
 					spans := level[file.FileNum-1]
 					if keyType == manifest.KeyTypePoint {
@@ -458,6 +460,7 @@ func TestLevelIter(t *testing.T) {
 				v, err := b.Apply(nil, base.DefaultComparer, 0, 0)
 				require.NoError(t, err)
 				iter = NewLevelIter(
+					context.Background(),
 					keyspan.SpanIterOptions{}, base.DefaultComparer.Compare,
 					tableNewIters, v.Levels[6].Iter(), 6, keyType,
 				)

--- a/iterator.go
+++ b/iterator.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/humanize"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/keyspan"
-	"github.com/cockroachdb/pebble/internal/keyspan/keyspanimpl"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/rangekeystack"
 	"github.com/cockroachdb/pebble/sstable"
@@ -233,7 +232,6 @@ type Iterator struct {
 	// Non-nil if this Iterator includes a Batch.
 	batch            *Batch
 	newIters         tableNewIters
-	newIterRangeKey  keyspanimpl.TableNewSpanIter
 	lazyCombinedIter lazyCombinedIter
 	seqNum           uint64
 	// batchSeqNum is used by Iterators over indexed batches to detect when the
@@ -2822,7 +2820,6 @@ func (i *Iterator) CloneWithContext(ctx context.Context, opts CloneOptions) (*It
 		batch:               i.batch,
 		batchSeqNum:         i.batchSeqNum,
 		newIters:            i.newIters,
-		newIterRangeKey:     i.newIterRangeKey,
 		seqNum:              i.seqNum,
 	}
 	dbi.processBounds(dbi.opts.LowerBound, dbi.opts.UpperBound)

--- a/open.go
+++ b/open.go
@@ -400,7 +400,6 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 		opts.TableCache, d.cacheID, d.objProvider, d.opts, tableCacheSize,
 		&sstable.CategoryStatsCollector{})
 	d.newIters = d.tableCache.newIters
-	d.tableNewRangeKeyIter = tableNewRangeKeyIter(context.TODO(), d.newIters)
 
 	var previousOptionsFileNum base.DiskFileNum
 	var previousOptionsFilename string

--- a/overlap.go
+++ b/overlap.go
@@ -97,9 +97,8 @@ func (c *overlapChecker) determinePointKeyOverlapInLevel(
 	// Check for overlapping range deletions.
 	{
 		c.keyspanLevelIter.Init(
-			keyspan.SpanIterOptions{}, c.comparer.Compare, tableNewRangeDelIter(ctx, c.newIters),
-			metadataIter, level, manifest.KeyTypePoint,
-		)
+			ctx, keyspan.SpanIterOptions{}, c.comparer.Compare,
+			c.newIters.NewRangeDelIter, metadataIter, level, manifest.KeyTypePoint)
 		rangeDeletionOverlap, err := determineOverlapKeyspanIterator(c.comparer.Compare, bounds, &c.keyspanLevelIter)
 		err = errors.CombineErrors(err, c.keyspanLevelIter.Close())
 		if rangeDeletionOverlap || err != nil {
@@ -117,9 +116,8 @@ func (c *overlapChecker) determineRangeKeyOverlapInLevel(
 ) (bool, error) {
 	// Check for overlapping range keys.
 	c.keyspanLevelIter.Init(
-		keyspan.SpanIterOptions{}, c.comparer.Compare, tableNewRangeKeyIter(ctx, c.newIters),
-		metadataIter, level, manifest.KeyTypeRange,
-	)
+		ctx, keyspan.SpanIterOptions{}, c.comparer.Compare,
+		c.newIters.NewRangeKeyIter, metadataIter, level, manifest.KeyTypeRange)
 	rangeKeyOverlap, err := determineOverlapKeyspanIterator(c.comparer.Compare, bounds, &c.keyspanLevelIter)
 	return rangeKeyOverlap, errors.CombineErrors(err, c.keyspanLevelIter.Close())
 }


### PR DESCRIPTION
The tableNewIters func requires a context, but the keyspanimpl.TableNewSpanIter func used by keyspan.LevelIter did not take one. This required iterator construction to close over the context and the tableNewIters to create an keyspanimpl.TableNewSpanIter, forcing an allocation.

This commit refactors the keyspanimpl.LevelIter to embed a context, like the point iterator's levelIter, and propagate the context into TableNewSpanIter through an argument.