### PR TITLE
db: interleave range deletion boundaries in levelIter 

### DIFF
--- a/internal/keyspan/interleaving_iter.go
+++ b/internal/keyspan/interleaving_iter.go
@@ -1036,9 +1036,10 @@ func (i *InterleavingIter) verify(kv *base.InternalKV) *base.InternalKV {
 		switch {
 		case i.dir == -1 && i.spanMarkerTruncated:
 			panic("pebble: invariant violation: truncated span key in reverse iteration")
-		case kv != nil && i.opts.LowerBound != nil && i.cmp(kv.K.UserKey, i.opts.LowerBound) < 0:
+		case kv != nil && i.opts.LowerBound != nil && !kv.K.IsExclusiveSentinel() &&
+			i.cmp(kv.K.UserKey, i.opts.LowerBound) < 0:
 			panic("pebble: invariant violation: key < lower bound")
-		case kv != nil && i.opts.UpperBound != nil &&
+		case kv != nil && i.opts.UpperBound != nil && !kv.K.IsExclusiveSentinel() &&
 			!base.UserKeyExclusive(i.opts.UpperBound).IsUpperBoundForInternalKey(i.comparer.Compare, kv.K):
 			panic("pebble: invariant violation: key ≥ upper bound")
 		case i.err != nil && kv != nil:

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invalidating"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/private"
@@ -85,6 +86,10 @@ func (f *failMerger) Close() error {
 }
 
 func TestCheckLevelsCornerCases(t *testing.T) {
+	if invariants.Enabled {
+		t.Skip("disabled under invariants; relies on violating invariants to detect them")
+	}
+
 	memFS := vfs.NewMem()
 	var levels [][]*fileMetadata
 	formatKey := testkeys.Comparer.FormatKey

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -53,7 +53,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 569B
 Block cache: 6 entries (945B)  hit rate: 30.8%
-Table cache: 1 entries (760B)  hit rate: 50.0%
+Table cache: 1 entries (760B)  hit rate: 66.7%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0

--- a/testdata/level_iter_boundaries
+++ b/testdata/level_iter_boundaries
@@ -7,11 +7,31 @@ b.RANGEDEL.2:d
 iter
 first
 next
+next
+next
+next
+next
+next
 last
 prev
+prev
+prev
+prev
+prev
+prev
 ----
+a#72057594037927935,RANGEDEL:
+b#72057594037927935,RANGEDEL:
+b#72057594037927935,RANGEDEL:
+c#72057594037927935,RANGEDEL:
+c#72057594037927935,RANGEDEL:
 d#72057594037927935,RANGEDEL:
 .
+d#72057594037927935,RANGEDEL:
+c#72057594037927935,RANGEDEL:
+c#72057594037927935,RANGEDEL:
+b#72057594037927935,RANGEDEL:
+b#72057594037927935,RANGEDEL:
 a#72057594037927935,RANGEDEL:
 .
 
@@ -21,10 +41,10 @@ seek-ge d
 seek-lt b
 prev
 ----
-d#72057594037927935,RANGEDEL:
+c#72057594037927935,RANGEDEL:
 .
+b#72057594037927935,RANGEDEL:
 a#72057594037927935,RANGEDEL:
-.
 
 iter
 seek-prefix-ge c
@@ -32,10 +52,10 @@ seek-prefix-ge d
 seek-lt b
 prev
 ----
-d#72057594037927935,RANGEDEL:
+c#72057594037927935,RANGEDEL:
 .
+b#72057594037927935,RANGEDEL:
 a#72057594037927935,RANGEDEL:
-.
 
 iter
 seek-ge e
@@ -77,8 +97,10 @@ first
 next
 next
 next
+next
 ----
 a#1,SET:a
+b#72057594037927935,RANGEDEL:
 c#72057594037927935,RANGEDEL:
 c#3,SET:c
 .
@@ -88,8 +110,10 @@ last
 prev
 prev
 prev
+prev
 ----
 c#3,SET:c
+c#72057594037927935,RANGEDEL:
 b#72057594037927935,RANGEDEL:
 a#1,SET:a
 .
@@ -107,17 +131,23 @@ iter
 first
 next
 next
+next
 ----
 a#1,SET:b
+b#72057594037927935,RANGEDEL:
 c#72057594037927935,RANGEDEL:
 .
 
 iter
 last
 prev
+prev
+prev
 ----
+c#72057594037927935,RANGEDEL:
+b#72057594037927935,RANGEDEL:
 a#1,SET:b
-a#72057594037927935,RANGEDEL:
+.
 
 clear
 ----
@@ -132,17 +162,21 @@ iter
 first
 next
 next
+next
 ----
+a#72057594037927935,RANGEDEL:
+b#72057594037927935,RANGEDEL:
 c#2,SET:c
-c#72057594037927935,RANGEDEL:
 .
 
 iter
 last
 prev
 prev
+prev
 ----
 c#2,SET:c
+b#72057594037927935,RANGEDEL:
 a#72057594037927935,RANGEDEL:
 .
 
@@ -169,15 +203,15 @@ seek-ge d
 prev
 seek-lt e
 ----
+d#72057594037927935,RANGEDEL:
+d#3,SET:d
+d#72057594037927935,RANGEDEL:
 d#3,SET:d
 e#72057594037927935,RANGEDEL:
 d#3,SET:d
+d#72057594037927935,RANGEDEL:
+c#72057594037927935,RANGEDEL:
 e#72057594037927935,RANGEDEL:
-d#3,SET:d
-c#72057594037927935,RANGEDEL:
-d#3,SET:d
-c#72057594037927935,RANGEDEL:
-d#3,SET:d
 
 # Regression test to check that Seek{GE,LT}, First, and Last do not
 # have iteration bounds affected by SeekPrefixGE. Previously,
@@ -343,10 +377,8 @@ iter save continue
 set-bounds lower=e upper=f
 seek-ge e
 next
-next
 ----
 e#5,SET:z
-f#72057594037927935,RANGEDEL:
 .
 
 file-pos
@@ -356,10 +388,8 @@ file 000001 [loaded]
 iter save continue
 seek-lt f
 prev
-prev
 ----
 e#5,SET:z
-e#72057594037927935,RANGEDEL:
 .
 
 file-pos
@@ -370,10 +400,8 @@ iter save continue
 set-bounds lower=f upper=g
 seek-lt g
 prev
-prev
 ----
 f#6,SET:z
-f#72057594037927935,RANGEDEL:
 .
 
 file-pos

--- a/testdata/level_iter_seek
+++ b/testdata/level_iter_seek
@@ -33,14 +33,18 @@ h.SET.3:h
 
 iter
 seek-ge d
+next
+next
 ----
-f#5,SET:f / d-e:{(#6,RANGEDEL)}
+d#72057594037927935,RANGEDEL: / d-e:{(#6,RANGEDEL)}
+e#72057594037927935,RANGEDEL:
+f#5,SET:f
 
 iter
 set-bounds upper=d
 seek-ge d
 ----
-d#72057594037927935,RANGEDEL: / d-e:{(#6,RANGEDEL)}
+.
 
 iter
 set-bounds upper=d
@@ -48,28 +52,29 @@ seek-ge c
 next
 prev
 next
-next
 ----
 c#7,SET:c / d-e:{(#6,RANGEDEL)}
-d#72057594037927935,RANGEDEL:
+.
 c#7,SET:c
-d#72057594037927935,RANGEDEL:
 .
 
 # There is no point key with d, but since there is a rangedel, levelIter returns
 # the boundary key using the largest key, f, in the file.
 iter
 seek-prefix-ge d
+next
 ----
-f#72057594037927935,RANGEDEL: / d-e:{(#6,RANGEDEL)}
+d#72057594037927935,RANGEDEL: / d-e:{(#6,RANGEDEL)}
+d\x00#72057594037927935,RANGEDEL:
 
 # Tests a sequence of SeekPrefixGE with monotonically increasing keys, some of
 # which are present and some not (so fail the bloom filter match). The seek to
-# cc returns a boundary key.
+# cc returns a range deletion tombstone's start key.
 iter
 seek-prefix-ge aa
 seek-prefix-ge c
 seek-prefix-ge cc
+next
 seek-prefix-ge f
 seek-prefix-ge g
 seek-prefix-ge gg
@@ -77,7 +82,8 @@ seek-prefix-ge h
 ----
 .
 c#7,SET:c / d-e:{(#6,RANGEDEL)}
-f#72057594037927935,RANGEDEL: / d-e:{(#6,RANGEDEL)}
+d#72057594037927935,RANGEDEL: / d-e:{(#6,RANGEDEL)}
+cc\x00#72057594037927935,RANGEDEL:
 f#5,SET:f
 g#4,SET:g
 .
@@ -107,6 +113,8 @@ next
 stats
 next
 stats
+next
+stats
 reset-stats
 stats
 ----
@@ -117,9 +125,11 @@ b#8,SET:b
 {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 c#7,SET:c
 {BlockBytes:56 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
-f#5,SET:f
+d#72057594037927935,RANGEDEL:
 {BlockBytes:56 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
-f#72057594037927935,RANGEDEL:
+e#72057594037927935,RANGEDEL:
+{BlockBytes:56 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
+f#5,SET:f
 {BlockBytes:56 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 g#4,SET:g
 {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
@@ -133,7 +143,7 @@ iter
 set-bounds lower=d
 seek-lt d
 ----
-d#72057594037927935,RANGEDEL: / d-e:{(#6,RANGEDEL)}
+.
 
 iter
 set-bounds lower=d
@@ -142,15 +152,17 @@ prev
 next
 prev
 prev
+prev
 ----
 f#5,SET:f / d-e:{(#6,RANGEDEL)}
-d#72057594037927935,RANGEDEL:
+e#72057594037927935,RANGEDEL:
 f#5,SET:f
+e#72057594037927935,RANGEDEL:
 d#72057594037927935,RANGEDEL:
 .
 
 # Verify that First() in the presence of an upper-bound pauses at the
-# table containing the upper-bound.
+# first range deletion's start key.
 
 clear
 ----
@@ -165,10 +177,10 @@ iter
 set-bounds upper=f
 first
 ----
-f#72057594037927935,RANGEDEL:
+d#72057594037927935,RANGEDEL:
 
 # Verify that Last() in the presence of a lower-bound pauses at the
-# table containing the lower-bound.
+# last range deletion's end key.
 
 clear
 ----
@@ -182,7 +194,11 @@ d.RANGEDEL.6:e
 iter
 set-bounds lower=c
 last
+prev
+prev
 ----
+e#72057594037927935,RANGEDEL:
+d#72057594037927935,RANGEDEL:
 c#7,SET:c
 
 # Verify that a seek to a file with range tombstones as boundaries pauses on
@@ -210,9 +226,11 @@ seek-ge d
 prev
 next
 next
+next
 ----
-e#72057594037927935,RANGEDEL: / d-e:{(#6,RANGEDEL)}
+d#72057594037927935,RANGEDEL: / d-e:{(#6,RANGEDEL)}
 c#7,SET:c
+d#72057594037927935,RANGEDEL:
 e#72057594037927935,RANGEDEL:
 f#8,SET:f
 
@@ -221,14 +239,16 @@ seek-lt b
 next
 prev
 prev
+prev
 ----
-a#72057594037927935,RANGEDEL: / a-b:{(#5,RANGEDEL)}
+b#72057594037927935,RANGEDEL: / a-b:{(#5,RANGEDEL)}
 c#7,SET:c
+b#72057594037927935,RANGEDEL:
 a#72057594037927935,RANGEDEL:
 .
 
-# Verify that prev when positioned at the largest boundary returns the
-# last key.
+# Verify that prev when positioned at the start bound of the first range
+# deletion returns the last key.
 
 clear
 ----
@@ -246,11 +266,11 @@ seek-ge d
 prev
 ----
 b#1,SET:b
-e#72057594037927935,RANGEDEL: / d-e:{(#2,RANGEDEL)}
+d#72057594037927935,RANGEDEL: / d-e:{(#2,RANGEDEL)}
 b#1,SET:b
 
-# Verify that next when positioned at the smallest boundary returns
-# the first key.
+# Verify that next when positioned at the start boundary of the first range
+# deletion returns the first key.
 
 clear
 ----
@@ -268,7 +288,7 @@ seek-lt d
 next
 ----
 d#2,SET:d
-a#72057594037927935,RANGEDEL: / a-b:{(#1,RANGEDEL)}
+b#72057594037927935,RANGEDEL: / a-b:{(#1,RANGEDEL)}
 d#2,SET:d
 
 # Verify SeekPrefixGE correctness with trySeekUsingNext=true
@@ -325,9 +345,9 @@ seek-prefix-ge j true
 a#1,SET:a / c-e:{(#4,RANGEDEL)}
 a#1,SET:a / c-e:{(#4,RANGEDEL)}
 b#2,SET:b / c-e:{(#4,RANGEDEL)}
-e#72057594037927935,RANGEDEL:
-e#72057594037927935,RANGEDEL: / c-e:{(#4,RANGEDEL)}
-e#72057594037927935,RANGEDEL: / c-e:{(#4,RANGEDEL)}
+c#72057594037927935,RANGEDEL:
+c#72057594037927935,RANGEDEL: / c-e:{(#4,RANGEDEL)}
+d#72057594037927935,RANGEDEL: / c-e:{(#4,RANGEDEL)}
 f#5,SINGLEDEL:
 g#6,SET:g
 h#7,SINGLEDEL:
@@ -384,14 +404,14 @@ j.SET.3:j
 iter
 seek-ge f
 next
-next
 ----
 f#5,SET:f
-f#72057594037927935,RANGEDEL:
 i#4,SET:i
 
-# The below count should be 2, as we skip over the rangekey-only file.
+# The below count should be 4, as we skip over the rangekey-only file.
+# TODO(jackson): When we stop opening range deletion iterators twice, this
+# should be 2.
 
 iters-created
 ----
-2
+4

--- a/testdata/merging_iter
+++ b/testdata/merging_iter
@@ -58,11 +58,16 @@ seek-ge d
 next
 ----
 #  000000.rangeDelIter.opSpanSeekGE("d") = a-e:{(#8,RANGEDEL)}
+#  000000.rangeDelIter.opSpanSeekGE("d") = a-e:{(#8,RANGEDEL)}
 #  000001.rangeDelIter.opSpanSeekGE("e") = e-g:{(#8,RANGEDEL)}
-#  000000.rangeDelIter.opSpanSeekGE("e") = nil
+#  000001.rangeDelIter.opSpanSeekGE("e") = e-g:{(#8,RANGEDEL)}
+#  000000.rangeDelIter.opSpanSeekGE("d") = a-e:{(#8,RANGEDEL)}
+#  000000.rangeDelIter.opSpanNext() = nil
+#  000000.rangeDelIter.opSpanClose() = nil
 #  000000.rangeDelIter.opSpanClose() = nil
 #  000001.rangeDelIter.opSpanSeekGE("e") = e-g:{(#8,RANGEDEL)}
 e#10,SET:10
+#  000001.rangeDelIter.opSpanNext() = nil
 #  000001.rangeDelIter.opSpanSeekGE("g") = nil <err="injected error">
 err=injected error
 
@@ -820,16 +825,16 @@ seek-lt coo
 seek-prefix-ge b
 ----
 #  iter.First() = (a#30,SET,"30")
-#  rangedelIter.opSpanSeekGE("a") = nil <err="injected error">
+#  rangedelIter.opSpanFirst() = nil <err="injected error">
 err=injected error
 #  iter.Last() = (f#21,SET,"21")
-#  rangedelIter.opSpanSeekGE("f") = nil <err="injected error">
+#  rangedelIter.opSpanLast() = nil <err="injected error">
 err=injected error
 #  iter.SeekGE("boo") = (c#18,SET,"18")
 #  rangedelIter.opSpanSeekGE("boo") = nil <err="injected error">
 err=injected error
 #  iter.SeekLT("coo") = (c#18,SET,"18")
-#  rangedelIter.opSpanSeekGE("coo") = nil <err="injected error">
+#  rangedelIter.opSpanSeekLT("coo") = nil <err="injected error">
 err=injected error
 #  iter.SeekPrefixGE("b") = (b#19,SET,"19")
 #  rangedelIter.opSpanSeekGE("b") = nil <err="injected error">

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -73,7 +73,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 589B
 Block cache: 3 entries (484B)  hit rate: 0.0%
-Table cache: 1 entries (760B)  hit rate: 0.0%
+Table cache: 1 entries (760B)  hit rate: 50.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
@@ -128,7 +128,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 595B
 Block cache: 5 entries (946B)  hit rate: 33.3%
-Table cache: 2 entries (1.5KB)  hit rate: 66.7%
+Table cache: 2 entries (1.5KB)  hit rate: 75.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 2
@@ -170,7 +170,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 595B
 Block cache: 5 entries (946B)  hit rate: 33.3%
-Table cache: 2 entries (1.5KB)  hit rate: 66.7%
+Table cache: 2 entries (1.5KB)  hit rate: 75.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 2
@@ -209,7 +209,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 595B
 Block cache: 3 entries (484B)  hit rate: 33.3%
-Table cache: 1 entries (760B)  hit rate: 66.7%
+Table cache: 1 entries (760B)  hit rate: 75.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
@@ -252,7 +252,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 595B
 Block cache: 0 entries (0B)  hit rate: 33.3%
-Table cache: 0 entries (0B)  hit rate: 66.7%
+Table cache: 0 entries (0B)  hit rate: 75.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
@@ -322,7 +322,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 2.6KB
 Block cache: 0 entries (0B)  hit rate: 33.3%
-Table cache: 0 entries (0B)  hit rate: 66.7%
+Table cache: 0 entries (0B)  hit rate: 75.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
@@ -376,7 +376,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 2.0KB
 Block cache: 0 entries (0B)  hit rate: 14.3%
-Table cache: 0 entries (0B)  hit rate: 58.3%
+Table cache: 0 entries (0B)  hit rate: 64.3%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
@@ -479,7 +479,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 4.3KB
 Block cache: 12 entries (1.9KB)  hit rate: 16.7%
-Table cache: 1 entries (760B)  hit rate: 60.0%
+Table cache: 1 entries (760B)  hit rate: 64.7%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
@@ -541,7 +541,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 6.1KB
 Block cache: 12 entries (1.9KB)  hit rate: 16.7%
-Table cache: 1 entries (760B)  hit rate: 60.0%
+Table cache: 1 entries (760B)  hit rate: 64.7%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0


### PR DESCRIPTION
Previously, levelIter would sometimes interleave fake keys at file boundaries
or user-provided iteration boundaries when a file contains range deletions.
This commit reworks the levelIter to instead interleave the individual bounds
of the range deletions themselves, using an interleaving iterator. This
simplifies the levelIter. Because range deletions are now read in two places:
once for interleaving bounds and once to expose a rangeDelIter to the
mergingIter, this commit requires opening a file's range deletion iterator
twice. This is an intermediary state until https://github.com/cockroachdb/pebble/issues/2863 is completed when the
mergingIter will consult the levelIter's interleaving iterator to determine
which range deletions overlap the current iterator position.

Informs https://github.com/cockroachdb/pebble/issues/2863.