### PR TITLE
sstable: improve the property collector interface

### DIFF
--- a/ingest_test.go
+++ b/ingest_test.go
@@ -103,7 +103,7 @@ func TestIngestLoad(t *testing.T) {
 				if strings.HasPrefix(data, "rangekey: ") {
 					data = strings.TrimPrefix(data, "rangekey: ")
 					s := keyspan.ParseSpan(data)
-					err := rangekey.Encode(&s, w.AddRangeKey)
+					err := w.EncodeSpan(&s)
 					if err != nil {
 						return err.Error()
 					}
@@ -1083,9 +1083,7 @@ func testIngestSharedImpl(
 						Keys:      keys,
 						KeysOrder: 0,
 					}
-					require.NoError(t, rangekey.Encode(&s, func(k base.InternalKey, v []byte) error {
-						return w.AddRangeKey(base.MakeInternalKey(k.UserKey, 0, k.Kind()), v)
-					}))
+					require.NoError(t, w.EncodeSpan(&s))
 					return nil
 				},
 				func(sst *SharedSSTMeta) error {
@@ -1581,9 +1579,7 @@ func TestConcurrentExcise(t *testing.T) {
 						Keys:      keys,
 						KeysOrder: 0,
 					}
-					require.NoError(t, rangekey.Encode(&s, func(k base.InternalKey, v []byte) error {
-						return w.AddRangeKey(base.MakeInternalKey(k.UserKey, 0, k.Kind()), v)
-					}))
+					require.NoError(t, w.EncodeSpan(&s))
 					return nil
 				},
 				func(sst *SharedSSTMeta) error {
@@ -2016,9 +2012,7 @@ func TestIngestExternal(t *testing.T) {
 						Keys:      keys,
 						KeysOrder: 0,
 					}
-					require.NoError(t, rangekey.Encode(&s, func(k base.InternalKey, v []byte) error {
-						return w.AddRangeKey(base.MakeInternalKey(k.UserKey, 0, k.Kind()), v)
-					}))
+					require.NoError(t, w.EncodeSpan(&s))
 					return nil
 				},
 				nil,
@@ -3200,7 +3194,7 @@ func TestIngest_UpdateSequenceNumber(t *testing.T) {
 			if strings.HasPrefix(data, "rangekey: ") {
 				data = strings.TrimPrefix(data, "rangekey: ")
 				s := keyspan.ParseSpan(data)
-				err := rangekey.Encode(&s, w.AddRangeKey)
+				err := w.EncodeSpan(&s)
 				if err != nil {
 					return nil, err
 				}

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/rangedel"
+	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/internal/sstableinternal"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
@@ -241,7 +242,11 @@ func (lt *levelIterTest) runBuild(d *datadriven.TestData) string {
 		case InternalKeyKindRangeDelete:
 			f.Add(rangedel.Decode(ikey, value, nil))
 		case InternalKeyKindRangeKeySet, InternalKeyKindRangeKeyUnset, InternalKeyKindRangeKeyDelete:
-			if err := w.AddRangeKey(ikey, value); err != nil {
+			span, err := rangekey.Decode(ikey, value, nil)
+			if err != nil {
+				return err.Error()
+			}
+			if err := w.EncodeSpan(&span); err != nil {
 				return err.Error()
 			}
 		default:

--- a/metamorphic/build.go
+++ b/metamorphic/build.go
@@ -142,7 +142,7 @@ func writeSSTForIngestion(
 				collapsed.Keys[i].Trailer = base.MakeTrailer(0, collapsed.Keys[i].Kind())
 			}
 			keyspan.SortKeysByTrailer(&collapsed.Keys)
-			if err := rangekey.Encode(&collapsed, w.AddRangeKey); err != nil {
+			if err := w.EncodeSpan(&collapsed); err != nil {
 				return nil, err
 			}
 		}

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -1935,7 +1935,7 @@ func (r *replicateOp) runSharedReplicate(
 				End:   end,
 				Keys:  keys,
 			}
-			return rangekey.Encode(&s, w.AddRangeKey)
+			return w.EncodeSpan(&s)
 		},
 		func(sst *pebble.SharedSSTMeta) error {
 			sharedSSTs = append(sharedSSTs, *sst)
@@ -1999,7 +1999,7 @@ func (r *replicateOp) runExternalReplicate(
 				End:   end,
 				Keys:  keys,
 			}
-			return rangekey.Encode(&s, w.AddRangeKey)
+			return w.EncodeSpan(&s)
 		},
 		nil,
 		func(sst *pebble.ExternalFile) error {
@@ -2112,7 +2112,7 @@ func (r *replicateOp) run(t *Test, h historyRecorder) {
 				}
 			}
 			keyspan.SortKeysByTrailer(&span.Keys)
-			if err := rangekey.Encode(span, w.AddRangeKey); err != nil {
+			if err := w.EncodeSpan(span); err != nil {
 				panic(err)
 			}
 		}

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/itertest"
 	"github.com/cockroachdb/pebble/internal/keyspan"
-	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
@@ -428,7 +427,7 @@ func TestScanInternal(t *testing.T) {
 						}
 						keyspan.SortKeysByTrailer(&keys)
 						newSpan := &keyspan.Span{Start: span.Start, End: span.End, Keys: keys}
-						require.NoError(t, rangekey.Encode(newSpan, w.AddRangeKey))
+						require.NoError(t, w.EncodeSpan(newSpan))
 					}
 					require.NoError(t, err)
 				}

--- a/sstable/block_property_obsolete.go
+++ b/sstable/block_property_obsolete.go
@@ -28,8 +28,14 @@ func (o *obsoleteKeyBlockPropertyCollector) Name() string {
 	return "obsolete-key"
 }
 
-// Add is part of the BlockPropertyCollector interface.
-func (o *obsoleteKeyBlockPropertyCollector) Add(key InternalKey, value []byte) error {
+// AddPointKey is part of the BlockPropertyCollector interface.
+func (o *obsoleteKeyBlockPropertyCollector) AddPointKey(key InternalKey, value []byte) error {
+	// Ignore.
+	return nil
+}
+
+// AddRangeKeys is part of the BlockPropertyCollector interface.
+func (o *obsoleteKeyBlockPropertyCollector) AddRangeKeys(span Span) error {
 	// Ignore.
 	return nil
 }

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -153,7 +153,7 @@ func runBuildCmd(
 	}
 	rangeKeyFrag.Finish()
 	for _, s := range rangeKeys {
-		if err := w.addRangeKeySpan(s); err != nil {
+		if err := w.addRangeKeySpanToFragmenter(s); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -206,7 +206,7 @@ func runBuildRawCmd(
 	for _, data := range strings.Split(td.Input, "\n") {
 		if strings.HasPrefix(data, "rangekey:") {
 			data = strings.TrimPrefix(data, "rangekey:")
-			if err := w.addRangeKeySpan(keyspan.ParseSpan(data)); err != nil {
+			if err := w.addRangeKeySpanToFragmenter(keyspan.ParseSpan(data)); err != nil {
 				return nil, nil, err
 			}
 			continue
@@ -219,7 +219,10 @@ func runBuildRawCmd(
 		case base.InternalKeyKindRangeKeyDelete,
 			base.InternalKeyKindRangeKeyUnset,
 			base.InternalKeyKindRangeKeySet:
-			if err := w.AddRangeKey(key, value); err != nil {
+			// Note: specifying range keys directly (instead of spans) should only be
+			// done to check for error handling; they will not contribute to block
+			// properties.
+			if err := w.addRangeKey(key, value); err != nil {
 				return nil, nil, err
 			}
 		default:

--- a/sstable/internal.go
+++ b/sstable/internal.go
@@ -4,7 +4,10 @@
 
 package sstable
 
-import "github.com/cockroachdb/pebble/internal/base"
+import (
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/keyspan"
+)
 
 // These constants are part of the file format, and should not be changed.
 const (
@@ -22,3 +25,6 @@ const (
 
 // InternalKey exports the base.InternalKey type.
 type InternalKey = base.InternalKey
+
+// Span exports the keyspan.Span type.
+type Span = keyspan.Span

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/bytealloc"
 	"github.com/cockroachdb/pebble/internal/invariants"
-	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/sstable/rowblk"
@@ -416,13 +415,7 @@ func rewriteRangeKeyBlockToWriter(r *Reader, w *Writer, from, to []byte) error {
 			s.Keys[i].Suffix = to
 		}
 
-		err = rangekey.Encode(s, func(k base.InternalKey, v []byte) error {
-			// Calling AddRangeKey instead of addRangeKeySpan bypasses the fragmenter.
-			// This is okay because the raw fragments off of `iter` are already
-			// fragmented, and suffix replacement should not affect fragmentation.
-			return w.AddRangeKey(k, v)
-		})
-		if err != nil {
+		if err := w.EncodeSpan(s); err != nil {
 			return err
 		}
 	}

--- a/sstable/suffix_rewriter_test.go
+++ b/sstable/suffix_rewriter_test.go
@@ -42,8 +42,8 @@ func TestRewriteSuffixProps(t *testing.T) {
 			// at the correct (new) shortIDs. Seeing the rolled up value here is almost an
 			// end-to-end test since we only fed them each block during rewrite.
 			expectedProps["count"] = string(append([]byte{1}, strconv.Itoa(keyCount+rangeKeyCount)...))
-			expectedProps["bp2"] = string(interval{46, 47}.encode([]byte{2}))
-			expectedProps["bp3"] = string(interval{646, 647}.encode([]byte{0}))
+			expectedProps["bp2"] = string(encodeBlockInterval(BlockInterval{46, 47}, []byte{2}))
+			expectedProps["bp3"] = string(encodeBlockInterval(BlockInterval{646, 647}, []byte{0}))
 
 			// Swap the order of two of the props so they have new shortIDs, and remove
 			// one. rwOpts inherits the IsStrictObsolete value from wOpts.
@@ -110,7 +110,6 @@ func TestRewriteSuffixProps(t *testing.T) {
 					newLayout, err := rRewritten.Layout()
 					require.NoError(t, err)
 
-					ival := interval{}
 					for i := range layout.Data {
 						oldProps := make([][]byte, len(wOpts.BlockPropertyCollectors))
 						oldDecoder := makeBlockPropertiesDecoder(len(oldProps), layout.Data[i].Props)
@@ -129,10 +128,8 @@ func TestRewriteSuffixProps(t *testing.T) {
 							}
 						}
 						require.Equal(t, oldProps[0], newProps[1])
-						require.NoError(t, ival.decode(newProps[0]))
-						require.Equal(t, interval{646, 647}, ival)
-						require.NoError(t, ival.decode(newProps[2]))
-						require.Equal(t, interval{46, 47}, ival)
+						decodeAndCheck(t, newProps[0], BlockInterval{646, 647})
+						decodeAndCheck(t, newProps[2], BlockInterval{46, 47})
 					}
 				})
 			}

--- a/sstable/testdata/block_properties
+++ b/sstable/testdata/block_properties
@@ -287,7 +287,7 @@ ranges: false
 
 build collectors=(nil-points-and-ranges)
 ----
-sstable: at least one interval collector must be provided
+mapper must be provided
 
 # Test a small index-block-size and block-size, so every data block has one KV
 # and every index block points to one data block.

--- a/sstable/testdata/virtual_reader_iter
+++ b/sstable/testdata/virtual_reader_iter
@@ -32,9 +32,9 @@ a.SET.1:a
 d.SET.2:d
 f.SET.3:f
 d.RANGEDEL.4:e
-rangekey: a-d:{(#11,RANGEKEYSET,@t10,foo)}
+rangekey: a-d:{(#11,RANGEKEYSET,@10,foo)}
 g.RANGEDEL.5:l
-rangekey: y-z:{(#12,RANGEKEYSET,@t11,foo)}
+rangekey: y-z:{(#12,RANGEKEYSET,@11,foo)}
 ----
 point:    [a#1,SET-f#3,SET]
 rangedel: [d#4,RANGEDEL-l#inf,RANGEDEL]
@@ -53,7 +53,7 @@ d-e:{(#4,RANGEDEL)}
 
 scan-range-key
 ----
-a-d:{(#11,RANGEKEYSET,@t10,foo)}
+a-d:{(#11,RANGEKEYSET,@10,foo)}
 
 # Test iterators with various bounds, and various operations. This calls
 # VirtualReader.NewIterWithBlockPropertyFilters and performs various operations
@@ -570,9 +570,9 @@ b.SET.5:b
 d.SET.2:d
 f.SET.3:f
 d.RANGEDEL.4:e
-rangekey: a-d:{(#11,RANGEKEYSET,@t10,foo)}
+rangekey: a-d:{(#11,RANGEKEYSET,@10,foo)}
 g.RANGEDEL.5:l
-rangekey: y-z:{(#12,RANGEKEYSET,@t11,foo)}
+rangekey: y-z:{(#12,RANGEKEYSET,@11,foo)}
 ----
 point:    [a#1,SET-f#3,SET]
 rangedel: [d#4,RANGEDEL-l#inf,RANGEDEL]

--- a/sstable/testdata/virtual_reader_props
+++ b/sstable/testdata/virtual_reader_props
@@ -99,9 +99,9 @@ a.SET.1:a
 d.SET.2:d
 f.SET.3:f
 d.RANGEDEL.4:e
-rangekey: a-d:{(#11,RANGEKEYSET,@t10,foo)}
+rangekey: a-d:{(#11,RANGEKEYSET,@10,foo)}
 g.RANGEDEL.5:l
-rangekey: y-z:{(#12,RANGEKEYSET,@t11,foo)}
+rangekey: y-z:{(#12,RANGEKEYSET,@11,foo)}
 ----
 point:    [a#1,SET-f#3,SET]
 rangedel: [d#4,RANGEDEL-l#inf,RANGEDEL]

--- a/sstable/testdata/writer
+++ b/sstable/testdata/writer
@@ -24,8 +24,8 @@ g.DEL.6:
 h.MERGE.7:h
 i.RANGEDEL.8:j
 rangekey: j-k:{(#9,RANGEKEYDEL)}
-rangekey: k-l:{(#10,RANGEKEYUNSET,@t5)}
-rangekey: l-m:{(#11,RANGEKEYSET,@t10,foo)}
+rangekey: k-l:{(#10,RANGEKEYUNSET,@5)}
+rangekey: l-m:{(#11,RANGEKEYSET,@10,foo)}
 ----
 point:    [a#1,SET-h#7,MERGE]
 rangedel: [d#4,RANGEDEL-j#inf,RANGEDEL]
@@ -47,8 +47,8 @@ f.SET.6:f
 g.DEL.7:
 h.SINGLEDEL.8:
 rangekey: j-k:{(#9,RANGEKEYDEL)}
-rangekey: k-l:{(#10,RANGEKEYUNSET,@t5)}
-rangekey: l-m:{(#11,RANGEKEYSET,@t10,foo)}
+rangekey: k-l:{(#10,RANGEKEYUNSET,@5)}
+rangekey: l-m:{(#11,RANGEKEYSET,@10,foo)}
 ----
 point:    [a#1,SET-h#8,SINGLEDEL]
 rangekey: [j#9,RANGEKEYDEL-m#inf,RANGEKEYSET]
@@ -192,15 +192,15 @@ rangedel: [a#1,RANGEDEL-d#inf,RANGEDEL]
 seqnums:  [1-2]
 
 build-raw
-rangekey: a-b:{(#1,RANGEKEYSET,@t10,foo)}
-rangekey: a-b:{(#2,RANGEKEYSET,@t10,foo)}
+rangekey: a-b:{(#1,RANGEKEYSET,@10,foo)}
+rangekey: a-b:{(#2,RANGEKEYSET,@10,foo)}
 ----
 rangekey: [a#2,RANGEKEYSET-b#inf,RANGEKEYSET]
 seqnums:  [1-2]
 
 build-raw
-rangekey: b-c:{(#2,RANGEKEYSET,@t10,foo)}
-rangekey: a-b:{(#1,RANGEKEYSET,@t10,foo)}
+rangekey: b-c:{(#2,RANGEKEYSET,@10,foo)}
+rangekey: a-b:{(#1,RANGEKEYSET,@10,foo)}
 ----
 pebble: spans must be added in order: b > a
 
@@ -217,8 +217,8 @@ a.RANGEKEYDEL.1:d
 pebble: overlapping range keys must be fragmented: a#2,RANGEKEYDEL, a#1,RANGEKEYDEL
 
 build-raw
-rangekey: a-c:{(#1,RANGEKEYSET,@t10,foo)}
-rangekey: c-d:{(#2,RANGEKEYSET,@t10,foo)}
+rangekey: a-c:{(#1,RANGEKEYSET,@10,foo)}
+rangekey: c-d:{(#2,RANGEKEYSET,@10,foo)}
 ----
 rangekey: [a#1,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-2]
@@ -233,7 +233,7 @@ a.RANGEKEYDEL.1:b
 pebble: range keys starts must be added in increasing order: a#1,RANGEKEYDEL, a#1,RANGEKEYDEL
 
 build-raw
-rangekey: a-b:{(#1,RANGEKEYSET,@t10,foo) (#1,RANGEKEYUNSET,@t10) (#1,RANGEKEYDEL)}
+rangekey: a-b:{(#1,RANGEKEYSET,@10,foo) (#1,RANGEKEYUNSET,@t10) (#1,RANGEKEYDEL)}
 ----
 rangekey: [a#1,RANGEKEYSET-b#inf,RANGEKEYDEL]
 seqnums:  [1-1]
@@ -293,9 +293,9 @@ layout
 # Range keys, if present, are shown in the layout.
 
 build
-rangekey: a-b:{(#3,RANGEKEYSET,@t3,foo)}
-rangekey: b-c:{(#2,RANGEKEYSET,@t2,bar)}
-rangekey: c-d:{(#1,RANGEKEYSET,@t1,baz)}
+rangekey: a-b:{(#3,RANGEKEYSET,@3,foo)}
+rangekey: b-c:{(#2,RANGEKEYSET,@2,bar)}
+rangekey: c-d:{(#1,RANGEKEYSET,@1,baz)}
 ----
 rangekey: [a#3,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-3]
@@ -304,8 +304,8 @@ layout
 ----
          0  data (8)
         13  index (21)
-        39  range-key (82)
-       126  properties (501)
-       632  meta-index (57)
-       694  footer (53)
-       747  EOF
+        39  range-key (79)
+       123  properties (501)
+       629  meta-index (57)
+       691  footer (53)
+       744  EOF

--- a/sstable/testdata/writer_v3
+++ b/sstable/testdata/writer_v3
@@ -24,8 +24,8 @@ g.DEL.6:
 h.MERGE.7:h
 i.RANGEDEL.8:j
 rangekey: j-k:{(#9,RANGEKEYDEL)}
-rangekey: k-l:{(#10,RANGEKEYUNSET,@t5)}
-rangekey: l-m:{(#11,RANGEKEYSET,@t10,foo)}
+rangekey: k-l:{(#10,RANGEKEYUNSET,@5)}
+rangekey: l-m:{(#11,RANGEKEYSET,@10,foo)}
 ----
 point:    [a#1,SET-h#7,MERGE]
 rangedel: [d#4,RANGEDEL-j#inf,RANGEDEL]
@@ -165,15 +165,15 @@ rangedel: [a#1,RANGEDEL-d#inf,RANGEDEL]
 seqnums:  [1-2]
 
 build-raw
-rangekey: a-b:{(#1,RANGEKEYSET,@t10,foo)}
-rangekey: a-b:{(#2,RANGEKEYSET,@t10,foo)}
+rangekey: a-b:{(#1,RANGEKEYSET,@10,foo)}
+rangekey: a-b:{(#2,RANGEKEYSET,@10,foo)}
 ----
 rangekey: [a#2,RANGEKEYSET-b#inf,RANGEKEYSET]
 seqnums:  [1-2]
 
 build-raw
-rangekey: b-c:{(#2,RANGEKEYSET,@t10,foo)}
-rangekey: a-b:{(#1,RANGEKEYSET,@t10,foo)}
+rangekey: b-c:{(#2,RANGEKEYSET,@10,foo)}
+rangekey: a-b:{(#1,RANGEKEYSET,@10,foo)}
 ----
 pebble: spans must be added in order: b > a
 
@@ -190,8 +190,8 @@ a.RANGEKEYDEL.1:d
 pebble: overlapping range keys must be fragmented: a#2,RANGEKEYDEL, a#1,RANGEKEYDEL
 
 build-raw
-rangekey: a-c:{(#1,RANGEKEYSET,@t10,foo)}
-rangekey: c-d:{(#2,RANGEKEYSET,@t10,foo)}
+rangekey: a-c:{(#1,RANGEKEYSET,@10,foo)}
+rangekey: c-d:{(#2,RANGEKEYSET,@10,foo)}
 ----
 rangekey: [a#1,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-2]
@@ -206,7 +206,7 @@ a.RANGEKEYDEL.1:b
 pebble: range keys starts must be added in increasing order: a#1,RANGEKEYDEL, a#1,RANGEKEYDEL
 
 build-raw
-rangekey: a-b:{(#1,RANGEKEYSET,@t10,foo) (#1,RANGEKEYUNSET,@t10) (#1,RANGEKEYDEL)}
+rangekey: a-b:{(#1,RANGEKEYSET,@10,foo) (#1,RANGEKEYUNSET,@10) (#1,RANGEKEYDEL)}
 ----
 rangekey: [a#1,RANGEKEYSET-b#inf,RANGEKEYDEL]
 seqnums:  [1-1]
@@ -266,9 +266,9 @@ layout
 # Range keys, if present, are shown in the layout.
 
 build
-rangekey: a-b:{(#3,RANGEKEYSET,@t3,foo)}
-rangekey: b-c:{(#2,RANGEKEYSET,@t2,bar)}
-rangekey: c-d:{(#1,RANGEKEYSET,@t1,baz)}
+rangekey: a-b:{(#3,RANGEKEYSET,@3,foo)}
+rangekey: b-c:{(#2,RANGEKEYSET,@2,bar)}
+rangekey: c-d:{(#1,RANGEKEYSET,@1,baz)}
 ----
 rangekey: [a#3,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-3]
@@ -277,8 +277,8 @@ layout
 ----
          0  data (8)
         13  index (21)
-        39  range-key (82)
-       126  properties (501)
-       632  meta-index (57)
-       694  footer (53)
-       747  EOF
+        39  range-key (79)
+       123  properties (501)
+       629  meta-index (57)
+       691  footer (53)
+       744  EOF

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -758,7 +758,14 @@ var _ BlockPropertyCollector = (*testBlockPropCollector)(nil)
 
 func (c *testBlockPropCollector) Name() string { return "testBlockPropCollector" }
 
-func (c *testBlockPropCollector) Add(_ InternalKey, _ []byte) error {
+func (c *testBlockPropCollector) AddPointKey(_ InternalKey, _ []byte) error {
+	if c.errSite == errSiteAdd {
+		return c.err
+	}
+	return nil
+}
+
+func (c *testBlockPropCollector) AddRangeKeys(_ Span) error {
 	if c.errSite == errSiteAdd {
 		return c.err
 	}
@@ -887,7 +894,7 @@ func TestWriter_TableFormatCompatibility(t *testing.T) {
 				opts.BlockPropertyCollectors = []func() BlockPropertyCollector{
 					func() BlockPropertyCollector {
 						return NewBlockIntervalCollector(
-							"collector", &valueCharBlockIntervalCollector{charIdx: 0}, nil,
+							"collector", &valueCharIntervalMapper{charIdx: 0}, nil,
 						)
 					},
 				}

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -219,9 +219,7 @@ func TestTableRangeDeletionIter(t *testing.T) {
 						}
 					}
 				}
-				err = rangekey.Encode(rKeySpan, func(k base.InternalKey, v []byte) error {
-					return w.AddRangeKey(k, v)
-				})
+				err = w.EncodeSpan(rKeySpan)
 				if err != nil {
 					return err.Error()
 				}

--- a/testdata/ingest_target_level
+++ b/testdata/ingest_target_level
@@ -224,7 +224,7 @@ target
 # Point key-range key overlap
 define
 L5
-  rangekey:a-c:{(#1,RANGEKEYSET,@t10,foo)}
+  rangekey:a-c:{(#1,RANGEKEYSET,@10,foo)}
 ----
 L5:
   000004:[a#1,RANGEKEYSET-c#inf,RANGEKEYSET]
@@ -237,7 +237,7 @@ target
 # Range key-range key overlap.
 define
 L5
-  rangekey:a-c:{(#1,RANGEKEYSET,@t10,foo)}
+  rangekey:a-c:{(#1,RANGEKEYSET,@10,foo)}
 ----
 L5:
   000004:[a#1,RANGEKEYSET-c#inf,RANGEKEYSET]


### PR DESCRIPTION
This change makes the following improvements:

 - we now pass range key spans through a separate `AddRangeKeys` API.
   This is cleaner and avoids an unnecessary decode step on a span we
   just encoded.  The Writer no longer has a public `AddRangeKey`
   method - `EncodeSpan` is used instead.

 - we simplify the interface for block interval collectors: we now
   have an interface to map point keys and range key spans to
   intervals, plus an optional interface to apply a synthetic suffix.
   This greatly simplifies the implementation on the CRDB side (and
   allows it to be stateless).