### PR TITLE
base: rename Trailer to InternalKeyTrailer

### DIFF
--- a/internal.go
+++ b/internal.go
@@ -6,6 +6,9 @@ package pebble
 
 import "github.com/cockroachdb/pebble/internal/base"
 
+// SeqNum exports the base.SeqNum type.
+type SeqNum = base.SeqNum
+
 // InternalKeyKind exports the base.InternalKeyKind type.
 type InternalKeyKind = base.InternalKeyKind
 
@@ -32,11 +35,17 @@ const (
 	InternalKeyRangeDeleteSentinel = base.InternalKeyRangeDeleteSentinel
 )
 
+// InternalKeyTrailer exports the base.InternalKeyTrailer type.
+type InternalKeyTrailer = base.InternalKeyTrailer
+
 // InternalKey exports the base.InternalKey type.
 type InternalKey = base.InternalKey
 
-// SeqNum exports the base.SeqNum type.
-type SeqNum = base.SeqNum
+// MakeInternalKey constructs an internal key from a specified user key,
+// sequence number and kind.
+func MakeInternalKey(userKey []byte, seqNum SeqNum, kind InternalKeyKind) InternalKey {
+	return base.MakeInternalKey(userKey, seqNum, kind)
+}
 
 type internalIterator = base.InternalIterator
 

