### PR TITLE
db: change leveliter.rangeDelIterPtr to a function

### DIFF
--- a/db.go
+++ b/db.go
@@ -1479,7 +1479,7 @@ func (i *Iterator) constructPointIter(
 			li := &levels[levelsIndex]
 
 			li.init(ctx, i.opts, &i.comparer, i.newIters, files, level, internalOpts)
-			li.initRangeDel(&mlevels[mlevelsIndex].rangeDelIter)
+			li.initRangeDel(mlevels[mlevelsIndex].setRangeDelIter)
 			li.initCombinedIterState(&i.lazyCombinedIter.combinedIterState)
 			mlevels[mlevelsIndex].levelIter = li
 			mlevels[mlevelsIndex].iter = invalidating.MaybeWrapIfInvariants(li)

--- a/level_checker.go
+++ b/level_checker.go
@@ -54,6 +54,14 @@ type simpleMergingIterLevel struct {
 	tombstone *keyspan.Span
 }
 
+func (ml *simpleMergingIterLevel) setRangeDelIter(iter keyspan.FragmentIterator) {
+	ml.tombstone = nil
+	if ml.rangeDelIter != nil {
+		ml.rangeDelIter.Close()
+	}
+	ml.rangeDelIter = iter
+}
+
 type simpleMergingIter struct {
 	levels   []simpleMergingIterLevel
 	snapshot base.SeqNum
@@ -634,7 +642,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 		li := &levelIter{}
 		li.init(context.Background(), iterOpts, c.comparer, c.newIters, manifestIter,
 			manifest.L0Sublevel(sublevel), internalIterOpts{})
-		li.initRangeDel(&mlevelAlloc[0].rangeDelIter)
+		li.initRangeDel(mlevelAlloc[0].setRangeDelIter)
 		mlevelAlloc[0].iter = li
 		mlevelAlloc = mlevelAlloc[1:]
 	}
@@ -647,7 +655,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 		li := &levelIter{}
 		li.init(context.Background(), iterOpts, c.comparer, c.newIters,
 			current.Levels[level].Iter(), manifest.Level(level), internalIterOpts{})
-		li.initRangeDel(&mlevelAlloc[0].rangeDelIter)
+		li.initRangeDel(mlevelAlloc[0].setRangeDelIter)
 		mlevelAlloc[0].iter = li
 		mlevelAlloc = mlevelAlloc[1:]
 	}

