### PR TITLE
ssstable: temporarily disable reuse of fragment iterators

### DIFF
--- a/sstable/block_fragment_iter.go
+++ b/sstable/block_fragment_iter.go
@@ -216,7 +216,8 @@ func (i *fragmentBlockIter) Close() {
 			blockIter:        i.blockIter.resetForReuse(),
 			doubleCloseCheck: i.doubleCloseCheck,
 		}
-		fragmentBlockIterPool.Put(i)
+		// TODO(radu): reenable this, see #3678.
+		//fragmentBlockIterPool.Put(i)
 	}
 }
 


### PR DESCRIPTION
Informs #3678.