### PR TITLE
db: skip counting flushable ingest in compaction duration metric

### DIFF
--- a/db.go
+++ b/db.go
@@ -1944,7 +1944,7 @@ func (d *DB) Metrics() *Metrics {
 	metrics.Compact.MarkedFiles = vers.Stats.MarkedForCompaction
 	metrics.Compact.Duration = d.mu.compact.duration
 	for c := range d.mu.compact.inProgress {
-		if c.kind != compactionKindFlush {
+		if c.kind != compactionKindFlush && c.kind != compactionKindIngestedFlushable {
 			metrics.Compact.Duration += d.timeNow().Sub(c.beganAt)
 		}
 	}


### PR DESCRIPTION
We do not include flushes in our compaction duration metrics, which should also exclude flushableIngests. When they are complete, we do not update the aggregate duration metric, but we were including them in our in-progress compaction adjustments.

This patch ignores flushableIngests in `db.Metrics()` to preserve monotonicity of the duration metric.