### PR TITLE
sstable: clean up TODO in fragmentBlockIter

### DIFF
--- a/internal/rangekey/rangekey_test.go
+++ b/internal/rangekey/rangekey_test.go
@@ -90,10 +90,8 @@ func TestSetValue_Roundtrip(t *testing.T) {
 		n := EncodeSetValue(b, tc.endKey, tc.suffixValues)
 		require.Equal(t, l, n)
 
-		var endKey, rest []byte
-		var ok bool
-		endKey, rest, ok = DecodeEndKey(base.InternalKeyKindRangeKeySet, b[:n])
-		require.True(t, ok)
+		endKey, rest, err := DecodeEndKey(base.InternalKeyKindRangeKeySet, b[:n])
+		require.NoError(t, err)
 
 		var suffixValues []SuffixValue
 		for len(rest) > 0 {
@@ -184,10 +182,8 @@ func TestUnsetValue_Roundtrip(t *testing.T) {
 		n := EncodeUnsetValue(b, tc.endKey, tc.suffixes)
 		require.Equal(t, l, n)
 
-		var ok bool
-		var endKey, rest []byte
-		endKey, rest, ok = DecodeEndKey(base.InternalKeyKindRangeKeyUnset, b[:n])
-		require.True(t, ok)
+		endKey, rest, err := DecodeEndKey(base.InternalKeyKindRangeKeyUnset, b[:n])
+		require.NoError(t, err)
 		var suffixes [][]byte
 		for len(rest) > 0 {
 			var ok bool

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -498,7 +498,7 @@ type rangeKeyFragmentBlockIter struct {
 
 func (i *rangeKeyFragmentBlockIter) Close() error {
 	err := i.fragmentBlockIter.Close()
-	i.fragmentBlockIter = i.fragmentBlockIter.resetForReuse()
+	i.fragmentBlockIter.ResetForReuse()
 	rangeKeyFragmentBlockIterPool.Put(i)
 	return err
 }


### PR DESCRIPTION
The way we use `Decode` to append to an existing span is pretty
subtle. This change adds a separate `DecodeIntoSpan` which is used to
add keys to an existing span. Checks for consistency of the start/end
keys are moved here.