### PR TITLE
metrics: fix Compact.Duration metric bug

### DIFF
--- a/db.go
+++ b/db.go
@@ -1944,7 +1944,7 @@ func (d *DB) Metrics() *Metrics {
 	metrics.Compact.MarkedFiles = vers.Stats.MarkedForCompaction
 	metrics.Compact.Duration = d.mu.compact.duration
 	for c := range d.mu.compact.inProgress {
-		if c.kind != compactionKindFlush {
+		if c.kind != compactionKindFlush && c.kind != compactionKindIngestedFlushable {
 			metrics.Compact.Duration += d.timeNow().Sub(c.beganAt)
 		}
 	}


### PR DESCRIPTION
Don't include in-progress ingested flushables for Compact.Duration.
They don't contribute to the total when they complete, so we can see
non-monotonic blips in the value.

I reproduced this by keeping track of the last reported duration and
setting up a goroutine to poll the metrics frequently.

Fixes #3706