### PR TITLE
go.mod: require Go 1.22+

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,4 +48,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.21
+go 1.22


### PR DESCRIPTION
Require go 1.22 or later.