### PR TITLE
sstable: support synthetic suffix in range keys

### DIFF
--- a/internal/keyspan/span.go
+++ b/internal/keyspan/span.go
@@ -26,6 +26,13 @@ import (
 // Currently the only supported key kinds are:
 //
 //	RANGEDEL, RANGEKEYSET, RANGEKEYUNSET, RANGEKEYDEL.
+//
+// Spans either have only RANGEDEL keys (range del spans), or a mix of
+// RANGEKESET/RANGEKEYUNSET/RANGEKEYDEL keys (range key spans).
+//
+// Note that at the user level, range key span start and end keys never have
+// suffixes. Internally, range key spans get fragmented along sstable
+// boundaries; however, this is transparent to the user.
 type Span struct {
 	// Start and End encode the user key range of all the contained items, with
 	// an inclusive start key and exclusive end key. Both Start and End must be

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -341,8 +341,7 @@ func (m *FileMetadata) IterTransforms() sstable.IterTransforms {
 func (m *FileMetadata) FragmentIterTransforms() sstable.FragmentIterTransforms {
 	return sstable.FragmentIterTransforms{
 		SyntheticSeqNum: m.SyntheticSeqNum(),
-		// TODO(radu): support this
-		//SyntheticSuffix: m.SyntheticSuffix,
+		SyntheticSuffix: m.SyntheticSuffix,
 		SyntheticPrefix: m.SyntheticPrefix,
 	}
 }

--- a/metamorphic/build.go
+++ b/metamorphic/build.go
@@ -51,7 +51,7 @@ func writeSSTForIngestion(
 		}
 	}()
 
-	outputKey := func(key []byte) []byte {
+	outputKey := func(key []byte, syntheticSuffix sstable.SyntheticSuffix) []byte {
 		if !syntheticPrefix.IsSet() && !syntheticSuffix.IsSet() {
 			return slices.Clone(key)
 		}
@@ -83,7 +83,7 @@ func writeSSTForIngestion(
 
 		k := *kv
 		k.K.SetSeqNum(base.SeqNumZero)
-		k.K.UserKey = outputKey(k.K.UserKey)
+		k.K.UserKey = outputKey(k.K.UserKey, syntheticSuffix)
 		value := kv.V
 		// It's possible that we wrote the key on a batch from a db that supported
 		// DeleteSized, but will be ingesting into a db that does not. Detect this
@@ -107,7 +107,10 @@ func writeSSTForIngestion(
 	if rangeDelIter != nil {
 		span, err := rangeDelIter.First()
 		for ; span != nil; span, err = rangeDelIter.Next() {
-			if err := w.DeleteRange(outputKey(span.Start), outputKey(span.End)); err != nil {
+			if syntheticSuffix.IsSet() {
+				panic("synthetic suffix with RangeDel")
+			}
+			if err := w.DeleteRange(outputKey(span.Start, nil), outputKey(span.End, nil)); err != nil {
 				return nil, err
 			}
 		}
@@ -131,11 +134,23 @@ func writeSSTForIngestion(
 			// same sequence number is nonsensical, so we "coalesce" or collapse
 			// the keys.
 			collapsed := keyspan.Span{
-				Start: outputKey(span.Start),
-				End:   outputKey(span.End),
+				Start: outputKey(span.Start, nil),
+				End:   outputKey(span.End, nil),
 				Keys:  make([]keyspan.Key, 0, len(span.Keys)),
 			}
-			rangekey.Coalesce(t.opts.Comparer.CompareSuffixes, span.Keys, &collapsed.Keys)
+			keys := span.Keys
+			if syntheticSuffix.IsSet() {
+				keys = slices.Clone(span.Keys)
+				for i := range keys {
+					if keys[i].Kind() == base.InternalKeyKindRangeKeyUnset {
+						panic("RangeKeyUnset with synthetic suffix")
+					}
+					if len(keys[i].Suffix) > 0 {
+						keys[i].Suffix = syntheticSuffix
+					}
+				}
+			}
+			rangekey.Coalesce(t.opts.Comparer.CompareSuffixes, keys, &collapsed.Keys)
 			for i := range collapsed.Keys {
 				collapsed.Keys[i].Trailer = base.MakeTrailer(0, collapsed.Keys[i].Kind())
 			}

--- a/metamorphic/generator.go
+++ b/metamorphic/generator.go
@@ -1393,10 +1393,8 @@ func (g *generator) writerIngestExternalFiles() {
 	// Randomly set synthetic suffixes.
 	for i := range objs {
 		if g.rng.Intn(2) == 0 {
-			// We can only use a synthetic suffix if we don't have range dels or range
-			// keys.
-			// TODO(radu): we will want to support this at some point.
-			if meta := g.keyManager.objKeyMeta(objs[i].externalObjID); meta.hasRangeDels || meta.hasRangeKeys {
+			// We can only use a synthetic suffix if we don't have range dels or RangeKeyUnsets.
+			if meta := g.keyManager.objKeyMeta(objs[i].externalObjID); meta.hasRangeDels || meta.hasRangeKeyUnset {
 				continue
 			}
 

--- a/metamorphic/key_manager.go
+++ b/metamorphic/key_manager.go
@@ -215,8 +215,9 @@ type objKeyMeta struct {
 	// object. It's updated within `update` when a new op is generated.
 	bounds bounds
 	// These flags are true if the object has had range del or range key operations.
-	hasRangeDels bool
-	hasRangeKeys bool
+	hasRangeDels     bool
+	hasRangeKeys     bool
+	hasRangeKeyUnset bool
 }
 
 // MergeKey adds the given key at the given meta timestamp, merging the histories as needed.
@@ -250,6 +251,7 @@ func (okm *objKeyMeta) MergeFrom(from *objKeyMeta, metaTimestamp int, cmp base.C
 	okm.bounds.Expand(cmp, from.bounds)
 	okm.hasRangeDels = okm.hasRangeDels || from.hasRangeDels
 	okm.hasRangeKeys = okm.hasRangeKeys || from.hasRangeKeys
+	okm.hasRangeKeyUnset = okm.hasRangeKeyUnset || from.hasRangeKeyUnset
 }
 
 // objKeyMeta looks up the objKeyMeta for a given object, creating it if necessary.
@@ -616,6 +618,7 @@ func (k *keyManager) update(o op) {
 	case *rangeKeyUnsetOp:
 		k.expandBounds(s.writerID, k.makeEndExclusiveBounds(s.start, s.end))
 		k.objKeyMeta(s.writerID).hasRangeKeys = true
+		k.objKeyMeta(s.writerID).hasRangeKeyUnset = true
 	case *ingestOp:
 		// Some ingestion operations may attempt to ingest overlapping sstables
 		// which is prohibited. We know at generation time whether these

--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -112,6 +112,7 @@ type FragmentIterTransforms struct {
 	// order) keyspan.Key for each sequence number.
 	ElideSameSeqNum bool
 	SyntheticPrefix SyntheticPrefix
+	SyntheticSuffix SyntheticSuffix
 }
 
 // NoFragmentTransforms is the default value for IterTransforms.
@@ -126,12 +127,18 @@ type SyntheticSeqNum base.SeqNum
 // disables overriding the sequence number.
 const NoSyntheticSeqNum SyntheticSeqNum = 0
 
-// SyntheticSuffix will replace every suffix of every key surfaced during block
-// iteration. A synthetic suffix can be used if:
+// SyntheticSuffix will replace every suffix of every point key surfaced during
+// block iteration. A synthetic suffix can be used if:
 //  1. no two keys in the sst share the same prefix; and
 //  2. pebble.Compare(prefix + replacementSuffix, prefix + originalSuffix) < 0,
 //     for all keys in the backing sst which have a suffix (i.e. originalSuffix
 //     is not empty).
+//
+// Range dels are not supported when synthetic suffix is used.
+//
+// For range keys, the synthetic suffix applies to the suffix that is part of
+// RangeKeySet - if it is non-empty, it is replaced with the SyntheticSuffix.
+// RangeKeyUnset keys are not supported when a synthetic suffix is used.
 type SyntheticSuffix []byte
 
 // IsSet returns true if the synthetic suffix is not enpty.

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -297,7 +297,7 @@ func (r *Reader) NewRawRangeDelIter(
 		return nil, err
 	}
 	transforms.ElideSameSeqNum = true
-	i, err := rowblk.NewFragmentIter(r.cacheOpts.FileNum, r.Compare, r.Split, h, transforms)
+	i, err := rowblk.NewFragmentIter(r.cacheOpts.FileNum, r.Compare, r.Comparer.CompareSuffixes, r.Split, h, transforms)
 	if err != nil {
 		return nil, err
 	}
@@ -317,7 +317,7 @@ func (r *Reader) NewRawRangeKeyIter(
 	if err != nil {
 		return nil, err
 	}
-	i, err := rowblk.NewFragmentIter(r.cacheOpts.FileNum, r.Compare, r.Split, h, transforms)
+	i, err := rowblk.NewFragmentIter(r.cacheOpts.FileNum, r.Compare, r.Comparer.CompareSuffixes, r.Split, h, transforms)
 	if err != nil {
 		return nil, err
 	}

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -368,7 +368,7 @@ func runVirtualReaderTest(t *testing.T, path string, blockSize, indexBlockSize i
 			if v == nil {
 				return "virtualize must be called before scan-range-del"
 			}
-			transforms := FragmentIterTransforms{} // TODO(radu): SyntheticSuffix: syntheticSuffix
+			transforms := FragmentIterTransforms{SyntheticSuffix: syntheticSuffix}
 			iter, err := v.NewRawRangeDelIter(context.Background(), transforms)
 			if err != nil {
 				return err.Error()
@@ -392,7 +392,7 @@ func runVirtualReaderTest(t *testing.T, path string, blockSize, indexBlockSize i
 			if v == nil {
 				return "virtualize must be called before scan-range-key"
 			}
-			transforms := FragmentIterTransforms{} // TODO(radu): SyntheticSuffix: syntheticSuffix
+			transforms := FragmentIterTransforms{SyntheticSuffix: syntheticSuffix}
 			iter, err := v.NewRawRangeKeyIter(context.Background(), transforms)
 			if err != nil {
 				return err.Error()

--- a/sstable/rowblk/rowblk_fragment_iter.go
+++ b/sstable/rowblk/rowblk_fragment_iter.go
@@ -39,6 +39,7 @@ import (
 // byte slices (start, end, suffix, value) as stable for the lifetime of the
 // iterator.
 type fragmentIter struct {
+	suffixCmp base.CompareSuffixes
 	blockIter Iter
 	keyBuf    [2]keyspan.Key
 	span      keyspan.Span
@@ -51,6 +52,7 @@ type fragmentIter struct {
 	// order) Key for each sequence number.
 	elideSameSeqnum bool
 
+	syntheticSuffix block.SyntheticSuffix
 	syntheticPrefix block.SyntheticPrefix
 	// startKeyBuf is a buffer that is reused to store the start key of the span
 	// when a synthetic prefix is used.
@@ -78,17 +80,20 @@ var fragmentBlockIterPool = sync.Pool{
 func NewFragmentIter(
 	fileNum base.DiskFileNum,
 	cmp base.Compare,
+	suffixCmp base.CompareSuffixes,
 	split base.Split,
 	blockHandle block.BufferHandle,
 	transforms block.FragmentIterTransforms,
 ) (keyspan.FragmentIterator, error) {
 	i := fragmentBlockIterPool.Get().(*fragmentIter)
 
+	i.suffixCmp = suffixCmp
 	// Use the i.keyBuf array to back the Keys slice to prevent an allocation
 	// when the spans contain few keys.
 	i.span.Keys = i.keyBuf[:0]
 	i.fileNum = fileNum
 	i.elideSameSeqnum = transforms.ElideSameSeqNum
+	i.syntheticSuffix = transforms.SyntheticSuffix
 	i.syntheticPrefix = transforms.SyntheticPrefix
 	if transforms.SyntheticPrefix.IsSet() {
 		i.endKeyBuf = append(i.endKeyBuf[:0], transforms.SyntheticPrefix...)
@@ -115,10 +120,11 @@ func NewFragmentIter(
 }
 
 // initSpan initializes the span with a single fragment.
+//
 // Note that the span start and end keys and range key contents are aliased to
-// the key or value. This is ok because the range del/key block doesn't use
-// prefix compression (and we don't perform any transforms), so the key/value
-// will be pointing directly into the buffer data.
+// the key or value when we don't have a synthetic prefix. This is ok because
+// the range del/key block doesn't use prefix compression, so the key/value will
+// be pointing directly into the buffer data.
 func (i *fragmentIter) initSpan(ik base.InternalKey, internalValue []byte) error {
 	if ik.Kind() == base.InternalKeyKindRangeDelete {
 		i.span = rangedel.Decode(ik, internalValue, i.span.Keys[:0])
@@ -154,7 +160,7 @@ func (i *fragmentIter) addToSpan(
 
 // applySpanTransforms applies changes to the span that we decoded, if
 // appropriate.
-func (i *fragmentIter) applySpanTransforms() {
+func (i *fragmentIter) applySpanTransforms() error {
 	if i.elideSameSeqnum && len(i.span.Keys) > 0 {
 		lastSeqNum := i.span.Keys[0].SeqNum()
 		k := 1
@@ -179,6 +185,28 @@ func (i *fragmentIter) applySpanTransforms() {
 		i.endKeyBuf = append(i.endKeyBuf[:len(i.syntheticPrefix)], i.span.End...)
 		i.span.End = i.endKeyBuf
 	}
+
+	if i.syntheticSuffix.IsSet() {
+		for keyIdx := range i.span.Keys {
+			k := &i.span.Keys[keyIdx]
+
+			switch k.Kind() {
+			case base.InternalKeyKindRangeKeySet:
+				if len(k.Suffix) > 0 {
+					if invariants.Enabled && i.suffixCmp(i.syntheticSuffix, k.Suffix) >= 0 {
+						return base.AssertionFailedf("synthetic suffix %q >= RangeKeySet suffix %q",
+							i.syntheticSuffix, k.Suffix)
+					}
+					k.Suffix = i.syntheticSuffix
+				}
+			case base.InternalKeyKindRangeKeyDelete:
+				// Nothing to do.
+			default:
+				return base.AssertionFailedf("synthetic suffix not supported with key kind %s", k.Kind())
+			}
+		}
+	}
+	return nil
 }
 
 // gatherForward gathers internal keys with identical bounds. Keys defined over
@@ -214,7 +242,9 @@ func (i *fragmentIter) gatherForward(kv *base.InternalKV) (*keyspan.Span, error)
 			return nil, err
 		}
 	}
-	i.applySpanTransforms()
+	if err := i.applySpanTransforms(); err != nil {
+		return nil, err
+	}
 	// i.blockIter is positioned over the first internal key for the next span.
 	return &i.span, nil
 }

--- a/sstable/rowblk/testdata/rowblk_fragment_iter
+++ b/sstable/rowblk/testdata/rowblk_fragment_iter
@@ -115,3 +115,59 @@ seek-lt fop_a
  seek-lt:  <nil>
     next:  foo_a-foo_b:{(#11,RANGEDEL)}
  seek-lt:  foo_d-foo_e:{(#12,RANGEDEL) (#11,RANGEDEL)}
+
+# Tests with synthetic suffix.
+iter synthetic-suffix=@20 invariants-only
+first
+----
+panic: synthetic suffix not supported with key kind RANGEDEL
+
+build
+a-d:{(#11,RANGEKEYSET,@9,foo)}
+c-g:{(#11,RANGEKEYDEL)}
+f-h:{(#11,RANGEKEYSET,@11,foo)}
+----
+a-c:{(#11,RANGEKEYSET,@9,foo)}
+c-d:{(#11,RANGEKEYSET,@9,foo) (#11,RANGEKEYDEL)}
+d-f:{(#11,RANGEKEYDEL)}
+f-g:{(#11,RANGEKEYSET,@11,foo) (#11,RANGEKEYDEL)}
+g-h:{(#11,RANGEKEYSET,@11,foo)}
+
+iter synthetic-suffix=@20
+first
+next
+next
+next
+----
+   first:  a-c:{(#11,RANGEKEYSET,@20,foo)}
+    next:  c-d:{(#11,RANGEKEYSET,@20,foo) (#11,RANGEKEYDEL)}
+    next:  d-f:{(#11,RANGEKEYDEL)}
+    next:  f-g:{(#11,RANGEKEYSET,@20,foo) (#11,RANGEKEYDEL)}
+
+iter synthetic-prefix=foo_ synthetic-suffix=@20
+seek-ge foo_c1
+prev
+next
+next
+next
+----
+ seek-ge:  foo_c-foo_d:{(#11,RANGEKEYSET,@20,foo) (#11,RANGEKEYDEL)}
+    prev:  foo_a-foo_c:{(#11,RANGEKEYSET,@20,foo)}
+    next:  foo_c-foo_d:{(#11,RANGEKEYSET,@20,foo) (#11,RANGEKEYDEL)}
+    next:  foo_d-foo_f:{(#11,RANGEKEYDEL)}
+    next:  foo_f-foo_g:{(#11,RANGEKEYSET,@20,foo) (#11,RANGEKEYDEL)}
+
+iter synthetic-suffix=@4 invariants-only
+first
+----
+panic: synthetic suffix "@4" >= RangeKeySet suffix "@9"
+
+build
+a-d:{(#11,RANGEKEYUNSET,@9,foo)}
+----
+a-d:{(#11,RANGEKEYUNSET,@9,foo)}
+
+iter synthetic-suffix=@4 invariants-only
+last
+----
+panic: synthetic suffix not supported with key kind RANGEKEYUNSET

--- a/table_cache.go
+++ b/table_cache.go
@@ -658,7 +658,7 @@ func (c *tableCacheShard) newRangeKeyIter(
 	// done here, rather than deferring to the block-property collector in order
 	// to maintain parity with point keys and the treatment of RANGEDELs.
 	if v.reader.Properties.NumRangeKeyDels == 0 && len(opts.RangeKeyFilters) > 0 {
-		ok, _, err := c.checkAndIntersectFilters(v, opts.RangeKeyFilters, nil, nil /* TODO(radu) transforms.SyntheticSuffix */)
+		ok, _, err := c.checkAndIntersectFilters(v, opts.RangeKeyFilters, nil, transforms.SyntheticSuffix)
 		if err != nil {
 			return nil, err
 		} else if !ok {

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -169,7 +169,7 @@ set bg foo
 set bh foo
 ----
 
-# Test that ingestion with a syntehtic prefix or suffix fails on older
+# Test that ingestion with a synthetic prefix or suffix fails on older
 # major versions.
 
 reset format-major-version=16
@@ -1065,3 +1065,22 @@ z_b: (., [z_b-"z_c1") @2=vrange UPDATED)
 z_b@1: (vb, [z_b-"z_c1") @2=vrange)
 z_c@1: (vc, [z_b-"z_c1") @2=vrange)
 .
+
+ingest-external
+points-and-ranges.sst synthetic-prefix=y_ synthetic-suffix=@4 bounds=(y_a,y_d) has-range-keys
+----
+
+iter
+seek-lt y
+next
+next
+next
+next
+next
+----
+x_c@1: (vc, [x_b-"x_c1") @2=vrange UPDATED)
+y_a@4: (va, . UPDATED)
+y_b: (., [y_b-"y_c1") @4=vrange UPDATED)
+y_b@4: (vb, [y_b-"y_c1") @4=vrange)
+y_c@4: (vc, [y_b-"y_c1") @4=vrange)
+z_a@1: (va, . UPDATED)


### PR DESCRIPTION
This commit adds support for synthetic suffix for external ingestions
with range keys. The synthetic suffix applies to the `RangeKeySet`
suffix.