### PR TITLE
base: add SeqNum type

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"math"
 	"math/rand"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -292,7 +291,7 @@ func testBatchEmpty(t *testing.T, size int, opts ...BatchOption) {
 	require.True(t, b.Empty())
 	b = newBatchWithSize(nil, size)
 
-	require.Equal(t, uint64(0), b.SeqNum())
+	require.Equal(t, base.SeqNumZero, b.SeqNum())
 	require.True(t, b.Empty())
 	b.Reset()
 	require.True(t, b.Empty())
@@ -396,7 +395,7 @@ func TestBatchReset(t *testing.T) {
 	require.Equal(t, uint64(0), b.countRangeDels)
 	require.Equal(t, uint64(0), b.countRangeKeys)
 	require.Equal(t, batchrepr.HeaderLen, len(b.data))
-	require.Equal(t, uint64(0), b.SeqNum())
+	require.Equal(t, base.SeqNumZero, b.SeqNum())
 	require.Equal(t, uint64(0), b.memTableSize)
 	require.Equal(t, FormatMajorVersion(0x00), b.minimumFormatMajorVersion)
 	require.Equal(t, b.deferredOp, DeferredBatchOp{})
@@ -1188,11 +1187,8 @@ func TestFlushableBatch(t *testing.T) {
 			if len(d.CmdArgs) != 1 || len(d.CmdArgs[0].Vals) != 1 || d.CmdArgs[0].Key != "seq" {
 				return "dump seq=<value>\n"
 			}
-			seqNum, err := strconv.Atoi(d.CmdArgs[0].Vals[0])
-			if err != nil {
-				return err.Error()
-			}
-			b.setSeqNum(uint64(seqNum))
+			seqNum := base.ParseSeqNum(d.CmdArgs[0].Vals[0])
+			b.setSeqNum(seqNum)
 
 			var buf bytes.Buffer
 

--- a/batchrepr/reader.go
+++ b/batchrepr/reader.go
@@ -48,7 +48,7 @@ func ReadHeader(repr []byte) (h Header, ok bool) {
 type Header struct {
 	// SeqNum is the sequence number at which the batch is committed. A batch
 	// that has not yet committed will have a zero sequence number.
-	SeqNum uint64
+	SeqNum base.SeqNum
 	// Count is the count of keys written to the batch.
 	Count uint32
 }
@@ -62,8 +62,8 @@ func (h Header) String() string {
 // does not validate that the repr is valid. It's exported only for very
 // performance sensitive code paths that should not necessarily read the rest of
 // the header as well.
-func ReadSeqNum(repr []byte) uint64 {
-	return binary.LittleEndian.Uint64(repr[:countOffset])
+func ReadSeqNum(repr []byte) base.SeqNum {
+	return base.SeqNum(binary.LittleEndian.Uint64(repr[:countOffset]))
 }
 
 // Read constructs a Reader from an encoded batch representation, ignoring the

--- a/batchrepr/writer.go
+++ b/batchrepr/writer.go
@@ -4,13 +4,17 @@
 
 package batchrepr
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+
+	"github.com/cockroachdb/pebble/internal/base"
+)
 
 // SetSeqNum mutates the provided batch representation, storing the provided
 // sequence number in its header. The provided byte slice must already be at
 // least HeaderLen bytes long or else SetSeqNum will panic.
-func SetSeqNum(repr []byte, seqNum uint64) {
-	binary.LittleEndian.PutUint64(repr[:countOffset], seqNum)
+func SetSeqNum(repr []byte, seqNum base.SeqNum) {
+	binary.LittleEndian.PutUint64(repr[:countOffset], uint64(seqNum))
 }
 
 // SetCount mutates the provided batch representation, storing the provided

--- a/batchrepr/writer_test.go
+++ b/batchrepr/writer_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/binfmt"
 )
 
@@ -37,10 +38,7 @@ func TestWriter(t *testing.T) {
 			return prettyBinaryRepr(repr)
 
 		case "set-seqnum":
-			seqNum, err := strconv.ParseUint(td.CmdArgs[0].Key, 10, 64)
-			if err != nil {
-				return err.Error()
-			}
+			seqNum := base.ParseSeqNum(td.CmdArgs[0].Key)
 			SetSeqNum(repr, seqNum)
 			return prettyBinaryRepr(repr)
 

--- a/compaction.go
+++ b/compaction.go
@@ -255,8 +255,8 @@ type compaction struct {
 
 // inputLargestSeqNumAbsolute returns the maximum LargestSeqNumAbsolute of any
 // input sstables.
-func (c *compaction) inputLargestSeqNumAbsolute() uint64 {
-	var seqNum uint64
+func (c *compaction) inputLargestSeqNumAbsolute() base.SeqNum {
+	var seqNum base.SeqNum
 	for _, cl := range c.inputs {
 		cl.files.Each(func(m *manifest.FileMetadata) {
 			seqNum = max(seqNum, m.LargestSeqNumAbsolute)
@@ -1889,15 +1889,15 @@ type deleteCompactionHint struct {
 	// tombstone smallest sequence number to be deleted. All of a tables'
 	// sequence numbers must fall into the same snapshot stripe as the
 	// tombstone largest sequence number to be deleted.
-	tombstoneLargestSeqNum  uint64
-	tombstoneSmallestSeqNum uint64
+	tombstoneLargestSeqNum  base.SeqNum
+	tombstoneSmallestSeqNum base.SeqNum
 	// The smallest sequence number of a sstable that was found to be covered
 	// by this hint. The hint cannot be resolved until this sequence number is
 	// in the same snapshot stripe as the largest tombstone sequence number.
 	// This is set when a hint is created, so the LSM may look different and
 	// notably no longer contain the sstable that contained the key at this
 	// sequence number.
-	fileSmallestSeqNum uint64
+	fileSmallestSeqNum base.SeqNum
 }
 
 func (h deleteCompactionHint) String() string {

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -33,8 +33,8 @@ type compactionEnv struct {
 	// flushes are longer, slower operations and provide a much looser bound
 	// when available bytes is decreasing.
 	diskAvailBytes          uint64
-	earliestUnflushedSeqNum uint64
-	earliestSnapshotSeqNum  uint64
+	earliestUnflushedSeqNum base.SeqNum
+	earliestSnapshotSeqNum  base.SeqNum
 	inProgressCompactions   []compactionInfo
 	readCompactionEnv       readCompactionEnv
 }
@@ -1041,7 +1041,7 @@ func pickCompactionSeedFile(
 	virtualBackings *manifest.VirtualBackings,
 	opts *Options,
 	level, outputLevel int,
-	earliestSnapshotSeqNum uint64,
+	earliestSnapshotSeqNum base.SeqNum,
 ) (manifest.LevelFile, bool) {
 	// Select the file within the level to compact. We want to minimize write
 	// amplification, but also ensure that (a) deletes are propagated to the

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -80,9 +80,9 @@ func loadVersion(t *testing.T, d *datadriven.TestData) (*version, *Options, stri
 				var key InternalKey
 				if level == 0 {
 					// For L0, make `size` overlapping files.
-					key = base.MakeInternalKey([]byte(fmt.Sprintf("%04d", 1)), i, InternalKeyKindSet)
+					key = base.MakeInternalKey([]byte(fmt.Sprintf("%04d", 1)), base.SeqNum(i), InternalKeyKindSet)
 				} else {
-					key = base.MakeInternalKey([]byte(fmt.Sprintf("%04d", i)), i, InternalKeyKindSet)
+					key = base.MakeInternalKey([]byte(fmt.Sprintf("%04d", i)), base.SeqNum(i), InternalKeyKindSet)
 				}
 				m := (&fileMetadata{
 					FileNum:               base.FileNum(uint64(level)*100_000 + i),
@@ -107,7 +107,7 @@ func loadVersion(t *testing.T, d *datadriven.TestData) (*version, *Options, stri
 					// TestCompactionPickerTargetLevel. Clean this up somehow.
 					m.Size = size
 					if level != 0 {
-						endKey := base.MakeInternalKey([]byte(fmt.Sprintf("%04d", size)), i, InternalKeyKindSet)
+						endKey := base.MakeInternalKey([]byte(fmt.Sprintf("%04d", size)), base.SeqNum(i), InternalKeyKindSet)
 						m.ExtendPointKeyBounds(opts.Comparer.Compare, key, endKey)
 					}
 				}

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1423,11 +1423,11 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 						hintType:                hintType,
 						start:                   start,
 						end:                     end,
-						fileSmallestSeqNum:      parseUint64(parts[4]),
+						fileSmallestSeqNum:      base.SeqNum(parseUint64(parts[4])),
 						tombstoneLevel:          tombstoneLevel,
 						tombstoneFile:           tombstoneFile,
-						tombstoneSmallestSeqNum: parseUint64(parts[5]),
-						tombstoneLargestSeqNum:  parseUint64(parts[6]),
+						tombstoneSmallestSeqNum: base.SeqNum(parseUint64(parts[5])),
+						tombstoneLargestSeqNum:  base.SeqNum(parseUint64(parts[6])),
 					}
 					d.mu.compact.deletionHints = append(d.mu.compact.deletionHints, h)
 					fmt.Fprintln(&buf, h.String())
@@ -1497,10 +1497,7 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 				return s
 
 			case "close-snapshot":
-				seqNum, err := strconv.ParseUint(strings.TrimSpace(td.Input), 0, 64)
-				if err != nil {
-					return err.Error()
-				}
+				seqNum := base.ParseSeqNum(strings.TrimSpace(td.Input))
 				d.mu.Lock()
 				var s *Snapshot
 				l := &d.mu.snapshots
@@ -1633,10 +1630,7 @@ func TestCompactionTombstones(t *testing.T) {
 				return runTableStatsCmd(td, d)
 
 			case "close-snapshot":
-				seqNum, err := strconv.ParseUint(strings.TrimSpace(td.Input), 0, 64)
-				if err != nil {
-					return err.Error()
-				}
+				seqNum := base.ParseSeqNum(strings.TrimSpace(td.Input))
 				d.mu.Lock()
 				var s *Snapshot
 				l := &d.mu.snapshots

--- a/db_test.go
+++ b/db_test.go
@@ -384,7 +384,7 @@ func TestLargeBatch(t *testing.T) {
 		require.NoError(t, err)
 		return logs[len(logs)-1]
 	}
-	memTableCreationSeqNum := func() uint64 {
+	memTableCreationSeqNum := func() base.SeqNum {
 		d.mu.Lock()
 		defer d.mu.Unlock()
 		return d.mu.mem.mutable.logSeqNum

--- a/download.go
+++ b/download.go
@@ -292,7 +292,7 @@ type downloadCursor struct {
 	// Inclusive lower bound for sequence number for tables on level with
 	// Smallest.UserKey equaling key. Used to break ties within L0, and also used
 	// to position a cursor immediately after a given file.
-	seqNum uint64
+	seqNum base.SeqNum
 }
 
 var endCursor = downloadCursor{level: manifest.NumLevels}

--- a/event.go
+++ b/event.go
@@ -384,7 +384,7 @@ type TableIngestInfo struct {
 	}
 	// GlobalSeqNum is the sequence number that was assigned to all entries in
 	// the ingested table.
-	GlobalSeqNum uint64
+	GlobalSeqNum base.SeqNum
 	// flushable indicates whether the ingested sstable was treated as a
 	// flushable.
 	flushable bool

--- a/flushable.go
+++ b/flushable.go
@@ -85,7 +85,7 @@ type flushableEntry struct {
 	logSize uint64
 	// The current logSeqNum at the time the memtable was created. This is
 	// guaranteed to be less than or equal to any seqnum stored in the memtable.
-	logSeqNum uint64
+	logSeqNum base.SeqNum
 	// readerRefs tracks the read references on the flushable. The two sources of
 	// reader references are DB.mu.mem.queue and readState.memtables. The memory
 	// reserved by the flushable in the cache is released when the reader refs

--- a/get_iter.go
+++ b/get_iter.go
@@ -20,7 +20,7 @@ import (
 type getIter struct {
 	comparer *Comparer
 	newIters tableNewIters
-	snapshot uint64
+	snapshot base.SeqNum
 	iterOpts IterOptions
 	key      []byte
 	prefix   []byte
@@ -36,7 +36,7 @@ type getIter struct {
 	// deletion encounterd transitions tombstoned to true. The tombstonedSeqNum
 	// field is updated to hold the sequence number of the tombstone.
 	tombstoned       bool
-	tombstonedSeqNum uint64
+	tombstonedSeqNum base.SeqNum
 	err              error
 }
 

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1072,7 +1072,7 @@ func testIngestSharedImpl(
 					require.NoError(t, w.Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val))
 					return nil
 				},
-				func(start, end []byte, seqNum uint64) error {
+				func(start, end []byte, seqNum base.SeqNum) error {
 					require.NoError(t, w.DeleteRange(start, end))
 					return nil
 				},
@@ -1570,7 +1570,7 @@ func TestConcurrentExcise(t *testing.T) {
 					require.NoError(t, w.Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val))
 					return nil
 				},
-				func(start, end []byte, seqNum uint64) error {
+				func(start, end []byte, seqNum base.SeqNum) error {
 					require.NoError(t, w.DeleteRange(start, end))
 					return nil
 				},
@@ -2005,7 +2005,7 @@ func TestIngestExternal(t *testing.T) {
 					require.NoError(t, w.Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val))
 					return nil
 				},
-				func(start, end []byte, seqNum uint64) error {
+				func(start, end []byte, seqNum base.SeqNum) error {
 					require.NoError(t, w.DeleteRange(start, end))
 					return nil
 				},
@@ -3220,17 +3220,13 @@ func TestIngest_UpdateSequenceNumber(t *testing.T) {
 	}
 
 	var (
-		seqNum uint64
-		err    error
+		seqNum base.SeqNum
 		metas  []*fileMetadata
 	)
 	datadriven.RunTest(t, "testdata/ingest_update_seqnums", func(t *testing.T, td *datadriven.TestData) string {
 		switch td.Cmd {
 		case "starting-seqnum":
-			seqNum, err = strconv.ParseUint(td.Input, 10, 64)
-			if err != nil {
-				return err.Error()
-			}
+			seqNum = base.ParseSeqNum(td.Input)
 			return ""
 
 		case "reset":
@@ -3301,7 +3297,7 @@ func TestIngest_UpdateSequenceNumber(t *testing.T) {
 		case "update-files":
 			// Update the bounds across all files.
 			for i, m := range metas {
-				if err := setSeqNumInMetadata(m, seqNum+uint64(i), cmp, base.DefaultFormatter); err != nil {
+				if err := setSeqNumInMetadata(m, seqNum+base.SeqNum(i), cmp, base.DefaultFormatter); err != nil {
 					return err.Error()
 				}
 			}

--- a/internal.go
+++ b/internal.go
@@ -35,6 +35,9 @@ const (
 // InternalKey exports the base.InternalKey type.
 type InternalKey = base.InternalKey
 
+// SeqNum exports the base.SeqNum type.
+type SeqNum = base.SeqNum
+
 type internalIterator = base.InternalIterator
 
 type topLevelIterator = base.TopLevelIterator

--- a/internal/arenaskl/node.go
+++ b/internal/arenaskl/node.go
@@ -47,7 +47,7 @@ type node struct {
 	// Immutable fields, so no need to lock to access key.
 	keyOffset  uint32
 	keySize    uint32
-	keyTrailer uint64
+	keyTrailer base.Trailer
 	valueSize  uint32
 	allocSize  uint32
 

--- a/internal/base/internal_test.go
+++ b/internal/base/internal_test.go
@@ -30,7 +30,7 @@ func TestInternalKey(t *testing.T) {
 	if got, want := k.Kind(), InternalKeyKind(1); got != want {
 		t.Errorf("kind = %d want %d", got, want)
 	}
-	if got, want := k.SeqNum(), uint64(0x08070605040302); got != want {
+	if got, want := k.SeqNum(), SeqNum(0x08070605040302); got != want {
 		t.Errorf("seqNum = %d want %d", got, want)
 	}
 }

--- a/internal/base/test_utils.go
+++ b/internal/base/test_utils.go
@@ -69,7 +69,7 @@ func fakeIkey(s string) InternalKey {
 	if err != nil {
 		panic(err)
 	}
-	return MakeInternalKey([]byte(s[:j]), uint64(seqNum), InternalKeyKindSet)
+	return MakeInternalKey([]byte(s[:j]), SeqNum(seqNum), InternalKeyKindSet)
 }
 
 // NewFakeIter returns an iterator over the given KVs.

--- a/internal/batchskl/skl.go
+++ b/internal/batchskl/skl.go
@@ -415,7 +415,7 @@ func (s *Skiplist) getKey(nd uint32) base.InternalKey {
 	n := s.node(nd)
 	kind := base.InternalKeyKind((*s.storage)[n.offset])
 	key := (*s.storage)[n.keyStart:n.keyEnd]
-	return base.MakeInternalKey(key, uint64(n.offset)|base.InternalKeySeqNumBatch, kind)
+	return base.MakeInternalKey(key, base.SeqNum(n.offset)|base.InternalKeySeqNumBatch, kind)
 }
 
 func (s *Skiplist) getNext(nd, h uint32) uint32 {

--- a/internal/compact/iterator_test.go
+++ b/internal/compact/iterator_test.go
@@ -158,11 +158,7 @@ func TestCompactionIter(t *testing.T) {
 					switch arg.Key {
 					case "snapshots":
 						for _, val := range arg.Vals {
-							seqNum, err := strconv.Atoi(val)
-							if err != nil {
-								return err.Error()
-							}
-							snapshots = append(snapshots, uint64(seqNum))
+							snapshots = append(snapshots, base.ParseSeqNum(val))
 						}
 					case "elide-tombstones":
 						var err error

--- a/internal/compact/snapshots.go
+++ b/internal/compact/snapshots.go
@@ -43,11 +43,11 @@ import (
 //	--             --
 //	a.DEL.6  --->  a.DEL.6
 //	a.PUT.5
-type Snapshots []uint64
+type Snapshots []base.SeqNum
 
 // Index returns the index of the first snapshot sequence number which is >= seq
 // or len(s) if there is no such sequence number.
-func (s Snapshots) Index(seq uint64) int {
+func (s Snapshots) Index(seq base.SeqNum) int {
 	return sort.Search(len(s), func(i int) bool {
 		return s[i] > seq
 	})
@@ -56,7 +56,7 @@ func (s Snapshots) Index(seq uint64) int {
 // IndexAndSeqNum returns the index of the first snapshot sequence number which
 // is >= seq and that sequence number, or len(s) and InternalKeySeqNumMax if
 // there is no such sequence number.
-func (s Snapshots) IndexAndSeqNum(seq uint64) (int, uint64) {
+func (s Snapshots) IndexAndSeqNum(seq base.SeqNum) (int, base.SeqNum) {
 	index := s.Index(seq)
 	if index == len(s) {
 		return index, base.InternalKeySeqNumMax

--- a/internal/compact/snapshots_test.go
+++ b/internal/compact/snapshots_test.go
@@ -12,20 +12,20 @@ import (
 
 func TestSnapshotIndex(t *testing.T) {
 	testCases := []struct {
-		snapshots      []uint64
-		seq            uint64
+		snapshots      []base.SeqNum
+		seq            base.SeqNum
 		expectedIndex  int
-		expectedSeqNum uint64
+		expectedSeqNum base.SeqNum
 	}{
-		{snapshots: []uint64{}, seq: 1, expectedIndex: 0, expectedSeqNum: base.InternalKeySeqNumMax},
-		{snapshots: []uint64{1}, seq: 0, expectedIndex: 0, expectedSeqNum: 1},
-		{snapshots: []uint64{1}, seq: 1, expectedIndex: 1, expectedSeqNum: base.InternalKeySeqNumMax},
-		{snapshots: []uint64{1}, seq: 2, expectedIndex: 1, expectedSeqNum: base.InternalKeySeqNumMax},
-		{snapshots: []uint64{1, 3}, seq: 1, expectedIndex: 1, expectedSeqNum: 3},
-		{snapshots: []uint64{1, 3}, seq: 2, expectedIndex: 1, expectedSeqNum: 3},
-		{snapshots: []uint64{1, 3}, seq: 3, expectedIndex: 2, expectedSeqNum: base.InternalKeySeqNumMax},
-		{snapshots: []uint64{1, 3}, seq: 4, expectedIndex: 2, expectedSeqNum: base.InternalKeySeqNumMax},
-		{snapshots: []uint64{1, 3, 3}, seq: 2, expectedIndex: 1, expectedSeqNum: 3},
+		{snapshots: []base.SeqNum{}, seq: 1, expectedIndex: 0, expectedSeqNum: base.InternalKeySeqNumMax},
+		{snapshots: []base.SeqNum{1}, seq: 0, expectedIndex: 0, expectedSeqNum: 1},
+		{snapshots: []base.SeqNum{1}, seq: 1, expectedIndex: 1, expectedSeqNum: base.InternalKeySeqNumMax},
+		{snapshots: []base.SeqNum{1}, seq: 2, expectedIndex: 1, expectedSeqNum: base.InternalKeySeqNumMax},
+		{snapshots: []base.SeqNum{1, 3}, seq: 1, expectedIndex: 1, expectedSeqNum: 3},
+		{snapshots: []base.SeqNum{1, 3}, seq: 2, expectedIndex: 1, expectedSeqNum: 3},
+		{snapshots: []base.SeqNum{1, 3}, seq: 3, expectedIndex: 2, expectedSeqNum: base.InternalKeySeqNumMax},
+		{snapshots: []base.SeqNum{1, 3}, seq: 4, expectedIndex: 2, expectedSeqNum: base.InternalKeySeqNumMax},
+		{snapshots: []base.SeqNum{1, 3, 3}, seq: 2, expectedIndex: 1, expectedSeqNum: 3},
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {

--- a/internal/compact/spans_test.go
+++ b/internal/compact/spans_test.go
@@ -26,13 +26,17 @@ func TestRangeDelSpanCompactor(t *testing.T) {
 		case "compact":
 			var snapshots []uint64
 			td.MaybeScanArgs(t, "snapshots", &snapshots)
+			var s Snapshots
+			for _, v := range snapshots {
+				s = append(s, base.SeqNum(v))
+			}
 			keyRanges := maybeParseInUseKeyRanges(td)
 			span := keyspan.ParseSpan(td.Input)
 
 			c = MakeRangeDelSpanCompactor(
 				base.DefaultComparer.Compare,
 				base.DefaultComparer.Equal,
-				snapshots,
+				s,
 				ElideTombstonesOutsideOf(keyRanges),
 			)
 
@@ -58,13 +62,17 @@ func TestRangeKeySpanCompactor(t *testing.T) {
 		case "compact":
 			var snapshots []uint64
 			td.MaybeScanArgs(t, "snapshots", &snapshots)
+			var s Snapshots
+			for _, v := range snapshots {
+				s = append(s, base.SeqNum(v))
+			}
 			keyRanges := maybeParseInUseKeyRanges(td)
 			span := keyspan.ParseSpan(td.Input)
 
 			c = MakeRangeKeySpanCompactor(
 				base.DefaultComparer.Compare,
 				base.DefaultComparer.Equal,
-				snapshots,
+				s,
 				ElideTombstonesOutsideOf(keyRanges),
 			)
 

--- a/internal/keyspan/defragment_test.go
+++ b/internal/keyspan/defragment_test.go
@@ -132,7 +132,7 @@ func testDefragmentingIteRandomizedOnce(t *testing.T, seed int64) {
 		}
 
 		key := Key{
-			Trailer: base.MakeTrailer(uint64(i), base.InternalKeyKindRangeKeySet),
+			Trailer: base.MakeTrailer(base.SeqNum(i), base.InternalKeyKindRangeKeySet),
 			Value:   []byte(fmt.Sprintf("v%d", rng.Intn(3))),
 		}
 		// Generate suffixes 0, 1, 2, or 3 with 0 indicating none.

--- a/internal/keyspan/keyspanimpl/merging_iter_test.go
+++ b/internal/keyspan/keyspanimpl/merging_iter_test.go
@@ -51,9 +51,7 @@ func TestMergingIter(t *testing.T) {
 			for _, cmdArg := range td.CmdArgs {
 				switch cmdArg.Key {
 				case "snapshot":
-					var err error
-					snapshot, err = strconv.ParseUint(cmdArg.Vals[0], 10, 64)
-					require.NoError(t, err)
+					snapshot = base.ParseSeqNum(cmdArg.Vals[0])
 				case "probes":
 					// The first value indicates which of the merging iterator's
 					// child iterators is the target.
@@ -134,7 +132,7 @@ func testFragmenterEquivalenceOnce(t *testing.T, seed int64) {
 					Keys:  make([]keyspan.Key, 0, keyCount),
 				}
 				for k := keyCount; k > 0; k-- {
-					seqNum := uint64((len(levels)-l)*3) + k
+					seqNum := base.SeqNum((len(levels)-l)*3) + base.SeqNum(k)
 					s.Keys = append(s.Keys, keyspan.Key{
 						Trailer: base.MakeTrailer(seqNum, base.InternalKeyKindRangeKeySet),
 					})

--- a/internal/keyspan/seek_test.go
+++ b/internal/keyspan/seek_test.go
@@ -7,7 +7,6 @@ package keyspan
 import (
 	"bytes"
 	"fmt"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -49,10 +48,7 @@ func TestSeek(t *testing.T) {
 				if len(parts) != 2 {
 					return fmt.Sprintf("malformed input: %s", line)
 				}
-				seq, err := strconv.ParseUint(parts[1], 10, 64)
-				if err != nil {
-					return err.Error()
-				}
+				seq := base.ParseSeqNum(parts[1])
 				span, err := seek(cmp, iter, []byte(parts[0]))
 				if err != nil {
 					fmt.Fprintf(&buf, "<nil> <err=%q>\n", err)

--- a/internal/keyspan/span_test.go
+++ b/internal/keyspan/span_test.go
@@ -7,12 +7,11 @@ package keyspan
 import (
 	"bytes"
 	"fmt"
-	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/cockroachdb/datadriven"
-	"github.com/stretchr/testify/require"
+	"github.com/cockroachdb/pebble/internal/base"
 )
 
 // TODO(jackson): Add unit tests for all of the various Span methods.
@@ -41,8 +40,7 @@ func TestSpan_Visible(t *testing.T) {
 		case "visible":
 			var buf bytes.Buffer
 			for _, line := range strings.Split(d.Input, "\n") {
-				snapshot, err := strconv.ParseUint(line, 10, 64)
-				require.NoError(t, err)
+				snapshot := base.ParseSeqNum(line)
 				fmt.Fprintf(&buf, "%-2d: %s\n", snapshot, s.Visible(snapshot))
 			}
 			return buf.String()
@@ -62,8 +60,7 @@ func TestSpan_VisibleAt(t *testing.T) {
 		case "visible-at":
 			var buf bytes.Buffer
 			for _, line := range strings.Split(d.Input, "\n") {
-				snapshot, err := strconv.ParseUint(line, 10, 64)
-				require.NoError(t, err)
+				snapshot := base.ParseSeqNum(line)
 				fmt.Fprintf(&buf, "%-2d: %t\n", snapshot, s.VisibleAt(snapshot))
 			}
 			return buf.String()
@@ -84,11 +81,9 @@ func TestSpan_CoversAt(t *testing.T) {
 			var buf bytes.Buffer
 			for _, line := range strings.Split(d.Input, "\n") {
 				fields := strings.Fields(line)
-				snapshot, err := strconv.ParseUint(fields[0], 10, 64)
-				require.NoError(t, err)
-				seqNum, err := strconv.ParseUint(fields[1], 10, 64)
-				require.NoError(t, err)
-				fmt.Fprintf(&buf, "%d %d : %t\n", snapshot, seqNum, s.CoversAt(snapshot, seqNum))
+				snapshot := base.ParseSeqNum(fields[0])
+				seqNum := base.ParseSeqNum(fields[1])
+				fmt.Fprintf(&buf, "%d %d : %t\n", snapshot, seqNum, s.CoversAt(base.SeqNum(snapshot), base.SeqNum(seqNum)))
 			}
 			return buf.String()
 		default:

--- a/internal/keyspan/transformer.go
+++ b/internal/keyspan/transformer.go
@@ -33,7 +33,7 @@ var NoopTransform Transformer = TransformerFunc(func(_ base.Compare, s Span, dst
 
 // VisibleTransform filters keys that are invisible at the provided snapshot
 // sequence number.
-func VisibleTransform(snapshot uint64) Transformer {
+func VisibleTransform(snapshot base.SeqNum) Transformer {
 	return TransformerFunc(func(_ base.Compare, s Span, dst *Span) error {
 		dst.Start, dst.End = s.Start, s.End
 		dst.Keys = dst.Keys[:0]

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -1152,7 +1152,7 @@ type L0CompactionFiles struct {
 	// Set for intra-L0 compactions. SSTables with sequence numbers greater
 	// than earliestUnflushedSeqNum cannot be a part of intra-L0 compactions.
 	isIntraL0               bool
-	earliestUnflushedSeqNum uint64
+	earliestUnflushedSeqNum base.SeqNum
 
 	// For debugging purposes only. Used in checkCompaction().
 	preExtensionMinInterval int
@@ -1563,7 +1563,7 @@ func (s *L0Sublevels) baseCompactionUsingSeed(
 // compaction is possible (i.e. does not conflict with any base/intra-L0
 // compacting files).
 func (s *L0Sublevels) extendFiles(
-	sl int, earliestUnflushedSeqNum uint64, cFiles *L0CompactionFiles,
+	sl int, earliestUnflushedSeqNum base.SeqNum, cFiles *L0CompactionFiles,
 ) bool {
 	index, _ := slices.BinarySearchFunc(s.levelFiles[sl], cFiles.minIntervalIndex, func(a *FileMetadata, b int) int {
 		return stdcmp.Compare(a.maxIntervalIndex, b)
@@ -1595,7 +1595,7 @@ func (s *L0Sublevels) extendFiles(
 // See comment above [PickBaseCompaction] for heuristics involved in this
 // selection.
 func (s *L0Sublevels) PickIntraL0Compaction(
-	earliestUnflushedSeqNum uint64, minCompactionDepth int,
+	earliestUnflushedSeqNum base.SeqNum, minCompactionDepth int,
 ) (*L0CompactionFiles, error) {
 	scoredIntervals := make([]intervalAndScore, len(s.orderedIntervals))
 	for i := range s.orderedIntervals {
@@ -1663,7 +1663,7 @@ func (s *L0Sublevels) PickIntraL0Compaction(
 }
 
 func (s *L0Sublevels) intraL0CompactionUsingSeed(
-	f *FileMetadata, intervalIndex int, earliestUnflushedSeqNum uint64, minCompactionDepth int,
+	f *FileMetadata, intervalIndex int, earliestUnflushedSeqNum base.SeqNum, minCompactionDepth int,
 ) *L0CompactionFiles {
 	// We know that all the files that overlap with intervalIndex have
 	// LargestSeqNum < earliestUnflushedSeqNum, but for other intervals

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -338,7 +338,7 @@ func TestL0Sublevels(t *testing.T) {
 			fallthrough
 		case "pick-intra-l0-compaction":
 			minCompactionDepth := 3
-			earliestUnflushedSeqNum := uint64(math.MaxUint64)
+			earliestUnflushedSeqNum := base.SeqNum(math.MaxUint64)
 			for _, arg := range td.CmdArgs {
 				switch arg.Key {
 				case "min_depth":
@@ -347,11 +347,7 @@ func TestL0Sublevels(t *testing.T) {
 						t.Fatal(err)
 					}
 				case "earliest_unflushed_seqnum":
-					eusnInt, err := strconv.Atoi(arg.Vals[0])
-					if err != nil {
-						t.Fatal(err)
-					}
-					earliestUnflushedSeqNum = uint64(eusnInt)
+					earliestUnflushedSeqNum = base.ParseSeqNum(arg.Vals[0])
 				}
 			}
 
@@ -534,12 +530,12 @@ func TestAddL0FilesEquivalence(t *testing.T) {
 			meta := (&FileMetadata{
 				FileNum:               base.FileNum(i*10 + j + 1),
 				Size:                  rng.Uint64n(1 << 20),
-				SmallestSeqNum:        uint64(2*i + 1),
-				LargestSeqNum:         uint64(2*i + 2),
-				LargestSeqNumAbsolute: uint64(2*i + 2),
+				SmallestSeqNum:        base.SeqNum(2*i + 1),
+				LargestSeqNum:         base.SeqNum(2*i + 2),
+				LargestSeqNumAbsolute: base.SeqNum(2*i + 2),
 			}).ExtendPointKeyBounds(
 				base.DefaultComparer.Compare,
-				base.MakeInternalKey(startKey, uint64(2*i+1), base.InternalKeyKindSet),
+				base.MakeInternalKey(startKey, base.SeqNum(2*i+1), base.InternalKeyKindSet),
 				base.MakeRangeDeleteSentinelKey(endKey),
 			)
 			meta.InitPhysicalBacking()

--- a/internal/manifest/testutils.go
+++ b/internal/manifest/testutils.go
@@ -133,6 +133,11 @@ func (p *debugParser) Uint64() uint64 {
 	return x
 }
 
+// Uint64 parses the next token as a sequence number.
+func (p *debugParser) SeqNum() base.SeqNum {
+	return base.ParseSeqNum(p.Next())
+}
+
 // FileNum parses the next token as a FileNum.
 func (p *debugParser) FileNum() base.FileNum {
 	return base.FileNum(p.Int())

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -37,9 +37,9 @@ type TableInfo struct {
 	// Largest is the largest internal key in the table.
 	Largest InternalKey
 	// SmallestSeqNum is the smallest sequence number in the table.
-	SmallestSeqNum uint64
+	SmallestSeqNum base.SeqNum
 	// LargestSeqNum is the largest sequence number in the table.
-	LargestSeqNum uint64
+	LargestSeqNum base.SeqNum
 }
 
 // TableStats contains statistics on a table used for compaction heuristics,
@@ -196,14 +196,14 @@ type FileMetadata struct {
 	// LargestSeqNumAbsolute will be at least as high as the pre-zeroing
 	// sequence number. LargestSeqNumAbsolute is NOT durably persisted, so after
 	// a database restart it takes on the value of LargestSeqNum.
-	LargestSeqNumAbsolute uint64
+	LargestSeqNumAbsolute base.SeqNum
 	// Lower and upper bounds for the smallest and largest sequence numbers in
 	// the table, across both point and range keys. For physical sstables, these
 	// values are tight bounds. For virtual sstables, there is no guarantee that
 	// there will be keys with SmallestSeqNum or LargestSeqNum within virtual
 	// sstable bounds.
-	SmallestSeqNum uint64
-	LargestSeqNum  uint64
+	SmallestSeqNum base.SeqNum
+	LargestSeqNum  base.SeqNum
 	// SmallestPointKey and LargestPointKey are the inclusive bounds for the
 	// internal point keys stored in the table. This includes RANGEDELs, which
 	// alter point keys.
@@ -787,9 +787,9 @@ func ParseFileMetadataDebug(s string) (_ *FileMetadata, err error) {
 		switch field {
 		case "seqnums":
 			p.Expect("[")
-			m.SmallestSeqNum = p.Uint64()
+			m.SmallestSeqNum = p.SeqNum()
 			p.Expect("-")
-			m.LargestSeqNum = p.Uint64()
+			m.LargestSeqNum = p.SeqNum()
 			p.Expect("]")
 			m.LargestSeqNumAbsolute = m.LargestSeqNum
 

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -421,7 +421,7 @@ func TestVersionEditEncodeLastSeqNum(t *testing.T) {
 				}
 				val, err := d.readUvarint()
 				require.NoError(t, err)
-				if c.edit.LastSeqNum != val {
+				if c.edit.LastSeqNum != base.SeqNum(val) {
 					t.Fatalf("expected %d, but found %d", c.edit.LastSeqNum, val)
 				}
 			}

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -658,9 +658,9 @@ func TestCalculateInuseKeyRangesRandomized(t *testing.T) {
 			return []byte{byte(i/26 + 'a'), byte(i%26 + 'a')}
 		}
 		makeIK := func(level, i int) InternalKey {
-			seqNum := uint64(NumLevels-level) * 100
+			seqNum := base.SeqNum(NumLevels-level) * 100
 			if level == 0 {
-				seqNum += uint64(i)
+				seqNum += base.SeqNum(i)
 			}
 			return base.MakeInternalKey(
 				makeUserKey(i),

--- a/internal/rangekey/coalesce.go
+++ b/internal/rangekey/coalesce.go
@@ -66,7 +66,7 @@ func Coalesce(cmp base.Compare, eq base.Equal, keys []keyspan.Key, dst *[]keyspa
 // CoalesceIntoKeysBySuffix is a variant of Coalesce which outputs the results into
 // keyspan.KeysBySuffix without sorting them.
 func CoalesceIntoKeysBySuffix(
-	equal base.Equal, keysBySuffix *keyspan.KeysBySuffix, snapshot uint64, keys []keyspan.Key,
+	equal base.Equal, keysBySuffix *keyspan.KeysBySuffix, snapshot base.SeqNum, keys []keyspan.Key,
 ) {
 	// First, enforce visibility and RangeKeyDelete mechanics. We only need to
 	// consider the prefix of keys before and including the first
@@ -160,7 +160,7 @@ func CoalesceIntoKeysBySuffix(
 // rest of the iterator stack expects.
 type ForeignSSTTransformer struct {
 	Equal   base.Equal
-	SeqNum  uint64
+	SeqNum  base.SeqNum
 	sortBuf keyspan.KeysBySuffix
 }
 

--- a/internal/rangekey/rangekey.go
+++ b/internal/rangekey/rangekey.go
@@ -91,7 +91,7 @@ func (e *Encoder) Encode(s *keyspan.Span) error {
 	// sequence number descending, grouping them into sequence numbers. All keys
 	// with identical sequence numbers are flushed together.
 	var del bool
-	var seqNum uint64
+	var seqNum base.SeqNum
 	for i := range s.Keys {
 		if i == 0 || s.Keys[i].SeqNum() != seqNum {
 			if i > 0 {
@@ -127,7 +127,7 @@ func (e *Encoder) Encode(s *keyspan.Span) error {
 
 // flush constructs internal keys for accumulated key state, and emits the
 // internal keys.
-func (e *Encoder) flush(s *keyspan.Span, seqNum uint64, del bool) error {
+func (e *Encoder) flush(s *keyspan.Span, seqNum base.SeqNum, del bool) error {
 	if len(e.sets) > 0 {
 		ik := base.MakeInternalKey(s.Start, seqNum, base.InternalKeyKindRangeKeySet)
 		l := EncodedSetValueLen(s.End, e.sets)

--- a/internal/rangekeystack/user_iterator.go
+++ b/internal/rangekeystack/user_iterator.go
@@ -52,7 +52,7 @@ import (
 //	                        │
 //	                        ╰── <?>.Next
 type UserIteratorConfig struct {
-	snapshot     uint64
+	snapshot     base.SeqNum
 	comparer     *base.Comparer
 	miter        keyspanimpl.MergingIter
 	biter        keyspan.BoundedIter
@@ -88,7 +88,7 @@ func (bufs *Buffers) PrepareForReuse() {
 // keys not visible at the provided snapshot are ignored.
 func (ui *UserIteratorConfig) Init(
 	comparer *base.Comparer,
-	snapshot uint64,
+	snapshot base.SeqNum,
 	lower, upper []byte,
 	hasPrefix *bool,
 	prefix *[]byte,

--- a/internal/rangekeystack/user_iterator_test.go
+++ b/internal/rangekeystack/user_iterator_test.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"math"
 	"math/rand"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -38,9 +37,7 @@ func TestIter(t *testing.T) {
 			visibleSeqNum := base.InternalKeySeqNumMax
 			for _, arg := range td.CmdArgs {
 				if arg.Key == "visible-seq-num" {
-					var err error
-					visibleSeqNum, err = strconv.ParseUint(arg.Vals[0], 10, 64)
-					require.NoError(t, err)
+					visibleSeqNum = base.ParseSeqNum(arg.Vals[0])
 				}
 			}
 
@@ -177,7 +174,7 @@ func testDefragmentingIteRandomizedOnce(t *testing.T, seed int64) {
 		}
 
 		key := keyspan.Key{
-			Trailer: base.MakeTrailer(uint64(i), base.InternalKeyKindRangeKeySet),
+			Trailer: base.MakeTrailer(base.SeqNum(i), base.InternalKeyKindRangeKeySet),
 			Value:   []byte(fmt.Sprintf("v%d", rng.Intn(3))),
 		}
 		// Generate suffixes 0, 1, 2, or 3 with 0 indicating none.
@@ -375,7 +372,7 @@ func BenchmarkTransform(b *testing.B) {
 					var keys []keyspan.Key
 					for k := 0; k < n; k++ {
 						keys = append(keys, keyspan.Key{
-							Trailer: base.MakeTrailer(uint64(n-k), base.InternalKeyKindRangeKeySet),
+							Trailer: base.MakeTrailer(base.SeqNum(n-k), base.InternalKeyKindRangeKeySet),
 							Suffix:  suffixes[k],
 						})
 					}

--- a/iterator.go
+++ b/iterator.go
@@ -247,12 +247,12 @@ type Iterator struct {
 	newIters         tableNewIters
 	newIterRangeKey  keyspanimpl.TableNewSpanIter
 	lazyCombinedIter lazyCombinedIter
-	seqNum           uint64
+	seqNum           base.SeqNum
 	// batchSeqNum is used by Iterators over indexed batches to detect when the
 	// underlying batch has been mutated. The batch beneath an indexed batch may
 	// be mutated while the Iterator is open, but new keys are not surfaced
 	// until the next call to SetOptions.
-	batchSeqNum uint64
+	batchSeqNum base.SeqNum
 	// batch{PointIter,RangeDelIter,RangeKeyIter} are used when the Iterator is
 	// configured to read through an indexed batch. If a batch is set, these
 	// iterators will be included within the iterator stack regardless of
@@ -2608,7 +2608,7 @@ func (i *Iterator) SetOptions(o *IterOptions) {
 	// iterator or range-key iterator but we require one, it'll be created in
 	// the slow path that reconstructs the iterator in finishInitializingIter.
 	if i.batch != nil {
-		nextBatchSeqNum := (uint64(len(i.batch.data)) | base.InternalKeySeqNumBatch)
+		nextBatchSeqNum := (base.SeqNum(len(i.batch.data)) | base.InternalKeySeqNumBatch)
 		if nextBatchSeqNum != i.batchSeqNum {
 			i.batchSeqNum = nextBatchSeqNum
 			if i.merging != nil {
@@ -2867,7 +2867,7 @@ func (i *Iterator) CloneWithContext(ctx context.Context, opts CloneOptions) (*It
 	// If the caller requested the clone have a current view of the indexed
 	// batch, set the clone's batch sequence number appropriately.
 	if i.batch != nil && opts.RefreshBatchView {
-		dbi.batchSeqNum = (uint64(len(i.batch.data)) | base.InternalKeySeqNumBatch)
+		dbi.batchSeqNum = (base.SeqNum(len(i.batch.data)) | base.InternalKeySeqNumBatch)
 	}
 
 	return finishInitializingIter(ctx, buf), nil

--- a/iterator_histories_test.go
+++ b/iterator_histories_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/sstable"
@@ -337,10 +338,7 @@ func TestIterHistories(t *testing.T) {
 							return uint64(v) < min || uint64(v) >= max
 						}
 					case "snapshot":
-						s, err := strconv.ParseUint(arg.Vals[0], 10, 64)
-						if err != nil {
-							return err.Error()
-						}
+						s := base.ParseSeqNum(arg.Vals[0])
 						func() {
 							d.mu.Lock()
 							defer d.mu.Unlock()

--- a/level_checker.go
+++ b/level_checker.go
@@ -56,7 +56,7 @@ type simpleMergingIterLevel struct {
 
 type simpleMergingIter struct {
 	levels   []simpleMergingIterLevel
-	snapshot uint64
+	snapshot base.SeqNum
 	heap     simpleMergingIterHeap
 	// The last point's key and level. For validation.
 	lastKey     InternalKey
@@ -74,7 +74,7 @@ type simpleMergingIter struct {
 func (m *simpleMergingIter) init(
 	merge Merge,
 	cmp Compare,
-	snapshot uint64,
+	snapshot base.SeqNum,
 	formatKey base.FormatKey,
 	levels ...simpleMergingIterLevel,
 ) {
@@ -358,7 +358,7 @@ type checkConfig struct {
 	comparer  *Comparer
 	readState *readState
 	newIters  tableNewIters
-	seqNum    uint64
+	seqNum    base.SeqNum
 	stats     *CheckLevelsStats
 	merge     Merge
 	formatKey base.FormatKey
@@ -448,7 +448,7 @@ func addTombstonesFromIter(
 	lsmLevel int,
 	fileNum FileNum,
 	tombstones []tombstoneWithLevel,
-	seqNum uint64,
+	seqNum base.SeqNum,
 	cmp Compare,
 	formatKey base.FormatKey,
 ) (_ []tombstoneWithLevel, err error) {

--- a/mem_table.go
+++ b/mem_table.go
@@ -85,7 +85,7 @@ type memTable struct {
 	rangeKeys  keySpanCache
 	// The current logSeqNum at the time the memtable was created. This is
 	// guaranteed to be less than or equal to any seqnum stored in the memtable.
-	logSeqNum                    uint64
+	logSeqNum                    base.SeqNum
 	releaseAccountingReservation func()
 }
 
@@ -104,7 +104,7 @@ type memTableOptions struct {
 	*Options
 	arenaBuf                     []byte
 	size                         int
-	logSeqNum                    uint64
+	logSeqNum                    base.SeqNum
 	releaseAccountingReservation func()
 }
 
@@ -201,7 +201,7 @@ func (m *memTable) prepare(batch *Batch) error {
 	return nil
 }
 
-func (m *memTable) apply(batch *Batch, seqNum uint64) error {
+func (m *memTable) apply(batch *Batch, seqNum base.SeqNum) error {
 	if seqNum < m.logSeqNum {
 		return base.CorruptionErrorf("pebble: batch seqnum %d is less than memtable creation seqnum %d",
 			errors.Safe(seqNum), errors.Safe(m.logSeqNum))
@@ -239,9 +239,9 @@ func (m *memTable) apply(batch *Batch, seqNum uint64) error {
 			return err
 		}
 	}
-	if seqNum != startSeqNum+uint64(batch.Count()) {
+	if seqNum != startSeqNum+base.SeqNum(batch.Count()) {
 		return base.CorruptionErrorf("pebble: inconsistent batch count: %d vs %d",
-			errors.Safe(seqNum), errors.Safe(startSeqNum+uint64(batch.Count())))
+			errors.Safe(seqNum), errors.Safe(startSeqNum+base.SeqNum(batch.Count())))
 	}
 	if tombstoneCount != 0 {
 		m.tombstones.invalidate(tombstoneCount)

--- a/mem_table_test.go
+++ b/mem_table_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 	"unicode"
@@ -276,7 +275,7 @@ func TestMemTableIter(t *testing.T) {
 
 func TestMemTableDeleteRange(t *testing.T) {
 	var mem *memTable
-	var seqNum uint64
+	var seqNum base.SeqNum
 
 	datadriven.RunTest(t, "testdata/delete_range", func(t *testing.T, td *datadriven.TestData) string {
 		switch td.Cmd {
@@ -296,7 +295,7 @@ func TestMemTableDeleteRange(t *testing.T) {
 			if err := mem.apply(b, seqNum); err != nil {
 				return err.Error()
 			}
-			seqNum += uint64(b.Count())
+			seqNum += base.SeqNum(b.Count())
 			return ""
 
 		case "scan":
@@ -327,7 +326,7 @@ func TestMemTableConcurrentDeleteRange(t *testing.T) {
 
 	const workers = 10
 	eg, _ := errgroup.WithContext(context.Background())
-	var seqNum atomic.Uint64
+	var seqNum base.AtomicSeqNum
 	seqNum.Store(1)
 	for i := 0; i < workers; i++ {
 		i := i
@@ -416,7 +415,7 @@ func TestMemTable(t *testing.T) {
 			var seqNum uint64
 			td.ScanArgs(t, "name", &name)
 			td.ScanArgs(t, "seq", &seqNum)
-			if err := m.apply(batches[name], seqNum); err != nil {
+			if err := m.apply(batches[name], base.SeqNum(seqNum)); err != nil {
 				return err.Error()
 			}
 			delete(batches, name)

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -228,8 +228,8 @@ type mergingIter struct {
 	logger        Logger
 	split         Split
 	dir           int
-	snapshot      uint64
-	batchSnapshot uint64
+	snapshot      base.SeqNum
+	batchSnapshot base.SeqNum
 	levels        []mergingIterLevel
 	heap          mergingIterHeap
 	err           error

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -585,14 +585,14 @@ func buildLevelsForMergingIterSeqSeek(
 	}
 	for j := 1; j < len(files); j++ {
 		for _, k := range []int{0, len(keys) - 1} {
-			ikey := base.MakeInternalKey(keys[k], uint64(j), InternalKeyKindSet)
+			ikey := base.MakeInternalKey(keys[k], base.SeqNum(j), InternalKeyKindSet)
 			writers[j][0].Add(ikey, nil)
 		}
 	}
 	lastKey := []byte(fmt.Sprintf("%08d", i))
 	keys = append(keys, lastKey)
 	for j := 0; j < len(files); j++ {
-		lastIKey := base.MakeInternalKey(lastKey, uint64(j), InternalKeyKindSet)
+		lastIKey := base.MakeInternalKey(lastKey, base.SeqNum(j), InternalKeyKindSet)
 		writers[j][1].Add(lastIKey, nil)
 	}
 	for _, levelWriters := range writers {

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -1926,7 +1926,7 @@ func (r *replicateOp) runSharedReplicate(
 			}
 			return w.Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val)
 		},
-		func(start, end []byte, seqNum uint64) error {
+		func(start, end []byte, seqNum base.SeqNum) error {
 			return w.DeleteRange(start, end)
 		},
 		func(start, end []byte, keys []keyspan.Key) error {
@@ -1990,7 +1990,7 @@ func (r *replicateOp) runExternalReplicate(
 			}
 			return w.Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val)
 		},
-		func(start, end []byte, seqNum uint64) error {
+		func(start, end []byte, seqNum base.SeqNum) error {
 			return w.DeleteRange(start, end)
 		},
 		func(start, end []byte, keys []keyspan.Key) error {

--- a/metrics.go
+++ b/metrics.go
@@ -239,7 +239,7 @@ type Metrics struct {
 		// The number of currently open snapshots.
 		Count int
 		// The sequence number of the earliest, currently open snapshot.
-		EarliestSeqNum uint64
+		EarliestSeqNum base.SeqNum
 		// A running tally of keys written to sstables during flushes or
 		// compactions that would've been elided if it weren't for open
 		// snapshots.

--- a/open.go
+++ b/open.go
@@ -758,7 +758,7 @@ func GetVersion(dir string, fs vfs.FS) (string, error) {
 // re-acquired during the course of this method.
 func (d *DB) replayWAL(
 	jobID JobID, ve *versionEdit, ll wal.LogicalLog, strictWALTail bool,
-) (toFlush flushableList, maxSeqNum uint64, err error) {
+) (toFlush flushableList, maxSeqNum base.SeqNum, err error) {
 	rr := ll.OpenForRead()
 	defer rr.Close()
 	var (
@@ -805,7 +805,7 @@ func (d *DB) replayWAL(
 		mem, entry = nil, nil
 	}
 	// Creates a new memtable if there is no current memtable.
-	ensureMem := func(seqNum uint64) {
+	ensureMem := func(seqNum base.SeqNum) {
 		if mem != nil {
 			return
 		}
@@ -874,7 +874,7 @@ func (d *DB) replayWAL(
 		b.db = d
 		b.SetRepr(buf.Bytes())
 		seqNum := b.SeqNum()
-		maxSeqNum = seqNum + uint64(b.Count())
+		maxSeqNum = seqNum + base.SeqNum(b.Count())
 		keysReplayed += int64(b.Count())
 		batchesReplayed++
 		{

--- a/options.go
+++ b/options.go
@@ -204,7 +204,7 @@ type IterOptions struct {
 	// snapshotForHideObsoletePoints is specified for/by levelIter when opening
 	// files and is used to decide whether to hide obsolete points. A value of 0
 	// implies obsolete points should not be hidden.
-	snapshotForHideObsoletePoints uint64
+	snapshotForHideObsoletePoints base.SeqNum
 
 	// NB: If adding new Options, you must account for them in iterator
 	// construction and Iterator.SetOptions.
@@ -264,7 +264,7 @@ type scanInternalOptions struct {
 	IterOptions
 
 	visitPointKey     func(key *InternalKey, value LazyValue, iterInfo IteratorLevel) error
-	visitRangeDel     func(start, end []byte, seqNum uint64) error
+	visitRangeDel     func(start, end []byte, seqNum SeqNum) error
 	visitRangeKey     func(start, end []byte, keys []rangekey.Key) error
 	visitSharedFile   func(sst *SharedSSTMeta) error
 	visitExternalFile func(sst *ExternalFile) error

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -80,7 +80,11 @@ func TestRangeDel(t *testing.T) {
 				db:     d,
 				seqNum: InternalKeySeqNumMax,
 			}
-			td.MaybeScanArgs(t, "seq", &snap.seqNum)
+			if td.HasArg("seq") {
+				var n uint64
+				td.ScanArgs(t, "seq", &n)
+				snap.seqNum = base.SeqNum(n)
+			}
 			iter, _ := snap.NewIter(nil)
 			return runIterCmd(td, iter, true)
 

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -126,7 +126,7 @@ type pointCollapsingIterator struct {
 	comparer *base.Comparer
 	merge    base.Merge
 	err      error
-	seqNum   uint64
+	seqNum   base.SeqNum
 	// The current position of `iter`. Always owned by the underlying iter.
 	iterKV *base.InternalKV
 	// The last saved key. findNextEntry and similar methods are expected to save
@@ -144,7 +144,7 @@ type pointCollapsingIterator struct {
 	savedKeyBuf []byte
 	// If fixedSeqNum is non-zero, all emitted points are verified to have this
 	// fixed sequence number.
-	fixedSeqNum uint64
+	fixedSeqNum base.SeqNum
 }
 
 func (p *pointCollapsingIterator) Span() *keyspan.Span {
@@ -423,7 +423,7 @@ type scanInternalIterator struct {
 	alloc           *iterAlloc
 	newIters        tableNewIters
 	newIterRangeKey keyspanimpl.TableNewSpanIter
-	seqNum          uint64
+	seqNum          base.SeqNum
 	iterLevels      []IteratorLevel
 	mergingIter     *mergingIter
 

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -217,7 +217,7 @@ func TestScanInternal(t *testing.T) {
 			categoryAndQoS sstable.CategoryAndQoS,
 			lower, upper []byte,
 			visitPointKey func(key *InternalKey, value LazyValue, iterInfo IteratorLevel) error,
-			visitRangeDel func(start, end []byte, seqNum uint64) error,
+			visitRangeDel func(start, end []byte, seqNum base.SeqNum) error,
 			visitRangeKey func(start, end []byte, keys []keyspan.Key) error,
 			visitSharedFile func(sst *SharedSSTMeta) error,
 			visitExternalFile func(sst *ExternalFile) error,
@@ -565,7 +565,7 @@ func TestScanInternal(t *testing.T) {
 					fmt.Fprintf(&b, "%s (%s)\n", key, v)
 					return nil
 				},
-				func(start, end []byte, seqNum uint64) error {
+				func(start, end []byte, seqNum base.SeqNum) error {
 					fmt.Fprintf(&b, "%s-%s#%d,RANGEDEL\n", start, end, seqNum)
 					return nil
 				},

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -17,18 +17,19 @@ import (
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSnapshotListToSlice(t *testing.T) {
 	testCases := []struct {
-		vals []uint64
+		vals []base.SeqNum
 	}{
 		{nil},
-		{[]uint64{1}},
-		{[]uint64{1, 2, 3}},
-		{[]uint64{3, 2, 1}},
+		{[]base.SeqNum{1}},
+		{[]base.SeqNum{1, 2, 3}},
+		{[]base.SeqNum{3, 2, 1}},
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {

--- a/sstable/block_test.go
+++ b/sstable/block_test.go
@@ -7,7 +7,6 @@ package sstable
 import (
 	"bytes"
 	"fmt"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -148,7 +147,7 @@ func TestInvalidInternalKeyDecoding(t *testing.T) {
 		i := blockIter{}
 		i.decodeInternalKey([]byte(tc))
 		require.Nil(t, i.ikv.K.UserKey)
-		require.Equal(t, uint64(InternalKeyKindInvalid), i.ikv.K.Trailer)
+		require.Equal(t, base.Trailer(InternalKeyKindInvalid), i.ikv.K.Trailer)
 	}
 }
 
@@ -224,11 +223,8 @@ func TestBlockIter(t *testing.T) {
 func TestBlockIter2(t *testing.T) {
 	makeIkey := func(s string) InternalKey {
 		j := strings.Index(s, ":")
-		seqNum, err := strconv.Atoi(s[j+1:])
-		if err != nil {
-			panic(err)
-		}
-		return base.MakeInternalKey([]byte(s[:j]), uint64(seqNum), InternalKeyKindSet)
+		seqNum := base.ParseSeqNum(s[j+1:])
+		return base.MakeInternalKey([]byte(s[:j]), seqNum, InternalKeyKindSet)
 	}
 
 	var block []byte

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -218,7 +218,7 @@ func (l *Layout) Describe(
 						// fetched from a blockIter which does not know about value
 						// blocks.
 						v := kv.InPlaceValue()
-						if base.TrailerKind(kv.K.Trailer) != InternalKeyKindSet {
+						if kv.K.Kind() != InternalKeyKindSet {
 							fmtRecord(&kv.K, v)
 						} else if !isValueHandle(valuePrefix(v[0])) {
 							fmtRecord(&kv.K, v[1:])

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -328,8 +328,8 @@ func (r *Reader) NewIterWithBlockPropertyFiltersAndContextEtc(
 // before the call to NewIterWithBlockPropertyFiltersAndContextEtc, to get the
 // value of hideObsoletePoints and potentially add a block property filter.
 func (r *Reader) TryAddBlockPropertyFilterForHideObsoletePoints(
-	snapshotForHideObsoletePoints uint64,
-	fileLargestSeqNum uint64,
+	snapshotForHideObsoletePoints base.SeqNum,
+	fileLargestSeqNum base.SeqNum,
 	pointKeyFilters []BlockPropertyFilter,
 ) (hideObsoletePoints bool, filters []BlockPropertyFilter) {
 	hideObsoletePoints = r.tableFormat >= TableFormatPebblev4 &&

--- a/sstable/reader_common.go
+++ b/sstable/reader_common.go
@@ -62,7 +62,7 @@ var NoTransforms = IterTransforms{}
 // SyntheticSeqNum is used to override all sequence numbers in a table. It is
 // set to a non-zero value when the table was created externally and ingested
 // whole.
-type SyntheticSeqNum uint64
+type SyntheticSeqNum base.SeqNum
 
 // NoSyntheticSeqNum is the default zero value for SyntheticSeqNum, which
 // disables overriding the sequence number.

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -179,7 +179,7 @@ func (v *VirtualReader) NewRawRangeKeyIter(
 		// transform iter into VirtualReader.
 		transform := &rangekey.ForeignSSTTransformer{
 			Equal:  v.reader.Equal,
-			SeqNum: uint64(syntheticSeqNum),
+			SeqNum: base.SeqNum(syntheticSeqNum),
 		}
 		transformIter := &keyspan.TransformerIter{
 			FragmentIterator: iter,

--- a/sstable/testdata/virtual_reader_iter
+++ b/sstable/testdata/virtual_reader_iter
@@ -198,9 +198,9 @@ h.SET.9:h
 point:    [a#1,SET-h#9,SET]
 seqnums:  [1-9]
 
-virtualize lower=c.SET.3 upper=f.SET.1:ff
+virtualize lower=c.SET.3 upper=f.SET.1
 ----
-bounds:  [c#3,SET-f#0,SET]
+bounds:  [c#3,SET-f#1,SET]
 
 iter
 set-bounds lower=d upper=e
@@ -413,9 +413,9 @@ h.SET.9:h
 point:    [a#1,SET-h#9,SET]
 seqnums:  [1-9]
 
-virtualize lower=c.SET.3 upper=f.SET.1:ff
+virtualize lower=c.SET.3 upper=f.SET.1
 ----
-bounds:  [c#3,SET-f#0,SET]
+bounds:  [c#3,SET-f#1,SET]
 
 iter
 set-bounds lower=d upper=e

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -951,7 +951,7 @@ func TestWriterRace(t *testing.T) {
 			for ki := 0; ki < len(keys); ki++ {
 				require.NoError(
 					t,
-					w.Add(base.MakeInternalKey(keys[ki], uint64(ki), InternalKeyKindSet), val),
+					w.Add(base.MakeInternalKey(keys[ki], base.SeqNum(ki), InternalKeyKindSet), val),
 				)
 				require.Equal(
 					t, w.dataBlockBuf.dataBlock.getCurKey().UserKey, keys[ki],

--- a/table_stats.go
+++ b/table_stats.go
@@ -377,7 +377,7 @@ func (d *DB) loadTableRangeDelStats(
 		start, end := s.Start, s.End
 		// We only need to consider deletion size estimates for tables that contain
 		// RANGEDELs.
-		var maxRangeDeleteSeqNum uint64
+		var maxRangeDeleteSeqNum base.SeqNum
 		for _, k := range s.Keys {
 			if k.Kind() == base.InternalKeyKindRangeDelete && maxRangeDeleteSeqNum < k.SeqNum() {
 				maxRangeDeleteSeqNum = k.SeqNum()
@@ -540,7 +540,7 @@ func (d *DB) estimateSizesBeneath(
 
 func (d *DB) estimateReclaimedSizeBeneath(
 	v *version, level int, start, end []byte, hintType deleteCompactionHintType,
-) (estimate uint64, hintSeqNum uint64, err error) {
+) (estimate uint64, hintSeqNum base.SeqNum, err error) {
 	// Find all files in lower levels that overlap with the deleted range
 	// [start, end).
 	//

--- a/tool/db.go
+++ b/tool/db.go
@@ -819,8 +819,8 @@ func propArgs(props []props, getProp func(*props) interface{}) []interface{} {
 
 type props struct {
 	Count                      uint64
-	SmallestSeqNum             uint64
-	LargestSeqNum              uint64
+	SmallestSeqNum             base.SeqNum
+	LargestSeqNum              base.SeqNum
 	DataSize                   uint64
 	FilterSize                 uint64
 	IndexSize                  uint64

--- a/tool/lsm.go
+++ b/tool/lsm.go
@@ -27,8 +27,8 @@ type lsmFileMetadata struct {
 	Size           uint64
 	Smallest       int // ID of smallest key
 	Largest        int // ID of largest key
-	SmallestSeqNum uint64
-	LargestSeqNum  uint64
+	SmallestSeqNum base.SeqNum
+	LargestSeqNum  base.SeqNum
 	Virtual        bool
 }
 
@@ -45,7 +45,7 @@ type lsmVersionEdit struct {
 
 type lsmKey struct {
 	Pretty string
-	SeqNum uint64
+	SeqNum base.SeqNum
 	Kind   int
 }
 

--- a/tool/util.go
+++ b/tool/util.go
@@ -254,7 +254,7 @@ func formatKey(w io.Writer, fmtKey keyFormatter, key *base.InternalKey) bool {
 	return true
 }
 
-func formatSeqNumRange(w io.Writer, start, end uint64) {
+func formatSeqNumRange(w io.Writer, start, end base.SeqNum) {
 	fmt.Fprintf(w, "<#%d-#%d>", start, end)
 }
 

--- a/tool/wal.go
+++ b/tool/wal.go
@@ -153,7 +153,7 @@ func (w *walT) runDump(cmd *cobra.Command, args []string) {
 					case base.InternalKeyKindRangeDelete:
 						fmt.Fprintf(stdout, "%s,%s", w.fmtKey.fn(ukey), w.fmtKey.fn(value))
 					case base.InternalKeyKindRangeKeySet, base.InternalKeyKindRangeKeyUnset, base.InternalKeyKindRangeKeyDelete:
-						ik := base.MakeInternalKey(ukey, b.SeqNum()+uint64(idx), kind)
+						ik := base.MakeInternalKey(ukey, b.SeqNum()+base.SeqNum(idx), kind)
 						s, err := rangekey.Decode(ik, value, nil)
 						if err != nil {
 							fmt.Fprintf(stdout, "%s: error decoding %s", w.fmtKey.fn(ukey), err)

--- a/version_set.go
+++ b/version_set.go
@@ -43,13 +43,13 @@ type versionList = manifest.VersionList
 // to the MANIFEST file, which is replayed at startup.
 type versionSet struct {
 	// Next seqNum to use for WAL writes.
-	logSeqNum atomic.Uint64
+	logSeqNum base.AtomicSeqNum
 
 	// The upper bound on sequence numbers that have been assigned so far. A
 	// suffix of these sequence numbers may not have been written to a WAL. Both
 	// logSeqNum and visibleSeqNum are atomically updated by the commitPipeline.
 	// visibleSeqNum is <= logSeqNum.
-	visibleSeqNum atomic.Uint64
+	visibleSeqNum base.AtomicSeqNum
 
 	// Number of bytes present in sstables being written by in-progress
 	// compactions. This value will be zero if there are no in-progress

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -298,7 +298,7 @@ func TestVersionSetSeqNums(t *testing.T) {
 	require.NotNil(t, manifest)
 	defer manifest.Close()
 	rr := record.NewReader(manifest, 0 /* logNum */)
-	lastSeqNum := uint64(0)
+	var lastSeqNum base.SeqNum
 	for {
 		r, err := rr.Next()
 		if err == io.EOF {
@@ -313,7 +313,7 @@ func TestVersionSetSeqNums(t *testing.T) {
 		}
 	}
 	// 2 ingestions happened, so LastSeqNum should equal base.SeqNumStart + 1.
-	require.Equal(t, uint64(11), lastSeqNum)
+	require.Equal(t, base.SeqNum(11), lastSeqNum)
 	// logSeqNum is always one greater than the last assigned sequence number.
 	require.Equal(t, d.mu.versions.logSeqNum.Load(), lastSeqNum+1)
 }

--- a/wal/reader.go
+++ b/wal/reader.go
@@ -227,7 +227,7 @@ type virtualWALReader struct {
 	// should monotonically increase as we iterate over the WAL files. If we
 	// ever observe a batch encoding a sequence number <= lastSeqNum, we must
 	// have already returned the batch and should skip it.
-	lastSeqNum uint64
+	lastSeqNum base.SeqNum
 	// recordBuf is a buffer used to hold the latest record read from a physical
 	// file, and then returned to the user. A pointer to this buffer is returned
 	// directly to the caller of NextRecord.

--- a/wal/reader_test.go
+++ b/wal/reader_test.go
@@ -143,7 +143,7 @@ func TestReader(t *testing.T) {
 						count := uint32(fields.MustKeyValue("count").Uint64())
 						seq = fields.MustKeyValue("seq").Uint64()
 						rng.Read(repr[batchrepr.HeaderLen:])
-						batchrepr.SetSeqNum(repr, seq)
+						batchrepr.SetSeqNum(repr, base.SeqNum(seq))
 						batchrepr.SetCount(repr, count)
 					}
 


### PR DESCRIPTION
We add a `SeqNum` type for sequence numbers. This makes the code more
self-documenting, and will allow a custom `String` implementation.

All changes outside `base/internal.go` were mechanical.