### PR TITLE
colblk: add keyspan block writer, reader, iterator

### DIFF
--- a/sstable/colblk/block.go
+++ b/sstable/colblk/block.go
@@ -60,6 +60,76 @@
 // This ensures that if any individual column or piece of data requires
 // word-alignment, the writer can align the offset into the block buffer
 // appropriately to ensure that the data is word-aligned.
+//
+// # Keyspan blocks
+//
+// Blocks encoding key spans (range deletions, range keys) decompose the fields
+// of keyspan.Key into columns. Key spans are always stored fragmented, such
+// that all overlapping keys have identical bounds. When encoding key spans to a
+// columnar block, we take advantage of this fragmentation to store the set of
+// unique user key span boundaries in a separate column. This column does not
+// have the same number of rows as the other columns. Each individual fragment
+// stores the index of its start boundary user key within the user key column.
+//
+// For example, consider the three unfragmented spans:
+//
+//	a-e:{(#0,RANGEDEL)}
+//	b-d:{(#100,RANGEDEL)}
+//	f-g:{(#20,RANGEDEL)}
+//
+// Once fragmented, these spans become five keyspan.Keys:
+//
+//	a-b:{(#0,RANGEDEL)}
+//	b-d:{(#100,RANGEDEL), (#0,RANGEDEL)}
+//	d-e:{(#0,RANGEDEL)}
+//	f-g:{(#20,RANGEDEL)}
+//
+// When encoded within a columnar keyspan block, the boundary columns (user key
+// and start indices) would hold six rows:
+//
+//	+-----------------+-----------------+
+//	| User key        | Start index     |
+//	+-----------------+-----------------+
+//	| a               | 0               |
+//	+-----------------+-----------------+
+//	| b               | 1               |
+//	+-----------------+-----------------+
+//	| d               | 3               |
+//	+-----------------+-----------------+
+//	| e               | 4               |
+//	+-----------------+-----------------+
+//	| f               | 4               |
+//	+-----------------+-----------------+
+//	| g               | 5               |
+//	+-----------------+-----------------+
+//
+// The remaining keyspan.Key columns would look like:
+//
+//	+-----------------+-----------------+-----------------+
+//	| Trailer         | Suffix          | Value           |
+//	+-----------------+-----------------+-----------------+
+//	| (#0,RANGEDEL)   | -               | -               | (0)
+//	+-----------------+-----------------+-----------------+
+//	| (#100,RANGEDEL) | -               | -               | (1)
+//	+-----------------+-----------------+-----------------+
+//	| (#0,RANGEDEL)   | -               | -               | (2)
+//	+-----------------+-----------------+-----------------+
+//	| (#0,RANGEDEL)   | -               | -               | (3)
+//	+-----------------+-----------------+-----------------+
+//	| (#20,RANGEDEL)  | -               | -               | (4)
+//	+-----------------+-----------------+-----------------+
+//
+// This encoding does not explicitly encode the mapping of keyspan.Key to
+// boundary keys.  Rather each boundary key encodes the index where keys
+// beginning at a boundary >= the key begin. Readers look up the key start index
+// for the start boundary (s) and the end boundary (e). Any keys within indexes
+// [s,e) have the corresponding bounds.
+//
+// Both range deletions and range keys are encoded with the same schema. Range
+// deletion keyspan.Keys never contain suffixes or values. When encoded, the
+// RawBytes encoding uses the UintDeltaEncodingConstant encoding to avoid
+// materializing encoding N offsets. Each of these empty columns is encoded in
+// just ~5 bytes of column data.
 package colblk
 
 import (
@@ -71,7 +141,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/aligned"
 	"github.com/cockroachdb/pebble/internal/binfmt"
-	"github.com/cockroachdb/pebble/internal/invariants"
 )
 
 // Version indicates the version of the columnar block format encoded. The
