### PR TITLE
sstable: increment BlockBytes and BlockReadDuration together

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -661,6 +661,7 @@ func (r *Reader) readBlock(
 			int(bh.Length+blockTrailerLen), readDuration.String())
 	}
 	if stats != nil {
+		stats.BlockBytes += bh.Length
 		stats.BlockReadDuration += readDuration
 	}
 	if err != nil {
@@ -718,9 +719,6 @@ func (r *Reader) readBlock(
 		decompressed = transformed
 	}
 
-	if stats != nil {
-		stats.BlockBytes += bh.Length
-	}
 	if iterStats != nil {
 		iterStats.reportStats(bh.Length, 0, readDuration)
 	}


### PR DESCRIPTION
During a cache miss, increment the BlockBytes and BlockReadDuration iterator stats together, immediately after the read. Previously, if an error occurred, it was possible for the duration to be incremented without updating the bytes stats.