### PR TITLE
sstable/rowblk: new package

### DIFF
--- a/sstable/block_iter.go
+++ b/sstable/block_iter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/manual"
 	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/sstable/rowblk"
 )
 
 // blockIter is an iterator over a single block of data.
@@ -435,19 +436,14 @@ func (i *blockIter) readFirstKey() error {
 	return nil
 }
 
-// The sstable internal obsolete bit is set when writing a block and unset by
-// blockIter, so no code outside block writing/reading code ever sees it.
-const trailerObsoleteBit = base.InternalKeyTrailer(base.InternalKeyKindSSTableInternalObsoleteBit)
-const trailerObsoleteMask = (base.InternalKeyTrailer(base.SeqNumMax) << 8) | base.InternalKeyTrailer(base.InternalKeyKindSSTableInternalObsoleteMask)
-
 func (i *blockIter) decodeInternalKey(key []byte) (hiddenPoint bool) {
 	// Manually inlining base.DecodeInternalKey provides a 5-10% speedup on
 	// BlockIter benchmarks.
 	if n := len(key) - 8; n >= 0 {
 		trailer := base.InternalKeyTrailer(binary.LittleEndian.Uint64(key[n:]))
 		hiddenPoint = i.transforms.HideObsoletePoints &&
-			(trailer&trailerObsoleteBit != 0)
-		i.ikv.K.Trailer = trailer & trailerObsoleteMask
+			(trailer&rowblk.TrailerObsoleteBit != 0)
+		i.ikv.K.Trailer = trailer & rowblk.TrailerObsoleteMask
 		i.ikv.K.UserKey = key[:n:n]
 		if n := i.transforms.SyntheticSeqNum; n != 0 {
 			i.ikv.K.SetSeqNum(base.SeqNum(n))
@@ -975,6 +971,9 @@ func (i *blockIter) First() *base.InternalKV {
 	return &i.ikv
 }
 
+const restartMaskLittleEndianHighByteWithoutSetHasSamePrefix byte = 0b0111_1111
+const restartMaskLittleEndianHighByteOnlySetHasSamePrefix byte = 0b1000_0000
+
 func decodeRestart(b []byte) int32 {
 	_ = b[3] // bounds check hint to compiler; see golang.org/issue/14808
 	return int32(uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 |
@@ -1046,8 +1045,8 @@ start:
 	if n := len(i.key) - 8; n >= 0 {
 		trailer := base.InternalKeyTrailer(binary.LittleEndian.Uint64(i.key[n:]))
 		hiddenPoint := i.transforms.HideObsoletePoints &&
-			(trailer&trailerObsoleteBit != 0)
-		i.ikv.K.Trailer = trailer & trailerObsoleteMask
+			(trailer&rowblk.TrailerObsoleteBit != 0)
+		i.ikv.K.Trailer = trailer & rowblk.TrailerObsoleteMask
 		i.ikv.K.UserKey = i.key[:n:n]
 		if n := i.transforms.SyntheticSeqNum; n != 0 {
 			i.ikv.K.SetSeqNum(base.SeqNum(n))
@@ -1326,9 +1325,9 @@ func (i *blockIter) nextPrefixV3(succKey []byte) *base.InternalKV {
 		if n := len(i.key) - 8; n >= 0 {
 			trailer := base.InternalKeyTrailer(binary.LittleEndian.Uint64(i.key[n:]))
 			hiddenPoint = i.transforms.HideObsoletePoints &&
-				(trailer&trailerObsoleteBit != 0)
+				(trailer&rowblk.TrailerObsoleteBit != 0)
 			i.ikv.K = base.InternalKey{
-				Trailer: trailer & trailerObsoleteMask,
+				Trailer: trailer & rowblk.TrailerObsoleteMask,
 				UserKey: i.key[:n:n],
 			}
 			if n := i.transforms.SyntheticSeqNum; n != 0 {
@@ -1390,12 +1389,12 @@ start:
 		if n := len(i.key) - 8; n >= 0 {
 			trailer := base.InternalKeyTrailer(binary.LittleEndian.Uint64(i.key[n:]))
 			hiddenPoint := i.transforms.HideObsoletePoints &&
-				(trailer&trailerObsoleteBit != 0)
+				(trailer&rowblk.TrailerObsoleteBit != 0)
 			if hiddenPoint {
 				continue
 			}
 			i.ikv.K = base.InternalKey{
-				Trailer: trailer & trailerObsoleteMask,
+				Trailer: trailer & rowblk.TrailerObsoleteMask,
 				UserKey: i.key[:n:n],
 			}
 			if n := i.transforms.SyntheticSeqNum; n != 0 {

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -9,7 +9,11 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/sstable/rowblk"
 )
+
+// MaximumBlockSize is the maximum permissible size of a block.
+const MaximumBlockSize = rowblk.MaximumSize
 
 // Compression is the per-block compression algorithm to use.
 type Compression int

--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -13,7 +13,9 @@ import (
 	"sort"
 	"unsafe"
 
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/intern"
+	"github.com/cockroachdb/pebble/sstable/rowblk"
 )
 
 const propertiesBlockRestartInterval = math.MaxInt32
@@ -326,7 +328,7 @@ func (p *Properties) saveString(m map[string][]byte, offset uintptr, value strin
 	m[propOffsetTagMap[offset]] = []byte(value)
 }
 
-func (p *Properties) save(tblFormat TableFormat, w *rawBlockWriter) {
+func (p *Properties) save(tblFormat TableFormat, w *rowblk.RawWriter) {
 	m := make(map[string][]byte)
 	for k, v := range p.UserProperties {
 		m[k] = []byte(v)
@@ -419,6 +421,6 @@ func (p *Properties) save(tblFormat TableFormat, w *rawBlockWriter) {
 	}
 	sort.Strings(keys)
 	for _, key := range keys {
-		w.add(InternalKey{UserKey: []byte(key)}, m[key])
+		w.Add(base.InternalKey{UserKey: []byte(key)}, m[key])
 	}
 }

--- a/sstable/properties_test.go
+++ b/sstable/properties_test.go
@@ -14,6 +14,7 @@ import (
 	"testing/quick"
 	"time"
 
+	"github.com/cockroachdb/pebble/sstable/rowblk"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
 )
@@ -95,12 +96,12 @@ func TestPropertiesSave(t *testing.T) {
 
 	check1 := func(e *Properties) {
 		// Check that we can save properties and read them back.
-		var w rawBlockWriter
-		w.restartInterval = propertiesBlockRestartInterval
+		var w rowblk.RawWriter
+		w.RestartInterval = propertiesBlockRestartInterval
 		e.save(TableFormatPebblev2, &w)
 		var props Properties
 
-		require.NoError(t, props.load(w.finish(), 0, make(map[string]struct{})))
+		require.NoError(t, props.load(w.Finish(), 0, make(map[string]struct{})))
 		props.Loaded = nil
 		if diff := pretty.Diff(*e, props); diff != nil {
 			t.Fatalf("%s", strings.Join(diff, "\n"))
@@ -122,10 +123,10 @@ func TestPropertiesSave(t *testing.T) {
 }
 
 func BenchmarkPropertiesLoad(b *testing.B) {
-	var w rawBlockWriter
-	w.restartInterval = propertiesBlockRestartInterval
+	var w rowblk.RawWriter
+	w.RestartInterval = propertiesBlockRestartInterval
 	testProps.save(TableFormatPebblev2, &w)
-	block := w.finish()
+	block := w.Finish()
 
 	b.ResetTimer()
 	p := &Properties{}

--- a/sstable/raw_block.go
+++ b/sstable/raw_block.go
@@ -12,24 +12,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 )
 
-type rawBlockWriter struct {
-	blockWriter
-}
-
-func (w *rawBlockWriter) add(key InternalKey, value []byte) {
-	w.curKey, w.prevKey = w.prevKey, w.curKey
-
-	size := len(key.UserKey)
-	if cap(w.curKey) < size {
-		w.curKey = make([]byte, 0, size*2)
-	}
-	w.curKey = w.curKey[:size]
-	copy(w.curKey, key.UserKey)
-
-	w.storeWithOptionalValuePrefix(
-		size, value, len(key.UserKey), false, 0, false)
-}
-
 // rawBlockIter is an iterator over a single block of data. Unlike blockIter,
 // keys are stored in "raw" format (i.e. not as internal keys). Note that there
 // is significant similarity between this code and the code in blockIter. Yet

--- a/sstable/rowblk/rowblk_test.go
+++ b/sstable/rowblk/rowblk_test.go
@@ -1,0 +1,126 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package rowblk
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/stretchr/testify/require"
+)
+
+func testBlockCleared(t *testing.T, w, b *Writer) {
+	require.Equal(t, w.RestartInterval, b.RestartInterval)
+	require.Equal(t, w.nEntries, b.nEntries)
+	require.Equal(t, w.nextRestart, b.nextRestart)
+	require.Equal(t, len(w.buf), len(b.buf))
+	require.Equal(t, len(w.restarts), len(b.restarts))
+	require.Equal(t, len(w.curKey), len(b.curKey))
+	require.Equal(t, len(w.prevKey), len(b.prevKey))
+	require.Equal(t, len(w.curValue), len(b.curValue))
+	require.Equal(t, w.tmp, b.tmp)
+
+	// Make sure that we didn't lose the allocated byte slices.
+	require.True(t, cap(w.buf) > 0 && cap(b.buf) == 0)
+	require.True(t, cap(w.restarts) > 0 && cap(b.restarts) == 0)
+	require.True(t, cap(w.curKey) > 0 && cap(b.curKey) == 0)
+	require.True(t, cap(w.prevKey) > 0 && cap(b.prevKey) == 0)
+	require.True(t, cap(w.curValue) > 0 && cap(b.curValue) == 0)
+}
+
+func TestBlockClear(t *testing.T) {
+	w := Writer{RestartInterval: 16}
+	w.Add(ikey("apple"), nil)
+	w.Add(ikey("apricot"), nil)
+	w.Add(ikey("banana"), nil)
+
+	w.Reset()
+
+	// Once a block is cleared, we expect its fields to be cleared, but we expect
+	// it to keep its allocated byte slices.
+	b := Writer{}
+	testBlockCleared(t, &w, &b)
+}
+
+func TestBlockWriter(t *testing.T) {
+	w := &RawWriter{Writer: Writer{RestartInterval: 16}}
+	w.Add(ikey("apple"), nil)
+	w.Add(ikey("apricot"), nil)
+	w.Add(ikey("banana"), nil)
+	block := w.Finish()
+
+	expected := []byte(
+		"\x00\x05\x00apple" +
+			"\x02\x05\x00ricot" +
+			"\x00\x06\x00banana" +
+			"\x00\x00\x00\x00\x01\x00\x00\x00")
+	if !bytes.Equal(expected, block) {
+		t.Fatalf("expected\n%q\nfound\n%q", expected, block)
+	}
+}
+
+func TestBlockWriterWithPrefix(t *testing.T) {
+	w := &RawWriter{Writer: Writer{RestartInterval: 2}}
+	curKey := func() string {
+		return string(base.DecodeInternalKey(w.curKey).UserKey)
+	}
+	addAdapter := func(
+		key base.InternalKey,
+		value []byte,
+		addValuePrefix bool,
+		valuePrefix block.ValuePrefix,
+		setHasSameKeyPrefix bool) {
+		w.AddWithOptionalValuePrefix(
+			key, false, value, len(key.UserKey), addValuePrefix, valuePrefix, setHasSameKeyPrefix)
+	}
+	addAdapter(
+		ikey("apple"), []byte("red"), false, 0, true)
+	require.Equal(t, "apple", curKey())
+	require.Equal(t, "red", string(w.CurValue()))
+	addAdapter(
+		ikey("apricot"), []byte("orange"), true, '\xff', false)
+	require.Equal(t, "apricot", curKey())
+	require.Equal(t, "orange", string(w.CurValue()))
+	// Even though this call has setHasSameKeyPrefix=true, the previous call,
+	// which was after the last restart set it to false. So the restart encoded
+	// with banana has this cumulative bit set to false.
+	addAdapter(
+		ikey("banana"), []byte("yellow"), true, '\x00', true)
+	require.Equal(t, "banana", curKey())
+	require.Equal(t, "yellow", string(w.CurValue()))
+	addAdapter(
+		ikey("cherry"), []byte("red"), false, 0, true)
+	require.Equal(t, "cherry", curKey())
+	require.Equal(t, "red", string(w.CurValue()))
+	// All intervening calls has setHasSameKeyPrefix=true, so the cumulative bit
+	// will be set to true in this restart.
+	addAdapter(
+		ikey("mango"), []byte("juicy"), false, 0, true)
+	require.Equal(t, "mango", curKey())
+	require.Equal(t, "juicy", string(w.CurValue()))
+
+	blk := w.Finish()
+
+	expected := []byte(
+		"\x00\x0d\x03apple\x00\x00\x00\x00\x00\x00\x00\x00red" +
+			"\x02\x0d\x07ricot\x00\x00\x00\x00\x00\x00\x00\x00\xfforange" +
+			"\x00\x0e\x07banana\x00\x00\x00\x00\x00\x00\x00\x00\x00yellow" +
+			"\x00\x0e\x03cherry\x00\x00\x00\x00\x00\x00\x00\x00red" +
+			"\x00\x0d\x05mango\x00\x00\x00\x00\x00\x00\x00\x00juicy" +
+			// Restarts are:
+			// 00000000 (restart at apple), 2a000000 (restart at banana), 56000080 (restart at mango)
+			// 03000000 (number of restart, i.e., 3). The restart at mango has 1 in the most significant
+			// bit of the uint32, so the last byte in the little endian encoding is \x80.
+			"\x00\x00\x00\x00\x2a\x00\x00\x00\x56\x00\x00\x80\x03\x00\x00\x00")
+	if !bytes.Equal(expected, blk) {
+		t.Fatalf("expected\n%x\nfound\n%x", expected, blk)
+	}
+}
+
+func ikey(s string) base.InternalKey {
+	return base.InternalKey{UserKey: []byte(s)}
+}


### PR DESCRIPTION
Move the blockWriter and rawBlockWriter types into a new sstable/rowblk package for organizing code specific to the row-oriented block format.