@@ -86,6 +155,7 @@ const (
 
 const blockHeaderBaseSize = 7
 const columnHeaderSize = 5
+const maxBlockRetainedSize = 256 << 10
 
 // Header holds the metadata extracted from a columnar block's header.
 type Header struct {
@@ -128,53 +198,98 @@ func DecodeHeader(data []byte) Header {
 	}
 }
 
+// A blockEncoder encodes a columnar block and handles encoding the block's
+// header, including individual column headers.
+type blockEncoder struct {
+	buf          []byte
+	headerOffset uint32
+	pageOffset   uint32
+}
+
+func (e *blockEncoder) reset() {
+	if cap(e.buf) > maxBlockRetainedSize {
+		e.buf = nil
+	}
+	e.headerOffset = 0
+	e.pageOffset = 0
+}
+
+// init initializes the block encoder with a buffer of the specified size and
+// header.
+func (e *blockEncoder) init(size int, h Header, customHeaderSize int) {
+	if cap(e.buf) < size {
+		e.buf = aligned.ByteSlice(size)
+	} else {
+		e.buf = e.buf[:size]
+	}
+	e.headerOffset = uint32(customHeaderSize) + blockHeaderBaseSize
+	e.pageOffset = blockHeaderSize(int(h.Columns), customHeaderSize)
+	h.Encode(e.buf[customHeaderSize:])
+}
+
+// data returns the underlying buffer.
+func (e *blockEncoder) data() []byte {
+	return e.buf
+}
+
+// encode writes w's columns to the block.
+func (e *blockEncoder) encode(rows int, w ColumnWriter) {
+	for i := 0; i < w.NumColumns(); i++ {
+		e.buf[e.headerOffset] = byte(w.DataType(i))
+		binary.LittleEndian.PutUint32(e.buf[e.headerOffset+1:], e.pageOffset)
+		e.headerOffset += columnHeaderSize
+		e.pageOffset = w.Finish(i, rows, e.pageOffset, e.buf)
+	}
+}
+
+// finish finalizes the block encoding, returning the encoded block. The
+// returned byte slice points to the encoder's buffer, so if the encoder is
+// reused the returned slice will be invalidated.
+func (e *blockEncoder) finish() []byte {
+	e.buf[e.pageOffset] = 0x00 // Padding byte
+	e.pageOffset++
+	if e.pageOffset != uint32(len(e.buf)) {
+		panic(errors.AssertionFailedf("expected pageOffset=%d to equal size=%d", e.pageOffset, len(e.buf)))
+	}
+	return e.buf
+}
+
 // FinishBlock writes the columnar block to a heap-allocated byte slice.
 // FinishBlock assumes all columns have the same number of rows. If that's not
 // the case, the caller should manually construct their own block.
 func FinishBlock(rows int, writers []ColumnWriter) []byte {
 	size := blockHeaderSize(len(writers), 0)
-	nCols := 0
+	nCols := uint16(0)
 	for _, cw := range writers {
 		size = cw.Size(rows, size)
-		nCols += cw.NumColumns()
+		nCols += uint16(cw.NumColumns())
 	}
 	size++ // +1 for the trailing version byte.
 
-	buf := aligned.ByteSlice(int(size))
-	Header{
+	var enc blockEncoder
+	enc.init(int(size), Header{
 		Version: Version1,
-		Columns: uint16(nCols),
+		Columns: nCols,
 		Rows:    uint32(rows),
-	}.Encode(buf)
-	pageOffset := blockHeaderSize(len(writers), 0)
-	col := 0
+	}, 0)
 	for _, cw := range writers {
-		for i := 0; i < cw.NumColumns(); i++ {
-			hi := blockHeaderSize(col, 0)
-			buf[hi] = byte(cw.DataType(i))
-			binary.LittleEndian.PutUint32(buf[hi+1:], pageOffset)
-			pageOffset = cw.Finish(i, rows, pageOffset, buf)
-			col++
-		}
+		enc.encode(rows, cw)
 	}
-	buf[pageOffset] = 0x00 // Padding byte
-	pageOffset++
-	if invariants.Enabled && pageOffset != size {
-		panic(fmt.Sprintf("expected pageOffset=%d to be equal to size=%d", pageOffset, size))
-	}
-	return buf
+	return enc.finish()
 }
 
 // DecodeColumn decodes the col'th column of the provided reader's block as a
 // column of dataType using decodeFunc.
-func DecodeColumn[V any](r *BlockReader, col int, dataType DataType, decodeFunc DecodeFunc[V]) V {
+func DecodeColumn[V any](
+	r *BlockReader, col int, rows int, dataType DataType, decodeFunc DecodeFunc[V],
+) V {
 	if uint16(col) >= r.header.Columns {
 		panic(errors.AssertionFailedf("column %d is out of range [0, %d)", col, r.header.Columns))
 	}
 	if dt := r.dataType(col); dt != dataType {
 		panic(errors.AssertionFailedf("column %d is type %s; not %s", col, dt, dataType))
 	}
-	v, endOffset := decodeFunc(r.data, r.pageStart(col), int(r.header.Rows))
+	v, endOffset := decodeFunc(r.data, r.pageStart(col), rows)
 	if nextColumnOff := r.pageStart(col + 1); endOffset != nextColumnOff {
 		panic(errors.AssertionFailedf("column %d decoded to offset %d; expected %d", col, endOffset, nextColumnOff))
 	}
@@ -222,43 +337,43 @@ func (r *BlockReader) dataType(col int) DataType {
 // Bitmap retrieves the col'th column as a bitmap. The column must be of type
 // DataTypeBool.
 func (r *BlockReader) Bitmap(col int) Bitmap {
-	return DecodeColumn(r, col, DataTypeBool, DecodeBitmap)
+	return DecodeColumn(r, col, int(r.header.Rows), DataTypeBool, DecodeBitmap)
 }
 
 // RawBytes retrieves the col'th column as a column of byte slices. The column
 // must be of type DataTypeBytes.
 func (r *BlockReader) RawBytes(col int) RawBytes {
-	return DecodeColumn(r, col, DataTypeBytes, DecodeRawBytes)
+	return DecodeColumn(r, col, int(r.header.Rows), DataTypeBytes, DecodeRawBytes)
 }
 
 // PrefixBytes retrieves the col'th column as a prefix-compressed byte slice column. The column
 // must be of type DataTypePrefixBytes.
 func (r *BlockReader) PrefixBytes(col int) PrefixBytes {
-	return DecodeColumn(r, col, DataTypePrefixBytes, DecodePrefixBytes)
+	return DecodeColumn(r, col, int(r.header.Rows), DataTypePrefixBytes, DecodePrefixBytes)
 }
 
 // Uint8s retrieves the col'th column as a column of uint8s. The column must be
 // of type DataTypeUint8.
 func (r *BlockReader) Uint8s(col int) UnsafeUint8s {
-	return DecodeColumn(r, col, DataTypeUint8, DecodeUnsafeIntegerSlice[uint8])
+	return DecodeColumn(r, col, int(r.header.Rows), DataTypeUint8, DecodeUnsafeIntegerSlice[uint8])
 }
 
 // Uint16s retrieves the col'th column as a column of uint8s. The column must be
 // of type DataTypeUint16.
 func (r *BlockReader) Uint16s(col int) UnsafeUint16s {
-	return DecodeColumn(r, col, DataTypeUint16, DecodeUnsafeIntegerSlice[uint16])
+	return DecodeColumn(r, col, int(r.header.Rows), DataTypeUint16, DecodeUnsafeIntegerSlice[uint16])
 }
 
 // Uint32s retrieves the col'th column as a column of uint32s. The column must be
 // of type DataTypeUint32.
 func (r *BlockReader) Uint32s(col int) UnsafeUint32s {
-	return DecodeColumn(r, col, DataTypeUint32, DecodeUnsafeIntegerSlice[uint32])
+	return DecodeColumn(r, col, int(r.header.Rows), DataTypeUint32, DecodeUnsafeIntegerSlice[uint32])
 }
 
 // Uint64s retrieves the col'th column as a column of uint64s. The column must be
 // of type DataTypeUint64.
 func (r *BlockReader) Uint64s(col int) UnsafeUint64s {
-	return DecodeColumn(r, col, DataTypeUint64, DecodeUnsafeIntegerSlice[uint64])
+	return DecodeColumn(r, col, int(r.header.Rows), DataTypeUint64, DecodeUnsafeIntegerSlice[uint64])
 }
 
 func (r *BlockReader) pageStart(col int) uint32 {

--- a/sstable/colblk/keyspan.go
+++ b/sstable/colblk/keyspan.go
@@ -1,0 +1,424 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package colblk
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/binfmt"
+	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/internal/keyspan"
+	"github.com/cockroachdb/pebble/internal/treeprinter"
+)
+
+// the keyspan header encodes a 32-bit count of the number of unique boundary
+// user keys in the block.
+const keyspanHeaderSize = 4
+
+// keyspan block column indexes
+const (
+	// Columns with 1 row per unique boundary user key contained within the
+	// block (with the count indicated via the keyspan custom block header).
+	keyspanColBoundaryUserKeys   = 0
+	keyspanColBoundaryKeyIndices = 1
+	// Columns with 1 row per keyspan.Key (with the count indicated via the
+	// columnar header's row count).
+	keyspanColTrailers = 2
+	keyspanColSuffixes = 3
+	keyspanColValues   = 4
+	keyspanColumnCount = 5
+)
+
+// A KeyspanBlockWriter writes keyspan blocks. See the colblk package
+// documentation for more details on the schema.
+type KeyspanBlockWriter struct {
+	equal base.Equal
+
+	// boundary columns
+	boundaryUserKeys   RawBytesBuilder
+	boundaryKeyIndexes UintBuilder[uint32]
+
+	// keyspan.Key columns
+	trailers UintBuilder[uint64]
+	suffixes RawBytesBuilder
+	values   RawBytesBuilder
+
+	enc               blockEncoder
+	keyCount          int
+	unsafeLastUserKey []byte
+}
+
+// Init initializes a keyspan block writer.
+func (w *KeyspanBlockWriter) Init(equal base.Equal) {
+	w.equal = equal
+	w.boundaryUserKeys.Init()
+	w.boundaryKeyIndexes.Init()
+	w.trailers.Init()
+	w.suffixes.Init()
+	w.values.Init()
+	w.keyCount = 0
+	w.unsafeLastUserKey = nil
+}
+
+// Reset resets the keyspan block writer to an empty state, retaining memory for
+// reuse.
+func (w *KeyspanBlockWriter) Reset() {
+	w.boundaryUserKeys.Reset()
+	w.boundaryKeyIndexes.Reset()
+	w.trailers.Reset()
+	w.suffixes.Reset()
+	w.values.Reset()
+	w.enc.reset()
+	w.keyCount = 0
+	w.unsafeLastUserKey = nil
+}
+
+// AddSpan appends a new Span to the pending block. Spans must already be
+// fragmented (non-overlapping) and added in sorted order.
+func (w *KeyspanBlockWriter) AddSpan(s *keyspan.Span) {
+	// When keyspans are fragmented, abutting spans share a user key. One span's
+	// end key is the next span's start key.  Check if the previous user key
+	// equals this span's start key, and avoid encoding it again if so.
+	if w.unsafeLastUserKey == nil || !w.equal(w.unsafeLastUserKey, s.Start) {
+		w.boundaryKeyIndexes.Set(w.boundaryUserKeys.rows, uint32(w.keyCount))
+		w.boundaryUserKeys.Put(s.Start)
+	}
+	// The end key must be strictly greater than the start key and spans are
+	// already sorted, so the end key is guaranteed to not be present in the
+	// column yet. We need to encode it.
+	w.boundaryKeyIndexes.Set(w.boundaryUserKeys.rows, uint32(w.keyCount+len(s.Keys)))
+	w.boundaryUserKeys.Put(s.End)
+
+	// Hold on to a slice of the copy of s.End we just added to the bytes
+	// builder so that we can compare it to the next span's start key.
+	w.unsafeLastUserKey = w.boundaryUserKeys.data[len(w.boundaryUserKeys.data)-len(s.End):]
+
+	// Encode each keyspan.Key in the span.
+	for i := range s.Keys {
+		w.trailers.Set(w.keyCount, uint64(s.Keys[i].Trailer))
+		w.suffixes.Put(s.Keys[i].Suffix)
+		w.values.Put(s.Keys[i].Value)
+		w.keyCount++
+	}
+}
+
+// Size returns the size of the pending block.
+func (w *KeyspanBlockWriter) Size() int {
+	off := blockHeaderSize(keyspanColumnCount, keyspanHeaderSize)
+	// Span boundary columns (with userKeyCount elements).
+	off = w.boundaryUserKeys.Size(w.boundaryUserKeys.rows, off)
+	off = w.boundaryKeyIndexes.Size(w.boundaryUserKeys.rows, off)
+
+	// keyspan.Key columns (with keyCount elements).
+	off = w.trailers.Size(w.keyCount, off)
+	off = w.suffixes.Size(w.keyCount, off)
+	off = w.values.Size(w.keyCount, off)
+	off++ // trailing padding
+	return int(off)
+}
+
+// Finish finalizes the pending block and returns the encoded block.
+func (w *KeyspanBlockWriter) Finish() []byte {
+	w.enc.init(w.Size(), Header{
+		Version: Version1,
+		Columns: keyspanColumnCount,
+		Rows:    uint32(w.keyCount),
+	}, keyspanHeaderSize)
+
+	// The keyspan block has a 4-byte custom header used to encode the number of
+	// user keys encoded within the user key and start indices columns. All
+	// other columns have the number of rows indicated by the shared columnar
+	// block header.
+	binary.LittleEndian.PutUint32(w.enc.data()[:keyspanHeaderSize], uint32(w.boundaryUserKeys.rows))
+
+	// Columns with userKeyCount elements.
+	w.enc.encode(w.boundaryUserKeys.rows, &w.boundaryUserKeys)
+	w.enc.encode(w.boundaryUserKeys.rows, &w.boundaryKeyIndexes)
+	// Columns with keyCount elements.
+	w.enc.encode(w.keyCount, &w.trailers)
+	w.enc.encode(w.keyCount, &w.suffixes)
+	w.enc.encode(w.keyCount, &w.values)
+	return w.enc.finish()
+}
+
+// String returns a string representation of the pending block's state.
+func (w *KeyspanBlockWriter) String() string {
+	var buf bytes.Buffer
+	size := uint32(w.Size())
+	fmt.Fprintf(&buf, "size=%d:\n", size)
+
+	fmt.Fprint(&buf, "0: user keys:      ")
+	w.boundaryUserKeys.WriteDebug(&buf, w.boundaryUserKeys.rows)
+	fmt.Fprintln(&buf)
+	fmt.Fprint(&buf, "1: start indices:  ")
+	w.boundaryKeyIndexes.WriteDebug(&buf, w.boundaryUserKeys.rows)
+	fmt.Fprintln(&buf)
+
+	fmt.Fprint(&buf, "2: trailers:       ")
+	w.trailers.WriteDebug(&buf, w.keyCount)
+	fmt.Fprintln(&buf)
+	fmt.Fprint(&buf, "3: suffixes:       ")
+	w.suffixes.WriteDebug(&buf, w.keyCount)
+	fmt.Fprintln(&buf)
+	fmt.Fprint(&buf, "4: values:         ")
+	w.values.WriteDebug(&buf, w.keyCount)
+	fmt.Fprintln(&buf)
+
+	return buf.String()
+}
+
+// A KeyspanReader exposes facilities for reading a keyspan block. A
+// KeyspanReader is safe for concurrent use and may be used by multiple
+// KeyspanIters concurrently.
+type KeyspanReader struct {
+	blockReader BlockReader
+	// Span boundary columns with boundaryKeysCount elements.
+	boundaryKeysCount  uint32
+	boundaryKeys       RawBytes
+	boundaryKeyIndices UnsafeUint32s
+
+	// keyspan.Key columns with blockReader.header.Rows elements.
+	trailers UnsafeUint64s
+	suffixes RawBytes
+	values   RawBytes
+}
+
+// Init initializes the keyspan reader with the given block data.
+func (r *KeyspanReader) Init(data []byte) {
+	r.boundaryKeysCount = binary.LittleEndian.Uint32(data[:4])
+	r.blockReader.Init(data, keyspanHeaderSize)
+	// The boundary key columns have a different number of rows than the other
+	// columns, so we call DecodeColumn directly, taking care to pass in
+	// rows=r.boundaryKeysCount.
+	r.boundaryKeys = DecodeColumn(&r.blockReader, keyspanColBoundaryUserKeys,
+		int(r.boundaryKeysCount), DataTypeBytes, DecodeRawBytes)
+	r.boundaryKeyIndices = DecodeColumn(&r.blockReader, keyspanColBoundaryKeyIndices,
+		int(r.boundaryKeysCount), DataTypeUint32, DecodeUnsafeIntegerSlice[uint32])
+
+	r.trailers = r.blockReader.Uint64s(keyspanColTrailers)
+	r.suffixes = r.blockReader.RawBytes(keyspanColSuffixes)
+	r.values = r.blockReader.RawBytes(keyspanColValues)
+}
+
+// DebugString prints a human-readable explanation of the keyspan block's binary
+// representation.
+func (r *KeyspanReader) DebugString() string {
+	f := binfmt.New(r.blockReader.data).LineWidth(20)
+	f.CommentLine("keyspan block header")
+	f.HexBytesln(4, "user key count: %d", r.boundaryKeysCount)
+	r.blockReader.headerToBinFormatter(f)
+
+	for i := 0; i < keyspanColumnCount; i++ {
+		// Not all columns in a keyspan block have the same number of rows; the
+		// boundary columns columns are different (and their lengths are held in
+		// the keyspan block header that precedes the ordinary columnar block
+		// header).
+		rows := int(r.blockReader.header.Rows)
+		if i == keyspanColBoundaryUserKeys || i == keyspanColBoundaryKeyIndices {
+			rows = int(r.boundaryKeysCount)
+		}
+		r.blockReader.columnToBinFormatter(f, i, rows)
+	}
+	return f.String()
+}
+
+// searchBoundaryKeys returns the index of the first boundary key greater than
+// or equal to key and whether or not the key was found exactly.
+func (r *KeyspanReader) searchBoundaryKeys(cmp base.Compare, key []byte) (index int, equal bool) {
+	i, j := 0, int(r.boundaryKeysCount)
+	for i < j {
+		h := int(uint(i+j) >> 1) // avoid overflow when computing h
+		// i ≤ h < j
+		switch cmp(key, r.boundaryKeys.At(h)) {
+		case +1:
+			i = h + 1
+		case 0:
+			return h, true
+		default:
+			// -1
+			j = h
+		}
+	}
+	return i, false
+}
+
+// A KeyspanIter is an iterator over a keyspan block. It implements the
+// keyspan.FragmentIterator interface.
+type KeyspanIter struct {
+	r    *KeyspanReader
+	cmp  base.Compare
+	span keyspan.Span
+	// When positioned, the current span's start key is the user key at
+	//   i.r.userKeys.At(i.startBoundIndex)
+	// and the current span's end key is the user key at
+	//   i.r.userKeys.At(i.startBoundIndex+1)
+	startBoundIndex int
+	keyBuf          [2]keyspan.Key
+}
+
+// Assert that KeyspanIter implements the FragmentIterator interface.
+var _ keyspan.FragmentIterator = (*KeyspanIter)(nil)
+
+// Init initializes the iterator with the given comparison function and keyspan
+// reader.
+func (i *KeyspanIter) Init(cmp base.Compare, r *KeyspanReader) {
+	i.r = r
+	i.cmp = cmp
+	i.span.Start, i.span.End = nil, nil
+	i.startBoundIndex = -1
+	if i.span.Keys == nil {
+		i.span.Keys = i.keyBuf[:0]
+	}
+}
+
+// SeekGE moves the iterator to the first span covering a key greater than
+// or equal to the given key. This is equivalent to seeking to the first
+// span with an end key greater than the given key.
+func (i *KeyspanIter) SeekGE(key []byte) (*keyspan.Span, error) {
+	// Seek among the boundary keys.
+	j, eq := i.r.searchBoundaryKeys(i.cmp, key)
+	// If the found boundary key does not exactly equal the given key, it's
+	// strictly greater than key. We need to back up one to consider the span
+	// that ends at the this boundary key.
+	if !eq {
+		j = max(j-1, 0)
+	}
+	return i.gatherKeysForward(j), nil
+}
+
+// SeekLT moves the iterator to the last span covering a key less than the
+// given key. This is equivalent to seeking to the last span with a start
+// key less than the given key.
+func (i *KeyspanIter) SeekLT(key []byte) (*keyspan.Span, error) {
+	// Seek among the boundary keys.
+	j, eq := i.r.searchBoundaryKeys(i.cmp, key)
+	// If eq is true, the found boundary key exactly equals the given key. A
+	// span that starts at exactly [key] does not contain any keys strictly less
+	// than [key], so back up one index.
+	if eq {
+		j--
+	}
+	// If all boundaries are less than [key], or only the last boundary is
+	// greater than the key, then we want the last span so we clamp the index to
+	// the second to last boundary.
+	return i.gatherKeysBackward(min(j, int(i.r.boundaryKeysCount)-2)), nil
+}
+
+// First moves the iterator to the first span.
+func (i *KeyspanIter) First() (*keyspan.Span, error) {
+	return i.gatherKeysForward(0), nil
+}
+
+// Last moves the iterator to the last span.
+func (i *KeyspanIter) Last() (*keyspan.Span, error) {
+	return i.gatherKeysBackward(int(i.r.boundaryKeysCount) - 2), nil
+}
+
+// Next moves the iterator to the next span.
+func (i *KeyspanIter) Next() (*keyspan.Span, error) {
+	return i.gatherKeysForward(i.startBoundIndex + 1), nil
+}
+
+// Prev moves the iterator to the previous span.
+func (i *KeyspanIter) Prev() (*keyspan.Span, error) {
+	return i.gatherKeysBackward(max(i.startBoundIndex-1, -1)), nil
+}
+
+// gatherKeysForward returns the first non-empty Span in the forward direction,
+// starting with the span formed by using the boundary key at index
+// [startBoundIndex] as the span's start boundary.
+func (i *KeyspanIter) gatherKeysForward(startBoundIndex int) *keyspan.Span {
+	if invariants.Enabled && startBoundIndex < 0 {
+		panic(errors.AssertionFailedf("out of bounds: i.startBoundIndex=%d", startBoundIndex))
+	}
+	i.startBoundIndex = startBoundIndex
+	if i.startBoundIndex >= int(i.r.boundaryKeysCount)-1 {
+		return nil
+	}
+	if !i.isNonemptySpan(i.startBoundIndex) {
+		if i.startBoundIndex == int(i.r.boundaryKeysCount)-2 {
+			// Corruption error
+			panic(base.CorruptionErrorf("keyspan block has empty span at end"))
+		}
+		i.startBoundIndex++
+		if !i.isNonemptySpan(i.startBoundIndex) {
+			panic(base.CorruptionErrorf("keyspan block has consecutive empty spans"))
+		}
+	}
+	return i.materializeSpan()
+}
+
+// gatherKeysBackward returns the first non-empty Span in the backward direction,
+// starting with the span formed by using the boundary key at index
+// [startBoundIndex] as the span's start boundary.
+func (i *KeyspanIter) gatherKeysBackward(startBoundIndex int) *keyspan.Span {
+	i.startBoundIndex = startBoundIndex
+	if i.startBoundIndex < 0 {
+		return nil
+	}
+	if invariants.Enabled && i.startBoundIndex >= int(i.r.boundaryKeysCount)-1 {
+		panic(errors.AssertionFailedf("out of bounds: i.startBoundIndex=%d, i.r.boundaryKeysCount=%d",
+			i.startBoundIndex, i.r.boundaryKeysCount))
+	}
+	if !i.isNonemptySpan(i.startBoundIndex) {
+		if i.startBoundIndex == 0 {
+			// Corruption error
+			panic(base.CorruptionErrorf("keyspan block has empty span at beginning"))
+		}
+		i.startBoundIndex--
+		if !i.isNonemptySpan(i.startBoundIndex) {
+			panic(base.CorruptionErrorf("keyspan block has consecutive empty spans"))
+		}
+	}
+	return i.materializeSpan()
+}
+
+// isNonemptySpan returns true if the span starting at i.startBoundIndex
+// contains keys.
+func (i *KeyspanIter) isNonemptySpan(startBoundIndex int) bool {
+	return i.r.boundaryKeyIndices.At(startBoundIndex) < i.r.boundaryKeyIndices.At(startBoundIndex+1)
+}
+
+// materializeSpan constructs the current span from i.startBoundIndex and
+// i.{start,end}KeyIndex.
+func (i *KeyspanIter) materializeSpan() *keyspan.Span {
+	i.span = keyspan.Span{
+		Start: i.r.boundaryKeys.At(i.startBoundIndex),
+		End:   i.r.boundaryKeys.At(i.startBoundIndex + 1),
+		Keys:  i.span.Keys[:0],
+	}
+	startIndex := i.r.boundaryKeyIndices.At(i.startBoundIndex)
+	endIndex := i.r.boundaryKeyIndices.At(i.startBoundIndex + 1)
+	if cap(i.span.Keys) < int(endIndex-startIndex) {
+		i.span.Keys = make([]keyspan.Key, 0, int(endIndex-startIndex))
+	}
+	for j := startIndex; j < endIndex; j++ {
+		i.span.Keys = append(i.span.Keys, keyspan.Key{
+			Trailer: base.InternalKeyTrailer(i.r.trailers.At(int(j))),
+			Suffix:  i.r.suffixes.At(int(j)),
+			Value:   i.r.values.At(int(j)),
+		})
+	}
+	return &i.span
+}
+
+// Close closes the iterator.
+func (i *KeyspanIter) Close() {}
+
+// SetContext implements keyspan.FragmentIterator.
+func (i *KeyspanIter) SetContext(context.Context) {}
+
+// WrapChildren implements keyspan.FragmentIterator.
+func (i *KeyspanIter) WrapChildren(keyspan.WrapFn) {}
+
+// DebugTree is part of the FragmentIterator interface.
+func (i *KeyspanIter) DebugTree(tp treeprinter.Node) {
+	tp.Childf("%T(%p)", i, i)
+}

--- a/sstable/colblk/keyspan_test.go
+++ b/sstable/colblk/keyspan_test.go
@@ -1,0 +1,136 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package colblk
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/keyspan"
+	"golang.org/x/exp/rand"
+)
+
+func TestKeyspanBlock(t *testing.T) {
+	var buf bytes.Buffer
+	var kr KeyspanReader
+	var w KeyspanBlockWriter
+	datadriven.RunTest(t, "testdata/keyspan_block", func(t *testing.T, td *datadriven.TestData) string {
+		buf.Reset()
+		switch td.Cmd {
+		case "init":
+			w.Init(bytes.Equal)
+			fmt.Fprint(&buf, &w)
+			return buf.String()
+		case "reset":
+			w.Reset()
+			fmt.Fprint(&buf, &w)
+			return buf.String()
+		case "add":
+			for _, line := range strings.Split(td.Input, "\n") {
+				s := keyspan.ParseSpan(line)
+				w.AddSpan(&s)
+			}
+			fmt.Fprint(&buf, &w)
+			return buf.String()
+		case "finish":
+			block := w.Finish()
+			kr.Init(block)
+			fmt.Fprint(&buf, kr.DebugString())
+			return buf.String()
+		case "iter":
+			var iter KeyspanIter
+			iter.Init(base.DefaultComparer.Compare, &kr)
+			return keyspan.RunFragmentIteratorCmd(&iter, td.Input, nil)
+		default:
+			return fmt.Sprintf("unknown command: %s", td.Cmd)
+		}
+	})
+}
+
+func BenchmarkKeyspanBlock_RangeDeletions(b *testing.B) {
+	for _, numSpans := range []int{1, 10, 100} {
+		for _, keysPerSpan := range []int{1, 2, 5} {
+			for _, keySize := range []int{10, 128} {
+				b.Run(fmt.Sprintf("numSpans=%d/keysPerSpan=%d/keySize=%d", numSpans, keysPerSpan, keySize), func(b *testing.B) {
+					benchmarkKeyspanBlockRangeDeletions(b, numSpans, keysPerSpan, keySize)
+				})
+			}
+		}
+	}
+}
+
+func benchmarkKeyspanBlockRangeDeletions(b *testing.B, numSpans, keysPerSpan, keySize int) {
+	var w KeyspanBlockWriter
+	w.Init(bytes.Equal)
+	format := fmt.Sprintf("%%0%dd", keySize)
+	s := keyspan.Span{
+		Start: make([]byte, 0, keySize),
+		End:   make([]byte, 0, keySize),
+		Keys:  make([]keyspan.Key, 0, keysPerSpan),
+	}
+	keys := make([][]byte, numSpans+1)
+	for k := range keys {
+		keys[k] = fmt.Appendf([]byte{}, format, k)
+	}
+	for i := 0; i < numSpans; i++ {
+		s = keyspan.Span{
+			Start: keys[i],
+			End:   keys[i+1],
+			Keys:  s.Keys[:0],
+		}
+		for j := 0; j < keysPerSpan; j++ {
+			t := base.MakeTrailer(base.SeqNum(j), base.InternalKeyKindRangeDelete)
+			s.Keys = append(s.Keys, keyspan.Key{Trailer: t})
+		}
+		w.AddSpan(&s)
+	}
+	block := w.Finish()
+	avgRowSize := float64(w.Size()) / float64(numSpans*keysPerSpan)
+
+	var kr KeyspanReader
+	kr.Init(block)
+
+	var it KeyspanIter
+	it.Init(base.DefaultComparer.Compare, &kr)
+	b.Run("SeekGE", func(b *testing.B) {
+		rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
+
+		b.ResetTimer()
+		var sum uint64
+		for i := 0; i < b.N; i++ {
+			if s, _ := it.SeekGE(keys[rng.Intn(len(keys))]); s != nil {
+				for _, k := range s.Keys {
+					sum += uint64(k.Trailer)
+				}
+			}
+		}
+		b.StopTimer()
+		b.ReportMetric(avgRowSize, "bytes/row")
+		fmt.Fprint(io.Discard, sum)
+	})
+	b.Run("Next", func(b *testing.B) {
+		_, _ = it.First()
+		b.ResetTimer()
+		var sum uint64
+		for i := 0; i < b.N; i++ {
+			s, _ := it.Next()
+			if s == nil {
+				s, _ = it.First()
+			}
+			for _, k := range s.Keys {
+				sum += uint64(k.Trailer)
+			}
+		}
+		b.StopTimer()
+		b.ReportMetric(avgRowSize, "bytes/row")
+		fmt.Fprint(io.Discard, sum)
+	})
+}

--- a/sstable/colblk/raw_bytes.go
+++ b/sstable/colblk/raw_bytes.go
@@ -123,8 +123,13 @@ type RawBytesBuilder struct {
 // Assert that *RawBytesBuilder implements ColumnWriter.
 var _ ColumnWriter = (*RawBytesBuilder)(nil)
 
-// Reset resets the builder to an empty state, preserving the existing bundle
-// size.
+// Init initializes the builder for first-time use.
+func (b *RawBytesBuilder) Init() {
+	b.offsets.Init()
+	b.Reset()
+}
+
+// Reset resets the builder to an empty state.
 func (b *RawBytesBuilder) Reset() {
 	b.rows = 0
 	b.data = b.data[:0]

--- a/sstable/colblk/testdata/keyspan_block
+++ b/sstable/colblk/testdata/keyspan_block
@@ -1,0 +1,423 @@
+init
+----
+size=1:
+0: user keys:      bytes: 0 rows set; 0 bytes in data
+1: start indices:  uint32: 0 rows
+2: trailers:       uint64: 0 rows
+3: suffixes:       bytes: 0 rows set; 0 bytes in data
+4: values:         bytes: 0 rows set; 0 bytes in data
+
+add
+a-b:{(#0,RANGEDEL)}
+----
+size=73:
+0: user keys:      bytes: 2 rows set; 2 bytes in data
+1: start indices:  uint32: 2 rows
+2: trailers:       uint64: 1 rows
+3: suffixes:       bytes: 1 rows set; 0 bytes in data
+4: values:         bytes: 1 rows set; 0 bytes in data
+
+add
+b-c:{(#100,RANGEDEL) (#20,RANGEDEL) (#0,RANGEDEL)}
+----
+size=85:
+0: user keys:      bytes: 3 rows set; 3 bytes in data
+1: start indices:  uint32: 3 rows
+2: trailers:       uint64: 4 rows
+3: suffixes:       bytes: 4 rows set; 0 bytes in data
+4: values:         bytes: 4 rows set; 0 bytes in data
+
+add
+c-d:{(#100,RANGEDEL) (#0,RANGEDEL)}
+----
+size=91:
+0: user keys:      bytes: 4 rows set; 4 bytes in data
+1: start indices:  uint32: 4 rows
+2: trailers:       uint64: 6 rows
+3: suffixes:       bytes: 6 rows set; 0 bytes in data
+4: values:         bytes: 6 rows set; 0 bytes in data
+
+add
+d-e:{(#0,RANGEDEL)}
+----
+size=97:
+0: user keys:      bytes: 5 rows set; 5 bytes in data
+1: start indices:  uint32: 5 rows
+2: trailers:       uint64: 7 rows
+3: suffixes:       bytes: 7 rows set; 0 bytes in data
+4: values:         bytes: 7 rows set; 0 bytes in data
+
+finish
+----
+# keyspan block header
+00-04: x 05000000         # user key count: 5
+# columnar block header
+04-05: x 01               # version 1
+05-07: x 0500             # 5 columns
+07-11: x 07000000         # 7 rows
+# column 0
+11-12: b 00000110         # bytes
+12-16: x 24000000         # page start 36
+# column 1
+16-17: b 00000100         # uint32
+17-21: x 34000000         # page start 52
+# column 2
+21-22: b 00000101         # uint64
+22-26: x 3e000000         # page start 62
+# column 3
+26-27: b 00000110         # bytes
+27-31: x 56000000         # page start 86
+# column 4
+31-32: b 00000110         # bytes
+32-36: x 5b000000         # page start 91
+# data for column 0
+# rawbytes
+# offsets table
+36-37: x 02               # delta encoding: delta8
+37-41: x 00000000         # 32-bit constant: 0
+41-42: x 00               # data[0] = 0 [47 overall]
+42-43: x 01               # data[1] = 1 [48 overall]
+43-44: x 02               # data[2] = 2 [49 overall]
+44-45: x 03               # data[3] = 3 [50 overall]
+45-46: x 04               # data[4] = 4 [51 overall]
+46-47: x 05               # data[5] = 5 [52 overall]
+# data
+47-48: x 61               # data[0]: a
+48-49: x 62               # data[1]: b
+49-50: x 63               # data[2]: c
+50-51: x 64               # data[3]: d
+51-52: x 65               # data[4]: e
+# data for column 1
+52-53: x 02               # delta encoding: delta8
+53-57: x 00000000         # 32-bit constant: 0
+57-58: x 00               # data[0] = 0
+58-59: x 01               # data[1] = 1
+59-60: x 04               # data[2] = 4
+60-61: x 06               # data[3] = 6
+61-62: x 07               # data[4] = 7
+# data for column 2
+62-63: x 03               # delta encoding: delta16
+63-71: x 0f00000000000000 # 64-bit constant: 15
+# padding
+71-72: x 00               # aligning to 16-bit boundary
+72-74: x 0000             # data[0] = 0 + 15 = 15
+74-76: x 0064             # data[1] = 25600 + 15 = 25615
+76-78: x 0014             # data[2] = 5120 + 15 = 5135
+78-80: x 0000             # data[3] = 0 + 15 = 15
+80-82: x 0064             # data[4] = 25600 + 15 = 25615
+82-84: x 0000             # data[5] = 0 + 15 = 15
+84-86: x 0000             # data[6] = 0 + 15 = 15
+# data for column 3
+# rawbytes
+# offsets table
+86-87: x 01               # delta encoding: const
+87-91: x 00000000         # 32-bit constant: 0
+# data
+91-91: x                  # data[0]:
+91-91: x                  # data[1]:
+91-91: x                  # data[2]:
+91-91: x                  # data[3]:
+91-91: x                  # data[4]:
+91-91: x                  # data[5]:
+91-91: x                  # data[6]:
+# data for column 4
+# rawbytes
+# offsets table
+91-92: x 01               # delta encoding: const
+92-96: x 00000000         # 32-bit constant: 0
+# data
+96-96: x                  # data[0]:
+96-96: x                  # data[1]:
+96-96: x                  # data[2]:
+96-96: x                  # data[3]:
+96-96: x                  # data[4]:
+96-96: x                  # data[5]:
+96-96: x                  # data[6]:
+
+# Test iterating over the block's spans.
+
+iter
+seek-ge a
+seek-ge apple
+seek-ge b
+seek-ge banana
+seek-ge c
+seek-ge coconut
+seek-ge d
+seek-ge dragonfruit
+seek-ge e
+seek-ge z
+----
+a-b:{(#0,RANGEDEL)}
+a-b:{(#0,RANGEDEL)}
+b-c:{(#100,RANGEDEL) (#20,RANGEDEL) (#0,RANGEDEL)}
+b-c:{(#100,RANGEDEL) (#20,RANGEDEL) (#0,RANGEDEL)}
+c-d:{(#100,RANGEDEL) (#0,RANGEDEL)}
+c-d:{(#100,RANGEDEL) (#0,RANGEDEL)}
+d-e:{(#0,RANGEDEL)}
+d-e:{(#0,RANGEDEL)}
+.
+.
+
+iter
+seek-lt z
+seek-lt e
+seek-lt dragonfruit
+seek-lt d
+----
+d-e:{(#0,RANGEDEL)}
+d-e:{(#0,RANGEDEL)}
+d-e:{(#0,RANGEDEL)}
+c-d:{(#100,RANGEDEL) (#0,RANGEDEL)}
+
+iter
+first
+next
+next
+next
+next
+prev
+prev
+prev
+prev
+prev
+----
+a-b:{(#0,RANGEDEL)}
+b-c:{(#100,RANGEDEL) (#20,RANGEDEL) (#0,RANGEDEL)}
+c-d:{(#100,RANGEDEL) (#0,RANGEDEL)}
+d-e:{(#0,RANGEDEL)}
+.
+d-e:{(#0,RANGEDEL)}
+c-d:{(#100,RANGEDEL) (#0,RANGEDEL)}
+b-c:{(#100,RANGEDEL) (#20,RANGEDEL) (#0,RANGEDEL)}
+a-b:{(#0,RANGEDEL)}
+.
+
+iter
+last
+prev
+prev
+prev
+prev
+next
+next
+next
+next
+next
+----
+d-e:{(#0,RANGEDEL)}
+c-d:{(#100,RANGEDEL) (#0,RANGEDEL)}
+b-c:{(#100,RANGEDEL) (#20,RANGEDEL) (#0,RANGEDEL)}
+a-b:{(#0,RANGEDEL)}
+.
+a-b:{(#0,RANGEDEL)}
+b-c:{(#100,RANGEDEL) (#20,RANGEDEL) (#0,RANGEDEL)}
+c-d:{(#100,RANGEDEL) (#0,RANGEDEL)}
+d-e:{(#0,RANGEDEL)}
+.
+
+init
+----
+size=1:
+0: user keys:      bytes: 0 rows set; 0 bytes in data
+1: start indices:  uint32: 0 rows
+2: trailers:       uint64: 0 rows
+3: suffixes:       bytes: 0 rows set; 0 bytes in data
+4: values:         bytes: 0 rows set; 0 bytes in data
+
+add
+b-d:{(#4,RANGEKEYSET,@3,coconut)}
+----
+size=86:
+0: user keys:      bytes: 2 rows set; 2 bytes in data
+1: start indices:  uint32: 2 rows
+2: trailers:       uint64: 1 rows
+3: suffixes:       bytes: 1 rows set; 2 bytes in data
+4: values:         bytes: 1 rows set; 7 bytes in data
+
+finish
+----
+# keyspan block header
+00-04: x 02000000         # user key count: 2
+# columnar block header
+04-05: x 01               # version 1
+05-07: x 0500             # 5 columns
+07-11: x 01000000         # 1 rows
+# column 0
+11-12: b 00000110         # bytes
+12-16: x 24000000         # page start 36
+# column 1
+16-17: b 00000100         # uint32
+17-21: x 2e000000         # page start 46
+# column 2
+21-22: b 00000101         # uint64
+22-26: x 35000000         # page start 53
+# column 3
+26-27: b 00000110         # bytes
+27-31: x 3e000000         # page start 62
+# column 4
+31-32: b 00000110         # bytes
+32-36: x 47000000         # page start 71
+# data for column 0
+# rawbytes
+# offsets table
+36-37: x 02               # delta encoding: delta8
+37-41: x 00000000         # 32-bit constant: 0
+41-42: x 00               # data[0] = 0 [44 overall]
+42-43: x 01               # data[1] = 1 [45 overall]
+43-44: x 02               # data[2] = 2 [46 overall]
+# data
+44-45: x 62               # data[0]: b
+45-46: x 64               # data[1]: d
+# data for column 1
+46-47: x 02               # delta encoding: delta8
+47-51: x 00000000         # 32-bit constant: 0
+51-52: x 00               # data[0] = 0
+52-53: x 01               # data[1] = 1
+# data for column 2
+53-54: x 01               # delta encoding: const
+54-62: x 1504000000000000 # 64-bit constant: 1045
+# data for column 3
+# rawbytes
+# offsets table
+62-63: x 02               # delta encoding: delta8
+63-67: x 00000000         # 32-bit constant: 0
+67-68: x 00               # data[0] = 0 [69 overall]
+68-69: x 02               # data[1] = 2 [71 overall]
+# data
+69-71: x 4033             # data[0]: @3
+# data for column 4
+# rawbytes
+# offsets table
+71-72: x 02               # delta encoding: delta8
+72-76: x 00000000         # 32-bit constant: 0
+76-77: x 00               # data[0] = 0 [78 overall]
+77-78: x 07               # data[1] = 7 [85 overall]
+# data
+78-85: x 636f636f6e7574   # data[0]: coconut
+
+iter
+seek-ge a
+next
+prev
+prev
+next
+----
+b-d:{(#4,RANGEKEYSET,@3,coconut)}
+.
+b-d:{(#4,RANGEKEYSET,@3,coconut)}
+.
+b-d:{(#4,RANGEKEYSET,@3,coconut)}
+
+reset
+----
+size=1:
+0: user keys:      bytes: 0 rows set; 0 bytes in data
+1: start indices:  uint32: 0 rows
+2: trailers:       uint64: 0 rows
+3: suffixes:       bytes: 0 rows set; 0 bytes in data
+4: values:         bytes: 0 rows set; 0 bytes in data
+
+add
+b-d:{(#4,RANGEKEYSET,@3,coconut)}
+e-g:{(#5,RANGEKEYSET,@1,tree)}
+----
+size=104:
+0: user keys:      bytes: 4 rows set; 4 bytes in data
+1: start indices:  uint32: 4 rows
+2: trailers:       uint64: 2 rows
+3: suffixes:       bytes: 2 rows set; 4 bytes in data
+4: values:         bytes: 2 rows set; 11 bytes in data
+
+finish
+----
+# keyspan block header
+000-004: x 04000000         # user key count: 4
+# columnar block header
+004-005: x 01               # version 1
+005-007: x 0500             # 5 columns
+007-011: x 02000000         # 2 rows
+# column 0
+011-012: b 00000110         # bytes
+012-016: x 24000000         # page start 36
+# column 1
+016-017: b 00000100         # uint32
+017-021: x 32000000         # page start 50
+# column 2
+021-022: b 00000101         # uint64
+022-026: x 3b000000         # page start 59
+# column 3
+026-027: b 00000110         # bytes
+027-031: x 48000000         # page start 72
+# column 4
+031-032: b 00000110         # bytes
+032-036: x 54000000         # page start 84
+# data for column 0
+# rawbytes
+# offsets table
+036-037: x 02               # delta encoding: delta8
+037-041: x 00000000         # 32-bit constant: 0
+041-042: x 00               # data[0] = 0 [46 overall]
+042-043: x 01               # data[1] = 1 [47 overall]
+043-044: x 02               # data[2] = 2 [48 overall]
+044-045: x 03               # data[3] = 3 [49 overall]
+045-046: x 04               # data[4] = 4 [50 overall]
+# data
+046-047: x 62               # data[0]: b
+047-048: x 64               # data[1]: d
+048-049: x 65               # data[2]: e
+049-050: x 67               # data[3]: g
+# data for column 1
+050-051: x 02               # delta encoding: delta8
+051-055: x 00000000         # 32-bit constant: 0
+055-056: x 00               # data[0] = 0
+056-057: x 01               # data[1] = 1
+057-058: x 01               # data[2] = 1
+058-059: x 02               # data[3] = 2
+# data for column 2
+059-060: x 03               # delta encoding: delta16
+060-068: x 1504000000000000 # 64-bit constant: 1045
+068-070: x 0000             # data[0] = 0 + 1045 = 1045
+070-072: x 0001             # data[1] = 256 + 1045 = 1301
+# data for column 3
+# rawbytes
+# offsets table
+072-073: x 02               # delta encoding: delta8
+073-077: x 00000000         # 32-bit constant: 0
+077-078: x 00               # data[0] = 0 [80 overall]
+078-079: x 02               # data[1] = 2 [82 overall]
+079-080: x 04               # data[2] = 4 [84 overall]
+# data
+080-082: x 4033             # data[0]: @3
+082-084: x 4031             # data[1]: @1
+# data for column 4
+# rawbytes
+# offsets table
+084-085: x 02               # delta encoding: delta8
+085-089: x 00000000         # 32-bit constant: 0
+089-090: x 00               # data[0] = 0 [92 overall]
+090-091: x 07               # data[1] = 7 [99 overall]
+091-092: x 0b               # data[2] = 11 [103 overall]
+# data
+092-099: x 636f636f6e7574   # data[0]: coconut
+099-103: x 74726565         # data[1]: tree
+
+iter
+seek-ge dog
+seek-ge g
+seek-ge z
+----
+e-g:{(#5,RANGEKEYSET,@1,tree)}
+.
+.
+
+iter
+seek-lt dog
+seek-lt g
+seek-lt z
+seek-lt e
+----
+e-g:{(#5,RANGEKEYSET,@1,tree)}
+e-g:{(#5,RANGEKEYSET,@1,tree)}
+e-g:{(#5,RANGEKEYSET,@1,tree)}
+b-d:{(#4,RANGEKEYSET,@3,coconut)}


### PR DESCRIPTION
Add a columnar block schema for keyspans, used for range deletion and range keys.

```
goos: linux
goarch: amd64
pkg: github.com/cockroachdb/pebble/sstable/colblk
cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
                                                                             │    old.log    │              newer.log               │
                                                                             │    sec/op     │    sec/op     vs base                │
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=1/keySize=10/SeekGE-24       156.20n ± 1%    73.42n ± 0%  -53.00% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=1/keySize=10/Next-24          49.36n ± 0%    71.46n ± 0%  +44.77% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=1/keySize=128/SeekGE-24      171.00n ± 0%    80.19n ± 0%  -53.11% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=1/keySize=128/Next-24         54.04n ± 0%    71.32n ± 0%  +31.98% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=2/keySize=10/SeekGE-24       292.45n ± 1%    88.55n ± 0%  -69.72% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=2/keySize=10/Next-24          83.44n ± 0%   102.00n ± 0%  +22.25% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=2/keySize=128/SeekGE-24      325.20n ± 0%    95.70n ± 0%  -70.57% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=2/keySize=128/Next-24         95.14n ± 0%   102.20n ± 0%   +7.42% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=5/keySize=10/SeekGE-24        916.0n ± 1%    135.9n ± 0%  -85.16% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=5/keySize=10/Next-24          487.4n ± 1%    196.8n ± 0%  -59.64% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=5/keySize=128/SeekGE-24      1061.5n ± 1%    143.6n ± 0%  -86.47% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=5/keySize=128/Next-24         541.1n ± 0%    197.5n ± 0%  -63.50% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=1/keySize=10/SeekGE-24      3602.5n ± 0%    138.1n ± 0%  -96.17% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=1/keySize=10/Next-24       3608.50n ± 0%    69.97n ± 0%  -98.06% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=1/keySize=128/SeekGE-24     3687.0n ± 0%    154.1n ± 0%  -95.82% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=1/keySize=128/Next-24      3649.50n ± 0%    70.40n ± 0%  -98.07% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=2/keySize=10/SeekGE-24      3958.0n ± 0%    166.4n ± 0%  -95.80% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=2/keySize=10/Next-24        3700.0n ± 0%    100.8n ± 0%  -97.28% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=2/keySize=128/SeekGE-24     4091.5n ± 0%    182.5n ± 0%  -95.54% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=2/keySize=128/Next-24       3749.5n ± 0%    101.1n ± 0%  -97.30% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=5/keySize=10/SeekGE-24      5440.5n ± 1%    251.3n ± 0%  -95.38% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=5/keySize=10/Next-24        4626.0n ± 0%    196.6n ± 0%  -95.75% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=5/keySize=128/SeekGE-24     5756.0n ± 0%    267.6n ± 0%  -95.35% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=5/keySize=128/Next-24       4738.0n ± 0%    196.4n ± 0%  -95.85% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=1/keySize=10/SeekGE-24     5528.5n ± 0%    200.8n ± 0%  -96.37% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=1/keySize=10/Next-24      3611.00n ± 0%    70.10n ± 0%  -98.06% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=1/keySize=128/SeekGE-24    5909.0n ± 0%    227.2n ± 0%  -96.16% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=1/keySize=128/Next-24     3650.00n ± 0%    70.09n ± 0%  -98.08% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=2/keySize=10/SeekGE-24     7137.0n ± 0%    231.7n ± 0%  -96.75% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=2/keySize=10/Next-24       3697.5n ± 0%    101.0n ± 0%  -97.27% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=2/keySize=128/SeekGE-24    7847.5n ± 0%    258.7n ± 0%  -96.70% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=2/keySize=128/Next-24      3754.5n ± 0%    101.0n ± 0%  -97.31% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=5/keySize=10/SeekGE-24    12801.5n ± 0%    324.1n ± 0%  -97.47% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=5/keySize=10/Next-24       4644.5n ± 1%    195.8n ± 0%  -95.79% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=5/keySize=128/SeekGE-24   14830.5n ± 0%    352.1n ± 0%  -97.63% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=5/keySize=128/Next-24      4752.5n ± 1%    196.2n ± 0%  -95.87% (p=0.000 n=10)
geomean                                                                          1.746µ         137.7n       -92.11%

                                                                             │   old.log   │              newer.log              │
                                                                             │  bytes/row  │ bytes/row   vs base                 │
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=1/keySize=10/SeekGE-24       39.00 ± 0%   91.00 ± 0%  +133.33% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=1/keySize=10/Next-24         39.00 ± 0%   91.00 ± 0%  +133.33% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=1/keySize=128/SeekGE-24      277.0 ± 0%   331.0 ± 0%   +19.49% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=1/keySize=128/Next-24        277.0 ± 0%   331.0 ± 0%   +19.49% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=2/keySize=10/SeekGE-24       30.00 ± 0%   47.50 ± 0%   +58.33% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=2/keySize=10/Next-24         30.00 ± 0%   47.50 ± 0%   +58.33% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=2/keySize=128/SeekGE-24      209.0 ± 0%   167.5 ± 0%   -19.86% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=2/keySize=128/Next-24        209.0 ± 0%   167.5 ± 0%   -19.86% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=5/keySize=10/SeekGE-24       24.60 ± 0%   20.20 ± 0%   -17.89% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=5/keySize=10/Next-24         24.60 ± 0%   20.20 ± 0%   -17.89% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=5/keySize=128/SeekGE-24     168.20 ± 0%   68.20 ± 0%   -59.45% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=1/keysPerSpan=5/keySize=128/Next-24       168.20 ± 0%   68.20 ± 0%   -59.45% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=1/keySize=10/SeekGE-24      23.70 ± 0%   19.90 ± 0%   -16.03% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=1/keySize=10/Next-24        23.70 ± 0%   19.90 ± 0%   -16.03% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=1/keySize=128/SeekGE-24     154.6 ± 0%   151.0 ± 0%    -2.33% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=1/keySize=128/Next-24       154.6 ± 0%   151.0 ± 0%    -2.33% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=2/keySize=10/SeekGE-24      22.35 ± 0%   11.95 ± 0%   -46.53% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=2/keySize=10/Next-24        22.35 ± 0%   11.95 ± 0%   -46.53% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=2/keySize=128/SeekGE-24    147.80 ± 0%   77.55 ± 0%   -47.53% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=2/keySize=128/Next-24      147.80 ± 0%   77.55 ± 0%   -47.53% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=5/keySize=10/SeekGE-24     21.540 ± 0%   5.980 ± 0%   -72.24% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=5/keySize=10/Next-24       21.540 ± 0%   5.980 ± 0%   -72.24% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=5/keySize=128/SeekGE-24    143.70 ± 0%   32.22 ± 0%   -77.58% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=10/keysPerSpan=5/keySize=128/Next-24      143.70 ± 0%   32.22 ± 0%   -77.58% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=1/keySize=10/SeekGE-24     22.26 ± 0%   13.82 ± 0%   -37.92% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=1/keySize=10/Next-24       22.26 ± 0%   13.82 ± 0%   -37.92% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=1/keySize=128/SeekGE-24    142.4 ± 0%   133.0 ± 0%    -6.60% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=1/keySize=128/Next-24      142.4 ± 0%   133.0 ± 0%    -6.60% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=2/keySize=10/SeekGE-24    21.630 ± 0%   8.915 ± 0%   -58.78% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=2/keySize=10/Next-24      21.630 ± 0%   8.915 ± 0%   -58.78% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=2/keySize=128/SeekGE-24   141.70 ± 0%   68.50 ± 0%   -51.66% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=2/keySize=128/Next-24     141.70 ± 0%   68.50 ± 0%   -51.66% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=5/keySize=10/SeekGE-24    21.250 ± 0%   4.970 ± 0%   -76.61% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=5/keySize=10/Next-24      21.250 ± 0%   4.970 ± 0%   -76.61% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=5/keySize=128/SeekGE-24   141.30 ± 0%   28.81 ± 0%   -79.61% (p=0.000 n=10)
KeyspanBlock_RangeDeletions/numSpans=100/keysPerSpan=5/keySize=128/Next-24     141.30 ± 0%   28.81 ± 0%   -79.61% (p=0.000 n=10)
geomean                                                                         63.79        38.09        -40.29%
```