### PR TITLE
keyspan: add contexts to keyspan iterators

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -807,9 +807,8 @@ func (c *compaction) newInputIters(
 				}
 			}
 			if hasRangeKeys {
-				li := &keyspanimpl.LevelIter{}
-				newRangeKeyIterWrapper := func(file *manifest.FileMetadata, iterOptions keyspan.SpanIterOptions) (keyspan.FragmentIterator, error) {
-					rangeKeyIter, err := newRangeKeyIter(file, iterOptions)
+				newRangeKeyIterWrapper := func(ctx context.Context, file *manifest.FileMetadata, iterOptions keyspan.SpanIterOptions) (keyspan.FragmentIterator, error) {
+					rangeKeyIter, err := newRangeKeyIter(ctx, file, iterOptions)
 					if err != nil {
 						return nil, err
 					} else if rangeKeyIter == nil {
@@ -829,7 +828,10 @@ func (c *compaction) newInputIters(
 					// in this sstable must wholly lie within the file's bounds.
 					return noCloseIter, err
 				}
-				li.Init(keyspan.SpanIterOptions{}, c.cmp, newRangeKeyIterWrapper, level.files.Iter(), l, manifest.KeyTypeRange)
+				li := keyspanimpl.NewLevelIter(
+					context.Background(), keyspan.SpanIterOptions{}, c.cmp,
+					newRangeKeyIterWrapper, level.files.Iter(), l, manifest.KeyTypeRange,
+				)
 				rangeKeyIters = append(rangeKeyIters, li)
 			}
 			return nil

--- a/db_test.go
+++ b/db_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/fifo"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
+	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable"
@@ -1447,6 +1448,7 @@ func TestTracing(t *testing.T) {
 			}
 			db = testutils.CheckErr(Open("", &Options{
 				FS:              vfs.NewMem(),
+				Comparer:        testkeys.Comparer,
 				Cache:           cache,
 				LoggerAndTracer: &tracer,
 			}))

--- a/error_iter.go
+++ b/error_iter.go
@@ -90,6 +90,7 @@ func (i *errorKeyspanIter) First() (*keyspan.Span, error)            { return ni
 func (i *errorKeyspanIter) Last() (*keyspan.Span, error)             { return nil, i.err }
 func (i *errorKeyspanIter) Next() (*keyspan.Span, error)             { return nil, i.err }
 func (i *errorKeyspanIter) Prev() (*keyspan.Span, error)             { return nil, i.err }
+func (i *errorKeyspanIter) SetContext(ctx context.Context)           {}
 func (i *errorKeyspanIter) Close()                                   {}
 func (*errorKeyspanIter) String() string                             { return "error" }
 func (*errorKeyspanIter) WrapChildren(wrap keyspan.WrapFn)           {}

--- a/flushable.go
+++ b/flushable.go
@@ -233,9 +233,9 @@ func (s *ingestedFlushable) newFlushIter(*IterOptions) internalIterator {
 }
 
 func (s *ingestedFlushable) constructRangeDelIter(
-	file *manifest.FileMetadata, _ keyspan.SpanIterOptions,
+	ctx context.Context, file *manifest.FileMetadata, _ keyspan.SpanIterOptions,
 ) (keyspan.FragmentIterator, error) {
-	iters, err := s.newIters(context.Background(), file, nil, internalIterOpts{}, iterRangeDeletions)
+	iters, err := s.newIters(ctx, file, nil, internalIterOpts{}, iterRangeDeletions)
 	if err != nil {
 		return nil, err
 	}
@@ -250,6 +250,7 @@ func (s *ingestedFlushable) constructRangeDelIter(
 // the point iterator in constructRangeDeIter is not tracked.
 func (s *ingestedFlushable) newRangeDelIter(_ *IterOptions) keyspan.FragmentIterator {
 	return keyspanimpl.NewLevelIter(
+		context.TODO(),
 		keyspan.SpanIterOptions{}, s.comparer.Compare,
 		s.constructRangeDelIter, s.slice.Iter(), manifest.Level(0),
 		manifest.KeyTypePoint,
@@ -263,6 +264,7 @@ func (s *ingestedFlushable) newRangeKeyIter(o *IterOptions) keyspan.FragmentIter
 	}
 
 	return keyspanimpl.NewLevelIter(
+		context.TODO(),
 		keyspan.SpanIterOptions{}, s.comparer.Compare, s.newRangeKeyIters,
 		s.slice.Iter(), manifest.Level(0), manifest.KeyTypeRange,
 	)

--- a/internal/keyspan/assert_iter.go
+++ b/internal/keyspan/assert_iter.go
@@ -5,6 +5,7 @@
 package keyspan
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/cockroachdb/errors"
@@ -163,6 +164,11 @@ func (i *assertIter) Prev() (*Span, error) {
 	}
 	i.check(span)
 	return span, err
+}
+
+// SetContext is part of the FragmentIterator interface.
+func (i *assertIter) SetContext(ctx context.Context) {
+	i.iter.SetContext(ctx)
 }
 
 // Close implements FragmentIterator.

--- a/internal/keyspan/bounded.go
+++ b/internal/keyspan/bounded.go
@@ -5,6 +5,8 @@
 package keyspan
 
 import (
+	"context"
+
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/treeprinter"
 )
@@ -207,6 +209,11 @@ func (i *BoundedIter) Prev() (*Span, error) {
 // Close implements FragmentIterator.
 func (i *BoundedIter) Close() {
 	i.iter.Close()
+}
+
+// SetContext is part of the FragmentIterator interface.
+func (i *BoundedIter) SetContext(ctx context.Context) {
+	i.iter.SetContext(ctx)
 }
 
 // SetBounds modifies the FragmentIterator's bounds.

--- a/internal/keyspan/defragment.go
+++ b/internal/keyspan/defragment.go
@@ -6,6 +6,7 @@ package keyspan
 
 import (
 	"bytes"
+	"context"
 
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/bytealloc"
@@ -194,6 +195,11 @@ func (i *DefragmentingIter) Init(
 		method:               equal,
 		reduce:               reducer,
 	}
+}
+
+// SetContext is part of the FragmentIterator interface.
+func (i *DefragmentingIter) SetContext(ctx context.Context) {
+	i.iter.SetContext(ctx)
 }
 
 // Close closes the underlying iterators.

--- a/internal/keyspan/filter.go
+++ b/internal/keyspan/filter.go
@@ -5,6 +5,8 @@
 package keyspan
 
 import (
+	"context"
+
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/treeprinter"
 )
@@ -91,6 +93,11 @@ func (i *filteringIter) Prev() (*Span, error) {
 		return nil, err
 	}
 	return i.filter(s, -1)
+}
+
+// SetContext is part of the FragmentIterator interface.
+func (i *filteringIter) SetContext(ctx context.Context) {
+	i.iter.SetContext(ctx)
 }
 
 // Close implements FragmentIterator.

--- a/internal/keyspan/interleaving_iter.go
+++ b/internal/keyspan/interleaving_iter.go
@@ -1140,6 +1140,7 @@ func (i *InterleavingIter) SetBounds(lower, upper []byte) {
 // SetContext implements (base.InternalIterator).SetContext.
 func (i *InterleavingIter) SetContext(ctx context.Context) {
 	i.pointIter.SetContext(ctx)
+	i.keyspanIter.SetContext(ctx)
 }
 
 // DebugTree is part of the InternalIterator interface.

--- a/internal/keyspan/iter.go
+++ b/internal/keyspan/iter.go
@@ -5,6 +5,8 @@
 package keyspan
 
 import (
+	"context"
+
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/treeprinter"
 )
@@ -68,6 +70,10 @@ type FragmentIterator interface {
 	// function can call WrapChildren to recursively wrap an entire iterator
 	// stack. Used only for debug logging.
 	WrapChildren(wrap WrapFn)
+
+	// SetContext replaces the context provided at iterator creation, or the last
+	// one provided by SetContext.
+	SetContext(ctx context.Context)
 
 	base.IteratorDebug
 }
@@ -210,6 +216,9 @@ func (i *Iter) Prev() (*Span, error) {
 	}
 	return &i.spans[i.index], nil
 }
+
+// SetContext is part of the FragmentIterator interface.
+func (i *Iter) SetContext(ctx context.Context) {}
 
 // Close implements FragmentIterator.Close.
 func (i *Iter) Close() {}

--- a/internal/keyspan/keyspanimpl/level_iter_test.go
+++ b/internal/keyspan/keyspanimpl/level_iter_test.go
@@ -5,6 +5,7 @@
 package keyspanimpl
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -301,7 +302,7 @@ func TestLevelIterEquivalence(t *testing.T) {
 				metas = append(metas, meta)
 			}
 
-			tableNewIters := func(file *manifest.FileMetadata, iterOptions keyspan.SpanIterOptions) (keyspan.FragmentIterator, error) {
+			tableNewIters := func(ctx context.Context, file *manifest.FileMetadata, iterOptions keyspan.SpanIterOptions) (keyspan.FragmentIterator, error) {
 				return keyspan.NewIter(base.DefaultComparer.Compare, tc.levels[j][file.FileNum-1]), nil
 			}
 			// Add all the fileMetadatas to L6.
@@ -314,6 +315,7 @@ func TestLevelIterEquivalence(t *testing.T) {
 			v, err := b.Apply(nil, base.DefaultComparer, 0, 0)
 			require.NoError(t, err)
 			levelIter.Init(
+				context.Background(),
 				keyspan.SpanIterOptions{}, base.DefaultComparer.Compare, tableNewIters,
 				v.Levels[6].Iter(), 0, manifest.KeyTypeRange,
 			)
@@ -414,7 +416,7 @@ func TestLevelIter(t *testing.T) {
 					keyType = manifest.KeyTypePoint
 				}
 			}
-			tableNewIters := func(file *manifest.FileMetadata, _ keyspan.SpanIterOptions) (keyspan.FragmentIterator, error) {
+			tableNewIters := func(ctx context.Context, file *manifest.FileMetadata, _ keyspan.SpanIterOptions) (keyspan.FragmentIterator, error) {
 				f := files[file.FileNum-1]
 				if keyType == manifest.KeyTypePoint {
 					return keyspan.NewIter(cmp, f.rangeDels), nil
@@ -426,7 +428,7 @@ func TestLevelIter(t *testing.T) {
 				metas[i] = files[i].meta
 			}
 			lm := manifest.MakeLevelMetadata(cmp, 6, metas)
-			iter := NewLevelIter(keyspan.SpanIterOptions{}, cmp, tableNewIters, lm.Iter(), 6, keyType)
+			iter := NewLevelIter(context.Background(), keyspan.SpanIterOptions{}, cmp, tableNewIters, lm.Iter(), 6, keyType)
 			extraInfo := func() string {
 				return iter.String()
 			}

--- a/internal/keyspan/keyspanimpl/merging_iter.go
+++ b/internal/keyspan/keyspanimpl/merging_iter.go
@@ -7,6 +7,7 @@ package keyspanimpl
 import (
 	"bytes"
 	"cmp"
+	"context"
 	"fmt"
 	"slices"
 
@@ -674,6 +675,13 @@ func (m *MergingIter) Prev() (*keyspan.Span, error) {
 		}
 	}
 	return m.findPrevFragmentSet()
+}
+
+// SetContext is part of the FragmentIterator interface.
+func (m *MergingIter) SetContext(ctx context.Context) {
+	for i := range m.levels {
+		m.levels[i].iter.SetContext(ctx)
+	}
 }
 
 // Close closes the iterator, releasing all acquired resources.

--- a/internal/keyspan/logging_iter.go
+++ b/internal/keyspan/logging_iter.go
@@ -5,6 +5,7 @@
 package keyspan
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/cockroachdb/pebble/internal/base"
@@ -130,6 +131,11 @@ func (i *loggingIter) Prev() (*Span, error) {
 	span, err := i.iter.Prev()
 	opEnd(span, err)
 	return span, err
+}
+
+// SetContext is part of the FragmentIterator interface.
+func (i *loggingIter) SetContext(ctx context.Context) {
+	i.iter.SetContext(ctx)
 }
 
 // Close implements FragmentIterator.

--- a/internal/keyspan/test_utils.go
+++ b/internal/keyspan/test_utils.go
@@ -6,6 +6,7 @@ package keyspan
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"go/token"
 	"io"
@@ -365,6 +366,11 @@ func (p *probeIterator) Prev() (*Span, error) {
 	return p.handleOp(op)
 }
 
+// SetContext is part of the FragmentIterator interface.
+func (p *probeIterator) SetContext(ctx context.Context) {
+	p.iter.SetContext(ctx)
+}
+
 func (p *probeIterator) Close() {
 	op := op{Kind: OpClose}
 	if p.iter != nil {
@@ -560,6 +566,11 @@ func (i *invalidatingIter) First() (*Span, error)            { return i.invalida
 func (i *invalidatingIter) Last() (*Span, error)             { return i.invalidate(i.iter.Last()) }
 func (i *invalidatingIter) Next() (*Span, error)             { return i.invalidate(i.iter.Next()) }
 func (i *invalidatingIter) Prev() (*Span, error)             { return i.invalidate(i.iter.Prev()) }
+
+// SetContext is part of the FragmentIterator interface.
+func (i *invalidatingIter) SetContext(ctx context.Context) {
+	i.iter.SetContext(ctx)
+}
 
 func (i *invalidatingIter) Close() {
 	_, _ = i.invalidate(nil, nil)

--- a/internal/keyspan/truncate.go
+++ b/internal/keyspan/truncate.go
@@ -5,6 +5,8 @@
 package keyspan
 
 import (
+	"context"
+
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/treeprinter"
@@ -110,6 +112,11 @@ func (i *truncatingIter) Prev() (*Span, error) {
 	}
 	span, _, err = i.nextSpanWithinBounds(span, -1)
 	return span, err
+}
+
+// SetContext is part of the FragmentIterator interface.
+func (i *truncatingIter) SetContext(ctx context.Context) {
+	i.iter.SetContext(ctx)
 }
 
 // Close implements FragmentIterator.

--- a/keyspan_probe_test.go
+++ b/keyspan_probe_test.go
@@ -5,6 +5,7 @@
 package pebble
 
 import (
+	"context"
 	"fmt"
 	"go/token"
 	"io"
@@ -375,6 +376,11 @@ func (p *probeKeyspanIterator) DebugTree(tp treeprinter.Node) {
 	if p.iter != nil {
 		p.iter.DebugTree(n)
 	}
+}
+
+// SetContext is part of the FragmentIterator interface.
+func (p *probeKeyspanIterator) SetContext(ctx context.Context) {
+	p.iter.SetContext(ctx)
 }
 
 func (p *probeKeyspanIterator) Close() {

--- a/open.go
+++ b/open.go
@@ -401,7 +401,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 		opts.TableCache, d.cacheID, d.objProvider, d.opts, tableCacheSize,
 		&sstable.CategoryStatsCollector{})
 	d.newIters = d.tableCache.newIters
-	d.tableNewRangeKeyIter = tableNewRangeKeyIter(context.TODO(), d.newIters)
+	d.tableNewRangeKeyIter = tableNewRangeKeyIter(d.newIters)
 
 	var previousOptionsFileNum base.DiskFileNum
 	var previousOptionsFilename string

--- a/range_keys.go
+++ b/range_keys.go
@@ -92,6 +92,7 @@ func (i *Iterator) constructRangeKeyIter() {
 
 				li := i.rangeKey.iterConfig.NewLevelIter()
 				li.Init(
+					i.ctx,
 					i.opts.SpanIterOptions(),
 					i.cmp,
 					i.newIterRangeKey,
@@ -110,7 +111,7 @@ func (i *Iterator) constructRangeKeyIter() {
 			}
 			li := i.rangeKey.iterConfig.NewLevelIter()
 			spanIterOpts := i.opts.SpanIterOptions()
-			li.Init(spanIterOpts, i.cmp, i.newIterRangeKey, current.RangeKeyLevels[level].Iter(),
+			li.Init(i.ctx, spanIterOpts, i.cmp, i.newIterRangeKey, current.RangeKeyLevels[level].Iter(),
 				manifest.Level(level), manifest.KeyTypeRange)
 			i.rangeKey.iterConfig.AddLevel(li)
 		}

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -908,8 +908,8 @@ func (i *scanInternalIterator) constructPointIter(
 			i.ctx, i.opts.IterOptions, i.comparer, i.newIters, files, level,
 			internalIterOpts{})
 		mlevels[mlevelsIndex].iter = li
-		rli.Init(keyspan.SpanIterOptions{RangeKeyFilters: i.opts.RangeKeyFilters},
-			i.comparer.Compare, tableNewRangeDelIter(i.ctx, i.newIters), files, level,
+		rli.Init(i.ctx, keyspan.SpanIterOptions{RangeKeyFilters: i.opts.RangeKeyFilters},
+			i.comparer.Compare, tableNewRangeDelIter(i.newIters), files, level,
 			manifest.KeyTypePoint)
 		rangeDelIters = append(rangeDelIters, rli)
 
@@ -1030,7 +1030,7 @@ func (i *scanInternalIterator) constructRangeKeyIter() error {
 	// around Key InternalKeyTrailer order.
 	iter := current.RangeKeyLevels[0].Iter()
 	for f := iter.Last(); f != nil; f = iter.Prev() {
-		spanIter, err := i.newIterRangeKey(f, i.opts.SpanIterOptions())
+		spanIter, err := i.newIterRangeKey(i.ctx, f, i.opts.SpanIterOptions())
 		if err != nil {
 			return err
 		}
@@ -1065,7 +1065,7 @@ func (i *scanInternalIterator) constructRangeKeyIter() error {
 			levSlice := manifest.NewLevelSliceKeySorted(i.db.cmp, nonRemoteFiles)
 			levIter = levSlice.Iter()
 		}
-		li.Init(spanIterOpts, i.comparer.Compare, i.newIterRangeKey, levIter,
+		li.Init(i.ctx, spanIterOpts, i.comparer.Compare, i.newIterRangeKey, levIter,
 			manifest.Level(level), manifest.KeyTypeRange)
 		i.rangeKey.iterConfig.AddLevel(li)
 	}

--- a/sstable/rowblk/rowblk_fragment_iter.go
+++ b/sstable/rowblk/rowblk_fragment_iter.go
@@ -6,6 +6,7 @@ package rowblk
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"sync"
@@ -257,6 +258,9 @@ func (i *fragmentIter) gatherBackward(kv *base.InternalKV) (*keyspan.Span, error
 	i.applySpanTransforms()
 	return &i.span, nil
 }
+
+// SetContext is part of the FragmentIterator interface.
+func (i *fragmentIter) SetContext(ctx context.Context) {}
 
 // Close implements (keyspan.FragmentIterator).Close.
 func (i *fragmentIter) Close() {

--- a/table_cache.go
+++ b/table_cache.go
@@ -62,10 +62,8 @@ type tableNewIters func(
 
 // tableNewRangeDelIter takes a tableNewIters and returns a TableNewSpanIter
 // for the rangedel iterator returned by tableNewIters.
-func tableNewRangeDelIter(
-	ctx context.Context, newIters tableNewIters,
-) keyspanimpl.TableNewSpanIter {
-	return func(file *manifest.FileMetadata, iterOptions keyspan.SpanIterOptions) (keyspan.FragmentIterator, error) {
+func tableNewRangeDelIter(newIters tableNewIters) keyspanimpl.TableNewSpanIter {
+	return func(ctx context.Context, file *manifest.FileMetadata, iterOptions keyspan.SpanIterOptions) (keyspan.FragmentIterator, error) {
 		iters, err := newIters(ctx, file, nil, internalIterOpts{}, iterRangeDeletions)
 		if err != nil {
 			return nil, err
@@ -76,10 +74,8 @@ func tableNewRangeDelIter(
 
 // tableNewRangeKeyIter takes a tableNewIters and returns a TableNewSpanIter
 // for the range key iterator returned by tableNewIters.
-func tableNewRangeKeyIter(
-	ctx context.Context, newIters tableNewIters,
-) keyspanimpl.TableNewSpanIter {
-	return func(file *manifest.FileMetadata, iterOptions keyspan.SpanIterOptions) (keyspan.FragmentIterator, error) {
+func tableNewRangeKeyIter(newIters tableNewIters) keyspanimpl.TableNewSpanIter {
+	return func(ctx context.Context, file *manifest.FileMetadata, iterOptions keyspan.SpanIterOptions) (keyspan.FragmentIterator, error) {
 		iters, err := newIters(ctx, file, nil, internalIterOpts{}, iterRangeKeys)
 		if err != nil {
 			return nil, err

--- a/testdata/tracing
+++ b/testdata/tracing
@@ -7,8 +7,8 @@ hello
 ----
 reading footer of 53 bytes took 5ms
 reading block of 37 bytes took 5ms (<redacted>)
-reading block of 419 bytes took 5ms (<redacted>)
-reading block of 27 bytes took 5ms (<redacted>)
+reading block of 417 bytes took 5ms (<redacted>)
+reading block of 31 bytes took 5ms (<redacted>)
 reading block of 32 bytes took 5ms (<redacted>)
 hello:foo
 
@@ -21,20 +21,20 @@ hello:foo
 iter
 seek-ge hello
 ----
-reading block of 27 bytes took 5ms (<redacted>)
+reading block of 31 bytes took 5ms (<redacted>)
 reading block of 32 bytes took 5ms (<redacted>)
 hello: (foo, .)
 
 snapshot-iter
 seek-ge hello
 ----
-reading block of 27 bytes took 5ms (<redacted>)
+reading block of 31 bytes took 5ms (<redacted>)
 reading block of 32 bytes took 5ms (<redacted>)
 hello: (foo, .)
 
 indexed-batch-iter
 seek-ge hello
 ----
-reading block of 27 bytes took 5ms (<redacted>)
+reading block of 31 bytes took 5ms (<redacted>)
 reading block of 32 bytes took 5ms (<redacted>)
 hello: (foo, .)

--- a/testdata/tracing
+++ b/testdata/tracing
@@ -1,0 +1,40 @@
+build
+set hello foo
+----
+
+get
+hello
+----
+reading footer of 53 bytes took 5ms
+reading block of 37 bytes took 5ms (<redacted>)
+reading block of 419 bytes took 5ms (<redacted>)
+reading block of 27 bytes took 5ms (<redacted>)
+reading block of 32 bytes took 5ms (<redacted>)
+hello:foo
+
+# If we disable background tracing, we should see no traces with Get.
+get disable-background-tracing
+hello
+----
+hello:foo
+
+iter
+seek-ge hello
+----
+reading block of 27 bytes took 5ms (<redacted>)
+reading block of 32 bytes took 5ms (<redacted>)
+hello: (foo, .)
+
+snapshot-iter
+seek-ge hello
+----
+reading block of 27 bytes took 5ms (<redacted>)
+reading block of 32 bytes took 5ms (<redacted>)
+hello: (foo, .)
+
+indexed-batch-iter
+seek-ge hello
+----
+reading block of 27 bytes took 5ms (<redacted>)
+reading block of 32 bytes took 5ms (<redacted>)
+hello: (foo, .)

--- a/testdata/tracing
+++ b/testdata/tracing
@@ -38,3 +38,51 @@ seek-ge hello
 reading block of 31 bytes took 5ms (<redacted>)
 reading block of 32 bytes took 5ms (<redacted>)
 hello: (foo, .)
+
+build
+set hello@2 foo1
+range-key-set a z @4 foo2
+----
+
+# This operation should not read the range key block.
+get
+hello@2
+----
+reading footer of 53 bytes took 5ms
+reading block of 62 bytes took 5ms (<redacted>)
+reading block of 504 bytes took 5ms (<redacted>)
+reading block of 27 bytes took 5ms (<redacted>)
+reading block of 35 bytes took 5ms (<redacted>)
+hello@2:foo1
+
+# These operations should read the range key block, which shows up as a third
+# log.
+iter
+seek-ge hello
+next
+----
+reading block of 27 bytes took 5ms (<redacted>)
+reading block of 35 bytes took 5ms (<redacted>)
+reading block of 35 bytes took 5ms (<redacted>)
+hello: (., [a-z) @4=foo2 UPDATED)
+hello@2: (foo1, [a-z) @4=foo2)
+
+snapshot-iter
+seek-ge hello
+next
+----
+reading block of 27 bytes took 5ms (<redacted>)
+reading block of 35 bytes took 5ms (<redacted>)
+reading block of 35 bytes took 5ms (<redacted>)
+hello: (., [a-z) @4=foo2 UPDATED)
+hello@2: (foo1, [a-z) @4=foo2)
+
+indexed-batch-iter
+seek-ge hello
+next
+----
+reading block of 27 bytes took 5ms (<redacted>)
+reading block of 35 bytes took 5ms (<redacted>)
+reading block of 35 bytes took 5ms (<redacted>)
+hello: (., [a-z) @4=foo2 UPDATED)
+hello@2: (foo1, [a-z) @4=foo2)


### PR DESCRIPTION
Informs #3728

#### db: convert TestTracing to datadriven

Rewrite this test to use `datadriven`. This will make it much easier
to update and extend.

#### keyspan: add contexts to keyspan iterators

This change adds a `SetContext()` method to `FragmentIterator` which
updates any context stored in an iterator and its children. The
iterator context is now plumbed correctly through to the table range
key iterators.