### PR TITLE
db: fix level checker use of stale iterator value

### DIFF
--- a/level_checker.go
+++ b/level_checker.go
@@ -146,13 +146,13 @@ func (m *simpleMergingIter) step() bool {
 		m.err = errors.CombineErrors(l.iter.Error(), l.iter.Close())
 		l.iter = nil
 		m.heap.pop()
-	} else if !l.iterKV.K.IsExclusiveSentinel() {
+	} else {
 		// Check point keys in an sstable are ordered. Although not required, we check
 		// for memtables as well. A subtle check here is that successive sstables of
 		// L1 and higher levels are ordered. This happens when levelIter moves to the
 		// next sstable in the level, in which case item.key is previous sstable's
 		// last point key.
-		if base.InternalCompare(m.heap.cmp, item.key, l.iterKV.K) >= 0 {
+		if !l.iterKV.K.IsExclusiveSentinel() && base.InternalCompare(m.heap.cmp, item.key, l.iterKV.K) >= 0 {
 			m.err = errors.Errorf("out of order keys %s >= %s in %s",
 				item.key.Pretty(m.formatKey), l.iterKV.K.Pretty(m.formatKey), l.iter)
 			return false

--- a/testdata/level_checker
+++ b/testdata/level_checker
@@ -356,3 +356,21 @@ Level 1
 check merger=fail-merger
 ----
 merge processing error on key a#9,SINGLEDEL in L1: fileNum=000033: finish failed
+
+# Test a case where we pause at a range deletion end boundary at the end of a
+# file and the last point key of the same file has its value stored out-of-band
+# in a value block (because it's the second key with the same prefix 'a').
+
+define
+L
+a@9.SET.9 f.RANGEDEL.72057594037927935
+a@9.SET.9:a9 a@6.SET.6:a6 a.RANGEDEL.5:f
+f@6.SET.6 f@6.SET.6
+f@6.SET.6:f6
+----
+Level 1
+  file 0: [a@9#9,SET-f#72057594037927935,RANGEDEL]
+  file 1: [f@6#6,SET-f@6#6,SET]
+
+check
+----


### PR DESCRIPTION
Recent refactors made it possible for the level checker to visit a point key twice if the point key's levelIter interleaved a boundary sentinel key. The corresponding level's simpleMergingIterItem's key and value were not updated, leaving the old point key on the heap. When the point key remained at the top of the heap, but the underlying levelIter had moved on, it was possible to access freed memory associated with the old point key's value.

Fix #3556.
Fix #3583.