### PR TITLE
crl-release-24.1: ingest: avoid unnecessary I/O when checking overlap

### DIFF
--- a/testdata/ingest
+++ b/testdata/ingest
@@ -442,6 +442,9 @@ d
 z:40
 d:40
 
+# Here 000024:[i#24,RANGEDEL-j#inf,RANGEDEL] slips under
+# 000016:[a#20,RANGEDEL-z#inf,RANGEDEL] because the latter only contains range
+# dels [a, c) and [x, z).
 lsm
 ----
 L0.4:


### PR DESCRIPTION
This commit sets the upper bound on the level iterator used when checking for overlap. This avoids unnecessarily opening a file that starts after the key range of interest.