### PR TITLE
crl-release-24.1: sstable: handle synthetic prefix when checking bloom filter

### DIFF
--- a/metamorphic/key_manager.go
+++ b/metamorphic/key_manager.go
@@ -284,11 +284,12 @@ func (k *keyManager) SortedKeysForObj(o objID) []keyMeta {
 }
 
 // InRangeKeysForObj returns all keys in the range [lower, upper) associated with the
-// given object, in sorted order.
+// given object, in sorted order. If either of the bounds is nil, it is ignored.
 func (k *keyManager) InRangeKeysForObj(o objID, lower, upper []byte) []keyMeta {
 	var inRangeKeys []keyMeta
 	for _, km := range k.SortedKeysForObj(o) {
-		if k.comparer.Compare(km.key, lower) >= 0 && k.comparer.Compare(km.key, upper) < 0 {
+		if (lower == nil || k.comparer.Compare(km.key, lower) >= 0) &&
+			(upper == nil || k.comparer.Compare(km.key, upper) < 0) {
 			inRangeKeys = append(inRangeKeys, km)
 		}
 	}

--- a/options.go
+++ b/options.go
@@ -792,7 +792,8 @@ type Options struct {
 	// Filters is a map from filter policy name to filter policy. It is used for
 	// debugging tools which may be used on multiple databases configured with
 	// different filter policies. It is not necessary to populate this filters
-	// map during normal usage of a DB.
+	// map during normal usage of a DB (it will be done automatically by
+	// EnsureDefaults).
 	Filters map[string]FilterPolicy
 
 	// FlushDelayDeleteRange configures how long the database should wait before

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -81,10 +81,8 @@ type ReaderOptions struct {
 	// Merge defines the Merge function in use for this keyspace.
 	Merge base.Merge
 
-	// Filters is a map from filter policy name to filter policy. It is used for
-	// debugging tools which may be used on multiple databases configured with
-	// different filter policies. It is not necessary to populate this filters
-	// map during normal usage of a DB.
+	// Filters is a map from filter policy name to filter policy. Filters with
+	// policies that are not in this map will be ignored.
 	Filters map[string]FilterPolicy
 
 	// Merger defines the associative merge operation to use for merging values


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/pebble/issues/3627

#### metamorphic: fix derived db ID

We had a bug in `deriveDB` and we weren't setting the right entry in
the map. This resulted in `iterSeekPrefixGE` not being able to use
known keys; in this case it falls back to returning a previously
generated random key, which is highly unlikely to match a key from an
external object ingested with prefix replacement. This caused the meta
test to completely miss a severe bug with bloom filters and prefix
replacement.

#### sstable: handle synthetic prefix when checking bloom filter

Fix the sstable iterators to strip the synthetic prefix before
checking the bloom filter.

Fix the `TestRandomizedPrefixSuffixRewriter` to check `SeekPrefixGE`
and randomly enable filters.