### PR TITLE
rowblk: support synthetic prefix in FragmentIter

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -1344,7 +1344,7 @@ func runIngestExternalCmd(
 		usageErr := func(info interface{}) {
 			t.Helper()
 			td.Fatalf(t, "error parsing %q: %v; "+
-				"usage: obj bounds=(smallest,largest) [size=x] [synthetic-prefix=prefix] [synthetic-suffix=suffix]",
+				"usage: obj bounds=(smallest,largest) [size=x] [synthetic-prefix=prefix] [synthetic-suffix=suffix] [no-point-keys] [has-range-keys]",
 				line, info,
 			)
 		}
@@ -1392,6 +1392,12 @@ func runIngestExternalCmd(
 			case "synthetic-suffix":
 				nArgs(1)
 				ef.SyntheticSuffix = []byte(arg.Vals[0])
+
+			case "no-point-keys":
+				ef.HasPointKey = false
+
+			case "has-range-keys":
+				ef.HasRangeKey = true
 
 			default:
 				usageErr(fmt.Sprintf("unknown argument %v", arg.Key))

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -340,9 +340,9 @@ func (m *FileMetadata) IterTransforms() sstable.IterTransforms {
 func (m *FileMetadata) FragmentIterTransforms() sstable.FragmentIterTransforms {
 	return sstable.FragmentIterTransforms{
 		SyntheticSeqNum: m.SyntheticSeqNum(),
-		// TODO(radu): support these.
+		// TODO(radu): support this
 		//SyntheticSuffix: m.SyntheticSuffix,
-		//SyntheticPrefix: m.SyntheticPrefix,
+		SyntheticPrefix: m.SyntheticPrefix,
 	}
 }
 

--- a/metamorphic/generator.go
+++ b/metamorphic/generator.go
@@ -1358,9 +1358,7 @@ func (g *generator) writerIngestExternalFiles() {
 		}
 		// Randomly set up synthetic prefix.
 		var syntheticPrefix sstable.SyntheticPrefix
-		// We can only use a synthetic prefix if we don't have range dels.
-		// TODO(radu): we will want to support this at some point.
-		if !g.keyManager.objKeyMeta(id).hasRangeDels && g.rng.Intn(2) == 0 {
+		if g.rng.Intn(2) == 0 {
 			syntheticPrefix = randBytes(g.rng, 1, 5)
 			start = syntheticPrefix.Apply(start)
 			end = syntheticPrefix.Apply(end)

--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -111,6 +111,7 @@ type FragmentIterTransforms struct {
 	// ElideSameSeqNum, if true, returns only the first-occurring (in forward
 	// order) keyspan.Key for each sequence number.
 	ElideSameSeqNum bool
+	SyntheticPrefix SyntheticPrefix
 }
 
 // NoFragmentTransforms is the default value for IterTransforms.

--- a/sstable/rowblk/rowblk_fragment_iter_test.go
+++ b/sstable/rowblk/rowblk_fragment_iter_test.go
@@ -83,6 +83,9 @@ func TestBlockFragmentIterator(t *testing.T) {
 			var seqNum uint64
 			d.MaybeScanArgs(t, "synthetic-seq-num", &seqNum)
 			transforms.SyntheticSeqNum = block.SyntheticSeqNum(seqNum)
+			var syntheticPrefix string
+			d.MaybeScanArgs(t, "synthetic-prefix", &syntheticPrefix)
+			transforms.SyntheticPrefix = []byte(syntheticPrefix)
 
 			blockHandle := block.CacheBufferHandle(c.Get(1, 0, 0))
 			i, err := NewFragmentIter(comparer.Compare, comparer.Split, blockHandle, transforms)

--- a/sstable/rowblk/rowblk_iter.go
+++ b/sstable/rowblk/rowblk_iter.go
@@ -532,10 +532,11 @@ func (i *Iter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	}
 	searchKey := key
 	if i.transforms.SyntheticPrefix != nil {
-		// The seek key is before or after the entire block of keys that start with
-		// SyntheticPrefix. To determine which, we need to compare against a valid
-		// key in the block. We use firstUserKey which has the synthetic prefix.
 		if !bytes.HasPrefix(key, i.transforms.SyntheticPrefix) {
+			// The seek key is before or after the entire block of keys that start
+			// with SyntheticPrefix. To determine which, we need to compare against a
+			// valid key in the block. We use firstUserKey which has the synthetic
+			// prefix.
 			if i.cmp(i.firstUserKey, key) >= 0 {
 				return i.First()
 			}
@@ -712,10 +713,11 @@ func (i *Iter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
 	}
 	searchKey := key
 	if i.transforms.SyntheticPrefix != nil {
-		// The seek key is before or after the entire block of keys that start with
-		// SyntheticPrefix. To determine which, we need to compare against a valid
-		// key in the block. We use firstUserKey which has the synthetic prefix.
 		if !bytes.HasPrefix(key, i.transforms.SyntheticPrefix) {
+			// The seek key is before or after the entire block of keys that start
+			// with SyntheticPrefix. To determine which, we need to compare against a
+			// valid key in the block. We use firstUserKey which has the synthetic
+			// prefix.
 			if i.cmp(i.firstUserKey, key) < 0 {
 				return i.Last()
 			}

--- a/sstable/rowblk/testdata/rowblk_fragment_iter
+++ b/sstable/rowblk/testdata/rowblk_fragment_iter
@@ -81,3 +81,37 @@ next
    first:  a-b:{(#10,RANGEDEL)}
     next:  b-d:{(#10,RANGEDEL)}
     next:  d-e:{(#10,RANGEDEL)}
+
+# Tests with synthetic prefix.
+iter synthetic-prefix=foo_
+first
+next
+prev
+seek-ge foo_a
+seek-ge foo_b
+seek-lt foo_b
+seek-lt foo_z
+----
+   first:  foo_a-foo_b:{(#11,RANGEDEL)}
+    next:  foo_b-foo_d:{(#12,RANGEDEL) (#11,RANGEDEL) (#11,RANGEDEL)}
+    prev:  foo_a-foo_b:{(#11,RANGEDEL)}
+ seek-ge:  foo_a-foo_b:{(#11,RANGEDEL)}
+ seek-ge:  foo_b-foo_d:{(#12,RANGEDEL) (#11,RANGEDEL) (#11,RANGEDEL)}
+ seek-lt:  foo_a-foo_b:{(#11,RANGEDEL)}
+ seek-lt:  foo_d-foo_e:{(#12,RANGEDEL) (#11,RANGEDEL)}
+
+# Try seeks that don't have the synthetic prefix.
+iter synthetic-prefix=foo_
+seek-ge fon_a
+seek-ge fop_a
+prev
+seek-lt fon_a
+next
+seek-lt fop_a
+----
+ seek-ge:  foo_a-foo_b:{(#11,RANGEDEL)}
+ seek-ge:  <nil>
+    prev:  foo_d-foo_e:{(#12,RANGEDEL) (#11,RANGEDEL)}
+ seek-lt:  <nil>
+    next:  foo_a-foo_b:{(#11,RANGEDEL)}
+ seek-lt:  foo_d-foo_e:{(#12,RANGEDEL) (#11,RANGEDEL)}

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -909,3 +909,90 @@ next
 a@10: (a, .)
 b@11: (b, .)
 .
+
+
+# Tests with range tombstones.
+
+reset
+----
+
+build-remote points.sst
+set a@1 va
+set b@1 vb
+set c@1 vc
+set d@1 vc
+----
+
+build-remote ranges.sst
+del-range b b1
+----
+
+ingest-external
+points.sst bounds=(a,d)
+----
+
+ingest-external
+ranges.sst bounds=(a,d)
+----
+
+iter
+first
+next
+next
+next
+----
+a@1: (va, .)
+c@1: (vc, .)
+.
+.
+
+ingest-external
+points.sst bounds=(p1_a,p1_d) synthetic-prefix=p1_
+points.sst bounds=(p2_b,p2_c) synthetic-prefix=p2_
+----
+
+ingest-external
+ranges.sst bounds=(p1_a,p1_d) synthetic-prefix=p1_
+ranges.sst bounds=(p3_a,p3_d) synthetic-prefix=p3_
+----
+
+iter
+first
+next
+next
+next
+next
+next
+----
+a@1: (va, .)
+c@1: (vc, .)
+p1_a@1: (va, .)
+p1_c@1: (vc, .)
+p2_b@1: (vb, .)
+.
+
+iter
+seek-ge p
+next
+next
+next
+----
+p1_a@1: (va, .)
+p1_c@1: (vc, .)
+p2_b@1: (vb, .)
+.
+
+iter
+seek-lt p3
+prev
+prev
+prev
+prev
+prev
+----
+p2_b@1: (vb, .)
+p1_c@1: (vc, .)
+p1_a@1: (va, .)
+c@1: (vc, .)
+a@1: (va, .)
+.


### PR DESCRIPTION
We rely on the blockIter to prepend the prefix for start keys, and the
fragment iterator adjusts the end keys.

We still don't support range keys in external files because of an
outstanding issue which I will start tackling.