### PR TITLE
crl-release-23.2: sstable: increment BlockBytes and BlockReadDuration together

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -571,6 +571,7 @@ func (r *Reader) readBlock(
 			int(bh.Length+blockTrailerLen), readDuration.String())
 	}
 	if stats != nil {
+		stats.BlockBytes += bh.Length
 		stats.BlockReadDuration += readDuration
 	}
 	if err != nil {
@@ -628,9 +629,6 @@ func (r *Reader) readBlock(
 		decompressed = transformed
 	}
 
-	if stats != nil {
-		stats.BlockBytes += bh.Length
-	}
 	if decompressed.buf.Valid() {
 		return bufferHandle{b: decompressed.buf}, nil
 	}


### PR DESCRIPTION
During a cache miss, increment the BlockBytes and BlockReadDuration iterator stats together, immediately after the read. Previously, if an error occurred, it was possible for the duration to be incremented without updating the bytes stats.

23.2 backport of #3641.