### PR TITLE
manifest: add range annotations

### DIFF
--- a/internal/manifest/annotator_test.go
+++ b/internal/manifest/annotator_test.go
@@ -5,54 +5,47 @@
 package manifest
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/stretchr/testify/require"
 )
 
-func makeTestLevelMetadata(count int) (LevelMetadata, []*FileMetadata) {
-	files := make([]*FileMetadata, count)
-	for i := 0; i < count; i++ {
-		files[i] = newItem(key(i))
+// Creates a version with numFiles files in level 6.
+func makeTestVersion(numFiles int) (*Version, []*FileMetadata) {
+	files := make([]*FileMetadata, numFiles)
+	for i := 0; i < numFiles; i++ {
+		// Each file spans 10 keys, e.g. [0->9], [10->19], etc.
+		files[i] = (&FileMetadata{}).ExtendPointKeyBounds(
+			base.DefaultComparer.Compare, key(i*10), key(i*10+9),
+		)
+		files[i].InitPhysicalBacking()
 	}
 
-	lm := MakeLevelMetadata(base.DefaultComparer.Compare, 6, files)
-	return lm, files
-}
+	var levelFiles [7][]*FileMetadata
+	levelFiles[6] = files
 
-// NumFilesAnnotator is an Annotator which computes an annotation value
-// equal to the number of files included in the annotation.
-var NumFilesAnnotator = SumAnnotator(func(f *FileMetadata) (uint64, bool) {
-	return 1, true
-})
+	v := NewVersion(base.DefaultComparer, 0, levelFiles)
+	return v, files
+}
 
 func TestNumFilesAnnotator(t *testing.T) {
 	const count = 1000
-	lm, _ := makeTestLevelMetadata(0)
+	v, _ := makeTestVersion(0)
 
 	for i := 1; i <= count; i++ {
-		lm.tree.Insert(newItem(key(i)))
-		numFiles := *NumFilesAnnotator.LevelAnnotation(lm)
+		v.Levels[6].tree.Insert(newItem(key(i)))
+		numFiles := *NumFilesAnnotator.LevelAnnotation(v.Levels[6])
 		require.EqualValues(t, i, numFiles)
 	}
-
-	numFiles := *NumFilesAnnotator.LevelAnnotation(lm)
-	require.EqualValues(t, count, numFiles)
-
-	numFiles = *NumFilesAnnotator.LevelAnnotation(lm)
-	require.EqualValues(t, count, numFiles)
-
-	lm.tree.Delete(newItem(key(count / 2)))
-	numFiles = *NumFilesAnnotator.LevelAnnotation(lm)
-	require.EqualValues(t, count-1, numFiles)
 }
 
 func BenchmarkNumFilesAnnotator(b *testing.B) {
-	lm, _ := makeTestLevelMetadata(0)
+	v, _ := makeTestVersion(0)
 	for i := 1; i <= b.N; i++ {
-		lm.tree.Insert(newItem(key(i)))
-		numFiles := *NumFilesAnnotator.LevelAnnotation(lm)
+		v.Levels[6].tree.Insert(newItem(key(i)))
+		numFiles := *NumFilesAnnotator.LevelAnnotation(v.Levels[6])
 		require.EqualValues(b, uint64(i), numFiles)
 	}
 }
@@ -70,12 +63,115 @@ func TestPickFileAggregator(t *testing.T) {
 		},
 	}
 
-	lm, files := makeTestLevelMetadata(1)
+	v, files := makeTestVersion(1)
 
 	for i := 1; i <= count; i++ {
-		lm.tree.Insert(newItem(key(i)))
-		pickedFile := a.LevelAnnotation(lm)
+		v.Levels[6].tree.Insert(newItem(key(i)))
+		pickedFile := a.LevelAnnotation(v.Levels[6])
 		// The picked file should always be the one with the smallest key.
 		require.Same(t, files[0], pickedFile)
 	}
