### PR TITLE
sstable: clean up reader/writer options

### DIFF
--- a/sstable/filter.go
+++ b/sstable/filter.go
@@ -34,7 +34,11 @@ type FilterMetricsTracker struct {
 
 var _ ReaderOption = (*FilterMetricsTracker)(nil)
 
-func (m *FilterMetricsTracker) readerApply(r *Reader) {
+// readerApplyPre is part of ReaderOption.
+func (m *FilterMetricsTracker) readerApplyPre(r *Reader) {}
+
+// readerApplyPost is part of ReaderOption.
+func (m *FilterMetricsTracker) readerApplyPost(r *Reader) {
 	if r.tableFilter != nil {
 		r.tableFilter.metrics = m
 	}


### PR DESCRIPTION
The current code uses a `preApply` marker method to change when
`readerApply/writerApply` is called. This is unnecessarily subtle.
We change `ReaderOption` to have `readerApplyPre` and
`readerApplyPost`. We change `WriterOption` to always be called at the
beginning (we only have one implementation).