### PR TITLE
manifest: improve Annotator interface with generics

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -639,39 +639,13 @@ func compensatedSize(f *fileMetadata) uint64 {
 	return f.Size + fileCompensation(f)
 }
 
-// compensatedSizeAnnotator implements manifest.Annotator, annotating B-Tree
-// nodes with the sum of the files' compensated sizes. Its annotation type is
-// a *uint64. Compensated sizes may change once a table's stats are loaded
-// asynchronously, so its values are marked as cacheable only if a file's
-// stats have been loaded.
-type compensatedSizeAnnotator struct {
-}
-
-var _ manifest.Annotator = compensatedSizeAnnotator{}
-
-func (a compensatedSizeAnnotator) Zero(dst interface{}) interface{} {
-	if dst == nil {
-		return new(uint64)
-	}
-	v := dst.(*uint64)
-	*v = 0
-	return v
-}
-
-func (a compensatedSizeAnnotator) Accumulate(
-	f *fileMetadata, dst interface{},
-) (v interface{}, cacheOK bool) {
-	vptr := dst.(*uint64)
-	*vptr = *vptr + compensatedSize(f)
-	return vptr, f.StatsValid()
-}
-
-func (a compensatedSizeAnnotator) Merge(src interface{}, dst interface{}) interface{} {
-	srcV := src.(*uint64)
-	dstV := dst.(*uint64)
-	*dstV = *dstV + *srcV
-	return dstV
-}
+// compensatedSizeAnnotator is a manifest.Annotator that annotates B-Tree
+// nodes with the sum of the files' compensated sizes. Compensated sizes may
+// change once a table's stats are loaded asynchronously, so its values are
+// marked as cacheable only if a file's stats have been loaded.
+var compensatedSizeAnnotator = manifest.SumAnnotator(func(f *fileMetadata) (uint64, bool) {
+	return compensatedSize(f), f.StatsValid()
+})
 
 // totalCompensatedSize computes the compensated size over a file metadata
 // iterator. Note that this function is linear in the files available to the
@@ -912,10 +886,6 @@ func calculateSizeAdjust(inProgressCompactions []compactionInfo) [numLevels]leve
 	return sizeAdjust
 }
 
-func levelCompensatedSize(lm manifest.LevelMetadata) uint64 {
-	return *lm.Annotation(compensatedSizeAnnotator{}).(*uint64)
-}
-
 func (p *compactionPickerByScore) calculateLevelScores(
 	inProgressCompactions []compactionInfo,
 ) [numLevels]candidateLevelInfo {
@@ -932,7 +902,7 @@ func (p *compactionPickerByScore) calculateLevelScores(
 	}
 	sizeAdjust := calculateSizeAdjust(inProgressCompactions)
 	for level := 1; level < numLevels; level++ {
-		compensatedLevelSize := levelCompensatedSize(p.vers.Levels[level]) + sizeAdjust[level].compensated()
+		compensatedLevelSize := *compensatedSizeAnnotator.LevelAnnotation(p.vers.Levels[level]) + sizeAdjust[level].compensated()
 		scores[level].compensatedScore = float64(compensatedLevelSize) / float64(p.levelMaxBytes[level])
 		scores[level].uncompensatedScore = float64(p.vers.Levels[level].Size()+sizeAdjust[level].actual()) / float64(p.levelMaxBytes[level])
 	}
@@ -1393,109 +1363,56 @@ func (p *compactionPickerByScore) addScoresToPickedCompactionMetrics(
 	}
 }
 
