### PR TITLE
sstable: export SeekGEFlags and SeekLTFlags

### DIFF
--- a/sstable/internal.go
+++ b/sstable/internal.go
@@ -20,5 +20,11 @@ const (
 	InternalKeyKindInvalid       = base.InternalKeyKindInvalid
 )
 
+// SeekGEFlags exports base.SeekGEFlags.
+type SeekGEFlags = base.SeekGEFlags
+
+// SeekLTFlags exports base.SeekLTFlags.
+type SeekLTFlags = base.SeekLTFlags
+
 // InternalKey exports the base.InternalKey type.
 type InternalKey = base.InternalKey


### PR DESCRIPTION
This undoes part of #3705 - `SeekGEFlags` is used by cockroach.