### PR TITLE
crl-release-23.1: db: don't load large filter blocks for flushable ingests

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -537,6 +537,23 @@ func runBatchDefineCmd(d *datadriven.TestData, b *Batch) error {
 				return errors.Errorf("%s expects 2 arguments", parts[0])
 			}
 			err = b.Set([]byte(parts[1]), []byte(parts[2]), nil)
+
+		case "set-multiple":
+			if len(parts) != 3 {
+				return errors.Errorf("%s expects 2 arguments (n and prefix)", parts[0])
+			}
+			n, err := strconv.ParseUint(parts[1], 10, 32)
+			if err != nil {
+				return err
+			}
+			for i := uint64(0); i < n; i++ {
+				key := fmt.Sprintf("%s-%05d", parts[2], i)
+				val := fmt.Sprintf("val-%05d", i)
+				if err := b.Set([]byte(key), []byte(val), nil); err != nil {
+					return err
+				}
+			}
+
 		case "del":
 			if len(parts) != 2 {
 				return errors.Errorf("%s expects 1 argument", parts[0])

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -213,8 +213,8 @@ func createExternalPointIter(ctx context.Context, it *Iterator) (internalIterato
 				ctx,
 				it.opts.LowerBound,
 				it.opts.UpperBound,
-				nil,   /* BlockPropertiesFilterer */
-				false, /* useFilterBlock */
+				nil, /* BlockPropertiesFilterer */
+				sstable.NeverUseFilterBlock,
 				&it.stats.InternalStats,
 				sstable.TrivialReaderProvider{Reader: r},
 			)

--- a/external_iterator_test.go
+++ b/external_iterator_test.go
@@ -245,7 +245,7 @@ func TestIterRandomizedMaybeFilteredKeys(t *testing.T) {
 
 			var iter sstable.Iterator
 			iter, err = r.NewIterWithBlockPropertyFilters(
-				nil, nil, filterer, false /* useFilterBlock */, nil, /* stats */
+				nil, nil, filterer, sstable.NeverUseFilterBlock, nil, /* stats */
 				sstable.TrivialReaderProvider{Reader: r})
 			require.NoError(t, err)
 			defer iter.Close()

--- a/flushable.go
+++ b/flushable.go
@@ -164,12 +164,8 @@ func (s *ingestedFlushable) newIter(o *IterOptions) internalIterator {
 	if o != nil {
 		opts = *o
 	}
-	// TODO(bananabrick): The manifest.Level in newLevelIter is only used for
-	// logging. Update the manifest.Level encoding to account for levels which
-	// aren't truly levels in the lsm. Right now, the encoding only supports
-	// L0 sublevels, and the rest of the levels in the lsm.
 	return newLevelIter(
-		opts, s.cmp, s.split, s.newIters, s.slice.Iter(), manifest.Level(0), nil,
+		opts, s.cmp, s.split, s.newIters, s.slice.Iter(), manifest.FlushableIngestLevel(), nil,
 	)
 }
 
@@ -201,7 +197,7 @@ func (s *ingestedFlushable) constructRangeDelIter(
 func (s *ingestedFlushable) newRangeDelIter(_ *IterOptions) keyspan.FragmentIterator {
 	return keyspan.NewLevelIter(
 		keyspan.SpanIterOptions{}, s.cmp,
-		s.constructRangeDelIter, s.slice.Iter(), manifest.Level(0),
+		s.constructRangeDelIter, s.slice.Iter(), manifest.FlushableIngestLevel(),
 		manifest.KeyTypePoint,
 	)
 }
@@ -213,7 +209,7 @@ func (s *ingestedFlushable) newRangeKeyIter(o *IterOptions) keyspan.FragmentIter
 
 	return keyspan.NewLevelIter(
 		keyspan.SpanIterOptions{}, s.cmp, s.newRangeKeyIters,
-		s.slice.Iter(), manifest.Level(0), manifest.KeyTypeRange,
+		s.slice.Iter(), manifest.FlushableIngestLevel(), manifest.KeyTypeRange,
 	)
 }
 

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -22,7 +22,7 @@ import (
 const (
 	cmdGo       = "go"
 	golint      = "golang.org/x/lint/golint@6edffad5e6160f5949cdefc81710b2706fbcd4f6"
-	staticcheck = "honnef.co/go/tools/cmd/staticcheck@2023.1"
+	staticcheck = "honnef.co/go/tools/cmd/staticcheck@2023.1.7"
 	crlfmt      = "github.com/cockroachdb/crlfmt@44a36ec7"
 )
 

--- a/internal/manifest/level.go
+++ b/internal/manifest/level.go
@@ -7,25 +7,33 @@ package manifest
 import "fmt"
 
 const (
-	// 3 bits are necessary to represent level values from 0-6.
+	// 3 bits are necessary to represent level values from 0-6 or 7 for flushable
+	// ingests.
 	levelBits = 3
 	levelMask = (1 << levelBits) - 1
 	// invalidSublevel denotes an invalid or non-applicable sublevel.
-	invalidSublevel = -1
+	invalidSublevel           = -1
+	flushableIngestLevelValue = 7
 )
 
-// Level encodes a level and optional sublevel for use in log and error
-// messages. The encoding has the property that Level(0) ==
-// L0Sublevel(invalidSublevel).
+// Level encodes a level and optional sublevel. It can also represent the
+// conceptual layer of flushable ingests as "level" -1.
+//
+// The encoding has the property that Level(0) == L0Sublevel(invalidSublevel).
 type Level uint32
 
 func makeLevel(level, sublevel int) Level {
 	return Level(((sublevel + 1) << levelBits) | level)
 }
 
-// LevelToInt returns the int representation of a Level
+// LevelToInt returns the int representation of a Level. Returns -1 if the Level
+// refers to the flushable ingests pseudo-level.
 func LevelToInt(l Level) int {
-	return int(l) & levelMask
+	l &= levelMask
+	if l == flushableIngestLevelValue {
+		return -1
+	}
+	return int(l)
 }
 
 // L0Sublevel returns a Level representing the specified L0 sublevel.
@@ -36,11 +44,26 @@ func L0Sublevel(sublevel int) Level {
 	return makeLevel(0, sublevel)
 }
 
+// FlushableIngestLevel returns a Level that represents the flushable ingests
+// pseudo-level.
+func FlushableIngestLevel() Level {
+	return makeLevel(flushableIngestLevelValue, invalidSublevel)
+}
+
+// FlushableIngestLevel returns true if l represents the flushable ingests
+// pseudo-level.
+func (l Level) FlushableIngestLevel() bool {
+	return LevelToInt(l) == -1
+}
+
 func (l Level) String() string {
 	level := int(l) & levelMask
 	sublevel := (int(l) >> levelBits) - 1
 	if sublevel != invalidSublevel {
 		return fmt.Sprintf("L%d.%d", level, sublevel)
+	}
+	if level == flushableIngestLevelValue {
+		return "flushable-ingest"
 	}
 	return fmt.Sprintf("L%d", level)
 }

--- a/internal/manifest/level_test.go
+++ b/internal/manifest/level_test.go
@@ -5,7 +5,6 @@
 package manifest
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,51 +12,27 @@ import (
 
 func TestLevel(t *testing.T) {
 	testCases := []struct {
-		level    int
+		level    Level
 		expected string
 	}{
-		{0, "L0"},
-		{1, "L1"},
-		{2, "L2"},
-		{3, "L3"},
-		{4, "L4"},
-		{5, "L5"},
-		{6, "L6"},
-		{7, "L7"},
+		{Level(0), "L0"},
+		{Level(1), "L1"},
+		{Level(2), "L2"},
+		{Level(3), "L3"},
+		{Level(4), "L4"},
+		{Level(5), "L5"},
+		{Level(6), "L6"},
+
+		{L0Sublevel(0), "L0.0"},
+		{L0Sublevel(1), "L0.1"},
+		{L0Sublevel(2), "L0.2"},
+
+		{FlushableIngestLevel(), "flushable-ingest"},
 	}
 
 	for _, c := range testCases {
-		t.Run("", func(t *testing.T) {
-			s := Level(c.level).String()
-			require.EqualValues(t, c.expected, s)
-		})
-	}
-}
-
-func TestL0Sublevel(t *testing.T) {
-	testCases := []struct {
-		level    int
-		sublevel int
-		expected string
-	}{
-		{0, 0, "L0.0"},
-		{0, 1, "L0.1"},
-		{0, 2, "L0.2"},
-		{0, 1000, "L0.1000"},
-		{0, -1, "invalid L0 sublevel: -1"},
-		{0, -2, "invalid L0 sublevel: -2"},
-	}
-
-	for _, c := range testCases {
-		t.Run("", func(t *testing.T) {
-			s := func() (result string) {
-				defer func() {
-					if r := recover(); r != nil {
-						result = fmt.Sprint(r)
-					}
-				}()
-				return L0Sublevel(c.sublevel).String()
-			}()
+		t.Run(c.expected, func(t *testing.T) {
+			s := c.level.String()
 			require.EqualValues(t, c.expected, s)
 		})
 	}

--- a/iterator.go
+++ b/iterator.go
@@ -775,7 +775,10 @@ func (i *Iterator) sampleRead() {
 	topLevel, numOverlappingLevels := numLevels, 0
 	if mi, ok := i.iter.(*mergingIter); ok {
 		if len(mi.levels) > 1 {
-			mi.ForEachLevelIter(func(li *levelIter) bool {
+			mi.ForEachLevelIter(func(li *levelIter) (done bool) {
+				if li.level.FlushableIngestLevel() {
+					return false
+				}
 				l := manifest.LevelToInt(li.level)
 				if f := li.iterFile; f != nil {
 					var containsKey bool

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -163,7 +163,7 @@ func (lt *levelIterTest) newIters(
 ) (internalIterator, keyspan.FragmentIterator, error) {
 	lt.itersCreated++
 	iter, err := lt.readers[file.FileNum].NewIterWithBlockPropertyFiltersAndContext(
-		ctx, opts.LowerBound, opts.UpperBound, nil, true, iio.stats,
+		ctx, opts.LowerBound, opts.UpperBound, nil, sstable.AlwaysUseFilterBlock, iio.stats,
 		sstable.TrivialReaderProvider{Reader: lt.readers[file.FileNum]})
 	if err != nil {
 		return nil, nil, err

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -161,7 +161,7 @@ func TestMergingIterCornerCases(t *testing.T) {
 				return nil, nil, err
 			}
 			iter, err := r.NewIterWithBlockPropertyFilters(
-				opts.GetLowerBound(), opts.GetUpperBound(), nil, true /* useFilterBlock */, iio.stats,
+				opts.GetLowerBound(), opts.GetUpperBound(), nil, sstable.AlwaysUseFilterBlock, iio.stats,
 				sstable.TrivialReaderProvider{Reader: r})
 			if err != nil {
 				return nil, nil, err

--- a/objstorage/testdata/provider/local
+++ b/objstorage/testdata/provider/local
@@ -14,6 +14,8 @@ foo
 
 read 1
 ----
+<local fs> open: p0/000001.sst (options: *vfs.randomReadsOption)
+<local fs> read-at(0, 3): p0/000001.sst
 data: foo
 
 # A provider without shared storage creates object with shared preference
@@ -27,6 +29,8 @@ bar
 
 read 2
 ----
+<local fs> open: p0/000002.sst (options: *vfs.randomReadsOption)
+<local fs> read-at(0, 3): p0/000002.sst
 data: bar
 
 close

--- a/objstorage/testdata/provider/shared_basic
+++ b/objstorage/testdata/provider/shared_basic
@@ -22,6 +22,8 @@ obj-one
 
 read 1
 ----
+<local fs> open: p1/000001.sst (options: *vfs.randomReadsOption)
+<local fs> read-at(0, 7): p1/000001.sst
 data: obj-one
 
 create 2 shared
@@ -53,6 +55,8 @@ open p1 1
 <local fs> mkdir-all: p1 0755
 <local fs> open-dir: p1
 <local fs> open-dir: p1
+<local fs> open: p1/SHARED-CATALOG-000001
+<local fs> close: p1/SHARED-CATALOG-000001
 
 list
 ----

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -1009,7 +1009,7 @@ func TestBlockProperties(t *testing.T) {
 				return "filter excludes entire table"
 			}
 			iter, err := r.NewIterWithBlockPropertyFilters(
-				lower, upper, filterer, false /* use (bloom) filter */, &stats,
+				lower, upper, filterer, NeverUseFilterBlock, &stats,
 				TrivialReaderProvider{Reader: r})
 			if err != nil {
 				return err.Error()
@@ -1089,7 +1089,7 @@ func TestBlockProperties_BoundLimited(t *testing.T) {
 				return "filter excludes entire table"
 			}
 			iter, err := r.NewIterWithBlockPropertyFilters(
-				lower, upper, filterer, false /* use (bloom) filter */, &stats,
+				lower, upper, filterer, NeverUseFilterBlock, &stats,
 				TrivialReaderProvider{Reader: r})
 			if err != nil {
 				return err.Error()

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -504,7 +504,7 @@ func runTestReader(t *testing.T, o WriterOptions, dir string, r *Reader, printVa
 					nil, /* lower */
 					nil, /* upper */
 					filterer,
-					true, /* use filter block */
+					AlwaysUseFilterBlock,
 					&stats,
 					TrivialReaderProvider{Reader: r},
 				)

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -5,6 +5,7 @@ open-dir: db
 lock: db/LOCK
 open-dir: db
 open-dir: db
+open: db/CURRENT
 create: db/MANIFEST-000001
 sync: db/MANIFEST-000001
 remove: db/temporary.000001.dbtmp
@@ -145,18 +146,22 @@ sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 link: db/000005.sst -> checkpoints/checkpoint1/000005.sst
 link: db/000007.sst -> checkpoints/checkpoint1/000007.sst
+open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
 create: checkpoints/checkpoint1/MANIFEST-000001
 sync-data: checkpoints/checkpoint1/MANIFEST-000001
 close: checkpoints/checkpoint1/MANIFEST-000001
+close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint1
 create: checkpoints/checkpoint1/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint1/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint1/marker.manifest.000001.MANIFEST-000001
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
+open: db/000006.log (options: *vfs.sequentialReadsOption)
 create: checkpoints/checkpoint1/000006.log
 sync-data: checkpoints/checkpoint1/000006.log
 close: checkpoints/checkpoint1/000006.log
+close: db/000006.log
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 
@@ -180,18 +185,22 @@ close: checkpoints/checkpoint2/marker.format-version.000001.014
 sync: checkpoints/checkpoint2
 close: checkpoints/checkpoint2
 link: db/000007.sst -> checkpoints/checkpoint2/000007.sst
+open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
 create: checkpoints/checkpoint2/MANIFEST-000001
 sync-data: checkpoints/checkpoint2/MANIFEST-000001
 close: checkpoints/checkpoint2/MANIFEST-000001
+close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint2
 create: checkpoints/checkpoint2/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint2/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint2/marker.manifest.000001.MANIFEST-000001
 sync: checkpoints/checkpoint2
 close: checkpoints/checkpoint2
+open: db/000006.log (options: *vfs.sequentialReadsOption)
 create: checkpoints/checkpoint2/000006.log
 sync-data: checkpoints/checkpoint2/000006.log
 close: checkpoints/checkpoint2/000006.log
+close: db/000006.log
 sync: checkpoints/checkpoint2
 close: checkpoints/checkpoint2
 
@@ -212,18 +221,22 @@ sync: checkpoints/checkpoint3
 close: checkpoints/checkpoint3
 link: db/000005.sst -> checkpoints/checkpoint3/000005.sst
 link: db/000007.sst -> checkpoints/checkpoint3/000007.sst
+open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
 create: checkpoints/checkpoint3/MANIFEST-000001
 sync-data: checkpoints/checkpoint3/MANIFEST-000001
 close: checkpoints/checkpoint3/MANIFEST-000001
+close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint3
 create: checkpoints/checkpoint3/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint3/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint3/marker.manifest.000001.MANIFEST-000001
 sync: checkpoints/checkpoint3
 close: checkpoints/checkpoint3
+open: db/000006.log (options: *vfs.sequentialReadsOption)
 create: checkpoints/checkpoint3/000006.log
 sync-data: checkpoints/checkpoint3/000006.log
 close: checkpoints/checkpoint3/000006.log
+close: db/000006.log
 sync: checkpoints/checkpoint3
 close: checkpoints/checkpoint3
 
@@ -238,11 +251,32 @@ sync-data: db/000009.sst
 close: db/000009.sst
 sync: db
 sync: db/MANIFEST-000001
+open: db/000005.sst (options: *vfs.randomReadsOption)
+read-at(744, 53): db/000005.sst
+read-at(707, 37): db/000005.sst
+read-at(79, 628): db/000005.sst
+read-at(52, 27): db/000005.sst
+open: db/000009.sst (options: *vfs.randomReadsOption)
+read-at(732, 53): db/000009.sst
+read-at(695, 37): db/000009.sst
+read-at(67, 628): db/000009.sst
+read-at(40, 27): db/000009.sst
+open: db/000007.sst (options: *vfs.randomReadsOption)
+read-at(744, 53): db/000007.sst
+read-at(707, 37): db/000007.sst
+read-at(79, 628): db/000007.sst
+read-at(52, 27): db/000007.sst
+read-at(0, 52): db/000005.sst
+read-at(0, 52): db/000007.sst
 create: db/000010.sst
+read-at(0, 40): db/000009.sst
 sync-data: db/000010.sst
 close: db/000010.sst
 sync: db
 sync: db/MANIFEST-000001
+close: db/000005.sst
+close: db/000007.sst
+close: db/000009.sst
 remove: db/000005.sst
 remove: db/000007.sst
 remove: db/000009.sst
@@ -280,10 +314,28 @@ open-dir: checkpoints/checkpoint1
 lock: checkpoints/checkpoint1/LOCK
 open-dir: checkpoints/checkpoint1
 open-dir: checkpoints/checkpoint1
+open: checkpoints/checkpoint1/MANIFEST-000001
+close: checkpoints/checkpoint1/MANIFEST-000001
 open-dir: checkpoints/checkpoint1
+open: checkpoints/checkpoint1/OPTIONS-000003
+close: checkpoints/checkpoint1/OPTIONS-000003
+open: checkpoints/checkpoint1/000006.log
+close: checkpoints/checkpoint1/000006.log
 
 scan checkpoints/checkpoint1
 ----
+open: checkpoints/checkpoint1/000007.sst (options: *vfs.randomReadsOption)
+read-at(744, 53): checkpoints/checkpoint1/000007.sst
+read-at(707, 37): checkpoints/checkpoint1/000007.sst
+read-at(79, 628): checkpoints/checkpoint1/000007.sst
+read-at(52, 27): checkpoints/checkpoint1/000007.sst
+read-at(0, 52): checkpoints/checkpoint1/000007.sst
+open: checkpoints/checkpoint1/000005.sst (options: *vfs.randomReadsOption)
+read-at(744, 53): checkpoints/checkpoint1/000005.sst
+read-at(707, 37): checkpoints/checkpoint1/000005.sst
+read-at(79, 628): checkpoints/checkpoint1/000005.sst
+read-at(52, 27): checkpoints/checkpoint1/000005.sst
+read-at(0, 52): checkpoints/checkpoint1/000005.sst
 a 1
 b 5
 c 3
@@ -295,6 +347,12 @@ g 10
 
 scan db
 ----
+open: db/000010.sst (options: *vfs.randomReadsOption)
+read-at(766, 53): db/000010.sst
+read-at(729, 37): db/000010.sst
+read-at(101, 628): db/000010.sst
+read-at(74, 27): db/000010.sst
+read-at(0, 74): db/000010.sst
 a 1
 b 5
 c 3
@@ -321,10 +379,22 @@ open-dir: checkpoints/checkpoint2
 lock: checkpoints/checkpoint2/LOCK
 open-dir: checkpoints/checkpoint2
 open-dir: checkpoints/checkpoint2
+open: checkpoints/checkpoint2/MANIFEST-000001
+close: checkpoints/checkpoint2/MANIFEST-000001
 open-dir: checkpoints/checkpoint2
+open: checkpoints/checkpoint2/OPTIONS-000003
+close: checkpoints/checkpoint2/OPTIONS-000003
+open: checkpoints/checkpoint2/000006.log
+close: checkpoints/checkpoint2/000006.log
 
 scan checkpoints/checkpoint2
 ----
+open: checkpoints/checkpoint2/000007.sst (options: *vfs.randomReadsOption)
+read-at(744, 53): checkpoints/checkpoint2/000007.sst
+read-at(707, 37): checkpoints/checkpoint2/000007.sst
+read-at(79, 628): checkpoints/checkpoint2/000007.sst
+read-at(52, 27): checkpoints/checkpoint2/000007.sst
+read-at(0, 52): checkpoints/checkpoint2/000007.sst
 b 5
 d 7
 e 8
@@ -349,10 +419,28 @@ open-dir: checkpoints/checkpoint3
 lock: checkpoints/checkpoint3/LOCK
 open-dir: checkpoints/checkpoint3
 open-dir: checkpoints/checkpoint3
+open: checkpoints/checkpoint3/MANIFEST-000001
+close: checkpoints/checkpoint3/MANIFEST-000001
 open-dir: checkpoints/checkpoint3
+open: checkpoints/checkpoint3/OPTIONS-000003
+close: checkpoints/checkpoint3/OPTIONS-000003
+open: checkpoints/checkpoint3/000006.log
+close: checkpoints/checkpoint3/000006.log
 
 scan checkpoints/checkpoint3
 ----
+open: checkpoints/checkpoint3/000007.sst (options: *vfs.randomReadsOption)
+read-at(744, 53): checkpoints/checkpoint3/000007.sst
+read-at(707, 37): checkpoints/checkpoint3/000007.sst
+read-at(79, 628): checkpoints/checkpoint3/000007.sst
+read-at(52, 27): checkpoints/checkpoint3/000007.sst
+read-at(0, 52): checkpoints/checkpoint3/000007.sst
+open: checkpoints/checkpoint3/000005.sst (options: *vfs.randomReadsOption)
+read-at(744, 53): checkpoints/checkpoint3/000005.sst
+read-at(707, 37): checkpoints/checkpoint3/000005.sst
+read-at(79, 628): checkpoints/checkpoint3/000005.sst
+read-at(52, 27): checkpoints/checkpoint3/000005.sst
+read-at(0, 52): checkpoints/checkpoint3/000005.sst
 a 1
 b 5
 c 3

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -8,6 +8,7 @@ open-dir: db_wal
 lock: db/LOCK
 open-dir: db
 open-dir: db
+open: db/CURRENT
 create: db/MANIFEST-000001
 sync: db/MANIFEST-000001
 remove: db/temporary.000001.dbtmp
@@ -65,11 +66,25 @@ sync: db
 sync: db/MANIFEST-000001
 mkdir-all: db_wal/archive 0755
 rename: db_wal/000004.log -> db_wal/archive/000004.log
+open: db/000005.sst (options: *vfs.randomReadsOption)
+read-at(744, 53): db/000005.sst
+read-at(707, 37): db/000005.sst
+read-at(79, 628): db/000005.sst
+read-at(52, 27): db/000005.sst
+open: db/000007.sst (options: *vfs.randomReadsOption)
+read-at(718, 53): db/000007.sst
+read-at(681, 37): db/000007.sst
+read-at(53, 628): db/000007.sst
+read-at(26, 27): db/000007.sst
+read-at(0, 52): db/000005.sst
 create: db/000008.sst
+read-at(0, 26): db/000007.sst
 sync-data: db/000008.sst
 close: db/000008.sst
 sync: db
 sync: db/MANIFEST-000001
+close: db/000005.sst
+close: db/000007.sst
 mkdir-all: db/archive 0755
 rename: db/000005.sst -> db/archive/000005.sst
 mkdir-all: db/archive 0755
@@ -109,6 +124,7 @@ open-dir: db1_wal
 lock: db1/LOCK
 open-dir: db1
 open-dir: db1
+open: db1/CURRENT
 create: db1/MANIFEST-000001
 sync: db1/MANIFEST-000001
 remove: db1/temporary.000001.dbtmp
@@ -178,7 +194,16 @@ open-dir: db1_wal
 lock: db1/LOCK
 open-dir: db1
 open-dir: db1
+open: db1/CURRENT
+read-at(0, 16): db1/CURRENT
+close: db1/CURRENT
+open: db1/MANIFEST-000001
+close: db1/MANIFEST-000001
 open-dir: db1
+open: db1/OPTIONS-000003
+close: db1/OPTIONS-000003
+open: db1_wal/000004.log
+close: db1_wal/000004.log
 create: db1/MANIFEST-000458
 sync: db1/MANIFEST-000458
 remove: db1/temporary.000458.dbtmp

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -7,6 +7,7 @@ open-dir: wal
 lock: db/LOCK
 open-dir: db
 open-dir: db
+open: db/CURRENT
 create: db/MANIFEST-000001
 sync: db/MANIFEST-000001
 remove: db/temporary.000001.dbtmp
@@ -149,6 +150,18 @@ sync: db
 remove: db/MANIFEST-000001
 [JOB 7] MANIFEST deleted 000001
 [JOB 8] compacting(default) L0 [000005 000008] (1.5 K) + L6 [] (0 B)
+open: db/000005.sst (options: *vfs.randomReadsOption)
+read-at(717, 53): db/000005.sst
+read-at(680, 37): db/000005.sst
+read-at(52, 628): db/000005.sst
+read-at(25, 27): db/000005.sst
+open: db/000008.sst (options: *vfs.randomReadsOption)
+read-at(717, 53): db/000008.sst
+read-at(680, 37): db/000008.sst
+read-at(52, 628): db/000008.sst
+read-at(25, 27): db/000008.sst
+read-at(0, 25): db/000005.sst
+read-at(0, 25): db/000008.sst
 create: db/000010.sst
 [JOB 8] compacting: sstable created 000010
 sync-data: db/000010.sst
@@ -163,6 +176,8 @@ remove: db/marker.manifest.000003.MANIFEST-000009
 sync: db
 [JOB 8] MANIFEST created 000011
 [JOB 8] compacted(default) L0 [000005 000008] (1.5 K) + L6 [] (0 B) -> L6 [000010] (770 B), in 1.0s (2.0s total), output rate 770 B/s
+close: db/000005.sst
+close: db/000008.sst
 remove: db/000005.sst
 [JOB 8] sstable deleted 000005
 remove: db/000008.sst
@@ -204,9 +219,22 @@ remove: db/MANIFEST-000009
 
 ingest
 ----
+open: ext/0
+read-at(773, 53): ext/0
+read-at(736, 37): ext/0
+read-at(53, 683): ext/0
+read-at(26, 27): ext/0
+read-at(0, 26): ext/0
+close: ext/0
 link: ext/0 -> db/000015.sst
 [JOB 12] ingesting: sstable created 000015
 sync: db
+open: db/000013.sst (options: *vfs.randomReadsOption)
+read-at(717, 53): db/000013.sst
+read-at(680, 37): db/000013.sst
+read-at(52, 628): db/000013.sst
+read-at(25, 27): db/000013.sst
+read-at(0, 25): db/000013.sst
 create: db/MANIFEST-000016
 close: db/MANIFEST-000014
 sync: db/MANIFEST-000016
@@ -251,6 +279,20 @@ zmemtbl         0     0 B
 ingest-flushable
 ----
 sync-data: wal/000012.log
+open: ext/a
+read-at(773, 53): ext/a
+read-at(736, 37): ext/a
+read-at(53, 683): ext/a
+read-at(26, 27): ext/a
+read-at(0, 26): ext/a
+close: ext/a
+open: ext/b
+read-at(773, 53): ext/b
+read-at(736, 37): ext/b
+read-at(53, 683): ext/b
+read-at(26, 27): ext/b
+read-at(0, 26): ext/b
+close: ext/b
 link: ext/a -> db/000017.sst
 [JOB 13] ingesting: sstable created 000017
 link: ext/b -> db/000018.sst
@@ -354,18 +396,22 @@ link: db/000022.sst -> checkpoint/000022.sst
 link: db/000017.sst -> checkpoint/000017.sst
 link: db/000010.sst -> checkpoint/000010.sst
 link: db/000018.sst -> checkpoint/000018.sst
+open: db/MANIFEST-000023 (options: *vfs.sequentialReadsOption)
 create: checkpoint/MANIFEST-000023
 sync-data: checkpoint/MANIFEST-000023
 close: checkpoint/MANIFEST-000023
+close: db/MANIFEST-000023
 open-dir: checkpoint
 create: checkpoint/marker.manifest.000001.MANIFEST-000023
 sync-data: checkpoint/marker.manifest.000001.MANIFEST-000023
 close: checkpoint/marker.manifest.000001.MANIFEST-000023
 sync: checkpoint
 close: checkpoint
+open: wal/000021.log (options: *vfs.sequentialReadsOption)
 create: checkpoint/000021.log
 sync-data: checkpoint/000021.log
 close: checkpoint/000021.log
+close: wal/000021.log
 sync: checkpoint
 close: checkpoint
 
@@ -376,6 +422,7 @@ pebble: file deletion disablement invariant violated
 close
 ----
 close: db
+close: db/000013.sst
 sync-data: wal/000021.log
 close: wal/000021.log
 close: db/MANIFEST-000023

--- a/testdata/flushable_ingest
+++ b/testdata/flushable_ingest
@@ -625,3 +625,84 @@ lsm
   000004:[a#3,SET-b#3,SET]
 0.0:
   000007:[a#1,SET-b#2,SET]
+
+close
+----
+
+reset
+----
+
+build small
+set-multiple 10 small
+----
+
+build large
+set-multiple 100000 large
+----
+
+batch
+set small-00001 before-ingest
+set large-00001 before-ingest
+----
+
+blockFlush
+----
+
+ingest small large
+----
+
+allowFlush
+----
+
+# When looking inside the small table, we will read the index block, then we
+# should read the bloom filter, followed by a data block read.
+#
+# The extra index block reads are due to inefficiencies of the iterator
+# implementations (fixed in later versions).
+iter with-fs-logging
+seek-prefix-ge small-00001
+----
+read-at(194, 37): 000004.sst
+read-at(120, 74): 000004.sst
+read-at(0, 120): 000004.sst
+read-at(194, 37): 000004.sst
+read-at(194, 37): 000004.sst
+small-00001: (val-00001, .)
+
+# When the key doesn't pass the bloom filter, we should not see the data block
+# read at offset 0.
+iter with-fs-logging
+seek-prefix-ge small-00001-does-not-exist
+----
+read-at(194, 37): 000004.sst
+read-at(120, 74): 000004.sst
+read-at(194, 37): 000004.sst
+.
+
+# When looking inside the large table, we will not read the bloom filter which
+# is large. We read the top-level index block, a second-level index block, and a
+# data block.
+iter with-fs-logging
+seek-prefix-ge large-00001
+----
+read-at(775296, 112): 000005.sst
+read-at(765608, 2235): 000005.sst
+read-at(0, 1114): 000005.sst
+read-at(775296, 112): 000005.sst
+read-at(194, 37): 000004.sst
+read-at(775296, 112): 000005.sst
+read-at(194, 37): 000004.sst
+large-00001: (val-00001, .)
+
+# We still read the data block (at offset 0) for a key that doesn't exist.
+iter with-fs-logging
+seek-prefix-ge large-00001-does-not-exist
+----
+read-at(775296, 112): 000005.sst
+read-at(765608, 2235): 000005.sst
+read-at(0, 1114): 000005.sst
+read-at(775296, 112): 000005.sst
+read-at(194, 37): 000004.sst
+read-at(775296, 112): 000005.sst
+read-at(194, 37): 000004.sst
+.


### PR DESCRIPTION
#### vfs: log ReadAt in loggingFS


#### crl-release-23.1: db: don't load large filter blocks for flushable ingests

We have seen cases where a very large file is ingested as flushable,
and reads block on loading a very large bloom filter.

This PR sets a size limit of 64KB for bloom filter blocks for ingested
flushables. We achieve this by extending `manifest.Level` to be able
to represent flushable ingests as a "pseudo-level" and changing the
`useFilterBlock` flag for new iterator creation to a
`filterBlockSizeLimit` value.

Fixes #3787