-// elisionOnlyAnnotator implements the manifest.Annotator interface,
-// annotating B-Tree nodes with the *fileMetadata of a file meeting the
-// obsolete keys criteria for an elision-only compaction within the subtree.
-// If multiple files meet the criteria, it chooses whichever file has the
-// lowest LargestSeqNum. The lowest LargestSeqNum file will be the first
-// eligible for an elision-only compaction once snapshots less than or equal
-// to its LargestSeqNum are closed.
-type elisionOnlyAnnotator struct{}
-
-var _ manifest.Annotator = elisionOnlyAnnotator{}
-
-func (a elisionOnlyAnnotator) Zero(interface{}) interface{} {
-	return nil
+// elisionOnlyAnnotator is a manifest.Annotator that annotates B-Tree
+// nodes with the *fileMetadata of a file meeting the obsolete keys criteria
+// for an elision-only compaction within the subtree. If multiple files meet
+// the criteria, it chooses whichever file has the lowest LargestSeqNum. The
+// lowest LargestSeqNum file will be the first eligible for an elision-only
+// compaction once snapshots less than or equal to its LargestSeqNum are closed.
+var elisionOnlyAnnotator = &manifest.Annotator[fileMetadata]{
+	Aggregator: manifest.PickFileAggregator{
+		Filter: func(f *fileMetadata) (eligible bool, cacheOK bool) {
+			if f.IsCompacting() {
+				return false, true
+			}
+			if !f.StatsValid() {
+				return false, false
+			}
+			// Bottommost files are large and not worthwhile to compact just
+			// to remove a few tombstones. Consider a file eligible only if
+			// either its own range deletions delete at least 10% of its data or
+			// its deletion tombstones make at least 10% of its entries.
+			//
+			// TODO(jackson): This does not account for duplicate user keys
+			// which may be collapsed. Ideally, we would have 'obsolete keys'
+			// statistics that would include tombstones, the keys that are
+			// dropped by tombstones and duplicated user keys. See #847.
+			//
+			// Note that tables that contain exclusively range keys (i.e. no point keys,
+			// `NumEntries` and `RangeDeletionsBytesEstimate` are both zero) are excluded
+			// from elision-only compactions.
+			// TODO(travers): Consider an alternative heuristic for elision of range-keys.
+			return f.Stats.RangeDeletionsBytesEstimate*10 >= f.Size || f.Stats.NumDeletions*10 > f.Stats.NumEntries, true
+		},
+		Compare: func(f1 *fileMetadata, f2 *fileMetadata) bool {
+			return f1.LargestSeqNum < f2.LargestSeqNum
+		},
+	},
 }
 
-func (a elisionOnlyAnnotator) Accumulate(f *fileMetadata, dst interface{}) (interface{}, bool) {
-	if f.IsCompacting() {
-		return dst, true
-	}
-	if !f.StatsValid() {
-		return dst, false
-	}
-	// Bottommost files are large and not worthwhile to compact just
-	// to remove a few tombstones. Consider a file ineligible if its
-	// own range deletions delete less than 10% of its data and its
-	// deletion tombstones make up less than 10% of its entries.
-	//
-	// TODO(jackson): This does not account for duplicate user keys
-	// which may be collapsed. Ideally, we would have 'obsolete keys'
-	// statistics that would include tombstones, the keys that are
-	// dropped by tombstones and duplicated user keys. See #847.
-	//
-	// Note that tables that contain exclusively range keys (i.e. no point keys,
-	// `NumEntries` and `RangeDeletionsBytesEstimate` are both zero) are excluded
-	// from elision-only compactions.
-	// TODO(travers): Consider an alternative heuristic for elision of range-keys.
-	if f.Stats.RangeDeletionsBytesEstimate*10 < f.Size &&
-		f.Stats.NumDeletions*10 <= f.Stats.NumEntries {
-		return dst, true
-	}
-	if dst == nil {
-		return f, true
-	} else if dstV := dst.(*fileMetadata); dstV.LargestSeqNum > f.LargestSeqNum {
-		return f, true
-	}
-	return dst, true
-}
-
-func (a elisionOnlyAnnotator) Merge(v interface{}, accum interface{}) interface{} {
-	if v == nil {
-		return accum
-	}
-	// If we haven't accumulated an eligible file yet, or f's LargestSeqNum is
-	// less than the accumulated file's, use f.
-	if accum == nil {
-		return v
-	}
-	f := v.(*fileMetadata)
-	accumV := accum.(*fileMetadata)
-	if accumV == nil || accumV.LargestSeqNum > f.LargestSeqNum {
-		return f
-	}
-	return accumV
-}
-
-// markedForCompactionAnnotator implements the manifest.Annotator interface,
-// annotating B-Tree nodes with the *fileMetadata of a file that is marked for
-// compaction within the subtree. If multiple files meet the criteria, it
-// chooses whichever file has the lowest LargestSeqNum.
-type markedForCompactionAnnotator struct{}
-
-var _ manifest.Annotator = markedForCompactionAnnotator{}
-
-func (a markedForCompactionAnnotator) Zero(interface{}) interface{} {
-	return nil
-}
-
-func (a markedForCompactionAnnotator) Accumulate(
-	f *fileMetadata, dst interface{},
-) (interface{}, bool) {
-	if !f.MarkedForCompaction {
-		// Not marked for compaction; return dst.
-		return dst, true
-	}
-	return markedMergeHelper(f, dst)
-}
-
-func (a markedForCompactionAnnotator) Merge(v interface{}, accum interface{}) interface{} {
-	if v == nil {
-		return accum
-	}
-	accum, _ = markedMergeHelper(v.(*fileMetadata), accum)
-	return accum
-}
-
-// REQUIRES: f is non-nil, and f.MarkedForCompaction=true.
-func markedMergeHelper(f *fileMetadata, dst interface{}) (interface{}, bool) {
-	if dst == nil {
-		return f, true
-	} else if dstV := dst.(*fileMetadata); dstV.LargestSeqNum > f.LargestSeqNum {
-		return f, true
-	}
-	return dst, true
+// markedForCompactionAnnotator is a manifest.Annotator that annotates B-Tree
+// nodes with the *fileMetadata of a file that is marked for compaction
+// within the subtree. If multiple files meet the criteria, it chooses
+// whichever file has the lowest LargestSeqNum.
+var markedForCompactionAnnotator = &manifest.Annotator[fileMetadata]{
+	Aggregator: manifest.PickFileAggregator{
+		Filter: func(f *fileMetadata) (eligible bool, cacheOK bool) {
+			return f.MarkedForCompaction, true
+		},
+		Compare: func(f1 *fileMetadata, f2 *fileMetadata) bool {
+			return f1.LargestSeqNum < f2.LargestSeqNum
+		},
+	},
 }
 
 // pickElisionOnlyCompaction looks for compactions of sstables in the
@@ -1506,11 +1423,10 @@ func (p *compactionPickerByScore) pickElisionOnlyCompaction(
 	if p.opts.private.disableElisionOnlyCompactions {
 		return nil
 	}
-	v := p.vers.Levels[numLevels-1].Annotation(elisionOnlyAnnotator{})
-	if v == nil {
+	candidate := elisionOnlyAnnotator.LevelAnnotation(p.vers.Levels[numLevels-1])
+	if candidate == nil {
 		return nil
 	}
-	candidate := v.(*fileMetadata)
 	if candidate.IsCompacting() || candidate.LargestSeqNum >= env.earliestSnapshotSeqNum {
 		return nil
 	}
@@ -1542,12 +1458,11 @@ func (p *compactionPickerByScore) pickElisionOnlyCompaction(
 // the input level.
 func (p *compactionPickerByScore) pickRewriteCompaction(env compactionEnv) (pc *pickedCompaction) {
 	for l := numLevels - 1; l >= 0; l-- {
-		v := p.vers.Levels[l].Annotation(markedForCompactionAnnotator{})
-		if v == nil {
+		candidate := markedForCompactionAnnotator.LevelAnnotation(p.vers.Levels[l])
+		if candidate == nil {
 			// Try the next level.
 			continue
 		}
-		candidate := v.(*fileMetadata)
 		if candidate.IsCompacting() {
 			// Try the next level.
 			continue

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -563,7 +563,7 @@ func TestCompactionPickerL0(t *testing.T) {
 					}
 					f.MarkedForCompaction = true
 					picker.vers.Stats.MarkedForCompaction++
-					picker.vers.Levels[l].InvalidateAnnotation(markedForCompactionAnnotator{})
+					markedForCompactionAnnotator.InvalidateLevelAnnotation(picker.vers.Levels[l])
 					return fmt.Sprintf("marked L%d.%s", l, f.FileNum)
 				}
 			}

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2505,7 +2505,7 @@ func TestMarkedForCompaction(t *testing.T) {
 					}
 					f.MarkedForCompaction = true
 					vers.Stats.MarkedForCompaction++
-					vers.Levels[l].InvalidateAnnotation(markedForCompactionAnnotator{})
+					markedForCompactionAnnotator.InvalidateLevelAnnotation(vers.Levels[l])
 					return fmt.Sprintf("marked L%d.%s", l, f.FileNum)
 				}
 			}

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -517,7 +517,7 @@ func (d *DB) markFilesLocked(findFn findFilesFunc) error {
 		// annotations will be out of date. Clear the compaction-picking
 		// annotation, so that it's recomputed the next time the compaction
 		// picker looks for a file marked for compaction.
-		vers.Levels[l].InvalidateAnnotation(markedForCompactionAnnotator{})
+		markedForCompactionAnnotator.InvalidateLevelAnnotation(vers.Levels[l])
 	}
 
 	// The 'marked-for-compaction' bit is persisted in the MANIFEST file

--- a/internal/manifest/annotator.go
+++ b/internal/manifest/annotator.go
@@ -1,0 +1,253 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package manifest
+
+// The Annotator type defined below is used by other packages to lazily
+// compute a value over a B-Tree. Each node of the B-Tree stores one
+// `annotation` per annotator, containing the result of the computation over
+// the node's subtree.
+//
+// An annotation is marked as valid if it's current with the current subtree
+// state. Annotations are marked as invalid whenever a node will be mutated
+// (in mut).  Annotators may also return `false` from `Accumulate` to signal
+// that a computation for a file is not stable and may change in the future.
+// Annotations that include these unstable values are also marked as invalid
+// on the node, ensuring that future queries for the annotation will recompute
+// the value.
+
+// An Annotator defines a computation over a level's FileMetadata. If the
+// computation is stable and uses inputs that are fixed for the lifetime of
+// a FileMetadata, the LevelMetadata's internal data structures are annotated
+// with the intermediary computations. This allows the computation to be
+// computed incrementally as edits are applied to a level.
+type Annotator[T any] struct {
+	Aggregator AnnotationAggregator[T]
+}
+
+// An AnnotationAggregator defines how an annotation should be accumulated
+// from a single FileMetadata and merged with other annotated values.
+type AnnotationAggregator[T any] interface {
+	// Zero returns the zero value of an annotation. This value is returned
+	// when a LevelMetadata is empty. The dst argument, if non-nil, is an
+	// obsolete value previously returned by this Annotator and may be
+	// overwritten and reused to avoid a memory allocation.
+	Zero(dst *T) *T
+
+	// Accumulate computes the annotation for a single file in a level's
+	// metadata. It merges the file's value into dst and returns a bool flag
+	// indicating whether or not the value is stable and okay to cache as an
+	// annotation. If the file's value may change over the life of the file,
+	// the annotator must return false.
+	//
+	// Implementations may modify dst and return it to avoid an allocation.
+	Accumulate(f *FileMetadata, dst *T) (v *T, cacheOK bool)
+
+	// Merge combines two values src and dst, returning the result.
+	// Implementations may modify dst and return it to avoid an allocation.
+	Merge(src *T, dst *T) *T
+}
+
+type annotation struct {
+	// annotator is a pointer to the Annotator that computed this annotation.
+	// NB: This is untyped to allow AnnotationAggregator to use Go generics,
+	// since annotations are stored in a slice on each node and a single
+	// slice cannot contain elements with different type parameters.
+	annotator interface{}
+	// v is contains the annotation value, the output of either
+	// AnnotationAggregator.Accumulate or AnnotationAggregator.Merge.
+	// NB: This is untyped for the same reason as annotator above.
+	v interface{}
+	// valid indicates whether future reads of the annotation may use the
+	// value as-is. If false, v will be zeroed and recalculated.
+	valid bool
+}
+
+// findAnnotation finds this Annotator's annotation on a node, creating
+// one if it doesn't already exist.
+func (a *Annotator[T]) findAnnotation(n *node) *annotation {
+	for i := range n.annot {
+		if n.annot[i].annotator == a {
+			return &n.annot[i]
+		}
+	}
+
+	// This node has never been annotated by a. Create a new annotation.
+	n.annot = append(n.annot, annotation{
+		annotator: a,
+		v:         a.Aggregator.Zero(nil),
+	})
+	return &n.annot[len(n.annot)-1]
+}
+
+// nodeAnnotation computes this annotator's annotation of this node across all
+// files in the node's subtree. The second return value indicates whether the
+// annotation is stable and thus cacheable.
+func (a *Annotator[T]) nodeAnnotation(n *node) (v *T, cacheOK bool) {
+	annot := a.findAnnotation(n)
+	vtyped := annot.v.(*T)
+	// If the annotation is already marked as valid, we can return it without
+	// recomputing anything.
+	if annot.valid {
+		return vtyped, true
+	}
+
+	annot.v = a.Aggregator.Zero(vtyped)
+	annot.valid = true
+
+	for i := int16(0); i <= n.count; i++ {
+		if !n.leaf {
+			v, ok := a.nodeAnnotation(n.children[i])
+			annot.v = a.Aggregator.Merge(v, vtyped)
+			annot.valid = annot.valid && ok
+		}
+
+		if i < n.count {
+			v, ok := a.Aggregator.Accumulate(n.items[i], vtyped)
+			annot.v = v
+			annot.valid = annot.valid && ok
+		}
+	}
+
+	return annot.v.(*T), annot.valid
+}
+
+// InvalidateAnnotation removes any existing cached annotations from this
+// annotator from a node's subtree.
+func (a *Annotator[T]) invalidateNodeAnnotation(n *node) {
+	annot := a.findAnnotation(n)
+	annot.valid = false
+	if !n.leaf {
+		for i := int16(0); i <= n.count; i++ {
+			a.invalidateNodeAnnotation(n.children[i])
+		}
+	}
+}
+
+// LevelAnnotation calculates the annotation defined by this Annotator for all
+// files in the given LevelMetadata. A pointer to the Annotator is used as the
+// key for pre-calculated values, so the same Annotator must be used to avoid
+// duplicate computation. Annotation must not be called concurrently, and in
+// practice this is achieved by requiring callers to hold DB.mu.
+func (a *Annotator[T]) LevelAnnotation(lm LevelMetadata) *T {
+	if lm.Empty() {
+		return a.Aggregator.Zero(nil)
+	}
+
+	v, _ := a.nodeAnnotation(lm.tree.root)
+	return v
+}
+
+// LevelAnnotation calculates the annotation defined by this Annotator for all
+// files across the given levels. A pointer to the Annotator is used as the
+// key for pre-calculated values, so the same Annotator must be used to avoid
+// duplicate computation. Annotation must not be called concurrently, and in
+// practice this is achieved by requiring callers to hold DB.mu.
+func (a *Annotator[T]) MultiLevelAnnotation(lms []LevelMetadata) *T {
+	aggregated := a.Aggregator.Zero(nil)
+	for l := 0; l < len(lms); l++ {
+		if !lms[l].Empty() {
+			v := a.LevelAnnotation(lms[l])
+			aggregated = a.Aggregator.Merge(v, aggregated)
+		}
+	}
+	return aggregated
+}
+
+// InvalidateAnnotation clears any cached annotations defined by Annotator. A
+// pointer to the Annotator is used as the key for pre-calculated values, so
+// the same Annotator must be used to clear the appropriate cached annotation.
+// InvalidateAnnotation must not be called concurrently, and in practice this
+// is achieved by requiring callers to hold DB.mu.
+func (a *Annotator[T]) InvalidateLevelAnnotation(lm LevelMetadata) {
+	if lm.Empty() {
+		return
+	}
+	a.invalidateNodeAnnotation(lm.tree.root)
+}
+
+// sumAggregator defines an Aggregator which sums together a uint64 value
+// across files.
+type sumAggregator struct {
+	accumulateFunc func(f *FileMetadata) (v uint64, cacheOK bool)
+}
+
+func (sa sumAggregator) Zero(dst *uint64) *uint64 {
+	if dst == nil {
+		return new(uint64)
+	}
+	*dst = 0
+	return dst
+}
+
+func (sa sumAggregator) Accumulate(f *FileMetadata, dst *uint64) (v *uint64, cacheOK bool) {
+	accumulated, ok := sa.accumulateFunc(f)
+	*dst += accumulated
+	return dst, ok
+}
+
+func (sa sumAggregator) Merge(src *uint64, dst *uint64) *uint64 {
+	*dst += *src
+	return dst
+}
+
+// SumAnnotator takes a function that computes a uint64 value from a single
+// FileMetadata and returns an Annotator that sums together the values across
+// files.
+func SumAnnotator(accumulate func(f *FileMetadata) (v uint64, cacheOK bool)) *Annotator[uint64] {
+	return &Annotator[uint64]{
+		Aggregator: sumAggregator{
+			accumulateFunc: accumulate,
+		},
+	}
+}
+
+// PickFileAggregator implements the AnnotationAggregator interface. It defines
+// an aggregator that picks a single file from a set of eligible files.
+type PickFileAggregator struct {
+	// Filter takes a FileMetadata and returns whether it is eligible to be
+	// picked by this PickFileAggregator. The second return value indicates
+	// whether this eligibility is stable and thus cacheable.
+	Filter func(f *FileMetadata) (eligible bool, cacheOK bool)
+	// Compare compares two instances of FileMetadata and returns true if
+	// the first one should be picked over the second one. It may assume
+	// that both arguments are non-nil.
+	Compare func(f1 *FileMetadata, f2 *FileMetadata) bool
+}
+
+// Zero implements AnnotationAggregator.Zero, returning nil as the zero value.
+func (fa PickFileAggregator) Zero(dst *FileMetadata) *FileMetadata {
+	return nil
+}
+
+func (fa PickFileAggregator) mergePickedFiles(src *FileMetadata, dst *FileMetadata) *FileMetadata {
+	switch {
+	case src == nil:
+		return dst
+	case dst == nil:
+		return src
+	case fa.Compare(src, dst):
+		return src
+	default:
+		return dst
+	}
+}
+
+// Accumulate implements AnnotationAggregator.Accumulate, accumulating a single
+// file as long as it is eligible to be picked.
+func (fa PickFileAggregator) Accumulate(
+	f *FileMetadata, dst *FileMetadata,
+) (v *FileMetadata, cacheOK bool) {
+	eligible, ok := fa.Filter(f)
+	if eligible {
+		return fa.mergePickedFiles(f, dst), ok
+	}
+	return dst, ok
+}
+
+// Merge implements AnnotationAggregator.Merge by picking a single file based
+// on the output of PickFileAggregator.Compare.
+func (fa PickFileAggregator) Merge(src *FileMetadata, dst *FileMetadata) *FileMetadata {
+	return fa.mergePickedFiles(src, dst)
+}

--- a/internal/manifest/annotator_test.go
+++ b/internal/manifest/annotator_test.go
@@ -1,0 +1,58 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package manifest
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/stretchr/testify/require"
+)
+
+func makeTestLevelMetadata(count int) (LevelMetadata, []*FileMetadata) {
+	files := make([]*FileMetadata, count)
+	for i := 0; i < count; i++ {
+		files[i] = newItem(key(i))
+	}
+
+	lm := MakeLevelMetadata(base.DefaultComparer.Compare, 6, files)
+	return lm, files
+}
+
+// NumFilesAnnotator is an Annotator which computes an annotation value
+// equal to the number of files included in the annotation.
+var NumFilesAnnotator = SumAnnotator(func(f *FileMetadata) (uint64, bool) {
+	return 1, true
+})
+
+func TestNumFilesAnnotator(t *testing.T) {
+	const count = 1000
+	lm, _ := makeTestLevelMetadata(0)
+
+	for i := 1; i <= count; i++ {
+		lm.tree.Insert(newItem(key(i)))
+		numFiles := *NumFilesAnnotator.LevelAnnotation(lm)
+		require.EqualValues(t, i, numFiles)
+	}
+
+	numFiles := *NumFilesAnnotator.LevelAnnotation(lm)
+	require.EqualValues(t, count, numFiles)
+
+	numFiles = *NumFilesAnnotator.LevelAnnotation(lm)
+	require.EqualValues(t, count, numFiles)
+
+	lm.tree.Delete(newItem(key(count / 2)))
+	numFiles = *NumFilesAnnotator.LevelAnnotation(lm)
+	require.EqualValues(t, count-1, numFiles)
+}
+
+func BenchmarkNumFilesAnnotator(b *testing.B) {
+	lm, _ := makeTestLevelMetadata(0)
+	for i := 1; i <= b.N; i++ {
+		lm.tree.Insert(newItem(key(i)))
+		numFiles := *NumFilesAnnotator.LevelAnnotation(lm)
+		require.EqualValues(b, uint64(i), numFiles)
+	}
+}

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -140,31 +140,6 @@ func (lm *LevelMetadata) Find(cmp base.Compare, m *FileMetadata) LevelSlice {
 	return LevelSlice{}
 }
 
-// Annotation lazily calculates and returns the annotation defined by
-// Annotator. The Annotator is used as the key for pre-calculated
-// values, so equal Annotators must be used to avoid duplicate computations
-// and cached annotations. Annotation must not be called concurrently, and in
-// practice this is achieved by requiring callers to hold DB.mu.
-func (lm *LevelMetadata) Annotation(annotator Annotator) interface{} {
-	if lm.Empty() {
-		return annotator.Zero(nil)
-	}
-	v, _ := lm.tree.root.Annotation(annotator)
-	return v
-}
-
-// InvalidateAnnotation clears any cached annotations defined by Annotator. The
-// Annotator is used as the key for pre-calculated values, so equal Annotators
-// must be used to clear the appropriate cached annotation. InvalidateAnnotation
-// must not be called concurrently, and in practice this is achieved by
-// requiring callers to hold DB.mu.
-func (lm *LevelMetadata) InvalidateAnnotation(annotator Annotator) {
-	if lm.Empty() {
-		return
-	}
-	lm.tree.root.InvalidateAnnotation(annotator)
-}
-
 // LevelFile holds a file's metadata along with its position
 // within a level of the LSM.
 type LevelFile struct {

--- a/table_stats.go
+++ b/table_stats.go
@@ -989,206 +989,76 @@ func newCombinedDeletionKeyspanIter(
 	return mIter, nil
 }
 
-// rangeKeySetsAnnotator implements manifest.Annotator, annotating B-Tree nodes
-// with the sum of the files' counts of range key fragments. Its annotation type
-// is a *uint64. The count of range key sets may change once a table's stats are
+// rangeKeySetsAnnotator is a manifest.Annotator that annotates B-Tree nodes
+// with the sum of the files' counts of range key fragments. The count of range
+// key sets may change once a table's stats are loaded asynchronously, so its
+// values are marked as cacheable only if a file's stats have been loaded.
+var rangeKeySetsAnnotator = manifest.SumAnnotator(func(f *manifest.FileMetadata) (uint64, bool) {
+	return f.Stats.NumRangeKeySets, f.StatsValid()
+})
+
+// tombstonesAnnotator is a manifest.Annotator that annotates B-Tree nodes
+// with the sum of the files' counts of tombstones (DEL, SINGLEDEL and RANGEDEL
+// keys). The count of tombstones may change once a table's stats are loaded
+// asynchronously, so its values are marked as cacheable only if a file's stats
+// have been loaded.
+var tombstonesAnnotator = manifest.SumAnnotator(func(f *manifest.FileMetadata) (uint64, bool) {
+	return f.Stats.NumDeletions, f.StatsValid()
+})
+
+// valueBlocksSizeAnnotator is a manifest.Annotator that annotates B-Tree
+// nodes with the sum of the files' Properties.ValueBlocksSize. The value block
+// size may change once a table's stats are loaded asynchronously, so its
+// values are marked as cacheable only if a file's stats have been loaded.
+var valueBlockSizeAnnotator = manifest.SumAnnotator(func(f *fileMetadata) (uint64, bool) {
+	return f.Stats.ValueBlocksSize, f.StatsValid()
+})
+
+// compressionTypeAnnotator is a manifest.Annotator that annotates B-tree
+// nodes with the compression type of the file. Its annotation type is
+// compressionTypes. The compression type may change once a table's stats are
 // loaded asynchronously, so its values are marked as cacheable only if a file's
 // stats have been loaded.
-type rangeKeySetsAnnotator struct{}
-
-var _ manifest.Annotator = rangeKeySetsAnnotator{}
-
-func (a rangeKeySetsAnnotator) Zero(dst interface{}) interface{} {
-	if dst == nil {
-		return new(uint64)
-	}
-	v := dst.(*uint64)
-	*v = 0
-	return v
+var compressionTypeAnnotator = manifest.Annotator[compressionTypes]{
+	Aggregator: compressionTypeAggregator{},
 }
 
-func (a rangeKeySetsAnnotator) Accumulate(
-	f *fileMetadata, dst interface{},
-) (v interface{}, cacheOK bool) {
-	vptr := dst.(*uint64)
-	*vptr = *vptr + f.Stats.NumRangeKeySets
-	return vptr, f.StatsValid()
-}
-
-func (a rangeKeySetsAnnotator) Merge(src interface{}, dst interface{}) interface{} {
-	srcV := src.(*uint64)
-	dstV := dst.(*uint64)
-	*dstV = *dstV + *srcV
-	return dstV
-}
-
-// countRangeKeySetFragments counts the number of RANGEKEYSET keys across all
-// files of the LSM. It only counts keys in files for which table stats have
-// been loaded. It uses a b-tree annotator to cache intermediate values between
-// calculations when possible.
-func countRangeKeySetFragments(v *version) (count uint64) {
-	for l := 0; l < numLevels; l++ {
-		if v.RangeKeyLevels[l].Empty() {
-			continue
-		}
-		count += *v.RangeKeyLevels[l].Annotation(rangeKeySetsAnnotator{}).(*uint64)
-	}
-	return count
-}
-
-// tombstonesAnnotator implements manifest.Annotator, annotating B-Tree nodes
-// with the sum of the files' counts of tombstones (DEL, SINGLEDEL and RANGEDELk
-// eys). Its annotation type is a *uint64. The count of tombstones may change
-// once a table's stats are loaded asynchronously, so its values are marked as
-// cacheable only if a file's stats have been loaded.
-type tombstonesAnnotator struct{}
-
-var _ manifest.Annotator = tombstonesAnnotator{}
-
-func (a tombstonesAnnotator) Zero(dst interface{}) interface{} {
-	if dst == nil {
-		return new(uint64)
-	}
-	v := dst.(*uint64)
-	*v = 0
-	return v
-}
-
-func (a tombstonesAnnotator) Accumulate(
-	f *fileMetadata, dst interface{},
-) (v interface{}, cacheOK bool) {
-	vptr := dst.(*uint64)
-	*vptr = *vptr + f.Stats.NumDeletions
-	return vptr, f.StatsValid()
-}
-
-func (a tombstonesAnnotator) Merge(src interface{}, dst interface{}) interface{} {
-	srcV := src.(*uint64)
-	dstV := dst.(*uint64)
-	*dstV = *dstV + *srcV
-	return dstV
-}
-
-// countTombstones counts the number of tombstone (DEL, SINGLEDEL and RANGEDEL)
-// internal keys across all files of the LSM. It only counts keys in files for
-// which table stats have been loaded. It uses a b-tree annotator to cache
-// intermediate values between calculations when possible.
-func countTombstones(v *version) (count uint64) {
-	for l := 0; l < numLevels; l++ {
-		if v.Levels[l].Empty() {
-			continue
-		}
-		count += *v.Levels[l].Annotation(tombstonesAnnotator{}).(*uint64)
-	}
-	return count
-}
-
-// valueBlocksSizeAnnotator implements manifest.Annotator, annotating B-Tree
-// nodes with the sum of the files' Properties.ValueBlocksSize. Its annotation
-// type is a *uint64. The value block size may change once a table's stats are
-// loaded asynchronously, so its values are marked as cacheable only if a
-// file's stats have been loaded.
-type valueBlocksSizeAnnotator struct{}
-
-var _ manifest.Annotator = valueBlocksSizeAnnotator{}
-
-func (a valueBlocksSizeAnnotator) Zero(dst interface{}) interface{} {
-	if dst == nil {
-		return new(uint64)
-	}
-	v := dst.(*uint64)
-	*v = 0
-	return v
-}
-
-func (a valueBlocksSizeAnnotator) Accumulate(
-	f *fileMetadata, dst interface{},
-) (v interface{}, cacheOK bool) {
-	vptr := dst.(*uint64)
-	*vptr = *vptr + f.Stats.ValueBlocksSize
-	return vptr, f.StatsValid()
-}
-
-func (a valueBlocksSizeAnnotator) Merge(src interface{}, dst interface{}) interface{} {
-	srcV := src.(*uint64)
-	dstV := dst.(*uint64)
-	*dstV = *dstV + *srcV
-	return dstV
-}
-
-// valueBlocksSizeForLevel returns the Properties.ValueBlocksSize across all
-// files for a level of the LSM. It only includes the size for files for which
-// table stats have been loaded. It uses a b-tree annotator to cache
-// intermediate values between calculations when possible. It must not be
-// called concurrently.
-//
-// REQUIRES: 0 <= level <= numLevels.
-func valueBlocksSizeForLevel(v *version, level int) (count uint64) {
-	if v.Levels[level].Empty() {
-		return 0
-	}
-	return *v.Levels[level].Annotation(valueBlocksSizeAnnotator{}).(*uint64)
-}
-
-// compressionTypeAnnotator implements manifest.Annotator, annotating B-tree
-// nodes with the compression type of the file. Its annotation type is a
-// *compressionTypes. The compression type may change once a table's stats are
-// loaded asynchronously, so its values are marked as cacheable only if a file's
-// stats have been loaded.
-type compressionTypeAnnotator struct{}
+type compressionTypeAggregator struct{}
 
 type compressionTypes struct {
 	snappy, zstd, none, unknown uint64
 }
 
-var _ manifest.Annotator = compressionTypeAnnotator{}
-
-func (a compressionTypeAnnotator) Zero(dst interface{}) interface{} {
+func (a compressionTypeAggregator) Zero(dst *compressionTypes) *compressionTypes {
 	if dst == nil {
 		return new(compressionTypes)
 	}
-	v := dst.(*compressionTypes)
-	*v = compressionTypes{}
-	return v
+	*dst = compressionTypes{}
+	return dst
 }
 
-func (a compressionTypeAnnotator) Accumulate(
-	f *fileMetadata, dst interface{},
-) (v interface{}, cacheOK bool) {
-	vptr := dst.(*compressionTypes)
+func (a compressionTypeAggregator) Accumulate(
+	f *fileMetadata, dst *compressionTypes,
+) (v *compressionTypes, cacheOK bool) {
 	switch f.Stats.CompressionType {
 	case sstable.SnappyCompression:
-		vptr.snappy++
+		dst.snappy++
 	case sstable.ZstdCompression:
-		vptr.zstd++
+		dst.zstd++
 	case sstable.NoCompression:
-		vptr.none++
+		dst.none++
 	default:
-		vptr.unknown++
+		dst.unknown++
 	}
-	return vptr, f.StatsValid()
+	return dst, f.StatsValid()
 }
 
-func (a compressionTypeAnnotator) Merge(src interface{}, dst interface{}) interface{} {
-	srcV := src.(*compressionTypes)
-	dstV := dst.(*compressionTypes)
-	dstV.snappy = dstV.snappy + srcV.snappy
-	dstV.zstd = dstV.zstd + srcV.zstd
-	dstV.none = dstV.none + srcV.none
-	dstV.unknown = dstV.unknown + srcV.unknown
-	return dstV
-}
-
-// compressionTypesForLevel returns the count of sstables by compression type
-// used for a level in the LSM. Sstables with compression type snappy or zstd
-// are returned, while others are ignored.
-func compressionTypesForLevel(v *version, level int) (unknown, snappy, none, zstd uint64) {
-	if v.Levels[level].Empty() {
-		return
-	}
-	compression := v.Levels[level].Annotation(compressionTypeAnnotator{}).(*compressionTypes)
-	if compression == nil {
-		return
-	}
-	return compression.unknown, compression.snappy, compression.none, compression.zstd
+func (a compressionTypeAggregator) Merge(
+	src *compressionTypes, dst *compressionTypes,
+) *compressionTypes {
+	dst.snappy += src.snappy
+	dst.zstd += src.zstd
+	dst.none += src.none
+	dst.unknown += src.unknown
+	return dst
 }


### PR DESCRIPTION
Refactors `manifest.Annotator` to use generics and a simplified API. This eliminates the need to perform pointer manipulation and unsafe typecasting when defining a new Annotator. The goal of this change is to improve the `Annotator` interface while not changing any existing behavior.

`BenchmarkNumFilesAnnotator` shows roughly the same performance as master when compared
to the equivalent implementation of `orderStatistic`:
```
pkg: github.com/cockroachdb/pebble/internal/manifest
                     │     old     │             new              │
                     │   sec/op    │   sec/op     vs base         │
NumFilesAnnotator-10   1.635µ ± 1%   1.572µ ± 7%  ~ (p=0.065 n=6)

                     │    old     │              new              │
                     │    B/op    │    B/op     vs base           │
NumFilesAnnotator-10   536.0 ± 0%   536.0 ± 0%  ~ (p=1.000 n=6) ¹
¹ all samples are equal

                     │    old     │              new              │
                     │ allocs/op  │ allocs/op   vs base           │
NumFilesAnnotator-10   7.000 ± 0%   7.000 ± 0%  ~ (p=1.000 n=6) ¹
¹ all samples are equal
```