### PR TITLE
sstable: fix double close of fragmentBlockIter

### DIFF
--- a/internal/invariants/off.go
+++ b/internal/invariants/off.go
@@ -9,3 +9,10 @@ package invariants
 
 // Enabled is true if we were built with the "invariants" or "race" build tags.
 const Enabled = false
+
+// DoubleCloseCheck is used to check that objects are not double-closed.
+type DoubleCloseCheck struct{}
+
+// Close panics if called twice on the same object (if we were built with the
+// "invariants" or "race" build tags).
+func (d *DoubleCloseCheck) Close() {}

--- a/internal/invariants/on.go
+++ b/internal/invariants/on.go
@@ -9,3 +9,17 @@ package invariants
 
 // Enabled is true if we were built with the "invariants" or "race" build tags.
 const Enabled = true
+
+// DoubleCloseCheck is used to check that objects are not double-closed.
+type DoubleCloseCheck struct {
+	closed bool
+}
+
+// Close panics if called twice on the same object (if we were built with the
+// "invariants" or "race" build tags).
+func (d *DoubleCloseCheck) Close() {
+	if d.closed {
+		panic("double close")
+	}
+	d.closed = true
+}

--- a/internal/keyspan/iter.go
+++ b/internal/keyspan/iter.go
@@ -55,8 +55,9 @@ type FragmentIterator interface {
 	// previous call to SeekLT or Prev returned an invalid span.
 	Prev() (*Span, error)
 
-	// Close closes the iterator. It is valid to call Close multiple times. Other
-	// methods should not be called after the iterator has been closed.
+	// Close closes the iterator. It is not in general valid to call Close
+	// multiple times. Other methods should not be called after the iterator has
+	// been closed.
 	Close()
 
 	// WrapChildren wraps any child iterators using the given function. The

--- a/level_iter.go
+++ b/level_iter.go
@@ -601,6 +601,7 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) loadFileReturnIndicato
 			if l.err != nil {
 				l.iter = nil
 				*l.rangeDelIterPtr = nil
+				l.rangeDelIterCopy = nil
 				l.err = errors.CombineErrors(l.err, iters.CloseAll())
 				return noFileLoaded
 			}

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -453,7 +453,7 @@ func (r *Reader) NewRawRangeDelIter(transforms IterTransforms) (keyspan.Fragment
 	if err != nil {
 		return nil, err
 	}
-	i := &fragmentBlockIter{elideSameSeqnum: true}
+	i := newFragmentBlockIter(true /* elideSameSeqnum */)
 	// It's okay for hideObsoletePoints to be false here, even for shared ingested
 	// sstables. This is because rangedels do not apply to points in the same
 	// sstable at the same sequence number anyway, so exposing obsolete rangedels
@@ -484,22 +484,11 @@ func (r *Reader) NewRawRangeKeyIter(transforms IterTransforms) (keyspan.Fragment
 	if err != nil {
 		return nil, err
 	}
-	i := rangeKeyFragmentBlockIterPool.Get().(*rangeKeyFragmentBlockIter)
-
+	i := newFragmentBlockIter(false /* elideSameSeqnum */)
 	if err := i.blockIter.initHandle(r.Compare, r.Split, h, transforms); err != nil {
 		return nil, err
 	}
 	return i, nil
-}
-
-type rangeKeyFragmentBlockIter struct {
-	fragmentBlockIter
-}
-
-func (i *rangeKeyFragmentBlockIter) Close() {
-	i.fragmentBlockIter.Close()
-	i.fragmentBlockIter.ResetForReuse()
-	rangeKeyFragmentBlockIterPool.Put(i)
 }
 
 func (r *Reader) readIndex(

--- a/sstable/reader_iter.go
+++ b/sstable/reader_iter.go
@@ -126,19 +126,6 @@ var twoLevelIterPool = sync.Pool{
 	},
 }
 
-// TODO(jackson): rangedel fragmentBlockIters can't be pooled because of some
-// code paths that double Close the iters. Fix the double close and pool the
-// *fragmentBlockIter type directly.
-
-var rangeKeyFragmentBlockIterPool = sync.Pool{
-	New: func() interface{} {
-		i := &rangeKeyFragmentBlockIter{}
-		// Note: this is a no-op if invariants are disabled or race is enabled.
-		invariants.SetFinalizer(i, checkRangeKeyFragmentBlockIterator)
-		return i
-	},
-}
-
 func checkSingleLevelIterator(obj interface{}) {
 	i := obj.(*singleLevelIterator)
 	if p := i.data.handle.Get(); p != nil {
@@ -159,14 +146,6 @@ func checkTwoLevelIterator(obj interface{}) {
 	}
 	if p := i.index.handle.Get(); p != nil {
 		fmt.Fprintf(os.Stderr, "singleLevelIterator.index.handle is not nil: %p\n", p)
-		os.Exit(1)
-	}
-}
-
-func checkRangeKeyFragmentBlockIterator(obj interface{}) {
-	i := obj.(*rangeKeyFragmentBlockIter)
-	if p := i.blockIter.handle.Get(); p != nil {
-		fmt.Fprintf(os.Stderr, "fragmentBlockIter.blockIter.handle is not nil: %p\n", p)
 		os.Exit(1)
 	}
 }

--- a/table_cache.go
+++ b/table_cache.go
@@ -1270,12 +1270,15 @@ func (s *iterSet) CloseAll() error {
 	var err error
 	if s.point != nil {
 		err = s.point.Close()
+		s.point = nil
 	}
 	if s.rangeDeletion != nil {
 		s.rangeDeletion.Close()
+		s.rangeDeletion = nil
 	}
 	if s.rangeKey != nil {
 		s.rangeKey.Close()
+		s.rangeKey = nil
 	}
 	return err
 }


### PR DESCRIPTION
This change addresses a TODO to fix double closing of the
`fragmentBlockIter`. We can now use a sync.Pool and we can remove the
wrapper type that used a sync pool only for range key iterators.

We add an `invariants.DoubleCloseCheck` type which checks for multiple
close calls in invariant builds. In these builds we sometimes don't
put objects back in the pool, so that this check can run.

We now always call `fragmentBlockIter.init()` (we were missing on a
minor optimization before).