### PR TITLE
ingest: perform LSM overlap checks outside of DB.mu

### DIFF
--- a/ingest_test.go
+++ b/ingest_test.go
@@ -2289,8 +2289,12 @@ func TestIngestTargetLevel(t *testing.T) {
 					},
 					v: d.mu.versions.currentVersion(),
 				}
-				level, overlapFile, err := ingestTargetLevel(context.Background(), overlapChecker,
-					1, d.mu.compact.inProgress, meta, suggestSplit)
+				lsmOverlap, err := overlapChecker.DetermineLSMOverlap(context.Background(), meta.UserKeyBounds())
+				if err != nil {
+					return err.Error()
+				}
+				level, overlapFile, err := ingestTargetLevel(
+					context.Background(), d.cmp, lsmOverlap, 1, d.mu.compact.inProgress, meta, suggestSplit)
 				if err != nil {
 					return err.Error()
 				}


### PR DESCRIPTION
This change separates the LSM overlap checking from
`ingestTargetLevel`, with the former now happening without holding
`DB.mu`.

We will make more improvements in this area soon, but this change
should be a significant improvement on its own.

Informs #2112