### PR TITLE
crl-release-24.1: sstable: improve slow block read log

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1437,9 +1437,16 @@ func TestTracing(t *testing.T) {
 	_, closer, err := d.Get([]byte("hello"))
 	require.NoError(t, err)
 	closer.Close()
-	readerInitTraceString := "reading 53 bytes took 5ms\nreading 37 bytes took 5ms\nreading 419 bytes took 5ms\n"
-	iterTraceString := "reading 27 bytes took 5ms\nreading 29 bytes took 5ms\n"
-	require.Equal(t, readerInitTraceString+iterTraceString, tracer.buf.String())
+	readerInitRegexp := `reading footer of 53 bytes took 5ms
+reading block of 37 bytes took 5ms \([^)]*\)
+reading block of 419 bytes took 5ms \([^)]*\)
+`
+	iterTraceRegexp :=
+		`reading block of 27 bytes took 5ms \([^)]*\)
+reading block of 29 bytes took 5ms \([^)]*\)
+`
+
+	require.Regexp(t, "^"+readerInitRegexp+iterTraceRegexp+"$", tracer.buf.String())
 
 	// Get again, but since it currently uses context.Background(), no trace
 	// output is produced.
@@ -1455,14 +1462,14 @@ func TestTracing(t *testing.T) {
 	iter, _ := d.NewIterWithContext(ctx, nil)
 	iter.SeekGE([]byte("hello"))
 	iter.Close()
-	require.Equal(t, iterTraceString, tracer.buf.String())
+	require.Regexp(t, iterTraceRegexp, tracer.buf.String())
 
 	tracer.buf.Reset()
 	snap := d.NewSnapshot()
 	iter, _ = snap.NewIterWithContext(ctx, nil)
 	iter.SeekGE([]byte("hello"))
 	iter.Close()
-	require.Equal(t, iterTraceString, tracer.buf.String())
+	require.Regexp(t, iterTraceRegexp, tracer.buf.String())
 	snap.Close()
 
 	tracer.buf.Reset()
@@ -1471,7 +1478,7 @@ func TestTracing(t *testing.T) {
 	require.NoError(t, err)
 	iter.SeekGE([]byte("hello"))
 	iter.Close()
-	require.Equal(t, iterTraceString, tracer.buf.String())
+	require.Regexp(t, iterTraceRegexp, tracer.buf.String())
 	b.Close()
 }
 

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"runtime"
 	"slices"
 	"time"
 
@@ -661,8 +663,13 @@ func (r *Reader) readBlock(
 	// Call IsTracingEnabled to avoid the allocations of boxing integers into an
 	// interface{}, unless necessary.
 	if readDuration >= slowReadTracingThreshold && r.opts.LoggerAndTracer.IsTracingEnabled(ctx) {
-		r.opts.LoggerAndTracer.Eventf(ctx, "reading %d bytes took %s",
-			int(bh.Length+blockTrailerLen), readDuration.String())
+		_, file1, line1, _ := runtime.Caller(1)
+		_, file2, line2, _ := runtime.Caller(2)
+		r.opts.LoggerAndTracer.Eventf(ctx, "reading block of %d bytes took %s (fileNum=%s; %s/%s:%d -> %s/%s:%d)",
+			int(bh.Length+blockTrailerLen), readDuration.String(),
+			r.fileNum,
+			filepath.Base(filepath.Dir(file2)), filepath.Base(file2), line2,
+			filepath.Base(filepath.Dir(file1)), filepath.Base(file1), line1)
 	}
 	if stats != nil {
 		stats.BlockBytes += bh.Length

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -349,7 +349,7 @@ func readFooter(f objstorage.Readable, logger base.LoggerAndTracer) (footer, err
 	// Call IsTracingEnabled to avoid the allocations of boxing integers into an
 	// interface{}, unless necessary.
 	if readDuration >= slowReadTracingThreshold && logger.IsTracingEnabled(context.TODO()) {
-		logger.Eventf(context.TODO(), "reading %d bytes took %s",
+		logger.Eventf(context.TODO(), "reading footer of %d bytes took %s",
 			len(buf), readDuration.String())
 	}
 


### PR DESCRIPTION
Add the two callers to identify the code path (and implicitly what
kind of block it is).