### PR TITLE
crl-release-23.1: ci: bump macOS version to 12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,7 @@ jobs:
 
   darwin:
     name: go-macos
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
Backport of #2409 to 23.1.

---

Use the latest available runner image for macOS.