### PR TITLE
invariants: add Sometimes

### DIFF
--- a/internal/invalidating/iter.go
+++ b/internal/invalidating/iter.go
@@ -8,17 +8,14 @@ import (
 	"context"
 
 	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/internal/fastrand"
 	"github.com/cockroachdb/pebble/internal/invariants"
 )
 
 // MaybeWrapIfInvariants wraps some iterators with an invalidating iterator.
 // MaybeWrapIfInvariants does nothing in non-invariant builds.
 func MaybeWrapIfInvariants(iter base.InternalIterator) base.InternalIterator {
-	if invariants.Enabled {
-		if fastrand.Uint32n(10) == 1 {
-			return NewIter(iter)
-		}
+	if invariants.Sometimes(10) {
+		return NewIter(iter)
 	}
 	return iter
 }

--- a/internal/invariants/off.go
+++ b/internal/invariants/off.go
@@ -8,11 +8,22 @@
 package invariants
 
 // Enabled is true if we were built with the "invariants" or "race" build tags.
+//
+// Enabled should be used to gate invariant checks that may be expensive. It
+// should not be used to unconditionally alter a code path significantly (e.g.
+// wrapping an iterator - see #3678); Sometimes() should be used instead so that
+// the production code path gets test coverage as well.
 const Enabled = false
 
-// DoubleCloseCheck is used to check that objects are not double-closed.
-type DoubleCloseCheck struct{}
+// CloseChecker is used to check that objects are closed exactly once.
+type CloseChecker struct{}
 
 // Close panics if called twice on the same object (if we were built with the
 // "invariants" or "race" build tags).
-func (d *DoubleCloseCheck) Close() {}
+func (d *CloseChecker) Close() {}
+
+// AssertClosed panics in invariant builds if Close was not called.
+func (d *CloseChecker) AssertClosed() {}
+
+// AssertNotClosed panics in invariant builds if Close was called.
+func (d *CloseChecker) AssertNotClosed() {}

--- a/internal/invariants/on.go
+++ b/internal/invariants/on.go
@@ -10,16 +10,33 @@ package invariants
 // Enabled is true if we were built with the "invariants" or "race" build tags.
 const Enabled = true
 
-// DoubleCloseCheck is used to check that objects are not double-closed.
-type DoubleCloseCheck struct {
+// CloseChecker is used to check that objects are closed exactly once.
+type CloseChecker struct {
 	closed bool
 }
 
 // Close panics if called twice on the same object (if we were built with the
 // "invariants" or "race" build tags).
-func (d *DoubleCloseCheck) Close() {
+func (d *CloseChecker) Close() {
 	if d.closed {
+		// Note: to debug a double-close, you can add a stack field to CloseChecker
+		// and set it to string(debug.Stack()) in Close, then print that in this
+		// panic.
 		panic("double close")
 	}
 	d.closed = true
+}
+
+// AssertClosed panics in invariant builds if Close was not called.
+func (d *CloseChecker) AssertClosed() {
+	if !d.closed {
+		panic("not closed")
+	}
+}
+
+// AssertNotClosed panics in invariant builds if Close was called.
+func (d *CloseChecker) AssertNotClosed() {
+	if d.closed {
+		panic("closed")
+	}
 }

--- a/internal/invariants/utils.go
+++ b/internal/invariants/utils.go
@@ -1,0 +1,13 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package invariants
+
+import "github.com/cockroachdb/pebble/internal/fastrand"
+
+// Sometimes returns true percent% of the time if we were built with the
+// "invariants" of "race" build tags
+func Sometimes(percent int) bool {
+	return Enabled && fastrand.Uint32()%100 < uint32(percent)
+}

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -937,8 +937,7 @@ func (m *mergingIter) seekGE(key []byte, level int, flags base.SeekGEFlags) erro
 	// Because the L5 iterator has already advanced to the next sstable, the
 	// merging iterator cannot observe the [b-c) range tombstone and will
 	// mistakenly return L6's deleted point key 'b'.
-	if invariants.Enabled && flags.TrySeekUsingNext() && !m.forceEnableSeekOpt &&
-		disableSeekOpt(key, uintptr(unsafe.Pointer(m))) {
+	if testingDisableSeekOpt(key, uintptr(unsafe.Pointer(m))) && !m.forceEnableSeekOpt {
 		flags = flags.DisableTrySeekUsingNext()
 	}
 

--- a/table_cache.go
+++ b/table_cache.go
@@ -623,7 +623,7 @@ func (c *tableCacheShard) newRangeDelIter(
 		return nil, err
 	}
 	// Assert expected bounds in tests.
-	if invariants.Enabled && rangeDelIter != nil {
+	if invariants.Sometimes(50) && rangeDelIter != nil {
 		cmp := base.DefaultComparer.Compare
 		if dbOpts.opts.Comparer != nil {
 			cmp = dbOpts.opts.Comparer.Compare

--- a/table_stats.go
+++ b/table_stats.go
@@ -963,7 +963,7 @@ func newCombinedDeletionKeyspanIter(
 	}
 	if iter != nil {
 		// Assert expected bounds in tests.
-		if invariants.Enabled {
+		if invariants.Sometimes(50) {
 			iter = keyspan.AssertBounds(
 				iter, m.SmallestRangeKey, m.LargestRangeKey.UserKey, comparer.Compare,
 			)


### PR DESCRIPTION
This commit adds `invariants.Sometimes` which returns true in
invariants builds with a given probability.

We audit all uses of `invariants.Enabled` and switch to `Sometimes` if
they involve non-trivial code path changes (like wrapping iterators).

We also make some improvements to the close checker.

Informs #3678