### PR TITLE
internal/keyspan: prohibit NextPrefix at span boundary

### DIFF
--- a/internal/keyspan/interleaving_iter.go
+++ b/internal/keyspan/interleaving_iter.go
@@ -479,6 +479,8 @@ func (i *InterleavingIter) Next() *base.InternalKV {
 }
 
 // NextPrefix implements (base.InternalIterator).NextPrefix.
+//
+// Calling NextPrefix while positioned at a span boundary is prohibited.
 func (i *InterleavingIter) NextPrefix(succKey []byte) *base.InternalKV {
 	if i.dir == -1 {
 		panic("pebble: cannot switch directions with NextPrefix")
@@ -499,7 +501,7 @@ func (i *InterleavingIter) NextPrefix(succKey []byte) *base.InternalKV {
 			i.computeSmallestPos()
 		}
 	case posKeyspanStart, posKeyspanEnd:
-		i.nextPos()
+		panic(errors.AssertionFailedf("NextPrefix called while positioned on a span boundary"))
 	}
 	return i.yieldPosition(i.opts.LowerBound, i.nextPos)
 }

--- a/internal/keyspan/testdata/interleaving_iter
+++ b/internal/keyspan/testdata/interleaving_iter
@@ -1053,12 +1053,11 @@ OK
 iter
 first
 next-prefix
+next
 next-prefix
 next-prefix
 next-prefix
-next-prefix
-next-prefix
-next-prefix
+next
 ----
 -- SpanChanged(nil)
 -- SpanChanged(nil)
@@ -1084,7 +1083,6 @@ PointKey: f#72057594037927935,RANGEKEYSET
 Span: f-g:{(#6,RANGEKEYSET,@9,foo)}
 -
 -- SpanChanged(nil)
-.
 .
 
 define-spans


### PR DESCRIPTION
Previously when the interleaving iterator interleaved a span boundary, the semantics of calling NextPrefix were undefined. Ordinarily NextPrefix guarantees that it advances to a key with a new prefix. The existing interleaving iterator implementation didn't guarantee this when positioned on a span boundary. Guaranteeing it would require otherwise unnecessary key comparisons.

In existing use cases (for range keys, which always begin and end at prefix keys), we never call NextPrefix while positioned at a span boundary. With the planned refactor of #2863, we'll begin to use the interleaving iterator to interleave range deletions which may have bounds within the keys of a prefix. This assertion will ensure we don't unintentionally rely on currently undefined behavior of calling NextPrefix on a span boundary.