### PR TITLE
base: make Compare more restrictive

### DIFF
--- a/open.go
+++ b/open.go
@@ -86,6 +86,11 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 		opts.Logger = opts.LoggerAndTracer
 	}
 
+	if invariants.Sometimes(5) {
+		assertComparer := base.MakeAssertComparer(*opts.Comparer)
+		opts.Comparer = &assertComparer
+	}
+
 	// In all error cases, we return db = nil; this is used by various
 	// deferred cleanups.
 


### PR DESCRIPTION
The new block format assumes that prefixes are ordered lexicographically. We now require the `Compare` function to adhere to this assumption. This is already the case with our test comparators and the CRDB comparator.

We add a `Comparer` wrapper that verifies this assumption, and we use this in a low percentage of `invariant` test runs.