### PR TITLE
crl-release-23.2: provider: consult readahead config when initializing handle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ mutex.prof
 coverprofile.out
 # Testing artifacts
 meta.*.test
+
+# Bazel files, generated with 'make gen-bazel'.
+/WORKSPACE
+BUILD.bazel
+
+

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ all:
 	@echo "  make crossversion-meta"
 	@echo "  make testcoverage"
 	@echo "  make mod-update"
+	@echo "  make gen-bazel"
 	@echo "  make generate"
 	@echo "  make generate-test-data"
 	@echo "  make clean"
@@ -72,6 +73,19 @@ crossversion-meta:
 .PHONY: stress-crossversion
 stress-crossversion:
 	STRESS=1 ./scripts/run-crossversion-meta.sh crl-release-21.2 crl-release-22.1 crl-release-22.2 crl-release-23.1 master
+
+.PHONY: gen-bazel
+gen-bazel:
+	@echo "Generating WORKSPACE"
+	@echo 'workspace(name = "com_github_cockroachdb_pebble")' > WORKSPACE
+	@echo 'Running gazelle...'
+	${GO} run github.com/bazelbuild/bazel-gazelle/cmd/gazelle@v0.37.0 update --go_prefix=github.com/cockroachdb/pebble --repo_root=.
+	@echo 'You should now be able to build Cockroach using:'
+	@echo '  ./dev build short -- --override_repository=com_github_cockroachdb_pebble=${CURDIR}'
+
+.PHONY: clean-bazel
+clean-bazel:
+	git clean -dxf WORKSPACE BUILD.bazel '**/BUILD.bazel'
 
 .PHONY: generate
 generate:

