### PR TITLE
manifest: minor cleanup

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -93,7 +93,7 @@ type compactionLevel struct {
 func (cl compactionLevel) Clone() compactionLevel {
 	newCL := compactionLevel{
 		level: cl.level,
-		files: cl.files.Reslice(func(start, end *manifest.LevelIterator) {}),
+		files: cl.files,
 	}
 	return newCL
 }

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -136,7 +136,7 @@ type sublevelInfo struct {
 func (cl sublevelInfo) Clone() sublevelInfo {
 	return sublevelInfo{
 		sublevel:   cl.sublevel,
-		LevelSlice: cl.LevelSlice.Reslice(func(start, end *manifest.LevelIterator) {}),
+		LevelSlice: cl.LevelSlice,
 	}
 }
 func (cl sublevelInfo) String() string {
@@ -1515,7 +1515,7 @@ func (p *compactionPickerByScore) pickElisionOnlyCompaction(
 		return nil
 	}
 	lf := p.vers.Levels[numLevels-1].Find(p.opts.Comparer.Compare, candidate)
-	if lf == nil {
+	if lf.Empty() {
 		panic(fmt.Sprintf("file %s not found in level %d as expected", candidate.FileNum, numLevels-1))
 	}
 
@@ -1523,8 +1523,8 @@ func (p *compactionPickerByScore) pickElisionOnlyCompaction(
 	// compaction unit.
 	pc = newPickedCompaction(p.opts, p.vers, numLevels-1, numLevels-1, p.baseLevel)
 	pc.kind = compactionKindElisionOnly
-	pc.startLevel.files = lf.Slice()
-	if anyTablesCompacting(lf.Slice()) {
+	pc.startLevel.files = lf
+	if anyTablesCompacting(lf) {
 		return nil
 	}
 	pc.smallest, pc.largest = manifest.KeyRange(pc.cmp, pc.startLevel.files.Iter())
@@ -1553,11 +1553,11 @@ func (p *compactionPickerByScore) pickRewriteCompaction(env compactionEnv) (pc *
 			continue
 		}
 		lf := p.vers.Levels[l].Find(p.opts.Comparer.Compare, candidate)
-		if lf == nil {
+		if lf.Empty() {
 			panic(fmt.Sprintf("file %s not found in level %d as expected", candidate.FileNum, numLevels-1))
 		}
 
-		inputs := lf.Slice()
+		inputs := lf
 		if anyTablesCompacting(inputs) {
 			// Try the next level.
 			continue

--- a/ingest.go
+++ b/ingest.go
@@ -2214,7 +2214,7 @@ func (d *DB) ingestApply(
 
 			if splitFile != nil {
 				if invariants.Enabled {
-					if lf := current.Levels[f.Level].Find(d.cmp, splitFile); lf == nil {
+					if lf := current.Levels[f.Level].Find(d.cmp, splitFile); lf.Empty() {
 						panic("splitFile returned is not in level it should be")
 					}
 				}

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -1111,7 +1111,7 @@ func (b *BulkVersionEdit) Apply(
 
 		// Check consistency of the level in the vicinity of our edits.
 		if sm != nil && la != nil {
-			overlap := overlaps(v.Levels[level].Iter(), comparer.Compare, sm.UserKeyBounds())
+			overlap := v.Levels[level].Slice().Overlaps(comparer.Compare, sm.UserKeyBounds())
 			// overlap contains all of the added files. We want to ensure that
 			// the added files are consistent with neighboring existing files
 			// too, so reslice the overlap to pull in a neighbor on each side.


### PR DESCRIPTION
This change cleans up a few aspects of the `manifest` package:
 - we move `overlaps` to a method on the `LevelSlice`
 - we simplify the interface and improve the implementation of
   `LevelIterator.Find()`
 - we remove no-op uses of `LevelSlice.Reslice()`