### PR TITLE
compact: remove unused parameter in pickAutoLPositive

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1304,7 +1304,7 @@ func (p *compactionPickerByScore) pickAuto(env compactionEnv) (pc *pickedCompact
 			continue
 		}
 
-		pc := pickAutoLPositive(env, p.opts, p.vers, *info, p.baseLevel, p.levelMaxBytes)
+		pc := pickAutoLPositive(env, p.opts, p.vers, *info, p.baseLevel)
 		// Fail-safe to protect against compacting the same sstable concurrently.
 		if pc != nil && !inputRangeAlreadyCompacting(env, pc) {
 			p.addScoresToPickedCompactionMetrics(pc, scores)
@@ -1584,12 +1584,7 @@ func (p *compactionPickerByScore) pickRewriteCompaction(env compactionEnv) (pc *
 // file in a positive-numbered level. This function must not be used for
 // L0.
 func pickAutoLPositive(
-	env compactionEnv,
-	opts *Options,
-	vers *version,
-	cInfo candidateLevelInfo,
-	baseLevel int,
-	levelMaxBytes [numLevels]int64,
+	env compactionEnv, opts *Options, vers *version, cInfo candidateLevelInfo, baseLevel int,
 ) (pc *pickedCompaction) {
 	if cInfo.level == 0 {
 		panic("pebble: pickAutoLPositive called for L0")

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -48,12 +48,11 @@ func newVersion(opts *Options, files [numLevels][]*fileMetadata) *version {
 }
 
 type compactionPickerForTesting struct {
-	score         float64
-	level         int
-	baseLevel     int
-	opts          *Options
-	vers          *manifest.Version
-	maxLevelBytes [7]int64
+	score     float64
+	level     int
+	baseLevel int
+	opts      *Options
+	vers      *manifest.Version
 }
 
 var _ compactionPicker = &compactionPickerForTesting{}
@@ -90,7 +89,7 @@ func (p *compactionPickerForTesting) pickAuto(env compactionEnv) (pc *pickedComp
 	if cInfo.level == 0 {
 		return pickL0(env, p.opts, p.vers, p.baseLevel)
 	}
-	return pickAutoLPositive(env, p.opts, p.vers, cInfo, p.baseLevel, p.maxLevelBytes)
+	return pickAutoLPositive(env, p.opts, p.vers, cInfo, p.baseLevel)
 }
 
 func (p *compactionPickerForTesting) pickElisionOnlyCompaction(


### PR DESCRIPTION
Removes the unused `levelMaxBytes` parameter from `pickAutoLPositive`.