### PR TITLE
db: tolerate empty external ingestions

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -698,68 +698,6 @@ func (d *DB) ingestAttachRemote(jobID JobID, lr ingestLoadResult) error {
 		}
 	}
 
-	if invariants.Enabled || d.opts.Experimental.CheckExternalIngestions {
-		// Verify that the ingestion is not empty. Empty tables cause correctness
-		// issues in some iterators.
-		for i := range lr.external {
-			e := &lr.external[i]
-			isEmpty, err := func() (bool, error) {
-				readable, err := d.objProvider.OpenForReading(
-					context.Background(), fileTypeTable, e.FileBacking.DiskFileNum, objstorage.OpenOptions{},
-				)
-				if err != nil {
-					return false, err
-				}
-				reader, err := sstable.NewReader(readable, d.opts.MakeReaderOptions())
-				if err != nil {
-					readable.Close()
-					return false, err
-				}
-				defer reader.Close()
-				iter, err := reader.NewIter(e.IterTransforms(), nil, nil)
-				if err != nil {
-					return false, err
-				}
-				if iter != nil {
-					defer iter.Close()
-					if kv := iter.SeekGE(e.external.StartKey, base.SeekGEFlagsNone); kv != nil {
-						cmp := d.opts.Comparer.Compare(kv.K.UserKey, e.external.EndKey)
-						if cmp < 0 || (cmp == 0 && e.external.EndKeyIsInclusive) {
-							return false, nil
-						}
-					}
-					if err := iter.Error(); err != nil {
-						return false, err
-					}
-				}
-				rangeIter, err := reader.NewRawRangeDelIter(e.IterTransforms())
-				if err != nil {
-					return false, err
-				}
-				if rangeIter != nil {
-					defer rangeIter.Close()
-					span, err := rangeIter.SeekGE(e.external.StartKey)
-					if err != nil {
-						return false, err
-					}
-					if span != nil {
-						cmp := d.opts.Comparer.Compare(span.Start, e.external.EndKey)
-						if cmp < 0 || (cmp == 0 && e.external.EndKeyIsInclusive) {
-							return false, nil
-						}
-					}
-				}
-				return true, nil
-			}()
-			if err != nil {
-				return err
-			}
-			if isEmpty {
-				panic(fmt.Sprintf("external ingestion is empty: %s (%q %q)", e.external.ObjName, e.external.StartKey, e.external.EndKey))
-			}
-		}
-	}
-
 	if d.opts.EventListener.TableCreated != nil {
 		for i := range remoteObjMetas {
 			d.opts.EventListener.TableCreated(TableCreateInfo{

--- a/metamorphic/build.go
+++ b/metamorphic/build.go
@@ -274,32 +274,6 @@ func openExternalObj(
 	return reader, pointIter, rangeDelIter, rangeKeyIter
 }
 
-// externalObjIsEmpty returns true if the given external object has no point or
-// range keys withing the given bounds.
-func externalObjIsEmpty(
-	t *Test, externalObjID objID, bounds pebble.KeyRange, syntheticPrefix sstable.SyntheticPrefix,
-) bool {
-	reader, pointIter, rangeDelIter, rangeKeyIter := openExternalObj(t, externalObjID, bounds, syntheticPrefix)
-	defer reader.Close()
-	defer closeIters(pointIter, rangeDelIter, rangeKeyIter)
-
-	kv := pointIter.First()
-	panicIfErr(pointIter.Error())
-	if kv != nil {
-		return false
-	}
-	for _, it := range []keyspan.FragmentIterator{rangeDelIter, rangeKeyIter} {
-		if it != nil {
-			span, err := it.First()
-			panicIfErr(err)
-			if span != nil {
-				return false
-			}
-		}
-	}
-	return true
-}
-
 func panicIfErr(err error) {
 	if err != nil {
 		panic(err)

--- a/options.go
+++ b/options.go
@@ -682,10 +682,6 @@ type Options struct {
 		// major version is at least `FormatFlushableIngest`.
 		DisableIngestAsFlushable func() bool
 
-		// CheckExternalIngestions enables opening external ssts at ingest time and
-		// validating that they are not empty. Used for testing/debugging.
-		CheckExternalIngestions bool
-
 		// RemoteStorage enables use of remote storage (e.g. S3) for storing
 		// sstables. Setting this option enables use of CreateOnShared option and
 		// allows ingestion of external files.

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -830,3 +830,81 @@ a: (foo, .)
 aa@10: (a, .)
 b@11: (b, .)
 .
+
+# Test empty external ingestion.
+reset
+----
+
+build-remote ext
+set a@10 a
+set b@11 b
+----
+
+ingest-external
+ext bounds=(u,v)
+----
+
+lsm
+----
+L6:
+  000004(000004):[u#10,DELSIZED-v#inf,RANGEDEL]
+
+iter
+first
+----
+.
+
+download a z via-backing-file-download
+----
+ok
+
+# LSM should be empty now.
+lsm
+----
+
+iter
+first
+----
+.
+
+# Test with two external files, one empty.
+ingest-external
+ext bounds=(a,c)
+----
+
+ingest-external
+ext bounds=(u,v)
+----
+
+lsm
+----
+L6:
+  000006(000006):[a#11,DELSIZED-c#inf,RANGEDEL]
+  000007(000006):[u#12,DELSIZED-v#inf,RANGEDEL]
+
+iter
+first
+next
+next
+----
+a@10: (a, .)
+b@11: (b, .)
+.
+
+download a z
+----
+ok
+
+lsm
+----
+L6:
+  000008:[a@10#0,SET-b@11#0,SET]
+
+iter
+first
+next
+next
+----
+a@10: (a, .)
+b@11: (b, .)
+.


### PR DESCRIPTION
We now tolerate empty external ingestions.

When we encounter an empty table in a download compaction, we just
delete the table.

The iterator correctness issues that occurred before seem to no longer
apply, very likely thanks to the recent refactoring and cleanup of the
iterator stack (I ran the meta test for ~5hrs and saw no failures).

Fixes #3408