### PR TITLE
db: fix iterator error propagation, NextPrefix violation

### DIFF
--- a/flushable.go
+++ b/flushable.go
@@ -237,10 +237,10 @@ func (s *ingestedFlushable) constructRangeDelIter(
 	file *manifest.FileMetadata, _ keyspan.SpanIterOptions,
 ) (keyspan.FragmentIterator, error) {
 	iters, err := s.newIters(context.Background(), file, nil, internalIterOpts{}, iterRangeDeletions)
-	// Note that the keyspan level iter expects a non-nil iterator to be
-	// returned even if there is an error. So, we return iters.RangeDeletion()
-	// regardless of the value of err.
-	return iters.RangeDeletion(), err
+	if err != nil {
+		return nil, err
+	}
+	return iters.RangeDeletion(), nil
 }
 
 // newRangeDelIter is part of the flushable interface.


### PR DESCRIPTION
This commit fixes a few issues surrounding NextPrefix and iterator errors. Previously, under some circumstances, an error propagated by the underlying iterator would not immediately be propagated up. Instead the Iterator could in some circumstances call Next or NextPrefix on an already exhausted, errored iterator, resulting in undefined behavior.

Similarly, the results of calling NextPrefix on an exhausted top-level pebble.Iterator are not defined. This commit adapts the implementation to early exit in this case. The metamorphic test may generate such operations.

Fix #3592.