### PR TITLE
sstable: use MaybeScanArgs for global seq num

### DIFF
--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -249,23 +249,6 @@ func runBuildRawCmd(
 	return meta, r, nil
 }
 
-func scanGlobalSeqNum(td *datadriven.TestData) (uint64, error) {
-	for _, arg := range td.CmdArgs {
-		switch arg.Key {
-		case "globalSeqNum":
-			if len(arg.Vals) != 1 {
-				return 0, errors.Errorf("%s: arg %s expects 1 value", td.Cmd, arg.Key)
-			}
-			v, err := strconv.Atoi(arg.Vals[0])
-			if err != nil {
-				return 0, err
-			}
-			return uint64(v), nil
-		}
-	}
-	return 0, nil
-}
-
 type runIterCmdOption func(*runIterCmdOptions)
 
 type runIterCmdOptions struct {

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -770,13 +770,11 @@ func runTestReader(t *testing.T, o WriterOptions, dir string, r *Reader, printVa
 				return ""
 
 			case "iter":
-				seqNum, err := scanGlobalSeqNum(d)
-				if err != nil {
-					return err.Error()
-				}
+				var globalSeqNum uint64
+				d.MaybeScanArgs(t, "globalSeqNum", &globalSeqNum)
 				var stats base.InternalIteratorStats
 				transforms := IterTransforms{
-					SyntheticSeqNum: SyntheticSeqNum(seqNum),
+					SyntheticSeqNum: SyntheticSeqNum(globalSeqNum),
 				}
 				var bpfs []BlockPropertyFilter
 				if d.HasArg("block-property-filter") {


### PR DESCRIPTION
Use the datadriven package's MaybeScanArgs helper to scan the global sequence number, removing some test code duplication.