### PR TITLE
colblk: impose consistent interfaces

### DIFF
--- a/sstable/colblk/bitmap.go
+++ b/sstable/colblk/bitmap.go
@@ -30,6 +30,9 @@ type Bitmap struct {
 	bitCount int
 }
 
+// Assert that Bitmap implements Array[bool].
+var _ Array[bool] = Bitmap{}
+
 // DecodeBitmap decodes the structure of a Bitmap and returns a Bitmap that
 // reads from b supporting bitCount logical bits. No bounds checking is
 // performed, so the caller must guarantee the bitmap is appropriately sized and
@@ -50,8 +53,8 @@ func DecodeBitmap(b []byte, off uint32, bitCount int) (bitmap Bitmap, endOffset 
 // Assert that DecodeBitmap implements DecodeFunc.
 var _ DecodeFunc[Bitmap] = DecodeBitmap
 
-// Get returns true if the bit at position i is set and false otherwise.
-func (b Bitmap) Get(i int) bool {
+// At returns true if the bit at position i is set and false otherwise.
+func (b Bitmap) At(i int) bool {
 	return (b.data.At(i>>6 /* i/64 */) & (1 << uint(i%64))) != 0
 }
 

--- a/sstable/colblk/bitmap.go
+++ b/sstable/colblk/bitmap.go
@@ -30,21 +30,25 @@ type Bitmap struct {
 	bitCount int
 }
 
-// MakeBitmap returns a Bitmap that reads from b supporting bitCount logical
-// bits. No bounds checking is performed, so the caller must guarantee the
-// bitmap is appropriately sized and the provided bitCount correctly identifies
-// the number of bits in the bitmap.
-func MakeBitmap(b []byte, off uint32, bitCount int) Bitmap {
-	if len(b) < int(off)+bitmapRequiredSize(bitCount) {
+// DecodeBitmap decodes the structure of a Bitmap and returns a Bitmap that
+// reads from b supporting bitCount logical bits. No bounds checking is
+// performed, so the caller must guarantee the bitmap is appropriately sized and
+// the provided bitCount correctly identifies the number of bits in the bitmap.
+func DecodeBitmap(b []byte, off uint32, bitCount int) (bitmap Bitmap, endOffset uint32) {
+	sz := bitmapRequiredSize(bitCount)
+	off = align(off, align64)
+	if len(b) < int(off)+sz {
 		panic(errors.AssertionFailedf("bitmap of %d bits requires at least %d bytes; provided with %d-byte slice",
 			bitCount, bitmapRequiredSize(bitCount), len(b[off:])))
 	}
-	off = align(off, align64)
 	return Bitmap{
 		data:     makeUnsafeRawSlice[uint64](unsafe.Pointer(&b[off])),
 		bitCount: bitCount,
-	}
+	}, off + uint32(sz)
 }
+
+// Assert that DecodeBitmap implements DecodeFunc.
+var _ DecodeFunc[Bitmap] = DecodeBitmap
 
 // Get returns true if the bit at position i is set and false otherwise.
 func (b Bitmap) Get(i int) bool {

--- a/sstable/colblk/bitmap_test.go
+++ b/sstable/colblk/bitmap_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/binfmt"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
 )
 
@@ -43,7 +44,7 @@ func TestBitmapFixed(t *testing.T) {
 			}
 
 			_ = builder.Finish(0, n, 0, data)
-			bitmap = MakeBitmap(data, 0, n)
+			bitmap, _ = DecodeBitmap(data, 0, n)
 			dumpBitmap(&buf, bitmap)
 			fmt.Fprint(&buf, "\nBinary representation:\n")
 			f := binfmt.New(data)
@@ -100,7 +101,8 @@ func TestBitmapRandom(t *testing.T) {
 		}
 		data := make([]byte, builder.Size(size, 0))
 		_ = builder.Finish(0, size, 0, data)
-		bitmap := MakeBitmap(data, 0, size)
+		bitmap, endOffset := DecodeBitmap(data, 0, size)
+		require.Equal(t, uint32(len(data)), endOffset)
 		for i := 0; i < size; i++ {
 			if got := bitmap.Get(i); got != v[i] {
 				t.Fatalf("b.Get(%d) = %t; want %t", i, got, v[i])

--- a/sstable/colblk/bitmap_test.go
+++ b/sstable/colblk/bitmap_test.go
@@ -76,7 +76,7 @@ func dumpBitmap(w io.Writer, b Bitmap) {
 		if i > 0 && i%64 == 0 {
 			w.Write([]byte{'\n'})
 		}
-		if b.Get(i) {
+		if b.At(i) {
 			w.Write([]byte{'1'})
 		} else {
 			w.Write([]byte{'0'})
@@ -104,31 +104,31 @@ func TestBitmapRandom(t *testing.T) {
 		bitmap, endOffset := DecodeBitmap(data, 0, size)
 		require.Equal(t, uint32(len(data)), endOffset)
 		for i := 0; i < size; i++ {
-			if got := bitmap.Get(i); got != v[i] {
+			if got := bitmap.At(i); got != v[i] {
 				t.Fatalf("b.Get(%d) = %t; want %t", i, got, v[i])
 			}
 		}
 		for i := 0; i < size; i++ {
 			succ := bitmap.Successor(i)
 			// Ensure that Successor always returns the index of a set bit.
-			if succ != size && !bitmap.Get(succ) {
+			if succ != size && !bitmap.At(succ) {
 				t.Fatalf("b.Successor(%d) = %d; bit at index %d is not set", i, succ, succ)
 			}
 			pred := bitmap.Predecessor(i)
 			// Ensure that Predecessor always returns the index of a set bit.
-			if pred >= 0 && !bitmap.Get(pred) {
+			if pred >= 0 && !bitmap.At(pred) {
 				t.Fatalf("b.Predecessor(%d) = %d; bit at index %d is not set", i, pred, pred)
 			}
 
 			// Ensure there are no set bits between i and succ.
 			for j := i; j < succ; j++ {
-				if bitmap.Get(j) {
+				if bitmap.At(j) {
 					t.Fatalf("b.Successor(%d) = %d; bit at index %d is set", i, succ, j)
 				}
 			}
 			// Ensure there are no set bits between pred and i.
 			for j := pred + 1; j < i; j++ {
-				if bitmap.Get(j) {
+				if bitmap.At(j) {
 					t.Fatalf("b.Predecessor(%d) = %d; bit at index %d is set", i, pred, j)
 				}
 			}

--- a/sstable/colblk/block_test.go
+++ b/sstable/colblk/block_test.go
@@ -305,34 +305,19 @@ func testRandomBlock(t *testing.T, rng *rand.Rand, rows int, schema []ColumnSpec
 			var got interface{}
 			switch spec.DataType {
 			case DataTypeBool:
-				b := r.Bitmap(col)
-				vals := make([]bool, r.header.Rows)
-				for i := range vals {
-					vals[i] = b.At(i)
-				}
-				got = vals
+				got = Clone(r.Bitmap(col), rows)
 			case DataTypeUint8:
-				got = r.Uint8s(col).Clone(rows)
+				got = Clone(r.Uint8s(col), rows)
 			case DataTypeUint16:
-				got = r.Uint16s(col).Clone(rows)
+				got = Clone(r.Uint16s(col), rows)
 			case DataTypeUint32:
-				got = r.Uint32s(col).Clone(rows)
+				got = Clone(r.Uint32s(col), rows)
 			case DataTypeUint64:
-				got = r.Uint64s(col).Clone(rows)
+				got = Clone(r.Uint64s(col), rows)
 			case DataTypeBytes:
-				vals2 := make([][]byte, rows)
-				vals := r.RawBytes(col)
-				for i := range vals2 {
-					vals2[i] = vals.At(i)
-				}
-				got = vals2
+				got = Clone(r.RawBytes(col), rows)
 			case DataTypePrefixBytes:
-				vals2 := make([][]byte, rows)
-				vals := r.PrefixBytes(col)
-				for i := range vals2 {
-					vals2[i] = slices.Concat(vals.SharedPrefix(), vals.RowBundlePrefix(i), vals.RowSuffix(i))
-				}
-				got = vals2
+				got = Clone(r.PrefixBytes(col), rows)
 			}
 			if !reflect.DeepEqual(data[col], got) {
 				t.Fatalf("%d: %s: expected\n%+v\ngot\n%+v\n% x",

--- a/sstable/colblk/block_test.go
+++ b/sstable/colblk/block_test.go
@@ -303,7 +303,7 @@ func testRandomBlock(t *testing.T, rng *rand.Rand, rows int, schema []DataType) 
 				b := r.Bitmap(col)
 				vals := make([]bool, r.header.Rows)
 				for i := range vals {
-					vals[i] = b.Get(i)
+					vals[i] = b.At(i)
 				}
 				got = vals
 			case DataTypeUint8:

--- a/sstable/colblk/column.go
+++ b/sstable/colblk/column.go
@@ -114,3 +114,9 @@ type Encoder interface {
 // The rows argument must be number of logical rows encoded within the data
 // structure.
 type DecodeFunc[T any] func(buf []byte, offset uint32, rows int) (decoded T, nextOffset uint32)
+
+// An Array provides indexed access to an array of values.
+type Array[V any] interface {
+	// At returns the i'th value in the array.
+	At(i int) V
+}

--- a/sstable/colblk/column.go
+++ b/sstable/colblk/column.go
@@ -120,3 +120,12 @@ type Array[V any] interface {
 	// At returns the i'th value in the array.
 	At(i int) V
 }
+
+// Clone clones the first n elements of the array a.
+func Clone[V any](a Array[V], n int) []V {
+	c := make([]V, n)
+	for i := 0; i < n; i++ {
+		c[i] = a.At(i)
+	}
+	return c
+}

--- a/sstable/colblk/column.go
+++ b/sstable/colblk/column.go
@@ -108,3 +108,9 @@ type Encoder interface {
 	// state to the provided writer.
 	WriteDebug(w io.Writer, rows int)
 }
+
+// A DecodeFunc decodes a data structure from a byte slice, returning an
+// accessor for the data and the offset of the first byte after the structure.
+// The rows argument must be number of logical rows encoded within the data
+// structure.
+type DecodeFunc[T any] func(buf []byte, offset uint32, rows int) (decoded T, nextOffset uint32)

--- a/sstable/colblk/prefix_bytes.go
+++ b/sstable/colblk/prefix_bytes.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"math/bits"
+	"slices"
 	"strings"
 	"unsafe"
 
@@ -171,6 +172,9 @@ type PrefixBytes struct {
 	rawBytes        RawBytes
 }
 
+// Assert that PrefixBytes implements Array[[]byte].
+var _ Array[[]byte] = PrefixBytes{}
+
 // DecodePrefixBytes decodes the structure of a PrefixBytes, constructing an
 // accessor for an array of lexicographically sorted byte slices constructed by
 // PrefixBytesBuilder. Count must be the number of logical slices within the
@@ -204,6 +208,13 @@ func DecodePrefixBytes(
 
 // Assert that DecodePrefixBytes implements DecodeFunc.
 var _ DecodeFunc[PrefixBytes] = DecodePrefixBytes
+
+// At returns the i'th []byte slice in the PrefixBytes. At must allocate, so
+// callers should prefer accessing a slice's constituent components through
+// SharedPrefix, BundlePrefix and RowSuffix.
+func (b PrefixBytes) At(i int) []byte {
+	return slices.Concat(b.SharedPrefix(), b.RowBundlePrefix(i), b.RowSuffix(i))
+}
 
 // SharedPrefix return a []byte of the shared prefix that was extracted from
 // all of the values in the Bytes vector. The returned slice should not be

--- a/sstable/colblk/prefix_bytes_test.go
+++ b/sstable/colblk/prefix_bytes_test.go
@@ -69,7 +69,9 @@ func TestPrefixBytes(t *testing.T) {
 
 			f := binfmt.New(buf)
 			prefixBytesToBinFormatter(f, rows, nil)
-			pb = MakePrefixBytes(rows, buf, 0)
+			var endOffset uint32
+			pb, endOffset = DecodePrefixBytes(buf, 0, rows)
+			require.Equal(t, offset, endOffset)
 			require.Equal(t, rows, pb.Rows())
 			return f.String()
 		case "get":
@@ -169,7 +171,8 @@ func TestPrefixBytesRandomized(t *testing.T) {
 		t.Logf("Size: %d; NumUserKeys: %d (%d); Aggregate pre-compressed string data: %d",
 			size, n, len(userKeys), totalSize)
 
-		pb := MakePrefixBytes(n, buf, 0)
+		pb, endOffset := DecodePrefixBytes(buf, 0, n)
+		require.Equal(t, offset, endOffset)
 		f := binfmt.New(buf)
 		prefixBytesToBinFormatter(f, n, nil)
 		t.Logf("PrefixBytes:\n%s", f.String())
@@ -268,7 +271,7 @@ func BenchmarkPrefixBytes(b *testing.B) {
 		b.Run("iteration", func(b *testing.B) {
 			n := len(userKeys)
 			buf = build(n)
-			pb := MakePrefixBytes(n, buf, 0)
+			pb, _ := DecodePrefixBytes(buf, 0, n)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				k := append([]byte(nil), pb.SharedPrefix()...)

--- a/sstable/colblk/raw_bytes.go
+++ b/sstable/colblk/raw_bytes.go
@@ -49,6 +49,9 @@ type RawBytes struct {
 	data    unsafe.Pointer
 }
 
+// Assert that RawBytes implements Array[[]byte].
+var _ Array[[]byte] = RawBytes{}
+
 // DecodeRawBytes decodes the structure of a RawBytes, constructing an accessor
 // for an array of byte slices constructed by RawBytesBuilder. Count must be the
 // number of byte slices within the array.

--- a/sstable/colblk/raw_bytes.go
+++ b/sstable/colblk/raw_bytes.go
@@ -49,20 +49,24 @@ type RawBytes struct {
 	data    unsafe.Pointer
 }
 
-// MakeRawBytes constructs an accessor for an array of byte slices constructed
-// by RawBytesBuilder. Count must be the number of byte slices within the array.
-func MakeRawBytes(count int, b []byte, offset uint32) RawBytes {
+// DecodeRawBytes decodes the structure of a RawBytes, constructing an accessor
+// for an array of byte slices constructed by RawBytesBuilder. Count must be the
+// number of byte slices within the array.
+func DecodeRawBytes(b []byte, offset uint32, count int) (rawBytes RawBytes, endOffset uint32) {
 	if count == 0 {
-		return RawBytes{}
+		return RawBytes{}, 0
 	}
-	dataOff, offsets := readUnsafeIntegerSlice[uint32](count+1 /* +1 offset */, b, offset)
+	offsets, dataOff := DecodeUnsafeIntegerSlice[uint32](b, offset, count+1 /* +1 offset */)
 	return RawBytes{
 		slices:  count,
 		offsets: offsets,
 		start:   unsafe.Pointer(&b[offset]),
 		data:    unsafe.Pointer(&b[dataOff]),
-	}
+	}, dataOff + offsets.At(count)
 }
+
+// Assert that DecodeRawBytes implements DecodeFunc.
+var _ DecodeFunc[RawBytes] = DecodeRawBytes
 
 func defaultSliceFormatter(x []byte) string {
 	return string(x)
@@ -73,7 +77,7 @@ func rawBytesToBinFormatter(f *binfmt.Formatter, count int, sliceFormatter func(
 		sliceFormatter = defaultSliceFormatter
 	}
 
-	rb := MakeRawBytes(count, f.Data(), uint32(f.Offset()))
+	rb, _ := DecodeRawBytes(f.Data(), uint32(f.Offset()), count)
 	dataOffset := uint64(f.Offset()) + uint64(uintptr(rb.data)-uintptr(rb.start))
 	f.CommentLine("rawbytes")
 	f.CommentLine("offsets table")

--- a/sstable/colblk/raw_bytes_test.go
+++ b/sstable/colblk/raw_bytes_test.go
@@ -51,7 +51,9 @@ func TestRawBytes(t *testing.T) {
 				f.HexBytesln(startOffset, "start offset")
 			}
 			rawBytesToBinFormatter(f, count, nil)
-			rawBytes = MakeRawBytes(count, buf[startOffset:], 0)
+			var decodedEndOffset uint32
+			rawBytes, decodedEndOffset = DecodeRawBytes(buf[startOffset:], 0, count)
+			require.Equal(t, endOffset, decodedEndOffset+uint32(startOffset))
 			return f.String()
 		case "at":
 			var indices []int
@@ -126,7 +128,7 @@ func BenchmarkRawBytes(b *testing.B) {
 			b.Run(fmt.Sprintf("sliceLen=%d", sz), func(b *testing.B) {
 				slices := generateRandomSlices(sz, 32<<10 /* 32 KiB */)
 				data := buildRawBytes(slices)
-				rb := MakeRawBytes(len(slices), data, 0)
+				rb, _ := DecodeRawBytes(data, 0, len(slices))
 				b.ResetTimer()
 				b.SetBytes(32 << 10)
 				for i := 0; i < b.N; i++ {

--- a/sstable/colblk/unsafe_slice.go
+++ b/sstable/colblk/unsafe_slice.go
@@ -67,9 +67,11 @@ type UnsafeIntegerSlice[T constraints.Integer] struct {
 	deltaWidth uintptr
 }
 
-func readUnsafeIntegerSlice[T constraints.Integer](
-	rows int, b []byte, off uint32,
-) (endOffset uint32, slice UnsafeIntegerSlice[T]) {
+// DecodeUnsafeIntegerSlice decodes the structure of a slice of uints from a
+// byte slice.
+func DecodeUnsafeIntegerSlice[T constraints.Integer](
+	b []byte, off uint32, rows int,
+) (slice UnsafeIntegerSlice[T], endOffset uint32) {
 	delta := UintDeltaEncoding(b[off])
 	off++
 	switch delta {
@@ -91,8 +93,11 @@ func readUnsafeIntegerSlice[T constraints.Integer](
 	default:
 		panic("unreachable")
 	}
-	return off, slice
+	return slice, off
 }
+
+// Assert that DecodeUnsafeIntegerSlice implements DecodeFunc.
+var _ DecodeFunc[UnsafeUint8s] = DecodeUnsafeIntegerSlice[uint8]
 
 func makeUnsafeIntegerSlice[T constraints.Integer](
 	base T, deltaPtr unsafe.Pointer, deltaWidth int,

--- a/sstable/colblk/unsafe_slice.go
+++ b/sstable/colblk/unsafe_slice.go
@@ -67,6 +67,9 @@ type UnsafeIntegerSlice[T constraints.Integer] struct {
 	deltaWidth uintptr
 }
 
+// Assert that UnsafeIntegerSlice implements Array.
+var _ Array[uint8] = UnsafeIntegerSlice[uint8]{}
+
 // DecodeUnsafeIntegerSlice decodes the structure of a slice of uints from a
 // byte slice.
 func DecodeUnsafeIntegerSlice[T constraints.Integer](
@@ -108,9 +111,6 @@ func makeUnsafeIntegerSlice[T constraints.Integer](
 		deltaWidth: uintptr(deltaWidth),
 	}
 }
-
-// TODO(jackson): Remove when more of the read path is hooked up.
-var _ = makeUnsafeIntegerSlice[uint64]
 
 // At returns the `i`-th element of the slice.
 func (s UnsafeIntegerSlice[T]) At(i int) T {

--- a/sstable/colblk/unsafe_slice.go
+++ b/sstable/colblk/unsafe_slice.go
@@ -134,12 +134,3 @@ func (s UnsafeIntegerSlice[T]) At(i int) T {
 		panic("unreachable")
 	}
 }
-
-// Clone allocates a new slice and copies the first `rows` elements.
-func (s UnsafeIntegerSlice[T]) Clone(rows int) []T {
-	result := make([]T, rows)
-	for i := 0; i < rows; i++ {
-		result[i] = s.At(i)
-	}
-	return result
-}


### PR DESCRIPTION
**colblk: make decoder function signatures consistent**

Unify the various functions that decode data structures from a columnar block
so that they all have consistent function signatures, and define a generic
DecodeFunc that captures this consistency. In future work, the DecodeFunc will
be used to aid in composing decoders.

**colblk: implement a common interface across column data accessors**

Introduce a new generic `Array[T]` type that allows indexed access to data and
implement it across the various accessors.

**colblk: randomize BundleSizes in block writer randomized test**

Randomize the BundleSize used for PrefixBytes columns in the
TestBlockWriterRandomized test.

**colblk: add facility for cloning an Array to a []T**

Add a `Clone[T](Array[T], int)` func that clones an array of n elements into a
heap-allocated Go slice. It's primarily intended for use in tests.