### PR TITLE
tool: add more summaries to manifest summarize

### DIFF
--- a/tool/testdata/manifest_summarize
+++ b/tool/testdata/manifest_summarize
@@ -16,12 +16,14 @@ manifest summarize
 ./testdata/find-db/MANIFEST-000001
 ----
 MANIFEST-000001
-                     _______L0_______L1_______L2_______L3_______L4_______L5_______L6_____TOTAL
+                        _______L0_______L1_______L2_______L3_______L4_______L5_______L6_____TOTAL
 2023-12-12T18:55:00Z
-        Ingest+Flush      2.0KB        .        .        .        .        .     671B    2.7KB
-        Ingest+Flush    2.0KB/s        .        .        .        .        .   671B/s  2.7KB/s
-       Compact (out)      2.0KB        .        .        .        .        .        .    2.0KB
-       Compact (out)    2.0KB/s        .        .        .        .        .        .  2.0KB/s
+     Ingest+Flush Bytes      2.0KB        .        .        .        .        .     671B    2.7KB
+   Ingest+Flush Bytes/s    2.0KB/s        .        .        .        .        .   671B/s  2.7KB/s
+      Compact Out Bytes      2.0KB        .        .        .        .        .        .    2.0KB
+    Compact Out Bytes/s    2.0KB/s        .        .        .        .        .        .  2.0KB/s
+     Compact In Bytes/s          .        .        .        .        .        .  2.2KB/s  2.2KB/s
+     Compact In Files/s          .        .        .        .        .        .    3.0/s    3.0/s
 2023-12-12T18:55:00Z
 ---
 Estimated start time: 2023-12-12T18:55:00Z
@@ -32,12 +34,14 @@ manifest summarize
 ./testdata/mixed/MANIFEST-000001
 ----
 MANIFEST-000001
-                     _______L0_______L1_______L2_______L3_______L4_______L5_______L6_____TOTAL
+                        _______L0_______L1_______L2_______L3_______L4_______L5_______L6_____TOTAL
 2023-12-11T18:59:04Z
-        Ingest+Flush      1.0KB        .        .        .        .        .        .    1.0KB
-        Ingest+Flush    1.0KB/s        .        .        .        .        .        .  1.0KB/s
-       Compact (out)          .        .        .        .        .        .        .        .
-       Compact (out)          .        .        .        .        .        .        .        .
+     Ingest+Flush Bytes      1.0KB        .        .        .        .        .        .    1.0KB
+   Ingest+Flush Bytes/s    1.0KB/s        .        .        .        .        .        .  1.0KB/s
+      Compact Out Bytes          .        .        .        .        .        .        .        .
+    Compact Out Bytes/s          .        .        .        .        .        .        .        .
+     Compact In Bytes/s          .        .        .        .        .        .        .        .
+     Compact In Files/s          .        .        .        .        .        .        .        .
 2023-12-11T18:59:04Z
 ---
 Estimated start time: 2023-12-11T18:59:04Z


### PR DESCRIPTION
These were motivated by some disagg storage experimentation. There are summaries for compacted in bytes and files. Also, a histogram of file lifetimes when the file gets deleted. The classification of what is a compaction is slightly improved, and there is some small cleanup (unused field).

On a real manifest, in verbose mode (for the lifetime histograms) the output looks like:
                        _______L0_______L1_______L2_______L3_______L4_______L5_______L6_____TOTAL
2024-05-01T12:00:00Z
     Ingest+Flush Bytes       16GB        .        .        .        .        .        .     16GB
   Ingest+Flush Bytes/s    4.5MB/s        .        .        .        .        .        .  4.5MB/s
      Compact Out Bytes       16GB        .     32GB     36GB     36GB     32GB        .    151GB
    Compact Out Bytes/s    4.5MB/s        .  9.0MB/s   10MB/s   10MB/s  9.1MB/s        .   43MB/s
     Compact In Bytes/s          .        .  9.0MB/s   10MB/s   10MB/s  9.5MB/s  7.7MB/s   47MB/s
     Compact In Files/s          .        .    2.8/s    2.1/s    1.2/s    0.6/s    0.2/s    6.8/s
<snip>
Lifetime histograms
2024-05-01T12:00:00Z
  L0: mean: 15s p25: 10s p50: 15s p75: 21s p90: 26s
  L2: mean: 14s p25: 6s p50: 13s p75: 22s p90: 28s
  L3: mean: 1m7s p25: 13s p50: 1m3s p75: 1m39s p90: 2m23s
  L4: mean: 5m53s p25: 15s p50: 5m19s p75: 10m7s p90: 14m23s
  L5: mean: 34m10s p25: 35s p50: 30m55s p75: 59m43s p90: 1h21m3s
  L6: mean: 3h34m3s p25: 2h42m7s p50: 4h24m31s p75: 5h7m11s p90: 5h41m19s
<snip>