--- a/objstorage/objstorageprovider/provider_test.go
+++ b/objstorage/objstorageprovider/provider_test.go
@@ -40,9 +40,9 @@ func TestProvider(t *testing.T) {
 		backings := make(map[string]objstorage.RemoteObjectBacking)
 		backingHandles := make(map[string]objstorage.RemoteObjectBackingHandle)
 		var curProvider objstorage.Provider
-		readaheadConfig := DefaultReadaheadConfig
+		readaheadConfig := NewReadaheadConfig()
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
-			readaheadConfig = DefaultReadaheadConfig
+			readaheadConfig.Set(defaultReadaheadInformed, defaultReadaheadSpeculative)
 			scanArgs := func(desc string, args ...interface{}) {
 				t.Helper()
 				if len(d.CmdArgs) != len(args) {
@@ -70,9 +70,7 @@ func TestProvider(t *testing.T) {
 					st.Remote.CreateOnShared = remote.CreateOnSharedAll
 					st.Remote.CreateOnSharedLocator = ""
 				}
-				st.Local.ReadaheadConfigFn = func() ReadaheadConfig {
-					return readaheadConfig
-				}
+				st.Local.ReadaheadConfig = readaheadConfig
 				require.NoError(t, fs.MkdirAll(fsDir, 0755))
 				p, err := Open(st)
 				require.NoError(t, err)
@@ -189,9 +187,9 @@ func TestProvider(t *testing.T) {
 						d.Fatalf(t, "unknown readahead mode %s", arg.Vals[0])
 					}
 					if forCompaction {
-						readaheadConfig.Informed = mode
+						readaheadConfig.Set(mode, defaultReadaheadSpeculative)
 					} else {
-						readaheadConfig.Speculative = mode
+						readaheadConfig.Set(defaultReadaheadInformed, mode)
 					}
 				}
 

--- a/objstorage/objstorageprovider/vfs.go
+++ b/objstorage/objstorageprovider/vfs.go
@@ -31,11 +31,7 @@ func (p *provider) vfsOpenForReading(
 		}
 		return nil, err
 	}
-	readaheadConfig := DefaultReadaheadConfig
-	if f := p.st.Local.ReadaheadConfigFn; f != nil {
-		readaheadConfig = f()
-	}
-	return newFileReadable(file, p.st.FS, readaheadConfig, filename)
+	return newFileReadable(file, p.st.FS, p.st.Local.ReadaheadConfig, filename)
 }
 
 func (p *provider) vfsCreate(

--- a/objstorage/objstorageprovider/vfs_readable.go
+++ b/objstorage/objstorageprovider/vfs_readable.go
@@ -25,17 +25,18 @@ type fileReadable struct {
 	file vfs.File
 	size int64
 
+	readaheadConfig *ReadaheadConfig
+
 	// The following fields are used to possibly open the file again using the
 	// sequential reads option (see vfsReadHandle).
-	filename        string
-	fs              vfs.FS
-	readaheadConfig ReadaheadConfig
+	filename string
+	fs       vfs.FS
 }
 
 var _ objstorage.Readable = (*fileReadable)(nil)
 
 func newFileReadable(
-	file vfs.File, fs vfs.FS, readaheadConfig ReadaheadConfig, filename string,
+	file vfs.File, fs vfs.FS, readaheadConfig *ReadaheadConfig, filename string,
 ) (*fileReadable, error) {
 	info, err := file.Stat()
 	if err != nil {
@@ -116,7 +117,7 @@ func (rh *vfsReadHandle) init(r *fileReadable) {
 	*rh = vfsReadHandle{
 		r:             r,
 		rs:            makeReadaheadState(fileMaxReadaheadSize),
-		readaheadMode: r.readaheadConfig.Speculative,
+		readaheadMode: r.readaheadConfig.Speculative(),
 	}
 }
 
@@ -161,7 +162,7 @@ func (rh *vfsReadHandle) ReadAt(_ context.Context, p []byte, offset int64) error
 
 // SetupForCompaction is part of the objstorage.ReadHandle interface.
 func (rh *vfsReadHandle) SetupForCompaction() {
-	rh.readaheadMode = rh.r.readaheadConfig.Informed
+	rh.readaheadMode = rh.r.readaheadConfig.Informed()
 	if rh.readaheadMode == FadviseSequential {
 		rh.switchToOSReadahead()
 	}

--- a/open.go
+++ b/open.go
@@ -310,7 +310,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 		NoSyncOnClose:       opts.NoSyncOnClose,
 		BytesPerSync:        opts.BytesPerSync,
 	}
-	providerSettings.Local.ReadaheadConfigFn = opts.Local.ReadaheadConfigFn
+	providerSettings.Local.ReadaheadConfig = opts.Local.ReadaheadConfig
 	providerSettings.Remote.StorageFactory = opts.Experimental.RemoteStorage
 	providerSettings.Remote.CreateOnShared = opts.Experimental.CreateOnShared
 	providerSettings.Remote.CreateOnSharedLocator = opts.Experimental.CreateOnSharedLocator

--- a/options.go
+++ b/options.go
@@ -495,9 +495,9 @@ type Options struct {
 
 	// Local contains option that pertain to files stored on the local filesystem.
 	Local struct {
-		// ReadaheadConfigFn is a function used to retrieve the current readahead
-		// mode. This function is consulted when a table enters the table cache.
-		ReadaheadConfigFn func() ReadaheadConfig
+		// ReadaheadConfig is used to retrieve the current readahead mode; it is
+		// consulted whenever a read handle is initialized.
+		ReadaheadConfig *ReadaheadConfig
 
 		// TODO(radu): move BytesPerSync, LoadBlockSema, Cleaner here.
 	}


### PR DESCRIPTION
Backport of #3668

#### Makefile: add gen-bazel target

This change adds a `gen-bazel` target which generates a `WORKSPACE`
file and runs gazelle to generate `BUILD.bazel `files. Generating
these files  allows a local clone of the repository to be used
directly when building Cockroach using the `override_repository` flag,
for example:

```
./dev build short -- --override_repository=com_github_cockroachdb_pebble=~/go/src/github.com/cockroachdb/pebble
```

The new files are added to `.gitignore` so that generating them
doesn't interfere with commits.

We also add a `clean-bazel` target that cleans up these files (useful
when switching back to an older branch).

#### provider: consult readahead config when initializing handle

We currently retrieve the readahead config when we create a `Readable`
and then we use that config for all read handles. This makes the
settings not responsive, as any tables already in the table cache will
have the `Readable` created.

We change `ReadaheadConfig` to an atomic that is loaded every time we
initialize a read handle.