### PR TITLE
db: avoid loading later files for a level in SeekPrefixGE

### DIFF
--- a/internal/base/comparer.go
+++ b/internal/base/comparer.go
@@ -123,6 +123,12 @@ type ImmediateSuccessor func(dst, a []byte) []byte
 //     If Compare(prefix(a), prefix(b)) = 0, then Compare(a, b) = Compare(suffix(a), suffix(b)).
 type Split func(a []byte) int
 
+// Prefix returns the prefix of the key k, using s to split the key.
+func (s Split) Prefix(k []byte) []byte {
+	i := s(k)
+	return k[:i:i]
+}
+
 // DefaultSplit is a trivial implementation of Split which always returns the
 // full key.
 var DefaultSplit Split = func(key []byte) int { return len(key) }

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -184,7 +184,7 @@ func TestIterator(t *testing.T) {
 		// NB: Use a mergingIter to filter entries newer than seqNum.
 		fakeIter := base.NewFakeIter(kvs)
 		fakeIter.SetBounds(opts.GetLowerBound(), opts.GetUpperBound())
-		iter := newMergingIter(nil /* logger */, &it.stats.InternalStats, it.cmp, it.split, fakeIter)
+		iter := newMergingIter(nil /* logger */, &it.stats.InternalStats, it.cmp, it.comparer.Split, fakeIter)
 		iter.snapshot = seqNum
 		// NB: This Iterator cannot be cloned since it is not constructed
 		// with a readState. It suffices for this test.

--- a/level_iter.go
+++ b/level_iter.go
@@ -559,7 +559,7 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) loadFileReturnIndicato
 		// any keys within the iteration prefix. Loading the next file is
 		// unnecessary. This has been observed in practice on slow shared
 		// storage. See #3575.
-		if l.prefix != nil && l.cmp(file.SmallestPointKey.UserKey[:l.split(file.SmallestPointKey.UserKey)], l.prefix) > 0 {
+		if l.prefix != nil && l.cmp(l.split.Prefix(file.SmallestPointKey.UserKey), l.prefix) > 0 {
 			// Note that because l.iter is nil, a subsequent call to
 			// SeekPrefixGE with TrySeekUsingNext()=true will load the file
 			// (returning newFileLoaded) and disable TrySeekUsingNext before
@@ -848,8 +848,7 @@ func (l *levelIter) skipEmptyFileForward() *base.InternalKV {
 		// subsequent SeekPrefixGE with TrySeekUsingNext could mistakenly skip
 		// the file's relevant keys.
 		if l.prefix != nil {
-			fileLargestPrefix := l.iterFile.LargestPointKey.UserKey[:l.split(l.iterFile.LargestPointKey.UserKey)]
-			if l.cmp(fileLargestPrefix, l.prefix) > 0 {
+			if l.cmp(l.split.Prefix(l.iterFile.LargestPointKey.UserKey), l.prefix) > 0 {
 				l.exhaustedForward()
 				return nil
 			}

--- a/testdata/iter_histories/prefix_iteration
+++ b/testdata/iter_histories/prefix_iteration
@@ -362,3 +362,23 @@ seek-prefix-ge c@10
 ----
 b@0: (b@0, .)
 c@3: (c@3, .)
+
+# Test a seek for a prefix that falls entirely in the gap between file
+# boundaries. The iterator stats should indicate that no blocks are loaded.
+
+define bloom-bits-per-key=100
+L4
+  b@0.SET.10:b@0
+L4
+  d@3.SET.10:d@3
+----
+L4:
+  000004:[b@0#10,SET-b@0#10,SET]
+  000005:[d@3#10,SET-d@3#10,SET]
+
+combined-iter
+seek-prefix-ge c@10
+stats
+----
+.
+stats: seeked 1 times (1 internal); stepped 0 times (0 internal)

--- a/testdata/iterator_seek_opt
+++ b/testdata/iterator_seek_opt
@@ -244,7 +244,7 @@ seek-prefix-ge d
 d: (2, .)
 stats: seeked 22 times (21 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 8
-SeekPrefixGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 5
 
 # Shifting bounds, with non-overlapping and monotonic bounds, but using
 # SetOptions. A set-options sits between every two seeks. We don't call
@@ -260,7 +260,7 @@ seek-ge b
 b: (1, .)
 stats: seeked 23 times (22 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 8
-SeekPrefixGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 5
 
 iter
 set-options lower=c upper=e
@@ -270,7 +270,7 @@ seek-ge c
 c: (1, .)
 stats: seeked 24 times (23 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 8
-SeekPrefixGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 5
 
 # NB: Equal bounds.
 
@@ -282,7 +282,7 @@ seek-ge d
 d: (2, .)
 stats: seeked 25 times (24 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 10
-SeekPrefixGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 5
 
 iter
 set-options lower=a upper=c
@@ -292,7 +292,7 @@ seek-prefix-ge b
 b: (1, .)
 stats: seeked 26 times (25 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 10
-SeekPrefixGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 5
 
 iter
 set-options lower=c upper=e
@@ -302,7 +302,7 @@ seek-prefix-ge c
 c: (1, .)
 stats: seeked 27 times (26 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 10
-SeekPrefixGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 5
 
 # NB: Equal bounds.
 
@@ -314,4 +314,4 @@ seek-prefix-ge d
 d: (2, .)
 stats: seeked 28 times (27 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 10
-SeekPrefixGEs with trySeekUsingNext: 8
+SeekPrefixGEs with trySeekUsingNext: 6

--- a/testdata/level_iter
+++ b/testdata/level_iter
@@ -164,10 +164,8 @@ b#2,SET:2
 iter
 seek-prefix-ge d
 next
-next
 ----
 d#4,SET:4
-dd#5,SET:5
 .
 
 iter
@@ -180,27 +178,19 @@ dd#5,SET:5
 iter
 seek-prefix-ge d
 next
-prev
-prev
 ----
 d#4,SET:4
-dd#5,SET:5
-d#4,SET:4
-c#3,SET:3
+.
 
 iter
 seek-prefix-ge d
-prev
 ----
 d#4,SET:4
-c#3,SET:3
 
 iter
 seek-prefix-ge dd
-prev
 ----
 dd#5,SET:5
-d#4,SET:4
 
 iter lower=a
 seek-ge a
@@ -449,10 +439,8 @@ d#4,SET:4
 iter upper=e
 seek-prefix-ge d
 next
-next
 ----
 d#4,SET:4
-dd#5,SET:5
 .
 
 iter lower=dd
@@ -464,17 +452,13 @@ dd#5,SET:5
 
 iter lower=d
 seek-prefix-ge dd
-prev
 ----
 dd#5,SET:5
-d#4,SET:4
 
 iter lower=c
 seek-prefix-ge dd
-prev
 ----
 dd#5,SET:5
-d#4,SET:4
 
 iter lower=c
 seek-lt c

--- a/testdata/merging_iter
+++ b/testdata/merging_iter
@@ -730,8 +730,7 @@ err=injected error
 # L2.000029.Close() = nil <err="injected error">
 err=injected error
 # L1.000028.SeekPrefixGE("b") = (c#27,SET,"27")
-# L2.000029.SeekPrefixGE("b") = nil <err="injected error">
-err=injected error
+.
 
 # Inject errors during L1.{Next,NextPrefix,Prev}.
 


### PR DESCRIPTION
Don't load arbitrarily later files during levelIter.SeekPrefixGE. This avoids unnecessary IO and CPU overhead.

Close #3575.