### PR TITLE
vfs: fix capping of latency in errorfs

### DIFF
--- a/vfs/errorfs/latency.go
+++ b/vfs/errorfs/latency.go
@@ -27,6 +27,7 @@ func RandomLatency(pred Predicate, mean time.Duration, seed int64, limit time.Du
 	rl := &randomLatency{
 		predicate: pred,
 		mean:      mean,
+		limit:     limit,
 	}
 	rl.keyedPrng.init(seed)
 	return rl


### PR DESCRIPTION
Previously, we didn't obey the limit that was passed into errorfs.RandomLatency due to a bug. This change fixes it.

Fixes #3748.
Fixes #3757.