### PR TITLE
colblk: only align uint deltas

### DIFF
--- a/sstable/colblk/column.go
+++ b/sstable/colblk/column.go
@@ -192,6 +192,21 @@ func (d DeltaEncoding) String() string {
 	}
 }
 
+func (d DeltaEncoding) width() int {
+	switch d {
+	case DeltaEncodingConstant:
+		return 0
+	case DeltaEncodingUint8:
+		return 1
+	case DeltaEncodingUint16:
+		return 2
+	case DeltaEncodingUint32:
+		return 4
+	default:
+		panic("unreachable")
+	}
+}
+
 // ColumnWriter is an interface implemented by column encoders that accumulate a
 // column's values and then serialize them.
 type ColumnWriter interface {

--- a/sstable/colblk/testdata/raw_bytes
+++ b/sstable/colblk/testdata/raw_bytes
@@ -16,16 +16,14 @@ a
 build offset=1
 a
 ----
-00-01: x 00       # start offset
+0-1: x 00       # start offset
 # RawBytes
 # Offsets table
-# Padding
-01-04: x 000000   # aligning to 32-bit boundary
-04-08: x 00000000 # 32-bit constant: 0
-08-09: x 00       # data[0] = 0 [10 overall]
-09-10: x 01       # data[1] = 1 [11 overall]
+1-5: x 00000000 # 32-bit constant: 0
+5-6: x 00       # data[0] = 0 [7 overall]
+6-7: x 01       # data[1] = 1 [8 overall]
 # Data
-10-11: x 61       # data[0]: a
+7-8: x 61       # data[0]: a
 
 build offset=2
 a
@@ -33,13 +31,11 @@ a
 00-02: x 0000     # start offset
 # RawBytes
 # Offsets table
-# Padding
-02-04: x 0000     # aligning to 32-bit boundary
-04-08: x 00000000 # 32-bit constant: 0
-08-09: x 00       # data[0] = 0 [10 overall]
-09-10: x 01       # data[1] = 1 [11 overall]
+02-06: x 00000000 # 32-bit constant: 0
+06-07: x 00       # data[0] = 0 [8 overall]
+07-08: x 01       # data[1] = 1 [9 overall]
 # Data
-10-11: x 61       # data[0]: a
+08-09: x 61       # data[0]: a
 
 build offset=3
 a
@@ -47,13 +43,11 @@ a
 00-03: x 000000   # start offset
 # RawBytes
 # Offsets table
-# Padding
-03-04: x 00       # aligning to 32-bit boundary
-04-08: x 00000000 # 32-bit constant: 0
-08-09: x 00       # data[0] = 0 [10 overall]
-09-10: x 01       # data[1] = 1 [11 overall]
+03-07: x 00000000 # 32-bit constant: 0
+07-08: x 00       # data[0] = 0 [9 overall]
+08-09: x 01       # data[1] = 1 [10 overall]
 # Data
-10-11: x 61       # data[0]: a
+09-10: x 61       # data[0]: a
 
 build offset=4
 a

--- a/sstable/colblk/testdata/uints
+++ b/sstable/colblk/testdata/uints
@@ -140,6 +140,43 @@ b64:
   64: *colblk.UintBuilder[uint64].Size(9, 0) = 26
   64: *colblk.UintBuilder[uint64].Size(8, 0) = 16
 
+size rows=(9, 8) offset=1
+----
+b16:
+  16: *colblk.UintBuilder[uint16].Size(9, 1) = 20 [19 w/o offset]
+  16: *colblk.UintBuilder[uint16].Size(8, 1) = 11 [10 w/o offset]
+b32:
+  32: *colblk.UintBuilder[uint32].Size(9, 1) = 24 [23 w/o offset]
+  32: *colblk.UintBuilder[uint32].Size(8, 1) = 13 [12 w/o offset]
+b64:
+  64: *colblk.UintBuilder[uint64].Size(9, 1) = 28 [27 w/o offset]
+  64: *colblk.UintBuilder[uint64].Size(8, 1) = 17 [16 w/o offset]
+
+size rows=(9, 8) offset=2
+----
+b16:
+  16: *colblk.UintBuilder[uint16].Size(9, 2) = 20 [18 w/o offset]
+  16: *colblk.UintBuilder[uint16].Size(8, 2) = 12 [10 w/o offset]
+b32:
+  32: *colblk.UintBuilder[uint32].Size(9, 2) = 24 [22 w/o offset]
+  32: *colblk.UintBuilder[uint32].Size(8, 2) = 14 [12 w/o offset]
+b64:
+  64: *colblk.UintBuilder[uint64].Size(9, 2) = 28 [26 w/o offset]
+  64: *colblk.UintBuilder[uint64].Size(8, 2) = 18 [16 w/o offset]
+
+
+size rows=(9, 8) offset=5
+----
+b16:
+  16: *colblk.UintBuilder[uint16].Size(9, 5) = 24 [19 w/o offset]
+  16: *colblk.UintBuilder[uint16].Size(8, 5) = 15 [10 w/o offset]
+b32:
+  32: *colblk.UintBuilder[uint32].Size(9, 5) = 28 [23 w/o offset]
+  32: *colblk.UintBuilder[uint32].Size(8, 5) = 17 [12 w/o offset]
+b64:
+  64: *colblk.UintBuilder[uint64].Size(9, 5) = 32 [27 w/o offset]
+  64: *colblk.UintBuilder[uint64].Size(8, 5) = 21 [16 w/o offset]
+
 # We should be able to write up to 2^16-1 without triggering a 32-bit encoding.
 
 write
@@ -646,15 +683,18 @@ write
 0:1 1:63936 2:2957252
 ----
 
-size rows=(3)
+size rows=(3) offset=1
 ----
 b64:
-  64: *colblk.UintBuilder[uint64].Size(3, 0) = 20
+  64: *colblk.UintBuilder[uint64].Size(3, 1) = 24 [23 w/o offset]
 
-finish widths=(64) rows=3
+finish widths=(64) rows=3 offset=1
 ----
 b64: *colblk.UintBuilder[uint64]:
-00-08: x 0100000000000000 # 64-bit constant: 1
-08-12: x 00000000         # data[0] = 0
-12-16: x bff90000         # data[1] = 63935
-16-20: x c31f2d00         # data[2] = 2957251
+00-01: x 00               # artificial start offset
+01-09: x 0100000000000000 # 64-bit constant: 1
+# Padding
+09-12: x 000000           # aligning to 32-bit boundary
+12-16: x 00000000         # data[0] = 0
+16-20: x bff90000         # data[1] = 63935
+20-24: x c31f2d00         # data[2] = 2957251


### PR DESCRIPTION
Previously, even when using a delta-encoding, the uint column encoding aligned its output to the width of the logical uint. This was necessary to read the full-width constant using a pointer cast. This commit adapts the encoding to only align to the width of the deltas, using ordinary binary.LittleEndian methods for setting and getting the constant. This get only needs to happen once, while parsing the column. This reduces the amount of alignment padding necessary when delta encoding is effective.