### PR TITLE
sstable: add FragmentIterTransforms

### DIFF
--- a/external_iterator.go
+++ b/external_iterator.go
@@ -208,7 +208,9 @@ func createExternalPointIter(ctx context.Context, it *Iterator) (topLevelIterato
 			if err != nil {
 				return nil, err
 			}
-			rangeDelIter, err = r.NewRawRangeDelIter(transforms)
+			rangeDelIter, err = r.NewRawRangeDelIter(sstable.FragmentIterTransforms{
+				SyntheticSeqNum: sstable.SyntheticSeqNum(seqNum),
+			})
 			if err != nil {
 				return nil, err
 			}
@@ -255,7 +257,7 @@ func finishInitializingExternal(ctx context.Context, it *Iterator) error {
 			}
 			for _, readers := range it.externalReaders {
 				for _, r := range readers {
-					transforms := sstable.IterTransforms{SyntheticSeqNum: sstable.SyntheticSeqNum(seqNum)}
+					transforms := sstable.FragmentIterTransforms{SyntheticSeqNum: sstable.SyntheticSeqNum(seqNum)}
 					seqNum--
 					if rki, err := r.NewRawRangeKeyIter(transforms); err != nil {
 						return err

--- a/ingest.go
+++ b/ingest.go
@@ -316,7 +316,7 @@ func ingestLoad1(
 		}
 	}
 
-	iter, err := r.NewRawRangeDelIter(sstable.NoTransforms)
+	iter, err := r.NewRawRangeDelIter(sstable.NoFragmentTransforms)
 	if err != nil {
 		return nil, err
 	}
@@ -346,7 +346,7 @@ func ingestLoad1(
 
 	// Update the range-key bounds for the table.
 	{
-		iter, err := r.NewRawRangeKeyIter(sstable.NoTransforms)
+		iter, err := r.NewRawRangeKeyIter(sstable.NoFragmentTransforms)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -325,12 +325,24 @@ func (m *FileMetadata) SyntheticSeqNum() sstable.SyntheticSeqNum {
 	return sstable.NoSyntheticSeqNum
 }
 
-// IterTransforms returns an sstable.IterTransforms that has SyntheticSeqNum set as needed.
+// IterTransforms returns an sstable.IterTransforms populated according to the
+// file.
 func (m *FileMetadata) IterTransforms() sstable.IterTransforms {
 	return sstable.IterTransforms{
 		SyntheticSeqNum: m.SyntheticSeqNum(),
 		SyntheticSuffix: m.SyntheticSuffix,
 		SyntheticPrefix: m.SyntheticPrefix,
+	}
+}
+
+// FragmentIterTransforms returns an sstable.FragmentIterTransforms populated
+// according to the file.
+func (m *FileMetadata) FragmentIterTransforms() sstable.FragmentIterTransforms {
+	return sstable.FragmentIterTransforms{
+		SyntheticSeqNum: m.SyntheticSeqNum(),
+		// TODO(radu): support these.
+		//SyntheticSuffix: m.SyntheticSuffix,
+		//SyntheticPrefix: m.SyntheticPrefix,
 	}
 }
 

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -105,7 +105,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 	newIters :=
 		func(_ context.Context, file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts, _ iterKinds) (iterSet, error) {
 			r := readers[file.FileNum]
-			rangeDelIter, err := r.NewRawRangeDelIter(sstable.NoTransforms)
+			rangeDelIter, err := r.NewRawRangeDelIter(sstable.NoFragmentTransforms)
 			if err != nil {
 				return iterSet{}, err
 			}

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -181,7 +181,7 @@ func (lt *levelIterTest) newIters(
 		set.point = iter
 	}
 	if kinds.RangeDeletion() {
-		rangeDelIter, err := lt.readers[file.FileNum].NewRawRangeDelIter(transforms)
+		rangeDelIter, err := lt.readers[file.FileNum].NewRawRangeDelIter(file.FragmentIterTransforms())
 		if err != nil {
 			return iterSet{}, errors.CombineErrors(err, set.CloseAll())
 		}

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -168,7 +168,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 			var err error
 			r := readers[file.FileNum]
 			if kinds.RangeDeletion() {
-				set.rangeDeletion, err = r.NewRawRangeDelIter(sstable.NoTransforms)
+				set.rangeDeletion, err = r.NewRawRangeDelIter(sstable.NoFragmentTransforms)
 				if err != nil {
 					return iterSet{}, errors.CombineErrors(err, set.CloseAll())
 				}
@@ -667,7 +667,7 @@ func buildMergingIter(readers [][]*sstable.Reader, levelSlices []manifest.LevelS
 			if err != nil {
 				return iterSet{}, err
 			}
-			rdIter, err := readers[levelIndex][file.FileNum].NewRawRangeDelIter(sstable.NoTransforms)
+			rdIter, err := readers[levelIndex][file.FileNum].NewRawRangeDelIter(sstable.NoFragmentTransforms)
 			if err != nil {
 				iter.Close()
 				return iterSet{}, err

--- a/metamorphic/build.go
+++ b/metamorphic/build.go
@@ -254,7 +254,7 @@ func openExternalObj(
 	pointIter, err = reader.NewIter(sstable.NoTransforms, start, end)
 	panicIfErr(err)
 
-	rangeDelIter, err = reader.NewRawRangeDelIter(sstable.NoTransforms)
+	rangeDelIter, err = reader.NewRawRangeDelIter(sstable.NoFragmentTransforms)
 	panicIfErr(err)
 	if rangeDelIter != nil {
 		rangeDelIter = keyspan.Truncate(
@@ -264,7 +264,7 @@ func openExternalObj(
 		)
 	}
 
-	rangeKeyIter, err = reader.NewRawRangeKeyIter(sstable.NoTransforms)
+	rangeKeyIter, err = reader.NewRawRangeKeyIter(sstable.NoFragmentTransforms)
 	panicIfErr(err)
 	if rangeKeyIter != nil {
 		rangeKeyIter = keyspan.Truncate(

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -1020,7 +1020,7 @@ func loadFlushedSSTableKeys(
 			}
 
 			// Load all the range tombstones.
-			if iter, err := r.NewRawRangeDelIter(sstable.NoTransforms); err != nil {
+			if iter, err := r.NewRawRangeDelIter(sstable.NoFragmentTransforms); err != nil {
 				return err
 			} else if iter != nil {
 				defer iter.Close()
@@ -1043,7 +1043,7 @@ func loadFlushedSSTableKeys(
 			}
 
 			// Load all the range keys.
-			if iter, err := r.NewRawRangeKeyIter(sstable.NoTransforms); err != nil {
+			if iter, err := r.NewRawRangeKeyIter(sstable.NoFragmentTransforms); err != nil {
 				return err
 			} else if iter != nil {
 				defer iter.Close()

--- a/sstable/reader_common.go
+++ b/sstable/reader_common.go
@@ -16,9 +16,9 @@ import (
 // can be used by code which doesn't care to distinguish between a reader and a
 // virtual reader.
 type CommonReader interface {
-	NewRawRangeKeyIter(transforms IterTransforms) (keyspan.FragmentIterator, error)
+	NewRawRangeKeyIter(transforms FragmentIterTransforms) (keyspan.FragmentIterator, error)
 
-	NewRawRangeDelIter(transforms IterTransforms) (keyspan.FragmentIterator, error)
+	NewRawRangeDelIter(transforms FragmentIterTransforms) (keyspan.FragmentIterator, error)
 
 	NewIterWithBlockPropertyFiltersAndContextEtc(
 		ctx context.Context,
@@ -50,6 +50,8 @@ type (
 	BufferPool = block.BufferPool
 	// IterTransforms re-exports block.IterTransforms.
 	IterTransforms = block.IterTransforms
+	// FragmentIterTransforms re-exports block.FragmentIterTransforms.
+	FragmentIterTransforms = block.FragmentIterTransforms
 	// SyntheticSeqNum re-exports block.SyntheticSeqNum.
 	SyntheticSeqNum = block.SyntheticSeqNum
 	// SyntheticSuffix re-exports block.SyntheticSuffix.
@@ -60,6 +62,9 @@ type (
 
 // NoTransforms is the default value for IterTransforms.
 var NoTransforms = block.NoTransforms
+
+// NoFragmentTransforms is the default value for FragmentIterTransforms.
+var NoFragmentTransforms = block.NoFragmentTransforms
 
 // NoSyntheticSeqNum is the default zero value for SyntheticSeqNum, which
 // disables overriding the sequence number.

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -129,7 +129,7 @@ func (v *VirtualReader) ValidateBlockChecksumsOnBacking() error {
 
 // NewRawRangeDelIter wraps Reader.NewRawRangeDelIter.
 func (v *VirtualReader) NewRawRangeDelIter(
-	transforms IterTransforms,
+	transforms FragmentIterTransforms,
 ) (keyspan.FragmentIterator, error) {
 	iter, err := v.reader.NewRawRangeDelIter(transforms)
 	if err != nil {
@@ -155,7 +155,7 @@ func (v *VirtualReader) NewRawRangeDelIter(
 
 // NewRawRangeKeyIter wraps Reader.NewRawRangeKeyIter.
 func (v *VirtualReader) NewRawRangeKeyIter(
-	transforms IterTransforms,
+	transforms FragmentIterTransforms,
 ) (keyspan.FragmentIterator, error) {
 	syntheticSeqNum := transforms.SyntheticSeqNum
 	if v.vState.isSharedIngested {

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -393,7 +393,7 @@ func rewriteDataBlocksToWriter(
 }
 
 func rewriteRangeKeyBlockToWriter(r *Reader, w *Writer, from, to []byte) error {
-	iter, err := r.NewRawRangeKeyIter(NoTransforms)
+	iter, err := r.NewRawRangeKeyIter(NoFragmentTransforms)
 	if err != nil {
 		return err
 	}

--- a/sstable/test_utils.go
+++ b/sstable/test_utils.go
@@ -29,14 +29,14 @@ func ReadAll(
 		})
 	}
 
-	if rangeDelIter := testutils.CheckErr(reader.NewRawRangeDelIter(NoTransforms)); rangeDelIter != nil {
+	if rangeDelIter := testutils.CheckErr(reader.NewRawRangeDelIter(NoFragmentTransforms)); rangeDelIter != nil {
 		defer rangeDelIter.Close()
 		for s := testutils.CheckErr(rangeDelIter.First()); s != nil; s = testutils.CheckErr(rangeDelIter.Next()) {
 			rangeDels = append(rangeDels, s.Clone())
 		}
 	}
 
-	if rangeKeyIter := testutils.CheckErr(reader.NewRawRangeKeyIter(NoTransforms)); rangeKeyIter != nil {
+	if rangeKeyIter := testutils.CheckErr(reader.NewRawRangeKeyIter(NoFragmentTransforms)); rangeKeyIter != nil {
 		defer rangeKeyIter.Close()
 		for s := testutils.CheckErr(rangeKeyIter.First()); s != nil; s = testutils.CheckErr(rangeKeyIter.Next()) {
 			rangeKeys = append(rangeKeys, s.Clone())

--- a/sstable/writer_rangekey_test.go
+++ b/sstable/writer_rangekey_test.go
@@ -105,7 +105,7 @@ func TestWriter_RangeKeys(t *testing.T) {
 				return err.Error()
 			}
 
-			iter, err := r.NewRawRangeKeyIter(NoTransforms)
+			iter, err := r.NewRawRangeKeyIter(NoFragmentTransforms)
 			if err != nil {
 				return err.Error()
 			}

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -169,7 +169,7 @@ func runDataDriven(t *testing.T, file string, tableFormat TableFormat, paralleli
 			return buf.String()
 
 		case "scan-range-del":
-			iter, err := r.NewRawRangeDelIter(NoTransforms)
+			iter, err := r.NewRawRangeDelIter(NoFragmentTransforms)
 			if err != nil {
 				return err.Error()
 			}
@@ -189,7 +189,7 @@ func runDataDriven(t *testing.T, file string, tableFormat TableFormat, paralleli
 			return buf.String()
 
 		case "scan-range-key":
-			iter, err := r.NewRawRangeKeyIter(NoTransforms)
+			iter, err := r.NewRawRangeKeyIter(NoFragmentTransforms)
 			if err != nil {
 				return err.Error()
 			}

--- a/table_cache.go
+++ b/table_cache.go
@@ -618,7 +618,7 @@ func (c *tableCacheShard) newRangeDelIter(
 ) (keyspan.FragmentIterator, error) {
 	// NB: range-del iterator does not maintain a reference to the table, nor
 	// does it need to read from it after creation.
-	rangeDelIter, err := cr.NewRawRangeDelIter(file.IterTransforms())
+	rangeDelIter, err := cr.NewRawRangeDelIter(file.FragmentIterTransforms())
 	if err != nil {
 		return nil, err
 	}
@@ -641,14 +641,14 @@ func (c *tableCacheShard) newRangeDelIter(
 func (c *tableCacheShard) newRangeKeyIter(
 	v *tableCacheValue, file *fileMetadata, cr sstable.CommonReader, opts keyspan.SpanIterOptions,
 ) (keyspan.FragmentIterator, error) {
-	transforms := file.IterTransforms()
+	transforms := file.FragmentIterTransforms()
 	// Don't filter a table's range keys if the file contains RANGEKEYDELs.
 	// The RANGEKEYDELs may delete range keys in other levels. Skipping the
 	// file's range key blocks may surface deleted range keys below. This is
 	// done here, rather than deferring to the block-property collector in order
 	// to maintain parity with point keys and the treatment of RANGEDELs.
 	if v.reader.Properties.NumRangeKeyDels == 0 && len(opts.RangeKeyFilters) > 0 {
-		ok, _, err := c.checkAndIntersectFilters(v, nil, opts.RangeKeyFilters, nil, transforms.SyntheticSuffix)
+		ok, _, err := c.checkAndIntersectFilters(v, nil, opts.RangeKeyFilters, nil, nil /* TODO(radu) transforms.SyntheticSuffix */)
 		if err != nil {
 			return nil, err
 		} else if !ok {

--- a/table_stats.go
+++ b/table_stats.go
@@ -906,7 +906,7 @@ func newCombinedDeletionKeyspanIter(
 	})
 	mIter.Init(comparer, transform, new(keyspanimpl.MergingBuffers))
 
-	iter, err := cr.NewRawRangeDelIter(m.IterTransforms())
+	iter, err := cr.NewRawRangeDelIter(m.FragmentIterTransforms())
 	if err != nil {
 		return nil, err
 	}
@@ -957,7 +957,7 @@ func newCombinedDeletionKeyspanIter(
 		mIter.AddLevel(iter)
 	}
 
-	iter, err = cr.NewRawRangeKeyIter(m.IterTransforms())
+	iter, err = cr.NewRawRangeKeyIter(m.FragmentIterTransforms())
 	if err != nil {
 		return nil, err
 	}

--- a/tool/find.go
+++ b/tool/find.go
@@ -457,8 +457,10 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 			defer r.Close()
 
 			var transforms sstable.IterTransforms
+			var fragTransforms sstable.FragmentIterTransforms
 			if m != nil {
 				transforms = m.IterTransforms()
+				fragTransforms = m.FragmentIterTransforms()
 			}
 
 			iter, err := r.NewIter(transforms, nil, nil)
@@ -472,7 +474,7 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 			// bit more work here to put them in a form that can be iterated in
 			// parallel with the point records.
 			rangeDelIter, err := func() (keyspan.FragmentIterator, error) {
-				iter, err := r.NewRawRangeDelIter(transforms)
+				iter, err := r.NewRawRangeDelIter(fragTransforms)
 				if err != nil {
 					return nil, err
 				}

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -387,7 +387,7 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 		// bit more work here to put them in a form that can be iterated in
 		// parallel with the point records.
 		rangeDelIter, err := func() (keyspan.FragmentIterator, error) {
-			iter, err := r.NewRawRangeDelIter(sstable.NoTransforms)
+			iter, err := r.NewRawRangeDelIter(sstable.NoFragmentTransforms)
 			if err != nil {
 				return nil, err
 			}
@@ -489,7 +489,7 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 		}
 
 		// Handle range keys.
-		rkIter, err := r.NewRawRangeKeyIter(sstable.NoTransforms)
+		rkIter, err := r.NewRawRangeKeyIter(sstable.NoFragmentTransforms)
 		if err != nil {
 			fmt.Fprintf(stdout, "%s\n", err)
 			os.Exit(1)


### PR DESCRIPTION
We add a separate struct for transforms passed to the fragment
iterator. This includes the option to elide keys at the same sequence
number.

We also move the underlying `block.Iter` handle initialization to the
fragment iterator constructor. It's up to the iterator to decide what
transformations to pass to that "raw" iterator. For example, prefix
and suffix synthesis will happen in the `FragmentIter` and these
options won't be passed to the `block.Iter`.