### PR TITLE
db: fix missing close in TestOverlappingIngestedSSTs

### DIFF
--- a/ingest_test.go
+++ b/ingest_test.go
@@ -481,6 +481,7 @@ func TestOverlappingIngestedSSTs(t *testing.T) {
 		var err error
 		d, err = Open(dir, opts)
 		require.NoError(t, err)
+		closed = false
 		d.TestOnlyWaitForCleaning()
 	}
 	waitForFlush := func() {


### PR DESCRIPTION
We don't reset `closed` which can lead to the DB not being closed. Surprisingly, the finalizers did not detect this issue (except in crl-release-23.1).