### PR TITLE
Revert "cmd/pebble: use zstd in Pebble nightly benchmarks"

### DIFF
--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/bytealloc"
 	"github.com/cockroachdb/pebble/internal/crdbtest"
 	"github.com/cockroachdb/pebble/objstorage/remote"
-	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 )
 
@@ -79,8 +78,7 @@ func newPebbleDB(dir string) DB {
 
 	for i := 0; i < len(opts.Levels); i++ {
 		l := &opts.Levels[i]
-		l.BlockSize = 32 << 10 // 32 KB
-		l.Compression = func() sstable.Compression { return pebble.ZstdCompression }
+		l.BlockSize = 32 << 10       // 32 KB
 		l.IndexBlockSize = 256 << 10 // 256 KB
 		l.FilterPolicy = bloom.FilterPolicy(10)
 		l.FilterType = pebble.TableFilter


### PR DESCRIPTION
This reverts commit 0e4fb77b8172d4d1b26f72658cd2ab74705897fc.

The effect on throughput is substantial enough that it might obscure minor regressions.