### PR TITLE
colblk: add PrefixBytes, PrefixBytesBuilder

### DIFF
--- a/sstable/colblk/column.go
+++ b/sstable/colblk/column.go
@@ -220,8 +220,10 @@ type ColumnWriter interface {
 	//
 	// The supplied buf must have enough space at the provided offset to fit the
 	// column. The caller may use Size() to calculate the exact size required.
-	// If [rows] is ≤ the highest row index at which a value has been set,
-	// Finish will only serialize the first [rows] values.
+	// The caller passes the number of rows they want to serialize. All
+	// implementations of Finish must support cases where rows is the number of
+	// rows the caller has set, or one less. Some implementations may be more
+	// permissive.
 	//
 	// The provided column index must be less than NumColumns(). Finish is
 	// called for each index < NumColumns() in order.

--- a/sstable/colblk/prefix_bytes.go
+++ b/sstable/colblk/prefix_bytes.go
@@ -1,0 +1,956 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package colblk
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math/bits"
+	"strings"
+	"unsafe"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/binfmt"
+	"github.com/cockroachdb/pebble/internal/invariants"
+)
+
+// PrefixBytes holds an array of lexicograpghically ordered byte slices. It
+// provides prefix compression. Prefix compression applies strongly to two cases
+// in CockroachDB: removal of the "[/tenantID]/tableID/indexID" prefix that is
+// present on all table data keys, and multiple versions of a key that are
+// distinguished only by different timestamp suffixes. With columnar blocks
+// enabling the timestamp to be placed in a separate column, the multiple
+// version problem becomes one of efficiently handling exact duplicate keys.
+// PrefixBytes builds offs of the RawBytes encoding, introducing n/bundleSize+1
+// additional slices for encoding n/bundleSize bundle prefixes and 1
+// column-level prefix.
+//
+// To understand the PrefixBytes layout, we'll work through an example using
+// these 15 keys:
+//
+//	   01234567890
+//	 0 aaabbbc
+//	 1 aaabbbcc
+//	 2 aaabbbcde
+//	 3 aaabbbce
+//	 4 aaabbbdee*
+//	 5 aaabbbdee*
+//	 6 aaabbbdee*
+//	 7 aaabbbeff
+//	 8 aaabbe
+//	 9 aaabbeef*
+//	10 aaabbeef*
+//	11 aaabc
+//	12 aabcceef*
+//	13 aabcceef*
+//	14 aabcceef*
+//
+// The total length of these keys is 127 bytes. There are 3 keys which occur
+// multiple times (delineated by the * suffix) which models multiple versions of
+// the same MVCC key in CockroachDB. There is a shared prefix to all of the keys
+// which models the "[/tenantID]/tableID/indexID" present on CockroachDB table
+// data keys. There are other shared prefixes which model identical values in
+// table key columns.
+//
+// The table below shows the components of the KeyBytes encoding for these 15
+// keys when using a bundle size of 4 which results in 4 bundles. The 15 keys
+// are encoded into 20 slices: 1 block prefix, 4 bundle prefixes, and 15
+// suffixes. The first slice in the table is the block prefix that is shared by
+// all keys in the block. The first slice in each bundle is the bundle prefix
+// which is shared by all keys in the bundle.
+//
+//	 idx   | row   | offset | data
+//	-------+-------+--------+------
+//	     0 |       |      2 | aa
+//	     1 |       |      7 | ..abbbc
+//	     2 |     0 |      7 | .......
+//	     3 |     1 |      8 | .......c
+//	     4 |     2 |     10 | .......de
+//	     5 |     3 |     11 | .......e
+//	     6 |       |     15 | ..abbb
+//	     7 |     4 |     19 | ......dee*
+//	     8 |     5 |     19 | ......
+//	     9 |     6 |     19 | ......
+//	    10 |     7 |     22 | ......eff
+//	    11 |       |     24 | ..ab
+//	    12 |     8 |     26 | ....be
+//	    13 |     9 |     31 | ....beef*
+//	    14 |    10 |     31 | ....
+//	    15 |    11 |     32 | ....c
+//	    16 |       |     39 | ..bcceef*
+//	    17 |    12 |     39 | .........
+//	    18 |    13 |     39 | .........
+//	    19 |    14 |     39 | .........
+//
+// The offset column in the table points to the start and end index within the
+// RawBytes data array for each of the 20 slices defined above (the 15 key
+// suffixes + 4 bundle key prefixes + block key prefix). Offset[0] is the length
+// of the first slice which is always anchored at data[0]. The data columns
+// display the portion of the data array the slice covers. For row slices, an
+// empty suffix column indicates that the slice is identical to the slice at the
+// previous index which is indicated by the slice's offset being equal to the
+// previous slice's offset. Due to the lexicographic sorting, the key at row i
+// can't be a prefix of the key at row i-1 or it would have sorted before the
+// key at row i-1. And if the key differs then only the differing bytes will be
+// part of the suffix and not contained in the bundle prefix.
+//
+// The end result of this encoding is that we can store the 127 bytes of the 15
+// keys plus their start and end offsets (which would naively consume 15*4=60
+// bytes for at least the key lengths) in 64 bytes (39 bytes of data + 4 bytes
+// of offset constant + 20 bytes of offset delta data + 1 byte of bundle size).
+//
+// # Physical representation
+//
+//	+==================================================================+
+//	|                        Bundle size (1 byte)                      |
+//	|                                                                  |
+//	| The bundle size indicates how many keys prefix compression may   |
+//	| apply across. Every bundleSize keys, prefix compression restarts.|
+//	| The bundleSize is required to be a power of two,  and this 1-    |
+//	| byte prefix stores log2(bundleSize).                             |
+//	+==================================================================+
+//	|                            RawBytes                              |
+//	|                                                                  |
+//	| A modified RawBytes encoding is used to store the data slices. A |
+//	| PrefixBytes column storing n keys will encode 2+n+n/bundleSize   |
+//	| slices. Unlike the RawBytes encoding, the first offset encoded   |
+//	| is not guaranteed to be zero. In the PrefixBytes encoding, the   |
+//	| first offset encodes the length of the column-wide prefix. The   |
+//	| column-wide prefix is stored in slice(0, offset(0)).             |
+//	|                                                                  |
+//	|  +------------------------------------------------------------+  |
+//	|  |                       Offset table                         |  |
+//	|  |                                                            |  |
+//	|  | A Uint32 column encoding offsets into the string data,     |  |
+//	|  | possibly delta8 or delta16 encoded. When a delta encoding  |  |
+//	|  | is used, the base constant is always zero.                 |  |
+//	|  +------------------------------------------------------------+  |
+//	|  | offsetDelta[0] | offsetDelta[1] | ... | offsetDelta[m]     |  |
+//	|  +------------------------------------------------------------+  |
+//	|  | prefix-compressed string data                              |  |
+//	|  | ...                                                        |  |
+//	|  +------------------------------------------------------------+  |
+//	+==================================================================+
+//
+// # Reads
+//
+// This encoding provides O(1) access to any row by calculating the bundle for
+// the row (5*(row/4)), then the row's index within the bundle (1+(row%4)). If
+// the slice's offset equals the previous slice's offset then we step backward
+// until we find a non-empty slice or the start of the bundle (a variable number
+// of steps, but bounded by the bundle size).
+//
+// Forward iteration can easily reuse the previous row's key with a check on
+// whether the row's slice is empty.  Reverse iteration can reuse the next row's
+// key by looking at the next row's offset to determine whether we are in the
+// middle of a run of equal keys or at an edge. When reverse iteration steps
+// over an edge it has to continue backward until a non-empty slice is found
+// (just as in absolute positioning).
+//
+// The Seek{GE,LT} routines first binary search on the first key of each bundle
+// which can be retrieved without data movement because the bundle prefix is
+// immediately adjacent to it in the data array. We can slightly optimize the
+// binary search by skipping over all of the keys in the bundle on prefix
+// mismatches.
+type PrefixBytes struct {
+	rows            int
+	bundleShift     int
+	bundleMask      int
+	sharedPrefixLen int
+	rawBytes        RawBytes
+}
+
+// MakePrefixBytes constructs an accessor for an array of lexicographically
+// sorted byte slices constructed by PrefixBytesBuilder. Count must be the
+// number of logical slices within the array.
+func MakePrefixBytes(count int, b []byte, offset uint32, enc ColumnEncoding) PrefixBytes {
+	// The first byte of a PrefixBytes-encoded column is the bundle size
+	// expressed as log2 of the bundle size (the bundle size must always be a
+	// power of two).
+	bundleShift := int(*((*uint8)(unsafe.Pointer(&b[offset]))))
+	nBundles := 1 + (count-1)>>bundleShift
+
+	pb := PrefixBytes{
+		rows:        count,
+		bundleShift: bundleShift,
+		bundleMask:  ^((1 << bundleShift) - 1),
+		rawBytes:    MakeRawBytes(count+nBundles, b, offset+1, enc),
+	}
+	// We always set the base to zero.
+	if pb.rawBytes.offsets.base != 0 {
+		panic(errors.AssertionFailedf("unexpected non-zero base in offsets"))
+	}
+	pb.sharedPrefixLen = int(pb.rawBytes.offsets.At(0))
+	return pb
+}
+
+// SharedPrefix return a []byte of the shared prefix that was extracted from
+// all of the values in the Bytes vector. The returned slice should not be
+// mutated.
+func (b PrefixBytes) SharedPrefix() []byte {
+	// The very first slice is the prefix for the entire column.
+	return b.rawBytes.slice(0, b.rawBytes.offsets.At(0))
+}
+
+// RowBundlePrefix takes a row index and returns a []byte of the prefix shared
+// among all the keys in the row's bundle. The returned slice should not be
+// mutated.
+func (b PrefixBytes) RowBundlePrefix(row int) []byte {
+	// AND-ing the row with the bundle mask removes the least significant bits
+	// of the row, which encode the row's index within the bundle.
+	i := (row >> b.bundleShift) + (row & b.bundleMask)
+	return b.rawBytes.slice(b.rawBytes.offsets.At(i), b.rawBytes.offsets.At(i+1))
+}
+
+// BundlePrefix returns the prefix of the i-th bundle in the column. The
+// provided i must be in the range [0, Bundles()). The returned slice should not
+// be mutated.
+func (b PrefixBytes) BundlePrefix(i int) []byte {
+	j := (i << b.bundleShift) + i
+	return b.rawBytes.slice(b.rawBytes.offsets.At(j), b.rawBytes.offsets.At(j+1))
+}
+
+// RowSuffix returns a []byte of the suffix unique to the row. A row's full key
+// is the result of concatenating SharedPrefix(), BundlePrefix() and
+// RowSuffix().
+//
+// The returned slice should not be mutated.
+func (b PrefixBytes) RowSuffix(row int) []byte {
+	i := 1 + (row >> b.bundleShift) + row
+	// Retrieve the low and high offsets indicating the start and end of the
+	// row's suffix slice.
+	lowOff := b.rawBytes.offsets.At(i)
+	highOff := b.rawBytes.offsets.At(i + 1)
+	// If there's a non-empty slice for the row, this row is different than its
+	// predecessor.
+	if lowOff != highOff {
+		return b.rawBytes.slice(lowOff, highOff)
+	}
+	// Otherwise, an empty slice indicates a duplicate key. We need to find the
+	// first non-empty predecessor within the bundle, or if all the rows are
+	// empty, return nil.
+	//
+	// Compute the index of the first row in the bundle so we know when to stop.
+	firstIndex := 1 + (row >> b.bundleShift) + (row & b.bundleMask)
+	for i > firstIndex {
+		// Step back a row, and check if the slice is non-empty.
+		i--
+		highOff = lowOff
+		lowOff = b.rawBytes.offsets.At(i)
+		if lowOff != highOff {
+			return b.rawBytes.slice(lowOff, highOff)
+		}
+	}
+	// All the rows in the bundle are empty.
+	return nil
+}
+
+// Rows returns the count of rows whose keys are encoded within the PrefixBytes.
+func (b PrefixBytes) Rows() int {
+	return b.rows
+}
+
+// BundleCount returns the count of bundles within the PrefixBytes.
+func (b PrefixBytes) BundleCount() int {
+	return 1 + (b.rows-1)>>b.bundleShift
+}
+
+// Search searchs for the first key in the PrefixBytes that is greater than or
+// equal to k, returning the index of the key and whether an equal key was
+// found.
+func (b PrefixBytes) Search(k []byte) (int, bool) {
+	// First compare to the block-level shared prefix.
+	n := min(len(k), b.sharedPrefixLen)
+	c := bytes.Compare(k[:n], unsafe.Slice((*byte)(b.rawBytes.data), b.sharedPrefixLen))
+	switch {
+	case c < 0 || (c == 0 && n < b.sharedPrefixLen):
+		// Search key is less than any prefix in the block.
+		return 0, false
+	case c > 0:
+		// Search key is greater than any key in the block.
+		return b.rows, false
+	}
+	// Trim the block-level shared prefix from the search key.
+	k = k[b.sharedPrefixLen:]
+
+	// Binary search among the first keys of each bundle.
+	//
+	// Define f(-1) == false and f(upper) == true.
+	// Invariant: f(bi-1) == false, f(upper) == true.
+	nBundles := b.BundleCount()
+	bi, upper := 0, nBundles
+	upperEqual := false
+	for bi < upper {
+		h := int(uint(bi+upper) >> 1) // avoid overflow when computing h
+		// bi ≤ h < upper
+
+		// Retrieve the first key in the h-th (zero-indexed) bundle. We take
+		// advantage of the fact that the first row is stored contiguously in
+		// the data array (modulo the block prefix) to slice the entirety of the
+		// first key:
+		//
+		//       b u n d l e p r e f i x f i r s t k e y r e m a i n d e r
+		//       ^                       ^                                 ^
+		//     offset(j)             offset(j+1)                       offset(j+2)
+		//
+		j := (h << b.bundleShift) + h
+		bundleFirstKey := b.rawBytes.slice(b.rawBytes.offsets.At(j), b.rawBytes.offsets.At(j+2))
+		c = bytes.Compare(k, bundleFirstKey)
+		switch {
+		case c > 0:
+			bi = h + 1 // preserves f(bi-1) == false
+		case c < 0:
+			upper = h // preserves f(upper) == true
+			upperEqual = false
+		default:
+			// c == 0
+			upper = h // preserves f(upper) == true
+			upperEqual = true
+		}
+	}
+	if bi == 0 {
+		// The very first key is ≥ k. Return it.
+		return 0, upperEqual
+	}
+	// The first key of the bundle bi is ≥ k, but any of the keys in the
+	// previous bundle besides the first could also be ≥ k. We can binary search
+	// among them, but if the seek key doesn't share the previous bundle's
+	// prefix there's no need.
+	j := ((bi - 1) << b.bundleShift) + (bi - 1)
+	bundlePrefix := b.rawBytes.slice(b.rawBytes.offsets.At(j), b.rawBytes.offsets.At(j+1))
+	if len(bundlePrefix) > len(k) || !bytes.Equal(k[:len(bundlePrefix)], bundlePrefix) {
+		// The search key doesn't share the previous bundle's prefix, so all of
+		// the keys in the previous bundle must be less than k. We know the
+		// first key of bi is ≥ k, so return it.
+		if bi<<b.bundleShift < b.rows {
+			return bi << b.bundleShift, upperEqual
+		} else {
+			return b.rows, false
+		}
+	}
+	// Binary search among bundle bi-1's key remainders after stripping bundle
+	// bi-1's prefix.
+	//
+	// Define f(l-1) == false and f(u) == true.
+	// Invariant: f(l-1) == false, f(u) == true.
+	k = k[len(bundlePrefix):]
+	l := 1
+	u := min(1<<b.bundleShift, b.rows-(bi-1)<<b.bundleShift)
+	for l < u {
+		h := int(uint(l+u) >> 1) // avoid overflow when computing h
+		// l ≤ h < u
+
+		// j is currently the index of the offset of bundle bi-i's prefix.
+		//
+		//     b u n d l e p r e f i x f i r s t k e y s e c o n d k e y
+		//     ^                       ^               ^
+		//  offset(j)              offset(j+1)     offset(j+2)
+		//
+		// The beginning of the zero-indexed i-th key of the bundle is at
+		// offset(j+i+1).
+		//
+		hStart := b.rawBytes.offsets.At(j + h + 1)
+		hEnd := b.rawBytes.offsets.At(j + h + 2)
+		// There's a complication with duplicate keys. When keys are repeated,
+		// the PrefixBytes encoding avoids re-encoding the duplciate key,
+		// instead encoding an empty slice. While binary searching, if we land
+		// on an empty slice, we need to back up until we find a non-empty slice
+		// which is the key at index h. We iterate with p. If we eventually find
+		// the duplicated key at index p < h and determine f(p) == true, then we
+		// can set u=p (rather than h). If we determine f(p)==false, then we
+		// know f(h)==false too and set l=h+1.
+		p := h
+		if hStart == hEnd {
+			// Back up looking for an empty slice.
+			for hStart == hEnd && p >= l {
+				p--
+				hEnd = hStart
+				hStart = b.rawBytes.offsets.At(j + p + 1)
+			}
+			// If we backed up to l-1, then all the rows in indexes [l, h] have
+			// the same keys as index l-1. We know f(l-1) == false [see the
+			// invariants above], so we can move l to h+1 and continue the loop
+			// without performing any key comparisons.
+			if p < l {
+				l = h + 1
+				continue
+			}
+		}
+		rem := b.rawBytes.slice(hStart, hEnd)
+		c = bytes.Compare(k, rem)
+		switch {
+		case c > 0:
+			l = h + 1 // preserves f(l-1) == false
+		case c < 0:
+			u = p // preserves f(u) == true
+			upperEqual = false
+		default:
+			// c == 0
+			u = p // preserves f(u) == true
+			upperEqual = true
+		}
+	}
+	i := (bi-1)<<b.bundleShift + l
+	if i < b.rows {
+		return i, upperEqual
+	} else {
+		return b.rows, false
+	}
+}
+
+func prefixBytesToBinFormatter(
+	f *binfmt.Formatter, count int, enc ColumnEncoding, sliceFormatter func([]byte) string,
+) {
+	if sliceFormatter == nil {
+		sliceFormatter = defaultSliceFormatter
+	}
+	pb := MakePrefixBytes(count, f.Data(), uint32(f.Offset()), enc)
+	f.CommentLine("PrefixBytes")
+	f.HexBytesln(1, "bundleSize: %d", 1<<pb.bundleShift)
+	f.CommentLine("Offsets table")
+	dataOffset := uint64(f.Offset()) + uint64(uintptr(pb.rawBytes.data)-uintptr(pb.rawBytes.start))
+	uintsToBinFormatter(f, pb.rawBytes.slices+1, ColumnDesc{DataType: DataTypeUint32, Encoding: enc},
+		func(offsetDelta, offsetBase uint64) string {
+			// NB: offsetBase will always be zero for PrefixBytes columns.
+			return fmt.Sprintf("%d [%d overall]", offsetDelta+offsetBase, offsetDelta+offsetBase+dataOffset)
+		})
+	f.CommentLine("Data")
+
+	// The first offset encodes the length of the block prefix.
+	blockPrefixLen := pb.rawBytes.offsets.At(0)
+	f.HexBytesln(int(blockPrefixLen), "data[00]: %s (block prefix)",
+		sliceFormatter(pb.rawBytes.slice(0, blockPrefixLen)))
+
+	k := 2 + (count-1)>>pb.bundleShift + count
+	startOff := blockPrefixLen
+	prevLen := blockPrefixLen
+
+	// Use dots to indicate string data that's elided because it falls within
+	// the block or bundle prefix.
+	dots := strings.Repeat(".", int(blockPrefixLen))
+	// Iterate through all the slices in the data section, annotating bundle
+	// prefixes and using dots to indicate elided data.
+	for i := 1; i < k; i++ {
+		endOff := pb.rawBytes.offsets.At(i)
+		if (i-1)%(1+(1<<pb.bundleShift)) == 0 {
+			// This is a bundle prefix.
+			dots = strings.Repeat(".", int(blockPrefixLen))
+			f.HexBytesln(int(endOff-startOff), "data[%02d]: %s%s (bundle prefix)", i, dots, sliceFormatter(pb.rawBytes.At(i-1)))
+			dots = strings.Repeat(".", int(endOff-startOff+blockPrefixLen))
+			prevLen = endOff - startOff + blockPrefixLen
+		} else if startOff == endOff {
+			// An empty slice that's not a block or bundle prefix indicates a
+			// repeat key.
+			f.HexBytesln(0, "data[%02d]: %s", i, strings.Repeat(".", int(prevLen)))
+		} else {
+			f.HexBytesln(int(endOff-startOff), "data[%02d]: %s%s", i, dots, sliceFormatter(pb.rawBytes.At(i-1)))
+			prevLen = uint32(len(dots)) + endOff - startOff
+		}
+		startOff = endOff
+	}
+}
+
+// PrefixBytesBuilder encodes a column of lexicographically-sorted byte slices,
+// applying prefix compression to reduce the encoded size.
+type PrefixBytesBuilder struct {
+	// TODO(jackson): If prefix compression is very effective, the encoded size
+	// may remain very small while the physical in-memory size of the
+	// in-progress data slice may grow very large. This may pose memory usage
+	// problems during block building.
+	data                      []byte // The raw, concatenated keys w/o any prefix compression
+	nKeys                     int    // The number of keys added to the builder
+	bundleSize                int    // The number of keys per bundle
+	bundleShift               int    // log2(bundleSize)
+	completedBundleLen        int    // The encoded size of completed bundles
+	currentBundleLen          int    // The raw size of the current bundle's keys
+	currentBundleKeys         int    // The number of physical keys in the current bundle
+	currentBundlePrefixOffset int    // The index of the offset for the current bundle prefix
+	blockPrefixLen            uint32 // The length of the block-level prefix
+	blockPrefixLenUpdated     int    // The row index of the last row that updated the block prefix
+	lastKeyLen                int    // The length of the last key added to the builder
+	lastLastKeyLen            int    // The length of the key before the last key added to the builder
+	offsets                   struct {
+		count int // The number of offsets in the builder
+		// elemsSize is the size of the array (in count of uint32 elements; not
+		// bytes)
+		elemsSize int
+		// elems provides access to elements without bounds checking. elems is
+		// grown automatically in addOffset.
+		elems UnsafeRawSlice[uint32]
+	}
+	maxShared uint16
+}
+
+// Init initializes the PrefixBytesBuilder with the specified bundle size. The
+// builder will produce a prefix-compressed column of data type
+// DataTypePrefixBytes. The [bundleSize] indicates the number of keys that form
+// a "bundle," across which prefix-compression is applied. All keys in the
+// column will share a column-wide prefix if there is one.
+func (b *PrefixBytesBuilder) Init(bundleSize int) {
+	if bundleSize > 0 && (bundleSize&(bundleSize-1)) != 0 {
+		panic(errors.AssertionFailedf("prefixbytes bundle size %d is not a power of 2", bundleSize))
+	}
+	*b = PrefixBytesBuilder{
+		data:       b.data[:0],
+		bundleSize: bundleSize,
+		offsets:    b.offsets,
+	}
+	b.offsets.count = 0
+	if b.bundleSize > 0 {
+		b.bundleShift = bits.TrailingZeros32(uint32(bundleSize))
+		b.maxShared = (1 << 16) - 1
+	}
+}
+
+// NumColumns implements ColumnWriter.
+func (b *PrefixBytesBuilder) NumColumns() int { return 1 }
+
+// Reset resets the builder to an empty state, preserving the existing bundle
+// size.
+func (b *PrefixBytesBuilder) Reset() {
+	*b = PrefixBytesBuilder{
+		data:        b.data[:0],
+		bundleSize:  b.bundleSize,
+		bundleShift: b.bundleShift,
+		offsets:     b.offsets,
+		maxShared:   b.maxShared,
+	}
+	b.offsets.count = 0
+}
+
+// Put adds the provided key to the column. The provided key must be
+// lexicographically greater than or equal to the previous key added to the
+// builder.
+//
+// The provided bytesSharedWithPrev must be the length of the byte prefix the
+// provided key shares with the previous key. The caller is required to provide
+// this because in the primary expected use, the caller will already need to
+// compute it for the purpose of determining whether successive blocks share the
+// same prefix.
+func (b *PrefixBytesBuilder) Put(key []byte, bytesSharedWithPrev int) {
+	if invariants.Enabled {
+		if b.maxShared == 0 {
+			panic(errors.AssertionFailedf("maxShared must be positive"))
+		}
+		if b.nKeys > 0 {
+			if bytes.Compare(key, b.data[len(b.data)-b.lastKeyLen:]) < 0 {
+				panic(errors.AssertionFailedf("keys must be added in order: %q < %q", key, b.data[len(b.data)-b.lastKeyLen:]))
+			}
+			if bytesSharedWithPrev != bytesSharedPrefix(key, b.data[len(b.data)-b.lastKeyLen:]) {
+				panic(errors.AssertionFailedf("bytesSharedWithPrev %d != %d", bytesSharedWithPrev,
+					bytesSharedPrefix(key, b.data[len(b.data)-b.lastKeyLen:])))
+			}
+		}
+	}
+
+	switch {
+	case b.nKeys == 0:
+		// We're adding the first key to the block. Initialize the
+		// block prefix to the length of this key.
+		b.blockPrefixLen = uint32(min(len(key), int(b.maxShared)))
+		b.blockPrefixLenUpdated = 0
+		// Set a placeholder offset for the block prefix length.
+		b.addOffset(0)
+		// Add an offset for the bundle prefix length.
+		b.addOffset(uint32(len(b.data) + min(len(key), int(b.maxShared))))
+		b.nKeys++
+		b.lastLastKeyLen = b.lastKeyLen
+		b.lastKeyLen = len(key)
+		b.currentBundleLen = len(key)
+		b.currentBundlePrefixOffset = 1
+		b.currentBundleKeys = 1
+		b.data = append(b.data, key...)
+		b.addOffset(uint32(len(b.data)))
+	case b.nKeys%b.bundleSize == 0:
+		// We're starting a new bundle so we can compute what the
+		// encoded size of the previous bundle will be.
+		bundlePrefixLen := b.offsets.elems.At(b.currentBundlePrefixOffset) - b.offsets.elems.At(b.currentBundlePrefixOffset-1)
+		b.completedBundleLen += b.currentBundleLen - (b.currentBundleKeys-1)*int(bundlePrefixLen)
+
+		// Update the block prefix length if necessary. The caller tells us how
+		// many bytes of prefix this key shares with the previous key. The block
+		// prefix can only shrink if the bytes shared with the previous key are
+		// less than the block prefix length, in which case the new block prefix
+		// is the number of bytes shared with the previous key.
+		if uint32(bytesSharedWithPrev) < b.blockPrefixLen {
+			b.blockPrefixLen = uint32(bytesSharedWithPrev)
+			b.blockPrefixLenUpdated = b.nKeys
+		}
+
+		// We're adding the first key to the current bundle. Initialize
+		// the bundle prefix to the length of this key.
+		b.currentBundlePrefixOffset = b.offsets.count
+		b.addOffset(uint32(len(b.data) + min(len(key), int(b.maxShared))))
+		b.nKeys++
+		b.lastLastKeyLen = b.lastKeyLen
+		b.lastKeyLen = len(key)
+		b.currentBundleLen = len(key)
+		b.currentBundleKeys = 1
+		b.data = append(b.data, key...)
+		b.addOffset(uint32(len(b.data)))
+	default:
+		// Adding a new key to an existing bundle.
+		// Update the bundle prefix length. Note that the shared prefix length
+		// can only shrink as new values are added. During construction, the
+		// bundle prefix value is stored contiguously in the data array so even
+		// if the bundle prefix length changes no adjustment is needed to that
+		// value or to the first key in the bundle.
+		bundlePrefixLen := b.offsets.elems.At(b.currentBundlePrefixOffset) - b.offsets.elems.At(b.currentBundlePrefixOffset-1)
+		if uint32(bytesSharedWithPrev) < bundlePrefixLen {
+			b.offsets.elems.set(b.currentBundlePrefixOffset, b.offsets.elems.At(b.currentBundlePrefixOffset-1)+uint32(bytesSharedWithPrev))
+			if uint32(bytesSharedWithPrev) < b.blockPrefixLen {
+				b.blockPrefixLen = uint32(bytesSharedWithPrev)
+				b.blockPrefixLenUpdated = b.nKeys
+			}
+		}
+		b.nKeys++
+		if bytesSharedWithPrev == len(key) {
+			b.addOffset(b.offsets.elems.At(b.offsets.count - 1))
+			return
+		}
+		b.lastLastKeyLen = b.lastKeyLen
+		b.lastKeyLen = len(key)
+		b.currentBundleLen += len(key)
+		b.currentBundleKeys++
+		b.data = append(b.data, key...)
+		b.addOffset(uint32(len(b.data)))
+	}
+}
+
+// PrevKey returns the previous key added to the builder through Put. The key is
+// guaranteed to be stable until Finish or Reset is called.
+func (b *PrefixBytesBuilder) PrevKey() []byte {
+	return b.data[len(b.data)-b.lastKeyLen:]
+}
+
+// addOffset adds an offset to the offsets table. If necessary, addOffset will
+// grow the offset table to accommodate the new offset.
+func (b *PrefixBytesBuilder) addOffset(offset uint32) {
+	if b.offsets.count == b.offsets.elemsSize {
+		// Double the size of the allocated array, or initialize it to at least
+		// 64 rows if this is the first allocation.
+		n2 := max(b.offsets.elemsSize<<1, 64)
+		newDataTyped := make([]uint32, n2)
+		copy(newDataTyped, b.offsets.elems.Slice(b.offsets.elemsSize))
+		b.offsets.elems = makeUnsafeRawSlice[uint32](unsafe.Pointer(&newDataTyped[0]))
+		b.offsets.elemsSize = n2
+	}
+	b.offsets.elems.set(b.offsets.count, offset)
+	b.offsets.count++
+}
+
+// prefixCompressionSizing holds the sizing information for the
+// prefix-compressed data structure. It's used in
+// PrefixBytesBuilder.{Size,Finish}.
+type prefixCompressionSizing struct {
+	offsetCount       uint32 // number of offsets that will be encoded
+	offsetDeltaWidth  uint32 // width of each offset delta (1, 2 or 4)
+	compressedDataLen uint32 // length of the compressed string data
+	blockPrefixLen    uint32 // length of the prefix shared by all keys
+	// currentBundlePrefixLen is the length of the "current" bundle's prefix.
+	// The current bundle holds all keys that are not included within
+	// PrefixBytesBuilder.completedBundleLen. If the addition of a key causes
+	// the creation of a new bundle, the previous bundle's size is incorporated
+	// into completedBundleLen and currentBundlePrefixLen is updated to the
+	// length of the new bundle key. This ensures that there's always at least 1
+	// key in the "current" bundle allowing Finish to accept rows = nKeys-1.
+	//
+	// Note that currentBundlePrefixLen is inclusive of the blockPrefixLen.
+	currentBundlePrefixLen uint32
+}
+
+// computePrefixCompressionSizing computes the size of the prefix-compressed
+// PrefixBytes structure's components if encoding the first [rows] rows. Like
+// [Finish], computePrefixCompressionSizing requires [rows] == nKeys or nKeys-1.
+func (b *PrefixBytesBuilder) computePrefixCompressionSizing(
+	rows int,
+) (sizing prefixCompressionSizing) {
+	// To encode [rows] rows, we need to encode:
+	// - 1 block prefix,
+	// - (rows-1)/bundleSize+1 bundle prefixes
+	// - [rows] per-row suffixes
+	sizing.offsetCount = uint32(2 + (rows-1)>>b.bundleShift + rows)
+
+	if rows <= 1 {
+		// If we haven't added enough offsets to perform prefix compression,
+		// then the compressed length is the uncompressed length.
+		sizing.compressedDataLen = b.offsets.elems.At(int(sizing.offsetCount) - 1)
+		sizing.offsetDeltaWidth = max(1, deltaWidth(uint64(sizing.compressedDataLen)))
+		sizing.blockPrefixLen = sizing.compressedDataLen
+		sizing.currentBundlePrefixLen = sizing.compressedDataLen
+		return sizing
+	}
+
+	// We support computing the prefix-compressed size of serializing either
+	// with or without the last row (eg, rows == b.nKeys or rows == b.nKeys-1).
+	// Regardless, the completedBundle{Len,Keys} fields are accurate because a
+	// bundle is only considered completed once the first key of the next bundle
+	// is added.
+	//
+	// Any difference in the size comes from
+	// a) a difference in the current bundle size
+	// b) a difference in the block-prefix len
+	//
+	// We compute a) here and b) down below.
+	currentBundleLen := b.currentBundleLen
+	currentBundleKeys := b.currentBundleKeys
+	sizing.currentBundlePrefixLen = b.offsets.elems.At(b.currentBundlePrefixOffset) -
+		b.offsets.elems.At(b.currentBundlePrefixOffset-1)
+	if int(rows) == b.nKeys-1 {
+		currentBundleKeys--
+		currentBundleLen -= b.lastKeyLen
+		// The bundle prefix length currently saved in the offsets table may be
+		// shorter than it needs to be. We can compute the correct bundle
+		// length.
+		bundleFirstKey := b.data[b.offsets.elems.At(b.currentBundlePrefixOffset-1):b.offsets.elems.At(b.currentBundlePrefixOffset+1)]
+		lastOffset := b.offsets.elems.At(int(sizing.offsetCount - 1))
+		bundleLastKey := b.data[lastOffset-uint32(b.lastLastKeyLen) : lastOffset]
+		sizing.currentBundlePrefixLen = uint32(bytesSharedPrefix(bundleFirstKey, bundleLastKey))
+	} else if int(rows) != b.nKeys {
+		panic(errors.AssertionFailedf("PrefixBytes has accumulated %d keys, asked to size %d", b.nKeys, rows))
+	}
+
+	// Compute the block prefix length for the first [rows] rows. If [rows]
+	// includes all rows that have been Put, we can use a cached value.
+	// Otherwise, we need to recompute it the block prefix len by computing the
+	// shared prefix between the first and last bundles.
+	sizing.blockPrefixLen = b.blockPrefixLen
+	if b.blockPrefixLenUpdated >= rows {
+		// If we're not writing out all the rows that have been Put (ie, rows <
+		// b.nKeys), and one of the later rows that we're not writing updated the
+		// block prefix length, then the cached block prefix length may be shorter
+		// than necessary. In this case, we recompute it from the bundle prefixes.
+		// Initialize the block prefix length to the current bundle prefix.
+		sizing.blockPrefixLen = sizing.currentBundlePrefixLen
+		if rows > b.bundleSize {
+			bi := (rows - 1) >> b.bundleShift
+			i := bi<<b.bundleShift + bi
+			sizing.blockPrefixLen = uint32(bytesSharedPrefix(
+				b.data[b.offsets.elems.At(0):b.offsets.elems.At(1)],
+				b.data[b.offsets.elems.At(i):b.offsets.elems.At(i+1)]))
+		}
+	}
+
+	// Compute the length of the compressed string data. The
+	// b.completedBundleLen is pre-computed and holds length of the compressed
+	// string data for all keys except the last [currentBundleKeys] keys. Note
+	// that [completedBundleLen] assumes a blockPrefixLen=0.
+	sizing.compressedDataLen = uint32(b.completedBundleLen)
+	// If there are any keys that aren't included within the 'completed
+	// bundles,' add them.
+	if currentBundleKeys > 0 {
+		// Adjust the current bundle length by stripping off the bundle prefix
+		// from all but one of the keys in the bundle (which is accounting for
+		// storage of the bundle prefix itself).
+		sizing.compressedDataLen += uint32(currentBundleLen) - uint32(currentBundleKeys-1)*sizing.currentBundlePrefixLen
+	}
+	// Currently compressedDataLen is correct, except that it includes the block
+	// prefix length for all bundle prefixes.  Adjust the length to account for
+	// the block prefix being stripped from every bundle except the first one.
+	numBundles := uint32(rows+b.bundleSize-1) >> b.bundleShift
+	sizing.compressedDataLen -= (numBundles - 1) * sizing.blockPrefixLen
+	// The compressedDataLen is the largest offset we'll need to encode in the
+	// offset table, so we can use it to compute the width of the offset deltas.
+	sizing.offsetDeltaWidth = max(1, deltaWidth(uint64(sizing.compressedDataLen)))
+	return sizing
+}
+
+// writePrefixCompressed writes the provided builder's first [rows] rows with
+// prefix-compression applied. It writes offsets and string data in tandem,
+// writing offsets of width T into [offsetDeltas] and compressed string data
+// into [buf]. The builder's internal state is not modified by
+// writePrefixCompressed.  writePrefixCompressed is generic in terms of the type
+// T of the offset deltas.
+//
+// The caller must have correctly constructed [offsetDeltas] such that writing
+// [sizing.nOffsets] offsets of size T does not overwrite the beginning of
+// [buf]:
+//
+//	+-------------------------------------+  <- offsetDeltas.ptr
+//	| offsetDeltas[0]                     |
+//	+-------------------------------------+
+//	| offsetDeltas[1]                     |
+//	+-------------------------------------+
+//	| ...                                 |
+//	+-------------------------------------+
+//	| offsetDeltas[sizing.offsetCount-1]  |
+//	+-------------------------------------+ <- &buf[0]
+//	| buf (string data)                   |
+//	| ...                                 |
+//	+-------------------------------------+
+//
+// writePrefixCompressed returns the length of the compressed string data it
+// wrote, which should match sizing.compressedDataLen.
+func writePrefixCompressed[T Uint](
+	b *PrefixBytesBuilder,
+	rows int,
+	sizing prefixCompressionSizing,
+	offsetDeltas UnsafeRawSlice[T],
+	buf []byte,
+) {
+	if rows == 0 {
+		return
+	} else if rows == 1 {
+		// If there's just 1 row, no prefix compression is necessary and we can
+		// just encode first key as the entire block prefix and first bundle
+		// prefix.
+		e := b.offsets.elems.At(2)
+		offsetDeltas.set(0, T(e))
+		offsetDeltas.set(1, T(e))
+		offsetDeltas.set(2, T(e))
+		copy(buf, b.data[:e])
+		return
+	}
+
+	// The offset at index 0 is the block prefix length.
+	offsetDeltas.set(0, T(sizing.blockPrefixLen))
+	destOffset := T(copy(buf, b.data[:sizing.blockPrefixLen]))
+	var lastRowOffset uint32
+	var shared uint32
+
+	// Loop over the slices starting at the bundle prefix of the first bundle.
+	// If the slice is a bundle prefix, carve off the suffix that excludes the
+	// block prefix. Otherwise, carve off the suffix that excludes the block
+	// prefix + bundle prefix.
+	for i := 1; i < int(sizing.offsetCount); i++ {
+		var suffix []byte
+		if (i-1)%(b.bundleSize+1) == 0 {
+			// This is a bundle prefix.
+			if i == b.currentBundlePrefixOffset {
+				suffix = b.data[lastRowOffset+sizing.blockPrefixLen : lastRowOffset+sizing.currentBundlePrefixLen]
+			} else {
+				suffix = b.data[lastRowOffset+sizing.blockPrefixLen : b.offsets.elems.At(i)]
+			}
+			shared = sizing.blockPrefixLen + uint32(len(suffix))
+			// We don't update lastRowOffset here because the bundle prefix
+			// was never actually stored in the data array.
+		} else {
+			// If the offset of this key is the same as the offset of the
+			// previous key, then the key is a duplicate. All we need to do is
+			// set the same offset in the destination.
+			if b.offsets.elems.At(i) == lastRowOffset {
+				offsetDeltas.set(i, offsetDeltas.At(i-1))
+				continue
+			}
+			suffix = b.data[lastRowOffset+shared : b.offsets.elems.At(i)]
+			// Update lastRowOffset for the next iteration of this loop.
+			lastRowOffset = b.offsets.elems.At(i)
+		}
+		destOffset += T(copy(buf[destOffset:], suffix))
+		offsetDeltas.set(i, destOffset)
+	}
+	if destOffset != T(sizing.compressedDataLen) {
+		panic(errors.AssertionFailedf("wrote %d, expected %d", destOffset, sizing.compressedDataLen))
+	}
+}
+
+// Finish writes the serialized byte slices to buf starting at offset. The buf
+// slice must be sufficiently large to store the serialized output. The caller
+// should use [Size] to size buf appropriately before calling Finish.
+//
+// Finish only supports values of [rows] equal to the number of keys set on the
+// builder, or one less.
+func (b *PrefixBytesBuilder) Finish(
+	col int, rows int, offset uint32, buf []byte,
+) (uint32, ColumnDesc) {
+	if rows < b.nKeys-1 || rows > b.nKeys {
+		panic(errors.AssertionFailedf("PrefixBytes has accumulated %d keys, asked to Finish %d", b.nKeys, rows))
+	}
+
+	desc := ColumnDesc{DataType: DataTypePrefixBytes}
+	if rows == 0 {
+		return offset, desc
+	}
+	// Encode the bundle shift.
+	buf[offset] = byte(b.bundleShift)
+	offset++
+
+	// Compute the length of the prefix-compressed data. The size of the of the
+	// offsets table is dependent on the value of the largest offset, which is
+	// dependent on the length of the compressed data.
+	sizing := b.computePrefixCompressionSizing(rows)
+
+	// With compressed data length, we can compute the size of the offsets
+	// table. The minimum offset that we need to encode is zero, and the largest
+	// is the length of the compressedDataLen. The actual offsets themselves
+	// haven't been computed yet, but precomputing the size allows us to write
+	// the offset table and the string data to buf in tandem.
+	stringDataOffset := uintColumnSize[uint32](sizing.offsetCount, offset, sizing.offsetDeltaWidth)
+	switch sizing.offsetDeltaWidth {
+	case 1:
+		// The uint32 delta-encoding requires a uint32 constant representing the
+		// base value. This is always zero for PrefixBytes, but we include it
+		// anyways for format consistency.
+		buf[offset], buf[offset+1], buf[offset+2], buf[offset+3] = 0, 0, 0, 0
+		offset += align32
+
+		offsetDest := makeUnsafeRawSlice[uint8](unsafe.Pointer(&buf[offset]))
+		desc.Encoding = desc.Encoding.WithDelta(DeltaEncodingUint8)
+		writePrefixCompressed[uint8](b, rows, sizing, offsetDest, buf[stringDataOffset:])
+	case align16:
+		// The uint32 delta-encoding requires a uint32 constant representing the
+		// base value. This is always zero for PrefixBytes, but we include it
+		// anyways for format consistency.
+		buf[offset], buf[offset+1], buf[offset+2], buf[offset+3] = 0, 0, 0, 0
+		offset += align32
+
+		offset = alignWithZeroes(buf, offset, align16)
+		uintColumnSize[uint32](uint32(rows), offset, sizing.offsetDeltaWidth)
+		offsetDest := makeUnsafeRawSlice[uint16](unsafe.Pointer(&buf[offset]))
+		desc.Encoding = desc.Encoding.WithDelta(DeltaEncodingUint16)
+		writePrefixCompressed[uint16](b, rows, sizing, offsetDest, buf[stringDataOffset:])
+	case align32:
+		offset = alignWithZeroes(buf, offset, align32)
+		uintColumnSize[uint32](uint32(rows), offset, sizing.offsetDeltaWidth)
+		offsetDest := makeUnsafeRawSlice[uint32](unsafe.Pointer(&buf[offset]))
+		writePrefixCompressed[uint32](b, rows, sizing, offsetDest, buf[stringDataOffset:])
+	default:
+		panic("unreachable")
+	}
+	return stringDataOffset + sizing.compressedDataLen, desc
+}
+
+// Size computes the size required to encode the byte slices beginning at the
+// provided offset. The offset is required to ensure proper alignment. The
+// returned uint32 is the offset of the first byte after the end of the encoded
+// data. To compute the size in bytes, subtract the [offset] passed into Size
+// from the returned offset.
+func (b *PrefixBytesBuilder) Size(rows int, offset uint32) uint32 {
+	if rows == 0 {
+		return 0
+	}
+	// The 1-byte bundleSize.
+	offset++
+
+	// Compute the prefix-compressed sizing.
+	sizing := b.computePrefixCompressionSizing(rows)
+	// Compute the size of the offsets table, given that the maximal offset it
+	// needs to encode is dataLen.
+	offset = uintColumnSize[uint32](sizing.offsetCount, offset, sizing.offsetDeltaWidth)
+	return offset + sizing.compressedDataLen
+}
+
+// Writedebug implements the Encoder interface.
+func (b *PrefixBytesBuilder) WriteDebug(w io.Writer, rows int) {
+	fmt.Fprintf(w, "prefixbytes(%d): %d keys", b.bundleSize, b.nKeys)
+}
+
+// bytesSharedPrefix returns the length of the shared prefix between a and b.
+func bytesSharedPrefix(a, b []byte) int {
+	asUint64 := func(data []byte, i int) uint64 {
+		return binary.LittleEndian.Uint64(data[i:])
+	}
+	var shared int
+	n := min(len(a), len(b))
+	for shared < n-7 && asUint64(a, shared) == asUint64(b, shared) {
+		shared += 8
+	}
+	for shared < n && a[shared] == b[shared] {
+		shared++
+	}
+	return shared
+}