+}
+
+func bounds(i int, j int, exclusive bool) base.UserKeyBounds {
+	b := base.UserKeyBoundsEndExclusiveIf(key(i).UserKey, key(j).UserKey, exclusive)
+	return b
+}
+
+func randomBounds(rng *rand.Rand, count int) base.UserKeyBounds {
+	first := rng.Intn(count)
+	second := rng.Intn(count)
+	exclusive := rng.Intn(2) == 0
+	return bounds(min(first, second), max(first, second), exclusive)
+}
+
+func requireMatchOverlaps(t *testing.T, v *Version, bounds base.UserKeyBounds) {
+	overlaps := v.Overlaps(6, bounds)
+	numFiles := *NumFilesAnnotator.LevelRangeAnnotation(v.Levels[6], bounds)
+	require.EqualValues(t, overlaps.length, numFiles)
+}
+
+func TestNumFilesRangeAnnotationEmptyRanges(t *testing.T) {
+	const count = 5_000
+	v, files := makeTestVersion(count)
+
+	// Delete files containing key ranges [0, 999] and [24_000, 25_999].
+	for i := 0; i < 100; i++ {
+		v.Levels[6].tree.Delete(files[i])
+	}
+	for i := 2400; i < 2600; i++ {
+		v.Levels[6].tree.Delete(files[i])
+	}
+
+	// Ranges that are completely empty.
+	requireMatchOverlaps(t, v, bounds(1, 999, false))
+	requireMatchOverlaps(t, v, bounds(0, 1000, true))
+	requireMatchOverlaps(t, v, bounds(50_000, 60_000, false))
+	requireMatchOverlaps(t, v, bounds(24_500, 25_500, false))
+	requireMatchOverlaps(t, v, bounds(24_000, 26_000, true))
+
+	// Partial overlaps with empty ranges.
+	requireMatchOverlaps(t, v, bounds(0, 1000, false))
+	requireMatchOverlaps(t, v, bounds(20, 1001, true))
+	requireMatchOverlaps(t, v, bounds(20, 1010, true))
+	requireMatchOverlaps(t, v, bounds(23_000, 27_000, true))
+	requireMatchOverlaps(t, v, bounds(25_000, 40_000, false))
+	requireMatchOverlaps(t, v, bounds(25_500, 26_001, true))
+
+	// Ranges which only spans a single table.
+	requireMatchOverlaps(t, v, bounds(45_000, 45_000, true))
+	requireMatchOverlaps(t, v, bounds(30_000, 30_001, true))
+	requireMatchOverlaps(t, v, bounds(23_000, 23_000, false))
+}
+
+func TestNumFilesRangeAnnotationRandomized(t *testing.T) {
+	const count = 10_000
+	const numIterations = 10_000
+
+	v, _ := makeTestVersion(count)
+
+	rng := rand.New(rand.NewSource(int64(0)))
+	for i := 0; i < numIterations; i++ {
+		requireMatchOverlaps(t, v, randomBounds(rng, count*11))
+	}
+}
+
+func BenchmarkNumFilesRangeAnnotation(b *testing.B) {
+	const count = 100_000
+	v, files := makeTestVersion(count)
+
+	rng := rand.New(rand.NewSource(int64(0)))
+	b.Run("annotator", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			b := randomBounds(rng, count*11)
+			// Randomly delete and reinsert a file to verify that range
+			// annotations are still fast despite small mutations.
+			toDelete := rng.Intn(count)
+			v.Levels[6].tree.Delete(files[toDelete])
+
+			NumFilesAnnotator.LevelRangeAnnotation(v.Levels[6], b)
+
+			v.Levels[6].tree.Insert(files[toDelete])
+		}
+	})
+
+	// Also benchmark an equivalent aggregation using version.Overlaps to show
+	// the difference in performance.
+	b.Run("overlaps", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			b := randomBounds(rng, count*11)
+			toDelete := rng.Intn(count)
+			v.Levels[6].tree.Delete(files[toDelete])
+
+			overlaps := v.Overlaps(6, b)
+			iter := overlaps.Iter()
+			numFiles := 0
+			for f := iter.First(); f != nil; f = iter.Next() {
+				numFiles++
+			}
+
+			v.Levels[6].tree.Insert(files[toDelete])
+		}
+	})
+
 }

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -337,7 +337,7 @@ func NewL0Sublevels(
 	// Construct a parallel slice of sublevel B-Trees.
 	// TODO(jackson): Consolidate and only use the B-Trees.
 	for _, sublevelFiles := range s.levelFiles {
-		tr, ls := makeBTree(btreeCmpSmallestKey(cmp), sublevelFiles)
+		tr, ls := makeBTree(cmp, btreeCmpSmallestKey(cmp), sublevelFiles)
 		s.Levels = append(s.Levels, ls)
 		tr.Release()
 	}
@@ -630,7 +630,7 @@ func (s *L0Sublevels) AddL0Files(
 	// Construct a parallel slice of sublevel B-Trees.
 	// TODO(jackson): Consolidate and only use the B-Trees.
 	for _, sublevel := range updatedSublevels {
-		tr, ls := makeBTree(btreeCmpSmallestKey(newVal.cmp), newVal.levelFiles[sublevel])
+		tr, ls := makeBTree(newVal.cmp, btreeCmpSmallestKey(newVal.cmp), newVal.levelFiles[sublevel])
 		if sublevel == len(newVal.Levels) {
 			newVal.Levels = append(newVal.Levels, ls)
 		} else {

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -49,7 +49,7 @@ func MakeLevelMetadata(cmp Compare, level int, files []*FileMetadata) LevelMetad
 	}
 	var lm LevelMetadata
 	lm.level = level
-	lm.tree, _ = makeBTree(bcmp, files)
+	lm.tree, _ = makeBTree(cmp, bcmp, files)
 	for _, f := range files {
 		lm.totalSize += f.Size
 		if f.Virtual {
@@ -60,9 +60,10 @@ func MakeLevelMetadata(cmp Compare, level int, files []*FileMetadata) LevelMetad
 	return lm
 }
 
-func makeBTree(cmp btreeCmp, files []*FileMetadata) (btree, LevelSlice) {
+func makeBTree(cmp base.Compare, bcmp btreeCmp, files []*FileMetadata) (btree, LevelSlice) {
 	var t btree
 	t.cmp = cmp
+	t.bcmp = bcmp
 	for _, f := range files {
 		t.Insert(f)
 	}
@@ -157,7 +158,7 @@ func (lf LevelFile) Slice() LevelSlice {
 // TODO(jackson): Can we improve this interface or avoid needing to export
 // a slice constructor like this?
 func NewLevelSliceSeqSorted(files []*FileMetadata) LevelSlice {
-	tr, slice := makeBTree(btreeCmpSeqNum, files)
+	tr, slice := makeBTree(nil, btreeCmpSeqNum, files)
 	tr.Release()
 	slice.verifyInvariants()
 	return slice
@@ -168,7 +169,7 @@ func NewLevelSliceSeqSorted(files []*FileMetadata) LevelSlice {
 // TODO(jackson): Can we improve this interface or avoid needing to export
 // a slice constructor like this?
 func NewLevelSliceKeySorted(cmp base.Compare, files []*FileMetadata) LevelSlice {
-	tr, slice := makeBTree(btreeCmpSmallestKey(cmp), files)
+	tr, slice := makeBTree(cmp, btreeCmpSmallestKey(cmp), files)
 	tr.Release()
 	slice.verifyInvariants()
 	return slice
@@ -179,7 +180,7 @@ func NewLevelSliceKeySorted(cmp base.Compare, files []*FileMetadata) LevelSlice 
 // tests.
 // TODO(jackson): Update tests to avoid requiring this and remove it.
 func NewLevelSliceSpecificOrder(files []*FileMetadata) LevelSlice {
-	tr, slice := makeBTree(btreeCmpSpecificOrder(files), files)
+	tr, slice := makeBTree(nil, btreeCmpSpecificOrder(files), files)
 	tr.Release()
 	slice.verifyInvariants()
 	return slice

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -1068,12 +1068,12 @@ func NewVersion(
 		// order to test consistency checking, etc. Once we've constructed the
 		// initial B-Tree, we swap out the btreeCmp for the correct one.
 		// TODO(jackson): Adjust or remove the tests and remove this.
-		v.Levels[l].tree, _ = makeBTree(btreeCmpSpecificOrder(files[l]), files[l])
+		v.Levels[l].tree, _ = makeBTree(comparer.Compare, btreeCmpSpecificOrder(files[l]), files[l])
 		v.Levels[l].level = l
 		if l == 0 {
-			v.Levels[l].tree.cmp = btreeCmpSeqNum
+			v.Levels[l].tree.bcmp = btreeCmpSeqNum
 		} else {
-			v.Levels[l].tree.cmp = btreeCmpSmallestKey(comparer.Compare)
+			v.Levels[l].tree.bcmp = btreeCmpSmallestKey(comparer.Compare)
 		}
 		for _, f := range files[l] {
 			v.Levels[l].totalSize += f.Size
@@ -1501,7 +1501,7 @@ func (v *Version) Overlaps(level int, bounds base.UserKeyBounds) LevelSlice {
 			if !restart {
 				// Construct a B-Tree containing only the matching items.
 				var tr btree
-				tr.cmp = v.Levels[level].tree.cmp
+				tr.bcmp = v.Levels[level].tree.bcmp
 				for i, meta := 0, l0Iter.First(); meta != nil; i, meta = i+1, l0Iter.Next() {
 					if selectedIndices[i] {
 						err := tr.Insert(meta)


### PR DESCRIPTION
manifest: add range annotations

This change adds a "range annotation" feature to Annotators , which are computations that aggregate some value over a specific key range within a level. Range annotations use the same B-tree caching behavior as regular annotations, so queries remain fast even with thousands of tables because they avoid a sequential iteration over a level's files.

This PR only sets up range annotations without changing any existing behavior. See cockroachdb#3793 for some potential use cases.

`BenchmarkNumFilesRangeAnnotation` shows that range annotations are significantly faster than using `version.Overlaps` to aggregate over a key range:
```
pkg: github.com/cockroachdb/pebble/internal/manifest
BenchmarkNumFilesRangeAnnotation/annotator-10         	  306010	      4015 ns/op	      48 B/op	       6 allocs/op
BenchmarkNumFilesRangeAnnotation/overlaps-10          	    2223	    513519 ns/op	     336 B/op	       8 allocs/op
```