### PR TITLE
metamorphic: use 12 as the minimum target file size

### DIFF
--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -495,7 +495,7 @@ func standardOptions() []*TestOptions {
 `,
 		15: `
 [Level "0"]
-  target_file_size=1
+  target_file_size=12
 `,
 		16: `
 [Level "0"]
@@ -706,6 +706,9 @@ func RandomOptions(
 	lopts.BlockSizeThreshold = 50 + rng.Intn(50)   // 50 - 100
 	lopts.IndexBlockSize = 1 << uint(rng.Intn(24)) // 1 - 16MB
 	lopts.TargetFileSize = 1 << uint(rng.Intn(28)) // 1 - 256MB
+	// The EstimatedSize of an empty table writer is 8 bytes. We want something a
+	// little bigger than that as the minimum target.
+	lopts.TargetFileSize = max(lopts.TargetFileSize, 12)
 
 	// We either use no bloom filter, the default filter, or a filter with
 	// randomized bits-per-key setting. We zero out the Filters map. It'll get


### PR DESCRIPTION
Before the recent compaction cleanup, the output table writer was
initialized lazily, which means that until the first key was written
the estimated size was 0. So even with a tiny target size, we will get
at least one point key and any associated spans.

Now the table writer is initialized up front and the estimated size of
an empty table writer is 8. When the target file size is less than
that, we try to split the table as soon as possible (and emit just a
small piece of a span in many cases). These many tiny tables slow down
the tests a lot, to the point of timing out certain operations.

This change sets the minimum target file size in the metamorphic
tests to 12.

Fixes #3594
Fixes #3595