--- a/internal/arenaskl/node.go
+++ b/internal/arenaskl/node.go
@@ -47,7 +47,7 @@ type node struct {
 	// Immutable fields, so no need to lock to access key.
 	keyOffset  uint32
 	keySize    uint32
-	keyTrailer base.Trailer
+	keyTrailer base.InternalKeyTrailer
 	valueSize  uint32
 	allocSize  uint32
 

--- a/internal/compact/iterator.go
+++ b/internal/compact/iterator.go
@@ -167,7 +167,7 @@ type Iter struct {
 	rangeKeyCompactor RangeKeySpanCompactor
 	err               error
 	// `key.UserKey` is set to `keyBuf` caused by saving `i.iterKV.UserKey`
-	// and `key.Trailer` is set to `i.iterKV.Trailer`. This is the
+	// and `key.InternalKeyTrailer` is set to `i.iterKV.InternalKeyTrailer`. This is the
 	// case on return from all public methods -- these methods return `key`.
 	// Additionally, it is the internal state when the code is moving to the
 	// next key so it can determine whether the user key has changed from
@@ -176,7 +176,7 @@ type Iter struct {
 	// keyTrailer is updated when `i.key` is updated and holds the key's
 	// original trailer (eg, before any sequence-number zeroing or changes to
 	// key kind).
-	keyTrailer  base.Trailer
+	keyTrailer  base.InternalKeyTrailer
 	value       []byte
 	valueCloser io.Closer
 	// Temporary buffer used for storing the previous user key in order to

--- a/internal/keyspan/fragmenter.go
+++ b/internal/keyspan/fragmenter.go
@@ -184,7 +184,7 @@ func (f *Fragmenter) checkInvariants(buf []Span) {
 // stability, typically callers only need to perform a shallow clone of the Span
 // before Add-ing it to the fragmenter.
 //
-// Add requires the provided span's keys are sorted in Trailer descending order.
+// Add requires the provided span's keys are sorted in InternalKeyTrailer descending order.
 func (f *Fragmenter) Add(s Span) {
 	if f.finished {
 		panic("pebble: span fragmenter already finished")

--- a/internal/keyspan/keyspanimpl/merging_iter.go
+++ b/internal/keyspan/keyspanimpl/merging_iter.go
@@ -200,7 +200,7 @@ type MergingIter struct {
 // MergingBuffers holds buffers used while merging keyspans.
 type MergingBuffers struct {
 	// keys holds all of the keys across all levels that overlap the key span
-	// [start, end), sorted by Trailer descending. This slice is reconstituted
+	// [start, end), sorted by InternalKeyTrailer descending. This slice is reconstituted
 	// in synthesizeKeys from each mergingIterLevel's keys every time the
 	// [start, end) bounds change.
 	//

--- a/internal/keyspan/span.go
+++ b/internal/keyspan/span.go
@@ -47,7 +47,7 @@ type Span struct {
 type KeysOrder int8
 
 const (
-	// ByTrailerDesc indicates a Span's keys are sorted by Trailer descending.
+	// ByTrailerDesc indicates a Span's keys are sorted by InternalKeyTrailer descending.
 	// This is the default ordering, and the ordering used during physical
 	// storage.
 	ByTrailerDesc KeysOrder = iota
@@ -61,7 +61,7 @@ const (
 // is applied.
 type Key struct {
 	// Trailer contains the key kind and sequence number.
-	Trailer base.Trailer
+	Trailer base.InternalKeyTrailer
 	// Suffix holds an optional suffix associated with the key. This is only
 	// non-nil for RANGEKEYSET and RANGEKEYUNSET keys.
 	Suffix []byte

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -1685,7 +1685,7 @@ func CheckOrdering(cmp Compare, format base.FormatKey, level Level, files LevelI
 				// In all supported format major version, split user keys are
 				// prohibited, so both files cannot contain keys with the same user
 				// keys. If the bounds have the same user key, the previous file's
-				// boundary must have a Trailer indicating that it's exclusive.
+				// boundary must have a InternalKeyTrailer indicating that it's exclusive.
 				if v := cmp(prev.Largest.UserKey, f.Smallest.UserKey); v > 0 || (v == 0 && !prev.Largest.IsExclusiveSentinel()) {
 					return base.CorruptionErrorf("%s files %s and %s have overlapping ranges: [%s-%s] vs [%s-%s]",
 						errors.Safe(level), errors.Safe(prev.FileNum), errors.Safe(f.FileNum),

--- a/internal/rangekey/coalesce.go
+++ b/internal/rangekey/coalesce.go
@@ -48,7 +48,7 @@ import (
 // consistent with respect to the set/unset suffixes: A given suffix should be
 // set or unset but not both.
 //
-// The resulting dst Keys slice is sorted by Trailer.
+// The resulting dst Keys slice is sorted by InternalKeyTrailer.
 func Coalesce(cmp base.Compare, eq base.Equal, keys []keyspan.Key, dst *[]keyspan.Key) {
 	// TODO(jackson): Currently, Coalesce doesn't actually perform the sequence
 	// number promotion described in the comment above.
@@ -101,7 +101,7 @@ func CoalesceIntoKeysBySuffix(
 	// suffix, in which case the one with a larger trailer survives.
 	//
 	// We use a stable sort so that the first key with a given suffix is the one
-	// that with the highest Trailer (because the input `keys` was sorted by
+	// that with the highest InternalKeyTrailer (because the input `keys` was sorted by
 	// trailer descending).
 	sort.Stable(keysBySuffix)
 
@@ -125,7 +125,7 @@ func CoalesceIntoKeysBySuffix(
 	for i := range sorted {
 		if i > 0 && equal(prevSuffix, sorted[i].Suffix) {
 			// Skip; this key is shadowed by the predecessor that had a larger
-			// Trailer. If this is the first shadowed key, set shadowing=true
+			// InternalKeyTrailer. If this is the first shadowed key, set shadowing=true
 			// and reslice keysBySuffix.keys to hold the entire unshadowed
 			// prefix.
 			if !shadowing {

--- a/iterator.go
+++ b/iterator.go
@@ -766,7 +766,7 @@ func (i *Iterator) nextUserKey() {
 		// NB: We're guaranteed to be on the next user key if the previous key
 		// had a zero sequence number (`done`), or the new key has a trailer
 		// greater or equal to the previous key's trailer. This is true because
-		// internal keys with the same user key are sorted by Trailer in
+		// internal keys with the same user key are sorted by InternalKeyTrailer in
 		// strictly monotonically descending order. We expect the trailer
 		// optimization to trigger around 50% of the time with randomly
 		// distributed writes. We expect it to trigger very frequently when

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -1020,7 +1020,7 @@ func (i *scanInternalIterator) constructRangeKeyIter() error {
 	// NB: We iterate L0's files in reverse order. They're sorted by
 	// LargestSeqNum ascending, and we need to add them to the merging iterator
 	// in LargestSeqNum descending to preserve the merging iterator's invariants
-	// around Key Trailer order.
+	// around Key InternalKeyTrailer order.
 	iter := current.RangeKeyLevels[0].Iter()
 	for f := iter.Last(); f != nil; f = iter.Prev() {
 		spanIter, err := i.newIterRangeKey(f, i.opts.SpanIterOptions())

--- a/sstable/block_iter.go
+++ b/sstable/block_iter.go
@@ -436,14 +436,14 @@ func (i *blockIter) readFirstKey() error {
 
 // The sstable internal obsolete bit is set when writing a block and unset by
 // blockIter, so no code outside block writing/reading code ever sees it.
-const trailerObsoleteBit = base.Trailer(base.InternalKeyKindSSTableInternalObsoleteBit)
-const trailerObsoleteMask = (base.Trailer(InternalKeySeqNumMax) << 8) | base.Trailer(base.InternalKeyKindSSTableInternalObsoleteMask)
+const trailerObsoleteBit = base.InternalKeyTrailer(base.InternalKeyKindSSTableInternalObsoleteBit)
+const trailerObsoleteMask = (base.InternalKeyTrailer(InternalKeySeqNumMax) << 8) | base.InternalKeyTrailer(base.InternalKeyKindSSTableInternalObsoleteMask)
 
 func (i *blockIter) decodeInternalKey(key []byte) (hiddenPoint bool) {
 	// Manually inlining base.DecodeInternalKey provides a 5-10% speedup on
 	// BlockIter benchmarks.
 	if n := len(key) - 8; n >= 0 {
-		trailer := base.Trailer(binary.LittleEndian.Uint64(key[n:]))
+		trailer := base.InternalKeyTrailer(binary.LittleEndian.Uint64(key[n:]))
 		hiddenPoint = i.transforms.HideObsoletePoints &&
 			(trailer&trailerObsoleteBit != 0)
 		i.ikv.K.Trailer = trailer & trailerObsoleteMask
@@ -452,7 +452,7 @@ func (i *blockIter) decodeInternalKey(key []byte) (hiddenPoint bool) {
 			i.ikv.K.SetSeqNum(base.SeqNum(n))
 		}
 	} else {
-		i.ikv.K.Trailer = base.Trailer(InternalKeyKindInvalid)
+		i.ikv.K.Trailer = base.InternalKeyTrailer(InternalKeyKindInvalid)
 		i.ikv.K.UserKey = nil
 	}
 	return hiddenPoint
@@ -1043,7 +1043,7 @@ start:
 	i.readEntry()
 	// Manually inlined version of i.decodeInternalKey(i.key).
 	if n := len(i.key) - 8; n >= 0 {
-		trailer := base.Trailer(binary.LittleEndian.Uint64(i.key[n:]))
+		trailer := base.InternalKeyTrailer(binary.LittleEndian.Uint64(i.key[n:]))
 		hiddenPoint := i.transforms.HideObsoletePoints &&
 			(trailer&trailerObsoleteBit != 0)
 		i.ikv.K.Trailer = trailer & trailerObsoleteMask
@@ -1062,7 +1062,7 @@ start:
 			i.ikv.K.UserKey = i.synthSuffixBuf
 		}
 	} else {
-		i.ikv.K.Trailer = base.Trailer(InternalKeyKindInvalid)
+		i.ikv.K.Trailer = base.InternalKeyTrailer(InternalKeyKindInvalid)
 		i.ikv.K.UserKey = nil
 	}
 	if !i.lazyValueHandling.hasValuePrefix ||
@@ -1323,7 +1323,7 @@ func (i *blockIter) nextPrefixV3(succKey []byte) *base.InternalKV {
 		// Manually inlined version of i.decodeInternalKey(i.key).
 		hiddenPoint := false
 		if n := len(i.key) - 8; n >= 0 {
-			trailer := base.Trailer(binary.LittleEndian.Uint64(i.key[n:]))
+			trailer := base.InternalKeyTrailer(binary.LittleEndian.Uint64(i.key[n:]))
 			hiddenPoint = i.transforms.HideObsoletePoints &&
 				(trailer&trailerObsoleteBit != 0)
 			i.ikv.K = base.InternalKey{
@@ -1341,7 +1341,7 @@ func (i *blockIter) nextPrefixV3(succKey []byte) *base.InternalKV {
 				i.ikv.K.UserKey = i.synthSuffixBuf
 			}
 		} else {
-			i.ikv.K.Trailer = base.Trailer(InternalKeyKindInvalid)
+			i.ikv.K.Trailer = base.InternalKeyTrailer(InternalKeyKindInvalid)
 			i.ikv.K.UserKey = nil
 		}
 		nextCmpCount++
@@ -1387,7 +1387,7 @@ start:
 		// Manually inlined version of i.decodeInternalKey(i.key).
 		i.key = i.cachedBuf[e.keyStart:e.keyEnd]
 		if n := len(i.key) - 8; n >= 0 {
-			trailer := base.Trailer(binary.LittleEndian.Uint64(i.key[n:]))
+			trailer := base.InternalKeyTrailer(binary.LittleEndian.Uint64(i.key[n:]))
 			hiddenPoint := i.transforms.HideObsoletePoints &&
 				(trailer&trailerObsoleteBit != 0)
 			if hiddenPoint {
@@ -1410,7 +1410,7 @@ start:
 				i.ikv.K.UserKey = i.synthSuffixBuf
 			}
 		} else {
-			i.ikv.K.Trailer = base.Trailer(InternalKeyKindInvalid)
+			i.ikv.K.Trailer = base.InternalKeyTrailer(InternalKeyKindInvalid)
 			i.ikv.K.UserKey = nil
 		}
 		i.cached = i.cached[:n]

--- a/sstable/block_test.go
+++ b/sstable/block_test.go
@@ -147,7 +147,7 @@ func TestInvalidInternalKeyDecoding(t *testing.T) {
 		i := blockIter{}
 		i.decodeInternalKey([]byte(tc))
 		require.Nil(t, i.ikv.K.UserKey)
-		require.Equal(t, base.Trailer(InternalKeyKindInvalid), i.ikv.K.Trailer)
+		require.Equal(t, base.InternalKeyTrailer(InternalKeyKindInvalid), i.ikv.K.Trailer)
 	}
 }
 

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -227,7 +227,7 @@ type Writer struct {
 }
 
 type pointKeyInfo struct {
-	trailer base.Trailer
+	trailer base.InternalKeyTrailer
 	// Only computed when w.valueBlockWriter is not nil.
 	userKeyLen int
 	// prefixLen uses w.split, if not nil. Only computed when w.valueBlockWriter


### PR DESCRIPTION
This type needs to be used by Cockroach and is now exported as
`pebble.InternalKeyTrailer`.