### PR TITLE
crl-release-23.1: sstable: trace/expensive log when sstable footer read is slow

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1337,7 +1337,7 @@ func TestTracing(t *testing.T) {
 	_, closer, err := d.Get([]byte("hello"))
 	require.NoError(t, err)
 	closer.Close()
-	readerInitTraceString := "reading 37 bytes took 5ms\nreading 628 bytes took 5ms\n"
+	readerInitTraceString := "reading 53 bytes took 5ms\nreading 37 bytes took 5ms\nreading 628 bytes took 5ms\n"
 	iterTraceString := "reading 27 bytes took 5ms\nreading 29 bytes took 5ms\n"
 	require.Equal(t, readerInitTraceString+iterTraceString, tracer.buf.String())
 

--- a/internal/base/logger.go
+++ b/internal/base/logger.go
@@ -85,11 +85,13 @@ func (b *InMemLogger) Fatalf(format string, args ...interface{}) {
 type LoggerAndTracer interface {
 	Logger
 	// Eventf formats and emits a tracing log, if tracing is enabled in the
-	// current context.
+	// current context. It can also emit to a regular log, if expensive
+	// logging is enabled.
 	Eventf(ctx context.Context, format string, args ...interface{})
-	// IsTracingEnabled returns true if tracing is enabled. It can be used as an
-	// optimization to avoid calling Eventf (which will be a noop when tracing
-	// is not enabled) to avoid the overhead of boxing the args.
+	// IsTracingEnabled returns true if tracing is enabled for this context,
+	// or expensive logging is enabled. It can be used as an optimization to
+	// avoid calling Eventf (which will be a noop when tracing or expensive
+	// logging is not enabled) to avoid the overhead of boxing the args.
 	IsTracingEnabled(ctx context.Context) bool
 }
 

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -752,7 +752,7 @@ func TestFooterRoundTrip(t *testing.T) {
 							readable, err := NewSimpleReadable(f)
 							require.NoError(t, err)
 
-							result, err := readFooter(readable)
+							result, err := readFooter(readable, base.NoopLoggerAndTracer{})
 							require.NoError(t, err)
 							require.NoError(t, readable.Close())
 
@@ -805,7 +805,7 @@ func TestReadFooter(t *testing.T) {
 			readable, err := NewSimpleReadable(f)
 			require.NoError(t, err)
 
-			if _, err := readFooter(readable); err == nil {
+			if _, err := readFooter(readable, base.NoopLoggerAndTracer{}); err == nil {
 				t.Fatalf("expected %q, but found success", c.expected)
 			} else if !strings.Contains(err.Error(), c.expected) {
 				t.Fatalf("expected %q, but found %v", c.expected, err)


### PR DESCRIPTION
backport https://github.com/cockroachdb/pebble/pull/3745

----

This is a manual backport of https://github.com/cockroachdb/pebble/pull/3745

Relates to #3728