### PR TITLE
github: don't use -v flag for windows test run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,7 +120,7 @@ jobs:
       with:
         go-version: "${{ env.GO_VERSION }}"
 
-    - run: go test -v ./...
+    - run: go test -tags invariants ./...
 
   bsds:
     name: go-bsds


### PR DESCRIPTION
The windows test run is the only one that uses the `-v` flag which makes the output hard to use in the UI and likely makes the run much slower.

Adjust to not use `-v` and use `-tags invariants`.