### PR TITLE
sstable/block: additional refactoring

### DIFF
--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -6,6 +6,7 @@ package block
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 
 	"github.com/cespare/xxhash/v2"
@@ -14,10 +15,25 @@ import (
 	"github.com/cockroachdb/pebble/internal/crc"
 )
 
+// TrailerLen is the length of the trailer at the end of a block.
+const TrailerLen = 5
+
+// Trailer is the trailer at the end of a block, encoding the block type
+// (compression) and a checksum.
+type Trailer = [TrailerLen]byte
+
+// MakeTrailer constructs a trailer from a block type and a checksum.
+func MakeTrailer(blockType byte, checksum uint32) (t Trailer) {
+	t[0] = blockType
+	binary.LittleEndian.PutUint32(t[1:5], checksum)
+	return t
+}
+
 // ChecksumType specifies the checksum used for blocks.
 type ChecksumType byte
 
-// The available checksum types.
+// The available checksum types. These values are part of the durable format and
+// should not be changed.
 const (
 	ChecksumTypeNone     ChecksumType = 0
 	ChecksumTypeCRC32c   ChecksumType = 1

--- a/sstable/block/buffer_pool.go
+++ b/sstable/block/buffer_pool.go
@@ -6,22 +6,22 @@ package block
 
 import (
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
 )
 
-// MakeCacheValue constructs a CacheValueOrBuf backed by a block cache Value.
-func MakeCacheValue(v *cache.Value) CacheValueOrBuf {
-	return CacheValueOrBuf{v: v}
+// Alloc allocates a new Value for a block of length n (excluding the block
+// trailer). If bufferPool is non-nil, Alloc allocates the buffer from the pool.
+// Otherwise it allocates it from the block cache.
+func Alloc(n int, p *BufferPool) Value {
+	if p != nil {
+		return Value{buf: p.Alloc(int(n))}
+	}
+	return Value{v: cache.Alloc(int(n))}
 }
 
-// MakeBlockBuf constructs a CacheValueOrBuf backed by a BufferPool buffer.
-func MakeBlockBuf(buf Buf) CacheValueOrBuf {
-	return CacheValueOrBuf{buf: buf}
-}
-
-// CacheValueOrBuf is a handle to a block, either backed by the block cache or a
-// BufferPool.
-type CacheValueOrBuf struct {
+// Value is a block buffer, either backed by the block cache or a BufferPool.
+type Value struct {
 	// buf.Valid() returns true if backed by a BufferPool.
 	buf Buf
 	// v is non-nil if backed by the block cache.
@@ -29,21 +29,27 @@ type CacheValueOrBuf struct {
 }
 
 // Get returns the underlying block's byte slice.
-func (b CacheValueOrBuf) Get() []byte {
+func (b Value) Get() []byte {
 	if b.buf.Valid() {
 		return b.buf.p.pool[b.buf.i].b
 	}
 	return b.v.Buf()
 }
 
-// Unpack returns the underlying block's Buf and cache.Value. For a valid
-// CacheValueOrBuf, either Buf.Valid() or cache.Value is non-nil.
-func (b CacheValueOrBuf) Unpack() (Buf, *cache.Value) {
-	return b.buf, b.v
+// MakeHandle constructs a BufferHandle from the Value. If the Value is not
+// backed by a buffer pool, MakeHandle inserts the value into the block cache,
+// returning a handle to the now resident value.
+func (b Value) MakeHandle(
+	c *cache.Cache, cacheID uint64, fileNum base.DiskFileNum, offset uint64,
+) BufferHandle {
+	if b.buf.Valid() {
+		return BufferHandle{b: b.buf}
+	}
+	return BufferHandle{h: c.Set(cacheID, fileNum, offset, b.v)}
 }
 
 // Release releases the handle.
-func (b CacheValueOrBuf) Release() {
+func (b Value) Release() {
 	if b.buf.Valid() {
 		b.buf.Release()
 	} else {
@@ -52,7 +58,7 @@ func (b CacheValueOrBuf) Release() {
 }
 
 // Truncate truncates the block to n bytes.
-func (b CacheValueOrBuf) Truncate(n int) {
+func (b Value) Truncate(n int) {
 	if b.buf.Valid() {
 		b.buf.p.pool[b.buf.i].b = b.buf.p.pool[b.buf.i].b[:n]
 	} else {
@@ -66,11 +72,6 @@ func (b CacheValueOrBuf) Truncate(n int) {
 type BufferHandle struct {
 	h cache.Handle
 	b Buf
-}
-
-// PooledBufferHandle returns a BufferHandle for a pooled buffer.
-func PooledBufferHandle(b Buf) BufferHandle {
-	return BufferHandle{b: b}
 }
 
 // CacheBufferHandle constructs a BufferHandle from a block cache Handle.

--- a/sstable/block/kv.go
+++ b/sstable/block/kv.go
@@ -1,0 +1,70 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package block
+
+import "github.com/cockroachdb/pebble/internal/base"
+
+// ValuePrefix is the single byte prefix in values indicating either an in-place
+// value or a value encoding a valueHandle. It encodes multiple kinds of
+// information (see below).
+type ValuePrefix byte
+
+const (
+	// 2 most-significant bits of valuePrefix encodes the value-kind.
+	valueKindMask           ValuePrefix = 0xC0
+	valueKindIsValueHandle  ValuePrefix = 0x80
+	valueKindIsInPlaceValue ValuePrefix = 0x00
+
+	// 1 bit indicates SET has same key prefix as immediately preceding key that
+	// is also a SET. If the immediately preceding key in the same block is a
+	// SET, AND this bit is 0, the prefix must have changed.
+	//
+	// Note that the current policy of only storing older MVCC versions in value
+	// blocks means that valueKindIsValueHandle => SET has same prefix. But no
+	// code should rely on this behavior. Also, SET has same prefix does *not*
+	// imply valueKindIsValueHandle.
+	setHasSameKeyPrefixMask ValuePrefix = 0x20
+
+	// 3 least-significant bits for the user-defined base.ShortAttribute.
+	// Undefined for valueKindIsInPlaceValue.
+	userDefinedShortAttributeMask ValuePrefix = 0x07
+)
+
+// IsValueHandle returns true if the ValuePrefix is for a valueHandle.
+func (vp ValuePrefix) IsValueHandle() bool {
+	return vp&valueKindMask == valueKindIsValueHandle
+}
+
+// SetHasSamePrefix returns true if the ValuePrefix encodes that the key is a
+// set with the same prefix as the preceding key which also is a set.
+func (vp ValuePrefix) SetHasSamePrefix() bool {
+	return vp&setHasSameKeyPrefixMask == setHasSameKeyPrefixMask
+}
+
+// ShortAttribute returns the user-defined base.ShortAttribute encoded in the
+// ValuePrefix.
+//
+// REQUIRES: IsValueHandle()
+func (vp ValuePrefix) ShortAttribute() base.ShortAttribute {
+	return base.ShortAttribute(vp & userDefinedShortAttributeMask)
+}
+
+// ValueHandlePrefix returns the ValuePrefix for a valueHandle.
+func ValueHandlePrefix(setHasSameKeyPrefix bool, attribute base.ShortAttribute) ValuePrefix {
+	prefix := valueKindIsValueHandle | ValuePrefix(attribute)
+	if setHasSameKeyPrefix {
+		prefix = prefix | setHasSameKeyPrefixMask
+	}
+	return prefix
+}
+
+// InPlaceValuePrefix returns the ValuePrefix for an in-place value.
+func InPlaceValuePrefix(setHasSameKeyPrefix bool) ValuePrefix {
+	prefix := valueKindIsInPlaceValue
+	if setHasSameKeyPrefix {
+		prefix = prefix | setHasSameKeyPrefixMask
+	}
+	return prefix
+}

--- a/sstable/block/kv_test.go
+++ b/sstable/block/kv_test.go
@@ -1,0 +1,55 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package block
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValuePrefix(t *testing.T) {
+	testCases := []struct {
+		isHandle         bool
+		setHasSamePrefix bool
+		attr             base.ShortAttribute
+	}{
+		{
+			isHandle:         false,
+			setHasSamePrefix: false,
+		},
+		{
+			isHandle:         false,
+			setHasSamePrefix: true,
+		},
+		{
+			isHandle:         true,
+			setHasSamePrefix: false,
+			attr:             5,
+		},
+		{
+			isHandle:         true,
+			setHasSamePrefix: true,
+			attr:             2,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%+v", tc), func(t *testing.T) {
+			var prefix ValuePrefix
+			if tc.isHandle {
+				prefix = ValueHandlePrefix(tc.setHasSamePrefix, tc.attr)
+			} else {
+				prefix = InPlaceValuePrefix(tc.setHasSamePrefix)
+			}
+			require.Equal(t, tc.isHandle, prefix.IsValueHandle())
+			require.Equal(t, tc.setHasSamePrefix, prefix.SetHasSamePrefix())
+			if tc.isHandle {
+				require.Equal(t, tc.attr, prefix.ShortAttribute())
+			}
+		})
+	}
+}

--- a/sstable/block_iter.go
+++ b/sstable/block_iter.go
@@ -655,7 +655,7 @@ func (i *blockIter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV 
 		if !i.lazyValueHandling.hasValuePrefix ||
 			i.ikv.K.Kind() != InternalKeyKindSet {
 			i.ikv.V = base.MakeInPlaceValue(i.val)
-		} else if i.lazyValueHandling.vbr == nil || !isValueHandle(valuePrefix(i.val[0])) {
+		} else if i.lazyValueHandling.vbr == nil || !block.ValuePrefix(i.val[0]).IsValueHandle() {
 			i.ikv.V = base.MakeInPlaceValue(i.val[1:])
 		} else {
 			i.ikv.V = i.lazyValueHandling.vbr.getLazyValueForPrefixAndValueHandle(i.val)
@@ -938,7 +938,7 @@ func (i *blockIter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV 
 	if !i.lazyValueHandling.hasValuePrefix ||
 		i.ikv.K.Kind() != InternalKeyKindSet {
 		i.ikv.V = base.MakeInPlaceValue(i.val)
-	} else if i.lazyValueHandling.vbr == nil || !isValueHandle(valuePrefix(i.val[0])) {
+	} else if i.lazyValueHandling.vbr == nil || !block.ValuePrefix(i.val[0]).IsValueHandle() {
 		i.ikv.V = base.MakeInPlaceValue(i.val[1:])
 	} else {
 		i.ikv.V = i.lazyValueHandling.vbr.getLazyValueForPrefixAndValueHandle(i.val)
@@ -967,7 +967,7 @@ func (i *blockIter) First() *base.InternalKV {
 	if !i.lazyValueHandling.hasValuePrefix ||
 		i.ikv.K.Kind() != InternalKeyKindSet {
 		i.ikv.V = base.MakeInPlaceValue(i.val)
-	} else if i.lazyValueHandling.vbr == nil || !isValueHandle(valuePrefix(i.val[0])) {
+	} else if i.lazyValueHandling.vbr == nil || !block.ValuePrefix(i.val[0]).IsValueHandle() {
 		i.ikv.V = base.MakeInPlaceValue(i.val[1:])
 	} else {
 		i.ikv.V = i.lazyValueHandling.vbr.getLazyValueForPrefixAndValueHandle(i.val)
@@ -1010,7 +1010,7 @@ func (i *blockIter) Last() *base.InternalKV {
 	if !i.lazyValueHandling.hasValuePrefix ||
 		i.ikv.K.Kind() != InternalKeyKindSet {
 		i.ikv.V = base.MakeInPlaceValue(i.val)
-	} else if i.lazyValueHandling.vbr == nil || !isValueHandle(valuePrefix(i.val[0])) {
+	} else if i.lazyValueHandling.vbr == nil || !block.ValuePrefix(i.val[0]).IsValueHandle() {
 		i.ikv.V = base.MakeInPlaceValue(i.val[1:])
 	} else {
 		i.ikv.V = i.lazyValueHandling.vbr.getLazyValueForPrefixAndValueHandle(i.val)
@@ -1069,7 +1069,7 @@ start:
 	if !i.lazyValueHandling.hasValuePrefix ||
 		i.ikv.K.Kind() != InternalKeyKindSet {
 		i.ikv.V = base.MakeInPlaceValue(i.val)
-	} else if i.lazyValueHandling.vbr == nil || !isValueHandle(valuePrefix(i.val[0])) {
+	} else if i.lazyValueHandling.vbr == nil || !block.ValuePrefix(i.val[0]).IsValueHandle() {
 		i.ikv.V = base.MakeInPlaceValue(i.val[1:])
 	} else {
 		i.ikv.V = i.lazyValueHandling.vbr.getLazyValueForPrefixAndValueHandle(i.val)
@@ -1212,8 +1212,8 @@ func (i *blockIter) nextPrefixV3(succKey []byte) *base.InternalKV {
 			if invariants.Enabled && value == 0 {
 				panic(errors.AssertionFailedf("value is of length 0, but we expect a valuePrefix"))
 			}
-			valPrefix := *((*valuePrefix)(valuePtr))
-			if setHasSamePrefix(valPrefix) {
+			valPrefix := *((*block.ValuePrefix)(valuePtr))
+			if valPrefix.SetHasSamePrefix() {
 				// Fast-path. No need to assemble i.fullKey, or update i.key. We know
 				// that subsequent keys will not have a shared length that is greater
 				// than the prefix of the current key, which is also the prefix of
@@ -1360,7 +1360,7 @@ func (i *blockIter) nextPrefixV3(succKey []byte) *base.InternalKV {
 			}
 			if i.ikv.K.Kind() != InternalKeyKindSet {
 				i.ikv.V = base.MakeInPlaceValue(i.val)
-			} else if i.lazyValueHandling.vbr == nil || !isValueHandle(valuePrefix(i.val[0])) {
+			} else if i.lazyValueHandling.vbr == nil || !block.ValuePrefix(i.val[0]).IsValueHandle() {
 				i.ikv.V = base.MakeInPlaceValue(i.val[1:])
 			} else {
 				i.ikv.V = i.lazyValueHandling.vbr.getLazyValueForPrefixAndValueHandle(i.val)
@@ -1418,7 +1418,7 @@ start:
 		if !i.lazyValueHandling.hasValuePrefix ||
 			i.ikv.K.Kind() != InternalKeyKindSet {
 			i.ikv.V = base.MakeInPlaceValue(i.val)
-		} else if i.lazyValueHandling.vbr == nil || !isValueHandle(valuePrefix(i.val[0])) {
+		} else if i.lazyValueHandling.vbr == nil || !block.ValuePrefix(i.val[0]).IsValueHandle() {
 			i.ikv.V = base.MakeInPlaceValue(i.val[1:])
 		} else {
 			i.ikv.V = i.lazyValueHandling.vbr.getLazyValueForPrefixAndValueHandle(i.val)
@@ -1499,7 +1499,7 @@ start:
 	if !i.lazyValueHandling.hasValuePrefix ||
 		i.ikv.K.Kind() != InternalKeyKindSet {
 		i.ikv.V = base.MakeInPlaceValue(i.val)
-	} else if i.lazyValueHandling.vbr == nil || !isValueHandle(valuePrefix(i.val[0])) {
+	} else if i.lazyValueHandling.vbr == nil || !block.ValuePrefix(i.val[0]).IsValueHandle() {
 		i.ikv.V = base.MakeInPlaceValue(i.val[1:])
 	} else {
 		i.ikv.V = i.lazyValueHandling.vbr.getLazyValueForPrefixAndValueHandle(i.val)

--- a/sstable/block_test.go
+++ b/sstable/block_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/itertest"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
 )
@@ -54,7 +55,7 @@ func TestBlockWriterWithPrefix(t *testing.T) {
 		key InternalKey,
 		value []byte,
 		addValuePrefix bool,
-		valuePrefix valuePrefix,
+		valuePrefix block.ValuePrefix,
 		setHasSameKeyPrefix bool) {
 		w.addWithOptionalValuePrefix(
 			key, false, value, len(key.UserKey), addValuePrefix, valuePrefix, setHasSameKeyPrefix)

--- a/sstable/block_writer.go
+++ b/sstable/block_writer.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/sstable/block"
 )
 
 type blockWriter struct {
@@ -86,7 +87,7 @@ func (w *blockWriter) storeWithOptionalValuePrefix(
 	value []byte,
 	maxSharedKeyLen int,
 	addValuePrefix bool,
-	valuePrefix valuePrefix,
+	valuePrefix block.ValuePrefix,
 	setHasSameKeyPrefix bool,
 ) {
 	shared := 0
@@ -210,7 +211,7 @@ func (w *blockWriter) addWithOptionalValuePrefix(
 	value []byte,
 	maxSharedKeyLen int,
 	addValuePrefix bool,
-	valuePrefix valuePrefix,
+	valuePrefix block.ValuePrefix,
 	setHasSameKeyPrefix bool,
 ) {
 	w.curKey, w.prevKey = w.prevKey, w.curKey

--- a/sstable/copier.go
+++ b/sstable/copier.go
@@ -156,7 +156,7 @@ func CopySpan(
 	// The block lengths don't include their trailers, which just sit after the
 	// block length, before the next offset; We get the ones between the blocks
 	// we copy implicitly but need to explicitly add the last trailer to length.
-	length := blocks[len(blocks)-1].bh.Offset + blocks[len(blocks)-1].bh.Length + blockTrailerLen - offset
+	length := blocks[len(blocks)-1].bh.Offset + blocks[len(blocks)-1].bh.Length + block.TrailerLen - offset
 
 	if spanEnd := length + offset; spanEnd < offset {
 		return 0, base.AssertionFailedf("invalid intersecting span for CopySpan [%d, %d)", offset, spanEnd)

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -176,7 +176,7 @@ func (l *Layout) Describe(
 		}
 
 		formatTrailer := func() {
-			trailer := make([]byte, blockTrailerLen)
+			trailer := make([]byte, block.TrailerLen)
 			offset := int64(b.Offset + b.Length)
 			_ = r.readable.ReadAt(ctx, trailer, offset)
 			bt := blockType(trailer[0])

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -221,7 +221,7 @@ func (l *Layout) Describe(
 						v := kv.InPlaceValue()
 						if kv.K.Kind() != InternalKeyKindSet {
 							fmtRecord(&kv.K, v)
-						} else if !isValueHandle(valuePrefix(v[0])) {
+						} else if !block.ValuePrefix(v[0]).IsValueHandle() {
 							fmtRecord(&kv.K, v[1:])
 						} else {
 							vh := decodeValueHandle(v[1:])

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cockroachdb/fifo"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
+	"github.com/cockroachdb/pebble/sstable/block"
 )
 
 // Compression is the per-block compression algorithm to use.
@@ -234,7 +235,7 @@ type WriterOptions struct {
 	BlockPropertyCollectors []func() BlockPropertyCollector
 
 	// Checksum specifies which checksum to use.
-	Checksum ChecksumType
+	Checksum block.ChecksumType
 
 	// Parallelism is used to indicate that the sstable Writer is allowed to
 	// compress data blocks and write datablocks to disk in parallel with the
@@ -292,8 +293,8 @@ func (o WriterOptions) ensureDefaults() WriterOptions {
 	if o.MergerName == "" {
 		o.MergerName = base.DefaultMerger.Name
 	}
-	if o.Checksum == ChecksumTypeNone {
-		o.Checksum = ChecksumTypeCRC32c
+	if o.Checksum == block.ChecksumTypeNone {
+		o.Checksum = block.ChecksumTypeCRC32c
 	}
 	// By default, if the table format is not specified, fall back to using the
 	// most compatible format that is supported by Pebble.

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -519,7 +519,7 @@ func (r *Reader) readBlock(
 	if h := r.opts.Cache.Get(r.cacheID, r.fileNum, bh.Offset); h.Get() != nil {
 		// Cache hit.
 		if readHandle != nil {
-			readHandle.RecordCacheHit(ctx, int64(bh.Offset), int64(bh.Length+blockTrailerLen))
+			readHandle.RecordCacheHit(ctx, int64(bh.Offset), int64(bh.Length+block.TrailerLen))
 		}
 		if stats != nil {
 			stats.BlockBytes += bh.Length
@@ -545,9 +545,9 @@ func (r *Reader) readBlock(
 
 	var compressed block.CacheValueOrBuf
 	if bufferPool != nil {
-		compressed = block.MakeBlockBuf(bufferPool.Alloc(int(bh.Length + blockTrailerLen)))
+		compressed = block.MakeBlockBuf(bufferPool.Alloc(int(bh.Length + block.TrailerLen)))
 	} else {
-		compressed = block.MakeCacheValue(cache.Alloc(int(bh.Length + blockTrailerLen)))
+		compressed = block.MakeCacheValue(cache.Alloc(int(bh.Length + block.TrailerLen)))
 	}
 
 	readStartTime := time.Now()
@@ -568,7 +568,7 @@ func (r *Reader) readBlock(
 	// interface{}, unless necessary.
 	if readDuration >= slowReadTracingThreshold && r.opts.LoggerAndTracer.IsTracingEnabled(ctx) {
 		r.opts.LoggerAndTracer.Eventf(ctx, "reading %d bytes took %s",
-			int(bh.Length+blockTrailerLen), readDuration.String())
+			int(bh.Length+block.TrailerLen), readDuration.String())
 	}
 	if stats != nil {
 		stats.BlockBytes += bh.Length
@@ -1087,7 +1087,7 @@ func (r *Reader) EstimateDiskUsage(start, end []byte) (uint64, error) {
 		return 0, errCorruptIndexEntry(err)
 	}
 	return includeInterpolatedValueBlocksSize(
-		endBH.Offset + endBH.Length + blockTrailerLen - startBH.Offset), nil
+		endBH.Offset + endBH.Length + block.TrailerLen - startBH.Offset), nil
 }
 
 // TableFormat returns the format version for the table.

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -200,7 +200,7 @@ type Reader struct {
 	tableFormat   TableFormat
 	rawTombstones bool
 	mergerOK      bool
-	checksumType  ChecksumType
+	checksumType  block.ChecksumType
 	// metaBufferPool is a buffer pool used exclusively when opening a table and
 	// loading its meta blocks. metaBufferPoolAlloc is used to batch-allocate
 	// the BufferPool.pool slice as a part of the Reader allocation. It's
@@ -473,14 +473,14 @@ func (r *Reader) readRangeKey(
 }
 
 func checkChecksum(
-	checksumType ChecksumType, b []byte, bh BlockHandle, fileNum base.DiskFileNum,
+	checksumType block.ChecksumType, b []byte, bh BlockHandle, fileNum base.DiskFileNum,
 ) error {
 	expectedChecksum := binary.LittleEndian.Uint32(b[bh.Length+1:])
 	var computedChecksum uint32
 	switch checksumType {
-	case ChecksumTypeCRC32c:
+	case block.ChecksumTypeCRC32c:
 		computedChecksum = crc.New(b[:bh.Length+1]).Value()
-	case ChecksumTypeXXHash64:
+	case block.ChecksumTypeXXHash64:
 		computedChecksum = uint32(xxhash.Sum64(b[:bh.Length+1]))
 	default:
 		return errors.Errorf("unsupported checksum type: %d", checksumType)

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -1411,7 +1411,7 @@ func TestRandomizedPrefixSuffixRewriter(t *testing.T) {
 }
 
 func TestReaderChecksumErrors(t *testing.T) {
-	for _, checksumType := range []ChecksumType{ChecksumTypeCRC32c, ChecksumTypeXXHash64} {
+	for _, checksumType := range []block.ChecksumType{block.ChecksumTypeCRC32c, block.ChecksumTypeXXHash64} {
 		t.Run(fmt.Sprintf("checksum-type=%d", checksumType), func(t *testing.T) {
 			for _, twoLevelIndex := range []bool{false, true} {
 				t.Run(fmt.Sprintf("two-level-index=%t", twoLevelIndex), func(t *testing.T) {

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -226,11 +226,11 @@ func rewriteBlocks(
 				if len(v) < 1 {
 					return errors.Errorf("value has no prefix")
 				}
-				prefix := valuePrefix(v[0])
-				if isValueHandle(prefix) {
+				prefix := block.ValuePrefix(v[0])
+				if prefix.IsValueHandle() {
 					return errors.Errorf("value prefix is incorrect")
 				}
-				if setHasSamePrefix(prefix) {
+				if prefix.SetHasSamePrefix() {
 					return errors.Errorf("multiple keys with same key prefix")
 				}
 			}

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -185,7 +185,6 @@ Data blocks have some additional features:
 */
 
 const (
-	blockTrailerLen                    = 5
 	blockHandleMaxLenWithoutProperties = 10 + 10
 	// blockHandleLikelyMaxLen can be used for pre-allocating buffers to
 	// reduce memory copies. It is not guaranteed that a block handle will not

--- a/sstable/value_block.go
+++ b/sstable/value_block.go
@@ -392,7 +392,7 @@ type valueBlockWriter struct {
 	// Configured compression.
 	compression Compression
 	// checksummer with configured checksum type.
-	checksummer checksummer
+	checksummer block.Checksummer
 	// Block finished callback.
 	blockFinishedFunc func(compressedSize int)
 
@@ -461,7 +461,7 @@ func newValueBlockWriter(
 	blockSize int,
 	blockSizeThreshold int,
 	compression Compression,
-	checksumType ChecksumType,
+	checksumType block.ChecksumType,
 	// compressedSize should exclude the block trailer.
 	blockFinishedFunc func(compressedSize int),
 ) *valueBlockWriter {
@@ -470,8 +470,8 @@ func newValueBlockWriter(
 		blockSize:          blockSize,
 		blockSizeThreshold: blockSizeThreshold,
 		compression:        compression,
-		checksummer: checksummer{
-			checksumType: checksumType,
+		checksummer: block.Checksummer{
+			Type: checksumType,
 		},
 		blockFinishedFunc: blockFinishedFunc,
 		buf:               uncompressedValueBlockBufPool.Get().(*blockBuffer),
@@ -594,7 +594,7 @@ func (w *valueBlockWriter) compressAndFlush() {
 
 func (w *valueBlockWriter) computeChecksum(block []byte) {
 	n := len(block) - blockTrailerLen
-	checksum := w.checksummer.checksum(block[:n], block[n:n+1])
+	checksum := w.checksummer.Checksum(block[:n], block[n:n+1])
 	binary.LittleEndian.PutUint32(block[n+1:], checksum)
 }
 

--- a/sstable/value_block_test.go
+++ b/sstable/value_block_test.go
@@ -10,7 +10,6 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,48 +24,6 @@ func TestValueHandleEncodeDecode(t *testing.T) {
 			n := encodeValueHandle(buf[:], tc)
 			vh := decodeValueHandle(buf[:n])
 			require.Equal(t, tc, vh)
-		})
-	}
-}
-
-func TestValuePrefix(t *testing.T) {
-	testCases := []struct {
-		isHandle         bool
-		setHasSamePrefix bool
-		attr             base.ShortAttribute
-	}{
-		{
-			isHandle:         false,
-			setHasSamePrefix: false,
-		},
-		{
-			isHandle:         false,
-			setHasSamePrefix: true,
-		},
-		{
-			isHandle:         true,
-			setHasSamePrefix: false,
-			attr:             5,
-		},
-		{
-			isHandle:         true,
-			setHasSamePrefix: true,
-			attr:             2,
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%+v", tc), func(t *testing.T) {
-			var prefix valuePrefix
-			if tc.isHandle {
-				prefix = makePrefixForValueHandle(tc.setHasSamePrefix, tc.attr)
-			} else {
-				prefix = makePrefixForInPlaceValue(tc.setHasSamePrefix)
-			}
-			require.Equal(t, tc.isHandle, isValueHandle(prefix))
-			require.Equal(t, tc.setHasSamePrefix, setHasSamePrefix(prefix))
-			if tc.isHandle {
-				require.Equal(t, tc.attr, getShortAttribute(prefix))
-			}
 		})
 	}
 }

--- a/sstable/write_queue.go
+++ b/sstable/write_queue.go
@@ -63,7 +63,7 @@ func (w *writeQueue) performWrite(task *writeTask) error {
 	var bhp BlockHandleWithProperties
 
 	var err error
-	if bh, err = w.writer.writeCompressedBlock(task.buf.compressed, task.buf.tmp[:]); err != nil {
+	if bh, err = w.writer.writeCompressedBlock(task.buf.compressed, task.buf.trailer); err != nil {
 		return err
 	}
 

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -937,7 +937,7 @@ func (w *Writer) addPoint(key InternalKey, value []byte, forceObsolete bool) err
 	isObsolete = w.tableFormat >= TableFormatPebblev4 && (isObsolete || forceObsolete)
 	w.lastPointKeyInfo.isObsolete = isObsolete
 	var valueStoredWithKey []byte
-	var prefix valuePrefix
+	var prefix block.ValuePrefix
 	var valueStoredWithKeyLen int
 	if writeToValueBlock {
 		vh, err := w.valueBlockWriter.addValue(value)
@@ -958,14 +958,14 @@ func (w *Writer) addPoint(key InternalKey, value []byte, forceObsolete bool) err
 				return err
 			}
 		}
-		prefix = makePrefixForValueHandle(setHasSameKeyPrefix, attribute)
+		prefix = block.ValueHandlePrefix(setHasSameKeyPrefix, attribute)
 	} else {
 		valueStoredWithKey = value
 		valueStoredWithKeyLen = len(value)
 		if addPrefixToValueStoredWithKey {
 			valueStoredWithKeyLen++
 		}
-		prefix = makePrefixForInPlaceValue(setHasSameKeyPrefix)
+		prefix = block.InPlaceValuePrefix(setHasSameKeyPrefix)
 	}
 
 	if err := w.maybeFlush(key, valueStoredWithKeyLen); err != nil {

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -344,10 +344,10 @@ func TestWriterWithValueBlocks(t *testing.T) {
 			for valid := iter.First(); valid; valid = iter.Next() {
 				v := iter.Value()
 				if iter.Key().Kind() == InternalKeyKindSet {
-					prefix := valuePrefix(v[0])
-					setWithSamePrefix := setHasSamePrefix(prefix)
-					if isValueHandle(prefix) {
-						attribute := getShortAttribute(prefix)
+					prefix := block.ValuePrefix(v[0])
+					setWithSamePrefix := prefix.SetHasSamePrefix()
+					if prefix.IsValueHandle() {
+						attribute := prefix.ShortAttribute()
 						vh := decodeValueHandle(v[1:])
 						fmt.Fprintf(&buf, "%s:value-handle len %d block %d offset %d, att %d, same-pre %t\n",
 							iter.Key(), vh.valueLen, vh.blockNum, vh.offsetInBlock, attribute, setWithSamePrefix)

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
@@ -434,7 +435,7 @@ func TestBlockBufClear(t *testing.T) {
 }
 
 func TestClearDataBlockBuf(t *testing.T) {
-	d := newDataBlockBuf(1, ChecksumTypeCRC32c)
+	d := newDataBlockBuf(1, block.ChecksumTypeCRC32c)
 	d.blockBuf.compressedBuf = make([]byte, 1)
 	d.dataBlock.add(ikey("apple"), nil)
 	d.dataBlock.add(ikey("banana"), nil)


### PR DESCRIPTION
**sstable/block: move Checksummer, ChecksumType**

Move sstable.ChecksumType and sstable.Checksummer types into the sstable/block
package.

**sstable/block: add Trailer type**

Add a fixed-width block.Trailer type, and use it to avoid subtle usage of
blockBuf.tmp to pass encoded trailers.

**sstable/block: clean up cache.Value and BufferPool union**
    
Clean up the block.CacheValueOrBuf union type, renaming it to block.Value and
adding a single block.Alloc entry point for constructing values.