### PR TITLE
sstable: factor out common iterator init code

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -221,23 +221,22 @@ func (r *Reader) newIterWithBlockPropertyFiltersAndContext(
 	// NB: pebble.tableCache wraps the returned iterator with one which performs
 	// reference counting on the Reader, preventing the Reader from being closed
 	// until the final iterator closes.
+	var res Iterator
+	var err error
 	if r.Properties.IndexType == twoLevelIndex {
-		i := twoLevelIterPool.Get().(*twoLevelIterator)
-		err := i.init(ctx, r, vState, transforms, lower, upper, filterer, useFilterBlock,
+		res, err = newTwoLevelIterator(ctx, r, vState, transforms, lower, upper, filterer, useFilterBlock,
 			stats, categoryAndQoS, statsCollector, rp, nil /* bufferPool */)
-		if err != nil {
-			return nil, err
-		}
-		return i, nil
+	} else {
+		res, err = newSingleLevelIterator(
+			ctx, r, vState, transforms, lower, upper, filterer, useFilterBlock,
+			stats, categoryAndQoS, statsCollector, rp, nil /* bufferPool */)
 	}
-
-	i := singleLevelIterPool.Get().(*singleLevelIterator)
-	err := i.init(ctx, r, vState, transforms, lower, upper, filterer, useFilterBlock,
-		stats, categoryAndQoS, statsCollector, rp, nil /* bufferPool */)
 	if err != nil {
+		// Note: we don't want to return res here - it will be a nil
+		// single/twoLevelIterator, not a nil Iterator.
 		return nil, err
 	}
-	return i, nil
+	return res, nil
 }
 
 // NewIter returns an iterator for the contents of the table. If an error
@@ -275,8 +274,7 @@ func (r *Reader) newCompactionIter(
 		transforms.HideObsoletePoints = true
 	}
 	if r.Properties.IndexType == twoLevelIndex {
-		i := twoLevelIterPool.Get().(*twoLevelIterator)
-		err := i.init(
+		i, err := newTwoLevelIterator(
 			context.Background(),
 			r, vState, transforms, nil /* lower */, nil /* upper */, nil,
 			false /* useFilter */, nil /* stats */, categoryAndQoS, statsCollector, rp, bufferPool,
@@ -287,8 +285,7 @@ func (r *Reader) newCompactionIter(
 		i.setupForCompaction()
 		return &twoLevelCompactionIterator{twoLevelIterator: i}, nil
 	}
-	i := singleLevelIterPool.Get().(*singleLevelIterator)
-	err := i.init(
+	i, err := newSingleLevelIterator(
 		context.Background(), r, vState, transforms, nil /* lower */, nil, /* upper */
 		nil, false /* useFilter */, nil /* stats */, categoryAndQoS, statsCollector, rp, bufferPool,
 	)

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -174,13 +174,40 @@ type singleLevelIterator struct {
 // singleLevelIterator implements the base.InternalIterator interface.
 var _ base.InternalIterator = (*singleLevelIterator)(nil)
 
-// init initializes a singleLevelIterator for reading from the table. It is
-// synonmous with Reader.NewIter, but allows for reusing of the iterator
-// between different Readers.
+// newSingleLevelIterator reads the index block and creates and initializes a
+// singleLevelIterator.
 //
-// Note that lower, upper passed into init has nothing to do with virtual sstable
-// bounds. If the virtualState passed in is not nil, then virtual sstable bounds
-// will be enforced.
+// Note that lower, upper are iterator bounds and are separate from virtual
+// sstable bounds. If the virtualState passed in is not nil, then virtual
+// sstable bounds will be enforced.
+func newSingleLevelIterator(
+	ctx context.Context,
+	r *Reader,
+	v *virtualState,
+	transforms IterTransforms,
+	lower, upper []byte,
+	filterer *BlockPropertiesFilterer,
+	useFilter bool,
+	stats *base.InternalIteratorStats,
+	categoryAndQoS CategoryAndQoS,
+	statsCollector *CategoryStatsCollector,
+	rp ReaderProvider,
+	bufferPool *block.BufferPool,
+) (*singleLevelIterator, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	i := singleLevelIterPool.Get().(*singleLevelIterator)
+	i.inPool = false
+	if err := i.init(
+		ctx, r, v, transforms, lower, upper, filterer, useFilter, stats, categoryAndQoS, statsCollector, rp, bufferPool,
+	); err != nil {
+		_ = i.Close()
+		return nil, err
+	}
+	return i, nil
+}
+
 func (i *singleLevelIterator) init(
 	ctx context.Context,
 	r *Reader,
@@ -195,9 +222,6 @@ func (i *singleLevelIterator) init(
 	rp ReaderProvider,
 	bufferPool *block.BufferPool,
 ) error {
-	if r.err != nil {
-		return r.err
-	}
 	i.iterStats.init(categoryAndQoS, statsCollector)
 	i.indexFilterRH = objstorageprovider.UsePreallocatedReadHandle(
 		ctx, r.readable, objstorage.ReadBeforeForIndexAndFilter, &i.indexFilterRHPrealloc)
@@ -210,7 +234,6 @@ func (i *singleLevelIterator) init(
 		i.endKeyInclusive, lower, upper = v.constrainBounds(lower, upper, false /* endInclusive */)
 	}
 
-	i.inPool = false
 	i.ctx = ctx
 	i.lower = lower
 	i.upper = upper

--- a/sstable/reader_iter_test.go
+++ b/sstable/reader_iter_test.go
@@ -1,0 +1,89 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/testutils"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIteratorErrorOnInit tests the path where creation of an iterator fails
+// when reading the index block.
+func TestIteratorErrorOnInit(t *testing.T) {
+	mem := vfs.NewMem()
+
+	f0, err := mem.Create("test.sst", vfs.WriteCategoryUnspecified)
+	require.NoError(t, err)
+	writerOpts := WriterOptions{
+		Comparer:   base.DefaultComparer,
+		MergerName: base.DefaultMerger.Name,
+	}
+	w := NewWriter(objstorageprovider.NewFileWritable(f0), writerOpts)
+	require.NoError(t, w.Set([]byte("test"), nil))
+	require.NoError(t, w.Close())
+
+	f1 := testutils.CheckErr(mem.Open("test.sst"))
+	r, err := newReader(f1, ReaderOptions{
+		Comparer: base.DefaultComparer,
+		Merger:   base.DefaultMerger,
+	})
+	require.NoError(t, err)
+	defer r.Close()
+
+	// Swap the readable in the reader.
+	bad := testutils.CheckErr(mem.Create("bad.sst", vfs.WriteCategoryUnspecified))
+	require.NoError(t, bad.Close())
+	bad = testutils.CheckErr(mem.Open("bad.sst"))
+	saveReadable := r.readable
+	r.readable = testutils.CheckErr(NewSimpleReadable(bad))
+
+	var pool block.BufferPool
+	pool.Init(5)
+
+	var stats base.InternalIteratorStats
+	for k := 0; k < 20; k++ {
+		if rand.Intn(2) == 0 {
+			_, err := newSingleLevelIterator(
+				context.Background(),
+				r,
+				nil, /* v */
+				NoTransforms,
+				nil /* lower */, nil, /* upper */
+				nil /* filterer */, false, /* useFilter */
+				&stats,
+				CategoryAndQoS{},
+				nil, /* statsCollector */
+				TrivialReaderProvider{Reader: r},
+				&pool,
+			)
+			require.Error(t, err)
+		} else {
+			_, err := newTwoLevelIterator(
+				context.Background(),
+				r,
+				nil, /* v */
+				NoTransforms,
+				nil /* lower */, nil, /* upper */
+				nil /* filterer */, false, /* useFilter */
+				&stats,
+				CategoryAndQoS{},
+				nil, /* statsCollector */
+				TrivialReaderProvider{Reader: r},
+				&pool,
+			)
+			require.Error(t, err)
+		}
+	}
+	require.NoError(t, r.readable.Close())
+	r.readable = saveReadable
+}

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -12,8 +12,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/treeprinter"
-	"github.com/cockroachdb/pebble/objstorage"
-	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/sstable/rowblk"
@@ -42,7 +40,7 @@ func (i *twoLevelIterator) loadIndex(dir int8) loadBlockResult {
 	v := i.topLevelIndex.Value()
 	bhp, err := decodeBlockHandleWithProperties(v.InPlaceValue())
 	if err != nil {
-		i.err = base.CorruptionErrorf("pebble/table: corrupt top level index entry")
+		i.err = base.CorruptionErrorf("pebble/table: corrupt top level index entry (%v)", err)
 		return loadBlockFailed
 	}
 	if i.bpfs != nil {
@@ -62,20 +60,20 @@ func (i *twoLevelIterator) loadIndex(dir int8) loadBlockResult {
 	ctx := objiotracing.WithBlockType(i.ctx, objiotracing.MetadataBlock)
 	indexBlock, err := i.reader.readBlock(
 		ctx, bhp.Handle, nil /* transform */, i.indexFilterRH, i.stats, &i.iterStats, i.bufferPool)
+	if err == nil {
+		err = i.index.InitHandle(i.cmp, i.reader.Split, indexBlock, i.transforms)
+	}
 	if err != nil {
 		i.err = err
 		return loadBlockFailed
 	}
-	if i.err = i.index.InitHandle(i.cmp, i.reader.Split, indexBlock, i.transforms); i.err == nil {
-		return loadBlockOK
-	}
-	return loadBlockFailed
+	return loadBlockOK
 }
 
 // resolveMaybeExcluded is invoked when the block-property filterer has found
 // that an index block is excluded according to its properties but only if its
 // bounds fall within the filter's current bounds. This function consults the
-// apprioriate bound, depending on the iteration direction, and returns either
+// appropriate bound, depending on the iteration direction, and returns either
 // `blockIntersects` or `blockExcluded`.
 func (i *twoLevelIterator) resolveMaybeExcluded(dir int8) intersectsResult {
 	// This iterator is configured with a bound-limited block property filter.
@@ -158,52 +156,16 @@ func newTwoLevelIterator(
 		return nil, r.err
 	}
 	i := twoLevelIterPool.Get().(*twoLevelIterator)
-	i.inPool = false
-	i.iterStats.init(categoryAndQoS, statsCollector)
-	i.indexFilterRH = objstorageprovider.UsePreallocatedReadHandle(
-		ctx, r.readable, objstorage.ReadBeforeForIndexAndFilter, &i.indexFilterRHPrealloc)
-	topLevelIndexH, err := r.readIndex(ctx, i.indexFilterRH, stats, &i.iterStats)
-	if err != nil {
-		_ = i.Close()
-		return nil, err
-	}
-	if v != nil {
-		i.vState = v
-		// Note that upper is exclusive here.
-		i.endKeyInclusive, lower, upper = v.constrainBounds(lower, upper, false /* endInclusive */)
-	}
+	i.singleLevelIterator.init(ctx, r, v, transforms, lower, upper, filterer, useFilter,
+		stats, categoryAndQoS, statsCollector, rp, bufferPool)
 
-	i.ctx = ctx
-	i.lower = lower
-	i.upper = upper
-	i.bpfs = filterer
-	i.useFilter = useFilter
-	i.reader = r
-	i.cmp = r.Compare
-	i.stats = stats
-	i.transforms = transforms
-	i.bufferPool = bufferPool
-	err = i.topLevelIndex.InitHandle(i.cmp, i.reader.Split, topLevelIndexH, transforms)
+	topLevelIndexH, err := r.readIndex(ctx, i.indexFilterRH, stats, &i.iterStats)
+	if err == nil {
+		err = i.topLevelIndex.InitHandle(i.cmp, i.reader.Split, topLevelIndexH, transforms)
+	}
 	if err != nil {
-		// blockIter.Close releases topLevelIndexH and always returns a nil error
 		_ = i.Close()
 		return nil, err
-	}
-	i.dataRH = objstorageprovider.UsePreallocatedReadHandle(
-		ctx, r.readable, objstorage.NoReadBefore, &i.dataRHPrealloc)
-	if r.tableFormat >= TableFormatPebblev3 {
-		if r.Properties.NumValueBlocks > 0 {
-			i.vbReader = &valueBlockReader{
-				bpOpen: i,
-				rp:     rp,
-				vbih:   r.valueBIH,
-				stats:  stats,
-			}
-			i.data.SetGetLazyValue(i.vbReader.getLazyValueForPrefixAndValueHandle)
-			i.vbRH = objstorageprovider.UsePreallocatedReadHandle(
-				ctx, r.readable, objstorage.NoReadBefore, &i.vbRHPrealloc)
-		}
-		i.data.SetHasValuePrefix(true)
 	}
 	return i, nil
 }


### PR DESCRIPTION
We've had multiple issues with divergences between initializing the data block read handles. This PR removes the code duplication.

#### sstable: add constructors for iterators

Add `newSingleLevelIterator` and `newTwoLevelIterator` constructors.

#### sstable: factor out common iterator init code

This commits factors out most of the `singleLevelIterator`
initialization code, so that `twoLevelIterator` can use it too.