### PR TITLE
crl-release-23.2: db: don't load large filter blocks for flushable ingests

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -545,6 +545,23 @@ func runBatchDefineCmd(d *datadriven.TestData, b *Batch) error {
 				return errors.Errorf("%s expects 2 arguments", parts[0])
 			}
 			err = b.Set([]byte(parts[1]), []byte(parts[2]), nil)
+
+		case "set-multiple":
+			if len(parts) != 3 {
+				return errors.Errorf("%s expects 2 arguments (n and prefix)", parts[0])
+			}
+			n, err := strconv.ParseUint(parts[1], 10, 32)
+			if err != nil {
+				return err
+			}
+			for i := uint64(0); i < n; i++ {
+				key := fmt.Sprintf("%s-%05d", parts[2], i)
+				val := fmt.Sprintf("val-%05d", i)
+				if err := b.Set([]byte(key), []byte(val), nil); err != nil {
+					return err
+				}
+			}
+
 		case "del":
 			if len(parts) != 2 {
 				return errors.Errorf("%s expects 1 argument", parts[0])

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -216,7 +216,7 @@ func createExternalPointIter(ctx context.Context, it *Iterator) (internalIterato
 			// BlockPropertiesFilterer that includes obsoleteKeyBlockPropertyFilter.
 			pointIter, err = r.NewIterWithBlockPropertyFiltersAndContextEtc(
 				ctx, it.opts.LowerBound, it.opts.UpperBound, nil, /* BlockPropertiesFilterer */
-				false /* hideObsoletePoints */, false, /* useFilterBlock */
+				false /* hideObsoletePoints */, sstable.NeverUseFilterBlock,
 				&it.stats.InternalStats, sstable.TrivialReaderProvider{Reader: r})
 			if err != nil {
 				return nil, err

--- a/external_iterator_test.go
+++ b/external_iterator_test.go
@@ -242,7 +242,7 @@ func TestIterRandomizedMaybeFilteredKeys(t *testing.T) {
 
 			var iter sstable.Iterator
 			iter, err = r.NewIterWithBlockPropertyFilters(
-				nil, nil, filterer, false /* useFilterBlock */, nil, /* stats */
+				nil, nil, filterer, sstable.NeverUseFilterBlock, nil, /* stats */
 				sstable.TrivialReaderProvider{Reader: r})
 			require.NoError(t, err)
 			defer iter.Close()

--- a/flushable.go
+++ b/flushable.go
@@ -165,12 +165,8 @@ func (s *ingestedFlushable) newIter(o *IterOptions) internalIterator {
 	if o != nil {
 		opts = *o
 	}
-	// TODO(bananabrick): The manifest.Level in newLevelIter is only used for
-	// logging. Update the manifest.Level encoding to account for levels which
-	// aren't truly levels in the lsm. Right now, the encoding only supports
-	// L0 sublevels, and the rest of the levels in the lsm.
 	return newLevelIter(
-		opts, s.comparer, s.newIters, s.slice.Iter(), manifest.Level(0), internalIterOpts{},
+		opts, s.comparer, s.newIters, s.slice.Iter(), manifest.FlushableIngestLevel(), internalIterOpts{},
 	)
 }
 
@@ -204,7 +200,7 @@ func (s *ingestedFlushable) constructRangeDelIter(
 func (s *ingestedFlushable) newRangeDelIter(_ *IterOptions) keyspan.FragmentIterator {
 	return keyspan.NewLevelIter(
 		keyspan.SpanIterOptions{}, s.comparer.Compare,
-		s.constructRangeDelIter, s.slice.Iter(), manifest.Level(0),
+		s.constructRangeDelIter, s.slice.Iter(), manifest.FlushableIngestLevel(),
 		manifest.KeyTypePoint,
 	)
 }
@@ -217,7 +213,7 @@ func (s *ingestedFlushable) newRangeKeyIter(o *IterOptions) keyspan.FragmentIter
 
 	return keyspan.NewLevelIter(
 		keyspan.SpanIterOptions{}, s.comparer.Compare, s.newRangeKeyIters,
-		s.slice.Iter(), manifest.Level(0), manifest.KeyTypeRange,
+		s.slice.Iter(), manifest.FlushableIngestLevel(), manifest.KeyTypeRange,
 	)
 }
 

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
+	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
@@ -424,12 +425,17 @@ func TestOverlappingIngestedSSTs(t *testing.T) {
 		closed     = false
 		blockFlush = false
 	)
+	cache := NewCache(0)
 	defer func() {
 		if !closed {
 			require.NoError(t, d.Close())
 		}
+		cache.Unref()
 	}()
-
+	var fsLog struct {
+		sync.Mutex
+		buf bytes.Buffer
+	}
 	reset := func(strictMem bool) {
 		if d != nil && !closed {
 			require.NoError(t, d.Close())
@@ -444,13 +450,27 @@ func TestOverlappingIngestedSSTs(t *testing.T) {
 
 		require.NoError(t, mem.MkdirAll("ext", 0755))
 		opts = (&Options{
-			FS:                          mem,
+			FS: vfs.WithLogging(mem, func(format string, args ...interface{}) {
+				fsLog.Lock()
+				defer fsLog.Unlock()
+				fmt.Fprintf(&fsLog.buf, format+"\n", args...)
+			}),
+			Cache:                       cache,
 			MemTableStopWritesThreshold: 4,
 			L0CompactionThreshold:       100,
 			L0StopWritesThreshold:       100,
 			DebugCheck:                  DebugCheckLevels,
 			FormatMajorVersion:          internalFormatNewest,
+			Comparer:                    testkeys.Comparer,
 		}).WithFSDefaults()
+		if testing.Verbose() {
+			lel := MakeLoggingEventListener(DefaultLogger)
+			opts.EventListener = &lel
+		}
+		opts.EnsureDefaults()
+		// Some of the tests require bloom filters.
+		opts.Levels[0].FilterPolicy = bloom.FilterPolicy(10)
+
 		// Disable automatic compactions because otherwise we'll race with
 		// delete-only compactions triggered by ingesting range tombstones.
 		opts.DisableAutomaticCompactions = true
@@ -458,6 +478,7 @@ func TestOverlappingIngestedSSTs(t *testing.T) {
 		var err error
 		d, err = Open(dir, opts)
 		require.NoError(t, err)
+		closed = false
 		d.TestOnlyWaitForCleaning()
 	}
 	waitForFlush := func() {
@@ -472,7 +493,18 @@ func TestOverlappingIngestedSSTs(t *testing.T) {
 	}
 	reset(false)
 
-	datadriven.RunTest(t, "testdata/flushable_ingest", func(t *testing.T, td *datadriven.TestData) string {
+	datadriven.RunTest(t, "testdata/flushable_ingest", func(t *testing.T, td *datadriven.TestData) (result string) {
+		if td.HasArg("with-fs-logging") {
+			fsLog.Lock()
+			fsLog.buf.Reset()
+			fsLog.Unlock()
+			defer func() {
+				fsLog.Lock()
+				defer fsLog.Unlock()
+				result = fsLog.buf.String() + result
+			}()
+		}
+
 		switch td.Cmd {
 		case "reset":
 			reset(td.HasArg("strictMem"))

--- a/internal/manifest/level.go
+++ b/internal/manifest/level.go
@@ -7,25 +7,33 @@ package manifest
 import "fmt"
 
 const (
-	// 3 bits are necessary to represent level values from 0-6.
+	// 3 bits are necessary to represent level values from 0-6 or 7 for flushable
+	// ingests.
 	levelBits = 3
 	levelMask = (1 << levelBits) - 1
 	// invalidSublevel denotes an invalid or non-applicable sublevel.
-	invalidSublevel = -1
+	invalidSublevel           = -1
+	flushableIngestLevelValue = 7
 )
 
-// Level encodes a level and optional sublevel for use in log and error
-// messages. The encoding has the property that Level(0) ==
-// L0Sublevel(invalidSublevel).
+// Level encodes a level and optional sublevel. It can also represent the
+// conceptual layer of flushable ingests as "level" -1.
+//
+// The encoding has the property that Level(0) == L0Sublevel(invalidSublevel).
 type Level uint32
 
 func makeLevel(level, sublevel int) Level {
 	return Level(((sublevel + 1) << levelBits) | level)
 }
 
-// LevelToInt returns the int representation of a Level
+// LevelToInt returns the int representation of a Level. Returns -1 if the Level
+// refers to the flushable ingests pseudo-level.
 func LevelToInt(l Level) int {
-	return int(l) & levelMask
+	l &= levelMask
+	if l == flushableIngestLevelValue {
+		return -1
+	}
+	return int(l)
 }
 
 // L0Sublevel returns a Level representing the specified L0 sublevel.
@@ -36,11 +44,26 @@ func L0Sublevel(sublevel int) Level {
 	return makeLevel(0, sublevel)
 }
 
+// FlushableIngestLevel returns a Level that represents the flushable ingests
+// pseudo-level.
+func FlushableIngestLevel() Level {
+	return makeLevel(flushableIngestLevelValue, invalidSublevel)
+}
+
+// FlushableIngestLevel returns true if l represents the flushable ingests
+// pseudo-level.
+func (l Level) FlushableIngestLevel() bool {
+	return LevelToInt(l) == -1
+}
+
 func (l Level) String() string {
 	level := int(l) & levelMask
 	sublevel := (int(l) >> levelBits) - 1
 	if sublevel != invalidSublevel {
 		return fmt.Sprintf("L%d.%d", level, sublevel)
+	}
+	if level == flushableIngestLevelValue {
+		return "flushable-ingest"
 	}
 	return fmt.Sprintf("L%d", level)
 }

--- a/internal/manifest/level_test.go
+++ b/internal/manifest/level_test.go
@@ -5,7 +5,6 @@
 package manifest
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,51 +12,27 @@ import (
 
 func TestLevel(t *testing.T) {
 	testCases := []struct {
-		level    int
+		level    Level
 		expected string
 	}{
-		{0, "L0"},
-		{1, "L1"},
-		{2, "L2"},
-		{3, "L3"},
-		{4, "L4"},
-		{5, "L5"},
-		{6, "L6"},
-		{7, "L7"},
+		{Level(0), "L0"},
+		{Level(1), "L1"},
+		{Level(2), "L2"},
+		{Level(3), "L3"},
+		{Level(4), "L4"},
+		{Level(5), "L5"},
+		{Level(6), "L6"},
+
+		{L0Sublevel(0), "L0.0"},
+		{L0Sublevel(1), "L0.1"},
+		{L0Sublevel(2), "L0.2"},
+
+		{FlushableIngestLevel(), "flushable-ingest"},
 	}
 
 	for _, c := range testCases {
-		t.Run("", func(t *testing.T) {
-			s := Level(c.level).String()
-			require.EqualValues(t, c.expected, s)
-		})
-	}
-}
-
-func TestL0Sublevel(t *testing.T) {
-	testCases := []struct {
-		level    int
-		sublevel int
-		expected string
-	}{
-		{0, 0, "L0.0"},
-		{0, 1, "L0.1"},
-		{0, 2, "L0.2"},
-		{0, 1000, "L0.1000"},
-		{0, -1, "invalid L0 sublevel: -1"},
-		{0, -2, "invalid L0 sublevel: -2"},
-	}
-
-	for _, c := range testCases {
-		t.Run("", func(t *testing.T) {
-			s := func() (result string) {
-				defer func() {
-					if r := recover(); r != nil {
-						result = fmt.Sprint(r)
-					}
-				}()
-				return L0Sublevel(c.sublevel).String()
-			}()
+		t.Run(c.expected, func(t *testing.T) {
+			s := c.level.String()
 			require.EqualValues(t, c.expected, s)
 		})
 	}

--- a/iterator.go
+++ b/iterator.go
@@ -824,7 +824,10 @@ func (i *Iterator) sampleRead() {
 		return
 	}
 	if len(mi.levels) > 1 {
-		mi.ForEachLevelIter(func(li *levelIter) bool {
+		mi.ForEachLevelIter(func(li *levelIter) (done bool) {
+			if li.level.FlushableIngestLevel() {
+				return false
+			}
 			l := manifest.LevelToInt(li.level)
 			if f := li.iterFile; f != nil {
 				var containsKey bool

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -163,7 +163,7 @@ func (lt *levelIterTest) newIters(
 ) (internalIterator, keyspan.FragmentIterator, error) {
 	lt.itersCreated++
 	iter, err := lt.readers[file.FileNum].NewIterWithBlockPropertyFiltersAndContextEtc(
-		ctx, opts.LowerBound, opts.UpperBound, nil, false, true, iio.stats,
+		ctx, opts.LowerBound, opts.UpperBound, nil, false, sstable.AlwaysUseFilterBlock, iio.stats,
 		sstable.TrivialReaderProvider{Reader: lt.readers[file.FileNum]})
 	if err != nil {
 		return nil, nil, err

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -162,7 +162,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 				return nil, nil, err
 			}
 			iter, err := r.NewIterWithBlockPropertyFilters(
-				opts.GetLowerBound(), opts.GetUpperBound(), nil, true /* useFilterBlock */, iio.stats,
+				opts.GetLowerBound(), opts.GetUpperBound(), nil, sstable.AlwaysUseFilterBlock, iio.stats,
 				sstable.TrivialReaderProvider{Reader: r})
 			if err != nil {
 				return nil, nil, err

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -1009,7 +1009,7 @@ func TestBlockProperties(t *testing.T) {
 				return "filter excludes entire table"
 			}
 			iter, err := r.NewIterWithBlockPropertyFilters(
-				lower, upper, filterer, false /* use (bloom) filter */, &stats,
+				lower, upper, filterer, NeverUseFilterBlock, &stats,
 				TrivialReaderProvider{Reader: r})
 			if err != nil {
 				return err.Error()
@@ -1089,7 +1089,7 @@ func TestBlockProperties_BoundLimited(t *testing.T) {
 				return "filter excludes entire table"
 			}
 			iter, err := r.NewIterWithBlockPropertyFilters(
-				lower, upper, filterer, false /* use (bloom) filter */, &stats,
+				lower, upper, filterer, NeverUseFilterBlock, &stats,
 				TrivialReaderProvider{Reader: r})
 			if err != nil {
 				return err.Error()

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -146,11 +146,11 @@ type singleLevelIterator struct {
 	// block-property filters when positioning the index.
 	maybeFilteredKeysSingleLevel bool
 
-	// useFilter specifies whether the filter block in this sstable, if present,
-	// should be used for prefix seeks or not. In some cases it is beneficial
-	// to skip a filter block even if it exists (eg. if probability of a match
-	// is high).
-	useFilter              bool
+	// filterBlockSizeLimit controls whether the bloom filter block in this
+	// sstable, if present, should be used for prefix seeks or not (depending on
+	// its size). In some cases it is beneficial to skip a filter block even if it
+	// exists (eg. if probability of a match is high).
+	filterBlockSizeLimit   FilterBlockSizeLimit
 	lastBloomFilterMatched bool
 
 	hideObsoletePoints bool
@@ -172,7 +172,8 @@ func (i *singleLevelIterator) init(
 	v *virtualState,
 	lower, upper []byte,
 	filterer *BlockPropertiesFilterer,
-	useFilter, hideObsoletePoints bool,
+	filterBlockSizeLimit FilterBlockSizeLimit,
+	hideObsoletePoints bool,
 	stats *base.InternalIteratorStats,
 	rp ReaderProvider,
 	bufferPool *BufferPool,
@@ -193,7 +194,7 @@ func (i *singleLevelIterator) init(
 	i.lower = lower
 	i.upper = upper
 	i.bpfs = filterer
-	i.useFilter = useFilter
+	i.filterBlockSizeLimit = filterBlockSizeLimit
 	i.reader = r
 	i.cmp = r.Compare
 	i.stats = stats
@@ -762,11 +763,11 @@ func (i *singleLevelIterator) SeekPrefixGE(
 			key = i.lower
 		}
 	}
-	return i.seekPrefixGE(prefix, key, flags, i.useFilter)
+	return i.seekPrefixGE(prefix, key, flags, i.filterBlockSizeLimit)
 }
 
 func (i *singleLevelIterator) seekPrefixGE(
-	prefix, key []byte, flags base.SeekGEFlags, checkFilter bool,
+	prefix, key []byte, flags base.SeekGEFlags, filterBlockSizeLimit FilterBlockSizeLimit,
 ) (k *InternalKey, value base.LazyValue) {
 	// NOTE: prefix is only used for bloom filter checking and not later work in
 	// this method. Hence, we can use the existing iterator position if the last
@@ -774,7 +775,7 @@ func (i *singleLevelIterator) seekPrefixGE(
 
 	err := i.err
 	i.err = nil // clear cached iteration error
-	if checkFilter && i.reader.tableFilter != nil {
+	if shouldUseFilterBlock(i.reader, filterBlockSizeLimit) {
 		if !i.lastBloomFilterMatched {
 			// Iterator is not positioned based on last seek.
 			flags = flags.DisableTrySeekUsingNext()
@@ -827,6 +828,12 @@ func (i *singleLevelIterator) seekPrefixGE(
 	i.positionedUsingLatestBounds = true
 	k, value = i.seekGEHelper(key, boundsCmp, flags)
 	return i.maybeVerifyKey(k, value)
+}
+
+// shouldUseFilterBlock returns whether we should use the filter block, based on
+// its length and the size limit.
+func shouldUseFilterBlock(reader *Reader, filterBlockSizeLimit FilterBlockSizeLimit) bool {
+	return reader.tableFilter != nil && reader.filterBH.Length <= uint64(filterBlockSizeLimit)
 }
 
 // virtualLast should only be called if i.vReader != nil.

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -144,7 +144,8 @@ func (i *twoLevelIterator) init(
 	v *virtualState,
 	lower, upper []byte,
 	filterer *BlockPropertiesFilterer,
-	useFilter, hideObsoletePoints bool,
+	filterBlockSizeLimit FilterBlockSizeLimit,
+	hideObsoletePoints bool,
 	stats *base.InternalIteratorStats,
 	rp ReaderProvider,
 	bufferPool *BufferPool,
@@ -166,7 +167,7 @@ func (i *twoLevelIterator) init(
 	i.lower = lower
 	i.upper = upper
 	i.bpfs = filterer
-	i.useFilter = useFilter
+	i.filterBlockSizeLimit = filterBlockSizeLimit
 	i.reader = r
 	i.cmp = r.Compare
 	i.stats = stats
@@ -402,11 +403,11 @@ func (i *twoLevelIterator) SeekPrefixGE(
 	err := i.err
 	i.err = nil // clear cached iteration error
 
+	useFilter := shouldUseFilterBlock(i.reader, i.filterBlockSizeLimit)
 	// The twoLevelIterator could be already exhausted. Utilize that when
 	// trySeekUsingNext is true. See the comment about data-exhausted, PGDE, and
 	// bounds-exhausted near the top of the file.
-	filterUsedAndDidNotMatch :=
-		i.reader.tableFilter != nil && i.useFilter && !i.lastBloomFilterMatched
+	filterUsedAndDidNotMatch := useFilter && !i.lastBloomFilterMatched
 	if flags.TrySeekUsingNext() && !filterUsedAndDidNotMatch &&
 		(i.exhaustedBounds == +1 || (i.data.isDataInvalidated() && i.index.isDataInvalidated())) &&
 		err == nil {
@@ -415,7 +416,7 @@ func (i *twoLevelIterator) SeekPrefixGE(
 	}
 
 	// Check prefix bloom filter.
-	if i.reader.tableFilter != nil && i.useFilter {
+	if useFilter {
 		if !i.lastBloomFilterMatched {
 			// Iterator is not positioned based on last seek.
 			flags = flags.DisableTrySeekUsingNext()
@@ -557,7 +558,7 @@ func (i *twoLevelIterator) SeekPrefixGE(
 
 	if !dontSeekWithinSingleLevelIter {
 		if ikey, val := i.singleLevelIterator.seekPrefixGE(
-			prefix, key, flags, false /* checkFilter */); ikey != nil {
+			prefix, key, flags, NeverUseFilterBlock); ikey != nil {
 			return ikey, val
 		}
 	}

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -439,7 +439,7 @@ func TestVirtualReader(t *testing.T) {
 
 			var stats base.InternalIteratorStats
 			iter, err := v.NewIterWithBlockPropertyFiltersAndContextEtc(
-				context.Background(), lower, upper, nil, false, false,
+				context.Background(), lower, upper, nil, false, NeverUseFilterBlock,
 				&stats, TrivialReaderProvider{Reader: r})
 			if err != nil {
 				return err.Error()
@@ -826,7 +826,7 @@ func runTestReader(t *testing.T, o WriterOptions, dir string, r *Reader, printVa
 					nil, /* upper */
 					filterer,
 					hideObsoletePoints,
-					true, /* use filter block */
+					AlwaysUseFilterBlock,
 					&stats,
 					TrivialReaderProvider{Reader: r},
 				)
@@ -2070,7 +2070,7 @@ func BenchmarkIteratorScanObsolete(b *testing.B) {
 								}
 								iter, err := r.NewIterWithBlockPropertyFiltersAndContextEtc(
 									context.Background(), nil, nil, filterer, hideObsoletePoints,
-									true, nil, TrivialReaderProvider{Reader: r})
+									AlwaysUseFilterBlock, nil, TrivialReaderProvider{Reader: r})
 								require.NoError(b, err)
 								b.ResetTimer()
 								for i := 0; i < b.N; i++ {

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -92,12 +92,13 @@ func (v *VirtualReader) NewIterWithBlockPropertyFiltersAndContextEtc(
 	ctx context.Context,
 	lower, upper []byte,
 	filterer *BlockPropertiesFilterer,
-	hideObsoletePoints, useFilterBlock bool,
+	hideObsoletePoints bool,
+	filterBlockSizeLimit FilterBlockSizeLimit,
 	stats *base.InternalIteratorStats,
 	rp ReaderProvider,
 ) (Iterator, error) {
 	return v.reader.newIterWithBlockPropertyFiltersAndContext(
-		ctx, lower, upper, filterer, hideObsoletePoints, useFilterBlock, stats, rp, &v.vState,
+		ctx, lower, upper, filterer, hideObsoletePoints, filterBlockSizeLimit, stats, rp, &v.vState,
 	)
 }
 

--- a/table_cache.go
+++ b/table_cache.go
@@ -417,6 +417,10 @@ func (c *tableCacheShard) checkAndIntersectFilters(
 	return true, filterer, nil
 }
 
+// For flushable ingests, we decide whether to use the bloom filter base on
+// size.
+const filterBlockSizeLimitForFlushableIngests = 64 * 1024
+
 func (c *tableCacheShard) newIters(
 	ctx context.Context,
 	file *manifest.FileMetadata,
@@ -506,9 +510,17 @@ func (c *tableCacheShard) newIters(
 	}
 
 	var iter sstable.Iterator
-	useFilter := true
+	filterBlockSizeLimit := sstable.AlwaysUseFilterBlock
 	if opts != nil {
-		useFilter = manifest.LevelToInt(opts.level) != 6 || opts.UseL6Filters
+		// By default, we don't use block filters for L6 and restrict the size for
+		// flushable ingests, as these blocks can be very big.
+		if !opts.UseL6Filters {
+			if opts.level == manifest.Level(6) {
+				filterBlockSizeLimit = sstable.NeverUseFilterBlock
+			} else if opts.level.FlushableIngestLevel() {
+				filterBlockSizeLimit = filterBlockSizeLimitForFlushableIngests
+			}
+		}
 		ctx = objiotracing.WithLevel(ctx, manifest.LevelToInt(opts.level))
 	}
 	tableFormat, err := v.reader.TableFormat()
@@ -530,7 +542,7 @@ func (c *tableCacheShard) newIters(
 		iter, err = cr.NewCompactionIter(internalOpts.bytesIterated, rp, internalOpts.bufferPool)
 	} else {
 		iter, err = cr.NewIterWithBlockPropertyFiltersAndContextEtc(
-			ctx, opts.GetLowerBound(), opts.GetUpperBound(), filterer, hideObsoletePoints, useFilter,
+			ctx, opts.GetLowerBound(), opts.GetUpperBound(), filterer, hideObsoletePoints, filterBlockSizeLimit,
 			internalOpts.stats, rp)
 	}
 	if err != nil {

--- a/testdata/flushable_ingest
+++ b/testdata/flushable_ingest
@@ -625,3 +625,84 @@ lsm
   000004:[a#12,SET-b#12,SET]
 0.0:
   000007:[a#10,SET-b#11,SET]
+
+close
+----
+
+reset
+----
+
+build small
+set-multiple 10 small
+----
+
+build large
+set-multiple 100000 large
+----
+
+batch
+set small-00001 before-ingest
+set large-00001 before-ingest
+----
+
+blockFlush
+----
+
+ingest small large
+----
+
+allowFlush
+----
+
+# When looking inside the small table, we will read the index block, then we
+# should read the bloom filter, followed by a data block read.
+#
+# The extra index block reads are due to inefficiencies of the iterator
+# implementations (fixed in later versions).
+iter with-fs-logging
+seek-prefix-ge small-00001
+----
+read-at(194, 37): 000004.sst
+read-at(120, 74): 000004.sst
+read-at(0, 120): 000004.sst
+read-at(194, 37): 000004.sst
+read-at(194, 37): 000004.sst
+small-00001: (val-00001, .)
+
+# When the key doesn't pass the bloom filter, we should not see the data block
+# read at offset 0.
+iter with-fs-logging
+seek-prefix-ge small-00001-does-not-exist
+----
+read-at(194, 37): 000004.sst
+read-at(120, 74): 000004.sst
+read-at(194, 37): 000004.sst
+.
+
+# When looking inside the large table, we will not read the bloom filter which
+# is large. We read the top-level index block, a second-level index block, and a
+# data block.
+iter with-fs-logging
+seek-prefix-ge large-00001
+----
+read-at(775296, 112): 000005.sst
+read-at(765608, 2235): 000005.sst
+read-at(0, 1114): 000005.sst
+read-at(775296, 112): 000005.sst
+read-at(194, 37): 000004.sst
+read-at(775296, 112): 000005.sst
+read-at(194, 37): 000004.sst
+large-00001: (val-00001, .)
+
+# We still read the data block (at offset 0) for a key that doesn't exist.
+iter with-fs-logging
+seek-prefix-ge large-00001-does-not-exist
+----
+read-at(775296, 112): 000005.sst
+read-at(765608, 2235): 000005.sst
+read-at(0, 1114): 000005.sst
+read-at(775296, 112): 000005.sst
+read-at(194, 37): 000004.sst
+read-at(775296, 112): 000005.sst
+read-at(194, 37): 000004.sst
+.


### PR DESCRIPTION
We have seen cases where a very large file is ingested as flushable,
and reads block on loading a very large bloom filter.

This PR sets a size limit of 64KB for bloom filter blocks for ingested
flushables. We achieve this by extending `manifest.Level` to be able
to represent flushable ingests as a "pseudo-level" and changing the
`useFilterBlock` flag for new iterator creation to a
`filterBlockSizeLimit` value.

Fixes #3787