### PR TITLE
db: handle truncation of shared files with no points

### DIFF
--- a/scan_internal.go
+++ b/scan_internal.go
@@ -559,7 +559,10 @@ func (d *DB) truncateSharedFile(
 	if needsLowerTruncate {
 		sst.SmallestPointKey.UserKey = sst.SmallestPointKey.UserKey[:0]
 		sst.SmallestPointKey.Trailer = 0
-		kv := iter.SeekGE(lower, base.SeekGEFlagsNone)
+		var kv *base.InternalKV
+		if iter != nil {
+			kv = iter.SeekGE(lower, base.SeekGEFlagsNone)
+		}
 		foundPointKey := kv != nil
 		if kv != nil {
 			sst.SmallestPointKey.CopyFrom(kv.K)
@@ -598,7 +601,10 @@ func (d *DB) truncateSharedFile(
 	if needsUpperTruncate {
 		sst.LargestPointKey.UserKey = sst.LargestPointKey.UserKey[:0]
 		sst.LargestPointKey.Trailer = 0
-		kv := iter.SeekLT(upper, base.SeekLTFlagsNone)
+		var kv *base.InternalKV
+		if iter != nil {
+			kv = iter.SeekLT(upper, base.SeekLTFlagsNone)
+		}
 		foundPointKey := kv != nil
 		if kv != nil {
 			sst.LargestPointKey.CopyFrom(kv.K)

--- a/testdata/ingest_shared
+++ b/testdata/ingest_shared
@@ -1307,3 +1307,53 @@ next
 ----
 .
 .
+
+# Regression test for #3761. Replicate an sstable
+# which does not have point keys.
+
+reset
+----
+
+switch 2
+----
+ok
+
+batch
+range-key-set a c @4 value
+----
+
+flush
+----
+
+compact a-z
+----
+ok
+
+lsm
+----
+L6:
+  000005:[a#10,RANGEKEYSET-c#inf,RANGEKEYSET]
+
+switch 1
+----
+ok
+
+replicate 2 1 a z
+----
+replicated 1 shared SSTs
+
+lsm
+----
+L6:
+  000005(000005):[a#11,RANGEKEYSET-c#inf,RANGEKEYDEL]
+
+iter
+first
+next
+next
+next
+----
+a: (., [a-c) @4=value UPDATED)
+.
+.
+.


### PR DESCRIPTION
Previously, if we shared a truncated file with no points,
we would try to seek on a nil point iterator, which has undefined
behaviour. This change addresses it in truncateSharedFiles, to not
use a nil point iterator.


Fixes #3761.