### PR TITLE
metamorphic: limit aggregate injected I/O latency

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -2214,7 +2214,8 @@ func TestDeterminism(t *testing.T) {
 						if cmdArg.Key == "io-latency" {
 							prevMkfs := mkfs
 							mkfs = func() vfs.FS {
-								return errorfs.Wrap(prevMkfs(), errorfs.RandomLatency(errorfs.Randomly(p, 0), mean, 0))
+								return errorfs.Wrap(prevMkfs(), errorfs.RandomLatency(
+									errorfs.Randomly(p, 0), mean, 0 /* seed */, 0 /* no limit */))
 							}
 						} else if cmdArg.Key == "step-latency" {
 							beforeStep = func() {

--- a/error_test.go
+++ b/error_test.go
@@ -447,7 +447,7 @@ func TestDBCompactionCrash(t *testing.T) {
 		// really slow. See https://github.com/golang/go/issues/61042,
 		// https://github.com/golang/go/issues/44343.
 		if runtime.GOOS != "windows" {
-			fs = errorfs.Wrap(fs, errorfs.RandomLatency(nil, 20*time.Microsecond, seed))
+			fs = errorfs.Wrap(fs, errorfs.RandomLatency(nil, 20*time.Microsecond, seed, 0 /* no limit */))
 		}
 		rng := rand.New(rand.NewSource(seed))
 		maxConcurrentCompactions := rng.Intn(3) + 2

--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -492,13 +492,16 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 	} else {
 		opts.Cleaner = base.ArchiveCleaner{}
 	}
-	// Wrap the filesystem with a VFS that will inject random latency if
-	// the test options require it.
+	// Wrap the filesystem with a VFS that will inject random latency if the
+	// test options require it. We cap the overlal injected latency to ten
+	// seconds to avoid excessive test run times when paired with small target
+	// file sizes, block sizes, etc.
 	if testOpts.ioLatencyProbability > 0 {
 		opts.FS = errorfs.Wrap(opts.FS, errorfs.RandomLatency(
 			errorfs.Randomly(testOpts.ioLatencyProbability, testOpts.ioLatencySeed),
 			testOpts.ioLatencyMean,
 			testOpts.ioLatencySeed,
+			10*time.Second,
 		))
 	}
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -442,7 +442,8 @@ func TestMetricsWAmpDisableWAL(t *testing.T) {
 // Metrics.WAL.BytesWritten metric is always nondecreasing.
 // It's a regression test for issue #3505.
 func TestMetricsWALBytesWrittenMonotonicity(t *testing.T) {
-	fs := errorfs.Wrap(vfs.NewMem(), errorfs.RandomLatency(nil, 100*time.Microsecond, time.Now().UnixNano()))
+	fs := errorfs.Wrap(vfs.NewMem(), errorfs.RandomLatency(
+		nil, 100*time.Microsecond, time.Now().UnixNano(), 0 /* no limit */))
 	d, err := Open("", &Options{
 		FS: fs,
 		// Use a tiny memtable size so that we get frequent flushes. While a

--- a/wal/failover_manager_test.go
+++ b/wal/failover_manager_test.go
@@ -573,7 +573,8 @@ func TestFailoverManager_Quiesce(t *testing.T) {
 	memFS := vfs.NewMem()
 	require.NoError(t, memFS.MkdirAll("primary", os.ModePerm))
 	require.NoError(t, memFS.MkdirAll("secondary", os.ModePerm))
-	fs := errorfs.Wrap(memFS, errorfs.RandomLatency(errorfs.Randomly(0.50, seed), 10*time.Millisecond, seed))
+	fs := errorfs.Wrap(memFS, errorfs.RandomLatency(
+		errorfs.Randomly(0.50, seed), 10*time.Millisecond, seed, 0 /* no limit */))
 
 	var m failoverManager
 	require.NoError(t, m.init(Options{


### PR DESCRIPTION
Limit the amount of I/O latency injected into any individual run of the metamorphic test to improve worst-case test runtimes.

Informs #3681.
Informs #3733.