### PR TITLE
sstable: fix a few lint issues

### DIFF
--- a/sstable/internal.go
+++ b/sstable/internal.go
@@ -6,15 +6,6 @@ package sstable
 
 import "github.com/cockroachdb/pebble/internal/base"
 
-// InternalKeyKind exports the base.InternalKeyKind type.
-type InternalKeyKind = base.InternalKeyKind
-
-// SeekGEFlags exports base.SeekGEFlags.
-type SeekGEFlags = base.SeekGEFlags
-
-// SeekLTFlags exports base.SeekLTFlags.
-type SeekLTFlags = base.SeekLTFlags
-
 // These constants are part of the file format, and should not be changed.
 const (
 	InternalKeyKindDelete        = base.InternalKeyKindDelete

--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -255,9 +255,7 @@ func (p *Properties) String() string {
 	return buf.String()
 }
 
-func (p *Properties) load(
-	b []byte, blockOffset uint64, deniedUserProperties map[string]struct{},
-) error {
+func (p *Properties) load(b []byte, deniedUserProperties map[string]struct{}) error {
 	i, err := rowblk.NewRawIter(bytes.Compare, b)
 	if err != nil {
 		return err

--- a/sstable/properties_test.go
+++ b/sstable/properties_test.go
@@ -101,7 +101,7 @@ func TestPropertiesSave(t *testing.T) {
 		e.save(TableFormatPebblev2, &w)
 		var props Properties
 
-		require.NoError(t, props.load(w.Finish(), 0, make(map[string]struct{})))
+		require.NoError(t, props.load(w.Finish(), make(map[string]struct{})))
 		props.Loaded = nil
 		if diff := pretty.Diff(*e, props); diff != nil {
 			t.Fatalf("%s", strings.Join(diff, "\n"))
@@ -132,6 +132,6 @@ func BenchmarkPropertiesLoad(b *testing.B) {
 	p := &Properties{}
 	for i := 0; i < b.N; i++ {
 		*p = Properties{}
-		require.NoError(b, p.load(block, 0, nil))
+		require.NoError(b, p.load(block, nil))
 	}
 }

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -730,7 +730,7 @@ func (r *Reader) readMetaindex(metaindexBH block.Handle, readHandle objstorage.R
 			return err
 		}
 		r.propertiesBH = bh
-		err := r.Properties.load(b.Get(), bh.Offset, r.opts.DeniedUserProperties)
+		err := r.Properties.load(b.Get(), r.opts.DeniedUserProperties)
 		b.Release()
 		if err != nil {
 			return err

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -2025,7 +2025,7 @@ func BenchmarkSeqSeekGEExhausted(b *testing.B) {
 						require.NoError(b, err)
 						b.ResetTimer()
 						pos := 0
-						var seekGEFlags SeekGEFlags
+						var seekGEFlags base.SeekGEFlags
 						for i := 0; i < b.N; i++ {
 							seekKey := seekKeys[0]
 							var kv *base.InternalKV

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -490,9 +490,7 @@ func RewriteKeySuffixesViaWriter(
 		if err != nil {
 			return nil, err
 		}
-		if w.addPoint(scratch, val, false); err != nil {
-			return nil, err
-		}
+		w.addPoint(scratch, val, false)
 		kv = i.Next()
 	}
 	if err := rewriteRangeKeyBlockToWriter(r, w, from, to); err != nil {

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -234,9 +234,6 @@ func runDataDriven(t *testing.T, file string, tableFormat TableFormat, paralleli
 			if err != nil {
 				return err.Error()
 			}
-			if err != nil {
-				return err.Error()
-			}
 			return format(td, meta)
 
 		default:


### PR DESCRIPTION
Fix a few lint issues, like an unused parameter and a few ineffective nil checks.