--- a/sstable/colblk/prefix_bytes_test.go
+++ b/sstable/colblk/prefix_bytes_test.go
@@ -1,0 +1,287 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package colblk
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/binfmt"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/rand"
+)
+
+func TestPrefixBytes(t *testing.T) {
+	var out bytes.Buffer
+	var pb PrefixBytes
+	var builder PrefixBytesBuilder
+	var keys int
+	var getBuf []byte
+	var sizeAtRowCount []uint32
+
+	datadriven.RunTest(t, "testdata/prefix_bytes", func(t *testing.T, td *datadriven.TestData) string {
+		out.Reset()
+		switch td.Cmd {
+		case "init":
+			var bundleSize int
+			td.ScanArgs(t, "bundle-size", &bundleSize)
+			builder.Init(bundleSize)
+
+			keys = 0
+			size := builder.Size(keys, 0)
+			sizeAtRowCount = append(sizeAtRowCount[:0], size)
+			fmt.Fprintf(&out, "Size: %d", size)
+			return out.String()
+		case "put":
+			inputKeys := bytes.Split([]byte(strings.TrimSpace(td.Input)), []byte{'\n'})
+			for _, k := range inputKeys {
+				keyPrefixLenSharedWithPrev := len(k)
+				if builder.nKeys > 0 {
+					keyPrefixLenSharedWithPrev = bytesSharedPrefix(builder.PrevKey(), k)
+				}
+				p := []byte(k)
+				builder.Put(p, keyPrefixLenSharedWithPrev)
+				keys++
+				sizeAtRowCount = append(sizeAtRowCount, builder.Size(keys, 0))
+			}
+			fmt.Fprint(&out, builder.debugString(0))
+			return out.String()
+		case "finish":
+			var rows int
+			td.ScanArgs(t, "rows", &rows)
+			buf := make([]byte, sizeAtRowCount[rows])
+			offset, desc := builder.Finish(0, rows, 0, buf)
+			require.Equal(t, uint32(len(buf)), offset)
+
+			f := binfmt.New(buf)
+			prefixBytesToBinFormatter(f, rows, desc.Encoding, nil)
+			pb = MakePrefixBytes(rows, buf, 0, desc.Encoding)
+			return f.String()
+		case "get":
+			var indices []int
+			td.ScanArgs(t, "indices", &indices)
+
+			getBuf = append(getBuf[:0], pb.SharedPrefix()...)
+			l := len(getBuf)
+			for _, i := range indices {
+				getBuf = append(append(getBuf[:l], pb.RowBundlePrefix(i)...), pb.RowSuffix(i)...)
+				fmt.Fprintf(&out, "%s\n", getBuf)
+			}
+			return out.String()
+		case "search":
+			for _, l := range strings.Split(strings.TrimSpace(td.Input), "\n") {
+				i, eq := pb.Search([]byte(l))
+				fmt.Fprintf(&out, "Search(%q) = (%d, %t)\n", l, i, eq)
+			}
+			return out.String()
+		default:
+			panic(fmt.Sprintf("unrecognized command %q", td.Cmd))
+		}
+	})
+}
+
+func TestPrefixBytesRandomized(t *testing.T) {
+	seed := uint64(time.Now().UnixNano())
+	t.Logf("Seed: %d", seed)
+
+	runTest := func(t *testing.T, maxKeyCount, maxKeyLen int) {
+		rng := rand.New(rand.NewSource(seed))
+		randInt := func(lo, hi int) int {
+			return lo + rng.Intn(hi-lo)
+		}
+		minLen := randInt(4, maxKeyLen)
+		maxLen := randInt(4, maxKeyLen)
+		if maxLen < minLen {
+			minLen, maxLen = maxLen, minLen
+		}
+		blockPrefixLen := randInt(1, minLen+1)
+		userKeys := make([][]byte, randInt(1, maxKeyCount))
+		// Create the first user key.
+		userKeys[0] = make([]byte, randInt(minLen, maxLen+1))
+		totalSize := len(userKeys[0])
+		for j := range userKeys[0] {
+			userKeys[0][j] = byte(randInt(int('a'), int('z')+1))
+		}
+		// Create the remainder of the user keys, giving them the same block prefix
+		// of length [blockPrefixLen].
+		for i := 1; i < len(userKeys); i++ {
+			userKeys[i] = make([]byte, randInt(minLen, maxLen+1))
+			totalSize += len(userKeys[i])
+			copy(userKeys[i], userKeys[0][:blockPrefixLen])
+			for j := blockPrefixLen; j < len(userKeys[i]); j++ {
+				userKeys[i][j] = byte(randInt(int('a'), int('z')+1))
+			}
+		}
+		slices.SortFunc(userKeys, bytes.Compare)
+
+		var pbb PrefixBytesBuilder
+		pbb.Init(1 << randInt(1, 4))
+		for i := 0; i < len(userKeys); i++ {
+			keyPrefixLenSharedWithPrev := 0
+			if i > 0 {
+				keyPrefixLenSharedWithPrev = bytesSharedPrefix(userKeys[i-1], userKeys[i])
+			}
+			pbb.Put(userKeys[i], keyPrefixLenSharedWithPrev)
+		}
+
+		size := pbb.Size(len(userKeys), 0)
+		buf := make([]byte, size)
+		offset, desc := pbb.Finish(0, len(userKeys), 0, buf)
+		if uint32(size) != offset {
+			t.Fatalf("bb.Size(...) computed %d, but bb.Finish(...) produced slice of len %d",
+				size, offset)
+		}
+		require.Equal(t, uint32(len(buf)), offset)
+		t.Logf("Size: %d; NumUserKeys: %d; Encoding: %s; Aggregate pre-compressed string data: %d",
+			size, len(userKeys), desc.Encoding, totalSize)
+
+		pb := MakePrefixBytes(len(userKeys), buf, 0, desc.Encoding)
+
+		k := append([]byte(nil), pb.SharedPrefix()...)
+		l := len(k)
+		for i := 0; i < min(10000, len(userKeys)); i++ {
+			j := rand.Intn(len(userKeys))
+
+			// Ensure that reconstructing the key from the prefix bytes interface
+			// produces an identical key.
+			k = append(append(k[:l], pb.RowBundlePrefix(j)...), pb.RowSuffix(j)...)
+			if !bytes.Equal(k, userKeys[j]) {
+				t.Fatalf("Constructed key %q (%q, %q, %q) for index %d; expected %q",
+					k, pb.SharedPrefix(), pb.RowBundlePrefix(j), pb.RowSuffix(j), j, userKeys[j])
+			}
+			// Ensure that searching for the key finds a match.
+			idx, equal := pb.Search(userKeys[j])
+			require.True(t, equal)
+			// NB: idx may be less than j if there are duplicate keys. But if so,
+			// the key at index j should still be equal to the key at index idx.
+			require.LessOrEqual(t, idx, j)
+			require.Equal(t, userKeys[idx], userKeys[j])
+		}
+	}
+	for _, maxKeyCount := range []int{10, 100, 1000, 10000} {
+		for _, maxKeyLen := range []int{10, 100} {
+			t.Run(fmt.Sprintf("maxKeyCount=%d,maxKeyLen=%d", maxKeyCount, maxKeyLen), func(t *testing.T) {
+				runTest(t, maxKeyCount, maxKeyLen)
+			})
+		}
+	}
+}
+
+func BenchmarkPrefixBytes(b *testing.B) {
+	seed := uint64(205295296)
+	rng := rand.New(rand.NewSource(seed))
+	randInt := func(lo, hi int) int {
+		return lo + rng.Intn(hi-lo)
+	}
+	minLen := 8
+	maxLen := 128
+	if maxLen < minLen {
+		minLen, maxLen = maxLen, minLen
+	}
+	blockPrefixLen := 6
+	userKeys := make([][]byte, 1000)
+	// Create the first user key.
+	userKeys[0] = make([]byte, randInt(minLen, maxLen+1))
+	for j := range userKeys[0] {
+		userKeys[0][j] = byte(randInt(int('a'), int('z')+1))
+	}
+	// Create the remainder of the user keys, giving them the same block prefix
+	// of length [blockPrefixLen].
+	for i := 1; i < len(userKeys); i++ {
+		userKeys[i] = make([]byte, randInt(minLen, maxLen+1))
+		copy(userKeys[i], userKeys[0][:blockPrefixLen])
+		for j := blockPrefixLen; j < len(userKeys[i]); j++ {
+			userKeys[i][j] = byte(randInt(int('a'), int('z')+1))
+		}
+	}
+	slices.SortFunc(userKeys, bytes.Compare)
+
+	var pbb PrefixBytesBuilder
+	var buf []byte
+	var enc ColumnEncoding
+	build := func(n int) ([]byte, ColumnEncoding) {
+		pbb.Init(16)
+		for i := 0; i < n; i++ {
+			keyPrefixLenSharedWithPrev := 0
+			if i > 0 {
+				keyPrefixLenSharedWithPrev = bytesSharedPrefix(userKeys[i-1], userKeys[i])
+			}
+			pbb.Put(userKeys[i], keyPrefixLenSharedWithPrev)
+		}
+		size := pbb.Size(n, 0)
+		if cap(buf) < int(size) {
+			buf = make([]byte, size)
+		} else {
+			buf = buf[:size]
+		}
+		_, desc := pbb.Finish(0, n, 0, buf)
+		return buf, desc.Encoding
+	}
+
+	b.Run("building", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			data, _ := build(len(userKeys))
+			fmt.Fprint(io.Discard, data)
+		}
+	})
+
+	b.Run("iteration", func(b *testing.B) {
+		n := len(userKeys)
+		buf, enc = build(n)
+		pb := MakePrefixBytes(n, buf, 0, enc)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			k := append([]byte(nil), pb.SharedPrefix()...)
+			l := len(k)
+			for i := 0; i < n; i++ {
+				j := rand.Intn(n)
+				k = append(append(k[:l], pb.RowBundlePrefix(j)...), pb.RowSuffix(j)...)
+				if !bytes.Equal(k, userKeys[j]) {
+					b.Fatalf("Constructed key %q (%q, %q, %q) for index %d; expected %q",
+						k, pb.SharedPrefix(), pb.RowBundlePrefix(j), pb.RowSuffix(j), j, userKeys[j])
+				}
+			}
+		}
+	})
+}
+
+func (b *PrefixBytesBuilder) debugString(offset uint32) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Size: %d", b.Size(b.nKeys, offset))
+	fmt.Fprintf(&sb, "\nnKeys=%d; bundleSize=%d", b.nKeys, b.bundleSize)
+	if b.bundleSize > 0 {
+		fmt.Fprintf(&sb, "\nblockPrefixLen=%d; currentBundleLen=%d; currentBundleKeys=%d",
+			b.blockPrefixLen, b.currentBundleLen, b.currentBundleKeys)
+	}
+	fmt.Fprint(&sb, "\nOffsets:")
+	for i := 0; i < b.offsets.count; i++ {
+		if i%10 == 0 {
+			fmt.Fprintf(&sb, "\n  %04d", b.offsets.elems.At(i))
+		} else {
+			fmt.Fprintf(&sb, "  %04d", b.offsets.elems.At(i))
+		}
+	}
+	fmt.Fprintf(&sb, "\nData (len=%d):\n", len(b.data))
+	wrapStr(&sb, string(b.data), 60)
+	return sb.String()
+}
+
+func wrapStr(w io.Writer, s string, width int) {
+	for len(s) > 0 {
+		n := min(width, len(s))
+		fmt.Fprint(w, s[:n])
+		s = s[n:]
+		if len(s) > 0 {
+			fmt.Fprintln(w)
+		}
+	}
+}

