### PR TITLE
crdbtest: tolerate empty keys in the comparer

### DIFF
--- a/internal/crdbtest/crdbtest.go
+++ b/internal/crdbtest/crdbtest.go
@@ -167,6 +167,10 @@ func Split(key []byte) int {
 // Compare compares cockroach keys, including the version (which could be MVCC
 // timestamps).
 func Compare(a, b []byte) int {
+	if len(a) == 0 || len(b) == 0 {
+		return bytes.Compare(a, b)
+	}
+
 	// NB: For performance, this routine manually splits the key into the
 	// user-key and version components rather than using DecodeEngineKey. In
 	// most situations, use DecodeEngineKey or GetKeyPartFromEngineKey or


### PR DESCRIPTION
The compaction picker compares keys to the empty key, so it must be
supported by the Compare function. We recently made this function more
strict but we have to account for the empty key case.

This was causing some nightly benchmarks to error out.