### PR TITLE
sstable: wrap raw fragment iterators with checkers, fix issues found

### DIFF
--- a/internal/keyspan/interleaving_iter.go
+++ b/internal/keyspan/interleaving_iter.go
@@ -1117,9 +1117,13 @@ func (i *InterleavingIter) savePoint(kv *base.InternalKV) {
 //
 // Span will never return an invalid or empty span.
 func (i *InterleavingIter) Span() *Span {
+	if invariants.Enabled && i.pointIter == nil {
+		panic("Span() called after close")
+	}
 	if !i.withinSpan || len(i.span.Keys) == 0 {
 		return nil
-	} else if i.truncated {
+	}
+	if i.truncated {
 		return &i.truncatedSpan
 	}
 	return i.span
@@ -1153,7 +1157,9 @@ func (i *InterleavingIter) Error() error {
 // Close implements (base.InternalIterator).Close.
 func (i *InterleavingIter) Close() error {
 	err := i.pointIter.Close()
+	i.pointIter = nil
 	i.keyspanIter.Close()
+	i.keyspanIter = nil
 	return err
 }
 

--- a/internal/keyspan/iter.go
+++ b/internal/keyspan/iter.go
@@ -57,7 +57,8 @@ type FragmentIterator interface {
 
 	// Close closes the iterator. It is not in general valid to call Close
 	// multiple times. Other methods should not be called after the iterator has
-	// been closed.
+	// been closed. Spans returned by a previous method should also not be used
+	// after the iterator has been closed.
 	Close()
 
 	// WrapChildren wraps any child iterators using the given function. The

--- a/internal/keyspan/span.go
+++ b/internal/keyspan/span.go
@@ -340,23 +340,9 @@ func (s *Span) VisibleAt(snapshot uint64) bool {
 	}
 }
 
-// ShallowClone returns the span with a Keys slice owned by the span itself.
-// None of the key byte slices are cloned (see Span.DeepClone).
-func (s *Span) ShallowClone() Span {
-	c := Span{
-		Start:     s.Start,
-		End:       s.End,
-		Keys:      make([]Key, len(s.Keys)),
-		KeysOrder: s.KeysOrder,
-	}
-	copy(c.Keys, s.Keys)
-	return c
-}
-
-// DeepClone clones the span, creating copies of all contained slices. DeepClone
-// is intended for non-production code paths like tests, the level checker, etc
-// because it is allocation heavy.
-func (s *Span) DeepClone() Span {
+// Clone clones the span, creating copies of all contained slices. Clone is
+// allocation heavy and should not be used in hot paths.
+func (s *Span) Clone() Span {
 	c := Span{
 		Start:     slices.Clone(s.Start),
 		End:       slices.Clone(s.End),

--- a/internal/keyspan/truncate_test.go
+++ b/internal/keyspan/truncate_test.go
@@ -58,7 +58,7 @@ func TestTruncate(t *testing.T) {
 			var s *Span
 			var err error
 			for s, err = tIter.First(); s != nil; s, err = tIter.Next() {
-				truncated = append(truncated, s.ShallowClone())
+				truncated = append(truncated, s.Clone())
 			}
 			require.NoError(t, err)
 			return formatAlphabeticSpans(truncated)

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -180,8 +180,9 @@ func TestLint(t *testing.T) {
 
 		// Forbidden-import-pkg -> permitted-replacement-pkg
 		forbiddenImports := map[string]string{
-			"errors":     "github.com/cockroachdb/errors",
-			"pkg/errors": "github.com/cockroachdb/errors",
+			"errors":                  "github.com/cockroachdb/errors",
+			"pkg/errors":              "github.com/cockroachdb/errors",
+			"golang.org/x/exp/slices": "slices",
 		}
 
 		// grepBuf creates a grep string that matches any forbidden import pkgs.

--- a/level_checker.go
+++ b/level_checker.go
@@ -459,7 +459,7 @@ func addTombstonesFromIter(
 		if t.Empty() {
 			continue
 		}
-		t = t.DeepClone()
+		t = t.Clone()
 		// This is mainly a test for rangeDelV2 formatted blocks which are expected to
 		// be ordered and fragmented on disk. But we anyways check for memtables,
 		// rangeDelV1 as well.

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -778,7 +778,7 @@ func scanInternalImpl(
 				// call visitRangeKey.
 				keysCopy := make([]keyspan.Key, len(span.Keys))
 				for i := range span.Keys {
-					keysCopy[i] = span.Keys[i]
+					keysCopy[i].CopyFrom(span.Keys[i])
 					keysCopy[i].Trailer = base.MakeTrailer(0, span.Keys[i].Kind())
 				}
 				keyspan.SortKeysByTrailer(&keysCopy)

--- a/sstable/block_iter.go
+++ b/sstable/block_iter.go
@@ -8,13 +8,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"slices"
 	"unsafe"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/manual"
-	"golang.org/x/exp/slices"
 )
 
 // blockIter is an iterator over a single block of data.

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -461,7 +461,7 @@ func (r *Reader) NewRawRangeDelIter(transforms IterTransforms) (keyspan.Fragment
 	if err := i.blockIter.initHandle(r.Compare, r.Split, h, transforms); err != nil {
 		return nil, err
 	}
-	return i, nil
+	return keyspan.MaybeAssert(i, r.Compare), nil
 }
 
 // NewRawRangeKeyIter returns an internal iterator for the contents of the
@@ -488,7 +488,7 @@ func (r *Reader) NewRawRangeKeyIter(transforms IterTransforms) (keyspan.Fragment
 	if err := i.blockIter.initHandle(r.Compare, r.Split, h, transforms); err != nil {
 		return nil, err
 	}
-	return i, nil
+	return keyspan.MaybeAssert(i, r.Compare), nil
 }
 
 func (r *Reader) readIndex(

--- a/sstable/test_utils.go
+++ b/sstable/test_utils.go
@@ -32,14 +32,14 @@ func ReadAll(
 	if rangeDelIter := testutils.CheckErr(reader.NewRawRangeDelIter(NoTransforms)); rangeDelIter != nil {
 		defer rangeDelIter.Close()
 		for s := testutils.CheckErr(rangeDelIter.First()); s != nil; s = testutils.CheckErr(rangeDelIter.Next()) {
-			rangeDels = append(rangeDels, s.DeepClone())
+			rangeDels = append(rangeDels, s.Clone())
 		}
 	}
 
 	if rangeKeyIter := testutils.CheckErr(reader.NewRawRangeKeyIter(NoTransforms)); rangeKeyIter != nil {
 		defer rangeKeyIter.Close()
 		for s := testutils.CheckErr(rangeKeyIter.First()); s != nil; s = testutils.CheckErr(rangeKeyIter.Next()) {
-			rangeKeys = append(rangeKeys, s.DeepClone())
+			rangeKeys = append(rangeKeys, s.Clone())
 		}
 	}
 	return points, rangeDels, rangeKeys

--- a/tool/find.go
+++ b/tool/find.go
@@ -487,7 +487,7 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 					if !t.Contains(r.Compare, searchKey) {
 						continue
 					}
-					tombstones = append(tombstones, t.ShallowClone())
+					tombstones = append(tombstones, t.Clone())
 				}
 				if err != nil {
 					return nil, err

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -407,7 +407,7 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 					// The range tombstone lies before the scan range.
 					continue
 				}
-				tombstones = append(tombstones, t.ShallowClone())
+				tombstones = append(tombstones, t.Clone())
 			}
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
#### keyspan: copy Suffix/Value in CopyFrom


#### tool: use DeepClone instead of ShallowClone

We were performing shallow clones of spans, which is not sufficient
when the spans come from a FragmentIterator.

#### sstable: wrap raw fragment iterators with checkers

This change wraps raw range del and range key iterators with
`assertIter` and `invalidatingIter` and we fix a few cases of using
stale values (especially Prefix/Value for range keys).