--- a/sstable/colblk/raw_bytes.go
+++ b/sstable/colblk/raw_bytes.go
@@ -79,8 +79,9 @@ func rawBytesToBinFormatter(
 	dataOffset := uint64(f.Offset()) + uint64(uintptr(rb.data)-uintptr(rb.start))
 	f.CommentLine("RawBytes")
 	f.CommentLine("Offsets table")
-	uintsToBinFormatter(f, count+1, ColumnDesc{DataType: DataTypeUint32, Encoding: enc}, func(offset uint64) string {
-		return fmt.Sprintf("%d [%d overall]", offset, offset+dataOffset)
+	uintsToBinFormatter(f, count+1, ColumnDesc{DataType: DataTypeUint32, Encoding: enc}, func(offset, base uint64) string {
+		// NB: base is always zero for RawBytes columns.
+		return fmt.Sprintf("%d [%d overall]", offset+base, offset+base+dataOffset)
 	})
 	f.CommentLine("Data")
 	for i := 0; i < rb.slices; i++ {
@@ -89,17 +90,17 @@ func rawBytesToBinFormatter(
 	}
 }
 
-func (b RawBytes) ptr(offset int) unsafe.Pointer {
+func (b RawBytes) ptr(offset uint32) unsafe.Pointer {
 	return unsafe.Pointer(uintptr(b.data) + uintptr(offset))
 }
 
-func (b RawBytes) slice(start, end int) []byte {
+func (b RawBytes) slice(start, end uint32) []byte {
 	return unsafe.Slice((*byte)(b.ptr(start)), end-start)
 }
 
 // At returns the []byte at index i. The returned slice should not be mutated.
 func (b RawBytes) At(i int) []byte {
-	return b.slice(int(b.offsets.At(i)), int(b.offsets.At(i+1)))
+	return b.slice(b.offsets.At(i), b.offsets.At(i+1))
 }
 
 // Slices returns the number of []byte slices encoded within the RawBytes.

--- a/sstable/colblk/testdata/prefix_bytes
+++ b/sstable/colblk/testdata/prefix_bytes
@@ -1,0 +1,852 @@
+init bundle-size=4
+----
+Size: 0
+
+put
+abc
+----
+Size: 11
+nKeys=1; bundleSize=4
+blockPrefixLen=3; currentBundleLen=3; currentBundleKeys=1
+Offsets:
+  0000  0003  0003
+Data (len=3):
+abc
+
+finish rows=1
+----
+# PrefixBytes
+00-01: x 02       # bundleSize: 4
+# Offsets table
+01-05: x 00000000 # 32-bit constant: 0
+05-06: x 03       # data[0] = 3 [11 overall]
+06-07: x 03       # data[1] = 3 [11 overall]
+07-08: x 03       # data[2] = 3 [11 overall]
+# Data
+08-11: x 616263   # data[00]: abc (block prefix)
+11-11: x          # data[01]: ... (bundle prefix)
+11-11: x          # data[02]: ...
+
+init bundle-size=4
+----
+Size: 0
+
+put
+abc
+----
+Size: 11
+nKeys=1; bundleSize=4
+blockPrefixLen=3; currentBundleLen=3; currentBundleKeys=1
+Offsets:
+  0000  0003  0003
+Data (len=3):
+abc
+
+put
+abcd
+----
+Size: 13
+nKeys=2; bundleSize=4
+blockPrefixLen=3; currentBundleLen=7; currentBundleKeys=2
+Offsets:
+  0000  0003  0003  0007
+Data (len=7):
+abcabcd
+
+put
+abce
+----
+Size: 15
+nKeys=3; bundleSize=4
+blockPrefixLen=3; currentBundleLen=11; currentBundleKeys=3
+Offsets:
+  0000  0003  0003  0007  0011
+Data (len=11):
+abcabcdabce
+
+put
+abdd
+----
+Size: 20
+nKeys=4; bundleSize=4
+blockPrefixLen=2; currentBundleLen=15; currentBundleKeys=4
+Offsets:
+  0000  0002  0003  0007  0011  0015
+Data (len=15):
+abcabcdabceabdd
+
+put
+abde
+----
+Size: 24
+nKeys=5; bundleSize=4
+blockPrefixLen=2; currentBundleLen=4; currentBundleKeys=1
+Offsets:
+  0000  0002  0003  0007  0011  0015  0019  0019
+Data (len=19):
+abcabcdabceabddabde
+
+# Try finishing just the n-1 rows.
+
+finish rows=4
+----
+# PrefixBytes
+00-01: x 02       # bundleSize: 4
+# Offsets table
+01-05: x 00000000 # 32-bit constant: 0
+05-06: x 02       # data[0] = 2 [13 overall]
+06-07: x 02       # data[1] = 2 [13 overall]
+07-08: x 03       # data[2] = 3 [14 overall]
+08-09: x 05       # data[3] = 5 [16 overall]
+09-10: x 07       # data[4] = 7 [18 overall]
+10-11: x 09       # data[5] = 9 [20 overall]
+# Data
+11-13: x 6162     # data[00]: ab (block prefix)
+13-13: x          # data[01]: .. (bundle prefix)
+13-14: x 63       # data[02]: ..c
+14-16: x 6364     # data[03]: ..cd
+16-18: x 6365     # data[04]: ..ce
+18-20: x 6464     # data[05]: ..dd
+
+# Finish the entirety of all put rows.
+
+finish rows=5
+----
+# PrefixBytes
+00-01: x 02       # bundleSize: 4
+# Offsets table
+01-05: x 00000000 # 32-bit constant: 0
+05-06: x 02       # data[0] = 2 [15 overall]
+06-07: x 02       # data[1] = 2 [15 overall]
+07-08: x 03       # data[2] = 3 [16 overall]
+08-09: x 05       # data[3] = 5 [18 overall]
+09-10: x 07       # data[4] = 7 [20 overall]
+10-11: x 09       # data[5] = 9 [22 overall]
+11-12: x 0b       # data[6] = 11 [24 overall]
+12-13: x 0b       # data[7] = 11 [24 overall]
+# Data
+13-15: x 6162     # data[00]: ab (block prefix)
+15-15: x          # data[01]: .. (bundle prefix)
+15-16: x 63       # data[02]: ..c
+16-18: x 6364     # data[03]: ..cd
+18-20: x 6365     # data[04]: ..ce
+20-22: x 6464     # data[05]: ..dd
+22-24: x 6465     # data[06]: ..de (bundle prefix)
+24-24: x          # data[07]: ....
+
+get indices=(0, 1, 2, 3, 4)
+----
+abc
+abcd
+abce
+abdd
+abde
+
+search
+a
+ab
+abaaaa
+abc
+abcc
+abccaat
+abcd
+abcda
+----
+Search("a") = (0, false)
+Search("ab") = (0, false)
+Search("abaaaa") = (0, false)
+Search("abc") = (0, true)
+Search("abcc") = (1, false)
+Search("abccaat") = (1, false)
+Search("abcd") = (1, true)
+Search("abcda") = (2, false)
+
+search
+abce
+abdd
+abde
+abdeee
+abdf
+----
+Search("abce") = (2, true)
+Search("abdd") = (3, true)
+Search("abde") = (4, true)
+Search("abdeee") = (5, false)
+Search("abdf") = (5, false)
+
+init bundle-size=4
+----
+Size: 0
+
+put
+aaabbbc
+----
+Size: 15
+nKeys=1; bundleSize=4
+blockPrefixLen=7; currentBundleLen=7; currentBundleKeys=1
+Offsets:
+  0000  0007  0007
+Data (len=7):
+aaabbbc
+
+put
+aaabbbcc
+----
+Size: 17
+nKeys=2; bundleSize=4
+blockPrefixLen=7; currentBundleLen=15; currentBundleKeys=2
+Offsets:
+  0000  0007  0007  0015
+Data (len=15):
+aaabbbcaaabbbcc
+
+put
+aaabbbcde
+----
+Size: 20
+nKeys=3; bundleSize=4
+blockPrefixLen=7; currentBundleLen=24; currentBundleKeys=3
+Offsets:
+  0000  0007  0007  0015  0024
+Data (len=24):
+aaabbbcaaabbbccaaabbbcde
+
+put
+aaabbbce
+----
+Size: 22
+nKeys=4; bundleSize=4
+blockPrefixLen=7; currentBundleLen=32; currentBundleKeys=4
+Offsets:
+  0000  0007  0007  0015  0024  0032
+Data (len=32):
+aaabbbcaaabbbccaaabbbcdeaaabbbce
+
+put
+aaabbbdee*
+----
+Size: 28
+nKeys=5; bundleSize=4
+blockPrefixLen=6; currentBundleLen=10; currentBundleKeys=1
+Offsets:
+  0000  0007  0007  0015  0024  0032  0042  0042
+Data (len=42):
+aaabbbcaaabbbccaaabbbcdeaaabbbceaaabbbdee*
+
+put
+aaabbbdee*
+----
+Size: 29
+nKeys=6; bundleSize=4
+blockPrefixLen=6; currentBundleLen=10; currentBundleKeys=1
+Offsets:
+  0000  0007  0007  0015  0024  0032  0042  0042  0042
+Data (len=42):
+aaabbbcaaabbbccaaabbbcdeaaabbbceaaabbbdee*
+
+put
+aaabbbdee*
+----
+Size: 30
+nKeys=7; bundleSize=4
+blockPrefixLen=6; currentBundleLen=10; currentBundleKeys=1
+Offsets:
+  0000  0007  0007  0015  0024  0032  0042  0042  0042  0042
+Data (len=42):
+aaabbbcaaabbbccaaabbbcdeaaabbbceaaabbbdee*
+
+put
+aaabbbeff
+----
+Size: 34
+nKeys=8; bundleSize=4
+blockPrefixLen=6; currentBundleLen=19; currentBundleKeys=2
+Offsets:
+  0000  0007  0007  0015  0024  0032  0038  0042  0042  0042
+  0051
+Data (len=51):
+aaabbbcaaabbbccaaabbbcdeaaabbbceaaabbbdee*aaabbbeff
+
+put
+aaabbe
+----
+Size: 38
+nKeys=9; bundleSize=4
+blockPrefixLen=5; currentBundleLen=6; currentBundleKeys=1
+Offsets:
+  0000  0007  0007  0015  0024  0032  0038  0042  0042  0042
+  0051  0057  0057
+Data (len=57):
+aaabbbcaaabbbccaaabbbcdeaaabbbceaaabbbdee*aaabbbeffaaabbe
+
+put
+aaabbeef*
+----
+Size: 42
+nKeys=10; bundleSize=4
+blockPrefixLen=5; currentBundleLen=15; currentBundleKeys=2
+Offsets:
+  0000  0007  0007  0015  0024  0032  0038  0042  0042  0042
+  0051  0057  0057  0066
+Data (len=66):
+aaabbbcaaabbbccaaabbbcdeaaabbbceaaabbbdee*aaabbbeffaaabbeaaa
+bbeef*
+
+put
+aaabbeef*
+----
+Size: 43
+nKeys=11; bundleSize=4
+blockPrefixLen=5; currentBundleLen=15; currentBundleKeys=2
+Offsets:
+  0000  0007  0007  0015  0024  0032  0038  0042  0042  0042
+  0051  0057  0057  0066  0066
+Data (len=66):
+aaabbbcaaabbbccaaabbbcdeaaabbbceaaabbbdee*aaabbbeffaaabbeaaa
+bbeef*
+
+put
+aaabc
+----
+Size: 49
+nKeys=12; bundleSize=4
+blockPrefixLen=4; currentBundleLen=20; currentBundleKeys=3
+Offsets:
+  0000  0007  0007  0015  0024  0032  0038  0042  0042  0042
+  0051  0055  0057  0066  0066  0071
+Data (len=71):
+aaabbbcaaabbbccaaabbbcdeaaabbbceaaabbbdee*aaabbbeffaaabbeaaa
+bbeef*aaabc
+
+put
+aabcceef*
+aabcceef*
+----
+Size: 63
+nKeys=14; bundleSize=4
+blockPrefixLen=2; currentBundleLen=9; currentBundleKeys=1
+Offsets:
+  0000  0007  0007  0015  0024  0032  0038  0042  0042  0042
+  0051  0055  0057  0066  0066  0071  0080  0080  0080
+Data (len=80):
+aaabbbcaaabbbccaaabbbcdeaaabbbceaaabbbdee*aaabbbeffaaabbeaaa
+bbeef*aaabcaabcceef*
+
+# Add a 15th key that will force 16-bit offsets if we include it.
+
+put
+aabcceegggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+----
+Size: 339
+nKeys=15; bundleSize=4
+blockPrefixLen=2; currentBundleLen=270; currentBundleKeys=2
+Offsets:
+  0000  0007  0007  0015  0024  0032  0038  0042  0042  0042
+  0051  0055  0057  0066  0066  0071  0078  0080  0080  0341
+Data (len=341):
+aaabbbcaaabbbccaaabbbcdeaaabbbceaaabbbdee*aaabbbeffaaabbeaaa
+bbeef*aaabcaabcceef*aabcceeggggggggggggggggggggggggggggggggg
+gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+ggggggggggggggggggggggggggggggggggggggggg
+
+# But if we don't include it, we should still get 8-bit offsets.
+
+finish rows=14
+----
+# PrefixBytes
+00-01: x 02             # bundleSize: 4
+# Offsets table
+01-05: x 00000000       # 32-bit constant: 0
+05-06: x 02             # data[0] = 2 [26 overall]
+06-07: x 07             # data[1] = 7 [31 overall]
+07-08: x 07             # data[2] = 7 [31 overall]
+08-09: x 08             # data[3] = 8 [32 overall]
+09-10: x 0a             # data[4] = 10 [34 overall]
+10-11: x 0b             # data[5] = 11 [35 overall]
+11-12: x 0f             # data[6] = 15 [39 overall]
+12-13: x 13             # data[7] = 19 [43 overall]
+13-14: x 13             # data[8] = 19 [43 overall]
+14-15: x 13             # data[9] = 19 [43 overall]
+15-16: x 16             # data[10] = 22 [46 overall]
+16-17: x 18             # data[11] = 24 [48 overall]
+17-18: x 1a             # data[12] = 26 [50 overall]
+18-19: x 1f             # data[13] = 31 [55 overall]
+19-20: x 1f             # data[14] = 31 [55 overall]
+20-21: x 20             # data[15] = 32 [56 overall]
+21-22: x 27             # data[16] = 39 [63 overall]
+22-23: x 27             # data[17] = 39 [63 overall]
+23-24: x 27             # data[18] = 39 [63 overall]
+# Data
+24-26: x 6161           # data[00]: aa (block prefix)
+26-31: x 6162626263     # data[01]: ..abbbc (bundle prefix)
+31-31: x                # data[02]: .......
+31-32: x 63             # data[03]: .......c
+32-34: x 6465           # data[04]: .......de
+34-35: x 65             # data[05]: .......e
+35-39: x 61626262       # data[06]: ..abbb (bundle prefix)
+39-43: x 6465652a       # data[07]: ......dee*
+43-43: x                # data[08]: ..........
+43-43: x                # data[09]: ..........
+43-46: x 656666         # data[10]: ......eff
+46-48: x 6162           # data[11]: ..ab (bundle prefix)
+48-50: x 6265           # data[12]: ....be
+50-55: x 626565662a     # data[13]: ....beef*
+55-55: x                # data[14]: .........
+55-56: x 63             # data[15]: ....c
+56-63: x 6263636565662a # data[16]: ..bcceef* (bundle prefix)
+63-63: x                # data[17]: .........
+63-63: x                # data[18]: .........
+
+
+get indices=(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
+----
+aaabbbc
+aaabbbcc
+aaabbbcde
+aaabbbce
+aaabbbdee*
+aaabbbdee*
+aaabbbdee*
+aaabbbeff
+aaabbe
+aaabbeef*
+aaabbeef*
+aaabc
+aabcceef*
+aabcceef*
+
+search
+a
+aaabb
+aaabbbc
+aaabbbca
+aaabbbcc
+aaabbbcca
+aaabbbcde
+----
+Search("a") = (0, false)
+Search("aaabb") = (0, false)
+Search("aaabbbc") = (0, true)
+Search("aaabbbca") = (1, false)
+Search("aaabbbcc") = (1, true)
+Search("aaabbbcca") = (2, false)
+Search("aaabbbcde") = (2, true)
+
+search
+aaabbbcef
+aaabbbdee
+aaabbbdee*
+aaabbee
+aabcceef*
+aabcceef**
+----
+Search("aaabbbcef") = (4, false)
+Search("aaabbbdee") = (4, false)
+Search("aaabbbdee*") = (4, true)
+Search("aaabbee") = (9, false)
+Search("aabcceef*") = (12, true)
+Search("aabcceef**") = (14, false)
+
+# But if we do include the 15-th key, we should get 16-bit offsets.
+
+finish rows=15
+----
+# PrefixBytes
+000-001: x 02                                       # bundleSize: 4
+# Offsets table
+001-005: x 00000000                                 # 32-bit constant: 0
+# Padding
+005-006: x 00                                       # aligning to 16-bit boundary
+006-008: x 0200                                     # data[0] = 2 [48 overall]
+008-010: x 0700                                     # data[1] = 7 [53 overall]
+010-012: x 0700                                     # data[2] = 7 [53 overall]
+012-014: x 0800                                     # data[3] = 8 [54 overall]
+014-016: x 0a00                                     # data[4] = 10 [56 overall]
+016-018: x 0b00                                     # data[5] = 11 [57 overall]
+018-020: x 0f00                                     # data[6] = 15 [61 overall]
+020-022: x 1300                                     # data[7] = 19 [65 overall]
+022-024: x 1300                                     # data[8] = 19 [65 overall]
+024-026: x 1300                                     # data[9] = 19 [65 overall]
+026-028: x 1600                                     # data[10] = 22 [68 overall]
+028-030: x 1800                                     # data[11] = 24 [70 overall]
+030-032: x 1a00                                     # data[12] = 26 [72 overall]
+032-034: x 1f00                                     # data[13] = 31 [77 overall]
+034-036: x 1f00                                     # data[14] = 31 [77 overall]
+036-038: x 2000                                     # data[15] = 32 [78 overall]
+038-040: x 2500                                     # data[16] = 37 [83 overall]
+040-042: x 2700                                     # data[17] = 39 [85 overall]
+042-044: x 2700                                     # data[18] = 39 [85 overall]
+044-046: x 2501                                     # data[19] = 293 [339 overall]
+# Data
+046-048: x 6161                                     # data[00]: aa (block prefix)
+048-053: x 6162626263                               # data[01]: ..abbbc (bundle prefix)
+053-053: x                                          # data[02]: .......
+053-054: x 63                                       # data[03]: .......c
+054-056: x 6465                                     # data[04]: .......de
+056-057: x 65                                       # data[05]: .......e
+057-061: x 61626262                                 # data[06]: ..abbb (bundle prefix)
+061-065: x 6465652a                                 # data[07]: ......dee*
+065-065: x                                          # data[08]: ..........
+065-065: x                                          # data[09]: ..........
+065-068: x 656666                                   # data[10]: ......eff
+068-070: x 6162                                     # data[11]: ..ab (bundle prefix)
+070-072: x 6265                                     # data[12]: ....be
+072-077: x 626565662a                               # data[13]: ....beef*
+077-077: x                                          # data[14]: .........
+077-078: x 63                                       # data[15]: ....c
+078-083: x 6263636565                               # data[16]: ..bccee (bundle prefix)
+083-085: x 662a                                     # data[17]: .......f*
+085-085: x                                          # data[18]: .........
+085-105: x 6767676767676767676767676767676767676767 # data[19]: .......gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+105-125: x 6767676767676767676767676767676767676767 # (continued...)
+125-145: x 6767676767676767676767676767676767676767 # (continued...)
+145-165: x 6767676767676767676767676767676767676767 # (continued...)
+165-185: x 6767676767676767676767676767676767676767 # (continued...)
+185-205: x 6767676767676767676767676767676767676767 # (continued...)
+205-225: x 6767676767676767676767676767676767676767 # (continued...)
+225-245: x 6767676767676767676767676767676767676767 # (continued...)
+245-265: x 6767676767676767676767676767676767676767 # (continued...)
+265-285: x 6767676767676767676767676767676767676767 # (continued...)
+285-305: x 6767676767676767676767676767676767676767 # (continued...)
+305-325: x 6767676767676767676767676767676767676767 # (continued...)
+325-339: x 6767676767676767676767676767             # (continued...)
+
+init bundle-size=2
+----
+Size: 0
+
+put
+aaabbbc
+aaabbbcc
+aaabbbcde
+aaabbbce
+aaabbbdee*
+aaabbbdee*
+aaabbbdee*
+aaabbbeff
+aaabbe
+aaabbeef*
+aaabbeef*
+aaabc
+aabcceef*
+aabcceef*
+aabcceef*
+----
+Size: 93
+nKeys=15; bundleSize=2
+blockPrefixLen=2; currentBundleLen=9; currentBundleKeys=1
+Offsets:
+  0000  0007  0007  0015  0022  0024  0032  0042  0042  0042
+  0048  0052  0061  0067  0067  0076  0080  0085  0090  0099
+  0099  0099  0108  0108
+Data (len=108):
+aaabbbcaaabbbccaaabbbcdeaaabbbceaaabbbdee*aaabbbdee*aaabbbef
+faaabbeaaabbeef*aaabbeef*aaabcaabcceef*aabcceef*
+
+finish rows=14
+----
+# PrefixBytes
+00-01: x 01               # bundleSize: 2
+# Offsets table
+01-05: x 00000000         # 32-bit constant: 0
+05-06: x 02               # data[0] = 2 [29 overall]
+06-07: x 07               # data[1] = 7 [34 overall]
+07-08: x 07               # data[2] = 7 [34 overall]
+08-09: x 08               # data[3] = 8 [35 overall]
+09-10: x 0d               # data[4] = 13 [40 overall]
+10-11: x 0f               # data[5] = 15 [42 overall]
+11-12: x 10               # data[6] = 16 [43 overall]
+12-13: x 18               # data[7] = 24 [51 overall]
+13-14: x 18               # data[8] = 24 [51 overall]
+14-15: x 18               # data[9] = 24 [51 overall]
+15-16: x 1c               # data[10] = 28 [55 overall]
+16-17: x 20               # data[11] = 32 [59 overall]
+17-18: x 23               # data[12] = 35 [62 overall]
+18-19: x 27               # data[13] = 39 [66 overall]
+19-20: x 27               # data[14] = 39 [66 overall]
+20-21: x 2a               # data[15] = 42 [69 overall]
+21-22: x 2c               # data[16] = 44 [71 overall]
+22-23: x 31               # data[17] = 49 [76 overall]
+23-24: x 32               # data[18] = 50 [77 overall]
+24-25: x 39               # data[19] = 57 [84 overall]
+25-26: x 39               # data[20] = 57 [84 overall]
+26-27: x 39               # data[21] = 57 [84 overall]
+# Data
+27-29: x 6161             # data[00]: aa (block prefix)
+29-34: x 6162626263       # data[01]: ..abbbc (bundle prefix)
+34-34: x                  # data[02]: .......
+34-35: x 63               # data[03]: .......c
+35-40: x 6162626263       # data[04]: ..abbbc (bundle prefix)
+40-42: x 6465             # data[05]: .......de
+42-43: x 65               # data[06]: .......e
+43-51: x 616262626465652a # data[07]: ..abbbdee* (bundle prefix)
+51-51: x                  # data[08]: ..........
+51-51: x                  # data[09]: ..........
+51-55: x 61626262         # data[10]: ..abbb (bundle prefix)
+55-59: x 6465652a         # data[11]: ......dee*
+59-62: x 656666           # data[12]: ......eff
+62-66: x 61626265         # data[13]: ..abbe (bundle prefix)
+66-66: x                  # data[14]: ......
+66-69: x 65662a           # data[15]: ......ef*
+69-71: x 6162             # data[16]: ..ab (bundle prefix)
+71-76: x 626565662a       # data[17]: ....beef*
+76-77: x 63               # data[18]: ....c
+77-84: x 6263636565662a   # data[19]: ..bcceef* (bundle prefix)
+84-84: x                  # data[20]: .........
+84-84: x                  # data[21]: .........
+
+finish rows=15
+----
+# PrefixBytes
+00-01: x 01               # bundleSize: 2
+# Offsets table
+01-05: x 00000000         # 32-bit constant: 0
+05-06: x 02               # data[0] = 2 [31 overall]
+06-07: x 07               # data[1] = 7 [36 overall]
+07-08: x 07               # data[2] = 7 [36 overall]
+08-09: x 08               # data[3] = 8 [37 overall]
+09-10: x 0d               # data[4] = 13 [42 overall]
+10-11: x 0f               # data[5] = 15 [44 overall]
+11-12: x 10               # data[6] = 16 [45 overall]
+12-13: x 18               # data[7] = 24 [53 overall]
+13-14: x 18               # data[8] = 24 [53 overall]
+14-15: x 18               # data[9] = 24 [53 overall]
+15-16: x 1c               # data[10] = 28 [57 overall]
+16-17: x 20               # data[11] = 32 [61 overall]
+17-18: x 23               # data[12] = 35 [64 overall]
+18-19: x 27               # data[13] = 39 [68 overall]
+19-20: x 27               # data[14] = 39 [68 overall]
+20-21: x 2a               # data[15] = 42 [71 overall]
+21-22: x 2c               # data[16] = 44 [73 overall]
+22-23: x 31               # data[17] = 49 [78 overall]
+23-24: x 32               # data[18] = 50 [79 overall]
+24-25: x 39               # data[19] = 57 [86 overall]
+25-26: x 39               # data[20] = 57 [86 overall]
+26-27: x 39               # data[21] = 57 [86 overall]
+27-28: x 40               # data[22] = 64 [93 overall]
+28-29: x 40               # data[23] = 64 [93 overall]
+# Data
+29-31: x 6161             # data[00]: aa (block prefix)
+31-36: x 6162626263       # data[01]: ..abbbc (bundle prefix)
+36-36: x                  # data[02]: .......
+36-37: x 63               # data[03]: .......c
+37-42: x 6162626263       # data[04]: ..abbbc (bundle prefix)
+42-44: x 6465             # data[05]: .......de
+44-45: x 65               # data[06]: .......e
+45-53: x 616262626465652a # data[07]: ..abbbdee* (bundle prefix)
+53-53: x                  # data[08]: ..........
+53-53: x                  # data[09]: ..........
+53-57: x 61626262         # data[10]: ..abbb (bundle prefix)
+57-61: x 6465652a         # data[11]: ......dee*
+61-64: x 656666           # data[12]: ......eff
+64-68: x 61626265         # data[13]: ..abbe (bundle prefix)
+68-68: x                  # data[14]: ......
+68-71: x 65662a           # data[15]: ......ef*
+71-73: x 6162             # data[16]: ..ab (bundle prefix)
+73-78: x 626565662a       # data[17]: ....beef*
+78-79: x 63               # data[18]: ....c
+79-86: x 6263636565662a   # data[19]: ..bcceef* (bundle prefix)
+86-86: x                  # data[20]: .........
+86-86: x                  # data[21]: .........
+86-93: x 6263636565662a   # data[22]: ..bcceef* (bundle prefix)
+93-93: x                  # data[23]: .........
+
+get indices=(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)
+----
+aaabbbc
+aaabbbcc
+aaabbbcde
+aaabbbce
+aaabbbdee*
+aaabbbdee*
+aaabbbdee*
+aaabbbeff
+aaabbe
+aaabbeef*
+aaabbeef*
+aaabc
+aabcceef*
+aabcceef*
+aabcceef*
+
+# Try finishing without the last key which forces a shorter bundle+block prefix.
+
+init bundle-size=4
+----
+Size: 0
+
+put
+abcd
+abce
+abcf
+abg
+----
+Size: 20
+nKeys=4; bundleSize=4
+blockPrefixLen=2; currentBundleLen=15; currentBundleKeys=4
+Offsets:
+  0000  0002  0004  0008  0012  0015
+Data (len=15):
+abcdabceabcfabg
+
+finish rows=3
+----
+# PrefixBytes
+00-01: x 02       # bundleSize: 4
+# Offsets table
+01-05: x 00000000 # 32-bit constant: 0
+05-06: x 03       # data[0] = 3 [13 overall]
+06-07: x 03       # data[1] = 3 [13 overall]
+07-08: x 04       # data[2] = 4 [14 overall]
+08-09: x 05       # data[3] = 5 [15 overall]
+09-10: x 06       # data[4] = 6 [16 overall]
+# Data
+10-13: x 616263   # data[00]: abc (block prefix)
+13-13: x          # data[01]: ... (bundle prefix)
+13-14: x 64       # data[02]: ...d
+14-15: x 65       # data[03]: ...e
+15-16: x 66       # data[04]: ...f
+
+# Try finishing without the last key which forces a shorter bundle prefix only.
+
+init bundle-size=2
+----
+Size: 0
+
+put
+abad
+abae
+abbf
+abc
+----
+Size: 20
+nKeys=4; bundleSize=2
+blockPrefixLen=2; currentBundleLen=7; currentBundleKeys=2
+Offsets:
+  0000  0003  0004  0008  0010  0012  0015
+Data (len=15):
+abadabaeabbfabc
+
+finish rows=3
+----
+# PrefixBytes
+00-01: x 01       # bundleSize: 2
+# Offsets table
+01-05: x 00000000 # 32-bit constant: 0
+05-06: x 02       # data[0] = 2 [13 overall]
+06-07: x 03       # data[1] = 3 [14 overall]
+07-08: x 04       # data[2] = 4 [15 overall]
+08-09: x 05       # data[3] = 5 [16 overall]
+09-10: x 07       # data[4] = 7 [18 overall]
+10-11: x 07       # data[5] = 7 [18 overall]
+# Data
+11-13: x 6162     # data[00]: ab (block prefix)
+13-14: x 61       # data[01]: ..a (bundle prefix)
+14-15: x 64       # data[02]: ...d
+15-16: x 65       # data[03]: ...e
+16-18: x 6266     # data[04]: ..bf (bundle prefix)
+18-18: x          # data[05]: ....
+
+# Test strings long enough to force 16-bit offsets, and have zero-length block
+# and bundle prefixes.
+
+init bundle-size=2
+----
+Size: 0
+
+put
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+----
+Size: 686
+nKeys=6; bundleSize=2
+blockPrefixLen=0; currentBundleLen=220; currentBundleKeys=2
+Offsets:
+  0000  0000  0110  0220  0220  0330  0440  0440  0550  0660
+Data (len=660):
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbcccccccccccccccccccc
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+ccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddd
+dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+ddddddddddddddddddddeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+eeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffff
+ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+
+finish rows=6
+----
+# PrefixBytes
+000-001: x 01                                       # bundleSize: 2
+# Offsets table
+001-005: x 00000000                                 # 32-bit constant: 0
+# Padding
+005-006: x 00                                       # aligning to 16-bit boundary
+006-008: x 0000                                     # data[0] = 0 [26 overall]
+008-010: x 0000                                     # data[1] = 0 [26 overall]
+010-012: x 6e00                                     # data[2] = 110 [136 overall]
+012-014: x dc00                                     # data[3] = 220 [246 overall]
+014-016: x dc00                                     # data[4] = 220 [246 overall]
+016-018: x 4a01                                     # data[5] = 330 [356 overall]
+018-020: x b801                                     # data[6] = 440 [466 overall]
+020-022: x b801                                     # data[7] = 440 [466 overall]
+022-024: x 2602                                     # data[8] = 550 [576 overall]
+024-026: x 9402                                     # data[9] = 660 [686 overall]
+# Data
+026-026: x                                          # data[00]:  (block prefix)
+026-026: x                                          # data[01]:  (bundle prefix)
+026-046: x 6161616161616161616161616161616161616161 # data[02]: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+046-066: x 6161616161616161616161616161616161616161 # (continued...)
+066-086: x 6161616161616161616161616161616161616161 # (continued...)
+086-106: x 6161616161616161616161616161616161616161 # (continued...)
+106-126: x 6161616161616161616161616161616161616161 # (continued...)
+126-136: x 61616161616161616161                     # (continued...)
+136-156: x 6262626262626262626262626262626262626262 # data[03]: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+156-176: x 6262626262626262626262626262626262626262 # (continued...)
+176-196: x 6262626262626262626262626262626262626262 # (continued...)
+196-216: x 6262626262626262626262626262626262626262 # (continued...)
+216-236: x 6262626262626262626262626262626262626262 # (continued...)
+236-246: x 62626262626262626262                     # (continued...)
+246-246: x                                          # data[04]:  (bundle prefix)
+246-266: x 6363636363636363636363636363636363636363 # data[05]: cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+266-286: x 6363636363636363636363636363636363636363 # (continued...)
+286-306: x 6363636363636363636363636363636363636363 # (continued...)
+306-326: x 6363636363636363636363636363636363636363 # (continued...)
+326-346: x 6363636363636363636363636363636363636363 # (continued...)
+346-356: x 63636363636363636363                     # (continued...)
+356-376: x 6464646464646464646464646464646464646464 # data[06]: dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+376-396: x 6464646464646464646464646464646464646464 # (continued...)
+396-416: x 6464646464646464646464646464646464646464 # (continued...)
+416-436: x 6464646464646464646464646464646464646464 # (continued...)
+436-456: x 6464646464646464646464646464646464646464 # (continued...)
+456-466: x 64646464646464646464                     # (continued...)
+466-466: x                                          # data[07]:  (bundle prefix)
+466-486: x 6565656565656565656565656565656565656565 # data[08]: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+486-506: x 6565656565656565656565656565656565656565 # (continued...)
+506-526: x 6565656565656565656565656565656565656565 # (continued...)
+526-546: x 6565656565656565656565656565656565656565 # (continued...)
+546-566: x 6565656565656565656565656565656565656565 # (continued...)
+566-576: x 65656565656565656565                     # (continued...)
+576-596: x 6666666666666666666666666666666666666666 # data[09]: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+596-616: x 6666666666666666666666666666666666666666 # (continued...)
+616-636: x 6666666666666666666666666666666666666666 # (continued...)
+636-656: x 6666666666666666666666666666666666666666 # (continued...)
+656-676: x 6666666666666666666666666666666666666666 # (continued...)
+676-686: x 66666666666666666666                     # (continued...)
+
+get indices=(0, 1, 2, 3, 4, 5)
+----
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/sstable/colblk/testdata/uints
+++ b/sstable/colblk/testdata/uints
@@ -695,6 +695,6 @@ b64: *colblk.UintBuilder[uint64]:
 01-09: x 0100000000000000 # 64-bit constant: 1
 # Padding
 09-12: x 000000           # aligning to 32-bit boundary
-12-16: x 00000000         # data[0] = 0
-16-20: x bff90000         # data[1] = 63935
-20-24: x c31f2d00         # data[2] = 2957251
+12-16: x 00000000         # data[0] = 0 + 1 = 1
+16-20: x bff90000         # data[1] = 63935 + 1 = 63936
+20-24: x c31f2d00         # data[2] = 2957251 + 1 = 2957252


### PR DESCRIPTION
Add a new column data type primitive, PrefixBytes, for encoding lexicographically-sorted byte slices. This data type applies prefix compression at two levels: a) column-wide and b) across "bundles" of N keys.