--- a/level_iter.go
+++ b/level_iter.go
@@ -80,19 +80,22 @@ type levelIter struct {
 	// iterFile holds the current file. It is always equal to l.files.Current().
 	iterFile *fileMetadata
 	newIters tableNewIters
-	// When rangeDelIterPtr != nil, the caller requires that *rangeDelIterPtr must
-	// point to a range del iterator corresponding to the current file. When this
-	// iterator returns nil, *rangeDelIterPtr should also be set to nil. Whenever
-	// a non-nil internalIterator is placed in rangeDelIterPtr, a copy is placed
-	// in rangeDelIterCopy. This is done for the following special case:
-	// when this iterator returns nil because of exceeding the bounds, we don't
-	// close iter and *rangeDelIterPtr since we could reuse it in the next seek. But
-	// we need to set *rangeDelIterPtr to nil because of the aforementioned contract.
-	// This copy is used to revive the *rangeDelIterPtr in the case of reuse.
-	rangeDelIterPtr  *keyspan.FragmentIterator
-	rangeDelIterCopy keyspan.FragmentIterator
-	files            manifest.LevelIterator
-	err              error
+	files    manifest.LevelIterator
+	err      error
+
+	// When rangeDelIterFn != nil, the caller requires that this function gets
+	// called with a range deletion iterator whenever the current file changes.
+	// The iterator is relinquished to the caller which is responsible for closing
+	// it.
+	// When rangeDelIterFn != nil, the levelIter will also interleave the
+	// boundaries of range deletions among point keys.
+	rangeDelIterFn func(rangeDelIter keyspan.FragmentIterator)
+
+	// interleaving is used when rangeDelIterFn != nil to interleave the
+	// boundaries of range deletions among point keys. When the leve iterator is
+	// used by a merging iterator, this ensures that we don't advance to a new
+	// file until the range deletions are no longer needed by other levels.
+	interleaving keyspan.InterleavingIter
 
 	// internalOpts holds the internal iterator options to pass to the table
 	// cache when constructing new table iterators.
@@ -102,12 +105,6 @@ type levelIter struct {
 	// property filters specified. See the performance note where
 	// IterOptions.PointKeyFilters is declared.
 	filtersBuf [1]BlockPropertyFilter
-
-	// interleaving is used when rangeDelIterPtr != nil to interleave the
-	// boundaries of range deletions among point keys. This ensures that we
-	// don't advance to a new file until the range deletions are no longer
-	// needed by other levels.
-	interleaving keyspan.InterleavingIter
 
 	// exhaustedDir is set to +1 or -1 when the levelIter has been exhausted in
 	// the forward or backward direction respectively. It is set when the
@@ -178,8 +175,14 @@ func (l *levelIter) init(
 	l.internalOpts = internalOpts
 }
 
-func (l *levelIter) initRangeDel(rangeDelIter *keyspan.FragmentIterator) {
-	l.rangeDelIterPtr = rangeDelIter
+// initRangeDel puts the level iterator into a mode where it interleaves range
+// deletion boundaries with point keys and provides a range deletion iterator
+// (through rangeDelIterFn) whenever the current file changes.
+//
+// The range deletion iterator passed to rangeDelIterFn is relinquished to the
+// implementor who is responsible for closing it.
+func (l *levelIter) initRangeDel(rangeDelIterFn func(rangeDelIter keyspan.FragmentIterator)) {
+	l.rangeDelIterFn = rangeDelIterFn
 }
 
 func (l *levelIter) initCombinedIterState(state *combinedIterState) {
@@ -491,9 +494,6 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) loadFileReturnIndicato
 			// We don't bother comparing the file bounds with the iteration bounds when we have
 			// an already open iterator. It is possible that the iter may not be relevant given the
 			// current iteration bounds, but it knows those bounds, so it will enforce them.
-			if l.rangeDelIterPtr != nil {
-				*l.rangeDelIterPtr = l.rangeDelIterCopy
-			}
 
 			// There are a few reasons we might not have triggered combined
 			// iteration yet, even though we already had `file` open.
@@ -511,10 +511,7 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) loadFileReturnIndicato
 		// have changed. We handle that below.
 	}
 
-	// Close both iter and rangeDelIterPtr. While mergingIter knows about
-	// rangeDelIterPtr, it can't call Close() on it because it does not know
-	// when the levelIter will switch it. Note that levelIter.Close() can be
-	// called multiple times.
+	// Close iter and send a nil iterator through rangeDelIterFn.rangeDelIterFn.
 	if err := l.Close(); err != nil {
 		return noFileLoaded
 	}
@@ -568,20 +565,20 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) loadFileReturnIndicato
 		}
 
 		iterKinds := iterPointKeys
-		if l.rangeDelIterPtr != nil {
+		if l.rangeDelIterFn != nil {
 			iterKinds |= iterRangeDeletions
 		}
 
 		var iters iterSet
 		iters, l.err = l.newIters(l.ctx, l.iterFile, &l.tableOpts, l.internalOpts, iterKinds)
 		if l.err != nil {
+			if l.rangeDelIterFn != nil {
+				l.rangeDelIterFn(nil)
+			}
 			return noFileLoaded
 		}
 		l.iter = iters.Point()
-		if l.rangeDelIterPtr != nil && iters.rangeDeletion != nil {
-			*l.rangeDelIterPtr = iters.rangeDeletion
-			l.rangeDelIterCopy = iters.rangeDeletion
-
+		if l.rangeDelIterFn != nil && iters.rangeDeletion != nil {
 			// If this file has range deletions, interleave the bounds of the
 			// range deletions among the point keys. When used with a
 			// mergingIter, this ensures we don't move beyond a file with range
@@ -589,23 +586,22 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) loadFileReturnIndicato
 			//
 			// For now, we open a second range deletion iterator. Future work
 			// will avoid the need to open a second range deletion iterator, and
-			// avoid surfacing the file's range deletion iterator directly to
-			// the caller.
-			var itersForBounds iterSet
-			itersForBounds, l.err = l.newIters(l.ctx, l.iterFile, &l.tableOpts, l.internalOpts, iterRangeDeletions)
+			// avoid surfacing the file's range deletion iterator via rangeDelIterFn.
+			itersForBounds, err := l.newIters(l.ctx, l.iterFile, &l.tableOpts, l.internalOpts, iterRangeDeletions)
+			if err != nil {
+				l.iter = nil
+				l.err = errors.CombineErrors(err, iters.CloseAll())
+				return noFileLoaded
+			}
 			l.interleaving.Init(l.comparer, l.iter, itersForBounds.RangeDeletion(), keyspan.InterleavingIterOpts{
 				LowerBound:        l.tableOpts.LowerBound,
 				UpperBound:        l.tableOpts.UpperBound,
 				InterleaveEndKeys: true,
 			})
-			if l.err != nil {
-				l.iter = nil
-				*l.rangeDelIterPtr = nil
-				l.rangeDelIterCopy = nil
-				l.err = errors.CombineErrors(l.err, iters.CloseAll())
-				return noFileLoaded
-			}
 			l.iter = &l.interleaving
+
+			// Relinquish iters.rangeDeletion to the caller.
+			l.rangeDelIterFn(iters.rangeDeletion)
 		}
 		return newFileLoaded
 	}
