### PR TITLE
objstorageprovider: small readahead improvements

### DIFF
--- a/objstorage/objstorageprovider/readahead_test.go
+++ b/objstorage/objstorageprovider/readahead_test.go
@@ -20,9 +20,7 @@ func TestMaybeReadahead(t *testing.T) {
 		cacheHit := false
 		switch d.Cmd {
 		case "reset":
-			rs.size = initialReadaheadSize
-			rs.limit = 0
-			rs.numReads = 0
+			rs = makeReadaheadState(rs.maxReadaheadSize)
 			return ""
 
 		case "cache-read":

--- a/objstorage/objstorageprovider/testdata/readahead
+++ b/objstorage/objstorageprovider/testdata/readahead
@@ -8,7 +8,7 @@ readahead:  0
 numReads:   1
 size:       65536
 prevSize:   0
-limit:      0
+limit:      2064
 
 read
 2096, 16
@@ -17,7 +17,7 @@ readahead:  0
 numReads:   2
 size:       65536
 prevSize:   0
-limit:      0
+limit:      2112
 
 read
 2112, 16
@@ -84,7 +84,7 @@ readahead:  0
 numReads:   2
 size:       65536
 prevSize:   0
-limit:      16208
+limit:      16209
 
 # The next read is too far ahead to benefit from readahead
 # (i.e. 540497 > 16208 (limit) + (512 << 10) (maxReadaheadSize))
@@ -126,45 +126,49 @@ readahead:  0
 numReads:   2
 size:       65536
 prevSize:   0
-limit:      16
+limit:      7796
 
 read
-7680, 16
+7800, 16
 ----
 readahead:  65536
 numReads:   3
 size:       131072
 prevSize:   65536
-limit:      73216
-
-read
-7780, 16
----
-readahead:  0
-numReads:   4
-size:       131072
-prevSize:   65536
-limit:      73216
+limit:      73336
 
 read
 7880, 16
 ----
-expected 2 args: offset, size
+readahead:  0
+numReads:   4
+size:       131072
+prevSize:   65536
+limit:      73336
 
 read
 7980, 16
 ----
 readahead:  0
-numReads:   4
+numReads:   5
 size:       131072
 prevSize:   65536
-limit:      73216
+limit:      73336
+
+read
+8080, 16
+----
+readahead:  0
+numReads:   6
+size:       131072
+prevSize:   65536
+limit:      73336
 
 read
 73416, 16
 ----
 readahead:  131072
-numReads:   5
+numReads:   7
 size:       262144
 prevSize:   131072
 limit:      204488
@@ -173,7 +177,7 @@ read
 204488, 16
 ----
 readahead:  262144
-numReads:   6
+numReads:   8
 size:       262144
 prevSize:   262144
 limit:      466632
@@ -184,7 +188,7 @@ read
 466632, 16
 ----
 readahead:  262144
-numReads:   7
+numReads:   9
 size:       262144
 prevSize:   262144
 limit:      728776
@@ -195,7 +199,7 @@ cache-read
 728770, 16
 ----
 readahead:  0
-numReads:   7
+numReads:   10
 size:       262144
 prevSize:   262144
 limit:      728786
@@ -204,7 +208,7 @@ read
 728780, 16
 ----
 readahead:  262144
-numReads:   8
+numReads:   11
 size:       262144
 prevSize:   262144
 limit:      990924
@@ -219,3 +223,36 @@ numReads:   1
 size:       65536
 prevSize:   0
 limit:      1216
+
+reset
+----
+
+# Offset 240KiB, length 32KiB.
+read
+245760, 32768
+----
+readahead:  0
+numReads:   1
+size:       65536
+prevSize:   0
+limit:      278528
+
+# Offset 280KiB, length 32KiB.
+read
+286720, 32768
+----
+readahead:  0
+numReads:   2
+size:       65536
+prevSize:   0
+limit:      319488
+
+# Offset 320KiB, length 32KiB.
+read
+327680, 32768
+----
+readahead:  65536
+numReads:   3
+size:       131072
+prevSize:   65536
+limit:      393216


### PR DESCRIPTION
- The limit was not being updated in certain cases, which delayed when readahead would occur. This is fixed, and new test case exercises this.
- The code in recordCacheHit is almost identical to the one in maybeReadahead and the main comprehension challenge of the code is the various predicates (and their code comments with examples), which are repeated (without the examples). These are now merged into a single helper method.
- A small side-effect of the previous change is that numReads is incremented on a cache hit when we are already above the threshold. This has no actual effect on when readahead will happen. And arguably, this new behavior is more principled.
- One of the test cases had a missing - and was not being exercised, and resulting in an incorrect error in a later test case. This is fixed.
- There is additional invariant documentation.