### PR TITLE
manifest: minor improvement to CalculateInuseKeyRanges

### DIFF
--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -72,13 +72,13 @@ func TestInuseKeyRangesRandomized(t *testing.T) {
 				// CalculateInuseKeyRanges only guarantees that it returns key
 				// ranges covering in-use ranges within [smallest, largest]. If
 				// this file extends before or after smallest/largest, truncate
-				// it to be within [smallest,largest] for the purpose of
+				// it to be within [smallest, largest] for the purpose of
 				// correctness checking.
 				b := f.UserKeyBounds()
 				if cmp(b.Start, smallest) < 0 {
 					b.Start = smallest
 				}
-				if cmp(b.End.Key, largest) >= 0 {
+				if b.End.IsUpperBoundFor(cmp, largest) {
 					b.End = base.UserKeyInclusive(largest)
 				}
 
@@ -87,8 +87,8 @@ func TestInuseKeyRangesRandomized(t *testing.T) {
 					containedWithin = containedWithin || kr.ContainsBounds(cmp, &b)
 				}
 				if !containedWithin {
-					t.Fatalf("file L%d.%s overlaps [%s, %s] but no in-use key range contains it",
-						l, f, smallest, largest)
+					t.Fatalf("file L%d.%s with bounds %s overlaps [%s, %s] but no in-use key range contains it",
+						l, f, b, smallest, largest)
 				}
 			}
 		}

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -630,6 +630,34 @@ func TestCalculateInuseKeyRanges(t *testing.T) {
 				base.UserKeyBoundsInclusive([]byte("d"), []byte("w")),
 			},
 		},
+		{
+			name: "Touching ranges",
+			v: newVersion([NumLevels][]*FileMetadata{
+				1: {
+					newFileMeta(
+						1,
+						1,
+						base.ParseInternalKey("a.SET.1"),
+						base.ParseInternalKey("b.RANGEDEL.inf"),
+					),
+				},
+				2: {
+					newFileMeta(
+						4,
+						1,
+						base.ParseInternalKey("b.SET.1"),
+						base.ParseInternalKey("c.SET.1"),
+					),
+				},
+			}),
+			level:    1,
+			depth:    2,
+			smallest: []byte("a"),
+			largest:  []byte("z"),
+			want: []base.UserKeyBounds{
+				base.UserKeyBoundsInclusive([]byte("a"), []byte("c")),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Updating this function to better handle end-exclusive ranges. In
particular, we now merge ranges that "touch", like [a, b) and [b, c].

Informs #3673