@@ -896,16 +892,10 @@ func (l *levelIter) skipEmptyFileBackward() *base.InternalKV {
 
 func (l *levelIter) exhaustedForward() {
 	l.exhaustedDir = +1
-	if l.rangeDelIterPtr != nil {
-		*l.rangeDelIterPtr = nil
-	}
 }
 
 func (l *levelIter) exhaustedBackward() {
 	l.exhaustedDir = -1
-	if l.rangeDelIterPtr != nil {
-		*l.rangeDelIterPtr = nil
-	}
 }
 
 func (l *levelIter) Error() error {
@@ -920,12 +910,8 @@ func (l *levelIter) Close() error {
 		l.err = l.iter.Close()
 		l.iter = nil
 	}
-	if l.rangeDelIterPtr != nil {
-		if t := l.rangeDelIterCopy; t != nil {
-			t.Close()
-		}
-		*l.rangeDelIterPtr = nil
-		l.rangeDelIterCopy = nil
+	if l.rangeDelIterFn != nil {
+		l.rangeDelIterFn(nil)
 	}
 	return l.err
 }

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -25,6 +25,8 @@ type mergingIterLevel struct {
 	// are crossed. See levelIter.initRangeDel and the Range Deletions comment
 	// below.
 	rangeDelIter keyspan.FragmentIterator
+	// rangeDelIterGeneration is incremented whenever rangeDelIter changes.
+	rangeDelIterGeneration int
 	// iterKV caches the current key-value pair iter points to.
 	iterKV *base.InternalKV
 	// levelIter is non-nil if this level's iter is ultimately backed by a
@@ -39,6 +41,15 @@ type mergingIterLevel struct {
 	// positioning tombstones at lower levels which cannot possibly shadow the
 	// current key.
 	tombstone *keyspan.Span
+}
+
+func (ml *mergingIterLevel) setRangeDelIter(iter keyspan.FragmentIterator) {
+	ml.tombstone = nil
+	if ml.rangeDelIter != nil {
+		ml.rangeDelIter.Close()
+	}
+	ml.rangeDelIter = iter
+	ml.rangeDelIterGeneration++
 }
 
 // mergingIter provides a merged view of multiple iterators from different
@@ -237,6 +248,7 @@ type mergingIter struct {
 	lower         []byte
 	upper         []byte
 	stats         *InternalIteratorStats
+	seekKeyBuf    []byte
 
 	// levelsPositioned, if non-nil, is a slice of the same length as levels.
 	// It's used by NextPrefix to record which levels have already been
@@ -519,7 +531,7 @@ func (m *mergingIter) nextEntry(l *mergingIterLevel, succKey []byte) error {
 	}
 
 	oldTopLevel := l.index
-	oldRangeDelIter := l.rangeDelIter
+	oldRangeDelIterGeneration := l.rangeDelIterGeneration
 
 	if succKey == nil {
 		l.iterKV = l.iter.Next()
@@ -541,7 +553,7 @@ func (m *mergingIter) nextEntry(l *mergingIterLevel, succKey []byte) error {
 		} else if m.heap.len() > 1 {
 			m.heap.fix(0)
 		}
-		if l.rangeDelIter != oldRangeDelIter {
+		if l.rangeDelIterGeneration != oldRangeDelIterGeneration {
 			// The rangeDelIter changed which indicates that the l.iter moved to the
 			// next sstable. We have to update the tombstone for oldTopLevel as well.
 			oldTopLevel--
@@ -613,7 +625,8 @@ func (m *mergingIter) isNextEntryDeleted(item *mergingIterLevel) (bool, error) {
 				// We also know that l.tombstone.End > item.iterKV.UserKey. So the min of these,
 				// seekKey, computed below, is > item.iterKV.UserKey, so the call to seekGE() will
 				// make forward progress.
-				seekKey := l.tombstone.End
+				m.seekKeyBuf = append(m.seekKeyBuf[:0], l.tombstone.End...)
+				seekKey := m.seekKeyBuf
 				// This seek is not directly due to a SeekGE call, so we don't know
 				// enough about the underlying iterator positions, and so we keep the
 				// try-seek-using-next optimization disabled. Additionally, if we're in
@@ -740,12 +753,12 @@ func (m *mergingIter) findNextEntry() *base.InternalKV {
 // Steps to the prev entry. item is the current top item in the heap.
 func (m *mergingIter) prevEntry(l *mergingIterLevel) error {
 	oldTopLevel := l.index
-	oldRangeDelIter := l.rangeDelIter
+	oldRangeDelIterGeneration := l.rangeDelIterGeneration
 	if l.iterKV = l.iter.Prev(); l.iterKV != nil {
 		if m.heap.len() > 1 {
 			m.heap.fix(0)
 		}
-		if l.rangeDelIter != oldRangeDelIter && l.rangeDelIter != nil {
+		if l.rangeDelIterGeneration != oldRangeDelIterGeneration && l.rangeDelIter != nil {
 			// The rangeDelIter changed which indicates that the l.iter moved to the
 			// previous sstable. We have to update the tombstone for oldTopLevel as
 			// well.
@@ -815,7 +828,8 @@ func (m *mergingIter) isPrevEntryDeleted(item *mergingIterLevel) (bool, error) {
 				// l.tombstone.Start.UserKey <= item.iterKV.UserKey. So the seekKey computed below
 				// is <= item.iterKV.UserKey, and since we do a seekLT() we will make backwards
 				// progress.
-				seekKey := l.tombstone.Start
+				m.seekKeyBuf = append(m.seekKeyBuf[:0], l.tombstone.Start...)
+				seekKey := m.seekKeyBuf
 				// We set the relative-seek flag. This is important when
 				// iterating with lazy combined iteration. If there's a range
 				// key between this level's current file and the file the seek
@@ -1289,9 +1303,7 @@ func (m *mergingIter) Close() error {
 		if err := iter.Close(); err != nil && m.err == nil {
 			m.err = err
 		}
-		if rangeDelIter := m.levels[i].rangeDelIter; rangeDelIter != nil {
-			rangeDelIter.Close()
-		}
+		m.levels[i].setRangeDelIter(nil)
 	}
 	m.levels = nil
 	m.heap.items = m.heap.items[:0]

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -306,7 +306,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 
 				i := len(levelIters)
 				levelIters = append(levelIters, mergingIterLevel{iter: li})
-				li.initRangeDel(&levelIters[i].rangeDelIter)
+				li.initRangeDel(levelIters[i].setRangeDelIter)
 			}
 			miter := &mergingIter{}
 			miter.init(nil /* opts */, &stats, cmp, func(a []byte) int { return len(a) }, levelIters...)
@@ -677,7 +677,7 @@ func buildMergingIter(readers [][]*sstable.Reader, levelSlices []manifest.LevelS
 		l := newLevelIter(
 			context.Background(), IterOptions{}, testkeys.Comparer, newIters, levelSlices[i].Iter(),
 			manifest.Level(level), internalIterOpts{})
-		l.initRangeDel(&mils[level].rangeDelIter)
+		l.initRangeDel(mils[level].setRangeDelIter)
 		mils[level].iter = l
 	}
 	var stats base.InternalIteratorStats

--- a/testdata/level_iter_seek
+++ b/testdata/level_iter_seek
@@ -44,7 +44,7 @@ iter
 set-bounds upper=d
 seek-ge d
 ----
-.
+. / d-e:{(#6,RANGEDEL)}
 
 iter
 set-bounds upper=d
@@ -143,7 +143,7 @@ iter
 set-bounds lower=d
 seek-lt d
 ----
-.
+. / d-e:{(#6,RANGEDEL)}
 
 iter
 set-bounds lower=d


### PR DESCRIPTION
`rangeDelIterPtr` is a mechanism through which the level iter passes
a range deletion iterator to the merge iterator (which uses it to
maintain a heap of tombstones).

This change cleans up the mechanism by making it a function instead.
This makes the ownership much clearer and allows the caller to add
more logic whenever the iterator changes. The merge iterator now
maintains a generation counter to detect changes (instead of comparing
by pointer, which doesn't work when iterators are pooled).