### PR TITLE
crl-release-24.1: db: don't load large filter blocks for flushable ingests

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -409,6 +409,23 @@ func runBatchDefineCmd(d *datadriven.TestData, b *Batch) error {
 				return errors.Errorf("%s expects 2 arguments", parts[0])
 			}
 			err = b.Set([]byte(parts[1]), []byte(parts[2]), nil)
+
+		case "set-multiple":
+			if len(parts) != 3 {
+				return errors.Errorf("%s expects 2 arguments (n and prefix)", parts[0])
+			}
+			n, err := strconv.ParseUint(parts[1], 10, 32)
+			if err != nil {
+				return err
+			}
+			for i := uint64(0); i < n; i++ {
+				key := fmt.Sprintf("%s-%05d", parts[2], i)
+				val := fmt.Sprintf("val-%05d", i)
+				if err := b.Set([]byte(key), []byte(val), nil); err != nil {
+					return err
+				}
+			}
+
 		case "del":
 			if len(parts) != 2 {
 				return errors.Errorf("%s expects 1 argument", parts[0])

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -205,7 +205,7 @@ func createExternalPointIter(ctx context.Context, it *Iterator) (topLevelIterato
 			seqNum--
 			pointIter, err = r.NewIterWithBlockPropertyFiltersAndContextEtc(
 				ctx, transforms, it.opts.LowerBound, it.opts.UpperBound, nil, /* BlockPropertiesFilterer */
-				false, /* useFilterBlock */
+				sstable.NeverUseFilterBlock,
 				&it.stats.InternalStats, it.opts.CategoryAndQoS, nil,
 				sstable.TrivialReaderProvider{Reader: r})
 			if err != nil {

--- a/external_iterator_test.go
+++ b/external_iterator_test.go
@@ -241,7 +241,7 @@ func TestIterRandomizedMaybeFilteredKeys(t *testing.T) {
 
 			var iter sstable.Iterator
 			iter, err = r.NewIterWithBlockPropertyFilters(
-				sstable.NoTransforms, nil, nil, filterer, false /* useFilterBlock */, nil, /* stats */
+				sstable.NoTransforms, nil, nil, filterer, sstable.NeverUseFilterBlock, nil, /* stats */
 				sstable.CategoryAndQoS{}, nil, sstable.TrivialReaderProvider{Reader: r})
 			require.NoError(t, err)
 			defer iter.Close()

--- a/flushable.go
+++ b/flushable.go
@@ -215,12 +215,8 @@ func (s *ingestedFlushable) newIter(o *IterOptions) internalIterator {
 	if o != nil {
 		opts = *o
 	}
-	// TODO(bananabrick): The manifest.Level in newLevelIter is only used for
-	// logging. Update the manifest.Level encoding to account for levels which
-	// aren't truly levels in the lsm. Right now, the encoding only supports
-	// L0 sublevels, and the rest of the levels in the lsm.
 	return newLevelIter(
-		context.Background(), opts, s.comparer, s.newIters, s.slice.Iter(), manifest.Level(0),
+		context.Background(), opts, s.comparer, s.newIters, s.slice.Iter(), manifest.FlushableIngestLevel(),
 		internalIterOpts{},
 	)
 }
@@ -258,7 +254,7 @@ func (s *ingestedFlushable) constructRangeDelIter(
 func (s *ingestedFlushable) newRangeDelIter(_ *IterOptions) keyspan.FragmentIterator {
 	return keyspanimpl.NewLevelIter(
 		keyspan.SpanIterOptions{}, s.comparer.Compare,
-		s.constructRangeDelIter, s.slice.Iter(), manifest.Level(0),
+		s.constructRangeDelIter, s.slice.Iter(), manifest.FlushableIngestLevel(),
 		manifest.KeyTypePoint,
 	)
 }
@@ -271,7 +267,7 @@ func (s *ingestedFlushable) newRangeKeyIter(o *IterOptions) keyspan.FragmentIter
 
 	return keyspanimpl.NewLevelIter(
 		keyspan.SpanIterOptions{}, s.comparer.Compare, s.newRangeKeyIters,
-		s.slice.Iter(), manifest.Level(0), manifest.KeyTypeRange,
+		s.slice.Iter(), manifest.FlushableIngestLevel(), manifest.KeyTypeRange,
 	)
 }
 

--- a/internal/manifest/level.go
+++ b/internal/manifest/level.go
@@ -7,25 +7,33 @@ package manifest
 import "fmt"
 
 const (
-	// 3 bits are necessary to represent level values from 0-6.
+	// 3 bits are necessary to represent level values from 0-6 or 7 for flushable
+	// ingests.
 	levelBits = 3
 	levelMask = (1 << levelBits) - 1
 	// invalidSublevel denotes an invalid or non-applicable sublevel.
-	invalidSublevel = -1
+	invalidSublevel           = -1
+	flushableIngestLevelValue = 7
 )
 
-// Level encodes a level and optional sublevel for use in log and error
-// messages. The encoding has the property that Level(0) ==
-// L0Sublevel(invalidSublevel).
+// Level encodes a level and optional sublevel. It can also represent the
+// conceptual layer of flushable ingests as "level" -1.
+//
+// The encoding has the property that Level(0) == L0Sublevel(invalidSublevel).
 type Level uint32
 
 func makeLevel(level, sublevel int) Level {
 	return Level(((sublevel + 1) << levelBits) | level)
 }
 
-// LevelToInt returns the int representation of a Level
+// LevelToInt returns the int representation of a Level. Returns -1 if the Level
+// refers to the flushable ingests pseudo-level.
 func LevelToInt(l Level) int {
-	return int(l) & levelMask
+	l &= levelMask
+	if l == flushableIngestLevelValue {
+		return -1
+	}
+	return int(l)
 }
 
 // L0Sublevel returns a Level representing the specified L0 sublevel.
@@ -36,11 +44,26 @@ func L0Sublevel(sublevel int) Level {
 	return makeLevel(0, sublevel)
 }
 
+// FlushableIngestLevel returns a Level that represents the flushable ingests
+// pseudo-level.
+func FlushableIngestLevel() Level {
+	return makeLevel(flushableIngestLevelValue, invalidSublevel)
+}
+
+// FlushableIngestLevel returns true if l represents the flushable ingests
+// pseudo-level.
+func (l Level) FlushableIngestLevel() bool {
+	return LevelToInt(l) == -1
+}
+
 func (l Level) String() string {
 	level := int(l) & levelMask
 	sublevel := (int(l) >> levelBits) - 1
 	if sublevel != invalidSublevel {
 		return fmt.Sprintf("L%d.%d", level, sublevel)
+	}
+	if level == flushableIngestLevelValue {
+		return "flushable-ingest"
 	}
 	return fmt.Sprintf("L%d", level)
 }

--- a/internal/manifest/level_test.go
+++ b/internal/manifest/level_test.go
@@ -5,7 +5,6 @@
 package manifest
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,51 +12,27 @@ import (
 
 func TestLevel(t *testing.T) {
 	testCases := []struct {
-		level    int
+		level    Level
 		expected string
 	}{
-		{0, "L0"},
-		{1, "L1"},
-		{2, "L2"},
-		{3, "L3"},
-		{4, "L4"},
-		{5, "L5"},
-		{6, "L6"},
-		{7, "L7"},
+		{Level(0), "L0"},
+		{Level(1), "L1"},
+		{Level(2), "L2"},
+		{Level(3), "L3"},
+		{Level(4), "L4"},
+		{Level(5), "L5"},
+		{Level(6), "L6"},
+
+		{L0Sublevel(0), "L0.0"},
+		{L0Sublevel(1), "L0.1"},
+		{L0Sublevel(2), "L0.2"},
+
+		{FlushableIngestLevel(), "flushable-ingest"},
 	}
 
 	for _, c := range testCases {
-		t.Run("", func(t *testing.T) {
-			s := Level(c.level).String()
-			require.EqualValues(t, c.expected, s)
-		})
-	}
-}
-
-func TestL0Sublevel(t *testing.T) {
-	testCases := []struct {
-		level    int
-		sublevel int
-		expected string
-	}{
-		{0, 0, "L0.0"},
-		{0, 1, "L0.1"},
-		{0, 2, "L0.2"},
-		{0, 1000, "L0.1000"},
-		{0, -1, "invalid L0 sublevel: -1"},
-		{0, -2, "invalid L0 sublevel: -2"},
-	}
-
-	for _, c := range testCases {
-		t.Run("", func(t *testing.T) {
-			s := func() (result string) {
-				defer func() {
-					if r := recover(); r != nil {
-						result = fmt.Sprint(r)
-					}
-				}()
-				return L0Sublevel(c.sublevel).String()
-			}()
+		t.Run(c.expected, func(t *testing.T) {
+			s := c.level.String()
 			require.EqualValues(t, c.expected, s)
 		})
 	}

--- a/iterator.go
+++ b/iterator.go
@@ -839,7 +839,10 @@ func (i *Iterator) sampleRead() {
 		return
 	}
 	if len(mi.levels) > 1 {
-		mi.ForEachLevelIter(func(li *levelIter) bool {
+		mi.ForEachLevelIter(func(li *levelIter) (done bool) {
+			if li.level.FlushableIngestLevel() {
+				return false
+			}
 			l := manifest.LevelToInt(li.level)
 			if f := li.iterFile; f != nil {
 				var containsKey bool

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -168,7 +168,7 @@ func (lt *levelIterTest) newIters(
 	transforms := file.IterTransforms()
 	iter, err := lt.readers[file.FileNum].NewIterWithBlockPropertyFiltersAndContextEtc(
 		ctx, transforms,
-		opts.LowerBound, opts.UpperBound, nil, true /* useFilterBlock */, iio.stats, sstable.CategoryAndQoS{},
+		opts.LowerBound, opts.UpperBound, nil, sstable.AlwaysUseFilterBlock, iio.stats, sstable.CategoryAndQoS{},
 		nil, sstable.TrivialReaderProvider{Reader: lt.readers[file.FileNum]})
 	if err != nil {
 		return iterSet{}, err

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -172,7 +172,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 			}
 			iter, err := r.NewIterWithBlockPropertyFilters(
 				sstable.NoTransforms,
-				opts.GetLowerBound(), opts.GetUpperBound(), nil, true /* useFilterBlock */, iio.stats,
+				opts.GetLowerBound(), opts.GetUpperBound(), nil, sstable.AlwaysUseFilterBlock, iio.stats,
 				sstable.CategoryAndQoS{}, nil, sstable.TrivialReaderProvider{Reader: r})
 			if err != nil {
 				return iterSet{}, err

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -1023,7 +1023,7 @@ func TestBlockProperties(t *testing.T) {
 				return "filter excludes entire table"
 			}
 			iter, err := r.NewIterWithBlockPropertyFilters(
-				NoTransforms, lower, upper, filterer, false /* useFilterBlock */, &stats,
+				NoTransforms, lower, upper, filterer, NeverUseFilterBlock, &stats,
 				CategoryAndQoS{}, nil, TrivialReaderProvider{Reader: r})
 			if err != nil {
 				return err.Error()
@@ -1108,7 +1108,7 @@ func TestBlockProperties_BoundLimited(t *testing.T) {
 				return "filter excludes entire table"
 			}
 			iter, err := r.NewIterWithBlockPropertyFilters(
-				NoTransforms, lower, upper, filterer, false /* useFilterBlock */, &stats,
+				NoTransforms, lower, upper, filterer, NeverUseFilterBlock, &stats,
 				CategoryAndQoS{}, nil, TrivialReaderProvider{Reader: r})
 			if err != nil {
 				return err.Error()

--- a/sstable/random_test.go
+++ b/sstable/random_test.go
@@ -95,11 +95,15 @@ func runErrorInjectionTest(t *testing.T, seed int64) {
 	// point keys only. Should we add variants of this test that run random
 	// operations on the range deletion and range key iterators?
 	var stats base.InternalIteratorStats
+	filterBlockSizeLimit := AlwaysUseFilterBlock
+	if rng.Intn(2) == 1 {
+		filterBlockSizeLimit = NeverUseFilterBlock
+	}
 	it, err := r.NewIterWithBlockPropertyFilters(
 		NoTransforms,
 		nil /* lower TODO */, nil, /* upper TODO */
 		filterer,
-		rng.Intn(2) == 1, /* use filter block */
+		filterBlockSizeLimit,
 		&stats,
 		CategoryAndQoS{},
 		nil, /* CategoryStatsCollector */

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -291,14 +291,14 @@ func (r *Reader) NewIterWithBlockPropertyFilters(
 	transforms IterTransforms,
 	lower, upper []byte,
 	filterer *BlockPropertiesFilterer,
-	useFilterBlock bool,
+	filterBlockSizeLimit FilterBlockSizeLimit,
 	stats *base.InternalIteratorStats,
 	categoryAndQoS CategoryAndQoS,
 	statsCollector *CategoryStatsCollector,
 	rp ReaderProvider,
 ) (Iterator, error) {
 	return r.newIterWithBlockPropertyFiltersAndContext(
-		context.Background(), transforms, lower, upper, filterer, useFilterBlock,
+		context.Background(), transforms, lower, upper, filterer, filterBlockSizeLimit,
 		stats, categoryAndQoS, statsCollector, rp, nil)
 }
 
@@ -314,14 +314,14 @@ func (r *Reader) NewIterWithBlockPropertyFiltersAndContextEtc(
 	transforms IterTransforms,
 	lower, upper []byte,
 	filterer *BlockPropertiesFilterer,
-	useFilterBlock bool,
+	filterBlockSizeLimit FilterBlockSizeLimit,
 	stats *base.InternalIteratorStats,
 	categoryAndQoS CategoryAndQoS,
 	statsCollector *CategoryStatsCollector,
 	rp ReaderProvider,
 ) (Iterator, error) {
 	return r.newIterWithBlockPropertyFiltersAndContext(
-		ctx, transforms, lower, upper, filterer, useFilterBlock,
+		ctx, transforms, lower, upper, filterer, filterBlockSizeLimit,
 		stats, categoryAndQoS, statsCollector, rp, nil)
 }
 
@@ -346,7 +346,7 @@ func (r *Reader) newIterWithBlockPropertyFiltersAndContext(
 	transforms IterTransforms,
 	lower, upper []byte,
 	filterer *BlockPropertiesFilterer,
-	useFilterBlock bool,
+	filterBlockSizeLimit FilterBlockSizeLimit,
 	stats *base.InternalIteratorStats,
 	categoryAndQoS CategoryAndQoS,
 	statsCollector *CategoryStatsCollector,
@@ -358,7 +358,7 @@ func (r *Reader) newIterWithBlockPropertyFiltersAndContext(
 	// until the final iterator closes.
 	if r.Properties.IndexType == twoLevelIndex {
 		i := twoLevelIterPool.Get().(*twoLevelIterator)
-		err := i.init(ctx, r, vState, transforms, lower, upper, filterer, useFilterBlock,
+		err := i.init(ctx, r, vState, transforms, lower, upper, filterer, filterBlockSizeLimit,
 			stats, categoryAndQoS, statsCollector, rp, nil /* bufferPool */)
 		if err != nil {
 			return nil, err
@@ -367,7 +367,7 @@ func (r *Reader) newIterWithBlockPropertyFiltersAndContext(
 	}
 
 	i := singleLevelIterPool.Get().(*singleLevelIterator)
-	err := i.init(ctx, r, vState, transforms, lower, upper, filterer, useFilterBlock,
+	err := i.init(ctx, r, vState, transforms, lower, upper, filterer, filterBlockSizeLimit,
 		stats, categoryAndQoS, statsCollector, rp, nil /* bufferPool */)
 	if err != nil {
 		return nil, err
@@ -380,8 +380,10 @@ func (r *Reader) newIterWithBlockPropertyFiltersAndContext(
 // must only be used when the Reader is guaranteed to outlive any LazyValues
 // returned from the iter.
 func (r *Reader) NewIter(transforms IterTransforms, lower, upper []byte) (Iterator, error) {
+	// TODO(radu): we should probably not use bloom filters in this case, as there
+	// likely isn't a cache set up.
 	return r.NewIterWithBlockPropertyFilters(
-		transforms, lower, upper, nil, true, /* useFilterBlock */
+		transforms, lower, upper, nil, AlwaysUseFilterBlock,
 		nil /* stats */, CategoryAndQoS{}, nil /* statsCollector */, TrivialReaderProvider{Reader: r})
 }
 
@@ -416,7 +418,7 @@ func (r *Reader) newCompactionIter(
 		err := i.init(
 			context.Background(),
 			r, vState, transforms, nil /* lower */, nil /* upper */, nil,
-			false /* useFilter */, nil /* stats */, categoryAndQoS, statsCollector, rp, bufferPool,
+			NeverUseFilterBlock, nil /* stats */, categoryAndQoS, statsCollector, rp, bufferPool,
 		)
 		if err != nil {
 			return nil, err
@@ -430,7 +432,7 @@ func (r *Reader) newCompactionIter(
 	i := singleLevelIterPool.Get().(*singleLevelIterator)
 	err := i.init(
 		context.Background(), r, vState, transforms, nil /* lower */, nil, /* upper */
-		nil, false /* useFilter */, nil /* stats */, categoryAndQoS, statsCollector, rp, bufferPool,
+		nil, NeverUseFilterBlock, nil /* stats */, categoryAndQoS, statsCollector, rp, bufferPool,
 	)
 	if err != nil {
 		return nil, err

--- a/sstable/reader_common.go
+++ b/sstable/reader_common.go
@@ -6,6 +6,7 @@ package sstable
 
 import (
 	"context"
+	"math"
 
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/keyspan"
@@ -24,7 +25,7 @@ type CommonReader interface {
 		transforms IterTransforms,
 		lower, upper []byte,
 		filterer *BlockPropertiesFilterer,
-		useFilterBlock bool,
+		filterBlockSizeLimit FilterBlockSizeLimit,
 		stats *base.InternalIteratorStats,
 		categoryAndQoS CategoryAndQoS,
 		statsCollector *CategoryStatsCollector,
@@ -44,6 +45,18 @@ type CommonReader interface {
 
 	CommonProperties() *CommonProperties
 }
+
+// FilterBlockSizeLimit is a size limit for bloom filter blocks - if a bloom
+// filter is present, it is used only when it is at most this size.
+type FilterBlockSizeLimit uint32
+
+const (
+	// NeverUseFilterBlock indicates that bloom filter blocks should never be used.
+	NeverUseFilterBlock FilterBlockSizeLimit = 0
+	// AlwaysUseFilterBlock indicates that bloom filter blocks should always be
+	// used, regardless of size.
+	AlwaysUseFilterBlock FilterBlockSizeLimit = math.MaxUint32
+)
 
 // IterTransforms allow on-the-fly transformation of data at iteration time.
 //

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -439,7 +439,7 @@ func runVirtualReaderTest(t *testing.T, path string, blockSize, indexBlockSize i
 			}
 
 			iter, err := v.NewIterWithBlockPropertyFiltersAndContextEtc(
-				context.Background(), transforms, lower, upper, filterer, false,
+				context.Background(), transforms, lower, upper, filterer, NeverUseFilterBlock,
 				&stats, CategoryAndQoS{}, nil, TrivialReaderProvider{Reader: r})
 			if err != nil {
 				return err.Error()
@@ -808,7 +808,7 @@ func runTestReader(t *testing.T, o WriterOptions, dir string, r *Reader, printVa
 					nil, /* lower */
 					nil, /* upper */
 					filterer,
-					true, /* use filter block */
+					AlwaysUseFilterBlock,
 					&stats,
 					CategoryAndQoS{},
 					nil,
@@ -1361,7 +1361,7 @@ func TestRandomizedPrefixSuffixRewriter(t *testing.T) {
 			context.Background(),
 			IterTransforms{SyntheticSuffix: syntheticSuffix, SyntheticPrefix: syntheticPrefix},
 			nil, nil, nil,
-			true, nil, CategoryAndQoS{}, nil,
+			AlwaysUseFilterBlock, nil, CategoryAndQoS{}, nil,
 			TrivialReaderProvider{Reader: eReader}, &virtualState{
 				lower: base.MakeInternalKey([]byte("_"), base.InternalKeySeqNumMax, base.InternalKeyKindSet),
 				upper: base.MakeRangeDeleteSentinelKey([]byte("~~~~~~~~~~~~~~~~")),
@@ -2447,7 +2447,7 @@ func BenchmarkIteratorScanObsolete(b *testing.B) {
 								transforms := IterTransforms{HideObsoletePoints: hideObsoletePoints}
 								iter, err := r.NewIterWithBlockPropertyFiltersAndContextEtc(
 									context.Background(), transforms, nil, nil, filterer,
-									true, nil, CategoryAndQoS{}, nil,
+									AlwaysUseFilterBlock, nil, CategoryAndQoS{}, nil,
 									TrivialReaderProvider{Reader: r})
 								require.NoError(b, err)
 								b.ResetTimer()

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -110,14 +110,14 @@ func (v *VirtualReader) NewIterWithBlockPropertyFiltersAndContextEtc(
 	transforms IterTransforms,
 	lower, upper []byte,
 	filterer *BlockPropertiesFilterer,
-	useFilterBlock bool,
+	filterBlockSizeLimit FilterBlockSizeLimit,
 	stats *base.InternalIteratorStats,
 	categoryAndQoS CategoryAndQoS,
 	statsCollector *CategoryStatsCollector,
 	rp ReaderProvider,
 ) (Iterator, error) {
 	return v.reader.newIterWithBlockPropertyFiltersAndContext(
-		ctx, transforms, lower, upper, filterer, useFilterBlock,
+		ctx, transforms, lower, upper, filterer, filterBlockSizeLimit,
 		stats, categoryAndQoS, statsCollector, rp, &v.vState)
 }
 

--- a/table_cache.go
+++ b/table_cache.go
@@ -546,6 +546,10 @@ func (c *tableCacheShard) newIters(
 	return iters, nil
 }
 
+// For flushable ingests, we decide whether to use the bloom filter base on
+// size.
+const filterBlockSizeLimitForFlushableIngests = 64 * 1024
+
 // newPointIter is an internal helper that constructs a point iterator over a
 // sstable. This function is for internal use only, and callers should use
 // newIters instead.
@@ -607,9 +611,17 @@ func (c *tableCacheShard) newPointIter(
 	}
 
 	var iter sstable.Iterator
-	useFilter := true
+	filterBlockSizeLimit := sstable.AlwaysUseFilterBlock
 	if opts != nil {
-		useFilter = manifest.LevelToInt(opts.level) != 6 || opts.UseL6Filters
+		// By default, we don't use block filters for L6 and restrict the size for
+		// flushable ingests, as these blocks can be very big.
+		if !opts.UseL6Filters {
+			if opts.level == manifest.Level(6) {
+				filterBlockSizeLimit = sstable.NeverUseFilterBlock
+			} else if opts.level.FlushableIngestLevel() {
+				filterBlockSizeLimit = filterBlockSizeLimitForFlushableIngests
+			}
+		}
 		ctx = objiotracing.WithLevel(ctx, manifest.LevelToInt(opts.level))
 	}
 	tableFormat, err := v.reader.TableFormat()
@@ -640,7 +652,7 @@ func (c *tableCacheShard) newPointIter(
 			internalOpts.bufferPool)
 	} else {
 		iter, err = cr.NewIterWithBlockPropertyFiltersAndContextEtc(
-			ctx, transforms, opts.GetLowerBound(), opts.GetUpperBound(), filterer, useFilter,
+			ctx, transforms, opts.GetLowerBound(), opts.GetUpperBound(), filterer, filterBlockSizeLimit,
 			internalOpts.stats, categoryAndQoS, dbOpts.sstStatsCollector, rp)
 	}
 	if err != nil {

--- a/testdata/flushable_ingest
+++ b/testdata/flushable_ingest
@@ -618,3 +618,82 @@ L0.1:
   000004:[a#12,SET-b#12,SET]
 L0.0:
   000007:[a#10,SET-b#11,SET]
+
+close
+----
+
+reset
+----
+
+build small
+set-multiple 10 small
+----
+
+build large
+set-multiple 100000 large
+----
+
+batch
+set small-00001 before-ingest
+set large-00001 before-ingest
+----
+
+blockFlush
+----
+
+ingest small large
+----
+
+allowFlush
+----
+
+# When looking inside the small table, we will read the index block, then we
+# should read the bloom filter, followed by a data block read.
+#
+# The extra index block reads are due to inefficiencies of the iterator
+# implementations (fixed in later versions).
+iter with-fs-logging
+seek-prefix-ge small-00001
+----
+read-at(194, 27): 000004.sst
+read-at(120, 74): 000004.sst
+read-at(0, 120): 000004.sst
+read-at(194, 27): 000004.sst
+read-at(194, 27): 000004.sst
+small-00001: (val-00001, .)
+
+# When the key doesn't pass the bloom filter, we should not see the data block
+# read at offset 0.
+iter with-fs-logging
+seek-prefix-ge small-00001-does-not-exist
+----
+read-at(194, 27): 000004.sst
+read-at(120, 74): 000004.sst
+read-at(194, 27): 000004.sst
+.
+
+# When looking inside the large table, we will not read the bloom filter which
+# is large. We read the top-level index block, a second-level index block, and a
+# data block.
+iter with-fs-logging
+seek-prefix-ge large-00001
+----
+read-at(775373, 117): 000005.sst
+read-at(765608, 2268): 000005.sst
+read-at(0, 1114): 000005.sst
+read-at(775373, 117): 000005.sst
+read-at(194, 27): 000004.sst
+read-at(775373, 117): 000005.sst
+read-at(194, 27): 000004.sst
+large-00001: (val-00001, .)
+
+# We still read the data block (at offset 0) for a key that doesn't exist.
+iter with-fs-logging
+seek-prefix-ge large-00001-does-not-exist
+----
+read-at(775373, 117): 000005.sst
+read-at(765608, 2268): 000005.sst
+read-at(0, 1114): 000005.sst
+read-at(775373, 117): 000005.sst
+read-at(194, 27): 000004.sst
+.


### PR DESCRIPTION
We have seen cases where a very large file is ingested as flushable,
and reads block on loading a very large bloom filter.

This PR sets a size limit of 64KB for bloom filter blocks for ingested
flushables. We achieve this by extending `manifest.Level` to be able
to represent flushable ingests as a "pseudo-level" and changing the
`useFilterBlock` flag for new iterator creation to a
`filterBlockSizeLimit` value.

Fixes #3787