### PR TITLE
crl-release-23.2: sstable: improve slow block read log

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -10,6 +10,8 @@ import (
 	"encoding/binary"
 	"io"
 	"os"
+	"path/filepath"
+	"runtime"
 	"sort"
 	"time"
 
@@ -570,8 +572,13 @@ func (r *Reader) readBlock(
 	// Call IsTracingEnabled to avoid the allocations of boxing integers into an
 	// interface{}, unless necessary.
 	if readDuration >= slowReadTracingThreshold && r.opts.LoggerAndTracer.IsTracingEnabled(ctx) {
-		r.opts.LoggerAndTracer.Eventf(ctx, "reading %d bytes took %s",
-			int(bh.Length+blockTrailerLen), readDuration.String())
+		_, file1, line1, _ := runtime.Caller(1)
+		_, file2, line2, _ := runtime.Caller(2)
+		r.opts.LoggerAndTracer.Eventf(ctx, "reading block of %d bytes took %s (fileNum=%s; %s/%s:%d -> %s/%s:%d)",
+			int(bh.Length+blockTrailerLen), readDuration.String(),
+			r.fileNum,
+			filepath.Base(filepath.Dir(file2)), filepath.Base(file2), line2,
+			filepath.Base(filepath.Dir(file1)), filepath.Base(file1), line1)
 	}
 	if stats != nil {
 		stats.BlockBytes += bh.Length

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -349,7 +349,7 @@ func readFooter(f objstorage.Readable, logger base.LoggerAndTracer) (footer, err
 	// Call IsTracingEnabled to avoid the allocations of boxing integers into an
 	// interface{}, unless necessary.
 	if readDuration >= slowReadTracingThreshold && logger.IsTracingEnabled(context.TODO()) {
-		logger.Eventf(context.TODO(), "reading %d bytes took %s",
+		logger.Eventf(context.TODO(), "reading footer of %d bytes took %s",
 			len(buf), readDuration.String())
 	}
 


### PR DESCRIPTION
Add the two callers to identify the code path (and implicitly what
kind of block it is).