### PR TITLE
keyspanimpl: use base.Equal in MergingIter

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -883,7 +883,7 @@ func (c *compaction) newInputIters(
 	// boundaries.
 	if len(rangeDelIters) > 0 {
 		mi := &keyspanimpl.MergingIter{}
-		mi.Init(c.cmp, keyspan.NoopTransform, new(keyspanimpl.MergingBuffers), rangeDelIters...)
+		mi.Init(c.comparer, keyspan.NoopTransform, new(keyspanimpl.MergingBuffers), rangeDelIters...)
 		rangeDelIter = mi
 	}
 
@@ -891,7 +891,7 @@ func (c *compaction) newInputIters(
 	// keyspanimpl.MergingIter, and then interleave them among the points.
 	if len(rangeKeyIters) > 0 {
 		mi := &keyspanimpl.MergingIter{}
-		mi.Init(c.cmp, keyspan.NoopTransform, new(keyspanimpl.MergingBuffers), rangeKeyIters...)
+		mi.Init(c.comparer, keyspan.NoopTransform, new(keyspanimpl.MergingBuffers), rangeKeyIters...)
 		// TODO(radu): why do we have a defragmenter here but not above?
 		di := &keyspan.DefragmentingIter{}
 		di.Init(c.comparer, mi, keyspan.DefragmentInternal, keyspan.StaticDefragmentReducer, new(keyspan.DefragmentingBuffers))

--- a/internal/keyspan/keyspanimpl/level_iter_test.go
+++ b/internal/keyspan/keyspanimpl/level_iter_test.go
@@ -320,8 +320,8 @@ func TestLevelIterEquivalence(t *testing.T) {
 			levelIters = append(levelIters, &levelIter)
 		}
 
-		iter1.Init(base.DefaultComparer.Compare, keyspan.VisibleTransform(base.InternalKeySeqNumMax), new(MergingBuffers), fileIters...)
-		iter2.Init(base.DefaultComparer.Compare, keyspan.VisibleTransform(base.InternalKeySeqNumMax), new(MergingBuffers), levelIters...)
+		iter1.Init(base.DefaultComparer, keyspan.VisibleTransform(base.InternalKeySeqNumMax), new(MergingBuffers), fileIters...)
+		iter2.Init(base.DefaultComparer, keyspan.VisibleTransform(base.InternalKeySeqNumMax), new(MergingBuffers), levelIters...)
 
 		// Check iter1 and iter2 for equivalence.
 		s1, err1 := iter1.First()

--- a/internal/keyspan/keyspanimpl/merging_iter_test.go
+++ b/internal/keyspan/keyspanimpl/merging_iter_test.go
@@ -68,7 +68,7 @@ func TestMergingIter(t *testing.T) {
 				}
 			}
 			var iter MergingIter
-			iter.Init(cmp, keyspan.VisibleTransform(snapshot), new(MergingBuffers), iters...)
+			iter.Init(base.DefaultComparer, keyspan.VisibleTransform(snapshot), new(MergingBuffers), iters...)
 			keyspan.RunIterCmd(td.Input, &iter, &buf)
 			return buf.String()
 		default:
@@ -181,7 +181,7 @@ func testFragmenterEquivalenceOnce(t *testing.T, seed int64) {
 
 	fragmenterIter := keyspan.NewIter(f.Cmp, allFragmented)
 	mergingIter := &MergingIter{}
-	mergingIter.Init(f.Cmp, keyspan.VisibleTransform(base.InternalKeySeqNumMax), new(MergingBuffers), iters...)
+	mergingIter.Init(testkeys.Comparer, keyspan.VisibleTransform(base.InternalKeySeqNumMax), new(MergingBuffers), iters...)
 
 	// Position both so that it's okay to perform relative positioning
 	// operations immediately.

--- a/internal/rangekeystack/user_iterator.go
+++ b/internal/rangekeystack/user_iterator.go
@@ -99,7 +99,7 @@ func (ui *UserIteratorConfig) Init(
 	ui.snapshot = snapshot
 	ui.comparer = comparer
 	ui.internalKeys = internalKeys
-	ui.miter.Init(comparer.Compare, ui, &bufs.merging, iters...)
+	ui.miter.Init(comparer, ui, &bufs.merging, iters...)
 	ui.biter.Init(comparer.Compare, comparer.Split, &ui.miter, lower, upper, hasPrefix, prefix)
 	if internalKeys {
 		ui.diter.Init(comparer, &ui.biter, keyspan.DefragmentInternal, keyspan.StaticDefragmentReducer, &bufs.defragmenting)

--- a/internal/rangekeystack/user_iterator_test.go
+++ b/internal/rangekeystack/user_iterator_test.go
@@ -63,7 +63,7 @@ func TestIter(t *testing.T) {
 				dst.End = s.End
 				return nil
 			})
-			iter.Init(cmp, transform, new(keyspanimpl.MergingBuffers), keyspan.NewIter(cmp, spans))
+			iter.Init(testkeys.Comparer, transform, new(keyspanimpl.MergingBuffers), keyspan.NewIter(cmp, spans))
 			return "OK"
 		case "iter":
 			buf.Reset()

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -952,7 +952,7 @@ func (i *scanInternalIterator) constructPointIter(
 
 	buf.merging.init(&i.opts.IterOptions, &InternalIteratorStats{}, i.comparer.Compare, i.comparer.Split, mlevels...)
 	buf.merging.snapshot = i.seqNum
-	rangeDelMiter.Init(i.comparer.Compare, keyspan.VisibleTransform(i.seqNum), new(keyspanimpl.MergingBuffers), rangeDelIters...)
+	rangeDelMiter.Init(i.comparer, keyspan.VisibleTransform(i.seqNum), new(keyspanimpl.MergingBuffers), rangeDelIters...)
 
 	if i.opts.includeObsoleteKeys {
 		iiter := &keyspan.InterleavingIter{}

--- a/table_stats.go
+++ b/table_stats.go
@@ -902,7 +902,7 @@ func newCombinedDeletionKeyspanIter(
 		keyspan.SortKeysByTrailer(&out.Keys)
 		return nil
 	})
-	mIter.Init(comparer.Compare, transform, new(keyspanimpl.MergingBuffers))
+	mIter.Init(comparer, transform, new(keyspanimpl.MergingBuffers))
 
 	iter, err := cr.NewRawRangeDelIter(m.IterTransforms())
 	if err != nil {


### PR DESCRIPTION
Adapt keyspanimpl.MergingIter to take a *base.Comparer and use its equals Equal method when appropriate.