### PR TITLE
db: document memTable.writerRefs subtlety

### DIFF
--- a/mem_table.go
+++ b/mem_table.go
@@ -290,6 +290,12 @@ func (m *memTable) containsRangeKeys() bool {
 func (m *memTable) availBytes() uint32 {
 	a := m.skl.Arena()
 	if m.writerRefs.Load() == 1 {
+		// Note that one ref is maintained as long as the memtable is the
+		// current mutable memtable, so when evaluating whether the current
+		// mutable memtable has sufficient space for committing a batch, it is
+		// guaranteed that m.writerRefs() >= 1. This means a writerRefs() of 1
+		// indicates there are no other concurrent apply operations.
+		//
 		// If there are no other concurrent apply operations, we can update the
 		// reserved bytes setting to accurately reflect how many bytes of been
 		// allocated vs the over-estimation present in memTableEntrySize.

--- a/testdata/determinism
+++ b/testdata/determinism
@@ -82,3 +82,55 @@ run io-latency=(.1,100µs) step-latency=(.2,5ms) count=10
 sequential( 0:define 1:build 2:build parallel( 3:batch 4:batch 5:flush 6:maybe-compact 7:batch 8:ingest-and-excise 9:ingest-and-excise ) )
 ----
 ok
+
+# Run a test with two batches committing in parallel, competing for the
+# remaining bytes of the mutable memtable. Only one of the batches can fit in
+# the remaining bytes, and the other must rotate the memtable.
+
+reset
+----
+
+define memtable-size=65536
+----
+0:define
+
+memtable-info reserved in-use
+----
+flushable queue: 1 entries
+mutable:
+  alloced:  65536
+  reserved: 1123
+  in-use:   0
+1:memtable-info
+
+batch
+set a <rand-bytes=30000>
+----
+2:batch
+
+batch
+set b <rand-bytes=30000>
+----
+3:batch
+
+memtable-info
+----
+flushable queue: 1 entries
+mutable:
+  alloced:  65536
+4:memtable-info
+
+batch
+set c <rand-bytes=3000>
+----
+5:batch
+
+batch
+set d <rand-bytes=3000>
+----
+6:batch
+
+run count=100
+sequential( 0:define 1:memtable-info 2:batch 3:batch 4:memtable-info parallel( 5:batch 6:batch ) )
+----
+ok


### PR DESCRIPTION
Previously it was not obvious why memTable.availBytes() could reset the memtable's reserved size when memTable.writerRefs() == 1. In #3557, a code reading lead us to believe there was a race where competing writers could improperly double reserve the tail of the memtable's arena. However, in the code reading we missed that the mutable memtable always has a writerRefs()≥1, which is why a writerRefs()==1 indicates there are no concurrent applications to the memtable.

Additionally, add a unit test that exercises the race of two batches competing for the tail of the memtable arena.

Close #3557.