### PR TITLE
Makefile: add gen-bazel target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ mutex.prof
 coverprofile.out
 # Testing artifacts
 meta.*.test
+
+# Bazel files, generated with 'make gen-bazel'.
+/WORKSPACE
+BUILD.bazel
+
+

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ all:
 	@echo "  make crossversion-meta"
 	@echo "  make testcoverage"
 	@echo "  make mod-update"
+	@echo "  make gen-bazel"
 	@echo "  make generate"
 	@echo "  make generate-test-data"
 	@echo "  make clean"
@@ -72,6 +73,19 @@ crossversion-meta:
 .PHONY: stress-crossversion
 stress-crossversion:
 	STRESS=1 ./scripts/run-crossversion-meta.sh crl-release-22.1 crl-release-22.2 crl-release-23.1 crl-release-23.2 master
+
+.PHONY: gen-bazel
+gen-bazel:
+	@echo "Generating WORKSPACE"
+	@echo 'workspace(name = "com_github_cockroachdb_pebble")' > WORKSPACE
+	@echo 'Running gazelle...'
+	${GO} run github.com/bazelbuild/bazel-gazelle/cmd/gazelle@v0.37.0 update --go_prefix=github.com/cockroachdb/pebble --repo_root=.
+	@echo 'You should now be able to build Cockroach using:'
+	@echo '  ./dev build short -- --override_repository=com_github_cockroachdb_pebble=${CURDIR}'
+
+.PHONY: clean-bazel
+clean-bazel:
+	git clean -dxf WORKSPACE BUILD.bazel '**/BUILD.bazel'
 
 .PHONY: generate
 generate:


### PR DESCRIPTION
This change adds a `gen-bazel` target which generates a `WORKSPACE`
file and runs gazelle to generate `BUILD.bazel `files. Generating
these files  allows a local clone of the repository to be used
directly when building Cockroach using the `override_repository` flag,
for example:

```
./dev build short -- --override_repository=com_github_cockroachdb_pebble=~/go/src/github.com/cockroachdb/pebble
```

The new files are added to `.gitignore` so that generating them
doesn't interfere with commits.

We also add a `clean-bazel` target that cleans up these files (useful 
when switching back to an older branch)
