### PR TITLE
sstable: add semaphore limiting parallel block reads

### DIFF
--- a/sstable/options.go
+++ b/sstable/options.go
@@ -111,6 +111,8 @@ type ReaderOptions struct {
 	// The default cache size is a zero-size cache.
 	Cache *cache.Cache
 
+	ReadBlockSema chan struct{}
+
 	// User properties specified in this map will not be added to sst.Properties.UserProperties.
 	DeniedUserProperties map[string]struct{}
 

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -539,6 +539,11 @@ func (r *Reader) readBlock(
 	}
 
 	// Cache miss.
+	if r.opts.ReadBlockSema != nil {
+		// Limit the number of concurrent block reads.
+		r.opts.ReadBlockSema <- struct{}{}
+		defer func() { <-r.opts.ReadBlockSema }()
+	}
 	var compressed cacheValueOrBuf
 	if bufferPool != nil {
 		compressed = cacheValueOrBuf{


### PR DESCRIPTION
Add a semaphore limiting the number of block reads in parallel to 1000 (per store).

This is intended for a one-off build.